### PR TITLE
fix(#8191): package wxWidgets translations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -472,6 +472,7 @@ endif()
 ## Subdirectories with targets ##
 add_subdirectory(3rd)
 add_subdirectory(po)
+add_subdirectory(po_wxstd)
 add_subdirectory(src)
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -507,6 +507,7 @@ ENDFOREACH()
 add_custom_target(generate_theme_files ALL DEPENDS ${THEMEFILES})
 
 # Generate Reports
+MAKE_DIRECTORY("${CMAKE_CURRENT_BINARY_DIR}/grm")
 GETSUBDIRS(GRMGROUPDIR "${PROJECT_SOURCE_DIR}/general-reports/packages/")
 FOREACH(GRMGROUP ${GRMGROUPDIR})
     GETSUBDIRS(GRMDIR "${PROJECT_SOURCE_DIR}/general-reports/packages/${GRMGROUP}/")
@@ -516,8 +517,8 @@ FOREACH(GRMGROUP ${GRMGROUPDIR})
                                 "${PROJECT_SOURCE_DIR}/general-reports/packages/${GRMGROUP}/${GRMNAME}/sqlcontent.sql"
                                 "${PROJECT_SOURCE_DIR}/general-reports/packages/${GRMGROUP}/${GRMNAME}/template.htt"
         )
-        create_zip("${CMAKE_CURRENT_BINARY_DIR}/${GRMGROUP}-${GRMNAME}.grm" "${GRM_DEFAULT_FILES}" "${PROJECT_SOURCE_DIR}/general-reports/packages/${GRMGROUP}/${GRMNAME}/")
-        list(APPEND GRMFILES "${CMAKE_CURRENT_BINARY_DIR}/${GRMGROUP}-${GRMNAME}.grm")
+        create_zip("${CMAKE_CURRENT_BINARY_DIR}/grm/${GRMGROUP}-${GRMNAME}.grm" "${GRM_DEFAULT_FILES}" "${PROJECT_SOURCE_DIR}/general-reports/packages/${GRMGROUP}/${GRMNAME}/")
+        list(APPEND GRMFILES "${CMAKE_CURRENT_BINARY_DIR}/grm/${GRMGROUP}-${GRMNAME}.grm")
     ENDFOREACH()
 ENDFOREACH()
 add_custom_target(generate_grm_files ALL DEPENDS ${GRMFILES})

--- a/po_wxstd/CMakeLists.txt
+++ b/po_wxstd/CMakeLists.txt
@@ -58,18 +58,10 @@ set(WXSTD_MAP_vi_VN "vi")
 set(WXSTD_MAP_zh_CN "zh_CN")
 set(WXSTD_MAP_zh_TW "zh_TW")
 
-execute_process(
-    COMMAND sh "${wxWidgets_CONFIG_EXECUTABLE}" --prefix
-    OUTPUT_VARIABLE wxWidgets_prefix
-    RESULT_VARIABLE wxWidgets_prefix_result
-    OUTPUT_STRIP_TRAILING_WHITESPACE
-    ERROR_QUIET
-)
-
 set(MMEX_PO_DIRECTORY "${CMAKE_SOURCE_DIR}/po")
-set(WXSTD_PO_DIRECTORY "${wxWidgets_prefix}/locale")
-message(STATUS "MMEX_PO_DIRECTORY: ${MMEX_PO_DIRECTORY}")
-message(STATUS "WXSTD_PO_DIRECTORY: ${WXSTD_PO_DIRECTORY}")
+set(WXSTD_PO_DIRECTORY "${CMAKE_SOURCE_DIR}/po_wxstd")
+#message(STATUS "MMEX_PO_DIRECTORY: ${MMEX_PO_DIRECTORY}")
+#message(STATUS "WXSTD_PO_DIRECTORY: ${WXSTD_PO_DIRECTORY}")
 
 file(GLOB MMEX_PO_FILES RELATIVE "${MMEX_PO_DIRECTORY}" ${MMEX_PO_DIRECTORY}/*.po)
 foreach(mmex_po_file ${MMEX_PO_FILES})
@@ -109,7 +101,7 @@ foreach(mmex_po_file ${MMEX_PO_FILES})
         DESTINATION ${WXSTD_MO_DIRECTORY}
         RENAME ${WXSTD}.mo
     )
-    message(STATUS "wxstd map: ${mmex_basename} -> ${wxstd_basename}")
+    #message(STATUS "wxstd map: ${mmex_basename} -> ${wxstd_basename}")
 
     list(APPEND WXSTD_MO_FILES "${CMAKE_CURRENT_BINARY_DIR}/${wxstd_basename}.mo")
 endforeach()

--- a/po_wxstd/CMakeLists.txt
+++ b/po_wxstd/CMakeLists.txt
@@ -1,0 +1,118 @@
+get_directory_property(m_hasParent PARENT_DIRECTORY)
+if(NOT m_hasParent)
+    message(FATAL_ERROR "Use the top-level CMake script!")
+endif()
+unset(m_hasParent)
+
+find_package(Gettext REQUIRED)
+
+if(NOT GETTEXT_VERSION_STRING)
+    execute_process(COMMAND ${GETTEXT_MSGMERGE_EXECUTABLE} --version
+        OUTPUT_VARIABLE m_version
+        OUTPUT_STRIP_TRAILING_WHITESPACE ERROR_QUIET)
+    get_filename_component(m_name ${GETTEXT_MSGMERGE_EXECUTABLE} NAME)
+    get_filename_component(m_namewe ${GETTEXT_MSGMERGE_EXECUTABLE} NAME_WE)
+    if(m_version MATCHES "^(${m_name}|${m_namewe}) \\([^\\)]*\\) ([0-9\\.]+[^ \n]*)")
+        set(GETTEXT_VERSION_STRING "${CMAKE_MATCH_2}")
+    endif()
+    unset(m_version)
+    unset(m_name)
+    unset(m_namewe)
+endif()
+set(GETTEXT_VERSION_STRING "${GETTEXT_VERSION_STRING}"
+    CACHE INTERNAL "gettext version detected")
+
+# mapping from MMEX basename to wxWidgets basename
+set(WXSTD "wxstd")
+set(WXSTD_MAP_ar_SA "ar")
+set(WXSTD_MAP_ca_ES "ca")
+set(WXSTD_MAP_cs_CZ "cs")
+set(WXSTD_MAP_da_DK "da")
+set(WXSTD_MAP_de_DE "de")
+set(WXSTD_MAP_el_GR "el")
+set(WXSTD_MAP_es_ES "es")
+set(WXSTD_MAP_fa_IR "fa_IR")
+set(WXSTD_MAP_fr_FR "fr")
+set(WXSTD_MAP_hr_HR "hr")
+set(WXSTD_MAP_hu_HU "hu")
+set(WXSTD_MAP_id_ID "id")
+set(WXSTD_MAP_it_IT "it")
+set(WXSTD_MAP_ja_JP "ja")
+set(WXSTD_MAP_ko_KR "ko_KR")
+set(WXSTD_MAP_lt_LT "lt")
+set(WXSTD_MAP_nl_NL "nl")
+set(WXSTD_MAP_pl_PL "pl")
+set(WXSTD_MAP_pt_BR "pt_BR")
+set(WXSTD_MAP_pt_PT "pt")
+set(WXSTD_MAP_ro_RO "ro")
+set(WXSTD_MAP_ru_RU "ru")
+set(WXSTD_MAP_sk_SK "sk")
+set(WXSTD_MAP_sl_SI "sl")
+set(WXSTD_MAP_sq_AL "sq")
+set(WXSTD_MAP_sr    "sr")
+set(WXSTD_MAP_sv_SE "sv")
+set(WXSTD_MAP_ta_IN "ta")
+set(WXSTD_MAP_tr_TR "tr")
+set(WXSTD_MAP_uk_UA "uk")
+set(WXSTD_MAP_vi_VN "vi")
+set(WXSTD_MAP_zh_CN "zh_CN")
+set(WXSTD_MAP_zh_TW "zh_TW")
+
+execute_process(
+    COMMAND sh "${wxWidgets_CONFIG_EXECUTABLE}" --prefix
+    OUTPUT_VARIABLE wxWidgets_prefix
+    RESULT_VARIABLE wxWidgets_prefix_result
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    ERROR_QUIET
+)
+
+set(MMEX_PO_DIRECTORY "${CMAKE_SOURCE_DIR}/po")
+set(WXSTD_PO_DIRECTORY "${wxWidgets_prefix}/locale")
+message(STATUS "MMEX_PO_DIRECTORY: ${MMEX_PO_DIRECTORY}")
+message(STATUS "WXSTD_PO_DIRECTORY: ${WXSTD_PO_DIRECTORY}")
+
+file(GLOB MMEX_PO_FILES RELATIVE "${MMEX_PO_DIRECTORY}" ${MMEX_PO_DIRECTORY}/*.po)
+foreach(mmex_po_file ${MMEX_PO_FILES})
+    get_filename_component(mmex_basename "${mmex_po_file}" NAME_WE)
+
+    # map mmex basename to wxstd basename
+    if(NOT DEFINED WXSTD_MAP_${mmex_basename})
+        continue()
+    endif()
+    set(wxstd_basename "${WXSTD_MAP_${mmex_basename}}")
+
+    # check if wxstd po file exists
+    set(wxstd_po_file "${WXSTD_PO_DIRECTORY}/${wxstd_basename}.po")
+    if(NOT EXISTS "${wxstd_po_file}")
+        continue()
+    endif()
+
+    # copy wxstd file to CMAKE_CURRENT_BINARY_DIR
+    file(COPY ${wxstd_po_file} DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
+
+    # compile wxstd po file
+    add_custom_command(
+        OUTPUT ${wxstd_basename}.mo
+        COMMAND ${GETTEXT_MSGFMT_EXECUTABLE} -v --statistics -o ${wxstd_basename}.mo ${wxstd_basename}.po
+        COMMENT ""
+        MAIN_DEPENDENCY "${wxstd_po_file}"
+    )
+
+    if(APPLE)
+        set(WXSTD_MO_DIRECTORY ${MMEX_EXE}.app/Contents/Resources/${mmex_basename}.lproj)
+    elseif(WIN32)
+        set(WXSTD_MO_DIRECTORY bin/${mmex_basename})
+    else()
+        set(WXSTD_MO_DIRECTORY share/${MMEX_EXE}/${mmex_basename})
+    endif()
+    install(FILES "${CMAKE_CURRENT_BINARY_DIR}/${wxstd_basename}.mo"
+        DESTINATION ${WXSTD_MO_DIRECTORY}
+        RENAME ${WXSTD}.mo
+    )
+    message(STATUS "wxstd map: ${mmex_basename} -> ${wxstd_basename}")
+
+    list(APPEND WXSTD_MO_FILES "${CMAKE_CURRENT_BINARY_DIR}/${wxstd_basename}.mo")
+endforeach()
+
+add_custom_target(wxstd_translations ALL DEPENDS ${WXSTD_MO_FILES}
+    COMMENT "Generated wxstd translations")

--- a/po_wxstd/_readme.txt
+++ b/po_wxstd/_readme.txt
@@ -1,0 +1,10 @@
+Do not modify the .po and .pot files in this directory!
+
+The following files belong to the MMEX project:
+    _readme.txt
+    CMakeLists.txt
+
+The .po and .pot files have been copied from:
+    https://github.com/wxWidgets/wxWidgets/
+
+Last copy: 2026-03-10, from wxWidgets v3.3.2

--- a/po_wxstd/af.po
+++ b/po_wxstd/af.po
@@ -1,0 +1,10324 @@
+# F Wolff <friedel@translate.org.za>, 2013.
+msgid ""
+msgstr ""
+"Project-Id-Version: wxWidgets 3.3\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-05-14 20:23+0200\n"
+"PO-Revision-Date: 2013-11-04 10:21+0200\n"
+"Last-Translator: F Wolff <friedel@translate.org.za>\n"
+"Language-Team: translate-discuss-af@lists.sourceforge.net\n"
+"Language: af\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Virtaal 0.9.0-rc1\n"
+"X-Project-Style: kde\n"
+
+#: ../include/wx/defs.h:2582
+msgid "All files (*.*)|*.*"
+msgstr "Alle lêers (*.*)|*.*"
+
+#: ../include/wx/defs.h:2585
+msgid "All files (*)|*"
+msgstr "Alle lêers (*)|*"
+
+#: ../include/wx/generic/progdlgg.h:85
+msgid "Elapsed time:"
+msgstr "Tydsduur sovêr:"
+
+#: ../include/wx/generic/progdlgg.h:86
+msgid "Estimated time:"
+msgstr "Geskatte tyd:"
+
+#: ../include/wx/generic/progdlgg.h:87
+msgid "Remaining time:"
+msgstr "Oorblywende tyd:"
+
+#. TRANSLATORS: HTML printout default title.
+#: ../include/wx/html/htmprint.h:121 ../include/wx/prntbase.h:273
+#: ../include/wx/richtext/richtextprint.h:109 ../src/common/docview.cpp:2161
+#, fuzzy
+msgid "Printout"
+msgstr "Druk"
+
+#. TRANSLATORS: HTML easy print default title.
+#: ../include/wx/html/htmprint.h:234 ../include/wx/richtext/richtextprint.h:163
+#: ../src/common/prntbase.cpp:522 ../src/html/htmprint.cpp:291
+#, fuzzy
+msgid "Printing"
+msgstr "Besig met drukwerk"
+
+#: ../include/wx/msgdlg.h:277 ../src/common/stockitem.cpp:211
+msgid "Yes"
+msgstr "Ja"
+
+#: ../include/wx/msgdlg.h:278 ../src/common/stockitem.cpp:182
+msgid "No"
+msgstr "Nee"
+
+#: ../include/wx/msgdlg.h:279 ../src/common/stockitem.cpp:183
+#: ../src/msw/msgdlg.cpp:430 ../src/msw/msgdlg.cpp:734
+#: ../src/richtext/richtextstyledlg.cpp:292
+msgid "OK"
+msgstr "Goed"
+
+#: ../include/wx/msgdlg.h:280 ../src/common/stockitem.cpp:150
+#: ../src/msw/msgdlg.cpp:430 ../src/msw/progdlg.cpp:884
+#: ../src/richtext/richtextstyledlg.cpp:295
+msgid "Cancel"
+msgstr "Kanselleer"
+
+#: ../include/wx/msgdlg.h:281 ../src/common/stockitem.cpp:168
+#: ../src/html/helpdlg.cpp:63 ../src/html/helpfrm.cpp:108
+#: ../src/osx/button_osx.cpp:38
+msgid "Help"
+msgstr "Hulp"
+
+#: ../include/wx/msw/ole/oleutils.h:52
+msgid "Cannot initialize OLE"
+msgstr "Kan OLE nie inisialiseer nie"
+
+#: ../include/wx/msw/private/fswatcher.h:48
+#, fuzzy, c-format
+msgid "Unable to close the handle for '%s'"
+msgstr "Toemaak van lêer het misluk."
+
+#: ../include/wx/msw/private/fswatcher.h:92
+#, c-format
+msgid "Failed to open directory \"%s\" for monitoring."
+msgstr "Opening van gids \"%s\" vir monitering het misluk."
+
+#: ../include/wx/msw/private/fswatcher.h:125
+#, fuzzy
+msgid "Unable to close I/O completion port handle"
+msgstr "Toemaak van T/A-voltooipoort het misluk"
+
+#: ../include/wx/msw/private/fswatcher.h:142
+msgid "Unable to associate handle with I/O completion port"
+msgstr ""
+
+#: ../include/wx/msw/private/fswatcher.h:148
+msgid "Unexpectedly new I/O completion port was created"
+msgstr ""
+
+#: ../include/wx/msw/private/fswatcher.h:213
+msgid "Unable to post completion status"
+msgstr ""
+
+#: ../include/wx/msw/private/fswatcher.h:262
+msgid "Unable to dequeue completion packet"
+msgstr ""
+
+#: ../include/wx/msw/private/fswatcher.h:273
+#, fuzzy
+msgid "Unable to create I/O completion port"
+msgstr "Wyser kon nie geskep word nie."
+
+#: ../include/wx/richmsgdlg.h:29
+msgid "&See details"
+msgstr "&Wys besonderhede"
+
+#: ../include/wx/richmsgdlg.h:30
+msgid "&Hide details"
+msgstr "&Versteek besonderhede"
+
+#: ../include/wx/richtext/richtextbuffer.h:3864
+msgid "&Box"
+msgstr "&Boks"
+
+#: ../include/wx/richtext/richtextbuffer.h:5008
+msgid "&Picture"
+msgstr "&Prent"
+
+#: ../include/wx/richtext/richtextbuffer.h:5958
+msgid "&Cell"
+msgstr "&Sel"
+
+#: ../include/wx/richtext/richtextbuffer.h:6067
+msgid "&Table"
+msgstr "&Tabel"
+
+#: ../include/wx/richtext/richtextimagedlg.h:37
+msgid "Object Properties"
+msgstr "Objek-eienskappe"
+
+#: ../include/wx/richtext/richtextsymboldlg.h:39
+msgid "Symbols"
+msgstr "Simbole"
+
+#: ../include/wx/unix/pipe.h:46
+msgid "Pipe creation failed"
+msgstr "Opstel van pyp het misluk"
+
+#: ../include/wx/unix/private/displayx11.h:65
+msgid "Failed to enumerate video modes"
+msgstr "Videomodusse kon nie gelys word nie"
+
+#: ../include/wx/unix/private/displayx11.h:89
+msgid "Failed to change video mode"
+msgstr "Videomodus kon nie verander word nie"
+
+#: ../include/wx/unix/private/fswatcher_kqueue.h:57
+#, c-format
+msgid "Unable to open path '%s'"
+msgstr "Kan nie die pad '%s' open nie"
+
+#: ../include/wx/unix/private/fswatcher_kqueue.h:74
+#, c-format
+msgid "Unable to close path '%s'"
+msgstr "Kan nie die pad '%s' toemaak nie"
+
+#: ../include/wx/xtiprop.h:175
+msgid "SetProperty called w/o valid setter"
+msgstr "SetProperty is geroep sonder geldige 'set'-metode"
+
+#: ../include/wx/xtiprop.h:184
+msgid "GetProperty called w/o valid getter"
+msgstr "GetProperty is geroep sonder 'n geldige 'get'-metode"
+
+#: ../include/wx/xtiprop.h:193
+msgid "AddToPropertyCollection called w/o valid adder"
+msgstr "AddToPropertyCollection is geroep sonder geldige byvoeger"
+
+#: ../include/wx/xtiprop.h:202
+msgid "GetPropertyCollection called w/o valid collection getter"
+msgstr "GetPropertyCollection is geroep sonder geldige metode"
+
+#: ../include/wx/xtiprop.h:255
+msgid "AddToPropertyCollection called on a generic accessor"
+msgstr "AddToPropertyCollection is geroep op 'n generiese toegangsmetode"
+
+#: ../include/wx/xtiprop.h:262
+msgid "GetPropertyCollection called on a generic accessor"
+msgstr "GetPropertyCollection is geroep vir 'n generiese toegangsmetode"
+
+#: ../src/aui/tabmdi.cpp:106 ../src/generic/mdig.cpp:94
+msgid "Cl&ose"
+msgstr "Maak &toe"
+
+#: ../src/aui/tabmdi.cpp:107 ../src/generic/mdig.cpp:95
+msgid "Close All"
+msgstr "Maak alles toe"
+
+#: ../src/aui/tabmdi.cpp:109 ../src/generic/mdig.cpp:97 ../src/msw/mdi.cpp:175
+#: ../src/qt/mdi.cpp:258
+msgid "&Next"
+msgstr "&Volgende"
+
+#: ../src/aui/tabmdi.cpp:110 ../src/generic/mdig.cpp:98 ../src/msw/mdi.cpp:176
+#: ../src/qt/mdi.cpp:259
+msgid "&Previous"
+msgstr "Vo&rige"
+
+#: ../src/aui/tabmdi.cpp:332 ../src/aui/tabmdi.cpp:348
+#: ../src/aui/tabmdi.cpp:350 ../src/generic/mdig.cpp:291
+#: ../src/generic/mdig.cpp:307 ../src/generic/mdig.cpp:311
+#: ../src/msw/mdi.cpp:337 ../src/qt/mdi.cpp:462
+msgid "&Window"
+msgstr "&Venster"
+
+#: ../src/common/accelcmn.cpp:47
+msgctxt "keyboard key"
+msgid "Delete"
+msgstr "Skrap"
+
+#: ../src/common/accelcmn.cpp:48
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Del"
+msgstr "Skrap"
+
+#: ../src/common/accelcmn.cpp:49
+msgctxt "keyboard key"
+msgid "Back"
+msgstr "Terug"
+
+#: ../src/common/accelcmn.cpp:49
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Backspace"
+msgstr "Terug"
+
+#: ../src/common/accelcmn.cpp:50
+msgctxt "keyboard key"
+msgid "Insert"
+msgstr "Voeg in"
+
+#: ../src/common/accelcmn.cpp:51
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Ins"
+msgstr "Indeks"
+
+#: ../src/common/accelcmn.cpp:52
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Enter"
+msgstr "Drukker"
+
+#: ../src/common/accelcmn.cpp:53
+msgctxt "keyboard key"
+msgid "Return"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:54
+#, fuzzy
+msgctxt "keyboard key"
+msgid "PageUp"
+msgstr "Bladsye"
+
+#: ../src/common/accelcmn.cpp:54
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Page Up"
+msgstr "Bladsy %d"
+
+#: ../src/common/accelcmn.cpp:55
+#, fuzzy
+msgctxt "keyboard key"
+msgid "PageDown"
+msgstr "Af"
+
+#: ../src/common/accelcmn.cpp:55
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Page Down"
+msgstr "Bladsy %d"
+
+#: ../src/common/accelcmn.cpp:56
+msgctxt "keyboard key"
+msgid "PgUp"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:57
+msgctxt "keyboard key"
+msgid "PgDn"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:58
+msgctxt "keyboard key"
+msgid "Left"
+msgstr "Links"
+
+#: ../src/common/accelcmn.cpp:59
+msgctxt "keyboard key"
+msgid "Right"
+msgstr "Regs"
+
+#: ../src/common/accelcmn.cpp:60
+msgctxt "keyboard key"
+msgid "Up"
+msgstr "Op"
+
+#: ../src/common/accelcmn.cpp:61
+msgctxt "keyboard key"
+msgid "Down"
+msgstr "Af"
+
+#: ../src/common/accelcmn.cpp:62
+msgctxt "keyboard key"
+msgid "Home"
+msgstr "Tuis"
+
+#: ../src/common/accelcmn.cpp:63
+msgctxt "keyboard key"
+msgid "End"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:64
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Space"
+msgstr "Spasiëring"
+
+#: ../src/common/accelcmn.cpp:65
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Tab"
+msgstr "&Tabel"
+
+#: ../src/common/accelcmn.cpp:66
+msgctxt "keyboard key"
+msgid "Esc"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:67
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Escape"
+msgstr "Dwars"
+
+#: ../src/common/accelcmn.cpp:68
+msgctxt "keyboard key"
+msgid "Cancel"
+msgstr "Kanselleer"
+
+#: ../src/common/accelcmn.cpp:69
+msgctxt "keyboard key"
+msgid "Clear"
+msgstr "Maak skoon"
+
+#: ../src/common/accelcmn.cpp:70
+msgctxt "keyboard key"
+msgid "Menu"
+msgstr "Kieslys"
+
+#: ../src/common/accelcmn.cpp:71
+msgctxt "keyboard key"
+msgid "Pause"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:72
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Capital"
+msgstr "Hoof&letters"
+
+#: ../src/common/accelcmn.cpp:73
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Select"
+msgstr "Seleksie"
+
+#: ../src/common/accelcmn.cpp:74
+msgctxt "keyboard key"
+msgid "Print"
+msgstr "Druk"
+
+#: ../src/common/accelcmn.cpp:75
+msgctxt "keyboard key"
+msgid "Execute"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:76
+msgctxt "keyboard key"
+msgid "Snapshot"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:77
+msgctxt "keyboard key"
+msgid "Help"
+msgstr "Hulp"
+
+#: ../src/common/accelcmn.cpp:78
+msgctxt "keyboard key"
+msgid "Add"
+msgstr "Voeg by"
+
+#: ../src/common/accelcmn.cpp:79
+msgctxt "keyboard key"
+msgid "Separator"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:80
+msgctxt "keyboard key"
+msgid "Subtract"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:81
+msgctxt "keyboard key"
+msgid "Decimal"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:82
+msgctxt "keyboard key"
+msgid "Multiply"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:83
+msgctxt "keyboard key"
+msgid "Divide"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:84
+msgctxt "keyboard key"
+msgid "Num_lock"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:84
+msgctxt "keyboard key"
+msgid "Num Lock"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:85
+msgctxt "keyboard key"
+msgid "Scroll_lock"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:85
+msgctxt "keyboard key"
+msgid "Scroll Lock"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:86
+msgctxt "keyboard key"
+msgid "KP_Space"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:86
+msgctxt "keyboard key"
+msgid "Num Space"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:87
+msgctxt "keyboard key"
+msgid "KP_Tab"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:87
+msgctxt "keyboard key"
+msgid "Num Tab"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:88
+#, fuzzy
+msgctxt "keyboard key"
+msgid "KP_Enter"
+msgstr "Drukker"
+
+#: ../src/common/accelcmn.cpp:88
+msgctxt "keyboard key"
+msgid "Num Enter"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:89
+#, fuzzy
+msgctxt "keyboard key"
+msgid "KP_Home"
+msgstr "Tuis"
+
+#: ../src/common/accelcmn.cpp:89
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Num Home"
+msgstr "Tuis"
+
+#: ../src/common/accelcmn.cpp:90
+#, fuzzy
+msgctxt "keyboard key"
+msgid "KP_Left"
+msgstr "Links"
+
+#: ../src/common/accelcmn.cpp:90
+msgctxt "keyboard key"
+msgid "Num left"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:91
+msgctxt "keyboard key"
+msgid "KP_Up"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:91
+msgctxt "keyboard key"
+msgid "Num Up"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:92
+#, fuzzy
+msgctxt "keyboard key"
+msgid "KP_Right"
+msgstr "Regs"
+
+#: ../src/common/accelcmn.cpp:92
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Num Right"
+msgstr "Regs"
+
+#: ../src/common/accelcmn.cpp:93
+#, fuzzy
+msgctxt "keyboard key"
+msgid "KP_Down"
+msgstr "Af"
+
+#: ../src/common/accelcmn.cpp:93
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Num Down"
+msgstr "Af"
+
+#: ../src/common/accelcmn.cpp:94
+msgctxt "keyboard key"
+msgid "KP_PageUp"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:94
+msgctxt "keyboard key"
+msgid "Num Page Up"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:95
+msgctxt "keyboard key"
+msgid "KP_PageDown"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:95
+msgctxt "keyboard key"
+msgid "Num Page Down"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:96
+msgctxt "keyboard key"
+msgid "KP_Prior"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:97
+#, fuzzy
+msgctxt "keyboard key"
+msgid "KP_Next"
+msgstr "Volgende"
+
+#: ../src/common/accelcmn.cpp:98
+msgctxt "keyboard key"
+msgid "KP_End"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:98
+msgctxt "keyboard key"
+msgid "Num End"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:99
+msgctxt "keyboard key"
+msgid "KP_Begin"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:99
+msgctxt "keyboard key"
+msgid "Num Begin"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:100
+#, fuzzy
+msgctxt "keyboard key"
+msgid "KP_Insert"
+msgstr "Voeg in"
+
+#: ../src/common/accelcmn.cpp:100
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Num Insert"
+msgstr "Voeg in"
+
+#: ../src/common/accelcmn.cpp:101
+#, fuzzy
+msgctxt "keyboard key"
+msgid "KP_Delete"
+msgstr "Skrap"
+
+#: ../src/common/accelcmn.cpp:101
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Num Delete"
+msgstr "Skrap"
+
+#: ../src/common/accelcmn.cpp:102
+msgctxt "keyboard key"
+msgid "KP_Equal"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:102
+msgctxt "keyboard key"
+msgid "Num ="
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:103
+msgctxt "keyboard key"
+msgid "KP_Multiply"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:103
+msgctxt "keyboard key"
+msgid "Num *"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:104
+msgctxt "keyboard key"
+msgid "KP_Add"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:104
+msgctxt "keyboard key"
+msgid "Num +"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:105
+msgctxt "keyboard key"
+msgid "KP_Separator"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:105
+msgctxt "keyboard key"
+msgid "Num ,"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:106
+msgctxt "keyboard key"
+msgid "KP_Subtract"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:106
+msgctxt "keyboard key"
+msgid "Num -"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:107
+msgctxt "keyboard key"
+msgid "KP_Decimal"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:107
+msgctxt "keyboard key"
+msgid "Num ."
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:108
+msgctxt "keyboard key"
+msgid "KP_Divide"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:108
+msgctxt "keyboard key"
+msgid "Num /"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:109
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Windows_Left"
+msgstr "Windows 7"
+
+#: ../src/common/accelcmn.cpp:110
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Windows_Right"
+msgstr "Windows Vista"
+
+#: ../src/common/accelcmn.cpp:111
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Windows_Menu"
+msgstr "Windows ME"
+
+#: ../src/common/accelcmn.cpp:112
+msgctxt "keyboard key"
+msgid "Command"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:186 ../src/common/accelcmn.cpp:359
+msgctxt "keyboard key"
+msgid "Ctrl"
+msgstr "Ctrl"
+
+#: ../src/common/accelcmn.cpp:188 ../src/common/accelcmn.cpp:363
+msgctxt "keyboard key"
+msgid "Alt"
+msgstr "Alt"
+
+#: ../src/common/accelcmn.cpp:190 ../src/common/accelcmn.cpp:361
+msgctxt "keyboard key"
+msgid "Shift"
+msgstr "Shift"
+
+#: ../src/common/accelcmn.cpp:196
+msgctxt "keyboard key"
+msgid "num "
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:260 ../src/common/accelcmn.cpp:382
+msgctxt "keyboard key"
+msgid "F"
+msgstr "F"
+
+#: ../src/common/accelcmn.cpp:277 ../src/common/accelcmn.cpp:385
+msgctxt "keyboard key"
+msgid "KP_F"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:280 ../src/common/accelcmn.cpp:388
+msgctxt "keyboard key"
+msgid "KP_"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:283 ../src/common/accelcmn.cpp:391
+msgctxt "keyboard key"
+msgid "SPECIAL"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:373
+#, fuzzy
+msgid "Ctrl"
+msgstr "Ctrl"
+
+#: ../src/common/appbase.cpp:786
+msgid "show this help message"
+msgstr "Wys hierdie hulpboodskap"
+
+#: ../src/common/appbase.cpp:796
+msgid "generate verbose log messages"
+msgstr "genereer uitgebreide boekstaafboodskappe"
+
+#: ../src/common/appcmn.cpp:256
+msgid "specify the theme to use"
+msgstr "Kies die tema om te gebruik"
+
+#: ../src/common/appcmn.cpp:270
+msgid "specify display mode to use (e.g. 640x480-16)"
+msgstr "Kies die vertoonskerm modus (bv. 640x480-16) om te gebruik"
+
+#: ../src/common/appcmn.cpp:292
+#, c-format
+msgid "Unsupported theme '%s'."
+msgstr "Nie-ondersteunde tema '%s'."
+
+#: ../src/common/appcmn.cpp:309
+#, c-format
+msgid "Invalid display mode specification '%s'."
+msgstr "Spesifikasie '%s' vir vertoonskermmodus is ongeldig."
+
+#: ../src/common/cmdline.cpp:875
+#, fuzzy, c-format
+msgid "Option '%s' can't be negated"
+msgstr "Gids '%s' kon nie geskep word nie"
+
+#: ../src/common/cmdline.cpp:889
+#, c-format
+msgid "Unknown long option '%s'"
+msgstr "Onbekende lang opsie '%s'"
+
+#: ../src/common/cmdline.cpp:904 ../src/common/cmdline.cpp:926
+#, c-format
+msgid "Unknown option '%s'"
+msgstr "Onbekende opsie '%s'"
+
+#: ../src/common/cmdline.cpp:1004
+#, c-format
+msgid "Unexpected characters following option '%s'."
+msgstr "Onverwagte karakters wat volg op opsie '%s'."
+
+#: ../src/common/cmdline.cpp:1039
+#, c-format
+msgid "Option '%s' requires a value."
+msgstr "Opsie '%s' vereis 'n waarde."
+
+#: ../src/common/cmdline.cpp:1058
+#, c-format
+msgid "Separator expected after the option '%s'."
+msgstr "Skeidingsteken is verwag na die opsie '%s'."
+
+#: ../src/common/cmdline.cpp:1088 ../src/common/cmdline.cpp:1106
+#, c-format
+msgid "'%s' is not a correct numeric value for option '%s'."
+msgstr "'%s' is nie 'n geldige numeriese waarde vir opsie '%s' nie."
+
+#: ../src/common/cmdline.cpp:1122
+#, c-format
+msgid "Option '%s': '%s' cannot be converted to a date."
+msgstr "Opsie '%s': '%s' kan nie na 'n datum omgeskakel word nie."
+
+#: ../src/common/cmdline.cpp:1170
+#, c-format
+msgid "Unexpected parameter '%s'"
+msgstr "Onverwagte parameter '%s'"
+
+#. TRANSLATORS: Short name and long name for a command line option
+#: ../src/common/cmdline.cpp:1197
+#, c-format
+msgid "%s (or %s)"
+msgstr "%s (of %s)"
+
+#: ../src/common/cmdline.cpp:1208
+#, c-format
+msgid "The value for the option '%s' must be specified."
+msgstr "Die waarde voor die opsie '%s' moet gespesifiseer word."
+
+#: ../src/common/cmdline.cpp:1230
+#, c-format
+msgid "The required parameter '%s' was not specified."
+msgstr "Die vereiste parameter '%s' is nie gespesifiseer nie."
+
+#: ../src/common/cmdline.cpp:1289
+#, c-format
+msgid "Usage: %s"
+msgstr "Gebruik: %s"
+
+#: ../src/common/cmdline.cpp:1498
+msgid "str"
+msgstr "str"
+
+#: ../src/common/cmdline.cpp:1502
+msgid "num"
+msgstr "num"
+
+#: ../src/common/cmdline.cpp:1506
+msgid "double"
+msgstr ""
+
+#: ../src/common/cmdline.cpp:1510
+msgid "date"
+msgstr "datum"
+
+#: ../src/common/cmdproc.cpp:250 ../src/common/cmdproc.cpp:276
+#: ../src/common/cmdproc.cpp:296
+msgid "Unnamed command"
+msgstr "Naamlose bevel"
+
+#: ../src/common/cmdproc.cpp:253
+msgid "&Undo "
+msgstr "&Ontdoen"
+
+#: ../src/common/cmdproc.cpp:255
+msgid "Can't &Undo "
+msgstr "Kan nie &ontdoen nie "
+
+#: ../src/common/cmdproc.cpp:259 ../src/common/stockitem.cpp:208
+#: ../src/msw/textctrl.cpp:2880 ../src/osx/textctrl_osx.cpp:649
+#: ../src/richtext/richtextctrl.cpp:327
+msgid "&Undo"
+msgstr "&Ontdoen"
+
+#: ../src/common/cmdproc.cpp:277 ../src/common/cmdproc.cpp:297
+msgid "&Redo "
+msgstr "He&rdoen "
+
+#: ../src/common/cmdproc.cpp:281 ../src/common/cmdproc.cpp:288
+#: ../src/common/stockitem.cpp:190 ../src/msw/textctrl.cpp:2881
+#: ../src/osx/textctrl_osx.cpp:650 ../src/richtext/richtextctrl.cpp:328
+msgid "&Redo"
+msgstr "He&rdoen"
+
+#: ../src/common/colourcmn.cpp:41
+#, c-format
+msgid "String To Colour : Incorrect colour specification : %s"
+msgstr "String-na-kleur : Verkeerde kleurspesifikasie : %s"
+
+#: ../src/common/config.cpp:259
+#, c-format
+msgid "Invalid value %ld for a boolean key \"%s\" in config file."
+msgstr ""
+
+#: ../src/common/config.cpp:526
+#, fuzzy, c-format
+msgid ""
+"Environment variables expansion failed: missing '%c' at position %u in '%s'."
+msgstr ""
+"Uitbreiding van omgewingsveranderlikes het misluk: ontbrekende '%c' op "
+"posisie %d in '%s'."
+
+#: ../src/common/config.cpp:576 ../src/msw/regconf.cpp:272
+#, c-format
+msgid "'%s' has extra '..', ignored."
+msgstr "'%s' het ekstra '..', geïgnoreer."
+
+#. TRANSLATORS: Checkbox state name
+#: ../src/common/datavcmn.cpp:2166 ../src/generic/datavgen.cpp:1430
+msgid "checked"
+msgstr ""
+
+#. TRANSLATORS: Checkbox state name
+#: ../src/common/datavcmn.cpp:2170 ../src/generic/datavgen.cpp:1432
+msgid "unchecked"
+msgstr ""
+
+#. TRANSLATORS: Checkbox state name
+#: ../src/common/datavcmn.cpp:2174
+#, fuzzy
+msgid "undetermined"
+msgstr "onderstreep"
+
+#: ../src/common/datetimefmt.cpp:1875
+msgid "today"
+msgstr "vandag"
+
+#: ../src/common/datetimefmt.cpp:1876
+msgid "yesterday"
+msgstr "gister"
+
+#: ../src/common/datetimefmt.cpp:1877
+msgid "tomorrow"
+msgstr "môre"
+
+#: ../src/common/datetimefmt.cpp:2071
+msgid "first"
+msgstr "eerste"
+
+#: ../src/common/datetimefmt.cpp:2072
+msgid "second"
+msgstr "tweede"
+
+#: ../src/common/datetimefmt.cpp:2073
+msgid "third"
+msgstr "derde"
+
+#: ../src/common/datetimefmt.cpp:2074
+msgid "fourth"
+msgstr "vierde"
+
+#: ../src/common/datetimefmt.cpp:2075
+msgid "fifth"
+msgstr "vyfde"
+
+#: ../src/common/datetimefmt.cpp:2076
+msgid "sixth"
+msgstr "sesde"
+
+#: ../src/common/datetimefmt.cpp:2077
+msgid "seventh"
+msgstr "sewende"
+
+#: ../src/common/datetimefmt.cpp:2078
+msgid "eighth"
+msgstr "agtste"
+
+#: ../src/common/datetimefmt.cpp:2079
+msgid "ninth"
+msgstr "negende"
+
+#: ../src/common/datetimefmt.cpp:2080
+msgid "tenth"
+msgstr "tiende"
+
+#: ../src/common/datetimefmt.cpp:2081
+msgid "eleventh"
+msgstr "elfde"
+
+#: ../src/common/datetimefmt.cpp:2082
+msgid "twelfth"
+msgstr "twaalfde"
+
+#: ../src/common/datetimefmt.cpp:2083
+msgid "thirteenth"
+msgstr "dertiende"
+
+#: ../src/common/datetimefmt.cpp:2084
+msgid "fourteenth"
+msgstr "veertiende"
+
+#: ../src/common/datetimefmt.cpp:2085
+msgid "fifteenth"
+msgstr "vyftiende"
+
+#: ../src/common/datetimefmt.cpp:2086
+msgid "sixteenth"
+msgstr "sestiende"
+
+#: ../src/common/datetimefmt.cpp:2087
+msgid "seventeenth"
+msgstr "sewentiende"
+
+#: ../src/common/datetimefmt.cpp:2088
+msgid "eighteenth"
+msgstr "agtiende"
+
+#: ../src/common/datetimefmt.cpp:2089
+msgid "nineteenth"
+msgstr "negentiende"
+
+#: ../src/common/datetimefmt.cpp:2090
+msgid "twentieth"
+msgstr "twintigste"
+
+#: ../src/common/datetimefmt.cpp:2248
+msgid "noon"
+msgstr "middag"
+
+#: ../src/common/datetimefmt.cpp:2249
+msgid "midnight"
+msgstr "middernag"
+
+#: ../src/common/debugrpt.cpp:209
+#, c-format
+msgid "Failed to create directory \"%s\""
+msgstr "Gids \"%s\" kon nie geskep word nie"
+
+#: ../src/common/debugrpt.cpp:210
+#, fuzzy
+msgid "Debug report couldn't be created."
+msgstr "Gids '%s' kon nie geskep word nie"
+
+#: ../src/common/debugrpt.cpp:227
+#, fuzzy, c-format
+msgid "Failed to remove debug report file \"%s\""
+msgstr "Verwydering van slotlêer '%s' het misluk"
+
+#: ../src/common/debugrpt.cpp:239
+#, fuzzy, c-format
+msgid "Failed to clean up debug report directory \"%s\""
+msgstr "Die gids %s/.gnome kon nie geskep word nie."
+
+#: ../src/common/debugrpt.cpp:514
+msgid "process context description"
+msgstr ""
+
+#: ../src/common/debugrpt.cpp:538
+msgid "dump of the process state (binary)"
+msgstr ""
+
+#: ../src/common/debugrpt.cpp:553
+msgid "Debug report generation has failed."
+msgstr ""
+
+#: ../src/common/debugrpt.cpp:560
+#, c-format
+msgid ""
+"Processing debug report has failed, leaving the files in \"%s\" directory."
+msgstr ""
+
+#: ../src/common/debugrpt.cpp:573
+msgid "A debug report has been generated. It can be found in"
+msgstr ""
+
+#: ../src/common/debugrpt.cpp:576
+msgid "And includes the following files:\n"
+msgstr ""
+
+#: ../src/common/debugrpt.cpp:586
+msgid ""
+"\n"
+"Please send this report to the program maintainer, thank you!\n"
+msgstr ""
+"\n"
+"Stuur asb. die verslag aan wie ook al die program onderhou. Dankie!\n"
+
+#: ../src/common/debugrpt.cpp:729
+msgid "Failed to execute curl, please install it in PATH."
+msgstr "Kon nie curl laat loop nie. Installeer dit asb. in PATH."
+
+#: ../src/common/debugrpt.cpp:742
+#, fuzzy, c-format
+msgid "Failed to upload the debug report (error code %d)."
+msgstr ""
+"Die standaard soek/vervang-dialoog kon nie geskep word nie (foutkode %d)"
+
+#: ../src/common/docview.cpp:366
+msgid "Save As"
+msgstr "Stoor as"
+
+#: ../src/common/docview.cpp:457
+msgid "Discard changes and reload the last saved version?"
+msgstr "Verwerp veranderinge en herlaai die laaste gestoorde weergawe?"
+
+#: ../src/common/docview.cpp:488
+msgid "unnamed"
+msgstr "naamloos"
+
+#: ../src/common/docview.cpp:513
+#, c-format
+msgid "Do you want to save changes to %s?"
+msgstr "Wil u die veranderinge aan %s stoor?"
+
+#: ../src/common/docview.cpp:521 ../src/common/docview.cpp:560
+#: ../src/common/stockitem.cpp:195
+msgid "&Save"
+msgstr "&Stoor"
+
+#: ../src/common/docview.cpp:522 ../src/common/docview.cpp:560
+msgid "&Discard changes"
+msgstr ""
+
+#: ../src/common/docview.cpp:523
+#, fuzzy
+msgid "Do&n't close"
+msgstr "Moenie stoor nie"
+
+#: ../src/common/docview.cpp:553
+#, fuzzy, c-format
+msgid "Do you want to save changes to %s before closing it?"
+msgstr "Wil u die veranderinge aan %s stoor?"
+
+#: ../src/common/docview.cpp:559
+#, fuzzy
+msgid "The document must be closed."
+msgstr "Die teks kon nie gestoor word nie."
+
+#: ../src/common/docview.cpp:571
+#, c-format
+msgid "Saving %s failed, would you like to retry?"
+msgstr ""
+
+#: ../src/common/docview.cpp:577
+msgid "Retry"
+msgstr ""
+
+#: ../src/common/docview.cpp:577
+msgid "Discard changes"
+msgstr ""
+
+#: ../src/common/docview.cpp:679
+#, c-format
+msgid "File \"%s\" could not be opened for writing."
+msgstr "Opening van \"%s\" vir skryfwerk het misluk."
+
+#: ../src/common/docview.cpp:685
+#, c-format
+msgid "Failed to save document to the file \"%s\"."
+msgstr "Kon nie dokument stoor na die lêer \"%s\" nie."
+
+#: ../src/common/docview.cpp:702
+#, c-format
+msgid "File \"%s\" could not be opened for reading."
+msgstr "Opening van \"%s\" vir leeswerk het misluk."
+
+#: ../src/common/docview.cpp:714
+#, c-format
+msgid "Failed to read document from the file \"%s\"."
+msgstr "Lees van dokument vanuit lêer \"%s\" het misluk."
+
+#: ../src/common/docview.cpp:1236
+#, c-format
+msgid ""
+"The file '%s' doesn't exist and couldn't be opened.\n"
+"It has been removed from the most recently used files list."
+msgstr ""
+"Die lêer '%s' bestaan nie en kon nie oopgemaak word nie.\n"
+"Dit is verwyder van die lys van 'onlangse lêers'."
+
+#: ../src/common/docview.cpp:1296
+#, fuzzy
+msgid "Print preview creation failed."
+msgstr "Opstel van pyp het misluk"
+
+#: ../src/common/docview.cpp:1302
+msgid "Print Preview"
+msgstr "Drukvoorskou"
+
+#: ../src/common/docview.cpp:1517
+#, fuzzy, c-format
+msgid "The format of file '%s' couldn't be determined."
+msgstr "Gids '%s' kon nie geskep word nie"
+
+#: ../src/common/docview.cpp:1643
+#, c-format
+msgid "unnamed%d"
+msgstr "naamloos%d"
+
+#: ../src/common/docview.cpp:1660
+msgid " - "
+msgstr " - "
+
+#: ../src/common/docview.cpp:1791 ../src/common/docview.cpp:1844
+msgid "Open File"
+msgstr "Open Lêer"
+
+#: ../src/common/docview.cpp:1807
+msgid "File error"
+msgstr "Lêerfout"
+
+#: ../src/common/docview.cpp:1809
+msgid "Sorry, could not open this file."
+msgstr "Jammer, hierdie lêer kon nie oopgemaak word nie."
+
+#: ../src/common/docview.cpp:1843
+msgid "Sorry, the format for this file is unknown."
+msgstr "Jammer, die lêer het 'n onbekende formaat."
+
+#: ../src/common/docview.cpp:1924
+msgid "Select a document template"
+msgstr "Kies 'n dokumentsjabloon"
+
+#: ../src/common/docview.cpp:1925
+msgid "Templates"
+msgstr "Sjablone"
+
+#: ../src/common/docview.cpp:1998
+msgid "Select a document view"
+msgstr "Kies 'n dokumentweergawe"
+
+#: ../src/common/docview.cpp:1999
+msgid "Views"
+msgstr "Aansigte"
+
+#: ../src/common/dynlib.cpp:81
+#, c-format
+msgid "Failed to load shared library '%s'"
+msgstr "Laai van gedeelde biblioteek '%s' het misluk"
+
+#: ../src/common/dynlib.cpp:105
+#, c-format
+msgid "Couldn't find symbol '%s' in a dynamic library"
+msgstr "Kon nie simbool %s vind in 'n dinamiese biblioteek nie"
+
+#: ../src/common/ffile.cpp:56 ../src/common/file.cpp:215
+#, c-format
+msgid "can't open file '%s'"
+msgstr "kan lêer '%s' nie oopmaak nie"
+
+#: ../src/common/ffile.cpp:72
+#, c-format
+msgid "can't close file '%s'"
+msgstr "kan lêer '%s' nie toemaak nie"
+
+#: ../src/common/ffile.cpp:106 ../src/common/ffile.cpp:131
+#, c-format
+msgid "Read error on file '%s'"
+msgstr "Leesfout by lêer '%s'"
+
+#: ../src/common/ffile.cpp:148
+#, c-format
+msgid "Write error on file '%s'"
+msgstr "Skryffout by lêer '%s'"
+
+#: ../src/common/ffile.cpp:182
+#, c-format
+msgid "failed to flush the file '%s'"
+msgstr "leegmaak van lêer '%s' het misluk"
+
+#: ../src/common/ffile.cpp:222
+#, c-format
+msgid "Seek error on file '%s' (large files not supported by stdio)"
+msgstr ""
+
+#: ../src/common/ffile.cpp:232
+#, c-format
+msgid "Seek error on file '%s'"
+msgstr "Soekfout by lêer '%s'"
+
+#: ../src/common/ffile.cpp:248
+#, c-format
+msgid "Can't find current position in file '%s'"
+msgstr "Kan nie huidige posisie in lêer '%s' vind nie"
+
+#: ../src/common/ffile.cpp:349 ../src/common/file.cpp:569
+msgid "Failed to set temporary file permissions"
+msgstr "Opstelling van magtigings van tydelyke lêer het misluk"
+
+#: ../src/common/ffile.cpp:371
+#, c-format
+msgid "can't remove file '%s'"
+msgstr "kan lêer '%s' nie verwyder nie"
+
+#: ../src/common/ffile.cpp:376 ../src/common/file.cpp:591
+#, c-format
+msgid "can't commit changes to file '%s'"
+msgstr "kan verandering nie deurvoer na lêer '%s' nie"
+
+#: ../src/common/ffile.cpp:388 ../src/common/file.cpp:603
+#, c-format
+msgid "can't remove temporary file '%s'"
+msgstr "kan tydelike lêer '%s' nie verwyder nie"
+
+#: ../src/common/file.cpp:162
+#, c-format
+msgid "can't create file '%s'"
+msgstr "kan lêer '%s' nie maak nie"
+
+#: ../src/common/file.cpp:229
+#, c-format
+msgid "can't close file descriptor %d"
+msgstr "kan lêeretiket %d nie toemaak nie"
+
+#: ../src/common/file.cpp:332
+#, c-format
+msgid "can't read from file descriptor %d"
+msgstr "kan nie lees van lêeretiket %d"
+
+#: ../src/common/file.cpp:351
+#, c-format
+msgid "can't write to file descriptor %d"
+msgstr "kan nie skryf na lêeretiket %d nie"
+
+#: ../src/common/file.cpp:390
+#, c-format
+msgid "can't flush file descriptor %d"
+msgstr "kan lêeretiket %d nie leegmaak nie"
+
+#: ../src/common/file.cpp:432
+#, c-format
+msgid "can't seek on file descriptor %d"
+msgstr "kan nie 'n soekbewerking doen op lêeretiket %d nie"
+
+#: ../src/common/file.cpp:446
+#, c-format
+msgid "can't get seek position on file descriptor %d"
+msgstr "kan nie soekposisie verkry by lêeretiket %d nie"
+
+#: ../src/common/file.cpp:475
+#, c-format
+msgid "can't find length of file on file descriptor %d"
+msgstr "kan lêerlengte nie vind vir lêeretiket %d nie"
+
+#: ../src/common/file.cpp:505
+#, c-format
+msgid "can't determine if the end of file is reached on descriptor %d"
+msgstr "kan nie bepaal of lêereinde bereik is vir lêeretiket %d nie"
+
+#: ../src/common/fileconf.cpp:352
+#, c-format
+msgid ""
+" and additionally, the existing configuration file was renamed to \"%s\" and "
+"couldn't be renamed back, please rename it to its original path \"%s\""
+msgstr ""
+
+#: ../src/common/fileconf.cpp:389
+msgid " due to the following error:\n"
+msgstr ""
+
+#: ../src/common/fileconf.cpp:412
+#, fuzzy
+msgid "failed to rename the existing file"
+msgstr "Lees van dokument vanuit lêer \"%s\" het misluk."
+
+#: ../src/common/fileconf.cpp:421
+#, fuzzy
+msgid "failed to create the new file directory"
+msgstr "Die werkgids kon nie verkry word nie"
+
+#: ../src/common/fileconf.cpp:428
+#, fuzzy
+msgid "failed to move the file to the new location"
+msgstr "Verbreking van inbelverbinding het misluk: %s"
+
+#: ../src/common/fileconf.cpp:462
+#, c-format
+msgid "can't open global configuration file '%s'."
+msgstr "kan globale konfigurasielêer '%s' nie oopmaak nie."
+
+#: ../src/common/fileconf.cpp:478
+#, c-format
+msgid "can't open user configuration file '%s'."
+msgstr "kan gebruikers-konfigurasielêer '%s' nie oopmaak nie."
+
+#: ../src/common/fileconf.cpp:483
+#, c-format
+msgid "Changes won't be saved to avoid overwriting the existing file \"%s\""
+msgstr ""
+
+#: ../src/common/fileconf.cpp:583
+msgid "Error reading config options."
+msgstr "Fout met lees van konfigurasie-opsies."
+
+#: ../src/common/fileconf.cpp:593
+#, fuzzy
+msgid "Failed to read config options."
+msgstr "Fout met lees van konfigurasie-opsies."
+
+#: ../src/common/fileconf.cpp:700
+#, fuzzy, c-format
+msgid "file '%s': unexpected character %c at line %zu."
+msgstr "lêer '%s': onverwagte teken %c in reël %d."
+
+#: ../src/common/fileconf.cpp:736
+#, fuzzy, c-format
+msgid "file '%s', line %zu: '%s' ignored after group header."
+msgstr "lêer '%s', reël %d: '%s' geïgnoreer na groepkopstuk."
+
+#: ../src/common/fileconf.cpp:765
+#, fuzzy, c-format
+msgid "file '%s', line %zu: '=' expected."
+msgstr "lêer '%s', reël %d: '=' verwag."
+
+#: ../src/common/fileconf.cpp:778
+#, fuzzy, c-format
+msgid "file '%s', line %zu: value for immutable key '%s' ignored."
+msgstr "lêer '%s', reël %d: waarde vir onveranderbare sleutel '%s' geïgnoreer."
+
+#: ../src/common/fileconf.cpp:788
+#, fuzzy, c-format
+msgid "file '%s', line %zu: key '%s' was first found at line %d."
+msgstr "lêer '%s', reël %d: sleutel '%s' is eerste gevind op reël %d."
+
+#: ../src/common/fileconf.cpp:1091
+#, c-format
+msgid "Config entry name cannot start with '%c'."
+msgstr "Naam van konfigurasie-inskrywing mag nie begin met '%c' nie."
+
+#: ../src/common/fileconf.cpp:1146
+#, fuzzy
+msgid "Failed to create configuration file directory."
+msgstr "kan gebruikers-konfigurasielêer nie oopmaak nie."
+
+#: ../src/common/fileconf.cpp:1158
+msgid "can't open user configuration file."
+msgstr "kan gebruikers-konfigurasielêer nie oopmaak nie."
+
+#: ../src/common/fileconf.cpp:1172
+msgid "can't write user configuration file."
+msgstr "kan gebruikers-konfigurasielêer nie skryf nie."
+
+#: ../src/common/fileconf.cpp:1178
+#, fuzzy
+msgid "Failed to update user configuration file."
+msgstr "kan gebruikers-konfigurasielêer nie oopmaak nie."
+
+#: ../src/common/fileconf.cpp:1201
+#, fuzzy
+msgid "Error saving user configuration data."
+msgstr "Fout met lees van konfigurasie-opsies."
+
+#: ../src/common/fileconf.cpp:1313
+#, c-format
+msgid "can't delete user configuration file '%s'"
+msgstr "kan lêer met gebruikersopstelling '%s' nie uitvee nie"
+
+#: ../src/common/fileconf.cpp:2007
+#, c-format
+msgid "entry '%s' appears more than once in group '%s'"
+msgstr "inskrywing '%s' kom meer as één keer voor in groep '%s'"
+
+#: ../src/common/fileconf.cpp:2021
+#, c-format
+msgid "attempt to change immutable key '%s' ignored."
+msgstr "poging tot wysiging van onveranderbare sleutel '%s' geïgnoreer."
+
+#: ../src/common/fileconf.cpp:2118
+#, c-format
+msgid "trailing backslash ignored in '%s'"
+msgstr ""
+
+#: ../src/common/fileconf.cpp:2153
+#, c-format
+msgid "unexpected \" at position %d in '%s'."
+msgstr "onverwagte \" op posisie %d in '%s'."
+
+#: ../src/common/filefn.cpp:474
+#, c-format
+msgid "Failed to copy the file '%s' to '%s'"
+msgstr "Kopiëring van lêer '%s' na '%s' het misluk"
+
+#: ../src/common/filefn.cpp:487
+#, c-format
+msgid "Impossible to get permissions for file '%s'"
+msgstr "Onmoontlik om magtigings vir lêer '%s' te kry"
+
+#: ../src/common/filefn.cpp:501
+#, c-format
+msgid "Impossible to overwrite the file '%s'"
+msgstr "Onmoontlik om lêer '%s' te oorskryf"
+
+#: ../src/common/filefn.cpp:508
+#, fuzzy, c-format
+msgid "Error copying the file '%s' to '%s'."
+msgstr "Kopiëring van lêer '%s' na '%s' het misluk"
+
+#: ../src/common/filefn.cpp:556
+#, c-format
+msgid "Impossible to set permissions for the file '%s'"
+msgstr "Onmoontlik om magtigings vir lêer '%s' op te stel"
+
+#: ../src/common/filefn.cpp:606
+#, c-format
+msgid ""
+"Failed to rename the file '%s' to '%s' because the destination file already "
+"exists."
+msgstr ""
+
+#: ../src/common/filefn.cpp:623
+#, fuzzy, c-format
+msgid "File '%s' couldn't be renamed '%s'"
+msgstr "Gids '%s' kon nie geskep word nie"
+
+#: ../src/common/filefn.cpp:639
+#, c-format
+msgid "File '%s' couldn't be removed"
+msgstr "Lêer '%s' kon nie verwyd word nie"
+
+#: ../src/common/filefn.cpp:666
+#, c-format
+msgid "Directory '%s' couldn't be created"
+msgstr "Gids '%s' kon nie geskep word nie"
+
+#: ../src/common/filefn.cpp:680
+#, c-format
+msgid "Directory '%s' couldn't be deleted"
+msgstr "Gids '%s' kon nie geskrap word nie"
+
+#: ../src/common/filefn.cpp:714
+#, c-format
+msgid "Cannot enumerate files '%s'"
+msgstr "Kan lêers in gids '%s' nie opsom nie"
+
+#: ../src/common/filefn.cpp:798
+msgid "Failed to get the working directory"
+msgstr "Die werkgids kon nie verkry word nie"
+
+#: ../src/common/filefn.cpp:843
+#, fuzzy
+msgid "Could not set current working directory"
+msgstr "Die werkgids kon nie verkry word nie"
+
+#: ../src/common/filefn.cpp:974
+#, fuzzy, c-format
+msgid "Files (%s)"
+msgstr "Lêers (%s)|%s"
+
+#: ../src/common/filename.cpp:182
+#, fuzzy, c-format
+msgid "Failed to open '%s' for reading"
+msgstr "Opening van '%s' vir %s het misluk"
+
+#: ../src/common/filename.cpp:187
+#, fuzzy, c-format
+msgid "Failed to open '%s' for writing"
+msgstr "Opening van '%s' vir %s het misluk"
+
+#: ../src/common/filename.cpp:199
+msgid "Failed to close file handle"
+msgstr "Toemaak van lêer het misluk."
+
+#: ../src/common/filename.cpp:1046
+msgid "Failed to create a temporary file name"
+msgstr "'n Tydelyke lêernaam kon nie geskep word nie"
+
+#: ../src/common/filename.cpp:1081
+msgid "Failed to open temporary file."
+msgstr "Opening van tydelyk lêer het misluk."
+
+#: ../src/common/filename.cpp:2862
+#, c-format
+msgid "Failed to modify file times for '%s'"
+msgstr "Verandering van lêertye van '%s' het misluk"
+
+#: ../src/common/filename.cpp:2877
+#, c-format
+msgid "Failed to touch the file '%s'"
+msgstr "Aanraking van lêer '%s' het misluk"
+
+#: ../src/common/filename.cpp:2958
+#, c-format
+msgid "Failed to retrieve file times for '%s'"
+msgstr "Verkryging van lêertye vir '%s' het misluk"
+
+#: ../src/common/filepickercmn.cpp:39 ../src/common/filepickercmn.cpp:40
+msgid "Browse"
+msgstr ""
+
+#: ../src/common/fldlgcmn.cpp:792 ../src/generic/filectrlg.cpp:1185
+#, c-format
+msgid "All files (%s)|%s"
+msgstr "Alle lêers (%s)|%s"
+
+#. TRANSLATORS: %s are a file extension used to build a file wildcard string
+#: ../src/common/fldlgcmn.cpp:810
+#, c-format
+msgid "%s files (%s)|%s"
+msgstr "%s lêers (%s)|%s"
+
+#: ../src/common/fldlgcmn.cpp:1072
+#, c-format
+msgid "Load %s file"
+msgstr "Laai %s-lêer"
+
+#: ../src/common/fldlgcmn.cpp:1074
+#, c-format
+msgid "Save %s file"
+msgstr "Stoor %s-lêer"
+
+#: ../src/common/fmapbase.cpp:144
+msgid "Western European (ISO-8859-1)"
+msgstr "Wes-Europees (ISO-8859-1)"
+
+#: ../src/common/fmapbase.cpp:145
+msgid "Central European (ISO-8859-2)"
+msgstr "Sentraal-Europees (ISO-8859-2)"
+
+#: ../src/common/fmapbase.cpp:146
+msgid "Esperanto (ISO-8859-3)"
+msgstr "Esperanto (ISO-8859-3)"
+
+#: ../src/common/fmapbase.cpp:147
+msgid "Baltic (old) (ISO-8859-4)"
+msgstr "Balties (oud) (ISO-8859-4)"
+
+#: ../src/common/fmapbase.cpp:148
+msgid "Cyrillic (ISO-8859-5)"
+msgstr "Cyrillic (ISO-8859-5)"
+
+#: ../src/common/fmapbase.cpp:149
+msgid "Arabic (ISO-8859-6)"
+msgstr "Arabies (ISO-8859-6)"
+
+#: ../src/common/fmapbase.cpp:150
+msgid "Greek (ISO-8859-7)"
+msgstr "Grieks (ISO-8859-7)"
+
+#: ../src/common/fmapbase.cpp:151
+msgid "Hebrew (ISO-8859-8)"
+msgstr "Hebreeus (ISO-8859-8)"
+
+#: ../src/common/fmapbase.cpp:152
+msgid "Turkish (ISO-8859-9)"
+msgstr "Turks (ISO-8859-9)"
+
+#: ../src/common/fmapbase.cpp:153
+msgid "Nordic (ISO-8859-10)"
+msgstr "Noors (ISO-8859-10)"
+
+#: ../src/common/fmapbase.cpp:154
+msgid "Thai (ISO-8859-11)"
+msgstr "Thais (ISO-8859-11)"
+
+#: ../src/common/fmapbase.cpp:155
+msgid "Indian (ISO-8859-12)"
+msgstr "Indies (ISO-8859-12)"
+
+#: ../src/common/fmapbase.cpp:156
+msgid "Baltic (ISO-8859-13)"
+msgstr "Balties (ISO-8859-13)"
+
+#: ../src/common/fmapbase.cpp:157
+msgid "Celtic (ISO-8859-14)"
+msgstr "Kelties (ISO-8859-14)"
+
+#: ../src/common/fmapbase.cpp:158
+msgid "Western European with Euro (ISO-8859-15)"
+msgstr "Wes-Europees met Euro teken (ISO-8859-15)"
+
+#: ../src/common/fmapbase.cpp:159
+msgid "KOI8-R"
+msgstr "KOI8-R"
+
+#: ../src/common/fmapbase.cpp:160
+msgid "KOI8-U"
+msgstr "KOI8-U"
+
+#: ../src/common/fmapbase.cpp:161
+msgid "Windows/DOS OEM Cyrillic (CP 866)"
+msgstr "Windows/DOS OEM Cyrillies (CP 866)"
+
+#: ../src/common/fmapbase.cpp:162
+msgid "Windows Thai (CP 874)"
+msgstr "Windows Thai (CP 874)"
+
+#: ../src/common/fmapbase.cpp:163
+msgid "Windows Japanese (CP 932) or Shift-JIS"
+msgstr "Windows Japannees (CP 932) of Shift-JIS"
+
+#: ../src/common/fmapbase.cpp:164
+msgid "Windows Chinese Simplified (CP 936) or GB-2312"
+msgstr "Windows Vereenvoudigde Sjinees (CP 936) of GB-2312"
+
+#: ../src/common/fmapbase.cpp:165
+msgid "Windows Korean (CP 949)"
+msgstr "Windows Koreaans (CP 949)"
+
+#: ../src/common/fmapbase.cpp:166
+msgid "Windows Chinese Traditional (CP 950) or Big-5"
+msgstr "Windows Tradisionele Sjinees (CP 950) of Big-5"
+
+#: ../src/common/fmapbase.cpp:167
+msgid "Windows Central European (CP 1250)"
+msgstr "Windows Sentraal Europees (CP 1250)"
+
+#: ../src/common/fmapbase.cpp:168
+msgid "Windows Cyrillic (CP 1251)"
+msgstr "Windows Cyrillies (CP 1251)"
+
+#: ../src/common/fmapbase.cpp:169
+msgid "Windows Western European (CP 1252)"
+msgstr "Windows Wes Europees (CP 1252)"
+
+#: ../src/common/fmapbase.cpp:170
+msgid "Windows Greek (CP 1253)"
+msgstr "Windows Grieks (CP 1253)"
+
+#: ../src/common/fmapbase.cpp:171
+msgid "Windows Turkish (CP 1254)"
+msgstr "Windows Turks (CP 1254)"
+
+#: ../src/common/fmapbase.cpp:172
+msgid "Windows Hebrew (CP 1255)"
+msgstr "Windows Hebreeus (CP 1255)"
+
+#: ../src/common/fmapbase.cpp:173
+msgid "Windows Arabic (CP 1256)"
+msgstr "Windows Arabies (CP 1256)"
+
+#: ../src/common/fmapbase.cpp:174
+msgid "Windows Baltic (CP 1257)"
+msgstr "Windows Balties (CP 1257)"
+
+#: ../src/common/fmapbase.cpp:175
+msgid "Windows Vietnamese (CP 1258)"
+msgstr "Windows Viëtnamees (CP 1258)"
+
+#: ../src/common/fmapbase.cpp:176
+#, fuzzy
+msgid "Windows Johab (CP 1361)"
+msgstr "Windows Johab (CP 1361)"
+
+#: ../src/common/fmapbase.cpp:177
+msgid "Windows/DOS OEM (CP 437)"
+msgstr "Windows/DOS OEM (CP 437)"
+
+#: ../src/common/fmapbase.cpp:178
+msgid "Unicode 7 bit (UTF-7)"
+msgstr "Unicode 7-bis (UTF-7)"
+
+#: ../src/common/fmapbase.cpp:179
+msgid "Unicode 8 bit (UTF-8)"
+msgstr "Unicode 8-bis (UTF-8)"
+
+#: ../src/common/fmapbase.cpp:181 ../src/common/fmapbase.cpp:187
+msgid "Unicode 16 bit (UTF-16)"
+msgstr "Unicode 16 bis (UTF-16)"
+
+#: ../src/common/fmapbase.cpp:182
+msgid "Unicode 16 bit Little Endian (UTF-16LE)"
+msgstr "Unicode 16 bis Little Endian (UTF-16LE)"
+
+#: ../src/common/fmapbase.cpp:183 ../src/common/fmapbase.cpp:189
+msgid "Unicode 32 bit (UTF-32)"
+msgstr "Unicode 32 bis (UTF-32)"
+
+#: ../src/common/fmapbase.cpp:184
+msgid "Unicode 32 bit Little Endian (UTF-32LE)"
+msgstr "Unicode 32 bis Little Endian (UTF-32LE)"
+
+#: ../src/common/fmapbase.cpp:186
+msgid "Unicode 16 bit Big Endian (UTF-16BE)"
+msgstr "Unicode 16 bis Big Endian (UTF-16BE)"
+
+#: ../src/common/fmapbase.cpp:188
+msgid "Unicode 32 bit Big Endian (UTF-32BE)"
+msgstr "Unicode 32 bis Big Endian (UTF-32BE)"
+
+#: ../src/common/fmapbase.cpp:191
+msgid "Extended Unix Codepage for Japanese (EUC-JP)"
+msgstr "Extended Unix Codepage vir Japannees (EUC-JP)"
+
+#: ../src/common/fmapbase.cpp:192
+msgid "US-ASCII"
+msgstr "US-ASCII"
+
+#: ../src/common/fmapbase.cpp:193
+msgid "ISO-2022-JP"
+msgstr "ISO-2022-JP"
+
+#: ../src/common/fmapbase.cpp:195
+msgid "MacRoman"
+msgstr "MacRoman"
+
+#: ../src/common/fmapbase.cpp:196
+msgid "MacJapanese"
+msgstr "MacJapanese"
+
+#: ../src/common/fmapbase.cpp:197
+msgid "MacChineseTrad"
+msgstr "MacChineseTrad"
+
+#: ../src/common/fmapbase.cpp:198
+msgid "MacKorean"
+msgstr "MacKorean"
+
+#: ../src/common/fmapbase.cpp:199
+msgid "MacArabic"
+msgstr "MacArabic"
+
+#: ../src/common/fmapbase.cpp:200
+msgid "MacHebrew"
+msgstr "MacHebrew"
+
+#: ../src/common/fmapbase.cpp:201
+msgid "MacGreek"
+msgstr "MacGreek"
+
+#: ../src/common/fmapbase.cpp:202
+msgid "MacCyrillic"
+msgstr "MacCyrillic"
+
+#: ../src/common/fmapbase.cpp:203
+msgid "MacDevanagari"
+msgstr "MacDevanagari"
+
+#: ../src/common/fmapbase.cpp:204
+msgid "MacGurmukhi"
+msgstr "MacGurmukhi"
+
+#: ../src/common/fmapbase.cpp:205
+msgid "MacGujarati"
+msgstr "MacGujarati"
+
+#: ../src/common/fmapbase.cpp:206
+msgid "MacOriya"
+msgstr "MacOriya"
+
+#: ../src/common/fmapbase.cpp:207
+msgid "MacBengali"
+msgstr "MacBengali"
+
+#: ../src/common/fmapbase.cpp:208
+msgid "MacTamil"
+msgstr "MacTamil"
+
+#: ../src/common/fmapbase.cpp:209
+msgid "MacTelugu"
+msgstr "MacTelugu"
+
+#: ../src/common/fmapbase.cpp:210
+msgid "MacKannada"
+msgstr "MacKannada"
+
+#: ../src/common/fmapbase.cpp:211
+msgid "MacMalayalam"
+msgstr "MacMalayalam"
+
+#: ../src/common/fmapbase.cpp:212
+msgid "MacSinhalese"
+msgstr "MacSinhalese"
+
+#: ../src/common/fmapbase.cpp:213
+msgid "MacBurmese"
+msgstr "MacBurmese"
+
+#: ../src/common/fmapbase.cpp:214
+msgid "MacKhmer"
+msgstr "MacKhmer"
+
+#: ../src/common/fmapbase.cpp:215
+msgid "MacThai"
+msgstr "MacThai"
+
+#: ../src/common/fmapbase.cpp:216
+msgid "MacLaotian"
+msgstr "MacLaotian"
+
+#: ../src/common/fmapbase.cpp:217
+msgid "MacGeorgian"
+msgstr "MacGeorgian"
+
+#: ../src/common/fmapbase.cpp:218
+msgid "MacArmenian"
+msgstr "MacArmenian"
+
+#: ../src/common/fmapbase.cpp:219
+msgid "MacChineseSimp"
+msgstr "MacChineseSimp"
+
+#: ../src/common/fmapbase.cpp:220
+msgid "MacTibetan"
+msgstr "MacTibetan"
+
+#: ../src/common/fmapbase.cpp:221
+msgid "MacMongolian"
+msgstr "MacMongolian"
+
+#: ../src/common/fmapbase.cpp:222
+msgid "MacEthiopic"
+msgstr "MacEthiopic"
+
+#: ../src/common/fmapbase.cpp:223
+msgid "MacCentralEurRoman"
+msgstr "MacCentralEurRoman"
+
+#: ../src/common/fmapbase.cpp:224
+msgid "MacVietnamese"
+msgstr "MacVietnamese"
+
+#: ../src/common/fmapbase.cpp:225
+msgid "MacExtArabic"
+msgstr "MacExtArabic"
+
+#: ../src/common/fmapbase.cpp:226
+msgid "MacSymbol"
+msgstr "MacSymbol"
+
+#: ../src/common/fmapbase.cpp:227
+msgid "MacDingbats"
+msgstr "MacDingbats"
+
+#: ../src/common/fmapbase.cpp:228
+msgid "MacTurkish"
+msgstr "MacTurkish"
+
+#: ../src/common/fmapbase.cpp:229
+msgid "MacCroatian"
+msgstr "MacCroatian"
+
+#: ../src/common/fmapbase.cpp:230
+msgid "MacIcelandic"
+msgstr "MacIcelandic"
+
+#: ../src/common/fmapbase.cpp:231
+msgid "MacRomanian"
+msgstr "MacRomanian"
+
+#: ../src/common/fmapbase.cpp:232
+msgid "MacCeltic"
+msgstr "MacCeltic"
+
+#: ../src/common/fmapbase.cpp:233
+msgid "MacGaelic"
+msgstr "MacGaelic"
+
+#: ../src/common/fmapbase.cpp:234
+msgid "MacKeyboardGlyphs"
+msgstr "MacKeyboardGlyphs"
+
+#: ../src/common/fmapbase.cpp:791
+msgid "Default encoding"
+msgstr "Standaard-enkodering"
+
+#: ../src/common/fmapbase.cpp:805
+#, c-format
+msgid "Unknown encoding (%d)"
+msgstr "Onbekende kodering (%d)"
+
+#: ../src/common/fmapbase.cpp:815 ../src/richtext/richtextstyles.cpp:776
+msgid "default"
+msgstr "standaard"
+
+#: ../src/common/fmapbase.cpp:829
+#, c-format
+msgid "unknown-%d"
+msgstr "onbekend-%d"
+
+#: ../src/common/fontcmn.cpp:924 ../src/common/fontcmn.cpp:1130
+msgid "underlined"
+msgstr "onderstreep"
+
+#: ../src/common/fontcmn.cpp:929
+msgid " strikethrough"
+msgstr " deurhaal"
+
+#: ../src/common/fontcmn.cpp:942
+msgid " thin"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:946
+#, fuzzy
+msgid " extra light"
+msgstr " lig"
+
+#: ../src/common/fontcmn.cpp:950
+msgid " light"
+msgstr " lig"
+
+#: ../src/common/fontcmn.cpp:954
+msgid " medium"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:958
+#, fuzzy
+msgid " semi bold"
+msgstr " vetdruk"
+
+#: ../src/common/fontcmn.cpp:962
+msgid " bold"
+msgstr " vetdruk"
+
+#: ../src/common/fontcmn.cpp:966
+#, fuzzy
+msgid " extra bold"
+msgstr " vetdruk"
+
+#: ../src/common/fontcmn.cpp:970
+msgid " heavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:974
+msgid " extra heavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:990
+msgid " italic"
+msgstr " kursief"
+
+#: ../src/common/fontcmn.cpp:1134
+msgid "strikethrough"
+msgstr "deurhaal"
+
+#: ../src/common/fontcmn.cpp:1143
+msgid "thin"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1156
+#, fuzzy
+msgid "extralight"
+msgstr "lig"
+
+#: ../src/common/fontcmn.cpp:1161
+msgid "light"
+msgstr "lig"
+
+#: ../src/common/fontcmn.cpp:1169 ../src/richtext/richtextstyles.cpp:775
+msgid "normal"
+msgstr "normaal"
+
+#: ../src/common/fontcmn.cpp:1174
+msgid "medium"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1179 ../src/common/fontcmn.cpp:1199
+#, fuzzy
+msgid "semibold"
+msgstr "vet"
+
+#: ../src/common/fontcmn.cpp:1184
+msgid "bold"
+msgstr "vet"
+
+#: ../src/common/fontcmn.cpp:1194
+#, fuzzy
+msgid "extrabold"
+msgstr "vet"
+
+#: ../src/common/fontcmn.cpp:1204
+msgid "heavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1212
+msgid "extraheavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1217
+msgid "italic"
+msgstr "kursief"
+
+#: ../src/common/fontmap.cpp:195
+msgid ": unknown charset"
+msgstr ": onbekende karakterstel"
+
+#: ../src/common/fontmap.cpp:199
+#, c-format
+msgid ""
+"The charset '%s' is unknown. You may select\n"
+"another charset to replace it with or choose\n"
+"[Cancel] if it cannot be replaced"
+msgstr ""
+"Die karakterstel '%s' is onbekend. Jy kan 'n ander\n"
+"karakterstel kies om te vervang of kies [Kanselleer]\n"
+"as dit nie vervang kan word nie"
+
+#: ../src/common/fontmap.cpp:241
+#, c-format
+msgid "Failed to remember the encoding for the charset '%s'."
+msgstr "Die kodering vir karakterstel '%s' kon nie onthou word nie."
+
+#: ../src/common/fontmap.cpp:321
+msgid "can't load any font, aborting"
+msgstr "kan geen lettertipe laai nie, besig om te laat vaar"
+
+#: ../src/common/fontmap.cpp:409
+msgid ": unknown encoding"
+msgstr ": onbekende kodering"
+
+#: ../src/common/fontmap.cpp:417
+#, c-format
+msgid ""
+"No font for displaying text in encoding '%s' found,\n"
+"but an alternative encoding '%s' is available.\n"
+"Do you want to use this encoding (otherwise you will have to choose another "
+"one)?"
+msgstr ""
+"Geen lettertipe is gevind om die teks in enkodering '%s' te wys nie,\n"
+"maar 'n alternatiewe enkodering '%s' is beskikbaar.\n"
+"Wil jy hierdie enkodering gebruik (Anders moet jy 'n ander een kies)?"
+
+#: ../src/common/fontmap.cpp:422
+#, c-format
+msgid ""
+"No font for displaying text in encoding '%s' found.\n"
+"Would you like to select a font to be used for this encoding\n"
+"(otherwise the text in this encoding will not be shown correctly)?"
+msgstr ""
+"Geen lettertipe is gevind om die teks in enkodering '%s' te wys nie.\n"
+"Wil jy 'n lettertipe kies vir hierdie enkodering\n"
+"(anders sal die teks in hierdie kodering nie korrek weergegee word nie)?"
+
+#: ../src/common/fs_mem.cpp:169
+#, c-format
+msgid "Memory VFS already contains file '%s'!"
+msgstr "VFS in geheue bevat reeds die lêer '%s'!"
+
+#: ../src/common/fs_mem.cpp:232
+#, c-format
+msgid "Trying to remove file '%s' from memory VFS, but it is not loaded!"
+msgstr ""
+"Poging om lêer '%s' uit VFS in geheue te verwyder, maar dit is nie gelaai "
+"nie!"
+
+#: ../src/common/fs_mem.cpp:262
+#, c-format
+msgid "Failed to store image '%s' to memory VFS!"
+msgstr "Stoor van beeld '%s' na VFS in geheue het misluk!"
+
+#: ../src/common/ftp.cpp:197
+msgid "Timeout while waiting for FTP server to connect, try passive mode."
+msgstr ""
+"Wagtyd vir FTP-bediener om te koppel het uitgetel. Probeer passiewe modus."
+
+#: ../src/common/ftp.cpp:399
+#, c-format
+msgid "Failed to set FTP transfer mode to %s."
+msgstr "Kon nie FTP-oordragmodus na %s stel nie."
+
+#: ../src/common/ftp.cpp:400 ../src/richtext/richtextsymboldlg.cpp:432
+msgid "ASCII"
+msgstr "ASCII"
+
+#: ../src/common/ftp.cpp:400
+msgid "binary"
+msgstr "binêr"
+
+#: ../src/common/ftp.cpp:608
+msgid "The FTP server doesn't support the PORT command."
+msgstr "Die FTP-bediener ondersteun nie die PORT-opdrag nie."
+
+#: ../src/common/ftp.cpp:622
+msgid "The FTP server doesn't support passive mode."
+msgstr "Die FTP-bediener ondersteun nie passiewe modus nie."
+
+#: ../src/common/gifdecod.cpp:822
+#, c-format
+msgid "Incorrect GIF frame size (%u, %d) for the frame #%u"
+msgstr ""
+
+#: ../src/common/glcmn.cpp:108
+#, fuzzy
+msgid "Failed to allocate colour for OpenGL"
+msgstr "Wyser kon nie geskep word nie."
+
+#: ../src/common/headerctrlcmn.cpp:57
+msgid "Please select the columns to show and define their order:"
+msgstr ""
+
+#: ../src/common/headerctrlcmn.cpp:58
+msgid "Customize Columns"
+msgstr "Pasmaak kolomme"
+
+#: ../src/common/headerctrlcmn.cpp:304
+msgid "&Customize..."
+msgstr "&Pasmaak..."
+
+#: ../src/common/hyperlnkcmn.cpp:132
+#, fuzzy, c-format
+msgid "Failed to open URL \"%s\" in the default browser"
+msgstr "Opening van URL \"%s\" in verstekblaaier het misluk."
+
+#: ../src/common/iconbndl.cpp:195
+#, fuzzy, c-format
+msgid "Failed to load image %%d from file '%s'."
+msgstr "Laaiing van beeld %d vanuit lêer '%s' het misluk."
+
+#: ../src/common/iconbndl.cpp:203
+#, fuzzy, c-format
+msgid "Failed to load image %d from stream."
+msgstr "Laaiing van beeld %d vanuit lêer '%s' het misluk."
+
+#: ../src/common/iconbndl.cpp:221
+#, fuzzy, c-format
+msgid "Failed to load icons from resource '%s'."
+msgstr "Laai van ikoon \"%s\" vanuit hulpbronne het misluk."
+
+#: ../src/common/imagbmp.cpp:97
+msgid "BMP: Couldn't save invalid image."
+msgstr "BMP: kon nie ongeldige beeld stoor nie"
+
+#: ../src/common/imagbmp.cpp:137
+msgid "BMP: wxImage doesn't have own wxPalette."
+msgstr "BMP: wxImage het nie 'n eie wxPalette nie."
+
+#: ../src/common/imagbmp.cpp:243
+msgid "BMP: Couldn't write the file (Bitmap) header."
+msgstr "BMP: kon nie die lêerkopreëls (Bitmap) skryf nie"
+
+#: ../src/common/imagbmp.cpp:266
+msgid "BMP: Couldn't write the file (BitmapInfo) header."
+msgstr "BMP: Kon nie die lêerkopreëls (BitmapInfo) skryf nie."
+
+#: ../src/common/imagbmp.cpp:353
+msgid "BMP: Couldn't write RGB color map."
+msgstr "BMP: Kon nie RGB-kleurkaart skryf nie."
+
+#: ../src/common/imagbmp.cpp:487
+msgid "BMP: Couldn't write data."
+msgstr "BMP: kon nie data skryf nie"
+
+#: ../src/common/imagbmp.cpp:561 ../src/common/imagbmp.cpp:642
+msgid "BMP: Couldn't allocate memory."
+msgstr "BMP: kon geen geheue toeken nie."
+
+#: ../src/common/imagbmp.cpp:1041
+msgid "DIB Header: Image width > 32767 pixels for file."
+msgstr "DIB Opskrif: Beeldbreedte > 32767 pixels in lêer."
+
+#: ../src/common/imagbmp.cpp:1049
+msgid "DIB Header: Image height > 32767 pixels for file."
+msgstr "DIB Opskrif: Beeldhoogte > 32767 pixels in lêer."
+
+#: ../src/common/imagbmp.cpp:1081
+msgid "DIB Header: Unknown bitdepth in file."
+msgstr "DIB Opskrif: Onbekende bisdiepte in lêer."
+
+#: ../src/common/imagbmp.cpp:1156
+msgid "DIB Header: Unknown encoding in file."
+msgstr "DIB Opskrif: Onbekende kodering in lêer."
+
+#: ../src/common/imagbmp.cpp:1165
+msgid "DIB Header: Encoding doesn't match bitdepth."
+msgstr "DIB Opskrif: Kodering kom nie ooreen met bis-diepte nie."
+
+#: ../src/common/imagbmp.cpp:1180
+#, c-format
+msgid "BMP Header: Invalid number of colors (%d)."
+msgstr ""
+
+#: ../src/common/imagbmp.cpp:1273
+#, fuzzy
+msgid "Error in reading image DIB."
+msgstr "Fout tydens lees van DIB-beeld."
+
+#: ../src/common/imagbmp.cpp:1294
+msgid "ICO: Error in reading mask DIB."
+msgstr "ICO: Fout by inlees van masker DIB."
+
+#: ../src/common/imagbmp.cpp:1353
+msgid "ICO: Image too tall for an icon."
+msgstr "ICO: Beeld is te hoog vir 'n ikoon."
+
+#: ../src/common/imagbmp.cpp:1361
+msgid "ICO: Image too wide for an icon."
+msgstr "ICO: Beeld is te breed vir 'n ikoon."
+
+#: ../src/common/imagbmp.cpp:1388 ../src/common/imagbmp.cpp:1488
+#: ../src/common/imagbmp.cpp:1503 ../src/common/imagbmp.cpp:1514
+#: ../src/common/imagbmp.cpp:1528 ../src/common/imagbmp.cpp:1576
+#: ../src/common/imagbmp.cpp:1591 ../src/common/imagbmp.cpp:1605
+#: ../src/common/imagbmp.cpp:1616
+msgid "ICO: Error writing the image file!"
+msgstr "ICO: Fout tydens wegskryf van die beeld!"
+
+#: ../src/common/imagbmp.cpp:1701
+msgid "ICO: Invalid icon index."
+msgstr "ICO: Ongeldige ikoonindeks."
+
+#: ../src/common/image.cpp:2410
+msgid "Image and mask have different sizes."
+msgstr "Beeld en masker het verskillende groottes."
+
+#: ../src/common/image.cpp:2418 ../src/common/image.cpp:2459
+#, fuzzy
+msgid "No unused colour in image being masked."
+msgstr "Daar word geen ongebruikte kleur in die beeld uitgemasker nie"
+
+#: ../src/common/image.cpp:2641
+#, c-format
+msgid "Failed to load bitmap \"%s\" from resources."
+msgstr "Laai van beeld \"%s\" vanuit hulpbronne het misluk."
+
+#: ../src/common/image.cpp:2650
+#, c-format
+msgid "Failed to load icon \"%s\" from resources."
+msgstr "Laai van ikoon \"%s\" vanuit hulpbronne het misluk."
+
+#: ../src/common/image.cpp:2728 ../src/common/image.cpp:2747
+#, c-format
+msgid "Failed to load image from file \"%s\"."
+msgstr "Laai van beeld vanuit lêer \"%s\" het misluk."
+
+#: ../src/common/image.cpp:2761
+#, c-format
+msgid "Can't save image to file '%s': unknown extension."
+msgstr "Kan beeld nie stoor na lêer '%s': Onbekende uitgang."
+
+#: ../src/common/image.cpp:2869
+msgid "No handler found for image type."
+msgstr "Geen hanteerder is gevind vir beeldtipe."
+
+#: ../src/common/image.cpp:2877 ../src/common/image.cpp:3000
+#: ../src/common/image.cpp:3066
+#, c-format
+msgid "No image handler for type %d defined."
+msgstr "Geen beeldhanteerder is vir die tipe %d gedefinieer nie."
+
+#: ../src/common/image.cpp:2887
+#, fuzzy, c-format
+msgid "Image file is not of type %d."
+msgstr "Beeldlêer is nie van die tipe %d."
+
+#: ../src/common/image.cpp:2970
+msgid "Can't automatically determine the image format for non-seekable input."
+msgstr ""
+
+#: ../src/common/image.cpp:2988
+#, fuzzy
+msgid "Unknown image data format."
+msgstr "fout in dataformaat."
+
+#: ../src/common/image.cpp:3009
+#, fuzzy, c-format
+msgid "This is not a %s."
+msgstr "PCX: dit is nie 'n PCX-lêer nie."
+
+#: ../src/common/image.cpp:3032 ../src/common/image.cpp:3080
+#, c-format
+msgid "No image handler for type %s defined."
+msgstr "Geen beeldhanteerder is vir die tipe %s gedefinieer nie."
+
+#: ../src/common/image.cpp:3041
+#, fuzzy, c-format
+msgid "Image is not of type %s."
+msgstr "Beeldlêer is nie van die tipe %d."
+
+#: ../src/common/image.cpp:3509
+#, c-format
+msgid "Failed to check format of image file \"%s\"."
+msgstr ""
+
+#: ../src/common/imaggif.cpp:124
+msgid "GIF: error in GIF image format."
+msgstr "GIF: fout in GIF-lêerformaat."
+
+#: ../src/common/imaggif.cpp:129
+msgid "GIF: not enough memory."
+msgstr "GIF: onvoldoende geheue."
+
+#: ../src/common/imaggif.cpp:134
+msgid "GIF: data stream seems to be truncated."
+msgstr "GIF: datastroom lyk afgekap."
+
+#: ../src/common/imaggif.cpp:240
+#, fuzzy
+msgid "Couldn't initialize GIF hash table."
+msgstr "Kan nie zlib-afblaasstroom inisialiseer nie."
+
+#: ../src/common/imagiff.cpp:739
+msgid "IFF: error in IFF image format."
+msgstr "IFF: fout in IFF lêerformaat."
+
+#: ../src/common/imagiff.cpp:742
+msgid "IFF: not enough memory."
+msgstr "IFF: onvoldoende geheue."
+
+#: ../src/common/imagiff.cpp:745
+msgid "IFF: unknown error!!!"
+msgstr "IFF: onbekende fout!!!"
+
+#: ../src/common/imagiff.cpp:755
+msgid "IFF: data stream seems to be truncated."
+msgstr "IFFF: datastroom lyk afgekap."
+
+#: ../src/common/imagjpeg.cpp:258
+msgid "JPEG: Couldn't load - file is probably corrupted."
+msgstr "JPEG: kon nie laai nie - lêer is waarskynlik korrup."
+
+#: ../src/common/imagjpeg.cpp:437
+msgid "JPEG: Couldn't save image."
+msgstr "JPEG: kon beeld nie stoor nie."
+
+#: ../src/common/imagpcx.cpp:439
+msgid "PCX: this is not a PCX file."
+msgstr "PCX: dit is nie 'n PCX-lêer nie."
+
+#: ../src/common/imagpcx.cpp:453
+msgid "PCX: image format unsupported"
+msgstr "PCX: lêerformaat word nie ondersteun nie"
+
+#: ../src/common/imagpcx.cpp:454 ../src/common/imagpcx.cpp:477
+msgid "PCX: couldn't allocate memory"
+msgstr "PCX: kon geen geheue reserveer"
+
+#: ../src/common/imagpcx.cpp:455
+msgid "PCX: version number too low"
+msgstr "PCX: weergawenommer te laag"
+
+#: ../src/common/imagpcx.cpp:456 ../src/common/imagpcx.cpp:478
+msgid "PCX: unknown error !!!"
+msgstr "PCX: onbekende fout!"
+
+#: ../src/common/imagpcx.cpp:476
+msgid "PCX: invalid image"
+msgstr "PCX: ongeldige beeld"
+
+#: ../src/common/imagpng.cpp:385
+#, fuzzy, c-format
+msgid "Unknown PNG resolution unit %d"
+msgstr "Onbekende opsie '%s'"
+
+#: ../src/common/imagpng.cpp:439
+msgid "Couldn't load a PNG image - file is corrupted or not enough memory."
+msgstr "Kon PNG-beeld nie laai nie: lêer is korrup of geheue is onvoldoende."
+
+#: ../src/common/imagpng.cpp:513 ../src/common/imagpng.cpp:524
+#: ../src/common/imagpng.cpp:534
+msgid "Couldn't save PNG image."
+msgstr "Kon PNG-beeld nie stoor nie."
+
+#: ../src/common/imagpnm.cpp:71
+msgid "PNM: File format is not recognized."
+msgstr "PNM: lêerformaat onbekend."
+
+#: ../src/common/imagpnm.cpp:89
+msgid "PNM: Couldn't allocate memory."
+msgstr "PNM: kon nie geheue reserveer nie."
+
+#: ../src/common/imagpnm.cpp:111 ../src/common/imagpnm.cpp:134
+#: ../src/common/imagpnm.cpp:156
+msgid "PNM: File seems truncated."
+msgstr "PNM: lêer lyk afgekap."
+
+#: ../src/common/imagtiff.cpp:69
+#, c-format
+msgid " (in module \"%s\")"
+msgstr " (in module \"%s\")"
+
+#: ../src/common/imagtiff.cpp:304
+msgid "TIFF: Error loading image."
+msgstr "TIFF: fout by laai van beeld."
+
+#: ../src/common/imagtiff.cpp:314
+msgid "Invalid TIFF image index."
+msgstr "Ongeldige TIFF-beeldindeks."
+
+#: ../src/common/imagtiff.cpp:358
+msgid "TIFF: Image size is abnormally big."
+msgstr "TIFF: beeldgrootte is abnormaal groot."
+
+#: ../src/common/imagtiff.cpp:372 ../src/common/imagtiff.cpp:385
+#: ../src/common/imagtiff.cpp:769
+msgid "TIFF: Couldn't allocate memory."
+msgstr "TIFF: kon nie geheue reserveer nie."
+
+#: ../src/common/imagtiff.cpp:471
+msgid "TIFF: Error reading image."
+msgstr "TIFF: fout by lees van beeld."
+
+#: ../src/common/imagtiff.cpp:532
+#, c-format
+msgid "Unknown TIFF resolution unit %d ignored"
+msgstr ""
+
+#: ../src/common/imagtiff.cpp:611
+msgid "TIFF: Error saving image."
+msgstr "TIFF: fout by stoor van beeld."
+
+#: ../src/common/imagtiff.cpp:868
+msgid "TIFF: Error writing image."
+msgstr "TIFF: fout by skryf van beeld."
+
+#: ../src/common/imagtiff.cpp:881
+#, fuzzy
+msgid "TIFF: Error flushing data."
+msgstr "TIFF: fout by stoor van beeld."
+
+#: ../src/common/imagwebp.cpp:56
+msgid "WebP: Invalid data (failed to get features)."
+msgstr ""
+
+#: ../src/common/imagwebp.cpp:65
+msgid "WebP: Allocating image memory failed."
+msgstr ""
+
+#: ../src/common/imagwebp.cpp:82
+msgid "WebP: Decoding RGBA image data failed."
+msgstr ""
+
+#: ../src/common/imagwebp.cpp:98
+msgid "WebP: Decoding RGB image data failed."
+msgstr ""
+
+#: ../src/common/imagwebp.cpp:113 ../src/common/imagwebp.cpp:201
+msgid "WebP: Allocating stream buffer failed."
+msgstr ""
+
+#: ../src/common/imagwebp.cpp:131
+#, fuzzy
+msgid "WebP: Failed to parse container data."
+msgstr "Opstelling van knipborddata het misluk."
+
+#: ../src/common/imagwebp.cpp:222
+#, fuzzy
+msgid "WebP: Error decoding animation."
+msgstr "Fout met lees van konfigurasie-opsies."
+
+#: ../src/common/imagwebp.cpp:240
+msgid "WebP: Error getting next animation frame."
+msgstr ""
+
+#: ../src/common/init.cpp:172
+#, c-format
+msgid ""
+"Command line argument %d couldn't be converted to Unicode and will be "
+"ignored."
+msgstr ""
+
+#: ../src/common/init.cpp:344
+msgid "Initialization failed in post init, aborting."
+msgstr ""
+
+#: ../src/common/intl.cpp:378
+#, c-format
+msgid "Cannot set locale to language \"%s\"."
+msgstr "Kan nie landinstelling na taal \"%s\" stel nie."
+
+#: ../src/common/log.cpp:232
+msgid "Error: "
+msgstr "Fout: "
+
+#: ../src/common/log.cpp:236
+msgid "Warning: "
+msgstr "Waarskuwing: "
+
+#: ../src/common/log.cpp:284
+msgid "The previous message repeated once."
+msgstr "Die vorige boodskap het een keer herhaal."
+
+#: ../src/common/log.cpp:291
+#, fuzzy, c-format
+msgid "The previous message repeated %u time."
+msgid_plural "The previous message repeated %u times."
+msgstr[0] "Die vorige boodskap het %lu keer herhaal."
+msgstr[1] "Die vorige boodskap het %lu keer herhaal."
+
+#: ../src/common/log.cpp:319
+#, c-format
+msgid "Last repeated message (\"%s\", %u time) wasn't output"
+msgid_plural "Last repeated message (\"%s\", %u times) wasn't output"
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../src/common/log.cpp:435
+#, c-format
+msgid " (error %ld: %s)"
+msgstr " (fout %ld: %s)"
+
+#: ../src/common/lzmastream.cpp:121
+#, fuzzy
+msgid "Failed to allocate memory for LZMA decompression."
+msgstr "Wyser kon nie geskep word nie."
+
+#: ../src/common/lzmastream.cpp:125
+#, c-format
+msgid "Failed to initialize LZMA decompression: unexpected error %u."
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:179
+msgid "input is not in XZ format"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:183
+msgid "input compressed using unknown XZ option"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:188
+msgid "input is corrupted"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:192
+#, fuzzy
+msgid "unknown decompression error"
+msgstr "uitpakfout"
+
+#: ../src/common/lzmastream.cpp:196
+#, fuzzy, c-format
+msgid "LZMA decompression error: %s"
+msgstr "uitpakfout"
+
+#: ../src/common/lzmastream.cpp:231
+#, fuzzy
+msgid "Failed to allocate memory for LZMA compression."
+msgstr "Wyser kon nie geskep word nie."
+
+#: ../src/common/lzmastream.cpp:235
+#, c-format
+msgid "Failed to initialize LZMA compression: unexpected error %u."
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:267 ../src/common/lzmastream.cpp:342
+#: ../src/html/chm.cpp:336
+msgid "out of memory"
+msgstr "te min geheue"
+
+#: ../src/common/lzmastream.cpp:276 ../src/common/lzmastream.cpp:346
+#, fuzzy
+msgid "unknown compression error"
+msgstr "inpakfout"
+
+#: ../src/common/lzmastream.cpp:280
+#, fuzzy, c-format
+msgid "LZMA compression error: %s"
+msgstr "inpakfout"
+
+#: ../src/common/lzmastream.cpp:350
+#, c-format
+msgid "LZMA compression error when flushing output: %s"
+msgstr ""
+
+#: ../src/common/mimecmn.cpp:167
+#, c-format
+msgid "Unmatched '{' in an entry for mime type %s."
+msgstr "On-afgeslote '{' in mime-tipe %s inskrywing."
+
+#: ../src/common/module.cpp:76
+#, c-format
+msgid "Circular dependency involving module \"%s\" detected."
+msgstr ""
+
+#: ../src/common/module.cpp:128
+#, c-format
+msgid "Dependency \"%s\" of module \"%s\" doesn't exist."
+msgstr ""
+
+#: ../src/common/module.cpp:137
+#, c-format
+msgid "Module \"%s\" initialization failed"
+msgstr ""
+
+#: ../src/common/msgout.cpp:96
+msgid "Message"
+msgstr "Boodskap"
+
+#: ../src/common/paper.cpp:70
+msgid "Letter, 8 1/2 x 11 in"
+msgstr "VSA Letter, 8 1/2 x 11 duim"
+
+#: ../src/common/paper.cpp:71
+msgid "Legal, 8 1/2 x 14 in"
+msgstr "VSA Legal, 8 1/2 x 14 duim"
+
+#: ../src/common/paper.cpp:72
+msgid "A4 sheet, 210 x 297 mm"
+msgstr "A4, 210 x 297 mm"
+
+#: ../src/common/paper.cpp:73
+msgid "C sheet, 17 x 22 in"
+msgstr "C, 17 x 22 duim"
+
+#: ../src/common/paper.cpp:74
+msgid "D sheet, 22 x 34 in"
+msgstr "D, 22 x34 duim"
+
+#: ../src/common/paper.cpp:75
+msgid "E sheet, 34 x 44 in"
+msgstr "E, 34 x 44 duim"
+
+#: ../src/common/paper.cpp:76
+msgid "Letter Small, 8 1/2 x 11 in"
+msgstr "VSA Letter Small, 8 1/2 x 11 duim"
+
+#: ../src/common/paper.cpp:77
+msgid "Tabloid, 11 x 17 in"
+msgstr "VSA Tabloid, 11 x 17 duim"
+
+#: ../src/common/paper.cpp:78
+msgid "Ledger, 17 x 11 in"
+msgstr "VSA Ledger, 17 x 11 duim"
+
+#: ../src/common/paper.cpp:79
+msgid "Statement, 5 1/2 x 8 1/2 in"
+msgstr "VSA Statement, 5 1/2 x 8 1/2 duim"
+
+#: ../src/common/paper.cpp:80
+msgid "Executive, 7 1/4 x 10 1/2 in"
+msgstr "VSA Executive, 7 1/4 x 10 1/2 duim"
+
+#: ../src/common/paper.cpp:81
+msgid "A3 sheet, 297 x 420 mm"
+msgstr "A3, 297 x 420 mm"
+
+#: ../src/common/paper.cpp:82
+msgid "A4 small sheet, 210 x 297 mm"
+msgstr "A4 klein, 210 x 297 mm"
+
+#: ../src/common/paper.cpp:83
+msgid "A5 sheet, 148 x 210 mm"
+msgstr "A5, 148 x 210 mm"
+
+#: ../src/common/paper.cpp:84
+msgid "B4 sheet, 250 x 354 mm"
+msgstr "B4, 250 x 354 mm"
+
+#: ../src/common/paper.cpp:85
+msgid "B5 sheet, 182 x 257 millimeter"
+msgstr "B5, 182, 257 mm"
+
+#: ../src/common/paper.cpp:86
+msgid "Folio, 8 1/2 x 13 in"
+msgstr "Folio, 8 1/2 x 13 duim"
+
+#: ../src/common/paper.cpp:87
+msgid "Quarto, 215 x 275 mm"
+msgstr "Kwarto, 215 x 275 mm"
+
+#: ../src/common/paper.cpp:88
+msgid "10 x 14 in"
+msgstr "10 x 14 duim"
+
+#: ../src/common/paper.cpp:89
+msgid "11 x 17 in"
+msgstr "11 x 17 duim"
+
+#: ../src/common/paper.cpp:90
+msgid "Note, 8 1/2 x 11 in"
+msgstr "Nota, 8 1/2 x 11 duim"
+
+#: ../src/common/paper.cpp:91
+msgid "#9 Envelope, 3 7/8 x 8 7/8 in"
+msgstr "Koevert nr.9, 3 7/8 x 8 7/8 duim"
+
+#: ../src/common/paper.cpp:92
+msgid "#10 Envelope, 4 1/8 x 9 1/2 in"
+msgstr "Koevert nr.10, 4 1/8 x 9 1/2 duim"
+
+#: ../src/common/paper.cpp:93
+msgid "#11 Envelope, 4 1/2 x 10 3/8 in"
+msgstr "Koevert nr.11, 4 1/2 x 10 3/8 duim"
+
+#: ../src/common/paper.cpp:94
+msgid "#12 Envelope, 4 3/4 x 11 in"
+msgstr "Koevert nr.12, 4 3/4 x 11 duim"
+
+#: ../src/common/paper.cpp:95
+msgid "#14 Envelope, 5 x 11 1/2 in"
+msgstr "Koevert nr.14, 5 x 11 1/2 duim"
+
+#: ../src/common/paper.cpp:96
+msgid "DL Envelope, 110 x 220 mm"
+msgstr "Koevert DL, 110 x 220 mm"
+
+#: ../src/common/paper.cpp:97
+msgid "C5 Envelope, 162 x 229 mm"
+msgstr "C5 Koevert, 162 x 229 mm"
+
+#: ../src/common/paper.cpp:98
+msgid "C3 Envelope, 324 x 458 mm"
+msgstr "C3 Koevert, 324 x 458 mm"
+
+#: ../src/common/paper.cpp:99
+msgid "C4 Envelope, 229 x 324 mm"
+msgstr "C4 Koevert, 229 x 324 mm"
+
+#: ../src/common/paper.cpp:100
+msgid "C6 Envelope, 114 x 162 mm"
+msgstr "C6 Koevert, 114 x 162 mm"
+
+#: ../src/common/paper.cpp:101
+msgid "C65 Envelope, 114 x 229 mm"
+msgstr "C65 Koevert, 114 x 229 mm"
+
+#: ../src/common/paper.cpp:102
+msgid "B4 Envelope, 250 x 353 mm"
+msgstr "B4 Koevert, 250 x 353 mm"
+
+#: ../src/common/paper.cpp:103
+msgid "B5 Envelope, 176 x 250 mm"
+msgstr "B5 Koevert, 176 x 250 mm"
+
+#: ../src/common/paper.cpp:104
+msgid "B6 Envelope, 176 x 125 mm"
+msgstr "B6 Koevert, 176 x 125 mm"
+
+#: ../src/common/paper.cpp:105
+msgid "Italy Envelope, 110 x 230 mm"
+msgstr "Koevert 'Italy', 110 x 230 mm"
+
+#: ../src/common/paper.cpp:106
+msgid "Monarch Envelope, 3 7/8 x 7 1/2 in"
+msgstr "Koevert 'Monarch', 3 7/8 x 7 1/2 duim"
+
+#: ../src/common/paper.cpp:107
+msgid "6 3/4 Envelope, 3 5/8 x 6 1/2 in"
+msgstr "6 3/4 koevert, 3 5/8 x 6 1/2 duim"
+
+#: ../src/common/paper.cpp:108
+msgid "US Std Fanfold, 14 7/8 x 11 in"
+msgstr "VSA Std Fanfold, 14 7/8 x 11 duim"
+
+#: ../src/common/paper.cpp:109
+msgid "German Std Fanfold, 8 1/2 x 12 in"
+msgstr "Duitse Std Fanfold, 8 1/2 x 12 duim"
+
+#: ../src/common/paper.cpp:110
+msgid "German Legal Fanfold, 8 1/2 x 13 in"
+msgstr "Duitse Legal Fanfold, 8 1/2 x 13 duim"
+
+#: ../src/common/paper.cpp:112
+msgid "B4 (ISO) 250 x 353 mm"
+msgstr "B4 (ISO) 250 x 353 mm"
+
+#: ../src/common/paper.cpp:113
+msgid "Japanese Postcard 100 x 148 mm"
+msgstr "Japannese poskaart 100 x 148 mm"
+
+#: ../src/common/paper.cpp:114
+msgid "9 x 11 in"
+msgstr "9 x 11 duim"
+
+#: ../src/common/paper.cpp:115
+msgid "10 x 11 in"
+msgstr "10 x 11 duim"
+
+#: ../src/common/paper.cpp:116
+msgid "15 x 11 in"
+msgstr "15 x 11 duim"
+
+#: ../src/common/paper.cpp:117
+#, fuzzy
+msgid "Envelope Invite 220 x 220 mm"
+msgstr "Koevert DL, 110 x 220 mm"
+
+#: ../src/common/paper.cpp:118
+msgid "Letter Extra 9 1/2 x 12 in"
+msgstr "VSA Letter ekstra 9 1/2 x 12 duim"
+
+#: ../src/common/paper.cpp:119
+msgid "Legal Extra 9 1/2 x 15 in"
+msgstr "VSA Legal ekstra 9 1/2 x 15 duim"
+
+#: ../src/common/paper.cpp:120
+msgid "Tabloid Extra 11.69 x 18 in"
+msgstr "VSA Tabloid ekstra 11.69 x 18 duim"
+
+#: ../src/common/paper.cpp:121
+msgid "A4 Extra 9.27 x 12.69 in"
+msgstr "A4 ekstra 9.27 x 12.69 duim"
+
+#: ../src/common/paper.cpp:122
+msgid "Letter Transverse 8 1/2 x 11 in"
+msgstr ""
+
+#: ../src/common/paper.cpp:123
+msgid "A4 Transverse 210 x 297 mm"
+msgstr ""
+
+#: ../src/common/paper.cpp:124
+msgid "Letter Extra Transverse 9.275 x 12 in"
+msgstr ""
+
+#: ../src/common/paper.cpp:125
+msgid "SuperA/SuperA/A4 227 x 356 mm"
+msgstr "SuperA/SuperA/A4 227 x 356 mm"
+
+#: ../src/common/paper.cpp:126
+msgid "SuperB/SuperB/A3 305 x 487 mm"
+msgstr "SuperB/SuperB/A3 305 x 487 mm"
+
+#: ../src/common/paper.cpp:127
+msgid "Letter Plus 8 1/2 x 12.69 in"
+msgstr "VSA Letter plus 8 1/2 x 12.69 duim"
+
+#: ../src/common/paper.cpp:128
+msgid "A4 Plus 210 x 330 mm"
+msgstr "A4 plus 210 x 330 mm"
+
+#: ../src/common/paper.cpp:129
+#, fuzzy
+msgid "A5 Transverse 148 x 210 mm"
+msgstr "A5, 148 x 210 mm"
+
+#: ../src/common/paper.cpp:130
+#, fuzzy
+msgid "B5 (JIS) Transverse 182 x 257 mm"
+msgstr "B5, 182, 257 mm"
+
+#: ../src/common/paper.cpp:131
+msgid "A3 Extra 322 x 445 mm"
+msgstr "A3 ekstra 322 x 445 mm"
+
+#: ../src/common/paper.cpp:132
+msgid "A5 Extra 174 x 235 mm"
+msgstr "A5 ekstra 174 x 235 mm"
+
+#: ../src/common/paper.cpp:133
+msgid "B5 (ISO) Extra 201 x 276 mm"
+msgstr "B5 (ISO) ekstra 201 x 276 mm"
+
+#: ../src/common/paper.cpp:134
+msgid "A2 420 x 594 mm"
+msgstr "A2 420 x 594 mm"
+
+#: ../src/common/paper.cpp:135
+#, fuzzy
+msgid "A3 Transverse 297 x 420 mm"
+msgstr "A3, 297 x 420 mm"
+
+#: ../src/common/paper.cpp:136
+#, fuzzy
+msgid "A3 Extra Transverse 322 x 445 mm"
+msgstr "C3 Koevert, 324 x 458 mm"
+
+#: ../src/common/paper.cpp:138
+msgid "Japanese Double Postcard 200 x 148 mm"
+msgstr "Japannese dubbele poskaart 200 x 148 mm"
+
+#: ../src/common/paper.cpp:139
+#, fuzzy
+msgid "A6 105 x 148 mm"
+msgstr "A6 105 x 148 mm"
+
+#: ../src/common/paper.cpp:140
+msgid "Japanese Envelope Kaku #2"
+msgstr ""
+
+#: ../src/common/paper.cpp:141
+msgid "Japanese Envelope Kaku #3"
+msgstr ""
+
+#: ../src/common/paper.cpp:142
+msgid "Japanese Envelope Chou #3"
+msgstr ""
+
+#: ../src/common/paper.cpp:143
+msgid "Japanese Envelope Chou #4"
+msgstr ""
+
+#: ../src/common/paper.cpp:144
+msgid "Letter Rotated 11 x 8 1/2 in"
+msgstr "VSA Letter geroteer 11 x 8 1/2 duim"
+
+#: ../src/common/paper.cpp:145
+msgid "A3 Rotated 420 x 297 mm"
+msgstr "A3 geroteer 420 x 297 mm"
+
+#: ../src/common/paper.cpp:146
+msgid "A4 Rotated 297 x 210 mm"
+msgstr "A4 geroteer 297 x 210 mm"
+
+#: ../src/common/paper.cpp:147
+msgid "A5 Rotated 210 x 148 mm"
+msgstr "A5 geroteer 210 x 148 mm"
+
+#: ../src/common/paper.cpp:148
+msgid "B4 (JIS) Rotated 364 x 257 mm"
+msgstr "B4 (JIS) geroteer 364 x 257 mm"
+
+#: ../src/common/paper.cpp:149
+msgid "B5 (JIS) Rotated 257 x 182 mm"
+msgstr "B5 (JIS) geroteer 257 x 182 mm"
+
+#: ../src/common/paper.cpp:150
+msgid "Japanese Postcard Rotated 148 x 100 mm"
+msgstr "Japannese poskaart, geroteer 148 x 100 mm"
+
+#: ../src/common/paper.cpp:151
+msgid "Double Japanese Postcard Rotated 148 x 200 mm"
+msgstr "Dubbele Japannese poskaart, geroteer 148 x 200 mm"
+
+#: ../src/common/paper.cpp:152
+msgid "A6 Rotated 148 x 105 mm"
+msgstr "A6 geroteer 148 x 105 mm"
+
+#: ../src/common/paper.cpp:153
+msgid "Japanese Envelope Kaku #2 Rotated"
+msgstr ""
+
+#: ../src/common/paper.cpp:154
+msgid "Japanese Envelope Kaku #3 Rotated"
+msgstr ""
+
+#: ../src/common/paper.cpp:155
+msgid "Japanese Envelope Chou #3 Rotated"
+msgstr ""
+
+#: ../src/common/paper.cpp:156
+msgid "Japanese Envelope Chou #4 Rotated"
+msgstr ""
+
+#: ../src/common/paper.cpp:157
+msgid "B6 (JIS) 128 x 182 mm"
+msgstr ""
+
+#: ../src/common/paper.cpp:158
+msgid "B6 (JIS) Rotated 182 x 128 mm"
+msgstr ""
+
+#: ../src/common/paper.cpp:159
+msgid "12 x 11 in"
+msgstr "12 x 11 duim"
+
+#: ../src/common/paper.cpp:160
+msgid "Japanese Envelope You #4"
+msgstr ""
+
+#: ../src/common/paper.cpp:161
+msgid "Japanese Envelope You #4 Rotated"
+msgstr ""
+
+#: ../src/common/paper.cpp:162
+msgid "PRC 16K 146 x 215 mm"
+msgstr ""
+
+#: ../src/common/paper.cpp:163
+msgid "PRC 32K 97 x 151 mm"
+msgstr ""
+
+#: ../src/common/paper.cpp:164
+msgid "PRC 32K(Big) 97 x 151 mm"
+msgstr ""
+
+#: ../src/common/paper.cpp:165
+#, fuzzy
+msgid "PRC Envelope #1 102 x 165 mm"
+msgstr "C6 Koevert, 114 x 162 mm"
+
+#: ../src/common/paper.cpp:166
+#, fuzzy
+msgid "PRC Envelope #2 102 x 176 mm"
+msgstr "C6 Koevert, 114 x 162 mm"
+
+#: ../src/common/paper.cpp:167
+#, fuzzy
+msgid "PRC Envelope #3 125 x 176 mm"
+msgstr "C6 Koevert, 114 x 162 mm"
+
+#: ../src/common/paper.cpp:168
+#, fuzzy
+msgid "PRC Envelope #4 110 x 208 mm"
+msgstr "Koevert DL, 110 x 220 mm"
+
+#: ../src/common/paper.cpp:169
+#, fuzzy
+msgid "PRC Envelope #5 110 x 220 mm"
+msgstr "Koevert DL, 110 x 220 mm"
+
+#: ../src/common/paper.cpp:170
+#, fuzzy
+msgid "PRC Envelope #6 120 x 230 mm"
+msgstr "C5 Koevert, 162 x 229 mm"
+
+#: ../src/common/paper.cpp:171
+#, fuzzy
+msgid "PRC Envelope #7 160 x 230 mm"
+msgstr "B5 Koevert, 176 x 250 mm"
+
+#: ../src/common/paper.cpp:172
+#, fuzzy
+msgid "PRC Envelope #8 120 x 309 mm"
+msgstr "C5 Koevert, 162 x 229 mm"
+
+#: ../src/common/paper.cpp:173
+#, fuzzy
+msgid "PRC Envelope #9 229 x 324 mm"
+msgstr "C4 Koevert, 229 x 324 mm"
+
+#: ../src/common/paper.cpp:174
+#, fuzzy
+msgid "PRC Envelope #10 324 x 458 mm"
+msgstr "C3 Koevert, 324 x 458 mm"
+
+#: ../src/common/paper.cpp:175
+msgid "PRC 16K Rotated"
+msgstr ""
+
+#: ../src/common/paper.cpp:176
+msgid "PRC 32K Rotated"
+msgstr ""
+
+#: ../src/common/paper.cpp:177
+msgid "PRC 32K(Big) Rotated"
+msgstr ""
+
+#: ../src/common/paper.cpp:178
+#, fuzzy
+msgid "PRC Envelope #1 Rotated 165 x 102 mm"
+msgstr "C6 Koevert, 114 x 162 mm"
+
+#: ../src/common/paper.cpp:179
+#, fuzzy
+msgid "PRC Envelope #2 Rotated 176 x 102 mm"
+msgstr "B6 Koevert, 176 x 125 mm"
+
+#: ../src/common/paper.cpp:180
+#, fuzzy
+msgid "PRC Envelope #3 Rotated 176 x 125 mm"
+msgstr "B6 Koevert, 176 x 125 mm"
+
+#: ../src/common/paper.cpp:181
+#, fuzzy
+msgid "PRC Envelope #4 Rotated 208 x 110 mm"
+msgstr "C6 Koevert, 114 x 162 mm"
+
+#: ../src/common/paper.cpp:182
+#, fuzzy
+msgid "PRC Envelope #5 Rotated 220 x 110 mm"
+msgstr "C4 Koevert, 229 x 324 mm"
+
+#: ../src/common/paper.cpp:183
+#, fuzzy
+msgid "PRC Envelope #6 Rotated 230 x 120 mm"
+msgstr "C5 Koevert, 162 x 229 mm"
+
+#: ../src/common/paper.cpp:184
+#, fuzzy
+msgid "PRC Envelope #7 Rotated 230 x 160 mm"
+msgstr "C6 Koevert, 114 x 162 mm"
+
+#: ../src/common/paper.cpp:185
+#, fuzzy
+msgid "PRC Envelope #8 Rotated 309 x 120 mm"
+msgstr "C4 Koevert, 229 x 324 mm"
+
+#: ../src/common/paper.cpp:186
+#, fuzzy
+msgid "PRC Envelope #9 Rotated 324 x 229 mm"
+msgstr "C5 Koevert, 162 x 229 mm"
+
+#: ../src/common/paper.cpp:187
+#, fuzzy
+msgid "PRC Envelope #10 Rotated 458 x 324 mm"
+msgstr "C4 Koevert, 229 x 324 mm"
+
+#: ../src/common/paper.cpp:192
+msgid "A0 sheet, 841 x 1189 mm"
+msgstr "A0, 841 x 1189 mm"
+
+#: ../src/common/paper.cpp:193
+msgid "A1 sheet, 594 x 841 mm"
+msgstr "A1, 594 x 841 mm"
+
+#: ../src/common/preferencescmn.cpp:37
+msgid "General"
+msgstr "Algemeen"
+
+#: ../src/common/preferencescmn.cpp:40
+msgid "Advanced"
+msgstr "Gevorderd"
+
+#: ../src/common/prntbase.cpp:245
+msgid "Generic PostScript"
+msgstr "Generiese PostScript"
+
+#: ../src/common/prntbase.cpp:259
+msgid "Ready"
+msgstr "Gereed"
+
+#: ../src/common/prntbase.cpp:331
+msgid "Printing Error"
+msgstr "Drukwerkfout"
+
+#: ../src/common/prntbase.cpp:413 ../src/common/prntbase.cpp:1597
+#: ../src/generic/prntdlgg.cpp:135 ../src/generic/prntdlgg.cpp:149
+#: ../src/gtk/print.cpp:628 ../src/gtk/print.cpp:646
+msgid "Print"
+msgstr "Druk"
+
+#: ../src/common/prntbase.cpp:471 ../src/generic/prntdlgg.cpp:809
+msgid "Page setup"
+msgstr "Bladsy-opstelling"
+
+#: ../src/common/prntbase.cpp:525
+msgid "Please wait while printing..."
+msgstr "Wag asb. tydens drukwerk..."
+
+#: ../src/common/prntbase.cpp:529
+msgid "Document:"
+msgstr "Dokument:"
+
+#: ../src/common/prntbase.cpp:532
+msgid "Progress:"
+msgstr "Vordering:"
+
+#: ../src/common/prntbase.cpp:533
+msgid "Preparing"
+msgstr "Berei tans voor"
+
+#: ../src/common/prntbase.cpp:552
+#, fuzzy, c-format
+msgid "Printing page %d"
+msgstr "Druk tans bladsy %d..."
+
+#: ../src/common/prntbase.cpp:557
+#, c-format
+msgid "Printing page %d of %d"
+msgstr "Druk tans bladsy %d van %d"
+
+#: ../src/common/prntbase.cpp:560
+#, c-format
+msgid " (copy %d of %d)"
+msgstr " (kopie %d van %d)"
+
+#: ../src/common/prntbase.cpp:1604
+msgid "First page"
+msgstr "Eerste bladsy"
+
+#: ../src/common/prntbase.cpp:1609 ../src/html/helpwnd.cpp:659
+msgid "Previous page"
+msgstr "Vorige bladsy"
+
+#: ../src/common/prntbase.cpp:1623 ../src/html/helpwnd.cpp:660
+msgid "Next page"
+msgstr "Volgende bladsy"
+
+#: ../src/common/prntbase.cpp:1628
+msgid "Last page"
+msgstr "Laaste bladsy"
+
+#: ../src/common/prntbase.cpp:1636 ../src/common/stockitem.cpp:215
+msgid "Zoom Out"
+msgstr "Zoem uit"
+
+#: ../src/common/prntbase.cpp:1650 ../src/common/stockitem.cpp:214
+msgid "Zoom In"
+msgstr "Zoem in"
+
+#: ../src/common/prntbase.cpp:1656 ../src/common/stockitem.cpp:153
+#: ../src/generic/logg.cpp:553 ../src/univ/themes/win32.cpp:3752
+msgid "&Close"
+msgstr "Maak &toe"
+
+#: ../src/common/prntbase.cpp:2085
+msgid "Could not start document preview."
+msgstr "Kon drukvoorskou nie begin nie."
+
+#: ../src/common/prntbase.cpp:2085 ../src/common/prntbase.cpp:2129
+#: ../src/common/prntbase.cpp:2137
+msgid "Print Preview Failure"
+msgstr "Drukvoorskou het misluk"
+
+#: ../src/common/prntbase.cpp:2129 ../src/common/prntbase.cpp:2137
+msgid "Sorry, not enough memory to create a preview."
+msgstr "Jammer, onvoldoende geheue vir drukvoorskou."
+
+#: ../src/common/prntbase.cpp:2144
+#, c-format
+msgid "Page %d of %d"
+msgstr "Bladsy %d van %d"
+
+#: ../src/common/prntbase.cpp:2146
+#, c-format
+msgid "Page %d"
+msgstr "Bladsy %d"
+
+#: ../src/common/regex.cpp:382 ../src/html/chm.cpp:348
+msgid "unknown error"
+msgstr "onbekende fout"
+
+#: ../src/common/regex.cpp:995
+#, c-format
+msgid "Invalid regular expression '%s': %s"
+msgstr "Ongeldige reëlmatige uitdrukking '%s': %s"
+
+#: ../src/common/regex.cpp:1059
+#, fuzzy, c-format
+msgid "Failed to find match for regular expression: %s"
+msgstr "'%s' kon nie in reëlmatige uitdrukking '%s' gevind word nie"
+
+#: ../src/common/rendcmn.cpp:188
+#, c-format
+msgid "Renderer \"%s\" has incompatible version %d.%d and couldn't be loaded."
+msgstr ""
+"Renderer \"%s\" het onversoenbare weergawe %d.%d en kon nie gelaai word nie."
+
+#: ../src/common/secretstore.cpp:162
+msgid "Not available for this platform"
+msgstr ""
+
+#: ../src/common/secretstore.cpp:183
+#, fuzzy, c-format
+msgid "Saving password for \"%s\" failed: %s."
+msgstr "Uitpak van '%s' binne-in '%s' het misluk."
+
+#: ../src/common/secretstore.cpp:205
+#, fuzzy, c-format
+msgid "Reading password for \"%s\" failed: %s."
+msgstr "Uitpak van '%s' binne-in '%s' het misluk."
+
+#: ../src/common/secretstore.cpp:228
+#, fuzzy, c-format
+msgid "Deleting password for \"%s\" failed: %s."
+msgstr "Uitpak van '%s' binne-in '%s' het misluk."
+
+#: ../src/common/selectdispatcher.cpp:254
+msgid "Failed to monitor I/O channels"
+msgstr ""
+
+#: ../src/common/sizer.cpp:3054 ../src/common/stockitem.cpp:195
+msgid "Save"
+msgstr "Stoor"
+
+#: ../src/common/sizer.cpp:3056
+msgid "Don't Save"
+msgstr "Moenie stoor nie"
+
+#: ../src/common/socket.cpp:870
+#, fuzzy
+msgid "Cannot initialize sockets"
+msgstr "Kan OLE nie inisialiseer nie"
+
+#: ../src/common/stockitem.cpp:127
+#, fuzzy
+msgctxt "standard Windows menu"
+msgid "&Help"
+msgstr "&Hulp"
+
+#: ../src/common/stockitem.cpp:144
+msgid "&About"
+msgstr "&Aangaande"
+
+#: ../src/common/stockitem.cpp:144
+msgid "About"
+msgstr "Aangaande"
+
+#: ../src/common/stockitem.cpp:145
+msgid "Add"
+msgstr "Voeg by"
+
+#: ../src/common/stockitem.cpp:146
+msgid "&Apply"
+msgstr "P&as toe"
+
+#: ../src/common/stockitem.cpp:146
+msgid "Apply"
+msgstr "Pas toe"
+
+#: ../src/common/stockitem.cpp:147
+msgid "&Back"
+msgstr "&Terug"
+
+#: ../src/common/stockitem.cpp:147
+msgid "Back"
+msgstr "Terug"
+
+#: ../src/common/stockitem.cpp:148
+msgid "&Bold"
+msgstr "&Vet"
+
+#: ../src/common/stockitem.cpp:148 ../src/generic/fontdlgg.cpp:326
+#: ../src/richtext/richtextfontpage.cpp:354
+msgid "Bold"
+msgstr "Vet"
+
+#: ../src/common/stockitem.cpp:149
+msgid "&Bottom"
+msgstr "&Onder"
+
+#: ../src/common/stockitem.cpp:149 ../src/richtext/richtextsizepage.cpp:287
+msgid "Bottom"
+msgstr "Onder"
+
+#: ../src/common/stockitem.cpp:150 ../src/generic/fontdlgg.cpp:462
+#: ../src/generic/fontdlgg.cpp:481 ../src/generic/wizard.cpp:415
+msgid "&Cancel"
+msgstr "&Kanselleer"
+
+#: ../src/common/stockitem.cpp:151
+#, fuzzy
+msgid "&CD-ROM"
+msgstr "&CD-ROM"
+
+#: ../src/common/stockitem.cpp:151
+#, fuzzy
+msgid "CD-ROM"
+msgstr "CD-ROM"
+
+#: ../src/common/stockitem.cpp:152
+msgid "&Clear"
+msgstr "&Maak skoon"
+
+#: ../src/common/stockitem.cpp:152
+msgid "Clear"
+msgstr "Maak skoon"
+
+#: ../src/common/stockitem.cpp:153 ../src/generic/dbgrptg.cpp:93
+#: ../src/generic/progdlgg.cpp:778 ../src/html/helpdlg.cpp:86
+#: ../src/msw/progdlg.cpp:209 ../src/msw/progdlg.cpp:890
+#: ../src/richtext/richtextstyledlg.cpp:272
+#: ../src/richtext/richtextsymboldlg.cpp:448
+msgid "Close"
+msgstr "Maak toe"
+
+#: ../src/common/stockitem.cpp:154
+msgid "&Convert"
+msgstr "S&kakel om"
+
+#: ../src/common/stockitem.cpp:154
+msgid "Convert"
+msgstr "Skakel om"
+
+#: ../src/common/stockitem.cpp:155 ../src/msw/textctrl.cpp:2884
+#: ../src/osx/textctrl_osx.cpp:653 ../src/richtext/richtextctrl.cpp:331
+msgid "&Copy"
+msgstr "&Kopieer"
+
+#: ../src/common/stockitem.cpp:155 ../src/stc/stc_i18n.cpp:18
+msgid "Copy"
+msgstr "Kopieer"
+
+#: ../src/common/stockitem.cpp:156 ../src/msw/textctrl.cpp:2883
+#: ../src/osx/textctrl_osx.cpp:652 ../src/richtext/richtextctrl.cpp:330
+msgid "Cu&t"
+msgstr "Kn&ip"
+
+#: ../src/common/stockitem.cpp:156 ../src/stc/stc_i18n.cpp:17
+msgid "Cut"
+msgstr "Knip"
+
+#: ../src/common/stockitem.cpp:157 ../src/msw/textctrl.cpp:2886
+#: ../src/osx/textctrl_osx.cpp:655 ../src/richtext/richtextctrl.cpp:333
+#: ../src/richtext/richtexttabspage.cpp:137
+msgid "&Delete"
+msgstr "&Skrap"
+
+#: ../src/common/stockitem.cpp:157 ../src/richtext/richtextbuffer.cpp:8266
+#: ../src/stc/stc_i18n.cpp:20
+msgid "Delete"
+msgstr "Skrap"
+
+#: ../src/common/stockitem.cpp:158
+msgid "&Down"
+msgstr "&Af"
+
+#: ../src/common/stockitem.cpp:158 ../src/generic/fdrepdlg.cpp:148
+msgid "Down"
+msgstr "Af"
+
+#: ../src/common/stockitem.cpp:159
+msgid "&Edit"
+msgstr "R&edigeer"
+
+#: ../src/common/stockitem.cpp:159
+msgid "Edit"
+msgstr "Redigeer"
+
+#: ../src/common/stockitem.cpp:160
+msgid "&Execute"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:160
+msgid "Execute"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:161
+msgid "&Quit"
+msgstr "&Sluit af"
+
+#: ../src/common/stockitem.cpp:161
+msgid "Quit"
+msgstr "Sluit af"
+
+#: ../src/common/stockitem.cpp:162
+msgid "&File"
+msgstr "&Lêer"
+
+#: ../src/common/stockitem.cpp:162
+msgid "File"
+msgstr "Lêer"
+
+#: ../src/common/stockitem.cpp:163
+#, fuzzy
+msgid "&Find..."
+msgstr "&Soek"
+
+#: ../src/common/stockitem.cpp:163
+#, fuzzy
+msgid "Find..."
+msgstr "Soek"
+
+#: ../src/common/stockitem.cpp:164
+msgid "&First"
+msgstr "&Eerste"
+
+#: ../src/common/stockitem.cpp:164
+msgid "First"
+msgstr "Eerste"
+
+#: ../src/common/stockitem.cpp:165
+#, fuzzy
+msgid "&Floppy"
+msgstr "&Kopieer "
+
+#: ../src/common/stockitem.cpp:165
+#, fuzzy
+msgid "Floppy"
+msgstr "&Kopieer "
+
+#: ../src/common/stockitem.cpp:166
+msgid "&Forward"
+msgstr "&Vorentoe"
+
+#: ../src/common/stockitem.cpp:166
+msgid "Forward"
+msgstr "Vorentoe"
+
+#: ../src/common/stockitem.cpp:167
+msgid "&Harddisk"
+msgstr "&Hardeskyf"
+
+#: ../src/common/stockitem.cpp:167
+msgid "Harddisk"
+msgstr "Hardeskyf"
+
+#: ../src/common/stockitem.cpp:168 ../src/generic/wizard.cpp:418
+#: ../src/osx/cocoa/menu.mm:225 ../src/richtext/richtextstyledlg.cpp:298
+#: ../src/richtext/richtextsymboldlg.cpp:451
+msgid "&Help"
+msgstr "&Hulp"
+
+#: ../src/common/stockitem.cpp:169
+msgid "&Home"
+msgstr "&Tuis"
+
+#: ../src/common/stockitem.cpp:169
+msgid "Home"
+msgstr "Tuis"
+
+#: ../src/common/stockitem.cpp:170
+msgid "Indent"
+msgstr "Keep in"
+
+#: ../src/common/stockitem.cpp:171
+msgid "&Index"
+msgstr "&Indeks"
+
+#: ../src/common/stockitem.cpp:171 ../src/html/helpwnd.cpp:510
+msgid "Index"
+msgstr "Indeks"
+
+#: ../src/common/stockitem.cpp:172
+msgid "&Info"
+msgstr "&Inligting"
+
+#: ../src/common/stockitem.cpp:172
+msgid "Info"
+msgstr "Inligting"
+
+#: ../src/common/stockitem.cpp:173
+msgid "&Italic"
+msgstr "&Kursief"
+
+#: ../src/common/stockitem.cpp:173 ../src/generic/fontdlgg.cpp:322
+#: ../src/richtext/richtextfontpage.cpp:350
+msgid "Italic"
+msgstr "Kursief"
+
+#: ../src/common/stockitem.cpp:174
+msgid "&Jump to"
+msgstr "&Spring na"
+
+#: ../src/common/stockitem.cpp:174
+msgid "Jump to"
+msgstr "Spring na"
+
+#: ../src/common/stockitem.cpp:175
+msgid "Centered"
+msgstr "Gesentreer"
+
+#: ../src/common/stockitem.cpp:176
+msgid "Justified"
+msgstr "Alkantbelyn"
+
+#: ../src/common/stockitem.cpp:177
+msgid "Align Left"
+msgstr "Belyn links"
+
+#: ../src/common/stockitem.cpp:178
+msgid "Align Right"
+msgstr "Belyn regs"
+
+#: ../src/common/stockitem.cpp:179
+msgid "&Last"
+msgstr "&Laaste"
+
+#: ../src/common/stockitem.cpp:179
+msgid "Last"
+msgstr "Laaste"
+
+#: ../src/common/stockitem.cpp:180
+msgid "&Network"
+msgstr "&Netwerk"
+
+#: ../src/common/stockitem.cpp:180
+msgid "Network"
+msgstr "Netwerk"
+
+#: ../src/common/stockitem.cpp:181 ../src/richtext/richtexttabspage.cpp:131
+msgid "&New"
+msgstr "&Nuwe"
+
+#: ../src/common/stockitem.cpp:181
+msgid "New"
+msgstr "Nuwe"
+
+#: ../src/common/stockitem.cpp:182 ../src/msw/msgdlg.cpp:417
+msgid "&No"
+msgstr "&Nee"
+
+#: ../src/common/stockitem.cpp:183 ../src/generic/fontdlgg.cpp:467
+#: ../src/generic/fontdlgg.cpp:474
+msgid "&OK"
+msgstr "G&oed"
+
+#: ../src/common/stockitem.cpp:184 ../src/generic/dbgrptg.cpp:341
+msgid "&Open..."
+msgstr "&Open..."
+
+#: ../src/common/stockitem.cpp:184
+msgid "Open..."
+msgstr "Open..."
+
+#: ../src/common/stockitem.cpp:185 ../src/msw/textctrl.cpp:2885
+#: ../src/osx/textctrl_osx.cpp:654 ../src/richtext/richtextctrl.cpp:332
+msgid "&Paste"
+msgstr "&Plak"
+
+#: ../src/common/stockitem.cpp:185 ../src/richtext/richtextctrl.cpp:3484
+#: ../src/stc/stc_i18n.cpp:19
+msgid "Paste"
+msgstr "Plak"
+
+#: ../src/common/stockitem.cpp:186
+msgid "&Preferences"
+msgstr "&Voorkeure"
+
+#: ../src/common/stockitem.cpp:186 ../src/osx/cocoa/preferences.mm:304
+msgid "Preferences"
+msgstr "Voorkeure"
+
+#: ../src/common/stockitem.cpp:187
+msgid "Print previe&w..."
+msgstr "&Drukvoorskou..."
+
+#: ../src/common/stockitem.cpp:187
+msgid "Print preview..."
+msgstr "Drukvoorskou..."
+
+#: ../src/common/stockitem.cpp:188
+msgid "&Print..."
+msgstr "&Druk..."
+
+#: ../src/common/stockitem.cpp:188
+msgid "Print..."
+msgstr "Druk..."
+
+#: ../src/common/stockitem.cpp:189 ../src/richtext/richtextctrl.cpp:337
+#: ../src/richtext/richtextctrl.cpp:5479
+msgid "&Properties"
+msgstr "&Eienskappe"
+
+#: ../src/common/stockitem.cpp:189
+msgid "Properties"
+msgstr "Eienskappe"
+
+#: ../src/common/stockitem.cpp:190 ../src/stc/stc_i18n.cpp:16
+msgid "Redo"
+msgstr "Herdoen"
+
+#: ../src/common/stockitem.cpp:191
+msgid "Refresh"
+msgstr "Verfris"
+
+#: ../src/common/stockitem.cpp:192
+msgid "Remove"
+msgstr "Verwyder"
+
+#: ../src/common/stockitem.cpp:193
+#, fuzzy
+msgid "Rep&lace..."
+msgstr "&Vervang"
+
+#: ../src/common/stockitem.cpp:193
+#, fuzzy
+msgid "Replace..."
+msgstr "Vervang"
+
+#: ../src/common/stockitem.cpp:194
+#, fuzzy
+msgid "Revert to Saved"
+msgstr "Keer terug na gestoorde weergawe"
+
+#: ../src/common/stockitem.cpp:196 ../src/generic/logg.cpp:549
+msgid "Save &As..."
+msgstr "Stoor &as..."
+
+#: ../src/common/stockitem.cpp:196
+#, fuzzy
+msgid "Save As..."
+msgstr "Stoor &as..."
+
+#: ../src/common/stockitem.cpp:197 ../src/msw/textctrl.cpp:2888
+#: ../src/osx/textctrl_osx.cpp:657 ../src/richtext/richtextctrl.cpp:335
+msgid "Select &All"
+msgstr "Kies &alles"
+
+#: ../src/common/stockitem.cpp:197 ../src/stc/stc_i18n.cpp:21
+msgid "Select All"
+msgstr "Kies alles"
+
+#: ../src/common/stockitem.cpp:198
+msgid "&Color"
+msgstr "&Kleur"
+
+#: ../src/common/stockitem.cpp:198
+msgid "Color"
+msgstr "Kleur"
+
+#: ../src/common/stockitem.cpp:199
+msgid "&Font"
+msgstr "&Lettertipe"
+
+#: ../src/common/stockitem.cpp:199 ../src/richtext/richtextformatdlg.cpp:336
+msgid "Font"
+msgstr "Lettertipe"
+
+#: ../src/common/stockitem.cpp:200
+msgid "&Ascending"
+msgstr "&Stygend"
+
+#: ../src/common/stockitem.cpp:200
+msgid "Ascending"
+msgstr "Stygend"
+
+#: ../src/common/stockitem.cpp:201
+msgid "&Descending"
+msgstr "&Dalend"
+
+#: ../src/common/stockitem.cpp:201
+msgid "Descending"
+msgstr "Dalend"
+
+#: ../src/common/stockitem.cpp:202
+msgid "&Spell Check"
+msgstr "&Speltoets"
+
+#: ../src/common/stockitem.cpp:202
+msgid "Spell Check"
+msgstr "Speltoets"
+
+#: ../src/common/stockitem.cpp:203
+msgid "&Stop"
+msgstr "&Stop"
+
+#: ../src/common/stockitem.cpp:203
+msgid "Stop"
+msgstr "Stop"
+
+#: ../src/common/stockitem.cpp:204 ../src/richtext/richtextfontpage.cpp:274
+msgid "&Strikethrough"
+msgstr "&Deurhaal"
+
+#: ../src/common/stockitem.cpp:204
+msgid "Strikethrough"
+msgstr "Deurhaal"
+
+#: ../src/common/stockitem.cpp:205
+msgid "&Top"
+msgstr "Bokan&t"
+
+#: ../src/common/stockitem.cpp:205 ../src/richtext/richtextsizepage.cpp:285
+#: ../src/richtext/richtextsizepage.cpp:289
+msgid "Top"
+msgstr "Bokant"
+
+#: ../src/common/stockitem.cpp:206
+#, fuzzy
+msgid "Undelete"
+msgstr "Ontskrap"
+
+#: ../src/common/stockitem.cpp:207 ../src/generic/fontdlgg.cpp:437
+msgid "&Underline"
+msgstr "&Onderstreep"
+
+#: ../src/common/stockitem.cpp:207
+msgid "Underline"
+msgstr "Onderstreep"
+
+#: ../src/common/stockitem.cpp:208 ../src/stc/stc_i18n.cpp:15
+msgid "Undo"
+msgstr "Ontdoen"
+
+#: ../src/common/stockitem.cpp:209
+msgid "&Unindent"
+msgstr "Keep &uit"
+
+#: ../src/common/stockitem.cpp:209
+msgid "Unindent"
+msgstr "Keep uit"
+
+#: ../src/common/stockitem.cpp:210
+msgid "&Up"
+msgstr "&Op"
+
+#: ../src/common/stockitem.cpp:210 ../src/generic/fdrepdlg.cpp:148
+msgid "Up"
+msgstr "Op"
+
+#: ../src/common/stockitem.cpp:211 ../src/msw/msgdlg.cpp:417
+msgid "&Yes"
+msgstr "&Ja"
+
+#: ../src/common/stockitem.cpp:212
+msgid "&Actual Size"
+msgstr "&Werklike grootte"
+
+#: ../src/common/stockitem.cpp:212
+msgid "Actual Size"
+msgstr "Werklike grootte"
+
+#: ../src/common/stockitem.cpp:213
+#, fuzzy
+msgid "Zoom to &Fit"
+msgstr "Zoem om te &pas"
+
+#: ../src/common/stockitem.cpp:213
+msgid "Zoom to Fit"
+msgstr "Zoem om te pas"
+
+#: ../src/common/stockitem.cpp:214
+msgid "Zoom &In"
+msgstr "Zoem &in"
+
+#: ../src/common/stockitem.cpp:215
+msgid "Zoom &Out"
+msgstr "Zoem &uit"
+
+#: ../src/common/stockitem.cpp:262
+msgid "Show about dialog"
+msgstr "Wys \"Aangaande\"-dialoog"
+
+#: ../src/common/stockitem.cpp:263
+msgid "Copy selection"
+msgstr "Kopieer seleksie"
+
+#: ../src/common/stockitem.cpp:264
+msgid "Cut selection"
+msgstr "Knip seleksie"
+
+#: ../src/common/stockitem.cpp:265
+msgid "Delete selection"
+msgstr "Skrap seleksie"
+
+#: ../src/common/stockitem.cpp:266
+#, fuzzy
+msgid "Find in document"
+msgstr "Maak HTML-dokument oop"
+
+#: ../src/common/stockitem.cpp:267
+msgid "Find and replace in document"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:268
+msgid "Paste selection"
+msgstr "Plak seleksie"
+
+#: ../src/common/stockitem.cpp:269
+msgid "Quit this program"
+msgstr "Sluit die program af"
+
+#: ../src/common/stockitem.cpp:270
+msgid "Redo last action"
+msgstr "Herdoen laaste aksie"
+
+#: ../src/common/stockitem.cpp:271
+msgid "Undo last action"
+msgstr "Ontdoen laaste aksie"
+
+#: ../src/common/stockitem.cpp:272
+#, fuzzy
+msgid "Create new document"
+msgstr "Maak nuwe gids"
+
+#: ../src/common/stockitem.cpp:273
+#, fuzzy
+msgid "Open an existing document"
+msgstr "Maak HTML-dokument oop"
+
+#: ../src/common/stockitem.cpp:274
+msgid "Close current document"
+msgstr "Sluit huidige dokument"
+
+#: ../src/common/stockitem.cpp:275
+msgid "Save current document"
+msgstr "Stoor huidige dokument"
+
+#: ../src/common/stockitem.cpp:276
+msgid "Save current document with a different filename"
+msgstr "Stoor huidige dokument met 'n ander lêernaam"
+
+#: ../src/common/strconv.cpp:2324
+#, c-format
+msgid "Conversion to charset '%s' doesn't work."
+msgstr "Omskakeling na karakterstel '%s' werk nie."
+
+#: ../src/common/tarstrm.cpp:352 ../src/common/tarstrm.cpp:375
+#: ../src/common/tarstrm.cpp:406 ../src/generic/progdlgg.cpp:373
+msgid "unknown"
+msgstr "onbekend"
+
+#: ../src/common/tarstrm.cpp:774
+msgid "incomplete header block in tar"
+msgstr ""
+
+#: ../src/common/tarstrm.cpp:798
+msgid "checksum failure reading tar header block"
+msgstr ""
+
+#: ../src/common/tarstrm.cpp:971
+msgid "invalid data in extended tar header"
+msgstr ""
+
+#: ../src/common/tarstrm.cpp:981 ../src/common/tarstrm.cpp:1003
+#: ../src/common/tarstrm.cpp:1477 ../src/common/tarstrm.cpp:1499
+msgid "tar entry not open"
+msgstr ""
+
+#: ../src/common/tarstrm.cpp:1023
+msgid "unexpected end of file"
+msgstr ""
+
+#: ../src/common/tarstrm.cpp:1297
+#, c-format
+msgid "%s did not fit the tar header for entry '%s'"
+msgstr ""
+
+#: ../src/common/tarstrm.cpp:1359
+msgid "incorrect size given for tar entry"
+msgstr ""
+
+#: ../src/common/textbuf.cpp:232
+#, c-format
+msgid "'%s' is probably a binary buffer."
+msgstr "'%s' is waarskynlik 'n binêre buffer."
+
+#: ../src/common/textcmn.cpp:1006 ../src/richtext/richtextctrl.cpp:3053
+msgid "File couldn't be loaded."
+msgstr "Lêer kon nie gelaai word nie."
+
+#: ../src/common/textfile.cpp:95
+#, fuzzy, c-format
+msgid "Failed to read text file \"%s\"."
+msgstr "Lees van dokument vanuit lêer \"%s\" het misluk."
+
+#: ../src/common/textfile.cpp:160
+#, c-format
+msgid "can't write buffer '%s' to disk."
+msgstr "kan buffer '%s' nie na skyf skryf nie."
+
+#: ../src/common/time.cpp:212
+msgid "Failed to get the local system time"
+msgstr "Die plaaslike stelseltyd kon nie verkry word nie"
+
+#: ../src/common/time.cpp:279
+msgid "wxGetTimeOfDay failed."
+msgstr "wxGetTimeOfDay het misluk."
+
+#: ../src/common/translation.cpp:929
+#, c-format
+msgid "'%s' is not a valid message catalog."
+msgstr "'%s' is nie 'n geldige boodskapkatalogus."
+
+#: ../src/common/translation.cpp:954
+#, fuzzy
+msgid "Invalid message catalog."
+msgstr "'%s' is nie 'n geldige boodskapkatalogus."
+
+#: ../src/common/translation.cpp:1013
+#, fuzzy, c-format
+msgid "Failed to parse Plural-Forms: '%s'"
+msgstr "Kan nie meervoudvorme ontleed nie: `%s'"
+
+#: ../src/common/translation.cpp:1723
+#, c-format
+msgid "using catalog '%s' from '%s'."
+msgstr "katalogus '%s' van '%s' word gebruik."
+
+#: ../src/common/translation.cpp:1816
+#, fuzzy, c-format
+msgid "Resource '%s' is not a valid message catalog."
+msgstr "'%s' is nie 'n geldige boodskapkatalogus."
+
+#: ../src/common/translation.cpp:1865
+#, fuzzy
+msgid "Couldn't enumerate translations"
+msgstr "Kon uitvoerdraad nie beëindig nie"
+
+#: ../src/common/utilscmn.cpp:1145
+msgid "No default application configured for HTML files."
+msgstr ""
+
+#: ../src/common/utilscmn.cpp:1190
+#, c-format
+msgid "Failed to open URL \"%s\" in default browser."
+msgstr "Opening van URL \"%s\" in verstekblaaier het misluk."
+
+#: ../src/common/valtext.cpp:144
+msgid "Validation conflict"
+msgstr "Geldigheidskonflik"
+
+#: ../src/common/valtext.cpp:186
+msgid "Required information entry is empty."
+msgstr ""
+
+#: ../src/common/valtext.cpp:188
+#, fuzzy, c-format
+msgid "'%s' is one of the invalid strings"
+msgstr "'%s' is ongeldig"
+
+#: ../src/common/valtext.cpp:190
+#, fuzzy, c-format
+msgid "'%s' is not one of the valid strings"
+msgstr "'%s' is nie 'n geldige boodskapkatalogus."
+
+#: ../src/common/valtext.cpp:199
+#, fuzzy, c-format
+msgid "'%s' contains invalid character(s)"
+msgstr "'%s' mag slegs letters bevat."
+
+#: ../src/common/webrequest.cpp:139
+#, fuzzy, c-format
+msgid "Error: %s (%d)"
+msgstr "Fout: "
+
+#: ../src/common/webrequest.cpp:655
+#, c-format
+msgid ""
+"Not enough free disk space for download: %llu needed but only %llu available."
+msgstr ""
+
+#: ../src/common/webrequest.cpp:669
+#, fuzzy, c-format
+msgid "Failed to create temporary file in %s"
+msgstr "'n Tydelyke lêernaam kon nie geskep word nie"
+
+#: ../src/common/webrequest_curl.cpp:1106
+#, fuzzy
+msgid "libcurl could not be initialized"
+msgstr "Lêer kon nie gelaai word nie."
+
+#: ../src/common/webview.cpp:392
+#, fuzzy
+msgid "RunScriptAsync not supported"
+msgstr "String-omskakelings word nie ondersteun nie"
+
+#: ../src/common/webview.cpp:403 ../src/msw/webview_ie.cpp:1073
+#, c-format
+msgid "Error running JavaScript: %s"
+msgstr ""
+
+#: ../src/common/webview_chromium.cpp:858
+#, fuzzy, c-format
+msgid "Failed to set proxy \"%s\": %s"
+msgstr "Gids \"%s\" kon nie geskep word nie"
+
+#: ../src/common/webview_chromium.cpp:989
+msgid ""
+"Chromium can't be used because libcef.so wasn't loaded early enough; please "
+"relink the application or use LD_PRELOAD to load it earlier."
+msgstr ""
+
+#: ../src/common/webview_chromium.cpp:1108
+#, fuzzy
+msgid "Could not initialize Chromium"
+msgstr "Kon nie begin met drukwerk nie."
+
+#: ../src/common/webview_chromium.cpp:1616
+msgid "Show DevTools"
+msgstr ""
+
+#: ../src/common/webview_chromium.cpp:1617
+#, fuzzy
+msgid "Close DevTools"
+msgstr "Maak alles toe"
+
+#: ../src/common/webview_chromium.cpp:1623
+msgid "Inspect"
+msgstr ""
+
+#: ../src/common/wincmn.cpp:1628
+msgid "This platform does not support background transparency."
+msgstr ""
+
+#: ../src/common/wincmn.cpp:2097
+msgid "Could not transfer data to window"
+msgstr "Kon data nie na venster oordra nie"
+
+#: ../src/common/windowid.cpp:240
+msgid "Out of window IDs.  Recommend shutting down application."
+msgstr ""
+
+#: ../src/common/xpmdecod.cpp:678
+msgid "XPM: incorrect header format!"
+msgstr ""
+
+#: ../src/common/xpmdecod.cpp:703
+#, c-format
+msgid "XPM: incorrect colour description in line %d"
+msgstr "XPM: verkeerde kleurbeskrywing in lyn %d"
+
+#: ../src/common/xpmdecod.cpp:715 ../src/common/xpmdecod.cpp:724
+#, fuzzy, c-format
+msgid "XPM: malformed colour definition '%s' at line %d!"
+msgstr "XPM: Misvormde kleurdefinisie '%s'!"
+
+#: ../src/common/xpmdecod.cpp:754
+msgid "XPM: no colors left to use for mask!"
+msgstr ""
+
+#: ../src/common/xpmdecod.cpp:781
+#, c-format
+msgid "XPM: truncated image data at line %d!"
+msgstr ""
+
+#: ../src/common/xpmdecod.cpp:795
+msgid "XPM: Malformed pixel data!"
+msgstr "XPM: Misvormde pixel data!"
+
+#: ../src/common/xti.cpp:492
+msgid "Illegal Parameter Count for Create Method"
+msgstr "Ongeldige aantal parameters vir Createt-metode"
+
+#: ../src/common/xti.cpp:504
+msgid "Illegal Parameter Count for ConstructObject Method"
+msgstr "Ongeldige aantal parameters vir ConstructObject-metode"
+
+#: ../src/common/xtistrm.cpp:161
+#, fuzzy, c-format
+msgid "Create Parameter %s not found in declared RTTI Parameters"
+msgstr "Create-parameter nie gevind in die verklaarde RTTI parameters nie"
+
+#: ../src/common/xtistrm.cpp:290
+msgid "Illegal Object Class (Non-wxEvtHandler) as Event Source"
+msgstr "Ongeldige objekklas (Non-wxEvtHandler) as bron van gebeurtenis"
+
+#: ../src/common/xtistrm.cpp:313 ../src/common/xtixml.cpp:345
+#: ../src/common/xtixml.cpp:498
+msgid "Type must have enum - long conversion"
+msgstr "Tipe moet 'n enum - long omskakeling bevat"
+
+#: ../src/common/xtistrm.cpp:400 ../src/common/xtistrm.cpp:415
+msgid "Invalid or Null Object ID passed to GetObjectClassInfo"
+msgstr "Ongeldige- of Null-objek ID is aangestuur vir GetObjectClassInfo"
+
+#: ../src/common/xtistrm.cpp:405
+msgid "Unknown Object passed to GetObjectClassInfo"
+msgstr "Onbekende objek is aangestuur vir GetObjectClassInfo"
+
+#: ../src/common/xtistrm.cpp:420
+msgid "Already Registered Object passed to SetObjectClassInfo"
+msgstr ""
+"Die objek wat aangestuur is vir SetObjectClassInfo is alreeds geregistreer"
+
+#: ../src/common/xtistrm.cpp:430
+msgid "Invalid or Null Object ID passed to HasObjectClassInfo"
+msgstr "Ongeldige- of Null-objek ID is aangestuur vir HasObjectClassInfo"
+
+#: ../src/common/xtistrm.cpp:460
+msgid "Passing a already registered object to SetObject"
+msgstr "'n Reedsgeregistreerde objek word aangestuur vir SetObject"
+
+#: ../src/common/xtistrm.cpp:471
+#, fuzzy
+msgid "Passing an unknown object to GetObject"
+msgstr "'n Onbekende objek word aangestuur vir GetObject"
+
+#: ../src/common/xtixml.cpp:229
+msgid "Forward hrefs are not supported"
+msgstr "Voorwaartse 'href'-verwysings word nie ondersteun nie"
+
+#: ../src/common/xtixml.cpp:247
+#, c-format
+msgid "unknown class %s"
+msgstr "onbekende klas %s"
+
+#: ../src/common/xtixml.cpp:253
+msgid "objects cannot have XML Text Nodes"
+msgstr "objekte kan nie XML-teksnodusse bevat nie"
+
+#: ../src/common/xtixml.cpp:258
+msgid "Objects must have an id attribute"
+msgstr "Objekte moet elkeen 'n id-attribuut hê"
+
+#: ../src/common/xtixml.cpp:267
+#, c-format
+msgid "Doubly used id : %d"
+msgstr "Dubbelgebruikte id: %d"
+
+#: ../src/common/xtixml.cpp:316
+#, fuzzy, c-format
+msgid "Unknown Property %s"
+msgstr "Onbekende eienskap %s"
+
+#: ../src/common/xtixml.cpp:407
+msgid "A non empty collection must consist of 'element' nodes"
+msgstr "'n Nie-leë versameling moet bestaan uit 'element'-nodes"
+
+#: ../src/common/xtixml.cpp:478
+msgid "incorrect event handler string, missing dot"
+msgstr "verkeerde gebeurtenishanteerder, punt ontbreek"
+
+#: ../src/common/zipstrm.cpp:559
+#, fuzzy
+msgid "can't re-initialize zlib deflate stream"
+msgstr "Kan nie zlib-afblaasstroom inisialiseer nie."
+
+#: ../src/common/zipstrm.cpp:584
+#, fuzzy
+msgid "can't re-initialize zlib inflate stream"
+msgstr "Kan nie zlib-opblaasstroom inisialiseer nie."
+
+#: ../src/common/zipstrm.cpp:1023
+msgid "Ignoring malformed extra data record, ZIP file may be corrupted"
+msgstr ""
+
+#: ../src/common/zipstrm.cpp:1502
+msgid "assuming this is a multi-part zip concatenated"
+msgstr ""
+
+#: ../src/common/zipstrm.cpp:1664
+msgid "invalid zip file"
+msgstr "ongeldig ZIP-lêer"
+
+#: ../src/common/zipstrm.cpp:1723
+#, fuzzy
+msgid "can't find central directory in zip"
+msgstr "Kan nie huidige posisie in lêer '%s' vind nie"
+
+#: ../src/common/zipstrm.cpp:1812
+#, fuzzy
+msgid "error reading zip central directory"
+msgstr "Fout tydens skepping van gids"
+
+#: ../src/common/zipstrm.cpp:1916
+msgid "error reading zip local header"
+msgstr ""
+
+#: ../src/common/zipstrm.cpp:1964
+msgid "bad zipfile offset to entry"
+msgstr ""
+
+#: ../src/common/zipstrm.cpp:2031
+msgid "stored file length not in Zip header"
+msgstr ""
+
+#: ../src/common/zipstrm.cpp:2045 ../src/common/zipstrm.cpp:2362
+msgid "unsupported Zip compression method"
+msgstr ""
+
+#: ../src/common/zipstrm.cpp:2126
+#, c-format
+msgid "reading zip stream (entry %s): bad length"
+msgstr ""
+
+#: ../src/common/zipstrm.cpp:2131
+#, c-format
+msgid "reading zip stream (entry %s): bad crc"
+msgstr ""
+
+#: ../src/common/zipstrm.cpp:2578
+#, c-format
+msgid "error writing zip entry '%s': file too large without ZIP64"
+msgstr ""
+
+#: ../src/common/zipstrm.cpp:2585
+#, c-format
+msgid "error writing zip entry '%s': bad crc or length"
+msgstr ""
+
+#: ../src/common/zstream.cpp:155 ../src/common/zstream.cpp:315
+msgid "Gzip not supported by this version of zlib"
+msgstr ""
+
+#: ../src/common/zstream.cpp:182
+msgid "Can't initialize zlib inflate stream."
+msgstr "Kan nie zlib-opblaasstroom inisialiseer nie."
+
+#: ../src/common/zstream.cpp:241
+msgid "Can't read inflate stream: unexpected EOF in underlying stream."
+msgstr ""
+"Kan nie opblaasstroom lees nie: onverwagte EOF in onderliggende stroom."
+
+#: ../src/common/zstream.cpp:248 ../src/common/zstream.cpp:423
+#, c-format
+msgid "zlib error %d"
+msgstr "zlib fout %d"
+
+#: ../src/common/zstream.cpp:249
+#, c-format
+msgid "Can't read from inflate stream: %s"
+msgstr "Kan nie van opblaasstroom lees nie: %s"
+
+#: ../src/common/zstream.cpp:343
+msgid "Can't initialize zlib deflate stream."
+msgstr "Kan nie zlib-afblaasstroom inisialiseer nie."
+
+#: ../src/common/zstream.cpp:424
+#, c-format
+msgid "Can't write to deflate stream: %s"
+msgstr "Kan nie skryf na afblaasstroom nie: %s"
+
+#: ../src/dfb/bitmap.cpp:633 ../src/dfb/bitmap.cpp:667
+#, fuzzy, c-format
+msgid "No bitmap handler for type %d defined."
+msgstr "Geen beeldhanteerder is vir die tipe %d gedefinieer nie."
+
+#: ../src/dfb/evtloop.cpp:99
+#, fuzzy
+msgid "Failed to read event from DirectFB pipe"
+msgstr "Inlees van PID vanuit slotlêer het misluk."
+
+#: ../src/dfb/evtloop.cpp:171
+msgid "Failed to switch DirectFB pipe to non-blocking mode"
+msgstr ""
+
+#: ../src/dfb/fontmgr.cpp:171
+#, c-format
+msgid "no fonts found in %s, using builtin font"
+msgstr "Geen lettertipes in %s gevind nie. Gebruik ingeboude een."
+
+#: ../src/dfb/fontmgr.cpp:177
+msgid "Default font"
+msgstr "Versteklettertipe"
+
+#: ../src/dfb/fontmgr.cpp:195
+#, c-format
+msgid "Fonts index file %s disappeared while loading fonts."
+msgstr ""
+"Indekslêer vir lettertipes %s het verdwyn terwyl lettertipes gelaai is."
+
+#: ../src/dfb/wrapdfb.cpp:60
+#, c-format
+msgid "DirectFB error %d occurred."
+msgstr ""
+
+#: ../src/generic/aboutdlgg.cpp:69
+msgid "Developed by "
+msgstr "Ontwikkel deur "
+
+#: ../src/generic/aboutdlgg.cpp:72
+msgid "Documentation by "
+msgstr "Dokumentasie deur "
+
+#: ../src/generic/aboutdlgg.cpp:75
+msgid "Graphics art by "
+msgstr "Grafiese kuns deur "
+
+#: ../src/generic/aboutdlgg.cpp:78
+msgid "Translations by "
+msgstr "Vertalings deur "
+
+#: ../src/generic/aboutdlgg.cpp:133 ../src/osx/cocoa/aboutdlg.mm:83
+msgid "Version "
+msgstr "Weergawe "
+
+#. TRANSLATORS: %s is application name
+#: ../src/generic/aboutdlgg.cpp:146 ../src/msw/aboutdlg.cpp:60
+#, c-format
+msgid "About %s"
+msgstr "Aangaande %s"
+
+#: ../src/generic/aboutdlgg.cpp:181
+msgid "License"
+msgstr "Lisensie"
+
+#: ../src/generic/aboutdlgg.cpp:184
+msgid "Developers"
+msgstr "Programmeerders"
+
+#: ../src/generic/aboutdlgg.cpp:188
+msgid "Documentation writers"
+msgstr "Dokumentasieskrywers"
+
+#: ../src/generic/aboutdlgg.cpp:192
+msgid "Artists"
+msgstr "Kunstenaars"
+
+#: ../src/generic/aboutdlgg.cpp:196
+msgid "Translators"
+msgstr "Vertalers"
+
+#: ../src/generic/animateg.cpp:125
+#, fuzzy
+msgid "No handler found for animation type."
+msgstr "Geen hanteerder is gevind vir beeldtipe."
+
+#: ../src/generic/animateg.cpp:133
+#, fuzzy, c-format
+msgid "No animation handler for type %ld defined."
+msgstr "Geen beeldhanteerder is vir die tipe %d gedefinieer nie."
+
+#: ../src/generic/animateg.cpp:145
+#, fuzzy, c-format
+msgid "Animation file is not of type %ld."
+msgstr "Beeldlêer is nie van die tipe %d."
+
+#: ../src/generic/colrdlgg.cpp:154 ../src/gtk/colordlg.cpp:47
+#, fuzzy
+msgid "Choose colour"
+msgstr "Kies lettertipe"
+
+#: ../src/generic/colrdlgg.cpp:357
+msgid "Red:"
+msgstr ""
+
+#: ../src/generic/colrdlgg.cpp:360
+#, fuzzy
+msgid "Green:"
+msgstr "MacGreek"
+
+#: ../src/generic/colrdlgg.cpp:363
+msgid "Blue:"
+msgstr ""
+
+#: ../src/generic/colrdlgg.cpp:372
+msgid "Opacity:"
+msgstr ""
+
+#: ../src/generic/colrdlgg.cpp:384
+msgid "Add to custom colours"
+msgstr "Voeg by aangepaste kleure"
+
+#: ../src/generic/creddlgg.cpp:56
+msgid "Username:"
+msgstr ""
+
+#: ../src/generic/creddlgg.cpp:63
+msgid "Password:"
+msgstr ""
+
+#. TRANSLATORS: Name of Boolean true value
+#: ../src/generic/datavgen.cpp:1178
+msgid "true"
+msgstr ""
+
+#. TRANSLATORS: Name of Boolean false value
+#: ../src/generic/datavgen.cpp:1180
+#, fuzzy
+msgid "false"
+msgstr "Vals"
+
+#: ../src/generic/datavgen.cpp:6897
+#, c-format
+msgid "Row %i"
+msgstr ""
+
+#. TRANSLATORS: Action for manipulating a tree control
+#: ../src/generic/datavgen.cpp:6987
+msgid "Collapse"
+msgstr ""
+
+#. TRANSLATORS: Action for manipulating a tree control
+#: ../src/generic/datavgen.cpp:6990
+msgid "Expand"
+msgstr ""
+
+#. TRANSLATORS: Name of data view control and number of rows
+#: ../src/generic/datavgen.cpp:7011
+#, fuzzy, c-format
+msgid "%s (%d items)"
+msgstr "%s (of %s)"
+
+#: ../src/generic/datavgen.cpp:7062
+#, fuzzy, c-format
+msgid "Column %u"
+msgstr "Voeg kolom by"
+
+#. TRANSLATORS: Keystroke for manipulating a tree control
+#: ../src/generic/datavgen.cpp:7131 ../src/richtext/richtextbulletspage.cpp:189
+#: ../src/richtext/richtextbulletspage.cpp:192
+#: ../src/richtext/richtextbulletspage.cpp:193
+#: ../src/richtext/richtextliststylepage.cpp:252
+#: ../src/richtext/richtextliststylepage.cpp:255
+#: ../src/richtext/richtextliststylepage.cpp:256
+#: ../src/richtext/richtextsizepage.cpp:248
+msgid "Left"
+msgstr "Links"
+
+#. TRANSLATORS: Keystroke for manipulating a tree control
+#: ../src/generic/datavgen.cpp:7134 ../src/richtext/richtextbulletspage.cpp:191
+#: ../src/richtext/richtextliststylepage.cpp:254
+#: ../src/richtext/richtextsizepage.cpp:249
+msgid "Right"
+msgstr "Regs"
+
+#: ../src/generic/datectlg.cpp:90
+#, c-format
+msgid ""
+"\"%s\" is not in the expected date format, please enter it as e.g. \"%s\"."
+msgstr ""
+
+#: ../src/generic/datectlg.cpp:94
+#, fuzzy
+msgid "Invalid date"
+msgstr "PCX: ongeldige beeld"
+
+#: ../src/generic/dbgrptg.cpp:159
+#, c-format
+msgid "Open file \"%s\""
+msgstr "Open lêer \"%s\""
+
+#: ../src/generic/dbgrptg.cpp:170
+#, c-format
+msgid "Enter command to open file \"%s\":"
+msgstr "Gee opdrag om die lêer \"%s\" mee te open:"
+
+#: ../src/generic/dbgrptg.cpp:230
+#, fuzzy
+msgid "Executable files (*.exe)|*.exe|"
+msgstr "Alle lêers (*.*)|*.*"
+
+#: ../src/generic/dbgrptg.cpp:300
+#, c-format
+msgid "Debug report \"%s\""
+msgstr ""
+
+#: ../src/generic/dbgrptg.cpp:316
+msgid "A debug report has been generated in the directory\n"
+msgstr ""
+
+#: ../src/generic/dbgrptg.cpp:317
+msgid "The following debug report will be generated\n"
+msgstr ""
+
+#: ../src/generic/dbgrptg.cpp:321
+msgid ""
+"The report contains the files listed below. If any of these files contain "
+"private information,\n"
+"please uncheck them and they will be removed from the report.\n"
+msgstr ""
+
+#: ../src/generic/dbgrptg.cpp:323
+msgid ""
+"If you wish to suppress this debug report completely, please choose the "
+"\"Cancel\" button,\n"
+"but be warned that it may hinder improving the program, so if\n"
+"at all possible please do continue with the report generation.\n"
+msgstr ""
+
+#: ../src/generic/dbgrptg.cpp:325
+msgid "              Thank you and we're sorry for the inconvenience!\n"
+msgstr "              Dankie, en jammer vir die ongerief!\n"
+
+#: ../src/generic/dbgrptg.cpp:333
+msgid "&Debug report preview:"
+msgstr ""
+
+#: ../src/generic/dbgrptg.cpp:339
+msgid "&View..."
+msgstr "&Bekyk..."
+
+#: ../src/generic/dbgrptg.cpp:359
+msgid "&Notes:"
+msgstr "&Notas:"
+
+#: ../src/generic/dbgrptg.cpp:361
+msgid ""
+"If you have any additional information pertaining to this bug\n"
+"report, please enter it here and it will be joined to it:"
+msgstr ""
+
+#: ../src/generic/dcpsg.cpp:1627
+msgid "Cannot open file for PostScript printing!"
+msgstr "Kan nie lêer vir PostScript-drukwerk oopmaak nie!"
+
+#: ../src/generic/dirctrlg.cpp:402
+msgid "Computer"
+msgstr "Rekenaar"
+
+#: ../src/generic/dirctrlg.cpp:404
+msgid "Sections"
+msgstr "Seksies"
+
+#: ../src/generic/dirctrlg.cpp:482
+msgid "Home directory"
+msgstr "Tuisgids"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/generic/dirctrlg.cpp:484 ../src/propgrid/advprops.cpp:811
+msgid "Desktop"
+msgstr "Werkarea"
+
+#: ../src/generic/dirctrlg.cpp:528 ../src/generic/filectrlg.cpp:752
+msgid "Illegal directory name."
+msgstr "Ongeldige gidsnaam."
+
+#: ../src/generic/dirctrlg.cpp:528 ../src/generic/dirctrlg.cpp:546
+#: ../src/generic/dirctrlg.cpp:557 ../src/generic/dirdlgg.cpp:317
+#: ../src/generic/filectrlg.cpp:638 ../src/generic/filectrlg.cpp:752
+#: ../src/generic/filectrlg.cpp:766 ../src/generic/filectrlg.cpp:782
+#: ../src/generic/filectrlg.cpp:1356 ../src/generic/filectrlg.cpp:1387
+#: ../src/generic/filedlgg.cpp:362 ../src/gtk/filedlg.cpp:76
+msgid "Error"
+msgstr "Fout"
+
+#: ../src/generic/dirctrlg.cpp:546 ../src/generic/filectrlg.cpp:766
+msgid "File name exists already."
+msgstr "Lêernaam bestaan al."
+
+#: ../src/generic/dirctrlg.cpp:557 ../src/generic/dirdlgg.cpp:317
+#: ../src/generic/filectrlg.cpp:638 ../src/generic/filectrlg.cpp:782
+msgid "Operation not permitted."
+msgstr "Bewerking nie toelaatbaar."
+
+#: ../src/generic/dirdlgg.cpp:107 ../src/generic/filedlgg.cpp:207
+msgid "Create new directory"
+msgstr "Maak nuwe gids"
+
+#: ../src/generic/dirdlgg.cpp:112 ../src/generic/filedlgg.cpp:203
+msgid "Go to home directory"
+msgstr "Gaan na tuisgids"
+
+#: ../src/generic/dirdlgg.cpp:143
+msgid "Show &hidden directories"
+msgstr "Wys &verborge gidse"
+
+#: ../src/generic/dirdlgg.cpp:196
+#, c-format
+msgid ""
+"The directory '%s' does not exist\n"
+"Create it now?"
+msgstr ""
+"Die gids '%s' bestaan nie\n"
+"Moet dit nou gemaak word?"
+
+#: ../src/generic/dirdlgg.cpp:198
+msgid "Directory does not exist"
+msgstr "Gids bestaan nie"
+
+#: ../src/generic/dirdlgg.cpp:214
+#, c-format
+msgid ""
+"Failed to create directory '%s'\n"
+"(Do you have the required permissions?)"
+msgstr ""
+"Die gids '%s' kon nie geskep word nie\n"
+"(Het jy die nodige magtiging?)"
+
+#: ../src/generic/dirdlgg.cpp:216
+msgid "Error creating directory"
+msgstr "Fout tydens skep van gids"
+
+#: ../src/generic/dirdlgg.cpp:281
+msgid "You cannot add a new directory to this section."
+msgstr "Jy kan nie 'n nuwe gids by hierdie seksie voeg nie."
+
+#: ../src/generic/dirdlgg.cpp:282
+msgid "Create directory"
+msgstr "Maak gids"
+
+#: ../src/generic/dirdlgg.cpp:291 ../src/generic/dirdlgg.cpp:301
+#: ../src/generic/filectrlg.cpp:614 ../src/generic/filectrlg.cpp:623
+msgid "NewName"
+msgstr "Nuwe gids"
+
+#: ../src/generic/editlbox.cpp:135
+msgid "Edit item"
+msgstr "Redigeer item"
+
+#: ../src/generic/editlbox.cpp:143
+msgid "New item"
+msgstr "Nuwe item"
+
+#: ../src/generic/editlbox.cpp:151
+msgid "Delete item"
+msgstr "Skrap item"
+
+#: ../src/generic/editlbox.cpp:159
+msgid "Move up"
+msgstr "Skuif op"
+
+#: ../src/generic/editlbox.cpp:164
+msgid "Move down"
+msgstr "Skuif af"
+
+#: ../src/generic/fdrepdlg.cpp:108
+msgid "Search for:"
+msgstr "Soek na:"
+
+#: ../src/generic/fdrepdlg.cpp:120
+msgid "Replace with:"
+msgstr "Vervang met:"
+
+#: ../src/generic/fdrepdlg.cpp:140
+msgid "Whole word"
+msgstr "Heelwoorde"
+
+#: ../src/generic/fdrepdlg.cpp:143
+msgid "Match case"
+msgstr "Kassensitief"
+
+#: ../src/generic/fdrepdlg.cpp:156
+msgid "Search direction"
+msgstr "Soekrigting"
+
+#: ../src/generic/fdrepdlg.cpp:175
+msgid "&Replace"
+msgstr "Ve&rvang"
+
+#: ../src/generic/fdrepdlg.cpp:178
+msgid "Replace &all"
+msgstr "Vervang &almal"
+
+#: ../src/generic/filectrlg.cpp:246 ../src/generic/filectrlg.cpp:269
+msgid "<DIR>"
+msgstr "<GIDS>"
+
+#: ../src/generic/filectrlg.cpp:248 ../src/generic/filectrlg.cpp:271
+msgid "<LINK>"
+msgstr "<SKAKEL>"
+
+#: ../src/generic/filectrlg.cpp:250 ../src/generic/filectrlg.cpp:273
+msgid "<DRIVE>"
+msgstr "<AANDRYWER>"
+
+#: ../src/generic/filectrlg.cpp:275
+#, c-format
+msgid "%ld byte"
+msgid_plural "%ld bytes"
+msgstr[0] "%ld greep"
+msgstr[1] "%ld grepe"
+
+#: ../src/generic/filectrlg.cpp:420
+msgid "Name"
+msgstr "Naam"
+
+#: ../src/generic/filectrlg.cpp:421 ../src/richtext/richtextformatdlg.cpp:361
+#: ../src/richtext/richtextsizepage.cpp:298
+msgid "Size"
+msgstr "Grootte"
+
+#: ../src/generic/filectrlg.cpp:422
+msgid "Type"
+msgstr "Tipe"
+
+#: ../src/generic/filectrlg.cpp:423
+msgid "Modified"
+msgstr "Verander"
+
+#: ../src/generic/filectrlg.cpp:426
+msgid "Permissions"
+msgstr "Magtigings"
+
+#: ../src/generic/filectrlg.cpp:429
+msgid "Attributes"
+msgstr "Eienskappe"
+
+#: ../src/generic/filectrlg.cpp:936
+msgid "Current directory:"
+msgstr "Huidige gids:"
+
+#: ../src/generic/filectrlg.cpp:979
+msgid "Show &hidden files"
+msgstr "Wys &verborge lêers"
+
+#: ../src/generic/filectrlg.cpp:1355
+msgid "Illegal file specification."
+msgstr "Ongeldige lêerspesifikasie."
+
+#: ../src/generic/filectrlg.cpp:1387
+msgid "Directory doesn't exist."
+msgstr "Gids bestaan nie."
+
+#: ../src/generic/filedlgg.cpp:195
+msgid "View files as a list view"
+msgstr "Wys lêers in lys-aansig"
+
+#: ../src/generic/filedlgg.cpp:197
+msgid "View files as a detailed view"
+msgstr "Wys lêers in detail-aansig"
+
+#: ../src/generic/filedlgg.cpp:200
+msgid "Go to parent directory"
+msgstr "Gaan na moedergids"
+
+#: ../src/generic/filedlgg.cpp:351 ../src/gtk/filedlg.cpp:59
+#, c-format
+msgid "File '%s' already exists, do you really want to overwrite it?"
+msgstr "Lêer '%s' bestaan al. Moet dit oorskryf word?"
+
+#: ../src/generic/filedlgg.cpp:354 ../src/gtk/filedlg.cpp:62
+msgid "Confirm"
+msgstr "Bevestig"
+
+#: ../src/generic/filedlgg.cpp:362 ../src/gtk/filedlg.cpp:75
+msgid "Please choose an existing file."
+msgstr "Kies asb. 'n bestaande lêer."
+
+#: ../src/generic/filepickerg.cpp:64
+msgid "..."
+msgstr "..."
+
+#: ../src/generic/fontdlgg.cpp:76 ../src/richtext/richtextformatdlg.cpp:519
+msgid "ABCDEFGabcdefg12345"
+msgstr "ABCDEÊÉFGabcdeêéfg12345"
+
+#: ../src/generic/fontdlgg.cpp:315
+msgid "Roman"
+msgstr "Roman"
+
+#: ../src/generic/fontdlgg.cpp:316
+msgid "Decorative"
+msgstr "Dekoratief"
+
+#: ../src/generic/fontdlgg.cpp:317
+msgid "Modern"
+msgstr "Modern"
+
+#: ../src/generic/fontdlgg.cpp:318
+msgid "Script"
+msgstr "Skrif-letter"
+
+#: ../src/generic/fontdlgg.cpp:319
+msgid "Swiss"
+msgstr "Switsers"
+
+#: ../src/generic/fontdlgg.cpp:320
+msgid "Teletype"
+msgstr "Nie-proporsioneel (Teletype)"
+
+#: ../src/generic/fontdlgg.cpp:321 ../src/generic/fontdlgg.cpp:324
+msgid "Normal"
+msgstr "Normaal"
+
+#: ../src/generic/fontdlgg.cpp:323
+msgid "Slant"
+msgstr "Skuins"
+
+#: ../src/generic/fontdlgg.cpp:325
+msgid "Light"
+msgstr "Lig"
+
+#: ../src/generic/fontdlgg.cpp:363
+msgid "&Font family:"
+msgstr "&Lettertipe-familie"
+
+#: ../src/generic/fontdlgg.cpp:367 ../src/generic/fontdlgg.cpp:369
+msgid "The font family."
+msgstr "Die lettertipe se familie."
+
+#: ../src/generic/fontdlgg.cpp:374 ../src/richtext/richtextstylepage.cpp:105
+msgid "&Style:"
+msgstr ""
+
+#: ../src/generic/fontdlgg.cpp:378 ../src/generic/fontdlgg.cpp:380
+msgid "The font style."
+msgstr "Die lettertipestyl."
+
+#: ../src/generic/fontdlgg.cpp:385
+msgid "&Weight:"
+msgstr "Ge&wig:"
+
+#: ../src/generic/fontdlgg.cpp:389 ../src/generic/fontdlgg.cpp:391
+msgid "The font weight."
+msgstr "Die lettertipegewig."
+
+#: ../src/generic/fontdlgg.cpp:399
+msgid "C&olour:"
+msgstr ""
+
+#: ../src/generic/fontdlgg.cpp:407 ../src/generic/fontdlgg.cpp:409
+msgid "The font colour."
+msgstr "Die tekskleur."
+
+#: ../src/generic/fontdlgg.cpp:415
+msgid "&Point size:"
+msgstr "&Puntgrootte:"
+
+#: ../src/generic/fontdlgg.cpp:420 ../src/generic/fontdlgg.cpp:422
+#: ../src/generic/fontdlgg.cpp:426 ../src/generic/fontdlgg.cpp:428
+msgid "The font point size."
+msgstr "Die puntgrootte van die lettertipe."
+
+#: ../src/generic/fontdlgg.cpp:439 ../src/generic/fontdlgg.cpp:441
+msgid "Whether the font is underlined."
+msgstr "Of die lettertipe onderstreep word."
+
+#: ../src/generic/fontdlgg.cpp:448 ../src/html/helpwnd.cpp:1215
+msgid "Preview:"
+msgstr "Drukvoorskou:"
+
+#: ../src/generic/fontdlgg.cpp:452 ../src/generic/fontdlgg.cpp:454
+msgid "Shows the font preview."
+msgstr "Wys die lettertipevoorskou."
+
+#: ../src/generic/fontdlgg.cpp:464 ../src/generic/fontdlgg.cpp:483
+msgid "Click to cancel the font selection."
+msgstr "Klik om dei lettertipekeuse te kanselleer."
+
+#: ../src/generic/fontdlgg.cpp:469 ../src/generic/fontdlgg.cpp:471
+#: ../src/generic/fontdlgg.cpp:476 ../src/generic/fontdlgg.cpp:478
+msgid "Click to confirm the font selection."
+msgstr "Klik om dei lettertipekeuse te bevestig."
+
+#: ../src/generic/fontpickerg.cpp:50 ../src/gtk/fontdlg.cpp:77
+msgid "Choose font"
+msgstr "Kies lettertipe"
+
+#: ../src/generic/grid.cpp:6542
+msgid ""
+"Error copying grid to the clipboard. Either selected cells were not "
+"contiguous or no cell was selected."
+msgstr ""
+
+#: ../src/generic/grid.cpp:12739
+msgid "Grid Corner"
+msgstr ""
+
+#: ../src/generic/grid.cpp:12741
+#, fuzzy, c-format
+msgid "Column %s Header"
+msgstr "Voeg kolom by"
+
+#: ../src/generic/grid.cpp:12743
+#, c-format
+msgid "Row %s Header"
+msgstr ""
+
+#: ../src/generic/grid.cpp:12745
+#, fuzzy, c-format
+msgid "Column %s: %s"
+msgstr "Voeg kolom by"
+
+#: ../src/generic/grid.cpp:12749
+#, c-format
+msgid "Row %s: %s"
+msgstr ""
+
+#: ../src/generic/grid.cpp:12753
+#, c-format
+msgid "Row %s, Column %s: %s"
+msgstr ""
+
+#: ../src/generic/helpext.cpp:257
+#, c-format
+msgid "Help directory \"%s\" not found."
+msgstr ""
+
+#: ../src/generic/helpext.cpp:265
+#, c-format
+msgid "Help file \"%s\" not found."
+msgstr "Hulplêer \"%s\" nie gevind nie."
+
+#: ../src/generic/helpext.cpp:284
+#, c-format
+msgid "Line %lu of map file \"%s\" has invalid syntax, skipped."
+msgstr ""
+
+#: ../src/generic/helpext.cpp:292
+#, c-format
+msgid "No valid mappings found in the file \"%s\"."
+msgstr ""
+
+#: ../src/generic/helpext.cpp:435
+msgid "No entries found."
+msgstr "Geen inskrywings gevind."
+
+#: ../src/generic/helpext.cpp:444 ../src/generic/helpext.cpp:445
+msgid "Help Index"
+msgstr "Hulpindeks"
+
+#: ../src/generic/helpext.cpp:448
+msgid "Relevant entries:"
+msgstr "Relevante inskrywings:"
+
+#: ../src/generic/helpext.cpp:449
+msgid "Entries found"
+msgstr "Inskrywings gevind"
+
+#: ../src/generic/hyperlinkg.cpp:170
+msgid "&Copy URL"
+msgstr "&Kopieer URL"
+
+#: ../src/generic/infobar.cpp:119
+msgid "Hide this notification message."
+msgstr "Versteek dié kennisgewing."
+
+#. TRANSLATORS: %s will be either the application name or "Application"
+#: ../src/generic/logg.cpp:257
+#, c-format
+msgid "%s Error"
+msgstr "%s-fout"
+
+#. TRANSLATORS: %s will be either the application name or "Application"
+#: ../src/generic/logg.cpp:263
+#, c-format
+msgid "%s Warning"
+msgstr "%s-waarskuwing"
+
+#. TRANSLATORS: %s will be either the application name or "Application"
+#: ../src/generic/logg.cpp:273
+#, c-format
+msgid "%s Information"
+msgstr "%s-inligting"
+
+#: ../src/generic/logg.cpp:276
+msgid "Application"
+msgstr "Toepassing"
+
+#: ../src/generic/logg.cpp:549
+msgid "Save log contents to file"
+msgstr "Stoor boekstawing-inhoud na lêer"
+
+#: ../src/generic/logg.cpp:551
+msgid "C&lear"
+msgstr "&Vee uit"
+
+#: ../src/generic/logg.cpp:551
+msgid "Clear the log contents"
+msgstr "Maak boekstawing skoon"
+
+#: ../src/generic/logg.cpp:553
+msgid "Close this window"
+msgstr "Maak hierdie venster toe"
+
+#: ../src/generic/logg.cpp:554
+msgid "&Log"
+msgstr "&Boekstawing"
+
+#: ../src/generic/logg.cpp:610 ../src/generic/logg.cpp:992
+msgid "Can't save log contents to file."
+msgstr "Boekstawing kan nie in lêer gestoor word nie."
+
+#: ../src/generic/logg.cpp:613
+#, c-format
+msgid "Log saved to the file '%s'."
+msgstr "Boekstawing geskryf na lêer '%s'."
+
+#: ../src/generic/logg.cpp:719
+msgid "&Details"
+msgstr "&Besonderhede"
+
+#: ../src/generic/logg.cpp:972
+#, fuzzy
+msgid "Failed to copy dialog contents to the clipboard."
+msgstr "Kopieer van dialooginhoud na knipbord het misluk."
+
+#: ../src/generic/logg.cpp:1022
+#, c-format
+msgid "Append log to file '%s' (choosing [No] will overwrite it)?"
+msgstr "Voeg log by lêer '%s' (kies [Nee] om te oorskryf)?"
+
+#: ../src/generic/logg.cpp:1024
+msgid "Question"
+msgstr "Vraag"
+
+#: ../src/generic/logg.cpp:1038
+msgid "invalid message box return value"
+msgstr "ongeldige teruggee-waarde van boodskapvenster"
+
+#: ../src/generic/notifmsgg.cpp:129
+msgid "Notice"
+msgstr "Kennisgewing"
+
+#: ../src/generic/preferencesg.cpp:118
+#, c-format
+msgid "%s Preferences"
+msgstr "%s-voorkeure"
+
+#: ../src/generic/printps.cpp:143
+msgid "Printing..."
+msgstr "Druk tans..."
+
+#: ../src/generic/printps.cpp:160 ../src/gtk/print.cpp:1076
+#: ../src/msw/printwin.cpp:235
+msgid "Could not start printing."
+msgstr "Kon nie begin met drukwerk nie."
+
+#: ../src/generic/printps.cpp:183
+#, c-format
+msgid "Printing page %d..."
+msgstr "Druk tans bladsy %d..."
+
+#: ../src/generic/prntdlgg.cpp:171
+msgid "Printer options"
+msgstr "Drukker-opsies"
+
+#: ../src/generic/prntdlgg.cpp:176
+msgid "Print to File"
+msgstr "Druk na 'n lêer"
+
+#: ../src/generic/prntdlgg.cpp:179
+msgid "Setup..."
+msgstr "Opstelling..."
+
+#: ../src/generic/prntdlgg.cpp:187
+msgid "Printer:"
+msgstr "Drukker:"
+
+#: ../src/generic/prntdlgg.cpp:195
+msgid "Status:"
+msgstr "Status:"
+
+#: ../src/generic/prntdlgg.cpp:206
+msgid "All"
+msgstr "Almal"
+
+#: ../src/generic/prntdlgg.cpp:207
+msgid "Pages"
+msgstr "Bladsye"
+
+#: ../src/generic/prntdlgg.cpp:215
+msgid "Print Range"
+msgstr "Drukomvang"
+
+#: ../src/generic/prntdlgg.cpp:229
+msgid "From:"
+msgstr "Van:"
+
+#: ../src/generic/prntdlgg.cpp:233
+msgid "To:"
+msgstr "Aan:"
+
+#: ../src/generic/prntdlgg.cpp:238
+msgid "Copies:"
+msgstr "Kopieë:"
+
+#: ../src/generic/prntdlgg.cpp:288
+msgid "PostScript file"
+msgstr "PostScript-lêer"
+
+#: ../src/generic/prntdlgg.cpp:439
+msgid "Print Setup"
+msgstr "Drukopstelling"
+
+#: ../src/generic/prntdlgg.cpp:483
+msgid "Printer"
+msgstr "Drukker"
+
+#: ../src/generic/prntdlgg.cpp:501
+msgid "Default printer"
+msgstr "Verstekdrukker"
+
+#: ../src/generic/prntdlgg.cpp:595 ../src/generic/prntdlgg.cpp:782
+#: ../src/generic/prntdlgg.cpp:822 ../src/generic/prntdlgg.cpp:835
+#: ../src/generic/prntdlgg.cpp:1031 ../src/generic/prntdlgg.cpp:1036
+msgid "Paper size"
+msgstr "Papiergrootte"
+
+#: ../src/generic/prntdlgg.cpp:604 ../src/generic/prntdlgg.cpp:847
+msgid "Portrait"
+msgstr "Regop"
+
+#: ../src/generic/prntdlgg.cpp:605 ../src/generic/prntdlgg.cpp:848
+msgid "Landscape"
+msgstr "Dwars"
+
+#: ../src/generic/prntdlgg.cpp:607 ../src/generic/prntdlgg.cpp:849
+msgid "Orientation"
+msgstr "Oriëntasie"
+
+#: ../src/generic/prntdlgg.cpp:610
+msgid "Options"
+msgstr "Opstellings"
+
+#: ../src/generic/prntdlgg.cpp:612
+msgid "Print in colour"
+msgstr "Druk in kleur"
+
+#: ../src/generic/prntdlgg.cpp:621
+msgid "Print spooling"
+msgstr "Drukwerkskedulering"
+
+#: ../src/generic/prntdlgg.cpp:623
+msgid "Printer command:"
+msgstr "Drukkerbevel:"
+
+#: ../src/generic/prntdlgg.cpp:631
+msgid "Printer options:"
+msgstr "Drukkeropsies:"
+
+#: ../src/generic/prntdlgg.cpp:860
+msgid "Left margin (mm):"
+msgstr "Linkerkantlyn (mm):"
+
+#: ../src/generic/prntdlgg.cpp:861
+msgid "Top margin (mm):"
+msgstr "Boonste kantlyn (mm):"
+
+#: ../src/generic/prntdlgg.cpp:872
+msgid "Right margin (mm):"
+msgstr "Regterkantlyn (mm):"
+
+#: ../src/generic/prntdlgg.cpp:873
+msgid "Bottom margin (mm):"
+msgstr "Onderste kantlyn (mm):"
+
+#: ../src/generic/prntdlgg.cpp:896
+msgid "Printer..."
+msgstr "Drukker..."
+
+#: ../src/generic/progdlgg.cpp:246
+msgid "&Skip"
+msgstr "&Slaan oor"
+
+#: ../src/generic/progdlgg.cpp:347 ../src/generic/progdlgg.cpp:626
+msgid "Unknown"
+msgstr "Onbekend"
+
+#: ../src/generic/progdlgg.cpp:451 ../src/msw/progdlg.cpp:526
+msgid "Done."
+msgstr "Klaar."
+
+#: ../src/generic/srchctlg.cpp:55 ../src/gtk/srchctrl.cpp:206
+#: ../src/html/helpwnd.cpp:530 ../src/html/helpwnd.cpp:545
+msgid "Search"
+msgstr "Soek"
+
+#: ../src/generic/tabg.cpp:1026
+msgid "Could not find tab for id"
+msgstr "Kon nie die etiket vir die id vind nie"
+
+#: ../src/generic/tipdlg.cpp:136
+msgid "Tips not available, sorry!"
+msgstr "Wenke is nie beskikbaar nie, jammer!"
+
+#: ../src/generic/tipdlg.cpp:197
+msgid "Tip of the Day"
+msgstr "Wenk van die dag"
+
+#: ../src/generic/tipdlg.cpp:207
+msgid "Did you know..."
+msgstr "Het u geweet..."
+
+#: ../src/generic/tipdlg.cpp:232
+msgid "&Show tips at startup"
+msgstr "&Wys wenke as program begin"
+
+#: ../src/generic/tipdlg.cpp:236
+msgid "&Next Tip"
+msgstr "&Volgende wenk"
+
+#: ../src/generic/wizard.cpp:411
+msgid "&Next >"
+msgstr "&Volgende >"
+
+#: ../src/generic/wizard.cpp:412
+msgid "&Finish"
+msgstr "&Voltooi"
+
+#: ../src/generic/wizard.cpp:420
+msgid "< &Back"
+msgstr "< &Terug"
+
+#: ../src/gtk/aboutdlg.cpp:204
+msgid "translator-credits"
+msgstr ""
+"Petri Jooste\n"
+"Friedel Wolff"
+
+#: ../src/gtk/app.cpp:517
+msgid ""
+"WARNING: using XIM input method is unsupported and may result in problems "
+"with input handling and flickering. Consider unsetting GTK_IM_MODULE or "
+"setting to \"ibus\"."
+msgstr ""
+
+#: ../src/gtk/app.cpp:569
+msgid "Unable to initialize GTK+, is DISPLAY set properly?"
+msgstr "Kan nie GTK+ inisialiseer nie. Is DISPLAY reg ingestel?"
+
+#: ../src/gtk/filedlg.cpp:89 ../src/gtk/filepicker.cpp:255
+#, fuzzy, c-format
+msgid "Changing current directory to \"%s\" failed"
+msgstr "Gids \"%s\" kon nie geskep word nie"
+
+#: ../src/gtk/font.cpp:548
+msgid ""
+"Using private fonts is not supported on this system: Pango library is too "
+"old, 1.38 or later required."
+msgstr ""
+
+#: ../src/gtk/font.cpp:558
+#, fuzzy
+msgid "Failed to create font configuration object."
+msgstr "kan gebruikers-konfigurasielêer nie oopmaak nie."
+
+#: ../src/gtk/font.cpp:568
+#, fuzzy, c-format
+msgid "Failed to add custom font \"%s\"."
+msgstr "Lees van dokument vanuit lêer \"%s\" het misluk."
+
+#: ../src/gtk/font.cpp:576
+#, fuzzy
+msgid "Failed to register font configuration using private fonts."
+msgstr "kan gebruikers-konfigurasielêer nie oopmaak nie."
+
+#: ../src/gtk/glcanvas.cpp:117 ../src/gtk/glcanvas.cpp:132
+#, fuzzy
+msgid "Fatal Error"
+msgstr "Fatale fout"
+
+#: ../src/gtk/glcanvas.cpp:117
+msgid ""
+"This program wasn't compiled with EGL support required under Wayland, "
+"either\n"
+"install EGL libraries and rebuild or run it under X11 backend by setting\n"
+"environment variable GDK_BACKEND=x11 before starting your program."
+msgstr ""
+
+#: ../src/gtk/glcanvas.cpp:132
+msgid ""
+"wxGLCanvas is only supported on Wayland and X11 currently.  You may be able "
+"to\n"
+"work around this by setting environment variable GDK_BACKEND=x11 before\n"
+"starting your program."
+msgstr ""
+
+#: ../src/gtk/mdi.cpp:433
+msgid "MDI child"
+msgstr "MDI-subvenster"
+
+#: ../src/gtk/power.cpp:188
+#, fuzzy, c-format
+msgid "Failed to open D-Bus connection to the login manager: %s"
+msgstr "%s van inbelverbinding het misluk: %s"
+
+#: ../src/gtk/power.cpp:214
+#, fuzzy
+msgid "wxWidgets application"
+msgstr "Toepassing"
+
+#: ../src/gtk/power.cpp:226
+msgid "Application needs to keep running"
+msgstr ""
+
+#: ../src/gtk/power.cpp:233
+msgid "Clean up before suspend"
+msgstr ""
+
+#: ../src/gtk/power.cpp:259
+#, fuzzy, c-format
+msgid "Failed to inhibit sleep: %s"
+msgstr "Verbreking van inbelverbinding het misluk: %s"
+
+#: ../src/gtk/power.cpp:265
+msgid "Unexpected response to D-Bus \"Inhibit\" request."
+msgstr ""
+
+#: ../src/gtk/print.cpp:218
+msgid "Custom size"
+msgstr "Pasgemaakte grootte"
+
+#: ../src/gtk/print.cpp:752
+#, fuzzy, c-format
+msgid "Error while printing: %s"
+msgstr "Fout tydens drukwerk: "
+
+#: ../src/gtk/print.cpp:816
+msgid "Page Setup"
+msgstr "Bladsy-opstelling"
+
+#: ../src/gtk/webview_webkit.cpp:932
+msgid "Retrieving JavaScript script output is not supported with WebKit v1"
+msgstr ""
+
+#: ../src/gtk/webview_webkit2.cpp:1098
+msgid ""
+"Setting proxy is not supported by WebKit, at least version 2.16 is required."
+msgstr ""
+
+#: ../src/gtk/webview_webkit2.cpp:1104
+msgid "This program was compiled without support for setting WebKit proxy."
+msgstr ""
+
+#: ../src/gtk/window.cpp:6289
+msgid ""
+"GTK+ installed on this machine is too old to support screen compositing, "
+"please install GTK+ 2.12 or later."
+msgstr ""
+"Die weergawe van GTK+ wat op dié rekenaar geïnstalleer is, is te oud om "
+"skermsaamstelling te ondersteun. Installeer asb. GTK+ 2.12 of later."
+
+#: ../src/gtk/window.cpp:6307
+msgid ""
+"Compositing not supported by this system, please enable it in your Window "
+"Manager."
+msgstr ""
+
+#: ../src/gtk/window.cpp:6318
+msgid ""
+"This program was compiled with a too old version of GTK+, please rebuild "
+"with GTK+ 2.12 or newer."
+msgstr ""
+
+#: ../src/html/chm.cpp:138
+#, c-format
+msgid "Failed to open CHM archive '%s'."
+msgstr "CHM-argief '%s' kon nie oopgemaak word nie."
+
+#: ../src/html/chm.cpp:270
+#, c-format
+msgid "Could not extract %s into %s: %s"
+msgstr "Kon nie %s binne-in %s uitpak nie: %s"
+
+#: ../src/html/chm.cpp:324
+msgid "no error"
+msgstr "geen fout"
+
+#: ../src/html/chm.cpp:326
+msgid "bad arguments to library function"
+msgstr "verkeerde argumente vir biblioteekfunksie"
+
+#: ../src/html/chm.cpp:328
+msgid "error opening file"
+msgstr "fout tydens oopmaak van lêer"
+
+#: ../src/html/chm.cpp:330
+msgid "read error"
+msgstr "leesfout"
+
+#: ../src/html/chm.cpp:332
+msgid "write error"
+msgstr "skryffout"
+
+#: ../src/html/chm.cpp:334
+msgid "seek error"
+msgstr "soekfout"
+
+#: ../src/html/chm.cpp:338
+msgid "bad signature"
+msgstr "slegte handtekening"
+
+#: ../src/html/chm.cpp:340
+msgid "error in data format"
+msgstr "fout in dataformaat"
+
+#: ../src/html/chm.cpp:342
+msgid "checksum error"
+msgstr "toetssomfout"
+
+#: ../src/html/chm.cpp:344
+msgid "compression error"
+msgstr "inpakfout"
+
+#: ../src/html/chm.cpp:346
+msgid "decompression error"
+msgstr "uitpakfout"
+
+#: ../src/html/chm.cpp:437
+#, c-format
+msgid "Could not locate file '%s'."
+msgstr "Kon nie lêer '%s' opspoor nie."
+
+#: ../src/html/chm.cpp:711
+#, c-format
+msgid "Could not create temporary file '%s'"
+msgstr "Kon nie tydelike lêer '%s' skep nie"
+
+#: ../src/html/chm.cpp:718
+#, c-format
+msgid "Extraction of '%s' into '%s' failed."
+msgstr "Uitpak van '%s' binne-in '%s' het misluk."
+
+#: ../src/html/chm.cpp:806 ../src/html/chm.cpp:863
+msgid "CHM handler currently supports only local files!"
+msgstr "CHM-hanteerder ondersteun tans slegs plaaslike lêers!"
+
+#: ../src/html/chm.cpp:827
+msgid "Link contained '//', converted to absolute link."
+msgstr "Skakel het '//' bevat; dit is omskep in 'n absolute skakel."
+
+#: ../src/html/helpctrl.cpp:59
+#, c-format
+msgid "Help: %s"
+msgstr "Hulp: %s"
+
+#: ../src/html/helpctrl.cpp:155
+#, c-format
+msgid "Adding book %s"
+msgstr "Besig om boek %s by te voeg"
+
+#: ../src/html/helpdata.cpp:295
+#, c-format
+msgid "Cannot open contents file: %s"
+msgstr "Kan inhoudsopgawe-lêer nie oopmaak nie: %s"
+
+#: ../src/html/helpdata.cpp:309
+#, c-format
+msgid "Cannot open index file: %s"
+msgstr "Kan indekslêer nie oopmaak nie: %s"
+
+#: ../src/html/helpdata.cpp:643
+msgid "noname"
+msgstr "naamloos"
+
+#: ../src/html/helpdata.cpp:652
+#, c-format
+msgid "Cannot open HTML help book: %s"
+msgstr "Kan nie HTML-hulplêer oopmaak nie: %s"
+
+#: ../src/html/helpwnd.cpp:315
+msgid "Displays help as you browse the books on the left."
+msgstr ""
+
+#: ../src/html/helpwnd.cpp:411 ../src/html/helpwnd.cpp:1100
+#: ../src/html/helpwnd.cpp:1735
+msgid "(bookmarks)"
+msgstr "(gunstelinge)"
+
+#: ../src/html/helpwnd.cpp:424
+msgid "Add current page to bookmarks"
+msgstr "Voeg huidige bladsy by gunstelinge"
+
+#: ../src/html/helpwnd.cpp:425
+msgid "Remove current page from bookmarks"
+msgstr "Verwyder huidige bladsy uit gunstelinge"
+
+#: ../src/html/helpwnd.cpp:470
+msgid "Contents"
+msgstr "Inhoud"
+
+#: ../src/html/helpwnd.cpp:485
+msgid "Find"
+msgstr "Soek"
+
+#: ../src/html/helpwnd.cpp:487
+msgid "Show all"
+msgstr "Wys alles"
+
+#: ../src/html/helpwnd.cpp:497
+msgid ""
+"Display all index items that contain given substring. Search is case "
+"insensitive."
+msgstr ""
+"Wys alle indeks-items wat die gegewe substring bevat. (Nie kassensitief nie.)"
+
+#: ../src/html/helpwnd.cpp:498
+msgid "Show all items in index"
+msgstr "Wys alle items in die indeks"
+
+#: ../src/html/helpwnd.cpp:528
+msgid "Case sensitive"
+msgstr "Kassensitief"
+
+#: ../src/html/helpwnd.cpp:529
+msgid "Whole words only"
+msgstr "Slegs heelwoorde"
+
+#: ../src/html/helpwnd.cpp:532
+msgid ""
+"Search contents of help book(s) for all occurrences of the text you typed "
+"above"
+msgstr ""
+"Soek in inhoudsopgawe van hulplêer(s) vir alle voorkomste van die teks wat "
+"bó getik is"
+
+#: ../src/html/helpwnd.cpp:653
+msgid "Show/hide navigation panel"
+msgstr "Wys/verberg navigasiepaneel"
+
+#: ../src/html/helpwnd.cpp:655
+msgid "Go back"
+msgstr "Gaan terug"
+
+#: ../src/html/helpwnd.cpp:656
+msgid "Go forward"
+msgstr "Gaan vorentoe"
+
+#: ../src/html/helpwnd.cpp:658
+msgid "Go one level up in document hierarchy"
+msgstr "Gaan een vlak hoër in dokument-hiërargie"
+
+#: ../src/html/helpwnd.cpp:666 ../src/html/helpwnd.cpp:1547
+msgid "Open HTML document"
+msgstr "Maak HTML-dokument oop"
+
+#: ../src/html/helpwnd.cpp:670
+msgid "Print this page"
+msgstr "Druk hierdie bladsy"
+
+#: ../src/html/helpwnd.cpp:674
+msgid "Display options dialog"
+msgstr "Wys opsies-dialoog"
+
+#: ../src/html/helpwnd.cpp:795
+msgid "Please choose the page to display:"
+msgstr "Kies die bladsy om te vertoon:"
+
+#: ../src/html/helpwnd.cpp:796
+msgid "Help Topics"
+msgstr "Hulponderwerpe"
+
+#: ../src/html/helpwnd.cpp:852
+msgid "Searching..."
+msgstr "Soek tans..."
+
+#: ../src/html/helpwnd.cpp:853
+msgid "No matching page found yet"
+msgstr "Nog geen ooreenstemmende bladsy is gevind nie"
+
+#: ../src/html/helpwnd.cpp:870
+#, c-format
+msgid "Found %i matches"
+msgstr "%i ooreenkomste gevind"
+
+#: ../src/html/helpwnd.cpp:958
+msgid "(Help)"
+msgstr "(Help)"
+
+#: ../src/html/helpwnd.cpp:1026
+#, c-format
+msgid "%d of %lu"
+msgstr "%d van %lu"
+
+#: ../src/html/helpwnd.cpp:1028
+#, c-format
+msgid "%lu of %lu"
+msgstr "%lu van %lu"
+
+#: ../src/html/helpwnd.cpp:1047
+msgid "Search in all books"
+msgstr "Soek in alle boeke"
+
+#: ../src/html/helpwnd.cpp:1193
+msgid "Help Browser Options"
+msgstr "Hulpblaaier-opsies"
+
+#: ../src/html/helpwnd.cpp:1198
+msgid "Normal font:"
+msgstr "Normale lettertipe:"
+
+#: ../src/html/helpwnd.cpp:1199
+msgid "Fixed font:"
+msgstr "Nie-proporsionele lettertipe:"
+
+#: ../src/html/helpwnd.cpp:1200
+msgid "Font size:"
+msgstr "Lettergrootte:"
+
+#: ../src/html/helpwnd.cpp:1245
+msgid "font size"
+msgstr "lettergrootte"
+
+#: ../src/html/helpwnd.cpp:1256
+msgid "Normal face<br>and <u>underlined</u>. "
+msgstr "Normaal en<br><u>onderstreep</u>. "
+
+#: ../src/html/helpwnd.cpp:1257
+msgid "<i>Italic face.</i> "
+msgstr "<i>Kursief.</i> "
+
+#: ../src/html/helpwnd.cpp:1258
+msgid "<b>Bold face.</b> "
+msgstr "<b>Vetdruk.</b> "
+
+#: ../src/html/helpwnd.cpp:1259
+msgid "<b><i>Bold italic face.</i></b><br>"
+msgstr "<b><i>Vet en kursief.</i></b><br>"
+
+#: ../src/html/helpwnd.cpp:1262
+msgid "Fixed size face.<br> <b>bold</b> <i>italic</i> "
+msgstr "Vaste lettergrootte.<br> <b>vetdruk</b> <i>kursief</i> "
+
+#: ../src/html/helpwnd.cpp:1263
+msgid "<b><i>bold italic <u>underlined</u></i></b><br>"
+msgstr "<b><i>vet kursief <u>onderstreep</u></i></b><br>"
+
+#: ../src/html/helpwnd.cpp:1524
+msgid "Help Printing"
+msgstr "Hulpdrukwerk"
+
+#: ../src/html/helpwnd.cpp:1527
+msgid "Cannot print empty page."
+msgstr "Kan nie leë bladsy druk nie."
+
+#: ../src/html/helpwnd.cpp:1540
+msgid "HTML files (*.html;*.htm)|*.html;*.htm|"
+msgstr "HTML-lêers (*.html;*.htm)|*.html;*.htm|"
+
+#: ../src/html/helpwnd.cpp:1541
+msgid "Help books (*.htb)|*.htb|Help books (*.zip)|*.zip|"
+msgstr "Hulpboeke (*.htb)|*.htb|Hulpboeke (*.zip)|*.zip|"
+
+#: ../src/html/helpwnd.cpp:1542
+msgid "HTML Help Project (*.hhp)|*.hhp|"
+msgstr "HTML-hulpprojek (*.hhp)|*.hhp|"
+
+#: ../src/html/helpwnd.cpp:1544
+msgid "Compressed HTML Help file (*.chm)|*.chm|"
+msgstr "Saamgeperste HTML-hulplêer (*.chm)|*.chm|"
+
+#: ../src/html/helpwnd.cpp:1671
+#, fuzzy, c-format
+msgid "%i of %u"
+msgstr "%i van %i"
+
+#: ../src/html/helpwnd.cpp:1709
+#, fuzzy, c-format
+msgid "%u of %u"
+msgstr "%lu van %lu"
+
+#: ../src/html/htmlfilt.cpp:134
+#, c-format
+msgid "Cannot open HTML document: %s"
+msgstr "Kan HTML-dokument '%s' nie oopmaak nie"
+
+#: ../src/html/htmlwin.cpp:599
+msgid "Connecting..."
+msgstr "Koppel tans..."
+
+#: ../src/html/htmlwin.cpp:616
+#, c-format
+msgid "Unable to open requested HTML document: %s"
+msgstr "Kan gevraagde HTML-dokument nie oopmaak nie: %s"
+
+#: ../src/html/htmlwin.cpp:630
+msgid "Loading : "
+msgstr "Laai tans: "
+
+#: ../src/html/htmlwin.cpp:673
+msgid "Done"
+msgstr "Klaar"
+
+#: ../src/html/htmlwin.cpp:723
+#, c-format
+msgid "HTML anchor %s does not exist."
+msgstr "HTML-anker %s bestaan nie."
+
+#: ../src/html/htmlwin.cpp:1057
+#, c-format
+msgid "Copied to clipboard:\"%s\""
+msgstr "Gekopieer na knipbord:\"%s\""
+
+#: ../src/html/htmprint.cpp:269
+msgid ""
+"This document doesn't fit on the page horizontally and will be truncated "
+"when it is printed."
+msgstr ""
+"Hierdie dokument pas nie horisontaal op die bladsy nie en sal afgekap word "
+"as dit gedruk word."
+
+#: ../src/html/htmprint.cpp:285
+#, c-format
+msgid ""
+"The document \"%s\" doesn't fit on the page horizontally and will be "
+"truncated if printed.\n"
+"\n"
+"Would you like to proceed with printing it nevertheless?"
+msgstr ""
+"Die dokument \"%s\" pas nie horisontaal op die bladsy nie en sal afgekap "
+"word as dit gedruk word.\n"
+"\n"
+"Wil u nogtans voortgaan om te druk?"
+
+#: ../src/html/htmprint.cpp:296
+msgid ""
+"If possible, try changing the layout parameters to make the printout more "
+"narrow."
+msgstr ""
+"Indien moontlik, probeer om die uitlegparameters te verander om die drukstuk "
+"maerder te maak."
+
+#: ../src/html/htmprint.cpp:445
+msgid ": file does not exist!"
+msgstr ": lêer bestaan nie!"
+
+#. TRANSLATORS: %s may be a document title.
+#: ../src/html/htmprint.cpp:717
+#, fuzzy, c-format
+msgid "%s Preview"
+msgstr " Voorskou"
+
+#: ../src/html/htmprint.cpp:755 ../src/richtext/richtextprint.cpp:618
+msgid ""
+"There was a problem during page setup: you may need to set a default printer."
+msgstr ""
+"Daar was 'n probleem tydens bladsy-opstelling: Jy moet dalk 'n "
+"standaarddrukker opstel."
+
+#: ../src/msw/clipbrd.cpp:80
+msgid "Failed to open the clipboard."
+msgstr "Open van knipbord het misluk."
+
+#: ../src/msw/clipbrd.cpp:101
+msgid "Failed to close the clipboard."
+msgstr "Toemaak van knipbord het misluk."
+
+#: ../src/msw/clipbrd.cpp:113
+msgid "Failed to empty the clipboard."
+msgstr "Skoonmaak van knipbord het misluk."
+
+#: ../src/msw/clipbrd.cpp:284
+msgid "Failed to put data on the clipboard"
+msgstr "Stoor van data op knipbord het misluk"
+
+#: ../src/msw/clipbrd.cpp:326
+msgid "Failed to get data from the clipboard"
+msgstr "Data kon nie vanaf die knipbord verkry word nie"
+
+#: ../src/msw/clipbrd.cpp:363
+msgid "Failed to retrieve the supported clipboard formats"
+msgstr "Verkryging van ondersteunde knipbord-formate het misluk"
+
+#: ../src/msw/colordlg.cpp:228
+#, c-format
+msgid "Colour selection dialog failed with error %0lx."
+msgstr "Kleurseleksiedialoog het misluk met fout %0lx."
+
+#: ../src/msw/cursor.cpp:141
+msgid "Failed to create cursor."
+msgstr "Wyser kon nie geskep word nie."
+
+#: ../src/msw/dde.cpp:279
+#, c-format
+msgid "Failed to register DDE server '%s'"
+msgstr "Registrasie van DDE-bediener '%s' het misluk"
+
+#: ../src/msw/dde.cpp:300
+#, c-format
+msgid "Failed to unregister DDE server '%s'"
+msgstr "Deregistrering van DDE-bediener '%s' het misluk"
+
+#: ../src/msw/dde.cpp:428
+#, c-format
+msgid "Failed to create connection to server '%s' on topic '%s'"
+msgstr ""
+"'n Verbinding met bediener '%s' vir onderwerp '%s' kon nie gemaak word nie"
+
+#: ../src/msw/dde.cpp:655
+msgid "DDE poke request failed"
+msgstr "DDE 'poke'-versoek het misluk"
+
+#: ../src/msw/dde.cpp:674
+msgid "Failed to establish an advise loop with DDE server"
+msgstr "Opstelling van advies-lus met die DDE-server het misluk"
+
+#: ../src/msw/dde.cpp:693
+msgid "Failed to terminate the advise loop with DDE server"
+msgstr "Beëindiging van advies-lus met die DDE-server het misluk"
+
+#: ../src/msw/dde.cpp:768
+msgid "Failed to send DDE advise notification"
+msgstr "DDE-advieskennisgewing kon nie gestuur word nie"
+
+#: ../src/msw/dde.cpp:1085
+msgid "Failed to create DDE string"
+msgstr "Skepping van DDE-string het misluk"
+
+#: ../src/msw/dde.cpp:1131
+msgid "no DDE error."
+msgstr "geen DDE-fout."
+
+#: ../src/msw/dde.cpp:1135
+msgid "a request for a synchronous advise transaction has timed out."
+msgstr "'n versoek vir 'n sinkrone advies-transaksie se tyd is verstreke."
+
+#: ../src/msw/dde.cpp:1138
+msgid "the response to the transaction caused the DDE_FBUSY bit to be set."
+msgstr "die antwoord op die transaksie het die DDE_FBUSY-bit na 1 gestel."
+
+#: ../src/msw/dde.cpp:1141
+msgid "a request for a synchronous data transaction has timed out."
+msgstr "'n versoek vir 'n sinkrone data-transaksie se tyd is verstreke."
+
+#: ../src/msw/dde.cpp:1144
+msgid ""
+"a DDEML function was called without first calling the DdeInitialize "
+"function,\n"
+"or an invalid instance identifier\n"
+"was passed to a DDEML function."
+msgstr ""
+"'n DDEML-funksie is geroep sonder om eers die DdeInitialize-funksie te roep\n"
+"of 'n ongeldige proses-ID is deurgegee aan 'n DDEML-funksie."
+
+#: ../src/msw/dde.cpp:1147
+msgid ""
+"an application initialized as APPCLASS_MONITOR has\n"
+"attempted to perform a DDE transaction,\n"
+"or an application initialized as APPCMD_CLIENTONLY has \n"
+"attempted to perform server transactions."
+msgstr ""
+"'n toepassing wat as APPCLASS_MONITOR begin is, het probeer om\n"
+"'n DDE-transaksie uit te voer of 'n toepassing wat as APPCMD_CLIENTONLY \n"
+"begin is, het probeer om 'n bediener-transaksie uit te voer."
+
+#: ../src/msw/dde.cpp:1150
+msgid "a request for a synchronous execute transaction has timed out."
+msgstr "'n versoek vir 'n sinkrone uitvoer-transaksie se tyd is verstreke."
+
+#: ../src/msw/dde.cpp:1153
+msgid "a parameter failed to be validated by the DDEML."
+msgstr "'n parameter kon nie deur die DDEML gevalideer word nie."
+
+#: ../src/msw/dde.cpp:1156
+msgid "a DDEML application has created a prolonged race condition."
+msgstr ""
+"'n DDEML-toepassing het deur 'n wedrentoestand geheuegebrek veroorsaak."
+
+#: ../src/msw/dde.cpp:1159
+msgid "a memory allocation failed."
+msgstr "'n geheuereservering het misluk."
+
+#: ../src/msw/dde.cpp:1162
+msgid "a client's attempt to establish a conversation has failed."
+msgstr "Kliënt se poging om 'n gesprek te begin, het misluk."
+
+#: ../src/msw/dde.cpp:1165
+msgid "a transaction failed."
+msgstr "'n transaksie het misluk."
+
+#: ../src/msw/dde.cpp:1168
+msgid "a request for a synchronous poke transaction has timed out."
+msgstr "'n versoek vir 'n sinkrone 'poke'-transaksie se tyd is verstreke."
+
+#: ../src/msw/dde.cpp:1171
+msgid "an internal call to the PostMessage function has failed. "
+msgstr "'n interne oproep van die PostMessage-funksie het misluk."
+
+#: ../src/msw/dde.cpp:1174
+msgid "reentrancy problem."
+msgstr "probleem met hertoetreding."
+
+#: ../src/msw/dde.cpp:1177
+msgid ""
+"a server-side transaction was attempted on a conversation\n"
+"that was terminated by the client, or the server\n"
+"terminated before completing a transaction."
+msgstr ""
+"vanaf die bediener is gepoog om 'n transaksie op die gesprek uit te voer\n"
+"wat deur die kliënt beëindig is of deur die bediener laat vaar is\n"
+"voordat die transaksie voltooi is."
+
+#: ../src/msw/dde.cpp:1180
+msgid "an internal error has occurred in the DDEML."
+msgstr "'n interne fout het voorgekom in die DDEML."
+
+#: ../src/msw/dde.cpp:1183
+msgid "a request to end an advise transaction has timed out."
+msgstr ""
+"'n versoek vir beëindiging van 'n advies-transaksie se tyd is verstreke."
+
+#: ../src/msw/dde.cpp:1186
+msgid ""
+"an invalid transaction identifier was passed to a DDEML function.\n"
+"Once the application has returned from an XTYP_XACT_COMPLETE callback,\n"
+"the transaction identifier for that callback is no longer valid."
+msgstr ""
+"'n ongeldige transaksie-id is deurgegee aan 'n DDEML-funksie.\n"
+"As die toepassing verdergaan na 'n XTYP_XACT_COMPLETE-callback dan is\n"
+"die transaksie-id vir die callback nie meer geldig nie."
+
+#: ../src/msw/dde.cpp:1189
+#, c-format
+msgid "Unknown DDE error %08x"
+msgstr "Onbekende DDE-fout %08x"
+
+#: ../src/msw/dialup.cpp:343
+msgid ""
+"Dial up functions are unavailable because the remote access service (RAS) is "
+"not installed on this machine. Please install it."
+msgstr ""
+"Inbel-funksies is nie beskikbaar nie omdat die afstandtoegangsdiens (RAS) "
+"nie op hierdie masjien geïnstalleer is nie. Installeer dit asb."
+
+#: ../src/msw/dialup.cpp:402
+#, c-format
+msgid ""
+"The version of remote access service (RAS) installed on this machine is too "
+"old, please upgrade (the following required function is missing: %s)."
+msgstr ""
+"Die weergawe van die inbelprogrammatuur (RAS) op hierdie masjien is te oud "
+"(die volgende benodigde funksie ontbreek: %s)."
+
+#: ../src/msw/dialup.cpp:437
+msgid "Failed to retrieve text of RAS error message"
+msgstr "Verkryging van teks van inbel-foutmelding het misluk"
+
+#: ../src/msw/dialup.cpp:440
+#, c-format
+msgid "unknown error (error code %08x)."
+msgstr "onbekende fout (foutnommer %08x)."
+
+#: ../src/msw/dialup.cpp:492
+#, c-format
+msgid "Cannot find active dialup connection: %s"
+msgstr "Kan geen aktiewe inbelverbinding vind nie: %s"
+
+#: ../src/msw/dialup.cpp:513
+msgid "Several active dialup connections found, choosing one randomly."
+msgstr ""
+"Meer as een aktiewe inbelverbindings gevind, willekeurige keuse is gemaak."
+
+#: ../src/msw/dialup.cpp:598 ../src/msw/dialup.cpp:832
+#, c-format
+msgid "Failed to establish dialup connection: %s"
+msgstr "'n Inbelverbinding kon nie gemaak word nie: %s"
+
+#: ../src/msw/dialup.cpp:664
+#, c-format
+msgid "Failed to get ISP names: %s"
+msgstr "ISP name %s kon nie verkry word nie"
+
+#: ../src/msw/dialup.cpp:712
+msgid "Failed to connect: no ISP to dial."
+msgstr "Verbinding het misluk: geen ISP om te bel."
+
+#: ../src/msw/dialup.cpp:732
+msgid "Choose ISP to dial"
+msgstr "Kies ISP om te bel"
+
+#: ../src/msw/dialup.cpp:733
+msgid "Please choose which ISP do you want to connect to"
+msgstr "Kies asb. 'n internetdiensverskaffer om mee te koppel"
+
+#: ../src/msw/dialup.cpp:766
+msgid "Failed to connect: missing username/password."
+msgstr "Verbinding het misluk: gebruikersnaam/wagwoord ontbreek."
+
+#: ../src/msw/dialup.cpp:796
+msgid "Cannot find the location of address book file"
+msgstr "Kan stoorplek van adresboeklêer nie vind nie"
+
+#: ../src/msw/dialup.cpp:827
+#, fuzzy, c-format
+msgid "Failed to initiate dialup connection: %s"
+msgstr "Verbreking van inbelverbinding het misluk: %s"
+
+#: ../src/msw/dialup.cpp:897
+msgid "Cannot hang up - no active dialup connection."
+msgstr "Kan nie neersit nie - geen aktiewe inbelverbinding"
+
+#: ../src/msw/dialup.cpp:907
+#, c-format
+msgid "Failed to terminate the dialup connection: %s"
+msgstr "Verbreking van inbelverbinding het misluk: %s"
+
+#: ../src/msw/dib.cpp:313
+#, c-format
+msgid "Failed to save the bitmap image to file \"%s\"."
+msgstr "Die bitmap-beeld kon nie na lêer \"%s\" gestoor word nie."
+
+#: ../src/msw/dib.cpp:543
+#, fuzzy, c-format
+msgid "Failed to allocate %luKb of memory for bitmap data."
+msgstr "Kon nie %luKb geheue toeken vir bitmap-data nie."
+
+#: ../src/msw/dir.cpp:241
+#, c-format
+msgid "Cannot enumerate files in directory '%s'"
+msgstr "Kan lêers in gids '%s' nie opsom nie"
+
+#: ../src/msw/dirdlg.cpp:368
+msgid "Couldn't obtain folder name"
+msgstr "Kon nie gidsnaam kry nie"
+
+#: ../src/msw/dlmsw.cpp:163
+#, fuzzy, c-format
+msgid "(error %d: %s)"
+msgstr " (fout %ld: %s)"
+
+#: ../src/msw/dragimag.cpp:143 ../src/msw/dragimag.cpp:178
+#: ../src/msw/imaglist.cpp:309 ../src/msw/imaglist.cpp:331
+msgid "Couldn't add an image to the image list."
+msgstr "Kon geen beeld by die lys voeg nie."
+
+#: ../src/msw/enhmeta.cpp:94
+#, c-format
+msgid "Failed to load metafile from file \"%s\"."
+msgstr "Laai van metalêer vanuit lêer \"%s\" het misluk."
+
+#: ../src/msw/fdrepdlg.cpp:412
+#, c-format
+msgid "Failed to create the standard find/replace dialog (error code %d)"
+msgstr ""
+"Die standaard soek/vervang-dialoog kon nie geskep word nie (foutkode %d)"
+
+#: ../src/msw/filedlg.cpp:1241
+msgid "Access to the file system is not allowed from secure desktop."
+msgstr ""
+
+#: ../src/msw/filedlg.cpp:1242
+msgid "Security warning"
+msgstr ""
+
+#: ../src/msw/filedlg.cpp:1533
+#, c-format
+msgid "File dialog failed with error code %0lx."
+msgstr "Lêerdialoog het misluk met foutkode %0lx."
+
+#: ../src/msw/font.cpp:1120
+#, fuzzy, c-format
+msgid "Font file \"%s\" couldn't be loaded"
+msgstr "Lêer kon nie gelaai word nie."
+
+#: ../src/msw/fontdlg.cpp:220
+#, c-format
+msgid "Common dialog failed with error code %0lx."
+msgstr "Algemene dialoog het misluk met foutkode %0lx."
+
+#: ../src/msw/fswatcher.cpp:67
+#, fuzzy
+msgid "Ungraceful worker thread termination"
+msgstr "Kan nie wag vir uitvoerdraad-beëindiging nie"
+
+#: ../src/msw/fswatcher.cpp:81
+#, fuzzy
+msgid "Unable to create IOCP worker thread"
+msgstr "Skepping van MDI-hoofvenster het misluk."
+
+#: ../src/msw/fswatcher.cpp:88
+msgid "Unable to start IOCP worker thread"
+msgstr ""
+
+#: ../src/msw/fswatcher.cpp:140
+msgid "Monitoring individual files for changes is not supported currently."
+msgstr ""
+"Die monitering van veranderinge aan individuele lêers word nie tans "
+"ondersteun nie."
+
+#: ../src/msw/fswatcher.cpp:165
+#, fuzzy, c-format
+msgid "Unable to set up watch for '%s'"
+msgstr "Aanraking van lêer '%s' het misluk"
+
+#: ../src/msw/fswatcher.cpp:466
+#, c-format
+msgid "Can't monitor non-existent directory \"%s\" for changes."
+msgstr "Kan nie veranderinge moniteer aan niebestaande gids \"%s\" nie."
+
+#: ../src/msw/glcanvas.cpp:577 ../src/unix/glx11.cpp:507
+msgid "OpenGL 3.0 or later is not supported by the OpenGL driver."
+msgstr ""
+
+#: ../src/msw/glcanvas.cpp:601 ../src/osx/glcanvas_osx.cpp:395
+#: ../src/unix/glegl.cpp:304 ../src/unix/glx11.cpp:553
+#, fuzzy
+msgid "Couldn't create OpenGL context"
+msgstr "Kon nie 'n tydhouer skep nie"
+
+#: ../src/msw/glcanvas.cpp:1294
+msgid "Failed to initialize OpenGL"
+msgstr "Inisialisering van OpenGL het misluk."
+
+#: ../src/msw/graphicsd2d.cpp:607
+msgid "Could not register custom DirectWrite font loader."
+msgstr ""
+
+#: ../src/msw/helpchm.cpp:48
+msgid ""
+"MS HTML Help functions are unavailable because the MS HTML Help library is "
+"not installed on this machine. Please install it."
+msgstr ""
+"MS HTML Help-funksies is nie beskikbaar nie omdat die MS HTML Help-"
+"biblioteek nie op hierdie masjien geïnstalleer is nie. Installeer dit asb."
+
+#: ../src/msw/helpchm.cpp:55
+msgid "Failed to initialize MS HTML Help."
+msgstr "Inisialisering van MS HTML Help het misluk."
+
+#: ../src/msw/iniconf.cpp:458
+#, c-format
+msgid "Can't delete the INI file '%s'"
+msgstr "Kan INI-lêer '%s' nie uitvee nie"
+
+#: ../src/msw/listctrl.cpp:995
+#, c-format
+msgid "Couldn't retrieve information about list control item %d."
+msgstr "Kon geen inligting oor lys-item %d kry nie."
+
+#: ../src/msw/mdi.cpp:170 ../src/qt/mdi.cpp:253
+msgid "&Cascade"
+msgstr "&Trapsgewys"
+
+#: ../src/msw/mdi.cpp:171
+msgid "Tile &Horizontally"
+msgstr "Teël &horisontaal"
+
+#: ../src/msw/mdi.cpp:172
+msgid "Tile &Vertically"
+msgstr "Teël &vertikaal"
+
+#: ../src/msw/mdi.cpp:174
+msgid "&Arrange Icons"
+msgstr "R&angskik ikone"
+
+#: ../src/msw/mdi.cpp:621
+msgid "Failed to create MDI parent frame."
+msgstr "Skepping van MDI-hoofvenster het misluk."
+
+#: ../src/msw/mimetype.cpp:234
+#, c-format
+msgid "Failed to create registry entry for '%s' files."
+msgstr "Die registersleutel vir '%s'-lêers kon nie geskep word nie."
+
+#: ../src/msw/ole/automtn.cpp:495
+#, fuzzy, c-format
+msgid "Failed to find CLSID of \"%s\""
+msgstr "Opening van '%s' vir %s het misluk"
+
+#: ../src/msw/ole/automtn.cpp:512
+#, fuzzy, c-format
+msgid "Failed to create an instance of \"%s\""
+msgstr "Die gids %s/.gnome kon nie geskep word nie."
+
+#: ../src/msw/ole/automtn.cpp:552
+#, fuzzy, c-format
+msgid "Cannot get an active instance of \"%s\""
+msgstr "Kan geen actiewe inbelverbinding vind nie: %s"
+
+#: ../src/msw/ole/automtn.cpp:564
+#, fuzzy, c-format
+msgid "Failed to get OLE automation interface for \"%s\""
+msgstr "Die gids %s/.gnome kon nie geskep word nie."
+
+#: ../src/msw/ole/automtn.cpp:621
+msgid "Unknown name or named argument."
+msgstr ""
+
+#: ../src/msw/ole/automtn.cpp:625
+msgid "Incorrect number of arguments."
+msgstr "Verkeerde aantal argumente."
+
+#: ../src/msw/ole/automtn.cpp:637
+#, fuzzy
+msgid "Unknown exception"
+msgstr "Onbekende opsie '%s'"
+
+#: ../src/msw/ole/automtn.cpp:642
+msgid "Method or property not found."
+msgstr ""
+
+#: ../src/msw/ole/automtn.cpp:646
+msgid "Overflow while coercing argument values."
+msgstr ""
+
+#: ../src/msw/ole/automtn.cpp:650
+msgid "Object implementation does not support named arguments."
+msgstr ""
+
+#: ../src/msw/ole/automtn.cpp:654
+msgid "The locale ID is unknown."
+msgstr ""
+
+#: ../src/msw/ole/automtn.cpp:658
+msgid "Missing a required parameter."
+msgstr ""
+
+#: ../src/msw/ole/automtn.cpp:662
+#, fuzzy, c-format
+msgid "Argument %u not found."
+msgstr "katalogus-lêer vir domein '%s' nie gevind nie."
+
+#: ../src/msw/ole/automtn.cpp:666
+#, c-format
+msgid "Type mismatch in argument %u."
+msgstr ""
+
+#: ../src/msw/ole/automtn.cpp:670
+msgid "The system cannot find the file specified."
+msgstr "Die stelsel kan nie die gespesifiseerde lêer kry nie."
+
+#: ../src/msw/ole/automtn.cpp:674
+msgid "Class not registered."
+msgstr "Klas nie geregistreer nie."
+
+#: ../src/msw/ole/automtn.cpp:678
+#, c-format
+msgid "Unknown error %08x"
+msgstr "Onbekende fout %08x"
+
+#: ../src/msw/ole/automtn.cpp:682
+#, c-format
+msgid "OLE Automation error in %s: %s"
+msgstr "OLE-outomasiefout in %s: %s"
+
+#: ../src/msw/ole/dataobj.cpp:385
+#, c-format
+msgid "Couldn't register clipboard format '%s'."
+msgstr "Kon nie knipbord-formaat '%s' registreer nie."
+
+#: ../src/msw/ole/dataobj.cpp:402
+#, c-format
+msgid "The clipboard format '%d' doesn't exist."
+msgstr "Die knipbord-formaat '%d' bestaan nie."
+
+#: ../src/msw/progdlg.cpp:1025
+msgid "Skip"
+msgstr "Slaan oor"
+
+#: ../src/msw/registry.cpp:141
+#, fuzzy, c-format
+msgid "unknown (%lu)"
+msgstr "onbekend"
+
+#: ../src/msw/registry.cpp:409
+#, c-format
+msgid "Can't get info about registry key '%s'"
+msgstr "Kan geen informasie kry oor registersleutel '%s'"
+
+#: ../src/msw/registry.cpp:445
+#, c-format
+msgid "Can't open registry key '%s'"
+msgstr "Kan registersleutel '%s' nie open nie"
+
+#: ../src/msw/registry.cpp:478
+#, c-format
+msgid "Can't create registry key '%s'"
+msgstr "Kan registersleutel '%s' nie skep nie"
+
+#: ../src/msw/registry.cpp:497
+#, c-format
+msgid "Can't close registry key '%s'"
+msgstr "Kan registersleutel '%s' nie toemaak nie"
+
+#: ../src/msw/registry.cpp:512
+#, c-format
+msgid "Registry value '%s' already exists."
+msgstr "Registerwaarde '%s' bestaan al."
+
+#: ../src/msw/registry.cpp:520
+#, c-format
+msgid "Failed to rename registry value '%s' to '%s'."
+msgstr "Hernoeming van registerwaarde '%s' na '%s' het misluk"
+
+#: ../src/msw/registry.cpp:575
+#, c-format
+msgid "Can't copy values of unsupported type %d."
+msgstr "Kan geen waardes van nie-ondersteunde tipe %d kopieer nie."
+
+#: ../src/msw/registry.cpp:586
+#, c-format
+msgid "Registry key '%s' does not exist, cannot rename it."
+msgstr "Registersleutel '%s' bestaan nie, kan dit dus nie hernoem nie."
+
+#: ../src/msw/registry.cpp:617
+#, c-format
+msgid "Registry key '%s' already exists."
+msgstr "Registersleutel '%s' bestaan al."
+
+#: ../src/msw/registry.cpp:625
+#, c-format
+msgid "Failed to rename the registry key '%s' to '%s'."
+msgstr "Hernoeming van registersleutel '%s' na '%s' het misluk"
+
+#: ../src/msw/registry.cpp:670
+#, c-format
+msgid "Failed to copy the registry subkey '%s' to '%s'."
+msgstr "Kopiëring van registersleutel '%s' na '%s' het misluk"
+
+#: ../src/msw/registry.cpp:683
+#, c-format
+msgid "Failed to copy registry value '%s'"
+msgstr "Kopiëring van registerwaarde '%s' het misluk"
+
+#: ../src/msw/registry.cpp:692
+#, c-format
+msgid "Failed to copy the contents of registry key '%s' to '%s'."
+msgstr "Kopiëring van registersleutel '%s' na '%s' het misluk."
+
+#: ../src/msw/registry.cpp:718
+#, c-format
+msgid ""
+"Registry key '%s' is needed for normal system operation,\n"
+"deleting it will leave your system in unusable state:\n"
+"operation aborted."
+msgstr ""
+"Registersleutel '%s' is nodig vir normale stelselgebruik,\n"
+"as jy dit uitvee word jou stelsel onbruikbaar:\n"
+"bewerking is laat vaar."
+
+#: ../src/msw/registry.cpp:754
+#, c-format
+msgid "Can't delete key '%s'"
+msgstr "Kan sleutel '%s' nie skrap nie"
+
+#: ../src/msw/registry.cpp:782
+#, c-format
+msgid "Can't delete value '%s' from key '%s'"
+msgstr "Kan waarde '%s' nie uit sleutel '%s' verwyder nie."
+
+#: ../src/msw/registry.cpp:855 ../src/msw/registry.cpp:887
+#: ../src/msw/registry.cpp:929 ../src/msw/registry.cpp:1000
+#, c-format
+msgid "Can't read value of key '%s'"
+msgstr "Kan waarde van sleutel '%s' nie lees nie"
+
+#: ../src/msw/registry.cpp:873 ../src/msw/registry.cpp:915
+#: ../src/msw/registry.cpp:963 ../src/msw/registry.cpp:1106
+#, c-format
+msgid "Can't set value of '%s'"
+msgstr "Kan waarde van '%s' nie verstel nie"
+
+#: ../src/msw/registry.cpp:894 ../src/msw/registry.cpp:943
+#, c-format
+msgid "Registry value \"%s\" is not numeric (but of type %s)"
+msgstr ""
+
+#: ../src/msw/registry.cpp:979
+#, c-format
+msgid "Registry value \"%s\" is not binary (but of type %s)"
+msgstr ""
+
+#: ../src/msw/registry.cpp:1028
+#, c-format
+msgid "Registry value \"%s\" is not text (but of type %s)"
+msgstr ""
+
+#: ../src/msw/registry.cpp:1089
+#, c-format
+msgid "Can't read value of '%s'"
+msgstr "Kan waarde van '%s' nie lees nie"
+
+#: ../src/msw/registry.cpp:1157
+#, c-format
+msgid "Can't enumerate values of key '%s'"
+msgstr "Kan waarden van sleutel '%s' nie opsom nie"
+
+#: ../src/msw/registry.cpp:1196
+#, c-format
+msgid "Can't enumerate subkeys of key '%s'"
+msgstr "Kan subsleutels van sleutel '%s' nie opsom nie"
+
+#: ../src/msw/registry.cpp:1262
+#, c-format
+msgid ""
+"Exporting registry key: file \"%s\" already exists and won't be overwritten."
+msgstr ""
+
+#: ../src/msw/registry.cpp:1411
+#, fuzzy, c-format
+msgid "Can't export value of unsupported type %d."
+msgstr "Kan geen waardes van nie-ondersteunde tipe %d kopieer nie."
+
+#: ../src/msw/registry.cpp:1427
+#, c-format
+msgid "Ignoring value \"%s\" of the key \"%s\"."
+msgstr ""
+
+#: ../src/msw/textctrl.cpp:596
+msgid ""
+"Impossible to create a rich edit control, using simple text control instead. "
+"Please reinstall riched32.dll"
+msgstr ""
+"Onmoontlik om Rich Edit beheerelement te skep, gewone teks word gebruik. "
+"Herinstalleer riched32.dll asb."
+
+#: ../src/msw/thread.cpp:522 ../src/unix/threadpsx.cpp:850
+msgid "Cannot start thread: error writing TLS."
+msgstr "Kan uitvoerdraad nie laat begin nie: fout met skryf van TLS."
+
+#: ../src/msw/thread.cpp:613
+msgid "Can't set thread priority"
+msgstr "Kan thread-prioriteit nie instellen"
+
+#: ../src/msw/thread.cpp:649
+msgid "Can't create thread"
+msgstr "Kan uitvoerdraad nie skep nie"
+
+#: ../src/msw/thread.cpp:668
+msgid "Couldn't terminate thread"
+msgstr "Kon uitvoerdraad nie beëindig nie"
+
+#: ../src/msw/thread.cpp:799
+msgid "Cannot wait for thread termination"
+msgstr "Kan nie wag vir uitvoerdraad-beëindiging nie"
+
+#: ../src/msw/thread.cpp:873
+#, fuzzy, c-format
+msgid "Cannot suspend thread %lx"
+msgstr "Kan uitvoerdraad %x nie opskort nie"
+
+#: ../src/msw/thread.cpp:903
+#, fuzzy, c-format
+msgid "Cannot resume thread %lx"
+msgstr "Kan uitvoerdraad %x nie laat voortgaan nie"
+
+#: ../src/msw/thread.cpp:932
+msgid "Couldn't get the current thread pointer"
+msgstr "Kon nie wyser na die huidige uitvoerdraad verkry nie"
+
+#: ../src/msw/thread.cpp:1333
+msgid ""
+"Thread module initialization failed: impossible to allocate index in thread "
+"local storage"
+msgstr ""
+"Inisialisasie van uitvoerdraadmodule het misluk: onmoontlik om 'n indeks te "
+"reserveer in lokale uitvoerdraad-geheueruimte."
+
+#: ../src/msw/thread.cpp:1345
+msgid ""
+"Thread module initialization failed: cannot store value in thread local "
+"storage"
+msgstr ""
+"Inisialisasie van uitvoerdraadmodule het misluk: kan geen waarde in lokale "
+"uitvoerdraad-geheueruimte stoor nie."
+
+#: ../src/msw/timer.cpp:133
+msgid "Couldn't create a timer"
+msgstr "Kon nie 'n tydhouer skep nie"
+
+#: ../src/msw/utils.cpp:372
+msgid "can't find user's HOME, using current directory."
+msgstr "kan gebruiker se tuisgids nie vind nie, gebruik dus huidige gids."
+
+#: ../src/msw/utils.cpp:662
+#, c-format
+msgid "Failed to kill process %d"
+msgstr "Process %d kon nie doodgemaak word nie"
+
+#: ../src/msw/utils.cpp:986
+#, c-format
+msgid "Failed to load resource \"%s\"."
+msgstr "Kon nie hulpbron \"%s\" laai nie."
+
+#: ../src/msw/utils.cpp:993
+#, c-format
+msgid "Failed to lock resource \"%s\"."
+msgstr "Kon nie hulpbron \"%s\" vassluit nie."
+
+#. TRANSLATORS: MS Windows build number
+#: ../src/msw/utils.cpp:1209
+#, c-format
+msgid "build %lu"
+msgstr ""
+
+#: ../src/msw/utils.cpp:1218
+msgid ", 64-bit edition"
+msgstr ", 64-bisweergawe"
+
+#: ../src/msw/utilsexc.cpp:224
+msgid "Failed to create an anonymous pipe"
+msgstr "'n Anonieme pyp kon nie geskep word nie"
+
+#: ../src/msw/utilsexc.cpp:697
+msgid "Failed to redirect the child process IO"
+msgstr "Herleiding van toevoer/afvoer van subproses het misluk"
+
+#: ../src/msw/utilsexc.cpp:870
+#, c-format
+msgid "Execution of command '%s' failed"
+msgstr "Uitvoering van opdrag '%s' het misluk"
+
+#: ../src/msw/volume.cpp:337
+msgid "Failed to load mpr.dll."
+msgstr "Laai van mpr.dll het misluk."
+
+#: ../src/msw/volume.cpp:506
+#, c-format
+msgid "Cannot read typename from '%s'!"
+msgstr "Kan nie die tipenaam van '%s' lees nie!"
+
+#: ../src/msw/volume.cpp:615
+#, c-format
+msgid "Cannot load icon from '%s'."
+msgstr "Kan ikoon nie laai van '%s'."
+
+#: ../src/msw/webview_edge.cpp:285
+msgid "This program was compiled without support for setting Edge proxy."
+msgstr ""
+
+#: ../src/msw/webview_ie.cpp:1010
+msgid "Failed to find web view emulation level in the registry"
+msgstr ""
+
+#: ../src/msw/webview_ie.cpp:1019
+msgid "Failed to set web view to modern emulation level"
+msgstr ""
+
+#: ../src/msw/webview_ie.cpp:1027
+msgid "Failed to reset web view to standard emulation level"
+msgstr ""
+
+#: ../src/msw/webview_ie.cpp:1049
+msgid "Can't run JavaScript script without a valid HTML document"
+msgstr ""
+
+#: ../src/msw/webview_ie.cpp:1056
+#, fuzzy
+msgid "Can't get the JavaScript object"
+msgstr "Kan thread-prioriteit nie instellen"
+
+#: ../src/msw/webview_ie.cpp:1070
+#, fuzzy
+msgid "failed to evaluate"
+msgstr "Uitvoering van '%s' het misluk\n"
+
+#: ../src/osx/cocoa/filedlg.mm:412
+#, fuzzy
+msgid "File type:"
+msgstr "Nie-proporsioneel (Teletype)"
+
+#: ../src/osx/cocoa/menu.mm:242
+#, fuzzy
+msgctxt "macOS menu name"
+msgid "Window"
+msgstr "&Venster"
+
+#: ../src/osx/cocoa/menu.mm:259
+#, fuzzy
+msgctxt "macOS menu name"
+msgid "Help"
+msgstr "Hulp"
+
+#: ../src/osx/cocoa/menu.mm:298
+#, fuzzy
+msgctxt "macOS menu item"
+msgid "Minimize"
+msgstr "Mi&nimaliseer"
+
+#: ../src/osx/cocoa/menu.mm:303
+#, fuzzy
+msgctxt "macOS menu item"
+msgid "Zoom"
+msgstr "Zoem in"
+
+#: ../src/osx/cocoa/menu.mm:309
+msgctxt "macOS menu item"
+msgid "Bring All to Front"
+msgstr ""
+
+#: ../src/osx/core/sound.cpp:143
+#, fuzzy, c-format
+msgid "Failed to load sound from \"%s\" (error %d)."
+msgstr "Kon nie hulpbron \"%s\" laai nie."
+
+#: ../src/osx/fontutil.cpp:80
+#, fuzzy, c-format
+msgid "Font file \"%s\" doesn't exist."
+msgstr "Lêer %s bestaan nie."
+
+#: ../src/osx/fontutil.cpp:88
+#, c-format
+msgid ""
+"Font file \"%s\" cannot be used as it is not inside the font directory "
+"\"%s\"."
+msgstr ""
+
+#: ../src/osx/menu_osx.cpp:496
+#, c-format
+msgctxt "macOS menu item"
+msgid "About %s"
+msgstr "Aangaande %s"
+
+#: ../src/osx/menu_osx.cpp:499
+#, fuzzy
+msgctxt "macOS menu item"
+msgid "About..."
+msgstr "Aangaande"
+
+#: ../src/osx/menu_osx.cpp:508
+msgctxt "macOS menu item"
+msgid "Preferences..."
+msgstr "Voorkeure..."
+
+#: ../src/osx/menu_osx.cpp:512
+msgctxt "macOS menu item"
+msgid "Services"
+msgstr ""
+
+#: ../src/osx/menu_osx.cpp:519
+#, c-format
+msgctxt "macOS menu item"
+msgid "Hide %s"
+msgstr "Versteek %s"
+
+#: ../src/osx/menu_osx.cpp:522
+#, fuzzy
+msgctxt "macOS menu item"
+msgid "Hide Application"
+msgstr "Toepassing"
+
+#: ../src/osx/menu_osx.cpp:526
+msgctxt "macOS menu item"
+msgid "Hide Others"
+msgstr "Versteek ander"
+
+#: ../src/osx/menu_osx.cpp:528
+msgctxt "macOS menu item"
+msgid "Show All"
+msgstr "Wys almal"
+
+#: ../src/osx/menu_osx.cpp:534
+#, c-format
+msgctxt "macOS menu item"
+msgid "Quit %s"
+msgstr "Sluit %s af"
+
+#: ../src/osx/menu_osx.cpp:537
+#, fuzzy
+msgctxt "macOS menu item"
+msgid "Quit Application"
+msgstr "Toepassing"
+
+#: ../src/osx/webview_webkit.mm:444
+msgid "Printing is not supported by the system web control"
+msgstr ""
+
+#: ../src/osx/webview_webkit.mm:453
+#, fuzzy
+msgid "Print operation could not be initialized"
+msgstr "Kan vertoonskerm nie inisialiseer nie."
+
+#. TRANSLATORS: Label of font point size
+#: ../src/propgrid/advprops.cpp:605
+#, fuzzy
+msgid "Point Size"
+msgstr "Lettertipe-grootte:"
+
+#. TRANSLATORS: Label of font face name
+#: ../src/propgrid/advprops.cpp:615
+#, fuzzy
+msgid "Face Name"
+msgstr "Nuwe gids"
+
+#. TRANSLATORS: Label of font style
+#: ../src/propgrid/advprops.cpp:623 ../src/richtext/richtextformatdlg.cpp:331
+#, fuzzy
+msgid "Style"
+msgstr "Styl"
+
+#. TRANSLATORS: Label of font weight
+#: ../src/propgrid/advprops.cpp:628
+msgid "Weight"
+msgstr "Gewig"
+
+#. TRANSLATORS: Label of underlined font
+#: ../src/propgrid/advprops.cpp:633 ../src/richtext/richtextfontpage.cpp:358
+msgid "Underlined"
+msgstr "Onderstreep"
+
+#. TRANSLATORS: Label of font family
+#: ../src/propgrid/advprops.cpp:637
+msgid "Family"
+msgstr "Familie"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:801
+msgid "AppWorkspace"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:802
+#, fuzzy
+msgid "ActiveBorder"
+msgstr "Modern"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:803
+msgid "ActiveCaption"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:804
+msgid "ButtonFace"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:805
+msgid "ButtonHighlight"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:806
+msgid "ButtonShadow"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:807
+msgid "ButtonText"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:808
+msgid "CaptionText"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:809
+msgid "ControlDark"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:810
+msgid "ControlLight"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:812
+msgid "GrayText"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:813
+#, fuzzy
+msgid "Highlight"
+msgstr "lig"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:814
+#, fuzzy
+msgid "HighlightText"
+msgstr "Belyn teks regs."
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:815
+#, fuzzy
+msgid "InactiveBorder"
+msgstr "Modern"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:816
+msgid "InactiveCaption"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:817
+msgid "InactiveCaptionText"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:818
+msgid "Menu"
+msgstr "Kieslys"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:819
+msgid "Scrollbar"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:820
+msgid "Tooltip"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:821
+msgid "TooltipText"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:822
+#, fuzzy
+msgid "Window"
+msgstr "&Venster"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:823
+#, fuzzy
+msgid "WindowFrame"
+msgstr "&Venster"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:824
+#, fuzzy
+msgid "WindowText"
+msgstr "&Venster"
+
+#. TRANSLATORS: Custom colour choice entry
+#: ../src/propgrid/advprops.cpp:825 ../src/propgrid/advprops.cpp:1532
+#: ../src/propgrid/advprops.cpp:1576
+#, fuzzy
+msgid "Custom"
+msgstr "Pasgemaakte grootte"
+
+#: ../src/propgrid/advprops.cpp:1558
+msgid "Black"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1559
+msgid "Maroon"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1560
+msgid "Navy"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1561
+msgid "Purple"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1562
+msgid "Teal"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1563
+msgid "Gray"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1564
+#, fuzzy
+msgid "Green"
+msgstr "MacGreek"
+
+#: ../src/propgrid/advprops.cpp:1565
+msgid "Olive"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1566
+msgid "Brown"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1567
+msgid "Blue"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1568
+msgid "Fuchsia"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1569
+#, fuzzy
+msgid "Red"
+msgstr "Herdoen"
+
+#: ../src/propgrid/advprops.cpp:1570
+msgid "Orange"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1571
+msgid "Silver"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1572
+msgid "Lime"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1573
+msgid "Aqua"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1574
+msgid "Yellow"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1575
+msgid "White"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1718
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Default"
+msgstr "standaard"
+
+#: ../src/propgrid/advprops.cpp:1719
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Arrow"
+msgstr "môre"
+
+#: ../src/propgrid/advprops.cpp:1720
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Right Arrow"
+msgstr "Regs"
+
+#: ../src/propgrid/advprops.cpp:1721
+msgctxt "system cursor name"
+msgid "Blank"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1722
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Bullseye"
+msgstr "Koeëltjiestyl"
+
+#: ../src/propgrid/advprops.cpp:1723
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Character"
+msgstr "&Karakterkode:"
+
+#: ../src/propgrid/advprops.cpp:1724
+msgctxt "system cursor name"
+msgid "Cross"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1725
+msgctxt "system cursor name"
+msgid "Hand"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1726
+msgctxt "system cursor name"
+msgid "I-Beam"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1727
+msgctxt "system cursor name"
+msgid "Left Button"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1728
+msgctxt "system cursor name"
+msgid "Magnifier"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1729
+msgctxt "system cursor name"
+msgid "Middle Button"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1730
+msgctxt "system cursor name"
+msgid "No Entry"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1731
+msgctxt "system cursor name"
+msgid "Paint Brush"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1732
+msgctxt "system cursor name"
+msgid "Pencil"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1733
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Point Left"
+msgstr "Lettertipe-grootte:"
+
+#: ../src/propgrid/advprops.cpp:1734
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Point Right"
+msgstr "Belyn regs"
+
+#: ../src/propgrid/advprops.cpp:1735
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Question Arrow"
+msgstr "Vraag"
+
+#: ../src/propgrid/advprops.cpp:1736
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Right Button"
+msgstr "Regs"
+
+#: ../src/propgrid/advprops.cpp:1737
+msgctxt "system cursor name"
+msgid "Sizing NE-SW"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1738
+msgctxt "system cursor name"
+msgid "Sizing N-S"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1739
+msgctxt "system cursor name"
+msgid "Sizing NW-SE"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1740
+msgctxt "system cursor name"
+msgid "Sizing W-E"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1741
+msgctxt "system cursor name"
+msgid "Sizing"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1742
+msgctxt "system cursor name"
+msgid "Spraycan"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1743
+msgctxt "system cursor name"
+msgid "Wait"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1744
+msgctxt "system cursor name"
+msgid "Watch"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1745
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Wait Arrow"
+msgstr "Regs"
+
+#: ../src/propgrid/advprops.cpp:2109
+msgid "Make a selection:"
+msgstr "Maak 'n keuse:"
+
+#: ../src/propgrid/manager.cpp:394
+msgid "Property"
+msgstr "Eienskap"
+
+#: ../src/propgrid/manager.cpp:395
+msgid "Value"
+msgstr "Waarde"
+
+#: ../src/propgrid/manager.cpp:1683
+msgid "Categorized Mode"
+msgstr "Gekategoriseerde modus"
+
+#: ../src/propgrid/manager.cpp:1709
+msgid "Alphabetic Mode"
+msgstr "Alfabetiese modus"
+
+#. TRANSLATORS: Name of Boolean false value
+#: ../src/propgrid/propgrid.cpp:230
+msgid "False"
+msgstr "Vals"
+
+#. TRANSLATORS: Name of Boolean true value
+#: ../src/propgrid/propgrid.cpp:232
+msgid "True"
+msgstr "Waar"
+
+#. TRANSLATORS: Text  displayed for unspecified value
+#: ../src/propgrid/propgrid.cpp:428
+msgid "Unspecified"
+msgstr "Nie gespesifiseer nie"
+
+#. TRANSLATORS: Caption of message box displaying any property error
+#: ../src/propgrid/propgrid.cpp:3145 ../src/propgrid/propgrid.cpp:3282
+#, fuzzy
+msgid "Property Error"
+msgstr "Drukwerkfout"
+
+#: ../src/propgrid/propgrid.cpp:3259
+msgid "You have entered invalid value. Press ESC to cancel editing."
+msgstr ""
+
+#: ../src/propgrid/propgrid.cpp:6608
+#, c-format
+msgid "Error in resource: %s"
+msgstr ""
+
+#: ../src/propgrid/propgridiface.cpp:377
+#, c-format
+msgid ""
+"Type operation \"%s\" failed: Property labeled \"%s\" is of type \"%s\", NOT "
+"\"%s\"."
+msgstr ""
+
+#: ../src/propgrid/props.cpp:159
+#, c-format
+msgid "Unknown base %d. Base 10 will be used."
+msgstr ""
+
+#: ../src/propgrid/props.cpp:324
+#, c-format
+msgid "Value must be %s or higher."
+msgstr "Waarde moet %s of meer wees."
+
+#: ../src/propgrid/props.cpp:329 ../src/propgrid/props.cpp:356
+#, c-format
+msgid "Value must be between %s and %s."
+msgstr "Waarde moet tussen %s en %s wees."
+
+#: ../src/propgrid/props.cpp:351
+#, c-format
+msgid "Value must be %s or less."
+msgstr "Waarde moet %s of minder wees."
+
+#: ../src/propgrid/props.cpp:1058
+#, c-format
+msgid "Not %s"
+msgstr "Nie %s nie"
+
+#: ../src/propgrid/props.cpp:1770
+msgid "Choose a directory:"
+msgstr "Kies 'n gids:"
+
+#: ../src/propgrid/props.cpp:2055
+msgid "Choose a file"
+msgstr "Kies 'n lêer"
+
+#: ../src/qt/mdi.cpp:254
+msgid "&Tile"
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:147
+#: ../src/richtext/richtextformatdlg.cpp:376
+msgid "Background"
+msgstr "Agtergrond"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:159
+msgid "Background &colour:"
+msgstr "Agtergrond&kleur:"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:161
+#: ../src/richtext/richtextbackgroundpage.cpp:163
+msgid "Enables a background colour."
+msgstr "Aktiveer 'n agtergrondkleur."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:167
+#: ../src/richtext/richtextbackgroundpage.cpp:169
+msgid "The background colour."
+msgstr "Die agtergrondkleur."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:178
+msgid "Shadow"
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:193
+msgid "Use &shadow"
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:195
+#: ../src/richtext/richtextbackgroundpage.cpp:197
+#, fuzzy
+msgid "Enables a shadow."
+msgstr "Aktiveer 'n agtergrondkleur."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:211
+msgid "&Horizontal offset:"
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:218
+#: ../src/richtext/richtextbackgroundpage.cpp:220
+#, fuzzy
+msgid "The horizontal offset."
+msgstr "Teël &horisontaal"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:224
+#: ../src/richtext/richtextbackgroundpage.cpp:227
+#: ../src/richtext/richtextbackgroundpage.cpp:228
+#: ../src/richtext/richtextbackgroundpage.cpp:247
+#: ../src/richtext/richtextbackgroundpage.cpp:250
+#: ../src/richtext/richtextbackgroundpage.cpp:251
+#: ../src/richtext/richtextbackgroundpage.cpp:287
+#: ../src/richtext/richtextbackgroundpage.cpp:290
+#: ../src/richtext/richtextbackgroundpage.cpp:291
+#: ../src/richtext/richtextbackgroundpage.cpp:314
+#: ../src/richtext/richtextbackgroundpage.cpp:317
+#: ../src/richtext/richtextbackgroundpage.cpp:318
+#: ../src/richtext/richtextborderspage.cpp:252
+#: ../src/richtext/richtextborderspage.cpp:255
+#: ../src/richtext/richtextborderspage.cpp:256
+#: ../src/richtext/richtextborderspage.cpp:286
+#: ../src/richtext/richtextborderspage.cpp:289
+#: ../src/richtext/richtextborderspage.cpp:290
+#: ../src/richtext/richtextborderspage.cpp:320
+#: ../src/richtext/richtextborderspage.cpp:323
+#: ../src/richtext/richtextborderspage.cpp:324
+#: ../src/richtext/richtextborderspage.cpp:354
+#: ../src/richtext/richtextborderspage.cpp:357
+#: ../src/richtext/richtextborderspage.cpp:358
+#: ../src/richtext/richtextborderspage.cpp:420
+#: ../src/richtext/richtextborderspage.cpp:423
+#: ../src/richtext/richtextborderspage.cpp:424
+#: ../src/richtext/richtextborderspage.cpp:454
+#: ../src/richtext/richtextborderspage.cpp:457
+#: ../src/richtext/richtextborderspage.cpp:458
+#: ../src/richtext/richtextborderspage.cpp:488
+#: ../src/richtext/richtextborderspage.cpp:491
+#: ../src/richtext/richtextborderspage.cpp:492
+#: ../src/richtext/richtextborderspage.cpp:522
+#: ../src/richtext/richtextborderspage.cpp:525
+#: ../src/richtext/richtextborderspage.cpp:526
+#: ../src/richtext/richtextborderspage.cpp:590
+#: ../src/richtext/richtextborderspage.cpp:593
+#: ../src/richtext/richtextborderspage.cpp:594
+#: ../src/richtext/richtextfontpage.cpp:177
+#: ../src/richtext/richtextmarginspage.cpp:199
+#: ../src/richtext/richtextmarginspage.cpp:201
+#: ../src/richtext/richtextmarginspage.cpp:202
+#: ../src/richtext/richtextmarginspage.cpp:224
+#: ../src/richtext/richtextmarginspage.cpp:226
+#: ../src/richtext/richtextmarginspage.cpp:227
+#: ../src/richtext/richtextmarginspage.cpp:247
+#: ../src/richtext/richtextmarginspage.cpp:249
+#: ../src/richtext/richtextmarginspage.cpp:250
+#: ../src/richtext/richtextmarginspage.cpp:272
+#: ../src/richtext/richtextmarginspage.cpp:274
+#: ../src/richtext/richtextmarginspage.cpp:275
+#: ../src/richtext/richtextmarginspage.cpp:313
+#: ../src/richtext/richtextmarginspage.cpp:315
+#: ../src/richtext/richtextmarginspage.cpp:316
+#: ../src/richtext/richtextmarginspage.cpp:338
+#: ../src/richtext/richtextmarginspage.cpp:340
+#: ../src/richtext/richtextmarginspage.cpp:341
+#: ../src/richtext/richtextmarginspage.cpp:361
+#: ../src/richtext/richtextmarginspage.cpp:363
+#: ../src/richtext/richtextmarginspage.cpp:364
+#: ../src/richtext/richtextmarginspage.cpp:386
+#: ../src/richtext/richtextmarginspage.cpp:388
+#: ../src/richtext/richtextmarginspage.cpp:389
+#: ../src/richtext/richtextsizepage.cpp:337
+#: ../src/richtext/richtextsizepage.cpp:340
+#: ../src/richtext/richtextsizepage.cpp:341
+#: ../src/richtext/richtextsizepage.cpp:371
+#: ../src/richtext/richtextsizepage.cpp:374
+#: ../src/richtext/richtextsizepage.cpp:375
+#: ../src/richtext/richtextsizepage.cpp:398
+#: ../src/richtext/richtextsizepage.cpp:401
+#: ../src/richtext/richtextsizepage.cpp:402
+#: ../src/richtext/richtextsizepage.cpp:425
+#: ../src/richtext/richtextsizepage.cpp:428
+#: ../src/richtext/richtextsizepage.cpp:429
+#: ../src/richtext/richtextsizepage.cpp:452
+#: ../src/richtext/richtextsizepage.cpp:455
+#: ../src/richtext/richtextsizepage.cpp:456
+#: ../src/richtext/richtextsizepage.cpp:479
+#: ../src/richtext/richtextsizepage.cpp:482
+#: ../src/richtext/richtextsizepage.cpp:483
+#: ../src/richtext/richtextsizepage.cpp:553
+#: ../src/richtext/richtextsizepage.cpp:556
+#: ../src/richtext/richtextsizepage.cpp:557
+#: ../src/richtext/richtextsizepage.cpp:588
+#: ../src/richtext/richtextsizepage.cpp:591
+#: ../src/richtext/richtextsizepage.cpp:592
+#: ../src/richtext/richtextsizepage.cpp:623
+#: ../src/richtext/richtextsizepage.cpp:626
+#: ../src/richtext/richtextsizepage.cpp:627
+#: ../src/richtext/richtextsizepage.cpp:658
+#: ../src/richtext/richtextsizepage.cpp:661
+#: ../src/richtext/richtextsizepage.cpp:662
+msgid "px"
+msgstr "px"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:225
+#: ../src/richtext/richtextbackgroundpage.cpp:248
+#: ../src/richtext/richtextbackgroundpage.cpp:288
+#: ../src/richtext/richtextbackgroundpage.cpp:315
+#: ../src/richtext/richtextborderspage.cpp:253
+#: ../src/richtext/richtextborderspage.cpp:287
+#: ../src/richtext/richtextborderspage.cpp:321
+#: ../src/richtext/richtextborderspage.cpp:355
+#: ../src/richtext/richtextborderspage.cpp:421
+#: ../src/richtext/richtextborderspage.cpp:455
+#: ../src/richtext/richtextborderspage.cpp:489
+#: ../src/richtext/richtextborderspage.cpp:523
+#: ../src/richtext/richtextborderspage.cpp:591
+#: ../src/richtext/richtextmarginspage.cpp:200
+#: ../src/richtext/richtextmarginspage.cpp:225
+#: ../src/richtext/richtextmarginspage.cpp:248
+#: ../src/richtext/richtextmarginspage.cpp:273
+#: ../src/richtext/richtextmarginspage.cpp:314
+#: ../src/richtext/richtextmarginspage.cpp:339
+#: ../src/richtext/richtextmarginspage.cpp:362
+#: ../src/richtext/richtextmarginspage.cpp:387
+#: ../src/richtext/richtextsizepage.cpp:338
+#: ../src/richtext/richtextsizepage.cpp:372
+#: ../src/richtext/richtextsizepage.cpp:399
+#: ../src/richtext/richtextsizepage.cpp:426
+#: ../src/richtext/richtextsizepage.cpp:453
+#: ../src/richtext/richtextsizepage.cpp:480
+#: ../src/richtext/richtextsizepage.cpp:554
+#: ../src/richtext/richtextsizepage.cpp:589
+#: ../src/richtext/richtextsizepage.cpp:624
+#: ../src/richtext/richtextsizepage.cpp:659
+msgid "cm"
+msgstr "cm"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:226
+#: ../src/richtext/richtextbackgroundpage.cpp:249
+#: ../src/richtext/richtextbackgroundpage.cpp:289
+#: ../src/richtext/richtextbackgroundpage.cpp:316
+#: ../src/richtext/richtextborderspage.cpp:254
+#: ../src/richtext/richtextborderspage.cpp:288
+#: ../src/richtext/richtextborderspage.cpp:322
+#: ../src/richtext/richtextborderspage.cpp:356
+#: ../src/richtext/richtextborderspage.cpp:422
+#: ../src/richtext/richtextborderspage.cpp:456
+#: ../src/richtext/richtextborderspage.cpp:490
+#: ../src/richtext/richtextborderspage.cpp:524
+#: ../src/richtext/richtextborderspage.cpp:592
+#: ../src/richtext/richtextfontpage.cpp:176
+#: ../src/richtext/richtextfontpage.cpp:179
+msgid "pt"
+msgstr "pt"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:229
+#: ../src/richtext/richtextbackgroundpage.cpp:231
+#: ../src/richtext/richtextbackgroundpage.cpp:252
+#: ../src/richtext/richtextbackgroundpage.cpp:254
+#: ../src/richtext/richtextbackgroundpage.cpp:292
+#: ../src/richtext/richtextbackgroundpage.cpp:294
+#: ../src/richtext/richtextbackgroundpage.cpp:319
+#: ../src/richtext/richtextbackgroundpage.cpp:321
+#, fuzzy
+msgid "Units for this value."
+msgstr "Kan nie wag vir uitvoerdraad-beëindiging nie"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:234
+#, fuzzy
+msgid "&Vertical offset:"
+msgstr "&Vertikale belyning:"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:241
+#: ../src/richtext/richtextbackgroundpage.cpp:243
+#, fuzzy
+msgid "The vertical offset."
+msgstr "Aktiveer vertikale belyning."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:257
+#, fuzzy
+msgid "Shadow c&olour:"
+msgstr "Kies lettertipe"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:259
+#: ../src/richtext/richtextbackgroundpage.cpp:261
+#, fuzzy
+msgid "Enables the shadow colour."
+msgstr "Aktiveer 'n agtergrondkleur."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:265
+#: ../src/richtext/richtextbackgroundpage.cpp:267
+#, fuzzy
+msgid "The shadow colour."
+msgstr "Die tekskleur."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:270
+msgid "Sh&adow spread:"
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:272
+#: ../src/richtext/richtextbackgroundpage.cpp:274
+msgid "Enables the shadow spread."
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:281
+#: ../src/richtext/richtextbackgroundpage.cpp:283
+msgid "The shadow spread."
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:297
+msgid "&Blur distance:"
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:299
+#: ../src/richtext/richtextbackgroundpage.cpp:301
+#, fuzzy
+msgid "Enables the blur distance."
+msgstr "Kon nie begin met drukwerk nie."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:308
+#: ../src/richtext/richtextbackgroundpage.cpp:310
+msgid "The shadow blur distance."
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:324
+msgid "Opaci&ty:"
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:326
+#: ../src/richtext/richtextbackgroundpage.cpp:328
+msgid "Enables the shadow opacity."
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:335
+#: ../src/richtext/richtextbackgroundpage.cpp:337
+msgid "The shadow opacity."
+msgstr ""
+
+#. TRANSLATORS: Rich text page units (percentage)
+#: ../src/richtext/richtextbackgroundpage.cpp:340
+#: ../src/richtext/richtextsizepage.cpp:339
+#: ../src/richtext/richtextsizepage.cpp:373
+#: ../src/richtext/richtextsizepage.cpp:400
+#: ../src/richtext/richtextsizepage.cpp:427
+#: ../src/richtext/richtextsizepage.cpp:454
+#: ../src/richtext/richtextsizepage.cpp:481
+#: ../src/richtext/richtextsizepage.cpp:555
+#: ../src/richtext/richtextsizepage.cpp:590
+#: ../src/richtext/richtextsizepage.cpp:625
+#: ../src/richtext/richtextsizepage.cpp:660
+msgid "%"
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:229
+#: ../src/richtext/richtextborderspage.cpp:387
+#, fuzzy
+msgid "Border"
+msgstr "Modern"
+
+#: ../src/richtext/richtextborderspage.cpp:242
+#: ../src/richtext/richtextborderspage.cpp:410
+#: ../src/richtext/richtextindentspage.cpp:194
+#: ../src/richtext/richtextliststylepage.cpp:384
+#: ../src/richtext/richtextmarginspage.cpp:185
+#: ../src/richtext/richtextmarginspage.cpp:299
+#: ../src/richtext/richtextsizepage.cpp:531
+#: ../src/richtext/richtextsizepage.cpp:538
+msgid "&Left:"
+msgstr "&Links:"
+
+#: ../src/richtext/richtextborderspage.cpp:257
+#: ../src/richtext/richtextborderspage.cpp:259
+msgid "Units for the left border width."
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:266
+#: ../src/richtext/richtextborderspage.cpp:268
+#: ../src/richtext/richtextborderspage.cpp:300
+#: ../src/richtext/richtextborderspage.cpp:302
+#: ../src/richtext/richtextborderspage.cpp:334
+#: ../src/richtext/richtextborderspage.cpp:336
+#: ../src/richtext/richtextborderspage.cpp:368
+#: ../src/richtext/richtextborderspage.cpp:370
+#: ../src/richtext/richtextborderspage.cpp:434
+#: ../src/richtext/richtextborderspage.cpp:436
+#: ../src/richtext/richtextborderspage.cpp:468
+#: ../src/richtext/richtextborderspage.cpp:470
+#: ../src/richtext/richtextborderspage.cpp:502
+#: ../src/richtext/richtextborderspage.cpp:504
+#: ../src/richtext/richtextborderspage.cpp:536
+#: ../src/richtext/richtextborderspage.cpp:538
+#, fuzzy
+msgid "The border line style."
+msgstr "Die lettertipestyl."
+
+#: ../src/richtext/richtextborderspage.cpp:276
+#: ../src/richtext/richtextborderspage.cpp:444
+#: ../src/richtext/richtextindentspage.cpp:212
+#: ../src/richtext/richtextliststylepage.cpp:402
+#: ../src/richtext/richtextmarginspage.cpp:210
+#: ../src/richtext/richtextmarginspage.cpp:324
+#: ../src/richtext/richtextsizepage.cpp:601
+#: ../src/richtext/richtextsizepage.cpp:608
+msgid "&Right:"
+msgstr "&Regs:"
+
+#: ../src/richtext/richtextborderspage.cpp:291
+#: ../src/richtext/richtextborderspage.cpp:293
+msgid "Units for the right border width."
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:310
+#: ../src/richtext/richtextborderspage.cpp:478
+#: ../src/richtext/richtextmarginspage.cpp:233
+#: ../src/richtext/richtextmarginspage.cpp:347
+#: ../src/richtext/richtextsizepage.cpp:566
+#: ../src/richtext/richtextsizepage.cpp:573
+msgid "&Top:"
+msgstr "Bokan&t:"
+
+#: ../src/richtext/richtextborderspage.cpp:325
+#: ../src/richtext/richtextborderspage.cpp:327
+msgid "Units for the top border width."
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:344
+#: ../src/richtext/richtextborderspage.cpp:512
+#: ../src/richtext/richtextmarginspage.cpp:258
+#: ../src/richtext/richtextmarginspage.cpp:372
+#: ../src/richtext/richtextsizepage.cpp:636
+#: ../src/richtext/richtextsizepage.cpp:643
+msgid "&Bottom:"
+msgstr "&Onderkant:"
+
+#: ../src/richtext/richtextborderspage.cpp:359
+#: ../src/richtext/richtextborderspage.cpp:361
+msgid "Units for the bottom border width."
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:380
+#: ../src/richtext/richtextborderspage.cpp:548
+msgid "&Synchronize values"
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:382
+#: ../src/richtext/richtextborderspage.cpp:384
+#: ../src/richtext/richtextborderspage.cpp:550
+#: ../src/richtext/richtextborderspage.cpp:552
+msgid "Check to edit all borders simultaneously."
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:397
+#: ../src/richtext/richtextborderspage.cpp:555
+msgid "Outline"
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:425
+#: ../src/richtext/richtextborderspage.cpp:427
+msgid "Units for the left outline width."
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:459
+#: ../src/richtext/richtextborderspage.cpp:461
+msgid "Units for the right outline width."
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:493
+#: ../src/richtext/richtextborderspage.cpp:495
+msgid "Units for the top outline width."
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:527
+#: ../src/richtext/richtextborderspage.cpp:529
+msgid "Units for the bottom outline width."
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:565
+#: ../src/richtext/richtextborderspage.cpp:600
+msgid "Corner"
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:574
+msgid "Corner &radius:"
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:576
+#: ../src/richtext/richtextborderspage.cpp:578
+msgid "An optional corner radius for adding rounded corners."
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:584
+#: ../src/richtext/richtextborderspage.cpp:586
+msgid "The value of the corner radius."
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:595
+#: ../src/richtext/richtextborderspage.cpp:597
+#, fuzzy
+msgid "Units for the corner radius."
+msgstr "Kan nie wag vir uitvoerdraad-beëindiging nie"
+
+#: ../src/richtext/richtextborderspage.cpp:609
+#: ../src/richtext/richtextsizepage.cpp:247
+#: ../src/richtext/richtextsizepage.cpp:251
+msgid "None"
+msgstr "Geen"
+
+#: ../src/richtext/richtextborderspage.cpp:610
+msgid "Solid"
+msgstr "Solied"
+
+#: ../src/richtext/richtextborderspage.cpp:611
+msgid "Dotted"
+msgstr "Stippels"
+
+#: ../src/richtext/richtextborderspage.cpp:612
+msgid "Dashed"
+msgstr "Strepies"
+
+#: ../src/richtext/richtextborderspage.cpp:613
+msgid "Double"
+msgstr "Dubbel"
+
+#: ../src/richtext/richtextborderspage.cpp:614
+msgid "Groove"
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:615
+msgid "Ridge"
+msgstr "Rif"
+
+#: ../src/richtext/richtextborderspage.cpp:616
+#, fuzzy
+msgid "Inset"
+msgstr "Indeks"
+
+#: ../src/richtext/richtextborderspage.cpp:617
+msgid "Outset"
+msgstr ""
+
+#: ../src/richtext/richtextbuffer.cpp:3518
+msgid "Change Style"
+msgstr "Verander styl"
+
+#: ../src/richtext/richtextbuffer.cpp:3701
+msgid "Change Object Style"
+msgstr "Verander objekstyl"
+
+#: ../src/richtext/richtextbuffer.cpp:3974
+#: ../src/richtext/richtextbuffer.cpp:8174
+msgid "Change Properties"
+msgstr "Verander eienskappe"
+
+#: ../src/richtext/richtextbuffer.cpp:4346
+msgid "Change List Style"
+msgstr "Verander lysstyl"
+
+#: ../src/richtext/richtextbuffer.cpp:4519
+msgid "Renumber List"
+msgstr "Hernommeer lys"
+
+#: ../src/richtext/richtextbuffer.cpp:7867
+#: ../src/richtext/richtextbuffer.cpp:7897
+#: ../src/richtext/richtextbuffer.cpp:7939
+#: ../src/richtext/richtextctrl.cpp:1279 ../src/richtext/richtextctrl.cpp:1473
+msgid "Insert Text"
+msgstr "Voeg teks in"
+
+#: ../src/richtext/richtextbuffer.cpp:8023
+#: ../src/richtext/richtextbuffer.cpp:8979
+msgid "Insert Image"
+msgstr "Voeg beeld in"
+
+#: ../src/richtext/richtextbuffer.cpp:8070
+msgid "Insert Object"
+msgstr "Voeg objek in"
+
+#: ../src/richtext/richtextbuffer.cpp:8112
+msgid "Insert Field"
+msgstr "Voeg veld in"
+
+#: ../src/richtext/richtextbuffer.cpp:8410
+msgid "Too many EndStyle calls!"
+msgstr "Te veel EndStyle-roepe!"
+
+#: ../src/richtext/richtextbuffer.cpp:8785
+msgid "files"
+msgstr "lêers"
+
+#: ../src/richtext/richtextbuffer.cpp:9380
+msgid "standard/circle"
+msgstr "standaard/sirkel"
+
+#: ../src/richtext/richtextbuffer.cpp:9381
+msgid "standard/circle-outline"
+msgstr "standaard/sirkelbuitelyn"
+
+#: ../src/richtext/richtextbuffer.cpp:9382
+msgid "standard/square"
+msgstr "standaard/vierkant"
+
+#: ../src/richtext/richtextbuffer.cpp:9383
+msgid "standard/diamond"
+msgstr "standaard/diamant"
+
+#: ../src/richtext/richtextbuffer.cpp:9384
+msgid "standard/triangle"
+msgstr "standaard/driehoek"
+
+#: ../src/richtext/richtextbuffer.cpp:9423
+msgid "Box Properties"
+msgstr "Boks-eienskappe"
+
+#: ../src/richtext/richtextbuffer.cpp:10006
+#, fuzzy
+msgid "Multiple Cell Properties"
+msgstr "Veelvuldige sel-eienskappe"
+
+#: ../src/richtext/richtextbuffer.cpp:10008
+msgid "Cell Properties"
+msgstr "Seleienskappe"
+
+#: ../src/richtext/richtextbuffer.cpp:11256
+#, fuzzy
+msgid "Set Cell Style"
+msgstr "Verwyder item"
+
+#: ../src/richtext/richtextbuffer.cpp:11330
+msgid "Delete Row"
+msgstr "Skrap ry"
+
+#: ../src/richtext/richtextbuffer.cpp:11380
+msgid "Delete Column"
+msgstr "Skrap kolom"
+
+#: ../src/richtext/richtextbuffer.cpp:11431
+msgid "Add Row"
+msgstr "Voeg ry by"
+
+#: ../src/richtext/richtextbuffer.cpp:11494
+msgid "Add Column"
+msgstr "Voeg kolom by"
+
+#: ../src/richtext/richtextbuffer.cpp:11537
+msgid "Table Properties"
+msgstr "Tabel-eienskappe"
+
+#: ../src/richtext/richtextbuffer.cpp:12899
+msgid "Picture Properties"
+msgstr "Prent-eienskappe"
+
+#: ../src/richtext/richtextbuffer.cpp:13169
+#: ../src/richtext/richtextbuffer.cpp:13279
+msgid "image"
+msgstr "beeld"
+
+#: ../src/richtext/richtextbulletspage.cpp:145
+#: ../src/richtext/richtextliststylepage.cpp:209
+msgid "&Bullet style:"
+msgstr "&Koeëltjiestyl:"
+
+#: ../src/richtext/richtextbulletspage.cpp:150
+#: ../src/richtext/richtextbulletspage.cpp:152
+#: ../src/richtext/richtextliststylepage.cpp:214
+#: ../src/richtext/richtextliststylepage.cpp:216
+msgid "The available bullet styles."
+msgstr "Die beskikbare koeëltjiestyle."
+
+#: ../src/richtext/richtextbulletspage.cpp:158
+#: ../src/richtext/richtextliststylepage.cpp:221
+msgid "Peri&od"
+msgstr "P&unt"
+
+#: ../src/richtext/richtextbulletspage.cpp:160
+#: ../src/richtext/richtextbulletspage.cpp:162
+#: ../src/richtext/richtextliststylepage.cpp:223
+#: ../src/richtext/richtextliststylepage.cpp:225
+msgid "Check to add a period after the bullet."
+msgstr "Merk om 'n punt na die koeëltjie te sit."
+
+#. TRANSLATORS: Bullet point in parentheses option
+#: ../src/richtext/richtextbulletspage.cpp:167
+#: ../src/richtext/richtextliststylepage.cpp:230
+msgid "(*)"
+msgstr "(*)"
+
+#: ../src/richtext/richtextbulletspage.cpp:169
+#: ../src/richtext/richtextbulletspage.cpp:171
+#: ../src/richtext/richtextliststylepage.cpp:232
+#: ../src/richtext/richtextliststylepage.cpp:234
+msgid "Check to enclose the bullet in parentheses."
+msgstr "Merk om die koeëltjie in hakies te sit."
+
+#. TRANSLATORS: Right parenthesis bullet point option
+#: ../src/richtext/richtextbulletspage.cpp:176
+#: ../src/richtext/richtextliststylepage.cpp:239
+msgid "*)"
+msgstr "*)"
+
+#: ../src/richtext/richtextbulletspage.cpp:178
+#: ../src/richtext/richtextbulletspage.cpp:180
+#: ../src/richtext/richtextliststylepage.cpp:241
+#: ../src/richtext/richtextliststylepage.cpp:243
+msgid "Check to add a right parenthesis."
+msgstr "Merk om 'n hakie regs by te sit."
+
+#: ../src/richtext/richtextbulletspage.cpp:185
+#: ../src/richtext/richtextliststylepage.cpp:248
+msgid "Bullet &Alignment:"
+msgstr "Koeëltjie&belyning:"
+
+#: ../src/richtext/richtextbulletspage.cpp:190
+#: ../src/richtext/richtextliststylepage.cpp:253
+msgid "Centre"
+msgstr "Gesentreer"
+
+#: ../src/richtext/richtextbulletspage.cpp:194
+#: ../src/richtext/richtextbulletspage.cpp:196
+#: ../src/richtext/richtextbulletspage.cpp:217
+#: ../src/richtext/richtextbulletspage.cpp:219
+#: ../src/richtext/richtextliststylepage.cpp:257
+#: ../src/richtext/richtextliststylepage.cpp:259
+#: ../src/richtext/richtextliststylepage.cpp:278
+#: ../src/richtext/richtextliststylepage.cpp:280
+msgid "The bullet character."
+msgstr "Die koeëltjiekarakter."
+
+#: ../src/richtext/richtextbulletspage.cpp:212
+#: ../src/richtext/richtextliststylepage.cpp:271
+msgid "&Symbol:"
+msgstr "&Simbool:"
+
+#: ../src/richtext/richtextbulletspage.cpp:222
+#: ../src/richtext/richtextliststylepage.cpp:283
+msgid "Ch&oose..."
+msgstr "&Kies..."
+
+#: ../src/richtext/richtextbulletspage.cpp:223
+#: ../src/richtext/richtextbulletspage.cpp:225
+#: ../src/richtext/richtextliststylepage.cpp:284
+#: ../src/richtext/richtextliststylepage.cpp:286
+msgid "Click to browse for a symbol."
+msgstr "Klik om te soek vir 'n simbool."
+
+#: ../src/richtext/richtextbulletspage.cpp:230
+#: ../src/richtext/richtextliststylepage.cpp:291
+#, fuzzy
+msgid "Symbol &font:"
+msgstr "Normale lettertipe:"
+
+#: ../src/richtext/richtextbulletspage.cpp:235
+#: ../src/richtext/richtextbulletspage.cpp:237
+#: ../src/richtext/richtextliststylepage.cpp:297
+msgid "Available fonts."
+msgstr "Beskikbare lettertipes."
+
+#: ../src/richtext/richtextbulletspage.cpp:242
+#: ../src/richtext/richtextliststylepage.cpp:302
+msgid "S&tandard bullet name:"
+msgstr ""
+
+#: ../src/richtext/richtextbulletspage.cpp:247
+#: ../src/richtext/richtextbulletspage.cpp:249
+#: ../src/richtext/richtextliststylepage.cpp:307
+#: ../src/richtext/richtextliststylepage.cpp:309
+msgid "A standard bullet name."
+msgstr ""
+
+#: ../src/richtext/richtextbulletspage.cpp:254
+msgid "&Number:"
+msgstr ""
+
+#: ../src/richtext/richtextbulletspage.cpp:258
+#: ../src/richtext/richtextbulletspage.cpp:260
+msgid "The list item number."
+msgstr ""
+
+#: ../src/richtext/richtextbulletspage.cpp:266
+#: ../src/richtext/richtextbulletspage.cpp:268
+#: ../src/richtext/richtextliststylepage.cpp:475
+#: ../src/richtext/richtextliststylepage.cpp:477
+msgid "Shows a preview of the bullet settings."
+msgstr ""
+
+#: ../src/richtext/richtextbulletspage.cpp:276
+#: ../src/richtext/richtextliststylepage.cpp:484
+msgid "(None)"
+msgstr "(Geen)"
+
+#: ../src/richtext/richtextbulletspage.cpp:277
+#: ../src/richtext/richtextliststylepage.cpp:485
+msgid "Arabic"
+msgstr "Arabies (gewone syfers)"
+
+#: ../src/richtext/richtextbulletspage.cpp:278
+#: ../src/richtext/richtextliststylepage.cpp:486
+msgid "Upper case letters"
+msgstr "Hoofletters"
+
+#: ../src/richtext/richtextbulletspage.cpp:279
+#: ../src/richtext/richtextliststylepage.cpp:487
+msgid "Lower case letters"
+msgstr "Kleinletters"
+
+#: ../src/richtext/richtextbulletspage.cpp:280
+#: ../src/richtext/richtextliststylepage.cpp:488
+msgid "Upper case roman numerals"
+msgstr "Groot romeinse syfers"
+
+#: ../src/richtext/richtextbulletspage.cpp:281
+#: ../src/richtext/richtextliststylepage.cpp:489
+msgid "Lower case roman numerals"
+msgstr "Klein romeinse syfers"
+
+#: ../src/richtext/richtextbulletspage.cpp:282
+#: ../src/richtext/richtextliststylepage.cpp:490
+msgid "Numbered outline"
+msgstr ""
+
+#: ../src/richtext/richtextbulletspage.cpp:283
+#: ../src/richtext/richtextliststylepage.cpp:491
+msgid "Symbol"
+msgstr "Simbool"
+
+#: ../src/richtext/richtextbulletspage.cpp:284
+#: ../src/richtext/richtextliststylepage.cpp:492
+msgid "Bitmap"
+msgstr ""
+
+#: ../src/richtext/richtextbulletspage.cpp:285
+#: ../src/richtext/richtextliststylepage.cpp:493
+msgid "Standard"
+msgstr "Standaard"
+
+#: ../src/richtext/richtextbulletspage.cpp:287
+#: ../src/richtext/richtextliststylepage.cpp:495
+msgid "*"
+msgstr "*"
+
+#: ../src/richtext/richtextbulletspage.cpp:288
+#: ../src/richtext/richtextliststylepage.cpp:496
+msgid "-"
+msgstr "-"
+
+#: ../src/richtext/richtextbulletspage.cpp:289
+#: ../src/richtext/richtextliststylepage.cpp:497
+msgid ">"
+msgstr ">"
+
+#: ../src/richtext/richtextbulletspage.cpp:290
+#: ../src/richtext/richtextliststylepage.cpp:498
+msgid "+"
+msgstr "+"
+
+#: ../src/richtext/richtextbulletspage.cpp:291
+#: ../src/richtext/richtextliststylepage.cpp:499
+msgid "~"
+msgstr "~"
+
+#: ../src/richtext/richtextctrl.cpp:859
+msgid "Drag"
+msgstr "Sleep"
+
+#: ../src/richtext/richtextctrl.cpp:1338 ../src/richtext/richtextctrl.cpp:1559
+msgid "Delete Text"
+msgstr "Skrap teks"
+
+#: ../src/richtext/richtextctrl.cpp:1537
+msgid "Remove Bullet"
+msgstr "Verwyder koeëltjie"
+
+#: ../src/richtext/richtextctrl.cpp:3070
+msgid "The text couldn't be saved."
+msgstr "Die teks kon nie gestoor word nie."
+
+#: ../src/richtext/richtextctrl.cpp:3644
+msgid "Replace"
+msgstr "Vervang"
+
+#: ../src/richtext/richtextfontpage.cpp:146
+#: ../src/richtext/richtextsymboldlg.cpp:384
+#, fuzzy
+msgid "&Font:"
+msgstr "Lettertipe-grootte:"
+
+#: ../src/richtext/richtextfontpage.cpp:150
+#: ../src/richtext/richtextfontpage.cpp:152
+msgid "Type a font name."
+msgstr ""
+
+#: ../src/richtext/richtextfontpage.cpp:158
+msgid "&Size:"
+msgstr "&Grootte:"
+
+#: ../src/richtext/richtextfontpage.cpp:165
+#: ../src/richtext/richtextfontpage.cpp:167
+msgid "Type a size in points."
+msgstr "Tik 'n grootte in punte."
+
+#: ../src/richtext/richtextfontpage.cpp:180
+#: ../src/richtext/richtextfontpage.cpp:182
+#, fuzzy
+msgid "The font size units, points or pixels."
+msgstr "fontgrootte"
+
+#: ../src/richtext/richtextfontpage.cpp:189
+#: ../src/richtext/richtextfontpage.cpp:191
+#, fuzzy
+msgid "Lists the available fonts."
+msgstr "Wenke is nie beskikbaar nie, jammer!"
+
+#: ../src/richtext/richtextfontpage.cpp:196
+#: ../src/richtext/richtextfontpage.cpp:198
+msgid "Lists font sizes in points."
+msgstr ""
+
+#: ../src/richtext/richtextfontpage.cpp:207
+#, fuzzy
+msgid "Font st&yle:"
+msgstr "Lettertipe-grootte:"
+
+#: ../src/richtext/richtextfontpage.cpp:212
+#: ../src/richtext/richtextfontpage.cpp:214
+msgid "Select regular or italic style."
+msgstr "Kies tussen gewone of kursiewe styl."
+
+#: ../src/richtext/richtextfontpage.cpp:220
+#, fuzzy
+msgid "Font &weight:"
+msgstr "agtste"
+
+#: ../src/richtext/richtextfontpage.cpp:225
+#: ../src/richtext/richtextfontpage.cpp:227
+msgid "Select regular or bold."
+msgstr "Kies tussen gewone of vetdruk."
+
+#: ../src/richtext/richtextfontpage.cpp:233
+msgid "&Underlining:"
+msgstr "&Onderstreep:"
+
+#: ../src/richtext/richtextfontpage.cpp:238
+#: ../src/richtext/richtextfontpage.cpp:240
+msgid "Select underlining or no underlining."
+msgstr "Kies met of sonder onderstreep."
+
+#: ../src/richtext/richtextfontpage.cpp:248
+msgid "&Colour:"
+msgstr "&Kleur:"
+
+#: ../src/richtext/richtextfontpage.cpp:253
+#: ../src/richtext/richtextfontpage.cpp:255
+msgid "Click to change the text colour."
+msgstr "Klik om die tekskleur te verander."
+
+#: ../src/richtext/richtextfontpage.cpp:261
+msgid "&Bg colour:"
+msgstr "&Agtergrondkleur:"
+
+#: ../src/richtext/richtextfontpage.cpp:266
+#: ../src/richtext/richtextfontpage.cpp:268
+msgid "Click to change the text background colour."
+msgstr "Kliek om die agtergrond kleur te verander."
+
+#: ../src/richtext/richtextfontpage.cpp:276
+#: ../src/richtext/richtextfontpage.cpp:278
+msgid "Check to show a line through the text."
+msgstr "Merk om 'n lyn deur die teks te wys."
+
+#: ../src/richtext/richtextfontpage.cpp:281
+msgid "Ca&pitals"
+msgstr "Hoof&letters"
+
+#: ../src/richtext/richtextfontpage.cpp:283
+#: ../src/richtext/richtextfontpage.cpp:285
+msgid "Check to show the text in capitals."
+msgstr "Merk om die teks in hoorletters te wys."
+
+#: ../src/richtext/richtextfontpage.cpp:288
+msgid "Small C&apitals"
+msgstr "&Klein hoofletters"
+
+#: ../src/richtext/richtextfontpage.cpp:290
+#: ../src/richtext/richtextfontpage.cpp:292
+msgid "Check to show the text in small capitals."
+msgstr "Merk om die teks in klein hoorletters te wys."
+
+#: ../src/richtext/richtextfontpage.cpp:295
+msgid "Supe&rscript"
+msgstr "Bosk&rif"
+
+#: ../src/richtext/richtextfontpage.cpp:297
+#: ../src/richtext/richtextfontpage.cpp:299
+msgid "Check to show the text in superscript."
+msgstr "Merk om die teks as boskrif te wys."
+
+#: ../src/richtext/richtextfontpage.cpp:302
+msgid "Subscrip&t"
+msgstr "Onde&rskrif"
+
+#: ../src/richtext/richtextfontpage.cpp:304
+#: ../src/richtext/richtextfontpage.cpp:306
+msgid "Check to show the text in subscript."
+msgstr "Merk om die teks as onderskrif te wys."
+
+#: ../src/richtext/richtextfontpage.cpp:312
+msgid "Rig&ht-to-left"
+msgstr ""
+
+#: ../src/richtext/richtextfontpage.cpp:314
+#: ../src/richtext/richtextfontpage.cpp:316
+#, fuzzy
+msgid "Check to indicate right-to-left text layout."
+msgstr "Klik om die tekskleur te verander."
+
+#: ../src/richtext/richtextfontpage.cpp:319
+msgid "Suppress hyphe&nation"
+msgstr ""
+
+#: ../src/richtext/richtextfontpage.cpp:321
+#: ../src/richtext/richtextfontpage.cpp:323
+msgid "Check to suppress hyphenation."
+msgstr ""
+
+#: ../src/richtext/richtextfontpage.cpp:329
+#: ../src/richtext/richtextfontpage.cpp:331
+msgid "Shows a preview of the font settings."
+msgstr ""
+
+#: ../src/richtext/richtextfontpage.cpp:348
+#: ../src/richtext/richtextfontpage.cpp:352
+#: ../src/richtext/richtextfontpage.cpp:356
+#: ../src/richtext/richtextformatdlg.cpp:873
+#: ../src/richtext/richtextindentspage.cpp:273
+#: ../src/richtext/richtextindentspage.cpp:285
+#: ../src/richtext/richtextindentspage.cpp:286
+#: ../src/richtext/richtextindentspage.cpp:310
+#: ../src/richtext/richtextindentspage.cpp:325
+#: ../src/richtext/richtextliststylepage.cpp:451
+#: ../src/richtext/richtextliststylepage.cpp:463
+#: ../src/richtext/richtextliststylepage.cpp:464
+msgid "(none)"
+msgstr "(geen)"
+
+#: ../src/richtext/richtextfontpage.cpp:349
+#: ../src/richtext/richtextfontpage.cpp:353
+msgid "Regular"
+msgstr "Gewoon"
+
+#: ../src/richtext/richtextfontpage.cpp:357
+msgid "Not underlined"
+msgstr "Nie onderstreep nie"
+
+#: ../src/richtext/richtextformatdlg.cpp:341
+msgid "Indents && Spacing"
+msgstr "Inkepe en spasiëring"
+
+#: ../src/richtext/richtextformatdlg.cpp:346
+msgid "Tabs"
+msgstr ""
+
+#: ../src/richtext/richtextformatdlg.cpp:351
+msgid "Bullets"
+msgstr "Koeëltjies"
+
+#: ../src/richtext/richtextformatdlg.cpp:356
+msgid "List Style"
+msgstr "Lysstyl"
+
+#: ../src/richtext/richtextformatdlg.cpp:366
+#: ../src/richtext/richtextmarginspage.cpp:170
+msgid "Margins"
+msgstr "Kantlyne"
+
+#: ../src/richtext/richtextformatdlg.cpp:371
+#, fuzzy
+msgid "Borders"
+msgstr "Modern"
+
+#: ../src/richtext/richtextformatdlg.cpp:765
+msgid "Colour"
+msgstr "Kleur"
+
+#: ../src/richtext/richtextindentspage.cpp:127
+#: ../src/richtext/richtextliststylepage.cpp:322
+msgid "&Alignment"
+msgstr "&Belyning"
+
+#: ../src/richtext/richtextindentspage.cpp:138
+#: ../src/richtext/richtextliststylepage.cpp:331
+msgid "&Left"
+msgstr "&Links"
+
+#: ../src/richtext/richtextindentspage.cpp:140
+#: ../src/richtext/richtextindentspage.cpp:142
+#: ../src/richtext/richtextliststylepage.cpp:333
+#: ../src/richtext/richtextliststylepage.cpp:335
+msgid "Left-align text."
+msgstr "Belyn teks links."
+
+#: ../src/richtext/richtextindentspage.cpp:145
+#: ../src/richtext/richtextliststylepage.cpp:338
+msgid "&Right"
+msgstr "&Regs"
+
+#: ../src/richtext/richtextindentspage.cpp:147
+#: ../src/richtext/richtextindentspage.cpp:149
+#: ../src/richtext/richtextliststylepage.cpp:340
+#: ../src/richtext/richtextliststylepage.cpp:342
+msgid "Right-align text."
+msgstr "Belyn teks regs."
+
+#: ../src/richtext/richtextindentspage.cpp:152
+#: ../src/richtext/richtextliststylepage.cpp:345
+msgid "&Justified"
+msgstr "Al&kantbelyn"
+
+#: ../src/richtext/richtextindentspage.cpp:154
+#: ../src/richtext/richtextindentspage.cpp:156
+#: ../src/richtext/richtextliststylepage.cpp:347
+#: ../src/richtext/richtextliststylepage.cpp:349
+msgid "Justify text left and right."
+msgstr "Belyn teks links en regs."
+
+#: ../src/richtext/richtextindentspage.cpp:159
+#: ../src/richtext/richtextliststylepage.cpp:352
+msgid "Cen&tred"
+msgstr "Gesen&treer"
+
+#: ../src/richtext/richtextindentspage.cpp:161
+#: ../src/richtext/richtextindentspage.cpp:163
+#: ../src/richtext/richtextliststylepage.cpp:354
+#: ../src/richtext/richtextliststylepage.cpp:356
+msgid "Centre text."
+msgstr "Sentreer teks."
+
+#: ../src/richtext/richtextindentspage.cpp:166
+#: ../src/richtext/richtextliststylepage.cpp:359
+msgid "&Indeterminate"
+msgstr "N&ie gespesifiseer nie"
+
+#: ../src/richtext/richtextindentspage.cpp:168
+#: ../src/richtext/richtextindentspage.cpp:170
+#: ../src/richtext/richtextliststylepage.cpp:361
+#: ../src/richtext/richtextliststylepage.cpp:363
+msgid "Use the current alignment setting."
+msgstr "Gebruik die huidige instelling vir belyning."
+
+#: ../src/richtext/richtextindentspage.cpp:183
+#: ../src/richtext/richtextliststylepage.cpp:375
+msgid "&Indentation (tenths of a mm)"
+msgstr "&Inkeep (tiendes van 'n mm.)"
+
+#: ../src/richtext/richtextindentspage.cpp:198
+#: ../src/richtext/richtextindentspage.cpp:200
+#: ../src/richtext/richtextliststylepage.cpp:388
+#: ../src/richtext/richtextliststylepage.cpp:390
+msgid "The left indent."
+msgstr "Die linkerkeep"
+
+#: ../src/richtext/richtextindentspage.cpp:203
+#: ../src/richtext/richtextliststylepage.cpp:393
+msgid "Left (&first line):"
+msgstr "Links (&eerste lyn):"
+
+#: ../src/richtext/richtextindentspage.cpp:207
+#: ../src/richtext/richtextindentspage.cpp:209
+#: ../src/richtext/richtextliststylepage.cpp:397
+#: ../src/richtext/richtextliststylepage.cpp:399
+msgid "The first line indent."
+msgstr "Die eerste lyn se keep."
+
+#: ../src/richtext/richtextindentspage.cpp:216
+#: ../src/richtext/richtextindentspage.cpp:218
+#: ../src/richtext/richtextliststylepage.cpp:406
+#: ../src/richtext/richtextliststylepage.cpp:408
+msgid "The right indent."
+msgstr "Die regterkeep."
+
+#: ../src/richtext/richtextindentspage.cpp:221
+msgid "&Outline level:"
+msgstr ""
+
+#: ../src/richtext/richtextindentspage.cpp:226
+#: ../src/richtext/richtextindentspage.cpp:228
+#, fuzzy
+msgid "The outline level."
+msgstr "fontgrootte"
+
+#: ../src/richtext/richtextindentspage.cpp:241
+#: ../src/richtext/richtextliststylepage.cpp:420
+msgid "&Spacing (tenths of a mm)"
+msgstr "&Spasiëring (tiendes van 'n mm.):"
+
+#: ../src/richtext/richtextindentspage.cpp:252
+msgid "&Before a paragraph:"
+msgstr "&Voor 'n paragraaf:"
+
+#: ../src/richtext/richtextindentspage.cpp:256
+#: ../src/richtext/richtextindentspage.cpp:258
+#: ../src/richtext/richtextliststylepage.cpp:433
+#: ../src/richtext/richtextliststylepage.cpp:435
+msgid "The spacing before the paragraph."
+msgstr "Die spasiëring voor die paragraaf."
+
+#: ../src/richtext/richtextindentspage.cpp:261
+msgid "&After a paragraph:"
+msgstr "N&a 'n paragraaf:"
+
+#: ../src/richtext/richtextindentspage.cpp:266
+#: ../src/richtext/richtextliststylepage.cpp:442
+#: ../src/richtext/richtextliststylepage.cpp:444
+msgid "The spacing after the paragraph."
+msgstr "Die spasiëring ná die paragraaf."
+
+#: ../src/richtext/richtextindentspage.cpp:269
+msgid "L&ine spacing:"
+msgstr "&Lynspasiëring:"
+
+#: ../src/richtext/richtextindentspage.cpp:274
+#: ../src/richtext/richtextliststylepage.cpp:452
+msgid "Single"
+msgstr "Enkel"
+
+#: ../src/richtext/richtextindentspage.cpp:275
+#: ../src/richtext/richtextliststylepage.cpp:453
+msgid "1.1"
+msgstr "1,1"
+
+#: ../src/richtext/richtextindentspage.cpp:276
+#: ../src/richtext/richtextliststylepage.cpp:454
+msgid "1.2"
+msgstr "1,2"
+
+#: ../src/richtext/richtextindentspage.cpp:277
+#: ../src/richtext/richtextliststylepage.cpp:455
+msgid "1.3"
+msgstr "1,3"
+
+#: ../src/richtext/richtextindentspage.cpp:278
+#: ../src/richtext/richtextliststylepage.cpp:456
+msgid "1.4"
+msgstr "1,4"
+
+#: ../src/richtext/richtextindentspage.cpp:279
+#: ../src/richtext/richtextliststylepage.cpp:457
+msgid "1.5"
+msgstr "1,5"
+
+#: ../src/richtext/richtextindentspage.cpp:280
+#: ../src/richtext/richtextliststylepage.cpp:458
+msgid "1.6"
+msgstr "1,6"
+
+#: ../src/richtext/richtextindentspage.cpp:281
+#: ../src/richtext/richtextliststylepage.cpp:459
+msgid "1.7"
+msgstr "1,7"
+
+#: ../src/richtext/richtextindentspage.cpp:282
+#: ../src/richtext/richtextliststylepage.cpp:460
+msgid "1.8"
+msgstr "1,8"
+
+#: ../src/richtext/richtextindentspage.cpp:283
+#: ../src/richtext/richtextliststylepage.cpp:461
+msgid "1.9"
+msgstr "1,9"
+
+#: ../src/richtext/richtextindentspage.cpp:284
+#: ../src/richtext/richtextliststylepage.cpp:462
+msgid "2"
+msgstr "2"
+
+#: ../src/richtext/richtextindentspage.cpp:287
+#: ../src/richtext/richtextindentspage.cpp:289
+#: ../src/richtext/richtextliststylepage.cpp:465
+#: ../src/richtext/richtextliststylepage.cpp:467
+msgid "The line spacing."
+msgstr "Die lynspasiëring."
+
+#: ../src/richtext/richtextindentspage.cpp:292
+msgid "&Page Break"
+msgstr "&Bladsybreuk"
+
+#: ../src/richtext/richtextindentspage.cpp:294
+#: ../src/richtext/richtextindentspage.cpp:296
+msgid "Inserts a page break before the paragraph."
+msgstr "Voeg 'n bladsybreuk in voor die paragraaf."
+
+#: ../src/richtext/richtextindentspage.cpp:302
+#: ../src/richtext/richtextindentspage.cpp:304
+msgid "Shows a preview of the paragraph settings."
+msgstr "Wys 'n voorskou van die paragraafinstellings."
+
+#: ../src/richtext/richtextliststylepage.cpp:182
+msgid "&List level:"
+msgstr "&Lysvlak:"
+
+#: ../src/richtext/richtextliststylepage.cpp:186
+#: ../src/richtext/richtextliststylepage.cpp:188
+msgid "Selects the list level to edit."
+msgstr "Kies watter lysvlak om te redigeer."
+
+#: ../src/richtext/richtextliststylepage.cpp:193
+msgid "&Font for Level..."
+msgstr ""
+
+#: ../src/richtext/richtextliststylepage.cpp:194
+#: ../src/richtext/richtextliststylepage.cpp:196
+msgid "Click to choose the font for this level."
+msgstr ""
+
+#: ../src/richtext/richtextliststylepage.cpp:312
+msgid "Bullet style"
+msgstr "Koeëltjiestyl"
+
+#: ../src/richtext/richtextliststylepage.cpp:429
+msgid "Before a paragraph:"
+msgstr "Voor 'n paragraaf:"
+
+#: ../src/richtext/richtextliststylepage.cpp:438
+msgid "After a paragraph:"
+msgstr "Na 'n paragraaf:"
+
+#: ../src/richtext/richtextliststylepage.cpp:447
+msgid "Line spacing:"
+msgstr "Lynspasiëring:"
+
+#: ../src/richtext/richtextliststylepage.cpp:470
+msgid "Spacing"
+msgstr "Spasiëring"
+
+#: ../src/richtext/richtextmarginspage.cpp:193
+#: ../src/richtext/richtextmarginspage.cpp:195
+#, fuzzy
+msgid "The left margin size."
+msgstr "fontgrootte"
+
+#: ../src/richtext/richtextmarginspage.cpp:203
+#: ../src/richtext/richtextmarginspage.cpp:205
+msgid "Units for the left margin."
+msgstr ""
+
+#: ../src/richtext/richtextmarginspage.cpp:218
+#: ../src/richtext/richtextmarginspage.cpp:220
+#, fuzzy
+msgid "The right margin size."
+msgstr "fontgrootte"
+
+#: ../src/richtext/richtextmarginspage.cpp:228
+#: ../src/richtext/richtextmarginspage.cpp:230
+msgid "Units for the right margin."
+msgstr ""
+
+#: ../src/richtext/richtextmarginspage.cpp:241
+#: ../src/richtext/richtextmarginspage.cpp:243
+#, fuzzy
+msgid "The top margin size."
+msgstr "fontgrootte"
+
+#: ../src/richtext/richtextmarginspage.cpp:251
+#: ../src/richtext/richtextmarginspage.cpp:253
+#, fuzzy
+msgid "Units for the top margin."
+msgstr "Kan nie wag vir uitvoerdraad-beëindiging nie"
+
+#: ../src/richtext/richtextmarginspage.cpp:266
+#: ../src/richtext/richtextmarginspage.cpp:268
+#, fuzzy
+msgid "The bottom margin size."
+msgstr "fontgrootte"
+
+#: ../src/richtext/richtextmarginspage.cpp:276
+#: ../src/richtext/richtextmarginspage.cpp:278
+msgid "Units for the bottom margin."
+msgstr ""
+
+#: ../src/richtext/richtextmarginspage.cpp:284
+#, fuzzy
+msgid "Padding"
+msgstr "besig om te lees"
+
+#: ../src/richtext/richtextmarginspage.cpp:307
+#: ../src/richtext/richtextmarginspage.cpp:309
+#, fuzzy
+msgid "The left padding size."
+msgstr "fontgrootte"
+
+#: ../src/richtext/richtextmarginspage.cpp:317
+#: ../src/richtext/richtextmarginspage.cpp:319
+msgid "Units for the left padding."
+msgstr ""
+
+#: ../src/richtext/richtextmarginspage.cpp:332
+#: ../src/richtext/richtextmarginspage.cpp:334
+#, fuzzy
+msgid "The right padding size."
+msgstr "fontgrootte"
+
+#: ../src/richtext/richtextmarginspage.cpp:342
+#: ../src/richtext/richtextmarginspage.cpp:344
+msgid "Units for the right padding."
+msgstr ""
+
+#: ../src/richtext/richtextmarginspage.cpp:355
+#: ../src/richtext/richtextmarginspage.cpp:357
+#, fuzzy
+msgid "The top padding size."
+msgstr "fontgrootte"
+
+#: ../src/richtext/richtextmarginspage.cpp:365
+#: ../src/richtext/richtextmarginspage.cpp:367
+msgid "Units for the top padding."
+msgstr ""
+
+#: ../src/richtext/richtextmarginspage.cpp:380
+#: ../src/richtext/richtextmarginspage.cpp:382
+#, fuzzy
+msgid "The bottom padding size."
+msgstr "fontgrootte"
+
+#: ../src/richtext/richtextmarginspage.cpp:390
+#: ../src/richtext/richtextmarginspage.cpp:392
+msgid "Units for the bottom padding."
+msgstr ""
+
+#: ../src/richtext/richtextprint.cpp:592
+msgid " Preview"
+msgstr " Voorskou"
+
+#: ../src/richtext/richtextsizepage.cpp:228
+msgid "Floating"
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:243
+msgid "&Floating mode:"
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:252
+#: ../src/richtext/richtextsizepage.cpp:254
+msgid "How the object will float relative to the text."
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:265
+msgid "Alignment"
+msgstr "Belyning"
+
+#: ../src/richtext/richtextsizepage.cpp:277
+msgid "&Vertical alignment:"
+msgstr "&Vertikale belyning:"
+
+#: ../src/richtext/richtextsizepage.cpp:279
+#: ../src/richtext/richtextsizepage.cpp:281
+msgid "Enable vertical alignment."
+msgstr "Aktiveer vertikale belyning."
+
+#: ../src/richtext/richtextsizepage.cpp:286
+msgid "Centred"
+msgstr "Gesentreer"
+
+#: ../src/richtext/richtextsizepage.cpp:290
+#: ../src/richtext/richtextsizepage.cpp:292
+msgid "Vertical alignment."
+msgstr "Vertikale belyning"
+
+#: ../src/richtext/richtextsizepage.cpp:316
+#: ../src/richtext/richtextsizepage.cpp:323
+msgid "&Width:"
+msgstr "&Wydte:"
+
+#: ../src/richtext/richtextsizepage.cpp:318
+#: ../src/richtext/richtextsizepage.cpp:320
+msgid "Enable the width value."
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:331
+#: ../src/richtext/richtextsizepage.cpp:333
+msgid "The object width."
+msgstr "Die objekwydte."
+
+#: ../src/richtext/richtextsizepage.cpp:342
+#: ../src/richtext/richtextsizepage.cpp:344
+msgid "Units for the object width."
+msgstr "Eenhede vir die objekwydte."
+
+#: ../src/richtext/richtextsizepage.cpp:350
+#: ../src/richtext/richtextsizepage.cpp:357
+msgid "&Height:"
+msgstr "&Hoogte:"
+
+#: ../src/richtext/richtextsizepage.cpp:352
+#: ../src/richtext/richtextsizepage.cpp:354
+#: ../src/richtext/richtextsizepage.cpp:464
+#: ../src/richtext/richtextsizepage.cpp:466
+msgid "Enable the height value."
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:365
+#: ../src/richtext/richtextsizepage.cpp:367
+msgid "The object height."
+msgstr "Die objekhoogte."
+
+#: ../src/richtext/richtextsizepage.cpp:376
+#: ../src/richtext/richtextsizepage.cpp:378
+msgid "Units for the object height."
+msgstr "Eenhede vir die objekhoogte."
+
+#: ../src/richtext/richtextsizepage.cpp:381
+msgid "Min width:"
+msgstr "Minimum wydte:"
+
+#: ../src/richtext/richtextsizepage.cpp:383
+#: ../src/richtext/richtextsizepage.cpp:385
+#, fuzzy
+msgid "Enable the minimum width value."
+msgstr "Kon nie begin met drukwerk nie."
+
+#: ../src/richtext/richtextsizepage.cpp:392
+#: ../src/richtext/richtextsizepage.cpp:394
+msgid "The object minimum width."
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:403
+#: ../src/richtext/richtextsizepage.cpp:405
+msgid "Units for the minimum object width."
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:408
+msgid "Min height:"
+msgstr "Minimum hoogte:"
+
+#: ../src/richtext/richtextsizepage.cpp:410
+#: ../src/richtext/richtextsizepage.cpp:412
+msgid "Enable the minimum height value."
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:419
+#: ../src/richtext/richtextsizepage.cpp:421
+msgid "The object minimum height."
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:430
+#: ../src/richtext/richtextsizepage.cpp:432
+msgid "Units for the minimum object height."
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:435
+msgid "Max width:"
+msgstr "Maksimum wydte:"
+
+#: ../src/richtext/richtextsizepage.cpp:437
+#: ../src/richtext/richtextsizepage.cpp:439
+#, fuzzy
+msgid "Enable the maximum width value."
+msgstr "Kon nie begin met drukwerk nie."
+
+#: ../src/richtext/richtextsizepage.cpp:446
+#: ../src/richtext/richtextsizepage.cpp:448
+#, fuzzy
+msgid "The object maximum width."
+msgstr "fontgrootte"
+
+#: ../src/richtext/richtextsizepage.cpp:457
+#: ../src/richtext/richtextsizepage.cpp:459
+#, fuzzy
+msgid "Units for the maximum object width."
+msgstr "fontgrootte"
+
+#: ../src/richtext/richtextsizepage.cpp:462
+#, fuzzy
+msgid "Max height:"
+msgstr "agtste"
+
+#: ../src/richtext/richtextsizepage.cpp:473
+#: ../src/richtext/richtextsizepage.cpp:475
+#, fuzzy
+msgid "The object maximum height."
+msgstr "fontgrootte"
+
+#: ../src/richtext/richtextsizepage.cpp:484
+#: ../src/richtext/richtextsizepage.cpp:486
+msgid "Units for the maximum object height."
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:495
+msgid "Position"
+msgstr "Posisie"
+
+#: ../src/richtext/richtextsizepage.cpp:513
+msgid "&Position mode:"
+msgstr "&Posisiemodus:"
+
+#: ../src/richtext/richtextsizepage.cpp:517
+#: ../src/richtext/richtextsizepage.cpp:522
+msgid "Static"
+msgstr "Staties"
+
+#: ../src/richtext/richtextsizepage.cpp:518
+msgid "Relative"
+msgstr "Relatief"
+
+#: ../src/richtext/richtextsizepage.cpp:519
+msgid "Absolute"
+msgstr "Absoluut"
+
+#: ../src/richtext/richtextsizepage.cpp:520
+msgid "Fixed"
+msgstr "Vas"
+
+#: ../src/richtext/richtextsizepage.cpp:533
+#: ../src/richtext/richtextsizepage.cpp:535
+#: ../src/richtext/richtextsizepage.cpp:547
+#: ../src/richtext/richtextsizepage.cpp:549
+#, fuzzy
+msgid "The left position."
+msgstr "fontgrootte"
+
+#: ../src/richtext/richtextsizepage.cpp:558
+#: ../src/richtext/richtextsizepage.cpp:560
+#, fuzzy
+msgid "Units for the left position."
+msgstr "Kan nie wag vir uitvoerdraad-beëindiging nie"
+
+#: ../src/richtext/richtextsizepage.cpp:568
+#: ../src/richtext/richtextsizepage.cpp:570
+#: ../src/richtext/richtextsizepage.cpp:582
+#: ../src/richtext/richtextsizepage.cpp:584
+#, fuzzy
+msgid "The top position."
+msgstr "fontgrootte"
+
+#: ../src/richtext/richtextsizepage.cpp:593
+#: ../src/richtext/richtextsizepage.cpp:595
+#, fuzzy
+msgid "Units for the top position."
+msgstr "Kan nie wag vir uitvoerdraad-beëindiging nie"
+
+#: ../src/richtext/richtextsizepage.cpp:603
+#: ../src/richtext/richtextsizepage.cpp:605
+#: ../src/richtext/richtextsizepage.cpp:617
+#: ../src/richtext/richtextsizepage.cpp:619
+#, fuzzy
+msgid "The right position."
+msgstr "fontgrootte"
+
+#: ../src/richtext/richtextsizepage.cpp:628
+#: ../src/richtext/richtextsizepage.cpp:630
+#, fuzzy
+msgid "Units for the right position."
+msgstr "Kan nie wag vir uitvoerdraad-beëindiging nie"
+
+#: ../src/richtext/richtextsizepage.cpp:638
+#: ../src/richtext/richtextsizepage.cpp:640
+#: ../src/richtext/richtextsizepage.cpp:652
+#: ../src/richtext/richtextsizepage.cpp:654
+#, fuzzy
+msgid "The bottom position."
+msgstr "fontgrootte"
+
+#: ../src/richtext/richtextsizepage.cpp:663
+#: ../src/richtext/richtextsizepage.cpp:665
+#, fuzzy
+msgid "Units for the bottom position."
+msgstr "Kan nie wag vir uitvoerdraad-beëindiging nie"
+
+#: ../src/richtext/richtextsizepage.cpp:671
+msgid "&Move the object to:"
+msgstr "&Skuif die objek na:"
+
+#: ../src/richtext/richtextsizepage.cpp:674
+msgid "&Previous Paragraph"
+msgstr "Vorige &paragraaf"
+
+#: ../src/richtext/richtextsizepage.cpp:675
+#: ../src/richtext/richtextsizepage.cpp:677
+msgid "Moves the object to the previous paragraph."
+msgstr "Skuif die objek na die vorige paragraaf."
+
+#: ../src/richtext/richtextsizepage.cpp:680
+msgid "&Next Paragraph"
+msgstr "Volge&nde paragraaf"
+
+#: ../src/richtext/richtextsizepage.cpp:681
+#: ../src/richtext/richtextsizepage.cpp:683
+msgid "Moves the object to the next paragraph."
+msgstr "Skuif die objek na die volgende paragraaf."
+
+#: ../src/richtext/richtextstyledlg.cpp:193
+msgid "&Styles:"
+msgstr "&Style:"
+
+#: ../src/richtext/richtextstyledlg.cpp:197
+#: ../src/richtext/richtextstyledlg.cpp:199
+msgid "The available styles."
+msgstr "Die beskikbare style."
+
+#: ../src/richtext/richtextstyledlg.cpp:205
+#: ../src/richtext/richtextstyledlg.cpp:217
+msgid " "
+msgstr " "
+
+#: ../src/richtext/richtextstyledlg.cpp:209
+#: ../src/richtext/richtextstyledlg.cpp:211
+msgid "The style preview."
+msgstr "Die stylvoorskou."
+
+#: ../src/richtext/richtextstyledlg.cpp:220
+msgid "New &Character Style..."
+msgstr "Nuwe &karakterstyl..."
+
+#: ../src/richtext/richtextstyledlg.cpp:221
+#: ../src/richtext/richtextstyledlg.cpp:223
+msgid "Click to create a new character style."
+msgstr "Klik om 'n nuwe karakterstyl te skep."
+
+#: ../src/richtext/richtextstyledlg.cpp:226
+msgid "New &Paragraph Style..."
+msgstr "Nuwe &paragraafstyl..."
+
+#: ../src/richtext/richtextstyledlg.cpp:227
+#: ../src/richtext/richtextstyledlg.cpp:229
+msgid "Click to create a new paragraph style."
+msgstr "Klik om 'n nuwe paragraafstyl te skep."
+
+#: ../src/richtext/richtextstyledlg.cpp:232
+msgid "New &List Style..."
+msgstr "Nuwe &lysstyl..."
+
+#: ../src/richtext/richtextstyledlg.cpp:233
+#: ../src/richtext/richtextstyledlg.cpp:235
+msgid "Click to create a new list style."
+msgstr "Klik om 'n nuwe lysstyl te skep."
+
+#: ../src/richtext/richtextstyledlg.cpp:238
+msgid "New &Box Style..."
+msgstr "Nuwe &boxstyl..."
+
+#: ../src/richtext/richtextstyledlg.cpp:239
+#: ../src/richtext/richtextstyledlg.cpp:241
+msgid "Click to create a new box style."
+msgstr "Klik om 'n nuwe boksstyl te skep."
+
+#: ../src/richtext/richtextstyledlg.cpp:246
+msgid "&Apply Style"
+msgstr "P&as styl toe"
+
+#: ../src/richtext/richtextstyledlg.cpp:247
+#: ../src/richtext/richtextstyledlg.cpp:249
+msgid "Click to apply the selected style."
+msgstr "Klik om die gekose styl toe te pas."
+
+#: ../src/richtext/richtextstyledlg.cpp:252
+msgid "&Rename Style..."
+msgstr "He&rnoem styl..."
+
+#: ../src/richtext/richtextstyledlg.cpp:253
+#: ../src/richtext/richtextstyledlg.cpp:255
+msgid "Click to rename the selected style."
+msgstr "Klik om die gekose styl te hernoem."
+
+#: ../src/richtext/richtextstyledlg.cpp:258
+msgid "&Edit Style..."
+msgstr "R&edigeer styl..."
+
+#: ../src/richtext/richtextstyledlg.cpp:259
+#: ../src/richtext/richtextstyledlg.cpp:261
+msgid "Click to edit the selected style."
+msgstr "Klik om die gekose styl te redigeer."
+
+#: ../src/richtext/richtextstyledlg.cpp:264
+msgid "&Delete Style..."
+msgstr "&Skrap styl..."
+
+#: ../src/richtext/richtextstyledlg.cpp:265
+#: ../src/richtext/richtextstyledlg.cpp:267
+msgid "Click to delete the selected style."
+msgstr "Klik om die gekose styl te skrap."
+
+#: ../src/richtext/richtextstyledlg.cpp:274
+#: ../src/richtext/richtextstyledlg.cpp:276
+msgid "Click to close this window."
+msgstr "Klik om dié venster te sluit."
+
+#: ../src/richtext/richtextstyledlg.cpp:282
+msgid "&Restart numbering"
+msgstr "He&rbegin nommering"
+
+#: ../src/richtext/richtextstyledlg.cpp:284
+#: ../src/richtext/richtextstyledlg.cpp:286
+msgid "Check to restart numbering."
+msgstr "Merk om nommering te herbegin."
+
+#: ../src/richtext/richtextstyledlg.cpp:601
+msgid "Enter a character style name"
+msgstr "Tik 'n naam vir die karakterstyl"
+
+#: ../src/richtext/richtextstyledlg.cpp:601
+#: ../src/richtext/richtextstyledlg.cpp:606
+#: ../src/richtext/richtextstyledlg.cpp:649
+#: ../src/richtext/richtextstyledlg.cpp:654
+#: ../src/richtext/richtextstyledlg.cpp:815
+#: ../src/richtext/richtextstyledlg.cpp:820
+#: ../src/richtext/richtextstyledlg.cpp:888
+#: ../src/richtext/richtextstyledlg.cpp:896
+#: ../src/richtext/richtextstyledlg.cpp:929
+#: ../src/richtext/richtextstyledlg.cpp:934
+msgid "New Style"
+msgstr "Nuwe styl"
+
+#: ../src/richtext/richtextstyledlg.cpp:606
+#: ../src/richtext/richtextstyledlg.cpp:654
+#: ../src/richtext/richtextstyledlg.cpp:820
+#: ../src/richtext/richtextstyledlg.cpp:896
+#: ../src/richtext/richtextstyledlg.cpp:934
+msgid "Sorry, that name is taken. Please choose another."
+msgstr "Jammer, daardie naam is gevat. Kies gerus 'n ander een."
+
+#: ../src/richtext/richtextstyledlg.cpp:649
+msgid "Enter a paragraph style name"
+msgstr "Tik 'n naam vir die paragraafstyl"
+
+#: ../src/richtext/richtextstyledlg.cpp:777
+#, c-format
+msgid "Delete style %s?"
+msgstr "Skrap styl %s?"
+
+#: ../src/richtext/richtextstyledlg.cpp:777
+msgid "Delete Style"
+msgstr "Skrap styl"
+
+#: ../src/richtext/richtextstyledlg.cpp:815
+msgid "Enter a list style name"
+msgstr "Tik 'n naam vir die lysstyl"
+
+#: ../src/richtext/richtextstyledlg.cpp:888
+msgid "Enter a new style name"
+msgstr "Tik 'n nuwe naam vir die styl"
+
+#: ../src/richtext/richtextstyledlg.cpp:929
+msgid "Enter a box style name"
+msgstr "Tik 'n naam vir die boksstyl"
+
+#: ../src/richtext/richtextstylepage.cpp:109
+#: ../src/richtext/richtextstylepage.cpp:111
+msgid "The style name."
+msgstr "Die stylnaam."
+
+#: ../src/richtext/richtextstylepage.cpp:114
+msgid "&Based on:"
+msgstr "Ge&baseer op:"
+
+#: ../src/richtext/richtextstylepage.cpp:119
+#: ../src/richtext/richtextstylepage.cpp:121
+msgid "The style on which this style is based."
+msgstr "Die styl waarop hierdie styl gebaseer is."
+
+#: ../src/richtext/richtextstylepage.cpp:124
+msgid "&Next style:"
+msgstr "&Volgende styl:"
+
+#: ../src/richtext/richtextstylepage.cpp:129
+#: ../src/richtext/richtextstylepage.cpp:131
+msgid "The default style for the next paragraph."
+msgstr "Die verstekstyl vir die volgende paragraaf."
+
+#: ../src/richtext/richtextstyles.cpp:1057
+msgid "All styles"
+msgstr "Alle style"
+
+#: ../src/richtext/richtextstyles.cpp:1058
+msgid "Paragraph styles"
+msgstr "Paragraafstyle"
+
+#: ../src/richtext/richtextstyles.cpp:1059
+msgid "Character styles"
+msgstr "Karakterstyle"
+
+#: ../src/richtext/richtextstyles.cpp:1060
+msgid "List styles"
+msgstr "Lysstyle"
+
+#: ../src/richtext/richtextstyles.cpp:1061
+msgid "Box styles"
+msgstr "Boksstyle"
+
+#: ../src/richtext/richtextsymboldlg.cpp:389
+#: ../src/richtext/richtextsymboldlg.cpp:391
+msgid "The font from which to take the symbol."
+msgstr ""
+
+#: ../src/richtext/richtextsymboldlg.cpp:396
+msgid "&Subset:"
+msgstr "&Substel:"
+
+#: ../src/richtext/richtextsymboldlg.cpp:401
+#: ../src/richtext/richtextsymboldlg.cpp:403
+msgid "Shows a Unicode subset."
+msgstr "Wys 'n Unicode-substel."
+
+#: ../src/richtext/richtextsymboldlg.cpp:412
+msgid "xxxx"
+msgstr ""
+
+#: ../src/richtext/richtextsymboldlg.cpp:417
+msgid "&Character code:"
+msgstr "&Karakterkode:"
+
+#: ../src/richtext/richtextsymboldlg.cpp:421
+#: ../src/richtext/richtextsymboldlg.cpp:423
+msgid "The character code."
+msgstr "Die karakterkode."
+
+#: ../src/richtext/richtextsymboldlg.cpp:428
+msgid "&From:"
+msgstr "&Van:"
+
+#: ../src/richtext/richtextsymboldlg.cpp:433
+#: ../src/richtext/richtextsymboldlg.cpp:434
+#: ../src/richtext/richtextsymboldlg.cpp:435
+msgid "Unicode"
+msgstr "Unicode"
+
+#: ../src/richtext/richtextsymboldlg.cpp:436
+#: ../src/richtext/richtextsymboldlg.cpp:438
+msgid "The range to show."
+msgstr "Die omvang om te wys."
+
+#: ../src/richtext/richtextsymboldlg.cpp:444
+msgid "Insert"
+msgstr "Voeg in"
+
+#: ../src/richtext/richtextsymboldlg.cpp:478
+msgid "(Normal text)"
+msgstr "(Normale teks)"
+
+#: ../src/richtext/richtexttabspage.cpp:109
+msgid "&Position (tenths of a mm):"
+msgstr "&Posisie (tiendes van 'n mm.):"
+
+#: ../src/richtext/richtexttabspage.cpp:113
+#: ../src/richtext/richtexttabspage.cpp:115
+msgid "The tab position."
+msgstr "Die oortjieposisie."
+
+#: ../src/richtext/richtexttabspage.cpp:119
+msgid "The tab positions."
+msgstr "Die oortjieposisies."
+
+#: ../src/richtext/richtexttabspage.cpp:132
+#: ../src/richtext/richtexttabspage.cpp:134
+msgid "Click to create a new tab position."
+msgstr "Klik om 'n nuwe oortjieposisie te skep."
+
+#: ../src/richtext/richtexttabspage.cpp:138
+#: ../src/richtext/richtexttabspage.cpp:140
+msgid "Click to delete the selected tab position."
+msgstr "Klik om die gekose oortjieposisie te skrap."
+
+#: ../src/richtext/richtexttabspage.cpp:143
+msgid "Delete A&ll"
+msgstr "Skrap &almal"
+
+#: ../src/richtext/richtexttabspage.cpp:144
+#: ../src/richtext/richtexttabspage.cpp:146
+msgid "Click to delete all tab positions."
+msgstr "Skrap om alle oortjieposisies te skrap."
+
+#: ../src/univ/theme.cpp:110
+msgid "Failed to initialize GUI: no built-in themes found."
+msgstr "Initialisering van GUI het misluk: Geen ingeboude tema gevind nie."
+
+#: ../src/univ/themes/gtk.cpp:521
+msgid "GTK+ theme"
+msgstr "GTK+ tema"
+
+#: ../src/univ/themes/metal.cpp:164
+msgid "Metal theme"
+msgstr "Metaaltema"
+
+#: ../src/univ/themes/mono.cpp:512
+msgid "Simple monochrome theme"
+msgstr "Eenvoudige monochroomtema"
+
+#: ../src/univ/themes/win32.cpp:1098
+msgid "Win32 theme"
+msgstr "Win32-tema"
+
+#: ../src/univ/themes/win32.cpp:3743
+msgid "&Restore"
+msgstr "He&rstel"
+
+#: ../src/univ/themes/win32.cpp:3744
+msgid "&Move"
+msgstr "&Verskuif"
+
+#: ../src/univ/themes/win32.cpp:3746
+msgid "&Size"
+msgstr "&Grootte"
+
+#: ../src/univ/themes/win32.cpp:3748
+msgid "Mi&nimize"
+msgstr "Mi&nimaliseer"
+
+#: ../src/univ/themes/win32.cpp:3750
+msgid "Ma&ximize"
+msgstr "Ma&ksimaliseer"
+
+#: ../src/univ/themes/win32.cpp:3752
+msgid "Alt+"
+msgstr "Alt+"
+
+#: ../src/unix/appunix.cpp:178
+#, fuzzy
+msgid "Failed to install signal handler"
+msgstr "Toemaak van lêer het misluk."
+
+#: ../src/unix/dialup.cpp:351
+msgid "Already dialling ISP."
+msgstr "Reeds besig om ISP te bel."
+
+#: ../src/unix/dlunix.cpp:93
+#, fuzzy
+msgid "Failed to unload shared library"
+msgstr "Laai van gedeelde biblioteek '%s' het misluk"
+
+#: ../src/unix/dlunix.cpp:121
+msgid "Unknown dynamic library error"
+msgstr ""
+
+#: ../src/unix/epolldispatcher.cpp:84
+#, fuzzy
+msgid "Failed to create epoll descriptor"
+msgstr "Wyser kon nie geskep word nie."
+
+#: ../src/unix/epolldispatcher.cpp:103
+#, fuzzy
+msgid "Error closing epoll descriptor"
+msgstr "Fout tydens skepping van gids"
+
+#: ../src/unix/epolldispatcher.cpp:116
+#, fuzzy, c-format
+msgid "Failed to add descriptor %d to epoll descriptor %d"
+msgstr "kan nie skryf na lêeretiket %d nie"
+
+#: ../src/unix/epolldispatcher.cpp:136
+#, c-format
+msgid "Failed to modify descriptor %d in epoll descriptor %d"
+msgstr ""
+
+#: ../src/unix/epolldispatcher.cpp:155
+#, fuzzy, c-format
+msgid "Failed to unregister descriptor %d from epoll descriptor %d"
+msgstr "Onttrekking van data uit knipbord het misluk"
+
+#: ../src/unix/epolldispatcher.cpp:213
+#, fuzzy, c-format
+msgid "Waiting for IO on epoll descriptor %d failed"
+msgstr "Kon nie wag vir beëindiging van subproses nie"
+
+#: ../src/unix/fswatcher_inotify.cpp:71
+#, fuzzy
+msgid "Unable to create inotify instance"
+msgstr "Skepping van DDE-string het misluk"
+
+#: ../src/unix/fswatcher_inotify.cpp:94
+#, fuzzy
+msgid "Unable to close inotify instance"
+msgstr "Toemaak van lêer het misluk."
+
+#: ../src/unix/fswatcher_inotify.cpp:106
+msgid "Unable to add inotify watch"
+msgstr ""
+
+#: ../src/unix/fswatcher_inotify.cpp:138
+#, fuzzy, c-format
+msgid "Unable to remove inotify watch %i"
+msgstr "Skepping van DDE-string het misluk"
+
+#: ../src/unix/fswatcher_inotify.cpp:271
+#, c-format
+msgid "Unexpected event for \"%s\": no matching watch descriptor."
+msgstr ""
+
+#: ../src/unix/fswatcher_inotify.cpp:320
+#, c-format
+msgid "Invalid inotify event for \"%s\""
+msgstr ""
+
+#: ../src/unix/fswatcher_inotify.cpp:553
+#, fuzzy
+msgid "Unable to read from inotify descriptor"
+msgstr "kan nie lees van lêeretiket %d"
+
+#: ../src/unix/fswatcher_inotify.cpp:558
+#, fuzzy
+msgid "EOF while reading from inotify descriptor"
+msgstr "kan nie lees van lêeretiket %d"
+
+#: ../src/unix/fswatcher_kqueue.cpp:114
+#, fuzzy
+msgid "Unable to create kqueue instance"
+msgstr "Skepping van DDE-string het misluk"
+
+#: ../src/unix/fswatcher_kqueue.cpp:131
+#, fuzzy
+msgid "Error closing kqueue instance"
+msgstr "Fout tydens skepping van gids"
+
+#: ../src/unix/fswatcher_kqueue.cpp:153
+msgid "Unable to add kqueue watch"
+msgstr ""
+
+#: ../src/unix/fswatcher_kqueue.cpp:170
+msgid "Unable to remove kqueue watch"
+msgstr ""
+
+#: ../src/unix/fswatcher_kqueue.cpp:202
+msgid "Unable to get events from kqueue"
+msgstr ""
+
+#: ../src/unix/mediactrl.cpp:966
+#, c-format
+msgid "Media playback error: %s"
+msgstr ""
+
+#: ../src/unix/mediactrl.cpp:1228
+#, c-format
+msgid "Failed to prepare playing \"%s\"."
+msgstr "Voorbereiding vir speel van \"%s\" het misluk."
+
+#: ../src/unix/snglinst.cpp:164
+#, c-format
+msgid "Failed to write to lock file '%s'"
+msgstr "Skryfbewerking na slotlêer '%s' het misluk"
+
+#: ../src/unix/snglinst.cpp:177
+#, fuzzy, c-format
+msgid "Failed to set permissions on lock file '%s'"
+msgstr "Onmoontlik om magtigings vir lêer '%s' op te stel"
+
+#: ../src/unix/snglinst.cpp:194
+#, c-format
+msgid "Failed to lock the lock file '%s'"
+msgstr "Sluiting van die slotlêer '%s' het misluk"
+
+#: ../src/unix/snglinst.cpp:237
+#, fuzzy, c-format
+msgid "Failed to inspect the lock file '%s'"
+msgstr "Sluiting van die slotlêer '%s' het misluk"
+
+#: ../src/unix/snglinst.cpp:242
+#, fuzzy, c-format
+msgid "Lock file '%s' has incorrect owner."
+msgstr "Klanklêer '%s' se formaat word nie ondersteun nie."
+
+#: ../src/unix/snglinst.cpp:247
+#, c-format
+msgid "Lock file '%s' has incorrect permissions."
+msgstr ""
+
+#: ../src/unix/snglinst.cpp:265
+msgid "Failed to access lock file."
+msgstr "Toegang na slotlêer het misluk."
+
+#: ../src/unix/snglinst.cpp:274
+msgid "Failed to read PID from lock file."
+msgstr "Inlees van PID vanuit slotlêer het misluk."
+
+#: ../src/unix/snglinst.cpp:284
+#, c-format
+msgid "Failed to remove stale lock file '%s'."
+msgstr "Verwydering van verouderd slotlêer '%s' het misluk."
+
+#: ../src/unix/snglinst.cpp:297
+#, c-format
+msgid "Deleted stale lock file '%s'."
+msgstr "Verouderde slot-lêer '%s' is geskrap."
+
+#: ../src/unix/snglinst.cpp:308
+#, c-format
+msgid "Invalid lock file '%s'."
+msgstr "Ongeldig slotlêer '%s'."
+
+#: ../src/unix/snglinst.cpp:324
+#, c-format
+msgid "Failed to remove lock file '%s'"
+msgstr "Verwydering van slotlêer '%s' het misluk"
+
+#: ../src/unix/snglinst.cpp:330
+#, c-format
+msgid "Failed to unlock lock file '%s'"
+msgstr "Oopsluit van die slotlêer '%s' het misluk"
+
+#: ../src/unix/snglinst.cpp:336
+#, c-format
+msgid "Failed to close lock file '%s'"
+msgstr "Toemaak van slotlêer '%s' het misluk"
+
+#: ../src/unix/sound.cpp:77
+msgid "No sound"
+msgstr "Geen klank"
+
+#: ../src/unix/sound.cpp:364
+msgid "Unable to play sound asynchronously."
+msgstr "Klank kan nie asinkronies gespeel word nie."
+
+#: ../src/unix/sound.cpp:458
+#, c-format
+msgid "Couldn't load sound data from '%s'."
+msgstr "Kon nie klankdata vanaf '%s' laai nie."
+
+#: ../src/unix/sound.cpp:465
+#, c-format
+msgid "Sound file '%s' is in unsupported format."
+msgstr "Klanklêer '%s' se formaat word nie ondersteun nie."
+
+#: ../src/unix/sound.cpp:480
+msgid "Sound data are in unsupported format."
+msgstr "Klankdata se formaat word nie ondersteun nie."
+
+#: ../src/unix/sound_sdl.cpp:226
+#, c-format
+msgid "Couldn't open audio: %s"
+msgstr "Kan nie oudio oopmaak nie: %s"
+
+#: ../src/unix/threadpsx.cpp:1033
+msgid "Cannot retrieve thread scheduling policy."
+msgstr "Kan nie die uitvoerdraadskeduleringsbeleid verkry nie."
+
+#: ../src/unix/threadpsx.cpp:1058
+#, c-format
+msgid "Cannot get priority range for scheduling policy %d."
+msgstr ""
+"Kan nie die omvang van prioriteite bepaal vir skeduleringsbeleid %d nie."
+
+#: ../src/unix/threadpsx.cpp:1066
+msgid "Thread priority setting is ignored."
+msgstr "Uitvoerdraad-prioriteitstelling is geïgnoreer."
+
+#: ../src/unix/threadpsx.cpp:1221
+msgid ""
+"Failed to join a thread, potential memory leak detected - please restart the "
+"program"
+msgstr ""
+"Aansluiting by 'n uitvoerdraad het misluk, moontlik 'n geheuelekkasie "
+"teëgekom - herbegin die programma asb."
+
+#: ../src/unix/threadpsx.cpp:1352
+#, fuzzy, c-format
+msgid "Failed to set thread concurrency level to %lu"
+msgstr "Opstelling van prioriteit van thread %d het misluk."
+
+#: ../src/unix/threadpsx.cpp:1481
+#, c-format
+msgid "Failed to set thread priority %d."
+msgstr "Opstelling van prioriteit van thread %d het misluk."
+
+#: ../src/unix/threadpsx.cpp:1666
+msgid "Failed to terminate a thread."
+msgstr "Beëindiging van uitvoerdraad het misluk."
+
+#: ../src/unix/threadpsx.cpp:1893
+msgid "Thread module initialization failed: failed to create thread key"
+msgstr ""
+"Inisialisasie van uitvoerdraadmodule het misluk: 'n uitvoerdraad-sleutel kon "
+"nie geskep word nie"
+
+#: ../src/unix/utilsunx.cpp:340
+msgid "Impossible to get child process input"
+msgstr "Onmoontlik om subproses-toevoer te verkry"
+
+#: ../src/unix/utilsunx.cpp:390
+#, fuzzy
+msgid "Can't write to child process's stdin"
+msgstr "Process %d kon nie doodgemaak word nie"
+
+#: ../src/unix/utilsunx.cpp:644
+#, c-format
+msgid "Failed to execute '%s'\n"
+msgstr "Uitvoering van '%s' het misluk\n"
+
+#: ../src/unix/utilsunx.cpp:678
+msgid "Fork failed"
+msgstr "'Fork' het misluk"
+
+#: ../src/unix/utilsunx.cpp:701
+#, fuzzy
+msgid "Failed to set process priority"
+msgstr "Opstelling van prioriteit van thread %d het misluk."
+
+#: ../src/unix/utilsunx.cpp:712
+msgid "Failed to redirect child process input/output"
+msgstr "Herleiding van toevoer/afvoer van subproses het misluk"
+
+#: ../src/unix/utilsunx.cpp:816
+msgid "Failed to set up non-blocking pipe, the program might hang."
+msgstr ""
+
+#: ../src/unix/utilsunx.cpp:1023
+msgid "Cannot get the hostname"
+msgstr "Kan masjiennaam nie vasstel nie"
+
+#: ../src/unix/utilsunx.cpp:1059
+msgid "Cannot get the official hostname"
+msgstr "Kan die amptelike masjiennaam nie vasstel nie."
+
+#: ../src/unix/wakeuppipe.cpp:49
+#, fuzzy
+msgid "Failed to create wake up pipe used by event loop."
+msgstr "Skepping van stasb.lk het misluk."
+
+#: ../src/unix/wakeuppipe.cpp:56
+msgid "Failed to switch wake up pipe to non-blocking mode"
+msgstr ""
+
+#: ../src/unix/wakeuppipe.cpp:117
+#, fuzzy
+msgid "Failed to read from wake-up pipe"
+msgstr "Inlees van PID vanuit slotlêer het misluk."
+
+#: ../src/x11/app.cpp:124
+#, c-format
+msgid "Invalid geometry specification '%s'"
+msgstr "Ongeldige geometrie-spesifikasie '%s'"
+
+#: ../src/x11/app.cpp:167
+msgid "wxWidgets could not open display. Exiting."
+msgstr "wxWidgets kon vertoonskerm nie oopmaak nie. Gaan dus uit."
+
+#: ../src/x11/utils.cpp:169
+#, fuzzy, c-format
+msgid "Failed to close the display \"%s\""
+msgstr "Toemaak van knibord het misluk."
+
+#: ../src/x11/utils.cpp:188
+#, fuzzy, c-format
+msgid "Failed to open display \"%s\"."
+msgstr "Opening van '%s' vir %s het misluk"
+
+#: ../src/xml/xml.cpp:868
+#, c-format
+msgid "XML parsing error: '%s' at line %d"
+msgstr "XML-ontledingsfout: '%s' in lyn %d"
+
+#: ../src/xrc/xh_propgrid.cpp:239
+#, fuzzy, c-format
+msgid "Page %i"
+msgstr "Bladsy %d"
+
+#: ../src/xrc/xmlres.cpp:448
+#, c-format
+msgid "Cannot load resources from '%s'."
+msgstr "Kan hulpbronne nie uit '%s' laai nie."
+
+#: ../src/xrc/xmlres.cpp:799
+#, c-format
+msgid "Cannot open resources file '%s'."
+msgstr "Kan hulpbronlêer '%s' nie laai nie."
+
+#: ../src/xrc/xmlres.cpp:806
+#, c-format
+msgid "Cannot load resources from file '%s'."
+msgstr "Kan hulpbronne nie uit lêer '%s' laai nie."
+
+#: ../src/xrc/xmlres.cpp:2767
+#, fuzzy, c-format
+msgid "Creating %s \"%s\" failed."
+msgstr "Uitpak van '%s' binne-in '%s' het misluk."
+
+#~ msgctxt "keyboard key"
+#~ msgid "Alt+"
+#~ msgstr "Alt+"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Ctrl+"
+#~ msgstr "Ctrl+"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Shift+"
+#~ msgstr "Shift+"
+
+#~ msgctxt "keyboard key"
+#~ msgid "RawCtrl+"
+#~ msgstr "RawCtrl+"
+
+#~ msgid "Unsupported clipboard format."
+#~ msgstr "Nie-ondersteunde knipbord-formaat."
+
+#~ msgid "Background colour"
+#~ msgstr "Agtergrondkleur"
+
+#~ msgid "Font:"
+#~ msgstr "Lettertipe:"
+
+#~ msgid "Size:"
+#~ msgstr "Grootte:"
+
+#~ msgid "The font size in points."
+#~ msgstr "Lettergrootte in punte."
+
+#~ msgid "Style:"
+#~ msgstr "Styl:"
+
+#~ msgid "Check to make the font bold."
+#~ msgstr "Merk om die lettertipe vet te maak."
+
+#~ msgid "Check to make the font italic."
+#~ msgstr "Merk om die lettertipe kursief te maak."
+
+#~ msgid "Check to make the font underlined."
+#~ msgstr "Merk om die lettertipe te onderstreep."
+
+#~ msgid "Colour:"
+#~ msgstr "Kleur:"
+
+#~ msgid "Click to change the font colour."
+#~ msgstr "Klik om die tekskleur te verander."
+
+#~ msgid "Shows a preview of the font."
+#~ msgstr "Wys 'n voorskou van die lettertipe."
+
+#~ msgid "Click to cancel changes to the font."
+#~ msgstr "Klik om veranderinge aan die lettertipe te kanselleer."
+
+#~ msgid "Click to confirm changes to the font."
+#~ msgstr "Klik om veranderinge aan die lettertipe te bevestig."
+
+#~ msgid "<Any>"
+#~ msgstr "<Enige>"
+
+#, fuzzy
+#~ msgid "<Any Roman>"
+#~ msgstr "Roman"
+
+#, fuzzy
+#~ msgid "<Any Decorative>"
+#~ msgstr "Dekoratief"
+
+#, fuzzy
+#~ msgid "<Any Modern>"
+#~ msgstr "Modern"
+
+#, fuzzy
+#~ msgid "<Any Script>"
+#~ msgstr "Skrif-letter"
+
+#, fuzzy
+#~ msgid "<Any Swiss>"
+#~ msgstr "Switsers"
+
+#, fuzzy
+#~ msgid "<Any Teletype>"
+#~ msgstr "<Enige teletipe>"
+
+#~ msgid "Printing "
+#~ msgstr "Druk tans "
+
+#~ msgid "Failed to insert text in the control."
+#~ msgstr "Kon nie teks in die tekskontrole invoeg nie."
+
+#~ msgid "Please choose a valid font."
+#~ msgstr "Kies asb. 'n geldige lettertipe."
+
+#, c-format
+#~ msgid "Failed to display HTML document in %s encoding"
+#~ msgstr "Weergee van HTML-document in %s-kodering het misluk"
+
+#, c-format
+#~ msgid "wxWidgets could not open display for '%s': exiting."
+#~ msgstr "wxWidgets kon vertoonskerm nie oopmaak vir '%s' nie: gaan afsluit."
+
+#~ msgid "Filter"
+#~ msgstr "Filter"
+
+#~ msgid "Directories"
+#~ msgstr "Gidse"
+
+#~ msgid "Files"
+#~ msgstr "Lêers"
+
+#~ msgid "Selection"
+#~ msgstr "Seleksie"
+
+#, fuzzy
+#~ msgid "failed to retrieve execution result"
+#~ msgstr "Verkryging van teks van inbel-foutmelding het misluk"
+
+#~ msgid "&Save as"
+#~ msgstr "&Stoor as"
+
+#, fuzzy
+#~ msgid "'%s' doesn't consist only of valid characters"
+#~ msgstr "'%s' mag slegs letters bevat."
+
+#~ msgid "'%s' should be numeric."
+#~ msgstr "'%s' moet numeries wees."
+
+#~ msgid "'%s' should only contain ASCII characters."
+#~ msgstr "'%s' mag slegs ASCII-tekens bevat."
+
+#~ msgid "'%s' should only contain alphabetic characters."
+#~ msgstr "'%s' mag slegs letters bevat."
+
+#~ msgid "'%s' should only contain alphabetic or numeric characters."
+#~ msgstr "'%s' mag alleen alfa-numerieke tekens bevat."
+
+#, fuzzy
+#~ msgid "'%s' should only contain digits."
+#~ msgstr "'%s' mag slegs ASCII-tekens bevat."
+
+#~ msgid "Can't create window of class %s"
+#~ msgstr "Kan venster van klas '%s' nie skep nie"
+
+#, fuzzy
+#~ msgid "Couldn't create the overlay window"
+#~ msgstr "Kon nie 'n tydhouer skep nie"
+
+#, fuzzy
+#~ msgid "Couldn't init the context on the overlay window"
+#~ msgstr "Kon nie wyser na die huidige uitvoerdraad verkry nie"
+
+#~ msgid "Failed to convert file \"%s\" to Unicode."
+#~ msgstr "Omskakel van lêer \"%s\" na Unicode het misluk."
+
+#~ msgid "Failed to set text in the text control."
+#~ msgstr "Kon nie teks in die tekskontrole stel nie."
+
+#~ msgid "Invalid GTK+ command line option, use \"%s --help\""
+#~ msgstr "Ongeldige opdraglynkeuse vir GTK+. Gebruik \"%s --help\""
+
+#, fuzzy
+#~ msgid "No unused colour in image."
+#~ msgstr "Daar word geen ongebruikte kleur in die beeld uitgemasker nie"
+
+#~ msgid "Not available"
+#~ msgstr "Nie beskikbaar nie"
+
+#~ msgid "Replace selection"
+#~ msgstr "Vervang seleksie"
+
+#~ msgid "Save as"
+#~ msgstr "Stoor as"
+
+#~ msgid "Style Organiser"
+#~ msgstr "Stylorganiseerder"
+
+#~ msgid "The following standard GTK+ options are also supported:\n"
+#~ msgstr "Die volgende standaard-GTK+-keuses word ook ondersteun:\n"
+
+#, fuzzy
+#~ msgid "You cannot Clear an overlay that is not inited"
+#~ msgstr "Jy kan nie 'n nuwe gids by hierdie seksie voeg nie."
+
+#~ msgid "locale '%s' cannot be set."
+#~ msgstr "landinstelling '%s' kan nie opgestel word nie."
+
+#, fuzzy
+#~ msgid "Column index not found."
+#~ msgstr "katalogus-lêer vir domein '%s' nie gevind nie."
+
+#~ msgid "Confirm registry update"
+#~ msgstr "Bevestig registerbywerking"
+
+#, fuzzy
+#~ msgid "Could not determine column index."
+#~ msgstr "Kon drukvoorskou nie begin nie."
+
+#, fuzzy
+#~ msgid "Could not determine number of columns."
+#~ msgstr "Kon nie lêer '%s' opspoor nie."
+
+#, fuzzy
+#~ msgid "Could not determine number of items"
+#~ msgstr "Kon nie lêer '%s' opspoor nie."
+
+#, fuzzy
+#~ msgid "Could not get header description."
+#~ msgstr "Kon nie begin met drukwerk nie."
+
+#, fuzzy
+#~ msgid "Could not get items."
+#~ msgstr "Kon nie lêer '%s' opspoor nie."
+
+#, fuzzy
+#~ msgid "Could not get property flags."
+#~ msgstr "Kon nie tydelike lêer '%s'skep nie"
+
+#, fuzzy
+#~ msgid "Could not get selected items."
+#~ msgstr "Kon nie lêer '%s' opspoor nie."
+
+#, fuzzy
+#~ msgid "Could not remove column."
+#~ msgstr "Kon nie 'n wyser skep nie"
+
+#, fuzzy
+#~ msgid "Could not retrieve number of items"
+#~ msgstr "Kon nie tydelike lêer '%s'skep nie"
+
+#, fuzzy
+#~ msgid "Could not set column width."
+#~ msgstr "Kon drukvoorskou nie begin nie."
+
+#, fuzzy
+#~ msgid "Could not set header description."
+#~ msgstr "Kon nie begin met drukwerk nie."
+
+#, fuzzy
+#~ msgid "Could not set icon."
+#~ msgstr "Kon nie begin met drukwerk nie."
+
+#, fuzzy
+#~ msgid "Could not set maximum width."
+#~ msgstr "Kon nie begin met drukwerk nie."
+
+#, fuzzy
+#~ msgid "Could not set minimum width."
+#~ msgstr "Kon nie begin met drukwerk nie."
+
+#, fuzzy
+#~ msgid "Could not set property flags."
+#~ msgstr "Kon nie begin met drukwerk nie."
+
+#~ msgid ""
+#~ "Do you want to overwrite the command used to %s files with extension "
+#~ "\"%s\" ?\n"
+#~ "Current value is \n"
+#~ "%s, \n"
+#~ "New value is \n"
+#~ "%s %1"
+#~ msgstr ""
+#~ "Wil jy die '%s'-bevel wat gebruik word vir lêers met uitgang \"%s\" "
+#~ "verander?\n"
+#~ "Huidige waarde is \n"
+#~ "%s, \n"
+#~ "Nuwe waarde is \n"
+#~ "%s %1"
+
+#~ msgid "Failed to retrieve data from the clipboard."
+#~ msgstr "Onttrekking van data uit knipbord het misluk."
+
+#~ msgid "GIF: Invalid gif index."
+#~ msgstr "GIF: Ongeldige gif index."
+
+#~ msgid "GIF: unknown error!!!"
+#~ msgstr "GIF: onbekende fout!"
+
+#~ msgid "New directory"
+#~ msgstr "Nuwe gids"
+
+#~ msgid "Next"
+#~ msgstr "Volgende"
+
+#, fuzzy
+#~ msgid "Number of columns could not be determined."
+#~ msgstr "Lêer kon nie gelaai word nie."
+
+#~ msgid "OpenGL function \"%s\" failed: %s (error %d)"
+#~ msgstr "OpenGL-funksie \"%s\" het misluk: %s (fout %d)"
+
+#~ msgid ""
+#~ "Please install a newer version of comctl32.dll\n"
+#~ "(at least version 4.70 is required but you have %d.%02d)\n"
+#~ "or this program won't operate correctly."
+#~ msgstr ""
+#~ "Installeer asb. 'n nuwer weergawe van comctl32.dll\n"
+#~ "(Ten minste weergawe 4.70 is nodig, maar jy het %d.%02d)\n"
+#~ "anders kan hierdie program nie korrek funksioneer nie."
+
+#, fuzzy
+#~ msgid "Rendering failed."
+#~ msgstr "Opstel van tydhouer het misluk"
+
+#~ msgid "Show hidden directories"
+#~ msgstr "Wys verborge gidse"
+
+#~ msgid ""
+#~ "This system doesn't support date controls, please upgrade your version of "
+#~ "comctl32.dll"
+#~ msgstr ""
+#~ "Die stelsel ondersteun nie datumkontroles nie. Gradeer u weergawe van "
+#~ "comctl32.dll op."
+
+#~ msgid "Too many colours in PNG, the image may be slightly blurred."
+#~ msgstr "Te veel kleure in PNG, die beeld kan effens dof wees."
+
+#~ msgid "Unable to initialize Hildon program"
+#~ msgstr "Inisialisering van Hildon-program het misluk"
+
+#, fuzzy
+#~ msgid "Unknown data format"
+#~ msgstr "Onbekende dataformaat"
+
+#~ msgid "Win32s on Windows 3.1"
+#~ msgstr "Win32s op Windows 3.1"
+
+#, fuzzy
+#~ msgid "Windows 10"
+#~ msgstr "Windows 98"
+
+#~ msgid "Windows 2000"
+#~ msgstr "Windows 2000"
+
+#~ msgid "Windows 7"
+#~ msgstr "Windows 7"
+
+#, fuzzy
+#~ msgid "Windows 8"
+#~ msgstr "Windows 98"
+
+#, fuzzy
+#~ msgid "Windows 8.1"
+#~ msgstr "Windows 98"
+
+#~ msgid "Windows 95"
+#~ msgstr "Windows 95"
+
+#~ msgid "Windows 95 OSR2"
+#~ msgstr "Windows 95 OSR2"
+
+#~ msgid "Windows 98"
+#~ msgstr "Windows 98"
+
+#~ msgid "Windows 98 SE"
+#~ msgstr "Windows 98 SE"
+
+#~ msgid "Windows 9x (%d.%d)"
+#~ msgstr "Windows 9x (%d.%d)"
+
+#~ msgid "Windows CE (%d.%d)"
+#~ msgstr "Windows CE (%d.%d)"
+
+#~ msgid "Windows ME"
+#~ msgstr "Windows ME"
+
+#~ msgid "Windows NT %lu.%lu"
+#~ msgstr "Windows NT %lu.%lu"
+
+#, fuzzy
+#~ msgid "Windows Server 10"
+#~ msgstr "Windows Server 2003"
+
+#~ msgid "Windows Server 2003"
+#~ msgstr "Windows Server 2003"
+
+#~ msgid "Windows Server 2008"
+#~ msgstr "Windows Server 2008"
+
+#~ msgid "Windows Server 2008 R2"
+#~ msgstr "Windows Server 2008 R2"
+
+#, fuzzy
+#~ msgid "Windows Server 2012"
+#~ msgstr "Windows Server 2003"
+
+#, fuzzy
+#~ msgid "Windows Server 2012 R2"
+#~ msgstr "Windows Server 2008 R2"
+
+#~ msgid "Windows Vista"
+#~ msgstr "Windows Vista"
+
+#~ msgid "Windows XP"
+#~ msgstr "Windows XP"
+
+#~ msgid "can't execute '%s'"
+#~ msgstr "uitvoer van '%s' het misluk"
+
+#~ msgid "error opening '%s'"
+#~ msgstr "fout tydens oopmaak van '%s'"
+
+#~ msgid "unknown seek origin"
+#~ msgstr "onbekende beginpunt vir soektog"
+
+#~ msgid "Cannot create mutex."
+#~ msgstr "Kan nie wedersydse slot skep nie."
+
+#~ msgid "Cannot resume thread %lu"
+#~ msgstr "Kan nie uitvoerdraad %lu laat voortgaan nie"
+
+#~ msgid "Cannot suspend thread %lu"
+#~ msgstr "Kan nie uitvoerdraad %lu tydelik ophef nie"
+
+#~ msgid "Couldn't acquire a mutex lock"
+#~ msgstr "Kon nie 'n wedersydse slot bekom nie"
+
+#~ msgid "Couldn't release a mutex"
+#~ msgstr "Kon nie 'n wedersydse slot beskikbaar stel nie"
+
+#~ msgid "Execution of command '%s' failed with error: %ul"
+#~ msgstr "Uitvoering van opdrag '%s' het misluk met foutboodskap: %ul"
+
+#~ msgid ""
+#~ "File '%s' already exists.\n"
+#~ "Do you want to replace it?"
+#~ msgstr ""
+#~ "Lêer '%s' bestaan al.\n"
+#~ "Wil jy dit vervang?"
+
+#~ msgid "The print dialog returned an error."
+#~ msgstr "Die drukkerdialoog het met 'n fout geëindig."
+
+#~ msgid "The wxGtkPrinterDC cannot be used."
+#~ msgstr "Die wxGtkPrinterDC kan nie gebruik word nie."
+
+#~ msgid "Timer creation failed."
+#~ msgstr "Opstel van tydhouer het misluk"
+
+#~ msgid "not implemented"
+#~ msgstr "nie geïmplementeer nie"
+
+#~ msgid "wxPrintout::GetPageInfo gives a null maxPage."
+#~ msgstr "wxPrintout::GetPageInfo gee 'n maxPage van null."
+
+#~ msgid "percent"
+#~ msgstr "persent"
+
+#~ msgid "GetUnusedColour:: No Unused Color in image "
+#~ msgstr "GetUnusedColour: Daar is geen ongebruikte kleur in die beeld"
+
+#~ msgid "/#SYSTEM"
+#~ msgstr "/#SYSTEM"
+
+#~ msgid "Setup"
+#~ msgstr "Opstellings"
+
+#~ msgid "More..."
+#~ msgstr "Meer..."
+
+#, fuzzy
+#~ msgid ""
+#~ "can't seek on file descriptor %d, large files support is not enabled."
+#~ msgstr "kan nie 'n soekbewerking doen op lêeretiket %d nie"
+
+#~ msgid "ZIP handler currently supports only local files!"
+#~ msgstr "ZIP-hanteerder ondersteun tans slegs plaaslike lêers!"
+
+#~ msgid "Could not load Rich Edit DLL '%s'"
+#~ msgstr "Kon Rich Edit dll '%s' nie laai nie"
+
+#, fuzzy
+#~ msgid "Cannot wait on thread to exit."
+#~ msgstr "Kan nie wag vir uitvoerdraad-beëindiging nie"
+
+#~ msgid "Loading Grey Raw PNM image is not yet implemented."
+#~ msgstr ""
+#~ "Laaiing van Raw PNM-beeld met grysvlakke is nog nie geïmplementeer nie."
+
+#~ msgid "Loading Grey Ascii PNM image is not yet implemented."
+#~ msgstr ""
+#~ "Laaiing van Ascii PNM-beeld met grysvlakke is nog nie geïmplementeer nie."
+
+#, fuzzy
+#~ msgid ""
+#~ "Failed to get stack backtrace:\n"
+#~ "%s"
+#~ msgstr "ISP name %s kon nie verkry word nie"
+
+#~ msgid "underlined "
+#~ msgstr "onderstreep"
+
+#~ msgid "light "
+#~ msgstr "lig"
+
+#~ msgid "can't query for GUI plugins name in console applications"
+#~ msgstr "kan nie die GUI-inprop se naam in konsole-toepassings bepaal nie"
+
+#~ msgid "bold "
+#~ msgstr "vet"
+
+#~ msgid "Unknown field in file %s, line %d: '%s'."
+#~ msgstr "Onbekende veld in lêer %s, reël %d: '%s''. "
+
+#~ msgid "Mime.types file %s, line %d: unterminated quoted string."
+#~ msgstr "Mime.types-lêer %s, reël %d: onafgeslote aangehalingsteken."
+
+#~ msgid "Mailcap file %s, line %d: incomplete entry ignored."
+#~ msgstr "Mailcap-lêer %s, reël %d: onvolledige inskrywing geïgnoreer."
+
+#~ msgid "Failed to create directory %s/mime-info."
+#~ msgstr "Die gids %s/.mime-info kon nie geskep word nie."
+
+#~ msgid "Failed to create directory %s/.gnome."
+#~ msgstr "Die gids %s/.gnome kon nie geskep word nie."
+
+#~ msgid "Error "
+#~ msgstr "Fout "
+
+#~ msgid "Cannot open URL '%s'"
+#~ msgstr "Kan URL '%s' nie oopmaak nie"
+
+#~ msgid "."
+#~ msgstr "."
+
+#~ msgid "writing"
+#~ msgstr "besig om te skryf"
+
+#~ msgid "unknown line terminator"
+#~ msgstr "onbekende reëltermineerder"
+
+#~ msgid "invalid eof() return value."
+#~ msgstr "ongeldige eof() teruggee-waarde."
+
+#~ msgid "initiate"
+#~ msgstr "Begin"
+
+#~ msgid "establish"
+#~ msgstr "Maak"
+
+#~ msgid "Warning: attempt to remove HTML tag handler from empty stack."
+#~ msgstr ""
+#~ "Waarskuwing: poging om HTML-merkerhanteerder van leë stapel te verwyder."
+
+#~ msgid "Video Output"
+#~ msgstr "video-afvoer"
+
+#, fuzzy
+#~ msgid "Select all"
+#~ msgstr "Kies &almal"
+
+#~ msgid "Option '%s' requires a value, '=' expected."
+#~ msgstr "Opsie '%s' vereis 'n waarde, '=' verwag"
+
+#~ msgid "Long Conversions not supported"
+#~ msgstr "'long'-omskakelings word nie ondersteun nie"
+
+#, fuzzy
+#~ msgid "Icon resource specification %s not found."
+#~ msgstr "XRC-hulpbron '%s' (klas '%s') nie gevind nie!"
+
+#, fuzzy
+#~ msgid "Found "
+#~ msgstr "Soek"
+
+#~ msgid "Failed to load shared library '%s' Error '%s'"
+#~ msgstr "Laaiing van gedeelde biblioteek '%s' het misluk. Fout '%s'"
+
+#, fuzzy
+#~ msgid "Failed to get clipboard data."
+#~ msgstr "Opstelling van knipborddata het misluk."
+
+#, fuzzy
+#~ msgid "Couldn't end the context on the overlay window"
+#~ msgstr "Kon nie wyser na die huidige uitvoerdraad verkry nie"
+
+#, fuzzy
+#~ msgid "Bitmap resource specification %s not found."
+#~ msgstr "XRC-hulpbron '%s' (klas '%s') nie gevind nie!"
+
+#, fuzzy
+#~ msgid "&Print"
+#~ msgstr "Druk"
+
+#, fuzzy
+#~ msgid "&Open"
+#~ msgstr "&Open..."
+
+#, fuzzy
+#~ msgid " Couldn't create the UnicodeConverter"
+#~ msgstr "Kon nie 'n tydhouer skep nie"
+
+#~ msgid "|<<"
+#~ msgstr "|<<"
+
+#~ msgid "wxSocket: unknown event!."
+#~ msgstr "wxSocket: onbekende gebeurtenis!"
+
+#~ msgid "wxSocket: invalid signature in ReadMsg."
+#~ msgstr "wxSocket: ongeldige handtekening in ReadMsg."
+
+#~ msgid "looking for catalog '%s' in path '%s'."
+#~ msgstr "besig met soek vir katalogus '%s' in pad '%s'."
+
+#, fuzzy
+#~ msgid "encoding %i"
+#~ msgstr "enkodeer tans %s"
+
+#~ msgid "delegate has no type info"
+#~ msgstr "afgevaardigde het geen tipe-inligting nie"
+
+#~ msgid "catalog file for domain '%s' not found."
+#~ msgstr "katalogus-lêer vir domein '%s' nie gevind nie."
+
+#~ msgid "[EMPTY]"
+#~ msgstr "[LEEG]"
+
+#, fuzzy
+#~ msgid ""
+#~ "XRC resource: Incorrect colour specification '%s' for attribute '%s'."
+#~ msgstr "XRC-hulpbron: Ongeldige kleurspesifikasie '%s' vir eienskap '%s'."
+
+#~ msgid "XRC resource: Cannot create bitmap from '%s'."
+#~ msgstr "XRC-hulpbron: Kan nie 'n bitmap maak van '%s' nie."
+
+#, fuzzy
+#~ msgid "XRC resource: Cannot create animation from '%s'."
+#~ msgstr "XRC-hulpbron: Kan nie 'n bitmap maak van '%s' nie."
+
+#~ msgid "XRC resource '%s' (class '%s') not found!"
+#~ msgstr "XRC-hulpbron '%s' (klas '%s') nie gevind nie!"
+
+#~ msgid "Warning"
+#~ msgstr "Waarskuwing"
+
+#~ msgid "Unknown style flag "
+#~ msgstr "Onbekende stylvlag"
+
+#~ msgid "Trying to solve a NULL hostname: giving up"
+#~ msgstr "Poging om 'n leë masjiennaam te vind: besig om op te gee"
+
+#~ msgid "The path '%s' contains too many \"..\"!"
+#~ msgstr "Die pad '%s' bevat te veel \"..\"!"
+
+#~ msgid ""
+#~ "The file '%s' couldn't be opened.\n"
+#~ "It has been removed from the most recently used files list."
+#~ msgstr ""
+#~ "Die lêer '%s' kon nie oopgemaak word nie.\n"
+#~ "Dit is verwyder van die lys van 'onlangse lêers'."
+
+#~ msgid "Subclass '%s' not found for resource '%s', not subclassing!"
+#~ msgstr "Subclass '%s' nie gevind voor bron '%s', zal nie subclasseren!"
+
+#~ msgid "Status: "
+#~ msgstr "Status: "
+
+#~ msgid "Sorry, print preview needs a printer to be installed."
+#~ msgstr ""
+#~ "Jammer, 'n drukker moet geïnstalleer wees om 'n drukvoorskou te kan doen."
+
+#~ msgid "Sorry, could not save this file."
+#~ msgstr "Jammer, hierdie lêer kon nie gestoor word nie."
+
+#~ msgid "Sorry, could not open this file for saving."
+#~ msgstr "Jammer, hierdie lêer kon nie gestoor word nie."
+
+#, fuzzy
+#~ msgid "Search!"
+#~ msgstr "Soek"
+
+#~ msgid "Resource files must have same version number!"
+#~ msgstr "Hulpbronlêers moet dieselfde weergawenommer hê!"
+
+#~ msgid "Referenced object node with ref=\"%s\" not found!"
+#~ msgstr "Verwysde objeknode met ref=\"%s\" nie gevind nie!"
+
+#~ msgid "Program aborted."
+#~ msgstr "Program is laat vaar."
+
+#~ msgid "Passing a already registered object to SetObjectName"
+#~ msgstr "'n Reedsgeregistreerde objek word aangestuur vir SetObjectName"
+
+#, fuzzy
+#~ msgid "Passed item is invalid."
+#~ msgstr "'%s' is ongeldig"
+
+#, fuzzy
+#~ msgid "Owner not initialized."
+#~ msgstr "Kan vertoonskerm nie inisialiseer nie."
+
+#, fuzzy
+#~ msgid "No image handler for type %ld defined."
+#~ msgstr "Geen beeldhanteerder is vir die tipe %d gedefinieer nie."
+
+#~ msgid "No handler found for XML node '%s', class '%s'!"
+#~ msgstr "Geen hanteerder is gevind vir XML-node '%s', klas '%s' nie!"
+
+#~ msgid "Invalid XRC resource '%s': doesn't have root node 'resource'."
+#~ msgstr "Ongeldige XRC hulpbron '%s': het geen wortelnode 'hulpbron'."
+
+#~ msgid "Internal error, illegal wxCustomTypeInfo"
+#~ msgstr "Interne fout, ongeldige wxCustomTypeInfo"
+
+#, fuzzy
+#~ msgid "Help : %s"
+#~ msgstr "Hulp: %s"
+
+#~ msgid "Goto Page"
+#~ msgstr "Gaan na bladsy"
+
+#~ msgid "Fatal error: "
+#~ msgstr "Fatale fout: "
+
+#, fuzzy
+#~ msgid "Failed to register OpenGL window class."
+#~ msgstr "Inisialisering van OpenGL het misluk."
+
+#~ msgid "Failed to create a status bar."
+#~ msgstr "Skepping van stasb.lk het misluk."
+
+#, fuzzy
+#~ msgid "Could not unlock mutex"
+#~ msgstr "Kon nie 'n wedersydse slot beskikbaar stel nie"
+
+#, fuzzy
+#~ msgid "Click to cancel this window."
+#~ msgstr "Maak hierdie venster toe"
+
+#, fuzzy
+#~ msgid "Cant create the thread event queue"
+#~ msgstr "Kan uitvoerdraad nie skep nie"
+
+#~ msgid "Cannot parse dimension from '%s'."
+#~ msgstr "Kan dimensie van '%s' nie ontleed nie."
+
+#~ msgid "Cannot parse coordinates from '%s'."
+#~ msgstr "Kan koördinate van '%s' nie ontleed nie."
+
+#~ msgid "Cannot open file '%s'."
+#~ msgstr "Kan lêer '%s' nie oopmaak nie."
+
+#~ msgid "Cannot find font node '%s'."
+#~ msgstr "Kan lettertipenode '%s' nie vind nie."
+
+#~ msgid "Cannot find container for unknown control '%s'."
+#~ msgstr "Kan geen houer vind vir onbekende beheerelement '%s'."
+
+#~ msgid "Cannot convert from the charset '%s'!"
+#~ msgstr "Kan nie omskakel vanaf karakterstel '%s' nie!"
+
+#~ msgid "Cannot convert dialog units: dialog unknown."
+#~ msgstr "Dialoogeenhede kan nie omgeskakel word nie: dialoog is onbekend."
+
+#~ msgid "Can't load image from file '%s': file does not exist."
+#~ msgstr "Kan geen beeld laai uit lêer '%s': lêer bestaan nie."
+
+#~ msgid "Can't check image format of file '%s': file does not exist."
+#~ msgstr "Kan beeldstipe van lêer '%s' nie bepaal nie: lêer bestaan nie."
+
+#~ msgid ">>|"
+#~ msgstr ">>|"
+
+#~ msgid ">>"
+#~ msgstr ">>"
+
+#~ msgid "<<"
+#~ msgstr "<<"
+
+#~ msgid "&Goto..."
+#~ msgstr "&Gaan na..."
+
+#~ msgid "Paper Size"
+#~ msgstr "Papierformaat"
+
+#~ msgid "Mode %ix%i-%i not available."
+#~ msgstr "Modus %ix%i-%i nie beskikbaar nie."
+
+#~ msgid "Directory '%s' doesn't exist!"
+#~ msgstr "Gids '%s' bestaan nie!"
+
+#~ msgid "Couldn't create cursor."
+#~ msgstr "Kon nie 'n wyser skep nie"
+
+#~ msgid "Close\tAlt-F4"
+#~ msgstr "Sluit af\tAlt-F4"
+
+#~ msgid "Cannot start thread: error writing TLS"
+#~ msgstr "Kan uitvoerdraad nie begin nie: fout met skryf van TLS"
+
+#~ msgid "Cannot initialize display."
+#~ msgstr "Kan vertoonskerm nie inisialiseer nie."
+
+#~ msgid "Cannot initialize SciTech MGL!"
+#~ msgstr "Kan SciTech MGL nie inisialiseer nie!"
+
+#~ msgid "All files (*.*)|*"
+#~ msgstr "Alle lêers (*.*)|*"
+
+#, fuzzy
+#~ msgid "About "
+#~ msgstr "&Aangaande..."
+
+#~ msgid "&Save..."
+#~ msgstr "&Stoor..."
+
+#, fuzzy
+#~ msgid "Preview..."
+#~ msgstr "Drukvoorskou"
+
+#, fuzzy
+#~ msgid "&Preview..."
+#~ msgstr "Drukvoorskou"
+
+#, fuzzy
+#~ msgid "Print preview"
+#~ msgstr "Drukvoorskou"

--- a/po_wxstd/an.po
+++ b/po_wxstd/an.po
@@ -1,0 +1,10204 @@
+# WXWidgets in aragonese language
+# Copyright (C) 2013 THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# Traducción: Jorge Pérez Pérez <jorgtum@gmail.com>, 2013
+# Revisión: Juan Pablo Martínez <jpmart[arroba]unizar.es>, 2014.
+msgid ""
+msgstr ""
+"Project-Id-Version: wxWidgets 3.3\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-05-14 20:23+0200\n"
+"PO-Revision-Date: 2014-04-13 17:41+0100\n"
+"Last-Translator: Jorge Pérez Pérez <jorgtum@gmail.com>\n"
+"Language-Team: softaragonés\n"
+"Language: an\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Poedit 1.6.4\n"
+"X-Poedit-Bookmarks: -1,752,-1,-1,-1,-1,-1,-1,-1,-1\n"
+
+#: ../include/wx/defs.h:2582
+msgid "All files (*.*)|*.*"
+msgstr "Totz os fichers (*.*)|*"
+
+#: ../include/wx/defs.h:2585
+msgid "All files (*)|*"
+msgstr "Totz os fichers (*)|*"
+
+#: ../include/wx/generic/progdlgg.h:85
+msgid "Elapsed time:"
+msgstr "Tiempo transcorriu:"
+
+#: ../include/wx/generic/progdlgg.h:86
+msgid "Estimated time:"
+msgstr "Tiempo estimau:"
+
+#: ../include/wx/generic/progdlgg.h:87
+msgid "Remaining time:"
+msgstr "Tiempo restant:"
+
+#. TRANSLATORS: HTML printout default title.
+#: ../include/wx/html/htmprint.h:121 ../include/wx/prntbase.h:273
+#: ../include/wx/richtext/richtextprint.h:109 ../src/common/docview.cpp:2161
+msgid "Printout"
+msgstr "Impresión"
+
+#. TRANSLATORS: HTML easy print default title.
+#: ../include/wx/html/htmprint.h:234 ../include/wx/richtext/richtextprint.h:163
+#: ../src/common/prntbase.cpp:522 ../src/html/htmprint.cpp:291
+msgid "Printing"
+msgstr "Imprentando"
+
+#: ../include/wx/msgdlg.h:277 ../src/common/stockitem.cpp:211
+msgid "Yes"
+msgstr "Sí"
+
+#: ../include/wx/msgdlg.h:278 ../src/common/stockitem.cpp:182
+msgid "No"
+msgstr "No"
+
+#: ../include/wx/msgdlg.h:279 ../src/common/stockitem.cpp:183
+#: ../src/msw/msgdlg.cpp:430 ../src/msw/msgdlg.cpp:734
+#: ../src/richtext/richtextstyledlg.cpp:292
+msgid "OK"
+msgstr "Acceptar"
+
+#: ../include/wx/msgdlg.h:280 ../src/common/stockitem.cpp:150
+#: ../src/msw/msgdlg.cpp:430 ../src/msw/progdlg.cpp:884
+#: ../src/richtext/richtextstyledlg.cpp:295
+msgid "Cancel"
+msgstr "Cancelar"
+
+#: ../include/wx/msgdlg.h:281 ../src/common/stockitem.cpp:168
+#: ../src/html/helpdlg.cpp:63 ../src/html/helpfrm.cpp:108
+#: ../src/osx/button_osx.cpp:38
+msgid "Help"
+msgstr "Aduya"
+
+#: ../include/wx/msw/ole/oleutils.h:52
+msgid "Cannot initialize OLE"
+msgstr "No se puet inicializar l'OLE"
+
+#: ../include/wx/msw/private/fswatcher.h:48
+#, c-format
+msgid "Unable to close the handle for '%s'"
+msgstr "No s'ha puesto zarrar o maniador ta '%s'"
+
+#: ../include/wx/msw/private/fswatcher.h:92
+#, c-format
+msgid "Failed to open directory \"%s\" for monitoring."
+msgstr "No s'ha puesto ubrir o directorio \"%s\" ta monitorizar-lo."
+
+#: ../include/wx/msw/private/fswatcher.h:125
+msgid "Unable to close I/O completion port handle"
+msgstr ""
+"No s'ha puesto zarrar o maniador d'o puerto de dentrada/salida de rematanza"
+
+#: ../include/wx/msw/private/fswatcher.h:142
+msgid "Unable to associate handle with I/O completion port"
+msgstr ""
+"No s'ha puesto asociar o maniador con o puerto de dentrada/salida de "
+"rematanza"
+
+#: ../include/wx/msw/private/fswatcher.h:148
+msgid "Unexpectedly new I/O completion port was created"
+msgstr "S'ha creyau un nuevo puerto de dentrada/salida inasperadament"
+
+#: ../include/wx/msw/private/fswatcher.h:213
+msgid "Unable to post completion status"
+msgstr "No s'ha puesto publicar o estau de rematanza"
+
+#: ../include/wx/msw/private/fswatcher.h:262
+msgid "Unable to dequeue completion packet"
+msgstr "No s'ha puesto sacar d'a coda o paquet de rematanza"
+
+#: ../include/wx/msw/private/fswatcher.h:273
+msgid "Unable to create I/O completion port"
+msgstr "No s'ha puesto creyar o puerto de dentrada/salida de rematanza"
+
+#: ../include/wx/richmsgdlg.h:29
+msgid "&See details"
+msgstr "&Veyer os detalles"
+
+#: ../include/wx/richmsgdlg.h:30
+msgid "&Hide details"
+msgstr "&Amagar os detalles"
+
+#: ../include/wx/richtext/richtextbuffer.h:3864
+msgid "&Box"
+msgstr "&Caixa"
+
+#: ../include/wx/richtext/richtextbuffer.h:5008
+msgid "&Picture"
+msgstr "&Imachen"
+
+#: ../include/wx/richtext/richtextbuffer.h:5958
+msgid "&Cell"
+msgstr "&Celda"
+
+#: ../include/wx/richtext/richtextbuffer.h:6067
+msgid "&Table"
+msgstr "&Tabla"
+
+#: ../include/wx/richtext/richtextimagedlg.h:37
+msgid "Object Properties"
+msgstr "Propiedatz d'obchecto"
+
+#: ../include/wx/richtext/richtextsymboldlg.h:39
+msgid "Symbols"
+msgstr "Simbolos"
+
+#: ../include/wx/unix/pipe.h:46
+msgid "Pipe creation failed"
+msgstr "S'ha produciu una error en a creyación d'a canyería"
+
+#: ../include/wx/unix/private/displayx11.h:65
+msgid "Failed to enumerate video modes"
+msgstr "S'ha produciu una error en enumerar os modos de video"
+
+#: ../include/wx/unix/private/displayx11.h:89
+msgid "Failed to change video mode"
+msgstr "S'ha produciu una error en cambiar o modo de video"
+
+#: ../include/wx/unix/private/fswatcher_kqueue.h:57
+#, c-format
+msgid "Unable to open path '%s'"
+msgstr "No s'ha puesto ubrir a rota '%s'"
+
+#: ../include/wx/unix/private/fswatcher_kqueue.h:74
+#, c-format
+msgid "Unable to close path '%s'"
+msgstr "No s'ha puesto zarrar a rota '%s'"
+
+#: ../include/wx/xtiprop.h:175
+msgid "SetProperty called w/o valid setter"
+msgstr "S'ha clamau a SetProperty sin un establidor valido"
+
+#: ../include/wx/xtiprop.h:184
+msgid "GetProperty called w/o valid getter"
+msgstr "S'ha clamau a GetProperty sin un obtenedor valido"
+
+#: ../include/wx/xtiprop.h:193
+msgid "AddToPropertyCollection called w/o valid adder"
+msgstr "S'ha clamau a AddToPropertyCollection sin un adhibidor valiu"
+
+#: ../include/wx/xtiprop.h:202
+msgid "GetPropertyCollection called w/o valid collection getter"
+msgstr ""
+"S'ha clamau a GetPropertyCollection sin un obtenedor de colección valido"
+
+#: ../include/wx/xtiprop.h:255
+msgid "AddToPropertyCollection called on a generic accessor"
+msgstr "S'ha clamau a AddToPropertyCollection sobre un accedente chenerico"
+
+#: ../include/wx/xtiprop.h:262
+msgid "GetPropertyCollection called on a generic accessor"
+msgstr "S'ha clamau a GetPropertyCollection sobre un accedent chenerico"
+
+#: ../src/aui/tabmdi.cpp:106 ../src/generic/mdig.cpp:94
+msgid "Cl&ose"
+msgstr "&Zarrar"
+
+#: ../src/aui/tabmdi.cpp:107 ../src/generic/mdig.cpp:95
+msgid "Close All"
+msgstr "Zarrar-lo Tot"
+
+#: ../src/aui/tabmdi.cpp:109 ../src/generic/mdig.cpp:97 ../src/msw/mdi.cpp:175
+#: ../src/qt/mdi.cpp:258
+msgid "&Next"
+msgstr "&Siguient"
+
+#: ../src/aui/tabmdi.cpp:110 ../src/generic/mdig.cpp:98 ../src/msw/mdi.cpp:176
+#: ../src/qt/mdi.cpp:259
+msgid "&Previous"
+msgstr "&Anterior"
+
+#: ../src/aui/tabmdi.cpp:332 ../src/aui/tabmdi.cpp:348
+#: ../src/aui/tabmdi.cpp:350 ../src/generic/mdig.cpp:291
+#: ../src/generic/mdig.cpp:307 ../src/generic/mdig.cpp:311
+#: ../src/msw/mdi.cpp:337 ../src/qt/mdi.cpp:462
+msgid "&Window"
+msgstr "&Finestra"
+
+#: ../src/common/accelcmn.cpp:47
+msgctxt "keyboard key"
+msgid "Delete"
+msgstr "Eliminar"
+
+#: ../src/common/accelcmn.cpp:48
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Del"
+msgstr "Eliminar"
+
+#: ../src/common/accelcmn.cpp:49
+msgctxt "keyboard key"
+msgid "Back"
+msgstr "Dezaga"
+
+#: ../src/common/accelcmn.cpp:49
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Backspace"
+msgstr "Dezaga"
+
+#: ../src/common/accelcmn.cpp:50
+msgctxt "keyboard key"
+msgid "Insert"
+msgstr "Ficar"
+
+#: ../src/common/accelcmn.cpp:51
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Ins"
+msgstr "Interno"
+
+#: ../src/common/accelcmn.cpp:52
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Enter"
+msgstr "Impresora"
+
+#: ../src/common/accelcmn.cpp:53
+msgctxt "keyboard key"
+msgid "Return"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:54
+#, fuzzy
+msgctxt "keyboard key"
+msgid "PageUp"
+msgstr "Pachinas"
+
+#: ../src/common/accelcmn.cpp:54
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Page Up"
+msgstr "Pachina %d"
+
+#: ../src/common/accelcmn.cpp:55
+#, fuzzy
+msgctxt "keyboard key"
+msgid "PageDown"
+msgstr "Abaixo"
+
+#: ../src/common/accelcmn.cpp:55
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Page Down"
+msgstr "Pachina %d"
+
+#: ../src/common/accelcmn.cpp:56
+msgctxt "keyboard key"
+msgid "PgUp"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:57
+msgctxt "keyboard key"
+msgid "PgDn"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:58
+msgctxt "keyboard key"
+msgid "Left"
+msgstr "Cucha"
+
+#: ../src/common/accelcmn.cpp:59
+msgctxt "keyboard key"
+msgid "Right"
+msgstr "Dreita"
+
+#: ../src/common/accelcmn.cpp:60
+msgctxt "keyboard key"
+msgid "Up"
+msgstr "Alto"
+
+#: ../src/common/accelcmn.cpp:61
+msgctxt "keyboard key"
+msgid "Down"
+msgstr "Abaixo"
+
+#: ../src/common/accelcmn.cpp:62
+msgctxt "keyboard key"
+msgid "Home"
+msgstr "Inicio"
+
+#: ../src/common/accelcmn.cpp:63
+msgctxt "keyboard key"
+msgid "End"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:64
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Space"
+msgstr "Espaciau"
+
+#: ../src/common/accelcmn.cpp:65
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Tab"
+msgstr "Tabulacions"
+
+#: ../src/common/accelcmn.cpp:66
+msgctxt "keyboard key"
+msgid "Esc"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:67
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Escape"
+msgstr "Horizontal"
+
+#: ../src/common/accelcmn.cpp:68
+msgctxt "keyboard key"
+msgid "Cancel"
+msgstr "Cancelar"
+
+#: ../src/common/accelcmn.cpp:69
+msgctxt "keyboard key"
+msgid "Clear"
+msgstr "Limpiar"
+
+#: ../src/common/accelcmn.cpp:70
+msgctxt "keyboard key"
+msgid "Menu"
+msgstr "Menú"
+
+#: ../src/common/accelcmn.cpp:71
+msgctxt "keyboard key"
+msgid "Pause"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:72
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Capital"
+msgstr "&Mayusclas"
+
+#: ../src/common/accelcmn.cpp:73
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Select"
+msgstr "Selección"
+
+#: ../src/common/accelcmn.cpp:74
+msgctxt "keyboard key"
+msgid "Print"
+msgstr "Imprentar"
+
+#: ../src/common/accelcmn.cpp:75
+msgctxt "keyboard key"
+msgid "Execute"
+msgstr "Executar"
+
+#: ../src/common/accelcmn.cpp:76
+msgctxt "keyboard key"
+msgid "Snapshot"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:77
+msgctxt "keyboard key"
+msgid "Help"
+msgstr "Aduya"
+
+#: ../src/common/accelcmn.cpp:78
+msgctxt "keyboard key"
+msgid "Add"
+msgstr "Adhibir"
+
+#: ../src/common/accelcmn.cpp:79
+msgctxt "keyboard key"
+msgid "Separator"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:80
+msgctxt "keyboard key"
+msgid "Subtract"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:81
+msgctxt "keyboard key"
+msgid "Decimal"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:82
+msgctxt "keyboard key"
+msgid "Multiply"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:83
+msgctxt "keyboard key"
+msgid "Divide"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:84
+msgctxt "keyboard key"
+msgid "Num_lock"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:84
+msgctxt "keyboard key"
+msgid "Num Lock"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:85
+msgctxt "keyboard key"
+msgid "Scroll_lock"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:85
+msgctxt "keyboard key"
+msgid "Scroll Lock"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:86
+msgctxt "keyboard key"
+msgid "KP_Space"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:86
+msgctxt "keyboard key"
+msgid "Num Space"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:87
+#, fuzzy
+msgctxt "keyboard key"
+msgid "KP_Tab"
+msgstr "KP_TAB"
+
+#: ../src/common/accelcmn.cpp:87
+msgctxt "keyboard key"
+msgid "Num Tab"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:88
+#, fuzzy
+msgctxt "keyboard key"
+msgid "KP_Enter"
+msgstr "Impresora"
+
+#: ../src/common/accelcmn.cpp:88
+msgctxt "keyboard key"
+msgid "Num Enter"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:89
+#, fuzzy
+msgctxt "keyboard key"
+msgid "KP_Home"
+msgstr "Inicio"
+
+#: ../src/common/accelcmn.cpp:89
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Num Home"
+msgstr "Inicio"
+
+#: ../src/common/accelcmn.cpp:90
+#, fuzzy
+msgctxt "keyboard key"
+msgid "KP_Left"
+msgstr "Cucha"
+
+#: ../src/common/accelcmn.cpp:90
+msgctxt "keyboard key"
+msgid "Num left"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:91
+#, fuzzy
+msgctxt "keyboard key"
+msgid "KP_Up"
+msgstr "KP_ALTO"
+
+#: ../src/common/accelcmn.cpp:91
+msgctxt "keyboard key"
+msgid "Num Up"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:92
+#, fuzzy
+msgctxt "keyboard key"
+msgid "KP_Right"
+msgstr "Dreita"
+
+#: ../src/common/accelcmn.cpp:92
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Num Right"
+msgstr "Dreita"
+
+#: ../src/common/accelcmn.cpp:93
+#, fuzzy
+msgctxt "keyboard key"
+msgid "KP_Down"
+msgstr "Abaixo"
+
+#: ../src/common/accelcmn.cpp:93
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Num Down"
+msgstr "Abaixo"
+
+#: ../src/common/accelcmn.cpp:94
+msgctxt "keyboard key"
+msgid "KP_PageUp"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:94
+msgctxt "keyboard key"
+msgid "Num Page Up"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:95
+msgctxt "keyboard key"
+msgid "KP_PageDown"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:95
+msgctxt "keyboard key"
+msgid "Num Page Down"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:96
+msgctxt "keyboard key"
+msgid "KP_Prior"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:97
+#, fuzzy
+msgctxt "keyboard key"
+msgid "KP_Next"
+msgstr "Siguient"
+
+#: ../src/common/accelcmn.cpp:98
+#, fuzzy
+msgctxt "keyboard key"
+msgid "KP_End"
+msgstr "KP_FIN"
+
+#: ../src/common/accelcmn.cpp:98
+msgctxt "keyboard key"
+msgid "Num End"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:99
+msgctxt "keyboard key"
+msgid "KP_Begin"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:99
+msgctxt "keyboard key"
+msgid "Num Begin"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:100
+#, fuzzy
+msgctxt "keyboard key"
+msgid "KP_Insert"
+msgstr "Ficar"
+
+#: ../src/common/accelcmn.cpp:100
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Num Insert"
+msgstr "Ficar"
+
+#: ../src/common/accelcmn.cpp:101
+#, fuzzy
+msgctxt "keyboard key"
+msgid "KP_Delete"
+msgstr "Eliminar"
+
+#: ../src/common/accelcmn.cpp:101
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Num Delete"
+msgstr "Eliminar"
+
+#: ../src/common/accelcmn.cpp:102
+msgctxt "keyboard key"
+msgid "KP_Equal"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:102
+msgctxt "keyboard key"
+msgid "Num ="
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:103
+msgctxt "keyboard key"
+msgid "KP_Multiply"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:103
+msgctxt "keyboard key"
+msgid "Num *"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:104
+#, fuzzy
+msgctxt "keyboard key"
+msgid "KP_Add"
+msgstr "KP_SUMAR"
+
+#: ../src/common/accelcmn.cpp:104
+msgctxt "keyboard key"
+msgid "Num +"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:105
+msgctxt "keyboard key"
+msgid "KP_Separator"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:105
+msgctxt "keyboard key"
+msgid "Num ,"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:106
+msgctxt "keyboard key"
+msgid "KP_Subtract"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:106
+msgctxt "keyboard key"
+msgid "Num -"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:107
+msgctxt "keyboard key"
+msgid "KP_Decimal"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:107
+msgctxt "keyboard key"
+msgid "Num ."
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:108
+msgctxt "keyboard key"
+msgid "KP_Divide"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:108
+msgctxt "keyboard key"
+msgid "Num /"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:109
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Windows_Left"
+msgstr "Windows 7"
+
+#: ../src/common/accelcmn.cpp:110
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Windows_Right"
+msgstr "Windows Vista"
+
+#: ../src/common/accelcmn.cpp:111
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Windows_Menu"
+msgstr "Windows ME"
+
+#: ../src/common/accelcmn.cpp:112
+msgctxt "keyboard key"
+msgid "Command"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:186 ../src/common/accelcmn.cpp:359
+msgctxt "keyboard key"
+msgid "Ctrl"
+msgstr "Ctrl"
+
+#: ../src/common/accelcmn.cpp:188 ../src/common/accelcmn.cpp:363
+msgctxt "keyboard key"
+msgid "Alt"
+msgstr "Alt"
+
+#: ../src/common/accelcmn.cpp:190 ../src/common/accelcmn.cpp:361
+msgctxt "keyboard key"
+msgid "Shift"
+msgstr "Mayusclas"
+
+#: ../src/common/accelcmn.cpp:196
+msgctxt "keyboard key"
+msgid "num "
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:260 ../src/common/accelcmn.cpp:382
+msgctxt "keyboard key"
+msgid "F"
+msgstr "F"
+
+#: ../src/common/accelcmn.cpp:277 ../src/common/accelcmn.cpp:385
+msgctxt "keyboard key"
+msgid "KP_F"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:280 ../src/common/accelcmn.cpp:388
+msgctxt "keyboard key"
+msgid "KP_"
+msgstr "KP_"
+
+#: ../src/common/accelcmn.cpp:283 ../src/common/accelcmn.cpp:391
+msgctxt "keyboard key"
+msgid "SPECIAL"
+msgstr "ESPECIAL"
+
+#: ../src/common/accelcmn.cpp:373
+#, fuzzy
+msgid "Ctrl"
+msgstr "Ctrl"
+
+#: ../src/common/appbase.cpp:786
+msgid "show this help message"
+msgstr "amostrar iste mensache d'aduya"
+
+#: ../src/common/appbase.cpp:796
+msgid "generate verbose log messages"
+msgstr "chenerar mensaches de log explicitos"
+
+#: ../src/common/appcmn.cpp:256
+msgid "specify the theme to use"
+msgstr "especifica lo tema que fer servir"
+
+#: ../src/common/appcmn.cpp:270
+msgid "specify display mode to use (e.g. 640x480-16)"
+msgstr "especifica lo modo que fer servir (eix.: 640x480-16)"
+
+#: ../src/common/appcmn.cpp:292
+#, c-format
+msgid "Unsupported theme '%s'."
+msgstr "Tema no suportau '%s'."
+
+#: ../src/common/appcmn.cpp:309
+#, c-format
+msgid "Invalid display mode specification '%s'."
+msgstr "Especificación de 'display' no valida: '%s'."
+
+#: ../src/common/cmdline.cpp:875
+#, c-format
+msgid "Option '%s' can't be negated"
+msgstr "A opción '%s' no puet estar negada"
+
+#: ../src/common/cmdline.cpp:889
+#, c-format
+msgid "Unknown long option '%s'"
+msgstr "O parametro '%s' entero luengo ye desconoixiu"
+
+#: ../src/common/cmdline.cpp:904 ../src/common/cmdline.cpp:926
+#, c-format
+msgid "Unknown option '%s'"
+msgstr "O parametro '%s' ye desconoixiu"
+
+#: ../src/common/cmdline.cpp:1004
+#, c-format
+msgid "Unexpected characters following option '%s'."
+msgstr "Caracters no asperaus dezaga d'a opción '%s'."
+
+#: ../src/common/cmdline.cpp:1039
+#, c-format
+msgid "Option '%s' requires a value."
+msgstr "A opción '%s' ameneste una valor."
+
+#: ../src/common/cmdline.cpp:1058
+#, c-format
+msgid "Separator expected after the option '%s'."
+msgstr "S'asperaba un separador dimpués d'opción '%s'."
+
+#: ../src/common/cmdline.cpp:1088 ../src/common/cmdline.cpp:1106
+#, c-format
+msgid "'%s' is not a correct numeric value for option '%s'."
+msgstr "'%s' no ye una valor numerica correcta ta lo parametro '%s'."
+
+#: ../src/common/cmdline.cpp:1122
+#, c-format
+msgid "Option '%s': '%s' cannot be converted to a date."
+msgstr "A opción '%s': '%s' no puet convertir-se en una calendata."
+
+#: ../src/common/cmdline.cpp:1170
+#, c-format
+msgid "Unexpected parameter '%s'"
+msgstr "Parametro '%s' inasperau"
+
+#. TRANSLATORS: Short name and long name for a command line option
+#: ../src/common/cmdline.cpp:1197
+#, c-format
+msgid "%s (or %s)"
+msgstr "%s (u %s)"
+
+#: ../src/common/cmdline.cpp:1208
+#, c-format
+msgid "The value for the option '%s' must be specified."
+msgstr "Cal especificar a valor ta lo parametro '%s'."
+
+#: ../src/common/cmdline.cpp:1230
+#, c-format
+msgid "The required parameter '%s' was not specified."
+msgstr "No s'ha especificau o parametro requeriu '%s'."
+
+#: ../src/common/cmdline.cpp:1289
+#, c-format
+msgid "Usage: %s"
+msgstr "Uso: %s"
+
+#: ../src/common/cmdline.cpp:1498
+msgid "str"
+msgstr "cad"
+
+#: ../src/common/cmdline.cpp:1502
+msgid "num"
+msgstr "núm"
+
+#: ../src/common/cmdline.cpp:1506
+msgid "double"
+msgstr "dople"
+
+#: ../src/common/cmdline.cpp:1510
+msgid "date"
+msgstr "calendata"
+
+#: ../src/common/cmdproc.cpp:250 ../src/common/cmdproc.cpp:276
+#: ../src/common/cmdproc.cpp:296
+msgid "Unnamed command"
+msgstr "Comando sin nombre"
+
+#: ../src/common/cmdproc.cpp:253
+msgid "&Undo "
+msgstr "&Desfer "
+
+#: ../src/common/cmdproc.cpp:255
+msgid "Can't &Undo "
+msgstr "No se puet desfer "
+
+#: ../src/common/cmdproc.cpp:259 ../src/common/stockitem.cpp:208
+#: ../src/msw/textctrl.cpp:2880 ../src/osx/textctrl_osx.cpp:649
+#: ../src/richtext/richtextctrl.cpp:327
+msgid "&Undo"
+msgstr "&Desfer"
+
+#: ../src/common/cmdproc.cpp:277 ../src/common/cmdproc.cpp:297
+msgid "&Redo "
+msgstr "&Refer "
+
+#: ../src/common/cmdproc.cpp:281 ../src/common/cmdproc.cpp:288
+#: ../src/common/stockitem.cpp:190 ../src/msw/textctrl.cpp:2881
+#: ../src/osx/textctrl_osx.cpp:650 ../src/richtext/richtextctrl.cpp:328
+msgid "&Redo"
+msgstr "&Refer"
+
+#: ../src/common/colourcmn.cpp:41
+#, c-format
+msgid "String To Colour : Incorrect colour specification : %s"
+msgstr "Cadena a Color: Especificación de color '%s' incorrecta"
+
+#: ../src/common/config.cpp:259
+#, c-format
+msgid "Invalid value %ld for a boolean key \"%s\" in config file."
+msgstr ""
+"Valor invalida %ld ta una clau booleana \"%s\" en o fichero de configuración."
+
+#: ../src/common/config.cpp:526
+#, c-format
+msgid ""
+"Environment variables expansion failed: missing '%c' at position %u in '%s'."
+msgstr ""
+"A expansión de variable d'entorno ha fallau: falta '%c' en a posición %u en "
+"'%s'."
+
+#: ../src/common/config.cpp:576 ../src/msw/regconf.cpp:272
+#, c-format
+msgid "'%s' has extra '..', ignored."
+msgstr "'%s' tien bell '..' adicional, será ignorau."
+
+#. TRANSLATORS: Checkbox state name
+#: ../src/common/datavcmn.cpp:2166 ../src/generic/datavgen.cpp:1430
+msgid "checked"
+msgstr ""
+
+#. TRANSLATORS: Checkbox state name
+#: ../src/common/datavcmn.cpp:2170 ../src/generic/datavgen.cpp:1432
+msgid "unchecked"
+msgstr ""
+
+#. TRANSLATORS: Checkbox state name
+#: ../src/common/datavcmn.cpp:2174
+#, fuzzy
+msgid "undetermined"
+msgstr "subrayau"
+
+#: ../src/common/datetimefmt.cpp:1875
+msgid "today"
+msgstr "hue"
+
+#: ../src/common/datetimefmt.cpp:1876
+msgid "yesterday"
+msgstr "ahiere"
+
+#: ../src/common/datetimefmt.cpp:1877
+msgid "tomorrow"
+msgstr "maitín"
+
+#: ../src/common/datetimefmt.cpp:2071
+msgid "first"
+msgstr "primer"
+
+#: ../src/common/datetimefmt.cpp:2072
+msgid "second"
+msgstr "segundo"
+
+#: ../src/common/datetimefmt.cpp:2073
+msgid "third"
+msgstr "tercer"
+
+#: ../src/common/datetimefmt.cpp:2074
+msgid "fourth"
+msgstr "quatreno"
+
+#: ../src/common/datetimefmt.cpp:2075
+msgid "fifth"
+msgstr "cinqueno"
+
+#: ../src/common/datetimefmt.cpp:2076
+msgid "sixth"
+msgstr "seiseno"
+
+#: ../src/common/datetimefmt.cpp:2077
+msgid "seventh"
+msgstr "seteno"
+
+#: ../src/common/datetimefmt.cpp:2078
+msgid "eighth"
+msgstr "uiteno"
+
+#: ../src/common/datetimefmt.cpp:2079
+msgid "ninth"
+msgstr "nueno"
+
+#: ../src/common/datetimefmt.cpp:2080
+msgid "tenth"
+msgstr "deceno"
+
+#: ../src/common/datetimefmt.cpp:2081
+msgid "eleventh"
+msgstr "onceno"
+
+#: ../src/common/datetimefmt.cpp:2082
+msgid "twelfth"
+msgstr "doceno"
+
+#: ../src/common/datetimefmt.cpp:2083
+msgid "thirteenth"
+msgstr "treceno"
+
+#: ../src/common/datetimefmt.cpp:2084
+msgid "fourteenth"
+msgstr "catorceno"
+
+#: ../src/common/datetimefmt.cpp:2085
+msgid "fifteenth"
+msgstr "quinceno"
+
+#: ../src/common/datetimefmt.cpp:2086
+msgid "sixteenth"
+msgstr "setzeno"
+
+#: ../src/common/datetimefmt.cpp:2087
+msgid "seventeenth"
+msgstr "deciseteno"
+
+#: ../src/common/datetimefmt.cpp:2088
+msgid "eighteenth"
+msgstr "deciuiteno"
+
+#: ../src/common/datetimefmt.cpp:2089
+msgid "nineteenth"
+msgstr "decinueno"
+
+#: ../src/common/datetimefmt.cpp:2090
+msgid "twentieth"
+msgstr "vinteno"
+
+#: ../src/common/datetimefmt.cpp:2248
+msgid "noon"
+msgstr "meyodiya"
+
+#: ../src/common/datetimefmt.cpp:2249
+msgid "midnight"
+msgstr "meyanueit"
+
+#: ../src/common/debugrpt.cpp:209
+#, c-format
+msgid "Failed to create directory \"%s\""
+msgstr "S'ha produciu una error en creyar o directorio \"%s\""
+
+#: ../src/common/debugrpt.cpp:210
+msgid "Debug report couldn't be created."
+msgstr "No s'ha puesto creyar o reporte de depuración."
+
+#: ../src/common/debugrpt.cpp:227
+#, c-format
+msgid "Failed to remove debug report file \"%s\""
+msgstr "No s'ha puesto eliminar o fichero de reporte de depuración \"%s\""
+
+#: ../src/common/debugrpt.cpp:239
+#, c-format
+msgid "Failed to clean up debug report directory \"%s\""
+msgstr "No s'ha puesto vuedar o directorio de reportes de depuración \"%s\""
+
+#: ../src/common/debugrpt.cpp:514
+msgid "process context description"
+msgstr "descripción d'o contexto d'o proceso"
+
+#: ../src/common/debugrpt.cpp:538
+msgid "dump of the process state (binary)"
+msgstr "vulcau d'estau de proceso (binario)"
+
+#: ../src/common/debugrpt.cpp:553
+msgid "Debug report generation has failed."
+msgstr "A cheneración de o reporte de depuración ha fallau."
+
+#: ../src/common/debugrpt.cpp:560
+#, c-format
+msgid ""
+"Processing debug report has failed, leaving the files in \"%s\" directory."
+msgstr ""
+"O procesau d'o reporte de depuración ha fallau, os fichers quedan en o "
+"directorio \"%s\"."
+
+#: ../src/common/debugrpt.cpp:573
+msgid "A debug report has been generated. It can be found in"
+msgstr "S'ha chenerau un reporte de depuración. Se puet trobar en"
+
+#: ../src/common/debugrpt.cpp:576
+msgid "And includes the following files:\n"
+msgstr "Y incluye os siguients fichers:\n"
+
+#: ../src/common/debugrpt.cpp:586
+msgid ""
+"\n"
+"Please send this report to the program maintainer, thank you!\n"
+msgstr ""
+"\n"
+"Por favor, ninvia iste reporte a lo mantenedor d'o programa, gracias!\n"
+
+#: ../src/common/debugrpt.cpp:729
+msgid "Failed to execute curl, please install it in PATH."
+msgstr ""
+"S'ha produciu una error en executar o curl, por favor, instala-lo en PATH."
+
+#: ../src/common/debugrpt.cpp:742
+#, c-format
+msgid "Failed to upload the debug report (error code %d)."
+msgstr "No s'ha puesto ninviar o reporte de depuración (codigo d'error %d)."
+
+#: ../src/common/docview.cpp:366
+msgid "Save As"
+msgstr "Alzar como"
+
+#: ../src/common/docview.cpp:457
+msgid "Discard changes and reload the last saved version?"
+msgstr "Descartar os cambeos y recargar a zaguera versión alzada?"
+
+#: ../src/common/docview.cpp:488
+msgid "unnamed"
+msgstr "sin nombre"
+
+#: ../src/common/docview.cpp:513
+#, c-format
+msgid "Do you want to save changes to %s?"
+msgstr "Quiers alzar os cambeos ta %s?"
+
+#: ../src/common/docview.cpp:521 ../src/common/docview.cpp:560
+#: ../src/common/stockitem.cpp:195
+msgid "&Save"
+msgstr "&Alzar"
+
+#: ../src/common/docview.cpp:522 ../src/common/docview.cpp:560
+msgid "&Discard changes"
+msgstr ""
+
+#: ../src/common/docview.cpp:523
+#, fuzzy
+msgid "Do&n't close"
+msgstr "No alzar-lo"
+
+#: ../src/common/docview.cpp:553
+#, fuzzy, c-format
+msgid "Do you want to save changes to %s before closing it?"
+msgstr "Quiers alzar os cambeos ta %s?"
+
+#: ../src/common/docview.cpp:559
+#, fuzzy
+msgid "The document must be closed."
+msgstr "No s'ha puesto alzar o texto."
+
+#: ../src/common/docview.cpp:571
+#, c-format
+msgid "Saving %s failed, would you like to retry?"
+msgstr ""
+
+#: ../src/common/docview.cpp:577
+msgid "Retry"
+msgstr ""
+
+#: ../src/common/docview.cpp:577
+msgid "Discard changes"
+msgstr ""
+
+#: ../src/common/docview.cpp:679
+#, c-format
+msgid "File \"%s\" could not be opened for writing."
+msgstr "No s'ha puesto ubrir o fichero \"%s\" ta escribir."
+
+#: ../src/common/docview.cpp:685
+#, c-format
+msgid "Failed to save document to the file \"%s\"."
+msgstr "No s'ha puesto alzar o documento en o fichero \"%s\"."
+
+#: ../src/common/docview.cpp:702
+#, c-format
+msgid "File \"%s\" could not be opened for reading."
+msgstr "No s'ha puesto ubrir o fichero \"%s\" ta leyer."
+
+#: ../src/common/docview.cpp:714
+#, c-format
+msgid "Failed to read document from the file \"%s\"."
+msgstr "No s'ha puesto leyer o documento dende \"%s\"."
+
+#: ../src/common/docview.cpp:1236
+#, c-format
+msgid ""
+"The file '%s' doesn't exist and couldn't be opened.\n"
+"It has been removed from the most recently used files list."
+msgstr ""
+"O fichero '%s' no existe y no puet ubrir-se.\n"
+"Tamién ye estau eliminau d'a lista de fichers recients."
+
+#: ../src/common/docview.cpp:1296
+msgid "Print preview creation failed."
+msgstr "S'ha produciu una error en creyar l'anvista previa d'impresión."
+
+#: ../src/common/docview.cpp:1302
+msgid "Print Preview"
+msgstr "Anvista previa d'a impresión"
+
+#: ../src/common/docview.cpp:1517
+#, c-format
+msgid "The format of file '%s' couldn't be determined."
+msgstr "No s'ha puestodeterminar o formato d'o fichero '%s'."
+
+#: ../src/common/docview.cpp:1643
+#, c-format
+msgid "unnamed%d"
+msgstr "sin nombre%d"
+
+#: ../src/common/docview.cpp:1660
+msgid " - "
+msgstr " - "
+
+#: ../src/common/docview.cpp:1791 ../src/common/docview.cpp:1844
+msgid "Open File"
+msgstr "Ubrir un fichero"
+
+#: ../src/common/docview.cpp:1807
+msgid "File error"
+msgstr "Error de fichero"
+
+#: ../src/common/docview.cpp:1809
+msgid "Sorry, could not open this file."
+msgstr "No s'ha puesto ubrir iste fichero."
+
+#: ../src/common/docview.cpp:1843
+msgid "Sorry, the format for this file is unknown."
+msgstr "O formato d'iste fichero ye desconoixiu."
+
+#: ../src/common/docview.cpp:1924
+msgid "Select a document template"
+msgstr "Seleccionar una plantilla de documento"
+
+#: ../src/common/docview.cpp:1925
+msgid "Templates"
+msgstr "Plantillas"
+
+#: ../src/common/docview.cpp:1998
+msgid "Select a document view"
+msgstr "Seleccionar una anvista de documento"
+
+#: ../src/common/docview.cpp:1999
+msgid "Views"
+msgstr "Anvistas"
+
+#: ../src/common/dynlib.cpp:81
+#, c-format
+msgid "Failed to load shared library '%s'"
+msgstr "No s'ha puesto cargar a biblioteca compartida '%s'"
+
+#: ../src/common/dynlib.cpp:105
+#, c-format
+msgid "Couldn't find symbol '%s' in a dynamic library"
+msgstr "No s'ha puesto trobar o simbolo '%s' en a librería dinamica"
+
+#: ../src/common/ffile.cpp:56 ../src/common/file.cpp:215
+#, c-format
+msgid "can't open file '%s'"
+msgstr "no se puet ubrir o fichero '%s'"
+
+#: ../src/common/ffile.cpp:72
+#, c-format
+msgid "can't close file '%s'"
+msgstr "no se puet zarrar o fichero '%s'"
+
+#: ../src/common/ffile.cpp:106 ../src/common/ffile.cpp:131
+#, c-format
+msgid "Read error on file '%s'"
+msgstr "S'ha produciu una error de lectura en o fichero '%s'"
+
+#: ../src/common/ffile.cpp:148
+#, c-format
+msgid "Write error on file '%s'"
+msgstr "S'ha produciu una error d'escritura en o fichero '%s'"
+
+#: ../src/common/ffile.cpp:182
+#, c-format
+msgid "failed to flush the file '%s'"
+msgstr "s'ha produciu una error en limpiar o fichero '%s'"
+
+#: ../src/common/ffile.cpp:222
+#, c-format
+msgid "Seek error on file '%s' (large files not supported by stdio)"
+msgstr ""
+"Mirar a error en o fichero '%s' (os fichers grans no son suportaus por stdio)"
+
+#: ../src/common/ffile.cpp:232
+#, c-format
+msgid "Seek error on file '%s'"
+msgstr "Mirar a error en o fichero '%s'"
+
+#: ../src/common/ffile.cpp:248
+#, c-format
+msgid "Can't find current position in file '%s'"
+msgstr "No se puet trobar a posición actual en o fichero '%s'"
+
+#: ../src/common/ffile.cpp:349 ../src/common/file.cpp:569
+msgid "Failed to set temporary file permissions"
+msgstr "No s'ha puesto cambiar os permisos d'o fichero temporal"
+
+#: ../src/common/ffile.cpp:371
+#, c-format
+msgid "can't remove file '%s'"
+msgstr "no se puet eliminar o fichero '%s'"
+
+#: ../src/common/ffile.cpp:376 ../src/common/file.cpp:591
+#, c-format
+msgid "can't commit changes to file '%s'"
+msgstr "no se pueden fer efectivos os cambeos en o fichero '%s'"
+
+#: ../src/common/ffile.cpp:388 ../src/common/file.cpp:603
+#, c-format
+msgid "can't remove temporary file '%s'"
+msgstr "no se puet eliminar o fichero temporal '%s'"
+
+#: ../src/common/file.cpp:162
+#, c-format
+msgid "can't create file '%s'"
+msgstr "no se puet creyar o fichero '%s'"
+
+#: ../src/common/file.cpp:229
+#, c-format
+msgid "can't close file descriptor %d"
+msgstr "no se puet zarrar o descriptor de fichero %d"
+
+#: ../src/common/file.cpp:332
+#, c-format
+msgid "can't read from file descriptor %d"
+msgstr "no se puet leyer dende o descriptor de fichero %d"
+
+#: ../src/common/file.cpp:351
+#, c-format
+msgid "can't write to file descriptor %d"
+msgstr "no se puet escribir o descriptor de fichero %d"
+
+#: ../src/common/file.cpp:390
+#, c-format
+msgid "can't flush file descriptor %d"
+msgstr "no se puet vuedar o descriptor de fichero %d"
+
+#: ../src/common/file.cpp:432
+#, c-format
+msgid "can't seek on file descriptor %d"
+msgstr "no se puet mirar en o descriptor de fichero %d"
+
+#: ../src/common/file.cpp:446
+#, c-format
+msgid "can't get seek position on file descriptor %d"
+msgstr ""
+"no se puet aconseguir a posición de busca en o descriptor de fichero %d"
+
+#: ../src/common/file.cpp:475
+#, c-format
+msgid "can't find length of file on file descriptor %d"
+msgstr "no se puet obtener a grandaria d'o fichero con descriptor %d"
+
+#: ../src/common/file.cpp:505
+#, c-format
+msgid "can't determine if the end of file is reached on descriptor %d"
+msgstr ""
+"no se puet determinar si o final d'o fichero con descriptor %d s'ha "
+"aconseguiu"
+
+#: ../src/common/fileconf.cpp:352
+#, c-format
+msgid ""
+" and additionally, the existing configuration file was renamed to \"%s\" and "
+"couldn't be renamed back, please rename it to its original path \"%s\""
+msgstr ""
+
+#: ../src/common/fileconf.cpp:389
+#, fuzzy
+msgid " due to the following error:\n"
+msgstr "Y incluye os siguients fichers:\n"
+
+#: ../src/common/fileconf.cpp:412
+#, fuzzy
+msgid "failed to rename the existing file"
+msgstr "No s'ha puesto leyer o documento dende \"%s\"."
+
+#: ../src/common/fileconf.cpp:421
+#, fuzzy
+msgid "failed to create the new file directory"
+msgstr "S'ha produciu una error en obtener o directorio de treballo"
+
+#: ../src/common/fileconf.cpp:428
+#, fuzzy
+msgid "failed to move the file to the new location"
+msgstr "No s'ha puesto rematar a connexión: %s"
+
+#: ../src/common/fileconf.cpp:462
+#, c-format
+msgid "can't open global configuration file '%s'."
+msgstr "no se puet ubrir o fichero de configuración global '%s'."
+
+#: ../src/common/fileconf.cpp:478
+#, c-format
+msgid "can't open user configuration file '%s'."
+msgstr "no se puet ubrir o fichero de configuración d'usuario '%s'."
+
+#: ../src/common/fileconf.cpp:483
+#, c-format
+msgid "Changes won't be saved to avoid overwriting the existing file \"%s\""
+msgstr ""
+"Os cambeos no s'alzarán ta privar sobreescribir o fichero existent \"%s\""
+
+#: ../src/common/fileconf.cpp:583
+msgid "Error reading config options."
+msgstr "S'ha produciu una error en leyer as opcions de configuración."
+
+#: ../src/common/fileconf.cpp:593
+msgid "Failed to read config options."
+msgstr "No s'ha puesto leyer as opcions de configuración."
+
+#: ../src/common/fileconf.cpp:700
+#, fuzzy, c-format
+msgid "file '%s': unexpected character %c at line %zu."
+msgstr "fichero '%s': caracter %c inasperau en a linia %d."
+
+#: ../src/common/fileconf.cpp:736
+#, fuzzy, c-format
+msgid "file '%s', line %zu: '%s' ignored after group header."
+msgstr "fichero '%s', linia %d: '%s' ignorau dimpués d'o capitero de grupo."
+
+#: ../src/common/fileconf.cpp:765
+#, fuzzy, c-format
+msgid "file '%s', line %zu: '=' expected."
+msgstr "fichero '%s', linia %d: '=' asperau."
+
+#: ../src/common/fileconf.cpp:778
+#, fuzzy, c-format
+msgid "file '%s', line %zu: value for immutable key '%s' ignored."
+msgstr "fichero '%s', linia %d: valor ignorada ta la clau immutable '%s'."
+
+#: ../src/common/fileconf.cpp:788
+#, fuzzy, c-format
+msgid "file '%s', line %zu: key '%s' was first found at line %d."
+msgstr ""
+"fichero '%s', linia %d: a clau '%s' ye estada trobada por primera vegada en "
+"a linia %d."
+
+#: ../src/common/fileconf.cpp:1091
+#, c-format
+msgid "Config entry name cannot start with '%c'."
+msgstr "Un nombre de dentrada de configuración no puet empecipiar por '%c'."
+
+#: ../src/common/fileconf.cpp:1146
+#, fuzzy
+msgid "Failed to create configuration file directory."
+msgstr "No s'ha puesto esviellar o fichero de configuración d'usuario."
+
+#: ../src/common/fileconf.cpp:1158
+msgid "can't open user configuration file."
+msgstr "no se puet ubrir o fichero de configuración d'usuario."
+
+#: ../src/common/fileconf.cpp:1172
+msgid "can't write user configuration file."
+msgstr "no se puet escribir o fichero de configuración de l'usuario."
+
+#: ../src/common/fileconf.cpp:1178
+msgid "Failed to update user configuration file."
+msgstr "No s'ha puesto esviellar o fichero de configuración d'usuario."
+
+#: ../src/common/fileconf.cpp:1201
+msgid "Error saving user configuration data."
+msgstr ""
+"S'ha produciu una error en alzar os datos de configuración de l'usuario."
+
+#: ../src/common/fileconf.cpp:1313
+#, c-format
+msgid "can't delete user configuration file '%s'"
+msgstr "no se puet eliminar o fichero de configuración d'usuario '%s'"
+
+#: ../src/common/fileconf.cpp:2007
+#, c-format
+msgid "entry '%s' appears more than once in group '%s'"
+msgstr "a dentrada '%s' amaneix mas d'una vegada en o grupo '%s'"
+
+#: ../src/common/fileconf.cpp:2021
+#, c-format
+msgid "attempt to change immutable key '%s' ignored."
+msgstr "intento de cambiar clau immutable '%s', ignorau."
+
+#: ../src/common/fileconf.cpp:2118
+#, c-format
+msgid "trailing backslash ignored in '%s'"
+msgstr "s'ha ignorau a barra inversa sobrant en '%s'"
+
+#: ../src/common/fileconf.cpp:2153
+#, c-format
+msgid "unexpected \" at position %d in '%s'."
+msgstr "\" inasperau en a posición %d en '%s'."
+
+#: ../src/common/filefn.cpp:474
+#, c-format
+msgid "Failed to copy the file '%s' to '%s'"
+msgstr "S'ha produciu una error en copiar o fichero '%s' ta '%s'"
+
+#: ../src/common/filefn.cpp:487
+#, c-format
+msgid "Impossible to get permissions for file '%s'"
+msgstr "Ye imposible obtener permisos ta lo fichero '%s'"
+
+#: ../src/common/filefn.cpp:501
+#, c-format
+msgid "Impossible to overwrite the file '%s'"
+msgstr "Ye imposible sobrescribir o fichero '%s'"
+
+#: ../src/common/filefn.cpp:508
+#, fuzzy, c-format
+msgid "Error copying the file '%s' to '%s'."
+msgstr "S'ha produciu una error en copiar o fichero '%s' ta '%s'"
+
+#: ../src/common/filefn.cpp:556
+#, c-format
+msgid "Impossible to set permissions for the file '%s'"
+msgstr "Ye imposible establir permisos ta lo fichero '%s'"
+
+#: ../src/common/filefn.cpp:606
+#, c-format
+msgid ""
+"Failed to rename the file '%s' to '%s' because the destination file already "
+"exists."
+msgstr ""
+"No s'ha puesto renombrar o fichero '%s' a '%s' porque o fichero de destín ya "
+"existe."
+
+#: ../src/common/filefn.cpp:623
+#, c-format
+msgid "File '%s' couldn't be renamed '%s'"
+msgstr "No s'ha puesto renombrar o fichero '%s' como '%s'"
+
+#: ../src/common/filefn.cpp:639
+#, c-format
+msgid "File '%s' couldn't be removed"
+msgstr "No s'ha puesto esborrar o fichero '%s'"
+
+#: ../src/common/filefn.cpp:666
+#, c-format
+msgid "Directory '%s' couldn't be created"
+msgstr "No s'ha puesto creyar o directorio '%s'"
+
+#: ../src/common/filefn.cpp:680
+#, c-format
+msgid "Directory '%s' couldn't be deleted"
+msgstr "No se puet esborrar o directorio '%s'"
+
+#: ../src/common/filefn.cpp:714
+#, c-format
+msgid "Cannot enumerate files '%s'"
+msgstr "No se pueden enumerar os fichers '%s'"
+
+#: ../src/common/filefn.cpp:798
+msgid "Failed to get the working directory"
+msgstr "S'ha produciu una error en obtener o directorio de treballo"
+
+#: ../src/common/filefn.cpp:843
+msgid "Could not set current working directory"
+msgstr "No s'ha puesto establir o directorio de treballo actual"
+
+#: ../src/common/filefn.cpp:974
+#, c-format
+msgid "Files (%s)"
+msgstr "Fichers (%s)"
+
+#: ../src/common/filename.cpp:182
+#, c-format
+msgid "Failed to open '%s' for reading"
+msgstr "No s'ha puesto ubrir '%s' ta lectura"
+
+#: ../src/common/filename.cpp:187
+#, c-format
+msgid "Failed to open '%s' for writing"
+msgstr "No s'ha puesto ubrir '%s' ta escritura"
+
+#: ../src/common/filename.cpp:199
+msgid "Failed to close file handle"
+msgstr "S'ha produciu una error en zarrar o maniador d'o fichero"
+
+#: ../src/common/filename.cpp:1046
+msgid "Failed to create a temporary file name"
+msgstr "S'ha produciu una error en creyar un nombre temporal de fichero"
+
+#: ../src/common/filename.cpp:1081
+msgid "Failed to open temporary file."
+msgstr "No s'ha puesto ubrir o fichero temporal."
+
+#: ../src/common/filename.cpp:2862
+#, c-format
+msgid "Failed to modify file times for '%s'"
+msgstr "No s'ha puesto modificar as horas d'o fichero ta '%s'"
+
+#: ../src/common/filename.cpp:2877
+#, c-format
+msgid "Failed to touch the file '%s'"
+msgstr "No s'ha puesto retocar o fichero '%s'"
+
+#: ../src/common/filename.cpp:2958
+#, c-format
+msgid "Failed to retrieve file times for '%s'"
+msgstr "No s'ha puesto recuperar horas d'o fichero ta '%s'"
+
+#: ../src/common/filepickercmn.cpp:39 ../src/common/filepickercmn.cpp:40
+msgid "Browse"
+msgstr "Examinar"
+
+#: ../src/common/fldlgcmn.cpp:792 ../src/generic/filectrlg.cpp:1185
+#, c-format
+msgid "All files (%s)|%s"
+msgstr "Totz os fichers (%s)|%s"
+
+#. TRANSLATORS: %s are a file extension used to build a file wildcard string
+#: ../src/common/fldlgcmn.cpp:810
+#, c-format
+msgid "%s files (%s)|%s"
+msgstr "Fichers %s (%s)|%s"
+
+#: ../src/common/fldlgcmn.cpp:1072
+#, c-format
+msgid "Load %s file"
+msgstr "Cargar o fichero %s"
+
+#: ../src/common/fldlgcmn.cpp:1074
+#, c-format
+msgid "Save %s file"
+msgstr "Alzar o fichero %s"
+
+#: ../src/common/fmapbase.cpp:144
+msgid "Western European (ISO-8859-1)"
+msgstr "Europa Occidental (ISO-8859-1)"
+
+#: ../src/common/fmapbase.cpp:145
+msgid "Central European (ISO-8859-2)"
+msgstr "Europa Central (ISO-8859-2)"
+
+#: ../src/common/fmapbase.cpp:146
+msgid "Esperanto (ISO-8859-3)"
+msgstr "Esperanto (ISO-8859-3)"
+
+#: ../src/common/fmapbase.cpp:147
+msgid "Baltic (old) (ISO-8859-4)"
+msgstr "Baltico (antigo) (ISO-8859-4)"
+
+#: ../src/common/fmapbase.cpp:148
+msgid "Cyrillic (ISO-8859-5)"
+msgstr "Cirilico (ISO-8859-5)"
+
+#: ../src/common/fmapbase.cpp:149
+msgid "Arabic (ISO-8859-6)"
+msgstr "Arabe (ISO-8859-6)"
+
+#: ../src/common/fmapbase.cpp:150
+msgid "Greek (ISO-8859-7)"
+msgstr "Griego (ISO-8859-7)"
+
+#: ../src/common/fmapbase.cpp:151
+msgid "Hebrew (ISO-8859-8)"
+msgstr "Hebreu (ISO-8859-8)"
+
+#: ../src/common/fmapbase.cpp:152
+msgid "Turkish (ISO-8859-9)"
+msgstr "Turco (ISO-8859-9)"
+
+#: ../src/common/fmapbase.cpp:153
+msgid "Nordic (ISO-8859-10)"
+msgstr "Nordico (ISO-8859-10)"
+
+#: ../src/common/fmapbase.cpp:154
+msgid "Thai (ISO-8859-11)"
+msgstr "Tailandés (ISO-8859-11)"
+
+#: ../src/common/fmapbase.cpp:155
+msgid "Indian (ISO-8859-12)"
+msgstr "Indico (ISO-8859-12)"
+
+#: ../src/common/fmapbase.cpp:156
+msgid "Baltic (ISO-8859-13)"
+msgstr "Baltico (ISO-8859-13)"
+
+#: ../src/common/fmapbase.cpp:157
+msgid "Celtic (ISO-8859-14)"
+msgstr "Celtico (ISO-8859-14)"
+
+#: ../src/common/fmapbase.cpp:158
+msgid "Western European with Euro (ISO-8859-15)"
+msgstr "Europa Occidental con Euro (ISO-8859-15)"
+
+#: ../src/common/fmapbase.cpp:159
+msgid "KOI8-R"
+msgstr "KOI8-R"
+
+#: ../src/common/fmapbase.cpp:160
+msgid "KOI8-U"
+msgstr "KOI8-U"
+
+#: ../src/common/fmapbase.cpp:161
+msgid "Windows/DOS OEM Cyrillic (CP 866)"
+msgstr "Windows/DOS OEM Cyrilico (CP 866)"
+
+#: ../src/common/fmapbase.cpp:162
+msgid "Windows Thai (CP 874)"
+msgstr "Windows Tailandés (CP 874)"
+
+#: ../src/common/fmapbase.cpp:163
+msgid "Windows Japanese (CP 932) or Shift-JIS"
+msgstr "Windows Chaponés (CP 932) u Shift-JIS"
+
+#: ../src/common/fmapbase.cpp:164
+msgid "Windows Chinese Simplified (CP 936) or GB-2312"
+msgstr "Windows chino simplificau (CP 936) u GB-2312"
+
+#: ../src/common/fmapbase.cpp:165
+msgid "Windows Korean (CP 949)"
+msgstr "Windows Coreán (CP 949)"
+
+#: ../src/common/fmapbase.cpp:166
+msgid "Windows Chinese Traditional (CP 950) or Big-5"
+msgstr "Windows chino Tradicional (CP 950) u big-5"
+
+#: ../src/common/fmapbase.cpp:167
+msgid "Windows Central European (CP 1250)"
+msgstr "Windows Centro Europeu (CP 1250)"
+
+#: ../src/common/fmapbase.cpp:168
+msgid "Windows Cyrillic (CP 1251)"
+msgstr "Windows Cirilico (CP 1251)"
+
+#: ../src/common/fmapbase.cpp:169
+msgid "Windows Western European (CP 1252)"
+msgstr "Windows Europeu Occidental (CP 1252)"
+
+#: ../src/common/fmapbase.cpp:170
+msgid "Windows Greek (CP 1253)"
+msgstr "Windows Griego (CP 1253)"
+
+#: ../src/common/fmapbase.cpp:171
+msgid "Windows Turkish (CP 1254)"
+msgstr "Windows Turco (CP 1254)"
+
+#: ../src/common/fmapbase.cpp:172
+msgid "Windows Hebrew (CP 1255)"
+msgstr "Windows Hebreu (CP 1255)"
+
+#: ../src/common/fmapbase.cpp:173
+msgid "Windows Arabic (CP 1256)"
+msgstr "Windows Arabe (CP 1256)"
+
+#: ../src/common/fmapbase.cpp:174
+msgid "Windows Baltic (CP 1257)"
+msgstr "Windows Baltico (CP 1257)"
+
+#: ../src/common/fmapbase.cpp:175
+msgid "Windows Vietnamese (CP 1258)"
+msgstr "Windows Vietnamita (CP 1258)"
+
+#: ../src/common/fmapbase.cpp:176
+msgid "Windows Johab (CP 1361)"
+msgstr "Windows Johab (CP 1361)"
+
+#: ../src/common/fmapbase.cpp:177
+msgid "Windows/DOS OEM (CP 437)"
+msgstr "Windows/DOS OEM (CP 437)"
+
+#: ../src/common/fmapbase.cpp:178
+msgid "Unicode 7 bit (UTF-7)"
+msgstr "Unicode 7 bit (UTF-7)"
+
+#: ../src/common/fmapbase.cpp:179
+msgid "Unicode 8 bit (UTF-8)"
+msgstr "Unicode 8 bit (UTF-8)"
+
+#: ../src/common/fmapbase.cpp:181 ../src/common/fmapbase.cpp:187
+msgid "Unicode 16 bit (UTF-16)"
+msgstr "Unicode 16 bits (UTF-16)"
+
+#: ../src/common/fmapbase.cpp:182
+msgid "Unicode 16 bit Little Endian (UTF-16LE)"
+msgstr "Unicode 16 bits Endian Chicot (UTF-16LE)"
+
+#: ../src/common/fmapbase.cpp:183 ../src/common/fmapbase.cpp:189
+msgid "Unicode 32 bit (UTF-32)"
+msgstr "Unicode 32 bits (UTF-32)"
+
+#: ../src/common/fmapbase.cpp:184
+msgid "Unicode 32 bit Little Endian (UTF-32LE)"
+msgstr "Unicode 32 bits Endian Chicot (UTF-32LE)"
+
+#: ../src/common/fmapbase.cpp:186
+msgid "Unicode 16 bit Big Endian (UTF-16BE)"
+msgstr "Unicode 16 bits Endian Gran (UTF-16BE)"
+
+#: ../src/common/fmapbase.cpp:188
+msgid "Unicode 32 bit Big Endian (UTF-32BE)"
+msgstr "Unicode 32 bits Endian Gran (UTF-32BE)"
+
+#: ../src/common/fmapbase.cpp:191
+msgid "Extended Unix Codepage for Japanese (EUC-JP)"
+msgstr "Pachina de Codigos Unix Extendida ta lo Chaponés (EUC-JP)"
+
+#: ../src/common/fmapbase.cpp:192
+msgid "US-ASCII"
+msgstr "US-ASCII"
+
+#: ../src/common/fmapbase.cpp:193
+msgid "ISO-2022-JP"
+msgstr "ISO-2022-JP"
+
+#: ../src/common/fmapbase.cpp:195
+msgid "MacRoman"
+msgstr "Mac Román"
+
+#: ../src/common/fmapbase.cpp:196
+msgid "MacJapanese"
+msgstr "Mac Chaponés"
+
+#: ../src/common/fmapbase.cpp:197
+msgid "MacChineseTrad"
+msgstr "Mac Chino Tradicional"
+
+#: ../src/common/fmapbase.cpp:198
+msgid "MacKorean"
+msgstr "Mac Coreán"
+
+#: ../src/common/fmapbase.cpp:199
+msgid "MacArabic"
+msgstr "Mac Arabe"
+
+#: ../src/common/fmapbase.cpp:200
+msgid "MacHebrew"
+msgstr "Mac Hebreu"
+
+#: ../src/common/fmapbase.cpp:201
+msgid "MacGreek"
+msgstr "Mac Griego"
+
+#: ../src/common/fmapbase.cpp:202
+msgid "MacCyrillic"
+msgstr "Mac Cirilico"
+
+#: ../src/common/fmapbase.cpp:203
+msgid "MacDevanagari"
+msgstr "Mac Devanagari"
+
+#: ../src/common/fmapbase.cpp:204
+msgid "MacGurmukhi"
+msgstr "Mac gurmukhi"
+
+#: ../src/common/fmapbase.cpp:205
+msgid "MacGujarati"
+msgstr "Mac gujarati"
+
+#: ../src/common/fmapbase.cpp:206
+msgid "MacOriya"
+msgstr "MacOriya"
+
+#: ../src/common/fmapbase.cpp:207
+msgid "MacBengali"
+msgstr "Mac Bengalí"
+
+#: ../src/common/fmapbase.cpp:208
+msgid "MacTamil"
+msgstr "Mac tamil"
+
+#: ../src/common/fmapbase.cpp:209
+msgid "MacTelugu"
+msgstr "Mac telugu"
+
+#: ../src/common/fmapbase.cpp:210
+msgid "MacKannada"
+msgstr "Mac Canadá"
+
+#: ../src/common/fmapbase.cpp:211
+msgid "MacMalayalam"
+msgstr "Mac Malayo"
+
+#: ../src/common/fmapbase.cpp:212
+msgid "MacSinhalese"
+msgstr "Mac cingalés"
+
+#: ../src/common/fmapbase.cpp:213
+msgid "MacBurmese"
+msgstr "Mac Burmese"
+
+#: ../src/common/fmapbase.cpp:214
+msgid "MacKhmer"
+msgstr "Mac Camboyano"
+
+#: ../src/common/fmapbase.cpp:215
+msgid "MacThai"
+msgstr "Mac Tailandés"
+
+#: ../src/common/fmapbase.cpp:216
+msgid "MacLaotian"
+msgstr "Mac Laosián"
+
+#: ../src/common/fmapbase.cpp:217
+msgid "MacGeorgian"
+msgstr "Mac Cheorchiano"
+
+#: ../src/common/fmapbase.cpp:218
+msgid "MacArmenian"
+msgstr "Mac Armenio"
+
+#: ../src/common/fmapbase.cpp:219
+msgid "MacChineseSimp"
+msgstr "Mac Chino Simplificau"
+
+#: ../src/common/fmapbase.cpp:220
+msgid "MacTibetan"
+msgstr "Mac Tibetán"
+
+#: ../src/common/fmapbase.cpp:221
+msgid "MacMongolian"
+msgstr "Mac mongol"
+
+#: ../src/common/fmapbase.cpp:222
+msgid "MacEthiopic"
+msgstr "Mac Etiope"
+
+#: ../src/common/fmapbase.cpp:223
+msgid "MacCentralEurRoman"
+msgstr "Mac Román Centroeuropeu"
+
+#: ../src/common/fmapbase.cpp:224
+msgid "MacVietnamese"
+msgstr "Mac Vietnamita"
+
+#: ../src/common/fmapbase.cpp:225
+msgid "MacExtArabic"
+msgstr "Mac Arabe Ext"
+
+#: ../src/common/fmapbase.cpp:226
+msgid "MacSymbol"
+msgstr "Mac Simbolos"
+
+#: ../src/common/fmapbase.cpp:227
+msgid "MacDingbats"
+msgstr "Mac pictogramas"
+
+#: ../src/common/fmapbase.cpp:228
+msgid "MacTurkish"
+msgstr "Mac Turco"
+
+#: ../src/common/fmapbase.cpp:229
+msgid "MacCroatian"
+msgstr "Mac Crovata"
+
+#: ../src/common/fmapbase.cpp:230
+msgid "MacIcelandic"
+msgstr "Mac Islandés"
+
+#: ../src/common/fmapbase.cpp:231
+msgid "MacRomanian"
+msgstr "Mac Rumán"
+
+#: ../src/common/fmapbase.cpp:232
+msgid "MacCeltic"
+msgstr "Mac Celtico"
+
+#: ../src/common/fmapbase.cpp:233
+msgid "MacGaelic"
+msgstr "Mac Gaelico"
+
+#: ../src/common/fmapbase.cpp:234
+msgid "MacKeyboardGlyphs"
+msgstr "Mac Caracters Especials"
+
+#: ../src/common/fmapbase.cpp:791
+msgid "Default encoding"
+msgstr "Codificación predeterminada"
+
+#: ../src/common/fmapbase.cpp:805
+#, c-format
+msgid "Unknown encoding (%d)"
+msgstr "Codificación desconoixida (%d)"
+
+#: ../src/common/fmapbase.cpp:815 ../src/richtext/richtextstyles.cpp:776
+msgid "default"
+msgstr "predeterminau"
+
+#: ../src/common/fmapbase.cpp:829
+#, c-format
+msgid "unknown-%d"
+msgstr "desconoixiu-%d"
+
+#: ../src/common/fontcmn.cpp:924 ../src/common/fontcmn.cpp:1130
+msgid "underlined"
+msgstr "subrayau"
+
+#: ../src/common/fontcmn.cpp:929
+msgid " strikethrough"
+msgstr " rayau"
+
+#: ../src/common/fontcmn.cpp:942
+msgid " thin"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:946
+#, fuzzy
+msgid " extra light"
+msgstr " lichera"
+
+#: ../src/common/fontcmn.cpp:950
+msgid " light"
+msgstr " lichera"
+
+#: ../src/common/fontcmn.cpp:954
+msgid " medium"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:958
+#, fuzzy
+msgid " semi bold"
+msgstr " negreta"
+
+#: ../src/common/fontcmn.cpp:962
+msgid " bold"
+msgstr " negreta"
+
+#: ../src/common/fontcmn.cpp:966
+#, fuzzy
+msgid " extra bold"
+msgstr " negreta"
+
+#: ../src/common/fontcmn.cpp:970
+msgid " heavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:974
+msgid " extra heavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:990
+msgid " italic"
+msgstr " cursiva"
+
+#: ../src/common/fontcmn.cpp:1134
+msgid "strikethrough"
+msgstr "rayau"
+
+#: ../src/common/fontcmn.cpp:1143
+msgid "thin"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1156
+#, fuzzy
+msgid "extralight"
+msgstr "lichera"
+
+#: ../src/common/fontcmn.cpp:1161
+msgid "light"
+msgstr "lichera"
+
+#: ../src/common/fontcmn.cpp:1169 ../src/richtext/richtextstyles.cpp:775
+msgid "normal"
+msgstr "normal"
+
+#: ../src/common/fontcmn.cpp:1174
+msgid "medium"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1179 ../src/common/fontcmn.cpp:1199
+#, fuzzy
+msgid "semibold"
+msgstr "negreta"
+
+#: ../src/common/fontcmn.cpp:1184
+msgid "bold"
+msgstr "negreta"
+
+#: ../src/common/fontcmn.cpp:1194
+#, fuzzy
+msgid "extrabold"
+msgstr "negreta"
+
+#: ../src/common/fontcmn.cpp:1204
+msgid "heavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1212
+msgid "extraheavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1217
+msgid "italic"
+msgstr "cursiva"
+
+#: ../src/common/fontmap.cpp:195
+msgid ": unknown charset"
+msgstr ": conchunto de caracters desconoixiu"
+
+#: ../src/common/fontmap.cpp:199
+#, c-format
+msgid ""
+"The charset '%s' is unknown. You may select\n"
+"another charset to replace it with or choose\n"
+"[Cancel] if it cannot be replaced"
+msgstr ""
+"O conchunto de caracters '%s' ye desconoixiu. Puetz\n"
+"seleccionar unatro conchunto ta substituir-lo u trigar\n"
+"[Cancelar] si no puet estar substituiu"
+
+#: ../src/common/fontmap.cpp:241
+#, c-format
+msgid "Failed to remember the encoding for the charset '%s'."
+msgstr ""
+"S'ha produciu una error a lo remerar a codificación ta lo conchunto de "
+"caracters '%s'."
+
+#: ../src/common/fontmap.cpp:321
+msgid "can't load any font, aborting"
+msgstr "no se puet cargar garra fuent, se ye abortando"
+
+#: ../src/common/fontmap.cpp:409
+msgid ": unknown encoding"
+msgstr ": codificación desconoixida"
+
+#: ../src/common/fontmap.cpp:417
+#, c-format
+msgid ""
+"No font for displaying text in encoding '%s' found,\n"
+"but an alternative encoding '%s' is available.\n"
+"Do you want to use this encoding (otherwise you will have to choose another "
+"one)?"
+msgstr ""
+"No bi ha garra fuent ta amostrar texto con a codificación '%s',\n"
+"pero existe una codificación '%s' alternativa.\n"
+"Te fería goyo fer servir ista codificación (d'atra traza habrás a trigar "
+"unatra)?"
+
+#: ../src/common/fontmap.cpp:422
+#, c-format
+msgid ""
+"No font for displaying text in encoding '%s' found.\n"
+"Would you like to select a font to be used for this encoding\n"
+"(otherwise the text in this encoding will not be shown correctly)?"
+msgstr ""
+"No bi ha garra fuent ta amostrar texto con a codificación '%s'.\n"
+"Te fería goyo seleccionar unatra fuent ta fer-la servir con ista "
+"codificación\n"
+"(d'atra traza o texto con ista codificación no s'amostrará correctament)?"
+
+#: ../src/common/fs_mem.cpp:169
+#, c-format
+msgid "Memory VFS already contains file '%s'!"
+msgstr "VFS en memoria ya contién o fichero '%s'!"
+
+#: ../src/common/fs_mem.cpp:232
+#, c-format
+msgid "Trying to remove file '%s' from memory VFS, but it is not loaded!"
+msgstr ""
+"Se ye mirando d'eliminar o fichero '%s' de VFS de memoria, pero no'n ye "
+"ubierto!"
+
+#: ../src/common/fs_mem.cpp:262
+#, c-format
+msgid "Failed to store image '%s' to memory VFS!"
+msgstr "No s'ha puesto almagazenar a imachen '%s' en a memoria VFS."
+
+#: ../src/common/ftp.cpp:197
+msgid "Timeout while waiting for FTP server to connect, try passive mode."
+msgstr ""
+"Tiempo d'aspera d'a connexión d'o servidor FTP acotolau, preba a establir o "
+"modo pasivo."
+
+#: ../src/common/ftp.cpp:399
+#, c-format
+msgid "Failed to set FTP transfer mode to %s."
+msgstr "No s'ha puesto establir o modo de transferencia FTP a %s."
+
+#: ../src/common/ftp.cpp:400 ../src/richtext/richtextsymboldlg.cpp:432
+msgid "ASCII"
+msgstr "ASCII"
+
+#: ../src/common/ftp.cpp:400
+msgid "binary"
+msgstr "binario"
+
+#: ../src/common/ftp.cpp:608
+msgid "The FTP server doesn't support the PORT command."
+msgstr "O servidor FTP no suporta o comando PORT."
+
+#: ../src/common/ftp.cpp:622
+msgid "The FTP server doesn't support passive mode."
+msgstr "O servidor FTP no suporta o modo pasivo."
+
+#: ../src/common/gifdecod.cpp:822
+#, c-format
+msgid "Incorrect GIF frame size (%u, %d) for the frame #%u"
+msgstr "Grandaria de marco GIF incorrecta (%u, %d) pa lo marco #%u"
+
+#: ../src/common/glcmn.cpp:108
+msgid "Failed to allocate colour for OpenGL"
+msgstr "S'ha produciu una error en asignar a color ta l'OpenGL"
+
+#: ../src/common/headerctrlcmn.cpp:57
+msgid "Please select the columns to show and define their order:"
+msgstr ""
+"Por favor selecciona as columnas que amostrar y define l'orden d'ellas:"
+
+#: ../src/common/headerctrlcmn.cpp:58
+msgid "Customize Columns"
+msgstr "Columnas personalizadas"
+
+#: ../src/common/headerctrlcmn.cpp:304
+msgid "&Customize..."
+msgstr "&Personalizar..."
+
+#: ../src/common/hyperlnkcmn.cpp:132
+#, fuzzy, c-format
+msgid "Failed to open URL \"%s\" in the default browser"
+msgstr "No s'ha puesto ubrir a URL \"%s\" en o navegador predeterminau."
+
+#: ../src/common/iconbndl.cpp:195
+#, c-format
+msgid "Failed to load image %%d from file '%s'."
+msgstr "No s'ha puesto cargar a imachen %%d dende o fichero '%s'."
+
+#: ../src/common/iconbndl.cpp:203
+#, c-format
+msgid "Failed to load image %d from stream."
+msgstr "No s'ha puesto cargar a imachen %d dende o fluxo."
+
+#: ../src/common/iconbndl.cpp:221
+#, fuzzy, c-format
+msgid "Failed to load icons from resource '%s'."
+msgstr "No s'ha puesto cargar l'icono \"%s\" dende os recursos."
+
+#: ../src/common/imagbmp.cpp:97
+msgid "BMP: Couldn't save invalid image."
+msgstr "BMP: No s'ha puesto alzar a imachen no valida."
+
+#: ../src/common/imagbmp.cpp:137
+msgid "BMP: wxImage doesn't have own wxPalette."
+msgstr "BMP: wxImage no tien a suya propia wxPalette."
+
+#: ../src/common/imagbmp.cpp:243
+msgid "BMP: Couldn't write the file (Bitmap) header."
+msgstr "BMP: No s'ha puesto escribir o capitero (Bitmap) d'o fichero."
+
+#: ../src/common/imagbmp.cpp:266
+msgid "BMP: Couldn't write the file (BitmapInfo) header."
+msgstr "BMP: No s'ha puesto escribir o capitero (BitmapInfo) d'o fichero."
+
+#: ../src/common/imagbmp.cpp:353
+msgid "BMP: Couldn't write RGB color map."
+msgstr "BMP: No s'ha puesto escribir o mapa de color RGB."
+
+#: ../src/common/imagbmp.cpp:487
+msgid "BMP: Couldn't write data."
+msgstr "BMP: No s'han puesto escribir datos."
+
+#: ../src/common/imagbmp.cpp:561 ../src/common/imagbmp.cpp:642
+msgid "BMP: Couldn't allocate memory."
+msgstr "BMP: No s'ha puesto reservar memoria."
+
+#: ../src/common/imagbmp.cpp:1041
+msgid "DIB Header: Image width > 32767 pixels for file."
+msgstr "Capitero DIB: Amplaria d'imachen > 32767 pixels por fichero."
+
+#: ../src/common/imagbmp.cpp:1049
+msgid "DIB Header: Image height > 32767 pixels for file."
+msgstr "Capitero DIB: Altura d'a imachen > 32767 pixels por fichero."
+
+#: ../src/common/imagbmp.cpp:1081
+msgid "DIB Header: Unknown bitdepth in file."
+msgstr "Capitero DIB: Profundidat de color desconoixida en o fichero."
+
+#: ../src/common/imagbmp.cpp:1156
+msgid "DIB Header: Unknown encoding in file."
+msgstr "Capitero DIB: Codificación desconoixida en o fichero."
+
+#: ../src/common/imagbmp.cpp:1165
+msgid "DIB Header: Encoding doesn't match bitdepth."
+msgstr "Capitero DIB: A codificación no coincide con a profundidat de bits."
+
+#: ../src/common/imagbmp.cpp:1180
+#, c-format
+msgid "BMP Header: Invalid number of colors (%d)."
+msgstr ""
+
+#: ../src/common/imagbmp.cpp:1273
+msgid "Error in reading image DIB."
+msgstr "S'ha produciu una error en leyer a imachen DIB."
+
+#: ../src/common/imagbmp.cpp:1294
+msgid "ICO: Error in reading mask DIB."
+msgstr "ICO: Error en leyer a mascareta DIB."
+
+#: ../src/common/imagbmp.cpp:1353
+msgid "ICO: Image too tall for an icon."
+msgstr "ICO: Imachen masiau alta ta un icono."
+
+#: ../src/common/imagbmp.cpp:1361
+msgid "ICO: Image too wide for an icon."
+msgstr "ICO: Imachen masiau ampla ta un icono."
+
+#: ../src/common/imagbmp.cpp:1388 ../src/common/imagbmp.cpp:1488
+#: ../src/common/imagbmp.cpp:1503 ../src/common/imagbmp.cpp:1514
+#: ../src/common/imagbmp.cpp:1528 ../src/common/imagbmp.cpp:1576
+#: ../src/common/imagbmp.cpp:1591 ../src/common/imagbmp.cpp:1605
+#: ../src/common/imagbmp.cpp:1616
+msgid "ICO: Error writing the image file!"
+msgstr "ICO: Error en escribir o fichero d'imachen!"
+
+#: ../src/common/imagbmp.cpp:1701
+msgid "ICO: Invalid icon index."
+msgstr "ICO: Indiz d'icono no valido."
+
+#: ../src/common/image.cpp:2410
+msgid "Image and mask have different sizes."
+msgstr "A imachen y a mascareta tienen grandarias diferents."
+
+#: ../src/common/image.cpp:2418 ../src/common/image.cpp:2459
+msgid "No unused colour in image being masked."
+msgstr "No bi ha garra color sin usar en a imachen que se ye enmascarando."
+
+#: ../src/common/image.cpp:2641
+#, c-format
+msgid "Failed to load bitmap \"%s\" from resources."
+msgstr "No s'ha puesto cargar o mapa de bits \"%s\" dende os recursos."
+
+#: ../src/common/image.cpp:2650
+#, c-format
+msgid "Failed to load icon \"%s\" from resources."
+msgstr "No s'ha puesto cargar l'icono \"%s\" dende os recursos."
+
+#: ../src/common/image.cpp:2728 ../src/common/image.cpp:2747
+#, c-format
+msgid "Failed to load image from file \"%s\"."
+msgstr "No s'ha puesto cargar a imachen dende o fichero \"%s\"."
+
+#: ../src/common/image.cpp:2761
+#, c-format
+msgid "Can't save image to file '%s': unknown extension."
+msgstr ""
+"No se puet alzar a imachen en o fichero '%s': a extensión ye desconoixida."
+
+#: ../src/common/image.cpp:2869
+msgid "No handler found for image type."
+msgstr "No s'ha trobau garra maniador ta la mena d'imachen."
+
+#: ../src/common/image.cpp:2877 ../src/common/image.cpp:3000
+#: ../src/common/image.cpp:3066
+#, c-format
+msgid "No image handler for type %d defined."
+msgstr "No bi ha definiu garra maniador d'imachen ta la mena %d."
+
+#: ../src/common/image.cpp:2887
+#, c-format
+msgid "Image file is not of type %d."
+msgstr "O fichero de imachen no ye d'a mena %d."
+
+#: ../src/common/image.cpp:2970
+msgid "Can't automatically determine the image format for non-seekable input."
+msgstr ""
+"No se puet determinar automaticament o formato d'a imachen a causa d'una "
+"dentrada no localizable."
+
+#: ../src/common/image.cpp:2988
+msgid "Unknown image data format."
+msgstr "Formato de datos d'imachen desconoixiu."
+
+#: ../src/common/image.cpp:3009
+#, c-format
+msgid "This is not a %s."
+msgstr "Isto no ye un %s."
+
+#: ../src/common/image.cpp:3032 ../src/common/image.cpp:3080
+#, c-format
+msgid "No image handler for type %s defined."
+msgstr "No s'ha definiu garra maniador d'imachen ta la mena %s."
+
+#: ../src/common/image.cpp:3041
+#, c-format
+msgid "Image is not of type %s."
+msgstr "A imachen no ye d'a mena %s."
+
+#: ../src/common/image.cpp:3509
+#, c-format
+msgid "Failed to check format of image file \"%s\"."
+msgstr ""
+"S'ha produciu una error en comprebar o formato d'o fichero d'imachen \"%s\"."
+
+#: ../src/common/imaggif.cpp:124
+msgid "GIF: error in GIF image format."
+msgstr "GIF: error en o formato d'imachen GIF."
+
+#: ../src/common/imaggif.cpp:129
+msgid "GIF: not enough memory."
+msgstr "GIF: memoria insuficient."
+
+#: ../src/common/imaggif.cpp:134
+msgid "GIF: data stream seems to be truncated."
+msgstr "GIF: O fluxo de datos pareix haber-se truncau."
+
+#: ../src/common/imaggif.cpp:240
+msgid "Couldn't initialize GIF hash table."
+msgstr "No s'ha puesto inicializar a tabla hash d'o GIF."
+
+#: ../src/common/imagiff.cpp:739
+msgid "IFF: error in IFF image format."
+msgstr "IFF: error en o formato d'imachen IFF."
+
+#: ../src/common/imagiff.cpp:742
+msgid "IFF: not enough memory."
+msgstr "IFF: memoria insuficient."
+
+#: ../src/common/imagiff.cpp:745
+msgid "IFF: unknown error!!!"
+msgstr "IFF: error desconoixida!!!"
+
+#: ../src/common/imagiff.cpp:755
+msgid "IFF: data stream seems to be truncated."
+msgstr "IFF: o fluxo de datos pareix truncau."
+
+#: ../src/common/imagjpeg.cpp:258
+msgid "JPEG: Couldn't load - file is probably corrupted."
+msgstr "JPEG: No s'ha puesto ubrir - o fichero ye prebablement corrupto."
+
+#: ../src/common/imagjpeg.cpp:437
+msgid "JPEG: Couldn't save image."
+msgstr "JPEG: No s'ha puesto alzar a imachen."
+
+#: ../src/common/imagpcx.cpp:439
+msgid "PCX: this is not a PCX file."
+msgstr "PCX: iste no ye un fichero PCX."
+
+#: ../src/common/imagpcx.cpp:453
+msgid "PCX: image format unsupported"
+msgstr "PCX: formato d'imachen no suportau"
+
+#: ../src/common/imagpcx.cpp:454 ../src/common/imagpcx.cpp:477
+msgid "PCX: couldn't allocate memory"
+msgstr "PCX: no s'ha puesto reservar memoria"
+
+#: ../src/common/imagpcx.cpp:455
+msgid "PCX: version number too low"
+msgstr "PCX: numero de versión masiau antiga"
+
+#: ../src/common/imagpcx.cpp:456 ../src/common/imagpcx.cpp:478
+msgid "PCX: unknown error !!!"
+msgstr "PCX: error desconoixida!!!"
+
+#: ../src/common/imagpcx.cpp:476
+msgid "PCX: invalid image"
+msgstr "PCX: imachen invalida"
+
+#: ../src/common/imagpng.cpp:385
+#, c-format
+msgid "Unknown PNG resolution unit %d"
+msgstr "Unidat de resolución de PNG desconoixida %d"
+
+#: ../src/common/imagpng.cpp:439
+msgid "Couldn't load a PNG image - file is corrupted or not enough memory."
+msgstr ""
+"No s'ha puesto ubrir a imachen PNG - o fichero ye corrupto u no bi ha "
+"suficient memoria."
+
+#: ../src/common/imagpng.cpp:513 ../src/common/imagpng.cpp:524
+#: ../src/common/imagpng.cpp:534
+msgid "Couldn't save PNG image."
+msgstr "No se puet alzar a imachen PNG."
+
+#: ../src/common/imagpnm.cpp:71
+msgid "PNM: File format is not recognized."
+msgstr "PNM: Formato de fichero no reconoixiu."
+
+#: ../src/common/imagpnm.cpp:89
+msgid "PNM: Couldn't allocate memory."
+msgstr "PNM: No s'ha puesto reservar memoria."
+
+#: ../src/common/imagpnm.cpp:111 ../src/common/imagpnm.cpp:134
+#: ../src/common/imagpnm.cpp:156
+msgid "PNM: File seems truncated."
+msgstr "PNM: O fichero pareix estar truncau."
+
+#: ../src/common/imagtiff.cpp:69
+#, c-format
+msgid " (in module \"%s\")"
+msgstr " (en o modulo \"%s\")"
+
+#: ../src/common/imagtiff.cpp:304
+msgid "TIFF: Error loading image."
+msgstr "TIFF: S'ha produciu una error en ubrir a imachen."
+
+#: ../src/common/imagtiff.cpp:314
+msgid "Invalid TIFF image index."
+msgstr "Indiz d'imachen TIFF no valido."
+
+#: ../src/common/imagtiff.cpp:358
+msgid "TIFF: Image size is abnormally big."
+msgstr "TIF: A grandaria d'a imachen ye anormalment gran."
+
+#: ../src/common/imagtiff.cpp:372 ../src/common/imagtiff.cpp:385
+#: ../src/common/imagtiff.cpp:769
+msgid "TIFF: Couldn't allocate memory."
+msgstr "TIFF: No s'ha puesto reservar memoria."
+
+#: ../src/common/imagtiff.cpp:471
+msgid "TIFF: Error reading image."
+msgstr "TIFF: S'ha produciu una error en leyer a imachen."
+
+#: ../src/common/imagtiff.cpp:532
+#, c-format
+msgid "Unknown TIFF resolution unit %d ignored"
+msgstr "Unidat de resolución de TIF desconoixida %d ignorada"
+
+#: ../src/common/imagtiff.cpp:611
+msgid "TIFF: Error saving image."
+msgstr "TIFF: S'ha produciu una error en alzar a imachen."
+
+#: ../src/common/imagtiff.cpp:868
+msgid "TIFF: Error writing image."
+msgstr "TIFF: S'ha produciu una error en escribir a imachen."
+
+#: ../src/common/imagtiff.cpp:881
+#, fuzzy
+msgid "TIFF: Error flushing data."
+msgstr "TIFF: S'ha produciu una error en alzar a imachen."
+
+#: ../src/common/imagwebp.cpp:56
+msgid "WebP: Invalid data (failed to get features)."
+msgstr ""
+
+#: ../src/common/imagwebp.cpp:65
+msgid "WebP: Allocating image memory failed."
+msgstr ""
+
+#: ../src/common/imagwebp.cpp:82
+msgid "WebP: Decoding RGBA image data failed."
+msgstr ""
+
+#: ../src/common/imagwebp.cpp:98
+msgid "WebP: Decoding RGB image data failed."
+msgstr ""
+
+#: ../src/common/imagwebp.cpp:113 ../src/common/imagwebp.cpp:201
+msgid "WebP: Allocating stream buffer failed."
+msgstr ""
+
+#: ../src/common/imagwebp.cpp:131
+#, fuzzy
+msgid "WebP: Failed to parse container data."
+msgstr "No s'ha puesto meter datos en o portafuellas."
+
+#: ../src/common/imagwebp.cpp:222
+#, fuzzy
+msgid "WebP: Error decoding animation."
+msgstr "S'ha produciu una error en leyer as opcions de configuración."
+
+#: ../src/common/imagwebp.cpp:240
+msgid "WebP: Error getting next animation frame."
+msgstr ""
+
+#: ../src/common/init.cpp:172
+#, c-format
+msgid ""
+"Command line argument %d couldn't be converted to Unicode and will be "
+"ignored."
+msgstr ""
+"No se puet convertir l'argumento %d d'a linia de comandos ta Unicode y será "
+"ignorau."
+
+#: ../src/common/init.cpp:344
+msgid "Initialization failed in post init, aborting."
+msgstr "Ha fallau a inicialización en post init, abortando-la."
+
+#: ../src/common/intl.cpp:378
+#, c-format
+msgid "Cannot set locale to language \"%s\"."
+msgstr "No se puet establir a localización ta l'idioma \"%s\"."
+
+#: ../src/common/log.cpp:232
+msgid "Error: "
+msgstr "Error: "
+
+#: ../src/common/log.cpp:236
+msgid "Warning: "
+msgstr "Alvertencia: "
+
+#: ../src/common/log.cpp:284
+msgid "The previous message repeated once."
+msgstr "L'anterior mensache repetiu una vegada."
+
+#: ../src/common/log.cpp:291
+#, fuzzy, c-format
+msgid "The previous message repeated %u time."
+msgid_plural "The previous message repeated %u times."
+msgstr[0] "L'anterior mensache repetiu %lu vegada."
+msgstr[1] "L'anterior mensache repetiu %lu vegadas."
+
+#: ../src/common/log.cpp:319
+#, fuzzy, c-format
+msgid "Last repeated message (\"%s\", %u time) wasn't output"
+msgid_plural "Last repeated message (\"%s\", %u times) wasn't output"
+msgstr[0] "O zaguer mensache repetiu (\"%s\", %lu vegada) no yera a salida."
+msgstr[1] "O zaguer mensache repetiu (\"%s\", %lu vegadas) no yera a salida."
+
+#: ../src/common/log.cpp:435
+#, c-format
+msgid " (error %ld: %s)"
+msgstr " (error %ld: %s)"
+
+#: ../src/common/lzmastream.cpp:121
+#, fuzzy
+msgid "Failed to allocate memory for LZMA decompression."
+msgstr "S'ha produciu una error en asignar a color ta l'OpenGL"
+
+#: ../src/common/lzmastream.cpp:125
+#, c-format
+msgid "Failed to initialize LZMA decompression: unexpected error %u."
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:179
+msgid "input is not in XZ format"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:183
+msgid "input compressed using unknown XZ option"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:188
+msgid "input is corrupted"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:192
+#, fuzzy
+msgid "unknown decompression error"
+msgstr "s'ha produciu una error de descompresión"
+
+#: ../src/common/lzmastream.cpp:196
+#, fuzzy, c-format
+msgid "LZMA decompression error: %s"
+msgstr "s'ha produciu una error de descompresión"
+
+#: ../src/common/lzmastream.cpp:231
+#, fuzzy
+msgid "Failed to allocate memory for LZMA compression."
+msgstr "S'ha produciu una error en asignar a color ta l'OpenGL"
+
+#: ../src/common/lzmastream.cpp:235
+#, c-format
+msgid "Failed to initialize LZMA compression: unexpected error %u."
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:267 ../src/common/lzmastream.cpp:342
+#: ../src/html/chm.cpp:336
+msgid "out of memory"
+msgstr "memoria acotolada"
+
+#: ../src/common/lzmastream.cpp:276 ../src/common/lzmastream.cpp:346
+#, fuzzy
+msgid "unknown compression error"
+msgstr "s'ha produciu una error de compresión"
+
+#: ../src/common/lzmastream.cpp:280
+#, fuzzy, c-format
+msgid "LZMA compression error: %s"
+msgstr "s'ha produciu una error de compresión"
+
+#: ../src/common/lzmastream.cpp:350
+#, c-format
+msgid "LZMA compression error when flushing output: %s"
+msgstr ""
+
+#: ../src/common/mimecmn.cpp:167
+#, c-format
+msgid "Unmatched '{' in an entry for mime type %s."
+msgstr "Bi ha una '{' no emparellada en una dentrada ta o tipo mime %s."
+
+#: ../src/common/module.cpp:76
+#, c-format
+msgid "Circular dependency involving module \"%s\" detected."
+msgstr "S'ha detectau una dependencia circular tocant a lo modulo \"%s\"."
+
+#: ../src/common/module.cpp:128
+#, c-format
+msgid "Dependency \"%s\" of module \"%s\" doesn't exist."
+msgstr "No existe a dependencia \"%s\" d'o modulo \"%s\"."
+
+#: ../src/common/module.cpp:137
+#, c-format
+msgid "Module \"%s\" initialization failed"
+msgstr "No s'ha puesto inicializar o modulo \"%s\""
+
+#: ../src/common/msgout.cpp:96
+msgid "Message"
+msgstr "Mensache"
+
+#: ../src/common/paper.cpp:70
+msgid "Letter, 8 1/2 x 11 in"
+msgstr "Carta, 8 1/2 x 11 in"
+
+#: ../src/common/paper.cpp:71
+msgid "Legal, 8 1/2 x 14 in"
+msgstr "Legal, 8 1/2 x 14 in"
+
+#: ../src/common/paper.cpp:72
+msgid "A4 sheet, 210 x 297 mm"
+msgstr "Fuella A4, 210 x 297 mm"
+
+#: ../src/common/paper.cpp:73
+msgid "C sheet, 17 x 22 in"
+msgstr "Fuella C, 17 x 22 in"
+
+#: ../src/common/paper.cpp:74
+msgid "D sheet, 22 x 34 in"
+msgstr "Fuella D, 22 x 34 in"
+
+#: ../src/common/paper.cpp:75
+msgid "E sheet, 34 x 44 in"
+msgstr "Fuella E, 34 x 44 in"
+
+#: ../src/common/paper.cpp:76
+msgid "Letter Small, 8 1/2 x 11 in"
+msgstr "Carta chicota, 8 1/2 x 11 in"
+
+#: ../src/common/paper.cpp:77
+msgid "Tabloid, 11 x 17 in"
+msgstr "Tabloide, 11 x 17 in"
+
+#: ../src/common/paper.cpp:78
+msgid "Ledger, 17 x 11 in"
+msgstr "Libro de contos, 17 x 11 in"
+
+#: ../src/common/paper.cpp:79
+msgid "Statement, 5 1/2 x 8 1/2 in"
+msgstr "Statement, 5 1/2 x 8 1/2 in"
+
+#: ../src/common/paper.cpp:80
+msgid "Executive, 7 1/4 x 10 1/2 in"
+msgstr "Executivo, 7 1/4 x 10 1/2 in"
+
+#: ../src/common/paper.cpp:81
+msgid "A3 sheet, 297 x 420 mm"
+msgstr "Fuella A3, 297 x 420 mm"
+
+#: ../src/common/paper.cpp:82
+msgid "A4 small sheet, 210 x 297 mm"
+msgstr "Fuella chicota A4, 210 x 297 mm"
+
+#: ../src/common/paper.cpp:83
+msgid "A5 sheet, 148 x 210 mm"
+msgstr "Fuella A5, 148 x 210 mm"
+
+#: ../src/common/paper.cpp:84
+msgid "B4 sheet, 250 x 354 mm"
+msgstr "Fuella B4, 250 x 354 mm"
+
+#: ../src/common/paper.cpp:85
+msgid "B5 sheet, 182 x 257 millimeter"
+msgstr "Fuella B5, 182 x 257 mm"
+
+#: ../src/common/paper.cpp:86
+msgid "Folio, 8 1/2 x 13 in"
+msgstr "Folio, 8 1/2 x 13 in"
+
+#: ../src/common/paper.cpp:87
+msgid "Quarto, 215 x 275 mm"
+msgstr "Quarto, 215 x 275 mm"
+
+#: ../src/common/paper.cpp:88
+msgid "10 x 14 in"
+msgstr "10 x 14 in"
+
+#: ../src/common/paper.cpp:89
+msgid "11 x 17 in"
+msgstr "11 x 17 in"
+
+#: ../src/common/paper.cpp:90
+msgid "Note, 8 1/2 x 11 in"
+msgstr "Nota, 8 1/2 x 11 in"
+
+#: ../src/common/paper.cpp:91
+msgid "#9 Envelope, 3 7/8 x 8 7/8 in"
+msgstr "Sobre #9, 3 7/8 x 8 7/8 in"
+
+#: ../src/common/paper.cpp:92
+msgid "#10 Envelope, 4 1/8 x 9 1/2 in"
+msgstr "Sobre #10, 4 1/8 x 9 1/2 in"
+
+#: ../src/common/paper.cpp:93
+msgid "#11 Envelope, 4 1/2 x 10 3/8 in"
+msgstr "Sobre #11, 4 1/2 x 10 3/8 in"
+
+#: ../src/common/paper.cpp:94
+msgid "#12 Envelope, 4 3/4 x 11 in"
+msgstr "Sobre #12, 4 3/4 x 11 in"
+
+#: ../src/common/paper.cpp:95
+msgid "#14 Envelope, 5 x 11 1/2 in"
+msgstr "Sobre #14, 5 x 11 1/2 in"
+
+#: ../src/common/paper.cpp:96
+msgid "DL Envelope, 110 x 220 mm"
+msgstr "Sobre DL, 110 x 220 mm"
+
+#: ../src/common/paper.cpp:97
+msgid "C5 Envelope, 162 x 229 mm"
+msgstr "Sobre C5, 162 x 229 mm"
+
+#: ../src/common/paper.cpp:98
+msgid "C3 Envelope, 324 x 458 mm"
+msgstr "Sobre C3, 324 x 458 mm"
+
+#: ../src/common/paper.cpp:99
+msgid "C4 Envelope, 229 x 324 mm"
+msgstr "Sobre C4, 229 x 324 mm"
+
+#: ../src/common/paper.cpp:100
+msgid "C6 Envelope, 114 x 162 mm"
+msgstr "Sobre C6, 114 x 162 mm"
+
+#: ../src/common/paper.cpp:101
+msgid "C65 Envelope, 114 x 229 mm"
+msgstr "Sobre C65, 114 x 229 mm"
+
+#: ../src/common/paper.cpp:102
+msgid "B4 Envelope, 250 x 353 mm"
+msgstr "Sobre B4, 250 x 353 mm"
+
+#: ../src/common/paper.cpp:103
+msgid "B5 Envelope, 176 x 250 mm"
+msgstr "Sobre B5, 176 x 250 mm"
+
+#: ../src/common/paper.cpp:104
+msgid "B6 Envelope, 176 x 125 mm"
+msgstr "Sobre B6, 176 x 125 mm"
+
+#: ../src/common/paper.cpp:105
+msgid "Italy Envelope, 110 x 230 mm"
+msgstr "Sobre Italián, 110 x 230 mm"
+
+#: ../src/common/paper.cpp:106
+msgid "Monarch Envelope, 3 7/8 x 7 1/2 in"
+msgstr "Sobre Monarch, 3 7/8 x 7 1/2 in"
+
+#: ../src/common/paper.cpp:107
+msgid "6 3/4 Envelope, 3 5/8 x 6 1/2 in"
+msgstr "Sobre 6 3/4, 3 5/8 x 6 1/2 in"
+
+#: ../src/common/paper.cpp:108
+msgid "US Std Fanfold, 14 7/8 x 11 in"
+msgstr "US Estandar en aventador, 14 7/8 x 11 in"
+
+#: ../src/common/paper.cpp:109
+msgid "German Std Fanfold, 8 1/2 x 12 in"
+msgstr "Estandar alemana en aventador, 8 1/2 x 12 in"
+
+#: ../src/common/paper.cpp:110
+msgid "German Legal Fanfold, 8 1/2 x 13 in"
+msgstr "Legal alemana en aventador, 8 1/2 x 13 in"
+
+#: ../src/common/paper.cpp:112
+msgid "B4 (ISO) 250 x 353 mm"
+msgstr "B4 (ISO) 250 x 353 mm"
+
+#: ../src/common/paper.cpp:113
+msgid "Japanese Postcard 100 x 148 mm"
+msgstr "Tarcheta Chaponesa 100 x 148 mm"
+
+#: ../src/common/paper.cpp:114
+msgid "9 x 11 in"
+msgstr "9 x 11 in"
+
+#: ../src/common/paper.cpp:115
+msgid "10 x 11 in"
+msgstr "10 x 11 in"
+
+#: ../src/common/paper.cpp:116
+msgid "15 x 11 in"
+msgstr "15 x 11 in"
+
+#: ../src/common/paper.cpp:117
+msgid "Envelope Invite 220 x 220 mm"
+msgstr "Sobre Invite 220 x 220 mm"
+
+#: ../src/common/paper.cpp:118
+msgid "Letter Extra 9 1/2 x 12 in"
+msgstr "Carta extra 9 1/2 x 12 in"
+
+#: ../src/common/paper.cpp:119
+msgid "Legal Extra 9 1/2 x 15 in"
+msgstr "Legal Extra 9 1/2 x 15 in"
+
+#: ../src/common/paper.cpp:120
+msgid "Tabloid Extra 11.69 x 18 in"
+msgstr "Tabloide Extra 11.69 x 18 in"
+
+#: ../src/common/paper.cpp:121
+msgid "A4 Extra 9.27 x 12.69 in"
+msgstr "A4 Extra 9.27 x 12.69 in"
+
+#: ../src/common/paper.cpp:122
+msgid "Letter Transverse 8 1/2 x 11 in"
+msgstr "Carta transversal 8 1/2 x 11 in"
+
+#: ../src/common/paper.cpp:123
+msgid "A4 Transverse 210 x 297 mm"
+msgstr "A4 Transversal 210 x 297 mm"
+
+#: ../src/common/paper.cpp:124
+msgid "Letter Extra Transverse 9.275 x 12 in"
+msgstr "Carta extra transversal 9.275 x 12 in"
+
+#: ../src/common/paper.cpp:125
+msgid "SuperA/SuperA/A4 227 x 356 mm"
+msgstr "SUPERA/SUPERA/A4 227 x 356 mm"
+
+#: ../src/common/paper.cpp:126
+msgid "SuperB/SuperB/A3 305 x 487 mm"
+msgstr "SuperB/SuperB/A3 305 x 487 mm"
+
+#: ../src/common/paper.cpp:127
+msgid "Letter Plus 8 1/2 x 12.69 in"
+msgstr "Carta Plus 8 1/2 x 12.69 in"
+
+#: ../src/common/paper.cpp:128
+msgid "A4 Plus 210 x 330 mm"
+msgstr "A4 Plus 210 x 330 mm"
+
+#: ../src/common/paper.cpp:129
+msgid "A5 Transverse 148 x 210 mm"
+msgstr "A5 Transversal 148 x 210 mm"
+
+#: ../src/common/paper.cpp:130
+msgid "B5 (JIS) Transverse 182 x 257 mm"
+msgstr "B5 (JIS) Transversal 182 x 257 mm"
+
+#: ../src/common/paper.cpp:131
+msgid "A3 Extra 322 x 445 mm"
+msgstr "A3 Extra 322 x 445 mm"
+
+#: ../src/common/paper.cpp:132
+msgid "A5 Extra 174 x 235 mm"
+msgstr "A5 Extra 174 x 235 mm"
+
+#: ../src/common/paper.cpp:133
+msgid "B5 (ISO) Extra 201 x 276 mm"
+msgstr "B5 (ISO) Extra 201 x 276 mm"
+
+#: ../src/common/paper.cpp:134
+msgid "A2 420 x 594 mm"
+msgstr "A2 420 x 594 mm"
+
+#: ../src/common/paper.cpp:135
+msgid "A3 Transverse 297 x 420 mm"
+msgstr "A3 Transversal 297 x 420 mm"
+
+#: ../src/common/paper.cpp:136
+msgid "A3 Extra Transverse 322 x 445 mm"
+msgstr "A3 Extra Transversal 322 x 445 mm"
+
+#: ../src/common/paper.cpp:138
+msgid "Japanese Double Postcard 200 x 148 mm"
+msgstr "Tarcheta Chaponesa Dople 200 x 148 mm"
+
+#: ../src/common/paper.cpp:139
+msgid "A6 105 x 148 mm"
+msgstr "A6 105 x 148 mm"
+
+#: ../src/common/paper.cpp:140
+msgid "Japanese Envelope Kaku #2"
+msgstr "Sobre chaponés Kaku #2"
+
+#: ../src/common/paper.cpp:141
+msgid "Japanese Envelope Kaku #3"
+msgstr "Sobre chaponés Kaku #3"
+
+#: ../src/common/paper.cpp:142
+msgid "Japanese Envelope Chou #3"
+msgstr "Sobre chaponés Chou #3"
+
+#: ../src/common/paper.cpp:143
+msgid "Japanese Envelope Chou #4"
+msgstr "Sobre chaponés Chou #4"
+
+#: ../src/common/paper.cpp:144
+msgid "Letter Rotated 11 x 8 1/2 in"
+msgstr "Carta chirada 11 x 8 1/2 in"
+
+#: ../src/common/paper.cpp:145
+msgid "A3 Rotated 420 x 297 mm"
+msgstr "A3 Chirada 420 x 297 mm"
+
+#: ../src/common/paper.cpp:146
+msgid "A4 Rotated 297 x 210 mm"
+msgstr "A4 Chirada 297 x 210 mm"
+
+#: ../src/common/paper.cpp:147
+msgid "A5 Rotated 210 x 148 mm"
+msgstr "A5 Chirada 210 x 148 mm"
+
+#: ../src/common/paper.cpp:148
+msgid "B4 (JIS) Rotated 364 x 257 mm"
+msgstr "B4 (JIS) Chirada 364 x 257 mm"
+
+#: ../src/common/paper.cpp:149
+msgid "B5 (JIS) Rotated 257 x 182 mm"
+msgstr "B5 (JIS) Chirada 257 x 182 mm"
+
+#: ../src/common/paper.cpp:150
+msgid "Japanese Postcard Rotated 148 x 100 mm"
+msgstr "Tarcheta Chaponesa Chirada 148 x 100 mm"
+
+#: ../src/common/paper.cpp:151
+msgid "Double Japanese Postcard Rotated 148 x 200 mm"
+msgstr "Tarcheta Chaponesa Dople Chirada 148 x 200 mm"
+
+#: ../src/common/paper.cpp:152
+msgid "A6 Rotated 148 x 105 mm"
+msgstr "A6 Chirada 148 x 105 mm"
+
+#: ../src/common/paper.cpp:153
+msgid "Japanese Envelope Kaku #2 Rotated"
+msgstr "Sobre chaponés Kaku #2 Chirau"
+
+#: ../src/common/paper.cpp:154
+msgid "Japanese Envelope Kaku #3 Rotated"
+msgstr "Sobre chaponés Kaku #3 Chirau"
+
+#: ../src/common/paper.cpp:155
+msgid "Japanese Envelope Chou #3 Rotated"
+msgstr "Sobre chaponés Chou #3 Chirau"
+
+#: ../src/common/paper.cpp:156
+msgid "Japanese Envelope Chou #4 Rotated"
+msgstr "Sobre chaponés Chou #4 Chirau"
+
+#: ../src/common/paper.cpp:157
+msgid "B6 (JIS) 128 x 182 mm"
+msgstr "B6 (JIS) 128 x 182 mm"
+
+#: ../src/common/paper.cpp:158
+msgid "B6 (JIS) Rotated 182 x 128 mm"
+msgstr "B6 (JIS) Chirada 182 x 128 mm"
+
+#: ../src/common/paper.cpp:159
+msgid "12 x 11 in"
+msgstr "12 x 11 in"
+
+#: ../src/common/paper.cpp:160
+msgid "Japanese Envelope You #4"
+msgstr "Sobre chaponés You #4"
+
+#: ../src/common/paper.cpp:161
+msgid "Japanese Envelope You #4 Rotated"
+msgstr "Sobre chaponés You #4 Chirau"
+
+#: ../src/common/paper.cpp:162
+msgid "PRC 16K 146 x 215 mm"
+msgstr "PRC 16K 146 x 215 mm"
+
+#: ../src/common/paper.cpp:163
+msgid "PRC 32K 97 x 151 mm"
+msgstr "PRC 32K 97 x 151 mm"
+
+#: ../src/common/paper.cpp:164
+msgid "PRC 32K(Big) 97 x 151 mm"
+msgstr "PRC 32K(Gran) 97 x 151 mm"
+
+#: ../src/common/paper.cpp:165
+msgid "PRC Envelope #1 102 x 165 mm"
+msgstr "Sobre PRC #1 102 x 165 mm"
+
+#: ../src/common/paper.cpp:166
+msgid "PRC Envelope #2 102 x 176 mm"
+msgstr "Sobre PRC#2 102 x 176 mm"
+
+#: ../src/common/paper.cpp:167
+msgid "PRC Envelope #3 125 x 176 mm"
+msgstr "Sobre PRC#3 125 x 176 mm"
+
+#: ../src/common/paper.cpp:168
+msgid "PRC Envelope #4 110 x 208 mm"
+msgstr "Sobre PRC#4 110 x 208 mm"
+
+#: ../src/common/paper.cpp:169
+msgid "PRC Envelope #5 110 x 220 mm"
+msgstr "Sobre PRC#5 110 x 220 mm"
+
+#: ../src/common/paper.cpp:170
+msgid "PRC Envelope #6 120 x 230 mm"
+msgstr "Sobre PRC#6 120 x 230 mm"
+
+#: ../src/common/paper.cpp:171
+msgid "PRC Envelope #7 160 x 230 mm"
+msgstr "Sobre PRC#7 160 x 230 mm"
+
+#: ../src/common/paper.cpp:172
+msgid "PRC Envelope #8 120 x 309 mm"
+msgstr "Sobre PRC#8 120 x 309 mm"
+
+#: ../src/common/paper.cpp:173
+msgid "PRC Envelope #9 229 x 324 mm"
+msgstr "Sobre PRC#9 229 x 324 mm"
+
+#: ../src/common/paper.cpp:174
+msgid "PRC Envelope #10 324 x 458 mm"
+msgstr "Sobre PRC #10 324 x 458 mm"
+
+#: ../src/common/paper.cpp:175
+msgid "PRC 16K Rotated"
+msgstr "PRC 16K Chirau"
+
+#: ../src/common/paper.cpp:176
+msgid "PRC 32K Rotated"
+msgstr "PRC 32K Chirau"
+
+#: ../src/common/paper.cpp:177
+msgid "PRC 32K(Big) Rotated"
+msgstr "PRC 32K(Gran) Chirau"
+
+#: ../src/common/paper.cpp:178
+msgid "PRC Envelope #1 Rotated 165 x 102 mm"
+msgstr "Sobre PRC #1 Chirau 165 x 102 mm"
+
+#: ../src/common/paper.cpp:179
+msgid "PRC Envelope #2 Rotated 176 x 102 mm"
+msgstr "Sobre PRC#2 Chirau 176 x 102 mm"
+
+#: ../src/common/paper.cpp:180
+msgid "PRC Envelope #3 Rotated 176 x 125 mm"
+msgstr "Sobre PRC#3 Chirau 176 x 125 mm"
+
+#: ../src/common/paper.cpp:181
+msgid "PRC Envelope #4 Rotated 208 x 110 mm"
+msgstr "Sobre PRC#4 Chirau 208 x 110 mm"
+
+#: ../src/common/paper.cpp:182
+msgid "PRC Envelope #5 Rotated 220 x 110 mm"
+msgstr "Sobre PRC#5 Chirau 220 x 110 mm"
+
+#: ../src/common/paper.cpp:183
+msgid "PRC Envelope #6 Rotated 230 x 120 mm"
+msgstr "Sobre PRC#6 Chirau 230 x 120 mm"
+
+#: ../src/common/paper.cpp:184
+msgid "PRC Envelope #7 Rotated 230 x 160 mm"
+msgstr "Sobre PRC#7 Chirau 230 x 160 mm"
+
+#: ../src/common/paper.cpp:185
+msgid "PRC Envelope #8 Rotated 309 x 120 mm"
+msgstr "Sobre PRC#8 Chirau 309 x 120 mm"
+
+#: ../src/common/paper.cpp:186
+msgid "PRC Envelope #9 Rotated 324 x 229 mm"
+msgstr "Sobre PRC#9 Chirau 324 x 229 mm"
+
+#: ../src/common/paper.cpp:187
+msgid "PRC Envelope #10 Rotated 458 x 324 mm"
+msgstr "Sobre PRC#10 Chirau 458 x 324 mm"
+
+#: ../src/common/paper.cpp:192
+msgid "A0 sheet, 841 x 1189 mm"
+msgstr "Fuella A0, 841 x 1189 mm"
+
+#: ../src/common/paper.cpp:193
+msgid "A1 sheet, 594 x 841 mm"
+msgstr "Fuella A1, 594 x 841 mm"
+
+#: ../src/common/preferencescmn.cpp:37
+msgid "General"
+msgstr "Cheneral"
+
+#: ../src/common/preferencescmn.cpp:40
+msgid "Advanced"
+msgstr "Abanzau"
+
+#: ../src/common/prntbase.cpp:245
+msgid "Generic PostScript"
+msgstr "PostScript chenerico"
+
+#: ../src/common/prntbase.cpp:259
+msgid "Ready"
+msgstr "Presto"
+
+#: ../src/common/prntbase.cpp:331
+msgid "Printing Error"
+msgstr "S'ha produciu una error d'impresión"
+
+#: ../src/common/prntbase.cpp:413 ../src/common/prntbase.cpp:1597
+#: ../src/generic/prntdlgg.cpp:135 ../src/generic/prntdlgg.cpp:149
+#: ../src/gtk/print.cpp:628 ../src/gtk/print.cpp:646
+msgid "Print"
+msgstr "Imprentar"
+
+#: ../src/common/prntbase.cpp:471 ../src/generic/prntdlgg.cpp:809
+msgid "Page setup"
+msgstr "Configurar a pachina"
+
+#: ../src/common/prntbase.cpp:525
+msgid "Please wait while printing..."
+msgstr "Por favor aguarda entre que s'imprenta..."
+
+#: ../src/common/prntbase.cpp:529
+msgid "Document:"
+msgstr "Documento:"
+
+#: ../src/common/prntbase.cpp:532
+msgid "Progress:"
+msgstr "Progreso:"
+
+#: ../src/common/prntbase.cpp:533
+msgid "Preparing"
+msgstr "Parando"
+
+#: ../src/common/prntbase.cpp:552
+#, fuzzy, c-format
+msgid "Printing page %d"
+msgstr "Imprentando a pachina %d..."
+
+#: ../src/common/prntbase.cpp:557
+#, c-format
+msgid "Printing page %d of %d"
+msgstr "Imprentando a pachina %d de %d"
+
+#: ../src/common/prntbase.cpp:560
+#, c-format
+msgid " (copy %d of %d)"
+msgstr " (copiar %d de %d)"
+
+#: ../src/common/prntbase.cpp:1604
+msgid "First page"
+msgstr "Primera pachina"
+
+#: ../src/common/prntbase.cpp:1609 ../src/html/helpwnd.cpp:659
+msgid "Previous page"
+msgstr "Pachina anterior"
+
+#: ../src/common/prntbase.cpp:1623 ../src/html/helpwnd.cpp:660
+msgid "Next page"
+msgstr "Pachina siguient"
+
+#: ../src/common/prntbase.cpp:1628
+msgid "Last page"
+msgstr "Zaguera pachina"
+
+#: ../src/common/prntbase.cpp:1636 ../src/common/stockitem.cpp:215
+msgid "Zoom Out"
+msgstr "Achiquir"
+
+#: ../src/common/prntbase.cpp:1650 ../src/common/stockitem.cpp:214
+msgid "Zoom In"
+msgstr "Agrandir"
+
+#: ../src/common/prntbase.cpp:1656 ../src/common/stockitem.cpp:153
+#: ../src/generic/logg.cpp:553 ../src/univ/themes/win32.cpp:3752
+msgid "&Close"
+msgstr "&Zarrar"
+
+#: ../src/common/prntbase.cpp:2085
+msgid "Could not start document preview."
+msgstr "No se puet encetar l'anvista previa d'o documento."
+
+#: ../src/common/prntbase.cpp:2085 ../src/common/prntbase.cpp:2129
+#: ../src/common/prntbase.cpp:2137
+msgid "Print Preview Failure"
+msgstr "S'ha produciu una error en l'anvista previa d'impresión"
+
+#: ../src/common/prntbase.cpp:2129 ../src/common/prntbase.cpp:2137
+msgid "Sorry, not enough memory to create a preview."
+msgstr "Memoria insuficient ta creyar l'anvista previa."
+
+#: ../src/common/prntbase.cpp:2144
+#, c-format
+msgid "Page %d of %d"
+msgstr "Pachina %d de %d"
+
+#: ../src/common/prntbase.cpp:2146
+#, c-format
+msgid "Page %d"
+msgstr "Pachina %d"
+
+#: ../src/common/regex.cpp:382 ../src/html/chm.cpp:348
+msgid "unknown error"
+msgstr "s'ha produciu una error desconoixida"
+
+#: ../src/common/regex.cpp:995
+#, c-format
+msgid "Invalid regular expression '%s': %s"
+msgstr "Expresión regular no valida '%s': %s"
+
+#: ../src/common/regex.cpp:1059
+#, c-format
+msgid "Failed to find match for regular expression: %s"
+msgstr ""
+"S'ha produciu una error en mirar as coincidencias ta la expresión regular: %s"
+
+#: ../src/common/rendcmn.cpp:188
+#, c-format
+msgid "Renderer \"%s\" has incompatible version %d.%d and couldn't be loaded."
+msgstr ""
+"O renderizador \"%s\" tién una versión %d.%d incompatible y no s'ha puesto "
+"ubrir."
+
+#: ../src/common/secretstore.cpp:162
+msgid "Not available for this platform"
+msgstr ""
+
+#: ../src/common/secretstore.cpp:183
+#, fuzzy, c-format
+msgid "Saving password for \"%s\" failed: %s."
+msgstr "Ha fallau a extracción de '%s' en '%s'."
+
+#: ../src/common/secretstore.cpp:205
+#, fuzzy, c-format
+msgid "Reading password for \"%s\" failed: %s."
+msgstr "Ha fallau a extracción de '%s' en '%s'."
+
+#: ../src/common/secretstore.cpp:228
+#, fuzzy, c-format
+msgid "Deleting password for \"%s\" failed: %s."
+msgstr "Ha fallau a extracción de '%s' en '%s'."
+
+#: ../src/common/selectdispatcher.cpp:254
+msgid "Failed to monitor I/O channels"
+msgstr "No s'ha puesto monitorizar as canals de dentrada/salida"
+
+#: ../src/common/sizer.cpp:3054 ../src/common/stockitem.cpp:195
+msgid "Save"
+msgstr "Alzar"
+
+#: ../src/common/sizer.cpp:3056
+msgid "Don't Save"
+msgstr "No alzar-lo"
+
+#: ../src/common/socket.cpp:870
+msgid "Cannot initialize sockets"
+msgstr "No se pueden inicializar os zocalos"
+
+#: ../src/common/stockitem.cpp:127
+#, fuzzy
+msgctxt "standard Windows menu"
+msgid "&Help"
+msgstr "&Aduya"
+
+#: ../src/common/stockitem.cpp:144
+msgid "&About"
+msgstr "&Arredol de"
+
+#: ../src/common/stockitem.cpp:144
+msgid "About"
+msgstr "Arredol de"
+
+#: ../src/common/stockitem.cpp:145
+msgid "Add"
+msgstr "Adhibir"
+
+#: ../src/common/stockitem.cpp:146
+msgid "&Apply"
+msgstr "&Aplicar"
+
+#: ../src/common/stockitem.cpp:146
+msgid "Apply"
+msgstr "Aplicar"
+
+#: ../src/common/stockitem.cpp:147
+msgid "&Back"
+msgstr "&Dezaga"
+
+#: ../src/common/stockitem.cpp:147
+msgid "Back"
+msgstr "Dezaga"
+
+#: ../src/common/stockitem.cpp:148
+msgid "&Bold"
+msgstr "&Negreta"
+
+#: ../src/common/stockitem.cpp:148 ../src/generic/fontdlgg.cpp:326
+#: ../src/richtext/richtextfontpage.cpp:354
+msgid "Bold"
+msgstr "Negreta"
+
+#: ../src/common/stockitem.cpp:149
+msgid "&Bottom"
+msgstr "&Inferior"
+
+#: ../src/common/stockitem.cpp:149 ../src/richtext/richtextsizepage.cpp:287
+msgid "Bottom"
+msgstr "Inferior"
+
+#: ../src/common/stockitem.cpp:150 ../src/generic/fontdlgg.cpp:462
+#: ../src/generic/fontdlgg.cpp:481 ../src/generic/wizard.cpp:415
+msgid "&Cancel"
+msgstr "&Cancelar"
+
+#: ../src/common/stockitem.cpp:151
+#, fuzzy
+msgid "&CD-ROM"
+msgstr "&CD-Rom"
+
+#: ../src/common/stockitem.cpp:151
+#, fuzzy
+msgid "CD-ROM"
+msgstr "CD-Rom"
+
+#: ../src/common/stockitem.cpp:152
+msgid "&Clear"
+msgstr "&Limpiar"
+
+#: ../src/common/stockitem.cpp:152
+msgid "Clear"
+msgstr "Limpiar"
+
+#: ../src/common/stockitem.cpp:153 ../src/generic/dbgrptg.cpp:93
+#: ../src/generic/progdlgg.cpp:778 ../src/html/helpdlg.cpp:86
+#: ../src/msw/progdlg.cpp:209 ../src/msw/progdlg.cpp:890
+#: ../src/richtext/richtextstyledlg.cpp:272
+#: ../src/richtext/richtextsymboldlg.cpp:448
+msgid "Close"
+msgstr "Zarrar"
+
+#: ../src/common/stockitem.cpp:154
+msgid "&Convert"
+msgstr "&Convertir"
+
+#: ../src/common/stockitem.cpp:154
+msgid "Convert"
+msgstr "Convertir"
+
+#: ../src/common/stockitem.cpp:155 ../src/msw/textctrl.cpp:2884
+#: ../src/osx/textctrl_osx.cpp:653 ../src/richtext/richtextctrl.cpp:331
+msgid "&Copy"
+msgstr "&Copiar"
+
+#: ../src/common/stockitem.cpp:155 ../src/stc/stc_i18n.cpp:18
+msgid "Copy"
+msgstr "Copiar"
+
+#: ../src/common/stockitem.cpp:156 ../src/msw/textctrl.cpp:2883
+#: ../src/osx/textctrl_osx.cpp:652 ../src/richtext/richtextctrl.cpp:330
+msgid "Cu&t"
+msgstr "&Tallar"
+
+#: ../src/common/stockitem.cpp:156 ../src/stc/stc_i18n.cpp:17
+msgid "Cut"
+msgstr "Tallar"
+
+#: ../src/common/stockitem.cpp:157 ../src/msw/textctrl.cpp:2886
+#: ../src/osx/textctrl_osx.cpp:655 ../src/richtext/richtextctrl.cpp:333
+#: ../src/richtext/richtexttabspage.cpp:137
+msgid "&Delete"
+msgstr "&Eliminar"
+
+#: ../src/common/stockitem.cpp:157 ../src/richtext/richtextbuffer.cpp:8266
+#: ../src/stc/stc_i18n.cpp:20
+msgid "Delete"
+msgstr "Eliminar"
+
+#: ../src/common/stockitem.cpp:158
+msgid "&Down"
+msgstr "A&baixo"
+
+#: ../src/common/stockitem.cpp:158 ../src/generic/fdrepdlg.cpp:148
+msgid "Down"
+msgstr "Abaixo"
+
+#: ../src/common/stockitem.cpp:159
+msgid "&Edit"
+msgstr "&Editar"
+
+#: ../src/common/stockitem.cpp:159
+msgid "Edit"
+msgstr "Editar"
+
+#: ../src/common/stockitem.cpp:160
+msgid "&Execute"
+msgstr "&Executar"
+
+#: ../src/common/stockitem.cpp:160
+msgid "Execute"
+msgstr "Executar"
+
+#: ../src/common/stockitem.cpp:161
+msgid "&Quit"
+msgstr "&Salir"
+
+#: ../src/common/stockitem.cpp:161
+msgid "Quit"
+msgstr "Salir"
+
+#: ../src/common/stockitem.cpp:162
+msgid "&File"
+msgstr "&Fichero"
+
+#: ../src/common/stockitem.cpp:162
+msgid "File"
+msgstr "Fichero"
+
+#: ../src/common/stockitem.cpp:163
+#, fuzzy
+msgid "&Find..."
+msgstr "&Mirar"
+
+#: ../src/common/stockitem.cpp:163
+#, fuzzy
+msgid "Find..."
+msgstr "Mirar"
+
+#: ../src/common/stockitem.cpp:164
+msgid "&First"
+msgstr "&Primer"
+
+#: ../src/common/stockitem.cpp:164
+msgid "First"
+msgstr "Primeºr"
+
+#: ../src/common/stockitem.cpp:165
+msgid "&Floppy"
+msgstr "&Disquet"
+
+#: ../src/common/stockitem.cpp:165
+msgid "Floppy"
+msgstr "Disquet"
+
+#: ../src/common/stockitem.cpp:166
+msgid "&Forward"
+msgstr "Abanz"
+
+#: ../src/common/stockitem.cpp:166
+msgid "Forward"
+msgstr "Recular"
+
+#: ../src/common/stockitem.cpp:167
+msgid "&Harddisk"
+msgstr "&Disco duro"
+
+#: ../src/common/stockitem.cpp:167
+msgid "Harddisk"
+msgstr "Disco duro"
+
+#: ../src/common/stockitem.cpp:168 ../src/generic/wizard.cpp:418
+#: ../src/osx/cocoa/menu.mm:225 ../src/richtext/richtextstyledlg.cpp:298
+#: ../src/richtext/richtextsymboldlg.cpp:451
+msgid "&Help"
+msgstr "&Aduya"
+
+#: ../src/common/stockitem.cpp:169
+msgid "&Home"
+msgstr "&Inicio"
+
+#: ../src/common/stockitem.cpp:169
+msgid "Home"
+msgstr "Inicio"
+
+#: ../src/common/stockitem.cpp:170
+msgid "Indent"
+msgstr "Escalonau"
+
+#: ../src/common/stockitem.cpp:171
+msgid "&Index"
+msgstr "Ind&iz"
+
+#: ../src/common/stockitem.cpp:171 ../src/html/helpwnd.cpp:510
+msgid "Index"
+msgstr "Indiz"
+
+#: ../src/common/stockitem.cpp:172
+msgid "&Info"
+msgstr "&Información"
+
+#: ../src/common/stockitem.cpp:172
+msgid "Info"
+msgstr "Información"
+
+#: ../src/common/stockitem.cpp:173
+msgid "&Italic"
+msgstr "Curs&iva"
+
+#: ../src/common/stockitem.cpp:173 ../src/generic/fontdlgg.cpp:322
+#: ../src/richtext/richtextfontpage.cpp:350
+msgid "Italic"
+msgstr "Cursiva"
+
+#: ../src/common/stockitem.cpp:174
+msgid "&Jump to"
+msgstr "&Blincar ta"
+
+#: ../src/common/stockitem.cpp:174
+msgid "Jump to"
+msgstr "Blincar ta"
+
+#: ../src/common/stockitem.cpp:175
+msgid "Centered"
+msgstr "Centrau"
+
+#: ../src/common/stockitem.cpp:176
+msgid "Justified"
+msgstr "Chustificau"
+
+#: ../src/common/stockitem.cpp:177
+msgid "Align Left"
+msgstr "Aliniar a la cucha"
+
+#: ../src/common/stockitem.cpp:178
+msgid "Align Right"
+msgstr "Aliniar a la dreita"
+
+#: ../src/common/stockitem.cpp:179
+msgid "&Last"
+msgstr "&Zaguer"
+
+#: ../src/common/stockitem.cpp:179
+msgid "Last"
+msgstr "Zaguer"
+
+#: ../src/common/stockitem.cpp:180
+msgid "&Network"
+msgstr "&Ret"
+
+#: ../src/common/stockitem.cpp:180
+msgid "Network"
+msgstr "Ret"
+
+#: ../src/common/stockitem.cpp:181 ../src/richtext/richtexttabspage.cpp:131
+msgid "&New"
+msgstr "&Nuevo"
+
+#: ../src/common/stockitem.cpp:181
+msgid "New"
+msgstr "Nuevo"
+
+#: ../src/common/stockitem.cpp:182 ../src/msw/msgdlg.cpp:417
+msgid "&No"
+msgstr "&No"
+
+#: ../src/common/stockitem.cpp:183 ../src/generic/fontdlgg.cpp:467
+#: ../src/generic/fontdlgg.cpp:474
+msgid "&OK"
+msgstr "&Acceptar"
+
+#: ../src/common/stockitem.cpp:184 ../src/generic/dbgrptg.cpp:341
+msgid "&Open..."
+msgstr "U&brir..."
+
+#: ../src/common/stockitem.cpp:184
+msgid "Open..."
+msgstr "Ubrir..."
+
+#: ../src/common/stockitem.cpp:185 ../src/msw/textctrl.cpp:2885
+#: ../src/osx/textctrl_osx.cpp:654 ../src/richtext/richtextctrl.cpp:332
+msgid "&Paste"
+msgstr "&Apegar"
+
+#: ../src/common/stockitem.cpp:185 ../src/richtext/richtextctrl.cpp:3484
+#: ../src/stc/stc_i18n.cpp:19
+msgid "Paste"
+msgstr "Apegar"
+
+#: ../src/common/stockitem.cpp:186
+msgid "&Preferences"
+msgstr "&Preferencias"
+
+#: ../src/common/stockitem.cpp:186 ../src/osx/cocoa/preferences.mm:304
+msgid "Preferences"
+msgstr "Preferencias"
+
+#: ../src/common/stockitem.cpp:187
+msgid "Print previe&w..."
+msgstr "An&vista previa d'imprentau..."
+
+#: ../src/common/stockitem.cpp:187
+msgid "Print preview..."
+msgstr "Anvista previa d'imprentau..."
+
+#: ../src/common/stockitem.cpp:188
+msgid "&Print..."
+msgstr "Im&prentar..."
+
+#: ../src/common/stockitem.cpp:188
+msgid "Print..."
+msgstr "Imprentar..."
+
+#: ../src/common/stockitem.cpp:189 ../src/richtext/richtextctrl.cpp:337
+#: ../src/richtext/richtextctrl.cpp:5479
+msgid "&Properties"
+msgstr "&Propiedatz"
+
+#: ../src/common/stockitem.cpp:189
+msgid "Properties"
+msgstr "Propiedatz"
+
+#: ../src/common/stockitem.cpp:190 ../src/stc/stc_i18n.cpp:16
+msgid "Redo"
+msgstr "Refer"
+
+#: ../src/common/stockitem.cpp:191
+msgid "Refresh"
+msgstr "Refrescar"
+
+#: ../src/common/stockitem.cpp:192
+msgid "Remove"
+msgstr "Eliminar"
+
+#: ../src/common/stockitem.cpp:193
+#, fuzzy
+msgid "Rep&lace..."
+msgstr "&Substituir"
+
+#: ../src/common/stockitem.cpp:193
+#, fuzzy
+msgid "Replace..."
+msgstr "Substituir"
+
+#: ../src/common/stockitem.cpp:194
+msgid "Revert to Saved"
+msgstr "Recuperar a versión alzada"
+
+#: ../src/common/stockitem.cpp:196 ../src/generic/logg.cpp:549
+msgid "Save &As..."
+msgstr "&Alzar como..."
+
+#: ../src/common/stockitem.cpp:196
+#, fuzzy
+msgid "Save As..."
+msgstr "&Alzar como..."
+
+#: ../src/common/stockitem.cpp:197 ../src/msw/textctrl.cpp:2888
+#: ../src/osx/textctrl_osx.cpp:657 ../src/richtext/richtextctrl.cpp:335
+msgid "Select &All"
+msgstr "Seleccionar-lo &Tot"
+
+#: ../src/common/stockitem.cpp:197 ../src/stc/stc_i18n.cpp:21
+msgid "Select All"
+msgstr "Seleccionar-lo tot"
+
+#: ../src/common/stockitem.cpp:198
+msgid "&Color"
+msgstr "&Color"
+
+#: ../src/common/stockitem.cpp:198
+msgid "Color"
+msgstr "Color"
+
+#: ../src/common/stockitem.cpp:199
+msgid "&Font"
+msgstr "&Fuent"
+
+#: ../src/common/stockitem.cpp:199 ../src/richtext/richtextformatdlg.cpp:336
+msgid "Font"
+msgstr "Fuent"
+
+#: ../src/common/stockitem.cpp:200
+msgid "&Ascending"
+msgstr "&Ascendent"
+
+#: ../src/common/stockitem.cpp:200
+msgid "Ascending"
+msgstr "Ascendent"
+
+#: ../src/common/stockitem.cpp:201
+msgid "&Descending"
+msgstr "&Descendent"
+
+#: ../src/common/stockitem.cpp:201
+msgid "Descending"
+msgstr "Descendent"
+
+#: ../src/common/stockitem.cpp:202
+msgid "&Spell Check"
+msgstr "&Revisar ortografía"
+
+#: ../src/common/stockitem.cpp:202
+msgid "Spell Check"
+msgstr "Ortografía"
+
+#: ../src/common/stockitem.cpp:203
+msgid "&Stop"
+msgstr "&Aturar"
+
+#: ../src/common/stockitem.cpp:203
+msgid "Stop"
+msgstr "Aturar"
+
+#: ../src/common/stockitem.cpp:204 ../src/richtext/richtextfontpage.cpp:274
+msgid "&Strikethrough"
+msgstr "&Rayau"
+
+#: ../src/common/stockitem.cpp:204
+msgid "Strikethrough"
+msgstr "Rayau"
+
+#: ../src/common/stockitem.cpp:205
+msgid "&Top"
+msgstr "&Superior"
+
+#: ../src/common/stockitem.cpp:205 ../src/richtext/richtextsizepage.cpp:285
+#: ../src/richtext/richtextsizepage.cpp:289
+msgid "Top"
+msgstr "Superior"
+
+#: ../src/common/stockitem.cpp:206
+msgid "Undelete"
+msgstr "Restaurar"
+
+#: ../src/common/stockitem.cpp:207 ../src/generic/fontdlgg.cpp:437
+msgid "&Underline"
+msgstr "S&ubrayau"
+
+#: ../src/common/stockitem.cpp:207
+msgid "Underline"
+msgstr "Subrayau"
+
+#: ../src/common/stockitem.cpp:208 ../src/stc/stc_i18n.cpp:15
+msgid "Undo"
+msgstr "Desfer"
+
+#: ../src/common/stockitem.cpp:209
+msgid "&Unindent"
+msgstr "&No escalonau"
+
+#: ../src/common/stockitem.cpp:209
+msgid "Unindent"
+msgstr "Sin escalonau"
+
+#: ../src/common/stockitem.cpp:210
+msgid "&Up"
+msgstr "&Alto"
+
+#: ../src/common/stockitem.cpp:210 ../src/generic/fdrepdlg.cpp:148
+msgid "Up"
+msgstr "Alto"
+
+#: ../src/common/stockitem.cpp:211 ../src/msw/msgdlg.cpp:417
+msgid "&Yes"
+msgstr "&Sí"
+
+#: ../src/common/stockitem.cpp:212
+msgid "&Actual Size"
+msgstr "Grandaria &real"
+
+#: ../src/common/stockitem.cpp:212
+msgid "Actual Size"
+msgstr "Grandaria real"
+
+#: ../src/common/stockitem.cpp:213
+msgid "Zoom to &Fit"
+msgstr "&Achustar a la grandaria"
+
+#: ../src/common/stockitem.cpp:213
+msgid "Zoom to Fit"
+msgstr "Achustar l'anvista"
+
+#: ../src/common/stockitem.cpp:214
+msgid "Zoom &In"
+msgstr "A&manar"
+
+#: ../src/common/stockitem.cpp:215
+msgid "Zoom &Out"
+msgstr "A&luenyar"
+
+#: ../src/common/stockitem.cpp:262
+msgid "Show about dialog"
+msgstr "Amostrar o dialogo Sobre"
+
+#: ../src/common/stockitem.cpp:263
+msgid "Copy selection"
+msgstr "Copiar a selección"
+
+#: ../src/common/stockitem.cpp:264
+msgid "Cut selection"
+msgstr "Tallar a selección"
+
+#: ../src/common/stockitem.cpp:265
+msgid "Delete selection"
+msgstr "Esborrar a selección"
+
+#: ../src/common/stockitem.cpp:266
+#, fuzzy
+msgid "Find in document"
+msgstr "Ubrir un documento HTML"
+
+#: ../src/common/stockitem.cpp:267
+msgid "Find and replace in document"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:268
+msgid "Paste selection"
+msgstr "Apegar a selección"
+
+#: ../src/common/stockitem.cpp:269
+msgid "Quit this program"
+msgstr "Salir d'iste programa"
+
+#: ../src/common/stockitem.cpp:270
+msgid "Redo last action"
+msgstr "Refer a zaguera acción"
+
+#: ../src/common/stockitem.cpp:271
+msgid "Undo last action"
+msgstr "Desfer a zaguera acción"
+
+#: ../src/common/stockitem.cpp:272
+#, fuzzy
+msgid "Create new document"
+msgstr "Creyar un nuevo directorio"
+
+#: ../src/common/stockitem.cpp:273
+#, fuzzy
+msgid "Open an existing document"
+msgstr "Ubrir un documento HTML"
+
+#: ../src/common/stockitem.cpp:274
+msgid "Close current document"
+msgstr "Zarrar o documento actual"
+
+#: ../src/common/stockitem.cpp:275
+msgid "Save current document"
+msgstr "Alzar o documento actual"
+
+#: ../src/common/stockitem.cpp:276
+msgid "Save current document with a different filename"
+msgstr "Alzar o documento actual con unatro nombre"
+
+#: ../src/common/strconv.cpp:2324
+#, c-format
+msgid "Conversion to charset '%s' doesn't work."
+msgstr "A conversión t'o chuego de caracters '%s' no funciona."
+
+#: ../src/common/tarstrm.cpp:352 ../src/common/tarstrm.cpp:375
+#: ../src/common/tarstrm.cpp:406 ../src/generic/progdlgg.cpp:373
+msgid "unknown"
+msgstr "desconoixiu"
+
+#: ../src/common/tarstrm.cpp:774
+msgid "incomplete header block in tar"
+msgstr "bloque de capitero incompleto en tar"
+
+#: ../src/common/tarstrm.cpp:798
+msgid "checksum failure reading tar header block"
+msgstr ""
+"s'ha produciu una error de suma de comprebación leyendo lo bloque de "
+"capitero de tar"
+
+#: ../src/common/tarstrm.cpp:971
+msgid "invalid data in extended tar header"
+msgstr "datos no validos en o capitero de tar extendiu"
+
+#: ../src/common/tarstrm.cpp:981 ../src/common/tarstrm.cpp:1003
+#: ../src/common/tarstrm.cpp:1477 ../src/common/tarstrm.cpp:1499
+msgid "tar entry not open"
+msgstr "dentrada tar no ubierta"
+
+#: ../src/common/tarstrm.cpp:1023
+msgid "unexpected end of file"
+msgstr "fin de fichero inasperau"
+
+#: ../src/common/tarstrm.cpp:1297
+#, c-format
+msgid "%s did not fit the tar header for entry '%s'"
+msgstr "%s no encaixaba en o capitero tar ta la dentrada '%s'"
+
+#: ../src/common/tarstrm.cpp:1359
+msgid "incorrect size given for tar entry"
+msgstr "grandaria incorrecta ta la dentrada de tar"
+
+#: ../src/common/textbuf.cpp:232
+#, c-format
+msgid "'%s' is probably a binary buffer."
+msgstr "'%s' ye prebablement un fichero binario."
+
+#: ../src/common/textcmn.cpp:1006 ../src/richtext/richtextctrl.cpp:3053
+msgid "File couldn't be loaded."
+msgstr "No s'ha puesto cargar o fichero."
+
+#: ../src/common/textfile.cpp:95
+#, fuzzy, c-format
+msgid "Failed to read text file \"%s\"."
+msgstr "No s'ha puesto leyer o documento dende \"%s\"."
+
+#: ../src/common/textfile.cpp:160
+#, c-format
+msgid "can't write buffer '%s' to disk."
+msgstr "no se puet alzar o buffer '%s' en o disco."
+
+#: ../src/common/time.cpp:212
+msgid "Failed to get the local system time"
+msgstr "S'ha produciu una error en obtener o sistema horario local"
+
+#: ../src/common/time.cpp:279
+msgid "wxGetTimeOfDay failed."
+msgstr "Ha fallau o wxGetTimeOfDay."
+
+#: ../src/common/translation.cpp:929
+#, c-format
+msgid "'%s' is not a valid message catalog."
+msgstr "'%s' no ye un catalogo de mensaches valiu."
+
+#: ../src/common/translation.cpp:954
+msgid "Invalid message catalog."
+msgstr "Catalogo de mensaches invalido."
+
+#: ../src/common/translation.cpp:1013
+#, c-format
+msgid "Failed to parse Plural-Forms: '%s'"
+msgstr "No s'ha puesto analisar as formas plurals: '%s'"
+
+#: ../src/common/translation.cpp:1723
+#, c-format
+msgid "using catalog '%s' from '%s'."
+msgstr "usando lo catalogo '%s' de '%s'."
+
+#: ../src/common/translation.cpp:1816
+#, c-format
+msgid "Resource '%s' is not a valid message catalog."
+msgstr "O recurso '%s' no ye un catalogo valido de mensaches."
+
+#: ../src/common/translation.cpp:1865
+msgid "Couldn't enumerate translations"
+msgstr "No s'han puesto enumerar as traduccions"
+
+#: ../src/common/utilscmn.cpp:1145
+msgid "No default application configured for HTML files."
+msgstr "No bi ha garra aplicación configurada ta os documentos HTML."
+
+#: ../src/common/utilscmn.cpp:1190
+#, c-format
+msgid "Failed to open URL \"%s\" in default browser."
+msgstr "No s'ha puesto ubrir a URL \"%s\" en o navegador predeterminau."
+
+#: ../src/common/valtext.cpp:144
+msgid "Validation conflict"
+msgstr "Conflicto de validación"
+
+#: ../src/common/valtext.cpp:186
+msgid "Required information entry is empty."
+msgstr "A dentrada d'información requerida ye vueda."
+
+#: ../src/common/valtext.cpp:188
+#, c-format
+msgid "'%s' is one of the invalid strings"
+msgstr "'%s' ye una d'as cadenas invalidas"
+
+#: ../src/common/valtext.cpp:190
+#, c-format
+msgid "'%s' is not one of the valid strings"
+msgstr "'%s' no ye una d'as cadenas validas"
+
+#: ../src/common/valtext.cpp:199
+#, fuzzy, c-format
+msgid "'%s' contains invalid character(s)"
+msgstr "'%s' contién caracters no validos"
+
+#: ../src/common/webrequest.cpp:139
+#, fuzzy, c-format
+msgid "Error: %s (%d)"
+msgstr "Error: "
+
+#: ../src/common/webrequest.cpp:655
+#, c-format
+msgid ""
+"Not enough free disk space for download: %llu needed but only %llu available."
+msgstr ""
+
+#: ../src/common/webrequest.cpp:669
+#, fuzzy, c-format
+msgid "Failed to create temporary file in %s"
+msgstr "S'ha produciu una error en creyar un nombre temporal de fichero"
+
+#: ../src/common/webrequest_curl.cpp:1106
+#, fuzzy
+msgid "libcurl could not be initialized"
+msgstr "No s'ha puesto inicializar a descripción de columna."
+
+#: ../src/common/webview.cpp:392
+msgid "RunScriptAsync not supported"
+msgstr ""
+
+#: ../src/common/webview.cpp:403 ../src/msw/webview_ie.cpp:1073
+#, c-format
+msgid "Error running JavaScript: %s"
+msgstr ""
+
+#: ../src/common/webview_chromium.cpp:858
+#, fuzzy, c-format
+msgid "Failed to set proxy \"%s\": %s"
+msgstr "S'ha produciu una error en creyar o directorio \"%s\""
+
+#: ../src/common/webview_chromium.cpp:989
+msgid ""
+"Chromium can't be used because libcef.so wasn't loaded early enough; please "
+"relink the application or use LD_PRELOAD to load it earlier."
+msgstr ""
+
+#: ../src/common/webview_chromium.cpp:1108
+#, fuzzy
+msgid "Could not initialize Chromium"
+msgstr "No s'ha puesto establir l'aliniación."
+
+#: ../src/common/webview_chromium.cpp:1616
+msgid "Show DevTools"
+msgstr ""
+
+#: ../src/common/webview_chromium.cpp:1617
+#, fuzzy
+msgid "Close DevTools"
+msgstr "Zarrar-lo Tot"
+
+#: ../src/common/webview_chromium.cpp:1623
+msgid "Inspect"
+msgstr ""
+
+#: ../src/common/wincmn.cpp:1628
+msgid "This platform does not support background transparency."
+msgstr "Ista plataforma no suporta a transparencia d'o fondo."
+
+#: ../src/common/wincmn.cpp:2097
+msgid "Could not transfer data to window"
+msgstr "No se pueden transferir datos ta la finestra"
+
+#: ../src/common/windowid.cpp:240
+msgid "Out of window IDs.  Recommend shutting down application."
+msgstr ""
+"Difuera d'os identificadors de finestra.  Ye recomendable zarrar "
+"l'aplicación."
+
+#: ../src/common/xpmdecod.cpp:678
+msgid "XPM: incorrect header format!"
+msgstr "XPM: formato de capitero incorrecto!"
+
+#: ../src/common/xpmdecod.cpp:703
+#, c-format
+msgid "XPM: incorrect colour description in line %d"
+msgstr "XPM: definición de color erronia en a linia %d"
+
+#: ../src/common/xpmdecod.cpp:715 ../src/common/xpmdecod.cpp:724
+#, c-format
+msgid "XPM: malformed colour definition '%s' at line %d!"
+msgstr "XPM: definición de color erronia '%s' en a linia %d!"
+
+#: ../src/common/xpmdecod.cpp:754
+msgid "XPM: no colors left to use for mask!"
+msgstr "XPM: No s'han deixau colors ta fer-las servir en a mascara!"
+
+#: ../src/common/xpmdecod.cpp:781
+#, c-format
+msgid "XPM: truncated image data at line %d!"
+msgstr "XPM: datos d'imachen truncaus en a linia %d!"
+
+#: ../src/common/xpmdecod.cpp:795
+msgid "XPM: Malformed pixel data!"
+msgstr "XPM: Datos de pixel erronios!"
+
+#: ../src/common/xti.cpp:492
+msgid "Illegal Parameter Count for Create Method"
+msgstr "Numero ilegal de parametros ta lo metodo Create"
+
+#: ../src/common/xti.cpp:504
+msgid "Illegal Parameter Count for ConstructObject Method"
+msgstr "Numero ilegal de parametros ta lo metodo ConstructObject"
+
+#: ../src/common/xtistrm.cpp:161
+#, c-format
+msgid "Create Parameter %s not found in declared RTTI Parameters"
+msgstr ""
+"No s'ha trobau creyar parametro %s not found en os parametrosRTTI declaraus"
+
+#: ../src/common/xtistrm.cpp:290
+msgid "Illegal Object Class (Non-wxEvtHandler) as Event Source"
+msgstr "Clase d'obchecto (Non-wxEvtHandler) como Event Source ilegal"
+
+#: ../src/common/xtistrm.cpp:313 ../src/common/xtixml.cpp:345
+#: ../src/common/xtixml.cpp:498
+msgid "Type must have enum - long conversion"
+msgstr "O tipo ha de tener conversión d'enum ta long"
+
+#: ../src/common/xtistrm.cpp:400 ../src/common/xtistrm.cpp:415
+msgid "Invalid or Null Object ID passed to GetObjectClassInfo"
+msgstr "Identificador d'obchecto pasau a GetObjectClassInfo nulo u invalido"
+
+#: ../src/common/xtistrm.cpp:405
+msgid "Unknown Object passed to GetObjectClassInfo"
+msgstr "Obchecto desconoixiu pasau a GetObjectClassInfo"
+
+#: ../src/common/xtistrm.cpp:420
+msgid "Already Registered Object passed to SetObjectClassInfo"
+msgstr "S'ha pasau un Obchecto Ya Rechistrau a SetObjectClassInfo"
+
+#: ../src/common/xtistrm.cpp:430
+msgid "Invalid or Null Object ID passed to HasObjectClassInfo"
+msgstr "Identificador d'obchecto pasau a HasObjectClassInfo nulo u invalido"
+
+#: ../src/common/xtistrm.cpp:460
+msgid "Passing a already registered object to SetObject"
+msgstr "Paso d'un obchecto ya rechistrau a SetObject"
+
+#: ../src/common/xtistrm.cpp:471
+msgid "Passing an unknown object to GetObject"
+msgstr "Pasando-le un obchecto desconoixiu a GetObject"
+
+#: ../src/common/xtixml.cpp:229
+msgid "Forward hrefs are not supported"
+msgstr "As referencias de tipo forward no son suportadas"
+
+#: ../src/common/xtixml.cpp:247
+#, c-format
+msgid "unknown class %s"
+msgstr "clase %s desconoixida"
+
+#: ../src/common/xtixml.cpp:253
+msgid "objects cannot have XML Text Nodes"
+msgstr "os obchectos no pueden tener nodos XML de texto"
+
+#: ../src/common/xtixml.cpp:258
+msgid "Objects must have an id attribute"
+msgstr "Os obchectos han a tener un atributo d'identificación"
+
+#: ../src/common/xtixml.cpp:267
+#, c-format
+msgid "Doubly used id : %d"
+msgstr "Identificador duplicau: %d"
+
+#: ../src/common/xtixml.cpp:316
+#, c-format
+msgid "Unknown Property %s"
+msgstr "Propiedat desconoixida %s"
+
+#: ../src/common/xtixml.cpp:407
+msgid "A non empty collection must consist of 'element' nodes"
+msgstr "Una colección no vueda ha de consistir en nodos d'a clase 'elemento'"
+
+#: ../src/common/xtixml.cpp:478
+msgid "incorrect event handler string, missing dot"
+msgstr "cadena d'identificador d'evento incorrecta, i falta o punto"
+
+#: ../src/common/zipstrm.cpp:559
+msgid "can't re-initialize zlib deflate stream"
+msgstr "no se puet reinicializar o fluxo de compresión de zlib."
+
+#: ../src/common/zipstrm.cpp:584
+msgid "can't re-initialize zlib inflate stream"
+msgstr "no se puet reinicializar o fluxo de descompresión de zlib"
+
+#: ../src/common/zipstrm.cpp:1023
+msgid "Ignoring malformed extra data record, ZIP file may be corrupted"
+msgstr ""
+
+#: ../src/common/zipstrm.cpp:1502
+msgid "assuming this is a multi-part zip concatenated"
+msgstr "se suposa que ye un fichero zip multiparti concatenau"
+
+#: ../src/common/zipstrm.cpp:1664
+msgid "invalid zip file"
+msgstr "fichero zip no valido"
+
+#: ../src/common/zipstrm.cpp:1723
+msgid "can't find central directory in zip"
+msgstr "no se puet trobar o directorio central en o zip"
+
+#: ../src/common/zipstrm.cpp:1812
+msgid "error reading zip central directory"
+msgstr "s'ha produciu una error en leyer o directorio central d'o zip"
+
+#: ../src/common/zipstrm.cpp:1916
+msgid "error reading zip local header"
+msgstr "s'ha produciu una error en leyer o capitero local d'o fichero zip"
+
+#: ../src/common/zipstrm.cpp:1964
+msgid "bad zipfile offset to entry"
+msgstr "desplazamiento erronio ta l'elemento d'o fichero zip"
+
+#: ../src/common/zipstrm.cpp:2031
+msgid "stored file length not in Zip header"
+msgstr "a longaria d'o fichero almagazenau no ye en o capitero d'o Zip"
+
+#: ../src/common/zipstrm.cpp:2045 ../src/common/zipstrm.cpp:2362
+msgid "unsupported Zip compression method"
+msgstr "metodo de compresión de Zip no suportau"
+
+#: ../src/common/zipstrm.cpp:2126
+#, c-format
+msgid "reading zip stream (entry %s): bad length"
+msgstr "a lo leyer o fluxo de zip (elemento %s): longaria erronia"
+
+#: ../src/common/zipstrm.cpp:2131
+#, c-format
+msgid "reading zip stream (entry %s): bad crc"
+msgstr "a lo leyer o fluxo de zip (elemento %s): crc erronio"
+
+#: ../src/common/zipstrm.cpp:2578
+#, fuzzy, c-format
+msgid "error writing zip entry '%s': file too large without ZIP64"
+msgstr ""
+"s'ha produciu una error en escribir l'elemento de zip '%s': crc u longaria "
+"erronios"
+
+#: ../src/common/zipstrm.cpp:2585
+#, c-format
+msgid "error writing zip entry '%s': bad crc or length"
+msgstr ""
+"s'ha produciu una error en escribir l'elemento de zip '%s': crc u longaria "
+"erronios"
+
+#: ../src/common/zstream.cpp:155 ../src/common/zstream.cpp:315
+msgid "Gzip not supported by this version of zlib"
+msgstr "Gzip no ye suportau por ista versión de zlib"
+
+#: ../src/common/zstream.cpp:182
+msgid "Can't initialize zlib inflate stream."
+msgstr "No se puet inicializar o fluxo de descompresión de zlib."
+
+#: ../src/common/zstream.cpp:241
+msgid "Can't read inflate stream: unexpected EOF in underlying stream."
+msgstr ""
+"Ye imposible leyer o fluxo de descompresión: Fin de fichero inasperau en o "
+"fluxo subchacent."
+
+#: ../src/common/zstream.cpp:248 ../src/common/zstream.cpp:423
+#, c-format
+msgid "zlib error %d"
+msgstr "s'ha produciu a error de zlib %d"
+
+#: ../src/common/zstream.cpp:249
+#, c-format
+msgid "Can't read from inflate stream: %s"
+msgstr "No se puet leyer dende o fluxo de descompresión %s"
+
+#: ../src/common/zstream.cpp:343
+msgid "Can't initialize zlib deflate stream."
+msgstr "No se puet inicializar o fluxo de compresión de zlib."
+
+#: ../src/common/zstream.cpp:424
+#, c-format
+msgid "Can't write to deflate stream: %s"
+msgstr "No se puet escribir en o fluxo de compresión %s"
+
+#: ../src/dfb/bitmap.cpp:633 ../src/dfb/bitmap.cpp:667
+#, c-format
+msgid "No bitmap handler for type %d defined."
+msgstr "No bi ha garra maniador de mapa de bits ta la mena %d definida."
+
+#: ../src/dfb/evtloop.cpp:99
+msgid "Failed to read event from DirectFB pipe"
+msgstr "No s'ha puesto leyer l'evento dende a canal DirectFB"
+
+#: ../src/dfb/evtloop.cpp:171
+msgid "Failed to switch DirectFB pipe to non-blocking mode"
+msgstr "No s'ha puesto cambiar a canyería ta lo modo de no bloqueyo"
+
+#: ../src/dfb/fontmgr.cpp:171
+#, c-format
+msgid "no fonts found in %s, using builtin font"
+msgstr "no s'han trobau fuents en %s, se ye usando a fuent integrada"
+
+#: ../src/dfb/fontmgr.cpp:177
+msgid "Default font"
+msgstr "Fuent predeterminada"
+
+#: ../src/dfb/fontmgr.cpp:195
+#, c-format
+msgid "Fonts index file %s disappeared while loading fonts."
+msgstr ""
+"O fichero indiz de fuents %s ha desapareixiu entre que se cargaban fuents."
+
+#: ../src/dfb/wrapdfb.cpp:60
+#, c-format
+msgid "DirectFB error %d occurred."
+msgstr "S'ha produciu a error %d de DirectFB."
+
+#: ../src/generic/aboutdlgg.cpp:69
+msgid "Developed by "
+msgstr "Desembolicau por "
+
+#: ../src/generic/aboutdlgg.cpp:72
+msgid "Documentation by "
+msgstr "Documentau por "
+
+#: ../src/generic/aboutdlgg.cpp:75
+msgid "Graphics art by "
+msgstr "Graficos por "
+
+#: ../src/generic/aboutdlgg.cpp:78
+msgid "Translations by "
+msgstr "Traduccions por "
+
+#: ../src/generic/aboutdlgg.cpp:133 ../src/osx/cocoa/aboutdlg.mm:83
+msgid "Version "
+msgstr "Versión "
+
+#. TRANSLATORS: %s is application name
+#: ../src/generic/aboutdlgg.cpp:146 ../src/msw/aboutdlg.cpp:60
+#, c-format
+msgid "About %s"
+msgstr "Arredol de %s"
+
+#: ../src/generic/aboutdlgg.cpp:181
+msgid "License"
+msgstr "Licencia"
+
+#: ../src/generic/aboutdlgg.cpp:184
+msgid "Developers"
+msgstr "Desembolicadors"
+
+#: ../src/generic/aboutdlgg.cpp:188
+msgid "Documentation writers"
+msgstr "Escritors de documentos"
+
+#: ../src/generic/aboutdlgg.cpp:192
+msgid "Artists"
+msgstr "Artistas"
+
+#: ../src/generic/aboutdlgg.cpp:196
+msgid "Translators"
+msgstr "Traductors"
+
+#: ../src/generic/animateg.cpp:125
+msgid "No handler found for animation type."
+msgstr "No s'ha trobau garra maniador ta la mena d'animación."
+
+#: ../src/generic/animateg.cpp:133
+#, c-format
+msgid "No animation handler for type %ld defined."
+msgstr "No bi ha definiu garra maniador d'animación ta la mena%ld."
+
+#: ../src/generic/animateg.cpp:145
+#, c-format
+msgid "Animation file is not of type %ld."
+msgstr "O fichero d'animación no ye de tipo %ld."
+
+#: ../src/generic/colrdlgg.cpp:154 ../src/gtk/colordlg.cpp:47
+msgid "Choose colour"
+msgstr "Trigar a color"
+
+#: ../src/generic/colrdlgg.cpp:357
+msgid "Red:"
+msgstr ""
+
+#: ../src/generic/colrdlgg.cpp:360
+#, fuzzy
+msgid "Green:"
+msgstr "Mac Griego"
+
+#: ../src/generic/colrdlgg.cpp:363
+msgid "Blue:"
+msgstr ""
+
+#: ../src/generic/colrdlgg.cpp:372
+msgid "Opacity:"
+msgstr ""
+
+#: ../src/generic/colrdlgg.cpp:384
+msgid "Add to custom colours"
+msgstr "Adhibir a las colors personalizadas"
+
+#: ../src/generic/creddlgg.cpp:56
+msgid "Username:"
+msgstr ""
+
+#: ../src/generic/creddlgg.cpp:63
+msgid "Password:"
+msgstr ""
+
+#. TRANSLATORS: Name of Boolean true value
+#: ../src/generic/datavgen.cpp:1178
+msgid "true"
+msgstr ""
+
+#. TRANSLATORS: Name of Boolean false value
+#: ../src/generic/datavgen.cpp:1180
+#, fuzzy
+msgid "false"
+msgstr "Falso"
+
+#: ../src/generic/datavgen.cpp:6897
+#, c-format
+msgid "Row %i"
+msgstr ""
+
+#. TRANSLATORS: Action for manipulating a tree control
+#: ../src/generic/datavgen.cpp:6987
+msgid "Collapse"
+msgstr ""
+
+#. TRANSLATORS: Action for manipulating a tree control
+#: ../src/generic/datavgen.cpp:6990
+msgid "Expand"
+msgstr ""
+
+#. TRANSLATORS: Name of data view control and number of rows
+#: ../src/generic/datavgen.cpp:7011
+#, fuzzy, c-format
+msgid "%s (%d items)"
+msgstr "%s (u %s)"
+
+#: ../src/generic/datavgen.cpp:7062
+#, fuzzy, c-format
+msgid "Column %u"
+msgstr "Adhibir unacolumna"
+
+#. TRANSLATORS: Keystroke for manipulating a tree control
+#: ../src/generic/datavgen.cpp:7131 ../src/richtext/richtextbulletspage.cpp:189
+#: ../src/richtext/richtextbulletspage.cpp:192
+#: ../src/richtext/richtextbulletspage.cpp:193
+#: ../src/richtext/richtextliststylepage.cpp:252
+#: ../src/richtext/richtextliststylepage.cpp:255
+#: ../src/richtext/richtextliststylepage.cpp:256
+#: ../src/richtext/richtextsizepage.cpp:248
+msgid "Left"
+msgstr "Cucha"
+
+#. TRANSLATORS: Keystroke for manipulating a tree control
+#: ../src/generic/datavgen.cpp:7134 ../src/richtext/richtextbulletspage.cpp:191
+#: ../src/richtext/richtextliststylepage.cpp:254
+#: ../src/richtext/richtextsizepage.cpp:249
+msgid "Right"
+msgstr "Dreita"
+
+#: ../src/generic/datectlg.cpp:90
+#, c-format
+msgid ""
+"\"%s\" is not in the expected date format, please enter it as e.g. \"%s\"."
+msgstr ""
+
+#: ../src/generic/datectlg.cpp:94
+#, fuzzy
+msgid "Invalid date"
+msgstr "Elemento d'anvista de datos invalido"
+
+#: ../src/generic/dbgrptg.cpp:159
+#, c-format
+msgid "Open file \"%s\""
+msgstr "Ubrir o fichero \"%s\""
+
+#: ../src/generic/dbgrptg.cpp:170
+#, c-format
+msgid "Enter command to open file \"%s\":"
+msgstr "Introduz o comando ta ubrir o fichero \"%s\":"
+
+#: ../src/generic/dbgrptg.cpp:230
+msgid "Executable files (*.exe)|*.exe|"
+msgstr "Fichers executables (*.exe)|*.exe|"
+
+#: ../src/generic/dbgrptg.cpp:300
+#, c-format
+msgid "Debug report \"%s\""
+msgstr "Reporte de depuración \"%s\""
+
+#: ../src/generic/dbgrptg.cpp:316
+msgid "A debug report has been generated in the directory\n"
+msgstr "S'ha chenerau un reporte de depuración en o directorio\n"
+
+#: ../src/generic/dbgrptg.cpp:317
+msgid "The following debug report will be generated\n"
+msgstr ""
+
+#: ../src/generic/dbgrptg.cpp:321
+msgid ""
+"The report contains the files listed below. If any of these files contain "
+"private information,\n"
+"please uncheck them and they will be removed from the report.\n"
+msgstr ""
+"O reporte contién os fichers amostraus abaixo. Si belún d'istos fichers "
+"contién información privada,\n"
+"por favor, desmarca-los y serán eliminaus d'o reporte.\n"
+
+#: ../src/generic/dbgrptg.cpp:323
+msgid ""
+"If you wish to suppress this debug report completely, please choose the "
+"\"Cancel\" button,\n"
+"but be warned that it may hinder improving the program, so if\n"
+"at all possible please do continue with the report generation.\n"
+msgstr ""
+"Si deseyas eliminar iste reporte de depuración de raso, por favor, triga lo "
+"botón \"Cancelar\",\n"
+"pero saba que isto no aduya a la millora d'o programa, por tanto, si\n"
+"ye posible, por favor, contina con a cheneración d'o reporte.\n"
+
+#: ../src/generic/dbgrptg.cpp:325
+msgid "              Thank you and we're sorry for the inconvenience!\n"
+msgstr "              Gracias y desincuse as molestias!\n"
+
+#: ../src/generic/dbgrptg.cpp:333
+msgid "&Debug report preview:"
+msgstr "&Anvista previa d'o reporte de depuración:"
+
+#: ../src/generic/dbgrptg.cpp:339
+msgid "&View..."
+msgstr "An&vista..."
+
+#: ../src/generic/dbgrptg.cpp:359
+msgid "&Notes:"
+msgstr "&Notas:"
+
+#: ../src/generic/dbgrptg.cpp:361
+msgid ""
+"If you have any additional information pertaining to this bug\n"
+"report, please enter it here and it will be joined to it:"
+msgstr ""
+"Si tiens bella información adicional tocant a iste reporte\n"
+"d'error, por favor, introduce-lo aquí y en será adchuntau:"
+
+#: ../src/generic/dcpsg.cpp:1627
+msgid "Cannot open file for PostScript printing!"
+msgstr "No se puet ubrir o fichero ta impresión PostScript!"
+
+#: ../src/generic/dirctrlg.cpp:402
+msgid "Computer"
+msgstr "Ordinador"
+
+#: ../src/generic/dirctrlg.cpp:404
+msgid "Sections"
+msgstr "Seccions"
+
+#: ../src/generic/dirctrlg.cpp:482
+msgid "Home directory"
+msgstr "Directorio prencipal"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/generic/dirctrlg.cpp:484 ../src/propgrid/advprops.cpp:811
+msgid "Desktop"
+msgstr "Escritorio"
+
+#: ../src/generic/dirctrlg.cpp:528 ../src/generic/filectrlg.cpp:752
+msgid "Illegal directory name."
+msgstr "Nombre de directorio ilegal."
+
+#: ../src/generic/dirctrlg.cpp:528 ../src/generic/dirctrlg.cpp:546
+#: ../src/generic/dirctrlg.cpp:557 ../src/generic/dirdlgg.cpp:317
+#: ../src/generic/filectrlg.cpp:638 ../src/generic/filectrlg.cpp:752
+#: ../src/generic/filectrlg.cpp:766 ../src/generic/filectrlg.cpp:782
+#: ../src/generic/filectrlg.cpp:1356 ../src/generic/filectrlg.cpp:1387
+#: ../src/generic/filedlgg.cpp:362 ../src/gtk/filedlg.cpp:76
+msgid "Error"
+msgstr "Error"
+
+#: ../src/generic/dirctrlg.cpp:546 ../src/generic/filectrlg.cpp:766
+msgid "File name exists already."
+msgstr "Ya existe un fichero con o mesmo nombre."
+
+#: ../src/generic/dirctrlg.cpp:557 ../src/generic/dirdlgg.cpp:317
+#: ../src/generic/filectrlg.cpp:638 ../src/generic/filectrlg.cpp:782
+msgid "Operation not permitted."
+msgstr "Operación no permitida."
+
+#: ../src/generic/dirdlgg.cpp:107 ../src/generic/filedlgg.cpp:207
+msgid "Create new directory"
+msgstr "Creyar un nuevo directorio"
+
+#: ../src/generic/dirdlgg.cpp:112 ../src/generic/filedlgg.cpp:203
+msgid "Go to home directory"
+msgstr "Ir ta lo directorio prencipal"
+
+#: ../src/generic/dirdlgg.cpp:143
+msgid "Show &hidden directories"
+msgstr "Amostrar os directorios &amagaus"
+
+#: ../src/generic/dirdlgg.cpp:196
+#, c-format
+msgid ""
+"The directory '%s' does not exist\n"
+"Create it now?"
+msgstr ""
+"O directorio '%s' no existe\n"
+"Creyar-lo agora?"
+
+#: ../src/generic/dirdlgg.cpp:198
+msgid "Directory does not exist"
+msgstr "O directorio no existe"
+
+#: ../src/generic/dirdlgg.cpp:214
+#, c-format
+msgid ""
+"Failed to create directory '%s'\n"
+"(Do you have the required permissions?)"
+msgstr ""
+"S'ha produciu una error en creyar o directorio '%s'\n"
+"(Tiens os permisos necesarios?)"
+
+#: ../src/generic/dirdlgg.cpp:216
+msgid "Error creating directory"
+msgstr "S'ha produciu una error en creyar o directorio"
+
+#: ../src/generic/dirdlgg.cpp:281
+msgid "You cannot add a new directory to this section."
+msgstr "No puetz adhibir un nuevo directorio a ista sección."
+
+#: ../src/generic/dirdlgg.cpp:282
+msgid "Create directory"
+msgstr "Creyar un directorio"
+
+#: ../src/generic/dirdlgg.cpp:291 ../src/generic/dirdlgg.cpp:301
+#: ../src/generic/filectrlg.cpp:614 ../src/generic/filectrlg.cpp:623
+msgid "NewName"
+msgstr "Nuevo Nombre"
+
+#: ../src/generic/editlbox.cpp:135
+msgid "Edit item"
+msgstr "Editar l'elemento"
+
+#: ../src/generic/editlbox.cpp:143
+msgid "New item"
+msgstr "Nuevo elemento"
+
+#: ../src/generic/editlbox.cpp:151
+msgid "Delete item"
+msgstr "Eliminar l'elemento"
+
+#: ../src/generic/editlbox.cpp:159
+msgid "Move up"
+msgstr "Mover enta alto"
+
+#: ../src/generic/editlbox.cpp:164
+msgid "Move down"
+msgstr "Mover enta baixo"
+
+#: ../src/generic/fdrepdlg.cpp:108
+msgid "Search for:"
+msgstr "Mirar por:"
+
+#: ../src/generic/fdrepdlg.cpp:120
+msgid "Replace with:"
+msgstr "Substituir por:"
+
+#: ../src/generic/fdrepdlg.cpp:140
+msgid "Whole word"
+msgstr "Parola completa"
+
+#: ../src/generic/fdrepdlg.cpp:143
+msgid "Match case"
+msgstr "Coincidir as mayusclas y minusclas"
+
+#: ../src/generic/fdrepdlg.cpp:156
+msgid "Search direction"
+msgstr "Adreza d'a busca"
+
+#: ../src/generic/fdrepdlg.cpp:175
+msgid "&Replace"
+msgstr "&Substituir"
+
+#: ../src/generic/fdrepdlg.cpp:178
+msgid "Replace &all"
+msgstr "Substituir-lo &tot"
+
+#: ../src/generic/filectrlg.cpp:246 ../src/generic/filectrlg.cpp:269
+msgid "<DIR>"
+msgstr "<DIR>"
+
+#: ../src/generic/filectrlg.cpp:248 ../src/generic/filectrlg.cpp:271
+msgid "<LINK>"
+msgstr "<VINCLO>"
+
+#: ../src/generic/filectrlg.cpp:250 ../src/generic/filectrlg.cpp:273
+msgid "<DRIVE>"
+msgstr "<UNIDAT>"
+
+#: ../src/generic/filectrlg.cpp:275
+#, c-format
+msgid "%ld byte"
+msgid_plural "%ld bytes"
+msgstr[0] "%ld byte"
+msgstr[1] "%ld bytes"
+
+#: ../src/generic/filectrlg.cpp:420
+msgid "Name"
+msgstr "Nombre"
+
+#: ../src/generic/filectrlg.cpp:421 ../src/richtext/richtextformatdlg.cpp:361
+#: ../src/richtext/richtextsizepage.cpp:298
+msgid "Size"
+msgstr "Grandaria"
+
+#: ../src/generic/filectrlg.cpp:422
+msgid "Type"
+msgstr "Tipo"
+
+#: ../src/generic/filectrlg.cpp:423
+msgid "Modified"
+msgstr "Modificau"
+
+#: ../src/generic/filectrlg.cpp:426
+msgid "Permissions"
+msgstr "Permisos"
+
+#: ../src/generic/filectrlg.cpp:429
+msgid "Attributes"
+msgstr "Atributos"
+
+#: ../src/generic/filectrlg.cpp:936
+msgid "Current directory:"
+msgstr "Directorio actual:"
+
+#: ../src/generic/filectrlg.cpp:979
+msgid "Show &hidden files"
+msgstr "Amostrar os fichers &amagaus"
+
+#: ../src/generic/filectrlg.cpp:1355
+msgid "Illegal file specification."
+msgstr "Especificación de fichero ilegal."
+
+#: ../src/generic/filectrlg.cpp:1387
+msgid "Directory doesn't exist."
+msgstr "O directorio no existe."
+
+#: ../src/generic/filedlgg.cpp:195
+msgid "View files as a list view"
+msgstr "Veyer os fichers en anvista de lista"
+
+#: ../src/generic/filedlgg.cpp:197
+msgid "View files as a detailed view"
+msgstr "Veyer os fichers en anvista de detalle"
+
+#: ../src/generic/filedlgg.cpp:200
+msgid "Go to parent directory"
+msgstr "Ir ta lo directorio pai"
+
+#: ../src/generic/filedlgg.cpp:351 ../src/gtk/filedlg.cpp:59
+#, c-format
+msgid "File '%s' already exists, do you really want to overwrite it?"
+msgstr "O fichero '%s' ya existe, realment quiers sobrescribir-lo?"
+
+#: ../src/generic/filedlgg.cpp:354 ../src/gtk/filedlg.cpp:62
+msgid "Confirm"
+msgstr "Confirmar"
+
+#: ../src/generic/filedlgg.cpp:362 ../src/gtk/filedlg.cpp:75
+msgid "Please choose an existing file."
+msgstr "Por favor triga un fichero existent."
+
+#: ../src/generic/filepickerg.cpp:64
+msgid "..."
+msgstr "..."
+
+#: ../src/generic/fontdlgg.cpp:76 ../src/richtext/richtextformatdlg.cpp:519
+msgid "ABCDEFGabcdefg12345"
+msgstr "ABCDEFGabcdefg12345"
+
+#: ../src/generic/fontdlgg.cpp:315
+msgid "Roman"
+msgstr "Román"
+
+#: ../src/generic/fontdlgg.cpp:316
+msgid "Decorative"
+msgstr "Decorativo"
+
+#: ../src/generic/fontdlgg.cpp:317
+msgid "Modern"
+msgstr "Moderno"
+
+#: ../src/generic/fontdlgg.cpp:318
+msgid "Script"
+msgstr "Script"
+
+#: ../src/generic/fontdlgg.cpp:319
+msgid "Swiss"
+msgstr "Swiss"
+
+#: ../src/generic/fontdlgg.cpp:320
+msgid "Teletype"
+msgstr "Teletipo"
+
+#: ../src/generic/fontdlgg.cpp:321 ../src/generic/fontdlgg.cpp:324
+msgid "Normal"
+msgstr "Normal"
+
+#: ../src/generic/fontdlgg.cpp:323
+msgid "Slant"
+msgstr "Cursiva"
+
+#: ../src/generic/fontdlgg.cpp:325
+msgid "Light"
+msgstr "Lichera"
+
+#: ../src/generic/fontdlgg.cpp:363
+msgid "&Font family:"
+msgstr "Tipo de &fuent:"
+
+#: ../src/generic/fontdlgg.cpp:367 ../src/generic/fontdlgg.cpp:369
+msgid "The font family."
+msgstr "O tipo de fuent."
+
+#: ../src/generic/fontdlgg.cpp:374 ../src/richtext/richtextstylepage.cpp:105
+msgid "&Style:"
+msgstr "E&stilo:"
+
+#: ../src/generic/fontdlgg.cpp:378 ../src/generic/fontdlgg.cpp:380
+msgid "The font style."
+msgstr "O estilo de fuent."
+
+#: ../src/generic/fontdlgg.cpp:385
+msgid "&Weight:"
+msgstr "&Peso:"
+
+#: ../src/generic/fontdlgg.cpp:389 ../src/generic/fontdlgg.cpp:391
+msgid "The font weight."
+msgstr "O peso d'a fuent."
+
+#: ../src/generic/fontdlgg.cpp:399
+msgid "C&olour:"
+msgstr "C&olor:"
+
+#: ../src/generic/fontdlgg.cpp:407 ../src/generic/fontdlgg.cpp:409
+msgid "The font colour."
+msgstr "A color de fuent."
+
+#: ../src/generic/fontdlgg.cpp:415
+msgid "&Point size:"
+msgstr "Grandaria de &punto:"
+
+#: ../src/generic/fontdlgg.cpp:420 ../src/generic/fontdlgg.cpp:422
+#: ../src/generic/fontdlgg.cpp:426 ../src/generic/fontdlgg.cpp:428
+msgid "The font point size."
+msgstr "A grandaria d'a fuent en puntos."
+
+#: ../src/generic/fontdlgg.cpp:439 ../src/generic/fontdlgg.cpp:441
+msgid "Whether the font is underlined."
+msgstr "Si a fuent ye subrayada."
+
+#: ../src/generic/fontdlgg.cpp:448 ../src/html/helpwnd.cpp:1215
+msgid "Preview:"
+msgstr "Anvista previa:"
+
+#: ../src/generic/fontdlgg.cpp:452 ../src/generic/fontdlgg.cpp:454
+msgid "Shows the font preview."
+msgstr "Amuestra l'anvista previa d'a fuent."
+
+#: ../src/generic/fontdlgg.cpp:464 ../src/generic/fontdlgg.cpp:483
+msgid "Click to cancel the font selection."
+msgstr "Fe clic ta cancelar a selección de fuent."
+
+#: ../src/generic/fontdlgg.cpp:469 ../src/generic/fontdlgg.cpp:471
+#: ../src/generic/fontdlgg.cpp:476 ../src/generic/fontdlgg.cpp:478
+msgid "Click to confirm the font selection."
+msgstr "Fe clic ta confirmar a selección de fuent."
+
+#: ../src/generic/fontpickerg.cpp:50 ../src/gtk/fontdlg.cpp:77
+msgid "Choose font"
+msgstr "Trigar a fuent"
+
+#: ../src/generic/grid.cpp:6542
+msgid ""
+"Error copying grid to the clipboard. Either selected cells were not "
+"contiguous or no cell was selected."
+msgstr ""
+
+#: ../src/generic/grid.cpp:12739
+#, fuzzy
+msgid "Grid Corner"
+msgstr "Cantonada"
+
+#: ../src/generic/grid.cpp:12741
+#, fuzzy, c-format
+msgid "Column %s Header"
+msgstr "Adhibir unacolumna"
+
+#: ../src/generic/grid.cpp:12743
+#, c-format
+msgid "Row %s Header"
+msgstr ""
+
+#: ../src/generic/grid.cpp:12745
+#, fuzzy, c-format
+msgid "Column %s: %s"
+msgstr "Adhibir unacolumna"
+
+#: ../src/generic/grid.cpp:12749
+#, c-format
+msgid "Row %s: %s"
+msgstr ""
+
+#: ../src/generic/grid.cpp:12753
+#, c-format
+msgid "Row %s, Column %s: %s"
+msgstr ""
+
+#: ../src/generic/helpext.cpp:257
+#, c-format
+msgid "Help directory \"%s\" not found."
+msgstr "Directorio d'aduya \"%s\" no trobau."
+
+#: ../src/generic/helpext.cpp:265
+#, c-format
+msgid "Help file \"%s\" not found."
+msgstr "Fichero d'aduya \"%s\" no trobau."
+
+#: ../src/generic/helpext.cpp:284
+#, c-format
+msgid "Line %lu of map file \"%s\" has invalid syntax, skipped."
+msgstr ""
+"A linia %lu d'o fichero de mapa \"%s\" tien una sintaxi no valida, ye estau "
+"blincau."
+
+#: ../src/generic/helpext.cpp:292
+#, c-format
+msgid "No valid mappings found in the file \"%s\"."
+msgstr "No s'han trobau mapiaus validos en o fichero \"%s\"."
+
+#: ../src/generic/helpext.cpp:435
+msgid "No entries found."
+msgstr "No s'han trobau dentradas."
+
+#: ../src/generic/helpext.cpp:444 ../src/generic/helpext.cpp:445
+msgid "Help Index"
+msgstr "Indiz de l'Aduya"
+
+#: ../src/generic/helpext.cpp:448
+msgid "Relevant entries:"
+msgstr "Dentradas relevants:"
+
+#: ../src/generic/helpext.cpp:449
+msgid "Entries found"
+msgstr "Dentradas trobadas"
+
+#: ../src/generic/hyperlinkg.cpp:170
+msgid "&Copy URL"
+msgstr "&Copiar URL"
+
+#: ../src/generic/infobar.cpp:119
+msgid "Hide this notification message."
+msgstr "Amagar iste mensache de notificación."
+
+#. TRANSLATORS: %s will be either the application name or "Application"
+#: ../src/generic/logg.cpp:257
+#, c-format
+msgid "%s Error"
+msgstr "%s Error"
+
+#. TRANSLATORS: %s will be either the application name or "Application"
+#: ../src/generic/logg.cpp:263
+#, c-format
+msgid "%s Warning"
+msgstr "%s Alvertencia"
+
+#. TRANSLATORS: %s will be either the application name or "Application"
+#: ../src/generic/logg.cpp:273
+#, c-format
+msgid "%s Information"
+msgstr "%s Información"
+
+#: ../src/generic/logg.cpp:276
+msgid "Application"
+msgstr "Aplicación"
+
+#: ../src/generic/logg.cpp:549
+msgid "Save log contents to file"
+msgstr "Alzar os contenius d'o log en un fichero"
+
+#: ../src/generic/logg.cpp:551
+msgid "C&lear"
+msgstr "&Limpiar"
+
+#: ../src/generic/logg.cpp:551
+msgid "Clear the log contents"
+msgstr "Eliminar os contenius d'o rechistro"
+
+#: ../src/generic/logg.cpp:553
+msgid "Close this window"
+msgstr "Zarrar ista finestra"
+
+#: ../src/generic/logg.cpp:554
+msgid "&Log"
+msgstr "&Rechistro"
+
+#: ../src/generic/logg.cpp:610 ../src/generic/logg.cpp:992
+msgid "Can't save log contents to file."
+msgstr "No se pueden alzar os contenius d'o rechistro en un fichero."
+
+#: ../src/generic/logg.cpp:613
+#, c-format
+msgid "Log saved to the file '%s'."
+msgstr "Rechistro alzau en o fichero '%s'."
+
+#: ../src/generic/logg.cpp:719
+msgid "&Details"
+msgstr "&Detalles"
+
+#: ../src/generic/logg.cpp:972
+msgid "Failed to copy dialog contents to the clipboard."
+msgstr ""
+"S'ha produciu una error en copiar os contenius d'o dialogo en o portafuellas."
+
+#: ../src/generic/logg.cpp:1022
+#, c-format
+msgid "Append log to file '%s' (choosing [No] will overwrite it)?"
+msgstr ""
+"Adhibir o rechistro a lo fichero '%s'? (si triga [No] se sobrescribirá o "
+"fichero)"
+
+#: ../src/generic/logg.cpp:1024
+msgid "Question"
+msgstr "Pregunta"
+
+#: ../src/generic/logg.cpp:1038
+msgid "invalid message box return value"
+msgstr "avalor de retorno de servilla de dentrada no ye valida"
+
+#: ../src/generic/notifmsgg.cpp:129
+msgid "Notice"
+msgstr "Aviso"
+
+#: ../src/generic/preferencesg.cpp:118
+#, c-format
+msgid "%s Preferences"
+msgstr "%s Preferencias"
+
+#: ../src/generic/printps.cpp:143
+msgid "Printing..."
+msgstr "Imprentando..."
+
+#: ../src/generic/printps.cpp:160 ../src/gtk/print.cpp:1076
+#: ../src/msw/printwin.cpp:235
+msgid "Could not start printing."
+msgstr "No se puet encetar a impresión."
+
+#: ../src/generic/printps.cpp:183
+#, c-format
+msgid "Printing page %d..."
+msgstr "Imprentando a pachina %d..."
+
+#: ../src/generic/prntdlgg.cpp:171
+msgid "Printer options"
+msgstr "Opcions d'impresión"
+
+#: ../src/generic/prntdlgg.cpp:176
+msgid "Print to File"
+msgstr "Imprentar-lo en un Fichero"
+
+#: ../src/generic/prntdlgg.cpp:179
+msgid "Setup..."
+msgstr "Configuración..."
+
+#: ../src/generic/prntdlgg.cpp:187
+msgid "Printer:"
+msgstr "Impresora:"
+
+#: ../src/generic/prntdlgg.cpp:195
+msgid "Status:"
+msgstr "Estau:"
+
+#: ../src/generic/prntdlgg.cpp:206
+msgid "All"
+msgstr "Tot"
+
+#: ../src/generic/prntdlgg.cpp:207
+msgid "Pages"
+msgstr "Pachinas"
+
+#: ../src/generic/prntdlgg.cpp:215
+msgid "Print Range"
+msgstr "Rango d'Impresión"
+
+#: ../src/generic/prntdlgg.cpp:229
+msgid "From:"
+msgstr "De:"
+
+#: ../src/generic/prntdlgg.cpp:233
+msgid "To:"
+msgstr "Dica:"
+
+#: ../src/generic/prntdlgg.cpp:238
+msgid "Copies:"
+msgstr "Copias:"
+
+#: ../src/generic/prntdlgg.cpp:288
+msgid "PostScript file"
+msgstr "Fichero PostScript"
+
+#: ../src/generic/prntdlgg.cpp:439
+msgid "Print Setup"
+msgstr "Configuración d'Impresión"
+
+#: ../src/generic/prntdlgg.cpp:483
+msgid "Printer"
+msgstr "Impresora"
+
+#: ../src/generic/prntdlgg.cpp:501
+msgid "Default printer"
+msgstr "Impresora predeterminada"
+
+#: ../src/generic/prntdlgg.cpp:595 ../src/generic/prntdlgg.cpp:782
+#: ../src/generic/prntdlgg.cpp:822 ../src/generic/prntdlgg.cpp:835
+#: ../src/generic/prntdlgg.cpp:1031 ../src/generic/prntdlgg.cpp:1036
+msgid "Paper size"
+msgstr "Grandaria d'o paper"
+
+#: ../src/generic/prntdlgg.cpp:604 ../src/generic/prntdlgg.cpp:847
+msgid "Portrait"
+msgstr "Vertical"
+
+#: ../src/generic/prntdlgg.cpp:605 ../src/generic/prntdlgg.cpp:848
+msgid "Landscape"
+msgstr "Horizontal"
+
+#: ../src/generic/prntdlgg.cpp:607 ../src/generic/prntdlgg.cpp:849
+msgid "Orientation"
+msgstr "Orientación"
+
+#: ../src/generic/prntdlgg.cpp:610
+msgid "Options"
+msgstr "Opcions"
+
+#: ../src/generic/prntdlgg.cpp:612
+msgid "Print in colour"
+msgstr "Impresión en color"
+
+#: ../src/generic/prntdlgg.cpp:621
+msgid "Print spooling"
+msgstr "Coda d'impresión"
+
+#: ../src/generic/prntdlgg.cpp:623
+msgid "Printer command:"
+msgstr "Comando d'impresión:"
+
+#: ../src/generic/prntdlgg.cpp:631
+msgid "Printer options:"
+msgstr "Opcions d'impresora:"
+
+#: ../src/generic/prntdlgg.cpp:860
+msgid "Left margin (mm):"
+msgstr "Marguin cucha (mm):"
+
+#: ../src/generic/prntdlgg.cpp:861
+msgid "Top margin (mm):"
+msgstr "Marguin superior (mm):"
+
+#: ../src/generic/prntdlgg.cpp:872
+msgid "Right margin (mm):"
+msgstr "Marguin dreita (mm):"
+
+#: ../src/generic/prntdlgg.cpp:873
+msgid "Bottom margin (mm):"
+msgstr "Marguin inferior (mm):"
+
+#: ../src/generic/prntdlgg.cpp:896
+msgid "Printer..."
+msgstr "Impresora..."
+
+#: ../src/generic/progdlgg.cpp:246
+msgid "&Skip"
+msgstr "&Privar"
+
+#: ../src/generic/progdlgg.cpp:347 ../src/generic/progdlgg.cpp:626
+msgid "Unknown"
+msgstr "Desconoixiu"
+
+#: ../src/generic/progdlgg.cpp:451 ../src/msw/progdlg.cpp:526
+msgid "Done."
+msgstr "Feito."
+
+#: ../src/generic/srchctlg.cpp:55 ../src/gtk/srchctrl.cpp:206
+#: ../src/html/helpwnd.cpp:530 ../src/html/helpwnd.cpp:545
+msgid "Search"
+msgstr "Mirar"
+
+#: ../src/generic/tabg.cpp:1026
+msgid "Could not find tab for id"
+msgstr "No se puet trobar a pestanya pa l'identificador"
+
+#: ../src/generic/tipdlg.cpp:136
+msgid "Tips not available, sorry!"
+msgstr "As sucherencias no son disponibles!"
+
+#: ../src/generic/tipdlg.cpp:197
+msgid "Tip of the Day"
+msgstr "Sucherencia d'o Día"
+
+#: ../src/generic/tipdlg.cpp:207
+msgid "Did you know..."
+msgstr "Sabebas que...?"
+
+#: ../src/generic/tipdlg.cpp:232
+msgid "&Show tips at startup"
+msgstr "&Amostrar as sucherencias a l'inicio"
+
+#: ../src/generic/tipdlg.cpp:236
+msgid "&Next Tip"
+msgstr "&Siguient Sucherencia"
+
+#: ../src/generic/wizard.cpp:411
+msgid "&Next >"
+msgstr "&Siguient >"
+
+#: ../src/generic/wizard.cpp:412
+msgid "&Finish"
+msgstr "&Finalizar"
+
+#: ../src/generic/wizard.cpp:420
+msgid "< &Back"
+msgstr "< &Dezaga"
+
+#: ../src/gtk/aboutdlg.cpp:204
+msgid "translator-credits"
+msgstr "traductor-creditos"
+
+#: ../src/gtk/app.cpp:517
+msgid ""
+"WARNING: using XIM input method is unsupported and may result in problems "
+"with input handling and flickering. Consider unsetting GTK_IM_MODULE or "
+"setting to \"ibus\"."
+msgstr ""
+
+#: ../src/gtk/app.cpp:569
+msgid "Unable to initialize GTK+, is DISPLAY set properly?"
+msgstr "No s'ha puesto enchegar o GTK+, ye a pantalla bien achustada?"
+
+#: ../src/gtk/filedlg.cpp:89 ../src/gtk/filepicker.cpp:255
+#, fuzzy, c-format
+msgid "Changing current directory to \"%s\" failed"
+msgstr "S'ha produciu una error en creyar o directorio \"%s\""
+
+#: ../src/gtk/font.cpp:548
+msgid ""
+"Using private fonts is not supported on this system: Pango library is too "
+"old, 1.38 or later required."
+msgstr ""
+
+#: ../src/gtk/font.cpp:558
+#, fuzzy
+msgid "Failed to create font configuration object."
+msgstr "No s'ha puesto esviellar o fichero de configuración d'usuario."
+
+#: ../src/gtk/font.cpp:568
+#, fuzzy, c-format
+msgid "Failed to add custom font \"%s\"."
+msgstr "No s'ha puesto leyer o documento dende \"%s\"."
+
+#: ../src/gtk/font.cpp:576
+#, fuzzy
+msgid "Failed to register font configuration using private fonts."
+msgstr "No s'ha puesto esviellar o fichero de configuración d'usuario."
+
+#: ../src/gtk/glcanvas.cpp:117 ../src/gtk/glcanvas.cpp:132
+#, fuzzy
+msgid "Fatal Error"
+msgstr "Error de fichero"
+
+#: ../src/gtk/glcanvas.cpp:117
+msgid ""
+"This program wasn't compiled with EGL support required under Wayland, "
+"either\n"
+"install EGL libraries and rebuild or run it under X11 backend by setting\n"
+"environment variable GDK_BACKEND=x11 before starting your program."
+msgstr ""
+
+#: ../src/gtk/glcanvas.cpp:132
+msgid ""
+"wxGLCanvas is only supported on Wayland and X11 currently.  You may be able "
+"to\n"
+"work around this by setting environment variable GDK_BACKEND=x11 before\n"
+"starting your program."
+msgstr ""
+
+#: ../src/gtk/mdi.cpp:433
+msgid "MDI child"
+msgstr "Finestra filla MDI"
+
+#: ../src/gtk/power.cpp:188
+#, fuzzy, c-format
+msgid "Failed to open D-Bus connection to the login manager: %s"
+msgstr ""
+"S'ha produciu una error en creyar a connexión enta lo servidor '%s' en '%s'"
+
+#: ../src/gtk/power.cpp:214
+#, fuzzy
+msgid "wxWidgets application"
+msgstr "Aplicación"
+
+#: ../src/gtk/power.cpp:226
+msgid "Application needs to keep running"
+msgstr ""
+
+#: ../src/gtk/power.cpp:233
+msgid "Clean up before suspend"
+msgstr ""
+
+#: ../src/gtk/power.cpp:259
+#, fuzzy, c-format
+msgid "Failed to inhibit sleep: %s"
+msgstr "No s'ha puesto encetar a connexión d'acceso telefonico: %s"
+
+#: ../src/gtk/power.cpp:265
+msgid "Unexpected response to D-Bus \"Inhibit\" request."
+msgstr ""
+
+#: ../src/gtk/print.cpp:218
+msgid "Custom size"
+msgstr "Grandaria personalizada"
+
+#: ../src/gtk/print.cpp:752
+#, fuzzy, c-format
+msgid "Error while printing: %s"
+msgstr "S'ha produciu una error en imprentar: "
+
+#: ../src/gtk/print.cpp:816
+msgid "Page Setup"
+msgstr "Configurar a Pachina"
+
+#: ../src/gtk/webview_webkit.cpp:932
+msgid "Retrieving JavaScript script output is not supported with WebKit v1"
+msgstr ""
+
+#: ../src/gtk/webview_webkit2.cpp:1098
+msgid ""
+"Setting proxy is not supported by WebKit, at least version 2.16 is required."
+msgstr ""
+
+#: ../src/gtk/webview_webkit2.cpp:1104
+msgid "This program was compiled without support for setting WebKit proxy."
+msgstr ""
+
+#: ../src/gtk/window.cpp:6289
+msgid ""
+"GTK+ installed on this machine is too old to support screen compositing, "
+"please install GTK+ 2.12 or later."
+msgstr ""
+"O GTK+ instalau en iste ordinador ye masiau antigo ta suportar a composición "
+"de pantalla, por favor instala o GTK+ 2.12 u superior."
+
+#: ../src/gtk/window.cpp:6307
+msgid ""
+"Compositing not supported by this system, please enable it in your Window "
+"Manager."
+msgstr ""
+"A composición no ye suportada por iste sistema, por favor activa-la en o "
+"tuyo administrador de finestras."
+
+#: ../src/gtk/window.cpp:6318
+msgid ""
+"This program was compiled with a too old version of GTK+, please rebuild "
+"with GTK+ 2.12 or newer."
+msgstr ""
+"Iste programa estió compilau con una versión de GTK+ masiau antiga, por "
+"favor recomplila-lo con o GR+ 2.12 u superior."
+
+#: ../src/html/chm.cpp:138
+#, c-format
+msgid "Failed to open CHM archive '%s'."
+msgstr "No s'ha puesto ubrir o fichero CHM '%s'."
+
+#: ../src/html/chm.cpp:270
+#, c-format
+msgid "Could not extract %s into %s: %s"
+msgstr "No s'ha puesto extrayer %s en %s: %s"
+
+#: ../src/html/chm.cpp:324
+msgid "no error"
+msgstr "sin error"
+
+#: ../src/html/chm.cpp:326
+msgid "bad arguments to library function"
+msgstr "argumentos erronios ta la función de biblioteca"
+
+#: ../src/html/chm.cpp:328
+msgid "error opening file"
+msgstr "s'ha produciu una error en ubrir o fichero"
+
+#: ../src/html/chm.cpp:330
+msgid "read error"
+msgstr "s'ha produciu una error de lectura"
+
+#: ../src/html/chm.cpp:332
+msgid "write error"
+msgstr "s'ha produciu una error d'escritura"
+
+#: ../src/html/chm.cpp:334
+msgid "seek error"
+msgstr "error de busca"
+
+#: ../src/html/chm.cpp:338
+msgid "bad signature"
+msgstr "sinyatura erronia"
+
+#: ../src/html/chm.cpp:340
+msgid "error in data format"
+msgstr "s'ha produciu una error en o formato de datos"
+
+#: ../src/html/chm.cpp:342
+msgid "checksum error"
+msgstr "s'ha produciu una error de suma de comprebación"
+
+#: ../src/html/chm.cpp:344
+msgid "compression error"
+msgstr "s'ha produciu una error de compresión"
+
+#: ../src/html/chm.cpp:346
+msgid "decompression error"
+msgstr "s'ha produciu una error de descompresión"
+
+#: ../src/html/chm.cpp:437
+#, c-format
+msgid "Could not locate file '%s'."
+msgstr "No s'ha puesto trobar o fichero '%s'."
+
+#: ../src/html/chm.cpp:711
+#, c-format
+msgid "Could not create temporary file '%s'"
+msgstr "No se puet creyar o fichero temporal '%s'"
+
+#: ../src/html/chm.cpp:718
+#, c-format
+msgid "Extraction of '%s' into '%s' failed."
+msgstr "Ha fallau a extracción de '%s' en '%s'."
+
+#: ../src/html/chm.cpp:806 ../src/html/chm.cpp:863
+msgid "CHM handler currently supports only local files!"
+msgstr "O maniador CHM actualment nomás permite fichers locals!"
+
+#: ../src/html/chm.cpp:827
+msgid "Link contained '//', converted to absolute link."
+msgstr "O vinclo contién '//', convertiu a vinclo absoluto."
+
+#: ../src/html/helpctrl.cpp:59
+#, c-format
+msgid "Help: %s"
+msgstr "Aduya: %s"
+
+#: ../src/html/helpctrl.cpp:155
+#, c-format
+msgid "Adding book %s"
+msgstr "Adhibindo lo libro %s"
+
+#: ../src/html/helpdata.cpp:295
+#, c-format
+msgid "Cannot open contents file: %s"
+msgstr "No se puet ubrir o fichero de contenius: %s"
+
+#: ../src/html/helpdata.cpp:309
+#, c-format
+msgid "Cannot open index file: %s"
+msgstr "No se puet ubrir o fichero indiz: %s"
+
+#: ../src/html/helpdata.cpp:643
+msgid "noname"
+msgstr "sin nombre"
+
+#: ../src/html/helpdata.cpp:652
+#, c-format
+msgid "Cannot open HTML help book: %s"
+msgstr "No se puet ubrir o libro d'aduya HTML: %s"
+
+#: ../src/html/helpwnd.cpp:315
+msgid "Displays help as you browse the books on the left."
+msgstr "Amuestra l'aduya con o navegador de libros a la cucha."
+
+#: ../src/html/helpwnd.cpp:411 ../src/html/helpwnd.cpp:1100
+#: ../src/html/helpwnd.cpp:1735
+msgid "(bookmarks)"
+msgstr "(marcapachinas)"
+
+#: ../src/html/helpwnd.cpp:424
+msgid "Add current page to bookmarks"
+msgstr "Adhibir a pachina actual a los marcapachinas"
+
+#: ../src/html/helpwnd.cpp:425
+msgid "Remove current page from bookmarks"
+msgstr "Eliminar a pachina actual d'os marcapachinas"
+
+#: ../src/html/helpwnd.cpp:470
+msgid "Contents"
+msgstr "Contenius"
+
+#: ../src/html/helpwnd.cpp:485
+msgid "Find"
+msgstr "Mirar"
+
+#: ../src/html/helpwnd.cpp:487
+msgid "Show all"
+msgstr "Amostrar-lo tot"
+
+#: ../src/html/helpwnd.cpp:497
+msgid ""
+"Display all index items that contain given substring. Search is case "
+"insensitive."
+msgstr ""
+"Amostrar totz os elementos de l'indiz que contiengan a subcadena dada. A "
+"busca ye Insensitiva."
+
+#: ../src/html/helpwnd.cpp:498
+msgid "Show all items in index"
+msgstr "Amostrar totz os datos en l'indiz"
+
+#: ../src/html/helpwnd.cpp:528
+msgid "Case sensitive"
+msgstr "Sensible a las mayusclas y minusclas"
+
+#: ../src/html/helpwnd.cpp:529
+msgid "Whole words only"
+msgstr "Nomás parolas completas"
+
+#: ../src/html/helpwnd.cpp:532
+msgid ""
+"Search contents of help book(s) for all occurrences of the text you typed "
+"above"
+msgstr ""
+"Mirar contenius d'o(s) libro(s) d'aduya ta todas as aparicions d'o texto que "
+"has escrito mas alto"
+
+#: ../src/html/helpwnd.cpp:653
+msgid "Show/hide navigation panel"
+msgstr "Amostrar/amagar o panel de navegación"
+
+#: ../src/html/helpwnd.cpp:655
+msgid "Go back"
+msgstr "Ir ta zaga"
+
+#: ../src/html/helpwnd.cpp:656
+msgid "Go forward"
+msgstr "Ir ta debant"
+
+#: ../src/html/helpwnd.cpp:658
+msgid "Go one level up in document hierarchy"
+msgstr "Puyar un libel en a hierarquía d'o documento"
+
+#: ../src/html/helpwnd.cpp:666 ../src/html/helpwnd.cpp:1547
+msgid "Open HTML document"
+msgstr "Ubrir un documento HTML"
+
+#: ../src/html/helpwnd.cpp:670
+msgid "Print this page"
+msgstr "Imprentar ista pachina"
+
+#: ../src/html/helpwnd.cpp:674
+msgid "Display options dialog"
+msgstr "Amostrar o dialogo d'opcions"
+
+#: ../src/html/helpwnd.cpp:795
+msgid "Please choose the page to display:"
+msgstr "Por favor triga la pachina que quiers presentar:"
+
+#: ../src/html/helpwnd.cpp:796
+msgid "Help Topics"
+msgstr "Temas d'aduya"
+
+#: ../src/html/helpwnd.cpp:852
+msgid "Searching..."
+msgstr "Mirando..."
+
+#: ../src/html/helpwnd.cpp:853
+msgid "No matching page found yet"
+msgstr "Encara no s'ha trobau garra pachina con coincidencias"
+
+#: ../src/html/helpwnd.cpp:870
+#, c-format
+msgid "Found %i matches"
+msgstr "Trobadas %i coincidencias"
+
+#: ../src/html/helpwnd.cpp:958
+msgid "(Help)"
+msgstr "(Aduya)"
+
+#: ../src/html/helpwnd.cpp:1026
+#, c-format
+msgid "%d of %lu"
+msgstr "%d de %lu"
+
+#: ../src/html/helpwnd.cpp:1028
+#, c-format
+msgid "%lu of %lu"
+msgstr "%lu de %lu"
+
+#: ../src/html/helpwnd.cpp:1047
+msgid "Search in all books"
+msgstr "Mirar en totz os libros"
+
+#: ../src/html/helpwnd.cpp:1193
+msgid "Help Browser Options"
+msgstr "Opcions d'o Navegador de l'Aduya"
+
+#: ../src/html/helpwnd.cpp:1198
+msgid "Normal font:"
+msgstr "Fuent normal:"
+
+#: ../src/html/helpwnd.cpp:1199
+msgid "Fixed font:"
+msgstr "Fuent fixa:"
+
+#: ../src/html/helpwnd.cpp:1200
+msgid "Font size:"
+msgstr "Grandaria d'a fuent:"
+
+#: ../src/html/helpwnd.cpp:1245
+msgid "font size"
+msgstr "grandaria de fuent"
+
+#: ../src/html/helpwnd.cpp:1256
+msgid "Normal face<br>and <u>underlined</u>. "
+msgstr "Nnormal<br>y <u>subrayau</u>. "
+
+#: ../src/html/helpwnd.cpp:1257
+msgid "<i>Italic face.</i> "
+msgstr "<i>Cursiva.</i> "
+
+#: ../src/html/helpwnd.cpp:1258
+msgid "<b>Bold face.</b> "
+msgstr "<b>Negreta.</b> "
+
+#: ../src/html/helpwnd.cpp:1259
+msgid "<b><i>Bold italic face.</i></b><br>"
+msgstr "<b><i>Negreta cursiva.</i></b><br>"
+
+#: ../src/html/helpwnd.cpp:1262
+msgid "Fixed size face.<br> <b>bold</b> <i>italic</i> "
+msgstr "Monoespaciau.<br> <b>negreta</b> <i>cursiva</i> "
+
+#: ../src/html/helpwnd.cpp:1263
+msgid "<b><i>bold italic <u>underlined</u></i></b><br>"
+msgstr "<b><i>negreta cursiva <u>subrayada</u></i></b><br>"
+
+#: ../src/html/helpwnd.cpp:1524
+msgid "Help Printing"
+msgstr "Aduya d'Impresión"
+
+#: ../src/html/helpwnd.cpp:1527
+msgid "Cannot print empty page."
+msgstr "No se puet imprentar una pachina vueda."
+
+#: ../src/html/helpwnd.cpp:1540
+msgid "HTML files (*.html;*.htm)|*.html;*.htm|"
+msgstr "Fichers HTML (*.html;*.htm)|*.html;*.htm|"
+
+#: ../src/html/helpwnd.cpp:1541
+msgid "Help books (*.htb)|*.htb|Help books (*.zip)|*.zip|"
+msgstr "Libros d'aduya (*.htb)|*.htb|Libros d'aduya (*.zip)|*.zip|"
+
+#: ../src/html/helpwnd.cpp:1542
+msgid "HTML Help Project (*.hhp)|*.hhp|"
+msgstr "Prochecto d'aduya HTML (*.hhp)|*.hhp|"
+
+#: ../src/html/helpwnd.cpp:1544
+msgid "Compressed HTML Help file (*.chm)|*.chm|"
+msgstr "Fichero d'aduya HTML comprimiu (*.chm)|*.chm|"
+
+#: ../src/html/helpwnd.cpp:1671
+#, fuzzy, c-format
+msgid "%i of %u"
+msgstr "%i de %u"
+
+#: ../src/html/helpwnd.cpp:1709
+#, fuzzy, c-format
+msgid "%u of %u"
+msgstr "%u de %u"
+
+#: ../src/html/htmlfilt.cpp:134
+#, c-format
+msgid "Cannot open HTML document: %s"
+msgstr "No se puet ubrir o documento HTML: %s"
+
+#: ../src/html/htmlwin.cpp:599
+msgid "Connecting..."
+msgstr "Connectando..."
+
+#: ../src/html/htmlwin.cpp:616
+#, c-format
+msgid "Unable to open requested HTML document: %s"
+msgstr "No s'ha puesto ubrir o documento HTML demandau: %s"
+
+#: ../src/html/htmlwin.cpp:630
+msgid "Loading : "
+msgstr "Cargando : "
+
+#: ../src/html/htmlwin.cpp:673
+msgid "Done"
+msgstr "Feito"
+
+#: ../src/html/htmlwin.cpp:723
+#, c-format
+msgid "HTML anchor %s does not exist."
+msgstr "L'ancorache HTML %s no existe."
+
+#: ../src/html/htmlwin.cpp:1057
+#, c-format
+msgid "Copied to clipboard:\"%s\""
+msgstr "Copiau en o portafuellas:\"%s\""
+
+#: ../src/html/htmprint.cpp:269
+msgid ""
+"This document doesn't fit on the page horizontally and will be truncated "
+"when it is printed."
+msgstr ""
+"Iste documento no culle en a pachina horizontalment y se truncará si "
+"s'imprenta."
+
+#: ../src/html/htmprint.cpp:285
+#, c-format
+msgid ""
+"The document \"%s\" doesn't fit on the page horizontally and will be "
+"truncated if printed.\n"
+"\n"
+"Would you like to proceed with printing it nevertheless?"
+msgstr ""
+"O documento \"%s\" no culle en a pachina horizontalment y se truncará si "
+"s'imprenta.\n"
+"\n"
+"Deseyas continar con a impresión de todas trazas?"
+
+#: ../src/html/htmprint.cpp:296
+msgid ""
+"If possible, try changing the layout parameters to make the printout more "
+"narrow."
+msgstr ""
+"Si ye posible, preba a cambiar a distribución d'os parametros ta fer a "
+"impresión mas estreita."
+
+#: ../src/html/htmprint.cpp:445
+msgid ": file does not exist!"
+msgstr ": o fichero no existe!"
+
+#. TRANSLATORS: %s may be a document title.
+#: ../src/html/htmprint.cpp:717
+#, fuzzy, c-format
+msgid "%s Preview"
+msgstr " Anvista previa"
+
+#: ../src/html/htmprint.cpp:755 ../src/richtext/richtextprint.cpp:618
+msgid ""
+"There was a problem during page setup: you may need to set a default printer."
+msgstr ""
+"S'ha produciu un problema en configurar a pachina: s'ameneste una impresora "
+"predeterminada."
+
+#: ../src/msw/clipbrd.cpp:80
+msgid "Failed to open the clipboard."
+msgstr "No s'ha puesto ubrir o portafuellas."
+
+#: ../src/msw/clipbrd.cpp:101
+msgid "Failed to close the clipboard."
+msgstr "S'ha produciu una error en zarrar o portafuellas."
+
+#: ../src/msw/clipbrd.cpp:113
+msgid "Failed to empty the clipboard."
+msgstr "S'ha produciu una error en vuedar o portafuellas."
+
+#: ../src/msw/clipbrd.cpp:284
+msgid "Failed to put data on the clipboard"
+msgstr "No s'ha puesto meter datos en o portafuellas"
+
+#: ../src/msw/clipbrd.cpp:326
+msgid "Failed to get data from the clipboard"
+msgstr "S'ha produciu una error en obtener os datos d'o portafuellas"
+
+#: ../src/msw/clipbrd.cpp:363
+msgid "Failed to retrieve the supported clipboard formats"
+msgstr "No s'ha puesto recuperar os formatos suportaus d'o portafuellas"
+
+#: ../src/msw/colordlg.cpp:228
+#, c-format
+msgid "Colour selection dialog failed with error %0lx."
+msgstr "O dialogo de selección de color ha fallau con a error %0lx."
+
+#: ../src/msw/cursor.cpp:141
+msgid "Failed to create cursor."
+msgstr "S'ha produciu una error en creyar o cursor."
+
+#: ../src/msw/dde.cpp:279
+#, c-format
+msgid "Failed to register DDE server '%s'"
+msgstr "No s'ha puesto rechistrar o servidor DDE '%s'"
+
+#: ../src/msw/dde.cpp:300
+#, c-format
+msgid "Failed to unregister DDE server '%s'"
+msgstr "No s'ha puesto desrechistrar o servidor DDE '%s'"
+
+#: ../src/msw/dde.cpp:428
+#, c-format
+msgid "Failed to create connection to server '%s' on topic '%s'"
+msgstr ""
+"S'ha produciu una error en creyar a connexión enta lo servidor '%s' en '%s'"
+
+#: ../src/msw/dde.cpp:655
+msgid "DDE poke request failed"
+msgstr "Ha fallau a petición de rastreo DDE"
+
+#: ../src/msw/dde.cpp:674
+msgid "Failed to establish an advise loop with DDE server"
+msgstr "S'ha produciu una error en establir un lazo d'aviso con o servidor DDE"
+
+#: ../src/msw/dde.cpp:693
+msgid "Failed to terminate the advise loop with DDE server"
+msgstr "No s'ha puesto rematar o bucle d'alvertencia con o servidor DDE"
+
+#: ../src/msw/dde.cpp:768
+msgid "Failed to send DDE advise notification"
+msgstr "No s'ha puesto ninviar a notificación d'alvertencia DDE"
+
+#: ../src/msw/dde.cpp:1085
+msgid "Failed to create DDE string"
+msgstr "S'ha produciu una error en creyar a cadena DDE"
+
+#: ../src/msw/dde.cpp:1131
+msgid "no DDE error."
+msgstr "sin error DDE."
+
+#: ../src/msw/dde.cpp:1135
+msgid "a request for a synchronous advise transaction has timed out."
+msgstr "una petición ta una transacción sincrona d'alvertencia ha caducau."
+
+#: ../src/msw/dde.cpp:1138
+msgid "the response to the transaction caused the DDE_FBUSY bit to be set."
+msgstr "a respuesta a la transacción causó que s'activase o bit DDE_FBUSY."
+
+#: ../src/msw/dde.cpp:1141
+msgid "a request for a synchronous data transaction has timed out."
+msgstr "una petición ta una transacción de datos sincrona ha caducau."
+
+#: ../src/msw/dde.cpp:1144
+msgid ""
+"a DDEML function was called without first calling the DdeInitialize "
+"function,\n"
+"or an invalid instance identifier\n"
+"was passed to a DDEML function."
+msgstr ""
+"una función DDEML ye estada clamada sin clamar en primeras a la función "
+"DdeInitialize,\n"
+"u s'ha pasau un identificador d'instancia no valido\n"
+"a una función DDEML."
+
+#: ../src/msw/dde.cpp:1147
+msgid ""
+"an application initialized as APPCLASS_MONITOR has\n"
+"attempted to perform a DDE transaction,\n"
+"or an application initialized as APPCMD_CLIENTONLY has \n"
+"attempted to perform server transactions."
+msgstr ""
+"una aplicación inicializada como APPCLASS_MONITOR ha\n"
+"prebau a levar a cabo una transacción DDE,\n"
+"u una aplicación inicializada como APPCMD_CLIENTONLY ha\n"
+"prebau a realizar transaccions de servidor."
+
+#: ../src/msw/dde.cpp:1150
+msgid "a request for a synchronous execute transaction has timed out."
+msgstr "una petición ta una transación d'execución sincrona ha caducau."
+
+#: ../src/msw/dde.cpp:1153
+msgid "a parameter failed to be validated by the DDEML."
+msgstr "ha fallau un parametro a lo validar-se por o DDEML."
+
+#: ../src/msw/dde.cpp:1156
+msgid "a DDEML application has created a prolonged race condition."
+msgstr "una aplicación DDEML ha creyau una condición accelerada prolongada."
+
+#: ../src/msw/dde.cpp:1159
+msgid "a memory allocation failed."
+msgstr "ha fallau a reserva de memoria."
+
+#: ../src/msw/dde.cpp:1162
+msgid "a client's attempt to establish a conversation has failed."
+msgstr "l'intento d'un client d'estableixer conversación ha fallau."
+
+#: ../src/msw/dde.cpp:1165
+msgid "a transaction failed."
+msgstr "ha fallau una transacción."
+
+#: ../src/msw/dde.cpp:1168
+msgid "a request for a synchronous poke transaction has timed out."
+msgstr "una petición ta una transacción sincrona de revisión ha caducau."
+
+#: ../src/msw/dde.cpp:1171
+msgid "an internal call to the PostMessage function has failed. "
+msgstr "ha fallau una clamada interna a la función PostMessage. "
+
+#: ../src/msw/dde.cpp:1174
+msgid "reentrancy problem."
+msgstr "problema de reentrada."
+
+#: ../src/msw/dde.cpp:1177
+msgid ""
+"a server-side transaction was attempted on a conversation\n"
+"that was terminated by the client, or the server\n"
+"terminated before completing a transaction."
+msgstr ""
+"s'ha intentau una transacción d'o lau d'o servidor en una conversación\n"
+"que estió rematada por o client, u lo servidor\n"
+"remató antes de completar una transacción."
+
+#: ../src/msw/dde.cpp:1180
+msgid "an internal error has occurred in the DDEML."
+msgstr "s'ha produciu una error interna en o DDEML."
+
+#: ../src/msw/dde.cpp:1183
+msgid "a request to end an advise transaction has timed out."
+msgstr ""
+"una petición ta rematar una transacción sincrona d'alvertencia ha caducau."
+
+#: ../src/msw/dde.cpp:1186
+msgid ""
+"an invalid transaction identifier was passed to a DDEML function.\n"
+"Once the application has returned from an XTYP_XACT_COMPLETE callback,\n"
+"the transaction identifier for that callback is no longer valid."
+msgstr ""
+"s'ha pasau un identificador de transacción no valido a la función DDEML.\n"
+"Una vegada que l'aplicación haiga retornau dende una clamada "
+"XTYP_XACT_COMPLETE,\n"
+"l'identificador d'a transacción ta ixa gritada deixa d'estar valido."
+
+#: ../src/msw/dde.cpp:1189
+#, c-format
+msgid "Unknown DDE error %08x"
+msgstr "S'ha produciu una error DDE desconoixiu %08x"
+
+#: ../src/msw/dialup.cpp:343
+msgid ""
+"Dial up functions are unavailable because the remote access service (RAS) is "
+"not installed on this machine. Please install it."
+msgstr ""
+"As funcions de marcau no son disponibles porque os servicios d'acceso remoto "
+"(RAS) no son instalaus en ista maquina. Por favor instala-los."
+
+#: ../src/msw/dialup.cpp:402
+#, c-format
+msgid ""
+"The version of remote access service (RAS) installed on this machine is too "
+"old, please upgrade (the following required function is missing: %s)."
+msgstr ""
+"A versión d'o servicio d'acceso remoto (RAS) instalau en iste sistema ye "
+"masiau antiga. Por favor, esviella-la (falta la siguient función requiesta: "
+"%s)."
+
+#: ../src/msw/dialup.cpp:437
+msgid "Failed to retrieve text of RAS error message"
+msgstr "No s'ha puesto recuperar o mensache d'error de RAS"
+
+#: ../src/msw/dialup.cpp:440
+#, c-format
+msgid "unknown error (error code %08x)."
+msgstr "s'ha produciu una error desconoixida (codigo d'error %08x)."
+
+#: ../src/msw/dialup.cpp:492
+#, c-format
+msgid "Cannot find active dialup connection: %s"
+msgstr "No se puet trobar a connexión activa: %s"
+
+#: ../src/msw/dialup.cpp:513
+msgid "Several active dialup connections found, choosing one randomly."
+msgstr ""
+"S'han trobau quantas connexions activas, se ye trigando una aleatoriament."
+
+#: ../src/msw/dialup.cpp:598 ../src/msw/dialup.cpp:832
+#, c-format
+msgid "Failed to establish dialup connection: %s"
+msgstr "S'ha produciu una error en establir a connexión de marcau: %s"
+
+#: ../src/msw/dialup.cpp:664
+#, c-format
+msgid "Failed to get ISP names: %s"
+msgstr "S'ha produciu una error en obtener os nombres d'ISP: %s"
+
+#: ../src/msw/dialup.cpp:712
+msgid "Failed to connect: no ISP to dial."
+msgstr "S'ha produciu una error en connectar: no bi ha un ISP a lo que gritar."
+
+#: ../src/msw/dialup.cpp:732
+msgid "Choose ISP to dial"
+msgstr "Trigar l'ISP a lo que connectar"
+
+#: ../src/msw/dialup.cpp:733
+msgid "Please choose which ISP do you want to connect to"
+msgstr "Por favor triga l'ISP a lo que te quiers connectar"
+
+#: ../src/msw/dialup.cpp:766
+msgid "Failed to connect: missing username/password."
+msgstr "S'ha produciu una error en connectar: falta o nombre d'usuario/clau."
+
+#: ../src/msw/dialup.cpp:796
+msgid "Cannot find the location of address book file"
+msgstr "No se puet trobar o fichero de libreta d'adrezas"
+
+#: ../src/msw/dialup.cpp:827
+#, c-format
+msgid "Failed to initiate dialup connection: %s"
+msgstr "No s'ha puesto encetar a connexión d'acceso telefonico: %s"
+
+#: ../src/msw/dialup.cpp:897
+msgid "Cannot hang up - no active dialup connection."
+msgstr "No se puet penchar - no bi ha connexions activas."
+
+#: ../src/msw/dialup.cpp:907
+#, c-format
+msgid "Failed to terminate the dialup connection: %s"
+msgstr "No s'ha puesto rematar a connexión: %s"
+
+#: ../src/msw/dib.cpp:313
+#, c-format
+msgid "Failed to save the bitmap image to file \"%s\"."
+msgstr "No s'ha puesto alzar a imachen de mapa de bits en o fichero \"%s\"."
+
+#: ../src/msw/dib.cpp:543
+#, c-format
+msgid "Failed to allocate %luKb of memory for bitmap data."
+msgstr ""
+"S'ha produciu una error en asignar %luKb de memoria ta lo mapa de bits."
+
+#: ../src/msw/dir.cpp:241
+#, c-format
+msgid "Cannot enumerate files in directory '%s'"
+msgstr "No se pueden enumerar os fichers en a carpeta '%s'"
+
+#: ../src/msw/dirdlg.cpp:368
+msgid "Couldn't obtain folder name"
+msgstr "No s'ha puesto obtener o nombre d'o directorio"
+
+#: ../src/msw/dlmsw.cpp:163
+#, fuzzy, c-format
+msgid "(error %d: %s)"
+msgstr " (error %d: %s)"
+
+#: ../src/msw/dragimag.cpp:143 ../src/msw/dragimag.cpp:178
+#: ../src/msw/imaglist.cpp:309 ../src/msw/imaglist.cpp:331
+msgid "Couldn't add an image to the image list."
+msgstr "No se puet adhibir a imachen a la lista d'imachens."
+
+#: ../src/msw/enhmeta.cpp:94
+#, c-format
+msgid "Failed to load metafile from file \"%s\"."
+msgstr "No s'ha puesto ubrir o metafichero dende o fichero \"%s\"."
+
+#: ../src/msw/fdrepdlg.cpp:412
+#, c-format
+msgid "Failed to create the standard find/replace dialog (error code %d)"
+msgstr ""
+"S'ha produciu una error en creyar o dialogo estandar de mirar u "
+"substituir(codigo d'error %d)"
+
+#: ../src/msw/filedlg.cpp:1241
+msgid "Access to the file system is not allowed from secure desktop."
+msgstr ""
+
+#: ../src/msw/filedlg.cpp:1242
+msgid "Security warning"
+msgstr ""
+
+#: ../src/msw/filedlg.cpp:1533
+#, c-format
+msgid "File dialog failed with error code %0lx."
+msgstr "O dialogo de fichero ha fallau con o codigo d'error %0lx."
+
+#: ../src/msw/font.cpp:1120
+#, fuzzy, c-format
+msgid "Font file \"%s\" couldn't be loaded"
+msgstr "No s'ha puesto cargar o fichero."
+
+#: ../src/msw/fontdlg.cpp:220
+#, c-format
+msgid "Common dialog failed with error code %0lx."
+msgstr "O dialogo común ha fallau con o codigo d'error %0lx."
+
+#: ../src/msw/fswatcher.cpp:67
+msgid "Ungraceful worker thread termination"
+msgstr "Rematanza incorrecta de fillos d'execución"
+
+#: ../src/msw/fswatcher.cpp:81
+msgid "Unable to create IOCP worker thread"
+msgstr "No s'ha puesto creyar o filo d'execución IOCP"
+
+#: ../src/msw/fswatcher.cpp:88
+msgid "Unable to start IOCP worker thread"
+msgstr "No s'ha puesto encetar o fillo d'execución d'IOCP"
+
+#: ../src/msw/fswatcher.cpp:140
+msgid "Monitoring individual files for changes is not supported currently."
+msgstr ""
+"Actualment no se suporta a monitorización d'os cambios d'os fichers "
+"individuals."
+
+#: ../src/msw/fswatcher.cpp:165
+#, c-format
+msgid "Unable to set up watch for '%s'"
+msgstr "No s'ha puesto configurar un observador ta '%s'"
+
+#: ../src/msw/fswatcher.cpp:466
+#, c-format
+msgid "Can't monitor non-existent directory \"%s\" for changes."
+msgstr "No se pueden monitorizar os cambeos d'o directorio no existent \"%s\"."
+
+#: ../src/msw/glcanvas.cpp:577 ../src/unix/glx11.cpp:507
+msgid "OpenGL 3.0 or later is not supported by the OpenGL driver."
+msgstr ""
+
+#: ../src/msw/glcanvas.cpp:601 ../src/osx/glcanvas_osx.cpp:395
+#: ../src/unix/glegl.cpp:304 ../src/unix/glx11.cpp:553
+#, fuzzy
+msgid "Couldn't create OpenGL context"
+msgstr "No se puet creyar un temporizador"
+
+#: ../src/msw/glcanvas.cpp:1294
+msgid "Failed to initialize OpenGL"
+msgstr "No s'ha puesto inicializar l'OpenGL"
+
+#: ../src/msw/graphicsd2d.cpp:607
+msgid "Could not register custom DirectWrite font loader."
+msgstr ""
+
+#: ../src/msw/helpchm.cpp:48
+msgid ""
+"MS HTML Help functions are unavailable because the MS HTML Help library is "
+"not installed on this machine. Please install it."
+msgstr ""
+"As funcions d'Aduya MS HTML no son disponibles porque a librería d'Aduya MS "
+"HTML no ye instalada. Por favor instala-la."
+
+#: ../src/msw/helpchm.cpp:55
+msgid "Failed to initialize MS HTML Help."
+msgstr "S'ha produciu una error en inicializar l'Aduya MS HTML."
+
+#: ../src/msw/iniconf.cpp:458
+#, c-format
+msgid "Can't delete the INI file '%s'"
+msgstr "No se puet elimininar o fichero INI '%s'"
+
+#: ../src/msw/listctrl.cpp:995
+#, c-format
+msgid "Couldn't retrieve information about list control item %d."
+msgstr "No se puet recuperar información sobre l'elemento %d d'a lista."
+
+#: ../src/msw/mdi.cpp:170 ../src/qt/mdi.cpp:253
+msgid "&Cascade"
+msgstr "&Cascada"
+
+#: ../src/msw/mdi.cpp:171
+msgid "Tile &Horizontally"
+msgstr "Mosaico &Horizontal"
+
+#: ../src/msw/mdi.cpp:172
+msgid "Tile &Vertically"
+msgstr "Mosaico &Vertical"
+
+#: ../src/msw/mdi.cpp:174
+msgid "&Arrange Icons"
+msgstr "&Organizar os iconos"
+
+#: ../src/msw/mdi.cpp:621
+msgid "Failed to create MDI parent frame."
+msgstr "S'ha produciu una error en creyar o panel MDI pai."
+
+#: ../src/msw/mimetype.cpp:234
+#, c-format
+msgid "Failed to create registry entry for '%s' files."
+msgstr ""
+"S'ha produciu una error en creyar a dentrada d'o rechistro ta os fichers "
+"'%s'."
+
+#: ../src/msw/ole/automtn.cpp:495
+#, c-format
+msgid "Failed to find CLSID of \"%s\""
+msgstr "No s'ha puesto trobar o CLSID de \"%s\""
+
+#: ../src/msw/ole/automtn.cpp:512
+#, c-format
+msgid "Failed to create an instance of \"%s\""
+msgstr "S'ha produciu una error en creyar una instancia de \"%s\""
+
+#: ../src/msw/ole/automtn.cpp:552
+#, c-format
+msgid "Cannot get an active instance of \"%s\""
+msgstr "No se puet obtener una instancia activa de \"%s\""
+
+#: ../src/msw/ole/automtn.cpp:564
+#, c-format
+msgid "Failed to get OLE automation interface for \"%s\""
+msgstr ""
+"S'ha produciu una error en obtener a interficie OLE d'automatización ta "
+"\"%s\""
+
+#: ../src/msw/ole/automtn.cpp:621
+msgid "Unknown name or named argument."
+msgstr "Nombre u argumento nombrau desconoixiu."
+
+#: ../src/msw/ole/automtn.cpp:625
+msgid "Incorrect number of arguments."
+msgstr "Numero incorrecto d'argumentos."
+
+#: ../src/msw/ole/automtn.cpp:637
+msgid "Unknown exception"
+msgstr "Excepción desconoixida"
+
+#: ../src/msw/ole/automtn.cpp:642
+msgid "Method or property not found."
+msgstr "No s'ha trobau o metodo u propiedatz."
+
+#: ../src/msw/ole/automtn.cpp:646
+msgid "Overflow while coercing argument values."
+msgstr "S'ha sobreixiu en aforzar as valors d'os argumentos."
+
+#: ../src/msw/ole/automtn.cpp:650
+msgid "Object implementation does not support named arguments."
+msgstr "A implementación de l'obchecto no suporta argumentos nombraus."
+
+#: ../src/msw/ole/automtn.cpp:654
+msgid "The locale ID is unknown."
+msgstr "L'identificador d'a localización ye desconoixiu."
+
+#: ../src/msw/ole/automtn.cpp:658
+msgid "Missing a required parameter."
+msgstr "Se requier un parametro."
+
+#: ../src/msw/ole/automtn.cpp:662
+#, c-format
+msgid "Argument %u not found."
+msgstr "No s'ha trobau l'argumento %u."
+
+#: ../src/msw/ole/automtn.cpp:666
+#, c-format
+msgid "Type mismatch in argument %u."
+msgstr "No coincide o tipo en l'argumento %u."
+
+#: ../src/msw/ole/automtn.cpp:670
+msgid "The system cannot find the file specified."
+msgstr "O sistema no puet trobar o fichero especificau."
+
+#: ../src/msw/ole/automtn.cpp:674
+msgid "Class not registered."
+msgstr "&Clase no rechistrada."
+
+#: ../src/msw/ole/automtn.cpp:678
+#, c-format
+msgid "Unknown error %08x"
+msgstr "Error desconoixida %08x"
+
+#: ../src/msw/ole/automtn.cpp:682
+#, c-format
+msgid "OLE Automation error in %s: %s"
+msgstr "S'ha produciu una error d'automatización d'OLE en %s: %s"
+
+#: ../src/msw/ole/dataobj.cpp:385
+#, c-format
+msgid "Couldn't register clipboard format '%s'."
+msgstr "No se puet rechistrar o formato de portafuellas '%s'."
+
+#: ../src/msw/ole/dataobj.cpp:402
+#, c-format
+msgid "The clipboard format '%d' doesn't exist."
+msgstr "O formato %d d'o portafuellas no existe."
+
+#: ../src/msw/progdlg.cpp:1025
+msgid "Skip"
+msgstr "Blincar"
+
+#: ../src/msw/registry.cpp:141
+#, fuzzy, c-format
+msgid "unknown (%lu)"
+msgstr "desconoixiu"
+
+#: ../src/msw/registry.cpp:409
+#, c-format
+msgid "Can't get info about registry key '%s'"
+msgstr "No s'ha puesto obtener información d'a clau d'o rechistro '%s'"
+
+#: ../src/msw/registry.cpp:445
+#, c-format
+msgid "Can't open registry key '%s'"
+msgstr "No se puet ubrir a clau d'o rechistro '%s'"
+
+#: ../src/msw/registry.cpp:478
+#, c-format
+msgid "Can't create registry key '%s'"
+msgstr "No se puet creyar a clau d'o rechistro '%s'"
+
+#: ../src/msw/registry.cpp:497
+#, c-format
+msgid "Can't close registry key '%s'"
+msgstr "No se puet zarrar a clau d'o rechistro '%s'"
+
+#: ../src/msw/registry.cpp:512
+#, c-format
+msgid "Registry value '%s' already exists."
+msgstr "A clau d'o rechistro '%s' ya existe."
+
+#: ../src/msw/registry.cpp:520
+#, c-format
+msgid "Failed to rename registry value '%s' to '%s'."
+msgstr "No s'ha puesto renombrar a valor d'o rechistro '%s' a '%s'."
+
+#: ../src/msw/registry.cpp:575
+#, c-format
+msgid "Can't copy values of unsupported type %d."
+msgstr "No se pueden copiar valuras d'un tipo no suportau %d."
+
+#: ../src/msw/registry.cpp:586
+#, c-format
+msgid "Registry key '%s' does not exist, cannot rename it."
+msgstr "A clau d'o rechistro '%s' no existe, no se'n puet renombrar."
+
+#: ../src/msw/registry.cpp:617
+#, c-format
+msgid "Registry key '%s' already exists."
+msgstr "A clau d'o rechistro '%s' ya existe."
+
+#: ../src/msw/registry.cpp:625
+#, c-format
+msgid "Failed to rename the registry key '%s' to '%s'."
+msgstr "No s'ha puesto renombrar a clau d'o rechistro '%s' a '%s'."
+
+#: ../src/msw/registry.cpp:670
+#, c-format
+msgid "Failed to copy the registry subkey '%s' to '%s'."
+msgstr ""
+"S'ha produciu una error en copiar a subclau d'o rechistro '%s' en '%s'."
+
+#: ../src/msw/registry.cpp:683
+#, c-format
+msgid "Failed to copy registry value '%s'"
+msgstr "S'ha produciu un a error en copiar a valor '%s' d'o rechistro"
+
+#: ../src/msw/registry.cpp:692
+#, c-format
+msgid "Failed to copy the contents of registry key '%s' to '%s'."
+msgstr ""
+"S'ha produciu una error en copiar os contenius d'a clau d'o rechistro '%s' "
+"ta '%s'."
+
+#: ../src/msw/registry.cpp:718
+#, c-format
+msgid ""
+"Registry key '%s' is needed for normal system operation,\n"
+"deleting it will leave your system in unusable state:\n"
+"operation aborted."
+msgstr ""
+"A clau d'o rechistro '%s' s'ameneste ta lo funcionamiento normal d'o "
+"sistema,\n"
+"si se'n elimina puede deixar o sistema en un estau inestable:\n"
+"operación abortada."
+
+#: ../src/msw/registry.cpp:754
+#, c-format
+msgid "Can't delete key '%s'"
+msgstr "No se puet eliminar a clau '%s'"
+
+#: ../src/msw/registry.cpp:782
+#, c-format
+msgid "Can't delete value '%s' from key '%s'"
+msgstr "No se puet eliminar a valor '%s' d'a clau '%s'"
+
+#: ../src/msw/registry.cpp:855 ../src/msw/registry.cpp:887
+#: ../src/msw/registry.cpp:929 ../src/msw/registry.cpp:1000
+#, c-format
+msgid "Can't read value of key '%s'"
+msgstr "No se puet leyer a valor d'a clau '%s'"
+
+#: ../src/msw/registry.cpp:873 ../src/msw/registry.cpp:915
+#: ../src/msw/registry.cpp:963 ../src/msw/registry.cpp:1106
+#, c-format
+msgid "Can't set value of '%s'"
+msgstr "No se puet establir a valor de '%s'"
+
+#: ../src/msw/registry.cpp:894 ../src/msw/registry.cpp:943
+#, c-format
+msgid "Registry value \"%s\" is not numeric (but of type %s)"
+msgstr ""
+
+#: ../src/msw/registry.cpp:979
+#, c-format
+msgid "Registry value \"%s\" is not binary (but of type %s)"
+msgstr ""
+
+#: ../src/msw/registry.cpp:1028
+#, c-format
+msgid "Registry value \"%s\" is not text (but of type %s)"
+msgstr ""
+
+#: ../src/msw/registry.cpp:1089
+#, c-format
+msgid "Can't read value of '%s'"
+msgstr "No se puet leyer a valor de '%s'"
+
+#: ../src/msw/registry.cpp:1157
+#, c-format
+msgid "Can't enumerate values of key '%s'"
+msgstr "No se pueden enumerar as valors d'a clau '%s'"
+
+#: ../src/msw/registry.cpp:1196
+#, c-format
+msgid "Can't enumerate subkeys of key '%s'"
+msgstr "No se pueden enumerar as subclaus d'a clau '%s'"
+
+#: ../src/msw/registry.cpp:1262
+#, c-format
+msgid ""
+"Exporting registry key: file \"%s\" already exists and won't be overwritten."
+msgstr ""
+"Se ye exportando a clau de rechistro: o fichero \"%s\" ya existe y no se "
+"sobrescribirá."
+
+#: ../src/msw/registry.cpp:1411
+#, c-format
+msgid "Can't export value of unsupported type %d."
+msgstr "No se puet exportar una valura d'un tipo no suportau %d."
+
+#: ../src/msw/registry.cpp:1427
+#, c-format
+msgid "Ignoring value \"%s\" of the key \"%s\"."
+msgstr "S'ignorará a valura \"%s\" d'a clau \"%s\"."
+
+#: ../src/msw/textctrl.cpp:596
+msgid ""
+"Impossible to create a rich edit control, using simple text control instead. "
+"Please reinstall riched32.dll"
+msgstr ""
+"Ye imposible de creyar o control 'rich edit', s'usará o control de texto "
+"simple. Por favor instala riched32.dll"
+
+#: ../src/msw/thread.cpp:522 ../src/unix/threadpsx.cpp:850
+msgid "Cannot start thread: error writing TLS."
+msgstr ""
+"No se puet empecipiar o filo d'execución: S'ha produciu una error en "
+"escribir TLS."
+
+#: ../src/msw/thread.cpp:613
+msgid "Can't set thread priority"
+msgstr "No se puet establir a prioridat d'o filo d'execución"
+
+#: ../src/msw/thread.cpp:649
+msgid "Can't create thread"
+msgstr "No se puet creyar o filo d'execución"
+
+#: ../src/msw/thread.cpp:668
+msgid "Couldn't terminate thread"
+msgstr "No se puet rematar o filo d'execución"
+
+#: ../src/msw/thread.cpp:799
+msgid "Cannot wait for thread termination"
+msgstr "No se puet asperar a la finalización d'o filo d'execución"
+
+#: ../src/msw/thread.cpp:873
+#, c-format
+msgid "Cannot suspend thread %lx"
+msgstr "No se puet suspender o filo d'execución %lx"
+
+#: ../src/msw/thread.cpp:903
+#, c-format
+msgid "Cannot resume thread %lx"
+msgstr "No se puet reprener o filo d'execución %lx"
+
+#: ../src/msw/thread.cpp:932
+msgid "Couldn't get the current thread pointer"
+msgstr "No s'ha puesto obtener o puntero a lo filo d'execución actual"
+
+#: ../src/msw/thread.cpp:1333
+msgid ""
+"Thread module initialization failed: impossible to allocate index in thread "
+"local storage"
+msgstr ""
+"S'ha produciu una error en a inicialización d'o modulo de filos d'execución: "
+"ye imposible reservar l'indiz en l'almagazén local de filos"
+
+#: ../src/msw/thread.cpp:1345
+msgid ""
+"Thread module initialization failed: cannot store value in thread local "
+"storage"
+msgstr ""
+"S'ha produciu una error en a inicialización d'o modulo de filos d'execución: "
+"no s'ha puesto almagazenar a valor en l'almagazén local de filos"
+
+#: ../src/msw/timer.cpp:133
+msgid "Couldn't create a timer"
+msgstr "No se puet creyar un temporizador"
+
+#: ../src/msw/utils.cpp:372
+msgid "can't find user's HOME, using current directory."
+msgstr ""
+"no s'ha puesto trobar l'HOME de l'usuario, se ye usando o directorio actual."
+
+#: ../src/msw/utils.cpp:662
+#, c-format
+msgid "Failed to kill process %d"
+msgstr "No s'ha puesto amortar o proceso %d"
+
+#: ../src/msw/utils.cpp:986
+#, c-format
+msgid "Failed to load resource \"%s\"."
+msgstr "No s'ha puesto cargar o recurso \"%s\"."
+
+#: ../src/msw/utils.cpp:993
+#, c-format
+msgid "Failed to lock resource \"%s\"."
+msgstr "No s'ha puesto blocar o recurso \"%s\"."
+
+#. TRANSLATORS: MS Windows build number
+#: ../src/msw/utils.cpp:1209
+#, c-format
+msgid "build %lu"
+msgstr "construir %lu"
+
+#: ../src/msw/utils.cpp:1218
+msgid ", 64-bit edition"
+msgstr ", edición de 64 bits"
+
+#: ../src/msw/utilsexc.cpp:224
+msgid "Failed to create an anonymous pipe"
+msgstr "S'ha produciu una error en creyar una canal anonima"
+
+#: ../src/msw/utilsexc.cpp:697
+msgid "Failed to redirect the child process IO"
+msgstr "No s'ha puesto reendrezar a dentrada/salida d'o proceso fillo"
+
+#: ../src/msw/utilsexc.cpp:870
+#, c-format
+msgid "Execution of command '%s' failed"
+msgstr "Ha fallau a execución d'o comando '%s'"
+
+#: ../src/msw/volume.cpp:337
+msgid "Failed to load mpr.dll."
+msgstr "No s'ha puesto cargar o mpr.dll."
+
+#: ../src/msw/volume.cpp:506
+#, c-format
+msgid "Cannot read typename from '%s'!"
+msgstr "No se puet leyer o tipo dende '%s'!"
+
+#: ../src/msw/volume.cpp:615
+#, c-format
+msgid "Cannot load icon from '%s'."
+msgstr "No se puet cargar l'icono de '%s'."
+
+#: ../src/msw/webview_edge.cpp:285
+msgid "This program was compiled without support for setting Edge proxy."
+msgstr ""
+
+#: ../src/msw/webview_ie.cpp:1010
+msgid "Failed to find web view emulation level in the registry"
+msgstr ""
+
+#: ../src/msw/webview_ie.cpp:1019
+msgid "Failed to set web view to modern emulation level"
+msgstr ""
+
+#: ../src/msw/webview_ie.cpp:1027
+msgid "Failed to reset web view to standard emulation level"
+msgstr ""
+
+#: ../src/msw/webview_ie.cpp:1049
+msgid "Can't run JavaScript script without a valid HTML document"
+msgstr ""
+
+#: ../src/msw/webview_ie.cpp:1056
+#, fuzzy
+msgid "Can't get the JavaScript object"
+msgstr "No se puet establir a prioridat d'o filo d'execución"
+
+#: ../src/msw/webview_ie.cpp:1070
+#, fuzzy
+msgid "failed to evaluate"
+msgstr "S'ha produciu una error en executar '%s'\n"
+
+#: ../src/osx/cocoa/filedlg.mm:412
+#, fuzzy
+msgid "File type:"
+msgstr "Teletipo"
+
+#: ../src/osx/cocoa/menu.mm:242
+#, fuzzy
+msgctxt "macOS menu name"
+msgid "Window"
+msgstr "&Finestra"
+
+#: ../src/osx/cocoa/menu.mm:259
+#, fuzzy
+msgctxt "macOS menu name"
+msgid "Help"
+msgstr "Aduya"
+
+#: ../src/osx/cocoa/menu.mm:298
+#, fuzzy
+msgctxt "macOS menu item"
+msgid "Minimize"
+msgstr "Mi&nimizar"
+
+#: ../src/osx/cocoa/menu.mm:303
+#, fuzzy
+msgctxt "macOS menu item"
+msgid "Zoom"
+msgstr "Agrandir"
+
+#: ../src/osx/cocoa/menu.mm:309
+msgctxt "macOS menu item"
+msgid "Bring All to Front"
+msgstr ""
+
+#: ../src/osx/core/sound.cpp:143
+#, fuzzy, c-format
+msgid "Failed to load sound from \"%s\" (error %d)."
+msgstr "No s'ha puesto cargar o recurso \"%s\"."
+
+#: ../src/osx/fontutil.cpp:80
+#, fuzzy, c-format
+msgid "Font file \"%s\" doesn't exist."
+msgstr ": o fichero no existe!"
+
+#: ../src/osx/fontutil.cpp:88
+#, c-format
+msgid ""
+"Font file \"%s\" cannot be used as it is not inside the font directory "
+"\"%s\"."
+msgstr ""
+
+#: ../src/osx/menu_osx.cpp:496
+#, c-format
+msgctxt "macOS menu item"
+msgid "About %s"
+msgstr "Arredol de %s"
+
+#: ../src/osx/menu_osx.cpp:499
+msgctxt "macOS menu item"
+msgid "About..."
+msgstr "Arredol de..."
+
+#: ../src/osx/menu_osx.cpp:508
+msgctxt "macOS menu item"
+msgid "Preferences..."
+msgstr "Preferencias..."
+
+#: ../src/osx/menu_osx.cpp:512
+msgctxt "macOS menu item"
+msgid "Services"
+msgstr "Servicios"
+
+#: ../src/osx/menu_osx.cpp:519
+#, c-format
+msgctxt "macOS menu item"
+msgid "Hide %s"
+msgstr "Amagar %s"
+
+#: ../src/osx/menu_osx.cpp:522
+#, fuzzy
+msgctxt "macOS menu item"
+msgid "Hide Application"
+msgstr "Aplicación"
+
+#: ../src/osx/menu_osx.cpp:526
+msgctxt "macOS menu item"
+msgid "Hide Others"
+msgstr "Amagar atros"
+
+#: ../src/osx/menu_osx.cpp:528
+msgctxt "macOS menu item"
+msgid "Show All"
+msgstr "Amostrar-lo tot"
+
+#: ../src/osx/menu_osx.cpp:534
+#, c-format
+msgctxt "macOS menu item"
+msgid "Quit %s"
+msgstr "Salir de %s"
+
+#: ../src/osx/menu_osx.cpp:537
+#, fuzzy
+msgctxt "macOS menu item"
+msgid "Quit Application"
+msgstr "Aplicación"
+
+#: ../src/osx/webview_webkit.mm:444
+#, fuzzy
+msgid "Printing is not supported by the system web control"
+msgstr "Gzip no ye suportau por ista versión de zlib"
+
+#: ../src/osx/webview_webkit.mm:453
+#, fuzzy
+msgid "Print operation could not be initialized"
+msgstr "No s'ha puesto inicializar a descripción de columna."
+
+#. TRANSLATORS: Label of font point size
+#: ../src/propgrid/advprops.cpp:605
+msgid "Point Size"
+msgstr "Grandaria de punto"
+
+#. TRANSLATORS: Label of font face name
+#: ../src/propgrid/advprops.cpp:615
+msgid "Face Name"
+msgstr "Nombre d'a fuent"
+
+#. TRANSLATORS: Label of font style
+#: ../src/propgrid/advprops.cpp:623 ../src/richtext/richtextformatdlg.cpp:331
+msgid "Style"
+msgstr "Estilo"
+
+#. TRANSLATORS: Label of font weight
+#: ../src/propgrid/advprops.cpp:628
+msgid "Weight"
+msgstr "Peso"
+
+#. TRANSLATORS: Label of underlined font
+#: ../src/propgrid/advprops.cpp:633 ../src/richtext/richtextfontpage.cpp:358
+msgid "Underlined"
+msgstr "Subrayau"
+
+#. TRANSLATORS: Label of font family
+#: ../src/propgrid/advprops.cpp:637
+msgid "Family"
+msgstr "Familia"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:801
+msgid "AppWorkspace"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:802
+#, fuzzy
+msgid "ActiveBorder"
+msgstr "Canto"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:803
+msgid "ActiveCaption"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:804
+msgid "ButtonFace"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:805
+msgid "ButtonHighlight"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:806
+msgid "ButtonShadow"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:807
+msgid "ButtonText"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:808
+msgid "CaptionText"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:809
+msgid "ControlDark"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:810
+msgid "ControlLight"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:812
+msgid "GrayText"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:813
+#, fuzzy
+msgid "Highlight"
+msgstr "lichera"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:814
+#, fuzzy
+msgid "HighlightText"
+msgstr "Texto aliniau a la dreita."
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:815
+#, fuzzy
+msgid "InactiveBorder"
+msgstr "Canto"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:816
+msgid "InactiveCaption"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:817
+msgid "InactiveCaptionText"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:818
+msgid "Menu"
+msgstr "Menú"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:819
+msgid "Scrollbar"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:820
+msgid "Tooltip"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:821
+msgid "TooltipText"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:822
+#, fuzzy
+msgid "Window"
+msgstr "&Finestra"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:823
+#, fuzzy
+msgid "WindowFrame"
+msgstr "&Finestra"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:824
+#, fuzzy
+msgid "WindowText"
+msgstr "&Finestra"
+
+#. TRANSLATORS: Custom colour choice entry
+#: ../src/propgrid/advprops.cpp:825 ../src/propgrid/advprops.cpp:1532
+#: ../src/propgrid/advprops.cpp:1576
+#, fuzzy
+msgid "Custom"
+msgstr "Grandaria personalizada"
+
+#: ../src/propgrid/advprops.cpp:1558
+msgid "Black"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1559
+msgid "Maroon"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1560
+msgid "Navy"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1561
+msgid "Purple"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1562
+msgid "Teal"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1563
+msgid "Gray"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1564
+#, fuzzy
+msgid "Green"
+msgstr "Mac Griego"
+
+#: ../src/propgrid/advprops.cpp:1565
+msgid "Olive"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1566
+#, fuzzy
+msgid "Brown"
+msgstr "Examinar"
+
+#: ../src/propgrid/advprops.cpp:1567
+msgid "Blue"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1568
+msgid "Fuchsia"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1569
+#, fuzzy
+msgid "Red"
+msgstr "Refer"
+
+#: ../src/propgrid/advprops.cpp:1570
+msgid "Orange"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1571
+msgid "Silver"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1572
+msgid "Lime"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1573
+msgid "Aqua"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1574
+msgid "Yellow"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1575
+msgid "White"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1718
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Default"
+msgstr "predeterminau"
+
+#: ../src/propgrid/advprops.cpp:1719
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Arrow"
+msgstr "maitín"
+
+#: ../src/propgrid/advprops.cpp:1720
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Right Arrow"
+msgstr "Dreita"
+
+#: ../src/propgrid/advprops.cpp:1721
+msgctxt "system cursor name"
+msgid "Blank"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1722
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Bullseye"
+msgstr "Estilo de vinyeta"
+
+#: ../src/propgrid/advprops.cpp:1723
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Character"
+msgstr "&Codigo de caracter:"
+
+#: ../src/propgrid/advprops.cpp:1724
+msgctxt "system cursor name"
+msgid "Cross"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1725
+msgctxt "system cursor name"
+msgid "Hand"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1726
+msgctxt "system cursor name"
+msgid "I-Beam"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1727
+msgctxt "system cursor name"
+msgid "Left Button"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1728
+msgctxt "system cursor name"
+msgid "Magnifier"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1729
+msgctxt "system cursor name"
+msgid "Middle Button"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1730
+msgctxt "system cursor name"
+msgid "No Entry"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1731
+msgctxt "system cursor name"
+msgid "Paint Brush"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1732
+msgctxt "system cursor name"
+msgid "Pencil"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1733
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Point Left"
+msgstr "Grandaria de punto"
+
+#: ../src/propgrid/advprops.cpp:1734
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Point Right"
+msgstr "Aliniar a la dreita"
+
+#: ../src/propgrid/advprops.cpp:1735
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Question Arrow"
+msgstr "Pregunta"
+
+#: ../src/propgrid/advprops.cpp:1736
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Right Button"
+msgstr "Dreita"
+
+#: ../src/propgrid/advprops.cpp:1737
+msgctxt "system cursor name"
+msgid "Sizing NE-SW"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1738
+msgctxt "system cursor name"
+msgid "Sizing N-S"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1739
+msgctxt "system cursor name"
+msgid "Sizing NW-SE"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1740
+msgctxt "system cursor name"
+msgid "Sizing W-E"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1741
+msgctxt "system cursor name"
+msgid "Sizing"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1742
+msgctxt "system cursor name"
+msgid "Spraycan"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1743
+msgctxt "system cursor name"
+msgid "Wait"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1744
+msgctxt "system cursor name"
+msgid "Watch"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1745
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Wait Arrow"
+msgstr "Dreita"
+
+#: ../src/propgrid/advprops.cpp:2109
+msgid "Make a selection:"
+msgstr "Selecciona una opción:"
+
+#: ../src/propgrid/manager.cpp:394
+msgid "Property"
+msgstr "Propiedat"
+
+#: ../src/propgrid/manager.cpp:395
+msgid "Value"
+msgstr "Valor"
+
+#: ../src/propgrid/manager.cpp:1683
+msgid "Categorized Mode"
+msgstr "Modo categorizau"
+
+#: ../src/propgrid/manager.cpp:1709
+msgid "Alphabetic Mode"
+msgstr "Modo alfabetico"
+
+#. TRANSLATORS: Name of Boolean false value
+#: ../src/propgrid/propgrid.cpp:230
+msgid "False"
+msgstr "Falso"
+
+#. TRANSLATORS: Name of Boolean true value
+#: ../src/propgrid/propgrid.cpp:232
+msgid "True"
+msgstr "Verdadero"
+
+#. TRANSLATORS: Text  displayed for unspecified value
+#: ../src/propgrid/propgrid.cpp:428
+msgid "Unspecified"
+msgstr "Sin especificar"
+
+#. TRANSLATORS: Caption of message box displaying any property error
+#: ../src/propgrid/propgrid.cpp:3145 ../src/propgrid/propgrid.cpp:3282
+msgid "Property Error"
+msgstr "Error de propiedat"
+
+#: ../src/propgrid/propgrid.cpp:3259
+msgid "You have entered invalid value. Press ESC to cancel editing."
+msgstr "Has introduciu una valor no valida. Preta l'ESC ta cancelar a edición."
+
+#: ../src/propgrid/propgrid.cpp:6608
+#, c-format
+msgid "Error in resource: %s"
+msgstr "S'ha produciu una error en o recurso: %s"
+
+#: ../src/propgrid/propgridiface.cpp:377
+#, c-format
+msgid ""
+"Type operation \"%s\" failed: Property labeled \"%s\" is of type \"%s\", NOT "
+"\"%s\"."
+msgstr ""
+"S'ha produciu una error en a operación de tipos \"%s\".: A propiedat "
+"etiquetada \"%s\" ye de tipo \"%s\" y no pas \"%s\"."
+
+#: ../src/propgrid/props.cpp:159
+#, c-format
+msgid "Unknown base %d. Base 10 will be used."
+msgstr ""
+
+#: ../src/propgrid/props.cpp:324
+#, c-format
+msgid "Value must be %s or higher."
+msgstr "A valor cal estar %s u mas alta."
+
+#: ../src/propgrid/props.cpp:329 ../src/propgrid/props.cpp:356
+#, c-format
+msgid "Value must be between %s and %s."
+msgstr "A valor cal estar entre %s y %s."
+
+#: ../src/propgrid/props.cpp:351
+#, c-format
+msgid "Value must be %s or less."
+msgstr "A valor cal estar %s u mas baixa."
+
+#: ../src/propgrid/props.cpp:1058
+#, c-format
+msgid "Not %s"
+msgstr "No bi ha %s"
+
+#: ../src/propgrid/props.cpp:1770
+msgid "Choose a directory:"
+msgstr "Triga un directorio:"
+
+#: ../src/propgrid/props.cpp:2055
+msgid "Choose a file"
+msgstr "Triga un fichero"
+
+#: ../src/qt/mdi.cpp:254
+msgid "&Tile"
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:147
+#: ../src/richtext/richtextformatdlg.cpp:376
+msgid "Background"
+msgstr "Fondo"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:159
+msgid "Background &colour:"
+msgstr "&Color de fondo:"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:161
+#: ../src/richtext/richtextbackgroundpage.cpp:163
+msgid "Enables a background colour."
+msgstr "Activa una color de fondo."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:167
+#: ../src/richtext/richtextbackgroundpage.cpp:169
+msgid "The background colour."
+msgstr "A color de fondo."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:178
+msgid "Shadow"
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:193
+msgid "Use &shadow"
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:195
+#: ../src/richtext/richtextbackgroundpage.cpp:197
+#, fuzzy
+msgid "Enables a shadow."
+msgstr "Activa una color de fondo."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:211
+msgid "&Horizontal offset:"
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:218
+#: ../src/richtext/richtextbackgroundpage.cpp:220
+#, fuzzy
+msgid "The horizontal offset."
+msgstr "Mosaico &Horizontal"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:224
+#: ../src/richtext/richtextbackgroundpage.cpp:227
+#: ../src/richtext/richtextbackgroundpage.cpp:228
+#: ../src/richtext/richtextbackgroundpage.cpp:247
+#: ../src/richtext/richtextbackgroundpage.cpp:250
+#: ../src/richtext/richtextbackgroundpage.cpp:251
+#: ../src/richtext/richtextbackgroundpage.cpp:287
+#: ../src/richtext/richtextbackgroundpage.cpp:290
+#: ../src/richtext/richtextbackgroundpage.cpp:291
+#: ../src/richtext/richtextbackgroundpage.cpp:314
+#: ../src/richtext/richtextbackgroundpage.cpp:317
+#: ../src/richtext/richtextbackgroundpage.cpp:318
+#: ../src/richtext/richtextborderspage.cpp:252
+#: ../src/richtext/richtextborderspage.cpp:255
+#: ../src/richtext/richtextborderspage.cpp:256
+#: ../src/richtext/richtextborderspage.cpp:286
+#: ../src/richtext/richtextborderspage.cpp:289
+#: ../src/richtext/richtextborderspage.cpp:290
+#: ../src/richtext/richtextborderspage.cpp:320
+#: ../src/richtext/richtextborderspage.cpp:323
+#: ../src/richtext/richtextborderspage.cpp:324
+#: ../src/richtext/richtextborderspage.cpp:354
+#: ../src/richtext/richtextborderspage.cpp:357
+#: ../src/richtext/richtextborderspage.cpp:358
+#: ../src/richtext/richtextborderspage.cpp:420
+#: ../src/richtext/richtextborderspage.cpp:423
+#: ../src/richtext/richtextborderspage.cpp:424
+#: ../src/richtext/richtextborderspage.cpp:454
+#: ../src/richtext/richtextborderspage.cpp:457
+#: ../src/richtext/richtextborderspage.cpp:458
+#: ../src/richtext/richtextborderspage.cpp:488
+#: ../src/richtext/richtextborderspage.cpp:491
+#: ../src/richtext/richtextborderspage.cpp:492
+#: ../src/richtext/richtextborderspage.cpp:522
+#: ../src/richtext/richtextborderspage.cpp:525
+#: ../src/richtext/richtextborderspage.cpp:526
+#: ../src/richtext/richtextborderspage.cpp:590
+#: ../src/richtext/richtextborderspage.cpp:593
+#: ../src/richtext/richtextborderspage.cpp:594
+#: ../src/richtext/richtextfontpage.cpp:177
+#: ../src/richtext/richtextmarginspage.cpp:199
+#: ../src/richtext/richtextmarginspage.cpp:201
+#: ../src/richtext/richtextmarginspage.cpp:202
+#: ../src/richtext/richtextmarginspage.cpp:224
+#: ../src/richtext/richtextmarginspage.cpp:226
+#: ../src/richtext/richtextmarginspage.cpp:227
+#: ../src/richtext/richtextmarginspage.cpp:247
+#: ../src/richtext/richtextmarginspage.cpp:249
+#: ../src/richtext/richtextmarginspage.cpp:250
+#: ../src/richtext/richtextmarginspage.cpp:272
+#: ../src/richtext/richtextmarginspage.cpp:274
+#: ../src/richtext/richtextmarginspage.cpp:275
+#: ../src/richtext/richtextmarginspage.cpp:313
+#: ../src/richtext/richtextmarginspage.cpp:315
+#: ../src/richtext/richtextmarginspage.cpp:316
+#: ../src/richtext/richtextmarginspage.cpp:338
+#: ../src/richtext/richtextmarginspage.cpp:340
+#: ../src/richtext/richtextmarginspage.cpp:341
+#: ../src/richtext/richtextmarginspage.cpp:361
+#: ../src/richtext/richtextmarginspage.cpp:363
+#: ../src/richtext/richtextmarginspage.cpp:364
+#: ../src/richtext/richtextmarginspage.cpp:386
+#: ../src/richtext/richtextmarginspage.cpp:388
+#: ../src/richtext/richtextmarginspage.cpp:389
+#: ../src/richtext/richtextsizepage.cpp:337
+#: ../src/richtext/richtextsizepage.cpp:340
+#: ../src/richtext/richtextsizepage.cpp:341
+#: ../src/richtext/richtextsizepage.cpp:371
+#: ../src/richtext/richtextsizepage.cpp:374
+#: ../src/richtext/richtextsizepage.cpp:375
+#: ../src/richtext/richtextsizepage.cpp:398
+#: ../src/richtext/richtextsizepage.cpp:401
+#: ../src/richtext/richtextsizepage.cpp:402
+#: ../src/richtext/richtextsizepage.cpp:425
+#: ../src/richtext/richtextsizepage.cpp:428
+#: ../src/richtext/richtextsizepage.cpp:429
+#: ../src/richtext/richtextsizepage.cpp:452
+#: ../src/richtext/richtextsizepage.cpp:455
+#: ../src/richtext/richtextsizepage.cpp:456
+#: ../src/richtext/richtextsizepage.cpp:479
+#: ../src/richtext/richtextsizepage.cpp:482
+#: ../src/richtext/richtextsizepage.cpp:483
+#: ../src/richtext/richtextsizepage.cpp:553
+#: ../src/richtext/richtextsizepage.cpp:556
+#: ../src/richtext/richtextsizepage.cpp:557
+#: ../src/richtext/richtextsizepage.cpp:588
+#: ../src/richtext/richtextsizepage.cpp:591
+#: ../src/richtext/richtextsizepage.cpp:592
+#: ../src/richtext/richtextsizepage.cpp:623
+#: ../src/richtext/richtextsizepage.cpp:626
+#: ../src/richtext/richtextsizepage.cpp:627
+#: ../src/richtext/richtextsizepage.cpp:658
+#: ../src/richtext/richtextsizepage.cpp:661
+#: ../src/richtext/richtextsizepage.cpp:662
+msgid "px"
+msgstr "px"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:225
+#: ../src/richtext/richtextbackgroundpage.cpp:248
+#: ../src/richtext/richtextbackgroundpage.cpp:288
+#: ../src/richtext/richtextbackgroundpage.cpp:315
+#: ../src/richtext/richtextborderspage.cpp:253
+#: ../src/richtext/richtextborderspage.cpp:287
+#: ../src/richtext/richtextborderspage.cpp:321
+#: ../src/richtext/richtextborderspage.cpp:355
+#: ../src/richtext/richtextborderspage.cpp:421
+#: ../src/richtext/richtextborderspage.cpp:455
+#: ../src/richtext/richtextborderspage.cpp:489
+#: ../src/richtext/richtextborderspage.cpp:523
+#: ../src/richtext/richtextborderspage.cpp:591
+#: ../src/richtext/richtextmarginspage.cpp:200
+#: ../src/richtext/richtextmarginspage.cpp:225
+#: ../src/richtext/richtextmarginspage.cpp:248
+#: ../src/richtext/richtextmarginspage.cpp:273
+#: ../src/richtext/richtextmarginspage.cpp:314
+#: ../src/richtext/richtextmarginspage.cpp:339
+#: ../src/richtext/richtextmarginspage.cpp:362
+#: ../src/richtext/richtextmarginspage.cpp:387
+#: ../src/richtext/richtextsizepage.cpp:338
+#: ../src/richtext/richtextsizepage.cpp:372
+#: ../src/richtext/richtextsizepage.cpp:399
+#: ../src/richtext/richtextsizepage.cpp:426
+#: ../src/richtext/richtextsizepage.cpp:453
+#: ../src/richtext/richtextsizepage.cpp:480
+#: ../src/richtext/richtextsizepage.cpp:554
+#: ../src/richtext/richtextsizepage.cpp:589
+#: ../src/richtext/richtextsizepage.cpp:624
+#: ../src/richtext/richtextsizepage.cpp:659
+msgid "cm"
+msgstr "cm"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:226
+#: ../src/richtext/richtextbackgroundpage.cpp:249
+#: ../src/richtext/richtextbackgroundpage.cpp:289
+#: ../src/richtext/richtextbackgroundpage.cpp:316
+#: ../src/richtext/richtextborderspage.cpp:254
+#: ../src/richtext/richtextborderspage.cpp:288
+#: ../src/richtext/richtextborderspage.cpp:322
+#: ../src/richtext/richtextborderspage.cpp:356
+#: ../src/richtext/richtextborderspage.cpp:422
+#: ../src/richtext/richtextborderspage.cpp:456
+#: ../src/richtext/richtextborderspage.cpp:490
+#: ../src/richtext/richtextborderspage.cpp:524
+#: ../src/richtext/richtextborderspage.cpp:592
+#: ../src/richtext/richtextfontpage.cpp:176
+#: ../src/richtext/richtextfontpage.cpp:179
+msgid "pt"
+msgstr "pt"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:229
+#: ../src/richtext/richtextbackgroundpage.cpp:231
+#: ../src/richtext/richtextbackgroundpage.cpp:252
+#: ../src/richtext/richtextbackgroundpage.cpp:254
+#: ../src/richtext/richtextbackgroundpage.cpp:292
+#: ../src/richtext/richtextbackgroundpage.cpp:294
+#: ../src/richtext/richtextbackgroundpage.cpp:319
+#: ../src/richtext/richtextbackgroundpage.cpp:321
+#, fuzzy
+msgid "Units for this value."
+msgstr "Unidatz ta la marguin cucha."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:234
+#, fuzzy
+msgid "&Vertical offset:"
+msgstr "Aliniación &vertical:"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:241
+#: ../src/richtext/richtextbackgroundpage.cpp:243
+#, fuzzy
+msgid "The vertical offset."
+msgstr "Activar l'aliniación vertical."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:257
+#, fuzzy
+msgid "Shadow c&olour:"
+msgstr "Trigar a color"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:259
+#: ../src/richtext/richtextbackgroundpage.cpp:261
+#, fuzzy
+msgid "Enables the shadow colour."
+msgstr "Activa una color de fondo."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:265
+#: ../src/richtext/richtextbackgroundpage.cpp:267
+#, fuzzy
+msgid "The shadow colour."
+msgstr "A color de fuent."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:270
+msgid "Sh&adow spread:"
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:272
+#: ../src/richtext/richtextbackgroundpage.cpp:274
+#, fuzzy
+msgid "Enables the shadow spread."
+msgstr "Activar a valor de l'amplaria."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:281
+#: ../src/richtext/richtextbackgroundpage.cpp:283
+msgid "The shadow spread."
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:297
+msgid "&Blur distance:"
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:299
+#: ../src/richtext/richtextbackgroundpage.cpp:301
+#, fuzzy
+msgid "Enables the blur distance."
+msgstr "Activar a valor de l'amplaria."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:308
+#: ../src/richtext/richtextbackgroundpage.cpp:310
+msgid "The shadow blur distance."
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:324
+msgid "Opaci&ty:"
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:326
+#: ../src/richtext/richtextbackgroundpage.cpp:328
+#, fuzzy
+msgid "Enables the shadow opacity."
+msgstr "Activar a valor de l'amplaria."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:335
+#: ../src/richtext/richtextbackgroundpage.cpp:337
+msgid "The shadow opacity."
+msgstr ""
+
+#. TRANSLATORS: Rich text page units (percentage)
+#: ../src/richtext/richtextbackgroundpage.cpp:340
+#: ../src/richtext/richtextsizepage.cpp:339
+#: ../src/richtext/richtextsizepage.cpp:373
+#: ../src/richtext/richtextsizepage.cpp:400
+#: ../src/richtext/richtextsizepage.cpp:427
+#: ../src/richtext/richtextsizepage.cpp:454
+#: ../src/richtext/richtextsizepage.cpp:481
+#: ../src/richtext/richtextsizepage.cpp:555
+#: ../src/richtext/richtextsizepage.cpp:590
+#: ../src/richtext/richtextsizepage.cpp:625
+#: ../src/richtext/richtextsizepage.cpp:660
+msgid "%"
+msgstr "%"
+
+#: ../src/richtext/richtextborderspage.cpp:229
+#: ../src/richtext/richtextborderspage.cpp:387
+msgid "Border"
+msgstr "Canto"
+
+#: ../src/richtext/richtextborderspage.cpp:242
+#: ../src/richtext/richtextborderspage.cpp:410
+#: ../src/richtext/richtextindentspage.cpp:194
+#: ../src/richtext/richtextliststylepage.cpp:384
+#: ../src/richtext/richtextmarginspage.cpp:185
+#: ../src/richtext/richtextmarginspage.cpp:299
+#: ../src/richtext/richtextsizepage.cpp:531
+#: ../src/richtext/richtextsizepage.cpp:538
+msgid "&Left:"
+msgstr "&Cucha:"
+
+#: ../src/richtext/richtextborderspage.cpp:257
+#: ../src/richtext/richtextborderspage.cpp:259
+msgid "Units for the left border width."
+msgstr "Unidatz ta l'amplaria d'o canto cucho."
+
+#: ../src/richtext/richtextborderspage.cpp:266
+#: ../src/richtext/richtextborderspage.cpp:268
+#: ../src/richtext/richtextborderspage.cpp:300
+#: ../src/richtext/richtextborderspage.cpp:302
+#: ../src/richtext/richtextborderspage.cpp:334
+#: ../src/richtext/richtextborderspage.cpp:336
+#: ../src/richtext/richtextborderspage.cpp:368
+#: ../src/richtext/richtextborderspage.cpp:370
+#: ../src/richtext/richtextborderspage.cpp:434
+#: ../src/richtext/richtextborderspage.cpp:436
+#: ../src/richtext/richtextborderspage.cpp:468
+#: ../src/richtext/richtextborderspage.cpp:470
+#: ../src/richtext/richtextborderspage.cpp:502
+#: ../src/richtext/richtextborderspage.cpp:504
+#: ../src/richtext/richtextborderspage.cpp:536
+#: ../src/richtext/richtextborderspage.cpp:538
+msgid "The border line style."
+msgstr "O estilo d'a linia d'o canto."
+
+#: ../src/richtext/richtextborderspage.cpp:276
+#: ../src/richtext/richtextborderspage.cpp:444
+#: ../src/richtext/richtextindentspage.cpp:212
+#: ../src/richtext/richtextliststylepage.cpp:402
+#: ../src/richtext/richtextmarginspage.cpp:210
+#: ../src/richtext/richtextmarginspage.cpp:324
+#: ../src/richtext/richtextsizepage.cpp:601
+#: ../src/richtext/richtextsizepage.cpp:608
+msgid "&Right:"
+msgstr "&Dreita:"
+
+#: ../src/richtext/richtextborderspage.cpp:291
+#: ../src/richtext/richtextborderspage.cpp:293
+msgid "Units for the right border width."
+msgstr "Unidatz ta l'amplaria d'o cantodreito."
+
+#: ../src/richtext/richtextborderspage.cpp:310
+#: ../src/richtext/richtextborderspage.cpp:478
+#: ../src/richtext/richtextmarginspage.cpp:233
+#: ../src/richtext/richtextmarginspage.cpp:347
+#: ../src/richtext/richtextsizepage.cpp:566
+#: ../src/richtext/richtextsizepage.cpp:573
+msgid "&Top:"
+msgstr "&Superior:"
+
+#: ../src/richtext/richtextborderspage.cpp:325
+#: ../src/richtext/richtextborderspage.cpp:327
+msgid "Units for the top border width."
+msgstr "Unidatz ta l'amplaria d'o canto superior."
+
+#: ../src/richtext/richtextborderspage.cpp:344
+#: ../src/richtext/richtextborderspage.cpp:512
+#: ../src/richtext/richtextmarginspage.cpp:258
+#: ../src/richtext/richtextmarginspage.cpp:372
+#: ../src/richtext/richtextsizepage.cpp:636
+#: ../src/richtext/richtextsizepage.cpp:643
+msgid "&Bottom:"
+msgstr "&Inferior:"
+
+#: ../src/richtext/richtextborderspage.cpp:359
+#: ../src/richtext/richtextborderspage.cpp:361
+msgid "Units for the bottom border width."
+msgstr "Unidatz ta l'amplaria d'o canto inferior."
+
+#: ../src/richtext/richtextborderspage.cpp:380
+#: ../src/richtext/richtextborderspage.cpp:548
+msgid "&Synchronize values"
+msgstr "&Sincronizar as valors"
+
+#: ../src/richtext/richtextborderspage.cpp:382
+#: ../src/richtext/richtextborderspage.cpp:384
+#: ../src/richtext/richtextborderspage.cpp:550
+#: ../src/richtext/richtextborderspage.cpp:552
+msgid "Check to edit all borders simultaneously."
+msgstr "Mirar d'editar totz os cantos simultaniament."
+
+#: ../src/richtext/richtextborderspage.cpp:397
+#: ../src/richtext/richtextborderspage.cpp:555
+msgid "Outline"
+msgstr "Esquema"
+
+#: ../src/richtext/richtextborderspage.cpp:425
+#: ../src/richtext/richtextborderspage.cpp:427
+msgid "Units for the left outline width."
+msgstr "Unidatz ta l'amplaria d'o esquema cucho."
+
+#: ../src/richtext/richtextborderspage.cpp:459
+#: ../src/richtext/richtextborderspage.cpp:461
+msgid "Units for the right outline width."
+msgstr "Unidatz ta l'amplaria d'o esquema dreito."
+
+#: ../src/richtext/richtextborderspage.cpp:493
+#: ../src/richtext/richtextborderspage.cpp:495
+msgid "Units for the top outline width."
+msgstr "Unidatz ta l'amplaria d'o esquema superior."
+
+#: ../src/richtext/richtextborderspage.cpp:527
+#: ../src/richtext/richtextborderspage.cpp:529
+msgid "Units for the bottom outline width."
+msgstr "Unidatz ta l'amplaria d'o esquema inferior."
+
+#: ../src/richtext/richtextborderspage.cpp:565
+#: ../src/richtext/richtextborderspage.cpp:600
+msgid "Corner"
+msgstr "Cantonada"
+
+#: ../src/richtext/richtextborderspage.cpp:574
+msgid "Corner &radius:"
+msgstr "&Radio d'a cantonada:"
+
+#: ../src/richtext/richtextborderspage.cpp:576
+#: ../src/richtext/richtextborderspage.cpp:578
+msgid "An optional corner radius for adding rounded corners."
+msgstr "Un radio de cantonada opcional ta adhibir cantonadas redondiadas."
+
+#: ../src/richtext/richtextborderspage.cpp:584
+#: ../src/richtext/richtextborderspage.cpp:586
+msgid "The value of the corner radius."
+msgstr "A valor d'o radio de cantonada."
+
+#: ../src/richtext/richtextborderspage.cpp:595
+#: ../src/richtext/richtextborderspage.cpp:597
+msgid "Units for the corner radius."
+msgstr "Unidatz ta lo radio de cantonada."
+
+#: ../src/richtext/richtextborderspage.cpp:609
+#: ../src/richtext/richtextsizepage.cpp:247
+#: ../src/richtext/richtextsizepage.cpp:251
+msgid "None"
+msgstr "Garra"
+
+#: ../src/richtext/richtextborderspage.cpp:610
+msgid "Solid"
+msgstr "Soliu"
+
+#: ../src/richtext/richtextborderspage.cpp:611
+msgid "Dotted"
+msgstr "Puntiau"
+
+#: ../src/richtext/richtextborderspage.cpp:612
+msgid "Dashed"
+msgstr "Discontina"
+
+#: ../src/richtext/richtextborderspage.cpp:613
+msgid "Double"
+msgstr "Dople"
+
+#: ../src/richtext/richtextborderspage.cpp:614
+msgid "Groove"
+msgstr "Acanalau"
+
+#: ../src/richtext/richtextborderspage.cpp:615
+msgid "Ridge"
+msgstr "Cresta"
+
+#: ../src/richtext/richtextborderspage.cpp:616
+msgid "Inset"
+msgstr "Interno"
+
+#: ../src/richtext/richtextborderspage.cpp:617
+msgid "Outset"
+msgstr "Externo"
+
+#: ../src/richtext/richtextbuffer.cpp:3518
+msgid "Change Style"
+msgstr "Cambiar o Estilo"
+
+#: ../src/richtext/richtextbuffer.cpp:3701
+msgid "Change Object Style"
+msgstr "Cambiar o estilo de l'obchecto"
+
+#: ../src/richtext/richtextbuffer.cpp:3974
+#: ../src/richtext/richtextbuffer.cpp:8174
+msgid "Change Properties"
+msgstr "Cambiar as propiedatz"
+
+#: ../src/richtext/richtextbuffer.cpp:4346
+msgid "Change List Style"
+msgstr "Cambiar o Estilo de Lista"
+
+#: ../src/richtext/richtextbuffer.cpp:4519
+msgid "Renumber List"
+msgstr "Renumerar a Lista"
+
+#: ../src/richtext/richtextbuffer.cpp:7867
+#: ../src/richtext/richtextbuffer.cpp:7897
+#: ../src/richtext/richtextbuffer.cpp:7939
+#: ../src/richtext/richtextctrl.cpp:1279 ../src/richtext/richtextctrl.cpp:1473
+msgid "Insert Text"
+msgstr "Ficar Texto"
+
+#: ../src/richtext/richtextbuffer.cpp:8023
+#: ../src/richtext/richtextbuffer.cpp:8979
+msgid "Insert Image"
+msgstr "Ficar una imachen"
+
+#: ../src/richtext/richtextbuffer.cpp:8070
+msgid "Insert Object"
+msgstr "Ficar un obchecto"
+
+#: ../src/richtext/richtextbuffer.cpp:8112
+msgid "Insert Field"
+msgstr "Ficar un campo"
+
+#: ../src/richtext/richtextbuffer.cpp:8410
+msgid "Too many EndStyle calls!"
+msgstr "Masiadas clamadas EndStyle!"
+
+#: ../src/richtext/richtextbuffer.cpp:8785
+msgid "files"
+msgstr "fichers"
+
+#: ../src/richtext/richtextbuffer.cpp:9380
+msgid "standard/circle"
+msgstr "estandar/cerclo"
+
+#: ../src/richtext/richtextbuffer.cpp:9381
+msgid "standard/circle-outline"
+msgstr "estandar/cerclo - esquema"
+
+#: ../src/richtext/richtextbuffer.cpp:9382
+msgid "standard/square"
+msgstr "estandar/quadrau"
+
+#: ../src/richtext/richtextbuffer.cpp:9383
+msgid "standard/diamond"
+msgstr "estandar/diamant"
+
+#: ../src/richtext/richtextbuffer.cpp:9384
+msgid "standard/triangle"
+msgstr "estandar/trianglo"
+
+#: ../src/richtext/richtextbuffer.cpp:9423
+msgid "Box Properties"
+msgstr "Propiedatz d'a caixa"
+
+#: ../src/richtext/richtextbuffer.cpp:10006
+msgid "Multiple Cell Properties"
+msgstr "Propiedatz de celda multiple"
+
+#: ../src/richtext/richtextbuffer.cpp:10008
+msgid "Cell Properties"
+msgstr "Propiedatz de celda"
+
+#: ../src/richtext/richtextbuffer.cpp:11256
+msgid "Set Cell Style"
+msgstr "Establir o estilo de celda"
+
+#: ../src/richtext/richtextbuffer.cpp:11330
+msgid "Delete Row"
+msgstr "Eliminar a ringlera"
+
+#: ../src/richtext/richtextbuffer.cpp:11380
+msgid "Delete Column"
+msgstr "Eliminar a columna"
+
+#: ../src/richtext/richtextbuffer.cpp:11431
+msgid "Add Row"
+msgstr "Adhibir una ringlera"
+
+#: ../src/richtext/richtextbuffer.cpp:11494
+msgid "Add Column"
+msgstr "Adhibir unacolumna"
+
+#: ../src/richtext/richtextbuffer.cpp:11537
+msgid "Table Properties"
+msgstr "Propiedatz d'a tabla"
+
+#: ../src/richtext/richtextbuffer.cpp:12899
+msgid "Picture Properties"
+msgstr "Propiedatz d'a imachen"
+
+#: ../src/richtext/richtextbuffer.cpp:13169
+#: ../src/richtext/richtextbuffer.cpp:13279
+msgid "image"
+msgstr "imachen"
+
+#: ../src/richtext/richtextbulletspage.cpp:145
+#: ../src/richtext/richtextliststylepage.cpp:209
+msgid "&Bullet style:"
+msgstr "Estilo de &vinyeta:"
+
+#: ../src/richtext/richtextbulletspage.cpp:150
+#: ../src/richtext/richtextbulletspage.cpp:152
+#: ../src/richtext/richtextliststylepage.cpp:214
+#: ../src/richtext/richtextliststylepage.cpp:216
+msgid "The available bullet styles."
+msgstr "Os estilos disponibles de vinyeta."
+
+#: ../src/richtext/richtextbulletspage.cpp:158
+#: ../src/richtext/richtextliststylepage.cpp:221
+msgid "Peri&od"
+msgstr "Peri&odo"
+
+#: ../src/richtext/richtextbulletspage.cpp:160
+#: ../src/richtext/richtextbulletspage.cpp:162
+#: ../src/richtext/richtextliststylepage.cpp:223
+#: ../src/richtext/richtextliststylepage.cpp:225
+msgid "Check to add a period after the bullet."
+msgstr "Marcar ta adhibir un punto dimpués d'a vinyeta."
+
+#. TRANSLATORS: Bullet point in parentheses option
+#: ../src/richtext/richtextbulletspage.cpp:167
+#: ../src/richtext/richtextliststylepage.cpp:230
+msgid "(*)"
+msgstr "(*)"
+
+#: ../src/richtext/richtextbulletspage.cpp:169
+#: ../src/richtext/richtextbulletspage.cpp:171
+#: ../src/richtext/richtextliststylepage.cpp:232
+#: ../src/richtext/richtextliststylepage.cpp:234
+msgid "Check to enclose the bullet in parentheses."
+msgstr "Marcar ta enzarrar a vinyeta entre parentesi."
+
+#. TRANSLATORS: Right parenthesis bullet point option
+#: ../src/richtext/richtextbulletspage.cpp:176
+#: ../src/richtext/richtextliststylepage.cpp:239
+msgid "*)"
+msgstr "*)"
+
+#: ../src/richtext/richtextbulletspage.cpp:178
+#: ../src/richtext/richtextbulletspage.cpp:180
+#: ../src/richtext/richtextliststylepage.cpp:241
+#: ../src/richtext/richtextliststylepage.cpp:243
+msgid "Check to add a right parenthesis."
+msgstr "Marcar ta adhibir un parentesi dreito."
+
+#: ../src/richtext/richtextbulletspage.cpp:185
+#: ../src/richtext/richtextliststylepage.cpp:248
+msgid "Bullet &Alignment:"
+msgstr "&Aliniación de vinyeta:"
+
+#: ../src/richtext/richtextbulletspage.cpp:190
+#: ../src/richtext/richtextliststylepage.cpp:253
+msgid "Centre"
+msgstr "Centrar"
+
+#: ../src/richtext/richtextbulletspage.cpp:194
+#: ../src/richtext/richtextbulletspage.cpp:196
+#: ../src/richtext/richtextbulletspage.cpp:217
+#: ../src/richtext/richtextbulletspage.cpp:219
+#: ../src/richtext/richtextliststylepage.cpp:257
+#: ../src/richtext/richtextliststylepage.cpp:259
+#: ../src/richtext/richtextliststylepage.cpp:278
+#: ../src/richtext/richtextliststylepage.cpp:280
+msgid "The bullet character."
+msgstr "O caracter vinyeta."
+
+#: ../src/richtext/richtextbulletspage.cpp:212
+#: ../src/richtext/richtextliststylepage.cpp:271
+msgid "&Symbol:"
+msgstr "&Simbolo:"
+
+#: ../src/richtext/richtextbulletspage.cpp:222
+#: ../src/richtext/richtextliststylepage.cpp:283
+msgid "Ch&oose..."
+msgstr "&Trigar..."
+
+#: ../src/richtext/richtextbulletspage.cpp:223
+#: ../src/richtext/richtextbulletspage.cpp:225
+#: ../src/richtext/richtextliststylepage.cpp:284
+#: ../src/richtext/richtextliststylepage.cpp:286
+msgid "Click to browse for a symbol."
+msgstr "Fe click ta mirar un simbolo."
+
+#: ../src/richtext/richtextbulletspage.cpp:230
+#: ../src/richtext/richtextliststylepage.cpp:291
+msgid "Symbol &font:"
+msgstr "&Fuent de simbolos:"
+
+#: ../src/richtext/richtextbulletspage.cpp:235
+#: ../src/richtext/richtextbulletspage.cpp:237
+#: ../src/richtext/richtextliststylepage.cpp:297
+msgid "Available fonts."
+msgstr "Fuents disponibles."
+
+#: ../src/richtext/richtextbulletspage.cpp:242
+#: ../src/richtext/richtextliststylepage.cpp:302
+msgid "S&tandard bullet name:"
+msgstr "Nombre de vinyeta es&tandar:"
+
+#: ../src/richtext/richtextbulletspage.cpp:247
+#: ../src/richtext/richtextbulletspage.cpp:249
+#: ../src/richtext/richtextliststylepage.cpp:307
+#: ../src/richtext/richtextliststylepage.cpp:309
+msgid "A standard bullet name."
+msgstr "Un nombre de vinyeta estandar."
+
+#: ../src/richtext/richtextbulletspage.cpp:254
+msgid "&Number:"
+msgstr "&Numero:"
+
+#: ../src/richtext/richtextbulletspage.cpp:258
+#: ../src/richtext/richtextbulletspage.cpp:260
+msgid "The list item number."
+msgstr "O numero d'elemento d'a lista."
+
+#: ../src/richtext/richtextbulletspage.cpp:266
+#: ../src/richtext/richtextbulletspage.cpp:268
+#: ../src/richtext/richtextliststylepage.cpp:475
+#: ../src/richtext/richtextliststylepage.cpp:477
+msgid "Shows a preview of the bullet settings."
+msgstr "Amuestra una anvista previa d'as opcions de vinyeta."
+
+#: ../src/richtext/richtextbulletspage.cpp:276
+#: ../src/richtext/richtextliststylepage.cpp:484
+msgid "(None)"
+msgstr "(Garra)"
+
+#: ../src/richtext/richtextbulletspage.cpp:277
+#: ../src/richtext/richtextliststylepage.cpp:485
+msgid "Arabic"
+msgstr "Arabe"
+
+#: ../src/richtext/richtextbulletspage.cpp:278
+#: ../src/richtext/richtextliststylepage.cpp:486
+msgid "Upper case letters"
+msgstr "Letras mayusclas"
+
+#: ../src/richtext/richtextbulletspage.cpp:279
+#: ../src/richtext/richtextliststylepage.cpp:487
+msgid "Lower case letters"
+msgstr "Letras minusclas"
+
+#: ../src/richtext/richtextbulletspage.cpp:280
+#: ../src/richtext/richtextliststylepage.cpp:488
+msgid "Upper case roman numerals"
+msgstr "Numeros romanos en mayusclas"
+
+#: ../src/richtext/richtextbulletspage.cpp:281
+#: ../src/richtext/richtextliststylepage.cpp:489
+msgid "Lower case roman numerals"
+msgstr "Numeros romanos en minuscla"
+
+#: ../src/richtext/richtextbulletspage.cpp:282
+#: ../src/richtext/richtextliststylepage.cpp:490
+msgid "Numbered outline"
+msgstr "Esquema numerau"
+
+#: ../src/richtext/richtextbulletspage.cpp:283
+#: ../src/richtext/richtextliststylepage.cpp:491
+msgid "Symbol"
+msgstr "Simbolo"
+
+#: ../src/richtext/richtextbulletspage.cpp:284
+#: ../src/richtext/richtextliststylepage.cpp:492
+msgid "Bitmap"
+msgstr "Mapa de bits"
+
+#: ../src/richtext/richtextbulletspage.cpp:285
+#: ../src/richtext/richtextliststylepage.cpp:493
+msgid "Standard"
+msgstr "Estandar"
+
+#: ../src/richtext/richtextbulletspage.cpp:287
+#: ../src/richtext/richtextliststylepage.cpp:495
+msgid "*"
+msgstr "*"
+
+#: ../src/richtext/richtextbulletspage.cpp:288
+#: ../src/richtext/richtextliststylepage.cpp:496
+msgid "-"
+msgstr "-"
+
+#: ../src/richtext/richtextbulletspage.cpp:289
+#: ../src/richtext/richtextliststylepage.cpp:497
+msgid ">"
+msgstr ">"
+
+#: ../src/richtext/richtextbulletspage.cpp:290
+#: ../src/richtext/richtextliststylepage.cpp:498
+msgid "+"
+msgstr "+"
+
+#: ../src/richtext/richtextbulletspage.cpp:291
+#: ../src/richtext/richtextliststylepage.cpp:499
+msgid "~"
+msgstr "~"
+
+#: ../src/richtext/richtextctrl.cpp:859
+msgid "Drag"
+msgstr "Arrocegar"
+
+#: ../src/richtext/richtextctrl.cpp:1338 ../src/richtext/richtextctrl.cpp:1559
+msgid "Delete Text"
+msgstr "Eliminar o Texto"
+
+#: ../src/richtext/richtextctrl.cpp:1537
+msgid "Remove Bullet"
+msgstr "Esborrar a vinyeta"
+
+#: ../src/richtext/richtextctrl.cpp:3070
+msgid "The text couldn't be saved."
+msgstr "No s'ha puesto alzar o texto."
+
+#: ../src/richtext/richtextctrl.cpp:3644
+msgid "Replace"
+msgstr "Substituir"
+
+#: ../src/richtext/richtextfontpage.cpp:146
+#: ../src/richtext/richtextsymboldlg.cpp:384
+msgid "&Font:"
+msgstr "&Fuent:"
+
+#: ../src/richtext/richtextfontpage.cpp:150
+#: ../src/richtext/richtextfontpage.cpp:152
+msgid "Type a font name."
+msgstr "Escribe un nombre de fuent."
+
+#: ../src/richtext/richtextfontpage.cpp:158
+msgid "&Size:"
+msgstr "&Grandaria:"
+
+#: ../src/richtext/richtextfontpage.cpp:165
+#: ../src/richtext/richtextfontpage.cpp:167
+msgid "Type a size in points."
+msgstr "Escribe una grandaria en puntos."
+
+#: ../src/richtext/richtextfontpage.cpp:180
+#: ../src/richtext/richtextfontpage.cpp:182
+msgid "The font size units, points or pixels."
+msgstr "As unidatz d'a grandaria de fuent, puntos u pixels."
+
+#: ../src/richtext/richtextfontpage.cpp:189
+#: ../src/richtext/richtextfontpage.cpp:191
+msgid "Lists the available fonts."
+msgstr "Lista las fuents disponibles."
+
+#: ../src/richtext/richtextfontpage.cpp:196
+#: ../src/richtext/richtextfontpage.cpp:198
+msgid "Lists font sizes in points."
+msgstr "Grandarias de fuent de listas en puntos."
+
+#: ../src/richtext/richtextfontpage.cpp:207
+msgid "Font st&yle:"
+msgstr "&Estilo d'a fuent:"
+
+#: ../src/richtext/richtextfontpage.cpp:212
+#: ../src/richtext/richtextfontpage.cpp:214
+msgid "Select regular or italic style."
+msgstr "Seleccionar estilo normal u cursiva."
+
+#: ../src/richtext/richtextfontpage.cpp:220
+msgid "Font &weight:"
+msgstr "&Peso d'a fuent:"
+
+#: ../src/richtext/richtextfontpage.cpp:225
+#: ../src/richtext/richtextfontpage.cpp:227
+msgid "Select regular or bold."
+msgstr "Seleccionar normal u negreta."
+
+#: ../src/richtext/richtextfontpage.cpp:233
+msgid "&Underlining:"
+msgstr "S&ubrayau:"
+
+#: ../src/richtext/richtextfontpage.cpp:238
+#: ../src/richtext/richtextfontpage.cpp:240
+msgid "Select underlining or no underlining."
+msgstr "Seleccionar subrayau u no pas subrayau."
+
+#: ../src/richtext/richtextfontpage.cpp:248
+msgid "&Colour:"
+msgstr "&Color:"
+
+#: ../src/richtext/richtextfontpage.cpp:253
+#: ../src/richtext/richtextfontpage.cpp:255
+msgid "Click to change the text colour."
+msgstr "Fe clic ta cambiar a color d'o texto."
+
+#: ../src/richtext/richtextfontpage.cpp:261
+msgid "&Bg colour:"
+msgstr "&Color de fondo:"
+
+#: ../src/richtext/richtextfontpage.cpp:266
+#: ../src/richtext/richtextfontpage.cpp:268
+msgid "Click to change the text background colour."
+msgstr "Fe clic ta cambiar a color de fondo d'o texto."
+
+#: ../src/richtext/richtextfontpage.cpp:276
+#: ../src/richtext/richtextfontpage.cpp:278
+msgid "Check to show a line through the text."
+msgstr "Prebar a amostrar una linia a traviés d'o texto."
+
+#: ../src/richtext/richtextfontpage.cpp:281
+msgid "Ca&pitals"
+msgstr "&Mayusclas"
+
+#: ../src/richtext/richtextfontpage.cpp:283
+#: ../src/richtext/richtextfontpage.cpp:285
+msgid "Check to show the text in capitals."
+msgstr "Prebar a amostrar o texto en mayusclas."
+
+#: ../src/richtext/richtextfontpage.cpp:288
+msgid "Small C&apitals"
+msgstr "M&ayusclas chicotas"
+
+#: ../src/richtext/richtextfontpage.cpp:290
+#: ../src/richtext/richtextfontpage.cpp:292
+msgid "Check to show the text in small capitals."
+msgstr "Prebar a amostrar o texto en mayusclas chicotas."
+
+#: ../src/richtext/richtextfontpage.cpp:295
+msgid "Supe&rscript"
+msgstr "Supe&rindiz"
+
+#: ../src/richtext/richtextfontpage.cpp:297
+#: ../src/richtext/richtextfontpage.cpp:299
+msgid "Check to show the text in superscript."
+msgstr "Prebar a amostrar o texto en superindiz."
+
+#: ../src/richtext/richtextfontpage.cpp:302
+msgid "Subscrip&t"
+msgstr "S&ubindiz"
+
+#: ../src/richtext/richtextfontpage.cpp:304
+#: ../src/richtext/richtextfontpage.cpp:306
+msgid "Check to show the text in subscript."
+msgstr "Prebar a amostrar o texto en subindiz."
+
+#: ../src/richtext/richtextfontpage.cpp:312
+msgid "Rig&ht-to-left"
+msgstr "De dreita ta cuc&ha"
+
+#: ../src/richtext/richtextfontpage.cpp:314
+#: ../src/richtext/richtextfontpage.cpp:316
+msgid "Check to indicate right-to-left text layout."
+msgstr "Mirar d'indicar a distribución d'o texto de dreita ta cucha."
+
+#: ../src/richtext/richtextfontpage.cpp:319
+msgid "Suppress hyphe&nation"
+msgstr "Eliminar as deseparacions de guio&ns"
+
+#: ../src/richtext/richtextfontpage.cpp:321
+#: ../src/richtext/richtextfontpage.cpp:323
+msgid "Check to suppress hyphenation."
+msgstr "Mirar d'eliminar as deseparacions de guions."
+
+#: ../src/richtext/richtextfontpage.cpp:329
+#: ../src/richtext/richtextfontpage.cpp:331
+msgid "Shows a preview of the font settings."
+msgstr "Amuestra una anvista previa d'as opcions d'a fuent."
+
+#: ../src/richtext/richtextfontpage.cpp:348
+#: ../src/richtext/richtextfontpage.cpp:352
+#: ../src/richtext/richtextfontpage.cpp:356
+#: ../src/richtext/richtextformatdlg.cpp:873
+#: ../src/richtext/richtextindentspage.cpp:273
+#: ../src/richtext/richtextindentspage.cpp:285
+#: ../src/richtext/richtextindentspage.cpp:286
+#: ../src/richtext/richtextindentspage.cpp:310
+#: ../src/richtext/richtextindentspage.cpp:325
+#: ../src/richtext/richtextliststylepage.cpp:451
+#: ../src/richtext/richtextliststylepage.cpp:463
+#: ../src/richtext/richtextliststylepage.cpp:464
+msgid "(none)"
+msgstr "(garra)"
+
+#: ../src/richtext/richtextfontpage.cpp:349
+#: ../src/richtext/richtextfontpage.cpp:353
+msgid "Regular"
+msgstr "Normal"
+
+#: ../src/richtext/richtextfontpage.cpp:357
+msgid "Not underlined"
+msgstr "No subrayau"
+
+#: ../src/richtext/richtextformatdlg.cpp:341
+msgid "Indents && Spacing"
+msgstr "Espaciau && Escalonaus"
+
+#: ../src/richtext/richtextformatdlg.cpp:346
+msgid "Tabs"
+msgstr "Tabulacions"
+
+#: ../src/richtext/richtextformatdlg.cpp:351
+msgid "Bullets"
+msgstr "Vinyetas"
+
+#: ../src/richtext/richtextformatdlg.cpp:356
+msgid "List Style"
+msgstr "Estilo de Lista"
+
+#: ../src/richtext/richtextformatdlg.cpp:366
+#: ../src/richtext/richtextmarginspage.cpp:170
+msgid "Margins"
+msgstr "Marguins"
+
+#: ../src/richtext/richtextformatdlg.cpp:371
+msgid "Borders"
+msgstr "Cantos"
+
+#: ../src/richtext/richtextformatdlg.cpp:765
+msgid "Colour"
+msgstr "Color"
+
+#: ../src/richtext/richtextindentspage.cpp:127
+#: ../src/richtext/richtextliststylepage.cpp:322
+msgid "&Alignment"
+msgstr "&Aliniación"
+
+#: ../src/richtext/richtextindentspage.cpp:138
+#: ../src/richtext/richtextliststylepage.cpp:331
+msgid "&Left"
+msgstr "&Cucha"
+
+#: ../src/richtext/richtextindentspage.cpp:140
+#: ../src/richtext/richtextindentspage.cpp:142
+#: ../src/richtext/richtextliststylepage.cpp:333
+#: ../src/richtext/richtextliststylepage.cpp:335
+msgid "Left-align text."
+msgstr "Texto aliniau a la cucha."
+
+#: ../src/richtext/richtextindentspage.cpp:145
+#: ../src/richtext/richtextliststylepage.cpp:338
+msgid "&Right"
+msgstr "&Dreita"
+
+#: ../src/richtext/richtextindentspage.cpp:147
+#: ../src/richtext/richtextindentspage.cpp:149
+#: ../src/richtext/richtextliststylepage.cpp:340
+#: ../src/richtext/richtextliststylepage.cpp:342
+msgid "Right-align text."
+msgstr "Texto aliniau a la dreita."
+
+#: ../src/richtext/richtextindentspage.cpp:152
+#: ../src/richtext/richtextliststylepage.cpp:345
+msgid "&Justified"
+msgstr "&Chustificau"
+
+#: ../src/richtext/richtextindentspage.cpp:154
+#: ../src/richtext/richtextindentspage.cpp:156
+#: ../src/richtext/richtextliststylepage.cpp:347
+#: ../src/richtext/richtextliststylepage.cpp:349
+msgid "Justify text left and right."
+msgstr "Chustificar o texto a cucha y dreita."
+
+#: ../src/richtext/richtextindentspage.cpp:159
+#: ../src/richtext/richtextliststylepage.cpp:352
+msgid "Cen&tred"
+msgstr "Cen&trau"
+
+#: ../src/richtext/richtextindentspage.cpp:161
+#: ../src/richtext/richtextindentspage.cpp:163
+#: ../src/richtext/richtextliststylepage.cpp:354
+#: ../src/richtext/richtextliststylepage.cpp:356
+msgid "Centre text."
+msgstr "Texto centrau."
+
+#: ../src/richtext/richtextindentspage.cpp:166
+#: ../src/richtext/richtextliststylepage.cpp:359
+msgid "&Indeterminate"
+msgstr "&Indeterminau"
+
+#: ../src/richtext/richtextindentspage.cpp:168
+#: ../src/richtext/richtextindentspage.cpp:170
+#: ../src/richtext/richtextliststylepage.cpp:361
+#: ../src/richtext/richtextliststylepage.cpp:363
+msgid "Use the current alignment setting."
+msgstr "Fer servir l'aliniau actual."
+
+#: ../src/richtext/richtextindentspage.cpp:183
+#: ../src/richtext/richtextliststylepage.cpp:375
+msgid "&Indentation (tenths of a mm)"
+msgstr "&Escalonau (decenas de mm)"
+
+#: ../src/richtext/richtextindentspage.cpp:198
+#: ../src/richtext/richtextindentspage.cpp:200
+#: ../src/richtext/richtextliststylepage.cpp:388
+#: ../src/richtext/richtextliststylepage.cpp:390
+msgid "The left indent."
+msgstr "O escalonau cucho."
+
+#: ../src/richtext/richtextindentspage.cpp:203
+#: ../src/richtext/richtextliststylepage.cpp:393
+msgid "Left (&first line):"
+msgstr "Cucha (&primera linia):"
+
+#: ../src/richtext/richtextindentspage.cpp:207
+#: ../src/richtext/richtextindentspage.cpp:209
+#: ../src/richtext/richtextliststylepage.cpp:397
+#: ../src/richtext/richtextliststylepage.cpp:399
+msgid "The first line indent."
+msgstr "O escalonau d'a primera linia."
+
+#: ../src/richtext/richtextindentspage.cpp:216
+#: ../src/richtext/richtextindentspage.cpp:218
+#: ../src/richtext/richtextliststylepage.cpp:406
+#: ../src/richtext/richtextliststylepage.cpp:408
+msgid "The right indent."
+msgstr "O escalonau dreito."
+
+#: ../src/richtext/richtextindentspage.cpp:221
+msgid "&Outline level:"
+msgstr "Libel d'&esquema:"
+
+#: ../src/richtext/richtextindentspage.cpp:226
+#: ../src/richtext/richtextindentspage.cpp:228
+msgid "The outline level."
+msgstr "O libel d'esquema."
+
+#: ../src/richtext/richtextindentspage.cpp:241
+#: ../src/richtext/richtextliststylepage.cpp:420
+msgid "&Spacing (tenths of a mm)"
+msgstr "&Espaciau (decenas de mm)"
+
+#: ../src/richtext/richtextindentspage.cpp:252
+msgid "&Before a paragraph:"
+msgstr "&Antis d'un paragrafo:"
+
+#: ../src/richtext/richtextindentspage.cpp:256
+#: ../src/richtext/richtextindentspage.cpp:258
+#: ../src/richtext/richtextliststylepage.cpp:433
+#: ../src/richtext/richtextliststylepage.cpp:435
+msgid "The spacing before the paragraph."
+msgstr "O espaciau antis de paragrafo."
+
+#: ../src/richtext/richtextindentspage.cpp:261
+msgid "&After a paragraph:"
+msgstr "&Dimpués d'un paragrafo:"
+
+#: ../src/richtext/richtextindentspage.cpp:266
+#: ../src/richtext/richtextliststylepage.cpp:442
+#: ../src/richtext/richtextliststylepage.cpp:444
+msgid "The spacing after the paragraph."
+msgstr "O espaciau dimpués d'o paragrafo."
+
+#: ../src/richtext/richtextindentspage.cpp:269
+msgid "L&ine spacing:"
+msgstr "Espaciau de l&inia:"
+
+#: ../src/richtext/richtextindentspage.cpp:274
+#: ../src/richtext/richtextliststylepage.cpp:452
+msgid "Single"
+msgstr "Sencillo"
+
+#: ../src/richtext/richtextindentspage.cpp:275
+#: ../src/richtext/richtextliststylepage.cpp:453
+msgid "1.1"
+msgstr "1.1"
+
+#: ../src/richtext/richtextindentspage.cpp:276
+#: ../src/richtext/richtextliststylepage.cpp:454
+msgid "1.2"
+msgstr "1.2"
+
+#: ../src/richtext/richtextindentspage.cpp:277
+#: ../src/richtext/richtextliststylepage.cpp:455
+msgid "1.3"
+msgstr "1.3"
+
+#: ../src/richtext/richtextindentspage.cpp:278
+#: ../src/richtext/richtextliststylepage.cpp:456
+msgid "1.4"
+msgstr "1.4"
+
+#: ../src/richtext/richtextindentspage.cpp:279
+#: ../src/richtext/richtextliststylepage.cpp:457
+msgid "1.5"
+msgstr "1.5"
+
+#: ../src/richtext/richtextindentspage.cpp:280
+#: ../src/richtext/richtextliststylepage.cpp:458
+msgid "1.6"
+msgstr "1.6"
+
+#: ../src/richtext/richtextindentspage.cpp:281
+#: ../src/richtext/richtextliststylepage.cpp:459
+msgid "1.7"
+msgstr "1.7"
+
+#: ../src/richtext/richtextindentspage.cpp:282
+#: ../src/richtext/richtextliststylepage.cpp:460
+msgid "1.8"
+msgstr "1.8"
+
+#: ../src/richtext/richtextindentspage.cpp:283
+#: ../src/richtext/richtextliststylepage.cpp:461
+msgid "1.9"
+msgstr "1.9"
+
+#: ../src/richtext/richtextindentspage.cpp:284
+#: ../src/richtext/richtextliststylepage.cpp:462
+msgid "2"
+msgstr "2"
+
+#: ../src/richtext/richtextindentspage.cpp:287
+#: ../src/richtext/richtextindentspage.cpp:289
+#: ../src/richtext/richtextliststylepage.cpp:465
+#: ../src/richtext/richtextliststylepage.cpp:467
+msgid "The line spacing."
+msgstr "O espaciau de linia."
+
+#: ../src/richtext/richtextindentspage.cpp:292
+msgid "&Page Break"
+msgstr "Blinco de &pachina"
+
+#: ../src/richtext/richtextindentspage.cpp:294
+#: ../src/richtext/richtextindentspage.cpp:296
+msgid "Inserts a page break before the paragraph."
+msgstr "Ficar un blinco de pachina antis d'o paragrafo."
+
+#: ../src/richtext/richtextindentspage.cpp:302
+#: ../src/richtext/richtextindentspage.cpp:304
+msgid "Shows a preview of the paragraph settings."
+msgstr "Amuestra una anvista previa d'as opcions de paragrafo."
+
+#: ../src/richtext/richtextliststylepage.cpp:182
+msgid "&List level:"
+msgstr "Libel de &Lista:"
+
+#: ../src/richtext/richtextliststylepage.cpp:186
+#: ../src/richtext/richtextliststylepage.cpp:188
+msgid "Selects the list level to edit."
+msgstr "Selecciona o libel de lista que editar."
+
+#: ../src/richtext/richtextliststylepage.cpp:193
+msgid "&Font for Level..."
+msgstr "&Fuent ta o libel..."
+
+#: ../src/richtext/richtextliststylepage.cpp:194
+#: ../src/richtext/richtextliststylepage.cpp:196
+msgid "Click to choose the font for this level."
+msgstr "Fe clic ta trigar a fuent ta iste libel."
+
+#: ../src/richtext/richtextliststylepage.cpp:312
+msgid "Bullet style"
+msgstr "Estilo de vinyeta"
+
+#: ../src/richtext/richtextliststylepage.cpp:429
+msgid "Before a paragraph:"
+msgstr "Antis d'un paragrafo:"
+
+#: ../src/richtext/richtextliststylepage.cpp:438
+msgid "After a paragraph:"
+msgstr "Dimpués d'un paragrafo:"
+
+#: ../src/richtext/richtextliststylepage.cpp:447
+msgid "Line spacing:"
+msgstr "Espaciau de linia:"
+
+#: ../src/richtext/richtextliststylepage.cpp:470
+msgid "Spacing"
+msgstr "Espaciau"
+
+#: ../src/richtext/richtextmarginspage.cpp:193
+#: ../src/richtext/richtextmarginspage.cpp:195
+msgid "The left margin size."
+msgstr "A grandaria d'a marguin cucha."
+
+#: ../src/richtext/richtextmarginspage.cpp:203
+#: ../src/richtext/richtextmarginspage.cpp:205
+msgid "Units for the left margin."
+msgstr "Unidatz ta la marguin cucha."
+
+#: ../src/richtext/richtextmarginspage.cpp:218
+#: ../src/richtext/richtextmarginspage.cpp:220
+msgid "The right margin size."
+msgstr "A grandaria d'a marguin dreita."
+
+#: ../src/richtext/richtextmarginspage.cpp:228
+#: ../src/richtext/richtextmarginspage.cpp:230
+msgid "Units for the right margin."
+msgstr "Unidatz ta la marguin dreita."
+
+#: ../src/richtext/richtextmarginspage.cpp:241
+#: ../src/richtext/richtextmarginspage.cpp:243
+msgid "The top margin size."
+msgstr "A grandaria d'a marguin superior."
+
+#: ../src/richtext/richtextmarginspage.cpp:251
+#: ../src/richtext/richtextmarginspage.cpp:253
+msgid "Units for the top margin."
+msgstr "Unidatz ta la marguin superior."
+
+#: ../src/richtext/richtextmarginspage.cpp:266
+#: ../src/richtext/richtextmarginspage.cpp:268
+msgid "The bottom margin size."
+msgstr "A grandaria d'a marguin inferior."
+
+#: ../src/richtext/richtextmarginspage.cpp:276
+#: ../src/richtext/richtextmarginspage.cpp:278
+msgid "Units for the bottom margin."
+msgstr "Unidatz ta la marguin inferior."
+
+#: ../src/richtext/richtextmarginspage.cpp:284
+msgid "Padding"
+msgstr "Repleno"
+
+#: ../src/richtext/richtextmarginspage.cpp:307
+#: ../src/richtext/richtextmarginspage.cpp:309
+msgid "The left padding size."
+msgstr "A grandaria d'o repleno cucho."
+
+#: ../src/richtext/richtextmarginspage.cpp:317
+#: ../src/richtext/richtextmarginspage.cpp:319
+msgid "Units for the left padding."
+msgstr "Unidatz ta lo repleno cucho."
+
+#: ../src/richtext/richtextmarginspage.cpp:332
+#: ../src/richtext/richtextmarginspage.cpp:334
+msgid "The right padding size."
+msgstr "A grandaria d'o repleno dreito."
+
+#: ../src/richtext/richtextmarginspage.cpp:342
+#: ../src/richtext/richtextmarginspage.cpp:344
+msgid "Units for the right padding."
+msgstr "Unidatz ta lo repleno dreito."
+
+#: ../src/richtext/richtextmarginspage.cpp:355
+#: ../src/richtext/richtextmarginspage.cpp:357
+msgid "The top padding size."
+msgstr "A grandaria d'o repleno superior."
+
+#: ../src/richtext/richtextmarginspage.cpp:365
+#: ../src/richtext/richtextmarginspage.cpp:367
+msgid "Units for the top padding."
+msgstr "Unidatz ta lo repleno superior."
+
+#: ../src/richtext/richtextmarginspage.cpp:380
+#: ../src/richtext/richtextmarginspage.cpp:382
+msgid "The bottom padding size."
+msgstr "A grandaria d'o repleno inferior."
+
+#: ../src/richtext/richtextmarginspage.cpp:390
+#: ../src/richtext/richtextmarginspage.cpp:392
+msgid "Units for the bottom padding."
+msgstr "Unidatz ta lo repleno inferior."
+
+#: ../src/richtext/richtextprint.cpp:592
+msgid " Preview"
+msgstr " Anvista previa"
+
+#: ../src/richtext/richtextsizepage.cpp:228
+msgid "Floating"
+msgstr "Flotant"
+
+#: ../src/richtext/richtextsizepage.cpp:243
+msgid "&Floating mode:"
+msgstr "Modo &flotant:"
+
+#: ../src/richtext/richtextsizepage.cpp:252
+#: ../src/richtext/richtextsizepage.cpp:254
+msgid "How the object will float relative to the text."
+msgstr "Como flotará l'obchecto en relación a lo texto."
+
+#: ../src/richtext/richtextsizepage.cpp:265
+msgid "Alignment"
+msgstr "Aliniación"
+
+#: ../src/richtext/richtextsizepage.cpp:277
+msgid "&Vertical alignment:"
+msgstr "Aliniación &vertical:"
+
+#: ../src/richtext/richtextsizepage.cpp:279
+#: ../src/richtext/richtextsizepage.cpp:281
+msgid "Enable vertical alignment."
+msgstr "Activar l'aliniación vertical."
+
+#: ../src/richtext/richtextsizepage.cpp:286
+msgid "Centred"
+msgstr "Centrau"
+
+#: ../src/richtext/richtextsizepage.cpp:290
+#: ../src/richtext/richtextsizepage.cpp:292
+msgid "Vertical alignment."
+msgstr "Aliniación vertical."
+
+#: ../src/richtext/richtextsizepage.cpp:316
+#: ../src/richtext/richtextsizepage.cpp:323
+msgid "&Width:"
+msgstr "&Amplaria:"
+
+#: ../src/richtext/richtextsizepage.cpp:318
+#: ../src/richtext/richtextsizepage.cpp:320
+msgid "Enable the width value."
+msgstr "Activar a valor de l'amplaria."
+
+#: ../src/richtext/richtextsizepage.cpp:331
+#: ../src/richtext/richtextsizepage.cpp:333
+msgid "The object width."
+msgstr "L'amplaria de l'obchecto."
+
+#: ../src/richtext/richtextsizepage.cpp:342
+#: ../src/richtext/richtextsizepage.cpp:344
+msgid "Units for the object width."
+msgstr "Unidatz ta l'amplaria de l'obchecto."
+
+#: ../src/richtext/richtextsizepage.cpp:350
+#: ../src/richtext/richtextsizepage.cpp:357
+msgid "&Height:"
+msgstr "&Altura:"
+
+#: ../src/richtext/richtextsizepage.cpp:352
+#: ../src/richtext/richtextsizepage.cpp:354
+#: ../src/richtext/richtextsizepage.cpp:464
+#: ../src/richtext/richtextsizepage.cpp:466
+msgid "Enable the height value."
+msgstr "Activar a valor de l'altura."
+
+#: ../src/richtext/richtextsizepage.cpp:365
+#: ../src/richtext/richtextsizepage.cpp:367
+msgid "The object height."
+msgstr "L'altura de l'obchecto."
+
+#: ../src/richtext/richtextsizepage.cpp:376
+#: ../src/richtext/richtextsizepage.cpp:378
+msgid "Units for the object height."
+msgstr "Unidatz ta l'altura de l'obchecto."
+
+#: ../src/richtext/richtextsizepage.cpp:381
+msgid "Min width:"
+msgstr "Amplaria minima:"
+
+#: ../src/richtext/richtextsizepage.cpp:383
+#: ../src/richtext/richtextsizepage.cpp:385
+msgid "Enable the minimum width value."
+msgstr "Activar a valor minima de l'amplaria."
+
+#: ../src/richtext/richtextsizepage.cpp:392
+#: ../src/richtext/richtextsizepage.cpp:394
+msgid "The object minimum width."
+msgstr "L'amplaria minima de l'obchecto."
+
+#: ../src/richtext/richtextsizepage.cpp:403
+#: ../src/richtext/richtextsizepage.cpp:405
+msgid "Units for the minimum object width."
+msgstr "Unidatz ta l'amplaria minima de l'obchecto."
+
+#: ../src/richtext/richtextsizepage.cpp:408
+msgid "Min height:"
+msgstr "Altura minima:"
+
+#: ../src/richtext/richtextsizepage.cpp:410
+#: ../src/richtext/richtextsizepage.cpp:412
+msgid "Enable the minimum height value."
+msgstr "Activar a valor minima de l'altura."
+
+#: ../src/richtext/richtextsizepage.cpp:419
+#: ../src/richtext/richtextsizepage.cpp:421
+msgid "The object minimum height."
+msgstr "L'altura minima de l'obchecto."
+
+#: ../src/richtext/richtextsizepage.cpp:430
+#: ../src/richtext/richtextsizepage.cpp:432
+msgid "Units for the minimum object height."
+msgstr "Unidatz ta l'altura minima de l'obchecto."
+
+#: ../src/richtext/richtextsizepage.cpp:435
+msgid "Max width:"
+msgstr "Amplaria maxima:"
+
+#: ../src/richtext/richtextsizepage.cpp:437
+#: ../src/richtext/richtextsizepage.cpp:439
+msgid "Enable the maximum width value."
+msgstr "Activar a valor maxima de l'amplaria."
+
+#: ../src/richtext/richtextsizepage.cpp:446
+#: ../src/richtext/richtextsizepage.cpp:448
+msgid "The object maximum width."
+msgstr "L'amplaria maxima de l'obchecto."
+
+#: ../src/richtext/richtextsizepage.cpp:457
+#: ../src/richtext/richtextsizepage.cpp:459
+msgid "Units for the maximum object width."
+msgstr "Unidatz ta l'amplaria maxima de l'obchecto."
+
+#: ../src/richtext/richtextsizepage.cpp:462
+msgid "Max height:"
+msgstr "Altura maxima:"
+
+#: ../src/richtext/richtextsizepage.cpp:473
+#: ../src/richtext/richtextsizepage.cpp:475
+msgid "The object maximum height."
+msgstr "L'altura maxima de l'obchecto."
+
+#: ../src/richtext/richtextsizepage.cpp:484
+#: ../src/richtext/richtextsizepage.cpp:486
+msgid "Units for the maximum object height."
+msgstr "Unidatz ta l'altura maxima de l'obchecto."
+
+#: ../src/richtext/richtextsizepage.cpp:495
+msgid "Position"
+msgstr "Posición"
+
+#: ../src/richtext/richtextsizepage.cpp:513
+msgid "&Position mode:"
+msgstr "Modo de &posición:"
+
+#: ../src/richtext/richtextsizepage.cpp:517
+#: ../src/richtext/richtextsizepage.cpp:522
+msgid "Static"
+msgstr "Estatico"
+
+#: ../src/richtext/richtextsizepage.cpp:518
+msgid "Relative"
+msgstr "Relativo"
+
+#: ../src/richtext/richtextsizepage.cpp:519
+msgid "Absolute"
+msgstr "Absoluto"
+
+#: ../src/richtext/richtextsizepage.cpp:520
+msgid "Fixed"
+msgstr "Fixa"
+
+#: ../src/richtext/richtextsizepage.cpp:533
+#: ../src/richtext/richtextsizepage.cpp:535
+#: ../src/richtext/richtextsizepage.cpp:547
+#: ../src/richtext/richtextsizepage.cpp:549
+msgid "The left position."
+msgstr "A posición cucha."
+
+#: ../src/richtext/richtextsizepage.cpp:558
+#: ../src/richtext/richtextsizepage.cpp:560
+msgid "Units for the left position."
+msgstr "Unidatz ta la posición cucha."
+
+#: ../src/richtext/richtextsizepage.cpp:568
+#: ../src/richtext/richtextsizepage.cpp:570
+#: ../src/richtext/richtextsizepage.cpp:582
+#: ../src/richtext/richtextsizepage.cpp:584
+msgid "The top position."
+msgstr "A posición superior."
+
+#: ../src/richtext/richtextsizepage.cpp:593
+#: ../src/richtext/richtextsizepage.cpp:595
+msgid "Units for the top position."
+msgstr "Unidatz ta la posición superior."
+
+#: ../src/richtext/richtextsizepage.cpp:603
+#: ../src/richtext/richtextsizepage.cpp:605
+#: ../src/richtext/richtextsizepage.cpp:617
+#: ../src/richtext/richtextsizepage.cpp:619
+msgid "The right position."
+msgstr "A posición dreita."
+
+#: ../src/richtext/richtextsizepage.cpp:628
+#: ../src/richtext/richtextsizepage.cpp:630
+msgid "Units for the right position."
+msgstr "Unidatz ta la posición dreita."
+
+#: ../src/richtext/richtextsizepage.cpp:638
+#: ../src/richtext/richtextsizepage.cpp:640
+#: ../src/richtext/richtextsizepage.cpp:652
+#: ../src/richtext/richtextsizepage.cpp:654
+msgid "The bottom position."
+msgstr "A posición inferior."
+
+#: ../src/richtext/richtextsizepage.cpp:663
+#: ../src/richtext/richtextsizepage.cpp:665
+msgid "Units for the bottom position."
+msgstr "Unidatz ta laposición inferior."
+
+#: ../src/richtext/richtextsizepage.cpp:671
+msgid "&Move the object to:"
+msgstr "&Mover l'obecto ta:"
+
+#: ../src/richtext/richtextsizepage.cpp:674
+msgid "&Previous Paragraph"
+msgstr "Anterior &paragrafo"
+
+#: ../src/richtext/richtextsizepage.cpp:675
+#: ../src/richtext/richtextsizepage.cpp:677
+msgid "Moves the object to the previous paragraph."
+msgstr "Mueve l'obchecto ta l'anterior paragrafo."
+
+#: ../src/richtext/richtextsizepage.cpp:680
+msgid "&Next Paragraph"
+msgstr "&Siguient paragrafo"
+
+#: ../src/richtext/richtextsizepage.cpp:681
+#: ../src/richtext/richtextsizepage.cpp:683
+msgid "Moves the object to the next paragraph."
+msgstr "Mueve l'obchecto ta lo siguient paragrafo."
+
+#: ../src/richtext/richtextstyledlg.cpp:193
+msgid "&Styles:"
+msgstr "E&stilos:"
+
+#: ../src/richtext/richtextstyledlg.cpp:197
+#: ../src/richtext/richtextstyledlg.cpp:199
+msgid "The available styles."
+msgstr "Os estilos disponibles."
+
+#: ../src/richtext/richtextstyledlg.cpp:205
+#: ../src/richtext/richtextstyledlg.cpp:217
+msgid " "
+msgstr " "
+
+#: ../src/richtext/richtextstyledlg.cpp:209
+#: ../src/richtext/richtextstyledlg.cpp:211
+msgid "The style preview."
+msgstr "L'anvista previa d'o estilo."
+
+#: ../src/richtext/richtextstyledlg.cpp:220
+msgid "New &Character Style..."
+msgstr "Nuevo Estilo de &Caracter..."
+
+#: ../src/richtext/richtextstyledlg.cpp:221
+#: ../src/richtext/richtextstyledlg.cpp:223
+msgid "Click to create a new character style."
+msgstr "Fe click ta creyar un nuevo estilo de caracter."
+
+#: ../src/richtext/richtextstyledlg.cpp:226
+msgid "New &Paragraph Style..."
+msgstr "Nuevo Estilo de &Paragrafo..."
+
+#: ../src/richtext/richtextstyledlg.cpp:227
+#: ../src/richtext/richtextstyledlg.cpp:229
+msgid "Click to create a new paragraph style."
+msgstr "Fe click ta creyar un nuevo estilo de paragrafo."
+
+#: ../src/richtext/richtextstyledlg.cpp:232
+msgid "New &List Style..."
+msgstr "Nuevo Estilo de &Lista..."
+
+#: ../src/richtext/richtextstyledlg.cpp:233
+#: ../src/richtext/richtextstyledlg.cpp:235
+msgid "Click to create a new list style."
+msgstr "Fe clic ta creyar una nueva lista d'estilo."
+
+#: ../src/richtext/richtextstyledlg.cpp:238
+msgid "New &Box Style..."
+msgstr "Nuevo estilo de &caixa..."
+
+#: ../src/richtext/richtextstyledlg.cpp:239
+#: ../src/richtext/richtextstyledlg.cpp:241
+msgid "Click to create a new box style."
+msgstr "Fe clic ta creyar un nuevo estilo de caixa."
+
+#: ../src/richtext/richtextstyledlg.cpp:246
+msgid "&Apply Style"
+msgstr "&Aplicar Estilo"
+
+#: ../src/richtext/richtextstyledlg.cpp:247
+#: ../src/richtext/richtextstyledlg.cpp:249
+msgid "Click to apply the selected style."
+msgstr "Fe clic ta aplicar o estilo seleccionau."
+
+#: ../src/richtext/richtextstyledlg.cpp:252
+msgid "&Rename Style..."
+msgstr "&Renombrar o Estilo..."
+
+#: ../src/richtext/richtextstyledlg.cpp:253
+#: ../src/richtext/richtextstyledlg.cpp:255
+msgid "Click to rename the selected style."
+msgstr "Fe clic ta renombrar o estilo seleccionau."
+
+#: ../src/richtext/richtextstyledlg.cpp:258
+msgid "&Edit Style..."
+msgstr "&Editar o Estilo..."
+
+#: ../src/richtext/richtextstyledlg.cpp:259
+#: ../src/richtext/richtextstyledlg.cpp:261
+msgid "Click to edit the selected style."
+msgstr "Fe clic ta editar o estilo seleccionau."
+
+#: ../src/richtext/richtextstyledlg.cpp:264
+msgid "&Delete Style..."
+msgstr "&Eliminar o estilo..."
+
+#: ../src/richtext/richtextstyledlg.cpp:265
+#: ../src/richtext/richtextstyledlg.cpp:267
+msgid "Click to delete the selected style."
+msgstr "Fe clic ta esborrar o estilo seleccionau."
+
+#: ../src/richtext/richtextstyledlg.cpp:274
+#: ../src/richtext/richtextstyledlg.cpp:276
+msgid "Click to close this window."
+msgstr "Fe clic ta zarrar ista finestra."
+
+#: ../src/richtext/richtextstyledlg.cpp:282
+msgid "&Restart numbering"
+msgstr "&Rempecipiar a numeración"
+
+#: ../src/richtext/richtextstyledlg.cpp:284
+#: ../src/richtext/richtextstyledlg.cpp:286
+msgid "Check to restart numbering."
+msgstr "Marcar ta reiniciar a numeración."
+
+#: ../src/richtext/richtextstyledlg.cpp:601
+msgid "Enter a character style name"
+msgstr "Introduz un nombre d'estilo de caracter"
+
+#: ../src/richtext/richtextstyledlg.cpp:601
+#: ../src/richtext/richtextstyledlg.cpp:606
+#: ../src/richtext/richtextstyledlg.cpp:649
+#: ../src/richtext/richtextstyledlg.cpp:654
+#: ../src/richtext/richtextstyledlg.cpp:815
+#: ../src/richtext/richtextstyledlg.cpp:820
+#: ../src/richtext/richtextstyledlg.cpp:888
+#: ../src/richtext/richtextstyledlg.cpp:896
+#: ../src/richtext/richtextstyledlg.cpp:929
+#: ../src/richtext/richtextstyledlg.cpp:934
+msgid "New Style"
+msgstr "Nuevo Estilo"
+
+#: ../src/richtext/richtextstyledlg.cpp:606
+#: ../src/richtext/richtextstyledlg.cpp:654
+#: ../src/richtext/richtextstyledlg.cpp:820
+#: ../src/richtext/richtextstyledlg.cpp:896
+#: ../src/richtext/richtextstyledlg.cpp:934
+msgid "Sorry, that name is taken. Please choose another."
+msgstr "Ixe nombre ya ye en uso. Por favor, en triga unatro."
+
+#: ../src/richtext/richtextstyledlg.cpp:649
+msgid "Enter a paragraph style name"
+msgstr "Introduz un nombre d'estilo de paragrafo"
+
+#: ../src/richtext/richtextstyledlg.cpp:777
+#, c-format
+msgid "Delete style %s?"
+msgstr "Eliminar o estilo %s?"
+
+#: ../src/richtext/richtextstyledlg.cpp:777
+msgid "Delete Style"
+msgstr "Eliminar o Estilo"
+
+#: ../src/richtext/richtextstyledlg.cpp:815
+msgid "Enter a list style name"
+msgstr "Introduz un nombre d'estilo de lista"
+
+#: ../src/richtext/richtextstyledlg.cpp:888
+msgid "Enter a new style name"
+msgstr "Introduz un nuevo nombre d'estilo"
+
+#: ../src/richtext/richtextstyledlg.cpp:929
+msgid "Enter a box style name"
+msgstr "Introduz un nombre d'estilo de caixa"
+
+#: ../src/richtext/richtextstylepage.cpp:109
+#: ../src/richtext/richtextstylepage.cpp:111
+msgid "The style name."
+msgstr "O nombre d'o estilo."
+
+#: ../src/richtext/richtextstylepage.cpp:114
+msgid "&Based on:"
+msgstr "&Basau en:"
+
+#: ../src/richtext/richtextstylepage.cpp:119
+#: ../src/richtext/richtextstylepage.cpp:121
+msgid "The style on which this style is based."
+msgstr "O estilo en que se basa iste estilo."
+
+#: ../src/richtext/richtextstylepage.cpp:124
+msgid "&Next style:"
+msgstr "&Siguient estilo:"
+
+#: ../src/richtext/richtextstylepage.cpp:129
+#: ../src/richtext/richtextstylepage.cpp:131
+msgid "The default style for the next paragraph."
+msgstr "O estilo predeterminau ta lo siguient paragrafo."
+
+#: ../src/richtext/richtextstyles.cpp:1057
+msgid "All styles"
+msgstr "Totz os estilos"
+
+#: ../src/richtext/richtextstyles.cpp:1058
+msgid "Paragraph styles"
+msgstr "Estilos de paragrafo"
+
+#: ../src/richtext/richtextstyles.cpp:1059
+msgid "Character styles"
+msgstr "Estilos de caracter"
+
+#: ../src/richtext/richtextstyles.cpp:1060
+msgid "List styles"
+msgstr "Estilos de lista"
+
+#: ../src/richtext/richtextstyles.cpp:1061
+msgid "Box styles"
+msgstr "Estilos de caixa"
+
+#: ../src/richtext/richtextsymboldlg.cpp:389
+#: ../src/richtext/richtextsymboldlg.cpp:391
+msgid "The font from which to take the symbol."
+msgstr "A fuent d'a que prener o simbolo."
+
+#: ../src/richtext/richtextsymboldlg.cpp:396
+msgid "&Subset:"
+msgstr "&Subconchunto:"
+
+#: ../src/richtext/richtextsymboldlg.cpp:401
+#: ../src/richtext/richtextsymboldlg.cpp:403
+msgid "Shows a Unicode subset."
+msgstr "Amuestra un subchuego Unicode."
+
+#: ../src/richtext/richtextsymboldlg.cpp:412
+msgid "xxxx"
+msgstr "xxxx"
+
+#: ../src/richtext/richtextsymboldlg.cpp:417
+msgid "&Character code:"
+msgstr "&Codigo de caracter:"
+
+#: ../src/richtext/richtextsymboldlg.cpp:421
+#: ../src/richtext/richtextsymboldlg.cpp:423
+msgid "The character code."
+msgstr "O codigo de caracter."
+
+#: ../src/richtext/richtextsymboldlg.cpp:428
+msgid "&From:"
+msgstr "&Dende:"
+
+#: ../src/richtext/richtextsymboldlg.cpp:433
+#: ../src/richtext/richtextsymboldlg.cpp:434
+#: ../src/richtext/richtextsymboldlg.cpp:435
+msgid "Unicode"
+msgstr "Unicode"
+
+#: ../src/richtext/richtextsymboldlg.cpp:436
+#: ../src/richtext/richtextsymboldlg.cpp:438
+msgid "The range to show."
+msgstr "O rango que amostrar."
+
+#: ../src/richtext/richtextsymboldlg.cpp:444
+msgid "Insert"
+msgstr "Ficar"
+
+#: ../src/richtext/richtextsymboldlg.cpp:478
+msgid "(Normal text)"
+msgstr "(Texto normal)"
+
+#: ../src/richtext/richtexttabspage.cpp:109
+msgid "&Position (tenths of a mm):"
+msgstr "&Posición (decenas de mm):"
+
+#: ../src/richtext/richtexttabspage.cpp:113
+#: ../src/richtext/richtexttabspage.cpp:115
+msgid "The tab position."
+msgstr "A posición d'o tabulador."
+
+#: ../src/richtext/richtexttabspage.cpp:119
+msgid "The tab positions."
+msgstr "As posicions d'o tabulador."
+
+#: ../src/richtext/richtexttabspage.cpp:132
+#: ../src/richtext/richtexttabspage.cpp:134
+msgid "Click to create a new tab position."
+msgstr "Fe clic ta creyar una nueva posición de tabulador."
+
+#: ../src/richtext/richtexttabspage.cpp:138
+#: ../src/richtext/richtexttabspage.cpp:140
+msgid "Click to delete the selected tab position."
+msgstr "Fe clic ta esborrar a posición de tabulador seleccionada."
+
+#: ../src/richtext/richtexttabspage.cpp:143
+msgid "Delete A&ll"
+msgstr "Eliminar-lo &Tot"
+
+#: ../src/richtext/richtexttabspage.cpp:144
+#: ../src/richtext/richtexttabspage.cpp:146
+msgid "Click to delete all tab positions."
+msgstr "Fe clic ta esborrar todas as posicions de tabulador."
+
+#: ../src/univ/theme.cpp:110
+msgid "Failed to initialize GUI: no built-in themes found."
+msgstr ""
+"S'ha produciu una error en inicializar a interfaz grafica d'usuario: no "
+"s'han trobau temas integraus."
+
+#: ../src/univ/themes/gtk.cpp:521
+msgid "GTK+ theme"
+msgstr "Tema GTK+"
+
+#: ../src/univ/themes/metal.cpp:164
+msgid "Metal theme"
+msgstr "Tema metal"
+
+#: ../src/univ/themes/mono.cpp:512
+msgid "Simple monochrome theme"
+msgstr "Tema monocromo simple"
+
+#: ../src/univ/themes/win32.cpp:1098
+msgid "Win32 theme"
+msgstr "Tema Win32"
+
+#: ../src/univ/themes/win32.cpp:3743
+msgid "&Restore"
+msgstr "&Restaurar"
+
+#: ../src/univ/themes/win32.cpp:3744
+msgid "&Move"
+msgstr "&Mover"
+
+#: ../src/univ/themes/win32.cpp:3746
+msgid "&Size"
+msgstr "&Grandaria"
+
+#: ../src/univ/themes/win32.cpp:3748
+msgid "Mi&nimize"
+msgstr "Mi&nimizar"
+
+#: ../src/univ/themes/win32.cpp:3750
+msgid "Ma&ximize"
+msgstr "Ma&ximizar"
+
+#: ../src/univ/themes/win32.cpp:3752
+msgid "Alt+"
+msgstr "Alt+"
+
+#: ../src/unix/appunix.cpp:178
+msgid "Failed to install signal handler"
+msgstr "No s'ha puesto instalar o maniador de sinyal"
+
+#: ../src/unix/dialup.cpp:351
+msgid "Already dialling ISP."
+msgstr "Ya se ye gritando a l'ISP."
+
+#: ../src/unix/dlunix.cpp:93
+#, fuzzy
+msgid "Failed to unload shared library"
+msgstr "No s'ha puesto cargar a biblioteca compartida '%s'"
+
+#: ../src/unix/dlunix.cpp:121
+msgid "Unknown dynamic library error"
+msgstr "S'ha produciu una error desconoixida d'a biblioteca dinamica"
+
+#: ../src/unix/epolldispatcher.cpp:84
+msgid "Failed to create epoll descriptor"
+msgstr "S'ha produciu una error en creyar o descriptor epoll"
+
+#: ../src/unix/epolldispatcher.cpp:103
+msgid "Error closing epoll descriptor"
+msgstr "S'ha produciu una error en zarrar o descriptor epoll"
+
+#: ../src/unix/epolldispatcher.cpp:116
+#, c-format
+msgid "Failed to add descriptor %d to epoll descriptor %d"
+msgstr ""
+"S'ha produciu una error en adhibir o descriptor %d a lo descriptor epoll %d"
+
+#: ../src/unix/epolldispatcher.cpp:136
+#, c-format
+msgid "Failed to modify descriptor %d in epoll descriptor %d"
+msgstr "No s'ha puesto modificar o descriptor %d en o descriptor %d"
+
+#: ../src/unix/epolldispatcher.cpp:155
+#, c-format
+msgid "Failed to unregister descriptor %d from epoll descriptor %d"
+msgstr "No s'ha puesto anular o rechistro descriptor%d d'o descriptor epoll%d"
+
+#: ../src/unix/epolldispatcher.cpp:213
+#, c-format
+msgid "Waiting for IO on epoll descriptor %d failed"
+msgstr ""
+"S'ha produciu una error en laspera de dentrada/salida d'o descriptor epool %d"
+
+#: ../src/unix/fswatcher_inotify.cpp:71
+msgid "Unable to create inotify instance"
+msgstr "No s'ha puesto creyar una instancia d'inotify"
+
+#: ../src/unix/fswatcher_inotify.cpp:94
+msgid "Unable to close inotify instance"
+msgstr "No s'ha puesto zarrar a instancia d'inotify"
+
+#: ../src/unix/fswatcher_inotify.cpp:106
+msgid "Unable to add inotify watch"
+msgstr "No s'ha puesto adhibir un observador de inotify"
+
+#: ../src/unix/fswatcher_inotify.cpp:138
+#, fuzzy, c-format
+msgid "Unable to remove inotify watch %i"
+msgstr "No s'ha puesto eliminar un observador inotify"
+
+#: ../src/unix/fswatcher_inotify.cpp:271
+#, c-format
+msgid "Unexpected event for \"%s\": no matching watch descriptor."
+msgstr ""
+"Evento no asperau de \"%s\": no bi ha garra descriptor d'observador que "
+"coincida."
+
+#: ../src/unix/fswatcher_inotify.cpp:320
+#, c-format
+msgid "Invalid inotify event for \"%s\""
+msgstr "Evento inotify invalido ta \"%s\""
+
+#: ../src/unix/fswatcher_inotify.cpp:553
+msgid "Unable to read from inotify descriptor"
+msgstr "No s'ha puesto leyer d'o descriptor inotify"
+
+#: ../src/unix/fswatcher_inotify.cpp:558
+msgid "EOF while reading from inotify descriptor"
+msgstr "Fin de fichero mientras se leyeba dende o descriptor inotify"
+
+#: ../src/unix/fswatcher_kqueue.cpp:114
+msgid "Unable to create kqueue instance"
+msgstr "No s'ha puesto creyar una instancia de kqueue"
+
+#: ../src/unix/fswatcher_kqueue.cpp:131
+msgid "Error closing kqueue instance"
+msgstr "S'ha produciu una error en zarrar a instancia de kqueu"
+
+#: ../src/unix/fswatcher_kqueue.cpp:153
+msgid "Unable to add kqueue watch"
+msgstr "No s'ha puesto adhibir un observador de kqueue"
+
+#: ../src/unix/fswatcher_kqueue.cpp:170
+msgid "Unable to remove kqueue watch"
+msgstr "No s'ha puesto eliminar un observador kqueue"
+
+#: ../src/unix/fswatcher_kqueue.cpp:202
+msgid "Unable to get events from kqueue"
+msgstr "No s'ha puesto obtener eventos de kqueue"
+
+#: ../src/unix/mediactrl.cpp:966
+#, c-format
+msgid "Media playback error: %s"
+msgstr "S'ha produciu una error en a reproducción multimedia: %s"
+
+#: ../src/unix/mediactrl.cpp:1228
+#, c-format
+msgid "Failed to prepare playing \"%s\"."
+msgstr "No s'ha puesto parar a reproducción \"%s\"."
+
+#: ../src/unix/snglinst.cpp:164
+#, c-format
+msgid "Failed to write to lock file '%s'"
+msgstr "No s'ha puesto escribir en blocar o fichero '%s'"
+
+#: ../src/unix/snglinst.cpp:177
+#, c-format
+msgid "Failed to set permissions on lock file '%s'"
+msgstr "No s'ha puesto establir os permisos d'o fichero de bloqueyo '%s'"
+
+#: ../src/unix/snglinst.cpp:194
+#, c-format
+msgid "Failed to lock the lock file '%s'"
+msgstr "No s'ha puesto blocar o fichero de bloqueyo '%s'"
+
+#: ../src/unix/snglinst.cpp:237
+#, c-format
+msgid "Failed to inspect the lock file '%s'"
+msgstr "S'ha produciu una error a l'inspeccionar o fichero de bloqueyo '%s'"
+
+#: ../src/unix/snglinst.cpp:242
+#, c-format
+msgid "Lock file '%s' has incorrect owner."
+msgstr "O fichero de bloqueyo '%s' tién un propietario incorrecto."
+
+#: ../src/unix/snglinst.cpp:247
+#, c-format
+msgid "Lock file '%s' has incorrect permissions."
+msgstr "O fichero de bloqueyo '%s' tién permisos incorrectos."
+
+#: ../src/unix/snglinst.cpp:265
+msgid "Failed to access lock file."
+msgstr "S'ha produciu un fallo en accedir a lo fichero de bloqueyo."
+
+#: ../src/unix/snglinst.cpp:274
+msgid "Failed to read PID from lock file."
+msgstr "No s'ha puesto leyer o PID d'o fichero de bloqueyo."
+
+#: ../src/unix/snglinst.cpp:284
+#, c-format
+msgid "Failed to remove stale lock file '%s'."
+msgstr "No s'ha puesto eliminar l'antigo fichero de bloqueyo '%s'."
+
+#: ../src/unix/snglinst.cpp:297
+#, c-format
+msgid "Deleted stale lock file '%s'."
+msgstr "Fichero antigo de bloqueyo '%s' eliminau."
+
+#: ../src/unix/snglinst.cpp:308
+#, c-format
+msgid "Invalid lock file '%s'."
+msgstr "Fichero de bloqueyo '%s' no valido."
+
+#: ../src/unix/snglinst.cpp:324
+#, c-format
+msgid "Failed to remove lock file '%s'"
+msgstr "No s'ha puesto sacar o fichero de bloqueyo '%s'"
+
+#: ../src/unix/snglinst.cpp:330
+#, c-format
+msgid "Failed to unlock lock file '%s'"
+msgstr "No s'ha puesto desbloquiar o fichero de bloqueyo '%s'"
+
+#: ../src/unix/snglinst.cpp:336
+#, c-format
+msgid "Failed to close lock file '%s'"
+msgstr "No s'ha puesto zarrar o fichero de bloqueyo '%s'"
+
+#: ../src/unix/sound.cpp:77
+msgid "No sound"
+msgstr "No bi ha garra son"
+
+#: ../src/unix/sound.cpp:364
+msgid "Unable to play sound asynchronously."
+msgstr "No s'ha puesto reproducir o son de traza asincrona."
+
+#: ../src/unix/sound.cpp:458
+#, c-format
+msgid "Couldn't load sound data from '%s'."
+msgstr "No s'han puesto cargar os datos de son dende '%s'."
+
+#: ../src/unix/sound.cpp:465
+#, c-format
+msgid "Sound file '%s' is in unsupported format."
+msgstr "O fichero de son '%s' ye en un formato no suportau."
+
+#: ../src/unix/sound.cpp:480
+msgid "Sound data are in unsupported format."
+msgstr "Os datos de son son en un formato no suportau."
+
+#: ../src/unix/sound_sdl.cpp:226
+#, c-format
+msgid "Couldn't open audio: %s"
+msgstr "No s'ha puesto ubrir l'audio: %s"
+
+#: ../src/unix/threadpsx.cpp:1033
+msgid "Cannot retrieve thread scheduling policy."
+msgstr "No se puet recuperar a politica de planificación de filos d'execución."
+
+#: ../src/unix/threadpsx.cpp:1058
+#, c-format
+msgid "Cannot get priority range for scheduling policy %d."
+msgstr ""
+"No se puet obtener un rango de prioridatz ta la politica de planificación %d."
+
+#: ../src/unix/threadpsx.cpp:1066
+msgid "Thread priority setting is ignored."
+msgstr "S'ha ignorau a configuración d'a prioridat d'o filo d'execución."
+
+#: ../src/unix/threadpsx.cpp:1221
+msgid ""
+"Failed to join a thread, potential memory leak detected - please restart the "
+"program"
+msgstr ""
+"No s'ha puesto sincronizar con un filo d'execución, perda potencial de "
+"memoria detectada - por favor reenchega o programa"
+
+#: ../src/unix/threadpsx.cpp:1352
+#, c-format
+msgid "Failed to set thread concurrency level to %lu"
+msgstr "No s'ha puesto establir o libel de concurrencia en %lu"
+
+#: ../src/unix/threadpsx.cpp:1481
+#, c-format
+msgid "Failed to set thread priority %d."
+msgstr "No s'ha puesto establir a prioridat d'o filo d'execución %d."
+
+#: ../src/unix/threadpsx.cpp:1666
+msgid "Failed to terminate a thread."
+msgstr "No s'ha puesto rematar un filo d'execución."
+
+#: ../src/unix/threadpsx.cpp:1893
+msgid "Thread module initialization failed: failed to create thread key"
+msgstr ""
+"S'ha produciu una error en a inicialización d'o modulo de filos d'execución: "
+"error en creyar a clau de filo"
+
+#: ../src/unix/utilsunx.cpp:340
+msgid "Impossible to get child process input"
+msgstr "Ye imposible obtener a dentrada d'o proceso fillo"
+
+#: ../src/unix/utilsunx.cpp:390
+msgid "Can't write to child process's stdin"
+msgstr "No se puet escribir en a dentrada estandar d'o proceso fillo"
+
+#: ../src/unix/utilsunx.cpp:644
+#, c-format
+msgid "Failed to execute '%s'\n"
+msgstr "S'ha produciu una error en executar '%s'\n"
+
+#: ../src/unix/utilsunx.cpp:678
+msgid "Fork failed"
+msgstr "No s'ha puesto a bifurcación d'o proceso"
+
+#: ../src/unix/utilsunx.cpp:701
+msgid "Failed to set process priority"
+msgstr "No s'ha puesto establir a prioridat d'o proceso"
+
+#: ../src/unix/utilsunx.cpp:712
+msgid "Failed to redirect child process input/output"
+msgstr "No s'ha puesto reendrezar a dentrada/salida d'o proceso fillo"
+
+#: ../src/unix/utilsunx.cpp:816
+msgid "Failed to set up non-blocking pipe, the program might hang."
+msgstr ""
+"No s'ha puesto configurar a canyería sin bloqueyo, o programa puet bloqueyar-"
+"se."
+
+#: ../src/unix/utilsunx.cpp:1023
+msgid "Cannot get the hostname"
+msgstr "No se puet obtener o nombre d'a maquina"
+
+#: ../src/unix/utilsunx.cpp:1059
+msgid "Cannot get the official hostname"
+msgstr "No se puet obtener o nombre oficial d'a maquina"
+
+#: ../src/unix/wakeuppipe.cpp:49
+msgid "Failed to create wake up pipe used by event loop."
+msgstr ""
+"S'ha produciu una error en creyar a canyería de dispertar que fa servir o "
+"bucle d'eventos."
+
+#: ../src/unix/wakeuppipe.cpp:56
+msgid "Failed to switch wake up pipe to non-blocking mode"
+msgstr ""
+"No s'ha puesto cambiar a canyería de dispertar ta lo modo de no bloqueyo"
+
+#: ../src/unix/wakeuppipe.cpp:117
+msgid "Failed to read from wake-up pipe"
+msgstr "No s'ha puesto leyer d'una tubería de dispertar"
+
+#: ../src/x11/app.cpp:124
+#, c-format
+msgid "Invalid geometry specification '%s'"
+msgstr "Especificación de cheometría no valida: '%s'"
+
+#: ../src/x11/app.cpp:167
+msgid "wxWidgets could not open display. Exiting."
+msgstr "Os wxWidgets no ha puesto ubrir o 'display'. Se'n ye salindo."
+
+#: ../src/x11/utils.cpp:169
+#, c-format
+msgid "Failed to close the display \"%s\""
+msgstr "S'ha produciu una error en zarrar o display \"%s\""
+
+#: ../src/x11/utils.cpp:188
+#, c-format
+msgid "Failed to open display \"%s\"."
+msgstr "No s'ha puesto ubrir o display \"%s\"."
+
+#: ../src/xml/xml.cpp:868
+#, c-format
+msgid "XML parsing error: '%s' at line %d"
+msgstr "S'ha produciu una error d'analisi de XML: '%s' en a linia %d"
+
+#: ../src/xrc/xh_propgrid.cpp:239
+#, fuzzy, c-format
+msgid "Page %i"
+msgstr "Pachina %d"
+
+#: ../src/xrc/xmlres.cpp:448
+#, c-format
+msgid "Cannot load resources from '%s'."
+msgstr "No se pueden cargar recursos dende '%s'."
+
+#: ../src/xrc/xmlres.cpp:799
+#, c-format
+msgid "Cannot open resources file '%s'."
+msgstr "No se puet ubrir o fichero de recursos '%s'."
+
+#: ../src/xrc/xmlres.cpp:806
+#, c-format
+msgid "Cannot load resources from file '%s'."
+msgstr "No se pueden cargar os recursos dende o fichero '%s'."
+
+#: ../src/xrc/xmlres.cpp:2767
+#, fuzzy, c-format
+msgid "Creating %s \"%s\" failed."
+msgstr "Ha fallau a extracción de '%s' en '%s'."
+
+#~ msgctxt "keyboard key"
+#~ msgid "Alt+"
+#~ msgstr "Alt+"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Ctrl+"
+#~ msgstr "Ctrl+"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Shift+"
+#~ msgstr "Mayus+"
+
+#~ msgctxt "keyboard key"
+#~ msgid "RawCtrl+"
+#~ msgstr "Ctrl+"
+
+#~ msgid "Unsupported clipboard format."
+#~ msgstr "Formato de portafuellas no suportau."
+
+#~ msgid "Background colour"
+#~ msgstr "Color de fondo"
+
+#~ msgid "Font:"
+#~ msgstr "Fuent:"
+
+#~ msgid "Size:"
+#~ msgstr "Grandaria:"
+
+#~ msgid "The font size in points."
+#~ msgstr "A grandaria de fuent en puntos."
+
+#~ msgid "Style:"
+#~ msgstr "Estilo:"
+
+#~ msgid "Check to make the font bold."
+#~ msgstr "Marcar ta fer negreta la fuent."
+
+#~ msgid "Check to make the font italic."
+#~ msgstr "Marcar ta fer cursiva la fuent."
+
+#~ msgid "Check to make the font underlined."
+#~ msgstr "Marcar ta fer subrayada a fuent."
+
+#~ msgid "Colour:"
+#~ msgstr "Color:"
+
+#~ msgid "Click to change the font colour."
+#~ msgstr "Fe clic ta cambiar a color d'a fuent."
+
+#~ msgid "Shows a preview of the font."
+#~ msgstr "Amuestra una anvista previa d'a fuent."
+
+#~ msgid "Click to cancel changes to the font."
+#~ msgstr "Fe clic ta cancelar os cambeos en a fuent."
+
+#~ msgid "Click to confirm changes to the font."
+#~ msgstr "Fe clic ta confirmar os cambeos en a fuent."
+
+#~ msgid "<Any>"
+#~ msgstr "<Cualsiquiera>"
+
+#~ msgid "<Any Roman>"
+#~ msgstr "<Cualsiquier Román>"
+
+#~ msgid "<Any Decorative>"
+#~ msgstr "<Cualsiquier Decorativo>"
+
+#~ msgid "<Any Modern>"
+#~ msgstr "<Cualsiquier Moderno>"
+
+#~ msgid "<Any Script>"
+#~ msgstr "<Cualsiquier Script>"
+
+#~ msgid "<Any Swiss>"
+#~ msgstr "<Cualsiquier Swiss>"
+
+#~ msgid "<Any Teletype>"
+#~ msgstr "<Cualsiquier Teletipo>"
+
+#~ msgid "Printing "
+#~ msgstr "Imprentando "
+
+#~ msgid "Failed to insert text in the control."
+#~ msgstr "No s'ha puesto ficar texto en o control."
+
+#~ msgid "Please choose a valid font."
+#~ msgstr "Por favor triga una fuent valida."
+
+#, c-format
+#~ msgid "Failed to display HTML document in %s encoding"
+#~ msgstr ""
+#~ "S'ha produciu una error en amostrar o documento HTML con codificación %s"
+
+#, c-format
+#~ msgid "wxWidgets could not open display for '%s': exiting."
+#~ msgstr ""
+#~ "o wxWidgets no ha puesto ubrir o 'display' ta '%s': Se'n ye salindo."
+
+#~ msgid "Filter"
+#~ msgstr "Filtro"
+
+#~ msgid "Directories"
+#~ msgstr "Directorios"
+
+#~ msgid "Files"
+#~ msgstr "Fichers"
+
+#~ msgid "Selection"
+#~ msgstr "Selección"
+
+#~ msgid "conversion to 8-bit encoding failed"
+#~ msgstr "ha fallau a conversión en codificación de 8 bits"
+
+#, fuzzy
+#~ msgid "failed to retrieve execution result"
+#~ msgstr "No s'ha puesto recuperar o mensache d'error de RAS"
+
+#~ msgid "&Save as"
+#~ msgstr "&Alzar como"
+
+#~ msgid "'%s' doesn't consist only of valid characters"
+#~ msgstr "'%s' no consiste nomás de caracters validos"
+
+#~ msgid "'%s' should be numeric."
+#~ msgstr "'%s' ha d'estar numerico."
+
+#~ msgid "'%s' should only contain ASCII characters."
+#~ msgstr "'%s' debe contener nomás caracters ASCII."
+
+#~ msgid "'%s' should only contain alphabetic characters."
+#~ msgstr "'%s' debe contener nomás caracters alfabeticos."
+
+#~ msgid "'%s' should only contain alphabetic or numeric characters."
+#~ msgstr "'%s' ha de contener nomás caracters alfanumericos."
+
+#~ msgid "'%s' should only contain digits."
+#~ msgstr "'%s' debe contener nomás numeros."
+
+#~ msgid "Can't create window of class %s"
+#~ msgstr "No se puet creyar a finestra de clase %s"
+
+#~ msgid "Couldn't create the overlay window"
+#~ msgstr "No s'ha puesto creyar a finestra de superposición"
+
+#~ msgid "Couldn't init the context on the overlay window"
+#~ msgstr ""
+#~ "No s'ha puesto inicializar o contexto en a finestra de superposición"
+
+#~ msgid "Failed to convert file \"%s\" to Unicode."
+#~ msgstr "S'ha produciu una error en convertir o fichero \"%s\" ta Unicode."
+
+#~ msgid "Failed to set text in the text control."
+#~ msgstr "No s'ha puesto colocar texto en o control de texto."
+
+#~ msgid "Invalid GTK+ command line option, use \"%s --help\""
+#~ msgstr "Opción GTK+ de linia de comandos invalida, Fe servir \"%s --help\""
+
+#~ msgid "No unused colour in image."
+#~ msgstr "No bi ha garra color sin usar en a imachen."
+
+#~ msgid "Not available"
+#~ msgstr "No disponible"
+
+#~ msgid "Replace selection"
+#~ msgstr "Substituir a selección"
+
+#~ msgid "Save as"
+#~ msgstr "Alzar como"
+
+#~ msgid "Style Organiser"
+#~ msgstr "Organizador d'Estilos"
+
+#~ msgid "The following standard GTK+ options are also supported:\n"
+#~ msgstr "As siguients opcions GTK+ estandar tamién son suportadas:\n"
+
+#~ msgid "You cannot Clear an overlay that is not inited"
+#~ msgstr "No puetz sacar una superposición que no ye estada inicializada"
+
+#~ msgid "You cannot Init an overlay twice"
+#~ msgstr "No puetz Inicializar una superposición dos vegadas"
+
+#~ msgid "locale '%s' cannot be set."
+#~ msgstr "no s'ha puesto establir a localización '%s'."
+
+#~ msgid "Adding flavor TEXT failed"
+#~ msgstr "S'ha produciu una error en adhibir a decoración de texto"
+
+#~ msgid "Adding flavor utxt failed"
+#~ msgstr "S'ha produciu una error en adhibir a decoración de utxt"
+
+#~ msgid "Bitmap renderer cannot render value; value type: "
+#~ msgstr ""
+#~ "O renderizador d'o mapa de bits no puet renderizar a valor; tipo de "
+#~ "valura: "
+
+#~ msgid ""
+#~ "Cannot create new column's ID. Probably max. number of columns reached."
+#~ msgstr ""
+#~ "No se puet creyar un nuevo identificador de columna. Prebablement s'haiga "
+#~ "acotolau o numero maximo de columnas."
+
+#~ msgid "Column could not be added."
+#~ msgstr "No s'ha puesto adhibir a columna."
+
+#~ msgid "Column index not found."
+#~ msgstr "No s'ha trobau l'indiz d'a columna."
+
+#~ msgid "Column width could not be determined"
+#~ msgstr "No s'ha puesto determinar l'amplaria d'a columna"
+
+#~ msgid "Column width could not be set."
+#~ msgstr "No s'ha puesto establir l'amplaria d'a columna."
+
+#~ msgid "Confirm registry update"
+#~ msgstr "Confirmar l'actualización d'o rechistro"
+
+#~ msgid "Could not determine column index."
+#~ msgstr "No s'ha puesto determinar l'indiz d'a columna."
+
+#~ msgid "Could not determine column's position"
+#~ msgstr "No s'ha puesto determinar a posición d'a columna"
+
+#~ msgid "Could not determine number of columns."
+#~ msgstr "No s'ha puesto determinar o numero de columnas."
+
+#~ msgid "Could not determine number of items"
+#~ msgstr "No s'ha puesto determinar o numero d'elementos"
+
+#~ msgid "Could not get header description."
+#~ msgstr "No s'ha puesto obtener a descripción d'o capitero."
+
+#~ msgid "Could not get items."
+#~ msgstr "No s'han puesto obtener elementos."
+
+#~ msgid "Could not get property flags."
+#~ msgstr "No se pueden obtener as marcas de propiedat."
+
+#~ msgid "Could not get selected items."
+#~ msgstr "No s'han puesto obtener os elementos seleccionaus."
+
+#~ msgid "Could not remove column."
+#~ msgstr "No s'ha puesto eliminar a columna."
+
+#~ msgid "Could not retrieve number of items"
+#~ msgstr "No s'ha puesto recuperar o numero d'elementos"
+
+#~ msgid "Could not set column width."
+#~ msgstr "No s'ha puesto establir l'amplaria d'a columna."
+
+#~ msgid "Could not set header description."
+#~ msgstr "No s'ha puesto establir a descripción d'o capitero."
+
+#~ msgid "Could not set icon."
+#~ msgstr "No s'ha puesto establir l'icono."
+
+#~ msgid "Could not set maximum width."
+#~ msgstr "No s'ha puesto establir l'amplaria maxima."
+
+#~ msgid "Could not set minimum width."
+#~ msgstr "No s'ha puesto establir l'amplaria minima."
+
+#~ msgid "Could not set property flags."
+#~ msgstr "No se pueden establir as marcas de propiedat."
+
+#~ msgid "Data object has invalid data format"
+#~ msgstr "L'obchecto de datos tien un formato invaliu de datos"
+
+#~ msgid "Date renderer cannot render value; value type: "
+#~ msgstr ""
+#~ "O renderizador de calendata no puet renderizar a valura; tipo de valura: "
+
+#~ msgid ""
+#~ "Do you want to overwrite the command used to %s files with extension "
+#~ "\"%s\" ?\n"
+#~ "Current value is \n"
+#~ "%s, \n"
+#~ "New value is \n"
+#~ "%s %1"
+#~ msgstr ""
+#~ "Quiers sobrescribir o comando usau en fichers %s con a extensión \"%s\"?\n"
+#~ "A valor actual ye \n"
+#~ "%s, \n"
+#~ "A nueva valor ye \n"
+#~ "%s %1"
+
+#~ msgid "Failed to retrieve data from the clipboard."
+#~ msgstr "No s'ha puesto recuperar datos d'o portafuellas."
+
+#~ msgid "GIF: Invalid gif index."
+#~ msgstr "GIF: Indiz de gif no valido."
+
+#~ msgid "GIF: unknown error!!!"
+#~ msgstr "GIF: error desconoixida!!!"
+
+#~ msgid "Icon & text renderer cannot render value; value type: "
+#~ msgstr ""
+#~ "O renderizador de textos y iconos no puet renderizar a valura; tipo de "
+#~ "valura: "
+
+#~ msgid "New directory"
+#~ msgstr "Nuevo directorio"
+
+#~ msgid "Next"
+#~ msgstr "Siguient"
+
+#~ msgid "No column existing."
+#~ msgstr "No existe a columna."
+
+#~ msgid "No column for the specified column existing."
+#~ msgstr "No existe columna ta la columna specificada."
+
+#~ msgid "No column for the specified column position existing."
+#~ msgstr "No existe columna ta la posición de columna especificada."
+
+#~ msgid ""
+#~ "No renderer or invalid renderer type specified for custom data column."
+#~ msgstr ""
+#~ "No bi ha renderizador u mena de renderizador especificada invalida ta la "
+#~ "columna personalizada de datos."
+
+#~ msgid "No renderer specified for column."
+#~ msgstr "No s'ha especificau un renderizador ta la columna."
+
+#~ msgid "Number of columns could not be determined."
+#~ msgstr "No s'ha puesto determinar o numero de columnas."
+
+#~ msgid "OpenGL function \"%s\" failed: %s (error %d)"
+#~ msgstr ""
+#~ "S'ha produciu una error en a función \"%s\" de l'OpenGL: %s (Error %d)"
+
+#~ msgid ""
+#~ "Please install a newer version of comctl32.dll\n"
+#~ "(at least version 4.70 is required but you have %d.%02d)\n"
+#~ "or this program won't operate correctly."
+#~ msgstr ""
+#~ "Por favor instala una versión mas recient de comctl32.dll\n"
+#~ "(s'ameneste a lo menos a versión 4.70 pero tiens %d.%02d)\n"
+#~ "u iste programa no funcionará correctament."
+
+#~ msgid "Pointer to data view control not set correctly."
+#~ msgstr ""
+#~ "O puntero ta lo control d'anvista de datos no s'ha establiu correctament."
+
+#~ msgid "Pointer to model not set correctly."
+#~ msgstr "O puntero ta lo modelo no s'ha establiu correctament."
+
+#~ msgid "Progress renderer cannot render value type; value type: "
+#~ msgstr ""
+#~ "O renderizador de progreso no puet renderizar o tipo de valura; tipo de "
+#~ "valura: "
+
+#~ msgid "Rendering failed."
+#~ msgstr "S'ha produciu una error en a renderización."
+
+#~ msgid ""
+#~ "Setting directory access times is not supported under this OS version"
+#~ msgstr ""
+#~ "En ista versión d'o sistema operativo no se suporta l'achuste d'os "
+#~ "tiempos d'acceso a directorios"
+
+#~ msgid "Show hidden directories"
+#~ msgstr "Amostrar os directorios amagaus"
+
+#~ msgid "Text renderer cannot render value; value type: "
+#~ msgstr "O renderizador de texto no puet renderizar a valor; tipo de valor: "
+
+#~ msgid "There is no column or renderer for the specified column index."
+#~ msgstr "No bi ha columna u renderizador ta l'indiz de columna especificau."
+
+#~ msgid ""
+#~ "This system doesn't support date controls, please upgrade your version of "
+#~ "comctl32.dll"
+#~ msgstr ""
+#~ "Iste sistema no suporta o control de datos, por favor esviella a tuya "
+#~ "versión d'o comctl32.dll"
+
+#~ msgid "Toggle renderer cannot render value; value type: "
+#~ msgstr "O renderizador activau no puet renderizar a valor; tipo de valor: "
+
+#~ msgid "Too many colours in PNG, the image may be slightly blurred."
+#~ msgstr ""
+#~ "Masiadas colors en o PNG, a imachen podría estar bella cosa borrosa."
+
+#~ msgid "Unable to handle native drag&drop data"
+#~ msgstr "No s'ha puesto maniar de traza nativa os datos d'arrocegar y soltar"
+
+#~ msgid "Unable to initialize Hildon program"
+#~ msgstr "No s'ha puesto enchegar o programa Hildon"
+
+#~ msgid "Unknown data format"
+#~ msgstr "Formato de datos desconoixiu"
+
+#~ msgid "Valid pointer to native data view control does not exist"
+#~ msgstr "No existe un puntero valido ta lo control d'anvista nativa de datos"
+
+#~ msgid "Win32s on Windows 3.1"
+#~ msgstr "Win32s en Windows 3.1"
+
+#, fuzzy
+#~ msgid "Windows 10"
+#~ msgstr "Windows 8.1"
+
+#~ msgid "Windows 2000"
+#~ msgstr "Windows 2000"
+
+#~ msgid "Windows 7"
+#~ msgstr "Windows 7"
+
+#~ msgid "Windows 8"
+#~ msgstr "Windows 8"
+
+#~ msgid "Windows 8.1"
+#~ msgstr "Windows 8.1"
+
+#~ msgid "Windows 95"
+#~ msgstr "Windows 95"
+
+#~ msgid "Windows 95 OSR2"
+#~ msgstr "Windows 95 OSR2"
+
+#~ msgid "Windows 98"
+#~ msgstr "Windows 98"
+
+#~ msgid "Windows 98 SE"
+#~ msgstr "Windows 98 SE"
+
+#~ msgid "Windows 9x (%d.%d)"
+#~ msgstr "Windows 9x (%d.%d)"
+
+#~ msgid "Windows CE (%d.%d)"
+#~ msgstr "Windows CE (%d.%d)"
+
+#~ msgid "Windows ME"
+#~ msgstr "Windows ME"
+
+#~ msgid "Windows NT %lu.%lu"
+#~ msgstr "Windows NT %lu.%lu"
+
+#, fuzzy
+#~ msgid "Windows Server 10"
+#~ msgstr "Windows Server 2003"
+
+#~ msgid "Windows Server 2003"
+#~ msgstr "Windows Server 2003"
+
+#~ msgid "Windows Server 2008"
+#~ msgstr "Windows Server 2008"
+
+#~ msgid "Windows Server 2008 R2"
+#~ msgstr "Windows Server 2008 R2"
+
+#~ msgid "Windows Server 2012"
+#~ msgstr "Windows Server 2012"
+
+#~ msgid "Windows Server 2012 R2"
+#~ msgstr "Windows Server 2012 R2"
+
+#~ msgid "Windows Vista"
+#~ msgstr "Windows Vista"
+
+#~ msgid "Windows XP"
+#~ msgstr "Windows XP"
+
+#~ msgid "can't execute '%s'"
+#~ msgstr "no se puet executar '%s'"
+
+#~ msgid "error opening '%s'"
+#~ msgstr "s'ha produciu una error en ubrir '%s'"
+
+#~ msgid "unknown seek origin"
+#~ msgstr "orichen de busca desconoixiu"
+
+#~ msgid "wxWidget control pointer is not a data view pointer"
+#~ msgstr "o puntero de control wxWidget no ye un puntero d'anvista de datos"
+
+#~ msgid "wxWidget's control not initialized."
+#~ msgstr "o control de wxWidget no ye inicializau."
+
+#~ msgid "ADD"
+#~ msgstr "ADHIBIR"
+
+#~ msgid "BACK"
+#~ msgstr "DEZAGA"
+
+#~ msgid "CANCEL"
+#~ msgstr "CANCELAR"
+
+#~ msgid "CAPITAL"
+#~ msgstr "MAYUSCLAS"
+
+#~ msgid "CLEAR"
+#~ msgstr "ESBORRAR"
+
+#~ msgid "COMMAND"
+#~ msgstr "COMANDO"
+
+#~ msgid "Cannot create mutex."
+#~ msgstr "No se puet creyar o mutex."
+
+#~ msgid "Cannot resume thread %lu"
+#~ msgstr "No se puet continar o filo d'execución %lu"
+
+#~ msgid "Cannot suspend thread %lu"
+#~ msgstr "No se puet suspender o filo d'execución %lu"
+
+#~ msgid "Couldn't acquire a mutex lock"
+#~ msgstr "No s'ha puesto adquirir un bloqueyo de mutex"
+
+#~ msgid "Couldn't get hatch style from wxBrush."
+#~ msgstr "No s'ha puesto obtener o estilo d'a trama d'o wxBrush."
+
+#~ msgid "Couldn't release a mutex"
+#~ msgstr "No s'ha puesto liberar un mutex"
+
+#~ msgid "DECIMAL"
+#~ msgstr "DECIMAL"
+
+#~ msgid "DEL"
+#~ msgstr "SUPR"
+
+#~ msgid "DELETE"
+#~ msgstr "SUPRIMIR"
+
+#~ msgid "DIVIDE"
+#~ msgstr "DIVIDE"
+
+#~ msgid "DOWN"
+#~ msgstr "ABAIXO"
+
+#~ msgid "END"
+#~ msgstr "FIN"
+
+#~ msgid "ENTER"
+#~ msgstr "INTRO"
+
+#~ msgid "ESC"
+#~ msgstr "ESC"
+
+#~ msgid "ESCAPE"
+#~ msgstr "ESCAPE"
+
+#~ msgid "EXECUTE"
+#~ msgstr "EXECUTAR"
+
+#~ msgid "Execution of command '%s' failed with error: %ul"
+#~ msgstr "Ha fallau a execución d'o comando '%s' con a error: %ul"
+
+#~ msgid ""
+#~ "File '%s' already exists.\n"
+#~ "Do you want to replace it?"
+#~ msgstr ""
+#~ "O fichero '%s' ya existe.\n"
+#~ "Realment quiers sobrescribir-lo?"
+
+#~ msgid "HELP"
+#~ msgstr "ADUYA"
+
+#~ msgid "HOME"
+#~ msgstr "INICIO"
+
+#~ msgid "INS"
+#~ msgstr "INS"
+
+#~ msgid "INSERT"
+#~ msgstr "INSERT"
+
+#~ msgid "KP_BEGIN"
+#~ msgstr "KP_BEGIN"
+
+#~ msgid "KP_DECIMAL"
+#~ msgstr "KP_DECIMAL"
+
+#~ msgid "KP_DELETE"
+#~ msgstr "KP_SUPR"
+
+#~ msgid "KP_DIVIDE"
+#~ msgstr "KP_DIVIDIR"
+
+#~ msgid "KP_DOWN"
+#~ msgstr "KP_ABAIXO"
+
+#~ msgid "KP_ENTER"
+#~ msgstr "KP_INTRO"
+
+#~ msgid "KP_EQUAL"
+#~ msgstr "KP_IGUAL"
+
+#~ msgid "KP_HOME"
+#~ msgstr "KP_INICIO"
+
+#~ msgid "KP_INSERT"
+#~ msgstr "KP_INSERT"
+
+#~ msgid "KP_LEFT"
+#~ msgstr "KP_CUCHA"
+
+#~ msgid "KP_MULTIPLY"
+#~ msgstr "KP_MULTIPLICAR"
+
+#~ msgid "KP_NEXT"
+#~ msgstr "KP_SIGUIENT"
+
+#~ msgid "KP_PAGEDOWN"
+#~ msgstr "KP_AVPACH"
+
+#~ msgid "KP_PAGEUP"
+#~ msgstr "KP_REPACH"
+
+#~ msgid "KP_PRIOR"
+#~ msgstr "KP_PRIOR"
+
+#~ msgid "KP_RIGHT"
+#~ msgstr "KP_DREITA"
+
+#~ msgid "KP_SEPARATOR"
+#~ msgstr "KP_SEPARADOR"
+
+#~ msgid "KP_SPACE"
+#~ msgstr "KP_ESPACIO"
+
+#~ msgid "KP_SUBTRACT"
+#~ msgstr "KP_RESTAR"
+
+#~ msgid "LEFT"
+#~ msgstr "CUCHA"
+
+#~ msgid "MENU"
+#~ msgstr "MENÚ"
+
+#~ msgid "NUM_LOCK"
+#~ msgstr "BLOQ_NUM"
+
+#~ msgid "PAGEDOWN"
+#~ msgstr "ABANZAR PACHINA"
+
+#~ msgid "PAGEUP"
+#~ msgstr "RECULAR PACHINA"
+
+#~ msgid "PAUSE"
+#~ msgstr "PAUSA"
+
+#~ msgid "PGDN"
+#~ msgstr "ABPACH"
+
+#~ msgid "PGUP"
+#~ msgstr "REPACH"
+
+#~ msgid "PRINT"
+#~ msgstr "IMPRENTAR"
+
+#~ msgid "RETURN"
+#~ msgstr "RETURN"
+
+#~ msgid "RIGHT"
+#~ msgstr "DREITA"
+
+#~ msgid "SCROLL_LOCK"
+#~ msgstr "BLOQ_DESPL"
+
+#~ msgid "SELECT"
+#~ msgstr "SELECCIONAR"
+
+#~ msgid "SEPARATOR"
+#~ msgstr "SEPARADOR"
+
+#~ msgid "SNAPSHOT"
+#~ msgstr "IMPR_PANT"
+
+#~ msgid "SPACE"
+#~ msgstr "ESPACIO"
+
+#~ msgid "SUBTRACT"
+#~ msgstr "SUBTRAYER"
+
+#~ msgid "TAB"
+#~ msgstr "TAB"
+
+#~ msgid "The print dialog returned an error."
+#~ msgstr "O dialogo d'impresión ha tornau una error."
+
+#~ msgid "The wxGtkPrinterDC cannot be used."
+#~ msgstr "No se puet fer servir o wxGtkPrinterDC."
+
+#~ msgid "Timer creation failed."
+#~ msgstr "S'ha produciu una error en a creyación d'o temporizador."
+
+#~ msgid "UP"
+#~ msgstr "ALTO"
+
+#~ msgid "WINDOWS_LEFT"
+#~ msgstr "WINDOWS_CUCHO"
+
+#~ msgid "WINDOWS_MENU"
+#~ msgstr "WINDOWS_MENU"
+
+#~ msgid "WINDOWS_RIGHT"
+#~ msgstr "WINDOWS_DREITO"
+
+#~ msgid "buffer is too small for Windows directory."
+#~ msgstr "o buffer ye masiau chicot ta lo directorio Windows."
+
+#~ msgid "not implemented"
+#~ msgstr "no implementau<"
+
+#~ msgid "wxPrintout::GetPageInfo gives a null maxPage."
+#~ msgstr "wxPrintout::GetPageInfo da un maxPage nulo."
+
+#~ msgid "Event queue overflowed"
+#~ msgstr "Coda d'eventos sobreixida"
+
+#~ msgid "percent"
+#~ msgstr "por cient"

--- a/po_wxstd/ar.po
+++ b/po_wxstd/ar.po
@@ -1,0 +1,9875 @@
+# wxWidgets I18N
+# Copyright (C) 2010-2025 wxWidgets
+# This file is distributed under the same license as the wxWidgets package.
+#
+# Abdullah Abouzekry <abouzekry@gmail.com>, 2010.
+# Fatma Mehanna <fatma.mehanna@gmail.com>, 2012.
+# Amar <al_janabi7@yahoo.com>, 2025.
+msgid ""
+msgstr ""
+"Project-Id-Version: wxWidgets Arabic Translation 3.1\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-05-14 20:23+0200\n"
+"PO-Revision-Date: 2025-05-08 23:30+0300\n"
+"Last-Translator: Amar <al_janabi7@yahoo.com>\n"
+"Language-Team: arabictranslationteam@googlegroups.com\n"
+"Language: ar\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=6; plural=(n==0 ? 0 : n==1 ? 1 : n==2 ? 2 : n%100>=3 "
+"&& n%100<=10 ? 3 : n%100>=11 && n%100<=99 ? 4 : 5);\n"
+"X-Generator: Poedit 2.4.3\n"
+"X-Poedit-SourceCharset: UTF-8\n"
+
+#: ../include/wx/defs.h:2582
+msgid "All files (*.*)|*.*"
+msgstr "كل الملفات (*.*)|*.*"
+
+#: ../include/wx/defs.h:2585
+msgid "All files (*)|*"
+msgstr "كل الملفات (*)|*"
+
+#: ../include/wx/generic/progdlgg.h:85
+msgid "Elapsed time:"
+msgstr "الوقت المنقضي:"
+
+#: ../include/wx/generic/progdlgg.h:86
+msgid "Estimated time:"
+msgstr "الوقت التقديري:"
+
+#: ../include/wx/generic/progdlgg.h:87
+msgid "Remaining time:"
+msgstr "الوقت المتبقي:"
+
+#. TRANSLATORS: HTML printout default title.
+#: ../include/wx/html/htmprint.h:121 ../include/wx/prntbase.h:273
+#: ../include/wx/richtext/richtextprint.h:109 ../src/common/docview.cpp:2161
+msgid "Printout"
+msgstr "المطبوعات"
+
+#. TRANSLATORS: HTML easy print default title.
+#: ../include/wx/html/htmprint.h:234 ../include/wx/richtext/richtextprint.h:163
+#: ../src/common/prntbase.cpp:522 ../src/html/htmprint.cpp:291
+msgid "Printing"
+msgstr "يطبع"
+
+#: ../include/wx/msgdlg.h:277 ../src/common/stockitem.cpp:211
+msgid "Yes"
+msgstr "نعم"
+
+#: ../include/wx/msgdlg.h:278 ../src/common/stockitem.cpp:182
+msgid "No"
+msgstr "لا"
+
+#: ../include/wx/msgdlg.h:279 ../src/common/stockitem.cpp:183
+#: ../src/msw/msgdlg.cpp:430 ../src/msw/msgdlg.cpp:734
+#: ../src/richtext/richtextstyledlg.cpp:292
+msgid "OK"
+msgstr "موافق"
+
+#: ../include/wx/msgdlg.h:280 ../src/common/stockitem.cpp:150
+#: ../src/msw/msgdlg.cpp:430 ../src/msw/progdlg.cpp:884
+#: ../src/richtext/richtextstyledlg.cpp:295
+msgid "Cancel"
+msgstr "إلغاء"
+
+#: ../include/wx/msgdlg.h:281 ../src/common/stockitem.cpp:168
+#: ../src/html/helpdlg.cpp:63 ../src/html/helpfrm.cpp:108
+#: ../src/osx/button_osx.cpp:38
+msgid "Help"
+msgstr "مساعدة"
+
+#: ../include/wx/msw/ole/oleutils.h:52
+msgid "Cannot initialize OLE"
+msgstr "تعذّر تجهيز OLE"
+
+#: ../include/wx/msw/private/fswatcher.h:48
+#, c-format
+msgid "Unable to close the handle for '%s'"
+msgstr "غير قادر على إغلاق المقبض لـ '%s'"
+
+#: ../include/wx/msw/private/fswatcher.h:92
+#, c-format
+msgid "Failed to open directory \"%s\" for monitoring."
+msgstr "أخفق فتح الدليل \"%s\" للمراقبة."
+
+#: ../include/wx/msw/private/fswatcher.h:125
+msgid "Unable to close I/O completion port handle"
+msgstr "غير قادر على إغلاق مقبض منفذ إكمال المُدخَلات\\المُخرَجات"
+
+#: ../include/wx/msw/private/fswatcher.h:142
+msgid "Unable to associate handle with I/O completion port"
+msgstr "غير قادر على إقران مقبض مع منفذ إكمال المُدخَلات\\المُخرَجات"
+
+#: ../include/wx/msw/private/fswatcher.h:148
+msgid "Unexpectedly new I/O completion port was created"
+msgstr "أُنشئ منفذ إكمال مُدخَلات\\مُخرَجات جديد على نحو غير متوقع"
+
+#: ../include/wx/msw/private/fswatcher.h:213
+msgid "Unable to post completion status"
+msgstr "غير قادر على نشر حالة الإكمال"
+
+#: ../include/wx/msw/private/fswatcher.h:262
+msgid "Unable to dequeue completion packet"
+msgstr "غير قادر على إزالة حزمة الإكمال من الطابور"
+
+#: ../include/wx/msw/private/fswatcher.h:273
+msgid "Unable to create I/O completion port"
+msgstr "غير قادر على إنشاء منفذ إكمال المُدخَلات\\المُخرَجات"
+
+#: ../include/wx/richmsgdlg.h:29
+msgid "&See details"
+msgstr "&شاهِد التفاصيل"
+
+#: ../include/wx/richmsgdlg.h:30
+msgid "&Hide details"
+msgstr "أخ&فِ التفاصيل"
+
+#: ../include/wx/richtext/richtextbuffer.h:3864
+msgid "&Box"
+msgstr "صن&دوق"
+
+#: ../include/wx/richtext/richtextbuffer.h:5008
+msgid "&Picture"
+msgstr "&صورة"
+
+#: ../include/wx/richtext/richtextbuffer.h:5958
+msgid "&Cell"
+msgstr "خ&لية"
+
+#: ../include/wx/richtext/richtextbuffer.h:6067
+msgid "&Table"
+msgstr "&جدول"
+
+#: ../include/wx/richtext/richtextimagedlg.h:37
+msgid "Object Properties"
+msgstr "خصائص الكائن"
+
+#: ../include/wx/richtext/richtextsymboldlg.h:39
+msgid "Symbols"
+msgstr "رموز"
+
+#: ../include/wx/unix/pipe.h:46
+msgid "Pipe creation failed"
+msgstr "أخفق إنشاء المسرى"
+
+#: ../include/wx/unix/private/displayx11.h:65
+msgid "Failed to enumerate video modes"
+msgstr "أخفق تعداد أوضاع الفيديو"
+
+#: ../include/wx/unix/private/displayx11.h:89
+msgid "Failed to change video mode"
+msgstr "أخفق تغيير وضع الفيديو"
+
+#: ../include/wx/unix/private/fswatcher_kqueue.h:57
+#, c-format
+msgid "Unable to open path '%s'"
+msgstr "غير قادر على فتح المسار '%s'"
+
+#: ../include/wx/unix/private/fswatcher_kqueue.h:74
+#, c-format
+msgid "Unable to close path '%s'"
+msgstr "غير قادر على إغلاق المسار '%s'"
+
+#: ../include/wx/xtiprop.h:175
+msgid "SetProperty called w/o valid setter"
+msgstr "استُدعي مُعِدّ الخاصية SetProperty بلا مُعِدّ سليم"
+
+#: ../include/wx/xtiprop.h:184
+msgid "GetProperty called w/o valid getter"
+msgstr "استُدعي محصِّل الخاصية GetProperty بلا محصِّل صحيح"
+
+#: ../include/wx/xtiprop.h:193
+msgid "AddToPropertyCollection called w/o valid adder"
+msgstr "استُدعي المُضيف إلى مجموعة الخاصية AddToPropertyCollection بلا مُضيف سليم"
+
+#: ../include/wx/xtiprop.h:202
+msgid "GetPropertyCollection called w/o valid collection getter"
+msgstr "استُدعي مُحصِّل مجموعة الخاصية GetPropertyCollection بلا مُحصِّل سليم"
+
+#: ../include/wx/xtiprop.h:255
+msgid "AddToPropertyCollection called on a generic accessor"
+msgstr ""
+"استُدعي المُضيف إلى مجموعة الخاصية AddToPropertyCollection على والج عمومي"
+
+#: ../include/wx/xtiprop.h:262
+msgid "GetPropertyCollection called on a generic accessor"
+msgstr "استُدعي مُحصِّل مجموعة الخاصية GetPropertyCollection على مُحصِّل عمومي"
+
+#: ../src/aui/tabmdi.cpp:106 ../src/generic/mdig.cpp:94
+msgid "Cl&ose"
+msgstr "إ&غلاق"
+
+#: ../src/aui/tabmdi.cpp:107 ../src/generic/mdig.cpp:95
+msgid "Close All"
+msgstr "إغلاق الكل"
+
+#: ../src/aui/tabmdi.cpp:109 ../src/generic/mdig.cpp:97 ../src/msw/mdi.cpp:175
+#: ../src/qt/mdi.cpp:258
+msgid "&Next"
+msgstr "&التالي"
+
+#: ../src/aui/tabmdi.cpp:110 ../src/generic/mdig.cpp:98 ../src/msw/mdi.cpp:176
+#: ../src/qt/mdi.cpp:259
+msgid "&Previous"
+msgstr "&سابق"
+
+#: ../src/aui/tabmdi.cpp:332 ../src/aui/tabmdi.cpp:348
+#: ../src/aui/tabmdi.cpp:350 ../src/generic/mdig.cpp:291
+#: ../src/generic/mdig.cpp:307 ../src/generic/mdig.cpp:311
+#: ../src/msw/mdi.cpp:337 ../src/qt/mdi.cpp:462
+msgid "&Window"
+msgstr "&نافذة"
+
+#: ../src/common/accelcmn.cpp:47
+msgctxt "keyboard key"
+msgid "Delete"
+msgstr "حذف"
+
+#: ../src/common/accelcmn.cpp:48
+msgctxt "keyboard key"
+msgid "Del"
+msgstr "م‌حذف"
+
+#: ../src/common/accelcmn.cpp:49
+msgctxt "keyboard key"
+msgid "Back"
+msgstr "م‌للخلف"
+
+#: ../src/common/accelcmn.cpp:49
+msgctxt "keyboard key"
+msgid "Backspace"
+msgstr "مسافة للخلف"
+
+#: ../src/common/accelcmn.cpp:50
+msgctxt "keyboard key"
+msgid "Insert"
+msgstr "إدراج"
+
+#: ../src/common/accelcmn.cpp:51
+msgctxt "keyboard key"
+msgid "Ins"
+msgstr "م‌إدراج"
+
+#: ../src/common/accelcmn.cpp:52
+msgctxt "keyboard key"
+msgid "Enter"
+msgstr "إدخال"
+
+#: ../src/common/accelcmn.cpp:53
+msgctxt "keyboard key"
+msgid "Return"
+msgstr "إرجاع"
+
+#: ../src/common/accelcmn.cpp:54
+msgctxt "keyboard key"
+msgid "PageUp"
+msgstr "صفحة‌أعلى"
+
+#: ../src/common/accelcmn.cpp:54
+msgctxt "keyboard key"
+msgid "Page Up"
+msgstr "صفحة للأعلى"
+
+#: ../src/common/accelcmn.cpp:55
+msgctxt "keyboard key"
+msgid "PageDown"
+msgstr "صفحة‌أسفل"
+
+#: ../src/common/accelcmn.cpp:55
+msgctxt "keyboard key"
+msgid "Page Down"
+msgstr "صفحة للأسفل"
+
+#: ../src/common/accelcmn.cpp:56
+msgctxt "keyboard key"
+msgid "PgUp"
+msgstr "ص‌أعلى"
+
+#: ../src/common/accelcmn.cpp:57
+msgctxt "keyboard key"
+msgid "PgDn"
+msgstr "ص‌أسفل"
+
+#: ../src/common/accelcmn.cpp:58
+msgctxt "keyboard key"
+msgid "Left"
+msgstr "يسار"
+
+#: ../src/common/accelcmn.cpp:59
+msgctxt "keyboard key"
+msgid "Right"
+msgstr "يمين"
+
+#: ../src/common/accelcmn.cpp:60
+msgctxt "keyboard key"
+msgid "Up"
+msgstr "أعلى"
+
+#: ../src/common/accelcmn.cpp:61
+msgctxt "keyboard key"
+msgid "Down"
+msgstr "أسفل"
+
+#: ../src/common/accelcmn.cpp:62
+msgctxt "keyboard key"
+msgid "Home"
+msgstr "«المنزل»"
+
+#: ../src/common/accelcmn.cpp:63
+msgctxt "keyboard key"
+msgid "End"
+msgstr "نهاية"
+
+#: ../src/common/accelcmn.cpp:64
+msgctxt "keyboard key"
+msgid "Space"
+msgstr "فراغ"
+
+#: ../src/common/accelcmn.cpp:65
+msgctxt "keyboard key"
+msgid "Tab"
+msgstr "لسان"
+
+#: ../src/common/accelcmn.cpp:66
+msgctxt "keyboard key"
+msgid "Esc"
+msgstr "هروب"
+
+#: ../src/common/accelcmn.cpp:67
+msgctxt "keyboard key"
+msgid "Escape"
+msgstr "الهروب"
+
+#: ../src/common/accelcmn.cpp:68
+msgctxt "keyboard key"
+msgid "Cancel"
+msgstr "إلغاء"
+
+#: ../src/common/accelcmn.cpp:69
+msgctxt "keyboard key"
+msgid "Clear"
+msgstr "محو"
+
+#: ../src/common/accelcmn.cpp:70
+msgctxt "keyboard key"
+msgid "Menu"
+msgstr "قائمة"
+
+#: ../src/common/accelcmn.cpp:71
+msgctxt "keyboard key"
+msgid "Pause"
+msgstr "لبث"
+
+#: ../src/common/accelcmn.cpp:72
+msgctxt "keyboard key"
+msgid "Capital"
+msgstr "كبيرة"
+
+#: ../src/common/accelcmn.cpp:73
+msgctxt "keyboard key"
+msgid "Select"
+msgstr "حدّد"
+
+#: ../src/common/accelcmn.cpp:74
+msgctxt "keyboard key"
+msgid "Print"
+msgstr "اطبع"
+
+#: ../src/common/accelcmn.cpp:75
+msgctxt "keyboard key"
+msgid "Execute"
+msgstr "نفّذ"
+
+#: ../src/common/accelcmn.cpp:76
+msgctxt "keyboard key"
+msgid "Snapshot"
+msgstr "لقطة"
+
+#: ../src/common/accelcmn.cpp:77
+msgctxt "keyboard key"
+msgid "Help"
+msgstr "مساعدة"
+
+#: ../src/common/accelcmn.cpp:78
+msgctxt "keyboard key"
+msgid "Add"
+msgstr "أضِف"
+
+#: ../src/common/accelcmn.cpp:79
+msgctxt "keyboard key"
+msgid "Separator"
+msgstr "فاصل"
+
+#: ../src/common/accelcmn.cpp:80
+msgctxt "keyboard key"
+msgid "Subtract"
+msgstr "طرح"
+
+#: ../src/common/accelcmn.cpp:81
+msgctxt "keyboard key"
+msgid "Decimal"
+msgstr "عشري"
+
+#: ../src/common/accelcmn.cpp:82
+msgctxt "keyboard key"
+msgid "Multiply"
+msgstr "ضرب"
+
+#: ../src/common/accelcmn.cpp:83
+msgctxt "keyboard key"
+msgid "Divide"
+msgstr "قسمة"
+
+#: ../src/common/accelcmn.cpp:84
+msgctxt "keyboard key"
+msgid "Num_lock"
+msgstr "‌قفل-_أرقام"
+
+#: ../src/common/accelcmn.cpp:84
+msgctxt "keyboard key"
+msgid "Num Lock"
+msgstr "قفل الأرقام"
+
+#: ../src/common/accelcmn.cpp:85
+msgctxt "keyboard key"
+msgid "Scroll_lock"
+msgstr "‌قفل‌-_لف"
+
+#: ../src/common/accelcmn.cpp:85
+msgctxt "keyboard key"
+msgid "Scroll Lock"
+msgstr "قفل اللف"
+
+#: ../src/common/accelcmn.cpp:86
+msgctxt "keyboard key"
+msgid "KP_Space"
+msgstr "_فراغ-وسادة"
+
+#: ../src/common/accelcmn.cpp:86
+msgctxt "keyboard key"
+msgid "Num Space"
+msgstr "فراغ الأرقام"
+
+#: ../src/common/accelcmn.cpp:87
+msgctxt "keyboard key"
+msgid "KP_Tab"
+msgstr "_لسان-وسادة"
+
+#: ../src/common/accelcmn.cpp:87
+msgctxt "keyboard key"
+msgid "Num Tab"
+msgstr "لسان الأرقام"
+
+#: ../src/common/accelcmn.cpp:88
+msgctxt "keyboard key"
+msgid "KP_Enter"
+msgstr "إ_دخال-وسادة"
+
+#: ../src/common/accelcmn.cpp:88
+msgctxt "keyboard key"
+msgid "Num Enter"
+msgstr "الإدخال الأرقام"
+
+#: ../src/common/accelcmn.cpp:89
+msgctxt "keyboard key"
+msgid "KP_Home"
+msgstr "_منزل-وسادة"
+
+#: ../src/common/accelcmn.cpp:89
+msgctxt "keyboard key"
+msgid "Num Home"
+msgstr "«المنزل» الأرقام"
+
+#: ../src/common/accelcmn.cpp:90
+msgctxt "keyboard key"
+msgid "KP_Left"
+msgstr "ي_سار-وسادة"
+
+#: ../src/common/accelcmn.cpp:90
+msgctxt "keyboard key"
+msgid "Num left"
+msgstr "اليسار الأرقام"
+
+#: ../src/common/accelcmn.cpp:91
+msgctxt "keyboard key"
+msgid "KP_Up"
+msgstr "أ_على-وسادة"
+
+#: ../src/common/accelcmn.cpp:91
+msgctxt "keyboard key"
+msgid "Num Up"
+msgstr "الأعلى الأرقام"
+
+#: ../src/common/accelcmn.cpp:92
+msgctxt "keyboard key"
+msgid "KP_Right"
+msgstr "_يمين-وسادة"
+
+#: ../src/common/accelcmn.cpp:92
+msgctxt "keyboard key"
+msgid "Num Right"
+msgstr "اليمين الأرقام"
+
+#: ../src/common/accelcmn.cpp:93
+msgctxt "keyboard key"
+msgid "KP_Down"
+msgstr "أس_فل-وسادة"
+
+#: ../src/common/accelcmn.cpp:93
+msgctxt "keyboard key"
+msgid "Num Down"
+msgstr "الأسفل الأرقام"
+
+#: ../src/common/accelcmn.cpp:94
+msgctxt "keyboard key"
+msgid "KP_PageUp"
+msgstr "_صفحةأعلى-وسادة"
+
+#: ../src/common/accelcmn.cpp:94
+msgctxt "keyboard key"
+msgid "Num Page Up"
+msgstr "صفحة للأعلى الأرقام"
+
+#: ../src/common/accelcmn.cpp:95
+msgctxt "keyboard key"
+msgid "KP_PageDown"
+msgstr "_صفحةأسفل-وسادة"
+
+#: ../src/common/accelcmn.cpp:95
+msgctxt "keyboard key"
+msgid "Num Page Down"
+msgstr "صفحة للأسفل الأرقام"
+
+#: ../src/common/accelcmn.cpp:96
+msgctxt "keyboard key"
+msgid "KP_Prior"
+msgstr "سا_بق-سادة"
+
+#: ../src/common/accelcmn.cpp:97
+msgctxt "keyboard key"
+msgid "KP_Next"
+msgstr "_تالي‌وسادة"
+
+#: ../src/common/accelcmn.cpp:98
+msgctxt "keyboard key"
+msgid "KP_End"
+msgstr "ن_هاية-وسادة"
+
+#: ../src/common/accelcmn.cpp:98
+msgctxt "keyboard key"
+msgid "Num End"
+msgstr "النهاية الأرقام"
+
+#: ../src/common/accelcmn.cpp:99
+msgctxt "keyboard key"
+msgid "KP_Begin"
+msgstr "_بدء-وسادة"
+
+#: ../src/common/accelcmn.cpp:99
+msgctxt "keyboard key"
+msgid "Num Begin"
+msgstr "البدء الأرقام"
+
+#: ../src/common/accelcmn.cpp:100
+msgctxt "keyboard key"
+msgid "KP_Insert"
+msgstr "إ_دراج-وسادة"
+
+#: ../src/common/accelcmn.cpp:100
+msgctxt "keyboard key"
+msgid "Num Insert"
+msgstr "الإدراج الأرقام"
+
+#: ../src/common/accelcmn.cpp:101
+msgctxt "keyboard key"
+msgid "KP_Delete"
+msgstr "ح_ذف-وسادة"
+
+#: ../src/common/accelcmn.cpp:101
+msgctxt "keyboard key"
+msgid "Num Delete"
+msgstr "الحذف الأرقام"
+
+#: ../src/common/accelcmn.cpp:102
+msgctxt "keyboard key"
+msgid "KP_Equal"
+msgstr "مسا_واة-وسادة"
+
+#: ../src/common/accelcmn.cpp:102
+msgctxt "keyboard key"
+msgid "Num ="
+msgstr "= الأرقام"
+
+#: ../src/common/accelcmn.cpp:103
+msgctxt "keyboard key"
+msgid "KP_Multiply"
+msgstr "_ضرب-وسادة"
+
+#: ../src/common/accelcmn.cpp:103
+msgctxt "keyboard key"
+msgid "Num *"
+msgstr "* الأرقام"
+
+#: ../src/common/accelcmn.cpp:104
+msgctxt "keyboard key"
+msgid "KP_Add"
+msgstr "_جمع-وسادة"
+
+#: ../src/common/accelcmn.cpp:104
+msgctxt "keyboard key"
+msgid "Num +"
+msgstr "+ الأرقام"
+
+#: ../src/common/accelcmn.cpp:105
+msgctxt "keyboard key"
+msgid "KP_Separator"
+msgstr "ف_اصل-وسادة"
+
+#: ../src/common/accelcmn.cpp:105
+msgctxt "keyboard key"
+msgid "Num ,"
+msgstr "الأرقام ،"
+
+#: ../src/common/accelcmn.cpp:106
+msgctxt "keyboard key"
+msgid "KP_Subtract"
+msgstr "_طرح-وسادة"
+
+#: ../src/common/accelcmn.cpp:106
+msgctxt "keyboard key"
+msgid "Num -"
+msgstr "- الأرقام"
+
+#: ../src/common/accelcmn.cpp:107
+msgctxt "keyboard key"
+msgid "KP_Decimal"
+msgstr "ع_شري-وسادة"
+
+#: ../src/common/accelcmn.cpp:107
+msgctxt "keyboard key"
+msgid "Num ."
+msgstr "الأرقام ."
+
+#: ../src/common/accelcmn.cpp:108
+msgctxt "keyboard key"
+msgid "KP_Divide"
+msgstr "_قسمة-وسادة"
+
+#: ../src/common/accelcmn.cpp:108
+msgctxt "keyboard key"
+msgid "Num /"
+msgstr "\\ الأرقام"
+
+#: ../src/common/accelcmn.cpp:109
+msgctxt "keyboard key"
+msgid "Windows_Left"
+msgstr "وندوز_يسار"
+
+#: ../src/common/accelcmn.cpp:110
+msgctxt "keyboard key"
+msgid "Windows_Right"
+msgstr "وندوز_يمين"
+
+#: ../src/common/accelcmn.cpp:111
+msgctxt "keyboard key"
+msgid "Windows_Menu"
+msgstr "وندوز_قائمة"
+
+#: ../src/common/accelcmn.cpp:112
+msgctxt "keyboard key"
+msgid "Command"
+msgstr "أمر"
+
+#: ../src/common/accelcmn.cpp:186 ../src/common/accelcmn.cpp:359
+msgctxt "keyboard key"
+msgid "Ctrl"
+msgstr "م‌تحكّم"
+
+#: ../src/common/accelcmn.cpp:188 ../src/common/accelcmn.cpp:363
+msgctxt "keyboard key"
+msgid "Alt"
+msgstr "م‌تغيير"
+
+#: ../src/common/accelcmn.cpp:190 ../src/common/accelcmn.cpp:361
+msgctxt "keyboard key"
+msgid "Shift"
+msgstr "م‌تبديل"
+
+#: ../src/common/accelcmn.cpp:196
+msgctxt "keyboard key"
+msgid "num "
+msgstr "م‌الأرقام "
+
+#: ../src/common/accelcmn.cpp:260 ../src/common/accelcmn.cpp:382
+msgctxt "keyboard key"
+msgid "F"
+msgstr "مفتاح F"
+
+#: ../src/common/accelcmn.cpp:277 ../src/common/accelcmn.cpp:385
+msgctxt "keyboard key"
+msgid "KP_F"
+msgstr "_م‌F_وسادة"
+
+#: ../src/common/accelcmn.cpp:280 ../src/common/accelcmn.cpp:388
+msgctxt "keyboard key"
+msgid "KP_"
+msgstr "وسادة_"
+
+#: ../src/common/accelcmn.cpp:283 ../src/common/accelcmn.cpp:391
+msgctxt "keyboard key"
+msgid "SPECIAL"
+msgstr "خاص"
+
+#: ../src/common/accelcmn.cpp:373
+#, fuzzy
+msgid "Ctrl"
+msgstr "م‌تحكّم"
+
+#: ../src/common/appbase.cpp:786
+msgid "show this help message"
+msgstr "أظهِر رسالة المساعدة هذه"
+
+#: ../src/common/appbase.cpp:796
+msgid "generate verbose log messages"
+msgstr "ولِّد رسائل سجِلّ مستفيضة"
+
+#: ../src/common/appcmn.cpp:256
+msgid "specify the theme to use"
+msgstr "حدّد السمة لاستخدامها"
+
+#: ../src/common/appcmn.cpp:270
+msgid "specify display mode to use (e.g. 640x480-16)"
+msgstr "حدد وضع العَرض لاستخدامه (مثلا 640×480 - 16)"
+
+#: ../src/common/appcmn.cpp:292
+#, c-format
+msgid "Unsupported theme '%s'."
+msgstr "سمة غير مدعومة '%s'."
+
+#: ../src/common/appcmn.cpp:309
+#, c-format
+msgid "Invalid display mode specification '%s'."
+msgstr "مواصفات وضع عَرض غير سليم '%s'."
+
+#: ../src/common/cmdline.cpp:875
+#, c-format
+msgid "Option '%s' can't be negated"
+msgstr "الخيار '%s' لا يمكن نفيه"
+
+#: ../src/common/cmdline.cpp:889
+#, c-format
+msgid "Unknown long option '%s'"
+msgstr "خيار طويل مجهول '%s'"
+
+#: ../src/common/cmdline.cpp:904 ../src/common/cmdline.cpp:926
+#, c-format
+msgid "Unknown option '%s'"
+msgstr "خيار مجهول '%s'"
+
+#: ../src/common/cmdline.cpp:1004
+#, c-format
+msgid "Unexpected characters following option '%s'."
+msgstr "محارف غير متوقعة تتلو الخيار '%s'."
+
+#: ../src/common/cmdline.cpp:1039
+#, c-format
+msgid "Option '%s' requires a value."
+msgstr "الخيار '%s' يتطلب قيمة."
+
+#: ../src/common/cmdline.cpp:1058
+#, c-format
+msgid "Separator expected after the option '%s'."
+msgstr "فاصل متوقع بعد الخيار '%s'."
+
+#: ../src/common/cmdline.cpp:1088 ../src/common/cmdline.cpp:1106
+#, c-format
+msgid "'%s' is not a correct numeric value for option '%s'."
+msgstr "'%s' ليس قيمة رقمية صحيحة للخيار'%s'."
+
+#: ../src/common/cmdline.cpp:1122
+#, c-format
+msgid "Option '%s': '%s' cannot be converted to a date."
+msgstr "الخيار '%s': لا يمكن تحويل '%s' إلى تأريخ."
+
+#: ../src/common/cmdline.cpp:1170
+#, c-format
+msgid "Unexpected parameter '%s'"
+msgstr "متغير وسيط غير متوقع '%s'"
+
+#. TRANSLATORS: Short name and long name for a command line option
+#: ../src/common/cmdline.cpp:1197
+#, c-format
+msgid "%s (or %s)"
+msgstr "%s (أو %s)"
+
+#: ../src/common/cmdline.cpp:1208
+#, c-format
+msgid "The value for the option '%s' must be specified."
+msgstr "قيمة الخيار '%s' يجب تحديدها."
+
+#: ../src/common/cmdline.cpp:1230
+#, c-format
+msgid "The required parameter '%s' was not specified."
+msgstr "لم يُحدَّد المتغير الوسيط المطلوب '%s'."
+
+#: ../src/common/cmdline.cpp:1289
+#, c-format
+msgid "Usage: %s"
+msgstr "الاستخدام: %s"
+
+#: ../src/common/cmdline.cpp:1498
+msgid "str"
+msgstr "مقطع"
+
+#: ../src/common/cmdline.cpp:1502
+msgid "num"
+msgstr "رقم"
+
+#: ../src/common/cmdline.cpp:1506
+msgid "double"
+msgstr "مضاعَف"
+
+#: ../src/common/cmdline.cpp:1510
+msgid "date"
+msgstr "تاريخ"
+
+#: ../src/common/cmdproc.cpp:250 ../src/common/cmdproc.cpp:276
+#: ../src/common/cmdproc.cpp:296
+msgid "Unnamed command"
+msgstr "أمر بلا إسم"
+
+#: ../src/common/cmdproc.cpp:253
+msgid "&Undo "
+msgstr "&تراجع "
+
+#: ../src/common/cmdproc.cpp:255
+msgid "Can't &Undo "
+msgstr "لا يمكن ال&تراجع "
+
+#: ../src/common/cmdproc.cpp:259 ../src/common/stockitem.cpp:208
+#: ../src/msw/textctrl.cpp:2880 ../src/osx/textctrl_osx.cpp:649
+#: ../src/richtext/richtextctrl.cpp:327
+msgid "&Undo"
+msgstr "&تراجع"
+
+#: ../src/common/cmdproc.cpp:277 ../src/common/cmdproc.cpp:297
+msgid "&Redo "
+msgstr "أ&عِد الفعل "
+
+#: ../src/common/cmdproc.cpp:281 ../src/common/cmdproc.cpp:288
+#: ../src/common/stockitem.cpp:190 ../src/msw/textctrl.cpp:2881
+#: ../src/osx/textctrl_osx.cpp:650 ../src/richtext/richtextctrl.cpp:328
+msgid "&Redo"
+msgstr "أ&عِد الفعل"
+
+#: ../src/common/colourcmn.cpp:41
+#, c-format
+msgid "String To Colour : Incorrect colour specification : %s"
+msgstr "العبارة للّون: مواصفات غير صحيحة للّون: %s"
+
+#: ../src/common/config.cpp:259
+#, c-format
+msgid "Invalid value %ld for a boolean key \"%s\" in config file."
+msgstr "قيمة غير سليمة %ld لمفتاح منطقي \"%s\" في ملف التكوين."
+
+#: ../src/common/config.cpp:526
+#, c-format
+msgid ""
+"Environment variables expansion failed: missing '%c' at position %u in '%s'."
+msgstr "أخفق توسيع متغيرات البيئة: ينقص '%c' عند الموضع %u في '%s'."
+
+#: ../src/common/config.cpp:576 ../src/msw/regconf.cpp:272
+#, c-format
+msgid "'%s' has extra '..', ignored."
+msgstr "'%s' به مزيد'..', تم تجاهله."
+
+#. TRANSLATORS: Checkbox state name
+#: ../src/common/datavcmn.cpp:2166 ../src/generic/datavgen.cpp:1430
+msgid "checked"
+msgstr "مؤشَّر"
+
+#. TRANSLATORS: Checkbox state name
+#: ../src/common/datavcmn.cpp:2170 ../src/generic/datavgen.cpp:1432
+msgid "unchecked"
+msgstr "غير مؤشَّر"
+
+#. TRANSLATORS: Checkbox state name
+#: ../src/common/datavcmn.cpp:2174
+msgid "undetermined"
+msgstr "غير محدد"
+
+#: ../src/common/datetimefmt.cpp:1875
+msgid "today"
+msgstr "اليوم"
+
+#: ../src/common/datetimefmt.cpp:1876
+msgid "yesterday"
+msgstr "أمس"
+
+#: ../src/common/datetimefmt.cpp:1877
+msgid "tomorrow"
+msgstr "غدا"
+
+#: ../src/common/datetimefmt.cpp:2071
+msgid "first"
+msgstr "الأول"
+
+#: ../src/common/datetimefmt.cpp:2072
+msgid "second"
+msgstr "الثاني"
+
+#: ../src/common/datetimefmt.cpp:2073
+msgid "third"
+msgstr "الثالث"
+
+#: ../src/common/datetimefmt.cpp:2074
+msgid "fourth"
+msgstr "الرابع"
+
+#: ../src/common/datetimefmt.cpp:2075
+msgid "fifth"
+msgstr "الخامس"
+
+#: ../src/common/datetimefmt.cpp:2076
+msgid "sixth"
+msgstr "السادس"
+
+#: ../src/common/datetimefmt.cpp:2077
+msgid "seventh"
+msgstr "السابع"
+
+#: ../src/common/datetimefmt.cpp:2078
+msgid "eighth"
+msgstr "الثامن"
+
+#: ../src/common/datetimefmt.cpp:2079
+msgid "ninth"
+msgstr "التاسع"
+
+#: ../src/common/datetimefmt.cpp:2080
+msgid "tenth"
+msgstr "العاشر"
+
+#: ../src/common/datetimefmt.cpp:2081
+msgid "eleventh"
+msgstr "الحادي عشر"
+
+#: ../src/common/datetimefmt.cpp:2082
+msgid "twelfth"
+msgstr "الثاني عشر"
+
+#: ../src/common/datetimefmt.cpp:2083
+msgid "thirteenth"
+msgstr "الثالث عشر"
+
+#: ../src/common/datetimefmt.cpp:2084
+msgid "fourteenth"
+msgstr "الرابع عشر"
+
+#: ../src/common/datetimefmt.cpp:2085
+msgid "fifteenth"
+msgstr "الخامس عشر"
+
+#: ../src/common/datetimefmt.cpp:2086
+msgid "sixteenth"
+msgstr "السادس عشر"
+
+#: ../src/common/datetimefmt.cpp:2087
+msgid "seventeenth"
+msgstr "السابع عشر"
+
+#: ../src/common/datetimefmt.cpp:2088
+msgid "eighteenth"
+msgstr "الثامن عشر"
+
+#: ../src/common/datetimefmt.cpp:2089
+msgid "nineteenth"
+msgstr "التاسع عشر"
+
+#: ../src/common/datetimefmt.cpp:2090
+msgid "twentieth"
+msgstr "العشرون"
+
+#: ../src/common/datetimefmt.cpp:2248
+msgid "noon"
+msgstr "ظُهراً"
+
+#: ../src/common/datetimefmt.cpp:2249
+msgid "midnight"
+msgstr "منتصف الليل"
+
+#: ../src/common/debugrpt.cpp:209
+#, c-format
+msgid "Failed to create directory \"%s\""
+msgstr "أخفق إنشاء الدليل \"%s\""
+
+#: ../src/common/debugrpt.cpp:210
+msgid "Debug report couldn't be created."
+msgstr "تعذّر إنشاء تقرير إزالة العِلل."
+
+#: ../src/common/debugrpt.cpp:227
+#, c-format
+msgid "Failed to remove debug report file \"%s\""
+msgstr "أخفقت إزالة ملف تقرير إزالة العِلل \"%s\""
+
+#: ../src/common/debugrpt.cpp:239
+#, c-format
+msgid "Failed to clean up debug report directory \"%s\""
+msgstr "أخفق تنظيف دليل تقرير إزالة العِلل \"%s\""
+
+#: ../src/common/debugrpt.cpp:514
+msgid "process context description"
+msgstr "وصف سياق العملية"
+
+#: ../src/common/debugrpt.cpp:538
+msgid "dump of the process state (binary)"
+msgstr "مكَبّ حالة العملية (ثنائي)"
+
+#: ../src/common/debugrpt.cpp:553
+msgid "Debug report generation has failed."
+msgstr "أخفق توليد تقرير إزالة العِلل."
+
+#: ../src/common/debugrpt.cpp:560
+#, c-format
+msgid ""
+"Processing debug report has failed, leaving the files in \"%s\" directory."
+msgstr "أخفقت معالجة تقرير إزالة العِلل، تركت الملفات في الدليل \"%s\"."
+
+#: ../src/common/debugrpt.cpp:573
+msgid "A debug report has been generated. It can be found in"
+msgstr "وُلّد تقرير إزالة العِلل. يمكن العثور عليه في"
+
+#: ../src/common/debugrpt.cpp:576
+msgid "And includes the following files:\n"
+msgstr "ويشتمل على الملفات التالية:\n"
+
+#: ../src/common/debugrpt.cpp:586
+msgid ""
+"\n"
+"Please send this report to the program maintainer, thank you!\n"
+msgstr ""
+"\n"
+"من فضلك أرسل هذا التقرير إلى المسؤول عن صيانة البرنامج، شكرا!\n"
+
+#: ../src/common/debugrpt.cpp:729
+msgid "Failed to execute curl, please install it in PATH."
+msgstr "أخفق تنفيذ curl، لطفًا ثبّته في المسار PATH."
+
+#: ../src/common/debugrpt.cpp:742
+#, c-format
+msgid "Failed to upload the debug report (error code %d)."
+msgstr "أخفق تحميل تقرير إزالة العِلل (رمز الخطأ %d)."
+
+#: ../src/common/docview.cpp:366
+msgid "Save As"
+msgstr "احفظ باسم"
+
+#: ../src/common/docview.cpp:457
+msgid "Discard changes and reload the last saved version?"
+msgstr "أستبعد التغييرات وأعيد تحميل آخِر نسخة محفوظة؟"
+
+#: ../src/common/docview.cpp:488
+msgid "unnamed"
+msgstr "غير مسمى"
+
+#: ../src/common/docview.cpp:513
+#, c-format
+msgid "Do you want to save changes to %s?"
+msgstr "أتريد حفظ التغييرات بالملف %s؟"
+
+#: ../src/common/docview.cpp:521 ../src/common/docview.cpp:560
+#: ../src/common/stockitem.cpp:195
+msgid "&Save"
+msgstr "&حفظ"
+
+#: ../src/common/docview.cpp:522 ../src/common/docview.cpp:560
+msgid "&Discard changes"
+msgstr "ا&ستبعد التغييرات"
+
+#: ../src/common/docview.cpp:523
+msgid "Do&n't close"
+msgstr "لا ت&غلق"
+
+#: ../src/common/docview.cpp:553
+#, c-format
+msgid "Do you want to save changes to %s before closing it?"
+msgstr "أ تريد حفظ التغييرات بالملف %s قبل إغلاقه؟"
+
+#: ../src/common/docview.cpp:559
+msgid "The document must be closed."
+msgstr "يجب إغلاق المستند."
+
+#: ../src/common/docview.cpp:571
+#, c-format
+msgid "Saving %s failed, would you like to retry?"
+msgstr "أخفق حفظ %s، أترغب في إعادة المحاولة؟"
+
+#: ../src/common/docview.cpp:577
+msgid "Retry"
+msgstr "أعِد المحاولة"
+
+#: ../src/common/docview.cpp:577
+msgid "Discard changes"
+msgstr "استبعد التغييرات"
+
+#: ../src/common/docview.cpp:679
+#, c-format
+msgid "File \"%s\" could not be opened for writing."
+msgstr "تعذّر فتح الملف \"%s\" للكتابة."
+
+#: ../src/common/docview.cpp:685
+#, c-format
+msgid "Failed to save document to the file \"%s\"."
+msgstr "أخفق حفظ المستند إلى الملف \"%s\"."
+
+#: ../src/common/docview.cpp:702
+#, c-format
+msgid "File \"%s\" could not be opened for reading."
+msgstr "تعذّر فتح الملف \"%s\" للقراءة."
+
+#: ../src/common/docview.cpp:714
+#, c-format
+msgid "Failed to read document from the file \"%s\"."
+msgstr "أخفقت قراءة المستند من الملف \"%s\"."
+
+#: ../src/common/docview.cpp:1236
+#, c-format
+msgid ""
+"The file '%s' doesn't exist and couldn't be opened.\n"
+"It has been removed from the most recently used files list."
+msgstr ""
+"الملف '%s' غير موجود وتعذّر فتحه.\n"
+"أُزيل من قائمة أحدث الملفات استخدامًا."
+
+#: ../src/common/docview.cpp:1296
+msgid "Print preview creation failed."
+msgstr "أخفق إنشاء معاينة الطباعة."
+
+#: ../src/common/docview.cpp:1302
+msgid "Print Preview"
+msgstr "معاينة الطباعة"
+
+#: ../src/common/docview.cpp:1517
+#, c-format
+msgid "The format of file '%s' couldn't be determined."
+msgstr "تعذّر تحديد نسَق الملف '%s'."
+
+#: ../src/common/docview.cpp:1643
+#, c-format
+msgid "unnamed%d"
+msgstr "غير مسمى %d"
+
+#: ../src/common/docview.cpp:1660
+msgid " - "
+msgstr " - "
+
+#: ../src/common/docview.cpp:1791 ../src/common/docview.cpp:1844
+msgid "Open File"
+msgstr "فتح ملف"
+
+#: ../src/common/docview.cpp:1807
+msgid "File error"
+msgstr "خطأ بالملف"
+
+#: ../src/common/docview.cpp:1809
+msgid "Sorry, could not open this file."
+msgstr "آسف، تعذّر فتح هذا الملف."
+
+#: ../src/common/docview.cpp:1843
+msgid "Sorry, the format for this file is unknown."
+msgstr "عذراً، نسَق هذا الملف مجهول."
+
+#: ../src/common/docview.cpp:1924
+msgid "Select a document template"
+msgstr "حدد قالب مستند"
+
+#: ../src/common/docview.cpp:1925
+msgid "Templates"
+msgstr "القوالب"
+
+#: ../src/common/docview.cpp:1998
+msgid "Select a document view"
+msgstr "حدد معاينة مستند"
+
+#: ../src/common/docview.cpp:1999
+msgid "Views"
+msgstr "المعايَنات"
+
+#: ../src/common/dynlib.cpp:81
+#, c-format
+msgid "Failed to load shared library '%s'"
+msgstr "أخفق تحميل المكتبة المشتركة '%s'"
+
+#: ../src/common/dynlib.cpp:105
+#, c-format
+msgid "Couldn't find symbol '%s' in a dynamic library"
+msgstr "تعذّر العثور على الرمز '%s' في مكتبة تفاعلية"
+
+#: ../src/common/ffile.cpp:56 ../src/common/file.cpp:215
+#, c-format
+msgid "can't open file '%s'"
+msgstr "تعذّر فتح الملف '%s'"
+
+#: ../src/common/ffile.cpp:72
+#, c-format
+msgid "can't close file '%s'"
+msgstr "تعذّر إغلاق الملف '%s'"
+
+#: ../src/common/ffile.cpp:106 ../src/common/ffile.cpp:131
+#, c-format
+msgid "Read error on file '%s'"
+msgstr "خطأ قراءة في الملف '%s'"
+
+#: ../src/common/ffile.cpp:148
+#, c-format
+msgid "Write error on file '%s'"
+msgstr "خطأ كتابة في الملف '%s'"
+
+#: ../src/common/ffile.cpp:182
+#, c-format
+msgid "failed to flush the file '%s'"
+msgstr "أخفق كسح الملف '%s'"
+
+#: ../src/common/ffile.cpp:222
+#, c-format
+msgid "Seek error on file '%s' (large files not supported by stdio)"
+msgstr "خطأ قصد في الملف '%s' (stdio لا يدعم الملفات الكبيرة)"
+
+#: ../src/common/ffile.cpp:232
+#, c-format
+msgid "Seek error on file '%s'"
+msgstr "خطأ قصد في الملف '%s'"
+
+#: ../src/common/ffile.cpp:248
+#, c-format
+msgid "Can't find current position in file '%s'"
+msgstr "لا يمكن العثور على الموضع الحالي في الملف '%s'"
+
+#: ../src/common/ffile.cpp:349 ../src/common/file.cpp:569
+msgid "Failed to set temporary file permissions"
+msgstr "أخفق إعداد تصاريح الملف المؤقت"
+
+#: ../src/common/ffile.cpp:371
+#, c-format
+msgid "can't remove file '%s'"
+msgstr "تعذّرت إزالة الملف '%s'"
+
+#: ../src/common/ffile.cpp:376 ../src/common/file.cpp:591
+#, c-format
+msgid "can't commit changes to file '%s'"
+msgstr "تعذّر إيداع التغييرات إلى الملف '%s'"
+
+#: ../src/common/ffile.cpp:388 ../src/common/file.cpp:603
+#, c-format
+msgid "can't remove temporary file '%s'"
+msgstr "تعذّرت إزالة الملف المؤقت '%s'"
+
+#: ../src/common/file.cpp:162
+#, c-format
+msgid "can't create file '%s'"
+msgstr "تعذّر إنشاء الملف '%s'"
+
+#: ../src/common/file.cpp:229
+#, c-format
+msgid "can't close file descriptor %d"
+msgstr "تعذّر إغلاق واصف الملف %d"
+
+#: ../src/common/file.cpp:332
+#, c-format
+msgid "can't read from file descriptor %d"
+msgstr "تعذّرت القراءة من واصف الملف %d"
+
+#: ../src/common/file.cpp:351
+#, c-format
+msgid "can't write to file descriptor %d"
+msgstr "تعذّرت الكتابة إلى واصف الملف %d"
+
+#: ../src/common/file.cpp:390
+#, c-format
+msgid "can't flush file descriptor %d"
+msgstr "تعذّر كسح واصف الملف %d"
+
+#: ../src/common/file.cpp:432
+#, c-format
+msgid "can't seek on file descriptor %d"
+msgstr "تعذّر القصد في واصف الملف %d"
+
+#: ../src/common/file.cpp:446
+#, c-format
+msgid "can't get seek position on file descriptor %d"
+msgstr "تعذّر جلب موضع القصد في واصف الملف %d"
+
+#: ../src/common/file.cpp:475
+#, c-format
+msgid "can't find length of file on file descriptor %d"
+msgstr "تعذّر إيجاد طول الملف في واصف الملف %d"
+
+#: ../src/common/file.cpp:505
+#, c-format
+msgid "can't determine if the end of file is reached on descriptor %d"
+msgstr "تعذّر تحديد فيما لو وُصل إلى نهاية الملف في واصف الملف %d"
+
+#: ../src/common/fileconf.cpp:352
+#, c-format
+msgid ""
+" and additionally, the existing configuration file was renamed to \"%s\" and "
+"couldn't be renamed back, please rename it to its original path \"%s\""
+msgstr ""
+" وعلاوة على ذلك، أُعيدت تسمية ملف التكوين الحالي إلى \"%s\" وتعذّر التراجع عن "
+"إعادة تسميته، لطفًا أعِد تسميته إلى مساره الأصلي \"%s\""
+
+#: ../src/common/fileconf.cpp:389
+msgid " due to the following error:\n"
+msgstr " بسبب الخطأ التالي:\n"
+
+#: ../src/common/fileconf.cpp:412
+msgid "failed to rename the existing file"
+msgstr "أخفقت إعادة تسمية الملف الحالي"
+
+#: ../src/common/fileconf.cpp:421
+msgid "failed to create the new file directory"
+msgstr "أخفق إنشاء دليل الملف الجديد"
+
+#: ../src/common/fileconf.cpp:428
+msgid "failed to move the file to the new location"
+msgstr "أخفق نقل الملف إلى الموضع الجديد"
+
+#: ../src/common/fileconf.cpp:462
+#, c-format
+msgid "can't open global configuration file '%s'."
+msgstr "تعذّر فتح ملف التكوين العمومي '%s'."
+
+#: ../src/common/fileconf.cpp:478
+#, c-format
+msgid "can't open user configuration file '%s'."
+msgstr "تعذّر فتح ملف تكوين المستخدم '%s'."
+
+#: ../src/common/fileconf.cpp:483
+#, c-format
+msgid "Changes won't be saved to avoid overwriting the existing file \"%s\""
+msgstr "لن تُحفَظ التغييرات لتجنُّب الكتابة على الملف الموجود \"%s\""
+
+#: ../src/common/fileconf.cpp:583
+msgid "Error reading config options."
+msgstr "خطأ عند قراءة خيارات التكوين."
+
+#: ../src/common/fileconf.cpp:593
+msgid "Failed to read config options."
+msgstr "أخفقت قراءة خيارات التكوين."
+
+#: ../src/common/fileconf.cpp:700
+#, c-format
+msgid "file '%s': unexpected character %c at line %zu."
+msgstr "الملف '%s': محرف %c غير متوقع في السطر %zu."
+
+#: ../src/common/fileconf.cpp:736
+#, c-format
+msgid "file '%s', line %zu: '%s' ignored after group header."
+msgstr "الملف '%s'، السطر %zu: أُهمل '%s' بعد ترويس المجموعة."
+
+#: ../src/common/fileconf.cpp:765
+#, c-format
+msgid "file '%s', line %zu: '=' expected."
+msgstr "الملف '%s'، السطر %zu: رمز '=' غير متوقع."
+
+#: ../src/common/fileconf.cpp:778
+#, c-format
+msgid "file '%s', line %zu: value for immutable key '%s' ignored."
+msgstr "الملف '%s'، السطر %zu: أُهملت قيمة المفتاح غير التبدلي '%s'."
+
+#: ../src/common/fileconf.cpp:788
+#, c-format
+msgid "file '%s', line %zu: key '%s' was first found at line %d."
+msgstr "الملف '%s'، السطر %zu: عُثر على المفتاح '%s' أولاً في السطر %d."
+
+#: ../src/common/fileconf.cpp:1091
+#, c-format
+msgid "Config entry name cannot start with '%c'."
+msgstr "لا يمكن أن يبدأ اسم مُدخَل التكوين بـ '%c'."
+
+#: ../src/common/fileconf.cpp:1146
+msgid "Failed to create configuration file directory."
+msgstr "أخفق إنشاء دليل ملف التكوين."
+
+#: ../src/common/fileconf.cpp:1158
+msgid "can't open user configuration file."
+msgstr "تعذّر فتح ملف تكوين المستخدم."
+
+#: ../src/common/fileconf.cpp:1172
+msgid "can't write user configuration file."
+msgstr "تعذّرت كتابة ملف تكوين المستخدم."
+
+#: ../src/common/fileconf.cpp:1178
+msgid "Failed to update user configuration file."
+msgstr "أخفق تحديث ملف تكوين المستخدم."
+
+#: ../src/common/fileconf.cpp:1201
+msgid "Error saving user configuration data."
+msgstr "خطأ عند حفظ بيانات تكوين المستخدم."
+
+#: ../src/common/fileconf.cpp:1313
+#, c-format
+msgid "can't delete user configuration file '%s'"
+msgstr "تعذّر حذف ملف تكوين المستخدم '%s'"
+
+#: ../src/common/fileconf.cpp:2007
+#, c-format
+msgid "entry '%s' appears more than once in group '%s'"
+msgstr "يظهر المُدخَل '%s' أكثر من مرة في المجموعة '%s'"
+
+#: ../src/common/fileconf.cpp:2021
+#, c-format
+msgid "attempt to change immutable key '%s' ignored."
+msgstr "أُهملت محاولة تغيير المفتاح غير التبدلي '%s'."
+
+#: ../src/common/fileconf.cpp:2118
+#, c-format
+msgid "trailing backslash ignored in '%s'"
+msgstr "أُهمل رمز الشرطة المائلة في '%s'"
+
+#: ../src/common/fileconf.cpp:2153
+#, c-format
+msgid "unexpected \" at position %d in '%s'."
+msgstr "رمز \" غير متوقع في الموضع %d في '%s'."
+
+#: ../src/common/filefn.cpp:474
+#, c-format
+msgid "Failed to copy the file '%s' to '%s'"
+msgstr "أخفق نسخ الملف '%s' إلى '%s'"
+
+#: ../src/common/filefn.cpp:487
+#, c-format
+msgid "Impossible to get permissions for file '%s'"
+msgstr "لا يمكن جلب تصاريح الملف '%s'"
+
+#: ../src/common/filefn.cpp:501
+#, c-format
+msgid "Impossible to overwrite the file '%s'"
+msgstr "لا يمكن الكتابة على الملف '%s'."
+
+#: ../src/common/filefn.cpp:508
+#, c-format
+msgid "Error copying the file '%s' to '%s'."
+msgstr "خطأ في نسخ الملف '%s' إلى '%s'."
+
+#: ../src/common/filefn.cpp:556
+#, c-format
+msgid "Impossible to set permissions for the file '%s'"
+msgstr "لا يمكن إعداد التصاريح للملف '%s'"
+
+#: ../src/common/filefn.cpp:606
+#, c-format
+msgid ""
+"Failed to rename the file '%s' to '%s' because the destination file already "
+"exists."
+msgstr "أخفقت إعادة تسمية الملف '%s' إلى '%s' لأنّ الملف الوِجهة موجود سلفًا."
+
+#: ../src/common/filefn.cpp:623
+#, c-format
+msgid "File '%s' couldn't be renamed '%s'"
+msgstr "الملف '%s' تعذّرت إعادة تسميته '%s'"
+
+#: ../src/common/filefn.cpp:639
+#, c-format
+msgid "File '%s' couldn't be removed"
+msgstr "تعذّرت إزالة الملف '%s'"
+
+#: ../src/common/filefn.cpp:666
+#, c-format
+msgid "Directory '%s' couldn't be created"
+msgstr "تعذّر إنشاء المجلد '%s'"
+
+#: ../src/common/filefn.cpp:680
+#, c-format
+msgid "Directory '%s' couldn't be deleted"
+msgstr "تعذّر حذف المجلد '%s'"
+
+#: ../src/common/filefn.cpp:714
+#, c-format
+msgid "Cannot enumerate files '%s'"
+msgstr "تعذّر تعداد الملفات '%s'"
+
+#: ../src/common/filefn.cpp:798
+msgid "Failed to get the working directory"
+msgstr "أخفق جلب الدليل الشغال"
+
+#: ../src/common/filefn.cpp:843
+msgid "Could not set current working directory"
+msgstr "تعذّر إعداد الدليل الشغال الحالي"
+
+#: ../src/common/filefn.cpp:974
+#, c-format
+msgid "Files (%s)"
+msgstr "ملفات (%s)"
+
+#: ../src/common/filename.cpp:182
+#, c-format
+msgid "Failed to open '%s' for reading"
+msgstr "أخفق فتح \"%s\" للقراءة"
+
+#: ../src/common/filename.cpp:187
+#, c-format
+msgid "Failed to open '%s' for writing"
+msgstr "أخفق فتح \"%s\" للكتابة"
+
+#: ../src/common/filename.cpp:199
+msgid "Failed to close file handle"
+msgstr "أخفق إغلاق مقبض الملف"
+
+#: ../src/common/filename.cpp:1046
+msgid "Failed to create a temporary file name"
+msgstr "أخفق إنشاء اسم ملف مؤقت"
+
+#: ../src/common/filename.cpp:1081
+msgid "Failed to open temporary file."
+msgstr "أخفق فتح الملف المؤقت."
+
+#: ../src/common/filename.cpp:2862
+#, c-format
+msgid "Failed to modify file times for '%s'"
+msgstr "أخفق تعديل أوقات الملف لـ '%s'"
+
+#: ../src/common/filename.cpp:2877
+#, c-format
+msgid "Failed to touch the file '%s'"
+msgstr "أخفق إنشاء الملف '%s'"
+
+#: ../src/common/filename.cpp:2958
+#, c-format
+msgid "Failed to retrieve file times for '%s'"
+msgstr "أخفق استحصال أوقات الملف لـ '%s'"
+
+#: ../src/common/filepickercmn.cpp:39 ../src/common/filepickercmn.cpp:40
+msgid "Browse"
+msgstr "تصفّح"
+
+#: ../src/common/fldlgcmn.cpp:792 ../src/generic/filectrlg.cpp:1185
+#, c-format
+msgid "All files (%s)|%s"
+msgstr "كل الملفات (%s)|%s"
+
+#. TRANSLATORS: %s are a file extension used to build a file wildcard string
+#: ../src/common/fldlgcmn.cpp:810
+#, c-format
+msgid "%s files (%s)|%s"
+msgstr "%s ملفات(%s)|%s"
+
+#: ../src/common/fldlgcmn.cpp:1072
+#, c-format
+msgid "Load %s file"
+msgstr "حمّل ملف %s"
+
+#: ../src/common/fldlgcmn.cpp:1074
+#, c-format
+msgid "Save %s file"
+msgstr "احفظ ملف %s"
+
+#: ../src/common/fmapbase.cpp:144
+msgid "Western European (ISO-8859-1)"
+msgstr "أوربية غربية (آيزو-8859-1)"
+
+#: ../src/common/fmapbase.cpp:145
+msgid "Central European (ISO-8859-2)"
+msgstr "أوربية وسطى (آيزو-8859-2)"
+
+#: ../src/common/fmapbase.cpp:146
+msgid "Esperanto (ISO-8859-3)"
+msgstr "اسبرانتو (آيزو-8859-3)"
+
+#: ../src/common/fmapbase.cpp:147
+msgid "Baltic (old) (ISO-8859-4)"
+msgstr "بلطيقية (قديمة) (آيزو-8859-4)"
+
+#: ../src/common/fmapbase.cpp:148
+msgid "Cyrillic (ISO-8859-5)"
+msgstr "سيريلية (آيزو-8859-5)"
+
+#: ../src/common/fmapbase.cpp:149
+msgid "Arabic (ISO-8859-6)"
+msgstr "عربية (آيزو-8859-6)"
+
+#: ../src/common/fmapbase.cpp:150
+msgid "Greek (ISO-8859-7)"
+msgstr "يونانية (آيزو-8859-7)"
+
+#: ../src/common/fmapbase.cpp:151
+msgid "Hebrew (ISO-8859-8)"
+msgstr "عبرية (آيزو-8859-8)"
+
+#: ../src/common/fmapbase.cpp:152
+msgid "Turkish (ISO-8859-9)"
+msgstr "تركية (آيزو-8859-9)"
+
+#: ../src/common/fmapbase.cpp:153
+msgid "Nordic (ISO-8859-10)"
+msgstr "شمالية (آيزو-8859-10)"
+
+#: ../src/common/fmapbase.cpp:154
+msgid "Thai (ISO-8859-11)"
+msgstr "تايلندية (آيزو-8859-11)"
+
+#: ../src/common/fmapbase.cpp:155
+msgid "Indian (ISO-8859-12)"
+msgstr "هندية (آيزو-8859-12)"
+
+#: ../src/common/fmapbase.cpp:156
+msgid "Baltic (ISO-8859-13)"
+msgstr "بلطيقية (آيزو-8859-13)"
+
+#: ../src/common/fmapbase.cpp:157
+msgid "Celtic (ISO-8859-14)"
+msgstr "قِلطية (آيزو-8859-14)"
+
+#: ../src/common/fmapbase.cpp:158
+msgid "Western European with Euro (ISO-8859-15)"
+msgstr "أوربية غربية باليورو (آيزو-8859-15)"
+
+#: ../src/common/fmapbase.cpp:159
+msgid "KOI8-R"
+msgstr "ترميز KOI8-R"
+
+#: ../src/common/fmapbase.cpp:160
+msgid "KOI8-U"
+msgstr "ترميز KOI8-U"
+
+#: ../src/common/fmapbase.cpp:161
+msgid "Windows/DOS OEM Cyrillic (CP 866)"
+msgstr "سيريلية وندوز (صفحة ترميز 866)"
+
+#: ../src/common/fmapbase.cpp:162
+msgid "Windows Thai (CP 874)"
+msgstr "تايلندية وندوز (صفحة ترميز 874)"
+
+#: ../src/common/fmapbase.cpp:163
+msgid "Windows Japanese (CP 932) or Shift-JIS"
+msgstr "يابانية وندوز (صفحة ترميز 932) أو Shift-JIS"
+
+#: ../src/common/fmapbase.cpp:164
+msgid "Windows Chinese Simplified (CP 936) or GB-2312"
+msgstr "صينية مبسطة وندوز (صفحة ترميز 936) أو GB-2312"
+
+#: ../src/common/fmapbase.cpp:165
+msgid "Windows Korean (CP 949)"
+msgstr "كورية وندوز (صفحة ترميز 949)"
+
+#: ../src/common/fmapbase.cpp:166
+msgid "Windows Chinese Traditional (CP 950) or Big-5"
+msgstr "صينية تقليدية وندوز (صفحة ترميز 950) أو Big-5"
+
+#: ../src/common/fmapbase.cpp:167
+msgid "Windows Central European (CP 1250)"
+msgstr "أوربية وسطى وندوز (صفحة ترميز 1250)"
+
+#: ../src/common/fmapbase.cpp:168
+msgid "Windows Cyrillic (CP 1251)"
+msgstr "سيريلية وندوز (صفحة ترميز 1251)"
+
+#: ../src/common/fmapbase.cpp:169
+msgid "Windows Western European (CP 1252)"
+msgstr "أوربية غربية وندوز (صفحة ترميز 1252)"
+
+#: ../src/common/fmapbase.cpp:170
+msgid "Windows Greek (CP 1253)"
+msgstr "يونانية وندوز (صفحة ترميز 1253)"
+
+#: ../src/common/fmapbase.cpp:171
+msgid "Windows Turkish (CP 1254)"
+msgstr "تركية وندوز (صفحة ترميز 1254)"
+
+#: ../src/common/fmapbase.cpp:172
+msgid "Windows Hebrew (CP 1255)"
+msgstr "عبرية وندوز (صفحة ترميز 1255)"
+
+#: ../src/common/fmapbase.cpp:173
+msgid "Windows Arabic (CP 1256)"
+msgstr "عربية وندوز (صفحة ترميز 1256)"
+
+#: ../src/common/fmapbase.cpp:174
+msgid "Windows Baltic (CP 1257)"
+msgstr "بلطيقية وندوز (صفحة ترميز 1257)"
+
+#: ../src/common/fmapbase.cpp:175
+msgid "Windows Vietnamese (CP 1258)"
+msgstr "فيتنامية وندوز (صفحة ترميز 1258)"
+
+#: ../src/common/fmapbase.cpp:176
+msgid "Windows Johab (CP 1361)"
+msgstr "جوهاب وندوز (صفحة ترميز 1361)"
+
+#: ../src/common/fmapbase.cpp:177
+msgid "Windows/DOS OEM (CP 437)"
+msgstr "وندوز\\دوز OEM (صفحة ترميز 437)"
+
+#: ../src/common/fmapbase.cpp:178
+msgid "Unicode 7 bit (UTF-7)"
+msgstr "ترميزموحد 7 بت (UTF-7)"
+
+#: ../src/common/fmapbase.cpp:179
+msgid "Unicode 8 bit (UTF-8)"
+msgstr "ترميزموحد 8 بت (UTF-8)"
+
+#: ../src/common/fmapbase.cpp:181 ../src/common/fmapbase.cpp:187
+msgid "Unicode 16 bit (UTF-16)"
+msgstr "ترميزموحد 16 بت (UTF-16)"
+
+#: ../src/common/fmapbase.cpp:182
+msgid "Unicode 16 bit Little Endian (UTF-16LE)"
+msgstr "ترميزموحد 16 بت طرف صغير (UTF-16LE)"
+
+#: ../src/common/fmapbase.cpp:183 ../src/common/fmapbase.cpp:189
+msgid "Unicode 32 bit (UTF-32)"
+msgstr "ترميزموحد 32 بت (UTF-32)"
+
+#: ../src/common/fmapbase.cpp:184
+msgid "Unicode 32 bit Little Endian (UTF-32LE)"
+msgstr "ترميزموحد 32 بت طرف صغير (UTF-32LE)"
+
+#: ../src/common/fmapbase.cpp:186
+msgid "Unicode 16 bit Big Endian (UTF-16BE)"
+msgstr "ترميزموحد 16 بت طرف كبير (UTF-16BE)"
+
+#: ../src/common/fmapbase.cpp:188
+msgid "Unicode 32 bit Big Endian (UTF-32BE)"
+msgstr "ترميزموحد 32 بت طرف كبير (UTF-32BE)"
+
+#: ../src/common/fmapbase.cpp:191
+msgid "Extended Unix Codepage for Japanese (EUC-JP)"
+msgstr "صفحة ترميز يونكس موسعة لليابانية (EUC-JP)"
+
+#: ../src/common/fmapbase.cpp:192
+msgid "US-ASCII"
+msgstr "ASCII-امريكي"
+
+#: ../src/common/fmapbase.cpp:193
+msgid "ISO-2022-JP"
+msgstr "آيزو-2022-يابانية"
+
+#: ../src/common/fmapbase.cpp:195
+msgid "MacRoman"
+msgstr "رومانيةماك"
+
+#: ../src/common/fmapbase.cpp:196
+msgid "MacJapanese"
+msgstr "يابانيةماك"
+
+#: ../src/common/fmapbase.cpp:197
+msgid "MacChineseTrad"
+msgstr "صينيةتقليديةماك"
+
+#: ../src/common/fmapbase.cpp:198
+msgid "MacKorean"
+msgstr "كوريةماك"
+
+#: ../src/common/fmapbase.cpp:199
+msgid "MacArabic"
+msgstr "عربيةماك"
+
+#: ../src/common/fmapbase.cpp:200
+msgid "MacHebrew"
+msgstr "عبريةماك"
+
+#: ../src/common/fmapbase.cpp:201
+msgid "MacGreek"
+msgstr "يونانيةماك"
+
+#: ../src/common/fmapbase.cpp:202
+msgid "MacCyrillic"
+msgstr "سيريليةماك"
+
+#: ../src/common/fmapbase.cpp:203
+msgid "MacDevanagari"
+msgstr "دفانغاريةماك"
+
+#: ../src/common/fmapbase.cpp:204
+msgid "MacGurmukhi"
+msgstr "غورموخيةماك"
+
+#: ../src/common/fmapbase.cpp:205
+msgid "MacGujarati"
+msgstr "غوجوراتيةماك"
+
+#: ../src/common/fmapbase.cpp:206
+msgid "MacOriya"
+msgstr "أوريةماك"
+
+#: ../src/common/fmapbase.cpp:207
+msgid "MacBengali"
+msgstr "بنغاليةماك"
+
+#: ../src/common/fmapbase.cpp:208
+msgid "MacTamil"
+msgstr "تاميليةماك"
+
+#: ../src/common/fmapbase.cpp:209
+msgid "MacTelugu"
+msgstr "تولوغيةماك"
+
+#: ../src/common/fmapbase.cpp:210
+msgid "MacKannada"
+msgstr "كاناديةماك"
+
+#: ../src/common/fmapbase.cpp:211
+msgid "MacMalayalam"
+msgstr "مالايالاميةماك"
+
+#: ../src/common/fmapbase.cpp:212
+msgid "MacSinhalese"
+msgstr "سنهاليةماك"
+
+#: ../src/common/fmapbase.cpp:213
+msgid "MacBurmese"
+msgstr "بروميةماك"
+
+#: ../src/common/fmapbase.cpp:214
+msgid "MacKhmer"
+msgstr "خميريةماك"
+
+#: ../src/common/fmapbase.cpp:215
+msgid "MacThai"
+msgstr "تايلنديةماك"
+
+#: ../src/common/fmapbase.cpp:216
+msgid "MacLaotian"
+msgstr "لاويةماك"
+
+#: ../src/common/fmapbase.cpp:217
+msgid "MacGeorgian"
+msgstr "جورجيةماك"
+
+#: ../src/common/fmapbase.cpp:218
+msgid "MacArmenian"
+msgstr "أرمينيةماك"
+
+#: ../src/common/fmapbase.cpp:219
+msgid "MacChineseSimp"
+msgstr "صينيةمبسطةماك"
+
+#: ../src/common/fmapbase.cpp:220
+msgid "MacTibetan"
+msgstr "تبتيةماك"
+
+#: ../src/common/fmapbase.cpp:221
+msgid "MacMongolian"
+msgstr "منغوليةماك"
+
+#: ../src/common/fmapbase.cpp:222
+msgid "MacEthiopic"
+msgstr "اثيوبيةماك"
+
+#: ../src/common/fmapbase.cpp:223
+msgid "MacCentralEurRoman"
+msgstr "رومانيةوسطأوربيةماك"
+
+#: ../src/common/fmapbase.cpp:224
+msgid "MacVietnamese"
+msgstr "فيتناميةماك"
+
+#: ../src/common/fmapbase.cpp:225
+msgid "MacExtArabic"
+msgstr "عربيةموسعةماك"
+
+#: ../src/common/fmapbase.cpp:226
+msgid "MacSymbol"
+msgstr "رموزماك"
+
+#: ../src/common/fmapbase.cpp:227
+msgid "MacDingbats"
+msgstr "محارف زينةماك"
+
+#: ../src/common/fmapbase.cpp:228
+msgid "MacTurkish"
+msgstr "تركيةماك"
+
+#: ../src/common/fmapbase.cpp:229
+msgid "MacCroatian"
+msgstr "كرواتيةماك"
+
+#: ../src/common/fmapbase.cpp:230
+msgid "MacIcelandic"
+msgstr "آيسلنديةماك"
+
+#: ../src/common/fmapbase.cpp:231
+msgid "MacRomanian"
+msgstr "رومانيةماك"
+
+#: ../src/common/fmapbase.cpp:232
+msgid "MacCeltic"
+msgstr "سلتيةماك"
+
+#: ../src/common/fmapbase.cpp:233
+msgid "MacGaelic"
+msgstr "غاليكيةماك"
+
+#: ../src/common/fmapbase.cpp:234
+msgid "MacKeyboardGlyphs"
+msgstr "تعانقات لوحةمفاتيح ماك"
+
+#: ../src/common/fmapbase.cpp:791
+msgid "Default encoding"
+msgstr "ترميز مبدئي"
+
+#: ../src/common/fmapbase.cpp:805
+#, c-format
+msgid "Unknown encoding (%d)"
+msgstr "ترميز مجهول (%d)"
+
+#: ../src/common/fmapbase.cpp:815 ../src/richtext/richtextstyles.cpp:776
+msgid "default"
+msgstr "مبدئي"
+
+#: ../src/common/fmapbase.cpp:829
+#, c-format
+msgid "unknown-%d"
+msgstr "مجهول-%d"
+
+#: ../src/common/fontcmn.cpp:924 ../src/common/fontcmn.cpp:1130
+msgid "underlined"
+msgstr "تحته خط"
+
+#: ../src/common/fontcmn.cpp:929
+msgid " strikethrough"
+msgstr " شطب"
+
+#: ../src/common/fontcmn.cpp:942
+msgid " thin"
+msgstr " نحيف"
+
+#: ../src/common/fontcmn.cpp:946
+msgid " extra light"
+msgstr " فاتح زيادة"
+
+#: ../src/common/fontcmn.cpp:950
+msgid " light"
+msgstr " فاتح"
+
+#: ../src/common/fontcmn.cpp:954
+msgid " medium"
+msgstr " متوسط"
+
+#: ../src/common/fontcmn.cpp:958
+msgid " semi bold"
+msgstr " شبه عريض"
+
+#: ../src/common/fontcmn.cpp:962
+msgid " bold"
+msgstr " عريض"
+
+#: ../src/common/fontcmn.cpp:966
+msgid " extra bold"
+msgstr " عريض زيادة"
+
+#: ../src/common/fontcmn.cpp:970
+msgid " heavy"
+msgstr " ثقيل"
+
+#: ../src/common/fontcmn.cpp:974
+msgid " extra heavy"
+msgstr " ثقيل زيادة"
+
+#: ../src/common/fontcmn.cpp:990
+msgid " italic"
+msgstr " مائل"
+
+#: ../src/common/fontcmn.cpp:1134
+msgid "strikethrough"
+msgstr "شطب"
+
+#: ../src/common/fontcmn.cpp:1143
+msgid "thin"
+msgstr "نحيف"
+
+#: ../src/common/fontcmn.cpp:1156
+msgid "extralight"
+msgstr "فاتح‌زيادة"
+
+#: ../src/common/fontcmn.cpp:1161
+msgid "light"
+msgstr "فاتح"
+
+#: ../src/common/fontcmn.cpp:1169 ../src/richtext/richtextstyles.cpp:775
+msgid "normal"
+msgstr "اعتيادي"
+
+#: ../src/common/fontcmn.cpp:1174
+msgid "medium"
+msgstr "متوسط"
+
+#: ../src/common/fontcmn.cpp:1179 ../src/common/fontcmn.cpp:1199
+msgid "semibold"
+msgstr "شبه‌عريض"
+
+#: ../src/common/fontcmn.cpp:1184
+msgid "bold"
+msgstr "عريض"
+
+#: ../src/common/fontcmn.cpp:1194
+msgid "extrabold"
+msgstr "عريض‌زيادة"
+
+#: ../src/common/fontcmn.cpp:1204
+msgid "heavy"
+msgstr "ثقيل"
+
+#: ../src/common/fontcmn.cpp:1212
+msgid "extraheavy"
+msgstr "ثقيل‌زيادة"
+
+#: ../src/common/fontcmn.cpp:1217
+msgid "italic"
+msgstr "مائل"
+
+#: ../src/common/fontmap.cpp:195
+msgid ": unknown charset"
+msgstr ": طقم محارف مجهول"
+
+#: ../src/common/fontmap.cpp:199
+#, c-format
+msgid ""
+"The charset '%s' is unknown. You may select\n"
+"another charset to replace it with or choose\n"
+"[Cancel] if it cannot be replaced"
+msgstr ""
+"طقم المحارف '%s' مجهول. يمكنك اختيار\n"
+"طقم محارف آخر لتستبدله به او تختار\n"
+"[ألغِ] إذا لم يمكن استبداله"
+
+#: ../src/common/fontmap.cpp:241
+#, c-format
+msgid "Failed to remember the encoding for the charset '%s'."
+msgstr "أخفق استذكار الترميز لطقم المحارف '%s'."
+
+#: ../src/common/fontmap.cpp:321
+msgid "can't load any font, aborting"
+msgstr "تعذّر تحميل أي خط، يترك الأمر"
+
+#: ../src/common/fontmap.cpp:409
+msgid ": unknown encoding"
+msgstr ": ترميز مجهول"
+
+#: ../src/common/fontmap.cpp:417
+#, c-format
+msgid ""
+"No font for displaying text in encoding '%s' found,\n"
+"but an alternative encoding '%s' is available.\n"
+"Do you want to use this encoding (otherwise you will have to choose another "
+"one)?"
+msgstr ""
+"لم يعثر على خط لعَرض النص بالترميز '%s'.\n"
+"يتوفر '%s' كترميز بديل.\n"
+"أتريد استخدام هذا الترميز (وإلا سيتعين عليك اختيار ترميز آخر)؟"
+
+#: ../src/common/fontmap.cpp:422
+#, c-format
+msgid ""
+"No font for displaying text in encoding '%s' found.\n"
+"Would you like to select a font to be used for this encoding\n"
+"(otherwise the text in this encoding will not be shown correctly)?"
+msgstr ""
+"لم يعثر على خط لعَرض النص بالترميز '%s'.\n"
+"أترغب في تحديد خط ليُستخدم لهذا الترميز\n"
+"(وإلا فلن يظهر النص بصورة صحيحة في هذا الترميز)؟"
+
+#: ../src/common/fs_mem.cpp:169
+#, c-format
+msgid "Memory VFS already contains file '%s'!"
+msgstr "نظام الملفات الافتراضي للذاكرة يحوي سلفًا الملف ’%s‘!"
+
+#: ../src/common/fs_mem.cpp:232
+#, c-format
+msgid "Trying to remove file '%s' from memory VFS, but it is not loaded!"
+msgstr ""
+"يحاول غزالة الملف ’%s‘ من نظام الملفات الافتراضي للذاكرة، لكنه غير محمَّل!"
+
+#: ../src/common/fs_mem.cpp:262
+#, c-format
+msgid "Failed to store image '%s' to memory VFS!"
+msgstr "أخفق خزن الصورة ’%s‘ في نظام الملفات الافتراضي للذاكرة!"
+
+#: ../src/common/ftp.cpp:197
+msgid "Timeout while waiting for FTP server to connect, try passive mode."
+msgstr "انقضى الوقت أثناء الانتظار ليتصل خادوم FTP، جرب الوضع غير المباشر."
+
+#: ../src/common/ftp.cpp:399
+#, c-format
+msgid "Failed to set FTP transfer mode to %s."
+msgstr "أخفق إعداد وضع نقل FTP الى %s."
+
+#: ../src/common/ftp.cpp:400 ../src/richtext/richtextsymboldlg.cpp:432
+msgid "ASCII"
+msgstr "أسكي"
+
+#: ../src/common/ftp.cpp:400
+msgid "binary"
+msgstr "ثنائي"
+
+#: ../src/common/ftp.cpp:608
+msgid "The FTP server doesn't support the PORT command."
+msgstr "خادوم FTP لا يدعم الأمر PORT."
+
+#: ../src/common/ftp.cpp:622
+msgid "The FTP server doesn't support passive mode."
+msgstr "خادوم FTP لا يدعم الوضع غير المباشر."
+
+#: ../src/common/gifdecod.cpp:822
+#, c-format
+msgid "Incorrect GIF frame size (%u, %d) for the frame #%u"
+msgstr "حجم إطار غير صحيح لملف GIF ‏(‏‎%u، ‎%d) للإطار #%u"
+
+#: ../src/common/glcmn.cpp:108
+msgid "Failed to allocate colour for OpenGL"
+msgstr "أخفق تخصيص لون لـ OpenGL"
+
+#: ../src/common/headerctrlcmn.cpp:57
+msgid "Please select the columns to show and define their order:"
+msgstr "لطفا حدد الأعمدة التي ستظهر وعرّف ترتيبها:"
+
+#: ../src/common/headerctrlcmn.cpp:58
+msgid "Customize Columns"
+msgstr "خصص الأعمدة"
+
+#: ../src/common/headerctrlcmn.cpp:304
+msgid "&Customize..."
+msgstr "&خصص..."
+
+#: ../src/common/hyperlnkcmn.cpp:132
+#, c-format
+msgid "Failed to open URL \"%s\" in the default browser"
+msgstr "أخفق فتح الرابط \"%s\" في المتصفح الافتراضي"
+
+#: ../src/common/iconbndl.cpp:195
+#, c-format
+msgid "Failed to load image %%d from file '%s'."
+msgstr "تعذّر تحميل الصورة %%d من الملف '%s'."
+
+#: ../src/common/iconbndl.cpp:203
+#, c-format
+msgid "Failed to load image %d from stream."
+msgstr "تعذّر تحميل الصورة %d من الدفق."
+
+#: ../src/common/iconbndl.cpp:221
+#, c-format
+msgid "Failed to load icons from resource '%s'."
+msgstr "تعذّر تحميل الأيقونات من المورد '%s'."
+
+#: ../src/common/imagbmp.cpp:97
+msgid "BMP: Couldn't save invalid image."
+msgstr "BMP: لا يمكن حفظ صورة تالفة."
+
+#: ../src/common/imagbmp.cpp:137
+msgid "BMP: wxImage doesn't have own wxPalette."
+msgstr "BMP‏: wxImage ليس لديها wxPalette خاص بها."
+
+#: ../src/common/imagbmp.cpp:243
+msgid "BMP: Couldn't write the file (Bitmap) header."
+msgstr "BMP: لا يمكن كتابة الملف (Bitmap) رأس."
+
+#: ../src/common/imagbmp.cpp:266
+msgid "BMP: Couldn't write the file (BitmapInfo) header."
+msgstr "BMP: لا يمكن كتابة الملف (BitmapInfo) رأس."
+
+#: ../src/common/imagbmp.cpp:353
+msgid "BMP: Couldn't write RGB color map."
+msgstr "BMP: لا يمكن كتابة خريطة لون RGB."
+
+#: ../src/common/imagbmp.cpp:487
+msgid "BMP: Couldn't write data."
+msgstr "BMP: لا يمكن كتابة بيانات."
+
+#: ../src/common/imagbmp.cpp:561 ../src/common/imagbmp.cpp:642
+msgid "BMP: Couldn't allocate memory."
+msgstr "BMP: لا يمكن تحديد الذاكرة."
+
+#: ../src/common/imagbmp.cpp:1041
+msgid "DIB Header: Image width > 32767 pixels for file."
+msgstr "ترويسة DIB: عُرض الصورة > 32767 بكسل للملف."
+
+#: ../src/common/imagbmp.cpp:1049
+msgid "DIB Header: Image height > 32767 pixels for file."
+msgstr "ترويسة DIB: ارتفاع الصورة > 32767 بكسل للملف."
+
+#: ../src/common/imagbmp.cpp:1081
+msgid "DIB Header: Unknown bitdepth in file."
+msgstr "ترويسة DIB: عُمق بت مجهول في الملف."
+
+#: ../src/common/imagbmp.cpp:1156
+msgid "DIB Header: Unknown encoding in file."
+msgstr "ترويسة DIB: ترميز مجهول في الملف."
+
+#: ../src/common/imagbmp.cpp:1165
+msgid "DIB Header: Encoding doesn't match bitdepth."
+msgstr "ترويسة DIB: الترميز لا يطابق عُمق البت."
+
+#: ../src/common/imagbmp.cpp:1180
+#, c-format
+msgid "BMP Header: Invalid number of colors (%d)."
+msgstr ""
+
+#: ../src/common/imagbmp.cpp:1273
+msgid "Error in reading image DIB."
+msgstr "خطأ في قراءة DIB الصورة."
+
+#: ../src/common/imagbmp.cpp:1294
+msgid "ICO: Error in reading mask DIB."
+msgstr "ملف ICO: خطأ في قراءة DIB القناع."
+
+#: ../src/common/imagbmp.cpp:1353
+msgid "ICO: Image too tall for an icon."
+msgstr "ملف ICO: الصورة طويلة جداً لأن تكون أيقونة."
+
+#: ../src/common/imagbmp.cpp:1361
+msgid "ICO: Image too wide for an icon."
+msgstr "ملف ICO: الصورة عريضة جداً لأن تكون أيقونة."
+
+#: ../src/common/imagbmp.cpp:1388 ../src/common/imagbmp.cpp:1488
+#: ../src/common/imagbmp.cpp:1503 ../src/common/imagbmp.cpp:1514
+#: ../src/common/imagbmp.cpp:1528 ../src/common/imagbmp.cpp:1576
+#: ../src/common/imagbmp.cpp:1591 ../src/common/imagbmp.cpp:1605
+#: ../src/common/imagbmp.cpp:1616
+msgid "ICO: Error writing the image file!"
+msgstr "ملف ICO: خطأ في كتابة ملف الصورة!"
+
+#: ../src/common/imagbmp.cpp:1701
+msgid "ICO: Invalid icon index."
+msgstr "ملف ICO: فهرس الأيقونة غير صحيح."
+
+#: ../src/common/image.cpp:2410
+msgid "Image and mask have different sizes."
+msgstr "للصورة والقناع حجمان مختلفان."
+
+#: ../src/common/image.cpp:2418 ../src/common/image.cpp:2459
+msgid "No unused colour in image being masked."
+msgstr "ليس هناك لون غير مستخدَم في الصورة مقنَّع."
+
+#: ../src/common/image.cpp:2641
+#, c-format
+msgid "Failed to load bitmap \"%s\" from resources."
+msgstr "أخفق تحميل صورة بت ماب \"%s\" من الموارد."
+
+#: ../src/common/image.cpp:2650
+#, c-format
+msgid "Failed to load icon \"%s\" from resources."
+msgstr "أخفق تحميل صورة الأيقونة \"%s\" من الموارد."
+
+#: ../src/common/image.cpp:2728 ../src/common/image.cpp:2747
+#, c-format
+msgid "Failed to load image from file \"%s\"."
+msgstr "أخفق تحميل الصورة من الملف \"%s\"."
+
+#: ../src/common/image.cpp:2761
+#, c-format
+msgid "Can't save image to file '%s': unknown extension."
+msgstr "لا يمكن حفظ الصورة بالملف '%s': الامتداد مجهول."
+
+#: ../src/common/image.cpp:2869
+msgid "No handler found for image type."
+msgstr "لم يُعثر على متولٍ لنوع الصورة."
+
+#: ../src/common/image.cpp:2877 ../src/common/image.cpp:3000
+#: ../src/common/image.cpp:3066
+#, c-format
+msgid "No image handler for type %d defined."
+msgstr "لم يُعرَّف متولي صورة للنوع %d."
+
+#: ../src/common/image.cpp:2887
+#, c-format
+msgid "Image file is not of type %d."
+msgstr "ملف الصورة ليس من نوع %d."
+
+#: ../src/common/image.cpp:2970
+msgid "Can't automatically determine the image format for non-seekable input."
+msgstr "يتعذّر تحديد نسَق الصورة آليًا للإدخال غير القابل للقصد."
+
+#: ../src/common/image.cpp:2988
+msgid "Unknown image data format."
+msgstr "نسَق بيانات الصورة مجهول."
+
+#: ../src/common/image.cpp:3009
+#, c-format
+msgid "This is not a %s."
+msgstr "هذا ليس %s."
+
+#: ../src/common/image.cpp:3032 ../src/common/image.cpp:3080
+#, c-format
+msgid "No image handler for type %s defined."
+msgstr "لم يُعرَّف متولي صورة للنوع %s."
+
+#: ../src/common/image.cpp:3041
+#, c-format
+msgid "Image is not of type %s."
+msgstr "الصورة ليست من نوع %s."
+
+#: ../src/common/image.cpp:3509
+#, c-format
+msgid "Failed to check format of image file \"%s\"."
+msgstr "أخفق التحقق من نسَق ملف الصورة \"%s\"."
+
+#: ../src/common/imaggif.cpp:124
+msgid "GIF: error in GIF image format."
+msgstr "صورة GIF: خطأ في نسَق صورة GIF."
+
+#: ../src/common/imaggif.cpp:129
+msgid "GIF: not enough memory."
+msgstr "صورة GIF: ليس هناك ذاكرة كافية."
+
+#: ../src/common/imaggif.cpp:134
+msgid "GIF: data stream seems to be truncated."
+msgstr "صورة GIF: يبدو أنّ دفق البيانات مبتور."
+
+#: ../src/common/imaggif.cpp:240
+msgid "Couldn't initialize GIF hash table."
+msgstr "تعذّر تجهيز جدول خلط hash لـ GIF."
+
+#: ../src/common/imagiff.cpp:739
+msgid "IFF: error in IFF image format."
+msgstr "صورة IFF: خطأ في نسَق صورة IFF."
+
+#: ../src/common/imagiff.cpp:742
+msgid "IFF: not enough memory."
+msgstr "صورة IFF: ليس هناك ذاكرة كافية."
+
+#: ../src/common/imagiff.cpp:745
+msgid "IFF: unknown error!!!"
+msgstr "صورة IFF: خطأ مجهول!!!"
+
+#: ../src/common/imagiff.cpp:755
+msgid "IFF: data stream seems to be truncated."
+msgstr "صورة IFF: يبدو أنّ دفق البيانات مبتور."
+
+#: ../src/common/imagjpeg.cpp:258
+msgid "JPEG: Couldn't load - file is probably corrupted."
+msgstr "صورة JPEG: تعذّر التحميل - من المرجح أن يكون الملف تالفًا."
+
+#: ../src/common/imagjpeg.cpp:437
+msgid "JPEG: Couldn't save image."
+msgstr "صورة JPEG: تعذّر حفظ الصورة."
+
+#: ../src/common/imagpcx.cpp:439
+msgid "PCX: this is not a PCX file."
+msgstr "صورة PCX: هذا ليس ملف PCX."
+
+#: ../src/common/imagpcx.cpp:453
+msgid "PCX: image format unsupported"
+msgstr "صورة PCX: نسَق الصورة غير مدعوم"
+
+#: ../src/common/imagpcx.cpp:454 ../src/common/imagpcx.cpp:477
+msgid "PCX: couldn't allocate memory"
+msgstr "صورة PCX: تعذّر تخصيص ذاكرة"
+
+#: ../src/common/imagpcx.cpp:455
+msgid "PCX: version number too low"
+msgstr "صورة PCX: رقم الإصدار قليل جداً"
+
+#: ../src/common/imagpcx.cpp:456 ../src/common/imagpcx.cpp:478
+msgid "PCX: unknown error !!!"
+msgstr "صورة PCX: خطأ مجهول !!!"
+
+#: ../src/common/imagpcx.cpp:476
+msgid "PCX: invalid image"
+msgstr "صورة PCX: صورة غير صحيحة"
+
+#: ../src/common/imagpng.cpp:385
+#, c-format
+msgid "Unknown PNG resolution unit %d"
+msgstr "وحدة ميْز PNG مجهولة %d"
+
+#: ../src/common/imagpng.cpp:439
+msgid "Couldn't load a PNG image - file is corrupted or not enough memory."
+msgstr "تعذّر تحميل صورة png - الملف تالف أو ليس هناك ذاكرة كافية."
+
+#: ../src/common/imagpng.cpp:513 ../src/common/imagpng.cpp:524
+#: ../src/common/imagpng.cpp:534
+msgid "Couldn't save PNG image."
+msgstr "تعذّر حفظ صورة PNG."
+
+#: ../src/common/imagpnm.cpp:71
+msgid "PNM: File format is not recognized."
+msgstr "نسَق PNM: لا يمكن التعرف على نسَق الملف."
+
+#: ../src/common/imagpnm.cpp:89
+msgid "PNM: Couldn't allocate memory."
+msgstr "نسَق PNM: تعذّر تخصيص ذاكرة."
+
+#: ../src/common/imagpnm.cpp:111 ../src/common/imagpnm.cpp:134
+#: ../src/common/imagpnm.cpp:156
+msgid "PNM: File seems truncated."
+msgstr "نسَق PNM: يبدو أنّ الملف مبتور."
+
+#: ../src/common/imagtiff.cpp:69
+#, c-format
+msgid " (in module \"%s\")"
+msgstr " (في الوحدة \"%s\")"
+
+#: ../src/common/imagtiff.cpp:304
+msgid "TIFF: Error loading image."
+msgstr "صورة TIFF: خطأ في تحميل الصورة."
+
+#: ../src/common/imagtiff.cpp:314
+msgid "Invalid TIFF image index."
+msgstr "فهوس صورة TIFF غير صحيح."
+
+#: ../src/common/imagtiff.cpp:358
+msgid "TIFF: Image size is abnormally big."
+msgstr "صورة TIFF: حجم الصورة كبير بشكل غير طبيعي."
+
+#: ../src/common/imagtiff.cpp:372 ../src/common/imagtiff.cpp:385
+#: ../src/common/imagtiff.cpp:769
+msgid "TIFF: Couldn't allocate memory."
+msgstr "صورة TIFF: تعذّر تخصيص ذاكرة."
+
+#: ../src/common/imagtiff.cpp:471
+msgid "TIFF: Error reading image."
+msgstr "صورة TIFF: خطأ في قراءة الصورة."
+
+#: ../src/common/imagtiff.cpp:532
+#, c-format
+msgid "Unknown TIFF resolution unit %d ignored"
+msgstr "أُهملَت وحدة ميْز TIFF غير المعروفة %d"
+
+#: ../src/common/imagtiff.cpp:611
+msgid "TIFF: Error saving image."
+msgstr "صورة TIFF: خطأ في حفظ الصورة."
+
+#: ../src/common/imagtiff.cpp:868
+msgid "TIFF: Error writing image."
+msgstr "صورة TIFF: خطأ في كتابة الصورة."
+
+#: ../src/common/imagtiff.cpp:881
+msgid "TIFF: Error flushing data."
+msgstr "صورة TIFF: خطأ في كسح البيانات."
+
+#: ../src/common/imagwebp.cpp:56
+msgid "WebP: Invalid data (failed to get features)."
+msgstr ""
+
+#: ../src/common/imagwebp.cpp:65
+msgid "WebP: Allocating image memory failed."
+msgstr ""
+
+#: ../src/common/imagwebp.cpp:82
+msgid "WebP: Decoding RGBA image data failed."
+msgstr ""
+
+#: ../src/common/imagwebp.cpp:98
+msgid "WebP: Decoding RGB image data failed."
+msgstr ""
+
+#: ../src/common/imagwebp.cpp:113 ../src/common/imagwebp.cpp:201
+msgid "WebP: Allocating stream buffer failed."
+msgstr ""
+
+#: ../src/common/imagwebp.cpp:131
+#, fuzzy
+msgid "WebP: Failed to parse container data."
+msgstr "فشل إعداد بيانات الحافظة."
+
+#: ../src/common/imagwebp.cpp:222
+#, fuzzy
+msgid "WebP: Error decoding animation."
+msgstr "خطأ عند قراءة خيارات التكوين."
+
+#: ../src/common/imagwebp.cpp:240
+msgid "WebP: Error getting next animation frame."
+msgstr ""
+
+#: ../src/common/init.cpp:172
+#, c-format
+msgid ""
+"Command line argument %d couldn't be converted to Unicode and will be "
+"ignored."
+msgstr "تعذّر تحويل مُعامِل سطر الأوامر %d إلى الترميز الموحد وسيُتجاهَل."
+
+#: ../src/common/init.cpp:344
+msgid "Initialization failed in post init, aborting."
+msgstr "أخفق التجهيز في post init، يترك الأمر."
+
+#: ../src/common/intl.cpp:378
+#, c-format
+msgid "Cannot set locale to language \"%s\"."
+msgstr "تعذّر إعداد المحلية إلى اللغة \"%s\"."
+
+#: ../src/common/log.cpp:232
+msgid "Error: "
+msgstr "خطأ: "
+
+#: ../src/common/log.cpp:236
+msgid "Warning: "
+msgstr "تحذير: "
+
+#: ../src/common/log.cpp:284
+msgid "The previous message repeated once."
+msgstr "كُررت الرسالة السابقة مرة واحدة."
+
+#: ../src/common/log.cpp:291
+#, c-format
+msgid "The previous message repeated %u time."
+msgid_plural "The previous message repeated %u times."
+msgstr[0] "لم تُكرر الرسالة السابقة."
+msgstr[1] "كُررت الرسالة السابقة مرة واحدة."
+msgstr[2] "كُررت الرسالة السابقة مرتين."
+msgstr[3] "كُررت الرسالة السابقة %u مرات."
+msgstr[4] "كُررت الرسالة السابقة %u مرةً."
+msgstr[5] "كُررت الرسالة السابقة %u مرةٍ."
+
+#: ../src/common/log.cpp:319
+#, c-format
+msgid "Last repeated message (\"%s\", %u time) wasn't output"
+msgid_plural "Last repeated message (\"%s\", %u times) wasn't output"
+msgstr[0] "لم تُخرَج آخر رسالة مكررة (\"%s\"، لم تُكرر)"
+msgstr[1] "لم تُخرَج آخر رسالة مكررة (\"%s\"، مرة واحدة)"
+msgstr[2] "لم تُخرَج آخر رسالة مكررة (\"%s\"، مرتين)"
+msgstr[3] "لم تُخرَج آخر رسالة مكررة (\"%s‏\"، %u مرات)"
+msgstr[4] "لم تُخرَج آخر رسالة مكررة (\"%s‏\"، %u مرةً)"
+msgstr[5] "لم تُخرَج آخر رسالة مكررة (\"%s‏\"، %u مرةٍ)"
+
+#: ../src/common/log.cpp:435
+#, c-format
+msgid " (error %ld: %s)"
+msgstr " (خطأ %ld: %s)"
+
+#: ../src/common/lzmastream.cpp:121
+msgid "Failed to allocate memory for LZMA decompression."
+msgstr "أخفق تخصيص ذاكرة لفك ضغط LZMA."
+
+#: ../src/common/lzmastream.cpp:125
+#, c-format
+msgid "Failed to initialize LZMA decompression: unexpected error %u."
+msgstr "أخفق تجهيز إزالة ضغط LZMA: خطأ غير متوقع %u."
+
+#: ../src/common/lzmastream.cpp:179
+msgid "input is not in XZ format"
+msgstr "المُدخَلات ليست بنسق XZ"
+
+#: ../src/common/lzmastream.cpp:183
+msgid "input compressed using unknown XZ option"
+msgstr "المُدخَلات مضغوطة باستخدام خيار XZ مجهول"
+
+#: ../src/common/lzmastream.cpp:188
+msgid "input is corrupted"
+msgstr "الإدخال تالف"
+
+#: ../src/common/lzmastream.cpp:192
+msgid "unknown decompression error"
+msgstr "خطأ فك ضغط مجهول"
+
+#: ../src/common/lzmastream.cpp:196
+#, c-format
+msgid "LZMA decompression error: %s"
+msgstr "خطأ في فك ضغط LZMA‏: %s"
+
+#: ../src/common/lzmastream.cpp:231
+msgid "Failed to allocate memory for LZMA compression."
+msgstr "أخفق تخصيص ذاكرة لضغط LZMA."
+
+#: ../src/common/lzmastream.cpp:235
+#, c-format
+msgid "Failed to initialize LZMA compression: unexpected error %u."
+msgstr "أخفق تجهيز ضغط LZMA: خطأ غير متوقع %u."
+
+#: ../src/common/lzmastream.cpp:267 ../src/common/lzmastream.cpp:342
+#: ../src/html/chm.cpp:336
+msgid "out of memory"
+msgstr "نفذت الذّاكرة"
+
+#: ../src/common/lzmastream.cpp:276 ../src/common/lzmastream.cpp:346
+msgid "unknown compression error"
+msgstr "خطأ ضغط مجهول"
+
+#: ../src/common/lzmastream.cpp:280
+#, c-format
+msgid "LZMA compression error: %s"
+msgstr "خطأ في ضغط LZMA: %s"
+
+#: ../src/common/lzmastream.cpp:350
+#, c-format
+msgid "LZMA compression error when flushing output: %s"
+msgstr "خطأ في ضغط LZMA عند كسح الإخراج: %s"
+
+#: ../src/common/mimecmn.cpp:167
+#, c-format
+msgid "Unmatched '{' in an entry for mime type %s."
+msgstr "رمز ’‎{‎‘ غير مطابَق في مُدخَلة لنوع نقل الملفات %s."
+
+#: ../src/common/module.cpp:76
+#, c-format
+msgid "Circular dependency involving module \"%s\" detected."
+msgstr "كُشفت تبعية حلقية تتضمن الوحدة \"%s\"."
+
+#: ../src/common/module.cpp:128
+#, c-format
+msgid "Dependency \"%s\" of module \"%s\" doesn't exist."
+msgstr "التبعية \"%s\" للوحدة \"%s\" غير موجودة."
+
+#: ../src/common/module.cpp:137
+#, c-format
+msgid "Module \"%s\" initialization failed"
+msgstr "أخفق تجهيز الوحدة \"%s\""
+
+#: ../src/common/msgout.cpp:96
+msgid "Message"
+msgstr "الرسالة"
+
+#: ../src/common/paper.cpp:70
+msgid "Letter, 8 1/2 x 11 in"
+msgstr "رسالة، 1/2 8 × 11 بوصة"
+
+#: ../src/common/paper.cpp:71
+msgid "Legal, 8 1/2 x 14 in"
+msgstr "رسمي، 1/2 8 × 14 بوصة"
+
+#: ../src/common/paper.cpp:72
+msgid "A4 sheet, 210 x 297 mm"
+msgstr "ورقة أي4، 210 × 297 مم"
+
+#: ../src/common/paper.cpp:73
+msgid "C sheet, 17 x 22 in"
+msgstr "ورقة سي، 17 × 22 بوصة"
+
+#: ../src/common/paper.cpp:74
+msgid "D sheet, 22 x 34 in"
+msgstr "ورقة دي، 22 × 34 بوصة"
+
+#: ../src/common/paper.cpp:75
+msgid "E sheet, 34 x 44 in"
+msgstr "ورقة إي، 34 × 44 بوصة"
+
+#: ../src/common/paper.cpp:76
+msgid "Letter Small, 8 1/2 x 11 in"
+msgstr "رسالة صغيرة، 1/2 8 × 11 بوصة"
+
+#: ../src/common/paper.cpp:77
+msgid "Tabloid, 11 x 17 in"
+msgstr "صحيفة مصغرة، 11 × 17 بوصة"
+
+#: ../src/common/paper.cpp:78
+msgid "Ledger, 17 x 11 in"
+msgstr "سجلّ، 17 × 11 بوصة"
+
+#: ../src/common/paper.cpp:79
+msgid "Statement, 5 1/2 x 8 1/2 in"
+msgstr "بيان، 1/2 5 × 1/2 8 بوصة"
+
+#: ../src/common/paper.cpp:80
+msgid "Executive, 7 1/4 x 10 1/2 in"
+msgstr "تنفيذي، 1/4 7 × 1/2 10 بوصة"
+
+#: ../src/common/paper.cpp:81
+msgid "A3 sheet, 297 x 420 mm"
+msgstr "ورقة أي3، 297 × 420 مم"
+
+#: ../src/common/paper.cpp:82
+msgid "A4 small sheet, 210 x 297 mm"
+msgstr "ورقة أي4 صغيرة، 210 × 297 مم"
+
+#: ../src/common/paper.cpp:83
+msgid "A5 sheet, 148 x 210 mm"
+msgstr "ورقة أي5، 148 × 210 مم"
+
+#: ../src/common/paper.cpp:84
+msgid "B4 sheet, 250 x 354 mm"
+msgstr "ورقة بي4، 250 × 354 مم"
+
+#: ../src/common/paper.cpp:85
+msgid "B5 sheet, 182 x 257 millimeter"
+msgstr "ورقة بي5، 182 × 257 ملمتر"
+
+#: ../src/common/paper.cpp:86
+msgid "Folio, 8 1/2 x 13 in"
+msgstr "مطوية، 1/2 8 × 13 بوصة"
+
+#: ../src/common/paper.cpp:87
+msgid "Quarto, 215 x 275 mm"
+msgstr "ربعي، 215 × 275 مم"
+
+#: ../src/common/paper.cpp:88
+msgid "10 x 14 in"
+msgstr "10 × 14 بوصة"
+
+#: ../src/common/paper.cpp:89
+msgid "11 x 17 in"
+msgstr "11 × 17 بوصة"
+
+#: ../src/common/paper.cpp:90
+msgid "Note, 8 1/2 x 11 in"
+msgstr "مذكّرة، 1/2 8 × 11 بوصة"
+
+#: ../src/common/paper.cpp:91
+msgid "#9 Envelope, 3 7/8 x 8 7/8 in"
+msgstr "مغلف #9، 3 7/8 × 8 7/8 بوصة"
+
+#: ../src/common/paper.cpp:92
+msgid "#10 Envelope, 4 1/8 x 9 1/2 in"
+msgstr "مغلف #10، 4 1/8 × 9 1/2 بوصة"
+
+#: ../src/common/paper.cpp:93
+msgid "#11 Envelope, 4 1/2 x 10 3/8 in"
+msgstr "مغلف #11، 4 1/2 × 10 3/8 بوصة"
+
+#: ../src/common/paper.cpp:94
+msgid "#12 Envelope, 4 3/4 x 11 in"
+msgstr "مغلف #12، 4 3/4 × 11 بوصة"
+
+#: ../src/common/paper.cpp:95
+msgid "#14 Envelope, 5 x 11 1/2 in"
+msgstr "مغلف #14، 5 × 11 1/2 بوصة"
+
+#: ../src/common/paper.cpp:96
+msgid "DL Envelope, 110 x 220 mm"
+msgstr "مغلف ط‌م DL‏، 110 × 220 مم"
+
+#: ../src/common/paper.cpp:97
+msgid "C5 Envelope, 162 x 229 mm"
+msgstr "مغلف سي5، 162 × 229 مم"
+
+#: ../src/common/paper.cpp:98
+msgid "C3 Envelope, 324 x 458 mm"
+msgstr "مغلف سي3، 324 × 458 مم"
+
+#: ../src/common/paper.cpp:99
+msgid "C4 Envelope, 229 x 324 mm"
+msgstr "مغلف سي4، 229 × 324 مم"
+
+#: ../src/common/paper.cpp:100
+msgid "C6 Envelope, 114 x 162 mm"
+msgstr "مغلف سي6، 114 × 162 مم"
+
+#: ../src/common/paper.cpp:101
+msgid "C65 Envelope, 114 x 229 mm"
+msgstr "مغلف سي65، 114 × 229 مم"
+
+#: ../src/common/paper.cpp:102
+msgid "B4 Envelope, 250 x 353 mm"
+msgstr "مغلف بي4، 250 × 353 مم"
+
+#: ../src/common/paper.cpp:103
+msgid "B5 Envelope, 176 x 250 mm"
+msgstr "مغلف بي5، 176 × 250 مم"
+
+#: ../src/common/paper.cpp:104
+msgid "B6 Envelope, 176 x 125 mm"
+msgstr "مغلف بي6، 176 × 125 مم"
+
+#: ../src/common/paper.cpp:105
+msgid "Italy Envelope, 110 x 230 mm"
+msgstr "مغلف ايطالي، 110 × 230 مم"
+
+#: ../src/common/paper.cpp:106
+msgid "Monarch Envelope, 3 7/8 x 7 1/2 in"
+msgstr "مغلف ملكي، 7/8 3 × 1/2 7 بوصة"
+
+#: ../src/common/paper.cpp:107
+msgid "6 3/4 Envelope, 3 5/8 x 6 1/2 in"
+msgstr "مغلف 3/4 6، 5/8 3 × 1/2 6 بوصة"
+
+#: ../src/common/paper.cpp:108
+msgid "US Std Fanfold, 14 7/8 x 11 in"
+msgstr "مطوية أمريكية معيارية، 7/8 14 × 11 بوصة"
+
+#: ../src/common/paper.cpp:109
+msgid "German Std Fanfold, 8 1/2 x 12 in"
+msgstr "مطوية ألمانية معيارية، 1/2 8 × 12 بوصة"
+
+#: ../src/common/paper.cpp:110
+msgid "German Legal Fanfold, 8 1/2 x 13 in"
+msgstr "مطوية ألمانية قانونية، 1/2 8 × 13 بوصة"
+
+#: ../src/common/paper.cpp:112
+msgid "B4 (ISO) 250 x 353 mm"
+msgstr "بي4 (آيزو) 250 × 353 مم"
+
+#: ../src/common/paper.cpp:113
+msgid "Japanese Postcard 100 x 148 mm"
+msgstr "بطاقة بريدية يابانية 100 × 148 مم"
+
+#: ../src/common/paper.cpp:114
+msgid "9 x 11 in"
+msgstr "9 × 11 بوصة"
+
+#: ../src/common/paper.cpp:115
+msgid "10 x 11 in"
+msgstr "10 × 11 بوصة"
+
+#: ../src/common/paper.cpp:116
+msgid "15 x 11 in"
+msgstr "15 × 11 بوصة"
+
+#: ../src/common/paper.cpp:117
+msgid "Envelope Invite 220 x 220 mm"
+msgstr "دعوة بمغلف 220 × 220 مم"
+
+#: ../src/common/paper.cpp:118
+msgid "Letter Extra 9 1/2 x 12 in"
+msgstr "رسالة بزيادة 1/2 9 × 12 بوصة"
+
+#: ../src/common/paper.cpp:119
+msgid "Legal Extra 9 1/2 x 15 in"
+msgstr "قانوني بزيادة 1/2 9 × 15 بوصة"
+
+#: ../src/common/paper.cpp:120
+msgid "Tabloid Extra 11.69 x 18 in"
+msgstr "صحيفة مصغرة بزيادة، 11.69 × 18 بوصة"
+
+#: ../src/common/paper.cpp:121
+msgid "A4 Extra 9.27 x 12.69 in"
+msgstr "أي4 زائدة، 9.27 × 12.69 بوصة"
+
+#: ../src/common/paper.cpp:122
+msgid "Letter Transverse 8 1/2 x 11 in"
+msgstr "رسالة مستعرَضة 1/2 8 × 11 بوصة"
+
+#: ../src/common/paper.cpp:123
+msgid "A4 Transverse 210 x 297 mm"
+msgstr "أي4 مستعرَض 210 × 297 مم"
+
+#: ../src/common/paper.cpp:124
+msgid "Letter Extra Transverse 9.275 x 12 in"
+msgstr "رسالة بزيادة مستعرَضة 9.275 × 12 بوصة"
+
+#: ../src/common/paper.cpp:125
+msgid "SuperA/SuperA/A4 227 x 356 mm"
+msgstr "أي فائق\\أي فائق\\أي4 227 × 356 مم"
+
+#: ../src/common/paper.cpp:126
+msgid "SuperB/SuperB/A3 305 x 487 mm"
+msgstr "بي فائق\\بي فائق\\أي3 305 × 487 مم"
+
+#: ../src/common/paper.cpp:127
+msgid "Letter Plus 8 1/2 x 12.69 in"
+msgstr "رسالة مزيدة 1/2 8 × 12.69 بوصة"
+
+#: ../src/common/paper.cpp:128
+msgid "A4 Plus 210 x 330 mm"
+msgstr "أي4 مزيد 210 × 330 مم"
+
+#: ../src/common/paper.cpp:129
+msgid "A5 Transverse 148 x 210 mm"
+msgstr "أي5 مستعرَض 148 × 210 مم"
+
+#: ../src/common/paper.cpp:130
+msgid "B5 (JIS) Transverse 182 x 257 mm"
+msgstr "بي5 (معايير يابانية) مستعرَض 182 × 257 مم"
+
+#: ../src/common/paper.cpp:131
+msgid "A3 Extra 322 x 445 mm"
+msgstr "أي3 بزيادة 322 × 445 مم"
+
+#: ../src/common/paper.cpp:132
+msgid "A5 Extra 174 x 235 mm"
+msgstr "أي5 بزيادة 174 × 235 مم"
+
+#: ../src/common/paper.cpp:133
+msgid "B5 (ISO) Extra 201 x 276 mm"
+msgstr "بي5 (آيزو) بزيادة 201 × 276 مم"
+
+#: ../src/common/paper.cpp:134
+msgid "A2 420 x 594 mm"
+msgstr "أي2 420 × 594 مم"
+
+#: ../src/common/paper.cpp:135
+msgid "A3 Transverse 297 x 420 mm"
+msgstr "أي3 مستعرَض 297 × 420 مم"
+
+#: ../src/common/paper.cpp:136
+msgid "A3 Extra Transverse 322 x 445 mm"
+msgstr "أي3 بزيادة مستعرَض 322 × 445 مم"
+
+#: ../src/common/paper.cpp:138
+msgid "Japanese Double Postcard 200 x 148 mm"
+msgstr "بطاقة بريدية يابانية مضاعَفة 200 × 148 مم"
+
+#: ../src/common/paper.cpp:139
+msgid "A6 105 x 148 mm"
+msgstr "أي6 105 × 148 مم"
+
+#: ../src/common/paper.cpp:140
+msgid "Japanese Envelope Kaku #2"
+msgstr "مغلف ياباني كاكو #2"
+
+#: ../src/common/paper.cpp:141
+msgid "Japanese Envelope Kaku #3"
+msgstr "مغلف ياباني كاكو #3"
+
+#: ../src/common/paper.cpp:142
+msgid "Japanese Envelope Chou #3"
+msgstr "مغلف ياباني جو #3"
+
+#: ../src/common/paper.cpp:143
+msgid "Japanese Envelope Chou #4"
+msgstr "مغلف ياباني جو #4"
+
+#: ../src/common/paper.cpp:144
+msgid "Letter Rotated 11 x 8 1/2 in"
+msgstr "رسالة مدورة 11 × 1/2 8 بوصة"
+
+#: ../src/common/paper.cpp:145
+msgid "A3 Rotated 420 x 297 mm"
+msgstr "أي3 مدورة 420 × 297 مم"
+
+#: ../src/common/paper.cpp:146
+msgid "A4 Rotated 297 x 210 mm"
+msgstr "أي4 مدورة 297 × 210 مم"
+
+#: ../src/common/paper.cpp:147
+msgid "A5 Rotated 210 x 148 mm"
+msgstr "أي5 مدورة 210 × 148 مم"
+
+#: ../src/common/paper.cpp:148
+msgid "B4 (JIS) Rotated 364 x 257 mm"
+msgstr "بي4 (معايير يابانية) مدورة 364 × 257 مم"
+
+#: ../src/common/paper.cpp:149
+msgid "B5 (JIS) Rotated 257 x 182 mm"
+msgstr "بي5 (معايير يابانية) مدورة 257 × 182 مم"
+
+#: ../src/common/paper.cpp:150
+msgid "Japanese Postcard Rotated 148 x 100 mm"
+msgstr "بطاقة بريدية يابانية مدورة 148 × 100 ملم"
+
+#: ../src/common/paper.cpp:151
+msgid "Double Japanese Postcard Rotated 148 x 200 mm"
+msgstr "بطاقة بريدية يابانية مدورة مضاعَفة 148 × 100 ملم"
+
+#: ../src/common/paper.cpp:152
+msgid "A6 Rotated 148 x 105 mm"
+msgstr "أي6 مدور 148 × 105 مم"
+
+#: ../src/common/paper.cpp:153
+msgid "Japanese Envelope Kaku #2 Rotated"
+msgstr "مغلف ياباني كاكو #2 مدوّر"
+
+#: ../src/common/paper.cpp:154
+msgid "Japanese Envelope Kaku #3 Rotated"
+msgstr "مغلف ياباني كاكو #3 مدوّر"
+
+#: ../src/common/paper.cpp:155
+msgid "Japanese Envelope Chou #3 Rotated"
+msgstr "مغلف ياباني جو #3 مدوّر"
+
+#: ../src/common/paper.cpp:156
+msgid "Japanese Envelope Chou #4 Rotated"
+msgstr "مغلف ياباني جو #4 مدوّر"
+
+#: ../src/common/paper.cpp:157
+msgid "B6 (JIS) 128 x 182 mm"
+msgstr "بي5 (معايير يابانية) 128 × 182 مم"
+
+#: ../src/common/paper.cpp:158
+msgid "B6 (JIS) Rotated 182 x 128 mm"
+msgstr "بي5 (معايير يابانية) مدوّر 128 × 182 مم"
+
+#: ../src/common/paper.cpp:159
+msgid "12 x 11 in"
+msgstr "12 × 11 بوصة"
+
+#: ../src/common/paper.cpp:160
+msgid "Japanese Envelope You #4"
+msgstr "مغلف ياباني يو #4"
+
+#: ../src/common/paper.cpp:161
+msgid "Japanese Envelope You #4 Rotated"
+msgstr "مغلف ياباني يو #4 مدوّر"
+
+#: ../src/common/paper.cpp:162
+msgid "PRC 16K 146 x 215 mm"
+msgstr "صيني 16ق 146 × 215 مم"
+
+#: ../src/common/paper.cpp:163
+msgid "PRC 32K 97 x 151 mm"
+msgstr "صيني 32ق 97 × 151 مم"
+
+#: ../src/common/paper.cpp:164
+msgid "PRC 32K(Big) 97 x 151 mm"
+msgstr "صيني 32ق (كبير) 97 × 151 مم"
+
+#: ../src/common/paper.cpp:165
+msgid "PRC Envelope #1 102 x 165 mm"
+msgstr "مغلف صيني #1 102 × 165 مم"
+
+#: ../src/common/paper.cpp:166
+msgid "PRC Envelope #2 102 x 176 mm"
+msgstr "مغلف صيني #2 102 × 176 مم"
+
+#: ../src/common/paper.cpp:167
+msgid "PRC Envelope #3 125 x 176 mm"
+msgstr "مغلف صيني #3 125 × 176 مم"
+
+#: ../src/common/paper.cpp:168
+msgid "PRC Envelope #4 110 x 208 mm"
+msgstr "مغلف صيني #4 110 × 208 مم"
+
+#: ../src/common/paper.cpp:169
+msgid "PRC Envelope #5 110 x 220 mm"
+msgstr "مغلف صيني #5 110 × 220 مم"
+
+#: ../src/common/paper.cpp:170
+msgid "PRC Envelope #6 120 x 230 mm"
+msgstr "مغلف صيني #6 120 × 230 مم"
+
+#: ../src/common/paper.cpp:171
+msgid "PRC Envelope #7 160 x 230 mm"
+msgstr "مغلف صيني #7 160 × 230 مم"
+
+#: ../src/common/paper.cpp:172
+msgid "PRC Envelope #8 120 x 309 mm"
+msgstr "مغلف صيني #8 120 × 309 مم"
+
+#: ../src/common/paper.cpp:173
+msgid "PRC Envelope #9 229 x 324 mm"
+msgstr "مغلف صيني #9 229 × 324 مم"
+
+#: ../src/common/paper.cpp:174
+msgid "PRC Envelope #10 324 x 458 mm"
+msgstr "مغلف صيني #10 324 × 458 مم"
+
+#: ../src/common/paper.cpp:175
+msgid "PRC 16K Rotated"
+msgstr "صيني 16ق مدور"
+
+#: ../src/common/paper.cpp:176
+msgid "PRC 32K Rotated"
+msgstr "صيني 32ق مدور"
+
+#: ../src/common/paper.cpp:177
+msgid "PRC 32K(Big) Rotated"
+msgstr "صيني 32ق(كبير) مدور"
+
+#: ../src/common/paper.cpp:178
+msgid "PRC Envelope #1 Rotated 165 x 102 mm"
+msgstr "مغلف صيني #1 مدور 165 × 102 مم"
+
+#: ../src/common/paper.cpp:179
+msgid "PRC Envelope #2 Rotated 176 x 102 mm"
+msgstr "مغلف صيني #2 مدور 176 × 102 مم"
+
+#: ../src/common/paper.cpp:180
+msgid "PRC Envelope #3 Rotated 176 x 125 mm"
+msgstr "مغلف صيني #3 مدور 176 × 125 مم"
+
+#: ../src/common/paper.cpp:181
+msgid "PRC Envelope #4 Rotated 208 x 110 mm"
+msgstr "مغلف صيني #4 مدور 208 × 110 مم"
+
+#: ../src/common/paper.cpp:182
+msgid "PRC Envelope #5 Rotated 220 x 110 mm"
+msgstr "مغلف صيني #5 مدور 220 × 110 مم"
+
+#: ../src/common/paper.cpp:183
+msgid "PRC Envelope #6 Rotated 230 x 120 mm"
+msgstr "مغلف صيني #6 مدور 230 × 120 مم"
+
+#: ../src/common/paper.cpp:184
+msgid "PRC Envelope #7 Rotated 230 x 160 mm"
+msgstr "مغلف صيني #7 مدور 230 × 160 مم"
+
+#: ../src/common/paper.cpp:185
+msgid "PRC Envelope #8 Rotated 309 x 120 mm"
+msgstr "مغلف صيني #8 مدور 309 × 120 مم"
+
+#: ../src/common/paper.cpp:186
+msgid "PRC Envelope #9 Rotated 324 x 229 mm"
+msgstr "مغلف صيني #9 مدور 324 × 229 مم"
+
+#: ../src/common/paper.cpp:187
+msgid "PRC Envelope #10 Rotated 458 x 324 mm"
+msgstr "مغلف صيني #10 مدور 458 × 324 مم"
+
+#: ../src/common/paper.cpp:192
+msgid "A0 sheet, 841 x 1189 mm"
+msgstr "ورقة أي0، 841 × 1189 مم"
+
+#: ../src/common/paper.cpp:193
+msgid "A1 sheet, 594 x 841 mm"
+msgstr "ورقة أي1، 594 × 841 مم"
+
+#: ../src/common/preferencescmn.cpp:37
+msgid "General"
+msgstr "عامّ"
+
+#: ../src/common/preferencescmn.cpp:40
+msgid "Advanced"
+msgstr "متقدّم"
+
+#: ../src/common/prntbase.cpp:245
+msgid "Generic PostScript"
+msgstr "بوستسكربت عمومي"
+
+#: ../src/common/prntbase.cpp:259
+msgid "Ready"
+msgstr "جاهز"
+
+#: ../src/common/prntbase.cpp:331
+msgid "Printing Error"
+msgstr "خطأ في الطباعة"
+
+#: ../src/common/prntbase.cpp:413 ../src/common/prntbase.cpp:1597
+#: ../src/generic/prntdlgg.cpp:135 ../src/generic/prntdlgg.cpp:149
+#: ../src/gtk/print.cpp:628 ../src/gtk/print.cpp:646
+msgid "Print"
+msgstr "م‌طباعة"
+
+#: ../src/common/prntbase.cpp:471 ../src/generic/prntdlgg.cpp:809
+msgid "Page setup"
+msgstr "إعدادات الصفحة"
+
+#: ../src/common/prntbase.cpp:525
+msgid "Please wait while printing..."
+msgstr "الرجاء الانتظار أثناء الطباعة..."
+
+#: ../src/common/prntbase.cpp:529
+msgid "Document:"
+msgstr "المستند:"
+
+#: ../src/common/prntbase.cpp:532
+msgid "Progress:"
+msgstr "التقدم:"
+
+#: ../src/common/prntbase.cpp:533
+msgid "Preparing"
+msgstr "يحضّر"
+
+#: ../src/common/prntbase.cpp:552
+#, c-format
+msgid "Printing page %d"
+msgstr "يطبع الصفحة %d"
+
+#: ../src/common/prntbase.cpp:557
+#, c-format
+msgid "Printing page %d of %d"
+msgstr "يطبع الصفحة %d من %d"
+
+#: ../src/common/prntbase.cpp:560
+#, c-format
+msgid " (copy %d of %d)"
+msgstr " (النسخة %d من %d)"
+
+#: ../src/common/prntbase.cpp:1604
+msgid "First page"
+msgstr "الصفحة الأولى"
+
+#: ../src/common/prntbase.cpp:1609 ../src/html/helpwnd.cpp:659
+msgid "Previous page"
+msgstr "الصفحة السابقة"
+
+#: ../src/common/prntbase.cpp:1623 ../src/html/helpwnd.cpp:660
+msgid "Next page"
+msgstr "الصفحة التالية"
+
+#: ../src/common/prntbase.cpp:1628
+msgid "Last page"
+msgstr "الصفحة الأخيرة"
+
+#: ../src/common/prntbase.cpp:1636 ../src/common/stockitem.cpp:215
+msgid "Zoom Out"
+msgstr "بعّد"
+
+#: ../src/common/prntbase.cpp:1650 ../src/common/stockitem.cpp:214
+msgid "Zoom In"
+msgstr "قرّب"
+
+#: ../src/common/prntbase.cpp:1656 ../src/common/stockitem.cpp:153
+#: ../src/generic/logg.cpp:553 ../src/univ/themes/win32.cpp:3752
+msgid "&Close"
+msgstr "&إغلاق"
+
+#: ../src/common/prntbase.cpp:2085
+msgid "Could not start document preview."
+msgstr "تعذّر بدء معاينة المستند."
+
+#: ../src/common/prntbase.cpp:2085 ../src/common/prntbase.cpp:2129
+#: ../src/common/prntbase.cpp:2137
+msgid "Print Preview Failure"
+msgstr "أخفقت معاينة الطباعة"
+
+#: ../src/common/prntbase.cpp:2129 ../src/common/prntbase.cpp:2137
+msgid "Sorry, not enough memory to create a preview."
+msgstr "عذرا، لا تتوفر ذاكرة كافية لإنشاء المعاينة."
+
+#: ../src/common/prntbase.cpp:2144
+#, c-format
+msgid "Page %d of %d"
+msgstr "الصفحة %d من %d"
+
+#: ../src/common/prntbase.cpp:2146
+#, c-format
+msgid "Page %d"
+msgstr "الصفحة %d"
+
+#: ../src/common/regex.cpp:382 ../src/html/chm.cpp:348
+msgid "unknown error"
+msgstr "خطأ مجهول"
+
+#: ../src/common/regex.cpp:995
+#, c-format
+msgid "Invalid regular expression '%s': %s"
+msgstr "تعبير نظامي غير صحيح '%s': %s"
+
+#: ../src/common/regex.cpp:1059
+#, c-format
+msgid "Failed to find match for regular expression: %s"
+msgstr "أخفق العثور على مُطابِق للتعبير النظامي: %s"
+
+#: ../src/common/rendcmn.cpp:188
+#, c-format
+msgid "Renderer \"%s\" has incompatible version %d.%d and couldn't be loaded."
+msgstr "للمصيِّر \"%s\" إصدار غير متوافق %d.%d وتعذّر تحميله."
+
+#: ../src/common/secretstore.cpp:162
+msgid "Not available for this platform"
+msgstr "غير متاح لهذه المنصة"
+
+#: ../src/common/secretstore.cpp:183
+#, c-format
+msgid "Saving password for \"%s\" failed: %s."
+msgstr "أخفق حفظ كلمة السر لـ \"%s‏\": %s."
+
+#: ../src/common/secretstore.cpp:205
+#, c-format
+msgid "Reading password for \"%s\" failed: %s."
+msgstr "أخفقت قراءة كلمة السر لـ \"%s‏\": %s."
+
+#: ../src/common/secretstore.cpp:228
+#, c-format
+msgid "Deleting password for \"%s\" failed: %s."
+msgstr "أخفق حذف كلمة السر لـ \"%s‏\": %s."
+
+#: ../src/common/selectdispatcher.cpp:254
+msgid "Failed to monitor I/O channels"
+msgstr "أخفق مراقبة قنوات الادخال\\الإخراج I/O"
+
+#: ../src/common/sizer.cpp:3054 ../src/common/stockitem.cpp:195
+msgid "Save"
+msgstr "احفظ"
+
+#: ../src/common/sizer.cpp:3056
+msgid "Don't Save"
+msgstr "لا تحفظ"
+
+#: ../src/common/socket.cpp:870
+msgid "Cannot initialize sockets"
+msgstr "تعذّر تجهيز المقابس sockets"
+
+#: ../src/common/stockitem.cpp:127
+msgctxt "standard Windows menu"
+msgid "&Help"
+msgstr "م‍&ساعدة"
+
+#: ../src/common/stockitem.cpp:144
+msgid "&About"
+msgstr "&عن"
+
+#: ../src/common/stockitem.cpp:144
+msgid "About"
+msgstr "عن"
+
+#: ../src/common/stockitem.cpp:145
+msgid "Add"
+msgstr "أضِف"
+
+#: ../src/common/stockitem.cpp:146
+msgid "&Apply"
+msgstr "&تطبيق"
+
+#: ../src/common/stockitem.cpp:146
+msgid "Apply"
+msgstr "طبّق"
+
+#: ../src/common/stockitem.cpp:147
+msgid "&Back"
+msgstr "&رجوع"
+
+#: ../src/common/stockitem.cpp:147
+msgid "Back"
+msgstr "رجوع"
+
+#: ../src/common/stockitem.cpp:148
+msgid "&Bold"
+msgstr "&عريض"
+
+#: ../src/common/stockitem.cpp:148 ../src/generic/fontdlgg.cpp:326
+#: ../src/richtext/richtextfontpage.cpp:354
+msgid "Bold"
+msgstr "عريض"
+
+#: ../src/common/stockitem.cpp:149
+msgid "&Bottom"
+msgstr "سف&لي"
+
+#: ../src/common/stockitem.cpp:149 ../src/richtext/richtextsizepage.cpp:287
+msgid "Bottom"
+msgstr "سفلي"
+
+#: ../src/common/stockitem.cpp:150 ../src/generic/fontdlgg.cpp:462
+#: ../src/generic/fontdlgg.cpp:481 ../src/generic/wizard.cpp:415
+msgid "&Cancel"
+msgstr "&إلغاء"
+
+#: ../src/common/stockitem.cpp:151
+msgid "&CD-ROM"
+msgstr "مشغل ا&قراص"
+
+#: ../src/common/stockitem.cpp:151
+msgid "CD-ROM"
+msgstr "مشغل اقراص"
+
+#: ../src/common/stockitem.cpp:152
+msgid "&Clear"
+msgstr "ف&رّغ"
+
+#: ../src/common/stockitem.cpp:152
+msgid "Clear"
+msgstr "فرّغ"
+
+#: ../src/common/stockitem.cpp:153 ../src/generic/dbgrptg.cpp:93
+#: ../src/generic/progdlgg.cpp:778 ../src/html/helpdlg.cpp:86
+#: ../src/msw/progdlg.cpp:209 ../src/msw/progdlg.cpp:890
+#: ../src/richtext/richtextstyledlg.cpp:272
+#: ../src/richtext/richtextsymboldlg.cpp:448
+msgid "Close"
+msgstr "أغلق"
+
+#: ../src/common/stockitem.cpp:154
+msgid "&Convert"
+msgstr "&حوّل"
+
+#: ../src/common/stockitem.cpp:154
+msgid "Convert"
+msgstr "حوّل"
+
+#: ../src/common/stockitem.cpp:155 ../src/msw/textctrl.cpp:2884
+#: ../src/osx/textctrl_osx.cpp:653 ../src/richtext/richtextctrl.cpp:331
+msgid "&Copy"
+msgstr "ا&نسخ"
+
+#: ../src/common/stockitem.cpp:155 ../src/stc/stc_i18n.cpp:18
+msgid "Copy"
+msgstr "انسخ"
+
+#: ../src/common/stockitem.cpp:156 ../src/msw/textctrl.cpp:2883
+#: ../src/osx/textctrl_osx.cpp:652 ../src/richtext/richtextctrl.cpp:330
+msgid "Cu&t"
+msgstr "ق&ص"
+
+#: ../src/common/stockitem.cpp:156 ../src/stc/stc_i18n.cpp:17
+msgid "Cut"
+msgstr "قص"
+
+#: ../src/common/stockitem.cpp:157 ../src/msw/textctrl.cpp:2886
+#: ../src/osx/textctrl_osx.cpp:655 ../src/richtext/richtextctrl.cpp:333
+#: ../src/richtext/richtexttabspage.cpp:137
+msgid "&Delete"
+msgstr "ا&حذف"
+
+#: ../src/common/stockitem.cpp:157 ../src/richtext/richtextbuffer.cpp:8266
+#: ../src/stc/stc_i18n.cpp:20
+msgid "Delete"
+msgstr "احذف"
+
+#: ../src/common/stockitem.cpp:158
+msgid "&Down"
+msgstr "&أسفل"
+
+#: ../src/common/stockitem.cpp:158 ../src/generic/fdrepdlg.cpp:148
+msgid "Down"
+msgstr "أسفل"
+
+#: ../src/common/stockitem.cpp:159
+msgid "&Edit"
+msgstr "&تحرير"
+
+#: ../src/common/stockitem.cpp:159
+msgid "Edit"
+msgstr "حرّر"
+
+#: ../src/common/stockitem.cpp:160
+msgid "&Execute"
+msgstr "ن&فّذ"
+
+#: ../src/common/stockitem.cpp:160
+msgid "Execute"
+msgstr "نفّذ"
+
+#: ../src/common/stockitem.cpp:161
+msgid "&Quit"
+msgstr "&إنهاء"
+
+#: ../src/common/stockitem.cpp:161
+msgid "Quit"
+msgstr "أنهِ"
+
+#: ../src/common/stockitem.cpp:162
+msgid "&File"
+msgstr "&ملف"
+
+#: ../src/common/stockitem.cpp:162
+msgid "File"
+msgstr "ملف"
+
+#: ../src/common/stockitem.cpp:163
+msgid "&Find..."
+msgstr "جِ&د..."
+
+#: ../src/common/stockitem.cpp:163
+msgid "Find..."
+msgstr "جِد..."
+
+#: ../src/common/stockitem.cpp:164
+msgid "&First"
+msgstr "&الأول"
+
+#: ../src/common/stockitem.cpp:164
+msgid "First"
+msgstr "الأول"
+
+#: ../src/common/stockitem.cpp:165
+msgid "&Floppy"
+msgstr "&القرص المرن"
+
+#: ../src/common/stockitem.cpp:165
+msgid "Floppy"
+msgstr "القرص المرن"
+
+#: ../src/common/stockitem.cpp:166
+msgid "&Forward"
+msgstr "&للأمام"
+
+#: ../src/common/stockitem.cpp:166
+msgid "Forward"
+msgstr "للأمام"
+
+#: ../src/common/stockitem.cpp:167
+msgid "&Harddisk"
+msgstr "القرص ال&صلب"
+
+#: ../src/common/stockitem.cpp:167
+msgid "Harddisk"
+msgstr "القرص الصلب"
+
+#: ../src/common/stockitem.cpp:168 ../src/generic/wizard.cpp:418
+#: ../src/osx/cocoa/menu.mm:225 ../src/richtext/richtextstyledlg.cpp:298
+#: ../src/richtext/richtextsymboldlg.cpp:451
+msgid "&Help"
+msgstr "ال&مساعدة"
+
+#: ../src/common/stockitem.cpp:169
+msgid "&Home"
+msgstr "ال&منزل"
+
+#: ../src/common/stockitem.cpp:169
+msgid "Home"
+msgstr "«المنزل»"
+
+#: ../src/common/stockitem.cpp:170
+msgid "Indent"
+msgstr "حاذِ"
+
+#: ../src/common/stockitem.cpp:171
+msgid "&Index"
+msgstr "&الفهرس"
+
+#: ../src/common/stockitem.cpp:171 ../src/html/helpwnd.cpp:510
+msgid "Index"
+msgstr "الفهرس"
+
+#: ../src/common/stockitem.cpp:172
+msgid "&Info"
+msgstr "م&علومات"
+
+#: ../src/common/stockitem.cpp:172
+msgid "Info"
+msgstr "معلومات"
+
+#: ../src/common/stockitem.cpp:173
+msgid "&Italic"
+msgstr "&مائل"
+
+#: ../src/common/stockitem.cpp:173 ../src/generic/fontdlgg.cpp:322
+#: ../src/richtext/richtextfontpage.cpp:350
+msgid "Italic"
+msgstr "مائل"
+
+#: ../src/common/stockitem.cpp:174
+msgid "&Jump to"
+msgstr "&انتقل إلى"
+
+#: ../src/common/stockitem.cpp:174
+msgid "Jump to"
+msgstr "انتقل إلى"
+
+#: ../src/common/stockitem.cpp:175
+msgid "Centered"
+msgstr "موسَّط"
+
+#: ../src/common/stockitem.cpp:176
+msgid "Justified"
+msgstr "مساوى"
+
+#: ../src/common/stockitem.cpp:177
+msgid "Align Left"
+msgstr "حاذِ يسارًا"
+
+#: ../src/common/stockitem.cpp:178
+msgid "Align Right"
+msgstr "حاذِ يمينًا"
+
+#: ../src/common/stockitem.cpp:179
+msgid "&Last"
+msgstr "الأ&خير"
+
+#: ../src/common/stockitem.cpp:179
+msgid "Last"
+msgstr "الأخير"
+
+#: ../src/common/stockitem.cpp:180
+msgid "&Network"
+msgstr "ال&شبكة"
+
+#: ../src/common/stockitem.cpp:180
+msgid "Network"
+msgstr "الشبكة"
+
+#: ../src/common/stockitem.cpp:181 ../src/richtext/richtexttabspage.cpp:131
+msgid "&New"
+msgstr "&جديد"
+
+#: ../src/common/stockitem.cpp:181
+msgid "New"
+msgstr "جديد"
+
+#: ../src/common/stockitem.cpp:182 ../src/msw/msgdlg.cpp:417
+msgid "&No"
+msgstr "&لا"
+
+#: ../src/common/stockitem.cpp:183 ../src/generic/fontdlgg.cpp:467
+#: ../src/generic/fontdlgg.cpp:474
+msgid "&OK"
+msgstr "&موافق"
+
+#: ../src/common/stockitem.cpp:184 ../src/generic/dbgrptg.cpp:341
+msgid "&Open..."
+msgstr "ا&فتح..."
+
+#: ../src/common/stockitem.cpp:184
+msgid "Open..."
+msgstr "افتح..."
+
+#: ../src/common/stockitem.cpp:185 ../src/msw/textctrl.cpp:2885
+#: ../src/osx/textctrl_osx.cpp:654 ../src/richtext/richtextctrl.cpp:332
+msgid "&Paste"
+msgstr "ا&لصق"
+
+#: ../src/common/stockitem.cpp:185 ../src/richtext/richtextctrl.cpp:3484
+#: ../src/stc/stc_i18n.cpp:19
+msgid "Paste"
+msgstr "الصق"
+
+#: ../src/common/stockitem.cpp:186
+msgid "&Preferences"
+msgstr "&التفضيلات"
+
+#: ../src/common/stockitem.cpp:186 ../src/osx/cocoa/preferences.mm:304
+msgid "Preferences"
+msgstr "التفضيلات"
+
+#: ../src/common/stockitem.cpp:187
+msgid "Print previe&w..."
+msgstr "معاينة الطبا&عة..."
+
+#: ../src/common/stockitem.cpp:187
+msgid "Print preview..."
+msgstr "معاينة الطباعة..."
+
+#: ../src/common/stockitem.cpp:188
+msgid "&Print..."
+msgstr "&طباعة..."
+
+#: ../src/common/stockitem.cpp:188
+msgid "Print..."
+msgstr "طباعة..."
+
+#: ../src/common/stockitem.cpp:189 ../src/richtext/richtextctrl.cpp:337
+#: ../src/richtext/richtextctrl.cpp:5479
+msgid "&Properties"
+msgstr "&الخصائص"
+
+#: ../src/common/stockitem.cpp:189
+msgid "Properties"
+msgstr "الخصائص"
+
+#: ../src/common/stockitem.cpp:190 ../src/stc/stc_i18n.cpp:16
+msgid "Redo"
+msgstr "تكرار"
+
+#: ../src/common/stockitem.cpp:191
+msgid "Refresh"
+msgstr "أعِد التحميل"
+
+#: ../src/common/stockitem.cpp:192
+msgid "Remove"
+msgstr "أزل"
+
+#: ../src/common/stockitem.cpp:193
+msgid "Rep&lace..."
+msgstr "است&بدل..."
+
+#: ../src/common/stockitem.cpp:193
+msgid "Replace..."
+msgstr "استبدل..."
+
+#: ../src/common/stockitem.cpp:194
+msgid "Revert to Saved"
+msgstr "تراجع إلى المحفوظ"
+
+#: ../src/common/stockitem.cpp:196 ../src/generic/logg.cpp:549
+msgid "Save &As..."
+msgstr "حفظ با&سم..."
+
+#: ../src/common/stockitem.cpp:196
+msgid "Save As..."
+msgstr "حفظ باسم..."
+
+#: ../src/common/stockitem.cpp:197 ../src/msw/textctrl.cpp:2888
+#: ../src/osx/textctrl_osx.cpp:657 ../src/richtext/richtextctrl.cpp:335
+msgid "Select &All"
+msgstr "تحديد ال&كل"
+
+#: ../src/common/stockitem.cpp:197 ../src/stc/stc_i18n.cpp:21
+msgid "Select All"
+msgstr "تحديد الكل"
+
+#: ../src/common/stockitem.cpp:198
+msgid "&Color"
+msgstr "&لون"
+
+#: ../src/common/stockitem.cpp:198
+msgid "Color"
+msgstr "لون"
+
+#: ../src/common/stockitem.cpp:199
+msgid "&Font"
+msgstr "&خط"
+
+#: ../src/common/stockitem.cpp:199 ../src/richtext/richtextformatdlg.cpp:336
+msgid "Font"
+msgstr "خط"
+
+#: ../src/common/stockitem.cpp:200
+msgid "&Ascending"
+msgstr "ت&صاعدي"
+
+#: ../src/common/stockitem.cpp:200
+msgid "Ascending"
+msgstr "تصاعدي"
+
+#: ../src/common/stockitem.cpp:201
+msgid "&Descending"
+msgstr "تنا&زلي"
+
+#: ../src/common/stockitem.cpp:201
+msgid "Descending"
+msgstr "تنازلي"
+
+#: ../src/common/stockitem.cpp:202
+msgid "&Spell Check"
+msgstr "تدقيق إملا&ئي"
+
+#: ../src/common/stockitem.cpp:202
+msgid "Spell Check"
+msgstr "تدقيق إملائي"
+
+#: ../src/common/stockitem.cpp:203
+msgid "&Stop"
+msgstr "أو&قِف"
+
+#: ../src/common/stockitem.cpp:203
+msgid "Stop"
+msgstr "أوقِف"
+
+#: ../src/common/stockitem.cpp:204 ../src/richtext/richtextfontpage.cpp:274
+msgid "&Strikethrough"
+msgstr "&شطب"
+
+#: ../src/common/stockitem.cpp:204
+msgid "Strikethrough"
+msgstr "شطب"
+
+#: ../src/common/stockitem.cpp:205
+msgid "&Top"
+msgstr "عُ&لوي"
+
+#: ../src/common/stockitem.cpp:205 ../src/richtext/richtextsizepage.cpp:285
+#: ../src/richtext/richtextsizepage.cpp:289
+msgid "Top"
+msgstr "عُلوي"
+
+#: ../src/common/stockitem.cpp:206
+msgid "Undelete"
+msgstr "تراجع عن الحذف"
+
+#: ../src/common/stockitem.cpp:207 ../src/generic/fontdlgg.cpp:437
+msgid "&Underline"
+msgstr "&تسطير"
+
+#: ../src/common/stockitem.cpp:207
+msgid "Underline"
+msgstr "تسطير"
+
+#: ../src/common/stockitem.cpp:208 ../src/stc/stc_i18n.cpp:15
+msgid "Undo"
+msgstr "تراجع"
+
+#: ../src/common/stockitem.cpp:209
+msgid "&Unindent"
+msgstr "أزِ&ل الإزاحة"
+
+#: ../src/common/stockitem.cpp:209
+msgid "Unindent"
+msgstr "أزِل الإزاحة"
+
+#: ../src/common/stockitem.cpp:210
+msgid "&Up"
+msgstr "أ&على"
+
+#: ../src/common/stockitem.cpp:210 ../src/generic/fdrepdlg.cpp:148
+msgid "Up"
+msgstr "أعلى"
+
+#: ../src/common/stockitem.cpp:211 ../src/msw/msgdlg.cpp:417
+msgid "&Yes"
+msgstr "&نعم"
+
+#: ../src/common/stockitem.cpp:212
+msgid "&Actual Size"
+msgstr "&المقاس الحقيقي"
+
+#: ../src/common/stockitem.cpp:212
+msgid "Actual Size"
+msgstr "المقاس الحقيقي"
+
+#: ../src/common/stockitem.cpp:213
+msgid "Zoom to &Fit"
+msgstr "قرّب للا&حتواء"
+
+#: ../src/common/stockitem.cpp:213
+msgid "Zoom to Fit"
+msgstr "قرّب للاحتواء"
+
+#: ../src/common/stockitem.cpp:214
+msgid "Zoom &In"
+msgstr "&قرّب"
+
+#: ../src/common/stockitem.cpp:215
+msgid "Zoom &Out"
+msgstr "&بعّد"
+
+#: ../src/common/stockitem.cpp:262
+msgid "Show about dialog"
+msgstr "أظهِر حوار ’عن‘"
+
+#: ../src/common/stockitem.cpp:263
+msgid "Copy selection"
+msgstr "نسخ التحديد"
+
+#: ../src/common/stockitem.cpp:264
+msgid "Cut selection"
+msgstr "قص التحديد"
+
+#: ../src/common/stockitem.cpp:265
+msgid "Delete selection"
+msgstr "حذف التحديد"
+
+#: ../src/common/stockitem.cpp:266
+msgid "Find in document"
+msgstr "جد في المستند"
+
+#: ../src/common/stockitem.cpp:267
+msgid "Find and replace in document"
+msgstr "جد واستبدل في المستند"
+
+#: ../src/common/stockitem.cpp:268
+msgid "Paste selection"
+msgstr "لصق التحديد"
+
+#: ../src/common/stockitem.cpp:269
+msgid "Quit this program"
+msgstr "إنهاء البرنامج"
+
+#: ../src/common/stockitem.cpp:270
+msgid "Redo last action"
+msgstr "أعِد عمل آخر إجراء"
+
+#: ../src/common/stockitem.cpp:271
+msgid "Undo last action"
+msgstr "تراجع عن عمل آخر إجراء"
+
+#: ../src/common/stockitem.cpp:272
+msgid "Create new document"
+msgstr "أنشئ مستندا جديدا"
+
+#: ../src/common/stockitem.cpp:273
+msgid "Open an existing document"
+msgstr "افتح مستندا موجودا"
+
+#: ../src/common/stockitem.cpp:274
+msgid "Close current document"
+msgstr "إغلاق الوثيقة الحالية"
+
+#: ../src/common/stockitem.cpp:275
+msgid "Save current document"
+msgstr "حفظ الوثيقة الحالية"
+
+#: ../src/common/stockitem.cpp:276
+msgid "Save current document with a different filename"
+msgstr "حفظ الوثيقة الحالية باسم مختلف"
+
+#: ../src/common/strconv.cpp:2324
+#, c-format
+msgid "Conversion to charset '%s' doesn't work."
+msgstr "التحويل إلى طقم المحارف '%s' لا يعمل."
+
+#: ../src/common/tarstrm.cpp:352 ../src/common/tarstrm.cpp:375
+#: ../src/common/tarstrm.cpp:406 ../src/generic/progdlgg.cpp:373
+msgid "unknown"
+msgstr "مجهول"
+
+#: ../src/common/tarstrm.cpp:774
+msgid "incomplete header block in tar"
+msgstr "كتلة ترويسة غير مكتملة في ملف tar"
+
+#: ../src/common/tarstrm.cpp:798
+msgid "checksum failure reading tar header block"
+msgstr "أخفق المجموع الاختباري عند اقراءة كتلة ترويسة ملف tar"
+
+#: ../src/common/tarstrm.cpp:971
+msgid "invalid data in extended tar header"
+msgstr "بيانات غير صحيحة في ترويسة ملف مضغوط موسع"
+
+#: ../src/common/tarstrm.cpp:981 ../src/common/tarstrm.cpp:1003
+#: ../src/common/tarstrm.cpp:1477 ../src/common/tarstrm.cpp:1499
+msgid "tar entry not open"
+msgstr "مُدخَلة ملف مضغوط غير مفتوحة"
+
+#: ../src/common/tarstrm.cpp:1023
+msgid "unexpected end of file"
+msgstr "نهاية ملف غير متوقّعة"
+
+#: ../src/common/tarstrm.cpp:1297
+#, c-format
+msgid "%s did not fit the tar header for entry '%s'"
+msgstr "لم يطابق %s ترويسة الملف المضغوط للمُدخَلة '%s'"
+
+#: ../src/common/tarstrm.cpp:1359
+msgid "incorrect size given for tar entry"
+msgstr "حجم غير صحيح مُعطى لمُدخَلة الملف المضغوط"
+
+#: ../src/common/textbuf.cpp:232
+#, c-format
+msgid "'%s' is probably a binary buffer."
+msgstr "'%s' من المحتمل أن تكون ذاكرة ثنائية."
+
+#: ../src/common/textcmn.cpp:1006 ../src/richtext/richtextctrl.cpp:3053
+msgid "File couldn't be loaded."
+msgstr "تعذّر تحميل الملف."
+
+#: ../src/common/textfile.cpp:95
+#, c-format
+msgid "Failed to read text file \"%s\"."
+msgstr "أخفقت قراءة الملف النصي \"%s\"."
+
+#: ../src/common/textfile.cpp:160
+#, c-format
+msgid "can't write buffer '%s' to disk."
+msgstr "تعذّرت كتابة البراح '%s' إلى القرص."
+
+#: ../src/common/time.cpp:212
+msgid "Failed to get the local system time"
+msgstr "أخفق جلب وقت النظام المحلي"
+
+#: ../src/common/time.cpp:279
+msgid "wxGetTimeOfDay failed."
+msgstr "أخفق wxGetTimeOfDay."
+
+#: ../src/common/translation.cpp:929
+#, c-format
+msgid "'%s' is not a valid message catalog."
+msgstr "'%s' ليس فهرس رسائل صحيحا."
+
+#: ../src/common/translation.cpp:954
+msgid "Invalid message catalog."
+msgstr "فهرس رسائل غير صحيح."
+
+#: ../src/common/translation.cpp:1013
+#, c-format
+msgid "Failed to parse Plural-Forms: '%s'"
+msgstr "أخفق تحليل صيغ الجمع: '%s'"
+
+#: ../src/common/translation.cpp:1723
+#, c-format
+msgid "using catalog '%s' from '%s'."
+msgstr "يستخدم الفهرس '%s' من '%s'."
+
+#: ../src/common/translation.cpp:1816
+#, c-format
+msgid "Resource '%s' is not a valid message catalog."
+msgstr "المورد '%s' ليس فهرس رسائل صحيحا."
+
+#: ../src/common/translation.cpp:1865
+msgid "Couldn't enumerate translations"
+msgstr "تعذّر تعداد الترجمات"
+
+#: ../src/common/utilscmn.cpp:1145
+msgid "No default application configured for HTML files."
+msgstr "لم يكوَّن أي تطبيق مبدئي لملفات HTML."
+
+#: ../src/common/utilscmn.cpp:1190
+#, c-format
+msgid "Failed to open URL \"%s\" in default browser."
+msgstr "أخفق فتح الرابط \"%s\" في المتصفح المبدئي."
+
+#: ../src/common/valtext.cpp:144
+msgid "Validation conflict"
+msgstr "تعارض في التحقق"
+
+#: ../src/common/valtext.cpp:186
+msgid "Required information entry is empty."
+msgstr "إحدى مُدخَلات البيانات الضرورية فارغة."
+
+#: ../src/common/valtext.cpp:188
+#, c-format
+msgid "'%s' is one of the invalid strings"
+msgstr "'%s' هو أحد المقاطع غير الصحيحة"
+
+#: ../src/common/valtext.cpp:190
+#, c-format
+msgid "'%s' is not one of the valid strings"
+msgstr "ليس '%s' أحد المقاطع الصحيحة"
+
+#: ../src/common/valtext.cpp:199
+#, c-format
+msgid "'%s' contains invalid character(s)"
+msgstr "يحتوي '%s' محرفا (محارفا) غير صحيح"
+
+#: ../src/common/webrequest.cpp:139
+#, c-format
+msgid "Error: %s (%d)"
+msgstr "خطأ: %s‏ (%d)"
+
+#: ../src/common/webrequest.cpp:655
+#, c-format
+msgid ""
+"Not enough free disk space for download: %llu needed but only %llu available."
+msgstr "لا تتوفر مساحة قرص فارغة كافية للتنزيل: يلزم %llu لكن المتاح %llu فقط."
+
+#: ../src/common/webrequest.cpp:669
+#, c-format
+msgid "Failed to create temporary file in %s"
+msgstr "أخفق إنشاء الملف المؤقت في %s"
+
+#: ../src/common/webrequest_curl.cpp:1106
+msgid "libcurl could not be initialized"
+msgstr "تعذّر تجهيز libcurl"
+
+#: ../src/common/webview.cpp:392
+msgid "RunScriptAsync not supported"
+msgstr "ليس RunScriptAsync مدعومًا"
+
+#: ../src/common/webview.cpp:403 ../src/msw/webview_ie.cpp:1073
+#, c-format
+msgid "Error running JavaScript: %s"
+msgstr "خطأ في تشغيل جافا سكربت: %s"
+
+#: ../src/common/webview_chromium.cpp:858
+#, c-format
+msgid "Failed to set proxy \"%s\": %s"
+msgstr "أخفق إعداد الملقم الوكيل \"%s‏\": %s"
+
+#: ../src/common/webview_chromium.cpp:989
+#, fuzzy
+msgid ""
+"Chromium can't be used because libcef.so wasn't loaded early enough; please "
+"relink the application or use LD_PRELOAD to load it earlier."
+msgstr ""
+"يتعذّر استخدام كروميوم لأنّ libcef.so لم يحمَّل مبكراً كفايةً؛ لطفًا أعِد ربط "
+"التطبيق او استخدم LD_PRELOAD لتحميله مبكراً."
+
+#: ../src/common/webview_chromium.cpp:1108
+msgid "Could not initialize Chromium"
+msgstr "تعذّر تجهيز كروميوم"
+
+#: ../src/common/webview_chromium.cpp:1616
+msgid "Show DevTools"
+msgstr "أظهِر أدوات المطور"
+
+#: ../src/common/webview_chromium.cpp:1617
+msgid "Close DevTools"
+msgstr "أغلِق أدوات المطور"
+
+#: ../src/common/webview_chromium.cpp:1623
+msgid "Inspect"
+msgstr "افحص"
+
+#: ../src/common/wincmn.cpp:1628
+msgid "This platform does not support background transparency."
+msgstr "هذه المنصة لا تدعم شفافية الخلفية."
+
+#: ../src/common/wincmn.cpp:2097
+msgid "Could not transfer data to window"
+msgstr "تعذّر نقل البيانات إلى النافذة"
+
+#: ../src/common/windowid.cpp:240
+msgid "Out of window IDs.  Recommend shutting down application."
+msgstr "معرِّفات خارج النافذة.  يُستحسن إطفاء التطبيق."
+
+#: ../src/common/xpmdecod.cpp:678
+msgid "XPM: incorrect header format!"
+msgstr "XPM: نسق ترويسة غير صحيح!"
+
+#: ../src/common/xpmdecod.cpp:703
+#, c-format
+msgid "XPM: incorrect colour description in line %d"
+msgstr "XPM: وصف لون غير صحيح في السطر %d"
+
+#: ../src/common/xpmdecod.cpp:715 ../src/common/xpmdecod.cpp:724
+#, c-format
+msgid "XPM: malformed colour definition '%s' at line %d!"
+msgstr "XPM: تعريف لون مشوه '%s' في السطر %d!"
+
+#: ../src/common/xpmdecod.cpp:754
+msgid "XPM: no colors left to use for mask!"
+msgstr "XPM: لم تتبقَ ألوان لتُستخدم للقناع!"
+
+#: ../src/common/xpmdecod.cpp:781
+#, c-format
+msgid "XPM: truncated image data at line %d!"
+msgstr "XPM: بيانات صورة مقتطَعة في السطر %d!"
+
+#: ../src/common/xpmdecod.cpp:795
+msgid "XPM: Malformed pixel data!"
+msgstr "XPM: بيانات بكسل مشوهة!"
+
+#: ../src/common/xti.cpp:492
+msgid "Illegal Parameter Count for Create Method"
+msgstr "عدد متغيرات وسيطة باطل لطريقة «إنشاء» Create"
+
+#: ../src/common/xti.cpp:504
+msgid "Illegal Parameter Count for ConstructObject Method"
+msgstr "عدد متغيرات وسيطة باطل لطريقة «تركيب الكائن» ConstructObject"
+
+#: ../src/common/xtistrm.cpp:161
+#, c-format
+msgid "Create Parameter %s not found in declared RTTI Parameters"
+msgstr "متغير وسيط الإنشاء %s غير موجود في متغيرات RTTI الوسيطة"
+
+#: ../src/common/xtistrm.cpp:290
+msgid "Illegal Object Class (Non-wxEvtHandler) as Event Source"
+msgstr "فئة كائن باطلة (Non-wxEvtHandler) كمصدر حدث"
+
+#: ../src/common/xtistrm.cpp:313 ../src/common/xtixml.cpp:345
+#: ../src/common/xtixml.cpp:498
+msgid "Type must have enum - long conversion"
+msgstr "يجب أن يكون للنوع تحويل ’تعداد - طويل‘"
+
+#: ../src/common/xtistrm.cpp:400 ../src/common/xtistrm.cpp:415
+msgid "Invalid or Null Object ID passed to GetObjectClassInfo"
+msgstr "مُرّر معرِّف كائن غير صحيح أو فارغ إلى GetObjectClassInfo"
+
+#: ../src/common/xtistrm.cpp:405
+msgid "Unknown Object passed to GetObjectClassInfo"
+msgstr "مُرّر كائن مجهول إلى GetObjectClassInfo"
+
+#: ../src/common/xtistrm.cpp:420
+msgid "Already Registered Object passed to SetObjectClassInfo"
+msgstr "كائن مسجل سلفًا قد مُرّر إلى SetObjectClassInfo"
+
+#: ../src/common/xtistrm.cpp:430
+msgid "Invalid or Null Object ID passed to HasObjectClassInfo"
+msgstr "مُرّر معرِّف كائن غير صحيح أو فارغ إلى HasObjectClassInfo"
+
+#: ../src/common/xtistrm.cpp:460
+msgid "Passing a already registered object to SetObject"
+msgstr "يمرر كائنًا مسجلاً سلفًا إلى SetObject"
+
+#: ../src/common/xtistrm.cpp:471
+msgid "Passing an unknown object to GetObject"
+msgstr "يمرر كائنًا مجهولا إلى GetObject"
+
+#: ../src/common/xtixml.cpp:229
+msgid "Forward hrefs are not supported"
+msgstr "تمرير hrefs غير مدعوم"
+
+#: ../src/common/xtixml.cpp:247
+#, c-format
+msgid "unknown class %s"
+msgstr "فئة مجهولة %s"
+
+#: ../src/common/xtixml.cpp:253
+msgid "objects cannot have XML Text Nodes"
+msgstr "لا يمكن أن يكون للكائنات عقَد XML نصية"
+
+#: ../src/common/xtixml.cpp:258
+msgid "Objects must have an id attribute"
+msgstr "يجب أ ن يكون للكائنات صفة المعرف id"
+
+#: ../src/common/xtixml.cpp:267
+#, c-format
+msgid "Doubly used id : %d"
+msgstr "معرِّف مستخدَم مضاعفًا: %d"
+
+#: ../src/common/xtixml.cpp:316
+#, c-format
+msgid "Unknown Property %s"
+msgstr "خاصية مجهولة %s"
+
+#: ../src/common/xtixml.cpp:407
+msgid "A non empty collection must consist of 'element' nodes"
+msgstr "نجمع غير فارغ يجب أن يتكون من 'عنصر' فروع"
+
+#: ../src/common/xtixml.cpp:478
+msgid "incorrect event handler string, missing dot"
+msgstr "عبارة متولي حدث غير صحيحة، تفتقد نقطة"
+
+#: ../src/common/zipstrm.cpp:559
+msgid "can't re-initialize zlib deflate stream"
+msgstr "يتعذّر إعادة تجهيز دفق zlib التضاؤلي"
+
+#: ../src/common/zipstrm.cpp:584
+msgid "can't re-initialize zlib inflate stream"
+msgstr "يتعذّر إعادة تجهيز دفق zlib التضخمي"
+
+#: ../src/common/zipstrm.cpp:1023
+msgid "Ignoring malformed extra data record, ZIP file may be corrupted"
+msgstr "يهمل قيد البيانات الإضافية المشوه، قد يكون ملف ZIP تالفًا"
+
+#: ../src/common/zipstrm.cpp:1502
+msgid "assuming this is a multi-part zip concatenated"
+msgstr "يفترض أنّ هذا ملف zip متعدد الأجزاء متسلسلاً"
+
+#: ../src/common/zipstrm.cpp:1664
+msgid "invalid zip file"
+msgstr "ملف zip غير صحيح"
+
+#: ../src/common/zipstrm.cpp:1723
+msgid "can't find central directory in zip"
+msgstr "يتعذّر العثور على الدليل المركزي في zip"
+
+#: ../src/common/zipstrm.cpp:1812
+msgid "error reading zip central directory"
+msgstr "خطأ عند قراءة دليل zip المركزي"
+
+#: ../src/common/zipstrm.cpp:1916
+msgid "error reading zip local header"
+msgstr "خطأ عند قراءة ترويسة zip المحلية"
+
+#: ../src/common/zipstrm.cpp:1964
+msgid "bad zipfile offset to entry"
+msgstr "حيود ملف مضغوط zip رديء للمُدخَلة"
+
+#: ../src/common/zipstrm.cpp:2031
+msgid "stored file length not in Zip header"
+msgstr "طول الملف المخزون ليس في ترويسة Zip"
+
+#: ../src/common/zipstrm.cpp:2045 ../src/common/zipstrm.cpp:2362
+msgid "unsupported Zip compression method"
+msgstr "طريقة ضغط zip غير مدعومة"
+
+#: ../src/common/zipstrm.cpp:2126
+#, c-format
+msgid "reading zip stream (entry %s): bad length"
+msgstr "يقرأ دفق zip (المُدخَلة %s): طول تالف"
+
+#: ../src/common/zipstrm.cpp:2131
+#, c-format
+msgid "reading zip stream (entry %s): bad crc"
+msgstr "يقرأ دفق zip (المُدخَلة %s): crc تالف"
+
+#: ../src/common/zipstrm.cpp:2578
+#, c-format
+msgid "error writing zip entry '%s': file too large without ZIP64"
+msgstr "خطأ عند كتابة مُدخَلة zip '%s': الملف كبير للغاية بلا ZIP64"
+
+#: ../src/common/zipstrm.cpp:2585
+#, c-format
+msgid "error writing zip entry '%s': bad crc or length"
+msgstr "خطأ عند كتابة مُدخَلة zip '%s': طول أو crc تالف"
+
+#: ../src/common/zstream.cpp:155 ../src/common/zstream.cpp:315
+msgid "Gzip not supported by this version of zlib"
+msgstr "هذا الاصدار من zlib لا يدعم Gzip"
+
+#: ../src/common/zstream.cpp:182
+msgid "Can't initialize zlib inflate stream."
+msgstr "يتعذّر تجهيز دفق zlib التضخمي."
+
+#: ../src/common/zstream.cpp:241
+msgid "Can't read inflate stream: unexpected EOF in underlying stream."
+msgstr "تعذّرت قراءة دفق التضخم: نهاية ملف EOF غير متوقعة في الدفق المستبطن."
+
+#: ../src/common/zstream.cpp:248 ../src/common/zstream.cpp:423
+#, c-format
+msgid "zlib error %d"
+msgstr "خطأ zlib‏ %d"
+
+#: ../src/common/zstream.cpp:249
+#, c-format
+msgid "Can't read from inflate stream: %s"
+msgstr "تتعذّر القراءة من الدفق التضخمي: %s"
+
+#: ../src/common/zstream.cpp:343
+msgid "Can't initialize zlib deflate stream."
+msgstr "يتعذّر تجهيز دفق zlib التضاؤلي."
+
+#: ../src/common/zstream.cpp:424
+#, c-format
+msgid "Can't write to deflate stream: %s"
+msgstr "تتعذّر الكتابة الى الدفق التضاؤلي: %s"
+
+#: ../src/dfb/bitmap.cpp:633 ../src/dfb/bitmap.cpp:667
+#, c-format
+msgid "No bitmap handler for type %d defined."
+msgstr "لم يعرَّف متولِّي bitmap للنوع %d."
+
+#: ../src/dfb/evtloop.cpp:99
+msgid "Failed to read event from DirectFB pipe"
+msgstr "أخفقت قراءة الحدث من مسرى DirectFB"
+
+#: ../src/dfb/evtloop.cpp:171
+msgid "Failed to switch DirectFB pipe to non-blocking mode"
+msgstr "أخفق تبديل مسرى DirectFB إلى وضع عدم الغلق"
+
+#: ../src/dfb/fontmgr.cpp:171
+#, c-format
+msgid "no fonts found in %s, using builtin font"
+msgstr "لم يعثر على خطوط في %s، ستُستخدَم الخطوط الداخلية"
+
+#: ../src/dfb/fontmgr.cpp:177
+msgid "Default font"
+msgstr "الخط الافتراضي"
+
+#: ../src/dfb/fontmgr.cpp:195
+#, c-format
+msgid "Fonts index file %s disappeared while loading fonts."
+msgstr "اختفى ملف فهرسة الخطوط %s أثناء تحميل الخطوط."
+
+#: ../src/dfb/wrapdfb.cpp:60
+#, c-format
+msgid "DirectFB error %d occurred."
+msgstr "حصل خطأ DirectFB %d."
+
+#: ../src/generic/aboutdlgg.cpp:69
+msgid "Developed by "
+msgstr "طوّره "
+
+#: ../src/generic/aboutdlgg.cpp:72
+msgid "Documentation by "
+msgstr "التوثيق بواسطة "
+
+#: ../src/generic/aboutdlgg.cpp:75
+msgid "Graphics art by "
+msgstr "فن الرسوم بواسطة "
+
+#: ../src/generic/aboutdlgg.cpp:78
+msgid "Translations by "
+msgstr "الترجمات بواسطة "
+
+#: ../src/generic/aboutdlgg.cpp:133 ../src/osx/cocoa/aboutdlg.mm:83
+msgid "Version "
+msgstr "الإصدار "
+
+#. TRANSLATORS: %s is application name
+#: ../src/generic/aboutdlgg.cpp:146 ../src/msw/aboutdlg.cpp:60
+#, c-format
+msgid "About %s"
+msgstr "عن %s"
+
+#: ../src/generic/aboutdlgg.cpp:181
+msgid "License"
+msgstr "الترخيص"
+
+#: ../src/generic/aboutdlgg.cpp:184
+msgid "Developers"
+msgstr "المطورون"
+
+#: ../src/generic/aboutdlgg.cpp:188
+msgid "Documentation writers"
+msgstr "كتّاب ملفات المساعدة"
+
+#: ../src/generic/aboutdlgg.cpp:192
+msgid "Artists"
+msgstr "الفنانون"
+
+#: ../src/generic/aboutdlgg.cpp:196
+msgid "Translators"
+msgstr "المترجمون"
+
+#: ../src/generic/animateg.cpp:125
+msgid "No handler found for animation type."
+msgstr "لم يُعثر على متولٍ لنوع الحركة."
+
+#: ../src/generic/animateg.cpp:133
+#, c-format
+msgid "No animation handler for type %ld defined."
+msgstr "لم يعرَّف متولي حركة للنوع %ld."
+
+#: ../src/generic/animateg.cpp:145
+#, c-format
+msgid "Animation file is not of type %ld."
+msgstr "ملف الحركة ليس من نوع %ld."
+
+#: ../src/generic/colrdlgg.cpp:154 ../src/gtk/colordlg.cpp:47
+msgid "Choose colour"
+msgstr "اختر اللون"
+
+#: ../src/generic/colrdlgg.cpp:357
+msgid "Red:"
+msgstr "أحمر:"
+
+#: ../src/generic/colrdlgg.cpp:360
+msgid "Green:"
+msgstr "أخضر:"
+
+#: ../src/generic/colrdlgg.cpp:363
+msgid "Blue:"
+msgstr "أزرق:"
+
+#: ../src/generic/colrdlgg.cpp:372
+msgid "Opacity:"
+msgstr "العتامة:"
+
+#: ../src/generic/colrdlgg.cpp:384
+msgid "Add to custom colours"
+msgstr "أضف للألوان المخصصة"
+
+#: ../src/generic/creddlgg.cpp:56
+msgid "Username:"
+msgstr "اسم المستخدم:"
+
+#: ../src/generic/creddlgg.cpp:63
+msgid "Password:"
+msgstr "كلمة المرور:"
+
+#. TRANSLATORS: Name of Boolean true value
+#: ../src/generic/datavgen.cpp:1178
+msgid "true"
+msgstr "صحيح"
+
+#. TRANSLATORS: Name of Boolean false value
+#: ../src/generic/datavgen.cpp:1180
+msgid "false"
+msgstr "خطأ"
+
+#: ../src/generic/datavgen.cpp:6897
+#, c-format
+msgid "Row %i"
+msgstr "الصف %i"
+
+#. TRANSLATORS: Action for manipulating a tree control
+#: ../src/generic/datavgen.cpp:6987
+msgid "Collapse"
+msgstr "اطوِ"
+
+#. TRANSLATORS: Action for manipulating a tree control
+#: ../src/generic/datavgen.cpp:6990
+msgid "Expand"
+msgstr "وسّع"
+
+#. TRANSLATORS: Name of data view control and number of rows
+#: ../src/generic/datavgen.cpp:7011
+#, c-format
+msgid "%s (%d items)"
+msgstr "%s (%d عنصر)"
+
+#: ../src/generic/datavgen.cpp:7062
+#, c-format
+msgid "Column %u"
+msgstr "العمود %u"
+
+#. TRANSLATORS: Keystroke for manipulating a tree control
+#: ../src/generic/datavgen.cpp:7131 ../src/richtext/richtextbulletspage.cpp:189
+#: ../src/richtext/richtextbulletspage.cpp:192
+#: ../src/richtext/richtextbulletspage.cpp:193
+#: ../src/richtext/richtextliststylepage.cpp:252
+#: ../src/richtext/richtextliststylepage.cpp:255
+#: ../src/richtext/richtextliststylepage.cpp:256
+#: ../src/richtext/richtextsizepage.cpp:248
+msgid "Left"
+msgstr "يسار"
+
+#. TRANSLATORS: Keystroke for manipulating a tree control
+#: ../src/generic/datavgen.cpp:7134 ../src/richtext/richtextbulletspage.cpp:191
+#: ../src/richtext/richtextliststylepage.cpp:254
+#: ../src/richtext/richtextsizepage.cpp:249
+msgid "Right"
+msgstr "يمين"
+
+#: ../src/generic/datectlg.cpp:90
+#, c-format
+msgid ""
+"\"%s\" is not in the expected date format, please enter it as e.g. \"%s\"."
+msgstr "ليس \"%s\" بنسَق التاريخ المتوقع، لطفًا أدخِله هكذا مثلاً \"%s\"."
+
+#: ../src/generic/datectlg.cpp:94
+msgid "Invalid date"
+msgstr "تاريخ غير صحيح"
+
+#: ../src/generic/dbgrptg.cpp:159
+#, c-format
+msgid "Open file \"%s\""
+msgstr "افتح الملف \"%s\""
+
+#: ../src/generic/dbgrptg.cpp:170
+#, c-format
+msgid "Enter command to open file \"%s\":"
+msgstr "أدخِل أمراً لفتح الملف \"%s\":"
+
+#: ../src/generic/dbgrptg.cpp:230
+msgid "Executable files (*.exe)|*.exe|"
+msgstr "ملفات تنفيذية (*.exe)|*.exe|"
+
+#: ../src/generic/dbgrptg.cpp:300
+#, c-format
+msgid "Debug report \"%s\""
+msgstr "تقرير إزالة العلل \"%s\""
+
+#: ../src/generic/dbgrptg.cpp:316
+msgid "A debug report has been generated in the directory\n"
+msgstr "وُلّد تقرير إزالة علل في الدليل\n"
+
+#: ../src/generic/dbgrptg.cpp:317
+msgid "The following debug report will be generated\n"
+msgstr "سيُولَّد تقرير إزالة العلل التالي\n"
+
+#: ../src/generic/dbgrptg.cpp:321
+msgid ""
+"The report contains the files listed below. If any of these files contain "
+"private information,\n"
+"please uncheck them and they will be removed from the report.\n"
+msgstr ""
+"التقرير يحوي الملفات المدرجة في أدناه. إذا كان أي من هذه الملفات يحوي "
+"معلومات خصوصية،\n"
+"فالرجاء إزالة تأشيرها وستُزال من التقرير.\n"
+
+#: ../src/generic/dbgrptg.cpp:323
+msgid ""
+"If you wish to suppress this debug report completely, please choose the "
+"\"Cancel\" button,\n"
+"but be warned that it may hinder improving the program, so if\n"
+"at all possible please do continue with the report generation.\n"
+msgstr ""
+"إذا رغبت في إخماد تقرير إزالة العلل هذا كليًا فالرجاء أن تختار زِر \"ألغِ\"،\n"
+"لكن كن على علم أنّ هذا قد يعيق تحسين البرنامج، لذا إن أمكن\n"
+"بأية طريقة ممكنة فالرجاء استمر بتوليد التقرير.\n"
+
+#: ../src/generic/dbgrptg.cpp:325
+msgid "              Thank you and we're sorry for the inconvenience!\n"
+msgstr "              شكرا ونعتذر عن الإزعاج غير المقصود!\n"
+
+#: ../src/generic/dbgrptg.cpp:333
+msgid "&Debug report preview:"
+msgstr "معاينة &تقرير إزالة العلل:"
+
+#: ../src/generic/dbgrptg.cpp:339
+msgid "&View..."
+msgstr "&عايِن..."
+
+#: ../src/generic/dbgrptg.cpp:359
+msgid "&Notes:"
+msgstr "&ملحوظات:"
+
+#: ../src/generic/dbgrptg.cpp:361
+msgid ""
+"If you have any additional information pertaining to this bug\n"
+"report, please enter it here and it will be joined to it:"
+msgstr ""
+"إن كانت لديك معلومات إضافية ذات صلة بتقرير العلة\n"
+"هذه فالرجاء إدخالها هنا وستُلحق به:"
+
+#: ../src/generic/dcpsg.cpp:1627
+msgid "Cannot open file for PostScript printing!"
+msgstr "تعذّر فتح الملف لطباعة PostScript!"
+
+#: ../src/generic/dirctrlg.cpp:402
+msgid "Computer"
+msgstr "حاسوب"
+
+#: ../src/generic/dirctrlg.cpp:404
+msgid "Sections"
+msgstr "أقسام"
+
+#: ../src/generic/dirctrlg.cpp:482
+msgid "Home directory"
+msgstr "دليل «المنزل»"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/generic/dirctrlg.cpp:484 ../src/propgrid/advprops.cpp:811
+msgid "Desktop"
+msgstr "سطح المكتب"
+
+#: ../src/generic/dirctrlg.cpp:528 ../src/generic/filectrlg.cpp:752
+msgid "Illegal directory name."
+msgstr "اسم الدليل باطل."
+
+#: ../src/generic/dirctrlg.cpp:528 ../src/generic/dirctrlg.cpp:546
+#: ../src/generic/dirctrlg.cpp:557 ../src/generic/dirdlgg.cpp:317
+#: ../src/generic/filectrlg.cpp:638 ../src/generic/filectrlg.cpp:752
+#: ../src/generic/filectrlg.cpp:766 ../src/generic/filectrlg.cpp:782
+#: ../src/generic/filectrlg.cpp:1356 ../src/generic/filectrlg.cpp:1387
+#: ../src/generic/filedlgg.cpp:362 ../src/gtk/filedlg.cpp:76
+msgid "Error"
+msgstr "خطأ"
+
+#: ../src/generic/dirctrlg.cpp:546 ../src/generic/filectrlg.cpp:766
+msgid "File name exists already."
+msgstr "اسم الملف موجود سلفًا."
+
+#: ../src/generic/dirctrlg.cpp:557 ../src/generic/dirdlgg.cpp:317
+#: ../src/generic/filectrlg.cpp:638 ../src/generic/filectrlg.cpp:782
+msgid "Operation not permitted."
+msgstr "العملية غير مسموح بها."
+
+#: ../src/generic/dirdlgg.cpp:107 ../src/generic/filedlgg.cpp:207
+msgid "Create new directory"
+msgstr "أنشئ دليلاً جديداً"
+
+#: ../src/generic/dirdlgg.cpp:112 ../src/generic/filedlgg.cpp:203
+msgid "Go to home directory"
+msgstr "اذهب الى دليل «المنزل»"
+
+#: ../src/generic/dirdlgg.cpp:143
+msgid "Show &hidden directories"
+msgstr "أظهر الدلائل الم&خفية"
+
+#: ../src/generic/dirdlgg.cpp:196
+#, c-format
+msgid ""
+"The directory '%s' does not exist\n"
+"Create it now?"
+msgstr ""
+"الدليل '%s' غير موجود\n"
+"إنشاؤه الآن؟"
+
+#: ../src/generic/dirdlgg.cpp:198
+msgid "Directory does not exist"
+msgstr "المجلد غير موجود"
+
+#: ../src/generic/dirdlgg.cpp:214
+#, c-format
+msgid ""
+"Failed to create directory '%s'\n"
+"(Do you have the required permissions?)"
+msgstr ""
+"أخفق إنشاء الدليل '%s'\n"
+"(ألديك التصاريح اللازمة؟)"
+
+#: ../src/generic/dirdlgg.cpp:216
+msgid "Error creating directory"
+msgstr "خطأ عند إنشاء الدليل"
+
+#: ../src/generic/dirdlgg.cpp:281
+msgid "You cannot add a new directory to this section."
+msgstr "لا يمكنك إضافة دليل جديد إلى هذا القسم."
+
+#: ../src/generic/dirdlgg.cpp:282
+msgid "Create directory"
+msgstr "أنشئ دليلاً"
+
+#: ../src/generic/dirdlgg.cpp:291 ../src/generic/dirdlgg.cpp:301
+#: ../src/generic/filectrlg.cpp:614 ../src/generic/filectrlg.cpp:623
+msgid "NewName"
+msgstr "اسم جديد"
+
+#: ../src/generic/editlbox.cpp:135
+msgid "Edit item"
+msgstr "حرر العنصر"
+
+#: ../src/generic/editlbox.cpp:143
+msgid "New item"
+msgstr "عنصر جديد"
+
+#: ../src/generic/editlbox.cpp:151
+msgid "Delete item"
+msgstr "حذف العنصر"
+
+#: ../src/generic/editlbox.cpp:159
+msgid "Move up"
+msgstr "تحريك لأعلى"
+
+#: ../src/generic/editlbox.cpp:164
+msgid "Move down"
+msgstr "تحريك لأسفل"
+
+#: ../src/generic/fdrepdlg.cpp:108
+msgid "Search for:"
+msgstr "بحث عن:"
+
+#: ../src/generic/fdrepdlg.cpp:120
+msgid "Replace with:"
+msgstr "استبدال ب:"
+
+#: ../src/generic/fdrepdlg.cpp:140
+msgid "Whole word"
+msgstr "كلمة كاملة"
+
+#: ../src/generic/fdrepdlg.cpp:143
+msgid "Match case"
+msgstr "توافق الحالة"
+
+#: ../src/generic/fdrepdlg.cpp:156
+msgid "Search direction"
+msgstr "اتجاه البحث"
+
+#: ../src/generic/fdrepdlg.cpp:175
+msgid "&Replace"
+msgstr "&إستبدال"
+
+#: ../src/generic/fdrepdlg.cpp:178
+msgid "Replace &all"
+msgstr "استبدال ال&كل"
+
+#: ../src/generic/filectrlg.cpp:246 ../src/generic/filectrlg.cpp:269
+msgid "<DIR>"
+msgstr "<DIR>"
+
+#: ../src/generic/filectrlg.cpp:248 ../src/generic/filectrlg.cpp:271
+msgid "<LINK>"
+msgstr "<LINK>"
+
+#: ../src/generic/filectrlg.cpp:250 ../src/generic/filectrlg.cpp:273
+msgid "<DRIVE>"
+msgstr "<DRIVE>"
+
+#: ../src/generic/filectrlg.cpp:275
+#, c-format
+msgid "%ld byte"
+msgid_plural "%ld bytes"
+msgstr[0] "صفر بايت"
+msgstr[1] "بايت واحد"
+msgstr[2] "بايتان اثنان"
+msgstr[3] "%ld بايتات"
+msgstr[4] "%ld بايت"
+msgstr[5] "%ld بايت"
+
+#: ../src/generic/filectrlg.cpp:420
+msgid "Name"
+msgstr "الاسم"
+
+#: ../src/generic/filectrlg.cpp:421 ../src/richtext/richtextformatdlg.cpp:361
+#: ../src/richtext/richtextsizepage.cpp:298
+msgid "Size"
+msgstr "الحجم"
+
+#: ../src/generic/filectrlg.cpp:422
+msgid "Type"
+msgstr "النوع"
+
+#: ../src/generic/filectrlg.cpp:423
+msgid "Modified"
+msgstr "التعديل"
+
+#: ../src/generic/filectrlg.cpp:426
+msgid "Permissions"
+msgstr "التصاريح"
+
+#: ../src/generic/filectrlg.cpp:429
+msgid "Attributes"
+msgstr "الصفات"
+
+#: ../src/generic/filectrlg.cpp:936
+msgid "Current directory:"
+msgstr "الدليل الحالي:"
+
+#: ../src/generic/filectrlg.cpp:979
+msgid "Show &hidden files"
+msgstr "أظهر الملفات الم&خفية"
+
+#: ../src/generic/filectrlg.cpp:1355
+msgid "Illegal file specification."
+msgstr "مواصفات ملف باطلة."
+
+#: ../src/generic/filectrlg.cpp:1387
+msgid "Directory doesn't exist."
+msgstr "المجلد غير موجود."
+
+#: ../src/generic/filedlgg.cpp:195
+msgid "View files as a list view"
+msgstr "عاين الملفات معاينة قائمة"
+
+#: ../src/generic/filedlgg.cpp:197
+msgid "View files as a detailed view"
+msgstr "عاين الملفات معاينة تفصيلية"
+
+#: ../src/generic/filedlgg.cpp:200
+msgid "Go to parent directory"
+msgstr "اذهب الى الدليل الحاضن"
+
+#: ../src/generic/filedlgg.cpp:351 ../src/gtk/filedlg.cpp:59
+#, c-format
+msgid "File '%s' already exists, do you really want to overwrite it?"
+msgstr "الملف '%s' موجود سلفًا، أتريد حقًا الكتابة عليه؟"
+
+#: ../src/generic/filedlgg.cpp:354 ../src/gtk/filedlg.cpp:62
+msgid "Confirm"
+msgstr "تأكيد"
+
+#: ../src/generic/filedlgg.cpp:362 ../src/gtk/filedlg.cpp:75
+msgid "Please choose an existing file."
+msgstr "لطفًا اختر ملفاً موجوداً."
+
+#: ../src/generic/filepickerg.cpp:64
+msgid "..."
+msgstr "..."
+
+#: ../src/generic/fontdlgg.cpp:76 ../src/richtext/richtextformatdlg.cpp:519
+msgid "ABCDEFGabcdefg12345"
+msgstr "ABCDEFGabcdefg12345"
+
+#: ../src/generic/fontdlgg.cpp:315
+msgid "Roman"
+msgstr "روماني"
+
+#: ../src/generic/fontdlgg.cpp:316
+msgid "Decorative"
+msgstr "مزخرف"
+
+#: ../src/generic/fontdlgg.cpp:317
+msgid "Modern"
+msgstr "حديث"
+
+#: ../src/generic/fontdlgg.cpp:318
+msgid "Script"
+msgstr "ملحق برمجي"
+
+#: ../src/generic/fontdlgg.cpp:319
+msgid "Swiss"
+msgstr "سويسري"
+
+#: ../src/generic/fontdlgg.cpp:320
+msgid "Teletype"
+msgstr "نوع تيليتايب"
+
+#: ../src/generic/fontdlgg.cpp:321 ../src/generic/fontdlgg.cpp:324
+msgid "Normal"
+msgstr "اعتيادي"
+
+#: ../src/generic/fontdlgg.cpp:323
+msgid "Slant"
+msgstr "مائل"
+
+#: ../src/generic/fontdlgg.cpp:325
+msgid "Light"
+msgstr "فاتح"
+
+#: ../src/generic/fontdlgg.cpp:363
+msgid "&Font family:"
+msgstr "&عائلة خط:"
+
+#: ../src/generic/fontdlgg.cpp:367 ../src/generic/fontdlgg.cpp:369
+msgid "The font family."
+msgstr "عائلة الخط."
+
+#: ../src/generic/fontdlgg.cpp:374 ../src/richtext/richtextstylepage.cpp:105
+msgid "&Style:"
+msgstr "&طراز:"
+
+#: ../src/generic/fontdlgg.cpp:378 ../src/generic/fontdlgg.cpp:380
+msgid "The font style."
+msgstr "طراز الخط."
+
+#: ../src/generic/fontdlgg.cpp:385
+msgid "&Weight:"
+msgstr "&وزن:"
+
+#: ../src/generic/fontdlgg.cpp:389 ../src/generic/fontdlgg.cpp:391
+msgid "The font weight."
+msgstr "وزن الخط."
+
+#: ../src/generic/fontdlgg.cpp:399
+msgid "C&olour:"
+msgstr "&لون:"
+
+#: ../src/generic/fontdlgg.cpp:407 ../src/generic/fontdlgg.cpp:409
+msgid "The font colour."
+msgstr "لون الخط."
+
+#: ../src/generic/fontdlgg.cpp:415
+msgid "&Point size:"
+msgstr "حجم ال&نقطة:"
+
+#: ../src/generic/fontdlgg.cpp:420 ../src/generic/fontdlgg.cpp:422
+#: ../src/generic/fontdlgg.cpp:426 ../src/generic/fontdlgg.cpp:428
+msgid "The font point size."
+msgstr "حجم نقطة الخط."
+
+#: ../src/generic/fontdlgg.cpp:439 ../src/generic/fontdlgg.cpp:441
+msgid "Whether the font is underlined."
+msgstr "فيما لو كان تحته خط."
+
+#: ../src/generic/fontdlgg.cpp:448 ../src/html/helpwnd.cpp:1215
+msgid "Preview:"
+msgstr "معاينة:"
+
+#: ../src/generic/fontdlgg.cpp:452 ../src/generic/fontdlgg.cpp:454
+msgid "Shows the font preview."
+msgstr "يُظهر معاينة للخط."
+
+#: ../src/generic/fontdlgg.cpp:464 ../src/generic/fontdlgg.cpp:483
+msgid "Click to cancel the font selection."
+msgstr "انقر لإلغاء اختيار الخط."
+
+#: ../src/generic/fontdlgg.cpp:469 ../src/generic/fontdlgg.cpp:471
+#: ../src/generic/fontdlgg.cpp:476 ../src/generic/fontdlgg.cpp:478
+msgid "Click to confirm the font selection."
+msgstr "انقر لتأكيد اختيار الخط."
+
+#: ../src/generic/fontpickerg.cpp:50 ../src/gtk/fontdlg.cpp:77
+msgid "Choose font"
+msgstr "اختر الخط"
+
+#: ../src/generic/grid.cpp:6542
+msgid ""
+"Error copying grid to the clipboard. Either selected cells were not "
+"contiguous or no cell was selected."
+msgstr ""
+"خطأ في نسْخ الشبكة الى الحافظة. إمّا أنّ الخلايا المحددة لم تكن متجاورة أو لم "
+"تحدد خلايا."
+
+#: ../src/generic/grid.cpp:12739
+msgid "Grid Corner"
+msgstr "زاوية الشبكة"
+
+#: ../src/generic/grid.cpp:12741
+#, c-format
+msgid "Column %s Header"
+msgstr "ترويسة العمود %s"
+
+#: ../src/generic/grid.cpp:12743
+#, c-format
+msgid "Row %s Header"
+msgstr "ترويسة الصف %s"
+
+#: ../src/generic/grid.cpp:12745
+#, c-format
+msgid "Column %s: %s"
+msgstr "العمود %s‏: %s"
+
+#: ../src/generic/grid.cpp:12749
+#, c-format
+msgid "Row %s: %s"
+msgstr "الصف %s‏: %s"
+
+#: ../src/generic/grid.cpp:12753
+#, c-format
+msgid "Row %s, Column %s: %s"
+msgstr "الصف %s، العمود %s‏: %s"
+
+#: ../src/generic/helpext.cpp:257
+#, c-format
+msgid "Help directory \"%s\" not found."
+msgstr "دليل المساعدة \"%s\" غير موجود."
+
+#: ../src/generic/helpext.cpp:265
+#, c-format
+msgid "Help file \"%s\" not found."
+msgstr "ملف المساعدة \"%s\" غير موجود."
+
+#: ../src/generic/helpext.cpp:284
+#, c-format
+msgid "Line %lu of map file \"%s\" has invalid syntax, skipped."
+msgstr "السطر %lu لملف الخريطة \"%s\" له بناء غير صحيح، نتخطاه."
+
+#: ../src/generic/helpext.cpp:292
+#, c-format
+msgid "No valid mappings found in the file \"%s\"."
+msgstr "لم يعثر على ترسيمات صحيحة في الملف \"%s\"."
+
+#: ../src/generic/helpext.cpp:435
+msgid "No entries found."
+msgstr "لم يعثر على مُدخَلات."
+
+#: ../src/generic/helpext.cpp:444 ../src/generic/helpext.cpp:445
+msgid "Help Index"
+msgstr "كشاف المساعدة"
+
+#: ../src/generic/helpext.cpp:448
+msgid "Relevant entries:"
+msgstr "مدخلات متقاربة:"
+
+#: ../src/generic/helpext.cpp:449
+msgid "Entries found"
+msgstr "عُثر على مُدخَلات"
+
+#: ../src/generic/hyperlinkg.cpp:170
+msgid "&Copy URL"
+msgstr "ا&نسخ الرابط"
+
+#: ../src/generic/infobar.cpp:119
+msgid "Hide this notification message."
+msgstr "أخفِ رسالة التنبيه هذه."
+
+#. TRANSLATORS: %s will be either the application name or "Application"
+#: ../src/generic/logg.cpp:257
+#, c-format
+msgid "%s Error"
+msgstr "%s خطأ"
+
+#. TRANSLATORS: %s will be either the application name or "Application"
+#: ../src/generic/logg.cpp:263
+#, c-format
+msgid "%s Warning"
+msgstr "%s تحذير"
+
+#. TRANSLATORS: %s will be either the application name or "Application"
+#: ../src/generic/logg.cpp:273
+#, c-format
+msgid "%s Information"
+msgstr "%s معلومات"
+
+#: ../src/generic/logg.cpp:276
+msgid "Application"
+msgstr "التطبيق"
+
+#: ../src/generic/logg.cpp:549
+msgid "Save log contents to file"
+msgstr "احفظ محتويات السجل في ملف"
+
+#: ../src/generic/logg.cpp:551
+msgid "C&lear"
+msgstr "&امحُ"
+
+#: ../src/generic/logg.cpp:551
+msgid "Clear the log contents"
+msgstr "امحُ محتوى السجل"
+
+#: ../src/generic/logg.cpp:553
+msgid "Close this window"
+msgstr "أغلق هذه النافذة"
+
+#: ../src/generic/logg.cpp:554
+msgid "&Log"
+msgstr "&سجل"
+
+#: ../src/generic/logg.cpp:610 ../src/generic/logg.cpp:992
+msgid "Can't save log contents to file."
+msgstr "تعذّر حفظ محتوى السجل في ملف."
+
+#: ../src/generic/logg.cpp:613
+#, c-format
+msgid "Log saved to the file '%s'."
+msgstr "حُفظ السجل في الملف '%s'."
+
+#: ../src/generic/logg.cpp:719
+msgid "&Details"
+msgstr "ال&تفاصيل"
+
+#: ../src/generic/logg.cpp:972
+msgid "Failed to copy dialog contents to the clipboard."
+msgstr "أخفق نسخ محتويات الحوار الى الحافظة."
+
+#: ../src/generic/logg.cpp:1022
+#, c-format
+msgid "Append log to file '%s' (choosing [No] will overwrite it)?"
+msgstr "إرفاق السجل بالملف '%s' (اختيار [لا] سيتخطاه)؟"
+
+#: ../src/generic/logg.cpp:1024
+msgid "Question"
+msgstr "سؤال"
+
+#: ../src/generic/logg.cpp:1038
+msgid "invalid message box return value"
+msgstr "قيمة مُرجَعة غير صحيحة من صندوق الرسائل"
+
+#: ../src/generic/notifmsgg.cpp:129
+msgid "Notice"
+msgstr "ملحوظة"
+
+#: ../src/generic/preferencesg.cpp:118
+#, c-format
+msgid "%s Preferences"
+msgstr "تفضيلات %s"
+
+#: ../src/generic/printps.cpp:143
+msgid "Printing..."
+msgstr "يطبع..."
+
+#: ../src/generic/printps.cpp:160 ../src/gtk/print.cpp:1076
+#: ../src/msw/printwin.cpp:235
+msgid "Could not start printing."
+msgstr "تعذّر بدء الطباعة."
+
+#: ../src/generic/printps.cpp:183
+#, c-format
+msgid "Printing page %d..."
+msgstr "يطبع الصفحة %d..."
+
+#: ../src/generic/prntdlgg.cpp:171
+msgid "Printer options"
+msgstr "خيارات الطابعة"
+
+#: ../src/generic/prntdlgg.cpp:176
+msgid "Print to File"
+msgstr "إطبع لملف"
+
+#: ../src/generic/prntdlgg.cpp:179
+msgid "Setup..."
+msgstr "إعداد..."
+
+#: ../src/generic/prntdlgg.cpp:187
+msgid "Printer:"
+msgstr "الطابعة:"
+
+#: ../src/generic/prntdlgg.cpp:195
+msgid "Status:"
+msgstr "الحالة:"
+
+#: ../src/generic/prntdlgg.cpp:206
+msgid "All"
+msgstr "الكل"
+
+#: ../src/generic/prntdlgg.cpp:207
+msgid "Pages"
+msgstr "صفحات"
+
+#: ../src/generic/prntdlgg.cpp:215
+msgid "Print Range"
+msgstr "مدى الطباعة"
+
+#: ../src/generic/prntdlgg.cpp:229
+msgid "From:"
+msgstr "من:"
+
+#: ../src/generic/prntdlgg.cpp:233
+msgid "To:"
+msgstr "إلى:"
+
+#: ../src/generic/prntdlgg.cpp:238
+msgid "Copies:"
+msgstr "نُسخ:"
+
+#: ../src/generic/prntdlgg.cpp:288
+msgid "PostScript file"
+msgstr "ملف PostScript"
+
+#: ../src/generic/prntdlgg.cpp:439
+msgid "Print Setup"
+msgstr "إعدادات الطباعة"
+
+#: ../src/generic/prntdlgg.cpp:483
+msgid "Printer"
+msgstr "الطابعة"
+
+#: ../src/generic/prntdlgg.cpp:501
+msgid "Default printer"
+msgstr "الطابعة الافتراضية"
+
+#: ../src/generic/prntdlgg.cpp:595 ../src/generic/prntdlgg.cpp:782
+#: ../src/generic/prntdlgg.cpp:822 ../src/generic/prntdlgg.cpp:835
+#: ../src/generic/prntdlgg.cpp:1031 ../src/generic/prntdlgg.cpp:1036
+msgid "Paper size"
+msgstr "حجم الورقة"
+
+#: ../src/generic/prntdlgg.cpp:604 ../src/generic/prntdlgg.cpp:847
+msgid "Portrait"
+msgstr "عرضي"
+
+#: ../src/generic/prntdlgg.cpp:605 ../src/generic/prntdlgg.cpp:848
+msgid "Landscape"
+msgstr "طولي"
+
+#: ../src/generic/prntdlgg.cpp:607 ../src/generic/prntdlgg.cpp:849
+msgid "Orientation"
+msgstr "التوجيه"
+
+#: ../src/generic/prntdlgg.cpp:610
+msgid "Options"
+msgstr "خيارات"
+
+#: ../src/generic/prntdlgg.cpp:612
+msgid "Print in colour"
+msgstr "اطبع بالالوان"
+
+#: ../src/generic/prntdlgg.cpp:621
+msgid "Print spooling"
+msgstr "لفيفة الطباعة"
+
+#: ../src/generic/prntdlgg.cpp:623
+msgid "Printer command:"
+msgstr "أمر الطابعة:"
+
+#: ../src/generic/prntdlgg.cpp:631
+msgid "Printer options:"
+msgstr "خيارات الطابعة:"
+
+#: ../src/generic/prntdlgg.cpp:860
+msgid "Left margin (mm):"
+msgstr "الهامش الايسر (ملم):"
+
+#: ../src/generic/prntdlgg.cpp:861
+msgid "Top margin (mm):"
+msgstr "الهامش الاعلى (ملم):"
+
+#: ../src/generic/prntdlgg.cpp:872
+msgid "Right margin (mm):"
+msgstr "الهامش الايمن (ملم):"
+
+#: ../src/generic/prntdlgg.cpp:873
+msgid "Bottom margin (mm):"
+msgstr "الهامش الأسفل (ملم):"
+
+#: ../src/generic/prntdlgg.cpp:896
+msgid "Printer..."
+msgstr "الطابعة..."
+
+#: ../src/generic/progdlgg.cpp:246
+msgid "&Skip"
+msgstr "ت&جاوز"
+
+#: ../src/generic/progdlgg.cpp:347 ../src/generic/progdlgg.cpp:626
+msgid "Unknown"
+msgstr "مجهول"
+
+#: ../src/generic/progdlgg.cpp:451 ../src/msw/progdlg.cpp:526
+msgid "Done."
+msgstr "تم."
+
+#: ../src/generic/srchctlg.cpp:55 ../src/gtk/srchctrl.cpp:206
+#: ../src/html/helpwnd.cpp:530 ../src/html/helpwnd.cpp:545
+msgid "Search"
+msgstr "بحث"
+
+#: ../src/generic/tabg.cpp:1026
+msgid "Could not find tab for id"
+msgstr "تعذّر العثور على لسان للمعرِّف"
+
+#: ../src/generic/tipdlg.cpp:136
+msgid "Tips not available, sorry!"
+msgstr "التلميحات غير متاحة، نأسف!"
+
+#: ../src/generic/tipdlg.cpp:197
+msgid "Tip of the Day"
+msgstr "تلميحة اليوم"
+
+#: ../src/generic/tipdlg.cpp:207
+msgid "Did you know..."
+msgstr "هل علمت..."
+
+#: ../src/generic/tipdlg.cpp:232
+msgid "&Show tips at startup"
+msgstr "إ&ظهار التنبيهات عند بدء التشغيل"
+
+#: ../src/generic/tipdlg.cpp:236
+msgid "&Next Tip"
+msgstr "التلميحة التال&ية"
+
+#: ../src/generic/wizard.cpp:411
+msgid "&Next >"
+msgstr "التا&لي>"
+
+#: ../src/generic/wizard.cpp:412
+msgid "&Finish"
+msgstr "إ&نهاء"
+
+#: ../src/generic/wizard.cpp:420
+msgid "< &Back"
+msgstr "< &عودة"
+
+#: ../src/gtk/aboutdlg.cpp:204
+msgid "translator-credits"
+msgstr ""
+"Abdullah Abouzekry <abouzekry@gmail.com>\n"
+"Fatma Mehanna <fatma.mehanna@gmail.com>\n"
+"Amar <al_janabi7@yahoo.com>"
+
+#: ../src/gtk/app.cpp:517
+msgid ""
+"WARNING: using XIM input method is unsupported and may result in problems "
+"with input handling and flickering. Consider unsetting GTK_IM_MODULE or "
+"setting to \"ibus\"."
+msgstr ""
+"تحذير: استخدام طريقة إدخال XIM غير مدعوم وقد يتسبب في مشاكل في التعامل مع "
+"الإدخال والإرجاف. ضع في اعتبارك إزالة ضبط GTK_IM_MODULE أو الضبط إلى "
+"\"ibus\"."
+
+#: ../src/gtk/app.cpp:569
+msgid "Unable to initialize GTK+, is DISPLAY set properly?"
+msgstr "يتعذّر تجهيز ج‌ت‌ك+، هل العارضة معدَّة بصورة صحيحة؟"
+
+#: ../src/gtk/filedlg.cpp:89 ../src/gtk/filepicker.cpp:255
+#, c-format
+msgid "Changing current directory to \"%s\" failed"
+msgstr "أخفق تغيير الدليل الحالي إلى \"%s\""
+
+#: ../src/gtk/font.cpp:548
+msgid ""
+"Using private fonts is not supported on this system: Pango library is too "
+"old, 1.38 or later required."
+msgstr ""
+"استخدام الخطوط الخاصة غير مدعوم في هذا النظام: مكتبة بانغو Pango قديمة  جداً، "
+"المطلوب 1.38 أو أحدث."
+
+#: ../src/gtk/font.cpp:558
+msgid "Failed to create font configuration object."
+msgstr "أخفق إنشاء كائن تكوين الخطوط."
+
+#: ../src/gtk/font.cpp:568
+#, c-format
+msgid "Failed to add custom font \"%s\"."
+msgstr "أخفقت إضافة خط مخصص \"%s\"."
+
+#: ../src/gtk/font.cpp:576
+msgid "Failed to register font configuration using private fonts."
+msgstr "أخفق تسجيل تكوين الخط باستخدام خطوط خاصة."
+
+#: ../src/gtk/glcanvas.cpp:117 ../src/gtk/glcanvas.cpp:132
+msgid "Fatal Error"
+msgstr "خطأ فادح"
+
+#: ../src/gtk/glcanvas.cpp:117
+msgid ""
+"This program wasn't compiled with EGL support required under Wayland, "
+"either\n"
+"install EGL libraries and rebuild or run it under X11 backend by setting\n"
+"environment variable GDK_BACKEND=x11 before starting your program."
+msgstr ""
+"لم يصرَّف هذا البرنامج بدعم EGL لـ Wayland، إما أن تثبّت\n"
+"مكتبات EGL وتعيد بناءه أو تشغله تحت طرف نهاية X11 بإعداد\n"
+"متغير البيئة GDK_BACKEND=x11 قبل بدء برنامجك."
+
+#: ../src/gtk/glcanvas.cpp:132
+msgid ""
+"wxGLCanvas is only supported on Wayland and X11 currently.  You may be able "
+"to\n"
+"work around this by setting environment variable GDK_BACKEND=x11 before\n"
+"starting your program."
+msgstr ""
+"ليس مدعومًا إلا في Wayland و X11 حاليا. قد يكون بإمكانك أن\n"
+"تلتف على هذا بضبط متغير البيئة GDK_BACKEND=x11 قبل\n"
+"بدء برنامجك."
+
+#: ../src/gtk/mdi.cpp:433
+msgid "MDI child"
+msgstr "فرع MDI"
+
+#: ../src/gtk/power.cpp:188
+#, fuzzy, c-format
+msgid "Failed to open D-Bus connection to the login manager: %s"
+msgstr "أخفق إنشاء اتصال إلى الخادوم ’%s‘ عن الموضوع ’%s‘"
+
+#: ../src/gtk/power.cpp:214
+#, fuzzy
+msgid "wxWidgets application"
+msgstr "أخفِ التطبيق"
+
+#: ../src/gtk/power.cpp:226
+msgid "Application needs to keep running"
+msgstr ""
+
+#: ../src/gtk/power.cpp:233
+msgid "Clean up before suspend"
+msgstr ""
+
+#: ../src/gtk/power.cpp:259
+#, fuzzy, c-format
+msgid "Failed to inhibit sleep: %s"
+msgstr "أخفق تجهيز الاتصال الهاتفي: %s"
+
+#: ../src/gtk/power.cpp:265
+msgid "Unexpected response to D-Bus \"Inhibit\" request."
+msgstr ""
+
+#: ../src/gtk/print.cpp:218
+msgid "Custom size"
+msgstr "حجم مخصص"
+
+#: ../src/gtk/print.cpp:752
+#, c-format
+msgid "Error while printing: %s"
+msgstr "خطأ أثناء الطباعة: %s"
+
+#: ../src/gtk/print.cpp:816
+msgid "Page Setup"
+msgstr "إعداد الصفحة"
+
+#: ../src/gtk/webview_webkit.cpp:932
+msgid "Retrieving JavaScript script output is not supported with WebKit v1"
+msgstr "ليس استحصال إخراج إخطاط جافا سكربت مدعومًا بـ WebKit v1"
+
+#: ../src/gtk/webview_webkit2.cpp:1098
+msgid ""
+"Setting proxy is not supported by WebKit, at least version 2.16 is required."
+msgstr "ليس إعداد الملقم الوكيل مدعومًا من WebKit، يلزم الإصدار 2.16 على الأقل."
+
+#: ../src/gtk/webview_webkit2.cpp:1104
+msgid "This program was compiled without support for setting WebKit proxy."
+msgstr "صُرّف هذا البرنامج بلا دعم لإعداد ملقم وكيل WebKit."
+
+#: ../src/gtk/window.cpp:6289
+msgid ""
+"GTK+ installed on this machine is too old to support screen compositing, "
+"please install GTK+ 2.12 or later."
+msgstr ""
+"ج‌ت‌ك+ المثبَّت على هذه الآلة قديم جدا ليدعم تراكب الشاشة، لطفًا ثبّت ج‌ت‌ك+ 2.12 أو "
+"أحدث."
+
+#: ../src/gtk/window.cpp:6307
+msgid ""
+"Compositing not supported by this system, please enable it in your Window "
+"Manager."
+msgstr "التراكب غير مدعوم من هذا النظام، لطفًا فعّله في مدير النوافذ لديك."
+
+#: ../src/gtk/window.cpp:6318
+msgid ""
+"This program was compiled with a too old version of GTK+, please rebuild "
+"with GTK+ 2.12 or newer."
+msgstr ""
+"صُرّف هذا البرنامج بإصدار قديم جدا من ج‌ت‌ك+، لطفًا أعد تركيبه مع ج‌ت‌ك+ 2.12 أو "
+"أحدث."
+
+#: ../src/html/chm.cpp:138
+#, c-format
+msgid "Failed to open CHM archive '%s'."
+msgstr "أخفق فتح أرشيف CHM‏ ’%s‘."
+
+#: ../src/html/chm.cpp:270
+#, c-format
+msgid "Could not extract %s into %s: %s"
+msgstr "تعذّر استخراج %s إلى %s‏: %s"
+
+#: ../src/html/chm.cpp:324
+msgid "no error"
+msgstr "ليس هناك خطأ"
+
+#: ../src/html/chm.cpp:326
+msgid "bad arguments to library function"
+msgstr "معامِلات رديئة لدالة المكتبة"
+
+#: ../src/html/chm.cpp:328
+msgid "error opening file"
+msgstr "خطأ في فتح الملف"
+
+#: ../src/html/chm.cpp:330
+msgid "read error"
+msgstr "خطأ قراءة"
+
+#: ../src/html/chm.cpp:332
+msgid "write error"
+msgstr "خطأ كتابة"
+
+#: ../src/html/chm.cpp:334
+msgid "seek error"
+msgstr "خطأ قصد"
+
+#: ../src/html/chm.cpp:338
+msgid "bad signature"
+msgstr "توقيع رديء"
+
+#: ../src/html/chm.cpp:340
+msgid "error in data format"
+msgstr "خطأ في نسَق البيانات"
+
+#: ../src/html/chm.cpp:342
+msgid "checksum error"
+msgstr "خطأ في مجموع التحقق"
+
+#: ../src/html/chm.cpp:344
+msgid "compression error"
+msgstr "خطأ ضغط"
+
+#: ../src/html/chm.cpp:346
+msgid "decompression error"
+msgstr "خطأ فك ضغط"
+
+#: ../src/html/chm.cpp:437
+#, c-format
+msgid "Could not locate file '%s'."
+msgstr "تعذّر تحديد مكان الملف '%s'."
+
+#: ../src/html/chm.cpp:711
+#, c-format
+msgid "Could not create temporary file '%s'"
+msgstr "تعذّر إنشاء الملف المؤقت '%s'"
+
+#: ../src/html/chm.cpp:718
+#, c-format
+msgid "Extraction of '%s' into '%s' failed."
+msgstr "أخفق فك '%s' إلى '%s'."
+
+#: ../src/html/chm.cpp:806 ../src/html/chm.cpp:863
+msgid "CHM handler currently supports only local files!"
+msgstr "متولي CHM لا يدعم في الوقت الراهن سوى الملفات المحلية!"
+
+#: ../src/html/chm.cpp:827
+msgid "Link contained '//', converted to absolute link."
+msgstr "احتوت الوصلة على ’//‘ وحُوّلَت إلى وصلة مطلقة."
+
+#: ../src/html/helpctrl.cpp:59
+#, c-format
+msgid "Help: %s"
+msgstr "مساعدة: %s"
+
+#: ../src/html/helpctrl.cpp:155
+#, c-format
+msgid "Adding book %s"
+msgstr "إضافة كتاب %s"
+
+#: ../src/html/helpdata.cpp:295
+#, c-format
+msgid "Cannot open contents file: %s"
+msgstr "تعذّر فتح ملف: المحتويات %s"
+
+#: ../src/html/helpdata.cpp:309
+#, c-format
+msgid "Cannot open index file: %s"
+msgstr "تعذّر فتح ملف التكشيف: %s"
+
+#: ../src/html/helpdata.cpp:643
+msgid "noname"
+msgstr "بلا-اسم"
+
+#: ../src/html/helpdata.cpp:652
+#, c-format
+msgid "Cannot open HTML help book: %s"
+msgstr "تعذّر فتح كتاب مساعدة HTML‏: %s"
+
+#: ../src/html/helpwnd.cpp:315
+msgid "Displays help as you browse the books on the left."
+msgstr "يعرض المساعدة أثناء تصفح الكتب إلى اليسار."
+
+#: ../src/html/helpwnd.cpp:411 ../src/html/helpwnd.cpp:1100
+#: ../src/html/helpwnd.cpp:1735
+msgid "(bookmarks)"
+msgstr "(علامات)"
+
+#: ../src/html/helpwnd.cpp:424
+msgid "Add current page to bookmarks"
+msgstr "أضف الصفحة الحالية الى العلامات"
+
+#: ../src/html/helpwnd.cpp:425
+msgid "Remove current page from bookmarks"
+msgstr "إزالة الصفحة الحالية من العلامات"
+
+#: ../src/html/helpwnd.cpp:470
+msgid "Contents"
+msgstr "المحتويات"
+
+#: ../src/html/helpwnd.cpp:485
+msgid "Find"
+msgstr "جِد"
+
+#: ../src/html/helpwnd.cpp:487
+msgid "Show all"
+msgstr "أظهر الكل"
+
+#: ../src/html/helpwnd.cpp:497
+msgid ""
+"Display all index items that contain given substring. Search is case "
+"insensitive."
+msgstr ""
+"اعرِض كل عناصر الفهرس التي تحوي العبارة الفرعية المعطاة. البحث غير حساس لحالة "
+"الأحرف."
+
+#: ../src/html/helpwnd.cpp:498
+msgid "Show all items in index"
+msgstr "أظهِر كل العناصر في الفهرس"
+
+#: ../src/html/helpwnd.cpp:528
+msgid "Case sensitive"
+msgstr "حساس لحالة الأحرف"
+
+#: ../src/html/helpwnd.cpp:529
+msgid "Whole words only"
+msgstr "كلمات كاملة فقط"
+
+#: ../src/html/helpwnd.cpp:532
+msgid ""
+"Search contents of help book(s) for all occurrences of the text you typed "
+"above"
+msgstr ""
+"ابحث محتويات كتاب (كتب)المساعدة عن كل مرات ورود النص الذي كتبته في أعلاه"
+
+#: ../src/html/helpwnd.cpp:653
+msgid "Show/hide navigation panel"
+msgstr "أظهِر\\أخفِ لوحة التنقل"
+
+#: ../src/html/helpwnd.cpp:655
+msgid "Go back"
+msgstr "عُد للخلف"
+
+#: ../src/html/helpwnd.cpp:656
+msgid "Go forward"
+msgstr "اذهب للأمام"
+
+#: ../src/html/helpwnd.cpp:658
+msgid "Go one level up in document hierarchy"
+msgstr "اصعد مستوى واحداً في هيكل الوثيقة"
+
+#: ../src/html/helpwnd.cpp:666 ../src/html/helpwnd.cpp:1547
+msgid "Open HTML document"
+msgstr "افتح مستند HTML"
+
+#: ../src/html/helpwnd.cpp:670
+msgid "Print this page"
+msgstr "إطبع هذه الصفحة"
+
+#: ../src/html/helpwnd.cpp:674
+msgid "Display options dialog"
+msgstr "اعرض حوار الخيارات"
+
+#: ../src/html/helpwnd.cpp:795
+msgid "Please choose the page to display:"
+msgstr "لطفًا اختر الصفحة لعرضها:"
+
+#: ../src/html/helpwnd.cpp:796
+msgid "Help Topics"
+msgstr "مواضيع المساعدة"
+
+#: ../src/html/helpwnd.cpp:852
+msgid "Searching..."
+msgstr "يبحث…"
+
+#: ../src/html/helpwnd.cpp:853
+msgid "No matching page found yet"
+msgstr "لم يعثر على صفحة مطابِقة بعد"
+
+#: ../src/html/helpwnd.cpp:870
+#, c-format
+msgid "Found %i matches"
+msgstr "عُثر على %i مُطابِق"
+
+#: ../src/html/helpwnd.cpp:958
+msgid "(Help)"
+msgstr "(مساعدة)"
+
+#: ../src/html/helpwnd.cpp:1026
+#, c-format
+msgid "%d of %lu"
+msgstr "%d من %lu"
+
+#: ../src/html/helpwnd.cpp:1028
+#, c-format
+msgid "%lu of %lu"
+msgstr "%lu من %lu"
+
+#: ../src/html/helpwnd.cpp:1047
+msgid "Search in all books"
+msgstr "ابحث في كل الكتب"
+
+#: ../src/html/helpwnd.cpp:1193
+msgid "Help Browser Options"
+msgstr "خيارات متصفح المساعدة"
+
+#: ../src/html/helpwnd.cpp:1198
+msgid "Normal font:"
+msgstr "خط اعتيادي:"
+
+#: ../src/html/helpwnd.cpp:1199
+msgid "Fixed font:"
+msgstr "خط ثابت:"
+
+#: ../src/html/helpwnd.cpp:1200
+msgid "Font size:"
+msgstr "مقاس الخط:"
+
+#: ../src/html/helpwnd.cpp:1245
+msgid "font size"
+msgstr "مقاس الخط"
+
+#: ../src/html/helpwnd.cpp:1256
+msgid "Normal face<br>and <u>underlined</u>. "
+msgstr "ضرب خط اعتيادي<br>و <u>تحته خط</u>. "
+
+#: ../src/html/helpwnd.cpp:1257
+msgid "<i>Italic face.</i> "
+msgstr "<i>ضرب خط مائل.</i> "
+
+#: ../src/html/helpwnd.cpp:1258
+msgid "<b>Bold face.</b> "
+msgstr "<b>ضرب خط ثخين.</b> "
+
+#: ../src/html/helpwnd.cpp:1259
+msgid "<b><i>Bold italic face.</i></b><br>"
+msgstr "<b><i>ضرب خط ثخين ومائل.</i></b><br>"
+
+#: ../src/html/helpwnd.cpp:1262
+msgid "Fixed size face.<br> <b>bold</b> <i>italic</i> "
+msgstr "ضرب خط بمقاس ثابت.<br> <b>ثخين</b> <i>مائل</i> "
+
+#: ../src/html/helpwnd.cpp:1263
+msgid "<b><i>bold italic <u>underlined</u></i></b><br>"
+msgstr "<b><i>bold italic <u>underlined</u></i></b><br>"
+
+#: ../src/html/helpwnd.cpp:1524
+msgid "Help Printing"
+msgstr "طباعة المساعدة"
+
+#: ../src/html/helpwnd.cpp:1527
+msgid "Cannot print empty page."
+msgstr "تعذّرت طباعة صفحة فارغة."
+
+#: ../src/html/helpwnd.cpp:1540
+msgid "HTML files (*.html;*.htm)|*.html;*.htm|"
+msgstr "ملفات أتش تي أم أل HTML (*.html;*.htm)|*.html;*.htm|‎"
+
+#: ../src/html/helpwnd.cpp:1541
+msgid "Help books (*.htb)|*.htb|Help books (*.zip)|*.zip|"
+msgstr "كتب مساعدة (*.htb)|*.htb|كتب مساعدة (*.zip)|*.zip‎‎|‎"
+
+#: ../src/html/helpwnd.cpp:1542
+msgid "HTML Help Project (*.hhp)|*.hhp|"
+msgstr "مشروع مساعدة ‎HTML ‏(*.hhp)|*.hhp‎|‎"
+
+#: ../src/html/helpwnd.cpp:1544
+msgid "Compressed HTML Help file (*.chm)|*.chm|"
+msgstr "ملف مساعدة HTML مضغوط (*.chm)|*.chm|‎"
+
+#: ../src/html/helpwnd.cpp:1671
+#, c-format
+msgid "%i of %u"
+msgstr "%i من %u"
+
+#: ../src/html/helpwnd.cpp:1709
+#, c-format
+msgid "%u of %u"
+msgstr "%u من %u"
+
+#: ../src/html/htmlfilt.cpp:134
+#, c-format
+msgid "Cannot open HTML document: %s"
+msgstr "تعذّر فتح مستند HTML‏: %s"
+
+#: ../src/html/htmlwin.cpp:599
+msgid "Connecting..."
+msgstr "يتصل..."
+
+#: ../src/html/htmlwin.cpp:616
+#, c-format
+msgid "Unable to open requested HTML document: %s"
+msgstr "تعذّر فتح مستند HTML المطلوب: %s"
+
+#: ../src/html/htmlwin.cpp:630
+msgid "Loading : "
+msgstr "يحمّل: "
+
+#: ../src/html/htmlwin.cpp:673
+msgid "Done"
+msgstr "تم"
+
+#: ../src/html/htmlwin.cpp:723
+#, c-format
+msgid "HTML anchor %s does not exist."
+msgstr "مغرز HTML‏ %s لا وجود له."
+
+#: ../src/html/htmlwin.cpp:1057
+#, c-format
+msgid "Copied to clipboard:\"%s\""
+msgstr "نسخ إلى الحافظة:\"%s\""
+
+#: ../src/html/htmprint.cpp:269
+msgid ""
+"This document doesn't fit on the page horizontally and will be truncated "
+"when it is printed."
+msgstr "هذا المستند لا يتلاءم مع الصفحة أفقيا وسيُقطع عند طباعته."
+
+#: ../src/html/htmprint.cpp:285
+#, c-format
+msgid ""
+"The document \"%s\" doesn't fit on the page horizontally and will be "
+"truncated if printed.\n"
+"\n"
+"Would you like to proceed with printing it nevertheless?"
+msgstr ""
+"المستند \"%s\" لا يتلاءم مع الصفحة أفقيا وسيُقطع عند طباعته.\n"
+"\n"
+"أترغب في الاستمرار بطباعته مع ذلك؟"
+
+#: ../src/html/htmprint.cpp:296
+msgid ""
+"If possible, try changing the layout parameters to make the printout more "
+"narrow."
+msgstr "إن أمكن حاول تغيير متغيرات التخطيط لجعل مخرَجات الطباعة أنحف."
+
+#: ../src/html/htmprint.cpp:445
+msgid ": file does not exist!"
+msgstr ": لا وجود للملف!"
+
+#. TRANSLATORS: %s may be a document title.
+#: ../src/html/htmprint.cpp:717
+#, c-format
+msgid "%s Preview"
+msgstr "معاينة %s"
+
+#: ../src/html/htmprint.cpp:755 ../src/richtext/richtextprint.cpp:618
+msgid ""
+"There was a problem during page setup: you may need to set a default printer."
+msgstr "كانت هناك مشكلة أثناء إعداد الصفحة: قد يلزمك إعداد طابعة مبدئية."
+
+#: ../src/msw/clipbrd.cpp:80
+msgid "Failed to open the clipboard."
+msgstr "أخفق فتح الحافظة."
+
+#: ../src/msw/clipbrd.cpp:101
+msgid "Failed to close the clipboard."
+msgstr "أخفق إغلاق الحافظة."
+
+#: ../src/msw/clipbrd.cpp:113
+msgid "Failed to empty the clipboard."
+msgstr "أخفق تفريغ الحافظة."
+
+#: ../src/msw/clipbrd.cpp:284
+msgid "Failed to put data on the clipboard"
+msgstr "أخفق وضع بيانات في الحافظة"
+
+#: ../src/msw/clipbrd.cpp:326
+msgid "Failed to get data from the clipboard"
+msgstr "أخفق جلب بيانات من الحافظة"
+
+#: ../src/msw/clipbrd.cpp:363
+msgid "Failed to retrieve the supported clipboard formats"
+msgstr "أخفق استحصال أنساق الحافظة المدعومة"
+
+#: ../src/msw/colordlg.cpp:228
+#, c-format
+msgid "Colour selection dialog failed with error %0lx."
+msgstr "أخفق حوار تحديد اللون مع خطأ %0lx."
+
+#: ../src/msw/cursor.cpp:141
+msgid "Failed to create cursor."
+msgstr "أخفق إنشاء المؤشِّر."
+
+#: ../src/msw/dde.cpp:279
+#, c-format
+msgid "Failed to register DDE server '%s'"
+msgstr "أخفق تسجيل خادوم DDE‏ ’%s‘"
+
+#: ../src/msw/dde.cpp:300
+#, c-format
+msgid "Failed to unregister DDE server '%s'"
+msgstr "أخفقت إزالة تسجيل خادوم DDE‏ ’%s‘"
+
+#: ../src/msw/dde.cpp:428
+#, c-format
+msgid "Failed to create connection to server '%s' on topic '%s'"
+msgstr "أخفق إنشاء اتصال إلى الخادوم ’%s‘ عن الموضوع ’%s‘"
+
+#: ../src/msw/dde.cpp:655
+msgid "DDE poke request failed"
+msgstr "أخفق طلب نكز DDE"
+
+#: ../src/msw/dde.cpp:674
+msgid "Failed to establish an advise loop with DDE server"
+msgstr "أخفق تأسيس حلقة تشاور مع خادوم DDE"
+
+#: ../src/msw/dde.cpp:693
+msgid "Failed to terminate the advise loop with DDE server"
+msgstr "أخفق إنهاء حلقة التشاور مع خادوم DDE"
+
+#: ../src/msw/dde.cpp:768
+msgid "Failed to send DDE advise notification"
+msgstr "أخفق إرسال إشعار تشاور DDE"
+
+#: ../src/msw/dde.cpp:1085
+msgid "Failed to create DDE string"
+msgstr "أخفق إنشاء عبارة DDE"
+
+#: ../src/msw/dde.cpp:1131
+msgid "no DDE error."
+msgstr "لا خطأ DDE."
+
+#: ../src/msw/dde.cpp:1135
+msgid "a request for a synchronous advise transaction has timed out."
+msgstr "نفذ وقت طلب لصفقة تشاور تزامنية."
+
+#: ../src/msw/dde.cpp:1138
+msgid "the response to the transaction caused the DDE_FBUSY bit to be set."
+msgstr "الاستجابة الى الصفقة تسببت في إعداد القطعة DDE_FBUSY."
+
+#: ../src/msw/dde.cpp:1141
+msgid "a request for a synchronous data transaction has timed out."
+msgstr "نفذ وقت طلب لصفقة بيانات تزامنية."
+
+#: ../src/msw/dde.cpp:1144
+msgid ""
+"a DDEML function was called without first calling the DdeInitialize "
+"function,\n"
+"or an invalid instance identifier\n"
+"was passed to a DDEML function."
+msgstr ""
+"استُدعيت دالة DDEML دون أن تُستدعى أولاً دالة DdeInitialize.\n"
+"أو أنّ معرِّف سيرورة غير صحيح\n"
+"قد مُرّر إلى دالة DDEML."
+
+#: ../src/msw/dde.cpp:1147
+msgid ""
+"an application initialized as APPCLASS_MONITOR has\n"
+"attempted to perform a DDE transaction,\n"
+"or an application initialized as APPCMD_CLIENTONLY has \n"
+"attempted to perform server transactions."
+msgstr ""
+"تطبيق ما مجهَّز كـ APPCLASS_MONITOR قد\n"
+"حاول تأدية صفقة DDE أو أنّ تطبيقًا\n"
+"مجهزاً كـ APPCMD_CLIENTONLY قد\n"
+"حاول تأدية صفقات خادوم."
+
+#: ../src/msw/dde.cpp:1150
+msgid "a request for a synchronous execute transaction has timed out."
+msgstr "نفذ وقت طلب لصفقة تنفيذ تزامنية."
+
+#: ../src/msw/dde.cpp:1153
+msgid "a parameter failed to be validated by the DDEML."
+msgstr "أخفق DDEML في التحقق من متغير وسيط."
+
+#: ../src/msw/dde.cpp:1156
+msgid "a DDEML application has created a prolonged race condition."
+msgstr "تطبيق DDEML ما أنشأ وضعية تسابُق مطوَّلة."
+
+#: ../src/msw/dde.cpp:1159
+msgid "a memory allocation failed."
+msgstr "أخفق تخصيص الذاكرة."
+
+#: ../src/msw/dde.cpp:1162
+msgid "a client's attempt to establish a conversation has failed."
+msgstr "أخفقت محاولة العميل لتأسيس محادثة."
+
+#: ../src/msw/dde.cpp:1165
+msgid "a transaction failed."
+msgstr "أخفقت صفقة."
+
+#: ../src/msw/dde.cpp:1168
+msgid "a request for a synchronous poke transaction has timed out."
+msgstr "نفذ وقت طلب لصفقة نكز تزامنية."
+
+#: ../src/msw/dde.cpp:1171
+msgid "an internal call to the PostMessage function has failed. "
+msgstr "أخفق استدعاء داخلي لدالة PostMessage. "
+
+#: ../src/msw/dde.cpp:1174
+msgid "reentrancy problem."
+msgstr "مشكلة إعادة الدخول."
+
+#: ../src/msw/dde.cpp:1177
+msgid ""
+"a server-side transaction was attempted on a conversation\n"
+"that was terminated by the client, or the server\n"
+"terminated before completing a transaction."
+msgstr ""
+"جُرّبت صفقة من جانب الخادوم لمحادثة\n"
+"قد أُنهيت من قبل العميل، أو أنّ الخادوم\n"
+"قد أُنهي قبل إنجاز الصفقة."
+
+#: ../src/msw/dde.cpp:1180
+msgid "an internal error has occurred in the DDEML."
+msgstr "حصل خطأ داخلي في DDEML."
+
+#: ../src/msw/dde.cpp:1183
+msgid "a request to end an advise transaction has timed out."
+msgstr "نفذ وقت طلب لإنهاء صفقة تشاور."
+
+#: ../src/msw/dde.cpp:1186
+msgid ""
+"an invalid transaction identifier was passed to a DDEML function.\n"
+"Once the application has returned from an XTYP_XACT_COMPLETE callback,\n"
+"the transaction identifier for that callback is no longer valid."
+msgstr ""
+"مُرّر معرِّف صفقة غير صحيح إلى دالة DDEML.\n"
+"فور عودة التطبيق من استدعاء XTYP_XACT_COMPLETE\n"
+"فلن يكون معرِّف الصفقة لذلك الاستدعاء ساري المفعول."
+
+#: ../src/msw/dde.cpp:1189
+#, c-format
+msgid "Unknown DDE error %08x"
+msgstr "خطأ DDE مجهول %08x"
+
+#: ../src/msw/dialup.cpp:343
+msgid ""
+"Dial up functions are unavailable because the remote access service (RAS) is "
+"not installed on this machine. Please install it."
+msgstr ""
+"دوال الاتصال الهاتفي غير متاحة لأنّ خدمة الوصول البعيد (RAS) غير مثبَّتة في هذه "
+"الآلة. لطفًا ثبّتها."
+
+#: ../src/msw/dialup.cpp:402
+#, c-format
+msgid ""
+"The version of remote access service (RAS) installed on this machine is too "
+"old, please upgrade (the following required function is missing: %s)."
+msgstr ""
+"إصدار خدمة الوصول البعيد (RAS) المثبَّت على هذه الآلة قديم جدا، الرجاء الترقية "
+"(الدالة اللازمة التالية مفقودة: %s)."
+
+#: ../src/msw/dialup.cpp:437
+msgid "Failed to retrieve text of RAS error message"
+msgstr "أخفق استحصال نص رسالة خطأ RAS"
+
+#: ../src/msw/dialup.cpp:440
+#, c-format
+msgid "unknown error (error code %08x)."
+msgstr "خطأ مجهول (رمز الخطأ %08x)."
+
+#: ../src/msw/dialup.cpp:492
+#, c-format
+msgid "Cannot find active dialup connection: %s"
+msgstr "تعذّر العثور على اتصال هاتفي نشط: %s"
+
+#: ../src/msw/dialup.cpp:513
+msgid "Several active dialup connections found, choosing one randomly."
+msgstr "عُثر على عدّة اتصالات هاتفية نشطة، نختار واحداً عشوائيًا."
+
+#: ../src/msw/dialup.cpp:598 ../src/msw/dialup.cpp:832
+#, c-format
+msgid "Failed to establish dialup connection: %s"
+msgstr "أخفق تأسيس اتصال هاتفي: %s"
+
+#: ../src/msw/dialup.cpp:664
+#, c-format
+msgid "Failed to get ISP names: %s"
+msgstr "أخفق جلب أسماء ISP‏: %s"
+
+#: ../src/msw/dialup.cpp:712
+msgid "Failed to connect: no ISP to dial."
+msgstr "أخفق الاتصال: ليس هناك مزود خدمة انترنت ISP للاتصال به."
+
+#: ../src/msw/dialup.cpp:732
+msgid "Choose ISP to dial"
+msgstr "اختر مزود خدمة انترنت isp للاتصال به"
+
+#: ../src/msw/dialup.cpp:733
+msgid "Please choose which ISP do you want to connect to"
+msgstr "لطفًا اختر مزود خدمة الانترنت ISP الذي تريد الاتصال به"
+
+#: ../src/msw/dialup.cpp:766
+msgid "Failed to connect: missing username/password."
+msgstr "أخفق الاتصال: اسم المستخدم\\كلمة السر مفقودة."
+
+#: ../src/msw/dialup.cpp:796
+msgid "Cannot find the location of address book file"
+msgstr "تعذّر وجود موقع ملف دفتر العناوين"
+
+#: ../src/msw/dialup.cpp:827
+#, c-format
+msgid "Failed to initiate dialup connection: %s"
+msgstr "أخفق تجهيز الاتصال الهاتفي: %s"
+
+#: ../src/msw/dialup.cpp:897
+msgid "Cannot hang up - no active dialup connection."
+msgstr "تعذّر تعليق الاتصال - لا يوجد اتصال هاتفي نشط."
+
+#: ../src/msw/dialup.cpp:907
+#, c-format
+msgid "Failed to terminate the dialup connection: %s"
+msgstr "أخفق إنهاء الاتصال الهاتفي: %s"
+
+#: ../src/msw/dib.cpp:313
+#, c-format
+msgid "Failed to save the bitmap image to file \"%s\"."
+msgstr "أخفق حفظ صورة bitmap إلى ملف \"%s\"."
+
+#: ../src/msw/dib.cpp:543
+#, c-format
+msgid "Failed to allocate %luKb of memory for bitmap data."
+msgstr "أخفق تخصيص %luك.ب من الذاكرة لبيانات bitmap."
+
+#: ../src/msw/dir.cpp:241
+#, c-format
+msgid "Cannot enumerate files in directory '%s'"
+msgstr "لا يمكن تعداد ملفات الدليل '%s'"
+
+#: ../src/msw/dirdlg.cpp:368
+msgid "Couldn't obtain folder name"
+msgstr "تعذَر الحصول على اسم المجلد"
+
+#: ../src/msw/dlmsw.cpp:163
+#, c-format
+msgid "(error %d: %s)"
+msgstr "(خطأ %d‏: %s)"
+
+#: ../src/msw/dragimag.cpp:143 ../src/msw/dragimag.cpp:178
+#: ../src/msw/imaglist.cpp:309 ../src/msw/imaglist.cpp:331
+msgid "Couldn't add an image to the image list."
+msgstr "تعذّرت إضافة صورة لقائمة الصور."
+
+#: ../src/msw/enhmeta.cpp:94
+#, c-format
+msgid "Failed to load metafile from file \"%s\"."
+msgstr "أخفق تحميل الملف الفوقي من الملف \"%s\"."
+
+#: ../src/msw/fdrepdlg.cpp:412
+#, c-format
+msgid "Failed to create the standard find/replace dialog (error code %d)"
+msgstr "أخفق إنشاء حوار جِد\\استبدل المعياري (رمز الخطأ %d)"
+
+#: ../src/msw/filedlg.cpp:1241
+msgid "Access to the file system is not allowed from secure desktop."
+msgstr "الوصول الى نظام الملفات غير مسموح من سطح المكتب الآمن."
+
+#: ../src/msw/filedlg.cpp:1242
+msgid "Security warning"
+msgstr "تحذير أمني"
+
+#: ../src/msw/filedlg.cpp:1533
+#, c-format
+msgid "File dialog failed with error code %0lx."
+msgstr "أخفق حوار الملف مع ارسال رمز الخطأ %0lx."
+
+#: ../src/msw/font.cpp:1120
+#, c-format
+msgid "Font file \"%s\" couldn't be loaded"
+msgstr "تعذّر تحميل ملف الخط \"%s\""
+
+#: ../src/msw/fontdlg.cpp:220
+#, c-format
+msgid "Common dialog failed with error code %0lx."
+msgstr "أخفق الحوار المشترَك مع ارسال رمز الخطأ %0lx."
+
+#: ../src/msw/fswatcher.cpp:67
+msgid "Ungraceful worker thread termination"
+msgstr "إنهاء شديد لتخييط عامل"
+
+#: ../src/msw/fswatcher.cpp:81
+msgid "Unable to create IOCP worker thread"
+msgstr "تعذّر إنشاء تخييط عامل بمنفذ IOCP"
+
+#: ../src/msw/fswatcher.cpp:88
+msgid "Unable to start IOCP worker thread"
+msgstr "تعذّر بدء تخييط عامل بمنفذ IOCP"
+
+#: ../src/msw/fswatcher.cpp:140
+msgid "Monitoring individual files for changes is not supported currently."
+msgstr "مراقبة الملفات المفردة لمعرفة التغييرات غير مدعوم حاليا."
+
+#: ../src/msw/fswatcher.cpp:165
+#, c-format
+msgid "Unable to set up watch for '%s'"
+msgstr "تعذّر إعداد مراقبة لـ ’%s‘"
+
+#: ../src/msw/fswatcher.cpp:466
+#, c-format
+msgid "Can't monitor non-existent directory \"%s\" for changes."
+msgstr "تتعذّر مراقبة الدليل الذي لا وجود له \"%s\" لمعرفة التغييرات."
+
+#: ../src/msw/glcanvas.cpp:577 ../src/unix/glx11.cpp:507
+msgid "OpenGL 3.0 or later is not supported by the OpenGL driver."
+msgstr "برنامج تشغيل OpenGL لا يدعم OpenGL 3.0 أو ما بعده."
+
+#: ../src/msw/glcanvas.cpp:601 ../src/osx/glcanvas_osx.cpp:395
+#: ../src/unix/glegl.cpp:304 ../src/unix/glx11.cpp:553
+msgid "Couldn't create OpenGL context"
+msgstr "أخفق إنشاء سياق OpenGL"
+
+#: ../src/msw/glcanvas.cpp:1294
+msgid "Failed to initialize OpenGL"
+msgstr "تعذّر تجهيز OpenGL"
+
+#: ../src/msw/graphicsd2d.cpp:607
+msgid "Could not register custom DirectWrite font loader."
+msgstr "تعذّر تسجيل محمِّل خط DirectWrite مخصص."
+
+#: ../src/msw/helpchm.cpp:48
+msgid ""
+"MS HTML Help functions are unavailable because the MS HTML Help library is "
+"not installed on this machine. Please install it."
+msgstr ""
+"دوال مساعدة HTML ميكروسوفت غير متاحة لأنّ مكتبة مساعدة HTML ميكروسوفت غير "
+"مثبَّتة على هذه الآلة. لطفًا ثبّتها."
+
+#: ../src/msw/helpchm.cpp:55
+msgid "Failed to initialize MS HTML Help."
+msgstr "أخفق تجهيز مساعدة HTML ميكروسوفت."
+
+#: ../src/msw/iniconf.cpp:458
+#, c-format
+msgid "Can't delete the INI file '%s'"
+msgstr "يتعذّر حذف ملف INI الإعدادات ’%s‘"
+
+#: ../src/msw/listctrl.cpp:995
+#, c-format
+msgid "Couldn't retrieve information about list control item %d."
+msgstr "تعذّر استحصال معلومات عن عنصر تحكّم القائمة %d."
+
+#: ../src/msw/mdi.cpp:170 ../src/qt/mdi.cpp:253
+msgid "&Cascade"
+msgstr "&متداخل"
+
+#: ../src/msw/mdi.cpp:171
+msgid "Tile &Horizontally"
+msgstr "صُفّ أ&فقيا"
+
+#: ../src/msw/mdi.cpp:172
+msgid "Tile &Vertically"
+msgstr "صُفّ &عموديا"
+
+#: ../src/msw/mdi.cpp:174
+msgid "&Arrange Icons"
+msgstr "&رتّب الأيقونات"
+
+#: ../src/msw/mdi.cpp:621
+msgid "Failed to create MDI parent frame."
+msgstr "أخفق إنشاء إطار MDI الحاضن."
+
+#: ../src/msw/mimetype.cpp:234
+#, c-format
+msgid "Failed to create registry entry for '%s' files."
+msgstr "أخفق إنشاء مُدخَلة سجلّ لملفات ’'%s‘."
+
+#: ../src/msw/ole/automtn.cpp:495
+#, c-format
+msgid "Failed to find CLSID of \"%s\""
+msgstr "أخفق العثور على CLSID لـ \"'%s\""
+
+#: ../src/msw/ole/automtn.cpp:512
+#, c-format
+msgid "Failed to create an instance of \"%s\""
+msgstr "أخفق إنشاء سيرورة من \"%s\""
+
+#: ../src/msw/ole/automtn.cpp:552
+#, c-format
+msgid "Cannot get an active instance of \"%s\""
+msgstr "تعذّر جلب سيرورة نشطة من \"%s\""
+
+#: ../src/msw/ole/automtn.cpp:564
+#, c-format
+msgid "Failed to get OLE automation interface for \"%s\""
+msgstr "أخفق جلب سيرورة أتمتة OLE لـ \"%s\""
+
+#: ../src/msw/ole/automtn.cpp:621
+msgid "Unknown name or named argument."
+msgstr "اسم او مُعامِل مسمَّى مجهول."
+
+#: ../src/msw/ole/automtn.cpp:625
+msgid "Incorrect number of arguments."
+msgstr "عدد غير صحيح من المُعامِلات."
+
+#: ../src/msw/ole/automtn.cpp:637
+msgid "Unknown exception"
+msgstr "استثناء مجهول"
+
+#: ../src/msw/ole/automtn.cpp:642
+msgid "Method or property not found."
+msgstr "الطريقة أو الخاصية غير موجودة."
+
+#: ../src/msw/ole/automtn.cpp:646
+msgid "Overflow while coercing argument values."
+msgstr "حصل فيض overflow أثناء إنفاذ قيم المعامِلات."
+
+#: ../src/msw/ole/automtn.cpp:650
+msgid "Object implementation does not support named arguments."
+msgstr "تنفيذ الكائن لا يدعم المعامِلات المسمّاة."
+
+#: ../src/msw/ole/automtn.cpp:654
+msgid "The locale ID is unknown."
+msgstr "معرِّف المحلية مجهول."
+
+#: ../src/msw/ole/automtn.cpp:658
+msgid "Missing a required parameter."
+msgstr "يوجد متغير وسيط مفقود."
+
+#: ../src/msw/ole/automtn.cpp:662
+#, c-format
+msgid "Argument %u not found."
+msgstr "المُعامِل %u غير موجود."
+
+#: ../src/msw/ole/automtn.cpp:666
+#, c-format
+msgid "Type mismatch in argument %u."
+msgstr "عدم تطابق نوع في المُعامِل %u."
+
+#: ../src/msw/ole/automtn.cpp:670
+msgid "The system cannot find the file specified."
+msgstr "يتعذّر على النظام أن يجد الملف المحدد."
+
+#: ../src/msw/ole/automtn.cpp:674
+msgid "Class not registered."
+msgstr "الفئة غير مسجلة."
+
+#: ../src/msw/ole/automtn.cpp:678
+#, c-format
+msgid "Unknown error %08x"
+msgstr "خطأ مجهول %08x"
+
+#: ../src/msw/ole/automtn.cpp:682
+#, c-format
+msgid "OLE Automation error in %s: %s"
+msgstr "خطأ أتمتة OLE في %s‏: %s"
+
+#: ../src/msw/ole/dataobj.cpp:385
+#, c-format
+msgid "Couldn't register clipboard format '%s'."
+msgstr "تعذّر تسجيل تنسق الحافظة '%s'."
+
+#: ../src/msw/ole/dataobj.cpp:402
+#, c-format
+msgid "The clipboard format '%d' doesn't exist."
+msgstr "نسَق الحافظة ’%d‘ لا وجود له."
+
+#: ../src/msw/progdlg.cpp:1025
+msgid "Skip"
+msgstr "تخطّ"
+
+#: ../src/msw/registry.cpp:141
+#, c-format
+msgid "unknown (%lu)"
+msgstr "مجهول (%lu)"
+
+#: ../src/msw/registry.cpp:409
+#, c-format
+msgid "Can't get info about registry key '%s'"
+msgstr "تعذّر جلب معلومات حول مفتاح السجل '%s'"
+
+#: ../src/msw/registry.cpp:445
+#, c-format
+msgid "Can't open registry key '%s'"
+msgstr "تعذّر فتح مفتاح السجل '%s'"
+
+#: ../src/msw/registry.cpp:478
+#, c-format
+msgid "Can't create registry key '%s'"
+msgstr "تعذّر إنشاء مفتاح السجل '%s'"
+
+#: ../src/msw/registry.cpp:497
+#, c-format
+msgid "Can't close registry key '%s'"
+msgstr "تعذّر إغلاق مفتاح السجل '%s'"
+
+#: ../src/msw/registry.cpp:512
+#, c-format
+msgid "Registry value '%s' already exists."
+msgstr "قيمة السجل ’%s‘ موجودة سلفًا."
+
+#: ../src/msw/registry.cpp:520
+#, c-format
+msgid "Failed to rename registry value '%s' to '%s'."
+msgstr "أخفقت إعادة تسمية قيمة السجل ’%s‘ إلى ’%s‘."
+
+#: ../src/msw/registry.cpp:575
+#, c-format
+msgid "Can't copy values of unsupported type %d."
+msgstr "يتعذّر نسخ قيم نوع غير مدعوم %d."
+
+#: ../src/msw/registry.cpp:586
+#, c-format
+msgid "Registry key '%s' does not exist, cannot rename it."
+msgstr "مفتاح السجل ’%s‘ لا وجود له، تتعذّر إعادة تسميته."
+
+#: ../src/msw/registry.cpp:617
+#, c-format
+msgid "Registry key '%s' already exists."
+msgstr "مفتاح السجل ’%s‘ موجود سلفًا."
+
+#: ../src/msw/registry.cpp:625
+#, c-format
+msgid "Failed to rename the registry key '%s' to '%s'."
+msgstr "أخفقت إعادة تسمية مفتاح السجل ’%s‘ إلى ’%s‘."
+
+#: ../src/msw/registry.cpp:670
+#, c-format
+msgid "Failed to copy the registry subkey '%s' to '%s'."
+msgstr "أخفق نسخ المفتاح الفرعي للسجل ’%s‘ إلى ’%s‘."
+
+#: ../src/msw/registry.cpp:683
+#, c-format
+msgid "Failed to copy registry value '%s'"
+msgstr "أخفق نسخ قيمة السجل ’%s‘"
+
+#: ../src/msw/registry.cpp:692
+#, c-format
+msgid "Failed to copy the contents of registry key '%s' to '%s'."
+msgstr "أخفق نسخ محتويات مفتاح السجل ’%s‘ إلى ’%s‘."
+
+#: ../src/msw/registry.cpp:718
+#, c-format
+msgid ""
+"Registry key '%s' is needed for normal system operation,\n"
+"deleting it will leave your system in unusable state:\n"
+"operation aborted."
+msgstr ""
+"مفتاح السجلّ '%s' ضروري للتشغيل الطبيعي لنظامك،\n"
+"حذفه سيترك النظام في حالة غير مستقرة:\n"
+"تُركت العملية."
+
+#: ../src/msw/registry.cpp:754
+#, c-format
+msgid "Can't delete key '%s'"
+msgstr "تعذّر حذف المفتاح '%s'"
+
+#: ../src/msw/registry.cpp:782
+#, c-format
+msgid "Can't delete value '%s' from key '%s'"
+msgstr "تعذّر حذف القيمة '%s' من المفتاح '%s'"
+
+#: ../src/msw/registry.cpp:855 ../src/msw/registry.cpp:887
+#: ../src/msw/registry.cpp:929 ../src/msw/registry.cpp:1000
+#, c-format
+msgid "Can't read value of key '%s'"
+msgstr "تعذّرت قراءة قيمة المفتاح '%s'"
+
+#: ../src/msw/registry.cpp:873 ../src/msw/registry.cpp:915
+#: ../src/msw/registry.cpp:963 ../src/msw/registry.cpp:1106
+#, c-format
+msgid "Can't set value of '%s'"
+msgstr "تعذّر تعيين قيمة '%s'"
+
+#: ../src/msw/registry.cpp:894 ../src/msw/registry.cpp:943
+#, c-format
+msgid "Registry value \"%s\" is not numeric (but of type %s)"
+msgstr "قيمة السجل \"%s\" ليست رقمية (لكنها من النوع %s)"
+
+#: ../src/msw/registry.cpp:979
+#, c-format
+msgid "Registry value \"%s\" is not binary (but of type %s)"
+msgstr "قيمة السجل \"%s\" ليست ثنائية (لكنها من النوع %s)"
+
+#: ../src/msw/registry.cpp:1028
+#, c-format
+msgid "Registry value \"%s\" is not text (but of type %s)"
+msgstr "قيمة السجل \"%s\" ليست نصية (لكنها من النوع %s)"
+
+#: ../src/msw/registry.cpp:1089
+#, c-format
+msgid "Can't read value of '%s'"
+msgstr "تعذّرت قراءة قيمة '%s'"
+
+#: ../src/msw/registry.cpp:1157
+#, c-format
+msgid "Can't enumerate values of key '%s'"
+msgstr "تعذّر تعداد قيم المفتاح '%s'"
+
+#: ../src/msw/registry.cpp:1196
+#, c-format
+msgid "Can't enumerate subkeys of key '%s'"
+msgstr "تعذّر تعداد المفاتيح الفرعية للمفتاح '%s'"
+
+#: ../src/msw/registry.cpp:1262
+#, c-format
+msgid ""
+"Exporting registry key: file \"%s\" already exists and won't be overwritten."
+msgstr "يصدّر مفتاح السجل: الملف \"%s\" موجود سلفًا ولن يُكتَب عليه."
+
+#: ../src/msw/registry.cpp:1411
+#, c-format
+msgid "Can't export value of unsupported type %d."
+msgstr "تعذّر تصدير قيمة نوع غير مدعوم %d."
+
+#: ../src/msw/registry.cpp:1427
+#, c-format
+msgid "Ignoring value \"%s\" of the key \"%s\"."
+msgstr "يتجاهل القيمة \"%s\" للمفتاح \"%s\"."
+
+#: ../src/msw/textctrl.cpp:596
+msgid ""
+"Impossible to create a rich edit control, using simple text control instead. "
+"Please reinstall riched32.dll"
+msgstr ""
+"يتعذّر إنشاء تحكّم تحرير غني، نستخدم تحكّم نص بسيط بدلا عنه. لطفًا أعِد تثبيت "
+"riched32.dll"
+
+#: ../src/msw/thread.cpp:522 ../src/unix/threadpsx.cpp:850
+msgid "Cannot start thread: error writing TLS."
+msgstr "تعذّر بدء التخييط: خطأ في كتابة TLS."
+
+#: ../src/msw/thread.cpp:613
+msgid "Can't set thread priority"
+msgstr "تعذّر تعيين أولوية التخييط"
+
+#: ../src/msw/thread.cpp:649
+msgid "Can't create thread"
+msgstr "تعذّر إنشاء التخييط"
+
+#: ../src/msw/thread.cpp:668
+msgid "Couldn't terminate thread"
+msgstr "تعذّر إنهاء التخييط"
+
+#: ../src/msw/thread.cpp:799
+msgid "Cannot wait for thread termination"
+msgstr "تعذّر الانتظار حتى إنهاء التخييط"
+
+#: ../src/msw/thread.cpp:873
+#, c-format
+msgid "Cannot suspend thread %lx"
+msgstr "تعذّر تعليق التخييط %lx"
+
+#: ../src/msw/thread.cpp:903
+#, c-format
+msgid "Cannot resume thread %lx"
+msgstr "تعذّر استئناف التخييط %lx"
+
+#: ../src/msw/thread.cpp:932
+msgid "Couldn't get the current thread pointer"
+msgstr "تعذّر جلب مؤشِّر التخييط الحالي"
+
+#: ../src/msw/thread.cpp:1333
+msgid ""
+"Thread module initialization failed: impossible to allocate index in thread "
+"local storage"
+msgstr "أخفق تجهيز وحدة التخييط: يتعذّر تخصيص الفهرس في التخزين المحلي للتخييط"
+
+#: ../src/msw/thread.cpp:1345
+msgid ""
+"Thread module initialization failed: cannot store value in thread local "
+"storage"
+msgstr "أخفق تجهيز وحدة التخييط: يتعذّر خزن القيمة في التخزين المحلي للتخييط"
+
+#: ../src/msw/timer.cpp:133
+msgid "Couldn't create a timer"
+msgstr "تعذّر إنشاء مؤقِّت"
+
+#: ../src/msw/utils.cpp:372
+msgid "can't find user's HOME, using current directory."
+msgstr "تعذّر العثور على دليل «المنزل» للمستخدِم، نستخدم الدليل الحالي."
+
+#: ../src/msw/utils.cpp:662
+#, c-format
+msgid "Failed to kill process %d"
+msgstr "أخفق تدمير العملية %d"
+
+#: ../src/msw/utils.cpp:986
+#, c-format
+msgid "Failed to load resource \"%s\"."
+msgstr "أخفق تحميل المورد \"%s\"."
+
+#: ../src/msw/utils.cpp:993
+#, c-format
+msgid "Failed to lock resource \"%s\"."
+msgstr "أخفق إيصاد المورد \"%s\"."
+
+#. TRANSLATORS: MS Windows build number
+#: ../src/msw/utils.cpp:1209
+#, c-format
+msgid "build %lu"
+msgstr "البناء %lu"
+
+#: ../src/msw/utils.cpp:1218
+msgid ", 64-bit edition"
+msgstr "، إصدار 64-بت"
+
+#: ../src/msw/utilsexc.cpp:224
+msgid "Failed to create an anonymous pipe"
+msgstr "أخفق إنشاء مسرى غير معرَّف"
+
+#: ../src/msw/utilsexc.cpp:697
+msgid "Failed to redirect the child process IO"
+msgstr "أخفقت إعادة توجيه مُدخَل\\مُخرَج IO العملية الفرعية"
+
+#: ../src/msw/utilsexc.cpp:870
+#, c-format
+msgid "Execution of command '%s' failed"
+msgstr "أخفق تنفيذ الامر ’%s‘"
+
+#: ../src/msw/volume.cpp:337
+msgid "Failed to load mpr.dll."
+msgstr "أخفق تحميل mpr.dll."
+
+#: ../src/msw/volume.cpp:506
+#, c-format
+msgid "Cannot read typename from '%s'!"
+msgstr "تعذّرت قراءة اسم النوع من '%s'!"
+
+#: ../src/msw/volume.cpp:615
+#, c-format
+msgid "Cannot load icon from '%s'."
+msgstr "تعذّر تحميل الأيقونة من '%s'."
+
+#: ../src/msw/webview_edge.cpp:285
+msgid "This program was compiled without support for setting Edge proxy."
+msgstr "صُرّف هذا البرنامج بلا دعم لإعداد ملقم وكيل Edge."
+
+#: ../src/msw/webview_ie.cpp:1010
+msgid "Failed to find web view emulation level in the registry"
+msgstr "أخفق العثور على مستوى محاكاة المشهد في السجل"
+
+#: ../src/msw/webview_ie.cpp:1019
+msgid "Failed to set web view to modern emulation level"
+msgstr "أخفق تعيين مشهد الانترنت إلى مستوى محاكاة حديث"
+
+#: ../src/msw/webview_ie.cpp:1027
+msgid "Failed to reset web view to standard emulation level"
+msgstr "أخفق تصفير مشهد الانترنت إلى مستوى المحاكاة المعياري"
+
+#: ../src/msw/webview_ie.cpp:1049
+msgid "Can't run JavaScript script without a valid HTML document"
+msgstr "يتعذّر تشغيل إخطاط جافا سكربت بلا مستند HTML صحيح"
+
+#: ../src/msw/webview_ie.cpp:1056
+msgid "Can't get the JavaScript object"
+msgstr "يتعذّر جلب كائن الجافاسكربت"
+
+#: ../src/msw/webview_ie.cpp:1070
+msgid "failed to evaluate"
+msgstr "أخفق التقييم"
+
+#: ../src/osx/cocoa/filedlg.mm:412
+msgid "File type:"
+msgstr "نوع الملف:"
+
+#: ../src/osx/cocoa/menu.mm:242
+msgctxt "macOS menu name"
+msgid "Window"
+msgstr "النافذة"
+
+#: ../src/osx/cocoa/menu.mm:259
+msgctxt "macOS menu name"
+msgid "Help"
+msgstr "المساعدة"
+
+#: ../src/osx/cocoa/menu.mm:298
+msgctxt "macOS menu item"
+msgid "Minimize"
+msgstr "صغّر"
+
+#: ../src/osx/cocoa/menu.mm:303
+msgctxt "macOS menu item"
+msgid "Zoom"
+msgstr "قرّب"
+
+#: ../src/osx/cocoa/menu.mm:309
+msgctxt "macOS menu item"
+msgid "Bring All to Front"
+msgstr "اجلب الكل إلى الأمام"
+
+#: ../src/osx/core/sound.cpp:143
+#, c-format
+msgid "Failed to load sound from \"%s\" (error %d)."
+msgstr "تعذّر تحميل الصوت من \"%s\" (الخطأ %d)."
+
+#: ../src/osx/fontutil.cpp:80
+#, c-format
+msgid "Font file \"%s\" doesn't exist."
+msgstr "ملف الخط \"%s\" لا وجود له."
+
+#: ../src/osx/fontutil.cpp:88
+#, c-format
+msgid ""
+"Font file \"%s\" cannot be used as it is not inside the font directory "
+"\"%s\"."
+msgstr "يتعذّر استخدام ملف الخط \"%s\" بما أنه ليس داخل دليل الخطوط \"%s\"."
+
+#: ../src/osx/menu_osx.cpp:496
+#, c-format
+msgctxt "macOS menu item"
+msgid "About %s"
+msgstr "عن %s"
+
+#: ../src/osx/menu_osx.cpp:499
+msgctxt "macOS menu item"
+msgid "About..."
+msgstr "عن..."
+
+#: ../src/osx/menu_osx.cpp:508
+msgctxt "macOS menu item"
+msgid "Preferences..."
+msgstr "التفضيلات..."
+
+#: ../src/osx/menu_osx.cpp:512
+msgctxt "macOS menu item"
+msgid "Services"
+msgstr "الخدمات"
+
+#: ../src/osx/menu_osx.cpp:519
+#, c-format
+msgctxt "macOS menu item"
+msgid "Hide %s"
+msgstr "أخفِ %s"
+
+#: ../src/osx/menu_osx.cpp:522
+msgctxt "macOS menu item"
+msgid "Hide Application"
+msgstr "أخفِ التطبيق"
+
+#: ../src/osx/menu_osx.cpp:526
+msgctxt "macOS menu item"
+msgid "Hide Others"
+msgstr "أخفِ الآخرين"
+
+#: ../src/osx/menu_osx.cpp:528
+msgctxt "macOS menu item"
+msgid "Show All"
+msgstr "أظهر الكلّ"
+
+#: ../src/osx/menu_osx.cpp:534
+#, c-format
+msgctxt "macOS menu item"
+msgid "Quit %s"
+msgstr "أنهِ %s"
+
+#: ../src/osx/menu_osx.cpp:537
+msgctxt "macOS menu item"
+msgid "Quit Application"
+msgstr "أنهِ التطبيق"
+
+#: ../src/osx/webview_webkit.mm:444
+msgid "Printing is not supported by the system web control"
+msgstr "الطباعة ليست مدعومة من تحكّم انترنت النظام"
+
+#: ../src/osx/webview_webkit.mm:453
+msgid "Print operation could not be initialized"
+msgstr "تعذّر تجهيز عملية الطباعة"
+
+#. TRANSLATORS: Label of font point size
+#: ../src/propgrid/advprops.cpp:605
+msgid "Point Size"
+msgstr "مقاس النقطة"
+
+#. TRANSLATORS: Label of font face name
+#: ../src/propgrid/advprops.cpp:615
+msgid "Face Name"
+msgstr "اسم ضرب الخط"
+
+#. TRANSLATORS: Label of font style
+#: ../src/propgrid/advprops.cpp:623 ../src/richtext/richtextformatdlg.cpp:331
+msgid "Style"
+msgstr "الطراز"
+
+#. TRANSLATORS: Label of font weight
+#: ../src/propgrid/advprops.cpp:628
+msgid "Weight"
+msgstr "الوزن"
+
+#. TRANSLATORS: Label of underlined font
+#: ../src/propgrid/advprops.cpp:633 ../src/richtext/richtextfontpage.cpp:358
+msgid "Underlined"
+msgstr "تحته خط"
+
+#. TRANSLATORS: Label of font family
+#: ../src/propgrid/advprops.cpp:637
+msgid "Family"
+msgstr "العائلة"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:801
+msgid "AppWorkspace"
+msgstr "لون مساحة العمل AppWorkspace"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:802
+msgid "ActiveBorder"
+msgstr "لون حد النافذة النشطة ActiveBorder"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:803
+msgid "ActiveCaption"
+msgstr "لون خلفية شريط العنوان ActiveCaption"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:804
+msgid "ButtonFace"
+msgstr "لون واجهة لزر ثلاثي ابعاد ButtonFace"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:805
+msgid "ButtonHighlight"
+msgstr "لون إبراز لزر ثلاثي ابعاد ButtonHighlight"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:806
+msgid "ButtonShadow"
+msgstr "لون ظل لزر ثلاثي ابعاد ButtonShadow"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:807
+msgid "ButtonText"
+msgstr "نص زر ButtonText"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:808
+msgid "CaptionText"
+msgstr "نص شرح CaptionText"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:809
+msgid "ControlDark"
+msgstr "لون ظل غامق لثلاثي ابعاد ControlDark"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:810
+msgid "ControlLight"
+msgstr "لون ظل فاتح لثلاثي ابعاد ControlLight"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:812
+msgid "GrayText"
+msgstr "لون نص رمادي GrayText"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:813
+msgid "Highlight"
+msgstr "لون الإبراز Highlight"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:814
+msgid "HighlightText"
+msgstr "لون إبراز النص HighlightText"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:815
+msgid "InactiveBorder"
+msgstr "لون حد غير نشط InactiveBorder"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:816
+msgid "InactiveCaption"
+msgstr "لون شريط عنوان غير نشط InactiveCaption"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:817
+msgid "InactiveCaptionText"
+msgstr "لون نص شريط عنوان غير نشط InactiveCaptionText"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:818
+msgid "Menu"
+msgstr "لون قائمة Menu"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:819
+msgid "Scrollbar"
+msgstr "لون شريط اللف Scrollbar"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:820
+msgid "Tooltip"
+msgstr "لون تلميحة أداة Tooltip"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:821
+msgid "TooltipText"
+msgstr "لون نص تلميحة أداة TooltipText"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:822
+msgid "Window"
+msgstr "لون النافذة Window"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:823
+msgid "WindowFrame"
+msgstr "لون اطار النافذة WindowFrame"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:824
+msgid "WindowText"
+msgstr "لون نص النافذة WindowText"
+
+#. TRANSLATORS: Custom colour choice entry
+#: ../src/propgrid/advprops.cpp:825 ../src/propgrid/advprops.cpp:1532
+#: ../src/propgrid/advprops.cpp:1576
+msgid "Custom"
+msgstr "مخصص"
+
+#: ../src/propgrid/advprops.cpp:1558
+msgid "Black"
+msgstr "أسود"
+
+#: ../src/propgrid/advprops.cpp:1559
+msgid "Maroon"
+msgstr "كستنائي"
+
+#: ../src/propgrid/advprops.cpp:1560
+msgid "Navy"
+msgstr "بحري"
+
+#: ../src/propgrid/advprops.cpp:1561
+msgid "Purple"
+msgstr "أرجواني"
+
+#: ../src/propgrid/advprops.cpp:1562
+msgid "Teal"
+msgstr "أزرق مخضر"
+
+#: ../src/propgrid/advprops.cpp:1563
+msgid "Gray"
+msgstr "رمادي"
+
+#: ../src/propgrid/advprops.cpp:1564
+msgid "Green"
+msgstr "أخضر"
+
+#: ../src/propgrid/advprops.cpp:1565
+msgid "Olive"
+msgstr "زيتوني"
+
+#: ../src/propgrid/advprops.cpp:1566
+msgid "Brown"
+msgstr "بني"
+
+#: ../src/propgrid/advprops.cpp:1567
+msgid "Blue"
+msgstr "أزرق"
+
+#: ../src/propgrid/advprops.cpp:1568
+msgid "Fuchsia"
+msgstr "ارجواني أحمر"
+
+#: ../src/propgrid/advprops.cpp:1569
+msgid "Red"
+msgstr "أحمر"
+
+#: ../src/propgrid/advprops.cpp:1570
+msgid "Orange"
+msgstr "برتقالي"
+
+#: ../src/propgrid/advprops.cpp:1571
+msgid "Silver"
+msgstr "فضي"
+
+#: ../src/propgrid/advprops.cpp:1572
+msgid "Lime"
+msgstr "ليموني"
+
+#: ../src/propgrid/advprops.cpp:1573
+msgid "Aqua"
+msgstr "مائي"
+
+#: ../src/propgrid/advprops.cpp:1574
+msgid "Yellow"
+msgstr "أصفر"
+
+#: ../src/propgrid/advprops.cpp:1575
+msgid "White"
+msgstr "أبيض"
+
+#: ../src/propgrid/advprops.cpp:1718
+msgctxt "system cursor name"
+msgid "Default"
+msgstr "المبدئي"
+
+#: ../src/propgrid/advprops.cpp:1719
+msgctxt "system cursor name"
+msgid "Arrow"
+msgstr "سهم"
+
+#: ../src/propgrid/advprops.cpp:1720
+msgctxt "system cursor name"
+msgid "Right Arrow"
+msgstr "سهم أيمن"
+
+#: ../src/propgrid/advprops.cpp:1721
+msgctxt "system cursor name"
+msgid "Blank"
+msgstr "فارغ"
+
+#: ../src/propgrid/advprops.cpp:1722
+msgctxt "system cursor name"
+msgid "Bullseye"
+msgstr "نقطةهدف"
+
+#: ../src/propgrid/advprops.cpp:1723
+msgctxt "system cursor name"
+msgid "Character"
+msgstr "مَحرَف"
+
+#: ../src/propgrid/advprops.cpp:1724
+msgctxt "system cursor name"
+msgid "Cross"
+msgstr "صليب"
+
+#: ../src/propgrid/advprops.cpp:1725
+msgctxt "system cursor name"
+msgid "Hand"
+msgstr "يد"
+
+#: ../src/propgrid/advprops.cpp:1726
+msgctxt "system cursor name"
+msgid "I-Beam"
+msgstr "شعاع-I"
+
+#: ../src/propgrid/advprops.cpp:1727
+msgctxt "system cursor name"
+msgid "Left Button"
+msgstr "الزر الأيسر"
+
+#: ../src/propgrid/advprops.cpp:1728
+msgctxt "system cursor name"
+msgid "Magnifier"
+msgstr "المكبّرة"
+
+#: ../src/propgrid/advprops.cpp:1729
+msgctxt "system cursor name"
+msgid "Middle Button"
+msgstr "الزر الأوسط"
+
+#: ../src/propgrid/advprops.cpp:1730
+msgctxt "system cursor name"
+msgid "No Entry"
+msgstr "لا مُدخَلة"
+
+#: ../src/propgrid/advprops.cpp:1731
+msgctxt "system cursor name"
+msgid "Paint Brush"
+msgstr "فرشاة تلوين"
+
+#: ../src/propgrid/advprops.cpp:1732
+msgctxt "system cursor name"
+msgid "Pencil"
+msgstr "قلم"
+
+#: ../src/propgrid/advprops.cpp:1733
+msgctxt "system cursor name"
+msgid "Point Left"
+msgstr "أشِر يسارا"
+
+#: ../src/propgrid/advprops.cpp:1734
+msgctxt "system cursor name"
+msgid "Point Right"
+msgstr "أشِر يمينا"
+
+#: ../src/propgrid/advprops.cpp:1735
+msgctxt "system cursor name"
+msgid "Question Arrow"
+msgstr "سهم سؤال"
+
+#: ../src/propgrid/advprops.cpp:1736
+msgctxt "system cursor name"
+msgid "Right Button"
+msgstr "الزر الأيمن"
+
+#: ../src/propgrid/advprops.cpp:1737
+msgctxt "system cursor name"
+msgid "Sizing NE-SW"
+msgstr "تحجيم ش‌ق-ج‌غ"
+
+#: ../src/propgrid/advprops.cpp:1738
+msgctxt "system cursor name"
+msgid "Sizing N-S"
+msgstr "تحجيم ش-ج"
+
+#: ../src/propgrid/advprops.cpp:1739
+msgctxt "system cursor name"
+msgid "Sizing NW-SE"
+msgstr "تحجيم ش‌غ-ج‌ق"
+
+#: ../src/propgrid/advprops.cpp:1740
+msgctxt "system cursor name"
+msgid "Sizing W-E"
+msgstr "تحجيم غ-ق"
+
+#: ../src/propgrid/advprops.cpp:1741
+msgctxt "system cursor name"
+msgid "Sizing"
+msgstr "تحجيم"
+
+#: ../src/propgrid/advprops.cpp:1742
+msgctxt "system cursor name"
+msgid "Spraycan"
+msgstr "علبةبخاخ"
+
+#: ../src/propgrid/advprops.cpp:1743
+msgctxt "system cursor name"
+msgid "Wait"
+msgstr "انتظر"
+
+#: ../src/propgrid/advprops.cpp:1744
+msgctxt "system cursor name"
+msgid "Watch"
+msgstr "ترقّب"
+
+#: ../src/propgrid/advprops.cpp:1745
+msgctxt "system cursor name"
+msgid "Wait Arrow"
+msgstr "سهم انتظار"
+
+#: ../src/propgrid/advprops.cpp:2109
+msgid "Make a selection:"
+msgstr "إعمل تحديداً:"
+
+#: ../src/propgrid/manager.cpp:394
+msgid "Property"
+msgstr "الخاصية"
+
+#: ../src/propgrid/manager.cpp:395
+msgid "Value"
+msgstr "القيمة"
+
+#: ../src/propgrid/manager.cpp:1683
+msgid "Categorized Mode"
+msgstr "الوضع الفئوي"
+
+#: ../src/propgrid/manager.cpp:1709
+msgid "Alphabetic Mode"
+msgstr "الوضع الألفبائي"
+
+#. TRANSLATORS: Name of Boolean false value
+#: ../src/propgrid/propgrid.cpp:230
+msgid "False"
+msgstr "خطأ"
+
+#. TRANSLATORS: Name of Boolean true value
+#: ../src/propgrid/propgrid.cpp:232
+msgid "True"
+msgstr "صحيح"
+
+#. TRANSLATORS: Text  displayed for unspecified value
+#: ../src/propgrid/propgrid.cpp:428
+msgid "Unspecified"
+msgstr "غير محدد"
+
+#. TRANSLATORS: Caption of message box displaying any property error
+#: ../src/propgrid/propgrid.cpp:3145 ../src/propgrid/propgrid.cpp:3282
+msgid "Property Error"
+msgstr "خطأ في الخاصية"
+
+#: ../src/propgrid/propgrid.cpp:3259
+msgid "You have entered invalid value. Press ESC to cancel editing."
+msgstr "لقد أدخلتَ قيمة غير صحيحة. اضغط م‌الهروب ESC لتلغي التحرير."
+
+#: ../src/propgrid/propgrid.cpp:6608
+#, c-format
+msgid "Error in resource: %s"
+msgstr "خطأ في المورد: %s"
+
+#: ../src/propgrid/propgridiface.cpp:377
+#, c-format
+msgid ""
+"Type operation \"%s\" failed: Property labeled \"%s\" is of type \"%s\", NOT "
+"\"%s\"."
+msgstr ""
+"عملية النوع \"%s\" أخفقت: الخاصية الموصوفة \"%s\" هي من النوع \"%s\" وليس "
+"\"%s\"."
+
+#: ../src/propgrid/props.cpp:159
+#, c-format
+msgid "Unknown base %d. Base 10 will be used."
+msgstr "أساس مجهول %d. سيُستخدم الأساس 10."
+
+#: ../src/propgrid/props.cpp:324
+#, c-format
+msgid "Value must be %s or higher."
+msgstr "يجب ان تكون القيمة %s أو أعلى."
+
+#: ../src/propgrid/props.cpp:329 ../src/propgrid/props.cpp:356
+#, c-format
+msgid "Value must be between %s and %s."
+msgstr "يجب ان تكون القيمة بين %s و %s."
+
+#: ../src/propgrid/props.cpp:351
+#, c-format
+msgid "Value must be %s or less."
+msgstr "يجب ان تكون القيمة %s أو أقل."
+
+#: ../src/propgrid/props.cpp:1058
+#, c-format
+msgid "Not %s"
+msgstr "ليس %s"
+
+#: ../src/propgrid/props.cpp:1770
+msgid "Choose a directory:"
+msgstr "اختر دليلا:"
+
+#: ../src/propgrid/props.cpp:2055
+msgid "Choose a file"
+msgstr "اختر ملفا"
+
+#: ../src/qt/mdi.cpp:254
+msgid "&Tile"
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:147
+#: ../src/richtext/richtextformatdlg.cpp:376
+msgid "Background"
+msgstr "الخلفية"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:159
+msgid "Background &colour:"
+msgstr "&لون الخلفية:"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:161
+#: ../src/richtext/richtextbackgroundpage.cpp:163
+msgid "Enables a background colour."
+msgstr "يفعّل لون الخلفية."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:167
+#: ../src/richtext/richtextbackgroundpage.cpp:169
+msgid "The background colour."
+msgstr "لون الخلفية."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:178
+msgid "Shadow"
+msgstr "الظل"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:193
+msgid "Use &shadow"
+msgstr "استخدم ال&ظل"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:195
+#: ../src/richtext/richtextbackgroundpage.cpp:197
+msgid "Enables a shadow."
+msgstr "يفعّل الظل."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:211
+msgid "&Horizontal offset:"
+msgstr "الحيود الأ&فقي:"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:218
+#: ../src/richtext/richtextbackgroundpage.cpp:220
+msgid "The horizontal offset."
+msgstr "الحيود الأفقي."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:224
+#: ../src/richtext/richtextbackgroundpage.cpp:227
+#: ../src/richtext/richtextbackgroundpage.cpp:228
+#: ../src/richtext/richtextbackgroundpage.cpp:247
+#: ../src/richtext/richtextbackgroundpage.cpp:250
+#: ../src/richtext/richtextbackgroundpage.cpp:251
+#: ../src/richtext/richtextbackgroundpage.cpp:287
+#: ../src/richtext/richtextbackgroundpage.cpp:290
+#: ../src/richtext/richtextbackgroundpage.cpp:291
+#: ../src/richtext/richtextbackgroundpage.cpp:314
+#: ../src/richtext/richtextbackgroundpage.cpp:317
+#: ../src/richtext/richtextbackgroundpage.cpp:318
+#: ../src/richtext/richtextborderspage.cpp:252
+#: ../src/richtext/richtextborderspage.cpp:255
+#: ../src/richtext/richtextborderspage.cpp:256
+#: ../src/richtext/richtextborderspage.cpp:286
+#: ../src/richtext/richtextborderspage.cpp:289
+#: ../src/richtext/richtextborderspage.cpp:290
+#: ../src/richtext/richtextborderspage.cpp:320
+#: ../src/richtext/richtextborderspage.cpp:323
+#: ../src/richtext/richtextborderspage.cpp:324
+#: ../src/richtext/richtextborderspage.cpp:354
+#: ../src/richtext/richtextborderspage.cpp:357
+#: ../src/richtext/richtextborderspage.cpp:358
+#: ../src/richtext/richtextborderspage.cpp:420
+#: ../src/richtext/richtextborderspage.cpp:423
+#: ../src/richtext/richtextborderspage.cpp:424
+#: ../src/richtext/richtextborderspage.cpp:454
+#: ../src/richtext/richtextborderspage.cpp:457
+#: ../src/richtext/richtextborderspage.cpp:458
+#: ../src/richtext/richtextborderspage.cpp:488
+#: ../src/richtext/richtextborderspage.cpp:491
+#: ../src/richtext/richtextborderspage.cpp:492
+#: ../src/richtext/richtextborderspage.cpp:522
+#: ../src/richtext/richtextborderspage.cpp:525
+#: ../src/richtext/richtextborderspage.cpp:526
+#: ../src/richtext/richtextborderspage.cpp:590
+#: ../src/richtext/richtextborderspage.cpp:593
+#: ../src/richtext/richtextborderspage.cpp:594
+#: ../src/richtext/richtextfontpage.cpp:177
+#: ../src/richtext/richtextmarginspage.cpp:199
+#: ../src/richtext/richtextmarginspage.cpp:201
+#: ../src/richtext/richtextmarginspage.cpp:202
+#: ../src/richtext/richtextmarginspage.cpp:224
+#: ../src/richtext/richtextmarginspage.cpp:226
+#: ../src/richtext/richtextmarginspage.cpp:227
+#: ../src/richtext/richtextmarginspage.cpp:247
+#: ../src/richtext/richtextmarginspage.cpp:249
+#: ../src/richtext/richtextmarginspage.cpp:250
+#: ../src/richtext/richtextmarginspage.cpp:272
+#: ../src/richtext/richtextmarginspage.cpp:274
+#: ../src/richtext/richtextmarginspage.cpp:275
+#: ../src/richtext/richtextmarginspage.cpp:313
+#: ../src/richtext/richtextmarginspage.cpp:315
+#: ../src/richtext/richtextmarginspage.cpp:316
+#: ../src/richtext/richtextmarginspage.cpp:338
+#: ../src/richtext/richtextmarginspage.cpp:340
+#: ../src/richtext/richtextmarginspage.cpp:341
+#: ../src/richtext/richtextmarginspage.cpp:361
+#: ../src/richtext/richtextmarginspage.cpp:363
+#: ../src/richtext/richtextmarginspage.cpp:364
+#: ../src/richtext/richtextmarginspage.cpp:386
+#: ../src/richtext/richtextmarginspage.cpp:388
+#: ../src/richtext/richtextmarginspage.cpp:389
+#: ../src/richtext/richtextsizepage.cpp:337
+#: ../src/richtext/richtextsizepage.cpp:340
+#: ../src/richtext/richtextsizepage.cpp:341
+#: ../src/richtext/richtextsizepage.cpp:371
+#: ../src/richtext/richtextsizepage.cpp:374
+#: ../src/richtext/richtextsizepage.cpp:375
+#: ../src/richtext/richtextsizepage.cpp:398
+#: ../src/richtext/richtextsizepage.cpp:401
+#: ../src/richtext/richtextsizepage.cpp:402
+#: ../src/richtext/richtextsizepage.cpp:425
+#: ../src/richtext/richtextsizepage.cpp:428
+#: ../src/richtext/richtextsizepage.cpp:429
+#: ../src/richtext/richtextsizepage.cpp:452
+#: ../src/richtext/richtextsizepage.cpp:455
+#: ../src/richtext/richtextsizepage.cpp:456
+#: ../src/richtext/richtextsizepage.cpp:479
+#: ../src/richtext/richtextsizepage.cpp:482
+#: ../src/richtext/richtextsizepage.cpp:483
+#: ../src/richtext/richtextsizepage.cpp:553
+#: ../src/richtext/richtextsizepage.cpp:556
+#: ../src/richtext/richtextsizepage.cpp:557
+#: ../src/richtext/richtextsizepage.cpp:588
+#: ../src/richtext/richtextsizepage.cpp:591
+#: ../src/richtext/richtextsizepage.cpp:592
+#: ../src/richtext/richtextsizepage.cpp:623
+#: ../src/richtext/richtextsizepage.cpp:626
+#: ../src/richtext/richtextsizepage.cpp:627
+#: ../src/richtext/richtextsizepage.cpp:658
+#: ../src/richtext/richtextsizepage.cpp:661
+#: ../src/richtext/richtextsizepage.cpp:662
+msgid "px"
+msgstr "بكسِل"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:225
+#: ../src/richtext/richtextbackgroundpage.cpp:248
+#: ../src/richtext/richtextbackgroundpage.cpp:288
+#: ../src/richtext/richtextbackgroundpage.cpp:315
+#: ../src/richtext/richtextborderspage.cpp:253
+#: ../src/richtext/richtextborderspage.cpp:287
+#: ../src/richtext/richtextborderspage.cpp:321
+#: ../src/richtext/richtextborderspage.cpp:355
+#: ../src/richtext/richtextborderspage.cpp:421
+#: ../src/richtext/richtextborderspage.cpp:455
+#: ../src/richtext/richtextborderspage.cpp:489
+#: ../src/richtext/richtextborderspage.cpp:523
+#: ../src/richtext/richtextborderspage.cpp:591
+#: ../src/richtext/richtextmarginspage.cpp:200
+#: ../src/richtext/richtextmarginspage.cpp:225
+#: ../src/richtext/richtextmarginspage.cpp:248
+#: ../src/richtext/richtextmarginspage.cpp:273
+#: ../src/richtext/richtextmarginspage.cpp:314
+#: ../src/richtext/richtextmarginspage.cpp:339
+#: ../src/richtext/richtextmarginspage.cpp:362
+#: ../src/richtext/richtextmarginspage.cpp:387
+#: ../src/richtext/richtextsizepage.cpp:338
+#: ../src/richtext/richtextsizepage.cpp:372
+#: ../src/richtext/richtextsizepage.cpp:399
+#: ../src/richtext/richtextsizepage.cpp:426
+#: ../src/richtext/richtextsizepage.cpp:453
+#: ../src/richtext/richtextsizepage.cpp:480
+#: ../src/richtext/richtextsizepage.cpp:554
+#: ../src/richtext/richtextsizepage.cpp:589
+#: ../src/richtext/richtextsizepage.cpp:624
+#: ../src/richtext/richtextsizepage.cpp:659
+msgid "cm"
+msgstr "سم"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:226
+#: ../src/richtext/richtextbackgroundpage.cpp:249
+#: ../src/richtext/richtextbackgroundpage.cpp:289
+#: ../src/richtext/richtextbackgroundpage.cpp:316
+#: ../src/richtext/richtextborderspage.cpp:254
+#: ../src/richtext/richtextborderspage.cpp:288
+#: ../src/richtext/richtextborderspage.cpp:322
+#: ../src/richtext/richtextborderspage.cpp:356
+#: ../src/richtext/richtextborderspage.cpp:422
+#: ../src/richtext/richtextborderspage.cpp:456
+#: ../src/richtext/richtextborderspage.cpp:490
+#: ../src/richtext/richtextborderspage.cpp:524
+#: ../src/richtext/richtextborderspage.cpp:592
+#: ../src/richtext/richtextfontpage.cpp:176
+#: ../src/richtext/richtextfontpage.cpp:179
+msgid "pt"
+msgstr "نقطة"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:229
+#: ../src/richtext/richtextbackgroundpage.cpp:231
+#: ../src/richtext/richtextbackgroundpage.cpp:252
+#: ../src/richtext/richtextbackgroundpage.cpp:254
+#: ../src/richtext/richtextbackgroundpage.cpp:292
+#: ../src/richtext/richtextbackgroundpage.cpp:294
+#: ../src/richtext/richtextbackgroundpage.cpp:319
+#: ../src/richtext/richtextbackgroundpage.cpp:321
+msgid "Units for this value."
+msgstr "الوحدات لهذه القيمة."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:234
+msgid "&Vertical offset:"
+msgstr "الحيود ال&عمودي:"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:241
+#: ../src/richtext/richtextbackgroundpage.cpp:243
+msgid "The vertical offset."
+msgstr "الحيود العمودي."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:257
+msgid "Shadow c&olour:"
+msgstr "ل&ون الظل:"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:259
+#: ../src/richtext/richtextbackgroundpage.cpp:261
+msgid "Enables the shadow colour."
+msgstr "يفعّل لون الظل."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:265
+#: ../src/richtext/richtextbackgroundpage.cpp:267
+msgid "The shadow colour."
+msgstr "لون الظل."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:270
+msgid "Sh&adow spread:"
+msgstr "انتشار الظل:"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:272
+#: ../src/richtext/richtextbackgroundpage.cpp:274
+msgid "Enables the shadow spread."
+msgstr "يفعّل انتشار الظل."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:281
+#: ../src/richtext/richtextbackgroundpage.cpp:283
+msgid "The shadow spread."
+msgstr "انتشار الظل."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:297
+msgid "&Blur distance:"
+msgstr "مسافة الت&مويه:"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:299
+#: ../src/richtext/richtextbackgroundpage.cpp:301
+msgid "Enables the blur distance."
+msgstr "يفعّل مسافة التمويه."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:308
+#: ../src/richtext/richtextbackgroundpage.cpp:310
+msgid "The shadow blur distance."
+msgstr "مسافة تمويه الظل."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:324
+msgid "Opaci&ty:"
+msgstr "ال&عتامة:"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:326
+#: ../src/richtext/richtextbackgroundpage.cpp:328
+msgid "Enables the shadow opacity."
+msgstr "يفعّل عتامة الظل."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:335
+#: ../src/richtext/richtextbackgroundpage.cpp:337
+msgid "The shadow opacity."
+msgstr "عتامة الظل."
+
+#. TRANSLATORS: Rich text page units (percentage)
+#: ../src/richtext/richtextbackgroundpage.cpp:340
+#: ../src/richtext/richtextsizepage.cpp:339
+#: ../src/richtext/richtextsizepage.cpp:373
+#: ../src/richtext/richtextsizepage.cpp:400
+#: ../src/richtext/richtextsizepage.cpp:427
+#: ../src/richtext/richtextsizepage.cpp:454
+#: ../src/richtext/richtextsizepage.cpp:481
+#: ../src/richtext/richtextsizepage.cpp:555
+#: ../src/richtext/richtextsizepage.cpp:590
+#: ../src/richtext/richtextsizepage.cpp:625
+#: ../src/richtext/richtextsizepage.cpp:660
+msgid "%"
+msgstr "٪"
+
+#: ../src/richtext/richtextborderspage.cpp:229
+#: ../src/richtext/richtextborderspage.cpp:387
+msgid "Border"
+msgstr "الحد"
+
+#: ../src/richtext/richtextborderspage.cpp:242
+#: ../src/richtext/richtextborderspage.cpp:410
+#: ../src/richtext/richtextindentspage.cpp:194
+#: ../src/richtext/richtextliststylepage.cpp:384
+#: ../src/richtext/richtextmarginspage.cpp:185
+#: ../src/richtext/richtextmarginspage.cpp:299
+#: ../src/richtext/richtextsizepage.cpp:531
+#: ../src/richtext/richtextsizepage.cpp:538
+msgid "&Left:"
+msgstr "&يسار:"
+
+#: ../src/richtext/richtextborderspage.cpp:257
+#: ../src/richtext/richtextborderspage.cpp:259
+msgid "Units for the left border width."
+msgstr "وحدات عُرض الحد الايسر."
+
+#: ../src/richtext/richtextborderspage.cpp:266
+#: ../src/richtext/richtextborderspage.cpp:268
+#: ../src/richtext/richtextborderspage.cpp:300
+#: ../src/richtext/richtextborderspage.cpp:302
+#: ../src/richtext/richtextborderspage.cpp:334
+#: ../src/richtext/richtextborderspage.cpp:336
+#: ../src/richtext/richtextborderspage.cpp:368
+#: ../src/richtext/richtextborderspage.cpp:370
+#: ../src/richtext/richtextborderspage.cpp:434
+#: ../src/richtext/richtextborderspage.cpp:436
+#: ../src/richtext/richtextborderspage.cpp:468
+#: ../src/richtext/richtextborderspage.cpp:470
+#: ../src/richtext/richtextborderspage.cpp:502
+#: ../src/richtext/richtextborderspage.cpp:504
+#: ../src/richtext/richtextborderspage.cpp:536
+#: ../src/richtext/richtextborderspage.cpp:538
+msgid "The border line style."
+msgstr "طراز خط الحد."
+
+#: ../src/richtext/richtextborderspage.cpp:276
+#: ../src/richtext/richtextborderspage.cpp:444
+#: ../src/richtext/richtextindentspage.cpp:212
+#: ../src/richtext/richtextliststylepage.cpp:402
+#: ../src/richtext/richtextmarginspage.cpp:210
+#: ../src/richtext/richtextmarginspage.cpp:324
+#: ../src/richtext/richtextsizepage.cpp:601
+#: ../src/richtext/richtextsizepage.cpp:608
+msgid "&Right:"
+msgstr "&يمين:"
+
+#: ../src/richtext/richtextborderspage.cpp:291
+#: ../src/richtext/richtextborderspage.cpp:293
+msgid "Units for the right border width."
+msgstr "وحدات عُرض الحد الايمن."
+
+#: ../src/richtext/richtextborderspage.cpp:310
+#: ../src/richtext/richtextborderspage.cpp:478
+#: ../src/richtext/richtextmarginspage.cpp:233
+#: ../src/richtext/richtextmarginspage.cpp:347
+#: ../src/richtext/richtextsizepage.cpp:566
+#: ../src/richtext/richtextsizepage.cpp:573
+msgid "&Top:"
+msgstr "أ&على:"
+
+#: ../src/richtext/richtextborderspage.cpp:325
+#: ../src/richtext/richtextborderspage.cpp:327
+msgid "Units for the top border width."
+msgstr "وحدات عُرض الحد الأعلى."
+
+#: ../src/richtext/richtextborderspage.cpp:344
+#: ../src/richtext/richtextborderspage.cpp:512
+#: ../src/richtext/richtextmarginspage.cpp:258
+#: ../src/richtext/richtextmarginspage.cpp:372
+#: ../src/richtext/richtextsizepage.cpp:636
+#: ../src/richtext/richtextsizepage.cpp:643
+msgid "&Bottom:"
+msgstr "أ&سفل:"
+
+#: ../src/richtext/richtextborderspage.cpp:359
+#: ../src/richtext/richtextborderspage.cpp:361
+msgid "Units for the bottom border width."
+msgstr "وحدات عُرض الحد الأسفل."
+
+#: ../src/richtext/richtextborderspage.cpp:380
+#: ../src/richtext/richtextborderspage.cpp:548
+msgid "&Synchronize values"
+msgstr "&زامِن القيم"
+
+#: ../src/richtext/richtextborderspage.cpp:382
+#: ../src/richtext/richtextborderspage.cpp:384
+#: ../src/richtext/richtextborderspage.cpp:550
+#: ../src/richtext/richtextborderspage.cpp:552
+msgid "Check to edit all borders simultaneously."
+msgstr "أشِّره لتحرير كل الحدود في وقت واحد."
+
+#: ../src/richtext/richtextborderspage.cpp:397
+#: ../src/richtext/richtextborderspage.cpp:555
+msgid "Outline"
+msgstr "الحد الخارجي"
+
+#: ../src/richtext/richtextborderspage.cpp:425
+#: ../src/richtext/richtextborderspage.cpp:427
+msgid "Units for the left outline width."
+msgstr "وحدات عُرض المحيط الايسر."
+
+#: ../src/richtext/richtextborderspage.cpp:459
+#: ../src/richtext/richtextborderspage.cpp:461
+msgid "Units for the right outline width."
+msgstr "وحدات عُرض المحيط الأيمن."
+
+#: ../src/richtext/richtextborderspage.cpp:493
+#: ../src/richtext/richtextborderspage.cpp:495
+msgid "Units for the top outline width."
+msgstr "وحدات عُرض المحيط الأعلى."
+
+#: ../src/richtext/richtextborderspage.cpp:527
+#: ../src/richtext/richtextborderspage.cpp:529
+msgid "Units for the bottom outline width."
+msgstr "وحدات عُرض المحيط الأسفل."
+
+#: ../src/richtext/richtextborderspage.cpp:565
+#: ../src/richtext/richtextborderspage.cpp:600
+msgid "Corner"
+msgstr "الزاوية"
+
+#: ../src/richtext/richtextborderspage.cpp:574
+msgid "Corner &radius:"
+msgstr "ن&صف قطر الزاوية:"
+
+#: ../src/richtext/richtextborderspage.cpp:576
+#: ../src/richtext/richtextborderspage.cpp:578
+msgid "An optional corner radius for adding rounded corners."
+msgstr "نصف قطر زاوية اختياري لإضافة زوايا مدورة."
+
+#: ../src/richtext/richtextborderspage.cpp:584
+#: ../src/richtext/richtextborderspage.cpp:586
+msgid "The value of the corner radius."
+msgstr "قيمة نصف قطر الزاوية."
+
+#: ../src/richtext/richtextborderspage.cpp:595
+#: ../src/richtext/richtextborderspage.cpp:597
+msgid "Units for the corner radius."
+msgstr "وحدات نصف قطر الزاوية."
+
+#: ../src/richtext/richtextborderspage.cpp:609
+#: ../src/richtext/richtextsizepage.cpp:247
+#: ../src/richtext/richtextsizepage.cpp:251
+msgid "None"
+msgstr "لا شيء"
+
+#: ../src/richtext/richtextborderspage.cpp:610
+msgid "Solid"
+msgstr "مملوء"
+
+#: ../src/richtext/richtextborderspage.cpp:611
+msgid "Dotted"
+msgstr "منقَّط"
+
+#: ../src/richtext/richtextborderspage.cpp:612
+msgid "Dashed"
+msgstr "متقطع"
+
+#: ../src/richtext/richtextborderspage.cpp:613
+msgid "Double"
+msgstr "مضاعَف"
+
+#: ../src/richtext/richtextborderspage.cpp:614
+msgid "Groove"
+msgstr "الأخدود"
+
+#: ../src/richtext/richtextborderspage.cpp:615
+msgid "Ridge"
+msgstr "الحافة"
+
+#: ../src/richtext/richtextborderspage.cpp:616
+msgid "Inset"
+msgstr "داخلا"
+
+#: ../src/richtext/richtextborderspage.cpp:617
+msgid "Outset"
+msgstr "خارجا"
+
+#: ../src/richtext/richtextbuffer.cpp:3518
+msgid "Change Style"
+msgstr "غيّر الطراز"
+
+#: ../src/richtext/richtextbuffer.cpp:3701
+msgid "Change Object Style"
+msgstr "غيّر طراز الكائن"
+
+#: ../src/richtext/richtextbuffer.cpp:3974
+#: ../src/richtext/richtextbuffer.cpp:8174
+msgid "Change Properties"
+msgstr "غيّر الخصائص"
+
+#: ../src/richtext/richtextbuffer.cpp:4346
+msgid "Change List Style"
+msgstr "غيّر طراز القائمة"
+
+#: ../src/richtext/richtextbuffer.cpp:4519
+msgid "Renumber List"
+msgstr "قائمة مرقَّمة"
+
+#: ../src/richtext/richtextbuffer.cpp:7867
+#: ../src/richtext/richtextbuffer.cpp:7897
+#: ../src/richtext/richtextbuffer.cpp:7939
+#: ../src/richtext/richtextctrl.cpp:1279 ../src/richtext/richtextctrl.cpp:1473
+msgid "Insert Text"
+msgstr "أدرج نصا"
+
+#: ../src/richtext/richtextbuffer.cpp:8023
+#: ../src/richtext/richtextbuffer.cpp:8979
+msgid "Insert Image"
+msgstr "أدرج صورة"
+
+#: ../src/richtext/richtextbuffer.cpp:8070
+msgid "Insert Object"
+msgstr "أدرج كائنا"
+
+#: ../src/richtext/richtextbuffer.cpp:8112
+msgid "Insert Field"
+msgstr "أدرج حقلا"
+
+#: ../src/richtext/richtextbuffer.cpp:8410
+msgid "Too many EndStyle calls!"
+msgstr "استدعاءات إنهاء طراز EndStyle كثيرة جدا!"
+
+#: ../src/richtext/richtextbuffer.cpp:8785
+msgid "files"
+msgstr "ملفات"
+
+#: ../src/richtext/richtextbuffer.cpp:9380
+msgid "standard/circle"
+msgstr "معياري\\دائرة"
+
+#: ../src/richtext/richtextbuffer.cpp:9381
+msgid "standard/circle-outline"
+msgstr "معياري\\دائرة-محيط"
+
+#: ../src/richtext/richtextbuffer.cpp:9382
+msgid "standard/square"
+msgstr "معياري\\مربع"
+
+#: ../src/richtext/richtextbuffer.cpp:9383
+msgid "standard/diamond"
+msgstr "معياري\\مَعيني"
+
+#: ../src/richtext/richtextbuffer.cpp:9384
+msgid "standard/triangle"
+msgstr "معياري\\مثلث"
+
+#: ../src/richtext/richtextbuffer.cpp:9423
+msgid "Box Properties"
+msgstr "خصائص الصندوق"
+
+#: ../src/richtext/richtextbuffer.cpp:10006
+msgid "Multiple Cell Properties"
+msgstr "خصائص خلايا متعددة"
+
+#: ../src/richtext/richtextbuffer.cpp:10008
+msgid "Cell Properties"
+msgstr "خصائص الخلية"
+
+#: ../src/richtext/richtextbuffer.cpp:11256
+msgid "Set Cell Style"
+msgstr "عيّن طراز الخلية"
+
+#: ../src/richtext/richtextbuffer.cpp:11330
+msgid "Delete Row"
+msgstr "احذف الصف"
+
+#: ../src/richtext/richtextbuffer.cpp:11380
+msgid "Delete Column"
+msgstr "احذف العمود"
+
+#: ../src/richtext/richtextbuffer.cpp:11431
+msgid "Add Row"
+msgstr "أضف صفًا"
+
+#: ../src/richtext/richtextbuffer.cpp:11494
+msgid "Add Column"
+msgstr "أضف عموداً"
+
+#: ../src/richtext/richtextbuffer.cpp:11537
+msgid "Table Properties"
+msgstr "خصائص الجدول"
+
+#: ../src/richtext/richtextbuffer.cpp:12899
+msgid "Picture Properties"
+msgstr "خصائص الصورة"
+
+#: ../src/richtext/richtextbuffer.cpp:13169
+#: ../src/richtext/richtextbuffer.cpp:13279
+msgid "image"
+msgstr "صورة"
+
+#: ../src/richtext/richtextbulletspage.cpp:145
+#: ../src/richtext/richtextliststylepage.cpp:209
+msgid "&Bullet style:"
+msgstr "طراز النقط&يات:"
+
+#: ../src/richtext/richtextbulletspage.cpp:150
+#: ../src/richtext/richtextbulletspage.cpp:152
+#: ../src/richtext/richtextliststylepage.cpp:214
+#: ../src/richtext/richtextliststylepage.cpp:216
+msgid "The available bullet styles."
+msgstr "طُرُز النقطيات المتاحة."
+
+#: ../src/richtext/richtextbulletspage.cpp:158
+#: ../src/richtext/richtextliststylepage.cpp:221
+msgid "Peri&od"
+msgstr "ن&قطة"
+
+#: ../src/richtext/richtextbulletspage.cpp:160
+#: ../src/richtext/richtextbulletspage.cpp:162
+#: ../src/richtext/richtextliststylepage.cpp:223
+#: ../src/richtext/richtextliststylepage.cpp:225
+msgid "Check to add a period after the bullet."
+msgstr "أشّر لتضيف نقطة بعد النقطية."
+
+#. TRANSLATORS: Bullet point in parentheses option
+#: ../src/richtext/richtextbulletspage.cpp:167
+#: ../src/richtext/richtextliststylepage.cpp:230
+msgid "(*)"
+msgstr "(*)"
+
+#: ../src/richtext/richtextbulletspage.cpp:169
+#: ../src/richtext/richtextbulletspage.cpp:171
+#: ../src/richtext/richtextliststylepage.cpp:232
+#: ../src/richtext/richtextliststylepage.cpp:234
+msgid "Check to enclose the bullet in parentheses."
+msgstr "أشّر لتغلق النُّقطية بأقواس."
+
+#. TRANSLATORS: Right parenthesis bullet point option
+#: ../src/richtext/richtextbulletspage.cpp:176
+#: ../src/richtext/richtextliststylepage.cpp:239
+msgid "*)"
+msgstr "*)"
+
+#: ../src/richtext/richtextbulletspage.cpp:178
+#: ../src/richtext/richtextbulletspage.cpp:180
+#: ../src/richtext/richtextliststylepage.cpp:241
+#: ../src/richtext/richtextliststylepage.cpp:243
+msgid "Check to add a right parenthesis."
+msgstr "أشّر لتضيف قوسًا أيمن."
+
+#: ../src/richtext/richtextbulletspage.cpp:185
+#: ../src/richtext/richtextliststylepage.cpp:248
+msgid "Bullet &Alignment:"
+msgstr "إزا&حة تنقيط:"
+
+#: ../src/richtext/richtextbulletspage.cpp:190
+#: ../src/richtext/richtextliststylepage.cpp:253
+msgid "Centre"
+msgstr "وسط"
+
+#: ../src/richtext/richtextbulletspage.cpp:194
+#: ../src/richtext/richtextbulletspage.cpp:196
+#: ../src/richtext/richtextbulletspage.cpp:217
+#: ../src/richtext/richtextbulletspage.cpp:219
+#: ../src/richtext/richtextliststylepage.cpp:257
+#: ../src/richtext/richtextliststylepage.cpp:259
+#: ../src/richtext/richtextliststylepage.cpp:278
+#: ../src/richtext/richtextliststylepage.cpp:280
+msgid "The bullet character."
+msgstr "محرف النقطية."
+
+#: ../src/richtext/richtextbulletspage.cpp:212
+#: ../src/richtext/richtextliststylepage.cpp:271
+msgid "&Symbol:"
+msgstr "&رمز:"
+
+#: ../src/richtext/richtextbulletspage.cpp:222
+#: ../src/richtext/richtextliststylepage.cpp:283
+msgid "Ch&oose..."
+msgstr "اخ&تر..."
+
+#: ../src/richtext/richtextbulletspage.cpp:223
+#: ../src/richtext/richtextbulletspage.cpp:225
+#: ../src/richtext/richtextliststylepage.cpp:284
+#: ../src/richtext/richtextliststylepage.cpp:286
+msgid "Click to browse for a symbol."
+msgstr "انقر للبحث عن رمز."
+
+#: ../src/richtext/richtextbulletspage.cpp:230
+#: ../src/richtext/richtextliststylepage.cpp:291
+msgid "Symbol &font:"
+msgstr "خ&ط الرمز:"
+
+#: ../src/richtext/richtextbulletspage.cpp:235
+#: ../src/richtext/richtextbulletspage.cpp:237
+#: ../src/richtext/richtextliststylepage.cpp:297
+msgid "Available fonts."
+msgstr "الخطوط المتاحة."
+
+#: ../src/richtext/richtextbulletspage.cpp:242
+#: ../src/richtext/richtextliststylepage.cpp:302
+msgid "S&tandard bullet name:"
+msgstr "اسم النقطية ال&قياسي:"
+
+#: ../src/richtext/richtextbulletspage.cpp:247
+#: ../src/richtext/richtextbulletspage.cpp:249
+#: ../src/richtext/richtextliststylepage.cpp:307
+#: ../src/richtext/richtextliststylepage.cpp:309
+msgid "A standard bullet name."
+msgstr "اسم نقطية قياسي."
+
+#: ../src/richtext/richtextbulletspage.cpp:254
+msgid "&Number:"
+msgstr "&رقم:"
+
+#: ../src/richtext/richtextbulletspage.cpp:258
+#: ../src/richtext/richtextbulletspage.cpp:260
+msgid "The list item number."
+msgstr "رقم عنصر القائمة."
+
+#: ../src/richtext/richtextbulletspage.cpp:266
+#: ../src/richtext/richtextbulletspage.cpp:268
+#: ../src/richtext/richtextliststylepage.cpp:475
+#: ../src/richtext/richtextliststylepage.cpp:477
+msgid "Shows a preview of the bullet settings."
+msgstr "يُظهر معاينة لإعدادات النقطية."
+
+#: ../src/richtext/richtextbulletspage.cpp:276
+#: ../src/richtext/richtextliststylepage.cpp:484
+msgid "(None)"
+msgstr "(لاشئ)"
+
+#: ../src/richtext/richtextbulletspage.cpp:277
+#: ../src/richtext/richtextliststylepage.cpp:485
+msgid "Arabic"
+msgstr "عربي"
+
+#: ../src/richtext/richtextbulletspage.cpp:278
+#: ../src/richtext/richtextliststylepage.cpp:486
+msgid "Upper case letters"
+msgstr "أحرف كبيرة"
+
+#: ../src/richtext/richtextbulletspage.cpp:279
+#: ../src/richtext/richtextliststylepage.cpp:487
+msgid "Lower case letters"
+msgstr "أحرف صغيرة"
+
+#: ../src/richtext/richtextbulletspage.cpp:280
+#: ../src/richtext/richtextliststylepage.cpp:488
+msgid "Upper case roman numerals"
+msgstr "أرقام رومانية بحروف كبيرة"
+
+#: ../src/richtext/richtextbulletspage.cpp:281
+#: ../src/richtext/richtextliststylepage.cpp:489
+msgid "Lower case roman numerals"
+msgstr "أرقام رومانية بحروف صغيرة"
+
+#: ../src/richtext/richtextbulletspage.cpp:282
+#: ../src/richtext/richtextliststylepage.cpp:490
+msgid "Numbered outline"
+msgstr "مخطط مرقَّم"
+
+#: ../src/richtext/richtextbulletspage.cpp:283
+#: ../src/richtext/richtextliststylepage.cpp:491
+msgid "Symbol"
+msgstr "رمز"
+
+#: ../src/richtext/richtextbulletspage.cpp:284
+#: ../src/richtext/richtextliststylepage.cpp:492
+msgid "Bitmap"
+msgstr "صورة نقطية"
+
+#: ../src/richtext/richtextbulletspage.cpp:285
+#: ../src/richtext/richtextliststylepage.cpp:493
+msgid "Standard"
+msgstr "قياسي"
+
+#: ../src/richtext/richtextbulletspage.cpp:287
+#: ../src/richtext/richtextliststylepage.cpp:495
+msgid "*"
+msgstr "*"
+
+#: ../src/richtext/richtextbulletspage.cpp:288
+#: ../src/richtext/richtextliststylepage.cpp:496
+msgid "-"
+msgstr "-"
+
+#: ../src/richtext/richtextbulletspage.cpp:289
+#: ../src/richtext/richtextliststylepage.cpp:497
+msgid ">"
+msgstr ">"
+
+#: ../src/richtext/richtextbulletspage.cpp:290
+#: ../src/richtext/richtextliststylepage.cpp:498
+msgid "+"
+msgstr "+"
+
+#: ../src/richtext/richtextbulletspage.cpp:291
+#: ../src/richtext/richtextliststylepage.cpp:499
+msgid "~"
+msgstr "~"
+
+#: ../src/richtext/richtextctrl.cpp:859
+msgid "Drag"
+msgstr "سحب"
+
+#: ../src/richtext/richtextctrl.cpp:1338 ../src/richtext/richtextctrl.cpp:1559
+msgid "Delete Text"
+msgstr "احذف النص"
+
+#: ../src/richtext/richtextctrl.cpp:1537
+msgid "Remove Bullet"
+msgstr "أزِل النقطية"
+
+#: ../src/richtext/richtextctrl.cpp:3070
+msgid "The text couldn't be saved."
+msgstr "تعذّر حفظ النص."
+
+#: ../src/richtext/richtextctrl.cpp:3644
+msgid "Replace"
+msgstr "استبدال"
+
+#: ../src/richtext/richtextfontpage.cpp:146
+#: ../src/richtext/richtextsymboldlg.cpp:384
+msgid "&Font:"
+msgstr "&خط:"
+
+#: ../src/richtext/richtextfontpage.cpp:150
+#: ../src/richtext/richtextfontpage.cpp:152
+msgid "Type a font name."
+msgstr "اكتب اسم خط."
+
+#: ../src/richtext/richtextfontpage.cpp:158
+msgid "&Size:"
+msgstr "&حجم:"
+
+#: ../src/richtext/richtextfontpage.cpp:165
+#: ../src/richtext/richtextfontpage.cpp:167
+msgid "Type a size in points."
+msgstr "اكتب حجمًا بالنقاط."
+
+#: ../src/richtext/richtextfontpage.cpp:180
+#: ../src/richtext/richtextfontpage.cpp:182
+msgid "The font size units, points or pixels."
+msgstr "وحدات حجم الخط، نقاط أو بكسلات."
+
+#: ../src/richtext/richtextfontpage.cpp:189
+#: ../src/richtext/richtextfontpage.cpp:191
+msgid "Lists the available fonts."
+msgstr "اسرد الخطوط المتاحة."
+
+#: ../src/richtext/richtextfontpage.cpp:196
+#: ../src/richtext/richtextfontpage.cpp:198
+msgid "Lists font sizes in points."
+msgstr "اسرد أحجام الخط بالنقاط."
+
+#: ../src/richtext/richtextfontpage.cpp:207
+msgid "Font st&yle:"
+msgstr "&طراز الخط:"
+
+#: ../src/richtext/richtextfontpage.cpp:212
+#: ../src/richtext/richtextfontpage.cpp:214
+msgid "Select regular or italic style."
+msgstr "حدد طرازا اعتياديًا أو مائلاً."
+
+#: ../src/richtext/richtextfontpage.cpp:220
+msgid "Font &weight:"
+msgstr "و&زن الخط:"
+
+#: ../src/richtext/richtextfontpage.cpp:225
+#: ../src/richtext/richtextfontpage.cpp:227
+msgid "Select regular or bold."
+msgstr "حدد اعتياديًا أو عريضاً."
+
+#: ../src/richtext/richtextfontpage.cpp:233
+msgid "&Underlining:"
+msgstr "&وضع خط تحته:"
+
+#: ../src/richtext/richtextfontpage.cpp:238
+#: ../src/richtext/richtextfontpage.cpp:240
+msgid "Select underlining or no underlining."
+msgstr "حدد وضع أو عدم خط تحته."
+
+#: ../src/richtext/richtextfontpage.cpp:248
+msgid "&Colour:"
+msgstr "&لون:"
+
+#: ../src/richtext/richtextfontpage.cpp:253
+#: ../src/richtext/richtextfontpage.cpp:255
+msgid "Click to change the text colour."
+msgstr "انقر لتغير لون النص."
+
+#: ../src/richtext/richtextfontpage.cpp:261
+msgid "&Bg colour:"
+msgstr "لون ال&خلفية:"
+
+#: ../src/richtext/richtextfontpage.cpp:266
+#: ../src/richtext/richtextfontpage.cpp:268
+msgid "Click to change the text background colour."
+msgstr "انقر لتغير لون خلفية النص."
+
+#: ../src/richtext/richtextfontpage.cpp:276
+#: ../src/richtext/richtextfontpage.cpp:278
+msgid "Check to show a line through the text."
+msgstr "أشّر لتُظهر خطًا عبر النص."
+
+#: ../src/richtext/richtextfontpage.cpp:281
+msgid "Ca&pitals"
+msgstr "أحرف &كبيرة"
+
+#: ../src/richtext/richtextfontpage.cpp:283
+#: ../src/richtext/richtextfontpage.cpp:285
+msgid "Check to show the text in capitals."
+msgstr "أشّر لتُظهر النص بالأحرف الكبيرة."
+
+#: ../src/richtext/richtextfontpage.cpp:288
+msgid "Small C&apitals"
+msgstr "&كبيرة مصغرة"
+
+#: ../src/richtext/richtextfontpage.cpp:290
+#: ../src/richtext/richtextfontpage.cpp:292
+msgid "Check to show the text in small capitals."
+msgstr "أشّر لتُظهر النص بأحرف كبيرة مصغرة."
+
+#: ../src/richtext/richtextfontpage.cpp:295
+msgid "Supe&rscript"
+msgstr "م&رتفع"
+
+#: ../src/richtext/richtextfontpage.cpp:297
+#: ../src/richtext/richtextfontpage.cpp:299
+msgid "Check to show the text in superscript."
+msgstr "أشّر لتُظهر النص مرتفعًا."
+
+#: ../src/richtext/richtextfontpage.cpp:302
+msgid "Subscrip&t"
+msgstr "منخف&ض"
+
+#: ../src/richtext/richtextfontpage.cpp:304
+#: ../src/richtext/richtextfontpage.cpp:306
+msgid "Check to show the text in subscript."
+msgstr "أشّر لتُظهر النص منخفضًا."
+
+#: ../src/richtext/richtextfontpage.cpp:312
+msgid "Rig&ht-to-left"
+msgstr "&يمين-إلى-يسار"
+
+#: ../src/richtext/richtextfontpage.cpp:314
+#: ../src/richtext/richtextfontpage.cpp:316
+msgid "Check to indicate right-to-left text layout."
+msgstr "أشّر لتشير إلى مخطط نص يمين-إلى-يسار."
+
+#: ../src/richtext/richtextfontpage.cpp:319
+msgid "Suppress hyphe&nation"
+msgstr "اكبح الو&اصلات"
+
+#: ../src/richtext/richtextfontpage.cpp:321
+#: ../src/richtext/richtextfontpage.cpp:323
+msgid "Check to suppress hyphenation."
+msgstr "أشّر لتكبح الواصلات."
+
+#: ../src/richtext/richtextfontpage.cpp:329
+#: ../src/richtext/richtextfontpage.cpp:331
+msgid "Shows a preview of the font settings."
+msgstr "يُظهر معاينة لإعدادات الخط."
+
+#: ../src/richtext/richtextfontpage.cpp:348
+#: ../src/richtext/richtextfontpage.cpp:352
+#: ../src/richtext/richtextfontpage.cpp:356
+#: ../src/richtext/richtextformatdlg.cpp:873
+#: ../src/richtext/richtextindentspage.cpp:273
+#: ../src/richtext/richtextindentspage.cpp:285
+#: ../src/richtext/richtextindentspage.cpp:286
+#: ../src/richtext/richtextindentspage.cpp:310
+#: ../src/richtext/richtextindentspage.cpp:325
+#: ../src/richtext/richtextliststylepage.cpp:451
+#: ../src/richtext/richtextliststylepage.cpp:463
+#: ../src/richtext/richtextliststylepage.cpp:464
+msgid "(none)"
+msgstr "(لاشئ)"
+
+#: ../src/richtext/richtextfontpage.cpp:349
+#: ../src/richtext/richtextfontpage.cpp:353
+msgid "Regular"
+msgstr "اعتيادي"
+
+#: ../src/richtext/richtextfontpage.cpp:357
+msgid "Not underlined"
+msgstr "ليس تحته خط"
+
+#: ../src/richtext/richtextformatdlg.cpp:341
+msgid "Indents && Spacing"
+msgstr "الإزاحات والتباعد"
+
+#: ../src/richtext/richtextformatdlg.cpp:346
+msgid "Tabs"
+msgstr "الألسنة"
+
+#: ../src/richtext/richtextformatdlg.cpp:351
+msgid "Bullets"
+msgstr "النقطيات"
+
+#: ../src/richtext/richtextformatdlg.cpp:356
+msgid "List Style"
+msgstr "طراز القائمة"
+
+#: ../src/richtext/richtextformatdlg.cpp:366
+#: ../src/richtext/richtextmarginspage.cpp:170
+msgid "Margins"
+msgstr "الحواشي"
+
+#: ../src/richtext/richtextformatdlg.cpp:371
+msgid "Borders"
+msgstr "الحدود"
+
+#: ../src/richtext/richtextformatdlg.cpp:765
+msgid "Colour"
+msgstr "اللون"
+
+#: ../src/richtext/richtextindentspage.cpp:127
+#: ../src/richtext/richtextliststylepage.cpp:322
+msgid "&Alignment"
+msgstr "&محاذاة"
+
+#: ../src/richtext/richtextindentspage.cpp:138
+#: ../src/richtext/richtextliststylepage.cpp:331
+msgid "&Left"
+msgstr "ي&سار"
+
+#: ../src/richtext/richtextindentspage.cpp:140
+#: ../src/richtext/richtextindentspage.cpp:142
+#: ../src/richtext/richtextliststylepage.cpp:333
+#: ../src/richtext/richtextliststylepage.cpp:335
+msgid "Left-align text."
+msgstr "حاذِ النص يساراً."
+
+#: ../src/richtext/richtextindentspage.cpp:145
+#: ../src/richtext/richtextliststylepage.cpp:338
+msgid "&Right"
+msgstr "&يمين"
+
+#: ../src/richtext/richtextindentspage.cpp:147
+#: ../src/richtext/richtextindentspage.cpp:149
+#: ../src/richtext/richtextliststylepage.cpp:340
+#: ../src/richtext/richtextliststylepage.cpp:342
+msgid "Right-align text."
+msgstr "حاذِ النص يميناً."
+
+#: ../src/richtext/richtextindentspage.cpp:152
+#: ../src/richtext/richtextliststylepage.cpp:345
+msgid "&Justified"
+msgstr "&مُساوى"
+
+#: ../src/richtext/richtextindentspage.cpp:154
+#: ../src/richtext/richtextindentspage.cpp:156
+#: ../src/richtext/richtextliststylepage.cpp:347
+#: ../src/richtext/richtextliststylepage.cpp:349
+msgid "Justify text left and right."
+msgstr "ساوِ النص يساراً ويمينًا."
+
+#: ../src/richtext/richtextindentspage.cpp:159
+#: ../src/richtext/richtextliststylepage.cpp:352
+msgid "Cen&tred"
+msgstr "مو&سط"
+
+#: ../src/richtext/richtextindentspage.cpp:161
+#: ../src/richtext/richtextindentspage.cpp:163
+#: ../src/richtext/richtextliststylepage.cpp:354
+#: ../src/richtext/richtextliststylepage.cpp:356
+msgid "Centre text."
+msgstr "وسّط النص."
+
+#: ../src/richtext/richtextindentspage.cpp:166
+#: ../src/richtext/richtextliststylepage.cpp:359
+msgid "&Indeterminate"
+msgstr "&غير محدد"
+
+#: ../src/richtext/richtextindentspage.cpp:168
+#: ../src/richtext/richtextindentspage.cpp:170
+#: ../src/richtext/richtextliststylepage.cpp:361
+#: ../src/richtext/richtextliststylepage.cpp:363
+msgid "Use the current alignment setting."
+msgstr "استخدم إعدادات المحاذاة الحالية."
+
+#: ../src/richtext/richtextindentspage.cpp:183
+#: ../src/richtext/richtextliststylepage.cpp:375
+msgid "&Indentation (tenths of a mm)"
+msgstr "الإ&زاحة (أعشار مم)"
+
+#: ../src/richtext/richtextindentspage.cpp:198
+#: ../src/richtext/richtextindentspage.cpp:200
+#: ../src/richtext/richtextliststylepage.cpp:388
+#: ../src/richtext/richtextliststylepage.cpp:390
+msgid "The left indent."
+msgstr "الإزاحة اليسرى."
+
+#: ../src/richtext/richtextindentspage.cpp:203
+#: ../src/richtext/richtextliststylepage.cpp:393
+msgid "Left (&first line):"
+msgstr "يسار (أو&ل سطر):"
+
+#: ../src/richtext/richtextindentspage.cpp:207
+#: ../src/richtext/richtextindentspage.cpp:209
+#: ../src/richtext/richtextliststylepage.cpp:397
+#: ../src/richtext/richtextliststylepage.cpp:399
+msgid "The first line indent."
+msgstr "إزاحة أول سطر."
+
+#: ../src/richtext/richtextindentspage.cpp:216
+#: ../src/richtext/richtextindentspage.cpp:218
+#: ../src/richtext/richtextliststylepage.cpp:406
+#: ../src/richtext/richtextliststylepage.cpp:408
+msgid "The right indent."
+msgstr "الإزاحة اليمنى."
+
+#: ../src/richtext/richtextindentspage.cpp:221
+msgid "&Outline level:"
+msgstr "&مستوى المخطط:"
+
+#: ../src/richtext/richtextindentspage.cpp:226
+#: ../src/richtext/richtextindentspage.cpp:228
+msgid "The outline level."
+msgstr "مستوى المخطط."
+
+#: ../src/richtext/richtextindentspage.cpp:241
+#: ../src/richtext/richtextliststylepage.cpp:420
+msgid "&Spacing (tenths of a mm)"
+msgstr "إ&زاحة (أعشار المليمتر)"
+
+#: ../src/richtext/richtextindentspage.cpp:252
+msgid "&Before a paragraph:"
+msgstr "&قبل الفقرة:"
+
+#: ../src/richtext/richtextindentspage.cpp:256
+#: ../src/richtext/richtextindentspage.cpp:258
+#: ../src/richtext/richtextliststylepage.cpp:433
+#: ../src/richtext/richtextliststylepage.cpp:435
+msgid "The spacing before the paragraph."
+msgstr "التباعد قبل الفقرة."
+
+#: ../src/richtext/richtextindentspage.cpp:261
+msgid "&After a paragraph:"
+msgstr "&بعد الفقرة:"
+
+#: ../src/richtext/richtextindentspage.cpp:266
+#: ../src/richtext/richtextliststylepage.cpp:442
+#: ../src/richtext/richtextliststylepage.cpp:444
+msgid "The spacing after the paragraph."
+msgstr "التباعد بعد الفقرة."
+
+#: ../src/richtext/richtextindentspage.cpp:269
+msgid "L&ine spacing:"
+msgstr "تباعد السطو&ر:"
+
+#: ../src/richtext/richtextindentspage.cpp:274
+#: ../src/richtext/richtextliststylepage.cpp:452
+msgid "Single"
+msgstr "مفرد"
+
+#: ../src/richtext/richtextindentspage.cpp:275
+#: ../src/richtext/richtextliststylepage.cpp:453
+msgid "1.1"
+msgstr "1,1"
+
+#: ../src/richtext/richtextindentspage.cpp:276
+#: ../src/richtext/richtextliststylepage.cpp:454
+msgid "1.2"
+msgstr "1.2"
+
+#: ../src/richtext/richtextindentspage.cpp:277
+#: ../src/richtext/richtextliststylepage.cpp:455
+msgid "1.3"
+msgstr "1.3"
+
+#: ../src/richtext/richtextindentspage.cpp:278
+#: ../src/richtext/richtextliststylepage.cpp:456
+msgid "1.4"
+msgstr "1.4"
+
+#: ../src/richtext/richtextindentspage.cpp:279
+#: ../src/richtext/richtextliststylepage.cpp:457
+msgid "1.5"
+msgstr "1.5"
+
+#: ../src/richtext/richtextindentspage.cpp:280
+#: ../src/richtext/richtextliststylepage.cpp:458
+msgid "1.6"
+msgstr "1.6"
+
+#: ../src/richtext/richtextindentspage.cpp:281
+#: ../src/richtext/richtextliststylepage.cpp:459
+msgid "1.7"
+msgstr "1.7"
+
+#: ../src/richtext/richtextindentspage.cpp:282
+#: ../src/richtext/richtextliststylepage.cpp:460
+msgid "1.8"
+msgstr "1.8"
+
+#: ../src/richtext/richtextindentspage.cpp:283
+#: ../src/richtext/richtextliststylepage.cpp:461
+msgid "1.9"
+msgstr "1.9"
+
+#: ../src/richtext/richtextindentspage.cpp:284
+#: ../src/richtext/richtextliststylepage.cpp:462
+msgid "2"
+msgstr "2"
+
+#: ../src/richtext/richtextindentspage.cpp:287
+#: ../src/richtext/richtextindentspage.cpp:289
+#: ../src/richtext/richtextliststylepage.cpp:465
+#: ../src/richtext/richtextliststylepage.cpp:467
+msgid "The line spacing."
+msgstr "تباعد الأسطر."
+
+#: ../src/richtext/richtextindentspage.cpp:292
+msgid "&Page Break"
+msgstr "فاصل ال&صفحة"
+
+#: ../src/richtext/richtextindentspage.cpp:294
+#: ../src/richtext/richtextindentspage.cpp:296
+msgid "Inserts a page break before the paragraph."
+msgstr "أدرج فاصل صفحة قبل الفقرة."
+
+#: ../src/richtext/richtextindentspage.cpp:302
+#: ../src/richtext/richtextindentspage.cpp:304
+msgid "Shows a preview of the paragraph settings."
+msgstr "يُظهر معاينة لإعدادات الفقرة."
+
+#: ../src/richtext/richtextliststylepage.cpp:182
+msgid "&List level:"
+msgstr "مستوى ال&قائمة:"
+
+#: ../src/richtext/richtextliststylepage.cpp:186
+#: ../src/richtext/richtextliststylepage.cpp:188
+msgid "Selects the list level to edit."
+msgstr "يحدد مستوى القائمة لتحريره."
+
+#: ../src/richtext/richtextliststylepage.cpp:193
+msgid "&Font for Level..."
+msgstr "&خط للمستوى..."
+
+#: ../src/richtext/richtextliststylepage.cpp:194
+#: ../src/richtext/richtextliststylepage.cpp:196
+msgid "Click to choose the font for this level."
+msgstr "انقر لتختار الخط لهذا المستوى."
+
+#: ../src/richtext/richtextliststylepage.cpp:312
+msgid "Bullet style"
+msgstr "إسلوب التنقيط"
+
+#: ../src/richtext/richtextliststylepage.cpp:429
+msgid "Before a paragraph:"
+msgstr "قبل الفقرة:"
+
+#: ../src/richtext/richtextliststylepage.cpp:438
+msgid "After a paragraph:"
+msgstr "بعد الفقرة:"
+
+#: ../src/richtext/richtextliststylepage.cpp:447
+msgid "Line spacing:"
+msgstr "مسافة السطر:"
+
+#: ../src/richtext/richtextliststylepage.cpp:470
+msgid "Spacing"
+msgstr "التباعد"
+
+#: ../src/richtext/richtextmarginspage.cpp:193
+#: ../src/richtext/richtextmarginspage.cpp:195
+msgid "The left margin size."
+msgstr "حجم الحاشية اليسرى."
+
+#: ../src/richtext/richtextmarginspage.cpp:203
+#: ../src/richtext/richtextmarginspage.cpp:205
+msgid "Units for the left margin."
+msgstr "الوحدات للهامش الأيسر."
+
+#: ../src/richtext/richtextmarginspage.cpp:218
+#: ../src/richtext/richtextmarginspage.cpp:220
+msgid "The right margin size."
+msgstr "حجم الحاشية اليمنى."
+
+#: ../src/richtext/richtextmarginspage.cpp:228
+#: ../src/richtext/richtextmarginspage.cpp:230
+msgid "Units for the right margin."
+msgstr "الوحدات للهامش الأيمن."
+
+#: ../src/richtext/richtextmarginspage.cpp:241
+#: ../src/richtext/richtextmarginspage.cpp:243
+msgid "The top margin size."
+msgstr "حجم الحاشية العليا."
+
+#: ../src/richtext/richtextmarginspage.cpp:251
+#: ../src/richtext/richtextmarginspage.cpp:253
+msgid "Units for the top margin."
+msgstr "الوحدات للهامش الأعلى."
+
+#: ../src/richtext/richtextmarginspage.cpp:266
+#: ../src/richtext/richtextmarginspage.cpp:268
+msgid "The bottom margin size."
+msgstr "حجم الحاشية السفلى."
+
+#: ../src/richtext/richtextmarginspage.cpp:276
+#: ../src/richtext/richtextmarginspage.cpp:278
+msgid "Units for the bottom margin."
+msgstr "الوحدات للهامش الأسفل."
+
+#: ../src/richtext/richtextmarginspage.cpp:284
+msgid "Padding"
+msgstr "الحشو"
+
+#: ../src/richtext/richtextmarginspage.cpp:307
+#: ../src/richtext/richtextmarginspage.cpp:309
+msgid "The left padding size."
+msgstr "حجم الحشو الأيسر."
+
+#: ../src/richtext/richtextmarginspage.cpp:317
+#: ../src/richtext/richtextmarginspage.cpp:319
+msgid "Units for the left padding."
+msgstr "الوحدات للحشو الأيسر."
+
+#: ../src/richtext/richtextmarginspage.cpp:332
+#: ../src/richtext/richtextmarginspage.cpp:334
+msgid "The right padding size."
+msgstr "حجم الحشو الأيمن."
+
+#: ../src/richtext/richtextmarginspage.cpp:342
+#: ../src/richtext/richtextmarginspage.cpp:344
+msgid "Units for the right padding."
+msgstr "الوحدات للحشو الأيمن."
+
+#: ../src/richtext/richtextmarginspage.cpp:355
+#: ../src/richtext/richtextmarginspage.cpp:357
+msgid "The top padding size."
+msgstr "حجم الحشو الأعلى."
+
+#: ../src/richtext/richtextmarginspage.cpp:365
+#: ../src/richtext/richtextmarginspage.cpp:367
+msgid "Units for the top padding."
+msgstr "الوحدات للحشو الأعلى."
+
+#: ../src/richtext/richtextmarginspage.cpp:380
+#: ../src/richtext/richtextmarginspage.cpp:382
+msgid "The bottom padding size."
+msgstr "حجم الحشو الأسفل."
+
+#: ../src/richtext/richtextmarginspage.cpp:390
+#: ../src/richtext/richtextmarginspage.cpp:392
+msgid "Units for the bottom padding."
+msgstr "الوحدات للحشو الأسفل."
+
+#: ../src/richtext/richtextprint.cpp:592
+msgid " Preview"
+msgstr " المعاينة"
+
+#: ../src/richtext/richtextsizepage.cpp:228
+msgid "Floating"
+msgstr "الطفو"
+
+#: ../src/richtext/richtextsizepage.cpp:243
+msgid "&Floating mode:"
+msgstr "وضع ال&طفو:"
+
+#: ../src/richtext/richtextsizepage.cpp:252
+#: ../src/richtext/richtextsizepage.cpp:254
+msgid "How the object will float relative to the text."
+msgstr "كيف سيطفو الكائن نسبة الى النص."
+
+#: ../src/richtext/richtextsizepage.cpp:265
+msgid "Alignment"
+msgstr "المحاذاة"
+
+#: ../src/richtext/richtextsizepage.cpp:277
+msgid "&Vertical alignment:"
+msgstr "المحاذاة ال&عمودية:"
+
+#: ../src/richtext/richtextsizepage.cpp:279
+#: ../src/richtext/richtextsizepage.cpp:281
+msgid "Enable vertical alignment."
+msgstr "فعّل المحاذاة العمودية."
+
+#: ../src/richtext/richtextsizepage.cpp:286
+msgid "Centred"
+msgstr "موسَّط"
+
+#: ../src/richtext/richtextsizepage.cpp:290
+#: ../src/richtext/richtextsizepage.cpp:292
+msgid "Vertical alignment."
+msgstr "المحاذاة العمودية."
+
+#: ../src/richtext/richtextsizepage.cpp:316
+#: ../src/richtext/richtextsizepage.cpp:323
+msgid "&Width:"
+msgstr "العُ&رض:"
+
+#: ../src/richtext/richtextsizepage.cpp:318
+#: ../src/richtext/richtextsizepage.cpp:320
+msgid "Enable the width value."
+msgstr "فعّل قيمة العُرض."
+
+#: ../src/richtext/richtextsizepage.cpp:331
+#: ../src/richtext/richtextsizepage.cpp:333
+msgid "The object width."
+msgstr "عُرض الكائن."
+
+#: ../src/richtext/richtextsizepage.cpp:342
+#: ../src/richtext/richtextsizepage.cpp:344
+msgid "Units for the object width."
+msgstr "وحدات لعُرض الكائن."
+
+#: ../src/richtext/richtextsizepage.cpp:350
+#: ../src/richtext/richtextsizepage.cpp:357
+msgid "&Height:"
+msgstr "الارت&فاع:"
+
+#: ../src/richtext/richtextsizepage.cpp:352
+#: ../src/richtext/richtextsizepage.cpp:354
+#: ../src/richtext/richtextsizepage.cpp:464
+#: ../src/richtext/richtextsizepage.cpp:466
+msgid "Enable the height value."
+msgstr "فعّل قيمة الارتفاع."
+
+#: ../src/richtext/richtextsizepage.cpp:365
+#: ../src/richtext/richtextsizepage.cpp:367
+msgid "The object height."
+msgstr "ارتفاع الكائن."
+
+#: ../src/richtext/richtextsizepage.cpp:376
+#: ../src/richtext/richtextsizepage.cpp:378
+msgid "Units for the object height."
+msgstr "وحدات لارتفاع الكائن."
+
+#: ../src/richtext/richtextsizepage.cpp:381
+msgid "Min width:"
+msgstr "العُرض الأدنى:"
+
+#: ../src/richtext/richtextsizepage.cpp:383
+#: ../src/richtext/richtextsizepage.cpp:385
+msgid "Enable the minimum width value."
+msgstr "فعّل قيمة العُرض الأدنى."
+
+#: ../src/richtext/richtextsizepage.cpp:392
+#: ../src/richtext/richtextsizepage.cpp:394
+msgid "The object minimum width."
+msgstr "العُرض الأدنى للكائن."
+
+#: ../src/richtext/richtextsizepage.cpp:403
+#: ../src/richtext/richtextsizepage.cpp:405
+msgid "Units for the minimum object width."
+msgstr "الوحدات للعُرض الأدنى للكائن."
+
+#: ../src/richtext/richtextsizepage.cpp:408
+msgid "Min height:"
+msgstr "الارتفاع الأدنى:"
+
+#: ../src/richtext/richtextsizepage.cpp:410
+#: ../src/richtext/richtextsizepage.cpp:412
+msgid "Enable the minimum height value."
+msgstr "فعّل قيمة الارتفاع الأدنى."
+
+#: ../src/richtext/richtextsizepage.cpp:419
+#: ../src/richtext/richtextsizepage.cpp:421
+msgid "The object minimum height."
+msgstr "الارتفاع الأدنى للكائن."
+
+#: ../src/richtext/richtextsizepage.cpp:430
+#: ../src/richtext/richtextsizepage.cpp:432
+msgid "Units for the minimum object height."
+msgstr "الوحدات للارتفاع الأدنى للكائن."
+
+#: ../src/richtext/richtextsizepage.cpp:435
+msgid "Max width:"
+msgstr "العُرض الأقصى:"
+
+#: ../src/richtext/richtextsizepage.cpp:437
+#: ../src/richtext/richtextsizepage.cpp:439
+msgid "Enable the maximum width value."
+msgstr "فعّل قيمة العُرض الأقصى."
+
+#: ../src/richtext/richtextsizepage.cpp:446
+#: ../src/richtext/richtextsizepage.cpp:448
+msgid "The object maximum width."
+msgstr "العُرض الأقصى للكائن."
+
+#: ../src/richtext/richtextsizepage.cpp:457
+#: ../src/richtext/richtextsizepage.cpp:459
+msgid "Units for the maximum object width."
+msgstr "الوحدات للعُرض الأقصى للكائن."
+
+#: ../src/richtext/richtextsizepage.cpp:462
+msgid "Max height:"
+msgstr "الارتفاع الأقصى:"
+
+#: ../src/richtext/richtextsizepage.cpp:473
+#: ../src/richtext/richtextsizepage.cpp:475
+msgid "The object maximum height."
+msgstr "الارتفاع الأقصى للكائن."
+
+#: ../src/richtext/richtextsizepage.cpp:484
+#: ../src/richtext/richtextsizepage.cpp:486
+msgid "Units for the maximum object height."
+msgstr "الوحدات للارتفاع الأقصى للكائن."
+
+#: ../src/richtext/richtextsizepage.cpp:495
+msgid "Position"
+msgstr "الموضع"
+
+#: ../src/richtext/richtextsizepage.cpp:513
+msgid "&Position mode:"
+msgstr "وضع ال&موضع:"
+
+#: ../src/richtext/richtextsizepage.cpp:517
+#: ../src/richtext/richtextsizepage.cpp:522
+msgid "Static"
+msgstr "ساكن"
+
+#: ../src/richtext/richtextsizepage.cpp:518
+msgid "Relative"
+msgstr "نسبي"
+
+#: ../src/richtext/richtextsizepage.cpp:519
+msgid "Absolute"
+msgstr "مطلق"
+
+#: ../src/richtext/richtextsizepage.cpp:520
+msgid "Fixed"
+msgstr "ثابت"
+
+#: ../src/richtext/richtextsizepage.cpp:533
+#: ../src/richtext/richtextsizepage.cpp:535
+#: ../src/richtext/richtextsizepage.cpp:547
+#: ../src/richtext/richtextsizepage.cpp:549
+msgid "The left position."
+msgstr "الموضع الأيسر."
+
+#: ../src/richtext/richtextsizepage.cpp:558
+#: ../src/richtext/richtextsizepage.cpp:560
+msgid "Units for the left position."
+msgstr "الوحدات للموضع الأيسر."
+
+#: ../src/richtext/richtextsizepage.cpp:568
+#: ../src/richtext/richtextsizepage.cpp:570
+#: ../src/richtext/richtextsizepage.cpp:582
+#: ../src/richtext/richtextsizepage.cpp:584
+msgid "The top position."
+msgstr "الموضع الأعلى."
+
+#: ../src/richtext/richtextsizepage.cpp:593
+#: ../src/richtext/richtextsizepage.cpp:595
+msgid "Units for the top position."
+msgstr "الوحدات للموضع الأعلى."
+
+#: ../src/richtext/richtextsizepage.cpp:603
+#: ../src/richtext/richtextsizepage.cpp:605
+#: ../src/richtext/richtextsizepage.cpp:617
+#: ../src/richtext/richtextsizepage.cpp:619
+msgid "The right position."
+msgstr "الموضع الأيمن."
+
+#: ../src/richtext/richtextsizepage.cpp:628
+#: ../src/richtext/richtextsizepage.cpp:630
+msgid "Units for the right position."
+msgstr "الوحدات للموضع الأيمن."
+
+#: ../src/richtext/richtextsizepage.cpp:638
+#: ../src/richtext/richtextsizepage.cpp:640
+#: ../src/richtext/richtextsizepage.cpp:652
+#: ../src/richtext/richtextsizepage.cpp:654
+msgid "The bottom position."
+msgstr "الموضع الأسفل."
+
+#: ../src/richtext/richtextsizepage.cpp:663
+#: ../src/richtext/richtextsizepage.cpp:665
+msgid "Units for the bottom position."
+msgstr "الوحدات للموضع الأسفل."
+
+#: ../src/richtext/richtextsizepage.cpp:671
+msgid "&Move the object to:"
+msgstr "ان&قل الكائن الى:"
+
+#: ../src/richtext/richtextsizepage.cpp:674
+msgid "&Previous Paragraph"
+msgstr "الفقرة ال&سابقة"
+
+#: ../src/richtext/richtextsizepage.cpp:675
+#: ../src/richtext/richtextsizepage.cpp:677
+msgid "Moves the object to the previous paragraph."
+msgstr "ينقل الكائن الى الفقرة السابقة."
+
+#: ../src/richtext/richtextsizepage.cpp:680
+msgid "&Next Paragraph"
+msgstr "الفقرة ال&تالية"
+
+#: ../src/richtext/richtextsizepage.cpp:681
+#: ../src/richtext/richtextsizepage.cpp:683
+msgid "Moves the object to the next paragraph."
+msgstr "ينقل الكائن الى الفقرة التالية."
+
+#: ../src/richtext/richtextstyledlg.cpp:193
+msgid "&Styles:"
+msgstr "ال&طُرُز:"
+
+#: ../src/richtext/richtextstyledlg.cpp:197
+#: ../src/richtext/richtextstyledlg.cpp:199
+msgid "The available styles."
+msgstr "الطُرُز المتاحة."
+
+#: ../src/richtext/richtextstyledlg.cpp:205
+#: ../src/richtext/richtextstyledlg.cpp:217
+msgid " "
+msgstr " "
+
+#: ../src/richtext/richtextstyledlg.cpp:209
+#: ../src/richtext/richtextstyledlg.cpp:211
+msgid "The style preview."
+msgstr "معاينة الطراز."
+
+#: ../src/richtext/richtextstyledlg.cpp:220
+msgid "New &Character Style..."
+msgstr "طراز م&حارف جديد..."
+
+#: ../src/richtext/richtextstyledlg.cpp:221
+#: ../src/richtext/richtextstyledlg.cpp:223
+msgid "Click to create a new character style."
+msgstr "انقر لتُنشئ طراز محارف جديداً."
+
+#: ../src/richtext/richtextstyledlg.cpp:226
+msgid "New &Paragraph Style..."
+msgstr "طراز &فقرة جديد..."
+
+#: ../src/richtext/richtextstyledlg.cpp:227
+#: ../src/richtext/richtextstyledlg.cpp:229
+msgid "Click to create a new paragraph style."
+msgstr "انقر لتُنشئ طراز فقرة جديداً."
+
+#: ../src/richtext/richtextstyledlg.cpp:232
+msgid "New &List Style..."
+msgstr "طراز &قائمة جديد..."
+
+#: ../src/richtext/richtextstyledlg.cpp:233
+#: ../src/richtext/richtextstyledlg.cpp:235
+msgid "Click to create a new list style."
+msgstr "انقر لتُنشئ طراز قائمة جديداً."
+
+#: ../src/richtext/richtextstyledlg.cpp:238
+msgid "New &Box Style..."
+msgstr "طراز مر&بعات جديد..."
+
+#: ../src/richtext/richtextstyledlg.cpp:239
+#: ../src/richtext/richtextstyledlg.cpp:241
+msgid "Click to create a new box style."
+msgstr "انقر لإنشاء طراز مربعات جديد."
+
+#: ../src/richtext/richtextstyledlg.cpp:246
+msgid "&Apply Style"
+msgstr "&طبّق الطراز"
+
+#: ../src/richtext/richtextstyledlg.cpp:247
+#: ../src/richtext/richtextstyledlg.cpp:249
+msgid "Click to apply the selected style."
+msgstr "انقر لتطبق الطراز المحدد."
+
+#: ../src/richtext/richtextstyledlg.cpp:252
+msgid "&Rename Style..."
+msgstr "أـ&عِد تسمية الطراز..."
+
+#: ../src/richtext/richtextstyledlg.cpp:253
+#: ../src/richtext/richtextstyledlg.cpp:255
+msgid "Click to rename the selected style."
+msgstr "انقر لتعيد تسمية الطراز المحدد."
+
+#: ../src/richtext/richtextstyledlg.cpp:258
+msgid "&Edit Style..."
+msgstr "&حرر الطراز..."
+
+#: ../src/richtext/richtextstyledlg.cpp:259
+#: ../src/richtext/richtextstyledlg.cpp:261
+msgid "Click to edit the selected style."
+msgstr "انقر لتحرر الطراز المحدد."
+
+#: ../src/richtext/richtextstyledlg.cpp:264
+msgid "&Delete Style..."
+msgstr "ا&حذف الطراز..."
+
+#: ../src/richtext/richtextstyledlg.cpp:265
+#: ../src/richtext/richtextstyledlg.cpp:267
+msgid "Click to delete the selected style."
+msgstr "انقر لتحذف الطراز المحدد."
+
+#: ../src/richtext/richtextstyledlg.cpp:274
+#: ../src/richtext/richtextstyledlg.cpp:276
+msgid "Click to close this window."
+msgstr "انقر لتغلق هذه النافذة."
+
+#: ../src/richtext/richtextstyledlg.cpp:282
+msgid "&Restart numbering"
+msgstr "أعِد &بدء الترقيم"
+
+#: ../src/richtext/richtextstyledlg.cpp:284
+#: ../src/richtext/richtextstyledlg.cpp:286
+msgid "Check to restart numbering."
+msgstr "أشّر لتعيد بدء الترقيم."
+
+#: ../src/richtext/richtextstyledlg.cpp:601
+msgid "Enter a character style name"
+msgstr "أدخِل اسم طراز مجارف جديد"
+
+#: ../src/richtext/richtextstyledlg.cpp:601
+#: ../src/richtext/richtextstyledlg.cpp:606
+#: ../src/richtext/richtextstyledlg.cpp:649
+#: ../src/richtext/richtextstyledlg.cpp:654
+#: ../src/richtext/richtextstyledlg.cpp:815
+#: ../src/richtext/richtextstyledlg.cpp:820
+#: ../src/richtext/richtextstyledlg.cpp:888
+#: ../src/richtext/richtextstyledlg.cpp:896
+#: ../src/richtext/richtextstyledlg.cpp:929
+#: ../src/richtext/richtextstyledlg.cpp:934
+msgid "New Style"
+msgstr "طراز جديد"
+
+#: ../src/richtext/richtextstyledlg.cpp:606
+#: ../src/richtext/richtextstyledlg.cpp:654
+#: ../src/richtext/richtextstyledlg.cpp:820
+#: ../src/richtext/richtextstyledlg.cpp:896
+#: ../src/richtext/richtextstyledlg.cpp:934
+msgid "Sorry, that name is taken. Please choose another."
+msgstr "عذرا، ذلك الاسم مأخوذ. لطفًا اختر آخر."
+
+#: ../src/richtext/richtextstyledlg.cpp:649
+msgid "Enter a paragraph style name"
+msgstr "أدخِل اسم طراز فقرة"
+
+#: ../src/richtext/richtextstyledlg.cpp:777
+#, c-format
+msgid "Delete style %s?"
+msgstr "أأحذف الطراز %s?"
+
+#: ../src/richtext/richtextstyledlg.cpp:777
+msgid "Delete Style"
+msgstr "احذف الطراز"
+
+#: ../src/richtext/richtextstyledlg.cpp:815
+msgid "Enter a list style name"
+msgstr "أدخِل اسم طراز قائمة"
+
+#: ../src/richtext/richtextstyledlg.cpp:888
+msgid "Enter a new style name"
+msgstr "أدخِل اسم طراز جديد"
+
+#: ../src/richtext/richtextstyledlg.cpp:929
+msgid "Enter a box style name"
+msgstr "أدخِل اسم طراز مربعات جديد"
+
+#: ../src/richtext/richtextstylepage.cpp:109
+#: ../src/richtext/richtextstylepage.cpp:111
+msgid "The style name."
+msgstr "اسم الطراز."
+
+#: ../src/richtext/richtextstylepage.cpp:114
+msgid "&Based on:"
+msgstr "ي&ستند الى:"
+
+#: ../src/richtext/richtextstylepage.cpp:119
+#: ../src/richtext/richtextstylepage.cpp:121
+msgid "The style on which this style is based."
+msgstr "الطراز الذي يستند إليه هذا الطراز."
+
+#: ../src/richtext/richtextstylepage.cpp:124
+msgid "&Next style:"
+msgstr "الطراز ال&تالي:"
+
+#: ../src/richtext/richtextstylepage.cpp:129
+#: ../src/richtext/richtextstylepage.cpp:131
+msgid "The default style for the next paragraph."
+msgstr "الطراز المبدئي للفقرة التالية."
+
+#: ../src/richtext/richtextstyles.cpp:1057
+msgid "All styles"
+msgstr "كل الطُرُز"
+
+#: ../src/richtext/richtextstyles.cpp:1058
+msgid "Paragraph styles"
+msgstr "طُرُز الفقرات"
+
+#: ../src/richtext/richtextstyles.cpp:1059
+msgid "Character styles"
+msgstr "طُرُز المحارف"
+
+#: ../src/richtext/richtextstyles.cpp:1060
+msgid "List styles"
+msgstr "طُرُز القوائم"
+
+#: ../src/richtext/richtextstyles.cpp:1061
+msgid "Box styles"
+msgstr "طُرُز المربعات"
+
+#: ../src/richtext/richtextsymboldlg.cpp:389
+#: ../src/richtext/richtextsymboldlg.cpp:391
+msgid "The font from which to take the symbol."
+msgstr "الخط ليؤخَذ منه الرمز."
+
+#: ../src/richtext/richtextsymboldlg.cpp:396
+msgid "&Subset:"
+msgstr "مجموعة &جزئية:"
+
+#: ../src/richtext/richtextsymboldlg.cpp:401
+#: ../src/richtext/richtextsymboldlg.cpp:403
+msgid "Shows a Unicode subset."
+msgstr "يُظهِر المجموعة الجزئية بالترميز الموحد."
+
+#: ../src/richtext/richtextsymboldlg.cpp:412
+msgid "xxxx"
+msgstr "xxxx"
+
+#: ../src/richtext/richtextsymboldlg.cpp:417
+msgid "&Character code:"
+msgstr "&ترميز المحارف:"
+
+#: ../src/richtext/richtextsymboldlg.cpp:421
+#: ../src/richtext/richtextsymboldlg.cpp:423
+msgid "The character code."
+msgstr "ترميز المحارف."
+
+#: ../src/richtext/richtextsymboldlg.cpp:428
+msgid "&From:"
+msgstr "&من:"
+
+#: ../src/richtext/richtextsymboldlg.cpp:433
+#: ../src/richtext/richtextsymboldlg.cpp:434
+#: ../src/richtext/richtextsymboldlg.cpp:435
+msgid "Unicode"
+msgstr "موحَّد"
+
+#: ../src/richtext/richtextsymboldlg.cpp:436
+#: ../src/richtext/richtextsymboldlg.cpp:438
+msgid "The range to show."
+msgstr "المدى لإظهاره."
+
+#: ../src/richtext/richtextsymboldlg.cpp:444
+msgid "Insert"
+msgstr "أدرِج"
+
+#: ../src/richtext/richtextsymboldlg.cpp:478
+msgid "(Normal text)"
+msgstr "(نص عادي)"
+
+#: ../src/richtext/richtexttabspage.cpp:109
+msgid "&Position (tenths of a mm):"
+msgstr "الم&وضع (أعشار المليمتر):"
+
+#: ../src/richtext/richtexttabspage.cpp:113
+#: ../src/richtext/richtexttabspage.cpp:115
+msgid "The tab position."
+msgstr "موقع اللسان."
+
+#: ../src/richtext/richtexttabspage.cpp:119
+msgid "The tab positions."
+msgstr "مواضع الألسنة."
+
+#: ../src/richtext/richtexttabspage.cpp:132
+#: ../src/richtext/richtexttabspage.cpp:134
+msgid "Click to create a new tab position."
+msgstr "انقر لتنشئ موضع لسان جديد."
+
+#: ../src/richtext/richtexttabspage.cpp:138
+#: ../src/richtext/richtexttabspage.cpp:140
+msgid "Click to delete the selected tab position."
+msgstr "انقر لتحذف موضع اللسان المحدد."
+
+#: ../src/richtext/richtexttabspage.cpp:143
+msgid "Delete A&ll"
+msgstr "احذف ال&كل"
+
+#: ../src/richtext/richtexttabspage.cpp:144
+#: ../src/richtext/richtexttabspage.cpp:146
+msgid "Click to delete all tab positions."
+msgstr "انقر لتحذف كل مواضع الألسنة."
+
+#: ../src/univ/theme.cpp:110
+msgid "Failed to initialize GUI: no built-in themes found."
+msgstr "أخفق تجهيز واجهة المستخدم الرسومية: لم يعثر على سمات مصوغة داخليا."
+
+#: ../src/univ/themes/gtk.cpp:521
+msgid "GTK+ theme"
+msgstr "سِمة ج‌ت‌ك+"
+
+#: ../src/univ/themes/metal.cpp:164
+msgid "Metal theme"
+msgstr "سمة المعادن"
+
+#: ../src/univ/themes/mono.cpp:512
+msgid "Simple monochrome theme"
+msgstr "سمة أحادية اللون بسيطة"
+
+#: ../src/univ/themes/win32.cpp:1098
+msgid "Win32 theme"
+msgstr "سمة Win32"
+
+#: ../src/univ/themes/win32.cpp:3743
+msgid "&Restore"
+msgstr "&استرجاع"
+
+#: ../src/univ/themes/win32.cpp:3744
+msgid "&Move"
+msgstr "&تحريك"
+
+#: ../src/univ/themes/win32.cpp:3746
+msgid "&Size"
+msgstr "&حجم"
+
+#: ../src/univ/themes/win32.cpp:3748
+msgid "Mi&nimize"
+msgstr "ت&صغير"
+
+#: ../src/univ/themes/win32.cpp:3750
+msgid "Ma&ximize"
+msgstr "ت&كبير"
+
+#: ../src/univ/themes/win32.cpp:3752
+msgid "Alt+"
+msgstr "م‌تغيير+"
+
+#: ../src/unix/appunix.cpp:178
+msgid "Failed to install signal handler"
+msgstr "أخفق تثبيت متولي الإشارة"
+
+#: ../src/unix/dialup.cpp:351
+msgid "Already dialling ISP."
+msgstr "يتصل بمزود خدمة الانترنت ISP سلفًا."
+
+#: ../src/unix/dlunix.cpp:93
+msgid "Failed to unload shared library"
+msgstr "أخفقت إزالة تحميل مكتبة مشاركة"
+
+#: ../src/unix/dlunix.cpp:121
+msgid "Unknown dynamic library error"
+msgstr "خطأ مجهول في مكتبة ديناميكية"
+
+#: ../src/unix/epolldispatcher.cpp:84
+msgid "Failed to create epoll descriptor"
+msgstr "أخفق إنشاء واصف epoll"
+
+#: ../src/unix/epolldispatcher.cpp:103
+msgid "Error closing epoll descriptor"
+msgstr "أخفق إغلاق واصف epoll"
+
+#: ../src/unix/epolldispatcher.cpp:116
+#, c-format
+msgid "Failed to add descriptor %d to epoll descriptor %d"
+msgstr "أخفقت إضافة الواصف %d إلى واصف epoll‏ %d"
+
+#: ../src/unix/epolldispatcher.cpp:136
+#, c-format
+msgid "Failed to modify descriptor %d in epoll descriptor %d"
+msgstr "أخفق تحرير الواصف %d في واصف epoll‏ %d"
+
+#: ../src/unix/epolldispatcher.cpp:155
+#, c-format
+msgid "Failed to unregister descriptor %d from epoll descriptor %d"
+msgstr "أخفقت إزالة تسجيل الواصف %d من واصف epoll‏ %d"
+
+#: ../src/unix/epolldispatcher.cpp:213
+#, c-format
+msgid "Waiting for IO on epoll descriptor %d failed"
+msgstr "أخفق انتظار الإدخال\\الإخراج IO لواصف epoll‏ %d"
+
+#: ../src/unix/fswatcher_inotify.cpp:71
+msgid "Unable to create inotify instance"
+msgstr "تعذّر إنشاء سيرورة inotify"
+
+#: ../src/unix/fswatcher_inotify.cpp:94
+msgid "Unable to close inotify instance"
+msgstr "تعذّر إغلاق سيرورة inotify"
+
+#: ../src/unix/fswatcher_inotify.cpp:106
+msgid "Unable to add inotify watch"
+msgstr "تعذّرت إضافة مراقبة inotify"
+
+#: ../src/unix/fswatcher_inotify.cpp:138
+#, c-format
+msgid "Unable to remove inotify watch %i"
+msgstr "تعذّرت إزالة مراقبة inotify‏ %i"
+
+#: ../src/unix/fswatcher_inotify.cpp:271
+#, c-format
+msgid "Unexpected event for \"%s\": no matching watch descriptor."
+msgstr "حدث غير متوقع لـ \"%s\": ليس هناك واصف مراقبة مطابِق."
+
+#: ../src/unix/fswatcher_inotify.cpp:320
+#, c-format
+msgid "Invalid inotify event for \"%s\""
+msgstr "حدث inotify غير صحيح لـ \"%s\""
+
+#: ../src/unix/fswatcher_inotify.cpp:553
+msgid "Unable to read from inotify descriptor"
+msgstr "تعذّرت القراءة من واصف inotify"
+
+#: ../src/unix/fswatcher_inotify.cpp:558
+msgid "EOF while reading from inotify descriptor"
+msgstr "واجهنا نهاية ملف EOF أثناء القراءة من واصف inotify"
+
+#: ../src/unix/fswatcher_kqueue.cpp:114
+msgid "Unable to create kqueue instance"
+msgstr "تعذّر إنشاء سيرورة kqueue"
+
+#: ../src/unix/fswatcher_kqueue.cpp:131
+msgid "Error closing kqueue instance"
+msgstr "خطأ في إغلاق سيرورة kqueue"
+
+#: ../src/unix/fswatcher_kqueue.cpp:153
+msgid "Unable to add kqueue watch"
+msgstr "تعذّرت إضافة مراقبة kqueue"
+
+#: ../src/unix/fswatcher_kqueue.cpp:170
+msgid "Unable to remove kqueue watch"
+msgstr "تعذّرت إزالة مراقبة kqueue"
+
+#: ../src/unix/fswatcher_kqueue.cpp:202
+msgid "Unable to get events from kqueue"
+msgstr "تعذّر جلب أحداث من kqueue"
+
+#: ../src/unix/mediactrl.cpp:966
+#, c-format
+msgid "Media playback error: %s"
+msgstr "خطأ في تشغيل الوسائط: %s"
+
+#: ../src/unix/mediactrl.cpp:1228
+#, c-format
+msgid "Failed to prepare playing \"%s\"."
+msgstr "أخفق تحضير تشغيل \"%s\"."
+
+#: ../src/unix/snglinst.cpp:164
+#, c-format
+msgid "Failed to write to lock file '%s'"
+msgstr "أخفقت الكتابة إلى ملف الإيصاد ’%s‘"
+
+#: ../src/unix/snglinst.cpp:177
+#, c-format
+msgid "Failed to set permissions on lock file '%s'"
+msgstr "أخفق إعداد التصاريح على ملف الإيصاد ’%s‘"
+
+#: ../src/unix/snglinst.cpp:194
+#, c-format
+msgid "Failed to lock the lock file '%s'"
+msgstr "أخفق إيصاد ملف الإيصاد ’%s‘"
+
+#: ../src/unix/snglinst.cpp:237
+#, c-format
+msgid "Failed to inspect the lock file '%s'"
+msgstr "أخفق فحص ملف الإيصاد ’%s‘"
+
+#: ../src/unix/snglinst.cpp:242
+#, c-format
+msgid "Lock file '%s' has incorrect owner."
+msgstr "لملف الإيصاد ’%s‘ مالك غير صحيح."
+
+#: ../src/unix/snglinst.cpp:247
+#, c-format
+msgid "Lock file '%s' has incorrect permissions."
+msgstr "لملف الإيصاد ’%s‘ تصاريح غير صحيحة."
+
+#: ../src/unix/snglinst.cpp:265
+msgid "Failed to access lock file."
+msgstr "أخفق الوصول الى ملف الإيصاد."
+
+#: ../src/unix/snglinst.cpp:274
+msgid "Failed to read PID from lock file."
+msgstr "أخفقت قراءة PID من ملف الإيصاد."
+
+#: ../src/unix/snglinst.cpp:284
+#, c-format
+msgid "Failed to remove stale lock file '%s'."
+msgstr "أخفقت إزالة ملف الإيصاد الهالك ’%s‘."
+
+#: ../src/unix/snglinst.cpp:297
+#, c-format
+msgid "Deleted stale lock file '%s'."
+msgstr "حُذف ملف الإيصاد الهالك ’%s‘."
+
+#: ../src/unix/snglinst.cpp:308
+#, c-format
+msgid "Invalid lock file '%s'."
+msgstr "ملف الإيصاد ’%s‘ غير صحيح."
+
+#: ../src/unix/snglinst.cpp:324
+#, c-format
+msgid "Failed to remove lock file '%s'"
+msgstr "أخفقت إزالة ملف الإيصاد ’%s‘."
+
+#: ../src/unix/snglinst.cpp:330
+#, c-format
+msgid "Failed to unlock lock file '%s'"
+msgstr "أخفقت إزالة إيصاد ملف الإيصاد ’%s‘"
+
+#: ../src/unix/snglinst.cpp:336
+#, c-format
+msgid "Failed to close lock file '%s'"
+msgstr "أخفق إغلاق ملف الإيصاد ’%s‘"
+
+#: ../src/unix/sound.cpp:77
+msgid "No sound"
+msgstr "بلا صوت"
+
+#: ../src/unix/sound.cpp:364
+msgid "Unable to play sound asynchronously."
+msgstr "تعذّر تشغيل الصوت بشكل غير متزامن."
+
+#: ../src/unix/sound.cpp:458
+#, c-format
+msgid "Couldn't load sound data from '%s'."
+msgstr "تعذّر تحميل بيانات الصوت من '%s'."
+
+#: ../src/unix/sound.cpp:465
+#, c-format
+msgid "Sound file '%s' is in unsupported format."
+msgstr "ملف الصوت '%s' بنسَق غير مدعوم."
+
+#: ../src/unix/sound.cpp:480
+msgid "Sound data are in unsupported format."
+msgstr "بيانات الصوت بنسَق غير مدعوم."
+
+#: ../src/unix/sound_sdl.cpp:226
+#, c-format
+msgid "Couldn't open audio: %s"
+msgstr "تعذّر فتح الملف الصوتي: %s"
+
+#: ../src/unix/threadpsx.cpp:1033
+msgid "Cannot retrieve thread scheduling policy."
+msgstr "يتعذّر استحصال سياسة جدولة التخييط."
+
+#: ../src/unix/threadpsx.cpp:1058
+#, c-format
+msgid "Cannot get priority range for scheduling policy %d."
+msgstr "تعذّر جلب مدى أولوية لسياسة الجدولة %d."
+
+#: ../src/unix/threadpsx.cpp:1066
+msgid "Thread priority setting is ignored."
+msgstr "إعداد أولوية التخييط متجاهَل."
+
+#: ../src/unix/threadpsx.cpp:1221
+msgid ""
+"Failed to join a thread, potential memory leak detected - please restart the "
+"program"
+msgstr "أخفق ضمّ تخييط، كُشف عن تسرب محتمل للذاكرة - لطفًا أعِد بدء البرنامج"
+
+#: ../src/unix/threadpsx.cpp:1352
+#, c-format
+msgid "Failed to set thread concurrency level to %lu"
+msgstr "أخفق إعداد مستوى تزامن حدوث التخييط إلى %lu"
+
+#: ../src/unix/threadpsx.cpp:1481
+#, c-format
+msgid "Failed to set thread priority %d."
+msgstr "أخفق إعداد أولوية التخييط %d."
+
+#: ../src/unix/threadpsx.cpp:1666
+msgid "Failed to terminate a thread."
+msgstr "أخفق إنهاء تخييط."
+
+#: ../src/unix/threadpsx.cpp:1893
+msgid "Thread module initialization failed: failed to create thread key"
+msgstr "أخفق تجهيز وحدة التخييط: أخفق إنشاء مفتاح التخييط"
+
+#: ../src/unix/utilsunx.cpp:340
+msgid "Impossible to get child process input"
+msgstr "يتعذّر جلب إدخال العملية الفرعية"
+
+#: ../src/unix/utilsunx.cpp:390
+msgid "Can't write to child process's stdin"
+msgstr "تعذّرت الكتابة إلى stdin للعملية الفرعية"
+
+#: ../src/unix/utilsunx.cpp:644
+#, c-format
+msgid "Failed to execute '%s'\n"
+msgstr "أخفق تنفيذ ’%s‘\n"
+
+#: ../src/unix/utilsunx.cpp:678
+msgid "Fork failed"
+msgstr "أخفق التشعيب"
+
+#: ../src/unix/utilsunx.cpp:701
+msgid "Failed to set process priority"
+msgstr "أخفق إعداد أولوية العملية"
+
+#: ../src/unix/utilsunx.cpp:712
+msgid "Failed to redirect child process input/output"
+msgstr "أخفقت إعادة توجيه إدخال\\إخراج العملية الفرعية"
+
+#: ../src/unix/utilsunx.cpp:816
+msgid "Failed to set up non-blocking pipe, the program might hang."
+msgstr "أخفق إعداد مسرى عديم الغلق، قد يعلق البرنامج."
+
+#: ../src/unix/utilsunx.cpp:1023
+msgid "Cannot get the hostname"
+msgstr "تعذّر جلب اسم المضيف"
+
+#: ../src/unix/utilsunx.cpp:1059
+msgid "Cannot get the official hostname"
+msgstr "تعذّر جلب اسم المضيف الرسمي"
+
+#: ../src/unix/wakeuppipe.cpp:49
+msgid "Failed to create wake up pipe used by event loop."
+msgstr "أخفق إنشاء مسرى إيقاظ مستخدَم لحلقة الحدث."
+
+#: ../src/unix/wakeuppipe.cpp:56
+msgid "Failed to switch wake up pipe to non-blocking mode"
+msgstr "أخفق تبديل مسرى الإيقاظ إلى وضع عدم الغلق"
+
+#: ../src/unix/wakeuppipe.cpp:117
+msgid "Failed to read from wake-up pipe"
+msgstr "أخفقت القراءة من مسرى الإيقاظ"
+
+#: ../src/x11/app.cpp:124
+#, c-format
+msgid "Invalid geometry specification '%s'"
+msgstr "مواصفات هندسية غير سليمة '%s'"
+
+#: ../src/x11/app.cpp:167
+msgid "wxWidgets could not open display. Exiting."
+msgstr "تعذّر على wxWidgets فتح الشاشة. يخرج."
+
+#: ../src/x11/utils.cpp:169
+#, c-format
+msgid "Failed to close the display \"%s\""
+msgstr "أخفق إغلاق العارضة \"%s\""
+
+#: ../src/x11/utils.cpp:188
+#, c-format
+msgid "Failed to open display \"%s\"."
+msgstr "أخفق فتح العارضة \"%s\"."
+
+#: ../src/xml/xml.cpp:868
+#, c-format
+msgid "XML parsing error: '%s' at line %d"
+msgstr "خطأ في تحليل XML: هناك ’%s‘ عند السطر %d"
+
+#: ../src/xrc/xh_propgrid.cpp:239
+#, c-format
+msgid "Page %i"
+msgstr "الصفحة %i"
+
+#: ../src/xrc/xmlres.cpp:448
+#, c-format
+msgid "Cannot load resources from '%s'."
+msgstr "تعذّر تحميل الموارد من '%s'."
+
+#: ../src/xrc/xmlres.cpp:799
+#, c-format
+msgid "Cannot open resources file '%s'."
+msgstr "تعذّر فتح ملف الموارد '%s'."
+
+#: ../src/xrc/xmlres.cpp:806
+#, c-format
+msgid "Cannot load resources from file '%s'."
+msgstr "تعذّر تحميل الموارد من الملف '%s'."
+
+#: ../src/xrc/xmlres.cpp:2767
+#, c-format
+msgid "Creating %s \"%s\" failed."
+msgstr "أخفق إنشاء %s‏ \"%s\"."
+
+#, c-format
+#~ msgid "BMP: header has biClrUsed=%d when biBitCount=%d."
+#~ msgstr "BMP: الترويسة لديها biClrUsed=%d حينما يكون biBitCount=%d."
+
+#~ msgctxt "keyboard key"
+#~ msgid "Alt+"
+#~ msgstr "م‌تغيير+"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Ctrl+"
+#~ msgstr "م‌تحكّم+"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Shift+"
+#~ msgstr "م‌تبديل+"
+
+#~ msgctxt "keyboard key"
+#~ msgid "RawCtrl+"
+#~ msgstr "م‌تحكّم‌خام+"
+
+#~ msgid "ctrl"
+#~ msgstr "م‌تحكّم"
+
+#~ msgid "alt"
+#~ msgstr "م‌تغيير"
+
+#~ msgid "shift"
+#~ msgstr "م‌تبديل"
+
+#~ msgid "rawctrl"
+#~ msgstr "م‌تحكّم‌خام"
+
+#~ msgid "Printing "
+#~ msgstr "يطبع "
+
+#~ msgid "conversion to 8-bit encoding failed"
+#~ msgstr "فشل التحويل الى الترميز 8-بت"
+
+#~ msgid "Copying more than one selected block to clipboard is not supported."
+#~ msgstr "نَسخ أكثر من كتلة محددة واحدة إلى الحافظة غير مدعوم."
+
+#, c-format
+#~ msgid "wxWidgets could not open display for '%s': exiting."
+#~ msgstr "لم يتمكن wxWidgets من فتح الشاشة لـ '%s': خروج."
+
+#~ msgid "Filter"
+#~ msgstr "تصفية"
+
+#~ msgid "Directories"
+#~ msgstr "مجلدات"
+
+#~ msgid "Files"
+#~ msgstr "ملفات"
+
+#~ msgid "Selection"
+#~ msgstr "تحديد"
+
+#~ msgid "Unsupported clipboard format."
+#~ msgstr "نسَق حافظة غير مدعوم."
+
+#~ msgid "failed to retrieve execution result"
+#~ msgstr "فشل استحصال نتيجة التنفيذ"
+
+#~ msgid "Background colour"
+#~ msgstr "لون الخلفية"
+
+#~ msgid "Font:"
+#~ msgstr "خط:"
+
+#~ msgid "Size:"
+#~ msgstr "حجم:"
+
+#~ msgid "Check to make the font bold."
+#~ msgstr "أشّر لتجعل الخط عريضًا."
+
+#~ msgid "Check to make the font italic."
+#~ msgstr "أشّر لتجعل الخط مائلا."
+
+#~ msgid "Check to make the font underlined."
+#~ msgstr "أشّر لتضع تحته خطًا."
+
+#~ msgid "Colour:"
+#~ msgstr "لون:"
+
+#~ msgid "Click to change the font colour."
+#~ msgstr "انقر لتغير لون الخط."
+
+#~ msgid "Click to cancel changes to the font."
+#~ msgstr "انقر لتلغي التغييرات على الخط."
+
+#~ msgid "Click to confirm changes to the font."
+#~ msgstr "انقر لتؤكد التغييرات على الخط."
+
+#~ msgid "<Any>"
+#~ msgstr "<Any>"
+
+#~ msgid "<Any Roman>"
+#~ msgstr "<Any Roman>"
+
+#~ msgid "<Any Decorative>"
+#~ msgstr "<Any Decorative>"
+
+#~ msgid "<Any Modern>"
+#~ msgstr "<Any Modern>"
+
+#~ msgid "<Any Script>"
+#~ msgstr "<Any Script>"
+
+#~ msgid "<Any Swiss>"
+#~ msgstr "<Any Swiss>"
+
+#~ msgid "<Any Teletype>"
+#~ msgstr "<Any Teletype>"
+
+#, fuzzy
+#~ msgid "&Save as"
+#~ msgstr "حفظ بإسم"
+
+#, fuzzy
+#~ msgid "'%s' doesn't consist only of valid characters"
+#~ msgstr "'%s' ينبغي أن يحتوي على أحرف أبجدية."
+
+#~ msgid "'%s' should be numeric."
+#~ msgstr "'%s' ينبغي أن يكون رقمي."
+
+#~ msgid "'%s' should only contain ASCII characters."
+#~ msgstr "'%s' ينبغي أن يحتوي على أحرف لها مكافئ رقمي."
+
+#~ msgid "'%s' should only contain alphabetic characters."
+#~ msgstr "'%s' ينبغي أن يحتوي على أحرف أبجدية."
+
+#~ msgid "'%s' should only contain alphabetic or numeric characters."
+#~ msgstr "'%s' ينبغي أن يحتوي على أحرف أبجدية أو رقمية."
+
+#, fuzzy
+#~ msgid "'%s' should only contain digits."
+#~ msgstr "'%s' ينبغي أن يحتوي على أحرف لها مكافئ رقمي."
+
+#~ msgid "Can't create window of class %s"
+#~ msgstr "لا يمكن إنشاء نافذة من تصنيف %s"
+
+#~ msgid "Replace selection"
+#~ msgstr "استبدال التحديد"
+
+#~ msgid "Save as"
+#~ msgstr "حفظ باسم"
+
+#~ msgid "Confirm registry update"
+#~ msgstr "تأكيد تحديثات السجل"
+
+#, fuzzy
+#~ msgid "Could not determine column index."
+#~ msgstr "تعذر بدأ معاينة المستند."
+
+#, fuzzy
+#~ msgid "Could not determine number of items"
+#~ msgstr "تعذر إنهاء الموضوع"
+
+#, fuzzy
+#~ msgid "Could not get header description."
+#~ msgstr "تعذر بدأ الطباعة."
+
+#, fuzzy
+#~ msgid "Could not get items."
+#~ msgstr "تعذر تحديد مكان الملف '%s'"
+
+#, fuzzy
+#~ msgid "Could not get property flags."
+#~ msgstr "تعذر إنشاء الملف المؤقت '%s'"
+
+#, fuzzy
+#~ msgid "Could not get selected items."
+#~ msgstr "تعذر تحديد مكان الملف '%s'"
+
+#, fuzzy
+#~ msgid "Could not remove column."
+#~ msgstr "تعذر إنشاء مؤشر."
+
+#, fuzzy
+#~ msgid "Could not retrieve number of items"
+#~ msgstr "تعذر إنشاء الملف المؤقت '%s'"
+
+#, fuzzy
+#~ msgid "Could not set column width."
+#~ msgstr "تعذر بدأ معاينة المستند."
+
+#, fuzzy
+#~ msgid "Could not set header description."
+#~ msgstr "تعذر بدأ الطباعة."
+
+#, fuzzy
+#~ msgid "Could not set icon."
+#~ msgstr "تعذر بدأ الطباعة."
+
+#, fuzzy
+#~ msgid "Could not set maximum width."
+#~ msgstr "تعذر بدأ الطباعة."
+
+#, fuzzy
+#~ msgid "Could not set minimum width."
+#~ msgstr "تعذر بدأ الطباعة."
+
+#, fuzzy
+#~ msgid "Could not set property flags."
+#~ msgstr "تعذر بدأ الطباعة."
+
+#~ msgid "Next"
+#~ msgstr "التالي"
+
+#, fuzzy
+#~ msgid "Windows 10"
+#~ msgstr "&نافذة"
+
+#, fuzzy
+#~ msgid "Windows 2000"
+#~ msgstr "&نافذة"
+
+#, fuzzy
+#~ msgid "Windows 7"
+#~ msgstr "&نافذة"
+
+#, fuzzy
+#~ msgid "Windows 8"
+#~ msgstr "&نافذة"
+
+#, fuzzy
+#~ msgid "Windows 8.1"
+#~ msgstr "&نافذة"
+
+#, fuzzy
+#~ msgid "Windows Server 10"
+#~ msgstr "&نافذة"
+
+#, fuzzy
+#~ msgid "Windows Server 2012"
+#~ msgstr "&نافذة"
+
+#, fuzzy
+#~ msgid "Windows Vista"
+#~ msgstr "&نافذة"
+
+#, fuzzy
+#~ msgid "Windows XP"
+#~ msgstr "&نافذة"
+
+#~ msgid "ADD"
+#~ msgstr "جمع"
+
+#~ msgid "BACK"
+#~ msgstr "رجوع"
+
+#~ msgid "CANCEL"
+#~ msgstr "إلغاء"
+
+#~ msgid "CAPITAL"
+#~ msgstr "كبير"
+
+#~ msgid "CLEAR"
+#~ msgstr "واضح"
+
+#~ msgid "COMMAND"
+#~ msgstr "أمر"
+
+#, fuzzy
+#~ msgid "Cannot create mutex."
+#~ msgstr "لا يمكن إنشاء كائن مزامن."
+
+#, fuzzy
+#~ msgid "Cannot resume thread %lu"
+#~ msgstr "لا يمكن استئناف الموضوع %lu"
+
+#, fuzzy
+#~ msgid "Cannot suspend thread %lu"
+#~ msgstr "لا يمكن توقف الموضوع %lu"
+
+#~ msgid "DECIMAL"
+#~ msgstr "عشري"
+
+#~ msgid "DEL"
+#~ msgstr "DEL"
+
+#~ msgid "DELETE"
+#~ msgstr "حذف"
+
+#~ msgid "DIVIDE"
+#~ msgstr "تقسيم"
+
+#~ msgid "DOWN"
+#~ msgstr "أسفل"
+
+#~ msgid "END"
+#~ msgstr "END"
+
+#~ msgid "ENTER"
+#~ msgstr "ENTER"
+
+#~ msgid "ESC"
+#~ msgstr "ESC"
+
+#~ msgid "ESCAPE"
+#~ msgstr "ESCAPE"
+
+#~ msgid ""
+#~ "File '%s' already exists.\n"
+#~ "Do you want to replace it?"
+#~ msgstr ""
+#~ "الملف '%s' موجود بالفعل.\n"
+#~ "هل تريد حقا استبداله؟"
+
+#~ msgid "HELP"
+#~ msgstr "مساعدة"
+
+#~ msgid "HOME"
+#~ msgstr "رئيسي"
+
+#~ msgid "INSERT"
+#~ msgstr "إدراج"
+
+#~ msgid "LEFT"
+#~ msgstr "يسار"
+
+#~ msgid "MENU"
+#~ msgstr "قازمة"
+
+#~ msgid "NUM_LOCK"
+#~ msgstr "الوحة ال&رقمية"
+
+#~ msgid "PAGEDOWN"
+#~ msgstr "PAGEDOWN"
+
+#~ msgid "PAGEUP"
+#~ msgstr "PAGEUP"
+
+#~ msgid "PAUSE"
+#~ msgstr "PAUSE"
+
+#~ msgid "PGDN"
+#~ msgstr "PGDN"
+
+#~ msgid "PGUP"
+#~ msgstr "PGUP"
+
+#~ msgid "PRINT"
+#~ msgstr "طبع"
+
+#~ msgid "RETURN"
+#~ msgstr "العودة"
+
+#~ msgid "RIGHT"
+#~ msgstr "يمين"
+
+#~ msgid "SELECT"
+#~ msgstr "حدد"
+
+#~ msgid "SEPARATOR"
+#~ msgstr "فاصل"
+
+#~ msgid "SNAPSHOT"
+#~ msgstr "نسخة يومية"
+
+#~ msgid "SPACE"
+#~ msgstr "مسافة"
+
+#~ msgid "SUBTRACT"
+#~ msgstr "طرح"
+
+#~ msgid "not implemented"
+#~ msgstr "غير منفذ"
+
+#~ msgid "Print preview"
+#~ msgstr "معاينة الطباعة"
+
+#~ msgid "1"
+#~ msgstr "1"
+
+#, fuzzy
+#~ msgid "10"
+#~ msgstr "1"
+
+#~ msgid "3"
+#~ msgstr "3"
+
+#~ msgid "4"
+#~ msgstr "4"
+
+#~ msgid "5"
+#~ msgstr "5"
+
+#~ msgid "6"
+#~ msgstr "6"
+
+#~ msgid "7"
+#~ msgstr "7"
+
+#~ msgid "8"
+#~ msgstr "8"
+
+#~ msgid "9"
+#~ msgstr "9"
+
+#~ msgid "#define %s must be an integer."
+#~ msgstr "#عرف%s يجب أن يكون عدد صحيح."
+
+#~ msgid "%.*f GB"
+#~ msgstr "%.*f GB"
+
+#~ msgid "%.*f MB"
+#~ msgstr "%.*f MB"
+
+#~ msgid "%.*f TB"
+#~ msgstr "%.*f TB"
+
+#~ msgid "%.*f kB"
+#~ msgstr "%.*f kB"
+
+#~ msgid "%s B"
+#~ msgstr "%s B"
+
+#~ msgid "%s not a bitmap resource specification."
+#~ msgstr "%s not a bitmap resource specification."
+
+#~ msgid "%s not an icon resource specification."
+#~ msgstr "%s ليس مصدر خاص بالأيقونات"
+
+#~ msgid "%s: ill-formed resource file syntax."
+#~ msgstr "%s: ill-formed resource file syntax."
+
+#~ msgid "&Goto..."
+#~ msgstr "&إذهب إلى..."
+
+#~ msgid "&Open"
+#~ msgstr "&فتح"
+
+#~ msgid "&Print"
+#~ msgstr "&طباعة"
+
+#~ msgid "&Save..."
+#~ msgstr "&حفظ..."
+
+#~ msgid ""
+#~ ", expected static, #include or #define\n"
+#~ "while parsing resource."
+#~ msgstr ""
+#~ ", expected static, #include or #define\n"
+#~ "while parsing resource."
+
+#~ msgid "<<"
+#~ msgstr "<<"
+
+#~ msgid ">>"
+#~ msgstr ">>"
+
+#~ msgid ">>|"
+#~ msgstr ">>|"
+
+#~ msgid "All files (*.*)|*"
+#~ msgstr "كل الملفات (*.*)|*"
+
+#~ msgid "Alt-"
+#~ msgstr "Alt-"
+
+#~ msgid "Archive doesnt contain #SYSTEM file"
+#~ msgstr "الأرشيف لا يحتوي على #ملف نظام"
+
+#~ msgid "BIG5"
+#~ msgstr "BIG5"
+
+#~ msgid "Bitmap resource specification %s not found."
+#~ msgstr "تحديد مصدر Bitmap %s غير موجود."
+
+#~ msgid "Can't check image format of file '%s': file does not exist."
+#~ msgstr "لا يمكن فحص تنسيق صورة الملف '%s': الملف غير موجود."
+
+#~ msgid "Can't load image from file '%s': file does not exist."
+#~ msgstr "لا يمكن تحميل الصورة من الملف '%s': الملف غير موجود."
+
+#~ msgid "Cannot convert dialog units: dialog unknown."
+#~ msgstr "تعذر تحويل وحدات المحاورة: المحاورة غير معروفة."
+
+#~ msgid "Cannot convert from the charset '%s'!"
+#~ msgstr "تعذر التويل من الحرف '%s'!"
+
+#~ msgid "Cannot find container for unknown control '%s'."
+#~ msgstr "تعذر العثور على حاضن للكائن المجهول '%s'"
+
+#~ msgid "Cannot find font node '%s'."
+#~ msgstr "تعذر وجود ملاحظة الخط '%s'."
+
+#~ msgid "Cannot initialize SciTech MGL!"
+#~ msgstr "Cannot initialize SciTech MGL!"
+
+#~ msgid "Cannot initialize display."
+#~ msgstr "تعذر بدأ العرض"
+
+#~ msgid "Cannot open file '%s'."
+#~ msgstr "تعذر فتح الملف '%s'."
+
+#~ msgid "Cannot parse coordinates from '%s'."
+#~ msgstr "تذعر مرور المراجع من '%s'"
+
+#~ msgid "Cannot parse dimension from '%s'."
+#~ msgstr "تعذر مرور البعد من '%s'."
+
+#~ msgid "Cannot start thread: error writing TLS"
+#~ msgstr "تعذر بدأ الموضوع: خطأ في كتابة tls"
+
+#~ msgid "Cant create the thread event queue"
+#~ msgstr "تعذر إنشاء صف حدث الموضوع"
+
+#~ msgid "Click to cancel this window."
+#~ msgstr "انقر لإلغاء هذه النافذة."
+
+#~ msgid "Click to confirm your selection."
+#~ msgstr "انقر للتأكيد على اختيارك"
+
+#~ msgid "Close\tAlt-F4"
+#~ msgstr "إغلاق\tAlt-F4"
+
+#~ msgid "Closes the dialog without inserting a symbol."
+#~ msgstr "إغلاق المحاورة دون إدراج رموز"
+
+#~ msgid "Directory '%s' doesn't exist!"
+#~ msgstr "المجلد '%s' غير موجود؟"
+
+#~ msgid "Fatal error: "
+#~ msgstr "خطأ فادح:"
+
+#~ msgid "Found "
+#~ msgstr "تم العثور عليه"
+
+#~ msgid "GB-2312"
+#~ msgstr "GB-2312"
+
+#~ msgid "Goto Page"
+#~ msgstr "الذهاب للصفحة"
+
+#~ msgid "Inserts the chosen symbol."
+#~ msgstr "إدراج الرمز المختار"
+
+#~ msgid "Paper Size"
+#~ msgstr "حجم الورقة"
+
+#~ msgid "Select all"
+#~ msgstr "تحديد الكل"
+
+#~ msgid "Status: "
+#~ msgstr "الحالة:"
+
+#~ msgid "Version %s"
+#~ msgstr "إصدار %s"
+
+#~ msgid "Warning"
+#~ msgstr "تحذير"
+
+#~ msgid "[EMPTY]"
+#~ msgstr "[فارغ]"
+
+#~ msgid "writing"
+#~ msgstr "كتابة"
+
+#~ msgid "|<<"
+#~ msgstr "|<<"
+
+#~ msgid "Added item is invalid."
+#~ msgstr "العنصر المضاف غير صالح"
+
+#~ msgid "Search!"
+#~ msgstr "بحث!"
+
+#, fuzzy
+#~ msgid "&Preview..."
+#~ msgstr "معاينة"
+
+#, fuzzy
+#~ msgid "Preview..."
+#~ msgstr "معاينة"

--- a/po_wxstd/ca.po
+++ b/po_wxstd/ca.po
@@ -1,0 +1,10353 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: wxWidgets 3.3\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-05-14 20:23+0200\n"
+"PO-Revision-Date: 2022-07-03 20:43+0200\n"
+"Last-Translator: Andriy Byelikov\n"
+"Language-Team: <wx-translators@wxwidgets.org>\n"
+"Language: ca\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
+"X-Generator: Poedit 3.0.1\n"
+
+#: ../include/wx/defs.h:2582
+msgid "All files (*.*)|*.*"
+msgstr "Tots els fitxers (*.*)|*.*"
+
+#: ../include/wx/defs.h:2585
+msgid "All files (*)|*"
+msgstr "Tots els fitxers (*)|*"
+
+#: ../include/wx/generic/progdlgg.h:85
+msgid "Elapsed time:"
+msgstr "Temps transcorregut:"
+
+#: ../include/wx/generic/progdlgg.h:86
+msgid "Estimated time:"
+msgstr "Temps estimat:"
+
+#: ../include/wx/generic/progdlgg.h:87
+msgid "Remaining time:"
+msgstr "Temps restant:"
+
+#. TRANSLATORS: HTML printout default title.
+#: ../include/wx/html/htmprint.h:121 ../include/wx/prntbase.h:273
+#: ../include/wx/richtext/richtextprint.h:109 ../src/common/docview.cpp:2161
+msgid "Printout"
+msgstr "Impressió"
+
+#. TRANSLATORS: HTML easy print default title.
+#: ../include/wx/html/htmprint.h:234 ../include/wx/richtext/richtextprint.h:163
+#: ../src/common/prntbase.cpp:522 ../src/html/htmprint.cpp:291
+msgid "Printing"
+msgstr "S'està imprimint"
+
+#: ../include/wx/msgdlg.h:277 ../src/common/stockitem.cpp:211
+msgid "Yes"
+msgstr "Sí"
+
+#: ../include/wx/msgdlg.h:278 ../src/common/stockitem.cpp:182
+msgid "No"
+msgstr "No"
+
+#: ../include/wx/msgdlg.h:279 ../src/common/stockitem.cpp:183
+#: ../src/msw/msgdlg.cpp:430 ../src/msw/msgdlg.cpp:734
+#: ../src/richtext/richtextstyledlg.cpp:292
+msgid "OK"
+msgstr "D'acord"
+
+#: ../include/wx/msgdlg.h:280 ../src/common/stockitem.cpp:150
+#: ../src/msw/msgdlg.cpp:430 ../src/msw/progdlg.cpp:884
+#: ../src/richtext/richtextstyledlg.cpp:295
+msgid "Cancel"
+msgstr "Cancel·la"
+
+#: ../include/wx/msgdlg.h:281 ../src/common/stockitem.cpp:168
+#: ../src/html/helpdlg.cpp:63 ../src/html/helpfrm.cpp:108
+#: ../src/osx/button_osx.cpp:38
+msgid "Help"
+msgstr "Ajuda"
+
+#: ../include/wx/msw/ole/oleutils.h:52
+msgid "Cannot initialize OLE"
+msgstr "No es pot inicialitzar OLE"
+
+#: ../include/wx/msw/private/fswatcher.h:48
+#, c-format
+msgid "Unable to close the handle for '%s'"
+msgstr "No s'ha pogut tancar el manegador de '%s'"
+
+#: ../include/wx/msw/private/fswatcher.h:92
+#, c-format
+msgid "Failed to open directory \"%s\" for monitoring."
+msgstr "No s'ha pogut obrir el directori \"%s\" per a supervisar-lo."
+
+#: ../include/wx/msw/private/fswatcher.h:125
+msgid "Unable to close I/O completion port handle"
+msgstr "No s'ha pogut tancar el manegador del port de compleció d'E/S"
+
+#: ../include/wx/msw/private/fswatcher.h:142
+msgid "Unable to associate handle with I/O completion port"
+msgstr "No s'ha pogut associar el manegador amb el port de compleció d'E/S"
+
+#: ../include/wx/msw/private/fswatcher.h:148
+msgid "Unexpectedly new I/O completion port was created"
+msgstr "S'ha creat un port de compleció d'E/S inesperadament nou"
+
+#: ../include/wx/msw/private/fswatcher.h:213
+msgid "Unable to post completion status"
+msgstr "No s'ha pogut publicar l'estat de compleció"
+
+#: ../include/wx/msw/private/fswatcher.h:262
+msgid "Unable to dequeue completion packet"
+msgstr "No s'ha pogut treure de la cua el paquet de compleció"
+
+#: ../include/wx/msw/private/fswatcher.h:273
+msgid "Unable to create I/O completion port"
+msgstr "No s'ha pogut crear el port de compleció d'E/S"
+
+#: ../include/wx/richmsgdlg.h:29
+msgid "&See details"
+msgstr "Mo&stra els detalls"
+
+#: ../include/wx/richmsgdlg.h:30
+msgid "&Hide details"
+msgstr "&Amaga els detalls"
+
+#: ../include/wx/richtext/richtextbuffer.h:3864
+msgid "&Box"
+msgstr "&Caixa"
+
+#: ../include/wx/richtext/richtextbuffer.h:5008
+msgid "&Picture"
+msgstr "&Imatge"
+
+#: ../include/wx/richtext/richtextbuffer.h:5958
+msgid "&Cell"
+msgstr "&Cel·la"
+
+#: ../include/wx/richtext/richtextbuffer.h:6067
+msgid "&Table"
+msgstr "&Taula"
+
+#: ../include/wx/richtext/richtextimagedlg.h:37
+msgid "Object Properties"
+msgstr "Propietats de l'objecte"
+
+#: ../include/wx/richtext/richtextsymboldlg.h:39
+msgid "Symbols"
+msgstr "Símbols"
+
+#: ../include/wx/unix/pipe.h:46
+msgid "Pipe creation failed"
+msgstr "No s'ha pogut crear la canonada"
+
+#: ../include/wx/unix/private/displayx11.h:65
+msgid "Failed to enumerate video modes"
+msgstr "No s'han pogut enumerar els modes de vídeo"
+
+#: ../include/wx/unix/private/displayx11.h:89
+msgid "Failed to change video mode"
+msgstr "No s'ha pogut canviar el mode de vídeo"
+
+#: ../include/wx/unix/private/fswatcher_kqueue.h:57
+#, c-format
+msgid "Unable to open path '%s'"
+msgstr "No s'ha pogut obrir el camí '%s'"
+
+#: ../include/wx/unix/private/fswatcher_kqueue.h:74
+#, c-format
+msgid "Unable to close path '%s'"
+msgstr "No s'ha pogut tancar el camí '%s'"
+
+#: ../include/wx/xtiprop.h:175
+msgid "SetProperty called w/o valid setter"
+msgstr "S'ha cridat SetProperty sense un setter vàlid"
+
+#: ../include/wx/xtiprop.h:184
+msgid "GetProperty called w/o valid getter"
+msgstr "S'ha cridat GetProperty sense un getter vàlid"
+
+#: ../include/wx/xtiprop.h:193
+msgid "AddToPropertyCollection called w/o valid adder"
+msgstr "S'ha cridat AddToPropertyCollection sense un afegidor vàlid"
+
+#: ../include/wx/xtiprop.h:202
+msgid "GetPropertyCollection called w/o valid collection getter"
+msgstr "S'ha cridat GetPropertyCollection sense un getter de col·lecció vàlid"
+
+#: ../include/wx/xtiprop.h:255
+msgid "AddToPropertyCollection called on a generic accessor"
+msgstr "S'ha cridat AddToPropertyCollection en un mètode d'accés genèric"
+
+#: ../include/wx/xtiprop.h:262
+msgid "GetPropertyCollection called on a generic accessor"
+msgstr "S'ha cridat GetPropertyCollection en un mètode d'accés genèric"
+
+#: ../src/aui/tabmdi.cpp:106 ../src/generic/mdig.cpp:94
+msgid "Cl&ose"
+msgstr "&Tanca"
+
+#: ../src/aui/tabmdi.cpp:107 ../src/generic/mdig.cpp:95
+msgid "Close All"
+msgstr "Tanca-ho tot"
+
+#: ../src/aui/tabmdi.cpp:109 ../src/generic/mdig.cpp:97 ../src/msw/mdi.cpp:175
+#: ../src/qt/mdi.cpp:258
+msgid "&Next"
+msgstr "&Següent"
+
+#: ../src/aui/tabmdi.cpp:110 ../src/generic/mdig.cpp:98 ../src/msw/mdi.cpp:176
+#: ../src/qt/mdi.cpp:259
+msgid "&Previous"
+msgstr "&Anterior"
+
+#: ../src/aui/tabmdi.cpp:332 ../src/aui/tabmdi.cpp:348
+#: ../src/aui/tabmdi.cpp:350 ../src/generic/mdig.cpp:291
+#: ../src/generic/mdig.cpp:307 ../src/generic/mdig.cpp:311
+#: ../src/msw/mdi.cpp:337 ../src/qt/mdi.cpp:462
+msgid "&Window"
+msgstr "&Finestra"
+
+#: ../src/common/accelcmn.cpp:47
+msgctxt "keyboard key"
+msgid "Delete"
+msgstr "Suprimeix"
+
+#: ../src/common/accelcmn.cpp:48
+msgctxt "keyboard key"
+msgid "Del"
+msgstr "Supr"
+
+#: ../src/common/accelcmn.cpp:49
+msgctxt "keyboard key"
+msgid "Back"
+msgstr "Endarrere"
+
+#: ../src/common/accelcmn.cpp:49
+msgctxt "keyboard key"
+msgid "Backspace"
+msgstr "Retrocés"
+
+#: ../src/common/accelcmn.cpp:50
+msgctxt "keyboard key"
+msgid "Insert"
+msgstr "Insereix"
+
+#: ../src/common/accelcmn.cpp:51
+msgctxt "keyboard key"
+msgid "Ins"
+msgstr "Inser"
+
+#: ../src/common/accelcmn.cpp:52
+msgctxt "keyboard key"
+msgid "Enter"
+msgstr "Retorn"
+
+#: ../src/common/accelcmn.cpp:53
+msgctxt "keyboard key"
+msgid "Return"
+msgstr "Retorn"
+
+#: ../src/common/accelcmn.cpp:54
+msgctxt "keyboard key"
+msgid "PageUp"
+msgstr "Re Pàg"
+
+#: ../src/common/accelcmn.cpp:54
+msgctxt "keyboard key"
+msgid "Page Up"
+msgstr "Re Pàg"
+
+#: ../src/common/accelcmn.cpp:55
+msgctxt "keyboard key"
+msgid "PageDown"
+msgstr "Av Pàg"
+
+#: ../src/common/accelcmn.cpp:55
+msgctxt "keyboard key"
+msgid "Page Down"
+msgstr "Av Pàg"
+
+#: ../src/common/accelcmn.cpp:56
+msgctxt "keyboard key"
+msgid "PgUp"
+msgstr "RePàg"
+
+#: ../src/common/accelcmn.cpp:57
+msgctxt "keyboard key"
+msgid "PgDn"
+msgstr "AvPàg"
+
+#: ../src/common/accelcmn.cpp:58
+msgctxt "keyboard key"
+msgid "Left"
+msgstr "Esquerra"
+
+#: ../src/common/accelcmn.cpp:59
+msgctxt "keyboard key"
+msgid "Right"
+msgstr "Dreta"
+
+#: ../src/common/accelcmn.cpp:60
+msgctxt "keyboard key"
+msgid "Up"
+msgstr "Amunt"
+
+#: ../src/common/accelcmn.cpp:61
+msgctxt "keyboard key"
+msgid "Down"
+msgstr "Avall"
+
+#: ../src/common/accelcmn.cpp:62
+msgctxt "keyboard key"
+msgid "Home"
+msgstr "Inici"
+
+#: ../src/common/accelcmn.cpp:63
+msgctxt "keyboard key"
+msgid "End"
+msgstr "Fi"
+
+#: ../src/common/accelcmn.cpp:64
+msgctxt "keyboard key"
+msgid "Space"
+msgstr "Espai"
+
+#: ../src/common/accelcmn.cpp:65
+msgctxt "keyboard key"
+msgid "Tab"
+msgstr "Tab"
+
+#: ../src/common/accelcmn.cpp:66
+msgctxt "keyboard key"
+msgid "Esc"
+msgstr "Esc"
+
+#: ../src/common/accelcmn.cpp:67
+msgctxt "keyboard key"
+msgid "Escape"
+msgstr "Escapada"
+
+#: ../src/common/accelcmn.cpp:68
+msgctxt "keyboard key"
+msgid "Cancel"
+msgstr "Cancel·la"
+
+#: ../src/common/accelcmn.cpp:69
+msgctxt "keyboard key"
+msgid "Clear"
+msgstr "Neteja"
+
+#: ../src/common/accelcmn.cpp:70
+msgctxt "keyboard key"
+msgid "Menu"
+msgstr "Menú"
+
+#: ../src/common/accelcmn.cpp:71
+msgctxt "keyboard key"
+msgid "Pause"
+msgstr "Pausa"
+
+#: ../src/common/accelcmn.cpp:72
+msgctxt "keyboard key"
+msgid "Capital"
+msgstr "Majúscules"
+
+#: ../src/common/accelcmn.cpp:73
+msgctxt "keyboard key"
+msgid "Select"
+msgstr "Selecciona"
+
+#: ../src/common/accelcmn.cpp:74
+msgctxt "keyboard key"
+msgid "Print"
+msgstr "Imprimeix"
+
+#: ../src/common/accelcmn.cpp:75
+msgctxt "keyboard key"
+msgid "Execute"
+msgstr "Executa"
+
+#: ../src/common/accelcmn.cpp:76
+msgctxt "keyboard key"
+msgid "Snapshot"
+msgstr "Impr Pant"
+
+#: ../src/common/accelcmn.cpp:77
+msgctxt "keyboard key"
+msgid "Help"
+msgstr "Ajuda"
+
+#: ../src/common/accelcmn.cpp:78
+msgctxt "keyboard key"
+msgid "Add"
+msgstr "Suma"
+
+#: ../src/common/accelcmn.cpp:79
+msgctxt "keyboard key"
+msgid "Separator"
+msgstr "Separador"
+
+#: ../src/common/accelcmn.cpp:80
+msgctxt "keyboard key"
+msgid "Subtract"
+msgstr "Resta"
+
+#: ../src/common/accelcmn.cpp:81
+msgctxt "keyboard key"
+msgid "Decimal"
+msgstr "Decimal"
+
+#: ../src/common/accelcmn.cpp:82
+msgctxt "keyboard key"
+msgid "Multiply"
+msgstr "Multiplicació"
+
+#: ../src/common/accelcmn.cpp:83
+msgctxt "keyboard key"
+msgid "Divide"
+msgstr "Divisió"
+
+#: ../src/common/accelcmn.cpp:84
+msgctxt "keyboard key"
+msgid "Num_lock"
+msgstr "Bloq Núm"
+
+#: ../src/common/accelcmn.cpp:84
+msgctxt "keyboard key"
+msgid "Num Lock"
+msgstr "Bloq Núm"
+
+#: ../src/common/accelcmn.cpp:85
+msgctxt "keyboard key"
+msgid "Scroll_lock"
+msgstr "Bloq Despl"
+
+#: ../src/common/accelcmn.cpp:85
+msgctxt "keyboard key"
+msgid "Scroll Lock"
+msgstr "Bloq Despl"
+
+#: ../src/common/accelcmn.cpp:86
+msgctxt "keyboard key"
+msgid "KP_Space"
+msgstr "Espai (teclat numèric)"
+
+#: ../src/common/accelcmn.cpp:86
+msgctxt "keyboard key"
+msgid "Num Space"
+msgstr "Espai (teclat numèric)"
+
+#: ../src/common/accelcmn.cpp:87
+msgctxt "keyboard key"
+msgid "KP_Tab"
+msgstr "Tab (teclat numèric)"
+
+#: ../src/common/accelcmn.cpp:87
+msgctxt "keyboard key"
+msgid "Num Tab"
+msgstr "Tab (teclat numèric)"
+
+#: ../src/common/accelcmn.cpp:88
+msgctxt "keyboard key"
+msgid "KP_Enter"
+msgstr "Retorn (teclat numèric)"
+
+#: ../src/common/accelcmn.cpp:88
+msgctxt "keyboard key"
+msgid "Num Enter"
+msgstr "Retorn (teclat numèric)"
+
+#: ../src/common/accelcmn.cpp:89
+msgctxt "keyboard key"
+msgid "KP_Home"
+msgstr "Inici (teclat numèric)"
+
+#: ../src/common/accelcmn.cpp:89
+msgctxt "keyboard key"
+msgid "Num Home"
+msgstr "Inici (teclat numèric)"
+
+#: ../src/common/accelcmn.cpp:90
+msgctxt "keyboard key"
+msgid "KP_Left"
+msgstr "Esquerra (teclat numèric)"
+
+#: ../src/common/accelcmn.cpp:90
+msgctxt "keyboard key"
+msgid "Num left"
+msgstr "Esquerra (teclat numèric)"
+
+#: ../src/common/accelcmn.cpp:91
+msgctxt "keyboard key"
+msgid "KP_Up"
+msgstr "Amunt (teclat numèric)"
+
+#: ../src/common/accelcmn.cpp:91
+msgctxt "keyboard key"
+msgid "Num Up"
+msgstr "Amunt (teclat numèric)"
+
+#: ../src/common/accelcmn.cpp:92
+msgctxt "keyboard key"
+msgid "KP_Right"
+msgstr "Dreta (teclat numèric)"
+
+#: ../src/common/accelcmn.cpp:92
+msgctxt "keyboard key"
+msgid "Num Right"
+msgstr "Dreta (teclat numèric)"
+
+#: ../src/common/accelcmn.cpp:93
+msgctxt "keyboard key"
+msgid "KP_Down"
+msgstr "Avall (teclat numèric)"
+
+#: ../src/common/accelcmn.cpp:93
+msgctxt "keyboard key"
+msgid "Num Down"
+msgstr "Avall (teclat numèric)"
+
+#: ../src/common/accelcmn.cpp:94
+msgctxt "keyboard key"
+msgid "KP_PageUp"
+msgstr "Re Pàg (teclat numèric)"
+
+#: ../src/common/accelcmn.cpp:94
+msgctxt "keyboard key"
+msgid "Num Page Up"
+msgstr "Re Pàg (teclat numèric)"
+
+#: ../src/common/accelcmn.cpp:95
+msgctxt "keyboard key"
+msgid "KP_PageDown"
+msgstr "Av Pàg (teclat numèric)"
+
+#: ../src/common/accelcmn.cpp:95
+msgctxt "keyboard key"
+msgid "Num Page Down"
+msgstr "Av Pàg (teclat numèric)"
+
+#: ../src/common/accelcmn.cpp:96
+msgctxt "keyboard key"
+msgid "KP_Prior"
+msgstr "Anterior (teclat numèric)"
+
+#: ../src/common/accelcmn.cpp:97
+msgctxt "keyboard key"
+msgid "KP_Next"
+msgstr "Següent (teclat numèric)"
+
+#: ../src/common/accelcmn.cpp:98
+msgctxt "keyboard key"
+msgid "KP_End"
+msgstr "Fi (teclat numèric)"
+
+#: ../src/common/accelcmn.cpp:98
+msgctxt "keyboard key"
+msgid "Num End"
+msgstr "Fi (teclat numèric)"
+
+#: ../src/common/accelcmn.cpp:99
+msgctxt "keyboard key"
+msgid "KP_Begin"
+msgstr "Inici (teclat numèric)"
+
+#: ../src/common/accelcmn.cpp:99
+msgctxt "keyboard key"
+msgid "Num Begin"
+msgstr "Inici (teclat numèric)"
+
+#: ../src/common/accelcmn.cpp:100
+msgctxt "keyboard key"
+msgid "KP_Insert"
+msgstr "Insereix (teclat numèric)"
+
+#: ../src/common/accelcmn.cpp:100
+msgctxt "keyboard key"
+msgid "Num Insert"
+msgstr "Insereix (teclat numèric)"
+
+#: ../src/common/accelcmn.cpp:101
+msgctxt "keyboard key"
+msgid "KP_Delete"
+msgstr "Suprimeix (teclat numèric)"
+
+#: ../src/common/accelcmn.cpp:101
+msgctxt "keyboard key"
+msgid "Num Delete"
+msgstr "Suprimeix (teclat numèric)"
+
+#: ../src/common/accelcmn.cpp:102
+msgctxt "keyboard key"
+msgid "KP_Equal"
+msgstr "Igual (teclat numèric)"
+
+#: ../src/common/accelcmn.cpp:102
+msgctxt "keyboard key"
+msgid "Num ="
+msgstr "= (teclat numèric)"
+
+#: ../src/common/accelcmn.cpp:103
+msgctxt "keyboard key"
+msgid "KP_Multiply"
+msgstr "Multiplicació (teclat numèric)"
+
+#: ../src/common/accelcmn.cpp:103
+msgctxt "keyboard key"
+msgid "Num *"
+msgstr "* (teclat numèric)"
+
+#: ../src/common/accelcmn.cpp:104
+msgctxt "keyboard key"
+msgid "KP_Add"
+msgstr "Suma (teclat numèric)"
+
+#: ../src/common/accelcmn.cpp:104
+msgctxt "keyboard key"
+msgid "Num +"
+msgstr "+ (teclat numèric)"
+
+#: ../src/common/accelcmn.cpp:105
+msgctxt "keyboard key"
+msgid "KP_Separator"
+msgstr "Separador (teclat numèric)"
+
+#: ../src/common/accelcmn.cpp:105
+msgctxt "keyboard key"
+msgid "Num ,"
+msgstr ", (teclat numèric)"
+
+#: ../src/common/accelcmn.cpp:106
+msgctxt "keyboard key"
+msgid "KP_Subtract"
+msgstr "Resta (teclat numèric)"
+
+#: ../src/common/accelcmn.cpp:106
+msgctxt "keyboard key"
+msgid "Num -"
+msgstr "- (teclat numèric)"
+
+#: ../src/common/accelcmn.cpp:107
+msgctxt "keyboard key"
+msgid "KP_Decimal"
+msgstr "Decimal (teclat numèric)"
+
+#: ../src/common/accelcmn.cpp:107
+msgctxt "keyboard key"
+msgid "Num ."
+msgstr ". (teclat numèric)"
+
+#: ../src/common/accelcmn.cpp:108
+msgctxt "keyboard key"
+msgid "KP_Divide"
+msgstr "Divisió (teclat numèric)"
+
+#: ../src/common/accelcmn.cpp:108
+msgctxt "keyboard key"
+msgid "Num /"
+msgstr "/ (teclat numèric)"
+
+#: ../src/common/accelcmn.cpp:109
+msgctxt "keyboard key"
+msgid "Windows_Left"
+msgstr "Windows (esquerra)"
+
+#: ../src/common/accelcmn.cpp:110
+msgctxt "keyboard key"
+msgid "Windows_Right"
+msgstr "Windows (dreta)"
+
+#: ../src/common/accelcmn.cpp:111
+msgctxt "keyboard key"
+msgid "Windows_Menu"
+msgstr "Windows (menú)"
+
+#: ../src/common/accelcmn.cpp:112
+msgctxt "keyboard key"
+msgid "Command"
+msgstr "Ordre"
+
+#: ../src/common/accelcmn.cpp:186 ../src/common/accelcmn.cpp:359
+msgctxt "keyboard key"
+msgid "Ctrl"
+msgstr "Ctrl"
+
+#: ../src/common/accelcmn.cpp:188 ../src/common/accelcmn.cpp:363
+msgctxt "keyboard key"
+msgid "Alt"
+msgstr "Alt"
+
+#: ../src/common/accelcmn.cpp:190 ../src/common/accelcmn.cpp:361
+msgctxt "keyboard key"
+msgid "Shift"
+msgstr "Maj"
+
+#: ../src/common/accelcmn.cpp:196
+msgctxt "keyboard key"
+msgid "num "
+msgstr "núm "
+
+#: ../src/common/accelcmn.cpp:260 ../src/common/accelcmn.cpp:382
+msgctxt "keyboard key"
+msgid "F"
+msgstr "F"
+
+#: ../src/common/accelcmn.cpp:277 ../src/common/accelcmn.cpp:385
+msgctxt "keyboard key"
+msgid "KP_F"
+msgstr "KP_F"
+
+#: ../src/common/accelcmn.cpp:280 ../src/common/accelcmn.cpp:388
+msgctxt "keyboard key"
+msgid "KP_"
+msgstr "KP_"
+
+#: ../src/common/accelcmn.cpp:283 ../src/common/accelcmn.cpp:391
+msgctxt "keyboard key"
+msgid "SPECIAL"
+msgstr "ESPECIAL"
+
+#: ../src/common/accelcmn.cpp:373
+#, fuzzy
+msgid "Ctrl"
+msgstr "Ctrl"
+
+#: ../src/common/appbase.cpp:786
+msgid "show this help message"
+msgstr "mostra aquest missatge d'ajuda"
+
+#: ../src/common/appbase.cpp:796
+msgid "generate verbose log messages"
+msgstr "genera missatges de registre detallats"
+
+#: ../src/common/appcmn.cpp:256
+msgid "specify the theme to use"
+msgstr "especifiqueu el tema a utilitzar"
+
+#: ../src/common/appcmn.cpp:270
+msgid "specify display mode to use (e.g. 640x480-16)"
+msgstr "especifiqueu el mode de pantalla a utilitzar (p. ex. 640x480-16)"
+
+#: ../src/common/appcmn.cpp:292
+#, c-format
+msgid "Unsupported theme '%s'."
+msgstr "Tema no suportat '%s'."
+
+#: ../src/common/appcmn.cpp:309
+#, c-format
+msgid "Invalid display mode specification '%s'."
+msgstr "Especificació de mode de pantalla invàlida '%s'."
+
+#: ../src/common/cmdline.cpp:875
+#, c-format
+msgid "Option '%s' can't be negated"
+msgstr "L'opció '%s' no es pot negar"
+
+#: ../src/common/cmdline.cpp:889
+#, c-format
+msgid "Unknown long option '%s'"
+msgstr "Opció llarga desconeguda '%s'"
+
+#: ../src/common/cmdline.cpp:904 ../src/common/cmdline.cpp:926
+#, c-format
+msgid "Unknown option '%s'"
+msgstr "Opció desconeguda '%s'"
+
+#: ../src/common/cmdline.cpp:1004
+#, c-format
+msgid "Unexpected characters following option '%s'."
+msgstr "Hi ha caràcters inesperats després de l'opció '%s'."
+
+#: ../src/common/cmdline.cpp:1039
+#, c-format
+msgid "Option '%s' requires a value."
+msgstr "L'opció '%s' requereix un valor."
+
+#: ../src/common/cmdline.cpp:1058
+#, c-format
+msgid "Separator expected after the option '%s'."
+msgstr "S'esperava un separador després de l'opció '%s'."
+
+#: ../src/common/cmdline.cpp:1088 ../src/common/cmdline.cpp:1106
+#, c-format
+msgid "'%s' is not a correct numeric value for option '%s'."
+msgstr "'%s' no és valor numèric correcte per a l'opció '%s'."
+
+#: ../src/common/cmdline.cpp:1122
+#, c-format
+msgid "Option '%s': '%s' cannot be converted to a date."
+msgstr "Opció '%s': '%s' no es pot convertir a data."
+
+#: ../src/common/cmdline.cpp:1170
+#, c-format
+msgid "Unexpected parameter '%s'"
+msgstr "Paràmetre inesperat '%s'"
+
+#. TRANSLATORS: Short name and long name for a command line option
+#: ../src/common/cmdline.cpp:1197
+#, c-format
+msgid "%s (or %s)"
+msgstr "%s (o %s)"
+
+#: ../src/common/cmdline.cpp:1208
+#, c-format
+msgid "The value for the option '%s' must be specified."
+msgstr "Cal especificar el valor de l'opció '%s'."
+
+#: ../src/common/cmdline.cpp:1230
+#, c-format
+msgid "The required parameter '%s' was not specified."
+msgstr "No s'ha especificat el paràmetre necessari '%s'."
+
+#: ../src/common/cmdline.cpp:1289
+#, c-format
+msgid "Usage: %s"
+msgstr "Ús: %s"
+
+#: ../src/common/cmdline.cpp:1498
+msgid "str"
+msgstr "str"
+
+#: ../src/common/cmdline.cpp:1502
+msgid "num"
+msgstr "núm"
+
+#: ../src/common/cmdline.cpp:1506
+msgid "double"
+msgstr "doble"
+
+#: ../src/common/cmdline.cpp:1510
+msgid "date"
+msgstr "data"
+
+#: ../src/common/cmdproc.cpp:250 ../src/common/cmdproc.cpp:276
+#: ../src/common/cmdproc.cpp:296
+msgid "Unnamed command"
+msgstr "Ordre sense nom"
+
+#: ../src/common/cmdproc.cpp:253
+msgid "&Undo "
+msgstr "&Desfés "
+
+#: ../src/common/cmdproc.cpp:255
+msgid "Can't &Undo "
+msgstr "No es pot &desfer "
+
+#: ../src/common/cmdproc.cpp:259 ../src/common/stockitem.cpp:208
+#: ../src/msw/textctrl.cpp:2880 ../src/osx/textctrl_osx.cpp:649
+#: ../src/richtext/richtextctrl.cpp:327
+msgid "&Undo"
+msgstr "&Desfés"
+
+#: ../src/common/cmdproc.cpp:277 ../src/common/cmdproc.cpp:297
+msgid "&Redo "
+msgstr "&Refés "
+
+#: ../src/common/cmdproc.cpp:281 ../src/common/cmdproc.cpp:288
+#: ../src/common/stockitem.cpp:190 ../src/msw/textctrl.cpp:2881
+#: ../src/osx/textctrl_osx.cpp:650 ../src/richtext/richtextctrl.cpp:328
+msgid "&Redo"
+msgstr "&Refés"
+
+#: ../src/common/colourcmn.cpp:41
+#, c-format
+msgid "String To Colour : Incorrect colour specification : %s"
+msgstr "Cadena a color: Especificació del color incorrecta: %s"
+
+#: ../src/common/config.cpp:259
+#, c-format
+msgid "Invalid value %ld for a boolean key \"%s\" in config file."
+msgstr ""
+"Valor invàlid %ld per a la clau booleana \"%s\" al fitxer de configuració."
+
+#: ../src/common/config.cpp:526
+#, c-format
+msgid ""
+"Environment variables expansion failed: missing '%c' at position %u in '%s'."
+msgstr ""
+"No s'han pogut expandir les variables d'entorn: manca '%c' a la posició %u a "
+"'%s'."
+
+#: ../src/common/config.cpp:576 ../src/msw/regconf.cpp:272
+#, c-format
+msgid "'%s' has extra '..', ignored."
+msgstr "'%s' té '..' extra, s'ha ignorat."
+
+#. TRANSLATORS: Checkbox state name
+#: ../src/common/datavcmn.cpp:2166 ../src/generic/datavgen.cpp:1430
+msgid "checked"
+msgstr "marcat"
+
+#. TRANSLATORS: Checkbox state name
+#: ../src/common/datavcmn.cpp:2170 ../src/generic/datavgen.cpp:1432
+msgid "unchecked"
+msgstr "no marcat"
+
+#. TRANSLATORS: Checkbox state name
+#: ../src/common/datavcmn.cpp:2174
+msgid "undetermined"
+msgstr "indeterminat"
+
+#: ../src/common/datetimefmt.cpp:1875
+msgid "today"
+msgstr "avui"
+
+#: ../src/common/datetimefmt.cpp:1876
+msgid "yesterday"
+msgstr "ahir"
+
+#: ../src/common/datetimefmt.cpp:1877
+msgid "tomorrow"
+msgstr "demà"
+
+#: ../src/common/datetimefmt.cpp:2071
+msgid "first"
+msgstr "primer"
+
+#: ../src/common/datetimefmt.cpp:2072
+msgid "second"
+msgstr "segon"
+
+#: ../src/common/datetimefmt.cpp:2073
+msgid "third"
+msgstr "tercer"
+
+#: ../src/common/datetimefmt.cpp:2074
+msgid "fourth"
+msgstr "quart"
+
+#: ../src/common/datetimefmt.cpp:2075
+msgid "fifth"
+msgstr "cinquè"
+
+#: ../src/common/datetimefmt.cpp:2076
+msgid "sixth"
+msgstr "sisè"
+
+#: ../src/common/datetimefmt.cpp:2077
+msgid "seventh"
+msgstr "setè"
+
+#: ../src/common/datetimefmt.cpp:2078
+msgid "eighth"
+msgstr "vuitè"
+
+#: ../src/common/datetimefmt.cpp:2079
+msgid "ninth"
+msgstr "novè"
+
+#: ../src/common/datetimefmt.cpp:2080
+msgid "tenth"
+msgstr "desè"
+
+#: ../src/common/datetimefmt.cpp:2081
+msgid "eleventh"
+msgstr "onzè"
+
+#: ../src/common/datetimefmt.cpp:2082
+msgid "twelfth"
+msgstr "dotzè"
+
+#: ../src/common/datetimefmt.cpp:2083
+msgid "thirteenth"
+msgstr "tretzè"
+
+#: ../src/common/datetimefmt.cpp:2084
+msgid "fourteenth"
+msgstr "catorzè"
+
+#: ../src/common/datetimefmt.cpp:2085
+msgid "fifteenth"
+msgstr "quinzè"
+
+#: ../src/common/datetimefmt.cpp:2086
+msgid "sixteenth"
+msgstr "setzè"
+
+#: ../src/common/datetimefmt.cpp:2087
+msgid "seventeenth"
+msgstr "dissetè"
+
+#: ../src/common/datetimefmt.cpp:2088
+msgid "eighteenth"
+msgstr "divuitè"
+
+#: ../src/common/datetimefmt.cpp:2089
+msgid "nineteenth"
+msgstr "dinovè"
+
+#: ../src/common/datetimefmt.cpp:2090
+msgid "twentieth"
+msgstr "vintè"
+
+#: ../src/common/datetimefmt.cpp:2248
+msgid "noon"
+msgstr "migdia"
+
+#: ../src/common/datetimefmt.cpp:2249
+msgid "midnight"
+msgstr "mitjanit"
+
+#: ../src/common/debugrpt.cpp:209
+#, c-format
+msgid "Failed to create directory \"%s\""
+msgstr "No s'ha pogut crear el directori \"%s\""
+
+#: ../src/common/debugrpt.cpp:210
+msgid "Debug report couldn't be created."
+msgstr "No s'ha pogut crear l'informe de depuració."
+
+#: ../src/common/debugrpt.cpp:227
+#, c-format
+msgid "Failed to remove debug report file \"%s\""
+msgstr "No s'ha pogut suprimir el fitxer d'informe de depuració \"%s\""
+
+#: ../src/common/debugrpt.cpp:239
+#, c-format
+msgid "Failed to clean up debug report directory \"%s\""
+msgstr "No s'ha pogut netejar el directori d'informes de depuració \"%s\""
+
+#: ../src/common/debugrpt.cpp:514
+msgid "process context description"
+msgstr "descripció del context del procés"
+
+#: ../src/common/debugrpt.cpp:538
+msgid "dump of the process state (binary)"
+msgstr "bolcat de l'estat del procés (binari)"
+
+#: ../src/common/debugrpt.cpp:553
+msgid "Debug report generation has failed."
+msgstr "No s'ha pogut generar l'informe de depuració."
+
+#: ../src/common/debugrpt.cpp:560
+#, c-format
+msgid ""
+"Processing debug report has failed, leaving the files in \"%s\" directory."
+msgstr ""
+"No s'ha pogut processar l'informe de depuració, es deixaran els fitxers al "
+"directori \"%s\"."
+
+#: ../src/common/debugrpt.cpp:573
+msgid "A debug report has been generated. It can be found in"
+msgstr "S'ha generat un informe de depuració. Podeu trobar-lo a"
+
+#: ../src/common/debugrpt.cpp:576
+msgid "And includes the following files:\n"
+msgstr "I inclou els següents fitxers:\n"
+
+#: ../src/common/debugrpt.cpp:586
+msgid ""
+"\n"
+"Please send this report to the program maintainer, thank you!\n"
+msgstr ""
+"\n"
+"Envieu aquest informe al mantenidor del programa. Gràcies!\n"
+
+#: ../src/common/debugrpt.cpp:729
+msgid "Failed to execute curl, please install it in PATH."
+msgstr "No s'ha pogut executar curl, instal·leu-lo al PATH."
+
+#: ../src/common/debugrpt.cpp:742
+#, c-format
+msgid "Failed to upload the debug report (error code %d)."
+msgstr "No s'ha pogut pujar l'informe de depuració (codi d'error %d)."
+
+#: ../src/common/docview.cpp:366
+msgid "Save As"
+msgstr "Anomena i desa"
+
+#: ../src/common/docview.cpp:457
+msgid "Discard changes and reload the last saved version?"
+msgstr ""
+"Voleu descartar els canvis i tornar a carregar la darrera versió desada?"
+
+#: ../src/common/docview.cpp:488
+msgid "unnamed"
+msgstr "sense nom"
+
+#: ../src/common/docview.cpp:513
+#, c-format
+msgid "Do you want to save changes to %s?"
+msgstr "Voleu desar els canvis fets a %s?"
+
+#: ../src/common/docview.cpp:521 ../src/common/docview.cpp:560
+#: ../src/common/stockitem.cpp:195
+msgid "&Save"
+msgstr "De&sa"
+
+#: ../src/common/docview.cpp:522 ../src/common/docview.cpp:560
+msgid "&Discard changes"
+msgstr ""
+
+#: ../src/common/docview.cpp:523
+#, fuzzy
+msgid "Do&n't close"
+msgstr "No desis"
+
+#: ../src/common/docview.cpp:553
+#, fuzzy, c-format
+msgid "Do you want to save changes to %s before closing it?"
+msgstr "Voleu desar els canvis fets a %s?"
+
+#: ../src/common/docview.cpp:559
+#, fuzzy
+msgid "The document must be closed."
+msgstr "No s'ha pogut desar el text."
+
+#: ../src/common/docview.cpp:571
+#, c-format
+msgid "Saving %s failed, would you like to retry?"
+msgstr ""
+
+#: ../src/common/docview.cpp:577
+msgid "Retry"
+msgstr ""
+
+#: ../src/common/docview.cpp:577
+msgid "Discard changes"
+msgstr ""
+
+#: ../src/common/docview.cpp:679
+#, c-format
+msgid "File \"%s\" could not be opened for writing."
+msgstr "No s'ha pogut obrir el fitxer \"%s\" per a escriure-hi."
+
+#: ../src/common/docview.cpp:685
+#, c-format
+msgid "Failed to save document to the file \"%s\"."
+msgstr "No s'ha pogut desar el document al fitxer \"%s\"."
+
+#: ../src/common/docview.cpp:702
+#, c-format
+msgid "File \"%s\" could not be opened for reading."
+msgstr "No s'ha pogut obrir el fitxer \"%s\" per a llegir-lo."
+
+#: ../src/common/docview.cpp:714
+#, c-format
+msgid "Failed to read document from the file \"%s\"."
+msgstr "No s'ha pogut llegir el document del fitxer \"%s\"."
+
+#: ../src/common/docview.cpp:1236
+#, c-format
+msgid ""
+"The file '%s' doesn't exist and couldn't be opened.\n"
+"It has been removed from the most recently used files list."
+msgstr ""
+"El fitxer '%s' no existeix i no s'ha pogut obrir.\n"
+"S'ha suprimit de la llista de fitxers utilitzats més recentment."
+
+#: ../src/common/docview.cpp:1296
+msgid "Print preview creation failed."
+msgstr "No s'ha pogut crear la previsualització de la impressió."
+
+#: ../src/common/docview.cpp:1302
+msgid "Print Preview"
+msgstr "Previsualització de la impressió"
+
+#: ../src/common/docview.cpp:1517
+#, c-format
+msgid "The format of file '%s' couldn't be determined."
+msgstr "No s'ha pogut determinar el format del fitxer '%s'."
+
+#: ../src/common/docview.cpp:1643
+#, c-format
+msgid "unnamed%d"
+msgstr "sense nom %d"
+
+#: ../src/common/docview.cpp:1660
+msgid " - "
+msgstr " - "
+
+#: ../src/common/docview.cpp:1791 ../src/common/docview.cpp:1844
+msgid "Open File"
+msgstr "Obre un fitxer"
+
+#: ../src/common/docview.cpp:1807
+msgid "File error"
+msgstr "Error de fitxer"
+
+#: ../src/common/docview.cpp:1809
+msgid "Sorry, could not open this file."
+msgstr "No s'ha pogut obrir aquest fitxer."
+
+#: ../src/common/docview.cpp:1843
+msgid "Sorry, the format for this file is unknown."
+msgstr "El format d'aquest fitxer és desconegut."
+
+#: ../src/common/docview.cpp:1924
+msgid "Select a document template"
+msgstr "Seleccioneu una plantilla de document"
+
+#: ../src/common/docview.cpp:1925
+msgid "Templates"
+msgstr "Plantilles"
+
+#: ../src/common/docview.cpp:1998
+msgid "Select a document view"
+msgstr "Seleccioneu una visualització del document"
+
+#: ../src/common/docview.cpp:1999
+msgid "Views"
+msgstr "Visualitzacions"
+
+#: ../src/common/dynlib.cpp:81
+#, c-format
+msgid "Failed to load shared library '%s'"
+msgstr "No s'ha pogut carregar la biblioteca compartida '%s'"
+
+#: ../src/common/dynlib.cpp:105
+#, c-format
+msgid "Couldn't find symbol '%s' in a dynamic library"
+msgstr "No s'ha pogut trobar el símbol '%s' en una biblioteca dinàmica"
+
+#: ../src/common/ffile.cpp:56 ../src/common/file.cpp:215
+#, c-format
+msgid "can't open file '%s'"
+msgstr "no es pot obrir el fitxer '%s'"
+
+#: ../src/common/ffile.cpp:72
+#, c-format
+msgid "can't close file '%s'"
+msgstr "no es pot tancar el fitxer '%s'"
+
+#: ../src/common/ffile.cpp:106 ../src/common/ffile.cpp:131
+#, c-format
+msgid "Read error on file '%s'"
+msgstr "S'ha produït un error de lectura al fitxer '%s'"
+
+#: ../src/common/ffile.cpp:148
+#, c-format
+msgid "Write error on file '%s'"
+msgstr "S'ha produït un error en escriure al fitxer '%s'"
+
+#: ../src/common/ffile.cpp:182
+#, c-format
+msgid "failed to flush the file '%s'"
+msgstr "no s'ha pogut buidar el fitxer '%s'"
+
+#: ../src/common/ffile.cpp:222
+#, c-format
+msgid "Seek error on file '%s' (large files not supported by stdio)"
+msgstr ""
+"S'ha produït un error de cerca al fitxer '%s' (els fitxers grossos no estan "
+"suportats per stdio)"
+
+#: ../src/common/ffile.cpp:232
+#, c-format
+msgid "Seek error on file '%s'"
+msgstr "S'ha produït un error de cerca al fitxer '%s'"
+
+#: ../src/common/ffile.cpp:248
+#, c-format
+msgid "Can't find current position in file '%s'"
+msgstr "No es pot trobar la posició actual al fitxer '%s'"
+
+#: ../src/common/ffile.cpp:349 ../src/common/file.cpp:569
+msgid "Failed to set temporary file permissions"
+msgstr "No s'ha pogut definir els permisos del fitxer temporal"
+
+#: ../src/common/ffile.cpp:371
+#, c-format
+msgid "can't remove file '%s'"
+msgstr "no es pot suprimir el fitxer '%s'"
+
+#: ../src/common/ffile.cpp:376 ../src/common/file.cpp:591
+#, c-format
+msgid "can't commit changes to file '%s'"
+msgstr "no es poden publicar els canvis al fitxer '%s'"
+
+#: ../src/common/ffile.cpp:388 ../src/common/file.cpp:603
+#, c-format
+msgid "can't remove temporary file '%s'"
+msgstr "no es pot suprimir el fitxer temporal '%s'"
+
+#: ../src/common/file.cpp:162
+#, c-format
+msgid "can't create file '%s'"
+msgstr "no es pot crear el fitxer '%s'"
+
+#: ../src/common/file.cpp:229
+#, c-format
+msgid "can't close file descriptor %d"
+msgstr "no es pot tancar el descriptor de fitxer %d"
+
+#: ../src/common/file.cpp:332
+#, c-format
+msgid "can't read from file descriptor %d"
+msgstr "no es pot llegir del descriptor de fitxer %d"
+
+#: ../src/common/file.cpp:351
+#, c-format
+msgid "can't write to file descriptor %d"
+msgstr "no es pot escriure al descriptor de fitxer %d"
+
+#: ../src/common/file.cpp:390
+#, c-format
+msgid "can't flush file descriptor %d"
+msgstr "no es pot buidar el descriptor del fitxer %d"
+
+#: ../src/common/file.cpp:432
+#, c-format
+msgid "can't seek on file descriptor %d"
+msgstr "no es pot cercar el descriptor de fitxer %d"
+
+#: ../src/common/file.cpp:446
+#, c-format
+msgid "can't get seek position on file descriptor %d"
+msgstr "no es pot cercar la posició al descriptor de fitxer %d"
+
+#: ../src/common/file.cpp:475
+#, c-format
+msgid "can't find length of file on file descriptor %d"
+msgstr "no es pot trobar la llargada del fitxer al descriptor del fitxer %d"
+
+#: ../src/common/file.cpp:505
+#, c-format
+msgid "can't determine if the end of file is reached on descriptor %d"
+msgstr ""
+"no es pot determinar si s'ha arribat al final del fitxer al descriptor %d"
+
+#: ../src/common/fileconf.cpp:352
+#, c-format
+msgid ""
+" and additionally, the existing configuration file was renamed to \"%s\" and "
+"couldn't be renamed back, please rename it to its original path \"%s\""
+msgstr ""
+
+#: ../src/common/fileconf.cpp:389
+#, fuzzy
+msgid " due to the following error:\n"
+msgstr "I inclou els següents fitxers:\n"
+
+#: ../src/common/fileconf.cpp:412
+#, fuzzy
+msgid "failed to rename the existing file"
+msgstr "No s'ha pogut llegir el fitxer de text \"%s\"."
+
+#: ../src/common/fileconf.cpp:421
+#, fuzzy
+msgid "failed to create the new file directory"
+msgstr "No s'ha pogut obtenir el directori de treball"
+
+#: ../src/common/fileconf.cpp:428
+#, fuzzy
+msgid "failed to move the file to the new location"
+msgstr "No s'ha pogut establir web view a un nivell d'emulació modern"
+
+#: ../src/common/fileconf.cpp:462
+#, c-format
+msgid "can't open global configuration file '%s'."
+msgstr "no es pot obrir el fitxer de configuració global '%s'."
+
+#: ../src/common/fileconf.cpp:478
+#, c-format
+msgid "can't open user configuration file '%s'."
+msgstr "no es pot obrir el fitxer de configuració de l'usuari '%s'."
+
+#: ../src/common/fileconf.cpp:483
+#, c-format
+msgid "Changes won't be saved to avoid overwriting the existing file \"%s\""
+msgstr ""
+"Els canvis no es desaran per a evitar sobreescriure el fitxer existent \"%s\""
+
+#: ../src/common/fileconf.cpp:583
+msgid "Error reading config options."
+msgstr "S'ha produït un error en llegir les opcions de configuració."
+
+#: ../src/common/fileconf.cpp:593
+msgid "Failed to read config options."
+msgstr "No s'han pogut llegir les opcions de la configuració."
+
+#: ../src/common/fileconf.cpp:700
+#, c-format
+msgid "file '%s': unexpected character %c at line %zu."
+msgstr "fiitxer '%s': caràcter inesperat %c a la línia %zu."
+
+#: ../src/common/fileconf.cpp:736
+#, c-format
+msgid "file '%s', line %zu: '%s' ignored after group header."
+msgstr ""
+"fitxer '%s', línia %zu: s'ha ignorat '%s' després de la capçalera de grup."
+
+#: ../src/common/fileconf.cpp:765
+#, c-format
+msgid "file '%s', line %zu: '=' expected."
+msgstr "fitxer '%s', línia %zu: '=' inesperat."
+
+#: ../src/common/fileconf.cpp:778
+#, c-format
+msgid "file '%s', line %zu: value for immutable key '%s' ignored."
+msgstr ""
+"fitxer '%s', línia %zu: s'ha ignorat el valor per a clau immutable '%s'."
+
+#: ../src/common/fileconf.cpp:788
+#, c-format
+msgid "file '%s', line %zu: key '%s' was first found at line %d."
+msgstr ""
+"fitxer '%s', línia %zu: s'ha trobat la clau '%s' per primer cop a la línia "
+"%d."
+
+#: ../src/common/fileconf.cpp:1091
+#, c-format
+msgid "Config entry name cannot start with '%c'."
+msgstr "El nom d'una entrada de configuració no pot començar amb '%c'."
+
+#: ../src/common/fileconf.cpp:1146
+#, fuzzy
+msgid "Failed to create configuration file directory."
+msgstr "No s'ha pogut crear l'objecte de configuració de tipus de lletra."
+
+#: ../src/common/fileconf.cpp:1158
+msgid "can't open user configuration file."
+msgstr "no es pot obrir el fitxer de configuració de l'usuari."
+
+#: ../src/common/fileconf.cpp:1172
+msgid "can't write user configuration file."
+msgstr "no es pot escriure al fitxer de configuració de l'usuari."
+
+#: ../src/common/fileconf.cpp:1178
+msgid "Failed to update user configuration file."
+msgstr "No s'ha pogut actualitzar el fitxer de configuració de l'usuari."
+
+#: ../src/common/fileconf.cpp:1201
+msgid "Error saving user configuration data."
+msgstr "S'ha produït un error en desar les dades de configuració de l'usuari."
+
+#: ../src/common/fileconf.cpp:1313
+#, c-format
+msgid "can't delete user configuration file '%s'"
+msgstr "no es pot suprimir el fitxer de configuració de l'usuari '%s'"
+
+#: ../src/common/fileconf.cpp:2007
+#, c-format
+msgid "entry '%s' appears more than once in group '%s'"
+msgstr "l'entrada '%s' apareix més d'un cop al grup '%s'"
+
+#: ../src/common/fileconf.cpp:2021
+#, c-format
+msgid "attempt to change immutable key '%s' ignored."
+msgstr "s'ha ignorat l'intent de canviar la clau immutable '%s'."
+
+#: ../src/common/fileconf.cpp:2118
+#, c-format
+msgid "trailing backslash ignored in '%s'"
+msgstr "s'ha ignorat la barra inversa al final a '%s'"
+
+#: ../src/common/fileconf.cpp:2153
+#, c-format
+msgid "unexpected \" at position %d in '%s'."
+msgstr "\" inesperat a la posició %d de '%s'."
+
+#: ../src/common/filefn.cpp:474
+#, c-format
+msgid "Failed to copy the file '%s' to '%s'"
+msgstr "No s'ha pogut copiar el fitxer '%s' a '%s'"
+
+#: ../src/common/filefn.cpp:487
+#, c-format
+msgid "Impossible to get permissions for file '%s'"
+msgstr "No és possible obtenir els permisos del fitxer '%s'"
+
+#: ../src/common/filefn.cpp:501
+#, c-format
+msgid "Impossible to overwrite the file '%s'"
+msgstr "No és possible sobreescriure el fitxer '%s'"
+
+#: ../src/common/filefn.cpp:508
+#, c-format
+msgid "Error copying the file '%s' to '%s'."
+msgstr "S'ha produït un error en copiar el fitxer '%s' a '%s'."
+
+#: ../src/common/filefn.cpp:556
+#, c-format
+msgid "Impossible to set permissions for the file '%s'"
+msgstr "No és possible definir els permisos del fitxer '%s'"
+
+#: ../src/common/filefn.cpp:606
+#, c-format
+msgid ""
+"Failed to rename the file '%s' to '%s' because the destination file already "
+"exists."
+msgstr ""
+"No s'ha pogut canviar el nom del fitxer '%s' a '%s' perquè el fitxer de "
+"destinació ja existeix."
+
+#: ../src/common/filefn.cpp:623
+#, c-format
+msgid "File '%s' couldn't be renamed '%s'"
+msgstr "No s'ha pogut canviar el nom del fitxer '%s' a '%s'"
+
+#: ../src/common/filefn.cpp:639
+#, c-format
+msgid "File '%s' couldn't be removed"
+msgstr "No s'ha pogut suprimir el fitxer '%s'"
+
+#: ../src/common/filefn.cpp:666
+#, c-format
+msgid "Directory '%s' couldn't be created"
+msgstr "No s'ha pogut crear el directori '%s'"
+
+#: ../src/common/filefn.cpp:680
+#, c-format
+msgid "Directory '%s' couldn't be deleted"
+msgstr "No s'ha pogut suprimir el directori '%s'"
+
+#: ../src/common/filefn.cpp:714
+#, c-format
+msgid "Cannot enumerate files '%s'"
+msgstr "No es poden enumerar els fitxers '%s'"
+
+#: ../src/common/filefn.cpp:798
+msgid "Failed to get the working directory"
+msgstr "No s'ha pogut obtenir el directori de treball"
+
+#: ../src/common/filefn.cpp:843
+msgid "Could not set current working directory"
+msgstr "No s'ha pogut definir el directori de treball actual"
+
+#: ../src/common/filefn.cpp:974
+#, c-format
+msgid "Files (%s)"
+msgstr "Fitxers (%s)"
+
+#: ../src/common/filename.cpp:182
+#, c-format
+msgid "Failed to open '%s' for reading"
+msgstr "No s'ha pogut obrir '%s' per a llegir-lo"
+
+#: ../src/common/filename.cpp:187
+#, c-format
+msgid "Failed to open '%s' for writing"
+msgstr "No s'ha pogut obrir '%s' per a escriure-hi"
+
+#: ../src/common/filename.cpp:199
+msgid "Failed to close file handle"
+msgstr "No s'ha pogut tancar el manegador del fitxer"
+
+#: ../src/common/filename.cpp:1046
+msgid "Failed to create a temporary file name"
+msgstr "No s'ha pogut crear un nom de fitxer temporal"
+
+#: ../src/common/filename.cpp:1081
+msgid "Failed to open temporary file."
+msgstr "No s'ha pogut obrir el fitxer temporal."
+
+#: ../src/common/filename.cpp:2862
+#, c-format
+msgid "Failed to modify file times for '%s'"
+msgstr "No s'han pogut modificar les hores del fitxer '%s'"
+
+#: ../src/common/filename.cpp:2877
+#, c-format
+msgid "Failed to touch the file '%s'"
+msgstr "No s'ha pogut fer touch al fitxer '%s'"
+
+#: ../src/common/filename.cpp:2958
+#, c-format
+msgid "Failed to retrieve file times for '%s'"
+msgstr "No s'han pogut obtenir les hores del fitxer '%s'"
+
+#: ../src/common/filepickercmn.cpp:39 ../src/common/filepickercmn.cpp:40
+msgid "Browse"
+msgstr "Navega"
+
+#: ../src/common/fldlgcmn.cpp:792 ../src/generic/filectrlg.cpp:1185
+#, c-format
+msgid "All files (%s)|%s"
+msgstr "Tots els fitxers (%s)|%s"
+
+#. TRANSLATORS: %s are a file extension used to build a file wildcard string
+#: ../src/common/fldlgcmn.cpp:810
+#, c-format
+msgid "%s files (%s)|%s"
+msgstr "Fitxers %s (%s)|%s"
+
+#: ../src/common/fldlgcmn.cpp:1072
+#, c-format
+msgid "Load %s file"
+msgstr "Carrega el fitxer %s"
+
+#: ../src/common/fldlgcmn.cpp:1074
+#, c-format
+msgid "Save %s file"
+msgstr "Desa el fitxer %s"
+
+#: ../src/common/fmapbase.cpp:144
+msgid "Western European (ISO-8859-1)"
+msgstr "Europa occidental (ISO-8859-1)"
+
+#: ../src/common/fmapbase.cpp:145
+msgid "Central European (ISO-8859-2)"
+msgstr "Europeu central (ISO-8859-2)"
+
+#: ../src/common/fmapbase.cpp:146
+msgid "Esperanto (ISO-8859-3)"
+msgstr "Esperanto (ISO-8859-3)"
+
+#: ../src/common/fmapbase.cpp:147
+msgid "Baltic (old) (ISO-8859-4)"
+msgstr "Bàltic (antic) (ISO-8859-4)"
+
+#: ../src/common/fmapbase.cpp:148
+msgid "Cyrillic (ISO-8859-5)"
+msgstr "Ciríl·lic (ISO-8859-5)"
+
+#: ../src/common/fmapbase.cpp:149
+msgid "Arabic (ISO-8859-6)"
+msgstr "Àrab (ISO-8859-6)"
+
+#: ../src/common/fmapbase.cpp:150
+msgid "Greek (ISO-8859-7)"
+msgstr "Grec (ISO-8859-7)"
+
+#: ../src/common/fmapbase.cpp:151
+msgid "Hebrew (ISO-8859-8)"
+msgstr "Hebreu (ISO-8859-8)"
+
+#: ../src/common/fmapbase.cpp:152
+msgid "Turkish (ISO-8859-9)"
+msgstr "Turc (ISO-8859-9)"
+
+#: ../src/common/fmapbase.cpp:153
+msgid "Nordic (ISO-8859-10)"
+msgstr "Nòrdic (ISO-8859-10)"
+
+#: ../src/common/fmapbase.cpp:154
+msgid "Thai (ISO-8859-11)"
+msgstr "Tailandès (ISO-8859-11)"
+
+#: ../src/common/fmapbase.cpp:155
+msgid "Indian (ISO-8859-12)"
+msgstr "Indi (ISO-8859-12)"
+
+#: ../src/common/fmapbase.cpp:156
+msgid "Baltic (ISO-8859-13)"
+msgstr "Bàltic (ISO-8859-13)"
+
+#: ../src/common/fmapbase.cpp:157
+msgid "Celtic (ISO-8859-14)"
+msgstr "Cèltic (ISO-8859-14)"
+
+#: ../src/common/fmapbase.cpp:158
+msgid "Western European with Euro (ISO-8859-15)"
+msgstr "Europa occidental amb euro (ISO-8859-15)"
+
+#: ../src/common/fmapbase.cpp:159
+msgid "KOI8-R"
+msgstr "KOI8-R"
+
+#: ../src/common/fmapbase.cpp:160
+msgid "KOI8-U"
+msgstr "KOI8-U"
+
+#: ../src/common/fmapbase.cpp:161
+msgid "Windows/DOS OEM Cyrillic (CP 866)"
+msgstr "Ciríl·lic OEM del Windows/DOS (CP 866)"
+
+#: ../src/common/fmapbase.cpp:162
+msgid "Windows Thai (CP 874)"
+msgstr "Tailandès del Windows (CP 874)"
+
+#: ../src/common/fmapbase.cpp:163
+msgid "Windows Japanese (CP 932) or Shift-JIS"
+msgstr "Japonès del Windows (CP 932) o Shift-JIS"
+
+#: ../src/common/fmapbase.cpp:164
+msgid "Windows Chinese Simplified (CP 936) or GB-2312"
+msgstr "Xinès simplificat del Windows (CP 936) o GB-2312"
+
+#: ../src/common/fmapbase.cpp:165
+msgid "Windows Korean (CP 949)"
+msgstr "Coreà del Windows (CP 949)"
+
+#: ../src/common/fmapbase.cpp:166
+msgid "Windows Chinese Traditional (CP 950) or Big-5"
+msgstr "Xinès tradicional del Windows (CP 950) o Big-5"
+
+#: ../src/common/fmapbase.cpp:167
+msgid "Windows Central European (CP 1250)"
+msgstr "Europa central del Windows (CP 1250)"
+
+#: ../src/common/fmapbase.cpp:168
+msgid "Windows Cyrillic (CP 1251)"
+msgstr "Ciríl·lic del Windows (CP 1251)"
+
+#: ../src/common/fmapbase.cpp:169
+msgid "Windows Western European (CP 1252)"
+msgstr "Europa occidental del Windows (CP 1252)"
+
+#: ../src/common/fmapbase.cpp:170
+msgid "Windows Greek (CP 1253)"
+msgstr "Grec del Windows (CP 1253)"
+
+#: ../src/common/fmapbase.cpp:171
+msgid "Windows Turkish (CP 1254)"
+msgstr "Turc del Windows (CP 1254)"
+
+#: ../src/common/fmapbase.cpp:172
+msgid "Windows Hebrew (CP 1255)"
+msgstr "Hebreu del Windows (CP 1255)"
+
+#: ../src/common/fmapbase.cpp:173
+msgid "Windows Arabic (CP 1256)"
+msgstr "Àrab del Windows (CP 1256)"
+
+#: ../src/common/fmapbase.cpp:174
+msgid "Windows Baltic (CP 1257)"
+msgstr "Bàltic del Windows (CP 1257)"
+
+#: ../src/common/fmapbase.cpp:175
+msgid "Windows Vietnamese (CP 1258)"
+msgstr "Vietnamita del Windows (CP 1258)"
+
+#: ../src/common/fmapbase.cpp:176
+msgid "Windows Johab (CP 1361)"
+msgstr "Johab del Windows (CP 1361)"
+
+#: ../src/common/fmapbase.cpp:177
+msgid "Windows/DOS OEM (CP 437)"
+msgstr "OEM del Windows/DOS (CP 437)"
+
+#: ../src/common/fmapbase.cpp:178
+msgid "Unicode 7 bit (UTF-7)"
+msgstr "Unicode de 7 bits (UTF-7)"
+
+#: ../src/common/fmapbase.cpp:179
+msgid "Unicode 8 bit (UTF-8)"
+msgstr "Unicode de 8 bits (UTF-8)"
+
+#: ../src/common/fmapbase.cpp:181 ../src/common/fmapbase.cpp:187
+msgid "Unicode 16 bit (UTF-16)"
+msgstr "Unicode de 16 bits (UTF-16)"
+
+#: ../src/common/fmapbase.cpp:182
+msgid "Unicode 16 bit Little Endian (UTF-16LE)"
+msgstr "Unicode de 16 bits Little Endian (UTF-16LE)"
+
+#: ../src/common/fmapbase.cpp:183 ../src/common/fmapbase.cpp:189
+msgid "Unicode 32 bit (UTF-32)"
+msgstr "Unicode de 32 bits (UTF-32)"
+
+#: ../src/common/fmapbase.cpp:184
+msgid "Unicode 32 bit Little Endian (UTF-32LE)"
+msgstr "Unicode de 32 bits Little Endian (UTF-32LE)"
+
+#: ../src/common/fmapbase.cpp:186
+msgid "Unicode 16 bit Big Endian (UTF-16BE)"
+msgstr "Unicode de 16 bits Big Endian (UTF-16BE)"
+
+#: ../src/common/fmapbase.cpp:188
+msgid "Unicode 32 bit Big Endian (UTF-32BE)"
+msgstr "Unicode de 32 bits Big Endian (UTF-32BE)"
+
+#: ../src/common/fmapbase.cpp:191
+msgid "Extended Unix Codepage for Japanese (EUC-JP)"
+msgstr "Codificació de pàgina estesa d'Unix per al japonès (EUC-JP)"
+
+#: ../src/common/fmapbase.cpp:192
+msgid "US-ASCII"
+msgstr "US-ASCII"
+
+#: ../src/common/fmapbase.cpp:193
+msgid "ISO-2022-JP"
+msgstr "ISO-2022-JP"
+
+#: ../src/common/fmapbase.cpp:195
+msgid "MacRoman"
+msgstr "MacRoman"
+
+#: ../src/common/fmapbase.cpp:196
+msgid "MacJapanese"
+msgstr "MacJapanese"
+
+#: ../src/common/fmapbase.cpp:197
+msgid "MacChineseTrad"
+msgstr "MacChineseTrad"
+
+#: ../src/common/fmapbase.cpp:198
+msgid "MacKorean"
+msgstr "MacKorean"
+
+#: ../src/common/fmapbase.cpp:199
+msgid "MacArabic"
+msgstr "MacArabic"
+
+#: ../src/common/fmapbase.cpp:200
+msgid "MacHebrew"
+msgstr "MacHebrew"
+
+#: ../src/common/fmapbase.cpp:201
+msgid "MacGreek"
+msgstr "MacGreek"
+
+#: ../src/common/fmapbase.cpp:202
+msgid "MacCyrillic"
+msgstr "MacCyrillic"
+
+#: ../src/common/fmapbase.cpp:203
+msgid "MacDevanagari"
+msgstr "MacDevanagari"
+
+#: ../src/common/fmapbase.cpp:204
+msgid "MacGurmukhi"
+msgstr "MacGurmukhi"
+
+#: ../src/common/fmapbase.cpp:205
+msgid "MacGujarati"
+msgstr "MacGujarati"
+
+#: ../src/common/fmapbase.cpp:206
+msgid "MacOriya"
+msgstr "MacOriya"
+
+#: ../src/common/fmapbase.cpp:207
+msgid "MacBengali"
+msgstr "MacBengali"
+
+#: ../src/common/fmapbase.cpp:208
+msgid "MacTamil"
+msgstr "MacTamil"
+
+#: ../src/common/fmapbase.cpp:209
+msgid "MacTelugu"
+msgstr "MacTelugu"
+
+#: ../src/common/fmapbase.cpp:210
+msgid "MacKannada"
+msgstr "MacKannada"
+
+#: ../src/common/fmapbase.cpp:211
+msgid "MacMalayalam"
+msgstr "MacMalayalam"
+
+#: ../src/common/fmapbase.cpp:212
+msgid "MacSinhalese"
+msgstr "MacSinhalese"
+
+#: ../src/common/fmapbase.cpp:213
+msgid "MacBurmese"
+msgstr "MacBurmese"
+
+#: ../src/common/fmapbase.cpp:214
+msgid "MacKhmer"
+msgstr "MacKhmer"
+
+#: ../src/common/fmapbase.cpp:215
+msgid "MacThai"
+msgstr "MacThai"
+
+#: ../src/common/fmapbase.cpp:216
+msgid "MacLaotian"
+msgstr "MacLaotian"
+
+#: ../src/common/fmapbase.cpp:217
+msgid "MacGeorgian"
+msgstr "MacGeorgian"
+
+#: ../src/common/fmapbase.cpp:218
+msgid "MacArmenian"
+msgstr "MacArmenian"
+
+#: ../src/common/fmapbase.cpp:219
+msgid "MacChineseSimp"
+msgstr "MacChineseSimp"
+
+#: ../src/common/fmapbase.cpp:220
+msgid "MacTibetan"
+msgstr "MacTibetan"
+
+#: ../src/common/fmapbase.cpp:221
+msgid "MacMongolian"
+msgstr "MacMongolian"
+
+#: ../src/common/fmapbase.cpp:222
+msgid "MacEthiopic"
+msgstr "MacEthiopic"
+
+#: ../src/common/fmapbase.cpp:223
+msgid "MacCentralEurRoman"
+msgstr "MacCentralEurRoman"
+
+#: ../src/common/fmapbase.cpp:224
+msgid "MacVietnamese"
+msgstr "MacVietnamese"
+
+#: ../src/common/fmapbase.cpp:225
+msgid "MacExtArabic"
+msgstr "MacExtArabic"
+
+#: ../src/common/fmapbase.cpp:226
+msgid "MacSymbol"
+msgstr "MacSymbol"
+
+#: ../src/common/fmapbase.cpp:227
+msgid "MacDingbats"
+msgstr "MacDingbats"
+
+#: ../src/common/fmapbase.cpp:228
+msgid "MacTurkish"
+msgstr "MacTurkish"
+
+#: ../src/common/fmapbase.cpp:229
+msgid "MacCroatian"
+msgstr "MacCroatian"
+
+#: ../src/common/fmapbase.cpp:230
+msgid "MacIcelandic"
+msgstr "MacIcelandic"
+
+#: ../src/common/fmapbase.cpp:231
+msgid "MacRomanian"
+msgstr "MacRomanian"
+
+#: ../src/common/fmapbase.cpp:232
+msgid "MacCeltic"
+msgstr "MacCeltic"
+
+#: ../src/common/fmapbase.cpp:233
+msgid "MacGaelic"
+msgstr "MacGaelic"
+
+#: ../src/common/fmapbase.cpp:234
+msgid "MacKeyboardGlyphs"
+msgstr "MacKeyboardGlyphs"
+
+#: ../src/common/fmapbase.cpp:791
+msgid "Default encoding"
+msgstr "Codificació per defecte"
+
+#: ../src/common/fmapbase.cpp:805
+#, c-format
+msgid "Unknown encoding (%d)"
+msgstr "Codificació desconeguda (%d)"
+
+#: ../src/common/fmapbase.cpp:815 ../src/richtext/richtextstyles.cpp:776
+msgid "default"
+msgstr "per defecte"
+
+#: ../src/common/fmapbase.cpp:829
+#, c-format
+msgid "unknown-%d"
+msgstr "desconegut-%d"
+
+#: ../src/common/fontcmn.cpp:924 ../src/common/fontcmn.cpp:1130
+msgid "underlined"
+msgstr "subratllat"
+
+#: ../src/common/fontcmn.cpp:929
+msgid " strikethrough"
+msgstr " ratllat"
+
+#: ../src/common/fontcmn.cpp:942
+msgid " thin"
+msgstr " prima"
+
+#: ../src/common/fontcmn.cpp:946
+msgid " extra light"
+msgstr " extra lleugera"
+
+#: ../src/common/fontcmn.cpp:950
+msgid " light"
+msgstr " lleugera"
+
+#: ../src/common/fontcmn.cpp:954
+msgid " medium"
+msgstr " mitjana"
+
+#: ../src/common/fontcmn.cpp:958
+msgid " semi bold"
+msgstr " semi negreta"
+
+#: ../src/common/fontcmn.cpp:962
+msgid " bold"
+msgstr " negreta"
+
+#: ../src/common/fontcmn.cpp:966
+msgid " extra bold"
+msgstr " extra negreta"
+
+#: ../src/common/fontcmn.cpp:970
+msgid " heavy"
+msgstr " pesada"
+
+#: ../src/common/fontcmn.cpp:974
+msgid " extra heavy"
+msgstr " extra pesada"
+
+#: ../src/common/fontcmn.cpp:990
+msgid " italic"
+msgstr " cursiva"
+
+#: ../src/common/fontcmn.cpp:1134
+msgid "strikethrough"
+msgstr "ratllat"
+
+#: ../src/common/fontcmn.cpp:1143
+msgid "thin"
+msgstr "prima"
+
+#: ../src/common/fontcmn.cpp:1156
+msgid "extralight"
+msgstr "extralleugera"
+
+#: ../src/common/fontcmn.cpp:1161
+msgid "light"
+msgstr "lleugera"
+
+#: ../src/common/fontcmn.cpp:1169 ../src/richtext/richtextstyles.cpp:775
+msgid "normal"
+msgstr "normal"
+
+#: ../src/common/fontcmn.cpp:1174
+msgid "medium"
+msgstr "mitjana"
+
+#: ../src/common/fontcmn.cpp:1179 ../src/common/fontcmn.cpp:1199
+msgid "semibold"
+msgstr "seminegreta"
+
+#: ../src/common/fontcmn.cpp:1184
+msgid "bold"
+msgstr "negreta"
+
+#: ../src/common/fontcmn.cpp:1194
+msgid "extrabold"
+msgstr "extranegreta"
+
+#: ../src/common/fontcmn.cpp:1204
+msgid "heavy"
+msgstr "pesada"
+
+#: ../src/common/fontcmn.cpp:1212
+msgid "extraheavy"
+msgstr "extrapesada"
+
+#: ../src/common/fontcmn.cpp:1217
+msgid "italic"
+msgstr "cursiva"
+
+#: ../src/common/fontmap.cpp:195
+msgid ": unknown charset"
+msgstr ": joc de caràcters desconegut"
+
+#: ../src/common/fontmap.cpp:199
+#, c-format
+msgid ""
+"The charset '%s' is unknown. You may select\n"
+"another charset to replace it with or choose\n"
+"[Cancel] if it cannot be replaced"
+msgstr ""
+"El joc de caràcters '%s' és desconegut. Podeu seleccionar\n"
+"un altre joc de caràcters per a substituir-lo o triar\n"
+"[Cancel·la] si no pot ser substituït"
+
+#: ../src/common/fontmap.cpp:241
+#, c-format
+msgid "Failed to remember the encoding for the charset '%s'."
+msgstr "No s'ha pogut recordar la codificació del joc de caràcters '%s'."
+
+#: ../src/common/fontmap.cpp:321
+msgid "can't load any font, aborting"
+msgstr "no es pot carregar cap tipus de lletra, s'avorta"
+
+#: ../src/common/fontmap.cpp:409
+msgid ": unknown encoding"
+msgstr ": codificació desconeguda"
+
+#: ../src/common/fontmap.cpp:417
+#, c-format
+msgid ""
+"No font for displaying text in encoding '%s' found,\n"
+"but an alternative encoding '%s' is available.\n"
+"Do you want to use this encoding (otherwise you will have to choose another "
+"one)?"
+msgstr ""
+"No s'ha trobat cap tipus de lletra per a mostrar text amb la codificació "
+"'%s',\n"
+"però hi ha una codificació alternativa, '%s'.\n"
+"Voleu fer servir aquesta codificació (si no, n'haureu de triar una altra)?"
+
+#: ../src/common/fontmap.cpp:422
+#, c-format
+msgid ""
+"No font for displaying text in encoding '%s' found.\n"
+"Would you like to select a font to be used for this encoding\n"
+"(otherwise the text in this encoding will not be shown correctly)?"
+msgstr ""
+"No s'ha trobat cap tipus de lletra per a mostrar text amb la codificació "
+"'%s'.\n"
+"Voleu triar un tipus de lletra perquè es faci servir per a aquesta "
+"codificació\n"
+"(si no, el text amb aquesta codificació no es mostrarà correctament)?"
+
+#: ../src/common/fs_mem.cpp:169
+#, c-format
+msgid "Memory VFS already contains file '%s'!"
+msgstr "El VFS en memòria ja conté el fitxer '%s'!"
+
+#: ../src/common/fs_mem.cpp:232
+#, c-format
+msgid "Trying to remove file '%s' from memory VFS, but it is not loaded!"
+msgstr ""
+"S'està provant de suprimir el fitxer '%s' del VFS en memòria, però no està "
+"carregat!"
+
+#: ../src/common/fs_mem.cpp:262
+#, c-format
+msgid "Failed to store image '%s' to memory VFS!"
+msgstr "No s'ha pogut emmagatzemar la imatge '%s' al VFS de la memòria!"
+
+#: ../src/common/ftp.cpp:197
+msgid "Timeout while waiting for FTP server to connect, try passive mode."
+msgstr ""
+"S'ha excedit el temps límit d'espera en connectar al servidor FTP, proveu el "
+"mode passiu."
+
+#: ../src/common/ftp.cpp:399
+#, c-format
+msgid "Failed to set FTP transfer mode to %s."
+msgstr "No s'ha pogut definir el mode de transferència FTP a %s."
+
+#: ../src/common/ftp.cpp:400 ../src/richtext/richtextsymboldlg.cpp:432
+msgid "ASCII"
+msgstr "ASCII"
+
+#: ../src/common/ftp.cpp:400
+msgid "binary"
+msgstr "binari"
+
+#: ../src/common/ftp.cpp:608
+msgid "The FTP server doesn't support the PORT command."
+msgstr "El servidor FTP no suporta l'ordre PORT."
+
+#: ../src/common/ftp.cpp:622
+msgid "The FTP server doesn't support passive mode."
+msgstr "El servidor FTP no suporta l'ús del mode passiu."
+
+#: ../src/common/gifdecod.cpp:822
+#, c-format
+msgid "Incorrect GIF frame size (%u, %d) for the frame #%u"
+msgstr ""
+"Mida de fotograma de GIF incorrecta (%u, %d) per al fotograma número %u"
+
+#: ../src/common/glcmn.cpp:108
+msgid "Failed to allocate colour for OpenGL"
+msgstr "No s'ha pogut assignar el color per a l'OpenGL"
+
+#: ../src/common/headerctrlcmn.cpp:57
+msgid "Please select the columns to show and define their order:"
+msgstr "Seleccioneu les columnes que es mostraran i definiu-ne l'ordre:"
+
+#: ../src/common/headerctrlcmn.cpp:58
+msgid "Customize Columns"
+msgstr "Personalitza les columnes"
+
+#: ../src/common/headerctrlcmn.cpp:304
+msgid "&Customize..."
+msgstr "&Personalitza..."
+
+#: ../src/common/hyperlnkcmn.cpp:132
+#, c-format
+msgid "Failed to open URL \"%s\" in the default browser"
+msgstr "No s'ha pogut obrir l'URL \"%s\" al navegador predeterminat"
+
+#: ../src/common/iconbndl.cpp:195
+#, c-format
+msgid "Failed to load image %%d from file '%s'."
+msgstr "No s'ha pogut carregar la imatge %%d del fitxer '%s'."
+
+#: ../src/common/iconbndl.cpp:203
+#, c-format
+msgid "Failed to load image %d from stream."
+msgstr "No s'ha pogut carregar la imatge %d del flux."
+
+#: ../src/common/iconbndl.cpp:221
+#, c-format
+msgid "Failed to load icons from resource '%s'."
+msgstr "No s'han pogut carregar les icones del recurs '%s'."
+
+#: ../src/common/imagbmp.cpp:97
+msgid "BMP: Couldn't save invalid image."
+msgstr "BMP: No s'ha pogut desar una imatge invàlida."
+
+#: ../src/common/imagbmp.cpp:137
+msgid "BMP: wxImage doesn't have own wxPalette."
+msgstr "BMP: wxImage no té una wxPallette pròpia."
+
+#: ../src/common/imagbmp.cpp:243
+msgid "BMP: Couldn't write the file (Bitmap) header."
+msgstr "BMP: No s'ha pogut escriure la capçalera del fitxer (Bitmap)."
+
+#: ../src/common/imagbmp.cpp:266
+msgid "BMP: Couldn't write the file (BitmapInfo) header."
+msgstr "BMP: No s'ha pogut escriure la capçalera del fitxer (BitmapInfo)."
+
+#: ../src/common/imagbmp.cpp:353
+msgid "BMP: Couldn't write RGB color map."
+msgstr "BMP: No s'ha pogut escriure el mapa de colors RGB."
+
+#: ../src/common/imagbmp.cpp:487
+msgid "BMP: Couldn't write data."
+msgstr "BMP: No s'han pogut escriure les dades."
+
+#: ../src/common/imagbmp.cpp:561 ../src/common/imagbmp.cpp:642
+msgid "BMP: Couldn't allocate memory."
+msgstr "BMP: No s'ha pogut assignar la memòria."
+
+#: ../src/common/imagbmp.cpp:1041
+msgid "DIB Header: Image width > 32767 pixels for file."
+msgstr "Capçalera DIB: Amplada de la imatge > 32767 píxels per fitxer."
+
+#: ../src/common/imagbmp.cpp:1049
+msgid "DIB Header: Image height > 32767 pixels for file."
+msgstr "Capçalera DIB: Alçada de la imatge > 32767 píxels per fitxer."
+
+#: ../src/common/imagbmp.cpp:1081
+msgid "DIB Header: Unknown bitdepth in file."
+msgstr "Capçalera DIB: Profunditat de bits desconeguda al fitxer."
+
+#: ../src/common/imagbmp.cpp:1156
+msgid "DIB Header: Unknown encoding in file."
+msgstr "Capçalera DIB: Codificació desconeguda al fitxer."
+
+#: ../src/common/imagbmp.cpp:1165
+msgid "DIB Header: Encoding doesn't match bitdepth."
+msgstr ""
+"Capçalera DIB: La codificació no coincideix amb la profunditat de bits."
+
+#: ../src/common/imagbmp.cpp:1180
+#, c-format
+msgid "BMP Header: Invalid number of colors (%d)."
+msgstr ""
+
+#: ../src/common/imagbmp.cpp:1273
+msgid "Error in reading image DIB."
+msgstr "S'ha produït un error en llegir la imatge DIB."
+
+#: ../src/common/imagbmp.cpp:1294
+msgid "ICO: Error in reading mask DIB."
+msgstr "ICO: S'ha produït un error en llegir la màscara DIB."
+
+#: ../src/common/imagbmp.cpp:1353
+msgid "ICO: Image too tall for an icon."
+msgstr "ICO: Imatge massa alta per a una icona."
+
+#: ../src/common/imagbmp.cpp:1361
+msgid "ICO: Image too wide for an icon."
+msgstr "ICO: Imatge massa ampla per a una icona."
+
+#: ../src/common/imagbmp.cpp:1388 ../src/common/imagbmp.cpp:1488
+#: ../src/common/imagbmp.cpp:1503 ../src/common/imagbmp.cpp:1514
+#: ../src/common/imagbmp.cpp:1528 ../src/common/imagbmp.cpp:1576
+#: ../src/common/imagbmp.cpp:1591 ../src/common/imagbmp.cpp:1605
+#: ../src/common/imagbmp.cpp:1616
+msgid "ICO: Error writing the image file!"
+msgstr "ICO: S'ha produït un error en escriure el fitxer d'imatge!"
+
+#: ../src/common/imagbmp.cpp:1701
+msgid "ICO: Invalid icon index."
+msgstr "ICO: Índex d'icona invàlid."
+
+#: ../src/common/image.cpp:2410
+msgid "Image and mask have different sizes."
+msgstr "La imatge i la màscara tenen mides diferents."
+
+#: ../src/common/image.cpp:2418 ../src/common/image.cpp:2459
+msgid "No unused colour in image being masked."
+msgstr "No hi ha cap color sense utilitzar a la imatge que voleu emmascarar."
+
+#: ../src/common/image.cpp:2641
+#, c-format
+msgid "Failed to load bitmap \"%s\" from resources."
+msgstr "No s'ha pogut carregar el mapa de bits \"%s\" dels recursos."
+
+#: ../src/common/image.cpp:2650
+#, c-format
+msgid "Failed to load icon \"%s\" from resources."
+msgstr "No s'ha pogut carregar la icona \"%s\" dels recursos."
+
+#: ../src/common/image.cpp:2728 ../src/common/image.cpp:2747
+#, c-format
+msgid "Failed to load image from file \"%s\"."
+msgstr "No s'ha pogut carregar la imatge del fitxer \"%s\"."
+
+#: ../src/common/image.cpp:2761
+#, c-format
+msgid "Can't save image to file '%s': unknown extension."
+msgstr "No es pot desar la imatge al fitxer '%s': extensió desconeguda."
+
+#: ../src/common/image.cpp:2869
+msgid "No handler found for image type."
+msgstr "No s'ha trobat cap gestor per al tipus d'imatge."
+
+#: ../src/common/image.cpp:2877 ../src/common/image.cpp:3000
+#: ../src/common/image.cpp:3066
+#, c-format
+msgid "No image handler for type %d defined."
+msgstr "No hi ha definit cap gestor d'imatge per al tipus %d."
+
+#: ../src/common/image.cpp:2887
+#, c-format
+msgid "Image file is not of type %d."
+msgstr "El fitxer d'imatge no és del tipus %d."
+
+#: ../src/common/image.cpp:2970
+msgid "Can't automatically determine the image format for non-seekable input."
+msgstr ""
+"No es pot determinar automàticament el format d'imatge en una entrada "
+"seqüencial."
+
+#: ../src/common/image.cpp:2988
+msgid "Unknown image data format."
+msgstr "Format de dades d'imatge desconegut."
+
+#: ../src/common/image.cpp:3009
+#, c-format
+msgid "This is not a %s."
+msgstr "Això no és un %s."
+
+#: ../src/common/image.cpp:3032 ../src/common/image.cpp:3080
+#, c-format
+msgid "No image handler for type %s defined."
+msgstr "No hi ha definit cap gestor d'imatge per al tipus %s."
+
+#: ../src/common/image.cpp:3041
+#, c-format
+msgid "Image is not of type %s."
+msgstr "La imatge no és del tipus %s."
+
+#: ../src/common/image.cpp:3509
+#, c-format
+msgid "Failed to check format of image file \"%s\"."
+msgstr "No s'ha pogut comprovar el format del fitxer d'imatge \"%s\"."
+
+#: ../src/common/imaggif.cpp:124
+msgid "GIF: error in GIF image format."
+msgstr "GIF: error al format d'imatge GIF."
+
+#: ../src/common/imaggif.cpp:129
+msgid "GIF: not enough memory."
+msgstr "GIF: no hi ha prou memòria."
+
+#: ../src/common/imaggif.cpp:134
+msgid "GIF: data stream seems to be truncated."
+msgstr "GIF: sembla que s'ha truncat el flux de dades."
+
+#: ../src/common/imaggif.cpp:240
+msgid "Couldn't initialize GIF hash table."
+msgstr "No s'ha pogut inicialitzar la taula de resums del GIF."
+
+#: ../src/common/imagiff.cpp:739
+msgid "IFF: error in IFF image format."
+msgstr "IFF: error en el format d'imatge IFF."
+
+#: ../src/common/imagiff.cpp:742
+msgid "IFF: not enough memory."
+msgstr "IFF: no hi ha prou memòria."
+
+#: ../src/common/imagiff.cpp:745
+msgid "IFF: unknown error!!!"
+msgstr "IFF: s'ha produït un error desconegut!!!"
+
+#: ../src/common/imagiff.cpp:755
+msgid "IFF: data stream seems to be truncated."
+msgstr "IFF: sembla que s'ha truncat el flux de dades."
+
+#: ../src/common/imagjpeg.cpp:258
+msgid "JPEG: Couldn't load - file is probably corrupted."
+msgstr "JPEG: No s'ha pogut carregar - probablement el fitxer és corrupte."
+
+#: ../src/common/imagjpeg.cpp:437
+msgid "JPEG: Couldn't save image."
+msgstr "JPEG: No s'ha pogut desar la imatge."
+
+#: ../src/common/imagpcx.cpp:439
+msgid "PCX: this is not a PCX file."
+msgstr "PCX: això no és un fitxer PCX."
+
+#: ../src/common/imagpcx.cpp:453
+msgid "PCX: image format unsupported"
+msgstr "PCX: format d'imatge no suportat"
+
+#: ../src/common/imagpcx.cpp:454 ../src/common/imagpcx.cpp:477
+msgid "PCX: couldn't allocate memory"
+msgstr "PCX: no s'ha pogut assignar la memòria"
+
+#: ../src/common/imagpcx.cpp:455
+msgid "PCX: version number too low"
+msgstr "PCX: número de versió massa baix"
+
+#: ../src/common/imagpcx.cpp:456 ../src/common/imagpcx.cpp:478
+msgid "PCX: unknown error !!!"
+msgstr "PCX: s'ha produït un error desconegut!!!"
+
+#: ../src/common/imagpcx.cpp:476
+msgid "PCX: invalid image"
+msgstr "PCX: imatge invàlida"
+
+#: ../src/common/imagpng.cpp:385
+#, c-format
+msgid "Unknown PNG resolution unit %d"
+msgstr "Unitat de resolució PNG desconeguda %d"
+
+#: ../src/common/imagpng.cpp:439
+msgid "Couldn't load a PNG image - file is corrupted or not enough memory."
+msgstr ""
+"No s'ha pogut carregar una imatge PNG - el fitxer és corrupte o no hi ha "
+"prou memòria."
+
+#: ../src/common/imagpng.cpp:513 ../src/common/imagpng.cpp:524
+#: ../src/common/imagpng.cpp:534
+msgid "Couldn't save PNG image."
+msgstr "No s'ha pogut desar la imatge PNG."
+
+#: ../src/common/imagpnm.cpp:71
+msgid "PNM: File format is not recognized."
+msgstr "PNM: Format de fitxer no reconegut."
+
+#: ../src/common/imagpnm.cpp:89
+msgid "PNM: Couldn't allocate memory."
+msgstr "PNM: No s'ha pogut assignar la memòria."
+
+#: ../src/common/imagpnm.cpp:111 ../src/common/imagpnm.cpp:134
+#: ../src/common/imagpnm.cpp:156
+msgid "PNM: File seems truncated."
+msgstr "PNM: El fitxer sembla truncat."
+
+#: ../src/common/imagtiff.cpp:69
+#, c-format
+msgid " (in module \"%s\")"
+msgstr " (al mòdul \"%s\")"
+
+#: ../src/common/imagtiff.cpp:304
+msgid "TIFF: Error loading image."
+msgstr "TIFF: S'ha produït un error en carregar la imatge."
+
+#: ../src/common/imagtiff.cpp:314
+msgid "Invalid TIFF image index."
+msgstr "Índex d'imatge TIFF invàlid."
+
+#: ../src/common/imagtiff.cpp:358
+msgid "TIFF: Image size is abnormally big."
+msgstr "TIFF: La mida de la imatge és anormalment gran."
+
+#: ../src/common/imagtiff.cpp:372 ../src/common/imagtiff.cpp:385
+#: ../src/common/imagtiff.cpp:769
+msgid "TIFF: Couldn't allocate memory."
+msgstr "TIFF: No s'ha pogut assignar la memòria."
+
+#: ../src/common/imagtiff.cpp:471
+msgid "TIFF: Error reading image."
+msgstr "TIFF: S'ha produït un error en llegir la imatge."
+
+#: ../src/common/imagtiff.cpp:532
+#, c-format
+msgid "Unknown TIFF resolution unit %d ignored"
+msgstr "S'ha ignorat la unitat de resolució TIFF desconeguda %d"
+
+#: ../src/common/imagtiff.cpp:611
+msgid "TIFF: Error saving image."
+msgstr "TIFF: S'ha produït un error en desar la imatge."
+
+#: ../src/common/imagtiff.cpp:868
+msgid "TIFF: Error writing image."
+msgstr "TIFF: S'ha produït un error en escriure la imatge."
+
+#: ../src/common/imagtiff.cpp:881
+#, fuzzy
+msgid "TIFF: Error flushing data."
+msgstr "TIFF: S'ha produït un error en desar la imatge."
+
+#: ../src/common/imagwebp.cpp:56
+msgid "WebP: Invalid data (failed to get features)."
+msgstr ""
+
+#: ../src/common/imagwebp.cpp:65
+msgid "WebP: Allocating image memory failed."
+msgstr ""
+
+#: ../src/common/imagwebp.cpp:82
+msgid "WebP: Decoding RGBA image data failed."
+msgstr ""
+
+#: ../src/common/imagwebp.cpp:98
+msgid "WebP: Decoding RGB image data failed."
+msgstr ""
+
+#: ../src/common/imagwebp.cpp:113 ../src/common/imagwebp.cpp:201
+msgid "WebP: Allocating stream buffer failed."
+msgstr ""
+
+#: ../src/common/imagwebp.cpp:131
+#, fuzzy
+msgid "WebP: Failed to parse container data."
+msgstr "No s'han pogut definir les dades del porta-retalls."
+
+#: ../src/common/imagwebp.cpp:222
+#, fuzzy
+msgid "WebP: Error decoding animation."
+msgstr "S'ha produït un error en llegir les opcions de configuració."
+
+#: ../src/common/imagwebp.cpp:240
+msgid "WebP: Error getting next animation frame."
+msgstr ""
+
+#: ../src/common/init.cpp:172
+#, c-format
+msgid ""
+"Command line argument %d couldn't be converted to Unicode and will be "
+"ignored."
+msgstr ""
+"No s'ha pogut convertir a Unicode l'argument %d de la línia d'ordres i "
+"s'ignorarà."
+
+#: ../src/common/init.cpp:344
+msgid "Initialization failed in post init, aborting."
+msgstr "Ha fallat la inicialització a post init, s'està avortant."
+
+#: ../src/common/intl.cpp:378
+#, c-format
+msgid "Cannot set locale to language \"%s\"."
+msgstr "No es pot definir la configuració local a la llengua \"%s\"."
+
+#: ../src/common/log.cpp:232
+msgid "Error: "
+msgstr "Error: "
+
+#: ../src/common/log.cpp:236
+msgid "Warning: "
+msgstr "Advertència: "
+
+#: ../src/common/log.cpp:284
+msgid "The previous message repeated once."
+msgstr "El missatge anterior s'ha repetit una vegada."
+
+#: ../src/common/log.cpp:291
+#, c-format
+msgid "The previous message repeated %u time."
+msgid_plural "The previous message repeated %u times."
+msgstr[0] "El missatge anterior s'ha repetit %u vegada."
+msgstr[1] "El missatge anterior s'ha repetit %u vegades."
+
+#: ../src/common/log.cpp:319
+#, c-format
+msgid "Last repeated message (\"%s\", %u time) wasn't output"
+msgid_plural "Last repeated message (\"%s\", %u times) wasn't output"
+msgstr[0] "No s'ha mostrat el darrer missatge repetit (\"%s\", %u vegada)"
+msgstr[1] "No s'ha mostrat el darrer missatge repetit (\"%s\", %u vegades)"
+
+#: ../src/common/log.cpp:435
+#, c-format
+msgid " (error %ld: %s)"
+msgstr " (error %ld: %s)"
+
+#: ../src/common/lzmastream.cpp:121
+msgid "Failed to allocate memory for LZMA decompression."
+msgstr "No s'ha pogut assignar memòria per a la descompressió LZMA."
+
+#: ../src/common/lzmastream.cpp:125
+#, c-format
+msgid "Failed to initialize LZMA decompression: unexpected error %u."
+msgstr "No s'ha pogut inicialitzar la descompressió LZMA: error inesperat %u."
+
+#: ../src/common/lzmastream.cpp:179
+msgid "input is not in XZ format"
+msgstr "l'entrada no està en format XZ"
+
+#: ../src/common/lzmastream.cpp:183
+msgid "input compressed using unknown XZ option"
+msgstr "l'entrada està comprimida amb una opció XZ desconeguda"
+
+#: ../src/common/lzmastream.cpp:188
+msgid "input is corrupted"
+msgstr "l'entrada està corrompuda"
+
+#: ../src/common/lzmastream.cpp:192
+msgid "unknown decompression error"
+msgstr "error de descompressió desconegut"
+
+#: ../src/common/lzmastream.cpp:196
+#, c-format
+msgid "LZMA decompression error: %s"
+msgstr "Error de descompressió LZMA: %s"
+
+#: ../src/common/lzmastream.cpp:231
+msgid "Failed to allocate memory for LZMA compression."
+msgstr "No s'ha pogut assignar memòria per a la compressió LZMA."
+
+#: ../src/common/lzmastream.cpp:235
+#, c-format
+msgid "Failed to initialize LZMA compression: unexpected error %u."
+msgstr "No s'ha pogut inicialitzar la compressió LZMA: error inesperat %u."
+
+#: ../src/common/lzmastream.cpp:267 ../src/common/lzmastream.cpp:342
+#: ../src/html/chm.cpp:336
+msgid "out of memory"
+msgstr "s'ha esgotat la memòria"
+
+#: ../src/common/lzmastream.cpp:276 ../src/common/lzmastream.cpp:346
+msgid "unknown compression error"
+msgstr "error de compressió desconegut"
+
+#: ../src/common/lzmastream.cpp:280
+#, c-format
+msgid "LZMA compression error: %s"
+msgstr "Error de compressió LZMA: %s"
+
+#: ../src/common/lzmastream.cpp:350
+#, c-format
+msgid "LZMA compression error when flushing output: %s"
+msgstr "Error de compressió LZMA a l'hora de buidar la sortida: %s"
+
+#: ../src/common/mimecmn.cpp:167
+#, c-format
+msgid "Unmatched '{' in an entry for mime type %s."
+msgstr "'{' no tancat en una entrada per a tipus mime %s."
+
+#: ../src/common/module.cpp:76
+#, c-format
+msgid "Circular dependency involving module \"%s\" detected."
+msgstr "S'ha detectat una dependència circular que implica el mòdul \"%s\"."
+
+#: ../src/common/module.cpp:128
+#, c-format
+msgid "Dependency \"%s\" of module \"%s\" doesn't exist."
+msgstr "La dependència \"%s\" del mòdul \"%s\" no existeix."
+
+#: ../src/common/module.cpp:137
+#, c-format
+msgid "Module \"%s\" initialization failed"
+msgstr "No s'ha pogut inicialitzar el mòdul \"%s\""
+
+#: ../src/common/msgout.cpp:96
+msgid "Message"
+msgstr "Missatge"
+
+#: ../src/common/paper.cpp:70
+msgid "Letter, 8 1/2 x 11 in"
+msgstr "Carta, 8 1/2 x 11 polz."
+
+#: ../src/common/paper.cpp:71
+msgid "Legal, 8 1/2 x 14 in"
+msgstr "Legal, 8 1/2 x 14 polz."
+
+#: ../src/common/paper.cpp:72
+msgid "A4 sheet, 210 x 297 mm"
+msgstr "Full A4, 210 x 297 mm"
+
+#: ../src/common/paper.cpp:73
+msgid "C sheet, 17 x 22 in"
+msgstr "Full C, 17 x 22 polz."
+
+#: ../src/common/paper.cpp:74
+msgid "D sheet, 22 x 34 in"
+msgstr "Full D, 22 x 34 polz."
+
+#: ../src/common/paper.cpp:75
+msgid "E sheet, 34 x 44 in"
+msgstr "Full E, 34 x 44 polz."
+
+#: ../src/common/paper.cpp:76
+msgid "Letter Small, 8 1/2 x 11 in"
+msgstr "Carta petita, 8 1/2 x 11 polz."
+
+#: ../src/common/paper.cpp:77
+msgid "Tabloid, 11 x 17 in"
+msgstr "Tabloide, 11 x 17 polz."
+
+#: ../src/common/paper.cpp:78
+msgid "Ledger, 17 x 11 in"
+msgstr "Ledger, 17 x 11 polz."
+
+#: ../src/common/paper.cpp:79
+msgid "Statement, 5 1/2 x 8 1/2 in"
+msgstr "Statement, 5 1/2 x 8 1/2 polz."
+
+#: ../src/common/paper.cpp:80
+msgid "Executive, 7 1/4 x 10 1/2 in"
+msgstr "Executiu, 7 1/4 x 10 1/2 polz."
+
+#: ../src/common/paper.cpp:81
+msgid "A3 sheet, 297 x 420 mm"
+msgstr "Full A3, 297 x 420 mm"
+
+#: ../src/common/paper.cpp:82
+msgid "A4 small sheet, 210 x 297 mm"
+msgstr "Full petit A4, 210 x 297 mm"
+
+#: ../src/common/paper.cpp:83
+msgid "A5 sheet, 148 x 210 mm"
+msgstr "Full A5, 148 x 210 mm"
+
+#: ../src/common/paper.cpp:84
+msgid "B4 sheet, 250 x 354 mm"
+msgstr "Full B4, 250 x 354 mm"
+
+#: ../src/common/paper.cpp:85
+msgid "B5 sheet, 182 x 257 millimeter"
+msgstr "Full B5, 182 x 257 mil·límetres"
+
+#: ../src/common/paper.cpp:86
+msgid "Folio, 8 1/2 x 13 in"
+msgstr "Foli, 8 1/2 x 13 polz."
+
+#: ../src/common/paper.cpp:87
+msgid "Quarto, 215 x 275 mm"
+msgstr "Quarto, 215 x 275 mm"
+
+#: ../src/common/paper.cpp:88
+msgid "10 x 14 in"
+msgstr "10 x 14 polz."
+
+#: ../src/common/paper.cpp:89
+msgid "11 x 17 in"
+msgstr "11 x 17 polz."
+
+#: ../src/common/paper.cpp:90
+msgid "Note, 8 1/2 x 11 in"
+msgstr "Nota, 8 1/2 x 11 polz."
+
+#: ../src/common/paper.cpp:91
+msgid "#9 Envelope, 3 7/8 x 8 7/8 in"
+msgstr "Sobre núm. 9, 3 7/8 x 8 7/8 polz."
+
+#: ../src/common/paper.cpp:92
+msgid "#10 Envelope, 4 1/8 x 9 1/2 in"
+msgstr "Sobre núm. 10, 4 1/8 x 9 1/2 polz."
+
+#: ../src/common/paper.cpp:93
+msgid "#11 Envelope, 4 1/2 x 10 3/8 in"
+msgstr "Sobre núm. 11, 4 1/2 x 10 3/8 polz."
+
+#: ../src/common/paper.cpp:94
+msgid "#12 Envelope, 4 3/4 x 11 in"
+msgstr "Sobre núm. 12, 4 3/4 x 11 polz."
+
+#: ../src/common/paper.cpp:95
+msgid "#14 Envelope, 5 x 11 1/2 in"
+msgstr "Sobre núm. 14, 5 x 11 1/2 polz."
+
+#: ../src/common/paper.cpp:96
+msgid "DL Envelope, 110 x 220 mm"
+msgstr "Sobre DL, 110 x 220 mm"
+
+#: ../src/common/paper.cpp:97
+msgid "C5 Envelope, 162 x 229 mm"
+msgstr "Sobre C5, 162 x 229 mm"
+
+#: ../src/common/paper.cpp:98
+msgid "C3 Envelope, 324 x 458 mm"
+msgstr "Sobre C3, 324 x 458 mm"
+
+#: ../src/common/paper.cpp:99
+msgid "C4 Envelope, 229 x 324 mm"
+msgstr "Sobre C4, 229 x 324 mm"
+
+#: ../src/common/paper.cpp:100
+msgid "C6 Envelope, 114 x 162 mm"
+msgstr "Sobre C6, 114 x 162 mm"
+
+#: ../src/common/paper.cpp:101
+msgid "C65 Envelope, 114 x 229 mm"
+msgstr "Sobre C65, 114 x 229 mm"
+
+#: ../src/common/paper.cpp:102
+msgid "B4 Envelope, 250 x 353 mm"
+msgstr "Sobre B4, 250 x 353 mm"
+
+#: ../src/common/paper.cpp:103
+msgid "B5 Envelope, 176 x 250 mm"
+msgstr "Sobre B5, 176 x 250 mm"
+
+#: ../src/common/paper.cpp:104
+msgid "B6 Envelope, 176 x 125 mm"
+msgstr "Sobre B6, 176 x 125 mm"
+
+#: ../src/common/paper.cpp:105
+msgid "Italy Envelope, 110 x 230 mm"
+msgstr "Sobre italià, 110 x 230 mm"
+
+#: ../src/common/paper.cpp:106
+msgid "Monarch Envelope, 3 7/8 x 7 1/2 in"
+msgstr "Sobre Monarch, 3 7/8 x 7 1/2 polz."
+
+#: ../src/common/paper.cpp:107
+msgid "6 3/4 Envelope, 3 5/8 x 6 1/2 in"
+msgstr "Sobre 6 3/4, 3 5/8 x 6 1/2 polz."
+
+#: ../src/common/paper.cpp:108
+msgid "US Std Fanfold, 14 7/8 x 11 in"
+msgstr "US Std Fanfold, 14 7/8 x 11 polz."
+
+#: ../src/common/paper.cpp:109
+msgid "German Std Fanfold, 8 1/2 x 12 in"
+msgstr "German Std Fanfold, 8 1/2 x 12 polz."
+
+#: ../src/common/paper.cpp:110
+msgid "German Legal Fanfold, 8 1/2 x 13 in"
+msgstr "German Legal Fanfold, 8 1/2 x 13 polz."
+
+#: ../src/common/paper.cpp:112
+msgid "B4 (ISO) 250 x 353 mm"
+msgstr "B4 (ISO), 250 x 353 mm"
+
+#: ../src/common/paper.cpp:113
+msgid "Japanese Postcard 100 x 148 mm"
+msgstr "Postal japonesa, 100 x 148 mm"
+
+#: ../src/common/paper.cpp:114
+msgid "9 x 11 in"
+msgstr "9 x 11 polz."
+
+#: ../src/common/paper.cpp:115
+msgid "10 x 11 in"
+msgstr "10 x 11 polz."
+
+#: ../src/common/paper.cpp:116
+msgid "15 x 11 in"
+msgstr "15 x 11 polz."
+
+#: ../src/common/paper.cpp:117
+msgid "Envelope Invite 220 x 220 mm"
+msgstr "Sobre d'invitació, 220 x 220 mm"
+
+#: ../src/common/paper.cpp:118
+msgid "Letter Extra 9 1/2 x 12 in"
+msgstr "Carta extra, 9 1/2 x 12 polz."
+
+#: ../src/common/paper.cpp:119
+msgid "Legal Extra 9 1/2 x 15 in"
+msgstr "Legal extra, 9 1/2 x 15 polz."
+
+#: ../src/common/paper.cpp:120
+msgid "Tabloid Extra 11.69 x 18 in"
+msgstr "Tabloide extra, 11,69 x 18 polz."
+
+#: ../src/common/paper.cpp:121
+msgid "A4 Extra 9.27 x 12.69 in"
+msgstr "A4 extra, 9,27 x 12,69 polz."
+
+#: ../src/common/paper.cpp:122
+msgid "Letter Transverse 8 1/2 x 11 in"
+msgstr "Carta transversal, 8 1/2 x 11 polz."
+
+#: ../src/common/paper.cpp:123
+msgid "A4 Transverse 210 x 297 mm"
+msgstr "A4 transversal, 210 x 297 mm"
+
+#: ../src/common/paper.cpp:124
+msgid "Letter Extra Transverse 9.275 x 12 in"
+msgstr "Carta extra transversal, 9,275 x 12 polz."
+
+#: ../src/common/paper.cpp:125
+msgid "SuperA/SuperA/A4 227 x 356 mm"
+msgstr "SuperA/SuperA/A4, 227 x 356 mm"
+
+#: ../src/common/paper.cpp:126
+msgid "SuperB/SuperB/A3 305 x 487 mm"
+msgstr "SuperB/SuperB/A3, 305 x 487 mm"
+
+#: ../src/common/paper.cpp:127
+msgid "Letter Plus 8 1/2 x 12.69 in"
+msgstr "Carta plus, 8 1/2 x 12,69 polz."
+
+#: ../src/common/paper.cpp:128
+msgid "A4 Plus 210 x 330 mm"
+msgstr "A4 plus, 210 x 330 mm"
+
+#: ../src/common/paper.cpp:129
+msgid "A5 Transverse 148 x 210 mm"
+msgstr "A5 transversal, 148 x 210 mm"
+
+#: ../src/common/paper.cpp:130
+msgid "B5 (JIS) Transverse 182 x 257 mm"
+msgstr "B5 (JIS) transversal, 182 x 257 mm"
+
+#: ../src/common/paper.cpp:131
+msgid "A3 Extra 322 x 445 mm"
+msgstr "A3 extra, 322 x 445 mm"
+
+#: ../src/common/paper.cpp:132
+msgid "A5 Extra 174 x 235 mm"
+msgstr "A5 extra, 174 x 235 mm"
+
+#: ../src/common/paper.cpp:133
+msgid "B5 (ISO) Extra 201 x 276 mm"
+msgstr "B5 (ISO) extra, 201 x 276 mm"
+
+#: ../src/common/paper.cpp:134
+msgid "A2 420 x 594 mm"
+msgstr "A2, 420 x 594 mm"
+
+#: ../src/common/paper.cpp:135
+msgid "A3 Transverse 297 x 420 mm"
+msgstr "A3 transversal, 297 x 420 mm"
+
+#: ../src/common/paper.cpp:136
+msgid "A3 Extra Transverse 322 x 445 mm"
+msgstr "A3 extra transversal, 322 x 445 mm"
+
+#: ../src/common/paper.cpp:138
+msgid "Japanese Double Postcard 200 x 148 mm"
+msgstr "Postal japonesa doble, 200 x 148 mm"
+
+#: ../src/common/paper.cpp:139
+msgid "A6 105 x 148 mm"
+msgstr "A6, 105 x 148 mm"
+
+#: ../src/common/paper.cpp:140
+msgid "Japanese Envelope Kaku #2"
+msgstr "Sobre japonès Kaku núm. 2"
+
+#: ../src/common/paper.cpp:141
+msgid "Japanese Envelope Kaku #3"
+msgstr "Sobre japonès Kaku núm. 3"
+
+#: ../src/common/paper.cpp:142
+msgid "Japanese Envelope Chou #3"
+msgstr "Sobre japonès Chou núm. 3"
+
+#: ../src/common/paper.cpp:143
+msgid "Japanese Envelope Chou #4"
+msgstr "Sobre japonès Chou núm. 4"
+
+#: ../src/common/paper.cpp:144
+msgid "Letter Rotated 11 x 8 1/2 in"
+msgstr "Carta girada, 11 x 8 1/2 polz."
+
+#: ../src/common/paper.cpp:145
+msgid "A3 Rotated 420 x 297 mm"
+msgstr "A3 girat, 420 x 297 mm"
+
+#: ../src/common/paper.cpp:146
+msgid "A4 Rotated 297 x 210 mm"
+msgstr "A4 girat, 297 x 210 mm"
+
+#: ../src/common/paper.cpp:147
+msgid "A5 Rotated 210 x 148 mm"
+msgstr "A5 girat, 210 x 148 mm"
+
+#: ../src/common/paper.cpp:148
+msgid "B4 (JIS) Rotated 364 x 257 mm"
+msgstr "B4 (JIS) girat, 364 x 257 mm"
+
+#: ../src/common/paper.cpp:149
+msgid "B5 (JIS) Rotated 257 x 182 mm"
+msgstr "B5 (JIS) girat, 257 x 182 mm"
+
+#: ../src/common/paper.cpp:150
+msgid "Japanese Postcard Rotated 148 x 100 mm"
+msgstr "Postal japonesa girada, 148 x 100 mm"
+
+#: ../src/common/paper.cpp:151
+msgid "Double Japanese Postcard Rotated 148 x 200 mm"
+msgstr "Targeta postal japonesa doble girada, 148 x 200 mm"
+
+#: ../src/common/paper.cpp:152
+msgid "A6 Rotated 148 x 105 mm"
+msgstr "A6 girat, 148 x 105 mm"
+
+#: ../src/common/paper.cpp:153
+msgid "Japanese Envelope Kaku #2 Rotated"
+msgstr "Sobre japonès Kaku núm. 2 girat"
+
+#: ../src/common/paper.cpp:154
+msgid "Japanese Envelope Kaku #3 Rotated"
+msgstr "Sobre japonès Kaku núm. 3 girat"
+
+#: ../src/common/paper.cpp:155
+msgid "Japanese Envelope Chou #3 Rotated"
+msgstr "Sobre japonès Chou núm. 3 girat"
+
+#: ../src/common/paper.cpp:156
+msgid "Japanese Envelope Chou #4 Rotated"
+msgstr "Sobre japonès Chou núm. 4 girat"
+
+#: ../src/common/paper.cpp:157
+msgid "B6 (JIS) 128 x 182 mm"
+msgstr "B6 (JIS), 128 x 182 mm"
+
+#: ../src/common/paper.cpp:158
+msgid "B6 (JIS) Rotated 182 x 128 mm"
+msgstr "B6 (JIS) girat, 182 x 128 mm"
+
+#: ../src/common/paper.cpp:159
+msgid "12 x 11 in"
+msgstr "12 x 11 polz."
+
+#: ../src/common/paper.cpp:160
+msgid "Japanese Envelope You #4"
+msgstr "Sobre japonès You núm. 4"
+
+#: ../src/common/paper.cpp:161
+msgid "Japanese Envelope You #4 Rotated"
+msgstr "Sobre japonès You núm. 4 girat"
+
+#: ../src/common/paper.cpp:162
+msgid "PRC 16K 146 x 215 mm"
+msgstr "PRC 16K, 146 x 215 mm"
+
+#: ../src/common/paper.cpp:163
+msgid "PRC 32K 97 x 151 mm"
+msgstr "PRC 32K, 97 x 151 mm"
+
+#: ../src/common/paper.cpp:164
+msgid "PRC 32K(Big) 97 x 151 mm"
+msgstr "PRC 32K (Gros), 97 x 151 mm"
+
+#: ../src/common/paper.cpp:165
+msgid "PRC Envelope #1 102 x 165 mm"
+msgstr "Sobre PRC núm. 1, 114 x 162 mm"
+
+#: ../src/common/paper.cpp:166
+msgid "PRC Envelope #2 102 x 176 mm"
+msgstr "Sobre PRC núm. 2, 102 x 176 mm"
+
+#: ../src/common/paper.cpp:167
+msgid "PRC Envelope #3 125 x 176 mm"
+msgstr "Sobre PRC núm. 3, 125 x 176 mm"
+
+#: ../src/common/paper.cpp:168
+msgid "PRC Envelope #4 110 x 208 mm"
+msgstr "Sobre PRC núm. 4, 110 x 208 mm"
+
+#: ../src/common/paper.cpp:169
+msgid "PRC Envelope #5 110 x 220 mm"
+msgstr "Sobre PRC núm. 5, 110 x 220 mm"
+
+#: ../src/common/paper.cpp:170
+msgid "PRC Envelope #6 120 x 230 mm"
+msgstr "Sobre PRC núm. 6, 120 x 230 mm"
+
+#: ../src/common/paper.cpp:171
+msgid "PRC Envelope #7 160 x 230 mm"
+msgstr "Sobre PRC núm. 7, 160 x 230 mm"
+
+#: ../src/common/paper.cpp:172
+msgid "PRC Envelope #8 120 x 309 mm"
+msgstr "Sobre PRC núm. 8, 120 x 309 mm"
+
+#: ../src/common/paper.cpp:173
+msgid "PRC Envelope #9 229 x 324 mm"
+msgstr "Sobre PRC núm. 9, 229 x 324 mm"
+
+#: ../src/common/paper.cpp:174
+msgid "PRC Envelope #10 324 x 458 mm"
+msgstr "Sobre PRC núm. 10, 324 x 458 mm"
+
+#: ../src/common/paper.cpp:175
+msgid "PRC 16K Rotated"
+msgstr "PRC 16K girat"
+
+#: ../src/common/paper.cpp:176
+msgid "PRC 32K Rotated"
+msgstr "PRC 32K girat"
+
+#: ../src/common/paper.cpp:177
+msgid "PRC 32K(Big) Rotated"
+msgstr "PRC 32K (Gros) girat"
+
+#: ../src/common/paper.cpp:178
+msgid "PRC Envelope #1 Rotated 165 x 102 mm"
+msgstr "Sobre PRC núm. 1 girat, 165 x 102 mm"
+
+#: ../src/common/paper.cpp:179
+msgid "PRC Envelope #2 Rotated 176 x 102 mm"
+msgstr "Sobre PRC núm. 2 girat, 176 x 102 mm"
+
+#: ../src/common/paper.cpp:180
+msgid "PRC Envelope #3 Rotated 176 x 125 mm"
+msgstr "Sobre PRC núm. 3 girat, 176 x 125 mm"
+
+#: ../src/common/paper.cpp:181
+msgid "PRC Envelope #4 Rotated 208 x 110 mm"
+msgstr "Sobre PRC núm. 4 girat, 208 x 110 mm"
+
+#: ../src/common/paper.cpp:182
+msgid "PRC Envelope #5 Rotated 220 x 110 mm"
+msgstr "Sobre PRC núm. 5 girat, 220 x 110 mm"
+
+#: ../src/common/paper.cpp:183
+msgid "PRC Envelope #6 Rotated 230 x 120 mm"
+msgstr "Sobre PRC núm. 6 girat, 230 x 120 mm"
+
+#: ../src/common/paper.cpp:184
+msgid "PRC Envelope #7 Rotated 230 x 160 mm"
+msgstr "Sobre PRC núm. 7 girat, 230 x 160 mm"
+
+#: ../src/common/paper.cpp:185
+msgid "PRC Envelope #8 Rotated 309 x 120 mm"
+msgstr "Sobre PRC núm. 8 girat, 309 x 120 mm"
+
+#: ../src/common/paper.cpp:186
+msgid "PRC Envelope #9 Rotated 324 x 229 mm"
+msgstr "Sobre PRC núm. 9 girat, 324 x 229 mm"
+
+#: ../src/common/paper.cpp:187
+msgid "PRC Envelope #10 Rotated 458 x 324 mm"
+msgstr "Sobre PRC núm. 10 girat, 458 x 324 mm"
+
+#: ../src/common/paper.cpp:192
+msgid "A0 sheet, 841 x 1189 mm"
+msgstr "Full A0, 841 x 1189 mm"
+
+#: ../src/common/paper.cpp:193
+msgid "A1 sheet, 594 x 841 mm"
+msgstr "Full A1, 594 x 841 mm"
+
+#: ../src/common/preferencescmn.cpp:37
+msgid "General"
+msgstr "General"
+
+#: ../src/common/preferencescmn.cpp:40
+msgid "Advanced"
+msgstr "Avançat"
+
+#: ../src/common/prntbase.cpp:245
+msgid "Generic PostScript"
+msgstr "PostScript genèric"
+
+#: ../src/common/prntbase.cpp:259
+msgid "Ready"
+msgstr "Llest"
+
+#: ../src/common/prntbase.cpp:331
+msgid "Printing Error"
+msgstr "S'ha produït un error d'impressió"
+
+#: ../src/common/prntbase.cpp:413 ../src/common/prntbase.cpp:1597
+#: ../src/generic/prntdlgg.cpp:135 ../src/generic/prntdlgg.cpp:149
+#: ../src/gtk/print.cpp:628 ../src/gtk/print.cpp:646
+msgid "Print"
+msgstr "Imprimeix"
+
+#: ../src/common/prntbase.cpp:471 ../src/generic/prntdlgg.cpp:809
+msgid "Page setup"
+msgstr "Configuració de la pàgina"
+
+#: ../src/common/prntbase.cpp:525
+msgid "Please wait while printing..."
+msgstr "Espereu mentre s'imprimeix..."
+
+#: ../src/common/prntbase.cpp:529
+msgid "Document:"
+msgstr "Document:"
+
+#: ../src/common/prntbase.cpp:532
+msgid "Progress:"
+msgstr "Progrés:"
+
+#: ../src/common/prntbase.cpp:533
+msgid "Preparing"
+msgstr "S'està preparant"
+
+#: ../src/common/prntbase.cpp:552
+#, c-format
+msgid "Printing page %d"
+msgstr "S'està imprimint la pàgina %d"
+
+#: ../src/common/prntbase.cpp:557
+#, c-format
+msgid "Printing page %d of %d"
+msgstr "S'està imprimint la pàgina %d de %d"
+
+#: ../src/common/prntbase.cpp:560
+#, c-format
+msgid " (copy %d of %d)"
+msgstr " (còpia %d de %d)"
+
+#: ../src/common/prntbase.cpp:1604
+msgid "First page"
+msgstr "Primera pàgina"
+
+#: ../src/common/prntbase.cpp:1609 ../src/html/helpwnd.cpp:659
+msgid "Previous page"
+msgstr "Pàgina anterior"
+
+#: ../src/common/prntbase.cpp:1623 ../src/html/helpwnd.cpp:660
+msgid "Next page"
+msgstr "Pàgina següent"
+
+#: ../src/common/prntbase.cpp:1628
+msgid "Last page"
+msgstr "Última pàgina"
+
+#: ../src/common/prntbase.cpp:1636 ../src/common/stockitem.cpp:215
+msgid "Zoom Out"
+msgstr "Allunya"
+
+#: ../src/common/prntbase.cpp:1650 ../src/common/stockitem.cpp:214
+msgid "Zoom In"
+msgstr "Amplia"
+
+#: ../src/common/prntbase.cpp:1656 ../src/common/stockitem.cpp:153
+#: ../src/generic/logg.cpp:553 ../src/univ/themes/win32.cpp:3752
+msgid "&Close"
+msgstr "Tan&ca"
+
+#: ../src/common/prntbase.cpp:2085
+msgid "Could not start document preview."
+msgstr "No s'ha pogut iniciar la previsualització del document."
+
+#: ../src/common/prntbase.cpp:2085 ../src/common/prntbase.cpp:2129
+#: ../src/common/prntbase.cpp:2137
+msgid "Print Preview Failure"
+msgstr "S'ha produït un error en la previsualització de la impressió"
+
+#: ../src/common/prntbase.cpp:2129 ../src/common/prntbase.cpp:2137
+msgid "Sorry, not enough memory to create a preview."
+msgstr "No hi ha prou memòria per a crear una previsualització."
+
+#: ../src/common/prntbase.cpp:2144
+#, c-format
+msgid "Page %d of %d"
+msgstr "Pàgina %d de %d"
+
+#: ../src/common/prntbase.cpp:2146
+#, c-format
+msgid "Page %d"
+msgstr "Pàgina %d"
+
+#: ../src/common/regex.cpp:382 ../src/html/chm.cpp:348
+msgid "unknown error"
+msgstr "s'ha produït un error desconegut"
+
+#: ../src/common/regex.cpp:995
+#, c-format
+msgid "Invalid regular expression '%s': %s"
+msgstr "Expressió regular invàlida '%s': %s"
+
+#: ../src/common/regex.cpp:1059
+#, c-format
+msgid "Failed to find match for regular expression: %s"
+msgstr "No s'ha pogut trobar cap coincidència per a l'expressió regular: %s"
+
+#: ../src/common/rendcmn.cpp:188
+#, c-format
+msgid "Renderer \"%s\" has incompatible version %d.%d and couldn't be loaded."
+msgstr ""
+"El renderitzador \"%s\" té la versió incompatible %d.%d i no s'ha pogut "
+"carregar."
+
+#: ../src/common/secretstore.cpp:162
+msgid "Not available for this platform"
+msgstr "No disponible per aquesta plataforma"
+
+#: ../src/common/secretstore.cpp:183
+#, c-format
+msgid "Saving password for \"%s\" failed: %s."
+msgstr "No s'ha pogut desar la clau d'accés per \"%s\": %s."
+
+#: ../src/common/secretstore.cpp:205
+#, c-format
+msgid "Reading password for \"%s\" failed: %s."
+msgstr "No s'ha pogut llegir la clau d'accés per \"%s\": %s."
+
+#: ../src/common/secretstore.cpp:228
+#, c-format
+msgid "Deleting password for \"%s\" failed: %s."
+msgstr "No s'ha pogut suprimir la clau d'accés per \"%s\": %s."
+
+#: ../src/common/selectdispatcher.cpp:254
+msgid "Failed to monitor I/O channels"
+msgstr "No s'han pogut supervisar els canals d'E/S"
+
+#: ../src/common/sizer.cpp:3054 ../src/common/stockitem.cpp:195
+msgid "Save"
+msgstr "Desa"
+
+#: ../src/common/sizer.cpp:3056
+msgid "Don't Save"
+msgstr "No desis"
+
+#: ../src/common/socket.cpp:870
+msgid "Cannot initialize sockets"
+msgstr "No es poden inicialitzar els sòcols"
+
+#: ../src/common/stockitem.cpp:127
+msgctxt "standard Windows menu"
+msgid "&Help"
+msgstr "&Ajuda"
+
+#: ../src/common/stockitem.cpp:144
+msgid "&About"
+msgstr "Qu&ant a"
+
+#: ../src/common/stockitem.cpp:144
+msgid "About"
+msgstr "Quant a"
+
+#: ../src/common/stockitem.cpp:145
+msgid "Add"
+msgstr "Suma"
+
+#: ../src/common/stockitem.cpp:146
+msgid "&Apply"
+msgstr "&Aplica"
+
+#: ../src/common/stockitem.cpp:146
+msgid "Apply"
+msgstr "Aplica"
+
+#: ../src/common/stockitem.cpp:147
+msgid "&Back"
+msgstr "&Endarrere"
+
+#: ../src/common/stockitem.cpp:147
+msgid "Back"
+msgstr "Endarrere"
+
+#: ../src/common/stockitem.cpp:148
+msgid "&Bold"
+msgstr "&Negreta"
+
+#: ../src/common/stockitem.cpp:148 ../src/generic/fontdlgg.cpp:326
+#: ../src/richtext/richtextfontpage.cpp:354
+msgid "Bold"
+msgstr "Negreta"
+
+#: ../src/common/stockitem.cpp:149
+msgid "&Bottom"
+msgstr "&Inferior"
+
+#: ../src/common/stockitem.cpp:149 ../src/richtext/richtextsizepage.cpp:287
+msgid "Bottom"
+msgstr "Inferior"
+
+#: ../src/common/stockitem.cpp:150 ../src/generic/fontdlgg.cpp:462
+#: ../src/generic/fontdlgg.cpp:481 ../src/generic/wizard.cpp:415
+msgid "&Cancel"
+msgstr "&Cancel·la"
+
+#: ../src/common/stockitem.cpp:151
+msgid "&CD-ROM"
+msgstr "&CD-ROM"
+
+#: ../src/common/stockitem.cpp:151
+msgid "CD-ROM"
+msgstr "CD-ROM"
+
+#: ../src/common/stockitem.cpp:152
+msgid "&Clear"
+msgstr "&Neteja"
+
+#: ../src/common/stockitem.cpp:152
+msgid "Clear"
+msgstr "Neteja"
+
+#: ../src/common/stockitem.cpp:153 ../src/generic/dbgrptg.cpp:93
+#: ../src/generic/progdlgg.cpp:778 ../src/html/helpdlg.cpp:86
+#: ../src/msw/progdlg.cpp:209 ../src/msw/progdlg.cpp:890
+#: ../src/richtext/richtextstyledlg.cpp:272
+#: ../src/richtext/richtextsymboldlg.cpp:448
+msgid "Close"
+msgstr "Tanca"
+
+#: ../src/common/stockitem.cpp:154
+msgid "&Convert"
+msgstr "&Converteix"
+
+#: ../src/common/stockitem.cpp:154
+msgid "Convert"
+msgstr "Converteix"
+
+#: ../src/common/stockitem.cpp:155 ../src/msw/textctrl.cpp:2884
+#: ../src/osx/textctrl_osx.cpp:653 ../src/richtext/richtextctrl.cpp:331
+msgid "&Copy"
+msgstr "&Copia"
+
+#: ../src/common/stockitem.cpp:155 ../src/stc/stc_i18n.cpp:18
+msgid "Copy"
+msgstr "Copia"
+
+#: ../src/common/stockitem.cpp:156 ../src/msw/textctrl.cpp:2883
+#: ../src/osx/textctrl_osx.cpp:652 ../src/richtext/richtextctrl.cpp:330
+msgid "Cu&t"
+msgstr "Re&talla"
+
+#: ../src/common/stockitem.cpp:156 ../src/stc/stc_i18n.cpp:17
+msgid "Cut"
+msgstr "Retalla"
+
+#: ../src/common/stockitem.cpp:157 ../src/msw/textctrl.cpp:2886
+#: ../src/osx/textctrl_osx.cpp:655 ../src/richtext/richtextctrl.cpp:333
+#: ../src/richtext/richtexttabspage.cpp:137
+msgid "&Delete"
+msgstr "&Suprimeix"
+
+#: ../src/common/stockitem.cpp:157 ../src/richtext/richtextbuffer.cpp:8266
+#: ../src/stc/stc_i18n.cpp:20
+msgid "Delete"
+msgstr "Suprimeix"
+
+#: ../src/common/stockitem.cpp:158
+msgid "&Down"
+msgstr "A&vall"
+
+#: ../src/common/stockitem.cpp:158 ../src/generic/fdrepdlg.cpp:148
+msgid "Down"
+msgstr "Avall"
+
+#: ../src/common/stockitem.cpp:159
+msgid "&Edit"
+msgstr "&Edita"
+
+#: ../src/common/stockitem.cpp:159
+msgid "Edit"
+msgstr "Edita"
+
+#: ../src/common/stockitem.cpp:160
+msgid "&Execute"
+msgstr "&Executa"
+
+#: ../src/common/stockitem.cpp:160
+msgid "Execute"
+msgstr "Executa"
+
+#: ../src/common/stockitem.cpp:161
+msgid "&Quit"
+msgstr "&Surt"
+
+#: ../src/common/stockitem.cpp:161
+msgid "Quit"
+msgstr "Surt"
+
+#: ../src/common/stockitem.cpp:162
+msgid "&File"
+msgstr "&Fitxer"
+
+#: ../src/common/stockitem.cpp:162
+msgid "File"
+msgstr "Fitxer"
+
+#: ../src/common/stockitem.cpp:163
+msgid "&Find..."
+msgstr "&Cerca..."
+
+#: ../src/common/stockitem.cpp:163
+msgid "Find..."
+msgstr "Cerca..."
+
+#: ../src/common/stockitem.cpp:164
+msgid "&First"
+msgstr "&Primer"
+
+#: ../src/common/stockitem.cpp:164
+msgid "First"
+msgstr "Primer"
+
+#: ../src/common/stockitem.cpp:165
+msgid "&Floppy"
+msgstr "&Disquet"
+
+#: ../src/common/stockitem.cpp:165
+msgid "Floppy"
+msgstr "Disquet"
+
+#: ../src/common/stockitem.cpp:166
+msgid "&Forward"
+msgstr "Enda&vant"
+
+#: ../src/common/stockitem.cpp:166
+msgid "Forward"
+msgstr "Endavant"
+
+#: ../src/common/stockitem.cpp:167
+msgid "&Harddisk"
+msgstr "&Disc dur"
+
+#: ../src/common/stockitem.cpp:167
+msgid "Harddisk"
+msgstr "Disc dur"
+
+#: ../src/common/stockitem.cpp:168 ../src/generic/wizard.cpp:418
+#: ../src/osx/cocoa/menu.mm:225 ../src/richtext/richtextstyledlg.cpp:298
+#: ../src/richtext/richtextsymboldlg.cpp:451
+msgid "&Help"
+msgstr "&Ajuda"
+
+#: ../src/common/stockitem.cpp:169
+msgid "&Home"
+msgstr "&Inici"
+
+#: ../src/common/stockitem.cpp:169
+msgid "Home"
+msgstr "Inici"
+
+#: ../src/common/stockitem.cpp:170
+msgid "Indent"
+msgstr "Sagnat"
+
+#: ../src/common/stockitem.cpp:171
+msgid "&Index"
+msgstr "Í&ndex"
+
+#: ../src/common/stockitem.cpp:171 ../src/html/helpwnd.cpp:510
+msgid "Index"
+msgstr "Índex"
+
+#: ../src/common/stockitem.cpp:172
+msgid "&Info"
+msgstr "&Informació"
+
+#: ../src/common/stockitem.cpp:172
+msgid "Info"
+msgstr "Informació"
+
+#: ../src/common/stockitem.cpp:173
+msgid "&Italic"
+msgstr "Curs&iva"
+
+#: ../src/common/stockitem.cpp:173 ../src/generic/fontdlgg.cpp:322
+#: ../src/richtext/richtextfontpage.cpp:350
+msgid "Italic"
+msgstr "Cursiva"
+
+#: ../src/common/stockitem.cpp:174
+msgid "&Jump to"
+msgstr "&Vés a"
+
+#: ../src/common/stockitem.cpp:174
+msgid "Jump to"
+msgstr "Vés a"
+
+#: ../src/common/stockitem.cpp:175
+msgid "Centered"
+msgstr "Centrat"
+
+#: ../src/common/stockitem.cpp:176
+msgid "Justified"
+msgstr "Justificat"
+
+#: ../src/common/stockitem.cpp:177
+msgid "Align Left"
+msgstr "Alinea a l'esquerra"
+
+#: ../src/common/stockitem.cpp:178
+msgid "Align Right"
+msgstr "Alinea a la dreta"
+
+#: ../src/common/stockitem.cpp:179
+msgid "&Last"
+msgstr "Ú&ltim"
+
+#: ../src/common/stockitem.cpp:179
+msgid "Last"
+msgstr "Últim"
+
+#: ../src/common/stockitem.cpp:180
+msgid "&Network"
+msgstr "&Xarxa"
+
+#: ../src/common/stockitem.cpp:180
+msgid "Network"
+msgstr "Xarxa"
+
+#: ../src/common/stockitem.cpp:181 ../src/richtext/richtexttabspage.cpp:131
+msgid "&New"
+msgstr "&Nou"
+
+#: ../src/common/stockitem.cpp:181
+msgid "New"
+msgstr "Nou"
+
+#: ../src/common/stockitem.cpp:182 ../src/msw/msgdlg.cpp:417
+msgid "&No"
+msgstr "&No"
+
+#: ../src/common/stockitem.cpp:183 ../src/generic/fontdlgg.cpp:467
+#: ../src/generic/fontdlgg.cpp:474
+msgid "&OK"
+msgstr "D'ac&ord"
+
+#: ../src/common/stockitem.cpp:184 ../src/generic/dbgrptg.cpp:341
+msgid "&Open..."
+msgstr "&Obre..."
+
+#: ../src/common/stockitem.cpp:184
+msgid "Open..."
+msgstr "Obre..."
+
+#: ../src/common/stockitem.cpp:185 ../src/msw/textctrl.cpp:2885
+#: ../src/osx/textctrl_osx.cpp:654 ../src/richtext/richtextctrl.cpp:332
+msgid "&Paste"
+msgstr "&Enganxa"
+
+#: ../src/common/stockitem.cpp:185 ../src/richtext/richtextctrl.cpp:3484
+#: ../src/stc/stc_i18n.cpp:19
+msgid "Paste"
+msgstr "Enganxa"
+
+#: ../src/common/stockitem.cpp:186
+msgid "&Preferences"
+msgstr "&Preferències"
+
+#: ../src/common/stockitem.cpp:186 ../src/osx/cocoa/preferences.mm:304
+msgid "Preferences"
+msgstr "Preferències"
+
+#: ../src/common/stockitem.cpp:187
+msgid "Print previe&w..."
+msgstr "Pre&visualitza la impressió..."
+
+#: ../src/common/stockitem.cpp:187
+msgid "Print preview..."
+msgstr "Previsualització de la impressió..."
+
+#: ../src/common/stockitem.cpp:188
+msgid "&Print..."
+msgstr "Im&primeix..."
+
+#: ../src/common/stockitem.cpp:188
+msgid "Print..."
+msgstr "Imprimeix..."
+
+#: ../src/common/stockitem.cpp:189 ../src/richtext/richtextctrl.cpp:337
+#: ../src/richtext/richtextctrl.cpp:5479
+msgid "&Properties"
+msgstr "&Propietats"
+
+#: ../src/common/stockitem.cpp:189
+msgid "Properties"
+msgstr "Propietats"
+
+#: ../src/common/stockitem.cpp:190 ../src/stc/stc_i18n.cpp:16
+msgid "Redo"
+msgstr "Refés"
+
+#: ../src/common/stockitem.cpp:191
+msgid "Refresh"
+msgstr "Refresca"
+
+#: ../src/common/stockitem.cpp:192
+msgid "Remove"
+msgstr "Suprimeix"
+
+#: ../src/common/stockitem.cpp:193
+msgid "Rep&lace..."
+msgstr "Su&bstitueix..."
+
+#: ../src/common/stockitem.cpp:193
+msgid "Replace..."
+msgstr "Substitueix..."
+
+#: ../src/common/stockitem.cpp:194
+msgid "Revert to Saved"
+msgstr "Reverteix a la versió desada"
+
+#: ../src/common/stockitem.cpp:196 ../src/generic/logg.cpp:549
+msgid "Save &As..."
+msgstr "&Anomena i desa..."
+
+#: ../src/common/stockitem.cpp:196
+msgid "Save As..."
+msgstr "Anomena i desa..."
+
+#: ../src/common/stockitem.cpp:197 ../src/msw/textctrl.cpp:2888
+#: ../src/osx/textctrl_osx.cpp:657 ../src/richtext/richtextctrl.cpp:335
+msgid "Select &All"
+msgstr "Seleccion&a-ho tot"
+
+#: ../src/common/stockitem.cpp:197 ../src/stc/stc_i18n.cpp:21
+msgid "Select All"
+msgstr "Selecciona-ho tot"
+
+#: ../src/common/stockitem.cpp:198
+msgid "&Color"
+msgstr "&Color"
+
+#: ../src/common/stockitem.cpp:198
+msgid "Color"
+msgstr "Color"
+
+#: ../src/common/stockitem.cpp:199
+msgid "&Font"
+msgstr "&Tipus de lletra"
+
+#: ../src/common/stockitem.cpp:199 ../src/richtext/richtextformatdlg.cpp:336
+msgid "Font"
+msgstr "Tipus de lletra"
+
+#: ../src/common/stockitem.cpp:200
+msgid "&Ascending"
+msgstr "&Ascendent"
+
+#: ../src/common/stockitem.cpp:200
+msgid "Ascending"
+msgstr "Ascendent"
+
+#: ../src/common/stockitem.cpp:201
+msgid "&Descending"
+msgstr "&Descendent"
+
+#: ../src/common/stockitem.cpp:201
+msgid "Descending"
+msgstr "Descendent"
+
+#: ../src/common/stockitem.cpp:202
+msgid "&Spell Check"
+msgstr "&Comprova l'ortografia"
+
+#: ../src/common/stockitem.cpp:202
+msgid "Spell Check"
+msgstr "Comprovació ortogràfica"
+
+#: ../src/common/stockitem.cpp:203
+msgid "&Stop"
+msgstr "A&tura"
+
+#: ../src/common/stockitem.cpp:203
+msgid "Stop"
+msgstr "Atura"
+
+#: ../src/common/stockitem.cpp:204 ../src/richtext/richtextfontpage.cpp:274
+msgid "&Strikethrough"
+msgstr "&Ratllat"
+
+#: ../src/common/stockitem.cpp:204
+msgid "Strikethrough"
+msgstr "Ratllat"
+
+#: ../src/common/stockitem.cpp:205
+msgid "&Top"
+msgstr "Dal&t de tot"
+
+#: ../src/common/stockitem.cpp:205 ../src/richtext/richtextsizepage.cpp:285
+#: ../src/richtext/richtextsizepage.cpp:289
+msgid "Top"
+msgstr "Superior"
+
+#: ../src/common/stockitem.cpp:206
+msgid "Undelete"
+msgstr "Desfés la supressió"
+
+#: ../src/common/stockitem.cpp:207 ../src/generic/fontdlgg.cpp:437
+msgid "&Underline"
+msgstr "S&ubratllat"
+
+#: ../src/common/stockitem.cpp:207
+msgid "Underline"
+msgstr "Subratlla"
+
+#: ../src/common/stockitem.cpp:208 ../src/stc/stc_i18n.cpp:15
+msgid "Undo"
+msgstr "Desfés"
+
+#: ../src/common/stockitem.cpp:209
+msgid "&Unindent"
+msgstr "Desfés el sa&gnat"
+
+#: ../src/common/stockitem.cpp:209
+msgid "Unindent"
+msgstr "Desfés el sagnat"
+
+#: ../src/common/stockitem.cpp:210
+msgid "&Up"
+msgstr "Am&unt"
+
+#: ../src/common/stockitem.cpp:210 ../src/generic/fdrepdlg.cpp:148
+msgid "Up"
+msgstr "Amunt"
+
+#: ../src/common/stockitem.cpp:211 ../src/msw/msgdlg.cpp:417
+msgid "&Yes"
+msgstr "&Sí"
+
+#: ../src/common/stockitem.cpp:212
+msgid "&Actual Size"
+msgstr "Mid&a real"
+
+#: ../src/common/stockitem.cpp:212
+msgid "Actual Size"
+msgstr "Mida real"
+
+#: ../src/common/stockitem.cpp:213
+msgid "Zoom to &Fit"
+msgstr "Amplia &fins a ajustar"
+
+#: ../src/common/stockitem.cpp:213
+msgid "Zoom to Fit"
+msgstr "Amplia fins a ajustar"
+
+#: ../src/common/stockitem.cpp:214
+msgid "Zoom &In"
+msgstr "Ampl&ia"
+
+#: ../src/common/stockitem.cpp:215
+msgid "Zoom &Out"
+msgstr "All&unya"
+
+#: ../src/common/stockitem.cpp:262
+msgid "Show about dialog"
+msgstr "Mostra el diàleg Quant a"
+
+#: ../src/common/stockitem.cpp:263
+msgid "Copy selection"
+msgstr "Copia la selecció"
+
+#: ../src/common/stockitem.cpp:264
+msgid "Cut selection"
+msgstr "Retalla la selecció"
+
+#: ../src/common/stockitem.cpp:265
+msgid "Delete selection"
+msgstr "Suprimeix la selecció"
+
+#: ../src/common/stockitem.cpp:266
+msgid "Find in document"
+msgstr "Cerca dins el document"
+
+#: ../src/common/stockitem.cpp:267
+msgid "Find and replace in document"
+msgstr "Troba i substitueix dins el document"
+
+#: ../src/common/stockitem.cpp:268
+msgid "Paste selection"
+msgstr "Enganxa la selecció"
+
+#: ../src/common/stockitem.cpp:269
+msgid "Quit this program"
+msgstr "Surt d'aquest programa"
+
+#: ../src/common/stockitem.cpp:270
+msgid "Redo last action"
+msgstr "Refés la darrera acció"
+
+#: ../src/common/stockitem.cpp:271
+msgid "Undo last action"
+msgstr "Desfés la darrera acció"
+
+#: ../src/common/stockitem.cpp:272
+msgid "Create new document"
+msgstr "Crea un document nou"
+
+#: ../src/common/stockitem.cpp:273
+msgid "Open an existing document"
+msgstr "Obre un document existent"
+
+#: ../src/common/stockitem.cpp:274
+msgid "Close current document"
+msgstr "Tanca el document actual"
+
+#: ../src/common/stockitem.cpp:275
+msgid "Save current document"
+msgstr "Desa el document actual"
+
+#: ../src/common/stockitem.cpp:276
+msgid "Save current document with a different filename"
+msgstr "Desa el document actual amb un nom de fitxer diferent"
+
+#: ../src/common/strconv.cpp:2324
+#, c-format
+msgid "Conversion to charset '%s' doesn't work."
+msgstr "La conversió al joc de caràcters '%s' no funciona."
+
+#: ../src/common/tarstrm.cpp:352 ../src/common/tarstrm.cpp:375
+#: ../src/common/tarstrm.cpp:406 ../src/generic/progdlgg.cpp:373
+msgid "unknown"
+msgstr "desconegut"
+
+#: ../src/common/tarstrm.cpp:774
+msgid "incomplete header block in tar"
+msgstr "bloc de capçalera incomplet al tar"
+
+#: ../src/common/tarstrm.cpp:798
+msgid "checksum failure reading tar header block"
+msgstr ""
+"ha fallat la suma de verificació en llegir el bloc de la capçalera de tar"
+
+#: ../src/common/tarstrm.cpp:971
+msgid "invalid data in extended tar header"
+msgstr "dades invàlides a la capçalera estesa del tar"
+
+#: ../src/common/tarstrm.cpp:981 ../src/common/tarstrm.cpp:1003
+#: ../src/common/tarstrm.cpp:1477 ../src/common/tarstrm.cpp:1499
+msgid "tar entry not open"
+msgstr "entrada tar no oberta"
+
+#: ../src/common/tarstrm.cpp:1023
+msgid "unexpected end of file"
+msgstr "final del fitxer inesperat"
+
+#: ../src/common/tarstrm.cpp:1297
+#, c-format
+msgid "%s did not fit the tar header for entry '%s'"
+msgstr "%s no s'ajustava a la capçalera tar per a l'entrada '%s'"
+
+#: ../src/common/tarstrm.cpp:1359
+msgid "incorrect size given for tar entry"
+msgstr "s'ha proporcionat una mida incorrecta per a una entrada del tar"
+
+#: ../src/common/textbuf.cpp:232
+#, c-format
+msgid "'%s' is probably a binary buffer."
+msgstr "'%s' és probablement memòria intermèdia binària."
+
+#: ../src/common/textcmn.cpp:1006 ../src/richtext/richtextctrl.cpp:3053
+msgid "File couldn't be loaded."
+msgstr "No s'ha pogut carregar el fitxer."
+
+#: ../src/common/textfile.cpp:95
+#, c-format
+msgid "Failed to read text file \"%s\"."
+msgstr "No s'ha pogut llegir el fitxer de text \"%s\"."
+
+#: ../src/common/textfile.cpp:160
+#, c-format
+msgid "can't write buffer '%s' to disk."
+msgstr "no es pot escriure la memòria intermèdia '%s' al disc."
+
+#: ../src/common/time.cpp:212
+msgid "Failed to get the local system time"
+msgstr "No s'ha pogut obtenir l'hora del sistema local"
+
+#: ../src/common/time.cpp:279
+msgid "wxGetTimeOfDay failed."
+msgstr "wxGetTimeOfDay ha fallat."
+
+#: ../src/common/translation.cpp:929
+#, c-format
+msgid "'%s' is not a valid message catalog."
+msgstr "'%s' no és un missatge de catàleg vàlid."
+
+#: ../src/common/translation.cpp:954
+msgid "Invalid message catalog."
+msgstr "Catàleg de missatges invàlid."
+
+#: ../src/common/translation.cpp:1013
+#, c-format
+msgid "Failed to parse Plural-Forms: '%s'"
+msgstr "No s'ha pogut analitzar el Plural-Forms: '%s'"
+
+#: ../src/common/translation.cpp:1723
+#, c-format
+msgid "using catalog '%s' from '%s'."
+msgstr "s'utilitzarà el catàleg '%s' de '%s'."
+
+#: ../src/common/translation.cpp:1816
+#, c-format
+msgid "Resource '%s' is not a valid message catalog."
+msgstr "El recurs '%s' no és un catàleg de missatges vàlid."
+
+#: ../src/common/translation.cpp:1865
+msgid "Couldn't enumerate translations"
+msgstr "No s'han pogut enumerar les traduccions"
+
+#: ../src/common/utilscmn.cpp:1145
+msgid "No default application configured for HTML files."
+msgstr "No hi ha configurada cap aplicació per defecte per als fitxers HTML."
+
+#: ../src/common/utilscmn.cpp:1190
+#, c-format
+msgid "Failed to open URL \"%s\" in default browser."
+msgstr "No s'ha pogut obrir l'URL \"%s\" al navegador per defecte."
+
+#: ../src/common/valtext.cpp:144
+msgid "Validation conflict"
+msgstr "Conflicte de validació"
+
+#: ../src/common/valtext.cpp:186
+msgid "Required information entry is empty."
+msgstr "L'entrada d'informació necessària és buida."
+
+#: ../src/common/valtext.cpp:188
+#, c-format
+msgid "'%s' is one of the invalid strings"
+msgstr "'%s' és una de les cadenes invàlides"
+
+#: ../src/common/valtext.cpp:190
+#, c-format
+msgid "'%s' is not one of the valid strings"
+msgstr "'%s' no és una de les cadenes vàlides"
+
+#: ../src/common/valtext.cpp:199
+#, c-format
+msgid "'%s' contains invalid character(s)"
+msgstr "'%s' conté caràcters no permesos"
+
+#: ../src/common/webrequest.cpp:139
+#, c-format
+msgid "Error: %s (%d)"
+msgstr "Error: %s (%d)"
+
+#: ../src/common/webrequest.cpp:655
+#, fuzzy, c-format
+msgid ""
+"Not enough free disk space for download: %llu needed but only %llu available."
+msgstr "No hi ha espai suficient al disc per a la descàrrega."
+
+#: ../src/common/webrequest.cpp:669
+#, fuzzy, c-format
+msgid "Failed to create temporary file in %s"
+msgstr "No s'ha pogut crear un nom de fitxer temporal"
+
+#: ../src/common/webrequest_curl.cpp:1106
+msgid "libcurl could not be initialized"
+msgstr "no s'ha pogut inicialitzar libcurl"
+
+#: ../src/common/webview.cpp:392
+msgid "RunScriptAsync not supported"
+msgstr "RunScriptAsync no suportat"
+
+#: ../src/common/webview.cpp:403 ../src/msw/webview_ie.cpp:1073
+#, c-format
+msgid "Error running JavaScript: %s"
+msgstr "Error executant JavaScript: %s"
+
+#: ../src/common/webview_chromium.cpp:858
+#, fuzzy, c-format
+msgid "Failed to set proxy \"%s\": %s"
+msgstr "No s'ha pogut crear el directori \"%s\""
+
+#: ../src/common/webview_chromium.cpp:989
+msgid ""
+"Chromium can't be used because libcef.so wasn't loaded early enough; please "
+"relink the application or use LD_PRELOAD to load it earlier."
+msgstr ""
+
+#: ../src/common/webview_chromium.cpp:1108
+#, fuzzy
+msgid "Could not initialize Chromium"
+msgstr "No s'ha pogut inicialitzar libnotify."
+
+#: ../src/common/webview_chromium.cpp:1616
+msgid "Show DevTools"
+msgstr ""
+
+#: ../src/common/webview_chromium.cpp:1617
+#, fuzzy
+msgid "Close DevTools"
+msgstr "Tanca-ho tot"
+
+#: ../src/common/webview_chromium.cpp:1623
+msgid "Inspect"
+msgstr ""
+
+#: ../src/common/wincmn.cpp:1628
+msgid "This platform does not support background transparency."
+msgstr "Aquesta plataforma no suporta la transparència al fons."
+
+#: ../src/common/wincmn.cpp:2097
+msgid "Could not transfer data to window"
+msgstr "No s'han pogut transferir dades a la finestra"
+
+#: ../src/common/windowid.cpp:240
+msgid "Out of window IDs.  Recommend shutting down application."
+msgstr ""
+"S'han esgotat els identificadors de finestra. És recomanable tancar "
+"l'aplicació."
+
+#: ../src/common/xpmdecod.cpp:678
+msgid "XPM: incorrect header format!"
+msgstr "XPM: format de la capçalera incorrecte!"
+
+#: ../src/common/xpmdecod.cpp:703
+#, c-format
+msgid "XPM: incorrect colour description in line %d"
+msgstr "XPM: descripció del color incorrecta a la línia %d"
+
+#: ../src/common/xpmdecod.cpp:715 ../src/common/xpmdecod.cpp:724
+#, c-format
+msgid "XPM: malformed colour definition '%s' at line %d!"
+msgstr "XPM: definició del color incorrecta '%s' a la línia %d!"
+
+#: ../src/common/xpmdecod.cpp:754
+msgid "XPM: no colors left to use for mask!"
+msgstr "XPM: no resten colors per a utilitzar per a la màscara!"
+
+#: ../src/common/xpmdecod.cpp:781
+#, c-format
+msgid "XPM: truncated image data at line %d!"
+msgstr "XPM: dades de la imatge truncades a la línia %d!"
+
+#: ../src/common/xpmdecod.cpp:795
+msgid "XPM: Malformed pixel data!"
+msgstr "XPM: Dades de píxel incorrectes!"
+
+#: ../src/common/xti.cpp:492
+msgid "Illegal Parameter Count for Create Method"
+msgstr "Nombre de paràmetres incorrecte per al mètode Create"
+
+#: ../src/common/xti.cpp:504
+msgid "Illegal Parameter Count for ConstructObject Method"
+msgstr "Nombre de paràmetres incorrecte per al mètode ConstructObject"
+
+#: ../src/common/xtistrm.cpp:161
+#, c-format
+msgid "Create Parameter %s not found in declared RTTI Parameters"
+msgstr "No s'ha trobat el paràmetre Create %s als paràmetres RTTI declarats"
+
+#: ../src/common/xtistrm.cpp:290
+msgid "Illegal Object Class (Non-wxEvtHandler) as Event Source"
+msgstr ""
+"Classe d'objecte invàlida (no és un wxEvtHandler) com a origen de "
+"l'esdeveniment"
+
+#: ../src/common/xtistrm.cpp:313 ../src/common/xtixml.cpp:345
+#: ../src/common/xtixml.cpp:498
+msgid "Type must have enum - long conversion"
+msgstr "El tipus ha de ser convertir d'enum a long"
+
+#: ../src/common/xtistrm.cpp:400 ../src/common/xtistrm.cpp:415
+msgid "Invalid or Null Object ID passed to GetObjectClassInfo"
+msgstr "Identificador d'objecte passat a GetObjectClassInfo nul o invàlid"
+
+#: ../src/common/xtistrm.cpp:405
+msgid "Unknown Object passed to GetObjectClassInfo"
+msgstr "S'ha passat un objecte desconegut a GetObjectClassInfo"
+
+#: ../src/common/xtistrm.cpp:420
+msgid "Already Registered Object passed to SetObjectClassInfo"
+msgstr "S'ha passat un objecte ja registrat a SetObjectClassInfo"
+
+#: ../src/common/xtistrm.cpp:430
+msgid "Invalid or Null Object ID passed to HasObjectClassInfo"
+msgstr "Identificador d'objecte passat a HasObjectClassInfo nul o invàlid"
+
+#: ../src/common/xtistrm.cpp:460
+msgid "Passing a already registered object to SetObject"
+msgstr "S'ha passat un objecte ja registrat a SetObject"
+
+#: ../src/common/xtistrm.cpp:471
+msgid "Passing an unknown object to GetObject"
+msgstr "S'ha passat un objecte desconegut a GetObject"
+
+#: ../src/common/xtixml.cpp:229
+msgid "Forward hrefs are not supported"
+msgstr "Els href de reenviament no estan suportats"
+
+#: ../src/common/xtixml.cpp:247
+#, c-format
+msgid "unknown class %s"
+msgstr "classe %s desconeguda"
+
+#: ../src/common/xtixml.cpp:253
+msgid "objects cannot have XML Text Nodes"
+msgstr "els objectes no poden tenir nodes XML de text"
+
+#: ../src/common/xtixml.cpp:258
+msgid "Objects must have an id attribute"
+msgstr "Els objectes han de tenir un atribut d'identificació"
+
+#: ../src/common/xtixml.cpp:267
+#, c-format
+msgid "Doubly used id : %d"
+msgstr "Identificador utilitzat dues vegades: %d"
+
+#: ../src/common/xtixml.cpp:316
+#, c-format
+msgid "Unknown Property %s"
+msgstr "Propietat desconeguda %s"
+
+#: ../src/common/xtixml.cpp:407
+msgid "A non empty collection must consist of 'element' nodes"
+msgstr "Una col·lecció no buida ha de consistir de nodes 'element'"
+
+#: ../src/common/xtixml.cpp:478
+msgid "incorrect event handler string, missing dot"
+msgstr "cadena de manegador d'esdeveniment incorrecte, hi manca un punt"
+
+#: ../src/common/zipstrm.cpp:559
+msgid "can't re-initialize zlib deflate stream"
+msgstr "no es pot reinicialitzar el flux de deflació de zlib"
+
+#: ../src/common/zipstrm.cpp:584
+msgid "can't re-initialize zlib inflate stream"
+msgstr "no es pot reinicialitzar el flux d'inflació de zlib"
+
+#: ../src/common/zipstrm.cpp:1023
+msgid "Ignoring malformed extra data record, ZIP file may be corrupted"
+msgstr ""
+"Ignorant el registre de dades addicionals mal format, el fitxer ZIP pot "
+"estar corromput"
+
+#: ../src/common/zipstrm.cpp:1502
+msgid "assuming this is a multi-part zip concatenated"
+msgstr "s'assumeix que això és un zip multipart concatenat"
+
+#: ../src/common/zipstrm.cpp:1664
+msgid "invalid zip file"
+msgstr "fitxer zip invàlid"
+
+#: ../src/common/zipstrm.cpp:1723
+msgid "can't find central directory in zip"
+msgstr "no es pot trobar el directori central al zip"
+
+#: ../src/common/zipstrm.cpp:1812
+msgid "error reading zip central directory"
+msgstr "s'ha produït un error en llegir el directori central del zip"
+
+#: ../src/common/zipstrm.cpp:1916
+msgid "error reading zip local header"
+msgstr "s'ha produït un error en llegir la capçalera local del zip"
+
+#: ../src/common/zipstrm.cpp:1964
+msgid "bad zipfile offset to entry"
+msgstr "desplaçament a l'entrada del fitxer zip erroni"
+
+#: ../src/common/zipstrm.cpp:2031
+msgid "stored file length not in Zip header"
+msgstr "la mida del fitxer emmagatzemat no és a la capçalera del Zip"
+
+#: ../src/common/zipstrm.cpp:2045 ../src/common/zipstrm.cpp:2362
+msgid "unsupported Zip compression method"
+msgstr "mètode de compressió Zip no suportat"
+
+#: ../src/common/zipstrm.cpp:2126
+#, c-format
+msgid "reading zip stream (entry %s): bad length"
+msgstr "en llegir el flux zip (entrada %s): longitud errònia"
+
+#: ../src/common/zipstrm.cpp:2131
+#, c-format
+msgid "reading zip stream (entry %s): bad crc"
+msgstr "en llegir el flux zip (entrada %s): crc erroni"
+
+#: ../src/common/zipstrm.cpp:2578
+#, c-format
+msgid "error writing zip entry '%s': file too large without ZIP64"
+msgstr ""
+"error a l'hora d'escriure l'entrada zip '%s': fitxer massa gran sense ZIP64"
+
+#: ../src/common/zipstrm.cpp:2585
+#, c-format
+msgid "error writing zip entry '%s': bad crc or length"
+msgstr "error a l'hora d'escriure l'entrada zip '%s': crc o longitud erronis"
+
+#: ../src/common/zstream.cpp:155 ../src/common/zstream.cpp:315
+msgid "Gzip not supported by this version of zlib"
+msgstr "Aquesta versió de zlib no suporta Gzip"
+
+#: ../src/common/zstream.cpp:182
+msgid "Can't initialize zlib inflate stream."
+msgstr "No es pot inicialitzar el flux d'inflació de zlib."
+
+#: ../src/common/zstream.cpp:241
+msgid "Can't read inflate stream: unexpected EOF in underlying stream."
+msgstr "No es pot llegir el flux d'inflació: EOF inesperat al flux subjacent."
+
+#: ../src/common/zstream.cpp:248 ../src/common/zstream.cpp:423
+#, c-format
+msgid "zlib error %d"
+msgstr "s'ha produït un error de zlib %d"
+
+#: ../src/common/zstream.cpp:249
+#, c-format
+msgid "Can't read from inflate stream: %s"
+msgstr "No es pot llegir del flux d'inflació: %s"
+
+#: ../src/common/zstream.cpp:343
+msgid "Can't initialize zlib deflate stream."
+msgstr "No es pot inicialitzar el flux de deflació de zlib."
+
+#: ../src/common/zstream.cpp:424
+#, c-format
+msgid "Can't write to deflate stream: %s"
+msgstr "No es pot escriure al flux de deflació: %s"
+
+#: ../src/dfb/bitmap.cpp:633 ../src/dfb/bitmap.cpp:667
+#, c-format
+msgid "No bitmap handler for type %d defined."
+msgstr "No hi ha definit cap gestor de mapa de bits per al tipus %d."
+
+#: ../src/dfb/evtloop.cpp:99
+msgid "Failed to read event from DirectFB pipe"
+msgstr "No s'ha pogut llegir l'esdeveniment de la canonada DirectFB"
+
+#: ../src/dfb/evtloop.cpp:171
+msgid "Failed to switch DirectFB pipe to non-blocking mode"
+msgstr "No s'ha pogut canviar la canonada DirectFB al mode no blocant"
+
+#: ../src/dfb/fontmgr.cpp:171
+#, c-format
+msgid "no fonts found in %s, using builtin font"
+msgstr ""
+"no s'ha trobat cap tipus de lletra a %s, es farà servir el tipus de lletra "
+"integrat"
+
+#: ../src/dfb/fontmgr.cpp:177
+msgid "Default font"
+msgstr "Tipus de lletra per defecte"
+
+#: ../src/dfb/fontmgr.cpp:195
+#, c-format
+msgid "Fonts index file %s disappeared while loading fonts."
+msgstr ""
+"El fitxer d'índex de tipus de lletra %s ha desaparegut mentre es carregaven "
+"els tipus de lletra."
+
+#: ../src/dfb/wrapdfb.cpp:60
+#, c-format
+msgid "DirectFB error %d occurred."
+msgstr "S'ha produït un error %d de DirectFB."
+
+#: ../src/generic/aboutdlgg.cpp:69
+msgid "Developed by "
+msgstr "Desenvolupat per "
+
+#: ../src/generic/aboutdlgg.cpp:72
+msgid "Documentation by "
+msgstr "Documentació feta per "
+
+#: ../src/generic/aboutdlgg.cpp:75
+msgid "Graphics art by "
+msgstr "Art gràfic per "
+
+#: ../src/generic/aboutdlgg.cpp:78
+msgid "Translations by "
+msgstr "Traduccions de "
+
+#: ../src/generic/aboutdlgg.cpp:133 ../src/osx/cocoa/aboutdlg.mm:83
+msgid "Version "
+msgstr "Versió "
+
+#. TRANSLATORS: %s is application name
+#: ../src/generic/aboutdlgg.cpp:146 ../src/msw/aboutdlg.cpp:60
+#, c-format
+msgid "About %s"
+msgstr "Quant a %s"
+
+#: ../src/generic/aboutdlgg.cpp:181
+msgid "License"
+msgstr "Llicència"
+
+#: ../src/generic/aboutdlgg.cpp:184
+msgid "Developers"
+msgstr "Desenvolupadors"
+
+#: ../src/generic/aboutdlgg.cpp:188
+msgid "Documentation writers"
+msgstr "Redactors de la documentació"
+
+#: ../src/generic/aboutdlgg.cpp:192
+msgid "Artists"
+msgstr "Artistes"
+
+#: ../src/generic/aboutdlgg.cpp:196
+msgid "Translators"
+msgstr "Traductors"
+
+#: ../src/generic/animateg.cpp:125
+msgid "No handler found for animation type."
+msgstr "No s'ha trobat cap gestor per al tipus d'animació."
+
+#: ../src/generic/animateg.cpp:133
+#, c-format
+msgid "No animation handler for type %ld defined."
+msgstr "No hi ha definit cap gestor d'animació per al tipus %ld."
+
+#: ../src/generic/animateg.cpp:145
+#, c-format
+msgid "Animation file is not of type %ld."
+msgstr "El fitxer d'animació no és del tipus %ld."
+
+#: ../src/generic/colrdlgg.cpp:154 ../src/gtk/colordlg.cpp:47
+msgid "Choose colour"
+msgstr "Trieu un color"
+
+#: ../src/generic/colrdlgg.cpp:357
+msgid "Red:"
+msgstr "Vermell:"
+
+#: ../src/generic/colrdlgg.cpp:360
+msgid "Green:"
+msgstr "Verd:"
+
+#: ../src/generic/colrdlgg.cpp:363
+msgid "Blue:"
+msgstr "Blau:"
+
+#: ../src/generic/colrdlgg.cpp:372
+msgid "Opacity:"
+msgstr "Opacitat:"
+
+#: ../src/generic/colrdlgg.cpp:384
+msgid "Add to custom colours"
+msgstr "Afegeix als colors personalitzats"
+
+#: ../src/generic/creddlgg.cpp:56
+msgid "Username:"
+msgstr "Nom d'usuari:"
+
+#: ../src/generic/creddlgg.cpp:63
+msgid "Password:"
+msgstr "Clau d'accés:"
+
+#. TRANSLATORS: Name of Boolean true value
+#: ../src/generic/datavgen.cpp:1178
+msgid "true"
+msgstr "cert"
+
+#. TRANSLATORS: Name of Boolean false value
+#: ../src/generic/datavgen.cpp:1180
+msgid "false"
+msgstr "fals"
+
+#: ../src/generic/datavgen.cpp:6897
+#, c-format
+msgid "Row %i"
+msgstr "Fila %i"
+
+#. TRANSLATORS: Action for manipulating a tree control
+#: ../src/generic/datavgen.cpp:6987
+msgid "Collapse"
+msgstr "Contrau"
+
+#. TRANSLATORS: Action for manipulating a tree control
+#: ../src/generic/datavgen.cpp:6990
+msgid "Expand"
+msgstr "Expandeix"
+
+#. TRANSLATORS: Name of data view control and number of rows
+#: ../src/generic/datavgen.cpp:7011
+#, c-format
+msgid "%s (%d items)"
+msgstr "%s (%d elements)"
+
+#: ../src/generic/datavgen.cpp:7062
+#, c-format
+msgid "Column %u"
+msgstr "Columna %u"
+
+#. TRANSLATORS: Keystroke for manipulating a tree control
+#: ../src/generic/datavgen.cpp:7131 ../src/richtext/richtextbulletspage.cpp:189
+#: ../src/richtext/richtextbulletspage.cpp:192
+#: ../src/richtext/richtextbulletspage.cpp:193
+#: ../src/richtext/richtextliststylepage.cpp:252
+#: ../src/richtext/richtextliststylepage.cpp:255
+#: ../src/richtext/richtextliststylepage.cpp:256
+#: ../src/richtext/richtextsizepage.cpp:248
+msgid "Left"
+msgstr "Esquerra"
+
+#. TRANSLATORS: Keystroke for manipulating a tree control
+#: ../src/generic/datavgen.cpp:7134 ../src/richtext/richtextbulletspage.cpp:191
+#: ../src/richtext/richtextliststylepage.cpp:254
+#: ../src/richtext/richtextsizepage.cpp:249
+msgid "Right"
+msgstr "Dreta"
+
+#: ../src/generic/datectlg.cpp:90
+#, c-format
+msgid ""
+"\"%s\" is not in the expected date format, please enter it as e.g. \"%s\"."
+msgstr ""
+
+#: ../src/generic/datectlg.cpp:94
+#, fuzzy
+msgid "Invalid date"
+msgstr "PCX: imatge invàlida"
+
+#: ../src/generic/dbgrptg.cpp:159
+#, c-format
+msgid "Open file \"%s\""
+msgstr "Obre el fitxer \"%s\""
+
+#: ../src/generic/dbgrptg.cpp:170
+#, c-format
+msgid "Enter command to open file \"%s\":"
+msgstr "Introduïu l'ordre per a obrir el fitxer \"%s\":"
+
+#: ../src/generic/dbgrptg.cpp:230
+msgid "Executable files (*.exe)|*.exe|"
+msgstr "Fitxers executables (*.exe)|*.exe|"
+
+#: ../src/generic/dbgrptg.cpp:300
+#, c-format
+msgid "Debug report \"%s\""
+msgstr "Informe de depuració \"%s\""
+
+#: ../src/generic/dbgrptg.cpp:316
+msgid "A debug report has been generated in the directory\n"
+msgstr "S'ha generat un informe de depuració al driectori\n"
+
+#: ../src/generic/dbgrptg.cpp:317
+msgid "The following debug report will be generated\n"
+msgstr "El següent informe de depuració serà generat\n"
+
+#: ../src/generic/dbgrptg.cpp:321
+msgid ""
+"The report contains the files listed below. If any of these files contain "
+"private information,\n"
+"please uncheck them and they will be removed from the report.\n"
+msgstr ""
+"L'informe conté els fitxers que es mostren a continuació. Si algun d'aquests "
+"fitxers conté informació privada,\n"
+"desmarqueu-los i se suprimiran de l'informe.\n"
+
+#: ../src/generic/dbgrptg.cpp:323
+msgid ""
+"If you wish to suppress this debug report completely, please choose the "
+"\"Cancel\" button,\n"
+"but be warned that it may hinder improving the program, so if\n"
+"at all possible please do continue with the report generation.\n"
+msgstr ""
+"Si voleu suprimir completament aquest informe de depuració, trieu el botó "
+"\"Cancel·la\",\n"
+"però tingueu en compte que això pot impedir que es millori el programa, de "
+"manera\n"
+"que si us és possible, continueu amb la generació de l'informe.\n"
+
+#: ../src/generic/dbgrptg.cpp:325
+msgid "              Thank you and we're sorry for the inconvenience!\n"
+msgstr "              Gràcies i disculpeu les molèsties!\n"
+
+#: ../src/generic/dbgrptg.cpp:333
+msgid "&Debug report preview:"
+msgstr "Previsualització &de l'informe de depuració:"
+
+#: ../src/generic/dbgrptg.cpp:339
+msgid "&View..."
+msgstr "&Visualitza..."
+
+#: ../src/generic/dbgrptg.cpp:359
+msgid "&Notes:"
+msgstr "&Notes:"
+
+#: ../src/generic/dbgrptg.cpp:361
+msgid ""
+"If you have any additional information pertaining to this bug\n"
+"report, please enter it here and it will be joined to it:"
+msgstr ""
+"Si teniu informació addicional relativa a aquest informe\n"
+"d'errors, introduïu-la aquí i s'hi adjuntarà:"
+
+#: ../src/generic/dcpsg.cpp:1627
+msgid "Cannot open file for PostScript printing!"
+msgstr "No es pot obrir el fitxer per a la impressió PostScript!"
+
+#: ../src/generic/dirctrlg.cpp:402
+msgid "Computer"
+msgstr "Ordinador"
+
+#: ../src/generic/dirctrlg.cpp:404
+msgid "Sections"
+msgstr "Seccions"
+
+#: ../src/generic/dirctrlg.cpp:482
+msgid "Home directory"
+msgstr "Directori de l'usuari"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/generic/dirctrlg.cpp:484 ../src/propgrid/advprops.cpp:811
+msgid "Desktop"
+msgstr "Desktop"
+
+#: ../src/generic/dirctrlg.cpp:528 ../src/generic/filectrlg.cpp:752
+msgid "Illegal directory name."
+msgstr "Nom de directori no permès."
+
+#: ../src/generic/dirctrlg.cpp:528 ../src/generic/dirctrlg.cpp:546
+#: ../src/generic/dirctrlg.cpp:557 ../src/generic/dirdlgg.cpp:317
+#: ../src/generic/filectrlg.cpp:638 ../src/generic/filectrlg.cpp:752
+#: ../src/generic/filectrlg.cpp:766 ../src/generic/filectrlg.cpp:782
+#: ../src/generic/filectrlg.cpp:1356 ../src/generic/filectrlg.cpp:1387
+#: ../src/generic/filedlgg.cpp:362 ../src/gtk/filedlg.cpp:76
+msgid "Error"
+msgstr "Error"
+
+#: ../src/generic/dirctrlg.cpp:546 ../src/generic/filectrlg.cpp:766
+msgid "File name exists already."
+msgstr "Aquest nom de fitxer ja existeix."
+
+#: ../src/generic/dirctrlg.cpp:557 ../src/generic/dirdlgg.cpp:317
+#: ../src/generic/filectrlg.cpp:638 ../src/generic/filectrlg.cpp:782
+msgid "Operation not permitted."
+msgstr "L'operació no és permesa."
+
+#: ../src/generic/dirdlgg.cpp:107 ../src/generic/filedlgg.cpp:207
+msgid "Create new directory"
+msgstr "Crea un directori nou"
+
+#: ../src/generic/dirdlgg.cpp:112 ../src/generic/filedlgg.cpp:203
+msgid "Go to home directory"
+msgstr "Vés al directori de l'usuari"
+
+#: ../src/generic/dirdlgg.cpp:143
+msgid "Show &hidden directories"
+msgstr "&Mostra els directoris ocults"
+
+#: ../src/generic/dirdlgg.cpp:196
+#, c-format
+msgid ""
+"The directory '%s' does not exist\n"
+"Create it now?"
+msgstr ""
+"El directori '%s' no existeix.\n"
+"El voleu crear ara?"
+
+#: ../src/generic/dirdlgg.cpp:198
+msgid "Directory does not exist"
+msgstr "El directori no existeix"
+
+#: ../src/generic/dirdlgg.cpp:214
+#, c-format
+msgid ""
+"Failed to create directory '%s'\n"
+"(Do you have the required permissions?)"
+msgstr ""
+"No s'ha pogut crear el directori '%s'\n"
+"(Teniu els permisos necessaris?)"
+
+#: ../src/generic/dirdlgg.cpp:216
+msgid "Error creating directory"
+msgstr "S'ha produït un error en crear el directori"
+
+#: ../src/generic/dirdlgg.cpp:281
+msgid "You cannot add a new directory to this section."
+msgstr "No podeu afegir un directori nou a aquesta secció."
+
+#: ../src/generic/dirdlgg.cpp:282
+msgid "Create directory"
+msgstr "Crea un directori"
+
+#: ../src/generic/dirdlgg.cpp:291 ../src/generic/dirdlgg.cpp:301
+#: ../src/generic/filectrlg.cpp:614 ../src/generic/filectrlg.cpp:623
+msgid "NewName"
+msgstr "Nom nou"
+
+#: ../src/generic/editlbox.cpp:135
+msgid "Edit item"
+msgstr "Edita l'element"
+
+#: ../src/generic/editlbox.cpp:143
+msgid "New item"
+msgstr "Element nou"
+
+#: ../src/generic/editlbox.cpp:151
+msgid "Delete item"
+msgstr "Suprimeix l'element"
+
+#: ../src/generic/editlbox.cpp:159
+msgid "Move up"
+msgstr "Mou cap amunt"
+
+#: ../src/generic/editlbox.cpp:164
+msgid "Move down"
+msgstr "Mou cap avall"
+
+#: ../src/generic/fdrepdlg.cpp:108
+msgid "Search for:"
+msgstr "Cerca:"
+
+#: ../src/generic/fdrepdlg.cpp:120
+msgid "Replace with:"
+msgstr "Substitueix per:"
+
+#: ../src/generic/fdrepdlg.cpp:140
+msgid "Whole word"
+msgstr "Paraula sencera"
+
+#: ../src/generic/fdrepdlg.cpp:143
+msgid "Match case"
+msgstr "Distingeix entre majúscules i minúscules"
+
+#: ../src/generic/fdrepdlg.cpp:156
+msgid "Search direction"
+msgstr "Direcció de la cerca"
+
+#: ../src/generic/fdrepdlg.cpp:175
+msgid "&Replace"
+msgstr "&Substitueix"
+
+#: ../src/generic/fdrepdlg.cpp:178
+msgid "Replace &all"
+msgstr "Substitueix-ho &tot"
+
+#: ../src/generic/filectrlg.cpp:246 ../src/generic/filectrlg.cpp:269
+msgid "<DIR>"
+msgstr "<DIRECTORI>"
+
+#: ../src/generic/filectrlg.cpp:248 ../src/generic/filectrlg.cpp:271
+msgid "<LINK>"
+msgstr "<ENLLAÇ>"
+
+#: ../src/generic/filectrlg.cpp:250 ../src/generic/filectrlg.cpp:273
+msgid "<DRIVE>"
+msgstr "<UNITAT>"
+
+#: ../src/generic/filectrlg.cpp:275
+#, c-format
+msgid "%ld byte"
+msgid_plural "%ld bytes"
+msgstr[0] "%ld byte"
+msgstr[1] "%ld bytes"
+
+#: ../src/generic/filectrlg.cpp:420
+msgid "Name"
+msgstr "Nom"
+
+#: ../src/generic/filectrlg.cpp:421 ../src/richtext/richtextformatdlg.cpp:361
+#: ../src/richtext/richtextsizepage.cpp:298
+msgid "Size"
+msgstr "Mida"
+
+#: ../src/generic/filectrlg.cpp:422
+msgid "Type"
+msgstr "Tipus"
+
+#: ../src/generic/filectrlg.cpp:423
+msgid "Modified"
+msgstr "Modificat"
+
+#: ../src/generic/filectrlg.cpp:426
+msgid "Permissions"
+msgstr "Permisos"
+
+#: ../src/generic/filectrlg.cpp:429
+msgid "Attributes"
+msgstr "Atributs"
+
+#: ../src/generic/filectrlg.cpp:936
+msgid "Current directory:"
+msgstr "Directori actual:"
+
+#: ../src/generic/filectrlg.cpp:979
+msgid "Show &hidden files"
+msgstr "&Mostra els fitxers ocults"
+
+#: ../src/generic/filectrlg.cpp:1355
+msgid "Illegal file specification."
+msgstr "Especificació de fitxer no permesa."
+
+#: ../src/generic/filectrlg.cpp:1387
+msgid "Directory doesn't exist."
+msgstr "El directori no existeix."
+
+#: ../src/generic/filedlgg.cpp:195
+msgid "View files as a list view"
+msgstr "Mostra els fitxers en visualització de llista"
+
+#: ../src/generic/filedlgg.cpp:197
+msgid "View files as a detailed view"
+msgstr "Mostra els fitxers en visualització detallada"
+
+#: ../src/generic/filedlgg.cpp:200
+msgid "Go to parent directory"
+msgstr "Vés al directori pare"
+
+#: ../src/generic/filedlgg.cpp:351 ../src/gtk/filedlg.cpp:59
+#, c-format
+msgid "File '%s' already exists, do you really want to overwrite it?"
+msgstr "El fitxer '%s' ja existex, esteu segur que el voleu sobreescriure?"
+
+#: ../src/generic/filedlgg.cpp:354 ../src/gtk/filedlg.cpp:62
+msgid "Confirm"
+msgstr "Confirma"
+
+#: ../src/generic/filedlgg.cpp:362 ../src/gtk/filedlg.cpp:75
+msgid "Please choose an existing file."
+msgstr "Trieu un fitxer existent."
+
+#: ../src/generic/filepickerg.cpp:64
+msgid "..."
+msgstr "..."
+
+#: ../src/generic/fontdlgg.cpp:76 ../src/richtext/richtextformatdlg.cpp:519
+msgid "ABCDEFGabcdefg12345"
+msgstr "ABCDabcd1234ÀÈÉÍÏÒóúüçl·l"
+
+#: ../src/generic/fontdlgg.cpp:315
+msgid "Roman"
+msgstr "Roman"
+
+#: ../src/generic/fontdlgg.cpp:316
+msgid "Decorative"
+msgstr "Decoratiu"
+
+#: ../src/generic/fontdlgg.cpp:317
+msgid "Modern"
+msgstr "Modern"
+
+#: ../src/generic/fontdlgg.cpp:318
+msgid "Script"
+msgstr "Script"
+
+#: ../src/generic/fontdlgg.cpp:319
+msgid "Swiss"
+msgstr "Suís"
+
+#: ../src/generic/fontdlgg.cpp:320
+msgid "Teletype"
+msgstr "Teletip"
+
+#: ../src/generic/fontdlgg.cpp:321 ../src/generic/fontdlgg.cpp:324
+msgid "Normal"
+msgstr "Normal"
+
+#: ../src/generic/fontdlgg.cpp:323
+msgid "Slant"
+msgstr "Inclinat"
+
+#: ../src/generic/fontdlgg.cpp:325
+msgid "Light"
+msgstr "Prima"
+
+#: ../src/generic/fontdlgg.cpp:363
+msgid "&Font family:"
+msgstr "&Família del tipus de lletra:"
+
+#: ../src/generic/fontdlgg.cpp:367 ../src/generic/fontdlgg.cpp:369
+msgid "The font family."
+msgstr "La família del tipus de lletra."
+
+#: ../src/generic/fontdlgg.cpp:374 ../src/richtext/richtextstylepage.cpp:105
+msgid "&Style:"
+msgstr "E&stil:"
+
+#: ../src/generic/fontdlgg.cpp:378 ../src/generic/fontdlgg.cpp:380
+msgid "The font style."
+msgstr "L'estil del tipus de lletra."
+
+#: ../src/generic/fontdlgg.cpp:385
+msgid "&Weight:"
+msgstr "&Pes:"
+
+#: ../src/generic/fontdlgg.cpp:389 ../src/generic/fontdlgg.cpp:391
+msgid "The font weight."
+msgstr "El pes de la lletra."
+
+#: ../src/generic/fontdlgg.cpp:399
+msgid "C&olour:"
+msgstr "C&olor:"
+
+#: ../src/generic/fontdlgg.cpp:407 ../src/generic/fontdlgg.cpp:409
+msgid "The font colour."
+msgstr "El color de la lletra."
+
+#: ../src/generic/fontdlgg.cpp:415
+msgid "&Point size:"
+msgstr "Mida en &punts:"
+
+#: ../src/generic/fontdlgg.cpp:420 ../src/generic/fontdlgg.cpp:422
+#: ../src/generic/fontdlgg.cpp:426 ../src/generic/fontdlgg.cpp:428
+msgid "The font point size."
+msgstr "La mida en punts del tipus de lletra."
+
+#: ../src/generic/fontdlgg.cpp:439 ../src/generic/fontdlgg.cpp:441
+msgid "Whether the font is underlined."
+msgstr "Si el tipus de lletra està subratllada."
+
+#: ../src/generic/fontdlgg.cpp:448 ../src/html/helpwnd.cpp:1215
+msgid "Preview:"
+msgstr "Previsualització:"
+
+#: ../src/generic/fontdlgg.cpp:452 ../src/generic/fontdlgg.cpp:454
+msgid "Shows the font preview."
+msgstr "Mostra la previsualització del tipus de lletra."
+
+#: ../src/generic/fontdlgg.cpp:464 ../src/generic/fontdlgg.cpp:483
+msgid "Click to cancel the font selection."
+msgstr "Feu clic per a cancel·lar la selecció del tipus de lletra."
+
+#: ../src/generic/fontdlgg.cpp:469 ../src/generic/fontdlgg.cpp:471
+#: ../src/generic/fontdlgg.cpp:476 ../src/generic/fontdlgg.cpp:478
+msgid "Click to confirm the font selection."
+msgstr "Feu clic per a confirmació la selecció del tipus de lletra."
+
+#: ../src/generic/fontpickerg.cpp:50 ../src/gtk/fontdlg.cpp:77
+msgid "Choose font"
+msgstr "Trieu el tipus de lletra"
+
+#: ../src/generic/grid.cpp:6542
+msgid ""
+"Error copying grid to the clipboard. Either selected cells were not "
+"contiguous or no cell was selected."
+msgstr ""
+
+#: ../src/generic/grid.cpp:12739
+#, fuzzy
+msgid "Grid Corner"
+msgstr "Cantonada"
+
+#: ../src/generic/grid.cpp:12741
+#, fuzzy, c-format
+msgid "Column %s Header"
+msgstr "Columna %u"
+
+#: ../src/generic/grid.cpp:12743
+#, c-format
+msgid "Row %s Header"
+msgstr ""
+
+#: ../src/generic/grid.cpp:12745
+#, fuzzy, c-format
+msgid "Column %s: %s"
+msgstr "Columna %u"
+
+#: ../src/generic/grid.cpp:12749
+#, fuzzy, c-format
+msgid "Row %s: %s"
+msgstr "Fila %i"
+
+#: ../src/generic/grid.cpp:12753
+#, c-format
+msgid "Row %s, Column %s: %s"
+msgstr ""
+
+#: ../src/generic/helpext.cpp:257
+#, c-format
+msgid "Help directory \"%s\" not found."
+msgstr "No s'ha trobat el directori d'ajuda \"%s\"."
+
+#: ../src/generic/helpext.cpp:265
+#, c-format
+msgid "Help file \"%s\" not found."
+msgstr "No s'ha trobat el fitxer d'ajuda \"%s\"."
+
+#: ../src/generic/helpext.cpp:284
+#, c-format
+msgid "Line %lu of map file \"%s\" has invalid syntax, skipped."
+msgstr "La línia %lu del fitxer de mapa \"%s\" té sintaxi invàlida, s'ha omès."
+
+#: ../src/generic/helpext.cpp:292
+#, c-format
+msgid "No valid mappings found in the file \"%s\"."
+msgstr "No s'ha trobat cap assignació vàlida al fitxer \"%s\"."
+
+#: ../src/generic/helpext.cpp:435
+msgid "No entries found."
+msgstr "No s'ha trobat cap entrada."
+
+#: ../src/generic/helpext.cpp:444 ../src/generic/helpext.cpp:445
+msgid "Help Index"
+msgstr "Índex de l'ajuda"
+
+#: ../src/generic/helpext.cpp:448
+msgid "Relevant entries:"
+msgstr "Entrades rellevants:"
+
+#: ../src/generic/helpext.cpp:449
+msgid "Entries found"
+msgstr "Entrades trobades"
+
+#: ../src/generic/hyperlinkg.cpp:170
+msgid "&Copy URL"
+msgstr "&Copia l'URL"
+
+#: ../src/generic/infobar.cpp:119
+msgid "Hide this notification message."
+msgstr "Amaga aquest missatge de notificació."
+
+#. TRANSLATORS: %s will be either the application name or "Application"
+#: ../src/generic/logg.cpp:257
+#, c-format
+msgid "%s Error"
+msgstr "Error: %s"
+
+#. TRANSLATORS: %s will be either the application name or "Application"
+#: ../src/generic/logg.cpp:263
+#, c-format
+msgid "%s Warning"
+msgstr "Advertència: %s"
+
+#. TRANSLATORS: %s will be either the application name or "Application"
+#: ../src/generic/logg.cpp:273
+#, c-format
+msgid "%s Information"
+msgstr "Informació: %s"
+
+#: ../src/generic/logg.cpp:276
+msgid "Application"
+msgstr "Aplicació"
+
+#: ../src/generic/logg.cpp:549
+msgid "Save log contents to file"
+msgstr "Desa el contingut del registre al fitxer"
+
+#: ../src/generic/logg.cpp:551
+msgid "C&lear"
+msgstr "&Neteja"
+
+#: ../src/generic/logg.cpp:551
+msgid "Clear the log contents"
+msgstr "Neteja el contingut del registre"
+
+#: ../src/generic/logg.cpp:553
+msgid "Close this window"
+msgstr "Tanca aquesta finestra"
+
+#: ../src/generic/logg.cpp:554
+msgid "&Log"
+msgstr "&Registre"
+
+#: ../src/generic/logg.cpp:610 ../src/generic/logg.cpp:992
+msgid "Can't save log contents to file."
+msgstr "No es pot desar el contingut de registre al fitxer."
+
+#: ../src/generic/logg.cpp:613
+#, c-format
+msgid "Log saved to the file '%s'."
+msgstr "Registre desat al fitxer '%s'."
+
+#: ../src/generic/logg.cpp:719
+msgid "&Details"
+msgstr "&Detalls"
+
+#: ../src/generic/logg.cpp:972
+msgid "Failed to copy dialog contents to the clipboard."
+msgstr "No s'ha pogut copiar el contingut del diàleg al porta-retalls."
+
+#: ../src/generic/logg.cpp:1022
+#, c-format
+msgid "Append log to file '%s' (choosing [No] will overwrite it)?"
+msgstr ""
+"Voleu afegir el registre al fitxer '%s'? (si trieu [No], se sobreescriurà)"
+
+#: ../src/generic/logg.cpp:1024
+msgid "Question"
+msgstr "Qüestió"
+
+#: ../src/generic/logg.cpp:1038
+msgid "invalid message box return value"
+msgstr "valor de retorn de la capsa de missatges invàlid"
+
+#: ../src/generic/notifmsgg.cpp:129
+msgid "Notice"
+msgstr "Avís"
+
+#: ../src/generic/preferencesg.cpp:118
+#, c-format
+msgid "%s Preferences"
+msgstr "Preferències de %s"
+
+#: ../src/generic/printps.cpp:143
+msgid "Printing..."
+msgstr "S'està imprimint..."
+
+#: ../src/generic/printps.cpp:160 ../src/gtk/print.cpp:1076
+#: ../src/msw/printwin.cpp:235
+msgid "Could not start printing."
+msgstr "No s'ha pogut iniciar la impressió."
+
+#: ../src/generic/printps.cpp:183
+#, c-format
+msgid "Printing page %d..."
+msgstr "S'està imprimint la pàgina %d..."
+
+#: ../src/generic/prntdlgg.cpp:171
+msgid "Printer options"
+msgstr "Opcions de la impressora"
+
+#: ../src/generic/prntdlgg.cpp:176
+msgid "Print to File"
+msgstr "Imprimeix a un fitxer"
+
+#: ../src/generic/prntdlgg.cpp:179
+msgid "Setup..."
+msgstr "Configura..."
+
+#: ../src/generic/prntdlgg.cpp:187
+msgid "Printer:"
+msgstr "Impressora:"
+
+#: ../src/generic/prntdlgg.cpp:195
+msgid "Status:"
+msgstr "Estat:"
+
+#: ../src/generic/prntdlgg.cpp:206
+msgid "All"
+msgstr "Tot"
+
+#: ../src/generic/prntdlgg.cpp:207
+msgid "Pages"
+msgstr "Pàgines"
+
+#: ../src/generic/prntdlgg.cpp:215
+msgid "Print Range"
+msgstr "Rang d'impressió"
+
+#: ../src/generic/prntdlgg.cpp:229
+msgid "From:"
+msgstr "De:"
+
+#: ../src/generic/prntdlgg.cpp:233
+msgid "To:"
+msgstr "A:"
+
+#: ../src/generic/prntdlgg.cpp:238
+msgid "Copies:"
+msgstr "Còpies:"
+
+#: ../src/generic/prntdlgg.cpp:288
+msgid "PostScript file"
+msgstr "Fitxer PostScript"
+
+#: ../src/generic/prntdlgg.cpp:439
+msgid "Print Setup"
+msgstr "Configuració de la impressió"
+
+#: ../src/generic/prntdlgg.cpp:483
+msgid "Printer"
+msgstr "Impressora"
+
+#: ../src/generic/prntdlgg.cpp:501
+msgid "Default printer"
+msgstr "Impressora per defecte"
+
+#: ../src/generic/prntdlgg.cpp:595 ../src/generic/prntdlgg.cpp:782
+#: ../src/generic/prntdlgg.cpp:822 ../src/generic/prntdlgg.cpp:835
+#: ../src/generic/prntdlgg.cpp:1031 ../src/generic/prntdlgg.cpp:1036
+msgid "Paper size"
+msgstr "Mida del paper"
+
+#: ../src/generic/prntdlgg.cpp:604 ../src/generic/prntdlgg.cpp:847
+msgid "Portrait"
+msgstr "Vertical"
+
+#: ../src/generic/prntdlgg.cpp:605 ../src/generic/prntdlgg.cpp:848
+msgid "Landscape"
+msgstr "Apaïsat"
+
+#: ../src/generic/prntdlgg.cpp:607 ../src/generic/prntdlgg.cpp:849
+msgid "Orientation"
+msgstr "Orientació"
+
+#: ../src/generic/prntdlgg.cpp:610
+msgid "Options"
+msgstr "Opcions"
+
+#: ../src/generic/prntdlgg.cpp:612
+msgid "Print in colour"
+msgstr "Imprimeix en color"
+
+#: ../src/generic/prntdlgg.cpp:621
+msgid "Print spooling"
+msgstr "Cua d'impressió"
+
+#: ../src/generic/prntdlgg.cpp:623
+msgid "Printer command:"
+msgstr "Ordre de la impressora:"
+
+#: ../src/generic/prntdlgg.cpp:631
+msgid "Printer options:"
+msgstr "Opcions de la impressora:"
+
+#: ../src/generic/prntdlgg.cpp:860
+msgid "Left margin (mm):"
+msgstr "Marge esquerre (mm):"
+
+#: ../src/generic/prntdlgg.cpp:861
+msgid "Top margin (mm):"
+msgstr "Marge superior (mm):"
+
+#: ../src/generic/prntdlgg.cpp:872
+msgid "Right margin (mm):"
+msgstr "Marge dret (mm):"
+
+#: ../src/generic/prntdlgg.cpp:873
+msgid "Bottom margin (mm):"
+msgstr "Marge inferior (mm):"
+
+#: ../src/generic/prntdlgg.cpp:896
+msgid "Printer..."
+msgstr "Impressora..."
+
+#: ../src/generic/progdlgg.cpp:246
+msgid "&Skip"
+msgstr "&Omet"
+
+#: ../src/generic/progdlgg.cpp:347 ../src/generic/progdlgg.cpp:626
+msgid "Unknown"
+msgstr "Desconegut"
+
+#: ../src/generic/progdlgg.cpp:451 ../src/msw/progdlg.cpp:526
+msgid "Done."
+msgstr "Fet."
+
+#: ../src/generic/srchctlg.cpp:55 ../src/gtk/srchctrl.cpp:206
+#: ../src/html/helpwnd.cpp:530 ../src/html/helpwnd.cpp:545
+msgid "Search"
+msgstr "Cerca"
+
+#: ../src/generic/tabg.cpp:1026
+msgid "Could not find tab for id"
+msgstr "No s'ha pogut trobar la pestanya per a l'identificador"
+
+#: ../src/generic/tipdlg.cpp:136
+msgid "Tips not available, sorry!"
+msgstr "Els consells no estan disponibles!"
+
+#: ../src/generic/tipdlg.cpp:197
+msgid "Tip of the Day"
+msgstr "Consell del dia"
+
+#: ../src/generic/tipdlg.cpp:207
+msgid "Did you know..."
+msgstr "Sabíeu que..."
+
+#: ../src/generic/tipdlg.cpp:232
+msgid "&Show tips at startup"
+msgstr "Mo&stra els consells en iniciar"
+
+#: ../src/generic/tipdlg.cpp:236
+msgid "&Next Tip"
+msgstr "Següe&nt consell"
+
+#: ../src/generic/wizard.cpp:411
+msgid "&Next >"
+msgstr "E&ndavant >"
+
+#: ../src/generic/wizard.cpp:412
+msgid "&Finish"
+msgstr "&Finalitza"
+
+#: ../src/generic/wizard.cpp:420
+msgid "< &Back"
+msgstr "< &Endarrere"
+
+#: ../src/gtk/aboutdlg.cpp:204
+msgid "translator-credits"
+msgstr ""
+"Eduard Ereza Martínez <eduard@ereza.cat>\n"
+"Andriy Byelikov https://github.com/andriybyelikov"
+
+#: ../src/gtk/app.cpp:517
+msgid ""
+"WARNING: using XIM input method is unsupported and may result in problems "
+"with input handling and flickering. Consider unsetting GTK_IM_MODULE or "
+"setting to \"ibus\"."
+msgstr ""
+"ADVERTÈNCIA: l'ús del mètode d'entrada XIM no és compatible i pot provocar "
+"problemes amb la gestió de l'entrada i parpelleig. Consideri desestablir "
+"GTK_IM_MODULE o establir-lo a \"ibus\"."
+
+#: ../src/gtk/app.cpp:569
+msgid "Unable to initialize GTK+, is DISPLAY set properly?"
+msgstr ""
+"No s'ha pogut inicialitzar el GTK+, teniu definit correctament DISPLAY?"
+
+#: ../src/gtk/filedlg.cpp:89 ../src/gtk/filepicker.cpp:255
+#, c-format
+msgid "Changing current directory to \"%s\" failed"
+msgstr "No s'ha pogut canviar el directori actual a \"%s\""
+
+#: ../src/gtk/font.cpp:548
+msgid ""
+"Using private fonts is not supported on this system: Pango library is too "
+"old, 1.38 or later required."
+msgstr ""
+"Utilitzar tipus de lletra privats no està suportat a aquest sistema: la "
+"biblioteca Pango és massa antiga, es requereix 1.38 o posterior."
+
+#: ../src/gtk/font.cpp:558
+msgid "Failed to create font configuration object."
+msgstr "No s'ha pogut crear l'objecte de configuració de tipus de lletra."
+
+#: ../src/gtk/font.cpp:568
+#, c-format
+msgid "Failed to add custom font \"%s\"."
+msgstr "No s'ha pogut afegir el tipus de lletra personalitzat \"%s\"."
+
+#: ../src/gtk/font.cpp:576
+msgid "Failed to register font configuration using private fonts."
+msgstr ""
+"No s'ha pogut registrar la configuració de tipus de lletra utilitzant tipus "
+"de lletra privats."
+
+#: ../src/gtk/glcanvas.cpp:117 ../src/gtk/glcanvas.cpp:132
+msgid "Fatal Error"
+msgstr "Error fatal"
+
+#: ../src/gtk/glcanvas.cpp:117
+msgid ""
+"This program wasn't compiled with EGL support required under Wayland, "
+"either\n"
+"install EGL libraries and rebuild or run it under X11 backend by setting\n"
+"environment variable GDK_BACKEND=x11 before starting your program."
+msgstr ""
+"Aquest programa no ha estat compilat amb el suport EGL requerit baix "
+"Wayland,\n"
+"o bé instal·li les biblioteques EGL i recompili, o bé executi'l baix un "
+"backend\n"
+"X11 establint la variable d'entorn GDK_BACKEND=x11 abans d'iniciar el seu\n"
+"programa."
+
+#: ../src/gtk/glcanvas.cpp:132
+msgid ""
+"wxGLCanvas is only supported on Wayland and X11 currently.  You may be able "
+"to\n"
+"work around this by setting environment variable GDK_BACKEND=x11 before\n"
+"starting your program."
+msgstr ""
+"wxGLCanvas actualment només està suportat a Wayland i X11. Una possible "
+"solució\n"
+"alternativa és establir la variable d'entorn GDK_BACKEND=x11 abans d'iniciar "
+"el\n"
+"seu programa."
+
+#: ../src/gtk/mdi.cpp:433
+msgid "MDI child"
+msgstr "Fill de l'MDI"
+
+#: ../src/gtk/power.cpp:188
+#, fuzzy, c-format
+msgid "Failed to open D-Bus connection to the login manager: %s"
+msgstr "No s'ha pogut %s a la connexió de marcatge directe: %s"
+
+#: ../src/gtk/power.cpp:214
+#, fuzzy
+msgid "wxWidgets application"
+msgstr "Amaga l'aplicació"
+
+#: ../src/gtk/power.cpp:226
+msgid "Application needs to keep running"
+msgstr ""
+
+#: ../src/gtk/power.cpp:233
+msgid "Clean up before suspend"
+msgstr ""
+
+#: ../src/gtk/power.cpp:259
+#, fuzzy, c-format
+msgid "Failed to inhibit sleep: %s"
+msgstr "No s'ha pogut inicialitzar la connexió de marcatge telefònic: %s"
+
+#: ../src/gtk/power.cpp:265
+msgid "Unexpected response to D-Bus \"Inhibit\" request."
+msgstr ""
+
+#: ../src/gtk/print.cpp:218
+msgid "Custom size"
+msgstr "Mida personalitzada"
+
+#: ../src/gtk/print.cpp:752
+#, fuzzy, c-format
+msgid "Error while printing: %s"
+msgstr "S'ha produït un error en imprimir: "
+
+#: ../src/gtk/print.cpp:816
+msgid "Page Setup"
+msgstr "Configuració de la pàgina"
+
+#: ../src/gtk/webview_webkit.cpp:932
+msgid "Retrieving JavaScript script output is not supported with WebKit v1"
+msgstr ""
+"L'obtenció de la sortida d'un script de JavaScript no està suportada amb "
+"WebKit v1"
+
+#: ../src/gtk/webview_webkit2.cpp:1098
+msgid ""
+"Setting proxy is not supported by WebKit, at least version 2.16 is required."
+msgstr ""
+
+#: ../src/gtk/webview_webkit2.cpp:1104
+msgid "This program was compiled without support for setting WebKit proxy."
+msgstr ""
+
+#: ../src/gtk/window.cpp:6289
+msgid ""
+"GTK+ installed on this machine is too old to support screen compositing, "
+"please install GTK+ 2.12 or later."
+msgstr ""
+"El GTK+ instal·lat en aquest dispositiu és massa antic i no suporta la "
+"composició de pantalla, instal·leu el GTK+ 2.12 o posterior."
+
+#: ../src/gtk/window.cpp:6307
+msgid ""
+"Compositing not supported by this system, please enable it in your Window "
+"Manager."
+msgstr ""
+"Aquest sistema no suporta la composició, activeu-la al vostre gestor de "
+"finestres."
+
+#: ../src/gtk/window.cpp:6318
+msgid ""
+"This program was compiled with a too old version of GTK+, please rebuild "
+"with GTK+ 2.12 or newer."
+msgstr ""
+"Aquest programa s'ha compilat amb una versió massa antiga del GTK+, "
+"recompileu-lo amb el GTK+ 2.12 o posterior."
+
+#: ../src/html/chm.cpp:138
+#, c-format
+msgid "Failed to open CHM archive '%s'."
+msgstr "No s'ha pogut obrir l'arxiu CHM '%s'."
+
+#: ../src/html/chm.cpp:270
+#, c-format
+msgid "Could not extract %s into %s: %s"
+msgstr "No s'ha pogut extreure %s a %s: %s"
+
+#: ../src/html/chm.cpp:324
+msgid "no error"
+msgstr "no hi ha cap error"
+
+#: ../src/html/chm.cpp:326
+msgid "bad arguments to library function"
+msgstr "arguments erronis per a una funció de la biblioteca"
+
+#: ../src/html/chm.cpp:328
+msgid "error opening file"
+msgstr "s'ha produït un error en obrir el fitxer"
+
+#: ../src/html/chm.cpp:330
+msgid "read error"
+msgstr "s'ha produït un error de lectura"
+
+#: ../src/html/chm.cpp:332
+msgid "write error"
+msgstr "s'ha produït un error d'escriptura"
+
+#: ../src/html/chm.cpp:334
+msgid "seek error"
+msgstr "s'ha produït un error de cerca"
+
+#: ../src/html/chm.cpp:338
+msgid "bad signature"
+msgstr "signatura errònia"
+
+#: ../src/html/chm.cpp:340
+msgid "error in data format"
+msgstr "error al format de dades"
+
+#: ../src/html/chm.cpp:342
+msgid "checksum error"
+msgstr "s'ha produït un error de suma de verificació"
+
+#: ../src/html/chm.cpp:344
+msgid "compression error"
+msgstr "s'ha produït un error de compressió"
+
+#: ../src/html/chm.cpp:346
+msgid "decompression error"
+msgstr "s'ha produït un error de descompressió"
+
+#: ../src/html/chm.cpp:437
+#, c-format
+msgid "Could not locate file '%s'."
+msgstr "No s'ha pogut trobar el fitxer '%s'."
+
+#: ../src/html/chm.cpp:711
+#, c-format
+msgid "Could not create temporary file '%s'"
+msgstr "No s'ha pogut crear el fitxer temporal '%s'"
+
+#: ../src/html/chm.cpp:718
+#, c-format
+msgid "Extraction of '%s' into '%s' failed."
+msgstr "No s'ha pogut executar '%s' a '%s'."
+
+#: ../src/html/chm.cpp:806 ../src/html/chm.cpp:863
+msgid "CHM handler currently supports only local files!"
+msgstr "El gestor de CHM actualment només suporta fitxers locals!"
+
+#: ../src/html/chm.cpp:827
+msgid "Link contained '//', converted to absolute link."
+msgstr "L'enllaç contenia '//', s'ha convertit a un enllaç absolut."
+
+#: ../src/html/helpctrl.cpp:59
+#, c-format
+msgid "Help: %s"
+msgstr "Ajuda: %s"
+
+#: ../src/html/helpctrl.cpp:155
+#, c-format
+msgid "Adding book %s"
+msgstr "S'està afegint el llibre %s"
+
+#: ../src/html/helpdata.cpp:295
+#, c-format
+msgid "Cannot open contents file: %s"
+msgstr "No es pot obrir el fitxer de continguts: %s"
+
+#: ../src/html/helpdata.cpp:309
+#, c-format
+msgid "Cannot open index file: %s"
+msgstr "No es pot obrir el fitxer d'índex: %s"
+
+#: ../src/html/helpdata.cpp:643
+msgid "noname"
+msgstr "sense nom"
+
+#: ../src/html/helpdata.cpp:652
+#, c-format
+msgid "Cannot open HTML help book: %s"
+msgstr "No es pot obrir el llibre d'ajuda HTML: %s"
+
+#: ../src/html/helpwnd.cpp:315
+msgid "Displays help as you browse the books on the left."
+msgstr "Mostra l'ajuda mentre navegueu pels llibres de l'esquerra."
+
+#: ../src/html/helpwnd.cpp:411 ../src/html/helpwnd.cpp:1100
+#: ../src/html/helpwnd.cpp:1735
+msgid "(bookmarks)"
+msgstr "(preferits)"
+
+#: ../src/html/helpwnd.cpp:424
+msgid "Add current page to bookmarks"
+msgstr "Afegeix la pàgina actual als preferits"
+
+#: ../src/html/helpwnd.cpp:425
+msgid "Remove current page from bookmarks"
+msgstr "Elimina la pàgina actual dels preferits"
+
+#: ../src/html/helpwnd.cpp:470
+msgid "Contents"
+msgstr "Contingut"
+
+#: ../src/html/helpwnd.cpp:485
+msgid "Find"
+msgstr "Cerca"
+
+#: ../src/html/helpwnd.cpp:487
+msgid "Show all"
+msgstr "Mostra-ho tot"
+
+#: ../src/html/helpwnd.cpp:497
+msgid ""
+"Display all index items that contain given substring. Search is case "
+"insensitive."
+msgstr ""
+"Mostra tots els elements de l'índex que continguin la subcadena donada. La "
+"cerca no distingeix entre majúscules i minúscules."
+
+#: ../src/html/helpwnd.cpp:498
+msgid "Show all items in index"
+msgstr "Mostra tots els elements a l'índex"
+
+#: ../src/html/helpwnd.cpp:528
+msgid "Case sensitive"
+msgstr "Distingeix entre majúscules i minúscules"
+
+#: ../src/html/helpwnd.cpp:529
+msgid "Whole words only"
+msgstr "Només paraules senceres"
+
+#: ../src/html/helpwnd.cpp:532
+msgid ""
+"Search contents of help book(s) for all occurrences of the text you typed "
+"above"
+msgstr ""
+"Cerca totes les coincidències del text que heu escrit a dalt al contingut "
+"dels llibres d'ajuda"
+
+#: ../src/html/helpwnd.cpp:653
+msgid "Show/hide navigation panel"
+msgstr "Mostra/amaga el plafó de navegació"
+
+#: ../src/html/helpwnd.cpp:655
+msgid "Go back"
+msgstr "Vés endarrere"
+
+#: ../src/html/helpwnd.cpp:656
+msgid "Go forward"
+msgstr "Vés endavant"
+
+#: ../src/html/helpwnd.cpp:658
+msgid "Go one level up in document hierarchy"
+msgstr "Puja un nivell en la jerarquia del document"
+
+#: ../src/html/helpwnd.cpp:666 ../src/html/helpwnd.cpp:1547
+msgid "Open HTML document"
+msgstr "Obre un document HTML"
+
+#: ../src/html/helpwnd.cpp:670
+msgid "Print this page"
+msgstr "Imprimeix aquesta pàgina"
+
+#: ../src/html/helpwnd.cpp:674
+msgid "Display options dialog"
+msgstr "Mostra el diàleg d'opcions"
+
+#: ../src/html/helpwnd.cpp:795
+msgid "Please choose the page to display:"
+msgstr "Trieu la pàgina que vulgueu mostrar:"
+
+#: ../src/html/helpwnd.cpp:796
+msgid "Help Topics"
+msgstr "Temes de l'ajuda"
+
+#: ../src/html/helpwnd.cpp:852
+msgid "Searching..."
+msgstr "S'està cercant..."
+
+#: ../src/html/helpwnd.cpp:853
+msgid "No matching page found yet"
+msgstr "Encara no s'ha trobat cap pàgina que hi coincideixi"
+
+#: ../src/html/helpwnd.cpp:870
+#, c-format
+msgid "Found %i matches"
+msgstr "S'han trobat %i coincidències"
+
+#: ../src/html/helpwnd.cpp:958
+msgid "(Help)"
+msgstr "(Ajuda)"
+
+#: ../src/html/helpwnd.cpp:1026
+#, c-format
+msgid "%d of %lu"
+msgstr "%d de %lu"
+
+#: ../src/html/helpwnd.cpp:1028
+#, c-format
+msgid "%lu of %lu"
+msgstr "%lu de %lu"
+
+#: ../src/html/helpwnd.cpp:1047
+msgid "Search in all books"
+msgstr "Cerca a tots els llibres"
+
+#: ../src/html/helpwnd.cpp:1193
+msgid "Help Browser Options"
+msgstr "Opcions del navegador de l'ajuda"
+
+#: ../src/html/helpwnd.cpp:1198
+msgid "Normal font:"
+msgstr "Tipus de lletra normal:"
+
+#: ../src/html/helpwnd.cpp:1199
+msgid "Fixed font:"
+msgstr "Tipus de lletra de mida fixa:"
+
+#: ../src/html/helpwnd.cpp:1200
+msgid "Font size:"
+msgstr "Mida de la lletra:"
+
+#: ../src/html/helpwnd.cpp:1245
+msgid "font size"
+msgstr "mida del tipus de lletra"
+
+#: ../src/html/helpwnd.cpp:1256
+msgid "Normal face<br>and <u>underlined</u>. "
+msgstr "Text normal<br>i <u>subratllat</u>. "
+
+#: ../src/html/helpwnd.cpp:1257
+msgid "<i>Italic face.</i> "
+msgstr "<i>Cursiva.</i> "
+
+#: ../src/html/helpwnd.cpp:1258
+msgid "<b>Bold face.</b> "
+msgstr "<b>Negreta.</b> "
+
+#: ../src/html/helpwnd.cpp:1259
+msgid "<b><i>Bold italic face.</i></b><br>"
+msgstr "<b><i>Negreta i cursiva.</i></b><br>"
+
+#: ../src/html/helpwnd.cpp:1262
+msgid "Fixed size face.<br> <b>bold</b> <i>italic</i> "
+msgstr "De mida fixa.<br> <b>negreta</b> <i>cursiva</i> "
+
+#: ../src/html/helpwnd.cpp:1263
+msgid "<b><i>bold italic <u>underlined</u></i></b><br>"
+msgstr "<b><i>negreta i cursiva <u>subratllada</u></i></b><br>"
+
+#: ../src/html/helpwnd.cpp:1524
+msgid "Help Printing"
+msgstr "Ajuda de la impressió"
+
+#: ../src/html/helpwnd.cpp:1527
+msgid "Cannot print empty page."
+msgstr "No es pot imprimir una pàgina buida."
+
+#: ../src/html/helpwnd.cpp:1540
+msgid "HTML files (*.html;*.htm)|*.html;*.htm|"
+msgstr "Fitxers HTML (*.html;*.htm)|*.html;*.htm|"
+
+#: ../src/html/helpwnd.cpp:1541
+msgid "Help books (*.htb)|*.htb|Help books (*.zip)|*.zip|"
+msgstr "Llibres d'ajuda (*.htb)|*.htb|Llibres d'ajuda (*.zip)|*.zip|"
+
+#: ../src/html/helpwnd.cpp:1542
+msgid "HTML Help Project (*.hhp)|*.hhp|"
+msgstr "Projecte d'ajuda HTML (*.hhp)|*.hhp|"
+
+#: ../src/html/helpwnd.cpp:1544
+msgid "Compressed HTML Help file (*.chm)|*.chm|"
+msgstr "Fitxer d'ajuda HTML comprimit (*.chm)|*.chm|"
+
+#: ../src/html/helpwnd.cpp:1671
+#, c-format
+msgid "%i of %u"
+msgstr "%i de %u"
+
+#: ../src/html/helpwnd.cpp:1709
+#, c-format
+msgid "%u of %u"
+msgstr "%u de %u"
+
+#: ../src/html/htmlfilt.cpp:134
+#, c-format
+msgid "Cannot open HTML document: %s"
+msgstr "No es pot obrir el document HTML: %s"
+
+#: ../src/html/htmlwin.cpp:599
+msgid "Connecting..."
+msgstr "S'està connectant..."
+
+#: ../src/html/htmlwin.cpp:616
+#, c-format
+msgid "Unable to open requested HTML document: %s"
+msgstr "No s'ha pogut obrir el document HTML sol·licitat: %s"
+
+#: ../src/html/htmlwin.cpp:630
+msgid "Loading : "
+msgstr "S'està carregant: "
+
+#: ../src/html/htmlwin.cpp:673
+msgid "Done"
+msgstr "Fet"
+
+#: ../src/html/htmlwin.cpp:723
+#, c-format
+msgid "HTML anchor %s does not exist."
+msgstr "L'àncora l'HTML %s no existeix."
+
+#: ../src/html/htmlwin.cpp:1057
+#, c-format
+msgid "Copied to clipboard:\"%s\""
+msgstr "S'ha copiat al porta-retalls: \"%s\""
+
+#: ../src/html/htmprint.cpp:269
+msgid ""
+"This document doesn't fit on the page horizontally and will be truncated "
+"when it is printed."
+msgstr ""
+"Aquest document no cap horitzontalment a la pàgina i es truncarà en imprimir-"
+"lo."
+
+#: ../src/html/htmprint.cpp:285
+#, c-format
+msgid ""
+"The document \"%s\" doesn't fit on the page horizontally and will be "
+"truncated if printed.\n"
+"\n"
+"Would you like to proceed with printing it nevertheless?"
+msgstr ""
+"El document \"%s\" no cap horitzontalment a la pàgina i es truncarà si "
+"s'imprimeix.\n"
+"\n"
+"Voleu continuar i imprimir-lo igualment?"
+
+#: ../src/html/htmprint.cpp:296
+msgid ""
+"If possible, try changing the layout parameters to make the printout more "
+"narrow."
+msgstr ""
+"Si és possible, proveu de canviar els paràmetres de disposició per a fer que "
+"la impressió sigui més estreta."
+
+#: ../src/html/htmprint.cpp:445
+msgid ": file does not exist!"
+msgstr ": el fitxer no existeix!"
+
+#. TRANSLATORS: %s may be a document title.
+#: ../src/html/htmprint.cpp:717
+#, fuzzy, c-format
+msgid "%s Preview"
+msgstr " Previsualitza"
+
+#: ../src/html/htmprint.cpp:755 ../src/richtext/richtextprint.cpp:618
+msgid ""
+"There was a problem during page setup: you may need to set a default printer."
+msgstr ""
+"Hi ha hagut un problema durant la configuració de la pàgina: pot ser que us "
+"calgui establir una impressora per defecte."
+
+#: ../src/msw/clipbrd.cpp:80
+msgid "Failed to open the clipboard."
+msgstr "No s'ha pogut obrir el porta-retalls."
+
+#: ../src/msw/clipbrd.cpp:101
+msgid "Failed to close the clipboard."
+msgstr "No s'ha pogut tancar el porta-retalls."
+
+#: ../src/msw/clipbrd.cpp:113
+msgid "Failed to empty the clipboard."
+msgstr "No s'ha pogut buidar el porta-retalls."
+
+#: ../src/msw/clipbrd.cpp:284
+msgid "Failed to put data on the clipboard"
+msgstr "No s'han pogut posar les dades al porta-retalls"
+
+#: ../src/msw/clipbrd.cpp:326
+msgid "Failed to get data from the clipboard"
+msgstr "No s'han pogut obtenir les dades del porta-retalls"
+
+#: ../src/msw/clipbrd.cpp:363
+msgid "Failed to retrieve the supported clipboard formats"
+msgstr "No s'han pogut obtenir els formats del porta-retalls suportats"
+
+#: ../src/msw/colordlg.cpp:228
+#, c-format
+msgid "Colour selection dialog failed with error %0lx."
+msgstr "El diàleg de selecció de color ha fallat amb l'error %0lx."
+
+#: ../src/msw/cursor.cpp:141
+msgid "Failed to create cursor."
+msgstr "No s'ha pogut crear el cursor."
+
+#: ../src/msw/dde.cpp:279
+#, c-format
+msgid "Failed to register DDE server '%s'"
+msgstr "No s'ha pogut registrar el servidor DDE '%s'"
+
+#: ../src/msw/dde.cpp:300
+#, c-format
+msgid "Failed to unregister DDE server '%s'"
+msgstr "No s'ha pogut desregistrar el servidor DDE '%s'"
+
+#: ../src/msw/dde.cpp:428
+#, c-format
+msgid "Failed to create connection to server '%s' on topic '%s'"
+msgstr "No s'ha pogut crear una connexió al servidor '%s' en el tema '%s'"
+
+#: ../src/msw/dde.cpp:655
+msgid "DDE poke request failed"
+msgstr "Ha fallat la petició d'atiar el DDE"
+
+#: ../src/msw/dde.cpp:674
+msgid "Failed to establish an advise loop with DDE server"
+msgstr "No s'ha pogut establir un bucle d'avís amb el servidor DDE"
+
+#: ../src/msw/dde.cpp:693
+msgid "Failed to terminate the advise loop with DDE server"
+msgstr "No s'ha pogut finalitzar el bucle d'avís amb el servidor DDE"
+
+#: ../src/msw/dde.cpp:768
+msgid "Failed to send DDE advise notification"
+msgstr "No s'ha pogut enviar una notificació d'avís DDE"
+
+#: ../src/msw/dde.cpp:1085
+msgid "Failed to create DDE string"
+msgstr "No s'ha pogut crear la cadena DDE"
+
+#: ../src/msw/dde.cpp:1131
+msgid "no DDE error."
+msgstr "no hi ha cap error DDE."
+
+#: ../src/msw/dde.cpp:1135
+msgid "a request for a synchronous advise transaction has timed out."
+msgstr ""
+"s'ha excedit el temps límit d'una sol·licitud per a una transacció d'avís "
+"síncrona."
+
+#: ../src/msw/dde.cpp:1138
+msgid "the response to the transaction caused the DDE_FBUSY bit to be set."
+msgstr ""
+"la resposta a la transacció ha provocat que es defineixi el bit DDE_FBUSY."
+
+#: ../src/msw/dde.cpp:1141
+msgid "a request for a synchronous data transaction has timed out."
+msgstr ""
+"s'ha excedit el temps límit d'una sol·licitud per a una transacció de dades "
+"síncrona."
+
+#: ../src/msw/dde.cpp:1144
+msgid ""
+"a DDEML function was called without first calling the DdeInitialize "
+"function,\n"
+"or an invalid instance identifier\n"
+"was passed to a DDEML function."
+msgstr ""
+"s'ha cridat una funció DDEML sense cridar abans la funció DdeInitialize,\n"
+"o s'ha passat un identificador d'instància invàlid\n"
+"a una funció DDEML."
+
+#: ../src/msw/dde.cpp:1147
+msgid ""
+"an application initialized as APPCLASS_MONITOR has\n"
+"attempted to perform a DDE transaction,\n"
+"or an application initialized as APPCMD_CLIENTONLY has \n"
+"attempted to perform server transactions."
+msgstr ""
+"una aplicació inicialitzada com a APPCLASS_MONITOR ha\n"
+"provat d'executar una transacció DDE,\n"
+"o bé una aplicació inicialitzada com a APPCMD_CLIENTONLY ha \n"
+"provat d'executar transaccions de servidor."
+
+#: ../src/msw/dde.cpp:1150
+msgid "a request for a synchronous execute transaction has timed out."
+msgstr ""
+"s'ha excedit el temps límit d'una sol·licitud per a una transacció "
+"d'execució síncrona."
+
+#: ../src/msw/dde.cpp:1153
+msgid "a parameter failed to be validated by the DDEML."
+msgstr "el DDEML no ha pogut validar un paràmetre."
+
+#: ../src/msw/dde.cpp:1156
+msgid "a DDEML application has created a prolonged race condition."
+msgstr "una aplicació DDEML ha creat una situació de competició prolongada."
+
+#: ../src/msw/dde.cpp:1159
+msgid "a memory allocation failed."
+msgstr "no s'ha pogut fer una assignació de memòria."
+
+#: ../src/msw/dde.cpp:1162
+msgid "a client's attempt to establish a conversation has failed."
+msgstr "un client no ha pogut establir una conversa."
+
+#: ../src/msw/dde.cpp:1165
+msgid "a transaction failed."
+msgstr "no s'ha pogut executar una transacció."
+
+#: ../src/msw/dde.cpp:1168
+msgid "a request for a synchronous poke transaction has timed out."
+msgstr ""
+"s'ha excedit el temps límit d'una sol·licitud per a una transacció poke "
+"síncrona."
+
+#: ../src/msw/dde.cpp:1171
+msgid "an internal call to the PostMessage function has failed. "
+msgstr "ha fallat una crida interna a la funció PostMessage. "
+
+#: ../src/msw/dde.cpp:1174
+msgid "reentrancy problem."
+msgstr "problema de reentrada."
+
+#: ../src/msw/dde.cpp:1177
+msgid ""
+"a server-side transaction was attempted on a conversation\n"
+"that was terminated by the client, or the server\n"
+"terminated before completing a transaction."
+msgstr ""
+"s'ha provat d'executar una transacció de servidor en una conversa\n"
+"que ha estat finalitzada pel client, o el servidor\n"
+"ha finalitzat abans de completar una transacció."
+
+#: ../src/msw/dde.cpp:1180
+msgid "an internal error has occurred in the DDEML."
+msgstr "s'ha produït un error intern al DDEML."
+
+#: ../src/msw/dde.cpp:1183
+msgid "a request to end an advise transaction has timed out."
+msgstr ""
+"s'ha excedit el temps límit d'una sol·licitud per a finalitzar una "
+"transacció d'avís."
+
+#: ../src/msw/dde.cpp:1186
+msgid ""
+"an invalid transaction identifier was passed to a DDEML function.\n"
+"Once the application has returned from an XTYP_XACT_COMPLETE callback,\n"
+"the transaction identifier for that callback is no longer valid."
+msgstr ""
+"s'ha passat un identificador de transacció invàlid a una funció DDEML.\n"
+"Un cop que l'aplicació ha retornat d'una crida XTYP_XACT_COMPLETE, \n"
+"l'identificador de transacció d'aquesta crida ja no és vàlid."
+
+#: ../src/msw/dde.cpp:1189
+#, c-format
+msgid "Unknown DDE error %08x"
+msgstr "Error DDE desconegut %08x"
+
+#: ../src/msw/dialup.cpp:343
+msgid ""
+"Dial up functions are unavailable because the remote access service (RAS) is "
+"not installed on this machine. Please install it."
+msgstr ""
+"Les funcions de marcatge telefònic no estan disponibles perquè el servei "
+"d'accés remot (RAS) no està instal·lat en aquest dispositiu. Instal·leu-lo."
+
+#: ../src/msw/dialup.cpp:402
+#, c-format
+msgid ""
+"The version of remote access service (RAS) installed on this machine is too "
+"old, please upgrade (the following required function is missing: %s)."
+msgstr ""
+"La versió del servei d'accés remot (RAS) instal·lada en aquest dispositiu és "
+"massa antiga, actualitzeu-la (hi manca la següent funció necessària: %s)."
+
+#: ../src/msw/dialup.cpp:437
+msgid "Failed to retrieve text of RAS error message"
+msgstr "No s'ha pogut recuperar el text del missatge d'error del RAS"
+
+#: ../src/msw/dialup.cpp:440
+#, c-format
+msgid "unknown error (error code %08x)."
+msgstr "s'ha produït un error desconegut (codi d'error %08x)."
+
+#: ../src/msw/dialup.cpp:492
+#, c-format
+msgid "Cannot find active dialup connection: %s"
+msgstr "No es pot trobar cap connexió activa de marcatge telefònic: %s"
+
+#: ../src/msw/dialup.cpp:513
+msgid "Several active dialup connections found, choosing one randomly."
+msgstr ""
+"S'han trobat diverses connexions actives de marcatge telefònic, se'n triarà "
+"una aleatòriament."
+
+#: ../src/msw/dialup.cpp:598 ../src/msw/dialup.cpp:832
+#, c-format
+msgid "Failed to establish dialup connection: %s"
+msgstr "No s'ha pogut establir la connexió de marcatge telefònic: %s"
+
+#: ../src/msw/dialup.cpp:664
+#, c-format
+msgid "Failed to get ISP names: %s"
+msgstr "No s'han pogut obtenir els noms dels proveïdors d'Internet: %s"
+
+#: ../src/msw/dialup.cpp:712
+msgid "Failed to connect: no ISP to dial."
+msgstr ""
+"No s'ha pogut connectar: no hi ha cap proveïdor d'Internet al qual trucar."
+
+#: ../src/msw/dialup.cpp:732
+msgid "Choose ISP to dial"
+msgstr "Trieu el proveïdor d'Internet a qui voleu trucar"
+
+#: ../src/msw/dialup.cpp:733
+msgid "Please choose which ISP do you want to connect to"
+msgstr "Trieu a quin proveïdor d'Internet us voleu connectar"
+
+#: ../src/msw/dialup.cpp:766
+msgid "Failed to connect: missing username/password."
+msgstr "No s'ha pogut connectar: manca el nom d'usuari o la contrasenya."
+
+#: ../src/msw/dialup.cpp:796
+msgid "Cannot find the location of address book file"
+msgstr "No es pot trobar la ubicació del fitxer de la llibreta d'adreces"
+
+#: ../src/msw/dialup.cpp:827
+#, c-format
+msgid "Failed to initiate dialup connection: %s"
+msgstr "No s'ha pogut inicialitzar la connexió de marcatge telefònic: %s"
+
+#: ../src/msw/dialup.cpp:897
+msgid "Cannot hang up - no active dialup connection."
+msgstr "No es pot penjar - no hi ha cap connexió de marcatge telefònic activa."
+
+#: ../src/msw/dialup.cpp:907
+#, c-format
+msgid "Failed to terminate the dialup connection: %s"
+msgstr "No s'ha pogut finalitzar la connexió de marcatge telefònic: %s"
+
+#: ../src/msw/dib.cpp:313
+#, c-format
+msgid "Failed to save the bitmap image to file \"%s\"."
+msgstr "No s'ha pogut desar la imatge de mapa de bits al fitxer \"%s\"."
+
+#: ../src/msw/dib.cpp:543
+#, c-format
+msgid "Failed to allocate %luKb of memory for bitmap data."
+msgstr "No s'ha pogut assignar %luKb de memòria per a dades de mapa de bits."
+
+#: ../src/msw/dir.cpp:241
+#, c-format
+msgid "Cannot enumerate files in directory '%s'"
+msgstr "No es poden enumerar els fitxers del directori '%s'"
+
+#: ../src/msw/dirdlg.cpp:368
+msgid "Couldn't obtain folder name"
+msgstr "No s'ha pogut obtenir el nom de la carpeta"
+
+#: ../src/msw/dlmsw.cpp:163
+#, c-format
+msgid "(error %d: %s)"
+msgstr "(error %d: %s)"
+
+#: ../src/msw/dragimag.cpp:143 ../src/msw/dragimag.cpp:178
+#: ../src/msw/imaglist.cpp:309 ../src/msw/imaglist.cpp:331
+msgid "Couldn't add an image to the image list."
+msgstr "No s'ha pogut afegir una imatge a la llista d'imatges."
+
+#: ../src/msw/enhmeta.cpp:94
+#, c-format
+msgid "Failed to load metafile from file \"%s\"."
+msgstr "No s'ha pogut carregar el metafitxer del fitxer \"%s\"."
+
+#: ../src/msw/fdrepdlg.cpp:412
+#, c-format
+msgid "Failed to create the standard find/replace dialog (error code %d)"
+msgstr ""
+"No s'ha pogut crear el diàleg estàndard de cerca/substitueix (codi d'error "
+"%d)"
+
+#: ../src/msw/filedlg.cpp:1241
+msgid "Access to the file system is not allowed from secure desktop."
+msgstr ""
+
+#: ../src/msw/filedlg.cpp:1242
+msgid "Security warning"
+msgstr ""
+
+#: ../src/msw/filedlg.cpp:1533
+#, c-format
+msgid "File dialog failed with error code %0lx."
+msgstr "El diàleg de fitxer ha fallat amb el codi d'error %0lx."
+
+#: ../src/msw/font.cpp:1120
+#, c-format
+msgid "Font file \"%s\" couldn't be loaded"
+msgstr "No s'ha pogut carregar el fitxer de tipus de lletra \"%s\""
+
+#: ../src/msw/fontdlg.cpp:220
+#, c-format
+msgid "Common dialog failed with error code %0lx."
+msgstr "El diàleg normal ha fallat amb el codi d'error %0lx."
+
+#: ../src/msw/fswatcher.cpp:67
+msgid "Ungraceful worker thread termination"
+msgstr "El fil d'execució de treballs ha finalitzat de manera inadequada"
+
+#: ../src/msw/fswatcher.cpp:81
+msgid "Unable to create IOCP worker thread"
+msgstr "No s'ha pogut crear el fil d'execució de treballs IOCP"
+
+#: ../src/msw/fswatcher.cpp:88
+msgid "Unable to start IOCP worker thread"
+msgstr "No s'ha pogut iniciar el fil d'execució de treballs IOCP"
+
+#: ../src/msw/fswatcher.cpp:140
+msgid "Monitoring individual files for changes is not supported currently."
+msgstr ""
+"Actualment no està suportat supervisar els canvis de fitxers individuals."
+
+#: ../src/msw/fswatcher.cpp:165
+#, c-format
+msgid "Unable to set up watch for '%s'"
+msgstr "No s'ha pogut configurar la supervisió de '%s'"
+
+#: ../src/msw/fswatcher.cpp:466
+#, c-format
+msgid "Can't monitor non-existent directory \"%s\" for changes."
+msgstr "No es pot supervisar si hi ha canvis al directori inexistent \"%s\"."
+
+#: ../src/msw/glcanvas.cpp:577 ../src/unix/glx11.cpp:507
+msgid "OpenGL 3.0 or later is not supported by the OpenGL driver."
+msgstr "El controlador d'OpenGL no suporta OpenGL 3.0 o superior."
+
+#: ../src/msw/glcanvas.cpp:601 ../src/osx/glcanvas_osx.cpp:395
+#: ../src/unix/glegl.cpp:304 ../src/unix/glx11.cpp:553
+msgid "Couldn't create OpenGL context"
+msgstr "No s'ha pogut crear el context d'OpenGL"
+
+#: ../src/msw/glcanvas.cpp:1294
+msgid "Failed to initialize OpenGL"
+msgstr "No s'ha pogut inicialitzar l'OpenGL"
+
+#: ../src/msw/graphicsd2d.cpp:607
+msgid "Could not register custom DirectWrite font loader."
+msgstr ""
+"No s'ha pogut enregistrar el carregador personalitzat de tipus de lletra de "
+"DirectWrite."
+
+#: ../src/msw/helpchm.cpp:48
+msgid ""
+"MS HTML Help functions are unavailable because the MS HTML Help library is "
+"not installed on this machine. Please install it."
+msgstr ""
+"Les funcions de l'ajuda MS HTML no estan disponibles perquè la biblioteca de "
+"l'ajuda MS HTML no està instal·lada en aquest dispositiu. Instal·leu-la."
+
+#: ../src/msw/helpchm.cpp:55
+msgid "Failed to initialize MS HTML Help."
+msgstr "No s'ha pogut inicialitzar l'ajuda MS HTML."
+
+#: ../src/msw/iniconf.cpp:458
+#, c-format
+msgid "Can't delete the INI file '%s'"
+msgstr "No es pot suprimir el fitxer INI '%s'"
+
+#: ../src/msw/listctrl.cpp:995
+#, c-format
+msgid "Couldn't retrieve information about list control item %d."
+msgstr ""
+"No es pot obtenir la informació de l'element de control de la llista %d."
+
+#: ../src/msw/mdi.cpp:170 ../src/qt/mdi.cpp:253
+msgid "&Cascade"
+msgstr "En &cascada"
+
+#: ../src/msw/mdi.cpp:171
+msgid "Tile &Horizontally"
+msgstr "Mosaic &horitzontal"
+
+#: ../src/msw/mdi.cpp:172
+msgid "Tile &Vertically"
+msgstr "Mosaic &vertical"
+
+#: ../src/msw/mdi.cpp:174
+msgid "&Arrange Icons"
+msgstr "&Organitza les icones"
+
+#: ../src/msw/mdi.cpp:621
+msgid "Failed to create MDI parent frame."
+msgstr "No s'ha pogut crear el marc pare de l'MDI."
+
+#: ../src/msw/mimetype.cpp:234
+#, c-format
+msgid "Failed to create registry entry for '%s' files."
+msgstr "No s'ha pogut crear l'entrada del registre dels fitxers '%s'."
+
+#: ../src/msw/ole/automtn.cpp:495
+#, c-format
+msgid "Failed to find CLSID of \"%s\""
+msgstr "No s'ha pogut trobar el CLSID de \"%s\""
+
+#: ../src/msw/ole/automtn.cpp:512
+#, c-format
+msgid "Failed to create an instance of \"%s\""
+msgstr "No s'ha pogut crear una instància de \"%s\""
+
+#: ../src/msw/ole/automtn.cpp:552
+#, c-format
+msgid "Cannot get an active instance of \"%s\""
+msgstr "No es pot obtenir una instància activa de \"%s\""
+
+#: ../src/msw/ole/automtn.cpp:564
+#, c-format
+msgid "Failed to get OLE automation interface for \"%s\""
+msgstr "No s'ha pogut obtenir la interfície d'automatització OLE per a \"%s\""
+
+#: ../src/msw/ole/automtn.cpp:621
+msgid "Unknown name or named argument."
+msgstr "Argument o argument amb nom desconegut."
+
+#: ../src/msw/ole/automtn.cpp:625
+msgid "Incorrect number of arguments."
+msgstr "Nombre incorrecte d'arguments."
+
+#: ../src/msw/ole/automtn.cpp:637
+msgid "Unknown exception"
+msgstr "Excepció desconeguda"
+
+#: ../src/msw/ole/automtn.cpp:642
+msgid "Method or property not found."
+msgstr "No s'ha trobat el mètode o la propietat."
+
+#: ../src/msw/ole/automtn.cpp:646
+msgid "Overflow while coercing argument values."
+msgstr "S'ha produït un desbordament en forçar els valors dels arguments."
+
+#: ../src/msw/ole/automtn.cpp:650
+msgid "Object implementation does not support named arguments."
+msgstr "La implementació de l'objecte no suporta arguments amb nom."
+
+#: ../src/msw/ole/automtn.cpp:654
+msgid "The locale ID is unknown."
+msgstr "L'identificador de la configuració local és desconegut."
+
+#: ../src/msw/ole/automtn.cpp:658
+msgid "Missing a required parameter."
+msgstr "Manca un paràmetre necessari."
+
+#: ../src/msw/ole/automtn.cpp:662
+#, c-format
+msgid "Argument %u not found."
+msgstr "No s'ha trobat l'argument %u."
+
+#: ../src/msw/ole/automtn.cpp:666
+#, c-format
+msgid "Type mismatch in argument %u."
+msgstr "El tipus de l'argument %u no coincideix."
+
+#: ../src/msw/ole/automtn.cpp:670
+msgid "The system cannot find the file specified."
+msgstr "El sistema no pot trobar el fitxer especificat."
+
+#: ../src/msw/ole/automtn.cpp:674
+msgid "Class not registered."
+msgstr "Classe no registrada."
+
+#: ../src/msw/ole/automtn.cpp:678
+#, c-format
+msgid "Unknown error %08x"
+msgstr "S'ha produït un error desconegut %08x"
+
+#: ../src/msw/ole/automtn.cpp:682
+#, c-format
+msgid "OLE Automation error in %s: %s"
+msgstr "S'ha produït un error d'automatització OLE a %s: %s"
+
+#: ../src/msw/ole/dataobj.cpp:385
+#, c-format
+msgid "Couldn't register clipboard format '%s'."
+msgstr "No s'ha pogut registrar el format '%s' del porta-retalls."
+
+#: ../src/msw/ole/dataobj.cpp:402
+#, c-format
+msgid "The clipboard format '%d' doesn't exist."
+msgstr "El format del porta-retalls '%d' no existeix."
+
+#: ../src/msw/progdlg.cpp:1025
+msgid "Skip"
+msgstr "Omet"
+
+#: ../src/msw/registry.cpp:141
+#, c-format
+msgid "unknown (%lu)"
+msgstr "desconegut (%lu)"
+
+#: ../src/msw/registry.cpp:409
+#, c-format
+msgid "Can't get info about registry key '%s'"
+msgstr "No es pot obtenir informació de la clau del registre '%s'"
+
+#: ../src/msw/registry.cpp:445
+#, c-format
+msgid "Can't open registry key '%s'"
+msgstr "No es pot obrir la clau del registre '%s'"
+
+#: ../src/msw/registry.cpp:478
+#, c-format
+msgid "Can't create registry key '%s'"
+msgstr "No es pot crear la clau de registre '%s'"
+
+#: ../src/msw/registry.cpp:497
+#, c-format
+msgid "Can't close registry key '%s'"
+msgstr "No es pot tancar la clau de registre '%s'"
+
+#: ../src/msw/registry.cpp:512
+#, c-format
+msgid "Registry value '%s' already exists."
+msgstr "El valor del registre '%s' ja existeix."
+
+#: ../src/msw/registry.cpp:520
+#, c-format
+msgid "Failed to rename registry value '%s' to '%s'."
+msgstr "No s'ha pogut canviar el nom del valor del registre '%s' a '%s'."
+
+#: ../src/msw/registry.cpp:575
+#, c-format
+msgid "Can't copy values of unsupported type %d."
+msgstr "No es poden copiar els valors del tipus no suportat %d."
+
+#: ../src/msw/registry.cpp:586
+#, c-format
+msgid "Registry key '%s' does not exist, cannot rename it."
+msgstr "La clau del registre '%s' no existeix, no en podeu canviar el nom."
+
+#: ../src/msw/registry.cpp:617
+#, c-format
+msgid "Registry key '%s' already exists."
+msgstr "La clau del registre '%s' ja existeix."
+
+#: ../src/msw/registry.cpp:625
+#, c-format
+msgid "Failed to rename the registry key '%s' to '%s'."
+msgstr "No s'ha pogut canviar el nom de la clau del registre '%s' a '%s'."
+
+#: ../src/msw/registry.cpp:670
+#, c-format
+msgid "Failed to copy the registry subkey '%s' to '%s'."
+msgstr "No s'ha pogut copiar la subclau del registre '%s' a '%s'."
+
+#: ../src/msw/registry.cpp:683
+#, c-format
+msgid "Failed to copy registry value '%s'"
+msgstr "No s'ha pogut copiar el valor del registre '%s'"
+
+#: ../src/msw/registry.cpp:692
+#, c-format
+msgid "Failed to copy the contents of registry key '%s' to '%s'."
+msgstr "No s'ha pogut copiar el contingut de la clau del registre '%s' a '%s'."
+
+#: ../src/msw/registry.cpp:718
+#, c-format
+msgid ""
+"Registry key '%s' is needed for normal system operation,\n"
+"deleting it will leave your system in unusable state:\n"
+"operation aborted."
+msgstr ""
+"La clau del registre '%s' és necessària per al funcionament normal del "
+"sistema,\n"
+"si la suprimiu, deixareu el sistema en un estat inservible:\n"
+"s'ha avortat l'operació."
+
+#: ../src/msw/registry.cpp:754
+#, c-format
+msgid "Can't delete key '%s'"
+msgstr "No es pot suprimir la clau '%s'"
+
+#: ../src/msw/registry.cpp:782
+#, c-format
+msgid "Can't delete value '%s' from key '%s'"
+msgstr "No es pot suprimir el valor '%s' de la clau '%s'"
+
+#: ../src/msw/registry.cpp:855 ../src/msw/registry.cpp:887
+#: ../src/msw/registry.cpp:929 ../src/msw/registry.cpp:1000
+#, c-format
+msgid "Can't read value of key '%s'"
+msgstr "No es pot llegir el valor de la clau '%s'"
+
+#: ../src/msw/registry.cpp:873 ../src/msw/registry.cpp:915
+#: ../src/msw/registry.cpp:963 ../src/msw/registry.cpp:1106
+#, c-format
+msgid "Can't set value of '%s'"
+msgstr "No es pot definir el valor de '%s'"
+
+#: ../src/msw/registry.cpp:894 ../src/msw/registry.cpp:943
+#, c-format
+msgid "Registry value \"%s\" is not numeric (but of type %s)"
+msgstr "El valor del registre \"%s\" no és numèric (sinó del tipus %s)"
+
+#: ../src/msw/registry.cpp:979
+#, c-format
+msgid "Registry value \"%s\" is not binary (but of type %s)"
+msgstr "El valor del registre \"%s\" no és binari (sinó del tipus %s)"
+
+#: ../src/msw/registry.cpp:1028
+#, c-format
+msgid "Registry value \"%s\" is not text (but of type %s)"
+msgstr "El valor del registre \"%s\" no és de text (sinó del tipus %s)"
+
+#: ../src/msw/registry.cpp:1089
+#, c-format
+msgid "Can't read value of '%s'"
+msgstr "No es pot llegir el valor de '%s'"
+
+#: ../src/msw/registry.cpp:1157
+#, c-format
+msgid "Can't enumerate values of key '%s'"
+msgstr "No es poden enumerar els valors de la clau '%s'"
+
+#: ../src/msw/registry.cpp:1196
+#, c-format
+msgid "Can't enumerate subkeys of key '%s'"
+msgstr "No es poden enumerar les subclaus de la clau '%s'"
+
+#: ../src/msw/registry.cpp:1262
+#, c-format
+msgid ""
+"Exporting registry key: file \"%s\" already exists and won't be overwritten."
+msgstr ""
+"Exportació de la clau del registre: el fitxer \"%s\" ja existeix i no se "
+"sobreescriurà."
+
+#: ../src/msw/registry.cpp:1411
+#, c-format
+msgid "Can't export value of unsupported type %d."
+msgstr "No es pot exportar el valor del tipus de no suportat %d."
+
+#: ../src/msw/registry.cpp:1427
+#, c-format
+msgid "Ignoring value \"%s\" of the key \"%s\"."
+msgstr "S'ignora el valor \"%s\" de la clau \"%s\"."
+
+#: ../src/msw/textctrl.cpp:596
+msgid ""
+"Impossible to create a rich edit control, using simple text control instead. "
+"Please reinstall riched32.dll"
+msgstr ""
+"No és possible crear un control d'edició rica, s'utilitzarà en el seu lloc "
+"un control de text simple. Reinstal·leu riched32.dll"
+
+#: ../src/msw/thread.cpp:522 ../src/unix/threadpsx.cpp:850
+msgid "Cannot start thread: error writing TLS."
+msgstr ""
+"No es pot iniciar el fil d'execució: s'ha produït un error en escriure el "
+"TLS."
+
+#: ../src/msw/thread.cpp:613
+msgid "Can't set thread priority"
+msgstr "No es pot definir la prioritat del fil d'execució"
+
+#: ../src/msw/thread.cpp:649
+msgid "Can't create thread"
+msgstr "No es pot crear el fil d'execució"
+
+#: ../src/msw/thread.cpp:668
+msgid "Couldn't terminate thread"
+msgstr "No s'ha pogut finalitzar el fil d'execució"
+
+#: ../src/msw/thread.cpp:799
+msgid "Cannot wait for thread termination"
+msgstr "No es pot esperar a la finalització del fil d'execució"
+
+#: ../src/msw/thread.cpp:873
+#, c-format
+msgid "Cannot suspend thread %lx"
+msgstr "No es pot suspendre el fil d'execució %lx"
+
+#: ../src/msw/thread.cpp:903
+#, c-format
+msgid "Cannot resume thread %lx"
+msgstr "No es pot reprendre el fil d'execució %lx"
+
+#: ../src/msw/thread.cpp:932
+msgid "Couldn't get the current thread pointer"
+msgstr "No s'ha pogut obtenir el punter del fil d'execució actual"
+
+#: ../src/msw/thread.cpp:1333
+msgid ""
+"Thread module initialization failed: impossible to allocate index in thread "
+"local storage"
+msgstr ""
+"No s'ha pogut inicialitzar el mòdul de fils d'execució: no és possible "
+"assignar l'índex a l'emmagatzematge local del fil d'execució"
+
+#: ../src/msw/thread.cpp:1345
+msgid ""
+"Thread module initialization failed: cannot store value in thread local "
+"storage"
+msgstr ""
+"No s'ha pogut inicialitzar el mòdul de fils d'execució: no es pot "
+"emmagatzemar el valor a l'emmagatzematge local del fil d'execució"
+
+#: ../src/msw/timer.cpp:133
+msgid "Couldn't create a timer"
+msgstr "No s'ha pogut crear un temporitzador"
+
+#: ../src/msw/utils.cpp:372
+msgid "can't find user's HOME, using current directory."
+msgstr ""
+"no es pot trobar el directori de l'usuari, s'utilitzarà el directori actual."
+
+#: ../src/msw/utils.cpp:662
+#, c-format
+msgid "Failed to kill process %d"
+msgstr "No s'ha pogut matar el procés %d"
+
+#: ../src/msw/utils.cpp:986
+#, c-format
+msgid "Failed to load resource \"%s\"."
+msgstr "No s'ha pogut carregar el recurs \"%s\"."
+
+#: ../src/msw/utils.cpp:993
+#, c-format
+msgid "Failed to lock resource \"%s\"."
+msgstr "No s'ha pogut blocar el recurs \"%s\"."
+
+#. TRANSLATORS: MS Windows build number
+#: ../src/msw/utils.cpp:1209
+#, c-format
+msgid "build %lu"
+msgstr "compilació %lu"
+
+#: ../src/msw/utils.cpp:1218
+msgid ", 64-bit edition"
+msgstr ", edició de 64 bits"
+
+#: ../src/msw/utilsexc.cpp:224
+msgid "Failed to create an anonymous pipe"
+msgstr "No s'ha pogut crear una canonada anònima"
+
+#: ../src/msw/utilsexc.cpp:697
+msgid "Failed to redirect the child process IO"
+msgstr "No s'ha pogut redirigir l'E/S del procés fill"
+
+#: ../src/msw/utilsexc.cpp:870
+#, c-format
+msgid "Execution of command '%s' failed"
+msgstr "Ha fallat l'execució de l'ordre '%s'"
+
+#: ../src/msw/volume.cpp:337
+msgid "Failed to load mpr.dll."
+msgstr "No s'ha pogut carregar mpr.dll."
+
+#: ../src/msw/volume.cpp:506
+#, c-format
+msgid "Cannot read typename from '%s'!"
+msgstr "No es pot llegir el nom del tipus de '%s'!"
+
+#: ../src/msw/volume.cpp:615
+#, c-format
+msgid "Cannot load icon from '%s'."
+msgstr "No es pot carregar la icona de '%s'."
+
+#: ../src/msw/webview_edge.cpp:285
+msgid "This program was compiled without support for setting Edge proxy."
+msgstr ""
+
+#: ../src/msw/webview_ie.cpp:1010
+msgid "Failed to find web view emulation level in the registry"
+msgstr "No s'ha pogut trobar el nivell d'emulació de web view al registre"
+
+#: ../src/msw/webview_ie.cpp:1019
+msgid "Failed to set web view to modern emulation level"
+msgstr "No s'ha pogut establir web view a un nivell d'emulació modern"
+
+#: ../src/msw/webview_ie.cpp:1027
+msgid "Failed to reset web view to standard emulation level"
+msgstr "No s'ha pogut restablir web view a un nivell d'emulació estàndard"
+
+#: ../src/msw/webview_ie.cpp:1049
+msgid "Can't run JavaScript script without a valid HTML document"
+msgstr ""
+"No es pot executar un script de JavaScript sense un document HTML vàlid"
+
+#: ../src/msw/webview_ie.cpp:1056
+msgid "Can't get the JavaScript object"
+msgstr "No es pot obtenir l'objecte de JavaScript"
+
+#: ../src/msw/webview_ie.cpp:1070
+msgid "failed to evaluate"
+msgstr "no s'ha pogut evaluar"
+
+#: ../src/osx/cocoa/filedlg.mm:412
+msgid "File type:"
+msgstr "Tipus de fitxer:"
+
+#: ../src/osx/cocoa/menu.mm:242
+#, fuzzy
+msgctxt "macOS menu name"
+msgid "Window"
+msgstr "Window"
+
+#: ../src/osx/cocoa/menu.mm:259
+#, fuzzy
+msgctxt "macOS menu name"
+msgid "Help"
+msgstr "Ajuda"
+
+#: ../src/osx/cocoa/menu.mm:298
+#, fuzzy
+msgctxt "macOS menu item"
+msgid "Minimize"
+msgstr "Minimitza"
+
+#: ../src/osx/cocoa/menu.mm:303
+#, fuzzy
+msgctxt "macOS menu item"
+msgid "Zoom"
+msgstr "Amplia"
+
+#: ../src/osx/cocoa/menu.mm:309
+#, fuzzy
+msgctxt "macOS menu item"
+msgid "Bring All to Front"
+msgstr "Porta tot al davant"
+
+#: ../src/osx/core/sound.cpp:143
+#, c-format
+msgid "Failed to load sound from \"%s\" (error %d)."
+msgstr "No s'ha pogut carregar el so de \"%s\" (error %d)."
+
+#: ../src/osx/fontutil.cpp:80
+#, c-format
+msgid "Font file \"%s\" doesn't exist."
+msgstr "El fitxer de tipus de lletra \"%s\" no existeix."
+
+#: ../src/osx/fontutil.cpp:88
+#, c-format
+msgid ""
+"Font file \"%s\" cannot be used as it is not inside the font directory "
+"\"%s\"."
+msgstr ""
+"El fitxer de tipus de lletra \"%s\" no es pot utilitzar ja que no es troba "
+"dins el directori de tipus de lletra \"%s\"."
+
+#: ../src/osx/menu_osx.cpp:496
+#, c-format
+msgctxt "macOS menu item"
+msgid "About %s"
+msgstr "Quant a %s"
+
+#: ../src/osx/menu_osx.cpp:499
+msgctxt "macOS menu item"
+msgid "About..."
+msgstr "Quant a..."
+
+#: ../src/osx/menu_osx.cpp:508
+msgctxt "macOS menu item"
+msgid "Preferences..."
+msgstr "Preferències..."
+
+#: ../src/osx/menu_osx.cpp:512
+msgctxt "macOS menu item"
+msgid "Services"
+msgstr "Serveis"
+
+#: ../src/osx/menu_osx.cpp:519
+#, c-format
+msgctxt "macOS menu item"
+msgid "Hide %s"
+msgstr "Amaga %s"
+
+#: ../src/osx/menu_osx.cpp:522
+msgctxt "macOS menu item"
+msgid "Hide Application"
+msgstr "Amaga l'aplicació"
+
+#: ../src/osx/menu_osx.cpp:526
+msgctxt "macOS menu item"
+msgid "Hide Others"
+msgstr "Amaga els altres"
+
+#: ../src/osx/menu_osx.cpp:528
+msgctxt "macOS menu item"
+msgid "Show All"
+msgstr "Mostra-ho tot"
+
+#: ../src/osx/menu_osx.cpp:534
+#, c-format
+msgctxt "macOS menu item"
+msgid "Quit %s"
+msgstr "Surt de %s"
+
+#: ../src/osx/menu_osx.cpp:537
+msgctxt "macOS menu item"
+msgid "Quit Application"
+msgstr "Surt de l'aplicació"
+
+#: ../src/osx/webview_webkit.mm:444
+msgid "Printing is not supported by the system web control"
+msgstr "El control web del sistema no suporta impressió"
+
+#: ../src/osx/webview_webkit.mm:453
+msgid "Print operation could not be initialized"
+msgstr "No s'ha pogut inicialitzar l'operació d'impressió"
+
+#. TRANSLATORS: Label of font point size
+#: ../src/propgrid/advprops.cpp:605
+msgid "Point Size"
+msgstr "Mida en punts"
+
+#. TRANSLATORS: Label of font face name
+#: ../src/propgrid/advprops.cpp:615
+msgid "Face Name"
+msgstr "Nom del tipus de lletra"
+
+#. TRANSLATORS: Label of font style
+#: ../src/propgrid/advprops.cpp:623 ../src/richtext/richtextformatdlg.cpp:331
+msgid "Style"
+msgstr "Estil"
+
+#. TRANSLATORS: Label of font weight
+#: ../src/propgrid/advprops.cpp:628
+msgid "Weight"
+msgstr "Pes"
+
+#. TRANSLATORS: Label of underlined font
+#: ../src/propgrid/advprops.cpp:633 ../src/richtext/richtextfontpage.cpp:358
+msgid "Underlined"
+msgstr "Subratllat"
+
+#. TRANSLATORS: Label of font family
+#: ../src/propgrid/advprops.cpp:637
+msgid "Family"
+msgstr "Família"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:801
+msgid "AppWorkspace"
+msgstr "AppWorkspace"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:802
+msgid "ActiveBorder"
+msgstr "ActiveBorder"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:803
+msgid "ActiveCaption"
+msgstr "ActiveCaption"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:804
+msgid "ButtonFace"
+msgstr "ButtonFace"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:805
+msgid "ButtonHighlight"
+msgstr "ButtonHighlight"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:806
+msgid "ButtonShadow"
+msgstr "ButtonShadow"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:807
+msgid "ButtonText"
+msgstr "ButtonText"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:808
+msgid "CaptionText"
+msgstr "CaptionText"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:809
+msgid "ControlDark"
+msgstr "ControlDark"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:810
+msgid "ControlLight"
+msgstr "ControlLight"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:812
+msgid "GrayText"
+msgstr "GrayText"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:813
+msgid "Highlight"
+msgstr "Highlight"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:814
+msgid "HighlightText"
+msgstr "HighlightText"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:815
+msgid "InactiveBorder"
+msgstr "InactiveBorder"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:816
+msgid "InactiveCaption"
+msgstr "InactiveCaption"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:817
+msgid "InactiveCaptionText"
+msgstr "InactiveCaptionText"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:818
+msgid "Menu"
+msgstr "Menú"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:819
+msgid "Scrollbar"
+msgstr "Scrollbar"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:820
+msgid "Tooltip"
+msgstr "Tooltip"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:821
+msgid "TooltipText"
+msgstr "TooltipText"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:822
+msgid "Window"
+msgstr "Window"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:823
+msgid "WindowFrame"
+msgstr "WindowFrame"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:824
+msgid "WindowText"
+msgstr "WindowText"
+
+#. TRANSLATORS: Custom colour choice entry
+#: ../src/propgrid/advprops.cpp:825 ../src/propgrid/advprops.cpp:1532
+#: ../src/propgrid/advprops.cpp:1576
+msgid "Custom"
+msgstr "Personalitzat"
+
+#: ../src/propgrid/advprops.cpp:1558
+msgid "Black"
+msgstr "Negre"
+
+#: ../src/propgrid/advprops.cpp:1559
+msgid "Maroon"
+msgstr "Marró"
+
+#: ../src/propgrid/advprops.cpp:1560
+msgid "Navy"
+msgstr "Blau marí"
+
+#: ../src/propgrid/advprops.cpp:1561
+msgid "Purple"
+msgstr "Porpra"
+
+#: ../src/propgrid/advprops.cpp:1562
+msgid "Teal"
+msgstr "Xarxet"
+
+#: ../src/propgrid/advprops.cpp:1563
+msgid "Gray"
+msgstr "Gris"
+
+#: ../src/propgrid/advprops.cpp:1564
+msgid "Green"
+msgstr "Verd"
+
+#: ../src/propgrid/advprops.cpp:1565
+msgid "Olive"
+msgstr "Oliva"
+
+#: ../src/propgrid/advprops.cpp:1566
+msgid "Brown"
+msgstr "Marró"
+
+#: ../src/propgrid/advprops.cpp:1567
+msgid "Blue"
+msgstr "Blau"
+
+#: ../src/propgrid/advprops.cpp:1568
+msgid "Fuchsia"
+msgstr "Fúcsia"
+
+#: ../src/propgrid/advprops.cpp:1569
+msgid "Red"
+msgstr "Vermell"
+
+#: ../src/propgrid/advprops.cpp:1570
+msgid "Orange"
+msgstr "Carabassa"
+
+#: ../src/propgrid/advprops.cpp:1571
+msgid "Silver"
+msgstr "Argent"
+
+#: ../src/propgrid/advprops.cpp:1572
+msgid "Lime"
+msgstr "Llima"
+
+#: ../src/propgrid/advprops.cpp:1573
+msgid "Aqua"
+msgstr "Cian"
+
+#: ../src/propgrid/advprops.cpp:1574
+msgid "Yellow"
+msgstr "Groc"
+
+#: ../src/propgrid/advprops.cpp:1575
+msgid "White"
+msgstr "Blanc"
+
+#: ../src/propgrid/advprops.cpp:1718
+msgctxt "system cursor name"
+msgid "Default"
+msgstr "Predeterminat"
+
+#: ../src/propgrid/advprops.cpp:1719
+msgctxt "system cursor name"
+msgid "Arrow"
+msgstr "Fletxa"
+
+#: ../src/propgrid/advprops.cpp:1720
+msgctxt "system cursor name"
+msgid "Right Arrow"
+msgstr "Fletxa dreta"
+
+#: ../src/propgrid/advprops.cpp:1721
+msgctxt "system cursor name"
+msgid "Blank"
+msgstr "Buit"
+
+#: ../src/propgrid/advprops.cpp:1722
+msgctxt "system cursor name"
+msgid "Bullseye"
+msgstr "Diana"
+
+#: ../src/propgrid/advprops.cpp:1723
+msgctxt "system cursor name"
+msgid "Character"
+msgstr "Caràcter"
+
+#: ../src/propgrid/advprops.cpp:1724
+msgctxt "system cursor name"
+msgid "Cross"
+msgstr "Creu"
+
+#: ../src/propgrid/advprops.cpp:1725
+msgctxt "system cursor name"
+msgid "Hand"
+msgstr "Mà"
+
+#: ../src/propgrid/advprops.cpp:1726
+msgctxt "system cursor name"
+msgid "I-Beam"
+msgstr "Perfil en I"
+
+#: ../src/propgrid/advprops.cpp:1727
+msgctxt "system cursor name"
+msgid "Left Button"
+msgstr "Botó esquerre"
+
+#: ../src/propgrid/advprops.cpp:1728
+msgctxt "system cursor name"
+msgid "Magnifier"
+msgstr "Lupa"
+
+#: ../src/propgrid/advprops.cpp:1729
+msgctxt "system cursor name"
+msgid "Middle Button"
+msgstr "Botó del mig"
+
+#: ../src/propgrid/advprops.cpp:1730
+msgctxt "system cursor name"
+msgid "No Entry"
+msgstr "Sense entrada"
+
+#: ../src/propgrid/advprops.cpp:1731
+msgctxt "system cursor name"
+msgid "Paint Brush"
+msgstr "Pinzell"
+
+#: ../src/propgrid/advprops.cpp:1732
+msgctxt "system cursor name"
+msgid "Pencil"
+msgstr "Llapis"
+
+#: ../src/propgrid/advprops.cpp:1733
+msgctxt "system cursor name"
+msgid "Point Left"
+msgstr "Apunta a l'esquerra"
+
+#: ../src/propgrid/advprops.cpp:1734
+msgctxt "system cursor name"
+msgid "Point Right"
+msgstr "Apunta a la dreta"
+
+#: ../src/propgrid/advprops.cpp:1735
+msgctxt "system cursor name"
+msgid "Question Arrow"
+msgstr "Fletxa amb interrogació"
+
+#: ../src/propgrid/advprops.cpp:1736
+msgctxt "system cursor name"
+msgid "Right Button"
+msgstr "Botó dret"
+
+#: ../src/propgrid/advprops.cpp:1737
+msgctxt "system cursor name"
+msgid "Sizing NE-SW"
+msgstr "Redimensionament NE-SO"
+
+#: ../src/propgrid/advprops.cpp:1738
+msgctxt "system cursor name"
+msgid "Sizing N-S"
+msgstr "Redimensionament N-S"
+
+#: ../src/propgrid/advprops.cpp:1739
+msgctxt "system cursor name"
+msgid "Sizing NW-SE"
+msgstr "Redimensionament NO-SE"
+
+#: ../src/propgrid/advprops.cpp:1740
+msgctxt "system cursor name"
+msgid "Sizing W-E"
+msgstr "Redimensionament O-E"
+
+#: ../src/propgrid/advprops.cpp:1741
+msgctxt "system cursor name"
+msgid "Sizing"
+msgstr "Redimensionament"
+
+#: ../src/propgrid/advprops.cpp:1742
+msgctxt "system cursor name"
+msgid "Spraycan"
+msgstr "Esprai"
+
+#: ../src/propgrid/advprops.cpp:1743
+msgctxt "system cursor name"
+msgid "Wait"
+msgstr "Espera"
+
+#: ../src/propgrid/advprops.cpp:1744
+msgctxt "system cursor name"
+msgid "Watch"
+msgstr "Rellotge"
+
+#: ../src/propgrid/advprops.cpp:1745
+msgctxt "system cursor name"
+msgid "Wait Arrow"
+msgstr "Fletxa d'espera"
+
+#: ../src/propgrid/advprops.cpp:2109
+msgid "Make a selection:"
+msgstr "Crea una selecció:"
+
+#: ../src/propgrid/manager.cpp:394
+msgid "Property"
+msgstr "Propietat"
+
+#: ../src/propgrid/manager.cpp:395
+msgid "Value"
+msgstr "Valor"
+
+#: ../src/propgrid/manager.cpp:1683
+msgid "Categorized Mode"
+msgstr "Mode categoritzat"
+
+#: ../src/propgrid/manager.cpp:1709
+msgid "Alphabetic Mode"
+msgstr "Mode alfabètic"
+
+#. TRANSLATORS: Name of Boolean false value
+#: ../src/propgrid/propgrid.cpp:230
+msgid "False"
+msgstr "Fals"
+
+#. TRANSLATORS: Name of Boolean true value
+#: ../src/propgrid/propgrid.cpp:232
+msgid "True"
+msgstr "Cert"
+
+#. TRANSLATORS: Text  displayed for unspecified value
+#: ../src/propgrid/propgrid.cpp:428
+msgid "Unspecified"
+msgstr "No especificat"
+
+#. TRANSLATORS: Caption of message box displaying any property error
+#: ../src/propgrid/propgrid.cpp:3145 ../src/propgrid/propgrid.cpp:3282
+msgid "Property Error"
+msgstr "Error de propietat"
+
+#: ../src/propgrid/propgrid.cpp:3259
+msgid "You have entered invalid value. Press ESC to cancel editing."
+msgstr "Heu introduït un valor invàlid. Premeu Esc per a cancel·lar l'edició."
+
+#: ../src/propgrid/propgrid.cpp:6608
+#, c-format
+msgid "Error in resource: %s"
+msgstr "S'ha produït un error al recurs: %s"
+
+#: ../src/propgrid/propgridiface.cpp:377
+#, c-format
+msgid ""
+"Type operation \"%s\" failed: Property labeled \"%s\" is of type \"%s\", NOT "
+"\"%s\"."
+msgstr ""
+"L'operació de tipus \"%s\" ha fallat: La propietat etiquetada \"%s\" és del "
+"tipus \"%s\", NO \"%s\"."
+
+#: ../src/propgrid/props.cpp:159
+#, c-format
+msgid "Unknown base %d. Base 10 will be used."
+msgstr "Base %d desconeguda. S'utilitzarà la base 10."
+
+#: ../src/propgrid/props.cpp:324
+#, c-format
+msgid "Value must be %s or higher."
+msgstr "El valor ha de ser més gran o igual que %s."
+
+#: ../src/propgrid/props.cpp:329 ../src/propgrid/props.cpp:356
+#, c-format
+msgid "Value must be between %s and %s."
+msgstr "El valor ha de ser entre %s i %s."
+
+#: ../src/propgrid/props.cpp:351
+#, c-format
+msgid "Value must be %s or less."
+msgstr "El valor ha de ser més petit o igual que %s."
+
+#: ../src/propgrid/props.cpp:1058
+#, c-format
+msgid "Not %s"
+msgstr "No %s"
+
+#: ../src/propgrid/props.cpp:1770
+msgid "Choose a directory:"
+msgstr "Trieu un directori:"
+
+#: ../src/propgrid/props.cpp:2055
+msgid "Choose a file"
+msgstr "Trieu un fitxer"
+
+#: ../src/qt/mdi.cpp:254
+msgid "&Tile"
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:147
+#: ../src/richtext/richtextformatdlg.cpp:376
+msgid "Background"
+msgstr "Fons"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:159
+msgid "Background &colour:"
+msgstr "&Color de fons:"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:161
+#: ../src/richtext/richtextbackgroundpage.cpp:163
+msgid "Enables a background colour."
+msgstr "Activa un color de fons."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:167
+#: ../src/richtext/richtextbackgroundpage.cpp:169
+msgid "The background colour."
+msgstr "El color de fons."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:178
+msgid "Shadow"
+msgstr "Ombra"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:193
+msgid "Use &shadow"
+msgstr "&Utilitza ombra"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:195
+#: ../src/richtext/richtextbackgroundpage.cpp:197
+msgid "Enables a shadow."
+msgstr "Activa una ombra."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:211
+msgid "&Horizontal offset:"
+msgstr "Desplaçament &horitzontal:"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:218
+#: ../src/richtext/richtextbackgroundpage.cpp:220
+msgid "The horizontal offset."
+msgstr "El desplaçament horitzontal."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:224
+#: ../src/richtext/richtextbackgroundpage.cpp:227
+#: ../src/richtext/richtextbackgroundpage.cpp:228
+#: ../src/richtext/richtextbackgroundpage.cpp:247
+#: ../src/richtext/richtextbackgroundpage.cpp:250
+#: ../src/richtext/richtextbackgroundpage.cpp:251
+#: ../src/richtext/richtextbackgroundpage.cpp:287
+#: ../src/richtext/richtextbackgroundpage.cpp:290
+#: ../src/richtext/richtextbackgroundpage.cpp:291
+#: ../src/richtext/richtextbackgroundpage.cpp:314
+#: ../src/richtext/richtextbackgroundpage.cpp:317
+#: ../src/richtext/richtextbackgroundpage.cpp:318
+#: ../src/richtext/richtextborderspage.cpp:252
+#: ../src/richtext/richtextborderspage.cpp:255
+#: ../src/richtext/richtextborderspage.cpp:256
+#: ../src/richtext/richtextborderspage.cpp:286
+#: ../src/richtext/richtextborderspage.cpp:289
+#: ../src/richtext/richtextborderspage.cpp:290
+#: ../src/richtext/richtextborderspage.cpp:320
+#: ../src/richtext/richtextborderspage.cpp:323
+#: ../src/richtext/richtextborderspage.cpp:324
+#: ../src/richtext/richtextborderspage.cpp:354
+#: ../src/richtext/richtextborderspage.cpp:357
+#: ../src/richtext/richtextborderspage.cpp:358
+#: ../src/richtext/richtextborderspage.cpp:420
+#: ../src/richtext/richtextborderspage.cpp:423
+#: ../src/richtext/richtextborderspage.cpp:424
+#: ../src/richtext/richtextborderspage.cpp:454
+#: ../src/richtext/richtextborderspage.cpp:457
+#: ../src/richtext/richtextborderspage.cpp:458
+#: ../src/richtext/richtextborderspage.cpp:488
+#: ../src/richtext/richtextborderspage.cpp:491
+#: ../src/richtext/richtextborderspage.cpp:492
+#: ../src/richtext/richtextborderspage.cpp:522
+#: ../src/richtext/richtextborderspage.cpp:525
+#: ../src/richtext/richtextborderspage.cpp:526
+#: ../src/richtext/richtextborderspage.cpp:590
+#: ../src/richtext/richtextborderspage.cpp:593
+#: ../src/richtext/richtextborderspage.cpp:594
+#: ../src/richtext/richtextfontpage.cpp:177
+#: ../src/richtext/richtextmarginspage.cpp:199
+#: ../src/richtext/richtextmarginspage.cpp:201
+#: ../src/richtext/richtextmarginspage.cpp:202
+#: ../src/richtext/richtextmarginspage.cpp:224
+#: ../src/richtext/richtextmarginspage.cpp:226
+#: ../src/richtext/richtextmarginspage.cpp:227
+#: ../src/richtext/richtextmarginspage.cpp:247
+#: ../src/richtext/richtextmarginspage.cpp:249
+#: ../src/richtext/richtextmarginspage.cpp:250
+#: ../src/richtext/richtextmarginspage.cpp:272
+#: ../src/richtext/richtextmarginspage.cpp:274
+#: ../src/richtext/richtextmarginspage.cpp:275
+#: ../src/richtext/richtextmarginspage.cpp:313
+#: ../src/richtext/richtextmarginspage.cpp:315
+#: ../src/richtext/richtextmarginspage.cpp:316
+#: ../src/richtext/richtextmarginspage.cpp:338
+#: ../src/richtext/richtextmarginspage.cpp:340
+#: ../src/richtext/richtextmarginspage.cpp:341
+#: ../src/richtext/richtextmarginspage.cpp:361
+#: ../src/richtext/richtextmarginspage.cpp:363
+#: ../src/richtext/richtextmarginspage.cpp:364
+#: ../src/richtext/richtextmarginspage.cpp:386
+#: ../src/richtext/richtextmarginspage.cpp:388
+#: ../src/richtext/richtextmarginspage.cpp:389
+#: ../src/richtext/richtextsizepage.cpp:337
+#: ../src/richtext/richtextsizepage.cpp:340
+#: ../src/richtext/richtextsizepage.cpp:341
+#: ../src/richtext/richtextsizepage.cpp:371
+#: ../src/richtext/richtextsizepage.cpp:374
+#: ../src/richtext/richtextsizepage.cpp:375
+#: ../src/richtext/richtextsizepage.cpp:398
+#: ../src/richtext/richtextsizepage.cpp:401
+#: ../src/richtext/richtextsizepage.cpp:402
+#: ../src/richtext/richtextsizepage.cpp:425
+#: ../src/richtext/richtextsizepage.cpp:428
+#: ../src/richtext/richtextsizepage.cpp:429
+#: ../src/richtext/richtextsizepage.cpp:452
+#: ../src/richtext/richtextsizepage.cpp:455
+#: ../src/richtext/richtextsizepage.cpp:456
+#: ../src/richtext/richtextsizepage.cpp:479
+#: ../src/richtext/richtextsizepage.cpp:482
+#: ../src/richtext/richtextsizepage.cpp:483
+#: ../src/richtext/richtextsizepage.cpp:553
+#: ../src/richtext/richtextsizepage.cpp:556
+#: ../src/richtext/richtextsizepage.cpp:557
+#: ../src/richtext/richtextsizepage.cpp:588
+#: ../src/richtext/richtextsizepage.cpp:591
+#: ../src/richtext/richtextsizepage.cpp:592
+#: ../src/richtext/richtextsizepage.cpp:623
+#: ../src/richtext/richtextsizepage.cpp:626
+#: ../src/richtext/richtextsizepage.cpp:627
+#: ../src/richtext/richtextsizepage.cpp:658
+#: ../src/richtext/richtextsizepage.cpp:661
+#: ../src/richtext/richtextsizepage.cpp:662
+msgid "px"
+msgstr "px"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:225
+#: ../src/richtext/richtextbackgroundpage.cpp:248
+#: ../src/richtext/richtextbackgroundpage.cpp:288
+#: ../src/richtext/richtextbackgroundpage.cpp:315
+#: ../src/richtext/richtextborderspage.cpp:253
+#: ../src/richtext/richtextborderspage.cpp:287
+#: ../src/richtext/richtextborderspage.cpp:321
+#: ../src/richtext/richtextborderspage.cpp:355
+#: ../src/richtext/richtextborderspage.cpp:421
+#: ../src/richtext/richtextborderspage.cpp:455
+#: ../src/richtext/richtextborderspage.cpp:489
+#: ../src/richtext/richtextborderspage.cpp:523
+#: ../src/richtext/richtextborderspage.cpp:591
+#: ../src/richtext/richtextmarginspage.cpp:200
+#: ../src/richtext/richtextmarginspage.cpp:225
+#: ../src/richtext/richtextmarginspage.cpp:248
+#: ../src/richtext/richtextmarginspage.cpp:273
+#: ../src/richtext/richtextmarginspage.cpp:314
+#: ../src/richtext/richtextmarginspage.cpp:339
+#: ../src/richtext/richtextmarginspage.cpp:362
+#: ../src/richtext/richtextmarginspage.cpp:387
+#: ../src/richtext/richtextsizepage.cpp:338
+#: ../src/richtext/richtextsizepage.cpp:372
+#: ../src/richtext/richtextsizepage.cpp:399
+#: ../src/richtext/richtextsizepage.cpp:426
+#: ../src/richtext/richtextsizepage.cpp:453
+#: ../src/richtext/richtextsizepage.cpp:480
+#: ../src/richtext/richtextsizepage.cpp:554
+#: ../src/richtext/richtextsizepage.cpp:589
+#: ../src/richtext/richtextsizepage.cpp:624
+#: ../src/richtext/richtextsizepage.cpp:659
+msgid "cm"
+msgstr "cm"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:226
+#: ../src/richtext/richtextbackgroundpage.cpp:249
+#: ../src/richtext/richtextbackgroundpage.cpp:289
+#: ../src/richtext/richtextbackgroundpage.cpp:316
+#: ../src/richtext/richtextborderspage.cpp:254
+#: ../src/richtext/richtextborderspage.cpp:288
+#: ../src/richtext/richtextborderspage.cpp:322
+#: ../src/richtext/richtextborderspage.cpp:356
+#: ../src/richtext/richtextborderspage.cpp:422
+#: ../src/richtext/richtextborderspage.cpp:456
+#: ../src/richtext/richtextborderspage.cpp:490
+#: ../src/richtext/richtextborderspage.cpp:524
+#: ../src/richtext/richtextborderspage.cpp:592
+#: ../src/richtext/richtextfontpage.cpp:176
+#: ../src/richtext/richtextfontpage.cpp:179
+msgid "pt"
+msgstr "pt"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:229
+#: ../src/richtext/richtextbackgroundpage.cpp:231
+#: ../src/richtext/richtextbackgroundpage.cpp:252
+#: ../src/richtext/richtextbackgroundpage.cpp:254
+#: ../src/richtext/richtextbackgroundpage.cpp:292
+#: ../src/richtext/richtextbackgroundpage.cpp:294
+#: ../src/richtext/richtextbackgroundpage.cpp:319
+#: ../src/richtext/richtextbackgroundpage.cpp:321
+msgid "Units for this value."
+msgstr "Unitats per a aquest valor."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:234
+msgid "&Vertical offset:"
+msgstr "Desplaçament &vertical:"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:241
+#: ../src/richtext/richtextbackgroundpage.cpp:243
+msgid "The vertical offset."
+msgstr "El desplaçament vertical."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:257
+msgid "Shadow c&olour:"
+msgstr "C&olor de l'ombra:"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:259
+#: ../src/richtext/richtextbackgroundpage.cpp:261
+msgid "Enables the shadow colour."
+msgstr "Activa el color de l'ombra."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:265
+#: ../src/richtext/richtextbackgroundpage.cpp:267
+msgid "The shadow colour."
+msgstr "El color de l'ombra."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:270
+msgid "Sh&adow spread:"
+msgstr "Difusió de l'ombr&a:"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:272
+#: ../src/richtext/richtextbackgroundpage.cpp:274
+msgid "Enables the shadow spread."
+msgstr "Activa la difusió de l'ombra."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:281
+#: ../src/richtext/richtextbackgroundpage.cpp:283
+msgid "The shadow spread."
+msgstr "La difusió de l'ombra."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:297
+msgid "&Blur distance:"
+msgstr "Distància del &difuminat:"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:299
+#: ../src/richtext/richtextbackgroundpage.cpp:301
+msgid "Enables the blur distance."
+msgstr "Activa la distància de difuminat."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:308
+#: ../src/richtext/richtextbackgroundpage.cpp:310
+msgid "The shadow blur distance."
+msgstr "La distància del difuminat de l'ombra."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:324
+msgid "Opaci&ty:"
+msgstr "Opaci&tat:"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:326
+#: ../src/richtext/richtextbackgroundpage.cpp:328
+msgid "Enables the shadow opacity."
+msgstr "Activa l'opacitat de l'ombra."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:335
+#: ../src/richtext/richtextbackgroundpage.cpp:337
+msgid "The shadow opacity."
+msgstr "L'opacitat de l'ombra."
+
+#. TRANSLATORS: Rich text page units (percentage)
+#: ../src/richtext/richtextbackgroundpage.cpp:340
+#: ../src/richtext/richtextsizepage.cpp:339
+#: ../src/richtext/richtextsizepage.cpp:373
+#: ../src/richtext/richtextsizepage.cpp:400
+#: ../src/richtext/richtextsizepage.cpp:427
+#: ../src/richtext/richtextsizepage.cpp:454
+#: ../src/richtext/richtextsizepage.cpp:481
+#: ../src/richtext/richtextsizepage.cpp:555
+#: ../src/richtext/richtextsizepage.cpp:590
+#: ../src/richtext/richtextsizepage.cpp:625
+#: ../src/richtext/richtextsizepage.cpp:660
+msgid "%"
+msgstr "%"
+
+#: ../src/richtext/richtextborderspage.cpp:229
+#: ../src/richtext/richtextborderspage.cpp:387
+msgid "Border"
+msgstr "Vora"
+
+#: ../src/richtext/richtextborderspage.cpp:242
+#: ../src/richtext/richtextborderspage.cpp:410
+#: ../src/richtext/richtextindentspage.cpp:194
+#: ../src/richtext/richtextliststylepage.cpp:384
+#: ../src/richtext/richtextmarginspage.cpp:185
+#: ../src/richtext/richtextmarginspage.cpp:299
+#: ../src/richtext/richtextsizepage.cpp:531
+#: ../src/richtext/richtextsizepage.cpp:538
+msgid "&Left:"
+msgstr "&Esquerra:"
+
+#: ../src/richtext/richtextborderspage.cpp:257
+#: ../src/richtext/richtextborderspage.cpp:259
+msgid "Units for the left border width."
+msgstr "Unitats per a l'amplada de la vora esquerra."
+
+#: ../src/richtext/richtextborderspage.cpp:266
+#: ../src/richtext/richtextborderspage.cpp:268
+#: ../src/richtext/richtextborderspage.cpp:300
+#: ../src/richtext/richtextborderspage.cpp:302
+#: ../src/richtext/richtextborderspage.cpp:334
+#: ../src/richtext/richtextborderspage.cpp:336
+#: ../src/richtext/richtextborderspage.cpp:368
+#: ../src/richtext/richtextborderspage.cpp:370
+#: ../src/richtext/richtextborderspage.cpp:434
+#: ../src/richtext/richtextborderspage.cpp:436
+#: ../src/richtext/richtextborderspage.cpp:468
+#: ../src/richtext/richtextborderspage.cpp:470
+#: ../src/richtext/richtextborderspage.cpp:502
+#: ../src/richtext/richtextborderspage.cpp:504
+#: ../src/richtext/richtextborderspage.cpp:536
+#: ../src/richtext/richtextborderspage.cpp:538
+msgid "The border line style."
+msgstr "L'estil de la línia de la vora."
+
+#: ../src/richtext/richtextborderspage.cpp:276
+#: ../src/richtext/richtextborderspage.cpp:444
+#: ../src/richtext/richtextindentspage.cpp:212
+#: ../src/richtext/richtextliststylepage.cpp:402
+#: ../src/richtext/richtextmarginspage.cpp:210
+#: ../src/richtext/richtextmarginspage.cpp:324
+#: ../src/richtext/richtextsizepage.cpp:601
+#: ../src/richtext/richtextsizepage.cpp:608
+msgid "&Right:"
+msgstr "D&reta:"
+
+#: ../src/richtext/richtextborderspage.cpp:291
+#: ../src/richtext/richtextborderspage.cpp:293
+msgid "Units for the right border width."
+msgstr "Unitats per a l'amplada de la vora dreta."
+
+#: ../src/richtext/richtextborderspage.cpp:310
+#: ../src/richtext/richtextborderspage.cpp:478
+#: ../src/richtext/richtextmarginspage.cpp:233
+#: ../src/richtext/richtextmarginspage.cpp:347
+#: ../src/richtext/richtextsizepage.cpp:566
+#: ../src/richtext/richtextsizepage.cpp:573
+msgid "&Top:"
+msgstr "&Superior:"
+
+#: ../src/richtext/richtextborderspage.cpp:325
+#: ../src/richtext/richtextborderspage.cpp:327
+msgid "Units for the top border width."
+msgstr "Unitats per a l'amplada de la vora superior."
+
+#: ../src/richtext/richtextborderspage.cpp:344
+#: ../src/richtext/richtextborderspage.cpp:512
+#: ../src/richtext/richtextmarginspage.cpp:258
+#: ../src/richtext/richtextmarginspage.cpp:372
+#: ../src/richtext/richtextsizepage.cpp:636
+#: ../src/richtext/richtextsizepage.cpp:643
+msgid "&Bottom:"
+msgstr "&Inferior:"
+
+#: ../src/richtext/richtextborderspage.cpp:359
+#: ../src/richtext/richtextborderspage.cpp:361
+msgid "Units for the bottom border width."
+msgstr "Unitats per a l'amplada de la vora inferior."
+
+#: ../src/richtext/richtextborderspage.cpp:380
+#: ../src/richtext/richtextborderspage.cpp:548
+msgid "&Synchronize values"
+msgstr "&Sincronitza els valors"
+
+#: ../src/richtext/richtextborderspage.cpp:382
+#: ../src/richtext/richtextborderspage.cpp:384
+#: ../src/richtext/richtextborderspage.cpp:550
+#: ../src/richtext/richtextborderspage.cpp:552
+msgid "Check to edit all borders simultaneously."
+msgstr "Marqueu-ho per a editar totes les vores alhora."
+
+#: ../src/richtext/richtextborderspage.cpp:397
+#: ../src/richtext/richtextborderspage.cpp:555
+msgid "Outline"
+msgstr "Contorn"
+
+#: ../src/richtext/richtextborderspage.cpp:425
+#: ../src/richtext/richtextborderspage.cpp:427
+msgid "Units for the left outline width."
+msgstr "Unitats per a l'amplada del contorn esquerre."
+
+#: ../src/richtext/richtextborderspage.cpp:459
+#: ../src/richtext/richtextborderspage.cpp:461
+msgid "Units for the right outline width."
+msgstr "Unitats per a l'amplada del contorn dret."
+
+#: ../src/richtext/richtextborderspage.cpp:493
+#: ../src/richtext/richtextborderspage.cpp:495
+msgid "Units for the top outline width."
+msgstr "Unitats per a l'amplada del contorn superior."
+
+#: ../src/richtext/richtextborderspage.cpp:527
+#: ../src/richtext/richtextborderspage.cpp:529
+msgid "Units for the bottom outline width."
+msgstr "Unitats per a l'amplada del contorn inferior."
+
+#: ../src/richtext/richtextborderspage.cpp:565
+#: ../src/richtext/richtextborderspage.cpp:600
+msgid "Corner"
+msgstr "Cantonada"
+
+#: ../src/richtext/richtextborderspage.cpp:574
+msgid "Corner &radius:"
+msgstr "&Radi de la cantonada:"
+
+#: ../src/richtext/richtextborderspage.cpp:576
+#: ../src/richtext/richtextborderspage.cpp:578
+msgid "An optional corner radius for adding rounded corners."
+msgstr "Un radi de cantonada opcional per a afegir cantonades arrodonides."
+
+#: ../src/richtext/richtextborderspage.cpp:584
+#: ../src/richtext/richtextborderspage.cpp:586
+msgid "The value of the corner radius."
+msgstr "El valor del radi de les cantonades."
+
+#: ../src/richtext/richtextborderspage.cpp:595
+#: ../src/richtext/richtextborderspage.cpp:597
+msgid "Units for the corner radius."
+msgstr "Unitats per al radi de les cantonades."
+
+#: ../src/richtext/richtextborderspage.cpp:609
+#: ../src/richtext/richtextsizepage.cpp:247
+#: ../src/richtext/richtextsizepage.cpp:251
+msgid "None"
+msgstr "Cap"
+
+#: ../src/richtext/richtextborderspage.cpp:610
+msgid "Solid"
+msgstr "Sòlid"
+
+#: ../src/richtext/richtextborderspage.cpp:611
+msgid "Dotted"
+msgstr "Puntejat"
+
+#: ../src/richtext/richtextborderspage.cpp:612
+msgid "Dashed"
+msgstr "Ratllat"
+
+#: ../src/richtext/richtextborderspage.cpp:613
+msgid "Double"
+msgstr "Doble"
+
+#: ../src/richtext/richtextborderspage.cpp:614
+msgid "Groove"
+msgstr "Ranura"
+
+#: ../src/richtext/richtextborderspage.cpp:615
+msgid "Ridge"
+msgstr "Arruga"
+
+#: ../src/richtext/richtextborderspage.cpp:616
+msgid "Inset"
+msgstr "Interior"
+
+#: ../src/richtext/richtextborderspage.cpp:617
+msgid "Outset"
+msgstr "Exterior"
+
+#: ../src/richtext/richtextbuffer.cpp:3518
+msgid "Change Style"
+msgstr "Canvia l'estil"
+
+#: ../src/richtext/richtextbuffer.cpp:3701
+msgid "Change Object Style"
+msgstr "Canvia l'estil d'objecte"
+
+#: ../src/richtext/richtextbuffer.cpp:3974
+#: ../src/richtext/richtextbuffer.cpp:8174
+msgid "Change Properties"
+msgstr "Canvia les propietats"
+
+#: ../src/richtext/richtextbuffer.cpp:4346
+msgid "Change List Style"
+msgstr "Canvia l'estil de llista"
+
+#: ../src/richtext/richtextbuffer.cpp:4519
+msgid "Renumber List"
+msgstr "Torna a numerar la llista"
+
+#: ../src/richtext/richtextbuffer.cpp:7867
+#: ../src/richtext/richtextbuffer.cpp:7897
+#: ../src/richtext/richtextbuffer.cpp:7939
+#: ../src/richtext/richtextctrl.cpp:1279 ../src/richtext/richtextctrl.cpp:1473
+msgid "Insert Text"
+msgstr "Insereix text"
+
+#: ../src/richtext/richtextbuffer.cpp:8023
+#: ../src/richtext/richtextbuffer.cpp:8979
+msgid "Insert Image"
+msgstr "Insereix una imatge"
+
+#: ../src/richtext/richtextbuffer.cpp:8070
+msgid "Insert Object"
+msgstr "Insereix un objecte"
+
+#: ../src/richtext/richtextbuffer.cpp:8112
+msgid "Insert Field"
+msgstr "Insereix un camp"
+
+#: ../src/richtext/richtextbuffer.cpp:8410
+msgid "Too many EndStyle calls!"
+msgstr "Massa crides a EndStyle!"
+
+#: ../src/richtext/richtextbuffer.cpp:8785
+msgid "files"
+msgstr "fitxers"
+
+#: ../src/richtext/richtextbuffer.cpp:9380
+msgid "standard/circle"
+msgstr "estàndard/cercle"
+
+#: ../src/richtext/richtextbuffer.cpp:9381
+msgid "standard/circle-outline"
+msgstr "estàndard/circumferència"
+
+#: ../src/richtext/richtextbuffer.cpp:9382
+msgid "standard/square"
+msgstr "estàndard/quadrat"
+
+#: ../src/richtext/richtextbuffer.cpp:9383
+msgid "standard/diamond"
+msgstr "estàndard/diamant"
+
+#: ../src/richtext/richtextbuffer.cpp:9384
+msgid "standard/triangle"
+msgstr "estàndard/triangle"
+
+#: ../src/richtext/richtextbuffer.cpp:9423
+msgid "Box Properties"
+msgstr "Propietats de la caixa"
+
+#: ../src/richtext/richtextbuffer.cpp:10006
+msgid "Multiple Cell Properties"
+msgstr "Propietats de múltiples cel·les"
+
+#: ../src/richtext/richtextbuffer.cpp:10008
+msgid "Cell Properties"
+msgstr "Propietats de la cel·la"
+
+#: ../src/richtext/richtextbuffer.cpp:11256
+msgid "Set Cell Style"
+msgstr "Defineix l'estil de la cel·la"
+
+#: ../src/richtext/richtextbuffer.cpp:11330
+msgid "Delete Row"
+msgstr "Suprimeix la fila"
+
+#: ../src/richtext/richtextbuffer.cpp:11380
+msgid "Delete Column"
+msgstr "Suprimeix la columna"
+
+#: ../src/richtext/richtextbuffer.cpp:11431
+msgid "Add Row"
+msgstr "Afegeix una fila"
+
+#: ../src/richtext/richtextbuffer.cpp:11494
+msgid "Add Column"
+msgstr "Afegeix una columna"
+
+#: ../src/richtext/richtextbuffer.cpp:11537
+msgid "Table Properties"
+msgstr "Propietats de la taula"
+
+#: ../src/richtext/richtextbuffer.cpp:12899
+msgid "Picture Properties"
+msgstr "Propietats de la imatge"
+
+#: ../src/richtext/richtextbuffer.cpp:13169
+#: ../src/richtext/richtextbuffer.cpp:13279
+msgid "image"
+msgstr "imatge"
+
+#: ../src/richtext/richtextbulletspage.cpp:145
+#: ../src/richtext/richtextliststylepage.cpp:209
+msgid "&Bullet style:"
+msgstr "Estil de &pic:"
+
+#: ../src/richtext/richtextbulletspage.cpp:150
+#: ../src/richtext/richtextbulletspage.cpp:152
+#: ../src/richtext/richtextliststylepage.cpp:214
+#: ../src/richtext/richtextliststylepage.cpp:216
+msgid "The available bullet styles."
+msgstr "Els estils de pic disponibles."
+
+#: ../src/richtext/richtextbulletspage.cpp:158
+#: ../src/richtext/richtextliststylepage.cpp:221
+msgid "Peri&od"
+msgstr "Perí&ode"
+
+#: ../src/richtext/richtextbulletspage.cpp:160
+#: ../src/richtext/richtextbulletspage.cpp:162
+#: ../src/richtext/richtextliststylepage.cpp:223
+#: ../src/richtext/richtextliststylepage.cpp:225
+msgid "Check to add a period after the bullet."
+msgstr "Marqueu-ho per a afegir un punt després del pic."
+
+#. TRANSLATORS: Bullet point in parentheses option
+#: ../src/richtext/richtextbulletspage.cpp:167
+#: ../src/richtext/richtextliststylepage.cpp:230
+msgid "(*)"
+msgstr "(*)"
+
+#: ../src/richtext/richtextbulletspage.cpp:169
+#: ../src/richtext/richtextbulletspage.cpp:171
+#: ../src/richtext/richtextliststylepage.cpp:232
+#: ../src/richtext/richtextliststylepage.cpp:234
+msgid "Check to enclose the bullet in parentheses."
+msgstr "Marqueu-ho per a envoltar el pic entre parèntesis."
+
+#. TRANSLATORS: Right parenthesis bullet point option
+#: ../src/richtext/richtextbulletspage.cpp:176
+#: ../src/richtext/richtextliststylepage.cpp:239
+msgid "*)"
+msgstr "*)"
+
+#: ../src/richtext/richtextbulletspage.cpp:178
+#: ../src/richtext/richtextbulletspage.cpp:180
+#: ../src/richtext/richtextliststylepage.cpp:241
+#: ../src/richtext/richtextliststylepage.cpp:243
+msgid "Check to add a right parenthesis."
+msgstr "Marqueu-ho per a afegir un parèntesi a la dreta."
+
+#: ../src/richtext/richtextbulletspage.cpp:185
+#: ../src/richtext/richtextliststylepage.cpp:248
+msgid "Bullet &Alignment:"
+msgstr "&Alineació del pic:"
+
+#: ../src/richtext/richtextbulletspage.cpp:190
+#: ../src/richtext/richtextliststylepage.cpp:253
+msgid "Centre"
+msgstr "Centre"
+
+#: ../src/richtext/richtextbulletspage.cpp:194
+#: ../src/richtext/richtextbulletspage.cpp:196
+#: ../src/richtext/richtextbulletspage.cpp:217
+#: ../src/richtext/richtextbulletspage.cpp:219
+#: ../src/richtext/richtextliststylepage.cpp:257
+#: ../src/richtext/richtextliststylepage.cpp:259
+#: ../src/richtext/richtextliststylepage.cpp:278
+#: ../src/richtext/richtextliststylepage.cpp:280
+msgid "The bullet character."
+msgstr "El caràcter del pic."
+
+#: ../src/richtext/richtextbulletspage.cpp:212
+#: ../src/richtext/richtextliststylepage.cpp:271
+msgid "&Symbol:"
+msgstr "&Símbol:"
+
+#: ../src/richtext/richtextbulletspage.cpp:222
+#: ../src/richtext/richtextliststylepage.cpp:283
+msgid "Ch&oose..."
+msgstr "T&ria..."
+
+#: ../src/richtext/richtextbulletspage.cpp:223
+#: ../src/richtext/richtextbulletspage.cpp:225
+#: ../src/richtext/richtextliststylepage.cpp:284
+#: ../src/richtext/richtextliststylepage.cpp:286
+msgid "Click to browse for a symbol."
+msgstr "Feu clic per a cercar un símbol."
+
+#: ../src/richtext/richtextbulletspage.cpp:230
+#: ../src/richtext/richtextliststylepage.cpp:291
+msgid "Symbol &font:"
+msgstr "&Tipus de lletra per a símbols:"
+
+#: ../src/richtext/richtextbulletspage.cpp:235
+#: ../src/richtext/richtextbulletspage.cpp:237
+#: ../src/richtext/richtextliststylepage.cpp:297
+msgid "Available fonts."
+msgstr "Tipus de lletra disponibles."
+
+#: ../src/richtext/richtextbulletspage.cpp:242
+#: ../src/richtext/richtextliststylepage.cpp:302
+msgid "S&tandard bullet name:"
+msgstr "Nom del pic es&tàndard:"
+
+#: ../src/richtext/richtextbulletspage.cpp:247
+#: ../src/richtext/richtextbulletspage.cpp:249
+#: ../src/richtext/richtextliststylepage.cpp:307
+#: ../src/richtext/richtextliststylepage.cpp:309
+msgid "A standard bullet name."
+msgstr "Un nom de pic estàndard."
+
+#: ../src/richtext/richtextbulletspage.cpp:254
+msgid "&Number:"
+msgstr "&Número:"
+
+#: ../src/richtext/richtextbulletspage.cpp:258
+#: ../src/richtext/richtextbulletspage.cpp:260
+msgid "The list item number."
+msgstr "El número de l'element de la llista."
+
+#: ../src/richtext/richtextbulletspage.cpp:266
+#: ../src/richtext/richtextbulletspage.cpp:268
+#: ../src/richtext/richtextliststylepage.cpp:475
+#: ../src/richtext/richtextliststylepage.cpp:477
+msgid "Shows a preview of the bullet settings."
+msgstr "Mostra una previsualització de la configuració dels pics."
+
+#: ../src/richtext/richtextbulletspage.cpp:276
+#: ../src/richtext/richtextliststylepage.cpp:484
+msgid "(None)"
+msgstr "(Cap)"
+
+#: ../src/richtext/richtextbulletspage.cpp:277
+#: ../src/richtext/richtextliststylepage.cpp:485
+msgid "Arabic"
+msgstr "Àrab"
+
+#: ../src/richtext/richtextbulletspage.cpp:278
+#: ../src/richtext/richtextliststylepage.cpp:486
+msgid "Upper case letters"
+msgstr "Lletres majúscules"
+
+#: ../src/richtext/richtextbulletspage.cpp:279
+#: ../src/richtext/richtextliststylepage.cpp:487
+msgid "Lower case letters"
+msgstr "Lletres en minúscules"
+
+#: ../src/richtext/richtextbulletspage.cpp:280
+#: ../src/richtext/richtextliststylepage.cpp:488
+msgid "Upper case roman numerals"
+msgstr "Nombres romans en majúscules"
+
+#: ../src/richtext/richtextbulletspage.cpp:281
+#: ../src/richtext/richtextliststylepage.cpp:489
+msgid "Lower case roman numerals"
+msgstr "Nombres romans en minúscules"
+
+#: ../src/richtext/richtextbulletspage.cpp:282
+#: ../src/richtext/richtextliststylepage.cpp:490
+msgid "Numbered outline"
+msgstr "Esquema numerat"
+
+#: ../src/richtext/richtextbulletspage.cpp:283
+#: ../src/richtext/richtextliststylepage.cpp:491
+msgid "Symbol"
+msgstr "Símbol"
+
+#: ../src/richtext/richtextbulletspage.cpp:284
+#: ../src/richtext/richtextliststylepage.cpp:492
+msgid "Bitmap"
+msgstr "Mapa de bits"
+
+#: ../src/richtext/richtextbulletspage.cpp:285
+#: ../src/richtext/richtextliststylepage.cpp:493
+msgid "Standard"
+msgstr "Estàndard"
+
+#: ../src/richtext/richtextbulletspage.cpp:287
+#: ../src/richtext/richtextliststylepage.cpp:495
+msgid "*"
+msgstr "*"
+
+#: ../src/richtext/richtextbulletspage.cpp:288
+#: ../src/richtext/richtextliststylepage.cpp:496
+msgid "-"
+msgstr "-"
+
+#: ../src/richtext/richtextbulletspage.cpp:289
+#: ../src/richtext/richtextliststylepage.cpp:497
+msgid ">"
+msgstr ">"
+
+#: ../src/richtext/richtextbulletspage.cpp:290
+#: ../src/richtext/richtextliststylepage.cpp:498
+msgid "+"
+msgstr "+"
+
+#: ../src/richtext/richtextbulletspage.cpp:291
+#: ../src/richtext/richtextliststylepage.cpp:499
+msgid "~"
+msgstr "~"
+
+#: ../src/richtext/richtextctrl.cpp:859
+msgid "Drag"
+msgstr "Arrossega"
+
+#: ../src/richtext/richtextctrl.cpp:1338 ../src/richtext/richtextctrl.cpp:1559
+msgid "Delete Text"
+msgstr "Suprimeix el text"
+
+#: ../src/richtext/richtextctrl.cpp:1537
+msgid "Remove Bullet"
+msgstr "Suprimeix el pic"
+
+#: ../src/richtext/richtextctrl.cpp:3070
+msgid "The text couldn't be saved."
+msgstr "No s'ha pogut desar el text."
+
+#: ../src/richtext/richtextctrl.cpp:3644
+msgid "Replace"
+msgstr "Substitueix"
+
+#: ../src/richtext/richtextfontpage.cpp:146
+#: ../src/richtext/richtextsymboldlg.cpp:384
+msgid "&Font:"
+msgstr "&Tipus de lletra:"
+
+#: ../src/richtext/richtextfontpage.cpp:150
+#: ../src/richtext/richtextfontpage.cpp:152
+msgid "Type a font name."
+msgstr "Escriviu un nom de tipus de lletra."
+
+#: ../src/richtext/richtextfontpage.cpp:158
+msgid "&Size:"
+msgstr "&Mida:"
+
+#: ../src/richtext/richtextfontpage.cpp:165
+#: ../src/richtext/richtextfontpage.cpp:167
+msgid "Type a size in points."
+msgstr "Escriviu una mida en punts."
+
+#: ../src/richtext/richtextfontpage.cpp:180
+#: ../src/richtext/richtextfontpage.cpp:182
+msgid "The font size units, points or pixels."
+msgstr "Les unitats, punts o píxels de la mida del tipus de lletra."
+
+#: ../src/richtext/richtextfontpage.cpp:189
+#: ../src/richtext/richtextfontpage.cpp:191
+msgid "Lists the available fonts."
+msgstr "Mostra la llista de tipus de lletra disponibles."
+
+#: ../src/richtext/richtextfontpage.cpp:196
+#: ../src/richtext/richtextfontpage.cpp:198
+msgid "Lists font sizes in points."
+msgstr "Mostra una llista de mides de lletra en punts."
+
+#: ../src/richtext/richtextfontpage.cpp:207
+msgid "Font st&yle:"
+msgstr "&Estil de la lletra:"
+
+#: ../src/richtext/richtextfontpage.cpp:212
+#: ../src/richtext/richtextfontpage.cpp:214
+msgid "Select regular or italic style."
+msgstr "Selecciona l'estil normal o cursiva."
+
+#: ../src/richtext/richtextfontpage.cpp:220
+msgid "Font &weight:"
+msgstr "&Pes de la lletra:"
+
+#: ../src/richtext/richtextfontpage.cpp:225
+#: ../src/richtext/richtextfontpage.cpp:227
+msgid "Select regular or bold."
+msgstr "Selecciona normal o negreta."
+
+#: ../src/richtext/richtextfontpage.cpp:233
+msgid "&Underlining:"
+msgstr "S&ubratllat:"
+
+#: ../src/richtext/richtextfontpage.cpp:238
+#: ../src/richtext/richtextfontpage.cpp:240
+msgid "Select underlining or no underlining."
+msgstr "Selecciona subratllat o sense subratllat."
+
+#: ../src/richtext/richtextfontpage.cpp:248
+msgid "&Colour:"
+msgstr "&Color:"
+
+#: ../src/richtext/richtextfontpage.cpp:253
+#: ../src/richtext/richtextfontpage.cpp:255
+msgid "Click to change the text colour."
+msgstr "Feu clic per a canviar el text del color."
+
+#: ../src/richtext/richtextfontpage.cpp:261
+msgid "&Bg colour:"
+msgstr "Color de &fons:"
+
+#: ../src/richtext/richtextfontpage.cpp:266
+#: ../src/richtext/richtextfontpage.cpp:268
+msgid "Click to change the text background colour."
+msgstr "Feu clic per a canviar el color de fons del text."
+
+#: ../src/richtext/richtextfontpage.cpp:276
+#: ../src/richtext/richtextfontpage.cpp:278
+msgid "Check to show a line through the text."
+msgstr "Marqueu-ho per a mostrar una ratlla a través del text."
+
+#: ../src/richtext/richtextfontpage.cpp:281
+msgid "Ca&pitals"
+msgstr "Ma&júscules"
+
+#: ../src/richtext/richtextfontpage.cpp:283
+#: ../src/richtext/richtextfontpage.cpp:285
+msgid "Check to show the text in capitals."
+msgstr "Marqueu-ho per a mostrar el text en majúscules."
+
+#: ../src/richtext/richtextfontpage.cpp:288
+msgid "Small C&apitals"
+msgstr "Vers&aleta"
+
+#: ../src/richtext/richtextfontpage.cpp:290
+#: ../src/richtext/richtextfontpage.cpp:292
+msgid "Check to show the text in small capitals."
+msgstr "Marqueu-ho per a mostrar el text en versaleta."
+
+#: ../src/richtext/richtextfontpage.cpp:295
+msgid "Supe&rscript"
+msgstr "Supe&ríndex"
+
+#: ../src/richtext/richtextfontpage.cpp:297
+#: ../src/richtext/richtextfontpage.cpp:299
+msgid "Check to show the text in superscript."
+msgstr "Marqueu-ho per a mostrar el text en superíndex."
+
+#: ../src/richtext/richtextfontpage.cpp:302
+msgid "Subscrip&t"
+msgstr "Subín&dex"
+
+#: ../src/richtext/richtextfontpage.cpp:304
+#: ../src/richtext/richtextfontpage.cpp:306
+msgid "Check to show the text in subscript."
+msgstr "Marqueu-ho per a mostrar el text en subíndex."
+
+#: ../src/richtext/richtextfontpage.cpp:312
+msgid "Rig&ht-to-left"
+msgstr "&De dreta a esquerra"
+
+#: ../src/richtext/richtextfontpage.cpp:314
+#: ../src/richtext/richtextfontpage.cpp:316
+msgid "Check to indicate right-to-left text layout."
+msgstr "Marqueu-ho per a indicar una disposició de text de dreta a esquerra."
+
+#: ../src/richtext/richtextfontpage.cpp:319
+msgid "Suppress hyphe&nation"
+msgstr "&Suprimeix la divisió de paraules"
+
+#: ../src/richtext/richtextfontpage.cpp:321
+#: ../src/richtext/richtextfontpage.cpp:323
+msgid "Check to suppress hyphenation."
+msgstr "Marqueu-ho per a suprimir la divisió de paraules."
+
+#: ../src/richtext/richtextfontpage.cpp:329
+#: ../src/richtext/richtextfontpage.cpp:331
+msgid "Shows a preview of the font settings."
+msgstr "Mostra una previsualització de la configuració del tipus de lletra."
+
+#: ../src/richtext/richtextfontpage.cpp:348
+#: ../src/richtext/richtextfontpage.cpp:352
+#: ../src/richtext/richtextfontpage.cpp:356
+#: ../src/richtext/richtextformatdlg.cpp:873
+#: ../src/richtext/richtextindentspage.cpp:273
+#: ../src/richtext/richtextindentspage.cpp:285
+#: ../src/richtext/richtextindentspage.cpp:286
+#: ../src/richtext/richtextindentspage.cpp:310
+#: ../src/richtext/richtextindentspage.cpp:325
+#: ../src/richtext/richtextliststylepage.cpp:451
+#: ../src/richtext/richtextliststylepage.cpp:463
+#: ../src/richtext/richtextliststylepage.cpp:464
+msgid "(none)"
+msgstr "(cap)"
+
+#: ../src/richtext/richtextfontpage.cpp:349
+#: ../src/richtext/richtextfontpage.cpp:353
+msgid "Regular"
+msgstr "Normal"
+
+#: ../src/richtext/richtextfontpage.cpp:357
+msgid "Not underlined"
+msgstr "No subratllat"
+
+#: ../src/richtext/richtextformatdlg.cpp:341
+msgid "Indents && Spacing"
+msgstr "Indentació i espaiat"
+
+#: ../src/richtext/richtextformatdlg.cpp:346
+msgid "Tabs"
+msgstr "Tabulacions"
+
+#: ../src/richtext/richtextformatdlg.cpp:351
+msgid "Bullets"
+msgstr "Pics"
+
+#: ../src/richtext/richtextformatdlg.cpp:356
+msgid "List Style"
+msgstr "Estil de llista"
+
+#: ../src/richtext/richtextformatdlg.cpp:366
+#: ../src/richtext/richtextmarginspage.cpp:170
+msgid "Margins"
+msgstr "Marges"
+
+#: ../src/richtext/richtextformatdlg.cpp:371
+msgid "Borders"
+msgstr "Vores"
+
+#: ../src/richtext/richtextformatdlg.cpp:765
+msgid "Colour"
+msgstr "Color"
+
+#: ../src/richtext/richtextindentspage.cpp:127
+#: ../src/richtext/richtextliststylepage.cpp:322
+msgid "&Alignment"
+msgstr "&Alineació"
+
+#: ../src/richtext/richtextindentspage.cpp:138
+#: ../src/richtext/richtextliststylepage.cpp:331
+msgid "&Left"
+msgstr "&Esquerra"
+
+#: ../src/richtext/richtextindentspage.cpp:140
+#: ../src/richtext/richtextindentspage.cpp:142
+#: ../src/richtext/richtextliststylepage.cpp:333
+#: ../src/richtext/richtextliststylepage.cpp:335
+msgid "Left-align text."
+msgstr "Alinea el text a l'esquerra."
+
+#: ../src/richtext/richtextindentspage.cpp:145
+#: ../src/richtext/richtextliststylepage.cpp:338
+msgid "&Right"
+msgstr "D&reta"
+
+#: ../src/richtext/richtextindentspage.cpp:147
+#: ../src/richtext/richtextindentspage.cpp:149
+#: ../src/richtext/richtextliststylepage.cpp:340
+#: ../src/richtext/richtextliststylepage.cpp:342
+msgid "Right-align text."
+msgstr "Alinea el text a la dreta."
+
+#: ../src/richtext/richtextindentspage.cpp:152
+#: ../src/richtext/richtextliststylepage.cpp:345
+msgid "&Justified"
+msgstr "&Justificat"
+
+#: ../src/richtext/richtextindentspage.cpp:154
+#: ../src/richtext/richtextindentspage.cpp:156
+#: ../src/richtext/richtextliststylepage.cpp:347
+#: ../src/richtext/richtextliststylepage.cpp:349
+msgid "Justify text left and right."
+msgstr "Justifica el text a l'esquerra i a la dreta."
+
+#: ../src/richtext/richtextindentspage.cpp:159
+#: ../src/richtext/richtextliststylepage.cpp:352
+msgid "Cen&tred"
+msgstr "Cen&trat"
+
+#: ../src/richtext/richtextindentspage.cpp:161
+#: ../src/richtext/richtextindentspage.cpp:163
+#: ../src/richtext/richtextliststylepage.cpp:354
+#: ../src/richtext/richtextliststylepage.cpp:356
+msgid "Centre text."
+msgstr "Centra el text."
+
+#: ../src/richtext/richtextindentspage.cpp:166
+#: ../src/richtext/richtextliststylepage.cpp:359
+msgid "&Indeterminate"
+msgstr "&Indeterminat"
+
+#: ../src/richtext/richtextindentspage.cpp:168
+#: ../src/richtext/richtextindentspage.cpp:170
+#: ../src/richtext/richtextliststylepage.cpp:361
+#: ../src/richtext/richtextliststylepage.cpp:363
+msgid "Use the current alignment setting."
+msgstr "Utilitza la configuració d'alineació actual."
+
+#: ../src/richtext/richtextindentspage.cpp:183
+#: ../src/richtext/richtextliststylepage.cpp:375
+msgid "&Indentation (tenths of a mm)"
+msgstr "Sagnat (dèc&imes de mm)"
+
+#: ../src/richtext/richtextindentspage.cpp:198
+#: ../src/richtext/richtextindentspage.cpp:200
+#: ../src/richtext/richtextliststylepage.cpp:388
+#: ../src/richtext/richtextliststylepage.cpp:390
+msgid "The left indent."
+msgstr "El sagnat esquerre."
+
+#: ../src/richtext/richtextindentspage.cpp:203
+#: ../src/richtext/richtextliststylepage.cpp:393
+msgid "Left (&first line):"
+msgstr "Esquerra (&primera línia):"
+
+#: ../src/richtext/richtextindentspage.cpp:207
+#: ../src/richtext/richtextindentspage.cpp:209
+#: ../src/richtext/richtextliststylepage.cpp:397
+#: ../src/richtext/richtextliststylepage.cpp:399
+msgid "The first line indent."
+msgstr "El sagnat de la primera línia."
+
+#: ../src/richtext/richtextindentspage.cpp:216
+#: ../src/richtext/richtextindentspage.cpp:218
+#: ../src/richtext/richtextliststylepage.cpp:406
+#: ../src/richtext/richtextliststylepage.cpp:408
+msgid "The right indent."
+msgstr "El sagnat dret."
+
+#: ../src/richtext/richtextindentspage.cpp:221
+msgid "&Outline level:"
+msgstr "Nivell del c&ontorn:"
+
+#: ../src/richtext/richtextindentspage.cpp:226
+#: ../src/richtext/richtextindentspage.cpp:228
+msgid "The outline level."
+msgstr "El nivell del contorn."
+
+#: ../src/richtext/richtextindentspage.cpp:241
+#: ../src/richtext/richtextliststylepage.cpp:420
+msgid "&Spacing (tenths of a mm)"
+msgstr "E&spaiat (dècimes de mm)"
+
+#: ../src/richtext/richtextindentspage.cpp:252
+msgid "&Before a paragraph:"
+msgstr "A&bans d'un paràgraf:"
+
+#: ../src/richtext/richtextindentspage.cpp:256
+#: ../src/richtext/richtextindentspage.cpp:258
+#: ../src/richtext/richtextliststylepage.cpp:433
+#: ../src/richtext/richtextliststylepage.cpp:435
+msgid "The spacing before the paragraph."
+msgstr "L'espaiat abans del paràgraf."
+
+#: ../src/richtext/richtextindentspage.cpp:261
+msgid "&After a paragraph:"
+msgstr "Després d'un p&aràgraf:"
+
+#: ../src/richtext/richtextindentspage.cpp:266
+#: ../src/richtext/richtextliststylepage.cpp:442
+#: ../src/richtext/richtextliststylepage.cpp:444
+msgid "The spacing after the paragraph."
+msgstr "L'espaiat després del paràgraf."
+
+#: ../src/richtext/richtextindentspage.cpp:269
+msgid "L&ine spacing:"
+msgstr "&Interlineat:"
+
+#: ../src/richtext/richtextindentspage.cpp:274
+#: ../src/richtext/richtextliststylepage.cpp:452
+msgid "Single"
+msgstr "Simple"
+
+#: ../src/richtext/richtextindentspage.cpp:275
+#: ../src/richtext/richtextliststylepage.cpp:453
+msgid "1.1"
+msgstr "1.1"
+
+#: ../src/richtext/richtextindentspage.cpp:276
+#: ../src/richtext/richtextliststylepage.cpp:454
+msgid "1.2"
+msgstr "1.2"
+
+#: ../src/richtext/richtextindentspage.cpp:277
+#: ../src/richtext/richtextliststylepage.cpp:455
+msgid "1.3"
+msgstr "1.3"
+
+#: ../src/richtext/richtextindentspage.cpp:278
+#: ../src/richtext/richtextliststylepage.cpp:456
+msgid "1.4"
+msgstr "1.4"
+
+#: ../src/richtext/richtextindentspage.cpp:279
+#: ../src/richtext/richtextliststylepage.cpp:457
+msgid "1.5"
+msgstr "1.5"
+
+#: ../src/richtext/richtextindentspage.cpp:280
+#: ../src/richtext/richtextliststylepage.cpp:458
+msgid "1.6"
+msgstr "1.6"
+
+#: ../src/richtext/richtextindentspage.cpp:281
+#: ../src/richtext/richtextliststylepage.cpp:459
+msgid "1.7"
+msgstr "1.7"
+
+#: ../src/richtext/richtextindentspage.cpp:282
+#: ../src/richtext/richtextliststylepage.cpp:460
+msgid "1.8"
+msgstr "1.8"
+
+#: ../src/richtext/richtextindentspage.cpp:283
+#: ../src/richtext/richtextliststylepage.cpp:461
+msgid "1.9"
+msgstr "1.9"
+
+#: ../src/richtext/richtextindentspage.cpp:284
+#: ../src/richtext/richtextliststylepage.cpp:462
+msgid "2"
+msgstr "2"
+
+#: ../src/richtext/richtextindentspage.cpp:287
+#: ../src/richtext/richtextindentspage.cpp:289
+#: ../src/richtext/richtextliststylepage.cpp:465
+#: ../src/richtext/richtextliststylepage.cpp:467
+msgid "The line spacing."
+msgstr "L'interlineat."
+
+#: ../src/richtext/richtextindentspage.cpp:292
+msgid "&Page Break"
+msgstr "Salt de &pàgina"
+
+#: ../src/richtext/richtextindentspage.cpp:294
+#: ../src/richtext/richtextindentspage.cpp:296
+msgid "Inserts a page break before the paragraph."
+msgstr "Insereix un salt de pàgina abans del paràgraf."
+
+#: ../src/richtext/richtextindentspage.cpp:302
+#: ../src/richtext/richtextindentspage.cpp:304
+msgid "Shows a preview of the paragraph settings."
+msgstr "Mostra una previsualització de la configuració del paràgraf."
+
+#: ../src/richtext/richtextliststylepage.cpp:182
+msgid "&List level:"
+msgstr "Nivell de la &llista:"
+
+#: ../src/richtext/richtextliststylepage.cpp:186
+#: ../src/richtext/richtextliststylepage.cpp:188
+msgid "Selects the list level to edit."
+msgstr "Selecciona el nivell de la llista a editar."
+
+#: ../src/richtext/richtextliststylepage.cpp:193
+msgid "&Font for Level..."
+msgstr "Tip&us de lletra per al nivell..."
+
+#: ../src/richtext/richtextliststylepage.cpp:194
+#: ../src/richtext/richtextliststylepage.cpp:196
+msgid "Click to choose the font for this level."
+msgstr "Feu clic per a triar el tipus de lletra d'aquest nivell."
+
+#: ../src/richtext/richtextliststylepage.cpp:312
+msgid "Bullet style"
+msgstr "Estil de pic"
+
+#: ../src/richtext/richtextliststylepage.cpp:429
+msgid "Before a paragraph:"
+msgstr "Abans d'un paràgraf:"
+
+#: ../src/richtext/richtextliststylepage.cpp:438
+msgid "After a paragraph:"
+msgstr "Després d'un paràgraf:"
+
+#: ../src/richtext/richtextliststylepage.cpp:447
+msgid "Line spacing:"
+msgstr "Interlineat:"
+
+#: ../src/richtext/richtextliststylepage.cpp:470
+msgid "Spacing"
+msgstr "Espaiat"
+
+#: ../src/richtext/richtextmarginspage.cpp:193
+#: ../src/richtext/richtextmarginspage.cpp:195
+msgid "The left margin size."
+msgstr "La mida del marge esquerre."
+
+#: ../src/richtext/richtextmarginspage.cpp:203
+#: ../src/richtext/richtextmarginspage.cpp:205
+msgid "Units for the left margin."
+msgstr "Unitats per al marge esquerre."
+
+#: ../src/richtext/richtextmarginspage.cpp:218
+#: ../src/richtext/richtextmarginspage.cpp:220
+msgid "The right margin size."
+msgstr "La mida del marge dret."
+
+#: ../src/richtext/richtextmarginspage.cpp:228
+#: ../src/richtext/richtextmarginspage.cpp:230
+msgid "Units for the right margin."
+msgstr "Unitats per al marge dret."
+
+#: ../src/richtext/richtextmarginspage.cpp:241
+#: ../src/richtext/richtextmarginspage.cpp:243
+msgid "The top margin size."
+msgstr "La mida del marge superior."
+
+#: ../src/richtext/richtextmarginspage.cpp:251
+#: ../src/richtext/richtextmarginspage.cpp:253
+msgid "Units for the top margin."
+msgstr "Unitats per al marge superior."
+
+#: ../src/richtext/richtextmarginspage.cpp:266
+#: ../src/richtext/richtextmarginspage.cpp:268
+msgid "The bottom margin size."
+msgstr "La mida del marge inferior."
+
+#: ../src/richtext/richtextmarginspage.cpp:276
+#: ../src/richtext/richtextmarginspage.cpp:278
+msgid "Units for the bottom margin."
+msgstr "Unitats per al marge inferior."
+
+#: ../src/richtext/richtextmarginspage.cpp:284
+msgid "Padding"
+msgstr "Separació"
+
+#: ../src/richtext/richtextmarginspage.cpp:307
+#: ../src/richtext/richtextmarginspage.cpp:309
+msgid "The left padding size."
+msgstr "La mida de l'espaiat esquerre."
+
+#: ../src/richtext/richtextmarginspage.cpp:317
+#: ../src/richtext/richtextmarginspage.cpp:319
+msgid "Units for the left padding."
+msgstr "Unitats per a l'espaiat esquerre."
+
+#: ../src/richtext/richtextmarginspage.cpp:332
+#: ../src/richtext/richtextmarginspage.cpp:334
+msgid "The right padding size."
+msgstr "La mida de l'espaiat dret."
+
+#: ../src/richtext/richtextmarginspage.cpp:342
+#: ../src/richtext/richtextmarginspage.cpp:344
+msgid "Units for the right padding."
+msgstr "Unitats per a l'espaiat dret."
+
+#: ../src/richtext/richtextmarginspage.cpp:355
+#: ../src/richtext/richtextmarginspage.cpp:357
+msgid "The top padding size."
+msgstr "La mida de l'espaiat superior."
+
+#: ../src/richtext/richtextmarginspage.cpp:365
+#: ../src/richtext/richtextmarginspage.cpp:367
+msgid "Units for the top padding."
+msgstr "Unitats per a l'espaiat superior."
+
+#: ../src/richtext/richtextmarginspage.cpp:380
+#: ../src/richtext/richtextmarginspage.cpp:382
+msgid "The bottom padding size."
+msgstr "La mida de l'espaiat inferior."
+
+#: ../src/richtext/richtextmarginspage.cpp:390
+#: ../src/richtext/richtextmarginspage.cpp:392
+msgid "Units for the bottom padding."
+msgstr "Unitats per a l'espaiat inferior."
+
+#: ../src/richtext/richtextprint.cpp:592
+msgid " Preview"
+msgstr " Previsualitza"
+
+#: ../src/richtext/richtextsizepage.cpp:228
+msgid "Floating"
+msgstr "Flotant"
+
+#: ../src/richtext/richtextsizepage.cpp:243
+msgid "&Floating mode:"
+msgstr "Mode &flotant:"
+
+#: ../src/richtext/richtextsizepage.cpp:252
+#: ../src/richtext/richtextsizepage.cpp:254
+msgid "How the object will float relative to the text."
+msgstr "Com flotarà l'objecte en relació al text."
+
+#: ../src/richtext/richtextsizepage.cpp:265
+msgid "Alignment"
+msgstr "Alineació"
+
+#: ../src/richtext/richtextsizepage.cpp:277
+msgid "&Vertical alignment:"
+msgstr "Alineació &vertical:"
+
+#: ../src/richtext/richtextsizepage.cpp:279
+#: ../src/richtext/richtextsizepage.cpp:281
+msgid "Enable vertical alignment."
+msgstr "Activa l'alineació vertical."
+
+#: ../src/richtext/richtextsizepage.cpp:286
+msgid "Centred"
+msgstr "Centrat"
+
+#: ../src/richtext/richtextsizepage.cpp:290
+#: ../src/richtext/richtextsizepage.cpp:292
+msgid "Vertical alignment."
+msgstr "Alineació vertical."
+
+#: ../src/richtext/richtextsizepage.cpp:316
+#: ../src/richtext/richtextsizepage.cpp:323
+msgid "&Width:"
+msgstr "A&mplada:"
+
+#: ../src/richtext/richtextsizepage.cpp:318
+#: ../src/richtext/richtextsizepage.cpp:320
+msgid "Enable the width value."
+msgstr "Activa el valor d'amplada."
+
+#: ../src/richtext/richtextsizepage.cpp:331
+#: ../src/richtext/richtextsizepage.cpp:333
+msgid "The object width."
+msgstr "L'amplada de l'objecte."
+
+#: ../src/richtext/richtextsizepage.cpp:342
+#: ../src/richtext/richtextsizepage.cpp:344
+msgid "Units for the object width."
+msgstr "Unitats per a l'amplada de l'objecte."
+
+#: ../src/richtext/richtextsizepage.cpp:350
+#: ../src/richtext/richtextsizepage.cpp:357
+msgid "&Height:"
+msgstr "&Alçada:"
+
+#: ../src/richtext/richtextsizepage.cpp:352
+#: ../src/richtext/richtextsizepage.cpp:354
+#: ../src/richtext/richtextsizepage.cpp:464
+#: ../src/richtext/richtextsizepage.cpp:466
+msgid "Enable the height value."
+msgstr "Activa el valor d'alçada."
+
+#: ../src/richtext/richtextsizepage.cpp:365
+#: ../src/richtext/richtextsizepage.cpp:367
+msgid "The object height."
+msgstr "L'alçada de l'objecte."
+
+#: ../src/richtext/richtextsizepage.cpp:376
+#: ../src/richtext/richtextsizepage.cpp:378
+msgid "Units for the object height."
+msgstr "Unitats per a l'alçada de l'objecte."
+
+#: ../src/richtext/richtextsizepage.cpp:381
+msgid "Min width:"
+msgstr "Amplada mínima:"
+
+#: ../src/richtext/richtextsizepage.cpp:383
+#: ../src/richtext/richtextsizepage.cpp:385
+msgid "Enable the minimum width value."
+msgstr "Activa el valor mínim d'amplada."
+
+#: ../src/richtext/richtextsizepage.cpp:392
+#: ../src/richtext/richtextsizepage.cpp:394
+msgid "The object minimum width."
+msgstr "L'amplada mínima de l'objecte."
+
+#: ../src/richtext/richtextsizepage.cpp:403
+#: ../src/richtext/richtextsizepage.cpp:405
+msgid "Units for the minimum object width."
+msgstr "Unitats per a l'amplada mínima de l'objecte."
+
+#: ../src/richtext/richtextsizepage.cpp:408
+msgid "Min height:"
+msgstr "Alçada mínima:"
+
+#: ../src/richtext/richtextsizepage.cpp:410
+#: ../src/richtext/richtextsizepage.cpp:412
+msgid "Enable the minimum height value."
+msgstr "Activa el valor d'alçada mínima."
+
+#: ../src/richtext/richtextsizepage.cpp:419
+#: ../src/richtext/richtextsizepage.cpp:421
+msgid "The object minimum height."
+msgstr "L'alçada mínima de l'objecte."
+
+#: ../src/richtext/richtextsizepage.cpp:430
+#: ../src/richtext/richtextsizepage.cpp:432
+msgid "Units for the minimum object height."
+msgstr "Unitats per a l'alçada mínima d'objecte."
+
+#: ../src/richtext/richtextsizepage.cpp:435
+msgid "Max width:"
+msgstr "Amplada màxima:"
+
+#: ../src/richtext/richtextsizepage.cpp:437
+#: ../src/richtext/richtextsizepage.cpp:439
+msgid "Enable the maximum width value."
+msgstr "Activa el valor màxim d'amplada."
+
+#: ../src/richtext/richtextsizepage.cpp:446
+#: ../src/richtext/richtextsizepage.cpp:448
+msgid "The object maximum width."
+msgstr "L'amplada màxima de l'objecte."
+
+#: ../src/richtext/richtextsizepage.cpp:457
+#: ../src/richtext/richtextsizepage.cpp:459
+msgid "Units for the maximum object width."
+msgstr "Unitats per a l'amplada màxima de l'objecte."
+
+#: ../src/richtext/richtextsizepage.cpp:462
+msgid "Max height:"
+msgstr "Alçada màxima:"
+
+#: ../src/richtext/richtextsizepage.cpp:473
+#: ../src/richtext/richtextsizepage.cpp:475
+msgid "The object maximum height."
+msgstr "L'alçada màxima de l'objecte."
+
+#: ../src/richtext/richtextsizepage.cpp:484
+#: ../src/richtext/richtextsizepage.cpp:486
+msgid "Units for the maximum object height."
+msgstr "Unitats per a l'alçada màxima d'objecte."
+
+#: ../src/richtext/richtextsizepage.cpp:495
+msgid "Position"
+msgstr "Posició"
+
+#: ../src/richtext/richtextsizepage.cpp:513
+msgid "&Position mode:"
+msgstr "&Mode de posicionament:"
+
+#: ../src/richtext/richtextsizepage.cpp:517
+#: ../src/richtext/richtextsizepage.cpp:522
+msgid "Static"
+msgstr "Estàtic"
+
+#: ../src/richtext/richtextsizepage.cpp:518
+msgid "Relative"
+msgstr "Relatiu"
+
+#: ../src/richtext/richtextsizepage.cpp:519
+msgid "Absolute"
+msgstr "Absolut"
+
+#: ../src/richtext/richtextsizepage.cpp:520
+msgid "Fixed"
+msgstr "Fixa"
+
+#: ../src/richtext/richtextsizepage.cpp:533
+#: ../src/richtext/richtextsizepage.cpp:535
+#: ../src/richtext/richtextsizepage.cpp:547
+#: ../src/richtext/richtextsizepage.cpp:549
+msgid "The left position."
+msgstr "La posició esquerra."
+
+#: ../src/richtext/richtextsizepage.cpp:558
+#: ../src/richtext/richtextsizepage.cpp:560
+msgid "Units for the left position."
+msgstr "Unitats per a la posició esquerra."
+
+#: ../src/richtext/richtextsizepage.cpp:568
+#: ../src/richtext/richtextsizepage.cpp:570
+#: ../src/richtext/richtextsizepage.cpp:582
+#: ../src/richtext/richtextsizepage.cpp:584
+msgid "The top position."
+msgstr "La posició superior."
+
+#: ../src/richtext/richtextsizepage.cpp:593
+#: ../src/richtext/richtextsizepage.cpp:595
+msgid "Units for the top position."
+msgstr "Unitats per a la posició superior."
+
+#: ../src/richtext/richtextsizepage.cpp:603
+#: ../src/richtext/richtextsizepage.cpp:605
+#: ../src/richtext/richtextsizepage.cpp:617
+#: ../src/richtext/richtextsizepage.cpp:619
+msgid "The right position."
+msgstr "La posició dreta."
+
+#: ../src/richtext/richtextsizepage.cpp:628
+#: ../src/richtext/richtextsizepage.cpp:630
+msgid "Units for the right position."
+msgstr "Unitats per a la posició dreta."
+
+#: ../src/richtext/richtextsizepage.cpp:638
+#: ../src/richtext/richtextsizepage.cpp:640
+#: ../src/richtext/richtextsizepage.cpp:652
+#: ../src/richtext/richtextsizepage.cpp:654
+msgid "The bottom position."
+msgstr "La posició inferior."
+
+#: ../src/richtext/richtextsizepage.cpp:663
+#: ../src/richtext/richtextsizepage.cpp:665
+msgid "Units for the bottom position."
+msgstr "Unitats per a la posició inferior."
+
+#: ../src/richtext/richtextsizepage.cpp:671
+msgid "&Move the object to:"
+msgstr "&Mou l'objecte a:"
+
+#: ../src/richtext/richtextsizepage.cpp:674
+msgid "&Previous Paragraph"
+msgstr "&Paràgraf anterior"
+
+#: ../src/richtext/richtextsizepage.cpp:675
+#: ../src/richtext/richtextsizepage.cpp:677
+msgid "Moves the object to the previous paragraph."
+msgstr "Mou l'objecte al paràgraf anterior."
+
+#: ../src/richtext/richtextsizepage.cpp:680
+msgid "&Next Paragraph"
+msgstr "Paràgraf següe&nt"
+
+#: ../src/richtext/richtextsizepage.cpp:681
+#: ../src/richtext/richtextsizepage.cpp:683
+msgid "Moves the object to the next paragraph."
+msgstr "Mou l'objecte al paràgraf següent."
+
+#: ../src/richtext/richtextstyledlg.cpp:193
+msgid "&Styles:"
+msgstr "E&stils:"
+
+#: ../src/richtext/richtextstyledlg.cpp:197
+#: ../src/richtext/richtextstyledlg.cpp:199
+msgid "The available styles."
+msgstr "Els estils disponibles."
+
+#: ../src/richtext/richtextstyledlg.cpp:205
+#: ../src/richtext/richtextstyledlg.cpp:217
+msgid " "
+msgstr " "
+
+#: ../src/richtext/richtextstyledlg.cpp:209
+#: ../src/richtext/richtextstyledlg.cpp:211
+msgid "The style preview."
+msgstr "La previsualització de l'estil."
+
+#: ../src/richtext/richtextstyledlg.cpp:220
+msgid "New &Character Style..."
+msgstr "Estil de &caràcter nou..."
+
+#: ../src/richtext/richtextstyledlg.cpp:221
+#: ../src/richtext/richtextstyledlg.cpp:223
+msgid "Click to create a new character style."
+msgstr "Feu clic per a crear un estil de caràcter nou."
+
+#: ../src/richtext/richtextstyledlg.cpp:226
+msgid "New &Paragraph Style..."
+msgstr "Estil de &paràgraf nou..."
+
+#: ../src/richtext/richtextstyledlg.cpp:227
+#: ../src/richtext/richtextstyledlg.cpp:229
+msgid "Click to create a new paragraph style."
+msgstr "Feu clic per a crear un estil de paràgraf nou."
+
+#: ../src/richtext/richtextstyledlg.cpp:232
+msgid "New &List Style..."
+msgstr "Estil de &llista nou..."
+
+#: ../src/richtext/richtextstyledlg.cpp:233
+#: ../src/richtext/richtextstyledlg.cpp:235
+msgid "Click to create a new list style."
+msgstr "Feu clic per a crear un estil de llista nou."
+
+#: ../src/richtext/richtextstyledlg.cpp:238
+msgid "New &Box Style..."
+msgstr "&Estil de caixa nou..."
+
+#: ../src/richtext/richtextstyledlg.cpp:239
+#: ../src/richtext/richtextstyledlg.cpp:241
+msgid "Click to create a new box style."
+msgstr "Feu clic per a crear un estil de caixa nou."
+
+#: ../src/richtext/richtextstyledlg.cpp:246
+msgid "&Apply Style"
+msgstr "&Aplica l'estil"
+
+#: ../src/richtext/richtextstyledlg.cpp:247
+#: ../src/richtext/richtextstyledlg.cpp:249
+msgid "Click to apply the selected style."
+msgstr "Feu clic per a aplicar l'estil seleccionat."
+
+#: ../src/richtext/richtextstyledlg.cpp:252
+msgid "&Rename Style..."
+msgstr "&Canvia el nom de l'estil..."
+
+#: ../src/richtext/richtextstyledlg.cpp:253
+#: ../src/richtext/richtextstyledlg.cpp:255
+msgid "Click to rename the selected style."
+msgstr "Feu clic per a canviar el nom de l'estil seleccionat."
+
+#: ../src/richtext/richtextstyledlg.cpp:258
+msgid "&Edit Style..."
+msgstr "&Edita l'estil..."
+
+#: ../src/richtext/richtextstyledlg.cpp:259
+#: ../src/richtext/richtextstyledlg.cpp:261
+msgid "Click to edit the selected style."
+msgstr "Feu clic per a editar l'estil seleccionat."
+
+#: ../src/richtext/richtextstyledlg.cpp:264
+msgid "&Delete Style..."
+msgstr "&Suprimeix l'estil..."
+
+#: ../src/richtext/richtextstyledlg.cpp:265
+#: ../src/richtext/richtextstyledlg.cpp:267
+msgid "Click to delete the selected style."
+msgstr "Feu clic per a suprimir l'estil seleccionat."
+
+#: ../src/richtext/richtextstyledlg.cpp:274
+#: ../src/richtext/richtextstyledlg.cpp:276
+msgid "Click to close this window."
+msgstr "Feu clic per a tancar aquesta finestra."
+
+#: ../src/richtext/richtextstyledlg.cpp:282
+msgid "&Restart numbering"
+msgstr "&Reinicia la numeració"
+
+#: ../src/richtext/richtextstyledlg.cpp:284
+#: ../src/richtext/richtextstyledlg.cpp:286
+msgid "Check to restart numbering."
+msgstr "Marqueu-ho per a reiniciar la numeració."
+
+#: ../src/richtext/richtextstyledlg.cpp:601
+msgid "Enter a character style name"
+msgstr "Introduïu un nom per a l'estil de caràcter"
+
+#: ../src/richtext/richtextstyledlg.cpp:601
+#: ../src/richtext/richtextstyledlg.cpp:606
+#: ../src/richtext/richtextstyledlg.cpp:649
+#: ../src/richtext/richtextstyledlg.cpp:654
+#: ../src/richtext/richtextstyledlg.cpp:815
+#: ../src/richtext/richtextstyledlg.cpp:820
+#: ../src/richtext/richtextstyledlg.cpp:888
+#: ../src/richtext/richtextstyledlg.cpp:896
+#: ../src/richtext/richtextstyledlg.cpp:929
+#: ../src/richtext/richtextstyledlg.cpp:934
+msgid "New Style"
+msgstr "Estil nou"
+
+#: ../src/richtext/richtextstyledlg.cpp:606
+#: ../src/richtext/richtextstyledlg.cpp:654
+#: ../src/richtext/richtextstyledlg.cpp:820
+#: ../src/richtext/richtextstyledlg.cpp:896
+#: ../src/richtext/richtextstyledlg.cpp:934
+msgid "Sorry, that name is taken. Please choose another."
+msgstr "Aquest nom ja s'utilitza. Trieu-ne un altre."
+
+#: ../src/richtext/richtextstyledlg.cpp:649
+msgid "Enter a paragraph style name"
+msgstr "Introduïu un nom per a l'estil de paràgraf"
+
+#: ../src/richtext/richtextstyledlg.cpp:777
+#, c-format
+msgid "Delete style %s?"
+msgstr "Voleu suprimir l'estil %s?"
+
+#: ../src/richtext/richtextstyledlg.cpp:777
+msgid "Delete Style"
+msgstr "Suprimeix l'estil"
+
+#: ../src/richtext/richtextstyledlg.cpp:815
+msgid "Enter a list style name"
+msgstr "Introduïu un nom per a l'estil de llista"
+
+#: ../src/richtext/richtextstyledlg.cpp:888
+msgid "Enter a new style name"
+msgstr "Introduïu un nom per a l'estil nou"
+
+#: ../src/richtext/richtextstyledlg.cpp:929
+msgid "Enter a box style name"
+msgstr "Introduïu un nom per a l'estil de caixa"
+
+#: ../src/richtext/richtextstylepage.cpp:109
+#: ../src/richtext/richtextstylepage.cpp:111
+msgid "The style name."
+msgstr "El nom de l'estil."
+
+#: ../src/richtext/richtextstylepage.cpp:114
+msgid "&Based on:"
+msgstr "&Basat en:"
+
+#: ../src/richtext/richtextstylepage.cpp:119
+#: ../src/richtext/richtextstylepage.cpp:121
+msgid "The style on which this style is based."
+msgstr "L'estil en què es basa aquest estil."
+
+#: ../src/richtext/richtextstylepage.cpp:124
+msgid "&Next style:"
+msgstr "Següe&nt estil:"
+
+#: ../src/richtext/richtextstylepage.cpp:129
+#: ../src/richtext/richtextstylepage.cpp:131
+msgid "The default style for the next paragraph."
+msgstr "L'estil per defecte per al paràgraf següent."
+
+#: ../src/richtext/richtextstyles.cpp:1057
+msgid "All styles"
+msgstr "Tots els estils"
+
+#: ../src/richtext/richtextstyles.cpp:1058
+msgid "Paragraph styles"
+msgstr "Estils de paràgraf"
+
+#: ../src/richtext/richtextstyles.cpp:1059
+msgid "Character styles"
+msgstr "Estils de caràcter"
+
+#: ../src/richtext/richtextstyles.cpp:1060
+msgid "List styles"
+msgstr "Estils de llista"
+
+#: ../src/richtext/richtextstyles.cpp:1061
+msgid "Box styles"
+msgstr "Estils de caixa"
+
+#: ../src/richtext/richtextsymboldlg.cpp:389
+#: ../src/richtext/richtextsymboldlg.cpp:391
+msgid "The font from which to take the symbol."
+msgstr "El tipus de lletra del qual prendre el símbol."
+
+#: ../src/richtext/richtextsymboldlg.cpp:396
+msgid "&Subset:"
+msgstr "&Subconjunt:"
+
+#: ../src/richtext/richtextsymboldlg.cpp:401
+#: ../src/richtext/richtextsymboldlg.cpp:403
+msgid "Shows a Unicode subset."
+msgstr "Mostra un subconjunt d'Unicode."
+
+#: ../src/richtext/richtextsymboldlg.cpp:412
+msgid "xxxx"
+msgstr "xxxx"
+
+#: ../src/richtext/richtextsymboldlg.cpp:417
+msgid "&Character code:"
+msgstr "&Codi de caràcter:"
+
+#: ../src/richtext/richtextsymboldlg.cpp:421
+#: ../src/richtext/richtextsymboldlg.cpp:423
+msgid "The character code."
+msgstr "El codi del caràcter."
+
+#: ../src/richtext/richtextsymboldlg.cpp:428
+msgid "&From:"
+msgstr "&De:"
+
+#: ../src/richtext/richtextsymboldlg.cpp:433
+#: ../src/richtext/richtextsymboldlg.cpp:434
+#: ../src/richtext/richtextsymboldlg.cpp:435
+msgid "Unicode"
+msgstr "Unicode"
+
+#: ../src/richtext/richtextsymboldlg.cpp:436
+#: ../src/richtext/richtextsymboldlg.cpp:438
+msgid "The range to show."
+msgstr "L'interval a mostrar."
+
+#: ../src/richtext/richtextsymboldlg.cpp:444
+msgid "Insert"
+msgstr "Insereix"
+
+#: ../src/richtext/richtextsymboldlg.cpp:478
+msgid "(Normal text)"
+msgstr "(Text normal)"
+
+#: ../src/richtext/richtexttabspage.cpp:109
+msgid "&Position (tenths of a mm):"
+msgstr "&Posició (dècimes de mm):"
+
+#: ../src/richtext/richtexttabspage.cpp:113
+#: ../src/richtext/richtexttabspage.cpp:115
+msgid "The tab position."
+msgstr "La posició de la tabulació."
+
+#: ../src/richtext/richtexttabspage.cpp:119
+msgid "The tab positions."
+msgstr "Les posicions de la tabulació."
+
+#: ../src/richtext/richtexttabspage.cpp:132
+#: ../src/richtext/richtexttabspage.cpp:134
+msgid "Click to create a new tab position."
+msgstr "Feu clic per a crear una posició de tabulació nova."
+
+#: ../src/richtext/richtexttabspage.cpp:138
+#: ../src/richtext/richtexttabspage.cpp:140
+msgid "Click to delete the selected tab position."
+msgstr "Feu clic per a suprimir la posició de tabulació seleccionada."
+
+#: ../src/richtext/richtexttabspage.cpp:143
+msgid "Delete A&ll"
+msgstr "Suprimeix-ho &tot"
+
+#: ../src/richtext/richtexttabspage.cpp:144
+#: ../src/richtext/richtexttabspage.cpp:146
+msgid "Click to delete all tab positions."
+msgstr "Feu clic per a suprimir totes les posicions de tabulació."
+
+#: ../src/univ/theme.cpp:110
+msgid "Failed to initialize GUI: no built-in themes found."
+msgstr "No s'ha pogut inicialitzar la GUI: no s'ha trobat cap tema integrat."
+
+#: ../src/univ/themes/gtk.cpp:521
+msgid "GTK+ theme"
+msgstr "Tema GTK+"
+
+#: ../src/univ/themes/metal.cpp:164
+msgid "Metal theme"
+msgstr "Tema metàl·lic"
+
+#: ../src/univ/themes/mono.cpp:512
+msgid "Simple monochrome theme"
+msgstr "Tema monocrom simple"
+
+#: ../src/univ/themes/win32.cpp:1098
+msgid "Win32 theme"
+msgstr "Tema Win32"
+
+#: ../src/univ/themes/win32.cpp:3743
+msgid "&Restore"
+msgstr "&Restaura"
+
+#: ../src/univ/themes/win32.cpp:3744
+msgid "&Move"
+msgstr "&Mou"
+
+#: ../src/univ/themes/win32.cpp:3746
+msgid "&Size"
+msgstr "&Mida"
+
+#: ../src/univ/themes/win32.cpp:3748
+msgid "Mi&nimize"
+msgstr "Mi&nimitza"
+
+#: ../src/univ/themes/win32.cpp:3750
+msgid "Ma&ximize"
+msgstr "Ma&ximitza"
+
+#: ../src/univ/themes/win32.cpp:3752
+msgid "Alt+"
+msgstr "Alt+"
+
+#: ../src/unix/appunix.cpp:178
+msgid "Failed to install signal handler"
+msgstr "No s'ha pogut instal·lar el gestor de senyals"
+
+#: ../src/unix/dialup.cpp:351
+msgid "Already dialling ISP."
+msgstr "Ja s'està trucant al proveïdor d'Internet."
+
+#: ../src/unix/dlunix.cpp:93
+msgid "Failed to unload shared library"
+msgstr "No s'ha pogut descarregar la biblioteca compartida"
+
+#: ../src/unix/dlunix.cpp:121
+msgid "Unknown dynamic library error"
+msgstr "S'ha produït un error desconegut de biblioteca dinàmica"
+
+#: ../src/unix/epolldispatcher.cpp:84
+msgid "Failed to create epoll descriptor"
+msgstr "No s'ha pogut crear el descriptor epoll"
+
+#: ../src/unix/epolldispatcher.cpp:103
+msgid "Error closing epoll descriptor"
+msgstr "S'ha produït un error en tancar el descriptor epoll"
+
+#: ../src/unix/epolldispatcher.cpp:116
+#, c-format
+msgid "Failed to add descriptor %d to epoll descriptor %d"
+msgstr "No s'ha pogut afegir el descriptor %d al descriptor epoll %d"
+
+#: ../src/unix/epolldispatcher.cpp:136
+#, c-format
+msgid "Failed to modify descriptor %d in epoll descriptor %d"
+msgstr "No s'ha pogut modificar el descriptor %d al descriptor epoll %d"
+
+#: ../src/unix/epolldispatcher.cpp:155
+#, c-format
+msgid "Failed to unregister descriptor %d from epoll descriptor %d"
+msgstr "No s'ha pogut desregistrar el descriptor %d del descriptor epoll %d"
+
+#: ../src/unix/epolldispatcher.cpp:213
+#, c-format
+msgid "Waiting for IO on epoll descriptor %d failed"
+msgstr "S'ha produït un error mentre s'esperava l'E/S del descriptor epoll %d"
+
+#: ../src/unix/fswatcher_inotify.cpp:71
+msgid "Unable to create inotify instance"
+msgstr "No s'ha pogut crear la instància d'inotify"
+
+#: ../src/unix/fswatcher_inotify.cpp:94
+msgid "Unable to close inotify instance"
+msgstr "No s'ha pogut tancar la instància d'inotify"
+
+#: ../src/unix/fswatcher_inotify.cpp:106
+msgid "Unable to add inotify watch"
+msgstr "No s'ha pogut afegir la supervisió inotify"
+
+#: ../src/unix/fswatcher_inotify.cpp:138
+#, c-format
+msgid "Unable to remove inotify watch %i"
+msgstr "No s'ha pogut suprimir la supervisió inotify %i"
+
+#: ../src/unix/fswatcher_inotify.cpp:271
+#, c-format
+msgid "Unexpected event for \"%s\": no matching watch descriptor."
+msgstr ""
+"Esdeveniment inesperat per a \"%s\": no hi ha cap descriptor de supervisió "
+"coincident."
+
+#: ../src/unix/fswatcher_inotify.cpp:320
+#, c-format
+msgid "Invalid inotify event for \"%s\""
+msgstr "Esdeveniment inotify invàlid per a \"%s\""
+
+#: ../src/unix/fswatcher_inotify.cpp:553
+msgid "Unable to read from inotify descriptor"
+msgstr "No s'ha pogut llegir el descriptor inotify"
+
+#: ../src/unix/fswatcher_inotify.cpp:558
+msgid "EOF while reading from inotify descriptor"
+msgstr "EOF mentre es llegia del descriptor inotify"
+
+#: ../src/unix/fswatcher_kqueue.cpp:114
+msgid "Unable to create kqueue instance"
+msgstr "No s'ha pogut crear la instància de kqueue"
+
+#: ../src/unix/fswatcher_kqueue.cpp:131
+msgid "Error closing kqueue instance"
+msgstr "S'ha produït un error en tancar la instància kqueue"
+
+#: ../src/unix/fswatcher_kqueue.cpp:153
+msgid "Unable to add kqueue watch"
+msgstr "No s'ha pogut afegir la supervisió kqueue"
+
+#: ../src/unix/fswatcher_kqueue.cpp:170
+msgid "Unable to remove kqueue watch"
+msgstr "No s'ha pogut suprimir la supervisió kqueue"
+
+#: ../src/unix/fswatcher_kqueue.cpp:202
+msgid "Unable to get events from kqueue"
+msgstr "No s'han pogut obtenir els esdeveniments de kqueue"
+
+#: ../src/unix/mediactrl.cpp:966
+#, c-format
+msgid "Media playback error: %s"
+msgstr "S'ha produït un error en la reproducció del mitjà: %s"
+
+#: ../src/unix/mediactrl.cpp:1228
+#, c-format
+msgid "Failed to prepare playing \"%s\"."
+msgstr "No s'ha pogut preparar la reproducció de \"%s\"."
+
+#: ../src/unix/snglinst.cpp:164
+#, c-format
+msgid "Failed to write to lock file '%s'"
+msgstr "No s'ha pogut escriure al fitxer de blocatge '%s'"
+
+#: ../src/unix/snglinst.cpp:177
+#, c-format
+msgid "Failed to set permissions on lock file '%s'"
+msgstr "No s'han pogut definir els permisos del fitxer de blocatge '%s'"
+
+#: ../src/unix/snglinst.cpp:194
+#, c-format
+msgid "Failed to lock the lock file '%s'"
+msgstr "No s'ha pogut blocar el fitxer de blocatge '%s'"
+
+#: ../src/unix/snglinst.cpp:237
+#, c-format
+msgid "Failed to inspect the lock file '%s'"
+msgstr "No s'ha pogut inspeccionar el fitxer de blocatge '%s'"
+
+#: ../src/unix/snglinst.cpp:242
+#, c-format
+msgid "Lock file '%s' has incorrect owner."
+msgstr "El fitxer de blocatge '%s' té un propietari incorrecte."
+
+#: ../src/unix/snglinst.cpp:247
+#, c-format
+msgid "Lock file '%s' has incorrect permissions."
+msgstr "El fitxer de blocatge '%s' té els permisos incorrectes."
+
+#: ../src/unix/snglinst.cpp:265
+msgid "Failed to access lock file."
+msgstr "No s'ha pogut accedir el fitxer de blocatge."
+
+#: ../src/unix/snglinst.cpp:274
+msgid "Failed to read PID from lock file."
+msgstr "No s'ha pogut llegir el PID del fitxer de blocatge."
+
+#: ../src/unix/snglinst.cpp:284
+#, c-format
+msgid "Failed to remove stale lock file '%s'."
+msgstr "No s'ha pogut suprimir el fitxer de blocatge antic '%s'."
+
+#: ../src/unix/snglinst.cpp:297
+#, c-format
+msgid "Deleted stale lock file '%s'."
+msgstr "S'ha suprimit el fitxer antic de blocatge '%s'."
+
+#: ../src/unix/snglinst.cpp:308
+#, c-format
+msgid "Invalid lock file '%s'."
+msgstr "Fitxer de blocatge invàlid '%s'."
+
+#: ../src/unix/snglinst.cpp:324
+#, c-format
+msgid "Failed to remove lock file '%s'"
+msgstr "No s'ha pogut suprimir el fitxer de blocatge '%s'"
+
+#: ../src/unix/snglinst.cpp:330
+#, c-format
+msgid "Failed to unlock lock file '%s'"
+msgstr "No s'ha pogut desblocar el fitxer de blocatge '%s'"
+
+#: ../src/unix/snglinst.cpp:336
+#, c-format
+msgid "Failed to close lock file '%s'"
+msgstr "No s'ha pogut tancar el fitxer de blocatge '%s'"
+
+#: ../src/unix/sound.cpp:77
+msgid "No sound"
+msgstr "No hi ha so"
+
+#: ../src/unix/sound.cpp:364
+msgid "Unable to play sound asynchronously."
+msgstr "No s'ha pogut reproduir el so asíncronament."
+
+#: ../src/unix/sound.cpp:458
+#, c-format
+msgid "Couldn't load sound data from '%s'."
+msgstr "No s'han pogut carregar les dades de so de '%s'."
+
+#: ../src/unix/sound.cpp:465
+#, c-format
+msgid "Sound file '%s' is in unsupported format."
+msgstr "El fitxer de so '%s' té un format no suportat."
+
+#: ../src/unix/sound.cpp:480
+msgid "Sound data are in unsupported format."
+msgstr "Les dades del so tenen un format no suportat."
+
+#: ../src/unix/sound_sdl.cpp:226
+#, c-format
+msgid "Couldn't open audio: %s"
+msgstr "No s'ha pogut obrir l'àudio: %s"
+
+#: ../src/unix/threadpsx.cpp:1033
+msgid "Cannot retrieve thread scheduling policy."
+msgstr "No es pot obtenir la política de planificació de fils d'execució."
+
+#: ../src/unix/threadpsx.cpp:1058
+#, c-format
+msgid "Cannot get priority range for scheduling policy %d."
+msgstr ""
+"No es pot obtenir el rang de prioritats per a la política de planificació %d."
+
+#: ../src/unix/threadpsx.cpp:1066
+msgid "Thread priority setting is ignored."
+msgstr "La configuració de prioritat del fil d'execució és ignorada."
+
+#: ../src/unix/threadpsx.cpp:1221
+msgid ""
+"Failed to join a thread, potential memory leak detected - please restart the "
+"program"
+msgstr ""
+"No s'ha pogut sincronitzar amb un fil d'execució, s'ha detectat una possible "
+"fuita de memòria - reinicieu el programa"
+
+#: ../src/unix/threadpsx.cpp:1352
+#, c-format
+msgid "Failed to set thread concurrency level to %lu"
+msgstr ""
+"No s'ha pogut definir el nivell de concurrència del fil d'execució a %lu"
+
+#: ../src/unix/threadpsx.cpp:1481
+#, c-format
+msgid "Failed to set thread priority %d."
+msgstr "No s'ha pogut definir la prioritat del fil d'execució %d."
+
+#: ../src/unix/threadpsx.cpp:1666
+msgid "Failed to terminate a thread."
+msgstr "No s'ha pogut finalitzar el fil d'execució."
+
+#: ../src/unix/threadpsx.cpp:1893
+msgid "Thread module initialization failed: failed to create thread key"
+msgstr ""
+"No s'ha pogut inicialitzar el mòdul de fils d'execució: no s'ha pogut crear "
+"la clau del fil d'execució"
+
+#: ../src/unix/utilsunx.cpp:340
+msgid "Impossible to get child process input"
+msgstr "No és possible obtenir l'entrada del procés fill"
+
+#: ../src/unix/utilsunx.cpp:390
+msgid "Can't write to child process's stdin"
+msgstr "No es pot escriure a l'entrada estàndard del procés fill"
+
+#: ../src/unix/utilsunx.cpp:644
+#, c-format
+msgid "Failed to execute '%s'\n"
+msgstr "No s'ha pogut executar '%s'\n"
+
+#: ../src/unix/utilsunx.cpp:678
+msgid "Fork failed"
+msgstr "No s'ha pogut bifurcar"
+
+#: ../src/unix/utilsunx.cpp:701
+msgid "Failed to set process priority"
+msgstr "No s'ha pogut definir la prioritat del procés"
+
+#: ../src/unix/utilsunx.cpp:712
+msgid "Failed to redirect child process input/output"
+msgstr "No s'ha pogut redirigir l'entrada/sortida del procés fill"
+
+#: ../src/unix/utilsunx.cpp:816
+msgid "Failed to set up non-blocking pipe, the program might hang."
+msgstr ""
+"No s'ha pogut configurar la canonada no blocant, és possible que el programa "
+"es pengi."
+
+#: ../src/unix/utilsunx.cpp:1023
+msgid "Cannot get the hostname"
+msgstr "No es pot obtenir el nom del servidor"
+
+#: ../src/unix/utilsunx.cpp:1059
+msgid "Cannot get the official hostname"
+msgstr "No es pot obtenir el nom oficial del servidor"
+
+#: ../src/unix/wakeuppipe.cpp:49
+msgid "Failed to create wake up pipe used by event loop."
+msgstr ""
+"No s'ha pogut crear la canonada de despertament utilitzada pel bucle "
+"d'esdeveniments."
+
+#: ../src/unix/wakeuppipe.cpp:56
+msgid "Failed to switch wake up pipe to non-blocking mode"
+msgstr "No s'ha pogut canviar la canonada de despertament al mode no blocant"
+
+#: ../src/unix/wakeuppipe.cpp:117
+msgid "Failed to read from wake-up pipe"
+msgstr "No s'ha pogut llegir la canonada de despertament"
+
+#: ../src/x11/app.cpp:124
+#, c-format
+msgid "Invalid geometry specification '%s'"
+msgstr "Especificació de geometria invàlida '%s'"
+
+#: ../src/x11/app.cpp:167
+msgid "wxWidgets could not open display. Exiting."
+msgstr "wxWidgets no ha pogut obrir la pantalla. Se sortirà."
+
+#: ../src/x11/utils.cpp:169
+#, c-format
+msgid "Failed to close the display \"%s\""
+msgstr "No s'ha pogut tancar la pantalla \"%s\""
+
+#: ../src/x11/utils.cpp:188
+#, c-format
+msgid "Failed to open display \"%s\"."
+msgstr "No s'ha pogut obrir la pantalla \"%s\"."
+
+#: ../src/xml/xml.cpp:868
+#, c-format
+msgid "XML parsing error: '%s' at line %d"
+msgstr "S'ha produït un error d'anàlisi XML: '%s' a la línia %d"
+
+#: ../src/xrc/xh_propgrid.cpp:239
+#, fuzzy, c-format
+msgid "Page %i"
+msgstr "Pàgina %d"
+
+#: ../src/xrc/xmlres.cpp:448
+#, c-format
+msgid "Cannot load resources from '%s'."
+msgstr "No es poden carregar recursos de '%s'."
+
+#: ../src/xrc/xmlres.cpp:799
+#, c-format
+msgid "Cannot open resources file '%s'."
+msgstr "No es pot obrir el fitxer de recursos '%s'."
+
+#: ../src/xrc/xmlres.cpp:806
+#, c-format
+msgid "Cannot load resources from file '%s'."
+msgstr "No es poden carregar els recursos del fitxer '%s'."
+
+#: ../src/xrc/xmlres.cpp:2767
+#, c-format
+msgid "Creating %s \"%s\" failed."
+msgstr "No s'ha pogut crear %s \"%s\"."
+
+#, c-format
+#~ msgid "BMP: header has biClrUsed=%d when biBitCount=%d."
+#~ msgstr "BMP: capçalera té biClrUsed=%d quan biBitCount=%d."
+
+#~ msgctxt "keyboard key"
+#~ msgid "Alt+"
+#~ msgstr "Alt+"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Ctrl+"
+#~ msgstr "Ctrl+"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Shift+"
+#~ msgstr "Maj+"
+
+#~ msgctxt "keyboard key"
+#~ msgid "RawCtrl+"
+#~ msgstr "RawCtrl+"
+
+#~ msgid "Copying more than one selected block to clipboard is not supported."
+#~ msgstr "No es suporta copiar més d'un bloc seleccionat al porta-retalls."
+
+#~ msgid "Unsupported clipboard format."
+#~ msgstr "Format de porta-retalls no suportat."
+
+#~ msgid "Background colour"
+#~ msgstr "Color de fons"
+
+#~ msgid "Font:"
+#~ msgstr "Tipus de lletra:"
+
+#~ msgid "Size:"
+#~ msgstr "Mida:"
+
+#~ msgid "The font size in points."
+#~ msgstr "La mida del tipus de lletra en punts."
+
+#~ msgid "Style:"
+#~ msgstr "Estil:"
+
+#~ msgid "Check to make the font bold."
+#~ msgstr "Marqueu-ho per a fer que la lletra sigui negreta."
+
+#~ msgid "Check to make the font italic."
+#~ msgstr "Marqueu-ho per a fer que la lletra sigui cursiva."
+
+#~ msgid "Check to make the font underlined."
+#~ msgstr "Marqueu-ho per a fer que la lletra sigui subratllada."
+
+#~ msgid "Colour:"
+#~ msgstr "Color:"
+
+#~ msgid "Click to change the font colour."
+#~ msgstr "Feu clic per a canviar el color de la lletra."
+
+#~ msgid "Shows a preview of the font."
+#~ msgstr "Mostra una previsualització del tipus de lletra."
+
+#~ msgid "Click to cancel changes to the font."
+#~ msgstr "Feu clic per a cancel·lar els canvis al tipus de lletra."
+
+#~ msgid "Click to confirm changes to the font."
+#~ msgstr "Feu clic per a confirmar els canvis al tipus de lletra."
+
+#~ msgid "<Any>"
+#~ msgstr "<Qualsevol>"
+
+#~ msgid "<Any Roman>"
+#~ msgstr "<Qualsevol Roman>"
+
+#~ msgid "<Any Decorative>"
+#~ msgstr "<Qualsevol decoratiu>"
+
+#~ msgid "<Any Modern>"
+#~ msgstr "<Qualsevol modern>"
+
+#~ msgid "<Any Script>"
+#~ msgstr "<Qualsevol Script>"
+
+#~ msgid "<Any Swiss>"
+#~ msgstr "<Qualsevol Suís>"
+
+#~ msgid "<Any Teletype>"
+#~ msgstr "<Qualsevol Teletip>"
+
+#~ msgid "Printing "
+#~ msgstr "S'està imprimint "
+
+#~ msgid "Failed to insert text in the control."
+#~ msgstr "No s'ha pogut inserir el text al control."
+
+#~ msgid "Please choose a valid font."
+#~ msgstr "Trieu un tipus de lletra vàlid."
+
+#, c-format
+#~ msgid "Failed to display HTML document in %s encoding"
+#~ msgstr "No s'ha pogut mostrar el document HTML amb la codificació %s"
+
+#, c-format
+#~ msgid "wxWidgets could not open display for '%s': exiting."
+#~ msgstr "wxWidgets no ha pogut obrir la pantalla de '%s': se sortirà."
+
+#~ msgid "Filter"
+#~ msgstr "Filtre"
+
+#~ msgid "Directories"
+#~ msgstr "Directoris"
+
+#~ msgid "Files"
+#~ msgstr "Fitxers"
+
+#~ msgid "Selection"
+#~ msgstr "Selecció"
+
+#~ msgid "conversion to 8-bit encoding failed"
+#~ msgstr "no s'ha pogut fer la conversió a una codificació de 8 bits"
+
+#~ msgid "failed to retrieve execution result"
+#~ msgstr "no s'ha pogut recuperar el resultat de l'execució"
+
+#~ msgid " (while overwriting an existing item)"
+#~ msgstr " (en sobreescriure un element existent)"
+
+#~ msgid "&Save as"
+#~ msgstr "Anomena i de&sa"
+
+#~ msgid "'%s' doesn't consist only of valid characters"
+#~ msgstr "'%s' no consisteix només de caràcters vàlids"
+
+#~ msgid "'%s' should be numeric."
+#~ msgstr "'%s' hauria de ser numèric."
+
+#~ msgid "'%s' should only contain ASCII characters."
+#~ msgstr "'%s' només hauria de contenir caràcters ASCII."
+
+#~ msgid "'%s' should only contain alphabetic characters."
+#~ msgstr "'%s' només hauria de contenir caràcters alfabètics."
+
+#~ msgid "'%s' should only contain alphabetic or numeric characters."
+#~ msgstr "'%s' només hauria de contenir caràcters alfabètics o numèrics."
+
+#~ msgid "'%s' should only contain digits."
+#~ msgstr "'%s' només hauria de contenir dígits."
+
+#~ msgid "Can't create window of class %s"
+#~ msgstr "No es pot crear una finestra de la classe '%s'"
+
+#~ msgid "Couldn't create the overlay window"
+#~ msgstr "No s'ha pogut crear la finestra de superposició"
+
+#~ msgid "Couldn't init the context on the overlay window"
+#~ msgstr "No s'ha pogut inicialitzar el context a la finestra de superposició"
+
+#~ msgid "Failed to convert file \"%s\" to Unicode."
+#~ msgstr "No s'ha pogut convertir el fitxer \"%s\" a Unicode."
+
+#~ msgid "Failed to set text in the text control."
+#~ msgstr "No s'ha pogut definir el text del control de text."
+
+#~ msgid "Invalid GTK+ command line option, use \"%s --help\""
+#~ msgstr "Optó de línia d'ordres de GTK+ invàlida, feu servir \"%s --help\""
+
+#~ msgid "No unused colour in image."
+#~ msgstr "No hi ha cap color sense utilitzar a la imatge."
+
+#~ msgid "Not available"
+#~ msgstr "No disponible"
+
+#~ msgid "Replace selection"
+#~ msgstr "Substitueix la selecció"
+
+#~ msgid "Save as"
+#~ msgstr "Anomena i desa"
+
+#~ msgid "Style Organiser"
+#~ msgstr "Organitzador d'estils"
+
+#~ msgid "The following standard GTK+ options are also supported:\n"
+#~ msgstr "També estan suportades les següents opcions estàndard de GTK+:\n"
+
+#~ msgid "You cannot Clear an overlay that is not inited"
+#~ msgstr "No podeu netejar una superposició que no s'ha inicialitzat"
+
+#~ msgid "You cannot Init an overlay twice"
+#~ msgstr "No podeu inicialitzar una superposició dues vegades"
+
+#~ msgid "locale '%s' cannot be set."
+#~ msgstr "no es pot definir la configuració local '%s'."
+
+#, fuzzy
+#~ msgid "Column index not found."
+#~ msgstr "no s'ha trobat el fitxer de catàleg per al domini '%s'"
+
+#~ msgid "Confirm registry update"
+#~ msgstr "Confirmeu l'actualització del registre"
+
+#, fuzzy
+#~ msgid "Could not determine column index."
+#~ msgstr "No s'ha pogut iniciar la previsualització del document."
+
+#, fuzzy
+#~ msgid "Could not determine number of columns."
+#~ msgstr "No es pot trobar el fitxer d'inclusió de recursos %s."
+
+#, fuzzy
+#~ msgid "Could not determine number of items"
+#~ msgstr "No es pot trobar el fitxer d'inclusió de recursos %s."
+
+#, fuzzy
+#~ msgid "Could not get header description."
+#~ msgstr "No s'ha pogut iniciar la impressió"
+
+#, fuzzy
+#~ msgid "Could not get items."
+#~ msgstr "No es pot obrir el fitxer '%s'."
+
+#, fuzzy
+#~ msgid "Could not get property flags."
+#~ msgstr "no es pot extreure el fitxer temporal '%s'"
+
+#, fuzzy
+#~ msgid "Could not get selected items."
+#~ msgstr "No es pot obrir el fitxer '%s'."
+
+#, fuzzy
+#~ msgid "Could not remove column."
+#~ msgstr "No s'ha pogut crear un cursor."
+
+#, fuzzy
+#~ msgid "Could not retrieve number of items"
+#~ msgstr "no es pot extreure el fitxer temporal '%s'"
+
+#, fuzzy
+#~ msgid "Could not set column width."
+#~ msgstr "No s'ha pogut iniciar la previsualització del document."
+
+#, fuzzy
+#~ msgid "Could not set header description."
+#~ msgstr "No s'ha pogut iniciar la impressió"
+
+#, fuzzy
+#~ msgid "Could not set icon."
+#~ msgstr "No s'ha pogut iniciar la impressió"
+
+#, fuzzy
+#~ msgid "Could not set maximum width."
+#~ msgstr "No s'ha pogut iniciar la impressió"
+
+#, fuzzy
+#~ msgid "Could not set minimum width."
+#~ msgstr "No s'ha pogut iniciar la impressió"
+
+#, fuzzy
+#~ msgid "Could not set property flags."
+#~ msgstr "No s'ha pogut iniciar la impressió"
+
+#~ msgid ""
+#~ "Do you want to overwrite the command used to %s files with extension "
+#~ "\"%s\" ?\n"
+#~ "Current value is \n"
+#~ "%s, \n"
+#~ "New value is \n"
+#~ "%s %1"
+#~ msgstr ""
+#~ "Desitgeu sobrescriure l'ordre utilitzada per als fitxer %s amb l'extensió "
+#~ "\"%s\" ?\n"
+#~ "el valor actual és \n"
+#~ "%s, \n"
+#~ "El nou valor és \n"
+#~ "%s %1"
+
+#~ msgid "Failed to retrieve data from the clipboard."
+#~ msgstr "No s'ha pogut recuperar les dades del porta-retalls."
+
+#~ msgid "GIF: Invalid gif index."
+#~ msgstr "GIF: Índex invàlid de gif."
+
+#~ msgid "GIF: unknown error!!!"
+#~ msgstr "GIF: error desconegut!!!"
+
+#, fuzzy
+#~ msgid "New directory"
+#~ msgstr "Crea directori"
+
+#, fuzzy
+#~ msgid "Next"
+#~ msgstr "&Següent"
+
+#, fuzzy
+#~ msgid "Number of columns could not be determined."
+#~ msgstr "No s'ha pogut carregar el fitxer."
+
+#~ msgid ""
+#~ "Please install a newer version of comctl32.dll\n"
+#~ "(at least version 4.70 is required but you have %d.%02d)\n"
+#~ "or this program won't operate correctly."
+#~ msgstr ""
+#~ "Cal que instal·leu una versió més nova de comctl32.dll\n"
+#~ "(com a mínim cal la versió 4.70 però teniu la %d.%02d)\n"
+#~ "o aquest programa no operarà correctament."
+
+#, fuzzy
+#~ msgid "Rendering failed."
+#~ msgstr "No s'ha pogut crear la canonada."
+
+#~ msgid "Show hidden directories"
+#~ msgstr "Mostra directoris ocults."
+
+#, fuzzy
+#~ msgid "Unable to initialize Hildon program"
+#~ msgstr "No s'ha pogut inicialitzar l'OpenGL"
+
+#, fuzzy
+#~ msgid "Unknown data format"
+#~ msgstr "IFF: error en format d'imatge IFF."
+
+#~ msgid "Win32s on Windows 3.1"
+#~ msgstr "Win32s en Windows 3.1"
+
+#, fuzzy
+#~ msgid "Windows 10"
+#~ msgstr "Windows 9%c"
+
+#, fuzzy
+#~ msgid "Windows 2000"
+#~ msgstr "Windows 9%c"
+
+#, fuzzy
+#~ msgid "Windows 7"
+#~ msgstr "Windows 9%c"
+
+#, fuzzy
+#~ msgid "Windows 8"
+#~ msgstr "Windows 9%c"
+
+#, fuzzy
+#~ msgid "Windows 8.1"
+#~ msgstr "Windows 9%c"
+
+#, fuzzy
+#~ msgid "Windows 95"
+#~ msgstr "Windows 9%c"
+
+#, fuzzy
+#~ msgid "Windows 95 OSR2"
+#~ msgstr "Windows 9%c"
+
+#, fuzzy
+#~ msgid "Windows 98"
+#~ msgstr "Windows 9%c"
+
+#, fuzzy
+#~ msgid "Windows 98 SE"
+#~ msgstr "Windows 9%c"
+
+#, fuzzy
+#~ msgid "Windows 9x (%d.%d)"
+#~ msgstr "Windows 9%c"
+
+#, fuzzy
+#~ msgid "Windows CE (%d.%d)"
+#~ msgstr "Windows 9%c"
+
+#, fuzzy
+#~ msgid "Windows ME"
+#~ msgstr "Windows 3.1"
+
+#, fuzzy
+#~ msgid "Windows NT %lu.%lu"
+#~ msgstr "Windows 9%c"
+
+#, fuzzy
+#~ msgid "Windows Server 10"
+#~ msgstr "Windows Grec (CP 1253)"
+
+#, fuzzy
+#~ msgid "Windows Server 2003"
+#~ msgstr "Windows Grec (CP 1253)"
+
+#, fuzzy
+#~ msgid "Windows Server 2008"
+#~ msgstr "Windows 9%c"
+
+#, fuzzy
+#~ msgid "Windows Server 2008 R2"
+#~ msgstr "Windows Hebreu (CP 1255)"
+
+#, fuzzy
+#~ msgid "Windows Server 2012"
+#~ msgstr "Windows Grec (CP 1253)"
+
+#, fuzzy
+#~ msgid "Windows Server 2012 R2"
+#~ msgstr "Windows Hebreu (CP 1255)"
+
+#, fuzzy
+#~ msgid "Windows Vista"
+#~ msgstr "Windows 9%c"
+
+#, fuzzy
+#~ msgid "Windows XP"
+#~ msgstr "Windows 9%c"
+
+#, fuzzy
+#~ msgid "can't execute '%s'"
+#~ msgstr "No s'ha pogut executar '%s'\n"
+
+#~ msgid "error opening '%s'"
+#~ msgstr "Error en llegir '%s'"
+
+#~ msgid "unknown seek origin"
+#~ msgstr "origen de recerca desconegut"
+
+#, fuzzy
+#~ msgid "Cannot create mutex."
+#~ msgstr "No es pot crear un fil"
+
+#, fuzzy
+#~ msgid "Cannot resume thread %lu"
+#~ msgstr "No es pot enumerar els fitxers en el directori '%s'"
+
+#, fuzzy
+#~ msgid "Cannot suspend thread %lu"
+#~ msgstr "No es pot suspendre en fil %x"
+
+#, fuzzy
+#~ msgid "Couldn't acquire a mutex lock"
+#~ msgstr "No s'ha pogut crear un temporitzador"
+
+#, fuzzy
+#~ msgid "Couldn't release a mutex"
+#~ msgstr "No s'ha pogut crear un temporitzador"
+
+#, fuzzy
+#~ msgid "DIVIDE"
+#~ msgstr "<DIR>"
+
+#, fuzzy
+#~ msgid "Execution of command '%s' failed with error: %ul"
+#~ msgstr "L'execució de l'ordre '%s' ha fallit."
+
+#~ msgid ""
+#~ "File '%s' already exists.\n"
+#~ "Do you want to replace it?"
+#~ msgstr ""
+#~ "El fitxer '%s' ja existeix,\n"
+#~ "Desitgeu substituir-lo?"
+
+#, fuzzy
+#~ msgid "Timer creation failed."
+#~ msgstr "No s'ha pogut crear la canonada."
+
+#, fuzzy
+#~ msgid "Print preview"
+#~ msgstr "Imprimeix previsualització"
+
+#, fuzzy
+#~ msgid "&Preview..."
+#~ msgstr " Previsualitza"
+
+#, fuzzy
+#~ msgid "Preview..."
+#~ msgstr " Previsualitza"
+
+#~ msgid "&Save..."
+#~ msgstr "&Desa..."
+
+#, fuzzy
+#~ msgid "All files (*.*)|*"
+#~ msgstr "Tots els fitxers (*.*) *.*  "
+
+#~ msgid "Cannot initialize SciTech MGL!"
+#~ msgstr "No es pot inicialitzar SciTech MGL!"
+
+#~ msgid "Cannot initialize display."
+#~ msgstr "No es pot començar a mostrar."
+
+#~ msgid "Cannot start thread: error writing TLS"
+#~ msgstr "No es pot iniciar el fil: s'ha comès un error en escriure TLS"
+
+#~ msgid "Close\tAlt-F4"
+#~ msgstr "Tanca\tAlt-F4"
+
+#~ msgid "Couldn't create cursor."
+#~ msgstr "No s'ha pogut crear un cursor."
+
+#~ msgid "Directory '%s' doesn't exist!"
+#~ msgstr "El directori '%s' no existeix!"
+
+#~ msgid "Mode %ix%i-%i not available."
+#~ msgstr "Mode %ix%i-%i no disponible."
+
+#~ msgid "Paper Size"
+#~ msgstr "Mida del paper"
+
+#~ msgid "Can't check image format of file '%s': file does not exist."
+#~ msgstr ""
+#~ "No es pot revisar el format d'imatge del fitxer '%s': el fitxer no "
+#~ "existeix."
+
+#~ msgid "Can't load image from file '%s': file does not exist."
+#~ msgstr ""
+#~ "No es pot carregar una imatge del fitxer '%s': el fitxer no existeix."
+
+#~ msgid "Cannot convert dialog units: dialog unknown."
+#~ msgstr "No es pot convertir el diàleg d'unitats: diàleg desconegut"
+
+#, fuzzy
+#~ msgid "Cannot convert from the charset '%s'!"
+#~ msgstr "No es pot convertir des de la codificació '%s'!"
+
+#~ msgid "Cannot find container for unknown control '%s'."
+#~ msgstr "No es pot trobar el contenidor del control desconegut '%s'."
+
+#~ msgid "Cannot find font node '%s'."
+#~ msgstr "No es pot trobar el node  '%s' de font."
+
+#~ msgid "Cannot open file '%s'."
+#~ msgstr "No es pot obrir el fitxer '%s'."
+
+#~ msgid "Cannot parse coordinates from '%s'."
+#~ msgstr "No es pot analitzar les coordenades des de '%s'."
+
+#~ msgid "Cannot parse dimension from '%s'."
+#~ msgstr "No es pot analitzar les dimensions des de '%s'."
+
+#, fuzzy
+#~ msgid "Cant create the thread event queue"
+#~ msgstr "No es pot crear un fil"
+
+#, fuzzy
+#~ msgid "Click to cancel this window."
+#~ msgstr "Tanca aquesta finestra"
+
+#, fuzzy
+#~ msgid "Could not unlock mutex"
+#~ msgstr "No s'ha pogut crear un temporitzador"
+
+#~ msgid "Failed to create a status bar."
+#~ msgstr "No s'ha pogut crear una barra d'estat."
+
+#, fuzzy
+#~ msgid "Failed to register OpenGL window class."
+#~ msgstr "No s'ha pogut inicialitzar l'OpenGL"
+
+#~ msgid "Fatal error: "
+#~ msgstr "Error fatal:"
+
+#~ msgid "Goto Page"
+#~ msgstr "Vés a la pàgina"
+
+#, fuzzy
+#~ msgid "Help : %s"
+#~ msgstr "Ajuda: %s"
+
+#~ msgid "Invalid XRC resource '%s': doesn't have root node 'resource'."
+#~ msgstr "Recurs XRC '%s' invàlid: no té una arrel del node de 'recurs'."
+
+#~ msgid "No handler found for XML node '%s', class '%s'!"
+#~ msgstr "No s'ha trobat cap manegador per als nodes XML '%s', classe '%s'!"
+
+#, fuzzy
+#~ msgid "No image handler for type %ld defined."
+#~ msgstr "No hi ha definit cap manegador per al tipus d'imatge %d."
+
+#, fuzzy
+#~ msgid "Owner not initialized."
+#~ msgstr "No es pot començar a mostrar."
+
+#, fuzzy
+#~ msgid "Passed item is invalid."
+#~ msgstr "'%s' és invàlid"
+
+#~ msgid "Program aborted."
+#~ msgstr "Programa avortat."
+
+#~ msgid "Referenced object node with ref=\"%s\" not found!"
+#~ msgstr "Objecte de node referenciat amb ref=\"%s\"\" no s'ha trobat!"
+
+#~ msgid "Resource files must have same version number!"
+#~ msgstr "Els fitxers de recursos han de tenir el mateix número de versió!"
+
+#, fuzzy
+#~ msgid "Search!"
+#~ msgstr "Cerca"
+
+#~ msgid "Sorry, could not open this file for saving."
+#~ msgstr "No es pot obrir aquest fitxer per desar."
+
+#~ msgid "Sorry, could not save this file."
+#~ msgstr "No s'ha pogut desar aquest fitxer."
+
+#~ msgid "Status: "
+#~ msgstr "Estat:"
+
+#~ msgid "Subclass '%s' not found for resource '%s', not subclassing!"
+#~ msgstr "Subclasse '%s' no trobada per recursos '%s', no subclassificant!"
+
+#, fuzzy
+#~ msgid ""
+#~ "The file '%s' couldn't be opened.\n"
+#~ "It has been removed from the most recently used files list."
+#~ msgstr ""
+#~ "El fitxer '%s' no existeix i per tant no pot ser obert.\n"
+#~ "Ha estat extret des de llistat de fitxers utilitzats més recentment."
+
+#~ msgid "The path '%s' contains too many \"..\"!"
+#~ msgstr "La ruta '%s' conté massa \"..\"!"
+
+#~ msgid "Trying to solve a NULL hostname: giving up"
+#~ msgstr "S'està intetant solucionar un nom d'hostetjador buit: no es pot."
+
+#~ msgid "Unknown style flag "
+#~ msgstr "Estil de bandera desconegut"
+
+#~ msgid "Warning"
+#~ msgstr "Atenció"
+
+#~ msgid "XRC resource '%s' (class '%s') not found!"
+#~ msgstr "recurs XRC: '%s' (tipus '%s') no trobada!"
+
+#, fuzzy
+#~ msgid "XRC resource: Cannot create animation from '%s'."
+#~ msgstr "recurs XRC: No es pot crear mapa de bits des de '%s'."
+
+#~ msgid "XRC resource: Cannot create bitmap from '%s'."
+#~ msgstr "recurs XRC: No es pot crear mapa de bits des de '%s'."
+
+#, fuzzy
+#~ msgid ""
+#~ "XRC resource: Incorrect colour specification '%s' for attribute '%s'."
+#~ msgstr ""
+#~ "recurs XRC: Color d'especificació incorrecte '%s'  per a la propietat "
+#~ "'%s'."
+
+#~ msgid "[EMPTY]"
+#~ msgstr "[BUIT]"
+
+#~ msgid "catalog file for domain '%s' not found."
+#~ msgstr "no s'ha trobat el fitxer de catàleg per al domini '%s'"
+
+#, fuzzy
+#~ msgid "encoding %i"
+#~ msgstr "Codificació (%d) desconeguda"
+
+#~ msgid "looking for catalog '%s' in path '%s'."
+#~ msgstr "s'està cercant el catàleg '%s' a la ruta '%s'."
+
+#~ msgid "wxSocket: invalid signature in ReadMsg."
+#~ msgstr "wxSocket: signatura invàlida en ReadMsg."
+
+#~ msgid "wxSocket: unknown event!."
+#~ msgstr "wxSocket: incidència desconeguda!."
+
+#, fuzzy
+#~ msgid " Couldn't create the UnicodeConverter"
+#~ msgstr "No s'ha pogut crear un temporitzador"
+
+#~ msgid "#define %s must be an integer."
+#~ msgstr "#define %s ha de ser un número sencer."
+
+#~ msgid "%s not a bitmap resource specification."
+#~ msgstr "%s no és una especificació de recursos de mapa de bits."
+
+#~ msgid "%s not an icon resource specification."
+#~ msgstr "%s no és una especificació de recursos d'icona"
+
+#, fuzzy
+#~ msgid "%s: ill-formed resource file syntax."
+#~ msgstr "hi ha hagut un error intern en el DDEML"
+
+#, fuzzy
+#~ msgid "&Open"
+#~ msgstr "&Desa..."
+
+#, fuzzy
+#~ msgid "&Print"
+#~ msgstr "Imprimeix"
+
+#, fuzzy
+#~ msgid ""
+#~ ", expected static, #include or #define\n"
+#~ "while parsing resource."
+#~ msgstr ""
+#~ ", les estadítiques esperades #include o #define\n"
+#~ "mentre s'està analitzant el recurs."
+
+#~ msgid "Bitmap resource specification %s not found."
+#~ msgstr "No s'ha trobat l'especificació %s de recursos de mapa de bits."
+
+#~ msgid ""
+#~ "Could not resolve control class or id '%s'. Use (non-zero) integer "
+#~ "instead\n"
+#~ " or provide #define (see manual for caveats)"
+#~ msgstr ""
+#~ "No es pot resoldre la classe de control o l'id '%s'. Utilitzeu un número "
+#~ "sencer diferent de zero\n"
+#~ " o proporcioneu el #define (vegeu els consells del manual)"
+
+#~ msgid ""
+#~ "Could not resolve menu id '%s'. Use (non-zero) integer instead\n"
+#~ "or provide #define (see manual for caveats)"
+#~ msgstr ""
+#~ "No es pot resoldre l'id del menú '%s'. Utilitza un sencer diferent de "
+#~ "zero\n"
+#~ " o proporciona el #define (vegeu els consells del manual)"
+
+#, fuzzy
+#~ msgid "Couldn't end the context on the overlay window"
+#~ msgstr "No es pot obtenir l'actual cadena de punter"
+
+#, fuzzy
+#~ msgid "Expected '*' while parsing resource."
+#~ msgstr "S'esperava '*' en analitzar el recurs."
+
+#, fuzzy
+#~ msgid "Expected '=' while parsing resource."
+#~ msgstr "S'esperava '=' en analitzar el recurs."
+
+#, fuzzy
+#~ msgid "Expected 'char' while parsing resource."
+#~ msgstr "S'esperava 'char' en analitzar el recurs."
+
+#~ msgid ""
+#~ "Failed to find XBM resource %s.\n"
+#~ "Forgot to use wxResourceLoadBitmapData?"
+#~ msgstr ""
+#~ "No s'ha pogut trobar el recurs XBM %s.\n"
+#~ "No us recordat d'utilitzar  wxResourceLoadBitmapData?"
+
+#~ msgid ""
+#~ "Failed to find XBM resource %s.\n"
+#~ "Forgot to use wxResourceLoadIconData?"
+#~ msgstr ""
+#~ "No s'ha pogut trobar el recurs XBM %s.\n"
+#~ "No us heu recordat d'utilitzar  wxResourceLoadIconData?"
+
+#~ msgid ""
+#~ "Failed to find XPM resource %s.\n"
+#~ "Forgot to use wxResourceLoadBitmapData?"
+#~ msgstr ""
+#~ "No s'ha pogut trobar el recurs XMP %s. \n"
+#~ "No us recordat d'utilitzar wxResourceLoadBitmapData?"
+
+#~ msgid "Failed to get clipboard data."
+#~ msgstr "No s'han pogut obtenir les dades del porta-retalls"
+
+#~ msgid "Failed to load shared library '%s' Error '%s'"
+#~ msgstr "No s'ha pogut carregar la llibreria compartida '%s' Error '%s'"
+
+#~ msgid "Found "
+#~ msgstr "Trobat"
+
+#~ msgid "Icon resource specification %s not found."
+#~ msgstr "No s'ha trobat l'especificació %s de recursos d'icones"
+
+#~ msgid "Ill-formed resource file syntax."
+#~ msgstr "Sintaxi incorrecta del codi font."
+
+#~ msgid "No XPM icon facility available!"
+#~ msgstr "No hi ha cap icona XPM disponible!"
+
+#~ msgid "Option '%s' requires a value, '=' expected."
+#~ msgstr "L'opció '%s' requereix un valor, '=' esperat."
+
+#, fuzzy
+#~ msgid "Select all"
+#~ msgstr "Selecciona-ho &tot"
+
+#, fuzzy
+#~ msgid "Unexpected end of file while parsing resource."
+#~ msgstr "Fi de fitxer inesperat en analitzar el recurs."
+
+#, fuzzy
+#~ msgid "Unrecognized style %s while parsing resource."
+#~ msgstr "Estil desconegut %s en analitzar el recurs."
+
+#~ msgid "Warning: attempt to remove HTML tag handler from empty stack."
+#~ msgstr "Atenció: intent d'extreure una etiqueta HTML d'una pila buida."
+
+#~ msgid "establish"
+#~ msgstr "estableix"
+
+#~ msgid "initiate"
+#~ msgstr "inicia"
+
+#~ msgid "invalid eof() return value."
+#~ msgstr "valor eof() de retorn invàlid."
+
+#~ msgid "unknown line terminator"
+#~ msgstr "acabament de línia desconegut"
+
+#~ msgid "writing"
+#~ msgstr "s'està escrivint"
+
+#~ msgid "."
+#~ msgstr "."
+
+#~ msgid "Cannot open URL '%s'"
+#~ msgstr "No es pot obrir l'URL '%s'."
+
+#~ msgid "Error "
+#~ msgstr "Error "
+
+#~ msgid "Failed to create directory %s/.gnome."
+#~ msgstr "No s'ha pogut crear un directori %s/.gnome."
+
+#~ msgid "Failed to create directory %s/mime-info."
+#~ msgstr "No s'ha pogut crear el directori %s/mime-info."
+
+#~ msgid "Mailcap file %s, line %d: incomplete entry ignored."
+#~ msgstr "Fitxer mailcap %s, línia %d: entrada incompleta ignorada."
+
+#~ msgid "Mime.types file %s, line %d: unterminated quoted string."
+#~ msgstr ""
+#~ "Mime. Tipus de fitxer %s, línia %d: cadena entre cometes no acabada."
+
+#~ msgid "Unknown field in file %s, line %d: '%s'."
+#~ msgstr "Camp desconegut en el fitxer %s, línia %d: '%s'."
+
+#~ msgid "bold "
+#~ msgstr "negreta"
+
+#~ msgid "light "
+#~ msgstr "il·luminació"
+
+#~ msgid "underlined "
+#~ msgstr "subratllat"
+
+#, fuzzy
+#~ msgid "unsupported zip archive"
+#~ msgstr "Format no suportat de porta-retalls"
+
+#, fuzzy
+#~ msgid ""
+#~ "Failed to get stack backtrace:\n"
+#~ "%s"
+#~ msgstr "No s'han pogut obtenir els noms ISP: %s"
+
+#~ msgid "Loading Grey Ascii PNM image is not yet implemented."
+#~ msgstr ""
+#~ "Carregar un fitxer Ascii PNM d'escala de grisos encara no està "
+#~ "implementat."
+
+#~ msgid "Loading Grey Raw PNM image is not yet implemented."
+#~ msgstr ""
+#~ "Carregar un fitxer d'imatge Raw PNM d'escala de grisos encara no està "
+#~ "implementat."
+
+#, fuzzy
+#~ msgid "Cannot wait on thread to exit."
+#~ msgstr "No es pot esperar per a l'acabament de cadena"
+
+#~ msgid "Could not load Rich Edit DLL '%s'"
+#~ msgstr "No es pot carregar el DLL d'edició rica '%s'"
+
+#~ msgid "ZIP handler currently supports only local files!"
+#~ msgstr "El manegador ZIP generalment només permet l'ús de fitxers locals!"
+
+#, fuzzy
+#~ msgid ""
+#~ "can't seek on file descriptor %d, large files support is not enabled."
+#~ msgstr "no és pot cercar el fitxer descriptor de %d"
+
+#~ msgid "More..."
+#~ msgstr "Més..."
+
+#~ msgid "Setup"
+#~ msgstr "Configuració"
+
+#~ msgid "GetUnusedColour:: No Unused Color in image "
+#~ msgstr "GetUnusedColour:: No s'ha utilitzat cap color a la imatge"
+
+#~ msgid ""
+#~ "Can't create list control window, check that comctl32.dll is installed."
+#~ msgstr ""
+#~ "No es pot crear un llistat de control de finestra, mireu si el "
+#~ "comctl32.dll es troba instal·lat."
+
+#~ msgid "Can't delete value of key '%s'"
+#~ msgstr "No es pot eliminar la clau de registre '%s'"
+
+#~ msgid "gmtime() failed"
+#~ msgstr "gmtime() ha fallat"
+
+#~ msgid "mktime() failed"
+#~ msgstr "mktime() ha fallat"
+
+#~ msgid "%d...%d"
+#~ msgstr "%d...%d"
+
+#~ msgid ""
+#~ "<html><body><table><tr><td>Normal face<br>(and <u>underlined</u>. "
+#~ "<i>Italic face.</i> <b>Bold face.</b> <b><i>Bold italic face.</i></"
+#~ "b><br><font size=-2>font size -2</font><br><font size=-1>font size -1</"
+#~ "font><br><font size=+0>font size +0</font><br><font size=+1>font size +1</"
+#~ "font><br><font size=+2>font size +2</font><br><font size=+3>font size +3</"
+#~ "font><br><font size=+4>font size +4</font><br><td><p><tt>Fixed size face."
+#~ "<br> <b>bold</b> <i>italic</i> <b><i>bold italic <u>underlined</u></i></"
+#~ "b><br><font size=-2>font size -2</font><br><font size=-1>font size -1</"
+#~ "font><br><font size=+0>font size +0</font><br><font size=+1>font size +1</"
+#~ "font><br><font size=+2>font size +2</font><br><font size=+3>font size +3</"
+#~ "font><br><font size=+4>font size +4</font></tt></table></body></html>"
+#~ msgstr ""
+#~ "<html><body><table><tr><td>Normal face<br>(and <u>underlined</u>. "
+#~ "<i>Italic face.</i> <b>Bold face.</b> <b><i>Bold italic face.</i></"
+#~ "b><br><font size=-2>font size -2</font><br><font size=-1>font size -1</"
+#~ "font><br><font size=+0>font size +0</font><br><font size=+1>font size +1</"
+#~ "font><br><font size=+2>font size +2</font><br><font size=+3>font size +3</"
+#~ "font><br><font size=+4>font size +4</font><br><td><p><tt>Fixed size face."
+#~ "<br> <b>bold</b> <i>italic</i> <b><i>bold italic <u>underlined</u></i></"
+#~ "b><br><font size=-2>font size -2</font><br><font size=-1>font size -1</"
+#~ "font><br><font size=+0>font size +0</font><br><font size=+1>font size +1</"
+#~ "font><br><font size=+2>font size +2</font><br><font size=+3>font size +3</"
+#~ "font><br><font size=+4>font size +4</font></tt></table></body></html>"
+
+#~ msgid "Can't create dialog using memory template"
+#~ msgstr "No es pot crear un diàleg utilitzant plantilla de memòria."
+
+#~ msgid "Can't create dialog using template '%ul'"
+#~ msgstr "No es pot crear un diàleg utilitzant la plantilla '%ul'"
+
+#~ msgid "Did you forget to include wx/os2/wx.rc in your resources?"
+#~ msgstr "Us n'heu oblidat d'incloure wx/os2/wx.rc en els recursos?"
+
+#~ msgid "Failed to create dialog. Incorrect DLGTEMPLATE?"
+#~ msgstr "No s'ha pogut crear el diàleg. És el DLGTEMPLATE incorrecte?"
+
+#~ msgid "Fatal error: exiting"
+#~ msgstr "Error fatal: sortint"
+
+#~ msgid ""
+#~ "HTML files (*.htm)|*.htm|HTML files (*.html)|*.html|Help books (*.htb)|"
+#~ "*.htb|Help books (*.zip)|*.zip|HTML Help Project (*.hhp)|*.hhp|All files "
+#~ "(*.*)|*"
+#~ msgstr ""
+#~ "arxius HTML (*.htm)|*.htm|arxius HTML(*.html)|*.html|Llibres d'ajuda "
+#~ "(*.htb)|*.htb|Llibres d'ajuda  (*.zip)|*.zip|Projectes d'ajuda HTML "
+#~ "(*.hhp)|*.hhp|Tots el arxius (*.*)|*"
+
+#~ msgid "Load file"
+#~ msgstr "Carrega fitxer"
+
+#~ msgid "Save file"
+#~ msgstr "Desa fitxer"
+
+#~ msgid "illegal scrollbar selector %d"
+#~ msgstr "seleccionador de lliscador il·legal %d"
+
+#~ msgid "wxDllLoader failed to GetSymbol '%s'"
+#~ msgstr "wxDllLoader ha fallat a GetSymbol '%s'"
+
+#~ msgid "wxDynamicLibrary failed to GetSymbol '%s'"
+#~ msgstr "wxDynamicLibrary ha fallat a GetSymbol '%s'"

--- a/po_wxstd/ca@valencia.po
+++ b/po_wxstd/ca@valencia.po
@@ -1,0 +1,10678 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: wxWidgets 3.3\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-05-14 20:23+0200\n"
+"PO-Revision-Date: 2003-07-22 11:31+0100\n"
+"Last-Translator: Robert Millan <rmh@aybabtu.com>\n"
+"Language-Team: <wx-translators@wxwidgets.org>\n"
+"Language: ca@valencia\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: ../include/wx/defs.h:2582
+msgid "All files (*.*)|*.*"
+msgstr "Tots els fitxers (*.*)|*.*"
+
+#: ../include/wx/defs.h:2585
+msgid "All files (*)|*"
+msgstr "Tots els fitxers (*)|*"
+
+#: ../include/wx/generic/progdlgg.h:85
+#, fuzzy
+msgid "Elapsed time:"
+msgstr "Temps transcorregut:"
+
+#: ../include/wx/generic/progdlgg.h:86
+#, fuzzy
+msgid "Estimated time:"
+msgstr "Temps estimat:"
+
+#: ../include/wx/generic/progdlgg.h:87
+#, fuzzy
+msgid "Remaining time:"
+msgstr "Temps restant :"
+
+#. TRANSLATORS: HTML printout default title.
+#: ../include/wx/html/htmprint.h:121 ../include/wx/prntbase.h:273
+#: ../include/wx/richtext/richtextprint.h:109 ../src/common/docview.cpp:2161
+#, fuzzy
+msgid "Printout"
+msgstr "Imprimix"
+
+#. TRANSLATORS: HTML easy print default title.
+#: ../include/wx/html/htmprint.h:234 ../include/wx/richtext/richtextprint.h:163
+#: ../src/common/prntbase.cpp:522 ../src/html/htmprint.cpp:291
+#, fuzzy
+msgid "Printing"
+msgstr "S'està imprimint"
+
+#: ../include/wx/msgdlg.h:277 ../src/common/stockitem.cpp:211
+msgid "Yes"
+msgstr "Sí"
+
+#: ../include/wx/msgdlg.h:278 ../src/common/stockitem.cpp:182
+msgid "No"
+msgstr "No"
+
+#: ../include/wx/msgdlg.h:279 ../src/common/stockitem.cpp:183
+#: ../src/msw/msgdlg.cpp:430 ../src/msw/msgdlg.cpp:734
+#: ../src/richtext/richtextstyledlg.cpp:292
+msgid "OK"
+msgstr "D'acord"
+
+#: ../include/wx/msgdlg.h:280 ../src/common/stockitem.cpp:150
+#: ../src/msw/msgdlg.cpp:430 ../src/msw/progdlg.cpp:884
+#: ../src/richtext/richtextstyledlg.cpp:295
+msgid "Cancel"
+msgstr "Anul·la"
+
+#: ../include/wx/msgdlg.h:281 ../src/common/stockitem.cpp:168
+#: ../src/html/helpdlg.cpp:63 ../src/html/helpfrm.cpp:108
+#: ../src/osx/button_osx.cpp:38
+msgid "Help"
+msgstr "Ajuda"
+
+#: ../include/wx/msw/ole/oleutils.h:52
+msgid "Cannot initialize OLE"
+msgstr "No es pot inicialitzar OLE"
+
+#: ../include/wx/msw/private/fswatcher.h:48
+#, fuzzy, c-format
+msgid "Unable to close the handle for '%s'"
+msgstr "No s'ha pogut tancar el manegador de fitxers"
+
+#: ../include/wx/msw/private/fswatcher.h:92
+#, fuzzy, c-format
+msgid "Failed to open directory \"%s\" for monitoring."
+msgstr "No s'ha pogut obrir '%s' per %s"
+
+#: ../include/wx/msw/private/fswatcher.h:125
+#, fuzzy
+msgid "Unable to close I/O completion port handle"
+msgstr "No s'ha pogut tancar el manegador de fitxers"
+
+#: ../include/wx/msw/private/fswatcher.h:142
+msgid "Unable to associate handle with I/O completion port"
+msgstr ""
+
+#: ../include/wx/msw/private/fswatcher.h:148
+msgid "Unexpectedly new I/O completion port was created"
+msgstr ""
+
+#: ../include/wx/msw/private/fswatcher.h:213
+msgid "Unable to post completion status"
+msgstr ""
+
+#: ../include/wx/msw/private/fswatcher.h:262
+msgid "Unable to dequeue completion packet"
+msgstr ""
+
+#: ../include/wx/msw/private/fswatcher.h:273
+#, fuzzy
+msgid "Unable to create I/O completion port"
+msgstr "No s'ha pogut crear una barra d'estat."
+
+#: ../include/wx/richmsgdlg.h:29
+#, fuzzy
+msgid "&See details"
+msgstr "&Detalls"
+
+#: ../include/wx/richmsgdlg.h:30
+#, fuzzy
+msgid "&Hide details"
+msgstr "&Detalls"
+
+#: ../include/wx/richtext/richtextbuffer.h:3864
+#, fuzzy
+msgid "&Box"
+msgstr "Negreta"
+
+#: ../include/wx/richtext/richtextbuffer.h:5008
+msgid "&Picture"
+msgstr ""
+
+#: ../include/wx/richtext/richtextbuffer.h:5958
+#, fuzzy
+msgid "&Cell"
+msgstr "&Anul·la"
+
+#: ../include/wx/richtext/richtextbuffer.h:6067
+msgid "&Table"
+msgstr ""
+
+#: ../include/wx/richtext/richtextimagedlg.h:37
+#, fuzzy
+msgid "Object Properties"
+msgstr "&Previ"
+
+#: ../include/wx/richtext/richtextsymboldlg.h:39
+#, fuzzy
+msgid "Symbols"
+msgstr "Font normal"
+
+#: ../include/wx/unix/pipe.h:46
+msgid "Pipe creation failed"
+msgstr "No s'ha pogut crear la canonada."
+
+#: ../include/wx/unix/private/displayx11.h:65
+#, fuzzy
+msgid "Failed to enumerate video modes"
+msgstr "No s'ha pogut crear un directori %s/.gnome."
+
+#: ../include/wx/unix/private/displayx11.h:89
+#, fuzzy
+msgid "Failed to change video mode"
+msgstr "No s'ha pogut tancar el manegador de fitxers"
+
+#: ../include/wx/unix/private/fswatcher_kqueue.h:57
+#, fuzzy, c-format
+msgid "Unable to open path '%s'"
+msgstr "No s'ha pogut obrir '%s' per %s"
+
+#: ../include/wx/unix/private/fswatcher_kqueue.h:74
+#, fuzzy, c-format
+msgid "Unable to close path '%s'"
+msgstr "No s'ha pogut tancar el fitxer de bloqueig '%s'"
+
+#: ../include/wx/xtiprop.h:175
+msgid "SetProperty called w/o valid setter"
+msgstr ""
+
+#: ../include/wx/xtiprop.h:184
+msgid "GetProperty called w/o valid getter"
+msgstr ""
+
+#: ../include/wx/xtiprop.h:193
+msgid "AddToPropertyCollection called w/o valid adder"
+msgstr ""
+
+#: ../include/wx/xtiprop.h:202
+msgid "GetPropertyCollection called w/o valid collection getter"
+msgstr ""
+
+#: ../include/wx/xtiprop.h:255
+msgid "AddToPropertyCollection called on a generic accessor"
+msgstr ""
+
+#: ../include/wx/xtiprop.h:262
+msgid "GetPropertyCollection called on a generic accessor"
+msgstr ""
+
+#: ../src/aui/tabmdi.cpp:106 ../src/generic/mdig.cpp:94
+msgid "Cl&ose"
+msgstr "&Tanca"
+
+#: ../src/aui/tabmdi.cpp:107 ../src/generic/mdig.cpp:95
+msgid "Close All"
+msgstr "Tanca-ho tot"
+
+#: ../src/aui/tabmdi.cpp:109 ../src/generic/mdig.cpp:97 ../src/msw/mdi.cpp:175
+#: ../src/qt/mdi.cpp:258
+msgid "&Next"
+msgstr "&Següent"
+
+#: ../src/aui/tabmdi.cpp:110 ../src/generic/mdig.cpp:98 ../src/msw/mdi.cpp:176
+#: ../src/qt/mdi.cpp:259
+msgid "&Previous"
+msgstr "&Previ"
+
+#: ../src/aui/tabmdi.cpp:332 ../src/aui/tabmdi.cpp:348
+#: ../src/aui/tabmdi.cpp:350 ../src/generic/mdig.cpp:291
+#: ../src/generic/mdig.cpp:307 ../src/generic/mdig.cpp:311
+#: ../src/msw/mdi.cpp:337 ../src/qt/mdi.cpp:462
+msgid "&Window"
+msgstr "&Finestra"
+
+#: ../src/common/accelcmn.cpp:47
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Delete"
+msgstr "&Elimina"
+
+#: ../src/common/accelcmn.cpp:48
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Del"
+msgstr "&Elimina"
+
+#: ../src/common/accelcmn.cpp:49
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Back"
+msgstr "< &Enrere"
+
+#: ../src/common/accelcmn.cpp:49
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Backspace"
+msgstr "< &Enrere"
+
+#: ../src/common/accelcmn.cpp:50
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Insert"
+msgstr "Índex"
+
+#: ../src/common/accelcmn.cpp:51
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Ins"
+msgstr "Índex"
+
+#: ../src/common/accelcmn.cpp:52
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Enter"
+msgstr "Imprimix"
+
+#: ../src/common/accelcmn.cpp:53
+msgctxt "keyboard key"
+msgid "Return"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:54
+#, fuzzy
+msgctxt "keyboard key"
+msgid "PageUp"
+msgstr "Pàgines"
+
+#: ../src/common/accelcmn.cpp:54
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Page Up"
+msgstr "Pàgina %d"
+
+#: ../src/common/accelcmn.cpp:55
+#, fuzzy
+msgctxt "keyboard key"
+msgid "PageDown"
+msgstr "Avall"
+
+#: ../src/common/accelcmn.cpp:55
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Page Down"
+msgstr "Pàgina %d"
+
+#: ../src/common/accelcmn.cpp:56
+msgctxt "keyboard key"
+msgid "PgUp"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:57
+msgctxt "keyboard key"
+msgid "PgDn"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:58
+msgctxt "keyboard key"
+msgid "Left"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:59
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Right"
+msgstr "Clar"
+
+#: ../src/common/accelcmn.cpp:60
+msgctxt "keyboard key"
+msgid "Up"
+msgstr "Amunt"
+
+#: ../src/common/accelcmn.cpp:61
+msgctxt "keyboard key"
+msgid "Down"
+msgstr "Avall"
+
+#: ../src/common/accelcmn.cpp:62
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Home"
+msgstr "sense nom"
+
+#: ../src/common/accelcmn.cpp:63
+msgctxt "keyboard key"
+msgid "End"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:64
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Space"
+msgstr "S'està cercant..."
+
+#: ../src/common/accelcmn.cpp:65
+msgctxt "keyboard key"
+msgid "Tab"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:66
+msgctxt "keyboard key"
+msgid "Esc"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:67
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Escape"
+msgstr "Apaïsat"
+
+#: ../src/common/accelcmn.cpp:68
+msgctxt "keyboard key"
+msgid "Cancel"
+msgstr "Anul·la"
+
+#: ../src/common/accelcmn.cpp:69
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Clear"
+msgstr "&Neteja"
+
+#: ../src/common/accelcmn.cpp:70
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Menu"
+msgstr "Modern"
+
+#: ../src/common/accelcmn.cpp:71
+msgctxt "keyboard key"
+msgid "Pause"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:72
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Capital"
+msgstr "cursiva"
+
+#: ../src/common/accelcmn.cpp:73
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Select"
+msgstr "Seccions"
+
+#: ../src/common/accelcmn.cpp:74
+msgctxt "keyboard key"
+msgid "Print"
+msgstr "Imprimix"
+
+#: ../src/common/accelcmn.cpp:75
+msgctxt "keyboard key"
+msgid "Execute"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:76
+msgctxt "keyboard key"
+msgid "Snapshot"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:77
+msgctxt "keyboard key"
+msgid "Help"
+msgstr "Ajuda"
+
+#: ../src/common/accelcmn.cpp:78
+msgctxt "keyboard key"
+msgid "Add"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:79
+msgctxt "keyboard key"
+msgid "Separator"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:80
+msgctxt "keyboard key"
+msgid "Subtract"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:81
+msgctxt "keyboard key"
+msgid "Decimal"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:82
+msgctxt "keyboard key"
+msgid "Multiply"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:83
+msgctxt "keyboard key"
+msgid "Divide"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:84
+msgctxt "keyboard key"
+msgid "Num_lock"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:84
+msgctxt "keyboard key"
+msgid "Num Lock"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:85
+msgctxt "keyboard key"
+msgid "Scroll_lock"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:85
+msgctxt "keyboard key"
+msgid "Scroll Lock"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:86
+msgctxt "keyboard key"
+msgid "KP_Space"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:86
+msgctxt "keyboard key"
+msgid "Num Space"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:87
+msgctxt "keyboard key"
+msgid "KP_Tab"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:87
+msgctxt "keyboard key"
+msgid "Num Tab"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:88
+#, fuzzy
+msgctxt "keyboard key"
+msgid "KP_Enter"
+msgstr "Imprimix"
+
+#: ../src/common/accelcmn.cpp:88
+msgctxt "keyboard key"
+msgid "Num Enter"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:89
+#, fuzzy
+msgctxt "keyboard key"
+msgid "KP_Home"
+msgstr "sense nom"
+
+#: ../src/common/accelcmn.cpp:89
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Num Home"
+msgstr "sense nom"
+
+#: ../src/common/accelcmn.cpp:90
+msgctxt "keyboard key"
+msgid "KP_Left"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:90
+msgctxt "keyboard key"
+msgid "Num left"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:91
+msgctxt "keyboard key"
+msgid "KP_Up"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:91
+msgctxt "keyboard key"
+msgid "Num Up"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:92
+#, fuzzy
+msgctxt "keyboard key"
+msgid "KP_Right"
+msgstr "Clar"
+
+#: ../src/common/accelcmn.cpp:92
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Num Right"
+msgstr "Clar"
+
+#: ../src/common/accelcmn.cpp:93
+#, fuzzy
+msgctxt "keyboard key"
+msgid "KP_Down"
+msgstr "Avall"
+
+#: ../src/common/accelcmn.cpp:93
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Num Down"
+msgstr "Avall"
+
+#: ../src/common/accelcmn.cpp:94
+msgctxt "keyboard key"
+msgid "KP_PageUp"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:94
+msgctxt "keyboard key"
+msgid "Num Page Up"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:95
+msgctxt "keyboard key"
+msgid "KP_PageDown"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:95
+msgctxt "keyboard key"
+msgid "Num Page Down"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:96
+msgctxt "keyboard key"
+msgid "KP_Prior"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:97
+#, fuzzy
+msgctxt "keyboard key"
+msgid "KP_Next"
+msgstr "&Següent"
+
+#: ../src/common/accelcmn.cpp:98
+msgctxt "keyboard key"
+msgid "KP_End"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:98
+msgctxt "keyboard key"
+msgid "Num End"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:99
+msgctxt "keyboard key"
+msgid "KP_Begin"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:99
+msgctxt "keyboard key"
+msgid "Num Begin"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:100
+#, fuzzy
+msgctxt "keyboard key"
+msgid "KP_Insert"
+msgstr "Índex"
+
+#: ../src/common/accelcmn.cpp:100
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Num Insert"
+msgstr "Índex"
+
+#: ../src/common/accelcmn.cpp:101
+#, fuzzy
+msgctxt "keyboard key"
+msgid "KP_Delete"
+msgstr "&Elimina"
+
+#: ../src/common/accelcmn.cpp:101
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Num Delete"
+msgstr "&Elimina"
+
+#: ../src/common/accelcmn.cpp:102
+msgctxt "keyboard key"
+msgid "KP_Equal"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:102
+msgctxt "keyboard key"
+msgid "Num ="
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:103
+msgctxt "keyboard key"
+msgid "KP_Multiply"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:103
+msgctxt "keyboard key"
+msgid "Num *"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:104
+msgctxt "keyboard key"
+msgid "KP_Add"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:104
+msgctxt "keyboard key"
+msgid "Num +"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:105
+msgctxt "keyboard key"
+msgid "KP_Separator"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:105
+msgctxt "keyboard key"
+msgid "Num ,"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:106
+msgctxt "keyboard key"
+msgid "KP_Subtract"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:106
+msgctxt "keyboard key"
+msgid "Num -"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:107
+msgctxt "keyboard key"
+msgid "KP_Decimal"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:107
+msgctxt "keyboard key"
+msgid "Num ."
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:108
+msgctxt "keyboard key"
+msgid "KP_Divide"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:108
+msgctxt "keyboard key"
+msgid "Num /"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:109
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Windows_Left"
+msgstr "Windows 9%c"
+
+#: ../src/common/accelcmn.cpp:110
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Windows_Right"
+msgstr "Windows 9%c"
+
+#: ../src/common/accelcmn.cpp:111
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Windows_Menu"
+msgstr "Windows 3.1"
+
+#: ../src/common/accelcmn.cpp:112
+msgctxt "keyboard key"
+msgid "Command"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:186 ../src/common/accelcmn.cpp:359
+msgctxt "keyboard key"
+msgid "Ctrl"
+msgstr "Control"
+
+#: ../src/common/accelcmn.cpp:188 ../src/common/accelcmn.cpp:363
+msgctxt "keyboard key"
+msgid "Alt"
+msgstr "Alt"
+
+#: ../src/common/accelcmn.cpp:190 ../src/common/accelcmn.cpp:361
+msgctxt "keyboard key"
+msgid "Shift"
+msgstr "Shift"
+
+#: ../src/common/accelcmn.cpp:196
+msgctxt "keyboard key"
+msgid "num "
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:260 ../src/common/accelcmn.cpp:382
+msgctxt "keyboard key"
+msgid "F"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:277 ../src/common/accelcmn.cpp:385
+msgctxt "keyboard key"
+msgid "KP_F"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:280 ../src/common/accelcmn.cpp:388
+msgctxt "keyboard key"
+msgid "KP_"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:283 ../src/common/accelcmn.cpp:391
+msgctxt "keyboard key"
+msgid "SPECIAL"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:373
+#, fuzzy
+msgid "Ctrl"
+msgstr "Control"
+
+#: ../src/common/appbase.cpp:786
+msgid "show this help message"
+msgstr "mostra este missatge d'ajuda"
+
+#: ../src/common/appbase.cpp:796
+msgid "generate verbose log messages"
+msgstr "genera missatges de registre detallats"
+
+#: ../src/common/appcmn.cpp:256
+msgid "specify the theme to use"
+msgstr "especifica el tema a utilitzar"
+
+#: ../src/common/appcmn.cpp:270
+msgid "specify display mode to use (e.g. 640x480-16)"
+msgstr "especifiqueu el mode de pantalla a utilitzar (p. ex. 640x480-16)"
+
+#: ../src/common/appcmn.cpp:292
+#, c-format
+msgid "Unsupported theme '%s'."
+msgstr "Tema '%s' no suportat."
+
+#: ../src/common/appcmn.cpp:309
+#, c-format
+msgid "Invalid display mode specification '%s'."
+msgstr "Mode d'especificació de mostreig '%s' invàlid."
+
+#: ../src/common/cmdline.cpp:875
+#, fuzzy, c-format
+msgid "Option '%s' can't be negated"
+msgstr "No s'ha pogut crear el directori '%s'"
+
+#: ../src/common/cmdline.cpp:889
+#, c-format
+msgid "Unknown long option '%s'"
+msgstr "Opció llarga desconeguda '%s'"
+
+#: ../src/common/cmdline.cpp:904 ../src/common/cmdline.cpp:926
+#, c-format
+msgid "Unknown option '%s'"
+msgstr "Opció '%s' desconeguda"
+
+#: ../src/common/cmdline.cpp:1004
+#, fuzzy, c-format
+msgid "Unexpected characters following option '%s'."
+msgstr "Paràmetre '%s' no esperat"
+
+#: ../src/common/cmdline.cpp:1039
+#, c-format
+msgid "Option '%s' requires a value."
+msgstr "L'opció '%s' requerix un valor."
+
+#: ../src/common/cmdline.cpp:1058
+#, c-format
+msgid "Separator expected after the option '%s'."
+msgstr "S'espera un separador després de l'opció '%s'."
+
+#: ../src/common/cmdline.cpp:1088 ../src/common/cmdline.cpp:1106
+#, c-format
+msgid "'%s' is not a correct numeric value for option '%s'."
+msgstr "'%s' no és valor numèric correcte per l'opció '%s'."
+
+#: ../src/common/cmdline.cpp:1122
+#, c-format
+msgid "Option '%s': '%s' cannot be converted to a date."
+msgstr "Opció '%s': '%s' no es pot convertir a data."
+
+#: ../src/common/cmdline.cpp:1170
+#, c-format
+msgid "Unexpected parameter '%s'"
+msgstr "Paràmetre '%s' no esperat"
+
+#. TRANSLATORS: Short name and long name for a command line option
+#: ../src/common/cmdline.cpp:1197
+#, c-format
+msgid "%s (or %s)"
+msgstr "%s (o %s)"
+
+#: ../src/common/cmdline.cpp:1208
+#, c-format
+msgid "The value for the option '%s' must be specified."
+msgstr "El valor per l'opció '%s' ha d'estar especificat."
+
+#: ../src/common/cmdline.cpp:1230
+#, c-format
+msgid "The required parameter '%s' was not specified."
+msgstr "El paràmetre requerit '%s' no ha estat especificat."
+
+#: ../src/common/cmdline.cpp:1289
+#, c-format
+msgid "Usage: %s"
+msgstr "Sintaxi: %s"
+
+#: ../src/common/cmdline.cpp:1498
+msgid "str"
+msgstr "str"
+
+#: ../src/common/cmdline.cpp:1502
+msgid "num"
+msgstr "núm."
+
+#: ../src/common/cmdline.cpp:1506
+msgid "double"
+msgstr ""
+
+#: ../src/common/cmdline.cpp:1510
+msgid "date"
+msgstr "data"
+
+#: ../src/common/cmdproc.cpp:250 ../src/common/cmdproc.cpp:276
+#: ../src/common/cmdproc.cpp:296
+msgid "Unnamed command"
+msgstr "Orde sense nom"
+
+#: ../src/common/cmdproc.cpp:253
+msgid "&Undo "
+msgstr "&Desfés"
+
+#: ../src/common/cmdproc.cpp:255
+msgid "Can't &Undo "
+msgstr "No s'ha pogut &desfer"
+
+#: ../src/common/cmdproc.cpp:259 ../src/common/stockitem.cpp:208
+#: ../src/msw/textctrl.cpp:2880 ../src/osx/textctrl_osx.cpp:649
+#: ../src/richtext/richtextctrl.cpp:327
+msgid "&Undo"
+msgstr "&Desfés"
+
+#: ../src/common/cmdproc.cpp:277 ../src/common/cmdproc.cpp:297
+msgid "&Redo "
+msgstr "&Refés"
+
+#: ../src/common/cmdproc.cpp:281 ../src/common/cmdproc.cpp:288
+#: ../src/common/stockitem.cpp:190 ../src/msw/textctrl.cpp:2881
+#: ../src/osx/textctrl_osx.cpp:650 ../src/richtext/richtextctrl.cpp:328
+msgid "&Redo"
+msgstr "&Refés"
+
+#: ../src/common/colourcmn.cpp:41
+#, fuzzy, c-format
+msgid "String To Colour : Incorrect colour specification : %s"
+msgstr ""
+"recurs XRC: Color d'especificació incorrecte '%s'  per a la propietat '%s'."
+
+#: ../src/common/config.cpp:259
+#, c-format
+msgid "Invalid value %ld for a boolean key \"%s\" in config file."
+msgstr ""
+
+#: ../src/common/config.cpp:526
+#, fuzzy, c-format
+msgid ""
+"Environment variables expansion failed: missing '%c' at position %u in '%s'."
+msgstr ""
+"Ha fallat l'expansió de las variables d'entorn: falta '%c' en la posició %d "
+"a '%s'."
+
+#: ../src/common/config.cpp:576 ../src/msw/regconf.cpp:272
+#, c-format
+msgid "'%s' has extra '..', ignored."
+msgstr "'%s' té '..' extres que han estat ignorats."
+
+#. TRANSLATORS: Checkbox state name
+#: ../src/common/datavcmn.cpp:2166 ../src/generic/datavgen.cpp:1430
+msgid "checked"
+msgstr ""
+
+#. TRANSLATORS: Checkbox state name
+#: ../src/common/datavcmn.cpp:2170 ../src/generic/datavgen.cpp:1432
+msgid "unchecked"
+msgstr ""
+
+#. TRANSLATORS: Checkbox state name
+#: ../src/common/datavcmn.cpp:2174
+#, fuzzy
+msgid "undetermined"
+msgstr "subratllat"
+
+#: ../src/common/datetimefmt.cpp:1875
+msgid "today"
+msgstr "avui"
+
+#: ../src/common/datetimefmt.cpp:1876
+msgid "yesterday"
+msgstr "ahir"
+
+#: ../src/common/datetimefmt.cpp:1877
+msgid "tomorrow"
+msgstr "demà"
+
+#: ../src/common/datetimefmt.cpp:2071
+msgid "first"
+msgstr "primer"
+
+#: ../src/common/datetimefmt.cpp:2072
+msgid "second"
+msgstr "segon"
+
+#: ../src/common/datetimefmt.cpp:2073
+msgid "third"
+msgstr "tercer"
+
+#: ../src/common/datetimefmt.cpp:2074
+msgid "fourth"
+msgstr "quart"
+
+#: ../src/common/datetimefmt.cpp:2075
+msgid "fifth"
+msgstr "cinquè"
+
+#: ../src/common/datetimefmt.cpp:2076
+msgid "sixth"
+msgstr "sisè"
+
+#: ../src/common/datetimefmt.cpp:2077
+msgid "seventh"
+msgstr "setè"
+
+#: ../src/common/datetimefmt.cpp:2078
+msgid "eighth"
+msgstr "vuitè"
+
+#: ../src/common/datetimefmt.cpp:2079
+msgid "ninth"
+msgstr "novè"
+
+#: ../src/common/datetimefmt.cpp:2080
+msgid "tenth"
+msgstr "desè"
+
+#: ../src/common/datetimefmt.cpp:2081
+msgid "eleventh"
+msgstr "onzè"
+
+#: ../src/common/datetimefmt.cpp:2082
+msgid "twelfth"
+msgstr "dotzè"
+
+#: ../src/common/datetimefmt.cpp:2083
+msgid "thirteenth"
+msgstr "tretzè"
+
+#: ../src/common/datetimefmt.cpp:2084
+msgid "fourteenth"
+msgstr "catorzé"
+
+#: ../src/common/datetimefmt.cpp:2085
+msgid "fifteenth"
+msgstr "quinzè"
+
+#: ../src/common/datetimefmt.cpp:2086
+msgid "sixteenth"
+msgstr "setzè"
+
+#: ../src/common/datetimefmt.cpp:2087
+msgid "seventeenth"
+msgstr "dissetè"
+
+#: ../src/common/datetimefmt.cpp:2088
+msgid "eighteenth"
+msgstr "divuitè"
+
+#: ../src/common/datetimefmt.cpp:2089
+msgid "nineteenth"
+msgstr "dinovè"
+
+#: ../src/common/datetimefmt.cpp:2090
+msgid "twentieth"
+msgstr "vintè"
+
+#: ../src/common/datetimefmt.cpp:2248
+msgid "noon"
+msgstr "migdia"
+
+#: ../src/common/datetimefmt.cpp:2249
+msgid "midnight"
+msgstr "mitja nit"
+
+#: ../src/common/debugrpt.cpp:209
+#, fuzzy, c-format
+msgid "Failed to create directory \"%s\""
+msgstr "No s'ha pogut crear un directori %s/.gnome."
+
+#: ../src/common/debugrpt.cpp:210
+#, fuzzy
+msgid "Debug report couldn't be created."
+msgstr "No s'ha pogut crear el directori '%s'"
+
+#: ../src/common/debugrpt.cpp:227
+#, fuzzy, c-format
+msgid "Failed to remove debug report file \"%s\""
+msgstr "És impossible d'eliminar el fitxer de blocatge '%s'"
+
+#: ../src/common/debugrpt.cpp:239
+#, fuzzy, c-format
+msgid "Failed to clean up debug report directory \"%s\""
+msgstr "No s'ha pogut crear un directori %s/.gnome."
+
+#: ../src/common/debugrpt.cpp:514
+msgid "process context description"
+msgstr ""
+
+#: ../src/common/debugrpt.cpp:538
+msgid "dump of the process state (binary)"
+msgstr ""
+
+#: ../src/common/debugrpt.cpp:553
+msgid "Debug report generation has failed."
+msgstr ""
+
+#: ../src/common/debugrpt.cpp:560
+#, c-format
+msgid ""
+"Processing debug report has failed, leaving the files in \"%s\" directory."
+msgstr ""
+
+#: ../src/common/debugrpt.cpp:573
+msgid "A debug report has been generated. It can be found in"
+msgstr ""
+
+#: ../src/common/debugrpt.cpp:576
+msgid "And includes the following files:\n"
+msgstr ""
+
+#: ../src/common/debugrpt.cpp:586
+msgid ""
+"\n"
+"Please send this report to the program maintainer, thank you!\n"
+msgstr ""
+
+#: ../src/common/debugrpt.cpp:729
+msgid "Failed to execute curl, please install it in PATH."
+msgstr ""
+
+#: ../src/common/debugrpt.cpp:742
+#, fuzzy, c-format
+msgid "Failed to upload the debug report (error code %d)."
+msgstr ""
+"No s'ha pogut crear el diàleg estàndard de cerca/substituix (codi d'error %d)"
+
+#: ../src/common/docview.cpp:366
+msgid "Save As"
+msgstr "Anomena i Alça"
+
+#: ../src/common/docview.cpp:457
+msgid "Discard changes and reload the last saved version?"
+msgstr ""
+
+#: ../src/common/docview.cpp:488
+msgid "unnamed"
+msgstr "sense nom"
+
+#: ../src/common/docview.cpp:513
+#, fuzzy, c-format
+msgid "Do you want to save changes to %s?"
+msgstr "Voleu alçar els canvis del document"
+
+#: ../src/common/docview.cpp:521 ../src/common/docview.cpp:560
+#: ../src/common/stockitem.cpp:195
+#, fuzzy
+msgid "&Save"
+msgstr "&Desa..."
+
+#: ../src/common/docview.cpp:522 ../src/common/docview.cpp:560
+msgid "&Discard changes"
+msgstr ""
+
+#: ../src/common/docview.cpp:523
+msgid "Do&n't close"
+msgstr ""
+
+#: ../src/common/docview.cpp:553
+#, fuzzy, c-format
+msgid "Do you want to save changes to %s before closing it?"
+msgstr "Voleu alçar els canvis del document"
+
+#: ../src/common/docview.cpp:559
+#, fuzzy
+msgid "The document must be closed."
+msgstr "No s'ha pogut alçar el text."
+
+#: ../src/common/docview.cpp:571
+#, c-format
+msgid "Saving %s failed, would you like to retry?"
+msgstr ""
+
+#: ../src/common/docview.cpp:577
+msgid "Retry"
+msgstr ""
+
+#: ../src/common/docview.cpp:577
+msgid "Discard changes"
+msgstr ""
+
+#: ../src/common/docview.cpp:679
+#, fuzzy, c-format
+msgid "File \"%s\" could not be opened for writing."
+msgstr "No s'ha pogut obrir '%s' per %s"
+
+#: ../src/common/docview.cpp:685
+#, fuzzy, c-format
+msgid "Failed to save document to the file \"%s\"."
+msgstr "No s'ha pogut carregar la imatge %d des del fitxer '%s'."
+
+#: ../src/common/docview.cpp:702
+#, fuzzy, c-format
+msgid "File \"%s\" could not be opened for reading."
+msgstr "No s'ha pogut obrir '%s' per %s"
+
+#: ../src/common/docview.cpp:714
+#, fuzzy, c-format
+msgid "Failed to read document from the file \"%s\"."
+msgstr "No s'ha pogut carregar la imatge %d des del fitxer '%s'."
+
+#: ../src/common/docview.cpp:1236
+#, c-format
+msgid ""
+"The file '%s' doesn't exist and couldn't be opened.\n"
+"It has been removed from the most recently used files list."
+msgstr ""
+"El fitxer '%s' no existix i per tant no pot ser obert.\n"
+"Ha estat extret des de llistat de fitxers utilitzats més recentment."
+
+#: ../src/common/docview.cpp:1296
+#, fuzzy
+msgid "Print preview creation failed."
+msgstr "No s'ha pogut crear la canonada."
+
+#: ../src/common/docview.cpp:1302
+msgid "Print Preview"
+msgstr "Imprimix previsualització"
+
+#: ../src/common/docview.cpp:1517
+#, fuzzy, c-format
+msgid "The format of file '%s' couldn't be determined."
+msgstr "No s'ha pogut crear el directori '%s'"
+
+#: ../src/common/docview.cpp:1643
+#, c-format
+msgid "unnamed%d"
+msgstr "%d sense nom"
+
+#: ../src/common/docview.cpp:1660
+msgid " - "
+msgstr " - "
+
+#: ../src/common/docview.cpp:1791 ../src/common/docview.cpp:1844
+msgid "Open File"
+msgstr "Selecciona un Fitxer"
+
+#: ../src/common/docview.cpp:1807
+msgid "File error"
+msgstr "Error de fitxer"
+
+#: ../src/common/docview.cpp:1809
+msgid "Sorry, could not open this file."
+msgstr "No s'ha pogut obrir este fitxer."
+
+#: ../src/common/docview.cpp:1843
+#, fuzzy
+msgid "Sorry, the format for this file is unknown."
+msgstr "No s'ha pogut obrir este fitxer."
+
+#: ../src/common/docview.cpp:1924
+msgid "Select a document template"
+msgstr "Seleccioneu una plantilla de document"
+
+#: ../src/common/docview.cpp:1925
+msgid "Templates"
+msgstr "Plantilles"
+
+#: ../src/common/docview.cpp:1998
+msgid "Select a document view"
+msgstr "Seleccioneu una vista del document"
+
+#: ../src/common/docview.cpp:1999
+msgid "Views"
+msgstr "Vistes"
+
+#: ../src/common/dynlib.cpp:81
+#, c-format
+msgid "Failed to load shared library '%s'"
+msgstr "No s'ha pogut carregar la llibreria compartida '%s'"
+
+#: ../src/common/dynlib.cpp:105
+#, c-format
+msgid "Couldn't find symbol '%s' in a dynamic library"
+msgstr "No s'ha pogut trobar el símbol '%s' en una llibreria dinàmica"
+
+#: ../src/common/ffile.cpp:56 ../src/common/file.cpp:215
+#, c-format
+msgid "can't open file '%s'"
+msgstr "no s'ha pogut obrir el fitxer '%s'"
+
+#: ../src/common/ffile.cpp:72
+#, c-format
+msgid "can't close file '%s'"
+msgstr "no s'ha pogut tancar el fitxer '%s'"
+
+#: ../src/common/ffile.cpp:106 ../src/common/ffile.cpp:131
+#, c-format
+msgid "Read error on file '%s'"
+msgstr "Llig error en el fitxer '%s'"
+
+#: ../src/common/ffile.cpp:148
+#, c-format
+msgid "Write error on file '%s'"
+msgstr "Error en el fitxer '%s'"
+
+#: ../src/common/ffile.cpp:182
+#, c-format
+msgid "failed to flush the file '%s'"
+msgstr "no s'ha pogut buidar la memòria del fitxer '%s'"
+
+#: ../src/common/ffile.cpp:222
+#, c-format
+msgid "Seek error on file '%s' (large files not supported by stdio)"
+msgstr ""
+
+#: ../src/common/ffile.cpp:232
+#, c-format
+msgid "Seek error on file '%s'"
+msgstr "Error de recerca en fitxer '%s'"
+
+#: ../src/common/ffile.cpp:248
+#, c-format
+msgid "Can't find current position in file '%s'"
+msgstr "No es pot trobar la posició actual en el fitxer '%s'"
+
+#: ../src/common/ffile.cpp:349 ../src/common/file.cpp:569
+msgid "Failed to set temporary file permissions"
+msgstr "No s'ha pogut fixar els permisos de fitxer temporals."
+
+#: ../src/common/ffile.cpp:371
+#, c-format
+msgid "can't remove file '%s'"
+msgstr "no s'ha pogut extreure el fitxer '%s'"
+
+#: ../src/common/ffile.cpp:376 ../src/common/file.cpp:591
+#, c-format
+msgid "can't commit changes to file '%s'"
+msgstr "no es pot confiar canvis al fitxer '%s'"
+
+#: ../src/common/ffile.cpp:388 ../src/common/file.cpp:603
+#, c-format
+msgid "can't remove temporary file '%s'"
+msgstr "no es pot extreure el fitxer temporal '%s'"
+
+#: ../src/common/file.cpp:162
+#, c-format
+msgid "can't create file '%s'"
+msgstr "no s'ha pot crear el fitxer '%s'"
+
+#: ../src/common/file.cpp:229
+#, c-format
+msgid "can't close file descriptor %d"
+msgstr "no s'ha pogut tancar el descriptor de fitxer %d"
+
+#: ../src/common/file.cpp:332
+#, fuzzy, c-format
+msgid "can't read from file descriptor %d"
+msgstr "no es pot llegir des del fitxer descriptor %s"
+
+#: ../src/common/file.cpp:351
+#, c-format
+msgid "can't write to file descriptor %d"
+msgstr "no es pot escriure en el fitxer descriptiu %d"
+
+#: ../src/common/file.cpp:390
+#, c-format
+msgid "can't flush file descriptor %d"
+msgstr "no es pot buidar el descriptor del fitxer %d"
+
+#: ../src/common/file.cpp:432
+#, c-format
+msgid "can't seek on file descriptor %d"
+msgstr "no és pot cercar el fitxer descriptor de %d"
+
+#: ../src/common/file.cpp:446
+#, c-format
+msgid "can't get seek position on file descriptor %d"
+msgstr "no es pot cercar en el descriptor del fitxer %d"
+
+#: ../src/common/file.cpp:475
+#, c-format
+msgid "can't find length of file on file descriptor %d"
+msgstr ""
+"no es pot trobar la llargària del fitxer en el descriptor del fitxer %d"
+
+#: ../src/common/file.cpp:505
+#, c-format
+msgid "can't determine if the end of file is reached on descriptor %d"
+msgstr ""
+"no es pot determinar si s'ha arribat al final del fitxer amb el descriptor %d"
+
+#: ../src/common/fileconf.cpp:352
+#, c-format
+msgid ""
+" and additionally, the existing configuration file was renamed to \"%s\" and "
+"couldn't be renamed back, please rename it to its original path \"%s\""
+msgstr ""
+
+#: ../src/common/fileconf.cpp:389
+msgid " due to the following error:\n"
+msgstr ""
+
+#: ../src/common/fileconf.cpp:412
+#, fuzzy
+msgid "failed to rename the existing file"
+msgstr "No s'ha pogut carregar la imatge %d des del fitxer '%s'."
+
+#: ../src/common/fileconf.cpp:421
+#, fuzzy
+msgid "failed to create the new file directory"
+msgstr "No s'ha pogut obtenir el directori en funcionament"
+
+#: ../src/common/fileconf.cpp:428
+#, fuzzy
+msgid "failed to move the file to the new location"
+msgstr "No s'ha pogut acabar la connexió de marcatge directe: %s"
+
+#: ../src/common/fileconf.cpp:462
+#, c-format
+msgid "can't open global configuration file '%s'."
+msgstr "no es pot obrir el fitxer de configuració global '%s'."
+
+#: ../src/common/fileconf.cpp:478
+#, c-format
+msgid "can't open user configuration file '%s'."
+msgstr "no es pot obrir el fitxer de configuració d'usuari '%s'."
+
+#: ../src/common/fileconf.cpp:483
+#, c-format
+msgid "Changes won't be saved to avoid overwriting the existing file \"%s\""
+msgstr ""
+
+#: ../src/common/fileconf.cpp:583
+#, fuzzy
+msgid "Error reading config options."
+msgstr "Error en llegir imatge DIB"
+
+#: ../src/common/fileconf.cpp:593
+#, fuzzy
+msgid "Failed to read config options."
+msgstr "Error en llegir imatge DIB"
+
+#: ../src/common/fileconf.cpp:700
+#, fuzzy, c-format
+msgid "file '%s': unexpected character %c at line %zu."
+msgstr "fiitxer '%s': caràcter inesperat %c a la línia %d."
+
+#: ../src/common/fileconf.cpp:736
+#, fuzzy, c-format
+msgid "file '%s', line %zu: '%s' ignored after group header."
+msgstr "fitxer '%s', línia %d: '%s' ignorada després de la capçalera de grup."
+
+#: ../src/common/fileconf.cpp:765
+#, fuzzy, c-format
+msgid "file '%s', line %zu: '=' expected."
+msgstr "fitxer '%s', línia %d: '=' inesperat."
+
+#: ../src/common/fileconf.cpp:778
+#, fuzzy, c-format
+msgid "file '%s', line %zu: value for immutable key '%s' ignored."
+msgstr "fitxer '%s', línia %d: valor per a clau immutable '%s' ignorat."
+
+#: ../src/common/fileconf.cpp:788
+#, fuzzy, c-format
+msgid "file '%s', line %zu: key '%s' was first found at line %d."
+msgstr ""
+"fitxer '%s', línia %d: clau '%s' ha estat trobat per primer cop a la línia "
+"%d."
+
+#: ../src/common/fileconf.cpp:1091
+#, c-format
+msgid "Config entry name cannot start with '%c'."
+msgstr "No es pot iniciar un nom d'entrada de configuració per '%c'."
+
+#: ../src/common/fileconf.cpp:1146
+#, fuzzy
+msgid "Failed to create configuration file directory."
+msgstr "no es pot obrir el fitxer de configuració de l'usuari."
+
+#: ../src/common/fileconf.cpp:1158
+msgid "can't open user configuration file."
+msgstr "no es pot obrir el fitxer de configuració de l'usuari."
+
+#: ../src/common/fileconf.cpp:1172
+msgid "can't write user configuration file."
+msgstr "no es pot escriure el fitxer de configuració de l'usuari"
+
+#: ../src/common/fileconf.cpp:1178
+#, fuzzy
+msgid "Failed to update user configuration file."
+msgstr "no es pot obrir el fitxer de configuració de l'usuari."
+
+#: ../src/common/fileconf.cpp:1201
+#, fuzzy
+msgid "Error saving user configuration data."
+msgstr "Error en llegir imatge DIB"
+
+#: ../src/common/fileconf.cpp:1313
+#, c-format
+msgid "can't delete user configuration file '%s'"
+msgstr "no s'ha pogut eliminar el fitxer de configuració '%s' d'usuari"
+
+#: ../src/common/fileconf.cpp:2007
+#, c-format
+msgid "entry '%s' appears more than once in group '%s'"
+msgstr "l'entrada '%s' apareix més d'un cop en el grup '%s'"
+
+#: ../src/common/fileconf.cpp:2021
+#, c-format
+msgid "attempt to change immutable key '%s' ignored."
+msgstr "intent de canviar la clau immutable '%s' ignorat."
+
+#: ../src/common/fileconf.cpp:2118
+#, c-format
+msgid "trailing backslash ignored in '%s'"
+msgstr ""
+
+#: ../src/common/fileconf.cpp:2153
+#, c-format
+msgid "unexpected \" at position %d in '%s'."
+msgstr "no esperat \" a la posició %d de '%s'."
+
+#: ../src/common/filefn.cpp:474
+#, c-format
+msgid "Failed to copy the file '%s' to '%s'"
+msgstr "Impossible de copiar el fitxer '%s' a '%s'"
+
+#: ../src/common/filefn.cpp:487
+#, c-format
+msgid "Impossible to get permissions for file '%s'"
+msgstr "No és possible obtenir permisos per al fitxer '%s'"
+
+#: ../src/common/filefn.cpp:501
+#, c-format
+msgid "Impossible to overwrite the file '%s'"
+msgstr "És impossible sobrescriure el fitxer '%s'"
+
+#: ../src/common/filefn.cpp:508
+#, fuzzy, c-format
+msgid "Error copying the file '%s' to '%s'."
+msgstr "Impossible de copiar el fitxer '%s' a '%s'"
+
+#: ../src/common/filefn.cpp:556
+#, c-format
+msgid "Impossible to set permissions for the file '%s'"
+msgstr "És impossible fixar els permisos per al fitxer '%s'"
+
+#: ../src/common/filefn.cpp:606
+#, c-format
+msgid ""
+"Failed to rename the file '%s' to '%s' because the destination file already "
+"exists."
+msgstr ""
+
+#: ../src/common/filefn.cpp:623
+#, fuzzy, c-format
+msgid "File '%s' couldn't be renamed '%s'"
+msgstr "No s'ha pogut crear el directori '%s'"
+
+#: ../src/common/filefn.cpp:639
+#, fuzzy, c-format
+msgid "File '%s' couldn't be removed"
+msgstr "No s'ha pogut crear el directori '%s'"
+
+#: ../src/common/filefn.cpp:666
+#, c-format
+msgid "Directory '%s' couldn't be created"
+msgstr "No s'ha pogut crear el directori '%s'"
+
+#: ../src/common/filefn.cpp:680
+#, fuzzy, c-format
+msgid "Directory '%s' couldn't be deleted"
+msgstr "No s'ha pogut crear el directori '%s'"
+
+#: ../src/common/filefn.cpp:714
+#, c-format
+msgid "Cannot enumerate files '%s'"
+msgstr "No es pot enumerar els fitxers '%s'"
+
+#: ../src/common/filefn.cpp:798
+msgid "Failed to get the working directory"
+msgstr "No s'ha pogut obtenir el directori en funcionament"
+
+#: ../src/common/filefn.cpp:843
+#, fuzzy
+msgid "Could not set current working directory"
+msgstr "No s'ha pogut obtenir el directori en funcionament"
+
+#: ../src/common/filefn.cpp:974
+#, fuzzy, c-format
+msgid "Files (%s)"
+msgstr "Fitxers (%s)|%s"
+
+#: ../src/common/filename.cpp:182
+#, fuzzy, c-format
+msgid "Failed to open '%s' for reading"
+msgstr "No s'ha pogut obrir '%s' per %s"
+
+#: ../src/common/filename.cpp:187
+#, fuzzy, c-format
+msgid "Failed to open '%s' for writing"
+msgstr "No s'ha pogut obrir '%s' per %s"
+
+#: ../src/common/filename.cpp:199
+msgid "Failed to close file handle"
+msgstr "No s'ha pogut tancar el manegador de fitxers"
+
+#: ../src/common/filename.cpp:1046
+msgid "Failed to create a temporary file name"
+msgstr "No s'ha pogut crear un nom d'arxiu temporal"
+
+#: ../src/common/filename.cpp:1081
+msgid "Failed to open temporary file."
+msgstr "No s'ha pogut obrir un fitxer temporal"
+
+#: ../src/common/filename.cpp:2862
+#, c-format
+msgid "Failed to modify file times for '%s'"
+msgstr "No s'ha pogut modificar les hores de fitxer de '%s'"
+
+#: ../src/common/filename.cpp:2877
+#, c-format
+msgid "Failed to touch the file '%s'"
+msgstr "No s'ha pogut posar en contacte amb el fitxer '%s'"
+
+#: ../src/common/filename.cpp:2958
+#, c-format
+msgid "Failed to retrieve file times for '%s'"
+msgstr "No s'ha pogut recuperar les hores de fitxer de '%s'"
+
+#: ../src/common/filepickercmn.cpp:39 ../src/common/filepickercmn.cpp:40
+msgid "Browse"
+msgstr ""
+
+#: ../src/common/fldlgcmn.cpp:792 ../src/generic/filectrlg.cpp:1185
+#, fuzzy, c-format
+msgid "All files (%s)|%s"
+msgstr "Tots els fitxers (*)|*"
+
+#. TRANSLATORS: %s are a file extension used to build a file wildcard string
+#: ../src/common/fldlgcmn.cpp:810
+#, fuzzy, c-format
+msgid "%s files (%s)|%s"
+msgstr "Fitxers (%s)|%s"
+
+#: ../src/common/fldlgcmn.cpp:1072
+#, c-format
+msgid "Load %s file"
+msgstr "Carrega fitxer %s"
+
+#: ../src/common/fldlgcmn.cpp:1074
+#, c-format
+msgid "Save %s file"
+msgstr "Alça fitxer %s"
+
+#: ../src/common/fmapbase.cpp:144
+msgid "Western European (ISO-8859-1)"
+msgstr "Europa de l'est, (ISO-8859-1)"
+
+#: ../src/common/fmapbase.cpp:145
+msgid "Central European (ISO-8859-2)"
+msgstr "Europeu central (ISO-8859-2)"
+
+#: ../src/common/fmapbase.cpp:146
+msgid "Esperanto (ISO-8859-3)"
+msgstr "Esperanto (ISO-8859-3)"
+
+#: ../src/common/fmapbase.cpp:147
+msgid "Baltic (old) (ISO-8859-4)"
+msgstr "Bàltic (antic) (ISO-8859-4)"
+
+#: ../src/common/fmapbase.cpp:148
+msgid "Cyrillic (ISO-8859-5)"
+msgstr "Ciríl·lic (ISO-8859-5)"
+
+#: ../src/common/fmapbase.cpp:149
+msgid "Arabic (ISO-8859-6)"
+msgstr "Àrab (ISO-8859-6)"
+
+#: ../src/common/fmapbase.cpp:150
+msgid "Greek (ISO-8859-7)"
+msgstr "Grec (ISO-8859-7)"
+
+#: ../src/common/fmapbase.cpp:151
+msgid "Hebrew (ISO-8859-8)"
+msgstr "Hebreu (ISO-8859-8)"
+
+#: ../src/common/fmapbase.cpp:152
+msgid "Turkish (ISO-8859-9)"
+msgstr "Turc (ISO-8859-9)"
+
+#: ../src/common/fmapbase.cpp:153
+msgid "Nordic (ISO-8859-10)"
+msgstr "Nòrdic (ISO-8859-10)"
+
+#: ../src/common/fmapbase.cpp:154
+msgid "Thai (ISO-8859-11)"
+msgstr "Tailandès (ISO-8859-11)"
+
+#: ../src/common/fmapbase.cpp:155
+msgid "Indian (ISO-8859-12)"
+msgstr "Indi (ISO-8859-12)"
+
+#: ../src/common/fmapbase.cpp:156
+msgid "Baltic (ISO-8859-13)"
+msgstr "Bàltic (ISO-8859-13)"
+
+#: ../src/common/fmapbase.cpp:157
+msgid "Celtic (ISO-8859-14)"
+msgstr "Cèltic (ISO-8859-14)"
+
+#: ../src/common/fmapbase.cpp:158
+msgid "Western European with Euro (ISO-8859-15)"
+msgstr "Europeu occidental amb Euro (ISO-8859-15)"
+
+#: ../src/common/fmapbase.cpp:159
+msgid "KOI8-R"
+msgstr "KOI8-R"
+
+#: ../src/common/fmapbase.cpp:160
+#, fuzzy
+msgid "KOI8-U"
+msgstr "KOI8-R"
+
+#: ../src/common/fmapbase.cpp:161
+#, fuzzy
+msgid "Windows/DOS OEM Cyrillic (CP 866)"
+msgstr "Windows Cirílic (CP 1251)"
+
+#: ../src/common/fmapbase.cpp:162
+#, fuzzy
+msgid "Windows Thai (CP 874)"
+msgstr "Windows Bàltic (CP 1257)"
+
+#: ../src/common/fmapbase.cpp:163
+#, fuzzy
+msgid "Windows Japanese (CP 932) or Shift-JIS"
+msgstr "Windows Japonès (CP 932)"
+
+#: ../src/common/fmapbase.cpp:164
+#, fuzzy
+msgid "Windows Chinese Simplified (CP 936) or GB-2312"
+msgstr "Windows Xinés Simplificat (CP 936)"
+
+#: ../src/common/fmapbase.cpp:165
+msgid "Windows Korean (CP 949)"
+msgstr "Windows Coreà (CP 949)"
+
+#: ../src/common/fmapbase.cpp:166
+#, fuzzy
+msgid "Windows Chinese Traditional (CP 950) or Big-5"
+msgstr "Windows Xinés Tradicional (CP 950)"
+
+#: ../src/common/fmapbase.cpp:167
+msgid "Windows Central European (CP 1250)"
+msgstr "Windows Central Europeu (CP 1250)"
+
+#: ../src/common/fmapbase.cpp:168
+msgid "Windows Cyrillic (CP 1251)"
+msgstr "Windows Cirílic (CP 1251)"
+
+#: ../src/common/fmapbase.cpp:169
+msgid "Windows Western European (CP 1252)"
+msgstr "Windows Europeu de l'est (CP 1252)"
+
+#: ../src/common/fmapbase.cpp:170
+msgid "Windows Greek (CP 1253)"
+msgstr "Windows Grec (CP 1253)"
+
+#: ../src/common/fmapbase.cpp:171
+msgid "Windows Turkish (CP 1254)"
+msgstr "Windows Turc (CP 1254)"
+
+#: ../src/common/fmapbase.cpp:172
+msgid "Windows Hebrew (CP 1255)"
+msgstr "Windows Hebreu (CP 1255)"
+
+#: ../src/common/fmapbase.cpp:173
+msgid "Windows Arabic (CP 1256)"
+msgstr "Windows Àrab (CP 1256)"
+
+#: ../src/common/fmapbase.cpp:174
+msgid "Windows Baltic (CP 1257)"
+msgstr "Windows Bàltic (CP 1257)"
+
+#: ../src/common/fmapbase.cpp:175
+#, fuzzy
+msgid "Windows Vietnamese (CP 1258)"
+msgstr "Windows Grec (CP 1253)"
+
+#: ../src/common/fmapbase.cpp:176
+#, fuzzy
+msgid "Windows Johab (CP 1361)"
+msgstr "Windows Àrab (CP 1256)"
+
+#: ../src/common/fmapbase.cpp:177
+msgid "Windows/DOS OEM (CP 437)"
+msgstr "Windows/DOS OEM (CP 437)"
+
+#: ../src/common/fmapbase.cpp:178
+msgid "Unicode 7 bit (UTF-7)"
+msgstr "Unicode 7 bit (UTF-7)"
+
+#: ../src/common/fmapbase.cpp:179
+msgid "Unicode 8 bit (UTF-8)"
+msgstr "Unicode 8 bit (UTF-8)"
+
+#: ../src/common/fmapbase.cpp:181 ../src/common/fmapbase.cpp:187
+#, fuzzy
+msgid "Unicode 16 bit (UTF-16)"
+msgstr "Unicode 7 bit (UTF-7)"
+
+#: ../src/common/fmapbase.cpp:182
+#, fuzzy
+msgid "Unicode 16 bit Little Endian (UTF-16LE)"
+msgstr "Unicode 8 bit (UTF-8)"
+
+#: ../src/common/fmapbase.cpp:183 ../src/common/fmapbase.cpp:189
+#, fuzzy
+msgid "Unicode 32 bit (UTF-32)"
+msgstr "Unicode 7 bit (UTF-7)"
+
+#: ../src/common/fmapbase.cpp:184
+#, fuzzy
+msgid "Unicode 32 bit Little Endian (UTF-32LE)"
+msgstr "Unicode 8 bit (UTF-8)"
+
+#: ../src/common/fmapbase.cpp:186
+#, fuzzy
+msgid "Unicode 16 bit Big Endian (UTF-16BE)"
+msgstr "Unicode 8 bit (UTF-8)"
+
+#: ../src/common/fmapbase.cpp:188
+#, fuzzy
+msgid "Unicode 32 bit Big Endian (UTF-32BE)"
+msgstr "Unicode 8 bit (UTF-8)"
+
+#: ../src/common/fmapbase.cpp:191
+msgid "Extended Unix Codepage for Japanese (EUC-JP)"
+msgstr "Codificació de pàgina estesa per al japonès (EUC-JP)"
+
+#: ../src/common/fmapbase.cpp:192
+#, fuzzy
+msgid "US-ASCII"
+msgstr "ASCII"
+
+#: ../src/common/fmapbase.cpp:193
+msgid "ISO-2022-JP"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:195
+#, fuzzy
+msgid "MacRoman"
+msgstr "Roman"
+
+#: ../src/common/fmapbase.cpp:196
+msgid "MacJapanese"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:197
+msgid "MacChineseTrad"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:198
+msgid "MacKorean"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:199
+msgid "MacArabic"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:200
+msgid "MacHebrew"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:201
+msgid "MacGreek"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:202
+msgid "MacCyrillic"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:203
+msgid "MacDevanagari"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:204
+msgid "MacGurmukhi"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:205
+msgid "MacGujarati"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:206
+msgid "MacOriya"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:207
+msgid "MacBengali"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:208
+msgid "MacTamil"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:209
+msgid "MacTelugu"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:210
+msgid "MacKannada"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:211
+msgid "MacMalayalam"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:212
+#, fuzzy
+msgid "MacSinhalese"
+msgstr "Coincidència exacta"
+
+#: ../src/common/fmapbase.cpp:213
+msgid "MacBurmese"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:214
+msgid "MacKhmer"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:215
+msgid "MacThai"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:216
+msgid "MacLaotian"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:217
+msgid "MacGeorgian"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:218
+msgid "MacArmenian"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:219
+msgid "MacChineseSimp"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:220
+msgid "MacTibetan"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:221
+msgid "MacMongolian"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:222
+msgid "MacEthiopic"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:223
+msgid "MacCentralEurRoman"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:224
+msgid "MacVietnamese"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:225
+msgid "MacExtArabic"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:226
+msgid "MacSymbol"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:227
+msgid "MacDingbats"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:228
+msgid "MacTurkish"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:229
+msgid "MacCroatian"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:230
+msgid "MacIcelandic"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:231
+#, fuzzy
+msgid "MacRomanian"
+msgstr "Roman"
+
+#: ../src/common/fmapbase.cpp:232
+msgid "MacCeltic"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:233
+msgid "MacGaelic"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:234
+msgid "MacKeyboardGlyphs"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:791
+msgid "Default encoding"
+msgstr "Codificació predeterminada"
+
+#: ../src/common/fmapbase.cpp:805
+#, c-format
+msgid "Unknown encoding (%d)"
+msgstr "Codificació (%d) desconeguda"
+
+#: ../src/common/fmapbase.cpp:815 ../src/richtext/richtextstyles.cpp:776
+msgid "default"
+msgstr "predeterminat"
+
+#: ../src/common/fmapbase.cpp:829
+#, c-format
+msgid "unknown-%d"
+msgstr "desconegut-%d"
+
+#: ../src/common/fontcmn.cpp:924 ../src/common/fontcmn.cpp:1130
+msgid "underlined"
+msgstr "subratllat"
+
+#: ../src/common/fontcmn.cpp:929
+msgid " strikethrough"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:942
+msgid " thin"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:946
+#, fuzzy
+msgid " extra light"
+msgstr "clar"
+
+#: ../src/common/fontcmn.cpp:950
+#, fuzzy
+msgid " light"
+msgstr "clar"
+
+#: ../src/common/fontcmn.cpp:954
+msgid " medium"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:958
+#, fuzzy
+msgid " semi bold"
+msgstr "negreta"
+
+#: ../src/common/fontcmn.cpp:962
+#, fuzzy
+msgid " bold"
+msgstr "negreta"
+
+#: ../src/common/fontcmn.cpp:966
+#, fuzzy
+msgid " extra bold"
+msgstr "negreta"
+
+#: ../src/common/fontcmn.cpp:970
+msgid " heavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:974
+msgid " extra heavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:990
+#, fuzzy
+msgid " italic"
+msgstr "cursiva"
+
+#: ../src/common/fontcmn.cpp:1134
+msgid "strikethrough"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1143
+msgid "thin"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1156
+#, fuzzy
+msgid "extralight"
+msgstr "clar"
+
+#: ../src/common/fontcmn.cpp:1161
+msgid "light"
+msgstr "clar"
+
+#: ../src/common/fontcmn.cpp:1169 ../src/richtext/richtextstyles.cpp:775
+#, fuzzy
+msgid "normal"
+msgstr "Normal"
+
+#: ../src/common/fontcmn.cpp:1174
+msgid "medium"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1179 ../src/common/fontcmn.cpp:1199
+#, fuzzy
+msgid "semibold"
+msgstr "negreta"
+
+#: ../src/common/fontcmn.cpp:1184
+msgid "bold"
+msgstr "negreta"
+
+#: ../src/common/fontcmn.cpp:1194
+#, fuzzy
+msgid "extrabold"
+msgstr "negreta"
+
+#: ../src/common/fontcmn.cpp:1204
+msgid "heavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1212
+msgid "extraheavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1217
+msgid "italic"
+msgstr "cursiva"
+
+#: ../src/common/fontmap.cpp:195
+msgid ": unknown charset"
+msgstr ": joc de caràcters desconegut"
+
+#: ../src/common/fontmap.cpp:199
+#, c-format
+msgid ""
+"The charset '%s' is unknown. You may select\n"
+"another charset to replace it with or choose\n"
+"[Cancel] if it cannot be replaced"
+msgstr ""
+"El joc de caràcters '%s' és desconegut. Podeu\n"
+"seleccionar un altre conjunt per substituir-lo o escolliu\n"
+"[Anul·la] si no pot ser substituït."
+
+#: ../src/common/fontmap.cpp:241
+#, c-format
+msgid "Failed to remember the encoding for the charset '%s'."
+msgstr "No es pot recordar la codificació del joc de caràcters '%s'."
+
+#: ../src/common/fontmap.cpp:321
+msgid "can't load any font, aborting"
+msgstr "no s'ha pogut carregar cap font, s'està avortant"
+
+#: ../src/common/fontmap.cpp:409
+msgid ": unknown encoding"
+msgstr ": codificació desconeguda"
+
+#: ../src/common/fontmap.cpp:417
+#, c-format
+msgid ""
+"No font for displaying text in encoding '%s' found,\n"
+"but an alternative encoding '%s' is available.\n"
+"Do you want to use this encoding (otherwise you will have to choose another "
+"one)?"
+msgstr ""
+"No s'ha trobat ha cap tipus de lletra per a mostrar text en codifiació "
+"'%s'.\n"
+"però hi ha la codificació '%s' alternativa.\n"
+"Voleu fer servir esta codificació (sino haureu de triar-ne una altra)?"
+
+#: ../src/common/fontmap.cpp:422
+#, c-format
+msgid ""
+"No font for displaying text in encoding '%s' found.\n"
+"Would you like to select a font to be used for this encoding\n"
+"(otherwise the text in this encoding will not be shown correctly)?"
+msgstr ""
+"No s'ha trobat ha cap tipus de lletra per a mostrar text en codifiació "
+"'%s'.\n"
+"Voleu triar un tipus de lletra per esta codificació\n"
+"(sino el text en esta codificació no es mostrarà correctament)?"
+
+#: ../src/common/fs_mem.cpp:169
+#, c-format
+msgid "Memory VFS already contains file '%s'!"
+msgstr "La memòria VFs encara conté el fitxer '%s'!"
+
+#: ../src/common/fs_mem.cpp:232
+#, c-format
+msgid "Trying to remove file '%s' from memory VFS, but it is not loaded!"
+msgstr ""
+"S'està intentant esborrar el fitxer '%s' de VFS de memòria, però no està "
+"carregat!"
+
+#: ../src/common/fs_mem.cpp:262
+#, c-format
+msgid "Failed to store image '%s' to memory VFS!"
+msgstr "No s'ha pogut emmagatzemar la imatge '%s' a la VFS de memòria!"
+
+#: ../src/common/ftp.cpp:197
+#, fuzzy
+msgid "Timeout while waiting for FTP server to connect, try passive mode."
+msgstr "El servidor FTP no permet l'ús de mode passiu."
+
+#: ../src/common/ftp.cpp:399
+#, c-format
+msgid "Failed to set FTP transfer mode to %s."
+msgstr "No s'ha pogut fixar el mode de transferència FTP a %s."
+
+#: ../src/common/ftp.cpp:400 ../src/richtext/richtextsymboldlg.cpp:432
+msgid "ASCII"
+msgstr "ASCII"
+
+#: ../src/common/ftp.cpp:400
+msgid "binary"
+msgstr "binari"
+
+#: ../src/common/ftp.cpp:608
+#, fuzzy
+msgid "The FTP server doesn't support the PORT command."
+msgstr "El servidor FTP no permet l'ús de mode passiu."
+
+#: ../src/common/ftp.cpp:622
+msgid "The FTP server doesn't support passive mode."
+msgstr "El servidor FTP no permet l'ús de mode passiu."
+
+#: ../src/common/gifdecod.cpp:822
+#, c-format
+msgid "Incorrect GIF frame size (%u, %d) for the frame #%u"
+msgstr ""
+
+#: ../src/common/glcmn.cpp:108
+#, fuzzy
+msgid "Failed to allocate colour for OpenGL"
+msgstr "No s'ha pogut crear una barra d'estat."
+
+#: ../src/common/headerctrlcmn.cpp:57
+msgid "Please select the columns to show and define their order:"
+msgstr ""
+
+#: ../src/common/headerctrlcmn.cpp:58
+#, fuzzy
+msgid "Customize Columns"
+msgstr "Grandària de la font:"
+
+#: ../src/common/headerctrlcmn.cpp:304
+#, fuzzy
+msgid "&Customize..."
+msgstr "Grandària de la font:"
+
+#: ../src/common/hyperlnkcmn.cpp:132
+#, fuzzy, c-format
+msgid "Failed to open URL \"%s\" in the default browser"
+msgstr "No s'ha pogut obrir '%s' per %s"
+
+#: ../src/common/iconbndl.cpp:195
+#, fuzzy, c-format
+msgid "Failed to load image %%d from file '%s'."
+msgstr "No s'ha pogut carregar la imatge %d des del fitxer '%s'."
+
+#: ../src/common/iconbndl.cpp:203
+#, fuzzy, c-format
+msgid "Failed to load image %d from stream."
+msgstr "No s'ha pogut carregar la imatge %d des del fitxer '%s'."
+
+#: ../src/common/iconbndl.cpp:221
+#, fuzzy, c-format
+msgid "Failed to load icons from resource '%s'."
+msgstr "No s'ha pogut carregar la imatge %d des del fitxer '%s'."
+
+#: ../src/common/imagbmp.cpp:97
+msgid "BMP: Couldn't save invalid image."
+msgstr "BMP:No s'ha pogut alçar la imatge invàlida."
+
+#: ../src/common/imagbmp.cpp:137
+msgid "BMP: wxImage doesn't have own wxPalette."
+msgstr "BMP:wxImage no té una wxPallette pròpia."
+
+#: ../src/common/imagbmp.cpp:243
+msgid "BMP: Couldn't write the file (Bitmap) header."
+msgstr "BMP: No s'ha pogut escriure la capçalera del fitxer (Mapa de bits)."
+
+#: ../src/common/imagbmp.cpp:266
+msgid "BMP: Couldn't write the file (BitmapInfo) header."
+msgstr "BMP: No s'ha pogut escriure la capçalera del fitxer (BitmapInfo)."
+
+#: ../src/common/imagbmp.cpp:353
+msgid "BMP: Couldn't write RGB color map."
+msgstr "BMP: No s'ha pogut escriure el mapa de colors RGB."
+
+#: ../src/common/imagbmp.cpp:487
+msgid "BMP: Couldn't write data."
+msgstr "BMP: No s'ha pogut escriure la dada."
+
+#: ../src/common/imagbmp.cpp:561 ../src/common/imagbmp.cpp:642
+msgid "BMP: Couldn't allocate memory."
+msgstr "BMP: No s'ha pogut localitzar la memòria."
+
+#: ../src/common/imagbmp.cpp:1041
+msgid "DIB Header: Image width > 32767 pixels for file."
+msgstr "Capçalera DIB: Imatge amb amplada  > 32767 píxels per fitxer."
+
+#: ../src/common/imagbmp.cpp:1049
+msgid "DIB Header: Image height > 32767 pixels for file."
+msgstr "Capçalera DIB: Imatge amb alçada > 32767 píxels per fitxer."
+
+#: ../src/common/imagbmp.cpp:1081
+msgid "DIB Header: Unknown bitdepth in file."
+msgstr "Capçalera DIB: profunditat de bits desconeguda en el fitxer."
+
+#: ../src/common/imagbmp.cpp:1156
+msgid "DIB Header: Unknown encoding in file."
+msgstr "Capçalera DIB: codificació desconeguda en el fitxer."
+
+#: ../src/common/imagbmp.cpp:1165
+msgid "DIB Header: Encoding doesn't match bitdepth."
+msgstr "Capçalera DIB: la codificació no coincidix amb la profunditat de bits."
+
+#: ../src/common/imagbmp.cpp:1180
+#, c-format
+msgid "BMP Header: Invalid number of colors (%d)."
+msgstr ""
+
+#: ../src/common/imagbmp.cpp:1273
+#, fuzzy
+msgid "Error in reading image DIB."
+msgstr "Error en llegir imatge DIB"
+
+#: ../src/common/imagbmp.cpp:1294
+msgid "ICO: Error in reading mask DIB."
+msgstr "ICO: Error en llegir la màscara DIB."
+
+#: ../src/common/imagbmp.cpp:1353
+msgid "ICO: Image too tall for an icon."
+msgstr "ICO: Imatge massa llarga per a una icona."
+
+#: ../src/common/imagbmp.cpp:1361
+msgid "ICO: Image too wide for an icon."
+msgstr "ICO:Imatge massa ampla per poder ser una icona."
+
+#: ../src/common/imagbmp.cpp:1388 ../src/common/imagbmp.cpp:1488
+#: ../src/common/imagbmp.cpp:1503 ../src/common/imagbmp.cpp:1514
+#: ../src/common/imagbmp.cpp:1528 ../src/common/imagbmp.cpp:1576
+#: ../src/common/imagbmp.cpp:1591 ../src/common/imagbmp.cpp:1605
+#: ../src/common/imagbmp.cpp:1616
+msgid "ICO: Error writing the image file!"
+msgstr "ICO: Error en llegir el fitxer d'imatge!"
+
+#: ../src/common/imagbmp.cpp:1701
+msgid "ICO: Invalid icon index."
+msgstr "ICO: Índex d'icones invàlid"
+
+#: ../src/common/image.cpp:2410
+#, fuzzy
+msgid "Image and mask have different sizes."
+msgstr "La imatge i la màscara tenen diferents grandàries"
+
+#: ../src/common/image.cpp:2418 ../src/common/image.cpp:2459
+#, fuzzy
+msgid "No unused colour in image being masked."
+msgstr "Cap color no utilitzat en la imatge està sent emmascarat"
+
+#: ../src/common/image.cpp:2641
+#, fuzzy, c-format
+msgid "Failed to load bitmap \"%s\" from resources."
+msgstr "No s'ha pogut carregar la imatge %d des del fitxer '%s'."
+
+#: ../src/common/image.cpp:2650
+#, fuzzy, c-format
+msgid "Failed to load icon \"%s\" from resources."
+msgstr "No s'ha pogut carregar la imatge %d des del fitxer '%s'."
+
+#: ../src/common/image.cpp:2728 ../src/common/image.cpp:2747
+#, fuzzy, c-format
+msgid "Failed to load image from file \"%s\"."
+msgstr "No s'ha pogut carregar la imatge %d des del fitxer '%s'."
+
+#: ../src/common/image.cpp:2761
+#, c-format
+msgid "Can't save image to file '%s': unknown extension."
+msgstr "No es pot alçar la imatge en el format '%s': extensió desconeguda."
+
+#: ../src/common/image.cpp:2869
+msgid "No handler found for image type."
+msgstr "No s'ha trobat cap manegador per al tipus d'imatge"
+
+#: ../src/common/image.cpp:2877 ../src/common/image.cpp:3000
+#: ../src/common/image.cpp:3066
+#, c-format
+msgid "No image handler for type %d defined."
+msgstr "No hi ha definit cap manegador per al tipus d'imatge %d."
+
+#: ../src/common/image.cpp:2887
+#, fuzzy, c-format
+msgid "Image file is not of type %d."
+msgstr "El fitxer d'imatge no és del tipus %d."
+
+#: ../src/common/image.cpp:2970
+msgid "Can't automatically determine the image format for non-seekable input."
+msgstr ""
+
+#: ../src/common/image.cpp:2988
+#, fuzzy
+msgid "Unknown image data format."
+msgstr "IFF: error en format d'imatge IFF."
+
+#: ../src/common/image.cpp:3009
+#, fuzzy, c-format
+msgid "This is not a %s."
+msgstr "PCX: este no és un fitxer PCX ."
+
+#: ../src/common/image.cpp:3032 ../src/common/image.cpp:3080
+#, c-format
+msgid "No image handler for type %s defined."
+msgstr "No hi ha definit cap manegador per al tipus d'imatge %s."
+
+#: ../src/common/image.cpp:3041
+#, fuzzy, c-format
+msgid "Image is not of type %s."
+msgstr "El fitxer d'imatge no és del tipus %d."
+
+#: ../src/common/image.cpp:3509
+#, fuzzy, c-format
+msgid "Failed to check format of image file \"%s\"."
+msgstr "No s'ha pogut carregar la imatge %d des del fitxer '%s'."
+
+#: ../src/common/imaggif.cpp:124
+msgid "GIF: error in GIF image format."
+msgstr "GIF: error en el format GIF d'imatge."
+
+#: ../src/common/imaggif.cpp:129
+msgid "GIF: not enough memory."
+msgstr "GIF: No hi ha prou memòria"
+
+#: ../src/common/imaggif.cpp:134
+msgid "GIF: data stream seems to be truncated."
+msgstr "GIF: el flux de dades sembla haver-se trencat."
+
+#: ../src/common/imaggif.cpp:240
+#, fuzzy
+msgid "Couldn't initialize GIF hash table."
+msgstr "No es pot començar a mostrar."
+
+#: ../src/common/imagiff.cpp:739
+msgid "IFF: error in IFF image format."
+msgstr "IFF: error en format d'imatge IFF."
+
+#: ../src/common/imagiff.cpp:742
+msgid "IFF: not enough memory."
+msgstr "IFF: no hi ha prou memòria."
+
+#: ../src/common/imagiff.cpp:745
+msgid "IFF: unknown error!!!"
+msgstr "IFF: error desconegut!!!"
+
+#: ../src/common/imagiff.cpp:755
+msgid "IFF: data stream seems to be truncated."
+msgstr "IFF: el fil de dades sembla estar trencades."
+
+#: ../src/common/imagjpeg.cpp:258
+msgid "JPEG: Couldn't load - file is probably corrupted."
+msgstr "JPEG: No s'ha pogut carregar - el fitxer deu estar corromput."
+
+#: ../src/common/imagjpeg.cpp:437
+msgid "JPEG: Couldn't save image."
+msgstr "JPEG: No s'ha pogut alçar la imatge."
+
+#: ../src/common/imagpcx.cpp:439
+msgid "PCX: this is not a PCX file."
+msgstr "PCX: este no és un fitxer PCX ."
+
+#: ../src/common/imagpcx.cpp:453
+msgid "PCX: image format unsupported"
+msgstr "PCX: format d'imatge no suportat"
+
+#: ../src/common/imagpcx.cpp:454 ../src/common/imagpcx.cpp:477
+msgid "PCX: couldn't allocate memory"
+msgstr "PCX: no es pot localitzar la memòria"
+
+#: ../src/common/imagpcx.cpp:455
+msgid "PCX: version number too low"
+msgstr "PCX: número de versió massa baix"
+
+#: ../src/common/imagpcx.cpp:456 ../src/common/imagpcx.cpp:478
+msgid "PCX: unknown error !!!"
+msgstr "PCX: error desconegut!!!"
+
+#: ../src/common/imagpcx.cpp:476
+msgid "PCX: invalid image"
+msgstr "PCX: imatge invàlida"
+
+#: ../src/common/imagpng.cpp:385
+#, fuzzy, c-format
+msgid "Unknown PNG resolution unit %d"
+msgstr "Opció '%s' desconeguda"
+
+#: ../src/common/imagpng.cpp:439
+msgid "Couldn't load a PNG image - file is corrupted or not enough memory."
+msgstr ""
+"No s'ha pogut carregar una imatge PNG - el fitxer és corromput o no hi ha "
+"prou memòria."
+
+#: ../src/common/imagpng.cpp:513 ../src/common/imagpng.cpp:524
+#: ../src/common/imagpng.cpp:534
+msgid "Couldn't save PNG image."
+msgstr "No s'ha pogut alçar la imatge PNG."
+
+#: ../src/common/imagpnm.cpp:71
+msgid "PNM: File format is not recognized."
+msgstr "PNM: Format de fitxer no reconegut."
+
+#: ../src/common/imagpnm.cpp:89
+msgid "PNM: Couldn't allocate memory."
+msgstr "PNM: No es pot localitzar la memòria."
+
+#: ../src/common/imagpnm.cpp:111 ../src/common/imagpnm.cpp:134
+#: ../src/common/imagpnm.cpp:156
+msgid "PNM: File seems truncated."
+msgstr "PNM: el fitxer sembla estroncat"
+
+#: ../src/common/imagtiff.cpp:69
+#, c-format
+msgid " (in module \"%s\")"
+msgstr ""
+
+#: ../src/common/imagtiff.cpp:304
+msgid "TIFF: Error loading image."
+msgstr "TIFF: Error en carregar la imatge."
+
+#: ../src/common/imagtiff.cpp:314
+msgid "Invalid TIFF image index."
+msgstr "Index d'imatge TIFF invàlid"
+
+#: ../src/common/imagtiff.cpp:358
+msgid "TIFF: Image size is abnormally big."
+msgstr ""
+
+#: ../src/common/imagtiff.cpp:372 ../src/common/imagtiff.cpp:385
+#: ../src/common/imagtiff.cpp:769
+msgid "TIFF: Couldn't allocate memory."
+msgstr "TIFF: No es pot localitzar la memòria"
+
+#: ../src/common/imagtiff.cpp:471
+msgid "TIFF: Error reading image."
+msgstr "TIFF: Error en llegir la imatge."
+
+#: ../src/common/imagtiff.cpp:532
+#, c-format
+msgid "Unknown TIFF resolution unit %d ignored"
+msgstr ""
+
+#: ../src/common/imagtiff.cpp:611
+msgid "TIFF: Error saving image."
+msgstr "TIFF: Error en alçar la imatge."
+
+#: ../src/common/imagtiff.cpp:868
+msgid "TIFF: Error writing image."
+msgstr "TIFF: Error en escriure la imatge."
+
+#: ../src/common/imagtiff.cpp:881
+#, fuzzy
+msgid "TIFF: Error flushing data."
+msgstr "TIFF: Error en alçar la imatge."
+
+#: ../src/common/imagwebp.cpp:56
+msgid "WebP: Invalid data (failed to get features)."
+msgstr ""
+
+#: ../src/common/imagwebp.cpp:65
+msgid "WebP: Allocating image memory failed."
+msgstr ""
+
+#: ../src/common/imagwebp.cpp:82
+msgid "WebP: Decoding RGBA image data failed."
+msgstr ""
+
+#: ../src/common/imagwebp.cpp:98
+msgid "WebP: Decoding RGB image data failed."
+msgstr ""
+
+#: ../src/common/imagwebp.cpp:113 ../src/common/imagwebp.cpp:201
+msgid "WebP: Allocating stream buffer failed."
+msgstr ""
+
+#: ../src/common/imagwebp.cpp:131
+#, fuzzy
+msgid "WebP: Failed to parse container data."
+msgstr "No s'ha pogut fixar les dades del porta-retalls"
+
+#: ../src/common/imagwebp.cpp:222
+#, fuzzy
+msgid "WebP: Error decoding animation."
+msgstr "Error en llegir imatge DIB"
+
+#: ../src/common/imagwebp.cpp:240
+msgid "WebP: Error getting next animation frame."
+msgstr ""
+
+#: ../src/common/init.cpp:172
+#, c-format
+msgid ""
+"Command line argument %d couldn't be converted to Unicode and will be "
+"ignored."
+msgstr ""
+
+#: ../src/common/init.cpp:344
+msgid "Initialization failed in post init, aborting."
+msgstr ""
+
+#: ../src/common/intl.cpp:378
+#, c-format
+msgid "Cannot set locale to language \"%s\"."
+msgstr ""
+
+#: ../src/common/log.cpp:232
+msgid "Error: "
+msgstr "Error: "
+
+#: ../src/common/log.cpp:236
+msgid "Warning: "
+msgstr "Advertència:"
+
+#: ../src/common/log.cpp:284
+msgid "The previous message repeated once."
+msgstr ""
+
+#: ../src/common/log.cpp:291
+#, c-format
+msgid "The previous message repeated %u time."
+msgid_plural "The previous message repeated %u times."
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../src/common/log.cpp:319
+#, c-format
+msgid "Last repeated message (\"%s\", %u time) wasn't output"
+msgid_plural "Last repeated message (\"%s\", %u times) wasn't output"
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../src/common/log.cpp:435
+#, c-format
+msgid " (error %ld: %s)"
+msgstr " (error %ld: %s)"
+
+#: ../src/common/lzmastream.cpp:121
+#, fuzzy
+msgid "Failed to allocate memory for LZMA decompression."
+msgstr "No s'ha pogut crear una barra d'estat."
+
+#: ../src/common/lzmastream.cpp:125
+#, c-format
+msgid "Failed to initialize LZMA decompression: unexpected error %u."
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:179
+msgid "input is not in XZ format"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:183
+msgid "input compressed using unknown XZ option"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:188
+msgid "input is corrupted"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:192
+#, fuzzy
+msgid "unknown decompression error"
+msgstr "error desconegut"
+
+#: ../src/common/lzmastream.cpp:196
+#, c-format
+msgid "LZMA decompression error: %s"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:231
+#, fuzzy
+msgid "Failed to allocate memory for LZMA compression."
+msgstr "No s'ha pogut crear una barra d'estat."
+
+#: ../src/common/lzmastream.cpp:235
+#, c-format
+msgid "Failed to initialize LZMA compression: unexpected error %u."
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:267 ../src/common/lzmastream.cpp:342
+#: ../src/html/chm.cpp:336
+#, fuzzy
+msgid "out of memory"
+msgstr "GIF: No hi ha prou memòria"
+
+#: ../src/common/lzmastream.cpp:276 ../src/common/lzmastream.cpp:346
+#, fuzzy
+msgid "unknown compression error"
+msgstr "error desconegut"
+
+#: ../src/common/lzmastream.cpp:280
+#, c-format
+msgid "LZMA compression error: %s"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:350
+#, c-format
+msgid "LZMA compression error when flushing output: %s"
+msgstr ""
+
+#: ../src/common/mimecmn.cpp:167
+#, c-format
+msgid "Unmatched '{' in an entry for mime type %s."
+msgstr "'{' no tancat per a tipus mime %s."
+
+#: ../src/common/module.cpp:76
+#, c-format
+msgid "Circular dependency involving module \"%s\" detected."
+msgstr ""
+
+#: ../src/common/module.cpp:128
+#, c-format
+msgid "Dependency \"%s\" of module \"%s\" doesn't exist."
+msgstr ""
+
+#: ../src/common/module.cpp:137
+#, c-format
+msgid "Module \"%s\" initialization failed"
+msgstr ""
+
+#: ../src/common/msgout.cpp:96
+#, fuzzy
+msgid "Message"
+msgstr "missatge %s"
+
+#: ../src/common/paper.cpp:70
+msgid "Letter, 8 1/2 x 11 in"
+msgstr "Carta (8 1/2 x 11 polzades)"
+
+#: ../src/common/paper.cpp:71
+msgid "Legal, 8 1/2 x 14 in"
+msgstr "Legal (8 1/2 x 14 polzades)"
+
+#: ../src/common/paper.cpp:72
+msgid "A4 sheet, 210 x 297 mm"
+msgstr "Full A4, 210 x 297 mm"
+
+#: ../src/common/paper.cpp:73
+msgid "C sheet, 17 x 22 in"
+msgstr "Full C, 17 x 22 polz."
+
+#: ../src/common/paper.cpp:74
+msgid "D sheet, 22 x 34 in"
+msgstr "Full D 22 x 34 polzades"
+
+#: ../src/common/paper.cpp:75
+msgid "E sheet, 34 x 44 in"
+msgstr "Full E, 34 x 44 polz."
+
+#: ../src/common/paper.cpp:76
+msgid "Letter Small, 8 1/2 x 11 in"
+msgstr "Carta petita, 8 1/2 x 11 polz"
+
+#: ../src/common/paper.cpp:77
+msgid "Tabloid, 11 x 17 in"
+msgstr "Tabloid, 11 x 17 polz"
+
+#: ../src/common/paper.cpp:78
+msgid "Ledger, 17 x 11 in"
+msgstr "Ledger, 17 x 11 polz."
+
+#: ../src/common/paper.cpp:79
+msgid "Statement, 5 1/2 x 8 1/2 in"
+msgstr "Statement, 5 1/2 x 8 1/2 polz."
+
+#: ../src/common/paper.cpp:80
+msgid "Executive, 7 1/4 x 10 1/2 in"
+msgstr "Executiu (7 1/4 x 10 1/2 polz. )"
+
+#: ../src/common/paper.cpp:81
+msgid "A3 sheet, 297 x 420 mm"
+msgstr "Full A3, 297 x 420 mm"
+
+#: ../src/common/paper.cpp:82
+msgid "A4 small sheet, 210 x 297 mm"
+msgstr "Full petit A4, 210 x 297 mm"
+
+#: ../src/common/paper.cpp:83
+msgid "A5 sheet, 148 x 210 mm"
+msgstr "Full A5, 148 x 210 mm"
+
+#: ../src/common/paper.cpp:84
+msgid "B4 sheet, 250 x 354 mm"
+msgstr "Full B4, 250 x 354 mm"
+
+#: ../src/common/paper.cpp:85
+msgid "B5 sheet, 182 x 257 millimeter"
+msgstr "Full B5, 182 x 257 mil·límetres"
+
+#: ../src/common/paper.cpp:86
+msgid "Folio, 8 1/2 x 13 in"
+msgstr "Foli, 8 1/2 x 13 polzades"
+
+#: ../src/common/paper.cpp:87
+msgid "Quarto, 215 x 275 mm"
+msgstr "Quarto, 215 x 275 mm"
+
+#: ../src/common/paper.cpp:88
+msgid "10 x 14 in"
+msgstr "10 x 14 polz."
+
+#: ../src/common/paper.cpp:89
+msgid "11 x 17 in"
+msgstr "11 x 17 polz."
+
+#: ../src/common/paper.cpp:90
+msgid "Note, 8 1/2 x 11 in"
+msgstr "Nota, 8 1/2 x 11 polzades"
+
+#: ../src/common/paper.cpp:91
+msgid "#9 Envelope, 3 7/8 x 8 7/8 in"
+msgstr "#9 Sobre, 3 7/8 x 8 7/8 polz. "
+
+#: ../src/common/paper.cpp:92
+msgid "#10 Envelope, 4 1/8 x 9 1/2 in"
+msgstr "#10 Sobre, 4 1/8 x 9 1/2 polz. "
+
+#: ../src/common/paper.cpp:93
+msgid "#11 Envelope, 4 1/2 x 10 3/8 in"
+msgstr "#11 Sobre, 4 1/2 x 10 3/8 polz. "
+
+#: ../src/common/paper.cpp:94
+msgid "#12 Envelope, 4 3/4 x 11 in"
+msgstr "#12 Sobre, 4 3/4 x 11 polz."
+
+#: ../src/common/paper.cpp:95
+msgid "#14 Envelope, 5 x 11 1/2 in"
+msgstr "#14 Sobre, 5 x 11 1/2 polz. "
+
+#: ../src/common/paper.cpp:96
+msgid "DL Envelope, 110 x 220 mm"
+msgstr "Sobre DL, 110 x 220 mm"
+
+#: ../src/common/paper.cpp:97
+msgid "C5 Envelope, 162 x 229 mm"
+msgstr "C5 Sobre, 162 x 229 mm"
+
+#: ../src/common/paper.cpp:98
+msgid "C3 Envelope, 324 x 458 mm"
+msgstr "C3 Sobre, 324 x 458 mm"
+
+#: ../src/common/paper.cpp:99
+msgid "C4 Envelope, 229 x 324 mm"
+msgstr "C4 Sobre, 229 x 324 mm"
+
+#: ../src/common/paper.cpp:100
+msgid "C6 Envelope, 114 x 162 mm"
+msgstr "C6 Sobre, 114 x 162 mm"
+
+#: ../src/common/paper.cpp:101
+msgid "C65 Envelope, 114 x 229 mm"
+msgstr "C65 Sobre, 114 x 229 mm"
+
+#: ../src/common/paper.cpp:102
+msgid "B4 Envelope, 250 x 353 mm"
+msgstr "B4 Sobre, 250 x 353 mm"
+
+#: ../src/common/paper.cpp:103
+msgid "B5 Envelope, 176 x 250 mm"
+msgstr "B5 Sobre, 176 x 250 mm"
+
+#: ../src/common/paper.cpp:104
+msgid "B6 Envelope, 176 x 125 mm"
+msgstr "B6 Sobre, 176 x 125 mm"
+
+#: ../src/common/paper.cpp:105
+msgid "Italy Envelope, 110 x 230 mm"
+msgstr "Sobre italià, 110 x 230 mm"
+
+#: ../src/common/paper.cpp:106
+msgid "Monarch Envelope, 3 7/8 x 7 1/2 in"
+msgstr "Sobre reial, 3 7/8 x 7 1/2 polz"
+
+#: ../src/common/paper.cpp:107
+msgid "6 3/4 Envelope, 3 5/8 x 6 1/2 in"
+msgstr "6 3/4 Sobre, 3 5/8 x 6 1/2 polz."
+
+#: ../src/common/paper.cpp:108
+msgid "US Std Fanfold, 14 7/8 x 11 in"
+msgstr "US Std Fanfold, 14 7/8 x 11 polz"
+
+#: ../src/common/paper.cpp:109
+msgid "German Std Fanfold, 8 1/2 x 12 in"
+msgstr "Fanfold alemany estàndard, 8 1/2 x 12 in"
+
+#: ../src/common/paper.cpp:110
+msgid "German Legal Fanfold, 8 1/2 x 13 in"
+msgstr "Fanfold legal alemany, 8 1/2 x 13 polz."
+
+#: ../src/common/paper.cpp:112
+#, fuzzy
+msgid "B4 (ISO) 250 x 353 mm"
+msgstr "Full B4, 250 x 354 mm"
+
+#: ../src/common/paper.cpp:113
+msgid "Japanese Postcard 100 x 148 mm"
+msgstr ""
+
+#: ../src/common/paper.cpp:114
+#, fuzzy
+msgid "9 x 11 in"
+msgstr "11 x 17 polz."
+
+#: ../src/common/paper.cpp:115
+#, fuzzy
+msgid "10 x 11 in"
+msgstr "10 x 14 polz."
+
+#: ../src/common/paper.cpp:116
+#, fuzzy
+msgid "15 x 11 in"
+msgstr "10 x 14 polz."
+
+#: ../src/common/paper.cpp:117
+#, fuzzy
+msgid "Envelope Invite 220 x 220 mm"
+msgstr "Sobre DL, 110 x 220 mm"
+
+#: ../src/common/paper.cpp:118
+#, fuzzy
+msgid "Letter Extra 9 1/2 x 12 in"
+msgstr "Carta (8 1/2 x 11 polzades)"
+
+#: ../src/common/paper.cpp:119
+#, fuzzy
+msgid "Legal Extra 9 1/2 x 15 in"
+msgstr "Legal (8 1/2 x 14 polzades)"
+
+#: ../src/common/paper.cpp:120
+#, fuzzy
+msgid "Tabloid Extra 11.69 x 18 in"
+msgstr "Tabloid, 11 x 17 polz"
+
+#: ../src/common/paper.cpp:121
+msgid "A4 Extra 9.27 x 12.69 in"
+msgstr ""
+
+#: ../src/common/paper.cpp:122
+#, fuzzy
+msgid "Letter Transverse 8 1/2 x 11 in"
+msgstr "Carta (8 1/2 x 11 polzades)"
+
+#: ../src/common/paper.cpp:123
+#, fuzzy
+msgid "A4 Transverse 210 x 297 mm"
+msgstr "Full A4, 210 x 297 mm"
+
+#: ../src/common/paper.cpp:124
+msgid "Letter Extra Transverse 9.275 x 12 in"
+msgstr ""
+
+#: ../src/common/paper.cpp:125
+msgid "SuperA/SuperA/A4 227 x 356 mm"
+msgstr ""
+
+#: ../src/common/paper.cpp:126
+msgid "SuperB/SuperB/A3 305 x 487 mm"
+msgstr ""
+
+#: ../src/common/paper.cpp:127
+#, fuzzy
+msgid "Letter Plus 8 1/2 x 12.69 in"
+msgstr "Carta (8 1/2 x 11 polzades)"
+
+#: ../src/common/paper.cpp:128
+#, fuzzy
+msgid "A4 Plus 210 x 330 mm"
+msgstr "Full A4, 210 x 297 mm"
+
+#: ../src/common/paper.cpp:129
+#, fuzzy
+msgid "A5 Transverse 148 x 210 mm"
+msgstr "Full A5, 148 x 210 mm"
+
+#: ../src/common/paper.cpp:130
+#, fuzzy
+msgid "B5 (JIS) Transverse 182 x 257 mm"
+msgstr "Full B5, 182 x 257 mil·límetres"
+
+#: ../src/common/paper.cpp:131
+#, fuzzy
+msgid "A3 Extra 322 x 445 mm"
+msgstr "C3 Sobre, 324 x 458 mm"
+
+#: ../src/common/paper.cpp:132
+#, fuzzy
+msgid "A5 Extra 174 x 235 mm"
+msgstr "Full A5, 148 x 210 mm"
+
+#: ../src/common/paper.cpp:133
+msgid "B5 (ISO) Extra 201 x 276 mm"
+msgstr ""
+
+#: ../src/common/paper.cpp:134
+msgid "A2 420 x 594 mm"
+msgstr ""
+
+#: ../src/common/paper.cpp:135
+#, fuzzy
+msgid "A3 Transverse 297 x 420 mm"
+msgstr "Full A3, 297 x 420 mm"
+
+#: ../src/common/paper.cpp:136
+#, fuzzy
+msgid "A3 Extra Transverse 322 x 445 mm"
+msgstr "C3 Sobre, 324 x 458 mm"
+
+#: ../src/common/paper.cpp:138
+msgid "Japanese Double Postcard 200 x 148 mm"
+msgstr ""
+
+#: ../src/common/paper.cpp:139
+#, fuzzy
+msgid "A6 105 x 148 mm"
+msgstr "10 x 14 polz."
+
+#: ../src/common/paper.cpp:140
+msgid "Japanese Envelope Kaku #2"
+msgstr ""
+
+#: ../src/common/paper.cpp:141
+msgid "Japanese Envelope Kaku #3"
+msgstr ""
+
+#: ../src/common/paper.cpp:142
+msgid "Japanese Envelope Chou #3"
+msgstr ""
+
+#: ../src/common/paper.cpp:143
+msgid "Japanese Envelope Chou #4"
+msgstr ""
+
+#: ../src/common/paper.cpp:144
+#, fuzzy
+msgid "Letter Rotated 11 x 8 1/2 in"
+msgstr "Carta (8 1/2 x 11 polzades)"
+
+#: ../src/common/paper.cpp:145
+#, fuzzy
+msgid "A3 Rotated 420 x 297 mm"
+msgstr "Full A4, 210 x 297 mm"
+
+#: ../src/common/paper.cpp:146
+#, fuzzy
+msgid "A4 Rotated 297 x 210 mm"
+msgstr "Full A3, 297 x 420 mm"
+
+#: ../src/common/paper.cpp:147
+msgid "A5 Rotated 210 x 148 mm"
+msgstr ""
+
+#: ../src/common/paper.cpp:148
+msgid "B4 (JIS) Rotated 364 x 257 mm"
+msgstr ""
+
+#: ../src/common/paper.cpp:149
+msgid "B5 (JIS) Rotated 257 x 182 mm"
+msgstr ""
+
+#: ../src/common/paper.cpp:150
+msgid "Japanese Postcard Rotated 148 x 100 mm"
+msgstr ""
+
+#: ../src/common/paper.cpp:151
+msgid "Double Japanese Postcard Rotated 148 x 200 mm"
+msgstr ""
+
+#: ../src/common/paper.cpp:152
+#, fuzzy
+msgid "A6 Rotated 148 x 105 mm"
+msgstr "Full A5, 148 x 210 mm"
+
+#: ../src/common/paper.cpp:153
+msgid "Japanese Envelope Kaku #2 Rotated"
+msgstr ""
+
+#: ../src/common/paper.cpp:154
+msgid "Japanese Envelope Kaku #3 Rotated"
+msgstr ""
+
+#: ../src/common/paper.cpp:155
+msgid "Japanese Envelope Chou #3 Rotated"
+msgstr ""
+
+#: ../src/common/paper.cpp:156
+msgid "Japanese Envelope Chou #4 Rotated"
+msgstr ""
+
+#: ../src/common/paper.cpp:157
+msgid "B6 (JIS) 128 x 182 mm"
+msgstr ""
+
+#: ../src/common/paper.cpp:158
+msgid "B6 (JIS) Rotated 182 x 128 mm"
+msgstr ""
+
+#: ../src/common/paper.cpp:159
+#, fuzzy
+msgid "12 x 11 in"
+msgstr "10 x 14 polz."
+
+#: ../src/common/paper.cpp:160
+msgid "Japanese Envelope You #4"
+msgstr ""
+
+#: ../src/common/paper.cpp:161
+msgid "Japanese Envelope You #4 Rotated"
+msgstr ""
+
+#: ../src/common/paper.cpp:162
+msgid "PRC 16K 146 x 215 mm"
+msgstr ""
+
+#: ../src/common/paper.cpp:163
+msgid "PRC 32K 97 x 151 mm"
+msgstr ""
+
+#: ../src/common/paper.cpp:164
+msgid "PRC 32K(Big) 97 x 151 mm"
+msgstr ""
+
+#: ../src/common/paper.cpp:165
+#, fuzzy
+msgid "PRC Envelope #1 102 x 165 mm"
+msgstr "C6 Sobre, 114 x 162 mm"
+
+#: ../src/common/paper.cpp:166
+#, fuzzy
+msgid "PRC Envelope #2 102 x 176 mm"
+msgstr "C6 Sobre, 114 x 162 mm"
+
+#: ../src/common/paper.cpp:167
+#, fuzzy
+msgid "PRC Envelope #3 125 x 176 mm"
+msgstr "C6 Sobre, 114 x 162 mm"
+
+#: ../src/common/paper.cpp:168
+#, fuzzy
+msgid "PRC Envelope #4 110 x 208 mm"
+msgstr "Sobre DL, 110 x 220 mm"
+
+#: ../src/common/paper.cpp:169
+#, fuzzy
+msgid "PRC Envelope #5 110 x 220 mm"
+msgstr "Sobre DL, 110 x 220 mm"
+
+#: ../src/common/paper.cpp:170
+#, fuzzy
+msgid "PRC Envelope #6 120 x 230 mm"
+msgstr "C5 Sobre, 162 x 229 mm"
+
+#: ../src/common/paper.cpp:171
+#, fuzzy
+msgid "PRC Envelope #7 160 x 230 mm"
+msgstr "B5 Sobre, 176 x 250 mm"
+
+#: ../src/common/paper.cpp:172
+#, fuzzy
+msgid "PRC Envelope #8 120 x 309 mm"
+msgstr "C5 Sobre, 162 x 229 mm"
+
+#: ../src/common/paper.cpp:173
+#, fuzzy
+msgid "PRC Envelope #9 229 x 324 mm"
+msgstr "C4 Sobre, 229 x 324 mm"
+
+#: ../src/common/paper.cpp:174
+#, fuzzy
+msgid "PRC Envelope #10 324 x 458 mm"
+msgstr "C3 Sobre, 324 x 458 mm"
+
+#: ../src/common/paper.cpp:175
+msgid "PRC 16K Rotated"
+msgstr ""
+
+#: ../src/common/paper.cpp:176
+msgid "PRC 32K Rotated"
+msgstr ""
+
+#: ../src/common/paper.cpp:177
+msgid "PRC 32K(Big) Rotated"
+msgstr ""
+
+#: ../src/common/paper.cpp:178
+#, fuzzy
+msgid "PRC Envelope #1 Rotated 165 x 102 mm"
+msgstr "C6 Sobre, 114 x 162 mm"
+
+#: ../src/common/paper.cpp:179
+#, fuzzy
+msgid "PRC Envelope #2 Rotated 176 x 102 mm"
+msgstr "B6 Sobre, 176 x 125 mm"
+
+#: ../src/common/paper.cpp:180
+#, fuzzy
+msgid "PRC Envelope #3 Rotated 176 x 125 mm"
+msgstr "B6 Sobre, 176 x 125 mm"
+
+#: ../src/common/paper.cpp:181
+#, fuzzy
+msgid "PRC Envelope #4 Rotated 208 x 110 mm"
+msgstr "C6 Sobre, 114 x 162 mm"
+
+#: ../src/common/paper.cpp:182
+#, fuzzy
+msgid "PRC Envelope #5 Rotated 220 x 110 mm"
+msgstr "C4 Sobre, 229 x 324 mm"
+
+#: ../src/common/paper.cpp:183
+#, fuzzy
+msgid "PRC Envelope #6 Rotated 230 x 120 mm"
+msgstr "C5 Sobre, 162 x 229 mm"
+
+#: ../src/common/paper.cpp:184
+#, fuzzy
+msgid "PRC Envelope #7 Rotated 230 x 160 mm"
+msgstr "C6 Sobre, 114 x 162 mm"
+
+#: ../src/common/paper.cpp:185
+#, fuzzy
+msgid "PRC Envelope #8 Rotated 309 x 120 mm"
+msgstr "C4 Sobre, 229 x 324 mm"
+
+#: ../src/common/paper.cpp:186
+#, fuzzy
+msgid "PRC Envelope #9 Rotated 324 x 229 mm"
+msgstr "C5 Sobre, 162 x 229 mm"
+
+#: ../src/common/paper.cpp:187
+#, fuzzy
+msgid "PRC Envelope #10 Rotated 458 x 324 mm"
+msgstr "C4 Sobre, 229 x 324 mm"
+
+#: ../src/common/paper.cpp:192
+#, fuzzy
+msgid "A0 sheet, 841 x 1189 mm"
+msgstr "Full A4, 210 x 297 mm"
+
+#: ../src/common/paper.cpp:193
+#, fuzzy
+msgid "A1 sheet, 594 x 841 mm"
+msgstr "Full A3, 297 x 420 mm"
+
+#: ../src/common/preferencescmn.cpp:37
+msgid "General"
+msgstr ""
+
+#: ../src/common/preferencescmn.cpp:40
+msgid "Advanced"
+msgstr ""
+
+#: ../src/common/prntbase.cpp:245
+#, fuzzy
+msgid "Generic PostScript"
+msgstr "Fitxer PostScript"
+
+#: ../src/common/prntbase.cpp:259
+#, fuzzy
+msgid "Ready"
+msgstr "&Refés"
+
+#: ../src/common/prntbase.cpp:331
+msgid "Printing Error"
+msgstr "Error d'impressió"
+
+#: ../src/common/prntbase.cpp:413 ../src/common/prntbase.cpp:1597
+#: ../src/generic/prntdlgg.cpp:135 ../src/generic/prntdlgg.cpp:149
+#: ../src/gtk/print.cpp:628 ../src/gtk/print.cpp:646
+msgid "Print"
+msgstr "Imprimix"
+
+#: ../src/common/prntbase.cpp:471 ../src/generic/prntdlgg.cpp:809
+#, fuzzy
+msgid "Page setup"
+msgstr "Configuració de la pàgina"
+
+#: ../src/common/prntbase.cpp:525
+#, fuzzy
+msgid "Please wait while printing..."
+msgstr "Espereu mentre simprimix\n"
+
+#: ../src/common/prntbase.cpp:529
+msgid "Document:"
+msgstr ""
+
+#: ../src/common/prntbase.cpp:532
+msgid "Progress:"
+msgstr ""
+
+#: ../src/common/prntbase.cpp:533
+msgid "Preparing"
+msgstr ""
+
+#: ../src/common/prntbase.cpp:552
+#, fuzzy, c-format
+msgid "Printing page %d"
+msgstr "S'està imprimint la pàgina %d..."
+
+#: ../src/common/prntbase.cpp:557
+#, fuzzy, c-format
+msgid "Printing page %d of %d"
+msgstr "S'està imprimint la pàgina %d..."
+
+#: ../src/common/prntbase.cpp:560
+#, fuzzy, c-format
+msgid " (copy %d of %d)"
+msgstr "Pàgina %d de %d"
+
+#: ../src/common/prntbase.cpp:1604
+#, fuzzy
+msgid "First page"
+msgstr "Pàgina següent"
+
+#: ../src/common/prntbase.cpp:1609 ../src/html/helpwnd.cpp:659
+msgid "Previous page"
+msgstr "Pàgina anterior"
+
+#: ../src/common/prntbase.cpp:1623 ../src/html/helpwnd.cpp:660
+msgid "Next page"
+msgstr "Pàgina següent"
+
+#: ../src/common/prntbase.cpp:1628
+#, fuzzy
+msgid "Last page"
+msgstr "Pàgina següent"
+
+#: ../src/common/prntbase.cpp:1636 ../src/common/stockitem.cpp:215
+msgid "Zoom Out"
+msgstr ""
+
+#: ../src/common/prntbase.cpp:1650 ../src/common/stockitem.cpp:214
+msgid "Zoom In"
+msgstr ""
+
+#: ../src/common/prntbase.cpp:1656 ../src/common/stockitem.cpp:153
+#: ../src/generic/logg.cpp:553 ../src/univ/themes/win32.cpp:3752
+msgid "&Close"
+msgstr "&Tanca"
+
+#: ../src/common/prntbase.cpp:2085
+msgid "Could not start document preview."
+msgstr "No s'ha pogut iniciar la previsualització del document."
+
+#: ../src/common/prntbase.cpp:2085 ../src/common/prntbase.cpp:2129
+#: ../src/common/prntbase.cpp:2137
+msgid "Print Preview Failure"
+msgstr "Error en la previsualització d'impressió"
+
+#: ../src/common/prntbase.cpp:2129 ../src/common/prntbase.cpp:2137
+msgid "Sorry, not enough memory to create a preview."
+msgstr "No hi ha prou memòria com per crear una previsualització"
+
+#: ../src/common/prntbase.cpp:2144
+#, c-format
+msgid "Page %d of %d"
+msgstr "Pàgina %d de %d"
+
+#: ../src/common/prntbase.cpp:2146
+#, c-format
+msgid "Page %d"
+msgstr "Pàgina %d"
+
+#: ../src/common/regex.cpp:382 ../src/html/chm.cpp:348
+msgid "unknown error"
+msgstr "error desconegut"
+
+#: ../src/common/regex.cpp:995
+#, c-format
+msgid "Invalid regular expression '%s': %s"
+msgstr "Expressió regular invàlida '%s': %s"
+
+#: ../src/common/regex.cpp:1059
+#, fuzzy, c-format
+msgid "Failed to find match for regular expression: %s"
+msgstr "No s'ha pogut coincidir '%s' en l'expressió regular: %s"
+
+#: ../src/common/rendcmn.cpp:188
+#, c-format
+msgid "Renderer \"%s\" has incompatible version %d.%d and couldn't be loaded."
+msgstr ""
+
+#: ../src/common/secretstore.cpp:162
+msgid "Not available for this platform"
+msgstr ""
+
+#: ../src/common/secretstore.cpp:183
+#, fuzzy, c-format
+msgid "Saving password for \"%s\" failed: %s."
+msgstr "L'execució de l'orde '%s' ha fallit."
+
+#: ../src/common/secretstore.cpp:205
+#, fuzzy, c-format
+msgid "Reading password for \"%s\" failed: %s."
+msgstr "L'execució de l'orde '%s' ha fallit."
+
+#: ../src/common/secretstore.cpp:228
+#, fuzzy, c-format
+msgid "Deleting password for \"%s\" failed: %s."
+msgstr "L'execució de l'orde '%s' ha fallit."
+
+#: ../src/common/selectdispatcher.cpp:254
+msgid "Failed to monitor I/O channels"
+msgstr ""
+
+#: ../src/common/sizer.cpp:3054 ../src/common/stockitem.cpp:195
+#, fuzzy
+msgid "Save"
+msgstr "&Desa..."
+
+#: ../src/common/sizer.cpp:3056
+msgid "Don't Save"
+msgstr ""
+
+#: ../src/common/socket.cpp:870
+#, fuzzy
+msgid "Cannot initialize sockets"
+msgstr "No es pot inicialitzar OLE"
+
+#: ../src/common/stockitem.cpp:127
+#, fuzzy
+msgctxt "standard Windows menu"
+msgid "&Help"
+msgstr "&Ajuda"
+
+#: ../src/common/stockitem.cpp:144
+msgid "&About"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:144
+msgid "About"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:145
+msgid "Add"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:146
+msgid "&Apply"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:146
+msgid "Apply"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:147
+#, fuzzy
+msgid "&Back"
+msgstr "< &Enrere"
+
+#: ../src/common/stockitem.cpp:147
+#, fuzzy
+msgid "Back"
+msgstr "< &Enrere"
+
+#: ../src/common/stockitem.cpp:148
+#, fuzzy
+msgid "&Bold"
+msgstr "Negreta"
+
+#: ../src/common/stockitem.cpp:148 ../src/generic/fontdlgg.cpp:326
+#: ../src/richtext/richtextfontpage.cpp:354
+msgid "Bold"
+msgstr "Negreta"
+
+#: ../src/common/stockitem.cpp:149
+msgid "&Bottom"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:149 ../src/richtext/richtextsizepage.cpp:287
+msgid "Bottom"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:150 ../src/generic/fontdlgg.cpp:462
+#: ../src/generic/fontdlgg.cpp:481 ../src/generic/wizard.cpp:415
+msgid "&Cancel"
+msgstr "&Anul·la"
+
+#: ../src/common/stockitem.cpp:151
+msgid "&CD-ROM"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:151
+msgid "CD-ROM"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:152
+#, fuzzy
+msgid "&Clear"
+msgstr "&Neteja"
+
+#: ../src/common/stockitem.cpp:152
+#, fuzzy
+msgid "Clear"
+msgstr "&Neteja"
+
+#: ../src/common/stockitem.cpp:153 ../src/generic/dbgrptg.cpp:93
+#: ../src/generic/progdlgg.cpp:778 ../src/html/helpdlg.cpp:86
+#: ../src/msw/progdlg.cpp:209 ../src/msw/progdlg.cpp:890
+#: ../src/richtext/richtextstyledlg.cpp:272
+#: ../src/richtext/richtextsymboldlg.cpp:448
+msgid "Close"
+msgstr "Tanca"
+
+#: ../src/common/stockitem.cpp:154
+#, fuzzy
+msgid "&Convert"
+msgstr "Contingut"
+
+#: ../src/common/stockitem.cpp:154
+#, fuzzy
+msgid "Convert"
+msgstr "Contingut"
+
+#: ../src/common/stockitem.cpp:155 ../src/msw/textctrl.cpp:2884
+#: ../src/osx/textctrl_osx.cpp:653 ../src/richtext/richtextctrl.cpp:331
+msgid "&Copy"
+msgstr "&Copia"
+
+#: ../src/common/stockitem.cpp:155 ../src/stc/stc_i18n.cpp:18
+#, fuzzy
+msgid "Copy"
+msgstr "&Copia"
+
+#: ../src/common/stockitem.cpp:156 ../src/msw/textctrl.cpp:2883
+#: ../src/osx/textctrl_osx.cpp:652 ../src/richtext/richtextctrl.cpp:330
+msgid "Cu&t"
+msgstr "Re&talla"
+
+#: ../src/common/stockitem.cpp:156 ../src/stc/stc_i18n.cpp:17
+#, fuzzy
+msgid "Cut"
+msgstr "Re&talla"
+
+#: ../src/common/stockitem.cpp:157 ../src/msw/textctrl.cpp:2886
+#: ../src/osx/textctrl_osx.cpp:655 ../src/richtext/richtextctrl.cpp:333
+#: ../src/richtext/richtexttabspage.cpp:137
+msgid "&Delete"
+msgstr "&Elimina"
+
+#: ../src/common/stockitem.cpp:157 ../src/richtext/richtextbuffer.cpp:8266
+#: ../src/stc/stc_i18n.cpp:20
+#, fuzzy
+msgid "Delete"
+msgstr "&Elimina"
+
+#: ../src/common/stockitem.cpp:158
+#, fuzzy
+msgid "&Down"
+msgstr "Avall"
+
+#: ../src/common/stockitem.cpp:158 ../src/generic/fdrepdlg.cpp:148
+msgid "Down"
+msgstr "Avall"
+
+#: ../src/common/stockitem.cpp:159
+msgid "&Edit"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:159
+msgid "Edit"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:160
+msgid "&Execute"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:160
+msgid "Execute"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:161
+msgid "&Quit"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:161
+msgid "Quit"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:162
+#, fuzzy
+msgid "&File"
+msgstr "&Mida"
+
+#: ../src/common/stockitem.cpp:162
+#, fuzzy
+msgid "File"
+msgstr "&Mida"
+
+#: ../src/common/stockitem.cpp:163
+#, fuzzy
+msgid "&Find..."
+msgstr "&Cerca"
+
+#: ../src/common/stockitem.cpp:163
+#, fuzzy
+msgid "Find..."
+msgstr "Cerca"
+
+#: ../src/common/stockitem.cpp:164
+#, fuzzy
+msgid "&First"
+msgstr "primer"
+
+#: ../src/common/stockitem.cpp:164
+#, fuzzy
+msgid "First"
+msgstr "primer"
+
+#: ../src/common/stockitem.cpp:165
+#, fuzzy
+msgid "&Floppy"
+msgstr "&Copia"
+
+#: ../src/common/stockitem.cpp:165
+#, fuzzy
+msgid "Floppy"
+msgstr "&Copia"
+
+#: ../src/common/stockitem.cpp:166
+#, fuzzy
+msgid "&Forward"
+msgstr "Avant"
+
+#: ../src/common/stockitem.cpp:166
+#, fuzzy
+msgid "Forward"
+msgstr "Avant"
+
+#: ../src/common/stockitem.cpp:167
+msgid "&Harddisk"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:167
+msgid "Harddisk"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:168 ../src/generic/wizard.cpp:418
+#: ../src/osx/cocoa/menu.mm:225 ../src/richtext/richtextstyledlg.cpp:298
+#: ../src/richtext/richtextsymboldlg.cpp:451
+msgid "&Help"
+msgstr "&Ajuda"
+
+#: ../src/common/stockitem.cpp:169
+#, fuzzy
+msgid "&Home"
+msgstr "&Mou"
+
+#: ../src/common/stockitem.cpp:169
+#, fuzzy
+msgid "Home"
+msgstr "sense nom"
+
+#: ../src/common/stockitem.cpp:170
+#, fuzzy
+msgid "Indent"
+msgstr "Índex"
+
+#: ../src/common/stockitem.cpp:171
+#, fuzzy
+msgid "&Index"
+msgstr "Índex"
+
+#: ../src/common/stockitem.cpp:171 ../src/html/helpwnd.cpp:510
+msgid "Index"
+msgstr "Índex"
+
+#: ../src/common/stockitem.cpp:172
+#, fuzzy
+msgid "&Info"
+msgstr "&Desfés"
+
+#: ../src/common/stockitem.cpp:172
+msgid "Info"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:173
+#, fuzzy
+msgid "&Italic"
+msgstr "Cursiva"
+
+#: ../src/common/stockitem.cpp:173 ../src/generic/fontdlgg.cpp:322
+#: ../src/richtext/richtextfontpage.cpp:350
+msgid "Italic"
+msgstr "Cursiva"
+
+#: ../src/common/stockitem.cpp:174
+msgid "&Jump to"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:174
+msgid "Jump to"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:175
+msgid "Centered"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:176
+msgid "Justified"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:177
+msgid "Align Left"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:178
+#, fuzzy
+msgid "Align Right"
+msgstr "mitja nit"
+
+#: ../src/common/stockitem.cpp:179
+#, fuzzy
+msgid "&Last"
+msgstr "&Enganxa"
+
+#: ../src/common/stockitem.cpp:179
+#, fuzzy
+msgid "Last"
+msgstr "&Enganxa"
+
+#: ../src/common/stockitem.cpp:180
+#, fuzzy
+msgid "&Network"
+msgstr "&Següent"
+
+#: ../src/common/stockitem.cpp:180
+msgid "Network"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:181 ../src/richtext/richtexttabspage.cpp:131
+#, fuzzy
+msgid "&New"
+msgstr "&Següent"
+
+#: ../src/common/stockitem.cpp:181
+#, fuzzy
+msgid "New"
+msgstr "&Següent"
+
+#: ../src/common/stockitem.cpp:182 ../src/msw/msgdlg.cpp:417
+#, fuzzy
+msgid "&No"
+msgstr "No"
+
+#: ../src/common/stockitem.cpp:183 ../src/generic/fontdlgg.cpp:467
+#: ../src/generic/fontdlgg.cpp:474
+#, fuzzy
+msgid "&OK"
+msgstr "D'acord"
+
+#: ../src/common/stockitem.cpp:184 ../src/generic/dbgrptg.cpp:341
+#, fuzzy
+msgid "&Open..."
+msgstr "&Desa..."
+
+#: ../src/common/stockitem.cpp:184
+#, fuzzy
+msgid "Open..."
+msgstr "&Desa..."
+
+#: ../src/common/stockitem.cpp:185 ../src/msw/textctrl.cpp:2885
+#: ../src/osx/textctrl_osx.cpp:654 ../src/richtext/richtextctrl.cpp:332
+msgid "&Paste"
+msgstr "&Enganxa"
+
+#: ../src/common/stockitem.cpp:185 ../src/richtext/richtextctrl.cpp:3484
+#: ../src/stc/stc_i18n.cpp:19
+#, fuzzy
+msgid "Paste"
+msgstr "&Enganxa"
+
+#: ../src/common/stockitem.cpp:186
+msgid "&Preferences"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:186 ../src/osx/cocoa/preferences.mm:304
+msgid "Preferences"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:187
+#, fuzzy
+msgid "Print previe&w..."
+msgstr "Imprimix previsualització"
+
+#: ../src/common/stockitem.cpp:187
+#, fuzzy
+msgid "Print preview..."
+msgstr "Imprimix previsualització"
+
+#: ../src/common/stockitem.cpp:188
+#, fuzzy
+msgid "&Print..."
+msgstr "Imprimix..."
+
+#: ../src/common/stockitem.cpp:188
+#, fuzzy
+msgid "Print..."
+msgstr "Imprimix..."
+
+#: ../src/common/stockitem.cpp:189 ../src/richtext/richtextctrl.cpp:337
+#: ../src/richtext/richtextctrl.cpp:5479
+#, fuzzy
+msgid "&Properties"
+msgstr "&Previ"
+
+#: ../src/common/stockitem.cpp:189
+#, fuzzy
+msgid "Properties"
+msgstr "&Previ"
+
+#: ../src/common/stockitem.cpp:190 ../src/stc/stc_i18n.cpp:16
+#, fuzzy
+msgid "Redo"
+msgstr "&Refés"
+
+#: ../src/common/stockitem.cpp:191
+msgid "Refresh"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:192
+msgid "Remove"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:193
+#, fuzzy
+msgid "Rep&lace..."
+msgstr "&Substituix"
+
+#: ../src/common/stockitem.cpp:193
+#, fuzzy
+msgid "Replace..."
+msgstr "&Substituix"
+
+#: ../src/common/stockitem.cpp:194
+msgid "Revert to Saved"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:196 ../src/generic/logg.cpp:549
+#, fuzzy
+msgid "Save &As..."
+msgstr "&Desa..."
+
+#: ../src/common/stockitem.cpp:196
+#, fuzzy
+msgid "Save As..."
+msgstr "&Desa..."
+
+#: ../src/common/stockitem.cpp:197 ../src/msw/textctrl.cpp:2888
+#: ../src/osx/textctrl_osx.cpp:657 ../src/richtext/richtextctrl.cpp:335
+msgid "Select &All"
+msgstr "Selecciona-ho &tot"
+
+#: ../src/common/stockitem.cpp:197 ../src/stc/stc_i18n.cpp:21
+#, fuzzy
+msgid "Select All"
+msgstr "Selecciona-ho &tot"
+
+#: ../src/common/stockitem.cpp:198
+#, fuzzy
+msgid "&Color"
+msgstr "Trieu la font"
+
+#: ../src/common/stockitem.cpp:198
+#, fuzzy
+msgid "Color"
+msgstr "Trieu la font"
+
+#: ../src/common/stockitem.cpp:199
+#, fuzzy
+msgid "&Font"
+msgstr "Grandària de la font:"
+
+#: ../src/common/stockitem.cpp:199 ../src/richtext/richtextformatdlg.cpp:336
+msgid "Font"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:200
+msgid "&Ascending"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:200
+#, fuzzy
+msgid "Ascending"
+msgstr "s'està llegint"
+
+#: ../src/common/stockitem.cpp:201
+msgid "&Descending"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:201
+#, fuzzy
+msgid "Descending"
+msgstr "Codificació predeterminada"
+
+#: ../src/common/stockitem.cpp:202
+msgid "&Spell Check"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:202
+msgid "Spell Check"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:203
+#, fuzzy
+msgid "&Stop"
+msgstr "Configuració"
+
+#: ../src/common/stockitem.cpp:203
+#, fuzzy
+msgid "Stop"
+msgstr "Configuració"
+
+#: ../src/common/stockitem.cpp:204 ../src/richtext/richtextfontpage.cpp:274
+msgid "&Strikethrough"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:204
+msgid "Strikethrough"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:205
+#, fuzzy
+msgid "&Top"
+msgstr "&Copia"
+
+#: ../src/common/stockitem.cpp:205 ../src/richtext/richtextsizepage.cpp:285
+#: ../src/richtext/richtextsizepage.cpp:289
+#, fuzzy
+msgid "Top"
+msgstr "Per a:"
+
+#: ../src/common/stockitem.cpp:206
+#, fuzzy
+msgid "Undelete"
+msgstr "Subratllat"
+
+#: ../src/common/stockitem.cpp:207 ../src/generic/fontdlgg.cpp:437
+#, fuzzy
+msgid "&Underline"
+msgstr "Subratllat"
+
+#: ../src/common/stockitem.cpp:207
+#, fuzzy
+msgid "Underline"
+msgstr "Subratllat"
+
+#: ../src/common/stockitem.cpp:208 ../src/stc/stc_i18n.cpp:15
+#, fuzzy
+msgid "Undo"
+msgstr "&Desfés"
+
+#: ../src/common/stockitem.cpp:209
+#, fuzzy
+msgid "&Unindent"
+msgstr "dinovè"
+
+#: ../src/common/stockitem.cpp:209
+#, fuzzy
+msgid "Unindent"
+msgstr "dinovè"
+
+#: ../src/common/stockitem.cpp:210
+#, fuzzy
+msgid "&Up"
+msgstr "Amunt"
+
+#: ../src/common/stockitem.cpp:210 ../src/generic/fdrepdlg.cpp:148
+msgid "Up"
+msgstr "Amunt"
+
+#: ../src/common/stockitem.cpp:211 ../src/msw/msgdlg.cpp:417
+#, fuzzy
+msgid "&Yes"
+msgstr "Sí"
+
+#: ../src/common/stockitem.cpp:212
+msgid "&Actual Size"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:212
+msgid "Actual Size"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:213
+msgid "Zoom to &Fit"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:213
+msgid "Zoom to Fit"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:214
+msgid "Zoom &In"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:215
+msgid "Zoom &Out"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:262
+msgid "Show about dialog"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:263
+#, fuzzy
+msgid "Copy selection"
+msgstr "Seccions"
+
+#: ../src/common/stockitem.cpp:264
+#, fuzzy
+msgid "Cut selection"
+msgstr "Seccions"
+
+#: ../src/common/stockitem.cpp:265
+#, fuzzy
+msgid "Delete selection"
+msgstr "Seccions"
+
+#: ../src/common/stockitem.cpp:266
+#, fuzzy
+msgid "Find in document"
+msgstr "Obri document HTML"
+
+#: ../src/common/stockitem.cpp:267
+msgid "Find and replace in document"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:268
+#, fuzzy
+msgid "Paste selection"
+msgstr "Seccions"
+
+#: ../src/common/stockitem.cpp:269
+#, fuzzy
+msgid "Quit this program"
+msgstr "Imprimix esta pàgina"
+
+#: ../src/common/stockitem.cpp:270
+msgid "Redo last action"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:271
+msgid "Undo last action"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:272
+#, fuzzy
+msgid "Create new document"
+msgstr "Crea un directori nou"
+
+#: ../src/common/stockitem.cpp:273
+#, fuzzy
+msgid "Open an existing document"
+msgstr "Obri document HTML"
+
+#: ../src/common/stockitem.cpp:274
+msgid "Close current document"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:275
+#, fuzzy
+msgid "Save current document"
+msgstr "Seleccioneu una vista del document"
+
+#: ../src/common/stockitem.cpp:276
+msgid "Save current document with a different filename"
+msgstr ""
+
+#: ../src/common/strconv.cpp:2324
+#, c-format
+msgid "Conversion to charset '%s' doesn't work."
+msgstr "La conversió al joc de caràcters '%s' no funciona."
+
+#: ../src/common/tarstrm.cpp:352 ../src/common/tarstrm.cpp:375
+#: ../src/common/tarstrm.cpp:406 ../src/generic/progdlgg.cpp:373
+msgid "unknown"
+msgstr "desconegut"
+
+#: ../src/common/tarstrm.cpp:774
+msgid "incomplete header block in tar"
+msgstr ""
+
+#: ../src/common/tarstrm.cpp:798
+msgid "checksum failure reading tar header block"
+msgstr ""
+
+#: ../src/common/tarstrm.cpp:971
+msgid "invalid data in extended tar header"
+msgstr ""
+
+#: ../src/common/tarstrm.cpp:981 ../src/common/tarstrm.cpp:1003
+#: ../src/common/tarstrm.cpp:1477 ../src/common/tarstrm.cpp:1499
+msgid "tar entry not open"
+msgstr ""
+
+#: ../src/common/tarstrm.cpp:1023
+#, fuzzy
+msgid "unexpected end of file"
+msgstr "Fi de fitxer inesperat en analitzar el recurs."
+
+#: ../src/common/tarstrm.cpp:1297
+#, c-format
+msgid "%s did not fit the tar header for entry '%s'"
+msgstr ""
+
+#: ../src/common/tarstrm.cpp:1359
+msgid "incorrect size given for tar entry"
+msgstr ""
+
+#: ../src/common/textbuf.cpp:232
+#, c-format
+msgid "'%s' is probably a binary buffer."
+msgstr "'%s' és probablement un búffer binari."
+
+#: ../src/common/textcmn.cpp:1006 ../src/richtext/richtextctrl.cpp:3053
+msgid "File couldn't be loaded."
+msgstr "No s'ha pogut carregar el fitxer."
+
+#: ../src/common/textfile.cpp:95
+#, fuzzy, c-format
+msgid "Failed to read text file \"%s\"."
+msgstr "No s'ha pogut carregar la imatge %d des del fitxer '%s'."
+
+#: ../src/common/textfile.cpp:160
+#, c-format
+msgid "can't write buffer '%s' to disk."
+msgstr "no es pot escriure el búfer '%s' al disc."
+
+#: ../src/common/time.cpp:212
+msgid "Failed to get the local system time"
+msgstr "No s'ha pogut obtenir l'horari local del sistema"
+
+#: ../src/common/time.cpp:279
+msgid "wxGetTimeOfDay failed."
+msgstr "wxGetTimeOfDay ha fallat."
+
+#: ../src/common/translation.cpp:929
+#, c-format
+msgid "'%s' is not a valid message catalog."
+msgstr "'%s' no és un missatge vàlid de catàleg"
+
+#: ../src/common/translation.cpp:954
+#, fuzzy
+msgid "Invalid message catalog."
+msgstr "'%s' no és un missatge vàlid de catàleg"
+
+#: ../src/common/translation.cpp:1013
+#, fuzzy, c-format
+msgid "Failed to parse Plural-Forms: '%s'"
+msgstr "No es pot analitzar les coordenades des de '%s'."
+
+#: ../src/common/translation.cpp:1723
+#, c-format
+msgid "using catalog '%s' from '%s'."
+msgstr "s'està utilitzant el catàleg '%s' des de '%s'."
+
+#: ../src/common/translation.cpp:1816
+#, fuzzy, c-format
+msgid "Resource '%s' is not a valid message catalog."
+msgstr "'%s' no és un missatge vàlid de catàleg"
+
+#: ../src/common/translation.cpp:1865
+#, fuzzy
+msgid "Couldn't enumerate translations"
+msgstr "No s'ha acabat la cadena"
+
+#: ../src/common/utilscmn.cpp:1145
+msgid "No default application configured for HTML files."
+msgstr ""
+
+#: ../src/common/utilscmn.cpp:1190
+#, fuzzy, c-format
+msgid "Failed to open URL \"%s\" in default browser."
+msgstr "No s'ha pogut obrir '%s' per %s"
+
+#: ../src/common/valtext.cpp:144
+msgid "Validation conflict"
+msgstr "Conflicte de validació"
+
+#: ../src/common/valtext.cpp:186
+msgid "Required information entry is empty."
+msgstr ""
+
+#: ../src/common/valtext.cpp:188
+#, fuzzy, c-format
+msgid "'%s' is one of the invalid strings"
+msgstr "'%s' és invàlid"
+
+#: ../src/common/valtext.cpp:190
+#, fuzzy, c-format
+msgid "'%s' is not one of the valid strings"
+msgstr "'%s' no és un missatge vàlid de catàleg"
+
+#: ../src/common/valtext.cpp:199
+#, fuzzy, c-format
+msgid "'%s' contains invalid character(s)"
+msgstr "'%s' només hauria de contenir caràcters alfabètics"
+
+#: ../src/common/webrequest.cpp:139
+#, fuzzy, c-format
+msgid "Error: %s (%d)"
+msgstr "Error: "
+
+#: ../src/common/webrequest.cpp:655
+#, c-format
+msgid ""
+"Not enough free disk space for download: %llu needed but only %llu available."
+msgstr ""
+
+#: ../src/common/webrequest.cpp:669
+#, fuzzy, c-format
+msgid "Failed to create temporary file in %s"
+msgstr "No s'ha pogut crear un nom d'arxiu temporal"
+
+#: ../src/common/webrequest_curl.cpp:1106
+#, fuzzy
+msgid "libcurl could not be initialized"
+msgstr "No s'ha pogut carregar el fitxer."
+
+#: ../src/common/webview.cpp:392
+msgid "RunScriptAsync not supported"
+msgstr ""
+
+#: ../src/common/webview.cpp:403 ../src/msw/webview_ie.cpp:1073
+#, c-format
+msgid "Error running JavaScript: %s"
+msgstr ""
+
+#: ../src/common/webview_chromium.cpp:858
+#, fuzzy, c-format
+msgid "Failed to set proxy \"%s\": %s"
+msgstr "No s'ha pogut crear un directori %s/.gnome."
+
+#: ../src/common/webview_chromium.cpp:989
+msgid ""
+"Chromium can't be used because libcef.so wasn't loaded early enough; please "
+"relink the application or use LD_PRELOAD to load it earlier."
+msgstr ""
+
+#: ../src/common/webview_chromium.cpp:1108
+#, fuzzy
+msgid "Could not initialize Chromium"
+msgstr "No s'ha pogut iniciar la impressió"
+
+#: ../src/common/webview_chromium.cpp:1616
+msgid "Show DevTools"
+msgstr ""
+
+#: ../src/common/webview_chromium.cpp:1617
+#, fuzzy
+msgid "Close DevTools"
+msgstr "Tanca-ho tot"
+
+#: ../src/common/webview_chromium.cpp:1623
+msgid "Inspect"
+msgstr ""
+
+#: ../src/common/wincmn.cpp:1628
+msgid "This platform does not support background transparency."
+msgstr ""
+
+#: ../src/common/wincmn.cpp:2097
+msgid "Could not transfer data to window"
+msgstr "No s'ha pogut transferir dades a la finestra"
+
+#: ../src/common/windowid.cpp:240
+msgid "Out of window IDs.  Recommend shutting down application."
+msgstr ""
+
+#: ../src/common/xpmdecod.cpp:678
+msgid "XPM: incorrect header format!"
+msgstr ""
+
+#: ../src/common/xpmdecod.cpp:703
+#, fuzzy, c-format
+msgid "XPM: incorrect colour description in line %d"
+msgstr "XPM: definició '%s' de color mal formulada!"
+
+#: ../src/common/xpmdecod.cpp:715 ../src/common/xpmdecod.cpp:724
+#, fuzzy, c-format
+msgid "XPM: malformed colour definition '%s' at line %d!"
+msgstr "XPM: definició '%s' de color mal formulada!"
+
+#: ../src/common/xpmdecod.cpp:754
+msgid "XPM: no colors left to use for mask!"
+msgstr ""
+
+#: ../src/common/xpmdecod.cpp:781
+#, c-format
+msgid "XPM: truncated image data at line %d!"
+msgstr ""
+
+#: ../src/common/xpmdecod.cpp:795
+msgid "XPM: Malformed pixel data!"
+msgstr "XPM: dades píxels mal formulades!"
+
+#: ../src/common/xti.cpp:492
+msgid "Illegal Parameter Count for Create Method"
+msgstr ""
+
+#: ../src/common/xti.cpp:504
+msgid "Illegal Parameter Count for ConstructObject Method"
+msgstr ""
+
+#: ../src/common/xtistrm.cpp:161
+#, c-format
+msgid "Create Parameter %s not found in declared RTTI Parameters"
+msgstr ""
+
+#: ../src/common/xtistrm.cpp:290
+msgid "Illegal Object Class (Non-wxEvtHandler) as Event Source"
+msgstr ""
+
+#: ../src/common/xtistrm.cpp:313 ../src/common/xtixml.cpp:345
+#: ../src/common/xtixml.cpp:498
+msgid "Type must have enum - long conversion"
+msgstr ""
+
+#: ../src/common/xtistrm.cpp:400 ../src/common/xtistrm.cpp:415
+msgid "Invalid or Null Object ID passed to GetObjectClassInfo"
+msgstr ""
+
+#: ../src/common/xtistrm.cpp:405
+msgid "Unknown Object passed to GetObjectClassInfo"
+msgstr ""
+
+#: ../src/common/xtistrm.cpp:420
+msgid "Already Registered Object passed to SetObjectClassInfo"
+msgstr ""
+
+#: ../src/common/xtistrm.cpp:430
+msgid "Invalid or Null Object ID passed to HasObjectClassInfo"
+msgstr ""
+
+#: ../src/common/xtistrm.cpp:460
+msgid "Passing a already registered object to SetObject"
+msgstr ""
+
+#: ../src/common/xtistrm.cpp:471
+msgid "Passing an unknown object to GetObject"
+msgstr ""
+
+#: ../src/common/xtixml.cpp:229
+msgid "Forward hrefs are not supported"
+msgstr ""
+
+#: ../src/common/xtixml.cpp:247
+#, fuzzy, c-format
+msgid "unknown class %s"
+msgstr ": joc de caràcters desconegut"
+
+#: ../src/common/xtixml.cpp:253
+msgid "objects cannot have XML Text Nodes"
+msgstr ""
+
+#: ../src/common/xtixml.cpp:258
+msgid "Objects must have an id attribute"
+msgstr ""
+
+#: ../src/common/xtixml.cpp:267
+#, c-format
+msgid "Doubly used id : %d"
+msgstr ""
+
+#: ../src/common/xtixml.cpp:316
+#, fuzzy, c-format
+msgid "Unknown Property %s"
+msgstr "Opció '%s' desconeguda"
+
+#: ../src/common/xtixml.cpp:407
+msgid "A non empty collection must consist of 'element' nodes"
+msgstr ""
+
+#: ../src/common/xtixml.cpp:478
+msgid "incorrect event handler string, missing dot"
+msgstr ""
+
+#: ../src/common/zipstrm.cpp:559
+#, fuzzy
+msgid "can't re-initialize zlib deflate stream"
+msgstr "No es pot començar a mostrar."
+
+#: ../src/common/zipstrm.cpp:584
+#, fuzzy
+msgid "can't re-initialize zlib inflate stream"
+msgstr "No es pot començar a mostrar."
+
+#: ../src/common/zipstrm.cpp:1023
+msgid "Ignoring malformed extra data record, ZIP file may be corrupted"
+msgstr ""
+
+#: ../src/common/zipstrm.cpp:1502
+msgid "assuming this is a multi-part zip concatenated"
+msgstr ""
+
+#: ../src/common/zipstrm.cpp:1664
+#, fuzzy
+msgid "invalid zip file"
+msgstr "Fitxer de bloqueig '%s' invàlid."
+
+#: ../src/common/zipstrm.cpp:1723
+#, fuzzy
+msgid "can't find central directory in zip"
+msgstr "No es pot trobar la posició actual en el fitxer '%s'"
+
+#: ../src/common/zipstrm.cpp:1812
+#, fuzzy
+msgid "error reading zip central directory"
+msgstr "Error en crear directori"
+
+#: ../src/common/zipstrm.cpp:1916
+msgid "error reading zip local header"
+msgstr ""
+
+#: ../src/common/zipstrm.cpp:1964
+msgid "bad zipfile offset to entry"
+msgstr ""
+
+#: ../src/common/zipstrm.cpp:2031
+#, fuzzy
+msgid "stored file length not in Zip header"
+msgstr "Format no suportat de porta-retalls"
+
+#: ../src/common/zipstrm.cpp:2045 ../src/common/zipstrm.cpp:2362
+msgid "unsupported Zip compression method"
+msgstr ""
+
+#: ../src/common/zipstrm.cpp:2126
+#, c-format
+msgid "reading zip stream (entry %s): bad length"
+msgstr ""
+
+#: ../src/common/zipstrm.cpp:2131
+#, c-format
+msgid "reading zip stream (entry %s): bad crc"
+msgstr ""
+
+#: ../src/common/zipstrm.cpp:2578
+#, c-format
+msgid "error writing zip entry '%s': file too large without ZIP64"
+msgstr ""
+
+#: ../src/common/zipstrm.cpp:2585
+#, c-format
+msgid "error writing zip entry '%s': bad crc or length"
+msgstr ""
+
+#: ../src/common/zstream.cpp:155 ../src/common/zstream.cpp:315
+msgid "Gzip not supported by this version of zlib"
+msgstr ""
+
+#: ../src/common/zstream.cpp:182
+#, fuzzy
+msgid "Can't initialize zlib inflate stream."
+msgstr "No es pot començar a mostrar."
+
+#: ../src/common/zstream.cpp:241
+msgid "Can't read inflate stream: unexpected EOF in underlying stream."
+msgstr ""
+
+#: ../src/common/zstream.cpp:248 ../src/common/zstream.cpp:423
+#, fuzzy, c-format
+msgid "zlib error %d"
+msgstr " (error %ld: %s)"
+
+#: ../src/common/zstream.cpp:249
+#, fuzzy, c-format
+msgid "Can't read from inflate stream: %s"
+msgstr "no es pot llegir des del fitxer descriptor %s"
+
+#: ../src/common/zstream.cpp:343
+#, fuzzy
+msgid "Can't initialize zlib deflate stream."
+msgstr "No es pot començar a mostrar."
+
+#: ../src/common/zstream.cpp:424
+#, fuzzy, c-format
+msgid "Can't write to deflate stream: %s"
+msgstr "no es pot escriure en el fitxer descriptiu %d"
+
+#: ../src/dfb/bitmap.cpp:633 ../src/dfb/bitmap.cpp:667
+#, fuzzy, c-format
+msgid "No bitmap handler for type %d defined."
+msgstr "No hi ha definit cap manegador per al tipus d'imatge %d."
+
+#: ../src/dfb/evtloop.cpp:99
+#, fuzzy
+msgid "Failed to read event from DirectFB pipe"
+msgstr "No s'ha pogut llegir el PID des del fitxer de registre."
+
+#: ../src/dfb/evtloop.cpp:171
+msgid "Failed to switch DirectFB pipe to non-blocking mode"
+msgstr ""
+
+#: ../src/dfb/fontmgr.cpp:171
+#, c-format
+msgid "no fonts found in %s, using builtin font"
+msgstr ""
+
+#: ../src/dfb/fontmgr.cpp:177
+#, fuzzy
+msgid "Default font"
+msgstr "Codificació predeterminada"
+
+#: ../src/dfb/fontmgr.cpp:195
+#, c-format
+msgid "Fonts index file %s disappeared while loading fonts."
+msgstr ""
+
+#: ../src/dfb/wrapdfb.cpp:60
+#, c-format
+msgid "DirectFB error %d occurred."
+msgstr ""
+
+#: ../src/generic/aboutdlgg.cpp:69
+msgid "Developed by "
+msgstr ""
+
+#: ../src/generic/aboutdlgg.cpp:72
+msgid "Documentation by "
+msgstr ""
+
+#: ../src/generic/aboutdlgg.cpp:75
+msgid "Graphics art by "
+msgstr ""
+
+#: ../src/generic/aboutdlgg.cpp:78
+msgid "Translations by "
+msgstr ""
+
+#: ../src/generic/aboutdlgg.cpp:133 ../src/osx/cocoa/aboutdlg.mm:83
+#, fuzzy
+msgid "Version "
+msgstr "Permisos"
+
+#. TRANSLATORS: %s is application name
+#: ../src/generic/aboutdlgg.cpp:146 ../src/msw/aboutdlg.cpp:60
+#, c-format
+msgid "About %s"
+msgstr ""
+
+#: ../src/generic/aboutdlgg.cpp:181
+msgid "License"
+msgstr ""
+
+#: ../src/generic/aboutdlgg.cpp:184
+msgid "Developers"
+msgstr ""
+
+#: ../src/generic/aboutdlgg.cpp:188
+msgid "Documentation writers"
+msgstr ""
+
+#: ../src/generic/aboutdlgg.cpp:192
+msgid "Artists"
+msgstr ""
+
+#: ../src/generic/aboutdlgg.cpp:196
+msgid "Translators"
+msgstr ""
+
+#: ../src/generic/animateg.cpp:125
+#, fuzzy
+msgid "No handler found for animation type."
+msgstr "No s'ha trobat cap manegador per al tipus d'imatge"
+
+#: ../src/generic/animateg.cpp:133
+#, fuzzy, c-format
+msgid "No animation handler for type %ld defined."
+msgstr "No hi ha definit cap manegador per al tipus d'imatge %d."
+
+#: ../src/generic/animateg.cpp:145
+#, fuzzy, c-format
+msgid "Animation file is not of type %ld."
+msgstr "El fitxer d'imatge no és del tipus %d."
+
+#: ../src/generic/colrdlgg.cpp:154 ../src/gtk/colordlg.cpp:47
+#, fuzzy
+msgid "Choose colour"
+msgstr "Trieu la font"
+
+#: ../src/generic/colrdlgg.cpp:357
+msgid "Red:"
+msgstr ""
+
+#: ../src/generic/colrdlgg.cpp:360
+msgid "Green:"
+msgstr ""
+
+#: ../src/generic/colrdlgg.cpp:363
+msgid "Blue:"
+msgstr ""
+
+#: ../src/generic/colrdlgg.cpp:372
+msgid "Opacity:"
+msgstr ""
+
+#: ../src/generic/colrdlgg.cpp:384
+msgid "Add to custom colours"
+msgstr "Afig a colors personalitzats"
+
+#: ../src/generic/creddlgg.cpp:56
+msgid "Username:"
+msgstr ""
+
+#: ../src/generic/creddlgg.cpp:63
+msgid "Password:"
+msgstr ""
+
+#. TRANSLATORS: Name of Boolean true value
+#: ../src/generic/datavgen.cpp:1178
+msgid "true"
+msgstr ""
+
+#. TRANSLATORS: Name of Boolean false value
+#: ../src/generic/datavgen.cpp:1180
+#, fuzzy
+msgid "false"
+msgstr "&Mida"
+
+#: ../src/generic/datavgen.cpp:6897
+#, c-format
+msgid "Row %i"
+msgstr ""
+
+#. TRANSLATORS: Action for manipulating a tree control
+#: ../src/generic/datavgen.cpp:6987
+msgid "Collapse"
+msgstr ""
+
+#. TRANSLATORS: Action for manipulating a tree control
+#: ../src/generic/datavgen.cpp:6990
+msgid "Expand"
+msgstr ""
+
+#. TRANSLATORS: Name of data view control and number of rows
+#: ../src/generic/datavgen.cpp:7011
+#, fuzzy, c-format
+msgid "%s (%d items)"
+msgstr "%s (o %s)"
+
+#: ../src/generic/datavgen.cpp:7062
+#, c-format
+msgid "Column %u"
+msgstr ""
+
+#. TRANSLATORS: Keystroke for manipulating a tree control
+#: ../src/generic/datavgen.cpp:7131 ../src/richtext/richtextbulletspage.cpp:189
+#: ../src/richtext/richtextbulletspage.cpp:192
+#: ../src/richtext/richtextbulletspage.cpp:193
+#: ../src/richtext/richtextliststylepage.cpp:252
+#: ../src/richtext/richtextliststylepage.cpp:255
+#: ../src/richtext/richtextliststylepage.cpp:256
+#: ../src/richtext/richtextsizepage.cpp:248
+msgid "Left"
+msgstr ""
+
+#. TRANSLATORS: Keystroke for manipulating a tree control
+#: ../src/generic/datavgen.cpp:7134 ../src/richtext/richtextbulletspage.cpp:191
+#: ../src/richtext/richtextliststylepage.cpp:254
+#: ../src/richtext/richtextsizepage.cpp:249
+#, fuzzy
+msgid "Right"
+msgstr "Clar"
+
+#: ../src/generic/datectlg.cpp:90
+#, c-format
+msgid ""
+"\"%s\" is not in the expected date format, please enter it as e.g. \"%s\"."
+msgstr ""
+
+#: ../src/generic/datectlg.cpp:94
+#, fuzzy
+msgid "Invalid date"
+msgstr "PCX: imatge invàlida"
+
+#: ../src/generic/dbgrptg.cpp:159
+#, fuzzy, c-format
+msgid "Open file \"%s\""
+msgstr "no s'ha pogut obrir el fitxer '%s'"
+
+#: ../src/generic/dbgrptg.cpp:170
+#, fuzzy, c-format
+msgid "Enter command to open file \"%s\":"
+msgstr "no s'ha pogut obrir el fitxer '%s'"
+
+#: ../src/generic/dbgrptg.cpp:230
+#, fuzzy
+msgid "Executable files (*.exe)|*.exe|"
+msgstr "Tots els fitxers (*.*) *.*  "
+
+#: ../src/generic/dbgrptg.cpp:300
+#, c-format
+msgid "Debug report \"%s\""
+msgstr ""
+
+#: ../src/generic/dbgrptg.cpp:316
+msgid "A debug report has been generated in the directory\n"
+msgstr ""
+
+#: ../src/generic/dbgrptg.cpp:317
+msgid "The following debug report will be generated\n"
+msgstr ""
+
+#: ../src/generic/dbgrptg.cpp:321
+msgid ""
+"The report contains the files listed below. If any of these files contain "
+"private information,\n"
+"please uncheck them and they will be removed from the report.\n"
+msgstr ""
+
+#: ../src/generic/dbgrptg.cpp:323
+msgid ""
+"If you wish to suppress this debug report completely, please choose the "
+"\"Cancel\" button,\n"
+"but be warned that it may hinder improving the program, so if\n"
+"at all possible please do continue with the report generation.\n"
+msgstr ""
+
+#: ../src/generic/dbgrptg.cpp:325
+msgid "              Thank you and we're sorry for the inconvenience!\n"
+msgstr ""
+
+#: ../src/generic/dbgrptg.cpp:333
+msgid "&Debug report preview:"
+msgstr ""
+
+#: ../src/generic/dbgrptg.cpp:339
+#, fuzzy
+msgid "&View..."
+msgstr "&Desa..."
+
+#: ../src/generic/dbgrptg.cpp:359
+#, fuzzy
+msgid "&Notes:"
+msgstr "No"
+
+#: ../src/generic/dbgrptg.cpp:361
+msgid ""
+"If you have any additional information pertaining to this bug\n"
+"report, please enter it here and it will be joined to it:"
+msgstr ""
+
+#: ../src/generic/dcpsg.cpp:1627
+msgid "Cannot open file for PostScript printing!"
+msgstr "No es pot obrir el fitxer per a la impressió PostScript!"
+
+#: ../src/generic/dirctrlg.cpp:402
+msgid "Computer"
+msgstr "Ordinador"
+
+#: ../src/generic/dirctrlg.cpp:404
+msgid "Sections"
+msgstr "Seccions"
+
+#: ../src/generic/dirctrlg.cpp:482
+#, fuzzy
+msgid "Home directory"
+msgstr "Crea directori"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/generic/dirctrlg.cpp:484 ../src/propgrid/advprops.cpp:811
+msgid "Desktop"
+msgstr ""
+
+#: ../src/generic/dirctrlg.cpp:528 ../src/generic/filectrlg.cpp:752
+msgid "Illegal directory name."
+msgstr "Nom il·legal de directori"
+
+#: ../src/generic/dirctrlg.cpp:528 ../src/generic/dirctrlg.cpp:546
+#: ../src/generic/dirctrlg.cpp:557 ../src/generic/dirdlgg.cpp:317
+#: ../src/generic/filectrlg.cpp:638 ../src/generic/filectrlg.cpp:752
+#: ../src/generic/filectrlg.cpp:766 ../src/generic/filectrlg.cpp:782
+#: ../src/generic/filectrlg.cpp:1356 ../src/generic/filectrlg.cpp:1387
+#: ../src/generic/filedlgg.cpp:362 ../src/gtk/filedlg.cpp:76
+msgid "Error"
+msgstr "Error"
+
+#: ../src/generic/dirctrlg.cpp:546 ../src/generic/filectrlg.cpp:766
+msgid "File name exists already."
+msgstr "Este nom de fitxer ja existix."
+
+#: ../src/generic/dirctrlg.cpp:557 ../src/generic/dirdlgg.cpp:317
+#: ../src/generic/filectrlg.cpp:638 ../src/generic/filectrlg.cpp:782
+msgid "Operation not permitted."
+msgstr "Operació no permesa."
+
+#: ../src/generic/dirdlgg.cpp:107 ../src/generic/filedlgg.cpp:207
+msgid "Create new directory"
+msgstr "Crea un directori nou"
+
+#: ../src/generic/dirdlgg.cpp:112 ../src/generic/filedlgg.cpp:203
+msgid "Go to home directory"
+msgstr "Vés al directori principal"
+
+#: ../src/generic/dirdlgg.cpp:143
+#, fuzzy
+msgid "Show &hidden directories"
+msgstr "Mostra directoris ocults."
+
+#: ../src/generic/dirdlgg.cpp:196
+#, c-format
+msgid ""
+"The directory '%s' does not exist\n"
+"Create it now?"
+msgstr ""
+"El directori '%s'  not existix\n"
+"Desitgeu crear-lo ara?"
+
+#: ../src/generic/dirdlgg.cpp:198
+msgid "Directory does not exist"
+msgstr "Directori no existix"
+
+#: ../src/generic/dirdlgg.cpp:214
+#, c-format
+msgid ""
+"Failed to create directory '%s'\n"
+"(Do you have the required permissions?)"
+msgstr ""
+"No s'ha pogut crear el directori '%s'\n"
+"(Disposeu dels permisos requerits?)"
+
+#: ../src/generic/dirdlgg.cpp:216
+msgid "Error creating directory"
+msgstr "Error en crear directori"
+
+#: ../src/generic/dirdlgg.cpp:281
+msgid "You cannot add a new directory to this section."
+msgstr "No podeu afegir un directori nou a esta secció"
+
+#: ../src/generic/dirdlgg.cpp:282
+msgid "Create directory"
+msgstr "Crea directori"
+
+#: ../src/generic/dirdlgg.cpp:291 ../src/generic/dirdlgg.cpp:301
+#: ../src/generic/filectrlg.cpp:614 ../src/generic/filectrlg.cpp:623
+msgid "NewName"
+msgstr "Nou nom"
+
+#: ../src/generic/editlbox.cpp:135
+msgid "Edit item"
+msgstr ""
+
+#: ../src/generic/editlbox.cpp:143
+msgid "New item"
+msgstr ""
+
+#: ../src/generic/editlbox.cpp:151
+#, fuzzy
+msgid "Delete item"
+msgstr "&Elimina"
+
+#: ../src/generic/editlbox.cpp:159
+#, fuzzy
+msgid "Move up"
+msgstr "&Mou"
+
+#: ../src/generic/editlbox.cpp:164
+msgid "Move down"
+msgstr ""
+
+#: ../src/generic/fdrepdlg.cpp:108
+msgid "Search for:"
+msgstr "Cerca:"
+
+#: ../src/generic/fdrepdlg.cpp:120
+msgid "Replace with:"
+msgstr "Substituix amb:"
+
+#: ../src/generic/fdrepdlg.cpp:140
+msgid "Whole word"
+msgstr "Tota la paraula"
+
+#: ../src/generic/fdrepdlg.cpp:143
+msgid "Match case"
+msgstr "Coincidència exacta"
+
+#: ../src/generic/fdrepdlg.cpp:156
+msgid "Search direction"
+msgstr "Direcció de cerca"
+
+#: ../src/generic/fdrepdlg.cpp:175
+msgid "&Replace"
+msgstr "&Substituix"
+
+#: ../src/generic/fdrepdlg.cpp:178
+msgid "Replace &all"
+msgstr "Substituix-ho &tot"
+
+#: ../src/generic/filectrlg.cpp:246 ../src/generic/filectrlg.cpp:269
+msgid "<DIR>"
+msgstr "<DIR>"
+
+#: ../src/generic/filectrlg.cpp:248 ../src/generic/filectrlg.cpp:271
+msgid "<LINK>"
+msgstr "<ENLLAÇ>"
+
+#: ../src/generic/filectrlg.cpp:250 ../src/generic/filectrlg.cpp:273
+#, fuzzy
+msgid "<DRIVE>"
+msgstr "<DIR>"
+
+#: ../src/generic/filectrlg.cpp:275
+#, c-format
+msgid "%ld byte"
+msgid_plural "%ld bytes"
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../src/generic/filectrlg.cpp:420
+msgid "Name"
+msgstr "Nom"
+
+#: ../src/generic/filectrlg.cpp:421 ../src/richtext/richtextformatdlg.cpp:361
+#: ../src/richtext/richtextsizepage.cpp:298
+msgid "Size"
+msgstr "Grandària"
+
+#: ../src/generic/filectrlg.cpp:422
+#, fuzzy
+msgid "Type"
+msgstr "Teletip"
+
+#: ../src/generic/filectrlg.cpp:423
+msgid "Modified"
+msgstr ""
+
+#: ../src/generic/filectrlg.cpp:426
+msgid "Permissions"
+msgstr "Permisos"
+
+#: ../src/generic/filectrlg.cpp:429
+msgid "Attributes"
+msgstr ""
+
+#: ../src/generic/filectrlg.cpp:936
+msgid "Current directory:"
+msgstr "Directori actual:"
+
+#: ../src/generic/filectrlg.cpp:979
+#, fuzzy
+msgid "Show &hidden files"
+msgstr "Mostra fitgers ocults."
+
+#: ../src/generic/filectrlg.cpp:1355
+msgid "Illegal file specification."
+msgstr "Especificació de fitxer il·legal."
+
+#: ../src/generic/filectrlg.cpp:1387
+#, fuzzy
+msgid "Directory doesn't exist."
+msgstr "Directori no existix"
+
+#: ../src/generic/filedlgg.cpp:195
+msgid "View files as a list view"
+msgstr "Mostra fitxers com a un llistat de vista"
+
+#: ../src/generic/filedlgg.cpp:197
+msgid "View files as a detailed view"
+msgstr "Mostra els fitxers en vista detallada"
+
+#: ../src/generic/filedlgg.cpp:200
+msgid "Go to parent directory"
+msgstr "Puja un directori "
+
+#: ../src/generic/filedlgg.cpp:351 ../src/gtk/filedlg.cpp:59
+#, fuzzy, c-format
+msgid "File '%s' already exists, do you really want to overwrite it?"
+msgstr "El fitxer '%' ja existex, n'esteu segur de voleu rescriure-hi?"
+
+#: ../src/generic/filedlgg.cpp:354 ../src/gtk/filedlg.cpp:62
+msgid "Confirm"
+msgstr "Confirma"
+
+#: ../src/generic/filedlgg.cpp:362 ../src/gtk/filedlg.cpp:75
+msgid "Please choose an existing file."
+msgstr "Trieu un fitxer existent."
+
+#: ../src/generic/filepickerg.cpp:64
+#, fuzzy
+msgid "..."
+msgstr ".."
+
+#: ../src/generic/fontdlgg.cpp:76 ../src/richtext/richtextformatdlg.cpp:519
+msgid "ABCDEFGabcdefg12345"
+msgstr "ABCDEFGabcdefg12345"
+
+#: ../src/generic/fontdlgg.cpp:315
+msgid "Roman"
+msgstr "Roman"
+
+#: ../src/generic/fontdlgg.cpp:316
+msgid "Decorative"
+msgstr "Decoratiu"
+
+#: ../src/generic/fontdlgg.cpp:317
+msgid "Modern"
+msgstr "Modern"
+
+#: ../src/generic/fontdlgg.cpp:318
+msgid "Script"
+msgstr "Script"
+
+#: ../src/generic/fontdlgg.cpp:319
+msgid "Swiss"
+msgstr "Suís"
+
+#: ../src/generic/fontdlgg.cpp:320
+msgid "Teletype"
+msgstr "Teletip"
+
+#: ../src/generic/fontdlgg.cpp:321 ../src/generic/fontdlgg.cpp:324
+msgid "Normal"
+msgstr "Normal"
+
+#: ../src/generic/fontdlgg.cpp:323
+msgid "Slant"
+msgstr "Inclina"
+
+#: ../src/generic/fontdlgg.cpp:325
+msgid "Light"
+msgstr "Clar"
+
+#: ../src/generic/fontdlgg.cpp:363
+#, fuzzy
+msgid "&Font family:"
+msgstr "Grandària de la font:"
+
+#: ../src/generic/fontdlgg.cpp:367 ../src/generic/fontdlgg.cpp:369
+msgid "The font family."
+msgstr ""
+
+#: ../src/generic/fontdlgg.cpp:374 ../src/richtext/richtextstylepage.cpp:105
+msgid "&Style:"
+msgstr ""
+
+#: ../src/generic/fontdlgg.cpp:378 ../src/generic/fontdlgg.cpp:380
+msgid "The font style."
+msgstr ""
+
+#: ../src/generic/fontdlgg.cpp:385
+#, fuzzy
+msgid "&Weight:"
+msgstr "vuitè"
+
+#: ../src/generic/fontdlgg.cpp:389 ../src/generic/fontdlgg.cpp:391
+msgid "The font weight."
+msgstr ""
+
+#: ../src/generic/fontdlgg.cpp:399
+msgid "C&olour:"
+msgstr ""
+
+#: ../src/generic/fontdlgg.cpp:407 ../src/generic/fontdlgg.cpp:409
+msgid "The font colour."
+msgstr ""
+
+#: ../src/generic/fontdlgg.cpp:415
+#, fuzzy
+msgid "&Point size:"
+msgstr "Grandària de la font:"
+
+#: ../src/generic/fontdlgg.cpp:420 ../src/generic/fontdlgg.cpp:422
+#: ../src/generic/fontdlgg.cpp:426 ../src/generic/fontdlgg.cpp:428
+#, fuzzy
+msgid "The font point size."
+msgstr "Grandària de la font:"
+
+#: ../src/generic/fontdlgg.cpp:439 ../src/generic/fontdlgg.cpp:441
+msgid "Whether the font is underlined."
+msgstr ""
+
+#: ../src/generic/fontdlgg.cpp:448 ../src/html/helpwnd.cpp:1215
+msgid "Preview:"
+msgstr "Previsualització:"
+
+#: ../src/generic/fontdlgg.cpp:452 ../src/generic/fontdlgg.cpp:454
+msgid "Shows the font preview."
+msgstr ""
+
+#: ../src/generic/fontdlgg.cpp:464 ../src/generic/fontdlgg.cpp:483
+msgid "Click to cancel the font selection."
+msgstr ""
+
+#: ../src/generic/fontdlgg.cpp:469 ../src/generic/fontdlgg.cpp:471
+#: ../src/generic/fontdlgg.cpp:476 ../src/generic/fontdlgg.cpp:478
+msgid "Click to confirm the font selection."
+msgstr ""
+
+#: ../src/generic/fontpickerg.cpp:50 ../src/gtk/fontdlg.cpp:77
+msgid "Choose font"
+msgstr "Trieu la font"
+
+#: ../src/generic/grid.cpp:6542
+msgid ""
+"Error copying grid to the clipboard. Either selected cells were not "
+"contiguous or no cell was selected."
+msgstr ""
+
+#: ../src/generic/grid.cpp:12739
+msgid "Grid Corner"
+msgstr ""
+
+#: ../src/generic/grid.cpp:12741
+#, c-format
+msgid "Column %s Header"
+msgstr ""
+
+#: ../src/generic/grid.cpp:12743
+#, c-format
+msgid "Row %s Header"
+msgstr ""
+
+#: ../src/generic/grid.cpp:12745
+#, c-format
+msgid "Column %s: %s"
+msgstr ""
+
+#: ../src/generic/grid.cpp:12749
+#, c-format
+msgid "Row %s: %s"
+msgstr ""
+
+#: ../src/generic/grid.cpp:12753
+#, c-format
+msgid "Row %s, Column %s: %s"
+msgstr ""
+
+#: ../src/generic/helpext.cpp:257
+#, c-format
+msgid "Help directory \"%s\" not found."
+msgstr ""
+
+#: ../src/generic/helpext.cpp:265
+#, fuzzy, c-format
+msgid "Help file \"%s\" not found."
+msgstr "no s'ha trobat el fitxer de catàleg per al domini '%s'"
+
+#: ../src/generic/helpext.cpp:284
+#, c-format
+msgid "Line %lu of map file \"%s\" has invalid syntax, skipped."
+msgstr ""
+
+#: ../src/generic/helpext.cpp:292
+#, c-format
+msgid "No valid mappings found in the file \"%s\"."
+msgstr ""
+
+#: ../src/generic/helpext.cpp:435
+msgid "No entries found."
+msgstr "No s'ha trobat entrades."
+
+#: ../src/generic/helpext.cpp:444 ../src/generic/helpext.cpp:445
+msgid "Help Index"
+msgstr "Índex de l'ajuda"
+
+#: ../src/generic/helpext.cpp:448
+msgid "Relevant entries:"
+msgstr "Entrades rellevants:"
+
+#: ../src/generic/helpext.cpp:449
+msgid "Entries found"
+msgstr "Entrades trobades:"
+
+#: ../src/generic/hyperlinkg.cpp:170
+#, fuzzy
+msgid "&Copy URL"
+msgstr "&Copia"
+
+#: ../src/generic/infobar.cpp:119
+msgid "Hide this notification message."
+msgstr ""
+
+#. TRANSLATORS: %s will be either the application name or "Application"
+#: ../src/generic/logg.cpp:257
+#, c-format
+msgid "%s Error"
+msgstr "Error %s"
+
+#. TRANSLATORS: %s will be either the application name or "Application"
+#: ../src/generic/logg.cpp:263
+#, c-format
+msgid "%s Warning"
+msgstr "Atenció %s"
+
+#. TRANSLATORS: %s will be either the application name or "Application"
+#: ../src/generic/logg.cpp:273
+#, c-format
+msgid "%s Information"
+msgstr "Informació %s"
+
+#: ../src/generic/logg.cpp:276
+#, fuzzy
+msgid "Application"
+msgstr "Seccions"
+
+#: ../src/generic/logg.cpp:549
+msgid "Save log contents to file"
+msgstr "Alça els continguts del registre al fitxer"
+
+#: ../src/generic/logg.cpp:551
+msgid "C&lear"
+msgstr "&Neteja"
+
+#: ../src/generic/logg.cpp:551
+msgid "Clear the log contents"
+msgstr "Neteja els continguts del registre."
+
+#: ../src/generic/logg.cpp:553
+msgid "Close this window"
+msgstr "Tanca esta finestra"
+
+#: ../src/generic/logg.cpp:554
+msgid "&Log"
+msgstr "&Registre"
+
+#: ../src/generic/logg.cpp:610 ../src/generic/logg.cpp:992
+msgid "Can't save log contents to file."
+msgstr "No es pot alçar els continguts de registre al fitxer."
+
+#: ../src/generic/logg.cpp:613
+#, c-format
+msgid "Log saved to the file '%s'."
+msgstr "Registre alçat en el fitxer '%s'."
+
+#: ../src/generic/logg.cpp:719
+msgid "&Details"
+msgstr "&Detalls"
+
+#: ../src/generic/logg.cpp:972
+#, fuzzy
+msgid "Failed to copy dialog contents to the clipboard."
+msgstr "No s'ha pogut obrir el porta-retalls"
+
+#: ../src/generic/logg.cpp:1022
+#, c-format
+msgid "Append log to file '%s' (choosing [No] will overwrite it)?"
+msgstr ""
+"Afig el registre al fitxer '%s' (escollir [No] sobrescriurà el fitxer)?"
+
+#: ../src/generic/logg.cpp:1024
+msgid "Question"
+msgstr "Pregunta"
+
+#: ../src/generic/logg.cpp:1038
+msgid "invalid message box return value"
+msgstr "valor de retorn de la caixa de missatges invàlid"
+
+#: ../src/generic/notifmsgg.cpp:129
+#, fuzzy
+msgid "Notice"
+msgstr "No"
+
+#: ../src/generic/preferencesg.cpp:118
+#, c-format
+msgid "%s Preferences"
+msgstr ""
+
+#: ../src/generic/printps.cpp:143
+msgid "Printing..."
+msgstr "S'està imprimint..."
+
+#: ../src/generic/printps.cpp:160 ../src/gtk/print.cpp:1076
+#: ../src/msw/printwin.cpp:235
+msgid "Could not start printing."
+msgstr "No s'ha pogut iniciar la impressió"
+
+#: ../src/generic/printps.cpp:183
+#, c-format
+msgid "Printing page %d..."
+msgstr "S'està imprimint la pàgina %d..."
+
+#: ../src/generic/prntdlgg.cpp:171
+msgid "Printer options"
+msgstr "Opcions d'impressió"
+
+#: ../src/generic/prntdlgg.cpp:176
+msgid "Print to File"
+msgstr "Imprimix al fitxer"
+
+#: ../src/generic/prntdlgg.cpp:179
+msgid "Setup..."
+msgstr "Configura..."
+
+#: ../src/generic/prntdlgg.cpp:187
+#, fuzzy
+msgid "Printer:"
+msgstr "Impressió..."
+
+#: ../src/generic/prntdlgg.cpp:195
+#, fuzzy
+msgid "Status:"
+msgstr "Estat:"
+
+#: ../src/generic/prntdlgg.cpp:206
+msgid "All"
+msgstr "Tot"
+
+#: ../src/generic/prntdlgg.cpp:207
+msgid "Pages"
+msgstr "Pàgines"
+
+#: ../src/generic/prntdlgg.cpp:215
+msgid "Print Range"
+msgstr "Rang d'impressió"
+
+#: ../src/generic/prntdlgg.cpp:229
+msgid "From:"
+msgstr "De:"
+
+#: ../src/generic/prntdlgg.cpp:233
+msgid "To:"
+msgstr "Per a:"
+
+#: ../src/generic/prntdlgg.cpp:238
+msgid "Copies:"
+msgstr "Còpies:"
+
+#: ../src/generic/prntdlgg.cpp:288
+msgid "PostScript file"
+msgstr "Fitxer PostScript"
+
+#: ../src/generic/prntdlgg.cpp:439
+msgid "Print Setup"
+msgstr "Paràmetres d'impressió"
+
+#: ../src/generic/prntdlgg.cpp:483
+#, fuzzy
+msgid "Printer"
+msgstr "Imprimix"
+
+#: ../src/generic/prntdlgg.cpp:501
+#, fuzzy
+msgid "Default printer"
+msgstr "Codificació predeterminada"
+
+#: ../src/generic/prntdlgg.cpp:595 ../src/generic/prntdlgg.cpp:782
+#: ../src/generic/prntdlgg.cpp:822 ../src/generic/prntdlgg.cpp:835
+#: ../src/generic/prntdlgg.cpp:1031 ../src/generic/prntdlgg.cpp:1036
+msgid "Paper size"
+msgstr "Grandària del paper"
+
+#: ../src/generic/prntdlgg.cpp:604 ../src/generic/prntdlgg.cpp:847
+msgid "Portrait"
+msgstr "Vertical"
+
+#: ../src/generic/prntdlgg.cpp:605 ../src/generic/prntdlgg.cpp:848
+msgid "Landscape"
+msgstr "Apaïsat"
+
+#: ../src/generic/prntdlgg.cpp:607 ../src/generic/prntdlgg.cpp:849
+msgid "Orientation"
+msgstr "Orientació"
+
+#: ../src/generic/prntdlgg.cpp:610
+msgid "Options"
+msgstr "Opcions"
+
+#: ../src/generic/prntdlgg.cpp:612
+msgid "Print in colour"
+msgstr "Imprimix en color"
+
+#: ../src/generic/prntdlgg.cpp:621
+msgid "Print spooling"
+msgstr "Cua d'impressió"
+
+#: ../src/generic/prntdlgg.cpp:623
+msgid "Printer command:"
+msgstr "Orde d'impressió"
+
+#: ../src/generic/prntdlgg.cpp:631
+msgid "Printer options:"
+msgstr "Opcions d'impressió:"
+
+#: ../src/generic/prntdlgg.cpp:860
+msgid "Left margin (mm):"
+msgstr "Marge esquerra (mm):"
+
+#: ../src/generic/prntdlgg.cpp:861
+msgid "Top margin (mm):"
+msgstr "Marge superior (mm):"
+
+#: ../src/generic/prntdlgg.cpp:872
+msgid "Right margin (mm):"
+msgstr "Marge dret (mm):"
+
+#: ../src/generic/prntdlgg.cpp:873
+msgid "Bottom margin (mm):"
+msgstr "Marge inferior (mm):"
+
+#: ../src/generic/prntdlgg.cpp:896
+msgid "Printer..."
+msgstr "Impressió..."
+
+#: ../src/generic/progdlgg.cpp:246
+#, fuzzy
+msgid "&Skip"
+msgstr "Script"
+
+#: ../src/generic/progdlgg.cpp:347 ../src/generic/progdlgg.cpp:626
+#, fuzzy
+msgid "Unknown"
+msgstr "desconegut"
+
+#: ../src/generic/progdlgg.cpp:451 ../src/msw/progdlg.cpp:526
+msgid "Done."
+msgstr "Fet."
+
+#: ../src/generic/srchctlg.cpp:55 ../src/gtk/srchctrl.cpp:206
+#: ../src/html/helpwnd.cpp:530 ../src/html/helpwnd.cpp:545
+msgid "Search"
+msgstr "Cerca"
+
+#: ../src/generic/tabg.cpp:1026
+msgid "Could not find tab for id"
+msgstr "No es pot trobar la pestanya per a id"
+
+#: ../src/generic/tipdlg.cpp:136
+msgid "Tips not available, sorry!"
+msgstr "Els consells no es troben disponibles!"
+
+#: ../src/generic/tipdlg.cpp:197
+msgid "Tip of the Day"
+msgstr "Consell del dia"
+
+#: ../src/generic/tipdlg.cpp:207
+msgid "Did you know..."
+msgstr "Sabíeu que..."
+
+#: ../src/generic/tipdlg.cpp:232
+msgid "&Show tips at startup"
+msgstr "&Mostra els consells al començar"
+
+#: ../src/generic/tipdlg.cpp:236
+msgid "&Next Tip"
+msgstr "Consell &següent"
+
+#: ../src/generic/wizard.cpp:411
+msgid "&Next >"
+msgstr "&Següent >"
+
+#: ../src/generic/wizard.cpp:412
+msgid "&Finish"
+msgstr "&Fi"
+
+#: ../src/generic/wizard.cpp:420
+msgid "< &Back"
+msgstr "< &Enrere"
+
+#: ../src/gtk/aboutdlg.cpp:204
+msgid "translator-credits"
+msgstr ""
+
+#: ../src/gtk/app.cpp:517
+msgid ""
+"WARNING: using XIM input method is unsupported and may result in problems "
+"with input handling and flickering. Consider unsetting GTK_IM_MODULE or "
+"setting to \"ibus\"."
+msgstr ""
+
+#: ../src/gtk/app.cpp:569
+msgid "Unable to initialize GTK+, is DISPLAY set properly?"
+msgstr ""
+
+#: ../src/gtk/filedlg.cpp:89 ../src/gtk/filepicker.cpp:255
+#, fuzzy, c-format
+msgid "Changing current directory to \"%s\" failed"
+msgstr "No s'ha pogut crear un directori %s/.gnome."
+
+#: ../src/gtk/font.cpp:548
+msgid ""
+"Using private fonts is not supported on this system: Pango library is too "
+"old, 1.38 or later required."
+msgstr ""
+
+#: ../src/gtk/font.cpp:558
+#, fuzzy
+msgid "Failed to create font configuration object."
+msgstr "no es pot obrir el fitxer de configuració de l'usuari."
+
+#: ../src/gtk/font.cpp:568
+#, fuzzy, c-format
+msgid "Failed to add custom font \"%s\"."
+msgstr "No s'ha pogut carregar la imatge %d des del fitxer '%s'."
+
+#: ../src/gtk/font.cpp:576
+#, fuzzy
+msgid "Failed to register font configuration using private fonts."
+msgstr "no es pot obrir el fitxer de configuració de l'usuari."
+
+#: ../src/gtk/glcanvas.cpp:117 ../src/gtk/glcanvas.cpp:132
+#, fuzzy
+msgid "Fatal Error"
+msgstr "Error fatal"
+
+#: ../src/gtk/glcanvas.cpp:117
+msgid ""
+"This program wasn't compiled with EGL support required under Wayland, "
+"either\n"
+"install EGL libraries and rebuild or run it under X11 backend by setting\n"
+"environment variable GDK_BACKEND=x11 before starting your program."
+msgstr ""
+
+#: ../src/gtk/glcanvas.cpp:132
+msgid ""
+"wxGLCanvas is only supported on Wayland and X11 currently.  You may be able "
+"to\n"
+"work around this by setting environment variable GDK_BACKEND=x11 before\n"
+"starting your program."
+msgstr ""
+
+#: ../src/gtk/mdi.cpp:433
+msgid "MDI child"
+msgstr "MDI fill"
+
+#: ../src/gtk/power.cpp:188
+#, fuzzy, c-format
+msgid "Failed to open D-Bus connection to the login manager: %s"
+msgstr "No s'ha pogut %s a la connexió de marcatge directe: %s"
+
+#: ../src/gtk/power.cpp:214
+#, fuzzy
+msgid "wxWidgets application"
+msgstr "Seccions"
+
+#: ../src/gtk/power.cpp:226
+msgid "Application needs to keep running"
+msgstr ""
+
+#: ../src/gtk/power.cpp:233
+msgid "Clean up before suspend"
+msgstr ""
+
+#: ../src/gtk/power.cpp:259
+#, fuzzy, c-format
+msgid "Failed to inhibit sleep: %s"
+msgstr "No s'ha pogut acabar la connexió de marcatge directe: %s"
+
+#: ../src/gtk/power.cpp:265
+msgid "Unexpected response to D-Bus \"Inhibit\" request."
+msgstr ""
+
+#: ../src/gtk/print.cpp:218
+#, fuzzy
+msgid "Custom size"
+msgstr "Grandària de la font:"
+
+#: ../src/gtk/print.cpp:752
+#, fuzzy, c-format
+msgid "Error while printing: %s"
+msgstr "Espereu mentre simprimix\n"
+
+#: ../src/gtk/print.cpp:816
+msgid "Page Setup"
+msgstr "Configuració de la pàgina"
+
+#: ../src/gtk/webview_webkit.cpp:932
+msgid "Retrieving JavaScript script output is not supported with WebKit v1"
+msgstr ""
+
+#: ../src/gtk/webview_webkit2.cpp:1098
+msgid ""
+"Setting proxy is not supported by WebKit, at least version 2.16 is required."
+msgstr ""
+
+#: ../src/gtk/webview_webkit2.cpp:1104
+msgid "This program was compiled without support for setting WebKit proxy."
+msgstr ""
+
+#: ../src/gtk/window.cpp:6289
+msgid ""
+"GTK+ installed on this machine is too old to support screen compositing, "
+"please install GTK+ 2.12 or later."
+msgstr ""
+
+#: ../src/gtk/window.cpp:6307
+msgid ""
+"Compositing not supported by this system, please enable it in your Window "
+"Manager."
+msgstr ""
+
+#: ../src/gtk/window.cpp:6318
+msgid ""
+"This program was compiled with a too old version of GTK+, please rebuild "
+"with GTK+ 2.12 or newer."
+msgstr ""
+
+#: ../src/html/chm.cpp:138
+#, fuzzy, c-format
+msgid "Failed to open CHM archive '%s'."
+msgstr "No s'ha pogut obrir '%s' per %s"
+
+#: ../src/html/chm.cpp:270
+#, c-format
+msgid "Could not extract %s into %s: %s"
+msgstr ""
+
+#: ../src/html/chm.cpp:324
+#, fuzzy
+msgid "no error"
+msgstr "error desconegut"
+
+#: ../src/html/chm.cpp:326
+msgid "bad arguments to library function"
+msgstr ""
+
+#: ../src/html/chm.cpp:328
+#, fuzzy
+msgid "error opening file"
+msgstr "Error en llegir el fitxer '%s'"
+
+#: ../src/html/chm.cpp:330
+#, fuzzy
+msgid "read error"
+msgstr "Error de fitxer"
+
+#: ../src/html/chm.cpp:332
+#, fuzzy
+msgid "write error"
+msgstr "Error de fitxer"
+
+#: ../src/html/chm.cpp:334
+#, fuzzy
+msgid "seek error"
+msgstr "Error de fitxer"
+
+#: ../src/html/chm.cpp:338
+msgid "bad signature"
+msgstr ""
+
+#: ../src/html/chm.cpp:340
+#, fuzzy
+msgid "error in data format"
+msgstr "IFF: error en format d'imatge IFF."
+
+#: ../src/html/chm.cpp:342
+msgid "checksum error"
+msgstr ""
+
+#: ../src/html/chm.cpp:344
+msgid "compression error"
+msgstr ""
+
+#: ../src/html/chm.cpp:346
+msgid "decompression error"
+msgstr ""
+
+#: ../src/html/chm.cpp:437
+#, fuzzy, c-format
+msgid "Could not locate file '%s'."
+msgstr "No es pot obrir el fitxer '%s'."
+
+#: ../src/html/chm.cpp:711
+#, fuzzy, c-format
+msgid "Could not create temporary file '%s'"
+msgstr "no es pot extreure el fitxer temporal '%s'"
+
+#: ../src/html/chm.cpp:718
+#, fuzzy, c-format
+msgid "Extraction of '%s' into '%s' failed."
+msgstr "L'execució de l'orde '%s' ha fallit."
+
+#: ../src/html/chm.cpp:806 ../src/html/chm.cpp:863
+#, fuzzy
+msgid "CHM handler currently supports only local files!"
+msgstr "El manegador ZIP generalment només permet l'ús de fitxers locals!"
+
+#: ../src/html/chm.cpp:827
+msgid "Link contained '//', converted to absolute link."
+msgstr ""
+
+#: ../src/html/helpctrl.cpp:59
+#, c-format
+msgid "Help: %s"
+msgstr "Ajuda: %s"
+
+#: ../src/html/helpctrl.cpp:155
+#, c-format
+msgid "Adding book %s"
+msgstr "S'està afegint el llibre %s"
+
+#: ../src/html/helpdata.cpp:295
+#, c-format
+msgid "Cannot open contents file: %s"
+msgstr "No es pot obrir fitxers de contingut: %s"
+
+#: ../src/html/helpdata.cpp:309
+#, c-format
+msgid "Cannot open index file: %s"
+msgstr "No es pot obrir el fitxer d'índex: %s"
+
+#: ../src/html/helpdata.cpp:643
+msgid "noname"
+msgstr "sense nom"
+
+#: ../src/html/helpdata.cpp:652
+#, c-format
+msgid "Cannot open HTML help book: %s"
+msgstr "No es pot obrir el llibre d'ajuda HTML: %s"
+
+#: ../src/html/helpwnd.cpp:315
+msgid "Displays help as you browse the books on the left."
+msgstr ""
+
+#: ../src/html/helpwnd.cpp:411 ../src/html/helpwnd.cpp:1100
+#: ../src/html/helpwnd.cpp:1735
+msgid "(bookmarks)"
+msgstr "(preferits)"
+
+#: ../src/html/helpwnd.cpp:424
+msgid "Add current page to bookmarks"
+msgstr "Afig la pàgina actual a preferits"
+
+#: ../src/html/helpwnd.cpp:425
+msgid "Remove current page from bookmarks"
+msgstr "Extreu la pàgina actual dels preferits"
+
+#: ../src/html/helpwnd.cpp:470
+msgid "Contents"
+msgstr "Contingut"
+
+#: ../src/html/helpwnd.cpp:485
+msgid "Find"
+msgstr "Cerca"
+
+#: ../src/html/helpwnd.cpp:487
+msgid "Show all"
+msgstr "Mostra-ho tot"
+
+#: ../src/html/helpwnd.cpp:497
+msgid ""
+"Display all index items that contain given substring. Search is case "
+"insensitive."
+msgstr ""
+"Mostra tots els elements de l'índex que continguin la subcadena donada. La "
+"recerca no distingix majúscules de minúscules."
+
+#: ../src/html/helpwnd.cpp:498
+msgid "Show all items in index"
+msgstr "Mostra tots els elements en el índex"
+
+#: ../src/html/helpwnd.cpp:528
+msgid "Case sensitive"
+msgstr "Distingix entre majúscules i minúscules"
+
+#: ../src/html/helpwnd.cpp:529
+msgid "Whole words only"
+msgstr "Només paraules senceres"
+
+#: ../src/html/helpwnd.cpp:532
+#, fuzzy
+msgid ""
+"Search contents of help book(s) for all occurrences of the text you typed "
+"above"
+msgstr ""
+"Cerqueu continguts en llibre(s) d'ajuda per totes les ocurrències del text "
+"escrit"
+
+#: ../src/html/helpwnd.cpp:653
+msgid "Show/hide navigation panel"
+msgstr "Mostra/amaga el plafó de navegació"
+
+#: ../src/html/helpwnd.cpp:655
+msgid "Go back"
+msgstr "Vés arrere"
+
+#: ../src/html/helpwnd.cpp:656
+msgid "Go forward"
+msgstr "Vés avant"
+
+#: ../src/html/helpwnd.cpp:658
+msgid "Go one level up in document hierarchy"
+msgstr "Puja un nivell de la jerarquia del document."
+
+#: ../src/html/helpwnd.cpp:666 ../src/html/helpwnd.cpp:1547
+msgid "Open HTML document"
+msgstr "Obri document HTML"
+
+#: ../src/html/helpwnd.cpp:670
+msgid "Print this page"
+msgstr "Imprimix esta pàgina"
+
+#: ../src/html/helpwnd.cpp:674
+msgid "Display options dialog"
+msgstr "Mostra les opcions del diàleg"
+
+#: ../src/html/helpwnd.cpp:795
+#, fuzzy
+msgid "Please choose the page to display:"
+msgstr "Trieu un fitxer existent."
+
+#: ../src/html/helpwnd.cpp:796
+#, fuzzy
+msgid "Help Topics"
+msgstr "Ajuda: %s"
+
+#: ../src/html/helpwnd.cpp:852
+msgid "Searching..."
+msgstr "S'està cercant..."
+
+#: ../src/html/helpwnd.cpp:853
+msgid "No matching page found yet"
+msgstr "Encara no s'ha trobat cap pàgina que coincidisca"
+
+#: ../src/html/helpwnd.cpp:870
+#, c-format
+msgid "Found %i matches"
+msgstr "S'han trobat %i coincidències"
+
+#: ../src/html/helpwnd.cpp:958
+msgid "(Help)"
+msgstr "(Ajuda)"
+
+#: ../src/html/helpwnd.cpp:1026
+#, fuzzy, c-format
+msgid "%d of %lu"
+msgstr "%d de %lu"
+
+#: ../src/html/helpwnd.cpp:1028
+#, fuzzy, c-format
+msgid "%lu of %lu"
+msgstr "%lu de %lu"
+
+#: ../src/html/helpwnd.cpp:1047
+msgid "Search in all books"
+msgstr "Cerca a tots els llibres"
+
+#: ../src/html/helpwnd.cpp:1193
+msgid "Help Browser Options"
+msgstr "Opcions d'ajuda del navegador"
+
+#: ../src/html/helpwnd.cpp:1198
+msgid "Normal font:"
+msgstr "Font normal"
+
+#: ../src/html/helpwnd.cpp:1199
+msgid "Fixed font:"
+msgstr "Font fixada:"
+
+#: ../src/html/helpwnd.cpp:1200
+msgid "Font size:"
+msgstr "Grandària de la font:"
+
+#: ../src/html/helpwnd.cpp:1245
+#, fuzzy
+msgid "font size"
+msgstr "Grandària de la font:"
+
+#: ../src/html/helpwnd.cpp:1256
+msgid "Normal face<br>and <u>underlined</u>. "
+msgstr ""
+
+#: ../src/html/helpwnd.cpp:1257
+msgid "<i>Italic face.</i> "
+msgstr ""
+
+#: ../src/html/helpwnd.cpp:1258
+msgid "<b>Bold face.</b> "
+msgstr ""
+
+#: ../src/html/helpwnd.cpp:1259
+msgid "<b><i>Bold italic face.</i></b><br>"
+msgstr ""
+
+#: ../src/html/helpwnd.cpp:1262
+msgid "Fixed size face.<br> <b>bold</b> <i>italic</i> "
+msgstr ""
+
+#: ../src/html/helpwnd.cpp:1263
+msgid "<b><i>bold italic <u>underlined</u></i></b><br>"
+msgstr ""
+
+#: ../src/html/helpwnd.cpp:1524
+msgid "Help Printing"
+msgstr "Ajuda de la impressió"
+
+#: ../src/html/helpwnd.cpp:1527
+msgid "Cannot print empty page."
+msgstr "No es pot imprimir una pàgina buida."
+
+#: ../src/html/helpwnd.cpp:1540
+msgid "HTML files (*.html;*.htm)|*.html;*.htm|"
+msgstr ""
+
+#: ../src/html/helpwnd.cpp:1541
+msgid "Help books (*.htb)|*.htb|Help books (*.zip)|*.zip|"
+msgstr ""
+
+#: ../src/html/helpwnd.cpp:1542
+msgid "HTML Help Project (*.hhp)|*.hhp|"
+msgstr ""
+
+#: ../src/html/helpwnd.cpp:1544
+msgid "Compressed HTML Help file (*.chm)|*.chm|"
+msgstr ""
+
+#: ../src/html/helpwnd.cpp:1671
+#, fuzzy, c-format
+msgid "%i of %u"
+msgstr "%i de %u"
+
+#: ../src/html/helpwnd.cpp:1709
+#, fuzzy, c-format
+msgid "%u of %u"
+msgstr "%u de %u"
+
+#: ../src/html/htmlfilt.cpp:134
+#, c-format
+msgid "Cannot open HTML document: %s"
+msgstr "No es pot obrir el document HTML %s"
+
+#: ../src/html/htmlwin.cpp:599
+msgid "Connecting..."
+msgstr "S'està connectant"
+
+#: ../src/html/htmlwin.cpp:616
+#, c-format
+msgid "Unable to open requested HTML document: %s"
+msgstr "No és possible obrir el document HTML sol·licitat: %s"
+
+#: ../src/html/htmlwin.cpp:630
+msgid "Loading : "
+msgstr "S'està carregant:"
+
+#: ../src/html/htmlwin.cpp:673
+msgid "Done"
+msgstr "Fet"
+
+#: ../src/html/htmlwin.cpp:723
+#, fuzzy, c-format
+msgid "HTML anchor %s does not exist."
+msgstr "L'ancoratge de l'HTML no existix."
+
+#: ../src/html/htmlwin.cpp:1057
+#, fuzzy, c-format
+msgid "Copied to clipboard:\"%s\""
+msgstr "No s'ha pogut fixar les dades del porta-retalls"
+
+#: ../src/html/htmprint.cpp:269
+msgid ""
+"This document doesn't fit on the page horizontally and will be truncated "
+"when it is printed."
+msgstr ""
+
+#: ../src/html/htmprint.cpp:285
+#, c-format
+msgid ""
+"The document \"%s\" doesn't fit on the page horizontally and will be "
+"truncated if printed.\n"
+"\n"
+"Would you like to proceed with printing it nevertheless?"
+msgstr ""
+
+#: ../src/html/htmprint.cpp:296
+msgid ""
+"If possible, try changing the layout parameters to make the printout more "
+"narrow."
+msgstr ""
+
+#: ../src/html/htmprint.cpp:445
+msgid ": file does not exist!"
+msgstr ": fitxer no existix!"
+
+#. TRANSLATORS: %s may be a document title.
+#: ../src/html/htmprint.cpp:717
+#, fuzzy, c-format
+msgid "%s Preview"
+msgstr " Previsualitza"
+
+#: ../src/html/htmprint.cpp:755 ../src/richtext/richtextprint.cpp:618
+msgid ""
+"There was a problem during page setup: you may need to set a default printer."
+msgstr ""
+"Hi ha hagut un problema durant l'actualització de la pàgina: potser caldrà "
+"establir la impressora predeterminada."
+
+#: ../src/msw/clipbrd.cpp:80
+msgid "Failed to open the clipboard."
+msgstr "No s'ha pogut obrir el porta-retalls"
+
+#: ../src/msw/clipbrd.cpp:101
+msgid "Failed to close the clipboard."
+msgstr "No s'ha pogut tancar el porta-retalls"
+
+#: ../src/msw/clipbrd.cpp:113
+msgid "Failed to empty the clipboard."
+msgstr "No s'ha pogut buidar el porta-retalls"
+
+#: ../src/msw/clipbrd.cpp:284
+msgid "Failed to put data on the clipboard"
+msgstr "No s'ha pogut posar dades al porta-retalls"
+
+#: ../src/msw/clipbrd.cpp:326
+msgid "Failed to get data from the clipboard"
+msgstr "No s'ha pogut obtenir les dades del porta-retalls"
+
+#: ../src/msw/clipbrd.cpp:363
+msgid "Failed to retrieve the supported clipboard formats"
+msgstr "No s'ha pogut recuperar els formats suportats del porta-retalls."
+
+#: ../src/msw/colordlg.cpp:228
+#, fuzzy, c-format
+msgid "Colour selection dialog failed with error %0lx."
+msgstr "L'execució de l'orde '%s' ha fallit."
+
+#: ../src/msw/cursor.cpp:141
+#, fuzzy
+msgid "Failed to create cursor."
+msgstr "No s'ha pogut crear una barra d'estat."
+
+#: ../src/msw/dde.cpp:279
+#, c-format
+msgid "Failed to register DDE server '%s'"
+msgstr "No es pot registrar el servidor DDE '%s'"
+
+#: ../src/msw/dde.cpp:300
+#, c-format
+msgid "Failed to unregister DDE server '%s'"
+msgstr "No s'ha pogut desenregistrar el servidor DDE '%s'"
+
+#: ../src/msw/dde.cpp:428
+#, c-format
+msgid "Failed to create connection to server '%s' on topic '%s'"
+msgstr "No s'ha pogut crear una connexió en el servidor '%s' en el tema '%s'"
+
+#: ../src/msw/dde.cpp:655
+msgid "DDE poke request failed"
+msgstr "Sol·licitud de DDE poke fallida"
+
+#: ../src/msw/dde.cpp:674
+msgid "Failed to establish an advise loop with DDE server"
+msgstr "No s'ha pogut establir un bucle d'avís amb el servidor DDE"
+
+#: ../src/msw/dde.cpp:693
+msgid "Failed to terminate the advise loop with DDE server"
+msgstr "No s'ha pogut acabar el bucle d'avís amb el servidor DDE."
+
+#: ../src/msw/dde.cpp:768
+msgid "Failed to send DDE advise notification"
+msgstr "No s'ha pogut enviar una notificació d'avís DDE"
+
+#: ../src/msw/dde.cpp:1085
+msgid "Failed to create DDE string"
+msgstr "No s'ha pogut crear una cadena DDE"
+
+#: ../src/msw/dde.cpp:1131
+msgid "no DDE error."
+msgstr "no hi ha error DDE."
+
+#: ../src/msw/dde.cpp:1135
+msgid "a request for a synchronous advise transaction has timed out."
+msgstr ""
+"una sol·licitud per a una transacció d'avís síncrona ha excedit el temps"
+
+#: ../src/msw/dde.cpp:1138
+msgid "the response to the transaction caused the DDE_FBUSY bit to be set."
+msgstr ""
+"la resposta a la transacció causada per la DDE_FBUSY s'ha de fixar una mica."
+
+#: ../src/msw/dde.cpp:1141
+msgid "a request for a synchronous data transaction has timed out."
+msgstr ""
+"una sol·licitud per a una transacció de dades síncrona ha excedit el temps"
+
+#: ../src/msw/dde.cpp:1144
+msgid ""
+"a DDEML function was called without first calling the DdeInitialize "
+"function,\n"
+"or an invalid instance identifier\n"
+"was passed to a DDEML function."
+msgstr ""
+"s'ha cridat una funció DDEML sense cridar primer la funció DdeInitialize,\n"
+"o un identificador invàlid d'instància\n"
+"ha passat a funció DDEML."
+
+#: ../src/msw/dde.cpp:1147
+msgid ""
+"an application initialized as APPCLASS_MONITOR has\n"
+"attempted to perform a DDE transaction,\n"
+"or an application initialized as APPCMD_CLIENTONLY has \n"
+"attempted to perform server transactions."
+msgstr ""
+"una aplicació començada com a APPCLASS_MONITOR ha\n"
+"intentat fer una transacció DDE,\n"
+"o bé una aplicació començada com a APPCMD_CLIENTONLY ha \n"
+"intentat fer transaccions de servidor."
+
+#: ../src/msw/dde.cpp:1150
+msgid "a request for a synchronous execute transaction has timed out."
+msgstr ""
+"una sol·licitud per a una transacció síncrona per a executar ha excedit el "
+"temps"
+
+#: ../src/msw/dde.cpp:1153
+msgid "a parameter failed to be validated by the DDEML."
+msgstr "un paràmetre ha fallat per ser validat pel DDEML"
+
+#: ../src/msw/dde.cpp:1156
+msgid "a DDEML application has created a prolonged race condition."
+msgstr "una aplicació DDEML ha creat una condició estreta prolongada."
+
+#: ../src/msw/dde.cpp:1159
+msgid "a memory allocation failed."
+msgstr "ha fallat una assignació de memòria"
+
+#: ../src/msw/dde.cpp:1162
+msgid "a client's attempt to establish a conversation has failed."
+msgstr "Un client que intentava establir una connexió ha fallit."
+
+#: ../src/msw/dde.cpp:1165
+msgid "a transaction failed."
+msgstr "ha fallat una transacció"
+
+#: ../src/msw/dde.cpp:1168
+msgid "a request for a synchronous poke transaction has timed out."
+msgstr "una sol·licitud per a una transacció poke ha excedit el temps"
+
+#: ../src/msw/dde.cpp:1171
+msgid "an internal call to the PostMessage function has failed. "
+msgstr "ha fallat una trucada interna cap a la funció PostMessage"
+
+#: ../src/msw/dde.cpp:1174
+msgid "reentrancy problem."
+msgstr "problema de reentrada."
+
+#: ../src/msw/dde.cpp:1177
+msgid ""
+"a server-side transaction was attempted on a conversation\n"
+"that was terminated by the client, or the server\n"
+"terminated before completing a transaction."
+msgstr ""
+"s'ha intentat una conversació de servidor lateral\n"
+"que ha acabat amb el client, o el servidor\n"
+"abans de completar una transacció."
+
+#: ../src/msw/dde.cpp:1180
+msgid "an internal error has occurred in the DDEML."
+msgstr "Hi ha hagut un error intern en el DDEML."
+
+#: ../src/msw/dde.cpp:1183
+msgid "a request to end an advise transaction has timed out."
+msgstr ""
+"una sol·licitud per finalitzar un avís de transacció s'ha excedit en el "
+"temps."
+
+#: ../src/msw/dde.cpp:1186
+msgid ""
+"an invalid transaction identifier was passed to a DDEML function.\n"
+"Once the application has returned from an XTYP_XACT_COMPLETE callback,\n"
+"the transaction identifier for that callback is no longer valid."
+msgstr ""
+"s'ha passat a función DDEML un identificador de transacció no vàlid.\n"
+"un cop que l'aplicació ha tornat d'una trucada XTYP_XACT_COMPLETE, \n"
+"l'identificador de transacció d'esta trucada ja no és vàlid."
+
+#: ../src/msw/dde.cpp:1189
+#, c-format
+msgid "Unknown DDE error %08x"
+msgstr "Error DDE desconegut %08x"
+
+#: ../src/msw/dialup.cpp:343
+msgid ""
+"Dial up functions are unavailable because the remote access service (RAS) is "
+"not installed on this machine. Please install it."
+msgstr ""
+"Les funcions de marcatge directe no es troben disponibles ja que el servici "
+"d'accés remot (RAS) no es troba instal·lat en este maquinari. Reinstal·leu-"
+"ho."
+
+#: ../src/msw/dialup.cpp:402
+#, fuzzy, c-format
+msgid ""
+"The version of remote access service (RAS) installed on this machine is too "
+"old, please upgrade (the following required function is missing: %s)."
+msgstr ""
+"La versió d'accés remot al servici (RAS) instal·lada en este maquinari és "
+"\"tooold\", l'hauríeu d'actualitzar (la següent funció sol·licitada s'ha "
+"passat per alt: %s)."
+
+#: ../src/msw/dialup.cpp:437
+msgid "Failed to retrieve text of RAS error message"
+msgstr "No s'ha pogut recuperar el text del missatge d'error RAS"
+
+#: ../src/msw/dialup.cpp:440
+#, c-format
+msgid "unknown error (error code %08x)."
+msgstr "error desconegut (error de codi %08x)."
+
+#: ../src/msw/dialup.cpp:492
+#, c-format
+msgid "Cannot find active dialup connection: %s"
+msgstr "No es pot trobar connexió activa de marcatge directe: %s"
+
+#: ../src/msw/dialup.cpp:513
+msgid "Several active dialup connections found, choosing one randomly."
+msgstr ""
+"S'han triat diverses connexions de marcatge directe, triant-ne una "
+"aleatòriament."
+
+#: ../src/msw/dialup.cpp:598 ../src/msw/dialup.cpp:832
+#, c-format
+msgid "Failed to establish dialup connection: %s"
+msgstr "No s'ha pogut establir la connexió: %s"
+
+#: ../src/msw/dialup.cpp:664
+#, c-format
+msgid "Failed to get ISP names: %s"
+msgstr "No s'han pogut obtenir els noms ISP: %s"
+
+#: ../src/msw/dialup.cpp:712
+msgid "Failed to connect: no ISP to dial."
+msgstr "No s'ha pogut connectar: no hi ha cap ISP a trucar."
+
+#: ../src/msw/dialup.cpp:732
+msgid "Choose ISP to dial"
+msgstr "Trieu l'ISP a trucar"
+
+#: ../src/msw/dialup.cpp:733
+msgid "Please choose which ISP do you want to connect to"
+msgstr "Trieu quin ISP us voleu connectar"
+
+#: ../src/msw/dialup.cpp:766
+msgid "Failed to connect: missing username/password."
+msgstr "Connexió fallida:  hi manca el nom d'usuari o la contrasenya."
+
+#: ../src/msw/dialup.cpp:796
+msgid "Cannot find the location of address book file"
+msgstr "No es pot localitzar el fitxer del llibre d'adreces"
+
+#: ../src/msw/dialup.cpp:827
+#, fuzzy, c-format
+msgid "Failed to initiate dialup connection: %s"
+msgstr "No s'ha pogut acabar la connexió de marcatge directe: %s"
+
+#: ../src/msw/dialup.cpp:897
+msgid "Cannot hang up - no active dialup connection."
+msgstr "No es pot penjar - no hi ha activa cap connexió de marcatge directe."
+
+#: ../src/msw/dialup.cpp:907
+#, c-format
+msgid "Failed to terminate the dialup connection: %s"
+msgstr "No s'ha pogut acabar la connexió de marcatge directe: %s"
+
+#: ../src/msw/dib.cpp:313
+#, fuzzy, c-format
+msgid "Failed to save the bitmap image to file \"%s\"."
+msgstr "No s'ha pogut carregar la imatge %d des del fitxer '%s'."
+
+#: ../src/msw/dib.cpp:543
+#, fuzzy, c-format
+msgid "Failed to allocate %luKb of memory for bitmap data."
+msgstr "No s'ha pogut crear una barra d'estat."
+
+#: ../src/msw/dir.cpp:241
+#, c-format
+msgid "Cannot enumerate files in directory '%s'"
+msgstr "No es pot enumerar els fitxers en el directori '%s'"
+
+#: ../src/msw/dirdlg.cpp:368
+#, fuzzy
+msgid "Couldn't obtain folder name"
+msgstr "No s'ha pogut crear un temporitzador"
+
+#: ../src/msw/dlmsw.cpp:163
+#, fuzzy, c-format
+msgid "(error %d: %s)"
+msgstr " (error %d: %s)"
+
+#: ../src/msw/dragimag.cpp:143 ../src/msw/dragimag.cpp:178
+#: ../src/msw/imaglist.cpp:309 ../src/msw/imaglist.cpp:331
+msgid "Couldn't add an image to the image list."
+msgstr "No s'ha pogut afegir una imatge al llistat d'imatges."
+
+#: ../src/msw/enhmeta.cpp:94
+#, fuzzy, c-format
+msgid "Failed to load metafile from file \"%s\"."
+msgstr "No s'ha pogut carregar la imatge %d des del fitxer '%s'."
+
+#: ../src/msw/fdrepdlg.cpp:412
+#, c-format
+msgid "Failed to create the standard find/replace dialog (error code %d)"
+msgstr ""
+"No s'ha pogut crear el diàleg estàndard de cerca/substituix (codi d'error %d)"
+
+#: ../src/msw/filedlg.cpp:1241
+msgid "Access to the file system is not allowed from secure desktop."
+msgstr ""
+
+#: ../src/msw/filedlg.cpp:1242
+msgid "Security warning"
+msgstr ""
+
+#: ../src/msw/filedlg.cpp:1533
+#, fuzzy, c-format
+msgid "File dialog failed with error code %0lx."
+msgstr "L'execució de l'orde '%s' ha fallit."
+
+#: ../src/msw/font.cpp:1120
+#, fuzzy, c-format
+msgid "Font file \"%s\" couldn't be loaded"
+msgstr "No s'ha pogut carregar el fitxer."
+
+#: ../src/msw/fontdlg.cpp:220
+#, fuzzy, c-format
+msgid "Common dialog failed with error code %0lx."
+msgstr "L'execució de l'orde '%s' ha fallit."
+
+#: ../src/msw/fswatcher.cpp:67
+#, fuzzy
+msgid "Ungraceful worker thread termination"
+msgstr "No es pot esperar per a l'acabament de cadena"
+
+#: ../src/msw/fswatcher.cpp:81
+#, fuzzy
+msgid "Unable to create IOCP worker thread"
+msgstr "No s'ha pogut crear un marc MDI principal."
+
+#: ../src/msw/fswatcher.cpp:88
+msgid "Unable to start IOCP worker thread"
+msgstr ""
+
+#: ../src/msw/fswatcher.cpp:140
+msgid "Monitoring individual files for changes is not supported currently."
+msgstr ""
+
+#: ../src/msw/fswatcher.cpp:165
+#, fuzzy, c-format
+msgid "Unable to set up watch for '%s'"
+msgstr "No s'ha pogut posar en contacte amb el fitxer '%s'"
+
+#: ../src/msw/fswatcher.cpp:466
+#, c-format
+msgid "Can't monitor non-existent directory \"%s\" for changes."
+msgstr ""
+
+#: ../src/msw/glcanvas.cpp:577 ../src/unix/glx11.cpp:507
+msgid "OpenGL 3.0 or later is not supported by the OpenGL driver."
+msgstr ""
+
+#: ../src/msw/glcanvas.cpp:601 ../src/osx/glcanvas_osx.cpp:395
+#: ../src/unix/glegl.cpp:304 ../src/unix/glx11.cpp:553
+#, fuzzy
+msgid "Couldn't create OpenGL context"
+msgstr "No s'ha pogut crear un temporitzador"
+
+#: ../src/msw/glcanvas.cpp:1294
+msgid "Failed to initialize OpenGL"
+msgstr "No s'ha pogut inicialitzar l'OpenGL"
+
+#: ../src/msw/graphicsd2d.cpp:607
+msgid "Could not register custom DirectWrite font loader."
+msgstr ""
+
+#: ../src/msw/helpchm.cpp:48
+msgid ""
+"MS HTML Help functions are unavailable because the MS HTML Help library is "
+"not installed on this machine. Please install it."
+msgstr ""
+"Les funcions d'ajuda MS HTML no están disponibles perque la llibreria "
+"d'Ajuda MS HTML no està instal·lada en este maquinari. L'heu d'instal·lar.."
+
+#: ../src/msw/helpchm.cpp:55
+msgid "Failed to initialize MS HTML Help."
+msgstr "No s'ha pogut inicialitzar l'ajuda MS HTML"
+
+#: ../src/msw/iniconf.cpp:458
+#, c-format
+msgid "Can't delete the INI file '%s'"
+msgstr "No es pot eliminar el fitxer INI '%s'"
+
+#: ../src/msw/listctrl.cpp:995
+#, c-format
+msgid "Couldn't retrieve information about list control item %d."
+msgstr ""
+"No es pot recuperar informació sobre els llistat %d de controls d'elements."
+
+#: ../src/msw/mdi.cpp:170 ../src/qt/mdi.cpp:253
+msgid "&Cascade"
+msgstr "&Cascada"
+
+#: ../src/msw/mdi.cpp:171
+msgid "Tile &Horizontally"
+msgstr "Col·loca &horitzontalment"
+
+#: ../src/msw/mdi.cpp:172
+msgid "Tile &Vertically"
+msgstr "Col·loca &verticalment"
+
+#: ../src/msw/mdi.cpp:174
+msgid "&Arrange Icons"
+msgstr "&Organitza les icones"
+
+#: ../src/msw/mdi.cpp:621
+msgid "Failed to create MDI parent frame."
+msgstr "No s'ha pogut crear un marc MDI principal."
+
+#: ../src/msw/mimetype.cpp:234
+#, c-format
+msgid "Failed to create registry entry for '%s' files."
+msgstr "No s'ha pogut crear una entrada de registre per '%s' fitxers."
+
+#: ../src/msw/ole/automtn.cpp:495
+#, fuzzy, c-format
+msgid "Failed to find CLSID of \"%s\""
+msgstr "No s'ha pogut obrir '%s' per %s"
+
+#: ../src/msw/ole/automtn.cpp:512
+#, fuzzy, c-format
+msgid "Failed to create an instance of \"%s\""
+msgstr "No s'ha pogut crear un directori %s/.gnome."
+
+#: ../src/msw/ole/automtn.cpp:552
+#, fuzzy, c-format
+msgid "Cannot get an active instance of \"%s\""
+msgstr "No es pot trobar connexió activa de marcatge directe: %s"
+
+#: ../src/msw/ole/automtn.cpp:564
+#, fuzzy, c-format
+msgid "Failed to get OLE automation interface for \"%s\""
+msgstr "No s'ha pogut crear un directori %s/.gnome."
+
+#: ../src/msw/ole/automtn.cpp:621
+msgid "Unknown name or named argument."
+msgstr ""
+
+#: ../src/msw/ole/automtn.cpp:625
+msgid "Incorrect number of arguments."
+msgstr ""
+
+#: ../src/msw/ole/automtn.cpp:637
+#, fuzzy
+msgid "Unknown exception"
+msgstr "Opció '%s' desconeguda"
+
+#: ../src/msw/ole/automtn.cpp:642
+msgid "Method or property not found."
+msgstr ""
+
+#: ../src/msw/ole/automtn.cpp:646
+msgid "Overflow while coercing argument values."
+msgstr ""
+
+#: ../src/msw/ole/automtn.cpp:650
+msgid "Object implementation does not support named arguments."
+msgstr ""
+
+#: ../src/msw/ole/automtn.cpp:654
+msgid "The locale ID is unknown."
+msgstr ""
+
+#: ../src/msw/ole/automtn.cpp:658
+msgid "Missing a required parameter."
+msgstr ""
+
+#: ../src/msw/ole/automtn.cpp:662
+#, fuzzy, c-format
+msgid "Argument %u not found."
+msgstr "no s'ha trobat el fitxer de catàleg per al domini '%s'"
+
+#: ../src/msw/ole/automtn.cpp:666
+#, c-format
+msgid "Type mismatch in argument %u."
+msgstr ""
+
+#: ../src/msw/ole/automtn.cpp:670
+msgid "The system cannot find the file specified."
+msgstr ""
+
+#: ../src/msw/ole/automtn.cpp:674
+#, fuzzy
+msgid "Class not registered."
+msgstr "No es pot crear un fil"
+
+#: ../src/msw/ole/automtn.cpp:678
+#, fuzzy, c-format
+msgid "Unknown error %08x"
+msgstr "Error DDE desconegut %08x"
+
+#: ../src/msw/ole/automtn.cpp:682
+#, c-format
+msgid "OLE Automation error in %s: %s"
+msgstr ""
+
+#: ../src/msw/ole/dataobj.cpp:385
+#, c-format
+msgid "Couldn't register clipboard format '%s'."
+msgstr "No s'ha pogut registrar el format '%s' del porta-retalls."
+
+#: ../src/msw/ole/dataobj.cpp:402
+#, fuzzy, c-format
+msgid "The clipboard format '%d' doesn't exist."
+msgstr "El format '%s' del porta-retalls no existix."
+
+#: ../src/msw/progdlg.cpp:1025
+#, fuzzy
+msgid "Skip"
+msgstr "Script"
+
+#: ../src/msw/registry.cpp:141
+#, fuzzy, c-format
+msgid "unknown (%lu)"
+msgstr "desconegut"
+
+#: ../src/msw/registry.cpp:409
+#, c-format
+msgid "Can't get info about registry key '%s'"
+msgstr "No es pot obtenir informació sobre la clau de registre '%s'"
+
+#: ../src/msw/registry.cpp:445
+#, c-format
+msgid "Can't open registry key '%s'"
+msgstr "No es pot obrir la clau de registre '%s'"
+
+#: ../src/msw/registry.cpp:478
+#, c-format
+msgid "Can't create registry key '%s'"
+msgstr "No es pot crear la clau de registre '%s'"
+
+#: ../src/msw/registry.cpp:497
+#, c-format
+msgid "Can't close registry key '%s'"
+msgstr "No es pot tancar la clau de registre '%s'"
+
+#: ../src/msw/registry.cpp:512
+#, c-format
+msgid "Registry value '%s' already exists."
+msgstr "El valor '%s' de registre encara existix."
+
+#: ../src/msw/registry.cpp:520
+#, c-format
+msgid "Failed to rename registry value '%s' to '%s'."
+msgstr "No s'ha pogut reanomenar el valor de registre '%s' a '%s'."
+
+#: ../src/msw/registry.cpp:575
+#, c-format
+msgid "Can't copy values of unsupported type %d."
+msgstr "No es pot copiar els valors del tipus %d no suportat."
+
+#: ../src/msw/registry.cpp:586
+#, c-format
+msgid "Registry key '%s' does not exist, cannot rename it."
+msgstr "La clau de registre '%s' no existix, no la podeu reanomenar."
+
+#: ../src/msw/registry.cpp:617
+#, c-format
+msgid "Registry key '%s' already exists."
+msgstr "La clau de registre '%s' ja existix."
+
+#: ../src/msw/registry.cpp:625
+#, c-format
+msgid "Failed to rename the registry key '%s' to '%s'."
+msgstr "No s'ha pogut reanomenar la clau de registre '%s' a '%s'."
+
+#: ../src/msw/registry.cpp:670
+#, fuzzy, c-format
+msgid "Failed to copy the registry subkey '%s' to '%s'."
+msgstr "No s'ha pogut reanomenar la clau de registre '%s' a '%s'."
+
+#: ../src/msw/registry.cpp:683
+#, c-format
+msgid "Failed to copy registry value '%s'"
+msgstr "No s'ha pogut copiar el valor '%s' de registre"
+
+#: ../src/msw/registry.cpp:692
+#, c-format
+msgid "Failed to copy the contents of registry key '%s' to '%s'."
+msgstr ""
+"No s'ha pogut copiar els continguts de la clau de registre '%s' a '%s'."
+
+#: ../src/msw/registry.cpp:718
+#, c-format
+msgid ""
+"Registry key '%s' is needed for normal system operation,\n"
+"deleting it will leave your system in unusable state:\n"
+"operation aborted."
+msgstr ""
+"La clau de registre '%s' és necessitada per operacions normals de sistema,\n"
+"eliminant-los deixarà el vostre sistema en un estat inservible:\n"
+"operació avortada."
+
+#: ../src/msw/registry.cpp:754
+#, c-format
+msgid "Can't delete key '%s'"
+msgstr "No es pot eliminar la tecla '%s'"
+
+#: ../src/msw/registry.cpp:782
+#, c-format
+msgid "Can't delete value '%s' from key '%s'"
+msgstr "No es pot eliminar el valor '%s' de la clau '%s'"
+
+#: ../src/msw/registry.cpp:855 ../src/msw/registry.cpp:887
+#: ../src/msw/registry.cpp:929 ../src/msw/registry.cpp:1000
+#, c-format
+msgid "Can't read value of key '%s'"
+msgstr "No es pot llegir el valor de la clau '%s'"
+
+#: ../src/msw/registry.cpp:873 ../src/msw/registry.cpp:915
+#: ../src/msw/registry.cpp:963 ../src/msw/registry.cpp:1106
+#, c-format
+msgid "Can't set value of '%s'"
+msgstr "No es pot fixar un valor de '%s'"
+
+#: ../src/msw/registry.cpp:894 ../src/msw/registry.cpp:943
+#, c-format
+msgid "Registry value \"%s\" is not numeric (but of type %s)"
+msgstr ""
+
+#: ../src/msw/registry.cpp:979
+#, c-format
+msgid "Registry value \"%s\" is not binary (but of type %s)"
+msgstr ""
+
+#: ../src/msw/registry.cpp:1028
+#, c-format
+msgid "Registry value \"%s\" is not text (but of type %s)"
+msgstr ""
+
+#: ../src/msw/registry.cpp:1089
+#, c-format
+msgid "Can't read value of '%s'"
+msgstr "No es pot llegir el valor de '%s'"
+
+#: ../src/msw/registry.cpp:1157
+#, c-format
+msgid "Can't enumerate values of key '%s'"
+msgstr "No es pot enumerar els valors de la clau '%s'"
+
+#: ../src/msw/registry.cpp:1196
+#, c-format
+msgid "Can't enumerate subkeys of key '%s'"
+msgstr "No es poden enumerar subclaus de la clau '%s'"
+
+#: ../src/msw/registry.cpp:1262
+#, c-format
+msgid ""
+"Exporting registry key: file \"%s\" already exists and won't be overwritten."
+msgstr ""
+
+#: ../src/msw/registry.cpp:1411
+#, fuzzy, c-format
+msgid "Can't export value of unsupported type %d."
+msgstr "No es pot copiar els valors del tipus %d no suportat."
+
+#: ../src/msw/registry.cpp:1427
+#, c-format
+msgid "Ignoring value \"%s\" of the key \"%s\"."
+msgstr ""
+
+#: ../src/msw/textctrl.cpp:596
+msgid ""
+"Impossible to create a rich edit control, using simple text control instead. "
+"Please reinstall riched32.dll"
+msgstr ""
+"No és possible crear un control d'edició rica, utilitzant en el seu lloc un "
+"control de text simple. Reinstal·leu riched32.dll"
+
+#: ../src/msw/thread.cpp:522 ../src/unix/threadpsx.cpp:850
+msgid "Cannot start thread: error writing TLS."
+msgstr "No es pot iniciar la cadena: error en escriure TLS."
+
+#: ../src/msw/thread.cpp:613
+msgid "Can't set thread priority"
+msgstr "No es pot fixar la prioritat fils"
+
+#: ../src/msw/thread.cpp:649
+msgid "Can't create thread"
+msgstr "No es pot crear un fil"
+
+#: ../src/msw/thread.cpp:668
+msgid "Couldn't terminate thread"
+msgstr "No s'ha acabat la cadena"
+
+#: ../src/msw/thread.cpp:799
+msgid "Cannot wait for thread termination"
+msgstr "No es pot esperar per a l'acabament de cadena"
+
+#: ../src/msw/thread.cpp:873
+#, fuzzy, c-format
+msgid "Cannot suspend thread %lx"
+msgstr "No es pot suspendre en fil %x"
+
+#: ../src/msw/thread.cpp:903
+#, fuzzy, c-format
+msgid "Cannot resume thread %lx"
+msgstr "No es pot enumerar els fitxers en el directori '%s'"
+
+#: ../src/msw/thread.cpp:932
+msgid "Couldn't get the current thread pointer"
+msgstr "No es pot obtenir l'actual cadena de punter"
+
+#: ../src/msw/thread.cpp:1333
+msgid ""
+"Thread module initialization failed: impossible to allocate index in thread "
+"local storage"
+msgstr ""
+"La inicialització de mòduls de la cadena ha fallat: no és possible "
+"localitzar l'índex en la cadena emmagatzemada localment"
+
+#: ../src/msw/thread.cpp:1345
+msgid ""
+"Thread module initialization failed: cannot store value in thread local "
+"storage"
+msgstr ""
+"La inicialització de mòduls de la cadena ha fallat: no es pot emmagatzemar "
+"valor en cadena emmagatzemada localment"
+
+#: ../src/msw/timer.cpp:133
+msgid "Couldn't create a timer"
+msgstr "No s'ha pogut crear un temporitzador"
+
+#: ../src/msw/utils.cpp:372
+msgid "can't find user's HOME, using current directory."
+msgstr "no es pot trobar la CASA de l'usuari utilitzant el directori actual."
+
+#: ../src/msw/utils.cpp:662
+#, c-format
+msgid "Failed to kill process %d"
+msgstr "No s'ha pogut acabar el procés %d"
+
+#: ../src/msw/utils.cpp:986
+#, fuzzy, c-format
+msgid "Failed to load resource \"%s\"."
+msgstr "No s'ha pogut carregar la imatge %d des del fitxer '%s'."
+
+#: ../src/msw/utils.cpp:993
+#, fuzzy, c-format
+msgid "Failed to lock resource \"%s\"."
+msgstr "No s'ha pogut bloquejar el fitxer de bloqueig '%s'"
+
+#. TRANSLATORS: MS Windows build number
+#: ../src/msw/utils.cpp:1209
+#, c-format
+msgid "build %lu"
+msgstr ""
+
+#: ../src/msw/utils.cpp:1218
+msgid ", 64-bit edition"
+msgstr ""
+
+#: ../src/msw/utilsexc.cpp:224
+msgid "Failed to create an anonymous pipe"
+msgstr "Creació fallida d'un conducte anònim."
+
+#: ../src/msw/utilsexc.cpp:697
+msgid "Failed to redirect the child process IO"
+msgstr "No s'ha pogut redireccionar el procés fill d'IO"
+
+#: ../src/msw/utilsexc.cpp:870
+#, c-format
+msgid "Execution of command '%s' failed"
+msgstr "L'execució de l'orde '%s' ha fallit."
+
+#: ../src/msw/volume.cpp:337
+msgid "Failed to load mpr.dll."
+msgstr "No s'ha pogut carregar el mpr.dll"
+
+#: ../src/msw/volume.cpp:506
+#, c-format
+msgid "Cannot read typename from '%s'!"
+msgstr "No es pot llegir el tipus de nom des de '%s'!"
+
+#: ../src/msw/volume.cpp:615
+#, c-format
+msgid "Cannot load icon from '%s'."
+msgstr "No es pot carregar la icona des de '%s'"
+
+#: ../src/msw/webview_edge.cpp:285
+msgid "This program was compiled without support for setting Edge proxy."
+msgstr ""
+
+#: ../src/msw/webview_ie.cpp:1010
+msgid "Failed to find web view emulation level in the registry"
+msgstr ""
+
+#: ../src/msw/webview_ie.cpp:1019
+msgid "Failed to set web view to modern emulation level"
+msgstr ""
+
+#: ../src/msw/webview_ie.cpp:1027
+msgid "Failed to reset web view to standard emulation level"
+msgstr ""
+
+#: ../src/msw/webview_ie.cpp:1049
+msgid "Can't run JavaScript script without a valid HTML document"
+msgstr ""
+
+#: ../src/msw/webview_ie.cpp:1056
+#, fuzzy
+msgid "Can't get the JavaScript object"
+msgstr "No es pot fixar la prioritat fils"
+
+#: ../src/msw/webview_ie.cpp:1070
+#, fuzzy
+msgid "failed to evaluate"
+msgstr "No s'ha pogut executar '%s'\n"
+
+#: ../src/osx/cocoa/filedlg.mm:412
+#, fuzzy
+msgid "File type:"
+msgstr "Teletip"
+
+#: ../src/osx/cocoa/menu.mm:242
+#, fuzzy
+msgctxt "macOS menu name"
+msgid "Window"
+msgstr "&Finestra"
+
+#: ../src/osx/cocoa/menu.mm:259
+#, fuzzy
+msgctxt "macOS menu name"
+msgid "Help"
+msgstr "Ajuda"
+
+#: ../src/osx/cocoa/menu.mm:298
+#, fuzzy
+msgctxt "macOS menu item"
+msgid "Minimize"
+msgstr "Mi&nimitza"
+
+#: ../src/osx/cocoa/menu.mm:303
+msgctxt "macOS menu item"
+msgid "Zoom"
+msgstr ""
+
+#: ../src/osx/cocoa/menu.mm:309
+msgctxt "macOS menu item"
+msgid "Bring All to Front"
+msgstr ""
+
+#: ../src/osx/core/sound.cpp:143
+#, fuzzy, c-format
+msgid "Failed to load sound from \"%s\" (error %d)."
+msgstr "No s'ha pogut carregar la imatge %d des del fitxer '%s'."
+
+#: ../src/osx/fontutil.cpp:80
+#, fuzzy, c-format
+msgid "Font file \"%s\" doesn't exist."
+msgstr "El fitxer %s no existix"
+
+#: ../src/osx/fontutil.cpp:88
+#, c-format
+msgid ""
+"Font file \"%s\" cannot be used as it is not inside the font directory "
+"\"%s\"."
+msgstr ""
+
+#: ../src/osx/menu_osx.cpp:496
+#, c-format
+msgctxt "macOS menu item"
+msgid "About %s"
+msgstr ""
+
+#: ../src/osx/menu_osx.cpp:499
+msgctxt "macOS menu item"
+msgid "About..."
+msgstr ""
+
+#: ../src/osx/menu_osx.cpp:508
+msgctxt "macOS menu item"
+msgid "Preferences..."
+msgstr ""
+
+#: ../src/osx/menu_osx.cpp:512
+msgctxt "macOS menu item"
+msgid "Services"
+msgstr ""
+
+#: ../src/osx/menu_osx.cpp:519
+#, fuzzy, c-format
+msgctxt "macOS menu item"
+msgid "Hide %s"
+msgstr "Ajuda: %s"
+
+#: ../src/osx/menu_osx.cpp:522
+#, fuzzy
+msgctxt "macOS menu item"
+msgid "Hide Application"
+msgstr "Seccions"
+
+#: ../src/osx/menu_osx.cpp:526
+msgctxt "macOS menu item"
+msgid "Hide Others"
+msgstr ""
+
+#: ../src/osx/menu_osx.cpp:528
+#, fuzzy
+msgctxt "macOS menu item"
+msgid "Show All"
+msgstr "Mostra-ho tot"
+
+#: ../src/osx/menu_osx.cpp:534
+#, fuzzy, c-format
+msgctxt "macOS menu item"
+msgid "Quit %s"
+msgstr "No"
+
+#: ../src/osx/menu_osx.cpp:537
+#, fuzzy
+msgctxt "macOS menu item"
+msgid "Quit Application"
+msgstr "Seccions"
+
+#: ../src/osx/webview_webkit.mm:444
+msgid "Printing is not supported by the system web control"
+msgstr ""
+
+#: ../src/osx/webview_webkit.mm:453
+#, fuzzy
+msgid "Print operation could not be initialized"
+msgstr "No es pot començar a mostrar."
+
+#. TRANSLATORS: Label of font point size
+#: ../src/propgrid/advprops.cpp:605
+#, fuzzy
+msgid "Point Size"
+msgstr "Grandària de la font:"
+
+#. TRANSLATORS: Label of font face name
+#: ../src/propgrid/advprops.cpp:615
+#, fuzzy
+msgid "Face Name"
+msgstr "Nou nom"
+
+#. TRANSLATORS: Label of font style
+#: ../src/propgrid/advprops.cpp:623 ../src/richtext/richtextformatdlg.cpp:331
+msgid "Style"
+msgstr ""
+
+#. TRANSLATORS: Label of font weight
+#: ../src/propgrid/advprops.cpp:628
+#, fuzzy
+msgid "Weight"
+msgstr "vuitè"
+
+#. TRANSLATORS: Label of underlined font
+#: ../src/propgrid/advprops.cpp:633 ../src/richtext/richtextfontpage.cpp:358
+#, fuzzy
+msgid "Underlined"
+msgstr "Subratllat"
+
+#. TRANSLATORS: Label of font family
+#: ../src/propgrid/advprops.cpp:637
+#, fuzzy
+msgid "Family"
+msgstr "Grandària de la font:"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:801
+msgid "AppWorkspace"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:802
+#, fuzzy
+msgid "ActiveBorder"
+msgstr "Modern"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:803
+msgid "ActiveCaption"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:804
+msgid "ButtonFace"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:805
+msgid "ButtonHighlight"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:806
+msgid "ButtonShadow"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:807
+msgid "ButtonText"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:808
+msgid "CaptionText"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:809
+msgid "ControlDark"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:810
+msgid "ControlLight"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:812
+msgid "GrayText"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:813
+#, fuzzy
+msgid "Highlight"
+msgstr "clar"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:814
+msgid "HighlightText"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:815
+#, fuzzy
+msgid "InactiveBorder"
+msgstr "Modern"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:816
+msgid "InactiveCaption"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:817
+msgid "InactiveCaptionText"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:818
+#, fuzzy
+msgid "Menu"
+msgstr "Modern"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:819
+msgid "Scrollbar"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:820
+msgid "Tooltip"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:821
+msgid "TooltipText"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:822
+#, fuzzy
+msgid "Window"
+msgstr "&Finestra"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:823
+#, fuzzy
+msgid "WindowFrame"
+msgstr "&Finestra"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:824
+#, fuzzy
+msgid "WindowText"
+msgstr "&Finestra"
+
+#. TRANSLATORS: Custom colour choice entry
+#: ../src/propgrid/advprops.cpp:825 ../src/propgrid/advprops.cpp:1532
+#: ../src/propgrid/advprops.cpp:1576
+#, fuzzy
+msgid "Custom"
+msgstr "Grandària de la font:"
+
+#: ../src/propgrid/advprops.cpp:1558
+msgid "Black"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1559
+msgid "Maroon"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1560
+msgid "Navy"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1561
+msgid "Purple"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1562
+msgid "Teal"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1563
+msgid "Gray"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1564
+msgid "Green"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1565
+msgid "Olive"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1566
+msgid "Brown"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1567
+msgid "Blue"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1568
+msgid "Fuchsia"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1569
+#, fuzzy
+msgid "Red"
+msgstr "&Refés"
+
+#: ../src/propgrid/advprops.cpp:1570
+msgid "Orange"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1571
+msgid "Silver"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1572
+msgid "Lime"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1573
+msgid "Aqua"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1574
+msgid "Yellow"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1575
+msgid "White"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1718
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Default"
+msgstr "predeterminat"
+
+#: ../src/propgrid/advprops.cpp:1719
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Arrow"
+msgstr "demà"
+
+#: ../src/propgrid/advprops.cpp:1720
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Right Arrow"
+msgstr "Clar"
+
+#: ../src/propgrid/advprops.cpp:1721
+msgctxt "system cursor name"
+msgid "Blank"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1722
+msgctxt "system cursor name"
+msgid "Bullseye"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1723
+msgctxt "system cursor name"
+msgid "Character"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1724
+msgctxt "system cursor name"
+msgid "Cross"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1725
+msgctxt "system cursor name"
+msgid "Hand"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1726
+msgctxt "system cursor name"
+msgid "I-Beam"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1727
+msgctxt "system cursor name"
+msgid "Left Button"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1728
+msgctxt "system cursor name"
+msgid "Magnifier"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1729
+msgctxt "system cursor name"
+msgid "Middle Button"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1730
+msgctxt "system cursor name"
+msgid "No Entry"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1731
+msgctxt "system cursor name"
+msgid "Paint Brush"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1732
+msgctxt "system cursor name"
+msgid "Pencil"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1733
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Point Left"
+msgstr "Grandària de la font:"
+
+#: ../src/propgrid/advprops.cpp:1734
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Point Right"
+msgstr "mitja nit"
+
+#: ../src/propgrid/advprops.cpp:1735
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Question Arrow"
+msgstr "Pregunta"
+
+#: ../src/propgrid/advprops.cpp:1736
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Right Button"
+msgstr "Clar"
+
+#: ../src/propgrid/advprops.cpp:1737
+msgctxt "system cursor name"
+msgid "Sizing NE-SW"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1738
+msgctxt "system cursor name"
+msgid "Sizing N-S"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1739
+msgctxt "system cursor name"
+msgid "Sizing NW-SE"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1740
+msgctxt "system cursor name"
+msgid "Sizing W-E"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1741
+msgctxt "system cursor name"
+msgid "Sizing"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1742
+msgctxt "system cursor name"
+msgid "Spraycan"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1743
+msgctxt "system cursor name"
+msgid "Wait"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1744
+msgctxt "system cursor name"
+msgid "Watch"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1745
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Wait Arrow"
+msgstr "Clar"
+
+#: ../src/propgrid/advprops.cpp:2109
+#, fuzzy
+msgid "Make a selection:"
+msgstr "Seccions"
+
+#: ../src/propgrid/manager.cpp:394
+#, fuzzy
+msgid "Property"
+msgstr "&Previ"
+
+#: ../src/propgrid/manager.cpp:395
+msgid "Value"
+msgstr ""
+
+#: ../src/propgrid/manager.cpp:1683
+msgid "Categorized Mode"
+msgstr ""
+
+#: ../src/propgrid/manager.cpp:1709
+msgid "Alphabetic Mode"
+msgstr ""
+
+#. TRANSLATORS: Name of Boolean false value
+#: ../src/propgrid/propgrid.cpp:230
+#, fuzzy
+msgid "False"
+msgstr "&Mida"
+
+#. TRANSLATORS: Name of Boolean true value
+#: ../src/propgrid/propgrid.cpp:232
+msgid "True"
+msgstr ""
+
+#. TRANSLATORS: Text  displayed for unspecified value
+#: ../src/propgrid/propgrid.cpp:428
+msgid "Unspecified"
+msgstr ""
+
+#. TRANSLATORS: Caption of message box displaying any property error
+#: ../src/propgrid/propgrid.cpp:3145 ../src/propgrid/propgrid.cpp:3282
+#, fuzzy
+msgid "Property Error"
+msgstr "Error d'impressió"
+
+#: ../src/propgrid/propgrid.cpp:3259
+msgid "You have entered invalid value. Press ESC to cancel editing."
+msgstr ""
+
+#: ../src/propgrid/propgrid.cpp:6608
+#, c-format
+msgid "Error in resource: %s"
+msgstr ""
+
+#: ../src/propgrid/propgridiface.cpp:377
+#, c-format
+msgid ""
+"Type operation \"%s\" failed: Property labeled \"%s\" is of type \"%s\", NOT "
+"\"%s\"."
+msgstr ""
+
+#: ../src/propgrid/props.cpp:159
+#, c-format
+msgid "Unknown base %d. Base 10 will be used."
+msgstr ""
+
+#: ../src/propgrid/props.cpp:324
+#, c-format
+msgid "Value must be %s or higher."
+msgstr ""
+
+#: ../src/propgrid/props.cpp:329 ../src/propgrid/props.cpp:356
+#, c-format
+msgid "Value must be between %s and %s."
+msgstr ""
+
+#: ../src/propgrid/props.cpp:351
+#, c-format
+msgid "Value must be %s or less."
+msgstr ""
+
+#: ../src/propgrid/props.cpp:1058
+#, fuzzy, c-format
+msgid "Not %s"
+msgstr "No"
+
+#: ../src/propgrid/props.cpp:1770
+#, fuzzy
+msgid "Choose a directory:"
+msgstr "Crea directori"
+
+#: ../src/propgrid/props.cpp:2055
+#, fuzzy
+msgid "Choose a file"
+msgstr "Trieu la font"
+
+#: ../src/qt/mdi.cpp:254
+msgid "&Tile"
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:147
+#: ../src/richtext/richtextformatdlg.cpp:376
+#, fuzzy
+msgid "Background"
+msgstr "Enrere"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:159
+msgid "Background &colour:"
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:161
+#: ../src/richtext/richtextbackgroundpage.cpp:163
+msgid "Enables a background colour."
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:167
+#: ../src/richtext/richtextbackgroundpage.cpp:169
+msgid "The background colour."
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:178
+msgid "Shadow"
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:193
+msgid "Use &shadow"
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:195
+#: ../src/richtext/richtextbackgroundpage.cpp:197
+msgid "Enables a shadow."
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:211
+msgid "&Horizontal offset:"
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:218
+#: ../src/richtext/richtextbackgroundpage.cpp:220
+#, fuzzy
+msgid "The horizontal offset."
+msgstr "Col·loca &horitzontalment"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:224
+#: ../src/richtext/richtextbackgroundpage.cpp:227
+#: ../src/richtext/richtextbackgroundpage.cpp:228
+#: ../src/richtext/richtextbackgroundpage.cpp:247
+#: ../src/richtext/richtextbackgroundpage.cpp:250
+#: ../src/richtext/richtextbackgroundpage.cpp:251
+#: ../src/richtext/richtextbackgroundpage.cpp:287
+#: ../src/richtext/richtextbackgroundpage.cpp:290
+#: ../src/richtext/richtextbackgroundpage.cpp:291
+#: ../src/richtext/richtextbackgroundpage.cpp:314
+#: ../src/richtext/richtextbackgroundpage.cpp:317
+#: ../src/richtext/richtextbackgroundpage.cpp:318
+#: ../src/richtext/richtextborderspage.cpp:252
+#: ../src/richtext/richtextborderspage.cpp:255
+#: ../src/richtext/richtextborderspage.cpp:256
+#: ../src/richtext/richtextborderspage.cpp:286
+#: ../src/richtext/richtextborderspage.cpp:289
+#: ../src/richtext/richtextborderspage.cpp:290
+#: ../src/richtext/richtextborderspage.cpp:320
+#: ../src/richtext/richtextborderspage.cpp:323
+#: ../src/richtext/richtextborderspage.cpp:324
+#: ../src/richtext/richtextborderspage.cpp:354
+#: ../src/richtext/richtextborderspage.cpp:357
+#: ../src/richtext/richtextborderspage.cpp:358
+#: ../src/richtext/richtextborderspage.cpp:420
+#: ../src/richtext/richtextborderspage.cpp:423
+#: ../src/richtext/richtextborderspage.cpp:424
+#: ../src/richtext/richtextborderspage.cpp:454
+#: ../src/richtext/richtextborderspage.cpp:457
+#: ../src/richtext/richtextborderspage.cpp:458
+#: ../src/richtext/richtextborderspage.cpp:488
+#: ../src/richtext/richtextborderspage.cpp:491
+#: ../src/richtext/richtextborderspage.cpp:492
+#: ../src/richtext/richtextborderspage.cpp:522
+#: ../src/richtext/richtextborderspage.cpp:525
+#: ../src/richtext/richtextborderspage.cpp:526
+#: ../src/richtext/richtextborderspage.cpp:590
+#: ../src/richtext/richtextborderspage.cpp:593
+#: ../src/richtext/richtextborderspage.cpp:594
+#: ../src/richtext/richtextfontpage.cpp:177
+#: ../src/richtext/richtextmarginspage.cpp:199
+#: ../src/richtext/richtextmarginspage.cpp:201
+#: ../src/richtext/richtextmarginspage.cpp:202
+#: ../src/richtext/richtextmarginspage.cpp:224
+#: ../src/richtext/richtextmarginspage.cpp:226
+#: ../src/richtext/richtextmarginspage.cpp:227
+#: ../src/richtext/richtextmarginspage.cpp:247
+#: ../src/richtext/richtextmarginspage.cpp:249
+#: ../src/richtext/richtextmarginspage.cpp:250
+#: ../src/richtext/richtextmarginspage.cpp:272
+#: ../src/richtext/richtextmarginspage.cpp:274
+#: ../src/richtext/richtextmarginspage.cpp:275
+#: ../src/richtext/richtextmarginspage.cpp:313
+#: ../src/richtext/richtextmarginspage.cpp:315
+#: ../src/richtext/richtextmarginspage.cpp:316
+#: ../src/richtext/richtextmarginspage.cpp:338
+#: ../src/richtext/richtextmarginspage.cpp:340
+#: ../src/richtext/richtextmarginspage.cpp:341
+#: ../src/richtext/richtextmarginspage.cpp:361
+#: ../src/richtext/richtextmarginspage.cpp:363
+#: ../src/richtext/richtextmarginspage.cpp:364
+#: ../src/richtext/richtextmarginspage.cpp:386
+#: ../src/richtext/richtextmarginspage.cpp:388
+#: ../src/richtext/richtextmarginspage.cpp:389
+#: ../src/richtext/richtextsizepage.cpp:337
+#: ../src/richtext/richtextsizepage.cpp:340
+#: ../src/richtext/richtextsizepage.cpp:341
+#: ../src/richtext/richtextsizepage.cpp:371
+#: ../src/richtext/richtextsizepage.cpp:374
+#: ../src/richtext/richtextsizepage.cpp:375
+#: ../src/richtext/richtextsizepage.cpp:398
+#: ../src/richtext/richtextsizepage.cpp:401
+#: ../src/richtext/richtextsizepage.cpp:402
+#: ../src/richtext/richtextsizepage.cpp:425
+#: ../src/richtext/richtextsizepage.cpp:428
+#: ../src/richtext/richtextsizepage.cpp:429
+#: ../src/richtext/richtextsizepage.cpp:452
+#: ../src/richtext/richtextsizepage.cpp:455
+#: ../src/richtext/richtextsizepage.cpp:456
+#: ../src/richtext/richtextsizepage.cpp:479
+#: ../src/richtext/richtextsizepage.cpp:482
+#: ../src/richtext/richtextsizepage.cpp:483
+#: ../src/richtext/richtextsizepage.cpp:553
+#: ../src/richtext/richtextsizepage.cpp:556
+#: ../src/richtext/richtextsizepage.cpp:557
+#: ../src/richtext/richtextsizepage.cpp:588
+#: ../src/richtext/richtextsizepage.cpp:591
+#: ../src/richtext/richtextsizepage.cpp:592
+#: ../src/richtext/richtextsizepage.cpp:623
+#: ../src/richtext/richtextsizepage.cpp:626
+#: ../src/richtext/richtextsizepage.cpp:627
+#: ../src/richtext/richtextsizepage.cpp:658
+#: ../src/richtext/richtextsizepage.cpp:661
+#: ../src/richtext/richtextsizepage.cpp:662
+msgid "px"
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:225
+#: ../src/richtext/richtextbackgroundpage.cpp:248
+#: ../src/richtext/richtextbackgroundpage.cpp:288
+#: ../src/richtext/richtextbackgroundpage.cpp:315
+#: ../src/richtext/richtextborderspage.cpp:253
+#: ../src/richtext/richtextborderspage.cpp:287
+#: ../src/richtext/richtextborderspage.cpp:321
+#: ../src/richtext/richtextborderspage.cpp:355
+#: ../src/richtext/richtextborderspage.cpp:421
+#: ../src/richtext/richtextborderspage.cpp:455
+#: ../src/richtext/richtextborderspage.cpp:489
+#: ../src/richtext/richtextborderspage.cpp:523
+#: ../src/richtext/richtextborderspage.cpp:591
+#: ../src/richtext/richtextmarginspage.cpp:200
+#: ../src/richtext/richtextmarginspage.cpp:225
+#: ../src/richtext/richtextmarginspage.cpp:248
+#: ../src/richtext/richtextmarginspage.cpp:273
+#: ../src/richtext/richtextmarginspage.cpp:314
+#: ../src/richtext/richtextmarginspage.cpp:339
+#: ../src/richtext/richtextmarginspage.cpp:362
+#: ../src/richtext/richtextmarginspage.cpp:387
+#: ../src/richtext/richtextsizepage.cpp:338
+#: ../src/richtext/richtextsizepage.cpp:372
+#: ../src/richtext/richtextsizepage.cpp:399
+#: ../src/richtext/richtextsizepage.cpp:426
+#: ../src/richtext/richtextsizepage.cpp:453
+#: ../src/richtext/richtextsizepage.cpp:480
+#: ../src/richtext/richtextsizepage.cpp:554
+#: ../src/richtext/richtextsizepage.cpp:589
+#: ../src/richtext/richtextsizepage.cpp:624
+#: ../src/richtext/richtextsizepage.cpp:659
+msgid "cm"
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:226
+#: ../src/richtext/richtextbackgroundpage.cpp:249
+#: ../src/richtext/richtextbackgroundpage.cpp:289
+#: ../src/richtext/richtextbackgroundpage.cpp:316
+#: ../src/richtext/richtextborderspage.cpp:254
+#: ../src/richtext/richtextborderspage.cpp:288
+#: ../src/richtext/richtextborderspage.cpp:322
+#: ../src/richtext/richtextborderspage.cpp:356
+#: ../src/richtext/richtextborderspage.cpp:422
+#: ../src/richtext/richtextborderspage.cpp:456
+#: ../src/richtext/richtextborderspage.cpp:490
+#: ../src/richtext/richtextborderspage.cpp:524
+#: ../src/richtext/richtextborderspage.cpp:592
+#: ../src/richtext/richtextfontpage.cpp:176
+#: ../src/richtext/richtextfontpage.cpp:179
+msgid "pt"
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:229
+#: ../src/richtext/richtextbackgroundpage.cpp:231
+#: ../src/richtext/richtextbackgroundpage.cpp:252
+#: ../src/richtext/richtextbackgroundpage.cpp:254
+#: ../src/richtext/richtextbackgroundpage.cpp:292
+#: ../src/richtext/richtextbackgroundpage.cpp:294
+#: ../src/richtext/richtextbackgroundpage.cpp:319
+#: ../src/richtext/richtextbackgroundpage.cpp:321
+#, fuzzy
+msgid "Units for this value."
+msgstr "No es pot esperar per a l'acabament de cadena"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:234
+#, fuzzy
+msgid "&Vertical offset:"
+msgstr "dinovè"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:241
+#: ../src/richtext/richtextbackgroundpage.cpp:243
+#, fuzzy
+msgid "The vertical offset."
+msgstr "No s'ha pogut iniciar la impressió"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:257
+#, fuzzy
+msgid "Shadow c&olour:"
+msgstr "Trieu la font"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:259
+#: ../src/richtext/richtextbackgroundpage.cpp:261
+msgid "Enables the shadow colour."
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:265
+#: ../src/richtext/richtextbackgroundpage.cpp:267
+msgid "The shadow colour."
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:270
+msgid "Sh&adow spread:"
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:272
+#: ../src/richtext/richtextbackgroundpage.cpp:274
+msgid "Enables the shadow spread."
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:281
+#: ../src/richtext/richtextbackgroundpage.cpp:283
+msgid "The shadow spread."
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:297
+msgid "&Blur distance:"
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:299
+#: ../src/richtext/richtextbackgroundpage.cpp:301
+#, fuzzy
+msgid "Enables the blur distance."
+msgstr "No s'ha pogut iniciar la impressió"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:308
+#: ../src/richtext/richtextbackgroundpage.cpp:310
+msgid "The shadow blur distance."
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:324
+msgid "Opaci&ty:"
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:326
+#: ../src/richtext/richtextbackgroundpage.cpp:328
+msgid "Enables the shadow opacity."
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:335
+#: ../src/richtext/richtextbackgroundpage.cpp:337
+msgid "The shadow opacity."
+msgstr ""
+
+#. TRANSLATORS: Rich text page units (percentage)
+#: ../src/richtext/richtextbackgroundpage.cpp:340
+#: ../src/richtext/richtextsizepage.cpp:339
+#: ../src/richtext/richtextsizepage.cpp:373
+#: ../src/richtext/richtextsizepage.cpp:400
+#: ../src/richtext/richtextsizepage.cpp:427
+#: ../src/richtext/richtextsizepage.cpp:454
+#: ../src/richtext/richtextsizepage.cpp:481
+#: ../src/richtext/richtextsizepage.cpp:555
+#: ../src/richtext/richtextsizepage.cpp:590
+#: ../src/richtext/richtextsizepage.cpp:625
+#: ../src/richtext/richtextsizepage.cpp:660
+#, fuzzy
+msgid "%"
+msgstr "%d"
+
+#: ../src/richtext/richtextborderspage.cpp:229
+#: ../src/richtext/richtextborderspage.cpp:387
+#, fuzzy
+msgid "Border"
+msgstr "Modern"
+
+#: ../src/richtext/richtextborderspage.cpp:242
+#: ../src/richtext/richtextborderspage.cpp:410
+#: ../src/richtext/richtextindentspage.cpp:194
+#: ../src/richtext/richtextliststylepage.cpp:384
+#: ../src/richtext/richtextmarginspage.cpp:185
+#: ../src/richtext/richtextmarginspage.cpp:299
+#: ../src/richtext/richtextsizepage.cpp:531
+#: ../src/richtext/richtextsizepage.cpp:538
+msgid "&Left:"
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:257
+#: ../src/richtext/richtextborderspage.cpp:259
+msgid "Units for the left border width."
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:266
+#: ../src/richtext/richtextborderspage.cpp:268
+#: ../src/richtext/richtextborderspage.cpp:300
+#: ../src/richtext/richtextborderspage.cpp:302
+#: ../src/richtext/richtextborderspage.cpp:334
+#: ../src/richtext/richtextborderspage.cpp:336
+#: ../src/richtext/richtextborderspage.cpp:368
+#: ../src/richtext/richtextborderspage.cpp:370
+#: ../src/richtext/richtextborderspage.cpp:434
+#: ../src/richtext/richtextborderspage.cpp:436
+#: ../src/richtext/richtextborderspage.cpp:468
+#: ../src/richtext/richtextborderspage.cpp:470
+#: ../src/richtext/richtextborderspage.cpp:502
+#: ../src/richtext/richtextborderspage.cpp:504
+#: ../src/richtext/richtextborderspage.cpp:536
+#: ../src/richtext/richtextborderspage.cpp:538
+#, fuzzy
+msgid "The border line style."
+msgstr "Grandària de la font:"
+
+#: ../src/richtext/richtextborderspage.cpp:276
+#: ../src/richtext/richtextborderspage.cpp:444
+#: ../src/richtext/richtextindentspage.cpp:212
+#: ../src/richtext/richtextliststylepage.cpp:402
+#: ../src/richtext/richtextmarginspage.cpp:210
+#: ../src/richtext/richtextmarginspage.cpp:324
+#: ../src/richtext/richtextsizepage.cpp:601
+#: ../src/richtext/richtextsizepage.cpp:608
+#, fuzzy
+msgid "&Right:"
+msgstr "vuitè"
+
+#: ../src/richtext/richtextborderspage.cpp:291
+#: ../src/richtext/richtextborderspage.cpp:293
+msgid "Units for the right border width."
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:310
+#: ../src/richtext/richtextborderspage.cpp:478
+#: ../src/richtext/richtextmarginspage.cpp:233
+#: ../src/richtext/richtextmarginspage.cpp:347
+#: ../src/richtext/richtextsizepage.cpp:566
+#: ../src/richtext/richtextsizepage.cpp:573
+#, fuzzy
+msgid "&Top:"
+msgstr "Per a:"
+
+#: ../src/richtext/richtextborderspage.cpp:325
+#: ../src/richtext/richtextborderspage.cpp:327
+msgid "Units for the top border width."
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:344
+#: ../src/richtext/richtextborderspage.cpp:512
+#: ../src/richtext/richtextmarginspage.cpp:258
+#: ../src/richtext/richtextmarginspage.cpp:372
+#: ../src/richtext/richtextsizepage.cpp:636
+#: ../src/richtext/richtextsizepage.cpp:643
+msgid "&Bottom:"
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:359
+#: ../src/richtext/richtextborderspage.cpp:361
+msgid "Units for the bottom border width."
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:380
+#: ../src/richtext/richtextborderspage.cpp:548
+msgid "&Synchronize values"
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:382
+#: ../src/richtext/richtextborderspage.cpp:384
+#: ../src/richtext/richtextborderspage.cpp:550
+#: ../src/richtext/richtextborderspage.cpp:552
+msgid "Check to edit all borders simultaneously."
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:397
+#: ../src/richtext/richtextborderspage.cpp:555
+msgid "Outline"
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:425
+#: ../src/richtext/richtextborderspage.cpp:427
+msgid "Units for the left outline width."
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:459
+#: ../src/richtext/richtextborderspage.cpp:461
+msgid "Units for the right outline width."
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:493
+#: ../src/richtext/richtextborderspage.cpp:495
+msgid "Units for the top outline width."
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:527
+#: ../src/richtext/richtextborderspage.cpp:529
+msgid "Units for the bottom outline width."
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:565
+#: ../src/richtext/richtextborderspage.cpp:600
+msgid "Corner"
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:574
+msgid "Corner &radius:"
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:576
+#: ../src/richtext/richtextborderspage.cpp:578
+msgid "An optional corner radius for adding rounded corners."
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:584
+#: ../src/richtext/richtextborderspage.cpp:586
+msgid "The value of the corner radius."
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:595
+#: ../src/richtext/richtextborderspage.cpp:597
+#, fuzzy
+msgid "Units for the corner radius."
+msgstr "No es pot esperar per a l'acabament de cadena"
+
+#: ../src/richtext/richtextborderspage.cpp:609
+#: ../src/richtext/richtextsizepage.cpp:247
+#: ../src/richtext/richtextsizepage.cpp:251
+#, fuzzy
+msgid "None"
+msgstr "Fet"
+
+#: ../src/richtext/richtextborderspage.cpp:610
+#, fuzzy
+msgid "Solid"
+msgstr "Negreta"
+
+#: ../src/richtext/richtextborderspage.cpp:611
+#, fuzzy
+msgid "Dotted"
+msgstr "Fet"
+
+#: ../src/richtext/richtextborderspage.cpp:612
+#, fuzzy
+msgid "Dashed"
+msgstr "Data"
+
+#: ../src/richtext/richtextborderspage.cpp:613
+#, fuzzy
+msgid "Double"
+msgstr "Fet"
+
+#: ../src/richtext/richtextborderspage.cpp:614
+msgid "Groove"
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:615
+#, fuzzy
+msgid "Ridge"
+msgstr "Clar"
+
+#: ../src/richtext/richtextborderspage.cpp:616
+#, fuzzy
+msgid "Inset"
+msgstr "Índex"
+
+#: ../src/richtext/richtextborderspage.cpp:617
+msgid "Outset"
+msgstr ""
+
+#: ../src/richtext/richtextbuffer.cpp:3518
+msgid "Change Style"
+msgstr ""
+
+#: ../src/richtext/richtextbuffer.cpp:3701
+msgid "Change Object Style"
+msgstr ""
+
+#: ../src/richtext/richtextbuffer.cpp:3974
+#: ../src/richtext/richtextbuffer.cpp:8174
+#, fuzzy
+msgid "Change Properties"
+msgstr "&Previ"
+
+#: ../src/richtext/richtextbuffer.cpp:4346
+msgid "Change List Style"
+msgstr ""
+
+#: ../src/richtext/richtextbuffer.cpp:4519
+msgid "Renumber List"
+msgstr ""
+
+#: ../src/richtext/richtextbuffer.cpp:7867
+#: ../src/richtext/richtextbuffer.cpp:7897
+#: ../src/richtext/richtextbuffer.cpp:7939
+#: ../src/richtext/richtextctrl.cpp:1279 ../src/richtext/richtextctrl.cpp:1473
+msgid "Insert Text"
+msgstr ""
+
+#: ../src/richtext/richtextbuffer.cpp:8023
+#: ../src/richtext/richtextbuffer.cpp:8979
+msgid "Insert Image"
+msgstr ""
+
+#: ../src/richtext/richtextbuffer.cpp:8070
+#, fuzzy
+msgid "Insert Object"
+msgstr "Índex"
+
+#: ../src/richtext/richtextbuffer.cpp:8112
+#, fuzzy
+msgid "Insert Field"
+msgstr "Índex"
+
+#: ../src/richtext/richtextbuffer.cpp:8410
+msgid "Too many EndStyle calls!"
+msgstr ""
+
+#: ../src/richtext/richtextbuffer.cpp:8785
+#, fuzzy
+msgid "files"
+msgstr "&Mida"
+
+#: ../src/richtext/richtextbuffer.cpp:9380
+msgid "standard/circle"
+msgstr ""
+
+#: ../src/richtext/richtextbuffer.cpp:9381
+msgid "standard/circle-outline"
+msgstr ""
+
+#: ../src/richtext/richtextbuffer.cpp:9382
+msgid "standard/square"
+msgstr ""
+
+#: ../src/richtext/richtextbuffer.cpp:9383
+msgid "standard/diamond"
+msgstr ""
+
+#: ../src/richtext/richtextbuffer.cpp:9384
+msgid "standard/triangle"
+msgstr ""
+
+#: ../src/richtext/richtextbuffer.cpp:9423
+#, fuzzy
+msgid "Box Properties"
+msgstr "&Previ"
+
+#: ../src/richtext/richtextbuffer.cpp:10006
+msgid "Multiple Cell Properties"
+msgstr ""
+
+#: ../src/richtext/richtextbuffer.cpp:10008
+#, fuzzy
+msgid "Cell Properties"
+msgstr "&Previ"
+
+#: ../src/richtext/richtextbuffer.cpp:11256
+#, fuzzy
+msgid "Set Cell Style"
+msgstr "&Elimina"
+
+#: ../src/richtext/richtextbuffer.cpp:11330
+#, fuzzy
+msgid "Delete Row"
+msgstr "&Elimina"
+
+#: ../src/richtext/richtextbuffer.cpp:11380
+#, fuzzy
+msgid "Delete Column"
+msgstr "Seccions"
+
+#: ../src/richtext/richtextbuffer.cpp:11431
+msgid "Add Row"
+msgstr ""
+
+#: ../src/richtext/richtextbuffer.cpp:11494
+msgid "Add Column"
+msgstr ""
+
+#: ../src/richtext/richtextbuffer.cpp:11537
+#, fuzzy
+msgid "Table Properties"
+msgstr "&Previ"
+
+#: ../src/richtext/richtextbuffer.cpp:12899
+#, fuzzy
+msgid "Picture Properties"
+msgstr "&Previ"
+
+#: ../src/richtext/richtextbuffer.cpp:13169
+#: ../src/richtext/richtextbuffer.cpp:13279
+#, fuzzy
+msgid "image"
+msgstr "Temps"
+
+#: ../src/richtext/richtextbulletspage.cpp:145
+#: ../src/richtext/richtextliststylepage.cpp:209
+msgid "&Bullet style:"
+msgstr ""
+
+#: ../src/richtext/richtextbulletspage.cpp:150
+#: ../src/richtext/richtextbulletspage.cpp:152
+#: ../src/richtext/richtextliststylepage.cpp:214
+#: ../src/richtext/richtextliststylepage.cpp:216
+msgid "The available bullet styles."
+msgstr ""
+
+#: ../src/richtext/richtextbulletspage.cpp:158
+#: ../src/richtext/richtextliststylepage.cpp:221
+msgid "Peri&od"
+msgstr ""
+
+#: ../src/richtext/richtextbulletspage.cpp:160
+#: ../src/richtext/richtextbulletspage.cpp:162
+#: ../src/richtext/richtextliststylepage.cpp:223
+#: ../src/richtext/richtextliststylepage.cpp:225
+msgid "Check to add a period after the bullet."
+msgstr ""
+
+#. TRANSLATORS: Bullet point in parentheses option
+#: ../src/richtext/richtextbulletspage.cpp:167
+#: ../src/richtext/richtextliststylepage.cpp:230
+msgid "(*)"
+msgstr ""
+
+#: ../src/richtext/richtextbulletspage.cpp:169
+#: ../src/richtext/richtextbulletspage.cpp:171
+#: ../src/richtext/richtextliststylepage.cpp:232
+#: ../src/richtext/richtextliststylepage.cpp:234
+msgid "Check to enclose the bullet in parentheses."
+msgstr ""
+
+#. TRANSLATORS: Right parenthesis bullet point option
+#: ../src/richtext/richtextbulletspage.cpp:176
+#: ../src/richtext/richtextliststylepage.cpp:239
+msgid "*)"
+msgstr ""
+
+#: ../src/richtext/richtextbulletspage.cpp:178
+#: ../src/richtext/richtextbulletspage.cpp:180
+#: ../src/richtext/richtextliststylepage.cpp:241
+#: ../src/richtext/richtextliststylepage.cpp:243
+msgid "Check to add a right parenthesis."
+msgstr ""
+
+#: ../src/richtext/richtextbulletspage.cpp:185
+#: ../src/richtext/richtextliststylepage.cpp:248
+msgid "Bullet &Alignment:"
+msgstr ""
+
+#: ../src/richtext/richtextbulletspage.cpp:190
+#: ../src/richtext/richtextliststylepage.cpp:253
+msgid "Centre"
+msgstr ""
+
+#: ../src/richtext/richtextbulletspage.cpp:194
+#: ../src/richtext/richtextbulletspage.cpp:196
+#: ../src/richtext/richtextbulletspage.cpp:217
+#: ../src/richtext/richtextbulletspage.cpp:219
+#: ../src/richtext/richtextliststylepage.cpp:257
+#: ../src/richtext/richtextliststylepage.cpp:259
+#: ../src/richtext/richtextliststylepage.cpp:278
+#: ../src/richtext/richtextliststylepage.cpp:280
+msgid "The bullet character."
+msgstr ""
+
+#: ../src/richtext/richtextbulletspage.cpp:212
+#: ../src/richtext/richtextliststylepage.cpp:271
+msgid "&Symbol:"
+msgstr ""
+
+#: ../src/richtext/richtextbulletspage.cpp:222
+#: ../src/richtext/richtextliststylepage.cpp:283
+#, fuzzy
+msgid "Ch&oose..."
+msgstr "&Tanca"
+
+#: ../src/richtext/richtextbulletspage.cpp:223
+#: ../src/richtext/richtextbulletspage.cpp:225
+#: ../src/richtext/richtextliststylepage.cpp:284
+#: ../src/richtext/richtextliststylepage.cpp:286
+msgid "Click to browse for a symbol."
+msgstr ""
+
+#: ../src/richtext/richtextbulletspage.cpp:230
+#: ../src/richtext/richtextliststylepage.cpp:291
+#, fuzzy
+msgid "Symbol &font:"
+msgstr "Font normal"
+
+#: ../src/richtext/richtextbulletspage.cpp:235
+#: ../src/richtext/richtextbulletspage.cpp:237
+#: ../src/richtext/richtextliststylepage.cpp:297
+msgid "Available fonts."
+msgstr ""
+
+#: ../src/richtext/richtextbulletspage.cpp:242
+#: ../src/richtext/richtextliststylepage.cpp:302
+msgid "S&tandard bullet name:"
+msgstr ""
+
+#: ../src/richtext/richtextbulletspage.cpp:247
+#: ../src/richtext/richtextbulletspage.cpp:249
+#: ../src/richtext/richtextliststylepage.cpp:307
+#: ../src/richtext/richtextliststylepage.cpp:309
+msgid "A standard bullet name."
+msgstr ""
+
+#: ../src/richtext/richtextbulletspage.cpp:254
+msgid "&Number:"
+msgstr ""
+
+#: ../src/richtext/richtextbulletspage.cpp:258
+#: ../src/richtext/richtextbulletspage.cpp:260
+msgid "The list item number."
+msgstr ""
+
+#: ../src/richtext/richtextbulletspage.cpp:266
+#: ../src/richtext/richtextbulletspage.cpp:268
+#: ../src/richtext/richtextliststylepage.cpp:475
+#: ../src/richtext/richtextliststylepage.cpp:477
+msgid "Shows a preview of the bullet settings."
+msgstr ""
+
+#: ../src/richtext/richtextbulletspage.cpp:276
+#: ../src/richtext/richtextliststylepage.cpp:484
+msgid "(None)"
+msgstr ""
+
+#: ../src/richtext/richtextbulletspage.cpp:277
+#: ../src/richtext/richtextliststylepage.cpp:485
+msgid "Arabic"
+msgstr ""
+
+#: ../src/richtext/richtextbulletspage.cpp:278
+#: ../src/richtext/richtextliststylepage.cpp:486
+msgid "Upper case letters"
+msgstr ""
+
+#: ../src/richtext/richtextbulletspage.cpp:279
+#: ../src/richtext/richtextliststylepage.cpp:487
+msgid "Lower case letters"
+msgstr ""
+
+#: ../src/richtext/richtextbulletspage.cpp:280
+#: ../src/richtext/richtextliststylepage.cpp:488
+msgid "Upper case roman numerals"
+msgstr ""
+
+#: ../src/richtext/richtextbulletspage.cpp:281
+#: ../src/richtext/richtextliststylepage.cpp:489
+msgid "Lower case roman numerals"
+msgstr ""
+
+#: ../src/richtext/richtextbulletspage.cpp:282
+#: ../src/richtext/richtextliststylepage.cpp:490
+msgid "Numbered outline"
+msgstr ""
+
+#: ../src/richtext/richtextbulletspage.cpp:283
+#: ../src/richtext/richtextliststylepage.cpp:491
+msgid "Symbol"
+msgstr ""
+
+#: ../src/richtext/richtextbulletspage.cpp:284
+#: ../src/richtext/richtextliststylepage.cpp:492
+msgid "Bitmap"
+msgstr ""
+
+#: ../src/richtext/richtextbulletspage.cpp:285
+#: ../src/richtext/richtextliststylepage.cpp:493
+msgid "Standard"
+msgstr ""
+
+#: ../src/richtext/richtextbulletspage.cpp:287
+#: ../src/richtext/richtextliststylepage.cpp:495
+msgid "*"
+msgstr ""
+
+#: ../src/richtext/richtextbulletspage.cpp:288
+#: ../src/richtext/richtextliststylepage.cpp:496
+msgid "-"
+msgstr ""
+
+#: ../src/richtext/richtextbulletspage.cpp:289
+#: ../src/richtext/richtextliststylepage.cpp:497
+msgid ">"
+msgstr ""
+
+#: ../src/richtext/richtextbulletspage.cpp:290
+#: ../src/richtext/richtextliststylepage.cpp:498
+msgid "+"
+msgstr ""
+
+#: ../src/richtext/richtextbulletspage.cpp:291
+#: ../src/richtext/richtextliststylepage.cpp:499
+msgid "~"
+msgstr ""
+
+#: ../src/richtext/richtextctrl.cpp:859
+msgid "Drag"
+msgstr ""
+
+#: ../src/richtext/richtextctrl.cpp:1338 ../src/richtext/richtextctrl.cpp:1559
+#, fuzzy
+msgid "Delete Text"
+msgstr "&Elimina"
+
+#: ../src/richtext/richtextctrl.cpp:1537
+msgid "Remove Bullet"
+msgstr ""
+
+#: ../src/richtext/richtextctrl.cpp:3070
+msgid "The text couldn't be saved."
+msgstr "No s'ha pogut alçar el text."
+
+#: ../src/richtext/richtextctrl.cpp:3644
+#, fuzzy
+msgid "Replace"
+msgstr "&Substituix"
+
+#: ../src/richtext/richtextfontpage.cpp:146
+#: ../src/richtext/richtextsymboldlg.cpp:384
+#, fuzzy
+msgid "&Font:"
+msgstr "Grandària de la font:"
+
+#: ../src/richtext/richtextfontpage.cpp:150
+#: ../src/richtext/richtextfontpage.cpp:152
+msgid "Type a font name."
+msgstr ""
+
+#: ../src/richtext/richtextfontpage.cpp:158
+#, fuzzy
+msgid "&Size:"
+msgstr "&Mida"
+
+#: ../src/richtext/richtextfontpage.cpp:165
+#: ../src/richtext/richtextfontpage.cpp:167
+msgid "Type a size in points."
+msgstr ""
+
+#: ../src/richtext/richtextfontpage.cpp:180
+#: ../src/richtext/richtextfontpage.cpp:182
+#, fuzzy
+msgid "The font size units, points or pixels."
+msgstr "Grandària de la font:"
+
+#: ../src/richtext/richtextfontpage.cpp:189
+#: ../src/richtext/richtextfontpage.cpp:191
+#, fuzzy
+msgid "Lists the available fonts."
+msgstr "Els consells no es troben disponibles!"
+
+#: ../src/richtext/richtextfontpage.cpp:196
+#: ../src/richtext/richtextfontpage.cpp:198
+msgid "Lists font sizes in points."
+msgstr ""
+
+#: ../src/richtext/richtextfontpage.cpp:207
+#, fuzzy
+msgid "Font st&yle:"
+msgstr "Grandària de la font:"
+
+#: ../src/richtext/richtextfontpage.cpp:212
+#: ../src/richtext/richtextfontpage.cpp:214
+msgid "Select regular or italic style."
+msgstr ""
+
+#: ../src/richtext/richtextfontpage.cpp:220
+#, fuzzy
+msgid "Font &weight:"
+msgstr "vuitè"
+
+#: ../src/richtext/richtextfontpage.cpp:225
+#: ../src/richtext/richtextfontpage.cpp:227
+msgid "Select regular or bold."
+msgstr ""
+
+#: ../src/richtext/richtextfontpage.cpp:233
+#, fuzzy
+msgid "&Underlining:"
+msgstr "Subratllat"
+
+#: ../src/richtext/richtextfontpage.cpp:238
+#: ../src/richtext/richtextfontpage.cpp:240
+msgid "Select underlining or no underlining."
+msgstr ""
+
+#: ../src/richtext/richtextfontpage.cpp:248
+msgid "&Colour:"
+msgstr ""
+
+#: ../src/richtext/richtextfontpage.cpp:253
+#: ../src/richtext/richtextfontpage.cpp:255
+msgid "Click to change the text colour."
+msgstr ""
+
+#: ../src/richtext/richtextfontpage.cpp:261
+msgid "&Bg colour:"
+msgstr ""
+
+#: ../src/richtext/richtextfontpage.cpp:266
+#: ../src/richtext/richtextfontpage.cpp:268
+msgid "Click to change the text background colour."
+msgstr ""
+
+#: ../src/richtext/richtextfontpage.cpp:276
+#: ../src/richtext/richtextfontpage.cpp:278
+msgid "Check to show a line through the text."
+msgstr ""
+
+#: ../src/richtext/richtextfontpage.cpp:281
+msgid "Ca&pitals"
+msgstr ""
+
+#: ../src/richtext/richtextfontpage.cpp:283
+#: ../src/richtext/richtextfontpage.cpp:285
+msgid "Check to show the text in capitals."
+msgstr ""
+
+#: ../src/richtext/richtextfontpage.cpp:288
+msgid "Small C&apitals"
+msgstr ""
+
+#: ../src/richtext/richtextfontpage.cpp:290
+#: ../src/richtext/richtextfontpage.cpp:292
+msgid "Check to show the text in small capitals."
+msgstr ""
+
+#: ../src/richtext/richtextfontpage.cpp:295
+#, fuzzy
+msgid "Supe&rscript"
+msgstr "Script"
+
+#: ../src/richtext/richtextfontpage.cpp:297
+#: ../src/richtext/richtextfontpage.cpp:299
+msgid "Check to show the text in superscript."
+msgstr ""
+
+#: ../src/richtext/richtextfontpage.cpp:302
+#, fuzzy
+msgid "Subscrip&t"
+msgstr "Script"
+
+#: ../src/richtext/richtextfontpage.cpp:304
+#: ../src/richtext/richtextfontpage.cpp:306
+msgid "Check to show the text in subscript."
+msgstr ""
+
+#: ../src/richtext/richtextfontpage.cpp:312
+msgid "Rig&ht-to-left"
+msgstr ""
+
+#: ../src/richtext/richtextfontpage.cpp:314
+#: ../src/richtext/richtextfontpage.cpp:316
+msgid "Check to indicate right-to-left text layout."
+msgstr ""
+
+#: ../src/richtext/richtextfontpage.cpp:319
+msgid "Suppress hyphe&nation"
+msgstr ""
+
+#: ../src/richtext/richtextfontpage.cpp:321
+#: ../src/richtext/richtextfontpage.cpp:323
+msgid "Check to suppress hyphenation."
+msgstr ""
+
+#: ../src/richtext/richtextfontpage.cpp:329
+#: ../src/richtext/richtextfontpage.cpp:331
+msgid "Shows a preview of the font settings."
+msgstr ""
+
+#: ../src/richtext/richtextfontpage.cpp:348
+#: ../src/richtext/richtextfontpage.cpp:352
+#: ../src/richtext/richtextfontpage.cpp:356
+#: ../src/richtext/richtextformatdlg.cpp:873
+#: ../src/richtext/richtextindentspage.cpp:273
+#: ../src/richtext/richtextindentspage.cpp:285
+#: ../src/richtext/richtextindentspage.cpp:286
+#: ../src/richtext/richtextindentspage.cpp:310
+#: ../src/richtext/richtextindentspage.cpp:325
+#: ../src/richtext/richtextliststylepage.cpp:451
+#: ../src/richtext/richtextliststylepage.cpp:463
+#: ../src/richtext/richtextliststylepage.cpp:464
+#, fuzzy
+msgid "(none)"
+msgstr "sense nom"
+
+#: ../src/richtext/richtextfontpage.cpp:349
+#: ../src/richtext/richtextfontpage.cpp:353
+msgid "Regular"
+msgstr ""
+
+#: ../src/richtext/richtextfontpage.cpp:357
+#, fuzzy
+msgid "Not underlined"
+msgstr "subratllat"
+
+#: ../src/richtext/richtextformatdlg.cpp:341
+msgid "Indents && Spacing"
+msgstr ""
+
+#: ../src/richtext/richtextformatdlg.cpp:346
+msgid "Tabs"
+msgstr ""
+
+#: ../src/richtext/richtextformatdlg.cpp:351
+msgid "Bullets"
+msgstr ""
+
+#: ../src/richtext/richtextformatdlg.cpp:356
+msgid "List Style"
+msgstr ""
+
+#: ../src/richtext/richtextformatdlg.cpp:366
+#: ../src/richtext/richtextmarginspage.cpp:170
+msgid "Margins"
+msgstr ""
+
+#: ../src/richtext/richtextformatdlg.cpp:371
+#, fuzzy
+msgid "Borders"
+msgstr "Modern"
+
+#: ../src/richtext/richtextformatdlg.cpp:765
+#, fuzzy
+msgid "Colour"
+msgstr "Trieu la font"
+
+#: ../src/richtext/richtextindentspage.cpp:127
+#: ../src/richtext/richtextliststylepage.cpp:322
+#, fuzzy
+msgid "&Alignment"
+msgstr "dinovè"
+
+#: ../src/richtext/richtextindentspage.cpp:138
+#: ../src/richtext/richtextliststylepage.cpp:331
+msgid "&Left"
+msgstr ""
+
+#: ../src/richtext/richtextindentspage.cpp:140
+#: ../src/richtext/richtextindentspage.cpp:142
+#: ../src/richtext/richtextliststylepage.cpp:333
+#: ../src/richtext/richtextliststylepage.cpp:335
+msgid "Left-align text."
+msgstr ""
+
+#: ../src/richtext/richtextindentspage.cpp:145
+#: ../src/richtext/richtextliststylepage.cpp:338
+#, fuzzy
+msgid "&Right"
+msgstr "Clar"
+
+#: ../src/richtext/richtextindentspage.cpp:147
+#: ../src/richtext/richtextindentspage.cpp:149
+#: ../src/richtext/richtextliststylepage.cpp:340
+#: ../src/richtext/richtextliststylepage.cpp:342
+msgid "Right-align text."
+msgstr ""
+
+#: ../src/richtext/richtextindentspage.cpp:152
+#: ../src/richtext/richtextliststylepage.cpp:345
+msgid "&Justified"
+msgstr ""
+
+#: ../src/richtext/richtextindentspage.cpp:154
+#: ../src/richtext/richtextindentspage.cpp:156
+#: ../src/richtext/richtextliststylepage.cpp:347
+#: ../src/richtext/richtextliststylepage.cpp:349
+msgid "Justify text left and right."
+msgstr ""
+
+#: ../src/richtext/richtextindentspage.cpp:159
+#: ../src/richtext/richtextliststylepage.cpp:352
+msgid "Cen&tred"
+msgstr ""
+
+#: ../src/richtext/richtextindentspage.cpp:161
+#: ../src/richtext/richtextindentspage.cpp:163
+#: ../src/richtext/richtextliststylepage.cpp:354
+#: ../src/richtext/richtextliststylepage.cpp:356
+#, fuzzy
+msgid "Centre text."
+msgstr "No es pot crear un fil"
+
+#: ../src/richtext/richtextindentspage.cpp:166
+#: ../src/richtext/richtextliststylepage.cpp:359
+#, fuzzy
+msgid "&Indeterminate"
+msgstr "Subratllat"
+
+#: ../src/richtext/richtextindentspage.cpp:168
+#: ../src/richtext/richtextindentspage.cpp:170
+#: ../src/richtext/richtextliststylepage.cpp:361
+#: ../src/richtext/richtextliststylepage.cpp:363
+msgid "Use the current alignment setting."
+msgstr ""
+
+#: ../src/richtext/richtextindentspage.cpp:183
+#: ../src/richtext/richtextliststylepage.cpp:375
+msgid "&Indentation (tenths of a mm)"
+msgstr ""
+
+#: ../src/richtext/richtextindentspage.cpp:198
+#: ../src/richtext/richtextindentspage.cpp:200
+#: ../src/richtext/richtextliststylepage.cpp:388
+#: ../src/richtext/richtextliststylepage.cpp:390
+#, fuzzy
+msgid "The left indent."
+msgstr "Grandària de la font:"
+
+#: ../src/richtext/richtextindentspage.cpp:203
+#: ../src/richtext/richtextliststylepage.cpp:393
+msgid "Left (&first line):"
+msgstr ""
+
+#: ../src/richtext/richtextindentspage.cpp:207
+#: ../src/richtext/richtextindentspage.cpp:209
+#: ../src/richtext/richtextliststylepage.cpp:397
+#: ../src/richtext/richtextliststylepage.cpp:399
+#, fuzzy
+msgid "The first line indent."
+msgstr "Grandària de la font:"
+
+#: ../src/richtext/richtextindentspage.cpp:216
+#: ../src/richtext/richtextindentspage.cpp:218
+#: ../src/richtext/richtextliststylepage.cpp:406
+#: ../src/richtext/richtextliststylepage.cpp:408
+msgid "The right indent."
+msgstr ""
+
+#: ../src/richtext/richtextindentspage.cpp:221
+msgid "&Outline level:"
+msgstr ""
+
+#: ../src/richtext/richtextindentspage.cpp:226
+#: ../src/richtext/richtextindentspage.cpp:228
+#, fuzzy
+msgid "The outline level."
+msgstr "Grandària de la font:"
+
+#: ../src/richtext/richtextindentspage.cpp:241
+#: ../src/richtext/richtextliststylepage.cpp:420
+msgid "&Spacing (tenths of a mm)"
+msgstr ""
+
+#: ../src/richtext/richtextindentspage.cpp:252
+msgid "&Before a paragraph:"
+msgstr ""
+
+#: ../src/richtext/richtextindentspage.cpp:256
+#: ../src/richtext/richtextindentspage.cpp:258
+#: ../src/richtext/richtextliststylepage.cpp:433
+#: ../src/richtext/richtextliststylepage.cpp:435
+msgid "The spacing before the paragraph."
+msgstr ""
+
+#: ../src/richtext/richtextindentspage.cpp:261
+msgid "&After a paragraph:"
+msgstr ""
+
+#: ../src/richtext/richtextindentspage.cpp:266
+#: ../src/richtext/richtextliststylepage.cpp:442
+#: ../src/richtext/richtextliststylepage.cpp:444
+msgid "The spacing after the paragraph."
+msgstr ""
+
+#: ../src/richtext/richtextindentspage.cpp:269
+msgid "L&ine spacing:"
+msgstr ""
+
+#: ../src/richtext/richtextindentspage.cpp:274
+#: ../src/richtext/richtextliststylepage.cpp:452
+msgid "Single"
+msgstr ""
+
+#: ../src/richtext/richtextindentspage.cpp:275
+#: ../src/richtext/richtextliststylepage.cpp:453
+msgid "1.1"
+msgstr ""
+
+#: ../src/richtext/richtextindentspage.cpp:276
+#: ../src/richtext/richtextliststylepage.cpp:454
+msgid "1.2"
+msgstr ""
+
+#: ../src/richtext/richtextindentspage.cpp:277
+#: ../src/richtext/richtextliststylepage.cpp:455
+msgid "1.3"
+msgstr ""
+
+#: ../src/richtext/richtextindentspage.cpp:278
+#: ../src/richtext/richtextliststylepage.cpp:456
+msgid "1.4"
+msgstr ""
+
+#: ../src/richtext/richtextindentspage.cpp:279
+#: ../src/richtext/richtextliststylepage.cpp:457
+msgid "1.5"
+msgstr ""
+
+#: ../src/richtext/richtextindentspage.cpp:280
+#: ../src/richtext/richtextliststylepage.cpp:458
+msgid "1.6"
+msgstr ""
+
+#: ../src/richtext/richtextindentspage.cpp:281
+#: ../src/richtext/richtextliststylepage.cpp:459
+msgid "1.7"
+msgstr ""
+
+#: ../src/richtext/richtextindentspage.cpp:282
+#: ../src/richtext/richtextliststylepage.cpp:460
+msgid "1.8"
+msgstr ""
+
+#: ../src/richtext/richtextindentspage.cpp:283
+#: ../src/richtext/richtextliststylepage.cpp:461
+msgid "1.9"
+msgstr ""
+
+#: ../src/richtext/richtextindentspage.cpp:284
+#: ../src/richtext/richtextliststylepage.cpp:462
+msgid "2"
+msgstr ""
+
+#: ../src/richtext/richtextindentspage.cpp:287
+#: ../src/richtext/richtextindentspage.cpp:289
+#: ../src/richtext/richtextliststylepage.cpp:465
+#: ../src/richtext/richtextliststylepage.cpp:467
+msgid "The line spacing."
+msgstr ""
+
+#: ../src/richtext/richtextindentspage.cpp:292
+msgid "&Page Break"
+msgstr ""
+
+#: ../src/richtext/richtextindentspage.cpp:294
+#: ../src/richtext/richtextindentspage.cpp:296
+msgid "Inserts a page break before the paragraph."
+msgstr ""
+
+#: ../src/richtext/richtextindentspage.cpp:302
+#: ../src/richtext/richtextindentspage.cpp:304
+msgid "Shows a preview of the paragraph settings."
+msgstr ""
+
+#: ../src/richtext/richtextliststylepage.cpp:182
+msgid "&List level:"
+msgstr ""
+
+#: ../src/richtext/richtextliststylepage.cpp:186
+#: ../src/richtext/richtextliststylepage.cpp:188
+msgid "Selects the list level to edit."
+msgstr ""
+
+#: ../src/richtext/richtextliststylepage.cpp:193
+msgid "&Font for Level..."
+msgstr ""
+
+#: ../src/richtext/richtextliststylepage.cpp:194
+#: ../src/richtext/richtextliststylepage.cpp:196
+msgid "Click to choose the font for this level."
+msgstr ""
+
+#: ../src/richtext/richtextliststylepage.cpp:312
+msgid "Bullet style"
+msgstr ""
+
+#: ../src/richtext/richtextliststylepage.cpp:429
+msgid "Before a paragraph:"
+msgstr ""
+
+#: ../src/richtext/richtextliststylepage.cpp:438
+msgid "After a paragraph:"
+msgstr ""
+
+#: ../src/richtext/richtextliststylepage.cpp:447
+msgid "Line spacing:"
+msgstr ""
+
+#: ../src/richtext/richtextliststylepage.cpp:470
+#, fuzzy
+msgid "Spacing"
+msgstr "S'està cercant..."
+
+#: ../src/richtext/richtextmarginspage.cpp:193
+#: ../src/richtext/richtextmarginspage.cpp:195
+#, fuzzy
+msgid "The left margin size."
+msgstr "Grandària de la font:"
+
+#: ../src/richtext/richtextmarginspage.cpp:203
+#: ../src/richtext/richtextmarginspage.cpp:205
+msgid "Units for the left margin."
+msgstr ""
+
+#: ../src/richtext/richtextmarginspage.cpp:218
+#: ../src/richtext/richtextmarginspage.cpp:220
+#, fuzzy
+msgid "The right margin size."
+msgstr "Grandària de la font:"
+
+#: ../src/richtext/richtextmarginspage.cpp:228
+#: ../src/richtext/richtextmarginspage.cpp:230
+msgid "Units for the right margin."
+msgstr ""
+
+#: ../src/richtext/richtextmarginspage.cpp:241
+#: ../src/richtext/richtextmarginspage.cpp:243
+#, fuzzy
+msgid "The top margin size."
+msgstr "Grandària de la font:"
+
+#: ../src/richtext/richtextmarginspage.cpp:251
+#: ../src/richtext/richtextmarginspage.cpp:253
+#, fuzzy
+msgid "Units for the top margin."
+msgstr "No es pot esperar per a l'acabament de cadena"
+
+#: ../src/richtext/richtextmarginspage.cpp:266
+#: ../src/richtext/richtextmarginspage.cpp:268
+#, fuzzy
+msgid "The bottom margin size."
+msgstr "Grandària de la font:"
+
+#: ../src/richtext/richtextmarginspage.cpp:276
+#: ../src/richtext/richtextmarginspage.cpp:278
+msgid "Units for the bottom margin."
+msgstr ""
+
+#: ../src/richtext/richtextmarginspage.cpp:284
+#, fuzzy
+msgid "Padding"
+msgstr "s'està llegint"
+
+#: ../src/richtext/richtextmarginspage.cpp:307
+#: ../src/richtext/richtextmarginspage.cpp:309
+#, fuzzy
+msgid "The left padding size."
+msgstr "Grandària de la font:"
+
+#: ../src/richtext/richtextmarginspage.cpp:317
+#: ../src/richtext/richtextmarginspage.cpp:319
+msgid "Units for the left padding."
+msgstr ""
+
+#: ../src/richtext/richtextmarginspage.cpp:332
+#: ../src/richtext/richtextmarginspage.cpp:334
+#, fuzzy
+msgid "The right padding size."
+msgstr "Grandària de la font:"
+
+#: ../src/richtext/richtextmarginspage.cpp:342
+#: ../src/richtext/richtextmarginspage.cpp:344
+msgid "Units for the right padding."
+msgstr ""
+
+#: ../src/richtext/richtextmarginspage.cpp:355
+#: ../src/richtext/richtextmarginspage.cpp:357
+#, fuzzy
+msgid "The top padding size."
+msgstr "Grandària de la font:"
+
+#: ../src/richtext/richtextmarginspage.cpp:365
+#: ../src/richtext/richtextmarginspage.cpp:367
+msgid "Units for the top padding."
+msgstr ""
+
+#: ../src/richtext/richtextmarginspage.cpp:380
+#: ../src/richtext/richtextmarginspage.cpp:382
+#, fuzzy
+msgid "The bottom padding size."
+msgstr "Grandària de la font:"
+
+#: ../src/richtext/richtextmarginspage.cpp:390
+#: ../src/richtext/richtextmarginspage.cpp:392
+msgid "Units for the bottom padding."
+msgstr ""
+
+#: ../src/richtext/richtextprint.cpp:592
+msgid " Preview"
+msgstr " Previsualitza"
+
+#: ../src/richtext/richtextsizepage.cpp:228
+msgid "Floating"
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:243
+msgid "&Floating mode:"
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:252
+#: ../src/richtext/richtextsizepage.cpp:254
+msgid "How the object will float relative to the text."
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:265
+#, fuzzy
+msgid "Alignment"
+msgstr "dinovè"
+
+#: ../src/richtext/richtextsizepage.cpp:277
+#, fuzzy
+msgid "&Vertical alignment:"
+msgstr "dinovè"
+
+#: ../src/richtext/richtextsizepage.cpp:279
+#: ../src/richtext/richtextsizepage.cpp:281
+#, fuzzy
+msgid "Enable vertical alignment."
+msgstr "No s'ha pogut iniciar la impressió"
+
+#: ../src/richtext/richtextsizepage.cpp:286
+#, fuzzy
+msgid "Centred"
+msgstr "No es pot crear un fil"
+
+#: ../src/richtext/richtextsizepage.cpp:290
+#: ../src/richtext/richtextsizepage.cpp:292
+#, fuzzy
+msgid "Vertical alignment."
+msgstr "No s'ha pogut iniciar la impressió"
+
+#: ../src/richtext/richtextsizepage.cpp:316
+#: ../src/richtext/richtextsizepage.cpp:323
+#, fuzzy
+msgid "&Width:"
+msgstr "vuitè"
+
+#: ../src/richtext/richtextsizepage.cpp:318
+#: ../src/richtext/richtextsizepage.cpp:320
+msgid "Enable the width value."
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:331
+#: ../src/richtext/richtextsizepage.cpp:333
+#, fuzzy
+msgid "The object width."
+msgstr "Grandària de la font:"
+
+#: ../src/richtext/richtextsizepage.cpp:342
+#: ../src/richtext/richtextsizepage.cpp:344
+msgid "Units for the object width."
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:350
+#: ../src/richtext/richtextsizepage.cpp:357
+#, fuzzy
+msgid "&Height:"
+msgstr "vuitè"
+
+#: ../src/richtext/richtextsizepage.cpp:352
+#: ../src/richtext/richtextsizepage.cpp:354
+#: ../src/richtext/richtextsizepage.cpp:464
+#: ../src/richtext/richtextsizepage.cpp:466
+msgid "Enable the height value."
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:365
+#: ../src/richtext/richtextsizepage.cpp:367
+msgid "The object height."
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:376
+#: ../src/richtext/richtextsizepage.cpp:378
+msgid "Units for the object height."
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:381
+msgid "Min width:"
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:383
+#: ../src/richtext/richtextsizepage.cpp:385
+#, fuzzy
+msgid "Enable the minimum width value."
+msgstr "No s'ha pogut iniciar la impressió"
+
+#: ../src/richtext/richtextsizepage.cpp:392
+#: ../src/richtext/richtextsizepage.cpp:394
+#, fuzzy
+msgid "The object minimum width."
+msgstr "Grandària de la font:"
+
+#: ../src/richtext/richtextsizepage.cpp:403
+#: ../src/richtext/richtextsizepage.cpp:405
+#, fuzzy
+msgid "Units for the minimum object width."
+msgstr "Grandària de la font:"
+
+#: ../src/richtext/richtextsizepage.cpp:408
+#, fuzzy
+msgid "Min height:"
+msgstr "vuitè"
+
+#: ../src/richtext/richtextsizepage.cpp:410
+#: ../src/richtext/richtextsizepage.cpp:412
+msgid "Enable the minimum height value."
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:419
+#: ../src/richtext/richtextsizepage.cpp:421
+#, fuzzy
+msgid "The object minimum height."
+msgstr "Grandària de la font:"
+
+#: ../src/richtext/richtextsizepage.cpp:430
+#: ../src/richtext/richtextsizepage.cpp:432
+msgid "Units for the minimum object height."
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:435
+#, fuzzy
+msgid "Max width:"
+msgstr "Substituix amb:"
+
+#: ../src/richtext/richtextsizepage.cpp:437
+#: ../src/richtext/richtextsizepage.cpp:439
+#, fuzzy
+msgid "Enable the maximum width value."
+msgstr "No s'ha pogut iniciar la impressió"
+
+#: ../src/richtext/richtextsizepage.cpp:446
+#: ../src/richtext/richtextsizepage.cpp:448
+#, fuzzy
+msgid "The object maximum width."
+msgstr "Grandària de la font:"
+
+#: ../src/richtext/richtextsizepage.cpp:457
+#: ../src/richtext/richtextsizepage.cpp:459
+#, fuzzy
+msgid "Units for the maximum object width."
+msgstr "Grandària de la font:"
+
+#: ../src/richtext/richtextsizepage.cpp:462
+#, fuzzy
+msgid "Max height:"
+msgstr "vuitè"
+
+#: ../src/richtext/richtextsizepage.cpp:473
+#: ../src/richtext/richtextsizepage.cpp:475
+#, fuzzy
+msgid "The object maximum height."
+msgstr "Grandària de la font:"
+
+#: ../src/richtext/richtextsizepage.cpp:484
+#: ../src/richtext/richtextsizepage.cpp:486
+msgid "Units for the maximum object height."
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:495
+#, fuzzy
+msgid "Position"
+msgstr "Pregunta"
+
+#: ../src/richtext/richtextsizepage.cpp:513
+#, fuzzy
+msgid "&Position mode:"
+msgstr "Pregunta"
+
+#: ../src/richtext/richtextsizepage.cpp:517
+#: ../src/richtext/richtextsizepage.cpp:522
+#, fuzzy
+msgid "Static"
+msgstr "Estat:"
+
+#: ../src/richtext/richtextsizepage.cpp:518
+#, fuzzy
+msgid "Relative"
+msgstr "Decoratiu"
+
+#: ../src/richtext/richtextsizepage.cpp:519
+msgid "Absolute"
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:520
+#, fuzzy
+msgid "Fixed"
+msgstr "Font fixada:"
+
+#: ../src/richtext/richtextsizepage.cpp:533
+#: ../src/richtext/richtextsizepage.cpp:535
+#: ../src/richtext/richtextsizepage.cpp:547
+#: ../src/richtext/richtextsizepage.cpp:549
+#, fuzzy
+msgid "The left position."
+msgstr "Grandària de la font:"
+
+#: ../src/richtext/richtextsizepage.cpp:558
+#: ../src/richtext/richtextsizepage.cpp:560
+#, fuzzy
+msgid "Units for the left position."
+msgstr "No es pot esperar per a l'acabament de cadena"
+
+#: ../src/richtext/richtextsizepage.cpp:568
+#: ../src/richtext/richtextsizepage.cpp:570
+#: ../src/richtext/richtextsizepage.cpp:582
+#: ../src/richtext/richtextsizepage.cpp:584
+#, fuzzy
+msgid "The top position."
+msgstr "Grandària de la font:"
+
+#: ../src/richtext/richtextsizepage.cpp:593
+#: ../src/richtext/richtextsizepage.cpp:595
+#, fuzzy
+msgid "Units for the top position."
+msgstr "No es pot esperar per a l'acabament de cadena"
+
+#: ../src/richtext/richtextsizepage.cpp:603
+#: ../src/richtext/richtextsizepage.cpp:605
+#: ../src/richtext/richtextsizepage.cpp:617
+#: ../src/richtext/richtextsizepage.cpp:619
+#, fuzzy
+msgid "The right position."
+msgstr "Grandària de la font:"
+
+#: ../src/richtext/richtextsizepage.cpp:628
+#: ../src/richtext/richtextsizepage.cpp:630
+#, fuzzy
+msgid "Units for the right position."
+msgstr "No es pot esperar per a l'acabament de cadena"
+
+#: ../src/richtext/richtextsizepage.cpp:638
+#: ../src/richtext/richtextsizepage.cpp:640
+#: ../src/richtext/richtextsizepage.cpp:652
+#: ../src/richtext/richtextsizepage.cpp:654
+#, fuzzy
+msgid "The bottom position."
+msgstr "Grandària de la font:"
+
+#: ../src/richtext/richtextsizepage.cpp:663
+#: ../src/richtext/richtextsizepage.cpp:665
+#, fuzzy
+msgid "Units for the bottom position."
+msgstr "No es pot esperar per a l'acabament de cadena"
+
+#: ../src/richtext/richtextsizepage.cpp:671
+msgid "&Move the object to:"
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:674
+#, fuzzy
+msgid "&Previous Paragraph"
+msgstr "Pàgina anterior"
+
+#: ../src/richtext/richtextsizepage.cpp:675
+#: ../src/richtext/richtextsizepage.cpp:677
+msgid "Moves the object to the previous paragraph."
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:680
+msgid "&Next Paragraph"
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:681
+#: ../src/richtext/richtextsizepage.cpp:683
+msgid "Moves the object to the next paragraph."
+msgstr ""
+
+#: ../src/richtext/richtextstyledlg.cpp:193
+#, fuzzy
+msgid "&Styles:"
+msgstr "No"
+
+#: ../src/richtext/richtextstyledlg.cpp:197
+#: ../src/richtext/richtextstyledlg.cpp:199
+msgid "The available styles."
+msgstr ""
+
+#: ../src/richtext/richtextstyledlg.cpp:205
+#: ../src/richtext/richtextstyledlg.cpp:217
+msgid " "
+msgstr ""
+
+#: ../src/richtext/richtextstyledlg.cpp:209
+#: ../src/richtext/richtextstyledlg.cpp:211
+msgid "The style preview."
+msgstr ""
+
+#: ../src/richtext/richtextstyledlg.cpp:220
+msgid "New &Character Style..."
+msgstr ""
+
+#: ../src/richtext/richtextstyledlg.cpp:221
+#: ../src/richtext/richtextstyledlg.cpp:223
+msgid "Click to create a new character style."
+msgstr ""
+
+#: ../src/richtext/richtextstyledlg.cpp:226
+msgid "New &Paragraph Style..."
+msgstr ""
+
+#: ../src/richtext/richtextstyledlg.cpp:227
+#: ../src/richtext/richtextstyledlg.cpp:229
+msgid "Click to create a new paragraph style."
+msgstr ""
+
+#: ../src/richtext/richtextstyledlg.cpp:232
+msgid "New &List Style..."
+msgstr ""
+
+#: ../src/richtext/richtextstyledlg.cpp:233
+#: ../src/richtext/richtextstyledlg.cpp:235
+msgid "Click to create a new list style."
+msgstr ""
+
+#: ../src/richtext/richtextstyledlg.cpp:238
+#, fuzzy
+msgid "New &Box Style..."
+msgstr "&Elimina"
+
+#: ../src/richtext/richtextstyledlg.cpp:239
+#: ../src/richtext/richtextstyledlg.cpp:241
+msgid "Click to create a new box style."
+msgstr ""
+
+#: ../src/richtext/richtextstyledlg.cpp:246
+msgid "&Apply Style"
+msgstr ""
+
+#: ../src/richtext/richtextstyledlg.cpp:247
+#: ../src/richtext/richtextstyledlg.cpp:249
+msgid "Click to apply the selected style."
+msgstr ""
+
+#: ../src/richtext/richtextstyledlg.cpp:252
+msgid "&Rename Style..."
+msgstr ""
+
+#: ../src/richtext/richtextstyledlg.cpp:253
+#: ../src/richtext/richtextstyledlg.cpp:255
+msgid "Click to rename the selected style."
+msgstr ""
+
+#: ../src/richtext/richtextstyledlg.cpp:258
+msgid "&Edit Style..."
+msgstr ""
+
+#: ../src/richtext/richtextstyledlg.cpp:259
+#: ../src/richtext/richtextstyledlg.cpp:261
+msgid "Click to edit the selected style."
+msgstr ""
+
+#: ../src/richtext/richtextstyledlg.cpp:264
+#, fuzzy
+msgid "&Delete Style..."
+msgstr "&Elimina"
+
+#: ../src/richtext/richtextstyledlg.cpp:265
+#: ../src/richtext/richtextstyledlg.cpp:267
+msgid "Click to delete the selected style."
+msgstr ""
+
+#: ../src/richtext/richtextstyledlg.cpp:274
+#: ../src/richtext/richtextstyledlg.cpp:276
+#, fuzzy
+msgid "Click to close this window."
+msgstr "Tanca esta finestra"
+
+#: ../src/richtext/richtextstyledlg.cpp:282
+msgid "&Restart numbering"
+msgstr ""
+
+#: ../src/richtext/richtextstyledlg.cpp:284
+#: ../src/richtext/richtextstyledlg.cpp:286
+msgid "Check to restart numbering."
+msgstr ""
+
+#: ../src/richtext/richtextstyledlg.cpp:601
+msgid "Enter a character style name"
+msgstr ""
+
+#: ../src/richtext/richtextstyledlg.cpp:601
+#: ../src/richtext/richtextstyledlg.cpp:606
+#: ../src/richtext/richtextstyledlg.cpp:649
+#: ../src/richtext/richtextstyledlg.cpp:654
+#: ../src/richtext/richtextstyledlg.cpp:815
+#: ../src/richtext/richtextstyledlg.cpp:820
+#: ../src/richtext/richtextstyledlg.cpp:888
+#: ../src/richtext/richtextstyledlg.cpp:896
+#: ../src/richtext/richtextstyledlg.cpp:929
+#: ../src/richtext/richtextstyledlg.cpp:934
+msgid "New Style"
+msgstr ""
+
+#: ../src/richtext/richtextstyledlg.cpp:606
+#: ../src/richtext/richtextstyledlg.cpp:654
+#: ../src/richtext/richtextstyledlg.cpp:820
+#: ../src/richtext/richtextstyledlg.cpp:896
+#: ../src/richtext/richtextstyledlg.cpp:934
+msgid "Sorry, that name is taken. Please choose another."
+msgstr ""
+
+#: ../src/richtext/richtextstyledlg.cpp:649
+msgid "Enter a paragraph style name"
+msgstr ""
+
+#: ../src/richtext/richtextstyledlg.cpp:777
+#, fuzzy, c-format
+msgid "Delete style %s?"
+msgstr "&Elimina"
+
+#: ../src/richtext/richtextstyledlg.cpp:777
+#, fuzzy
+msgid "Delete Style"
+msgstr "&Elimina"
+
+#: ../src/richtext/richtextstyledlg.cpp:815
+msgid "Enter a list style name"
+msgstr ""
+
+#: ../src/richtext/richtextstyledlg.cpp:888
+msgid "Enter a new style name"
+msgstr ""
+
+#: ../src/richtext/richtextstyledlg.cpp:929
+msgid "Enter a box style name"
+msgstr ""
+
+#: ../src/richtext/richtextstylepage.cpp:109
+#: ../src/richtext/richtextstylepage.cpp:111
+msgid "The style name."
+msgstr ""
+
+#: ../src/richtext/richtextstylepage.cpp:114
+msgid "&Based on:"
+msgstr ""
+
+#: ../src/richtext/richtextstylepage.cpp:119
+#: ../src/richtext/richtextstylepage.cpp:121
+msgid "The style on which this style is based."
+msgstr ""
+
+#: ../src/richtext/richtextstylepage.cpp:124
+#, fuzzy
+msgid "&Next style:"
+msgstr "&Següent >"
+
+#: ../src/richtext/richtextstylepage.cpp:129
+#: ../src/richtext/richtextstylepage.cpp:131
+msgid "The default style for the next paragraph."
+msgstr ""
+
+#: ../src/richtext/richtextstyles.cpp:1057
+msgid "All styles"
+msgstr ""
+
+#: ../src/richtext/richtextstyles.cpp:1058
+msgid "Paragraph styles"
+msgstr ""
+
+#: ../src/richtext/richtextstyles.cpp:1059
+msgid "Character styles"
+msgstr ""
+
+#: ../src/richtext/richtextstyles.cpp:1060
+msgid "List styles"
+msgstr ""
+
+#: ../src/richtext/richtextstyles.cpp:1061
+#, fuzzy
+msgid "Box styles"
+msgstr "&Següent >"
+
+#: ../src/richtext/richtextsymboldlg.cpp:389
+#: ../src/richtext/richtextsymboldlg.cpp:391
+msgid "The font from which to take the symbol."
+msgstr ""
+
+#: ../src/richtext/richtextsymboldlg.cpp:396
+msgid "&Subset:"
+msgstr ""
+
+#: ../src/richtext/richtextsymboldlg.cpp:401
+#: ../src/richtext/richtextsymboldlg.cpp:403
+msgid "Shows a Unicode subset."
+msgstr ""
+
+#: ../src/richtext/richtextsymboldlg.cpp:412
+msgid "xxxx"
+msgstr ""
+
+#: ../src/richtext/richtextsymboldlg.cpp:417
+msgid "&Character code:"
+msgstr ""
+
+#: ../src/richtext/richtextsymboldlg.cpp:421
+#: ../src/richtext/richtextsymboldlg.cpp:423
+msgid "The character code."
+msgstr ""
+
+#: ../src/richtext/richtextsymboldlg.cpp:428
+#, fuzzy
+msgid "&From:"
+msgstr "De:"
+
+#: ../src/richtext/richtextsymboldlg.cpp:433
+#: ../src/richtext/richtextsymboldlg.cpp:434
+#: ../src/richtext/richtextsymboldlg.cpp:435
+#, fuzzy
+msgid "Unicode"
+msgstr "dinovè"
+
+#: ../src/richtext/richtextsymboldlg.cpp:436
+#: ../src/richtext/richtextsymboldlg.cpp:438
+msgid "The range to show."
+msgstr ""
+
+#: ../src/richtext/richtextsymboldlg.cpp:444
+#, fuzzy
+msgid "Insert"
+msgstr "Índex"
+
+#: ../src/richtext/richtextsymboldlg.cpp:478
+#, fuzzy
+msgid "(Normal text)"
+msgstr "Font normal"
+
+#: ../src/richtext/richtexttabspage.cpp:109
+msgid "&Position (tenths of a mm):"
+msgstr ""
+
+#: ../src/richtext/richtexttabspage.cpp:113
+#: ../src/richtext/richtexttabspage.cpp:115
+#, fuzzy
+msgid "The tab position."
+msgstr "Grandària de la font:"
+
+#: ../src/richtext/richtexttabspage.cpp:119
+#, fuzzy
+msgid "The tab positions."
+msgstr "Grandària de la font:"
+
+#: ../src/richtext/richtexttabspage.cpp:132
+#: ../src/richtext/richtexttabspage.cpp:134
+msgid "Click to create a new tab position."
+msgstr ""
+
+#: ../src/richtext/richtexttabspage.cpp:138
+#: ../src/richtext/richtexttabspage.cpp:140
+msgid "Click to delete the selected tab position."
+msgstr ""
+
+#: ../src/richtext/richtexttabspage.cpp:143
+#, fuzzy
+msgid "Delete A&ll"
+msgstr "Selecciona-ho &tot"
+
+#: ../src/richtext/richtexttabspage.cpp:144
+#: ../src/richtext/richtexttabspage.cpp:146
+msgid "Click to delete all tab positions."
+msgstr ""
+
+#: ../src/univ/theme.cpp:110
+msgid "Failed to initialize GUI: no built-in themes found."
+msgstr ""
+"No s'ha pogut inicialitzar GUI: no s'ha trobat que estigués muntat en temes."
+
+#: ../src/univ/themes/gtk.cpp:521
+msgid "GTK+ theme"
+msgstr "GTK + tema"
+
+#: ../src/univ/themes/metal.cpp:164
+msgid "Metal theme"
+msgstr "Tema metal·litzat"
+
+#: ../src/univ/themes/mono.cpp:512
+msgid "Simple monochrome theme"
+msgstr ""
+
+#: ../src/univ/themes/win32.cpp:1098
+msgid "Win32 theme"
+msgstr "Tema Win32"
+
+#: ../src/univ/themes/win32.cpp:3743
+msgid "&Restore"
+msgstr "&Restaura"
+
+#: ../src/univ/themes/win32.cpp:3744
+msgid "&Move"
+msgstr "&Mou"
+
+#: ../src/univ/themes/win32.cpp:3746
+msgid "&Size"
+msgstr "&Mida"
+
+#: ../src/univ/themes/win32.cpp:3748
+msgid "Mi&nimize"
+msgstr "Mi&nimitza"
+
+#: ../src/univ/themes/win32.cpp:3750
+msgid "Ma&ximize"
+msgstr "Ma&ximitza"
+
+#: ../src/univ/themes/win32.cpp:3752
+msgid "Alt+"
+msgstr ""
+
+#: ../src/unix/appunix.cpp:178
+#, fuzzy
+msgid "Failed to install signal handler"
+msgstr "No s'ha pogut tancar el manegador de fitxers"
+
+#: ../src/unix/dialup.cpp:351
+msgid "Already dialling ISP."
+msgstr "Ja s'està trucant a l'ISP."
+
+#: ../src/unix/dlunix.cpp:93
+#, fuzzy
+msgid "Failed to unload shared library"
+msgstr "No s'ha pogut carregar la llibreria compartida '%s'"
+
+#: ../src/unix/dlunix.cpp:121
+msgid "Unknown dynamic library error"
+msgstr ""
+
+#: ../src/unix/epolldispatcher.cpp:84
+#, fuzzy
+msgid "Failed to create epoll descriptor"
+msgstr "No s'ha pogut crear una barra d'estat."
+
+#: ../src/unix/epolldispatcher.cpp:103
+#, fuzzy
+msgid "Error closing epoll descriptor"
+msgstr "Error en crear directori"
+
+#: ../src/unix/epolldispatcher.cpp:116
+#, fuzzy, c-format
+msgid "Failed to add descriptor %d to epoll descriptor %d"
+msgstr "no es pot escriure en el fitxer descriptiu %d"
+
+#: ../src/unix/epolldispatcher.cpp:136
+#, c-format
+msgid "Failed to modify descriptor %d in epoll descriptor %d"
+msgstr ""
+
+#: ../src/unix/epolldispatcher.cpp:155
+#, fuzzy, c-format
+msgid "Failed to unregister descriptor %d from epoll descriptor %d"
+msgstr "No s'ha pogut recuperar les dades del porta-retalls."
+
+#: ../src/unix/epolldispatcher.cpp:213
+#, fuzzy, c-format
+msgid "Waiting for IO on epoll descriptor %d failed"
+msgstr "Error en l'espera de la fi d'un subprocès"
+
+#: ../src/unix/fswatcher_inotify.cpp:71
+#, fuzzy
+msgid "Unable to create inotify instance"
+msgstr "No s'ha pogut crear una cadena DDE"
+
+#: ../src/unix/fswatcher_inotify.cpp:94
+#, fuzzy
+msgid "Unable to close inotify instance"
+msgstr "No s'ha pogut tancar el manegador de fitxers"
+
+#: ../src/unix/fswatcher_inotify.cpp:106
+msgid "Unable to add inotify watch"
+msgstr ""
+
+#: ../src/unix/fswatcher_inotify.cpp:138
+#, fuzzy, c-format
+msgid "Unable to remove inotify watch %i"
+msgstr "No s'ha pogut crear una cadena DDE"
+
+#: ../src/unix/fswatcher_inotify.cpp:271
+#, c-format
+msgid "Unexpected event for \"%s\": no matching watch descriptor."
+msgstr ""
+
+#: ../src/unix/fswatcher_inotify.cpp:320
+#, c-format
+msgid "Invalid inotify event for \"%s\""
+msgstr ""
+
+#: ../src/unix/fswatcher_inotify.cpp:553
+#, fuzzy
+msgid "Unable to read from inotify descriptor"
+msgstr "no es pot llegir des del fitxer descriptor %s"
+
+#: ../src/unix/fswatcher_inotify.cpp:558
+#, fuzzy
+msgid "EOF while reading from inotify descriptor"
+msgstr "no es pot llegir des del fitxer descriptor %s"
+
+#: ../src/unix/fswatcher_kqueue.cpp:114
+#, fuzzy
+msgid "Unable to create kqueue instance"
+msgstr "No s'ha pogut crear una cadena DDE"
+
+#: ../src/unix/fswatcher_kqueue.cpp:131
+#, fuzzy
+msgid "Error closing kqueue instance"
+msgstr "Error en crear directori"
+
+#: ../src/unix/fswatcher_kqueue.cpp:153
+msgid "Unable to add kqueue watch"
+msgstr ""
+
+#: ../src/unix/fswatcher_kqueue.cpp:170
+msgid "Unable to remove kqueue watch"
+msgstr ""
+
+#: ../src/unix/fswatcher_kqueue.cpp:202
+msgid "Unable to get events from kqueue"
+msgstr ""
+
+#: ../src/unix/mediactrl.cpp:966
+#, c-format
+msgid "Media playback error: %s"
+msgstr ""
+
+#: ../src/unix/mediactrl.cpp:1228
+#, fuzzy, c-format
+msgid "Failed to prepare playing \"%s\"."
+msgstr "No s'ha pogut obrir '%s' per %s"
+
+#: ../src/unix/snglinst.cpp:164
+#, c-format
+msgid "Failed to write to lock file '%s'"
+msgstr "No s'ha pogut escriure a l'arxiu de bloqueig '%s'"
+
+#: ../src/unix/snglinst.cpp:177
+#, fuzzy, c-format
+msgid "Failed to set permissions on lock file '%s'"
+msgstr "És impossible fixar els permisos per al fitxer '%s'"
+
+#: ../src/unix/snglinst.cpp:194
+#, c-format
+msgid "Failed to lock the lock file '%s'"
+msgstr "No s'ha pogut bloquejar el fitxer de bloqueig '%s'"
+
+#: ../src/unix/snglinst.cpp:237
+#, fuzzy, c-format
+msgid "Failed to inspect the lock file '%s'"
+msgstr "No s'ha pogut bloquejar el fitxer de bloqueig '%s'"
+
+#: ../src/unix/snglinst.cpp:242
+#, c-format
+msgid "Lock file '%s' has incorrect owner."
+msgstr ""
+
+#: ../src/unix/snglinst.cpp:247
+#, c-format
+msgid "Lock file '%s' has incorrect permissions."
+msgstr ""
+
+#: ../src/unix/snglinst.cpp:265
+msgid "Failed to access lock file."
+msgstr "No s'ha pogut accedir el fitxer de blocatge."
+
+#: ../src/unix/snglinst.cpp:274
+msgid "Failed to read PID from lock file."
+msgstr "No s'ha pogut llegir el PID des del fitxer de registre."
+
+#: ../src/unix/snglinst.cpp:284
+#, c-format
+msgid "Failed to remove stale lock file '%s'."
+msgstr "No s'ha pogut extreure  el fitxer antic de bloqueig '%s'"
+
+#: ../src/unix/snglinst.cpp:297
+#, c-format
+msgid "Deleted stale lock file '%s'."
+msgstr "S'ha eliminat el fitxer antic de bloqueig '%s'."
+
+#: ../src/unix/snglinst.cpp:308
+#, c-format
+msgid "Invalid lock file '%s'."
+msgstr "Fitxer de bloqueig '%s' invàlid."
+
+#: ../src/unix/snglinst.cpp:324
+#, c-format
+msgid "Failed to remove lock file '%s'"
+msgstr "És impossible d'eliminar el fitxer de blocatge '%s'"
+
+#: ../src/unix/snglinst.cpp:330
+#, c-format
+msgid "Failed to unlock lock file '%s'"
+msgstr "No s'ha pogut desbloquejar el fitxer de bloqueig '%s'"
+
+#: ../src/unix/snglinst.cpp:336
+#, c-format
+msgid "Failed to close lock file '%s'"
+msgstr "No s'ha pogut tancar el fitxer de bloqueig '%s'"
+
+#: ../src/unix/sound.cpp:77
+#, fuzzy
+msgid "No sound"
+msgstr "No s'ha trobat entrades."
+
+#: ../src/unix/sound.cpp:364
+msgid "Unable to play sound asynchronously."
+msgstr ""
+
+#: ../src/unix/sound.cpp:458
+#, fuzzy, c-format
+msgid "Couldn't load sound data from '%s'."
+msgstr "No es pot carregar la icona des de '%s'"
+
+#: ../src/unix/sound.cpp:465
+#, c-format
+msgid "Sound file '%s' is in unsupported format."
+msgstr ""
+
+#: ../src/unix/sound.cpp:480
+msgid "Sound data are in unsupported format."
+msgstr ""
+
+#: ../src/unix/sound_sdl.cpp:226
+#, fuzzy, c-format
+msgid "Couldn't open audio: %s"
+msgstr "No es pot obrir el fitxer '%s'"
+
+#: ../src/unix/threadpsx.cpp:1033
+msgid "Cannot retrieve thread scheduling policy."
+msgstr "No es pot recuperar la cadena de política de planificació."
+
+#: ../src/unix/threadpsx.cpp:1058
+#, c-format
+msgid "Cannot get priority range for scheduling policy %d."
+msgstr ""
+"No es pot obtenir un rang de prioritats per la política de planificació %d."
+
+#: ../src/unix/threadpsx.cpp:1066
+msgid "Thread priority setting is ignored."
+msgstr "La prioritat de paràmetres és ignorada."
+
+#: ../src/unix/threadpsx.cpp:1221
+msgid ""
+"Failed to join a thread, potential memory leak detected - please restart the "
+"program"
+msgstr ""
+"No s'ha pogut sincronitzar amb un fil, s'ha detectat un potencial de pèrdua "
+"de memòria - reinicieu el programa"
+
+#: ../src/unix/threadpsx.cpp:1352
+#, fuzzy, c-format
+msgid "Failed to set thread concurrency level to %lu"
+msgstr "No s'ha pogut establir la prioritat de la cadena %d"
+
+#: ../src/unix/threadpsx.cpp:1481
+#, c-format
+msgid "Failed to set thread priority %d."
+msgstr "No s'ha pogut establir la prioritat de la cadena %d"
+
+#: ../src/unix/threadpsx.cpp:1666
+msgid "Failed to terminate a thread."
+msgstr "No s'ha pogut acabar una cadena."
+
+#: ../src/unix/threadpsx.cpp:1893
+msgid "Thread module initialization failed: failed to create thread key"
+msgstr ""
+"La inicialització de mòduls de la cadena ha fallat: no s'ha pogut crear una "
+"clau de la cadena."
+
+#: ../src/unix/utilsunx.cpp:340
+msgid "Impossible to get child process input"
+msgstr "És impossible obtenir l'entrada de procés fill."
+
+#: ../src/unix/utilsunx.cpp:390
+#, fuzzy
+msgid "Can't write to child process's stdin"
+msgstr "No s'ha pogut acabar el procés %d"
+
+#: ../src/unix/utilsunx.cpp:644
+#, c-format
+msgid "Failed to execute '%s'\n"
+msgstr "No s'ha pogut executar '%s'\n"
+
+#: ../src/unix/utilsunx.cpp:678
+msgid "Fork failed"
+msgstr "El fork ha fallat!"
+
+#: ../src/unix/utilsunx.cpp:701
+#, fuzzy
+msgid "Failed to set process priority"
+msgstr "No s'ha pogut establir la prioritat de la cadena %d"
+
+#: ../src/unix/utilsunx.cpp:712
+msgid "Failed to redirect child process input/output"
+msgstr "No s'ha pogut redireccionar el procés fill d'entrada/eixida"
+
+#: ../src/unix/utilsunx.cpp:816
+msgid "Failed to set up non-blocking pipe, the program might hang."
+msgstr ""
+
+#: ../src/unix/utilsunx.cpp:1023
+msgid "Cannot get the hostname"
+msgstr "No es pot obtenir el nom d'hostatger"
+
+#: ../src/unix/utilsunx.cpp:1059
+msgid "Cannot get the official hostname"
+msgstr "No es pot obtenir el nom oficial de l'hostatger"
+
+#: ../src/unix/wakeuppipe.cpp:49
+#, fuzzy
+msgid "Failed to create wake up pipe used by event loop."
+msgstr "No s'ha pogut crear una barra d'estat."
+
+#: ../src/unix/wakeuppipe.cpp:56
+msgid "Failed to switch wake up pipe to non-blocking mode"
+msgstr ""
+
+#: ../src/unix/wakeuppipe.cpp:117
+#, fuzzy
+msgid "Failed to read from wake-up pipe"
+msgstr "No s'ha pogut llegir el PID des del fitxer de registre."
+
+#: ../src/x11/app.cpp:124
+#, c-format
+msgid "Invalid geometry specification '%s'"
+msgstr "Especificació geomètrica invàlida '%s'"
+
+#: ../src/x11/app.cpp:167
+msgid "wxWidgets could not open display. Exiting."
+msgstr "wxWidgets no podien obrien l'exhibició. S'està eixint."
+
+#: ../src/x11/utils.cpp:169
+#, fuzzy, c-format
+msgid "Failed to close the display \"%s\""
+msgstr "No s'ha pogut tancar el porta-retalls"
+
+#: ../src/x11/utils.cpp:188
+#, fuzzy, c-format
+msgid "Failed to open display \"%s\"."
+msgstr "No s'ha pogut obrir '%s' per %s"
+
+#: ../src/xml/xml.cpp:868
+#, c-format
+msgid "XML parsing error: '%s' at line %d"
+msgstr "error d'anàlisi XML: '%s' a la línia %d"
+
+#: ../src/xrc/xh_propgrid.cpp:239
+#, fuzzy, c-format
+msgid "Page %i"
+msgstr "Pàgina %d"
+
+#: ../src/xrc/xmlres.cpp:448
+#, fuzzy, c-format
+msgid "Cannot load resources from '%s'."
+msgstr "No es pot carregar recursos des del fitxer '%s'."
+
+#: ../src/xrc/xmlres.cpp:799
+#, fuzzy, c-format
+msgid "Cannot open resources file '%s'."
+msgstr "No es pot carregar recursos des del fitxer '%s'."
+
+#: ../src/xrc/xmlres.cpp:806
+#, c-format
+msgid "Cannot load resources from file '%s'."
+msgstr "No es pot carregar recursos des del fitxer '%s'."
+
+#: ../src/xrc/xmlres.cpp:2767
+#, fuzzy, c-format
+msgid "Creating %s \"%s\" failed."
+msgstr "L'execució de l'orde '%s' ha fallit."
+
+#, fuzzy
+#~ msgctxt "keyboard key"
+#~ msgid "Ctrl+"
+#~ msgstr "control"
+
+#, fuzzy
+#~ msgctxt "keyboard key"
+#~ msgid "Shift+"
+#~ msgstr "Shift"
+
+#, fuzzy
+#~ msgctxt "keyboard key"
+#~ msgid "RawCtrl+"
+#~ msgstr "control"
+
+#~ msgid "Unsupported clipboard format."
+#~ msgstr "Format no suportat de porta-retalls"
+
+#, fuzzy
+#~ msgid "Font:"
+#~ msgstr "Grandària de la font:"
+
+#, fuzzy
+#~ msgid "Size:"
+#~ msgstr "Grandària"
+
+#, fuzzy
+#~ msgid "The font size in points."
+#~ msgstr "Grandària de la font:"
+
+#, fuzzy
+#~ msgid "<Any Roman>"
+#~ msgstr "Roman"
+
+#, fuzzy
+#~ msgid "<Any Decorative>"
+#~ msgstr "Decoratiu"
+
+#, fuzzy
+#~ msgid "<Any Modern>"
+#~ msgstr "Modern"
+
+#, fuzzy
+#~ msgid "<Any Script>"
+#~ msgstr "Script"
+
+#, fuzzy
+#~ msgid "<Any Swiss>"
+#~ msgstr "Suís"
+
+#, fuzzy
+#~ msgid "<Any Teletype>"
+#~ msgstr "Teletip"
+
+#~ msgid "Printing "
+#~ msgstr "S'està imprimint"
+
+#, fuzzy
+#~ msgid "Failed to insert text in the control."
+#~ msgstr "No s'ha pogut obtenir el directori en funcionament"
+
+#~ msgid "Please choose a valid font."
+#~ msgstr "Trieu una font vàlida"
+
+#, c-format
+#~ msgid "Failed to display HTML document in %s encoding"
+#~ msgstr "No s'ha pogut mostrar el document HTML en codificació %s"
+
+#, c-format
+#~ msgid "wxWidgets could not open display for '%s': exiting."
+#~ msgstr "wxWidgets no podia obrir l'aplicació per '%s'; s'està eixint."
+
+#, fuzzy
+#~ msgid "Filter"
+#~ msgstr "&Mida"
+
+#, fuzzy
+#~ msgid "Directories"
+#~ msgstr "Decoratiu"
+
+#, fuzzy
+#~ msgid "Files"
+#~ msgstr "&Mida"
+
+#, fuzzy
+#~ msgid "Selection"
+#~ msgstr "Seccions"
+
+#, fuzzy
+#~ msgid "failed to retrieve execution result"
+#~ msgstr "No s'ha pogut recuperar el text del missatge d'error RAS"
+
+#, fuzzy
+#~ msgid "&Save as"
+#~ msgstr "Anomena i Alça"
+
+#, fuzzy
+#~ msgid "'%s' doesn't consist only of valid characters"
+#~ msgstr "'%s' només hauria de contenir caràcters alfabètics"
+
+#~ msgid "'%s' should be numeric."
+#~ msgstr "'%s' hauria de ser numèric."
+
+#~ msgid "'%s' should only contain ASCII characters."
+#~ msgstr "'%s' només hauria de contenir caràcters ASCII"
+
+#~ msgid "'%s' should only contain alphabetic characters."
+#~ msgstr "'%s' només hauria de contenir caràcters alfabètics"
+
+#~ msgid "'%s' should only contain alphabetic or numeric characters."
+#~ msgstr "'%s' només hauria de contenir caràcters alfabètics o numèrics."
+
+#, fuzzy
+#~ msgid "'%s' should only contain digits."
+#~ msgstr "'%s' només hauria de contenir caràcters ASCII"
+
+#~ msgid "Can't create window of class %s"
+#~ msgstr "No es pot crear una finestra de la classe '%s'"
+
+#, fuzzy
+#~ msgid "Couldn't create the overlay window"
+#~ msgstr "No s'ha pogut crear un temporitzador"
+
+#, fuzzy
+#~ msgid "Couldn't init the context on the overlay window"
+#~ msgstr "No es pot obtenir l'actual cadena de punter"
+
+#, fuzzy
+#~ msgid "Failed to convert file \"%s\" to Unicode."
+#~ msgstr "No s'ha pogut tancar el manegador de fitxers"
+
+#, fuzzy
+#~ msgid "Failed to set text in the text control."
+#~ msgstr "No s'ha pogut obtenir el temps UTC del sistema."
+
+#, fuzzy
+#~ msgid "No unused colour in image."
+#~ msgstr "Cap color no utilitzat en la imatge està sent emmascarat"
+
+#, fuzzy
+#~ msgid "Not available"
+#~ msgstr "Servei XBM no disponible!"
+
+#, fuzzy
+#~ msgid "Replace selection"
+#~ msgstr "Substituix-ho &tot"
+
+#, fuzzy
+#~ msgid "Save as"
+#~ msgstr "Anomena i Alça"
+
+#, fuzzy
+#~ msgid "You cannot Clear an overlay that is not inited"
+#~ msgstr "No podeu afegir un directori nou a esta secció"
+
+#~ msgid "locale '%s' cannot be set."
+#~ msgstr "la localització '%s' no es pot fixar"
+
+#, fuzzy
+#~ msgid "Column index not found."
+#~ msgstr "no s'ha trobat el fitxer de catàleg per al domini '%s'"
+
+#~ msgid "Confirm registry update"
+#~ msgstr "Confirmeu l'actualització del registre"
+
+#, fuzzy
+#~ msgid "Could not determine column index."
+#~ msgstr "No s'ha pogut iniciar la previsualització del document."
+
+#, fuzzy
+#~ msgid "Could not determine number of columns."
+#~ msgstr "No es pot trobar el fitxer d'inclusió de recursos %s."
+
+#, fuzzy
+#~ msgid "Could not determine number of items"
+#~ msgstr "No es pot trobar el fitxer d'inclusió de recursos %s."
+
+#, fuzzy
+#~ msgid "Could not get header description."
+#~ msgstr "No s'ha pogut iniciar la impressió"
+
+#, fuzzy
+#~ msgid "Could not get items."
+#~ msgstr "No es pot obrir el fitxer '%s'."
+
+#, fuzzy
+#~ msgid "Could not get property flags."
+#~ msgstr "no es pot extreure el fitxer temporal '%s'"
+
+#, fuzzy
+#~ msgid "Could not get selected items."
+#~ msgstr "No es pot obrir el fitxer '%s'."
+
+#, fuzzy
+#~ msgid "Could not remove column."
+#~ msgstr "No s'ha pogut crear un cursor."
+
+#, fuzzy
+#~ msgid "Could not retrieve number of items"
+#~ msgstr "no es pot extreure el fitxer temporal '%s'"
+
+#, fuzzy
+#~ msgid "Could not set column width."
+#~ msgstr "No s'ha pogut iniciar la previsualització del document."
+
+#, fuzzy
+#~ msgid "Could not set header description."
+#~ msgstr "No s'ha pogut iniciar la impressió"
+
+#, fuzzy
+#~ msgid "Could not set icon."
+#~ msgstr "No s'ha pogut iniciar la impressió"
+
+#, fuzzy
+#~ msgid "Could not set maximum width."
+#~ msgstr "No s'ha pogut iniciar la impressió"
+
+#, fuzzy
+#~ msgid "Could not set minimum width."
+#~ msgstr "No s'ha pogut iniciar la impressió"
+
+#, fuzzy
+#~ msgid "Could not set property flags."
+#~ msgstr "No s'ha pogut iniciar la impressió"
+
+#~ msgid ""
+#~ "Do you want to overwrite the command used to %s files with extension "
+#~ "\"%s\" ?\n"
+#~ "Current value is \n"
+#~ "%s, \n"
+#~ "New value is \n"
+#~ "%s %1"
+#~ msgstr ""
+#~ "Desitgeu sobrescriure l'orde utilitzada per als fitxer %s amb l'extensió "
+#~ "\"%s\" ?\n"
+#~ "el valor actual és \n"
+#~ "%s, \n"
+#~ "El nou valor és \n"
+#~ "%s %1"
+
+#~ msgid "Failed to retrieve data from the clipboard."
+#~ msgstr "No s'ha pogut recuperar les dades del porta-retalls."
+
+#~ msgid "GIF: Invalid gif index."
+#~ msgstr "GIF: Índex invàlid de gif."
+
+#~ msgid "GIF: unknown error!!!"
+#~ msgstr "GIF: error desconegut!!!"
+
+#, fuzzy
+#~ msgid "New directory"
+#~ msgstr "Crea directori"
+
+#, fuzzy
+#~ msgid "Next"
+#~ msgstr "&Següent"
+
+#, fuzzy
+#~ msgid "Number of columns could not be determined."
+#~ msgstr "No s'ha pogut carregar el fitxer."
+
+#~ msgid ""
+#~ "Please install a newer version of comctl32.dll\n"
+#~ "(at least version 4.70 is required but you have %d.%02d)\n"
+#~ "or this program won't operate correctly."
+#~ msgstr ""
+#~ "Cal que instal·leu una versió més nova de comctl32.dll\n"
+#~ "(com a mínim cal la versió 4.70 però teniu la %d.%02d)\n"
+#~ "o este programa no operarà correctament."
+
+#, fuzzy
+#~ msgid "Rendering failed."
+#~ msgstr "No s'ha pogut crear la canonada."
+
+#~ msgid "Show hidden directories"
+#~ msgstr "Mostra directoris ocults."
+
+#, fuzzy
+#~ msgid "Unable to initialize Hildon program"
+#~ msgstr "No s'ha pogut inicialitzar l'OpenGL"
+
+#, fuzzy
+#~ msgid "Unknown data format"
+#~ msgstr "IFF: error en format d'imatge IFF."
+
+#~ msgid "Win32s on Windows 3.1"
+#~ msgstr "Win32s en Windows 3.1"
+
+#, fuzzy
+#~ msgid "Windows 10"
+#~ msgstr "Windows 9%c"
+
+#, fuzzy
+#~ msgid "Windows 2000"
+#~ msgstr "Windows 9%c"
+
+#, fuzzy
+#~ msgid "Windows 7"
+#~ msgstr "Windows 9%c"
+
+#, fuzzy
+#~ msgid "Windows 8"
+#~ msgstr "Windows 9%c"
+
+#, fuzzy
+#~ msgid "Windows 8.1"
+#~ msgstr "Windows 9%c"
+
+#, fuzzy
+#~ msgid "Windows 95"
+#~ msgstr "Windows 9%c"
+
+#, fuzzy
+#~ msgid "Windows 95 OSR2"
+#~ msgstr "Windows 9%c"
+
+#, fuzzy
+#~ msgid "Windows 98"
+#~ msgstr "Windows 9%c"
+
+#, fuzzy
+#~ msgid "Windows 98 SE"
+#~ msgstr "Windows 9%c"
+
+#, fuzzy
+#~ msgid "Windows 9x (%d.%d)"
+#~ msgstr "Windows 9%c"
+
+#, fuzzy
+#~ msgid "Windows CE (%d.%d)"
+#~ msgstr "Windows 9%c"
+
+#, fuzzy
+#~ msgid "Windows ME"
+#~ msgstr "Windows 3.1"
+
+#, fuzzy
+#~ msgid "Windows NT %lu.%lu"
+#~ msgstr "Windows 9%c"
+
+#, fuzzy
+#~ msgid "Windows Server 10"
+#~ msgstr "Windows Grec (CP 1253)"
+
+#, fuzzy
+#~ msgid "Windows Server 2003"
+#~ msgstr "Windows Grec (CP 1253)"
+
+#, fuzzy
+#~ msgid "Windows Server 2008"
+#~ msgstr "Windows 9%c"
+
+#, fuzzy
+#~ msgid "Windows Server 2008 R2"
+#~ msgstr "Windows Hebreu (CP 1255)"
+
+#, fuzzy
+#~ msgid "Windows Server 2012"
+#~ msgstr "Windows Grec (CP 1253)"
+
+#, fuzzy
+#~ msgid "Windows Server 2012 R2"
+#~ msgstr "Windows Hebreu (CP 1255)"
+
+#, fuzzy
+#~ msgid "Windows Vista"
+#~ msgstr "Windows 9%c"
+
+#, fuzzy
+#~ msgid "Windows XP"
+#~ msgstr "Windows 9%c"
+
+#, fuzzy
+#~ msgid "can't execute '%s'"
+#~ msgstr "No s'ha pogut executar '%s'\n"
+
+#, fuzzy
+#~ msgid "error opening '%s'"
+#~ msgstr "Error en llegir '%s'"
+
+#~ msgid "unknown seek origin"
+#~ msgstr "origen de recerca desconegut"
+
+#, fuzzy
+#~ msgid "Cannot create mutex."
+#~ msgstr "No es pot crear un fil"
+
+#, fuzzy
+#~ msgid "Cannot resume thread %lu"
+#~ msgstr "No es pot enumerar els fitxers en el directori '%s'"
+
+#, fuzzy
+#~ msgid "Cannot suspend thread %lu"
+#~ msgstr "No es pot suspendre en fil %x"
+
+#, fuzzy
+#~ msgid "Couldn't acquire a mutex lock"
+#~ msgstr "No s'ha pogut crear un temporitzador"
+
+#, fuzzy
+#~ msgid "Couldn't release a mutex"
+#~ msgstr "No s'ha pogut crear un temporitzador"
+
+#, fuzzy
+#~ msgid "DIVIDE"
+#~ msgstr "<DIR>"
+
+#, fuzzy
+#~ msgid "Execution of command '%s' failed with error: %ul"
+#~ msgstr "L'execució de l'orde '%s' ha fallit."
+
+#~ msgid ""
+#~ "File '%s' already exists.\n"
+#~ "Do you want to replace it?"
+#~ msgstr ""
+#~ "El fitxer '%s' ja existix,\n"
+#~ "Desitgeu substituir-lo?"
+
+#, fuzzy
+#~ msgid "Timer creation failed."
+#~ msgstr "No s'ha pogut crear la canonada."
+
+#, fuzzy
+#~ msgid "Print preview"
+#~ msgstr "Imprimix previsualització"
+
+#, fuzzy
+#~ msgid "&Preview..."
+#~ msgstr " Previsualitza"
+
+#, fuzzy
+#~ msgid "Preview..."
+#~ msgstr " Previsualitza"
+
+#~ msgid "&Save..."
+#~ msgstr "&Desa..."
+
+#, fuzzy
+#~ msgid "All files (*.*)|*"
+#~ msgstr "Tots els fitxers (*.*) *.*  "
+
+#~ msgid "Cannot initialize SciTech MGL!"
+#~ msgstr "No es pot inicialitzar SciTech MGL!"
+
+#~ msgid "Cannot initialize display."
+#~ msgstr "No es pot començar a mostrar."
+
+#~ msgid "Cannot start thread: error writing TLS"
+#~ msgstr "No es pot iniciar el fil: s'ha comès un error en escriure TLS"
+
+#~ msgid "Close\tAlt-F4"
+#~ msgstr "Tanca\tAlt-F4"
+
+#~ msgid "Couldn't create cursor."
+#~ msgstr "No s'ha pogut crear un cursor."
+
+#~ msgid "Directory '%s' doesn't exist!"
+#~ msgstr "El directori '%s' no existix!"
+
+#~ msgid "Mode %ix%i-%i not available."
+#~ msgstr "Mode %ix%i-%i no disponible."
+
+#~ msgid "Paper Size"
+#~ msgstr "Grandària del paper"
+
+#~ msgid "Can't check image format of file '%s': file does not exist."
+#~ msgstr ""
+#~ "No es pot revisar el format d'imatge del fitxer '%s': el fitxer no "
+#~ "existix."
+
+#~ msgid "Can't load image from file '%s': file does not exist."
+#~ msgstr ""
+#~ "No es pot carregar una imatge del fitxer '%s': el fitxer no existix."
+
+#~ msgid "Cannot convert dialog units: dialog unknown."
+#~ msgstr "No es pot convertir el diàleg d'unitats: diàleg desconegut"
+
+#, fuzzy
+#~ msgid "Cannot convert from the charset '%s'!"
+#~ msgstr "No es pot convertir des de la codificació '%s'!"
+
+#~ msgid "Cannot find container for unknown control '%s'."
+#~ msgstr "No es pot trobar el contenidor del control desconegut '%s'."
+
+#~ msgid "Cannot find font node '%s'."
+#~ msgstr "No es pot trobar el node  '%s' de font."
+
+#~ msgid "Cannot open file '%s'."
+#~ msgstr "No es pot obrir el fitxer '%s'."
+
+#~ msgid "Cannot parse coordinates from '%s'."
+#~ msgstr "No es pot analitzar les coordenades des de '%s'."
+
+#~ msgid "Cannot parse dimension from '%s'."
+#~ msgstr "No es pot analitzar les dimensions des de '%s'."
+
+#, fuzzy
+#~ msgid "Cant create the thread event queue"
+#~ msgstr "No es pot crear un fil"
+
+#, fuzzy
+#~ msgid "Click to cancel this window."
+#~ msgstr "Tanca esta finestra"
+
+#, fuzzy
+#~ msgid "Could not unlock mutex"
+#~ msgstr "No s'ha pogut crear un temporitzador"
+
+#~ msgid "Failed to create a status bar."
+#~ msgstr "No s'ha pogut crear una barra d'estat."
+
+#, fuzzy
+#~ msgid "Failed to register OpenGL window class."
+#~ msgstr "No s'ha pogut inicialitzar l'OpenGL"
+
+#~ msgid "Fatal error: "
+#~ msgstr "Error fatal:"
+
+#~ msgid "Goto Page"
+#~ msgstr "Vés a la pàgina"
+
+#, fuzzy
+#~ msgid "Help : %s"
+#~ msgstr "Ajuda: %s"
+
+#~ msgid "Invalid XRC resource '%s': doesn't have root node 'resource'."
+#~ msgstr "Recurs XRC '%s' invàlid: no té una arrel del node de 'recurs'."
+
+#~ msgid "No handler found for XML node '%s', class '%s'!"
+#~ msgstr "No s'ha trobat cap manegador per als nodes XML '%s', classe '%s'!"
+
+#, fuzzy
+#~ msgid "No image handler for type %ld defined."
+#~ msgstr "No hi ha definit cap manegador per al tipus d'imatge %d."
+
+#, fuzzy
+#~ msgid "Owner not initialized."
+#~ msgstr "No es pot començar a mostrar."
+
+#, fuzzy
+#~ msgid "Passed item is invalid."
+#~ msgstr "'%s' és invàlid"
+
+#~ msgid "Program aborted."
+#~ msgstr "Programa avortat."
+
+#~ msgid "Referenced object node with ref=\"%s\" not found!"
+#~ msgstr "Objecte de node referenciat amb ref=\"%s\"\" no s'ha trobat!"
+
+#~ msgid "Resource files must have same version number!"
+#~ msgstr "Els fitxers de recursos han de tenir el mateix número de versió!"
+
+#, fuzzy
+#~ msgid "Search!"
+#~ msgstr "Cerca"
+
+#~ msgid "Sorry, could not open this file for saving."
+#~ msgstr "No es pot obrir este fitxer per alçar."
+
+#~ msgid "Sorry, could not save this file."
+#~ msgstr "No s'ha pogut alçar este fitxer."
+
+#~ msgid "Status: "
+#~ msgstr "Estat:"
+
+#~ msgid "Subclass '%s' not found for resource '%s', not subclassing!"
+#~ msgstr "Subclasse '%s' no trobada per recursos '%s', no subclassificant!"
+
+#, fuzzy
+#~ msgid ""
+#~ "The file '%s' couldn't be opened.\n"
+#~ "It has been removed from the most recently used files list."
+#~ msgstr ""
+#~ "El fitxer '%s' no existix i per tant no pot ser obert.\n"
+#~ "Ha estat extret des de llistat de fitxers utilitzats més recentment."
+
+#~ msgid "The path '%s' contains too many \"..\"!"
+#~ msgstr "La ruta '%s' conté massa \"..\"!"
+
+#~ msgid "Trying to solve a NULL hostname: giving up"
+#~ msgstr "S'està intetant solucionar un nom d'hostetjador buit: no es pot."
+
+#~ msgid "Unknown style flag "
+#~ msgstr "Estil de bandera desconegut"
+
+#~ msgid "Warning"
+#~ msgstr "Atenció"
+
+#~ msgid "XRC resource '%s' (class '%s') not found!"
+#~ msgstr "recurs XRC: '%s' (tipus '%s') no trobada!"
+
+#, fuzzy
+#~ msgid "XRC resource: Cannot create animation from '%s'."
+#~ msgstr "recurs XRC: No es pot crear mapa de bits des de '%s'."
+
+#~ msgid "XRC resource: Cannot create bitmap from '%s'."
+#~ msgstr "recurs XRC: No es pot crear mapa de bits des de '%s'."
+
+#, fuzzy
+#~ msgid ""
+#~ "XRC resource: Incorrect colour specification '%s' for attribute '%s'."
+#~ msgstr ""
+#~ "recurs XRC: Color d'especificació incorrecte '%s'  per a la propietat "
+#~ "'%s'."
+
+#~ msgid "[EMPTY]"
+#~ msgstr "[BUIT]"
+
+#~ msgid "catalog file for domain '%s' not found."
+#~ msgstr "no s'ha trobat el fitxer de catàleg per al domini '%s'"
+
+#, fuzzy
+#~ msgid "encoding %i"
+#~ msgstr "Codificació (%d) desconeguda"
+
+#~ msgid "looking for catalog '%s' in path '%s'."
+#~ msgstr "s'està cercant el catàleg '%s' a la ruta '%s'."
+
+#~ msgid "wxSocket: invalid signature in ReadMsg."
+#~ msgstr "wxSocket: signatura invàlida en ReadMsg."
+
+#~ msgid "wxSocket: unknown event!."
+#~ msgstr "wxSocket: incidència desconeguda!."
+
+#, fuzzy
+#~ msgid " Couldn't create the UnicodeConverter"
+#~ msgstr "No s'ha pogut crear un temporitzador"
+
+#~ msgid "#define %s must be an integer."
+#~ msgstr "#define %s ha de ser un número sencer."
+
+#~ msgid "%s not a bitmap resource specification."
+#~ msgstr "%s no és una especificació de recursos de mapa de bits."
+
+#~ msgid "%s not an icon resource specification."
+#~ msgstr "%s no és una especificació de recursos d'icona"
+
+#, fuzzy
+#~ msgid "%s: ill-formed resource file syntax."
+#~ msgstr "hi ha hagut un error intern en el DDEML"
+
+#, fuzzy
+#~ msgid "&Open"
+#~ msgstr "&Desa..."
+
+#, fuzzy
+#~ msgid "&Print"
+#~ msgstr "Imprimeix"
+
+#, fuzzy
+#~ msgid ""
+#~ ", expected static, #include or #define\n"
+#~ "while parsing resource."
+#~ msgstr ""
+#~ ", les estadítiques esperades #include o #define\n"
+#~ "mentre s'està analitzant el recurs."
+
+#~ msgid "Bitmap resource specification %s not found."
+#~ msgstr "No s'ha trobat l'especificació %s de recursos de mapa de bits."
+
+#~ msgid ""
+#~ "Could not resolve control class or id '%s'. Use (non-zero) integer "
+#~ "instead\n"
+#~ " or provide #define (see manual for caveats)"
+#~ msgstr ""
+#~ "No es pot resoldre la classe de control o l'id '%s'. Utilitzeu un número "
+#~ "sencer diferent de zero\n"
+#~ " o proporcioneu el #define (vegeu els consells del manual)"
+
+#~ msgid ""
+#~ "Could not resolve menu id '%s'. Use (non-zero) integer instead\n"
+#~ "or provide #define (see manual for caveats)"
+#~ msgstr ""
+#~ "No es pot resoldre l'id del menú '%s'. Utilitza un sencer diferent de "
+#~ "zero\n"
+#~ " o proporciona el #define (vegeu els consells del manual)"
+
+#, fuzzy
+#~ msgid "Couldn't end the context on the overlay window"
+#~ msgstr "No es pot obtenir l'actual cadena de punter"
+
+#, fuzzy
+#~ msgid "Expected '*' while parsing resource."
+#~ msgstr "S'esperava '*' en analitzar el recurs."
+
+#, fuzzy
+#~ msgid "Expected '=' while parsing resource."
+#~ msgstr "S'esperava '=' en analitzar el recurs."
+
+#, fuzzy
+#~ msgid "Expected 'char' while parsing resource."
+#~ msgstr "S'esperava 'char' en analitzar el recurs."
+
+#~ msgid ""
+#~ "Failed to find XBM resource %s.\n"
+#~ "Forgot to use wxResourceLoadBitmapData?"
+#~ msgstr ""
+#~ "No s'ha pogut trobar el recurs XBM %s.\n"
+#~ "No us recordat d'utilitzar  wxResourceLoadBitmapData?"
+
+#~ msgid ""
+#~ "Failed to find XBM resource %s.\n"
+#~ "Forgot to use wxResourceLoadIconData?"
+#~ msgstr ""
+#~ "No s'ha pogut trobar el recurs XBM %s.\n"
+#~ "No us heu recordat d'utilitzar  wxResourceLoadIconData?"
+
+#~ msgid ""
+#~ "Failed to find XPM resource %s.\n"
+#~ "Forgot to use wxResourceLoadBitmapData?"
+#~ msgstr ""
+#~ "No s'ha pogut trobar el recurs XMP %s. \n"
+#~ "No us recordat d'utilitzar wxResourceLoadBitmapData?"
+
+#~ msgid "Failed to get clipboard data."
+#~ msgstr "No s'han pogut obtenir les dades del porta-retalls"
+
+#~ msgid "Failed to load shared library '%s' Error '%s'"
+#~ msgstr "No s'ha pogut carregar la llibreria compartida '%s' Error '%s'"
+
+#~ msgid "Found "
+#~ msgstr "Trobat"
+
+#~ msgid "Icon resource specification %s not found."
+#~ msgstr "No s'ha trobat l'especificació %s de recursos d'icones"
+
+#~ msgid "Ill-formed resource file syntax."
+#~ msgstr "Sintaxi incorrecta del codi font."
+
+#~ msgid "No XPM icon facility available!"
+#~ msgstr "No hi ha cap icona XPM disponible!"
+
+#~ msgid "Option '%s' requires a value, '=' expected."
+#~ msgstr "L'opció '%s' requereix un valor, '=' esperat."
+
+#, fuzzy
+#~ msgid "Select all"
+#~ msgstr "Selecciona-ho &tot"
+
+#, fuzzy
+#~ msgid "Unexpected end of file while parsing resource."
+#~ msgstr "Fi de fitxer inesperat en analitzar el recurs."
+
+#, fuzzy
+#~ msgid "Unrecognized style %s while parsing resource."
+#~ msgstr "Estil desconegut %s en analitzar el recurs."
+
+#~ msgid "Warning: attempt to remove HTML tag handler from empty stack."
+#~ msgstr "Atenció: intent d'extreure una etiqueta HTML d'una pila buida."
+
+#~ msgid "establish"
+#~ msgstr "estableix"
+
+#~ msgid "initiate"
+#~ msgstr "inicia"
+
+#~ msgid "invalid eof() return value."
+#~ msgstr "valor eof() de retorn invàlid."
+
+#~ msgid "unknown line terminator"
+#~ msgstr "acabament de línia desconegut"
+
+#~ msgid "writing"
+#~ msgstr "s'està escrivint"
+
+#~ msgid "."
+#~ msgstr "."
+
+#~ msgid "Cannot open URL '%s'"
+#~ msgstr "No es pot obrir l'URL '%s'."
+
+#~ msgid "Error "
+#~ msgstr "Error "
+
+#~ msgid "Failed to create directory %s/.gnome."
+#~ msgstr "No s'ha pogut crear un directori %s/.gnome."
+
+#~ msgid "Failed to create directory %s/mime-info."
+#~ msgstr "No s'ha pogut crear el directori %s/mime-info."
+
+#~ msgid "Mailcap file %s, line %d: incomplete entry ignored."
+#~ msgstr "Fitxer mailcap %s, línia %d: entrada incompleta ignorada."
+
+#~ msgid "Mime.types file %s, line %d: unterminated quoted string."
+#~ msgstr ""
+#~ "Mime. Tipus de fitxer %s, línia %d: cadena entre cometes no acabada."
+
+#~ msgid "Unknown field in file %s, line %d: '%s'."
+#~ msgstr "Camp desconegut en el fitxer %s, línia %d: '%s'."
+
+#~ msgid "bold "
+#~ msgstr "negreta"
+
+#~ msgid "light "
+#~ msgstr "il·luminació"
+
+#~ msgid "underlined "
+#~ msgstr "subratllat"
+
+#, fuzzy
+#~ msgid "unsupported zip archive"
+#~ msgstr "Format no suportat de porta-retalls"
+
+#, fuzzy
+#~ msgid ""
+#~ "Failed to get stack backtrace:\n"
+#~ "%s"
+#~ msgstr "No s'han pogut obtenir els noms ISP: %s"
+
+#~ msgid "Loading Grey Ascii PNM image is not yet implemented."
+#~ msgstr ""
+#~ "Carregar un fitxer Ascii PNM d'escala de grisos encara no està "
+#~ "implementat."
+
+#~ msgid "Loading Grey Raw PNM image is not yet implemented."
+#~ msgstr ""
+#~ "Carregar un fitxer d'imatge Raw PNM d'escala de grisos encara no està "
+#~ "implementat."
+
+#, fuzzy
+#~ msgid "Cannot wait on thread to exit."
+#~ msgstr "No es pot esperar per a l'acabament de cadena"
+
+#~ msgid "Could not load Rich Edit DLL '%s'"
+#~ msgstr "No es pot carregar el DLL d'edició rica '%s'"
+
+#~ msgid "ZIP handler currently supports only local files!"
+#~ msgstr "El manegador ZIP generalment només permet l'ús de fitxers locals!"
+
+#, fuzzy
+#~ msgid ""
+#~ "can't seek on file descriptor %d, large files support is not enabled."
+#~ msgstr "no és pot cercar el fitxer descriptor de %d"
+
+#~ msgid "More..."
+#~ msgstr "Més..."
+
+#~ msgid "Setup"
+#~ msgstr "Configuració"
+
+#~ msgid "GetUnusedColour:: No Unused Color in image "
+#~ msgstr "GetUnusedColour:: No s'ha utilitzat cap color a la imatge"
+
+#~ msgid ""
+#~ "Can't create list control window, check that comctl32.dll is installed."
+#~ msgstr ""
+#~ "No es pot crear un llistat de control de finestra, mireu si el "
+#~ "comctl32.dll es troba instal·lat."
+
+#~ msgid "Can't delete value of key '%s'"
+#~ msgstr "No es pot eliminar la clau de registre '%s'"
+
+#~ msgid "gmtime() failed"
+#~ msgstr "gmtime() ha fallat"
+
+#~ msgid "mktime() failed"
+#~ msgstr "mktime() ha fallat"
+
+#~ msgid "%d...%d"
+#~ msgstr "%d...%d"
+
+#~ msgid ""
+#~ "<html><body><table><tr><td>Normal face<br>(and <u>underlined</u>. "
+#~ "<i>Italic face.</i> <b>Bold face.</b> <b><i>Bold italic face.</i></"
+#~ "b><br><font size=-2>font size -2</font><br><font size=-1>font size -1</"
+#~ "font><br><font size=+0>font size +0</font><br><font size=+1>font size +1</"
+#~ "font><br><font size=+2>font size +2</font><br><font size=+3>font size +3</"
+#~ "font><br><font size=+4>font size +4</font><br><td><p><tt>Fixed size face."
+#~ "<br> <b>bold</b> <i>italic</i> <b><i>bold italic <u>underlined</u></i></"
+#~ "b><br><font size=-2>font size -2</font><br><font size=-1>font size -1</"
+#~ "font><br><font size=+0>font size +0</font><br><font size=+1>font size +1</"
+#~ "font><br><font size=+2>font size +2</font><br><font size=+3>font size +3</"
+#~ "font><br><font size=+4>font size +4</font></tt></table></body></html>"
+#~ msgstr ""
+#~ "<html><body><table><tr><td>Normal face<br>(and <u>underlined</u>. "
+#~ "<i>Italic face.</i> <b>Bold face.</b> <b><i>Bold italic face.</i></"
+#~ "b><br><font size=-2>font size -2</font><br><font size=-1>font size -1</"
+#~ "font><br><font size=+0>font size +0</font><br><font size=+1>font size +1</"
+#~ "font><br><font size=+2>font size +2</font><br><font size=+3>font size +3</"
+#~ "font><br><font size=+4>font size +4</font><br><td><p><tt>Fixed size face."
+#~ "<br> <b>bold</b> <i>italic</i> <b><i>bold italic <u>underlined</u></i></"
+#~ "b><br><font size=-2>font size -2</font><br><font size=-1>font size -1</"
+#~ "font><br><font size=+0>font size +0</font><br><font size=+1>font size +1</"
+#~ "font><br><font size=+2>font size +2</font><br><font size=+3>font size +3</"
+#~ "font><br><font size=+4>font size +4</font></tt></table></body></html>"
+
+#~ msgid "Can't create dialog using memory template"
+#~ msgstr "No es pot crear un diàleg utilitzant plantilla de memòria."
+
+#~ msgid "Can't create dialog using template '%ul'"
+#~ msgstr "No es pot crear un diàleg utilitzant la plantilla '%ul'"
+
+#~ msgid "Did you forget to include wx/os2/wx.rc in your resources?"
+#~ msgstr "Us n'heu oblidat d'incloure wx/os2/wx.rc en els recursos?"
+
+#~ msgid "Failed to create dialog. Incorrect DLGTEMPLATE?"
+#~ msgstr "No s'ha pogut crear el diàleg. És el DLGTEMPLATE incorrecte?"
+
+#~ msgid "Fatal error: exiting"
+#~ msgstr "Error fatal: sortint"
+
+#~ msgid ""
+#~ "HTML files (*.htm)|*.htm|HTML files (*.html)|*.html|Help books (*.htb)|"
+#~ "*.htb|Help books (*.zip)|*.zip|HTML Help Project (*.hhp)|*.hhp|All files "
+#~ "(*.*)|*"
+#~ msgstr ""
+#~ "arxius HTML (*.htm)|*.htm|arxius HTML(*.html)|*.html|Llibres d'ajuda "
+#~ "(*.htb)|*.htb|Llibres d'ajuda  (*.zip)|*.zip|Projectes d'ajuda HTML "
+#~ "(*.hhp)|*.hhp|Tots el arxius (*.*)|*"
+
+#~ msgid "Load file"
+#~ msgstr "Carrega fitxer"
+
+#~ msgid "Save file"
+#~ msgstr "Desa fitxer"
+
+#~ msgid "illegal scrollbar selector %d"
+#~ msgstr "seleccionador de lliscador il·legal %d"
+
+#~ msgid "wxDllLoader failed to GetSymbol '%s'"
+#~ msgstr "wxDllLoader ha fallat a GetSymbol '%s'"
+
+#~ msgid "wxDynamicLibrary failed to GetSymbol '%s'"
+#~ msgstr "wxDynamicLibrary ha fallat a GetSymbol '%s'"

--- a/po_wxstd/co.po
+++ b/po_wxstd/co.po
@@ -1,0 +1,9581 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# Patriccollu di Santa Maria è Sichè <Patriccollu [at] gmail [dot] com>, 2022-2025.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: wxWidgets in Corsican\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-05-14 20:23+0200\n"
+"PO-Revision-Date: 2025-05-19 16:47+0200\n"
+"Last-Translator: Patriccollu di Santa Maria è Sichè <https://github.com/"
+"Patriccollu/Lingua_Corsa-Infurmatica/#readme>\n"
+"Language-Team: Patriccollu di Santa Maria è Sichè\n"
+"Language: co\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+"X-Generator: Poedit 3.6\n"
+
+#: ../include/wx/defs.h:2582
+msgid "All files (*.*)|*.*"
+msgstr "Tutti i schedarii (*.*)|*.*"
+
+#: ../include/wx/defs.h:2585
+msgid "All files (*)|*"
+msgstr "Tutti i schedarii (*)|*"
+
+#: ../include/wx/generic/progdlgg.h:85
+msgid "Elapsed time:"
+msgstr "Tempu scorsu :"
+
+#: ../include/wx/generic/progdlgg.h:86
+msgid "Estimated time:"
+msgstr "Tempu estimatu :"
+
+#: ../include/wx/generic/progdlgg.h:87
+msgid "Remaining time:"
+msgstr "Tempu rimanentu :"
+
+#. TRANSLATORS: HTML printout default title.
+#: ../include/wx/html/htmprint.h:121 ../include/wx/prntbase.h:273
+#: ../include/wx/richtext/richtextprint.h:109 ../src/common/docview.cpp:2161
+msgid "Printout"
+msgstr "Stampa"
+
+#. TRANSLATORS: HTML easy print default title.
+#: ../include/wx/html/htmprint.h:234 ../include/wx/richtext/richtextprint.h:163
+#: ../src/common/prntbase.cpp:522 ../src/html/htmprint.cpp:291
+msgid "Printing"
+msgstr "Stampa"
+
+#: ../include/wx/msgdlg.h:277 ../src/common/stockitem.cpp:211
+msgid "Yes"
+msgstr "Sì"
+
+#: ../include/wx/msgdlg.h:278 ../src/common/stockitem.cpp:182
+msgid "No"
+msgstr "Nò"
+
+#: ../include/wx/msgdlg.h:279 ../src/common/stockitem.cpp:183
+#: ../src/msw/msgdlg.cpp:430 ../src/msw/msgdlg.cpp:734
+#: ../src/richtext/richtextstyledlg.cpp:292
+msgid "OK"
+msgstr "Vai"
+
+#: ../include/wx/msgdlg.h:280 ../src/common/stockitem.cpp:150
+#: ../src/msw/msgdlg.cpp:430 ../src/msw/progdlg.cpp:884
+#: ../src/richtext/richtextstyledlg.cpp:295
+msgid "Cancel"
+msgstr "Abbandunà"
+
+#: ../include/wx/msgdlg.h:281 ../src/common/stockitem.cpp:168
+#: ../src/html/helpdlg.cpp:63 ../src/html/helpfrm.cpp:108
+#: ../src/osx/button_osx.cpp:38
+msgid "Help"
+msgstr "Aiutu"
+
+#: ../include/wx/msw/ole/oleutils.h:52
+msgid "Cannot initialize OLE"
+msgstr "Ùn si pò inizià OLE"
+
+#: ../include/wx/msw/private/fswatcher.h:48
+#, c-format
+msgid "Unable to close the handle for '%s'"
+msgstr "Impussibule di chjode u ghjestiunariu di « %s »"
+
+#: ../include/wx/msw/private/fswatcher.h:92
+#, c-format
+msgid "Failed to open directory \"%s\" for monitoring."
+msgstr "Fiascu à l’apertura di u cartulare « %s » per a surveglianza."
+
+#: ../include/wx/msw/private/fswatcher.h:125
+msgid "Unable to close I/O completion port handle"
+msgstr "Impussibule di chjode u ghjestiunariu di portu di cumpiimentu d’E/S"
+
+#: ../include/wx/msw/private/fswatcher.h:142
+msgid "Unable to associate handle with I/O completion port"
+msgstr ""
+"Impussibule d’assucià un ghjestiunariu cù un portu di cumpiimentu d’E/S"
+
+#: ../include/wx/msw/private/fswatcher.h:148
+msgid "Unexpectedly new I/O completion port was created"
+msgstr ""
+"Un novu portu di cumpiimentu d’E/S hè statu creatu d’una manera imprevista"
+
+#: ../include/wx/msw/private/fswatcher.h:213
+msgid "Unable to post completion status"
+msgstr "Impussibule di cumunicà u statu di cumpiimentu"
+
+#: ../include/wx/msw/private/fswatcher.h:262
+msgid "Unable to dequeue completion packet"
+msgstr "Impussibule d’estrae u pacchettu di cumpiimentu da a lista d’attesa"
+
+#: ../include/wx/msw/private/fswatcher.h:273
+msgid "Unable to create I/O completion port"
+msgstr "Impussibule di creà u portu di cumpiimentu d’E/S"
+
+#: ../include/wx/richmsgdlg.h:29
+msgid "&See details"
+msgstr "&Vede i detaglii"
+
+#: ../include/wx/richmsgdlg.h:30
+msgid "&Hide details"
+msgstr "&Piattà i detaglii"
+
+#: ../include/wx/richtext/richtextbuffer.h:3864
+msgid "&Box"
+msgstr "&Scatula"
+
+#: ../include/wx/richtext/richtextbuffer.h:5008
+msgid "&Picture"
+msgstr "&Fiura"
+
+#: ../include/wx/richtext/richtextbuffer.h:5958
+msgid "&Cell"
+msgstr "&Cellula"
+
+#: ../include/wx/richtext/richtextbuffer.h:6067
+msgid "&Table"
+msgstr "&Tavula"
+
+#: ../include/wx/richtext/richtextimagedlg.h:37
+msgid "Object Properties"
+msgstr "Pruprietà di l’oggettu"
+
+#: ../include/wx/richtext/richtextsymboldlg.h:39
+msgid "Symbols"
+msgstr "Simbuli"
+
+#: ../include/wx/unix/pipe.h:46
+msgid "Pipe creation failed"
+msgstr "Fiascu di a creazione di u cundottu"
+
+#: ../include/wx/unix/private/displayx11.h:65
+msgid "Failed to enumerate video modes"
+msgstr "Fiascu di l’enumerazione di i modi video"
+
+#: ../include/wx/unix/private/displayx11.h:89
+msgid "Failed to change video mode"
+msgstr "Fiascu di cambiamentu di modu video"
+
+#: ../include/wx/unix/private/fswatcher_kqueue.h:57
+#, c-format
+msgid "Unable to open path '%s'"
+msgstr "Impussibule d’apre u chjassu « %s »"
+
+#: ../include/wx/unix/private/fswatcher_kqueue.h:74
+#, c-format
+msgid "Unable to close path '%s'"
+msgstr "Impussibule di chjode u chjassu « %s »"
+
+#: ../include/wx/xtiprop.h:175
+msgid "SetProperty called w/o valid setter"
+msgstr "SetProperty chjamata senza mandante accettevule"
+
+#: ../include/wx/xtiprop.h:184
+msgid "GetProperty called w/o valid getter"
+msgstr "SetProperty chjamata senza ricevitore accettevule"
+
+#: ../include/wx/xtiprop.h:193
+msgid "AddToPropertyCollection called w/o valid adder"
+msgstr "AddToPropertyCollection chjamata senza tutalizadore accettevule"
+
+#: ../include/wx/xtiprop.h:202
+msgid "GetPropertyCollection called w/o valid collection getter"
+msgstr ""
+"GetPropertyCollection chjamata senza ricevitore accettevule di cullezzione"
+
+#: ../include/wx/xtiprop.h:255
+msgid "AddToPropertyCollection called on a generic accessor"
+msgstr "AddToPropertyCollection chjamata nant’à un assessore genericu"
+
+#: ../include/wx/xtiprop.h:262
+msgid "GetPropertyCollection called on a generic accessor"
+msgstr "GetPropertyCollection chjamata nant’à un assessore genericu"
+
+#: ../src/aui/tabmdi.cpp:106 ../src/generic/mdig.cpp:94
+msgid "Cl&ose"
+msgstr "&Chjode"
+
+#: ../src/aui/tabmdi.cpp:107 ../src/generic/mdig.cpp:95
+msgid "Close All"
+msgstr "Tuttu chjode"
+
+#: ../src/aui/tabmdi.cpp:109 ../src/generic/mdig.cpp:97 ../src/msw/mdi.cpp:175
+#: ../src/qt/mdi.cpp:258
+msgid "&Next"
+msgstr "&Seguente"
+
+#: ../src/aui/tabmdi.cpp:110 ../src/generic/mdig.cpp:98 ../src/msw/mdi.cpp:176
+#: ../src/qt/mdi.cpp:259
+msgid "&Previous"
+msgstr "&Precedente"
+
+#: ../src/aui/tabmdi.cpp:332 ../src/aui/tabmdi.cpp:348
+#: ../src/aui/tabmdi.cpp:350 ../src/generic/mdig.cpp:291
+#: ../src/generic/mdig.cpp:307 ../src/generic/mdig.cpp:311
+#: ../src/msw/mdi.cpp:337 ../src/qt/mdi.cpp:462
+msgid "&Window"
+msgstr "&Finestra"
+
+#: ../src/common/accelcmn.cpp:47
+msgctxt "keyboard key"
+msgid "Delete"
+msgstr "Squassà"
+
+#: ../src/common/accelcmn.cpp:48
+msgctxt "keyboard key"
+msgid "Del"
+msgstr "Suppr"
+
+#: ../src/common/accelcmn.cpp:49
+msgctxt "keyboard key"
+msgid "Back"
+msgstr "Ritornu"
+
+#: ../src/common/accelcmn.cpp:49
+msgctxt "keyboard key"
+msgid "Backspace"
+msgstr "Ritornu in daretu"
+
+#: ../src/common/accelcmn.cpp:50
+msgctxt "keyboard key"
+msgid "Insert"
+msgstr "Framette"
+
+#: ../src/common/accelcmn.cpp:51
+msgctxt "keyboard key"
+msgid "Ins"
+msgstr "Fram"
+
+#: ../src/common/accelcmn.cpp:52
+msgctxt "keyboard key"
+msgid "Enter"
+msgstr "Entrata"
+
+#: ../src/common/accelcmn.cpp:53
+msgctxt "keyboard key"
+msgid "Return"
+msgstr "Ritornu"
+
+#: ../src/common/accelcmn.cpp:54
+msgctxt "keyboard key"
+msgid "PageUp"
+msgstr "PaginaSù"
+
+#: ../src/common/accelcmn.cpp:54
+msgctxt "keyboard key"
+msgid "Page Up"
+msgstr "Pagina insù"
+
+#: ../src/common/accelcmn.cpp:55
+msgctxt "keyboard key"
+msgid "PageDown"
+msgstr "PaginaGhjò"
+
+#: ../src/common/accelcmn.cpp:55
+msgctxt "keyboard key"
+msgid "Page Down"
+msgstr "Pagina inghjò"
+
+#: ../src/common/accelcmn.cpp:56
+msgctxt "keyboard key"
+msgid "PgUp"
+msgstr "PgSù"
+
+#: ../src/common/accelcmn.cpp:57
+msgctxt "keyboard key"
+msgid "PgDn"
+msgstr "PgGhjò"
+
+#: ../src/common/accelcmn.cpp:58
+msgctxt "keyboard key"
+msgid "Left"
+msgstr "Manca"
+
+#: ../src/common/accelcmn.cpp:59
+msgctxt "keyboard key"
+msgid "Right"
+msgstr "Diritta"
+
+#: ../src/common/accelcmn.cpp:60
+msgctxt "keyboard key"
+msgid "Up"
+msgstr "Sù"
+
+#: ../src/common/accelcmn.cpp:61
+msgctxt "keyboard key"
+msgid "Down"
+msgstr "Ghjò"
+
+#: ../src/common/accelcmn.cpp:62
+msgctxt "keyboard key"
+msgid "Home"
+msgstr "Accolta"
+
+#: ../src/common/accelcmn.cpp:63
+msgctxt "keyboard key"
+msgid "End"
+msgstr "Fine"
+
+#: ../src/common/accelcmn.cpp:64
+msgctxt "keyboard key"
+msgid "Space"
+msgstr "Spaziu"
+
+#: ../src/common/accelcmn.cpp:65
+msgctxt "keyboard key"
+msgid "Tab"
+msgstr "Tabulazione"
+
+#: ../src/common/accelcmn.cpp:66
+msgctxt "keyboard key"
+msgid "Esc"
+msgstr "Esc"
+
+#: ../src/common/accelcmn.cpp:67
+msgctxt "keyboard key"
+msgid "Escape"
+msgstr "Scappamentu"
+
+#: ../src/common/accelcmn.cpp:68
+msgctxt "keyboard key"
+msgid "Cancel"
+msgstr "Abbandunà"
+
+#: ../src/common/accelcmn.cpp:69
+msgctxt "keyboard key"
+msgid "Clear"
+msgstr "Viutà"
+
+#: ../src/common/accelcmn.cpp:70
+msgctxt "keyboard key"
+msgid "Menu"
+msgstr "Interfaccia"
+
+#: ../src/common/accelcmn.cpp:71
+msgctxt "keyboard key"
+msgid "Pause"
+msgstr "Pausa"
+
+#: ../src/common/accelcmn.cpp:72
+msgctxt "keyboard key"
+msgid "Capital"
+msgstr "Maiuscula"
+
+#: ../src/common/accelcmn.cpp:73
+msgctxt "keyboard key"
+msgid "Select"
+msgstr "Selezziunà"
+
+#: ../src/common/accelcmn.cpp:74
+msgctxt "keyboard key"
+msgid "Print"
+msgstr "Stampà"
+
+#: ../src/common/accelcmn.cpp:75
+msgctxt "keyboard key"
+msgid "Execute"
+msgstr "Eseguisce"
+
+#: ../src/common/accelcmn.cpp:76
+msgctxt "keyboard key"
+msgid "Snapshot"
+msgstr "Istantanea"
+
+#: ../src/common/accelcmn.cpp:77
+msgctxt "keyboard key"
+msgid "Help"
+msgstr "Aiutu"
+
+#: ../src/common/accelcmn.cpp:78
+msgctxt "keyboard key"
+msgid "Add"
+msgstr "Aghjunghje"
+
+#: ../src/common/accelcmn.cpp:79
+msgctxt "keyboard key"
+msgid "Separator"
+msgstr "Separadore"
+
+#: ../src/common/accelcmn.cpp:80
+msgctxt "keyboard key"
+msgid "Subtract"
+msgstr "Suttrae"
+
+#: ../src/common/accelcmn.cpp:81
+msgctxt "keyboard key"
+msgid "Decimal"
+msgstr "Decimale"
+
+#: ../src/common/accelcmn.cpp:82
+msgctxt "keyboard key"
+msgid "Multiply"
+msgstr "Multiplicà"
+
+#: ../src/common/accelcmn.cpp:83
+msgctxt "keyboard key"
+msgid "Divide"
+msgstr "Divide"
+
+#: ../src/common/accelcmn.cpp:84
+msgctxt "keyboard key"
+msgid "Num_lock"
+msgstr "Bloccu_num"
+
+#: ../src/common/accelcmn.cpp:84
+msgctxt "keyboard key"
+msgid "Num Lock"
+msgstr "Bloccu num"
+
+#: ../src/common/accelcmn.cpp:85
+msgctxt "keyboard key"
+msgid "Scroll_lock"
+msgstr "Bloccu_sfilarata"
+
+#: ../src/common/accelcmn.cpp:85
+msgctxt "keyboard key"
+msgid "Scroll Lock"
+msgstr "Bloccu sfilarata"
+
+#: ../src/common/accelcmn.cpp:86
+msgctxt "keyboard key"
+msgid "KP_Space"
+msgstr "KP_Spaziu"
+
+#: ../src/common/accelcmn.cpp:86
+msgctxt "keyboard key"
+msgid "Num Space"
+msgstr "Num Spaziu"
+
+#: ../src/common/accelcmn.cpp:87
+msgctxt "keyboard key"
+msgid "KP_Tab"
+msgstr "KP_Tab"
+
+#: ../src/common/accelcmn.cpp:87
+msgctxt "keyboard key"
+msgid "Num Tab"
+msgstr "Num Tab"
+
+#: ../src/common/accelcmn.cpp:88
+msgctxt "keyboard key"
+msgid "KP_Enter"
+msgstr "KP_Entrata"
+
+#: ../src/common/accelcmn.cpp:88
+msgctxt "keyboard key"
+msgid "Num Enter"
+msgstr "Num Entrata"
+
+#: ../src/common/accelcmn.cpp:89
+msgctxt "keyboard key"
+msgid "KP_Home"
+msgstr "KP_Principiu"
+
+#: ../src/common/accelcmn.cpp:89
+msgctxt "keyboard key"
+msgid "Num Home"
+msgstr "Num Principiu"
+
+#: ../src/common/accelcmn.cpp:90
+msgctxt "keyboard key"
+msgid "KP_Left"
+msgstr "KP_Manca"
+
+#: ../src/common/accelcmn.cpp:90
+msgctxt "keyboard key"
+msgid "Num left"
+msgstr "Num Manca"
+
+#: ../src/common/accelcmn.cpp:91
+msgctxt "keyboard key"
+msgid "KP_Up"
+msgstr "KP_Insù"
+
+#: ../src/common/accelcmn.cpp:91
+msgctxt "keyboard key"
+msgid "Num Up"
+msgstr "Num Insù"
+
+#: ../src/common/accelcmn.cpp:92
+msgctxt "keyboard key"
+msgid "KP_Right"
+msgstr "KP_Diritta"
+
+#: ../src/common/accelcmn.cpp:92
+msgctxt "keyboard key"
+msgid "Num Right"
+msgstr "Num Diritta"
+
+#: ../src/common/accelcmn.cpp:93
+msgctxt "keyboard key"
+msgid "KP_Down"
+msgstr "KP_Inghjò"
+
+#: ../src/common/accelcmn.cpp:93
+msgctxt "keyboard key"
+msgid "Num Down"
+msgstr "Num Inghjò"
+
+#: ../src/common/accelcmn.cpp:94
+msgctxt "keyboard key"
+msgid "KP_PageUp"
+msgstr "KP_PaginaSù"
+
+#: ../src/common/accelcmn.cpp:94
+msgctxt "keyboard key"
+msgid "Num Page Up"
+msgstr "Num Pagina insù"
+
+#: ../src/common/accelcmn.cpp:95
+msgctxt "keyboard key"
+msgid "KP_PageDown"
+msgstr "KP_PaginaGhjò"
+
+#: ../src/common/accelcmn.cpp:95
+msgctxt "keyboard key"
+msgid "Num Page Down"
+msgstr "Num Pagina inghjò"
+
+#: ../src/common/accelcmn.cpp:96
+msgctxt "keyboard key"
+msgid "KP_Prior"
+msgstr "KP_Precedente"
+
+#: ../src/common/accelcmn.cpp:97
+msgctxt "keyboard key"
+msgid "KP_Next"
+msgstr "KP_Seguente"
+
+#: ../src/common/accelcmn.cpp:98
+msgctxt "keyboard key"
+msgid "KP_End"
+msgstr "KP_Fine"
+
+#: ../src/common/accelcmn.cpp:98
+msgctxt "keyboard key"
+msgid "Num End"
+msgstr "Num Fine"
+
+#: ../src/common/accelcmn.cpp:99
+msgctxt "keyboard key"
+msgid "KP_Begin"
+msgstr "KP_Principiu"
+
+#: ../src/common/accelcmn.cpp:99
+msgctxt "keyboard key"
+msgid "Num Begin"
+msgstr "Num Principiu"
+
+#: ../src/common/accelcmn.cpp:100
+msgctxt "keyboard key"
+msgid "KP_Insert"
+msgstr "KP_Framette"
+
+#: ../src/common/accelcmn.cpp:100
+msgctxt "keyboard key"
+msgid "Num Insert"
+msgstr "Num Framette"
+
+#: ../src/common/accelcmn.cpp:101
+msgctxt "keyboard key"
+msgid "KP_Delete"
+msgstr "KP_Squassà"
+
+#: ../src/common/accelcmn.cpp:101
+msgctxt "keyboard key"
+msgid "Num Delete"
+msgstr "Num Squassà"
+
+#: ../src/common/accelcmn.cpp:102
+msgctxt "keyboard key"
+msgid "KP_Equal"
+msgstr "KP_Uguale"
+
+#: ../src/common/accelcmn.cpp:102
+msgctxt "keyboard key"
+msgid "Num ="
+msgstr "Num ="
+
+#: ../src/common/accelcmn.cpp:103
+msgctxt "keyboard key"
+msgid "KP_Multiply"
+msgstr "KP_Multiplicà"
+
+#: ../src/common/accelcmn.cpp:103
+msgctxt "keyboard key"
+msgid "Num *"
+msgstr "Num *"
+
+#: ../src/common/accelcmn.cpp:104
+msgctxt "keyboard key"
+msgid "KP_Add"
+msgstr "KP_Aghjunghje"
+
+#: ../src/common/accelcmn.cpp:104
+msgctxt "keyboard key"
+msgid "Num +"
+msgstr "Num +"
+
+#: ../src/common/accelcmn.cpp:105
+msgctxt "keyboard key"
+msgid "KP_Separator"
+msgstr "KP_Separadore"
+
+#: ../src/common/accelcmn.cpp:105
+msgctxt "keyboard key"
+msgid "Num ,"
+msgstr "Num ,"
+
+#: ../src/common/accelcmn.cpp:106
+msgctxt "keyboard key"
+msgid "KP_Subtract"
+msgstr "KP_Suttrae"
+
+#: ../src/common/accelcmn.cpp:106
+msgctxt "keyboard key"
+msgid "Num -"
+msgstr "Num -"
+
+#: ../src/common/accelcmn.cpp:107
+msgctxt "keyboard key"
+msgid "KP_Decimal"
+msgstr "KP_Decimale"
+
+#: ../src/common/accelcmn.cpp:107
+msgctxt "keyboard key"
+msgid "Num ."
+msgstr "Num ."
+
+#: ../src/common/accelcmn.cpp:108
+msgctxt "keyboard key"
+msgid "KP_Divide"
+msgstr "KP_Divide"
+
+#: ../src/common/accelcmn.cpp:108
+msgctxt "keyboard key"
+msgid "Num /"
+msgstr "Num /"
+
+#: ../src/common/accelcmn.cpp:109
+msgctxt "keyboard key"
+msgid "Windows_Left"
+msgstr "Windows_Manca"
+
+#: ../src/common/accelcmn.cpp:110
+msgctxt "keyboard key"
+msgid "Windows_Right"
+msgstr "Windows_Diritta"
+
+#: ../src/common/accelcmn.cpp:111
+msgctxt "keyboard key"
+msgid "Windows_Menu"
+msgstr "Windows_Listinu"
+
+#: ../src/common/accelcmn.cpp:112
+msgctxt "keyboard key"
+msgid "Command"
+msgstr "Cumanda"
+
+#: ../src/common/accelcmn.cpp:186 ../src/common/accelcmn.cpp:359
+msgctxt "keyboard key"
+msgid "Ctrl"
+msgstr "Ctrl"
+
+#: ../src/common/accelcmn.cpp:188 ../src/common/accelcmn.cpp:363
+msgctxt "keyboard key"
+msgid "Alt"
+msgstr "Alt"
+
+#: ../src/common/accelcmn.cpp:190 ../src/common/accelcmn.cpp:361
+msgctxt "keyboard key"
+msgid "Shift"
+msgstr "Maiusc"
+
+#: ../src/common/accelcmn.cpp:196
+msgctxt "keyboard key"
+msgid "num "
+msgstr "num "
+
+#: ../src/common/accelcmn.cpp:260 ../src/common/accelcmn.cpp:382
+msgctxt "keyboard key"
+msgid "F"
+msgstr "F"
+
+#: ../src/common/accelcmn.cpp:277 ../src/common/accelcmn.cpp:385
+msgctxt "keyboard key"
+msgid "KP_F"
+msgstr "KP_F"
+
+#: ../src/common/accelcmn.cpp:280 ../src/common/accelcmn.cpp:388
+msgctxt "keyboard key"
+msgid "KP_"
+msgstr "KP_"
+
+#: ../src/common/accelcmn.cpp:283 ../src/common/accelcmn.cpp:391
+msgctxt "keyboard key"
+msgid "SPECIAL"
+msgstr "SPEZIALE"
+
+#: ../src/common/accelcmn.cpp:373
+msgid "Ctrl"
+msgstr "Ctrl"
+
+#: ../src/common/appbase.cpp:786
+msgid "show this help message"
+msgstr "affissà stu messaghju d’aiutu"
+
+#: ../src/common/appbase.cpp:796
+msgid "generate verbose log messages"
+msgstr "ingenerà messaghji verbosi di ghjurnale"
+
+#: ../src/common/appcmn.cpp:256
+msgid "specify the theme to use"
+msgstr "specificà u tema à impiegà"
+
+#: ../src/common/appcmn.cpp:270
+msgid "specify display mode to use (e.g. 640x480-16)"
+msgstr "specificà u modu d’affissera à impiegà (i.e. 640x480-16)"
+
+#: ../src/common/appcmn.cpp:292
+#, c-format
+msgid "Unsupported theme '%s'."
+msgstr "Tema « %s » micca accettatu."
+
+#: ../src/common/appcmn.cpp:309
+#, c-format
+msgid "Invalid display mode specification '%s'."
+msgstr "Specificazione di u modu d’affissera « %s » inaccettevule."
+
+#: ../src/common/cmdline.cpp:875
+#, c-format
+msgid "Option '%s' can't be negated"
+msgstr "L’ozzione « %s » ùn pò micca esse nigata"
+
+#: ../src/common/cmdline.cpp:889
+#, c-format
+msgid "Unknown long option '%s'"
+msgstr "Ozzione longa « %s » scunnisciuta"
+
+#: ../src/common/cmdline.cpp:904 ../src/common/cmdline.cpp:926
+#, c-format
+msgid "Unknown option '%s'"
+msgstr "Ozzione « %s » scunnisciuta"
+
+#: ../src/common/cmdline.cpp:1004
+#, c-format
+msgid "Unexpected characters following option '%s'."
+msgstr "Caratteri imprevisti dopu l’ozzione « %s »."
+
+#: ../src/common/cmdline.cpp:1039
+#, c-format
+msgid "Option '%s' requires a value."
+msgstr "L’ozzione « %s » richiede un valore."
+
+#: ../src/common/cmdline.cpp:1058
+#, c-format
+msgid "Separator expected after the option '%s'."
+msgstr "Separadore aspettatu dopu l’ozzione « %s »."
+
+#: ../src/common/cmdline.cpp:1088 ../src/common/cmdline.cpp:1106
+#, c-format
+msgid "'%s' is not a correct numeric value for option '%s'."
+msgstr "« %s » ùn hè micca un valore numericu currettu per l’ozzione « %s »."
+
+#: ../src/common/cmdline.cpp:1122
+#, c-format
+msgid "Option '%s': '%s' cannot be converted to a date."
+msgstr "L’ozzione « %s » : « %s » ùn pò micca esse cunvertita in una data."
+
+#: ../src/common/cmdline.cpp:1170
+#, c-format
+msgid "Unexpected parameter '%s'"
+msgstr "Parametru « %s » imprevistu"
+
+#. TRANSLATORS: Short name and long name for a command line option
+#: ../src/common/cmdline.cpp:1197
+#, c-format
+msgid "%s (or %s)"
+msgstr "%s (o %s)"
+
+#: ../src/common/cmdline.cpp:1208
+#, c-format
+msgid "The value for the option '%s' must be specified."
+msgstr "U valore deve esse specificatu per l’ozzione « %s »."
+
+#: ../src/common/cmdline.cpp:1230
+#, c-format
+msgid "The required parameter '%s' was not specified."
+msgstr "U parametru richiestu « %s » ùn hè micca specificatu."
+
+#: ../src/common/cmdline.cpp:1289
+#, c-format
+msgid "Usage: %s"
+msgstr "Impiegu : %s"
+
+#: ../src/common/cmdline.cpp:1498
+msgid "str"
+msgstr "str"
+
+#: ../src/common/cmdline.cpp:1502
+msgid "num"
+msgstr "num"
+
+#: ../src/common/cmdline.cpp:1506
+msgid "double"
+msgstr "doppiu"
+
+#: ../src/common/cmdline.cpp:1510
+msgid "date"
+msgstr "data"
+
+#: ../src/common/cmdproc.cpp:250 ../src/common/cmdproc.cpp:276
+#: ../src/common/cmdproc.cpp:296
+msgid "Unnamed command"
+msgstr "Cumanda senza nome"
+
+#: ../src/common/cmdproc.cpp:253
+msgid "&Undo "
+msgstr "&Disfà "
+
+#: ../src/common/cmdproc.cpp:255
+msgid "Can't &Undo "
+msgstr "Ùn si pò disfà "
+
+#: ../src/common/cmdproc.cpp:259 ../src/common/stockitem.cpp:208
+#: ../src/msw/textctrl.cpp:2880 ../src/osx/textctrl_osx.cpp:649
+#: ../src/richtext/richtextctrl.cpp:327
+msgid "&Undo"
+msgstr "&Disfà"
+
+#: ../src/common/cmdproc.cpp:277 ../src/common/cmdproc.cpp:297
+msgid "&Redo "
+msgstr "&Rifà "
+
+#: ../src/common/cmdproc.cpp:281 ../src/common/cmdproc.cpp:288
+#: ../src/common/stockitem.cpp:190 ../src/msw/textctrl.cpp:2881
+#: ../src/osx/textctrl_osx.cpp:650 ../src/richtext/richtextctrl.cpp:328
+msgid "&Redo"
+msgstr "&Rifà"
+
+#: ../src/common/colourcmn.cpp:41
+#, c-format
+msgid "String To Colour : Incorrect colour specification : %s"
+msgstr ""
+"Cunversione di catena in culore : specificazione incurretta di culore  :%s"
+
+#: ../src/common/config.cpp:259
+#, c-format
+msgid "Invalid value %ld for a boolean key \"%s\" in config file."
+msgstr ""
+"Valore %ld inaccettevule per una chjave booleana « %s » in u schedariu di "
+"cunfigurazione."
+
+#: ../src/common/config.cpp:526
+#, c-format
+msgid ""
+"Environment variables expansion failed: missing '%c' at position %u in '%s'."
+msgstr ""
+"Fiascu di l’espansione di e variabile d’ambiente : « %c » assente à a "
+"pusizione %u in « %s »."
+
+#: ../src/common/config.cpp:576 ../src/msw/regconf.cpp:272
+#, c-format
+msgid "'%s' has extra '..', ignored."
+msgstr "« %s » hà troppu di « .. » ; sò ignurati."
+
+#. TRANSLATORS: Checkbox state name
+#: ../src/common/datavcmn.cpp:2166 ../src/generic/datavgen.cpp:1430
+msgid "checked"
+msgstr "marcata"
+
+#. TRANSLATORS: Checkbox state name
+#: ../src/common/datavcmn.cpp:2170 ../src/generic/datavgen.cpp:1432
+msgid "unchecked"
+msgstr "micca marcata"
+
+#. TRANSLATORS: Checkbox state name
+#: ../src/common/datavcmn.cpp:2174
+msgid "undetermined"
+msgstr "indeterminata"
+
+#: ../src/common/datetimefmt.cpp:1875
+msgid "today"
+msgstr "oghje"
+
+#: ../src/common/datetimefmt.cpp:1876
+msgid "yesterday"
+msgstr "eri"
+
+#: ../src/common/datetimefmt.cpp:1877
+msgid "tomorrow"
+msgstr "dumane"
+
+#: ../src/common/datetimefmt.cpp:2071
+msgid "first"
+msgstr "primu"
+
+#: ../src/common/datetimefmt.cpp:2072
+msgid "second"
+msgstr "secondu"
+
+#: ../src/common/datetimefmt.cpp:2073
+msgid "third"
+msgstr "terzu"
+
+#: ../src/common/datetimefmt.cpp:2074
+msgid "fourth"
+msgstr "quartu"
+
+#: ../src/common/datetimefmt.cpp:2075
+msgid "fifth"
+msgstr "quintu"
+
+#: ../src/common/datetimefmt.cpp:2076
+msgid "sixth"
+msgstr "sestu"
+
+#: ../src/common/datetimefmt.cpp:2077
+msgid "seventh"
+msgstr "settimu"
+
+#: ../src/common/datetimefmt.cpp:2078
+msgid "eighth"
+msgstr "ottesimu"
+
+#: ../src/common/datetimefmt.cpp:2079
+msgid "ninth"
+msgstr "novesimu"
+
+#: ../src/common/datetimefmt.cpp:2080
+msgid "tenth"
+msgstr "decesimu"
+
+#: ../src/common/datetimefmt.cpp:2081
+msgid "eleventh"
+msgstr "ondecesimu"
+
+#: ../src/common/datetimefmt.cpp:2082
+msgid "twelfth"
+msgstr "dodicesimu"
+
+#: ../src/common/datetimefmt.cpp:2083
+msgid "thirteenth"
+msgstr "tredicesimu"
+
+#: ../src/common/datetimefmt.cpp:2084
+msgid "fourteenth"
+msgstr "quattordicesimu"
+
+#: ../src/common/datetimefmt.cpp:2085
+msgid "fifteenth"
+msgstr "quindecesimu"
+
+#: ../src/common/datetimefmt.cpp:2086
+msgid "sixteenth"
+msgstr "sedecesimu"
+
+#: ../src/common/datetimefmt.cpp:2087
+msgid "seventeenth"
+msgstr "dicessettesimu"
+
+#: ../src/common/datetimefmt.cpp:2088
+msgid "eighteenth"
+msgstr "diciottesimu"
+
+#: ../src/common/datetimefmt.cpp:2089
+msgid "nineteenth"
+msgstr "dicennovesimu"
+
+#: ../src/common/datetimefmt.cpp:2090
+msgid "twentieth"
+msgstr "vintesimu"
+
+#: ../src/common/datetimefmt.cpp:2248
+msgid "noon"
+msgstr "meziornu"
+
+#: ../src/common/datetimefmt.cpp:2249
+msgid "midnight"
+msgstr "mezanotte"
+
+#: ../src/common/debugrpt.cpp:209
+#, c-format
+msgid "Failed to create directory \"%s\""
+msgstr "Fiascu per creà u cartulare « %s »"
+
+#: ../src/common/debugrpt.cpp:210
+msgid "Debug report couldn't be created."
+msgstr "Ùn si pò creà u raportu di spannatura."
+
+#: ../src/common/debugrpt.cpp:227
+#, c-format
+msgid "Failed to remove debug report file \"%s\""
+msgstr "Fiascu per caccià u schedariu « %s » di raportu di spannatura"
+
+#: ../src/common/debugrpt.cpp:239
+#, c-format
+msgid "Failed to clean up debug report directory \"%s\""
+msgstr "Fiascu per nettà u cartulare « %s » di raporti di spannatura"
+
+#: ../src/common/debugrpt.cpp:514
+msgid "process context description"
+msgstr "discrizzione di u cuntestu di trattamentu"
+
+#: ../src/common/debugrpt.cpp:538
+msgid "dump of the process state (binary)"
+msgstr "rumenzulaghju di u statu di u trattamentu (binariu)"
+
+#: ../src/common/debugrpt.cpp:553
+msgid "Debug report generation has failed."
+msgstr "Ùn si pò ingenerà u raportu di spannatura."
+
+#: ../src/common/debugrpt.cpp:560
+#, c-format
+msgid ""
+"Processing debug report has failed, leaving the files in \"%s\" directory."
+msgstr ""
+"Fiascu di u trattamentu di u raportu di spannatura, lasciendu i schedarii in "
+"u cartulare « %s »."
+
+#: ../src/common/debugrpt.cpp:573
+msgid "A debug report has been generated. It can be found in"
+msgstr "Un raportu di spannatura hè statu creatu. Si pò truvallu in"
+
+#: ../src/common/debugrpt.cpp:576
+msgid "And includes the following files:\n"
+msgstr "È inchjude quelli schedarii :\n"
+
+#: ../src/common/debugrpt.cpp:586
+msgid ""
+"\n"
+"Please send this report to the program maintainer, thank you!\n"
+msgstr ""
+"\n"
+"Vi ringraziemu di mandà stu raportu à l’autore di u prugramma !\n"
+
+#: ../src/common/debugrpt.cpp:729
+msgid "Failed to execute curl, please install it in PATH."
+msgstr ""
+"Fiascu di l’esecuzione di curl, ci vole à installalu in a variabile PATH."
+
+#: ../src/common/debugrpt.cpp:742
+#, c-format
+msgid "Failed to upload the debug report (error code %d)."
+msgstr "Fiascu di l’inviu di u raportu di spannatura (codice di sbagliu %d)."
+
+#: ../src/common/docview.cpp:366
+msgid "Save As"
+msgstr "Arregistrà cù u nome"
+
+#: ../src/common/docview.cpp:457
+msgid "Discard changes and reload the last saved version?"
+msgstr "Scartà i cambiamenti è ricaricà l’ultima versione arregistrata ?"
+
+#: ../src/common/docview.cpp:488
+msgid "unnamed"
+msgstr "senza nome"
+
+#: ../src/common/docview.cpp:513
+#, c-format
+msgid "Do you want to save changes to %s?"
+msgstr "Vulete arregistrà i cambiamenti ver di %s ?"
+
+#: ../src/common/docview.cpp:521 ../src/common/docview.cpp:560
+#: ../src/common/stockitem.cpp:195
+msgid "&Save"
+msgstr "&Arregistrà"
+
+#: ../src/common/docview.cpp:522 ../src/common/docview.cpp:560
+msgid "&Discard changes"
+msgstr "&Scartà i cambiamenti"
+
+#: ../src/common/docview.cpp:523
+msgid "Do&n't close"
+msgstr "Ùn chjode &micca"
+
+#: ../src/common/docview.cpp:553
+#, c-format
+msgid "Do you want to save changes to %s before closing it?"
+msgstr "Vulete arregistrà i cambiamenti ver di %s nanzu a chjusura ?"
+
+#: ../src/common/docview.cpp:559
+msgid "The document must be closed."
+msgstr "U ducumentu deve esse chjosu."
+
+#: ../src/common/docview.cpp:571
+#, c-format
+msgid "Saving %s failed, would you like to retry?"
+msgstr "Fiascu à l’arregistramentu di %s ; vulete pruvà torna ?"
+
+#: ../src/common/docview.cpp:577
+msgid "Retry"
+msgstr "Pruvà torna"
+
+#: ../src/common/docview.cpp:577
+msgid "Discard changes"
+msgstr "Scartà i cambiamenti"
+
+#: ../src/common/docview.cpp:679
+#, c-format
+msgid "File \"%s\" could not be opened for writing."
+msgstr "U schedariu « %s » ùn pò micca esse apertu in scrittura."
+
+#: ../src/common/docview.cpp:685
+#, c-format
+msgid "Failed to save document to the file \"%s\"."
+msgstr "Fiascu à l’arregistramentu di u ducumentu in u schedariu « %s »."
+
+#: ../src/common/docview.cpp:702
+#, c-format
+msgid "File \"%s\" could not be opened for reading."
+msgstr "U schedariu « %s » ùn pò micca esse apertu in lettura."
+
+#: ../src/common/docview.cpp:714
+#, c-format
+msgid "Failed to read document from the file \"%s\"."
+msgstr "Fiascu di lettura di u ducumentu in u schedariu « %s »."
+
+#: ../src/common/docview.cpp:1236
+#, c-format
+msgid ""
+"The file '%s' doesn't exist and couldn't be opened.\n"
+"It has been removed from the most recently used files list."
+msgstr ""
+"U schedariu « %s » ùn esiste micca è ùn pò micca esse apertu.\n"
+"Hè statu cacciatu da a lista di i schedarii impiegati pocu fà."
+
+#: ../src/common/docview.cpp:1296
+msgid "Print preview creation failed."
+msgstr "Fiascu di a creazione di a fighjulata nanzu a stampa."
+
+#: ../src/common/docview.cpp:1302
+msgid "Print Preview"
+msgstr "Fighjulata nanzu a stampa"
+
+#: ../src/common/docview.cpp:1517
+#, c-format
+msgid "The format of file '%s' couldn't be determined."
+msgstr "Ùn si pò determinà u furmatu di u schedariu « %s »."
+
+#: ../src/common/docview.cpp:1643
+#, c-format
+msgid "unnamed%d"
+msgstr "senza nome %d"
+
+#: ../src/common/docview.cpp:1660
+msgid " - "
+msgstr " - "
+
+#: ../src/common/docview.cpp:1791 ../src/common/docview.cpp:1844
+msgid "Open File"
+msgstr "Apre un schedariu"
+
+#: ../src/common/docview.cpp:1807
+msgid "File error"
+msgstr "Sbagliu di schedariu"
+
+#: ../src/common/docview.cpp:1809
+msgid "Sorry, could not open this file."
+msgstr "Per disgrazia, ùn si pò apre stu schedariu."
+
+#: ../src/common/docview.cpp:1843
+msgid "Sorry, the format for this file is unknown."
+msgstr "Per disgrazia, u furmatu di stu schedariu hè scunnisciutu."
+
+#: ../src/common/docview.cpp:1924
+msgid "Select a document template"
+msgstr "Selezziunà un mudellu di ducumentu"
+
+#: ../src/common/docview.cpp:1925
+msgid "Templates"
+msgstr "Mudelli"
+
+#: ../src/common/docview.cpp:1998
+msgid "Select a document view"
+msgstr "Selezziunà una vista di u ducumentu"
+
+#: ../src/common/docview.cpp:1999
+msgid "Views"
+msgstr "Viste"
+
+#: ../src/common/dynlib.cpp:81
+#, c-format
+msgid "Failed to load shared library '%s'"
+msgstr "Fiascu di caricamentu di a bibliuteca sparta « %s »"
+
+#: ../src/common/dynlib.cpp:105
+#, c-format
+msgid "Couldn't find symbol '%s' in a dynamic library"
+msgstr "Ùn si pò truvà u simbulu « %s » in a bibliuteca dinamica"
+
+#: ../src/common/ffile.cpp:56 ../src/common/file.cpp:215
+#, c-format
+msgid "can't open file '%s'"
+msgstr "ùn si pò apre u schedariu « %s »"
+
+#: ../src/common/ffile.cpp:72
+#, c-format
+msgid "can't close file '%s'"
+msgstr "ùn si pò chjode u schedariu « %s »"
+
+#: ../src/common/ffile.cpp:106 ../src/common/ffile.cpp:131
+#, c-format
+msgid "Read error on file '%s'"
+msgstr "Sbagliu di lettura nant’à u schedariu « %s »"
+
+#: ../src/common/ffile.cpp:148
+#, c-format
+msgid "Write error on file '%s'"
+msgstr "Sbagliu di scrittura nant’à u schedariu « %s »"
+
+#: ../src/common/ffile.cpp:182
+#, c-format
+msgid "failed to flush the file '%s'"
+msgstr "impussibule di sfurzà a scrittura nant’à u discu di u schedariu « %s »"
+
+#: ../src/common/ffile.cpp:222
+#, c-format
+msgid "Seek error on file '%s' (large files not supported by stdio)"
+msgstr ""
+"Sbagliu di ricerca in u schedariu « %s » (i schedarii maiò ùn sò micca "
+"accettati da stdio)"
+
+#: ../src/common/ffile.cpp:232
+#, c-format
+msgid "Seek error on file '%s'"
+msgstr "Sbagliu di ricerca in u schedariu « %s »"
+
+#: ../src/common/ffile.cpp:248
+#, c-format
+msgid "Can't find current position in file '%s'"
+msgstr "Impussibule di truvà a pusizione currente in u schedariu « %s »"
+
+#: ../src/common/ffile.cpp:349 ../src/common/file.cpp:569
+msgid "Failed to set temporary file permissions"
+msgstr "Fiascu di definizione di i permessi di schedariu timpurariu"
+
+#: ../src/common/ffile.cpp:371
+#, c-format
+msgid "can't remove file '%s'"
+msgstr "ùn si pò caccià u schedariu « %s »"
+
+#: ../src/common/ffile.cpp:376 ../src/common/file.cpp:591
+#, c-format
+msgid "can't commit changes to file '%s'"
+msgstr "ùn si pò accettà i cambiamenti in u schedariu « %s »"
+
+#: ../src/common/ffile.cpp:388 ../src/common/file.cpp:603
+#, c-format
+msgid "can't remove temporary file '%s'"
+msgstr "ùn si pò caccià u schedariu timpurariu « %s »"
+
+#: ../src/common/file.cpp:162
+#, c-format
+msgid "can't create file '%s'"
+msgstr "ùn si pò creà u schedariu « %s »"
+
+#: ../src/common/file.cpp:229
+#, c-format
+msgid "can't close file descriptor %d"
+msgstr "ùn si pò chjode u discrittore di schedariu %d"
+
+#: ../src/common/file.cpp:332
+#, c-format
+msgid "can't read from file descriptor %d"
+msgstr "ùn si pò leghje da u discrittore di schedariu %d"
+
+#: ../src/common/file.cpp:351
+#, c-format
+msgid "can't write to file descriptor %d"
+msgstr "ùn si pò scrive in u discrittore di schedariu %d"
+
+#: ../src/common/file.cpp:390
+#, c-format
+msgid "can't flush file descriptor %d"
+msgstr ""
+"impussibule di sfurzà a scrittura nant’à u discu di u discrittore di "
+"schedariu %d"
+
+#: ../src/common/file.cpp:432
+#, c-format
+msgid "can't seek on file descriptor %d"
+msgstr "ùn si pò circà nant’à u discrittore di schedariu %d"
+
+#: ../src/common/file.cpp:446
+#, c-format
+msgid "can't get seek position on file descriptor %d"
+msgstr ""
+"ùn si pò ottene a pusizione di ricerca nant’à u discrittore di schedariu %d"
+
+#: ../src/common/file.cpp:475
+#, c-format
+msgid "can't find length of file on file descriptor %d"
+msgstr ""
+"ùn si pò truvà a dimensione di u schedariu nant’à u discrittore di schedariu "
+"%d"
+
+#: ../src/common/file.cpp:505
+#, c-format
+msgid "can't determine if the end of file is reached on descriptor %d"
+msgstr ""
+"ùn si pò sapè s’è a fine di u schedariu hè stata tocca in u discrittore %d"
+
+#: ../src/common/fileconf.cpp:352
+#, c-format
+msgid ""
+" and additionally, the existing configuration file was renamed to \"%s\" and "
+"couldn't be renamed back, please rename it to its original path \"%s\""
+msgstr ""
+" è dinù, u schedariu di cunfigurazione esistente hè statu rinuminatu in "
+"« %s » è ùn pò micca esse rinuminatu cum’ellu era nanzu ; ci vole à "
+"rinuminallu à u so chjassu d’origine « %s »"
+
+#: ../src/common/fileconf.cpp:389
+msgid " due to the following error:\n"
+msgstr " per via di quellu sbagliu :\n"
+
+#: ../src/common/fileconf.cpp:412
+msgid "failed to rename the existing file"
+msgstr "fiascu per rinuminà u schedariu esistente"
+
+#: ../src/common/fileconf.cpp:421
+msgid "failed to create the new file directory"
+msgstr "fiascu per creà u cartulare di schedariu novu"
+
+#: ../src/common/fileconf.cpp:428
+msgid "failed to move the file to the new location"
+msgstr "fiascu per dispiazzà u schedariu versu u locu novu"
+
+#: ../src/common/fileconf.cpp:462
+#, c-format
+msgid "can't open global configuration file '%s'."
+msgstr "ùn si pò apre u schedariu glubale di cunfigurazione « %s »."
+
+#: ../src/common/fileconf.cpp:478
+#, c-format
+msgid "can't open user configuration file '%s'."
+msgstr "ùn si pò apre u schedariu di cunfigurazione di l’utilizatore « %s »."
+
+#: ../src/common/fileconf.cpp:483
+#, c-format
+msgid "Changes won't be saved to avoid overwriting the existing file \"%s\""
+msgstr ""
+"I cambiamenti ùn seranu micca arregistrati per evità di rimpiazzà u "
+"schedariu esistente « %s »"
+
+#: ../src/common/fileconf.cpp:583
+msgid "Error reading config options."
+msgstr "Sbagliu durante a lettura di l’ozzioni di cunfigurazione."
+
+#: ../src/common/fileconf.cpp:593
+msgid "Failed to read config options."
+msgstr "Fiascu à a lettura di l’ozzioni di cunfigurazione."
+
+#: ../src/common/fileconf.cpp:700
+#, c-format
+msgid "file '%s': unexpected character %c at line %zu."
+msgstr "schedariu « %s » : caratteru %c imprevistu à a linea %zu."
+
+#: ../src/common/fileconf.cpp:736
+#, c-format
+msgid "file '%s', line %zu: '%s' ignored after group header."
+msgstr ""
+"schedariu « %s », linea %zu : « %s » ignuratu dopu l’intestatura di gruppu."
+
+#: ../src/common/fileconf.cpp:765
+#, c-format
+msgid "file '%s', line %zu: '=' expected."
+msgstr "schedariu « %s », linea %zu : simbulu « = » aspettatu."
+
+#: ../src/common/fileconf.cpp:778
+#, c-format
+msgid "file '%s', line %zu: value for immutable key '%s' ignored."
+msgstr ""
+"schedariu « %s », linea %zu : valore « %s » ignuratu per u tastu micca "
+"cunfigurevule."
+
+#: ../src/common/fileconf.cpp:788
+#, c-format
+msgid "file '%s', line %zu: key '%s' was first found at line %d."
+msgstr ""
+"schedariu « %s », linea %zu : prima occurenza di a chjave « %s » trova à a "
+"linea %d."
+
+#: ../src/common/fileconf.cpp:1091
+#, c-format
+msgid "Config entry name cannot start with '%c'."
+msgstr "U nome d’elementu di cunfigurazione ùn pò micca principià cù « %c »."
+
+#: ../src/common/fileconf.cpp:1146
+msgid "Failed to create configuration file directory."
+msgstr "Ùn si pò micca creà u cartulare di u schedariu di cunfigurazione."
+
+#: ../src/common/fileconf.cpp:1158
+msgid "can't open user configuration file."
+msgstr "ùn si pò apre u schedariu di cunfigurazione di l’utilizatore."
+
+#: ../src/common/fileconf.cpp:1172
+msgid "can't write user configuration file."
+msgstr "ùn si pò scrive nant’à u schedariu di cunfigurazione di l’utilizatore."
+
+#: ../src/common/fileconf.cpp:1178
+msgid "Failed to update user configuration file."
+msgstr "Fiascu per mudificà u schedariu di cunfigurazione di l’utilizatore."
+
+#: ../src/common/fileconf.cpp:1201
+msgid "Error saving user configuration data."
+msgstr ""
+"Sbagliu à l’arregistramentu di i dati di cunfigurazione di l’utilizatore."
+
+#: ../src/common/fileconf.cpp:1313
+#, c-format
+msgid "can't delete user configuration file '%s'"
+msgstr "ùn si pò squassà u schedariu di cunfigurazione di l’utilizatore « %s »"
+
+#: ../src/common/fileconf.cpp:2007
+#, c-format
+msgid "entry '%s' appears more than once in group '%s'"
+msgstr "l’elementu « %s » accade più d’una volta in u gruppu « %s »"
+
+#: ../src/common/fileconf.cpp:2021
+#, c-format
+msgid "attempt to change immutable key '%s' ignored."
+msgstr "tentativu ignuratu per cambià u tastu « %s » micca cunfigurevule."
+
+#: ../src/common/fileconf.cpp:2118
+#, c-format
+msgid "trailing backslash ignored in '%s'"
+msgstr "barra sbieca « \\ » di fine ignurata in « %s »"
+
+#: ../src/common/fileconf.cpp:2153
+#, c-format
+msgid "unexpected \" at position %d in '%s'."
+msgstr "simbulu « \" » imprevistu à a pusizione %d in « %s »."
+
+#: ../src/common/filefn.cpp:474
+#, c-format
+msgid "Failed to copy the file '%s' to '%s'"
+msgstr "Fiascu di a copia di u schedariu « %s » versu « %s »."
+
+#: ../src/common/filefn.cpp:487
+#, c-format
+msgid "Impossible to get permissions for file '%s'"
+msgstr "Impussibule d’ottene i permessi per u schedariu « %s »"
+
+#: ../src/common/filefn.cpp:501
+#, c-format
+msgid "Impossible to overwrite the file '%s'"
+msgstr "Impussibule di rimpiazzà u schedariu « %s »"
+
+#: ../src/common/filefn.cpp:508
+#, c-format
+msgid "Error copying the file '%s' to '%s'."
+msgstr "Sbagliu durante a copia di u schedariu « %s » versu « %s »."
+
+#: ../src/common/filefn.cpp:556
+#, c-format
+msgid "Impossible to set permissions for the file '%s'"
+msgstr "Impussibule di definisce i permessi per u schedariu « %s »"
+
+#: ../src/common/filefn.cpp:606
+#, c-format
+msgid ""
+"Failed to rename the file '%s' to '%s' because the destination file already "
+"exists."
+msgstr ""
+"Fiascu di a rinuminazione di u schedariu da « %s » à « %s » perchè u "
+"schedariu di destinazione esiste dighjà."
+
+#: ../src/common/filefn.cpp:623
+#, c-format
+msgid "File '%s' couldn't be renamed '%s'"
+msgstr "U schedariu « %s » ùn pò micca esse rinuminatu « %s »"
+
+#: ../src/common/filefn.cpp:639
+#, c-format
+msgid "File '%s' couldn't be removed"
+msgstr "U schedariu « %s » ùn pò micca esse cacciatura"
+
+#: ../src/common/filefn.cpp:666
+#, c-format
+msgid "Directory '%s' couldn't be created"
+msgstr "U cartulare « %s » ùn pò micca esse creatu"
+
+#: ../src/common/filefn.cpp:680
+#, c-format
+msgid "Directory '%s' couldn't be deleted"
+msgstr "U cartulare « %s » ùn pò micca esse squassatu"
+
+#: ../src/common/filefn.cpp:714
+#, c-format
+msgid "Cannot enumerate files '%s'"
+msgstr "Ùn si pò micca enumerà i schedarii « %s »"
+
+#: ../src/common/filefn.cpp:798
+msgid "Failed to get the working directory"
+msgstr "Fiascu per ottene u cartulare di travagliu"
+
+#: ../src/common/filefn.cpp:843
+msgid "Could not set current working directory"
+msgstr "Ùn si pò micca definisce u cartulare di travagliu attuale"
+
+#: ../src/common/filefn.cpp:974
+#, c-format
+msgid "Files (%s)"
+msgstr "Schedarii (%s)"
+
+#: ../src/common/filename.cpp:182
+#, c-format
+msgid "Failed to open '%s' for reading"
+msgstr "Fiascu per apre « %s » in lettura"
+
+#: ../src/common/filename.cpp:187
+#, c-format
+msgid "Failed to open '%s' for writing"
+msgstr "Fiascu per apre « %s » in scrittura"
+
+#: ../src/common/filename.cpp:199
+msgid "Failed to close file handle"
+msgstr "Fiascu per chjode u ghjestiunariu di schedariu"
+
+#: ../src/common/filename.cpp:1046
+msgid "Failed to create a temporary file name"
+msgstr "Fiascu per creà un nome di schedariu timpurariu"
+
+#: ../src/common/filename.cpp:1081
+msgid "Failed to open temporary file."
+msgstr "Fiascu per apre un schedariu timpurariu."
+
+#: ../src/common/filename.cpp:2862
+#, c-format
+msgid "Failed to modify file times for '%s'"
+msgstr "Fiascu per mudificà a data o l’ora per « %s »"
+
+#: ../src/common/filename.cpp:2877
+#, c-format
+msgid "Failed to touch the file '%s'"
+msgstr "Fiascu per tuccà u schedariu « %s »"
+
+#: ../src/common/filename.cpp:2958
+#, c-format
+msgid "Failed to retrieve file times for '%s'"
+msgstr "Fiascu per ricuperà a data o l’ora per « %s »"
+
+#: ../src/common/filepickercmn.cpp:39 ../src/common/filepickercmn.cpp:40
+msgid "Browse"
+msgstr "Navigà"
+
+#: ../src/common/fldlgcmn.cpp:792 ../src/generic/filectrlg.cpp:1185
+#, c-format
+msgid "All files (%s)|%s"
+msgstr "Tutti i schedarii (%s)|%s"
+
+#. TRANSLATORS: %s are a file extension used to build a file wildcard string
+#: ../src/common/fldlgcmn.cpp:810
+#, c-format
+msgid "%s files (%s)|%s"
+msgstr "%s schedarii (%s)|%s"
+
+#: ../src/common/fldlgcmn.cpp:1072
+#, c-format
+msgid "Load %s file"
+msgstr "Caricà u schedariu %s"
+
+#: ../src/common/fldlgcmn.cpp:1074
+#, c-format
+msgid "Save %s file"
+msgstr "Arregistrà u schedariu %s"
+
+#: ../src/common/fmapbase.cpp:144
+msgid "Western European (ISO-8859-1)"
+msgstr "Europeanu di u punente (ISO-8859-1)"
+
+#: ../src/common/fmapbase.cpp:145
+msgid "Central European (ISO-8859-2)"
+msgstr "Europeanu di u centru (ISO-8859-2)"
+
+#: ../src/common/fmapbase.cpp:146
+msgid "Esperanto (ISO-8859-3)"
+msgstr "Esperanto (ISO-8859-3)"
+
+#: ../src/common/fmapbase.cpp:147
+msgid "Baltic (old) (ISO-8859-4)"
+msgstr "Balticu (vechju) (ISO-8859-4)"
+
+#: ../src/common/fmapbase.cpp:148
+msgid "Cyrillic (ISO-8859-5)"
+msgstr "Cirillicu (ISO-8859-5)"
+
+#: ../src/common/fmapbase.cpp:149
+msgid "Arabic (ISO-8859-6)"
+msgstr "Arabu (ISO-8859-6)"
+
+#: ../src/common/fmapbase.cpp:150
+msgid "Greek (ISO-8859-7)"
+msgstr "Grecu (ISO-8859-7)"
+
+#: ../src/common/fmapbase.cpp:151
+msgid "Hebrew (ISO-8859-8)"
+msgstr "Ebreu (ISO-8859-8)"
+
+#: ../src/common/fmapbase.cpp:152
+msgid "Turkish (ISO-8859-9)"
+msgstr "Turcu (ISO-8859-9)"
+
+#: ../src/common/fmapbase.cpp:153
+msgid "Nordic (ISO-8859-10)"
+msgstr "Nordicu (ISO-8859-10)"
+
+#: ../src/common/fmapbase.cpp:154
+msgid "Thai (ISO-8859-11)"
+msgstr "Tailandese (ISO-8859-11)"
+
+#: ../src/common/fmapbase.cpp:155
+msgid "Indian (ISO-8859-12)"
+msgstr "Indianu (ISO-8859-12)"
+
+#: ../src/common/fmapbase.cpp:156
+msgid "Baltic (ISO-8859-13)"
+msgstr "Balticu (ISO-8859-13)"
+
+#: ../src/common/fmapbase.cpp:157
+msgid "Celtic (ISO-8859-14)"
+msgstr "Celtu (ISO-8859-14)"
+
+#: ../src/common/fmapbase.cpp:158
+msgid "Western European with Euro (ISO-8859-15)"
+msgstr "Europeanu di u punente cù l’Euro (ISO-8859-15)"
+
+#: ../src/common/fmapbase.cpp:159
+msgid "KOI8-R"
+msgstr "KOI8-R"
+
+#: ../src/common/fmapbase.cpp:160
+msgid "KOI8-U"
+msgstr "KOI8-U"
+
+#: ../src/common/fmapbase.cpp:161
+msgid "Windows/DOS OEM Cyrillic (CP 866)"
+msgstr "Cirillicu Windows/DOS OEM (CP 866)"
+
+#: ../src/common/fmapbase.cpp:162
+msgid "Windows Thai (CP 874)"
+msgstr "Tailandese Windows (CP 874)"
+
+#: ../src/common/fmapbase.cpp:163
+msgid "Windows Japanese (CP 932) or Shift-JIS"
+msgstr "Giappunese Windows (CP 932) o Maiusc-JIS"
+
+#: ../src/common/fmapbase.cpp:164
+msgid "Windows Chinese Simplified (CP 936) or GB-2312"
+msgstr "Chinese simplificatu Windows (CP 936) o GB-2312"
+
+#: ../src/common/fmapbase.cpp:165
+msgid "Windows Korean (CP 949)"
+msgstr "Cureanu Windows (CP 949)"
+
+#: ../src/common/fmapbase.cpp:166
+msgid "Windows Chinese Traditional (CP 950) or Big-5"
+msgstr "Chinese tradiziunale Windows (CP 950) o Big-5"
+
+#: ../src/common/fmapbase.cpp:167
+msgid "Windows Central European (CP 1250)"
+msgstr "Europeanu di u centru Windows (CP 1250)"
+
+#: ../src/common/fmapbase.cpp:168
+msgid "Windows Cyrillic (CP 1251)"
+msgstr "Cirillicu Windows (CP 1251)"
+
+#: ../src/common/fmapbase.cpp:169
+msgid "Windows Western European (CP 1252)"
+msgstr "Europeanu di u punente Windows (CP 1252)"
+
+#: ../src/common/fmapbase.cpp:170
+msgid "Windows Greek (CP 1253)"
+msgstr "Grecu Windows (CP 1253)"
+
+#: ../src/common/fmapbase.cpp:171
+msgid "Windows Turkish (CP 1254)"
+msgstr "Turcu Windows (CP 1254)"
+
+#: ../src/common/fmapbase.cpp:172
+msgid "Windows Hebrew (CP 1255)"
+msgstr "Ebreu Windows (CP 1255)"
+
+#: ../src/common/fmapbase.cpp:173
+msgid "Windows Arabic (CP 1256)"
+msgstr "Arabu Windows (CP 1256)"
+
+#: ../src/common/fmapbase.cpp:174
+msgid "Windows Baltic (CP 1257)"
+msgstr "Balticu Windows (CP 1257)"
+
+#: ../src/common/fmapbase.cpp:175
+msgid "Windows Vietnamese (CP 1258)"
+msgstr "Vietnamianu Windows (CP 1258)"
+
+#: ../src/common/fmapbase.cpp:176
+msgid "Windows Johab (CP 1361)"
+msgstr "Johab Windows (CP 1361)"
+
+#: ../src/common/fmapbase.cpp:177
+msgid "Windows/DOS OEM (CP 437)"
+msgstr "Windows/DOS OEM (CP 437)"
+
+#: ../src/common/fmapbase.cpp:178
+msgid "Unicode 7 bit (UTF-7)"
+msgstr "Unicode 7 bit (UTF-7)"
+
+#: ../src/common/fmapbase.cpp:179
+msgid "Unicode 8 bit (UTF-8)"
+msgstr "Unicode 8 bit (UTF-8)"
+
+#: ../src/common/fmapbase.cpp:181 ../src/common/fmapbase.cpp:187
+msgid "Unicode 16 bit (UTF-16)"
+msgstr "Unicode 16 bit (UTF-16)"
+
+#: ../src/common/fmapbase.cpp:182
+msgid "Unicode 16 bit Little Endian (UTF-16LE)"
+msgstr "Unicode 16 bit Little Endian (UTF-16LE)"
+
+#: ../src/common/fmapbase.cpp:183 ../src/common/fmapbase.cpp:189
+msgid "Unicode 32 bit (UTF-32)"
+msgstr "Unicode 32 bit (UTF-32)"
+
+#: ../src/common/fmapbase.cpp:184
+msgid "Unicode 32 bit Little Endian (UTF-32LE)"
+msgstr "Unicode 32 bit Little Endian (UTF-32LE)"
+
+#: ../src/common/fmapbase.cpp:186
+msgid "Unicode 16 bit Big Endian (UTF-16BE)"
+msgstr "Unicode 16 bit Big Endian (UTF-16BE)"
+
+#: ../src/common/fmapbase.cpp:188
+msgid "Unicode 32 bit Big Endian (UTF-32BE)"
+msgstr "Unicode 32 bit Big Endian (UTF-32BE)"
+
+#: ../src/common/fmapbase.cpp:191
+msgid "Extended Unix Codepage for Japanese (EUC-JP)"
+msgstr "Pagina di codice Unix estesu per u giappunese (EUC-JP)"
+
+#: ../src/common/fmapbase.cpp:192
+msgid "US-ASCII"
+msgstr "US-ASCII"
+
+#: ../src/common/fmapbase.cpp:193
+msgid "ISO-2022-JP"
+msgstr "ISO-2022-JP"
+
+#: ../src/common/fmapbase.cpp:195
+msgid "MacRoman"
+msgstr "Mac Rumanu"
+
+#: ../src/common/fmapbase.cpp:196
+msgid "MacJapanese"
+msgstr "Mac Giappunese"
+
+#: ../src/common/fmapbase.cpp:197
+msgid "MacChineseTrad"
+msgstr "Mac Chinese tradiziunale"
+
+#: ../src/common/fmapbase.cpp:198
+msgid "MacKorean"
+msgstr "Mac Cureanu"
+
+#: ../src/common/fmapbase.cpp:199
+msgid "MacArabic"
+msgstr "Mac Arabu"
+
+#: ../src/common/fmapbase.cpp:200
+msgid "MacHebrew"
+msgstr "Mac Ebreu"
+
+#: ../src/common/fmapbase.cpp:201
+msgid "MacGreek"
+msgstr "Mac Grecu"
+
+#: ../src/common/fmapbase.cpp:202
+msgid "MacCyrillic"
+msgstr "Mac Cirillicu"
+
+#: ../src/common/fmapbase.cpp:203
+msgid "MacDevanagari"
+msgstr "Mac Devanagari"
+
+#: ../src/common/fmapbase.cpp:204
+msgid "MacGurmukhi"
+msgstr "Mac Gurmukhi"
+
+#: ../src/common/fmapbase.cpp:205
+msgid "MacGujarati"
+msgstr "Mac Gujarati"
+
+#: ../src/common/fmapbase.cpp:206
+msgid "MacOriya"
+msgstr "MacOriya"
+
+#: ../src/common/fmapbase.cpp:207
+msgid "MacBengali"
+msgstr "Mac Bengalese"
+
+#: ../src/common/fmapbase.cpp:208
+msgid "MacTamil"
+msgstr "Mac Tamil"
+
+#: ../src/common/fmapbase.cpp:209
+msgid "MacTelugu"
+msgstr "Mac Telugu"
+
+#: ../src/common/fmapbase.cpp:210
+msgid "MacKannada"
+msgstr "Mac Canarese"
+
+#: ../src/common/fmapbase.cpp:211
+msgid "MacMalayalam"
+msgstr "Mac Malayalam"
+
+#: ../src/common/fmapbase.cpp:212
+msgid "MacSinhalese"
+msgstr "Mac Singalese"
+
+#: ../src/common/fmapbase.cpp:213
+msgid "MacBurmese"
+msgstr "Mac Birmanu"
+
+#: ../src/common/fmapbase.cpp:214
+msgid "MacKhmer"
+msgstr "Mac Khmer"
+
+#: ../src/common/fmapbase.cpp:215
+msgid "MacThai"
+msgstr "Mac Tailandese"
+
+#: ../src/common/fmapbase.cpp:216
+msgid "MacLaotian"
+msgstr "Mac Lauzianu"
+
+#: ../src/common/fmapbase.cpp:217
+msgid "MacGeorgian"
+msgstr "Mac Geurgianu"
+
+#: ../src/common/fmapbase.cpp:218
+msgid "MacArmenian"
+msgstr "Mac Armenianu"
+
+#: ../src/common/fmapbase.cpp:219
+msgid "MacChineseSimp"
+msgstr "Mac Chinese simplice"
+
+#: ../src/common/fmapbase.cpp:220
+msgid "MacTibetan"
+msgstr "Mac Tibetanu"
+
+#: ../src/common/fmapbase.cpp:221
+msgid "MacMongolian"
+msgstr "Mac Mongulu"
+
+#: ../src/common/fmapbase.cpp:222
+msgid "MacEthiopic"
+msgstr "Mac Etiupianu"
+
+#: ../src/common/fmapbase.cpp:223
+msgid "MacCentralEurRoman"
+msgstr "MacCentralEurRoman"
+
+#: ../src/common/fmapbase.cpp:224
+msgid "MacVietnamese"
+msgstr "Mac Vietnamianu"
+
+#: ../src/common/fmapbase.cpp:225
+msgid "MacExtArabic"
+msgstr "MacExtArabic"
+
+#: ../src/common/fmapbase.cpp:226
+msgid "MacSymbol"
+msgstr "Mac Simbulu"
+
+#: ../src/common/fmapbase.cpp:227
+msgid "MacDingbats"
+msgstr "Mac Dingbats"
+
+#: ../src/common/fmapbase.cpp:228
+msgid "MacTurkish"
+msgstr "Mac Turcu"
+
+#: ../src/common/fmapbase.cpp:229
+msgid "MacCroatian"
+msgstr "Mac Cruatu"
+
+#: ../src/common/fmapbase.cpp:230
+msgid "MacIcelandic"
+msgstr "Mac Islandese"
+
+#: ../src/common/fmapbase.cpp:231
+msgid "MacRomanian"
+msgstr "Mac Rumenu"
+
+#: ../src/common/fmapbase.cpp:232
+msgid "MacCeltic"
+msgstr "Mac Celtu"
+
+#: ../src/common/fmapbase.cpp:233
+msgid "MacGaelic"
+msgstr "Mac Gaelicu"
+
+#: ../src/common/fmapbase.cpp:234
+msgid "MacKeyboardGlyphs"
+msgstr "MacKeyboardGlyphs"
+
+#: ../src/common/fmapbase.cpp:791
+msgid "Default encoding"
+msgstr "Cudificazione predefinita"
+
+#: ../src/common/fmapbase.cpp:805
+#, c-format
+msgid "Unknown encoding (%d)"
+msgstr "Cudificazione scunnisciuta (%d)"
+
+#: ../src/common/fmapbase.cpp:815 ../src/richtext/richtextstyles.cpp:776
+msgid "default"
+msgstr "predefinitu"
+
+#: ../src/common/fmapbase.cpp:829
+#, c-format
+msgid "unknown-%d"
+msgstr "%d scunnisciutu"
+
+#: ../src/common/fontcmn.cpp:924 ../src/common/fontcmn.cpp:1130
+msgid "underlined"
+msgstr "sottulineata"
+
+#: ../src/common/fontcmn.cpp:929
+msgid " strikethrough"
+msgstr " rigata"
+
+#: ../src/common/fontcmn.cpp:942
+msgid " thin"
+msgstr " sdriglia"
+
+#: ../src/common/fontcmn.cpp:946
+msgid " extra light"
+msgstr " assai chjara"
+
+#: ../src/common/fontcmn.cpp:950
+msgid " light"
+msgstr " chjara"
+
+#: ../src/common/fontcmn.cpp:954
+msgid " medium"
+msgstr " mediana"
+
+#: ../src/common/fontcmn.cpp:958
+msgid " semi bold"
+msgstr " semi grassa"
+
+#: ../src/common/fontcmn.cpp:962
+msgid " bold"
+msgstr " grassa"
+
+#: ../src/common/fontcmn.cpp:966
+msgid " extra bold"
+msgstr " assai grassa"
+
+#: ../src/common/fontcmn.cpp:970
+msgid " heavy"
+msgstr " forta"
+
+#: ../src/common/fontcmn.cpp:974
+msgid " extra heavy"
+msgstr " assai forta"
+
+#: ../src/common/fontcmn.cpp:990
+msgid " italic"
+msgstr " cursiva"
+
+#: ../src/common/fontcmn.cpp:1134
+msgid "strikethrough"
+msgstr "rigata"
+
+#: ../src/common/fontcmn.cpp:1143
+msgid "thin"
+msgstr "sdriglia"
+
+#: ../src/common/fontcmn.cpp:1156
+msgid "extralight"
+msgstr "assai chjara"
+
+#: ../src/common/fontcmn.cpp:1161
+msgid "light"
+msgstr "chjara"
+
+#: ../src/common/fontcmn.cpp:1169 ../src/richtext/richtextstyles.cpp:775
+msgid "normal"
+msgstr "nurmale"
+
+#: ../src/common/fontcmn.cpp:1174
+msgid "medium"
+msgstr "mediana"
+
+#: ../src/common/fontcmn.cpp:1179 ../src/common/fontcmn.cpp:1199
+msgid "semibold"
+msgstr "semigrassa"
+
+#: ../src/common/fontcmn.cpp:1184
+msgid "bold"
+msgstr "grassa"
+
+#: ../src/common/fontcmn.cpp:1194
+msgid "extrabold"
+msgstr "assai grassa"
+
+#: ../src/common/fontcmn.cpp:1204
+msgid "heavy"
+msgstr "forta"
+
+#: ../src/common/fontcmn.cpp:1212
+msgid "extraheavy"
+msgstr "assai forta"
+
+#: ../src/common/fontcmn.cpp:1217
+msgid "italic"
+msgstr "cursiva"
+
+#: ../src/common/fontmap.cpp:195
+msgid ": unknown charset"
+msgstr ": gruppu di caratteri scunnisciutu"
+
+#: ../src/common/fontmap.cpp:199
+#, c-format
+msgid ""
+"The charset '%s' is unknown. You may select\n"
+"another charset to replace it with or choose\n"
+"[Cancel] if it cannot be replaced"
+msgstr ""
+"U gruppu di caratteri « %s » hè scunnisciutu. Pudete selezziunà un altru "
+"gruppu di caratteri\n"
+"per rimpiazzallu o sceglie [Abbandunà]\n"
+"s’ellu ùn pò micca esse rimpiazzatu"
+
+#: ../src/common/fontmap.cpp:241
+#, c-format
+msgid "Failed to remember the encoding for the charset '%s'."
+msgstr ""
+"Fiascu per arricurdassi di a cudificazione per u gruppu di caratteri « %s »."
+
+#: ../src/common/fontmap.cpp:321
+msgid "can't load any font, aborting"
+msgstr "impussibule di caricà una grafia, abbandonu"
+
+#: ../src/common/fontmap.cpp:409
+msgid ": unknown encoding"
+msgstr ": cudificazione scunnisciuta"
+
+#: ../src/common/fontmap.cpp:417
+#, c-format
+msgid ""
+"No font for displaying text in encoding '%s' found,\n"
+"but an alternative encoding '%s' is available.\n"
+"Do you want to use this encoding (otherwise you will have to choose another "
+"one)?"
+msgstr ""
+"Ùn si trova alcuna grafia per affissà u testu in a cudificazione « %s »,\n"
+"ma una cudificazione alternativa « %s » hè dispunibule.\n"
+"Vulete impiegà sta cudificazione (osinnò ci vulerà à scegliene un’altra) ?"
+
+#: ../src/common/fontmap.cpp:422
+#, c-format
+msgid ""
+"No font for displaying text in encoding '%s' found.\n"
+"Would you like to select a font to be used for this encoding\n"
+"(otherwise the text in this encoding will not be shown correctly)?"
+msgstr ""
+"Ùn si trova alcuna grafia per affissà u testu in a cudificazione « %s ».\n"
+"Vulete selezziunà una grafia à impiegà per sta cudificazione (osinnò u testu "
+"in sta cudificazione ùn serà micca affissatu currettamente) ?"
+
+#: ../src/common/fs_mem.cpp:169
+#, c-format
+msgid "Memory VFS already contains file '%s'!"
+msgstr "A memoria VFS cuntene dighjà u schedariu « %s » !"
+
+#: ../src/common/fs_mem.cpp:232
+#, c-format
+msgid "Trying to remove file '%s' from memory VFS, but it is not loaded!"
+msgstr ""
+"Tentativu di cacciatura di u schedariu « %s » da a memoria VFS, ma ùn hè "
+"micca caricatu !"
+
+#: ../src/common/fs_mem.cpp:262
+#, c-format
+msgid "Failed to store image '%s' to memory VFS!"
+msgstr "Fiascu per piazzà a fiura « %s » in a memoria VFS !"
+
+#: ../src/common/ftp.cpp:197
+msgid "Timeout while waiting for FTP server to connect, try passive mode."
+msgstr ""
+"Cumportu d’attesa ecciditu durante a cunnessione di u servitore FTP, prova "
+"in modu passivu."
+
+#: ../src/common/ftp.cpp:399
+#, c-format
+msgid "Failed to set FTP transfer mode to %s."
+msgstr "Fiascu per definisce u modu di trasferimentu FTP à %s."
+
+#: ../src/common/ftp.cpp:400 ../src/richtext/richtextsymboldlg.cpp:432
+msgid "ASCII"
+msgstr "ASCII"
+
+#: ../src/common/ftp.cpp:400
+msgid "binary"
+msgstr "binariu"
+
+#: ../src/common/ftp.cpp:608
+msgid "The FTP server doesn't support the PORT command."
+msgstr "U servitore FTP ùn accetta micca a cumanda PORT."
+
+#: ../src/common/ftp.cpp:622
+msgid "The FTP server doesn't support passive mode."
+msgstr "U servitore FTP ùn accetta micca u modu passivu."
+
+#: ../src/common/gifdecod.cpp:822
+#, c-format
+msgid "Incorrect GIF frame size (%u, %d) for the frame #%u"
+msgstr "Dimensione di fiura GIF incurretta (%u, %d) per a fiura #%u"
+
+#: ../src/common/glcmn.cpp:108
+msgid "Failed to allocate colour for OpenGL"
+msgstr "Fiascu per attribuisce u culore per OpenGL"
+
+#: ../src/common/headerctrlcmn.cpp:57
+msgid "Please select the columns to show and define their order:"
+msgstr "Selezziunate e culonne à affissà è definite e so ordine :"
+
+#: ../src/common/headerctrlcmn.cpp:58
+msgid "Customize Columns"
+msgstr "Persunalizà e culonne"
+
+#: ../src/common/headerctrlcmn.cpp:304
+msgid "&Customize..."
+msgstr "&Persunalizà…"
+
+#: ../src/common/hyperlnkcmn.cpp:132
+#, c-format
+msgid "Failed to open URL \"%s\" in the default browser"
+msgstr "Fiascu per apre l’indirizzu web « %s » in u navigatore predefinitu"
+
+#: ../src/common/iconbndl.cpp:195
+#, c-format
+msgid "Failed to load image %%d from file '%s'."
+msgstr "Fiascu per caricà a fiura %%d per u schedariu « %s »."
+
+#: ../src/common/iconbndl.cpp:203
+#, c-format
+msgid "Failed to load image %d from stream."
+msgstr "Fiascu per caricà a fiura %d da u flussu."
+
+#: ../src/common/iconbndl.cpp:221
+#, c-format
+msgid "Failed to load icons from resource '%s'."
+msgstr "Fiascu per caricà l’icone da a risorsa « %s »."
+
+#: ../src/common/imagbmp.cpp:97
+msgid "BMP: Couldn't save invalid image."
+msgstr "BMP : Ùn si pò micca arregistrà una fiura inaccettevule."
+
+#: ../src/common/imagbmp.cpp:137
+msgid "BMP: wxImage doesn't have own wxPalette."
+msgstr "BMP : wxImage ùn hà micca a so propia wxPalette."
+
+#: ../src/common/imagbmp.cpp:243
+msgid "BMP: Couldn't write the file (Bitmap) header."
+msgstr "BMP : Ùn si pò micca scrive l’intestatura di u schedariu (Bitmap)."
+
+#: ../src/common/imagbmp.cpp:266
+msgid "BMP: Couldn't write the file (BitmapInfo) header."
+msgstr "BMP : Ùn si pò micca scrive l’intestatura di u schedariu (BitmapInfo)."
+
+#: ../src/common/imagbmp.cpp:353
+msgid "BMP: Couldn't write RGB color map."
+msgstr "BMP : Ùn si pò micca scrive a cartugrafia di i culori RGB."
+
+#: ../src/common/imagbmp.cpp:487
+msgid "BMP: Couldn't write data."
+msgstr "BMP : Ùn si pò micca scrive i dati."
+
+#: ../src/common/imagbmp.cpp:561 ../src/common/imagbmp.cpp:642
+msgid "BMP: Couldn't allocate memory."
+msgstr "BMP : Ùn si pò micca riservà memoria."
+
+#: ../src/common/imagbmp.cpp:1041
+msgid "DIB Header: Image width > 32767 pixels for file."
+msgstr ""
+"Intestatura DIB : Larghezza di a fiura > 32767 pizzeli per u schedariu."
+
+#: ../src/common/imagbmp.cpp:1049
+msgid "DIB Header: Image height > 32767 pixels for file."
+msgstr "Intestatura DIB : Altezza di a fiura > 32767 pizzeli per u schedariu."
+
+#: ../src/common/imagbmp.cpp:1081
+msgid "DIB Header: Unknown bitdepth in file."
+msgstr ""
+"Intestatura DIB : Numeru di bit à u pizzelu scunnisciutu in u schedariu."
+
+#: ../src/common/imagbmp.cpp:1156
+msgid "DIB Header: Unknown encoding in file."
+msgstr "Intestatura DIB : Cudificazione scunnisciuta in u schedariu."
+
+#: ../src/common/imagbmp.cpp:1165
+msgid "DIB Header: Encoding doesn't match bitdepth."
+msgstr ""
+"Intestatura DIB : A cudificazione ùn currisponde micca à u numeru di bit à u "
+"pizzelu."
+
+#: ../src/common/imagbmp.cpp:1180
+#, c-format
+msgid "BMP Header: Invalid number of colors (%d)."
+msgstr "Intestatura BMP : Numeru inaccettevule di culori (%d)."
+
+#: ../src/common/imagbmp.cpp:1273
+msgid "Error in reading image DIB."
+msgstr "Sbagliu à a lettura di a fiura DIB."
+
+#: ../src/common/imagbmp.cpp:1294
+msgid "ICO: Error in reading mask DIB."
+msgstr "ICO : Sbagliu à a lettura di a maschera DIB."
+
+#: ../src/common/imagbmp.cpp:1353
+msgid "ICO: Image too tall for an icon."
+msgstr "ICO : A fiura hè troppu alta per un icona."
+
+#: ../src/common/imagbmp.cpp:1361
+msgid "ICO: Image too wide for an icon."
+msgstr "ICO : A fiura hè troppu larga per un icona."
+
+#: ../src/common/imagbmp.cpp:1388 ../src/common/imagbmp.cpp:1488
+#: ../src/common/imagbmp.cpp:1503 ../src/common/imagbmp.cpp:1514
+#: ../src/common/imagbmp.cpp:1528 ../src/common/imagbmp.cpp:1576
+#: ../src/common/imagbmp.cpp:1591 ../src/common/imagbmp.cpp:1605
+#: ../src/common/imagbmp.cpp:1616
+msgid "ICO: Error writing the image file!"
+msgstr "ICO : Sbagliu à a scrittura di u schedariu di fiura !"
+
+#: ../src/common/imagbmp.cpp:1701
+msgid "ICO: Invalid icon index."
+msgstr "ICO : Indice d’icona inaccettevule."
+
+#: ../src/common/image.cpp:2410
+msgid "Image and mask have different sizes."
+msgstr "A fiura è a maschera anu dimensioni sfarente."
+
+#: ../src/common/image.cpp:2418 ../src/common/image.cpp:2459
+msgid "No unused colour in image being masked."
+msgstr "Alcunu culore inimpiegatu in a fiura in corsu di mascarassi."
+
+#: ../src/common/image.cpp:2641
+#, c-format
+msgid "Failed to load bitmap \"%s\" from resources."
+msgstr "Fiascu per caricà a fiura bitmap « %s » da e risorse."
+
+#: ../src/common/image.cpp:2650
+#, c-format
+msgid "Failed to load icon \"%s\" from resources."
+msgstr "Fiascu per caricà l’icona « %s » da e risorse."
+
+#: ../src/common/image.cpp:2728 ../src/common/image.cpp:2747
+#, c-format
+msgid "Failed to load image from file \"%s\"."
+msgstr "Fiascu per caricà a fiura da u schedariu « %s »."
+
+#: ../src/common/image.cpp:2761
+#, c-format
+msgid "Can't save image to file '%s': unknown extension."
+msgstr ""
+"Ùn si pò micca arregistrà a fiura nant’à u schedariu « %s » : estensione "
+"scunnisciuta."
+
+#: ../src/common/image.cpp:2869
+msgid "No handler found for image type."
+msgstr "Nisunu ghjestiunariu trovu per u tipu di fiura."
+
+#: ../src/common/image.cpp:2877 ../src/common/image.cpp:3000
+#: ../src/common/image.cpp:3066
+#, c-format
+msgid "No image handler for type %d defined."
+msgstr "Nisunu ghjestiunariu di fiura definitu per u tipu %d."
+
+#: ../src/common/image.cpp:2887
+#, c-format
+msgid "Image file is not of type %d."
+msgstr "U schedariu di fiura ùn hè micca di tipu %d."
+
+#: ../src/common/image.cpp:2970
+msgid "Can't automatically determine the image format for non-seekable input."
+msgstr ""
+"Ùn si pò micca determinà autumaticamente u furmatu di a fiura per l’entrata "
+"non pusiziunevule."
+
+#: ../src/common/image.cpp:2988
+msgid "Unknown image data format."
+msgstr "Furmatu scunnisciutu di dati di fiura."
+
+#: ../src/common/image.cpp:3009
+#, c-format
+msgid "This is not a %s."
+msgstr "Què ùn hè micca un %s."
+
+#: ../src/common/image.cpp:3032 ../src/common/image.cpp:3080
+#, c-format
+msgid "No image handler for type %s defined."
+msgstr "Nisunu ghjestiunariu di fiura definitu per u tipu %s."
+
+#: ../src/common/image.cpp:3041
+#, c-format
+msgid "Image is not of type %s."
+msgstr "A fiura ùn hè micca di tipu %s."
+
+#: ../src/common/image.cpp:3509
+#, c-format
+msgid "Failed to check format of image file \"%s\"."
+msgstr "Fiascu per cuntrollà u furmatu di u schedariu di fiura « %s »."
+
+#: ../src/common/imaggif.cpp:124
+msgid "GIF: error in GIF image format."
+msgstr "GIF : sbagliu in u furmatu di fiura GIF."
+
+#: ../src/common/imaggif.cpp:129
+msgid "GIF: not enough memory."
+msgstr "GIF : micca abbastanza memoria."
+
+#: ../src/common/imaggif.cpp:134
+msgid "GIF: data stream seems to be truncated."
+msgstr "GIF : u flussu di dati pare esse truncatu."
+
+#: ../src/common/imaggif.cpp:240
+msgid "Couldn't initialize GIF hash table."
+msgstr "Impussibule d’inizià a tavula di tazzeghju GIF."
+
+#: ../src/common/imagiff.cpp:739
+msgid "IFF: error in IFF image format."
+msgstr "IFF : sbagliu in u furmatu di fiura IFF."
+
+#: ../src/common/imagiff.cpp:742
+msgid "IFF: not enough memory."
+msgstr "IFF : micca abbastanza memoria."
+
+#: ../src/common/imagiff.cpp:745
+msgid "IFF: unknown error!!!"
+msgstr "IFF : sbagliu scunnisciutu !"
+
+#: ../src/common/imagiff.cpp:755
+msgid "IFF: data stream seems to be truncated."
+msgstr "IFF : u flussu di dati pare esse truncatu."
+
+#: ../src/common/imagjpeg.cpp:258
+msgid "JPEG: Couldn't load - file is probably corrupted."
+msgstr "JPEG : Ùn si pò micca caricà ; forse u schedariu hè deteriuratu."
+
+#: ../src/common/imagjpeg.cpp:437
+msgid "JPEG: Couldn't save image."
+msgstr "JPEG : Ùn si pò micca arregistrà a fiura."
+
+#: ../src/common/imagpcx.cpp:439
+msgid "PCX: this is not a PCX file."
+msgstr "PCX : què ùn hè micca u schedariu PCX."
+
+#: ../src/common/imagpcx.cpp:453
+msgid "PCX: image format unsupported"
+msgstr "PCX : u furmatu di a fiura ùn hè micca accettatu"
+
+#: ../src/common/imagpcx.cpp:454 ../src/common/imagpcx.cpp:477
+msgid "PCX: couldn't allocate memory"
+msgstr "PCX : ùn si pò micca riservà memoria"
+
+#: ../src/common/imagpcx.cpp:455
+msgid "PCX: version number too low"
+msgstr "PCX : numeru di versione troppu bassu"
+
+#: ../src/common/imagpcx.cpp:456 ../src/common/imagpcx.cpp:478
+msgid "PCX: unknown error !!!"
+msgstr "PCX : sbagliu scunnisciutu !"
+
+#: ../src/common/imagpcx.cpp:476
+msgid "PCX: invalid image"
+msgstr "PCX : fiura inaccettevule"
+
+#: ../src/common/imagpng.cpp:385
+#, c-format
+msgid "Unknown PNG resolution unit %d"
+msgstr "Unità %d di risuluzione PNG scunnisciuta"
+
+#: ../src/common/imagpng.cpp:439
+msgid "Couldn't load a PNG image - file is corrupted or not enough memory."
+msgstr ""
+"Ùn si pò micca caricà a fiura PNG ; forse u schedariu hè deteriuratu o ùn ci "
+"hè abbastanza memoria."
+
+#: ../src/common/imagpng.cpp:513 ../src/common/imagpng.cpp:524
+#: ../src/common/imagpng.cpp:534
+msgid "Couldn't save PNG image."
+msgstr "Ùn si pò micca arregistrà a fiura PNG."
+
+#: ../src/common/imagpnm.cpp:71
+msgid "PNM: File format is not recognized."
+msgstr "PNM : u furmatu di schedariu ùn hè micca ricunnisciutu."
+
+#: ../src/common/imagpnm.cpp:89
+msgid "PNM: Couldn't allocate memory."
+msgstr "PNM : Ùn si pò micca riservà memoria."
+
+#: ../src/common/imagpnm.cpp:111 ../src/common/imagpnm.cpp:134
+#: ../src/common/imagpnm.cpp:156
+msgid "PNM: File seems truncated."
+msgstr "PNM : u schedariu pare truncatu."
+
+#: ../src/common/imagtiff.cpp:69
+#, c-format
+msgid " (in module \"%s\")"
+msgstr " (in u modulu « %s »)"
+
+#: ../src/common/imagtiff.cpp:304
+msgid "TIFF: Error loading image."
+msgstr "TIFF : Sbagliu à u caricamentu di a fiura."
+
+#: ../src/common/imagtiff.cpp:314
+msgid "Invalid TIFF image index."
+msgstr "Indice di fiura TIFF inaccettevule."
+
+#: ../src/common/imagtiff.cpp:358
+msgid "TIFF: Image size is abnormally big."
+msgstr "TIFF : A dimensione di a fiura hè sprupusitatamente maiò."
+
+#: ../src/common/imagtiff.cpp:372 ../src/common/imagtiff.cpp:385
+#: ../src/common/imagtiff.cpp:769
+msgid "TIFF: Couldn't allocate memory."
+msgstr "TIFF : Ùn si pò micca riservà memoria."
+
+#: ../src/common/imagtiff.cpp:471
+msgid "TIFF: Error reading image."
+msgstr "TIFF : Sbagliu à a lettura di a fiura."
+
+#: ../src/common/imagtiff.cpp:532
+#, c-format
+msgid "Unknown TIFF resolution unit %d ignored"
+msgstr "Unità %d di risuluzione TIFF scunnisciuta è ignurata"
+
+#: ../src/common/imagtiff.cpp:611
+msgid "TIFF: Error saving image."
+msgstr "TIFF : Sbagliu à l’arregistramentu di a fiura."
+
+#: ../src/common/imagtiff.cpp:868
+msgid "TIFF: Error writing image."
+msgstr "TIFF : Sbagliu à a scrittura di a fiura."
+
+#: ../src/common/imagtiff.cpp:881
+msgid "TIFF: Error flushing data."
+msgstr "TIFF : Sbagliu à a squassatura di i dati."
+
+#: ../src/common/imagwebp.cpp:56
+msgid "WebP: Invalid data (failed to get features)."
+msgstr "WebP : Dati inaccettevule (fiascu per ottene i funzioni)."
+
+#: ../src/common/imagwebp.cpp:65
+msgid "WebP: Allocating image memory failed."
+msgstr "WebP : Fiascu per attribuisce memoria à a fiura."
+
+#: ../src/common/imagwebp.cpp:82
+msgid "WebP: Decoding RGBA image data failed."
+msgstr "WebP : Fiascu per discudificà i dati di fiura RGBA."
+
+#: ../src/common/imagwebp.cpp:98
+msgid "WebP: Decoding RGB image data failed."
+msgstr "WebP : Fiascu per discudificà i dati di fiura RGB."
+
+#: ../src/common/imagwebp.cpp:113 ../src/common/imagwebp.cpp:201
+msgid "WebP: Allocating stream buffer failed."
+msgstr "WebP : Fiascu per attribuisce u stampone à u flussu."
+
+#: ../src/common/imagwebp.cpp:131
+msgid "WebP: Failed to parse container data."
+msgstr "WebP : Fiascu per analizà i dati di u cuntenidore."
+
+#: ../src/common/imagwebp.cpp:222
+msgid "WebP: Error decoding animation."
+msgstr "WebP : Sbagliu per discudificà l’animazione."
+
+#: ../src/common/imagwebp.cpp:240
+msgid "WebP: Error getting next animation frame."
+msgstr "WebP : Sbagliu per ottene a sequenza seguente d’animazione."
+
+#: ../src/common/init.cpp:172
+#, c-format
+msgid ""
+"Command line argument %d couldn't be converted to Unicode and will be "
+"ignored."
+msgstr ""
+"U parametru %d di a linea di cumanda ùn pò micca esse cunvertitu in Unicode "
+"è serà ignuratu."
+
+#: ../src/common/init.cpp:344
+msgid "Initialization failed in post init, aborting."
+msgstr "Fiascu di l’iniziu in « post init » ; abbandonu."
+
+#: ../src/common/intl.cpp:378
+#, c-format
+msgid "Cannot set locale to language \"%s\"."
+msgstr "Ùn si pò micca definisce « %s » cum’è lingua lucale."
+
+#: ../src/common/log.cpp:232
+msgid "Error: "
+msgstr "Sbagliu : "
+
+#: ../src/common/log.cpp:236
+msgid "Warning: "
+msgstr "Avertimentu : "
+
+#: ../src/common/log.cpp:284
+msgid "The previous message repeated once."
+msgstr "U messaghju precedente hè statu ripititu una volta."
+
+#: ../src/common/log.cpp:291
+#, c-format
+msgid "The previous message repeated %u time."
+msgid_plural "The previous message repeated %u times."
+msgstr[0] "U messaghju precedente hè statu ripititu %u volta."
+msgstr[1] "U messaghju precedente hè statu ripititu %u volte."
+
+#: ../src/common/log.cpp:319
+#, c-format
+msgid "Last repeated message (\"%s\", %u time) wasn't output"
+msgid_plural "Last repeated message (\"%s\", %u times) wasn't output"
+msgstr[0] ""
+"L’ultimu messaghju ripititu (« %s », %u volta) ùn hè statu micca inviatu"
+msgstr[1] ""
+"L’ultimu messaghju ripititu (« %s », %u volte) ùn hè statu micca inviatu"
+
+#: ../src/common/log.cpp:435
+#, c-format
+msgid " (error %ld: %s)"
+msgstr " (sbagliu %ld : %s)"
+
+#: ../src/common/lzmastream.cpp:121
+msgid "Failed to allocate memory for LZMA decompression."
+msgstr "Fiascu per attribuisce memoria per a scumpressione LZMA."
+
+#: ../src/common/lzmastream.cpp:125
+#, c-format
+msgid "Failed to initialize LZMA decompression: unexpected error %u."
+msgstr "Fiascu à l’iniziu di a scumpressione LZMA : sbagliu imprevistu %u."
+
+#: ../src/common/lzmastream.cpp:179
+msgid "input is not in XZ format"
+msgstr "l’entrata ùn hè micca in furmatu XZ"
+
+#: ../src/common/lzmastream.cpp:183
+msgid "input compressed using unknown XZ option"
+msgstr "l’entrata hè cumpressa cù l’ozzione scunnisciuta XZ"
+
+#: ../src/common/lzmastream.cpp:188
+msgid "input is corrupted"
+msgstr "l’entrata hè deteriurata"
+
+#: ../src/common/lzmastream.cpp:192
+msgid "unknown decompression error"
+msgstr "sbagliu scunnisciutu di scumpressione"
+
+#: ../src/common/lzmastream.cpp:196
+#, c-format
+msgid "LZMA decompression error: %s"
+msgstr "Sbagliu di scumpressione LZMA : %s"
+
+#: ../src/common/lzmastream.cpp:231
+msgid "Failed to allocate memory for LZMA compression."
+msgstr "Fiascu per attribuisce memoria per a cumpressione LZMA."
+
+#: ../src/common/lzmastream.cpp:235
+#, c-format
+msgid "Failed to initialize LZMA compression: unexpected error %u."
+msgstr "Fiascu à l’iniziu di a cumpressione LZMA : sbagliu imprevistu %u."
+
+#: ../src/common/lzmastream.cpp:267 ../src/common/lzmastream.cpp:342
+#: ../src/html/chm.cpp:336
+msgid "out of memory"
+msgstr "mancanza di memoria"
+
+#: ../src/common/lzmastream.cpp:276 ../src/common/lzmastream.cpp:346
+msgid "unknown compression error"
+msgstr "sbagliu scunnisciutu di cumpressione"
+
+#: ../src/common/lzmastream.cpp:280
+#, c-format
+msgid "LZMA compression error: %s"
+msgstr "Sbagliu di cumpressione LZMA : %s"
+
+#: ../src/common/lzmastream.cpp:350
+#, c-format
+msgid "LZMA compression error when flushing output: %s"
+msgstr "Sbagliu di cumpressione LZMA durante a squassatura di l’esciuta : %s"
+
+#: ../src/common/mimecmn.cpp:167
+#, c-format
+msgid "Unmatched '{' in an entry for mime type %s."
+msgstr "Simbulu « { » micca assurtitu in un elementu per u tipu mime %s."
+
+#: ../src/common/module.cpp:76
+#, c-format
+msgid "Circular dependency involving module \"%s\" detected."
+msgstr "Una dipendenza circulare hè stata avventata chì tocca u modulu « %s »."
+
+#: ../src/common/module.cpp:128
+#, c-format
+msgid "Dependency \"%s\" of module \"%s\" doesn't exist."
+msgstr "A dipendenza « %s » di u modulu « %s » ùn esiste micca."
+
+#: ../src/common/module.cpp:137
+#, c-format
+msgid "Module \"%s\" initialization failed"
+msgstr "Fiascu à l’iniziu di u modulu « %s »"
+
+#: ../src/common/msgout.cpp:96
+msgid "Message"
+msgstr "Messaghju"
+
+#: ../src/common/paper.cpp:70
+msgid "Letter, 8 1/2 x 11 in"
+msgstr "Lettera (8,5 x 11 pollici)"
+
+#: ../src/common/paper.cpp:71
+msgid "Legal, 8 1/2 x 14 in"
+msgstr "Ghjuridicu (8,5 x 14 pollici)"
+
+#: ../src/common/paper.cpp:72
+msgid "A4 sheet, 210 x 297 mm"
+msgstr "Fogliu A4 (210 x 297 mm)"
+
+#: ../src/common/paper.cpp:73
+msgid "C sheet, 17 x 22 in"
+msgstr "Fogliu C (17 x 22 pollici)"
+
+#: ../src/common/paper.cpp:74
+msgid "D sheet, 22 x 34 in"
+msgstr "Fogliu D (22 x 34 pollici)"
+
+#: ../src/common/paper.cpp:75
+msgid "E sheet, 34 x 44 in"
+msgstr "Fogliu E (34 x 44 pollici)"
+
+#: ../src/common/paper.cpp:76
+msgid "Letter Small, 8 1/2 x 11 in"
+msgstr "Lettera ridutta USA (8,5 x 11 pollici)"
+
+#: ../src/common/paper.cpp:77
+msgid "Tabloid, 11 x 17 in"
+msgstr "Tabloid USA (11 x 17 pollici)"
+
+#: ../src/common/paper.cpp:78
+msgid "Ledger, 17 x 11 in"
+msgstr "Gran libru USA (17 x 11 pollici)"
+
+#: ../src/common/paper.cpp:79
+msgid "Statement, 5 1/2 x 8 1/2 in"
+msgstr "Dichjarazione USA (5,5 x 8,5 pollici)"
+
+#: ../src/common/paper.cpp:80
+msgid "Executive, 7 1/4 x 10 1/2 in"
+msgstr "Esecutivu USA (7,25 x 10,5 pollici)"
+
+#: ../src/common/paper.cpp:81
+msgid "A3 sheet, 297 x 420 mm"
+msgstr "Fogliu A3 (297 x 420 mm)"
+
+#: ../src/common/paper.cpp:82
+msgid "A4 small sheet, 210 x 297 mm"
+msgstr "Chjucu fogliu A4 (210 x 297 mm)"
+
+#: ../src/common/paper.cpp:83
+msgid "A5 sheet, 148 x 210 mm"
+msgstr "Fogliu A5 (148 x 210 mm)"
+
+#: ../src/common/paper.cpp:84
+msgid "B4 sheet, 250 x 354 mm"
+msgstr "Fogliu B4 (250 x 354 mm)"
+
+#: ../src/common/paper.cpp:85
+msgid "B5 sheet, 182 x 257 millimeter"
+msgstr "Fogliu B5 (182 x 257 mm)"
+
+#: ../src/common/paper.cpp:86
+msgid "Folio, 8 1/2 x 13 in"
+msgstr "Folio (8,5 x 13 pollici)"
+
+#: ../src/common/paper.cpp:87
+msgid "Quarto, 215 x 275 mm"
+msgstr "Quarto (215 x 275 mm)"
+
+#: ../src/common/paper.cpp:88
+msgid "10 x 14 in"
+msgstr "10 x 14 pollici"
+
+#: ../src/common/paper.cpp:89
+msgid "11 x 17 in"
+msgstr "11 x 17 pollici"
+
+#: ../src/common/paper.cpp:90
+msgid "Note, 8 1/2 x 11 in"
+msgstr "Nota USA (8 1/2 x 11 pollici)"
+
+#: ../src/common/paper.cpp:91
+msgid "#9 Envelope, 3 7/8 x 8 7/8 in"
+msgstr "Inviluppu n° 9 USA (3,875 x 8,875 pollici)"
+
+#: ../src/common/paper.cpp:92
+msgid "#10 Envelope, 4 1/8 x 9 1/2 in"
+msgstr "Inviluppu n° 10 USA (4,125 x 9,5 pollici)"
+
+#: ../src/common/paper.cpp:93
+msgid "#11 Envelope, 4 1/2 x 10 3/8 in"
+msgstr "Inviluppu n° 11 USA (4,5 x 10,375 pollici)"
+
+#: ../src/common/paper.cpp:94
+msgid "#12 Envelope, 4 3/4 x 11 in"
+msgstr "Inviluppu n° 12 USA (4,75 x 11 pollici)"
+
+#: ../src/common/paper.cpp:95
+msgid "#14 Envelope, 5 x 11 1/2 in"
+msgstr "Inviluppu n° 14 USA (5 x 11,5 pollici)"
+
+#: ../src/common/paper.cpp:96
+msgid "DL Envelope, 110 x 220 mm"
+msgstr "Inviluppu DL (110 x 220 mm)"
+
+#: ../src/common/paper.cpp:97
+msgid "C5 Envelope, 162 x 229 mm"
+msgstr "Inviluppu C5 (162 x 229 mm)"
+
+#: ../src/common/paper.cpp:98
+msgid "C3 Envelope, 324 x 458 mm"
+msgstr "Inviluppu C3 (324 x 458 mm)"
+
+#: ../src/common/paper.cpp:99
+msgid "C4 Envelope, 229 x 324 mm"
+msgstr "Inviluppu C4 (229 x 324 mm)"
+
+#: ../src/common/paper.cpp:100
+msgid "C6 Envelope, 114 x 162 mm"
+msgstr "Inviluppu C6 (114 x 162 mm)"
+
+#: ../src/common/paper.cpp:101
+msgid "C65 Envelope, 114 x 229 mm"
+msgstr "Inviluppu C65 (114 x 229 mm)"
+
+#: ../src/common/paper.cpp:102
+msgid "B4 Envelope, 250 x 353 mm"
+msgstr "Inviluppu B4 (250 x 353 mm)"
+
+#: ../src/common/paper.cpp:103
+msgid "B5 Envelope, 176 x 250 mm"
+msgstr "Inviluppu B5 (176 x 250 mm)"
+
+#: ../src/common/paper.cpp:104
+msgid "B6 Envelope, 176 x 125 mm"
+msgstr "Inviluppu B6 (176 x 125 mm)"
+
+#: ../src/common/paper.cpp:105
+msgid "Italy Envelope, 110 x 230 mm"
+msgstr "Inviluppu talianu (110 x 230 mm)"
+
+#: ../src/common/paper.cpp:106
+msgid "Monarch Envelope, 3 7/8 x 7 1/2 in"
+msgstr "Inviluppu munarca USA (3,875 x 7,5 pollici)"
+
+#: ../src/common/paper.cpp:107
+msgid "6 3/4 Envelope, 3 5/8 x 6 1/2 in"
+msgstr "Inviluppu 6 3/4 (3,625 x 6,5 pollici)"
+
+#: ../src/common/paper.cpp:108
+msgid "US Std Fanfold, 14 7/8 x 11 in"
+msgstr "Classicu USA in organettu (14,875 x 11 pollici)"
+
+#: ../src/common/paper.cpp:109
+msgid "German Std Fanfold, 8 1/2 x 12 in"
+msgstr "Classicu tedescu in organettu (8,5 x 12 pollici)"
+
+#: ../src/common/paper.cpp:110
+msgid "German Legal Fanfold, 8 1/2 x 13 in"
+msgstr "Ghjuridicu tedescu in organettu (8,5 x 13 pollici)"
+
+#: ../src/common/paper.cpp:112
+msgid "B4 (ISO) 250 x 353 mm"
+msgstr "B4 (ISO) (250 x 353 mm)"
+
+#: ../src/common/paper.cpp:113
+msgid "Japanese Postcard 100 x 148 mm"
+msgstr "Carta pustale giappunese (100 x 148 mm)"
+
+#: ../src/common/paper.cpp:114
+msgid "9 x 11 in"
+msgstr "9 x 11 pollici"
+
+#: ../src/common/paper.cpp:115
+msgid "10 x 11 in"
+msgstr "10 x 11 pollici"
+
+#: ../src/common/paper.cpp:116
+msgid "15 x 11 in"
+msgstr "15 x 11 pollici"
+
+#: ../src/common/paper.cpp:117
+msgid "Envelope Invite 220 x 220 mm"
+msgstr "Inviluppu d’invitazione (220 x 220 mm)"
+
+#: ../src/common/paper.cpp:118
+msgid "Letter Extra 9 1/2 x 12 in"
+msgstr "Lettera USA estra (9,5 x 12 pollici)"
+
+#: ../src/common/paper.cpp:119
+msgid "Legal Extra 9 1/2 x 15 in"
+msgstr "Gjjuridicu USA estra (9,5 x 15 pollici)"
+
+#: ../src/common/paper.cpp:120
+msgid "Tabloid Extra 11.69 x 18 in"
+msgstr "Tabloid USA estra (11,69 x 18 pollici)"
+
+#: ../src/common/paper.cpp:121
+msgid "A4 Extra 9.27 x 12.69 in"
+msgstr "A4 estra (9,27 x 12,69 pollici)"
+
+#: ../src/common/paper.cpp:122
+msgid "Letter Transverse 8 1/2 x 11 in"
+msgstr "Lettera trasversale (8,5 x 11 pollici)"
+
+#: ../src/common/paper.cpp:123
+msgid "A4 Transverse 210 x 297 mm"
+msgstr "A4 trasversale (210 x 297 mm)"
+
+#: ../src/common/paper.cpp:124
+msgid "Letter Extra Transverse 9.275 x 12 in"
+msgstr "Lettera estra trasversale (9,275 x 12 pollici)"
+
+#: ../src/common/paper.cpp:125
+msgid "SuperA/SuperA/A4 227 x 356 mm"
+msgstr "SuperA / SuperA/A4 (227 x 356 mm)"
+
+#: ../src/common/paper.cpp:126
+msgid "SuperB/SuperB/A3 305 x 487 mm"
+msgstr "SuperB / SuperB/A3 (305 x 487 mm)"
+
+#: ../src/common/paper.cpp:127
+msgid "Letter Plus 8 1/2 x 12.69 in"
+msgstr "Lettera USA plus (8,5 x 12,69 pollici)"
+
+#: ../src/common/paper.cpp:128
+msgid "A4 Plus 210 x 330 mm"
+msgstr "A4 plus (210 x 330 mm)"
+
+#: ../src/common/paper.cpp:129
+msgid "A5 Transverse 148 x 210 mm"
+msgstr "A5 trasversale (148 x 210 mm)"
+
+#: ../src/common/paper.cpp:130
+msgid "B5 (JIS) Transverse 182 x 257 mm"
+msgstr "B5 (JIS) trasversale (182 x 257 mm)"
+
+#: ../src/common/paper.cpp:131
+msgid "A3 Extra 322 x 445 mm"
+msgstr "A3 estra (322 x 445 mm)"
+
+#: ../src/common/paper.cpp:132
+msgid "A5 Extra 174 x 235 mm"
+msgstr "A5 estra (174 x 235 mm)"
+
+#: ../src/common/paper.cpp:133
+msgid "B5 (ISO) Extra 201 x 276 mm"
+msgstr "B5 (ISO) extra (201 x 276 mm)"
+
+#: ../src/common/paper.cpp:134
+msgid "A2 420 x 594 mm"
+msgstr "Fogliu A2 (420 x 594 mm)"
+
+#: ../src/common/paper.cpp:135
+msgid "A3 Transverse 297 x 420 mm"
+msgstr "A3 trasversale (297 x 420 mm)"
+
+#: ../src/common/paper.cpp:136
+msgid "A3 Extra Transverse 322 x 445 mm"
+msgstr "A3 estra trasversale (322 x 445 mm)"
+
+#: ../src/common/paper.cpp:138
+msgid "Japanese Double Postcard 200 x 148 mm"
+msgstr "Carta pustale giappunese doppia (200 x 148 mm)"
+
+#: ../src/common/paper.cpp:139
+msgid "A6 105 x 148 mm"
+msgstr "Fogliu A6 (105 x 148 mm)"
+
+#: ../src/common/paper.cpp:140
+msgid "Japanese Envelope Kaku #2"
+msgstr "Inviluppu giappunese Kaku n°2"
+
+#: ../src/common/paper.cpp:141
+msgid "Japanese Envelope Kaku #3"
+msgstr "Inviluppu giappunese Kaku n°3"
+
+#: ../src/common/paper.cpp:142
+msgid "Japanese Envelope Chou #3"
+msgstr "Inviluppu giappunese Chou n°3"
+
+#: ../src/common/paper.cpp:143
+msgid "Japanese Envelope Chou #4"
+msgstr "Inviluppu giappunese Chou n°4"
+
+#: ../src/common/paper.cpp:144
+msgid "Letter Rotated 11 x 8 1/2 in"
+msgstr "Lettera paisagiu (11 x 8,5 pollici)"
+
+#: ../src/common/paper.cpp:145
+msgid "A3 Rotated 420 x 297 mm"
+msgstr "A3 paisagiu (420 x 297 mm)"
+
+#: ../src/common/paper.cpp:146
+msgid "A4 Rotated 297 x 210 mm"
+msgstr "A4 paisagiu (297 x 210 mm)"
+
+#: ../src/common/paper.cpp:147
+msgid "A5 Rotated 210 x 148 mm"
+msgstr "A5 paisagiu (210 x 148 mm)"
+
+#: ../src/common/paper.cpp:148
+msgid "B4 (JIS) Rotated 364 x 257 mm"
+msgstr "B4 (JIS) paisagiu (364 x 257 mm)"
+
+#: ../src/common/paper.cpp:149
+msgid "B5 (JIS) Rotated 257 x 182 mm"
+msgstr "B5 (JIS) paisagiu (257 x 182 mm)"
+
+#: ../src/common/paper.cpp:150
+msgid "Japanese Postcard Rotated 148 x 100 mm"
+msgstr "Carta pustale giappunese paisagiu (148 x 100 mm)"
+
+#: ../src/common/paper.cpp:151
+msgid "Double Japanese Postcard Rotated 148 x 200 mm"
+msgstr "Carta pustale giappunese paisagiu doppia (148 x 200 mm)"
+
+#: ../src/common/paper.cpp:152
+msgid "A6 Rotated 148 x 105 mm"
+msgstr "A6 paisagiu (148 x 105 mm)"
+
+#: ../src/common/paper.cpp:153
+msgid "Japanese Envelope Kaku #2 Rotated"
+msgstr "Inviluppu giappunese Kaku n°2 paisagiu"
+
+#: ../src/common/paper.cpp:154
+msgid "Japanese Envelope Kaku #3 Rotated"
+msgstr "Inviluppu giappunese Kaku n°3 paisagiu"
+
+#: ../src/common/paper.cpp:155
+msgid "Japanese Envelope Chou #3 Rotated"
+msgstr "Inviluppu giappunese Chou n°3 paisagiu"
+
+#: ../src/common/paper.cpp:156
+msgid "Japanese Envelope Chou #4 Rotated"
+msgstr "Inviluppu giappunese Chou n°4 paisagiu"
+
+#: ../src/common/paper.cpp:157
+msgid "B6 (JIS) 128 x 182 mm"
+msgstr "B6 (JIS) (128 x 182 mm)"
+
+#: ../src/common/paper.cpp:158
+msgid "B6 (JIS) Rotated 182 x 128 mm"
+msgstr "B6 (JIS) paisagiu (182 x 128 mm)"
+
+#: ../src/common/paper.cpp:159
+msgid "12 x 11 in"
+msgstr "12 x 11 pollici"
+
+#: ../src/common/paper.cpp:160
+msgid "Japanese Envelope You #4"
+msgstr "Inviluppu giappunese You n°4"
+
+#: ../src/common/paper.cpp:161
+msgid "Japanese Envelope You #4 Rotated"
+msgstr "Inviluppu giappunese You n°4 paisagiu"
+
+#: ../src/common/paper.cpp:162
+msgid "PRC 16K 146 x 215 mm"
+msgstr "PRC 16K (146 x 215 mm)"
+
+#: ../src/common/paper.cpp:163
+msgid "PRC 32K 97 x 151 mm"
+msgstr "PRC 32K (97 x 151 mm)"
+
+#: ../src/common/paper.cpp:164
+msgid "PRC 32K(Big) 97 x 151 mm"
+msgstr "PRC 32K (Big) (97 x 151 mm)"
+
+#: ../src/common/paper.cpp:165
+msgid "PRC Envelope #1 102 x 165 mm"
+msgstr "Inviluppu PRC n°1 (102 x 165 mm)"
+
+#: ../src/common/paper.cpp:166
+msgid "PRC Envelope #2 102 x 176 mm"
+msgstr "Inviluppu PRC n°2 (102 x 176 mm)"
+
+#: ../src/common/paper.cpp:167
+msgid "PRC Envelope #3 125 x 176 mm"
+msgstr "Inviluppu PRC n°3 (125 x 176 mm)"
+
+#: ../src/common/paper.cpp:168
+msgid "PRC Envelope #4 110 x 208 mm"
+msgstr "Inviluppu PRC n°4 (110 x 208 mm)"
+
+#: ../src/common/paper.cpp:169
+msgid "PRC Envelope #5 110 x 220 mm"
+msgstr "Inviluppu PRC n°5 (110 x 220 mm)"
+
+#: ../src/common/paper.cpp:170
+msgid "PRC Envelope #6 120 x 230 mm"
+msgstr "Inviluppu PRC n°6 (120 x 230 mm)"
+
+#: ../src/common/paper.cpp:171
+msgid "PRC Envelope #7 160 x 230 mm"
+msgstr "Inviluppu PRC n°7 (160 x 230 mm)"
+
+#: ../src/common/paper.cpp:172
+msgid "PRC Envelope #8 120 x 309 mm"
+msgstr "Inviluppu PRC n°8 (120 x 309 mm)"
+
+#: ../src/common/paper.cpp:173
+msgid "PRC Envelope #9 229 x 324 mm"
+msgstr "Inviluppu PRC n°9 (229 x 324 mm)"
+
+#: ../src/common/paper.cpp:174
+msgid "PRC Envelope #10 324 x 458 mm"
+msgstr "Inviluppu PRC n°10 (324 x 458 mm)"
+
+#: ../src/common/paper.cpp:175
+msgid "PRC 16K Rotated"
+msgstr "PRC 16K paisagiu"
+
+#: ../src/common/paper.cpp:176
+msgid "PRC 32K Rotated"
+msgstr "PRC 32K paisagiu"
+
+#: ../src/common/paper.cpp:177
+msgid "PRC 32K(Big) Rotated"
+msgstr "PRC 32K (Big) paisagiu"
+
+#: ../src/common/paper.cpp:178
+msgid "PRC Envelope #1 Rotated 165 x 102 mm"
+msgstr "Inviluppu PRC n°1 paisagiu (165 x 102 mm)"
+
+#: ../src/common/paper.cpp:179
+msgid "PRC Envelope #2 Rotated 176 x 102 mm"
+msgstr "Inviluppu PRC n°2 paisagiu (176 x 102 mm)"
+
+#: ../src/common/paper.cpp:180
+msgid "PRC Envelope #3 Rotated 176 x 125 mm"
+msgstr "Inviluppu PRC n°3 paisagiu (176 x 125 mm)"
+
+#: ../src/common/paper.cpp:181
+msgid "PRC Envelope #4 Rotated 208 x 110 mm"
+msgstr "Inviluppu PRC n°4 paisagiu (208 x 110 mm)"
+
+#: ../src/common/paper.cpp:182
+msgid "PRC Envelope #5 Rotated 220 x 110 mm"
+msgstr "Inviluppu PRC n°5 paisagiu (220 x 110 mm)"
+
+#: ../src/common/paper.cpp:183
+msgid "PRC Envelope #6 Rotated 230 x 120 mm"
+msgstr "Inviluppu PRC n°6 paisagiu (230 x 120 mm)"
+
+#: ../src/common/paper.cpp:184
+msgid "PRC Envelope #7 Rotated 230 x 160 mm"
+msgstr "Inviluppu PRC n°7 paisagiu (230 x 160 mm)"
+
+#: ../src/common/paper.cpp:185
+msgid "PRC Envelope #8 Rotated 309 x 120 mm"
+msgstr "Inviluppu PRC n°8 paisagiu (309 x 120 mm)"
+
+#: ../src/common/paper.cpp:186
+msgid "PRC Envelope #9 Rotated 324 x 229 mm"
+msgstr "Inviluppu PRC n°9 paisagiu (324 x 229 mm)"
+
+#: ../src/common/paper.cpp:187
+msgid "PRC Envelope #10 Rotated 458 x 324 mm"
+msgstr "Inviluppu PRC n°10 paisagiu (458 x 324 mm)"
+
+#: ../src/common/paper.cpp:192
+msgid "A0 sheet, 841 x 1189 mm"
+msgstr "Fogliu A0 (841 x 1189 mm)"
+
+#: ../src/common/paper.cpp:193
+msgid "A1 sheet, 594 x 841 mm"
+msgstr "Fogliu A1 (594 x 841 mm)"
+
+#: ../src/common/preferencescmn.cpp:37
+msgid "General"
+msgstr "Generale"
+
+#: ../src/common/preferencescmn.cpp:40
+msgid "Advanced"
+msgstr "Espertu"
+
+#: ../src/common/prntbase.cpp:245
+msgid "Generic PostScript"
+msgstr "PostScript genericu"
+
+#: ../src/common/prntbase.cpp:259
+msgid "Ready"
+msgstr "Prontu"
+
+#: ../src/common/prntbase.cpp:331
+msgid "Printing Error"
+msgstr "Sbagliu di stampa"
+
+#: ../src/common/prntbase.cpp:413 ../src/common/prntbase.cpp:1597
+#: ../src/generic/prntdlgg.cpp:135 ../src/generic/prntdlgg.cpp:149
+#: ../src/gtk/print.cpp:628 ../src/gtk/print.cpp:646
+msgid "Print"
+msgstr "Stampà"
+
+#: ../src/common/prntbase.cpp:471 ../src/generic/prntdlgg.cpp:809
+msgid "Page setup"
+msgstr "Definizione di a pagina"
+
+#: ../src/common/prntbase.cpp:525
+msgid "Please wait while printing..."
+msgstr "Stampa in corsu…"
+
+#: ../src/common/prntbase.cpp:529
+msgid "Document:"
+msgstr "Ducumentu :"
+
+#: ../src/common/prntbase.cpp:532
+msgid "Progress:"
+msgstr "Prugressione :"
+
+#: ../src/common/prntbase.cpp:533
+msgid "Preparing"
+msgstr "Preparazione"
+
+#: ../src/common/prntbase.cpp:552
+#, c-format
+msgid "Printing page %d"
+msgstr "Stampa di a pagina %d"
+
+#: ../src/common/prntbase.cpp:557
+#, c-format
+msgid "Printing page %d of %d"
+msgstr "Stampa di a pagina %d nant’à %d"
+
+#: ../src/common/prntbase.cpp:560
+#, c-format
+msgid " (copy %d of %d)"
+msgstr " (copia %d nant’à %d)"
+
+#: ../src/common/prntbase.cpp:1604
+msgid "First page"
+msgstr "Prima pagina"
+
+#: ../src/common/prntbase.cpp:1609 ../src/html/helpwnd.cpp:659
+msgid "Previous page"
+msgstr "Pagina precedente"
+
+#: ../src/common/prntbase.cpp:1623 ../src/html/helpwnd.cpp:660
+msgid "Next page"
+msgstr "Pagina seguente"
+
+#: ../src/common/prntbase.cpp:1628
+msgid "Last page"
+msgstr "Ultima pagina"
+
+#: ../src/common/prntbase.cpp:1636 ../src/common/stockitem.cpp:215
+msgid "Zoom Out"
+msgstr "Riduzzione"
+
+#: ../src/common/prntbase.cpp:1650 ../src/common/stockitem.cpp:214
+msgid "Zoom In"
+msgstr "Aumentazione"
+
+#: ../src/common/prntbase.cpp:1656 ../src/common/stockitem.cpp:153
+#: ../src/generic/logg.cpp:553 ../src/univ/themes/win32.cpp:3752
+msgid "&Close"
+msgstr "&Chjode"
+
+#: ../src/common/prntbase.cpp:2085
+msgid "Could not start document preview."
+msgstr "Ùn si pò micca lancià a fighjulata di u ducumentu."
+
+#: ../src/common/prntbase.cpp:2085 ../src/common/prntbase.cpp:2129
+#: ../src/common/prntbase.cpp:2137
+msgid "Print Preview Failure"
+msgstr "Fiascu di a fighjulata nanzu a stampa"
+
+#: ../src/common/prntbase.cpp:2129 ../src/common/prntbase.cpp:2137
+msgid "Sorry, not enough memory to create a preview."
+msgstr "Per disgrazia, ùn ci hè abbastanza memoria per creà una fighjulata."
+
+#: ../src/common/prntbase.cpp:2144
+#, c-format
+msgid "Page %d of %d"
+msgstr "Pagina %d nant’à %d"
+
+#: ../src/common/prntbase.cpp:2146
+#, c-format
+msgid "Page %d"
+msgstr "Pagina %d"
+
+#: ../src/common/regex.cpp:382 ../src/html/chm.cpp:348
+msgid "unknown error"
+msgstr "sbagliu scunnisciutu"
+
+#: ../src/common/regex.cpp:995
+#, c-format
+msgid "Invalid regular expression '%s': %s"
+msgstr "Espressione regulare « %s » inaccettevule : %s"
+
+#: ../src/common/regex.cpp:1059
+#, c-format
+msgid "Failed to find match for regular expression: %s"
+msgstr "Impussibule di truvà una currispundenza à l’espressione regulare : %s"
+
+#: ../src/common/rendcmn.cpp:188
+#, c-format
+msgid "Renderer \"%s\" has incompatible version %d.%d and couldn't be loaded."
+msgstr ""
+"U mutore di restituzione « %s » hà una versione %d.%d incumpatibile è ùn pò "
+"micca esse caricatu."
+
+#: ../src/common/secretstore.cpp:162
+msgid "Not available for this platform"
+msgstr "Micca dispunibule per sta piattaforma"
+
+#: ../src/common/secretstore.cpp:183
+#, c-format
+msgid "Saving password for \"%s\" failed: %s."
+msgstr "Arregistramentu di a parolla d’intesa per « %s » fiascatu : %s."
+
+#: ../src/common/secretstore.cpp:205
+#, c-format
+msgid "Reading password for \"%s\" failed: %s."
+msgstr "Lettura di a parolla d’intesa per « %s » fiascata : %s."
+
+#: ../src/common/secretstore.cpp:228
+#, c-format
+msgid "Deleting password for \"%s\" failed: %s."
+msgstr "Squassatura di a parolla d’intesa per « %s » fiascata : %s."
+
+#: ../src/common/selectdispatcher.cpp:254
+msgid "Failed to monitor I/O channels"
+msgstr "Fiascu per cuntrollà i canali I/O"
+
+#: ../src/common/sizer.cpp:3054 ../src/common/stockitem.cpp:195
+msgid "Save"
+msgstr "Arregistrà"
+
+#: ../src/common/sizer.cpp:3056
+msgid "Don't Save"
+msgstr "Ùn arregistrà micca"
+
+#: ../src/common/socket.cpp:870
+msgid "Cannot initialize sockets"
+msgstr "Ùn si pò micca inizià i « sockets »"
+
+#: ../src/common/stockitem.cpp:127
+msgctxt "standard Windows menu"
+msgid "&Help"
+msgstr "&Aiutu"
+
+#: ../src/common/stockitem.cpp:144
+msgid "&About"
+msgstr "&Apprupositu"
+
+#: ../src/common/stockitem.cpp:144
+msgid "About"
+msgstr "Apprupositu"
+
+#: ../src/common/stockitem.cpp:145
+msgid "Add"
+msgstr "Aghjunghje"
+
+#: ../src/common/stockitem.cpp:146
+msgid "&Apply"
+msgstr "&Appiecà"
+
+#: ../src/common/stockitem.cpp:146
+msgid "Apply"
+msgstr "Affettà"
+
+#: ../src/common/stockitem.cpp:147
+msgid "&Back"
+msgstr "&Ritornu"
+
+#: ../src/common/stockitem.cpp:147
+msgid "Back"
+msgstr "Ritornu"
+
+#: ../src/common/stockitem.cpp:148
+msgid "&Bold"
+msgstr "&Grassa"
+
+#: ../src/common/stockitem.cpp:148 ../src/generic/fontdlgg.cpp:326
+#: ../src/richtext/richtextfontpage.cpp:354
+msgid "Bold"
+msgstr "Grassa"
+
+#: ../src/common/stockitem.cpp:149
+msgid "&Bottom"
+msgstr "&Bassu"
+
+#: ../src/common/stockitem.cpp:149 ../src/richtext/richtextsizepage.cpp:287
+msgid "Bottom"
+msgstr "Bassu"
+
+#: ../src/common/stockitem.cpp:150 ../src/generic/fontdlgg.cpp:462
+#: ../src/generic/fontdlgg.cpp:481 ../src/generic/wizard.cpp:415
+msgid "&Cancel"
+msgstr "&Abbandunà"
+
+#: ../src/common/stockitem.cpp:151
+msgid "&CD-ROM"
+msgstr "&CD-Rom"
+
+#: ../src/common/stockitem.cpp:151
+msgid "CD-ROM"
+msgstr "CD-Rom"
+
+#: ../src/common/stockitem.cpp:152
+msgid "&Clear"
+msgstr "&Squassà"
+
+#: ../src/common/stockitem.cpp:152
+msgid "Clear"
+msgstr "Viutà"
+
+#: ../src/common/stockitem.cpp:153 ../src/generic/dbgrptg.cpp:93
+#: ../src/generic/progdlgg.cpp:778 ../src/html/helpdlg.cpp:86
+#: ../src/msw/progdlg.cpp:209 ../src/msw/progdlg.cpp:890
+#: ../src/richtext/richtextstyledlg.cpp:272
+#: ../src/richtext/richtextsymboldlg.cpp:448
+msgid "Close"
+msgstr "Chjode"
+
+#: ../src/common/stockitem.cpp:154
+msgid "&Convert"
+msgstr "&Cunvertisce"
+
+#: ../src/common/stockitem.cpp:154
+msgid "Convert"
+msgstr "Cunvertisce"
+
+#: ../src/common/stockitem.cpp:155 ../src/msw/textctrl.cpp:2884
+#: ../src/osx/textctrl_osx.cpp:653 ../src/richtext/richtextctrl.cpp:331
+msgid "&Copy"
+msgstr "&Cupià"
+
+#: ../src/common/stockitem.cpp:155 ../src/stc/stc_i18n.cpp:18
+msgid "Copy"
+msgstr "Cupià"
+
+#: ../src/common/stockitem.cpp:156 ../src/msw/textctrl.cpp:2883
+#: ../src/osx/textctrl_osx.cpp:652 ../src/richtext/richtextctrl.cpp:330
+msgid "Cu&t"
+msgstr "&Taglià"
+
+#: ../src/common/stockitem.cpp:156 ../src/stc/stc_i18n.cpp:17
+msgid "Cut"
+msgstr "Taglià"
+
+#: ../src/common/stockitem.cpp:157 ../src/msw/textctrl.cpp:2886
+#: ../src/osx/textctrl_osx.cpp:655 ../src/richtext/richtextctrl.cpp:333
+#: ../src/richtext/richtexttabspage.cpp:137
+msgid "&Delete"
+msgstr "&Squassà"
+
+#: ../src/common/stockitem.cpp:157 ../src/richtext/richtextbuffer.cpp:8266
+#: ../src/stc/stc_i18n.cpp:20
+msgid "Delete"
+msgstr "Squassà"
+
+#: ../src/common/stockitem.cpp:158
+msgid "&Down"
+msgstr "In&ghjò"
+
+#: ../src/common/stockitem.cpp:158 ../src/generic/fdrepdlg.cpp:148
+msgid "Down"
+msgstr "Ghjò"
+
+#: ../src/common/stockitem.cpp:159
+msgid "&Edit"
+msgstr "&Mudificà"
+
+#: ../src/common/stockitem.cpp:159
+msgid "Edit"
+msgstr "Mudificà"
+
+#: ../src/common/stockitem.cpp:160
+msgid "&Execute"
+msgstr "&Eseguisce"
+
+#: ../src/common/stockitem.cpp:160
+msgid "Execute"
+msgstr "Eseguisce"
+
+#: ../src/common/stockitem.cpp:161
+msgid "&Quit"
+msgstr "&Esce"
+
+#: ../src/common/stockitem.cpp:161
+msgid "Quit"
+msgstr "Esce"
+
+#: ../src/common/stockitem.cpp:162
+msgid "&File"
+msgstr "&Schedariu"
+
+#: ../src/common/stockitem.cpp:162
+msgid "File"
+msgstr "Schedariu"
+
+#: ../src/common/stockitem.cpp:163
+msgid "&Find..."
+msgstr "&Truvà…"
+
+#: ../src/common/stockitem.cpp:163
+msgid "Find..."
+msgstr "Truvà…"
+
+#: ../src/common/stockitem.cpp:164
+msgid "&First"
+msgstr "&Primu"
+
+#: ../src/common/stockitem.cpp:164
+msgid "First"
+msgstr "Primu"
+
+#: ../src/common/stockitem.cpp:165
+msgid "&Floppy"
+msgstr "&Dischettu"
+
+#: ../src/common/stockitem.cpp:165
+msgid "Floppy"
+msgstr "Dischettu"
+
+#: ../src/common/stockitem.cpp:166
+msgid "&Forward"
+msgstr "&Seguente"
+
+#: ../src/common/stockitem.cpp:166
+msgid "Forward"
+msgstr "Dopu"
+
+#: ../src/common/stockitem.cpp:167
+msgid "&Harddisk"
+msgstr "&Discu duru"
+
+#: ../src/common/stockitem.cpp:167
+msgid "Harddisk"
+msgstr "Discu duru"
+
+#: ../src/common/stockitem.cpp:168 ../src/generic/wizard.cpp:418
+#: ../src/osx/cocoa/menu.mm:225 ../src/richtext/richtextstyledlg.cpp:298
+#: ../src/richtext/richtextsymboldlg.cpp:451
+msgid "&Help"
+msgstr "&Aiutu"
+
+#: ../src/common/stockitem.cpp:169
+msgid "&Home"
+msgstr "&Accolta"
+
+#: ../src/common/stockitem.cpp:169
+msgid "Home"
+msgstr "Accolta"
+
+#: ../src/common/stockitem.cpp:170
+msgid "Indent"
+msgstr "Indentazione"
+
+#: ../src/common/stockitem.cpp:171
+msgid "&Index"
+msgstr "&Indice"
+
+#: ../src/common/stockitem.cpp:171 ../src/html/helpwnd.cpp:510
+msgid "Index"
+msgstr "Indice"
+
+#: ../src/common/stockitem.cpp:172
+msgid "&Info"
+msgstr "&Infurmazione"
+
+#: ../src/common/stockitem.cpp:172
+msgid "Info"
+msgstr "Infurmazione"
+
+#: ../src/common/stockitem.cpp:173
+msgid "&Italic"
+msgstr "&Cursiva"
+
+#: ../src/common/stockitem.cpp:173 ../src/generic/fontdlgg.cpp:322
+#: ../src/richtext/richtextfontpage.cpp:350
+msgid "Italic"
+msgstr "Cursiva"
+
+#: ../src/common/stockitem.cpp:174
+msgid "&Jump to"
+msgstr "&Saltà à"
+
+#: ../src/common/stockitem.cpp:174
+msgid "Jump to"
+msgstr "Saltà à"
+
+#: ../src/common/stockitem.cpp:175
+msgid "Centered"
+msgstr "Centru"
+
+#: ../src/common/stockitem.cpp:176
+msgid "Justified"
+msgstr "Ghjustificatu"
+
+#: ../src/common/stockitem.cpp:177
+msgid "Align Left"
+msgstr "Alineà à manca"
+
+#: ../src/common/stockitem.cpp:178
+msgid "Align Right"
+msgstr "Alineà à diritta"
+
+#: ../src/common/stockitem.cpp:179
+msgid "&Last"
+msgstr "&Ultimu"
+
+#: ../src/common/stockitem.cpp:179
+msgid "Last"
+msgstr "Ultimu"
+
+#: ../src/common/stockitem.cpp:180
+msgid "&Network"
+msgstr "&Reta"
+
+#: ../src/common/stockitem.cpp:180
+msgid "Network"
+msgstr "Reta"
+
+#: ../src/common/stockitem.cpp:181 ../src/richtext/richtexttabspage.cpp:131
+msgid "&New"
+msgstr "&Novu"
+
+#: ../src/common/stockitem.cpp:181
+msgid "New"
+msgstr "Novu"
+
+#: ../src/common/stockitem.cpp:182 ../src/msw/msgdlg.cpp:417
+msgid "&No"
+msgstr "&Nò"
+
+#: ../src/common/stockitem.cpp:183 ../src/generic/fontdlgg.cpp:467
+#: ../src/generic/fontdlgg.cpp:474
+msgid "&OK"
+msgstr "&Vai"
+
+#: ../src/common/stockitem.cpp:184 ../src/generic/dbgrptg.cpp:341
+msgid "&Open..."
+msgstr "&Apre..."
+
+#: ../src/common/stockitem.cpp:184
+msgid "Open..."
+msgstr "Apre..."
+
+#: ../src/common/stockitem.cpp:185 ../src/msw/textctrl.cpp:2885
+#: ../src/osx/textctrl_osx.cpp:654 ../src/richtext/richtextctrl.cpp:332
+msgid "&Paste"
+msgstr "&Incullà"
+
+#: ../src/common/stockitem.cpp:185 ../src/richtext/richtextctrl.cpp:3484
+#: ../src/stc/stc_i18n.cpp:19
+msgid "Paste"
+msgstr "Incullà"
+
+#: ../src/common/stockitem.cpp:186
+msgid "&Preferences"
+msgstr "Preferenze"
+
+#: ../src/common/stockitem.cpp:186 ../src/osx/cocoa/preferences.mm:304
+msgid "Preferences"
+msgstr "Preferenze"
+
+#: ../src/common/stockitem.cpp:187
+msgid "Print previe&w..."
+msgstr "Fighj&ulata nanzu a stampa…"
+
+#: ../src/common/stockitem.cpp:187
+msgid "Print preview..."
+msgstr "Fighjulata nanzu a stampa…"
+
+#: ../src/common/stockitem.cpp:188
+msgid "&Print..."
+msgstr "&Stampà..."
+
+#: ../src/common/stockitem.cpp:188
+msgid "Print..."
+msgstr "Stampà..."
+
+#: ../src/common/stockitem.cpp:189 ../src/richtext/richtextctrl.cpp:337
+#: ../src/richtext/richtextctrl.cpp:5479
+msgid "&Properties"
+msgstr "&Pruprietà"
+
+#: ../src/common/stockitem.cpp:189
+msgid "Properties"
+msgstr "Pruprietà"
+
+#: ../src/common/stockitem.cpp:190 ../src/stc/stc_i18n.cpp:16
+msgid "Redo"
+msgstr "Rifà"
+
+#: ../src/common/stockitem.cpp:191
+msgid "Refresh"
+msgstr "Attualizà"
+
+#: ../src/common/stockitem.cpp:192
+msgid "Remove"
+msgstr "Caccià"
+
+#: ../src/common/stockitem.cpp:193
+msgid "Rep&lace..."
+msgstr "Rimpia&zzà…"
+
+#: ../src/common/stockitem.cpp:193
+msgid "Replace..."
+msgstr "Rimpiazzà…"
+
+#: ../src/common/stockitem.cpp:194
+msgid "Revert to Saved"
+msgstr "Rivene à a versione arregistrata"
+
+#: ../src/common/stockitem.cpp:196 ../src/generic/logg.cpp:549
+msgid "Save &As..."
+msgstr "Arregistrà &cù u nome..."
+
+#: ../src/common/stockitem.cpp:196
+msgid "Save As..."
+msgstr "Arregistrà cù u nome…"
+
+#: ../src/common/stockitem.cpp:197 ../src/msw/textctrl.cpp:2888
+#: ../src/osx/textctrl_osx.cpp:657 ../src/richtext/richtextctrl.cpp:335
+msgid "Select &All"
+msgstr "&Tuttu selezziunà"
+
+#: ../src/common/stockitem.cpp:197 ../src/stc/stc_i18n.cpp:21
+msgid "Select All"
+msgstr "Tuttu selezziunà"
+
+#: ../src/common/stockitem.cpp:198
+msgid "&Color"
+msgstr "&Culore"
+
+#: ../src/common/stockitem.cpp:198
+msgid "Color"
+msgstr "Culore"
+
+#: ../src/common/stockitem.cpp:199
+msgid "&Font"
+msgstr "&Grafia"
+
+#: ../src/common/stockitem.cpp:199 ../src/richtext/richtextformatdlg.cpp:336
+msgid "Font"
+msgstr "Grafia"
+
+#: ../src/common/stockitem.cpp:200
+msgid "&Ascending"
+msgstr "&Crescente"
+
+#: ../src/common/stockitem.cpp:200
+msgid "Ascending"
+msgstr "Crescente"
+
+#: ../src/common/stockitem.cpp:201
+msgid "&Descending"
+msgstr "&Discendente"
+
+#: ../src/common/stockitem.cpp:201
+msgid "Descending"
+msgstr "Discendente"
+
+#: ../src/common/stockitem.cpp:202
+msgid "&Spell Check"
+msgstr "&Cuntrollu d’ortugrafia"
+
+#: ../src/common/stockitem.cpp:202
+msgid "Spell Check"
+msgstr "Cuntrollu d’ortugrafia"
+
+#: ../src/common/stockitem.cpp:203
+msgid "&Stop"
+msgstr "&Piantà"
+
+#: ../src/common/stockitem.cpp:203
+msgid "Stop"
+msgstr "Piantà"
+
+#: ../src/common/stockitem.cpp:204 ../src/richtext/richtextfontpage.cpp:274
+msgid "&Strikethrough"
+msgstr "&Rigata"
+
+#: ../src/common/stockitem.cpp:204
+msgid "Strikethrough"
+msgstr "Rigata"
+
+#: ../src/common/stockitem.cpp:205
+msgid "&Top"
+msgstr "&Altu"
+
+#: ../src/common/stockitem.cpp:205 ../src/richtext/richtextsizepage.cpp:285
+#: ../src/richtext/richtextsizepage.cpp:289
+msgid "Top"
+msgstr "Altu"
+
+#: ../src/common/stockitem.cpp:206
+msgid "Undelete"
+msgstr "Ristabilisce"
+
+#: ../src/common/stockitem.cpp:207 ../src/generic/fontdlgg.cpp:437
+msgid "&Underline"
+msgstr "&Sottulineà"
+
+#: ../src/common/stockitem.cpp:207
+msgid "Underline"
+msgstr "Sottulineatu"
+
+#: ../src/common/stockitem.cpp:208 ../src/stc/stc_i18n.cpp:15
+msgid "Undo"
+msgstr "Disfà"
+
+#: ../src/common/stockitem.cpp:209
+msgid "&Unindent"
+msgstr "&Caccià l’indentazione"
+
+#: ../src/common/stockitem.cpp:209
+msgid "Unindent"
+msgstr "Caccià l’indentazione"
+
+#: ../src/common/stockitem.cpp:210
+msgid "&Up"
+msgstr "In&sù"
+
+#: ../src/common/stockitem.cpp:210 ../src/generic/fdrepdlg.cpp:148
+msgid "Up"
+msgstr "Sù"
+
+#: ../src/common/stockitem.cpp:211 ../src/msw/msgdlg.cpp:417
+msgid "&Yes"
+msgstr "&Sì"
+
+#: ../src/common/stockitem.cpp:212
+msgid "&Actual Size"
+msgstr "&Dimensione attuale"
+
+#: ../src/common/stockitem.cpp:212
+msgid "Actual Size"
+msgstr "Dimensione attuale"
+
+#: ../src/common/stockitem.cpp:213
+msgid "Zoom to &Fit"
+msgstr "Adattatu à a &finestra"
+
+#: ../src/common/stockitem.cpp:213
+msgid "Zoom to Fit"
+msgstr "Adattatu à a finestra"
+
+#: ../src/common/stockitem.cpp:214
+msgid "Zoom &In"
+msgstr "&Aumentà"
+
+#: ../src/common/stockitem.cpp:215
+msgid "Zoom &Out"
+msgstr "&Riduce"
+
+#: ../src/common/stockitem.cpp:262
+msgid "Show about dialog"
+msgstr "Affissà a finestra d’apprupositu"
+
+#: ../src/common/stockitem.cpp:263
+msgid "Copy selection"
+msgstr "Cupià a selezzione"
+
+#: ../src/common/stockitem.cpp:264
+msgid "Cut selection"
+msgstr "Taglià a selezzione"
+
+#: ../src/common/stockitem.cpp:265
+msgid "Delete selection"
+msgstr "Squassà a selezzione"
+
+#: ../src/common/stockitem.cpp:266
+msgid "Find in document"
+msgstr "Truvà in u ducumentu"
+
+#: ../src/common/stockitem.cpp:267
+msgid "Find and replace in document"
+msgstr "Truvà è rimpiazzà in u ducumentu"
+
+#: ../src/common/stockitem.cpp:268
+msgid "Paste selection"
+msgstr "Incullà a selezzione"
+
+#: ../src/common/stockitem.cpp:269
+msgid "Quit this program"
+msgstr "Esce di stu prugramma"
+
+#: ../src/common/stockitem.cpp:270
+msgid "Redo last action"
+msgstr "Rifà l’ultima azzione"
+
+#: ../src/common/stockitem.cpp:271
+msgid "Undo last action"
+msgstr "Disfà l’ultima azzione"
+
+#: ../src/common/stockitem.cpp:272
+msgid "Create new document"
+msgstr "Creà un novu ducumentu"
+
+#: ../src/common/stockitem.cpp:273
+msgid "Open an existing document"
+msgstr "Apre un ducumentu esistente"
+
+#: ../src/common/stockitem.cpp:274
+msgid "Close current document"
+msgstr "Chjode u ducumentu attuale"
+
+#: ../src/common/stockitem.cpp:275
+msgid "Save current document"
+msgstr "Arregistrà u ducumentu attuale"
+
+#: ../src/common/stockitem.cpp:276
+msgid "Save current document with a different filename"
+msgstr "Arregistrà u ducumentu attuale cù un nome di schedariu sfarente"
+
+#: ../src/common/strconv.cpp:2324
+#, c-format
+msgid "Conversion to charset '%s' doesn't work."
+msgstr ""
+"A cunversione versu u gruppu di caratteri « %s » ùn funziuneghja micca."
+
+#: ../src/common/tarstrm.cpp:352 ../src/common/tarstrm.cpp:375
+#: ../src/common/tarstrm.cpp:406 ../src/generic/progdlgg.cpp:373
+msgid "unknown"
+msgstr "scunnisciutu"
+
+#: ../src/common/tarstrm.cpp:774
+msgid "incomplete header block in tar"
+msgstr "u bloccu d’intestatura hè incumpletu in tar"
+
+#: ../src/common/tarstrm.cpp:798
+msgid "checksum failure reading tar header block"
+msgstr ""
+"sbagliu di a somma di cuntrollu durante a lettura di u bloccu d’intestatura "
+"di tar"
+
+#: ../src/common/tarstrm.cpp:971
+msgid "invalid data in extended tar header"
+msgstr "dati inaccettevule in l’intestatura estesa di tar"
+
+#: ../src/common/tarstrm.cpp:981 ../src/common/tarstrm.cpp:1003
+#: ../src/common/tarstrm.cpp:1477 ../src/common/tarstrm.cpp:1499
+msgid "tar entry not open"
+msgstr "l’elementu tar ùn hè micca apertu"
+
+#: ../src/common/tarstrm.cpp:1023
+msgid "unexpected end of file"
+msgstr "fine di schedariu imprevista"
+
+#: ../src/common/tarstrm.cpp:1297
+#, c-format
+msgid "%s did not fit the tar header for entry '%s'"
+msgstr "%s ùn currisponde micca à l’intestatura tar per l’elementu « %s »"
+
+#: ../src/common/tarstrm.cpp:1359
+msgid "incorrect size given for tar entry"
+msgstr "a dimensione pruvista per l’elementu tar hè incurretta"
+
+#: ../src/common/textbuf.cpp:232
+#, c-format
+msgid "'%s' is probably a binary buffer."
+msgstr "« %s » hè forse un stampone binariu."
+
+#: ../src/common/textcmn.cpp:1006 ../src/richtext/richtextctrl.cpp:3053
+msgid "File couldn't be loaded."
+msgstr "Ùn si pò micca caricà u schedariu."
+
+#: ../src/common/textfile.cpp:95
+#, c-format
+msgid "Failed to read text file \"%s\"."
+msgstr "Fiascu per leghje u schedariu di testu « %s »."
+
+#: ../src/common/textfile.cpp:160
+#, c-format
+msgid "can't write buffer '%s' to disk."
+msgstr "impussibule di scrive u stampone « %s » nant’à u discu."
+
+#: ../src/common/time.cpp:212
+msgid "Failed to get the local system time"
+msgstr "Fiascu per ottene l’ora lucale di u sistema"
+
+#: ../src/common/time.cpp:279
+msgid "wxGetTimeOfDay failed."
+msgstr "Fiascu di « wxGetTimeOfDay »."
+
+#: ../src/common/translation.cpp:929
+#, c-format
+msgid "'%s' is not a valid message catalog."
+msgstr "« %s » ùn hè micca un catalogu accettevule di messaghji."
+
+#: ../src/common/translation.cpp:954
+msgid "Invalid message catalog."
+msgstr "Catalogu inaccettevule di messaghji."
+
+#: ../src/common/translation.cpp:1013
+#, c-format
+msgid "Failed to parse Plural-Forms: '%s'"
+msgstr "Fiascu di l’analisa di e forme plurale : « %s »"
+
+#: ../src/common/translation.cpp:1723
+#, c-format
+msgid "using catalog '%s' from '%s'."
+msgstr "impiegu di u catalogu « %s » da « %s »."
+
+#: ../src/common/translation.cpp:1816
+#, c-format
+msgid "Resource '%s' is not a valid message catalog."
+msgstr "A risorsa « %s » ùn hè micca un catalogu accettevule di messaghji."
+
+#: ../src/common/translation.cpp:1865
+msgid "Couldn't enumerate translations"
+msgstr "Ùn si pò micca enumerà e traduzzioni"
+
+#: ../src/common/utilscmn.cpp:1145
+msgid "No default application configured for HTML files."
+msgstr "Nisuna appiecazione predefinita hè cunfigurata per i schedarii HTML."
+
+#: ../src/common/utilscmn.cpp:1190
+#, c-format
+msgid "Failed to open URL \"%s\" in default browser."
+msgstr "Fiascu per apre l’indirizzu web « %s » in u navigatore predefinitu."
+
+#: ../src/common/valtext.cpp:144
+msgid "Validation conflict"
+msgstr "Cunflittu di cunvalidazione"
+
+#: ../src/common/valtext.cpp:186
+msgid "Required information entry is empty."
+msgstr "L’elementu d’infurmazione richiestu hè viotu."
+
+#: ../src/common/valtext.cpp:188
+#, c-format
+msgid "'%s' is one of the invalid strings"
+msgstr "« %s » hè una di e catene inaccettevule"
+
+#: ../src/common/valtext.cpp:190
+#, c-format
+msgid "'%s' is not one of the valid strings"
+msgstr "« %s » ùn hè micca una di e catene accettevule"
+
+#: ../src/common/valtext.cpp:199
+#, c-format
+msgid "'%s' contains invalid character(s)"
+msgstr "« %s » cuntene caratteru(i) inaccettevule"
+
+#: ../src/common/webrequest.cpp:139
+#, c-format
+msgid "Error: %s (%d)"
+msgstr "Sbagliu : %s (%d)"
+
+#: ../src/common/webrequest.cpp:655
+#, c-format
+msgid ""
+"Not enough free disk space for download: %llu needed but only %llu available."
+msgstr ""
+"Ùn ci hè abbastanza spaziu discu liberu per scaricà : %llu richiestu ma solu "
+"%llu dispunibule."
+
+#: ../src/common/webrequest.cpp:669
+#, c-format
+msgid "Failed to create temporary file in %s"
+msgstr "Ùn si pò micca creà u schedariu timpurariu in %s"
+
+#: ../src/common/webrequest_curl.cpp:1106
+msgid "libcurl could not be initialized"
+msgstr "Ùn si pò micca inizià « libcurl »"
+
+#: ../src/common/webview.cpp:392
+msgid "RunScriptAsync not supported"
+msgstr "RunScriptAsync ùn hè micca accettatu"
+
+#: ../src/common/webview.cpp:403 ../src/msw/webview_ie.cpp:1073
+#, c-format
+msgid "Error running JavaScript: %s"
+msgstr "Sbagliu à l’esecuzione di JavaScript : %s"
+
+#: ../src/common/webview_chromium.cpp:858
+#, c-format
+msgid "Failed to set proxy \"%s\": %s"
+msgstr "Fiascu per definisce u proxy « %s » : %s"
+
+#: ../src/common/webview_chromium.cpp:989
+msgid ""
+"Chromium can't be used because libcef.so wasn't loaded early enough; please "
+"relink the application or use LD_PRELOAD to load it earlier."
+msgstr ""
+"Ùn si pò micca impiegà Chromium perchè libcef.so ùn hè statu caricatu "
+"abbastanza prestu ; ci vole à fà un « relink » di l’appiecazione o impiegà "
+"LD_PRELOAD per caricallu più prestu."
+
+#: ../src/common/webview_chromium.cpp:1108
+msgid "Could not initialize Chromium"
+msgstr "Ùn si pò micca inizià Chromium"
+
+#: ../src/common/webview_chromium.cpp:1616
+msgid "Show DevTools"
+msgstr "Affissà DevTools"
+
+#: ../src/common/webview_chromium.cpp:1617
+msgid "Close DevTools"
+msgstr "Chjode DevTools"
+
+#: ../src/common/webview_chromium.cpp:1623
+msgid "Inspect"
+msgstr "Ispettà"
+
+#: ../src/common/wincmn.cpp:1628
+msgid "This platform does not support background transparency."
+msgstr "Sta piattaforma ùn accetta micca a trasparenza di sfondulu."
+
+#: ../src/common/wincmn.cpp:2097
+msgid "Could not transfer data to window"
+msgstr "Ùn si pò micca trasferisce i dati à a finestra"
+
+#: ../src/common/windowid.cpp:240
+msgid "Out of window IDs.  Recommend shutting down application."
+msgstr ""
+"Ùn ci hè più d’ID di finestra.  Hè ricumandatu di chjode l’appiecazione."
+
+#: ../src/common/xpmdecod.cpp:678
+msgid "XPM: incorrect header format!"
+msgstr "XPM : furmatu d’intestatura incurrettu !"
+
+#: ../src/common/xpmdecod.cpp:703
+#, c-format
+msgid "XPM: incorrect colour description in line %d"
+msgstr "XPM : discrizzione di culore incurretta à a linea %d"
+
+#: ../src/common/xpmdecod.cpp:715 ../src/common/xpmdecod.cpp:724
+#, c-format
+msgid "XPM: malformed colour definition '%s' at line %d!"
+msgstr "XPM : definizione di culore malcuncilia « %s » à a linea %d !"
+
+#: ../src/common/xpmdecod.cpp:754
+msgid "XPM: no colors left to use for mask!"
+msgstr "XPM : nisunu culore rimanente à impiegà per a maschera !"
+
+#: ../src/common/xpmdecod.cpp:781
+#, c-format
+msgid "XPM: truncated image data at line %d!"
+msgstr "XPM : i dati di a fiura sò truncati à a linea %d !"
+
+#: ../src/common/xpmdecod.cpp:795
+msgid "XPM: Malformed pixel data!"
+msgstr "XPM : i dati di pizzelu sò malcuncilii !"
+
+#: ../src/common/xti.cpp:492
+msgid "Illegal Parameter Count for Create Method"
+msgstr "Numeru illegale di parametri per u metoda « Create »"
+
+#: ../src/common/xti.cpp:504
+msgid "Illegal Parameter Count for ConstructObject Method"
+msgstr "Numeru illegale di parametri per u metoda « ConstructObject »"
+
+#: ../src/common/xtistrm.cpp:161
+#, c-format
+msgid "Create Parameter %s not found in declared RTTI Parameters"
+msgstr "Parametru di creazione %s intruvevule in i parametri RTTI dichjarati"
+
+#: ../src/common/xtistrm.cpp:290
+msgid "Illegal Object Class (Non-wxEvtHandler) as Event Source"
+msgstr "Classa d’oggettu illegale (Non-wxEvtHandler) cum’è fonte d’evenimentu"
+
+#: ../src/common/xtistrm.cpp:313 ../src/common/xtixml.cpp:345
+#: ../src/common/xtixml.cpp:498
+msgid "Type must have enum - long conversion"
+msgstr "U tipu deve avè una cunversione longa d’enumerazione"
+
+#: ../src/common/xtistrm.cpp:400 ../src/common/xtistrm.cpp:415
+msgid "Invalid or Null Object ID passed to GetObjectClassInfo"
+msgstr ""
+"Identificazione d’oggettu inaccettevule o nulla passata à "
+"« GetObjectClassInfo »"
+
+#: ../src/common/xtistrm.cpp:405
+msgid "Unknown Object passed to GetObjectClassInfo"
+msgstr "Oggettu scunnisciutu passatu à « GetObjectClassInfo »"
+
+#: ../src/common/xtistrm.cpp:420
+msgid "Already Registered Object passed to SetObjectClassInfo"
+msgstr "Oggettu dighjà arregistratu passatu à « SetObjectClassInfo »"
+
+#: ../src/common/xtistrm.cpp:430
+msgid "Invalid or Null Object ID passed to HasObjectClassInfo"
+msgstr ""
+"Identificazione d’oggettu inaccettevule o nulla passata à "
+"« HasObjectClassInfo »"
+
+#: ../src/common/xtistrm.cpp:460
+msgid "Passing a already registered object to SetObject"
+msgstr "Passagiu d’un oggettu dighjà arregistratu à « SetObject »"
+
+#: ../src/common/xtistrm.cpp:471
+msgid "Passing an unknown object to GetObject"
+msgstr "Passagiu d’un oggettu scunnisciutu à « GetObject »"
+
+#: ../src/common/xtixml.cpp:229
+msgid "Forward hrefs are not supported"
+msgstr "Trasferimenti « hrefs » ùn sò micca accettati"
+
+#: ../src/common/xtixml.cpp:247
+#, c-format
+msgid "unknown class %s"
+msgstr "classa scunnisciuta %s"
+
+#: ../src/common/xtixml.cpp:253
+msgid "objects cannot have XML Text Nodes"
+msgstr "l’oggetti ùn ponu micca avè nodi di testu XML"
+
+#: ../src/common/xtixml.cpp:258
+msgid "Objects must have an id attribute"
+msgstr "L’oggetti devenu avè un attributu d’identificazione"
+
+#: ../src/common/xtixml.cpp:267
+#, c-format
+msgid "Doubly used id : %d"
+msgstr "Identificazione impiegata in doppiu : %d"
+
+#: ../src/common/xtixml.cpp:316
+#, c-format
+msgid "Unknown Property %s"
+msgstr "Pruprietà scunnisciuta %s"
+
+#: ../src/common/xtixml.cpp:407
+msgid "A non empty collection must consist of 'element' nodes"
+msgstr "Una cullezzione micca viota deve cuntene nodi « elementi »"
+
+#: ../src/common/xtixml.cpp:478
+msgid "incorrect event handler string, missing dot"
+msgstr "catena di ghjestione d’evenimentu incurretta, puntu assente"
+
+#: ../src/common/zipstrm.cpp:559
+msgid "can't re-initialize zlib deflate stream"
+msgstr "ùn si pò micca inizià torna u flussu di scumpressione zlib"
+
+#: ../src/common/zipstrm.cpp:584
+msgid "can't re-initialize zlib inflate stream"
+msgstr "ùn si pò micca inizià torna u flussu di cumpressione zlib"
+
+#: ../src/common/zipstrm.cpp:1023
+msgid "Ignoring malformed extra data record, ZIP file may be corrupted"
+msgstr ""
+"Un arregistramentu addiziunale di dati malcunciliu hè statu ignuratu, forse "
+"u schedariu zip hè deteriuratu"
+
+#: ../src/common/zipstrm.cpp:1502
+msgid "assuming this is a multi-part zip concatenated"
+msgstr "si suppone chì ghjè un cuncatinamentu zip à parechje parti"
+
+#: ../src/common/zipstrm.cpp:1664
+msgid "invalid zip file"
+msgstr "schedariu zip inaccettevule"
+
+#: ../src/common/zipstrm.cpp:1723
+msgid "can't find central directory in zip"
+msgstr "ùn si pò micca truvà u cartulare principale in u zip"
+
+#: ../src/common/zipstrm.cpp:1812
+msgid "error reading zip central directory"
+msgstr "sbagliu à a lettura di u cartulare principale di u zip"
+
+#: ../src/common/zipstrm.cpp:1916
+msgid "error reading zip local header"
+msgstr "sbagliu à a lettura di l’intestatura lucale di u zip"
+
+#: ../src/common/zipstrm.cpp:1964
+msgid "bad zipfile offset to entry"
+msgstr "spustime incurrettu di l’elementu in u schedariu zip"
+
+#: ../src/common/zipstrm.cpp:2031
+msgid "stored file length not in Zip header"
+msgstr ""
+"a longhezza di u schedariu arregistrata ùn hè micca in l’intestatura di u zip"
+
+#: ../src/common/zipstrm.cpp:2045 ../src/common/zipstrm.cpp:2362
+msgid "unsupported Zip compression method"
+msgstr "a metoda di cumpressione zip ùn hè micca accettata"
+
+#: ../src/common/zipstrm.cpp:2126
+#, c-format
+msgid "reading zip stream (entry %s): bad length"
+msgstr "lettura di u flussu zip (elementu %s) : longhezza incurretta"
+
+#: ../src/common/zipstrm.cpp:2131
+#, c-format
+msgid "reading zip stream (entry %s): bad crc"
+msgstr "lettura di u flussu zip (elementu %s) : CRC incurrettu"
+
+#: ../src/common/zipstrm.cpp:2578
+#, c-format
+msgid "error writing zip entry '%s': file too large without ZIP64"
+msgstr ""
+"sbagliu à a scrittura di l’elementu zip « %s » : schedariu troppu maiò senza "
+"ZIP64"
+
+#: ../src/common/zipstrm.cpp:2585
+#, c-format
+msgid "error writing zip entry '%s': bad crc or length"
+msgstr ""
+"sbagliu à a scrittura di l’elementu zip « %s » : CRC o longhezza incurretta"
+
+#: ../src/common/zstream.cpp:155 ../src/common/zstream.cpp:315
+msgid "Gzip not supported by this version of zlib"
+msgstr "Gzip ùn hè micca accettatu da sta versione di zlib"
+
+#: ../src/common/zstream.cpp:182
+msgid "Can't initialize zlib inflate stream."
+msgstr "Ùn si pò micca inizià u flussu di cumpressione zlib."
+
+#: ../src/common/zstream.cpp:241
+msgid "Can't read inflate stream: unexpected EOF in underlying stream."
+msgstr "Ùn si pò micca leghje u flussu di cumpressione."
+
+#: ../src/common/zstream.cpp:248 ../src/common/zstream.cpp:423
+#, c-format
+msgid "zlib error %d"
+msgstr "sbagliu zlib %d"
+
+#: ../src/common/zstream.cpp:249
+#, c-format
+msgid "Can't read from inflate stream: %s"
+msgstr "Ùn si pò micca leghje da u flussu di cumpressione : %s"
+
+#: ../src/common/zstream.cpp:343
+msgid "Can't initialize zlib deflate stream."
+msgstr "Ùn si pò micca inizià u flussu di scumpressione zlib."
+
+#: ../src/common/zstream.cpp:424
+#, c-format
+msgid "Can't write to deflate stream: %s"
+msgstr "Ùn si pò micca scrive in u flussu di scumpressione : %s"
+
+#: ../src/dfb/bitmap.cpp:633 ../src/dfb/bitmap.cpp:667
+#, c-format
+msgid "No bitmap handler for type %d defined."
+msgstr "Nisunu ghjestiunariu di fiura bitmap definitu per u tipu %d."
+
+#: ../src/dfb/evtloop.cpp:99
+msgid "Failed to read event from DirectFB pipe"
+msgstr "Fiascu per leghje l’evenimentu da u cundottu DirectFB"
+
+#: ../src/dfb/evtloop.cpp:171
+msgid "Failed to switch DirectFB pipe to non-blocking mode"
+msgstr "Fiascu per passà u cundottu DirectFB à u modu senza blucchime"
+
+#: ../src/dfb/fontmgr.cpp:171
+#, c-format
+msgid "no fonts found in %s, using builtin font"
+msgstr "nisuna grafia trova in %s, impiegu d’una grafia integrata"
+
+#: ../src/dfb/fontmgr.cpp:177
+msgid "Default font"
+msgstr "Grafia predefinita"
+
+#: ../src/dfb/fontmgr.cpp:195
+#, c-format
+msgid "Fonts index file %s disappeared while loading fonts."
+msgstr ""
+"U schedariu d’indice di e grafie %s hè smaritu durante u caricamentu di e "
+"grafie."
+
+#: ../src/dfb/wrapdfb.cpp:60
+#, c-format
+msgid "DirectFB error %d occurred."
+msgstr "U sbagliu DirectFB %d hè accadutu."
+
+#: ../src/generic/aboutdlgg.cpp:69
+msgid "Developed by "
+msgstr "Sviluppatu da "
+
+#: ../src/generic/aboutdlgg.cpp:72
+msgid "Documentation by "
+msgstr "Documentazione da "
+
+#: ../src/generic/aboutdlgg.cpp:75
+msgid "Graphics art by "
+msgstr "Grafismi da "
+
+#: ../src/generic/aboutdlgg.cpp:78
+msgid "Translations by "
+msgstr "Traduzzioni da "
+
+#: ../src/generic/aboutdlgg.cpp:133 ../src/osx/cocoa/aboutdlg.mm:83
+msgid "Version "
+msgstr "Versione "
+
+#. TRANSLATORS: %s is application name
+#: ../src/generic/aboutdlgg.cpp:146 ../src/msw/aboutdlg.cpp:60
+#, c-format
+msgid "About %s"
+msgstr "Apprupositu di %s"
+
+#: ../src/generic/aboutdlgg.cpp:181
+msgid "License"
+msgstr "Licenza"
+
+#: ../src/generic/aboutdlgg.cpp:184
+msgid "Developers"
+msgstr "Sviluppatori"
+
+#: ../src/generic/aboutdlgg.cpp:188
+msgid "Documentation writers"
+msgstr "Autori di a documentazione"
+
+#: ../src/generic/aboutdlgg.cpp:192
+msgid "Artists"
+msgstr "Artisti"
+
+#: ../src/generic/aboutdlgg.cpp:196
+msgid "Translators"
+msgstr "Traduttori"
+
+#: ../src/generic/animateg.cpp:125
+msgid "No handler found for animation type."
+msgstr "Nisunu ghjestiunariu trovu per u tipu d’animazione."
+
+#: ../src/generic/animateg.cpp:133
+#, c-format
+msgid "No animation handler for type %ld defined."
+msgstr "Nisunu ghjestiunariu d’animazione definitu per u tipu %ld."
+
+#: ../src/generic/animateg.cpp:145
+#, c-format
+msgid "Animation file is not of type %ld."
+msgstr "U schedariu d’animazione ùn hè micca di tipu %ld."
+
+#: ../src/generic/colrdlgg.cpp:154 ../src/gtk/colordlg.cpp:47
+msgid "Choose colour"
+msgstr "Sceglie u culore"
+
+#: ../src/generic/colrdlgg.cpp:357
+msgid "Red:"
+msgstr "Rossu :"
+
+#: ../src/generic/colrdlgg.cpp:360
+msgid "Green:"
+msgstr "Verde :"
+
+#: ../src/generic/colrdlgg.cpp:363
+msgid "Blue:"
+msgstr "Turchinu :"
+
+#: ../src/generic/colrdlgg.cpp:372
+msgid "Opacity:"
+msgstr "Opacità :"
+
+#: ../src/generic/colrdlgg.cpp:384
+msgid "Add to custom colours"
+msgstr "Aghjunghje à i culori persunalizati"
+
+#: ../src/generic/creddlgg.cpp:56
+msgid "Username:"
+msgstr "Nome d’utilizatore :"
+
+#: ../src/generic/creddlgg.cpp:63
+msgid "Password:"
+msgstr "Parolla d’intesa :"
+
+#. TRANSLATORS: Name of Boolean true value
+#: ../src/generic/datavgen.cpp:1178
+msgid "true"
+msgstr "veru"
+
+#. TRANSLATORS: Name of Boolean false value
+#: ../src/generic/datavgen.cpp:1180
+msgid "false"
+msgstr "falsu"
+
+#: ../src/generic/datavgen.cpp:6897
+#, c-format
+msgid "Row %i"
+msgstr "Linea %i"
+
+#. TRANSLATORS: Action for manipulating a tree control
+#: ../src/generic/datavgen.cpp:6987
+msgid "Collapse"
+msgstr "Riduce"
+
+#. TRANSLATORS: Action for manipulating a tree control
+#: ../src/generic/datavgen.cpp:6990
+msgid "Expand"
+msgstr "Allargà"
+
+#. TRANSLATORS: Name of data view control and number of rows
+#: ../src/generic/datavgen.cpp:7011
+#, c-format
+msgid "%s (%d items)"
+msgstr "%s (%d elementi)"
+
+#: ../src/generic/datavgen.cpp:7062
+#, c-format
+msgid "Column %u"
+msgstr "Culonna %u"
+
+#. TRANSLATORS: Keystroke for manipulating a tree control
+#: ../src/generic/datavgen.cpp:7131 ../src/richtext/richtextbulletspage.cpp:189
+#: ../src/richtext/richtextbulletspage.cpp:192
+#: ../src/richtext/richtextbulletspage.cpp:193
+#: ../src/richtext/richtextliststylepage.cpp:252
+#: ../src/richtext/richtextliststylepage.cpp:255
+#: ../src/richtext/richtextliststylepage.cpp:256
+#: ../src/richtext/richtextsizepage.cpp:248
+msgid "Left"
+msgstr "Manca"
+
+#. TRANSLATORS: Keystroke for manipulating a tree control
+#: ../src/generic/datavgen.cpp:7134 ../src/richtext/richtextbulletspage.cpp:191
+#: ../src/richtext/richtextliststylepage.cpp:254
+#: ../src/richtext/richtextsizepage.cpp:249
+msgid "Right"
+msgstr "Diritta"
+
+#: ../src/generic/datectlg.cpp:90
+#, c-format
+msgid ""
+"\"%s\" is not in the expected date format, please enter it as e.g. \"%s\"."
+msgstr ""
+"« %s » ùn hè micca in u furmatu di data aspettatu ; ci vole à stampittallu "
+"cum’è, per indettu, « %s »."
+
+#: ../src/generic/datectlg.cpp:94
+msgid "Invalid date"
+msgstr "Data inaccettevule"
+
+#: ../src/generic/dbgrptg.cpp:159
+#, c-format
+msgid "Open file \"%s\""
+msgstr "Apre u schedariu « %s »"
+
+#: ../src/generic/dbgrptg.cpp:170
+#, c-format
+msgid "Enter command to open file \"%s\":"
+msgstr "Stampittà a cumanda per apre u schedariu « %s » :"
+
+#: ../src/generic/dbgrptg.cpp:230
+msgid "Executable files (*.exe)|*.exe|"
+msgstr "Schedarii d’esecuzione (*.exe)|*.exe|"
+
+#: ../src/generic/dbgrptg.cpp:300
+#, c-format
+msgid "Debug report \"%s\""
+msgstr "Raportu di spannatura « %s »"
+
+#: ../src/generic/dbgrptg.cpp:316
+msgid "A debug report has been generated in the directory\n"
+msgstr "Un raportu di spannatura hè statu creatu in u cartulare\n"
+
+#: ../src/generic/dbgrptg.cpp:317
+msgid "The following debug report will be generated\n"
+msgstr "Quellu raportu di spannatura serà ingeneratu\n"
+
+#: ../src/generic/dbgrptg.cpp:321
+msgid ""
+"The report contains the files listed below. If any of these files contain "
+"private information,\n"
+"please uncheck them and they will be removed from the report.\n"
+msgstr ""
+"U raportu cuntene i schedarii allistinati quì sottu. S’è unu di sti "
+"schedarii cuntene infurmazioni private,\n"
+"diselezziunatelu per cacciallu da u raportu.\n"
+
+#: ../src/generic/dbgrptg.cpp:323
+msgid ""
+"If you wish to suppress this debug report completely, please choose the "
+"\"Cancel\" button,\n"
+"but be warned that it may hinder improving the program, so if\n"
+"at all possible please do continue with the report generation.\n"
+msgstr ""
+"S’è vò vulete squassà u raportu di spannatura, ci vole à sceglie u buttone "
+"« Abbandunà »,\n"
+"ma sappiate chì què pò impedisce d’amendà u prugramma, dunque\n"
+"s’ella hè pussibule, cuntinuate cù a generazione di u raportu.\n"
+
+#: ../src/generic/dbgrptg.cpp:325
+msgid "              Thank you and we're sorry for the inconvenience!\n"
+msgstr "              Vi ringraziemu ; scusateci per stu penseru !\n"
+
+#: ../src/generic/dbgrptg.cpp:333
+msgid "&Debug report preview:"
+msgstr "&Fighjulata di u raportu di spannatura :"
+
+#: ../src/generic/dbgrptg.cpp:339
+msgid "&View..."
+msgstr "&Affissà…"
+
+#: ../src/generic/dbgrptg.cpp:359
+msgid "&Notes:"
+msgstr "&Note :"
+
+#: ../src/generic/dbgrptg.cpp:361
+msgid ""
+"If you have any additional information pertaining to this bug\n"
+"report, please enter it here and it will be joined to it:"
+msgstr ""
+"S’è vò avete d’altre infurmazioni relative à stu prublema,\n"
+"stampittatele quì è cusì, seranu aghjunte à u raportu :"
+
+#: ../src/generic/dcpsg.cpp:1627
+msgid "Cannot open file for PostScript printing!"
+msgstr "Ùn si pò micca apre u schedariu per una stampa PostScript !"
+
+#: ../src/generic/dirctrlg.cpp:402
+msgid "Computer"
+msgstr "Urdinatore"
+
+#: ../src/generic/dirctrlg.cpp:404
+msgid "Sections"
+msgstr "Sezzioni"
+
+#: ../src/generic/dirctrlg.cpp:482
+msgid "Home directory"
+msgstr "Cartulare d’accolta"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/generic/dirctrlg.cpp:484 ../src/propgrid/advprops.cpp:811
+msgid "Desktop"
+msgstr "Scagnu"
+
+#: ../src/generic/dirctrlg.cpp:528 ../src/generic/filectrlg.cpp:752
+msgid "Illegal directory name."
+msgstr "Nome di cartulare inaccettevule."
+
+#: ../src/generic/dirctrlg.cpp:528 ../src/generic/dirctrlg.cpp:546
+#: ../src/generic/dirctrlg.cpp:557 ../src/generic/dirdlgg.cpp:317
+#: ../src/generic/filectrlg.cpp:638 ../src/generic/filectrlg.cpp:752
+#: ../src/generic/filectrlg.cpp:766 ../src/generic/filectrlg.cpp:782
+#: ../src/generic/filectrlg.cpp:1356 ../src/generic/filectrlg.cpp:1387
+#: ../src/generic/filedlgg.cpp:362 ../src/gtk/filedlg.cpp:76
+msgid "Error"
+msgstr "Sbagliu"
+
+#: ../src/generic/dirctrlg.cpp:546 ../src/generic/filectrlg.cpp:766
+msgid "File name exists already."
+msgstr "U nome di schedariu esiste dighjà."
+
+#: ../src/generic/dirctrlg.cpp:557 ../src/generic/dirdlgg.cpp:317
+#: ../src/generic/filectrlg.cpp:638 ../src/generic/filectrlg.cpp:782
+msgid "Operation not permitted."
+msgstr "L’operazione ùn hè micca permessa."
+
+#: ../src/generic/dirdlgg.cpp:107 ../src/generic/filedlgg.cpp:207
+msgid "Create new directory"
+msgstr "Creà un novu cartulare"
+
+#: ../src/generic/dirdlgg.cpp:112 ../src/generic/filedlgg.cpp:203
+msgid "Go to home directory"
+msgstr "Andà à u cartulare d’accolta"
+
+#: ../src/generic/dirdlgg.cpp:143
+msgid "Show &hidden directories"
+msgstr "Affissà i cartulari &piattati"
+
+#: ../src/generic/dirdlgg.cpp:196
+#, c-format
+msgid ""
+"The directory '%s' does not exist\n"
+"Create it now?"
+msgstr ""
+"U cartulare « %s » ùn esiste micca\n"
+"Vulete creallu subitu ?"
+
+#: ../src/generic/dirdlgg.cpp:198
+msgid "Directory does not exist"
+msgstr "U cartulare ùn esiste micca"
+
+#: ../src/generic/dirdlgg.cpp:214
+#, c-format
+msgid ""
+"Failed to create directory '%s'\n"
+"(Do you have the required permissions?)"
+msgstr ""
+"Fiascu per creà u cartulare « %s »\n"
+"(Avete i permessi richiesti ?)"
+
+#: ../src/generic/dirdlgg.cpp:216
+msgid "Error creating directory"
+msgstr "Sbagliu durante a creazione di u cartulare"
+
+#: ../src/generic/dirdlgg.cpp:281
+msgid "You cannot add a new directory to this section."
+msgstr "Ùn si pò micca aghjughje un novu cartulare à sta sezzione."
+
+#: ../src/generic/dirdlgg.cpp:282
+msgid "Create directory"
+msgstr "Creà un cartulare"
+
+#: ../src/generic/dirdlgg.cpp:291 ../src/generic/dirdlgg.cpp:301
+#: ../src/generic/filectrlg.cpp:614 ../src/generic/filectrlg.cpp:623
+msgid "NewName"
+msgstr "NovuNome"
+
+#: ../src/generic/editlbox.cpp:135
+msgid "Edit item"
+msgstr "Mudificà l’elementu"
+
+#: ../src/generic/editlbox.cpp:143
+msgid "New item"
+msgstr "Novu elementu"
+
+#: ../src/generic/editlbox.cpp:151
+msgid "Delete item"
+msgstr "Squassà l’elementu"
+
+#: ../src/generic/editlbox.cpp:159
+msgid "Move up"
+msgstr "Move insù"
+
+#: ../src/generic/editlbox.cpp:164
+msgid "Move down"
+msgstr "Move inghjò"
+
+#: ../src/generic/fdrepdlg.cpp:108
+msgid "Search for:"
+msgstr "Circà :"
+
+#: ../src/generic/fdrepdlg.cpp:120
+msgid "Replace with:"
+msgstr "Rimpiazzà cù :"
+
+#: ../src/generic/fdrepdlg.cpp:140
+msgid "Whole word"
+msgstr "Parolla sana"
+
+#: ../src/generic/fdrepdlg.cpp:143
+msgid "Match case"
+msgstr "Rispettà a cassa"
+
+#: ../src/generic/fdrepdlg.cpp:156
+msgid "Search direction"
+msgstr "Direzzione di ricerca"
+
+#: ../src/generic/fdrepdlg.cpp:175
+msgid "&Replace"
+msgstr "&Rimpiazzà"
+
+#: ../src/generic/fdrepdlg.cpp:178
+msgid "Replace &all"
+msgstr "&Tuttu rimpiazzà"
+
+#: ../src/generic/filectrlg.cpp:246 ../src/generic/filectrlg.cpp:269
+msgid "<DIR>"
+msgstr "<CARTULARE>"
+
+#: ../src/generic/filectrlg.cpp:248 ../src/generic/filectrlg.cpp:271
+msgid "<LINK>"
+msgstr "<LIAME>"
+
+#: ../src/generic/filectrlg.cpp:250 ../src/generic/filectrlg.cpp:273
+msgid "<DRIVE>"
+msgstr "<LETTORE>"
+
+#: ../src/generic/filectrlg.cpp:275
+#, c-format
+msgid "%ld byte"
+msgid_plural "%ld bytes"
+msgstr[0] "%ld ottettu"
+msgstr[1] "%ld ottetti"
+
+#: ../src/generic/filectrlg.cpp:420
+msgid "Name"
+msgstr "Nome"
+
+#: ../src/generic/filectrlg.cpp:421 ../src/richtext/richtextformatdlg.cpp:361
+#: ../src/richtext/richtextsizepage.cpp:298
+msgid "Size"
+msgstr "Dimensione"
+
+#: ../src/generic/filectrlg.cpp:422
+msgid "Type"
+msgstr "Tipu"
+
+#: ../src/generic/filectrlg.cpp:423
+msgid "Modified"
+msgstr "Mudificatu"
+
+#: ../src/generic/filectrlg.cpp:426
+msgid "Permissions"
+msgstr "Permessi"
+
+#: ../src/generic/filectrlg.cpp:429
+msgid "Attributes"
+msgstr "Attributi"
+
+#: ../src/generic/filectrlg.cpp:936
+msgid "Current directory:"
+msgstr "Cartulare attuale :"
+
+#: ../src/generic/filectrlg.cpp:979
+msgid "Show &hidden files"
+msgstr "Affissà i schedarii &piattati"
+
+#: ../src/generic/filectrlg.cpp:1355
+msgid "Illegal file specification."
+msgstr "Specificazione di schedariu illegale."
+
+#: ../src/generic/filectrlg.cpp:1387
+msgid "Directory doesn't exist."
+msgstr "U cartulare ùn esiste micca."
+
+#: ../src/generic/filedlgg.cpp:195
+msgid "View files as a list view"
+msgstr "Vede i schedarii in una lista"
+
+#: ../src/generic/filedlgg.cpp:197
+msgid "View files as a detailed view"
+msgstr "Vede i schedarii in una lista detagliata"
+
+#: ../src/generic/filedlgg.cpp:200
+msgid "Go to parent directory"
+msgstr "Andà à u cartulare superiore"
+
+#: ../src/generic/filedlgg.cpp:351 ../src/gtk/filedlg.cpp:59
+#, c-format
+msgid "File '%s' already exists, do you really want to overwrite it?"
+msgstr "U schedariu « %s » esiste dighjà, vulete rimpiazzallu ?"
+
+#: ../src/generic/filedlgg.cpp:354 ../src/gtk/filedlg.cpp:62
+msgid "Confirm"
+msgstr "Cunfirmà"
+
+#: ../src/generic/filedlgg.cpp:362 ../src/gtk/filedlg.cpp:75
+msgid "Please choose an existing file."
+msgstr "Sciglite un schedariu esistente."
+
+#: ../src/generic/filepickerg.cpp:64
+msgid "..."
+msgstr "…"
+
+#: ../src/generic/fontdlgg.cpp:76 ../src/richtext/richtextformatdlg.cpp:519
+msgid "ABCDEFGabcdefg12345"
+msgstr "ABCDEFGabcdefg12345"
+
+#: ../src/generic/fontdlgg.cpp:315
+msgid "Roman"
+msgstr "Rumanu"
+
+#: ../src/generic/fontdlgg.cpp:316
+msgid "Decorative"
+msgstr "Decurativu"
+
+#: ../src/generic/fontdlgg.cpp:317
+msgid "Modern"
+msgstr "Mudernu"
+
+#: ../src/generic/fontdlgg.cpp:318
+msgid "Script"
+msgstr "Scenariu"
+
+#: ../src/generic/fontdlgg.cpp:319
+msgid "Swiss"
+msgstr "Svizzera"
+
+#: ../src/generic/fontdlgg.cpp:320
+msgid "Teletype"
+msgstr "Teletipu"
+
+#: ../src/generic/fontdlgg.cpp:321 ../src/generic/fontdlgg.cpp:324
+msgid "Normal"
+msgstr "Nurmale"
+
+#: ../src/generic/fontdlgg.cpp:323
+msgid "Slant"
+msgstr "Pendicatu"
+
+#: ../src/generic/fontdlgg.cpp:325
+msgid "Light"
+msgstr "Chjaru"
+
+#: ../src/generic/fontdlgg.cpp:363
+msgid "&Font family:"
+msgstr "&Famiglia di a grafia :"
+
+#: ../src/generic/fontdlgg.cpp:367 ../src/generic/fontdlgg.cpp:369
+msgid "The font family."
+msgstr "A famiglia di a grafia."
+
+#: ../src/generic/fontdlgg.cpp:374 ../src/richtext/richtextstylepage.cpp:105
+msgid "&Style:"
+msgstr "&Stilu :"
+
+#: ../src/generic/fontdlgg.cpp:378 ../src/generic/fontdlgg.cpp:380
+msgid "The font style."
+msgstr "U stilu di a grafia."
+
+#: ../src/generic/fontdlgg.cpp:385
+msgid "&Weight:"
+msgstr "&Spessore :"
+
+#: ../src/generic/fontdlgg.cpp:389 ../src/generic/fontdlgg.cpp:391
+msgid "The font weight."
+msgstr "A spessore di a grafia."
+
+#: ../src/generic/fontdlgg.cpp:399
+msgid "C&olour:"
+msgstr "&Culore :"
+
+#: ../src/generic/fontdlgg.cpp:407 ../src/generic/fontdlgg.cpp:409
+msgid "The font colour."
+msgstr "U culore di a grafia."
+
+#: ../src/generic/fontdlgg.cpp:415
+msgid "&Point size:"
+msgstr "&Dimensione di puntu :"
+
+#: ../src/generic/fontdlgg.cpp:420 ../src/generic/fontdlgg.cpp:422
+#: ../src/generic/fontdlgg.cpp:426 ../src/generic/fontdlgg.cpp:428
+msgid "The font point size."
+msgstr "A dimensione di puntu di a grafia."
+
+#: ../src/generic/fontdlgg.cpp:439 ../src/generic/fontdlgg.cpp:441
+msgid "Whether the font is underlined."
+msgstr "S’è a grafia hè sottulineata."
+
+#: ../src/generic/fontdlgg.cpp:448 ../src/html/helpwnd.cpp:1215
+msgid "Preview:"
+msgstr "Fighjulata :"
+
+#: ../src/generic/fontdlgg.cpp:452 ../src/generic/fontdlgg.cpp:454
+msgid "Shows the font preview."
+msgstr "Affisseghja una fighjulata di a grafia."
+
+#: ../src/generic/fontdlgg.cpp:464 ../src/generic/fontdlgg.cpp:483
+msgid "Click to cancel the font selection."
+msgstr "Cliccu per abbandunà a selezzione di a grafia."
+
+#: ../src/generic/fontdlgg.cpp:469 ../src/generic/fontdlgg.cpp:471
+#: ../src/generic/fontdlgg.cpp:476 ../src/generic/fontdlgg.cpp:478
+msgid "Click to confirm the font selection."
+msgstr "Cliccu per cunfirmà a selezzione di a grafia."
+
+#: ../src/generic/fontpickerg.cpp:50 ../src/gtk/fontdlg.cpp:77
+msgid "Choose font"
+msgstr "Sceglie a grafia"
+
+#: ../src/generic/grid.cpp:6542
+msgid ""
+"Error copying grid to the clipboard. Either selected cells were not "
+"contiguous or no cell was selected."
+msgstr ""
+"Sbagliu accadutu durante a copia dia quadrittera in u preme’papei. Sia e "
+"cellule selezziunate ùn eranu micca appicciate, o ùn ci era nisuna cellula "
+"selezziunata."
+
+#: ../src/generic/grid.cpp:12739
+msgid "Grid Corner"
+msgstr "Scornu di a quadrittera"
+
+#: ../src/generic/grid.cpp:12741
+#, c-format
+msgid "Column %s Header"
+msgstr "Intestatura di culonna %s"
+
+#: ../src/generic/grid.cpp:12743
+#, c-format
+msgid "Row %s Header"
+msgstr "Intestatura di linea %s"
+
+#: ../src/generic/grid.cpp:12745
+#, c-format
+msgid "Column %s: %s"
+msgstr "Culonna %s : %s"
+
+#: ../src/generic/grid.cpp:12749
+#, c-format
+msgid "Row %s: %s"
+msgstr "Linea %s : %s"
+
+#: ../src/generic/grid.cpp:12753
+#, c-format
+msgid "Row %s, Column %s: %s"
+msgstr "Linea %s, culonna %s : %s"
+
+#: ../src/generic/helpext.cpp:257
+#, c-format
+msgid "Help directory \"%s\" not found."
+msgstr "Ùn si pò truvà u cartulare d’aiutu « %s »."
+
+#: ../src/generic/helpext.cpp:265
+#, c-format
+msgid "Help file \"%s\" not found."
+msgstr "Ùn si pò truvà u schedariu d’aiutu « %s »."
+
+#: ../src/generic/helpext.cpp:284
+#, c-format
+msgid "Line %lu of map file \"%s\" has invalid syntax, skipped."
+msgstr ""
+"A linea %lu di u schedariu di cartugrafia « %s » hà una sintassa incurretta "
+"è hè stata ignurata."
+
+#: ../src/generic/helpext.cpp:292
+#, c-format
+msgid "No valid mappings found in the file \"%s\"."
+msgstr "Nisuna cartugrafia accettevule si trova in u schedariu « %s »."
+
+#: ../src/generic/helpext.cpp:435
+msgid "No entries found."
+msgstr "Nisunu elementu trovu."
+
+#: ../src/generic/helpext.cpp:444 ../src/generic/helpext.cpp:445
+msgid "Help Index"
+msgstr "Indice d’aiutu"
+
+#: ../src/generic/helpext.cpp:448
+msgid "Relevant entries:"
+msgstr "Elementi pertinente :"
+
+#: ../src/generic/helpext.cpp:449
+msgid "Entries found"
+msgstr "Elementi trovi"
+
+#: ../src/generic/hyperlinkg.cpp:170
+msgid "&Copy URL"
+msgstr "&Cupià l’indirizzu"
+
+#: ../src/generic/infobar.cpp:119
+msgid "Hide this notification message."
+msgstr "Piattà stu messaghju di nutificazione."
+
+#. TRANSLATORS: %s will be either the application name or "Application"
+#: ../src/generic/logg.cpp:257
+#, c-format
+msgid "%s Error"
+msgstr "Sbagliu %s"
+
+#. TRANSLATORS: %s will be either the application name or "Application"
+#: ../src/generic/logg.cpp:263
+#, c-format
+msgid "%s Warning"
+msgstr "Avertimentu %s"
+
+#. TRANSLATORS: %s will be either the application name or "Application"
+#: ../src/generic/logg.cpp:273
+#, c-format
+msgid "%s Information"
+msgstr "Infurmazione %s"
+
+#: ../src/generic/logg.cpp:276
+msgid "Application"
+msgstr "Appiecazione"
+
+#: ../src/generic/logg.cpp:549
+msgid "Save log contents to file"
+msgstr "Arregistrà u cuntenutu di u ghjurnale in un schedariu"
+
+#: ../src/generic/logg.cpp:551
+msgid "C&lear"
+msgstr "&Viutà"
+
+#: ../src/generic/logg.cpp:551
+msgid "Clear the log contents"
+msgstr "Viota u cuntenutu di u ghjurnale"
+
+#: ../src/generic/logg.cpp:553
+msgid "Close this window"
+msgstr "Chjode sta finestra"
+
+#: ../src/generic/logg.cpp:554
+msgid "&Log"
+msgstr "&Ghjurnale"
+
+#: ../src/generic/logg.cpp:610 ../src/generic/logg.cpp:992
+msgid "Can't save log contents to file."
+msgstr "Ùn si pò micca arregistrà u cuntenutu di u ghjurnale in un schedariu."
+
+#: ../src/generic/logg.cpp:613
+#, c-format
+msgid "Log saved to the file '%s'."
+msgstr "Ghjurnale arregistratu in u schedariu « %s »."
+
+#: ../src/generic/logg.cpp:719
+msgid "&Details"
+msgstr "&Detaglii"
+
+#: ../src/generic/logg.cpp:972
+msgid "Failed to copy dialog contents to the clipboard."
+msgstr "Fiascu per cupià u cuntenutu di u dialogu in u preme’papei."
+
+#: ../src/generic/logg.cpp:1022
+#, c-format
+msgid "Append log to file '%s' (choosing [No] will overwrite it)?"
+msgstr ""
+"Aghjunghje u ghjurnale à a fine di u schedariu « %s » (sceglie [Nò] per "
+"rimpiazzallu) ?"
+
+#: ../src/generic/logg.cpp:1024
+msgid "Question"
+msgstr "Dumanda"
+
+#: ../src/generic/logg.cpp:1038
+msgid "invalid message box return value"
+msgstr "u dialogu di messaghju hà restituitu un valore inaccettevule"
+
+#: ../src/generic/notifmsgg.cpp:129
+msgid "Notice"
+msgstr "Avertimentu"
+
+#: ../src/generic/preferencesg.cpp:118
+#, c-format
+msgid "%s Preferences"
+msgstr "Preferenze di %s"
+
+#: ../src/generic/printps.cpp:143
+msgid "Printing..."
+msgstr "Stampa…"
+
+#: ../src/generic/printps.cpp:160 ../src/gtk/print.cpp:1076
+#: ../src/msw/printwin.cpp:235
+msgid "Could not start printing."
+msgstr "Ùn si pò micca principià a stampa."
+
+#: ../src/generic/printps.cpp:183
+#, c-format
+msgid "Printing page %d..."
+msgstr "Stampa di a pagina %d…"
+
+#: ../src/generic/prntdlgg.cpp:171
+msgid "Printer options"
+msgstr "Ozzioni di a stampetta"
+
+#: ../src/generic/prntdlgg.cpp:176
+msgid "Print to File"
+msgstr "Stampà in un schedariu"
+
+#: ../src/generic/prntdlgg.cpp:179
+msgid "Setup..."
+msgstr "Cunfigurà…"
+
+#: ../src/generic/prntdlgg.cpp:187
+msgid "Printer:"
+msgstr "Stampetta :"
+
+#: ../src/generic/prntdlgg.cpp:195
+msgid "Status:"
+msgstr "Statu :"
+
+#: ../src/generic/prntdlgg.cpp:206
+msgid "All"
+msgstr "Tuttu"
+
+#: ../src/generic/prntdlgg.cpp:207
+msgid "Pages"
+msgstr "Pagine"
+
+#: ../src/generic/prntdlgg.cpp:215
+msgid "Print Range"
+msgstr "Stesa di stampa"
+
+#: ../src/generic/prntdlgg.cpp:229
+msgid "From:"
+msgstr "Da :"
+
+#: ../src/generic/prntdlgg.cpp:233
+msgid "To:"
+msgstr "À :"
+
+#: ../src/generic/prntdlgg.cpp:238
+msgid "Copies:"
+msgstr "Copie :"
+
+#: ../src/generic/prntdlgg.cpp:288
+msgid "PostScript file"
+msgstr "Schedariu PostScript"
+
+#: ../src/generic/prntdlgg.cpp:439
+msgid "Print Setup"
+msgstr "Cunfigurazione di a stampa"
+
+#: ../src/generic/prntdlgg.cpp:483
+msgid "Printer"
+msgstr "Stampetta"
+
+#: ../src/generic/prntdlgg.cpp:501
+msgid "Default printer"
+msgstr "Stampetta predefinita"
+
+#: ../src/generic/prntdlgg.cpp:595 ../src/generic/prntdlgg.cpp:782
+#: ../src/generic/prntdlgg.cpp:822 ../src/generic/prntdlgg.cpp:835
+#: ../src/generic/prntdlgg.cpp:1031 ../src/generic/prntdlgg.cpp:1036
+msgid "Paper size"
+msgstr "Dimensione di a carta"
+
+#: ../src/generic/prntdlgg.cpp:604 ../src/generic/prntdlgg.cpp:847
+msgid "Portrait"
+msgstr "Verticale"
+
+#: ../src/generic/prntdlgg.cpp:605 ../src/generic/prntdlgg.cpp:848
+msgid "Landscape"
+msgstr "Orizuntale"
+
+#: ../src/generic/prntdlgg.cpp:607 ../src/generic/prntdlgg.cpp:849
+msgid "Orientation"
+msgstr "Orientazione"
+
+#: ../src/generic/prntdlgg.cpp:610
+msgid "Options"
+msgstr "Ozzioni"
+
+#: ../src/generic/prntdlgg.cpp:612
+msgid "Print in colour"
+msgstr "Stampà in culore"
+
+#: ../src/generic/prntdlgg.cpp:621
+msgid "Print spooling"
+msgstr "File d’attesa di stampa"
+
+#: ../src/generic/prntdlgg.cpp:623
+msgid "Printer command:"
+msgstr "Cumanda per a stampetta :"
+
+#: ../src/generic/prntdlgg.cpp:631
+msgid "Printer options:"
+msgstr "Ozzioni di a stampetta :"
+
+#: ../src/generic/prntdlgg.cpp:860
+msgid "Left margin (mm):"
+msgstr "Margine à manca (mm) :"
+
+#: ../src/generic/prntdlgg.cpp:861
+msgid "Top margin (mm):"
+msgstr "Margine superiore (mm) :"
+
+#: ../src/generic/prntdlgg.cpp:872
+msgid "Right margin (mm):"
+msgstr "Margine à diritta (mm) :"
+
+#: ../src/generic/prntdlgg.cpp:873
+msgid "Bottom margin (mm):"
+msgstr "Margine inferiore (mm) :"
+
+#: ../src/generic/prntdlgg.cpp:896
+msgid "Printer..."
+msgstr "Stampetta…"
+
+#: ../src/generic/progdlgg.cpp:246
+msgid "&Skip"
+msgstr "&Tralascià"
+
+#: ../src/generic/progdlgg.cpp:347 ../src/generic/progdlgg.cpp:626
+msgid "Unknown"
+msgstr "Scunnisciutu"
+
+#: ../src/generic/progdlgg.cpp:451 ../src/msw/progdlg.cpp:526
+msgid "Done."
+msgstr "Compiu."
+
+#: ../src/generic/srchctlg.cpp:55 ../src/gtk/srchctrl.cpp:206
+#: ../src/html/helpwnd.cpp:530 ../src/html/helpwnd.cpp:545
+msgid "Search"
+msgstr "Ricercà"
+
+#: ../src/generic/tabg.cpp:1026
+msgid "Could not find tab for id"
+msgstr "Ùn si pò micca truvà l’unghjetta per l’identificazione"
+
+#: ../src/generic/tipdlg.cpp:136
+msgid "Tips not available, sorry!"
+msgstr "Per disgrazia, e minichichje ùn sò micca dispunibule !"
+
+#: ../src/generic/tipdlg.cpp:197
+msgid "Tip of the Day"
+msgstr "Minichichja oghjinca"
+
+#: ../src/generic/tipdlg.cpp:207
+msgid "Did you know..."
+msgstr "A sapete..."
+
+#: ../src/generic/tipdlg.cpp:232
+msgid "&Show tips at startup"
+msgstr "Affissà e &minichichje à l’avvià"
+
+#: ../src/generic/tipdlg.cpp:236
+msgid "&Next Tip"
+msgstr "Minichichja &seguente"
+
+#: ../src/generic/wizard.cpp:411
+msgid "&Next >"
+msgstr "&Seguente >"
+
+#: ../src/generic/wizard.cpp:412
+msgid "&Finish"
+msgstr "&Piantà"
+
+#: ../src/generic/wizard.cpp:420
+msgid "< &Back"
+msgstr "< &Precedente"
+
+#: ../src/gtk/aboutdlg.cpp:204
+msgid "translator-credits"
+msgstr "Ringraziamenti à i traduttori"
+
+#: ../src/gtk/app.cpp:517
+msgid ""
+"WARNING: using XIM input method is unsupported and may result in problems "
+"with input handling and flickering. Consider unsetting GTK_IM_MODULE or "
+"setting to \"ibus\"."
+msgstr ""
+"AVERTIMENTU : l’usu di a metoda d’entrata XIM ùn hè micca accettatu è pò "
+"cagiunà prublemi cù a ghjestione di l’interfaccia grafica è scintillime. "
+"Pensate à disattivà GTK_IM_MODULE o definisce à « ibus »."
+
+#: ../src/gtk/app.cpp:569
+msgid "Unable to initialize GTK+, is DISPLAY set properly?"
+msgstr "Impussibule d’inizià GTK+ ; DISPLAY seria definitu currettamente ?"
+
+#: ../src/gtk/filedlg.cpp:89 ../src/gtk/filepicker.cpp:255
+#, c-format
+msgid "Changing current directory to \"%s\" failed"
+msgstr "Fiascu di cambiamentu di u cartulare attuale versu « %s »"
+
+#: ../src/gtk/font.cpp:548
+msgid ""
+"Using private fonts is not supported on this system: Pango library is too "
+"old, 1.38 or later required."
+msgstr ""
+"L’usu di e grafie private ùn hè micca accettatu da stu sistema : a "
+"biblioteca Pango hè troppu vechja ; a versione 1.38 o più recente hè "
+"richiesta."
+
+#: ../src/gtk/font.cpp:558
+msgid "Failed to create font configuration object."
+msgstr "Ùn si pò micca creà l’oggettu di cunfigurazione di grafia."
+
+#: ../src/gtk/font.cpp:568
+#, c-format
+msgid "Failed to add custom font \"%s\"."
+msgstr "Ùn si pò micca aghjunghje a grafia persunalizata « %s »."
+
+#: ../src/gtk/font.cpp:576
+msgid "Failed to register font configuration using private fonts."
+msgstr ""
+"Ùn si pò micca arregistrà a cunfigurazione di grafia impieghendu fonte "
+"private."
+
+#: ../src/gtk/glcanvas.cpp:117 ../src/gtk/glcanvas.cpp:132
+msgid "Fatal Error"
+msgstr "Sbagliu impurtantissimu"
+
+#: ../src/gtk/glcanvas.cpp:117
+msgid ""
+"This program wasn't compiled with EGL support required under Wayland, "
+"either\n"
+"install EGL libraries and rebuild or run it under X11 backend by setting\n"
+"environment variable GDK_BACKEND=x11 before starting your program."
+msgstr ""
+"Stu prugramma ùn hè statu cumpilatu cù l’ozzione EGL chì hè richiesta per "
+"funziunà sottu Wayland, dunque, ci vole à installà e bibliuteche EGL è "
+"custruisce torna u prugramma, osinnò, lanciallu sottu l’ambiente X11 "
+"definiscendu a variabile d’ambiente GDK_BACKEND=x11 nanzu di lancià u vostru "
+"prugramma."
+
+#: ../src/gtk/glcanvas.cpp:132
+msgid ""
+"wxGLCanvas is only supported on Wayland and X11 currently.  You may be able "
+"to\n"
+"work around this by setting environment variable GDK_BACKEND=x11 before\n"
+"starting your program."
+msgstr ""
+"Attualmente, wxGLCanvas hè accettatu solu nant’à Wayland è X11.\n"
+"Si pò circurtà què definiscendu a variabile d’ambiente\n"
+"GDK_BACKEND=x11 nanzu di lancià u vostru prugramma."
+
+#: ../src/gtk/mdi.cpp:433
+msgid "MDI child"
+msgstr "Zitellu MDI"
+
+#: ../src/gtk/power.cpp:188
+#, c-format
+msgid "Failed to open D-Bus connection to the login manager: %s"
+msgstr ""
+"Fiascu per apre a cunnessione D-Bus per u ghjestiunariu di cunnessione : %s"
+
+#: ../src/gtk/power.cpp:214
+msgid "wxWidgets application"
+msgstr "Appiecazione wxWidgets"
+
+#: ../src/gtk/power.cpp:226
+msgid "Application needs to keep running"
+msgstr "L’appiecazione hà bisognu di cuntinuà à funziunà"
+
+#: ../src/gtk/power.cpp:233
+msgid "Clean up before suspend"
+msgstr "Nettata prima d’interrompe"
+
+#: ../src/gtk/power.cpp:259
+#, c-format
+msgid "Failed to inhibit sleep: %s"
+msgstr "Fiascu per impedisce a veghja : %s"
+
+#: ../src/gtk/power.cpp:265
+msgid "Unexpected response to D-Bus \"Inhibit\" request."
+msgstr "Risposta inespettata à a richiesta D-Bus d’inibizione."
+
+#: ../src/gtk/print.cpp:218
+msgid "Custom size"
+msgstr "Dimensione persunalizata"
+
+#: ../src/gtk/print.cpp:752
+#, c-format
+msgid "Error while printing: %s"
+msgstr "Sbagliu durante a stampa : %s"
+
+#: ../src/gtk/print.cpp:816
+msgid "Page Setup"
+msgstr "Parametri di a pagina"
+
+#: ../src/gtk/webview_webkit.cpp:932
+msgid "Retrieving JavaScript script output is not supported with WebKit v1"
+msgstr ""
+"Riacquistà l’esciuta di u scenariu JavaScript ùn hè micca accettatu cù "
+"WebKit v1"
+
+#: ../src/gtk/webview_webkit2.cpp:1098
+msgid ""
+"Setting proxy is not supported by WebKit, at least version 2.16 is required."
+msgstr ""
+"A definizione di u proxy ùn hè micca accettata da WebKit ; a versione 2.16 "
+"minima hè richiesta."
+
+#: ../src/gtk/webview_webkit2.cpp:1104
+msgid "This program was compiled without support for setting WebKit proxy."
+msgstr ""
+"Stu prugramma hè statu custruitu senza piglià in contu a definizione di u "
+"proxy WebKit."
+
+#: ../src/gtk/window.cpp:6289
+msgid ""
+"GTK+ installed on this machine is too old to support screen compositing, "
+"please install GTK+ 2.12 or later."
+msgstr ""
+"A versione di GTK+ installata nant’à sta mascina hè troppu anziana per "
+"permette a cumpusizione di screnu ; ci vole à installà GTK+ 2.12 o più "
+"recente."
+
+#: ../src/gtk/window.cpp:6307
+msgid ""
+"Compositing not supported by this system, please enable it in your Window "
+"Manager."
+msgstr ""
+"A cumpusizione di screnu ùn hè micca accettata da stu sistema ; ci vole à "
+"attivalla in u vostru Ghjestiunariu Windows."
+
+#: ../src/gtk/window.cpp:6318
+msgid ""
+"This program was compiled with a too old version of GTK+, please rebuild "
+"with GTK+ 2.12 or newer."
+msgstr ""
+"Stu prugramma hè statu cumpilatu cù una versione troppu anziana di GTK+ ; ci "
+"vole à custruiscelu torna cù GTK+ 2.12 o più recente."
+
+#: ../src/html/chm.cpp:138
+#, c-format
+msgid "Failed to open CHM archive '%s'."
+msgstr "Fiascu à l’apertura di l’archiviu CHM « %s »."
+
+#: ../src/html/chm.cpp:270
+#, c-format
+msgid "Could not extract %s into %s: %s"
+msgstr "Ùn si pò micca estrae %s in %s : %s"
+
+#: ../src/html/chm.cpp:324
+msgid "no error"
+msgstr "nisunu sbagliu"
+
+#: ../src/html/chm.cpp:326
+msgid "bad arguments to library function"
+msgstr "parametri gattivi per a funzione di biblioteca"
+
+#: ../src/html/chm.cpp:328
+msgid "error opening file"
+msgstr "sbagliu à l’apertura di u schedariu"
+
+#: ../src/html/chm.cpp:330
+msgid "read error"
+msgstr "sbagliu di lettura"
+
+#: ../src/html/chm.cpp:332
+msgid "write error"
+msgstr "sbagliu di scrittura"
+
+#: ../src/html/chm.cpp:334
+msgid "seek error"
+msgstr "sbagliu di pusizione"
+
+#: ../src/html/chm.cpp:338
+msgid "bad signature"
+msgstr "segnatura gattiva"
+
+#: ../src/html/chm.cpp:340
+msgid "error in data format"
+msgstr "sbagliu in u furmatu di i dati"
+
+#: ../src/html/chm.cpp:342
+msgid "checksum error"
+msgstr "sbagliu di a somma di cuntrollu"
+
+#: ../src/html/chm.cpp:344
+msgid "compression error"
+msgstr "sbagliu di cumpressione"
+
+#: ../src/html/chm.cpp:346
+msgid "decompression error"
+msgstr "sbagliu di scumpressione"
+
+#: ../src/html/chm.cpp:437
+#, c-format
+msgid "Could not locate file '%s'."
+msgstr "Ùn si pò micca lucalizà u schedariu « %s »."
+
+#: ../src/html/chm.cpp:711
+#, c-format
+msgid "Could not create temporary file '%s'"
+msgstr "Ùn si pò micca creà u schedariu timpurariu « %s »"
+
+#: ../src/html/chm.cpp:718
+#, c-format
+msgid "Extraction of '%s' into '%s' failed."
+msgstr "Fiascu di l’estrazzione di « %s » in « %s »."
+
+#: ../src/html/chm.cpp:806 ../src/html/chm.cpp:863
+msgid "CHM handler currently supports only local files!"
+msgstr "Attualmente, u ghjestiunariu CHM accetta solu i schedarii lucali !"
+
+#: ../src/html/chm.cpp:827
+msgid "Link contained '//', converted to absolute link."
+msgstr "U liame cuntinia « // » è hè statu cunvertitu in liame assulutu."
+
+#: ../src/html/helpctrl.cpp:59
+#, c-format
+msgid "Help: %s"
+msgstr "Aiutu : %s"
+
+#: ../src/html/helpctrl.cpp:155
+#, c-format
+msgid "Adding book %s"
+msgstr "Aghjuntu di u libru %s"
+
+#: ../src/html/helpdata.cpp:295
+#, c-format
+msgid "Cannot open contents file: %s"
+msgstr "Ùn si pò micca apre u schedariu di tavula di cuntenutu : %s"
+
+#: ../src/html/helpdata.cpp:309
+#, c-format
+msgid "Cannot open index file: %s"
+msgstr "Ùn si pò micca apre u schedariu d’indice : %s"
+
+#: ../src/html/helpdata.cpp:643
+msgid "noname"
+msgstr "senzanome"
+
+#: ../src/html/helpdata.cpp:652
+#, c-format
+msgid "Cannot open HTML help book: %s"
+msgstr "Ùn si pò micca apre u manuale d’aiutu HTML : %s"
+
+#: ../src/html/helpwnd.cpp:315
+msgid "Displays help as you browse the books on the left."
+msgstr "Affissera di l’aiutu quandu si naviga nant’à i manuali à manu manca."
+
+#: ../src/html/helpwnd.cpp:411 ../src/html/helpwnd.cpp:1100
+#: ../src/html/helpwnd.cpp:1735
+msgid "(bookmarks)"
+msgstr "(indette)"
+
+#: ../src/html/helpwnd.cpp:424
+msgid "Add current page to bookmarks"
+msgstr "Aghjunghje a pagina currente à l’indette"
+
+#: ../src/html/helpwnd.cpp:425
+msgid "Remove current page from bookmarks"
+msgstr "Caccià a pagina currente da l’indette"
+
+#: ../src/html/helpwnd.cpp:470
+msgid "Contents"
+msgstr "Tavula di cuntenutu"
+
+#: ../src/html/helpwnd.cpp:485
+msgid "Find"
+msgstr "Truvà"
+
+#: ../src/html/helpwnd.cpp:487
+msgid "Show all"
+msgstr "Tuttu affissà"
+
+#: ../src/html/helpwnd.cpp:497
+msgid ""
+"Display all index items that contain given substring. Search is case "
+"insensitive."
+msgstr ""
+"Affissà tutti l’elementi di l’indice chì cuntenenu una sottucatena "
+"particulare. A ricerca ùn sfarenzieghja micca maiuscule è minuscule."
+
+#: ../src/html/helpwnd.cpp:498
+msgid "Show all items in index"
+msgstr "Affissà tutti l’elementi di l’indice"
+
+#: ../src/html/helpwnd.cpp:528
+msgid "Case sensitive"
+msgstr "Sfarenzià maiuscule è minuscule"
+
+#: ../src/html/helpwnd.cpp:529
+msgid "Whole words only"
+msgstr "Solu e parolle sane"
+
+#: ../src/html/helpwnd.cpp:532
+msgid ""
+"Search contents of help book(s) for all occurrences of the text you typed "
+"above"
+msgstr ""
+"Ricercà in a tavula di cuntenutu di i manuali d’aiutu tutte l’occurrenze di "
+"u testu stampittatu quì sopra"
+
+#: ../src/html/helpwnd.cpp:653
+msgid "Show/hide navigation panel"
+msgstr "Affissà o piattà u pannellu di navigazione"
+
+#: ../src/html/helpwnd.cpp:655
+msgid "Go back"
+msgstr "Ritornu"
+
+#: ../src/html/helpwnd.cpp:656
+msgid "Go forward"
+msgstr "Cuntinuà"
+
+#: ../src/html/helpwnd.cpp:658
+msgid "Go one level up in document hierarchy"
+msgstr "Andà à u livellu superiore in a ierarchia di u ducumentu"
+
+#: ../src/html/helpwnd.cpp:666 ../src/html/helpwnd.cpp:1547
+msgid "Open HTML document"
+msgstr "Apre u ducumentu HTML"
+
+#: ../src/html/helpwnd.cpp:670
+msgid "Print this page"
+msgstr "Stampà sta pagina"
+
+#: ../src/html/helpwnd.cpp:674
+msgid "Display options dialog"
+msgstr "Affissà a finestra di l’ozzioni"
+
+#: ../src/html/helpwnd.cpp:795
+msgid "Please choose the page to display:"
+msgstr "Sciglite a pagina à affissà :"
+
+#: ../src/html/helpwnd.cpp:796
+msgid "Help Topics"
+msgstr "Rubriche d’aiutu"
+
+#: ../src/html/helpwnd.cpp:852
+msgid "Searching..."
+msgstr "Ricerca…"
+
+#: ../src/html/helpwnd.cpp:853
+msgid "No matching page found yet"
+msgstr "Nisuna pagina currispundente ùn hè stata ancu trova"
+
+#: ../src/html/helpwnd.cpp:870
+#, c-format
+msgid "Found %i matches"
+msgstr "%i currispundenze sò state trove"
+
+#: ../src/html/helpwnd.cpp:958
+msgid "(Help)"
+msgstr "(Aiutu)"
+
+#: ../src/html/helpwnd.cpp:1026
+#, c-format
+msgid "%d of %lu"
+msgstr "%d nant’à %lu"
+
+#: ../src/html/helpwnd.cpp:1028
+#, c-format
+msgid "%lu of %lu"
+msgstr "%lu nant’à %lu"
+
+#: ../src/html/helpwnd.cpp:1047
+msgid "Search in all books"
+msgstr "Circà in tutti i manuali"
+
+#: ../src/html/helpwnd.cpp:1193
+msgid "Help Browser Options"
+msgstr "Ozzioni di u navigatore di l’aiutu"
+
+#: ../src/html/helpwnd.cpp:1198
+msgid "Normal font:"
+msgstr "Grafia nurmale :"
+
+#: ../src/html/helpwnd.cpp:1199
+msgid "Fixed font:"
+msgstr "Dimensione fissa di a grafia :"
+
+#: ../src/html/helpwnd.cpp:1200
+msgid "Font size:"
+msgstr "Dimensione di a grafia :"
+
+#: ../src/html/helpwnd.cpp:1245
+msgid "font size"
+msgstr "dimensione di a grafia"
+
+#: ../src/html/helpwnd.cpp:1256
+msgid "Normal face<br>and <u>underlined</u>. "
+msgstr "Nurmale<br>è <u>sottulineata</u>. "
+
+#: ../src/html/helpwnd.cpp:1257
+msgid "<i>Italic face.</i> "
+msgstr "<i>Cursiva.</i> "
+
+#: ../src/html/helpwnd.cpp:1258
+msgid "<b>Bold face.</b> "
+msgstr "<b>Grassa.</b> "
+
+#: ../src/html/helpwnd.cpp:1259
+msgid "<b><i>Bold italic face.</i></b><br>"
+msgstr "<b><i>Grassa cursiva.</i></b><br>"
+
+#: ../src/html/helpwnd.cpp:1262
+msgid "Fixed size face.<br> <b>bold</b> <i>italic</i> "
+msgstr "Grafia di dimensione fissa.<br> <b>grassa</b> <i>cursiva</i> "
+
+#: ../src/html/helpwnd.cpp:1263
+msgid "<b><i>bold italic <u>underlined</u></i></b><br>"
+msgstr "<b><i>grassa cursiva <u>sottulineata</u></i></b><br>"
+
+#: ../src/html/helpwnd.cpp:1524
+msgid "Help Printing"
+msgstr "Aiutu per stampà"
+
+#: ../src/html/helpwnd.cpp:1527
+msgid "Cannot print empty page."
+msgstr "Ùn si pò micca stampà una pagina viota."
+
+#: ../src/html/helpwnd.cpp:1540
+msgid "HTML files (*.html;*.htm)|*.html;*.htm|"
+msgstr "Schedarii HTML (*.html;*.htm)|*.html;*.htm|"
+
+#: ../src/html/helpwnd.cpp:1541
+msgid "Help books (*.htb)|*.htb|Help books (*.zip)|*.zip|"
+msgstr "Manuali d’aiutu (*.htb)|*.htb|Manuali d’aiutu (*.zip)|*.zip|"
+
+#: ../src/html/helpwnd.cpp:1542
+msgid "HTML Help Project (*.hhp)|*.hhp|"
+msgstr "Prughjettu d’aiutu HTML (*.hhp)|*.hhp|"
+
+#: ../src/html/helpwnd.cpp:1544
+msgid "Compressed HTML Help file (*.chm)|*.chm|"
+msgstr "Schedariu d’aiutu HTML cumpressu (*.chm)|*.chm|"
+
+#: ../src/html/helpwnd.cpp:1671
+#, c-format
+msgid "%i of %u"
+msgstr "%i nant’à %u"
+
+#: ../src/html/helpwnd.cpp:1709
+#, c-format
+msgid "%u of %u"
+msgstr "%u nant’à %u"
+
+#: ../src/html/htmlfilt.cpp:134
+#, c-format
+msgid "Cannot open HTML document: %s"
+msgstr "Ùn si pò micca apre u ducumentu HTML : %s"
+
+#: ../src/html/htmlwin.cpp:599
+msgid "Connecting..."
+msgstr "Cunnessione..."
+
+#: ../src/html/htmlwin.cpp:616
+#, c-format
+msgid "Unable to open requested HTML document: %s"
+msgstr "Impussibule d’apre u ducumentu HTML richiestu : %s"
+
+#: ../src/html/htmlwin.cpp:630
+msgid "Loading : "
+msgstr "Caricamentu : "
+
+#: ../src/html/htmlwin.cpp:673
+msgid "Done"
+msgstr "Compiu"
+
+#: ../src/html/htmlwin.cpp:723
+#, c-format
+msgid "HTML anchor %s does not exist."
+msgstr "L’ancura HTML %s ùn esiste micca."
+
+#: ../src/html/htmlwin.cpp:1057
+#, c-format
+msgid "Copied to clipboard:\"%s\""
+msgstr "Cupiatu in u preme’papei : « %s »"
+
+#: ../src/html/htmprint.cpp:269
+msgid ""
+"This document doesn't fit on the page horizontally and will be truncated "
+"when it is printed."
+msgstr ""
+"Stu ducumentu ùn hè micca adattatu orizuntalemente à a pagina è serà "
+"truncatu durante a stampa."
+
+#: ../src/html/htmprint.cpp:285
+#, c-format
+msgid ""
+"The document \"%s\" doesn't fit on the page horizontally and will be "
+"truncated if printed.\n"
+"\n"
+"Would you like to proceed with printing it nevertheless?"
+msgstr ""
+"U ducumentu « %s » ùn hè micca adattatu orizuntalemente à a pagina è serà "
+"truncatu s’ellu hè stampatu.\n"
+"\n"
+"Vulete stampallu quantunque ?"
+
+#: ../src/html/htmprint.cpp:296
+msgid ""
+"If possible, try changing the layout parameters to make the printout more "
+"narrow."
+msgstr ""
+"S’ella hè pussibule, pruvate di cambià i parametri d’accunciamentu per rende "
+"à stampa più stretta."
+
+#: ../src/html/htmprint.cpp:445
+msgid ": file does not exist!"
+msgstr ": u schedariu ùn esiste micca !"
+
+#. TRANSLATORS: %s may be a document title.
+#: ../src/html/htmprint.cpp:717
+#, c-format
+msgid "%s Preview"
+msgstr "Fighjulata %s"
+
+#: ../src/html/htmprint.cpp:755 ../src/richtext/richtextprint.cpp:618
+msgid ""
+"There was a problem during page setup: you may need to set a default printer."
+msgstr ""
+"Un prublema hè accadutu durante a messa in pagina : forse hè bisognu di "
+"cunfigurà una stampetta predefinita."
+
+#: ../src/msw/clipbrd.cpp:80
+msgid "Failed to open the clipboard."
+msgstr "Fiascu à l’apertura di u preme’papei."
+
+#: ../src/msw/clipbrd.cpp:101
+msgid "Failed to close the clipboard."
+msgstr "Fiascu à a chjusura di u preme’papei."
+
+#: ../src/msw/clipbrd.cpp:113
+msgid "Failed to empty the clipboard."
+msgstr "Fiascu à a viutatura di u preme’papei."
+
+#: ../src/msw/clipbrd.cpp:284
+msgid "Failed to put data on the clipboard"
+msgstr "Fiascu à l’aghjuntu di dati in u preme’papei"
+
+#: ../src/msw/clipbrd.cpp:326
+msgid "Failed to get data from the clipboard"
+msgstr "Fiascu per ottene i dati da u preme’papei"
+
+#: ../src/msw/clipbrd.cpp:363
+msgid "Failed to retrieve the supported clipboard formats"
+msgstr "Fiascu per ritruvà i furmati accettati di preme’papei"
+
+#: ../src/msw/colordlg.cpp:228
+#, c-format
+msgid "Colour selection dialog failed with error %0lx."
+msgstr "Fiascu di u dialogu di selezzione di culore cù u sbagliu %0lx."
+
+#: ../src/msw/cursor.cpp:141
+msgid "Failed to create cursor."
+msgstr "Fiascu à a creazione di u cursore."
+
+#: ../src/msw/dde.cpp:279
+#, c-format
+msgid "Failed to register DDE server '%s'"
+msgstr "Fiascu à l’arregistramentu di u servitore DDE « %s »"
+
+#: ../src/msw/dde.cpp:300
+#, c-format
+msgid "Failed to unregister DDE server '%s'"
+msgstr "Fiascu à u disarregistramentu di u servitore DDE « %s »"
+
+#: ../src/msw/dde.cpp:428
+#, c-format
+msgid "Failed to create connection to server '%s' on topic '%s'"
+msgstr ""
+"Fiascu à a creazione di a cunnessione à u servitore « %s » nant’à u "
+"sughjettu « %s »"
+
+#: ../src/msw/dde.cpp:655
+msgid "DDE poke request failed"
+msgstr "Fiascu di a richiesta DDE « poke »"
+
+#: ../src/msw/dde.cpp:674
+msgid "Failed to establish an advise loop with DDE server"
+msgstr "Fiascu per stabilisce un « advise loop » cù u servitore DDE"
+
+#: ../src/msw/dde.cpp:693
+msgid "Failed to terminate the advise loop with DDE server"
+msgstr "Fiascu per compie un « advise loop » cù u servitore DDE"
+
+#: ../src/msw/dde.cpp:768
+msgid "Failed to send DDE advise notification"
+msgstr "Fiascu à l’inviu d’una nutificazione d’« advise » DDE"
+
+#: ../src/msw/dde.cpp:1085
+msgid "Failed to create DDE string"
+msgstr "Fiascu à a creazione di a catena DDE"
+
+#: ../src/msw/dde.cpp:1131
+msgid "no DDE error."
+msgstr "nisunu sbagliu DDE."
+
+#: ../src/msw/dde.cpp:1135
+msgid "a request for a synchronous advise transaction has timed out."
+msgstr ""
+"una dumanda di transazzione sincrona « advise » hà ecciditu u tempu massimu."
+
+#: ../src/msw/dde.cpp:1138
+msgid "the response to the transaction caused the DDE_FBUSY bit to be set."
+msgstr ""
+"a risposta à a transazzione hà cagiunatu a definizione di u bit DDE_FBUSY."
+
+#: ../src/msw/dde.cpp:1141
+msgid "a request for a synchronous data transaction has timed out."
+msgstr ""
+"una dumanda di transazzione sincrona di dati hà ecciditu u tempu massimu."
+
+#: ../src/msw/dde.cpp:1144
+msgid ""
+"a DDEML function was called without first calling the DdeInitialize "
+"function,\n"
+"or an invalid instance identifier\n"
+"was passed to a DDEML function."
+msgstr ""
+"una funzione DDEML hè stata chjamata senza chjamà in primu locu a funzione "
+"DdeInitialize,\n"
+"o un identificazione d’istanza inaccettevule\n"
+"hè stata passata à una funzione DDEML."
+
+#: ../src/msw/dde.cpp:1147
+msgid ""
+"an application initialized as APPCLASS_MONITOR has\n"
+"attempted to perform a DDE transaction,\n"
+"or an application initialized as APPCMD_CLIENTONLY has \n"
+"attempted to perform server transactions."
+msgstr ""
+"un’appiecazione iniziata cum’è APPCLASS_MONITOR hà\n"
+"pruvatu d’effettuà una transazzione DDE,\n"
+"o un’appiecazione iniziata cum’è APPCMD_CLIENTONLY hà\n"
+"pruvatu d’effettuà transazzioni servitore."
+
+#: ../src/msw/dde.cpp:1150
+msgid "a request for a synchronous execute transaction has timed out."
+msgstr ""
+"una dumanda di transazzione sincrona d’esecuzione hà ecciditu u tempu "
+"massimu."
+
+#: ../src/msw/dde.cpp:1153
+msgid "a parameter failed to be validated by the DDEML."
+msgstr "fiascu di a cunvalidazione d’un parametru da a DDEML."
+
+#: ../src/msw/dde.cpp:1156
+msgid "a DDEML application has created a prolonged race condition."
+msgstr ""
+"un’appiecazione DDEML hà creatu una situazione di cuncurrenza allungata."
+
+#: ../src/msw/dde.cpp:1159
+msgid "a memory allocation failed."
+msgstr "fiascu d’un’attribuzione di memoria."
+
+#: ../src/msw/dde.cpp:1162
+msgid "a client's attempt to establish a conversation has failed."
+msgstr "fiascu d’un tentativu d’un cliente per stabilisce una discursata."
+
+#: ../src/msw/dde.cpp:1165
+msgid "a transaction failed."
+msgstr "fiascu d’una transazzione."
+
+#: ../src/msw/dde.cpp:1168
+msgid "a request for a synchronous poke transaction has timed out."
+msgstr ""
+"una dumanda di transazzione sincrona « poke » hà ecciditu u tempu massimu."
+
+#: ../src/msw/dde.cpp:1171
+msgid "an internal call to the PostMessage function has failed. "
+msgstr "fiascu d’una chjama interna à a funzione PostMessage. "
+
+#: ../src/msw/dde.cpp:1174
+msgid "reentrancy problem."
+msgstr "prublema di rientrenza."
+
+#: ../src/msw/dde.cpp:1177
+msgid ""
+"a server-side transaction was attempted on a conversation\n"
+"that was terminated by the client, or the server\n"
+"terminated before completing a transaction."
+msgstr ""
+"ci hè statu un tentativu di transazzione da u servitore per\n"
+"una discursata chì hè stata compia da u cliente, osinnò u\n"
+"servitore hè statu piantatu nanzu di compie a transazzione."
+
+#: ../src/msw/dde.cpp:1180
+msgid "an internal error has occurred in the DDEML."
+msgstr "un sbagliu internu hè accadutu in a DDEML."
+
+#: ../src/msw/dde.cpp:1183
+msgid "a request to end an advise transaction has timed out."
+msgstr ""
+"una dumanda per compie una transazzione « advise » hà ecciditu u tempu "
+"massimu."
+
+#: ../src/msw/dde.cpp:1186
+msgid ""
+"an invalid transaction identifier was passed to a DDEML function.\n"
+"Once the application has returned from an XTYP_XACT_COMPLETE callback,\n"
+"the transaction identifier for that callback is no longer valid."
+msgstr ""
+"un’identificazione di transazzione inaccettevule hè stata passata à una "
+"funzione DDEML.\n"
+"Quandu l’appiecazione hè rivenuta d’una richjama XTYP_XACT_COMPLETE,\n"
+"l’identificazione di transazzione per sta richjama ùn hè più accettevule."
+
+#: ../src/msw/dde.cpp:1189
+#, c-format
+msgid "Unknown DDE error %08x"
+msgstr "Sbagliu DDE scunnisciutu %08x"
+
+#: ../src/msw/dialup.cpp:343
+msgid ""
+"Dial up functions are unavailable because the remote access service (RAS) is "
+"not installed on this machine. Please install it."
+msgstr ""
+"E funzioni di cumpusizione tefonica sò indispunibule perchè u serviziu "
+"d’accessu alluntanatu (RAS) ùn hè micca installatu nant’à sta mascina. "
+"Installatela."
+
+#: ../src/msw/dialup.cpp:402
+#, c-format
+msgid ""
+"The version of remote access service (RAS) installed on this machine is too "
+"old, please upgrade (the following required function is missing: %s)."
+msgstr ""
+"A versione di u serviziu d’accessu alluntanatu (RAS) installatu nant’à sta "
+"mascina hè troppu vechju, mudernizatelu (quella funzione richiesta hè "
+"assente : %s)."
+
+#: ../src/msw/dialup.cpp:437
+msgid "Failed to retrieve text of RAS error message"
+msgstr "Fiascu per ritruvà u testu di u messaghju di sbagliu RAS"
+
+#: ../src/msw/dialup.cpp:440
+#, c-format
+msgid "unknown error (error code %08x)."
+msgstr "sbagliu scunnisciutu (codice di sbagliu %08x)."
+
+#: ../src/msw/dialup.cpp:492
+#, c-format
+msgid "Cannot find active dialup connection: %s"
+msgstr "Ùn si pò micca truvà di cunnessione tefonica attiva : %s"
+
+#: ../src/msw/dialup.cpp:513
+msgid "Several active dialup connections found, choosing one randomly."
+msgstr ""
+"Parechje cunnessioni tefoniche attive esistenu, una hè stata scelta à "
+"l’azardu."
+
+#: ../src/msw/dialup.cpp:598 ../src/msw/dialup.cpp:832
+#, c-format
+msgid "Failed to establish dialup connection: %s"
+msgstr "Ùn si pò micca stabilisce a cunnessione tefonica : %s"
+
+#: ../src/msw/dialup.cpp:664
+#, c-format
+msgid "Failed to get ISP names: %s"
+msgstr "Ùn si pò micca ottene i nomi di i FAI : %s"
+
+#: ../src/msw/dialup.cpp:712
+msgid "Failed to connect: no ISP to dial."
+msgstr "Fiascu di a cunnessione : nisunu numeru di FAI à chjamà."
+
+#: ../src/msw/dialup.cpp:732
+msgid "Choose ISP to dial"
+msgstr "Sceglie u FAI à chjamà"
+
+#: ../src/msw/dialup.cpp:733
+msgid "Please choose which ISP do you want to connect to"
+msgstr "Sciglite à chì FAI vulete cunnettevi"
+
+#: ../src/msw/dialup.cpp:766
+msgid "Failed to connect: missing username/password."
+msgstr ""
+"Fiascu di a cunnessione : nome d’utilizatore è/o parolla d’intesa assente."
+
+#: ../src/msw/dialup.cpp:796
+msgid "Cannot find the location of address book file"
+msgstr "Ùn si pò micca truvà a lucalizazione di u schedariu di l’indirizzi"
+
+#: ../src/msw/dialup.cpp:827
+#, c-format
+msgid "Failed to initiate dialup connection: %s"
+msgstr "Ùn si pò micca inizià a cunnessione tefonica : %s"
+
+#: ../src/msw/dialup.cpp:897
+msgid "Cannot hang up - no active dialup connection."
+msgstr "Ùn si pò micca riappiccà, nisuna cunnessione tefonica attiva."
+
+#: ../src/msw/dialup.cpp:907
+#, c-format
+msgid "Failed to terminate the dialup connection: %s"
+msgstr "Ùn si pò micca piantà a cunnessione tefonica : %s"
+
+#: ../src/msw/dib.cpp:313
+#, c-format
+msgid "Failed to save the bitmap image to file \"%s\"."
+msgstr "Ùn si pò micca arregistrà a fiura bitmap versu u schedariu « %s »."
+
+#: ../src/msw/dib.cpp:543
+#, c-format
+msgid "Failed to allocate %luKb of memory for bitmap data."
+msgstr ""
+"Ùn si pò micca attribuisce %luKb di memoria per i dati di a fiura bitmap."
+
+#: ../src/msw/dir.cpp:241
+#, c-format
+msgid "Cannot enumerate files in directory '%s'"
+msgstr "Ùn si pò micca enumerà i schedarii in u cartulare « %s »"
+
+#: ../src/msw/dirdlg.cpp:368
+msgid "Couldn't obtain folder name"
+msgstr "Ùn si pò micca ottene u nome di u cartulare"
+
+#: ../src/msw/dlmsw.cpp:163
+#, c-format
+msgid "(error %d: %s)"
+msgstr "(sbagliu %d : %s)"
+
+#: ../src/msw/dragimag.cpp:143 ../src/msw/dragimag.cpp:178
+#: ../src/msw/imaglist.cpp:309 ../src/msw/imaglist.cpp:331
+msgid "Couldn't add an image to the image list."
+msgstr "Ùn si pò micca aghjunghje una fiura à a lista di e fiure."
+
+#: ../src/msw/enhmeta.cpp:94
+#, c-format
+msgid "Failed to load metafile from file \"%s\"."
+msgstr "Fiascu per caricà u metaschedariu da u schedariu « %s »."
+
+#: ../src/msw/fdrepdlg.cpp:412
+#, c-format
+msgid "Failed to create the standard find/replace dialog (error code %d)"
+msgstr ""
+"Fiascu à a creazione di u dialogu classicu circà/rimpiazzà (codice di "
+"sbagliu %d)"
+
+#: ../src/msw/filedlg.cpp:1241
+msgid "Access to the file system is not allowed from secure desktop."
+msgstr ""
+"L’accessu à u sistema di schedariu ùn hè micca permessu da u scagnu "
+"sicurizatu."
+
+#: ../src/msw/filedlg.cpp:1242
+msgid "Security warning"
+msgstr "Avertimentu di sicurità"
+
+#: ../src/msw/filedlg.cpp:1533
+#, c-format
+msgid "File dialog failed with error code %0lx."
+msgstr "Fiascu di u dialogu di schedariu cù u codice di sbagliu %0lx."
+
+#: ../src/msw/font.cpp:1120
+#, c-format
+msgid "Font file \"%s\" couldn't be loaded"
+msgstr "U schedariu di grafia « %s » ùn pò micca esse caricatu"
+
+#: ../src/msw/fontdlg.cpp:220
+#, c-format
+msgid "Common dialog failed with error code %0lx."
+msgstr "Fiascu di u dialogu cumunu cù u codice di sbagliu %0lx."
+
+#: ../src/msw/fswatcher.cpp:67
+msgid "Ungraceful worker thread termination"
+msgstr "Chjusura disgraziosa di u filu di travagliu"
+
+#: ../src/msw/fswatcher.cpp:81
+msgid "Unable to create IOCP worker thread"
+msgstr "Impussibule di creà un filu di travagliu IOCP"
+
+#: ../src/msw/fswatcher.cpp:88
+msgid "Unable to start IOCP worker thread"
+msgstr "Impussibule d’avvià un filu di travagliu IOCP"
+
+#: ../src/msw/fswatcher.cpp:140
+msgid "Monitoring individual files for changes is not supported currently."
+msgstr ""
+"A surveglianza di i cambiamenti di i schedarii individuali ùn hè micca "
+"accettata attualmente."
+
+#: ../src/msw/fswatcher.cpp:165
+#, c-format
+msgid "Unable to set up watch for '%s'"
+msgstr "Impussibule di mette in piazza a surveglianza di « %s »"
+
+#: ../src/msw/fswatcher.cpp:466
+#, c-format
+msgid "Can't monitor non-existent directory \"%s\" for changes."
+msgstr ""
+"Ùn si pò micca surveglià i cambiamenti di u cartulare non esistente « %s »."
+
+#: ../src/msw/glcanvas.cpp:577 ../src/unix/glx11.cpp:507
+msgid "OpenGL 3.0 or later is not supported by the OpenGL driver."
+msgstr "U pilotu OpenGL ùn accetta micca a versione OpenGL 3.0 o più recente."
+
+#: ../src/msw/glcanvas.cpp:601 ../src/osx/glcanvas_osx.cpp:395
+#: ../src/unix/glegl.cpp:304 ../src/unix/glx11.cpp:553
+msgid "Couldn't create OpenGL context"
+msgstr "Ùn si pò micca creà u cuntestu OpenGL"
+
+#: ../src/msw/glcanvas.cpp:1294
+msgid "Failed to initialize OpenGL"
+msgstr "Fiascu à l’iniziu d’OpenGL"
+
+#: ../src/msw/graphicsd2d.cpp:607
+msgid "Could not register custom DirectWrite font loader."
+msgstr ""
+"Ùn si pò micca arregistrà u caricadore persunalizatu di grafia DirectWrite."
+
+#: ../src/msw/helpchm.cpp:48
+msgid ""
+"MS HTML Help functions are unavailable because the MS HTML Help library is "
+"not installed on this machine. Please install it."
+msgstr ""
+"E funzioni d’aiutu MS HTML sò indispunibule perchè a biblioteca d’aiutu MS "
+"HTML ùn hè micca installata nant’à sta mascina. Installatela."
+
+#: ../src/msw/helpchm.cpp:55
+msgid "Failed to initialize MS HTML Help."
+msgstr "Fiascu à l’iniziu di l’aiutu MS HTML."
+
+#: ../src/msw/iniconf.cpp:458
+#, c-format
+msgid "Can't delete the INI file '%s'"
+msgstr "Ùn si pò micca squassà u schedariu INI « %s »"
+
+#: ../src/msw/listctrl.cpp:995
+#, c-format
+msgid "Couldn't retrieve information about list control item %d."
+msgstr ""
+"Ùn si pò micca ricuperà l’infurmazione nant’à l’elementu %d di cuntrollu di "
+"e liste."
+
+#: ../src/msw/mdi.cpp:170 ../src/qt/mdi.cpp:253
+msgid "&Cascade"
+msgstr "&Cascata"
+
+#: ../src/msw/mdi.cpp:171
+msgid "Tile &Horizontally"
+msgstr "Musaica &orizuntale"
+
+#: ../src/msw/mdi.cpp:172
+msgid "Tile &Vertically"
+msgstr "Musaica &verticale"
+
+#: ../src/msw/mdi.cpp:174
+msgid "&Arrange Icons"
+msgstr "&Aggalabà l’icone"
+
+#: ../src/msw/mdi.cpp:621
+msgid "Failed to create MDI parent frame."
+msgstr "Ùn si pò micca creà u quadru genitore MDI."
+
+#: ../src/msw/mimetype.cpp:234
+#, c-format
+msgid "Failed to create registry entry for '%s' files."
+msgstr "Ùn si pò micca creà l’elementu di registru per i schedarii « %s »."
+
+#: ../src/msw/ole/automtn.cpp:495
+#, c-format
+msgid "Failed to find CLSID of \"%s\""
+msgstr "Ùn si pò micca truvà u CLSID di « %s »"
+
+#: ../src/msw/ole/automtn.cpp:512
+#, c-format
+msgid "Failed to create an instance of \"%s\""
+msgstr "Ùn si pò micca creà un’istanza di « %s »"
+
+#: ../src/msw/ole/automtn.cpp:552
+#, c-format
+msgid "Cannot get an active instance of \"%s\""
+msgstr "Ùn si pò micca ottene un’istanza attiva di « %s »"
+
+#: ../src/msw/ole/automtn.cpp:564
+#, c-format
+msgid "Failed to get OLE automation interface for \"%s\""
+msgstr "Ùn si pò micca ottene l’interfaccia d’autumatisazione OLE per « %s »"
+
+#: ../src/msw/ole/automtn.cpp:621
+msgid "Unknown name or named argument."
+msgstr "Nome o parametru numinatu scunnisciutu."
+
+#: ../src/msw/ole/automtn.cpp:625
+msgid "Incorrect number of arguments."
+msgstr "Numeru di parametri incurrettu."
+
+#: ../src/msw/ole/automtn.cpp:637
+msgid "Unknown exception"
+msgstr "Eccezzione scunnisciuta"
+
+#: ../src/msw/ole/automtn.cpp:642
+msgid "Method or property not found."
+msgstr "Metoda o pruprietà intruvevule."
+
+#: ../src/msw/ole/automtn.cpp:646
+msgid "Overflow while coercing argument values."
+msgstr "Capacità eccidita durante a cuercizione di i valori di parametri."
+
+#: ../src/msw/ole/automtn.cpp:650
+msgid "Object implementation does not support named arguments."
+msgstr "A messa in ballu di l’oggettu ùn accetta micca i parametri numinati."
+
+#: ../src/msw/ole/automtn.cpp:654
+msgid "The locale ID is unknown."
+msgstr "L’identificazione di a lucale hè scunnisciuta."
+
+#: ../src/msw/ole/automtn.cpp:658
+msgid "Missing a required parameter."
+msgstr "Un parametru richiestu hè assente."
+
+#: ../src/msw/ole/automtn.cpp:662
+#, c-format
+msgid "Argument %u not found."
+msgstr "Parametru %u intruvevule."
+
+#: ../src/msw/ole/automtn.cpp:666
+#, c-format
+msgid "Type mismatch in argument %u."
+msgstr "Discurdanza di tipu in u parametru %u."
+
+#: ../src/msw/ole/automtn.cpp:670
+msgid "The system cannot find the file specified."
+msgstr "U sistema ùn pò micca truvà u schedariu specificatu."
+
+#: ../src/msw/ole/automtn.cpp:674
+msgid "Class not registered."
+msgstr "Classa micca arregistrata."
+
+#: ../src/msw/ole/automtn.cpp:678
+#, c-format
+msgid "Unknown error %08x"
+msgstr "Sbagliu scunnisciutu %08x"
+
+#: ../src/msw/ole/automtn.cpp:682
+#, c-format
+msgid "OLE Automation error in %s: %s"
+msgstr "Sbagliu d’autumatisazione OLE in %s : %s"
+
+#: ../src/msw/ole/dataobj.cpp:385
+#, c-format
+msgid "Couldn't register clipboard format '%s'."
+msgstr "Ùn si pò micca arregistrà u furmatu « %s » di preme’papei."
+
+#: ../src/msw/ole/dataobj.cpp:402
+#, c-format
+msgid "The clipboard format '%d' doesn't exist."
+msgstr "U furmatu « %d » di preme’papei ùn esiste micca."
+
+#: ../src/msw/progdlg.cpp:1025
+msgid "Skip"
+msgstr "Tralascià"
+
+#: ../src/msw/registry.cpp:141
+#, c-format
+msgid "unknown (%lu)"
+msgstr "scunnisciutu (%lu)"
+
+#: ../src/msw/registry.cpp:409
+#, c-format
+msgid "Can't get info about registry key '%s'"
+msgstr ""
+"Ùn si pò micca ottene l’infurmazione nant’à a chjave di registru « %s »"
+
+#: ../src/msw/registry.cpp:445
+#, c-format
+msgid "Can't open registry key '%s'"
+msgstr "Ùn si pò micca apre a chjave di registru « %s »"
+
+#: ../src/msw/registry.cpp:478
+#, c-format
+msgid "Can't create registry key '%s'"
+msgstr "Ùn si pò micca creà a chjave di registru « %s »"
+
+#: ../src/msw/registry.cpp:497
+#, c-format
+msgid "Can't close registry key '%s'"
+msgstr "Ùn si pò micca chjode a chjave di registru « %s »"
+
+#: ../src/msw/registry.cpp:512
+#, c-format
+msgid "Registry value '%s' already exists."
+msgstr "U valore di registru « %s » esiste dighjà."
+
+#: ../src/msw/registry.cpp:520
+#, c-format
+msgid "Failed to rename registry value '%s' to '%s'."
+msgstr "Fiascu di a rinuminazione di u valore di registru da « %s » à « %s »."
+
+#: ../src/msw/registry.cpp:575
+#, c-format
+msgid "Can't copy values of unsupported type %d."
+msgstr "Ùn si pò micca cupià i valori di u tipu %d non ricunnisciutu."
+
+#: ../src/msw/registry.cpp:586
+#, c-format
+msgid "Registry key '%s' does not exist, cannot rename it."
+msgstr ""
+"A chjave di registru « %s » ùn esiste micca è ùn pò micca esse rinuminata."
+
+#: ../src/msw/registry.cpp:617
+#, c-format
+msgid "Registry key '%s' already exists."
+msgstr "A chjave di registru « %s » esiste dighjà."
+
+#: ../src/msw/registry.cpp:625
+#, c-format
+msgid "Failed to rename the registry key '%s' to '%s'."
+msgstr "Fiascu di a rinuminazione di a chjave di registru da « %s » à « %s »."
+
+#: ../src/msw/registry.cpp:670
+#, c-format
+msgid "Failed to copy the registry subkey '%s' to '%s'."
+msgstr "Fiascu di a copia di a sottuchjave di registru da « %s » à « %s »."
+
+#: ../src/msw/registry.cpp:683
+#, c-format
+msgid "Failed to copy registry value '%s'"
+msgstr "Fiascu di a copia di u valore di registru « %s »"
+
+#: ../src/msw/registry.cpp:692
+#, c-format
+msgid "Failed to copy the contents of registry key '%s' to '%s'."
+msgstr ""
+"Fiascu di a copia di u cuntenutu di a chjave di registru da « %s » à « %s »."
+
+#: ../src/msw/registry.cpp:718
+#, c-format
+msgid ""
+"Registry key '%s' is needed for normal system operation,\n"
+"deleting it will leave your system in unusable state:\n"
+"operation aborted."
+msgstr ""
+"A chjave di registru « %s » hè richiesta per un funziunamentu nurmale di u "
+"sistema,\n"
+"a so squassatura lasceria u vostru sistema in un statu inutilizevule :\n"
+"l’operazione hè abbandunata."
+
+#: ../src/msw/registry.cpp:754
+#, c-format
+msgid "Can't delete key '%s'"
+msgstr "Ùn si pò micca squassà a chjave « %s »"
+
+#: ../src/msw/registry.cpp:782
+#, c-format
+msgid "Can't delete value '%s' from key '%s'"
+msgstr "Ùn si pò micca squassà u valore « %s » da a chjave « %s »"
+
+#: ../src/msw/registry.cpp:855 ../src/msw/registry.cpp:887
+#: ../src/msw/registry.cpp:929 ../src/msw/registry.cpp:1000
+#, c-format
+msgid "Can't read value of key '%s'"
+msgstr "Ùn si pò micca leghje u valore di a chjave « %s »"
+
+#: ../src/msw/registry.cpp:873 ../src/msw/registry.cpp:915
+#: ../src/msw/registry.cpp:963 ../src/msw/registry.cpp:1106
+#, c-format
+msgid "Can't set value of '%s'"
+msgstr "Ùn si pò micca definisce u valore di « %s »"
+
+#: ../src/msw/registry.cpp:894 ../src/msw/registry.cpp:943
+#, c-format
+msgid "Registry value \"%s\" is not numeric (but of type %s)"
+msgstr "U valore di registru « %s » ùn hè micca numericu (ma di tipu %s)"
+
+#: ../src/msw/registry.cpp:979
+#, c-format
+msgid "Registry value \"%s\" is not binary (but of type %s)"
+msgstr "U valore di registru « %s » ùn hè micca binariu (ma di tipu %s)"
+
+#: ../src/msw/registry.cpp:1028
+#, c-format
+msgid "Registry value \"%s\" is not text (but of type %s)"
+msgstr "U valore di registru « %s » ùn hè micca testu (ma di tipu %s)"
+
+#: ../src/msw/registry.cpp:1089
+#, c-format
+msgid "Can't read value of '%s'"
+msgstr "Ùn si pò micca leghje u valore di « %s »"
+
+#: ../src/msw/registry.cpp:1157
+#, c-format
+msgid "Can't enumerate values of key '%s'"
+msgstr "Ùn si pò micca enumerà i valori di a chjave « %s »"
+
+#: ../src/msw/registry.cpp:1196
+#, c-format
+msgid "Can't enumerate subkeys of key '%s'"
+msgstr "Ùn si pò micca enumerà e sottuchjavi di a chjave « %s »"
+
+#: ../src/msw/registry.cpp:1262
+#, c-format
+msgid ""
+"Exporting registry key: file \"%s\" already exists and won't be overwritten."
+msgstr ""
+"Espurtazione di a chjave di registru : u schedariu « %s » esiste dighjà è ùn "
+"serà micca rimpiazzatu."
+
+#: ../src/msw/registry.cpp:1411
+#, c-format
+msgid "Can't export value of unsupported type %d."
+msgstr "Ùn si pò micca espurtà u valoru di u tipu %d non ricunnisciutu."
+
+#: ../src/msw/registry.cpp:1427
+#, c-format
+msgid "Ignoring value \"%s\" of the key \"%s\"."
+msgstr "U valore « %s » di a chjave « %s » hè ignuratu."
+
+#: ../src/msw/textctrl.cpp:596
+msgid ""
+"Impossible to create a rich edit control, using simple text control instead. "
+"Please reinstall riched32.dll"
+msgstr ""
+"Impussibule di creà un cuntrollu « rich edit  », adopru piuttostu d’un "
+"cuntrollu di testu simplice. Ci vole à installà riched32.dll torna"
+
+#: ../src/msw/thread.cpp:522 ../src/unix/threadpsx.cpp:850
+msgid "Cannot start thread: error writing TLS."
+msgstr ""
+"Ùn si pò micca avvià u filu d’esecuzione : sbagliu à a scrittura di TLS."
+
+#: ../src/msw/thread.cpp:613
+msgid "Can't set thread priority"
+msgstr "Ùn si pò micca definisce a priurità di u filu d’esecuzione"
+
+#: ../src/msw/thread.cpp:649
+msgid "Can't create thread"
+msgstr "Ùn si pò micca creà u filu d’esecuzione"
+
+#: ../src/msw/thread.cpp:668
+msgid "Couldn't terminate thread"
+msgstr "Ùn si pò micca piantà u filu d’esecuzione"
+
+#: ../src/msw/thread.cpp:799
+msgid "Cannot wait for thread termination"
+msgstr "Ùn si pò micca aspettà a fine di u filu d’esecuzione"
+
+#: ../src/msw/thread.cpp:873
+#, c-format
+msgid "Cannot suspend thread %lx"
+msgstr "Ùn si pò micca interrompe u filu d’esecuzione %lx"
+
+#: ../src/msw/thread.cpp:903
+#, c-format
+msgid "Cannot resume thread %lx"
+msgstr "Ùn si pò micca ripiglià u filu d’esecuzione %lx"
+
+#: ../src/msw/thread.cpp:932
+msgid "Couldn't get the current thread pointer"
+msgstr "Ùn si pò micca ottene u puntatore di u filu d’esecuzione currente"
+
+#: ../src/msw/thread.cpp:1333
+msgid ""
+"Thread module initialization failed: impossible to allocate index in thread "
+"local storage"
+msgstr ""
+"Fiascu à l’iniziu di u modulu di u filu d’esecuzione : impussibule "
+"d’attribuisce l’indice in l’allucamentu lucale di fili d’esecuzione"
+
+#: ../src/msw/thread.cpp:1345
+msgid ""
+"Thread module initialization failed: cannot store value in thread local "
+"storage"
+msgstr ""
+"Fiascu à l’iniziu di u modulu di u filu d’esecuzione : impussibule d’allucà "
+"u valore in l’allucamentu lucale di fili d’esecuzione"
+
+#: ../src/msw/timer.cpp:133
+msgid "Couldn't create a timer"
+msgstr "Ùn si pò micca creà una minuteria"
+
+#: ../src/msw/utils.cpp:372
+msgid "can't find user's HOME, using current directory."
+msgstr ""
+"impussibule di truvà u cartulare HOME di l’utilizatore, impiegu di u "
+"cartulare currente."
+
+#: ../src/msw/utils.cpp:662
+#, c-format
+msgid "Failed to kill process %d"
+msgstr "Fiascu per tumbà u trattamentu %d"
+
+#: ../src/msw/utils.cpp:986
+#, c-format
+msgid "Failed to load resource \"%s\"."
+msgstr "Fiascu per caricà a risorsa « %s »."
+
+#: ../src/msw/utils.cpp:993
+#, c-format
+msgid "Failed to lock resource \"%s\"."
+msgstr "Fiascu per ammarchjunà a risorsa « %s »."
+
+#. TRANSLATORS: MS Windows build number
+#: ../src/msw/utils.cpp:1209
+#, c-format
+msgid "build %lu"
+msgstr "custruzzione %lu"
+
+#: ../src/msw/utils.cpp:1218
+msgid ", 64-bit edition"
+msgstr ", edizione 64-bit"
+
+#: ../src/msw/utilsexc.cpp:224
+msgid "Failed to create an anonymous pipe"
+msgstr "Fiascu à a creazione d’un cundottu anonimu"
+
+#: ../src/msw/utilsexc.cpp:697
+msgid "Failed to redirect the child process IO"
+msgstr ""
+"Fiascu di a ridirezzione di l’entrate è di l’esciute di u trattamentu zitellu"
+
+#: ../src/msw/utilsexc.cpp:870
+#, c-format
+msgid "Execution of command '%s' failed"
+msgstr "Fiascu di l’esecuzione di a cumanda « %s »"
+
+#: ../src/msw/volume.cpp:337
+msgid "Failed to load mpr.dll."
+msgstr "Fiascu di u caricamentu di mpr.dll."
+
+#: ../src/msw/volume.cpp:506
+#, c-format
+msgid "Cannot read typename from '%s'!"
+msgstr "Ùn si pò micca leghje u nome di u tipu da « %s » !"
+
+#: ../src/msw/volume.cpp:615
+#, c-format
+msgid "Cannot load icon from '%s'."
+msgstr "Ùn si pò micca caricà l’icona da « %s »."
+
+#: ../src/msw/webview_edge.cpp:285
+msgid "This program was compiled without support for setting Edge proxy."
+msgstr ""
+"Stu prugramma hè statu custruitu senza piglià in contu a definizione di u "
+"proxy Edge."
+
+#: ../src/msw/webview_ie.cpp:1010
+msgid "Failed to find web view emulation level in the registry"
+msgstr ""
+"Fiascu per truvà un livellu di simulazione di vista di u web in u registru"
+
+#: ../src/msw/webview_ie.cpp:1019
+msgid "Failed to set web view to modern emulation level"
+msgstr ""
+"Fiascu per definisce a vista di u web à u livellu di simulazione mudernu"
+
+#: ../src/msw/webview_ie.cpp:1027
+msgid "Failed to reset web view to standard emulation level"
+msgstr ""
+"Fiascu per reinizià a vista di u web à u livellu di simulazione classicu"
+
+#: ../src/msw/webview_ie.cpp:1049
+msgid "Can't run JavaScript script without a valid HTML document"
+msgstr ""
+"Ùn si pò micca lancià u scenariu JavaScript senza un ducumentu HTML "
+"accettevule"
+
+#: ../src/msw/webview_ie.cpp:1056
+msgid "Can't get the JavaScript object"
+msgstr "Ùn si pò micca ottene l’oggettu JavaScript"
+
+#: ../src/msw/webview_ie.cpp:1070
+msgid "failed to evaluate"
+msgstr "fiascu di a valutazione"
+
+#: ../src/osx/cocoa/filedlg.mm:412
+msgid "File type:"
+msgstr "Tipu di schedariu :"
+
+#: ../src/osx/cocoa/menu.mm:242
+msgctxt "macOS menu name"
+msgid "Window"
+msgstr "Finestra"
+
+#: ../src/osx/cocoa/menu.mm:259
+msgctxt "macOS menu name"
+msgid "Help"
+msgstr "Aiutu"
+
+#: ../src/osx/cocoa/menu.mm:298
+msgctxt "macOS menu item"
+msgid "Minimize"
+msgstr "Minimizà"
+
+#: ../src/osx/cocoa/menu.mm:303
+msgctxt "macOS menu item"
+msgid "Zoom"
+msgstr "Ingrandamentu"
+
+#: ../src/osx/cocoa/menu.mm:309
+msgctxt "macOS menu item"
+msgid "Bring All to Front"
+msgstr "Tuttu mette di fronte"
+
+#: ../src/osx/core/sound.cpp:143
+#, c-format
+msgid "Failed to load sound from \"%s\" (error %d)."
+msgstr "Fiascu per caricà u sonu da « %s » (sbagliu %d)."
+
+#: ../src/osx/fontutil.cpp:80
+#, c-format
+msgid "Font file \"%s\" doesn't exist."
+msgstr "U schedariu di grafia « %s » ùn esiste micca."
+
+#: ../src/osx/fontutil.cpp:88
+#, c-format
+msgid ""
+"Font file \"%s\" cannot be used as it is not inside the font directory "
+"\"%s\"."
+msgstr ""
+"U schedariu di grafia « %s » ùn pò micca esse impiegatu perchè ùn si trova "
+"micca in u cartulare di e grafie « %s »."
+
+#: ../src/osx/menu_osx.cpp:496
+#, c-format
+msgctxt "macOS menu item"
+msgid "About %s"
+msgstr "Apprupositu di %s"
+
+#: ../src/osx/menu_osx.cpp:499
+msgctxt "macOS menu item"
+msgid "About..."
+msgstr "Apprupositu…"
+
+#: ../src/osx/menu_osx.cpp:508
+msgctxt "macOS menu item"
+msgid "Preferences..."
+msgstr "Preferenze..."
+
+#: ../src/osx/menu_osx.cpp:512
+msgctxt "macOS menu item"
+msgid "Services"
+msgstr "Servizii"
+
+#: ../src/osx/menu_osx.cpp:519
+#, c-format
+msgctxt "macOS menu item"
+msgid "Hide %s"
+msgstr "Piattà %s"
+
+#: ../src/osx/menu_osx.cpp:522
+msgctxt "macOS menu item"
+msgid "Hide Application"
+msgstr "Piattà l’appiecazione"
+
+#: ../src/osx/menu_osx.cpp:526
+msgctxt "macOS menu item"
+msgid "Hide Others"
+msgstr "Piattà l’altre"
+
+#: ../src/osx/menu_osx.cpp:528
+msgctxt "macOS menu item"
+msgid "Show All"
+msgstr "Tuttu affissà"
+
+#: ../src/osx/menu_osx.cpp:534
+#, c-format
+msgctxt "macOS menu item"
+msgid "Quit %s"
+msgstr "Esce di %s"
+
+#: ../src/osx/menu_osx.cpp:537
+msgctxt "macOS menu item"
+msgid "Quit Application"
+msgstr "Esce di l’appiecazione"
+
+#: ../src/osx/webview_webkit.mm:444
+msgid "Printing is not supported by the system web control"
+msgstr "A stampa ùn hè micca accettata da u cuntrollu web di u sistema"
+
+#: ../src/osx/webview_webkit.mm:453
+msgid "Print operation could not be initialized"
+msgstr "L’operazione di stampa ùn pò micca esse iniziata"
+
+#. TRANSLATORS: Label of font point size
+#: ../src/propgrid/advprops.cpp:605
+msgid "Point Size"
+msgstr "Dimensione di puntu"
+
+#. TRANSLATORS: Label of font face name
+#: ../src/propgrid/advprops.cpp:615
+msgid "Face Name"
+msgstr "Nome di a grafia"
+
+#. TRANSLATORS: Label of font style
+#: ../src/propgrid/advprops.cpp:623 ../src/richtext/richtextformatdlg.cpp:331
+msgid "Style"
+msgstr "Stilu"
+
+#. TRANSLATORS: Label of font weight
+#: ../src/propgrid/advprops.cpp:628
+msgid "Weight"
+msgstr "Spessore"
+
+#. TRANSLATORS: Label of underlined font
+#: ../src/propgrid/advprops.cpp:633 ../src/richtext/richtextfontpage.cpp:358
+msgid "Underlined"
+msgstr "Sottulineata"
+
+#. TRANSLATORS: Label of font family
+#: ../src/propgrid/advprops.cpp:637
+msgid "Family"
+msgstr "Famiglia"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:801
+msgid "AppWorkspace"
+msgstr "SpaziuTravagliuAppiecazione"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:802
+msgid "ActiveBorder"
+msgstr "BorduAttivu"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:803
+msgid "ActiveCaption"
+msgstr "SottutituluAttivu"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:804
+msgid "ButtonFace"
+msgstr "FacciaButtone"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:805
+msgid "ButtonHighlight"
+msgstr "SopralineàButtone"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:806
+msgid "ButtonShadow"
+msgstr "UmbriaButtone"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:807
+msgid "ButtonText"
+msgstr "TestuButtone"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:808
+msgid "CaptionText"
+msgstr "TestuSottutitulu"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:809
+msgid "ControlDark"
+msgstr "CuntrolluScuru"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:810
+msgid "ControlLight"
+msgstr "CuntrolluChjaru"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:812
+msgid "GrayText"
+msgstr "TestuGrisgiu"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:813
+msgid "Highlight"
+msgstr "Sopralineà"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:814
+msgid "HighlightText"
+msgstr "TestuSopralineà"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:815
+msgid "InactiveBorder"
+msgstr "BorduInattivu"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:816
+msgid "InactiveCaption"
+msgstr "SottutituluInattivu"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:817
+msgid "InactiveCaptionText"
+msgstr "TestuSottutituluInattivu"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:818
+msgid "Menu"
+msgstr "Interfaccia"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:819
+msgid "Scrollbar"
+msgstr "BarraSfilarata"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:820
+msgid "Tooltip"
+msgstr "BollaInfurmazione"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:821
+msgid "TooltipText"
+msgstr "TestuBollaInfurmazione"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:822
+msgid "Window"
+msgstr "Finestra"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:823
+msgid "WindowFrame"
+msgstr "QuadruFinestra"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:824
+msgid "WindowText"
+msgstr "TestuFinestra"
+
+#. TRANSLATORS: Custom colour choice entry
+#: ../src/propgrid/advprops.cpp:825 ../src/propgrid/advprops.cpp:1532
+#: ../src/propgrid/advprops.cpp:1576
+msgid "Custom"
+msgstr "Persunalizatu"
+
+#: ../src/propgrid/advprops.cpp:1558
+msgid "Black"
+msgstr "Neru"
+
+#: ../src/propgrid/advprops.cpp:1559
+msgid "Maroon"
+msgstr "Cerriu"
+
+#: ../src/propgrid/advprops.cpp:1560
+msgid "Navy"
+msgstr "Marina"
+
+#: ../src/propgrid/advprops.cpp:1561
+msgid "Purple"
+msgstr "Purpura"
+
+#: ../src/propgrid/advprops.cpp:1562
+msgid "Teal"
+msgstr "Smeraldu"
+
+#: ../src/propgrid/advprops.cpp:1563
+msgid "Gray"
+msgstr "Grisgiu"
+
+#: ../src/propgrid/advprops.cpp:1564
+msgid "Green"
+msgstr "Verde"
+
+#: ../src/propgrid/advprops.cpp:1565
+msgid "Olive"
+msgstr "Aliva"
+
+#: ../src/propgrid/advprops.cpp:1566
+msgid "Brown"
+msgstr "Castagnu"
+
+#: ../src/propgrid/advprops.cpp:1567
+msgid "Blue"
+msgstr "Turchinu"
+
+#: ../src/propgrid/advprops.cpp:1568
+msgid "Fuchsia"
+msgstr "Rusulatu"
+
+#: ../src/propgrid/advprops.cpp:1569
+msgid "Red"
+msgstr "Rossu"
+
+#: ../src/propgrid/advprops.cpp:1570
+msgid "Orange"
+msgstr "Aranciu"
+
+#: ../src/propgrid/advprops.cpp:1571
+msgid "Silver"
+msgstr "Argentu"
+
+#: ../src/propgrid/advprops.cpp:1572
+msgid "Lime"
+msgstr "Limone verde"
+
+#: ../src/propgrid/advprops.cpp:1573
+msgid "Aqua"
+msgstr "Acqua"
+
+#: ../src/propgrid/advprops.cpp:1574
+msgid "Yellow"
+msgstr "Ghjallu"
+
+#: ../src/propgrid/advprops.cpp:1575
+msgid "White"
+msgstr "Biancu"
+
+#: ../src/propgrid/advprops.cpp:1718
+msgctxt "system cursor name"
+msgid "Default"
+msgstr "Predefinitu"
+
+#: ../src/propgrid/advprops.cpp:1719
+msgctxt "system cursor name"
+msgid "Arrow"
+msgstr "Fleccia"
+
+#: ../src/propgrid/advprops.cpp:1720
+msgctxt "system cursor name"
+msgid "Right Arrow"
+msgstr "Fleccia diritta"
+
+#: ../src/propgrid/advprops.cpp:1721
+msgctxt "system cursor name"
+msgid "Blank"
+msgstr "Biancu"
+
+#: ../src/propgrid/advprops.cpp:1722
+msgctxt "system cursor name"
+msgid "Bullseye"
+msgstr "Sibula"
+
+#: ../src/propgrid/advprops.cpp:1723
+msgctxt "system cursor name"
+msgid "Character"
+msgstr "Caratteru"
+
+#: ../src/propgrid/advprops.cpp:1724
+msgctxt "system cursor name"
+msgid "Cross"
+msgstr "Croce"
+
+#: ../src/propgrid/advprops.cpp:1725
+msgctxt "system cursor name"
+msgid "Hand"
+msgstr "Manu"
+
+#: ../src/propgrid/advprops.cpp:1726
+msgctxt "system cursor name"
+msgid "I-Beam"
+msgstr "Puntatore in I"
+
+#: ../src/propgrid/advprops.cpp:1727
+msgctxt "system cursor name"
+msgid "Left Button"
+msgstr "Buttone mancu"
+
+#: ../src/propgrid/advprops.cpp:1728
+msgctxt "system cursor name"
+msgid "Magnifier"
+msgstr "Luppa"
+
+#: ../src/propgrid/advprops.cpp:1729
+msgctxt "system cursor name"
+msgid "Middle Button"
+msgstr "Buttone centrale"
+
+#: ../src/propgrid/advprops.cpp:1730
+msgctxt "system cursor name"
+msgid "No Entry"
+msgstr "Sensu interdettu"
+
+#: ../src/propgrid/advprops.cpp:1731
+msgctxt "system cursor name"
+msgid "Paint Brush"
+msgstr "Pinnellu à tinta"
+
+#: ../src/propgrid/advprops.cpp:1732
+msgctxt "system cursor name"
+msgid "Pencil"
+msgstr "Mina"
+
+#: ../src/propgrid/advprops.cpp:1733
+msgctxt "system cursor name"
+msgid "Point Left"
+msgstr "Puntu à mancu"
+
+#: ../src/propgrid/advprops.cpp:1734
+msgctxt "system cursor name"
+msgid "Point Right"
+msgstr "Puntu à dirittu"
+
+#: ../src/propgrid/advprops.cpp:1735
+msgctxt "system cursor name"
+msgid "Question Arrow"
+msgstr "Fleccia di dumanda"
+
+#: ../src/propgrid/advprops.cpp:1736
+msgctxt "system cursor name"
+msgid "Right Button"
+msgstr "Buttone dirittu"
+
+#: ../src/propgrid/advprops.cpp:1737
+msgctxt "system cursor name"
+msgid "Sizing NE-SW"
+msgstr "Pusizione NE-SO"
+
+#: ../src/propgrid/advprops.cpp:1738
+msgctxt "system cursor name"
+msgid "Sizing N-S"
+msgstr "Pusizione N-S"
+
+#: ../src/propgrid/advprops.cpp:1739
+msgctxt "system cursor name"
+msgid "Sizing NW-SE"
+msgstr "Pusizione NO-SE"
+
+#: ../src/propgrid/advprops.cpp:1740
+msgctxt "system cursor name"
+msgid "Sizing W-E"
+msgstr "Pusizione O-E"
+
+#: ../src/propgrid/advprops.cpp:1741
+msgctxt "system cursor name"
+msgid "Sizing"
+msgstr "Pusizione"
+
+#: ../src/propgrid/advprops.cpp:1742
+msgctxt "system cursor name"
+msgid "Spraycan"
+msgstr "Vapurizadore"
+
+#: ../src/propgrid/advprops.cpp:1743
+msgctxt "system cursor name"
+msgid "Wait"
+msgstr "Attesa"
+
+#: ../src/propgrid/advprops.cpp:1744
+msgctxt "system cursor name"
+msgid "Watch"
+msgstr "Surveglianza"
+
+#: ../src/propgrid/advprops.cpp:1745
+msgctxt "system cursor name"
+msgid "Wait Arrow"
+msgstr "Fleccia d’attesa"
+
+#: ../src/propgrid/advprops.cpp:2109
+msgid "Make a selection:"
+msgstr "Effettuà una selezzione :"
+
+#: ../src/propgrid/manager.cpp:394
+msgid "Property"
+msgstr "Pruprietà"
+
+#: ../src/propgrid/manager.cpp:395
+msgid "Value"
+msgstr "Valore"
+
+#: ../src/propgrid/manager.cpp:1683
+msgid "Categorized Mode"
+msgstr "Modu categuriale"
+
+#: ../src/propgrid/manager.cpp:1709
+msgid "Alphabetic Mode"
+msgstr "Modu alfabeticu"
+
+#. TRANSLATORS: Name of Boolean false value
+#: ../src/propgrid/propgrid.cpp:230
+msgid "False"
+msgstr "Falsu"
+
+#. TRANSLATORS: Name of Boolean true value
+#: ../src/propgrid/propgrid.cpp:232
+msgid "True"
+msgstr "Veru"
+
+#. TRANSLATORS: Text  displayed for unspecified value
+#: ../src/propgrid/propgrid.cpp:428
+msgid "Unspecified"
+msgstr "Non specificatu"
+
+#. TRANSLATORS: Caption of message box displaying any property error
+#: ../src/propgrid/propgrid.cpp:3145 ../src/propgrid/propgrid.cpp:3282
+msgid "Property Error"
+msgstr "Sbagliu di pruprietà"
+
+#: ../src/propgrid/propgrid.cpp:3259
+msgid "You have entered invalid value. Press ESC to cancel editing."
+msgstr ""
+"Un valore inaccettevule hè statu stampittatu. Appughjate nant’à SCAP per "
+"abbandunà a mudificazione."
+
+#: ../src/propgrid/propgrid.cpp:6608
+#, c-format
+msgid "Error in resource: %s"
+msgstr "Sbagliu in a risorsa : %s"
+
+#: ../src/propgrid/propgridiface.cpp:377
+#, c-format
+msgid ""
+"Type operation \"%s\" failed: Property labeled \"%s\" is of type \"%s\", NOT "
+"\"%s\"."
+msgstr ""
+"Fiascu di u tipu d’operazione « %s » : A pruprietà cù l’etichetta « %s » hè "
+"di tipu « %s », è MICCA « %s »."
+
+#: ../src/propgrid/props.cpp:159
+#, c-format
+msgid "Unknown base %d. Base 10 will be used."
+msgstr "Basa %d scunnisciuta. A basa 10 serà impiegata."
+
+#: ../src/propgrid/props.cpp:324
+#, c-format
+msgid "Value must be %s or higher."
+msgstr "U valore deve esse %s o superiore."
+
+#: ../src/propgrid/props.cpp:329 ../src/propgrid/props.cpp:356
+#, c-format
+msgid "Value must be between %s and %s."
+msgstr "U valore deve esse trà %s è %s."
+
+#: ../src/propgrid/props.cpp:351
+#, c-format
+msgid "Value must be %s or less."
+msgstr "U valore deve esse %s o inferiore."
+
+#: ../src/propgrid/props.cpp:1058
+#, c-format
+msgid "Not %s"
+msgstr "Micca %s"
+
+#: ../src/propgrid/props.cpp:1770
+msgid "Choose a directory:"
+msgstr "Sceglie un cartulare :"
+
+#: ../src/propgrid/props.cpp:2055
+msgid "Choose a file"
+msgstr "Sceglie un schedariu"
+
+#: ../src/qt/mdi.cpp:254
+msgid "&Tile"
+msgstr "&Musaica"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:147
+#: ../src/richtext/richtextformatdlg.cpp:376
+msgid "Background"
+msgstr "Sfondulu"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:159
+msgid "Background &colour:"
+msgstr "&Culore di sfondulu :"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:161
+#: ../src/richtext/richtextbackgroundpage.cpp:163
+msgid "Enables a background colour."
+msgstr "Attiveghja u culore di sfondulu."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:167
+#: ../src/richtext/richtextbackgroundpage.cpp:169
+msgid "The background colour."
+msgstr "U culore di sfondulu."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:178
+msgid "Shadow"
+msgstr "Umbria"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:193
+msgid "Use &shadow"
+msgstr "Impiegà l’&umbria"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:195
+#: ../src/richtext/richtextbackgroundpage.cpp:197
+msgid "Enables a shadow."
+msgstr "Attiveghja un’umbria."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:211
+msgid "&Horizontal offset:"
+msgstr "Spustime &orizuntale :"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:218
+#: ../src/richtext/richtextbackgroundpage.cpp:220
+msgid "The horizontal offset."
+msgstr "U spustime orizuntale."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:224
+#: ../src/richtext/richtextbackgroundpage.cpp:227
+#: ../src/richtext/richtextbackgroundpage.cpp:228
+#: ../src/richtext/richtextbackgroundpage.cpp:247
+#: ../src/richtext/richtextbackgroundpage.cpp:250
+#: ../src/richtext/richtextbackgroundpage.cpp:251
+#: ../src/richtext/richtextbackgroundpage.cpp:287
+#: ../src/richtext/richtextbackgroundpage.cpp:290
+#: ../src/richtext/richtextbackgroundpage.cpp:291
+#: ../src/richtext/richtextbackgroundpage.cpp:314
+#: ../src/richtext/richtextbackgroundpage.cpp:317
+#: ../src/richtext/richtextbackgroundpage.cpp:318
+#: ../src/richtext/richtextborderspage.cpp:252
+#: ../src/richtext/richtextborderspage.cpp:255
+#: ../src/richtext/richtextborderspage.cpp:256
+#: ../src/richtext/richtextborderspage.cpp:286
+#: ../src/richtext/richtextborderspage.cpp:289
+#: ../src/richtext/richtextborderspage.cpp:290
+#: ../src/richtext/richtextborderspage.cpp:320
+#: ../src/richtext/richtextborderspage.cpp:323
+#: ../src/richtext/richtextborderspage.cpp:324
+#: ../src/richtext/richtextborderspage.cpp:354
+#: ../src/richtext/richtextborderspage.cpp:357
+#: ../src/richtext/richtextborderspage.cpp:358
+#: ../src/richtext/richtextborderspage.cpp:420
+#: ../src/richtext/richtextborderspage.cpp:423
+#: ../src/richtext/richtextborderspage.cpp:424
+#: ../src/richtext/richtextborderspage.cpp:454
+#: ../src/richtext/richtextborderspage.cpp:457
+#: ../src/richtext/richtextborderspage.cpp:458
+#: ../src/richtext/richtextborderspage.cpp:488
+#: ../src/richtext/richtextborderspage.cpp:491
+#: ../src/richtext/richtextborderspage.cpp:492
+#: ../src/richtext/richtextborderspage.cpp:522
+#: ../src/richtext/richtextborderspage.cpp:525
+#: ../src/richtext/richtextborderspage.cpp:526
+#: ../src/richtext/richtextborderspage.cpp:590
+#: ../src/richtext/richtextborderspage.cpp:593
+#: ../src/richtext/richtextborderspage.cpp:594
+#: ../src/richtext/richtextfontpage.cpp:177
+#: ../src/richtext/richtextmarginspage.cpp:199
+#: ../src/richtext/richtextmarginspage.cpp:201
+#: ../src/richtext/richtextmarginspage.cpp:202
+#: ../src/richtext/richtextmarginspage.cpp:224
+#: ../src/richtext/richtextmarginspage.cpp:226
+#: ../src/richtext/richtextmarginspage.cpp:227
+#: ../src/richtext/richtextmarginspage.cpp:247
+#: ../src/richtext/richtextmarginspage.cpp:249
+#: ../src/richtext/richtextmarginspage.cpp:250
+#: ../src/richtext/richtextmarginspage.cpp:272
+#: ../src/richtext/richtextmarginspage.cpp:274
+#: ../src/richtext/richtextmarginspage.cpp:275
+#: ../src/richtext/richtextmarginspage.cpp:313
+#: ../src/richtext/richtextmarginspage.cpp:315
+#: ../src/richtext/richtextmarginspage.cpp:316
+#: ../src/richtext/richtextmarginspage.cpp:338
+#: ../src/richtext/richtextmarginspage.cpp:340
+#: ../src/richtext/richtextmarginspage.cpp:341
+#: ../src/richtext/richtextmarginspage.cpp:361
+#: ../src/richtext/richtextmarginspage.cpp:363
+#: ../src/richtext/richtextmarginspage.cpp:364
+#: ../src/richtext/richtextmarginspage.cpp:386
+#: ../src/richtext/richtextmarginspage.cpp:388
+#: ../src/richtext/richtextmarginspage.cpp:389
+#: ../src/richtext/richtextsizepage.cpp:337
+#: ../src/richtext/richtextsizepage.cpp:340
+#: ../src/richtext/richtextsizepage.cpp:341
+#: ../src/richtext/richtextsizepage.cpp:371
+#: ../src/richtext/richtextsizepage.cpp:374
+#: ../src/richtext/richtextsizepage.cpp:375
+#: ../src/richtext/richtextsizepage.cpp:398
+#: ../src/richtext/richtextsizepage.cpp:401
+#: ../src/richtext/richtextsizepage.cpp:402
+#: ../src/richtext/richtextsizepage.cpp:425
+#: ../src/richtext/richtextsizepage.cpp:428
+#: ../src/richtext/richtextsizepage.cpp:429
+#: ../src/richtext/richtextsizepage.cpp:452
+#: ../src/richtext/richtextsizepage.cpp:455
+#: ../src/richtext/richtextsizepage.cpp:456
+#: ../src/richtext/richtextsizepage.cpp:479
+#: ../src/richtext/richtextsizepage.cpp:482
+#: ../src/richtext/richtextsizepage.cpp:483
+#: ../src/richtext/richtextsizepage.cpp:553
+#: ../src/richtext/richtextsizepage.cpp:556
+#: ../src/richtext/richtextsizepage.cpp:557
+#: ../src/richtext/richtextsizepage.cpp:588
+#: ../src/richtext/richtextsizepage.cpp:591
+#: ../src/richtext/richtextsizepage.cpp:592
+#: ../src/richtext/richtextsizepage.cpp:623
+#: ../src/richtext/richtextsizepage.cpp:626
+#: ../src/richtext/richtextsizepage.cpp:627
+#: ../src/richtext/richtextsizepage.cpp:658
+#: ../src/richtext/richtextsizepage.cpp:661
+#: ../src/richtext/richtextsizepage.cpp:662
+msgid "px"
+msgstr "px"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:225
+#: ../src/richtext/richtextbackgroundpage.cpp:248
+#: ../src/richtext/richtextbackgroundpage.cpp:288
+#: ../src/richtext/richtextbackgroundpage.cpp:315
+#: ../src/richtext/richtextborderspage.cpp:253
+#: ../src/richtext/richtextborderspage.cpp:287
+#: ../src/richtext/richtextborderspage.cpp:321
+#: ../src/richtext/richtextborderspage.cpp:355
+#: ../src/richtext/richtextborderspage.cpp:421
+#: ../src/richtext/richtextborderspage.cpp:455
+#: ../src/richtext/richtextborderspage.cpp:489
+#: ../src/richtext/richtextborderspage.cpp:523
+#: ../src/richtext/richtextborderspage.cpp:591
+#: ../src/richtext/richtextmarginspage.cpp:200
+#: ../src/richtext/richtextmarginspage.cpp:225
+#: ../src/richtext/richtextmarginspage.cpp:248
+#: ../src/richtext/richtextmarginspage.cpp:273
+#: ../src/richtext/richtextmarginspage.cpp:314
+#: ../src/richtext/richtextmarginspage.cpp:339
+#: ../src/richtext/richtextmarginspage.cpp:362
+#: ../src/richtext/richtextmarginspage.cpp:387
+#: ../src/richtext/richtextsizepage.cpp:338
+#: ../src/richtext/richtextsizepage.cpp:372
+#: ../src/richtext/richtextsizepage.cpp:399
+#: ../src/richtext/richtextsizepage.cpp:426
+#: ../src/richtext/richtextsizepage.cpp:453
+#: ../src/richtext/richtextsizepage.cpp:480
+#: ../src/richtext/richtextsizepage.cpp:554
+#: ../src/richtext/richtextsizepage.cpp:589
+#: ../src/richtext/richtextsizepage.cpp:624
+#: ../src/richtext/richtextsizepage.cpp:659
+msgid "cm"
+msgstr "cm"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:226
+#: ../src/richtext/richtextbackgroundpage.cpp:249
+#: ../src/richtext/richtextbackgroundpage.cpp:289
+#: ../src/richtext/richtextbackgroundpage.cpp:316
+#: ../src/richtext/richtextborderspage.cpp:254
+#: ../src/richtext/richtextborderspage.cpp:288
+#: ../src/richtext/richtextborderspage.cpp:322
+#: ../src/richtext/richtextborderspage.cpp:356
+#: ../src/richtext/richtextborderspage.cpp:422
+#: ../src/richtext/richtextborderspage.cpp:456
+#: ../src/richtext/richtextborderspage.cpp:490
+#: ../src/richtext/richtextborderspage.cpp:524
+#: ../src/richtext/richtextborderspage.cpp:592
+#: ../src/richtext/richtextfontpage.cpp:176
+#: ../src/richtext/richtextfontpage.cpp:179
+msgid "pt"
+msgstr "pt"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:229
+#: ../src/richtext/richtextbackgroundpage.cpp:231
+#: ../src/richtext/richtextbackgroundpage.cpp:252
+#: ../src/richtext/richtextbackgroundpage.cpp:254
+#: ../src/richtext/richtextbackgroundpage.cpp:292
+#: ../src/richtext/richtextbackgroundpage.cpp:294
+#: ../src/richtext/richtextbackgroundpage.cpp:319
+#: ../src/richtext/richtextbackgroundpage.cpp:321
+msgid "Units for this value."
+msgstr "Unità per stu valore."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:234
+msgid "&Vertical offset:"
+msgstr "Spustime &verticale :"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:241
+#: ../src/richtext/richtextbackgroundpage.cpp:243
+msgid "The vertical offset."
+msgstr "U spustime verticale."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:257
+msgid "Shadow c&olour:"
+msgstr "Cul&ore di l’umbria :"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:259
+#: ../src/richtext/richtextbackgroundpage.cpp:261
+msgid "Enables the shadow colour."
+msgstr "Attiveghja u culore di l’umbria."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:265
+#: ../src/richtext/richtextbackgroundpage.cpp:267
+msgid "The shadow colour."
+msgstr "U culore di l’umbria."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:270
+msgid "Sh&adow spread:"
+msgstr "Sp&arghjimentu di l’umbria :"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:272
+#: ../src/richtext/richtextbackgroundpage.cpp:274
+msgid "Enables the shadow spread."
+msgstr "Attiveghja u sparghjimentu di l’umbria."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:281
+#: ../src/richtext/richtextbackgroundpage.cpp:283
+msgid "The shadow spread."
+msgstr "U sparghjimentu di l’umbria."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:297
+msgid "&Blur distance:"
+msgstr "Distanza di &flosciu :"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:299
+#: ../src/richtext/richtextbackgroundpage.cpp:301
+msgid "Enables the blur distance."
+msgstr "Attiveghja a distanza di flosciu."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:308
+#: ../src/richtext/richtextbackgroundpage.cpp:310
+msgid "The shadow blur distance."
+msgstr "A distanza di flosciu di l’umbria."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:324
+msgid "Opaci&ty:"
+msgstr "Opaci&tà :"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:326
+#: ../src/richtext/richtextbackgroundpage.cpp:328
+msgid "Enables the shadow opacity."
+msgstr "Attiveghja l’opacità di l’umbria."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:335
+#: ../src/richtext/richtextbackgroundpage.cpp:337
+msgid "The shadow opacity."
+msgstr "L’opacità di l’umbria."
+
+#. TRANSLATORS: Rich text page units (percentage)
+#: ../src/richtext/richtextbackgroundpage.cpp:340
+#: ../src/richtext/richtextsizepage.cpp:339
+#: ../src/richtext/richtextsizepage.cpp:373
+#: ../src/richtext/richtextsizepage.cpp:400
+#: ../src/richtext/richtextsizepage.cpp:427
+#: ../src/richtext/richtextsizepage.cpp:454
+#: ../src/richtext/richtextsizepage.cpp:481
+#: ../src/richtext/richtextsizepage.cpp:555
+#: ../src/richtext/richtextsizepage.cpp:590
+#: ../src/richtext/richtextsizepage.cpp:625
+#: ../src/richtext/richtextsizepage.cpp:660
+msgid "%"
+msgstr "%"
+
+#: ../src/richtext/richtextborderspage.cpp:229
+#: ../src/richtext/richtextborderspage.cpp:387
+msgid "Border"
+msgstr "Bordu"
+
+#: ../src/richtext/richtextborderspage.cpp:242
+#: ../src/richtext/richtextborderspage.cpp:410
+#: ../src/richtext/richtextindentspage.cpp:194
+#: ../src/richtext/richtextliststylepage.cpp:384
+#: ../src/richtext/richtextmarginspage.cpp:185
+#: ../src/richtext/richtextmarginspage.cpp:299
+#: ../src/richtext/richtextsizepage.cpp:531
+#: ../src/richtext/richtextsizepage.cpp:538
+msgid "&Left:"
+msgstr "&Manca :"
+
+#: ../src/richtext/richtextborderspage.cpp:257
+#: ../src/richtext/richtextborderspage.cpp:259
+msgid "Units for the left border width."
+msgstr "Unità per a larghezza di u bordu mancu."
+
+#: ../src/richtext/richtextborderspage.cpp:266
+#: ../src/richtext/richtextborderspage.cpp:268
+#: ../src/richtext/richtextborderspage.cpp:300
+#: ../src/richtext/richtextborderspage.cpp:302
+#: ../src/richtext/richtextborderspage.cpp:334
+#: ../src/richtext/richtextborderspage.cpp:336
+#: ../src/richtext/richtextborderspage.cpp:368
+#: ../src/richtext/richtextborderspage.cpp:370
+#: ../src/richtext/richtextborderspage.cpp:434
+#: ../src/richtext/richtextborderspage.cpp:436
+#: ../src/richtext/richtextborderspage.cpp:468
+#: ../src/richtext/richtextborderspage.cpp:470
+#: ../src/richtext/richtextborderspage.cpp:502
+#: ../src/richtext/richtextborderspage.cpp:504
+#: ../src/richtext/richtextborderspage.cpp:536
+#: ../src/richtext/richtextborderspage.cpp:538
+msgid "The border line style."
+msgstr "A linea di stilu di u bordu."
+
+#: ../src/richtext/richtextborderspage.cpp:276
+#: ../src/richtext/richtextborderspage.cpp:444
+#: ../src/richtext/richtextindentspage.cpp:212
+#: ../src/richtext/richtextliststylepage.cpp:402
+#: ../src/richtext/richtextmarginspage.cpp:210
+#: ../src/richtext/richtextmarginspage.cpp:324
+#: ../src/richtext/richtextsizepage.cpp:601
+#: ../src/richtext/richtextsizepage.cpp:608
+msgid "&Right:"
+msgstr "&Diritta :"
+
+#: ../src/richtext/richtextborderspage.cpp:291
+#: ../src/richtext/richtextborderspage.cpp:293
+msgid "Units for the right border width."
+msgstr "Unità per a larghezza di u bordu dirittu."
+
+#: ../src/richtext/richtextborderspage.cpp:310
+#: ../src/richtext/richtextborderspage.cpp:478
+#: ../src/richtext/richtextmarginspage.cpp:233
+#: ../src/richtext/richtextmarginspage.cpp:347
+#: ../src/richtext/richtextsizepage.cpp:566
+#: ../src/richtext/richtextsizepage.cpp:573
+msgid "&Top:"
+msgstr "&Altu :"
+
+#: ../src/richtext/richtextborderspage.cpp:325
+#: ../src/richtext/richtextborderspage.cpp:327
+msgid "Units for the top border width."
+msgstr "Unità per a larghezza di u bordu superiore."
+
+#: ../src/richtext/richtextborderspage.cpp:344
+#: ../src/richtext/richtextborderspage.cpp:512
+#: ../src/richtext/richtextmarginspage.cpp:258
+#: ../src/richtext/richtextmarginspage.cpp:372
+#: ../src/richtext/richtextsizepage.cpp:636
+#: ../src/richtext/richtextsizepage.cpp:643
+msgid "&Bottom:"
+msgstr "&Bassu :"
+
+#: ../src/richtext/richtextborderspage.cpp:359
+#: ../src/richtext/richtextborderspage.cpp:361
+msgid "Units for the bottom border width."
+msgstr "Unità per a larghezza di u bordu inferiore."
+
+#: ../src/richtext/richtextborderspage.cpp:380
+#: ../src/richtext/richtextborderspage.cpp:548
+msgid "&Synchronize values"
+msgstr "&Sincrunizà i valori"
+
+#: ../src/richtext/richtextborderspage.cpp:382
+#: ../src/richtext/richtextborderspage.cpp:384
+#: ../src/richtext/richtextborderspage.cpp:550
+#: ../src/richtext/richtextborderspage.cpp:552
+msgid "Check to edit all borders simultaneously."
+msgstr "Selezziunà per mudificà attempu tutti i bordi."
+
+#: ../src/richtext/richtextborderspage.cpp:397
+#: ../src/richtext/richtextborderspage.cpp:555
+msgid "Outline"
+msgstr "Cuntornu"
+
+#: ../src/richtext/richtextborderspage.cpp:425
+#: ../src/richtext/richtextborderspage.cpp:427
+msgid "Units for the left outline width."
+msgstr "Unità per a larghezza di u cuntornu mancu."
+
+#: ../src/richtext/richtextborderspage.cpp:459
+#: ../src/richtext/richtextborderspage.cpp:461
+msgid "Units for the right outline width."
+msgstr "Unità per a larghezza di u cuntornu dirittu."
+
+#: ../src/richtext/richtextborderspage.cpp:493
+#: ../src/richtext/richtextborderspage.cpp:495
+msgid "Units for the top outline width."
+msgstr "Unità per a larghezza di u cuntornu superiore."
+
+#: ../src/richtext/richtextborderspage.cpp:527
+#: ../src/richtext/richtextborderspage.cpp:529
+msgid "Units for the bottom outline width."
+msgstr "Unità per a larghezza di u cuntornu inferiore."
+
+#: ../src/richtext/richtextborderspage.cpp:565
+#: ../src/richtext/richtextborderspage.cpp:600
+msgid "Corner"
+msgstr "Scornu"
+
+#: ../src/richtext/richtextborderspage.cpp:574
+msgid "Corner &radius:"
+msgstr "&Raghju di curvatura di i scorni :"
+
+#: ../src/richtext/richtextborderspage.cpp:576
+#: ../src/richtext/richtextborderspage.cpp:578
+msgid "An optional corner radius for adding rounded corners."
+msgstr "Un raghju di curvatura ozzionale per aghjunghje scorni tunduluti."
+
+#: ../src/richtext/richtextborderspage.cpp:584
+#: ../src/richtext/richtextborderspage.cpp:586
+msgid "The value of the corner radius."
+msgstr "U valore di u raghju di curvatura di i scorni."
+
+#: ../src/richtext/richtextborderspage.cpp:595
+#: ../src/richtext/richtextborderspage.cpp:597
+msgid "Units for the corner radius."
+msgstr "Unità per u raghju di curvatura di i scorni."
+
+#: ../src/richtext/richtextborderspage.cpp:609
+#: ../src/richtext/richtextsizepage.cpp:247
+#: ../src/richtext/richtextsizepage.cpp:251
+msgid "None"
+msgstr "Alcunu"
+
+#: ../src/richtext/richtextborderspage.cpp:610
+msgid "Solid"
+msgstr "Solidu"
+
+#: ../src/richtext/richtextborderspage.cpp:611
+msgid "Dotted"
+msgstr "Puntighjatu"
+
+#: ../src/richtext/richtextborderspage.cpp:612
+msgid "Dashed"
+msgstr "Lineette"
+
+#: ../src/richtext/richtextborderspage.cpp:613
+msgid "Double"
+msgstr "Doppiu"
+
+#: ../src/richtext/richtextborderspage.cpp:614
+msgid "Groove"
+msgstr "Scanalatura"
+
+#: ../src/richtext/richtextborderspage.cpp:615
+msgid "Ridge"
+msgstr "Crinale"
+
+#: ../src/richtext/richtextborderspage.cpp:616
+msgid "Inset"
+msgstr "Internu"
+
+#: ../src/richtext/richtextborderspage.cpp:617
+msgid "Outset"
+msgstr "Esternu"
+
+#: ../src/richtext/richtextbuffer.cpp:3518
+msgid "Change Style"
+msgstr "Cambià u stilu"
+
+#: ../src/richtext/richtextbuffer.cpp:3701
+msgid "Change Object Style"
+msgstr "Cambià u stilu di l’oggettu"
+
+#: ../src/richtext/richtextbuffer.cpp:3974
+#: ../src/richtext/richtextbuffer.cpp:8174
+msgid "Change Properties"
+msgstr "Cambià e pruprietà"
+
+#: ../src/richtext/richtextbuffer.cpp:4346
+msgid "Change List Style"
+msgstr "Cambià u stilu di a lista"
+
+#: ../src/richtext/richtextbuffer.cpp:4519
+msgid "Renumber List"
+msgstr "Rinumerà a lista"
+
+#: ../src/richtext/richtextbuffer.cpp:7867
+#: ../src/richtext/richtextbuffer.cpp:7897
+#: ../src/richtext/richtextbuffer.cpp:7939
+#: ../src/richtext/richtextctrl.cpp:1279 ../src/richtext/richtextctrl.cpp:1473
+msgid "Insert Text"
+msgstr "Framette un testu"
+
+#: ../src/richtext/richtextbuffer.cpp:8023
+#: ../src/richtext/richtextbuffer.cpp:8979
+msgid "Insert Image"
+msgstr "Framette una fiura"
+
+#: ../src/richtext/richtextbuffer.cpp:8070
+msgid "Insert Object"
+msgstr "Framette un oggettu"
+
+#: ../src/richtext/richtextbuffer.cpp:8112
+msgid "Insert Field"
+msgstr "Framette un campu"
+
+#: ../src/richtext/richtextbuffer.cpp:8410
+msgid "Too many EndStyle calls!"
+msgstr "Troppu chjamate à EndStyle !"
+
+#: ../src/richtext/richtextbuffer.cpp:8785
+msgid "files"
+msgstr "schedarii"
+
+#: ../src/richtext/richtextbuffer.cpp:9380
+msgid "standard/circle"
+msgstr "classicu/circulare"
+
+#: ../src/richtext/richtextbuffer.cpp:9381
+msgid "standard/circle-outline"
+msgstr "classicu/cuntornu circulare"
+
+#: ../src/richtext/richtextbuffer.cpp:9382
+msgid "standard/square"
+msgstr "classicu/quadratu"
+
+#: ../src/richtext/richtextbuffer.cpp:9383
+msgid "standard/diamond"
+msgstr "classicu/lusanga"
+
+#: ../src/richtext/richtextbuffer.cpp:9384
+msgid "standard/triangle"
+msgstr "classicu/triangulu"
+
+#: ../src/richtext/richtextbuffer.cpp:9423
+msgid "Box Properties"
+msgstr "Pruprietà di a scatula"
+
+#: ../src/richtext/richtextbuffer.cpp:10006
+msgid "Multiple Cell Properties"
+msgstr "Pruprietà di cellule multiple"
+
+#: ../src/richtext/richtextbuffer.cpp:10008
+msgid "Cell Properties"
+msgstr "Pruprietà di cellula"
+
+#: ../src/richtext/richtextbuffer.cpp:11256
+msgid "Set Cell Style"
+msgstr "Definisce u stilu di cellula"
+
+#: ../src/richtext/richtextbuffer.cpp:11330
+msgid "Delete Row"
+msgstr "Squassà una linea"
+
+#: ../src/richtext/richtextbuffer.cpp:11380
+msgid "Delete Column"
+msgstr "Squassà una culonna"
+
+#: ../src/richtext/richtextbuffer.cpp:11431
+msgid "Add Row"
+msgstr "Aghjunghje una linea"
+
+#: ../src/richtext/richtextbuffer.cpp:11494
+msgid "Add Column"
+msgstr "Aghjunghje una culonna"
+
+#: ../src/richtext/richtextbuffer.cpp:11537
+msgid "Table Properties"
+msgstr "Pruprietà di u tavulone"
+
+#: ../src/richtext/richtextbuffer.cpp:12899
+msgid "Picture Properties"
+msgstr "Pruprietà di a fiura"
+
+#: ../src/richtext/richtextbuffer.cpp:13169
+#: ../src/richtext/richtextbuffer.cpp:13279
+msgid "image"
+msgstr "fiura"
+
+#: ../src/richtext/richtextbulletspage.cpp:145
+#: ../src/richtext/richtextliststylepage.cpp:209
+msgid "&Bullet style:"
+msgstr "&Stilu di puce :"
+
+#: ../src/richtext/richtextbulletspage.cpp:150
+#: ../src/richtext/richtextbulletspage.cpp:152
+#: ../src/richtext/richtextliststylepage.cpp:214
+#: ../src/richtext/richtextliststylepage.cpp:216
+msgid "The available bullet styles."
+msgstr "I stili di puce dispunibule."
+
+#: ../src/richtext/richtextbulletspage.cpp:158
+#: ../src/richtext/richtextliststylepage.cpp:221
+msgid "Peri&od"
+msgstr "P&untu"
+
+#: ../src/richtext/richtextbulletspage.cpp:160
+#: ../src/richtext/richtextbulletspage.cpp:162
+#: ../src/richtext/richtextliststylepage.cpp:223
+#: ../src/richtext/richtextliststylepage.cpp:225
+msgid "Check to add a period after the bullet."
+msgstr "Selezziunà per aghjunghje un puntu dopu à a puce."
+
+#. TRANSLATORS: Bullet point in parentheses option
+#: ../src/richtext/richtextbulletspage.cpp:167
+#: ../src/richtext/richtextliststylepage.cpp:230
+msgid "(*)"
+msgstr "(*)"
+
+#: ../src/richtext/richtextbulletspage.cpp:169
+#: ../src/richtext/richtextbulletspage.cpp:171
+#: ../src/richtext/richtextliststylepage.cpp:232
+#: ../src/richtext/richtextliststylepage.cpp:234
+msgid "Check to enclose the bullet in parentheses."
+msgstr "Selezziunà per inserisce a puce trà parentesi."
+
+#. TRANSLATORS: Right parenthesis bullet point option
+#: ../src/richtext/richtextbulletspage.cpp:176
+#: ../src/richtext/richtextliststylepage.cpp:239
+msgid "*)"
+msgstr "*)"
+
+#: ../src/richtext/richtextbulletspage.cpp:178
+#: ../src/richtext/richtextbulletspage.cpp:180
+#: ../src/richtext/richtextliststylepage.cpp:241
+#: ../src/richtext/richtextliststylepage.cpp:243
+msgid "Check to add a right parenthesis."
+msgstr "Selezziunà per aghjunghje una parentesi diritta."
+
+#: ../src/richtext/richtextbulletspage.cpp:185
+#: ../src/richtext/richtextliststylepage.cpp:248
+msgid "Bullet &Alignment:"
+msgstr "&Aliniamentu di a puce :"
+
+#: ../src/richtext/richtextbulletspage.cpp:190
+#: ../src/richtext/richtextliststylepage.cpp:253
+msgid "Centre"
+msgstr "Centru"
+
+#: ../src/richtext/richtextbulletspage.cpp:194
+#: ../src/richtext/richtextbulletspage.cpp:196
+#: ../src/richtext/richtextbulletspage.cpp:217
+#: ../src/richtext/richtextbulletspage.cpp:219
+#: ../src/richtext/richtextliststylepage.cpp:257
+#: ../src/richtext/richtextliststylepage.cpp:259
+#: ../src/richtext/richtextliststylepage.cpp:278
+#: ../src/richtext/richtextliststylepage.cpp:280
+msgid "The bullet character."
+msgstr "U caratteru per a puce."
+
+#: ../src/richtext/richtextbulletspage.cpp:212
+#: ../src/richtext/richtextliststylepage.cpp:271
+msgid "&Symbol:"
+msgstr "&Simbulu :"
+
+#: ../src/richtext/richtextbulletspage.cpp:222
+#: ../src/richtext/richtextliststylepage.cpp:283
+msgid "Ch&oose..."
+msgstr "&Sceglie…"
+
+#: ../src/richtext/richtextbulletspage.cpp:223
+#: ../src/richtext/richtextbulletspage.cpp:225
+#: ../src/richtext/richtextliststylepage.cpp:284
+#: ../src/richtext/richtextliststylepage.cpp:286
+msgid "Click to browse for a symbol."
+msgstr "Cliccu per circà un simbulu."
+
+#: ../src/richtext/richtextbulletspage.cpp:230
+#: ../src/richtext/richtextliststylepage.cpp:291
+msgid "Symbol &font:"
+msgstr "&Grafia di u simbulu :"
+
+#: ../src/richtext/richtextbulletspage.cpp:235
+#: ../src/richtext/richtextbulletspage.cpp:237
+#: ../src/richtext/richtextliststylepage.cpp:297
+msgid "Available fonts."
+msgstr "Grafie dispunibule."
+
+#: ../src/richtext/richtextbulletspage.cpp:242
+#: ../src/richtext/richtextliststylepage.cpp:302
+msgid "S&tandard bullet name:"
+msgstr "&Nome di puce classica :"
+
+#: ../src/richtext/richtextbulletspage.cpp:247
+#: ../src/richtext/richtextbulletspage.cpp:249
+#: ../src/richtext/richtextliststylepage.cpp:307
+#: ../src/richtext/richtextliststylepage.cpp:309
+msgid "A standard bullet name."
+msgstr "Un nome di puce classica."
+
+#: ../src/richtext/richtextbulletspage.cpp:254
+msgid "&Number:"
+msgstr "&Numeru :"
+
+#: ../src/richtext/richtextbulletspage.cpp:258
+#: ../src/richtext/richtextbulletspage.cpp:260
+msgid "The list item number."
+msgstr "U numeru di l’elementu di a lista."
+
+#: ../src/richtext/richtextbulletspage.cpp:266
+#: ../src/richtext/richtextbulletspage.cpp:268
+#: ../src/richtext/richtextliststylepage.cpp:475
+#: ../src/richtext/richtextliststylepage.cpp:477
+msgid "Shows a preview of the bullet settings."
+msgstr "Affisseghja una fighjulata di i parametri di puce."
+
+#: ../src/richtext/richtextbulletspage.cpp:276
+#: ../src/richtext/richtextliststylepage.cpp:484
+msgid "(None)"
+msgstr "(Nisunu)"
+
+#: ../src/richtext/richtextbulletspage.cpp:277
+#: ../src/richtext/richtextliststylepage.cpp:485
+msgid "Arabic"
+msgstr "Arabu"
+
+#: ../src/richtext/richtextbulletspage.cpp:278
+#: ../src/richtext/richtextliststylepage.cpp:486
+msgid "Upper case letters"
+msgstr "Lettere maiuscule"
+
+#: ../src/richtext/richtextbulletspage.cpp:279
+#: ../src/richtext/richtextliststylepage.cpp:487
+msgid "Lower case letters"
+msgstr "Lettere minuscule"
+
+#: ../src/richtext/richtextbulletspage.cpp:280
+#: ../src/richtext/richtextliststylepage.cpp:488
+msgid "Upper case roman numerals"
+msgstr "Cifri rumani in maiuscule"
+
+#: ../src/richtext/richtextbulletspage.cpp:281
+#: ../src/richtext/richtextliststylepage.cpp:489
+msgid "Lower case roman numerals"
+msgstr "Cifri rumani in minuscule"
+
+#: ../src/richtext/richtextbulletspage.cpp:282
+#: ../src/richtext/richtextliststylepage.cpp:490
+msgid "Numbered outline"
+msgstr "Cuntornu numeratu"
+
+#: ../src/richtext/richtextbulletspage.cpp:283
+#: ../src/richtext/richtextliststylepage.cpp:491
+msgid "Symbol"
+msgstr "Simbulu"
+
+#: ../src/richtext/richtextbulletspage.cpp:284
+#: ../src/richtext/richtextliststylepage.cpp:492
+msgid "Bitmap"
+msgstr "Fiura bitmap"
+
+#: ../src/richtext/richtextbulletspage.cpp:285
+#: ../src/richtext/richtextliststylepage.cpp:493
+msgid "Standard"
+msgstr "Classicu"
+
+#: ../src/richtext/richtextbulletspage.cpp:287
+#: ../src/richtext/richtextliststylepage.cpp:495
+msgid "*"
+msgstr "*"
+
+#: ../src/richtext/richtextbulletspage.cpp:288
+#: ../src/richtext/richtextliststylepage.cpp:496
+msgid "-"
+msgstr "-"
+
+#: ../src/richtext/richtextbulletspage.cpp:289
+#: ../src/richtext/richtextliststylepage.cpp:497
+msgid ">"
+msgstr ">"
+
+#: ../src/richtext/richtextbulletspage.cpp:290
+#: ../src/richtext/richtextliststylepage.cpp:498
+msgid "+"
+msgstr "+"
+
+#: ../src/richtext/richtextbulletspage.cpp:291
+#: ../src/richtext/richtextliststylepage.cpp:499
+msgid "~"
+msgstr "~"
+
+#: ../src/richtext/richtextctrl.cpp:859
+msgid "Drag"
+msgstr "Trascinà"
+
+#: ../src/richtext/richtextctrl.cpp:1338 ../src/richtext/richtextctrl.cpp:1559
+msgid "Delete Text"
+msgstr "Squassà u testu"
+
+#: ../src/richtext/richtextctrl.cpp:1537
+msgid "Remove Bullet"
+msgstr "Caccià a puce"
+
+#: ../src/richtext/richtextctrl.cpp:3070
+msgid "The text couldn't be saved."
+msgstr "U testu ùn pò micca esse arregistratu."
+
+#: ../src/richtext/richtextctrl.cpp:3644
+msgid "Replace"
+msgstr "Rimpiazzà"
+
+#: ../src/richtext/richtextfontpage.cpp:146
+#: ../src/richtext/richtextsymboldlg.cpp:384
+msgid "&Font:"
+msgstr "&Grafia :"
+
+#: ../src/richtext/richtextfontpage.cpp:150
+#: ../src/richtext/richtextfontpage.cpp:152
+msgid "Type a font name."
+msgstr "Stampittà u nome d’una grafia."
+
+#: ../src/richtext/richtextfontpage.cpp:158
+msgid "&Size:"
+msgstr "&Dimensione :"
+
+#: ../src/richtext/richtextfontpage.cpp:165
+#: ../src/richtext/richtextfontpage.cpp:167
+msgid "Type a size in points."
+msgstr "Stampittà una dimensione in punti."
+
+#: ../src/richtext/richtextfontpage.cpp:180
+#: ../src/richtext/richtextfontpage.cpp:182
+msgid "The font size units, points or pixels."
+msgstr "L’unità di dimensione di grafia, punti o pizzeli."
+
+#: ../src/richtext/richtextfontpage.cpp:189
+#: ../src/richtext/richtextfontpage.cpp:191
+msgid "Lists the available fonts."
+msgstr "Lista di e grafie dispunibule."
+
+#: ../src/richtext/richtextfontpage.cpp:196
+#: ../src/richtext/richtextfontpage.cpp:198
+msgid "Lists font sizes in points."
+msgstr "Lista di e dimensioni di grafia in punti."
+
+#: ../src/richtext/richtextfontpage.cpp:207
+msgid "Font st&yle:"
+msgstr "St&ilu di a grafia :"
+
+#: ../src/richtext/richtextfontpage.cpp:212
+#: ../src/richtext/richtextfontpage.cpp:214
+msgid "Select regular or italic style."
+msgstr "Selezziunà u stilu ordinariu o cursiva."
+
+#: ../src/richtext/richtextfontpage.cpp:220
+msgid "Font &weight:"
+msgstr "A spess&ore di a grafia :"
+
+#: ../src/richtext/richtextfontpage.cpp:225
+#: ../src/richtext/richtextfontpage.cpp:227
+msgid "Select regular or bold."
+msgstr "Selezziunà a spessore nurmale o grassa."
+
+#: ../src/richtext/richtextfontpage.cpp:233
+msgid "&Underlining:"
+msgstr "&Sottulineamentu :"
+
+#: ../src/richtext/richtextfontpage.cpp:238
+#: ../src/richtext/richtextfontpage.cpp:240
+msgid "Select underlining or no underlining."
+msgstr "Selezziunà cù o senza sottulineamentu."
+
+#: ../src/richtext/richtextfontpage.cpp:248
+msgid "&Colour:"
+msgstr "&Culore :"
+
+#: ../src/richtext/richtextfontpage.cpp:253
+#: ../src/richtext/richtextfontpage.cpp:255
+msgid "Click to change the text colour."
+msgstr "Cliccu per cambià u culore di u testu."
+
+#: ../src/richtext/richtextfontpage.cpp:261
+msgid "&Bg colour:"
+msgstr "&Culore di sfondulu :"
+
+#: ../src/richtext/richtextfontpage.cpp:266
+#: ../src/richtext/richtextfontpage.cpp:268
+msgid "Click to change the text background colour."
+msgstr "Cliccu per cambià u culore di sfondulu di u testu."
+
+#: ../src/richtext/richtextfontpage.cpp:276
+#: ../src/richtext/richtextfontpage.cpp:278
+msgid "Check to show a line through the text."
+msgstr "Selezziunà per affissà una linea attraversendu u testu."
+
+#: ../src/richtext/richtextfontpage.cpp:281
+msgid "Ca&pitals"
+msgstr "&Maiuscule"
+
+#: ../src/richtext/richtextfontpage.cpp:283
+#: ../src/richtext/richtextfontpage.cpp:285
+msgid "Check to show the text in capitals."
+msgstr "Selezziunà per affissà u testu in maiuscule."
+
+#: ../src/richtext/richtextfontpage.cpp:288
+msgid "Small C&apitals"
+msgstr "&Chjuche maiuscule"
+
+#: ../src/richtext/richtextfontpage.cpp:290
+#: ../src/richtext/richtextfontpage.cpp:292
+msgid "Check to show the text in small capitals."
+msgstr "Selezziunà per affissà u testu in chjuche maiuscule."
+
+#: ../src/richtext/richtextfontpage.cpp:295
+msgid "Supe&rscript"
+msgstr "&Espunente"
+
+#: ../src/richtext/richtextfontpage.cpp:297
+#: ../src/richtext/richtextfontpage.cpp:299
+msgid "Check to show the text in superscript."
+msgstr "Selezziunà per affissà u testu in espunenti."
+
+#: ../src/richtext/richtextfontpage.cpp:302
+msgid "Subscrip&t"
+msgstr "&Indice"
+
+#: ../src/richtext/richtextfontpage.cpp:304
+#: ../src/richtext/richtextfontpage.cpp:306
+msgid "Check to show the text in subscript."
+msgstr "Selezziunà per affissà u testu in indice."
+
+#: ../src/richtext/richtextfontpage.cpp:312
+msgid "Rig&ht-to-left"
+msgstr "&Da-diritta-à-manca"
+
+#: ../src/richtext/richtextfontpage.cpp:314
+#: ../src/richtext/richtextfontpage.cpp:316
+msgid "Check to indicate right-to-left text layout."
+msgstr "Selezziunà per indicà un accunciamentu di testu da diritta à manca."
+
+#: ../src/richtext/richtextfontpage.cpp:319
+msgid "Suppress hyphe&nation"
+msgstr "Squassà a &tagliatura di e parolle"
+
+#: ../src/richtext/richtextfontpage.cpp:321
+#: ../src/richtext/richtextfontpage.cpp:323
+msgid "Check to suppress hyphenation."
+msgstr "Selezziunà per squassà a tagliatura di e parolle."
+
+#: ../src/richtext/richtextfontpage.cpp:329
+#: ../src/richtext/richtextfontpage.cpp:331
+msgid "Shows a preview of the font settings."
+msgstr "Affisseghja una fighjulata di i parametri di grafia."
+
+#: ../src/richtext/richtextfontpage.cpp:348
+#: ../src/richtext/richtextfontpage.cpp:352
+#: ../src/richtext/richtextfontpage.cpp:356
+#: ../src/richtext/richtextformatdlg.cpp:873
+#: ../src/richtext/richtextindentspage.cpp:273
+#: ../src/richtext/richtextindentspage.cpp:285
+#: ../src/richtext/richtextindentspage.cpp:286
+#: ../src/richtext/richtextindentspage.cpp:310
+#: ../src/richtext/richtextindentspage.cpp:325
+#: ../src/richtext/richtextliststylepage.cpp:451
+#: ../src/richtext/richtextliststylepage.cpp:463
+#: ../src/richtext/richtextliststylepage.cpp:464
+msgid "(none)"
+msgstr "(nisunu)"
+
+#: ../src/richtext/richtextfontpage.cpp:349
+#: ../src/richtext/richtextfontpage.cpp:353
+msgid "Regular"
+msgstr "Regulare"
+
+#: ../src/richtext/richtextfontpage.cpp:357
+msgid "Not underlined"
+msgstr "Non sottulineatu"
+
+#: ../src/richtext/richtextformatdlg.cpp:341
+msgid "Indents && Spacing"
+msgstr "Indentazione è spazii"
+
+#: ../src/richtext/richtextformatdlg.cpp:346
+msgid "Tabs"
+msgstr "Tabulazioni"
+
+#: ../src/richtext/richtextformatdlg.cpp:351
+msgid "Bullets"
+msgstr "Puci"
+
+#: ../src/richtext/richtextformatdlg.cpp:356
+msgid "List Style"
+msgstr "Stilu di lista"
+
+#: ../src/richtext/richtextformatdlg.cpp:366
+#: ../src/richtext/richtextmarginspage.cpp:170
+msgid "Margins"
+msgstr "Margine"
+
+#: ../src/richtext/richtextformatdlg.cpp:371
+msgid "Borders"
+msgstr "Bordi"
+
+#: ../src/richtext/richtextformatdlg.cpp:765
+msgid "Colour"
+msgstr "Culore"
+
+#: ../src/richtext/richtextindentspage.cpp:127
+#: ../src/richtext/richtextliststylepage.cpp:322
+msgid "&Alignment"
+msgstr "&Aliniamentu"
+
+#: ../src/richtext/richtextindentspage.cpp:138
+#: ../src/richtext/richtextliststylepage.cpp:331
+msgid "&Left"
+msgstr "&Manca"
+
+#: ../src/richtext/richtextindentspage.cpp:140
+#: ../src/richtext/richtextindentspage.cpp:142
+#: ../src/richtext/richtextliststylepage.cpp:333
+#: ../src/richtext/richtextliststylepage.cpp:335
+msgid "Left-align text."
+msgstr "Testu aliniatu à manca."
+
+#: ../src/richtext/richtextindentspage.cpp:145
+#: ../src/richtext/richtextliststylepage.cpp:338
+msgid "&Right"
+msgstr "&Diritta"
+
+#: ../src/richtext/richtextindentspage.cpp:147
+#: ../src/richtext/richtextindentspage.cpp:149
+#: ../src/richtext/richtextliststylepage.cpp:340
+#: ../src/richtext/richtextliststylepage.cpp:342
+msgid "Right-align text."
+msgstr "Testu aliniatu à diritta."
+
+#: ../src/richtext/richtextindentspage.cpp:152
+#: ../src/richtext/richtextliststylepage.cpp:345
+msgid "&Justified"
+msgstr "&Ghjustificatu"
+
+#: ../src/richtext/richtextindentspage.cpp:154
+#: ../src/richtext/richtextindentspage.cpp:156
+#: ../src/richtext/richtextliststylepage.cpp:347
+#: ../src/richtext/richtextliststylepage.cpp:349
+msgid "Justify text left and right."
+msgstr "Ghjustificà u testu à manca è à diritta."
+
+#: ../src/richtext/richtextindentspage.cpp:159
+#: ../src/richtext/richtextliststylepage.cpp:352
+msgid "Cen&tred"
+msgstr "Cen&tratu"
+
+#: ../src/richtext/richtextindentspage.cpp:161
+#: ../src/richtext/richtextindentspage.cpp:163
+#: ../src/richtext/richtextliststylepage.cpp:354
+#: ../src/richtext/richtextliststylepage.cpp:356
+msgid "Centre text."
+msgstr "Centrà u testu."
+
+#: ../src/richtext/richtextindentspage.cpp:166
+#: ../src/richtext/richtextliststylepage.cpp:359
+msgid "&Indeterminate"
+msgstr "&Indeterminatu"
+
+#: ../src/richtext/richtextindentspage.cpp:168
+#: ../src/richtext/richtextindentspage.cpp:170
+#: ../src/richtext/richtextliststylepage.cpp:361
+#: ../src/richtext/richtextliststylepage.cpp:363
+msgid "Use the current alignment setting."
+msgstr "Impiegà u parametru currente d’aliniamentu."
+
+#: ../src/richtext/richtextindentspage.cpp:183
+#: ../src/richtext/richtextliststylepage.cpp:375
+msgid "&Indentation (tenths of a mm)"
+msgstr "&Indentazione (decine di mm)"
+
+#: ../src/richtext/richtextindentspage.cpp:198
+#: ../src/richtext/richtextindentspage.cpp:200
+#: ../src/richtext/richtextliststylepage.cpp:388
+#: ../src/richtext/richtextliststylepage.cpp:390
+msgid "The left indent."
+msgstr "L’indentazione à manca."
+
+#: ../src/richtext/richtextindentspage.cpp:203
+#: ../src/richtext/richtextliststylepage.cpp:393
+msgid "Left (&first line):"
+msgstr "Manca (&prima linea) :"
+
+#: ../src/richtext/richtextindentspage.cpp:207
+#: ../src/richtext/richtextindentspage.cpp:209
+#: ../src/richtext/richtextliststylepage.cpp:397
+#: ../src/richtext/richtextliststylepage.cpp:399
+msgid "The first line indent."
+msgstr "L’indentazione di a prima linea."
+
+#: ../src/richtext/richtextindentspage.cpp:216
+#: ../src/richtext/richtextindentspage.cpp:218
+#: ../src/richtext/richtextliststylepage.cpp:406
+#: ../src/richtext/richtextliststylepage.cpp:408
+msgid "The right indent."
+msgstr "L’indentazione à diritta."
+
+#: ../src/richtext/richtextindentspage.cpp:221
+msgid "&Outline level:"
+msgstr "Livellu di &cuntornu :"
+
+#: ../src/richtext/richtextindentspage.cpp:226
+#: ../src/richtext/richtextindentspage.cpp:228
+msgid "The outline level."
+msgstr "U livellu di u cuntornu."
+
+#: ../src/richtext/richtextindentspage.cpp:241
+#: ../src/richtext/richtextliststylepage.cpp:420
+msgid "&Spacing (tenths of a mm)"
+msgstr "&Spaziamentu (decine di mm)"
+
+#: ../src/richtext/richtextindentspage.cpp:252
+msgid "&Before a paragraph:"
+msgstr "&Nanzu à un paragrafu :"
+
+#: ../src/richtext/richtextindentspage.cpp:256
+#: ../src/richtext/richtextindentspage.cpp:258
+#: ../src/richtext/richtextliststylepage.cpp:433
+#: ../src/richtext/richtextliststylepage.cpp:435
+msgid "The spacing before the paragraph."
+msgstr "U spaziamentu nanzu à un paragrafu."
+
+#: ../src/richtext/richtextindentspage.cpp:261
+msgid "&After a paragraph:"
+msgstr "&Dopu à un paragrafu :"
+
+#: ../src/richtext/richtextindentspage.cpp:266
+#: ../src/richtext/richtextliststylepage.cpp:442
+#: ../src/richtext/richtextliststylepage.cpp:444
+msgid "The spacing after the paragraph."
+msgstr "U spaziamentu dopu à un paragrafu."
+
+#: ../src/richtext/richtextindentspage.cpp:269
+msgid "L&ine spacing:"
+msgstr "&Interlinea :"
+
+#: ../src/richtext/richtextindentspage.cpp:274
+#: ../src/richtext/richtextliststylepage.cpp:452
+msgid "Single"
+msgstr "Simplice"
+
+#: ../src/richtext/richtextindentspage.cpp:275
+#: ../src/richtext/richtextliststylepage.cpp:453
+msgid "1.1"
+msgstr "1,1"
+
+#: ../src/richtext/richtextindentspage.cpp:276
+#: ../src/richtext/richtextliststylepage.cpp:454
+msgid "1.2"
+msgstr "1,2"
+
+#: ../src/richtext/richtextindentspage.cpp:277
+#: ../src/richtext/richtextliststylepage.cpp:455
+msgid "1.3"
+msgstr "1,3"
+
+#: ../src/richtext/richtextindentspage.cpp:278
+#: ../src/richtext/richtextliststylepage.cpp:456
+msgid "1.4"
+msgstr "1,4"
+
+#: ../src/richtext/richtextindentspage.cpp:279
+#: ../src/richtext/richtextliststylepage.cpp:457
+msgid "1.5"
+msgstr "1,5"
+
+#: ../src/richtext/richtextindentspage.cpp:280
+#: ../src/richtext/richtextliststylepage.cpp:458
+msgid "1.6"
+msgstr "1,6"
+
+#: ../src/richtext/richtextindentspage.cpp:281
+#: ../src/richtext/richtextliststylepage.cpp:459
+msgid "1.7"
+msgstr "1,7"
+
+#: ../src/richtext/richtextindentspage.cpp:282
+#: ../src/richtext/richtextliststylepage.cpp:460
+msgid "1.8"
+msgstr "1,8"
+
+#: ../src/richtext/richtextindentspage.cpp:283
+#: ../src/richtext/richtextliststylepage.cpp:461
+msgid "1.9"
+msgstr "1,9"
+
+#: ../src/richtext/richtextindentspage.cpp:284
+#: ../src/richtext/richtextliststylepage.cpp:462
+msgid "2"
+msgstr "2"
+
+#: ../src/richtext/richtextindentspage.cpp:287
+#: ../src/richtext/richtextindentspage.cpp:289
+#: ../src/richtext/richtextliststylepage.cpp:465
+#: ../src/richtext/richtextliststylepage.cpp:467
+msgid "The line spacing."
+msgstr "U spaziamentu trà e linee."
+
+#: ../src/richtext/richtextindentspage.cpp:292
+msgid "&Page Break"
+msgstr "Saltu di &pagina"
+
+#: ../src/richtext/richtextindentspage.cpp:294
+#: ../src/richtext/richtextindentspage.cpp:296
+msgid "Inserts a page break before the paragraph."
+msgstr "Framette un saltu di pagina nanzu à u paragrafu."
+
+#: ../src/richtext/richtextindentspage.cpp:302
+#: ../src/richtext/richtextindentspage.cpp:304
+msgid "Shows a preview of the paragraph settings."
+msgstr "Affisseghja una fighjulata di i parametri di paragrafu."
+
+#: ../src/richtext/richtextliststylepage.cpp:182
+msgid "&List level:"
+msgstr "&Livellu di lista :"
+
+#: ../src/richtext/richtextliststylepage.cpp:186
+#: ../src/richtext/richtextliststylepage.cpp:188
+msgid "Selects the list level to edit."
+msgstr "Sceglie u livellu di lista à mudificà."
+
+#: ../src/richtext/richtextliststylepage.cpp:193
+msgid "&Font for Level..."
+msgstr "&Grafia per u livellu…"
+
+#: ../src/richtext/richtextliststylepage.cpp:194
+#: ../src/richtext/richtextliststylepage.cpp:196
+msgid "Click to choose the font for this level."
+msgstr "Cliccu per sceglie a grafia per stu livellu."
+
+#: ../src/richtext/richtextliststylepage.cpp:312
+msgid "Bullet style"
+msgstr "Stilu di puce"
+
+#: ../src/richtext/richtextliststylepage.cpp:429
+msgid "Before a paragraph:"
+msgstr "Nanzu à un paragrafu :"
+
+#: ../src/richtext/richtextliststylepage.cpp:438
+msgid "After a paragraph:"
+msgstr "Dopu à un paragrafu :"
+
+#: ../src/richtext/richtextliststylepage.cpp:447
+msgid "Line spacing:"
+msgstr "Interlinea :"
+
+#: ../src/richtext/richtextliststylepage.cpp:470
+msgid "Spacing"
+msgstr "Spaziamentu"
+
+#: ../src/richtext/richtextmarginspage.cpp:193
+#: ../src/richtext/richtextmarginspage.cpp:195
+msgid "The left margin size."
+msgstr "A dimensione di a margine à manca."
+
+#: ../src/richtext/richtextmarginspage.cpp:203
+#: ../src/richtext/richtextmarginspage.cpp:205
+msgid "Units for the left margin."
+msgstr "Unità per a margine à manca."
+
+#: ../src/richtext/richtextmarginspage.cpp:218
+#: ../src/richtext/richtextmarginspage.cpp:220
+msgid "The right margin size."
+msgstr "A dimensione di a margine à diritta."
+
+#: ../src/richtext/richtextmarginspage.cpp:228
+#: ../src/richtext/richtextmarginspage.cpp:230
+msgid "Units for the right margin."
+msgstr "Unità per a margine à diritta."
+
+#: ../src/richtext/richtextmarginspage.cpp:241
+#: ../src/richtext/richtextmarginspage.cpp:243
+msgid "The top margin size."
+msgstr "A dimensione di a margine superiore."
+
+#: ../src/richtext/richtextmarginspage.cpp:251
+#: ../src/richtext/richtextmarginspage.cpp:253
+msgid "Units for the top margin."
+msgstr "Unità per a margine superiore."
+
+#: ../src/richtext/richtextmarginspage.cpp:266
+#: ../src/richtext/richtextmarginspage.cpp:268
+msgid "The bottom margin size."
+msgstr "A dimensione di a margine inferiore."
+
+#: ../src/richtext/richtextmarginspage.cpp:276
+#: ../src/richtext/richtextmarginspage.cpp:278
+msgid "Units for the bottom margin."
+msgstr "Unità per a margine inferiore."
+
+#: ../src/richtext/richtextmarginspage.cpp:284
+msgid "Padding"
+msgstr "Riempiimentu"
+
+#: ../src/richtext/richtextmarginspage.cpp:307
+#: ../src/richtext/richtextmarginspage.cpp:309
+msgid "The left padding size."
+msgstr "A dimensione di u riempiimentu à manca."
+
+#: ../src/richtext/richtextmarginspage.cpp:317
+#: ../src/richtext/richtextmarginspage.cpp:319
+msgid "Units for the left padding."
+msgstr "Unità per u riempiimentu à manca."
+
+#: ../src/richtext/richtextmarginspage.cpp:332
+#: ../src/richtext/richtextmarginspage.cpp:334
+msgid "The right padding size."
+msgstr "A dimensione di u riempiimentu à diritta."
+
+#: ../src/richtext/richtextmarginspage.cpp:342
+#: ../src/richtext/richtextmarginspage.cpp:344
+msgid "Units for the right padding."
+msgstr "Unità per u riempiimentu à diritta."
+
+#: ../src/richtext/richtextmarginspage.cpp:355
+#: ../src/richtext/richtextmarginspage.cpp:357
+msgid "The top padding size."
+msgstr "A dimensione di u riempiimentu superiore."
+
+#: ../src/richtext/richtextmarginspage.cpp:365
+#: ../src/richtext/richtextmarginspage.cpp:367
+msgid "Units for the top padding."
+msgstr "Unità per u riempiimentu superiore."
+
+#: ../src/richtext/richtextmarginspage.cpp:380
+#: ../src/richtext/richtextmarginspage.cpp:382
+msgid "The bottom padding size."
+msgstr "A dimensione di u riempiimentu inferiore."
+
+#: ../src/richtext/richtextmarginspage.cpp:390
+#: ../src/richtext/richtextmarginspage.cpp:392
+msgid "Units for the bottom padding."
+msgstr "Unità per u riempiimentu inferiore."
+
+#: ../src/richtext/richtextprint.cpp:592
+msgid " Preview"
+msgstr " Fighjulata"
+
+#: ../src/richtext/richtextsizepage.cpp:228
+msgid "Floating"
+msgstr "Undighjante"
+
+#: ../src/richtext/richtextsizepage.cpp:243
+msgid "&Floating mode:"
+msgstr "Modu &undighjante :"
+
+#: ../src/richtext/richtextsizepage.cpp:252
+#: ../src/richtext/richtextsizepage.cpp:254
+msgid "How the object will float relative to the text."
+msgstr "Cumu l’oggettu undighjerà secondu à u testu."
+
+#: ../src/richtext/richtextsizepage.cpp:265
+msgid "Alignment"
+msgstr "Aliniamentu"
+
+#: ../src/richtext/richtextsizepage.cpp:277
+msgid "&Vertical alignment:"
+msgstr "Aliniamentu &verticale :"
+
+#: ../src/richtext/richtextsizepage.cpp:279
+#: ../src/richtext/richtextsizepage.cpp:281
+msgid "Enable vertical alignment."
+msgstr "Attivà l’aliniamentu verticale."
+
+#: ../src/richtext/richtextsizepage.cpp:286
+msgid "Centred"
+msgstr "Centratu"
+
+#: ../src/richtext/richtextsizepage.cpp:290
+#: ../src/richtext/richtextsizepage.cpp:292
+msgid "Vertical alignment."
+msgstr "Aliniamentu verticale."
+
+#: ../src/richtext/richtextsizepage.cpp:316
+#: ../src/richtext/richtextsizepage.cpp:323
+msgid "&Width:"
+msgstr "&Larghezza :"
+
+#: ../src/richtext/richtextsizepage.cpp:318
+#: ../src/richtext/richtextsizepage.cpp:320
+msgid "Enable the width value."
+msgstr "Attivà u valore di larghezza."
+
+#: ../src/richtext/richtextsizepage.cpp:331
+#: ../src/richtext/richtextsizepage.cpp:333
+msgid "The object width."
+msgstr "A larghezza di l’oggettu."
+
+#: ../src/richtext/richtextsizepage.cpp:342
+#: ../src/richtext/richtextsizepage.cpp:344
+msgid "Units for the object width."
+msgstr "Unità per a larghezza di l’oggettu."
+
+#: ../src/richtext/richtextsizepage.cpp:350
+#: ../src/richtext/richtextsizepage.cpp:357
+msgid "&Height:"
+msgstr "&Altezza :"
+
+#: ../src/richtext/richtextsizepage.cpp:352
+#: ../src/richtext/richtextsizepage.cpp:354
+#: ../src/richtext/richtextsizepage.cpp:464
+#: ../src/richtext/richtextsizepage.cpp:466
+msgid "Enable the height value."
+msgstr "Attivà u valore d’altezza."
+
+#: ../src/richtext/richtextsizepage.cpp:365
+#: ../src/richtext/richtextsizepage.cpp:367
+msgid "The object height."
+msgstr "L’altezza di l’oggettu."
+
+#: ../src/richtext/richtextsizepage.cpp:376
+#: ../src/richtext/richtextsizepage.cpp:378
+msgid "Units for the object height."
+msgstr "Unità per l’altezza di l’oggettu."
+
+#: ../src/richtext/richtextsizepage.cpp:381
+msgid "Min width:"
+msgstr "Larghezza minima :"
+
+#: ../src/richtext/richtextsizepage.cpp:383
+#: ../src/richtext/richtextsizepage.cpp:385
+msgid "Enable the minimum width value."
+msgstr "Attivà u valore minimu di larghezza."
+
+#: ../src/richtext/richtextsizepage.cpp:392
+#: ../src/richtext/richtextsizepage.cpp:394
+msgid "The object minimum width."
+msgstr "A larghezza minima di l’oggettu."
+
+#: ../src/richtext/richtextsizepage.cpp:403
+#: ../src/richtext/richtextsizepage.cpp:405
+msgid "Units for the minimum object width."
+msgstr "Unità per a larghezza minima di l’oggettu."
+
+#: ../src/richtext/richtextsizepage.cpp:408
+msgid "Min height:"
+msgstr "Altezza minima :"
+
+#: ../src/richtext/richtextsizepage.cpp:410
+#: ../src/richtext/richtextsizepage.cpp:412
+msgid "Enable the minimum height value."
+msgstr "Attivà u valore minimu d’altezza."
+
+#: ../src/richtext/richtextsizepage.cpp:419
+#: ../src/richtext/richtextsizepage.cpp:421
+msgid "The object minimum height."
+msgstr "L’altezza minima di l’oggettu."
+
+#: ../src/richtext/richtextsizepage.cpp:430
+#: ../src/richtext/richtextsizepage.cpp:432
+msgid "Units for the minimum object height."
+msgstr "Unità per l’altezza minima di l’oggettu."
+
+#: ../src/richtext/richtextsizepage.cpp:435
+msgid "Max width:"
+msgstr "Larghezza massima :"
+
+#: ../src/richtext/richtextsizepage.cpp:437
+#: ../src/richtext/richtextsizepage.cpp:439
+msgid "Enable the maximum width value."
+msgstr "Attivà u valore massimu di larghezza."
+
+#: ../src/richtext/richtextsizepage.cpp:446
+#: ../src/richtext/richtextsizepage.cpp:448
+msgid "The object maximum width."
+msgstr "A larghezza massima di l’oggettu."
+
+#: ../src/richtext/richtextsizepage.cpp:457
+#: ../src/richtext/richtextsizepage.cpp:459
+msgid "Units for the maximum object width."
+msgstr "Unità per a larghezza massima di l’oggettu."
+
+#: ../src/richtext/richtextsizepage.cpp:462
+msgid "Max height:"
+msgstr "Altezza massima :"
+
+#: ../src/richtext/richtextsizepage.cpp:473
+#: ../src/richtext/richtextsizepage.cpp:475
+msgid "The object maximum height."
+msgstr "L’altezza massima di l’oggettu."
+
+#: ../src/richtext/richtextsizepage.cpp:484
+#: ../src/richtext/richtextsizepage.cpp:486
+msgid "Units for the maximum object height."
+msgstr "Unità per l’altezza massima di l’oggettu."
+
+#: ../src/richtext/richtextsizepage.cpp:495
+msgid "Position"
+msgstr "Pusizione"
+
+#: ../src/richtext/richtextsizepage.cpp:513
+msgid "&Position mode:"
+msgstr "Modu di &pusizione :"
+
+#: ../src/richtext/richtextsizepage.cpp:517
+#: ../src/richtext/richtextsizepage.cpp:522
+msgid "Static"
+msgstr "Staticu"
+
+#: ../src/richtext/richtextsizepage.cpp:518
+msgid "Relative"
+msgstr "Relativu"
+
+#: ../src/richtext/richtextsizepage.cpp:519
+msgid "Absolute"
+msgstr "Assulutu"
+
+#: ../src/richtext/richtextsizepage.cpp:520
+msgid "Fixed"
+msgstr "Fissu"
+
+#: ../src/richtext/richtextsizepage.cpp:533
+#: ../src/richtext/richtextsizepage.cpp:535
+#: ../src/richtext/richtextsizepage.cpp:547
+#: ../src/richtext/richtextsizepage.cpp:549
+msgid "The left position."
+msgstr "A pusizione manca."
+
+#: ../src/richtext/richtextsizepage.cpp:558
+#: ../src/richtext/richtextsizepage.cpp:560
+msgid "Units for the left position."
+msgstr "Unità per a pusizione manca."
+
+#: ../src/richtext/richtextsizepage.cpp:568
+#: ../src/richtext/richtextsizepage.cpp:570
+#: ../src/richtext/richtextsizepage.cpp:582
+#: ../src/richtext/richtextsizepage.cpp:584
+msgid "The top position."
+msgstr "A pusizione superiore."
+
+#: ../src/richtext/richtextsizepage.cpp:593
+#: ../src/richtext/richtextsizepage.cpp:595
+msgid "Units for the top position."
+msgstr "Unità per a pusizione superiore."
+
+#: ../src/richtext/richtextsizepage.cpp:603
+#: ../src/richtext/richtextsizepage.cpp:605
+#: ../src/richtext/richtextsizepage.cpp:617
+#: ../src/richtext/richtextsizepage.cpp:619
+msgid "The right position."
+msgstr "A pusizione diritta."
+
+#: ../src/richtext/richtextsizepage.cpp:628
+#: ../src/richtext/richtextsizepage.cpp:630
+msgid "Units for the right position."
+msgstr "Unità per a pusizione diritta."
+
+#: ../src/richtext/richtextsizepage.cpp:638
+#: ../src/richtext/richtextsizepage.cpp:640
+#: ../src/richtext/richtextsizepage.cpp:652
+#: ../src/richtext/richtextsizepage.cpp:654
+msgid "The bottom position."
+msgstr "A pusizione inferiore."
+
+#: ../src/richtext/richtextsizepage.cpp:663
+#: ../src/richtext/richtextsizepage.cpp:665
+msgid "Units for the bottom position."
+msgstr "Unità per a pusizione inferiore."
+
+#: ../src/richtext/richtextsizepage.cpp:671
+msgid "&Move the object to:"
+msgstr "&Dispiazzà l’oggettu versu :"
+
+#: ../src/richtext/richtextsizepage.cpp:674
+msgid "&Previous Paragraph"
+msgstr "&Paragrafu precedente"
+
+#: ../src/richtext/richtextsizepage.cpp:675
+#: ../src/richtext/richtextsizepage.cpp:677
+msgid "Moves the object to the previous paragraph."
+msgstr "Dispiazzà l’oggettu versu u paragrafu precedente."
+
+#: ../src/richtext/richtextsizepage.cpp:680
+msgid "&Next Paragraph"
+msgstr "Paragrafu &seguente"
+
+#: ../src/richtext/richtextsizepage.cpp:681
+#: ../src/richtext/richtextsizepage.cpp:683
+msgid "Moves the object to the next paragraph."
+msgstr "Dispiazzà l’oggettu versu u paragrafu seguente."
+
+#: ../src/richtext/richtextstyledlg.cpp:193
+msgid "&Styles:"
+msgstr "&Stili :"
+
+#: ../src/richtext/richtextstyledlg.cpp:197
+#: ../src/richtext/richtextstyledlg.cpp:199
+msgid "The available styles."
+msgstr "I stili dispunibule."
+
+#: ../src/richtext/richtextstyledlg.cpp:205
+#: ../src/richtext/richtextstyledlg.cpp:217
+msgid " "
+msgstr " "
+
+#: ../src/richtext/richtextstyledlg.cpp:209
+#: ../src/richtext/richtextstyledlg.cpp:211
+msgid "The style preview."
+msgstr "A fighjulata di stilu."
+
+#: ../src/richtext/richtextstyledlg.cpp:220
+msgid "New &Character Style..."
+msgstr "Novu stilu di &caratteru…"
+
+#: ../src/richtext/richtextstyledlg.cpp:221
+#: ../src/richtext/richtextstyledlg.cpp:223
+msgid "Click to create a new character style."
+msgstr "Cliccu per creà un novu stilu di caratteru."
+
+#: ../src/richtext/richtextstyledlg.cpp:226
+msgid "New &Paragraph Style..."
+msgstr "Novu stilu di &paragrafu…"
+
+#: ../src/richtext/richtextstyledlg.cpp:227
+#: ../src/richtext/richtextstyledlg.cpp:229
+msgid "Click to create a new paragraph style."
+msgstr "Cliccu per creà un novu stilu di paragrafu."
+
+#: ../src/richtext/richtextstyledlg.cpp:232
+msgid "New &List Style..."
+msgstr "Novu stilu di &lista…"
+
+#: ../src/richtext/richtextstyledlg.cpp:233
+#: ../src/richtext/richtextstyledlg.cpp:235
+msgid "Click to create a new list style."
+msgstr "Cliccu per creà un novu stilu di lista."
+
+#: ../src/richtext/richtextstyledlg.cpp:238
+msgid "New &Box Style..."
+msgstr "Novu stilu di &scatula…"
+
+#: ../src/richtext/richtextstyledlg.cpp:239
+#: ../src/richtext/richtextstyledlg.cpp:241
+msgid "Click to create a new box style."
+msgstr "Cliccu per creà un novu stilu di scatula."
+
+#: ../src/richtext/richtextstyledlg.cpp:246
+msgid "&Apply Style"
+msgstr "&Appiecà u stilu"
+
+#: ../src/richtext/richtextstyledlg.cpp:247
+#: ../src/richtext/richtextstyledlg.cpp:249
+msgid "Click to apply the selected style."
+msgstr "Cliccu per appiecà u stilu selezziunatu."
+
+#: ../src/richtext/richtextstyledlg.cpp:252
+msgid "&Rename Style..."
+msgstr "&Rinuminà u stilu…"
+
+#: ../src/richtext/richtextstyledlg.cpp:253
+#: ../src/richtext/richtextstyledlg.cpp:255
+msgid "Click to rename the selected style."
+msgstr "Cliccu per rinuminà u stilu selezziunatu."
+
+#: ../src/richtext/richtextstyledlg.cpp:258
+msgid "&Edit Style..."
+msgstr "&Mudificà u stilu…"
+
+#: ../src/richtext/richtextstyledlg.cpp:259
+#: ../src/richtext/richtextstyledlg.cpp:261
+msgid "Click to edit the selected style."
+msgstr "Cliccu per mudificà u stilu selezziunatu."
+
+#: ../src/richtext/richtextstyledlg.cpp:264
+msgid "&Delete Style..."
+msgstr "&Squassà u stilu…"
+
+#: ../src/richtext/richtextstyledlg.cpp:265
+#: ../src/richtext/richtextstyledlg.cpp:267
+msgid "Click to delete the selected style."
+msgstr "Cliccu per squassà u stilu selezziunatu."
+
+#: ../src/richtext/richtextstyledlg.cpp:274
+#: ../src/richtext/richtextstyledlg.cpp:276
+msgid "Click to close this window."
+msgstr "Cliccu per chjode sta finestra."
+
+#: ../src/richtext/richtextstyledlg.cpp:282
+msgid "&Restart numbering"
+msgstr "&Riprincipià a numerazione"
+
+#: ../src/richtext/richtextstyledlg.cpp:284
+#: ../src/richtext/richtextstyledlg.cpp:286
+msgid "Check to restart numbering."
+msgstr "Selezziunà per riprincipià a numerazione."
+
+#: ../src/richtext/richtextstyledlg.cpp:601
+msgid "Enter a character style name"
+msgstr "Stampittà u nome di stilu di caratteru"
+
+#: ../src/richtext/richtextstyledlg.cpp:601
+#: ../src/richtext/richtextstyledlg.cpp:606
+#: ../src/richtext/richtextstyledlg.cpp:649
+#: ../src/richtext/richtextstyledlg.cpp:654
+#: ../src/richtext/richtextstyledlg.cpp:815
+#: ../src/richtext/richtextstyledlg.cpp:820
+#: ../src/richtext/richtextstyledlg.cpp:888
+#: ../src/richtext/richtextstyledlg.cpp:896
+#: ../src/richtext/richtextstyledlg.cpp:929
+#: ../src/richtext/richtextstyledlg.cpp:934
+msgid "New Style"
+msgstr "Novu stilu"
+
+#: ../src/richtext/richtextstyledlg.cpp:606
+#: ../src/richtext/richtextstyledlg.cpp:654
+#: ../src/richtext/richtextstyledlg.cpp:820
+#: ../src/richtext/richtextstyledlg.cpp:896
+#: ../src/richtext/richtextstyledlg.cpp:934
+msgid "Sorry, that name is taken. Please choose another."
+msgstr "Per disgrazia, stu nome hè dighjà adupratu. Sciglitene un altru."
+
+#: ../src/richtext/richtextstyledlg.cpp:649
+msgid "Enter a paragraph style name"
+msgstr "Stampittà un nome di stilu di paragrafu"
+
+#: ../src/richtext/richtextstyledlg.cpp:777
+#, c-format
+msgid "Delete style %s?"
+msgstr "Squassà u stilu %s ?"
+
+#: ../src/richtext/richtextstyledlg.cpp:777
+msgid "Delete Style"
+msgstr "Squassà u stilu"
+
+#: ../src/richtext/richtextstyledlg.cpp:815
+msgid "Enter a list style name"
+msgstr "Stampittà un nome di stilu di lista"
+
+#: ../src/richtext/richtextstyledlg.cpp:888
+msgid "Enter a new style name"
+msgstr "Stampittà u nome d’un novu stilu"
+
+#: ../src/richtext/richtextstyledlg.cpp:929
+msgid "Enter a box style name"
+msgstr "Stampittà un nome di stilu di scatula"
+
+#: ../src/richtext/richtextstylepage.cpp:109
+#: ../src/richtext/richtextstylepage.cpp:111
+msgid "The style name."
+msgstr "U nome di stilu."
+
+#: ../src/richtext/richtextstylepage.cpp:114
+msgid "&Based on:"
+msgstr "&Appughjatu nant’à :"
+
+#: ../src/richtext/richtextstylepage.cpp:119
+#: ../src/richtext/richtextstylepage.cpp:121
+msgid "The style on which this style is based."
+msgstr "U stilu nant’à quellu stu stilu hè appughjatu."
+
+#: ../src/richtext/richtextstylepage.cpp:124
+msgid "&Next style:"
+msgstr "&Stilu seguente :"
+
+#: ../src/richtext/richtextstylepage.cpp:129
+#: ../src/richtext/richtextstylepage.cpp:131
+msgid "The default style for the next paragraph."
+msgstr "U stilu predefinitu per u paragrafu seguente."
+
+#: ../src/richtext/richtextstyles.cpp:1057
+msgid "All styles"
+msgstr "Tutti i stili"
+
+#: ../src/richtext/richtextstyles.cpp:1058
+msgid "Paragraph styles"
+msgstr "Stili di paragrafu"
+
+#: ../src/richtext/richtextstyles.cpp:1059
+msgid "Character styles"
+msgstr "Stili di caratteru"
+
+#: ../src/richtext/richtextstyles.cpp:1060
+msgid "List styles"
+msgstr "Stili di lista"
+
+#: ../src/richtext/richtextstyles.cpp:1061
+msgid "Box styles"
+msgstr "Stili di scatula"
+
+#: ../src/richtext/richtextsymboldlg.cpp:389
+#: ../src/richtext/richtextsymboldlg.cpp:391
+msgid "The font from which to take the symbol."
+msgstr "A grafia da quella piglià u simbulu."
+
+#: ../src/richtext/richtextsymboldlg.cpp:396
+msgid "&Subset:"
+msgstr "&Sottuinseme :"
+
+#: ../src/richtext/richtextsymboldlg.cpp:401
+#: ../src/richtext/richtextsymboldlg.cpp:403
+msgid "Shows a Unicode subset."
+msgstr "Affisseghja un sottuinseme Unicode."
+
+#: ../src/richtext/richtextsymboldlg.cpp:412
+msgid "xxxx"
+msgstr "xxxx"
+
+#: ../src/richtext/richtextsymboldlg.cpp:417
+msgid "&Character code:"
+msgstr "&Codice di caratteru :"
+
+#: ../src/richtext/richtextsymboldlg.cpp:421
+#: ../src/richtext/richtextsymboldlg.cpp:423
+msgid "The character code."
+msgstr "U codice di caratteru."
+
+#: ../src/richtext/richtextsymboldlg.cpp:428
+msgid "&From:"
+msgstr "&Da :"
+
+#: ../src/richtext/richtextsymboldlg.cpp:433
+#: ../src/richtext/richtextsymboldlg.cpp:434
+#: ../src/richtext/richtextsymboldlg.cpp:435
+msgid "Unicode"
+msgstr "Unicode"
+
+#: ../src/richtext/richtextsymboldlg.cpp:436
+#: ../src/richtext/richtextsymboldlg.cpp:438
+msgid "The range to show."
+msgstr "L’intervallu à affissà."
+
+#: ../src/richtext/richtextsymboldlg.cpp:444
+msgid "Insert"
+msgstr "Framette"
+
+#: ../src/richtext/richtextsymboldlg.cpp:478
+msgid "(Normal text)"
+msgstr "(Testu nurmale)"
+
+#: ../src/richtext/richtexttabspage.cpp:109
+msgid "&Position (tenths of a mm):"
+msgstr "&Pusizione (decine di mm) :"
+
+#: ../src/richtext/richtexttabspage.cpp:113
+#: ../src/richtext/richtexttabspage.cpp:115
+msgid "The tab position."
+msgstr "A pusizione di tabulazione."
+
+#: ../src/richtext/richtexttabspage.cpp:119
+msgid "The tab positions."
+msgstr "E pusizioni di tabulazione."
+
+#: ../src/richtext/richtexttabspage.cpp:132
+#: ../src/richtext/richtexttabspage.cpp:134
+msgid "Click to create a new tab position."
+msgstr "Cliccu per creà una nova pusizione di tabulazione."
+
+#: ../src/richtext/richtexttabspage.cpp:138
+#: ../src/richtext/richtexttabspage.cpp:140
+msgid "Click to delete the selected tab position."
+msgstr "Cliccu per squassà a pusizione di tabulazione selezziunata."
+
+#: ../src/richtext/richtexttabspage.cpp:143
+msgid "Delete A&ll"
+msgstr "&Tuttu squassà"
+
+#: ../src/richtext/richtexttabspage.cpp:144
+#: ../src/richtext/richtexttabspage.cpp:146
+msgid "Click to delete all tab positions."
+msgstr "Cliccu per squassà tutte e pusizioni di tabulazione selezziunate."
+
+#: ../src/univ/theme.cpp:110
+msgid "Failed to initialize GUI: no built-in themes found."
+msgstr ""
+"Fiascu à l’iniziu di l’interfaccia grafica : ùn si pò truvà alcunu tema "
+"integratu."
+
+#: ../src/univ/themes/gtk.cpp:521
+msgid "GTK+ theme"
+msgstr "Tema GTK+"
+
+#: ../src/univ/themes/metal.cpp:164
+msgid "Metal theme"
+msgstr "Tema metallicu"
+
+#: ../src/univ/themes/mono.cpp:512
+msgid "Simple monochrome theme"
+msgstr "Tema monocromu simplice"
+
+#: ../src/univ/themes/win32.cpp:1098
+msgid "Win32 theme"
+msgstr "Tema Win32"
+
+#: ../src/univ/themes/win32.cpp:3743
+msgid "&Restore"
+msgstr "&Risturà"
+
+#: ../src/univ/themes/win32.cpp:3744
+msgid "&Move"
+msgstr "&Dispiazzà"
+
+#: ../src/univ/themes/win32.cpp:3746
+msgid "&Size"
+msgstr "Dimen&sione"
+
+#: ../src/univ/themes/win32.cpp:3748
+msgid "Mi&nimize"
+msgstr "Mi&nimizà"
+
+#: ../src/univ/themes/win32.cpp:3750
+msgid "Ma&ximize"
+msgstr "Ingran&dà"
+
+#: ../src/univ/themes/win32.cpp:3752
+msgid "Alt+"
+msgstr "Alt+"
+
+#: ../src/unix/appunix.cpp:178
+msgid "Failed to install signal handler"
+msgstr "Fiascu durante l’installazione di u ghjestiunariu di signale"
+
+#: ../src/unix/dialup.cpp:351
+msgid "Already dialling ISP."
+msgstr "Chjamata dighjà en corsu di u FAI."
+
+#: ../src/unix/dlunix.cpp:93
+msgid "Failed to unload shared library"
+msgstr "Fiascu durante u scaricamentu di a biblioteca scumparta"
+
+#: ../src/unix/dlunix.cpp:121
+msgid "Unknown dynamic library error"
+msgstr "Sbagliu scunnisciutu di a biblioteca dinamica"
+
+#: ../src/unix/epolldispatcher.cpp:84
+msgid "Failed to create epoll descriptor"
+msgstr "Fiascu durante a creazione di u discrittore « epoll »"
+
+#: ../src/unix/epolldispatcher.cpp:103
+msgid "Error closing epoll descriptor"
+msgstr "Sbagliu durante a chjusura di u discrittore « epoll »"
+
+#: ../src/unix/epolldispatcher.cpp:116
+#, c-format
+msgid "Failed to add descriptor %d to epoll descriptor %d"
+msgstr ""
+"Fiascu durante l’aghjuntu di u discrittore %d à u discrittore « epoll » %d"
+
+#: ../src/unix/epolldispatcher.cpp:136
+#, c-format
+msgid "Failed to modify descriptor %d in epoll descriptor %d"
+msgstr ""
+"Fiascu durante a mudificazione di u discrittore %d in u discrittore "
+"« epoll » %d"
+
+#: ../src/unix/epolldispatcher.cpp:155
+#, c-format
+msgid "Failed to unregister descriptor %d from epoll descriptor %d"
+msgstr ""
+"Fiascu durante u disarregistramentu di u discrittore %d da u discrittore "
+"« epoll » %d"
+
+#: ../src/unix/epolldispatcher.cpp:213
+#, c-format
+msgid "Waiting for IO on epoll descriptor %d failed"
+msgstr ""
+"Fiascu di l’attesa di l’entrate è di l’esciute nant’à u discrittore "
+"« epoll » %d"
+
+#: ../src/unix/fswatcher_inotify.cpp:71
+msgid "Unable to create inotify instance"
+msgstr "Impussibule di creà un’istanza « inotify »"
+
+#: ../src/unix/fswatcher_inotify.cpp:94
+msgid "Unable to close inotify instance"
+msgstr "Impussibule di chjode un’istanza « inotify »"
+
+#: ../src/unix/fswatcher_inotify.cpp:106
+msgid "Unable to add inotify watch"
+msgstr "Impussibule d’aghjunghje una surveglianza « inotify »"
+
+#: ../src/unix/fswatcher_inotify.cpp:138
+#, c-format
+msgid "Unable to remove inotify watch %i"
+msgstr "Impussibule di caccià a surveglianza « inotify » %i"
+
+#: ../src/unix/fswatcher_inotify.cpp:271
+#, c-format
+msgid "Unexpected event for \"%s\": no matching watch descriptor."
+msgstr ""
+"Evenimentu imprevistu per « %s » : nisunu discrittore di surveglianza chì "
+"currisponde."
+
+#: ../src/unix/fswatcher_inotify.cpp:320
+#, c-format
+msgid "Invalid inotify event for \"%s\""
+msgstr "Evenimentu « inotify » inaccettevule per « %s »"
+
+#: ../src/unix/fswatcher_inotify.cpp:553
+msgid "Unable to read from inotify descriptor"
+msgstr "Impussibule di leghje da u discrittore« inotify »"
+
+#: ../src/unix/fswatcher_inotify.cpp:558
+msgid "EOF while reading from inotify descriptor"
+msgstr "Fine di schedariu tocca durante a lettura da u discrittore« inotify »"
+
+#: ../src/unix/fswatcher_kqueue.cpp:114
+msgid "Unable to create kqueue instance"
+msgstr "Impussibule di creà un’istanza « kqueue »"
+
+#: ../src/unix/fswatcher_kqueue.cpp:131
+msgid "Error closing kqueue instance"
+msgstr "Sbagliu durante a chjusura di l’istanza « kqueue »"
+
+#: ../src/unix/fswatcher_kqueue.cpp:153
+msgid "Unable to add kqueue watch"
+msgstr "Impussibule d’aghjunghje una surveglianza « kqueue »"
+
+#: ../src/unix/fswatcher_kqueue.cpp:170
+msgid "Unable to remove kqueue watch"
+msgstr "Impussibule di caccià una surveglianza « kqueue »"
+
+#: ../src/unix/fswatcher_kqueue.cpp:202
+msgid "Unable to get events from kqueue"
+msgstr "Impussibule d’ottene l’evenimenti da « kqueue »"
+
+#: ../src/unix/mediactrl.cpp:966
+#, c-format
+msgid "Media playback error: %s"
+msgstr "Sbagliu di ripruduzzione medià : %s"
+
+#: ../src/unix/mediactrl.cpp:1228
+#, c-format
+msgid "Failed to prepare playing \"%s\"."
+msgstr "Fiascu durante l’approntu di a ripruduzzione di « %s »."
+
+#: ../src/unix/snglinst.cpp:164
+#, c-format
+msgid "Failed to write to lock file '%s'"
+msgstr "Fiascu durante a scrittura nant’à u schedariu di marchjone « %s »"
+
+#: ../src/unix/snglinst.cpp:177
+#, c-format
+msgid "Failed to set permissions on lock file '%s'"
+msgstr ""
+"Fiascu durante a definizione di i permessi nant’à u schedariu di marchjone "
+"« %s »"
+
+#: ../src/unix/snglinst.cpp:194
+#, c-format
+msgid "Failed to lock the lock file '%s'"
+msgstr "Fiascu per ammarchjunà u schedariu di marchjone « %s »"
+
+#: ../src/unix/snglinst.cpp:237
+#, c-format
+msgid "Failed to inspect the lock file '%s'"
+msgstr "Fiascu durante l’spezzione di u schedariu di marchjone « %s »"
+
+#: ../src/unix/snglinst.cpp:242
+#, c-format
+msgid "Lock file '%s' has incorrect owner."
+msgstr "U prupietariu di u schedariu di marchjone « %s » hè incurrettu."
+
+#: ../src/unix/snglinst.cpp:247
+#, c-format
+msgid "Lock file '%s' has incorrect permissions."
+msgstr "I permessi di u schedariu di marchjone « %s » sò incurretti."
+
+#: ../src/unix/snglinst.cpp:265
+msgid "Failed to access lock file."
+msgstr "Fiascu durante l’accessu à u schedariu di marchjone."
+
+#: ../src/unix/snglinst.cpp:274
+msgid "Failed to read PID from lock file."
+msgstr ""
+"Fiascu durante a lettura di u numeru di trattamentu (PID) da u schedariu di "
+"marchjone."
+
+#: ../src/unix/snglinst.cpp:284
+#, c-format
+msgid "Failed to remove stale lock file '%s'."
+msgstr ""
+"Fiascu durante a cacciatura di u schedariu di marchjone « %s » scadutu."
+
+#: ../src/unix/snglinst.cpp:297
+#, c-format
+msgid "Deleted stale lock file '%s'."
+msgstr "Squassatura di u schedariu di marchjone « %s » scadutu."
+
+#: ../src/unix/snglinst.cpp:308
+#, c-format
+msgid "Invalid lock file '%s'."
+msgstr "U schedariu di marchjone « %s » hè inaccettevule."
+
+#: ../src/unix/snglinst.cpp:324
+#, c-format
+msgid "Failed to remove lock file '%s'"
+msgstr "Fiascu durante a cacciatura di u schedariu di marchjone « %s »."
+
+#: ../src/unix/snglinst.cpp:330
+#, c-format
+msgid "Failed to unlock lock file '%s'"
+msgstr "Fiascu durante a spalancata di u schedariu di marchjone « %s »."
+
+#: ../src/unix/snglinst.cpp:336
+#, c-format
+msgid "Failed to close lock file '%s'"
+msgstr "Fiascu durante a chjusura di u schedariu di marchjone « %s »."
+
+#: ../src/unix/sound.cpp:77
+msgid "No sound"
+msgstr "Nisunu sonu"
+
+#: ../src/unix/sound.cpp:364
+msgid "Unable to play sound asynchronously."
+msgstr "Impussibule di riproduce u sonu di manera asincrona."
+
+#: ../src/unix/sound.cpp:458
+#, c-format
+msgid "Couldn't load sound data from '%s'."
+msgstr "Ùn si pò micca caricà i dati sonori da « %s »."
+
+#: ../src/unix/sound.cpp:465
+#, c-format
+msgid "Sound file '%s' is in unsupported format."
+msgstr "U furmatu di u schedariu sonoru« %s » ùn hè micca accettatu."
+
+#: ../src/unix/sound.cpp:480
+msgid "Sound data are in unsupported format."
+msgstr "U furmatu di i dati sonori ùn hè micca accettatu."
+
+#: ../src/unix/sound_sdl.cpp:226
+#, c-format
+msgid "Couldn't open audio: %s"
+msgstr "Impussibule d’apre u schedariu audio : %s"
+
+#: ../src/unix/threadpsx.cpp:1033
+msgid "Cannot retrieve thread scheduling policy."
+msgstr ""
+"Ùn si pò micca ricuperà a strategia di pianificazione di i fili d’esecuzione."
+
+#: ../src/unix/threadpsx.cpp:1058
+#, c-format
+msgid "Cannot get priority range for scheduling policy %d."
+msgstr ""
+"Ùn si pò micca ottene una gamma di priurità per a strategia di "
+"pianificazione %d."
+
+#: ../src/unix/threadpsx.cpp:1066
+msgid "Thread priority setting is ignored."
+msgstr "A definizione di a priurità di u filu d’esecuzione hè ignurata."
+
+#: ../src/unix/threadpsx.cpp:1221
+msgid ""
+"Failed to join a thread, potential memory leak detected - please restart the "
+"program"
+msgstr ""
+"Fiascu per ghjunghje un filu d’esecuzione, avventata d’una sfughjime di "
+"memoria pussibule ; ci vole à rilancià u prugramma"
+
+#: ../src/unix/threadpsx.cpp:1352
+#, c-format
+msgid "Failed to set thread concurrency level to %lu"
+msgstr ""
+"Fiascu per definisce u livellu di cuncumitanza di u filu d’esecuzione à %lu"
+
+#: ../src/unix/threadpsx.cpp:1481
+#, c-format
+msgid "Failed to set thread priority %d."
+msgstr "Fiascu per definisce a priurità %d di u filu d’esecuzione."
+
+#: ../src/unix/threadpsx.cpp:1666
+msgid "Failed to terminate a thread."
+msgstr "Fiascu di a piantata di u u filu d’esecuzione."
+
+#: ../src/unix/threadpsx.cpp:1893
+msgid "Thread module initialization failed: failed to create thread key"
+msgstr ""
+"Fiascu à l’iniziu di u modulu di u filu d’esecuzione : fiascu à a creazione "
+"di a chjave di u filu d’esecuzione"
+
+#: ../src/unix/utilsunx.cpp:340
+msgid "Impossible to get child process input"
+msgstr "Impussibule d’ottene l’entrata di u trattamentu zitellu"
+
+#: ../src/unix/utilsunx.cpp:390
+msgid "Can't write to child process's stdin"
+msgstr "Ùn si pò micca scrive in u « stdin » di u trattamentu zitellu"
+
+#: ../src/unix/utilsunx.cpp:644
+#, c-format
+msgid "Failed to execute '%s'\n"
+msgstr "Fiascu di l’esecuzione di « %s »\n"
+
+#: ../src/unix/utilsunx.cpp:678
+msgid "Fork failed"
+msgstr "Fiascu di u « fork »"
+
+#: ../src/unix/utilsunx.cpp:701
+msgid "Failed to set process priority"
+msgstr "Fiascu per definisce a priurità di u trattamentu"
+
+#: ../src/unix/utilsunx.cpp:712
+msgid "Failed to redirect child process input/output"
+msgstr ""
+"Fiascu di a ridirezzione di l’entrate è di l’esciute di u trattamentu zitellu"
+
+#: ../src/unix/utilsunx.cpp:816
+msgid "Failed to set up non-blocking pipe, the program might hang."
+msgstr ""
+"Impussibule di cunfigurà un cundottu senza blucchime, u prugramma puderia "
+"piantassi."
+
+#: ../src/unix/utilsunx.cpp:1023
+msgid "Cannot get the hostname"
+msgstr "Ùn si pò micca ottene u nome d’ospite"
+
+#: ../src/unix/utilsunx.cpp:1059
+msgid "Cannot get the official hostname"
+msgstr "Ùn si pò micca ottene u nome d’ospite ufficiale"
+
+#: ../src/unix/wakeuppipe.cpp:49
+msgid "Failed to create wake up pipe used by event loop."
+msgstr ""
+"Fiascu di a creazione d’un cundottu di svegliata impiegatu da l’« event "
+"loop »."
+
+#: ../src/unix/wakeuppipe.cpp:56
+msgid "Failed to switch wake up pipe to non-blocking mode"
+msgstr "Fiascu per passà u cundottu di svegliata à u modu senza blucchime"
+
+#: ../src/unix/wakeuppipe.cpp:117
+msgid "Failed to read from wake-up pipe"
+msgstr "Fiascu per leghje in u cundottu di svegliata"
+
+#: ../src/x11/app.cpp:124
+#, c-format
+msgid "Invalid geometry specification '%s'"
+msgstr "Specificazione geometrica « %s » inaccettevule"
+
+#: ../src/x11/app.cpp:167
+msgid "wxWidgets could not open display. Exiting."
+msgstr "wxWidgets ùn pò micca apre un affissera. Abbandonu."
+
+#: ../src/x11/utils.cpp:169
+#, c-format
+msgid "Failed to close the display \"%s\""
+msgstr "Fiascu durante a chjusura di l’affissera « %s »."
+
+#: ../src/x11/utils.cpp:188
+#, c-format
+msgid "Failed to open display \"%s\"."
+msgstr "Fiascu durante l’apertura di l’affissera « %s »."
+
+#: ../src/xml/xml.cpp:868
+#, c-format
+msgid "XML parsing error: '%s' at line %d"
+msgstr "Sbagliu d’analisa XML : « %s » à a linea %d"
+
+#: ../src/xrc/xh_propgrid.cpp:239
+#, c-format
+msgid "Page %i"
+msgstr "Pagina %i"
+
+#: ../src/xrc/xmlres.cpp:448
+#, c-format
+msgid "Cannot load resources from '%s'."
+msgstr "Ùn si pò micca caricà e risorse da « %s »."
+
+#: ../src/xrc/xmlres.cpp:799
+#, c-format
+msgid "Cannot open resources file '%s'."
+msgstr "Ùn si pò micca apre u schedariu di risorse « %s »."
+
+#: ../src/xrc/xmlres.cpp:806
+#, c-format
+msgid "Cannot load resources from file '%s'."
+msgstr "Ùn si pò micca caricà e risorse da u schedariu « %s »."
+
+#: ../src/xrc/xmlres.cpp:2767
+#, c-format
+msgid "Creating %s \"%s\" failed."
+msgstr "Fiascu durante a creazione di %s « %s »."
+
+#, c-format
+#~ msgid "BMP: header has biClrUsed=%d when biBitCount=%d."
+#~ msgstr "BMP : L’intestatura hà biClrUsed=%d quandu biBitCount=%d."
+
+#~ msgctxt "keyboard key"
+#~ msgid "Alt+"
+#~ msgstr "Alt+"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Ctrl+"
+#~ msgstr "Ctrl+"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Shift+"
+#~ msgstr "Maiusc+"
+
+#~ msgctxt "keyboard key"
+#~ msgid "RawCtrl+"
+#~ msgstr "RawCtrl+"
+
+#~ msgid "Copying more than one selected block to clipboard is not supported."
+#~ msgstr ""
+#~ "A copia di più d’un bloccu selezziunatu versu u preme’papei ùn hè micca "
+#~ "accettata."
+
+#~ msgid "Unsupported clipboard format."
+#~ msgstr "Furmatu di preme’papei micca accettatu."
+
+#~ msgid "Background colour"
+#~ msgstr "Culore di sfondulu"
+
+#~ msgid "Font:"
+#~ msgstr "Grafia :"
+
+#~ msgid "Size:"
+#~ msgstr "Dimensione :"
+
+#~ msgid "The font size in points."
+#~ msgstr "A dimensione di a grafia in punti."
+
+#~ msgid "Style:"
+#~ msgstr "Stilu :"
+
+#~ msgid "Check to make the font bold."
+#~ msgstr "Selezziunà per rende grassa a grafia."
+
+#~ msgid "Check to make the font italic."
+#~ msgstr "Selezziunà per rende cursiva a grafia."
+
+#~ msgid "Check to make the font underlined."
+#~ msgstr "Selezziunà per rende sottulineata a grafia."
+
+#~ msgid "Colour:"
+#~ msgstr "Culore :"
+
+#~ msgid "Click to change the font colour."
+#~ msgstr "Cliccu per cambià u culore di a grafia."
+
+#~ msgid "Shows a preview of the font."
+#~ msgstr "Affisseghja una fighjulata di a grafia."
+
+#~ msgid "Click to cancel changes to the font."
+#~ msgstr "Cliccu per abbandunà i cambiamenti nant’à a grafia."
+
+#~ msgid "Click to confirm changes to the font."
+#~ msgstr "Cliccu per cunfirmà i cambiamenti nant’à a grafia."
+
+#~ msgid "<Any>"
+#~ msgstr "<Qualunque>"
+
+#~ msgid "<Any Roman>"
+#~ msgstr "<Qualunque rumanica>"
+
+#~ msgid "<Any Decorative>"
+#~ msgstr "<Qualunque decurativa>"
+
+#~ msgid "<Any Modern>"
+#~ msgstr "<Qualunque muderna>"
+
+#~ msgid "<Any Script>"
+#~ msgstr "<Qualunque scenariu>"
+
+#~ msgid "<Any Swiss>"
+#~ msgstr "<Qualunque svizzera>"
+
+#~ msgid "<Any Teletype>"
+#~ msgstr "<Qualunque teletipu>"
+
+#~ msgid "Printing "
+#~ msgstr "Stampa "
+
+#~ msgid "Failed to insert text in the control."
+#~ msgstr "Fiascu per framette u testu in u cuntrollu."
+
+#~ msgid "Please choose a valid font."
+#~ msgstr "Sciglite una grafia accettevule."
+
+#, c-format
+#~ msgid "Failed to display HTML document in %s encoding"
+#~ msgstr "Fiascu di l’affissera di u ducumentu HTML cù a cudificazione %s"
+
+#, c-format
+#~ msgid "wxWidgets could not open display for '%s': exiting."
+#~ msgstr "wxWidgets ùn pò micca apre un affissera per « %s » : abbandonu."
+
+#~ msgid "Filter"
+#~ msgstr "Filtru"
+
+#~ msgid "Directories"
+#~ msgstr "Cartulari"
+
+#~ msgid "Files"
+#~ msgstr "Schedarii"
+
+#~ msgid "Selection"
+#~ msgstr "Selezzione"
+
+#~ msgid "conversion to 8-bit encoding failed"
+#~ msgstr "fiascu di a cunversione in cudificazione 8-bit"
+
+#~ msgid "failed to retrieve execution result"
+#~ msgstr "fiascu per ricuperà u risultatu d’esecuzione"

--- a/po_wxstd/cs.po
+++ b/po_wxstd/cs.po
@@ -1,0 +1,10500 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: wxWidgets 3.3\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-05-14 20:23+0200\n"
+"PO-Revision-Date: 2025-05-16 21:09+0200\n"
+"Last-Translator: PB <pbfordev@gmail.com>\n"
+"Language-Team: wxWidgets translators <wx-translators@wxwidgets.org>\n"
+"Language: cs_CZ\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;\n"
+"X-Poedit-SourceCharset: UTF-8\n"
+"X-Poedit-Bookmarks: 1524,-1,-1,-1,-1,-1,-1,-1,-1,-1\n"
+"X-Generator: Poedit 3.6\n"
+
+#: ../include/wx/defs.h:2582
+msgid "All files (*.*)|*.*"
+msgstr "Všechny soubory (*.*)|*"
+
+#: ../include/wx/defs.h:2585
+msgid "All files (*)|*"
+msgstr "Všechny soubory (*)|*"
+
+#: ../include/wx/generic/progdlgg.h:85
+msgid "Elapsed time:"
+msgstr "Uplynulý čas:"
+
+#: ../include/wx/generic/progdlgg.h:86
+msgid "Estimated time:"
+msgstr "Odhadovaný čas:"
+
+#: ../include/wx/generic/progdlgg.h:87
+msgid "Remaining time:"
+msgstr "Zbývající čas:"
+
+#. TRANSLATORS: HTML printout default title.
+#: ../include/wx/html/htmprint.h:121 ../include/wx/prntbase.h:273
+#: ../include/wx/richtext/richtextprint.h:109 ../src/common/docview.cpp:2161
+msgid "Printout"
+msgstr "Výtisk"
+
+#. TRANSLATORS: HTML easy print default title.
+#: ../include/wx/html/htmprint.h:234 ../include/wx/richtext/richtextprint.h:163
+#: ../src/common/prntbase.cpp:522 ../src/html/htmprint.cpp:291
+msgid "Printing"
+msgstr "Tisk"
+
+#: ../include/wx/msgdlg.h:277 ../src/common/stockitem.cpp:211
+msgid "Yes"
+msgstr "Ano"
+
+#: ../include/wx/msgdlg.h:278 ../src/common/stockitem.cpp:182
+msgid "No"
+msgstr "Ne"
+
+#: ../include/wx/msgdlg.h:279 ../src/common/stockitem.cpp:183
+#: ../src/msw/msgdlg.cpp:430 ../src/msw/msgdlg.cpp:734
+#: ../src/richtext/richtextstyledlg.cpp:292
+msgid "OK"
+msgstr "OK"
+
+#: ../include/wx/msgdlg.h:280 ../src/common/stockitem.cpp:150
+#: ../src/msw/msgdlg.cpp:430 ../src/msw/progdlg.cpp:884
+#: ../src/richtext/richtextstyledlg.cpp:295
+msgid "Cancel"
+msgstr "Storno"
+
+#: ../include/wx/msgdlg.h:281 ../src/common/stockitem.cpp:168
+#: ../src/html/helpdlg.cpp:63 ../src/html/helpfrm.cpp:108
+#: ../src/osx/button_osx.cpp:38
+msgid "Help"
+msgstr "Nápověda"
+
+#: ../include/wx/msw/ole/oleutils.h:52
+msgid "Cannot initialize OLE"
+msgstr "Nelze zavést OLE"
+
+#: ../include/wx/msw/private/fswatcher.h:48
+#, c-format
+msgid "Unable to close the handle for '%s'"
+msgstr "Nelze uzavřít popisovač pro '%s'"
+
+#: ../include/wx/msw/private/fswatcher.h:92
+#, c-format
+msgid "Failed to open directory \"%s\" for monitoring."
+msgstr "Nelze otevřít adresář \"%s\" pro sledování."
+
+#: ../include/wx/msw/private/fswatcher.h:125
+msgid "Unable to close I/O completion port handle"
+msgstr "Nelze uzavřít popisovač I/O portu dokončení."
+
+#: ../include/wx/msw/private/fswatcher.h:142
+msgid "Unable to associate handle with I/O completion port"
+msgstr "Nelze přidružit obslužnou rutinu k I/O portu dokončení"
+
+#: ../include/wx/msw/private/fswatcher.h:148
+msgid "Unexpectedly new I/O completion port was created"
+msgstr "Byl neočekávaně vytvořen nový I/O port dokončení"
+
+#: ../include/wx/msw/private/fswatcher.h:213
+msgid "Unable to post completion status"
+msgstr "Nelze poslat stav dokončení"
+
+#: ../include/wx/msw/private/fswatcher.h:262
+msgid "Unable to dequeue completion packet"
+msgstr "Paket dokončení nelze vyřadit z fronty"
+
+#: ../include/wx/msw/private/fswatcher.h:273
+msgid "Unable to create I/O completion port"
+msgstr "Nelze vytvořit I/O port dokončení."
+
+#: ../include/wx/richmsgdlg.h:29
+msgid "&See details"
+msgstr "&Zobrazit podrobnosti"
+
+#: ../include/wx/richmsgdlg.h:30
+msgid "&Hide details"
+msgstr "&Skrýt podrobnosti"
+
+#: ../include/wx/richtext/richtextbuffer.h:3864
+msgid "&Box"
+msgstr "&Rámeček"
+
+#: ../include/wx/richtext/richtextbuffer.h:5008
+msgid "&Picture"
+msgstr "&Obrázek"
+
+#: ../include/wx/richtext/richtextbuffer.h:5958
+msgid "&Cell"
+msgstr "&Buňka"
+
+#: ../include/wx/richtext/richtextbuffer.h:6067
+msgid "&Table"
+msgstr "&Tabulka"
+
+#: ../include/wx/richtext/richtextimagedlg.h:37
+msgid "Object Properties"
+msgstr "Vlastnosti objektu"
+
+#: ../include/wx/richtext/richtextsymboldlg.h:39
+msgid "Symbols"
+msgstr "Symboly"
+
+#: ../include/wx/unix/pipe.h:46
+msgid "Pipe creation failed"
+msgstr "Nelze vytvořit rouru"
+
+#: ../include/wx/unix/private/displayx11.h:65
+msgid "Failed to enumerate video modes"
+msgstr "Nelze vyjmenovat zobrazovací režimy"
+
+#: ../include/wx/unix/private/displayx11.h:89
+msgid "Failed to change video mode"
+msgstr "Nelze změnit režim obrazu"
+
+#: ../include/wx/unix/private/fswatcher_kqueue.h:57
+#, c-format
+msgid "Unable to open path '%s'"
+msgstr "Nelze otevřít cestu '%s'"
+
+#: ../include/wx/unix/private/fswatcher_kqueue.h:74
+#, c-format
+msgid "Unable to close path '%s'"
+msgstr "Nelze uzavřít cestu '%s'"
+
+#: ../include/wx/xtiprop.h:175
+msgid "SetProperty called w/o valid setter"
+msgstr "SetProperty zavoláno bez platné čtečky"
+
+#: ../include/wx/xtiprop.h:184
+msgid "GetProperty called w/o valid getter"
+msgstr "GetProperty zavoláno bez platné čtečky"
+
+#: ../include/wx/xtiprop.h:193
+msgid "AddToPropertyCollection called w/o valid adder"
+msgstr "AddToPropertyCollection zavolána bez platného zapisovače"
+
+#: ../include/wx/xtiprop.h:202
+msgid "GetPropertyCollection called w/o valid collection getter"
+msgstr "GetPropertyCollection zavoláno bez platné čtečky kolekce"
+
+#: ../include/wx/xtiprop.h:255
+msgid "AddToPropertyCollection called on a generic accessor"
+msgstr "AddToPropertyCollection zavolána na obecném přistupujícím"
+
+#: ../include/wx/xtiprop.h:262
+msgid "GetPropertyCollection called on a generic accessor"
+msgstr "GetPropertyCollection zavolána na obecném přistupujícím"
+
+#: ../src/aui/tabmdi.cpp:106 ../src/generic/mdig.cpp:94
+msgid "Cl&ose"
+msgstr "&Zavřít"
+
+#: ../src/aui/tabmdi.cpp:107 ../src/generic/mdig.cpp:95
+msgid "Close All"
+msgstr "Zavřít vše"
+
+#: ../src/aui/tabmdi.cpp:109 ../src/generic/mdig.cpp:97 ../src/msw/mdi.cpp:175
+#: ../src/qt/mdi.cpp:258
+msgid "&Next"
+msgstr "&Další"
+
+#: ../src/aui/tabmdi.cpp:110 ../src/generic/mdig.cpp:98 ../src/msw/mdi.cpp:176
+#: ../src/qt/mdi.cpp:259
+msgid "&Previous"
+msgstr "&Předchozí"
+
+#: ../src/aui/tabmdi.cpp:332 ../src/aui/tabmdi.cpp:348
+#: ../src/aui/tabmdi.cpp:350 ../src/generic/mdig.cpp:291
+#: ../src/generic/mdig.cpp:307 ../src/generic/mdig.cpp:311
+#: ../src/msw/mdi.cpp:337 ../src/qt/mdi.cpp:462
+msgid "&Window"
+msgstr "&Okno"
+
+#: ../src/common/accelcmn.cpp:47
+msgctxt "keyboard key"
+msgid "Delete"
+msgstr "Delete"
+
+#: ../src/common/accelcmn.cpp:48
+msgctxt "keyboard key"
+msgid "Del"
+msgstr "Del"
+
+#: ../src/common/accelcmn.cpp:49
+msgctxt "keyboard key"
+msgid "Back"
+msgstr "Zpět"
+
+#: ../src/common/accelcmn.cpp:49
+msgctxt "keyboard key"
+msgid "Backspace"
+msgstr "Backspace"
+
+#: ../src/common/accelcmn.cpp:50
+msgctxt "keyboard key"
+msgid "Insert"
+msgstr "Insert"
+
+#: ../src/common/accelcmn.cpp:51
+msgctxt "keyboard key"
+msgid "Ins"
+msgstr "Ins"
+
+#: ../src/common/accelcmn.cpp:52
+msgctxt "keyboard key"
+msgid "Enter"
+msgstr "Enter"
+
+#: ../src/common/accelcmn.cpp:53
+msgctxt "keyboard key"
+msgid "Return"
+msgstr "Return"
+
+#: ../src/common/accelcmn.cpp:54
+msgctxt "keyboard key"
+msgid "PageUp"
+msgstr "PageUp"
+
+#: ../src/common/accelcmn.cpp:54
+msgctxt "keyboard key"
+msgid "Page Up"
+msgstr "Page Up"
+
+#: ../src/common/accelcmn.cpp:55
+msgctxt "keyboard key"
+msgid "PageDown"
+msgstr "PageDown"
+
+#: ../src/common/accelcmn.cpp:55
+msgctxt "keyboard key"
+msgid "Page Down"
+msgstr "Page Down"
+
+#: ../src/common/accelcmn.cpp:56
+msgctxt "keyboard key"
+msgid "PgUp"
+msgstr "PgUp"
+
+#: ../src/common/accelcmn.cpp:57
+msgctxt "keyboard key"
+msgid "PgDn"
+msgstr "PgDn"
+
+#: ../src/common/accelcmn.cpp:58
+msgctxt "keyboard key"
+msgid "Left"
+msgstr "Doleva"
+
+#: ../src/common/accelcmn.cpp:59
+msgctxt "keyboard key"
+msgid "Right"
+msgstr "Doprava"
+
+#: ../src/common/accelcmn.cpp:60
+msgctxt "keyboard key"
+msgid "Up"
+msgstr "Nahoru"
+
+#: ../src/common/accelcmn.cpp:61
+msgctxt "keyboard key"
+msgid "Down"
+msgstr "Dolů"
+
+#: ../src/common/accelcmn.cpp:62
+msgctxt "keyboard key"
+msgid "Home"
+msgstr "Home"
+
+#: ../src/common/accelcmn.cpp:63
+msgctxt "keyboard key"
+msgid "End"
+msgstr "Konec"
+
+#: ../src/common/accelcmn.cpp:64
+msgctxt "keyboard key"
+msgid "Space"
+msgstr "Mezerník"
+
+#: ../src/common/accelcmn.cpp:65
+msgctxt "keyboard key"
+msgid "Tab"
+msgstr "Tabulátor"
+
+#: ../src/common/accelcmn.cpp:66
+msgctxt "keyboard key"
+msgid "Esc"
+msgstr "Esc"
+
+#: ../src/common/accelcmn.cpp:67
+msgctxt "keyboard key"
+msgid "Escape"
+msgstr "Escape"
+
+#: ../src/common/accelcmn.cpp:68
+msgctxt "keyboard key"
+msgid "Cancel"
+msgstr "Storno"
+
+#: ../src/common/accelcmn.cpp:69
+msgctxt "keyboard key"
+msgid "Clear"
+msgstr "Vymazat"
+
+#: ../src/common/accelcmn.cpp:70
+msgctxt "keyboard key"
+msgid "Menu"
+msgstr "Menu"
+
+#: ../src/common/accelcmn.cpp:71
+msgctxt "keyboard key"
+msgid "Pause"
+msgstr "Pauza"
+
+#: ../src/common/accelcmn.cpp:72
+msgctxt "keyboard key"
+msgid "Capital"
+msgstr "Kapitálky"
+
+#: ../src/common/accelcmn.cpp:73
+msgctxt "keyboard key"
+msgid "Select"
+msgstr "Vybrat"
+
+#: ../src/common/accelcmn.cpp:74
+msgctxt "keyboard key"
+msgid "Print"
+msgstr "Tisk"
+
+#: ../src/common/accelcmn.cpp:75
+msgctxt "keyboard key"
+msgid "Execute"
+msgstr "Spustit"
+
+#: ../src/common/accelcmn.cpp:76
+msgctxt "keyboard key"
+msgid "Snapshot"
+msgstr "Snapshot"
+
+#: ../src/common/accelcmn.cpp:77
+msgctxt "keyboard key"
+msgid "Help"
+msgstr "Nápověda"
+
+#: ../src/common/accelcmn.cpp:78
+msgctxt "keyboard key"
+msgid "Add"
+msgstr "Přidat"
+
+#: ../src/common/accelcmn.cpp:79
+msgctxt "keyboard key"
+msgid "Separator"
+msgstr "Oddělovač"
+
+#: ../src/common/accelcmn.cpp:80
+msgctxt "keyboard key"
+msgid "Subtract"
+msgstr "Mínus"
+
+#: ../src/common/accelcmn.cpp:81
+msgctxt "keyboard key"
+msgid "Decimal"
+msgstr "Desetinná čárka"
+
+#: ../src/common/accelcmn.cpp:82
+msgctxt "keyboard key"
+msgid "Multiply"
+msgstr "Krát"
+
+#: ../src/common/accelcmn.cpp:83
+msgctxt "keyboard key"
+msgid "Divide"
+msgstr "Lomítko"
+
+#: ../src/common/accelcmn.cpp:84
+msgctxt "keyboard key"
+msgid "Num_lock"
+msgstr "Num_lock"
+
+#: ../src/common/accelcmn.cpp:84
+msgctxt "keyboard key"
+msgid "Num Lock"
+msgstr "Num Lock"
+
+#: ../src/common/accelcmn.cpp:85
+msgctxt "keyboard key"
+msgid "Scroll_lock"
+msgstr "Scroll_lock"
+
+#: ../src/common/accelcmn.cpp:85
+msgctxt "keyboard key"
+msgid "Scroll Lock"
+msgstr "Scroll Lock"
+
+#: ../src/common/accelcmn.cpp:86
+msgctxt "keyboard key"
+msgid "KP_Space"
+msgstr "NK_Mezerník"
+
+#: ../src/common/accelcmn.cpp:86
+msgctxt "keyboard key"
+msgid "Num Space"
+msgstr "Mezerník na numerické klávesnici"
+
+#: ../src/common/accelcmn.cpp:87
+msgctxt "keyboard key"
+msgid "KP_Tab"
+msgstr "NK_Tabulátor"
+
+#: ../src/common/accelcmn.cpp:87
+msgctxt "keyboard key"
+msgid "Num Tab"
+msgstr "Tabulátor na numerické klávesnici"
+
+#: ../src/common/accelcmn.cpp:88
+msgctxt "keyboard key"
+msgid "KP_Enter"
+msgstr "NK_Enter"
+
+#: ../src/common/accelcmn.cpp:88
+msgctxt "keyboard key"
+msgid "Num Enter"
+msgstr "Enter na numerické klávesnici"
+
+#: ../src/common/accelcmn.cpp:89
+msgctxt "keyboard key"
+msgid "KP_Home"
+msgstr "NK_Home"
+
+#: ../src/common/accelcmn.cpp:89
+msgctxt "keyboard key"
+msgid "Num Home"
+msgstr "Home na numerické klávesnici"
+
+#: ../src/common/accelcmn.cpp:90
+msgctxt "keyboard key"
+msgid "KP_Left"
+msgstr "NK_Doleva"
+
+#: ../src/common/accelcmn.cpp:90
+msgctxt "keyboard key"
+msgid "Num left"
+msgstr "Doleva na numerické klávesnici"
+
+#: ../src/common/accelcmn.cpp:91
+msgctxt "keyboard key"
+msgid "KP_Up"
+msgstr "NK_Nahoru"
+
+#: ../src/common/accelcmn.cpp:91
+msgctxt "keyboard key"
+msgid "Num Up"
+msgstr "Nahoru na numerické klávesnici"
+
+#: ../src/common/accelcmn.cpp:92
+msgctxt "keyboard key"
+msgid "KP_Right"
+msgstr "NK_Doprava"
+
+#: ../src/common/accelcmn.cpp:92
+msgctxt "keyboard key"
+msgid "Num Right"
+msgstr "Doprava na numerické klávesnici"
+
+#: ../src/common/accelcmn.cpp:93
+msgctxt "keyboard key"
+msgid "KP_Down"
+msgstr "NK_Dolů"
+
+#: ../src/common/accelcmn.cpp:93
+msgctxt "keyboard key"
+msgid "Num Down"
+msgstr "Dolů na numerické klávesnici"
+
+#: ../src/common/accelcmn.cpp:94
+msgctxt "keyboard key"
+msgid "KP_PageUp"
+msgstr "NK_PageUp"
+
+#: ../src/common/accelcmn.cpp:94
+msgctxt "keyboard key"
+msgid "Num Page Up"
+msgstr "Page Up na numerické klávesnici"
+
+#: ../src/common/accelcmn.cpp:95
+msgctxt "keyboard key"
+msgid "KP_PageDown"
+msgstr "NK_PageDown"
+
+#: ../src/common/accelcmn.cpp:95
+msgctxt "keyboard key"
+msgid "Num Page Down"
+msgstr "Page Down na numerické klávesnici"
+
+#: ../src/common/accelcmn.cpp:96
+msgctxt "keyboard key"
+msgid "KP_Prior"
+msgstr "NK_Předchozí"
+
+#: ../src/common/accelcmn.cpp:97
+msgctxt "keyboard key"
+msgid "KP_Next"
+msgstr "NK_Další"
+
+#: ../src/common/accelcmn.cpp:98
+msgctxt "keyboard key"
+msgid "KP_End"
+msgstr "NK_End"
+
+#: ../src/common/accelcmn.cpp:98
+msgctxt "keyboard key"
+msgid "Num End"
+msgstr "End na numerické klávesnici"
+
+#: ../src/common/accelcmn.cpp:99
+msgctxt "keyboard key"
+msgid "KP_Begin"
+msgstr "NK_Begin"
+
+#: ../src/common/accelcmn.cpp:99
+msgctxt "keyboard key"
+msgid "Num Begin"
+msgstr "Begin na numerické klávesnici"
+
+#: ../src/common/accelcmn.cpp:100
+msgctxt "keyboard key"
+msgid "KP_Insert"
+msgstr "NK_Insert"
+
+#: ../src/common/accelcmn.cpp:100
+msgctxt "keyboard key"
+msgid "Num Insert"
+msgstr "Insert na numerické klávesnici"
+
+#: ../src/common/accelcmn.cpp:101
+msgctxt "keyboard key"
+msgid "KP_Delete"
+msgstr "NK_Delete"
+
+#: ../src/common/accelcmn.cpp:101
+msgctxt "keyboard key"
+msgid "Num Delete"
+msgstr "Delete na numerické klávesnici"
+
+#: ../src/common/accelcmn.cpp:102
+msgctxt "keyboard key"
+msgid "KP_Equal"
+msgstr "NK_Rovná se"
+
+#: ../src/common/accelcmn.cpp:102
+msgctxt "keyboard key"
+msgid "Num ="
+msgstr "= na numerické klávesnici"
+
+#: ../src/common/accelcmn.cpp:103
+msgctxt "keyboard key"
+msgid "KP_Multiply"
+msgstr "NK_Krát"
+
+#: ../src/common/accelcmn.cpp:103
+msgctxt "keyboard key"
+msgid "Num *"
+msgstr "* na numerické klávesnici"
+
+#: ../src/common/accelcmn.cpp:104
+msgctxt "keyboard key"
+msgid "KP_Add"
+msgstr "NK_Plus"
+
+#: ../src/common/accelcmn.cpp:104
+msgctxt "keyboard key"
+msgid "Num +"
+msgstr "+ na numerické klávesnici"
+
+#: ../src/common/accelcmn.cpp:105
+msgctxt "keyboard key"
+msgid "KP_Separator"
+msgstr "NK_Oddělovač"
+
+#: ../src/common/accelcmn.cpp:105
+msgctxt "keyboard key"
+msgid "Num ,"
+msgstr ", na numerické klávesnici"
+
+#: ../src/common/accelcmn.cpp:106
+msgctxt "keyboard key"
+msgid "KP_Subtract"
+msgstr "NK_Mínus"
+
+#: ../src/common/accelcmn.cpp:106
+msgctxt "keyboard key"
+msgid "Num -"
+msgstr "- na numerické klávesnici"
+
+#: ../src/common/accelcmn.cpp:107
+msgctxt "keyboard key"
+msgid "KP_Decimal"
+msgstr "NK_Desetinná čárka"
+
+#: ../src/common/accelcmn.cpp:107
+msgctxt "keyboard key"
+msgid "Num ."
+msgstr ". na numerické klávesnici"
+
+#: ../src/common/accelcmn.cpp:108
+msgctxt "keyboard key"
+msgid "KP_Divide"
+msgstr "NK_Lomítko"
+
+#: ../src/common/accelcmn.cpp:108
+msgctxt "keyboard key"
+msgid "Num /"
+msgstr "/ na numerické klávesnici"
+
+#: ../src/common/accelcmn.cpp:109
+msgctxt "keyboard key"
+msgid "Windows_Left"
+msgstr "Klávesa Windows vlevo"
+
+#: ../src/common/accelcmn.cpp:110
+msgctxt "keyboard key"
+msgid "Windows_Right"
+msgstr "Klávesa Windows vpravo"
+
+#: ../src/common/accelcmn.cpp:111
+msgctxt "keyboard key"
+msgid "Windows_Menu"
+msgstr "Klávesa Menu"
+
+#: ../src/common/accelcmn.cpp:112
+msgctxt "keyboard key"
+msgid "Command"
+msgstr "Command"
+
+#: ../src/common/accelcmn.cpp:186 ../src/common/accelcmn.cpp:359
+msgctxt "keyboard key"
+msgid "Ctrl"
+msgstr "Ctrl"
+
+#: ../src/common/accelcmn.cpp:188 ../src/common/accelcmn.cpp:363
+msgctxt "keyboard key"
+msgid "Alt"
+msgstr "Alt"
+
+#: ../src/common/accelcmn.cpp:190 ../src/common/accelcmn.cpp:361
+msgctxt "keyboard key"
+msgid "Shift"
+msgstr "Shift"
+
+#: ../src/common/accelcmn.cpp:196
+msgctxt "keyboard key"
+msgid "num "
+msgstr "num "
+
+#: ../src/common/accelcmn.cpp:260 ../src/common/accelcmn.cpp:382
+msgctxt "keyboard key"
+msgid "F"
+msgstr "F"
+
+#: ../src/common/accelcmn.cpp:277 ../src/common/accelcmn.cpp:385
+msgctxt "keyboard key"
+msgid "KP_F"
+msgstr "NK_F"
+
+#: ../src/common/accelcmn.cpp:280 ../src/common/accelcmn.cpp:388
+msgctxt "keyboard key"
+msgid "KP_"
+msgstr "NK_"
+
+#: ../src/common/accelcmn.cpp:283 ../src/common/accelcmn.cpp:391
+msgctxt "keyboard key"
+msgid "SPECIAL"
+msgstr "SPECIÁLNÍ"
+
+#: ../src/common/accelcmn.cpp:373
+msgid "Ctrl"
+msgstr "Ctrl"
+
+#: ../src/common/appbase.cpp:786
+msgid "show this help message"
+msgstr "zobrazí tuto nápovědu"
+
+#: ../src/common/appbase.cpp:796
+msgid "generate verbose log messages"
+msgstr "v logu vypisovat podrobné zprávy"
+
+#: ../src/common/appcmn.cpp:256
+msgid "specify the theme to use"
+msgstr "určí, jaké téma použít"
+
+#: ../src/common/appcmn.cpp:270
+msgid "specify display mode to use (e.g. 640x480-16)"
+msgstr "určete režim obrazovky, který se má použít (např. 640x480-16)"
+
+#: ../src/common/appcmn.cpp:292
+#, c-format
+msgid "Unsupported theme '%s'."
+msgstr "Nepodporované téma '%s'."
+
+#: ../src/common/appcmn.cpp:309
+#, c-format
+msgid "Invalid display mode specification '%s'."
+msgstr "Špatné určení grafického režimu '%s'."
+
+#: ../src/common/cmdline.cpp:875
+#, c-format
+msgid "Option '%s' can't be negated"
+msgstr "Možnost '%s' nemůže být znegována"
+
+#: ../src/common/cmdline.cpp:889
+#, c-format
+msgid "Unknown long option '%s'"
+msgstr "Neznámá dlouhá volba '%s'"
+
+#: ../src/common/cmdline.cpp:904 ../src/common/cmdline.cpp:926
+#, c-format
+msgid "Unknown option '%s'"
+msgstr "Neznámá volba '%s'"
+
+#: ../src/common/cmdline.cpp:1004
+#, c-format
+msgid "Unexpected characters following option '%s'."
+msgstr "Volbu '%s' následovaly neočekávané znaky."
+
+#: ../src/common/cmdline.cpp:1039
+#, c-format
+msgid "Option '%s' requires a value."
+msgstr "Volba '%s' vyžaduje hodnotu."
+
+#: ../src/common/cmdline.cpp:1058
+#, c-format
+msgid "Separator expected after the option '%s'."
+msgstr "Za volbou '%s' se očekává oddělovač."
+
+#: ../src/common/cmdline.cpp:1088 ../src/common/cmdline.cpp:1106
+#, c-format
+msgid "'%s' is not a correct numeric value for option '%s'."
+msgstr "'%s' není správnou číselnou hodnotou pro volbu '%s'."
+
+#: ../src/common/cmdline.cpp:1122
+#, c-format
+msgid "Option '%s': '%s' cannot be converted to a date."
+msgstr "Volba '%s': '%s' nemůže být převedena na datum."
+
+#: ../src/common/cmdline.cpp:1170
+#, c-format
+msgid "Unexpected parameter '%s'"
+msgstr "Neočekávaný parametr '%s'"
+
+#. TRANSLATORS: Short name and long name for a command line option
+#: ../src/common/cmdline.cpp:1197
+#, c-format
+msgid "%s (or %s)"
+msgstr "%s (nebo %s)"
+
+#: ../src/common/cmdline.cpp:1208
+#, c-format
+msgid "The value for the option '%s' must be specified."
+msgstr "Musíte zadat hodnotu volby '%s'."
+
+#: ../src/common/cmdline.cpp:1230
+#, c-format
+msgid "The required parameter '%s' was not specified."
+msgstr "Požadovaný parametr '%s' nebyl zadán."
+
+#: ../src/common/cmdline.cpp:1289
+#, c-format
+msgid "Usage: %s"
+msgstr "Použití: %s"
+
+#: ../src/common/cmdline.cpp:1498
+msgid "str"
+msgstr "řetězec"
+
+#: ../src/common/cmdline.cpp:1502
+msgid "num"
+msgstr "číslo"
+
+#: ../src/common/cmdline.cpp:1506
+msgid "double"
+msgstr "číslo s plovoucí čárkou"
+
+#: ../src/common/cmdline.cpp:1510
+msgid "date"
+msgstr "datum"
+
+#: ../src/common/cmdproc.cpp:250 ../src/common/cmdproc.cpp:276
+#: ../src/common/cmdproc.cpp:296
+msgid "Unnamed command"
+msgstr "Nepojmenovaný příkaz"
+
+#: ../src/common/cmdproc.cpp:253
+msgid "&Undo "
+msgstr "&Zpět "
+
+#: ../src/common/cmdproc.cpp:255
+msgid "Can't &Undo "
+msgstr "&Nelze vzít zpět "
+
+#: ../src/common/cmdproc.cpp:259 ../src/common/stockitem.cpp:208
+#: ../src/msw/textctrl.cpp:2880 ../src/osx/textctrl_osx.cpp:649
+#: ../src/richtext/richtextctrl.cpp:327
+msgid "&Undo"
+msgstr "&Zpět"
+
+#: ../src/common/cmdproc.cpp:277 ../src/common/cmdproc.cpp:297
+msgid "&Redo "
+msgstr "P&rovést znovu "
+
+#: ../src/common/cmdproc.cpp:281 ../src/common/cmdproc.cpp:288
+#: ../src/common/stockitem.cpp:190 ../src/msw/textctrl.cpp:2881
+#: ../src/osx/textctrl_osx.cpp:650 ../src/richtext/richtextctrl.cpp:328
+msgid "&Redo"
+msgstr "P&rovést znovu"
+
+#: ../src/common/colourcmn.cpp:41
+#, c-format
+msgid "String To Colour : Incorrect colour specification : %s"
+msgstr "Text na barvu: chybná specifikace popisu barvy : %s"
+
+#: ../src/common/config.cpp:259
+#, c-format
+msgid "Invalid value %ld for a boolean key \"%s\" in config file."
+msgstr "Neplatná hodnota %ld booleovského klíče \"%s\"."
+
+#: ../src/common/config.cpp:526
+#, c-format
+msgid ""
+"Environment variables expansion failed: missing '%c' at position %u in '%s'."
+msgstr ""
+"Chyba během expanze proměnných prostředí: chybí '%c' na pozici %u v '%s'."
+
+#: ../src/common/config.cpp:576 ../src/msw/regconf.cpp:272
+#, c-format
+msgid "'%s' has extra '..', ignored."
+msgstr "'%s' obsahuje přebytečné '..', ignorováno."
+
+#. TRANSLATORS: Checkbox state name
+#: ../src/common/datavcmn.cpp:2166 ../src/generic/datavgen.cpp:1430
+msgid "checked"
+msgstr "zaškrtnuto"
+
+#. TRANSLATORS: Checkbox state name
+#: ../src/common/datavcmn.cpp:2170 ../src/generic/datavgen.cpp:1432
+msgid "unchecked"
+msgstr "zaškrtnuto"
+
+#. TRANSLATORS: Checkbox state name
+#: ../src/common/datavcmn.cpp:2174
+msgid "undetermined"
+msgstr "neurčité"
+
+#: ../src/common/datetimefmt.cpp:1875
+msgid "today"
+msgstr "dnes"
+
+#: ../src/common/datetimefmt.cpp:1876
+msgid "yesterday"
+msgstr "včera"
+
+#: ../src/common/datetimefmt.cpp:1877
+msgid "tomorrow"
+msgstr "zítra"
+
+#: ../src/common/datetimefmt.cpp:2071
+msgid "first"
+msgstr "prvního"
+
+#: ../src/common/datetimefmt.cpp:2072
+msgid "second"
+msgstr "druhého"
+
+#: ../src/common/datetimefmt.cpp:2073
+msgid "third"
+msgstr "třetího"
+
+#: ../src/common/datetimefmt.cpp:2074
+msgid "fourth"
+msgstr "čtvrtého"
+
+#: ../src/common/datetimefmt.cpp:2075
+msgid "fifth"
+msgstr "pátého"
+
+#: ../src/common/datetimefmt.cpp:2076
+msgid "sixth"
+msgstr "šestého"
+
+#: ../src/common/datetimefmt.cpp:2077
+msgid "seventh"
+msgstr "sedmého"
+
+#: ../src/common/datetimefmt.cpp:2078
+msgid "eighth"
+msgstr "osmého"
+
+#: ../src/common/datetimefmt.cpp:2079
+msgid "ninth"
+msgstr "devátého"
+
+#: ../src/common/datetimefmt.cpp:2080
+msgid "tenth"
+msgstr "desátého"
+
+#: ../src/common/datetimefmt.cpp:2081
+msgid "eleventh"
+msgstr "jedenáctého"
+
+#: ../src/common/datetimefmt.cpp:2082
+msgid "twelfth"
+msgstr "dvanáctého"
+
+#: ../src/common/datetimefmt.cpp:2083
+msgid "thirteenth"
+msgstr "třináctého"
+
+#: ../src/common/datetimefmt.cpp:2084
+msgid "fourteenth"
+msgstr "čtrnáctého"
+
+#: ../src/common/datetimefmt.cpp:2085
+msgid "fifteenth"
+msgstr "patnáctého"
+
+#: ../src/common/datetimefmt.cpp:2086
+msgid "sixteenth"
+msgstr "šestnáctého"
+
+#: ../src/common/datetimefmt.cpp:2087
+msgid "seventeenth"
+msgstr "sedmnáctého"
+
+#: ../src/common/datetimefmt.cpp:2088
+msgid "eighteenth"
+msgstr "osmnáctého"
+
+#: ../src/common/datetimefmt.cpp:2089
+msgid "nineteenth"
+msgstr "devatenáctého"
+
+#: ../src/common/datetimefmt.cpp:2090
+msgid "twentieth"
+msgstr "dvacátého"
+
+#: ../src/common/datetimefmt.cpp:2248
+msgid "noon"
+msgstr "poledne"
+
+#: ../src/common/datetimefmt.cpp:2249
+msgid "midnight"
+msgstr "půlnoc"
+
+#: ../src/common/debugrpt.cpp:209
+#, c-format
+msgid "Failed to create directory \"%s\""
+msgstr "Nelze vytvořit adresář \"%s\""
+
+#: ../src/common/debugrpt.cpp:210
+msgid "Debug report couldn't be created."
+msgstr "Protokol ladění nemohl být vytvořen."
+
+#: ../src/common/debugrpt.cpp:227
+#, c-format
+msgid "Failed to remove debug report file \"%s\""
+msgstr "Nelze odstranit soubor protokolu ladění \"%s\""
+
+#: ../src/common/debugrpt.cpp:239
+#, c-format
+msgid "Failed to clean up debug report directory \"%s\""
+msgstr "Nelze vyčistit adresář s protokoly ladění \"%s\""
+
+#: ../src/common/debugrpt.cpp:514
+msgid "process context description"
+msgstr "popis kontextu procesu"
+
+#: ../src/common/debugrpt.cpp:538
+msgid "dump of the process state (binary)"
+msgstr "výpis stavu procesu (binární)"
+
+#: ../src/common/debugrpt.cpp:553
+msgid "Debug report generation has failed."
+msgstr "Vytváření protokolu ladění selhalo."
+
+#: ../src/common/debugrpt.cpp:560
+#, c-format
+msgid ""
+"Processing debug report has failed, leaving the files in \"%s\" directory."
+msgstr ""
+"Zpracování protokolu ladění selhalo, ponechávám soubory v adresáři \"%s\"."
+
+#: ../src/common/debugrpt.cpp:573
+msgid "A debug report has been generated. It can be found in"
+msgstr "Protokol ladění byl vytvořen. Lze jej nalézt v"
+
+#: ../src/common/debugrpt.cpp:576
+msgid "And includes the following files:\n"
+msgstr "A zahrnuje následující soubory:\n"
+
+#: ../src/common/debugrpt.cpp:586
+msgid ""
+"\n"
+"Please send this report to the program maintainer, thank you!\n"
+msgstr ""
+"\n"
+"Pošlete, prosím, tento protokol udržovateli programu. Děkujeme!\n"
+
+#: ../src/common/debugrpt.cpp:729
+msgid "Failed to execute curl, please install it in PATH."
+msgstr "Nelze spustit curl, instalujte ho, prosím, do PATH."
+
+#: ../src/common/debugrpt.cpp:742
+#, c-format
+msgid "Failed to upload the debug report (error code %d)."
+msgstr "Nelze nahrát protokol ladění (kód chyby %d)."
+
+#: ../src/common/docview.cpp:366
+msgid "Save As"
+msgstr "Uložit jako"
+
+#: ../src/common/docview.cpp:457
+msgid "Discard changes and reload the last saved version?"
+msgstr "Zahodit změny a znovu nahrát poslední uloženou verzi?"
+
+#: ../src/common/docview.cpp:488
+msgid "unnamed"
+msgstr "nepojmenovaný"
+
+#: ../src/common/docview.cpp:513
+#, c-format
+msgid "Do you want to save changes to %s?"
+msgstr "Chcete uložit změny v %s?"
+
+#: ../src/common/docview.cpp:521 ../src/common/docview.cpp:560
+#: ../src/common/stockitem.cpp:195
+msgid "&Save"
+msgstr "&Uložit"
+
+#: ../src/common/docview.cpp:522 ../src/common/docview.cpp:560
+msgid "&Discard changes"
+msgstr "Zahodit změny"
+
+#: ../src/common/docview.cpp:523
+msgid "Do&n't close"
+msgstr "Nezavírat"
+
+#: ../src/common/docview.cpp:553
+#, c-format
+msgid "Do you want to save changes to %s before closing it?"
+msgstr "Chcete před uzavřením uložit změny v %s?"
+
+#: ../src/common/docview.cpp:559
+msgid "The document must be closed."
+msgstr "Dokument musí být uzavřen."
+
+#: ../src/common/docview.cpp:571
+#, c-format
+msgid "Saving %s failed, would you like to retry?"
+msgstr "Nepodařilo se uložit %s, chcete to zkusit znovu?"
+
+#: ../src/common/docview.cpp:577
+msgid "Retry"
+msgstr "Zkusit znovu"
+
+#: ../src/common/docview.cpp:577
+msgid "Discard changes"
+msgstr "Zahodit změny"
+
+#: ../src/common/docview.cpp:679
+#, c-format
+msgid "File \"%s\" could not be opened for writing."
+msgstr "Soubor \"%s\" nelze otevřít pro zápis."
+
+#: ../src/common/docview.cpp:685
+#, c-format
+msgid "Failed to save document to the file \"%s\"."
+msgstr "Nelze uložit dokument do souboru \"%s\"."
+
+#: ../src/common/docview.cpp:702
+#, c-format
+msgid "File \"%s\" could not be opened for reading."
+msgstr "Soubor \"%s\" nelze otevřít pro čtení."
+
+#: ../src/common/docview.cpp:714
+#, c-format
+msgid "Failed to read document from the file \"%s\"."
+msgstr "Nelze načíst dokument ze souboru \"%s\"."
+
+#: ../src/common/docview.cpp:1236
+#, c-format
+msgid ""
+"The file '%s' doesn't exist and couldn't be opened.\n"
+"It has been removed from the most recently used files list."
+msgstr ""
+"Soubor '%s' neexistuje a nemohl být otevřen.\n"
+"Byl odstraněn ze seznamu naposledy použitých souborů."
+
+#: ../src/common/docview.cpp:1296
+msgid "Print preview creation failed."
+msgstr "Nelze vytvořit náhled tisku."
+
+#: ../src/common/docview.cpp:1302
+msgid "Print Preview"
+msgstr "Náhled tisku"
+
+#: ../src/common/docview.cpp:1517
+#, c-format
+msgid "The format of file '%s' couldn't be determined."
+msgstr "Formát souboru '%s' nelze určit."
+
+#: ../src/common/docview.cpp:1643
+#, c-format
+msgid "unnamed%d"
+msgstr "nepojmenovaný%d"
+
+#: ../src/common/docview.cpp:1660
+msgid " - "
+msgstr " - "
+
+#: ../src/common/docview.cpp:1791 ../src/common/docview.cpp:1844
+msgid "Open File"
+msgstr "Otevřít soubor"
+
+#: ../src/common/docview.cpp:1807
+msgid "File error"
+msgstr "Chyba souboru"
+
+#: ../src/common/docview.cpp:1809
+msgid "Sorry, could not open this file."
+msgstr "Je nám líto, tento soubor nelze otevřít."
+
+#: ../src/common/docview.cpp:1843
+msgid "Sorry, the format for this file is unknown."
+msgstr "Je nám líto, tento formát souboru je neznámý."
+
+#: ../src/common/docview.cpp:1924
+msgid "Select a document template"
+msgstr "Vyberte šablonu dokumentu"
+
+#: ../src/common/docview.cpp:1925
+msgid "Templates"
+msgstr "Šablony"
+
+#: ../src/common/docview.cpp:1998
+msgid "Select a document view"
+msgstr "Vyberte zobrazení dokumentu"
+
+#: ../src/common/docview.cpp:1999
+msgid "Views"
+msgstr "Pohledy"
+
+#: ../src/common/dynlib.cpp:81
+#, c-format
+msgid "Failed to load shared library '%s'"
+msgstr "Nelze načíst sdílenou knihovnu '%s'"
+
+#: ../src/common/dynlib.cpp:105
+#, c-format
+msgid "Couldn't find symbol '%s' in a dynamic library"
+msgstr "V dynamické knihovně nelze nalézt symbol '%s'"
+
+#: ../src/common/ffile.cpp:56 ../src/common/file.cpp:215
+#, c-format
+msgid "can't open file '%s'"
+msgstr "nelze otevřít soubor '%s'"
+
+#: ../src/common/ffile.cpp:72
+#, c-format
+msgid "can't close file '%s'"
+msgstr "nelze zavřít soubor '%s'"
+
+#: ../src/common/ffile.cpp:106 ../src/common/ffile.cpp:131
+#, c-format
+msgid "Read error on file '%s'"
+msgstr "Chyba při čtení ze souboru '%s'"
+
+#: ../src/common/ffile.cpp:148
+#, c-format
+msgid "Write error on file '%s'"
+msgstr "Chyba při zápisu do souboru '%s'"
+
+#: ../src/common/ffile.cpp:182
+#, c-format
+msgid "failed to flush the file '%s'"
+msgstr "nelze vyprázdnit buffer souboru '%s'"
+
+#: ../src/common/ffile.cpp:222
+#, c-format
+msgid "Seek error on file '%s' (large files not supported by stdio)"
+msgstr "Chyba hledání v souboru '%s' (stdio nepodporuje velké soubory)"
+
+#: ../src/common/ffile.cpp:232
+#, c-format
+msgid "Seek error on file '%s'"
+msgstr "Chyba při nastavování pozice v souboru '%s'"
+
+#: ../src/common/ffile.cpp:248
+#, c-format
+msgid "Can't find current position in file '%s'"
+msgstr "Nelze zjistit současnou pozici v souboru '%s'"
+
+#: ../src/common/ffile.cpp:349 ../src/common/file.cpp:569
+msgid "Failed to set temporary file permissions"
+msgstr "Nelze nastavit přístupová práva k dočasnému souboru"
+
+#: ../src/common/ffile.cpp:371
+#, c-format
+msgid "can't remove file '%s'"
+msgstr "nelze odstranit soubor '%s'"
+
+#: ../src/common/ffile.cpp:376 ../src/common/file.cpp:591
+#, c-format
+msgid "can't commit changes to file '%s'"
+msgstr "nelze uložit změny v souboru '%s'"
+
+#: ../src/common/ffile.cpp:388 ../src/common/file.cpp:603
+#, c-format
+msgid "can't remove temporary file '%s'"
+msgstr "nelze odstranit dočasný soubor '%s'"
+
+#: ../src/common/file.cpp:162
+#, c-format
+msgid "can't create file '%s'"
+msgstr "nelze vytvořit soubor '%s'"
+
+#: ../src/common/file.cpp:229
+#, c-format
+msgid "can't close file descriptor %d"
+msgstr "nelze zavřít popisovač souboru %d"
+
+#: ../src/common/file.cpp:332
+#, c-format
+msgid "can't read from file descriptor %d"
+msgstr "nelze číst z popisovače souboru %d"
+
+#: ../src/common/file.cpp:351
+#, c-format
+msgid "can't write to file descriptor %d"
+msgstr "nelze zapisovat do popisovače souboru %d"
+
+#: ../src/common/file.cpp:390
+#, c-format
+msgid "can't flush file descriptor %d"
+msgstr "nelze vyprázdnit popisovač souboru %d"
+
+#: ../src/common/file.cpp:432
+#, c-format
+msgid "can't seek on file descriptor %d"
+msgstr "nelze změnit pozici pro popisovač souboru %d"
+
+#: ../src/common/file.cpp:446
+#, c-format
+msgid "can't get seek position on file descriptor %d"
+msgstr "nelze zjistit pozici pro popisovač souboru %d"
+
+#: ../src/common/file.cpp:475
+#, c-format
+msgid "can't find length of file on file descriptor %d"
+msgstr "nelze zjistit délku souboru pro popisovač souboru %d"
+
+#: ../src/common/file.cpp:505
+#, c-format
+msgid "can't determine if the end of file is reached on descriptor %d"
+msgstr "nelze zjistit, jestli byl dosažen konec souboru pro popisovač %d"
+
+#: ../src/common/fileconf.cpp:352
+#, c-format
+msgid ""
+" and additionally, the existing configuration file was renamed to \"%s\" and "
+"couldn't be renamed back, please rename it to its original path \"%s\""
+msgstr ""
+" a navíc byl stávající konfigurační soubor přejmenován na \"%s\" a nebylo "
+"možné jej přejmenovat zpět, prosím přejmenujte jej na původní cestu \"%s\""
+
+#: ../src/common/fileconf.cpp:389
+msgid " due to the following error:\n"
+msgstr " kvůli následující chybě:\n"
+
+#: ../src/common/fileconf.cpp:412
+msgid "failed to rename the existing file"
+msgstr "nelze přejmenovat existující soubor"
+
+#: ../src/common/fileconf.cpp:421
+msgid "failed to create the new file directory"
+msgstr "nelze vytvořit adresář pro nový soubor"
+
+#: ../src/common/fileconf.cpp:428
+msgid "failed to move the file to the new location"
+msgstr "soubor nelze přesunout do nového umístění"
+
+#: ../src/common/fileconf.cpp:462
+#, c-format
+msgid "can't open global configuration file '%s'."
+msgstr "nelze otevřít globální konfigurační soubor '%s'."
+
+#: ../src/common/fileconf.cpp:478
+#, c-format
+msgid "can't open user configuration file '%s'."
+msgstr "nelze otevřít uživatelský konfigurační soubor '%s'."
+
+#: ../src/common/fileconf.cpp:483
+#, c-format
+msgid "Changes won't be saved to avoid overwriting the existing file \"%s\""
+msgstr "Změny nebudou uloženy, aby se zabránilo přepsání souboru \"%s\""
+
+#: ../src/common/fileconf.cpp:583
+msgid "Error reading config options."
+msgstr "Chyba při čtení voleb nastavení."
+
+#: ../src/common/fileconf.cpp:593
+msgid "Failed to read config options."
+msgstr "Nelze načíst volby nastavení."
+
+#: ../src/common/fileconf.cpp:700
+#, c-format
+msgid "file '%s': unexpected character %c at line %zu."
+msgstr "soubor '%s': neočekávaný znak %c na řádku %zu."
+
+#: ../src/common/fileconf.cpp:736
+#, c-format
+msgid "file '%s', line %zu: '%s' ignored after group header."
+msgstr "soubor '%s', řádka %zu: '%s' po hlavičce skupiny ignorováno."
+
+#: ../src/common/fileconf.cpp:765
+#, c-format
+msgid "file '%s', line %zu: '=' expected."
+msgstr "soubor '%s', řádka %zu: očekáváno '='."
+
+#: ../src/common/fileconf.cpp:778
+#, c-format
+msgid "file '%s', line %zu: value for immutable key '%s' ignored."
+msgstr "soubor '%s', řádka %zu: hodnota pro neměnný klíč '%s' ignorována."
+
+#: ../src/common/fileconf.cpp:788
+#, c-format
+msgid "file '%s', line %zu: key '%s' was first found at line %d."
+msgstr "soubor '%s', řádka %zu: klíč '%s' byl poprvé nalezen na řádce %d."
+
+#: ../src/common/fileconf.cpp:1091
+#, c-format
+msgid "Config entry name cannot start with '%c'."
+msgstr "Položka konfigurace nesmí začínat na '%c'."
+
+#: ../src/common/fileconf.cpp:1146
+msgid "Failed to create configuration file directory."
+msgstr "Nelze vytvořit adresář pro konfigurační soubor."
+
+#: ../src/common/fileconf.cpp:1158
+msgid "can't open user configuration file."
+msgstr "nelze otevřít uživatelský konfigurační soubor."
+
+#: ../src/common/fileconf.cpp:1172
+msgid "can't write user configuration file."
+msgstr "nelze zapisovat do uživatelského konfigurační souboru."
+
+#: ../src/common/fileconf.cpp:1178
+msgid "Failed to update user configuration file."
+msgstr "Nelze aktualizovat soubor uživatelského nastavení."
+
+#: ../src/common/fileconf.cpp:1201
+msgid "Error saving user configuration data."
+msgstr "Chyba při ukládání dat uživatelského nastavení."
+
+#: ../src/common/fileconf.cpp:1313
+#, c-format
+msgid "can't delete user configuration file '%s'"
+msgstr "nelze smazat uživatelský konfigurační soubor '%s'"
+
+#: ../src/common/fileconf.cpp:2007
+#, c-format
+msgid "entry '%s' appears more than once in group '%s'"
+msgstr "položka '%s' se ve skupině '%s' vyskytuje víc než jednou"
+
+#: ../src/common/fileconf.cpp:2021
+#, c-format
+msgid "attempt to change immutable key '%s' ignored."
+msgstr "pokus o změnu neměnného klíče '%s' ignorován."
+
+#: ../src/common/fileconf.cpp:2118
+#, c-format
+msgid "trailing backslash ignored in '%s'"
+msgstr "zpětné lomítko na konci ignorováno v '%s'"
+
+#: ../src/common/fileconf.cpp:2153
+#, c-format
+msgid "unexpected \" at position %d in '%s'."
+msgstr "neočekávané \" na pozici %d v '%s'."
+
+#: ../src/common/filefn.cpp:474
+#, c-format
+msgid "Failed to copy the file '%s' to '%s'"
+msgstr "Selhalo kopírování souboru '%s' do '%s'"
+
+#: ../src/common/filefn.cpp:487
+#, c-format
+msgid "Impossible to get permissions for file '%s'"
+msgstr "Nelze zjistit přístupová práva souboru '%s'"
+
+#: ../src/common/filefn.cpp:501
+#, c-format
+msgid "Impossible to overwrite the file '%s'"
+msgstr "Nelze přepsat soubor '%s'"
+
+#: ../src/common/filefn.cpp:508
+#, c-format
+msgid "Error copying the file '%s' to '%s'."
+msgstr "Selhalo kopírování souboru '%s' do '%s'."
+
+#: ../src/common/filefn.cpp:556
+#, c-format
+msgid "Impossible to set permissions for the file '%s'"
+msgstr "Nelze nastavit přístupová práva souboru '%s'"
+
+#: ../src/common/filefn.cpp:606
+#, c-format
+msgid ""
+"Failed to rename the file '%s' to '%s' because the destination file already "
+"exists."
+msgstr ""
+"Nelze přejmenovat soubor '%s' na '%s' protože cílový soubor již existuje."
+
+#: ../src/common/filefn.cpp:623
+#, c-format
+msgid "File '%s' couldn't be renamed '%s'"
+msgstr "Soubor '%s' nelze přejmenovat na '%s'"
+
+#: ../src/common/filefn.cpp:639
+#, c-format
+msgid "File '%s' couldn't be removed"
+msgstr "Soubor '%s' nelze odstranit"
+
+#: ../src/common/filefn.cpp:666
+#, c-format
+msgid "Directory '%s' couldn't be created"
+msgstr "Nelze vytvořit adresář '%s'"
+
+#: ../src/common/filefn.cpp:680
+#, c-format
+msgid "Directory '%s' couldn't be deleted"
+msgstr "Nelze smazat adresář '%s'"
+
+#: ../src/common/filefn.cpp:714
+#, c-format
+msgid "Cannot enumerate files '%s'"
+msgstr "Nelze vyjmenovat soubory odpovídající masce '%s'"
+
+#: ../src/common/filefn.cpp:798
+msgid "Failed to get the working directory"
+msgstr "Nelze zjistit aktuální pracovní adresář"
+
+#: ../src/common/filefn.cpp:843
+msgid "Could not set current working directory"
+msgstr "Nelze nastavit současný pracovní adresář"
+
+#: ../src/common/filefn.cpp:974
+#, c-format
+msgid "Files (%s)"
+msgstr "Soubory (%s)"
+
+#: ../src/common/filename.cpp:182
+#, c-format
+msgid "Failed to open '%s' for reading"
+msgstr "Nelze otevřít '%s' pro čtení"
+
+#: ../src/common/filename.cpp:187
+#, c-format
+msgid "Failed to open '%s' for writing"
+msgstr "Nelze otevřít '%s' pro zápis"
+
+#: ../src/common/filename.cpp:199
+msgid "Failed to close file handle"
+msgstr "Nelze uzavřít soubor"
+
+#: ../src/common/filename.cpp:1046
+msgid "Failed to create a temporary file name"
+msgstr "Nelze vytvořit jméno dočasného souboru"
+
+#: ../src/common/filename.cpp:1081
+msgid "Failed to open temporary file."
+msgstr "Nelze otevřít dočasný soubor."
+
+#: ../src/common/filename.cpp:2862
+#, c-format
+msgid "Failed to modify file times for '%s'"
+msgstr "Nelze změnit hodnoty časů souboru '%s'"
+
+#: ../src/common/filename.cpp:2877
+#, c-format
+msgid "Failed to touch the file '%s'"
+msgstr "Nelze nastavit čas na aktuální pro soubor '%s'"
+
+#: ../src/common/filename.cpp:2958
+#, c-format
+msgid "Failed to retrieve file times for '%s'"
+msgstr "Nelze zjistit hodnoty časů souboru '%s'"
+
+#: ../src/common/filepickercmn.cpp:39 ../src/common/filepickercmn.cpp:40
+msgid "Browse"
+msgstr "Procházet"
+
+#: ../src/common/fldlgcmn.cpp:792 ../src/generic/filectrlg.cpp:1185
+#, c-format
+msgid "All files (%s)|%s"
+msgstr "Všechny soubory (%s)|%s"
+
+#. TRANSLATORS: %s are a file extension used to build a file wildcard string
+#: ../src/common/fldlgcmn.cpp:810
+#, c-format
+msgid "%s files (%s)|%s"
+msgstr "Soubory %s (%s)|%s"
+
+#: ../src/common/fldlgcmn.cpp:1072
+#, c-format
+msgid "Load %s file"
+msgstr "Otevřít soubor %s"
+
+#: ../src/common/fldlgcmn.cpp:1074
+#, c-format
+msgid "Save %s file"
+msgstr "Uložit soubor %s"
+
+#: ../src/common/fmapbase.cpp:144
+msgid "Western European (ISO-8859-1)"
+msgstr "Západoevropské (ISO-8859-1)"
+
+#: ../src/common/fmapbase.cpp:145
+msgid "Central European (ISO-8859-2)"
+msgstr "Středoevropské (ISO-8859-2)"
+
+#: ../src/common/fmapbase.cpp:146
+msgid "Esperanto (ISO-8859-3)"
+msgstr "Esperanto (ISO-8859-3)"
+
+#: ../src/common/fmapbase.cpp:147
+msgid "Baltic (old) (ISO-8859-4)"
+msgstr "Baltský (staré) (ISO-8859-4)"
+
+#: ../src/common/fmapbase.cpp:148
+msgid "Cyrillic (ISO-8859-5)"
+msgstr "Cyrilice (ISO-8859-5)"
+
+#: ../src/common/fmapbase.cpp:149
+msgid "Arabic (ISO-8859-6)"
+msgstr "Arabský (ISO-8859-6)"
+
+#: ../src/common/fmapbase.cpp:150
+msgid "Greek (ISO-8859-7)"
+msgstr "Řecky (ISO-8859-7)"
+
+#: ../src/common/fmapbase.cpp:151
+msgid "Hebrew (ISO-8859-8)"
+msgstr "Hebrejský (ISO-8859-8)"
+
+#: ../src/common/fmapbase.cpp:152
+msgid "Turkish (ISO-8859-9)"
+msgstr "Turecké (ISO-8859-9)"
+
+#: ../src/common/fmapbase.cpp:153
+msgid "Nordic (ISO-8859-10)"
+msgstr "Severské (ISO-8859-10)"
+
+#: ../src/common/fmapbase.cpp:154
+msgid "Thai (ISO-8859-11)"
+msgstr "Thajské (ISO-8859-11)"
+
+#: ../src/common/fmapbase.cpp:155
+msgid "Indian (ISO-8859-12)"
+msgstr "Indický (ISO-8859-12)"
+
+#: ../src/common/fmapbase.cpp:156
+msgid "Baltic (ISO-8859-13)"
+msgstr "Baltský (ISO-8859-13)"
+
+#: ../src/common/fmapbase.cpp:157
+msgid "Celtic (ISO-8859-14)"
+msgstr "Keltské (ISO-8859-14)"
+
+#: ../src/common/fmapbase.cpp:158
+msgid "Western European with Euro (ISO-8859-15)"
+msgstr "Západoevropské s eurem (ISO-8859-15)"
+
+#: ../src/common/fmapbase.cpp:159
+msgid "KOI8-R"
+msgstr "KOI8-R"
+
+#: ../src/common/fmapbase.cpp:160
+msgid "KOI8-U"
+msgstr "KOI8-U"
+
+#: ../src/common/fmapbase.cpp:161
+msgid "Windows/DOS OEM Cyrillic (CP 866)"
+msgstr "Windows/DOS OEM Cyrilické (CP 866)"
+
+#: ../src/common/fmapbase.cpp:162
+msgid "Windows Thai (CP 874)"
+msgstr "Thajské pro Windows (CP 874)"
+
+#: ../src/common/fmapbase.cpp:163
+msgid "Windows Japanese (CP 932) or Shift-JIS"
+msgstr "Japonské pro Windows (CP 932) nebo Shift-JIS"
+
+#: ../src/common/fmapbase.cpp:164
+msgid "Windows Chinese Simplified (CP 936) or GB-2312"
+msgstr "Zjednodušená čínština pro Windows (CP 936) nebo GB-2312"
+
+#: ../src/common/fmapbase.cpp:165
+msgid "Windows Korean (CP 949)"
+msgstr "Korejské pro Windows (CP 949)"
+
+#: ../src/common/fmapbase.cpp:166
+msgid "Windows Chinese Traditional (CP 950) or Big-5"
+msgstr "Tradiční čínština pro Windows (CP 950) nebo Big-5"
+
+#: ../src/common/fmapbase.cpp:167
+msgid "Windows Central European (CP 1250)"
+msgstr "Středoevropské pro Windows (CP 1250)"
+
+#: ../src/common/fmapbase.cpp:168
+msgid "Windows Cyrillic (CP 1251)"
+msgstr "Cyrilice pro Windows (CP 1251)"
+
+#: ../src/common/fmapbase.cpp:169
+msgid "Windows Western European (CP 1252)"
+msgstr "Západoevropské pro Windows (CP 1252)"
+
+#: ../src/common/fmapbase.cpp:170
+msgid "Windows Greek (CP 1253)"
+msgstr "Řecké pro Windows (CP 1253)"
+
+#: ../src/common/fmapbase.cpp:171
+msgid "Windows Turkish (CP 1254)"
+msgstr "Turecké pro Windows (CP 1254)"
+
+#: ../src/common/fmapbase.cpp:172
+msgid "Windows Hebrew (CP 1255)"
+msgstr "Hebrejské pro Windows (CP 1255)"
+
+#: ../src/common/fmapbase.cpp:173
+msgid "Windows Arabic (CP 1256)"
+msgstr "Arabské pro Windows (CP 1256)"
+
+#: ../src/common/fmapbase.cpp:174
+msgid "Windows Baltic (CP 1257)"
+msgstr "Baltské pro Windows (CP 1257)"
+
+#: ../src/common/fmapbase.cpp:175
+msgid "Windows Vietnamese (CP 1258)"
+msgstr "Vietnamština pro Windows (CP 1258)"
+
+#: ../src/common/fmapbase.cpp:176
+msgid "Windows Johab (CP 1361)"
+msgstr "Johab pro Windows (CP 1361)"
+
+#: ../src/common/fmapbase.cpp:177
+msgid "Windows/DOS OEM (CP 437)"
+msgstr "Windows/DOS OEM (CP 437)"
+
+#: ../src/common/fmapbase.cpp:178
+msgid "Unicode 7 bit (UTF-7)"
+msgstr "Unicode 7 bit (UTF-7)"
+
+#: ../src/common/fmapbase.cpp:179
+msgid "Unicode 8 bit (UTF-8)"
+msgstr "Unicode 8 bit (UTF-8)"
+
+#: ../src/common/fmapbase.cpp:181 ../src/common/fmapbase.cpp:187
+msgid "Unicode 16 bit (UTF-16)"
+msgstr "Unicode 16 bit (UTF-16)"
+
+#: ../src/common/fmapbase.cpp:182
+msgid "Unicode 16 bit Little Endian (UTF-16LE)"
+msgstr "Unicode 16 bit Little Endian (UTF-16LE)"
+
+#: ../src/common/fmapbase.cpp:183 ../src/common/fmapbase.cpp:189
+msgid "Unicode 32 bit (UTF-32)"
+msgstr "Unicode 32 bit (UTF-32)"
+
+#: ../src/common/fmapbase.cpp:184
+msgid "Unicode 32 bit Little Endian (UTF-32LE)"
+msgstr "Unicode 32 bit Little Endian (UTF-32LE)"
+
+#: ../src/common/fmapbase.cpp:186
+msgid "Unicode 16 bit Big Endian (UTF-16BE)"
+msgstr "Unicode 16 bit Big Endian (UTF-16BE)"
+
+#: ../src/common/fmapbase.cpp:188
+msgid "Unicode 32 bit Big Endian (UTF-32BE)"
+msgstr "Unicode 32 bit Big Endian (UTF-32BE)"
+
+#: ../src/common/fmapbase.cpp:191
+msgid "Extended Unix Codepage for Japanese (EUC-JP)"
+msgstr "Rozšířená unixová kódová stránka pro Japonštinu (EUC-JP)"
+
+#: ../src/common/fmapbase.cpp:192
+msgid "US-ASCII"
+msgstr "US-ASCII"
+
+#: ../src/common/fmapbase.cpp:193
+msgid "ISO-2022-JP"
+msgstr "ISO-2022-JP"
+
+#: ../src/common/fmapbase.cpp:195
+msgid "MacRoman"
+msgstr "MacPatkové"
+
+#: ../src/common/fmapbase.cpp:196
+msgid "MacJapanese"
+msgstr "MacJaponština"
+
+#: ../src/common/fmapbase.cpp:197
+msgid "MacChineseTrad"
+msgstr "MacČínštinaTrad"
+
+#: ../src/common/fmapbase.cpp:198
+msgid "MacKorean"
+msgstr "MacKorejština"
+
+#: ../src/common/fmapbase.cpp:199
+msgid "MacArabic"
+msgstr "MacArabština"
+
+#: ../src/common/fmapbase.cpp:200
+msgid "MacHebrew"
+msgstr "MacHebrejština"
+
+#: ../src/common/fmapbase.cpp:201
+msgid "MacGreek"
+msgstr "MacŘečtina"
+
+#: ../src/common/fmapbase.cpp:202
+msgid "MacCyrillic"
+msgstr "MacCyrilský"
+
+#: ../src/common/fmapbase.cpp:203
+msgid "MacDevanagari"
+msgstr "MacDévanágarí"
+
+#: ../src/common/fmapbase.cpp:204
+msgid "MacGurmukhi"
+msgstr "MacGurmukhí"
+
+#: ../src/common/fmapbase.cpp:205
+msgid "MacGujarati"
+msgstr "MacGudžarátština"
+
+#: ../src/common/fmapbase.cpp:206
+msgid "MacOriya"
+msgstr "MacOrijština"
+
+#: ../src/common/fmapbase.cpp:207
+msgid "MacBengali"
+msgstr "MacBengálština"
+
+#: ../src/common/fmapbase.cpp:208
+msgid "MacTamil"
+msgstr "MacTamilština"
+
+#: ../src/common/fmapbase.cpp:209
+msgid "MacTelugu"
+msgstr "MacTelugština"
+
+#: ../src/common/fmapbase.cpp:210
+msgid "MacKannada"
+msgstr "MacKannadština"
+
+#: ../src/common/fmapbase.cpp:211
+msgid "MacMalayalam"
+msgstr "MacMalajština"
+
+#: ../src/common/fmapbase.cpp:212
+msgid "MacSinhalese"
+msgstr "MacSinhalština"
+
+#: ../src/common/fmapbase.cpp:213
+msgid "MacBurmese"
+msgstr "MacBarmština"
+
+#: ../src/common/fmapbase.cpp:214
+msgid "MacKhmer"
+msgstr "MacKhmerština"
+
+#: ../src/common/fmapbase.cpp:215
+msgid "MacThai"
+msgstr "MacThajština"
+
+#: ../src/common/fmapbase.cpp:216
+msgid "MacLaotian"
+msgstr "Maclaoština"
+
+#: ../src/common/fmapbase.cpp:217
+msgid "MacGeorgian"
+msgstr "MacGruzinský"
+
+#: ../src/common/fmapbase.cpp:218
+msgid "MacArmenian"
+msgstr "MacArménština"
+
+#: ../src/common/fmapbase.cpp:219
+msgid "MacChineseSimp"
+msgstr "MacČínštinaZjed"
+
+#: ../src/common/fmapbase.cpp:220
+msgid "MacTibetan"
+msgstr "MacTibetština"
+
+#: ../src/common/fmapbase.cpp:221
+msgid "MacMongolian"
+msgstr "MacMongolština"
+
+#: ../src/common/fmapbase.cpp:222
+msgid "MacEthiopic"
+msgstr "MacEtiopské"
+
+#: ../src/common/fmapbase.cpp:223
+msgid "MacCentralEurRoman"
+msgstr "MacStředoevr.Římské"
+
+#: ../src/common/fmapbase.cpp:224
+msgid "MacVietnamese"
+msgstr "MacVietnamština"
+
+#: ../src/common/fmapbase.cpp:225
+msgid "MacExtArabic"
+msgstr "MacArabštinaRozš"
+
+#: ../src/common/fmapbase.cpp:226
+msgid "MacSymbol"
+msgstr "MacSymbol"
+
+#: ../src/common/fmapbase.cpp:227
+msgid "MacDingbats"
+msgstr "MacDingbats"
+
+#: ../src/common/fmapbase.cpp:228
+msgid "MacTurkish"
+msgstr "MacTurečtina"
+
+#: ../src/common/fmapbase.cpp:229
+msgid "MacCroatian"
+msgstr "MacChorvatština"
+
+#: ../src/common/fmapbase.cpp:230
+msgid "MacIcelandic"
+msgstr "MacIslandština"
+
+#: ../src/common/fmapbase.cpp:231
+msgid "MacRomanian"
+msgstr "MacPatkové"
+
+#: ../src/common/fmapbase.cpp:232
+msgid "MacCeltic"
+msgstr "MacKelština"
+
+#: ../src/common/fmapbase.cpp:233
+msgid "MacGaelic"
+msgstr "MacGaelština"
+
+#: ../src/common/fmapbase.cpp:234
+msgid "MacKeyboardGlyphs"
+msgstr "MacKlávesovéGlyfy"
+
+#: ../src/common/fmapbase.cpp:791
+msgid "Default encoding"
+msgstr "Výchozí znaková sada"
+
+#: ../src/common/fmapbase.cpp:805
+#, c-format
+msgid "Unknown encoding (%d)"
+msgstr "Neznámé kódování (%d)"
+
+#: ../src/common/fmapbase.cpp:815 ../src/richtext/richtextstyles.cpp:776
+msgid "default"
+msgstr "výchozí"
+
+#: ../src/common/fmapbase.cpp:829
+#, c-format
+msgid "unknown-%d"
+msgstr "neznámé-%d"
+
+#: ../src/common/fontcmn.cpp:924 ../src/common/fontcmn.cpp:1130
+msgid "underlined"
+msgstr "podtržené"
+
+#: ../src/common/fontcmn.cpp:929
+msgid " strikethrough"
+msgstr " přeškrtnuté"
+
+#: ../src/common/fontcmn.cpp:942
+msgid " thin"
+msgstr " tenké"
+
+#: ../src/common/fontcmn.cpp:946
+msgid " extra light"
+msgstr " velmi tenké"
+
+#: ../src/common/fontcmn.cpp:950
+msgid " light"
+msgstr " tenké"
+
+#: ../src/common/fontcmn.cpp:954
+msgid " medium"
+msgstr " polotučné"
+
+#: ../src/common/fontcmn.cpp:958
+msgid " semi bold"
+msgstr " tříčtvrtečně tučné"
+
+#: ../src/common/fontcmn.cpp:962
+msgid " bold"
+msgstr " tučné"
+
+#: ../src/common/fontcmn.cpp:966
+msgid " extra bold"
+msgstr " velmi tučné"
+
+#: ../src/common/fontcmn.cpp:970
+msgid " heavy"
+msgstr " tučné"
+
+#: ../src/common/fontcmn.cpp:974
+msgid " extra heavy"
+msgstr " velmi tučné"
+
+#: ../src/common/fontcmn.cpp:990
+msgid " italic"
+msgstr " kurzíva"
+
+#: ../src/common/fontcmn.cpp:1134
+msgid "strikethrough"
+msgstr "přeškrtnuté"
+
+#: ../src/common/fontcmn.cpp:1143
+msgid "thin"
+msgstr "tenké"
+
+#: ../src/common/fontcmn.cpp:1156
+msgid "extralight"
+msgstr "velmi tenké"
+
+#: ../src/common/fontcmn.cpp:1161
+msgid "light"
+msgstr "tenké"
+
+#: ../src/common/fontcmn.cpp:1169 ../src/richtext/richtextstyles.cpp:775
+msgid "normal"
+msgstr "normální"
+
+#: ../src/common/fontcmn.cpp:1174
+msgid "medium"
+msgstr "středně tučné"
+
+#: ../src/common/fontcmn.cpp:1179 ../src/common/fontcmn.cpp:1199
+msgid "semibold"
+msgstr "tříčvrtečně tučné"
+
+#: ../src/common/fontcmn.cpp:1184
+msgid "bold"
+msgstr "tučné"
+
+#: ../src/common/fontcmn.cpp:1194
+msgid "extrabold"
+msgstr "velmi tučné"
+
+#: ../src/common/fontcmn.cpp:1204
+msgid "heavy"
+msgstr "tučné"
+
+#: ../src/common/fontcmn.cpp:1212
+msgid "extraheavy"
+msgstr "velmi tučné"
+
+#: ../src/common/fontcmn.cpp:1217
+msgid "italic"
+msgstr "kurzíva"
+
+#: ../src/common/fontmap.cpp:195
+msgid ": unknown charset"
+msgstr ": neznámá znaková sada"
+
+#: ../src/common/fontmap.cpp:199
+#, c-format
+msgid ""
+"The charset '%s' is unknown. You may select\n"
+"another charset to replace it with or choose\n"
+"[Cancel] if it cannot be replaced"
+msgstr ""
+"Znaková sada '%s' je neznámá. Můžete vybrat\n"
+"jinou sadu jako náhradu nebo stiskněte\n"
+"[Storno], pokud ji nelze nahradit"
+
+#: ../src/common/fontmap.cpp:241
+#, c-format
+msgid "Failed to remember the encoding for the charset '%s'."
+msgstr "Nelze uložit kódování znakové sady '%s'."
+
+#: ../src/common/fontmap.cpp:321
+msgid "can't load any font, aborting"
+msgstr "žádné písmo nelze načíst, ukončeno"
+
+#: ../src/common/fontmap.cpp:409
+msgid ": unknown encoding"
+msgstr ": neznámé kódování"
+
+#: ../src/common/fontmap.cpp:417
+#, c-format
+msgid ""
+"No font for displaying text in encoding '%s' found,\n"
+"but an alternative encoding '%s' is available.\n"
+"Do you want to use this encoding (otherwise you will have to choose another "
+"one)?"
+msgstr ""
+"Nenalezen žádný font použitelný k zobrazení textu v kódování '%s',\n"
+"ale je k dispozici alternativní kódování '%s'.\n"
+"Přejete si použít toto kódování (jinak si budete muset vybrat jiné)?"
+
+#: ../src/common/fontmap.cpp:422
+#, c-format
+msgid ""
+"No font for displaying text in encoding '%s' found.\n"
+"Would you like to select a font to be used for this encoding\n"
+"(otherwise the text in this encoding will not be shown correctly)?"
+msgstr ""
+"Nenalezen žádný font použitelný k zobrazení textu v kódování '%s'.\n"
+"Přejete si vybrat font, který se má s tímto kódováním použít\n"
+"(jinak se text v tomto kódování nezobrazí správně)?"
+
+#: ../src/common/fs_mem.cpp:169
+#, c-format
+msgid "Memory VFS already contains file '%s'!"
+msgstr "Paměťový VFS už obsahuje soubor '%s'!"
+
+#: ../src/common/fs_mem.cpp:232
+#, c-format
+msgid "Trying to remove file '%s' from memory VFS, but it is not loaded!"
+msgstr "Soubor '%s' nelze odebrat z paměťového VFS, protože nebyl načten!"
+
+#: ../src/common/fs_mem.cpp:262
+#, c-format
+msgid "Failed to store image '%s' to memory VFS!"
+msgstr "Nepodařilo se uložit obrázek '%s' do paměťového VFS!"
+
+#: ../src/common/ftp.cpp:197
+msgid "Timeout while waiting for FTP server to connect, try passive mode."
+msgstr "Při čekání na spojení s FTP serverem vypršel čas, zkuste pasivní mód."
+
+#: ../src/common/ftp.cpp:399
+#, c-format
+msgid "Failed to set FTP transfer mode to %s."
+msgstr "Nelze nastavit přenosový mód FTP na %s."
+
+#: ../src/common/ftp.cpp:400 ../src/richtext/richtextsymboldlg.cpp:432
+msgid "ASCII"
+msgstr "ASCII"
+
+#: ../src/common/ftp.cpp:400
+msgid "binary"
+msgstr "binární"
+
+#: ../src/common/ftp.cpp:608
+msgid "The FTP server doesn't support the PORT command."
+msgstr "FTP server nepodporuje příkaz PORT."
+
+#: ../src/common/ftp.cpp:622
+msgid "The FTP server doesn't support passive mode."
+msgstr "FTP server nepodporuje pasivní mód."
+
+#: ../src/common/gifdecod.cpp:822
+#, c-format
+msgid "Incorrect GIF frame size (%u, %d) for the frame #%u"
+msgstr "Nesprávné rozměry snímku GIF (%u, %d) pro snímek č. %u"
+
+#: ../src/common/glcmn.cpp:108
+msgid "Failed to allocate colour for OpenGL"
+msgstr "Nelze přidělit barvu pro OpenGL"
+
+#: ../src/common/headerctrlcmn.cpp:57
+msgid "Please select the columns to show and define their order:"
+msgstr "Prosím vyberte sloupce k zobrazení a určete jejich pořadí:"
+
+#: ../src/common/headerctrlcmn.cpp:58
+msgid "Customize Columns"
+msgstr "Přizpůsobit sloupce"
+
+#: ../src/common/headerctrlcmn.cpp:304
+msgid "&Customize..."
+msgstr "&Upravit..."
+
+#: ../src/common/hyperlnkcmn.cpp:132
+#, c-format
+msgid "Failed to open URL \"%s\" in the default browser"
+msgstr "Nelze otevřít URL \"%s\"' ve výchozím prohlížeči."
+
+#: ../src/common/iconbndl.cpp:195
+#, c-format
+msgid "Failed to load image %%d from file '%s'."
+msgstr "Selhalo načítání obrázku %%d ze souboru '%s'."
+
+#: ../src/common/iconbndl.cpp:203
+#, c-format
+msgid "Failed to load image %d from stream."
+msgstr "Nelze načíst obrázek %d z proudu."
+
+#: ../src/common/iconbndl.cpp:221
+#, c-format
+msgid "Failed to load icons from resource '%s'."
+msgstr "Nelze načíst ikonu ze zdroje '%s' ."
+
+#: ../src/common/imagbmp.cpp:97
+msgid "BMP: Couldn't save invalid image."
+msgstr "BMP: Nelze uložit poškozený obrázek."
+
+#: ../src/common/imagbmp.cpp:137
+msgid "BMP: wxImage doesn't have own wxPalette."
+msgstr "BMP: wxImage nemá vlastní wxPalette."
+
+#: ../src/common/imagbmp.cpp:243
+msgid "BMP: Couldn't write the file (Bitmap) header."
+msgstr "BMP: Nelze zapsat hlavičku souboru (Bitmap)."
+
+#: ../src/common/imagbmp.cpp:266
+msgid "BMP: Couldn't write the file (BitmapInfo) header."
+msgstr "BMP: Nelze zapsat hlavičku souboru (BitmapInfo)."
+
+#: ../src/common/imagbmp.cpp:353
+msgid "BMP: Couldn't write RGB color map."
+msgstr "BMP: Nelze zapsat RGB paletu."
+
+#: ../src/common/imagbmp.cpp:487
+msgid "BMP: Couldn't write data."
+msgstr "BMP: Nelze zapsat data."
+
+#: ../src/common/imagbmp.cpp:561 ../src/common/imagbmp.cpp:642
+msgid "BMP: Couldn't allocate memory."
+msgstr "BMP: Nelze přidělit paměť."
+
+#: ../src/common/imagbmp.cpp:1041
+msgid "DIB Header: Image width > 32767 pixels for file."
+msgstr "DIB hlavička: Obrázek má šířku větší než 32767 pixelů."
+
+#: ../src/common/imagbmp.cpp:1049
+msgid "DIB Header: Image height > 32767 pixels for file."
+msgstr "DIB hlavička: Obrázek má výšku větší než 32767 pixelů."
+
+#: ../src/common/imagbmp.cpp:1081
+msgid "DIB Header: Unknown bitdepth in file."
+msgstr "DIB hlavička: Neznámá bitová hloubka."
+
+#: ../src/common/imagbmp.cpp:1156
+msgid "DIB Header: Unknown encoding in file."
+msgstr "DIB hlavička: Neznámé kódování."
+
+#: ../src/common/imagbmp.cpp:1165
+msgid "DIB Header: Encoding doesn't match bitdepth."
+msgstr "DIB hlavička: Kódování neodpovídá bitové hloubce."
+
+#: ../src/common/imagbmp.cpp:1180
+#, c-format
+msgid "BMP Header: Invalid number of colors (%d)."
+msgstr "BMP hlavička: Neplatný počet barev (%d)."
+
+#: ../src/common/imagbmp.cpp:1273
+msgid "Error in reading image DIB."
+msgstr "Chyba při čtení obrázku DIB."
+
+#: ../src/common/imagbmp.cpp:1294
+msgid "ICO: Error in reading mask DIB."
+msgstr "ICO: Chyba při načítání DIB masky."
+
+#: ../src/common/imagbmp.cpp:1353
+msgid "ICO: Image too tall for an icon."
+msgstr "ICO: Obrázek je na ikonu příliš vysoký."
+
+#: ../src/common/imagbmp.cpp:1361
+msgid "ICO: Image too wide for an icon."
+msgstr "ICO: Obrázek je na ikonu příliš široký."
+
+#: ../src/common/imagbmp.cpp:1388 ../src/common/imagbmp.cpp:1488
+#: ../src/common/imagbmp.cpp:1503 ../src/common/imagbmp.cpp:1514
+#: ../src/common/imagbmp.cpp:1528 ../src/common/imagbmp.cpp:1576
+#: ../src/common/imagbmp.cpp:1591 ../src/common/imagbmp.cpp:1605
+#: ../src/common/imagbmp.cpp:1616
+msgid "ICO: Error writing the image file!"
+msgstr "ICO: Chyba při zapisování obrázku!"
+
+#: ../src/common/imagbmp.cpp:1701
+msgid "ICO: Invalid icon index."
+msgstr "ICO: Neplatný index ikony."
+
+#: ../src/common/image.cpp:2410
+msgid "Image and mask have different sizes."
+msgstr "Obrázek a maska mají různé rozměry."
+
+#: ../src/common/image.cpp:2418 ../src/common/image.cpp:2459
+msgid "No unused colour in image being masked."
+msgstr "V obrázku není maskována žádná nepoužitá barva."
+
+#: ../src/common/image.cpp:2641
+#, c-format
+msgid "Failed to load bitmap \"%s\" from resources."
+msgstr "Nelze načíst bitmapu \"%s\" ze zdrojů."
+
+#: ../src/common/image.cpp:2650
+#, c-format
+msgid "Failed to load icon \"%s\" from resources."
+msgstr "Nelze načíst ikonu \"%s\" ze zdrojů."
+
+#: ../src/common/image.cpp:2728 ../src/common/image.cpp:2747
+#, c-format
+msgid "Failed to load image from file \"%s\"."
+msgstr "Nelze načíst obrázek ze souboru \"%s\"."
+
+#: ../src/common/image.cpp:2761
+#, c-format
+msgid "Can't save image to file '%s': unknown extension."
+msgstr "Obrázek nelze uložit do souboru '%s': neznámá přípona."
+
+#: ../src/common/image.cpp:2869
+msgid "No handler found for image type."
+msgstr "Nenalezen žádný ovladač pro tento typ obrázků."
+
+#: ../src/common/image.cpp:2877 ../src/common/image.cpp:3000
+#: ../src/common/image.cpp:3066
+#, c-format
+msgid "No image handler for type %d defined."
+msgstr "Nebyla stanovena žádná obslužná rutina obrázku pro typ %d."
+
+#: ../src/common/image.cpp:2887
+#, c-format
+msgid "Image file is not of type %d."
+msgstr "Soubor s obrázkem není typu %d."
+
+#: ../src/common/image.cpp:2970
+msgid "Can't automatically determine the image format for non-seekable input."
+msgstr "Nelze automaticky zjistit formát obrázku pro nepřevíjitelný vstup."
+
+#: ../src/common/image.cpp:2988
+msgid "Unknown image data format."
+msgstr "Neznámy formát dat obrázku."
+
+#: ../src/common/image.cpp:3009
+#, c-format
+msgid "This is not a %s."
+msgstr "Toto není %s."
+
+#: ../src/common/image.cpp:3032 ../src/common/image.cpp:3080
+#, c-format
+msgid "No image handler for type %s defined."
+msgstr "Nebyla stanovena žádná obslužná rutina obrázku pro typ %s."
+
+#: ../src/common/image.cpp:3041
+#, c-format
+msgid "Image is not of type %s."
+msgstr "Obrázek není typu %s."
+
+#: ../src/common/image.cpp:3509
+#, c-format
+msgid "Failed to check format of image file \"%s\"."
+msgstr "Nelze zkontrolovat formát souboru s obrázkem \"%s\"."
+
+#: ../src/common/imaggif.cpp:124
+msgid "GIF: error in GIF image format."
+msgstr "GIF: chyba ve formátu GIF obrázku."
+
+#: ../src/common/imaggif.cpp:129
+msgid "GIF: not enough memory."
+msgstr "GIF: nedostatek paměti."
+
+#: ../src/common/imaggif.cpp:134
+msgid "GIF: data stream seems to be truncated."
+msgstr "GIF: datový proud je useknutý před koncem."
+
+#: ../src/common/imaggif.cpp:240
+msgid "Couldn't initialize GIF hash table."
+msgstr "Nelze zavést hash tabulku GIF."
+
+#: ../src/common/imagiff.cpp:739
+msgid "IFF: error in IFF image format."
+msgstr "IFF: chyba v IFF formátu obrázku."
+
+#: ../src/common/imagiff.cpp:742
+msgid "IFF: not enough memory."
+msgstr "IFF: nedostatek paměti."
+
+#: ../src/common/imagiff.cpp:745
+msgid "IFF: unknown error!!!"
+msgstr "IFF: neznámá chyba!!!"
+
+#: ../src/common/imagiff.cpp:755
+msgid "IFF: data stream seems to be truncated."
+msgstr "IFF: datový proud je useknutý před koncem."
+
+#: ../src/common/imagjpeg.cpp:258
+msgid "JPEG: Couldn't load - file is probably corrupted."
+msgstr "JPEG: Nelze načíst obrázek - soubor je nejspíš poškozen."
+
+#: ../src/common/imagjpeg.cpp:437
+msgid "JPEG: Couldn't save image."
+msgstr "JPEG: Nelze uložit obrázek."
+
+#: ../src/common/imagpcx.cpp:439
+msgid "PCX: this is not a PCX file."
+msgstr "PCX: tento soubor není PCX."
+
+#: ../src/common/imagpcx.cpp:453
+msgid "PCX: image format unsupported"
+msgstr "PCX: nepodporovaný formát obrázku"
+
+#: ../src/common/imagpcx.cpp:454 ../src/common/imagpcx.cpp:477
+msgid "PCX: couldn't allocate memory"
+msgstr "PCX: nelze přidělit paměť"
+
+#: ../src/common/imagpcx.cpp:455
+msgid "PCX: version number too low"
+msgstr "PCX: číslo verze je příliš nízké"
+
+#: ../src/common/imagpcx.cpp:456 ../src/common/imagpcx.cpp:478
+msgid "PCX: unknown error !!!"
+msgstr "PCX: neznámá chyba !!!"
+
+#: ../src/common/imagpcx.cpp:476
+msgid "PCX: invalid image"
+msgstr "PCX: poškozený obrázek"
+
+#: ../src/common/imagpng.cpp:385
+#, c-format
+msgid "Unknown PNG resolution unit %d"
+msgstr "Neznámá jednotka rozlišení PNG %d"
+
+#: ../src/common/imagpng.cpp:439
+msgid "Couldn't load a PNG image - file is corrupted or not enough memory."
+msgstr ""
+"Nelze načíst PNG obrázek - buď je soubor poškozený nebo není dostatek paměti."
+
+#: ../src/common/imagpng.cpp:513 ../src/common/imagpng.cpp:524
+#: ../src/common/imagpng.cpp:534
+msgid "Couldn't save PNG image."
+msgstr "Nelze uložit PNG obrázek."
+
+#: ../src/common/imagpnm.cpp:71
+msgid "PNM: File format is not recognized."
+msgstr "PNM: formát souboru nerozeznán."
+
+#: ../src/common/imagpnm.cpp:89
+msgid "PNM: Couldn't allocate memory."
+msgstr "PNM: Nelze přidělit paměť."
+
+#: ../src/common/imagpnm.cpp:111 ../src/common/imagpnm.cpp:134
+#: ../src/common/imagpnm.cpp:156
+msgid "PNM: File seems truncated."
+msgstr "PNM: Soubor je nejspíš uříznutý před koncem."
+
+#: ../src/common/imagtiff.cpp:69
+#, c-format
+msgid " (in module \"%s\")"
+msgstr " (v modulu \"%s\")"
+
+#: ../src/common/imagtiff.cpp:304
+msgid "TIFF: Error loading image."
+msgstr "TIFF: Chyba při načítání obrázku."
+
+#: ../src/common/imagtiff.cpp:314
+msgid "Invalid TIFF image index."
+msgstr "Poškozený index v TIFF obrázku."
+
+#: ../src/common/imagtiff.cpp:358
+msgid "TIFF: Image size is abnormally big."
+msgstr "TIFF: Rozměr obrázku je abnormálně velký."
+
+#: ../src/common/imagtiff.cpp:372 ../src/common/imagtiff.cpp:385
+#: ../src/common/imagtiff.cpp:769
+msgid "TIFF: Couldn't allocate memory."
+msgstr "TIFF: Nelze přidělit paměť."
+
+#: ../src/common/imagtiff.cpp:471
+msgid "TIFF: Error reading image."
+msgstr "TIFF: Chyba při čtení obrázku."
+
+#: ../src/common/imagtiff.cpp:532
+#, c-format
+msgid "Unknown TIFF resolution unit %d ignored"
+msgstr "Ignorována neznámá jednotka rozlišení TIFF %d"
+
+#: ../src/common/imagtiff.cpp:611
+msgid "TIFF: Error saving image."
+msgstr "TIFF: Chyba při ukládání obrázku."
+
+#: ../src/common/imagtiff.cpp:868
+msgid "TIFF: Error writing image."
+msgstr "TIFF: Chyba při zapisování obrázku."
+
+#: ../src/common/imagtiff.cpp:881
+msgid "TIFF: Error flushing data."
+msgstr "TIFF: Chyba při vyprazdňování dat."
+
+#: ../src/common/imagwebp.cpp:56
+msgid "WebP: Invalid data (failed to get features)."
+msgstr "WebP: Neplatná data (nelze získat vlastnosti)."
+
+#: ../src/common/imagwebp.cpp:65
+msgid "WebP: Allocating image memory failed."
+msgstr "WebP: Nelze přidělit paměť pro obrazová data."
+
+#: ../src/common/imagwebp.cpp:82
+msgid "WebP: Decoding RGBA image data failed."
+msgstr "WebP: Nelze dekódovat obrazová RGBA data."
+
+#: ../src/common/imagwebp.cpp:98
+msgid "WebP: Decoding RGB image data failed."
+msgstr "WebP: Nelze dekódovat obrazová RGB data."
+
+#: ../src/common/imagwebp.cpp:113 ../src/common/imagwebp.cpp:201
+msgid "WebP: Allocating stream buffer failed."
+msgstr "WebP: Nelze přidělit vyrovnávací paměť proudu."
+
+#: ../src/common/imagwebp.cpp:131
+msgid "WebP: Failed to parse container data."
+msgstr "WebP: Nelze zpracovat data kontejneru."
+
+#: ../src/common/imagwebp.cpp:222
+msgid "WebP: Error decoding animation."
+msgstr "WebP: Chyba při dekódování animace."
+
+#: ../src/common/imagwebp.cpp:240
+msgid "WebP: Error getting next animation frame."
+msgstr "WebP: Chyba při čtení dalšího snímku animace."
+
+#: ../src/common/init.cpp:172
+#, c-format
+msgid ""
+"Command line argument %d couldn't be converted to Unicode and will be "
+"ignored."
+msgstr "Argument příkazové řádky %d nelze převést na Unicode a bude ignorován."
+
+#: ../src/common/init.cpp:344
+msgid "Initialization failed in post init, aborting."
+msgstr "Zavedení selhala v post init, ukončuji."
+
+#: ../src/common/intl.cpp:378
+#, c-format
+msgid "Cannot set locale to language \"%s\"."
+msgstr "Nepodařilo se nastavit místní a jazykové nastavení na \"%s\"."
+
+#: ../src/common/log.cpp:232
+msgid "Error: "
+msgstr "Chyba: "
+
+#: ../src/common/log.cpp:236
+msgid "Warning: "
+msgstr "Varování: "
+
+#: ../src/common/log.cpp:284
+msgid "The previous message repeated once."
+msgstr "Předchozí zpráva opakovaná jednou."
+
+#: ../src/common/log.cpp:291
+#, c-format
+msgid "The previous message repeated %u time."
+msgid_plural "The previous message repeated %u times."
+msgstr[0] "Předchozí zpráva opakovaná %ukrát."
+msgstr[1] "Předchozí zpráva opakovaná %ukrát."
+msgstr[2] "Předchozí zpráva opakovaná %ukrát."
+
+#: ../src/common/log.cpp:319
+#, c-format
+msgid "Last repeated message (\"%s\", %u time) wasn't output"
+msgid_plural "Last repeated message (\"%s\", %u times) wasn't output"
+msgstr[0] "Poslední opakovaná zpráva (\"%s\", %ukrát) nebyla vypsána"
+msgstr[1] "Poslední opakovaná zpráva (\"%s\", %ukrát) nebyla vypsána"
+msgstr[2] "Poslední opakovaná zpráva (\"%s\", %ukrát) nebyla vypsána"
+
+#: ../src/common/log.cpp:435
+#, c-format
+msgid " (error %ld: %s)"
+msgstr " (chyba %ld: %s)"
+
+#: ../src/common/lzmastream.cpp:121
+msgid "Failed to allocate memory for LZMA decompression."
+msgstr "Nelze přidělit paměť pro dekompresi LZMA."
+
+#: ../src/common/lzmastream.cpp:125
+#, c-format
+msgid "Failed to initialize LZMA decompression: unexpected error %u."
+msgstr "Nelze zavést kompresi LZMA: neočekáváná chyba %u."
+
+#: ../src/common/lzmastream.cpp:179
+msgid "input is not in XZ format"
+msgstr "vstupní data nejsou ve formátu XZ"
+
+#: ../src/common/lzmastream.cpp:183
+msgid "input compressed using unknown XZ option"
+msgstr "vstupní data zkomprimována neznámou volbou XZ"
+
+#: ../src/common/lzmastream.cpp:188
+msgid "input is corrupted"
+msgstr "vstupní data jsou poškozena"
+
+#: ../src/common/lzmastream.cpp:192
+msgid "unknown decompression error"
+msgstr "neznámá chyba dekomprese"
+
+#: ../src/common/lzmastream.cpp:196
+#, c-format
+msgid "LZMA decompression error: %s"
+msgstr "chyba dekomprese LZMA: %s"
+
+#: ../src/common/lzmastream.cpp:231
+msgid "Failed to allocate memory for LZMA compression."
+msgstr "Nelze přidělit paměť pro kompresi LZMA."
+
+#: ../src/common/lzmastream.cpp:235
+#, c-format
+msgid "Failed to initialize LZMA compression: unexpected error %u."
+msgstr "Nepodařilo se zavést kompresi LZMA: neočekávaná chyba %u."
+
+#: ../src/common/lzmastream.cpp:267 ../src/common/lzmastream.cpp:342
+#: ../src/html/chm.cpp:336
+msgid "out of memory"
+msgstr "nedostatek paměti"
+
+#: ../src/common/lzmastream.cpp:276 ../src/common/lzmastream.cpp:346
+msgid "unknown compression error"
+msgstr "neznámá chyba komprese"
+
+#: ../src/common/lzmastream.cpp:280
+#, c-format
+msgid "LZMA compression error: %s"
+msgstr "chyba komprese LZMA: %s"
+
+#: ../src/common/lzmastream.cpp:350
+#, c-format
+msgid "LZMA compression error when flushing output: %s"
+msgstr "Chyba komprese LZMA při vyprazdňování výstupních dat: %s"
+
+#: ../src/common/mimecmn.cpp:167
+#, c-format
+msgid "Unmatched '{' in an entry for mime type %s."
+msgstr "Přebytečná '{' v záznamu mime typu %s."
+
+#: ../src/common/module.cpp:76
+#, c-format
+msgid "Circular dependency involving module \"%s\" detected."
+msgstr "Zjištěna kruhová závislost zahrnující modul \"%s\"."
+
+#: ../src/common/module.cpp:128
+#, c-format
+msgid "Dependency \"%s\" of module \"%s\" doesn't exist."
+msgstr "Závislost \"%s\" modulu \"%s\" neexistuje."
+
+#: ../src/common/module.cpp:137
+#, c-format
+msgid "Module \"%s\" initialization failed"
+msgstr "Zavédení modulu \"%s\" selhalo"
+
+#: ../src/common/msgout.cpp:96
+msgid "Message"
+msgstr "Zpráva"
+
+#: ../src/common/paper.cpp:70
+msgid "Letter, 8 1/2 x 11 in"
+msgstr "Letter, 8 1/2 x 11 palců"
+
+#: ../src/common/paper.cpp:71
+msgid "Legal, 8 1/2 x 14 in"
+msgstr "Legal, 8 1/2 x 14 palců"
+
+#: ../src/common/paper.cpp:72
+msgid "A4 sheet, 210 x 297 mm"
+msgstr "A4, 210 x 297 mm"
+
+#: ../src/common/paper.cpp:73
+msgid "C sheet, 17 x 22 in"
+msgstr "C, 17 x 22 palců"
+
+#: ../src/common/paper.cpp:74
+msgid "D sheet, 22 x 34 in"
+msgstr "D, 22 x 34 palců"
+
+#: ../src/common/paper.cpp:75
+msgid "E sheet, 34 x 44 in"
+msgstr "E, 34 x 44 palců"
+
+#: ../src/common/paper.cpp:76
+msgid "Letter Small, 8 1/2 x 11 in"
+msgstr "Letter malý, 8 1/2 x 11 in"
+
+#: ../src/common/paper.cpp:77
+msgid "Tabloid, 11 x 17 in"
+msgstr "Tabloid, 11 x 17 palců"
+
+#: ../src/common/paper.cpp:78
+msgid "Ledger, 17 x 11 in"
+msgstr "Ledger, 17 x 11 palců"
+
+#: ../src/common/paper.cpp:79
+msgid "Statement, 5 1/2 x 8 1/2 in"
+msgstr "Statement, 5 1/2 x 8 1/2 palce"
+
+#: ../src/common/paper.cpp:80
+msgid "Executive, 7 1/4 x 10 1/2 in"
+msgstr "Executive, 7 1/4 x 10 1/2 palce"
+
+#: ../src/common/paper.cpp:81
+msgid "A3 sheet, 297 x 420 mm"
+msgstr "A3, 297 x 420 mm"
+
+#: ../src/common/paper.cpp:82
+msgid "A4 small sheet, 210 x 297 mm"
+msgstr "A4 malá, 210 x 297 mm"
+
+#: ../src/common/paper.cpp:83
+msgid "A5 sheet, 148 x 210 mm"
+msgstr "A5, 148 x 210 mm"
+
+#: ../src/common/paper.cpp:84
+msgid "B4 sheet, 250 x 354 mm"
+msgstr "B4, 250 x 354 mm"
+
+#: ../src/common/paper.cpp:85
+msgid "B5 sheet, 182 x 257 millimeter"
+msgstr "B5, 182 x 257 mm"
+
+#: ../src/common/paper.cpp:86
+msgid "Folio, 8 1/2 x 13 in"
+msgstr "Folio, 8 1/2 x 13 palců"
+
+#: ../src/common/paper.cpp:87
+msgid "Quarto, 215 x 275 mm"
+msgstr "Quarto, 215 x 275 mm"
+
+#: ../src/common/paper.cpp:88
+msgid "10 x 14 in"
+msgstr "10 x 14 palců"
+
+#: ../src/common/paper.cpp:89
+msgid "11 x 17 in"
+msgstr "11 x 17 palců"
+
+#: ../src/common/paper.cpp:90
+msgid "Note, 8 1/2 x 11 in"
+msgstr "Note, 8 1/2 x 11 palců"
+
+#: ../src/common/paper.cpp:91
+msgid "#9 Envelope, 3 7/8 x 8 7/8 in"
+msgstr "Obálka č. 9, 3 7/8 x 8 7/8 palce"
+
+#: ../src/common/paper.cpp:92
+msgid "#10 Envelope, 4 1/8 x 9 1/2 in"
+msgstr "Obálka č. 10, 4 1/8 x 9 1/2 palce"
+
+#: ../src/common/paper.cpp:93
+msgid "#11 Envelope, 4 1/2 x 10 3/8 in"
+msgstr "Obálka č. 11, 4 1/2 x 10 3/8 palce"
+
+#: ../src/common/paper.cpp:94
+msgid "#12 Envelope, 4 3/4 x 11 in"
+msgstr "Obálka č. 12, 4 3/4 x 11 palců"
+
+#: ../src/common/paper.cpp:95
+msgid "#14 Envelope, 5 x 11 1/2 in"
+msgstr "Obálka č. 14, 5 x 11 1/2 palce"
+
+#: ../src/common/paper.cpp:96
+msgid "DL Envelope, 110 x 220 mm"
+msgstr "Obálka DL, 110 x 220 mm"
+
+#: ../src/common/paper.cpp:97
+msgid "C5 Envelope, 162 x 229 mm"
+msgstr "Obálka C5, 162 x 229 mm"
+
+#: ../src/common/paper.cpp:98
+msgid "C3 Envelope, 324 x 458 mm"
+msgstr "Obálka C3, 324 x 458 mm"
+
+#: ../src/common/paper.cpp:99
+msgid "C4 Envelope, 229 x 324 mm"
+msgstr "Obálka C4, 229 x 324 mm"
+
+#: ../src/common/paper.cpp:100
+msgid "C6 Envelope, 114 x 162 mm"
+msgstr "Obálka C6, 114 x 162 mm"
+
+#: ../src/common/paper.cpp:101
+msgid "C65 Envelope, 114 x 229 mm"
+msgstr "Obálka C65, 114 x 229 mm"
+
+#: ../src/common/paper.cpp:102
+msgid "B4 Envelope, 250 x 353 mm"
+msgstr "Obálka B4, 250 x 353 mm"
+
+#: ../src/common/paper.cpp:103
+msgid "B5 Envelope, 176 x 250 mm"
+msgstr "Obálka B5, 176 x 250 mm"
+
+#: ../src/common/paper.cpp:104
+msgid "B6 Envelope, 176 x 125 mm"
+msgstr "Obálka B6, 176 x 125 mm"
+
+#: ../src/common/paper.cpp:105
+msgid "Italy Envelope, 110 x 230 mm"
+msgstr "Italská obálka, 110 x 230 mm"
+
+#: ../src/common/paper.cpp:106
+msgid "Monarch Envelope, 3 7/8 x 7 1/2 in"
+msgstr "Obálka Monarch, 3 7/8 x 7 1/2 palce"
+
+#: ../src/common/paper.cpp:107
+msgid "6 3/4 Envelope, 3 5/8 x 6 1/2 in"
+msgstr "Obálka č. 6 3/4, 3 5/8 x 6 1/2 palce"
+
+#: ../src/common/paper.cpp:108
+msgid "US Std Fanfold, 14 7/8 x 11 in"
+msgstr "US Std Fanfold, 17 7/8 x 11 palců"
+
+#: ../src/common/paper.cpp:109
+msgid "German Std Fanfold, 8 1/2 x 12 in"
+msgstr "Německý Std skládaný, 8 1/2 x 12 palců"
+
+#: ../src/common/paper.cpp:110
+msgid "German Legal Fanfold, 8 1/2 x 13 in"
+msgstr "Německý Legal skládaný, 8 1/2 x 13 palců"
+
+#: ../src/common/paper.cpp:112
+msgid "B4 (ISO) 250 x 353 mm"
+msgstr "B4 (ISO), 250 x 353 mm"
+
+#: ../src/common/paper.cpp:113
+msgid "Japanese Postcard 100 x 148 mm"
+msgstr "Japonská pohlednice 100 x 148 mm"
+
+#: ../src/common/paper.cpp:114
+msgid "9 x 11 in"
+msgstr "9 x 11 palců"
+
+#: ../src/common/paper.cpp:115
+msgid "10 x 11 in"
+msgstr "10 x 11 palců"
+
+#: ../src/common/paper.cpp:116
+msgid "15 x 11 in"
+msgstr "15 x 11 palců"
+
+#: ../src/common/paper.cpp:117
+msgid "Envelope Invite 220 x 220 mm"
+msgstr "Obálka pozvánka 220 x 220 mm"
+
+#: ../src/common/paper.cpp:118
+msgid "Letter Extra 9 1/2 x 12 in"
+msgstr "Letter Extra, 9 1/2 x 12 palců"
+
+#: ../src/common/paper.cpp:119
+msgid "Legal Extra 9 1/2 x 15 in"
+msgstr "Legal Extra, 9 1/2 x 15 palců"
+
+#: ../src/common/paper.cpp:120
+msgid "Tabloid Extra 11.69 x 18 in"
+msgstr "Tabloid Extra 11.69 x 18 palců"
+
+#: ../src/common/paper.cpp:121
+msgid "A4 Extra 9.27 x 12.69 in"
+msgstr "A4 Extra, 9,27 x 12,69 palce"
+
+#: ../src/common/paper.cpp:122
+msgid "Letter Transverse 8 1/2 x 11 in"
+msgstr "Letter napříč 8 1/2 x 11 palců"
+
+#: ../src/common/paper.cpp:123
+msgid "A4 Transverse 210 x 297 mm"
+msgstr "A4 napříč, 210 x 297 mm"
+
+#: ../src/common/paper.cpp:124
+msgid "Letter Extra Transverse 9.275 x 12 in"
+msgstr "Letter napříč Extra, 9,275 x 12 palců"
+
+#: ../src/common/paper.cpp:125
+msgid "SuperA/SuperA/A4 227 x 356 mm"
+msgstr "SuperA/SuperA/A4 227 x 356 mm"
+
+#: ../src/common/paper.cpp:126
+msgid "SuperB/SuperB/A3 305 x 487 mm"
+msgstr "SuperB/SuperB/A3, 305 x 487 mm"
+
+#: ../src/common/paper.cpp:127
+msgid "Letter Plus 8 1/2 x 12.69 in"
+msgstr "Letter Plus, 8 1/2 x 12,69 palce"
+
+#: ../src/common/paper.cpp:128
+msgid "A4 Plus 210 x 330 mm"
+msgstr "A4 Plus, 210 x 330 mm"
+
+#: ../src/common/paper.cpp:129
+msgid "A5 Transverse 148 x 210 mm"
+msgstr "A5 napříč, 148 x 210 mm"
+
+#: ../src/common/paper.cpp:130
+msgid "B5 (JIS) Transverse 182 x 257 mm"
+msgstr "B5 (JIS) napříč, 182 x 257 mm"
+
+#: ../src/common/paper.cpp:131
+msgid "A3 Extra 322 x 445 mm"
+msgstr "A3, Extra 322 x 445 mm"
+
+#: ../src/common/paper.cpp:132
+msgid "A5 Extra 174 x 235 mm"
+msgstr "A5 Extra, 174 x 235 mm"
+
+#: ../src/common/paper.cpp:133
+msgid "B5 (ISO) Extra 201 x 276 mm"
+msgstr "B5 (ISO) Extra, 201 x 276 mm"
+
+#: ../src/common/paper.cpp:134
+msgid "A2 420 x 594 mm"
+msgstr "A2, 420 x 594 mm"
+
+#: ../src/common/paper.cpp:135
+msgid "A3 Transverse 297 x 420 mm"
+msgstr "A3 napříč, 297 x 420 mm"
+
+#: ../src/common/paper.cpp:136
+msgid "A3 Extra Transverse 322 x 445 mm"
+msgstr "A3 napříč Extra, 324 x 458 mm"
+
+#: ../src/common/paper.cpp:138
+msgid "Japanese Double Postcard 200 x 148 mm"
+msgstr "Japonská dvojitá pohlednice 200 x 148 mm"
+
+#: ../src/common/paper.cpp:139
+msgid "A6 105 x 148 mm"
+msgstr "A6, 105 x 148 mm"
+
+#: ../src/common/paper.cpp:140
+msgid "Japanese Envelope Kaku #2"
+msgstr "Japonská obálka Kaku č. 2"
+
+#: ../src/common/paper.cpp:141
+msgid "Japanese Envelope Kaku #3"
+msgstr "Japonská obálka Kaku č. 3"
+
+#: ../src/common/paper.cpp:142
+msgid "Japanese Envelope Chou #3"
+msgstr "Japonská obálka Čó č. 3"
+
+#: ../src/common/paper.cpp:143
+msgid "Japanese Envelope Chou #4"
+msgstr "Japonská obálka Čó č. 4"
+
+#: ../src/common/paper.cpp:144
+msgid "Letter Rotated 11 x 8 1/2 in"
+msgstr "Letter na šířku, 11 x 8 1/2 palce"
+
+#: ../src/common/paper.cpp:145
+msgid "A3 Rotated 420 x 297 mm"
+msgstr "A3 na šířku, 420 x 297 mm"
+
+#: ../src/common/paper.cpp:146
+msgid "A4 Rotated 297 x 210 mm"
+msgstr "A4 na šířku, 297 x 210 mm"
+
+#: ../src/common/paper.cpp:147
+msgid "A5 Rotated 210 x 148 mm"
+msgstr "A5 na šířku, 210 x 148 mm"
+
+#: ../src/common/paper.cpp:148
+msgid "B4 (JIS) Rotated 364 x 257 mm"
+msgstr "B4 (JIS) na šířku, 364 x 257 mm"
+
+#: ../src/common/paper.cpp:149
+msgid "B5 (JIS) Rotated 257 x 182 mm"
+msgstr "B5 (JIS) na šířku, 257 x 182 mm"
+
+#: ../src/common/paper.cpp:150
+msgid "Japanese Postcard Rotated 148 x 100 mm"
+msgstr "Japonská pohlednice na šířku, 148 x 100 mm"
+
+#: ../src/common/paper.cpp:151
+msgid "Double Japanese Postcard Rotated 148 x 200 mm"
+msgstr "Japonská dvojitá pohlednice na šířku 148 x 200 mm"
+
+#: ../src/common/paper.cpp:152
+msgid "A6 Rotated 148 x 105 mm"
+msgstr "A6 na šířku, 148 x 105 mm"
+
+#: ../src/common/paper.cpp:153
+msgid "Japanese Envelope Kaku #2 Rotated"
+msgstr "Japonská obálka Kaku č. 2 na šířku"
+
+#: ../src/common/paper.cpp:154
+msgid "Japanese Envelope Kaku #3 Rotated"
+msgstr "Japonská obálka Kaku č. 3 na šířku"
+
+#: ../src/common/paper.cpp:155
+msgid "Japanese Envelope Chou #3 Rotated"
+msgstr "Japonská obálka Čó č. 3 na šířku"
+
+#: ../src/common/paper.cpp:156
+msgid "Japanese Envelope Chou #4 Rotated"
+msgstr "Japonská obálka Čó č. 4 na šířku"
+
+#: ../src/common/paper.cpp:157
+msgid "B6 (JIS) 128 x 182 mm"
+msgstr "B6 (JIS), 128 x 182 mm"
+
+#: ../src/common/paper.cpp:158
+msgid "B6 (JIS) Rotated 182 x 128 mm"
+msgstr "B6 (JIS) na šířku, 182 x 128 mm"
+
+#: ../src/common/paper.cpp:159
+msgid "12 x 11 in"
+msgstr "12 x 11 palců"
+
+#: ../src/common/paper.cpp:160
+msgid "Japanese Envelope You #4"
+msgstr "Japonská Obálka Jó č. 4"
+
+#: ../src/common/paper.cpp:161
+msgid "Japanese Envelope You #4 Rotated"
+msgstr "Japonská Obálka Jó č. 4 na šířku"
+
+#: ../src/common/paper.cpp:162
+msgid "PRC 16K 146 x 215 mm"
+msgstr "PRC 16K 146 x 215 mm"
+
+#: ../src/common/paper.cpp:163
+msgid "PRC 32K 97 x 151 mm"
+msgstr "PRC 32K 97 x 151 mm"
+
+#: ../src/common/paper.cpp:164
+msgid "PRC 32K(Big) 97 x 151 mm"
+msgstr "PRC 32K (velký) 97 x 151 mm"
+
+#: ../src/common/paper.cpp:165
+msgid "PRC Envelope #1 102 x 165 mm"
+msgstr "Obálka PRC č. 1, 102 x 165 mm"
+
+#: ../src/common/paper.cpp:166
+msgid "PRC Envelope #2 102 x 176 mm"
+msgstr "Obálka PRC č. 2, 102 x 176 mm"
+
+#: ../src/common/paper.cpp:167
+msgid "PRC Envelope #3 125 x 176 mm"
+msgstr "Obálka PRC č. 3, 125 x 176 mm"
+
+#: ../src/common/paper.cpp:168
+msgid "PRC Envelope #4 110 x 208 mm"
+msgstr "Obálka PRC č. 4, 110 x 208 mm"
+
+#: ../src/common/paper.cpp:169
+msgid "PRC Envelope #5 110 x 220 mm"
+msgstr "Obálka PRC č. 5, 110 x 220 mm"
+
+#: ../src/common/paper.cpp:170
+msgid "PRC Envelope #6 120 x 230 mm"
+msgstr "Obálka PRC č. 6, 120 x 230 mm"
+
+#: ../src/common/paper.cpp:171
+msgid "PRC Envelope #7 160 x 230 mm"
+msgstr "Obálka PRC č. 7, 160 x 230 mm"
+
+#: ../src/common/paper.cpp:172
+msgid "PRC Envelope #8 120 x 309 mm"
+msgstr "Obálka PRC č. 8, 120 x 309 mm"
+
+#: ../src/common/paper.cpp:173
+msgid "PRC Envelope #9 229 x 324 mm"
+msgstr "Obálka PRC č. 9, 229 x 324 mm"
+
+#: ../src/common/paper.cpp:174
+msgid "PRC Envelope #10 324 x 458 mm"
+msgstr "Obálka PRC č. 10, 324 x 458 mm"
+
+#: ../src/common/paper.cpp:175
+msgid "PRC 16K Rotated"
+msgstr "PRC 16K na šířku"
+
+#: ../src/common/paper.cpp:176
+msgid "PRC 32K Rotated"
+msgstr "PRC 32K na šířku"
+
+#: ../src/common/paper.cpp:177
+msgid "PRC 32K(Big) Rotated"
+msgstr "PRC 32K (velký) na šířku"
+
+#: ../src/common/paper.cpp:178
+msgid "PRC Envelope #1 Rotated 165 x 102 mm"
+msgstr "Obálka PRC č. 1 na šířku, 165 x 102 mm"
+
+#: ../src/common/paper.cpp:179
+msgid "PRC Envelope #2 Rotated 176 x 102 mm"
+msgstr "Obálka PRC č. 2, na šířku 176 x 102 mm"
+
+#: ../src/common/paper.cpp:180
+msgid "PRC Envelope #3 Rotated 176 x 125 mm"
+msgstr "Obálka PRC č. 3, na šířku 176 x 125 mm"
+
+#: ../src/common/paper.cpp:181
+msgid "PRC Envelope #4 Rotated 208 x 110 mm"
+msgstr "Obálka PRC č. 4, na šířku 208 x 110 mm"
+
+#: ../src/common/paper.cpp:182
+msgid "PRC Envelope #5 Rotated 220 x 110 mm"
+msgstr "Obálka PRC č. 5 na šířku, 220 x 110 mm"
+
+#: ../src/common/paper.cpp:183
+msgid "PRC Envelope #6 Rotated 230 x 120 mm"
+msgstr "Obálka PRC č. 6, na šířku 230 x 120 mm"
+
+#: ../src/common/paper.cpp:184
+msgid "PRC Envelope #7 Rotated 230 x 160 mm"
+msgstr "Obálka PRC č. 7 na šířku, 230 x 160 mm"
+
+#: ../src/common/paper.cpp:185
+msgid "PRC Envelope #8 Rotated 309 x 120 mm"
+msgstr "Obálka PRC č. 8 na šířku, 309 x 120 mm"
+
+#: ../src/common/paper.cpp:186
+msgid "PRC Envelope #9 Rotated 324 x 229 mm"
+msgstr "Obálka PRC č. 9 na šířku, 324 x 229 mm"
+
+#: ../src/common/paper.cpp:187
+msgid "PRC Envelope #10 Rotated 458 x 324 mm"
+msgstr "Obálka PRC č. 10 na šířku, 458 x 324 mm"
+
+#: ../src/common/paper.cpp:192
+msgid "A0 sheet, 841 x 1189 mm"
+msgstr "A0, 841 x 1189 mm"
+
+#: ../src/common/paper.cpp:193
+msgid "A1 sheet, 594 x 841 mm"
+msgstr "A1, 594 x 841 mm"
+
+#: ../src/common/preferencescmn.cpp:37
+msgid "General"
+msgstr "Obecné"
+
+#: ../src/common/preferencescmn.cpp:40
+msgid "Advanced"
+msgstr "Pokročilé"
+
+#: ../src/common/prntbase.cpp:245
+msgid "Generic PostScript"
+msgstr "Obecný PostScript"
+
+#: ../src/common/prntbase.cpp:259
+msgid "Ready"
+msgstr "&Hotovo"
+
+#: ../src/common/prntbase.cpp:331
+msgid "Printing Error"
+msgstr "Chyba tisku"
+
+#: ../src/common/prntbase.cpp:413 ../src/common/prntbase.cpp:1597
+#: ../src/generic/prntdlgg.cpp:135 ../src/generic/prntdlgg.cpp:149
+#: ../src/gtk/print.cpp:628 ../src/gtk/print.cpp:646
+msgid "Print"
+msgstr "Tisk"
+
+#: ../src/common/prntbase.cpp:471 ../src/generic/prntdlgg.cpp:809
+msgid "Page setup"
+msgstr "Nastavení stránky"
+
+#: ../src/common/prntbase.cpp:525
+msgid "Please wait while printing..."
+msgstr "Prosím vyčkejte až skončí tisk..."
+
+#: ../src/common/prntbase.cpp:529
+msgid "Document:"
+msgstr "Dokument:"
+
+#: ../src/common/prntbase.cpp:532
+msgid "Progress:"
+msgstr "Postup:"
+
+#: ../src/common/prntbase.cpp:533
+msgid "Preparing"
+msgstr "Připravování"
+
+#: ../src/common/prntbase.cpp:552
+#, c-format
+msgid "Printing page %d"
+msgstr "Tisk strany %d"
+
+#: ../src/common/prntbase.cpp:557
+#, c-format
+msgid "Printing page %d of %d"
+msgstr "Tisk strany %d z %d"
+
+#: ../src/common/prntbase.cpp:560
+#, c-format
+msgid " (copy %d of %d)"
+msgstr " (kopie %d z %d)"
+
+#: ../src/common/prntbase.cpp:1604
+msgid "First page"
+msgstr "První  stránka"
+
+#: ../src/common/prntbase.cpp:1609 ../src/html/helpwnd.cpp:659
+msgid "Previous page"
+msgstr "Předchozí stránka"
+
+#: ../src/common/prntbase.cpp:1623 ../src/html/helpwnd.cpp:660
+msgid "Next page"
+msgstr "Následující stránka"
+
+#: ../src/common/prntbase.cpp:1628
+msgid "Last page"
+msgstr "Poslední stránka"
+
+#: ../src/common/prntbase.cpp:1636 ../src/common/stockitem.cpp:215
+msgid "Zoom Out"
+msgstr "Oddálit"
+
+#: ../src/common/prntbase.cpp:1650 ../src/common/stockitem.cpp:214
+msgid "Zoom In"
+msgstr "Přiblížit"
+
+#: ../src/common/prntbase.cpp:1656 ../src/common/stockitem.cpp:153
+#: ../src/generic/logg.cpp:553 ../src/univ/themes/win32.cpp:3752
+msgid "&Close"
+msgstr "&Zavřít"
+
+#: ../src/common/prntbase.cpp:2085
+msgid "Could not start document preview."
+msgstr "Nelze zobrazit náhled dokumentu."
+
+#: ../src/common/prntbase.cpp:2085 ../src/common/prntbase.cpp:2129
+#: ../src/common/prntbase.cpp:2137
+msgid "Print Preview Failure"
+msgstr "Chyba během vytváření náhledu"
+
+#: ../src/common/prntbase.cpp:2129 ../src/common/prntbase.cpp:2137
+msgid "Sorry, not enough memory to create a preview."
+msgstr "Je nám líto, pro vytvoření náhledu je nedostatek paměti."
+
+#: ../src/common/prntbase.cpp:2144
+#, c-format
+msgid "Page %d of %d"
+msgstr "Strana %d z %d"
+
+#: ../src/common/prntbase.cpp:2146
+#, c-format
+msgid "Page %d"
+msgstr "Strana %d"
+
+#: ../src/common/regex.cpp:382 ../src/html/chm.cpp:348
+msgid "unknown error"
+msgstr "neznámá chyba"
+
+#: ../src/common/regex.cpp:995
+#, c-format
+msgid "Invalid regular expression '%s': %s"
+msgstr "Špatný regulární výraz '%s': %s"
+
+#: ../src/common/regex.cpp:1059
+#, c-format
+msgid "Failed to find match for regular expression: %s"
+msgstr "Nelze nalézt shodu pro regulární výraz: %s"
+
+#: ../src/common/rendcmn.cpp:188
+#, c-format
+msgid "Renderer \"%s\" has incompatible version %d.%d and couldn't be loaded."
+msgstr "Vykreslovač \"%s\" má nekompatibilní verzi %d.%d a nemohl být načten."
+
+#: ../src/common/secretstore.cpp:162
+msgid "Not available for this platform"
+msgstr "Není dostupné pro tuto platformu"
+
+#: ../src/common/secretstore.cpp:183
+#, c-format
+msgid "Saving password for \"%s\" failed: %s."
+msgstr "Nelze uložit heslo pro \"%s\": %s."
+
+#: ../src/common/secretstore.cpp:205
+#, c-format
+msgid "Reading password for \"%s\" failed: %s."
+msgstr "Nelze načíst heslo pro \"%s\": %s."
+
+#: ../src/common/secretstore.cpp:228
+#, c-format
+msgid "Deleting password for \"%s\" failed: %s."
+msgstr "Nelze smazat heslo pro \"%s\": %s."
+
+#: ../src/common/selectdispatcher.cpp:254
+msgid "Failed to monitor I/O channels"
+msgstr "Nelze monitorovat I/O kanály"
+
+#: ../src/common/sizer.cpp:3054 ../src/common/stockitem.cpp:195
+msgid "Save"
+msgstr "Uložit"
+
+#: ../src/common/sizer.cpp:3056
+msgid "Don't Save"
+msgstr "Neukládat"
+
+#: ../src/common/socket.cpp:870
+msgid "Cannot initialize sockets"
+msgstr "Nelze zavést sockety"
+
+#: ../src/common/stockitem.cpp:127
+msgctxt "standard Windows menu"
+msgid "&Help"
+msgstr "&Nápověda"
+
+#: ../src/common/stockitem.cpp:144
+msgid "&About"
+msgstr "O &aplikaci"
+
+#: ../src/common/stockitem.cpp:144
+msgid "About"
+msgstr "O"
+
+#: ../src/common/stockitem.cpp:145
+msgid "Add"
+msgstr "Přidat"
+
+#: ../src/common/stockitem.cpp:146
+msgid "&Apply"
+msgstr "&Použít"
+
+#: ../src/common/stockitem.cpp:146
+msgid "Apply"
+msgstr "Použít"
+
+#: ../src/common/stockitem.cpp:147
+msgid "&Back"
+msgstr "&Zpět"
+
+#: ../src/common/stockitem.cpp:147
+msgid "Back"
+msgstr "Zpět"
+
+#: ../src/common/stockitem.cpp:148
+msgid "&Bold"
+msgstr "&Tučné"
+
+#: ../src/common/stockitem.cpp:148 ../src/generic/fontdlgg.cpp:326
+#: ../src/richtext/richtextfontpage.cpp:354
+msgid "Bold"
+msgstr "Tučné"
+
+#: ../src/common/stockitem.cpp:149
+msgid "&Bottom"
+msgstr "&Dolů"
+
+#: ../src/common/stockitem.cpp:149 ../src/richtext/richtextsizepage.cpp:287
+msgid "Bottom"
+msgstr "Dolů"
+
+#: ../src/common/stockitem.cpp:150 ../src/generic/fontdlgg.cpp:462
+#: ../src/generic/fontdlgg.cpp:481 ../src/generic/wizard.cpp:415
+msgid "&Cancel"
+msgstr "&Storno"
+
+#: ../src/common/stockitem.cpp:151
+msgid "&CD-ROM"
+msgstr "&CD-ROM"
+
+#: ../src/common/stockitem.cpp:151
+msgid "CD-ROM"
+msgstr "CD-ROM"
+
+#: ../src/common/stockitem.cpp:152
+msgid "&Clear"
+msgstr "&Vymazat"
+
+#: ../src/common/stockitem.cpp:152
+msgid "Clear"
+msgstr "Vymazat"
+
+#: ../src/common/stockitem.cpp:153 ../src/generic/dbgrptg.cpp:93
+#: ../src/generic/progdlgg.cpp:778 ../src/html/helpdlg.cpp:86
+#: ../src/msw/progdlg.cpp:209 ../src/msw/progdlg.cpp:890
+#: ../src/richtext/richtextstyledlg.cpp:272
+#: ../src/richtext/richtextsymboldlg.cpp:448
+msgid "Close"
+msgstr "Zavřít"
+
+#: ../src/common/stockitem.cpp:154
+msgid "&Convert"
+msgstr "&Převést"
+
+#: ../src/common/stockitem.cpp:154
+msgid "Convert"
+msgstr "Převést"
+
+#: ../src/common/stockitem.cpp:155 ../src/msw/textctrl.cpp:2884
+#: ../src/osx/textctrl_osx.cpp:653 ../src/richtext/richtextctrl.cpp:331
+msgid "&Copy"
+msgstr "&Kopírovat"
+
+#: ../src/common/stockitem.cpp:155 ../src/stc/stc_i18n.cpp:18
+msgid "Copy"
+msgstr "Kopírovat"
+
+#: ../src/common/stockitem.cpp:156 ../src/msw/textctrl.cpp:2883
+#: ../src/osx/textctrl_osx.cpp:652 ../src/richtext/richtextctrl.cpp:330
+msgid "Cu&t"
+msgstr "&Vyjmout"
+
+#: ../src/common/stockitem.cpp:156 ../src/stc/stc_i18n.cpp:17
+msgid "Cut"
+msgstr "Vyjmout"
+
+#: ../src/common/stockitem.cpp:157 ../src/msw/textctrl.cpp:2886
+#: ../src/osx/textctrl_osx.cpp:655 ../src/richtext/richtextctrl.cpp:333
+#: ../src/richtext/richtexttabspage.cpp:137
+msgid "&Delete"
+msgstr "&Odstranit"
+
+#: ../src/common/stockitem.cpp:157 ../src/richtext/richtextbuffer.cpp:8266
+#: ../src/stc/stc_i18n.cpp:20
+msgid "Delete"
+msgstr "Delete"
+
+#: ../src/common/stockitem.cpp:158
+msgid "&Down"
+msgstr "&Dolů"
+
+#: ../src/common/stockitem.cpp:158 ../src/generic/fdrepdlg.cpp:148
+msgid "Down"
+msgstr "Dolů"
+
+#: ../src/common/stockitem.cpp:159
+msgid "&Edit"
+msgstr "&Upravit"
+
+#: ../src/common/stockitem.cpp:159
+msgid "Edit"
+msgstr "Upravit"
+
+#: ../src/common/stockitem.cpp:160
+msgid "&Execute"
+msgstr "&Spustit"
+
+#: ../src/common/stockitem.cpp:160
+msgid "Execute"
+msgstr "Spustit"
+
+#: ../src/common/stockitem.cpp:161
+msgid "&Quit"
+msgstr "&Ukončit"
+
+#: ../src/common/stockitem.cpp:161
+msgid "Quit"
+msgstr "Ukončit"
+
+#: ../src/common/stockitem.cpp:162
+msgid "&File"
+msgstr "&Soubor"
+
+#: ../src/common/stockitem.cpp:162
+msgid "File"
+msgstr "Soubor"
+
+#: ../src/common/stockitem.cpp:163
+msgid "&Find..."
+msgstr "&Najít..."
+
+#: ../src/common/stockitem.cpp:163
+msgid "Find..."
+msgstr "Najít..."
+
+#: ../src/common/stockitem.cpp:164
+msgid "&First"
+msgstr "&První"
+
+#: ../src/common/stockitem.cpp:164
+msgid "First"
+msgstr "První"
+
+#: ../src/common/stockitem.cpp:165
+msgid "&Floppy"
+msgstr "&Disketa"
+
+#: ../src/common/stockitem.cpp:165
+msgid "Floppy"
+msgstr "Disketa"
+
+#: ../src/common/stockitem.cpp:166
+msgid "&Forward"
+msgstr "&Dopředu"
+
+#: ../src/common/stockitem.cpp:166
+msgid "Forward"
+msgstr "Dopředu"
+
+#: ../src/common/stockitem.cpp:167
+msgid "&Harddisk"
+msgstr "&Pevný disk"
+
+#: ../src/common/stockitem.cpp:167
+msgid "Harddisk"
+msgstr "Pevný disk"
+
+#: ../src/common/stockitem.cpp:168 ../src/generic/wizard.cpp:418
+#: ../src/osx/cocoa/menu.mm:225 ../src/richtext/richtextstyledlg.cpp:298
+#: ../src/richtext/richtextsymboldlg.cpp:451
+msgid "&Help"
+msgstr "&Nápověda"
+
+#: ../src/common/stockitem.cpp:169
+msgid "&Home"
+msgstr "&Domů"
+
+#: ../src/common/stockitem.cpp:169
+msgid "Home"
+msgstr "Home"
+
+#: ../src/common/stockitem.cpp:170
+msgid "Indent"
+msgstr "Odsazení"
+
+#: ../src/common/stockitem.cpp:171
+msgid "&Index"
+msgstr "&Rejstřík"
+
+#: ../src/common/stockitem.cpp:171 ../src/html/helpwnd.cpp:510
+msgid "Index"
+msgstr "Rejstřík"
+
+#: ../src/common/stockitem.cpp:172
+msgid "&Info"
+msgstr "&Info"
+
+#: ../src/common/stockitem.cpp:172
+msgid "Info"
+msgstr "Info"
+
+#: ../src/common/stockitem.cpp:173
+msgid "&Italic"
+msgstr "&Kurzíva"
+
+#: ../src/common/stockitem.cpp:173 ../src/generic/fontdlgg.cpp:322
+#: ../src/richtext/richtextfontpage.cpp:350
+msgid "Italic"
+msgstr "Kurzíva"
+
+#: ../src/common/stockitem.cpp:174
+msgid "&Jump to"
+msgstr "&Přejít na"
+
+#: ../src/common/stockitem.cpp:174
+msgid "Jump to"
+msgstr "Přejít na"
+
+#: ../src/common/stockitem.cpp:175
+msgid "Centered"
+msgstr "Na střed"
+
+#: ../src/common/stockitem.cpp:176
+msgid "Justified"
+msgstr "Do bloku"
+
+#: ../src/common/stockitem.cpp:177
+msgid "Align Left"
+msgstr "Zarovnat vlevo"
+
+#: ../src/common/stockitem.cpp:178
+msgid "Align Right"
+msgstr "Zarovnat vpravo"
+
+#: ../src/common/stockitem.cpp:179
+msgid "&Last"
+msgstr "Pos&lední"
+
+#: ../src/common/stockitem.cpp:179
+msgid "Last"
+msgstr "Poslední"
+
+#: ../src/common/stockitem.cpp:180
+msgid "&Network"
+msgstr "&Síť"
+
+#: ../src/common/stockitem.cpp:180
+msgid "Network"
+msgstr "Síť"
+
+#: ../src/common/stockitem.cpp:181 ../src/richtext/richtexttabspage.cpp:131
+msgid "&New"
+msgstr "&Nový"
+
+#: ../src/common/stockitem.cpp:181
+msgid "New"
+msgstr "Nový"
+
+#: ../src/common/stockitem.cpp:182 ../src/msw/msgdlg.cpp:417
+msgid "&No"
+msgstr "&Ne"
+
+#: ../src/common/stockitem.cpp:183 ../src/generic/fontdlgg.cpp:467
+#: ../src/generic/fontdlgg.cpp:474
+msgid "&OK"
+msgstr "&OK"
+
+#: ../src/common/stockitem.cpp:184 ../src/generic/dbgrptg.cpp:341
+msgid "&Open..."
+msgstr "&Otevřít..."
+
+#: ../src/common/stockitem.cpp:184
+msgid "Open..."
+msgstr "Otevřít..."
+
+#: ../src/common/stockitem.cpp:185 ../src/msw/textctrl.cpp:2885
+#: ../src/osx/textctrl_osx.cpp:654 ../src/richtext/richtextctrl.cpp:332
+msgid "&Paste"
+msgstr "&Vložit"
+
+#: ../src/common/stockitem.cpp:185 ../src/richtext/richtextctrl.cpp:3484
+#: ../src/stc/stc_i18n.cpp:19
+msgid "Paste"
+msgstr "Vložit"
+
+#: ../src/common/stockitem.cpp:186
+msgid "&Preferences"
+msgstr "&Předvolby"
+
+#: ../src/common/stockitem.cpp:186 ../src/osx/cocoa/preferences.mm:304
+msgid "Preferences"
+msgstr "Předvolby"
+
+#: ../src/common/stockitem.cpp:187
+msgid "Print previe&w..."
+msgstr "Náhle&d tisku..."
+
+#: ../src/common/stockitem.cpp:187
+msgid "Print preview..."
+msgstr "Náhled tisku..."
+
+#: ../src/common/stockitem.cpp:188
+msgid "&Print..."
+msgstr "&Tisk..."
+
+#: ../src/common/stockitem.cpp:188
+msgid "Print..."
+msgstr "Tisk..."
+
+#: ../src/common/stockitem.cpp:189 ../src/richtext/richtextctrl.cpp:337
+#: ../src/richtext/richtextctrl.cpp:5479
+msgid "&Properties"
+msgstr "&Vlastnosti"
+
+#: ../src/common/stockitem.cpp:189
+msgid "Properties"
+msgstr "Vlastnosti"
+
+#: ../src/common/stockitem.cpp:190 ../src/stc/stc_i18n.cpp:16
+msgid "Redo"
+msgstr "&Zopakovat"
+
+#: ../src/common/stockitem.cpp:191
+msgid "Refresh"
+msgstr "Obnovit"
+
+#: ../src/common/stockitem.cpp:192
+msgid "Remove"
+msgstr "Odstranit"
+
+#: ../src/common/stockitem.cpp:193
+msgid "Rep&lace..."
+msgstr "Nah&radit..."
+
+#: ../src/common/stockitem.cpp:193
+msgid "Replace..."
+msgstr "Nahradit..."
+
+#: ../src/common/stockitem.cpp:194
+msgid "Revert to Saved"
+msgstr "Vrátit k uloženému"
+
+#: ../src/common/stockitem.cpp:196 ../src/generic/logg.cpp:549
+msgid "Save &As..."
+msgstr "Uložit &jako..."
+
+#: ../src/common/stockitem.cpp:196
+msgid "Save As..."
+msgstr "Uložit &jako..."
+
+#: ../src/common/stockitem.cpp:197 ../src/msw/textctrl.cpp:2888
+#: ../src/osx/textctrl_osx.cpp:657 ../src/richtext/richtextctrl.cpp:335
+msgid "Select &All"
+msgstr "Vybrat &vše"
+
+#: ../src/common/stockitem.cpp:197 ../src/stc/stc_i18n.cpp:21
+msgid "Select All"
+msgstr "Vybrat vše"
+
+#: ../src/common/stockitem.cpp:198
+msgid "&Color"
+msgstr "&Barva"
+
+#: ../src/common/stockitem.cpp:198
+msgid "Color"
+msgstr "Barva"
+
+#: ../src/common/stockitem.cpp:199
+msgid "&Font"
+msgstr "&Písmo"
+
+#: ../src/common/stockitem.cpp:199 ../src/richtext/richtextformatdlg.cpp:336
+msgid "Font"
+msgstr "Písmo"
+
+#: ../src/common/stockitem.cpp:200
+msgid "&Ascending"
+msgstr "&Vzestupně"
+
+#: ../src/common/stockitem.cpp:200
+msgid "Ascending"
+msgstr "Vzestupně"
+
+#: ../src/common/stockitem.cpp:201
+msgid "&Descending"
+msgstr "&Sestupně"
+
+#: ../src/common/stockitem.cpp:201
+msgid "Descending"
+msgstr "Sestupně"
+
+#: ../src/common/stockitem.cpp:202
+msgid "&Spell Check"
+msgstr "Kontrola pravopi&su"
+
+#: ../src/common/stockitem.cpp:202
+msgid "Spell Check"
+msgstr "Kontrola pravopisu"
+
+#: ../src/common/stockitem.cpp:203
+msgid "&Stop"
+msgstr "Za&stavit"
+
+#: ../src/common/stockitem.cpp:203
+msgid "Stop"
+msgstr "Zastavit"
+
+#: ../src/common/stockitem.cpp:204 ../src/richtext/richtextfontpage.cpp:274
+msgid "&Strikethrough"
+msgstr "&Přeškrtnuté"
+
+#: ../src/common/stockitem.cpp:204
+msgid "Strikethrough"
+msgstr "Přeškrtnuté"
+
+#: ../src/common/stockitem.cpp:205
+msgid "&Top"
+msgstr "&Nahoru"
+
+#: ../src/common/stockitem.cpp:205 ../src/richtext/richtextsizepage.cpp:285
+#: ../src/richtext/richtextsizepage.cpp:289
+msgid "Top"
+msgstr "Nahoru"
+
+#: ../src/common/stockitem.cpp:206
+msgid "Undelete"
+msgstr "Obnovit smazané"
+
+#: ../src/common/stockitem.cpp:207 ../src/generic/fontdlgg.cpp:437
+msgid "&Underline"
+msgstr "Podtrže&ní"
+
+#: ../src/common/stockitem.cpp:207
+msgid "Underline"
+msgstr "Podtržení"
+
+#: ../src/common/stockitem.cpp:208 ../src/stc/stc_i18n.cpp:15
+msgid "Undo"
+msgstr "&Zpět"
+
+#: ../src/common/stockitem.cpp:209
+msgid "&Unindent"
+msgstr "Zr&ušit odsazení"
+
+#: ../src/common/stockitem.cpp:209
+msgid "Unindent"
+msgstr "Zrušit odsazení"
+
+#: ../src/common/stockitem.cpp:210
+msgid "&Up"
+msgstr "Nahor&u"
+
+#: ../src/common/stockitem.cpp:210 ../src/generic/fdrepdlg.cpp:148
+msgid "Up"
+msgstr "Nahoru"
+
+#: ../src/common/stockitem.cpp:211 ../src/msw/msgdlg.cpp:417
+msgid "&Yes"
+msgstr "&Ano"
+
+#: ../src/common/stockitem.cpp:212
+msgid "&Actual Size"
+msgstr "&Skutečná velikost"
+
+#: ../src/common/stockitem.cpp:212
+msgid "Actual Size"
+msgstr "Skutečná velikost"
+
+#: ../src/common/stockitem.cpp:213
+msgid "Zoom to &Fit"
+msgstr "Při&způsobit"
+
+#: ../src/common/stockitem.cpp:213
+msgid "Zoom to Fit"
+msgstr "Přizpůsobit"
+
+#: ../src/common/stockitem.cpp:214
+msgid "Zoom &In"
+msgstr "Př&iblížit"
+
+#: ../src/common/stockitem.cpp:215
+msgid "Zoom &Out"
+msgstr "&Oddálit"
+
+#: ../src/common/stockitem.cpp:262
+msgid "Show about dialog"
+msgstr "Zobrazit dialogové okno O aplikaci"
+
+#: ../src/common/stockitem.cpp:263
+msgid "Copy selection"
+msgstr "Kopírovat výběr"
+
+#: ../src/common/stockitem.cpp:264
+msgid "Cut selection"
+msgstr "Vyjmout výběr"
+
+#: ../src/common/stockitem.cpp:265
+msgid "Delete selection"
+msgstr "Smazat výběr"
+
+#: ../src/common/stockitem.cpp:266
+msgid "Find in document"
+msgstr "Najít v dokumentu"
+
+#: ../src/common/stockitem.cpp:267
+msgid "Find and replace in document"
+msgstr "Najít a nahradit v dokumentu"
+
+#: ../src/common/stockitem.cpp:268
+msgid "Paste selection"
+msgstr "Vložit výběr"
+
+#: ../src/common/stockitem.cpp:269
+msgid "Quit this program"
+msgstr "Ukončit tento program"
+
+#: ../src/common/stockitem.cpp:270
+msgid "Redo last action"
+msgstr "Zopakovat poslední činnost"
+
+#: ../src/common/stockitem.cpp:271
+msgid "Undo last action"
+msgstr "Vrátit zpět poslední činnost"
+
+#: ../src/common/stockitem.cpp:272
+msgid "Create new document"
+msgstr "Vytvořit nový dokument"
+
+#: ../src/common/stockitem.cpp:273
+msgid "Open an existing document"
+msgstr "Otevřít existující dokument"
+
+#: ../src/common/stockitem.cpp:274
+msgid "Close current document"
+msgstr "Zavřít současný dokument"
+
+#: ../src/common/stockitem.cpp:275
+msgid "Save current document"
+msgstr "Uložit aktuální dokument"
+
+#: ../src/common/stockitem.cpp:276
+msgid "Save current document with a different filename"
+msgstr "Uložit aktuální dokument s jiným jménem"
+
+#: ../src/common/strconv.cpp:2324
+#, c-format
+msgid "Conversion to charset '%s' doesn't work."
+msgstr "Převod do znakové sady '%s' nefunguje."
+
+#: ../src/common/tarstrm.cpp:352 ../src/common/tarstrm.cpp:375
+#: ../src/common/tarstrm.cpp:406 ../src/generic/progdlgg.cpp:373
+msgid "unknown"
+msgstr "neznámý"
+
+#: ../src/common/tarstrm.cpp:774
+msgid "incomplete header block in tar"
+msgstr "neúplný blok hlavičky v tar"
+
+#: ../src/common/tarstrm.cpp:798
+msgid "checksum failure reading tar header block"
+msgstr "selhání kontrolního součtu při čtení bloku tar hlavičky"
+
+#: ../src/common/tarstrm.cpp:971
+msgid "invalid data in extended tar header"
+msgstr "neplatná data v rozšířené tar hlavičce"
+
+#: ../src/common/tarstrm.cpp:981 ../src/common/tarstrm.cpp:1003
+#: ../src/common/tarstrm.cpp:1477 ../src/common/tarstrm.cpp:1499
+msgid "tar entry not open"
+msgstr "záznam tar není otevřen"
+
+#: ../src/common/tarstrm.cpp:1023
+msgid "unexpected end of file"
+msgstr "neočekávaný konec souboru"
+
+#: ../src/common/tarstrm.cpp:1297
+#, c-format
+msgid "%s did not fit the tar header for entry '%s'"
+msgstr "%s se nevešlo do tar hlavičky záznamu '%s'"
+
+#: ../src/common/tarstrm.cpp:1359
+msgid "incorrect size given for tar entry"
+msgstr "předána neplatná velikost pro tar záznam"
+
+#: ../src/common/textbuf.cpp:232
+#, c-format
+msgid "'%s' is probably a binary buffer."
+msgstr "'%s' je zřejmě binární buffer."
+
+#: ../src/common/textcmn.cpp:1006 ../src/richtext/richtextctrl.cpp:3053
+msgid "File couldn't be loaded."
+msgstr "Soubor nelze načíst."
+
+#: ../src/common/textfile.cpp:95
+#, c-format
+msgid "Failed to read text file \"%s\"."
+msgstr "Nelze načíst textový soubor \"%s\"."
+
+#: ../src/common/textfile.cpp:160
+#, c-format
+msgid "can't write buffer '%s' to disk."
+msgstr "nelze zapsat vyrovnávací paměť '%s' na disk."
+
+#: ../src/common/time.cpp:212
+msgid "Failed to get the local system time"
+msgstr "Nelze zjistit místní systémový čas"
+
+#: ../src/common/time.cpp:279
+msgid "wxGetTimeOfDay failed."
+msgstr "wxGetTimeOfDay selhalo."
+
+#: ../src/common/translation.cpp:929
+#, c-format
+msgid "'%s' is not a valid message catalog."
+msgstr "'%s' není katalogem zpráv."
+
+#: ../src/common/translation.cpp:954
+msgid "Invalid message catalog."
+msgstr "Neplatný katalog zpráv."
+
+#: ../src/common/translation.cpp:1013
+#, c-format
+msgid "Failed to parse Plural-Forms: '%s'"
+msgstr "Nelze analyzovat formy množného čísla: '%s'"
+
+#: ../src/common/translation.cpp:1723
+#, c-format
+msgid "using catalog '%s' from '%s'."
+msgstr "používám katalog '%s' z '%s'."
+
+#: ../src/common/translation.cpp:1816
+#, c-format
+msgid "Resource '%s' is not a valid message catalog."
+msgstr "Zdroj '%s' není platný katalog zpráv."
+
+#: ../src/common/translation.cpp:1865
+msgid "Couldn't enumerate translations"
+msgstr "Nelze vyjmenovat překlady"
+
+#: ../src/common/utilscmn.cpp:1145
+msgid "No default application configured for HTML files."
+msgstr "Není nastavena žádná výchozí aplikace pro HTML soubory."
+
+#: ../src/common/utilscmn.cpp:1190
+#, c-format
+msgid "Failed to open URL \"%s\" in default browser."
+msgstr "Nelze otevřít URL \"%s\"' ve výchozím prohlížeči."
+
+#: ../src/common/valtext.cpp:144
+msgid "Validation conflict"
+msgstr "Konflikt validace"
+
+#: ../src/common/valtext.cpp:186
+msgid "Required information entry is empty."
+msgstr "Požadovaný informační údaj je prázdný."
+
+#: ../src/common/valtext.cpp:188
+#, c-format
+msgid "'%s' is one of the invalid strings"
+msgstr "'%s' je jeden z neplatných řetězců"
+
+#: ../src/common/valtext.cpp:190
+#, c-format
+msgid "'%s' is not one of the valid strings"
+msgstr "'%s' není jeden z platných řetězců"
+
+#: ../src/common/valtext.cpp:199
+#, c-format
+msgid "'%s' contains invalid character(s)"
+msgstr "'%s' obsahuje neplatné znaky"
+
+#: ../src/common/webrequest.cpp:139
+#, c-format
+msgid "Error: %s (%d)"
+msgstr "Chyba: %s (%d)"
+
+#: ../src/common/webrequest.cpp:655
+#, c-format
+msgid ""
+"Not enough free disk space for download: %llu needed but only %llu available."
+msgstr ""
+"Na disku není dostatek volného místa pro stažení: vyžadováno %llu ale "
+"dostupno jen %llu."
+
+#: ../src/common/webrequest.cpp:669
+#, c-format
+msgid "Failed to create temporary file in %s"
+msgstr "Nelze vytvořit dočasný soubor v %s"
+
+#: ../src/common/webrequest_curl.cpp:1106
+msgid "libcurl could not be initialized"
+msgstr "nelze zavést knihovnu libcurl"
+
+#: ../src/common/webview.cpp:392
+msgid "RunScriptAsync not supported"
+msgstr "RunScriptAsync není podporováno"
+
+#: ../src/common/webview.cpp:403 ../src/msw/webview_ie.cpp:1073
+#, c-format
+msgid "Error running JavaScript: %s"
+msgstr "Chyba při spuštění JavaScriptu: %s"
+
+#: ../src/common/webview_chromium.cpp:858
+#, c-format
+msgid "Failed to set proxy \"%s\": %s"
+msgstr "Nelze nastavit proxy \"%s\": %s"
+
+#: ../src/common/webview_chromium.cpp:989
+msgid ""
+"Chromium can't be used because libcef.so wasn't loaded early enough; please "
+"relink the application or use LD_PRELOAD to load it earlier."
+msgstr ""
+"Chromium nemůže být použito, protože knihovna libcef.so nebyla načtena "
+"dostatečně brzy; prosím sestavte aplikaci znovu nebo použijte LD_PRELOAD pro "
+"dřívější načtení."
+
+#: ../src/common/webview_chromium.cpp:1108
+msgid "Could not initialize Chromium"
+msgstr "Nelze zavést Chromium"
+
+#: ../src/common/webview_chromium.cpp:1616
+msgid "Show DevTools"
+msgstr "Zobrazit Nástroje pro vývojáře"
+
+#: ../src/common/webview_chromium.cpp:1617
+msgid "Close DevTools"
+msgstr "Zavřít Nástroje pro vývojáře"
+
+#: ../src/common/webview_chromium.cpp:1623
+msgid "Inspect"
+msgstr "Prozkoumat"
+
+#: ../src/common/wincmn.cpp:1628
+msgid "This platform does not support background transparency."
+msgstr "Tato platforma nepodporuje průhlednost pozadí."
+
+#: ../src/common/wincmn.cpp:2097
+msgid "Could not transfer data to window"
+msgstr "Nelze přenést data do okna"
+
+#: ../src/common/windowid.cpp:240
+msgid "Out of window IDs.  Recommend shutting down application."
+msgstr "Došla ID oken. Doporučujeme zavřít aplikaci."
+
+#: ../src/common/xpmdecod.cpp:678
+msgid "XPM: incorrect header format!"
+msgstr "XPM: nesprávný formát hlavičky!"
+
+#: ../src/common/xpmdecod.cpp:703
+#, c-format
+msgid "XPM: incorrect colour description in line %d"
+msgstr "XPM: špatný popis barvy na řádku %d"
+
+#: ../src/common/xpmdecod.cpp:715 ../src/common/xpmdecod.cpp:724
+#, c-format
+msgid "XPM: malformed colour definition '%s' at line %d!"
+msgstr "XPM: špatný formát definice barvy '%s' na řádku %d!"
+
+#: ../src/common/xpmdecod.cpp:754
+msgid "XPM: no colors left to use for mask!"
+msgstr "XPM: nezbyly žádné barvy na masku!"
+
+#: ../src/common/xpmdecod.cpp:781
+#, c-format
+msgid "XPM: truncated image data at line %d!"
+msgstr "XPM: ořezaná data obrázku na řádku %d!"
+
+#: ../src/common/xpmdecod.cpp:795
+msgid "XPM: Malformed pixel data!"
+msgstr "XPM: Špatná pixelová data!"
+
+#: ../src/common/xti.cpp:492
+msgid "Illegal Parameter Count for Create Method"
+msgstr "Neplatný počet parametrů pro metodu vytvoření"
+
+#: ../src/common/xti.cpp:504
+msgid "Illegal Parameter Count for ConstructObject Method"
+msgstr "Neplatný počet parametrů pro metodu ConstructObject"
+
+#: ../src/common/xtistrm.cpp:161
+#, c-format
+msgid "Create Parameter %s not found in declared RTTI Parameters"
+msgstr "Create Parameter %s nebyl nalezen v deklarovaných parametrech RTTI"
+
+#: ../src/common/xtistrm.cpp:290
+msgid "Illegal Object Class (Non-wxEvtHandler) as Event Source"
+msgstr "Neplatná třída objektu (Není wxEvtHandler) jako zdroj události"
+
+#: ../src/common/xtistrm.cpp:313 ../src/common/xtixml.cpp:345
+#: ../src/common/xtixml.cpp:498
+msgid "Type must have enum - long conversion"
+msgstr "Typ musí podporovat převod typu enum na long"
+
+#: ../src/common/xtistrm.cpp:400 ../src/common/xtistrm.cpp:415
+msgid "Invalid or Null Object ID passed to GetObjectClassInfo"
+msgstr "Neplatné nebo nulové ID objektu předáno GetObjectClassInfo"
+
+#: ../src/common/xtistrm.cpp:405
+msgid "Unknown Object passed to GetObjectClassInfo"
+msgstr "Neznámý objekt předán GetObjectClassInfo"
+
+#: ../src/common/xtistrm.cpp:420
+msgid "Already Registered Object passed to SetObjectClassInfo"
+msgstr "Již zaregistrovaný objekt předán SetObjectClassInfo"
+
+#: ../src/common/xtistrm.cpp:430
+msgid "Invalid or Null Object ID passed to HasObjectClassInfo"
+msgstr "Neplatné nebo nulové ID objektu předáno HasObjectClassInfo"
+
+#: ../src/common/xtistrm.cpp:460
+msgid "Passing a already registered object to SetObject"
+msgstr "Předávání už zaregistrovaného objektu do SetObject"
+
+#: ../src/common/xtistrm.cpp:471
+msgid "Passing an unknown object to GetObject"
+msgstr "Předávání neznámého objektu do GetObject"
+
+#: ../src/common/xtixml.cpp:229
+msgid "Forward hrefs are not supported"
+msgstr "Dopředné odkazy nejsou podporovány"
+
+#: ../src/common/xtixml.cpp:247
+#, c-format
+msgid "unknown class %s"
+msgstr "neznámá třida %s"
+
+#: ../src/common/xtixml.cpp:253
+msgid "objects cannot have XML Text Nodes"
+msgstr "objekty nemohou mít textové uzly XML"
+
+#: ../src/common/xtixml.cpp:258
+msgid "Objects must have an id attribute"
+msgstr "Objekt musí mít atribut id"
+
+#: ../src/common/xtixml.cpp:267
+#, c-format
+msgid "Doubly used id : %d"
+msgstr "Dvojitě použité id : %d"
+
+#: ../src/common/xtixml.cpp:316
+#, c-format
+msgid "Unknown Property %s"
+msgstr "Neznámá vlastnost %s"
+
+#: ../src/common/xtixml.cpp:407
+msgid "A non empty collection must consist of 'element' nodes"
+msgstr "Sbírka, která není prázdná, musí obsahovat uzly 'element'"
+
+#: ../src/common/xtixml.cpp:478
+msgid "incorrect event handler string, missing dot"
+msgstr "nesprávný řetězec obslužné rutiny události, chybí tečka"
+
+#: ../src/common/zipstrm.cpp:559
+msgid "can't re-initialize zlib deflate stream"
+msgstr "nelze znovu zavést proud zlib deflate"
+
+#: ../src/common/zipstrm.cpp:584
+msgid "can't re-initialize zlib inflate stream"
+msgstr "nelze znovu zavést proud zlib inflate"
+
+#: ../src/common/zipstrm.cpp:1023
+msgid "Ignoring malformed extra data record, ZIP file may be corrupted"
+msgstr "Ignorován chybný extra datový záznam, soubor ZIP může být poškozen"
+
+#: ../src/common/zipstrm.cpp:1502
+msgid "assuming this is a multi-part zip concatenated"
+msgstr "předpokládám, že toto je vícenásobný zřetězený zip"
+
+#: ../src/common/zipstrm.cpp:1664
+msgid "invalid zip file"
+msgstr "neplatný zip soubor"
+
+#: ../src/common/zipstrm.cpp:1723
+msgid "can't find central directory in zip"
+msgstr "v zipu nelze najít centrální adresář"
+
+#: ../src/common/zipstrm.cpp:1812
+msgid "error reading zip central directory"
+msgstr "chyba při čtení centrálního adresáře zip"
+
+#: ../src/common/zipstrm.cpp:1916
+msgid "error reading zip local header"
+msgstr "chyba při čtení místní zip hlavičky"
+
+#: ../src/common/zipstrm.cpp:1964
+msgid "bad zipfile offset to entry"
+msgstr "špatná adresa záznamu v souboru zip"
+
+#: ../src/common/zipstrm.cpp:2031
+msgid "stored file length not in Zip header"
+msgstr "v hlavičce zip není uložená délka souboru"
+
+#: ../src/common/zipstrm.cpp:2045 ../src/common/zipstrm.cpp:2362
+msgid "unsupported Zip compression method"
+msgstr "nepodporovaná metoda komprese zip"
+
+#: ../src/common/zipstrm.cpp:2126
+#, c-format
+msgid "reading zip stream (entry %s): bad length"
+msgstr "čtení proudu zip (záznam %s): špatná délka"
+
+#: ../src/common/zipstrm.cpp:2131
+#, c-format
+msgid "reading zip stream (entry %s): bad crc"
+msgstr "čtení proudu zip (záznam %s): špatná CRC"
+
+#: ../src/common/zipstrm.cpp:2578
+#, c-format
+msgid "error writing zip entry '%s': file too large without ZIP64"
+msgstr ""
+"chyba při zápisu záznamu zip '%s': soubor je bez použití ZIP64 příliš velký"
+
+#: ../src/common/zipstrm.cpp:2585
+#, c-format
+msgid "error writing zip entry '%s': bad crc or length"
+msgstr "chyba při zápisu záznamu zip '%s': špatná CRC nebo délka"
+
+#: ../src/common/zstream.cpp:155 ../src/common/zstream.cpp:315
+msgid "Gzip not supported by this version of zlib"
+msgstr "Gzip není v této verzi zlib podporován"
+
+#: ../src/common/zstream.cpp:182
+msgid "Can't initialize zlib inflate stream."
+msgstr "Nelze zavést zlib inflate proud."
+
+#: ../src/common/zstream.cpp:241
+msgid "Can't read inflate stream: unexpected EOF in underlying stream."
+msgstr ""
+"Nelze číst proud inflate: neočekávaný konec souboru v základovém proudu."
+
+#: ../src/common/zstream.cpp:248 ../src/common/zstream.cpp:423
+#, c-format
+msgid "zlib error %d"
+msgstr "chyba zlib %d"
+
+#: ../src/common/zstream.cpp:249
+#, c-format
+msgid "Can't read from inflate stream: %s"
+msgstr "Nelze číst z inflate proudu: %s"
+
+#: ../src/common/zstream.cpp:343
+msgid "Can't initialize zlib deflate stream."
+msgstr "Nelze zavést zlib deflate proud."
+
+#: ../src/common/zstream.cpp:424
+#, c-format
+msgid "Can't write to deflate stream: %s"
+msgstr "Nelze zapisovat do deflate proudu: %s"
+
+#: ../src/dfb/bitmap.cpp:633 ../src/dfb/bitmap.cpp:667
+#, c-format
+msgid "No bitmap handler for type %d defined."
+msgstr "Žádná obslužná rutina bitmapy pro typ %d není stanovena."
+
+#: ../src/dfb/evtloop.cpp:99
+msgid "Failed to read event from DirectFB pipe"
+msgstr "Nelze číst událost z roury DirectFB"
+
+#: ../src/dfb/evtloop.cpp:171
+msgid "Failed to switch DirectFB pipe to non-blocking mode"
+msgstr "Nelze přepnout rouru DirectFB do neblokujícího režimu"
+
+#: ../src/dfb/fontmgr.cpp:171
+#, c-format
+msgid "no fonts found in %s, using builtin font"
+msgstr "v %s nebylo nalezeno žádné písmo, použito zabudované písmo"
+
+#: ../src/dfb/fontmgr.cpp:177
+msgid "Default font"
+msgstr "Výchozí typ písma"
+
+#: ../src/dfb/fontmgr.cpp:195
+#, c-format
+msgid "Fonts index file %s disappeared while loading fonts."
+msgstr "Soubor rejstříku písem %s při načítaní písem zmizel ."
+
+#: ../src/dfb/wrapdfb.cpp:60
+#, c-format
+msgid "DirectFB error %d occurred."
+msgstr "Vyskytla se chyba DirectFB %d."
+
+#: ../src/generic/aboutdlgg.cpp:69
+msgid "Developed by "
+msgstr "Vyvinuto "
+
+#: ../src/generic/aboutdlgg.cpp:72
+msgid "Documentation by "
+msgstr "Dokumentace "
+
+#: ../src/generic/aboutdlgg.cpp:75
+msgid "Graphics art by "
+msgstr "Grafika "
+
+#: ../src/generic/aboutdlgg.cpp:78
+msgid "Translations by "
+msgstr "Překlad "
+
+#: ../src/generic/aboutdlgg.cpp:133 ../src/osx/cocoa/aboutdlg.mm:83
+msgid "Version "
+msgstr "Verze "
+
+#. TRANSLATORS: %s is application name
+#: ../src/generic/aboutdlgg.cpp:146 ../src/msw/aboutdlg.cpp:60
+#, c-format
+msgid "About %s"
+msgstr "O aplikaci %s"
+
+#: ../src/generic/aboutdlgg.cpp:181
+msgid "License"
+msgstr "Licence"
+
+#: ../src/generic/aboutdlgg.cpp:184
+msgid "Developers"
+msgstr "Vývojáři"
+
+#: ../src/generic/aboutdlgg.cpp:188
+msgid "Documentation writers"
+msgstr "Autoři dokumentace"
+
+#: ../src/generic/aboutdlgg.cpp:192
+msgid "Artists"
+msgstr "Umělci"
+
+#: ../src/generic/aboutdlgg.cpp:196
+msgid "Translators"
+msgstr "Překladatelé"
+
+#: ../src/generic/animateg.cpp:125
+msgid "No handler found for animation type."
+msgstr "Nenalezená žádná obslužná rutina pro typ animace."
+
+#: ../src/generic/animateg.cpp:133
+#, c-format
+msgid "No animation handler for type %ld defined."
+msgstr "Žádná obslužná rutina animací pro typ %ld není stanovena."
+
+#: ../src/generic/animateg.cpp:145
+#, c-format
+msgid "Animation file is not of type %ld."
+msgstr "Soubor animace není typu %ld."
+
+#: ../src/generic/colrdlgg.cpp:154 ../src/gtk/colordlg.cpp:47
+msgid "Choose colour"
+msgstr "Vyberte barvu"
+
+#: ../src/generic/colrdlgg.cpp:357
+msgid "Red:"
+msgstr "Červená:"
+
+#: ../src/generic/colrdlgg.cpp:360
+msgid "Green:"
+msgstr "Zelená:"
+
+#: ../src/generic/colrdlgg.cpp:363
+msgid "Blue:"
+msgstr "Modrá:"
+
+#: ../src/generic/colrdlgg.cpp:372
+msgid "Opacity:"
+msgstr "Neprůhlednost:"
+
+#: ../src/generic/colrdlgg.cpp:384
+msgid "Add to custom colours"
+msgstr "Přidat do vlastních barev"
+
+#: ../src/generic/creddlgg.cpp:56
+msgid "Username:"
+msgstr "Jméno uživatele:"
+
+#: ../src/generic/creddlgg.cpp:63
+msgid "Password:"
+msgstr "Heslo:"
+
+#. TRANSLATORS: Name of Boolean true value
+#: ../src/generic/datavgen.cpp:1178
+msgid "true"
+msgstr "pravda"
+
+#. TRANSLATORS: Name of Boolean false value
+#: ../src/generic/datavgen.cpp:1180
+msgid "false"
+msgstr "nepravda"
+
+#: ../src/generic/datavgen.cpp:6897
+#, c-format
+msgid "Row %i"
+msgstr "Řádka %i"
+
+#. TRANSLATORS: Action for manipulating a tree control
+#: ../src/generic/datavgen.cpp:6987
+msgid "Collapse"
+msgstr "Sbalit"
+
+#. TRANSLATORS: Action for manipulating a tree control
+#: ../src/generic/datavgen.cpp:6990
+msgid "Expand"
+msgstr "Rozbalit"
+
+#. TRANSLATORS: Name of data view control and number of rows
+#: ../src/generic/datavgen.cpp:7011
+#, c-format
+msgid "%s (%d items)"
+msgstr "%s (%d pložek)"
+
+#: ../src/generic/datavgen.cpp:7062
+#, c-format
+msgid "Column %u"
+msgstr "Sloupec %u"
+
+#. TRANSLATORS: Keystroke for manipulating a tree control
+#: ../src/generic/datavgen.cpp:7131 ../src/richtext/richtextbulletspage.cpp:189
+#: ../src/richtext/richtextbulletspage.cpp:192
+#: ../src/richtext/richtextbulletspage.cpp:193
+#: ../src/richtext/richtextliststylepage.cpp:252
+#: ../src/richtext/richtextliststylepage.cpp:255
+#: ../src/richtext/richtextliststylepage.cpp:256
+#: ../src/richtext/richtextsizepage.cpp:248
+msgid "Left"
+msgstr "Doleva"
+
+#. TRANSLATORS: Keystroke for manipulating a tree control
+#: ../src/generic/datavgen.cpp:7134 ../src/richtext/richtextbulletspage.cpp:191
+#: ../src/richtext/richtextliststylepage.cpp:254
+#: ../src/richtext/richtextsizepage.cpp:249
+msgid "Right"
+msgstr "Doprava"
+
+#: ../src/generic/datectlg.cpp:90
+#, c-format
+msgid ""
+"\"%s\" is not in the expected date format, please enter it as e.g. \"%s\"."
+msgstr "\"%s\" nemá očekávaný format data, prosím zadejte jako např. \"%s\"."
+
+#: ../src/generic/datectlg.cpp:94
+msgid "Invalid date"
+msgstr "Chybné datum"
+
+#: ../src/generic/dbgrptg.cpp:159
+#, c-format
+msgid "Open file \"%s\""
+msgstr "Otevřít soubor \"%s\""
+
+#: ../src/generic/dbgrptg.cpp:170
+#, c-format
+msgid "Enter command to open file \"%s\":"
+msgstr "Zadejte příkaz pro otevření souboru \"%s\":"
+
+#: ../src/generic/dbgrptg.cpp:230
+msgid "Executable files (*.exe)|*.exe|"
+msgstr "Spustitelné soubory (*.exe)|*.exe|"
+
+#: ../src/generic/dbgrptg.cpp:300
+#, c-format
+msgid "Debug report \"%s\""
+msgstr "Protokol ladění \"%s\""
+
+#: ../src/generic/dbgrptg.cpp:316
+msgid "A debug report has been generated in the directory\n"
+msgstr "Protokol ladění byl vytvořen v adresáři\n"
+
+#: ../src/generic/dbgrptg.cpp:317
+msgid "The following debug report will be generated\n"
+msgstr "Bude vygenerován následující protokol ladění\n"
+
+#: ../src/generic/dbgrptg.cpp:321
+msgid ""
+"The report contains the files listed below. If any of these files contain "
+"private information,\n"
+"please uncheck them and they will be removed from the report.\n"
+msgstr ""
+"Protokol obsahuje soubory uvedené níže. Pokud některý z těchto souborů "
+"obsahuje citlivé informace,\n"
+"prosím odškrtněte je a tyto budou z protokolu odstraněny.\n"
+
+#: ../src/generic/dbgrptg.cpp:323
+msgid ""
+"If you wish to suppress this debug report completely, please choose the "
+"\"Cancel\" button,\n"
+"but be warned that it may hinder improving the program, so if\n"
+"at all possible please do continue with the report generation.\n"
+msgstr ""
+"Pokud chcete úplně zrušit tento protokol ladění, zvolte, prosím, tlačítko "
+"\"Zrušit\",\n"
+"ale uvědomte si, že tímto můžete brzdit vylepšování programu, takže pokud\n"
+"je to možné, pokračujte, prosím, ve vytváření protokolu.\n"
+
+#: ../src/generic/dbgrptg.cpp:325
+msgid "              Thank you and we're sorry for the inconvenience!\n"
+msgstr "              Děkujeme Vám a omlouváme se za nepříjemnosti!\n"
+
+#: ../src/generic/dbgrptg.cpp:333
+msgid "&Debug report preview:"
+msgstr "Náhle&d protokolu ladění:"
+
+#: ../src/generic/dbgrptg.cpp:339
+msgid "&View..."
+msgstr "&Zobrazit..."
+
+#: ../src/generic/dbgrptg.cpp:359
+msgid "&Notes:"
+msgstr "Poz&námky:"
+
+#: ../src/generic/dbgrptg.cpp:361
+msgid ""
+"If you have any additional information pertaining to this bug\n"
+"report, please enter it here and it will be joined to it:"
+msgstr ""
+"Pokud máte nějaké další informace náležící k tomuto protokolu\n"
+"chyby, zadejte je prosím zde a tyto k němu budou přidány:"
+
+#: ../src/generic/dcpsg.cpp:1627
+msgid "Cannot open file for PostScript printing!"
+msgstr "Nelze otevřít soubor pro PostScriptový tisk!"
+
+#: ../src/generic/dirctrlg.cpp:402
+msgid "Computer"
+msgstr "Počítač"
+
+#: ../src/generic/dirctrlg.cpp:404
+msgid "Sections"
+msgstr "Sekce"
+
+#: ../src/generic/dirctrlg.cpp:482
+msgid "Home directory"
+msgstr "Domovský adresář"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/generic/dirctrlg.cpp:484 ../src/propgrid/advprops.cpp:811
+msgid "Desktop"
+msgstr "Plocha"
+
+#: ../src/generic/dirctrlg.cpp:528 ../src/generic/filectrlg.cpp:752
+msgid "Illegal directory name."
+msgstr "Neplatné jméno adresáře."
+
+#: ../src/generic/dirctrlg.cpp:528 ../src/generic/dirctrlg.cpp:546
+#: ../src/generic/dirctrlg.cpp:557 ../src/generic/dirdlgg.cpp:317
+#: ../src/generic/filectrlg.cpp:638 ../src/generic/filectrlg.cpp:752
+#: ../src/generic/filectrlg.cpp:766 ../src/generic/filectrlg.cpp:782
+#: ../src/generic/filectrlg.cpp:1356 ../src/generic/filectrlg.cpp:1387
+#: ../src/generic/filedlgg.cpp:362 ../src/gtk/filedlg.cpp:76
+msgid "Error"
+msgstr "Chyba"
+
+#: ../src/generic/dirctrlg.cpp:546 ../src/generic/filectrlg.cpp:766
+msgid "File name exists already."
+msgstr "Soubor tohoto jména již existuje."
+
+#: ../src/generic/dirctrlg.cpp:557 ../src/generic/dirdlgg.cpp:317
+#: ../src/generic/filectrlg.cpp:638 ../src/generic/filectrlg.cpp:782
+msgid "Operation not permitted."
+msgstr "Zakázaná operace."
+
+#: ../src/generic/dirdlgg.cpp:107 ../src/generic/filedlgg.cpp:207
+msgid "Create new directory"
+msgstr "Vytvořit nový adresář"
+
+#: ../src/generic/dirdlgg.cpp:112 ../src/generic/filedlgg.cpp:203
+msgid "Go to home directory"
+msgstr "Jít do domovského adresáře"
+
+#: ../src/generic/dirdlgg.cpp:143
+msgid "Show &hidden directories"
+msgstr "Zobrazit &skryté adresáře"
+
+#: ../src/generic/dirdlgg.cpp:196
+#, c-format
+msgid ""
+"The directory '%s' does not exist\n"
+"Create it now?"
+msgstr ""
+"Adresář '%s' neexistuje\n"
+"Chcete ho vytvořit?"
+
+#: ../src/generic/dirdlgg.cpp:198
+msgid "Directory does not exist"
+msgstr "Adresář neexistuje"
+
+#: ../src/generic/dirdlgg.cpp:214
+#, c-format
+msgid ""
+"Failed to create directory '%s'\n"
+"(Do you have the required permissions?)"
+msgstr ""
+"Nelze vytvořit adresář '%s'\n"
+"(Máte potřebná přístupová práva?)"
+
+#: ../src/generic/dirdlgg.cpp:216
+msgid "Error creating directory"
+msgstr "Chyba při vytváření adresáře"
+
+#: ../src/generic/dirdlgg.cpp:281
+msgid "You cannot add a new directory to this section."
+msgstr "Do této sekce nemůžete přidat nový adresář."
+
+#: ../src/generic/dirdlgg.cpp:282
+msgid "Create directory"
+msgstr "Vytvořit adresář"
+
+#: ../src/generic/dirdlgg.cpp:291 ../src/generic/dirdlgg.cpp:301
+#: ../src/generic/filectrlg.cpp:614 ../src/generic/filectrlg.cpp:623
+msgid "NewName"
+msgstr "NoveJmeno"
+
+#: ../src/generic/editlbox.cpp:135
+msgid "Edit item"
+msgstr "Upravit položku"
+
+#: ../src/generic/editlbox.cpp:143
+msgid "New item"
+msgstr "Nova položka"
+
+#: ../src/generic/editlbox.cpp:151
+msgid "Delete item"
+msgstr "Odstranit položku"
+
+#: ../src/generic/editlbox.cpp:159
+msgid "Move up"
+msgstr "Přesunout nahoru"
+
+#: ../src/generic/editlbox.cpp:164
+msgid "Move down"
+msgstr "Přesunout dolů"
+
+#: ../src/generic/fdrepdlg.cpp:108
+msgid "Search for:"
+msgstr "Vyhledat řetězec:"
+
+#: ../src/generic/fdrepdlg.cpp:120
+msgid "Replace with:"
+msgstr "Nahradit textem:"
+
+#: ../src/generic/fdrepdlg.cpp:140
+msgid "Whole word"
+msgstr "Pouze celá slova"
+
+#: ../src/generic/fdrepdlg.cpp:143
+msgid "Match case"
+msgstr "Rozlišuj malá a velká písmena"
+
+#: ../src/generic/fdrepdlg.cpp:156
+msgid "Search direction"
+msgstr "Směr hledání"
+
+#: ../src/generic/fdrepdlg.cpp:175
+msgid "&Replace"
+msgstr "Nah&radit"
+
+#: ../src/generic/fdrepdlg.cpp:178
+msgid "Replace &all"
+msgstr "N&ahradit vše"
+
+#: ../src/generic/filectrlg.cpp:246 ../src/generic/filectrlg.cpp:269
+msgid "<DIR>"
+msgstr "<ADR>"
+
+#: ../src/generic/filectrlg.cpp:248 ../src/generic/filectrlg.cpp:271
+msgid "<LINK>"
+msgstr "<ODKAZ>"
+
+#: ../src/generic/filectrlg.cpp:250 ../src/generic/filectrlg.cpp:273
+msgid "<DRIVE>"
+msgstr "<JEDNOTKA>"
+
+#: ../src/generic/filectrlg.cpp:275
+#, c-format
+msgid "%ld byte"
+msgid_plural "%ld bytes"
+msgstr[0] "%ld bajt"
+msgstr[1] "%ld bajty"
+msgstr[2] "%ld bajtů"
+
+#: ../src/generic/filectrlg.cpp:420
+msgid "Name"
+msgstr "Jméno"
+
+#: ../src/generic/filectrlg.cpp:421 ../src/richtext/richtextformatdlg.cpp:361
+#: ../src/richtext/richtextsizepage.cpp:298
+msgid "Size"
+msgstr "Velikost"
+
+#: ../src/generic/filectrlg.cpp:422
+msgid "Type"
+msgstr "Typ"
+
+#: ../src/generic/filectrlg.cpp:423
+msgid "Modified"
+msgstr "Změněno"
+
+#: ../src/generic/filectrlg.cpp:426
+msgid "Permissions"
+msgstr "Práva"
+
+#: ../src/generic/filectrlg.cpp:429
+msgid "Attributes"
+msgstr "Atributy"
+
+#: ../src/generic/filectrlg.cpp:936
+msgid "Current directory:"
+msgstr "Aktuální adresář:"
+
+#: ../src/generic/filectrlg.cpp:979
+msgid "Show &hidden files"
+msgstr "Zobrazit &skryté soubory"
+
+#: ../src/generic/filectrlg.cpp:1355
+msgid "Illegal file specification."
+msgstr "Neplatná specifikace souboru."
+
+#: ../src/generic/filectrlg.cpp:1387
+msgid "Directory doesn't exist."
+msgstr "Adresář neexistuje."
+
+#: ../src/generic/filedlgg.cpp:195
+msgid "View files as a list view"
+msgstr "Zobrazit soubory v seznamu"
+
+#: ../src/generic/filedlgg.cpp:197
+msgid "View files as a detailed view"
+msgstr "Zobrazit soubory v detailním pohledu"
+
+#: ../src/generic/filedlgg.cpp:200
+msgid "Go to parent directory"
+msgstr "Jít do nadřazeného adresáře"
+
+#: ../src/generic/filedlgg.cpp:351 ../src/gtk/filedlg.cpp:59
+#, c-format
+msgid "File '%s' already exists, do you really want to overwrite it?"
+msgstr "Soubor '%s' existuje, opravdu ho chcete přepsat?"
+
+#: ../src/generic/filedlgg.cpp:354 ../src/gtk/filedlg.cpp:62
+msgid "Confirm"
+msgstr "Potvrdit"
+
+#: ../src/generic/filedlgg.cpp:362 ../src/gtk/filedlg.cpp:75
+msgid "Please choose an existing file."
+msgstr "Prosím vyberte existující soubor."
+
+#: ../src/generic/filepickerg.cpp:64
+msgid "..."
+msgstr "..."
+
+#: ../src/generic/fontdlgg.cpp:76 ../src/richtext/richtextformatdlg.cpp:519
+msgid "ABCDEFGabcdefg12345"
+msgstr "ABCDEFGabcdefg12345"
+
+#: ../src/generic/fontdlgg.cpp:315
+msgid "Roman"
+msgstr "Patkové"
+
+#: ../src/generic/fontdlgg.cpp:316
+msgid "Decorative"
+msgstr "Ozdobné"
+
+#: ../src/generic/fontdlgg.cpp:317
+msgid "Modern"
+msgstr "Moderní"
+
+#: ../src/generic/fontdlgg.cpp:318
+msgid "Script"
+msgstr "Psací"
+
+#: ../src/generic/fontdlgg.cpp:319
+msgid "Swiss"
+msgstr "Bezpatkové"
+
+#: ../src/generic/fontdlgg.cpp:320
+msgid "Teletype"
+msgstr "Neproporcionální"
+
+#: ../src/generic/fontdlgg.cpp:321 ../src/generic/fontdlgg.cpp:324
+msgid "Normal"
+msgstr "Normální"
+
+#: ../src/generic/fontdlgg.cpp:323
+msgid "Slant"
+msgstr "Skloněné"
+
+#: ../src/generic/fontdlgg.cpp:325
+msgid "Light"
+msgstr "Tenké"
+
+#: ../src/generic/fontdlgg.cpp:363
+msgid "&Font family:"
+msgstr "&Rodina písma:"
+
+#: ../src/generic/fontdlgg.cpp:367 ../src/generic/fontdlgg.cpp:369
+msgid "The font family."
+msgstr "Rodina písma."
+
+#: ../src/generic/fontdlgg.cpp:374 ../src/richtext/richtextstylepage.cpp:105
+msgid "&Style:"
+msgstr "&Styl:"
+
+#: ../src/generic/fontdlgg.cpp:378 ../src/generic/fontdlgg.cpp:380
+msgid "The font style."
+msgstr "Styl písma."
+
+#: ../src/generic/fontdlgg.cpp:385
+msgid "&Weight:"
+msgstr "&Tučnost:"
+
+#: ../src/generic/fontdlgg.cpp:389 ../src/generic/fontdlgg.cpp:391
+msgid "The font weight."
+msgstr "Tučnost písma."
+
+#: ../src/generic/fontdlgg.cpp:399
+msgid "C&olour:"
+msgstr "B&arva:"
+
+#: ../src/generic/fontdlgg.cpp:407 ../src/generic/fontdlgg.cpp:409
+msgid "The font colour."
+msgstr "Barva písma."
+
+#: ../src/generic/fontdlgg.cpp:415
+msgid "&Point size:"
+msgstr "&Velikost bodu:"
+
+#: ../src/generic/fontdlgg.cpp:420 ../src/generic/fontdlgg.cpp:422
+#: ../src/generic/fontdlgg.cpp:426 ../src/generic/fontdlgg.cpp:428
+msgid "The font point size."
+msgstr "Velikost písma v bodech."
+
+#: ../src/generic/fontdlgg.cpp:439 ../src/generic/fontdlgg.cpp:441
+msgid "Whether the font is underlined."
+msgstr "Zdali má být písmo podtržené."
+
+#: ../src/generic/fontdlgg.cpp:448 ../src/html/helpwnd.cpp:1215
+msgid "Preview:"
+msgstr "Náhled:"
+
+#: ../src/generic/fontdlgg.cpp:452 ../src/generic/fontdlgg.cpp:454
+msgid "Shows the font preview."
+msgstr "Zobrazí náhled písma."
+
+#: ../src/generic/fontdlgg.cpp:464 ../src/generic/fontdlgg.cpp:483
+msgid "Click to cancel the font selection."
+msgstr "Klikněte pro zrušení výběru písma."
+
+#: ../src/generic/fontdlgg.cpp:469 ../src/generic/fontdlgg.cpp:471
+#: ../src/generic/fontdlgg.cpp:476 ../src/generic/fontdlgg.cpp:478
+msgid "Click to confirm the font selection."
+msgstr "Klikněte pro potvrzení výběru písma."
+
+#: ../src/generic/fontpickerg.cpp:50 ../src/gtk/fontdlg.cpp:77
+msgid "Choose font"
+msgstr "Vyberte písmo"
+
+#: ../src/generic/grid.cpp:6542
+msgid ""
+"Error copying grid to the clipboard. Either selected cells were not "
+"contiguous or no cell was selected."
+msgstr ""
+"Chyba při kopírování tabulky hodnot do schránky. Buď vybrané buňky netvořily "
+"souvislou oblast nebo nebyla vybraná žádná buňka."
+
+#: ../src/generic/grid.cpp:12739
+msgid "Grid Corner"
+msgstr "Roh tabulky hodnot"
+
+#: ../src/generic/grid.cpp:12741
+#, c-format
+msgid "Column %s Header"
+msgstr "Záhlaví sloupce %s"
+
+#: ../src/generic/grid.cpp:12743
+#, c-format
+msgid "Row %s Header"
+msgstr "Záhlaví řádku %s"
+
+#: ../src/generic/grid.cpp:12745
+#, c-format
+msgid "Column %s: %s"
+msgstr "Sloupec %s: %s"
+
+#: ../src/generic/grid.cpp:12749
+#, c-format
+msgid "Row %s: %s"
+msgstr "Řádka %s: %s"
+
+#: ../src/generic/grid.cpp:12753
+#, c-format
+msgid "Row %s, Column %s: %s"
+msgstr "Řádek %s, Sloupec %s: %s"
+
+#: ../src/generic/helpext.cpp:257
+#, c-format
+msgid "Help directory \"%s\" not found."
+msgstr "Adresář Nápovědy \"%s\" nenalezen."
+
+#: ../src/generic/helpext.cpp:265
+#, c-format
+msgid "Help file \"%s\" not found."
+msgstr "Soubor s nápovědou \"%s\" nebyl nalezen."
+
+#: ../src/generic/helpext.cpp:284
+#, c-format
+msgid "Line %lu of map file \"%s\" has invalid syntax, skipped."
+msgstr "Řádek %luz mapovacího souboru \"%s\" nemá platný formát, přeskočen."
+
+#: ../src/generic/helpext.cpp:292
+#, c-format
+msgid "No valid mappings found in the file \"%s\"."
+msgstr "Nenalezeno žádné platné mapování v souboru \"%s\"."
+
+#: ../src/generic/helpext.cpp:435
+msgid "No entries found."
+msgstr "Nenalezeny žádné položky."
+
+#: ../src/generic/helpext.cpp:444 ../src/generic/helpext.cpp:445
+msgid "Help Index"
+msgstr "Index nápovědy"
+
+#: ../src/generic/helpext.cpp:448
+msgid "Relevant entries:"
+msgstr "Související položky:"
+
+#: ../src/generic/helpext.cpp:449
+msgid "Entries found"
+msgstr "Nalezené položky"
+
+#: ../src/generic/hyperlinkg.cpp:170
+msgid "&Copy URL"
+msgstr "&Kopírovat URL"
+
+#: ../src/generic/infobar.cpp:119
+msgid "Hide this notification message."
+msgstr "Skrýt tuto oznamovací zprávu."
+
+#. TRANSLATORS: %s will be either the application name or "Application"
+#: ../src/generic/logg.cpp:257
+#, c-format
+msgid "%s Error"
+msgstr "%s - chyba"
+
+#. TRANSLATORS: %s will be either the application name or "Application"
+#: ../src/generic/logg.cpp:263
+#, c-format
+msgid "%s Warning"
+msgstr "%s - varování"
+
+#. TRANSLATORS: %s will be either the application name or "Application"
+#: ../src/generic/logg.cpp:273
+#, c-format
+msgid "%s Information"
+msgstr "%s - informace"
+
+#: ../src/generic/logg.cpp:276
+msgid "Application"
+msgstr "Aplikace"
+
+#: ../src/generic/logg.cpp:549
+msgid "Save log contents to file"
+msgstr "Uložit obsah logu do souboru"
+
+#: ../src/generic/logg.cpp:551
+msgid "C&lear"
+msgstr "&Vymazat"
+
+#: ../src/generic/logg.cpp:551
+msgid "Clear the log contents"
+msgstr "Smazat obsah logu"
+
+#: ../src/generic/logg.cpp:553
+msgid "Close this window"
+msgstr "Zavřít okno"
+
+#: ../src/generic/logg.cpp:554
+msgid "&Log"
+msgstr "&Log"
+
+#: ../src/generic/logg.cpp:610 ../src/generic/logg.cpp:992
+msgid "Can't save log contents to file."
+msgstr "Nelze uložit obsah logu do souboru."
+
+#: ../src/generic/logg.cpp:613
+#, c-format
+msgid "Log saved to the file '%s'."
+msgstr "Log uložen do souboru '%s'."
+
+#: ../src/generic/logg.cpp:719
+msgid "&Details"
+msgstr "&Detaily"
+
+#: ../src/generic/logg.cpp:972
+msgid "Failed to copy dialog contents to the clipboard."
+msgstr "Nelze zkopírovat obsah dialogového okna do schránky."
+
+#: ../src/generic/logg.cpp:1022
+#, c-format
+msgid "Append log to file '%s' (choosing [No] will overwrite it)?"
+msgstr "Připojit log k souboru '%s' (pokud zvolíte [Ne] soubor bude přepsán)?"
+
+#: ../src/generic/logg.cpp:1024
+msgid "Question"
+msgstr "Otázka"
+
+#: ../src/generic/logg.cpp:1038
+msgid "invalid message box return value"
+msgstr "špatná návratová hodnota message boxu"
+
+#: ../src/generic/notifmsgg.cpp:129
+msgid "Notice"
+msgstr "Oznámení"
+
+#: ../src/generic/preferencesg.cpp:118
+#, c-format
+msgid "%s Preferences"
+msgstr "Předvolby %s"
+
+#: ../src/generic/printps.cpp:143
+msgid "Printing..."
+msgstr "Tisk..."
+
+#: ../src/generic/printps.cpp:160 ../src/gtk/print.cpp:1076
+#: ../src/msw/printwin.cpp:235
+msgid "Could not start printing."
+msgstr "Nelze zahájit tisk."
+
+#: ../src/generic/printps.cpp:183
+#, c-format
+msgid "Printing page %d..."
+msgstr "Tisk strany %d..."
+
+#: ../src/generic/prntdlgg.cpp:171
+msgid "Printer options"
+msgstr "Nastavení tiskárny"
+
+#: ../src/generic/prntdlgg.cpp:176
+msgid "Print to File"
+msgstr "Tisk do souboru"
+
+#: ../src/generic/prntdlgg.cpp:179
+msgid "Setup..."
+msgstr "Nastavení..."
+
+#: ../src/generic/prntdlgg.cpp:187
+msgid "Printer:"
+msgstr "Tiskárna:"
+
+#: ../src/generic/prntdlgg.cpp:195
+msgid "Status:"
+msgstr "Stav:"
+
+#: ../src/generic/prntdlgg.cpp:206
+msgid "All"
+msgstr "Vše"
+
+#: ../src/generic/prntdlgg.cpp:207
+msgid "Pages"
+msgstr "Strany"
+
+#: ../src/generic/prntdlgg.cpp:215
+msgid "Print Range"
+msgstr "Rozsah tisku"
+
+#: ../src/generic/prntdlgg.cpp:229
+msgid "From:"
+msgstr "Od:"
+
+#: ../src/generic/prntdlgg.cpp:233
+msgid "To:"
+msgstr "Do:"
+
+#: ../src/generic/prntdlgg.cpp:238
+msgid "Copies:"
+msgstr "Kopie:"
+
+#: ../src/generic/prntdlgg.cpp:288
+msgid "PostScript file"
+msgstr "soubor PostScriptu"
+
+#: ../src/generic/prntdlgg.cpp:439
+msgid "Print Setup"
+msgstr "Nastavení tisku"
+
+#: ../src/generic/prntdlgg.cpp:483
+msgid "Printer"
+msgstr "Tiskárna"
+
+#: ../src/generic/prntdlgg.cpp:501
+msgid "Default printer"
+msgstr "Výchozí tiskárna"
+
+#: ../src/generic/prntdlgg.cpp:595 ../src/generic/prntdlgg.cpp:782
+#: ../src/generic/prntdlgg.cpp:822 ../src/generic/prntdlgg.cpp:835
+#: ../src/generic/prntdlgg.cpp:1031 ../src/generic/prntdlgg.cpp:1036
+msgid "Paper size"
+msgstr "Velikost papíru"
+
+#: ../src/generic/prntdlgg.cpp:604 ../src/generic/prntdlgg.cpp:847
+msgid "Portrait"
+msgstr "Na výšku"
+
+#: ../src/generic/prntdlgg.cpp:605 ../src/generic/prntdlgg.cpp:848
+msgid "Landscape"
+msgstr "Na šířku"
+
+#: ../src/generic/prntdlgg.cpp:607 ../src/generic/prntdlgg.cpp:849
+msgid "Orientation"
+msgstr "Orientace"
+
+#: ../src/generic/prntdlgg.cpp:610
+msgid "Options"
+msgstr "Nastavení"
+
+#: ../src/generic/prntdlgg.cpp:612
+msgid "Print in colour"
+msgstr "Tisknout barevně"
+
+#: ../src/generic/prntdlgg.cpp:621
+msgid "Print spooling"
+msgstr "Tisková fronta"
+
+#: ../src/generic/prntdlgg.cpp:623
+msgid "Printer command:"
+msgstr "Příkaz tisku:"
+
+#: ../src/generic/prntdlgg.cpp:631
+msgid "Printer options:"
+msgstr "Nastavení tiskárny:"
+
+#: ../src/generic/prntdlgg.cpp:860
+msgid "Left margin (mm):"
+msgstr "Levý okraj (mm):"
+
+#: ../src/generic/prntdlgg.cpp:861
+msgid "Top margin (mm):"
+msgstr "Horní okraj (mm):"
+
+#: ../src/generic/prntdlgg.cpp:872
+msgid "Right margin (mm):"
+msgstr "Pravý okraj (mm):"
+
+#: ../src/generic/prntdlgg.cpp:873
+msgid "Bottom margin (mm):"
+msgstr "Dolní okraj (mm):"
+
+#: ../src/generic/prntdlgg.cpp:896
+msgid "Printer..."
+msgstr "Tiskárna..."
+
+#: ../src/generic/progdlgg.cpp:246
+msgid "&Skip"
+msgstr "Pře&skočit"
+
+#: ../src/generic/progdlgg.cpp:347 ../src/generic/progdlgg.cpp:626
+msgid "Unknown"
+msgstr "Neznámo"
+
+#: ../src/generic/progdlgg.cpp:451 ../src/msw/progdlg.cpp:526
+msgid "Done."
+msgstr "Hotovo."
+
+#: ../src/generic/srchctlg.cpp:55 ../src/gtk/srchctrl.cpp:206
+#: ../src/html/helpwnd.cpp:530 ../src/html/helpwnd.cpp:545
+msgid "Search"
+msgstr "Hledat"
+
+#: ../src/generic/tabg.cpp:1026
+msgid "Could not find tab for id"
+msgstr "Nelze najít záložku pro id"
+
+#: ../src/generic/tipdlg.cpp:136
+msgid "Tips not available, sorry!"
+msgstr "Tipy nejsou k dispozici, omlouváme se!"
+
+#: ../src/generic/tipdlg.cpp:197
+msgid "Tip of the Day"
+msgstr "Tip dne"
+
+#: ../src/generic/tipdlg.cpp:207
+msgid "Did you know..."
+msgstr "Víte, že..."
+
+#: ../src/generic/tipdlg.cpp:232
+msgid "&Show tips at startup"
+msgstr "&Zobrazovat tipy při spuštění"
+
+#: ../src/generic/tipdlg.cpp:236
+msgid "&Next Tip"
+msgstr "&Další tip"
+
+#: ../src/generic/wizard.cpp:411
+msgid "&Next >"
+msgstr "&Další >"
+
+#: ../src/generic/wizard.cpp:412
+msgid "&Finish"
+msgstr "&Dokončit"
+
+#: ../src/generic/wizard.cpp:420
+msgid "< &Back"
+msgstr "< &Zpět"
+
+#: ../src/gtk/aboutdlg.cpp:204
+msgid "translator-credits"
+msgstr "překladatel-poděkování"
+
+#: ../src/gtk/app.cpp:517
+msgid ""
+"WARNING: using XIM input method is unsupported and may result in problems "
+"with input handling and flickering. Consider unsetting GTK_IM_MODULE or "
+"setting to \"ibus\"."
+msgstr ""
+"VAROVÁNÍ: použití vstupní metody XIM není podporováno a může způsobit "
+"problémy se zadáváním znaků a blikáním obrazovky. Zvažte odstranění proměnné "
+"GTK_IM_MODULE nebo její nastavení na \"ibus\"."
+
+#: ../src/gtk/app.cpp:569
+msgid "Unable to initialize GTK+, is DISPLAY set properly?"
+msgstr "Nelze spustit GTK+, je ZOBRAZENÍ nastaveno správně?"
+
+#: ../src/gtk/filedlg.cpp:89 ../src/gtk/filepicker.cpp:255
+#, c-format
+msgid "Changing current directory to \"%s\" failed"
+msgstr "Změna současného adresáře na \"%s\" selhala"
+
+#: ../src/gtk/font.cpp:548
+msgid ""
+"Using private fonts is not supported on this system: Pango library is too "
+"old, 1.38 or later required."
+msgstr ""
+"Na tomto systému nelze použít privátní fonty: Knihovna Pango je příliš "
+"stará, je požadována verze 1.38 a novější"
+
+#: ../src/gtk/font.cpp:558
+msgid "Failed to create font configuration object."
+msgstr "Nelze vytvořit objekt pro konfiguraci fontů."
+
+#: ../src/gtk/font.cpp:568
+#, c-format
+msgid "Failed to add custom font \"%s\"."
+msgstr "Nelze přidat vlastní font \"%s\"."
+
+#: ../src/gtk/font.cpp:576
+msgid "Failed to register font configuration using private fonts."
+msgstr "Nelze zaregistrovat nastavení fontu pro soukromé fonty."
+
+#: ../src/gtk/glcanvas.cpp:117 ../src/gtk/glcanvas.cpp:132
+msgid "Fatal Error"
+msgstr "Kritická chyba"
+
+#: ../src/gtk/glcanvas.cpp:117
+msgid ""
+"This program wasn't compiled with EGL support required under Wayland, "
+"either\n"
+"install EGL libraries and rebuild or run it under X11 backend by setting\n"
+"environment variable GDK_BACKEND=x11 before starting your program."
+msgstr ""
+"Tento program nebyl přeložen s podporou pro EGL požadovanou Waylandem, buď\n"
+"nainstalujete knihovny EGL a program znovu přeložte nebo jej spusťte pod X11 "
+"backendem pomocí\n"
+"nastavení proměnné prostředí GDK_BACKEND=x11 před spuštěním tohoto programu."
+
+#: ../src/gtk/glcanvas.cpp:132
+msgid ""
+"wxGLCanvas is only supported on Wayland and X11 currently.  You may be able "
+"to\n"
+"work around this by setting environment variable GDK_BACKEND=x11 before\n"
+"starting your program."
+msgstr ""
+"wxGLCanvas je nyní podporován jen na systémech Wayland and X11. Možná budete "
+"moci\n"
+"toto omezení obejít nastavením proměnné prostředí GDK_BACKEND=x11 před "
+"spuštěním\n"
+"tohoto programu."
+
+#: ../src/gtk/mdi.cpp:433
+msgid "MDI child"
+msgstr "MDI syn"
+
+#: ../src/gtk/power.cpp:188
+#, c-format
+msgid "Failed to open D-Bus connection to the login manager: %s"
+msgstr "Nelze otevřít spojení D-Bus se správcem přihlášení: %s"
+
+#: ../src/gtk/power.cpp:214
+msgid "wxWidgets application"
+msgstr "Aplikace používající wxWidgets"
+
+#: ../src/gtk/power.cpp:226
+msgid "Application needs to keep running"
+msgstr "Aplikace potřebuje pokračovat ve svém běhu"
+
+#: ../src/gtk/power.cpp:233
+msgid "Clean up before suspend"
+msgstr "Provedení údržby před pozastavením"
+
+#: ../src/gtk/power.cpp:259
+#, c-format
+msgid "Failed to inhibit sleep: %s"
+msgstr "Nelze předejít režimu spánku: %s"
+
+#: ../src/gtk/power.cpp:265
+msgid "Unexpected response to D-Bus \"Inhibit\" request."
+msgstr "Neočekávaná odpověď na D-Bus požadavek \"Inhibit\"."
+
+#: ../src/gtk/print.cpp:218
+msgid "Custom size"
+msgstr "Vlastní velikost"
+
+#: ../src/gtk/print.cpp:752
+#, c-format
+msgid "Error while printing: %s"
+msgstr "Chyba při tisku: %s"
+
+#: ../src/gtk/print.cpp:816
+msgid "Page Setup"
+msgstr "Nastavení stránky"
+
+#: ../src/gtk/webview_webkit.cpp:932
+msgid "Retrieving JavaScript script output is not supported with WebKit v1"
+msgstr "WebKit v1 neumožňuje získání výsledku spuštění skriptu JavaScript"
+
+#: ../src/gtk/webview_webkit2.cpp:1098
+msgid ""
+"Setting proxy is not supported by WebKit, at least version 2.16 is required."
+msgstr ""
+"Nastavení proxy není WebKitem podporováno, je vyžadována verze nejméně 2.16."
+
+#: ../src/gtk/webview_webkit2.cpp:1104
+msgid "This program was compiled without support for setting WebKit proxy."
+msgstr "Aplikace byla sestavena bez podpory nastavení proxy ve WebKitu."
+
+#: ../src/gtk/window.cpp:6289
+msgid ""
+"GTK+ installed on this machine is too old to support screen compositing, "
+"please install GTK+ 2.12 or later."
+msgstr ""
+"GTK+ instalovaný na tomto stroji je příliš starý pro podporu skládání "
+"obrazovky, nainstalujte prosím GTK+ 2.12 nebo novější."
+
+#: ../src/gtk/window.cpp:6307
+msgid ""
+"Compositing not supported by this system, please enable it in your Window "
+"Manager."
+msgstr ""
+"Skládání není podporováno v tomto systému, povolte ho prosím ve správci oken."
+
+#: ../src/gtk/window.cpp:6318
+msgid ""
+"This program was compiled with a too old version of GTK+, please rebuild "
+"with GTK+ 2.12 or newer."
+msgstr ""
+"Tento program byl sestaven s příliš starou verzí GTK+, znovu ho, prosím, "
+"sestavte s GTK+ 2.12 nebo novější."
+
+#: ../src/html/chm.cpp:138
+#, c-format
+msgid "Failed to open CHM archive '%s'."
+msgstr "Nelze otevřít CHM archiv '%s'."
+
+#: ../src/html/chm.cpp:270
+#, c-format
+msgid "Could not extract %s into %s: %s"
+msgstr "Nelze extrahovat %s do %s: %s"
+
+#: ../src/html/chm.cpp:324
+msgid "no error"
+msgstr "bez chyb"
+
+#: ../src/html/chm.cpp:326
+msgid "bad arguments to library function"
+msgstr "špatné argumenty pro funkci knihovny"
+
+#: ../src/html/chm.cpp:328
+msgid "error opening file"
+msgstr "chyba při otevírání souboru"
+
+#: ../src/html/chm.cpp:330
+msgid "read error"
+msgstr "chyba při čteni"
+
+#: ../src/html/chm.cpp:332
+msgid "write error"
+msgstr "chyba při zápisu"
+
+#: ../src/html/chm.cpp:334
+msgid "seek error"
+msgstr "chyba při hledání"
+
+#: ../src/html/chm.cpp:338
+msgid "bad signature"
+msgstr "špatný podpis"
+
+#: ../src/html/chm.cpp:340
+msgid "error in data format"
+msgstr "chyba ve formátu dat"
+
+#: ../src/html/chm.cpp:342
+msgid "checksum error"
+msgstr "chyba kontrolního součtu"
+
+#: ../src/html/chm.cpp:344
+msgid "compression error"
+msgstr "chyba komprese"
+
+#: ../src/html/chm.cpp:346
+msgid "decompression error"
+msgstr "chyba dekomprese"
+
+#: ../src/html/chm.cpp:437
+#, c-format
+msgid "Could not locate file '%s'."
+msgstr "Nelze nalézt soubor '%s'."
+
+#: ../src/html/chm.cpp:711
+#, c-format
+msgid "Could not create temporary file '%s'"
+msgstr "Nelze vytvořit dočasný soubor '%s'"
+
+#: ../src/html/chm.cpp:718
+#, c-format
+msgid "Extraction of '%s' into '%s' failed."
+msgstr "Extrakce '%s' do '%s' selhala."
+
+#: ../src/html/chm.cpp:806 ../src/html/chm.cpp:863
+msgid "CHM handler currently supports only local files!"
+msgstr "Obslužná rutina CHM v současnosti podporuje pouze místní soubory!"
+
+#: ../src/html/chm.cpp:827
+msgid "Link contained '//', converted to absolute link."
+msgstr "Odkaz obsahoval '//', převeden na absolutní."
+
+#: ../src/html/helpctrl.cpp:59
+#, c-format
+msgid "Help: %s"
+msgstr "Nápověda: %s"
+
+#: ../src/html/helpctrl.cpp:155
+#, c-format
+msgid "Adding book %s"
+msgstr "Přidávám knihu %s"
+
+#: ../src/html/helpdata.cpp:295
+#, c-format
+msgid "Cannot open contents file: %s"
+msgstr "Nelze otevřít soubor s obsahem: %s"
+
+#: ../src/html/helpdata.cpp:309
+#, c-format
+msgid "Cannot open index file: %s"
+msgstr "Nelze otevřít soubor s rejstříkem: %s"
+
+#: ../src/html/helpdata.cpp:643
+msgid "noname"
+msgstr "bezejmenná"
+
+#: ../src/html/helpdata.cpp:652
+#, c-format
+msgid "Cannot open HTML help book: %s"
+msgstr "Nelze otevřít knihu HTML nápovědy: %s"
+
+#: ../src/html/helpwnd.cpp:315
+msgid "Displays help as you browse the books on the left."
+msgstr "Při procházení knih zobrazí vlevo nápovědu."
+
+#: ../src/html/helpwnd.cpp:411 ../src/html/helpwnd.cpp:1100
+#: ../src/html/helpwnd.cpp:1735
+msgid "(bookmarks)"
+msgstr "(záložky)"
+
+#: ../src/html/helpwnd.cpp:424
+msgid "Add current page to bookmarks"
+msgstr "Přidá tuto stránku do záložek"
+
+#: ../src/html/helpwnd.cpp:425
+msgid "Remove current page from bookmarks"
+msgstr "Odstraní tuto stránku ze záložek"
+
+#: ../src/html/helpwnd.cpp:470
+msgid "Contents"
+msgstr "Obsah"
+
+#: ../src/html/helpwnd.cpp:485
+msgid "Find"
+msgstr "Najít"
+
+#: ../src/html/helpwnd.cpp:487
+msgid "Show all"
+msgstr "Zobraz vše"
+
+#: ../src/html/helpwnd.cpp:497
+msgid ""
+"Display all index items that contain given substring. Search is case "
+"insensitive."
+msgstr ""
+"Zobrazí všechny položky rejstříku, které obsahují daný podřetězec. "
+"Nerozlišuje velká a malá písmena."
+
+#: ../src/html/helpwnd.cpp:498
+msgid "Show all items in index"
+msgstr "Zobrazí všechny položky v rejstříku"
+
+#: ../src/html/helpwnd.cpp:528
+msgid "Case sensitive"
+msgstr "Rozlišovat velká/malá"
+
+#: ../src/html/helpwnd.cpp:529
+msgid "Whole words only"
+msgstr "Pouze celá slova"
+
+#: ../src/html/helpwnd.cpp:532
+msgid ""
+"Search contents of help book(s) for all occurrences of the text you typed "
+"above"
+msgstr ""
+"Prohledá obsah knih(y) s nápovědou a vypíše všechny výskyty textu, který "
+"jste zadali"
+
+#: ../src/html/helpwnd.cpp:653
+msgid "Show/hide navigation panel"
+msgstr "Zobraz/skryj navigační panel"
+
+#: ../src/html/helpwnd.cpp:655
+msgid "Go back"
+msgstr "Jdi zpět"
+
+#: ../src/html/helpwnd.cpp:656
+msgid "Go forward"
+msgstr "Jdi dopředu"
+
+#: ../src/html/helpwnd.cpp:658
+msgid "Go one level up in document hierarchy"
+msgstr "Jdi o úroveň výš"
+
+#: ../src/html/helpwnd.cpp:666 ../src/html/helpwnd.cpp:1547
+msgid "Open HTML document"
+msgstr "Otevřít dokument HTML"
+
+#: ../src/html/helpwnd.cpp:670
+msgid "Print this page"
+msgstr "Vytiskne tuto stránku"
+
+#: ../src/html/helpwnd.cpp:674
+msgid "Display options dialog"
+msgstr "Zobrazí dialogové okno s nastaveními"
+
+#: ../src/html/helpwnd.cpp:795
+msgid "Please choose the page to display:"
+msgstr "Prosím vyberte stránku k zobrazení:"
+
+#: ../src/html/helpwnd.cpp:796
+msgid "Help Topics"
+msgstr "Témata nápovědy"
+
+#: ../src/html/helpwnd.cpp:852
+msgid "Searching..."
+msgstr "Hledám..."
+
+#: ../src/html/helpwnd.cpp:853
+msgid "No matching page found yet"
+msgstr "Ještě nebylo nic nalezeno"
+
+#: ../src/html/helpwnd.cpp:870
+#, c-format
+msgid "Found %i matches"
+msgstr "Nalezeno výskytů: %i"
+
+#: ../src/html/helpwnd.cpp:958
+msgid "(Help)"
+msgstr "(Nápověda)"
+
+#: ../src/html/helpwnd.cpp:1026
+#, c-format
+msgid "%d of %lu"
+msgstr "%d z %lu"
+
+#: ../src/html/helpwnd.cpp:1028
+#, c-format
+msgid "%lu of %lu"
+msgstr "%lu z %lu"
+
+#: ../src/html/helpwnd.cpp:1047
+msgid "Search in all books"
+msgstr "Hledej ve všech knihách"
+
+#: ../src/html/helpwnd.cpp:1193
+msgid "Help Browser Options"
+msgstr "Nastavení prohlížeče nápovědy"
+
+#: ../src/html/helpwnd.cpp:1198
+msgid "Normal font:"
+msgstr "Normální písmo:"
+
+#: ../src/html/helpwnd.cpp:1199
+msgid "Fixed font:"
+msgstr "Neproporcionální písmo:"
+
+#: ../src/html/helpwnd.cpp:1200
+msgid "Font size:"
+msgstr "Velikost písma:"
+
+#: ../src/html/helpwnd.cpp:1245
+msgid "font size"
+msgstr "velikost písma"
+
+#: ../src/html/helpwnd.cpp:1256
+msgid "Normal face<br>and <u>underlined</u>. "
+msgstr "Normální písmo<br>a <u>podtržené</u>. "
+
+#: ../src/html/helpwnd.cpp:1257
+msgid "<i>Italic face.</i> "
+msgstr "<i>Kurzíva.</i> "
+
+#: ../src/html/helpwnd.cpp:1258
+msgid "<b>Bold face.</b> "
+msgstr "<b>Tučně.</b> "
+
+#: ../src/html/helpwnd.cpp:1259
+msgid "<b><i>Bold italic face.</i></b><br>"
+msgstr "<b><i>Tučná kurzíva.</i></b><br>"
+
+#: ../src/html/helpwnd.cpp:1262
+msgid "Fixed size face.<br> <b>bold</b> <i>italic</i> "
+msgstr "Písmo s pevnou velikostí.<br> <b>tučné</b> <i>kurzíva</i> "
+
+#: ../src/html/helpwnd.cpp:1263
+msgid "<b><i>bold italic <u>underlined</u></i></b><br>"
+msgstr "<b><i>tučná kurzíva <u>podtržené</u></i></b><br>"
+
+#: ../src/html/helpwnd.cpp:1524
+msgid "Help Printing"
+msgstr "Tisk nápovědy"
+
+#: ../src/html/helpwnd.cpp:1527
+msgid "Cannot print empty page."
+msgstr "Nelze tisknout prázdnou stránku."
+
+#: ../src/html/helpwnd.cpp:1540
+msgid "HTML files (*.html;*.htm)|*.html;*.htm|"
+msgstr "Soubory HTML (*.html;*.htm)|*.html;*.htm|"
+
+#: ../src/html/helpwnd.cpp:1541
+msgid "Help books (*.htb)|*.htb|Help books (*.zip)|*.zip|"
+msgstr "Knihy s nápovědou (*.htb)|*.htb|Knihy s nápovědou (*.zip)|*.zip|"
+
+#: ../src/html/helpwnd.cpp:1542
+msgid "HTML Help Project (*.hhp)|*.hhp|"
+msgstr "Projekt Nápovědy HTML (*.hhp)|*.hhp|"
+
+#: ../src/html/helpwnd.cpp:1544
+msgid "Compressed HTML Help file (*.chm)|*.chm|"
+msgstr "Komprimovaný soubor Nápovědy HTML (*.chm)|*.chm|"
+
+#: ../src/html/helpwnd.cpp:1671
+#, c-format
+msgid "%i of %u"
+msgstr "%i z %u"
+
+#: ../src/html/helpwnd.cpp:1709
+#, c-format
+msgid "%u of %u"
+msgstr "%u z %u"
+
+#: ../src/html/htmlfilt.cpp:134
+#, c-format
+msgid "Cannot open HTML document: %s"
+msgstr "Nelze otevřít HTML dokument: %s"
+
+#: ../src/html/htmlwin.cpp:599
+msgid "Connecting..."
+msgstr "Připojuji se..."
+
+#: ../src/html/htmlwin.cpp:616
+#, c-format
+msgid "Unable to open requested HTML document: %s"
+msgstr "Nelze otevřít požadovaný HTML dokument: %s"
+
+#: ../src/html/htmlwin.cpp:630
+msgid "Loading : "
+msgstr "Načítám : "
+
+#: ../src/html/htmlwin.cpp:673
+msgid "Done"
+msgstr "Hotovo"
+
+#: ../src/html/htmlwin.cpp:723
+#, c-format
+msgid "HTML anchor %s does not exist."
+msgstr "Kotva HTML %s neexistuje."
+
+#: ../src/html/htmlwin.cpp:1057
+#, c-format
+msgid "Copied to clipboard:\"%s\""
+msgstr "Zkopírováno do schránky: \"%s\""
+
+#: ../src/html/htmprint.cpp:269
+msgid ""
+"This document doesn't fit on the page horizontally and will be truncated "
+"when it is printed."
+msgstr ""
+"Tento dokument se vodorovně na stránku nevejde a bude při tisku zkrácen."
+
+#: ../src/html/htmprint.cpp:285
+#, c-format
+msgid ""
+"The document \"%s\" doesn't fit on the page horizontally and will be "
+"truncated if printed.\n"
+"\n"
+"Would you like to proceed with printing it nevertheless?"
+msgstr ""
+"Dokument \"%s\" se vodorovně na stránku nevejde a bude zkrácen, pokud bude "
+"vytisknut.\n"
+"\n"
+"Chcete přesto pokračovat v tisku?"
+
+#: ../src/html/htmprint.cpp:296
+msgid ""
+"If possible, try changing the layout parameters to make the printout more "
+"narrow."
+msgstr ""
+"Pokud je to možné, zkuste změnit parametry rozvržení, aby byl výtisk užší."
+
+#: ../src/html/htmprint.cpp:445
+msgid ": file does not exist!"
+msgstr ": soubor neexistuje!"
+
+#. TRANSLATORS: %s may be a document title.
+#: ../src/html/htmprint.cpp:717
+#, c-format
+msgid "%s Preview"
+msgstr "%s Náhled"
+
+#: ../src/html/htmprint.cpp:755 ../src/richtext/richtextprint.cpp:618
+msgid ""
+"There was a problem during page setup: you may need to set a default printer."
+msgstr "Při nastavování stránky nastala chyba: nastavte výchozí tiskárnu."
+
+#: ../src/msw/clipbrd.cpp:80
+msgid "Failed to open the clipboard."
+msgstr "Nelze otevřít schránku."
+
+#: ../src/msw/clipbrd.cpp:101
+msgid "Failed to close the clipboard."
+msgstr "Nelze uzavřít schránku."
+
+#: ../src/msw/clipbrd.cpp:113
+msgid "Failed to empty the clipboard."
+msgstr "Nelze vyprázdnit schránku."
+
+#: ../src/msw/clipbrd.cpp:284
+msgid "Failed to put data on the clipboard"
+msgstr "Nelze vložit data do schránky"
+
+#: ../src/msw/clipbrd.cpp:326
+msgid "Failed to get data from the clipboard"
+msgstr "Nelze získat data ze schránky"
+
+#: ../src/msw/clipbrd.cpp:363
+msgid "Failed to retrieve the supported clipboard formats"
+msgstr "Nelze zjistit formáty podporované schránkou"
+
+#: ../src/msw/colordlg.cpp:228
+#, c-format
+msgid "Colour selection dialog failed with error %0lx."
+msgstr "Dialogové okno výběru barvy selhalo s chybou %0lx."
+
+#: ../src/msw/cursor.cpp:141
+msgid "Failed to create cursor."
+msgstr "Nelze vytvořit kurzor."
+
+#: ../src/msw/dde.cpp:279
+#, c-format
+msgid "Failed to register DDE server '%s'"
+msgstr "Nelze zaregistrovat DDE server '%s'"
+
+#: ../src/msw/dde.cpp:300
+#, c-format
+msgid "Failed to unregister DDE server '%s'"
+msgstr "Nelze odregistrovat DDE server '%s'"
+
+#: ../src/msw/dde.cpp:428
+#, c-format
+msgid "Failed to create connection to server '%s' on topic '%s'"
+msgstr "Nelze navázat spojení se serverem '%s' na téma '%s'"
+
+#: ../src/msw/dde.cpp:655
+msgid "DDE poke request failed"
+msgstr "Požadavek na šťouchnutí DDE selhal"
+
+#: ../src/msw/dde.cpp:674
+msgid "Failed to establish an advise loop with DDE server"
+msgstr "Nelze navázat 'advise loop' s DDE serverem"
+
+#: ../src/msw/dde.cpp:693
+msgid "Failed to terminate the advise loop with DDE server"
+msgstr "Nelze ukončit 'advise loop' s DDE serverem"
+
+#: ../src/msw/dde.cpp:768
+msgid "Failed to send DDE advise notification"
+msgstr "Nepodařilo se poslat DDE advise notifikaci"
+
+#: ../src/msw/dde.cpp:1085
+msgid "Failed to create DDE string"
+msgstr "Nelze vytvořit DDE řetězec"
+
+#: ../src/msw/dde.cpp:1131
+msgid "no DDE error."
+msgstr "žádná chyba DDE."
+
+#: ../src/msw/dde.cpp:1135
+msgid "a request for a synchronous advise transaction has timed out."
+msgstr "požadavek na synchronní advise transakci vypršel."
+
+#: ../src/msw/dde.cpp:1138
+msgid "the response to the transaction caused the DDE_FBUSY bit to be set."
+msgstr "odpověď na transakci způsobila nastavení bitu DDE_FBUSY."
+
+#: ../src/msw/dde.cpp:1141
+msgid "a request for a synchronous data transaction has timed out."
+msgstr "požadavek na synchronní datovou transakci vypršel."
+
+#: ../src/msw/dde.cpp:1144
+msgid ""
+"a DDEML function was called without first calling the DdeInitialize "
+"function,\n"
+"or an invalid instance identifier\n"
+"was passed to a DDEML function."
+msgstr ""
+"Funkce DDEML byla zavolána bez předchozího volání DdeInitialize,\n"
+"nebo dostala neplatný identifikátor\n"
+"instance."
+
+#: ../src/msw/dde.cpp:1147
+msgid ""
+"an application initialized as APPCLASS_MONITOR has\n"
+"attempted to perform a DDE transaction,\n"
+"or an application initialized as APPCMD_CLIENTONLY has \n"
+"attempted to perform server transactions."
+msgstr ""
+"aplikace zavedená jako APPCLASS_MONITOR se\n"
+"pokusila o přenos DDE,\n"
+"nebo se aplikace zavedená jako APPCMD_CLIENTONLY pokusila\n"
+"o přenos přes server."
+
+#: ../src/msw/dde.cpp:1150
+msgid "a request for a synchronous execute transaction has timed out."
+msgstr "požadavek na synchronní execute transakci vypršel."
+
+#: ../src/msw/dde.cpp:1153
+msgid "a parameter failed to be validated by the DDEML."
+msgstr "nepodařilo se ověřit parametr pomocí DDEML."
+
+#: ../src/msw/dde.cpp:1156
+msgid "a DDEML application has created a prolonged race condition."
+msgstr "DDEML aplikace způsobila prodloužený souběh."
+
+#: ../src/msw/dde.cpp:1159
+msgid "a memory allocation failed."
+msgstr "selhalo přidělení paměti."
+
+#: ../src/msw/dde.cpp:1162
+msgid "a client's attempt to establish a conversation has failed."
+msgstr "klientův pokus navázat konverzaci selhal."
+
+#: ../src/msw/dde.cpp:1165
+msgid "a transaction failed."
+msgstr "transakce se nepodařila."
+
+#: ../src/msw/dde.cpp:1168
+msgid "a request for a synchronous poke transaction has timed out."
+msgstr "požadavek na synchronní poke transakci vypršel."
+
+#: ../src/msw/dde.cpp:1171
+msgid "an internal call to the PostMessage function has failed. "
+msgstr "interní volání PostMessage selhalo. "
+
+#: ../src/msw/dde.cpp:1174
+msgid "reentrancy problem."
+msgstr "problém reentrance."
+
+#: ../src/msw/dde.cpp:1177
+msgid ""
+"a server-side transaction was attempted on a conversation\n"
+"that was terminated by the client, or the server\n"
+"terminated before completing a transaction."
+msgstr ""
+"v konverzaci ukončené klientem došlo k pokusu o serverovou\n"
+"transakci, nebo se server před\n"
+"dokončením transakce ukončil ."
+
+#: ../src/msw/dde.cpp:1180
+msgid "an internal error has occurred in the DDEML."
+msgstr "nastala interní chyba v DDEML."
+
+#: ../src/msw/dde.cpp:1183
+msgid "a request to end an advise transaction has timed out."
+msgstr "požadavek na ukončení advise transakce vypršel."
+
+#: ../src/msw/dde.cpp:1186
+msgid ""
+"an invalid transaction identifier was passed to a DDEML function.\n"
+"Once the application has returned from an XTYP_XACT_COMPLETE callback,\n"
+"the transaction identifier for that callback is no longer valid."
+msgstr ""
+"DDEML funkce dostala neplatný identifikátor transakce.\n"
+"Jakmile se aplikace vrátí z XTYP_XACT_COMPLETE callbacku, \n"
+"identifikátor transakce se stává neplatným."
+
+#: ../src/msw/dde.cpp:1189
+#, c-format
+msgid "Unknown DDE error %08x"
+msgstr "Neznámá chyba DDE: %08x"
+
+#: ../src/msw/dialup.cpp:343
+msgid ""
+"Dial up functions are unavailable because the remote access service (RAS) is "
+"not installed on this machine. Please install it."
+msgstr ""
+"Funkce vytáčeného připojení nejsou dostupné, protože Služba vzdáleného "
+"přístupu (RAS) není nainstalována. Prosím, nainstalujte ji."
+
+#: ../src/msw/dialup.cpp:402
+#, c-format
+msgid ""
+"The version of remote access service (RAS) installed on this machine is too "
+"old, please upgrade (the following required function is missing: %s)."
+msgstr ""
+"Verze Služby vzdáleného přístupu (RAS) instalované na tomto počítači je "
+"příliš stará, prosím aktualizujte (následující požadovaná funkce chybí: %s)."
+
+#: ../src/msw/dialup.cpp:437
+msgid "Failed to retrieve text of RAS error message"
+msgstr "Nepodařilo se získat text chybového hlášení RAS"
+
+#: ../src/msw/dialup.cpp:440
+#, c-format
+msgid "unknown error (error code %08x)."
+msgstr "neznámá chyba (kód %08x)."
+
+#: ../src/msw/dialup.cpp:492
+#, c-format
+msgid "Cannot find active dialup connection: %s"
+msgstr "Nelze nalézt aktivní vytáčené připojení: %s"
+
+#: ../src/msw/dialup.cpp:513
+msgid "Several active dialup connections found, choosing one randomly."
+msgstr ""
+"Nalezeno několik aktivních vytáčených připojení, vybírám jedno náhodně."
+
+#: ../src/msw/dialup.cpp:598 ../src/msw/dialup.cpp:832
+#, c-format
+msgid "Failed to establish dialup connection: %s"
+msgstr "Nelze navázat vytáčené spojení: %s"
+
+#: ../src/msw/dialup.cpp:664
+#, c-format
+msgid "Failed to get ISP names: %s"
+msgstr "Nepodařilo se získat jména ISP: %s"
+
+#: ../src/msw/dialup.cpp:712
+msgid "Failed to connect: no ISP to dial."
+msgstr "Nelze se připojit: žádný ISP."
+
+#: ../src/msw/dialup.cpp:732
+msgid "Choose ISP to dial"
+msgstr "Vyberte ISP, ke kterému se má připojit"
+
+#: ../src/msw/dialup.cpp:733
+msgid "Please choose which ISP do you want to connect to"
+msgstr "Prosím vyberte si poskytovatele (ISP), ke kterému se chcete připojit"
+
+#: ../src/msw/dialup.cpp:766
+msgid "Failed to connect: missing username/password."
+msgstr "Nepodařilo se připojit: chybí uživatelské jméno nebo heslo."
+
+#: ../src/msw/dialup.cpp:796
+msgid "Cannot find the location of address book file"
+msgstr "Nelze nalézt umístění souboru s adresářem"
+
+#: ../src/msw/dialup.cpp:827
+#, c-format
+msgid "Failed to initiate dialup connection: %s"
+msgstr "Nelze zahájit vytáčené spojení: %s"
+
+#: ../src/msw/dialup.cpp:897
+msgid "Cannot hang up - no active dialup connection."
+msgstr "Nelze zavěsit - žádná aktivní vytáčená připojení."
+
+#: ../src/msw/dialup.cpp:907
+#, c-format
+msgid "Failed to terminate the dialup connection: %s"
+msgstr "Nelze ukončit vytáčené spojení: %s"
+
+#: ../src/msw/dib.cpp:313
+#, c-format
+msgid "Failed to save the bitmap image to file \"%s\"."
+msgstr "Nelze uložit obrázek do souboru \"%s\"."
+
+#: ../src/msw/dib.cpp:543
+#, c-format
+msgid "Failed to allocate %luKb of memory for bitmap data."
+msgstr "Nelze přidělit %luKb paměti pro bitmapová data."
+
+#: ../src/msw/dir.cpp:241
+#, c-format
+msgid "Cannot enumerate files in directory '%s'"
+msgstr "Nelze vyjmenovat soubory v adresáři '%s'"
+
+#: ../src/msw/dirdlg.cpp:368
+msgid "Couldn't obtain folder name"
+msgstr "Nelze získat název složky"
+
+#: ../src/msw/dlmsw.cpp:163
+#, c-format
+msgid "(error %d: %s)"
+msgstr "(chyba %d: %s)"
+
+#: ../src/msw/dragimag.cpp:143 ../src/msw/dragimag.cpp:178
+#: ../src/msw/imaglist.cpp:309 ../src/msw/imaglist.cpp:331
+msgid "Couldn't add an image to the image list."
+msgstr "Nelze přidat obrázek do seznamu obrázků."
+
+#: ../src/msw/enhmeta.cpp:94
+#, c-format
+msgid "Failed to load metafile from file \"%s\"."
+msgstr "Nelze načíst metasoubor ze souboru \"%s\"."
+
+#: ../src/msw/fdrepdlg.cpp:412
+#, c-format
+msgid "Failed to create the standard find/replace dialog (error code %d)"
+msgstr "Nelze vytvořit standardní dialogové okno najít/nahradit (kód chyby %d)"
+
+#: ../src/msw/filedlg.cpp:1241
+msgid "Access to the file system is not allowed from secure desktop."
+msgstr ""
+"V režimu zabezpečené pracovní plochy není povolen přístup k systému souborů."
+
+#: ../src/msw/filedlg.cpp:1242
+msgid "Security warning"
+msgstr "Bezpečnostní upozornění"
+
+#: ../src/msw/filedlg.cpp:1533
+#, c-format
+msgid "File dialog failed with error code %0lx."
+msgstr "Dialogové okno souboru selhalo s kódem chyby %0lx."
+
+#: ../src/msw/font.cpp:1120
+#, c-format
+msgid "Font file \"%s\" couldn't be loaded"
+msgstr "Nelze načíst soubor s fontem \"%s\""
+
+#: ../src/msw/fontdlg.cpp:220
+#, c-format
+msgid "Common dialog failed with error code %0lx."
+msgstr "Dialogové okno selhalo s kódem chyby %0lx."
+
+#: ../src/msw/fswatcher.cpp:67
+msgid "Ungraceful worker thread termination"
+msgstr "Vynucené ukončení pracovního vlákna"
+
+#: ../src/msw/fswatcher.cpp:81
+msgid "Unable to create IOCP worker thread"
+msgstr "Nelze vytvořit pracovní vlákno I/O portu dokončení."
+
+#: ../src/msw/fswatcher.cpp:88
+msgid "Unable to start IOCP worker thread"
+msgstr "Nelze spustit pracovní vlákno I/O portu dokončení."
+
+#: ../src/msw/fswatcher.cpp:140
+msgid "Monitoring individual files for changes is not supported currently."
+msgstr "Sledování změn jednotlivých souborů není v současnosti podporováno."
+
+#: ../src/msw/fswatcher.cpp:165
+#, c-format
+msgid "Unable to set up watch for '%s'"
+msgstr "Nelze nastavit sledování pro '%s'"
+
+#: ../src/msw/fswatcher.cpp:466
+#, c-format
+msgid "Can't monitor non-existent directory \"%s\" for changes."
+msgstr "Nelze sledovat změny neexistujícího adresáře \"%s\"."
+
+#: ../src/msw/glcanvas.cpp:577 ../src/unix/glx11.cpp:507
+msgid "OpenGL 3.0 or later is not supported by the OpenGL driver."
+msgstr "OpenGL 3.0 nebo novější není podporován ovladačem."
+
+#: ../src/msw/glcanvas.cpp:601 ../src/osx/glcanvas_osx.cpp:395
+#: ../src/unix/glegl.cpp:304 ../src/unix/glx11.cpp:553
+msgid "Couldn't create OpenGL context"
+msgstr "Nelze vytvořit OpenGL kontext"
+
+#: ../src/msw/glcanvas.cpp:1294
+msgid "Failed to initialize OpenGL"
+msgstr "Nelze zavést OpenGL"
+
+#: ../src/msw/graphicsd2d.cpp:607
+msgid "Could not register custom DirectWrite font loader."
+msgstr "Nelze zaregistrovat vlastní zavaděč fontů DirectWrite."
+
+#: ../src/msw/helpchm.cpp:48
+msgid ""
+"MS HTML Help functions are unavailable because the MS HTML Help library is "
+"not installed on this machine. Please install it."
+msgstr ""
+"Funkce MS HTML nápovědy nejsou dostupné, protože chybí příslušná komponenta. "
+"Prosím nainstalujte ji."
+
+#: ../src/msw/helpchm.cpp:55
+msgid "Failed to initialize MS HTML Help."
+msgstr "Nelze zavést MS HTML Help ."
+
+#: ../src/msw/iniconf.cpp:458
+#, c-format
+msgid "Can't delete the INI file '%s'"
+msgstr "Nelze smazat INI soubor '%s'"
+
+#: ../src/msw/listctrl.cpp:995
+#, c-format
+msgid "Couldn't retrieve information about list control item %d."
+msgstr "Nelze získat informace o položce seznamu %d."
+
+#: ../src/msw/mdi.cpp:170 ../src/qt/mdi.cpp:253
+msgid "&Cascade"
+msgstr "&Kaskádově"
+
+#: ../src/msw/mdi.cpp:171
+msgid "Tile &Horizontally"
+msgstr "Vyrovnat &vodorovně"
+
+#: ../src/msw/mdi.cpp:172
+msgid "Tile &Vertically"
+msgstr "Vyrovnat &svisle"
+
+#: ../src/msw/mdi.cpp:174
+msgid "&Arrange Icons"
+msgstr "Uspořád&at ikony"
+
+#: ../src/msw/mdi.cpp:621
+msgid "Failed to create MDI parent frame."
+msgstr "Nelze vytvořit nadřazené MDI okno."
+
+#: ../src/msw/mimetype.cpp:234
+#, c-format
+msgid "Failed to create registry entry for '%s' files."
+msgstr "Nelze vytvořit klíč registru pro soubory '%s'."
+
+#: ../src/msw/ole/automtn.cpp:495
+#, c-format
+msgid "Failed to find CLSID of \"%s\""
+msgstr "Nelze najít CLSID \"%s\""
+
+#: ../src/msw/ole/automtn.cpp:512
+#, c-format
+msgid "Failed to create an instance of \"%s\""
+msgstr "Nelze vytvořit instanci \"%s\""
+
+#: ../src/msw/ole/automtn.cpp:552
+#, c-format
+msgid "Cannot get an active instance of \"%s\""
+msgstr "Nelze nalézt aktivní instanci: \"%s\""
+
+#: ../src/msw/ole/automtn.cpp:564
+#, c-format
+msgid "Failed to get OLE automation interface for \"%s\""
+msgstr "Nelze získat rozhraní automatizace OLE pro \"%s\""
+
+#: ../src/msw/ole/automtn.cpp:621
+msgid "Unknown name or named argument."
+msgstr "Neznámý název nebo pojmenovaný argument."
+
+#: ../src/msw/ole/automtn.cpp:625
+msgid "Incorrect number of arguments."
+msgstr "Nesprávný počet argumentů."
+
+#: ../src/msw/ole/automtn.cpp:637
+msgid "Unknown exception"
+msgstr "Neznámá výjimka"
+
+#: ../src/msw/ole/automtn.cpp:642
+msgid "Method or property not found."
+msgstr "Metoda nebo vlastnost nenalezena."
+
+#: ../src/msw/ole/automtn.cpp:646
+msgid "Overflow while coercing argument values."
+msgstr "Přetečení při nucení hodnot argumentů."
+
+#: ../src/msw/ole/automtn.cpp:650
+msgid "Object implementation does not support named arguments."
+msgstr "Zavedení objektu nepodporuje pojmenované argumenty."
+
+#: ../src/msw/ole/automtn.cpp:654
+msgid "The locale ID is unknown."
+msgstr "ID jazyka je neznámé."
+
+#: ../src/msw/ole/automtn.cpp:658
+msgid "Missing a required parameter."
+msgstr "Chybí požadovaný parametr."
+
+#: ../src/msw/ole/automtn.cpp:662
+#, c-format
+msgid "Argument %u not found."
+msgstr "Argument %u nenalezen."
+
+#: ../src/msw/ole/automtn.cpp:666
+#, c-format
+msgid "Type mismatch in argument %u."
+msgstr "Neshoda typu v argumentu %u."
+
+#: ../src/msw/ole/automtn.cpp:670
+msgid "The system cannot find the file specified."
+msgstr "Systém nemůže nalézt uvedený soubor."
+
+#: ../src/msw/ole/automtn.cpp:674
+msgid "Class not registered."
+msgstr "Třída není zaregistrována."
+
+#: ../src/msw/ole/automtn.cpp:678
+#, c-format
+msgid "Unknown error %08x"
+msgstr "Neznámá chyba %08x"
+
+#: ../src/msw/ole/automtn.cpp:682
+#, c-format
+msgid "OLE Automation error in %s: %s"
+msgstr "Chyba automatizace OLE v %s: %s"
+
+#: ../src/msw/ole/dataobj.cpp:385
+#, c-format
+msgid "Couldn't register clipboard format '%s'."
+msgstr "Nelze zaregistrovat formát schránky '%s'."
+
+#: ../src/msw/ole/dataobj.cpp:402
+#, c-format
+msgid "The clipboard format '%d' doesn't exist."
+msgstr "Formát schránky '%d' neexistuje."
+
+#: ../src/msw/progdlg.cpp:1025
+msgid "Skip"
+msgstr "Přeskočit"
+
+#: ../src/msw/registry.cpp:141
+#, c-format
+msgid "unknown (%lu)"
+msgstr "neznámé (%lu)"
+
+#: ../src/msw/registry.cpp:409
+#, c-format
+msgid "Can't get info about registry key '%s'"
+msgstr "Nelze získat informace o klíči registru '%s'"
+
+#: ../src/msw/registry.cpp:445
+#, c-format
+msgid "Can't open registry key '%s'"
+msgstr "Nelze otevřít klíč registru '%s'"
+
+#: ../src/msw/registry.cpp:478
+#, c-format
+msgid "Can't create registry key '%s'"
+msgstr "Nelze vytvořit klíč registru '%s'"
+
+#: ../src/msw/registry.cpp:497
+#, c-format
+msgid "Can't close registry key '%s'"
+msgstr "Nelze zavřít klíč registru '%s'"
+
+#: ../src/msw/registry.cpp:512
+#, c-format
+msgid "Registry value '%s' already exists."
+msgstr "Hodnota klíče registru '%s' už existuje."
+
+#: ../src/msw/registry.cpp:520
+#, c-format
+msgid "Failed to rename registry value '%s' to '%s'."
+msgstr "Nelze přejmenovat klíč registru '%s' na '%s'."
+
+#: ../src/msw/registry.cpp:575
+#, c-format
+msgid "Can't copy values of unsupported type %d."
+msgstr "Nelze kopírovat hodnoty nepodporovaného typu %d."
+
+#: ../src/msw/registry.cpp:586
+#, c-format
+msgid "Registry key '%s' does not exist, cannot rename it."
+msgstr "Klíč registru '%s' neexistuje, Nelze ho přejmenovat."
+
+#: ../src/msw/registry.cpp:617
+#, c-format
+msgid "Registry key '%s' already exists."
+msgstr "Klíč registru '%s' už existuje."
+
+#: ../src/msw/registry.cpp:625
+#, c-format
+msgid "Failed to rename the registry key '%s' to '%s'."
+msgstr "Nelze přejmenovat klíč registru '%s' na '%s'."
+
+#: ../src/msw/registry.cpp:670
+#, c-format
+msgid "Failed to copy the registry subkey '%s' to '%s'."
+msgstr "Nelze zkopírovat podklíč registru '%s' do '%s'."
+
+#: ../src/msw/registry.cpp:683
+#, c-format
+msgid "Failed to copy registry value '%s'"
+msgstr "Nelze zkopírovat hodnotu registru '%s'"
+
+#: ../src/msw/registry.cpp:692
+#, c-format
+msgid "Failed to copy the contents of registry key '%s' to '%s'."
+msgstr "Nelze zkopírovat obsah klíče registru '%s' do '%s'."
+
+#: ../src/msw/registry.cpp:718
+#, c-format
+msgid ""
+"Registry key '%s' is needed for normal system operation,\n"
+"deleting it will leave your system in unusable state:\n"
+"operation aborted."
+msgstr ""
+"Klíč registru '%s' je potřeba k normálnímu běhu systému,\n"
+"pokud ho smažete, systém bude nestabilní:\n"
+"operace přerušena."
+
+#: ../src/msw/registry.cpp:754
+#, c-format
+msgid "Can't delete key '%s'"
+msgstr "Nelze smazat klíč '%s'"
+
+#: ../src/msw/registry.cpp:782
+#, c-format
+msgid "Can't delete value '%s' from key '%s'"
+msgstr "Nelze smazat hodnotu '%s' z klíče '%s'"
+
+#: ../src/msw/registry.cpp:855 ../src/msw/registry.cpp:887
+#: ../src/msw/registry.cpp:929 ../src/msw/registry.cpp:1000
+#, c-format
+msgid "Can't read value of key '%s'"
+msgstr "Nelze načíst hodnotu klíče '%s'"
+
+#: ../src/msw/registry.cpp:873 ../src/msw/registry.cpp:915
+#: ../src/msw/registry.cpp:963 ../src/msw/registry.cpp:1106
+#, c-format
+msgid "Can't set value of '%s'"
+msgstr "Nelze nastavit hodnotu '%s'"
+
+#: ../src/msw/registry.cpp:894 ../src/msw/registry.cpp:943
+#, c-format
+msgid "Registry value \"%s\" is not numeric (but of type %s)"
+msgstr "Hodnota registru \"%s\" není číselná (má typ %s)"
+
+#: ../src/msw/registry.cpp:979
+#, c-format
+msgid "Registry value \"%s\" is not binary (but of type %s)"
+msgstr "Hodnota registru \"%s\" není binární (má typ %s)"
+
+#: ../src/msw/registry.cpp:1028
+#, c-format
+msgid "Registry value \"%s\" is not text (but of type %s)"
+msgstr "Hodnota registru \"%s\" není textová (má typ %s)"
+
+#: ../src/msw/registry.cpp:1089
+#, c-format
+msgid "Can't read value of '%s'"
+msgstr "Nelze přečíst hodnotu '%s'"
+
+#: ../src/msw/registry.cpp:1157
+#, c-format
+msgid "Can't enumerate values of key '%s'"
+msgstr "Nelze vyjmenovat hodnoty klíče '%s'"
+
+#: ../src/msw/registry.cpp:1196
+#, c-format
+msgid "Can't enumerate subkeys of key '%s'"
+msgstr "Nelze vyjmenovat podklíče klíče '%s'"
+
+#: ../src/msw/registry.cpp:1262
+#, c-format
+msgid ""
+"Exporting registry key: file \"%s\" already exists and won't be overwritten."
+msgstr "Exportuji klíč registru: soubor \"%s\" již existuje a nebude přepsán."
+
+#: ../src/msw/registry.cpp:1411
+#, c-format
+msgid "Can't export value of unsupported type %d."
+msgstr "Nelze exportovat hodnotu nepodporovaného typu %d."
+
+#: ../src/msw/registry.cpp:1427
+#, c-format
+msgid "Ignoring value \"%s\" of the key \"%s\"."
+msgstr "Ignoruji hodnotu \"%s\" klíče \"%s\"."
+
+#: ../src/msw/textctrl.cpp:596
+msgid ""
+"Impossible to create a rich edit control, using simple text control instead. "
+"Please reinstall riched32.dll"
+msgstr ""
+"Není možné vytvořit prvek rich edit, místo něj použit obyčejný. "
+"Přeinstalujte prosím riched32.dll."
+
+#: ../src/msw/thread.cpp:522 ../src/unix/threadpsx.cpp:850
+msgid "Cannot start thread: error writing TLS."
+msgstr "Nelze spustit vlákno: chyba při zápisu do TLS."
+
+#: ../src/msw/thread.cpp:613
+msgid "Can't set thread priority"
+msgstr "Nelze nastavit prioritu vlákna"
+
+#: ../src/msw/thread.cpp:649
+msgid "Can't create thread"
+msgstr "Nelze vytvořit vlákno"
+
+#: ../src/msw/thread.cpp:668
+msgid "Couldn't terminate thread"
+msgstr "Nelze ukončit vlákno"
+
+#: ../src/msw/thread.cpp:799
+msgid "Cannot wait for thread termination"
+msgstr "Nelze počkat na ukončení vlákna"
+
+#: ../src/msw/thread.cpp:873
+#, c-format
+msgid "Cannot suspend thread %lx"
+msgstr "Nelze pozastavit vlákno %lx"
+
+#: ../src/msw/thread.cpp:903
+#, c-format
+msgid "Cannot resume thread %lx"
+msgstr "Nelze obnovit vlákno %lx"
+
+#: ../src/msw/thread.cpp:932
+msgid "Couldn't get the current thread pointer"
+msgstr "Nelze získat ukazatel na aktuální vlákno"
+
+#: ../src/msw/thread.cpp:1333
+msgid ""
+"Thread module initialization failed: impossible to allocate index in thread "
+"local storage"
+msgstr ""
+"Vlákno pro modul se nepodařilo zavést: Nelze přidělit index do místního "
+"úložiště vláken"
+
+#: ../src/msw/thread.cpp:1345
+msgid ""
+"Thread module initialization failed: cannot store value in thread local "
+"storage"
+msgstr ""
+"Vlákno pro modul se nepodařilo zavést: nelze ukládat hodnoty do místního "
+"úložiště vláken"
+
+#: ../src/msw/timer.cpp:133
+msgid "Couldn't create a timer"
+msgstr "Nelze vytvořit časovač"
+
+#: ../src/msw/utils.cpp:372
+msgid "can't find user's HOME, using current directory."
+msgstr "nelze najít uživatelův domovský adresář, použit aktuální adresář."
+
+#: ../src/msw/utils.cpp:662
+#, c-format
+msgid "Failed to kill process %d"
+msgstr "Nepodařilo se vynuceně ukončit proces %d"
+
+#: ../src/msw/utils.cpp:986
+#, c-format
+msgid "Failed to load resource \"%s\"."
+msgstr "Nelze načíst zdroj \"%s\"."
+
+#: ../src/msw/utils.cpp:993
+#, c-format
+msgid "Failed to lock resource \"%s\"."
+msgstr "Nelze uzamknout zdroj \"%s\"."
+
+#. TRANSLATORS: MS Windows build number
+#: ../src/msw/utils.cpp:1209
+#, c-format
+msgid "build %lu"
+msgstr "sestavení %lu"
+
+#: ../src/msw/utils.cpp:1218
+msgid ", 64-bit edition"
+msgstr ", 64bitová edice"
+
+#: ../src/msw/utilsexc.cpp:224
+msgid "Failed to create an anonymous pipe"
+msgstr "Nelze vytvořit anonymní rouru"
+
+#: ../src/msw/utilsexc.cpp:697
+msgid "Failed to redirect the child process IO"
+msgstr "Chyba při přesměrovávání vstupu a výstupu synovského procesu"
+
+#: ../src/msw/utilsexc.cpp:870
+#, c-format
+msgid "Execution of command '%s' failed"
+msgstr "Chyba při volání příkazu '%s'"
+
+#: ../src/msw/volume.cpp:337
+msgid "Failed to load mpr.dll."
+msgstr "Nelze načíst knihovnu mpr.dll."
+
+#: ../src/msw/volume.cpp:506
+#, c-format
+msgid "Cannot read typename from '%s'!"
+msgstr "Nelze přečíst typ z '%s'!"
+
+#: ../src/msw/volume.cpp:615
+#, c-format
+msgid "Cannot load icon from '%s'."
+msgstr "Nelze načíst ikonu z '%s'."
+
+#: ../src/msw/webview_edge.cpp:285
+msgid "This program was compiled without support for setting Edge proxy."
+msgstr "Aplikace byla sestavena bez podpory nastavení proxy v Edge."
+
+#: ../src/msw/webview_ie.cpp:1010
+msgid "Failed to find web view emulation level in the registry"
+msgstr "Nelze nalézt úroveň emulace pro web view v registru"
+
+#: ../src/msw/webview_ie.cpp:1019
+msgid "Failed to set web view to modern emulation level"
+msgstr "Nelze nastavit komponentu web view na moderní úroveň emulace"
+
+#: ../src/msw/webview_ie.cpp:1027
+msgid "Failed to reset web view to standard emulation level"
+msgstr "Nelze vyresetovat komponentu web view na výchozí úroveň emulace"
+
+#: ../src/msw/webview_ie.cpp:1049
+msgid "Can't run JavaScript script without a valid HTML document"
+msgstr "Skript v JavaScriptu nelze spustit bez platného dokumentu HTML"
+
+#: ../src/msw/webview_ie.cpp:1056
+msgid "Can't get the JavaScript object"
+msgstr "Nelze získat objekt JavaScriptu"
+
+#: ../src/msw/webview_ie.cpp:1070
+msgid "failed to evaluate"
+msgstr "nelze vyhodnotit"
+
+#: ../src/osx/cocoa/filedlg.mm:412
+msgid "File type:"
+msgstr "Typ souboru:"
+
+#: ../src/osx/cocoa/menu.mm:242
+msgctxt "macOS menu name"
+msgid "Window"
+msgstr "Okno"
+
+#: ../src/osx/cocoa/menu.mm:259
+msgctxt "macOS menu name"
+msgid "Help"
+msgstr "Nápověda"
+
+#: ../src/osx/cocoa/menu.mm:298
+msgctxt "macOS menu item"
+msgid "Minimize"
+msgstr "Minimalizovat"
+
+#: ../src/osx/cocoa/menu.mm:303
+msgctxt "macOS menu item"
+msgid "Zoom"
+msgstr "Přiblížit"
+
+#: ../src/osx/cocoa/menu.mm:309
+msgctxt "macOS menu item"
+msgid "Bring All to Front"
+msgstr "Všechna do popředí"
+
+#: ../src/osx/core/sound.cpp:143
+#, c-format
+msgid "Failed to load sound from \"%s\" (error %d)."
+msgstr "Nelze načíst zvuk z \"%s\" (chyba %d)."
+
+#: ../src/osx/fontutil.cpp:80
+#, c-format
+msgid "Font file \"%s\" doesn't exist."
+msgstr "Soubor s fontem \"%s\" neexistuje."
+
+#: ../src/osx/fontutil.cpp:88
+#, c-format
+msgid ""
+"Font file \"%s\" cannot be used as it is not inside the font directory "
+"\"%s\"."
+msgstr ""
+"Soubor s fontem \"%s\" nelze použít protože není ve složce s fonty \"%s\"."
+
+#: ../src/osx/menu_osx.cpp:496
+#, c-format
+msgctxt "macOS menu item"
+msgid "About %s"
+msgstr "O aplikaci %s"
+
+#: ../src/osx/menu_osx.cpp:499
+msgctxt "macOS menu item"
+msgid "About..."
+msgstr "O aplikaci..."
+
+#: ../src/osx/menu_osx.cpp:508
+msgctxt "macOS menu item"
+msgid "Preferences..."
+msgstr "Předvolby..."
+
+#: ../src/osx/menu_osx.cpp:512
+msgctxt "macOS menu item"
+msgid "Services"
+msgstr "Služby"
+
+#: ../src/osx/menu_osx.cpp:519
+#, c-format
+msgctxt "macOS menu item"
+msgid "Hide %s"
+msgstr "Skrýt %s"
+
+#: ../src/osx/menu_osx.cpp:522
+msgctxt "macOS menu item"
+msgid "Hide Application"
+msgstr "Skrýt aplikaci"
+
+#: ../src/osx/menu_osx.cpp:526
+msgctxt "macOS menu item"
+msgid "Hide Others"
+msgstr "Skrýt ostatní"
+
+#: ../src/osx/menu_osx.cpp:528
+msgctxt "macOS menu item"
+msgid "Show All"
+msgstr "Zobrazit vše"
+
+#: ../src/osx/menu_osx.cpp:534
+#, c-format
+msgctxt "macOS menu item"
+msgid "Quit %s"
+msgstr "Ukončit %s"
+
+#: ../src/osx/menu_osx.cpp:537
+msgctxt "macOS menu item"
+msgid "Quit Application"
+msgstr "Ukončit aplikaci"
+
+#: ../src/osx/webview_webkit.mm:444
+msgid "Printing is not supported by the system web control"
+msgstr "Systémová komponenta web control nepodporuje tisk"
+
+#: ../src/osx/webview_webkit.mm:453
+msgid "Print operation could not be initialized"
+msgstr "Nelze zavést tiskovou operaci."
+
+#. TRANSLATORS: Label of font point size
+#: ../src/propgrid/advprops.cpp:605
+msgid "Point Size"
+msgstr "Velikost bodu"
+
+#. TRANSLATORS: Label of font face name
+#: ../src/propgrid/advprops.cpp:615
+msgid "Face Name"
+msgstr "Jméno písma"
+
+#. TRANSLATORS: Label of font style
+#: ../src/propgrid/advprops.cpp:623 ../src/richtext/richtextformatdlg.cpp:331
+msgid "Style"
+msgstr "Styl"
+
+#. TRANSLATORS: Label of font weight
+#: ../src/propgrid/advprops.cpp:628
+msgid "Weight"
+msgstr "Tučnost"
+
+#. TRANSLATORS: Label of underlined font
+#: ../src/propgrid/advprops.cpp:633 ../src/richtext/richtextfontpage.cpp:358
+msgid "Underlined"
+msgstr "Podtržené"
+
+#. TRANSLATORS: Label of font family
+#: ../src/propgrid/advprops.cpp:637
+msgid "Family"
+msgstr "Písmo"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:801
+msgid "AppWorkspace"
+msgstr "Prostor aplikace"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:802
+msgid "ActiveBorder"
+msgstr "Aktivní okraj"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:803
+msgid "ActiveCaption"
+msgstr "Aktivní nadpis"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:804
+msgid "ButtonFace"
+msgstr "Plocha tlačítka"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:805
+msgid "ButtonHighlight"
+msgstr "Zvýraznění tlačítka"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:806
+msgid "ButtonShadow"
+msgstr "Stín tlačítka"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:807
+msgid "ButtonText"
+msgstr "Text tlačítka"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:808
+msgid "CaptionText"
+msgstr "Text nadpisu"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:809
+msgid "ControlDark"
+msgstr "Barva stínu"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:810
+msgid "ControlLight"
+msgstr "Barva světla"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:812
+msgid "GrayText"
+msgstr "Neaktivní text"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:813
+msgid "Highlight"
+msgstr "Zvýraznění"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:814
+msgid "HighlightText"
+msgstr "Zvýraznění textu"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:815
+msgid "InactiveBorder"
+msgstr "Neaktivní okraj"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:816
+msgid "InactiveCaption"
+msgstr "Neaktivní nadpis"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:817
+msgid "InactiveCaptionText"
+msgstr "Text neaktivního nadpisu"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:818
+msgid "Menu"
+msgstr "Menu"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:819
+msgid "Scrollbar"
+msgstr "Posuvník"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:820
+msgid "Tooltip"
+msgstr "Popisek"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:821
+msgid "TooltipText"
+msgstr "Text popisku"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:822
+msgid "Window"
+msgstr "Okno"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:823
+msgid "WindowFrame"
+msgstr "Rám okna"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:824
+msgid "WindowText"
+msgstr "Text okna"
+
+#. TRANSLATORS: Custom colour choice entry
+#: ../src/propgrid/advprops.cpp:825 ../src/propgrid/advprops.cpp:1532
+#: ../src/propgrid/advprops.cpp:1576
+msgid "Custom"
+msgstr "Vlastní"
+
+#: ../src/propgrid/advprops.cpp:1558
+msgid "Black"
+msgstr "Černá"
+
+#: ../src/propgrid/advprops.cpp:1559
+msgid "Maroon"
+msgstr "Kaštanová"
+
+#: ../src/propgrid/advprops.cpp:1560
+msgid "Navy"
+msgstr "Tmavě modrá"
+
+#: ../src/propgrid/advprops.cpp:1561
+msgid "Purple"
+msgstr "Nachová"
+
+#: ../src/propgrid/advprops.cpp:1562
+msgid "Teal"
+msgstr "Modrozelená"
+
+#: ../src/propgrid/advprops.cpp:1563
+msgid "Gray"
+msgstr "Šedá"
+
+#: ../src/propgrid/advprops.cpp:1564
+msgid "Green"
+msgstr "Zelená"
+
+#: ../src/propgrid/advprops.cpp:1565
+msgid "Olive"
+msgstr "Olivová"
+
+#: ../src/propgrid/advprops.cpp:1566
+msgid "Brown"
+msgstr "Hnědá"
+
+#: ../src/propgrid/advprops.cpp:1567
+msgid "Blue"
+msgstr "Modrá"
+
+#: ../src/propgrid/advprops.cpp:1568
+msgid "Fuchsia"
+msgstr "Fuchsiová"
+
+#: ../src/propgrid/advprops.cpp:1569
+msgid "Red"
+msgstr "Červená"
+
+#: ../src/propgrid/advprops.cpp:1570
+msgid "Orange"
+msgstr "Oranžová"
+
+#: ../src/propgrid/advprops.cpp:1571
+msgid "Silver"
+msgstr "Stříbrná"
+
+#: ../src/propgrid/advprops.cpp:1572
+msgid "Lime"
+msgstr "Limetková"
+
+#: ../src/propgrid/advprops.cpp:1573
+msgid "Aqua"
+msgstr "Akvamarinová"
+
+#: ../src/propgrid/advprops.cpp:1574
+msgid "Yellow"
+msgstr "Žlutá"
+
+#: ../src/propgrid/advprops.cpp:1575
+msgid "White"
+msgstr "Bílá"
+
+#: ../src/propgrid/advprops.cpp:1718
+msgctxt "system cursor name"
+msgid "Default"
+msgstr "Výchozí"
+
+#: ../src/propgrid/advprops.cpp:1719
+msgctxt "system cursor name"
+msgid "Arrow"
+msgstr "Šipka"
+
+#: ../src/propgrid/advprops.cpp:1720
+msgctxt "system cursor name"
+msgid "Right Arrow"
+msgstr "Šipka doprava"
+
+#: ../src/propgrid/advprops.cpp:1721
+msgctxt "system cursor name"
+msgid "Blank"
+msgstr "Prázdné"
+
+#: ../src/propgrid/advprops.cpp:1722
+msgctxt "system cursor name"
+msgid "Bullseye"
+msgstr "Střed terče"
+
+#: ../src/propgrid/advprops.cpp:1723
+msgctxt "system cursor name"
+msgid "Character"
+msgstr "Karet"
+
+#: ../src/propgrid/advprops.cpp:1724
+msgctxt "system cursor name"
+msgid "Cross"
+msgstr "Křížek"
+
+#: ../src/propgrid/advprops.cpp:1725
+msgctxt "system cursor name"
+msgid "Hand"
+msgstr "Ruka"
+
+#: ../src/propgrid/advprops.cpp:1726
+msgctxt "system cursor name"
+msgid "I-Beam"
+msgstr "Výběr textu"
+
+#: ../src/propgrid/advprops.cpp:1727
+msgctxt "system cursor name"
+msgid "Left Button"
+msgstr "Levé tlačítko"
+
+#: ../src/propgrid/advprops.cpp:1728
+msgctxt "system cursor name"
+msgid "Magnifier"
+msgstr "Lupa"
+
+#: ../src/propgrid/advprops.cpp:1729
+msgctxt "system cursor name"
+msgid "Middle Button"
+msgstr "Prostřední tlačítko"
+
+#: ../src/propgrid/advprops.cpp:1730
+msgctxt "system cursor name"
+msgid "No Entry"
+msgstr "Není k dispozici"
+
+#: ../src/propgrid/advprops.cpp:1731
+msgctxt "system cursor name"
+msgid "Paint Brush"
+msgstr "Štětec"
+
+#: ../src/propgrid/advprops.cpp:1732
+msgctxt "system cursor name"
+msgid "Pencil"
+msgstr "Tužka"
+
+#: ../src/propgrid/advprops.cpp:1733
+msgctxt "system cursor name"
+msgid "Point Left"
+msgstr "Ukazatel doleva"
+
+#: ../src/propgrid/advprops.cpp:1734
+msgctxt "system cursor name"
+msgid "Point Right"
+msgstr "Ukazatel doprava"
+
+#: ../src/propgrid/advprops.cpp:1735
+msgctxt "system cursor name"
+msgid "Question Arrow"
+msgstr "Výběr nápovědy"
+
+#: ../src/propgrid/advprops.cpp:1736
+msgctxt "system cursor name"
+msgid "Right Button"
+msgstr "Pravé tlačítko"
+
+#: ../src/propgrid/advprops.cpp:1737
+msgctxt "system cursor name"
+msgid "Sizing NE-SW"
+msgstr "Diagonální změna velikosti 2"
+
+#: ../src/propgrid/advprops.cpp:1738
+msgctxt "system cursor name"
+msgid "Sizing N-S"
+msgstr "Změna výšky"
+
+#: ../src/propgrid/advprops.cpp:1739
+msgctxt "system cursor name"
+msgid "Sizing NW-SE"
+msgstr "Diagonální změna velikosti 1"
+
+#: ../src/propgrid/advprops.cpp:1740
+msgctxt "system cursor name"
+msgid "Sizing W-E"
+msgstr "Změna šířky"
+
+#: ../src/propgrid/advprops.cpp:1741
+msgctxt "system cursor name"
+msgid "Sizing"
+msgstr "Změna velikosti"
+
+#: ../src/propgrid/advprops.cpp:1742
+msgctxt "system cursor name"
+msgid "Spraycan"
+msgstr "Sprej"
+
+#: ../src/propgrid/advprops.cpp:1743
+msgctxt "system cursor name"
+msgid "Wait"
+msgstr "Zaneprázdněn"
+
+#: ../src/propgrid/advprops.cpp:1744
+msgctxt "system cursor name"
+msgid "Watch"
+msgstr "Hodiny"
+
+#: ../src/propgrid/advprops.cpp:1745
+msgctxt "system cursor name"
+msgid "Wait Arrow"
+msgstr "Práce na pozadí"
+
+#: ../src/propgrid/advprops.cpp:2109
+msgid "Make a selection:"
+msgstr "Provést výběr:"
+
+#: ../src/propgrid/manager.cpp:394
+msgid "Property"
+msgstr "Vlastnost"
+
+#: ../src/propgrid/manager.cpp:395
+msgid "Value"
+msgstr "Hodnota"
+
+#: ../src/propgrid/manager.cpp:1683
+msgid "Categorized Mode"
+msgstr "Podle kategorií"
+
+#: ../src/propgrid/manager.cpp:1709
+msgid "Alphabetic Mode"
+msgstr "Podle abecedy"
+
+#. TRANSLATORS: Name of Boolean false value
+#: ../src/propgrid/propgrid.cpp:230
+msgid "False"
+msgstr "Nepravda"
+
+#. TRANSLATORS: Name of Boolean true value
+#: ../src/propgrid/propgrid.cpp:232
+msgid "True"
+msgstr "Pravda"
+
+#. TRANSLATORS: Text  displayed for unspecified value
+#: ../src/propgrid/propgrid.cpp:428
+msgid "Unspecified"
+msgstr "Neurčeno"
+
+#. TRANSLATORS: Caption of message box displaying any property error
+#: ../src/propgrid/propgrid.cpp:3145 ../src/propgrid/propgrid.cpp:3282
+msgid "Property Error"
+msgstr "Chyba vlastnosti"
+
+#: ../src/propgrid/propgrid.cpp:3259
+msgid "You have entered invalid value. Press ESC to cancel editing."
+msgstr "Zadali jste nesprávnou hodnotu. Stiskněte ESC pro zrušení úprav."
+
+#: ../src/propgrid/propgrid.cpp:6608
+#, c-format
+msgid "Error in resource: %s"
+msgstr "Chyba ve zdroji: %s"
+
+#: ../src/propgrid/propgridiface.cpp:377
+#, c-format
+msgid ""
+"Type operation \"%s\" failed: Property labeled \"%s\" is of type \"%s\", NOT "
+"\"%s\"."
+msgstr ""
+"Operace typu \"%s\" selhala: Vlastnost označená \"%s\" je typu \"%s\", NE "
+"\"%s\"."
+
+#: ../src/propgrid/props.cpp:159
+#, c-format
+msgid "Unknown base %d. Base 10 will be used."
+msgstr "Neznámý základ %d. Bude použitá desítková soustava."
+
+#: ../src/propgrid/props.cpp:324
+#, c-format
+msgid "Value must be %s or higher."
+msgstr "Hodnota musí být %s nebo větší."
+
+#: ../src/propgrid/props.cpp:329 ../src/propgrid/props.cpp:356
+#, c-format
+msgid "Value must be between %s and %s."
+msgstr "Hodnota musí být mezi %s a %s."
+
+#: ../src/propgrid/props.cpp:351
+#, c-format
+msgid "Value must be %s or less."
+msgstr "Hodnota musí být %s nebo menší."
+
+#: ../src/propgrid/props.cpp:1058
+#, c-format
+msgid "Not %s"
+msgstr "Není %s"
+
+#: ../src/propgrid/props.cpp:1770
+msgid "Choose a directory:"
+msgstr "Zvolte adresář:"
+
+#: ../src/propgrid/props.cpp:2055
+msgid "Choose a file"
+msgstr "Zvolte soubor"
+
+#: ../src/qt/mdi.cpp:254
+msgid "&Tile"
+msgstr "&Dlaždice"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:147
+#: ../src/richtext/richtextformatdlg.cpp:376
+msgid "Background"
+msgstr "Pozadí"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:159
+msgid "Background &colour:"
+msgstr "&Barva pozadí:"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:161
+#: ../src/richtext/richtextbackgroundpage.cpp:163
+msgid "Enables a background colour."
+msgstr "Povoluje barvu pozadí."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:167
+#: ../src/richtext/richtextbackgroundpage.cpp:169
+msgid "The background colour."
+msgstr "Barva pozadí."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:178
+msgid "Shadow"
+msgstr "Stín"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:193
+msgid "Use &shadow"
+msgstr "Použít &stín"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:195
+#: ../src/richtext/richtextbackgroundpage.cpp:197
+msgid "Enables a shadow."
+msgstr "Povoluje stín."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:211
+msgid "&Horizontal offset:"
+msgstr "&Vodorovné posunutí:"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:218
+#: ../src/richtext/richtextbackgroundpage.cpp:220
+msgid "The horizontal offset."
+msgstr "Vodorovné posunutí."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:224
+#: ../src/richtext/richtextbackgroundpage.cpp:227
+#: ../src/richtext/richtextbackgroundpage.cpp:228
+#: ../src/richtext/richtextbackgroundpage.cpp:247
+#: ../src/richtext/richtextbackgroundpage.cpp:250
+#: ../src/richtext/richtextbackgroundpage.cpp:251
+#: ../src/richtext/richtextbackgroundpage.cpp:287
+#: ../src/richtext/richtextbackgroundpage.cpp:290
+#: ../src/richtext/richtextbackgroundpage.cpp:291
+#: ../src/richtext/richtextbackgroundpage.cpp:314
+#: ../src/richtext/richtextbackgroundpage.cpp:317
+#: ../src/richtext/richtextbackgroundpage.cpp:318
+#: ../src/richtext/richtextborderspage.cpp:252
+#: ../src/richtext/richtextborderspage.cpp:255
+#: ../src/richtext/richtextborderspage.cpp:256
+#: ../src/richtext/richtextborderspage.cpp:286
+#: ../src/richtext/richtextborderspage.cpp:289
+#: ../src/richtext/richtextborderspage.cpp:290
+#: ../src/richtext/richtextborderspage.cpp:320
+#: ../src/richtext/richtextborderspage.cpp:323
+#: ../src/richtext/richtextborderspage.cpp:324
+#: ../src/richtext/richtextborderspage.cpp:354
+#: ../src/richtext/richtextborderspage.cpp:357
+#: ../src/richtext/richtextborderspage.cpp:358
+#: ../src/richtext/richtextborderspage.cpp:420
+#: ../src/richtext/richtextborderspage.cpp:423
+#: ../src/richtext/richtextborderspage.cpp:424
+#: ../src/richtext/richtextborderspage.cpp:454
+#: ../src/richtext/richtextborderspage.cpp:457
+#: ../src/richtext/richtextborderspage.cpp:458
+#: ../src/richtext/richtextborderspage.cpp:488
+#: ../src/richtext/richtextborderspage.cpp:491
+#: ../src/richtext/richtextborderspage.cpp:492
+#: ../src/richtext/richtextborderspage.cpp:522
+#: ../src/richtext/richtextborderspage.cpp:525
+#: ../src/richtext/richtextborderspage.cpp:526
+#: ../src/richtext/richtextborderspage.cpp:590
+#: ../src/richtext/richtextborderspage.cpp:593
+#: ../src/richtext/richtextborderspage.cpp:594
+#: ../src/richtext/richtextfontpage.cpp:177
+#: ../src/richtext/richtextmarginspage.cpp:199
+#: ../src/richtext/richtextmarginspage.cpp:201
+#: ../src/richtext/richtextmarginspage.cpp:202
+#: ../src/richtext/richtextmarginspage.cpp:224
+#: ../src/richtext/richtextmarginspage.cpp:226
+#: ../src/richtext/richtextmarginspage.cpp:227
+#: ../src/richtext/richtextmarginspage.cpp:247
+#: ../src/richtext/richtextmarginspage.cpp:249
+#: ../src/richtext/richtextmarginspage.cpp:250
+#: ../src/richtext/richtextmarginspage.cpp:272
+#: ../src/richtext/richtextmarginspage.cpp:274
+#: ../src/richtext/richtextmarginspage.cpp:275
+#: ../src/richtext/richtextmarginspage.cpp:313
+#: ../src/richtext/richtextmarginspage.cpp:315
+#: ../src/richtext/richtextmarginspage.cpp:316
+#: ../src/richtext/richtextmarginspage.cpp:338
+#: ../src/richtext/richtextmarginspage.cpp:340
+#: ../src/richtext/richtextmarginspage.cpp:341
+#: ../src/richtext/richtextmarginspage.cpp:361
+#: ../src/richtext/richtextmarginspage.cpp:363
+#: ../src/richtext/richtextmarginspage.cpp:364
+#: ../src/richtext/richtextmarginspage.cpp:386
+#: ../src/richtext/richtextmarginspage.cpp:388
+#: ../src/richtext/richtextmarginspage.cpp:389
+#: ../src/richtext/richtextsizepage.cpp:337
+#: ../src/richtext/richtextsizepage.cpp:340
+#: ../src/richtext/richtextsizepage.cpp:341
+#: ../src/richtext/richtextsizepage.cpp:371
+#: ../src/richtext/richtextsizepage.cpp:374
+#: ../src/richtext/richtextsizepage.cpp:375
+#: ../src/richtext/richtextsizepage.cpp:398
+#: ../src/richtext/richtextsizepage.cpp:401
+#: ../src/richtext/richtextsizepage.cpp:402
+#: ../src/richtext/richtextsizepage.cpp:425
+#: ../src/richtext/richtextsizepage.cpp:428
+#: ../src/richtext/richtextsizepage.cpp:429
+#: ../src/richtext/richtextsizepage.cpp:452
+#: ../src/richtext/richtextsizepage.cpp:455
+#: ../src/richtext/richtextsizepage.cpp:456
+#: ../src/richtext/richtextsizepage.cpp:479
+#: ../src/richtext/richtextsizepage.cpp:482
+#: ../src/richtext/richtextsizepage.cpp:483
+#: ../src/richtext/richtextsizepage.cpp:553
+#: ../src/richtext/richtextsizepage.cpp:556
+#: ../src/richtext/richtextsizepage.cpp:557
+#: ../src/richtext/richtextsizepage.cpp:588
+#: ../src/richtext/richtextsizepage.cpp:591
+#: ../src/richtext/richtextsizepage.cpp:592
+#: ../src/richtext/richtextsizepage.cpp:623
+#: ../src/richtext/richtextsizepage.cpp:626
+#: ../src/richtext/richtextsizepage.cpp:627
+#: ../src/richtext/richtextsizepage.cpp:658
+#: ../src/richtext/richtextsizepage.cpp:661
+#: ../src/richtext/richtextsizepage.cpp:662
+msgid "px"
+msgstr "px"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:225
+#: ../src/richtext/richtextbackgroundpage.cpp:248
+#: ../src/richtext/richtextbackgroundpage.cpp:288
+#: ../src/richtext/richtextbackgroundpage.cpp:315
+#: ../src/richtext/richtextborderspage.cpp:253
+#: ../src/richtext/richtextborderspage.cpp:287
+#: ../src/richtext/richtextborderspage.cpp:321
+#: ../src/richtext/richtextborderspage.cpp:355
+#: ../src/richtext/richtextborderspage.cpp:421
+#: ../src/richtext/richtextborderspage.cpp:455
+#: ../src/richtext/richtextborderspage.cpp:489
+#: ../src/richtext/richtextborderspage.cpp:523
+#: ../src/richtext/richtextborderspage.cpp:591
+#: ../src/richtext/richtextmarginspage.cpp:200
+#: ../src/richtext/richtextmarginspage.cpp:225
+#: ../src/richtext/richtextmarginspage.cpp:248
+#: ../src/richtext/richtextmarginspage.cpp:273
+#: ../src/richtext/richtextmarginspage.cpp:314
+#: ../src/richtext/richtextmarginspage.cpp:339
+#: ../src/richtext/richtextmarginspage.cpp:362
+#: ../src/richtext/richtextmarginspage.cpp:387
+#: ../src/richtext/richtextsizepage.cpp:338
+#: ../src/richtext/richtextsizepage.cpp:372
+#: ../src/richtext/richtextsizepage.cpp:399
+#: ../src/richtext/richtextsizepage.cpp:426
+#: ../src/richtext/richtextsizepage.cpp:453
+#: ../src/richtext/richtextsizepage.cpp:480
+#: ../src/richtext/richtextsizepage.cpp:554
+#: ../src/richtext/richtextsizepage.cpp:589
+#: ../src/richtext/richtextsizepage.cpp:624
+#: ../src/richtext/richtextsizepage.cpp:659
+msgid "cm"
+msgstr "cm"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:226
+#: ../src/richtext/richtextbackgroundpage.cpp:249
+#: ../src/richtext/richtextbackgroundpage.cpp:289
+#: ../src/richtext/richtextbackgroundpage.cpp:316
+#: ../src/richtext/richtextborderspage.cpp:254
+#: ../src/richtext/richtextborderspage.cpp:288
+#: ../src/richtext/richtextborderspage.cpp:322
+#: ../src/richtext/richtextborderspage.cpp:356
+#: ../src/richtext/richtextborderspage.cpp:422
+#: ../src/richtext/richtextborderspage.cpp:456
+#: ../src/richtext/richtextborderspage.cpp:490
+#: ../src/richtext/richtextborderspage.cpp:524
+#: ../src/richtext/richtextborderspage.cpp:592
+#: ../src/richtext/richtextfontpage.cpp:176
+#: ../src/richtext/richtextfontpage.cpp:179
+msgid "pt"
+msgstr "pt"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:229
+#: ../src/richtext/richtextbackgroundpage.cpp:231
+#: ../src/richtext/richtextbackgroundpage.cpp:252
+#: ../src/richtext/richtextbackgroundpage.cpp:254
+#: ../src/richtext/richtextbackgroundpage.cpp:292
+#: ../src/richtext/richtextbackgroundpage.cpp:294
+#: ../src/richtext/richtextbackgroundpage.cpp:319
+#: ../src/richtext/richtextbackgroundpage.cpp:321
+msgid "Units for this value."
+msgstr "Jednotky pro tuto hodnotu."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:234
+msgid "&Vertical offset:"
+msgstr "&Svislé posunutí:"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:241
+#: ../src/richtext/richtextbackgroundpage.cpp:243
+msgid "The vertical offset."
+msgstr "Svislé posunutí."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:257
+msgid "Shadow c&olour:"
+msgstr "&Barva stínu:"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:259
+#: ../src/richtext/richtextbackgroundpage.cpp:261
+msgid "Enables the shadow colour."
+msgstr "Povoluje barvu stínu."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:265
+#: ../src/richtext/richtextbackgroundpage.cpp:267
+msgid "The shadow colour."
+msgstr "Barva stínu."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:270
+msgid "Sh&adow spread:"
+msgstr "&Rozprostření stínu:"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:272
+#: ../src/richtext/richtextbackgroundpage.cpp:274
+msgid "Enables the shadow spread."
+msgstr "Povolí rozprostření stínu."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:281
+#: ../src/richtext/richtextbackgroundpage.cpp:283
+msgid "The shadow spread."
+msgstr "Rozprostření stínu."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:297
+msgid "&Blur distance:"
+msgstr "&Délka rozostření:"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:299
+#: ../src/richtext/richtextbackgroundpage.cpp:301
+msgid "Enables the blur distance."
+msgstr "Povolí délku rozostření."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:308
+#: ../src/richtext/richtextbackgroundpage.cpp:310
+msgid "The shadow blur distance."
+msgstr "Délka rozostření stínu."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:324
+msgid "Opaci&ty:"
+msgstr "&Neprůhlednost:"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:326
+#: ../src/richtext/richtextbackgroundpage.cpp:328
+msgid "Enables the shadow opacity."
+msgstr "Povoluje neprůhlednost stínu."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:335
+#: ../src/richtext/richtextbackgroundpage.cpp:337
+msgid "The shadow opacity."
+msgstr "Neprůhlednost stínu."
+
+#. TRANSLATORS: Rich text page units (percentage)
+#: ../src/richtext/richtextbackgroundpage.cpp:340
+#: ../src/richtext/richtextsizepage.cpp:339
+#: ../src/richtext/richtextsizepage.cpp:373
+#: ../src/richtext/richtextsizepage.cpp:400
+#: ../src/richtext/richtextsizepage.cpp:427
+#: ../src/richtext/richtextsizepage.cpp:454
+#: ../src/richtext/richtextsizepage.cpp:481
+#: ../src/richtext/richtextsizepage.cpp:555
+#: ../src/richtext/richtextsizepage.cpp:590
+#: ../src/richtext/richtextsizepage.cpp:625
+#: ../src/richtext/richtextsizepage.cpp:660
+msgid "%"
+msgstr "%"
+
+#: ../src/richtext/richtextborderspage.cpp:229
+#: ../src/richtext/richtextborderspage.cpp:387
+msgid "Border"
+msgstr "Okraj"
+
+#: ../src/richtext/richtextborderspage.cpp:242
+#: ../src/richtext/richtextborderspage.cpp:410
+#: ../src/richtext/richtextindentspage.cpp:194
+#: ../src/richtext/richtextliststylepage.cpp:384
+#: ../src/richtext/richtextmarginspage.cpp:185
+#: ../src/richtext/richtextmarginspage.cpp:299
+#: ../src/richtext/richtextsizepage.cpp:531
+#: ../src/richtext/richtextsizepage.cpp:538
+msgid "&Left:"
+msgstr "Do&leva:"
+
+#: ../src/richtext/richtextborderspage.cpp:257
+#: ../src/richtext/richtextborderspage.cpp:259
+msgid "Units for the left border width."
+msgstr "Jednotky pro šířku levého okraje."
+
+#: ../src/richtext/richtextborderspage.cpp:266
+#: ../src/richtext/richtextborderspage.cpp:268
+#: ../src/richtext/richtextborderspage.cpp:300
+#: ../src/richtext/richtextborderspage.cpp:302
+#: ../src/richtext/richtextborderspage.cpp:334
+#: ../src/richtext/richtextborderspage.cpp:336
+#: ../src/richtext/richtextborderspage.cpp:368
+#: ../src/richtext/richtextborderspage.cpp:370
+#: ../src/richtext/richtextborderspage.cpp:434
+#: ../src/richtext/richtextborderspage.cpp:436
+#: ../src/richtext/richtextborderspage.cpp:468
+#: ../src/richtext/richtextborderspage.cpp:470
+#: ../src/richtext/richtextborderspage.cpp:502
+#: ../src/richtext/richtextborderspage.cpp:504
+#: ../src/richtext/richtextborderspage.cpp:536
+#: ../src/richtext/richtextborderspage.cpp:538
+msgid "The border line style."
+msgstr "Styl ohraničení."
+
+#: ../src/richtext/richtextborderspage.cpp:276
+#: ../src/richtext/richtextborderspage.cpp:444
+#: ../src/richtext/richtextindentspage.cpp:212
+#: ../src/richtext/richtextliststylepage.cpp:402
+#: ../src/richtext/richtextmarginspage.cpp:210
+#: ../src/richtext/richtextmarginspage.cpp:324
+#: ../src/richtext/richtextsizepage.cpp:601
+#: ../src/richtext/richtextsizepage.cpp:608
+msgid "&Right:"
+msgstr "Dop&rava:"
+
+#: ../src/richtext/richtextborderspage.cpp:291
+#: ../src/richtext/richtextborderspage.cpp:293
+msgid "Units for the right border width."
+msgstr "Jednotky pro šířku pravého okraje."
+
+#: ../src/richtext/richtextborderspage.cpp:310
+#: ../src/richtext/richtextborderspage.cpp:478
+#: ../src/richtext/richtextmarginspage.cpp:233
+#: ../src/richtext/richtextmarginspage.cpp:347
+#: ../src/richtext/richtextsizepage.cpp:566
+#: ../src/richtext/richtextsizepage.cpp:573
+msgid "&Top:"
+msgstr "&Nahoru:"
+
+#: ../src/richtext/richtextborderspage.cpp:325
+#: ../src/richtext/richtextborderspage.cpp:327
+msgid "Units for the top border width."
+msgstr "Jednotky pro šířku horního okraje."
+
+#: ../src/richtext/richtextborderspage.cpp:344
+#: ../src/richtext/richtextborderspage.cpp:512
+#: ../src/richtext/richtextmarginspage.cpp:258
+#: ../src/richtext/richtextmarginspage.cpp:372
+#: ../src/richtext/richtextsizepage.cpp:636
+#: ../src/richtext/richtextsizepage.cpp:643
+msgid "&Bottom:"
+msgstr "&Dolů:"
+
+#: ../src/richtext/richtextborderspage.cpp:359
+#: ../src/richtext/richtextborderspage.cpp:361
+msgid "Units for the bottom border width."
+msgstr "Jednotky pro šířku dolního okraje."
+
+#: ../src/richtext/richtextborderspage.cpp:380
+#: ../src/richtext/richtextborderspage.cpp:548
+msgid "&Synchronize values"
+msgstr "&Synchronizovat hodnoty"
+
+#: ../src/richtext/richtextborderspage.cpp:382
+#: ../src/richtext/richtextborderspage.cpp:384
+#: ../src/richtext/richtextborderspage.cpp:550
+#: ../src/richtext/richtextborderspage.cpp:552
+msgid "Check to edit all borders simultaneously."
+msgstr "Zaškrtněte pro úpravu všech okrajů současně."
+
+#: ../src/richtext/richtextborderspage.cpp:397
+#: ../src/richtext/richtextborderspage.cpp:555
+msgid "Outline"
+msgstr "Obrys"
+
+#: ../src/richtext/richtextborderspage.cpp:425
+#: ../src/richtext/richtextborderspage.cpp:427
+msgid "Units for the left outline width."
+msgstr "Jednotky pro šířku levého obrysu."
+
+#: ../src/richtext/richtextborderspage.cpp:459
+#: ../src/richtext/richtextborderspage.cpp:461
+msgid "Units for the right outline width."
+msgstr "Jednotky pro šířku pravého obrysu."
+
+#: ../src/richtext/richtextborderspage.cpp:493
+#: ../src/richtext/richtextborderspage.cpp:495
+msgid "Units for the top outline width."
+msgstr "Jednotky pro šířku horního obrysu."
+
+#: ../src/richtext/richtextborderspage.cpp:527
+#: ../src/richtext/richtextborderspage.cpp:529
+msgid "Units for the bottom outline width."
+msgstr "Jednotky pro šířku dolního obrysu."
+
+#: ../src/richtext/richtextborderspage.cpp:565
+#: ../src/richtext/richtextborderspage.cpp:600
+msgid "Corner"
+msgstr "Roh"
+
+#: ../src/richtext/richtextborderspage.cpp:574
+msgid "Corner &radius:"
+msgstr "&Zaoblení rohu:"
+
+#: ../src/richtext/richtextborderspage.cpp:576
+#: ../src/richtext/richtextborderspage.cpp:578
+msgid "An optional corner radius for adding rounded corners."
+msgstr "Nepovinný poloměr zaoblení pro přidání zaoblených rohů."
+
+#: ../src/richtext/richtextborderspage.cpp:584
+#: ../src/richtext/richtextborderspage.cpp:586
+msgid "The value of the corner radius."
+msgstr "Hodnota zaoblení rohu."
+
+#: ../src/richtext/richtextborderspage.cpp:595
+#: ../src/richtext/richtextborderspage.cpp:597
+msgid "Units for the corner radius."
+msgstr "Jednotky pro zaoblení rohu."
+
+#: ../src/richtext/richtextborderspage.cpp:609
+#: ../src/richtext/richtextsizepage.cpp:247
+#: ../src/richtext/richtextsizepage.cpp:251
+msgid "None"
+msgstr "Žádný"
+
+#: ../src/richtext/richtextborderspage.cpp:610
+msgid "Solid"
+msgstr "Plný"
+
+#: ../src/richtext/richtextborderspage.cpp:611
+msgid "Dotted"
+msgstr "Tečkovaný"
+
+#: ../src/richtext/richtextborderspage.cpp:612
+msgid "Dashed"
+msgstr "Čárkovaný"
+
+#: ../src/richtext/richtextborderspage.cpp:613
+msgid "Double"
+msgstr "Dvojitý"
+
+#: ../src/richtext/richtextborderspage.cpp:614
+msgid "Groove"
+msgstr "Příkop"
+
+#: ../src/richtext/richtextborderspage.cpp:615
+msgid "Ridge"
+msgstr "Val"
+
+#: ../src/richtext/richtextborderspage.cpp:616
+msgid "Inset"
+msgstr "Ďolík"
+
+#: ../src/richtext/richtextborderspage.cpp:617
+msgid "Outset"
+msgstr "Návrší"
+
+#: ../src/richtext/richtextbuffer.cpp:3518
+msgid "Change Style"
+msgstr "Změnit styl"
+
+#: ../src/richtext/richtextbuffer.cpp:3701
+msgid "Change Object Style"
+msgstr "Změnit styl objektu"
+
+#: ../src/richtext/richtextbuffer.cpp:3974
+#: ../src/richtext/richtextbuffer.cpp:8174
+msgid "Change Properties"
+msgstr "Změnit vlastnosti"
+
+#: ../src/richtext/richtextbuffer.cpp:4346
+msgid "Change List Style"
+msgstr "Změnit styl seznamu"
+
+#: ../src/richtext/richtextbuffer.cpp:4519
+msgid "Renumber List"
+msgstr "Znovu očíslovat seznam"
+
+#: ../src/richtext/richtextbuffer.cpp:7867
+#: ../src/richtext/richtextbuffer.cpp:7897
+#: ../src/richtext/richtextbuffer.cpp:7939
+#: ../src/richtext/richtextctrl.cpp:1279 ../src/richtext/richtextctrl.cpp:1473
+msgid "Insert Text"
+msgstr "Vložit text"
+
+#: ../src/richtext/richtextbuffer.cpp:8023
+#: ../src/richtext/richtextbuffer.cpp:8979
+msgid "Insert Image"
+msgstr "Vložit obrázek"
+
+#: ../src/richtext/richtextbuffer.cpp:8070
+msgid "Insert Object"
+msgstr "Vložit objekt"
+
+#: ../src/richtext/richtextbuffer.cpp:8112
+msgid "Insert Field"
+msgstr "Vložit pole"
+
+#: ../src/richtext/richtextbuffer.cpp:8410
+msgid "Too many EndStyle calls!"
+msgstr "Příliš mnoho volání EndStyle!"
+
+#: ../src/richtext/richtextbuffer.cpp:8785
+msgid "files"
+msgstr "soubory"
+
+#: ../src/richtext/richtextbuffer.cpp:9380
+msgid "standard/circle"
+msgstr "standardní/kruh"
+
+#: ../src/richtext/richtextbuffer.cpp:9381
+msgid "standard/circle-outline"
+msgstr "standardní/obrys kruhu"
+
+#: ../src/richtext/richtextbuffer.cpp:9382
+msgid "standard/square"
+msgstr "standardní/čtverec"
+
+#: ../src/richtext/richtextbuffer.cpp:9383
+msgid "standard/diamond"
+msgstr "standardní/kosočtverec"
+
+#: ../src/richtext/richtextbuffer.cpp:9384
+msgid "standard/triangle"
+msgstr "standardní/trojúhelník"
+
+#: ../src/richtext/richtextbuffer.cpp:9423
+msgid "Box Properties"
+msgstr "Vlastnosti rámečku"
+
+#: ../src/richtext/richtextbuffer.cpp:10006
+msgid "Multiple Cell Properties"
+msgstr "Vlastnosti více buněk"
+
+#: ../src/richtext/richtextbuffer.cpp:10008
+msgid "Cell Properties"
+msgstr "&Vlastnosti buňky"
+
+#: ../src/richtext/richtextbuffer.cpp:11256
+msgid "Set Cell Style"
+msgstr "Nastavit styl buňky"
+
+#: ../src/richtext/richtextbuffer.cpp:11330
+msgid "Delete Row"
+msgstr "Smazat řádek"
+
+#: ../src/richtext/richtextbuffer.cpp:11380
+msgid "Delete Column"
+msgstr "Smazat sloupec"
+
+#: ../src/richtext/richtextbuffer.cpp:11431
+msgid "Add Row"
+msgstr "Přidat řádek"
+
+#: ../src/richtext/richtextbuffer.cpp:11494
+msgid "Add Column"
+msgstr "Přidat sloupec"
+
+#: ../src/richtext/richtextbuffer.cpp:11537
+msgid "Table Properties"
+msgstr "Vlastnosti tabulky"
+
+#: ../src/richtext/richtextbuffer.cpp:12899
+msgid "Picture Properties"
+msgstr "Vlastnosti obrázku"
+
+#: ../src/richtext/richtextbuffer.cpp:13169
+#: ../src/richtext/richtextbuffer.cpp:13279
+msgid "image"
+msgstr "obrázek"
+
+#: ../src/richtext/richtextbulletspage.cpp:145
+#: ../src/richtext/richtextliststylepage.cpp:209
+msgid "&Bullet style:"
+msgstr "&Styl odrážek:"
+
+#: ../src/richtext/richtextbulletspage.cpp:150
+#: ../src/richtext/richtextbulletspage.cpp:152
+#: ../src/richtext/richtextliststylepage.cpp:214
+#: ../src/richtext/richtextliststylepage.cpp:216
+msgid "The available bullet styles."
+msgstr "Dostupné styly odrážek."
+
+#: ../src/richtext/richtextbulletspage.cpp:158
+#: ../src/richtext/richtextliststylepage.cpp:221
+msgid "Peri&od"
+msgstr "Tečk&a"
+
+#: ../src/richtext/richtextbulletspage.cpp:160
+#: ../src/richtext/richtextbulletspage.cpp:162
+#: ../src/richtext/richtextliststylepage.cpp:223
+#: ../src/richtext/richtextliststylepage.cpp:225
+msgid "Check to add a period after the bullet."
+msgstr "Zaškrtněte pro přidání tečky za odrážku."
+
+#. TRANSLATORS: Bullet point in parentheses option
+#: ../src/richtext/richtextbulletspage.cpp:167
+#: ../src/richtext/richtextliststylepage.cpp:230
+msgid "(*)"
+msgstr "(*)"
+
+#: ../src/richtext/richtextbulletspage.cpp:169
+#: ../src/richtext/richtextbulletspage.cpp:171
+#: ../src/richtext/richtextliststylepage.cpp:232
+#: ../src/richtext/richtextliststylepage.cpp:234
+msgid "Check to enclose the bullet in parentheses."
+msgstr "Zaškrtněte pro uzavření odrážek do závorek."
+
+#. TRANSLATORS: Right parenthesis bullet point option
+#: ../src/richtext/richtextbulletspage.cpp:176
+#: ../src/richtext/richtextliststylepage.cpp:239
+msgid "*)"
+msgstr "*)"
+
+#: ../src/richtext/richtextbulletspage.cpp:178
+#: ../src/richtext/richtextbulletspage.cpp:180
+#: ../src/richtext/richtextliststylepage.cpp:241
+#: ../src/richtext/richtextliststylepage.cpp:243
+msgid "Check to add a right parenthesis."
+msgstr "Zaškrtněte pro přidání pravé závorky."
+
+#: ../src/richtext/richtextbulletspage.cpp:185
+#: ../src/richtext/richtextliststylepage.cpp:248
+msgid "Bullet &Alignment:"
+msgstr "Z&arovnání odrážek:"
+
+#: ../src/richtext/richtextbulletspage.cpp:190
+#: ../src/richtext/richtextliststylepage.cpp:253
+msgid "Centre"
+msgstr "Na střed"
+
+#: ../src/richtext/richtextbulletspage.cpp:194
+#: ../src/richtext/richtextbulletspage.cpp:196
+#: ../src/richtext/richtextbulletspage.cpp:217
+#: ../src/richtext/richtextbulletspage.cpp:219
+#: ../src/richtext/richtextliststylepage.cpp:257
+#: ../src/richtext/richtextliststylepage.cpp:259
+#: ../src/richtext/richtextliststylepage.cpp:278
+#: ../src/richtext/richtextliststylepage.cpp:280
+msgid "The bullet character."
+msgstr "Znak odrážky."
+
+#: ../src/richtext/richtextbulletspage.cpp:212
+#: ../src/richtext/richtextliststylepage.cpp:271
+msgid "&Symbol:"
+msgstr "&Symbol:"
+
+#: ../src/richtext/richtextbulletspage.cpp:222
+#: ../src/richtext/richtextliststylepage.cpp:283
+msgid "Ch&oose..."
+msgstr "Zv&olte..."
+
+#: ../src/richtext/richtextbulletspage.cpp:223
+#: ../src/richtext/richtextbulletspage.cpp:225
+#: ../src/richtext/richtextliststylepage.cpp:284
+#: ../src/richtext/richtextliststylepage.cpp:286
+msgid "Click to browse for a symbol."
+msgstr "Klikněte k procházení pro symbol."
+
+#: ../src/richtext/richtextbulletspage.cpp:230
+#: ../src/richtext/richtextliststylepage.cpp:291
+msgid "Symbol &font:"
+msgstr "Symbolové &písmo:"
+
+#: ../src/richtext/richtextbulletspage.cpp:235
+#: ../src/richtext/richtextbulletspage.cpp:237
+#: ../src/richtext/richtextliststylepage.cpp:297
+msgid "Available fonts."
+msgstr "Dostupná písma."
+
+#: ../src/richtext/richtextbulletspage.cpp:242
+#: ../src/richtext/richtextliststylepage.cpp:302
+msgid "S&tandard bullet name:"
+msgstr "S&tandardní jméno odrážky:"
+
+#: ../src/richtext/richtextbulletspage.cpp:247
+#: ../src/richtext/richtextbulletspage.cpp:249
+#: ../src/richtext/richtextliststylepage.cpp:307
+#: ../src/richtext/richtextliststylepage.cpp:309
+msgid "A standard bullet name."
+msgstr "Standardní jméno odrážky."
+
+#: ../src/richtext/richtextbulletspage.cpp:254
+msgid "&Number:"
+msgstr "&Číslo:"
+
+#: ../src/richtext/richtextbulletspage.cpp:258
+#: ../src/richtext/richtextbulletspage.cpp:260
+msgid "The list item number."
+msgstr "Číslo položky seznamu."
+
+#: ../src/richtext/richtextbulletspage.cpp:266
+#: ../src/richtext/richtextbulletspage.cpp:268
+#: ../src/richtext/richtextliststylepage.cpp:475
+#: ../src/richtext/richtextliststylepage.cpp:477
+msgid "Shows a preview of the bullet settings."
+msgstr "Zobrazí náhled nastavení odrážek."
+
+#: ../src/richtext/richtextbulletspage.cpp:276
+#: ../src/richtext/richtextliststylepage.cpp:484
+msgid "(None)"
+msgstr "(Žádný)"
+
+#: ../src/richtext/richtextbulletspage.cpp:277
+#: ../src/richtext/richtextliststylepage.cpp:485
+msgid "Arabic"
+msgstr "Arabský"
+
+#: ../src/richtext/richtextbulletspage.cpp:278
+#: ../src/richtext/richtextliststylepage.cpp:486
+msgid "Upper case letters"
+msgstr "Velká písmena"
+
+#: ../src/richtext/richtextbulletspage.cpp:279
+#: ../src/richtext/richtextliststylepage.cpp:487
+msgid "Lower case letters"
+msgstr "Malá písmena"
+
+#: ../src/richtext/richtextbulletspage.cpp:280
+#: ../src/richtext/richtextliststylepage.cpp:488
+msgid "Upper case roman numerals"
+msgstr "Velké římské číslice"
+
+#: ../src/richtext/richtextbulletspage.cpp:281
+#: ../src/richtext/richtextliststylepage.cpp:489
+msgid "Lower case roman numerals"
+msgstr "Malé římské číslice"
+
+#: ../src/richtext/richtextbulletspage.cpp:282
+#: ../src/richtext/richtextliststylepage.cpp:490
+msgid "Numbered outline"
+msgstr "Očíslovaný odstavec"
+
+#: ../src/richtext/richtextbulletspage.cpp:283
+#: ../src/richtext/richtextliststylepage.cpp:491
+msgid "Symbol"
+msgstr "Symbol"
+
+#: ../src/richtext/richtextbulletspage.cpp:284
+#: ../src/richtext/richtextliststylepage.cpp:492
+msgid "Bitmap"
+msgstr "Bitmapa"
+
+#: ../src/richtext/richtextbulletspage.cpp:285
+#: ../src/richtext/richtextliststylepage.cpp:493
+msgid "Standard"
+msgstr "Standardní"
+
+#: ../src/richtext/richtextbulletspage.cpp:287
+#: ../src/richtext/richtextliststylepage.cpp:495
+msgid "*"
+msgstr "*"
+
+#: ../src/richtext/richtextbulletspage.cpp:288
+#: ../src/richtext/richtextliststylepage.cpp:496
+msgid "-"
+msgstr "-"
+
+#: ../src/richtext/richtextbulletspage.cpp:289
+#: ../src/richtext/richtextliststylepage.cpp:497
+msgid ">"
+msgstr ">"
+
+#: ../src/richtext/richtextbulletspage.cpp:290
+#: ../src/richtext/richtextliststylepage.cpp:498
+msgid "+"
+msgstr "+"
+
+#: ../src/richtext/richtextbulletspage.cpp:291
+#: ../src/richtext/richtextliststylepage.cpp:499
+msgid "~"
+msgstr "~"
+
+#: ../src/richtext/richtextctrl.cpp:859
+msgid "Drag"
+msgstr "Táhnout"
+
+#: ../src/richtext/richtextctrl.cpp:1338 ../src/richtext/richtextctrl.cpp:1559
+msgid "Delete Text"
+msgstr "Smazat text"
+
+#: ../src/richtext/richtextctrl.cpp:1537
+msgid "Remove Bullet"
+msgstr "Odstranit odrážku"
+
+#: ../src/richtext/richtextctrl.cpp:3070
+msgid "The text couldn't be saved."
+msgstr "Text nelze uložit."
+
+#: ../src/richtext/richtextctrl.cpp:3644
+msgid "Replace"
+msgstr "Nahradit"
+
+#: ../src/richtext/richtextfontpage.cpp:146
+#: ../src/richtext/richtextsymboldlg.cpp:384
+msgid "&Font:"
+msgstr "&Písmo:"
+
+#: ../src/richtext/richtextfontpage.cpp:150
+#: ../src/richtext/richtextfontpage.cpp:152
+msgid "Type a font name."
+msgstr "Zadejte název písma."
+
+#: ../src/richtext/richtextfontpage.cpp:158
+msgid "&Size:"
+msgstr "Veliko&st:"
+
+#: ../src/richtext/richtextfontpage.cpp:165
+#: ../src/richtext/richtextfontpage.cpp:167
+msgid "Type a size in points."
+msgstr "Zadejte velikost v bodech."
+
+#: ../src/richtext/richtextfontpage.cpp:180
+#: ../src/richtext/richtextfontpage.cpp:182
+msgid "The font size units, points or pixels."
+msgstr "Jednotky velikosti písma, body nebo pixely."
+
+#: ../src/richtext/richtextfontpage.cpp:189
+#: ../src/richtext/richtextfontpage.cpp:191
+msgid "Lists the available fonts."
+msgstr "Zobrazí dostupná písma."
+
+#: ../src/richtext/richtextfontpage.cpp:196
+#: ../src/richtext/richtextfontpage.cpp:198
+msgid "Lists font sizes in points."
+msgstr "Zobrazí velikost písem v bodech."
+
+#: ../src/richtext/richtextfontpage.cpp:207
+msgid "Font st&yle:"
+msgstr "St&yl písma:"
+
+#: ../src/richtext/richtextfontpage.cpp:212
+#: ../src/richtext/richtextfontpage.cpp:214
+msgid "Select regular or italic style."
+msgstr "Vyberte obyčejné nebo kurzívu."
+
+#: ../src/richtext/richtextfontpage.cpp:220
+msgid "Font &weight:"
+msgstr "&Tučnost písma:"
+
+#: ../src/richtext/richtextfontpage.cpp:225
+#: ../src/richtext/richtextfontpage.cpp:227
+msgid "Select regular or bold."
+msgstr "Vyberte obyčejné nebo tučné."
+
+#: ../src/richtext/richtextfontpage.cpp:233
+msgid "&Underlining:"
+msgstr "&Podtržení:"
+
+#: ../src/richtext/richtextfontpage.cpp:238
+#: ../src/richtext/richtextfontpage.cpp:240
+msgid "Select underlining or no underlining."
+msgstr "Vyberte podtržené nebo bez podtržení."
+
+#: ../src/richtext/richtextfontpage.cpp:248
+msgid "&Colour:"
+msgstr "&Barva:"
+
+#: ../src/richtext/richtextfontpage.cpp:253
+#: ../src/richtext/richtextfontpage.cpp:255
+msgid "Click to change the text colour."
+msgstr "Klikněte pro změnu barvy písma."
+
+#: ../src/richtext/richtextfontpage.cpp:261
+msgid "&Bg colour:"
+msgstr "&Barva pozadí:"
+
+#: ../src/richtext/richtextfontpage.cpp:266
+#: ../src/richtext/richtextfontpage.cpp:268
+msgid "Click to change the text background colour."
+msgstr "Klikněte pro změnu barvy pozadí textu."
+
+#: ../src/richtext/richtextfontpage.cpp:276
+#: ../src/richtext/richtextfontpage.cpp:278
+msgid "Check to show a line through the text."
+msgstr "Zaškrtněte pro přeškrtnuté písmo."
+
+#: ../src/richtext/richtextfontpage.cpp:281
+msgid "Ca&pitals"
+msgstr "Ka&pitálky"
+
+#: ../src/richtext/richtextfontpage.cpp:283
+#: ../src/richtext/richtextfontpage.cpp:285
+msgid "Check to show the text in capitals."
+msgstr "Zaškrtněte pro zobrazení textu kapitálkami."
+
+#: ../src/richtext/richtextfontpage.cpp:288
+msgid "Small C&apitals"
+msgstr "Malé k&apitálky"
+
+#: ../src/richtext/richtextfontpage.cpp:290
+#: ../src/richtext/richtextfontpage.cpp:292
+msgid "Check to show the text in small capitals."
+msgstr "Zaškrtněte pro zobrazení textu malými kapitálkami."
+
+#: ../src/richtext/richtextfontpage.cpp:295
+msgid "Supe&rscript"
+msgstr "Ho&rní index"
+
+#: ../src/richtext/richtextfontpage.cpp:297
+#: ../src/richtext/richtextfontpage.cpp:299
+msgid "Check to show the text in superscript."
+msgstr "Zaškrtněte pro zobrazení textu v horním indexu."
+
+#: ../src/richtext/richtextfontpage.cpp:302
+msgid "Subscrip&t"
+msgstr "Dolní inde&x"
+
+#: ../src/richtext/richtextfontpage.cpp:304
+#: ../src/richtext/richtextfontpage.cpp:306
+msgid "Check to show the text in subscript."
+msgstr "Zaškrtněte pro zobrazení textu v dolním indexu."
+
+#: ../src/richtext/richtextfontpage.cpp:312
+msgid "Rig&ht-to-left"
+msgstr "&Zprava doleva"
+
+#: ../src/richtext/richtextfontpage.cpp:314
+#: ../src/richtext/richtextfontpage.cpp:316
+msgid "Check to indicate right-to-left text layout."
+msgstr "Zaškrtněte pro označení rozvržení textu jako zprava doleva."
+
+#: ../src/richtext/richtextfontpage.cpp:319
+msgid "Suppress hyphe&nation"
+msgstr "Potlačit &dělení slov"
+
+#: ../src/richtext/richtextfontpage.cpp:321
+#: ../src/richtext/richtextfontpage.cpp:323
+msgid "Check to suppress hyphenation."
+msgstr "Zaškrtněte pro potlačení dělení slov."
+
+#: ../src/richtext/richtextfontpage.cpp:329
+#: ../src/richtext/richtextfontpage.cpp:331
+msgid "Shows a preview of the font settings."
+msgstr "Zobrazí náhled nastavení písma."
+
+#: ../src/richtext/richtextfontpage.cpp:348
+#: ../src/richtext/richtextfontpage.cpp:352
+#: ../src/richtext/richtextfontpage.cpp:356
+#: ../src/richtext/richtextformatdlg.cpp:873
+#: ../src/richtext/richtextindentspage.cpp:273
+#: ../src/richtext/richtextindentspage.cpp:285
+#: ../src/richtext/richtextindentspage.cpp:286
+#: ../src/richtext/richtextindentspage.cpp:310
+#: ../src/richtext/richtextindentspage.cpp:325
+#: ../src/richtext/richtextliststylepage.cpp:451
+#: ../src/richtext/richtextliststylepage.cpp:463
+#: ../src/richtext/richtextliststylepage.cpp:464
+msgid "(none)"
+msgstr "(žádný)"
+
+#: ../src/richtext/richtextfontpage.cpp:349
+#: ../src/richtext/richtextfontpage.cpp:353
+msgid "Regular"
+msgstr "Normální"
+
+#: ../src/richtext/richtextfontpage.cpp:357
+msgid "Not underlined"
+msgstr "Není podtržený"
+
+#: ../src/richtext/richtextformatdlg.cpp:341
+msgid "Indents && Spacing"
+msgstr "Odsazení && mezery"
+
+#: ../src/richtext/richtextformatdlg.cpp:346
+msgid "Tabs"
+msgstr "Panely"
+
+#: ../src/richtext/richtextformatdlg.cpp:351
+msgid "Bullets"
+msgstr "Odrážky"
+
+#: ../src/richtext/richtextformatdlg.cpp:356
+msgid "List Style"
+msgstr "Styl seznamu"
+
+#: ../src/richtext/richtextformatdlg.cpp:366
+#: ../src/richtext/richtextmarginspage.cpp:170
+msgid "Margins"
+msgstr "Okraje"
+
+#: ../src/richtext/richtextformatdlg.cpp:371
+msgid "Borders"
+msgstr "Okraje"
+
+#: ../src/richtext/richtextformatdlg.cpp:765
+msgid "Colour"
+msgstr "Barva"
+
+#: ../src/richtext/richtextindentspage.cpp:127
+#: ../src/richtext/richtextliststylepage.cpp:322
+msgid "&Alignment"
+msgstr "Z&arovnání"
+
+#: ../src/richtext/richtextindentspage.cpp:138
+#: ../src/richtext/richtextliststylepage.cpp:331
+msgid "&Left"
+msgstr "Do&leva"
+
+#: ../src/richtext/richtextindentspage.cpp:140
+#: ../src/richtext/richtextindentspage.cpp:142
+#: ../src/richtext/richtextliststylepage.cpp:333
+#: ../src/richtext/richtextliststylepage.cpp:335
+msgid "Left-align text."
+msgstr "Zarovnat text doleva."
+
+#: ../src/richtext/richtextindentspage.cpp:145
+#: ../src/richtext/richtextliststylepage.cpp:338
+msgid "&Right"
+msgstr "Dop&rava"
+
+#: ../src/richtext/richtextindentspage.cpp:147
+#: ../src/richtext/richtextindentspage.cpp:149
+#: ../src/richtext/richtextliststylepage.cpp:340
+#: ../src/richtext/richtextliststylepage.cpp:342
+msgid "Right-align text."
+msgstr "Zarovnat text doprava."
+
+#: ../src/richtext/richtextindentspage.cpp:152
+#: ../src/richtext/richtextliststylepage.cpp:345
+msgid "&Justified"
+msgstr "&Do bloku"
+
+#: ../src/richtext/richtextindentspage.cpp:154
+#: ../src/richtext/richtextindentspage.cpp:156
+#: ../src/richtext/richtextliststylepage.cpp:347
+#: ../src/richtext/richtextliststylepage.cpp:349
+msgid "Justify text left and right."
+msgstr "Zarovnat text do bloku."
+
+#: ../src/richtext/richtextindentspage.cpp:159
+#: ../src/richtext/richtextliststylepage.cpp:352
+msgid "Cen&tred"
+msgstr "Na s&třed"
+
+#: ../src/richtext/richtextindentspage.cpp:161
+#: ../src/richtext/richtextindentspage.cpp:163
+#: ../src/richtext/richtextliststylepage.cpp:354
+#: ../src/richtext/richtextliststylepage.cpp:356
+msgid "Centre text."
+msgstr "Vystředit text."
+
+#: ../src/richtext/richtextindentspage.cpp:166
+#: ../src/richtext/richtextliststylepage.cpp:359
+msgid "&Indeterminate"
+msgstr "Neurč&ité"
+
+#: ../src/richtext/richtextindentspage.cpp:168
+#: ../src/richtext/richtextindentspage.cpp:170
+#: ../src/richtext/richtextliststylepage.cpp:361
+#: ../src/richtext/richtextliststylepage.cpp:363
+msgid "Use the current alignment setting."
+msgstr "Použít současné nastavení zarovnání."
+
+#: ../src/richtext/richtextindentspage.cpp:183
+#: ../src/richtext/richtextliststylepage.cpp:375
+msgid "&Indentation (tenths of a mm)"
+msgstr "Odsazení (desetiny m&ilimetrů)"
+
+#: ../src/richtext/richtextindentspage.cpp:198
+#: ../src/richtext/richtextindentspage.cpp:200
+#: ../src/richtext/richtextliststylepage.cpp:388
+#: ../src/richtext/richtextliststylepage.cpp:390
+msgid "The left indent."
+msgstr "Odsazení zleva."
+
+#: ../src/richtext/richtextindentspage.cpp:203
+#: ../src/richtext/richtextliststylepage.cpp:393
+msgid "Left (&first line):"
+msgstr "Zleva (&první řádek):"
+
+#: ../src/richtext/richtextindentspage.cpp:207
+#: ../src/richtext/richtextindentspage.cpp:209
+#: ../src/richtext/richtextliststylepage.cpp:397
+#: ../src/richtext/richtextliststylepage.cpp:399
+msgid "The first line indent."
+msgstr "Odsazení prvního řádku."
+
+#: ../src/richtext/richtextindentspage.cpp:216
+#: ../src/richtext/richtextindentspage.cpp:218
+#: ../src/richtext/richtextliststylepage.cpp:406
+#: ../src/richtext/richtextliststylepage.cpp:408
+msgid "The right indent."
+msgstr "Odsazení zprava."
+
+#: ../src/richtext/richtextindentspage.cpp:221
+msgid "&Outline level:"
+msgstr "Úr&oveň odstavce:"
+
+#: ../src/richtext/richtextindentspage.cpp:226
+#: ../src/richtext/richtextindentspage.cpp:228
+msgid "The outline level."
+msgstr "Úroveň odsazení."
+
+#: ../src/richtext/richtextindentspage.cpp:241
+#: ../src/richtext/richtextliststylepage.cpp:420
+msgid "&Spacing (tenths of a mm)"
+msgstr "Mezery (de&setiny mm)"
+
+#: ../src/richtext/richtextindentspage.cpp:252
+msgid "&Before a paragraph:"
+msgstr "&Před odstavcem:"
+
+#: ../src/richtext/richtextindentspage.cpp:256
+#: ../src/richtext/richtextindentspage.cpp:258
+#: ../src/richtext/richtextliststylepage.cpp:433
+#: ../src/richtext/richtextliststylepage.cpp:435
+msgid "The spacing before the paragraph."
+msgstr "Mezera před odstavcem."
+
+#: ../src/richtext/richtextindentspage.cpp:261
+msgid "&After a paragraph:"
+msgstr "Za odst&avcem:"
+
+#: ../src/richtext/richtextindentspage.cpp:266
+#: ../src/richtext/richtextliststylepage.cpp:442
+#: ../src/richtext/richtextliststylepage.cpp:444
+msgid "The spacing after the paragraph."
+msgstr "Mezera za odstavcem."
+
+#: ../src/richtext/richtextindentspage.cpp:269
+msgid "L&ine spacing:"
+msgstr "Řá&dkování:"
+
+#: ../src/richtext/richtextindentspage.cpp:274
+#: ../src/richtext/richtextliststylepage.cpp:452
+msgid "Single"
+msgstr "Jednoduché"
+
+#: ../src/richtext/richtextindentspage.cpp:275
+#: ../src/richtext/richtextliststylepage.cpp:453
+msgid "1.1"
+msgstr "1.1"
+
+#: ../src/richtext/richtextindentspage.cpp:276
+#: ../src/richtext/richtextliststylepage.cpp:454
+msgid "1.2"
+msgstr "1.2"
+
+#: ../src/richtext/richtextindentspage.cpp:277
+#: ../src/richtext/richtextliststylepage.cpp:455
+msgid "1.3"
+msgstr "1.3"
+
+#: ../src/richtext/richtextindentspage.cpp:278
+#: ../src/richtext/richtextliststylepage.cpp:456
+msgid "1.4"
+msgstr "1.4"
+
+#: ../src/richtext/richtextindentspage.cpp:279
+#: ../src/richtext/richtextliststylepage.cpp:457
+msgid "1.5"
+msgstr "1.5"
+
+#: ../src/richtext/richtextindentspage.cpp:280
+#: ../src/richtext/richtextliststylepage.cpp:458
+msgid "1.6"
+msgstr "1.6"
+
+#: ../src/richtext/richtextindentspage.cpp:281
+#: ../src/richtext/richtextliststylepage.cpp:459
+msgid "1.7"
+msgstr "1.7"
+
+#: ../src/richtext/richtextindentspage.cpp:282
+#: ../src/richtext/richtextliststylepage.cpp:460
+msgid "1.8"
+msgstr "1.8"
+
+#: ../src/richtext/richtextindentspage.cpp:283
+#: ../src/richtext/richtextliststylepage.cpp:461
+msgid "1.9"
+msgstr "1.9"
+
+#: ../src/richtext/richtextindentspage.cpp:284
+#: ../src/richtext/richtextliststylepage.cpp:462
+msgid "2"
+msgstr "2"
+
+#: ../src/richtext/richtextindentspage.cpp:287
+#: ../src/richtext/richtextindentspage.cpp:289
+#: ../src/richtext/richtextliststylepage.cpp:465
+#: ../src/richtext/richtextliststylepage.cpp:467
+msgid "The line spacing."
+msgstr "Řádkování."
+
+#: ../src/richtext/richtextindentspage.cpp:292
+msgid "&Page Break"
+msgstr "&Konec stránky"
+
+#: ../src/richtext/richtextindentspage.cpp:294
+#: ../src/richtext/richtextindentspage.cpp:296
+msgid "Inserts a page break before the paragraph."
+msgstr "Vloží konec stránky před odstavcem."
+
+#: ../src/richtext/richtextindentspage.cpp:302
+#: ../src/richtext/richtextindentspage.cpp:304
+msgid "Shows a preview of the paragraph settings."
+msgstr "Zobrazí náhled nastavení odstavce."
+
+#: ../src/richtext/richtextliststylepage.cpp:182
+msgid "&List level:"
+msgstr "Úroveň &seznamu:"
+
+#: ../src/richtext/richtextliststylepage.cpp:186
+#: ../src/richtext/richtextliststylepage.cpp:188
+msgid "Selects the list level to edit."
+msgstr "Vyberte úroveň seznamu k úpravě."
+
+#: ../src/richtext/richtextliststylepage.cpp:193
+msgid "&Font for Level..."
+msgstr "&Písmo pro úroveň..."
+
+#: ../src/richtext/richtextliststylepage.cpp:194
+#: ../src/richtext/richtextliststylepage.cpp:196
+msgid "Click to choose the font for this level."
+msgstr "Klikněte pro zvolení písma pro tuto úroveň."
+
+#: ../src/richtext/richtextliststylepage.cpp:312
+msgid "Bullet style"
+msgstr "Styl odrážek"
+
+#: ../src/richtext/richtextliststylepage.cpp:429
+msgid "Before a paragraph:"
+msgstr "Před odstavcem:"
+
+#: ../src/richtext/richtextliststylepage.cpp:438
+msgid "After a paragraph:"
+msgstr "Za odstavcem:"
+
+#: ../src/richtext/richtextliststylepage.cpp:447
+msgid "Line spacing:"
+msgstr "Řádkování:"
+
+#: ../src/richtext/richtextliststylepage.cpp:470
+msgid "Spacing"
+msgstr "Řádkování"
+
+#: ../src/richtext/richtextmarginspage.cpp:193
+#: ../src/richtext/richtextmarginspage.cpp:195
+msgid "The left margin size."
+msgstr "Velikost okraje vlevo."
+
+#: ../src/richtext/richtextmarginspage.cpp:203
+#: ../src/richtext/richtextmarginspage.cpp:205
+msgid "Units for the left margin."
+msgstr "Jednotky pro levý okraj."
+
+#: ../src/richtext/richtextmarginspage.cpp:218
+#: ../src/richtext/richtextmarginspage.cpp:220
+msgid "The right margin size."
+msgstr "Velikost okraje vpravo."
+
+#: ../src/richtext/richtextmarginspage.cpp:228
+#: ../src/richtext/richtextmarginspage.cpp:230
+msgid "Units for the right margin."
+msgstr "Jednotky pro pravý okraj."
+
+#: ../src/richtext/richtextmarginspage.cpp:241
+#: ../src/richtext/richtextmarginspage.cpp:243
+msgid "The top margin size."
+msgstr "Velikost okraje nahoře."
+
+#: ../src/richtext/richtextmarginspage.cpp:251
+#: ../src/richtext/richtextmarginspage.cpp:253
+msgid "Units for the top margin."
+msgstr "Jednotky pro horní okraj."
+
+#: ../src/richtext/richtextmarginspage.cpp:266
+#: ../src/richtext/richtextmarginspage.cpp:268
+msgid "The bottom margin size."
+msgstr "Velikost okraje dole."
+
+#: ../src/richtext/richtextmarginspage.cpp:276
+#: ../src/richtext/richtextmarginspage.cpp:278
+msgid "Units for the bottom margin."
+msgstr "Jednotky pro dolní okraj."
+
+#: ../src/richtext/richtextmarginspage.cpp:284
+msgid "Padding"
+msgstr "Vnitřní okraj"
+
+#: ../src/richtext/richtextmarginspage.cpp:307
+#: ../src/richtext/richtextmarginspage.cpp:309
+msgid "The left padding size."
+msgstr "Velikost vnitřního okraje vlevo."
+
+#: ../src/richtext/richtextmarginspage.cpp:317
+#: ../src/richtext/richtextmarginspage.cpp:319
+msgid "Units for the left padding."
+msgstr "Jednotky pro vnitřní okraj vlevo."
+
+#: ../src/richtext/richtextmarginspage.cpp:332
+#: ../src/richtext/richtextmarginspage.cpp:334
+msgid "The right padding size."
+msgstr "Velikost vnitřního okraje vpravo."
+
+#: ../src/richtext/richtextmarginspage.cpp:342
+#: ../src/richtext/richtextmarginspage.cpp:344
+msgid "Units for the right padding."
+msgstr "Jednotky pro vnitřní okraj vpravo."
+
+#: ../src/richtext/richtextmarginspage.cpp:355
+#: ../src/richtext/richtextmarginspage.cpp:357
+msgid "The top padding size."
+msgstr "Velikost vnitřního okraje nahoře."
+
+#: ../src/richtext/richtextmarginspage.cpp:365
+#: ../src/richtext/richtextmarginspage.cpp:367
+msgid "Units for the top padding."
+msgstr "Jednotky pro vnitřní okraj nahoře."
+
+#: ../src/richtext/richtextmarginspage.cpp:380
+#: ../src/richtext/richtextmarginspage.cpp:382
+msgid "The bottom padding size."
+msgstr "Velikost vnitřního okraje dole."
+
+#: ../src/richtext/richtextmarginspage.cpp:390
+#: ../src/richtext/richtextmarginspage.cpp:392
+msgid "Units for the bottom padding."
+msgstr "Jednotky pro vnitřní okraj dole."
+
+#: ../src/richtext/richtextprint.cpp:592
+msgid " Preview"
+msgstr " Náhled"
+
+#: ../src/richtext/richtextsizepage.cpp:228
+msgid "Floating"
+msgstr "Obtékání"
+
+#: ../src/richtext/richtextsizepage.cpp:243
+msgid "&Floating mode:"
+msgstr "&Režim obtékání:"
+
+#: ../src/richtext/richtextsizepage.cpp:252
+#: ../src/richtext/richtextsizepage.cpp:254
+msgid "How the object will float relative to the text."
+msgstr "Jak bude text obtékat vzhledem k objektu."
+
+#: ../src/richtext/richtextsizepage.cpp:265
+msgid "Alignment"
+msgstr "Zarovnání"
+
+#: ../src/richtext/richtextsizepage.cpp:277
+msgid "&Vertical alignment:"
+msgstr "&Svislé zarovnání:"
+
+#: ../src/richtext/richtextsizepage.cpp:279
+#: ../src/richtext/richtextsizepage.cpp:281
+msgid "Enable vertical alignment."
+msgstr "Povolit svislé zarovnání."
+
+#: ../src/richtext/richtextsizepage.cpp:286
+msgid "Centred"
+msgstr "Na střed"
+
+#: ../src/richtext/richtextsizepage.cpp:290
+#: ../src/richtext/richtextsizepage.cpp:292
+msgid "Vertical alignment."
+msgstr "Svislé zarovnání."
+
+#: ../src/richtext/richtextsizepage.cpp:316
+#: ../src/richtext/richtextsizepage.cpp:323
+msgid "&Width:"
+msgstr "Šíř&ka:"
+
+#: ../src/richtext/richtextsizepage.cpp:318
+#: ../src/richtext/richtextsizepage.cpp:320
+msgid "Enable the width value."
+msgstr "Povolit hodnotu šířky."
+
+#: ../src/richtext/richtextsizepage.cpp:331
+#: ../src/richtext/richtextsizepage.cpp:333
+msgid "The object width."
+msgstr "Šířka objektu."
+
+#: ../src/richtext/richtextsizepage.cpp:342
+#: ../src/richtext/richtextsizepage.cpp:344
+msgid "Units for the object width."
+msgstr "Jednotky pro šířku objektu."
+
+#: ../src/richtext/richtextsizepage.cpp:350
+#: ../src/richtext/richtextsizepage.cpp:357
+msgid "&Height:"
+msgstr "&Výška:"
+
+#: ../src/richtext/richtextsizepage.cpp:352
+#: ../src/richtext/richtextsizepage.cpp:354
+#: ../src/richtext/richtextsizepage.cpp:464
+#: ../src/richtext/richtextsizepage.cpp:466
+msgid "Enable the height value."
+msgstr "Povolit hodnotu výšky."
+
+#: ../src/richtext/richtextsizepage.cpp:365
+#: ../src/richtext/richtextsizepage.cpp:367
+msgid "The object height."
+msgstr "Výška objektu."
+
+#: ../src/richtext/richtextsizepage.cpp:376
+#: ../src/richtext/richtextsizepage.cpp:378
+msgid "Units for the object height."
+msgstr "Jednotky pro výšku objektu."
+
+#: ../src/richtext/richtextsizepage.cpp:381
+msgid "Min width:"
+msgstr "Min šířka:"
+
+#: ../src/richtext/richtextsizepage.cpp:383
+#: ../src/richtext/richtextsizepage.cpp:385
+msgid "Enable the minimum width value."
+msgstr "Povolit minimální hodnotu šířky."
+
+#: ../src/richtext/richtextsizepage.cpp:392
+#: ../src/richtext/richtextsizepage.cpp:394
+msgid "The object minimum width."
+msgstr "Minimální šířka objektu."
+
+#: ../src/richtext/richtextsizepage.cpp:403
+#: ../src/richtext/richtextsizepage.cpp:405
+msgid "Units for the minimum object width."
+msgstr "Jednotky pro minimální šířku objektu."
+
+#: ../src/richtext/richtextsizepage.cpp:408
+msgid "Min height:"
+msgstr "Min výška:"
+
+#: ../src/richtext/richtextsizepage.cpp:410
+#: ../src/richtext/richtextsizepage.cpp:412
+msgid "Enable the minimum height value."
+msgstr "Povolit minimální hodnotu výšky."
+
+#: ../src/richtext/richtextsizepage.cpp:419
+#: ../src/richtext/richtextsizepage.cpp:421
+msgid "The object minimum height."
+msgstr "Minimální výška objektu."
+
+#: ../src/richtext/richtextsizepage.cpp:430
+#: ../src/richtext/richtextsizepage.cpp:432
+msgid "Units for the minimum object height."
+msgstr "Jednotky pro minimální výšku objektu."
+
+#: ../src/richtext/richtextsizepage.cpp:435
+msgid "Max width:"
+msgstr "Max šířka:"
+
+#: ../src/richtext/richtextsizepage.cpp:437
+#: ../src/richtext/richtextsizepage.cpp:439
+msgid "Enable the maximum width value."
+msgstr "Povolit maximální hodnotu šířky."
+
+#: ../src/richtext/richtextsizepage.cpp:446
+#: ../src/richtext/richtextsizepage.cpp:448
+msgid "The object maximum width."
+msgstr "Maximální šířka objektu."
+
+#: ../src/richtext/richtextsizepage.cpp:457
+#: ../src/richtext/richtextsizepage.cpp:459
+msgid "Units for the maximum object width."
+msgstr "Jednotky pro maximální šířku objektu."
+
+#: ../src/richtext/richtextsizepage.cpp:462
+msgid "Max height:"
+msgstr "Max šířka:"
+
+#: ../src/richtext/richtextsizepage.cpp:473
+#: ../src/richtext/richtextsizepage.cpp:475
+msgid "The object maximum height."
+msgstr "Maximální výška objektu."
+
+#: ../src/richtext/richtextsizepage.cpp:484
+#: ../src/richtext/richtextsizepage.cpp:486
+msgid "Units for the maximum object height."
+msgstr "Jednotky pro maximální výšku objektu."
+
+#: ../src/richtext/richtextsizepage.cpp:495
+msgid "Position"
+msgstr "Pozice"
+
+#: ../src/richtext/richtextsizepage.cpp:513
+msgid "&Position mode:"
+msgstr "&Režim pozice:"
+
+#: ../src/richtext/richtextsizepage.cpp:517
+#: ../src/richtext/richtextsizepage.cpp:522
+msgid "Static"
+msgstr "Statické"
+
+#: ../src/richtext/richtextsizepage.cpp:518
+msgid "Relative"
+msgstr "Relativní"
+
+#: ../src/richtext/richtextsizepage.cpp:519
+msgid "Absolute"
+msgstr "Absolutní"
+
+#: ../src/richtext/richtextsizepage.cpp:520
+msgid "Fixed"
+msgstr "Pevná"
+
+#: ../src/richtext/richtextsizepage.cpp:533
+#: ../src/richtext/richtextsizepage.cpp:535
+#: ../src/richtext/richtextsizepage.cpp:547
+#: ../src/richtext/richtextsizepage.cpp:549
+msgid "The left position."
+msgstr "Pozice vlevo."
+
+#: ../src/richtext/richtextsizepage.cpp:558
+#: ../src/richtext/richtextsizepage.cpp:560
+msgid "Units for the left position."
+msgstr "Jednotky pro pozici vlevo."
+
+#: ../src/richtext/richtextsizepage.cpp:568
+#: ../src/richtext/richtextsizepage.cpp:570
+#: ../src/richtext/richtextsizepage.cpp:582
+#: ../src/richtext/richtextsizepage.cpp:584
+msgid "The top position."
+msgstr "Horní pozice."
+
+#: ../src/richtext/richtextsizepage.cpp:593
+#: ../src/richtext/richtextsizepage.cpp:595
+msgid "Units for the top position."
+msgstr "Jednotky pro horní pozici."
+
+#: ../src/richtext/richtextsizepage.cpp:603
+#: ../src/richtext/richtextsizepage.cpp:605
+#: ../src/richtext/richtextsizepage.cpp:617
+#: ../src/richtext/richtextsizepage.cpp:619
+msgid "The right position."
+msgstr "Pozice vpravo."
+
+#: ../src/richtext/richtextsizepage.cpp:628
+#: ../src/richtext/richtextsizepage.cpp:630
+msgid "Units for the right position."
+msgstr "Jednotky pro pozici vpravo."
+
+#: ../src/richtext/richtextsizepage.cpp:638
+#: ../src/richtext/richtextsizepage.cpp:640
+#: ../src/richtext/richtextsizepage.cpp:652
+#: ../src/richtext/richtextsizepage.cpp:654
+msgid "The bottom position."
+msgstr "Dolní pozice."
+
+#: ../src/richtext/richtextsizepage.cpp:663
+#: ../src/richtext/richtextsizepage.cpp:665
+msgid "Units for the bottom position."
+msgstr "Jednotky pro dolní pozici."
+
+#: ../src/richtext/richtextsizepage.cpp:671
+msgid "&Move the object to:"
+msgstr "&Přesunout objekt do:"
+
+#: ../src/richtext/richtextsizepage.cpp:674
+msgid "&Previous Paragraph"
+msgstr "&Předchozí odstavec"
+
+#: ../src/richtext/richtextsizepage.cpp:675
+#: ../src/richtext/richtextsizepage.cpp:677
+msgid "Moves the object to the previous paragraph."
+msgstr "Přesune objekt do předchozího odstavce."
+
+#: ../src/richtext/richtextsizepage.cpp:680
+msgid "&Next Paragraph"
+msgstr "&Další odstavec"
+
+#: ../src/richtext/richtextsizepage.cpp:681
+#: ../src/richtext/richtextsizepage.cpp:683
+msgid "Moves the object to the next paragraph."
+msgstr "Přesune objekt do dalšího odstavce."
+
+#: ../src/richtext/richtextstyledlg.cpp:193
+msgid "&Styles:"
+msgstr "&Styly:"
+
+#: ../src/richtext/richtextstyledlg.cpp:197
+#: ../src/richtext/richtextstyledlg.cpp:199
+msgid "The available styles."
+msgstr "Dostupné styly."
+
+#: ../src/richtext/richtextstyledlg.cpp:205
+#: ../src/richtext/richtextstyledlg.cpp:217
+msgid " "
+msgstr " "
+
+#: ../src/richtext/richtextstyledlg.cpp:209
+#: ../src/richtext/richtextstyledlg.cpp:211
+msgid "The style preview."
+msgstr "Náhled stylu."
+
+#: ../src/richtext/richtextstyledlg.cpp:220
+msgid "New &Character Style..."
+msgstr "&Nový styl znaku..."
+
+#: ../src/richtext/richtextstyledlg.cpp:221
+#: ../src/richtext/richtextstyledlg.cpp:223
+msgid "Click to create a new character style."
+msgstr "Klikněte pro vytvoření nového stylu znaků."
+
+#: ../src/richtext/richtextstyledlg.cpp:226
+msgid "New &Paragraph Style..."
+msgstr "&Nový styl odstavce..."
+
+#: ../src/richtext/richtextstyledlg.cpp:227
+#: ../src/richtext/richtextstyledlg.cpp:229
+msgid "Click to create a new paragraph style."
+msgstr "Klikněte pro vytvoření nového stylu odstavce."
+
+#: ../src/richtext/richtextstyledlg.cpp:232
+msgid "New &List Style..."
+msgstr "Nový Sty&l seznamu..."
+
+#: ../src/richtext/richtextstyledlg.cpp:233
+#: ../src/richtext/richtextstyledlg.cpp:235
+msgid "Click to create a new list style."
+msgstr "Klikněte pro vytvoření nového stylu seznamu."
+
+#: ../src/richtext/richtextstyledlg.cpp:238
+msgid "New &Box Style..."
+msgstr "Nový &styl rámečku..."
+
+#: ../src/richtext/richtextstyledlg.cpp:239
+#: ../src/richtext/richtextstyledlg.cpp:241
+msgid "Click to create a new box style."
+msgstr "Klikněte pro vytvoření nového stylu rámečku."
+
+#: ../src/richtext/richtextstyledlg.cpp:246
+msgid "&Apply Style"
+msgstr "&Použít styl"
+
+#: ../src/richtext/richtextstyledlg.cpp:247
+#: ../src/richtext/richtextstyledlg.cpp:249
+msgid "Click to apply the selected style."
+msgstr "Klikněte pro použití vybraného stylu."
+
+#: ../src/richtext/richtextstyledlg.cpp:252
+msgid "&Rename Style..."
+msgstr "&Přejmenovat styl..."
+
+#: ../src/richtext/richtextstyledlg.cpp:253
+#: ../src/richtext/richtextstyledlg.cpp:255
+msgid "Click to rename the selected style."
+msgstr "Klikněte pro přejmenování vybraného stylu."
+
+#: ../src/richtext/richtextstyledlg.cpp:258
+msgid "&Edit Style..."
+msgstr "&Upravit styl..."
+
+#: ../src/richtext/richtextstyledlg.cpp:259
+#: ../src/richtext/richtextstyledlg.cpp:261
+msgid "Click to edit the selected style."
+msgstr "Klikněte pro úpravu vybraného stylu."
+
+#: ../src/richtext/richtextstyledlg.cpp:264
+msgid "&Delete Style..."
+msgstr "O&dstranit styl..."
+
+#: ../src/richtext/richtextstyledlg.cpp:265
+#: ../src/richtext/richtextstyledlg.cpp:267
+msgid "Click to delete the selected style."
+msgstr "Klikněte pro vymazání vybraného stylu."
+
+#: ../src/richtext/richtextstyledlg.cpp:274
+#: ../src/richtext/richtextstyledlg.cpp:276
+msgid "Click to close this window."
+msgstr "Klikněte pro zavření tohoto okna."
+
+#: ../src/richtext/richtextstyledlg.cpp:282
+msgid "&Restart numbering"
+msgstr "&Restartovat číslování"
+
+#: ../src/richtext/richtextstyledlg.cpp:284
+#: ../src/richtext/richtextstyledlg.cpp:286
+msgid "Check to restart numbering."
+msgstr "Zaškrtněte pro číslování od začátku."
+
+#: ../src/richtext/richtextstyledlg.cpp:601
+msgid "Enter a character style name"
+msgstr "Zadejte název stylu znaku"
+
+#: ../src/richtext/richtextstyledlg.cpp:601
+#: ../src/richtext/richtextstyledlg.cpp:606
+#: ../src/richtext/richtextstyledlg.cpp:649
+#: ../src/richtext/richtextstyledlg.cpp:654
+#: ../src/richtext/richtextstyledlg.cpp:815
+#: ../src/richtext/richtextstyledlg.cpp:820
+#: ../src/richtext/richtextstyledlg.cpp:888
+#: ../src/richtext/richtextstyledlg.cpp:896
+#: ../src/richtext/richtextstyledlg.cpp:929
+#: ../src/richtext/richtextstyledlg.cpp:934
+msgid "New Style"
+msgstr "Nový styl"
+
+#: ../src/richtext/richtextstyledlg.cpp:606
+#: ../src/richtext/richtextstyledlg.cpp:654
+#: ../src/richtext/richtextstyledlg.cpp:820
+#: ../src/richtext/richtextstyledlg.cpp:896
+#: ../src/richtext/richtextstyledlg.cpp:934
+msgid "Sorry, that name is taken. Please choose another."
+msgstr "Je nám líto, toto jméno je zabrané. Vyberte si, prosím, jiné."
+
+#: ../src/richtext/richtextstyledlg.cpp:649
+msgid "Enter a paragraph style name"
+msgstr "Zadejte název stylu odstavce"
+
+#: ../src/richtext/richtextstyledlg.cpp:777
+#, c-format
+msgid "Delete style %s?"
+msgstr "Odstranit styl %s?"
+
+#: ../src/richtext/richtextstyledlg.cpp:777
+msgid "Delete Style"
+msgstr "Smazat styl"
+
+#: ../src/richtext/richtextstyledlg.cpp:815
+msgid "Enter a list style name"
+msgstr "Zadejte název stylu odrážek"
+
+#: ../src/richtext/richtextstyledlg.cpp:888
+msgid "Enter a new style name"
+msgstr "Zadejte nový název stylu"
+
+#: ../src/richtext/richtextstyledlg.cpp:929
+msgid "Enter a box style name"
+msgstr "Zadejte název stylu rámečku"
+
+#: ../src/richtext/richtextstylepage.cpp:109
+#: ../src/richtext/richtextstylepage.cpp:111
+msgid "The style name."
+msgstr "Jméno stylu."
+
+#: ../src/richtext/richtextstylepage.cpp:114
+msgid "&Based on:"
+msgstr "&Založeno na:"
+
+#: ../src/richtext/richtextstylepage.cpp:119
+#: ../src/richtext/richtextstylepage.cpp:121
+msgid "The style on which this style is based."
+msgstr "Styl, na kterém je tento styl založen."
+
+#: ../src/richtext/richtextstylepage.cpp:124
+msgid "&Next style:"
+msgstr "&Další styl:"
+
+#: ../src/richtext/richtextstylepage.cpp:129
+#: ../src/richtext/richtextstylepage.cpp:131
+msgid "The default style for the next paragraph."
+msgstr "Výchozí styl pro další odstavec."
+
+#: ../src/richtext/richtextstyles.cpp:1057
+msgid "All styles"
+msgstr "Všechny styly"
+
+#: ../src/richtext/richtextstyles.cpp:1058
+msgid "Paragraph styles"
+msgstr "Styly odstavce"
+
+#: ../src/richtext/richtextstyles.cpp:1059
+msgid "Character styles"
+msgstr "Styly znaků"
+
+#: ../src/richtext/richtextstyles.cpp:1060
+msgid "List styles"
+msgstr "Styly seznamů"
+
+#: ../src/richtext/richtextstyles.cpp:1061
+msgid "Box styles"
+msgstr "Styly rámečku"
+
+#: ../src/richtext/richtextsymboldlg.cpp:389
+#: ../src/richtext/richtextsymboldlg.cpp:391
+msgid "The font from which to take the symbol."
+msgstr "Písmo, z kterého použít symbol."
+
+#: ../src/richtext/richtextsymboldlg.cpp:396
+msgid "&Subset:"
+msgstr "Pod&skupina:"
+
+#: ../src/richtext/richtextsymboldlg.cpp:401
+#: ../src/richtext/richtextsymboldlg.cpp:403
+msgid "Shows a Unicode subset."
+msgstr "Zobrazí podskupinu Unicode."
+
+#: ../src/richtext/richtextsymboldlg.cpp:412
+msgid "xxxx"
+msgstr "xxxx"
+
+#: ../src/richtext/richtextsymboldlg.cpp:417
+msgid "&Character code:"
+msgstr "Kód &znaku:"
+
+#: ../src/richtext/richtextsymboldlg.cpp:421
+#: ../src/richtext/richtextsymboldlg.cpp:423
+msgid "The character code."
+msgstr "Kód znaku."
+
+#: ../src/richtext/richtextsymboldlg.cpp:428
+msgid "&From:"
+msgstr "&Od:"
+
+#: ../src/richtext/richtextsymboldlg.cpp:433
+#: ../src/richtext/richtextsymboldlg.cpp:434
+#: ../src/richtext/richtextsymboldlg.cpp:435
+msgid "Unicode"
+msgstr "Unicode"
+
+#: ../src/richtext/richtextsymboldlg.cpp:436
+#: ../src/richtext/richtextsymboldlg.cpp:438
+msgid "The range to show."
+msgstr "Rozsah k zobrazení."
+
+#: ../src/richtext/richtextsymboldlg.cpp:444
+msgid "Insert"
+msgstr "Insert"
+
+#: ../src/richtext/richtextsymboldlg.cpp:478
+msgid "(Normal text)"
+msgstr "(Normální text)"
+
+#: ../src/richtext/richtexttabspage.cpp:109
+msgid "&Position (tenths of a mm):"
+msgstr "&Pozice (desetiny mm):"
+
+#: ../src/richtext/richtexttabspage.cpp:113
+#: ../src/richtext/richtexttabspage.cpp:115
+msgid "The tab position."
+msgstr "Pozice tabulátoru."
+
+#: ../src/richtext/richtexttabspage.cpp:119
+msgid "The tab positions."
+msgstr "Pozice tabulátorů."
+
+#: ../src/richtext/richtexttabspage.cpp:132
+#: ../src/richtext/richtexttabspage.cpp:134
+msgid "Click to create a new tab position."
+msgstr "Klikněte pro vytvoření nové pozice tabulátoru."
+
+#: ../src/richtext/richtexttabspage.cpp:138
+#: ../src/richtext/richtexttabspage.cpp:140
+msgid "Click to delete the selected tab position."
+msgstr "Klikněte pro smazání pozic vybraných tabulátorů."
+
+#: ../src/richtext/richtexttabspage.cpp:143
+msgid "Delete A&ll"
+msgstr "Smazat &vše"
+
+#: ../src/richtext/richtexttabspage.cpp:144
+#: ../src/richtext/richtexttabspage.cpp:146
+msgid "Click to delete all tab positions."
+msgstr "Klikněte pro smazání všech pozicí tabulátorů."
+
+#: ../src/univ/theme.cpp:110
+msgid "Failed to initialize GUI: no built-in themes found."
+msgstr "Nelze zavést GUI: nebyly nalezeny žádné zabudované vzhledy."
+
+#: ../src/univ/themes/gtk.cpp:521
+msgid "GTK+ theme"
+msgstr "GTK+ téma"
+
+#: ../src/univ/themes/metal.cpp:164
+msgid "Metal theme"
+msgstr "Téma Metal"
+
+#: ../src/univ/themes/mono.cpp:512
+msgid "Simple monochrome theme"
+msgstr "Jednoduchý jednobarevný vzhled"
+
+#: ../src/univ/themes/win32.cpp:1098
+msgid "Win32 theme"
+msgstr "Téma Win32"
+
+#: ../src/univ/themes/win32.cpp:3743
+msgid "&Restore"
+msgstr "&Obnovit"
+
+#: ../src/univ/themes/win32.cpp:3744
+msgid "&Move"
+msgstr "&Přesunout"
+
+#: ../src/univ/themes/win32.cpp:3746
+msgid "&Size"
+msgstr "Veliko&st"
+
+#: ../src/univ/themes/win32.cpp:3748
+msgid "Mi&nimize"
+msgstr "Mi&nimalizovat"
+
+#: ../src/univ/themes/win32.cpp:3750
+msgid "Ma&ximize"
+msgstr "Ma&ximalizovat"
+
+#: ../src/univ/themes/win32.cpp:3752
+msgid "Alt+"
+msgstr "Alt+"
+
+#: ../src/unix/appunix.cpp:178
+msgid "Failed to install signal handler"
+msgstr "Nelze instalovat obslužnou rutinu signálu"
+
+#: ../src/unix/dialup.cpp:351
+msgid "Already dialling ISP."
+msgstr "ISP je už vytáčen."
+
+#: ../src/unix/dlunix.cpp:93
+msgid "Failed to unload shared library"
+msgstr "Nelze uvolnit sdílenou knihovnu"
+
+#: ../src/unix/dlunix.cpp:121
+msgid "Unknown dynamic library error"
+msgstr "Neznámá chyba dynamické knihovny"
+
+#: ../src/unix/epolldispatcher.cpp:84
+msgid "Failed to create epoll descriptor"
+msgstr "Nelze vytvořit epoll popisovače"
+
+#: ../src/unix/epolldispatcher.cpp:103
+msgid "Error closing epoll descriptor"
+msgstr "Chyba při zavírání epoll popisovače"
+
+#: ../src/unix/epolldispatcher.cpp:116
+#, c-format
+msgid "Failed to add descriptor %d to epoll descriptor %d"
+msgstr "Nelze přidat popisovač %d do epoll popisovače %d"
+
+#: ../src/unix/epolldispatcher.cpp:136
+#, c-format
+msgid "Failed to modify descriptor %d in epoll descriptor %d"
+msgstr "Nelze změnit popisovač %d v epoll popisovači %d"
+
+#: ../src/unix/epolldispatcher.cpp:155
+#, c-format
+msgid "Failed to unregister descriptor %d from epoll descriptor %d"
+msgstr "Nelze odregistrovat popisovač %d z epoll popisovače %d"
+
+#: ../src/unix/epolldispatcher.cpp:213
+#, c-format
+msgid "Waiting for IO on epoll descriptor %d failed"
+msgstr "Čekání na IO v epoll popisovači %d selhalo"
+
+#: ../src/unix/fswatcher_inotify.cpp:71
+msgid "Unable to create inotify instance"
+msgstr "Nelze vytvořit instanci inotify"
+
+#: ../src/unix/fswatcher_inotify.cpp:94
+msgid "Unable to close inotify instance"
+msgstr "Nelze uzavřít instanci inotify."
+
+#: ../src/unix/fswatcher_inotify.cpp:106
+msgid "Unable to add inotify watch"
+msgstr "Nelze přidat sledování inotify"
+
+#: ../src/unix/fswatcher_inotify.cpp:138
+#, c-format
+msgid "Unable to remove inotify watch %i"
+msgstr "Nelze odstranit sledování inotify %i"
+
+#: ../src/unix/fswatcher_inotify.cpp:271
+#, c-format
+msgid "Unexpected event for \"%s\": no matching watch descriptor."
+msgstr ""
+"Neočekávaná událost pro \"%s\": žádný odpovídající popisovač sledování."
+
+#: ../src/unix/fswatcher_inotify.cpp:320
+#, c-format
+msgid "Invalid inotify event for \"%s\""
+msgstr "Neplatná událost inotify pro \"%s\""
+
+#: ../src/unix/fswatcher_inotify.cpp:553
+msgid "Unable to read from inotify descriptor"
+msgstr "Nelze číst z popisovače inotify"
+
+#: ../src/unix/fswatcher_inotify.cpp:558
+msgid "EOF while reading from inotify descriptor"
+msgstr "Konec souboru při čtení z popisovače inotify"
+
+#: ../src/unix/fswatcher_kqueue.cpp:114
+msgid "Unable to create kqueue instance"
+msgstr "Nelze vytvořit instanci kqueue"
+
+#: ../src/unix/fswatcher_kqueue.cpp:131
+msgid "Error closing kqueue instance"
+msgstr "Chyba při zavírání instance kqueue"
+
+#: ../src/unix/fswatcher_kqueue.cpp:153
+msgid "Unable to add kqueue watch"
+msgstr "Nelze přidat sledování kqueue"
+
+#: ../src/unix/fswatcher_kqueue.cpp:170
+msgid "Unable to remove kqueue watch"
+msgstr "Nelze odstranit sledování kqueue"
+
+#: ../src/unix/fswatcher_kqueue.cpp:202
+msgid "Unable to get events from kqueue"
+msgstr "Nelze získat události z kqueue"
+
+#: ../src/unix/mediactrl.cpp:966
+#, c-format
+msgid "Media playback error: %s"
+msgstr "Chyba při přehrávání: %s"
+
+#: ../src/unix/mediactrl.cpp:1228
+#, c-format
+msgid "Failed to prepare playing \"%s\"."
+msgstr "\"%s\" nelze připravit k přehrávání."
+
+#: ../src/unix/snglinst.cpp:164
+#, c-format
+msgid "Failed to write to lock file '%s'"
+msgstr "Nelze zapisovat do zámkového souboru '%s'"
+
+#: ../src/unix/snglinst.cpp:177
+#, c-format
+msgid "Failed to set permissions on lock file '%s'"
+msgstr "Nelze nastavit přístupová práva pro zámkový soubor '%s'"
+
+#: ../src/unix/snglinst.cpp:194
+#, c-format
+msgid "Failed to lock the lock file '%s'"
+msgstr "Nelze uzamknout zámkový soubor '%s'"
+
+#: ../src/unix/snglinst.cpp:237
+#, c-format
+msgid "Failed to inspect the lock file '%s'"
+msgstr "Nelze prověřit zámkový soubor '%s'"
+
+#: ../src/unix/snglinst.cpp:242
+#, c-format
+msgid "Lock file '%s' has incorrect owner."
+msgstr "Zámkový soubor '%s' má nesprávného vlastníka."
+
+#: ../src/unix/snglinst.cpp:247
+#, c-format
+msgid "Lock file '%s' has incorrect permissions."
+msgstr "Zámkový soubor '%s' má nesprávná oprávnění."
+
+#: ../src/unix/snglinst.cpp:265
+msgid "Failed to access lock file."
+msgstr "Nelze přistoupit k zámkovému souboru."
+
+#: ../src/unix/snglinst.cpp:274
+msgid "Failed to read PID from lock file."
+msgstr "Nepodařilo se přečíst PID ze zámkového souboru."
+
+#: ../src/unix/snglinst.cpp:284
+#, c-format
+msgid "Failed to remove stale lock file '%s'."
+msgstr "Nelze odstranit starý zámkový soubor '%s'."
+
+#: ../src/unix/snglinst.cpp:297
+#, c-format
+msgid "Deleted stale lock file '%s'."
+msgstr "Smazán starý zámkový soubor '%s'."
+
+#: ../src/unix/snglinst.cpp:308
+#, c-format
+msgid "Invalid lock file '%s'."
+msgstr "Chybný zamykací soubor '%s'."
+
+#: ../src/unix/snglinst.cpp:324
+#, c-format
+msgid "Failed to remove lock file '%s'"
+msgstr "Nelze odstranit zámkový soubor '%s'"
+
+#: ../src/unix/snglinst.cpp:330
+#, c-format
+msgid "Failed to unlock lock file '%s'"
+msgstr "Nelze odemknout zámkový soubor '%s'"
+
+#: ../src/unix/snglinst.cpp:336
+#, c-format
+msgid "Failed to close lock file '%s'"
+msgstr "Nelze uzavřít zámkový soubor '%s'"
+
+#: ../src/unix/sound.cpp:77
+msgid "No sound"
+msgstr "Beze zvuku"
+
+#: ../src/unix/sound.cpp:364
+msgid "Unable to play sound asynchronously."
+msgstr "Nelze přehrát zvuk asynchronně."
+
+#: ../src/unix/sound.cpp:458
+#, c-format
+msgid "Couldn't load sound data from '%s'."
+msgstr "Nelze načíst zvuková data z '%s'."
+
+#: ../src/unix/sound.cpp:465
+#, c-format
+msgid "Sound file '%s' is in unsupported format."
+msgstr "Zvukový soubor '%s' je v nepodporovaném formátu."
+
+#: ../src/unix/sound.cpp:480
+msgid "Sound data are in unsupported format."
+msgstr "Zvuková data jsou v nepodporovaném formátu."
+
+#: ../src/unix/sound_sdl.cpp:226
+#, c-format
+msgid "Couldn't open audio: %s"
+msgstr "Nelze otevřít zvuk: %s"
+
+#: ../src/unix/threadpsx.cpp:1033
+msgid "Cannot retrieve thread scheduling policy."
+msgstr "Nelze získat plánovací politiku vlákna."
+
+#: ../src/unix/threadpsx.cpp:1058
+#, c-format
+msgid "Cannot get priority range for scheduling policy %d."
+msgstr "Nelze zjistit rozsah priorit pro plánovací politiku %d."
+
+#: ../src/unix/threadpsx.cpp:1066
+msgid "Thread priority setting is ignored."
+msgstr "Nastavení priority vlákna je ignorováno."
+
+#: ../src/unix/threadpsx.cpp:1221
+msgid ""
+"Failed to join a thread, potential memory leak detected - please restart the "
+"program"
+msgstr ""
+"Nelze připojit vlákno, zjištěna možná chybná alokace paměti - restartujte "
+"prosím program"
+
+#: ../src/unix/threadpsx.cpp:1352
+#, c-format
+msgid "Failed to set thread concurrency level to %lu"
+msgstr "Nelze nastavit úroveň souběžnosti vlákna na %lu"
+
+#: ../src/unix/threadpsx.cpp:1481
+#, c-format
+msgid "Failed to set thread priority %d."
+msgstr "Nelze nastavit prioritu vlákna %d."
+
+#: ../src/unix/threadpsx.cpp:1666
+msgid "Failed to terminate a thread."
+msgstr "Nelze ukončit vlákno."
+
+#: ../src/unix/threadpsx.cpp:1893
+msgid "Thread module initialization failed: failed to create thread key"
+msgstr "Selhalo zavedení modulu s vlákny: nelze vytvořit klíč vlákna"
+
+#: ../src/unix/utilsunx.cpp:340
+msgid "Impossible to get child process input"
+msgstr "Není možné získat vstup synovského procesu"
+
+#: ../src/unix/utilsunx.cpp:390
+msgid "Can't write to child process's stdin"
+msgstr "Nelze zapisovat na std. výstup podřazeného procesu"
+
+#: ../src/unix/utilsunx.cpp:644
+#, c-format
+msgid "Failed to execute '%s'\n"
+msgstr "Nelze spustit '%s'\n"
+
+#: ../src/unix/utilsunx.cpp:678
+msgid "Fork failed"
+msgstr "Selhalo forkování"
+
+#: ../src/unix/utilsunx.cpp:701
+msgid "Failed to set process priority"
+msgstr "Nelze nastavit prioritu procesu"
+
+#: ../src/unix/utilsunx.cpp:712
+msgid "Failed to redirect child process input/output"
+msgstr "Nepodařilo se přesměrovat vstup/výstup synovského procesu"
+
+#: ../src/unix/utilsunx.cpp:816
+msgid "Failed to set up non-blocking pipe, the program might hang."
+msgstr "Nelze nastavit neblokující rouru, program se může zaseknout."
+
+#: ../src/unix/utilsunx.cpp:1023
+msgid "Cannot get the hostname"
+msgstr "Nelze zjistit jméno počítače"
+
+#: ../src/unix/utilsunx.cpp:1059
+msgid "Cannot get the official hostname"
+msgstr "Nelze zjistit oficiální jméno počítače"
+
+#: ../src/unix/wakeuppipe.cpp:49
+msgid "Failed to create wake up pipe used by event loop."
+msgstr "Nelze vytvořit probouzecí rouru používanou smyčkou událostí."
+
+#: ../src/unix/wakeuppipe.cpp:56
+msgid "Failed to switch wake up pipe to non-blocking mode"
+msgstr "Nelze přepnout rouru buzení do neblokovacího režimu"
+
+#: ../src/unix/wakeuppipe.cpp:117
+msgid "Failed to read from wake-up pipe"
+msgstr "Nelze číst z probouzecí roury"
+
+#: ../src/x11/app.cpp:124
+#, c-format
+msgid "Invalid geometry specification '%s'"
+msgstr "Špatné určení geometrie '%s'."
+
+#: ../src/x11/app.cpp:167
+msgid "wxWidgets could not open display. Exiting."
+msgstr "wxWidgets nemůže otevřít zobrazení. Ukončeno."
+
+#: ../src/x11/utils.cpp:169
+#, c-format
+msgid "Failed to close the display \"%s\""
+msgstr "Nelze uzavřít zobrazení \"%s\""
+
+#: ../src/x11/utils.cpp:188
+#, c-format
+msgid "Failed to open display \"%s\"."
+msgstr "Nelze otevřít zobrazení \"%s\"."
+
+#: ../src/xml/xml.cpp:868
+#, c-format
+msgid "XML parsing error: '%s' at line %d"
+msgstr "Chyba při načítání XML: '%s' na řádce %d"
+
+#: ../src/xrc/xh_propgrid.cpp:239
+#, c-format
+msgid "Page %i"
+msgstr "Strana %i"
+
+#: ../src/xrc/xmlres.cpp:448
+#, c-format
+msgid "Cannot load resources from '%s'."
+msgstr "Nelze načíst zdroje z '%s'."
+
+#: ../src/xrc/xmlres.cpp:799
+#, c-format
+msgid "Cannot open resources file '%s'."
+msgstr "Nelze otevřít soubor zdrojů '%s'."
+
+#: ../src/xrc/xmlres.cpp:806
+#, c-format
+msgid "Cannot load resources from file '%s'."
+msgstr "Nelze načíst zdroje ze souboru '%s'."
+
+#: ../src/xrc/xmlres.cpp:2767
+#, c-format
+msgid "Creating %s \"%s\" failed."
+msgstr "Vytvoření %s \"%s\" selhalo."
+
+#, c-format
+#~ msgid "BMP: header has biClrUsed=%d when biBitCount=%d."
+#~ msgstr "BMP: hlavička obsahuje biClrUsed=%d když biBitCount=%d."
+
+#~ msgctxt "keyboard key"
+#~ msgid "Alt+"
+#~ msgstr "Alt+"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Ctrl+"
+#~ msgstr "Ctrl+"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Shift+"
+#~ msgstr "Shift+"
+
+#~ msgctxt "keyboard key"
+#~ msgid "RawCtrl+"
+#~ msgstr "RawCtrl+"
+
+#~ msgid "Copying more than one selected block to clipboard is not supported."
+#~ msgstr "Kopírování více bloků najednou do Schránky není podporováno."
+
+#~ msgid "Unsupported clipboard format."
+#~ msgstr "Nepodporovaný formát obsahu schránky."
+
+#~ msgid "Background colour"
+#~ msgstr "Barva pozadí"
+
+#~ msgid "Font:"
+#~ msgstr "Písmo:"
+
+#~ msgid "Size:"
+#~ msgstr "Velikost:"
+
+#~ msgid "The font size in points."
+#~ msgstr "Velikost písma v bodech."
+
+#~ msgid "Style:"
+#~ msgstr "Styl:"
+
+#~ msgid "Check to make the font bold."
+#~ msgstr "Zaškrtněte pro tučné písmo."
+
+#~ msgid "Check to make the font italic."
+#~ msgstr "Zaškrtněte pro kurzívu."
+
+#~ msgid "Check to make the font underlined."
+#~ msgstr "Zaškrtněte pro podtržené písmo."
+
+#~ msgid "Colour:"
+#~ msgstr "Barva:"
+
+#~ msgid "Click to change the font colour."
+#~ msgstr "Klikněte pro změnu barvy písma."
+
+#~ msgid "Shows a preview of the font."
+#~ msgstr "Zobrazí náhled písma."
+
+#~ msgid "Click to cancel changes to the font."
+#~ msgstr "Klikněte pro zrušení změn v písmu."
+
+#~ msgid "Click to confirm changes to the font."
+#~ msgstr "Klikněte pro potvrzení změn textu."
+
+#~ msgid "<Any>"
+#~ msgstr "<Libovolné>"
+
+#~ msgid "<Any Roman>"
+#~ msgstr "<Libovolné patkové>"
+
+#~ msgid "<Any Decorative>"
+#~ msgstr "<Libovolné ozdobné>"
+
+#~ msgid "<Any Modern>"
+#~ msgstr "<Libovolné moderní>"
+
+#~ msgid "<Any Script>"
+#~ msgstr "<Libovolné psací>"
+
+#~ msgid "<Any Swiss>"
+#~ msgstr "<Libovolné bezpatkové>"
+
+#~ msgid "<Any Teletype>"
+#~ msgstr "<Libovolné neproporcionální>"
+
+#~ msgid "Printing "
+#~ msgstr "Tisk "
+
+#~ msgid "Failed to insert text in the control."
+#~ msgstr "Do textového pole nelze vložit text."
+
+#~ msgid "Please choose a valid font."
+#~ msgstr "Prosím vyberte platný font."
+
+#, c-format
+#~ msgid "Failed to display HTML document in %s encoding"
+#~ msgstr "Nelze zobrazit HTML dokument v kódování %s"
+
+#, c-format
+#~ msgid "wxWidgets could not open display for '%s': exiting."
+#~ msgstr "wxWidgets nemůže otevřít zobrazení pro '%s': ukončeno."
+
+#~ msgid "Filter"
+#~ msgstr "Filtr"
+
+#~ msgid "Directories"
+#~ msgstr "Adresáře"
+
+#~ msgid "Files"
+#~ msgstr "Soubory"
+
+#~ msgid "Selection"
+#~ msgstr "Výběr"
+
+#~ msgid "conversion to 8-bit encoding failed"
+#~ msgstr "převod do 8bitového kódování selhal"
+
+#~ msgid "failed to retrieve execution result"
+#~ msgstr "nelze získat výsledek spuštění"
+
+#~ msgid " (while overwriting an existing item)"
+#~ msgstr " (při přepisování existující položky)"
+
+#~ msgid "&Save as"
+#~ msgstr "&Uložit jako"
+
+#~ msgid "'%s' doesn't consist only of valid characters"
+#~ msgstr "'%s' neobsahuje pouze platné znaky"
+
+#~ msgid "'%s' should be numeric."
+#~ msgstr "'%s' musí být číslo."
+
+#~ msgid "'%s' should only contain ASCII characters."
+#~ msgstr "'%s' musí obsahovat pouze ASCII znaky."
+
+#~ msgid "'%s' should only contain alphabetic characters."
+#~ msgstr "'%s' musí obsahovat pouze písmena."
+
+#~ msgid "'%s' should only contain alphabetic or numeric characters."
+#~ msgstr "'%s' musí obsahovat pouze písmena nebo číslice."
+
+#~ msgid "'%s' should only contain digits."
+#~ msgstr "'%s' musí obsahovat pouze čísla."
+
+#~ msgid "Can't create window of class %s"
+#~ msgstr "Nelze vytvořit okno třídy %s"
+
+#~ msgid "Couldn't create the overlay window"
+#~ msgstr "Nelze vytvořit okno překrytí"
+
+#~ msgid "Couldn't init the context on the overlay window"
+#~ msgstr "Nelze inicializovat kontext v okně překrytí"
+
+#~ msgid "Failed to convert file \"%s\" to Unicode."
+#~ msgstr "Nelze převést soubor \"%s\" na Unicode."
+
+#~ msgid "Failed to set text in the text control."
+#~ msgstr "Nelze nastavit text v textovém poli."
+
+#~ msgid "Invalid GTK+ command line option, use \"%s --help\""
+#~ msgstr "Neplatná volba příkazové řádky GTK+, použijte \"%s --help\""
+
+#~ msgid "No unused colour in image."
+#~ msgstr "V obrázku není žádná nepoužitá barva."
+
+#~ msgid "Not available"
+#~ msgstr "Není dostupný"
+
+#~ msgid "Replace selection"
+#~ msgstr "Nahradit výběr"
+
+#~ msgid "Save as"
+#~ msgstr "Uložit jako"
+
+#~ msgid "Style Organiser"
+#~ msgstr "Organizátor stylů"
+
+#~ msgid "The following standard GTK+ options are also supported:\n"
+#~ msgstr "Následující standardní volby GTK+ jsou také podporovány:\n"
+
+#~ msgid "You cannot Clear an overlay that is not inited"
+#~ msgstr "Nemůžete použít Clear pro překrytí, které není inicializované"
+
+#~ msgid "You cannot Init an overlay twice"
+#~ msgstr "Překrytí nemůžete inicializovat dvakrát"
+
+#~ msgid "locale '%s' cannot be set."
+#~ msgstr "Místní a jazykové nastavení '%s' nemůže být nastaveno."
+
+#~ msgid "Adding flavor TEXT failed"
+#~ msgstr "Přidání flavor TEXT selhalo"
+
+#~ msgid "Adding flavor utxt failed"
+#~ msgstr "Přidání flavor utxt selhalo"
+
+#~ msgid "Bitmap renderer cannot render value; value type: "
+#~ msgstr "Vykreslovač bitmap nemůže vykreslit hodnotu; typ hodnoty: "
+
+#~ msgid ""
+#~ "Cannot create new column's ID. Probably max. number of columns reached."
+#~ msgstr ""
+#~ "Nelze vytvořit nové ID sloupce. Pravděpodobně byl dosažen limit "
+#~ "maximálního počtu sloupců."
+
+#~ msgid "Column could not be added."
+#~ msgstr "Sloupec nelze přidat."
+
+#~ msgid "Column index not found."
+#~ msgstr "Index sloupce nenalezen."
+
+#~ msgid "Column width could not be determined"
+#~ msgstr "Nelze určit šířku sloupce"
+
+#~ msgid "Column width could not be set."
+#~ msgstr "Nelze nastavit šířku sloupce."
+
+#~ msgid "Confirm registry update"
+#~ msgstr "Potvrďte aktualizaci registru"
+
+#~ msgid "Could not determine column index."
+#~ msgstr "Nelze určit index sloupce."
+
+#~ msgid "Could not determine column's position"
+#~ msgstr "Nelze určit umístění sloupce"
+
+#~ msgid "Could not determine number of columns."
+#~ msgstr "Nelze určit počet sloupců."
+
+#~ msgid "Could not determine number of items"
+#~ msgstr "Nelze určit počet položek."
+
+#~ msgid "Could not get header description."
+#~ msgstr "Nelze získat popis hlavičky."
+
+#~ msgid "Could not get items."
+#~ msgstr "Nelze získat položky."
+
+#~ msgid "Could not get property flags."
+#~ msgstr "Nelze získat příznaky vlastností."
+
+#~ msgid "Could not get selected items."
+#~ msgstr "Nelze získat vybrané položky."
+
+#~ msgid "Could not remove column."
+#~ msgstr "Nelze odstranit sloupec."
+
+#~ msgid "Could not retrieve number of items"
+#~ msgstr "Nelze získat počet položek"
+
+#~ msgid "Could not set column width."
+#~ msgstr "Nelze nastavit šířku sloupce."
+
+#~ msgid "Could not set header description."
+#~ msgstr "Nelze nastavit popis hlavičky."
+
+#~ msgid "Could not set icon."
+#~ msgstr "Nelze nastavit ikonu."
+
+#~ msgid "Could not set maximum width."
+#~ msgstr "Nelze nastavit maximální šířku."
+
+#~ msgid "Could not set minimum width."
+#~ msgstr "Nelze nastavit minimální šířku."
+
+#~ msgid "Could not set property flags."
+#~ msgstr "Nelze nastavit příznak vlastnosti."
+
+#~ msgid "Data object has invalid data format"
+#~ msgstr "Datový objekt má neplatný formát dat"
+
+#~ msgid "Date renderer cannot render value; value type: "
+#~ msgstr "Vykreslovač data nemůže vykreslit hodnotu; typ hodnoty: "
+
+#~ msgid ""
+#~ "Do you want to overwrite the command used to %s files with extension "
+#~ "\"%s\" ?\n"
+#~ "Current value is \n"
+#~ "%s, \n"
+#~ "New value is \n"
+#~ "%s %1"
+#~ msgstr ""
+#~ "Chcete změnit příkaz používaný k %s souborů s příponou \"%s\" ?\n"
+#~ "Stávající hodnota je \n"
+#~ "%s, \n"
+#~ "Nová hodnota je \n"
+#~ "%s %1"
+
+#~ msgid "Failed to retrieve data from the clipboard."
+#~ msgstr "Nelze získat data ze schránky."
+
+#~ msgid "GIF: Invalid gif index."
+#~ msgstr "GIF: Neplatný index."
+
+#~ msgid "GIF: unknown error!!!"
+#~ msgstr "GIF: neznámá chyba!!!"
+
+#~ msgid "Icon & text renderer cannot render value; value type: "
+#~ msgstr "Vykreslovač ikon a textu nemohl vykreslit hodnotu; typ hodnoty: "
+
+#~ msgid "New directory"
+#~ msgstr "Nový adresář"
+
+#~ msgid "Next"
+#~ msgstr "Další"
+
+#~ msgid "No column existing."
+#~ msgstr "Žádný sloupec neexistuje."
+
+#~ msgid "No column for the specified column existing."
+#~ msgstr "Žádný sloupec pro zadaný sloupec neexistuje."
+
+#~ msgid "No column for the specified column position existing."
+#~ msgstr "Žádný sloupec pro zadanou pozici sloupce neexistuje."
+
+#~ msgid ""
+#~ "No renderer or invalid renderer type specified for custom data column."
+#~ msgstr ""
+#~ "Pro vlastní sloupec dat byl zadán žádný nebo neplatný typ vykreslovače."
+
+#~ msgid "No renderer specified for column."
+#~ msgstr "Pro sloupec nebyl určen žádný vykreslovač."
+
+#~ msgid "Number of columns could not be determined."
+#~ msgstr "Nelze určit počet sloupců."
+
+#~ msgid "OpenGL function \"%s\" failed: %s (error %d)"
+#~ msgstr "Funkce OpenGL \"%s\" selhala: %s (chyba %d)"
+
+#~ msgid ""
+#~ "Please install a newer version of comctl32.dll\n"
+#~ "(at least version 4.70 is required but you have %d.%02d)\n"
+#~ "or this program won't operate correctly."
+#~ msgstr ""
+#~ "Nainstalujte si prosím novou verzi knihovny comctl32.dll\n"
+#~ "(je potřeba alespoň verze 4.70, ale vy máte %d.%02d),\n"
+#~ "jinak tento program nebude fungovat správně."
+
+#~ msgid "Pointer to data view control not set correctly."
+#~ msgstr "Ukazatel na ovládací prvek data view není správně nastaven."
+
+#~ msgid "Pointer to model not set correctly."
+#~ msgstr "Ukazatel na model není správně nastaven."
+
+#~ msgid "Progress renderer cannot render value type; value type: "
+#~ msgstr "Vykreslovač průběhu nemůže vykreslit typ hodnoty; typ hodnoty: "
+
+#~ msgid "Rendering failed."
+#~ msgstr "Vykreslování selhalo."
+
+#~ msgid ""
+#~ "Setting directory access times is not supported under this OS version"
+#~ msgstr ""
+#~ "V této verzi OS není nastavení času přístupů do adresáře podporováno"
+
+#~ msgid "Show hidden directories"
+#~ msgstr "Zobrazit skryté adresáře"
+
+#~ msgid "Text renderer cannot render value; value type: "
+#~ msgstr "Vykreslovač textu nemůže hodnotu vykreslit; typ hodnoty:"
+
+#~ msgid "There is no column or renderer for the specified column index."
+#~ msgstr "Pro zadaný index sloupce neexistuje žádný sloupec nebo vykreslovač."
+
+#~ msgid ""
+#~ "This system doesn't support date controls, please upgrade your version of "
+#~ "comctl32.dll"
+#~ msgstr ""
+#~ "Tento systém nepodporuje ovládací prvky pro výběr data, aktualizujte, "
+#~ "prosím, Vaši verzi comctl32.dll"
+
+#~ msgid "Toggle renderer cannot render value; value type: "
+#~ msgstr "Vykreslovač přepínače nemůže vykreslit hodnotu; typ hodnoty: "
+
+#~ msgid "Too many colours in PNG, the image may be slightly blurred."
+#~ msgstr "V PNG je příliš mnoho barev, obrázek může být mírně rozmazaný."
+
+#~ msgid "Unable to handle native drag&drop data"
+#~ msgstr "Nelze zacházet s nativními táhni a pusť daty"
+
+#~ msgid "Unable to initialize Hildon program"
+#~ msgstr "Nelze spustit program Hildon"
+
+#~ msgid "Unknown data format"
+#~ msgstr "Neznámy formát dat"
+
+#~ msgid "Valid pointer to native data view control does not exist"
+#~ msgstr "Platný ukazatel na nativní ovládací prvek data view neexistuje"
+
+#~ msgid "Win32s on Windows 3.1"
+#~ msgstr "Win32s na Windows 3.1"
+
+#~ msgid "Windows 10"
+#~ msgstr "Windows 10"
+
+#~ msgid "Windows 2000"
+#~ msgstr "Windows 2000"
+
+#~ msgid "Windows 7"
+#~ msgstr "Windows 7"
+
+#~ msgid "Windows 8"
+#~ msgstr "Windows 8"
+
+#~ msgid "Windows 8.1"
+#~ msgstr "Windows 8.1"
+
+#~ msgid "Windows 95"
+#~ msgstr "Windows 95"
+
+#~ msgid "Windows 95 OSR2"
+#~ msgstr "Windows 95 OSR2"
+
+#~ msgid "Windows 98"
+#~ msgstr "Windows 98"
+
+#~ msgid "Windows 98 SE"
+#~ msgstr "Windows 98 SE"
+
+#~ msgid "Windows 9x (%d.%d)"
+#~ msgstr "Windows 9x (%d.%d)"
+
+#~ msgid "Windows CE (%d.%d)"
+#~ msgstr "Windows CE (%d.%d)"
+
+#~ msgid "Windows ME"
+#~ msgstr "Windows ME"
+
+#~ msgid "Windows NT %lu.%lu"
+#~ msgstr "Windows NT %lu.%lu"
+
+#~ msgid "Windows Server 10"
+#~ msgstr "Windows Server 10"
+
+#~ msgid "Windows Server 2003"
+#~ msgstr "Windows Server 2003"
+
+#~ msgid "Windows Server 2008"
+#~ msgstr "Windows Server 2008"
+
+#~ msgid "Windows Server 2008 R2"
+#~ msgstr "Windows Server 2008 R2"
+
+#~ msgid "Windows Server 2012"
+#~ msgstr "Windows Server 2012"
+
+#~ msgid "Windows Server 2012 R2"
+#~ msgstr "Windows Server 2012 R2"
+
+#~ msgid "Windows Vista"
+#~ msgstr "Windows Vista"
+
+#~ msgid "Windows XP"
+#~ msgstr "Windows XP"
+
+#~ msgid "can't execute '%s'"
+#~ msgstr "nelze spustit '%s'"
+
+#~ msgid "error opening '%s'"
+#~ msgstr "chyba při otevírání '%s'"
+
+#~ msgid "unknown seek origin"
+#~ msgstr "neznámý počátek pro nastavení pozice"
+
+#~ msgid "wxWidget control pointer is not a data view pointer"
+#~ msgstr "Ukazatel na ovládací prvek wxWidget není ukazatel na data view"
+
+#~ msgid "wxWidget's control not initialized."
+#~ msgstr "Ovládací prvek WxWidgets není zaveden."
+
+#~ msgid "ADD"
+#~ msgstr "PLUS"
+
+#~ msgid "BACK"
+#~ msgstr "BACKSPACE"
+
+#~ msgid "CANCEL"
+#~ msgstr "ZRUŠIT"
+
+#~ msgid "CAPITAL"
+#~ msgstr "KAPITÁLKY"
+
+#~ msgid "CLEAR"
+#~ msgstr "VYČISTIT"
+
+#~ msgid "COMMAND"
+#~ msgstr "PŘÍKAZ"
+
+#~ msgid "Cannot create mutex."
+#~ msgstr "Nelze vytvořit mutex."
+
+#~ msgid "Cannot resume thread %lu"
+#~ msgstr "Nelze obnovit vlákno %lu"
+
+#~ msgid "Cannot suspend thread %lu"
+#~ msgstr "Nelze ukončit vlákno %lu"
+
+#~ msgid "Couldn't acquire a mutex lock"
+#~ msgstr "Nelze získat zámek mutexu"
+
+#~ msgid "Couldn't get hatch style from wxBrush."
+#~ msgstr "Nelze získat styl šrafování z wxBrush."
+
+#~ msgid "Couldn't release a mutex"
+#~ msgstr "Nelze uvolnit mutex"
+
+#~ msgid "DECIMAL"
+#~ msgstr "DES. ČÁRKA"
+
+#~ msgid "DEL"
+#~ msgstr "DEL"
+
+#~ msgid "DELETE"
+#~ msgstr "DELETE"
+
+#~ msgid "DIVIDE"
+#~ msgstr "ROZDĚLIT"
+
+#~ msgid "DOWN"
+#~ msgstr "DOLŮ"
+
+#~ msgid "END"
+#~ msgstr "END"
+
+#~ msgid "ENTER"
+#~ msgstr "ENTER"
+
+#~ msgid "ESC"
+#~ msgstr "ESC"
+
+#~ msgid "ESCAPE"
+#~ msgstr "ESCAPE"
+
+#~ msgid "EXECUTE"
+#~ msgstr "SPUSTIT"
+
+#~ msgid "Execution of command '%s' failed with error: %ul"
+#~ msgstr "Volání příkazu '%s' selhalo s chybou: %ul"
+
+#~ msgid ""
+#~ "File '%s' already exists.\n"
+#~ "Do you want to replace it?"
+#~ msgstr ""
+#~ "Soubor '%s' již existuje.\n"
+#~ "Opravdu ho chcete přepsat?"
+
+#~ msgid "HELP"
+#~ msgstr "NÁPOVĚDA"
+
+#~ msgid "HOME"
+#~ msgstr "HOME"
+
+#~ msgid "INS"
+#~ msgstr "INS"
+
+#~ msgid "INSERT"
+#~ msgstr "INSERT"
+
+#~ msgid "KP_BEGIN"
+#~ msgstr "NK_ZAČÍT"
+
+#~ msgid "KP_DECIMAL"
+#~ msgstr "NK_DES. ČÁRKA"
+
+#~ msgid "KP_DELETE"
+#~ msgstr "NK_DELETE"
+
+#~ msgid "KP_DIVIDE"
+#~ msgstr "NK_LOMENO"
+
+#~ msgid "KP_DOWN"
+#~ msgstr "NK_DOLŮ"
+
+#~ msgid "KP_ENTER"
+#~ msgstr "NK_ENTER"
+
+#~ msgid "KP_EQUAL"
+#~ msgstr "NK_ROVNÁ SE"
+
+#~ msgid "KP_HOME"
+#~ msgstr "NK_HOME"
+
+#~ msgid "KP_INSERT"
+#~ msgstr "NK_INSERT"
+
+#~ msgid "KP_LEFT"
+#~ msgstr "NK_DOLEVA"
+
+#~ msgid "KP_MULTIPLY"
+#~ msgstr "NK_KRÁT"
+
+#~ msgid "KP_NEXT"
+#~ msgstr "NK_DALŠÍ"
+
+#~ msgid "KP_PAGEDOWN"
+#~ msgstr "NK_PAGEDOWN"
+
+#~ msgid "KP_PAGEUP"
+#~ msgstr "NK_PAGEUP"
+
+#~ msgid "KP_PRIOR"
+#~ msgstr "NK_PŘEDCHOZÍ"
+
+#~ msgid "KP_RIGHT"
+#~ msgstr "NK_DOPRAVA"
+
+#~ msgid "KP_SEPARATOR"
+#~ msgstr "NK_ODDĚLOVAČ"
+
+#~ msgid "KP_SPACE"
+#~ msgstr "NK_MEZERNÍK"
+
+#~ msgid "KP_SUBTRACT"
+#~ msgstr "NK_MÍNUS"
+
+#~ msgid "LEFT"
+#~ msgstr "DOLEVA"
+
+#~ msgid "MENU"
+#~ msgstr "MENU"
+
+#~ msgid "NUM_LOCK"
+#~ msgstr "NUM_LOCK"
+
+#~ msgid "PAGEDOWN"
+#~ msgstr "PAGEDOWN"
+
+#~ msgid "PAGEUP"
+#~ msgstr "PAGEUP"
+
+#~ msgid "PAUSE"
+#~ msgstr "PAUSE"
+
+#~ msgid "PGDN"
+#~ msgstr "PGDN"
+
+#~ msgid "PGUP"
+#~ msgstr "PGUP"
+
+#~ msgid "PRINT"
+#~ msgstr "PRINT"
+
+#~ msgid "RETURN"
+#~ msgstr "RETURN"
+
+#~ msgid "RIGHT"
+#~ msgstr "DOPRAVA"
+
+#~ msgid "SCROLL_LOCK"
+#~ msgstr "SCROLL_LOCK"
+
+#~ msgid "SELECT"
+#~ msgstr "VYBRAT"
+
+#~ msgid "SEPARATOR"
+#~ msgstr "ODDĚLOVAČ"
+
+#~ msgid "SNAPSHOT"
+#~ msgstr "SNAPSHOT"
+
+#~ msgid "SPACE"
+#~ msgstr "MEZERNÍK"
+
+#~ msgid "SUBTRACT"
+#~ msgstr "MÍNUS"
+
+#~ msgid "TAB"
+#~ msgstr "TAB"
+
+#~ msgid "The print dialog returned an error."
+#~ msgstr "Dialogové okno tisku vrátilo chybu."
+
+#~ msgid "The wxGtkPrinterDC cannot be used."
+#~ msgstr "Nelze použít wxGtkPrinterDC."
+
+#~ msgid "Timer creation failed."
+#~ msgstr "Vytvoření časovače selhalo."
+
+#~ msgid "UP"
+#~ msgstr "NAHORU"
+
+#~ msgid "WINDOWS_LEFT"
+#~ msgstr "WINDOWS_VLEVO"
+
+#~ msgid "WINDOWS_MENU"
+#~ msgstr "WINDOWS_MENU"
+
+#~ msgid "WINDOWS_RIGHT"
+#~ msgstr "WINDOWS_VPRAVO"
+
+#~ msgid "buffer is too small for Windows directory."
+#~ msgstr "vyrovnávací paměť pro adresář Windows je příliš malá."
+
+#~ msgid "not implemented"
+#~ msgstr "nezavedeno"
+
+#~ msgid "wxPrintout::GetPageInfo gives a null maxPage."
+#~ msgstr "wxPrintout::GetPageInfo dává nulový maxPage."
+
+#~ msgid "Event queue overflowed"
+#~ msgstr "Fronta událostí byla přeplněna"
+
+#~ msgid "percent"
+#~ msgstr "procent"
+
+#~ msgid "Print preview"
+#~ msgstr "Náhled tisku"
+
+#~ msgid "'"
+#~ msgstr "'"
+
+#~ msgid "1"
+#~ msgstr "1"
+
+#~ msgid "10"
+#~ msgstr "10"
+
+#~ msgid "3"
+#~ msgstr "3"
+
+#~ msgid "4"
+#~ msgstr "4"
+
+#~ msgid "5"
+#~ msgstr "5"
+
+#~ msgid "6"
+#~ msgstr "6"
+
+#~ msgid "7"
+#~ msgstr "7"
+
+#~ msgid "8"
+#~ msgstr "8"
+
+#~ msgid "9"
+#~ msgstr "9"
+
+#~ msgid "Can't monitor non-existent path \"%s\" for changes."
+#~ msgstr "Nelze sledovat změny neexistující cesty \"%s\""
+
+#~ msgid "File system containing watched object was unmounted"
+#~ msgstr "Systém souborů obsahující sledovaný objekt byl odpojen"
+
+#~ msgid "&Preview..."
+#~ msgstr "&Náhled..."
+
+#~ msgid "Passing an unkown object to GetObject"
+#~ msgstr "Předávání neznámého objektu do GetObject"
+
+#~ msgid "Preview..."
+#~ msgstr "Náhled..."
+
+#~ msgid "The vertical offset relative to the paragraph."
+#~ msgstr "Svislé posunutí vzhledem k odstavci."
+
+#~ msgid "Units for the object offset."
+#~ msgstr "Jednotky pro posunutí objektu."
+
+#~ msgid "&Save..."
+#~ msgstr "&Uložit..."
+
+#~ msgid "About "
+#~ msgstr "O"
+
+#~ msgid "All files (*.*)|*"
+#~ msgstr "Všechny soubory (*.*)|*"
+
+#~ msgid "Cannot initialize SciTech MGL!"
+#~ msgstr "Nelze zavést knihovnu SciTech MGL!"
+
+#~ msgid "Cannot initialize display."
+#~ msgstr "Nelze zavést zobrazení."
+
+#~ msgid "Cannot start thread: error writing TLS"
+#~ msgstr "Nelze spustit vlákno: chyba zápisu do TLS"
+
+#~ msgid "Close\tAlt-F4"
+#~ msgstr "Zavřít\tAlt-F4"
+
+#~ msgid "Couldn't create cursor."
+#~ msgstr "Nelze vytvořit kurzor."
+
+#~ msgid "Directory '%s' doesn't exist!"
+#~ msgstr "Adresář '%s' neexistuje!"
+
+#~ msgid "Mode %ix%i-%i not available."
+#~ msgstr "Režim %ix%i-%i není k dispozici."
+
+#~ msgid "Paper Size"
+#~ msgstr "Velikost papíru"
+
+#~ msgid "&Goto..."
+#~ msgstr "&Přejít..."
+
+#~ msgid "<<"
+#~ msgstr "<<"
+
+#~ msgid ">>"
+#~ msgstr ">>"
+
+#~ msgid ">>|"
+#~ msgstr ">>|"
+
+#~ msgid "Added item is invalid."
+#~ msgstr "Přidaná položka je neplatná."
+
+#~ msgid "BIG5"
+#~ msgstr "BIG5"
+
+#~ msgid "Can't check image format of file '%s': file does not exist."
+#~ msgstr "Nelze detekovat formát obrázku '%s': soubor neexistuje."
+
+#~ msgid "Can't load image from file '%s': file does not exist."
+#~ msgstr "Nelze načíst obrázek ze souboru '%s': soubor neexistuje."
+
+#~ msgid "Cannot open file '%s'."
+#~ msgstr "Soubor '%s' nelze otevřít."
+
+#~ msgid "Changed item is invalid."
+#~ msgstr "Změněná položka je neplatná."
+
+#~ msgid "Click to cancel this window."
+#~ msgstr "Klikněte pro zrušení okna."
+
+#~ msgid "Click to confirm your selection."
+#~ msgstr "Klikněte pro potvrzení Vašeho výběru"
+
+#~ msgid "Column could not be added to native control."
+#~ msgstr "Sloupec nelze přidat k nativnímu ovládacímu prvku."
+
+#~ msgid "Column does not have a renderer."
+#~ msgstr "Sloupec nemá vykreslovač."
+
+#~ msgid "Column pointer must not be NULL."
+#~ msgstr "Ukazatel na sloupec nesmí být NULL."
+
+#~ msgid "Column's model column has no equivalent in the associated model."
+#~ msgstr "Model sloupce nemá obdobu v přidruženém modelu."
+
+#~ msgid "Could not add column to internal structures."
+#~ msgstr "Nelze přidat sloupec do vnitřních struktur."
+
+#~ msgid "Enter a page number between %d and %d:"
+#~ msgstr "Zadejte číslo stránky mezi %d a %d."
+
+#~ msgid "Failed to create a status bar."
+#~ msgstr "Nelze vytvořit status bar."
+
+#~ msgid "GB-2312"
+#~ msgstr "GB-2312"
+
+#~ msgid "Goto Page"
+#~ msgstr "Jdi na stránku"
+
+#~ msgid ""
+#~ "HTML pagination algorithm generated more than the allowed maximum number "
+#~ "of pages and it can't continue any longer!"
+#~ msgstr ""
+#~ "Algoritmus stránkování HTML vytvořil více než maximálně povolený počet "
+#~ "stránek a nemůže dále pokračovat!"
+
+#~ msgid "I64"
+#~ msgstr "I64"
+
+#~ msgid "Internal error, illegal wxCustomTypeInfo"
+#~ msgstr "Vnitřní chyba, neplatné wxCustomTypeInfo"
+
+#~ msgid "Model pointer not initialized."
+#~ msgstr "Ukazatel modelu není spuštěn."
+
+#~ msgid "No image handler for type %ld defined."
+#~ msgstr "Nebyla stanovena žádná obslužná rutina obrázku pro typ %ld."
+
+#~ msgid "No model associated with control."
+#~ msgstr "S tímto ovládacím prvkem není spojen žádný model."
+
+#~ msgid "Owner not initialized."
+#~ msgstr "Vlastník není inicializován."
+
+#~ msgid "Passed item is invalid."
+#~ msgstr "Předaná položka je neplatná"
+
+#~ msgid "Passing a already registered object to SetObjectName"
+#~ msgstr "Předávání už zaregistrovaného objektu do SetObjectName"
+
+#~ msgid "Pointer to dataview control must not be NULL"
+#~ msgstr "Ukazatel na ovládací prvek data view dat nesmí být NULL"
+
+#~ msgid "Pointer to native control must not be NULL."
+#~ msgstr "Ukazatel na nativní ovládací prvek nesmí být NULL."
+
+#~ msgid "SHIFT-JIS"
+#~ msgstr "SHIFT-JIS"
+
+#~ msgid ""
+#~ "Streaming delegates for not already streamed objects not yet supported"
+#~ msgstr "Proudění delegátů pro ještě neproudící objekty není podporováno"
+
+#~ msgid ""
+#~ "The data format for the GET-direction of the to be added data object "
+#~ "already exists"
+#~ msgstr "Formát data pro směr ZÍSKAT přidávaných dat objektu už existuje"
+
+#~ msgid ""
+#~ "The data format for the SET-direction of the to be added data object "
+#~ "already exists"
+#~ msgstr "Formát data pro směr NASTAVIT přidávaných dat objektu už existuje"
+
+#~ msgid "The file '%s' doesn't exist and couldn't be opened."
+#~ msgstr "Soubor '%s' neexistuje a nemůže být otevřen."
+
+#~ msgid "The path '%s' contains too many \"..\"!"
+#~ msgstr "Cesta '%s' obsahuje příliš mnoho \"..\"!"
+
+#~ msgid "To be deleted item is invalid."
+#~ msgstr "Položka k vymazání je neplatná."
+
+#~ msgid "Update"
+#~ msgstr "Aktualizovat"
+
+#~ msgid "Value must be %lld or higher"
+#~ msgstr "Hodnota musí být %lld nebo větší"
+
+#~ msgid "Value must be %llu or higher"
+#~ msgstr "Hodnota musí být %llu nebo větší"
+
+#~ msgid "Value must be %llu or less"
+#~ msgstr "Hodnota musí být %llu nebo menší"
+
+#~ msgid "Warning"
+#~ msgstr "Varování"
+
+#~ msgid "Windows 2000 (build %lu"
+#~ msgstr "Windows 2000 (sestavení %lu"
+
+#~ msgid "delegate has no type info"
+#~ msgstr "delegát nemá informace o typu"
+
+#~ msgid "wxSearchEngine::LookFor must be called before scanning!"
+#~ msgstr "wxSearchEngine::LookFor musí být zavolán před skenováním!"
+
+#~ msgid "|<<"
+#~ msgstr "|<<"
+
+#~ msgid "%.*f GB"
+#~ msgstr "%.*f GB"
+
+#~ msgid "%.*f MB"
+#~ msgstr "%.*f MB"
+
+#~ msgid "%.*f TB"
+#~ msgstr "%.*f TB"
+
+#~ msgid "%.*f kB"
+#~ msgstr "%.*f kB"
+
+#~ msgid "%s B"
+#~ msgstr "%s B"
+
+#~ msgid "Cannot convert dialog units: dialog unknown."
+#~ msgstr "Nelze převést dialogové jednotky: dialog není znám."
+
+#, fuzzy
+#~ msgid "Cannot convert from the charset '%s'!"
+#~ msgstr "Text nelze zkonvertovat z kódování '%s'!"
+
+#~ msgid "Cannot find container for unknown control '%s'."
+#~ msgstr "Nelze nalézt kontejner pro anonymní ovládací prvek '%s'."
+
+#~ msgid "Cannot find font node '%s'."
+#~ msgstr "Chybí uzel s fontem '%s'."
+
+#~ msgid "Cannot parse coordinates from '%s'."
+#~ msgstr "Nelze získat souřadníce z '%s'."
+
+#~ msgid "Cannot parse dimension from '%s'."
+#~ msgstr "Nelze ze '%s' získat rozměry."
+
+#, fuzzy
+#~ msgid "Cant create the thread event queue"
+#~ msgstr "Nelze vytvořit vlákno"
+
+#, fuzzy
+#~ msgid "Could not unlock mutex"
+#~ msgstr "Nelze vytvořit časovač"
+
+#, fuzzy
+#~ msgid "Failed to register OpenGL window class."
+#~ msgstr "Nelze inicializovat OpenGL"
+
+#~ msgid "Fatal error: "
+#~ msgstr "Kritická chyba: "
+
+#~ msgid "Help : %s"
+#~ msgstr "Nápověda: %s"
+
+#~ msgid "Invalid XRC resource '%s': doesn't have root node 'resource'."
+#~ msgstr "Neplatný XRC zdroj '%s': chybí kořenový uzel 'resource'."
+
+#~ msgid "No handler found for XML node '%s', class '%s'!"
+#~ msgstr "Nenalezen žádný ovladač pro XML uzel '%s' třídy '%s'!"
+
+#~ msgid "Program aborted."
+#~ msgstr "Program přerušen."
+
+#~ msgid "Referenced object node with ref=\"%s\" not found!"
+#~ msgstr "Objektový uzel s ref=\"%s\" nenalezen!"
+
+#~ msgid "Resource files must have same version number!"
+#~ msgstr "Soubory se zdroji musí mít stejné číslo verze!"
+
+#~ msgid "Search!"
+#~ msgstr "Hledat!"
+
+#~ msgid "Sorry, could not open this file for saving."
+#~ msgstr "Tento soubor nelze otevřít pro zápis."
+
+#~ msgid "Sorry, could not save this file."
+#~ msgstr "Tento soubor nelze uložit."
+
+#~ msgid "Status: "
+#~ msgstr "Status: "
+
+#~ msgid "Subclass '%s' not found for resource '%s', not subclassing!"
+#~ msgstr "Podtřída '%s' ke zdroji '%s' nenalezena!"
+
+#~ msgid "Trying to solve a NULL hostname: giving up"
+#~ msgstr "Snažím se zjistit NULLové jméno počítače: vzdávám to"
+
+#~ msgid "Unknown style flag "
+#~ msgstr "Neznámý styl "
+
+#~ msgid "XRC resource '%s' (class '%s') not found!"
+#~ msgstr "XRC zdroj '%s' (třída '%s') nenalezen!"
+
+#, fuzzy
+#~ msgid "XRC resource: Cannot create animation from '%s'."
+#~ msgstr "XRC zdroje: Nelze vytvořit bitmapu z '%s'."
+
+#~ msgid "XRC resource: Cannot create bitmap from '%s'."
+#~ msgstr "XRC zdroje: Nelze vytvořit bitmapu z '%s'."
+
+#, fuzzy
+#~ msgid ""
+#~ "XRC resource: Incorrect colour specification '%s' for attribute '%s'."
+#~ msgstr "XRC zdroje: chybný popis barvy '%s' u vlastnosti '%s'."
+
+#~ msgid "[EMPTY]"
+#~ msgstr "[PRÁZDNÝ]"
+
+#~ msgid "catalog file for domain '%s' not found."
+#~ msgstr "katalog pro doménu '%s' nenalezen."
+
+#, fuzzy
+#~ msgid "encoding %i"
+#~ msgstr "Neznámá znaková sada %s"
+
+#~ msgid "looking for catalog '%s' in path '%s'."
+#~ msgstr "hledám katalog '%s' v cestě '%s'."
+
+#~ msgid "wxSocket: invalid signature in ReadMsg."
+#~ msgstr "wxSocket: chybná signatura v ReadMsg."
+
+#~ msgid "wxSocket: unknown event!."
+#~ msgstr "wxSocket: neznámá událost!"
+
+#, fuzzy
+#~ msgid " Couldn't create the UnicodeConverter"
+#~ msgstr "Nelze vytvořit časovač"
+
+#, fuzzy
+#~ msgid "&Open"
+#~ msgstr "&Otevřít..."
+
+#, fuzzy
+#~ msgid "&Print"
+#~ msgstr "Vytisknout"
+
+#, fuzzy
+#~ msgid "Bitmap resource specification %s not found."
+#~ msgstr "XRC zdroj '%s' (třída '%s') nenalezen!"
+
+#, fuzzy
+#~ msgid "Couldn't end the context on the overlay window"
+#~ msgstr "Nelze získat ukazatel na aktuální vlákno"
+
+#, fuzzy
+#~ msgid "Failed to get clipboard data."
+#~ msgstr "Nelze uložit data do schránky."
+
+#~ msgid "Failed to load shared library '%s' Error '%s'"
+#~ msgstr "Nelze načíst sdílenou knihovnu '%s', chyba '%s'"
+
+#, fuzzy
+#~ msgid "Found "
+#~ msgstr "Najít"
+
+#, fuzzy
+#~ msgid "Icon resource specification %s not found."
+#~ msgstr "XRC zdroj '%s' (třída '%s') nenalezen!"
+
+#~ msgid "Option '%s' requires a value, '=' expected."
+#~ msgstr "Volba '%s' vyžaduje hodnotu, očekávám '='."
+
+#, fuzzy
+#~ msgid "Select all"
+#~ msgstr "Vybrat &vše"
+
+#~ msgid "Warning: attempt to remove HTML tag handler from empty stack."
+#~ msgstr "Varování: pokus o vyjmutí HTML tag handleru z prázdného zásobníku."
+
+#~ msgid "establish"
+#~ msgstr "navázat"
+
+#~ msgid "initiate"
+#~ msgstr "inicializovat"
+
+#~ msgid "invalid eof() return value."
+#~ msgstr "špatná návratová hodnota eof()."
+
+#~ msgid "unknown line terminator"
+#~ msgstr "neznámý konec řádku"
+
+#~ msgid "writing"
+#~ msgstr "zápis"
+
+#~ msgid "."
+#~ msgstr "."
+
+#~ msgid "Cannot open URL '%s'"
+#~ msgstr "Nelze otevřít URL '%s'"
+
+#~ msgid "Error "
+#~ msgstr "Chyba"
+
+#~ msgid "Failed to create directory %s/.gnome."
+#~ msgstr "Nelze vytvořit uživatelský %s/.gnome."
+
+#~ msgid "Failed to create directory %s/mime-info."
+#~ msgstr "Nelze vytvořit adresář %s/mime-info."
+
+#~ msgid "Mailcap file %s, line %d: incomplete entry ignored."
+#~ msgstr "Soubor Mailcap %s, řádka %d: nekompletní položka ignorována."
+
+#~ msgid "Mime.types file %s, line %d: unterminated quoted string."
+#~ msgstr "Soubor Mime.types %s, řádka %d: neukončený uzávorkovaný řetězec."
+
+#~ msgid "Unknown field in file %s, line %d: '%s'."
+#~ msgstr "Neznámá položka v souboru %s, řádka %d: '%s'."
+
+#~ msgid "bold "
+#~ msgstr "tučné "
+
+#~ msgid "light "
+#~ msgstr "tenké "
+
+#~ msgid "underlined "
+#~ msgstr "podtržené "
+
+#, fuzzy
+#~ msgid ""
+#~ "Failed to get stack backtrace:\n"
+#~ "%s"
+#~ msgstr "Nepodařilo se získat jména ISP: %s"
+
+#~ msgid "Loading Grey Ascii PNM image is not yet implemented."
+#~ msgstr "Načítání šedých ascii PNM obrázků není ještě implementováno."
+
+#~ msgid "Loading Grey Raw PNM image is not yet implemented."
+#~ msgstr "Načítání šedých raw PNM obrázků není ještě implementováno."
+
+#, fuzzy
+#~ msgid "Cannot wait on thread to exit."
+#~ msgstr "Nelze počkat na ukončení vlákna"
+
+#~ msgid "Could not load Rich Edit DLL '%s'"
+#~ msgstr "Nelze načíst Rich Edit DLL '%s'"
+
+#~ msgid "ZIP handler currently supports only local files!"
+#~ msgstr "ZIP soubory lze otevřít jenom z disku!"
+
+#, fuzzy
+#~ msgid ""
+#~ "can't seek on file descriptor %d, large files support is not enabled."
+#~ msgstr "Nelze seekovat v deskriptoru %d"
+
+#~ msgid "More..."
+#~ msgstr "Více..."
+
+#~ msgid "Setup"
+#~ msgstr "Nastavení"
+
+#~ msgid "Backward"
+#~ msgstr "Zpět"
+
+#~ msgid "GetUnusedColour:: No Unused Color in image "
+#~ msgstr "GetUnusedColour: v obrázku není žádná nepoužitá barva"

--- a/po_wxstd/da.po
+++ b/po_wxstd/da.po
@@ -1,0 +1,9555 @@
+# Danish translation for wxWidgets.
+# Copyright (C) 2016 wxWidgets development team
+# This file is distributed under the same license as the wxWidgets package.
+# scootergrisen, 2016-2017.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: wxWidgets 3.3\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-05-14 20:23+0200\n"
+"PO-Revision-Date: 2017-07-26 00:00+0000\n"
+"Last-Translator: scootergrisen\n"
+"Language-Team: Danish\n"
+"Language: da\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Language: da_DK\n"
+"X-Source-Language: C\n"
+
+#: ../include/wx/defs.h:2582
+msgid "All files (*.*)|*.*"
+msgstr "Alle filer (*.*)|*.*"
+
+#: ../include/wx/defs.h:2585
+msgid "All files (*)|*"
+msgstr "Alle filer (*)|*"
+
+#: ../include/wx/generic/progdlgg.h:85
+msgid "Elapsed time:"
+msgstr "Forløbet tid:"
+
+#: ../include/wx/generic/progdlgg.h:86
+msgid "Estimated time:"
+msgstr "Anslået tid:"
+
+#: ../include/wx/generic/progdlgg.h:87
+msgid "Remaining time:"
+msgstr "Resterende tid:"
+
+#. TRANSLATORS: HTML printout default title.
+#: ../include/wx/html/htmprint.h:121 ../include/wx/prntbase.h:273
+#: ../include/wx/richtext/richtextprint.h:109 ../src/common/docview.cpp:2161
+msgid "Printout"
+msgstr "Udskrift"
+
+#. TRANSLATORS: HTML easy print default title.
+#: ../include/wx/html/htmprint.h:234 ../include/wx/richtext/richtextprint.h:163
+#: ../src/common/prntbase.cpp:522 ../src/html/htmprint.cpp:291
+msgid "Printing"
+msgstr "Udskriver"
+
+#: ../include/wx/msgdlg.h:277 ../src/common/stockitem.cpp:211
+msgid "Yes"
+msgstr "Ja"
+
+#: ../include/wx/msgdlg.h:278 ../src/common/stockitem.cpp:182
+msgid "No"
+msgstr "Nej"
+
+#: ../include/wx/msgdlg.h:279 ../src/common/stockitem.cpp:183
+#: ../src/msw/msgdlg.cpp:430 ../src/msw/msgdlg.cpp:734
+#: ../src/richtext/richtextstyledlg.cpp:292
+msgid "OK"
+msgstr "OK"
+
+#: ../include/wx/msgdlg.h:280 ../src/common/stockitem.cpp:150
+#: ../src/msw/msgdlg.cpp:430 ../src/msw/progdlg.cpp:884
+#: ../src/richtext/richtextstyledlg.cpp:295
+msgid "Cancel"
+msgstr "Annuller"
+
+#: ../include/wx/msgdlg.h:281 ../src/common/stockitem.cpp:168
+#: ../src/html/helpdlg.cpp:63 ../src/html/helpfrm.cpp:108
+#: ../src/osx/button_osx.cpp:38
+msgid "Help"
+msgstr "Hjælp"
+
+#: ../include/wx/msw/ole/oleutils.h:52
+msgid "Cannot initialize OLE"
+msgstr "Kan ikke initialisere OLE"
+
+#: ../include/wx/msw/private/fswatcher.h:48
+#, c-format
+msgid "Unable to close the handle for '%s'"
+msgstr "Kunne ikke lukke håndtaget til \"%s\""
+
+#: ../include/wx/msw/private/fswatcher.h:92
+#, c-format
+msgid "Failed to open directory \"%s\" for monitoring."
+msgstr "Kunne ikke åbne mappen \"%s\" for overvågning."
+
+#: ../include/wx/msw/private/fswatcher.h:125
+msgid "Unable to close I/O completion port handle"
+msgstr "Kunne ikke lukke I/O completion port handle"
+
+#: ../include/wx/msw/private/fswatcher.h:142
+msgid "Unable to associate handle with I/O completion port"
+msgstr "Kunne ikke tilknytte håndtag med I/O completion port"
+
+#: ../include/wx/msw/private/fswatcher.h:148
+msgid "Unexpectedly new I/O completion port was created"
+msgstr "Uventet ny I/O completion port blev oprettet"
+
+#: ../include/wx/msw/private/fswatcher.h:213
+msgid "Unable to post completion status"
+msgstr "Kunne ikke poste completion status"
+
+#: ../include/wx/msw/private/fswatcher.h:262
+msgid "Unable to dequeue completion packet"
+msgstr "Kunne ikke dequeue completion pakke"
+
+#: ../include/wx/msw/private/fswatcher.h:273
+msgid "Unable to create I/O completion port"
+msgstr "Kunne ikke oprette I/O completion port"
+
+#: ../include/wx/richmsgdlg.h:29
+msgid "&See details"
+msgstr "&Se detaljer"
+
+#: ../include/wx/richmsgdlg.h:30
+msgid "&Hide details"
+msgstr "&Højdedetaljer"
+
+#: ../include/wx/richtext/richtextbuffer.h:3864
+msgid "&Box"
+msgstr "&Boks"
+
+#: ../include/wx/richtext/richtextbuffer.h:5008
+msgid "&Picture"
+msgstr "&Billede"
+
+#: ../include/wx/richtext/richtextbuffer.h:5958
+msgid "&Cell"
+msgstr "&Celle"
+
+#: ../include/wx/richtext/richtextbuffer.h:6067
+msgid "&Table"
+msgstr "&Tabel"
+
+#: ../include/wx/richtext/richtextimagedlg.h:37
+msgid "Object Properties"
+msgstr "Objektegenskaber"
+
+#: ../include/wx/richtext/richtextsymboldlg.h:39
+msgid "Symbols"
+msgstr "Symboler"
+
+#: ../include/wx/unix/pipe.h:46
+msgid "Pipe creation failed"
+msgstr "Pipe oprettelse fejlede"
+
+#: ../include/wx/unix/private/displayx11.h:65
+msgid "Failed to enumerate video modes"
+msgstr "Kunne ikke optælle video modes"
+
+#: ../include/wx/unix/private/displayx11.h:89
+msgid "Failed to change video mode"
+msgstr "Kunne ikke ændre video mode"
+
+#: ../include/wx/unix/private/fswatcher_kqueue.h:57
+#, c-format
+msgid "Unable to open path '%s'"
+msgstr "Kunne ikke åbne stien \"%s\""
+
+#: ../include/wx/unix/private/fswatcher_kqueue.h:74
+#, c-format
+msgid "Unable to close path '%s'"
+msgstr "Kunne ikke lukke stien \"%s\""
+
+#: ../include/wx/xtiprop.h:175
+msgid "SetProperty called w/o valid setter"
+msgstr "SetProperty kaldt uden gyldig setter"
+
+#: ../include/wx/xtiprop.h:184
+msgid "GetProperty called w/o valid getter"
+msgstr "GetProperty kaldt uden valid getter"
+
+#: ../include/wx/xtiprop.h:193
+msgid "AddToPropertyCollection called w/o valid adder"
+msgstr "AddToPropertyCollection kaldt uden gyldig adder"
+
+#: ../include/wx/xtiprop.h:202
+msgid "GetPropertyCollection called w/o valid collection getter"
+msgstr "GetPropertyCollection kaldt uden gyldig collection getter"
+
+#: ../include/wx/xtiprop.h:255
+msgid "AddToPropertyCollection called on a generic accessor"
+msgstr "AddToPropertyCollection kaldt på en generisk accessor"
+
+#: ../include/wx/xtiprop.h:262
+msgid "GetPropertyCollection called on a generic accessor"
+msgstr "GetPropertyCollection kaldt på en generisk accessor"
+
+#: ../src/aui/tabmdi.cpp:106 ../src/generic/mdig.cpp:94
+msgid "Cl&ose"
+msgstr "L&uk"
+
+#: ../src/aui/tabmdi.cpp:107 ../src/generic/mdig.cpp:95
+msgid "Close All"
+msgstr "Luk alle"
+
+#: ../src/aui/tabmdi.cpp:109 ../src/generic/mdig.cpp:97 ../src/msw/mdi.cpp:175
+#: ../src/qt/mdi.cpp:258
+msgid "&Next"
+msgstr "&Næste"
+
+#: ../src/aui/tabmdi.cpp:110 ../src/generic/mdig.cpp:98 ../src/msw/mdi.cpp:176
+#: ../src/qt/mdi.cpp:259
+msgid "&Previous"
+msgstr "&Tilbage"
+
+#: ../src/aui/tabmdi.cpp:332 ../src/aui/tabmdi.cpp:348
+#: ../src/aui/tabmdi.cpp:350 ../src/generic/mdig.cpp:291
+#: ../src/generic/mdig.cpp:307 ../src/generic/mdig.cpp:311
+#: ../src/msw/mdi.cpp:337 ../src/qt/mdi.cpp:462
+msgid "&Window"
+msgstr "&Vindue"
+
+#: ../src/common/accelcmn.cpp:47
+msgctxt "keyboard key"
+msgid "Delete"
+msgstr "Slet"
+
+#: ../src/common/accelcmn.cpp:48
+msgctxt "keyboard key"
+msgid "Del"
+msgstr "Slet"
+
+#: ../src/common/accelcmn.cpp:49
+msgctxt "keyboard key"
+msgid "Back"
+msgstr "Tilbage"
+
+#: ../src/common/accelcmn.cpp:49
+msgctxt "keyboard key"
+msgid "Backspace"
+msgstr "Backspace"
+
+#: ../src/common/accelcmn.cpp:50
+msgctxt "keyboard key"
+msgid "Insert"
+msgstr "Indsæt"
+
+#: ../src/common/accelcmn.cpp:51
+msgctxt "keyboard key"
+msgid "Ins"
+msgstr "Ins"
+
+#: ../src/common/accelcmn.cpp:52
+msgctxt "keyboard key"
+msgid "Enter"
+msgstr "Enter"
+
+#: ../src/common/accelcmn.cpp:53
+msgctxt "keyboard key"
+msgid "Return"
+msgstr "Retur"
+
+#: ../src/common/accelcmn.cpp:54
+msgctxt "keyboard key"
+msgid "PageUp"
+msgstr "PageUp"
+
+#: ../src/common/accelcmn.cpp:54
+msgctxt "keyboard key"
+msgid "Page Up"
+msgstr "Side op"
+
+#: ../src/common/accelcmn.cpp:55
+msgctxt "keyboard key"
+msgid "PageDown"
+msgstr "PageDown"
+
+#: ../src/common/accelcmn.cpp:55
+msgctxt "keyboard key"
+msgid "Page Down"
+msgstr "Side ned"
+
+#: ../src/common/accelcmn.cpp:56
+msgctxt "keyboard key"
+msgid "PgUp"
+msgstr "PgUp"
+
+#: ../src/common/accelcmn.cpp:57
+msgctxt "keyboard key"
+msgid "PgDn"
+msgstr "PgDn"
+
+#: ../src/common/accelcmn.cpp:58
+msgctxt "keyboard key"
+msgid "Left"
+msgstr "Venstre"
+
+#: ../src/common/accelcmn.cpp:59
+msgctxt "keyboard key"
+msgid "Right"
+msgstr "Højre"
+
+#: ../src/common/accelcmn.cpp:60
+msgctxt "keyboard key"
+msgid "Up"
+msgstr "Op"
+
+#: ../src/common/accelcmn.cpp:61
+msgctxt "keyboard key"
+msgid "Down"
+msgstr "Ned"
+
+#: ../src/common/accelcmn.cpp:62
+msgctxt "keyboard key"
+msgid "Home"
+msgstr "Hjem"
+
+#: ../src/common/accelcmn.cpp:63
+msgctxt "keyboard key"
+msgid "End"
+msgstr "End"
+
+#: ../src/common/accelcmn.cpp:64
+msgctxt "keyboard key"
+msgid "Space"
+msgstr "Mellemrum"
+
+#: ../src/common/accelcmn.cpp:65
+msgctxt "keyboard key"
+msgid "Tab"
+msgstr "Tab"
+
+#: ../src/common/accelcmn.cpp:66
+msgctxt "keyboard key"
+msgid "Esc"
+msgstr "Esc"
+
+#: ../src/common/accelcmn.cpp:67
+msgctxt "keyboard key"
+msgid "Escape"
+msgstr "Escape"
+
+#: ../src/common/accelcmn.cpp:68
+msgctxt "keyboard key"
+msgid "Cancel"
+msgstr "Annuller"
+
+#: ../src/common/accelcmn.cpp:69
+msgctxt "keyboard key"
+msgid "Clear"
+msgstr "Rens"
+
+#: ../src/common/accelcmn.cpp:70
+msgctxt "keyboard key"
+msgid "Menu"
+msgstr "Menu"
+
+#: ../src/common/accelcmn.cpp:71
+msgctxt "keyboard key"
+msgid "Pause"
+msgstr "Pause"
+
+#: ../src/common/accelcmn.cpp:72
+msgctxt "keyboard key"
+msgid "Capital"
+msgstr "Stort"
+
+#: ../src/common/accelcmn.cpp:73
+msgctxt "keyboard key"
+msgid "Select"
+msgstr "Vælg"
+
+#: ../src/common/accelcmn.cpp:74
+msgctxt "keyboard key"
+msgid "Print"
+msgstr "Udskriv"
+
+#: ../src/common/accelcmn.cpp:75
+msgctxt "keyboard key"
+msgid "Execute"
+msgstr "Udfør"
+
+#: ../src/common/accelcmn.cpp:76
+msgctxt "keyboard key"
+msgid "Snapshot"
+msgstr "Snapshot"
+
+#: ../src/common/accelcmn.cpp:77
+msgctxt "keyboard key"
+msgid "Help"
+msgstr "Hjælp"
+
+#: ../src/common/accelcmn.cpp:78
+msgctxt "keyboard key"
+msgid "Add"
+msgstr "Tilføj"
+
+#: ../src/common/accelcmn.cpp:79
+msgctxt "keyboard key"
+msgid "Separator"
+msgstr "Separator"
+
+#: ../src/common/accelcmn.cpp:80
+msgctxt "keyboard key"
+msgid "Subtract"
+msgstr "Træk fra"
+
+#: ../src/common/accelcmn.cpp:81
+msgctxt "keyboard key"
+msgid "Decimal"
+msgstr "Decimal"
+
+#: ../src/common/accelcmn.cpp:82
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Multiply"
+msgstr "KP_Multiply"
+
+#: ../src/common/accelcmn.cpp:83
+msgctxt "keyboard key"
+msgid "Divide"
+msgstr "Divider"
+
+#: ../src/common/accelcmn.cpp:84
+msgctxt "keyboard key"
+msgid "Num_lock"
+msgstr "Num_lock"
+
+#: ../src/common/accelcmn.cpp:84
+msgctxt "keyboard key"
+msgid "Num Lock"
+msgstr "Num Lock"
+
+#: ../src/common/accelcmn.cpp:85
+msgctxt "keyboard key"
+msgid "Scroll_lock"
+msgstr "Scroll_lock"
+
+#: ../src/common/accelcmn.cpp:85
+msgctxt "keyboard key"
+msgid "Scroll Lock"
+msgstr "Scroll Lock"
+
+#: ../src/common/accelcmn.cpp:86
+msgctxt "keyboard key"
+msgid "KP_Space"
+msgstr "KP_Mellemrum"
+
+#: ../src/common/accelcmn.cpp:86
+msgctxt "keyboard key"
+msgid "Num Space"
+msgstr "Num Space"
+
+#: ../src/common/accelcmn.cpp:87
+msgctxt "keyboard key"
+msgid "KP_Tab"
+msgstr "KP_Tab"
+
+#: ../src/common/accelcmn.cpp:87
+msgctxt "keyboard key"
+msgid "Num Tab"
+msgstr "Num Tab"
+
+#: ../src/common/accelcmn.cpp:88
+msgctxt "keyboard key"
+msgid "KP_Enter"
+msgstr "KP_Enter"
+
+#: ../src/common/accelcmn.cpp:88
+msgctxt "keyboard key"
+msgid "Num Enter"
+msgstr "Num Enter"
+
+#: ../src/common/accelcmn.cpp:89
+msgctxt "keyboard key"
+msgid "KP_Home"
+msgstr "KP_Home"
+
+#: ../src/common/accelcmn.cpp:89
+msgctxt "keyboard key"
+msgid "Num Home"
+msgstr "Num Home"
+
+#: ../src/common/accelcmn.cpp:90
+msgctxt "keyboard key"
+msgid "KP_Left"
+msgstr "KP_Venstre"
+
+#: ../src/common/accelcmn.cpp:90
+msgctxt "keyboard key"
+msgid "Num left"
+msgstr "Num left"
+
+#: ../src/common/accelcmn.cpp:91
+msgctxt "keyboard key"
+msgid "KP_Up"
+msgstr "KP_Op"
+
+#: ../src/common/accelcmn.cpp:91
+msgctxt "keyboard key"
+msgid "Num Up"
+msgstr "Num Up"
+
+#: ../src/common/accelcmn.cpp:92
+msgctxt "keyboard key"
+msgid "KP_Right"
+msgstr "KP_Højre"
+
+#: ../src/common/accelcmn.cpp:92
+msgctxt "keyboard key"
+msgid "Num Right"
+msgstr "Num Right"
+
+#: ../src/common/accelcmn.cpp:93
+msgctxt "keyboard key"
+msgid "KP_Down"
+msgstr "KP_Ned"
+
+#: ../src/common/accelcmn.cpp:93
+msgctxt "keyboard key"
+msgid "Num Down"
+msgstr "Num Down"
+
+#: ../src/common/accelcmn.cpp:94
+msgctxt "keyboard key"
+msgid "KP_PageUp"
+msgstr "KP_PageUp"
+
+#: ../src/common/accelcmn.cpp:94
+msgctxt "keyboard key"
+msgid "Num Page Up"
+msgstr "Num Page Up"
+
+#: ../src/common/accelcmn.cpp:95
+msgctxt "keyboard key"
+msgid "KP_PageDown"
+msgstr "KP_PageDown"
+
+#: ../src/common/accelcmn.cpp:95
+msgctxt "keyboard key"
+msgid "Num Page Down"
+msgstr "Num Page Down"
+
+#: ../src/common/accelcmn.cpp:96
+msgctxt "keyboard key"
+msgid "KP_Prior"
+msgstr "KP_Prior"
+
+#: ../src/common/accelcmn.cpp:97
+msgctxt "keyboard key"
+msgid "KP_Next"
+msgstr "KP_Next"
+
+#: ../src/common/accelcmn.cpp:98
+msgctxt "keyboard key"
+msgid "KP_End"
+msgstr "KP_End"
+
+#: ../src/common/accelcmn.cpp:98
+msgctxt "keyboard key"
+msgid "Num End"
+msgstr "Num End"
+
+#: ../src/common/accelcmn.cpp:99
+msgctxt "keyboard key"
+msgid "KP_Begin"
+msgstr "KP_Begin"
+
+#: ../src/common/accelcmn.cpp:99
+msgctxt "keyboard key"
+msgid "Num Begin"
+msgstr "Num Begin"
+
+#: ../src/common/accelcmn.cpp:100
+msgctxt "keyboard key"
+msgid "KP_Insert"
+msgstr "KP_Insert"
+
+#: ../src/common/accelcmn.cpp:100
+msgctxt "keyboard key"
+msgid "Num Insert"
+msgstr "Num Insert"
+
+#: ../src/common/accelcmn.cpp:101
+msgctxt "keyboard key"
+msgid "KP_Delete"
+msgstr "KP_Delete"
+
+#: ../src/common/accelcmn.cpp:101
+msgctxt "keyboard key"
+msgid "Num Delete"
+msgstr "Num Delete"
+
+#: ../src/common/accelcmn.cpp:102
+msgctxt "keyboard key"
+msgid "KP_Equal"
+msgstr "KP_Equal"
+
+#: ../src/common/accelcmn.cpp:102
+msgctxt "keyboard key"
+msgid "Num ="
+msgstr "Num ="
+
+#: ../src/common/accelcmn.cpp:103
+msgctxt "keyboard key"
+msgid "KP_Multiply"
+msgstr "KP_Multiply"
+
+#: ../src/common/accelcmn.cpp:103
+msgctxt "keyboard key"
+msgid "Num *"
+msgstr "Num *"
+
+#: ../src/common/accelcmn.cpp:104
+msgctxt "keyboard key"
+msgid "KP_Add"
+msgstr "KP_Add"
+
+#: ../src/common/accelcmn.cpp:104
+msgctxt "keyboard key"
+msgid "Num +"
+msgstr "Num +"
+
+#: ../src/common/accelcmn.cpp:105
+msgctxt "keyboard key"
+msgid "KP_Separator"
+msgstr "KP_Separator"
+
+#: ../src/common/accelcmn.cpp:105
+msgctxt "keyboard key"
+msgid "Num ,"
+msgstr "Num ,"
+
+#: ../src/common/accelcmn.cpp:106
+msgctxt "keyboard key"
+msgid "KP_Subtract"
+msgstr "KP_Minus"
+
+#: ../src/common/accelcmn.cpp:106
+msgctxt "keyboard key"
+msgid "Num -"
+msgstr "Num -"
+
+#: ../src/common/accelcmn.cpp:107
+msgctxt "keyboard key"
+msgid "KP_Decimal"
+msgstr "KP_Decimal"
+
+#: ../src/common/accelcmn.cpp:107
+msgctxt "keyboard key"
+msgid "Num ."
+msgstr "Num ."
+
+#: ../src/common/accelcmn.cpp:108
+msgctxt "keyboard key"
+msgid "KP_Divide"
+msgstr "KP_Divide"
+
+#: ../src/common/accelcmn.cpp:108
+msgctxt "keyboard key"
+msgid "Num /"
+msgstr "Num /"
+
+#: ../src/common/accelcmn.cpp:109
+msgctxt "keyboard key"
+msgid "Windows_Left"
+msgstr "Windows_Venstre"
+
+#: ../src/common/accelcmn.cpp:110
+msgctxt "keyboard key"
+msgid "Windows_Right"
+msgstr "Windows_Højre"
+
+#: ../src/common/accelcmn.cpp:111
+msgctxt "keyboard key"
+msgid "Windows_Menu"
+msgstr "Windows_Menu"
+
+#: ../src/common/accelcmn.cpp:112
+msgctxt "keyboard key"
+msgid "Command"
+msgstr "Kommando"
+
+#: ../src/common/accelcmn.cpp:186 ../src/common/accelcmn.cpp:359
+msgctxt "keyboard key"
+msgid "Ctrl"
+msgstr "Ctrl"
+
+#: ../src/common/accelcmn.cpp:188 ../src/common/accelcmn.cpp:363
+msgctxt "keyboard key"
+msgid "Alt"
+msgstr "Alt"
+
+#: ../src/common/accelcmn.cpp:190 ../src/common/accelcmn.cpp:361
+msgctxt "keyboard key"
+msgid "Shift"
+msgstr "Skift"
+
+#: ../src/common/accelcmn.cpp:196
+msgctxt "keyboard key"
+msgid "num "
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:260 ../src/common/accelcmn.cpp:382
+msgctxt "keyboard key"
+msgid "F"
+msgstr "F"
+
+#: ../src/common/accelcmn.cpp:277 ../src/common/accelcmn.cpp:385
+msgctxt "keyboard key"
+msgid "KP_F"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:280 ../src/common/accelcmn.cpp:388
+msgctxt "keyboard key"
+msgid "KP_"
+msgstr "KP_"
+
+#: ../src/common/accelcmn.cpp:283 ../src/common/accelcmn.cpp:391
+msgctxt "keyboard key"
+msgid "SPECIAL"
+msgstr "SPECIEL"
+
+#: ../src/common/accelcmn.cpp:373
+#, fuzzy
+msgid "Ctrl"
+msgstr "Ctrl"
+
+#: ../src/common/appbase.cpp:786
+msgid "show this help message"
+msgstr "vis denne hjælp-meddelelse"
+
+#: ../src/common/appbase.cpp:796
+msgid "generate verbose log messages"
+msgstr "generer udførlige logmeddelelser"
+
+#: ../src/common/appcmn.cpp:256
+msgid "specify the theme to use"
+msgstr "angiv det tema, som skal bruges"
+
+#: ../src/common/appcmn.cpp:270
+msgid "specify display mode to use (e.g. 640x480-16)"
+msgstr "angiv ønskede skærmtilstand (f.eks. 640x480-16)"
+
+#: ../src/common/appcmn.cpp:292
+#, c-format
+msgid "Unsupported theme '%s'."
+msgstr "Ikke-understøttet tema \"%s\"."
+
+#: ../src/common/appcmn.cpp:309
+#, c-format
+msgid "Invalid display mode specification '%s'."
+msgstr "Ugyldig skærmtilstandsspecifikation \"%s\"."
+
+#: ../src/common/cmdline.cpp:875
+#, c-format
+msgid "Option '%s' can't be negated"
+msgstr "Tilvalget \"%s\" kan ikke annulleres"
+
+#: ../src/common/cmdline.cpp:889
+#, c-format
+msgid "Unknown long option '%s'"
+msgstr "Ukendt langt tilvalg \"%s\""
+
+#: ../src/common/cmdline.cpp:904 ../src/common/cmdline.cpp:926
+#, c-format
+msgid "Unknown option '%s'"
+msgstr "Ukendt tilvalg \"%s\""
+
+#: ../src/common/cmdline.cpp:1004
+#, c-format
+msgid "Unexpected characters following option '%s'."
+msgstr "Uventede tegn efter tilvalget \"%s\"."
+
+#: ../src/common/cmdline.cpp:1039
+#, c-format
+msgid "Option '%s' requires a value."
+msgstr "Tilvalget \"%s\" kræver en værdi."
+
+#: ../src/common/cmdline.cpp:1058
+#, c-format
+msgid "Separator expected after the option '%s'."
+msgstr "Separator forventet efter tilvalget \"%s\"."
+
+#: ../src/common/cmdline.cpp:1088 ../src/common/cmdline.cpp:1106
+#, c-format
+msgid "'%s' is not a correct numeric value for option '%s'."
+msgstr "\"%s\" er ikke en korrekt numerisk værdi til tilvalget \"%s\"."
+
+#: ../src/common/cmdline.cpp:1122
+#, c-format
+msgid "Option '%s': '%s' cannot be converted to a date."
+msgstr "Tilvalget \"%s\": \"%s\" kan ikke konverteres til en dato."
+
+#: ../src/common/cmdline.cpp:1170
+#, c-format
+msgid "Unexpected parameter '%s'"
+msgstr "Uventet parameter \"%s\""
+
+#. TRANSLATORS: Short name and long name for a command line option
+#: ../src/common/cmdline.cpp:1197
+#, c-format
+msgid "%s (or %s)"
+msgstr "%s (eller %s)"
+
+#: ../src/common/cmdline.cpp:1208
+#, c-format
+msgid "The value for the option '%s' must be specified."
+msgstr "Værdien til tilvalget \"%s\" skal angives."
+
+#: ../src/common/cmdline.cpp:1230
+#, c-format
+msgid "The required parameter '%s' was not specified."
+msgstr "Den nødvendige parameter \"%s\" blev ikke angivet."
+
+#: ../src/common/cmdline.cpp:1289
+#, c-format
+msgid "Usage: %s"
+msgstr "Brug: %s"
+
+#: ../src/common/cmdline.cpp:1498
+msgid "str"
+msgstr "str"
+
+#: ../src/common/cmdline.cpp:1502
+msgid "num"
+msgstr "nummer"
+
+#: ../src/common/cmdline.cpp:1506
+msgid "double"
+msgstr "double"
+
+#: ../src/common/cmdline.cpp:1510
+msgid "date"
+msgstr "dato"
+
+#: ../src/common/cmdproc.cpp:250 ../src/common/cmdproc.cpp:276
+#: ../src/common/cmdproc.cpp:296
+msgid "Unnamed command"
+msgstr "Unavngiven kommando"
+
+#: ../src/common/cmdproc.cpp:253
+msgid "&Undo "
+msgstr "&Fortryd "
+
+#: ../src/common/cmdproc.cpp:255
+msgid "Can't &Undo "
+msgstr "Kan ikke &fortryde "
+
+#: ../src/common/cmdproc.cpp:259 ../src/common/stockitem.cpp:208
+#: ../src/msw/textctrl.cpp:2880 ../src/osx/textctrl_osx.cpp:649
+#: ../src/richtext/richtextctrl.cpp:327
+msgid "&Undo"
+msgstr "&Fortryd"
+
+#: ../src/common/cmdproc.cpp:277 ../src/common/cmdproc.cpp:297
+msgid "&Redo "
+msgstr "&Omgør "
+
+#: ../src/common/cmdproc.cpp:281 ../src/common/cmdproc.cpp:288
+#: ../src/common/stockitem.cpp:190 ../src/msw/textctrl.cpp:2881
+#: ../src/osx/textctrl_osx.cpp:650 ../src/richtext/richtextctrl.cpp:328
+msgid "&Redo"
+msgstr "&Omgør"
+
+#: ../src/common/colourcmn.cpp:41
+#, c-format
+msgid "String To Colour : Incorrect colour specification : %s"
+msgstr "Streng til farve : forkert farvespecifikation : %s"
+
+#: ../src/common/config.cpp:259
+#, c-format
+msgid "Invalid value %ld for a boolean key \"%s\" in config file."
+msgstr "Ugyldig værdi %ld for en boolesk nøglen \"%s\" i konfigurationsfilen."
+
+#: ../src/common/config.cpp:526
+#, c-format
+msgid ""
+"Environment variables expansion failed: missing '%c' at position %u in '%s'."
+msgstr ""
+"Udvidelse af miljøvariabel fejlede: mangler \"%c\" på position %u i \"%s\"."
+
+#: ../src/common/config.cpp:576 ../src/msw/regconf.cpp:272
+#, c-format
+msgid "'%s' has extra '..', ignored."
+msgstr "\"%s\" har ekstra \"..\", ignoreret."
+
+#. TRANSLATORS: Checkbox state name
+#: ../src/common/datavcmn.cpp:2166 ../src/generic/datavgen.cpp:1430
+msgid "checked"
+msgstr "tilvalgt"
+
+#. TRANSLATORS: Checkbox state name
+#: ../src/common/datavcmn.cpp:2170 ../src/generic/datavgen.cpp:1432
+msgid "unchecked"
+msgstr "fravalgt"
+
+#. TRANSLATORS: Checkbox state name
+#: ../src/common/datavcmn.cpp:2174
+msgid "undetermined"
+msgstr "ubestemt"
+
+#: ../src/common/datetimefmt.cpp:1875
+msgid "today"
+msgstr "i dag"
+
+#: ../src/common/datetimefmt.cpp:1876
+msgid "yesterday"
+msgstr "i går"
+
+#: ../src/common/datetimefmt.cpp:1877
+msgid "tomorrow"
+msgstr "i morgen"
+
+#: ../src/common/datetimefmt.cpp:2071
+msgid "first"
+msgstr "første"
+
+#: ../src/common/datetimefmt.cpp:2072
+msgid "second"
+msgstr "anden"
+
+#: ../src/common/datetimefmt.cpp:2073
+msgid "third"
+msgstr "tredje"
+
+#: ../src/common/datetimefmt.cpp:2074
+msgid "fourth"
+msgstr "fjerde"
+
+#: ../src/common/datetimefmt.cpp:2075
+msgid "fifth"
+msgstr "femte"
+
+#: ../src/common/datetimefmt.cpp:2076
+msgid "sixth"
+msgstr "sjette"
+
+#: ../src/common/datetimefmt.cpp:2077
+msgid "seventh"
+msgstr "syvende"
+
+#: ../src/common/datetimefmt.cpp:2078
+msgid "eighth"
+msgstr "ottende"
+
+#: ../src/common/datetimefmt.cpp:2079
+msgid "ninth"
+msgstr "niende"
+
+#: ../src/common/datetimefmt.cpp:2080
+msgid "tenth"
+msgstr "tiende"
+
+#: ../src/common/datetimefmt.cpp:2081
+msgid "eleventh"
+msgstr "elvte"
+
+#: ../src/common/datetimefmt.cpp:2082
+msgid "twelfth"
+msgstr "tolvte"
+
+#: ../src/common/datetimefmt.cpp:2083
+msgid "thirteenth"
+msgstr "trettende"
+
+#: ../src/common/datetimefmt.cpp:2084
+msgid "fourteenth"
+msgstr "fjortende"
+
+#: ../src/common/datetimefmt.cpp:2085
+msgid "fifteenth"
+msgstr "femtende"
+
+#: ../src/common/datetimefmt.cpp:2086
+msgid "sixteenth"
+msgstr "sekstende"
+
+#: ../src/common/datetimefmt.cpp:2087
+msgid "seventeenth"
+msgstr "syttende"
+
+#: ../src/common/datetimefmt.cpp:2088
+msgid "eighteenth"
+msgstr "attende"
+
+#: ../src/common/datetimefmt.cpp:2089
+msgid "nineteenth"
+msgstr "nittende"
+
+#: ../src/common/datetimefmt.cpp:2090
+msgid "twentieth"
+msgstr "tyvende"
+
+#: ../src/common/datetimefmt.cpp:2248
+msgid "noon"
+msgstr "middag"
+
+#: ../src/common/datetimefmt.cpp:2249
+msgid "midnight"
+msgstr "midnat"
+
+#: ../src/common/debugrpt.cpp:209
+#, c-format
+msgid "Failed to create directory \"%s\""
+msgstr "Kunne ikke oprette mappen \"%s\""
+
+#: ../src/common/debugrpt.cpp:210
+msgid "Debug report couldn't be created."
+msgstr "Kunne ikke oprette fejlfindingsrapport."
+
+#: ../src/common/debugrpt.cpp:227
+#, c-format
+msgid "Failed to remove debug report file \"%s\""
+msgstr "Kunne ikke fjerne fejlfindingsrapportfilen \"%s\""
+
+#: ../src/common/debugrpt.cpp:239
+#, c-format
+msgid "Failed to clean up debug report directory \"%s\""
+msgstr "Kunne ikke rydde op i fejlfindingsrapportmappen \"%s\""
+
+#: ../src/common/debugrpt.cpp:514
+msgid "process context description"
+msgstr "proces kontekst beskrivelse"
+
+#: ../src/common/debugrpt.cpp:538
+msgid "dump of the process state (binary)"
+msgstr "dump af proces-status (binær)"
+
+#: ../src/common/debugrpt.cpp:553
+msgid "Debug report generation has failed."
+msgstr "Generering af fejlfindingsrapport fejlede."
+
+#: ../src/common/debugrpt.cpp:560
+#, c-format
+msgid ""
+"Processing debug report has failed, leaving the files in \"%s\" directory."
+msgstr ""
+"Behandling af fejlfindingsrapport fejlede. Efterlader filerne i mappen "
+"\"%s\"."
+
+#: ../src/common/debugrpt.cpp:573
+msgid "A debug report has been generated. It can be found in"
+msgstr "En fejlfindingsrapport er blevet oprettet. Den kan findes i"
+
+#: ../src/common/debugrpt.cpp:576
+msgid "And includes the following files:\n"
+msgstr "Og inkluderer de følgende filer:\n"
+
+#: ../src/common/debugrpt.cpp:586
+msgid ""
+"\n"
+"Please send this report to the program maintainer, thank you!\n"
+msgstr ""
+"\n"
+"Send venligst denne rapport til vedligeholderen af programmet. På forhånd "
+"tak.\n"
+
+#: ../src/common/debugrpt.cpp:729
+msgid "Failed to execute curl, please install it in PATH."
+msgstr "Kunne ikke eksekvere curl. Installer den venligst i PATH."
+
+#: ../src/common/debugrpt.cpp:742
+#, c-format
+msgid "Failed to upload the debug report (error code %d)."
+msgstr "Kunne ikke uploade fejlfindingsrapport (fejlkode %d)."
+
+#: ../src/common/docview.cpp:366
+msgid "Save As"
+msgstr "Gem som"
+
+#: ../src/common/docview.cpp:457
+msgid "Discard changes and reload the last saved version?"
+msgstr "Forkast ændringer og genindlæs den sidst gemte version?"
+
+#: ../src/common/docview.cpp:488
+msgid "unnamed"
+msgstr "unavngivet"
+
+#: ../src/common/docview.cpp:513
+#, c-format
+msgid "Do you want to save changes to %s?"
+msgstr "Ønsker du at gemme ændringer til %s?"
+
+#: ../src/common/docview.cpp:521 ../src/common/docview.cpp:560
+#: ../src/common/stockitem.cpp:195
+msgid "&Save"
+msgstr "&Gem"
+
+#: ../src/common/docview.cpp:522 ../src/common/docview.cpp:560
+msgid "&Discard changes"
+msgstr ""
+
+#: ../src/common/docview.cpp:523
+#, fuzzy
+msgid "Do&n't close"
+msgstr "Gem ikke"
+
+#: ../src/common/docview.cpp:553
+#, fuzzy, c-format
+msgid "Do you want to save changes to %s before closing it?"
+msgstr "Ønsker du at gemme ændringer til %s?"
+
+#: ../src/common/docview.cpp:559
+#, fuzzy
+msgid "The document must be closed."
+msgstr "Teksten kunne ikke gemmes."
+
+#: ../src/common/docview.cpp:571
+#, c-format
+msgid "Saving %s failed, would you like to retry?"
+msgstr ""
+
+#: ../src/common/docview.cpp:577
+msgid "Retry"
+msgstr ""
+
+#: ../src/common/docview.cpp:577
+msgid "Discard changes"
+msgstr ""
+
+#: ../src/common/docview.cpp:679
+#, c-format
+msgid "File \"%s\" could not be opened for writing."
+msgstr "Filen \"%s\" kunne ikke åbnes for skrivning."
+
+#: ../src/common/docview.cpp:685
+#, c-format
+msgid "Failed to save document to the file \"%s\"."
+msgstr "Kunne ikke gemme dokumentet i filen \"%s\"."
+
+#: ../src/common/docview.cpp:702
+#, c-format
+msgid "File \"%s\" could not be opened for reading."
+msgstr "Filen \"%s\" kunne ikke åbnes for læsning."
+
+#: ../src/common/docview.cpp:714
+#, c-format
+msgid "Failed to read document from the file \"%s\"."
+msgstr "Kunne ikke læse dokument fra filen \"%s\"."
+
+#: ../src/common/docview.cpp:1236
+#, c-format
+msgid ""
+"The file '%s' doesn't exist and couldn't be opened.\n"
+"It has been removed from the most recently used files list."
+msgstr ""
+"Filen \"%s\" findes ikke og kunne ikke åbnes.\n"
+"Den er fjernet fra listen over senest brugte filer."
+
+#: ../src/common/docview.cpp:1296
+msgid "Print preview creation failed."
+msgstr "Oprettelse af udskriftsvisning fejlede."
+
+#: ../src/common/docview.cpp:1302
+msgid "Print Preview"
+msgstr "Udskriftsvisning"
+
+#: ../src/common/docview.cpp:1517
+#, c-format
+msgid "The format of file '%s' couldn't be determined."
+msgstr "Formatet på filen \"%s\" kunne ikke bestemmes."
+
+#: ../src/common/docview.cpp:1643
+#, c-format
+msgid "unnamed%d"
+msgstr "unavngivet%d"
+
+#: ../src/common/docview.cpp:1660
+msgid " - "
+msgstr " - "
+
+#: ../src/common/docview.cpp:1791 ../src/common/docview.cpp:1844
+msgid "Open File"
+msgstr "Åbn fil"
+
+#: ../src/common/docview.cpp:1807
+msgid "File error"
+msgstr "Filfejl"
+
+#: ../src/common/docview.cpp:1809
+msgid "Sorry, could not open this file."
+msgstr "Beklager, kunne ikke åbne denne fil."
+
+#: ../src/common/docview.cpp:1843
+msgid "Sorry, the format for this file is unknown."
+msgstr "Beklager, formatet for denne fil er ukendt."
+
+#: ../src/common/docview.cpp:1924
+msgid "Select a document template"
+msgstr "Vælg en dokumentskabelon"
+
+#: ../src/common/docview.cpp:1925
+msgid "Templates"
+msgstr "Skabeloner"
+
+#: ../src/common/docview.cpp:1998
+msgid "Select a document view"
+msgstr "Vælg en dokumentvisning"
+
+#: ../src/common/docview.cpp:1999
+msgid "Views"
+msgstr "Visninger"
+
+#: ../src/common/dynlib.cpp:81
+#, c-format
+msgid "Failed to load shared library '%s'"
+msgstr "Kunne ikke åbne delt bibliotek \"%s\""
+
+#: ../src/common/dynlib.cpp:105
+#, c-format
+msgid "Couldn't find symbol '%s' in a dynamic library"
+msgstr "Kunne ikke finde symbolet \"%s\" i et dynamisk bibliotek"
+
+#: ../src/common/ffile.cpp:56 ../src/common/file.cpp:215
+#, c-format
+msgid "can't open file '%s'"
+msgstr "kan ikke åbne filen \"%s\""
+
+#: ../src/common/ffile.cpp:72
+#, c-format
+msgid "can't close file '%s'"
+msgstr "kan ikke lukke filen \"%s\""
+
+#: ../src/common/ffile.cpp:106 ../src/common/ffile.cpp:131
+#, c-format
+msgid "Read error on file '%s'"
+msgstr "Læsefejl på filen \"%s\""
+
+#: ../src/common/ffile.cpp:148
+#, c-format
+msgid "Write error on file '%s'"
+msgstr "Skrivefejl på filen \"%s\""
+
+#: ../src/common/ffile.cpp:182
+#, c-format
+msgid "failed to flush the file '%s'"
+msgstr "kunne ikke flushe filen \"%s\""
+
+#: ../src/common/ffile.cpp:222
+#, c-format
+msgid "Seek error on file '%s' (large files not supported by stdio)"
+msgstr "Søgefejl på filen \"%s\" (store filer understøttes ikke af stdio)"
+
+#: ../src/common/ffile.cpp:232
+#, c-format
+msgid "Seek error on file '%s'"
+msgstr "Søgefejl på filen \"%s\""
+
+#: ../src/common/ffile.cpp:248
+#, c-format
+msgid "Can't find current position in file '%s'"
+msgstr "Kan ikke finde aktuel position i filen \"%s\""
+
+#: ../src/common/ffile.cpp:349 ../src/common/file.cpp:569
+msgid "Failed to set temporary file permissions"
+msgstr "Kunne ikke sætte midlertidige filrettigheder"
+
+#: ../src/common/ffile.cpp:371
+#, c-format
+msgid "can't remove file '%s'"
+msgstr "kan ikke fjerne filen \"%s\""
+
+#: ../src/common/ffile.cpp:376 ../src/common/file.cpp:591
+#, c-format
+msgid "can't commit changes to file '%s'"
+msgstr "kan ikke udføre ændringer på filen \"%s\""
+
+#: ../src/common/ffile.cpp:388 ../src/common/file.cpp:603
+#, c-format
+msgid "can't remove temporary file '%s'"
+msgstr "kan ikke fjerne midlertidig fil \"%s\""
+
+#: ../src/common/file.cpp:162
+#, c-format
+msgid "can't create file '%s'"
+msgstr "kan ikke oprette filen \"%s\""
+
+#: ../src/common/file.cpp:229
+#, c-format
+msgid "can't close file descriptor %d"
+msgstr "kan ikke lukke fildeskriptoren %d"
+
+#: ../src/common/file.cpp:332
+#, c-format
+msgid "can't read from file descriptor %d"
+msgstr "kan ikke læse fra fildeskriptoren %d"
+
+#: ../src/common/file.cpp:351
+#, c-format
+msgid "can't write to file descriptor %d"
+msgstr "kan ikke skrive til fildeskriptoren %d"
+
+#: ../src/common/file.cpp:390
+#, c-format
+msgid "can't flush file descriptor %d"
+msgstr "kan ikke flushe fildeskriptoren %d"
+
+#: ../src/common/file.cpp:432
+#, c-format
+msgid "can't seek on file descriptor %d"
+msgstr "kan ikke søge på fildeskriptoren %d"
+
+#: ../src/common/file.cpp:446
+#, c-format
+msgid "can't get seek position on file descriptor %d"
+msgstr "kan ikke få søgeposition på fildeskriptoren %d"
+
+#: ../src/common/file.cpp:475
+#, c-format
+msgid "can't find length of file on file descriptor %d"
+msgstr "kan ikke finde længden af filen på fildeskriptor %d"
+
+#: ../src/common/file.cpp:505
+#, c-format
+msgid "can't determine if the end of file is reached on descriptor %d"
+msgstr "kan ikke afgøre om slutningen på filen er nået på deskriptoren %d"
+
+#: ../src/common/fileconf.cpp:352
+#, c-format
+msgid ""
+" and additionally, the existing configuration file was renamed to \"%s\" and "
+"couldn't be renamed back, please rename it to its original path \"%s\""
+msgstr ""
+
+#: ../src/common/fileconf.cpp:389
+#, fuzzy
+msgid " due to the following error:\n"
+msgstr "Og inkluderer de følgende filer:\n"
+
+#: ../src/common/fileconf.cpp:412
+#, fuzzy
+msgid "failed to rename the existing file"
+msgstr "Kunne ikke læse dokument fra filen \"%s\"."
+
+#: ../src/common/fileconf.cpp:421
+#, fuzzy
+msgid "failed to create the new file directory"
+msgstr "Kunne ikke få den aktuelle arbejdsmappe"
+
+#: ../src/common/fileconf.cpp:428
+#, fuzzy
+msgid "failed to move the file to the new location"
+msgstr "Kunne ikke afslutte netværk via modem forbindelse: %s"
+
+#: ../src/common/fileconf.cpp:462
+#, c-format
+msgid "can't open global configuration file '%s'."
+msgstr "kan ikke åbne global konfigurationsfilen \"%s\"."
+
+#: ../src/common/fileconf.cpp:478
+#, c-format
+msgid "can't open user configuration file '%s'."
+msgstr "kan ikke åbne brugerkonfigurationsfilen \"%s\"."
+
+#: ../src/common/fileconf.cpp:483
+#, c-format
+msgid "Changes won't be saved to avoid overwriting the existing file \"%s\""
+msgstr ""
+"Ændringer vil ikke blive gemt for at undgå at overskrive den eksisterende "
+"fil \"%s\""
+
+#: ../src/common/fileconf.cpp:583
+msgid "Error reading config options."
+msgstr "Fejl ved læsning af konfigurationsvalg."
+
+#: ../src/common/fileconf.cpp:593
+msgid "Failed to read config options."
+msgstr "Kunne ikke læse konfigurationsvalg."
+
+#: ../src/common/fileconf.cpp:700
+#, c-format
+msgid "file '%s': unexpected character %c at line %zu."
+msgstr "fil \"%s\": uventet tegn %c på linje %zu."
+
+#: ../src/common/fileconf.cpp:736
+#, c-format
+msgid "file '%s', line %zu: '%s' ignored after group header."
+msgstr "fil \"%s\", linje %zu: \"%s\" ignoreret efter gruppe-header."
+
+#: ../src/common/fileconf.cpp:765
+#, c-format
+msgid "file '%s', line %zu: '=' expected."
+msgstr "fil \"%s\", linje %zu: forventede \"=\"."
+
+#: ../src/common/fileconf.cpp:778
+#, c-format
+msgid "file '%s', line %zu: value for immutable key '%s' ignored."
+msgstr ""
+"fil \"%s\", linje %zu: værdi af uforanderlig nøgle \"%s\" blev ignoreret."
+
+#: ../src/common/fileconf.cpp:788
+#, c-format
+msgid "file '%s', line %zu: key '%s' was first found at line %d."
+msgstr "fil \"%s\", linje %zu: nøgle \"%s\" blev først fundet på linje %d."
+
+#: ../src/common/fileconf.cpp:1091
+#, c-format
+msgid "Config entry name cannot start with '%c'."
+msgstr "Konfigurationspunkt må ikke begynde med \"%c\"."
+
+#: ../src/common/fileconf.cpp:1146
+#, fuzzy
+msgid "Failed to create configuration file directory."
+msgstr "Kunne ikke opdatere brugerkonfigurationsfil."
+
+#: ../src/common/fileconf.cpp:1158
+msgid "can't open user configuration file."
+msgstr "kan ikke åbne brugerkonfigurationsfilen."
+
+#: ../src/common/fileconf.cpp:1172
+msgid "can't write user configuration file."
+msgstr "kan ikke skrive brugerkonfigurationsfilen."
+
+#: ../src/common/fileconf.cpp:1178
+msgid "Failed to update user configuration file."
+msgstr "Kunne ikke opdatere brugerkonfigurationsfil."
+
+#: ../src/common/fileconf.cpp:1201
+msgid "Error saving user configuration data."
+msgstr "Fejl under gem bruger konfiguration data."
+
+#: ../src/common/fileconf.cpp:1313
+#, c-format
+msgid "can't delete user configuration file '%s'"
+msgstr "kan ikke slette brugerkonfigurationsfilen \"%s\""
+
+#: ../src/common/fileconf.cpp:2007
+#, c-format
+msgid "entry '%s' appears more than once in group '%s'"
+msgstr "indgang \"%s\" optræder mere end en gang i gruppe \"%s\""
+
+#: ../src/common/fileconf.cpp:2021
+#, c-format
+msgid "attempt to change immutable key '%s' ignored."
+msgstr "forsøg på at ændre uforanderlig nøgle \"%s\" ignoreret."
+
+#: ../src/common/fileconf.cpp:2118
+#, c-format
+msgid "trailing backslash ignored in '%s'"
+msgstr "efterstillet omvendt skråstreg ignoreret i \"%s\""
+
+#: ../src/common/fileconf.cpp:2153
+#, c-format
+msgid "unexpected \" at position %d in '%s'."
+msgstr "uventet \" på position %d i \"%s\"."
+
+#: ../src/common/filefn.cpp:474
+#, c-format
+msgid "Failed to copy the file '%s' to '%s'"
+msgstr "Kunne ikke kopiere filen \"%s\" til \"%s\""
+
+#: ../src/common/filefn.cpp:487
+#, c-format
+msgid "Impossible to get permissions for file '%s'"
+msgstr "Kunne ikke få rettigheder til filen \"%s\""
+
+#: ../src/common/filefn.cpp:501
+#, c-format
+msgid "Impossible to overwrite the file '%s'"
+msgstr "Kunne ikke overskrive filen \"%s\""
+
+#: ../src/common/filefn.cpp:508
+#, c-format
+msgid "Error copying the file '%s' to '%s'."
+msgstr "Kunne ikke kopiere filen \"%s\" til \"%s\"."
+
+#: ../src/common/filefn.cpp:556
+#, c-format
+msgid "Impossible to set permissions for the file '%s'"
+msgstr "Kunne ikke sætte rettigheder for filen \"%s\""
+
+#: ../src/common/filefn.cpp:606
+#, c-format
+msgid ""
+"Failed to rename the file '%s' to '%s' because the destination file already "
+"exists."
+msgstr ""
+"Kunne ikke omdøbe filen \"%s\" til \"%s\". Destinationsfilen findes allerede."
+
+#: ../src/common/filefn.cpp:623
+#, c-format
+msgid "File '%s' couldn't be renamed '%s'"
+msgstr "Filen \"%s\" kunne ikke omdøbes til \"%s\""
+
+#: ../src/common/filefn.cpp:639
+#, c-format
+msgid "File '%s' couldn't be removed"
+msgstr "Filen \"%s\" kunne ikke fjernes"
+
+#: ../src/common/filefn.cpp:666
+#, c-format
+msgid "Directory '%s' couldn't be created"
+msgstr "Mappen \"%s\" kunne ikke oprettes"
+
+#: ../src/common/filefn.cpp:680
+#, c-format
+msgid "Directory '%s' couldn't be deleted"
+msgstr "Mappen \"%s\" kunne ikke slettes"
+
+#: ../src/common/filefn.cpp:714
+#, c-format
+msgid "Cannot enumerate files '%s'"
+msgstr "Kan ikke læse fillisten i mappen \"%s\""
+
+#: ../src/common/filefn.cpp:798
+msgid "Failed to get the working directory"
+msgstr "Kunne ikke få den aktuelle arbejdsmappe"
+
+#: ../src/common/filefn.cpp:843
+msgid "Could not set current working directory"
+msgstr "Kunne ikke sætte den aktuelle arbejdsmappe"
+
+#: ../src/common/filefn.cpp:974
+#, c-format
+msgid "Files (%s)"
+msgstr "Filer (%s)"
+
+#: ../src/common/filename.cpp:182
+#, c-format
+msgid "Failed to open '%s' for reading"
+msgstr "Kunne ikke åbne \"%s\" for læsning"
+
+#: ../src/common/filename.cpp:187
+#, c-format
+msgid "Failed to open '%s' for writing"
+msgstr "Kunne ikke åbne \"%s\" for skrivning"
+
+#: ../src/common/filename.cpp:199
+msgid "Failed to close file handle"
+msgstr "Kunne ikke lukke filhåndtag"
+
+#: ../src/common/filename.cpp:1046
+msgid "Failed to create a temporary file name"
+msgstr "Kunne ikke oprette et midlertidigt filnavn"
+
+#: ../src/common/filename.cpp:1081
+msgid "Failed to open temporary file."
+msgstr "Kunne ikke åbne midlertidig fil."
+
+#: ../src/common/filename.cpp:2862
+#, c-format
+msgid "Failed to modify file times for '%s'"
+msgstr "Kunne ikke ændre filtid for \"%s\""
+
+#: ../src/common/filename.cpp:2877
+#, c-format
+msgid "Failed to touch the file '%s'"
+msgstr "Kunne ikke røre (touch) filen \"%s\""
+
+#: ../src/common/filename.cpp:2958
+#, c-format
+msgid "Failed to retrieve file times for '%s'"
+msgstr "Kunne ikke hente filtider for \"%s\""
+
+#: ../src/common/filepickercmn.cpp:39 ../src/common/filepickercmn.cpp:40
+msgid "Browse"
+msgstr "Gennemse"
+
+#: ../src/common/fldlgcmn.cpp:792 ../src/generic/filectrlg.cpp:1185
+#, c-format
+msgid "All files (%s)|%s"
+msgstr "Alle filer (%s)|%s"
+
+#. TRANSLATORS: %s are a file extension used to build a file wildcard string
+#: ../src/common/fldlgcmn.cpp:810
+#, c-format
+msgid "%s files (%s)|%s"
+msgstr "%s filer (%s)|%s"
+
+#: ../src/common/fldlgcmn.cpp:1072
+#, c-format
+msgid "Load %s file"
+msgstr "Læs %s fil"
+
+#: ../src/common/fldlgcmn.cpp:1074
+#, c-format
+msgid "Save %s file"
+msgstr "Gem %s fil"
+
+#: ../src/common/fmapbase.cpp:144
+msgid "Western European (ISO-8859-1)"
+msgstr "Vesteuropæisk (ISO-8859-1)"
+
+#: ../src/common/fmapbase.cpp:145
+msgid "Central European (ISO-8859-2)"
+msgstr "Centraleuropæisk (ISO-8859-2)"
+
+#: ../src/common/fmapbase.cpp:146
+msgid "Esperanto (ISO-8859-3)"
+msgstr "Esperanto (ISO-8859-3)"
+
+#: ../src/common/fmapbase.cpp:147
+msgid "Baltic (old) (ISO-8859-4)"
+msgstr "Baltisk (gammel) (ISO-8859-4)"
+
+#: ../src/common/fmapbase.cpp:148
+msgid "Cyrillic (ISO-8859-5)"
+msgstr "Kyrillisk (ISO-8859-5)"
+
+#: ../src/common/fmapbase.cpp:149
+msgid "Arabic (ISO-8859-6)"
+msgstr "Arabisk (ISO-8859-6)"
+
+#: ../src/common/fmapbase.cpp:150
+msgid "Greek (ISO-8859-7)"
+msgstr "Græsk (ISO-8859-7)"
+
+#: ../src/common/fmapbase.cpp:151
+msgid "Hebrew (ISO-8859-8)"
+msgstr "Hebraisk (ISO-8859-8)"
+
+#: ../src/common/fmapbase.cpp:152
+msgid "Turkish (ISO-8859-9)"
+msgstr "Tyrkisk (ISO-8859-9)"
+
+#: ../src/common/fmapbase.cpp:153
+msgid "Nordic (ISO-8859-10)"
+msgstr "Nordisk (ISO-8859-10)"
+
+#: ../src/common/fmapbase.cpp:154
+msgid "Thai (ISO-8859-11)"
+msgstr "Thailandsk (ISO-8859-11)"
+
+#: ../src/common/fmapbase.cpp:155
+msgid "Indian (ISO-8859-12)"
+msgstr "Indisk (ISO-8859-12)"
+
+#: ../src/common/fmapbase.cpp:156
+msgid "Baltic (ISO-8859-13)"
+msgstr "Baltisk (ISO-8859-13)"
+
+#: ../src/common/fmapbase.cpp:157
+msgid "Celtic (ISO-8859-14)"
+msgstr "Keltisk (ISO-8859-14)"
+
+#: ../src/common/fmapbase.cpp:158
+msgid "Western European with Euro (ISO-8859-15)"
+msgstr "Vesteuropæisk med euro (ISO-8859-15)"
+
+#: ../src/common/fmapbase.cpp:159
+msgid "KOI8-R"
+msgstr "KOI8-R"
+
+#: ../src/common/fmapbase.cpp:160
+msgid "KOI8-U"
+msgstr "KOI8-U"
+
+#: ../src/common/fmapbase.cpp:161
+msgid "Windows/DOS OEM Cyrillic (CP 866)"
+msgstr "Windows/DOS OEM kyrillisk (CP 866)"
+
+#: ../src/common/fmapbase.cpp:162
+msgid "Windows Thai (CP 874)"
+msgstr "Windows thailandsk (CP 874)"
+
+#: ../src/common/fmapbase.cpp:163
+msgid "Windows Japanese (CP 932) or Shift-JIS"
+msgstr "Windows japansk (CP 932) eller Shift-JIS"
+
+#: ../src/common/fmapbase.cpp:164
+msgid "Windows Chinese Simplified (CP 936) or GB-2312"
+msgstr "Windows kinesisk forenklet (CP 936) eller GB-2312"
+
+#: ../src/common/fmapbase.cpp:165
+msgid "Windows Korean (CP 949)"
+msgstr "Windows koreansk (CP 949)"
+
+#: ../src/common/fmapbase.cpp:166
+msgid "Windows Chinese Traditional (CP 950) or Big-5"
+msgstr "Windows kinesisk traditionel (CP 950) eller Big-5"
+
+#: ../src/common/fmapbase.cpp:167
+msgid "Windows Central European (CP 1250)"
+msgstr "Windows centraleuropæisk (CP 1250)"
+
+#: ../src/common/fmapbase.cpp:168
+msgid "Windows Cyrillic (CP 1251)"
+msgstr "Windows kyrillisk (CP 1251)"
+
+#: ../src/common/fmapbase.cpp:169
+msgid "Windows Western European (CP 1252)"
+msgstr "Windows vesteuropæisk (CP 1252)"
+
+#: ../src/common/fmapbase.cpp:170
+msgid "Windows Greek (CP 1253)"
+msgstr "Windows græsk (CP 1253)"
+
+#: ../src/common/fmapbase.cpp:171
+msgid "Windows Turkish (CP 1254)"
+msgstr "Windows tyrkisk (CP 1254)"
+
+#: ../src/common/fmapbase.cpp:172
+msgid "Windows Hebrew (CP 1255)"
+msgstr "Windows hebraisk (CP 1255)"
+
+#: ../src/common/fmapbase.cpp:173
+msgid "Windows Arabic (CP 1256)"
+msgstr "Windows arabisk (CP 1256)"
+
+#: ../src/common/fmapbase.cpp:174
+msgid "Windows Baltic (CP 1257)"
+msgstr "Windows baltisk (CP 1257)"
+
+#: ../src/common/fmapbase.cpp:175
+msgid "Windows Vietnamese (CP 1258)"
+msgstr "Windows vietnamesisk (CP 1258)"
+
+#: ../src/common/fmapbase.cpp:176
+msgid "Windows Johab (CP 1361)"
+msgstr "Windows johab (CP 1361)"
+
+#: ../src/common/fmapbase.cpp:177
+msgid "Windows/DOS OEM (CP 437)"
+msgstr "Windows/DOS OEM (CP 437)"
+
+#: ../src/common/fmapbase.cpp:178
+msgid "Unicode 7 bit (UTF-7)"
+msgstr "Unicode 7 bit (UTF-7)"
+
+#: ../src/common/fmapbase.cpp:179
+msgid "Unicode 8 bit (UTF-8)"
+msgstr "Unicode 8 bit (UTF-8)"
+
+#: ../src/common/fmapbase.cpp:181 ../src/common/fmapbase.cpp:187
+msgid "Unicode 16 bit (UTF-16)"
+msgstr "Unicode 16 bit (UTF-16)"
+
+#: ../src/common/fmapbase.cpp:182
+msgid "Unicode 16 bit Little Endian (UTF-16LE)"
+msgstr "Unicode 16 bit Little Endian (UTF-16LE)"
+
+#: ../src/common/fmapbase.cpp:183 ../src/common/fmapbase.cpp:189
+msgid "Unicode 32 bit (UTF-32)"
+msgstr "Unicode 32 bit (UTF-32)"
+
+#: ../src/common/fmapbase.cpp:184
+msgid "Unicode 32 bit Little Endian (UTF-32LE)"
+msgstr "Unicode 32 bit Little Endian (UTF-32LE)"
+
+#: ../src/common/fmapbase.cpp:186
+msgid "Unicode 16 bit Big Endian (UTF-16BE)"
+msgstr "Unicode 16 bit Big Endian (UTF-16BE)"
+
+#: ../src/common/fmapbase.cpp:188
+msgid "Unicode 32 bit Big Endian (UTF-32BE)"
+msgstr "Unicode 32 bit Big Endian (UTF-32BE)"
+
+#: ../src/common/fmapbase.cpp:191
+msgid "Extended Unix Codepage for Japanese (EUC-JP)"
+msgstr "Extended Unix Codepage for Japansk (EUC-JP)"
+
+#: ../src/common/fmapbase.cpp:192
+msgid "US-ASCII"
+msgstr "US-ASCII"
+
+#: ../src/common/fmapbase.cpp:193
+msgid "ISO-2022-JP"
+msgstr "ISO-2022-JP"
+
+#: ../src/common/fmapbase.cpp:195
+msgid "MacRoman"
+msgstr "MacRoman"
+
+#: ../src/common/fmapbase.cpp:196
+msgid "MacJapanese"
+msgstr "MacJapanese"
+
+#: ../src/common/fmapbase.cpp:197
+msgid "MacChineseTrad"
+msgstr "MacChineseTrad"
+
+#: ../src/common/fmapbase.cpp:198
+msgid "MacKorean"
+msgstr "MacKorean"
+
+#: ../src/common/fmapbase.cpp:199
+msgid "MacArabic"
+msgstr "MacArabic"
+
+#: ../src/common/fmapbase.cpp:200
+msgid "MacHebrew"
+msgstr "MacHebrew"
+
+#: ../src/common/fmapbase.cpp:201
+msgid "MacGreek"
+msgstr "MacGreek"
+
+#: ../src/common/fmapbase.cpp:202
+msgid "MacCyrillic"
+msgstr "MacCyrillic"
+
+#: ../src/common/fmapbase.cpp:203
+msgid "MacDevanagari"
+msgstr "MacDevanagari"
+
+#: ../src/common/fmapbase.cpp:204
+msgid "MacGurmukhi"
+msgstr "MacGurmukhi"
+
+#: ../src/common/fmapbase.cpp:205
+msgid "MacGujarati"
+msgstr "MacGujarati"
+
+#: ../src/common/fmapbase.cpp:206
+msgid "MacOriya"
+msgstr "MacOriya"
+
+#: ../src/common/fmapbase.cpp:207
+msgid "MacBengali"
+msgstr "MacBengali"
+
+#: ../src/common/fmapbase.cpp:208
+msgid "MacTamil"
+msgstr "MacTamil"
+
+#: ../src/common/fmapbase.cpp:209
+msgid "MacTelugu"
+msgstr "MacTelugu"
+
+#: ../src/common/fmapbase.cpp:210
+msgid "MacKannada"
+msgstr "MacKannada"
+
+#: ../src/common/fmapbase.cpp:211
+msgid "MacMalayalam"
+msgstr "MacMalayalam"
+
+#: ../src/common/fmapbase.cpp:212
+msgid "MacSinhalese"
+msgstr "MacSinhalese"
+
+#: ../src/common/fmapbase.cpp:213
+msgid "MacBurmese"
+msgstr "MacBurmese"
+
+#: ../src/common/fmapbase.cpp:214
+msgid "MacKhmer"
+msgstr "MacKhmer"
+
+#: ../src/common/fmapbase.cpp:215
+msgid "MacThai"
+msgstr "MacThai"
+
+#: ../src/common/fmapbase.cpp:216
+msgid "MacLaotian"
+msgstr "MacLaotian"
+
+#: ../src/common/fmapbase.cpp:217
+msgid "MacGeorgian"
+msgstr "MacGeorgian"
+
+#: ../src/common/fmapbase.cpp:218
+msgid "MacArmenian"
+msgstr "MacArmenian"
+
+#: ../src/common/fmapbase.cpp:219
+msgid "MacChineseSimp"
+msgstr "MacChineseSimp"
+
+#: ../src/common/fmapbase.cpp:220
+msgid "MacTibetan"
+msgstr "MacTibetan"
+
+#: ../src/common/fmapbase.cpp:221
+msgid "MacMongolian"
+msgstr "MacMongolian"
+
+#: ../src/common/fmapbase.cpp:222
+msgid "MacEthiopic"
+msgstr "MacEthiopic"
+
+#: ../src/common/fmapbase.cpp:223
+msgid "MacCentralEurRoman"
+msgstr "MacCentralEurRoman"
+
+#: ../src/common/fmapbase.cpp:224
+msgid "MacVietnamese"
+msgstr "MacVietnamese"
+
+#: ../src/common/fmapbase.cpp:225
+msgid "MacExtArabic"
+msgstr "MacExtArabic"
+
+#: ../src/common/fmapbase.cpp:226
+msgid "MacSymbol"
+msgstr "MacSymbol"
+
+#: ../src/common/fmapbase.cpp:227
+msgid "MacDingbats"
+msgstr "MacDingbats"
+
+#: ../src/common/fmapbase.cpp:228
+msgid "MacTurkish"
+msgstr "MacTurkish"
+
+#: ../src/common/fmapbase.cpp:229
+msgid "MacCroatian"
+msgstr "MacCroatian"
+
+#: ../src/common/fmapbase.cpp:230
+msgid "MacIcelandic"
+msgstr "MacIcelandic"
+
+#: ../src/common/fmapbase.cpp:231
+msgid "MacRomanian"
+msgstr "MacRomanian"
+
+#: ../src/common/fmapbase.cpp:232
+msgid "MacCeltic"
+msgstr "MacCeltic"
+
+#: ../src/common/fmapbase.cpp:233
+msgid "MacGaelic"
+msgstr "MacGaelic"
+
+#: ../src/common/fmapbase.cpp:234
+msgid "MacKeyboardGlyphs"
+msgstr "MacKeyboardGlyphs"
+
+#: ../src/common/fmapbase.cpp:791
+msgid "Default encoding"
+msgstr "Standardkodning"
+
+#: ../src/common/fmapbase.cpp:805
+#, c-format
+msgid "Unknown encoding (%d)"
+msgstr "Ukendt kodning (%d)"
+
+#: ../src/common/fmapbase.cpp:815 ../src/richtext/richtextstyles.cpp:776
+msgid "default"
+msgstr "standard"
+
+#: ../src/common/fmapbase.cpp:829
+#, c-format
+msgid "unknown-%d"
+msgstr "ukendt-%d"
+
+#: ../src/common/fontcmn.cpp:924 ../src/common/fontcmn.cpp:1130
+msgid "underlined"
+msgstr "understreget"
+
+#: ../src/common/fontcmn.cpp:929
+msgid " strikethrough"
+msgstr " gennemstreget"
+
+#: ../src/common/fontcmn.cpp:942
+msgid " thin"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:946
+#, fuzzy
+msgid " extra light"
+msgstr " let"
+
+#: ../src/common/fontcmn.cpp:950
+msgid " light"
+msgstr " let"
+
+#: ../src/common/fontcmn.cpp:954
+msgid " medium"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:958
+#, fuzzy
+msgid " semi bold"
+msgstr " fed"
+
+#: ../src/common/fontcmn.cpp:962
+msgid " bold"
+msgstr " fed"
+
+#: ../src/common/fontcmn.cpp:966
+#, fuzzy
+msgid " extra bold"
+msgstr " fed"
+
+#: ../src/common/fontcmn.cpp:970
+msgid " heavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:974
+msgid " extra heavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:990
+msgid " italic"
+msgstr " kursiv"
+
+#: ../src/common/fontcmn.cpp:1134
+msgid "strikethrough"
+msgstr "gennemstreget"
+
+#: ../src/common/fontcmn.cpp:1143
+msgid "thin"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1156
+#, fuzzy
+msgid "extralight"
+msgstr "let"
+
+#: ../src/common/fontcmn.cpp:1161
+msgid "light"
+msgstr "let"
+
+#: ../src/common/fontcmn.cpp:1169 ../src/richtext/richtextstyles.cpp:775
+msgid "normal"
+msgstr "normal"
+
+#: ../src/common/fontcmn.cpp:1174
+msgid "medium"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1179 ../src/common/fontcmn.cpp:1199
+#, fuzzy
+msgid "semibold"
+msgstr "fed"
+
+#: ../src/common/fontcmn.cpp:1184
+msgid "bold"
+msgstr "fed"
+
+#: ../src/common/fontcmn.cpp:1194
+#, fuzzy
+msgid "extrabold"
+msgstr "fed"
+
+#: ../src/common/fontcmn.cpp:1204
+msgid "heavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1212
+msgid "extraheavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1217
+msgid "italic"
+msgstr "kursiv"
+
+#: ../src/common/fontmap.cpp:195
+msgid ": unknown charset"
+msgstr ": ukendt tegnsæt"
+
+#: ../src/common/fontmap.cpp:199
+#, c-format
+msgid ""
+"The charset '%s' is unknown. You may select\n"
+"another charset to replace it with or choose\n"
+"[Cancel] if it cannot be replaced"
+msgstr ""
+"Tegnsættet \"%s\" er ukendt. Du kan vælge\n"
+"et andet til at erstatte det, eller vælg\n"
+"[Annullér] hvis det ikke kan erstattes"
+
+#: ../src/common/fontmap.cpp:241
+#, c-format
+msgid "Failed to remember the encoding for the charset '%s'."
+msgstr "Kunne ikke huske kodning for tegnsættet \"%s\"."
+
+#: ../src/common/fontmap.cpp:321
+msgid "can't load any font, aborting"
+msgstr "kan ikke indlæse nogen skrifttype, afbryder"
+
+#: ../src/common/fontmap.cpp:409
+msgid ": unknown encoding"
+msgstr ": ukendt kodning"
+
+#: ../src/common/fontmap.cpp:417
+#, c-format
+msgid ""
+"No font for displaying text in encoding '%s' found,\n"
+"but an alternative encoding '%s' is available.\n"
+"Do you want to use this encoding (otherwise you will have to choose another "
+"one)?"
+msgstr ""
+"Fandt ikke skrifttype til at vise tekst med kodning \"%s\",\n"
+"men en alternativ kodning \"%s\" er tilgængelig.\n"
+"Vil du bruge denne kodning (eller skal du vælge en anden)?"
+
+#: ../src/common/fontmap.cpp:422
+#, c-format
+msgid ""
+"No font for displaying text in encoding '%s' found.\n"
+"Would you like to select a font to be used for this encoding\n"
+"(otherwise the text in this encoding will not be shown correctly)?"
+msgstr ""
+"Ingen skrifttype fundet til at vise tekst i kodningen \"%s\".\n"
+"Vil du vælge en skrifttype til brug for denne kodning\n"
+"(ellers bliver tekst i denne kodning ikke vist korrekt)?"
+
+#: ../src/common/fs_mem.cpp:169
+#, c-format
+msgid "Memory VFS already contains file '%s'!"
+msgstr "Hukommelse VFS indeholder allerede filen \"%s\"!"
+
+#: ../src/common/fs_mem.cpp:232
+#, c-format
+msgid "Trying to remove file '%s' from memory VFS, but it is not loaded!"
+msgstr ""
+"Prøver at fjerne filen \"%s\" fra hukommelsen VFS, men den er ikke indlæst!"
+
+#: ../src/common/fs_mem.cpp:262
+#, c-format
+msgid "Failed to store image '%s' to memory VFS!"
+msgstr "Kunne ikke gemme billede \"%s\" i hukommelsen VFS!"
+
+#: ../src/common/ftp.cpp:197
+msgid "Timeout while waiting for FTP server to connect, try passive mode."
+msgstr ""
+"Timeout under ventning på, at FTP-server skulle oprette forbindelse. Prøv "
+"passiv-tilstand."
+
+#: ../src/common/ftp.cpp:399
+#, c-format
+msgid "Failed to set FTP transfer mode to %s."
+msgstr "Kunne ikke sætte FTP transfer mode til %s."
+
+#: ../src/common/ftp.cpp:400 ../src/richtext/richtextsymboldlg.cpp:432
+msgid "ASCII"
+msgstr "ASCII"
+
+#: ../src/common/ftp.cpp:400
+msgid "binary"
+msgstr "binær"
+
+#: ../src/common/ftp.cpp:608
+msgid "The FTP server doesn't support the PORT command."
+msgstr "FTP-serveren understøtter ikke PORT-kommandoen."
+
+#: ../src/common/ftp.cpp:622
+msgid "The FTP server doesn't support passive mode."
+msgstr "FTP-serveren understøtter ikke passiv-tilstand."
+
+#: ../src/common/gifdecod.cpp:822
+#, c-format
+msgid "Incorrect GIF frame size (%u, %d) for the frame #%u"
+msgstr "Forkert GIF billedstørrelse (%u, %d) for ramme #%u"
+
+#: ../src/common/glcmn.cpp:108
+msgid "Failed to allocate colour for OpenGL"
+msgstr "Kunne ikke tildele farve til OpenGL"
+
+#: ../src/common/headerctrlcmn.cpp:57
+msgid "Please select the columns to show and define their order:"
+msgstr "Vælg de kolonner, der skal vises, og definer rækkefølge:"
+
+#: ../src/common/headerctrlcmn.cpp:58
+msgid "Customize Columns"
+msgstr "Tilpas kolonner"
+
+#: ../src/common/headerctrlcmn.cpp:304
+msgid "&Customize..."
+msgstr "&Tilpas..."
+
+#: ../src/common/hyperlnkcmn.cpp:132
+#, fuzzy, c-format
+msgid "Failed to open URL \"%s\" in the default browser"
+msgstr "Kunne ikke åbne URL \"%s\" standard-browseren."
+
+#: ../src/common/iconbndl.cpp:195
+#, c-format
+msgid "Failed to load image %%d from file '%s'."
+msgstr "Kunne ikke læse billede %%d fra file \"%s\"."
+
+#: ../src/common/iconbndl.cpp:203
+#, c-format
+msgid "Failed to load image %d from stream."
+msgstr "Kunne ikke læse billede %d fra strøm."
+
+#: ../src/common/iconbndl.cpp:221
+#, c-format
+msgid "Failed to load icons from resource '%s'."
+msgstr "Kunne ikke indlæse ikoner fra ressource \"%s\"."
+
+#: ../src/common/imagbmp.cpp:97
+msgid "BMP: Couldn't save invalid image."
+msgstr "BMP: kunne ikke gemme ugyldigt billede."
+
+#: ../src/common/imagbmp.cpp:137
+msgid "BMP: wxImage doesn't have own wxPalette."
+msgstr "BMP: wxImage har ikke sin egen wxPalette."
+
+#: ../src/common/imagbmp.cpp:243
+msgid "BMP: Couldn't write the file (Bitmap) header."
+msgstr "BMP: kunne ikke skrive filheaderen (Bitmap)."
+
+#: ../src/common/imagbmp.cpp:266
+msgid "BMP: Couldn't write the file (BitmapInfo) header."
+msgstr "BMP: kunne ikke skrive filheaderen (BitmapInfo)."
+
+#: ../src/common/imagbmp.cpp:353
+msgid "BMP: Couldn't write RGB color map."
+msgstr "BMP: kunne ikke skrive RGB-farvekort."
+
+#: ../src/common/imagbmp.cpp:487
+msgid "BMP: Couldn't write data."
+msgstr "BMP: kunne ikke skrive data."
+
+#: ../src/common/imagbmp.cpp:561 ../src/common/imagbmp.cpp:642
+msgid "BMP: Couldn't allocate memory."
+msgstr "BMP: kunne ikke tildele hukommelse."
+
+#: ../src/common/imagbmp.cpp:1041
+msgid "DIB Header: Image width > 32767 pixels for file."
+msgstr "DIB-header: billedbredde > 32767 pixels for filen."
+
+#: ../src/common/imagbmp.cpp:1049
+msgid "DIB Header: Image height > 32767 pixels for file."
+msgstr "DIB-header: billedhøjde > 32767 pixels i filen."
+
+#: ../src/common/imagbmp.cpp:1081
+msgid "DIB Header: Unknown bitdepth in file."
+msgstr "DIB-header: ukendt bitdybde i filen."
+
+#: ../src/common/imagbmp.cpp:1156
+msgid "DIB Header: Unknown encoding in file."
+msgstr "DIB-header: ukendt kodning i filen."
+
+#: ../src/common/imagbmp.cpp:1165
+msgid "DIB Header: Encoding doesn't match bitdepth."
+msgstr "DIB-header: kodning svarer ikke til bitdybden."
+
+#: ../src/common/imagbmp.cpp:1180
+#, c-format
+msgid "BMP Header: Invalid number of colors (%d)."
+msgstr ""
+
+#: ../src/common/imagbmp.cpp:1273
+msgid "Error in reading image DIB."
+msgstr "Fejl ved læsning af billede DIB."
+
+#: ../src/common/imagbmp.cpp:1294
+msgid "ICO: Error in reading mask DIB."
+msgstr "ICO: fejl ved læsning af maske DIB."
+
+#: ../src/common/imagbmp.cpp:1353
+msgid "ICO: Image too tall for an icon."
+msgstr "ICO: billede for højt til ikon."
+
+#: ../src/common/imagbmp.cpp:1361
+msgid "ICO: Image too wide for an icon."
+msgstr "ICO: billede for bredt til ikon."
+
+#: ../src/common/imagbmp.cpp:1388 ../src/common/imagbmp.cpp:1488
+#: ../src/common/imagbmp.cpp:1503 ../src/common/imagbmp.cpp:1514
+#: ../src/common/imagbmp.cpp:1528 ../src/common/imagbmp.cpp:1576
+#: ../src/common/imagbmp.cpp:1591 ../src/common/imagbmp.cpp:1605
+#: ../src/common/imagbmp.cpp:1616
+msgid "ICO: Error writing the image file!"
+msgstr "ICO: fejl ved skrivning af billedfilen!"
+
+#: ../src/common/imagbmp.cpp:1701
+msgid "ICO: Invalid icon index."
+msgstr "ICO: ugyldigt ikonindeks."
+
+#: ../src/common/image.cpp:2410
+msgid "Image and mask have different sizes."
+msgstr "Billede og maske har forskellige størrelser."
+
+#: ../src/common/image.cpp:2418 ../src/common/image.cpp:2459
+msgid "No unused colour in image being masked."
+msgstr "Ingen ubrugte farver i det billede, der skal maskes."
+
+#: ../src/common/image.cpp:2641
+#, c-format
+msgid "Failed to load bitmap \"%s\" from resources."
+msgstr "Kunne ikke indlæse bitmap \"%s\" fra ressourcer."
+
+#: ../src/common/image.cpp:2650
+#, c-format
+msgid "Failed to load icon \"%s\" from resources."
+msgstr "Kunne ikke indlæse ikon \"%s\" fra ressourcer."
+
+#: ../src/common/image.cpp:2728 ../src/common/image.cpp:2747
+#, c-format
+msgid "Failed to load image from file \"%s\"."
+msgstr "Kunne ikke indlæse billede fra file \"%s\"."
+
+#: ../src/common/image.cpp:2761
+#, c-format
+msgid "Can't save image to file '%s': unknown extension."
+msgstr "Kan ikke gemme til filen \"%s\": ukendt filtype."
+
+#: ../src/common/image.cpp:2869
+msgid "No handler found for image type."
+msgstr "Ingen rutine fundet til denne billedtype."
+
+#: ../src/common/image.cpp:2877 ../src/common/image.cpp:3000
+#: ../src/common/image.cpp:3066
+#, c-format
+msgid "No image handler for type %d defined."
+msgstr "Ingen billedrutine defineret for type %d."
+
+#: ../src/common/image.cpp:2887
+#, c-format
+msgid "Image file is not of type %d."
+msgstr "Billedfilen er ikke af type %d."
+
+#: ../src/common/image.cpp:2970
+msgid "Can't automatically determine the image format for non-seekable input."
+msgstr "Kan ikke automatisk bestemme billedformat for ikke-søgbart input."
+
+#: ../src/common/image.cpp:2988
+msgid "Unknown image data format."
+msgstr "Ukendt billeddataformat."
+
+#: ../src/common/image.cpp:3009
+#, c-format
+msgid "This is not a %s."
+msgstr "Dette er ikke nogen %s."
+
+#: ../src/common/image.cpp:3032 ../src/common/image.cpp:3080
+#, c-format
+msgid "No image handler for type %s defined."
+msgstr "Ingen billedrutine defineret for type %s."
+
+#: ../src/common/image.cpp:3041
+#, c-format
+msgid "Image is not of type %s."
+msgstr "Billedet er ikke af typen %s."
+
+#: ../src/common/image.cpp:3509
+#, c-format
+msgid "Failed to check format of image file \"%s\"."
+msgstr "Kunne ikke tjekke format af billedfilen \"%s\"."
+
+#: ../src/common/imaggif.cpp:124
+msgid "GIF: error in GIF image format."
+msgstr "GIF: fejl i GIF billedformat."
+
+#: ../src/common/imaggif.cpp:129
+msgid "GIF: not enough memory."
+msgstr "GIF: ikke nok ledig hukommelse."
+
+#: ../src/common/imaggif.cpp:134
+msgid "GIF: data stream seems to be truncated."
+msgstr "GIF: datastrøm tilsyneladende for kort."
+
+#: ../src/common/imaggif.cpp:240
+msgid "Couldn't initialize GIF hash table."
+msgstr "Kunne ikke initialisere GIF hash tabel."
+
+#: ../src/common/imagiff.cpp:739
+msgid "IFF: error in IFF image format."
+msgstr "IFF: fejl i IFF billedformat."
+
+#: ../src/common/imagiff.cpp:742
+msgid "IFF: not enough memory."
+msgstr "IFF: ikke nok ledig hukommelse."
+
+#: ../src/common/imagiff.cpp:745
+msgid "IFF: unknown error!!!"
+msgstr "IFF: ukendt fejl!!!"
+
+#: ../src/common/imagiff.cpp:755
+msgid "IFF: data stream seems to be truncated."
+msgstr "IFF: datastrøm tilsyneladende for kort."
+
+#: ../src/common/imagjpeg.cpp:258
+msgid "JPEG: Couldn't load - file is probably corrupted."
+msgstr "JPEG: kunne ikke læse - filen er sikkert defekt."
+
+#: ../src/common/imagjpeg.cpp:437
+msgid "JPEG: Couldn't save image."
+msgstr "JPEG: kunne ikke gemme billede."
+
+#: ../src/common/imagpcx.cpp:439
+msgid "PCX: this is not a PCX file."
+msgstr "PCX: dette er ikke en PCX-fil."
+
+#: ../src/common/imagpcx.cpp:453
+msgid "PCX: image format unsupported"
+msgstr "PCX: billedformat ikke understøttet"
+
+#: ../src/common/imagpcx.cpp:454 ../src/common/imagpcx.cpp:477
+msgid "PCX: couldn't allocate memory"
+msgstr "PCX: kunne ikke tildele hukommelse"
+
+#: ../src/common/imagpcx.cpp:455
+msgid "PCX: version number too low"
+msgstr "PCX: for lavt versionsnummer"
+
+#: ../src/common/imagpcx.cpp:456 ../src/common/imagpcx.cpp:478
+msgid "PCX: unknown error !!!"
+msgstr "PCX: ukendt fejl!!!"
+
+#: ../src/common/imagpcx.cpp:476
+msgid "PCX: invalid image"
+msgstr "PCX: ugyldigt billede"
+
+#: ../src/common/imagpng.cpp:385
+#, c-format
+msgid "Unknown PNG resolution unit %d"
+msgstr "Ukendt PNG opløsningsenhed %d"
+
+#: ../src/common/imagpng.cpp:439
+msgid "Couldn't load a PNG image - file is corrupted or not enough memory."
+msgstr ""
+"Kunne ikke indlæse et PNG-billede - filen er korrupt eller ikke nok ledig "
+"hukommelse."
+
+#: ../src/common/imagpng.cpp:513 ../src/common/imagpng.cpp:524
+#: ../src/common/imagpng.cpp:534
+msgid "Couldn't save PNG image."
+msgstr "Kunne ikke gemme PNG billede."
+
+#: ../src/common/imagpnm.cpp:71
+msgid "PNM: File format is not recognized."
+msgstr "PNM: filformatet ikke genkendt."
+
+#: ../src/common/imagpnm.cpp:89
+msgid "PNM: Couldn't allocate memory."
+msgstr "PNM: kunne ikke tildele hukommelse."
+
+#: ../src/common/imagpnm.cpp:111 ../src/common/imagpnm.cpp:134
+#: ../src/common/imagpnm.cpp:156
+msgid "PNM: File seems truncated."
+msgstr "PNM: filen synes at være afskåret."
+
+#: ../src/common/imagtiff.cpp:69
+#, c-format
+msgid " (in module \"%s\")"
+msgstr " (i modul \"%s\")"
+
+#: ../src/common/imagtiff.cpp:304
+msgid "TIFF: Error loading image."
+msgstr "TIFF: fejl ved læsning af billede."
+
+#: ../src/common/imagtiff.cpp:314
+msgid "Invalid TIFF image index."
+msgstr "Ugyldigt TIFF billedindeks."
+
+#: ../src/common/imagtiff.cpp:358
+msgid "TIFF: Image size is abnormally big."
+msgstr "TIFF: billedstørrelse er unormalt stor."
+
+#: ../src/common/imagtiff.cpp:372 ../src/common/imagtiff.cpp:385
+#: ../src/common/imagtiff.cpp:769
+msgid "TIFF: Couldn't allocate memory."
+msgstr "TIFF: kunne ikke få hukommelse."
+
+#: ../src/common/imagtiff.cpp:471
+msgid "TIFF: Error reading image."
+msgstr "TIFF: fejl ved læsning af billede."
+
+#: ../src/common/imagtiff.cpp:532
+#, c-format
+msgid "Unknown TIFF resolution unit %d ignored"
+msgstr "Ukendt TIFF opløsningsenhed %d ignoreret"
+
+#: ../src/common/imagtiff.cpp:611
+msgid "TIFF: Error saving image."
+msgstr "TIFF: fejl ved gemning af billede."
+
+#: ../src/common/imagtiff.cpp:868
+msgid "TIFF: Error writing image."
+msgstr "TIFF: fejl ved skrivning af billede."
+
+#: ../src/common/imagtiff.cpp:881
+#, fuzzy
+msgid "TIFF: Error flushing data."
+msgstr "TIFF: fejl ved gemning af billede."
+
+#: ../src/common/imagwebp.cpp:56
+msgid "WebP: Invalid data (failed to get features)."
+msgstr ""
+
+#: ../src/common/imagwebp.cpp:65
+msgid "WebP: Allocating image memory failed."
+msgstr ""
+
+#: ../src/common/imagwebp.cpp:82
+msgid "WebP: Decoding RGBA image data failed."
+msgstr ""
+
+#: ../src/common/imagwebp.cpp:98
+msgid "WebP: Decoding RGB image data failed."
+msgstr ""
+
+#: ../src/common/imagwebp.cpp:113 ../src/common/imagwebp.cpp:201
+msgid "WebP: Allocating stream buffer failed."
+msgstr ""
+
+#: ../src/common/imagwebp.cpp:131
+#, fuzzy
+msgid "WebP: Failed to parse container data."
+msgstr "Kunne ikke sende data til udklipsholder."
+
+#: ../src/common/imagwebp.cpp:222
+#, fuzzy
+msgid "WebP: Error decoding animation."
+msgstr "Fejl ved læsning af konfigurationsvalg."
+
+#: ../src/common/imagwebp.cpp:240
+msgid "WebP: Error getting next animation frame."
+msgstr ""
+
+#: ../src/common/init.cpp:172
+#, c-format
+msgid ""
+"Command line argument %d couldn't be converted to Unicode and will be "
+"ignored."
+msgstr ""
+"Kommandolinjeparameter %d kunne ikke konverteres til Unicode og ignoreres."
+
+#: ../src/common/init.cpp:344
+msgid "Initialization failed in post init, aborting."
+msgstr "Initialisering fejlede i efterinitialisering, afbryder."
+
+#: ../src/common/intl.cpp:378
+#, c-format
+msgid "Cannot set locale to language \"%s\"."
+msgstr "Kan ikke sætte lokale til sproget \"%s\"."
+
+#: ../src/common/log.cpp:232
+msgid "Error: "
+msgstr "Fejl: "
+
+#: ../src/common/log.cpp:236
+msgid "Warning: "
+msgstr "Advarsel: "
+
+#: ../src/common/log.cpp:284
+msgid "The previous message repeated once."
+msgstr "Den forrige meddelelse gentaget én gang."
+
+#: ../src/common/log.cpp:291
+#, c-format
+msgid "The previous message repeated %u time."
+msgid_plural "The previous message repeated %u times."
+msgstr[0] "Den forrige meddelelse gentaget %u gang."
+msgstr[1] "Den forrige meddelelse gentaget %u gange."
+
+#: ../src/common/log.cpp:319
+#, c-format
+msgid "Last repeated message (\"%s\", %u time) wasn't output"
+msgid_plural "Last repeated message (\"%s\", %u times) wasn't output"
+msgstr[0] "Sidste gentagne meddelelse (\"%s\", %u gang) blev ikke vist"
+msgstr[1] "Sidste gentagne meddelelse (\"%s\", %u gange) blev ikke vist"
+
+#: ../src/common/log.cpp:435
+#, c-format
+msgid " (error %ld: %s)"
+msgstr " (fejl %ld: %s)"
+
+#: ../src/common/lzmastream.cpp:121
+#, fuzzy
+msgid "Failed to allocate memory for LZMA decompression."
+msgstr "Kunne ikke tildele farve til OpenGL"
+
+#: ../src/common/lzmastream.cpp:125
+#, c-format
+msgid "Failed to initialize LZMA decompression: unexpected error %u."
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:179
+msgid "input is not in XZ format"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:183
+msgid "input compressed using unknown XZ option"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:188
+msgid "input is corrupted"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:192
+#, fuzzy
+msgid "unknown decompression error"
+msgstr "fejl ved udpakning"
+
+#: ../src/common/lzmastream.cpp:196
+#, fuzzy, c-format
+msgid "LZMA decompression error: %s"
+msgstr "fejl ved udpakning"
+
+#: ../src/common/lzmastream.cpp:231
+#, fuzzy
+msgid "Failed to allocate memory for LZMA compression."
+msgstr "Kunne ikke tildele farve til OpenGL"
+
+#: ../src/common/lzmastream.cpp:235
+#, c-format
+msgid "Failed to initialize LZMA compression: unexpected error %u."
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:267 ../src/common/lzmastream.cpp:342
+#: ../src/html/chm.cpp:336
+msgid "out of memory"
+msgstr "ikke mere ledig hukommelse"
+
+#: ../src/common/lzmastream.cpp:276 ../src/common/lzmastream.cpp:346
+#, fuzzy
+msgid "unknown compression error"
+msgstr "fejl ved komprimering"
+
+#: ../src/common/lzmastream.cpp:280
+#, fuzzy, c-format
+msgid "LZMA compression error: %s"
+msgstr "fejl ved komprimering"
+
+#: ../src/common/lzmastream.cpp:350
+#, c-format
+msgid "LZMA compression error when flushing output: %s"
+msgstr ""
+
+#: ../src/common/mimecmn.cpp:167
+#, c-format
+msgid "Unmatched '{' in an entry for mime type %s."
+msgstr "Uparret \"{\" i en indgang for mime type %s."
+
+#: ../src/common/module.cpp:76
+#, c-format
+msgid "Circular dependency involving module \"%s\" detected."
+msgstr "Registrerede cirkulær afhængighed, som involverer modulet \"%s\"."
+
+#: ../src/common/module.cpp:128
+#, c-format
+msgid "Dependency \"%s\" of module \"%s\" doesn't exist."
+msgstr "Afhængighed \"%s\" af modulet \"%s\" findes ikke."
+
+#: ../src/common/module.cpp:137
+#, c-format
+msgid "Module \"%s\" initialization failed"
+msgstr "Modul \"%s\" initialisering fejlede"
+
+#: ../src/common/msgout.cpp:96
+msgid "Message"
+msgstr "Meddelelse"
+
+#: ../src/common/paper.cpp:70
+msgid "Letter, 8 1/2 x 11 in"
+msgstr "Brev, 8 1/2 x 11 tommer"
+
+#: ../src/common/paper.cpp:71
+msgid "Legal, 8 1/2 x 14 in"
+msgstr "Legal, 8 1/2 x 14 tommer"
+
+#: ../src/common/paper.cpp:72
+msgid "A4 sheet, 210 x 297 mm"
+msgstr "A4-ark, 210 x 297 mm"
+
+#: ../src/common/paper.cpp:73
+msgid "C sheet, 17 x 22 in"
+msgstr "C-ark, 17 x 22 tommer"
+
+#: ../src/common/paper.cpp:74
+msgid "D sheet, 22 x 34 in"
+msgstr "D-ark, 22 x 34 tommer"
+
+#: ../src/common/paper.cpp:75
+msgid "E sheet, 34 x 44 in"
+msgstr "E-ark, 34 x 44 tommer"
+
+#: ../src/common/paper.cpp:76
+msgid "Letter Small, 8 1/2 x 11 in"
+msgstr "Brev lille, 8 1/2 x 11 tommer"
+
+#: ../src/common/paper.cpp:77
+msgid "Tabloid, 11 x 17 in"
+msgstr "Tabloid, 11 x 17 tommer"
+
+#: ../src/common/paper.cpp:78
+msgid "Ledger, 17 x 11 in"
+msgstr "Ledger, 17 x 11 tommer"
+
+#: ../src/common/paper.cpp:79
+msgid "Statement, 5 1/2 x 8 1/2 in"
+msgstr "Statement, 5 1/2 x 8 1/2 tommer"
+
+#: ../src/common/paper.cpp:80
+msgid "Executive, 7 1/4 x 10 1/2 in"
+msgstr "Executive, 7 1/4 x 10 1/2 tommer"
+
+#: ../src/common/paper.cpp:81
+msgid "A3 sheet, 297 x 420 mm"
+msgstr "A3-ark 297 x 420 mm"
+
+#: ../src/common/paper.cpp:82
+msgid "A4 small sheet, 210 x 297 mm"
+msgstr "A4-ark (lille), 210 x 297 mm"
+
+#: ../src/common/paper.cpp:83
+msgid "A5 sheet, 148 x 210 mm"
+msgstr "A5-ark, 148 x 210 mm"
+
+#: ../src/common/paper.cpp:84
+msgid "B4 sheet, 250 x 354 mm"
+msgstr "B4-ark, 250 x 354 mm"
+
+#: ../src/common/paper.cpp:85
+msgid "B5 sheet, 182 x 257 millimeter"
+msgstr "B5-ark, 182 x 257 millimeter"
+
+#: ../src/common/paper.cpp:86
+msgid "Folio, 8 1/2 x 13 in"
+msgstr "Folio, 8 1/2 x 13 tommer"
+
+#: ../src/common/paper.cpp:87
+msgid "Quarto, 215 x 275 mm"
+msgstr "Quarto, 215 x 275 mm"
+
+#: ../src/common/paper.cpp:88
+msgid "10 x 14 in"
+msgstr "10 x 14 tommer"
+
+#: ../src/common/paper.cpp:89
+msgid "11 x 17 in"
+msgstr "11 x 17 tommer"
+
+#: ../src/common/paper.cpp:90
+msgid "Note, 8 1/2 x 11 in"
+msgstr "Note, 8 1/2 x 11 tommer"
+
+#: ../src/common/paper.cpp:91
+msgid "#9 Envelope, 3 7/8 x 8 7/8 in"
+msgstr "#9-konvolut, 3 7/8 x 8 7/8 tommer"
+
+#: ../src/common/paper.cpp:92
+msgid "#10 Envelope, 4 1/8 x 9 1/2 in"
+msgstr "#10-konvolut, 4 1/8 x 9 1/2 tommer"
+
+#: ../src/common/paper.cpp:93
+msgid "#11 Envelope, 4 1/2 x 10 3/8 in"
+msgstr "#11-konvolut, 4 1/2 x 10 3/8 tommer"
+
+#: ../src/common/paper.cpp:94
+msgid "#12 Envelope, 4 3/4 x 11 in"
+msgstr "#12-konvolut, 4 3/4 x 11 tommer"
+
+#: ../src/common/paper.cpp:95
+msgid "#14 Envelope, 5 x 11 1/2 in"
+msgstr "#14-konvolut, 5 x 11 1/2 tommer"
+
+#: ../src/common/paper.cpp:96
+msgid "DL Envelope, 110 x 220 mm"
+msgstr "DL-konvolut, 110 x 220 mm"
+
+#: ../src/common/paper.cpp:97
+msgid "C5 Envelope, 162 x 229 mm"
+msgstr "C5-konvolut, 162 x 229 mm"
+
+#: ../src/common/paper.cpp:98
+msgid "C3 Envelope, 324 x 458 mm"
+msgstr "C3-konvolut, 324 x 458 mm"
+
+#: ../src/common/paper.cpp:99
+msgid "C4 Envelope, 229 x 324 mm"
+msgstr "C4-konvolut, 229 x 324 mm"
+
+#: ../src/common/paper.cpp:100
+msgid "C6 Envelope, 114 x 162 mm"
+msgstr "C6-konvolut, 114 x 162 mm"
+
+#: ../src/common/paper.cpp:101
+msgid "C65 Envelope, 114 x 229 mm"
+msgstr "C65-konvolut, 114 x 229 mm"
+
+#: ../src/common/paper.cpp:102
+msgid "B4 Envelope, 250 x 353 mm"
+msgstr "B4-konvolut, 250 x 353 mm"
+
+#: ../src/common/paper.cpp:103
+msgid "B5 Envelope, 176 x 250 mm"
+msgstr "B5-konvolut 176 x 250 mm"
+
+#: ../src/common/paper.cpp:104
+msgid "B6 Envelope, 176 x 125 mm"
+msgstr "B6-konvolut, 176 x 125 mm"
+
+#: ../src/common/paper.cpp:105
+msgid "Italy Envelope, 110 x 230 mm"
+msgstr "Italiensk konvolut, 110 x 230 mm"
+
+#: ../src/common/paper.cpp:106
+msgid "Monarch Envelope, 3 7/8 x 7 1/2 in"
+msgstr "Monarch konvolut, 3 7/8 x 7 1/2 tommer"
+
+#: ../src/common/paper.cpp:107
+msgid "6 3/4 Envelope, 3 5/8 x 6 1/2 in"
+msgstr "6 3/4 konvolut, 3 5/8 x 6 1/2 tommer"
+
+#: ../src/common/paper.cpp:108
+msgid "US Std Fanfold, 14 7/8 x 11 in"
+msgstr "US Std Fanfold, 14 7/8 x 11 tommer"
+
+#: ../src/common/paper.cpp:109
+msgid "German Std Fanfold, 8 1/2 x 12 in"
+msgstr "Tysk Std Fanfold, 8 1/2 x 12 tommer"
+
+#: ../src/common/paper.cpp:110
+msgid "German Legal Fanfold, 8 1/2 x 13 in"
+msgstr "Tysk Legal Fanfold, 8 1/2 x 13 tommer"
+
+#: ../src/common/paper.cpp:112
+msgid "B4 (ISO) 250 x 353 mm"
+msgstr "B4 (ISO) 250 x 353 mm"
+
+#: ../src/common/paper.cpp:113
+msgid "Japanese Postcard 100 x 148 mm"
+msgstr "Japansk postkort 100 x 148 mm"
+
+#: ../src/common/paper.cpp:114
+msgid "9 x 11 in"
+msgstr "9 x 11 tommer"
+
+#: ../src/common/paper.cpp:115
+msgid "10 x 11 in"
+msgstr "10 x 11 tommer"
+
+#: ../src/common/paper.cpp:116
+msgid "15 x 11 in"
+msgstr "15 x 11 tommer"
+
+#: ../src/common/paper.cpp:117
+msgid "Envelope Invite 220 x 220 mm"
+msgstr "Konvolut invitation 220 x 220 mm"
+
+#: ../src/common/paper.cpp:118
+msgid "Letter Extra 9 1/2 x 12 in"
+msgstr "Brev ekstra 9 1/2 x 12 tommer"
+
+#: ../src/common/paper.cpp:119
+msgid "Legal Extra 9 1/2 x 15 in"
+msgstr "Legal ekstra 9 1/2 x 15 tommer"
+
+#: ../src/common/paper.cpp:120
+msgid "Tabloid Extra 11.69 x 18 in"
+msgstr "Tabloid ekstra 11.69 x 18 tommer"
+
+#: ../src/common/paper.cpp:121
+msgid "A4 Extra 9.27 x 12.69 in"
+msgstr "A4 ekstra 9.27 x 12.69 tommer"
+
+#: ../src/common/paper.cpp:122
+msgid "Letter Transverse 8 1/2 x 11 in"
+msgstr "Brev transverse 8 1/2 x 11 tommer"
+
+#: ../src/common/paper.cpp:123
+msgid "A4 Transverse 210 x 297 mm"
+msgstr "A4 transverse 210 x 297 mm"
+
+#: ../src/common/paper.cpp:124
+msgid "Letter Extra Transverse 9.275 x 12 in"
+msgstr "Brev ekstra transverse 9.275 x 12 tommer"
+
+#: ../src/common/paper.cpp:125
+msgid "SuperA/SuperA/A4 227 x 356 mm"
+msgstr "SuperA/SuperA/A4 227 x 356 mm"
+
+#: ../src/common/paper.cpp:126
+msgid "SuperB/SuperB/A3 305 x 487 mm"
+msgstr "SuperB/SuperB/A3 305 x 487 mm"
+
+#: ../src/common/paper.cpp:127
+msgid "Letter Plus 8 1/2 x 12.69 in"
+msgstr "Brev plus 8 1/2 x 12.69 tommer"
+
+#: ../src/common/paper.cpp:128
+msgid "A4 Plus 210 x 330 mm"
+msgstr "A4 plus 210 x 330 mm"
+
+#: ../src/common/paper.cpp:129
+msgid "A5 Transverse 148 x 210 mm"
+msgstr "A5 transverse 148 x 210 mm"
+
+#: ../src/common/paper.cpp:130
+msgid "B5 (JIS) Transverse 182 x 257 mm"
+msgstr "B5 (JIS) transverse 182 x 257 mm"
+
+#: ../src/common/paper.cpp:131
+msgid "A3 Extra 322 x 445 mm"
+msgstr "A3 ekstra 322 x 445 mm"
+
+#: ../src/common/paper.cpp:132
+msgid "A5 Extra 174 x 235 mm"
+msgstr "A5 ekstra 174 x 235 mm"
+
+#: ../src/common/paper.cpp:133
+msgid "B5 (ISO) Extra 201 x 276 mm"
+msgstr "B5 (ISO) ekstra 201 x 276 mm"
+
+#: ../src/common/paper.cpp:134
+msgid "A2 420 x 594 mm"
+msgstr "A2 420 x 594 mm"
+
+#: ../src/common/paper.cpp:135
+msgid "A3 Transverse 297 x 420 mm"
+msgstr "A3 transverse 297 x 420 mm"
+
+#: ../src/common/paper.cpp:136
+msgid "A3 Extra Transverse 322 x 445 mm"
+msgstr "A3 ekstra transverse 322 x 445 mm"
+
+#: ../src/common/paper.cpp:138
+msgid "Japanese Double Postcard 200 x 148 mm"
+msgstr "Japansk dobbelt postkort 200 x 148 mm"
+
+#: ../src/common/paper.cpp:139
+msgid "A6 105 x 148 mm"
+msgstr "A6 105 x 148 mm"
+
+#: ../src/common/paper.cpp:140
+msgid "Japanese Envelope Kaku #2"
+msgstr "Japansk konvolut Kaku #2"
+
+#: ../src/common/paper.cpp:141
+msgid "Japanese Envelope Kaku #3"
+msgstr "Japansk konvolut Kaku #3"
+
+#: ../src/common/paper.cpp:142
+msgid "Japanese Envelope Chou #3"
+msgstr "Japansk konvolut Chou #3"
+
+#: ../src/common/paper.cpp:143
+msgid "Japanese Envelope Chou #4"
+msgstr "Japansk konvolut Chou #4"
+
+#: ../src/common/paper.cpp:144
+msgid "Letter Rotated 11 x 8 1/2 in"
+msgstr "Brev roteret 11 x 8 1/2 tommer"
+
+#: ../src/common/paper.cpp:145
+msgid "A3 Rotated 420 x 297 mm"
+msgstr "A3 roteret 420 x 297 mm"
+
+#: ../src/common/paper.cpp:146
+msgid "A4 Rotated 297 x 210 mm"
+msgstr "A4 roteret 297 x 210 mm"
+
+#: ../src/common/paper.cpp:147
+msgid "A5 Rotated 210 x 148 mm"
+msgstr "A5 roteret 210 x 148 mm"
+
+#: ../src/common/paper.cpp:148
+msgid "B4 (JIS) Rotated 364 x 257 mm"
+msgstr "B4 (JIS) roteret 364 x 257 mm"
+
+#: ../src/common/paper.cpp:149
+msgid "B5 (JIS) Rotated 257 x 182 mm"
+msgstr "B5 (JIS) roteret 257 x 182 mm"
+
+#: ../src/common/paper.cpp:150
+msgid "Japanese Postcard Rotated 148 x 100 mm"
+msgstr "Japansk postkort roteret 148 x 100 mm"
+
+#: ../src/common/paper.cpp:151
+msgid "Double Japanese Postcard Rotated 148 x 200 mm"
+msgstr "Dobbelt japansk postkort roteret 148 x 200 mm"
+
+#: ../src/common/paper.cpp:152
+msgid "A6 Rotated 148 x 105 mm"
+msgstr "A6 roteret 148 x 105 mm"
+
+#: ../src/common/paper.cpp:153
+msgid "Japanese Envelope Kaku #2 Rotated"
+msgstr "Japansk konvolut Kaku #2 roteret"
+
+#: ../src/common/paper.cpp:154
+msgid "Japanese Envelope Kaku #3 Rotated"
+msgstr "Japansk konvolut Kaku #3 roteret"
+
+#: ../src/common/paper.cpp:155
+msgid "Japanese Envelope Chou #3 Rotated"
+msgstr "Japansk konvolut Chou #3 roteret"
+
+#: ../src/common/paper.cpp:156
+msgid "Japanese Envelope Chou #4 Rotated"
+msgstr "Japansk konvolut Chou #4 roteret"
+
+#: ../src/common/paper.cpp:157
+msgid "B6 (JIS) 128 x 182 mm"
+msgstr "B6 (JIS) 128 x 182 mm"
+
+#: ../src/common/paper.cpp:158
+msgid "B6 (JIS) Rotated 182 x 128 mm"
+msgstr "B6 (JIS) roteret 182 x 128 mm"
+
+#: ../src/common/paper.cpp:159
+msgid "12 x 11 in"
+msgstr "12 x 11 tommer"
+
+#: ../src/common/paper.cpp:160
+msgid "Japanese Envelope You #4"
+msgstr "Japansk konvolut You #4"
+
+#: ../src/common/paper.cpp:161
+msgid "Japanese Envelope You #4 Rotated"
+msgstr "Japansk konvolut You #4 roteret"
+
+#: ../src/common/paper.cpp:162
+msgid "PRC 16K 146 x 215 mm"
+msgstr "PRC 16K 146 x 215 mm"
+
+#: ../src/common/paper.cpp:163
+msgid "PRC 32K 97 x 151 mm"
+msgstr "PRC 32K 97 x 151 mm"
+
+#: ../src/common/paper.cpp:164
+msgid "PRC 32K(Big) 97 x 151 mm"
+msgstr "PRC 32K(Big) 97 x 151 mm"
+
+#: ../src/common/paper.cpp:165
+msgid "PRC Envelope #1 102 x 165 mm"
+msgstr "PRC konvolut #1 102 x 165 mm"
+
+#: ../src/common/paper.cpp:166
+msgid "PRC Envelope #2 102 x 176 mm"
+msgstr "PRC konvolut #2 102 x 176 mm"
+
+#: ../src/common/paper.cpp:167
+msgid "PRC Envelope #3 125 x 176 mm"
+msgstr "PRC konvolut #3 125 x 176 mm"
+
+#: ../src/common/paper.cpp:168
+msgid "PRC Envelope #4 110 x 208 mm"
+msgstr "PRC konvolut #4 110 x 208 mm"
+
+#: ../src/common/paper.cpp:169
+msgid "PRC Envelope #5 110 x 220 mm"
+msgstr "PRC konvolut #5 110 x 220 mm"
+
+#: ../src/common/paper.cpp:170
+msgid "PRC Envelope #6 120 x 230 mm"
+msgstr "PRC konvolut #6 120 x 230 mm"
+
+#: ../src/common/paper.cpp:171
+msgid "PRC Envelope #7 160 x 230 mm"
+msgstr "PRC konvolut #7 160 x 230 mm"
+
+#: ../src/common/paper.cpp:172
+msgid "PRC Envelope #8 120 x 309 mm"
+msgstr "PRC konvolut #8 120 x 309 mm"
+
+#: ../src/common/paper.cpp:173
+msgid "PRC Envelope #9 229 x 324 mm"
+msgstr "PRC konvolut #9 229 x 324 mm"
+
+#: ../src/common/paper.cpp:174
+msgid "PRC Envelope #10 324 x 458 mm"
+msgstr "PRC konvolut #10 324 x 458 mm"
+
+#: ../src/common/paper.cpp:175
+msgid "PRC 16K Rotated"
+msgstr "PRC 16K roteret"
+
+#: ../src/common/paper.cpp:176
+msgid "PRC 32K Rotated"
+msgstr "PRC 32K roteret"
+
+#: ../src/common/paper.cpp:177
+msgid "PRC 32K(Big) Rotated"
+msgstr "PRC 32K(Big) roteret"
+
+#: ../src/common/paper.cpp:178
+msgid "PRC Envelope #1 Rotated 165 x 102 mm"
+msgstr "PRC konvolut #1 roteret 165 x 102 mm"
+
+#: ../src/common/paper.cpp:179
+msgid "PRC Envelope #2 Rotated 176 x 102 mm"
+msgstr "PRC konvolut #2 roteret 176 x 102 mm"
+
+#: ../src/common/paper.cpp:180
+msgid "PRC Envelope #3 Rotated 176 x 125 mm"
+msgstr "PRC konvolut #3 roteret 176 x 125 mm"
+
+#: ../src/common/paper.cpp:181
+msgid "PRC Envelope #4 Rotated 208 x 110 mm"
+msgstr "PRC konvolut #4 roteret 208 x 110 mm"
+
+#: ../src/common/paper.cpp:182
+msgid "PRC Envelope #5 Rotated 220 x 110 mm"
+msgstr "PRC konvolut #5 roteret 220 x 110 mm"
+
+#: ../src/common/paper.cpp:183
+msgid "PRC Envelope #6 Rotated 230 x 120 mm"
+msgstr "PRC konvolut #6 roteret 230 x 120 mm"
+
+#: ../src/common/paper.cpp:184
+msgid "PRC Envelope #7 Rotated 230 x 160 mm"
+msgstr "PRC konvolut #7 roteret 230 x 160 mm"
+
+#: ../src/common/paper.cpp:185
+msgid "PRC Envelope #8 Rotated 309 x 120 mm"
+msgstr "PRC konvolut #8 roteret 309 x 120 mm"
+
+#: ../src/common/paper.cpp:186
+msgid "PRC Envelope #9 Rotated 324 x 229 mm"
+msgstr "PRC konvolut #9 roteret 324 x 229 mm"
+
+#: ../src/common/paper.cpp:187
+msgid "PRC Envelope #10 Rotated 458 x 324 mm"
+msgstr "PRC konvolut #10 roteret 458 x 324 mm"
+
+#: ../src/common/paper.cpp:192
+msgid "A0 sheet, 841 x 1189 mm"
+msgstr "A0-ark, 841 x 1189 mm"
+
+#: ../src/common/paper.cpp:193
+msgid "A1 sheet, 594 x 841 mm"
+msgstr "A1-ark, 594 x 841 mm"
+
+#: ../src/common/preferencescmn.cpp:37
+msgid "General"
+msgstr "Generel"
+
+#: ../src/common/preferencescmn.cpp:40
+msgid "Advanced"
+msgstr "Avanceret"
+
+#: ../src/common/prntbase.cpp:245
+msgid "Generic PostScript"
+msgstr "Generisk PostScript"
+
+#: ../src/common/prntbase.cpp:259
+msgid "Ready"
+msgstr "Klar"
+
+#: ../src/common/prntbase.cpp:331
+msgid "Printing Error"
+msgstr "Udskriftsfejl"
+
+#: ../src/common/prntbase.cpp:413 ../src/common/prntbase.cpp:1597
+#: ../src/generic/prntdlgg.cpp:135 ../src/generic/prntdlgg.cpp:149
+#: ../src/gtk/print.cpp:628 ../src/gtk/print.cpp:646
+msgid "Print"
+msgstr "Udskriv"
+
+#: ../src/common/prntbase.cpp:471 ../src/generic/prntdlgg.cpp:809
+msgid "Page setup"
+msgstr "Sideopsætning"
+
+#: ../src/common/prntbase.cpp:525
+msgid "Please wait while printing..."
+msgstr "Vent, mens der udskrives..."
+
+#: ../src/common/prntbase.cpp:529
+msgid "Document:"
+msgstr "Dokument:"
+
+#: ../src/common/prntbase.cpp:532
+msgid "Progress:"
+msgstr "Behandling:"
+
+#: ../src/common/prntbase.cpp:533
+msgid "Preparing"
+msgstr "Forbereder"
+
+#: ../src/common/prntbase.cpp:552
+#, c-format
+msgid "Printing page %d"
+msgstr "Udskriver side %d"
+
+#: ../src/common/prntbase.cpp:557
+#, c-format
+msgid "Printing page %d of %d"
+msgstr "Udskriver side %d af %d"
+
+#: ../src/common/prntbase.cpp:560
+#, c-format
+msgid " (copy %d of %d)"
+msgstr " (kopi %d af %d)"
+
+#: ../src/common/prntbase.cpp:1604
+msgid "First page"
+msgstr "Første side"
+
+#: ../src/common/prntbase.cpp:1609 ../src/html/helpwnd.cpp:659
+msgid "Previous page"
+msgstr "Foregående side"
+
+#: ../src/common/prntbase.cpp:1623 ../src/html/helpwnd.cpp:660
+msgid "Next page"
+msgstr "Næste side"
+
+#: ../src/common/prntbase.cpp:1628
+msgid "Last page"
+msgstr "Sidste side"
+
+#: ../src/common/prntbase.cpp:1636 ../src/common/stockitem.cpp:215
+msgid "Zoom Out"
+msgstr "Zoom ud"
+
+#: ../src/common/prntbase.cpp:1650 ../src/common/stockitem.cpp:214
+msgid "Zoom In"
+msgstr "Zoom ind"
+
+#: ../src/common/prntbase.cpp:1656 ../src/common/stockitem.cpp:153
+#: ../src/generic/logg.cpp:553 ../src/univ/themes/win32.cpp:3752
+msgid "&Close"
+msgstr "&Luk"
+
+#: ../src/common/prntbase.cpp:2085
+msgid "Could not start document preview."
+msgstr "Kunne ikke starte udskriftsvisning."
+
+#: ../src/common/prntbase.cpp:2085 ../src/common/prntbase.cpp:2129
+#: ../src/common/prntbase.cpp:2137
+msgid "Print Preview Failure"
+msgstr "Udskriftsvisning fejlede"
+
+#: ../src/common/prntbase.cpp:2129 ../src/common/prntbase.cpp:2137
+msgid "Sorry, not enough memory to create a preview."
+msgstr "Beklager, der er ikke nok ledig hukommelse til Udskriftsvisning."
+
+#: ../src/common/prntbase.cpp:2144
+#, c-format
+msgid "Page %d of %d"
+msgstr "Side %d af %d"
+
+#: ../src/common/prntbase.cpp:2146
+#, c-format
+msgid "Page %d"
+msgstr "Side %d"
+
+#: ../src/common/regex.cpp:382 ../src/html/chm.cpp:348
+msgid "unknown error"
+msgstr "ukendt fejl"
+
+#: ../src/common/regex.cpp:995
+#, c-format
+msgid "Invalid regular expression '%s': %s"
+msgstr "Ugyldigt regulært udtryk: \"%s\": %s"
+
+#: ../src/common/regex.cpp:1059
+#, c-format
+msgid "Failed to find match for regular expression: %s"
+msgstr "Kunne ikke finde match for det regulære udtryk: %s"
+
+#: ../src/common/rendcmn.cpp:188
+#, c-format
+msgid "Renderer \"%s\" has incompatible version %d.%d and couldn't be loaded."
+msgstr ""
+"Gengiver \"%s\" er en inkompatibel version %d.%d og kunne ikke indlæses."
+
+#: ../src/common/secretstore.cpp:162
+msgid "Not available for this platform"
+msgstr ""
+
+#: ../src/common/secretstore.cpp:183
+#, fuzzy, c-format
+msgid "Saving password for \"%s\" failed: %s."
+msgstr "Kunne ikke gemme adganskode for \"%s/%s\": %s."
+
+#: ../src/common/secretstore.cpp:205
+#, fuzzy, c-format
+msgid "Reading password for \"%s\" failed: %s."
+msgstr "Kunne ikke læse adganskode for \"%s/%s\": %s."
+
+#: ../src/common/secretstore.cpp:228
+#, fuzzy, c-format
+msgid "Deleting password for \"%s\" failed: %s."
+msgstr "Kunne ikke slette adganskode for \"%s/%s\": %s."
+
+#: ../src/common/selectdispatcher.cpp:254
+msgid "Failed to monitor I/O channels"
+msgstr "Kunne ikke overvåge I/O-kanaler"
+
+#: ../src/common/sizer.cpp:3054 ../src/common/stockitem.cpp:195
+msgid "Save"
+msgstr "Gem"
+
+#: ../src/common/sizer.cpp:3056
+msgid "Don't Save"
+msgstr "Gem ikke"
+
+#: ../src/common/socket.cpp:870
+msgid "Cannot initialize sockets"
+msgstr "Kan ikke initialisere sockets"
+
+#: ../src/common/stockitem.cpp:127
+#, fuzzy
+msgctxt "standard Windows menu"
+msgid "&Help"
+msgstr "&Hjælp"
+
+#: ../src/common/stockitem.cpp:144
+msgid "&About"
+msgstr "&Om"
+
+#: ../src/common/stockitem.cpp:144
+msgid "About"
+msgstr "Om"
+
+#: ../src/common/stockitem.cpp:145
+msgid "Add"
+msgstr "Tilføj"
+
+#: ../src/common/stockitem.cpp:146
+msgid "&Apply"
+msgstr "&Anvend"
+
+#: ../src/common/stockitem.cpp:146
+msgid "Apply"
+msgstr "Anvend"
+
+#: ../src/common/stockitem.cpp:147
+msgid "&Back"
+msgstr "&Tilbage"
+
+#: ../src/common/stockitem.cpp:147
+msgid "Back"
+msgstr "Tilbage"
+
+#: ../src/common/stockitem.cpp:148
+msgid "&Bold"
+msgstr "&Fed"
+
+#: ../src/common/stockitem.cpp:148 ../src/generic/fontdlgg.cpp:326
+#: ../src/richtext/richtextfontpage.cpp:354
+msgid "Bold"
+msgstr "Fed"
+
+#: ../src/common/stockitem.cpp:149
+msgid "&Bottom"
+msgstr "&Bund"
+
+#: ../src/common/stockitem.cpp:149 ../src/richtext/richtextsizepage.cpp:287
+msgid "Bottom"
+msgstr "Bund"
+
+#: ../src/common/stockitem.cpp:150 ../src/generic/fontdlgg.cpp:462
+#: ../src/generic/fontdlgg.cpp:481 ../src/generic/wizard.cpp:415
+msgid "&Cancel"
+msgstr "&Annuller"
+
+#: ../src/common/stockitem.cpp:151
+#, fuzzy
+msgid "&CD-ROM"
+msgstr "&CD-Rom"
+
+#: ../src/common/stockitem.cpp:151
+#, fuzzy
+msgid "CD-ROM"
+msgstr "CD-Rom"
+
+#: ../src/common/stockitem.cpp:152
+msgid "&Clear"
+msgstr "&Rens"
+
+#: ../src/common/stockitem.cpp:152
+msgid "Clear"
+msgstr "Rens"
+
+#: ../src/common/stockitem.cpp:153 ../src/generic/dbgrptg.cpp:93
+#: ../src/generic/progdlgg.cpp:778 ../src/html/helpdlg.cpp:86
+#: ../src/msw/progdlg.cpp:209 ../src/msw/progdlg.cpp:890
+#: ../src/richtext/richtextstyledlg.cpp:272
+#: ../src/richtext/richtextsymboldlg.cpp:448
+msgid "Close"
+msgstr "Luk"
+
+#: ../src/common/stockitem.cpp:154
+msgid "&Convert"
+msgstr "&Konverter"
+
+#: ../src/common/stockitem.cpp:154
+msgid "Convert"
+msgstr "Konverter"
+
+#: ../src/common/stockitem.cpp:155 ../src/msw/textctrl.cpp:2884
+#: ../src/osx/textctrl_osx.cpp:653 ../src/richtext/richtextctrl.cpp:331
+msgid "&Copy"
+msgstr "&Kopiér"
+
+#: ../src/common/stockitem.cpp:155 ../src/stc/stc_i18n.cpp:18
+msgid "Copy"
+msgstr "Kopiér"
+
+#: ../src/common/stockitem.cpp:156 ../src/msw/textctrl.cpp:2883
+#: ../src/osx/textctrl_osx.cpp:652 ../src/richtext/richtextctrl.cpp:330
+msgid "Cu&t"
+msgstr "&Klip"
+
+#: ../src/common/stockitem.cpp:156 ../src/stc/stc_i18n.cpp:17
+msgid "Cut"
+msgstr "Klip"
+
+#: ../src/common/stockitem.cpp:157 ../src/msw/textctrl.cpp:2886
+#: ../src/osx/textctrl_osx.cpp:655 ../src/richtext/richtextctrl.cpp:333
+#: ../src/richtext/richtexttabspage.cpp:137
+msgid "&Delete"
+msgstr "&Slet"
+
+#: ../src/common/stockitem.cpp:157 ../src/richtext/richtextbuffer.cpp:8266
+#: ../src/stc/stc_i18n.cpp:20
+msgid "Delete"
+msgstr "Slet"
+
+#: ../src/common/stockitem.cpp:158
+msgid "&Down"
+msgstr "&Ned"
+
+#: ../src/common/stockitem.cpp:158 ../src/generic/fdrepdlg.cpp:148
+msgid "Down"
+msgstr "Ned"
+
+#: ../src/common/stockitem.cpp:159
+msgid "&Edit"
+msgstr "&Rediger"
+
+#: ../src/common/stockitem.cpp:159
+msgid "Edit"
+msgstr "Rediger"
+
+#: ../src/common/stockitem.cpp:160
+msgid "&Execute"
+msgstr "&Udfør"
+
+#: ../src/common/stockitem.cpp:160
+msgid "Execute"
+msgstr "Udfør"
+
+#: ../src/common/stockitem.cpp:161
+msgid "&Quit"
+msgstr "&Afslut"
+
+#: ../src/common/stockitem.cpp:161
+msgid "Quit"
+msgstr "Afslut"
+
+#: ../src/common/stockitem.cpp:162
+msgid "&File"
+msgstr "&Fil"
+
+#: ../src/common/stockitem.cpp:162
+msgid "File"
+msgstr "Fil"
+
+#: ../src/common/stockitem.cpp:163
+#, fuzzy
+msgid "&Find..."
+msgstr "&Find"
+
+#: ../src/common/stockitem.cpp:163
+#, fuzzy
+msgid "Find..."
+msgstr "Find"
+
+#: ../src/common/stockitem.cpp:164
+msgid "&First"
+msgstr "&Første"
+
+#: ../src/common/stockitem.cpp:164
+msgid "First"
+msgstr "Første"
+
+#: ../src/common/stockitem.cpp:165
+msgid "&Floppy"
+msgstr "&Floppy"
+
+#: ../src/common/stockitem.cpp:165
+msgid "Floppy"
+msgstr "Floppy"
+
+#: ../src/common/stockitem.cpp:166
+msgid "&Forward"
+msgstr "&Fremad"
+
+#: ../src/common/stockitem.cpp:166
+msgid "Forward"
+msgstr "Fremad"
+
+#: ../src/common/stockitem.cpp:167
+msgid "&Harddisk"
+msgstr "&Harddisk"
+
+#: ../src/common/stockitem.cpp:167
+msgid "Harddisk"
+msgstr "Harddisk"
+
+#: ../src/common/stockitem.cpp:168 ../src/generic/wizard.cpp:418
+#: ../src/osx/cocoa/menu.mm:225 ../src/richtext/richtextstyledlg.cpp:298
+#: ../src/richtext/richtextsymboldlg.cpp:451
+msgid "&Help"
+msgstr "&Hjælp"
+
+#: ../src/common/stockitem.cpp:169
+msgid "&Home"
+msgstr "&Hjem"
+
+#: ../src/common/stockitem.cpp:169
+msgid "Home"
+msgstr "Hjem"
+
+#: ../src/common/stockitem.cpp:170
+msgid "Indent"
+msgstr "Indryk"
+
+#: ../src/common/stockitem.cpp:171
+msgid "&Index"
+msgstr "&Indeks"
+
+#: ../src/common/stockitem.cpp:171 ../src/html/helpwnd.cpp:510
+msgid "Index"
+msgstr "Indeks"
+
+#: ../src/common/stockitem.cpp:172
+msgid "&Info"
+msgstr "&Info"
+
+#: ../src/common/stockitem.cpp:172
+msgid "Info"
+msgstr "Info"
+
+#: ../src/common/stockitem.cpp:173
+msgid "&Italic"
+msgstr "&Kursiv"
+
+#: ../src/common/stockitem.cpp:173 ../src/generic/fontdlgg.cpp:322
+#: ../src/richtext/richtextfontpage.cpp:350
+msgid "Italic"
+msgstr "Kursiv"
+
+#: ../src/common/stockitem.cpp:174
+msgid "&Jump to"
+msgstr "&Hop til"
+
+#: ../src/common/stockitem.cpp:174
+msgid "Jump to"
+msgstr "Hop til"
+
+#: ../src/common/stockitem.cpp:175
+msgid "Centered"
+msgstr "Centreret"
+
+#: ../src/common/stockitem.cpp:176
+msgid "Justified"
+msgstr "Justeret"
+
+#: ../src/common/stockitem.cpp:177
+msgid "Align Left"
+msgstr "Venstrejuster"
+
+#: ../src/common/stockitem.cpp:178
+msgid "Align Right"
+msgstr "Højrejuster"
+
+#: ../src/common/stockitem.cpp:179
+msgid "&Last"
+msgstr "&Sidste"
+
+#: ../src/common/stockitem.cpp:179
+msgid "Last"
+msgstr "Sidste"
+
+#: ../src/common/stockitem.cpp:180
+msgid "&Network"
+msgstr "&Netværk"
+
+#: ../src/common/stockitem.cpp:180
+msgid "Network"
+msgstr "Netværk"
+
+#: ../src/common/stockitem.cpp:181 ../src/richtext/richtexttabspage.cpp:131
+msgid "&New"
+msgstr "&Ny"
+
+#: ../src/common/stockitem.cpp:181
+msgid "New"
+msgstr "Ny"
+
+#: ../src/common/stockitem.cpp:182 ../src/msw/msgdlg.cpp:417
+msgid "&No"
+msgstr "&Nej"
+
+#: ../src/common/stockitem.cpp:183 ../src/generic/fontdlgg.cpp:467
+#: ../src/generic/fontdlgg.cpp:474
+msgid "&OK"
+msgstr "&OK"
+
+#: ../src/common/stockitem.cpp:184 ../src/generic/dbgrptg.cpp:341
+msgid "&Open..."
+msgstr "&Åben..."
+
+#: ../src/common/stockitem.cpp:184
+msgid "Open..."
+msgstr "Åbn..."
+
+#: ../src/common/stockitem.cpp:185 ../src/msw/textctrl.cpp:2885
+#: ../src/osx/textctrl_osx.cpp:654 ../src/richtext/richtextctrl.cpp:332
+msgid "&Paste"
+msgstr "&Sæt ind"
+
+#: ../src/common/stockitem.cpp:185 ../src/richtext/richtextctrl.cpp:3484
+#: ../src/stc/stc_i18n.cpp:19
+msgid "Paste"
+msgstr "Sæt ind"
+
+#: ../src/common/stockitem.cpp:186
+msgid "&Preferences"
+msgstr "&Indstillinger"
+
+#: ../src/common/stockitem.cpp:186 ../src/osx/cocoa/preferences.mm:304
+msgid "Preferences"
+msgstr "Indstillinger"
+
+#: ../src/common/stockitem.cpp:187
+msgid "Print previe&w..."
+msgstr "Udskrifts&visning..."
+
+#: ../src/common/stockitem.cpp:187
+msgid "Print preview..."
+msgstr "Udskriftsvisning..."
+
+#: ../src/common/stockitem.cpp:188
+msgid "&Print..."
+msgstr "&Udskriv..."
+
+#: ../src/common/stockitem.cpp:188
+msgid "Print..."
+msgstr "Udskriv..."
+
+#: ../src/common/stockitem.cpp:189 ../src/richtext/richtextctrl.cpp:337
+#: ../src/richtext/richtextctrl.cpp:5479
+msgid "&Properties"
+msgstr "&Egenskaber"
+
+#: ../src/common/stockitem.cpp:189
+msgid "Properties"
+msgstr "Egenskaber"
+
+#: ../src/common/stockitem.cpp:190 ../src/stc/stc_i18n.cpp:16
+msgid "Redo"
+msgstr "Omgør"
+
+#: ../src/common/stockitem.cpp:191
+msgid "Refresh"
+msgstr "Opdatér"
+
+#: ../src/common/stockitem.cpp:192
+msgid "Remove"
+msgstr "Fjern"
+
+#: ../src/common/stockitem.cpp:193
+#, fuzzy
+msgid "Rep&lace..."
+msgstr "&Erstat"
+
+#: ../src/common/stockitem.cpp:193
+#, fuzzy
+msgid "Replace..."
+msgstr "Erstat"
+
+#: ../src/common/stockitem.cpp:194
+msgid "Revert to Saved"
+msgstr "Tilbagefør til gemt"
+
+#: ../src/common/stockitem.cpp:196 ../src/generic/logg.cpp:549
+msgid "Save &As..."
+msgstr "Gem &som..."
+
+#: ../src/common/stockitem.cpp:196
+#, fuzzy
+msgid "Save As..."
+msgstr "Gem &som..."
+
+#: ../src/common/stockitem.cpp:197 ../src/msw/textctrl.cpp:2888
+#: ../src/osx/textctrl_osx.cpp:657 ../src/richtext/richtextctrl.cpp:335
+msgid "Select &All"
+msgstr "Vælg &alt"
+
+#: ../src/common/stockitem.cpp:197 ../src/stc/stc_i18n.cpp:21
+msgid "Select All"
+msgstr "Vælg alt"
+
+#: ../src/common/stockitem.cpp:198
+msgid "&Color"
+msgstr "F&arve"
+
+#: ../src/common/stockitem.cpp:198
+msgid "Color"
+msgstr "Farve"
+
+#: ../src/common/stockitem.cpp:199
+msgid "&Font"
+msgstr "&Skrift"
+
+#: ../src/common/stockitem.cpp:199 ../src/richtext/richtextformatdlg.cpp:336
+msgid "Font"
+msgstr "Skrifttype"
+
+#: ../src/common/stockitem.cpp:200
+msgid "&Ascending"
+msgstr "&Stigende"
+
+#: ../src/common/stockitem.cpp:200
+msgid "Ascending"
+msgstr "Stigende"
+
+#: ../src/common/stockitem.cpp:201
+msgid "&Descending"
+msgstr "&Faldende"
+
+#: ../src/common/stockitem.cpp:201
+msgid "Descending"
+msgstr "Faldende"
+
+#: ../src/common/stockitem.cpp:202
+msgid "&Spell Check"
+msgstr "&Stavekontrol"
+
+#: ../src/common/stockitem.cpp:202
+msgid "Spell Check"
+msgstr "Stavekontrol"
+
+#: ../src/common/stockitem.cpp:203
+msgid "&Stop"
+msgstr "&Stop"
+
+#: ../src/common/stockitem.cpp:203
+msgid "Stop"
+msgstr "Stop"
+
+#: ../src/common/stockitem.cpp:204 ../src/richtext/richtextfontpage.cpp:274
+msgid "&Strikethrough"
+msgstr "&Gennemstreget"
+
+#: ../src/common/stockitem.cpp:204
+msgid "Strikethrough"
+msgstr "Gennemstreget"
+
+#: ../src/common/stockitem.cpp:205
+msgid "&Top"
+msgstr "&Top"
+
+#: ../src/common/stockitem.cpp:205 ../src/richtext/richtextsizepage.cpp:285
+#: ../src/richtext/richtextsizepage.cpp:289
+msgid "Top"
+msgstr "Top"
+
+#: ../src/common/stockitem.cpp:206
+msgid "Undelete"
+msgstr "Gendan"
+
+#: ../src/common/stockitem.cpp:207 ../src/generic/fontdlgg.cpp:437
+msgid "&Underline"
+msgstr "&Understreget"
+
+#: ../src/common/stockitem.cpp:207
+msgid "Underline"
+msgstr "Understregning"
+
+#: ../src/common/stockitem.cpp:208 ../src/stc/stc_i18n.cpp:15
+msgid "Undo"
+msgstr "Fortryd"
+
+#: ../src/common/stockitem.cpp:209
+msgid "&Unindent"
+msgstr "&Afindryk"
+
+#: ../src/common/stockitem.cpp:209
+msgid "Unindent"
+msgstr "Afindryk"
+
+#: ../src/common/stockitem.cpp:210
+msgid "&Up"
+msgstr "&Op"
+
+#: ../src/common/stockitem.cpp:210 ../src/generic/fdrepdlg.cpp:148
+msgid "Up"
+msgstr "Op"
+
+#: ../src/common/stockitem.cpp:211 ../src/msw/msgdlg.cpp:417
+msgid "&Yes"
+msgstr "&Ja"
+
+#: ../src/common/stockitem.cpp:212
+msgid "&Actual Size"
+msgstr "&Faktisk størrelse"
+
+#: ../src/common/stockitem.cpp:212
+msgid "Actual Size"
+msgstr "Faktisk størrelse"
+
+#: ../src/common/stockitem.cpp:213
+msgid "Zoom to &Fit"
+msgstr "Zoom &tilpasset"
+
+#: ../src/common/stockitem.cpp:213
+msgid "Zoom to Fit"
+msgstr "Zoom tilpasset"
+
+#: ../src/common/stockitem.cpp:214
+msgid "Zoom &In"
+msgstr "Zoom &Ind"
+
+#: ../src/common/stockitem.cpp:215
+msgid "Zoom &Out"
+msgstr "Zoom &Ud"
+
+#: ../src/common/stockitem.cpp:262
+msgid "Show about dialog"
+msgstr "Vis dialogen Om"
+
+#: ../src/common/stockitem.cpp:263
+msgid "Copy selection"
+msgstr "Kopier markering"
+
+#: ../src/common/stockitem.cpp:264
+msgid "Cut selection"
+msgstr "Klip markering"
+
+#: ../src/common/stockitem.cpp:265
+msgid "Delete selection"
+msgstr "Slet markering"
+
+#: ../src/common/stockitem.cpp:266
+#, fuzzy
+msgid "Find in document"
+msgstr "Åbn HTML-dokument"
+
+#: ../src/common/stockitem.cpp:267
+msgid "Find and replace in document"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:268
+msgid "Paste selection"
+msgstr "Indsæt markering"
+
+#: ../src/common/stockitem.cpp:269
+msgid "Quit this program"
+msgstr "Afslut dette program"
+
+#: ../src/common/stockitem.cpp:270
+msgid "Redo last action"
+msgstr "Omgør seneste handling"
+
+#: ../src/common/stockitem.cpp:271
+msgid "Undo last action"
+msgstr "Fortryd seneste handling"
+
+#: ../src/common/stockitem.cpp:272
+#, fuzzy
+msgid "Create new document"
+msgstr "Opret ny mappe"
+
+#: ../src/common/stockitem.cpp:273
+#, fuzzy
+msgid "Open an existing document"
+msgstr "Åbn HTML-dokument"
+
+#: ../src/common/stockitem.cpp:274
+msgid "Close current document"
+msgstr "Luk det aktuelle dokument"
+
+#: ../src/common/stockitem.cpp:275
+msgid "Save current document"
+msgstr "Gem aktuelle dokument"
+
+#: ../src/common/stockitem.cpp:276
+msgid "Save current document with a different filename"
+msgstr "Gem det aktuelle dokument under et andet filnavn"
+
+#: ../src/common/strconv.cpp:2324
+#, c-format
+msgid "Conversion to charset '%s' doesn't work."
+msgstr "Konvertering til tegnsæt \"%s\" virker ikke."
+
+#: ../src/common/tarstrm.cpp:352 ../src/common/tarstrm.cpp:375
+#: ../src/common/tarstrm.cpp:406 ../src/generic/progdlgg.cpp:373
+msgid "unknown"
+msgstr "ukendt"
+
+#: ../src/common/tarstrm.cpp:774
+msgid "incomplete header block in tar"
+msgstr "ukomplet header-blok i tar"
+
+#: ../src/common/tarstrm.cpp:798
+msgid "checksum failure reading tar header block"
+msgstr "checksum fejlede ved læsning af tar-header-blok"
+
+#: ../src/common/tarstrm.cpp:971
+msgid "invalid data in extended tar header"
+msgstr "ugyldige data i udvidet tar-header"
+
+#: ../src/common/tarstrm.cpp:981 ../src/common/tarstrm.cpp:1003
+#: ../src/common/tarstrm.cpp:1477 ../src/common/tarstrm.cpp:1499
+msgid "tar entry not open"
+msgstr "tar-entry ikke åben"
+
+#: ../src/common/tarstrm.cpp:1023
+msgid "unexpected end of file"
+msgstr "uventet afslutning på fil"
+
+#: ../src/common/tarstrm.cpp:1297
+#, c-format
+msgid "%s did not fit the tar header for entry '%s'"
+msgstr "%s passede ikke til tar-headeren for \"%s\""
+
+#: ../src/common/tarstrm.cpp:1359
+msgid "incorrect size given for tar entry"
+msgstr "forkert størrelse givet for tar-entry"
+
+#: ../src/common/textbuf.cpp:232
+#, c-format
+msgid "'%s' is probably a binary buffer."
+msgstr "\"%s\" er sandsynligvis en binær buffer."
+
+#: ../src/common/textcmn.cpp:1006 ../src/richtext/richtextctrl.cpp:3053
+msgid "File couldn't be loaded."
+msgstr "Fil kunne ikke indlæses."
+
+#: ../src/common/textfile.cpp:95
+#, fuzzy, c-format
+msgid "Failed to read text file \"%s\"."
+msgstr "Kunne ikke læse dokument fra filen \"%s\"."
+
+#: ../src/common/textfile.cpp:160
+#, c-format
+msgid "can't write buffer '%s' to disk."
+msgstr "kan ikke skrive buffer \"%s\" til disk."
+
+#: ../src/common/time.cpp:212
+msgid "Failed to get the local system time"
+msgstr "Kunne ikke få lokal systemtid"
+
+#: ../src/common/time.cpp:279
+msgid "wxGetTimeOfDay failed."
+msgstr "wxGetTimeOfDay fejlede."
+
+#: ../src/common/translation.cpp:929
+#, c-format
+msgid "'%s' is not a valid message catalog."
+msgstr "\"%s\" er ikke et gyldigt meddelelseskatalog."
+
+#: ../src/common/translation.cpp:954
+msgid "Invalid message catalog."
+msgstr "Ugyldigt meddelelseskatalog."
+
+#: ../src/common/translation.cpp:1013
+#, c-format
+msgid "Failed to parse Plural-Forms: '%s'"
+msgstr "Kunne ikke fortolke flertalsformer: \"%s\""
+
+#: ../src/common/translation.cpp:1723
+#, c-format
+msgid "using catalog '%s' from '%s'."
+msgstr "bruger katalog \"%s\" fra \"%s\"."
+
+#: ../src/common/translation.cpp:1816
+#, c-format
+msgid "Resource '%s' is not a valid message catalog."
+msgstr "Ressource \"%s\" er ikke et gyldigt meddelelseskatalog."
+
+#: ../src/common/translation.cpp:1865
+msgid "Couldn't enumerate translations"
+msgstr "Kunne ikke optælle oversættelser"
+
+#: ../src/common/utilscmn.cpp:1145
+msgid "No default application configured for HTML files."
+msgstr "Intet standardprogram konfigureret for HTML-filer."
+
+#: ../src/common/utilscmn.cpp:1190
+#, c-format
+msgid "Failed to open URL \"%s\" in default browser."
+msgstr "Kunne ikke åbne URL \"%s\" standard-browseren."
+
+#: ../src/common/valtext.cpp:144
+msgid "Validation conflict"
+msgstr "Valideringskonflikt"
+
+#: ../src/common/valtext.cpp:186
+msgid "Required information entry is empty."
+msgstr "Krævet oplysning er tom."
+
+#: ../src/common/valtext.cpp:188
+#, c-format
+msgid "'%s' is one of the invalid strings"
+msgstr "\"%s\" er en af de ugyldige strenge"
+
+#: ../src/common/valtext.cpp:190
+#, c-format
+msgid "'%s' is not one of the valid strings"
+msgstr "\"%s\" er ikke en af de gyldige strenge"
+
+#: ../src/common/valtext.cpp:199
+#, fuzzy, c-format
+msgid "'%s' contains invalid character(s)"
+msgstr "\"%s\" indeholder ulovlige tegn"
+
+#: ../src/common/webrequest.cpp:139
+#, fuzzy, c-format
+msgid "Error: %s (%d)"
+msgstr "Fejl: "
+
+#: ../src/common/webrequest.cpp:655
+#, c-format
+msgid ""
+"Not enough free disk space for download: %llu needed but only %llu available."
+msgstr ""
+
+#: ../src/common/webrequest.cpp:669
+#, fuzzy, c-format
+msgid "Failed to create temporary file in %s"
+msgstr "Kunne ikke oprette et midlertidigt filnavn"
+
+#: ../src/common/webrequest_curl.cpp:1106
+#, fuzzy
+msgid "libcurl could not be initialized"
+msgstr "Fil kunne ikke indlæses."
+
+#: ../src/common/webview.cpp:392
+msgid "RunScriptAsync not supported"
+msgstr ""
+
+#: ../src/common/webview.cpp:403 ../src/msw/webview_ie.cpp:1073
+#, c-format
+msgid "Error running JavaScript: %s"
+msgstr ""
+
+#: ../src/common/webview_chromium.cpp:858
+#, fuzzy, c-format
+msgid "Failed to set proxy \"%s\": %s"
+msgstr "Kunne ikke oprette mappen \"%s\""
+
+#: ../src/common/webview_chromium.cpp:989
+msgid ""
+"Chromium can't be used because libcef.so wasn't loaded early enough; please "
+"relink the application or use LD_PRELOAD to load it earlier."
+msgstr ""
+
+#: ../src/common/webview_chromium.cpp:1108
+#, fuzzy
+msgid "Could not initialize Chromium"
+msgstr "Kunne ikke initialisere libnotify."
+
+#: ../src/common/webview_chromium.cpp:1616
+msgid "Show DevTools"
+msgstr ""
+
+#: ../src/common/webview_chromium.cpp:1617
+#, fuzzy
+msgid "Close DevTools"
+msgstr "Luk alle"
+
+#: ../src/common/webview_chromium.cpp:1623
+msgid "Inspect"
+msgstr ""
+
+#: ../src/common/wincmn.cpp:1628
+msgid "This platform does not support background transparency."
+msgstr "Denne platform understøtter ikke gennemsigtig baggrund."
+
+#: ../src/common/wincmn.cpp:2097
+msgid "Could not transfer data to window"
+msgstr "Kunne ikke overføre data til vindue"
+
+#: ../src/common/windowid.cpp:240
+msgid "Out of window IDs.  Recommend shutting down application."
+msgstr "Ikke flere vindue ID'er. Anbefaler at lukke programmet."
+
+#: ../src/common/xpmdecod.cpp:678
+msgid "XPM: incorrect header format!"
+msgstr "XPM: forkert header-format!"
+
+#: ../src/common/xpmdecod.cpp:703
+#, c-format
+msgid "XPM: incorrect colour description in line %d"
+msgstr "XPM: forkert farvebeskrivelse i linje %d"
+
+#: ../src/common/xpmdecod.cpp:715 ../src/common/xpmdecod.cpp:724
+#, c-format
+msgid "XPM: malformed colour definition '%s' at line %d!"
+msgstr "XPM: dårligt udformet farvedefinition \"%s\" i linje %d!"
+
+#: ../src/common/xpmdecod.cpp:754
+msgid "XPM: no colors left to use for mask!"
+msgstr "XPM: ingen farver tilbage at bruge til maske!"
+
+#: ../src/common/xpmdecod.cpp:781
+#, c-format
+msgid "XPM: truncated image data at line %d!"
+msgstr "XPM: afskåret billeddata på linje %d!"
+
+#: ../src/common/xpmdecod.cpp:795
+msgid "XPM: Malformed pixel data!"
+msgstr "XPM: dårligt udformet pixeldata!"
+
+#: ../src/common/xti.cpp:492
+msgid "Illegal Parameter Count for Create Method"
+msgstr "Forkert antal parametre til Create metode"
+
+#: ../src/common/xti.cpp:504
+msgid "Illegal Parameter Count for ConstructObject Method"
+msgstr "Forkert antal parametre til ConstructObject metode"
+
+#: ../src/common/xtistrm.cpp:161
+#, c-format
+msgid "Create Parameter %s not found in declared RTTI Parameters"
+msgstr "Create-parameter %s ikke fundet i deklarerede RTTI-parametre"
+
+#: ../src/common/xtistrm.cpp:290
+msgid "Illegal Object Class (Non-wxEvtHandler) as Event Source"
+msgstr "Ulovlig Objektklasse (ikke-wxEvtHandler) som Event Source"
+
+#: ../src/common/xtistrm.cpp:313 ../src/common/xtixml.cpp:345
+#: ../src/common/xtixml.cpp:498
+msgid "Type must have enum - long conversion"
+msgstr "Type skal have enum - long-konvertering"
+
+#: ../src/common/xtistrm.cpp:400 ../src/common/xtistrm.cpp:415
+msgid "Invalid or Null Object ID passed to GetObjectClassInfo"
+msgstr "Ugyldig eller null-objekt ID sendt til GetObjectClassInfo"
+
+#: ../src/common/xtistrm.cpp:405
+msgid "Unknown Object passed to GetObjectClassInfo"
+msgstr "Ukendt objekt sendt til GetObjectClassInfo"
+
+#: ../src/common/xtistrm.cpp:420
+msgid "Already Registered Object passed to SetObjectClassInfo"
+msgstr "Allerede registreret objekt sendt til SetObjectClassInfo"
+
+#: ../src/common/xtistrm.cpp:430
+msgid "Invalid or Null Object ID passed to HasObjectClassInfo"
+msgstr "Ugyldig eller null-objekt ID sendt til HasObjectClassInfo"
+
+#: ../src/common/xtistrm.cpp:460
+msgid "Passing a already registered object to SetObject"
+msgstr "Sender et allerede registreret objekt til SetObject"
+
+#: ../src/common/xtistrm.cpp:471
+msgid "Passing an unknown object to GetObject"
+msgstr "Sender et ukendt objekt til GetObject"
+
+#: ../src/common/xtixml.cpp:229
+msgid "Forward hrefs are not supported"
+msgstr "Fremad hrefs understøttes ikke"
+
+#: ../src/common/xtixml.cpp:247
+#, c-format
+msgid "unknown class %s"
+msgstr "ukendt klasse %s"
+
+#: ../src/common/xtixml.cpp:253
+msgid "objects cannot have XML Text Nodes"
+msgstr "objekter kan ikke have XML-tekstknuder"
+
+#: ../src/common/xtixml.cpp:258
+msgid "Objects must have an id attribute"
+msgstr "Objekter skal have en id-attribut"
+
+#: ../src/common/xtixml.cpp:267
+#, c-format
+msgid "Doubly used id : %d"
+msgstr "Id brugt to gange : %d"
+
+#: ../src/common/xtixml.cpp:316
+#, c-format
+msgid "Unknown Property %s"
+msgstr "Ukendt egenskab %s"
+
+#: ../src/common/xtixml.cpp:407
+msgid "A non empty collection must consist of 'element' nodes"
+msgstr "En samling som ikke er tom skal bestå af \"element\"-knuder"
+
+#: ../src/common/xtixml.cpp:478
+msgid "incorrect event handler string, missing dot"
+msgstr "forkert event-handler-streng. Mangler punktum"
+
+#: ../src/common/zipstrm.cpp:559
+msgid "can't re-initialize zlib deflate stream"
+msgstr "kan ikke re-initialisere zlib deflate strøm"
+
+#: ../src/common/zipstrm.cpp:584
+msgid "can't re-initialize zlib inflate stream"
+msgstr "kan ikke re-initialisere zlib inflate strøm"
+
+#: ../src/common/zipstrm.cpp:1023
+msgid "Ignoring malformed extra data record, ZIP file may be corrupted"
+msgstr ""
+
+#: ../src/common/zipstrm.cpp:1502
+msgid "assuming this is a multi-part zip concatenated"
+msgstr "antager at dette er en sammensat multi-part zip"
+
+#: ../src/common/zipstrm.cpp:1664
+msgid "invalid zip file"
+msgstr "ugyldig zip-fil"
+
+#: ../src/common/zipstrm.cpp:1723
+msgid "can't find central directory in zip"
+msgstr "kan ikke finde den centrale mappe i zip"
+
+#: ../src/common/zipstrm.cpp:1812
+msgid "error reading zip central directory"
+msgstr "fejl ved læsning af centrale zip-mappe"
+
+#: ../src/common/zipstrm.cpp:1916
+msgid "error reading zip local header"
+msgstr "fejl ved læsning af zip local header"
+
+#: ../src/common/zipstrm.cpp:1964
+msgid "bad zipfile offset to entry"
+msgstr "forkert zip-fil offset til entry"
+
+#: ../src/common/zipstrm.cpp:2031
+msgid "stored file length not in Zip header"
+msgstr "gemt fillængde ikke i Zip-header"
+
+#: ../src/common/zipstrm.cpp:2045 ../src/common/zipstrm.cpp:2362
+msgid "unsupported Zip compression method"
+msgstr "ikke-understøttet zip-komprimeringsmetode"
+
+#: ../src/common/zipstrm.cpp:2126
+#, c-format
+msgid "reading zip stream (entry %s): bad length"
+msgstr "læser zip-strøm (entry %s): forkert længde"
+
+#: ../src/common/zipstrm.cpp:2131
+#, c-format
+msgid "reading zip stream (entry %s): bad crc"
+msgstr "læser zip-strøm (entry %s): forkert crc"
+
+#: ../src/common/zipstrm.cpp:2578
+#, fuzzy, c-format
+msgid "error writing zip entry '%s': file too large without ZIP64"
+msgstr "fejl ved skrivning af zip-entry \"%s\": forkert crc eller længde"
+
+#: ../src/common/zipstrm.cpp:2585
+#, c-format
+msgid "error writing zip entry '%s': bad crc or length"
+msgstr "fejl ved skrivning af zip-entry \"%s\": forkert crc eller længde"
+
+#: ../src/common/zstream.cpp:155 ../src/common/zstream.cpp:315
+msgid "Gzip not supported by this version of zlib"
+msgstr "Gzip understøttes ikke af denne version af zlib"
+
+#: ../src/common/zstream.cpp:182
+msgid "Can't initialize zlib inflate stream."
+msgstr "Kan ikke initialisere zlib inflate strøm."
+
+#: ../src/common/zstream.cpp:241
+msgid "Can't read inflate stream: unexpected EOF in underlying stream."
+msgstr "Kan ikke læse inflate strøm: uventet EOF i den underliggende strøm."
+
+#: ../src/common/zstream.cpp:248 ../src/common/zstream.cpp:423
+#, c-format
+msgid "zlib error %d"
+msgstr "zlib fejl %d"
+
+#: ../src/common/zstream.cpp:249
+#, c-format
+msgid "Can't read from inflate stream: %s"
+msgstr "Kan ikke læse fra inflate strøm: %s"
+
+#: ../src/common/zstream.cpp:343
+msgid "Can't initialize zlib deflate stream."
+msgstr "Kan ikke initialisere zlib deflate strøm."
+
+#: ../src/common/zstream.cpp:424
+#, c-format
+msgid "Can't write to deflate stream: %s"
+msgstr "Kan ikke skrive til deflate strøm: %s"
+
+#: ../src/dfb/bitmap.cpp:633 ../src/dfb/bitmap.cpp:667
+#, c-format
+msgid "No bitmap handler for type %d defined."
+msgstr "Ingen bitmap-behandler defineret for type %d."
+
+#: ../src/dfb/evtloop.cpp:99
+msgid "Failed to read event from DirectFB pipe"
+msgstr "Kunne ikke læse event fra DirectFB pipe"
+
+#: ../src/dfb/evtloop.cpp:171
+msgid "Failed to switch DirectFB pipe to non-blocking mode"
+msgstr "Kunne ikke skifte DirectFB pipe til ikke-blokerende-tilstand"
+
+#: ../src/dfb/fontmgr.cpp:171
+#, c-format
+msgid "no fonts found in %s, using builtin font"
+msgstr "ingen skrifttyper fundet i %s. Bruger indbygget skrifttype"
+
+#: ../src/dfb/fontmgr.cpp:177
+msgid "Default font"
+msgstr "Standardskrifttype"
+
+#: ../src/dfb/fontmgr.cpp:195
+#, c-format
+msgid "Fonts index file %s disappeared while loading fonts."
+msgstr "Skrifttypeindeksfil %s forsvandt, mens skrifttyper blev indlæst."
+
+#: ../src/dfb/wrapdfb.cpp:60
+#, c-format
+msgid "DirectFB error %d occurred."
+msgstr "DirectFB fejl %d opstod."
+
+#: ../src/generic/aboutdlgg.cpp:69
+msgid "Developed by "
+msgstr "Udviklet af "
+
+#: ../src/generic/aboutdlgg.cpp:72
+msgid "Documentation by "
+msgstr "Dokumentation af "
+
+#: ../src/generic/aboutdlgg.cpp:75
+msgid "Graphics art by "
+msgstr "Illustrationer af "
+
+#: ../src/generic/aboutdlgg.cpp:78
+msgid "Translations by "
+msgstr "Oversat af "
+
+#: ../src/generic/aboutdlgg.cpp:133 ../src/osx/cocoa/aboutdlg.mm:83
+msgid "Version "
+msgstr "Version "
+
+#. TRANSLATORS: %s is application name
+#: ../src/generic/aboutdlgg.cpp:146 ../src/msw/aboutdlg.cpp:60
+#, c-format
+msgid "About %s"
+msgstr "Om %s"
+
+#: ../src/generic/aboutdlgg.cpp:181
+msgid "License"
+msgstr "Licens"
+
+#: ../src/generic/aboutdlgg.cpp:184
+msgid "Developers"
+msgstr "Udviklere"
+
+#: ../src/generic/aboutdlgg.cpp:188
+msgid "Documentation writers"
+msgstr "Dokumentforfattere"
+
+#: ../src/generic/aboutdlgg.cpp:192
+msgid "Artists"
+msgstr "Kunstnere"
+
+#: ../src/generic/aboutdlgg.cpp:196
+msgid "Translators"
+msgstr "Oversættere"
+
+#: ../src/generic/animateg.cpp:125
+msgid "No handler found for animation type."
+msgstr "Ingen rutine fundet til denne animationstype."
+
+#: ../src/generic/animateg.cpp:133
+#, c-format
+msgid "No animation handler for type %ld defined."
+msgstr "Ingen animationsbehandler defineret for type %ld."
+
+#: ../src/generic/animateg.cpp:145
+#, c-format
+msgid "Animation file is not of type %ld."
+msgstr "Animationsfilen er ikke af typen %ld."
+
+#: ../src/generic/colrdlgg.cpp:154 ../src/gtk/colordlg.cpp:47
+msgid "Choose colour"
+msgstr "Vælg farve"
+
+#: ../src/generic/colrdlgg.cpp:357
+msgid "Red:"
+msgstr "Rød:"
+
+#: ../src/generic/colrdlgg.cpp:360
+msgid "Green:"
+msgstr "Grøn:"
+
+#: ../src/generic/colrdlgg.cpp:363
+msgid "Blue:"
+msgstr "Blå:"
+
+#: ../src/generic/colrdlgg.cpp:372
+msgid "Opacity:"
+msgstr "Opacitet:"
+
+#: ../src/generic/colrdlgg.cpp:384
+msgid "Add to custom colours"
+msgstr "Tilføj til brugerfarver"
+
+#: ../src/generic/creddlgg.cpp:56
+msgid "Username:"
+msgstr ""
+
+#: ../src/generic/creddlgg.cpp:63
+msgid "Password:"
+msgstr ""
+
+#. TRANSLATORS: Name of Boolean true value
+#: ../src/generic/datavgen.cpp:1178
+msgid "true"
+msgstr "sand"
+
+#. TRANSLATORS: Name of Boolean false value
+#: ../src/generic/datavgen.cpp:1180
+msgid "false"
+msgstr "falsk"
+
+#: ../src/generic/datavgen.cpp:6897
+#, c-format
+msgid "Row %i"
+msgstr "Række %i"
+
+#. TRANSLATORS: Action for manipulating a tree control
+#: ../src/generic/datavgen.cpp:6987
+msgid "Collapse"
+msgstr "Fold sammen"
+
+#. TRANSLATORS: Action for manipulating a tree control
+#: ../src/generic/datavgen.cpp:6990
+msgid "Expand"
+msgstr "Fold ud"
+
+#. TRANSLATORS: Name of data view control and number of rows
+#: ../src/generic/datavgen.cpp:7011
+#, c-format
+msgid "%s (%d items)"
+msgstr "%s (%d punkter)"
+
+#: ../src/generic/datavgen.cpp:7062
+#, c-format
+msgid "Column %u"
+msgstr "Kolonne %u"
+
+#. TRANSLATORS: Keystroke for manipulating a tree control
+#: ../src/generic/datavgen.cpp:7131 ../src/richtext/richtextbulletspage.cpp:189
+#: ../src/richtext/richtextbulletspage.cpp:192
+#: ../src/richtext/richtextbulletspage.cpp:193
+#: ../src/richtext/richtextliststylepage.cpp:252
+#: ../src/richtext/richtextliststylepage.cpp:255
+#: ../src/richtext/richtextliststylepage.cpp:256
+#: ../src/richtext/richtextsizepage.cpp:248
+msgid "Left"
+msgstr "Venstre"
+
+#. TRANSLATORS: Keystroke for manipulating a tree control
+#: ../src/generic/datavgen.cpp:7134 ../src/richtext/richtextbulletspage.cpp:191
+#: ../src/richtext/richtextliststylepage.cpp:254
+#: ../src/richtext/richtextsizepage.cpp:249
+msgid "Right"
+msgstr "Højre"
+
+#: ../src/generic/datectlg.cpp:90
+#, c-format
+msgid ""
+"\"%s\" is not in the expected date format, please enter it as e.g. \"%s\"."
+msgstr ""
+
+#: ../src/generic/datectlg.cpp:94
+#, fuzzy
+msgid "Invalid date"
+msgstr "PCX: ugyldigt billede"
+
+#: ../src/generic/dbgrptg.cpp:159
+#, c-format
+msgid "Open file \"%s\""
+msgstr "Åbn filen \"%s\""
+
+#: ../src/generic/dbgrptg.cpp:170
+#, c-format
+msgid "Enter command to open file \"%s\":"
+msgstr "Skriv kommando for at åbne filen \"%s\":"
+
+#: ../src/generic/dbgrptg.cpp:230
+msgid "Executable files (*.exe)|*.exe|"
+msgstr "Programfiler (*.exe)|*.exe|"
+
+#: ../src/generic/dbgrptg.cpp:300
+#, c-format
+msgid "Debug report \"%s\""
+msgstr "Fejlfindingsrapport \"%s\""
+
+#: ../src/generic/dbgrptg.cpp:316
+msgid "A debug report has been generated in the directory\n"
+msgstr "En fejlfindingsrapport er blevet genereret i mappen\n"
+
+#: ../src/generic/dbgrptg.cpp:317
+msgid "The following debug report will be generated\n"
+msgstr ""
+
+#: ../src/generic/dbgrptg.cpp:321
+msgid ""
+"The report contains the files listed below. If any of these files contain "
+"private information,\n"
+"please uncheck them and they will be removed from the report.\n"
+msgstr ""
+"Rapporten indeholder de nedenstående filer. Hvis nogen af disse filer "
+"indeholder private oplysninger, \n"
+"så fravælg dem, og de vil blive fjernet fra rapporten.\n"
+
+#: ../src/generic/dbgrptg.cpp:323
+msgid ""
+"If you wish to suppress this debug report completely, please choose the "
+"\"Cancel\" button,\n"
+"but be warned that it may hinder improving the program, so if\n"
+"at all possible please do continue with the report generation.\n"
+msgstr ""
+"Hvis du helt vil undertrykke denne fejlfindingsrapport, så vælg \"Annullér\"-"
+"knappen.\n"
+"Det kan imidlertid hindre forbedringer i programmet, så hvis\n"
+"det overhovedet er muligt, så fortsæt med at genere rapporten.\n"
+
+#: ../src/generic/dbgrptg.cpp:325
+msgid "              Thank you and we're sorry for the inconvenience!\n"
+msgstr "              Mange tak. Vi beklager ulejligheden.\n"
+
+#: ../src/generic/dbgrptg.cpp:333
+msgid "&Debug report preview:"
+msgstr "&Forhåndsvis fejlfindingsrapport:"
+
+#: ../src/generic/dbgrptg.cpp:339
+msgid "&View..."
+msgstr "&Vis..."
+
+#: ../src/generic/dbgrptg.cpp:359
+msgid "&Notes:"
+msgstr "&Noter:"
+
+#: ../src/generic/dbgrptg.cpp:361
+msgid ""
+"If you have any additional information pertaining to this bug\n"
+"report, please enter it here and it will be joined to it:"
+msgstr ""
+"Hvis du har yderligere oplysninger til fejlfindingsrapporten, \n"
+"så skriv dem venligst her og de vil blive vedhæftet rapporten:"
+
+#: ../src/generic/dcpsg.cpp:1627
+msgid "Cannot open file for PostScript printing!"
+msgstr "Kan ikke åbne fil til PostScript udskrivning!"
+
+#: ../src/generic/dirctrlg.cpp:402
+msgid "Computer"
+msgstr "Computer"
+
+#: ../src/generic/dirctrlg.cpp:404
+msgid "Sections"
+msgstr "Afsnit"
+
+#: ../src/generic/dirctrlg.cpp:482
+msgid "Home directory"
+msgstr "Hjemmemappe"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/generic/dirctrlg.cpp:484 ../src/propgrid/advprops.cpp:811
+msgid "Desktop"
+msgstr "Skrivebord"
+
+#: ../src/generic/dirctrlg.cpp:528 ../src/generic/filectrlg.cpp:752
+msgid "Illegal directory name."
+msgstr "Ulovligt mappenavn."
+
+#: ../src/generic/dirctrlg.cpp:528 ../src/generic/dirctrlg.cpp:546
+#: ../src/generic/dirctrlg.cpp:557 ../src/generic/dirdlgg.cpp:317
+#: ../src/generic/filectrlg.cpp:638 ../src/generic/filectrlg.cpp:752
+#: ../src/generic/filectrlg.cpp:766 ../src/generic/filectrlg.cpp:782
+#: ../src/generic/filectrlg.cpp:1356 ../src/generic/filectrlg.cpp:1387
+#: ../src/generic/filedlgg.cpp:362 ../src/gtk/filedlg.cpp:76
+msgid "Error"
+msgstr "Fejl"
+
+#: ../src/generic/dirctrlg.cpp:546 ../src/generic/filectrlg.cpp:766
+msgid "File name exists already."
+msgstr "Filnavnet findes allerede."
+
+#: ../src/generic/dirctrlg.cpp:557 ../src/generic/dirdlgg.cpp:317
+#: ../src/generic/filectrlg.cpp:638 ../src/generic/filectrlg.cpp:782
+msgid "Operation not permitted."
+msgstr "Handling ikke tilladt."
+
+#: ../src/generic/dirdlgg.cpp:107 ../src/generic/filedlgg.cpp:207
+msgid "Create new directory"
+msgstr "Opret ny mappe"
+
+#: ../src/generic/dirdlgg.cpp:112 ../src/generic/filedlgg.cpp:203
+msgid "Go to home directory"
+msgstr "Gå til hjemmemappe"
+
+#: ../src/generic/dirdlgg.cpp:143
+msgid "Show &hidden directories"
+msgstr "Vis sk&julte mapper"
+
+#: ../src/generic/dirdlgg.cpp:196
+#, c-format
+msgid ""
+"The directory '%s' does not exist\n"
+"Create it now?"
+msgstr ""
+"Mappen \"%s\" findes ikke\n"
+"Opret den nu?"
+
+#: ../src/generic/dirdlgg.cpp:198
+msgid "Directory does not exist"
+msgstr "Mappen findes ikke"
+
+#: ../src/generic/dirdlgg.cpp:214
+#, c-format
+msgid ""
+"Failed to create directory '%s'\n"
+"(Do you have the required permissions?)"
+msgstr ""
+"Kunne ikke oprette mappen \"%s\"\n"
+"(har du de nødvendige tilladelser?)"
+
+#: ../src/generic/dirdlgg.cpp:216
+msgid "Error creating directory"
+msgstr "Fejl ved oprettelse af mappe"
+
+#: ../src/generic/dirdlgg.cpp:281
+msgid "You cannot add a new directory to this section."
+msgstr "Du kan ikke tilføje en mappe til denne sektion."
+
+#: ../src/generic/dirdlgg.cpp:282
+msgid "Create directory"
+msgstr "Opret mappe"
+
+#: ../src/generic/dirdlgg.cpp:291 ../src/generic/dirdlgg.cpp:301
+#: ../src/generic/filectrlg.cpp:614 ../src/generic/filectrlg.cpp:623
+msgid "NewName"
+msgstr "NytNavn"
+
+#: ../src/generic/editlbox.cpp:135
+msgid "Edit item"
+msgstr "Ret objekt"
+
+#: ../src/generic/editlbox.cpp:143
+msgid "New item"
+msgstr "Nyt objekt"
+
+#: ../src/generic/editlbox.cpp:151
+msgid "Delete item"
+msgstr "Slet objekt"
+
+#: ../src/generic/editlbox.cpp:159
+msgid "Move up"
+msgstr "Flyt op"
+
+#: ../src/generic/editlbox.cpp:164
+msgid "Move down"
+msgstr "Flyt ned"
+
+#: ../src/generic/fdrepdlg.cpp:108
+msgid "Search for:"
+msgstr "Søg efter:"
+
+#: ../src/generic/fdrepdlg.cpp:120
+msgid "Replace with:"
+msgstr "Erstat med:"
+
+#: ../src/generic/fdrepdlg.cpp:140
+msgid "Whole word"
+msgstr "Hele ord"
+
+#: ../src/generic/fdrepdlg.cpp:143
+msgid "Match case"
+msgstr "Forskel på store og små bogstaver"
+
+#: ../src/generic/fdrepdlg.cpp:156
+msgid "Search direction"
+msgstr "Søgeretning"
+
+#: ../src/generic/fdrepdlg.cpp:175
+msgid "&Replace"
+msgstr "&Erstat"
+
+#: ../src/generic/fdrepdlg.cpp:178
+msgid "Replace &all"
+msgstr "Erstat &alle"
+
+#: ../src/generic/filectrlg.cpp:246 ../src/generic/filectrlg.cpp:269
+msgid "<DIR>"
+msgstr "<DIR>"
+
+#: ../src/generic/filectrlg.cpp:248 ../src/generic/filectrlg.cpp:271
+msgid "<LINK>"
+msgstr "<LINK>"
+
+#: ../src/generic/filectrlg.cpp:250 ../src/generic/filectrlg.cpp:273
+msgid "<DRIVE>"
+msgstr "<DREV>"
+
+#: ../src/generic/filectrlg.cpp:275
+#, c-format
+msgid "%ld byte"
+msgid_plural "%ld bytes"
+msgstr[0] "%ld byte"
+msgstr[1] "%ld byte"
+
+#: ../src/generic/filectrlg.cpp:420
+msgid "Name"
+msgstr "Navn"
+
+#: ../src/generic/filectrlg.cpp:421 ../src/richtext/richtextformatdlg.cpp:361
+#: ../src/richtext/richtextsizepage.cpp:298
+msgid "Size"
+msgstr "Størrelse"
+
+#: ../src/generic/filectrlg.cpp:422
+msgid "Type"
+msgstr "Type"
+
+#: ../src/generic/filectrlg.cpp:423
+msgid "Modified"
+msgstr "Ændret"
+
+#: ../src/generic/filectrlg.cpp:426
+msgid "Permissions"
+msgstr "Tilladelser"
+
+#: ../src/generic/filectrlg.cpp:429
+msgid "Attributes"
+msgstr "Attributter"
+
+#: ../src/generic/filectrlg.cpp:936
+msgid "Current directory:"
+msgstr "Aktuel mappe:"
+
+#: ../src/generic/filectrlg.cpp:979
+msgid "Show &hidden files"
+msgstr "Vis sk&julte filer"
+
+#: ../src/generic/filectrlg.cpp:1355
+msgid "Illegal file specification."
+msgstr "Ulovlig filspecifikation."
+
+#: ../src/generic/filectrlg.cpp:1387
+msgid "Directory doesn't exist."
+msgstr "Mappen findes ikke."
+
+#: ../src/generic/filedlgg.cpp:195
+msgid "View files as a list view"
+msgstr "Vis filer med listevisning"
+
+#: ../src/generic/filedlgg.cpp:197
+msgid "View files as a detailed view"
+msgstr "Vis filer med detaljeretvisning"
+
+#: ../src/generic/filedlgg.cpp:200
+msgid "Go to parent directory"
+msgstr "Gå til overordnet mappe"
+
+#: ../src/generic/filedlgg.cpp:351 ../src/gtk/filedlg.cpp:59
+#, c-format
+msgid "File '%s' already exists, do you really want to overwrite it?"
+msgstr "Filen \"%s\" findes allerede, vil du virkelig overskrive den?"
+
+#: ../src/generic/filedlgg.cpp:354 ../src/gtk/filedlg.cpp:62
+msgid "Confirm"
+msgstr "Bekræft"
+
+#: ../src/generic/filedlgg.cpp:362 ../src/gtk/filedlg.cpp:75
+msgid "Please choose an existing file."
+msgstr "Vælg venligst en eksisterende fil."
+
+#: ../src/generic/filepickerg.cpp:64
+msgid "..."
+msgstr "..."
+
+#: ../src/generic/fontdlgg.cpp:76 ../src/richtext/richtextformatdlg.cpp:519
+msgid "ABCDEFGabcdefg12345"
+msgstr "ABCDEFGabcdefg12345"
+
+#: ../src/generic/fontdlgg.cpp:315
+msgid "Roman"
+msgstr "Roman"
+
+#: ../src/generic/fontdlgg.cpp:316
+msgid "Decorative"
+msgstr "Dekorativ"
+
+#: ../src/generic/fontdlgg.cpp:317
+msgid "Modern"
+msgstr "Moderne"
+
+#: ../src/generic/fontdlgg.cpp:318
+msgid "Script"
+msgstr "Script"
+
+#: ../src/generic/fontdlgg.cpp:319
+msgid "Swiss"
+msgstr "Swiss"
+
+#: ../src/generic/fontdlgg.cpp:320
+msgid "Teletype"
+msgstr "Teletype"
+
+#: ../src/generic/fontdlgg.cpp:321 ../src/generic/fontdlgg.cpp:324
+msgid "Normal"
+msgstr "Normal"
+
+#: ../src/generic/fontdlgg.cpp:323
+msgid "Slant"
+msgstr "Hældning"
+
+#: ../src/generic/fontdlgg.cpp:325
+msgid "Light"
+msgstr "Let"
+
+#: ../src/generic/fontdlgg.cpp:363
+msgid "&Font family:"
+msgstr "&Skrifttype:"
+
+#: ../src/generic/fontdlgg.cpp:367 ../src/generic/fontdlgg.cpp:369
+msgid "The font family."
+msgstr "Skrifttypefamilien."
+
+#: ../src/generic/fontdlgg.cpp:374 ../src/richtext/richtextstylepage.cpp:105
+msgid "&Style:"
+msgstr "&Typografi:"
+
+#: ../src/generic/fontdlgg.cpp:378 ../src/generic/fontdlgg.cpp:380
+msgid "The font style."
+msgstr "Skrifttypetypografi."
+
+#: ../src/generic/fontdlgg.cpp:385
+msgid "&Weight:"
+msgstr "&Vægt:"
+
+#: ../src/generic/fontdlgg.cpp:389 ../src/generic/fontdlgg.cpp:391
+msgid "The font weight."
+msgstr "Skrifttypens vægt."
+
+#: ../src/generic/fontdlgg.cpp:399
+msgid "C&olour:"
+msgstr "F&arve:"
+
+#: ../src/generic/fontdlgg.cpp:407 ../src/generic/fontdlgg.cpp:409
+msgid "The font colour."
+msgstr "Skriftfarven."
+
+#: ../src/generic/fontdlgg.cpp:415
+msgid "&Point size:"
+msgstr "&Punktstørrelse:"
+
+#: ../src/generic/fontdlgg.cpp:420 ../src/generic/fontdlgg.cpp:422
+#: ../src/generic/fontdlgg.cpp:426 ../src/generic/fontdlgg.cpp:428
+msgid "The font point size."
+msgstr "Skriftens punktstørrelse."
+
+#: ../src/generic/fontdlgg.cpp:439 ../src/generic/fontdlgg.cpp:441
+msgid "Whether the font is underlined."
+msgstr "Om skriften er understreget."
+
+#: ../src/generic/fontdlgg.cpp:448 ../src/html/helpwnd.cpp:1215
+msgid "Preview:"
+msgstr "Udskriftsvisning:"
+
+#: ../src/generic/fontdlgg.cpp:452 ../src/generic/fontdlgg.cpp:454
+msgid "Shows the font preview."
+msgstr "Viser skrifteksempel."
+
+#: ../src/generic/fontdlgg.cpp:464 ../src/generic/fontdlgg.cpp:483
+msgid "Click to cancel the font selection."
+msgstr "Klik for at annullere valg af skrifttype."
+
+#: ../src/generic/fontdlgg.cpp:469 ../src/generic/fontdlgg.cpp:471
+#: ../src/generic/fontdlgg.cpp:476 ../src/generic/fontdlgg.cpp:478
+msgid "Click to confirm the font selection."
+msgstr "Klik for at bekræfte valg af skrifttype."
+
+#: ../src/generic/fontpickerg.cpp:50 ../src/gtk/fontdlg.cpp:77
+msgid "Choose font"
+msgstr "Vælg skrifttype"
+
+#: ../src/generic/grid.cpp:6542
+msgid ""
+"Error copying grid to the clipboard. Either selected cells were not "
+"contiguous or no cell was selected."
+msgstr ""
+
+#: ../src/generic/grid.cpp:12739
+#, fuzzy
+msgid "Grid Corner"
+msgstr "Hjørne"
+
+#: ../src/generic/grid.cpp:12741
+#, fuzzy, c-format
+msgid "Column %s Header"
+msgstr "Kolonne %u"
+
+#: ../src/generic/grid.cpp:12743
+#, c-format
+msgid "Row %s Header"
+msgstr ""
+
+#: ../src/generic/grid.cpp:12745
+#, fuzzy, c-format
+msgid "Column %s: %s"
+msgstr "Kolonne %u"
+
+#: ../src/generic/grid.cpp:12749
+#, fuzzy, c-format
+msgid "Row %s: %s"
+msgstr "Række %i"
+
+#: ../src/generic/grid.cpp:12753
+#, c-format
+msgid "Row %s, Column %s: %s"
+msgstr ""
+
+#: ../src/generic/helpext.cpp:257
+#, c-format
+msgid "Help directory \"%s\" not found."
+msgstr "Hjælp-mappen \"%s\" ikke fundet."
+
+#: ../src/generic/helpext.cpp:265
+#, c-format
+msgid "Help file \"%s\" not found."
+msgstr "Hjælp-filen \"%s\" ikke fundet."
+
+#: ../src/generic/helpext.cpp:284
+#, c-format
+msgid "Line %lu of map file \"%s\" has invalid syntax, skipped."
+msgstr "Linje %lu i map-filen \"%s\" har ugyldig syntaks, sprunget over."
+
+#: ../src/generic/helpext.cpp:292
+#, c-format
+msgid "No valid mappings found in the file \"%s\"."
+msgstr "Ingen gyldige kortlægninger fundet i filen \"%s\"."
+
+#: ../src/generic/helpext.cpp:435
+msgid "No entries found."
+msgstr "Ingen indgange fundet."
+
+#: ../src/generic/helpext.cpp:444 ../src/generic/helpext.cpp:445
+msgid "Help Index"
+msgstr "Hjælp-indeks"
+
+#: ../src/generic/helpext.cpp:448
+msgid "Relevant entries:"
+msgstr "Relevante indgange:"
+
+#: ../src/generic/helpext.cpp:449
+msgid "Entries found"
+msgstr "Indgange fundet"
+
+#: ../src/generic/hyperlinkg.cpp:170
+msgid "&Copy URL"
+msgstr "&Kopiér URL"
+
+#: ../src/generic/infobar.cpp:119
+msgid "Hide this notification message."
+msgstr "Skjul denne påmindelsesmeddelelse."
+
+#. TRANSLATORS: %s will be either the application name or "Application"
+#: ../src/generic/logg.cpp:257
+#, c-format
+msgid "%s Error"
+msgstr "%s fejl"
+
+#. TRANSLATORS: %s will be either the application name or "Application"
+#: ../src/generic/logg.cpp:263
+#, c-format
+msgid "%s Warning"
+msgstr "%s advarsel"
+
+#. TRANSLATORS: %s will be either the application name or "Application"
+#: ../src/generic/logg.cpp:273
+#, c-format
+msgid "%s Information"
+msgstr "%s information"
+
+#: ../src/generic/logg.cpp:276
+msgid "Application"
+msgstr "Program"
+
+#: ../src/generic/logg.cpp:549
+msgid "Save log contents to file"
+msgstr "Gen log indhold til fil"
+
+#: ../src/generic/logg.cpp:551
+msgid "C&lear"
+msgstr "&Rens"
+
+#: ../src/generic/logg.cpp:551
+msgid "Clear the log contents"
+msgstr "Rens log indholdet"
+
+#: ../src/generic/logg.cpp:553
+msgid "Close this window"
+msgstr "Luk dette vindue"
+
+#: ../src/generic/logg.cpp:554
+msgid "&Log"
+msgstr "&Log"
+
+#: ../src/generic/logg.cpp:610 ../src/generic/logg.cpp:992
+msgid "Can't save log contents to file."
+msgstr "Kan ikke gemme logdata til fil."
+
+#: ../src/generic/logg.cpp:613
+#, c-format
+msgid "Log saved to the file '%s'."
+msgstr "Log gemt i filen \"%s\"."
+
+#: ../src/generic/logg.cpp:719
+msgid "&Details"
+msgstr "&Detaljer"
+
+#: ../src/generic/logg.cpp:972
+msgid "Failed to copy dialog contents to the clipboard."
+msgstr "Kunne ikke kopiere dialogens indhold til udklipsholder."
+
+#: ../src/generic/logg.cpp:1022
+#, c-format
+msgid "Append log to file '%s' (choosing [No] will overwrite it)?"
+msgstr "Tilføj log til filen \"%s\" (valg af [Nej] vil overskrive den)?"
+
+#: ../src/generic/logg.cpp:1024
+msgid "Question"
+msgstr "Spørgsmål"
+
+#: ../src/generic/logg.cpp:1038
+msgid "invalid message box return value"
+msgstr "ugyldig returværdi i meddelelsesboks"
+
+#: ../src/generic/notifmsgg.cpp:129
+msgid "Notice"
+msgstr "Note"
+
+#: ../src/generic/preferencesg.cpp:118
+#, c-format
+msgid "%s Preferences"
+msgstr "%s indstillinger"
+
+#: ../src/generic/printps.cpp:143
+msgid "Printing..."
+msgstr "Udskriver..."
+
+#: ../src/generic/printps.cpp:160 ../src/gtk/print.cpp:1076
+#: ../src/msw/printwin.cpp:235
+msgid "Could not start printing."
+msgstr "Kunne ikke starte udskrivning."
+
+#: ../src/generic/printps.cpp:183
+#, c-format
+msgid "Printing page %d..."
+msgstr "Udskriver side %d..."
+
+#: ../src/generic/prntdlgg.cpp:171
+msgid "Printer options"
+msgstr "Printervalg"
+
+#: ../src/generic/prntdlgg.cpp:176
+msgid "Print to File"
+msgstr "Udskriv til fil"
+
+#: ../src/generic/prntdlgg.cpp:179
+msgid "Setup..."
+msgstr "Opsætning..."
+
+#: ../src/generic/prntdlgg.cpp:187
+msgid "Printer:"
+msgstr "Printer:"
+
+#: ../src/generic/prntdlgg.cpp:195
+msgid "Status:"
+msgstr "Status:"
+
+#: ../src/generic/prntdlgg.cpp:206
+msgid "All"
+msgstr "Alle"
+
+#: ../src/generic/prntdlgg.cpp:207
+msgid "Pages"
+msgstr "Sider"
+
+#: ../src/generic/prntdlgg.cpp:215
+msgid "Print Range"
+msgstr "Udskriv sider"
+
+#: ../src/generic/prntdlgg.cpp:229
+msgid "From:"
+msgstr "Fra:"
+
+#: ../src/generic/prntdlgg.cpp:233
+msgid "To:"
+msgstr "Til:"
+
+#: ../src/generic/prntdlgg.cpp:238
+msgid "Copies:"
+msgstr "Kopier:"
+
+#: ../src/generic/prntdlgg.cpp:288
+msgid "PostScript file"
+msgstr "PostScript-fil"
+
+#: ../src/generic/prntdlgg.cpp:439
+msgid "Print Setup"
+msgstr "Udskriftsopsætning"
+
+#: ../src/generic/prntdlgg.cpp:483
+msgid "Printer"
+msgstr "Printer"
+
+#: ../src/generic/prntdlgg.cpp:501
+msgid "Default printer"
+msgstr "Standardprinter"
+
+#: ../src/generic/prntdlgg.cpp:595 ../src/generic/prntdlgg.cpp:782
+#: ../src/generic/prntdlgg.cpp:822 ../src/generic/prntdlgg.cpp:835
+#: ../src/generic/prntdlgg.cpp:1031 ../src/generic/prntdlgg.cpp:1036
+msgid "Paper size"
+msgstr "Papirstørrelse"
+
+#: ../src/generic/prntdlgg.cpp:604 ../src/generic/prntdlgg.cpp:847
+msgid "Portrait"
+msgstr "Opretstående"
+
+#: ../src/generic/prntdlgg.cpp:605 ../src/generic/prntdlgg.cpp:848
+msgid "Landscape"
+msgstr "Liggende"
+
+#: ../src/generic/prntdlgg.cpp:607 ../src/generic/prntdlgg.cpp:849
+msgid "Orientation"
+msgstr "Orientering"
+
+#: ../src/generic/prntdlgg.cpp:610
+msgid "Options"
+msgstr "Indstillinger"
+
+#: ../src/generic/prntdlgg.cpp:612
+msgid "Print in colour"
+msgstr "Udskriv i farver"
+
+#: ../src/generic/prntdlgg.cpp:621
+msgid "Print spooling"
+msgstr "Udskriftsspooling"
+
+#: ../src/generic/prntdlgg.cpp:623
+msgid "Printer command:"
+msgstr "Printerkommando:"
+
+#: ../src/generic/prntdlgg.cpp:631
+msgid "Printer options:"
+msgstr "Printervalg:"
+
+#: ../src/generic/prntdlgg.cpp:860
+msgid "Left margin (mm):"
+msgstr "Venstre margen (mm):"
+
+#: ../src/generic/prntdlgg.cpp:861
+msgid "Top margin (mm):"
+msgstr "Topmargen (mm):"
+
+#: ../src/generic/prntdlgg.cpp:872
+msgid "Right margin (mm):"
+msgstr "Højre margen (mm):"
+
+#: ../src/generic/prntdlgg.cpp:873
+msgid "Bottom margin (mm):"
+msgstr "Bundmargen (mm):"
+
+#: ../src/generic/prntdlgg.cpp:896
+msgid "Printer..."
+msgstr "Printer..."
+
+#: ../src/generic/progdlgg.cpp:246
+msgid "&Skip"
+msgstr "&Spring over"
+
+#: ../src/generic/progdlgg.cpp:347 ../src/generic/progdlgg.cpp:626
+msgid "Unknown"
+msgstr "Ukendt"
+
+#: ../src/generic/progdlgg.cpp:451 ../src/msw/progdlg.cpp:526
+msgid "Done."
+msgstr "Færdig."
+
+#: ../src/generic/srchctlg.cpp:55 ../src/gtk/srchctrl.cpp:206
+#: ../src/html/helpwnd.cpp:530 ../src/html/helpwnd.cpp:545
+msgid "Search"
+msgstr "Søg"
+
+#: ../src/generic/tabg.cpp:1026
+msgid "Could not find tab for id"
+msgstr "Kunne ikke finde tab til id"
+
+#: ../src/generic/tipdlg.cpp:136
+msgid "Tips not available, sorry!"
+msgstr "Tips ikke tilgængelige, beklager!"
+
+#: ../src/generic/tipdlg.cpp:197
+msgid "Tip of the Day"
+msgstr "Dagens tip"
+
+#: ../src/generic/tipdlg.cpp:207
+msgid "Did you know..."
+msgstr "Vidste du..."
+
+#: ../src/generic/tipdlg.cpp:232
+msgid "&Show tips at startup"
+msgstr "&Vis tips ved opstart"
+
+#: ../src/generic/tipdlg.cpp:236
+msgid "&Next Tip"
+msgstr "&Næste tip"
+
+#: ../src/generic/wizard.cpp:411
+msgid "&Next >"
+msgstr "&Næste >"
+
+#: ../src/generic/wizard.cpp:412
+msgid "&Finish"
+msgstr "&Slut"
+
+#: ../src/generic/wizard.cpp:420
+msgid "< &Back"
+msgstr "< &Tilbage"
+
+#: ../src/gtk/aboutdlg.cpp:204
+msgid "translator-credits"
+msgstr "scootergrisen"
+
+#: ../src/gtk/app.cpp:517
+msgid ""
+"WARNING: using XIM input method is unsupported and may result in problems "
+"with input handling and flickering. Consider unsetting GTK_IM_MODULE or "
+"setting to \"ibus\"."
+msgstr ""
+
+#: ../src/gtk/app.cpp:569
+msgid "Unable to initialize GTK+, is DISPLAY set properly?"
+msgstr "Kunne ikke initialisere GTK+. Er DISPLAY sat korrekt?"
+
+#: ../src/gtk/filedlg.cpp:89 ../src/gtk/filepicker.cpp:255
+#, c-format
+msgid "Changing current directory to \"%s\" failed"
+msgstr "Kunne ikke ændre den aktuelle mappe til \"%s\""
+
+#: ../src/gtk/font.cpp:548
+msgid ""
+"Using private fonts is not supported on this system: Pango library is too "
+"old, 1.38 or later required."
+msgstr ""
+
+#: ../src/gtk/font.cpp:558
+#, fuzzy
+msgid "Failed to create font configuration object."
+msgstr "Kunne ikke opdatere brugerkonfigurationsfil."
+
+#: ../src/gtk/font.cpp:568
+#, fuzzy, c-format
+msgid "Failed to add custom font \"%s\"."
+msgstr "Kunne ikke læse dokument fra filen \"%s\"."
+
+#: ../src/gtk/font.cpp:576
+#, fuzzy
+msgid "Failed to register font configuration using private fonts."
+msgstr "Kunne ikke opdatere brugerkonfigurationsfil."
+
+#: ../src/gtk/glcanvas.cpp:117 ../src/gtk/glcanvas.cpp:132
+#, fuzzy
+msgid "Fatal Error"
+msgstr "Filfejl"
+
+#: ../src/gtk/glcanvas.cpp:117
+msgid ""
+"This program wasn't compiled with EGL support required under Wayland, "
+"either\n"
+"install EGL libraries and rebuild or run it under X11 backend by setting\n"
+"environment variable GDK_BACKEND=x11 before starting your program."
+msgstr ""
+
+#: ../src/gtk/glcanvas.cpp:132
+msgid ""
+"wxGLCanvas is only supported on Wayland and X11 currently.  You may be able "
+"to\n"
+"work around this by setting environment variable GDK_BACKEND=x11 before\n"
+"starting your program."
+msgstr ""
+
+#: ../src/gtk/mdi.cpp:433
+msgid "MDI child"
+msgstr "MDI-barn"
+
+#: ../src/gtk/power.cpp:188
+#, fuzzy, c-format
+msgid "Failed to open D-Bus connection to the login manager: %s"
+msgstr "Kunne ikke oprette forbindelse til serveren \"%s\" ang. emne \"%s\""
+
+#: ../src/gtk/power.cpp:214
+#, fuzzy
+msgid "wxWidgets application"
+msgstr "Program"
+
+#: ../src/gtk/power.cpp:226
+msgid "Application needs to keep running"
+msgstr ""
+
+#: ../src/gtk/power.cpp:233
+msgid "Clean up before suspend"
+msgstr ""
+
+#: ../src/gtk/power.cpp:259
+#, fuzzy, c-format
+msgid "Failed to inhibit sleep: %s"
+msgstr "Kunne ikke initialisere netværk via modem forbindelse: %s"
+
+#: ../src/gtk/power.cpp:265
+msgid "Unexpected response to D-Bus \"Inhibit\" request."
+msgstr ""
+
+#: ../src/gtk/print.cpp:218
+msgid "Custom size"
+msgstr "Speciel størrelse"
+
+#: ../src/gtk/print.cpp:752
+#, fuzzy, c-format
+msgid "Error while printing: %s"
+msgstr "Fejl under udskrift: "
+
+#: ../src/gtk/print.cpp:816
+msgid "Page Setup"
+msgstr "Sideopsætning"
+
+#: ../src/gtk/webview_webkit.cpp:932
+msgid "Retrieving JavaScript script output is not supported with WebKit v1"
+msgstr ""
+
+#: ../src/gtk/webview_webkit2.cpp:1098
+msgid ""
+"Setting proxy is not supported by WebKit, at least version 2.16 is required."
+msgstr ""
+
+#: ../src/gtk/webview_webkit2.cpp:1104
+msgid "This program was compiled without support for setting WebKit proxy."
+msgstr ""
+
+#: ../src/gtk/window.cpp:6289
+msgid ""
+"GTK+ installed on this machine is too old to support screen compositing, "
+"please install GTK+ 2.12 or later."
+msgstr ""
+"Den GTK+, som er installeret maskine, er for gammel til at understøtte "
+"skærmkomposition. Installer venligst GTK+ 2.12 eller senere."
+
+#: ../src/gtk/window.cpp:6307
+msgid ""
+"Compositing not supported by this system, please enable it in your Window "
+"Manager."
+msgstr ""
+"Komposition understøttes ikke af dette system. Slå det venligst til i din "
+"vindueshåndtering."
+
+#: ../src/gtk/window.cpp:6318
+msgid ""
+"This program was compiled with a too old version of GTK+, please rebuild "
+"with GTK+ 2.12 or newer."
+msgstr ""
+"Dette program blev kompileret med en for gammel version af GTK+. Genbyg "
+"venligst med GTK+ 2.12 eller nyere."
+
+#: ../src/html/chm.cpp:138
+#, c-format
+msgid "Failed to open CHM archive '%s'."
+msgstr "Kunne ikke åbne CHM-arkivet \"%s\"."
+
+#: ../src/html/chm.cpp:270
+#, c-format
+msgid "Could not extract %s into %s: %s"
+msgstr "Kunne ikke udpakke %s til %s: %s"
+
+#: ../src/html/chm.cpp:324
+msgid "no error"
+msgstr "ingen fejl"
+
+#: ../src/html/chm.cpp:326
+msgid "bad arguments to library function"
+msgstr "ugyldige argumenter til biblioteksfunktion"
+
+#: ../src/html/chm.cpp:328
+msgid "error opening file"
+msgstr "fejl ved åbning af fil"
+
+#: ../src/html/chm.cpp:330
+msgid "read error"
+msgstr "læsefejl"
+
+#: ../src/html/chm.cpp:332
+msgid "write error"
+msgstr "skrivefejl"
+
+#: ../src/html/chm.cpp:334
+msgid "seek error"
+msgstr "søgefejl"
+
+#: ../src/html/chm.cpp:338
+msgid "bad signature"
+msgstr "forkert signatur"
+
+#: ../src/html/chm.cpp:340
+msgid "error in data format"
+msgstr "fejl i dataformat"
+
+#: ../src/html/chm.cpp:342
+msgid "checksum error"
+msgstr "checksum fejl"
+
+#: ../src/html/chm.cpp:344
+msgid "compression error"
+msgstr "fejl ved komprimering"
+
+#: ../src/html/chm.cpp:346
+msgid "decompression error"
+msgstr "fejl ved udpakning"
+
+#: ../src/html/chm.cpp:437
+#, c-format
+msgid "Could not locate file '%s'."
+msgstr "Kunne ikke finde filen \"%s\"."
+
+#: ../src/html/chm.cpp:711
+#, c-format
+msgid "Could not create temporary file '%s'"
+msgstr "Kunne ikke oprette midlertidig fil \"%s\""
+
+#: ../src/html/chm.cpp:718
+#, c-format
+msgid "Extraction of '%s' into '%s' failed."
+msgstr "Udpakning af \"%s\" til \"%s\" fejlede."
+
+#: ../src/html/chm.cpp:806 ../src/html/chm.cpp:863
+msgid "CHM handler currently supports only local files!"
+msgstr "CHM-handler understøtter i øjeblikket kun lokale filer!"
+
+#: ../src/html/chm.cpp:827
+msgid "Link contained '//', converted to absolute link."
+msgstr "Link indeholdt \"//\", konverteret til absolut link."
+
+#: ../src/html/helpctrl.cpp:59
+#, c-format
+msgid "Help: %s"
+msgstr "Hjælp: %s"
+
+#: ../src/html/helpctrl.cpp:155
+#, c-format
+msgid "Adding book %s"
+msgstr "Tilføjer bog %s"
+
+#: ../src/html/helpdata.cpp:295
+#, c-format
+msgid "Cannot open contents file: %s"
+msgstr "Kan ikke åbne indholdsfilen: %s"
+
+#: ../src/html/helpdata.cpp:309
+#, c-format
+msgid "Cannot open index file: %s"
+msgstr "Kan ikke åbne indeksfilen %s"
+
+#: ../src/html/helpdata.cpp:643
+msgid "noname"
+msgstr "unavngivet"
+
+#: ../src/html/helpdata.cpp:652
+#, c-format
+msgid "Cannot open HTML help book: %s"
+msgstr "Kan ikke åbne HTML Hjælp-bog: %s"
+
+#: ../src/html/helpwnd.cpp:315
+msgid "Displays help as you browse the books on the left."
+msgstr "Viser hjælp mens du gennemser bøgerne til venstre."
+
+#: ../src/html/helpwnd.cpp:411 ../src/html/helpwnd.cpp:1100
+#: ../src/html/helpwnd.cpp:1735
+msgid "(bookmarks)"
+msgstr "(bogmærker)"
+
+#: ../src/html/helpwnd.cpp:424
+msgid "Add current page to bookmarks"
+msgstr "Tilføj denne side til bogmærker"
+
+#: ../src/html/helpwnd.cpp:425
+msgid "Remove current page from bookmarks"
+msgstr "Fjern den aktuelle side fra bogmærkerne"
+
+#: ../src/html/helpwnd.cpp:470
+msgid "Contents"
+msgstr "Indhold"
+
+#: ../src/html/helpwnd.cpp:485
+msgid "Find"
+msgstr "Find"
+
+#: ../src/html/helpwnd.cpp:487
+msgid "Show all"
+msgstr "Vis alle"
+
+#: ../src/html/helpwnd.cpp:497
+msgid ""
+"Display all index items that contain given substring. Search is case "
+"insensitive."
+msgstr ""
+"Vis alle indeksemner, der indeholder understrengen. Ingen forskel på store "
+"og små bogstaver."
+
+#: ../src/html/helpwnd.cpp:498
+msgid "Show all items in index"
+msgstr "Vis alle punkter i indeks"
+
+#: ../src/html/helpwnd.cpp:528
+msgid "Case sensitive"
+msgstr "Forskel på store og små bogstaver"
+
+#: ../src/html/helpwnd.cpp:529
+msgid "Whole words only"
+msgstr "Kun hele ord"
+
+#: ../src/html/helpwnd.cpp:532
+msgid ""
+"Search contents of help book(s) for all occurrences of the text you typed "
+"above"
+msgstr "Søg i hjælp-bøger efter alle forekomster af den indtastede tekst"
+
+#: ../src/html/helpwnd.cpp:653
+msgid "Show/hide navigation panel"
+msgstr "Vis/skjul navigationspanel"
+
+#: ../src/html/helpwnd.cpp:655
+msgid "Go back"
+msgstr "Tilbage"
+
+#: ../src/html/helpwnd.cpp:656
+msgid "Go forward"
+msgstr "Frem"
+
+#: ../src/html/helpwnd.cpp:658
+msgid "Go one level up in document hierarchy"
+msgstr "Et niveau op i dokument hierarkiet"
+
+#: ../src/html/helpwnd.cpp:666 ../src/html/helpwnd.cpp:1547
+msgid "Open HTML document"
+msgstr "Åbn HTML-dokument"
+
+#: ../src/html/helpwnd.cpp:670
+msgid "Print this page"
+msgstr "Udskriv denne side"
+
+#: ../src/html/helpwnd.cpp:674
+msgid "Display options dialog"
+msgstr "Vis dialogen Indstillinger"
+
+#: ../src/html/helpwnd.cpp:795
+msgid "Please choose the page to display:"
+msgstr "Vælg siden der skal vises:"
+
+#: ../src/html/helpwnd.cpp:796
+msgid "Help Topics"
+msgstr "Hjælp-emner"
+
+#: ../src/html/helpwnd.cpp:852
+msgid "Searching..."
+msgstr "Søger..."
+
+#: ../src/html/helpwnd.cpp:853
+msgid "No matching page found yet"
+msgstr "Fandt ingen passende side endnu"
+
+#: ../src/html/helpwnd.cpp:870
+#, c-format
+msgid "Found %i matches"
+msgstr "Fandt %i matchende"
+
+#: ../src/html/helpwnd.cpp:958
+msgid "(Help)"
+msgstr "(hjælp)"
+
+#: ../src/html/helpwnd.cpp:1026
+#, c-format
+msgid "%d of %lu"
+msgstr "%d af %lu"
+
+#: ../src/html/helpwnd.cpp:1028
+#, c-format
+msgid "%lu of %lu"
+msgstr "%lu af %lu"
+
+#: ../src/html/helpwnd.cpp:1047
+msgid "Search in all books"
+msgstr "Søg i alle bøger"
+
+#: ../src/html/helpwnd.cpp:1193
+msgid "Help Browser Options"
+msgstr "Hjælp til browserindstillinger"
+
+#: ../src/html/helpwnd.cpp:1198
+msgid "Normal font:"
+msgstr "Normal skrift:"
+
+#: ../src/html/helpwnd.cpp:1199
+msgid "Fixed font:"
+msgstr "Fast type:"
+
+#: ../src/html/helpwnd.cpp:1200
+msgid "Font size:"
+msgstr "Skriftstørrelse:"
+
+#: ../src/html/helpwnd.cpp:1245
+msgid "font size"
+msgstr "skriftstørrelse"
+
+#: ../src/html/helpwnd.cpp:1256
+msgid "Normal face<br>and <u>underlined</u>. "
+msgstr "Normal skrift<br>og <u>understreget</u>. "
+
+#: ../src/html/helpwnd.cpp:1257
+msgid "<i>Italic face.</i> "
+msgstr "<i>Kursiv skrift.</i> "
+
+#: ../src/html/helpwnd.cpp:1258
+msgid "<b>Bold face.</b> "
+msgstr "<b>Fed skrift.</b> "
+
+#: ../src/html/helpwnd.cpp:1259
+msgid "<b><i>Bold italic face.</i></b><br>"
+msgstr "<b><i>Fed kursiv skrift.</i></b><br>"
+
+#: ../src/html/helpwnd.cpp:1262
+msgid "Fixed size face.<br> <b>bold</b> <i>italic</i> "
+msgstr "Fast skriftstørrelse.<br> <b>fed</b> <i>kursiv</i> "
+
+#: ../src/html/helpwnd.cpp:1263
+msgid "<b><i>bold italic <u>underlined</u></i></b><br>"
+msgstr "<b><i>fed kursiv <u>understreget</u></i></b><br>"
+
+#: ../src/html/helpwnd.cpp:1524
+msgid "Help Printing"
+msgstr "Hjælp til udskrift"
+
+#: ../src/html/helpwnd.cpp:1527
+msgid "Cannot print empty page."
+msgstr "Kan ikke udskrive tom side."
+
+#: ../src/html/helpwnd.cpp:1540
+msgid "HTML files (*.html;*.htm)|*.html;*.htm|"
+msgstr "HTML-filer (*.html;*.htm)|*.html;*.htm|"
+
+#: ../src/html/helpwnd.cpp:1541
+msgid "Help books (*.htb)|*.htb|Help books (*.zip)|*.zip|"
+msgstr "Hjælp-bøger (*.htb)|*.htb|Hjælp-bøger (*.zip)|*.zip|"
+
+#: ../src/html/helpwnd.cpp:1542
+msgid "HTML Help Project (*.hhp)|*.hhp|"
+msgstr "HTML Hjælp-projekt (*.hhp)|*.hhp|"
+
+#: ../src/html/helpwnd.cpp:1544
+msgid "Compressed HTML Help file (*.chm)|*.chm|"
+msgstr "Komprimeret HTML Hjælp-fil (*.chm)|*.chm|"
+
+#: ../src/html/helpwnd.cpp:1671
+#, c-format
+msgid "%i of %u"
+msgstr "%i af %u"
+
+#: ../src/html/helpwnd.cpp:1709
+#, c-format
+msgid "%u of %u"
+msgstr "%u af %u"
+
+#: ../src/html/htmlfilt.cpp:134
+#, c-format
+msgid "Cannot open HTML document: %s"
+msgstr "Kan ikke åbne HTML-dokument %s"
+
+#: ../src/html/htmlwin.cpp:599
+msgid "Connecting..."
+msgstr "Opretter forbindelse..."
+
+#: ../src/html/htmlwin.cpp:616
+#, c-format
+msgid "Unable to open requested HTML document: %s"
+msgstr "Kunne ikke åbne det ønskede HTML-dokument: %s"
+
+#: ../src/html/htmlwin.cpp:630
+msgid "Loading : "
+msgstr "Indlæser : "
+
+#: ../src/html/htmlwin.cpp:673
+msgid "Done"
+msgstr "Færdig"
+
+#: ../src/html/htmlwin.cpp:723
+#, c-format
+msgid "HTML anchor %s does not exist."
+msgstr "HTML-anker %s findes ikke."
+
+#: ../src/html/htmlwin.cpp:1057
+#, c-format
+msgid "Copied to clipboard:\"%s\""
+msgstr "Kopieret til udklipsholder:\"%s\""
+
+#: ../src/html/htmprint.cpp:269
+msgid ""
+"This document doesn't fit on the page horizontally and will be truncated "
+"when it is printed."
+msgstr ""
+"Dette dokument kan ikke være vandret på siden og vil blive afskåret under "
+"udskrift."
+
+#: ../src/html/htmprint.cpp:285
+#, c-format
+msgid ""
+"The document \"%s\" doesn't fit on the page horizontally and will be "
+"truncated if printed.\n"
+"\n"
+"Would you like to proceed with printing it nevertheless?"
+msgstr ""
+"Dokumentet \"%s\" kan ikke være vandret på siden og vil blive afskåret under "
+"udskrivning.\n"
+"\n"
+"Vil du alligevel fortsætte med udskrivningen?"
+
+#: ../src/html/htmprint.cpp:296
+msgid ""
+"If possible, try changing the layout parameters to make the printout more "
+"narrow."
+msgstr ""
+"Hvis det er muligt, så prøv at ændre layout-parametrene, så udskriften "
+"bliver smallere."
+
+#: ../src/html/htmprint.cpp:445
+msgid ": file does not exist!"
+msgstr ": filen findes ikke!"
+
+#. TRANSLATORS: %s may be a document title.
+#: ../src/html/htmprint.cpp:717
+#, fuzzy, c-format
+msgid "%s Preview"
+msgstr " Vis udskrift"
+
+#: ../src/html/htmprint.cpp:755 ../src/richtext/richtextprint.cpp:618
+msgid ""
+"There was a problem during page setup: you may need to set a default printer."
+msgstr "Problem ved sideopsætning: du skal muligvis vælge en standardprinter."
+
+#: ../src/msw/clipbrd.cpp:80
+msgid "Failed to open the clipboard."
+msgstr "Kunne ikke åbne udklipsholder."
+
+#: ../src/msw/clipbrd.cpp:101
+msgid "Failed to close the clipboard."
+msgstr "Kunne ikke lukke udklipsholder."
+
+#: ../src/msw/clipbrd.cpp:113
+msgid "Failed to empty the clipboard."
+msgstr "Kunne ikke tømme udklipsholder."
+
+#: ../src/msw/clipbrd.cpp:284
+msgid "Failed to put data on the clipboard"
+msgstr "Kunne ikke sende data til udklipsholder"
+
+#: ../src/msw/clipbrd.cpp:326
+msgid "Failed to get data from the clipboard"
+msgstr "Kunne ikke hente data fra udklipsholder"
+
+#: ../src/msw/clipbrd.cpp:363
+msgid "Failed to retrieve the supported clipboard formats"
+msgstr "Kunne ikke hente liste over understøttede udklipsholderformater"
+
+#: ../src/msw/colordlg.cpp:228
+#, c-format
+msgid "Colour selection dialog failed with error %0lx."
+msgstr "Dialogen Valg af farver fejlede med fejlkode %0lx."
+
+#: ../src/msw/cursor.cpp:141
+msgid "Failed to create cursor."
+msgstr "Kunne ikke oprette markør."
+
+#: ../src/msw/dde.cpp:279
+#, c-format
+msgid "Failed to register DDE server '%s'"
+msgstr "Kunne ikke registrere DDE-serveren \"%s\""
+
+#: ../src/msw/dde.cpp:300
+#, c-format
+msgid "Failed to unregister DDE server '%s'"
+msgstr "Kunne ikke afregistrere DDE-serveren \"%s\""
+
+#: ../src/msw/dde.cpp:428
+#, c-format
+msgid "Failed to create connection to server '%s' on topic '%s'"
+msgstr "Kunne ikke oprette forbindelse til serveren \"%s\" ang. emne \"%s\""
+
+#: ../src/msw/dde.cpp:655
+msgid "DDE poke request failed"
+msgstr "DDE-poke anmodning fejlede"
+
+#: ../src/msw/dde.cpp:674
+msgid "Failed to establish an advise loop with DDE server"
+msgstr "Kunne ikke oprette advice loop med DDE-server"
+
+#: ../src/msw/dde.cpp:693
+msgid "Failed to terminate the advise loop with DDE server"
+msgstr "Kunne ikke afslutte advice loop med DDE-server"
+
+#: ../src/msw/dde.cpp:768
+msgid "Failed to send DDE advise notification"
+msgstr "Kunne ikke sende DDE-advice påmindelse"
+
+#: ../src/msw/dde.cpp:1085
+msgid "Failed to create DDE string"
+msgstr "Kunne ikke oprette DDE-streng"
+
+#: ../src/msw/dde.cpp:1131
+msgid "no DDE error."
+msgstr "ingen DDE-fejl."
+
+#: ../src/msw/dde.cpp:1135
+msgid "a request for a synchronous advise transaction has timed out."
+msgstr "en anmodning om synkron advise-transaktion fik timeout."
+
+#: ../src/msw/dde.cpp:1138
+msgid "the response to the transaction caused the DDE_FBUSY bit to be set."
+msgstr "svaret på transaktionen bevirkede, at bitten DDE_FBUSY blev sat."
+
+#: ../src/msw/dde.cpp:1141
+msgid "a request for a synchronous data transaction has timed out."
+msgstr "en anmodning om en synkron data-transaktion fik timeout."
+
+#: ../src/msw/dde.cpp:1144
+msgid ""
+"a DDEML function was called without first calling the DdeInitialize "
+"function,\n"
+"or an invalid instance identifier\n"
+"was passed to a DDEML function."
+msgstr ""
+"en DDEML-funktion blev kaldt uden at kalde DdeInitialize først,\n"
+"eller der er sendt en ugyldig instans\n"
+"indentifikator til en DDEML-funktion."
+
+#: ../src/msw/dde.cpp:1147
+msgid ""
+"an application initialized as APPCLASS_MONITOR has\n"
+"attempted to perform a DDE transaction,\n"
+"or an application initialized as APPCMD_CLIENTONLY has \n"
+"attempted to perform server transactions."
+msgstr ""
+"et program initialiseret som APPCLASS_MONITOR har\n"
+"forsøgt at udføre en DDE-transaktion,\n"
+"eller et program initialiseret som APPCMD_CLIENTONLY\n"
+"har forsøgt at udføre server-transaktioner."
+
+#: ../src/msw/dde.cpp:1150
+msgid "a request for a synchronous execute transaction has timed out."
+msgstr "en anmodning om en synkron execute-transaktion fik timeout."
+
+#: ../src/msw/dde.cpp:1153
+msgid "a parameter failed to be validated by the DDEML."
+msgstr "en parameter kunne ikke valideres af DDEML."
+
+#: ../src/msw/dde.cpp:1156
+msgid "a DDEML application has created a prolonged race condition."
+msgstr "en DDEML-applikation har lavet en forlænget race condition."
+
+#: ../src/msw/dde.cpp:1159
+msgid "a memory allocation failed."
+msgstr "en hukommelsestildeling fejlede."
+
+#: ../src/msw/dde.cpp:1162
+msgid "a client's attempt to establish a conversation has failed."
+msgstr "en klients forsøg på at starte en samtale slog fejl."
+
+#: ../src/msw/dde.cpp:1165
+msgid "a transaction failed."
+msgstr "en transaktion fejlede."
+
+#: ../src/msw/dde.cpp:1168
+msgid "a request for a synchronous poke transaction has timed out."
+msgstr "en anmodning om en synkron poke-transaktion fik timeout."
+
+#: ../src/msw/dde.cpp:1171
+msgid "an internal call to the PostMessage function has failed. "
+msgstr "et internt kald til PostMessage-funktionen fejlede. "
+
+#: ../src/msw/dde.cpp:1174
+msgid "reentrancy problem."
+msgstr "reentrancy problem."
+
+#: ../src/msw/dde.cpp:1177
+msgid ""
+"a server-side transaction was attempted on a conversation\n"
+"that was terminated by the client, or the server\n"
+"terminated before completing a transaction."
+msgstr ""
+"en server-side-transaktion blev forsøgt i en samtale\n"
+"der blev afsluttet af klienten, eller serveren afsluttede\n"
+"inden fuldførslen af en transaktion."
+
+#: ../src/msw/dde.cpp:1180
+msgid "an internal error has occurred in the DDEML."
+msgstr "intern fejl opstået i DDEML."
+
+#: ../src/msw/dde.cpp:1183
+msgid "a request to end an advise transaction has timed out."
+msgstr "en anmodning om at afslutte en advise-transaktion fik timeout."
+
+#: ../src/msw/dde.cpp:1186
+msgid ""
+"an invalid transaction identifier was passed to a DDEML function.\n"
+"Once the application has returned from an XTYP_XACT_COMPLETE callback,\n"
+"the transaction identifier for that callback is no longer valid."
+msgstr ""
+"en ugyldig transaktions identifikation er sendt til en DDEML-funktion.\n"
+"Når programmet er returneret fra et XTYP_XACT_COMPLETE-tilbagekald,\n"
+"er transaktion identifikationen for dette tilbagekald ikke længere gyldig."
+
+#: ../src/msw/dde.cpp:1189
+#, c-format
+msgid "Unknown DDE error %08x"
+msgstr "Ukendt DDE-fejl %08x"
+
+#: ../src/msw/dialup.cpp:343
+msgid ""
+"Dial up functions are unavailable because the remote access service (RAS) is "
+"not installed on this machine. Please install it."
+msgstr ""
+"Opkaldsfunktion er ikke tilgængelig, fordi Remote Access Service (RAS) ikke "
+"er installeret på computeren. Installer det venligst."
+
+#: ../src/msw/dialup.cpp:402
+#, c-format
+msgid ""
+"The version of remote access service (RAS) installed on this machine is too "
+"old, please upgrade (the following required function is missing: %s)."
+msgstr ""
+"Versionen af Remote Access Service (RAS), som er installeret på denne "
+"computer, er for gammel, opgradering anbefales. (følgende nødvendige "
+"funktion mangler: %s)."
+
+#: ../src/msw/dialup.cpp:437
+msgid "Failed to retrieve text of RAS error message"
+msgstr "Kunne ikke hente tekst fra RAS fejlmeddelelse"
+
+#: ../src/msw/dialup.cpp:440
+#, c-format
+msgid "unknown error (error code %08x)."
+msgstr "ukendt fejl (fejlkode %08x)."
+
+#: ../src/msw/dialup.cpp:492
+#, c-format
+msgid "Cannot find active dialup connection: %s"
+msgstr "Kan ikke finde aktiv netværk via modem forbindelse: %s"
+
+#: ../src/msw/dialup.cpp:513
+msgid "Several active dialup connections found, choosing one randomly."
+msgstr "Har fundet flere netværk via modem forbindelser, vælger en tilfældig."
+
+#: ../src/msw/dialup.cpp:598 ../src/msw/dialup.cpp:832
+#, c-format
+msgid "Failed to establish dialup connection: %s"
+msgstr "Kunne ikke etablere netværk via modem forbindelse: %s"
+
+#: ../src/msw/dialup.cpp:664
+#, c-format
+msgid "Failed to get ISP names: %s"
+msgstr "Kunne ikke få ISP-navne: %s"
+
+#: ../src/msw/dialup.cpp:712
+msgid "Failed to connect: no ISP to dial."
+msgstr "Kunne ikke oprette forbindelse: ingen ISP at foretage opkald til."
+
+#: ../src/msw/dialup.cpp:732
+msgid "Choose ISP to dial"
+msgstr "Vælg ISP til opkald"
+
+#: ../src/msw/dialup.cpp:733
+msgid "Please choose which ISP do you want to connect to"
+msgstr "Vælg venligst den ISP, du vil oprette forbindelse til"
+
+#: ../src/msw/dialup.cpp:766
+msgid "Failed to connect: missing username/password."
+msgstr "Kunne ikke oprette forbindelse: mangler brugernavn/adgangskode."
+
+#: ../src/msw/dialup.cpp:796
+msgid "Cannot find the location of address book file"
+msgstr "Kan ikke finde placering af adressebog filen"
+
+#: ../src/msw/dialup.cpp:827
+#, c-format
+msgid "Failed to initiate dialup connection: %s"
+msgstr "Kunne ikke initialisere netværk via modem forbindelse: %s"
+
+#: ../src/msw/dialup.cpp:897
+msgid "Cannot hang up - no active dialup connection."
+msgstr "Kan ikke afbryde - ingen aktiv netværk via modem forbindelse."
+
+#: ../src/msw/dialup.cpp:907
+#, c-format
+msgid "Failed to terminate the dialup connection: %s"
+msgstr "Kunne ikke afslutte netværk via modem forbindelse: %s"
+
+#: ../src/msw/dib.cpp:313
+#, c-format
+msgid "Failed to save the bitmap image to file \"%s\"."
+msgstr "Kunne ikke gemme bitmap-billede i filen \"%s\"."
+
+#: ../src/msw/dib.cpp:543
+#, c-format
+msgid "Failed to allocate %luKb of memory for bitmap data."
+msgstr "Kunne ikke allokere %luKb hukommelse til bitmap data."
+
+#: ../src/msw/dir.cpp:241
+#, c-format
+msgid "Cannot enumerate files in directory '%s'"
+msgstr "Kan ikke få liste af filer i mappen \"%s\""
+
+#: ../src/msw/dirdlg.cpp:368
+msgid "Couldn't obtain folder name"
+msgstr "Kunne ikke få fat i mappenavn"
+
+#: ../src/msw/dlmsw.cpp:163
+#, fuzzy, c-format
+msgid "(error %d: %s)"
+msgstr " (fejl %ld: %s)"
+
+#: ../src/msw/dragimag.cpp:143 ../src/msw/dragimag.cpp:178
+#: ../src/msw/imaglist.cpp:309 ../src/msw/imaglist.cpp:331
+msgid "Couldn't add an image to the image list."
+msgstr "Kunne ikke tilføje et billede til billedlisten."
+
+#: ../src/msw/enhmeta.cpp:94
+#, c-format
+msgid "Failed to load metafile from file \"%s\"."
+msgstr "Kunne ikke indlæse metafil fra filen \"%s\"."
+
+#: ../src/msw/fdrepdlg.cpp:412
+#, c-format
+msgid "Failed to create the standard find/replace dialog (error code %d)"
+msgstr "Kunne ikke oprette den almindelige søg/erstat dialog (fejlkode %d)"
+
+#: ../src/msw/filedlg.cpp:1241
+msgid "Access to the file system is not allowed from secure desktop."
+msgstr ""
+
+#: ../src/msw/filedlg.cpp:1242
+msgid "Security warning"
+msgstr ""
+
+#: ../src/msw/filedlg.cpp:1533
+#, c-format
+msgid "File dialog failed with error code %0lx."
+msgstr "Fildialog fejlede med fejlkode %0lx."
+
+#: ../src/msw/font.cpp:1120
+#, fuzzy, c-format
+msgid "Font file \"%s\" couldn't be loaded"
+msgstr "Fil kunne ikke indlæses."
+
+#: ../src/msw/fontdlg.cpp:220
+#, c-format
+msgid "Common dialog failed with error code %0lx."
+msgstr "Almindelig dialog fejlede med fejlkode %0lx."
+
+#: ../src/msw/fswatcher.cpp:67
+msgid "Ungraceful worker thread termination"
+msgstr "Ureglementeret afslutning af arbejdstråd"
+
+#: ../src/msw/fswatcher.cpp:81
+msgid "Unable to create IOCP worker thread"
+msgstr "Kunne ikke oprette IOCP-arbejdstråd"
+
+#: ../src/msw/fswatcher.cpp:88
+msgid "Unable to start IOCP worker thread"
+msgstr "Kunne ikke starte IOCP-arbejdstråd"
+
+#: ../src/msw/fswatcher.cpp:140
+msgid "Monitoring individual files for changes is not supported currently."
+msgstr ""
+"Overvågning af ændringer på enkelte filer understøttes ikke i øjeblikket."
+
+#: ../src/msw/fswatcher.cpp:165
+#, c-format
+msgid "Unable to set up watch for '%s'"
+msgstr "Kunne ikke opsætte overvågning af \"%s\""
+
+#: ../src/msw/fswatcher.cpp:466
+#, c-format
+msgid "Can't monitor non-existent directory \"%s\" for changes."
+msgstr "Kan ikke overvåge den ikke-eksisterende mappe \"%s\" for ændringer."
+
+#: ../src/msw/glcanvas.cpp:577 ../src/unix/glx11.cpp:507
+msgid "OpenGL 3.0 or later is not supported by the OpenGL driver."
+msgstr "OpenGL 3.0 eller senere understøttes ikke af OpenGL-driveren."
+
+#: ../src/msw/glcanvas.cpp:601 ../src/osx/glcanvas_osx.cpp:395
+#: ../src/unix/glegl.cpp:304 ../src/unix/glx11.cpp:553
+msgid "Couldn't create OpenGL context"
+msgstr "Kunne ikke oprette OpenGL-kontekst"
+
+#: ../src/msw/glcanvas.cpp:1294
+msgid "Failed to initialize OpenGL"
+msgstr "Kunne ikke initialisere OpenGL"
+
+#: ../src/msw/graphicsd2d.cpp:607
+msgid "Could not register custom DirectWrite font loader."
+msgstr ""
+
+#: ../src/msw/helpchm.cpp:48
+msgid ""
+"MS HTML Help functions are unavailable because the MS HTML Help library is "
+"not installed on this machine. Please install it."
+msgstr ""
+"MS HTML Hjælp-funktioner er ikke tilgængelig fordi MS HTML Hjælp-biblioteket "
+"ikke er installeret på denne computer. Vi foreslår at installere det."
+
+#: ../src/msw/helpchm.cpp:55
+msgid "Failed to initialize MS HTML Help."
+msgstr "Kunne ikke initialisere MS HTML Hjælp."
+
+#: ../src/msw/iniconf.cpp:458
+#, c-format
+msgid "Can't delete the INI file '%s'"
+msgstr "Kan ikke slette INI-filen \"%s\""
+
+#: ../src/msw/listctrl.cpp:995
+#, c-format
+msgid "Couldn't retrieve information about list control item %d."
+msgstr "Kunne ikke hente information om listekontrolemne %d."
+
+#: ../src/msw/mdi.cpp:170 ../src/qt/mdi.cpp:253
+msgid "&Cascade"
+msgstr "&Taglagt"
+
+#: ../src/msw/mdi.cpp:171
+msgid "Tile &Horizontally"
+msgstr "Fordel &vandret"
+
+#: ../src/msw/mdi.cpp:172
+msgid "Tile &Vertically"
+msgstr "Fordel &lodret"
+
+#: ../src/msw/mdi.cpp:174
+msgid "&Arrange Icons"
+msgstr "&Arrangér ikoner"
+
+#: ../src/msw/mdi.cpp:621
+msgid "Failed to create MDI parent frame."
+msgstr "Kunne ikke oprette MDI-forældreramme."
+
+#: ../src/msw/mimetype.cpp:234
+#, c-format
+msgid "Failed to create registry entry for '%s' files."
+msgstr "Kunne ikke oprette registreringsindgang for \"%s\" filer."
+
+#: ../src/msw/ole/automtn.cpp:495
+#, c-format
+msgid "Failed to find CLSID of \"%s\""
+msgstr "Kunne ikke finde CLSID for \"%s\""
+
+#: ../src/msw/ole/automtn.cpp:512
+#, c-format
+msgid "Failed to create an instance of \"%s\""
+msgstr "Kunne ikke oprette en instans af \"%s\""
+
+#: ../src/msw/ole/automtn.cpp:552
+#, c-format
+msgid "Cannot get an active instance of \"%s\""
+msgstr "Kan ikke få fat i en aktiv instans af \"%s\""
+
+#: ../src/msw/ole/automtn.cpp:564
+#, c-format
+msgid "Failed to get OLE automation interface for \"%s\""
+msgstr "Kunne ikke få fat i OLE automation interface for \"%s\""
+
+#: ../src/msw/ole/automtn.cpp:621
+msgid "Unknown name or named argument."
+msgstr "Ukendt navn eller navngivet argument."
+
+#: ../src/msw/ole/automtn.cpp:625
+msgid "Incorrect number of arguments."
+msgstr "Forkert antal argumenter."
+
+#: ../src/msw/ole/automtn.cpp:637
+msgid "Unknown exception"
+msgstr "Ukendt undtagelse"
+
+#: ../src/msw/ole/automtn.cpp:642
+msgid "Method or property not found."
+msgstr "Metode eller egenskab ikke fundet."
+
+#: ../src/msw/ole/automtn.cpp:646
+msgid "Overflow while coercing argument values."
+msgstr "Overflow under tilpasning af argumentværdier."
+
+#: ../src/msw/ole/automtn.cpp:650
+msgid "Object implementation does not support named arguments."
+msgstr "Objektimplementering understøtter ikke navngivne argumenter."
+
+#: ../src/msw/ole/automtn.cpp:654
+msgid "The locale ID is unknown."
+msgstr "Den lokale ID er ukendt."
+
+#: ../src/msw/ole/automtn.cpp:658
+msgid "Missing a required parameter."
+msgstr "Mangler krævet parameter."
+
+#: ../src/msw/ole/automtn.cpp:662
+#, c-format
+msgid "Argument %u not found."
+msgstr "Argument %u ikke fundet."
+
+#: ../src/msw/ole/automtn.cpp:666
+#, c-format
+msgid "Type mismatch in argument %u."
+msgstr "Type uoverensstemmelse i argument %u."
+
+#: ../src/msw/ole/automtn.cpp:670
+msgid "The system cannot find the file specified."
+msgstr "Systemet kan ikke finde den angivne fil."
+
+#: ../src/msw/ole/automtn.cpp:674
+msgid "Class not registered."
+msgstr "Klasse er ikke registreret."
+
+#: ../src/msw/ole/automtn.cpp:678
+#, c-format
+msgid "Unknown error %08x"
+msgstr "Ukendt fejl %08x"
+
+#: ../src/msw/ole/automtn.cpp:682
+#, c-format
+msgid "OLE Automation error in %s: %s"
+msgstr "OLE automatiseringsfejl i %s: %s"
+
+#: ../src/msw/ole/dataobj.cpp:385
+#, c-format
+msgid "Couldn't register clipboard format '%s'."
+msgstr "Kunne ikke registrere udklipsholderformatet \"%s\"."
+
+#: ../src/msw/ole/dataobj.cpp:402
+#, c-format
+msgid "The clipboard format '%d' doesn't exist."
+msgstr "Udklipsholderformat \"%d\" findes ikke."
+
+#: ../src/msw/progdlg.cpp:1025
+msgid "Skip"
+msgstr "Spring over"
+
+#: ../src/msw/registry.cpp:141
+#, c-format
+msgid "unknown (%lu)"
+msgstr "ukendt (%lu)"
+
+#: ../src/msw/registry.cpp:409
+#, c-format
+msgid "Can't get info about registry key '%s'"
+msgstr "Kan ikke få information om registreringsnøglen \"%s\""
+
+#: ../src/msw/registry.cpp:445
+#, c-format
+msgid "Can't open registry key '%s'"
+msgstr "Kan ikke åbne registreringsnøglen \"%s\""
+
+#: ../src/msw/registry.cpp:478
+#, c-format
+msgid "Can't create registry key '%s'"
+msgstr "Kan ikke oprette registreringsnøglen \"%s\""
+
+#: ../src/msw/registry.cpp:497
+#, c-format
+msgid "Can't close registry key '%s'"
+msgstr "Kan ikke lukke registreringsnøglen \"%s\""
+
+#: ../src/msw/registry.cpp:512
+#, c-format
+msgid "Registry value '%s' already exists."
+msgstr "Registreringsværdien \"%s\" findes allerede."
+
+#: ../src/msw/registry.cpp:520
+#, c-format
+msgid "Failed to rename registry value '%s' to '%s'."
+msgstr "Kunne ikke omdøbe registreringsværdi \"%s\" til \"%s\"."
+
+#: ../src/msw/registry.cpp:575
+#, c-format
+msgid "Can't copy values of unsupported type %d."
+msgstr "Kan ikke kopiere værdier af ikke-understøttet type %d."
+
+#: ../src/msw/registry.cpp:586
+#, c-format
+msgid "Registry key '%s' does not exist, cannot rename it."
+msgstr "Registreringsnøglen \"%s\" findes ikke og kan ikke omdøbes."
+
+#: ../src/msw/registry.cpp:617
+#, c-format
+msgid "Registry key '%s' already exists."
+msgstr "Registreringsnøglen \"%s\" findes allerede."
+
+#: ../src/msw/registry.cpp:625
+#, c-format
+msgid "Failed to rename the registry key '%s' to '%s'."
+msgstr "Kunne ikke omdøbe registreringsnøglen \"%s\" til \"%s\"."
+
+#: ../src/msw/registry.cpp:670
+#, c-format
+msgid "Failed to copy the registry subkey '%s' to '%s'."
+msgstr "Kunne ikke kopiere registreringsundernøglen \"%s\" til \"%s\"."
+
+#: ../src/msw/registry.cpp:683
+#, c-format
+msgid "Failed to copy registry value '%s'"
+msgstr "Kunne ikke kopiere registreringsværdi \"%s\""
+
+#: ../src/msw/registry.cpp:692
+#, c-format
+msgid "Failed to copy the contents of registry key '%s' to '%s'."
+msgstr "Kunne ikke kopiere indholdet af registreringsnøglen \"%s\" til \"%s\"."
+
+#: ../src/msw/registry.cpp:718
+#, c-format
+msgid ""
+"Registry key '%s' is needed for normal system operation,\n"
+"deleting it will leave your system in unusable state:\n"
+"operation aborted."
+msgstr ""
+"Registreringsnøglen \"%s\" er nødvendig for systemets almindelige drift,\n"
+"hvis du sletter den vil efterlade dit system i ubrugelig tilstand:\n"
+"operationen blev afbrudt."
+
+#: ../src/msw/registry.cpp:754
+#, c-format
+msgid "Can't delete key '%s'"
+msgstr "Kan ikke slette nøglen \"%s\""
+
+#: ../src/msw/registry.cpp:782
+#, c-format
+msgid "Can't delete value '%s' from key '%s'"
+msgstr "Kan ikke slette værdi \"%s\" fra nøglen \"%s\""
+
+#: ../src/msw/registry.cpp:855 ../src/msw/registry.cpp:887
+#: ../src/msw/registry.cpp:929 ../src/msw/registry.cpp:1000
+#, c-format
+msgid "Can't read value of key '%s'"
+msgstr "Kan ikke læse værdien af nøglen \"%s\""
+
+#: ../src/msw/registry.cpp:873 ../src/msw/registry.cpp:915
+#: ../src/msw/registry.cpp:963 ../src/msw/registry.cpp:1106
+#, c-format
+msgid "Can't set value of '%s'"
+msgstr "Kan ikke sætte værdien af \"%s\""
+
+#: ../src/msw/registry.cpp:894 ../src/msw/registry.cpp:943
+#, c-format
+msgid "Registry value \"%s\" is not numeric (but of type %s)"
+msgstr "Registreringsværdien \"%s\" er ikke numerisk (men af typen %s)"
+
+#: ../src/msw/registry.cpp:979
+#, c-format
+msgid "Registry value \"%s\" is not binary (but of type %s)"
+msgstr "Registreringsværdien \"%s\" er ikke binær (men af typen %s)"
+
+#: ../src/msw/registry.cpp:1028
+#, c-format
+msgid "Registry value \"%s\" is not text (but of type %s)"
+msgstr "Registreringsværdien \"%s\" er ikke tekst (men af typen %s)"
+
+#: ../src/msw/registry.cpp:1089
+#, c-format
+msgid "Can't read value of '%s'"
+msgstr "Kan ikke læse værdien af \"%s\""
+
+#: ../src/msw/registry.cpp:1157
+#, c-format
+msgid "Can't enumerate values of key '%s'"
+msgstr "Kan ikke få en liste af værdierne fra nøglen \"%s\""
+
+#: ../src/msw/registry.cpp:1196
+#, c-format
+msgid "Can't enumerate subkeys of key '%s'"
+msgstr "Kan ikke få liste af undernøgler til nøglen \"%s\""
+
+#: ../src/msw/registry.cpp:1262
+#, c-format
+msgid ""
+"Exporting registry key: file \"%s\" already exists and won't be overwritten."
+msgstr ""
+"Eksporterer registernøgle: filen \"%s\" findes allerede og vil ikke blive "
+"overskrevet."
+
+#: ../src/msw/registry.cpp:1411
+#, c-format
+msgid "Can't export value of unsupported type %d."
+msgstr "Kan ikke eksportere værdi af ikke-understøttet type %d."
+
+#: ../src/msw/registry.cpp:1427
+#, c-format
+msgid "Ignoring value \"%s\" of the key \"%s\"."
+msgstr "Ignorerer værdien \"%s\" i nøglen \"%s\"."
+
+#: ../src/msw/textctrl.cpp:596
+msgid ""
+"Impossible to create a rich edit control, using simple text control instead. "
+"Please reinstall riched32.dll"
+msgstr ""
+"Kunne ikke oprette rich edit-kontrol, bruger i stedet en simpel "
+"tekstkontrol. Geninstallér venligst riched32.dll"
+
+#: ../src/msw/thread.cpp:522 ../src/unix/threadpsx.cpp:850
+msgid "Cannot start thread: error writing TLS."
+msgstr "Kan ikke starte tråd: fejl ved skrivning af TLS."
+
+#: ../src/msw/thread.cpp:613
+msgid "Can't set thread priority"
+msgstr "Kan ikke sætte trådprioritet"
+
+#: ../src/msw/thread.cpp:649
+msgid "Can't create thread"
+msgstr "Kan ikke oprette tråd"
+
+#: ../src/msw/thread.cpp:668
+msgid "Couldn't terminate thread"
+msgstr "Kunne ikke afslutte tråd"
+
+#: ../src/msw/thread.cpp:799
+msgid "Cannot wait for thread termination"
+msgstr "Kan ikke vente på afslutning af tråd"
+
+#: ../src/msw/thread.cpp:873
+#, c-format
+msgid "Cannot suspend thread %lx"
+msgstr "Kan ikke suspendere tråd %lx"
+
+#: ../src/msw/thread.cpp:903
+#, c-format
+msgid "Cannot resume thread %lx"
+msgstr "Kan ikke genoptage tråd %lx"
+
+#: ../src/msw/thread.cpp:932
+msgid "Couldn't get the current thread pointer"
+msgstr "Kunne ikke få aktuelle trådpointer"
+
+#: ../src/msw/thread.cpp:1333
+msgid ""
+"Thread module initialization failed: impossible to allocate index in thread "
+"local storage"
+msgstr ""
+"Trådmodul initialisering fejlede: umuligt at allokere indeks i trådens "
+"private lager"
+
+#: ../src/msw/thread.cpp:1345
+msgid ""
+"Thread module initialization failed: cannot store value in thread local "
+"storage"
+msgstr ""
+"Trådmodul initialisering fejlede: kan ikke gemme værdi i trådens private "
+"lager"
+
+#: ../src/msw/timer.cpp:133
+msgid "Couldn't create a timer"
+msgstr "Kunne ikke oprette en timer"
+
+#: ../src/msw/utils.cpp:372
+msgid "can't find user's HOME, using current directory."
+msgstr "kan ikke finde brugerens hjemmemappe, bruger aktuelle mappe."
+
+#: ../src/msw/utils.cpp:662
+#, c-format
+msgid "Failed to kill process %d"
+msgstr "Kunne ikke dræbe proces %d"
+
+#: ../src/msw/utils.cpp:986
+#, c-format
+msgid "Failed to load resource \"%s\"."
+msgstr "Kunne ikke indlæse ressource \"%s\"."
+
+#: ../src/msw/utils.cpp:993
+#, c-format
+msgid "Failed to lock resource \"%s\"."
+msgstr "Kunne ikke låse ressource \"%s\"."
+
+#. TRANSLATORS: MS Windows build number
+#: ../src/msw/utils.cpp:1209
+#, c-format
+msgid "build %lu"
+msgstr "byg %lu"
+
+#: ../src/msw/utils.cpp:1218
+msgid ", 64-bit edition"
+msgstr ", 64-bit-udgave"
+
+#: ../src/msw/utilsexc.cpp:224
+msgid "Failed to create an anonymous pipe"
+msgstr "Kunne ikke oprette anonym pipe"
+
+#: ../src/msw/utilsexc.cpp:697
+msgid "Failed to redirect the child process IO"
+msgstr "Kunne ikke omdirigere input/output fra underproces"
+
+#: ../src/msw/utilsexc.cpp:870
+#, c-format
+msgid "Execution of command '%s' failed"
+msgstr "Afvikling af kommandoen \"%s\" fejlede"
+
+#: ../src/msw/volume.cpp:337
+msgid "Failed to load mpr.dll."
+msgstr "Kunne ikke åbne mpr.dll."
+
+#: ../src/msw/volume.cpp:506
+#, c-format
+msgid "Cannot read typename from '%s'!"
+msgstr "Kan ikke læse typenavn fra \"%s\"!"
+
+#: ../src/msw/volume.cpp:615
+#, c-format
+msgid "Cannot load icon from '%s'."
+msgstr "Kan ikke hente ikon fra \"%s\"."
+
+#: ../src/msw/webview_edge.cpp:285
+msgid "This program was compiled without support for setting Edge proxy."
+msgstr ""
+
+#: ../src/msw/webview_ie.cpp:1010
+msgid "Failed to find web view emulation level in the registry"
+msgstr ""
+
+#: ../src/msw/webview_ie.cpp:1019
+msgid "Failed to set web view to modern emulation level"
+msgstr ""
+
+#: ../src/msw/webview_ie.cpp:1027
+msgid "Failed to reset web view to standard emulation level"
+msgstr ""
+
+#: ../src/msw/webview_ie.cpp:1049
+msgid "Can't run JavaScript script without a valid HTML document"
+msgstr ""
+
+#: ../src/msw/webview_ie.cpp:1056
+#, fuzzy
+msgid "Can't get the JavaScript object"
+msgstr "Kan ikke sætte trådprioritet"
+
+#: ../src/msw/webview_ie.cpp:1070
+#, fuzzy
+msgid "failed to evaluate"
+msgstr "Kunne ikke eksekvere \"%s\"\n"
+
+#: ../src/osx/cocoa/filedlg.mm:412
+#, fuzzy
+msgid "File type:"
+msgstr "Teletype"
+
+#: ../src/osx/cocoa/menu.mm:242
+#, fuzzy
+msgctxt "macOS menu name"
+msgid "Window"
+msgstr "Vindue"
+
+#: ../src/osx/cocoa/menu.mm:259
+#, fuzzy
+msgctxt "macOS menu name"
+msgid "Help"
+msgstr "Hjælp"
+
+#: ../src/osx/cocoa/menu.mm:298
+#, fuzzy
+msgctxt "macOS menu item"
+msgid "Minimize"
+msgstr "Mi&nimér"
+
+#: ../src/osx/cocoa/menu.mm:303
+#, fuzzy
+msgctxt "macOS menu item"
+msgid "Zoom"
+msgstr "Zoom ind"
+
+#: ../src/osx/cocoa/menu.mm:309
+msgctxt "macOS menu item"
+msgid "Bring All to Front"
+msgstr ""
+
+#: ../src/osx/core/sound.cpp:143
+#, c-format
+msgid "Failed to load sound from \"%s\" (error %d)."
+msgstr "Kunne ikke indlæse lyd fra \"%s\" (fejl %d)."
+
+#: ../src/osx/fontutil.cpp:80
+#, fuzzy, c-format
+msgid "Font file \"%s\" doesn't exist."
+msgstr ": filen findes ikke!"
+
+#: ../src/osx/fontutil.cpp:88
+#, c-format
+msgid ""
+"Font file \"%s\" cannot be used as it is not inside the font directory "
+"\"%s\"."
+msgstr ""
+
+#: ../src/osx/menu_osx.cpp:496
+#, c-format
+msgctxt "macOS menu item"
+msgid "About %s"
+msgstr "Om %s"
+
+#: ../src/osx/menu_osx.cpp:499
+msgctxt "macOS menu item"
+msgid "About..."
+msgstr "Om..."
+
+#: ../src/osx/menu_osx.cpp:508
+msgctxt "macOS menu item"
+msgid "Preferences..."
+msgstr "Indstillinger..."
+
+#: ../src/osx/menu_osx.cpp:512
+msgctxt "macOS menu item"
+msgid "Services"
+msgstr "Tjenester"
+
+#: ../src/osx/menu_osx.cpp:519
+#, c-format
+msgctxt "macOS menu item"
+msgid "Hide %s"
+msgstr "Skjul %s"
+
+#: ../src/osx/menu_osx.cpp:522
+#, fuzzy
+msgctxt "macOS menu item"
+msgid "Hide Application"
+msgstr "Program"
+
+#: ../src/osx/menu_osx.cpp:526
+msgctxt "macOS menu item"
+msgid "Hide Others"
+msgstr "Skjul andre"
+
+#: ../src/osx/menu_osx.cpp:528
+msgctxt "macOS menu item"
+msgid "Show All"
+msgstr "Vis alle"
+
+#: ../src/osx/menu_osx.cpp:534
+#, c-format
+msgctxt "macOS menu item"
+msgid "Quit %s"
+msgstr "Afslut %s"
+
+#: ../src/osx/menu_osx.cpp:537
+#, fuzzy
+msgctxt "macOS menu item"
+msgid "Quit Application"
+msgstr "Program"
+
+#: ../src/osx/webview_webkit.mm:444
+#, fuzzy
+msgid "Printing is not supported by the system web control"
+msgstr "Gzip understøttes ikke af denne version af zlib"
+
+#: ../src/osx/webview_webkit.mm:453
+msgid "Print operation could not be initialized"
+msgstr ""
+
+#. TRANSLATORS: Label of font point size
+#: ../src/propgrid/advprops.cpp:605
+msgid "Point Size"
+msgstr "Punktstørrelse"
+
+#. TRANSLATORS: Label of font face name
+#: ../src/propgrid/advprops.cpp:615
+msgid "Face Name"
+msgstr "Skriftnavn"
+
+#. TRANSLATORS: Label of font style
+#: ../src/propgrid/advprops.cpp:623 ../src/richtext/richtextformatdlg.cpp:331
+msgid "Style"
+msgstr "Typografi"
+
+#. TRANSLATORS: Label of font weight
+#: ../src/propgrid/advprops.cpp:628
+msgid "Weight"
+msgstr "Vægt"
+
+#. TRANSLATORS: Label of underlined font
+#: ../src/propgrid/advprops.cpp:633 ../src/richtext/richtextfontpage.cpp:358
+msgid "Underlined"
+msgstr "Understreget"
+
+#. TRANSLATORS: Label of font family
+#: ../src/propgrid/advprops.cpp:637
+msgid "Family"
+msgstr "Familie"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:801
+msgid "AppWorkspace"
+msgstr "Program arbejdsområde"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:802
+msgid "ActiveBorder"
+msgstr "Aktiv kant"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:803
+msgid "ActiveCaption"
+msgstr "Aktiv overskrift"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:804
+msgid "ButtonFace"
+msgstr "Knap ansigt"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:805
+msgid "ButtonHighlight"
+msgstr "Knap fremhævning"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:806
+msgid "ButtonShadow"
+msgstr "Knap skygge"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:807
+msgid "ButtonText"
+msgstr "Knap tekst"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:808
+msgid "CaptionText"
+msgstr "Overskrifttekst"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:809
+msgid "ControlDark"
+msgstr "Kontrol mørk"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:810
+msgid "ControlLight"
+msgstr "Kontrol lys"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:812
+msgid "GrayText"
+msgstr "Grå tekst"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:813
+msgid "Highlight"
+msgstr "Fremhæv"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:814
+msgid "HighlightText"
+msgstr "Fremhævet tekst"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:815
+msgid "InactiveBorder"
+msgstr "Inaktiv kant"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:816
+msgid "InactiveCaption"
+msgstr "Inaktiv overskrift"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:817
+msgid "InactiveCaptionText"
+msgstr "Inaktiv overskrifttekst"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:818
+msgid "Menu"
+msgstr "Menu"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:819
+msgid "Scrollbar"
+msgstr "Rullebjælke"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:820
+msgid "Tooltip"
+msgstr "Værktøjstip"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:821
+msgid "TooltipText"
+msgstr "Tekst til værktøjstip"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:822
+msgid "Window"
+msgstr "Vindue"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:823
+msgid "WindowFrame"
+msgstr "Vinduesramme"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:824
+msgid "WindowText"
+msgstr "Vinduestekst"
+
+#. TRANSLATORS: Custom colour choice entry
+#: ../src/propgrid/advprops.cpp:825 ../src/propgrid/advprops.cpp:1532
+#: ../src/propgrid/advprops.cpp:1576
+msgid "Custom"
+msgstr "Speciel"
+
+#: ../src/propgrid/advprops.cpp:1558
+msgid "Black"
+msgstr "Sort"
+
+#: ../src/propgrid/advprops.cpp:1559
+msgid "Maroon"
+msgstr "Rødbrun"
+
+#: ../src/propgrid/advprops.cpp:1560
+msgid "Navy"
+msgstr "Marineblå"
+
+#: ../src/propgrid/advprops.cpp:1561
+msgid "Purple"
+msgstr "Lilla"
+
+#: ../src/propgrid/advprops.cpp:1562
+msgid "Teal"
+msgstr "Grønblå"
+
+#: ../src/propgrid/advprops.cpp:1563
+msgid "Gray"
+msgstr "Grå"
+
+#: ../src/propgrid/advprops.cpp:1564
+msgid "Green"
+msgstr "Grøn"
+
+#: ../src/propgrid/advprops.cpp:1565
+msgid "Olive"
+msgstr "Oliven"
+
+#: ../src/propgrid/advprops.cpp:1566
+msgid "Brown"
+msgstr "Brun"
+
+#: ../src/propgrid/advprops.cpp:1567
+msgid "Blue"
+msgstr "Blå"
+
+#: ../src/propgrid/advprops.cpp:1568
+msgid "Fuchsia"
+msgstr "Fuchsiafarvet"
+
+#: ../src/propgrid/advprops.cpp:1569
+msgid "Red"
+msgstr "Rød"
+
+#: ../src/propgrid/advprops.cpp:1570
+msgid "Orange"
+msgstr "Orange"
+
+#: ../src/propgrid/advprops.cpp:1571
+msgid "Silver"
+msgstr "Sølv"
+
+#: ../src/propgrid/advprops.cpp:1572
+msgid "Lime"
+msgstr "Limegrøn"
+
+#: ../src/propgrid/advprops.cpp:1573
+msgid "Aqua"
+msgstr "Akvamarin"
+
+#: ../src/propgrid/advprops.cpp:1574
+msgid "Yellow"
+msgstr "Gul"
+
+#: ../src/propgrid/advprops.cpp:1575
+msgid "White"
+msgstr "Hvid"
+
+#: ../src/propgrid/advprops.cpp:1718
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Default"
+msgstr "Standard"
+
+#: ../src/propgrid/advprops.cpp:1719
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Arrow"
+msgstr "Pil"
+
+#: ../src/propgrid/advprops.cpp:1720
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Right Arrow"
+msgstr "Højre-pil"
+
+#: ../src/propgrid/advprops.cpp:1721
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Blank"
+msgstr "Tom"
+
+#: ../src/propgrid/advprops.cpp:1722
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Bullseye"
+msgstr "Bullseye"
+
+#: ../src/propgrid/advprops.cpp:1723
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Character"
+msgstr "Tegn"
+
+#: ../src/propgrid/advprops.cpp:1724
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Cross"
+msgstr "Kryds"
+
+#: ../src/propgrid/advprops.cpp:1725
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Hand"
+msgstr "Hånd"
+
+#: ../src/propgrid/advprops.cpp:1726
+#, fuzzy
+msgctxt "system cursor name"
+msgid "I-Beam"
+msgstr "Lodret streg"
+
+#: ../src/propgrid/advprops.cpp:1727
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Left Button"
+msgstr "Venstre knap"
+
+#: ../src/propgrid/advprops.cpp:1728
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Magnifier"
+msgstr "Forstørrelsesglas"
+
+#: ../src/propgrid/advprops.cpp:1729
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Middle Button"
+msgstr "Midterknap"
+
+#: ../src/propgrid/advprops.cpp:1730
+#, fuzzy
+msgctxt "system cursor name"
+msgid "No Entry"
+msgstr "Ingen adgang"
+
+#: ../src/propgrid/advprops.cpp:1731
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Paint Brush"
+msgstr "Malerpensel"
+
+#: ../src/propgrid/advprops.cpp:1732
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Pencil"
+msgstr "Pen"
+
+#: ../src/propgrid/advprops.cpp:1733
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Point Left"
+msgstr "Peg-venstre"
+
+#: ../src/propgrid/advprops.cpp:1734
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Point Right"
+msgstr "Peg-højre"
+
+#: ../src/propgrid/advprops.cpp:1735
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Question Arrow"
+msgstr "Spørgsmålspil"
+
+#: ../src/propgrid/advprops.cpp:1736
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Right Button"
+msgstr "Højre knap"
+
+#: ../src/propgrid/advprops.cpp:1737
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Sizing NE-SW"
+msgstr "Størrelse NØ-SV"
+
+#: ../src/propgrid/advprops.cpp:1738
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Sizing N-S"
+msgstr "Størrelse N-S"
+
+#: ../src/propgrid/advprops.cpp:1739
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Sizing NW-SE"
+msgstr "Størrelse NV-SØ"
+
+#: ../src/propgrid/advprops.cpp:1740
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Sizing W-E"
+msgstr "Størrelse V-Ø"
+
+#: ../src/propgrid/advprops.cpp:1741
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Sizing"
+msgstr "Størrelse"
+
+#: ../src/propgrid/advprops.cpp:1742
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Spraycan"
+msgstr "Spraydåse"
+
+#: ../src/propgrid/advprops.cpp:1743
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Wait"
+msgstr "Vent"
+
+#: ../src/propgrid/advprops.cpp:1744
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Watch"
+msgstr "Overvåg"
+
+#: ../src/propgrid/advprops.cpp:1745
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Wait Arrow"
+msgstr "Ventepil"
+
+#: ../src/propgrid/advprops.cpp:2109
+msgid "Make a selection:"
+msgstr "Foretag et valg:"
+
+#: ../src/propgrid/manager.cpp:394
+msgid "Property"
+msgstr "Egenskab"
+
+#: ../src/propgrid/manager.cpp:395
+msgid "Value"
+msgstr "Værdi"
+
+#: ../src/propgrid/manager.cpp:1683
+msgid "Categorized Mode"
+msgstr "Kategoritilstand"
+
+#: ../src/propgrid/manager.cpp:1709
+msgid "Alphabetic Mode"
+msgstr "Alfabetisk mode"
+
+#. TRANSLATORS: Name of Boolean false value
+#: ../src/propgrid/propgrid.cpp:230
+msgid "False"
+msgstr "Falsk"
+
+#. TRANSLATORS: Name of Boolean true value
+#: ../src/propgrid/propgrid.cpp:232
+msgid "True"
+msgstr "Sand"
+
+#. TRANSLATORS: Text  displayed for unspecified value
+#: ../src/propgrid/propgrid.cpp:428
+msgid "Unspecified"
+msgstr "Uspecificeret"
+
+#. TRANSLATORS: Caption of message box displaying any property error
+#: ../src/propgrid/propgrid.cpp:3145 ../src/propgrid/propgrid.cpp:3282
+msgid "Property Error"
+msgstr "Fejl i egenskab"
+
+#: ../src/propgrid/propgrid.cpp:3259
+msgid "You have entered invalid value. Press ESC to cancel editing."
+msgstr ""
+"Du har indtastet en ugyldig værdi. Tryk på ESC for at annullere redigeringen."
+
+#: ../src/propgrid/propgrid.cpp:6608
+#, c-format
+msgid "Error in resource: %s"
+msgstr "Fejl i ressource: %s"
+
+#: ../src/propgrid/propgridiface.cpp:377
+#, c-format
+msgid ""
+"Type operation \"%s\" failed: Property labeled \"%s\" is of type \"%s\", NOT "
+"\"%s\"."
+msgstr ""
+"Type-operation \"%s\" fejlede: egenskab med navnet \"%s\" er af typen "
+"\"%s\", ikke \"%s\"."
+
+#: ../src/propgrid/props.cpp:159
+#, c-format
+msgid "Unknown base %d. Base 10 will be used."
+msgstr ""
+
+#: ../src/propgrid/props.cpp:324
+#, c-format
+msgid "Value must be %s or higher."
+msgstr "Værdien skal være %s eller højere."
+
+#: ../src/propgrid/props.cpp:329 ../src/propgrid/props.cpp:356
+#, c-format
+msgid "Value must be between %s and %s."
+msgstr "Værdien skal være mellem %s og %s."
+
+#: ../src/propgrid/props.cpp:351
+#, c-format
+msgid "Value must be %s or less."
+msgstr "Værdien skal være %s eller lavere."
+
+#: ../src/propgrid/props.cpp:1058
+#, c-format
+msgid "Not %s"
+msgstr "Ikke %s"
+
+#: ../src/propgrid/props.cpp:1770
+msgid "Choose a directory:"
+msgstr "Vælg mappe:"
+
+#: ../src/propgrid/props.cpp:2055
+msgid "Choose a file"
+msgstr "Vælg en fil"
+
+#: ../src/qt/mdi.cpp:254
+msgid "&Tile"
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:147
+#: ../src/richtext/richtextformatdlg.cpp:376
+msgid "Background"
+msgstr "Baggrund"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:159
+msgid "Background &colour:"
+msgstr "Baggrunds&farve:"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:161
+#: ../src/richtext/richtextbackgroundpage.cpp:163
+msgid "Enables a background colour."
+msgstr "Aktiverer en baggrundsfarve."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:167
+#: ../src/richtext/richtextbackgroundpage.cpp:169
+msgid "The background colour."
+msgstr "Baggrundsfarven."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:178
+msgid "Shadow"
+msgstr "Skygge"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:193
+msgid "Use &shadow"
+msgstr "Brug &skygge"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:195
+#: ../src/richtext/richtextbackgroundpage.cpp:197
+msgid "Enables a shadow."
+msgstr "Aktiverer en skygge."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:211
+msgid "&Horizontal offset:"
+msgstr "&Lodret forskydning:"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:218
+#: ../src/richtext/richtextbackgroundpage.cpp:220
+msgid "The horizontal offset."
+msgstr "Den lodrette forskydning."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:224
+#: ../src/richtext/richtextbackgroundpage.cpp:227
+#: ../src/richtext/richtextbackgroundpage.cpp:228
+#: ../src/richtext/richtextbackgroundpage.cpp:247
+#: ../src/richtext/richtextbackgroundpage.cpp:250
+#: ../src/richtext/richtextbackgroundpage.cpp:251
+#: ../src/richtext/richtextbackgroundpage.cpp:287
+#: ../src/richtext/richtextbackgroundpage.cpp:290
+#: ../src/richtext/richtextbackgroundpage.cpp:291
+#: ../src/richtext/richtextbackgroundpage.cpp:314
+#: ../src/richtext/richtextbackgroundpage.cpp:317
+#: ../src/richtext/richtextbackgroundpage.cpp:318
+#: ../src/richtext/richtextborderspage.cpp:252
+#: ../src/richtext/richtextborderspage.cpp:255
+#: ../src/richtext/richtextborderspage.cpp:256
+#: ../src/richtext/richtextborderspage.cpp:286
+#: ../src/richtext/richtextborderspage.cpp:289
+#: ../src/richtext/richtextborderspage.cpp:290
+#: ../src/richtext/richtextborderspage.cpp:320
+#: ../src/richtext/richtextborderspage.cpp:323
+#: ../src/richtext/richtextborderspage.cpp:324
+#: ../src/richtext/richtextborderspage.cpp:354
+#: ../src/richtext/richtextborderspage.cpp:357
+#: ../src/richtext/richtextborderspage.cpp:358
+#: ../src/richtext/richtextborderspage.cpp:420
+#: ../src/richtext/richtextborderspage.cpp:423
+#: ../src/richtext/richtextborderspage.cpp:424
+#: ../src/richtext/richtextborderspage.cpp:454
+#: ../src/richtext/richtextborderspage.cpp:457
+#: ../src/richtext/richtextborderspage.cpp:458
+#: ../src/richtext/richtextborderspage.cpp:488
+#: ../src/richtext/richtextborderspage.cpp:491
+#: ../src/richtext/richtextborderspage.cpp:492
+#: ../src/richtext/richtextborderspage.cpp:522
+#: ../src/richtext/richtextborderspage.cpp:525
+#: ../src/richtext/richtextborderspage.cpp:526
+#: ../src/richtext/richtextborderspage.cpp:590
+#: ../src/richtext/richtextborderspage.cpp:593
+#: ../src/richtext/richtextborderspage.cpp:594
+#: ../src/richtext/richtextfontpage.cpp:177
+#: ../src/richtext/richtextmarginspage.cpp:199
+#: ../src/richtext/richtextmarginspage.cpp:201
+#: ../src/richtext/richtextmarginspage.cpp:202
+#: ../src/richtext/richtextmarginspage.cpp:224
+#: ../src/richtext/richtextmarginspage.cpp:226
+#: ../src/richtext/richtextmarginspage.cpp:227
+#: ../src/richtext/richtextmarginspage.cpp:247
+#: ../src/richtext/richtextmarginspage.cpp:249
+#: ../src/richtext/richtextmarginspage.cpp:250
+#: ../src/richtext/richtextmarginspage.cpp:272
+#: ../src/richtext/richtextmarginspage.cpp:274
+#: ../src/richtext/richtextmarginspage.cpp:275
+#: ../src/richtext/richtextmarginspage.cpp:313
+#: ../src/richtext/richtextmarginspage.cpp:315
+#: ../src/richtext/richtextmarginspage.cpp:316
+#: ../src/richtext/richtextmarginspage.cpp:338
+#: ../src/richtext/richtextmarginspage.cpp:340
+#: ../src/richtext/richtextmarginspage.cpp:341
+#: ../src/richtext/richtextmarginspage.cpp:361
+#: ../src/richtext/richtextmarginspage.cpp:363
+#: ../src/richtext/richtextmarginspage.cpp:364
+#: ../src/richtext/richtextmarginspage.cpp:386
+#: ../src/richtext/richtextmarginspage.cpp:388
+#: ../src/richtext/richtextmarginspage.cpp:389
+#: ../src/richtext/richtextsizepage.cpp:337
+#: ../src/richtext/richtextsizepage.cpp:340
+#: ../src/richtext/richtextsizepage.cpp:341
+#: ../src/richtext/richtextsizepage.cpp:371
+#: ../src/richtext/richtextsizepage.cpp:374
+#: ../src/richtext/richtextsizepage.cpp:375
+#: ../src/richtext/richtextsizepage.cpp:398
+#: ../src/richtext/richtextsizepage.cpp:401
+#: ../src/richtext/richtextsizepage.cpp:402
+#: ../src/richtext/richtextsizepage.cpp:425
+#: ../src/richtext/richtextsizepage.cpp:428
+#: ../src/richtext/richtextsizepage.cpp:429
+#: ../src/richtext/richtextsizepage.cpp:452
+#: ../src/richtext/richtextsizepage.cpp:455
+#: ../src/richtext/richtextsizepage.cpp:456
+#: ../src/richtext/richtextsizepage.cpp:479
+#: ../src/richtext/richtextsizepage.cpp:482
+#: ../src/richtext/richtextsizepage.cpp:483
+#: ../src/richtext/richtextsizepage.cpp:553
+#: ../src/richtext/richtextsizepage.cpp:556
+#: ../src/richtext/richtextsizepage.cpp:557
+#: ../src/richtext/richtextsizepage.cpp:588
+#: ../src/richtext/richtextsizepage.cpp:591
+#: ../src/richtext/richtextsizepage.cpp:592
+#: ../src/richtext/richtextsizepage.cpp:623
+#: ../src/richtext/richtextsizepage.cpp:626
+#: ../src/richtext/richtextsizepage.cpp:627
+#: ../src/richtext/richtextsizepage.cpp:658
+#: ../src/richtext/richtextsizepage.cpp:661
+#: ../src/richtext/richtextsizepage.cpp:662
+msgid "px"
+msgstr "px"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:225
+#: ../src/richtext/richtextbackgroundpage.cpp:248
+#: ../src/richtext/richtextbackgroundpage.cpp:288
+#: ../src/richtext/richtextbackgroundpage.cpp:315
+#: ../src/richtext/richtextborderspage.cpp:253
+#: ../src/richtext/richtextborderspage.cpp:287
+#: ../src/richtext/richtextborderspage.cpp:321
+#: ../src/richtext/richtextborderspage.cpp:355
+#: ../src/richtext/richtextborderspage.cpp:421
+#: ../src/richtext/richtextborderspage.cpp:455
+#: ../src/richtext/richtextborderspage.cpp:489
+#: ../src/richtext/richtextborderspage.cpp:523
+#: ../src/richtext/richtextborderspage.cpp:591
+#: ../src/richtext/richtextmarginspage.cpp:200
+#: ../src/richtext/richtextmarginspage.cpp:225
+#: ../src/richtext/richtextmarginspage.cpp:248
+#: ../src/richtext/richtextmarginspage.cpp:273
+#: ../src/richtext/richtextmarginspage.cpp:314
+#: ../src/richtext/richtextmarginspage.cpp:339
+#: ../src/richtext/richtextmarginspage.cpp:362
+#: ../src/richtext/richtextmarginspage.cpp:387
+#: ../src/richtext/richtextsizepage.cpp:338
+#: ../src/richtext/richtextsizepage.cpp:372
+#: ../src/richtext/richtextsizepage.cpp:399
+#: ../src/richtext/richtextsizepage.cpp:426
+#: ../src/richtext/richtextsizepage.cpp:453
+#: ../src/richtext/richtextsizepage.cpp:480
+#: ../src/richtext/richtextsizepage.cpp:554
+#: ../src/richtext/richtextsizepage.cpp:589
+#: ../src/richtext/richtextsizepage.cpp:624
+#: ../src/richtext/richtextsizepage.cpp:659
+msgid "cm"
+msgstr "cm"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:226
+#: ../src/richtext/richtextbackgroundpage.cpp:249
+#: ../src/richtext/richtextbackgroundpage.cpp:289
+#: ../src/richtext/richtextbackgroundpage.cpp:316
+#: ../src/richtext/richtextborderspage.cpp:254
+#: ../src/richtext/richtextborderspage.cpp:288
+#: ../src/richtext/richtextborderspage.cpp:322
+#: ../src/richtext/richtextborderspage.cpp:356
+#: ../src/richtext/richtextborderspage.cpp:422
+#: ../src/richtext/richtextborderspage.cpp:456
+#: ../src/richtext/richtextborderspage.cpp:490
+#: ../src/richtext/richtextborderspage.cpp:524
+#: ../src/richtext/richtextborderspage.cpp:592
+#: ../src/richtext/richtextfontpage.cpp:176
+#: ../src/richtext/richtextfontpage.cpp:179
+msgid "pt"
+msgstr "pt"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:229
+#: ../src/richtext/richtextbackgroundpage.cpp:231
+#: ../src/richtext/richtextbackgroundpage.cpp:252
+#: ../src/richtext/richtextbackgroundpage.cpp:254
+#: ../src/richtext/richtextbackgroundpage.cpp:292
+#: ../src/richtext/richtextbackgroundpage.cpp:294
+#: ../src/richtext/richtextbackgroundpage.cpp:319
+#: ../src/richtext/richtextbackgroundpage.cpp:321
+msgid "Units for this value."
+msgstr "Enheder for denne værdi."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:234
+msgid "&Vertical offset:"
+msgstr "&Lodret forskydning:"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:241
+#: ../src/richtext/richtextbackgroundpage.cpp:243
+msgid "The vertical offset."
+msgstr "Den lodrette forskydning."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:257
+msgid "Shadow c&olour:"
+msgstr "&Skyggefarve:"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:259
+#: ../src/richtext/richtextbackgroundpage.cpp:261
+msgid "Enables the shadow colour."
+msgstr "Aktiverer skyggefarven."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:265
+#: ../src/richtext/richtextbackgroundpage.cpp:267
+msgid "The shadow colour."
+msgstr "Skyggens farve."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:270
+msgid "Sh&adow spread:"
+msgstr "&Skyggeudbredelse:"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:272
+#: ../src/richtext/richtextbackgroundpage.cpp:274
+msgid "Enables the shadow spread."
+msgstr "Aktiverer skyggeudbredelsen."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:281
+#: ../src/richtext/richtextbackgroundpage.cpp:283
+msgid "The shadow spread."
+msgstr "Skyggens udbredelse."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:297
+msgid "&Blur distance:"
+msgstr "&Sløringsområde:"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:299
+#: ../src/richtext/richtextbackgroundpage.cpp:301
+msgid "Enables the blur distance."
+msgstr "Aktiverer sløringsområdet."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:308
+#: ../src/richtext/richtextbackgroundpage.cpp:310
+msgid "The shadow blur distance."
+msgstr "Skyggens sløringsområde."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:324
+msgid "Opaci&ty:"
+msgstr "Opaci&tet:"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:326
+#: ../src/richtext/richtextbackgroundpage.cpp:328
+msgid "Enables the shadow opacity."
+msgstr "Aktiverer skyggeopaciteten."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:335
+#: ../src/richtext/richtextbackgroundpage.cpp:337
+msgid "The shadow opacity."
+msgstr "Skyggens opacitet."
+
+#. TRANSLATORS: Rich text page units (percentage)
+#: ../src/richtext/richtextbackgroundpage.cpp:340
+#: ../src/richtext/richtextsizepage.cpp:339
+#: ../src/richtext/richtextsizepage.cpp:373
+#: ../src/richtext/richtextsizepage.cpp:400
+#: ../src/richtext/richtextsizepage.cpp:427
+#: ../src/richtext/richtextsizepage.cpp:454
+#: ../src/richtext/richtextsizepage.cpp:481
+#: ../src/richtext/richtextsizepage.cpp:555
+#: ../src/richtext/richtextsizepage.cpp:590
+#: ../src/richtext/richtextsizepage.cpp:625
+#: ../src/richtext/richtextsizepage.cpp:660
+msgid "%"
+msgstr "%"
+
+#: ../src/richtext/richtextborderspage.cpp:229
+#: ../src/richtext/richtextborderspage.cpp:387
+msgid "Border"
+msgstr "Kant"
+
+#: ../src/richtext/richtextborderspage.cpp:242
+#: ../src/richtext/richtextborderspage.cpp:410
+#: ../src/richtext/richtextindentspage.cpp:194
+#: ../src/richtext/richtextliststylepage.cpp:384
+#: ../src/richtext/richtextmarginspage.cpp:185
+#: ../src/richtext/richtextmarginspage.cpp:299
+#: ../src/richtext/richtextsizepage.cpp:531
+#: ../src/richtext/richtextsizepage.cpp:538
+msgid "&Left:"
+msgstr "&Venstre:"
+
+#: ../src/richtext/richtextborderspage.cpp:257
+#: ../src/richtext/richtextborderspage.cpp:259
+msgid "Units for the left border width."
+msgstr "Enheder for bredde af venstre kant."
+
+#: ../src/richtext/richtextborderspage.cpp:266
+#: ../src/richtext/richtextborderspage.cpp:268
+#: ../src/richtext/richtextborderspage.cpp:300
+#: ../src/richtext/richtextborderspage.cpp:302
+#: ../src/richtext/richtextborderspage.cpp:334
+#: ../src/richtext/richtextborderspage.cpp:336
+#: ../src/richtext/richtextborderspage.cpp:368
+#: ../src/richtext/richtextborderspage.cpp:370
+#: ../src/richtext/richtextborderspage.cpp:434
+#: ../src/richtext/richtextborderspage.cpp:436
+#: ../src/richtext/richtextborderspage.cpp:468
+#: ../src/richtext/richtextborderspage.cpp:470
+#: ../src/richtext/richtextborderspage.cpp:502
+#: ../src/richtext/richtextborderspage.cpp:504
+#: ../src/richtext/richtextborderspage.cpp:536
+#: ../src/richtext/richtextborderspage.cpp:538
+msgid "The border line style."
+msgstr "Kantlinjetypografi."
+
+#: ../src/richtext/richtextborderspage.cpp:276
+#: ../src/richtext/richtextborderspage.cpp:444
+#: ../src/richtext/richtextindentspage.cpp:212
+#: ../src/richtext/richtextliststylepage.cpp:402
+#: ../src/richtext/richtextmarginspage.cpp:210
+#: ../src/richtext/richtextmarginspage.cpp:324
+#: ../src/richtext/richtextsizepage.cpp:601
+#: ../src/richtext/richtextsizepage.cpp:608
+msgid "&Right:"
+msgstr "&Højre:"
+
+#: ../src/richtext/richtextborderspage.cpp:291
+#: ../src/richtext/richtextborderspage.cpp:293
+msgid "Units for the right border width."
+msgstr "Enheder for bredde af højre kant."
+
+#: ../src/richtext/richtextborderspage.cpp:310
+#: ../src/richtext/richtextborderspage.cpp:478
+#: ../src/richtext/richtextmarginspage.cpp:233
+#: ../src/richtext/richtextmarginspage.cpp:347
+#: ../src/richtext/richtextsizepage.cpp:566
+#: ../src/richtext/richtextsizepage.cpp:573
+msgid "&Top:"
+msgstr "&Top:"
+
+#: ../src/richtext/richtextborderspage.cpp:325
+#: ../src/richtext/richtextborderspage.cpp:327
+msgid "Units for the top border width."
+msgstr "Enheder for bredde af øverste kant."
+
+#: ../src/richtext/richtextborderspage.cpp:344
+#: ../src/richtext/richtextborderspage.cpp:512
+#: ../src/richtext/richtextmarginspage.cpp:258
+#: ../src/richtext/richtextmarginspage.cpp:372
+#: ../src/richtext/richtextsizepage.cpp:636
+#: ../src/richtext/richtextsizepage.cpp:643
+msgid "&Bottom:"
+msgstr "&Bund:"
+
+#: ../src/richtext/richtextborderspage.cpp:359
+#: ../src/richtext/richtextborderspage.cpp:361
+msgid "Units for the bottom border width."
+msgstr "Enheder for bredde af nederste kant."
+
+#: ../src/richtext/richtextborderspage.cpp:380
+#: ../src/richtext/richtextborderspage.cpp:548
+msgid "&Synchronize values"
+msgstr "&Synkroniser værdier"
+
+#: ../src/richtext/richtextborderspage.cpp:382
+#: ../src/richtext/richtextborderspage.cpp:384
+#: ../src/richtext/richtextborderspage.cpp:550
+#: ../src/richtext/richtextborderspage.cpp:552
+msgid "Check to edit all borders simultaneously."
+msgstr "Slå til for at ændre alle kanter på en gang."
+
+#: ../src/richtext/richtextborderspage.cpp:397
+#: ../src/richtext/richtextborderspage.cpp:555
+msgid "Outline"
+msgstr "Disposition"
+
+#: ../src/richtext/richtextborderspage.cpp:425
+#: ../src/richtext/richtextborderspage.cpp:427
+msgid "Units for the left outline width."
+msgstr "Enheder for venstre dispositionsbredde."
+
+#: ../src/richtext/richtextborderspage.cpp:459
+#: ../src/richtext/richtextborderspage.cpp:461
+msgid "Units for the right outline width."
+msgstr "Enheder for højre dispositionsbredde."
+
+#: ../src/richtext/richtextborderspage.cpp:493
+#: ../src/richtext/richtextborderspage.cpp:495
+msgid "Units for the top outline width."
+msgstr "Enheder for top dispositionsbredde."
+
+#: ../src/richtext/richtextborderspage.cpp:527
+#: ../src/richtext/richtextborderspage.cpp:529
+msgid "Units for the bottom outline width."
+msgstr "Enheder for nederste dispositionsbredde."
+
+#: ../src/richtext/richtextborderspage.cpp:565
+#: ../src/richtext/richtextborderspage.cpp:600
+msgid "Corner"
+msgstr "Hjørne"
+
+#: ../src/richtext/richtextborderspage.cpp:574
+msgid "Corner &radius:"
+msgstr "Hjørne&radius:"
+
+#: ../src/richtext/richtextborderspage.cpp:576
+#: ../src/richtext/richtextborderspage.cpp:578
+msgid "An optional corner radius for adding rounded corners."
+msgstr "Eventuel hjørneradius til tilføjelse af afrundede hjørner."
+
+#: ../src/richtext/richtextborderspage.cpp:584
+#: ../src/richtext/richtextborderspage.cpp:586
+msgid "The value of the corner radius."
+msgstr "Værdien af hjørneradius."
+
+#: ../src/richtext/richtextborderspage.cpp:595
+#: ../src/richtext/richtextborderspage.cpp:597
+msgid "Units for the corner radius."
+msgstr "Enheder for hjørneradius."
+
+#: ../src/richtext/richtextborderspage.cpp:609
+#: ../src/richtext/richtextsizepage.cpp:247
+#: ../src/richtext/richtextsizepage.cpp:251
+msgid "None"
+msgstr "Ingen"
+
+#: ../src/richtext/richtextborderspage.cpp:610
+msgid "Solid"
+msgstr "Fast"
+
+#: ../src/richtext/richtextborderspage.cpp:611
+msgid "Dotted"
+msgstr "Prikket"
+
+#: ../src/richtext/richtextborderspage.cpp:612
+msgid "Dashed"
+msgstr "Streget"
+
+#: ../src/richtext/richtextborderspage.cpp:613
+msgid "Double"
+msgstr "Dobbelt"
+
+#: ../src/richtext/richtextborderspage.cpp:614
+msgid "Groove"
+msgstr "Groove"
+
+#: ../src/richtext/richtextborderspage.cpp:615
+msgid "Ridge"
+msgstr "Ryg"
+
+#: ../src/richtext/richtextborderspage.cpp:616
+msgid "Inset"
+msgstr "Sænket"
+
+#: ../src/richtext/richtextborderspage.cpp:617
+msgid "Outset"
+msgstr "Start"
+
+#: ../src/richtext/richtextbuffer.cpp:3518
+msgid "Change Style"
+msgstr "Skift typografi"
+
+#: ../src/richtext/richtextbuffer.cpp:3701
+msgid "Change Object Style"
+msgstr "Skift objekttypografi"
+
+#: ../src/richtext/richtextbuffer.cpp:3974
+#: ../src/richtext/richtextbuffer.cpp:8174
+msgid "Change Properties"
+msgstr "Rediger egenskaber"
+
+#: ../src/richtext/richtextbuffer.cpp:4346
+msgid "Change List Style"
+msgstr "Skift listetypografi"
+
+#: ../src/richtext/richtextbuffer.cpp:4519
+msgid "Renumber List"
+msgstr "Renummerer liste"
+
+#: ../src/richtext/richtextbuffer.cpp:7867
+#: ../src/richtext/richtextbuffer.cpp:7897
+#: ../src/richtext/richtextbuffer.cpp:7939
+#: ../src/richtext/richtextctrl.cpp:1279 ../src/richtext/richtextctrl.cpp:1473
+msgid "Insert Text"
+msgstr "Indsæt tekst"
+
+#: ../src/richtext/richtextbuffer.cpp:8023
+#: ../src/richtext/richtextbuffer.cpp:8979
+msgid "Insert Image"
+msgstr "Indsæt billede"
+
+#: ../src/richtext/richtextbuffer.cpp:8070
+msgid "Insert Object"
+msgstr "Indsæt objekt"
+
+#: ../src/richtext/richtextbuffer.cpp:8112
+msgid "Insert Field"
+msgstr "Indsæt felt"
+
+#: ../src/richtext/richtextbuffer.cpp:8410
+msgid "Too many EndStyle calls!"
+msgstr "For mange EndStyle-kald!"
+
+#: ../src/richtext/richtextbuffer.cpp:8785
+msgid "files"
+msgstr "filer"
+
+#: ../src/richtext/richtextbuffer.cpp:9380
+msgid "standard/circle"
+msgstr "standard/cirkel"
+
+#: ../src/richtext/richtextbuffer.cpp:9381
+msgid "standard/circle-outline"
+msgstr "standard/cirkel-omrids"
+
+#: ../src/richtext/richtextbuffer.cpp:9382
+msgid "standard/square"
+msgstr "standard/firkant"
+
+#: ../src/richtext/richtextbuffer.cpp:9383
+msgid "standard/diamond"
+msgstr "standard/diamant"
+
+#: ../src/richtext/richtextbuffer.cpp:9384
+msgid "standard/triangle"
+msgstr "standard/trekant"
+
+#: ../src/richtext/richtextbuffer.cpp:9423
+msgid "Box Properties"
+msgstr "Boks-egenskaber"
+
+#: ../src/richtext/richtextbuffer.cpp:10006
+msgid "Multiple Cell Properties"
+msgstr "Egenskaber for flere celler"
+
+#: ../src/richtext/richtextbuffer.cpp:10008
+msgid "Cell Properties"
+msgstr "Celleegenskaber"
+
+#: ../src/richtext/richtextbuffer.cpp:11256
+msgid "Set Cell Style"
+msgstr "Indstil celletypografi"
+
+#: ../src/richtext/richtextbuffer.cpp:11330
+msgid "Delete Row"
+msgstr "Slet række"
+
+#: ../src/richtext/richtextbuffer.cpp:11380
+msgid "Delete Column"
+msgstr "Slet kolonne"
+
+#: ../src/richtext/richtextbuffer.cpp:11431
+msgid "Add Row"
+msgstr "Tilføj række"
+
+#: ../src/richtext/richtextbuffer.cpp:11494
+msgid "Add Column"
+msgstr "Tilføj kolonne"
+
+#: ../src/richtext/richtextbuffer.cpp:11537
+msgid "Table Properties"
+msgstr "Tabel-egenskaber"
+
+#: ../src/richtext/richtextbuffer.cpp:12899
+msgid "Picture Properties"
+msgstr "Billedegenskaber"
+
+#: ../src/richtext/richtextbuffer.cpp:13169
+#: ../src/richtext/richtextbuffer.cpp:13279
+msgid "image"
+msgstr "billede"
+
+#: ../src/richtext/richtextbulletspage.cpp:145
+#: ../src/richtext/richtextliststylepage.cpp:209
+msgid "&Bullet style:"
+msgstr "&Punkttegnstypografi:"
+
+#: ../src/richtext/richtextbulletspage.cpp:150
+#: ../src/richtext/richtextbulletspage.cpp:152
+#: ../src/richtext/richtextliststylepage.cpp:214
+#: ../src/richtext/richtextliststylepage.cpp:216
+msgid "The available bullet styles."
+msgstr "Tilgængelige punkttegnstypografier."
+
+#: ../src/richtext/richtextbulletspage.cpp:158
+#: ../src/richtext/richtextliststylepage.cpp:221
+msgid "Peri&od"
+msgstr "Punkt&um"
+
+#: ../src/richtext/richtextbulletspage.cpp:160
+#: ../src/richtext/richtextbulletspage.cpp:162
+#: ../src/richtext/richtextliststylepage.cpp:223
+#: ../src/richtext/richtextliststylepage.cpp:225
+msgid "Check to add a period after the bullet."
+msgstr "Slå til for at tilføje et punktum efter punkttegnet."
+
+#. TRANSLATORS: Bullet point in parentheses option
+#: ../src/richtext/richtextbulletspage.cpp:167
+#: ../src/richtext/richtextliststylepage.cpp:230
+msgid "(*)"
+msgstr "(*)"
+
+#: ../src/richtext/richtextbulletspage.cpp:169
+#: ../src/richtext/richtextbulletspage.cpp:171
+#: ../src/richtext/richtextliststylepage.cpp:232
+#: ../src/richtext/richtextliststylepage.cpp:234
+msgid "Check to enclose the bullet in parentheses."
+msgstr "Slå til for at sætte parentes om punkttegnet."
+
+#. TRANSLATORS: Right parenthesis bullet point option
+#: ../src/richtext/richtextbulletspage.cpp:176
+#: ../src/richtext/richtextliststylepage.cpp:239
+msgid "*)"
+msgstr "*)"
+
+#: ../src/richtext/richtextbulletspage.cpp:178
+#: ../src/richtext/richtextbulletspage.cpp:180
+#: ../src/richtext/richtextliststylepage.cpp:241
+#: ../src/richtext/richtextliststylepage.cpp:243
+msgid "Check to add a right parenthesis."
+msgstr "Slå til for at tilføje højre-parentes."
+
+#: ../src/richtext/richtextbulletspage.cpp:185
+#: ../src/richtext/richtextliststylepage.cpp:248
+msgid "Bullet &Alignment:"
+msgstr "&Justering af punkttegn:"
+
+#: ../src/richtext/richtextbulletspage.cpp:190
+#: ../src/richtext/richtextliststylepage.cpp:253
+msgid "Centre"
+msgstr "Centrér"
+
+#: ../src/richtext/richtextbulletspage.cpp:194
+#: ../src/richtext/richtextbulletspage.cpp:196
+#: ../src/richtext/richtextbulletspage.cpp:217
+#: ../src/richtext/richtextbulletspage.cpp:219
+#: ../src/richtext/richtextliststylepage.cpp:257
+#: ../src/richtext/richtextliststylepage.cpp:259
+#: ../src/richtext/richtextliststylepage.cpp:278
+#: ../src/richtext/richtextliststylepage.cpp:280
+msgid "The bullet character."
+msgstr "Punkttegn."
+
+#: ../src/richtext/richtextbulletspage.cpp:212
+#: ../src/richtext/richtextliststylepage.cpp:271
+msgid "&Symbol:"
+msgstr "&Symbol:"
+
+#: ../src/richtext/richtextbulletspage.cpp:222
+#: ../src/richtext/richtextliststylepage.cpp:283
+msgid "Ch&oose..."
+msgstr "V&ælg..."
+
+#: ../src/richtext/richtextbulletspage.cpp:223
+#: ../src/richtext/richtextbulletspage.cpp:225
+#: ../src/richtext/richtextliststylepage.cpp:284
+#: ../src/richtext/richtextliststylepage.cpp:286
+msgid "Click to browse for a symbol."
+msgstr "Klik for at kigge efter et symbol."
+
+#: ../src/richtext/richtextbulletspage.cpp:230
+#: ../src/richtext/richtextliststylepage.cpp:291
+msgid "Symbol &font:"
+msgstr "Symbol&font:"
+
+#: ../src/richtext/richtextbulletspage.cpp:235
+#: ../src/richtext/richtextbulletspage.cpp:237
+#: ../src/richtext/richtextliststylepage.cpp:297
+msgid "Available fonts."
+msgstr "Tilgængelige skrifttyper."
+
+#: ../src/richtext/richtextbulletspage.cpp:242
+#: ../src/richtext/richtextliststylepage.cpp:302
+msgid "S&tandard bullet name:"
+msgstr "Navn på s&tandard-punkttegn:"
+
+#: ../src/richtext/richtextbulletspage.cpp:247
+#: ../src/richtext/richtextbulletspage.cpp:249
+#: ../src/richtext/richtextliststylepage.cpp:307
+#: ../src/richtext/richtextliststylepage.cpp:309
+msgid "A standard bullet name."
+msgstr "Et standard punktnavn."
+
+#: ../src/richtext/richtextbulletspage.cpp:254
+msgid "&Number:"
+msgstr "&Nummer:"
+
+#: ../src/richtext/richtextbulletspage.cpp:258
+#: ../src/richtext/richtextbulletspage.cpp:260
+msgid "The list item number."
+msgstr "Nummeret på punktet i listen."
+
+#: ../src/richtext/richtextbulletspage.cpp:266
+#: ../src/richtext/richtextbulletspage.cpp:268
+#: ../src/richtext/richtextliststylepage.cpp:475
+#: ../src/richtext/richtextliststylepage.cpp:477
+msgid "Shows a preview of the bullet settings."
+msgstr "Viser en prøve på indstillinger for punkttegn."
+
+#: ../src/richtext/richtextbulletspage.cpp:276
+#: ../src/richtext/richtextliststylepage.cpp:484
+msgid "(None)"
+msgstr "(ingen)"
+
+#: ../src/richtext/richtextbulletspage.cpp:277
+#: ../src/richtext/richtextliststylepage.cpp:485
+msgid "Arabic"
+msgstr "Arabisk"
+
+#: ../src/richtext/richtextbulletspage.cpp:278
+#: ../src/richtext/richtextliststylepage.cpp:486
+msgid "Upper case letters"
+msgstr "Store bogstaver"
+
+#: ../src/richtext/richtextbulletspage.cpp:279
+#: ../src/richtext/richtextliststylepage.cpp:487
+msgid "Lower case letters"
+msgstr "Små bogstaver"
+
+#: ../src/richtext/richtextbulletspage.cpp:280
+#: ../src/richtext/richtextliststylepage.cpp:488
+msgid "Upper case roman numerals"
+msgstr "Store romertal"
+
+#: ../src/richtext/richtextbulletspage.cpp:281
+#: ../src/richtext/richtextliststylepage.cpp:489
+msgid "Lower case roman numerals"
+msgstr "Små romertal"
+
+#: ../src/richtext/richtextbulletspage.cpp:282
+#: ../src/richtext/richtextliststylepage.cpp:490
+msgid "Numbered outline"
+msgstr "Nummereret disposition"
+
+#: ../src/richtext/richtextbulletspage.cpp:283
+#: ../src/richtext/richtextliststylepage.cpp:491
+msgid "Symbol"
+msgstr "Symbol"
+
+#: ../src/richtext/richtextbulletspage.cpp:284
+#: ../src/richtext/richtextliststylepage.cpp:492
+msgid "Bitmap"
+msgstr "Bitmap"
+
+#: ../src/richtext/richtextbulletspage.cpp:285
+#: ../src/richtext/richtextliststylepage.cpp:493
+msgid "Standard"
+msgstr "Standard"
+
+#: ../src/richtext/richtextbulletspage.cpp:287
+#: ../src/richtext/richtextliststylepage.cpp:495
+msgid "*"
+msgstr "*"
+
+#: ../src/richtext/richtextbulletspage.cpp:288
+#: ../src/richtext/richtextliststylepage.cpp:496
+msgid "-"
+msgstr "-"
+
+#: ../src/richtext/richtextbulletspage.cpp:289
+#: ../src/richtext/richtextliststylepage.cpp:497
+msgid ">"
+msgstr ">"
+
+#: ../src/richtext/richtextbulletspage.cpp:290
+#: ../src/richtext/richtextliststylepage.cpp:498
+msgid "+"
+msgstr "+"
+
+#: ../src/richtext/richtextbulletspage.cpp:291
+#: ../src/richtext/richtextliststylepage.cpp:499
+msgid "~"
+msgstr "~"
+
+#: ../src/richtext/richtextctrl.cpp:859
+msgid "Drag"
+msgstr "Træk"
+
+#: ../src/richtext/richtextctrl.cpp:1338 ../src/richtext/richtextctrl.cpp:1559
+msgid "Delete Text"
+msgstr "Slet tekst"
+
+#: ../src/richtext/richtextctrl.cpp:1537
+msgid "Remove Bullet"
+msgstr "Fjern punkttegn"
+
+#: ../src/richtext/richtextctrl.cpp:3070
+msgid "The text couldn't be saved."
+msgstr "Teksten kunne ikke gemmes."
+
+#: ../src/richtext/richtextctrl.cpp:3644
+msgid "Replace"
+msgstr "Erstat"
+
+#: ../src/richtext/richtextfontpage.cpp:146
+#: ../src/richtext/richtextsymboldlg.cpp:384
+msgid "&Font:"
+msgstr "&Skrift:"
+
+#: ../src/richtext/richtextfontpage.cpp:150
+#: ../src/richtext/richtextfontpage.cpp:152
+msgid "Type a font name."
+msgstr "Indtast et skrifttypenavn."
+
+#: ../src/richtext/richtextfontpage.cpp:158
+msgid "&Size:"
+msgstr "&Størrelse:"
+
+#: ../src/richtext/richtextfontpage.cpp:165
+#: ../src/richtext/richtextfontpage.cpp:167
+msgid "Type a size in points."
+msgstr "Indtast en størrelse i punkter."
+
+#: ../src/richtext/richtextfontpage.cpp:180
+#: ../src/richtext/richtextfontpage.cpp:182
+msgid "The font size units, points or pixels."
+msgstr "Enhed for skriftstørrelse, punkt eller pixels."
+
+#: ../src/richtext/richtextfontpage.cpp:189
+#: ../src/richtext/richtextfontpage.cpp:191
+msgid "Lists the available fonts."
+msgstr "Viser tilgængelige skrifttyper."
+
+#: ../src/richtext/richtextfontpage.cpp:196
+#: ../src/richtext/richtextfontpage.cpp:198
+msgid "Lists font sizes in points."
+msgstr "Lister skriftstørrelser i punkter."
+
+#: ../src/richtext/richtextfontpage.cpp:207
+msgid "Font st&yle:"
+msgstr "Skriftst&ypografi:"
+
+#: ../src/richtext/richtextfontpage.cpp:212
+#: ../src/richtext/richtextfontpage.cpp:214
+msgid "Select regular or italic style."
+msgstr "Vælg normal eller kursiv."
+
+#: ../src/richtext/richtextfontpage.cpp:220
+msgid "Font &weight:"
+msgstr "&Skrifttypevægt:"
+
+#: ../src/richtext/richtextfontpage.cpp:225
+#: ../src/richtext/richtextfontpage.cpp:227
+msgid "Select regular or bold."
+msgstr "Vælg normal eller fed."
+
+#: ../src/richtext/richtextfontpage.cpp:233
+msgid "&Underlining:"
+msgstr "&Understregning:"
+
+#: ../src/richtext/richtextfontpage.cpp:238
+#: ../src/richtext/richtextfontpage.cpp:240
+msgid "Select underlining or no underlining."
+msgstr "Vælg understregning eller ingen understregning."
+
+#: ../src/richtext/richtextfontpage.cpp:248
+msgid "&Colour:"
+msgstr "F&arve:"
+
+#: ../src/richtext/richtextfontpage.cpp:253
+#: ../src/richtext/richtextfontpage.cpp:255
+msgid "Click to change the text colour."
+msgstr "Klik for at ændre tekstfarven."
+
+#: ../src/richtext/richtextfontpage.cpp:261
+msgid "&Bg colour:"
+msgstr "&Bg.-farve:"
+
+#: ../src/richtext/richtextfontpage.cpp:266
+#: ../src/richtext/richtextfontpage.cpp:268
+msgid "Click to change the text background colour."
+msgstr "Klik for at ændre tekstens baggrundsfarve."
+
+#: ../src/richtext/richtextfontpage.cpp:276
+#: ../src/richtext/richtextfontpage.cpp:278
+msgid "Check to show a line through the text."
+msgstr "Slå til for at vise en streg igennem teksten."
+
+#: ../src/richtext/richtextfontpage.cpp:281
+msgid "Ca&pitals"
+msgstr "St&ore bogstaver"
+
+#: ../src/richtext/richtextfontpage.cpp:283
+#: ../src/richtext/richtextfontpage.cpp:285
+msgid "Check to show the text in capitals."
+msgstr "Slå til for at vise teksten med stort."
+
+#: ../src/richtext/richtextfontpage.cpp:288
+msgid "Small C&apitals"
+msgstr "Små vers&aler"
+
+#: ../src/richtext/richtextfontpage.cpp:290
+#: ../src/richtext/richtextfontpage.cpp:292
+msgid "Check to show the text in small capitals."
+msgstr "Slå til for at vise teksten i små versaler."
+
+#: ../src/richtext/richtextfontpage.cpp:295
+msgid "Supe&rscript"
+msgstr "Hævet sk&rift"
+
+#: ../src/richtext/richtextfontpage.cpp:297
+#: ../src/richtext/richtextfontpage.cpp:299
+msgid "Check to show the text in superscript."
+msgstr "Slå til for at vise teksten som hævet skrift."
+
+#: ../src/richtext/richtextfontpage.cpp:302
+msgid "Subscrip&t"
+msgstr "Sænket skrif&t"
+
+#: ../src/richtext/richtextfontpage.cpp:304
+#: ../src/richtext/richtextfontpage.cpp:306
+msgid "Check to show the text in subscript."
+msgstr "Slå til for at vise teksten som sænket skrift."
+
+#: ../src/richtext/richtextfontpage.cpp:312
+msgid "Rig&ht-to-left"
+msgstr "&Højre-mod-venstre"
+
+#: ../src/richtext/richtextfontpage.cpp:314
+#: ../src/richtext/richtextfontpage.cpp:316
+msgid "Check to indicate right-to-left text layout."
+msgstr "Slå til for at indikere højre-til-venstre-tekstlayout."
+
+#: ../src/richtext/richtextfontpage.cpp:319
+msgid "Suppress hyphe&nation"
+msgstr "Undertryk ord&deling"
+
+#: ../src/richtext/richtextfontpage.cpp:321
+#: ../src/richtext/richtextfontpage.cpp:323
+msgid "Check to suppress hyphenation."
+msgstr "Slå til for at undertrykke orddeling."
+
+#: ../src/richtext/richtextfontpage.cpp:329
+#: ../src/richtext/richtextfontpage.cpp:331
+msgid "Shows a preview of the font settings."
+msgstr "Viser en prøve på skrifttypeindstillingerne."
+
+#: ../src/richtext/richtextfontpage.cpp:348
+#: ../src/richtext/richtextfontpage.cpp:352
+#: ../src/richtext/richtextfontpage.cpp:356
+#: ../src/richtext/richtextformatdlg.cpp:873
+#: ../src/richtext/richtextindentspage.cpp:273
+#: ../src/richtext/richtextindentspage.cpp:285
+#: ../src/richtext/richtextindentspage.cpp:286
+#: ../src/richtext/richtextindentspage.cpp:310
+#: ../src/richtext/richtextindentspage.cpp:325
+#: ../src/richtext/richtextliststylepage.cpp:451
+#: ../src/richtext/richtextliststylepage.cpp:463
+#: ../src/richtext/richtextliststylepage.cpp:464
+msgid "(none)"
+msgstr "(ingen)"
+
+#: ../src/richtext/richtextfontpage.cpp:349
+#: ../src/richtext/richtextfontpage.cpp:353
+msgid "Regular"
+msgstr "Normal"
+
+#: ../src/richtext/richtextfontpage.cpp:357
+msgid "Not underlined"
+msgstr "Ikke understreget"
+
+#: ../src/richtext/richtextformatdlg.cpp:341
+msgid "Indents && Spacing"
+msgstr "Indrykning og afstand"
+
+#: ../src/richtext/richtextformatdlg.cpp:346
+msgid "Tabs"
+msgstr "Faneblade"
+
+#: ../src/richtext/richtextformatdlg.cpp:351
+msgid "Bullets"
+msgstr "Punkttegn"
+
+#: ../src/richtext/richtextformatdlg.cpp:356
+msgid "List Style"
+msgstr "Listetypografi"
+
+#: ../src/richtext/richtextformatdlg.cpp:366
+#: ../src/richtext/richtextmarginspage.cpp:170
+msgid "Margins"
+msgstr "Margener"
+
+#: ../src/richtext/richtextformatdlg.cpp:371
+msgid "Borders"
+msgstr "Kanter"
+
+#: ../src/richtext/richtextformatdlg.cpp:765
+msgid "Colour"
+msgstr "Farve"
+
+#: ../src/richtext/richtextindentspage.cpp:127
+#: ../src/richtext/richtextliststylepage.cpp:322
+msgid "&Alignment"
+msgstr "&Justering"
+
+#: ../src/richtext/richtextindentspage.cpp:138
+#: ../src/richtext/richtextliststylepage.cpp:331
+msgid "&Left"
+msgstr "&Venstre"
+
+#: ../src/richtext/richtextindentspage.cpp:140
+#: ../src/richtext/richtextindentspage.cpp:142
+#: ../src/richtext/richtextliststylepage.cpp:333
+#: ../src/richtext/richtextliststylepage.cpp:335
+msgid "Left-align text."
+msgstr "Venstrejuster tekst."
+
+#: ../src/richtext/richtextindentspage.cpp:145
+#: ../src/richtext/richtextliststylepage.cpp:338
+msgid "&Right"
+msgstr "&Højre"
+
+#: ../src/richtext/richtextindentspage.cpp:147
+#: ../src/richtext/richtextindentspage.cpp:149
+#: ../src/richtext/richtextliststylepage.cpp:340
+#: ../src/richtext/richtextliststylepage.cpp:342
+msgid "Right-align text."
+msgstr "Højrejuster tekst."
+
+#: ../src/richtext/richtextindentspage.cpp:152
+#: ../src/richtext/richtextliststylepage.cpp:345
+msgid "&Justified"
+msgstr "&Justeret"
+
+#: ../src/richtext/richtextindentspage.cpp:154
+#: ../src/richtext/richtextindentspage.cpp:156
+#: ../src/richtext/richtextliststylepage.cpp:347
+#: ../src/richtext/richtextliststylepage.cpp:349
+msgid "Justify text left and right."
+msgstr "Juster tekst venstre og højre."
+
+#: ../src/richtext/richtextindentspage.cpp:159
+#: ../src/richtext/richtextliststylepage.cpp:352
+msgid "Cen&tred"
+msgstr "Cen&treret"
+
+#: ../src/richtext/richtextindentspage.cpp:161
+#: ../src/richtext/richtextindentspage.cpp:163
+#: ../src/richtext/richtextliststylepage.cpp:354
+#: ../src/richtext/richtextliststylepage.cpp:356
+msgid "Centre text."
+msgstr "Centrér tekst."
+
+#: ../src/richtext/richtextindentspage.cpp:166
+#: ../src/richtext/richtextliststylepage.cpp:359
+msgid "&Indeterminate"
+msgstr "&Ubestemt"
+
+#: ../src/richtext/richtextindentspage.cpp:168
+#: ../src/richtext/richtextindentspage.cpp:170
+#: ../src/richtext/richtextliststylepage.cpp:361
+#: ../src/richtext/richtextliststylepage.cpp:363
+msgid "Use the current alignment setting."
+msgstr "Brug aktuelle justering."
+
+#: ../src/richtext/richtextindentspage.cpp:183
+#: ../src/richtext/richtextliststylepage.cpp:375
+msgid "&Indentation (tenths of a mm)"
+msgstr "&Indryk (tiendedele mm)"
+
+#: ../src/richtext/richtextindentspage.cpp:198
+#: ../src/richtext/richtextindentspage.cpp:200
+#: ../src/richtext/richtextliststylepage.cpp:388
+#: ../src/richtext/richtextliststylepage.cpp:390
+msgid "The left indent."
+msgstr "Den venstre indrykning."
+
+#: ../src/richtext/richtextindentspage.cpp:203
+#: ../src/richtext/richtextliststylepage.cpp:393
+msgid "Left (&first line):"
+msgstr "Venstre (&første linje):"
+
+#: ../src/richtext/richtextindentspage.cpp:207
+#: ../src/richtext/richtextindentspage.cpp:209
+#: ../src/richtext/richtextliststylepage.cpp:397
+#: ../src/richtext/richtextliststylepage.cpp:399
+msgid "The first line indent."
+msgstr "Indrykning af første linje."
+
+#: ../src/richtext/richtextindentspage.cpp:216
+#: ../src/richtext/richtextindentspage.cpp:218
+#: ../src/richtext/richtextliststylepage.cpp:406
+#: ../src/richtext/richtextliststylepage.cpp:408
+msgid "The right indent."
+msgstr "Den højre indrykning."
+
+#: ../src/richtext/richtextindentspage.cpp:221
+msgid "&Outline level:"
+msgstr "&Dispositionsniveau:"
+
+#: ../src/richtext/richtextindentspage.cpp:226
+#: ../src/richtext/richtextindentspage.cpp:228
+msgid "The outline level."
+msgstr "Dispositionsniveauet."
+
+#: ../src/richtext/richtextindentspage.cpp:241
+#: ../src/richtext/richtextliststylepage.cpp:420
+msgid "&Spacing (tenths of a mm)"
+msgstr "&Afstand (tiendedele mm)"
+
+#: ../src/richtext/richtextindentspage.cpp:252
+msgid "&Before a paragraph:"
+msgstr "&Før et afsnit:"
+
+#: ../src/richtext/richtextindentspage.cpp:256
+#: ../src/richtext/richtextindentspage.cpp:258
+#: ../src/richtext/richtextliststylepage.cpp:433
+#: ../src/richtext/richtextliststylepage.cpp:435
+msgid "The spacing before the paragraph."
+msgstr "Afstand før afsnittet."
+
+#: ../src/richtext/richtextindentspage.cpp:261
+msgid "&After a paragraph:"
+msgstr "&Efter et afsnit:"
+
+#: ../src/richtext/richtextindentspage.cpp:266
+#: ../src/richtext/richtextliststylepage.cpp:442
+#: ../src/richtext/richtextliststylepage.cpp:444
+msgid "The spacing after the paragraph."
+msgstr "Afstand efter afsnittet."
+
+#: ../src/richtext/richtextindentspage.cpp:269
+msgid "L&ine spacing:"
+msgstr "L&injeafstand:"
+
+#: ../src/richtext/richtextindentspage.cpp:274
+#: ../src/richtext/richtextliststylepage.cpp:452
+msgid "Single"
+msgstr "Single"
+
+#: ../src/richtext/richtextindentspage.cpp:275
+#: ../src/richtext/richtextliststylepage.cpp:453
+msgid "1.1"
+msgstr "1.1"
+
+#: ../src/richtext/richtextindentspage.cpp:276
+#: ../src/richtext/richtextliststylepage.cpp:454
+msgid "1.2"
+msgstr "1.2"
+
+#: ../src/richtext/richtextindentspage.cpp:277
+#: ../src/richtext/richtextliststylepage.cpp:455
+msgid "1.3"
+msgstr "1.3"
+
+#: ../src/richtext/richtextindentspage.cpp:278
+#: ../src/richtext/richtextliststylepage.cpp:456
+msgid "1.4"
+msgstr "1.4"
+
+#: ../src/richtext/richtextindentspage.cpp:279
+#: ../src/richtext/richtextliststylepage.cpp:457
+msgid "1.5"
+msgstr "1.5"
+
+#: ../src/richtext/richtextindentspage.cpp:280
+#: ../src/richtext/richtextliststylepage.cpp:458
+msgid "1.6"
+msgstr "1.6"
+
+#: ../src/richtext/richtextindentspage.cpp:281
+#: ../src/richtext/richtextliststylepage.cpp:459
+msgid "1.7"
+msgstr "1.7"
+
+#: ../src/richtext/richtextindentspage.cpp:282
+#: ../src/richtext/richtextliststylepage.cpp:460
+msgid "1.8"
+msgstr "1.8"
+
+#: ../src/richtext/richtextindentspage.cpp:283
+#: ../src/richtext/richtextliststylepage.cpp:461
+msgid "1.9"
+msgstr "1.9"
+
+#: ../src/richtext/richtextindentspage.cpp:284
+#: ../src/richtext/richtextliststylepage.cpp:462
+msgid "2"
+msgstr "2"
+
+#: ../src/richtext/richtextindentspage.cpp:287
+#: ../src/richtext/richtextindentspage.cpp:289
+#: ../src/richtext/richtextliststylepage.cpp:465
+#: ../src/richtext/richtextliststylepage.cpp:467
+msgid "The line spacing."
+msgstr "Linjeafstand."
+
+#: ../src/richtext/richtextindentspage.cpp:292
+msgid "&Page Break"
+msgstr "&Sideskift"
+
+#: ../src/richtext/richtextindentspage.cpp:294
+#: ../src/richtext/richtextindentspage.cpp:296
+msgid "Inserts a page break before the paragraph."
+msgstr "Indsætter et sideskift før afsnittet."
+
+#: ../src/richtext/richtextindentspage.cpp:302
+#: ../src/richtext/richtextindentspage.cpp:304
+msgid "Shows a preview of the paragraph settings."
+msgstr "Viser en prøve på indstillinger for afsnit."
+
+#: ../src/richtext/richtextliststylepage.cpp:182
+msgid "&List level:"
+msgstr "&Listeniveau:"
+
+#: ../src/richtext/richtextliststylepage.cpp:186
+#: ../src/richtext/richtextliststylepage.cpp:188
+msgid "Selects the list level to edit."
+msgstr "Vælg hvilket listeniveau, der skal redigeres."
+
+#: ../src/richtext/richtextliststylepage.cpp:193
+msgid "&Font for Level..."
+msgstr "&Skrifttype for niveau..."
+
+#: ../src/richtext/richtextliststylepage.cpp:194
+#: ../src/richtext/richtextliststylepage.cpp:196
+msgid "Click to choose the font for this level."
+msgstr "Klik for at vælge skrifttype for dette niveau."
+
+#: ../src/richtext/richtextliststylepage.cpp:312
+msgid "Bullet style"
+msgstr "Punkttegnstypografi"
+
+#: ../src/richtext/richtextliststylepage.cpp:429
+msgid "Before a paragraph:"
+msgstr "Før et afsnit:"
+
+#: ../src/richtext/richtextliststylepage.cpp:438
+msgid "After a paragraph:"
+msgstr "Efter et afsnit:"
+
+#: ../src/richtext/richtextliststylepage.cpp:447
+msgid "Line spacing:"
+msgstr "Linjeafstand:"
+
+#: ../src/richtext/richtextliststylepage.cpp:470
+msgid "Spacing"
+msgstr "Afstand"
+
+#: ../src/richtext/richtextmarginspage.cpp:193
+#: ../src/richtext/richtextmarginspage.cpp:195
+msgid "The left margin size."
+msgstr "Størrelsen af venstre margen."
+
+#: ../src/richtext/richtextmarginspage.cpp:203
+#: ../src/richtext/richtextmarginspage.cpp:205
+msgid "Units for the left margin."
+msgstr "Enheder for venstre margen."
+
+#: ../src/richtext/richtextmarginspage.cpp:218
+#: ../src/richtext/richtextmarginspage.cpp:220
+msgid "The right margin size."
+msgstr "Størrelsen af højre margen."
+
+#: ../src/richtext/richtextmarginspage.cpp:228
+#: ../src/richtext/richtextmarginspage.cpp:230
+msgid "Units for the right margin."
+msgstr "Enheder for højre margen."
+
+#: ../src/richtext/richtextmarginspage.cpp:241
+#: ../src/richtext/richtextmarginspage.cpp:243
+msgid "The top margin size."
+msgstr "Størrelsen af topmargen."
+
+#: ../src/richtext/richtextmarginspage.cpp:251
+#: ../src/richtext/richtextmarginspage.cpp:253
+msgid "Units for the top margin."
+msgstr "Enheder for topmargen."
+
+#: ../src/richtext/richtextmarginspage.cpp:266
+#: ../src/richtext/richtextmarginspage.cpp:268
+msgid "The bottom margin size."
+msgstr "Størrelse på bundmargen."
+
+#: ../src/richtext/richtextmarginspage.cpp:276
+#: ../src/richtext/richtextmarginspage.cpp:278
+msgid "Units for the bottom margin."
+msgstr "Enheder for bundmargen."
+
+#: ../src/richtext/richtextmarginspage.cpp:284
+msgid "Padding"
+msgstr "Indre margen"
+
+#: ../src/richtext/richtextmarginspage.cpp:307
+#: ../src/richtext/richtextmarginspage.cpp:309
+msgid "The left padding size."
+msgstr "Størrelsen af venstre indre margen."
+
+#: ../src/richtext/richtextmarginspage.cpp:317
+#: ../src/richtext/richtextmarginspage.cpp:319
+msgid "Units for the left padding."
+msgstr "Enheder for indre venstre margen."
+
+#: ../src/richtext/richtextmarginspage.cpp:332
+#: ../src/richtext/richtextmarginspage.cpp:334
+msgid "The right padding size."
+msgstr "Størrelsen af indre højre margen."
+
+#: ../src/richtext/richtextmarginspage.cpp:342
+#: ../src/richtext/richtextmarginspage.cpp:344
+msgid "Units for the right padding."
+msgstr "Enheder for indre højre margen."
+
+#: ../src/richtext/richtextmarginspage.cpp:355
+#: ../src/richtext/richtextmarginspage.cpp:357
+msgid "The top padding size."
+msgstr "Størrelsen af indre topmargen."
+
+#: ../src/richtext/richtextmarginspage.cpp:365
+#: ../src/richtext/richtextmarginspage.cpp:367
+msgid "Units for the top padding."
+msgstr "Enheder for indre topmargen."
+
+#: ../src/richtext/richtextmarginspage.cpp:380
+#: ../src/richtext/richtextmarginspage.cpp:382
+msgid "The bottom padding size."
+msgstr "Størrelsen af den indre bundmargen."
+
+#: ../src/richtext/richtextmarginspage.cpp:390
+#: ../src/richtext/richtextmarginspage.cpp:392
+msgid "Units for the bottom padding."
+msgstr "Enheder for indre bundmargen."
+
+#: ../src/richtext/richtextprint.cpp:592
+msgid " Preview"
+msgstr " Vis udskrift"
+
+#: ../src/richtext/richtextsizepage.cpp:228
+msgid "Floating"
+msgstr "Flydende"
+
+#: ../src/richtext/richtextsizepage.cpp:243
+msgid "&Floating mode:"
+msgstr "&Flydende tilstand:"
+
+#: ../src/richtext/richtextsizepage.cpp:252
+#: ../src/richtext/richtextsizepage.cpp:254
+msgid "How the object will float relative to the text."
+msgstr "Hvordan objektet placerer sig i forhold til teksten."
+
+#: ../src/richtext/richtextsizepage.cpp:265
+msgid "Alignment"
+msgstr "Justering"
+
+#: ../src/richtext/richtextsizepage.cpp:277
+msgid "&Vertical alignment:"
+msgstr "&Lodret justering:"
+
+#: ../src/richtext/richtextsizepage.cpp:279
+#: ../src/richtext/richtextsizepage.cpp:281
+msgid "Enable vertical alignment."
+msgstr "Aktivér lodret justering."
+
+#: ../src/richtext/richtextsizepage.cpp:286
+msgid "Centred"
+msgstr "Centreret"
+
+#: ../src/richtext/richtextsizepage.cpp:290
+#: ../src/richtext/richtextsizepage.cpp:292
+msgid "Vertical alignment."
+msgstr "Lodret justering."
+
+#: ../src/richtext/richtextsizepage.cpp:316
+#: ../src/richtext/richtextsizepage.cpp:323
+msgid "&Width:"
+msgstr "&Bredde:"
+
+#: ../src/richtext/richtextsizepage.cpp:318
+#: ../src/richtext/richtextsizepage.cpp:320
+msgid "Enable the width value."
+msgstr "Aktivér værdi for bredde."
+
+#: ../src/richtext/richtextsizepage.cpp:331
+#: ../src/richtext/richtextsizepage.cpp:333
+msgid "The object width."
+msgstr "Bredden på objektet."
+
+#: ../src/richtext/richtextsizepage.cpp:342
+#: ../src/richtext/richtextsizepage.cpp:344
+msgid "Units for the object width."
+msgstr "Enheder for objektbredde."
+
+#: ../src/richtext/richtextsizepage.cpp:350
+#: ../src/richtext/richtextsizepage.cpp:357
+msgid "&Height:"
+msgstr "&Højde:"
+
+#: ../src/richtext/richtextsizepage.cpp:352
+#: ../src/richtext/richtextsizepage.cpp:354
+#: ../src/richtext/richtextsizepage.cpp:464
+#: ../src/richtext/richtextsizepage.cpp:466
+msgid "Enable the height value."
+msgstr "Aktivér værdi for højde."
+
+#: ../src/richtext/richtextsizepage.cpp:365
+#: ../src/richtext/richtextsizepage.cpp:367
+msgid "The object height."
+msgstr "Højden på objektet."
+
+#: ../src/richtext/richtextsizepage.cpp:376
+#: ../src/richtext/richtextsizepage.cpp:378
+msgid "Units for the object height."
+msgstr "Enheder for objekthøjde."
+
+#: ../src/richtext/richtextsizepage.cpp:381
+msgid "Min width:"
+msgstr "Min. bredde:"
+
+#: ../src/richtext/richtextsizepage.cpp:383
+#: ../src/richtext/richtextsizepage.cpp:385
+msgid "Enable the minimum width value."
+msgstr "Aktivér minimum bredde værdi."
+
+#: ../src/richtext/richtextsizepage.cpp:392
+#: ../src/richtext/richtextsizepage.cpp:394
+msgid "The object minimum width."
+msgstr "Objektets minimum bredde."
+
+#: ../src/richtext/richtextsizepage.cpp:403
+#: ../src/richtext/richtextsizepage.cpp:405
+msgid "Units for the minimum object width."
+msgstr "Enheder for minimum objektbredde."
+
+#: ../src/richtext/richtextsizepage.cpp:408
+msgid "Min height:"
+msgstr "Min. højde:"
+
+#: ../src/richtext/richtextsizepage.cpp:410
+#: ../src/richtext/richtextsizepage.cpp:412
+msgid "Enable the minimum height value."
+msgstr "Aktivér minimal værdi for højde."
+
+#: ../src/richtext/richtextsizepage.cpp:419
+#: ../src/richtext/richtextsizepage.cpp:421
+msgid "The object minimum height."
+msgstr "Objektets minimum højde."
+
+#: ../src/richtext/richtextsizepage.cpp:430
+#: ../src/richtext/richtextsizepage.cpp:432
+msgid "Units for the minimum object height."
+msgstr "Enheder for minimum objekthøjde."
+
+#: ../src/richtext/richtextsizepage.cpp:435
+msgid "Max width:"
+msgstr "Maks. bredde:"
+
+#: ../src/richtext/richtextsizepage.cpp:437
+#: ../src/richtext/richtextsizepage.cpp:439
+msgid "Enable the maximum width value."
+msgstr "Aktivér maksimum bredde værdi."
+
+#: ../src/richtext/richtextsizepage.cpp:446
+#: ../src/richtext/richtextsizepage.cpp:448
+msgid "The object maximum width."
+msgstr "Objektets maksimum bredde."
+
+#: ../src/richtext/richtextsizepage.cpp:457
+#: ../src/richtext/richtextsizepage.cpp:459
+msgid "Units for the maximum object width."
+msgstr "Enheder for maksimum objektbredde."
+
+#: ../src/richtext/richtextsizepage.cpp:462
+msgid "Max height:"
+msgstr "Maks. højde:"
+
+#: ../src/richtext/richtextsizepage.cpp:473
+#: ../src/richtext/richtextsizepage.cpp:475
+msgid "The object maximum height."
+msgstr "Objektets maksimum højde."
+
+#: ../src/richtext/richtextsizepage.cpp:484
+#: ../src/richtext/richtextsizepage.cpp:486
+msgid "Units for the maximum object height."
+msgstr "Enheder for maksimum objekthøjde."
+
+#: ../src/richtext/richtextsizepage.cpp:495
+msgid "Position"
+msgstr "Position"
+
+#: ../src/richtext/richtextsizepage.cpp:513
+msgid "&Position mode:"
+msgstr "&Position mode:"
+
+#: ../src/richtext/richtextsizepage.cpp:517
+#: ../src/richtext/richtextsizepage.cpp:522
+msgid "Static"
+msgstr "Statisk"
+
+#: ../src/richtext/richtextsizepage.cpp:518
+msgid "Relative"
+msgstr "Relativ"
+
+#: ../src/richtext/richtextsizepage.cpp:519
+msgid "Absolute"
+msgstr "Absolut"
+
+#: ../src/richtext/richtextsizepage.cpp:520
+msgid "Fixed"
+msgstr "Fast"
+
+#: ../src/richtext/richtextsizepage.cpp:533
+#: ../src/richtext/richtextsizepage.cpp:535
+#: ../src/richtext/richtextsizepage.cpp:547
+#: ../src/richtext/richtextsizepage.cpp:549
+msgid "The left position."
+msgstr "Venstre position."
+
+#: ../src/richtext/richtextsizepage.cpp:558
+#: ../src/richtext/richtextsizepage.cpp:560
+msgid "Units for the left position."
+msgstr "Enheder for venstre position."
+
+#: ../src/richtext/richtextsizepage.cpp:568
+#: ../src/richtext/richtextsizepage.cpp:570
+#: ../src/richtext/richtextsizepage.cpp:582
+#: ../src/richtext/richtextsizepage.cpp:584
+msgid "The top position."
+msgstr "Topposition."
+
+#: ../src/richtext/richtextsizepage.cpp:593
+#: ../src/richtext/richtextsizepage.cpp:595
+msgid "Units for the top position."
+msgstr "Enheder for øverste position."
+
+#: ../src/richtext/richtextsizepage.cpp:603
+#: ../src/richtext/richtextsizepage.cpp:605
+#: ../src/richtext/richtextsizepage.cpp:617
+#: ../src/richtext/richtextsizepage.cpp:619
+msgid "The right position."
+msgstr "Højre position."
+
+#: ../src/richtext/richtextsizepage.cpp:628
+#: ../src/richtext/richtextsizepage.cpp:630
+msgid "Units for the right position."
+msgstr "Enheder for højre position."
+
+#: ../src/richtext/richtextsizepage.cpp:638
+#: ../src/richtext/richtextsizepage.cpp:640
+#: ../src/richtext/richtextsizepage.cpp:652
+#: ../src/richtext/richtextsizepage.cpp:654
+msgid "The bottom position."
+msgstr "Bundposition."
+
+#: ../src/richtext/richtextsizepage.cpp:663
+#: ../src/richtext/richtextsizepage.cpp:665
+msgid "Units for the bottom position."
+msgstr "Enheder for nederste position."
+
+#: ../src/richtext/richtextsizepage.cpp:671
+msgid "&Move the object to:"
+msgstr "&Flyt objektet til:"
+
+#: ../src/richtext/richtextsizepage.cpp:674
+msgid "&Previous Paragraph"
+msgstr "&Forrige afsnit"
+
+#: ../src/richtext/richtextsizepage.cpp:675
+#: ../src/richtext/richtextsizepage.cpp:677
+msgid "Moves the object to the previous paragraph."
+msgstr "Flytter objektet til det forrige afsnit."
+
+#: ../src/richtext/richtextsizepage.cpp:680
+msgid "&Next Paragraph"
+msgstr "&Næste afsnit"
+
+#: ../src/richtext/richtextsizepage.cpp:681
+#: ../src/richtext/richtextsizepage.cpp:683
+msgid "Moves the object to the next paragraph."
+msgstr "Flytter objektet til det næste afsnit."
+
+#: ../src/richtext/richtextstyledlg.cpp:193
+msgid "&Styles:"
+msgstr "&Typografier:"
+
+#: ../src/richtext/richtextstyledlg.cpp:197
+#: ../src/richtext/richtextstyledlg.cpp:199
+msgid "The available styles."
+msgstr "Tilgængelige typografier."
+
+#: ../src/richtext/richtextstyledlg.cpp:205
+#: ../src/richtext/richtextstyledlg.cpp:217
+msgid " "
+msgstr " "
+
+#: ../src/richtext/richtextstyledlg.cpp:209
+#: ../src/richtext/richtextstyledlg.cpp:211
+msgid "The style preview."
+msgstr "Visning af typografi."
+
+#: ../src/richtext/richtextstyledlg.cpp:220
+msgid "New &Character Style..."
+msgstr "Ny &tegntypografi..."
+
+#: ../src/richtext/richtextstyledlg.cpp:221
+#: ../src/richtext/richtextstyledlg.cpp:223
+msgid "Click to create a new character style."
+msgstr "Klik for at oprette en ny tegntypografi."
+
+#: ../src/richtext/richtextstyledlg.cpp:226
+msgid "New &Paragraph Style..."
+msgstr "Ny &afsnitstypografi..."
+
+#: ../src/richtext/richtextstyledlg.cpp:227
+#: ../src/richtext/richtextstyledlg.cpp:229
+msgid "Click to create a new paragraph style."
+msgstr "Klik for at oprette en ny afsnitstypografi."
+
+#: ../src/richtext/richtextstyledlg.cpp:232
+msgid "New &List Style..."
+msgstr "Ny &listetypografi..."
+
+#: ../src/richtext/richtextstyledlg.cpp:233
+#: ../src/richtext/richtextstyledlg.cpp:235
+msgid "Click to create a new list style."
+msgstr "Klik for at oprette en ny listetypografi."
+
+#: ../src/richtext/richtextstyledlg.cpp:238
+msgid "New &Box Style..."
+msgstr "Ny &bokstypografi..."
+
+#: ../src/richtext/richtextstyledlg.cpp:239
+#: ../src/richtext/richtextstyledlg.cpp:241
+msgid "Click to create a new box style."
+msgstr "Klik for at oprette en ny bokstypografi."
+
+#: ../src/richtext/richtextstyledlg.cpp:246
+msgid "&Apply Style"
+msgstr "&Anvend typografi"
+
+#: ../src/richtext/richtextstyledlg.cpp:247
+#: ../src/richtext/richtextstyledlg.cpp:249
+msgid "Click to apply the selected style."
+msgstr "Klik for at anvende den valgte typografi."
+
+#: ../src/richtext/richtextstyledlg.cpp:252
+msgid "&Rename Style..."
+msgstr "&Omdøb typografi..."
+
+#: ../src/richtext/richtextstyledlg.cpp:253
+#: ../src/richtext/richtextstyledlg.cpp:255
+msgid "Click to rename the selected style."
+msgstr "Klik for at omdøbe den valgte typografi."
+
+#: ../src/richtext/richtextstyledlg.cpp:258
+msgid "&Edit Style..."
+msgstr "&Rediger typografi..."
+
+#: ../src/richtext/richtextstyledlg.cpp:259
+#: ../src/richtext/richtextstyledlg.cpp:261
+msgid "Click to edit the selected style."
+msgstr "Klik for at redigere den valgte typografi."
+
+#: ../src/richtext/richtextstyledlg.cpp:264
+msgid "&Delete Style..."
+msgstr "&Slet typografi..."
+
+#: ../src/richtext/richtextstyledlg.cpp:265
+#: ../src/richtext/richtextstyledlg.cpp:267
+msgid "Click to delete the selected style."
+msgstr "Klik for at slette den valgte typografi."
+
+#: ../src/richtext/richtextstyledlg.cpp:274
+#: ../src/richtext/richtextstyledlg.cpp:276
+msgid "Click to close this window."
+msgstr "Klik for at lukke dette vindue."
+
+#: ../src/richtext/richtextstyledlg.cpp:282
+msgid "&Restart numbering"
+msgstr "&Genstart nummerering"
+
+#: ../src/richtext/richtextstyledlg.cpp:284
+#: ../src/richtext/richtextstyledlg.cpp:286
+msgid "Check to restart numbering."
+msgstr "Slå til for at genstarte nummerering."
+
+#: ../src/richtext/richtextstyledlg.cpp:601
+msgid "Enter a character style name"
+msgstr "Indtast navnet på en tegntypografi"
+
+#: ../src/richtext/richtextstyledlg.cpp:601
+#: ../src/richtext/richtextstyledlg.cpp:606
+#: ../src/richtext/richtextstyledlg.cpp:649
+#: ../src/richtext/richtextstyledlg.cpp:654
+#: ../src/richtext/richtextstyledlg.cpp:815
+#: ../src/richtext/richtextstyledlg.cpp:820
+#: ../src/richtext/richtextstyledlg.cpp:888
+#: ../src/richtext/richtextstyledlg.cpp:896
+#: ../src/richtext/richtextstyledlg.cpp:929
+#: ../src/richtext/richtextstyledlg.cpp:934
+msgid "New Style"
+msgstr "Ny typografi"
+
+#: ../src/richtext/richtextstyledlg.cpp:606
+#: ../src/richtext/richtextstyledlg.cpp:654
+#: ../src/richtext/richtextstyledlg.cpp:820
+#: ../src/richtext/richtextstyledlg.cpp:896
+#: ../src/richtext/richtextstyledlg.cpp:934
+msgid "Sorry, that name is taken. Please choose another."
+msgstr "Beklager, navnet er taget. Vælg venligst et andet."
+
+#: ../src/richtext/richtextstyledlg.cpp:649
+msgid "Enter a paragraph style name"
+msgstr "Indtast navnet på en afsnitstypografi"
+
+#: ../src/richtext/richtextstyledlg.cpp:777
+#, c-format
+msgid "Delete style %s?"
+msgstr "Slet typografien %s?"
+
+#: ../src/richtext/richtextstyledlg.cpp:777
+msgid "Delete Style"
+msgstr "Slet typografi"
+
+#: ../src/richtext/richtextstyledlg.cpp:815
+msgid "Enter a list style name"
+msgstr "Indtast navnet på en listetypografi"
+
+#: ../src/richtext/richtextstyledlg.cpp:888
+msgid "Enter a new style name"
+msgstr "Indtast et nyt typografinavn"
+
+#: ../src/richtext/richtextstyledlg.cpp:929
+msgid "Enter a box style name"
+msgstr "Indtast navnet på en bokstypografi"
+
+#: ../src/richtext/richtextstylepage.cpp:109
+#: ../src/richtext/richtextstylepage.cpp:111
+msgid "The style name."
+msgstr "Navn på typografien."
+
+#: ../src/richtext/richtextstylepage.cpp:114
+msgid "&Based on:"
+msgstr "&Baseret på:"
+
+#: ../src/richtext/richtextstylepage.cpp:119
+#: ../src/richtext/richtextstylepage.cpp:121
+msgid "The style on which this style is based."
+msgstr "Typografien, som denne typografi er baseret på."
+
+#: ../src/richtext/richtextstylepage.cpp:124
+msgid "&Next style:"
+msgstr "&Næste typografi:"
+
+#: ../src/richtext/richtextstylepage.cpp:129
+#: ../src/richtext/richtextstylepage.cpp:131
+msgid "The default style for the next paragraph."
+msgstr "Standardtypografi for næste afsnit."
+
+#: ../src/richtext/richtextstyles.cpp:1057
+msgid "All styles"
+msgstr "Alle typografier"
+
+#: ../src/richtext/richtextstyles.cpp:1058
+msgid "Paragraph styles"
+msgstr "Afsnitstypografier"
+
+#: ../src/richtext/richtextstyles.cpp:1059
+msgid "Character styles"
+msgstr "Tegntypografier"
+
+#: ../src/richtext/richtextstyles.cpp:1060
+msgid "List styles"
+msgstr "Listetypografier"
+
+#: ../src/richtext/richtextstyles.cpp:1061
+msgid "Box styles"
+msgstr "Bokstypografier"
+
+#: ../src/richtext/richtextsymboldlg.cpp:389
+#: ../src/richtext/richtextsymboldlg.cpp:391
+msgid "The font from which to take the symbol."
+msgstr "Skrifttypen hvorfra symbolet skal tages."
+
+#: ../src/richtext/richtextsymboldlg.cpp:396
+msgid "&Subset:"
+msgstr "&Del af tegnsæt:"
+
+#: ../src/richtext/richtextsymboldlg.cpp:401
+#: ../src/richtext/richtextsymboldlg.cpp:403
+msgid "Shows a Unicode subset."
+msgstr "Viser en del af Unicode-tegnsættet."
+
+#: ../src/richtext/richtextsymboldlg.cpp:412
+msgid "xxxx"
+msgstr "xxxx"
+
+#: ../src/richtext/richtextsymboldlg.cpp:417
+msgid "&Character code:"
+msgstr "&Tegnkode:"
+
+#: ../src/richtext/richtextsymboldlg.cpp:421
+#: ../src/richtext/richtextsymboldlg.cpp:423
+msgid "The character code."
+msgstr "Tegnkode."
+
+#: ../src/richtext/richtextsymboldlg.cpp:428
+msgid "&From:"
+msgstr "&Fra:"
+
+#: ../src/richtext/richtextsymboldlg.cpp:433
+#: ../src/richtext/richtextsymboldlg.cpp:434
+#: ../src/richtext/richtextsymboldlg.cpp:435
+msgid "Unicode"
+msgstr "Unicode"
+
+#: ../src/richtext/richtextsymboldlg.cpp:436
+#: ../src/richtext/richtextsymboldlg.cpp:438
+msgid "The range to show."
+msgstr "Område, der skal vises."
+
+#: ../src/richtext/richtextsymboldlg.cpp:444
+msgid "Insert"
+msgstr "Indsæt"
+
+#: ../src/richtext/richtextsymboldlg.cpp:478
+msgid "(Normal text)"
+msgstr "(normal tekst)"
+
+#: ../src/richtext/richtexttabspage.cpp:109
+msgid "&Position (tenths of a mm):"
+msgstr "&Position (tiendedele mm):"
+
+#: ../src/richtext/richtexttabspage.cpp:113
+#: ../src/richtext/richtexttabspage.cpp:115
+msgid "The tab position."
+msgstr "Tab-positionen."
+
+#: ../src/richtext/richtexttabspage.cpp:119
+msgid "The tab positions."
+msgstr "Tab-positionerne."
+
+#: ../src/richtext/richtexttabspage.cpp:132
+#: ../src/richtext/richtexttabspage.cpp:134
+msgid "Click to create a new tab position."
+msgstr "Klik for at oprette et ny tabulatorposition."
+
+#: ../src/richtext/richtexttabspage.cpp:138
+#: ../src/richtext/richtexttabspage.cpp:140
+msgid "Click to delete the selected tab position."
+msgstr "Klik for at slette det valgte tabulatorstop."
+
+#: ../src/richtext/richtexttabspage.cpp:143
+msgid "Delete A&ll"
+msgstr "Slet &alt"
+
+#: ../src/richtext/richtexttabspage.cpp:144
+#: ../src/richtext/richtexttabspage.cpp:146
+msgid "Click to delete all tab positions."
+msgstr "Klik for at slette alle tabulatorpositioner."
+
+#: ../src/univ/theme.cpp:110
+msgid "Failed to initialize GUI: no built-in themes found."
+msgstr ""
+"Kunne ikke initialisere grafisk brugerflade: fandt ingen indbyggede temaer."
+
+#: ../src/univ/themes/gtk.cpp:521
+msgid "GTK+ theme"
+msgstr "GTK+ tema"
+
+#: ../src/univ/themes/metal.cpp:164
+msgid "Metal theme"
+msgstr "Metal tema"
+
+#: ../src/univ/themes/mono.cpp:512
+msgid "Simple monochrome theme"
+msgstr "Simpelt monokromatisk tema"
+
+#: ../src/univ/themes/win32.cpp:1098
+msgid "Win32 theme"
+msgstr "Win32 tema"
+
+#: ../src/univ/themes/win32.cpp:3743
+msgid "&Restore"
+msgstr "&Genindlæs"
+
+#: ../src/univ/themes/win32.cpp:3744
+msgid "&Move"
+msgstr "&Flyt"
+
+#: ../src/univ/themes/win32.cpp:3746
+msgid "&Size"
+msgstr "&Størrelse"
+
+#: ../src/univ/themes/win32.cpp:3748
+msgid "Mi&nimize"
+msgstr "Mi&nimér"
+
+#: ../src/univ/themes/win32.cpp:3750
+msgid "Ma&ximize"
+msgstr "Ma&ksimér"
+
+#: ../src/univ/themes/win32.cpp:3752
+msgid "Alt+"
+msgstr "Alt+"
+
+#: ../src/unix/appunix.cpp:178
+msgid "Failed to install signal handler"
+msgstr "Kunne ikke installere signalbehandler"
+
+#: ../src/unix/dialup.cpp:351
+msgid "Already dialling ISP."
+msgstr "Ringer allerede til ISP."
+
+#: ../src/unix/dlunix.cpp:93
+#, fuzzy
+msgid "Failed to unload shared library"
+msgstr "Kunne ikke åbne delt bibliotek \"%s\""
+
+#: ../src/unix/dlunix.cpp:121
+msgid "Unknown dynamic library error"
+msgstr "Ukendt fejl ved dynamisk bibliotek"
+
+#: ../src/unix/epolldispatcher.cpp:84
+msgid "Failed to create epoll descriptor"
+msgstr "Kunne ikke oprette epoll-deskriptor"
+
+#: ../src/unix/epolldispatcher.cpp:103
+msgid "Error closing epoll descriptor"
+msgstr "Fejl under lukning af epoll-deskriptor"
+
+#: ../src/unix/epolldispatcher.cpp:116
+#, c-format
+msgid "Failed to add descriptor %d to epoll descriptor %d"
+msgstr "Kunne ikke tilføje deskriptor %d til epoll-deskriptor %d"
+
+#: ../src/unix/epolldispatcher.cpp:136
+#, c-format
+msgid "Failed to modify descriptor %d in epoll descriptor %d"
+msgstr "Kunne ikke ændre deskriptor %d i epoll-deskriptor %d"
+
+#: ../src/unix/epolldispatcher.cpp:155
+#, c-format
+msgid "Failed to unregister descriptor %d from epoll descriptor %d"
+msgstr "Kunne ikke afregistrere deskriptor %d fra epoll-deskriptor %d"
+
+#: ../src/unix/epolldispatcher.cpp:213
+#, c-format
+msgid "Waiting for IO on epoll descriptor %d failed"
+msgstr "Venter på IO på epoll-deskriptor %d fejlede"
+
+#: ../src/unix/fswatcher_inotify.cpp:71
+msgid "Unable to create inotify instance"
+msgstr "Kunne ikke oprette inotify-instans"
+
+#: ../src/unix/fswatcher_inotify.cpp:94
+msgid "Unable to close inotify instance"
+msgstr "Kunne ikke lukke inotify-instans"
+
+#: ../src/unix/fswatcher_inotify.cpp:106
+msgid "Unable to add inotify watch"
+msgstr "Kunne ikke tilføje inotify-overvågning"
+
+#: ../src/unix/fswatcher_inotify.cpp:138
+#, c-format
+msgid "Unable to remove inotify watch %i"
+msgstr "Kunne ikke fjerne inotify-overvågning %i"
+
+#: ../src/unix/fswatcher_inotify.cpp:271
+#, c-format
+msgid "Unexpected event for \"%s\": no matching watch descriptor."
+msgstr "Uventet event for \"%s\": ingen matchende watch-deskriptor."
+
+#: ../src/unix/fswatcher_inotify.cpp:320
+#, c-format
+msgid "Invalid inotify event for \"%s\""
+msgstr "Ugyldig inotify-event for \"%s\""
+
+#: ../src/unix/fswatcher_inotify.cpp:553
+msgid "Unable to read from inotify descriptor"
+msgstr "Kunne ikke læse fra inotify-deskriptor"
+
+#: ../src/unix/fswatcher_inotify.cpp:558
+msgid "EOF while reading from inotify descriptor"
+msgstr "EOF under læsning fra inotify-deskriptor"
+
+#: ../src/unix/fswatcher_kqueue.cpp:114
+msgid "Unable to create kqueue instance"
+msgstr "Kunne ikke oprette kqueue-instans"
+
+#: ../src/unix/fswatcher_kqueue.cpp:131
+msgid "Error closing kqueue instance"
+msgstr "Fejl under lukning af kqueue-instans"
+
+#: ../src/unix/fswatcher_kqueue.cpp:153
+msgid "Unable to add kqueue watch"
+msgstr "Kunne ikke tilføje overvågning af kø"
+
+#: ../src/unix/fswatcher_kqueue.cpp:170
+msgid "Unable to remove kqueue watch"
+msgstr "Kunne ikke fjerne overvågning af kø"
+
+#: ../src/unix/fswatcher_kqueue.cpp:202
+msgid "Unable to get events from kqueue"
+msgstr "Kunne ikke hente events fra kø"
+
+#: ../src/unix/mediactrl.cpp:966
+#, c-format
+msgid "Media playback error: %s"
+msgstr "Medieafspilningsfejl: %s"
+
+#: ../src/unix/mediactrl.cpp:1228
+#, c-format
+msgid "Failed to prepare playing \"%s\"."
+msgstr "Kunne ikke forberede afspilning af \"%s\"."
+
+#: ../src/unix/snglinst.cpp:164
+#, c-format
+msgid "Failed to write to lock file '%s'"
+msgstr "Kunne ikke skrive til låsfilen \"%s\""
+
+#: ../src/unix/snglinst.cpp:177
+#, c-format
+msgid "Failed to set permissions on lock file '%s'"
+msgstr "Kunne ikke sætte rettigheder for Lock-filen \"%s\""
+
+#: ../src/unix/snglinst.cpp:194
+#, c-format
+msgid "Failed to lock the lock file '%s'"
+msgstr "Kunne ikke låse låsfilen \"%s\""
+
+#: ../src/unix/snglinst.cpp:237
+#, c-format
+msgid "Failed to inspect the lock file '%s'"
+msgstr "Kunne ikke inspicere låsfilen \"%s\""
+
+#: ../src/unix/snglinst.cpp:242
+#, c-format
+msgid "Lock file '%s' has incorrect owner."
+msgstr "Låsfilen \"%s\" har en forkert ejer."
+
+#: ../src/unix/snglinst.cpp:247
+#, c-format
+msgid "Lock file '%s' has incorrect permissions."
+msgstr "Låsfilen \"%s\" har forkerte rettigheder."
+
+#: ../src/unix/snglinst.cpp:265
+msgid "Failed to access lock file."
+msgstr "Kunne ikke tilgå låsfilen."
+
+#: ../src/unix/snglinst.cpp:274
+msgid "Failed to read PID from lock file."
+msgstr "Kunne ikke læse PID fra låsfilen."
+
+#: ../src/unix/snglinst.cpp:284
+#, c-format
+msgid "Failed to remove stale lock file '%s'."
+msgstr "Kunne ikke fjerne gammel låsfil \"%s\"."
+
+#: ../src/unix/snglinst.cpp:297
+#, c-format
+msgid "Deleted stale lock file '%s'."
+msgstr "Slettede gammel låsfilen \"%s\"."
+
+#: ../src/unix/snglinst.cpp:308
+#, c-format
+msgid "Invalid lock file '%s'."
+msgstr "Ugyldig låsfil \"%s\"."
+
+#: ../src/unix/snglinst.cpp:324
+#, c-format
+msgid "Failed to remove lock file '%s'"
+msgstr "Kunne ikke fjerne låsfilen \"%s\""
+
+#: ../src/unix/snglinst.cpp:330
+#, c-format
+msgid "Failed to unlock lock file '%s'"
+msgstr "Kunne ikke låse låsfilen \"%s\" op"
+
+#: ../src/unix/snglinst.cpp:336
+#, c-format
+msgid "Failed to close lock file '%s'"
+msgstr "Kunne ikke lukke låsfilen \"%s\""
+
+#: ../src/unix/sound.cpp:77
+msgid "No sound"
+msgstr "Ingen lyd"
+
+#: ../src/unix/sound.cpp:364
+msgid "Unable to play sound asynchronously."
+msgstr "Kunne ikke afspille lyd asynkront."
+
+#: ../src/unix/sound.cpp:458
+#, c-format
+msgid "Couldn't load sound data from '%s'."
+msgstr "Kunne ikke indlæse lyddata fra \"%s\"."
+
+#: ../src/unix/sound.cpp:465
+#, c-format
+msgid "Sound file '%s' is in unsupported format."
+msgstr "Lydfilen \"%s\" er i et ikke-understøttet format."
+
+#: ../src/unix/sound.cpp:480
+msgid "Sound data are in unsupported format."
+msgstr "Lyddata er i et ikke understøttet format."
+
+#: ../src/unix/sound_sdl.cpp:226
+#, c-format
+msgid "Couldn't open audio: %s"
+msgstr "Kunne ikke åbne lyd: %s"
+
+#: ../src/unix/threadpsx.cpp:1033
+msgid "Cannot retrieve thread scheduling policy."
+msgstr "Kan ikke hente trådafviklingsalgoritme."
+
+#: ../src/unix/threadpsx.cpp:1058
+#, c-format
+msgid "Cannot get priority range for scheduling policy %d."
+msgstr "Kan ikke få prioritetsområde for afviklingsalgoritme %d."
+
+#: ../src/unix/threadpsx.cpp:1066
+msgid "Thread priority setting is ignored."
+msgstr "Prioritetsindstilling for tråd ignoreret."
+
+#: ../src/unix/threadpsx.cpp:1221
+msgid ""
+"Failed to join a thread, potential memory leak detected - please restart the "
+"program"
+msgstr ""
+"Kunne ikke slutte til en tråd, muligt hukommelsestab registreret - genstart "
+"venligst programmet"
+
+#: ../src/unix/threadpsx.cpp:1352
+#, c-format
+msgid "Failed to set thread concurrency level to %lu"
+msgstr "Kunne ikke sætte tråd-samtidighed-niveau til %lu"
+
+#: ../src/unix/threadpsx.cpp:1481
+#, c-format
+msgid "Failed to set thread priority %d."
+msgstr "Kunne ikke sætte trådprioritet %d."
+
+#: ../src/unix/threadpsx.cpp:1666
+msgid "Failed to terminate a thread."
+msgstr "Kunne ikke afslutte en tråd."
+
+#: ../src/unix/threadpsx.cpp:1893
+msgid "Thread module initialization failed: failed to create thread key"
+msgstr "Trådmodul initialisering fejlede: kunne ikke oprette trådnøgle"
+
+#: ../src/unix/utilsunx.cpp:340
+msgid "Impossible to get child process input"
+msgstr "Kunne ikke få input til underproces"
+
+#: ../src/unix/utilsunx.cpp:390
+msgid "Can't write to child process's stdin"
+msgstr "Kan ikke skrive til barneprocesens stdin"
+
+#: ../src/unix/utilsunx.cpp:644
+#, c-format
+msgid "Failed to execute '%s'\n"
+msgstr "Kunne ikke eksekvere \"%s\"\n"
+
+#: ../src/unix/utilsunx.cpp:678
+msgid "Fork failed"
+msgstr "Fork fejlede"
+
+#: ../src/unix/utilsunx.cpp:701
+msgid "Failed to set process priority"
+msgstr "Kunne ikke sætte procesprioritet"
+
+#: ../src/unix/utilsunx.cpp:712
+msgid "Failed to redirect child process input/output"
+msgstr "Kunne ikke omdirigere input/output fra underproces"
+
+#: ../src/unix/utilsunx.cpp:816
+msgid "Failed to set up non-blocking pipe, the program might hang."
+msgstr "Kunne ikke opsætte ikke-blokerende pipe. Programmet hænger muligvis."
+
+#: ../src/unix/utilsunx.cpp:1023
+msgid "Cannot get the hostname"
+msgstr "Kan ikke finde værtsnavn"
+
+#: ../src/unix/utilsunx.cpp:1059
+msgid "Cannot get the official hostname"
+msgstr "Kan ikke finde det officielle værtsnavn"
+
+#: ../src/unix/wakeuppipe.cpp:49
+msgid "Failed to create wake up pipe used by event loop."
+msgstr "Kunne ikke oprette wake up pipe til brug for event loop."
+
+#: ../src/unix/wakeuppipe.cpp:56
+msgid "Failed to switch wake up pipe to non-blocking mode"
+msgstr "Kunne ikke skifte wake up pipe til ikke-blokerende-tilstand"
+
+#: ../src/unix/wakeuppipe.cpp:117
+msgid "Failed to read from wake-up pipe"
+msgstr "Kunne ikke læse fra wake-up pipe"
+
+#: ../src/x11/app.cpp:124
+#, c-format
+msgid "Invalid geometry specification '%s'"
+msgstr "Ugyldig geometrispecifikation \"%s\""
+
+#: ../src/x11/app.cpp:167
+msgid "wxWidgets could not open display. Exiting."
+msgstr "wxWidgets kunne ikke åbne skærmen. Afslutter."
+
+#: ../src/x11/utils.cpp:169
+#, c-format
+msgid "Failed to close the display \"%s\""
+msgstr "Kunne ikke lukke skærmen \"%s\""
+
+#: ../src/x11/utils.cpp:188
+#, c-format
+msgid "Failed to open display \"%s\"."
+msgstr "Kunne ikke åbne skærmen \"%s\"."
+
+#: ../src/xml/xml.cpp:868
+#, c-format
+msgid "XML parsing error: '%s' at line %d"
+msgstr "XML tolkningsfejl: \"%s\" på linje %d"
+
+#: ../src/xrc/xh_propgrid.cpp:239
+#, fuzzy, c-format
+msgid "Page %i"
+msgstr "Side %d"
+
+#: ../src/xrc/xmlres.cpp:448
+#, c-format
+msgid "Cannot load resources from '%s'."
+msgstr "Kan ikke indlæse ressourcer fra \"%s\"."
+
+#: ../src/xrc/xmlres.cpp:799
+#, c-format
+msgid "Cannot open resources file '%s'."
+msgstr "Kan ikke åbne ressourcefilen \"%s\"."
+
+#: ../src/xrc/xmlres.cpp:806
+#, c-format
+msgid "Cannot load resources from file '%s'."
+msgstr "Kan ikke indlæse ressourcer fra filen \"%s\"."
+
+#: ../src/xrc/xmlres.cpp:2767
+#, c-format
+msgid "Creating %s \"%s\" failed."
+msgstr "Oprettelse af %s \"%s\" fejlede."
+
+#~ msgctxt "keyboard key"
+#~ msgid "Alt+"
+#~ msgstr "Alt+"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Ctrl+"
+#~ msgstr "Ctrl+"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Shift+"
+#~ msgstr "Skift+"
+
+#~ msgctxt "keyboard key"
+#~ msgid "RawCtrl+"
+#~ msgstr "RawCtrl+"
+
+#~ msgid "Unsupported clipboard format."
+#~ msgstr "Ikke-understøttet udklipsholderformat."
+
+#~ msgid "Background colour"
+#~ msgstr "Baggrundsfarve"
+
+#~ msgid "Font:"
+#~ msgstr "Skrifttype:"
+
+#~ msgid "Size:"
+#~ msgstr "Størrelse:"
+
+#~ msgid "The font size in points."
+#~ msgstr "Skriftstørrelsen i punkt."
+
+#~ msgid "Style:"
+#~ msgstr "Typografi:"
+
+#~ msgid "Check to make the font bold."
+#~ msgstr "Slå til for at gøre teksten fed."
+
+#~ msgid "Check to make the font italic."
+#~ msgstr "Slå til for at gøre teksten kursiv."
+
+#~ msgid "Check to make the font underlined."
+#~ msgstr "Slå til for at gøre teksten understreget."
+
+#~ msgid "Colour:"
+#~ msgstr "Farve:"
+
+#~ msgid "Click to change the font colour."
+#~ msgstr "Klik for at ændre skriftfarven."
+
+#~ msgid "Shows a preview of the font."
+#~ msgstr "Viser en prøve på skrifttypen."
+
+#~ msgid "Click to cancel changes to the font."
+#~ msgstr "Klik for at annullere ændringer af skrifttypen."
+
+#~ msgid "Click to confirm changes to the font."
+#~ msgstr "Klik for at bekræfte ændringer af skrifttypen."
+
+#~ msgid "<Any>"
+#~ msgstr "<Hvilken som helst>"
+
+#~ msgid "<Any Roman>"
+#~ msgstr "<Roman>"
+
+#~ msgid "<Any Decorative>"
+#~ msgstr "<Dekorativ>"
+
+#~ msgid "<Any Modern>"
+#~ msgstr "<Moderne>"
+
+#~ msgid "<Any Script>"
+#~ msgstr "<Script>"
+
+#~ msgid "<Any Swiss>"
+#~ msgstr "<Swiss>"
+
+#~ msgid "<Any Teletype>"
+#~ msgstr "<Teletype>"
+
+#~ msgid "Printing "
+#~ msgstr "Udskriver "
+
+#~ msgid "Failed to insert text in the control."
+#~ msgstr "Kunne ikke indsætte tekst i kontrollen."
+
+#~ msgid "Please choose a valid font."
+#~ msgstr "Vælg venligst en gyldig skrifttype."
+
+#, c-format
+#~ msgid "Failed to display HTML document in %s encoding"
+#~ msgstr "Kunne ikke vise HTML-dokument i %s-kodning"
+
+#, c-format
+#~ msgid "wxWidgets could not open display for '%s': exiting."
+#~ msgstr "wxWidgets kunne ikke åbne skærmen for \"%s\": afslutter."
+
+#~ msgid "Filter"
+#~ msgstr "Filter"
+
+#~ msgid "Directories"
+#~ msgstr "Mapper"
+
+#~ msgid "Files"
+#~ msgstr "Filer"
+
+#~ msgid "Selection"
+#~ msgstr "Markering"
+
+#~ msgid "conversion to 8-bit encoding failed"
+#~ msgstr "konvertering til 8-bit kodning fejlede"
+
+#, fuzzy
+#~ msgid "failed to retrieve execution result"
+#~ msgstr "Kunne ikke hente tekst fra RAS fejlmeddelelse"
+
+#~ msgid " (while overwriting an existing item)"
+#~ msgstr " (under overskrivning af et eksisterende punkt)"
+
+#~ msgid "&Save as"
+#~ msgstr "Gem &som"
+
+#~ msgid "'%s' doesn't consist only of valid characters"
+#~ msgstr "\"%s\" består ikke kun af lovlige tegn"
+
+#~ msgid "'%s' should be numeric."
+#~ msgstr "\"%s\" skal være numerisk."
+
+#~ msgid "'%s' should only contain ASCII characters."
+#~ msgstr "\"%s\" må kun indeholde ASCII-tegn."
+
+#~ msgid "'%s' should only contain alphabetic characters."
+#~ msgstr "\"%s\" må kun indeholde bogstaver."
+
+#~ msgid "'%s' should only contain alphabetic or numeric characters."
+#~ msgstr "\"%s\" må kun indeholde bogstaver eller tal."
+
+#~ msgid "'%s' should only contain digits."
+#~ msgstr "\"%s\" må kun indeholde tal."
+
+#~ msgid "Can't create window of class %s"
+#~ msgstr "Kan ikke oprette vindue af klassen %s"
+
+#~ msgid "Couldn't create the overlay window"
+#~ msgstr "Kunne ikke oprette overlay-vinduet"
+
+#~ msgid "Couldn't init the context on the overlay window"
+#~ msgstr "Kunne ikke initialisere konteksten på overlay-vinduet"
+
+#~ msgid "Failed to convert file \"%s\" to Unicode."
+#~ msgstr "Kunne ikke konvertere filen \"%s\" til Unicode."
+
+#~ msgid "Failed to set text in the text control."
+#~ msgstr "Kunne ikke sætte tekst i tekstkontrollen."
+
+#~ msgid "Invalid GTK+ command line option, use \"%s --help\""
+#~ msgstr "Ugyldig GTK+ kommandolinjetilvalg, brug \"%s --help\""
+
+#~ msgid "No unused colour in image."
+#~ msgstr "Ingen ubrugte farver i det billede."
+
+#~ msgid "Not available"
+#~ msgstr "Ikke tilgængelig"
+
+#~ msgid "Replace selection"
+#~ msgstr "Erstat markering"
+
+#~ msgid "Save as"
+#~ msgstr "Gem som"
+
+#~ msgid "Style Organiser"
+#~ msgstr "Typografistyring"
+
+#~ msgid "The following standard GTK+ options are also supported:\n"
+#~ msgstr "Følgende standard GTK+ indstillinger understøttes også:\n"
+
+#~ msgid "You cannot Clear an overlay that is not inited"
+#~ msgstr "Du kan ikke cleare et overlay, som ikke er blevet initialiseret"
+
+#~ msgid "You cannot Init an overlay twice"
+#~ msgstr "Du kan ikke initialisere et overlay to gange"
+
+#~ msgid "locale '%s' cannot be set."
+#~ msgstr "lokale \"%s\" kan ikke sættes."

--- a/po_wxstd/de.po
+++ b/po_wxstd/de.po
@@ -1,0 +1,10634 @@
+# German translations for wxWidgets
+# Copyright (C) 2019 wxWidgets
+# This file is distributed under the same license as the wxWidgets package.
+# Initial translation by unknown translator
+# Updated by Thomas Krebs <Thomas.Krebs@mecadtron.de>
+# Wolfgang Stöggl <c72578@yahoo.de>, 2014-2015.
+# Milo Ivir <mail@milotype.de>, 2019.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: wxWidgets 3.3.x\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-05-14 20:23+0200\n"
+"PO-Revision-Date: 2025-09-28 14:53+0200\n"
+"Last-Translator: Ulrich Telle <ulrich@telle-online.eu>\n"
+"Language-Team: wxWidgets Team <wx-dev@wxwidgets.org>\n"
+"Language: de\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n!=1);\n"
+"X-Generator: Poedit 3.7\n"
+
+#: ../include/wx/defs.h:2582
+msgid "All files (*.*)|*.*"
+msgstr "Alle Dateien (*.*)|*.*"
+
+#: ../include/wx/defs.h:2585
+msgid "All files (*)|*"
+msgstr "Alle Dateien (*)|*"
+
+#: ../include/wx/generic/progdlgg.h:85
+msgid "Elapsed time:"
+msgstr "Benötigte Zeit:"
+
+#: ../include/wx/generic/progdlgg.h:86
+msgid "Estimated time:"
+msgstr "Geschätzte Zeit:"
+
+#: ../include/wx/generic/progdlgg.h:87
+msgid "Remaining time:"
+msgstr "Verbleibende Zeit:"
+
+#. TRANSLATORS: HTML printout default title.
+#: ../include/wx/html/htmprint.h:121 ../include/wx/prntbase.h:273
+#: ../include/wx/richtext/richtextprint.h:109 ../src/common/docview.cpp:2161
+msgid "Printout"
+msgstr "Ausdruck"
+
+#. TRANSLATORS: HTML easy print default title.
+#: ../include/wx/html/htmprint.h:234 ../include/wx/richtext/richtextprint.h:163
+#: ../src/common/prntbase.cpp:522 ../src/html/htmprint.cpp:291
+msgid "Printing"
+msgstr "Drucken"
+
+#: ../include/wx/msgdlg.h:277 ../src/common/stockitem.cpp:211
+msgid "Yes"
+msgstr "Ja"
+
+#: ../include/wx/msgdlg.h:278 ../src/common/stockitem.cpp:182
+msgid "No"
+msgstr "Nein"
+
+#: ../include/wx/msgdlg.h:279 ../src/common/stockitem.cpp:183
+#: ../src/msw/msgdlg.cpp:430 ../src/msw/msgdlg.cpp:734
+#: ../src/richtext/richtextstyledlg.cpp:292
+msgid "OK"
+msgstr "OK"
+
+#: ../include/wx/msgdlg.h:280 ../src/common/stockitem.cpp:150
+#: ../src/msw/msgdlg.cpp:430 ../src/msw/progdlg.cpp:884
+#: ../src/richtext/richtextstyledlg.cpp:295
+msgid "Cancel"
+msgstr "Abbrechen"
+
+#: ../include/wx/msgdlg.h:281 ../src/common/stockitem.cpp:168
+#: ../src/html/helpdlg.cpp:63 ../src/html/helpfrm.cpp:108
+#: ../src/osx/button_osx.cpp:38
+msgid "Help"
+msgstr "Hilfe"
+
+#: ../include/wx/msw/ole/oleutils.h:52
+msgid "Cannot initialize OLE"
+msgstr "Kann OLE nicht initialisieren"
+
+#: ../include/wx/msw/private/fswatcher.h:48
+#, c-format
+msgid "Unable to close the handle for '%s'"
+msgstr "Das Handle für „%s“ konnte nicht geschlossen werden"
+
+#: ../include/wx/msw/private/fswatcher.h:92
+#, c-format
+msgid "Failed to open directory \"%s\" for monitoring."
+msgstr "Konnte das Verzeichnis „%s“ nicht zur Überwachung öffnen."
+
+#: ../include/wx/msw/private/fswatcher.h:125
+msgid "Unable to close I/O completion port handle"
+msgstr "I/O-Completion-Port-Handle konnte nicht geschlossen werden"
+
+#: ../include/wx/msw/private/fswatcher.h:142
+msgid "Unable to associate handle with I/O completion port"
+msgstr "Das Handle konnte nicht mit dem I/O-Completion-Port verknüpft werden"
+
+#: ../include/wx/msw/private/fswatcher.h:148
+msgid "Unexpectedly new I/O completion port was created"
+msgstr "Neuer unerwarteter I/O-Completion-Port wurde erstellt"
+
+#: ../include/wx/msw/private/fswatcher.h:213
+msgid "Unable to post completion status"
+msgstr "Nicht möglich den Ausführungsstatus zu senden"
+
+#: ../include/wx/msw/private/fswatcher.h:262
+msgid "Unable to dequeue completion packet"
+msgstr "Nicht möglich das Komplettierungspaket aufzulösen"
+
+#: ../include/wx/msw/private/fswatcher.h:273
+msgid "Unable to create I/O completion port"
+msgstr "Der I/O-Completion-Port konnte nicht erstellt werden"
+
+#: ../include/wx/richmsgdlg.h:29
+msgid "&See details"
+msgstr "&Einzelheiten anzeigen"
+
+#: ../include/wx/richmsgdlg.h:30
+msgid "&Hide details"
+msgstr "&Einzelheiten ausblenden"
+
+#: ../include/wx/richtext/richtextbuffer.h:3864
+msgid "&Box"
+msgstr "&Rahmen"
+
+#: ../include/wx/richtext/richtextbuffer.h:5008
+msgid "&Picture"
+msgstr "&Bild"
+
+#: ../include/wx/richtext/richtextbuffer.h:5958
+msgid "&Cell"
+msgstr "&Zelle"
+
+#: ../include/wx/richtext/richtextbuffer.h:6067
+msgid "&Table"
+msgstr "&Tabelle"
+
+#: ../include/wx/richtext/richtextimagedlg.h:37
+msgid "Object Properties"
+msgstr "Objekteigenschaften"
+
+#: ../include/wx/richtext/richtextsymboldlg.h:39
+msgid "Symbols"
+msgstr "Symbole"
+
+#: ../include/wx/unix/pipe.h:46
+msgid "Pipe creation failed"
+msgstr "Konnte keine Pipe anlegen"
+
+#: ../include/wx/unix/private/displayx11.h:65
+msgid "Failed to enumerate video modes"
+msgstr "Auflisten der Video-Modi fehlgeschlagen"
+
+#: ../include/wx/unix/private/displayx11.h:89
+msgid "Failed to change video mode"
+msgstr "Änderung des Video-Modus fehlgeschlagen"
+
+#: ../include/wx/unix/private/fswatcher_kqueue.h:57
+#, c-format
+msgid "Unable to open path '%s'"
+msgstr "Pfad „%s“ lässt sich nicht öffnen"
+
+#: ../include/wx/unix/private/fswatcher_kqueue.h:74
+#, c-format
+msgid "Unable to close path '%s'"
+msgstr "Pfad „%s“ konnte nicht geschlossen werden"
+
+#: ../include/wx/xtiprop.h:175
+msgid "SetProperty called w/o valid setter"
+msgstr "SetProperty aufgerufen ohne gültigen Setter"
+
+#: ../include/wx/xtiprop.h:184
+msgid "GetProperty called w/o valid getter"
+msgstr "GetProperty aufgerufen ohne gültigen getter"
+
+#: ../include/wx/xtiprop.h:193
+msgid "AddToPropertyCollection called w/o valid adder"
+msgstr "AddToPropertyCollection aufgerufen ohne gültigen adder"
+
+#: ../include/wx/xtiprop.h:202
+msgid "GetPropertyCollection called w/o valid collection getter"
+msgstr "GetPropertyCollection aufgerufen ohne gültigen Collection getter"
+
+#: ../include/wx/xtiprop.h:255
+msgid "AddToPropertyCollection called on a generic accessor"
+msgstr "AddToPropertyCollection aufgerufen für einen allgemeinen accessor"
+
+#: ../include/wx/xtiprop.h:262
+msgid "GetPropertyCollection called on a generic accessor"
+msgstr "GetPropertyCollection aufgerufen für einen allgemeinen accessor"
+
+#: ../src/aui/tabmdi.cpp:106 ../src/generic/mdig.cpp:94
+msgid "Cl&ose"
+msgstr "S&chließen"
+
+#: ../src/aui/tabmdi.cpp:107 ../src/generic/mdig.cpp:95
+msgid "Close All"
+msgstr "Alles Schließen"
+
+#: ../src/aui/tabmdi.cpp:109 ../src/generic/mdig.cpp:97 ../src/msw/mdi.cpp:175
+#: ../src/qt/mdi.cpp:258
+msgid "&Next"
+msgstr "&Weiter"
+
+#: ../src/aui/tabmdi.cpp:110 ../src/generic/mdig.cpp:98 ../src/msw/mdi.cpp:176
+#: ../src/qt/mdi.cpp:259
+msgid "&Previous"
+msgstr "&Zurück"
+
+#: ../src/aui/tabmdi.cpp:332 ../src/aui/tabmdi.cpp:348
+#: ../src/aui/tabmdi.cpp:350 ../src/generic/mdig.cpp:291
+#: ../src/generic/mdig.cpp:307 ../src/generic/mdig.cpp:311
+#: ../src/msw/mdi.cpp:337 ../src/qt/mdi.cpp:462
+msgid "&Window"
+msgstr "&Fenster"
+
+#: ../src/common/accelcmn.cpp:47
+msgctxt "keyboard key"
+msgid "Delete"
+msgstr "Löschen"
+
+#: ../src/common/accelcmn.cpp:48
+msgctxt "keyboard key"
+msgid "Del"
+msgstr "Entf"
+
+#: ../src/common/accelcmn.cpp:49
+msgctxt "keyboard key"
+msgid "Back"
+msgstr "Zurück"
+
+#: ../src/common/accelcmn.cpp:49
+msgctxt "keyboard key"
+msgid "Backspace"
+msgstr "Rücktaste"
+
+#: ../src/common/accelcmn.cpp:50
+msgctxt "keyboard key"
+msgid "Insert"
+msgstr "Einfügen"
+
+#: ../src/common/accelcmn.cpp:51
+msgctxt "keyboard key"
+msgid "Ins"
+msgstr "Einfg"
+
+#: ../src/common/accelcmn.cpp:52
+msgctxt "keyboard key"
+msgid "Enter"
+msgstr "Eingabe"
+
+#: ../src/common/accelcmn.cpp:53
+msgctxt "keyboard key"
+msgid "Return"
+msgstr "Eingabe"
+
+#: ../src/common/accelcmn.cpp:54
+msgctxt "keyboard key"
+msgid "PageUp"
+msgstr "Bild↑"
+
+#: ../src/common/accelcmn.cpp:54
+msgctxt "keyboard key"
+msgid "Page Up"
+msgstr "Bild↑"
+
+#: ../src/common/accelcmn.cpp:55
+msgctxt "keyboard key"
+msgid "PageDown"
+msgstr "Bild↓"
+
+#: ../src/common/accelcmn.cpp:55
+msgctxt "keyboard key"
+msgid "Page Down"
+msgstr "Bild↓"
+
+#: ../src/common/accelcmn.cpp:56
+msgctxt "keyboard key"
+msgid "PgUp"
+msgstr "Bild↑"
+
+#: ../src/common/accelcmn.cpp:57
+msgctxt "keyboard key"
+msgid "PgDn"
+msgstr "Bild↓"
+
+#: ../src/common/accelcmn.cpp:58
+msgctxt "keyboard key"
+msgid "Left"
+msgstr "Links"
+
+#: ../src/common/accelcmn.cpp:59
+msgctxt "keyboard key"
+msgid "Right"
+msgstr "Rechts"
+
+#: ../src/common/accelcmn.cpp:60
+msgctxt "keyboard key"
+msgid "Up"
+msgstr "Hoch"
+
+#: ../src/common/accelcmn.cpp:61
+msgctxt "keyboard key"
+msgid "Down"
+msgstr "Herunter"
+
+#: ../src/common/accelcmn.cpp:62
+msgctxt "keyboard key"
+msgid "Home"
+msgstr "Start"
+
+#: ../src/common/accelcmn.cpp:63
+msgctxt "keyboard key"
+msgid "End"
+msgstr "Ende"
+
+#: ../src/common/accelcmn.cpp:64
+msgctxt "keyboard key"
+msgid "Space"
+msgstr "Leer"
+
+#: ../src/common/accelcmn.cpp:65
+msgctxt "keyboard key"
+msgid "Tab"
+msgstr "Tabulator"
+
+#: ../src/common/accelcmn.cpp:66
+msgctxt "keyboard key"
+msgid "Esc"
+msgstr "Esc"
+
+#: ../src/common/accelcmn.cpp:67
+msgctxt "keyboard key"
+msgid "Escape"
+msgstr "Esc"
+
+#: ../src/common/accelcmn.cpp:68
+msgctxt "keyboard key"
+msgid "Cancel"
+msgstr "Abbrechen"
+
+#: ../src/common/accelcmn.cpp:69
+msgctxt "keyboard key"
+msgid "Clear"
+msgstr "Löschen"
+
+#: ../src/common/accelcmn.cpp:70
+msgctxt "keyboard key"
+msgid "Menu"
+msgstr "Menü"
+
+#: ../src/common/accelcmn.cpp:71
+msgctxt "keyboard key"
+msgid "Pause"
+msgstr "Pause"
+
+#: ../src/common/accelcmn.cpp:72
+msgctxt "keyboard key"
+msgid "Capital"
+msgstr "Großbuchstaben"
+
+#: ../src/common/accelcmn.cpp:73
+msgctxt "keyboard key"
+msgid "Select"
+msgstr "Auswahl"
+
+#: ../src/common/accelcmn.cpp:74
+msgctxt "keyboard key"
+msgid "Print"
+msgstr "Drucken"
+
+#: ../src/common/accelcmn.cpp:75
+msgctxt "keyboard key"
+msgid "Execute"
+msgstr "Ausführen"
+
+#: ../src/common/accelcmn.cpp:76
+msgctxt "keyboard key"
+msgid "Snapshot"
+msgstr "Drucktaste"
+
+#: ../src/common/accelcmn.cpp:77
+msgctxt "keyboard key"
+msgid "Help"
+msgstr "Hilfe"
+
+#: ../src/common/accelcmn.cpp:78
+msgctxt "keyboard key"
+msgid "Add"
+msgstr "Hinzufügen"
+
+#: ../src/common/accelcmn.cpp:79
+msgctxt "keyboard key"
+msgid "Separator"
+msgstr "Trennzeichen"
+
+#: ../src/common/accelcmn.cpp:80
+msgctxt "keyboard key"
+msgid "Subtract"
+msgstr "Minus"
+
+#: ../src/common/accelcmn.cpp:81
+msgctxt "keyboard key"
+msgid "Decimal"
+msgstr "Dezimaltrennzeichen"
+
+#: ../src/common/accelcmn.cpp:82
+msgctxt "keyboard key"
+msgid "Multiply"
+msgstr "Multipliziere"
+
+#: ../src/common/accelcmn.cpp:83
+msgctxt "keyboard key"
+msgid "Divide"
+msgstr "Division"
+
+#: ../src/common/accelcmn.cpp:84
+msgctxt "keyboard key"
+msgid "Num_lock"
+msgstr "Num-Taste"
+
+#: ../src/common/accelcmn.cpp:84
+msgctxt "keyboard key"
+msgid "Num Lock"
+msgstr "Num-Taste"
+
+#: ../src/common/accelcmn.cpp:85
+msgctxt "keyboard key"
+msgid "Scroll_lock"
+msgstr "Rollen-Taste"
+
+#: ../src/common/accelcmn.cpp:85
+msgctxt "keyboard key"
+msgid "Scroll Lock"
+msgstr "Rollen-Taste"
+
+#: ../src/common/accelcmn.cpp:86
+msgctxt "keyboard key"
+msgid "KP_Space"
+msgstr "Num_Leertaste"
+
+#: ../src/common/accelcmn.cpp:86
+msgctxt "keyboard key"
+msgid "Num Space"
+msgstr "Num Leer"
+
+#: ../src/common/accelcmn.cpp:87
+msgctxt "keyboard key"
+msgid "KP_Tab"
+msgstr "Num_Tab"
+
+#: ../src/common/accelcmn.cpp:87
+msgctxt "keyboard key"
+msgid "Num Tab"
+msgstr "Num Tab"
+
+#: ../src/common/accelcmn.cpp:88
+msgctxt "keyboard key"
+msgid "KP_Enter"
+msgstr "Num_Eingabe"
+
+#: ../src/common/accelcmn.cpp:88
+msgctxt "keyboard key"
+msgid "Num Enter"
+msgstr "Num Eingabe"
+
+#: ../src/common/accelcmn.cpp:89
+msgctxt "keyboard key"
+msgid "KP_Home"
+msgstr "Num_Pos1"
+
+#: ../src/common/accelcmn.cpp:89
+msgctxt "keyboard key"
+msgid "Num Home"
+msgstr "Num Pos1"
+
+#: ../src/common/accelcmn.cpp:90
+msgctxt "keyboard key"
+msgid "KP_Left"
+msgstr "Num_Links"
+
+#: ../src/common/accelcmn.cpp:90
+msgctxt "keyboard key"
+msgid "Num left"
+msgstr "Num Links"
+
+#: ../src/common/accelcmn.cpp:91
+msgctxt "keyboard key"
+msgid "KP_Up"
+msgstr "Num_Hoch"
+
+#: ../src/common/accelcmn.cpp:91
+msgctxt "keyboard key"
+msgid "Num Up"
+msgstr "Num Hoch"
+
+#: ../src/common/accelcmn.cpp:92
+msgctxt "keyboard key"
+msgid "KP_Right"
+msgstr "Num_Rechts"
+
+#: ../src/common/accelcmn.cpp:92
+msgctxt "keyboard key"
+msgid "Num Right"
+msgstr "Num Rechts"
+
+#: ../src/common/accelcmn.cpp:93
+msgctxt "keyboard key"
+msgid "KP_Down"
+msgstr "Num_Runter"
+
+#: ../src/common/accelcmn.cpp:93
+msgctxt "keyboard key"
+msgid "Num Down"
+msgstr "Num Runter"
+
+#: ../src/common/accelcmn.cpp:94
+msgctxt "keyboard key"
+msgid "KP_PageUp"
+msgstr "Num_Bild↑"
+
+#: ../src/common/accelcmn.cpp:94
+msgctxt "keyboard key"
+msgid "Num Page Up"
+msgstr "Num Bild↑"
+
+#: ../src/common/accelcmn.cpp:95
+msgctxt "keyboard key"
+msgid "KP_PageDown"
+msgstr "Num_Bild↓"
+
+#: ../src/common/accelcmn.cpp:95
+msgctxt "keyboard key"
+msgid "Num Page Down"
+msgstr "Num Bild↓"
+
+#: ../src/common/accelcmn.cpp:96
+msgctxt "keyboard key"
+msgid "KP_Prior"
+msgstr "Num_Voriger"
+
+#: ../src/common/accelcmn.cpp:97
+msgctxt "keyboard key"
+msgid "KP_Next"
+msgstr "Num_Nächster"
+
+#: ../src/common/accelcmn.cpp:98
+msgctxt "keyboard key"
+msgid "KP_End"
+msgstr "Num_Ende"
+
+#: ../src/common/accelcmn.cpp:98
+msgctxt "keyboard key"
+msgid "Num End"
+msgstr "Num Ende"
+
+#: ../src/common/accelcmn.cpp:99
+msgctxt "keyboard key"
+msgid "KP_Begin"
+msgstr "Num_Anfang"
+
+#: ../src/common/accelcmn.cpp:99
+msgctxt "keyboard key"
+msgid "Num Begin"
+msgstr "Num Anfang"
+
+#: ../src/common/accelcmn.cpp:100
+msgctxt "keyboard key"
+msgid "KP_Insert"
+msgstr "Num_Einfg"
+
+#: ../src/common/accelcmn.cpp:100
+msgctxt "keyboard key"
+msgid "Num Insert"
+msgstr "Num Einfg"
+
+#: ../src/common/accelcmn.cpp:101
+msgctxt "keyboard key"
+msgid "KP_Delete"
+msgstr "Num_Entf"
+
+#: ../src/common/accelcmn.cpp:101
+msgctxt "keyboard key"
+msgid "Num Delete"
+msgstr "Num Löschen"
+
+#: ../src/common/accelcmn.cpp:102
+msgctxt "keyboard key"
+msgid "KP_Equal"
+msgstr "Num_Gleich"
+
+#: ../src/common/accelcmn.cpp:102
+msgctxt "keyboard key"
+msgid "Num ="
+msgstr "Num ="
+
+#: ../src/common/accelcmn.cpp:103
+msgctxt "keyboard key"
+msgid "KP_Multiply"
+msgstr "Num_Mal"
+
+# Ggf. auch Num ×, je nach Tastatur
+#: ../src/common/accelcmn.cpp:103
+msgctxt "keyboard key"
+msgid "Num *"
+msgstr "Num *"
+
+#: ../src/common/accelcmn.cpp:104
+msgctxt "keyboard key"
+msgid "KP_Add"
+msgstr "Num_Plus"
+
+#: ../src/common/accelcmn.cpp:104
+msgctxt "keyboard key"
+msgid "Num +"
+msgstr "Num +"
+
+#: ../src/common/accelcmn.cpp:105
+msgctxt "keyboard key"
+msgid "KP_Separator"
+msgstr "Num_Trennzeichen"
+
+#: ../src/common/accelcmn.cpp:105
+msgctxt "keyboard key"
+msgid "Num ,"
+msgstr "Num ,"
+
+#: ../src/common/accelcmn.cpp:106
+msgctxt "keyboard key"
+msgid "KP_Subtract"
+msgstr "Num_Minus"
+
+#: ../src/common/accelcmn.cpp:106
+msgctxt "keyboard key"
+msgid "Num -"
+msgstr "Num -"
+
+#: ../src/common/accelcmn.cpp:107
+msgctxt "keyboard key"
+msgid "KP_Decimal"
+msgstr "Num_Dezimal"
+
+#: ../src/common/accelcmn.cpp:107
+msgctxt "keyboard key"
+msgid "Num ."
+msgstr "Num ."
+
+#: ../src/common/accelcmn.cpp:108
+msgctxt "keyboard key"
+msgid "KP_Divide"
+msgstr "Num_Division"
+
+# Ggf. auch Num %, je nach Tastatur
+#: ../src/common/accelcmn.cpp:108
+msgctxt "keyboard key"
+msgid "Num /"
+msgstr "Num /"
+
+#: ../src/common/accelcmn.cpp:109
+msgctxt "keyboard key"
+msgid "Windows_Left"
+msgstr "Windows_Links"
+
+#: ../src/common/accelcmn.cpp:110
+msgctxt "keyboard key"
+msgid "Windows_Right"
+msgstr "Windows_Rechts"
+
+#: ../src/common/accelcmn.cpp:111
+msgctxt "keyboard key"
+msgid "Windows_Menu"
+msgstr "Windows_Menü"
+
+#: ../src/common/accelcmn.cpp:112
+msgctxt "keyboard key"
+msgid "Command"
+msgstr "Befehlstaste"
+
+#: ../src/common/accelcmn.cpp:186 ../src/common/accelcmn.cpp:359
+msgctxt "keyboard key"
+msgid "Ctrl"
+msgstr "Strg"
+
+#: ../src/common/accelcmn.cpp:188 ../src/common/accelcmn.cpp:363
+msgctxt "keyboard key"
+msgid "Alt"
+msgstr "Alt"
+
+#: ../src/common/accelcmn.cpp:190 ../src/common/accelcmn.cpp:361
+msgctxt "keyboard key"
+msgid "Shift"
+msgstr "Umschalt"
+
+#: ../src/common/accelcmn.cpp:196
+msgctxt "keyboard key"
+msgid "num "
+msgstr "Num "
+
+#: ../src/common/accelcmn.cpp:260 ../src/common/accelcmn.cpp:382
+msgctxt "keyboard key"
+msgid "F"
+msgstr "F"
+
+#: ../src/common/accelcmn.cpp:277 ../src/common/accelcmn.cpp:385
+msgctxt "keyboard key"
+msgid "KP_F"
+msgstr "KP_F"
+
+#: ../src/common/accelcmn.cpp:280 ../src/common/accelcmn.cpp:388
+msgctxt "keyboard key"
+msgid "KP_"
+msgstr "Num_"
+
+#: ../src/common/accelcmn.cpp:283 ../src/common/accelcmn.cpp:391
+msgctxt "keyboard key"
+msgid "SPECIAL"
+msgstr "SPEZIAL"
+
+#: ../src/common/accelcmn.cpp:373
+msgid "Ctrl"
+msgstr "Strg"
+
+#: ../src/common/appbase.cpp:786
+msgid "show this help message"
+msgstr "Zeige diesen Hilfstext"
+
+#: ../src/common/appbase.cpp:796
+msgid "generate verbose log messages"
+msgstr "ausführliche Log-Nachrichten erstellen"
+
+#: ../src/common/appcmn.cpp:256
+msgid "specify the theme to use"
+msgstr "geben Sie das zu benutzende Thema an"
+
+#: ../src/common/appcmn.cpp:270
+msgid "specify display mode to use (e.g. 640x480-16)"
+msgstr ""
+"Geben Sie eine zu verwendende Bildschirmauflösung ein (z. B. 640x480-16)"
+
+#: ../src/common/appcmn.cpp:292
+#, c-format
+msgid "Unsupported theme '%s'."
+msgstr "Unbekanntes Thema „%s“."
+
+#: ../src/common/appcmn.cpp:309
+#, c-format
+msgid "Invalid display mode specification '%s'."
+msgstr "Ungültige Angabe „%s“ des Displays."
+
+#: ../src/common/cmdline.cpp:875
+#, c-format
+msgid "Option '%s' can't be negated"
+msgstr "Option „%s“ konnte nicht negiert werden"
+
+#: ../src/common/cmdline.cpp:889
+#, c-format
+msgid "Unknown long option '%s'"
+msgstr "Unbekannte „long“-Option „%s“"
+
+#: ../src/common/cmdline.cpp:904 ../src/common/cmdline.cpp:926
+#, c-format
+msgid "Unknown option '%s'"
+msgstr "Unbekannte Option „%s“"
+
+#: ../src/common/cmdline.cpp:1004
+#, c-format
+msgid "Unexpected characters following option '%s'."
+msgstr "Unerwartete Zeichen folgen der Option „%s“."
+
+#: ../src/common/cmdline.cpp:1039
+#, c-format
+msgid "Option '%s' requires a value."
+msgstr "Option „%s“ erwartet einen Wert."
+
+#: ../src/common/cmdline.cpp:1058
+#, c-format
+msgid "Separator expected after the option '%s'."
+msgstr "Trennungszeichen nach der Option „%s“ erwartet."
+
+#: ../src/common/cmdline.cpp:1088 ../src/common/cmdline.cpp:1106
+#, c-format
+msgid "'%s' is not a correct numeric value for option '%s'."
+msgstr "„%s“ ist kein gültiger numerischer Wert für Option „%s“."
+
+#: ../src/common/cmdline.cpp:1122
+#, c-format
+msgid "Option '%s': '%s' cannot be converted to a date."
+msgstr "Option „%s“: „%s“ kann nicht in ein Datum umgewandelt werden."
+
+#: ../src/common/cmdline.cpp:1170
+#, c-format
+msgid "Unexpected parameter '%s'"
+msgstr "Unerwarteter Parameter „%s“"
+
+#. TRANSLATORS: Short name and long name for a command line option
+#: ../src/common/cmdline.cpp:1197
+#, c-format
+msgid "%s (or %s)"
+msgstr "%s (oder %s)"
+
+#: ../src/common/cmdline.cpp:1208
+#, c-format
+msgid "The value for the option '%s' must be specified."
+msgstr "Der Wert für die Option „%s“ muss angegeben werden."
+
+#: ../src/common/cmdline.cpp:1230
+#, c-format
+msgid "The required parameter '%s' was not specified."
+msgstr "Der benötigte Parameter „%s“ wurde nicht angegeben."
+
+#: ../src/common/cmdline.cpp:1289
+#, c-format
+msgid "Usage: %s"
+msgstr "Verwendung: %s"
+
+#: ../src/common/cmdline.cpp:1498
+msgid "str"
+msgstr "str"
+
+#: ../src/common/cmdline.cpp:1502
+msgid "num"
+msgstr "num"
+
+#: ../src/common/cmdline.cpp:1506
+msgid "double"
+msgstr "Doppelte Genauigkeit"
+
+#: ../src/common/cmdline.cpp:1510
+msgid "date"
+msgstr "Datum"
+
+#: ../src/common/cmdproc.cpp:250 ../src/common/cmdproc.cpp:276
+#: ../src/common/cmdproc.cpp:296
+msgid "Unnamed command"
+msgstr "Unbenanntes Kommando"
+
+#: ../src/common/cmdproc.cpp:253
+msgid "&Undo "
+msgstr "&Rückgängig "
+
+#: ../src/common/cmdproc.cpp:255
+msgid "Can't &Undo "
+msgstr "K&ann nicht rückgängig machen "
+
+#: ../src/common/cmdproc.cpp:259 ../src/common/stockitem.cpp:208
+#: ../src/msw/textctrl.cpp:2880 ../src/osx/textctrl_osx.cpp:649
+#: ../src/richtext/richtextctrl.cpp:327
+msgid "&Undo"
+msgstr "&Rückgängig"
+
+#: ../src/common/cmdproc.cpp:277 ../src/common/cmdproc.cpp:297
+msgid "&Redo "
+msgstr "&Wiederholen "
+
+#: ../src/common/cmdproc.cpp:281 ../src/common/cmdproc.cpp:288
+#: ../src/common/stockitem.cpp:190 ../src/msw/textctrl.cpp:2881
+#: ../src/osx/textctrl_osx.cpp:650 ../src/richtext/richtextctrl.cpp:328
+msgid "&Redo"
+msgstr "&Wiederholen"
+
+#: ../src/common/colourcmn.cpp:41
+#, c-format
+msgid "String To Colour : Incorrect colour specification : %s"
+msgstr "String To Colour: Falsche Farbangabe „%s“"
+
+#: ../src/common/config.cpp:259
+#, c-format
+msgid "Invalid value %ld for a boolean key \"%s\" in config file."
+msgstr ""
+"Ungültiger Wert %ld für einen booleschen Schlüssel „%s“ in der "
+"Konfigurationsdatei."
+
+#: ../src/common/config.cpp:526
+#, c-format
+msgid ""
+"Environment variables expansion failed: missing '%c' at position %u in '%s'."
+msgstr ""
+"Auswerten der Umgebungsvariablen schlug fehl. Es fehlt „%c“ an Position %u "
+"in „%s“."
+
+#: ../src/common/config.cpp:576 ../src/msw/regconf.cpp:272
+#, c-format
+msgid "'%s' has extra '..', ignored."
+msgstr "„%s“ hat extra „..“, ignoriert."
+
+#. TRANSLATORS: Checkbox state name
+#: ../src/common/datavcmn.cpp:2166 ../src/generic/datavgen.cpp:1430
+msgid "checked"
+msgstr "ausgewählt"
+
+#. TRANSLATORS: Checkbox state name
+#: ../src/common/datavcmn.cpp:2170 ../src/generic/datavgen.cpp:1432
+msgid "unchecked"
+msgstr "nicht ausgewählt"
+
+#. TRANSLATORS: Checkbox state name
+#: ../src/common/datavcmn.cpp:2174
+msgid "undetermined"
+msgstr "untentschieden"
+
+#: ../src/common/datetimefmt.cpp:1875
+msgid "today"
+msgstr "heute"
+
+#: ../src/common/datetimefmt.cpp:1876
+msgid "yesterday"
+msgstr "Gestern"
+
+#: ../src/common/datetimefmt.cpp:1877
+msgid "tomorrow"
+msgstr "morgen"
+
+#: ../src/common/datetimefmt.cpp:2071
+msgid "first"
+msgstr "erste"
+
+#: ../src/common/datetimefmt.cpp:2072
+msgid "second"
+msgstr "zweite"
+
+#: ../src/common/datetimefmt.cpp:2073
+msgid "third"
+msgstr "dritte"
+
+#: ../src/common/datetimefmt.cpp:2074
+msgid "fourth"
+msgstr "vierte"
+
+#: ../src/common/datetimefmt.cpp:2075
+msgid "fifth"
+msgstr "fünfte"
+
+#: ../src/common/datetimefmt.cpp:2076
+msgid "sixth"
+msgstr "sechste"
+
+#: ../src/common/datetimefmt.cpp:2077
+msgid "seventh"
+msgstr "siebte"
+
+#: ../src/common/datetimefmt.cpp:2078
+msgid "eighth"
+msgstr "achte"
+
+#: ../src/common/datetimefmt.cpp:2079
+msgid "ninth"
+msgstr "neunte"
+
+#: ../src/common/datetimefmt.cpp:2080
+msgid "tenth"
+msgstr "zehnte"
+
+#: ../src/common/datetimefmt.cpp:2081
+msgid "eleventh"
+msgstr "elfte"
+
+#: ../src/common/datetimefmt.cpp:2082
+msgid "twelfth"
+msgstr "zwölfte"
+
+#: ../src/common/datetimefmt.cpp:2083
+msgid "thirteenth"
+msgstr "dreizehnte"
+
+#: ../src/common/datetimefmt.cpp:2084
+msgid "fourteenth"
+msgstr "vierzehnte"
+
+#: ../src/common/datetimefmt.cpp:2085
+msgid "fifteenth"
+msgstr "fünfzehnte"
+
+#: ../src/common/datetimefmt.cpp:2086
+msgid "sixteenth"
+msgstr "sechzehnte"
+
+#: ../src/common/datetimefmt.cpp:2087
+msgid "seventeenth"
+msgstr "siebzehnte"
+
+#: ../src/common/datetimefmt.cpp:2088
+msgid "eighteenth"
+msgstr "achtzehnte"
+
+#: ../src/common/datetimefmt.cpp:2089
+msgid "nineteenth"
+msgstr "neunzehnte"
+
+#: ../src/common/datetimefmt.cpp:2090
+msgid "twentieth"
+msgstr "zwanzigste"
+
+#: ../src/common/datetimefmt.cpp:2248
+msgid "noon"
+msgstr "mittags"
+
+#: ../src/common/datetimefmt.cpp:2249
+msgid "midnight"
+msgstr "Mitternacht"
+
+#: ../src/common/debugrpt.cpp:209
+#, c-format
+msgid "Failed to create directory \"%s\""
+msgstr "Konnte das Verzeichnis „%s“ nicht erstellen."
+
+#: ../src/common/debugrpt.cpp:210
+msgid "Debug report couldn't be created."
+msgstr "Fehlerbericht konnte nicht erstellt werden."
+
+#: ../src/common/debugrpt.cpp:227
+#, c-format
+msgid "Failed to remove debug report file \"%s\""
+msgstr "Konnte Fehlerberichtsdatei „%s“ nicht entfernen."
+
+#: ../src/common/debugrpt.cpp:239
+#, c-format
+msgid "Failed to clean up debug report directory \"%s\""
+msgstr "Konnte Fehlerberichtsverzeichnis „%s“ nicht aufräumen."
+
+#: ../src/common/debugrpt.cpp:514
+msgid "process context description"
+msgstr "Bearbeite Kontextbeschreibung"
+
+#: ../src/common/debugrpt.cpp:538
+msgid "dump of the process state (binary)"
+msgstr "Dump des bearbeiteten Zustands (binär)"
+
+#: ../src/common/debugrpt.cpp:553
+msgid "Debug report generation has failed."
+msgstr "Das Erstellen des Fehlerberichts ist fehlgeschlagen."
+
+#: ../src/common/debugrpt.cpp:560
+#, c-format
+msgid ""
+"Processing debug report has failed, leaving the files in \"%s\" directory."
+msgstr ""
+"Bearbeitung des Fehlerberichts fehlgeschlagen, belasse die Dateien im Ordner "
+"„%s“."
+
+#: ../src/common/debugrpt.cpp:573
+msgid "A debug report has been generated. It can be found in"
+msgstr "Ein Fehlerbericht wurde erstellt. Er liegt im Verzeichnis"
+
+#: ../src/common/debugrpt.cpp:576
+msgid "And includes the following files:\n"
+msgstr "Und enthält die folgenden Dateien:\n"
+
+#: ../src/common/debugrpt.cpp:586
+msgid ""
+"\n"
+"Please send this report to the program maintainer, thank you!\n"
+msgstr ""
+"\n"
+"Bitte senden Sie diesen Bericht an den Programmautor. Vielen Dank!\n"
+
+#: ../src/common/debugrpt.cpp:729
+msgid "Failed to execute curl, please install it in PATH."
+msgstr "Konnte curl nicht starten, bitte im PATH installieren."
+
+#: ../src/common/debugrpt.cpp:742
+#, c-format
+msgid "Failed to upload the debug report (error code %d)."
+msgstr "Konnte den Fehlerbericht nicht hochladen (Fehlercode %d)."
+
+#: ../src/common/docview.cpp:366
+msgid "Save As"
+msgstr "Speichern unter"
+
+#: ../src/common/docview.cpp:457
+msgid "Discard changes and reload the last saved version?"
+msgstr "Änderungen verwerfen und letzte gesicherte Version laden?"
+
+#: ../src/common/docview.cpp:488
+msgid "unnamed"
+msgstr "Unbenannt"
+
+#: ../src/common/docview.cpp:513
+#, c-format
+msgid "Do you want to save changes to %s?"
+msgstr "Möchten Sie die Änderungen nach %s speichern?"
+
+#: ../src/common/docview.cpp:521 ../src/common/docview.cpp:560
+#: ../src/common/stockitem.cpp:195
+msgid "&Save"
+msgstr "&Speichern"
+
+#: ../src/common/docview.cpp:522 ../src/common/docview.cpp:560
+msgid "&Discard changes"
+msgstr "Änderungen &verwerfen"
+
+#: ../src/common/docview.cpp:523
+msgid "Do&n't close"
+msgstr "Nicht schließe&n"
+
+#: ../src/common/docview.cpp:553
+#, c-format
+msgid "Do you want to save changes to %s before closing it?"
+msgstr "Möchten Sie die Änderungen vor dem Schließen nach %s speichern?"
+
+#: ../src/common/docview.cpp:559
+msgid "The document must be closed."
+msgstr "Das Dokument muss geschlossen werden."
+
+#: ../src/common/docview.cpp:571
+#, c-format
+msgid "Saving %s failed, would you like to retry?"
+msgstr "Speichern %s fehlgeschlagen, wollen Sie es erneut versuchen?"
+
+#: ../src/common/docview.cpp:577
+msgid "Retry"
+msgstr "Erneut versuchen"
+
+#: ../src/common/docview.cpp:577
+msgid "Discard changes"
+msgstr "Änderungen verwerfen"
+
+#: ../src/common/docview.cpp:679
+#, c-format
+msgid "File \"%s\" could not be opened for writing."
+msgstr "Die Datei „%s“ konnte nicht zum Schreiben geöffnet werden."
+
+#: ../src/common/docview.cpp:685
+#, c-format
+msgid "Failed to save document to the file \"%s\"."
+msgstr "Das Dokument konnte nicht in die Datei „%s“ gesichert werden."
+
+#: ../src/common/docview.cpp:702
+#, c-format
+msgid "File \"%s\" could not be opened for reading."
+msgstr "Die Datei „%s“ konnte nicht zum Lesen geöffnet werden."
+
+#: ../src/common/docview.cpp:714
+#, c-format
+msgid "Failed to read document from the file \"%s\"."
+msgstr "Konnte Dokument aus der Datei „%s“ nicht lesen."
+
+#: ../src/common/docview.cpp:1236
+#, c-format
+msgid ""
+"The file '%s' doesn't exist and couldn't be opened.\n"
+"It has been removed from the most recently used files list."
+msgstr ""
+"Die Datei „%s“ existiert nicht und konnte nicht geöffnet werden.\n"
+"Sie wurde aus der Liste kürzlich verwendeter Dateien entfernt."
+
+#: ../src/common/docview.cpp:1296
+msgid "Print preview creation failed."
+msgstr "Erzeugung der Druckvorschau fehlgeschlagen."
+
+#: ../src/common/docview.cpp:1302
+msgid "Print Preview"
+msgstr "Druckvorschau"
+
+#: ../src/common/docview.cpp:1517
+#, c-format
+msgid "The format of file '%s' couldn't be determined."
+msgstr "Das Format der Datei „%s“ konnte nicht bestimmt werden."
+
+#: ../src/common/docview.cpp:1643
+#, c-format
+msgid "unnamed%d"
+msgstr "Unbenannt%d"
+
+#: ../src/common/docview.cpp:1660
+msgid " - "
+msgstr " - "
+
+#: ../src/common/docview.cpp:1791 ../src/common/docview.cpp:1844
+msgid "Open File"
+msgstr "Datei öffnen"
+
+#: ../src/common/docview.cpp:1807
+msgid "File error"
+msgstr "Dateifehler"
+
+#: ../src/common/docview.cpp:1809
+msgid "Sorry, could not open this file."
+msgstr "Datei konnte nicht geöffnet werden."
+
+#: ../src/common/docview.cpp:1843
+msgid "Sorry, the format for this file is unknown."
+msgstr "Unbekanntes Dateiformat."
+
+#: ../src/common/docview.cpp:1924
+msgid "Select a document template"
+msgstr "Dokument-Vorlage wählen"
+
+#: ../src/common/docview.cpp:1925
+msgid "Templates"
+msgstr "Vorlagen"
+
+#: ../src/common/docview.cpp:1998
+msgid "Select a document view"
+msgstr "Dokument-Anzeige („View“) wählen"
+
+#: ../src/common/docview.cpp:1999
+msgid "Views"
+msgstr "Darstellung"
+
+#: ../src/common/dynlib.cpp:81
+#, c-format
+msgid "Failed to load shared library '%s'"
+msgstr "Laden der dynamischen Bibliothek „%s“ fehlgeschlagen"
+
+#: ../src/common/dynlib.cpp:105
+#, c-format
+msgid "Couldn't find symbol '%s' in a dynamic library"
+msgstr "Kann Symbol „%s“ in der dynamischen Bibliothek nicht finden"
+
+#: ../src/common/ffile.cpp:56 ../src/common/file.cpp:215
+#, c-format
+msgid "can't open file '%s'"
+msgstr "Kann Datei „%s“ nicht öffnen"
+
+#: ../src/common/ffile.cpp:72
+#, c-format
+msgid "can't close file '%s'"
+msgstr "Kann Datei „%s“ nicht schließen"
+
+#: ../src/common/ffile.cpp:106 ../src/common/ffile.cpp:131
+#, c-format
+msgid "Read error on file '%s'"
+msgstr "Lesefehler in Datei „%s“"
+
+#: ../src/common/ffile.cpp:148
+#, c-format
+msgid "Write error on file '%s'"
+msgstr "Schreibfehler bei Datei „%s“"
+
+#: ../src/common/ffile.cpp:182
+#, c-format
+msgid "failed to flush the file '%s'"
+msgstr "Versuch, die Datei „%s“ zu entladen, fehlgeschlagen"
+
+#: ../src/common/ffile.cpp:222
+#, c-format
+msgid "Seek error on file '%s' (large files not supported by stdio)"
+msgstr ""
+"Positionierungsfehler bei Datei „%s“ (große Dateien werden nicht von stdio "
+"unterstützt)."
+
+#: ../src/common/ffile.cpp:232
+#, c-format
+msgid "Seek error on file '%s'"
+msgstr "Suchfehler in Datei „%s“"
+
+#: ../src/common/ffile.cpp:248
+#, c-format
+msgid "Can't find current position in file '%s'"
+msgstr "Kann aktuelle Position in Datei „%s“ nicht finden."
+
+#: ../src/common/ffile.cpp:349 ../src/common/file.cpp:569
+msgid "Failed to set temporary file permissions"
+msgstr "Konnte die Zugriffsrechte der temporären Datei nicht setzen"
+
+#: ../src/common/ffile.cpp:371
+#, c-format
+msgid "can't remove file '%s'"
+msgstr "Kann Datei „%s“ nicht löschen"
+
+#: ../src/common/ffile.cpp:376 ../src/common/file.cpp:591
+#, c-format
+msgid "can't commit changes to file '%s'"
+msgstr "Kann Änderungen in Datei „%s“ nicht sichern"
+
+#: ../src/common/ffile.cpp:388 ../src/common/file.cpp:603
+#, c-format
+msgid "can't remove temporary file '%s'"
+msgstr "Kann temporäre Datei „%s“ nicht löschen"
+
+#: ../src/common/file.cpp:162
+#, c-format
+msgid "can't create file '%s'"
+msgstr "Kann Datei „%s“ nicht anlegen"
+
+#: ../src/common/file.cpp:229
+#, c-format
+msgid "can't close file descriptor %d"
+msgstr "Kann Dateibeschreibung „%d“ nicht schließen"
+
+#: ../src/common/file.cpp:332
+#, c-format
+msgid "can't read from file descriptor %d"
+msgstr "Kann Dateibeschreibung „%d“ nicht lesen"
+
+#: ../src/common/file.cpp:351
+#, c-format
+msgid "can't write to file descriptor %d"
+msgstr "Kann auf Dateibeschreibung „%d“ nicht schreiben"
+
+#: ../src/common/file.cpp:390
+#, c-format
+msgid "can't flush file descriptor %d"
+msgstr "Kann auf die Dateibeschreibung „%d“ nicht entladen"
+
+#: ../src/common/file.cpp:432
+#, c-format
+msgid "can't seek on file descriptor %d"
+msgstr "Kann auf der Dateibeschreibung „%d“ nicht suchen"
+
+#: ../src/common/file.cpp:446
+#, c-format
+msgid "can't get seek position on file descriptor %d"
+msgstr "Kann auf die Dateibeschreibung %d nicht positionieren"
+
+#: ../src/common/file.cpp:475
+#, c-format
+msgid "can't find length of file on file descriptor %d"
+msgstr "Kann auf Dateibeschreibung „%d“ die Dateilänge nicht finden"
+
+#: ../src/common/file.cpp:505
+#, c-format
+msgid "can't determine if the end of file is reached on descriptor %d"
+msgstr ""
+"Auf Dateibeschreibung „%d“ kann nicht festgestellt werden, ob das Dateiende "
+"erreicht ist"
+
+#: ../src/common/fileconf.cpp:352
+#, c-format
+msgid ""
+" and additionally, the existing configuration file was renamed to \"%s\" and "
+"couldn't be renamed back, please rename it to its original path \"%s\""
+msgstr ""
+" und zusätzlich, die existierende Konfigurationsdatei wurde nach \"%s\" "
+"umbenannt und konnte nicht zurück umbenannt werden, bitte zum ursprünglichen "
+"Pfad umbenennen \"%s\""
+
+#: ../src/common/fileconf.cpp:389
+msgid " due to the following error:\n"
+msgstr " aufgrund des folgenden Fehlers:\n"
+
+#: ../src/common/fileconf.cpp:412
+msgid "failed to rename the existing file"
+msgstr "Konnte die existierende Datei nicht umbenennen"
+
+#: ../src/common/fileconf.cpp:421
+msgid "failed to create the new file directory"
+msgstr "Konnte Dateiverzeichnis nicht erstellen"
+
+#: ../src/common/fileconf.cpp:428
+msgid "failed to move the file to the new location"
+msgstr "Das Verschieben der Datei zum neuen Ort ist fehlgeschlagen"
+
+#: ../src/common/fileconf.cpp:462
+#, c-format
+msgid "can't open global configuration file '%s'."
+msgstr "Kann globale Konfigurationsdatei „%s“ nicht öffnen."
+
+#: ../src/common/fileconf.cpp:478
+#, c-format
+msgid "can't open user configuration file '%s'."
+msgstr "Kann Konfigurationsdatei „%s“ nicht öffnen."
+
+#: ../src/common/fileconf.cpp:483
+#, c-format
+msgid "Changes won't be saved to avoid overwriting the existing file \"%s\""
+msgstr ""
+"Änderungen werden nicht gesichert um das Überschreiben der vorhandenen Datei "
+"„%s“ zu vermeiden."
+
+#: ../src/common/fileconf.cpp:583
+msgid "Error reading config options."
+msgstr "Fehler beim Parsen der Optionen."
+
+#: ../src/common/fileconf.cpp:593
+msgid "Failed to read config options."
+msgstr "Lesen der Konfigurationsoptionen fehlgeschlagen."
+
+#: ../src/common/fileconf.cpp:700
+#, c-format
+msgid "file '%s': unexpected character %c at line %zu."
+msgstr "Datei „%s“: unerwartetes Zeichen %c in Zeile %zu."
+
+#: ../src/common/fileconf.cpp:736
+#, c-format
+msgid "file '%s', line %zu: '%s' ignored after group header."
+msgstr "Datei „%s“, Zeile %zu: „%s“ hinter Gruppenkopf ignoriert."
+
+#: ../src/common/fileconf.cpp:765
+#, c-format
+msgid "file '%s', line %zu: '=' expected."
+msgstr "Datei „%s“, Zeile %zu: „=“ erwartet."
+
+#: ../src/common/fileconf.cpp:778
+#, c-format
+msgid "file '%s', line %zu: value for immutable key '%s' ignored."
+msgstr ""
+"Datei „%s“, Zeile %zu: Wert für nicht-änderbaren Eintrag „%s“ ignoriert."
+
+#: ../src/common/fileconf.cpp:788
+#, c-format
+msgid "file '%s', line %zu: key '%s' was first found at line %d."
+msgstr "Datei „%s“, Zeile %zu: Eintrag „%s“ taucht erstmals in Zeile %d auf."
+
+#: ../src/common/fileconf.cpp:1091
+#, c-format
+msgid "Config entry name cannot start with '%c'."
+msgstr ""
+"Die Bezeichnung des Konfigurations-Eintrags kann nicht mit „%c“ beginnen."
+
+#: ../src/common/fileconf.cpp:1146
+msgid "Failed to create configuration file directory."
+msgstr "Erzeugung des Konfigurationsdateiverzeichnisses fehlgeschlagen."
+
+#: ../src/common/fileconf.cpp:1158
+msgid "can't open user configuration file."
+msgstr "Kann Benutzer-Konfigurationsdatei nicht öffnen."
+
+#: ../src/common/fileconf.cpp:1172
+msgid "can't write user configuration file."
+msgstr "Kann Benutzer-Konfigurationsdatei nicht schreiben."
+
+#: ../src/common/fileconf.cpp:1178
+msgid "Failed to update user configuration file."
+msgstr "Kann Benutzer-Konfigurationsdatei nicht aktualisieren."
+
+#: ../src/common/fileconf.cpp:1201
+msgid "Error saving user configuration data."
+msgstr "Fehler beim Speichern der Benutzer-Optionen."
+
+#: ../src/common/fileconf.cpp:1313
+#, c-format
+msgid "can't delete user configuration file '%s'"
+msgstr "Kann Konfigurationsdatei „%s“ nicht löschen"
+
+#: ../src/common/fileconf.cpp:2007
+#, c-format
+msgid "entry '%s' appears more than once in group '%s'"
+msgstr "Eintrag „%s“ erscheint in Gruppe „%s“ mehrfach"
+
+#: ../src/common/fileconf.cpp:2021
+#, c-format
+msgid "attempt to change immutable key '%s' ignored."
+msgstr ""
+"Versuch den unveränderlichen Schlüssel „%s“ anzupassen wurde ignoriert."
+
+#: ../src/common/fileconf.cpp:2118
+#, c-format
+msgid "trailing backslash ignored in '%s'"
+msgstr "Abschließenden Gegenschrägstrich in „%s“ ignoriert"
+
+#: ../src/common/fileconf.cpp:2153
+#, c-format
+msgid "unexpected \" at position %d in '%s'."
+msgstr "unerwartetes \" an Position %d in „%s“."
+
+#: ../src/common/filefn.cpp:474
+#, c-format
+msgid "Failed to copy the file '%s' to '%s'"
+msgstr "Konnte die Datei „%s“ nicht nach „%s“ kopieren"
+
+#: ../src/common/filefn.cpp:487
+#, c-format
+msgid "Impossible to get permissions for file '%s'"
+msgstr "Konnte die Zugriffsrechte der Datei „%s“ nicht ermitteln"
+
+#: ../src/common/filefn.cpp:501
+#, c-format
+msgid "Impossible to overwrite the file '%s'"
+msgstr "Versuch die Datei „%s“ zu überschreiben, fehlgeschlagen"
+
+#: ../src/common/filefn.cpp:508
+#, c-format
+msgid "Error copying the file '%s' to '%s'."
+msgstr "Fehler beim Speichern der Datei „%s“ nach „%s“."
+
+#: ../src/common/filefn.cpp:556
+#, c-format
+msgid "Impossible to set permissions for the file '%s'"
+msgstr "Konnte die Zugriffsrechte für Datei „%s“ nicht setzen"
+
+#: ../src/common/filefn.cpp:606
+#, c-format
+msgid ""
+"Failed to rename the file '%s' to '%s' because the destination file already "
+"exists."
+msgstr ""
+"Umbenennen der Datei „%s“ nach „%s“ fehlgeschlagen, da die Zieldatei bereits "
+"existiert."
+
+#: ../src/common/filefn.cpp:623
+#, c-format
+msgid "File '%s' couldn't be renamed '%s'"
+msgstr "Die Datei „%s“ konnte nicht nach „%s“ umbenannt werden."
+
+#: ../src/common/filefn.cpp:639
+#, c-format
+msgid "File '%s' couldn't be removed"
+msgstr "Die Datei „%s“ konnte nicht gelöscht werden"
+
+#: ../src/common/filefn.cpp:666
+#, c-format
+msgid "Directory '%s' couldn't be created"
+msgstr "Verzeichnis „%s“ konnte nicht angelegt werden"
+
+#: ../src/common/filefn.cpp:680
+#, c-format
+msgid "Directory '%s' couldn't be deleted"
+msgstr "Verzeichnis „%s“ konnte nicht gelöscht werden"
+
+#: ../src/common/filefn.cpp:714
+#, c-format
+msgid "Cannot enumerate files '%s'"
+msgstr "Kann Dateien „%s“ nicht auflisten"
+
+#: ../src/common/filefn.cpp:798
+msgid "Failed to get the working directory"
+msgstr "Konnte Arbeitsverzeichnis nicht ermitteln"
+
+#: ../src/common/filefn.cpp:843
+msgid "Could not set current working directory"
+msgstr "Konnte das Arbeitsverzeichnis nicht setzen"
+
+#: ../src/common/filefn.cpp:974
+#, c-format
+msgid "Files (%s)"
+msgstr "Dateien (%s)"
+
+#: ../src/common/filename.cpp:182
+#, c-format
+msgid "Failed to open '%s' for reading"
+msgstr "Konnte „%s“ nicht zum Lesen öffnen"
+
+#: ../src/common/filename.cpp:187
+#, c-format
+msgid "Failed to open '%s' for writing"
+msgstr "Konnte „%s“ nicht zum Schreiben öffnen"
+
+#: ../src/common/filename.cpp:199
+msgid "Failed to close file handle"
+msgstr "Konnte Datei-Handle nicht schließen"
+
+#: ../src/common/filename.cpp:1046
+msgid "Failed to create a temporary file name"
+msgstr "Konnte keinen temporären Dateinamen erstellen"
+
+#: ../src/common/filename.cpp:1081
+msgid "Failed to open temporary file."
+msgstr "Konnte temporäre Datei nicht öffnen."
+
+#: ../src/common/filename.cpp:2862
+#, c-format
+msgid "Failed to modify file times for '%s'"
+msgstr "Konnte Zugriffszeit von Datei „%s“ nicht ändern"
+
+#: ../src/common/filename.cpp:2877
+#, c-format
+msgid "Failed to touch the file '%s'"
+msgstr "Konnte die Datei „%s“ nicht „berühren“"
+
+#: ../src/common/filename.cpp:2958
+#, c-format
+msgid "Failed to retrieve file times for '%s'"
+msgstr "Konnte Zugriffszeit von Datei „%s“ nicht ermitteln"
+
+#: ../src/common/filepickercmn.cpp:39 ../src/common/filepickercmn.cpp:40
+msgid "Browse"
+msgstr "Durchsuchen"
+
+#: ../src/common/fldlgcmn.cpp:792 ../src/generic/filectrlg.cpp:1185
+#, c-format
+msgid "All files (%s)|%s"
+msgstr "Alle Dateien (%s)|%s"
+
+#. TRANSLATORS: %s are a file extension used to build a file wildcard string
+#: ../src/common/fldlgcmn.cpp:810
+#, c-format
+msgid "%s files (%s)|%s"
+msgstr "%s-Dateien (%s)|%s"
+
+#: ../src/common/fldlgcmn.cpp:1072
+#, c-format
+msgid "Load %s file"
+msgstr "%s-Datei laden"
+
+#: ../src/common/fldlgcmn.cpp:1074
+#, c-format
+msgid "Save %s file"
+msgstr "Datei %s speichern"
+
+#: ../src/common/fmapbase.cpp:144
+msgid "Western European (ISO-8859-1)"
+msgstr "Westeuropäisch (ISO-8859-1)"
+
+#: ../src/common/fmapbase.cpp:145
+msgid "Central European (ISO-8859-2)"
+msgstr "Zentraleuropäisch (ISO-8859-2)"
+
+#: ../src/common/fmapbase.cpp:146
+msgid "Esperanto (ISO-8859-3)"
+msgstr "Esperanto (ISO-8859-3)"
+
+#: ../src/common/fmapbase.cpp:147
+msgid "Baltic (old) (ISO-8859-4)"
+msgstr "Baltisch (alt) (ISO-8859-4)"
+
+#: ../src/common/fmapbase.cpp:148
+msgid "Cyrillic (ISO-8859-5)"
+msgstr "Kyrillisch (ISO-8859-5)"
+
+#: ../src/common/fmapbase.cpp:149
+msgid "Arabic (ISO-8859-6)"
+msgstr "Arabisch (ISO-8859-6)"
+
+#: ../src/common/fmapbase.cpp:150
+msgid "Greek (ISO-8859-7)"
+msgstr "Griechisch (ISO-8859-7)"
+
+#: ../src/common/fmapbase.cpp:151
+msgid "Hebrew (ISO-8859-8)"
+msgstr "Hebräisch (ISO-8859-8)"
+
+#: ../src/common/fmapbase.cpp:152
+msgid "Turkish (ISO-8859-9)"
+msgstr "Türkisch (ISO-8859-9)"
+
+#: ../src/common/fmapbase.cpp:153
+msgid "Nordic (ISO-8859-10)"
+msgstr "Nordisch (ISO-8859-10)"
+
+#: ../src/common/fmapbase.cpp:154
+msgid "Thai (ISO-8859-11)"
+msgstr "Thai (ISO-8859-11)"
+
+#: ../src/common/fmapbase.cpp:155
+msgid "Indian (ISO-8859-12)"
+msgstr "Indisch (ISO-8859-12)"
+
+#: ../src/common/fmapbase.cpp:156
+msgid "Baltic (ISO-8859-13)"
+msgstr "Baltisch (ISO-8859-13)"
+
+#: ../src/common/fmapbase.cpp:157
+msgid "Celtic (ISO-8859-14)"
+msgstr "Keltisch (ISO-8859-14)"
+
+#: ../src/common/fmapbase.cpp:158
+msgid "Western European with Euro (ISO-8859-15)"
+msgstr "Westeuropäisch mit Euro (ISO-8859-15)"
+
+#: ../src/common/fmapbase.cpp:159
+msgid "KOI8-R"
+msgstr "KOI8-R"
+
+#: ../src/common/fmapbase.cpp:160
+msgid "KOI8-U"
+msgstr "KOI8-U"
+
+#: ../src/common/fmapbase.cpp:161
+msgid "Windows/DOS OEM Cyrillic (CP 866)"
+msgstr "Windows/DOS OEM Kyrillisch (CP 866)"
+
+#: ../src/common/fmapbase.cpp:162
+msgid "Windows Thai (CP 874)"
+msgstr "Windows Thailändisch (CP 874)"
+
+#: ../src/common/fmapbase.cpp:163
+msgid "Windows Japanese (CP 932) or Shift-JIS"
+msgstr "Windows Japanisch (CP 932) oder Shift-JIS"
+
+#: ../src/common/fmapbase.cpp:164
+msgid "Windows Chinese Simplified (CP 936) or GB-2312"
+msgstr "Windows Vereinfachtes Chinesisch (CP 936) oder GB-2312"
+
+#: ../src/common/fmapbase.cpp:165
+msgid "Windows Korean (CP 949)"
+msgstr "Windows Koreanisch (CP 949)"
+
+#: ../src/common/fmapbase.cpp:166
+msgid "Windows Chinese Traditional (CP 950) or Big-5"
+msgstr "Windows Traditionelles Chinesisch (CP 950) oder Big-5"
+
+#: ../src/common/fmapbase.cpp:167
+msgid "Windows Central European (CP 1250)"
+msgstr "Windows Zentraleuropäisch (CP 1250)"
+
+#: ../src/common/fmapbase.cpp:168
+msgid "Windows Cyrillic (CP 1251)"
+msgstr "Windows Kyrillisch (CP 1251)"
+
+#: ../src/common/fmapbase.cpp:169
+msgid "Windows Western European (CP 1252)"
+msgstr "Windows Westeuropäisch (CP 1252)"
+
+#: ../src/common/fmapbase.cpp:170
+msgid "Windows Greek (CP 1253)"
+msgstr "Windows Griechisch (CP 1253)"
+
+#: ../src/common/fmapbase.cpp:171
+msgid "Windows Turkish (CP 1254)"
+msgstr "Windows Türkisch (CP 1254)"
+
+#: ../src/common/fmapbase.cpp:172
+msgid "Windows Hebrew (CP 1255)"
+msgstr "Windows Hebräisch (CP 1255)"
+
+#: ../src/common/fmapbase.cpp:173
+msgid "Windows Arabic (CP 1256)"
+msgstr "Windows Arabisch (CP 1256)"
+
+#: ../src/common/fmapbase.cpp:174
+msgid "Windows Baltic (CP 1257)"
+msgstr "Windows Baltisch (CP 1257)"
+
+#: ../src/common/fmapbase.cpp:175
+msgid "Windows Vietnamese (CP 1258)"
+msgstr "Windows Vietnamesisch (CP 1258)"
+
+#: ../src/common/fmapbase.cpp:176
+msgid "Windows Johab (CP 1361)"
+msgstr "Windows Johab (CP 1361)"
+
+#: ../src/common/fmapbase.cpp:177
+msgid "Windows/DOS OEM (CP 437)"
+msgstr "Windows/DOS OEM (CP 437)"
+
+#: ../src/common/fmapbase.cpp:178
+msgid "Unicode 7 bit (UTF-7)"
+msgstr "Unicode 7 Bit (UTF-7)"
+
+#: ../src/common/fmapbase.cpp:179
+msgid "Unicode 8 bit (UTF-8)"
+msgstr "Unicode 8 Bit (UTF-8)"
+
+#: ../src/common/fmapbase.cpp:181 ../src/common/fmapbase.cpp:187
+msgid "Unicode 16 bit (UTF-16)"
+msgstr "Unicode 16 Bit (UTF-16)"
+
+#: ../src/common/fmapbase.cpp:182
+msgid "Unicode 16 bit Little Endian (UTF-16LE)"
+msgstr "Unicode 16 Bit Little Endian (UTF-16LE)"
+
+#: ../src/common/fmapbase.cpp:183 ../src/common/fmapbase.cpp:189
+msgid "Unicode 32 bit (UTF-32)"
+msgstr "Unicode 32 Bit (UTF-32)"
+
+#: ../src/common/fmapbase.cpp:184
+msgid "Unicode 32 bit Little Endian (UTF-32LE)"
+msgstr "Unicode 32 Bit Little Endian (UTF-32LE)"
+
+#: ../src/common/fmapbase.cpp:186
+msgid "Unicode 16 bit Big Endian (UTF-16BE)"
+msgstr "Unicode 16 Bit Big Endian (UTF-16BE)"
+
+#: ../src/common/fmapbase.cpp:188
+msgid "Unicode 32 bit Big Endian (UTF-32BE)"
+msgstr "Unicode 32 Bit Big Endian (UTF-32BE)"
+
+#: ../src/common/fmapbase.cpp:191
+msgid "Extended Unix Codepage for Japanese (EUC-JP)"
+msgstr "Erweiterter Unix-Zeichensatz für Japanisch (EUC-JP)"
+
+#: ../src/common/fmapbase.cpp:192
+msgid "US-ASCII"
+msgstr "US-ASCII"
+
+#: ../src/common/fmapbase.cpp:193
+msgid "ISO-2022-JP"
+msgstr "ISO-2022-JP"
+
+#: ../src/common/fmapbase.cpp:195
+msgid "MacRoman"
+msgstr "MacRoman"
+
+#: ../src/common/fmapbase.cpp:196
+msgid "MacJapanese"
+msgstr "MacJapanese"
+
+#: ../src/common/fmapbase.cpp:197
+msgid "MacChineseTrad"
+msgstr "MacChineseTrad"
+
+#: ../src/common/fmapbase.cpp:198
+msgid "MacKorean"
+msgstr "MacKorean"
+
+#: ../src/common/fmapbase.cpp:199
+msgid "MacArabic"
+msgstr "MacArabic"
+
+#: ../src/common/fmapbase.cpp:200
+msgid "MacHebrew"
+msgstr "MacHebrew"
+
+#: ../src/common/fmapbase.cpp:201
+msgid "MacGreek"
+msgstr "MacGreek"
+
+#: ../src/common/fmapbase.cpp:202
+msgid "MacCyrillic"
+msgstr "MacCyrillic"
+
+#: ../src/common/fmapbase.cpp:203
+msgid "MacDevanagari"
+msgstr "MacDevanagari"
+
+#: ../src/common/fmapbase.cpp:204
+msgid "MacGurmukhi"
+msgstr "MacGurmukhi"
+
+#: ../src/common/fmapbase.cpp:205
+msgid "MacGujarati"
+msgstr "MacGujarati"
+
+#: ../src/common/fmapbase.cpp:206
+msgid "MacOriya"
+msgstr "MacOriya"
+
+#: ../src/common/fmapbase.cpp:207
+msgid "MacBengali"
+msgstr "MacBengali"
+
+#: ../src/common/fmapbase.cpp:208
+msgid "MacTamil"
+msgstr "MacTamil"
+
+#: ../src/common/fmapbase.cpp:209
+msgid "MacTelugu"
+msgstr "MacTelugu"
+
+#: ../src/common/fmapbase.cpp:210
+msgid "MacKannada"
+msgstr "MacKannada"
+
+#: ../src/common/fmapbase.cpp:211
+msgid "MacMalayalam"
+msgstr "MacMalayalam"
+
+#: ../src/common/fmapbase.cpp:212
+msgid "MacSinhalese"
+msgstr "MacSinhalese"
+
+#: ../src/common/fmapbase.cpp:213
+msgid "MacBurmese"
+msgstr "MacBurmese"
+
+#: ../src/common/fmapbase.cpp:214
+msgid "MacKhmer"
+msgstr "MacKhmer"
+
+#: ../src/common/fmapbase.cpp:215
+msgid "MacThai"
+msgstr "MacThai"
+
+#: ../src/common/fmapbase.cpp:216
+msgid "MacLaotian"
+msgstr "MacLaotian"
+
+#: ../src/common/fmapbase.cpp:217
+msgid "MacGeorgian"
+msgstr "MacGeorgian"
+
+#: ../src/common/fmapbase.cpp:218
+msgid "MacArmenian"
+msgstr "MacArmenian"
+
+#: ../src/common/fmapbase.cpp:219
+msgid "MacChineseSimp"
+msgstr "MacChineseSimp"
+
+#: ../src/common/fmapbase.cpp:220
+msgid "MacTibetan"
+msgstr "MacTibetan"
+
+#: ../src/common/fmapbase.cpp:221
+msgid "MacMongolian"
+msgstr "MacMongolian"
+
+#: ../src/common/fmapbase.cpp:222
+msgid "MacEthiopic"
+msgstr "MacEthiopic"
+
+#: ../src/common/fmapbase.cpp:223
+msgid "MacCentralEurRoman"
+msgstr "MacCentralEurRoman"
+
+#: ../src/common/fmapbase.cpp:224
+msgid "MacVietnamese"
+msgstr "MacVietnamese"
+
+#: ../src/common/fmapbase.cpp:225
+msgid "MacExtArabic"
+msgstr "MacExtArabic"
+
+#: ../src/common/fmapbase.cpp:226
+msgid "MacSymbol"
+msgstr "MacSymbol"
+
+#: ../src/common/fmapbase.cpp:227
+msgid "MacDingbats"
+msgstr "MacDingbats"
+
+#: ../src/common/fmapbase.cpp:228
+msgid "MacTurkish"
+msgstr "MacTurkish"
+
+#: ../src/common/fmapbase.cpp:229
+msgid "MacCroatian"
+msgstr "MacCroatian"
+
+#: ../src/common/fmapbase.cpp:230
+msgid "MacIcelandic"
+msgstr "MacIcelandic"
+
+#: ../src/common/fmapbase.cpp:231
+msgid "MacRomanian"
+msgstr "MacRomanian"
+
+#: ../src/common/fmapbase.cpp:232
+msgid "MacCeltic"
+msgstr "MacCeltic"
+
+#: ../src/common/fmapbase.cpp:233
+msgid "MacGaelic"
+msgstr "MacGaelic"
+
+#: ../src/common/fmapbase.cpp:234
+msgid "MacKeyboardGlyphs"
+msgstr "MacKeyboardGlyphs"
+
+#: ../src/common/fmapbase.cpp:791
+msgid "Default encoding"
+msgstr "Standardkodierung"
+
+#: ../src/common/fmapbase.cpp:805
+#, c-format
+msgid "Unknown encoding (%d)"
+msgstr "Unbekannte Kodierung (%d)"
+
+#: ../src/common/fmapbase.cpp:815 ../src/richtext/richtextstyles.cpp:776
+msgid "default"
+msgstr "Standard"
+
+#: ../src/common/fmapbase.cpp:829
+#, c-format
+msgid "unknown-%d"
+msgstr "unbekannt-%d"
+
+#: ../src/common/fontcmn.cpp:924 ../src/common/fontcmn.cpp:1130
+msgid "underlined"
+msgstr "unterstrichen"
+
+#: ../src/common/fontcmn.cpp:929
+msgid " strikethrough"
+msgstr " durchgestrichen"
+
+#: ../src/common/fontcmn.cpp:942
+msgid " thin"
+msgstr " dünn"
+
+#: ../src/common/fontcmn.cpp:946
+msgid " extra light"
+msgstr " sehr dünn"
+
+#: ../src/common/fontcmn.cpp:950
+msgid " light"
+msgstr " dünn"
+
+#: ../src/common/fontcmn.cpp:954
+msgid " medium"
+msgstr " mittel"
+
+#: ../src/common/fontcmn.cpp:958
+msgid " semi bold"
+msgstr " halbfett"
+
+#: ../src/common/fontcmn.cpp:962
+msgid " bold"
+msgstr " fett"
+
+#: ../src/common/fontcmn.cpp:966
+msgid " extra bold"
+msgstr " sehr fett"
+
+#: ../src/common/fontcmn.cpp:970
+msgid " heavy"
+msgstr " heavy"
+
+#: ../src/common/fontcmn.cpp:974
+msgid " extra heavy"
+msgstr " sehr schwer"
+
+#: ../src/common/fontcmn.cpp:990
+msgid " italic"
+msgstr " kursiv"
+
+#: ../src/common/fontcmn.cpp:1134
+msgid "strikethrough"
+msgstr "Durchstreichen"
+
+#: ../src/common/fontcmn.cpp:1143
+msgid "thin"
+msgstr "dünn"
+
+#: ../src/common/fontcmn.cpp:1156
+msgid "extralight"
+msgstr "extra dünn"
+
+#: ../src/common/fontcmn.cpp:1161
+msgid "light"
+msgstr "dünn"
+
+#: ../src/common/fontcmn.cpp:1169 ../src/richtext/richtextstyles.cpp:775
+msgid "normal"
+msgstr "Normal"
+
+#: ../src/common/fontcmn.cpp:1174
+msgid "medium"
+msgstr "mittel"
+
+#: ../src/common/fontcmn.cpp:1179 ../src/common/fontcmn.cpp:1199
+msgid "semibold"
+msgstr "halbfett"
+
+#: ../src/common/fontcmn.cpp:1184
+msgid "bold"
+msgstr "fett"
+
+#: ../src/common/fontcmn.cpp:1194
+msgid "extrabold"
+msgstr "sehr fett"
+
+#: ../src/common/fontcmn.cpp:1204
+msgid "heavy"
+msgstr "schwer"
+
+#: ../src/common/fontcmn.cpp:1212
+msgid "extraheavy"
+msgstr "sehr schwer"
+
+#: ../src/common/fontcmn.cpp:1217
+msgid "italic"
+msgstr "kursiv"
+
+#: ../src/common/fontmap.cpp:195
+msgid ": unknown charset"
+msgstr ": unbekannter Zeichensatz"
+
+#: ../src/common/fontmap.cpp:199
+#, c-format
+msgid ""
+"The charset '%s' is unknown. You may select\n"
+"another charset to replace it with or choose\n"
+"[Cancel] if it cannot be replaced"
+msgstr ""
+"Die Zeichensatz „%s“ ist nicht bekannt. Wählen Sie \n"
+"einen Ersatzzeichensatz oder „Abbrechen“, \n"
+"falls er nicht ersetzt werden kann"
+
+#: ../src/common/fontmap.cpp:241
+#, c-format
+msgid "Failed to remember the encoding for the charset '%s'."
+msgstr ""
+"Versuch fehlgeschlagen, an die Kodierung für den Zeichensatz „%s“ zu "
+"erinnern."
+
+#: ../src/common/fontmap.cpp:321
+msgid "can't load any font, aborting"
+msgstr "Kann keine Schriftarten mehr laden, Abbruch"
+
+#: ../src/common/fontmap.cpp:409
+msgid ": unknown encoding"
+msgstr ": unbekannte Kodierung"
+
+#: ../src/common/fontmap.cpp:417
+#, c-format
+msgid ""
+"No font for displaying text in encoding '%s' found,\n"
+"but an alternative encoding '%s' is available.\n"
+"Do you want to use this encoding (otherwise you will have to choose another "
+"one)?"
+msgstr ""
+"Keine Schriftart für die Kodierung „%s“ gefunden,\n"
+"es ist aber eine Alternativkodierung „%s“ verfügbar.\n"
+"Möchten Sie diese Kodierung wählen\n"
+"(sonst müssen Sie eine andere auswählen)?"
+
+#: ../src/common/fontmap.cpp:422
+#, c-format
+msgid ""
+"No font for displaying text in encoding '%s' found.\n"
+"Would you like to select a font to be used for this encoding\n"
+"(otherwise the text in this encoding will not be shown correctly)?"
+msgstr ""
+"Keine Schriftart für die Kodierung „%s“ gefunden,\n"
+"Möchten Sie eine Schriftart für die Kodierung wählen\n"
+"(sonst wird der Text mit dieser Kodierung nicht richtig dargestellt)?"
+
+#: ../src/common/fs_mem.cpp:169
+#, c-format
+msgid "Memory VFS already contains file '%s'!"
+msgstr "VFS-Speicher beinhaltet bereits die Datei „%s“!"
+
+#: ../src/common/fs_mem.cpp:232
+#, c-format
+msgid "Trying to remove file '%s' from memory VFS, but it is not loaded!"
+msgstr ""
+"Beim Versuch die Datei „%s“ aus dem VFS-Speicher zu entfernen, wurde "
+"festgestellt, dass sie gar nicht geladen war!"
+
+#: ../src/common/fs_mem.cpp:262
+#, c-format
+msgid "Failed to store image '%s' to memory VFS!"
+msgstr "Versuch das Bild „%s“ im VFS-Speicher zu laden, fehlgeschlagen!"
+
+#: ../src/common/ftp.cpp:197
+msgid "Timeout while waiting for FTP server to connect, try passive mode."
+msgstr ""
+"Timeout beim Warten auf eine Verbindung zum FTP-Server, versuchen Sie "
+"passiven Modus."
+
+#: ../src/common/ftp.cpp:399
+#, c-format
+msgid "Failed to set FTP transfer mode to %s."
+msgstr "Konnte den FTP-Transfermodus nicht auf „%s“ setzen."
+
+#: ../src/common/ftp.cpp:400 ../src/richtext/richtextsymboldlg.cpp:432
+msgid "ASCII"
+msgstr "ASCII"
+
+#: ../src/common/ftp.cpp:400
+msgid "binary"
+msgstr "binär"
+
+#: ../src/common/ftp.cpp:608
+msgid "The FTP server doesn't support the PORT command."
+msgstr "Der FTP-Server unterstützt nicht das PORT-Kommando."
+
+#: ../src/common/ftp.cpp:622
+msgid "The FTP server doesn't support passive mode."
+msgstr "Der FTP-Server unterstützt keinen passiven Transfermodus."
+
+#: ../src/common/gifdecod.cpp:822
+#, c-format
+msgid "Incorrect GIF frame size (%u, %d) for the frame #%u"
+msgstr "Ungültige GIF Bildgröße (%u, %d) für das Bild #%u"
+
+#: ../src/common/glcmn.cpp:108
+msgid "Failed to allocate colour for OpenGL"
+msgstr "Anforderung von Farbe für OpenGL fehlgeschlagen"
+
+#: ../src/common/headerctrlcmn.cpp:57
+msgid "Please select the columns to show and define their order:"
+msgstr ""
+"Bitte darzustellende Spalten auswählen und deren Reihenfolge festlegen:"
+
+#: ../src/common/headerctrlcmn.cpp:58
+msgid "Customize Columns"
+msgstr "Spalten anpassen"
+
+#: ../src/common/headerctrlcmn.cpp:304
+msgid "&Customize..."
+msgstr "&Anpassen …"
+
+#: ../src/common/hyperlnkcmn.cpp:132
+#, c-format
+msgid "Failed to open URL \"%s\" in the default browser"
+msgstr "Konnte die URL „%s“ nicht im voreingestellten Browser öffnen"
+
+#: ../src/common/iconbndl.cpp:195
+#, c-format
+msgid "Failed to load image %%d from file '%s'."
+msgstr "Konnte das Bild %%d aus der Datei „%s“ nicht laden."
+
+#: ../src/common/iconbndl.cpp:203
+#, c-format
+msgid "Failed to load image %d from stream."
+msgstr "Konnte das Bild %d aus dem Strom nicht laden."
+
+#: ../src/common/iconbndl.cpp:221
+#, c-format
+msgid "Failed to load icons from resource '%s'."
+msgstr "Konnte die Symbole aus der Ressource „%s“ nicht laden."
+
+#: ../src/common/imagbmp.cpp:97
+msgid "BMP: Couldn't save invalid image."
+msgstr "BMP: Konnte ungültiges Bild nicht speichern."
+
+#: ../src/common/imagbmp.cpp:137
+msgid "BMP: wxImage doesn't have own wxPalette."
+msgstr "BMP: wxImage hat keine eigene wxPalette."
+
+#: ../src/common/imagbmp.cpp:243
+msgid "BMP: Couldn't write the file (Bitmap) header."
+msgstr "BMP: Dateikopf (Bitmap) konnte nicht geschrieben werden."
+
+#: ../src/common/imagbmp.cpp:266
+msgid "BMP: Couldn't write the file (BitmapInfo) header."
+msgstr "BMP: Dateikopf (BitmapInfo) konnte nicht geschrieben werden."
+
+#: ../src/common/imagbmp.cpp:353
+msgid "BMP: Couldn't write RGB color map."
+msgstr "BMP: Konnte RGB Farbtabelle nicht speichern."
+
+#: ../src/common/imagbmp.cpp:487
+msgid "BMP: Couldn't write data."
+msgstr "BMP: Konnte Daten nicht speichern."
+
+#: ../src/common/imagbmp.cpp:561 ../src/common/imagbmp.cpp:642
+msgid "BMP: Couldn't allocate memory."
+msgstr "BMP: Speicheranforderung fehlgeschlagen."
+
+#: ../src/common/imagbmp.cpp:1041
+msgid "DIB Header: Image width > 32767 pixels for file."
+msgstr "DIB-Header: Bildbreite > 32767 Pixel."
+
+#: ../src/common/imagbmp.cpp:1049
+msgid "DIB Header: Image height > 32767 pixels for file."
+msgstr "DIB-Header: Bildhöhe > 32767 Pixel."
+
+#: ../src/common/imagbmp.cpp:1081
+msgid "DIB Header: Unknown bitdepth in file."
+msgstr "DIB-Header: Unbekannte Bittiefe."
+
+#: ../src/common/imagbmp.cpp:1156
+msgid "DIB Header: Unknown encoding in file."
+msgstr "DIB-Header: Unbekannte Kodierung."
+
+#: ../src/common/imagbmp.cpp:1165
+msgid "DIB Header: Encoding doesn't match bitdepth."
+msgstr "DIB-Header: Kodierung entspricht nicht der Bittiefe."
+
+#: ../src/common/imagbmp.cpp:1180
+#, c-format
+msgid "BMP Header: Invalid number of colors (%d)."
+msgstr "BMP Kopfzeile: Ungültige Anzahl der Farben (%d)."
+
+#: ../src/common/imagbmp.cpp:1273
+msgid "Error in reading image DIB."
+msgstr "Fehler beim Lesen des DIB-Bildes."
+
+#: ../src/common/imagbmp.cpp:1294
+msgid "ICO: Error in reading mask DIB."
+msgstr "ICO: Fehler beim Lesen der DIB-Maske."
+
+#: ../src/common/imagbmp.cpp:1353
+msgid "ICO: Image too tall for an icon."
+msgstr "ICO: Bild zu groß für ein Icon."
+
+#: ../src/common/imagbmp.cpp:1361
+msgid "ICO: Image too wide for an icon."
+msgstr "ICO: Bild zu breit für ein Icon."
+
+#: ../src/common/imagbmp.cpp:1388 ../src/common/imagbmp.cpp:1488
+#: ../src/common/imagbmp.cpp:1503 ../src/common/imagbmp.cpp:1514
+#: ../src/common/imagbmp.cpp:1528 ../src/common/imagbmp.cpp:1576
+#: ../src/common/imagbmp.cpp:1591 ../src/common/imagbmp.cpp:1605
+#: ../src/common/imagbmp.cpp:1616
+msgid "ICO: Error writing the image file!"
+msgstr "ICO: Schreibfehler beim Speichern!"
+
+#: ../src/common/imagbmp.cpp:1701
+msgid "ICO: Invalid icon index."
+msgstr "ICO: Ungültiger Icon-Index."
+
+#: ../src/common/image.cpp:2410
+msgid "Image and mask have different sizes."
+msgstr "Bild und Bildmaske haben verschiedene Größen."
+
+#: ../src/common/image.cpp:2418 ../src/common/image.cpp:2459
+msgid "No unused colour in image being masked."
+msgstr "Keine unbenutzte Farbe wurde im Bild unterdrückt."
+
+#: ../src/common/image.cpp:2641
+#, c-format
+msgid "Failed to load bitmap \"%s\" from resources."
+msgstr "Konnte das Bitmap „%s“ aus der Ressource nicht laden."
+
+#: ../src/common/image.cpp:2650
+#, c-format
+msgid "Failed to load icon \"%s\" from resources."
+msgstr "Konnte das Symbol „%s“ aus der Ressource nicht laden."
+
+#: ../src/common/image.cpp:2728 ../src/common/image.cpp:2747
+#, c-format
+msgid "Failed to load image from file \"%s\"."
+msgstr "Konnte das Bild aus der Datei „%s“ nicht laden."
+
+#: ../src/common/image.cpp:2761
+#, c-format
+msgid "Can't save image to file '%s': unknown extension."
+msgstr "Kann Bild nicht aus Datei „%s“ laden: Unbekannte Dateiendung."
+
+#: ../src/common/image.cpp:2869
+msgid "No handler found for image type."
+msgstr "Dieses Bildformat wird nicht unterstützt."
+
+#: ../src/common/image.cpp:2877 ../src/common/image.cpp:3000
+#: ../src/common/image.cpp:3066
+#, c-format
+msgid "No image handler for type %d defined."
+msgstr "Bildformat %d wurde nicht definiert."
+
+#: ../src/common/image.cpp:2887
+#, c-format
+msgid "Image file is not of type %d."
+msgstr "Bilddatei hat nicht den Typ %d."
+
+#: ../src/common/image.cpp:2970
+msgid "Can't automatically determine the image format for non-seekable input."
+msgstr ""
+"Das Bildformat für nicht durchsuchbare Eingabe kann nicht automatisch "
+"bestimmt werden."
+
+#: ../src/common/image.cpp:2988
+msgid "Unknown image data format."
+msgstr "Unbekanntes Bilddateiformat."
+
+#: ../src/common/image.cpp:3009
+#, c-format
+msgid "This is not a %s."
+msgstr "Dies ist kein %s."
+
+#: ../src/common/image.cpp:3032 ../src/common/image.cpp:3080
+#, c-format
+msgid "No image handler for type %s defined."
+msgstr "Bildformat %s wurde nicht definiert."
+
+#: ../src/common/image.cpp:3041
+#, c-format
+msgid "Image is not of type %s."
+msgstr "Bilddatei hat nicht den Typ %s."
+
+#: ../src/common/image.cpp:3509
+#, c-format
+msgid "Failed to check format of image file \"%s\"."
+msgstr "Überprüfung des Formats der Bilddatei „%s“ fehlgeschlagen."
+
+#: ../src/common/imaggif.cpp:124
+msgid "GIF: error in GIF image format."
+msgstr "GIF: Fehler im GIF-Bildformat."
+
+#: ../src/common/imaggif.cpp:129
+msgid "GIF: not enough memory."
+msgstr "GIF: nicht genug Speicher."
+
+#: ../src/common/imaggif.cpp:134
+msgid "GIF: data stream seems to be truncated."
+msgstr "GIF: Datenstrom scheint unvollständig zu sein."
+
+#: ../src/common/imaggif.cpp:240
+msgid "Couldn't initialize GIF hash table."
+msgstr "GIF Hash-Tabelle konnte nicht initialisiert werden."
+
+#: ../src/common/imagiff.cpp:739
+msgid "IFF: error in IFF image format."
+msgstr "IFF: Fehler im IFF-Bildformat."
+
+#: ../src/common/imagiff.cpp:742
+msgid "IFF: not enough memory."
+msgstr "IFF: nicht genug Speicher."
+
+#: ../src/common/imagiff.cpp:745
+msgid "IFF: unknown error!!!"
+msgstr "IFF: unbekannter Fehler!"
+
+#: ../src/common/imagiff.cpp:755
+msgid "IFF: data stream seems to be truncated."
+msgstr "IFF: Datenstrom scheint unvollständig zu sein."
+
+#: ../src/common/imagjpeg.cpp:258
+msgid "JPEG: Couldn't load - file is probably corrupted."
+msgstr "JPEG: Lesefehler - Datei ist vermutlich beschädigt."
+
+#: ../src/common/imagjpeg.cpp:437
+msgid "JPEG: Couldn't save image."
+msgstr "JPEG: Konnte Bild nicht speichern."
+
+#: ../src/common/imagpcx.cpp:439
+msgid "PCX: this is not a PCX file."
+msgstr "PCX: dies ist keine PCX-Datei."
+
+#: ../src/common/imagpcx.cpp:453
+msgid "PCX: image format unsupported"
+msgstr "PCX: Bildformat wird nicht unterstützt"
+
+#: ../src/common/imagpcx.cpp:454 ../src/common/imagpcx.cpp:477
+msgid "PCX: couldn't allocate memory"
+msgstr "PCX: Speicheranforderung fehlgeschlagen"
+
+#: ../src/common/imagpcx.cpp:455
+msgid "PCX: version number too low"
+msgstr "PCX: Versionsnummer zu niedrig"
+
+#: ../src/common/imagpcx.cpp:456 ../src/common/imagpcx.cpp:478
+msgid "PCX: unknown error !!!"
+msgstr "PCX: unbekannter Fehler!"
+
+#: ../src/common/imagpcx.cpp:476
+msgid "PCX: invalid image"
+msgstr "PCX: ungültiges Bild"
+
+#: ../src/common/imagpng.cpp:385
+#, c-format
+msgid "Unknown PNG resolution unit %d"
+msgstr "Unbekannte Einheit für die PNG-Auflösung %d"
+
+#: ../src/common/imagpng.cpp:439
+msgid "Couldn't load a PNG image - file is corrupted or not enough memory."
+msgstr ""
+"Konnte PNG-Bild nicht laden - Datei ist beschädigt oder der Speicher reicht "
+"nicht aus."
+
+#: ../src/common/imagpng.cpp:513 ../src/common/imagpng.cpp:524
+#: ../src/common/imagpng.cpp:534
+msgid "Couldn't save PNG image."
+msgstr "Konnte PNG-Bild nicht speichern."
+
+#: ../src/common/imagpnm.cpp:71
+msgid "PNM: File format is not recognized."
+msgstr "PNM: Datei-Format wurde nicht erkannt."
+
+#: ../src/common/imagpnm.cpp:89
+msgid "PNM: Couldn't allocate memory."
+msgstr "PNM: Speicheranforderung fehlgeschlagen."
+
+#: ../src/common/imagpnm.cpp:111 ../src/common/imagpnm.cpp:134
+#: ../src/common/imagpnm.cpp:156
+msgid "PNM: File seems truncated."
+msgstr "PNM: Datei wurde abgeschnitten."
+
+#: ../src/common/imagtiff.cpp:69
+#, c-format
+msgid " (in module \"%s\")"
+msgstr " (im Modul „%s“)"
+
+#: ../src/common/imagtiff.cpp:304
+msgid "TIFF: Error loading image."
+msgstr "TIFF: Fehler beim Laden des Bildes."
+
+#: ../src/common/imagtiff.cpp:314
+msgid "Invalid TIFF image index."
+msgstr "Ungültiger Index des TIFF-Bilds."
+
+#: ../src/common/imagtiff.cpp:358
+msgid "TIFF: Image size is abnormally big."
+msgstr "TIFF: Bildgröße ist außergewöhnlich groß."
+
+#: ../src/common/imagtiff.cpp:372 ../src/common/imagtiff.cpp:385
+#: ../src/common/imagtiff.cpp:769
+msgid "TIFF: Couldn't allocate memory."
+msgstr "TIFF: Speicheranforderung fehlgeschlagen."
+
+#: ../src/common/imagtiff.cpp:471
+msgid "TIFF: Error reading image."
+msgstr "TIFF: Fehler beim Lesen des Bildes."
+
+#: ../src/common/imagtiff.cpp:532
+#, c-format
+msgid "Unknown TIFF resolution unit %d ignored"
+msgstr "Unbekannte TIFF-Auflösungseinheit %d ignoriert"
+
+#: ../src/common/imagtiff.cpp:611
+msgid "TIFF: Error saving image."
+msgstr "TIFF: Schreibfehler beim Speichern."
+
+#: ../src/common/imagtiff.cpp:868
+msgid "TIFF: Error writing image."
+msgstr "TIFF: Schreibfehler beim Speichern."
+
+#: ../src/common/imagtiff.cpp:881
+msgid "TIFF: Error flushing data."
+msgstr "TIFF: Fehler beim Löschen der Daten."
+
+#: ../src/common/imagwebp.cpp:56
+msgid "WebP: Invalid data (failed to get features)."
+msgstr "WebP: Ungültige Daten (Eigenschaften konnten nicht abgerufen werden)."
+
+#: ../src/common/imagwebp.cpp:65
+msgid "WebP: Allocating image memory failed."
+msgstr "WebP: Zuweisung des Bildspeichers fehlgeschlagen."
+
+#: ../src/common/imagwebp.cpp:82
+msgid "WebP: Decoding RGBA image data failed."
+msgstr "WebP: Entschlüsselung der RGBA Bilddaten fehlgeschlagen."
+
+#: ../src/common/imagwebp.cpp:98
+msgid "WebP: Decoding RGB image data failed."
+msgstr "WebP: Entschlüsselung der RGB Bilddaten fehlgeschlagen."
+
+#: ../src/common/imagwebp.cpp:113 ../src/common/imagwebp.cpp:201
+msgid "WebP: Allocating stream buffer failed."
+msgstr "WebP: Zuweisung des Strömungspuffers fehlgeschlagen."
+
+#: ../src/common/imagwebp.cpp:131
+msgid "WebP: Failed to parse container data."
+msgstr "WebP: Konnte die Containerdaten nicht analysieren."
+
+#: ../src/common/imagwebp.cpp:222
+msgid "WebP: Error decoding animation."
+msgstr "WebP: Fehler beim Entschlüsseln der Animation."
+
+#: ../src/common/imagwebp.cpp:240
+msgid "WebP: Error getting next animation frame."
+msgstr "WebP: Fehler bei der Anforderung des nächsten Animationsfensters."
+
+#: ../src/common/init.cpp:172
+#, c-format
+msgid ""
+"Command line argument %d couldn't be converted to Unicode and will be "
+"ignored."
+msgstr ""
+"Kommandozeilenargument %d konnte nicht nach Unicode konvertiert werden und "
+"wird ignoriert."
+
+#: ../src/common/init.cpp:344
+msgid "Initialization failed in post init, aborting."
+msgstr "Initialisierung in „post init“ fehlgeschlagen, breche ab."
+
+#: ../src/common/intl.cpp:378
+#, c-format
+msgid "Cannot set locale to language \"%s\"."
+msgstr "Lokalisierung kann nicht auf die Sprache „%s“ gesetzt werden."
+
+#: ../src/common/log.cpp:232
+msgid "Error: "
+msgstr "Fehler: "
+
+#: ../src/common/log.cpp:236
+msgid "Warning: "
+msgstr "Warnung: "
+
+#: ../src/common/log.cpp:284
+msgid "The previous message repeated once."
+msgstr "Die vorangegangene Nachricht wurde ein Mal wiederholt."
+
+#: ../src/common/log.cpp:291
+#, c-format
+msgid "The previous message repeated %u time."
+msgid_plural "The previous message repeated %u times."
+msgstr[0] "Die vorangegangene Nachricht wurde %u Mal wiederholt."
+msgstr[1] "Die vorangegangene Nachricht wurde %u Mal wiederholt."
+
+#: ../src/common/log.cpp:319
+#, c-format
+msgid "Last repeated message (\"%s\", %u time) wasn't output"
+msgid_plural "Last repeated message (\"%s\", %u times) wasn't output"
+msgstr[0] ""
+"Die letzte wiederholte Nachricht („%s“, %u Mal) wurde nicht ausgegeben"
+msgstr[1] ""
+"Die letzte wiederholte Nachricht („%s“, %u Mal) wurde nicht ausgegeben"
+
+#: ../src/common/log.cpp:435
+#, c-format
+msgid " (error %ld: %s)"
+msgstr " (Fehler %ld: %s)"
+
+#: ../src/common/lzmastream.cpp:121
+msgid "Failed to allocate memory for LZMA decompression."
+msgstr "Speicheranforderung für LZMA-Entkomprimierung fehlgeschlagen."
+
+#: ../src/common/lzmastream.cpp:125
+#, c-format
+msgid "Failed to initialize LZMA decompression: unexpected error %u."
+msgstr ""
+"Die Initialisierung der LZMA Entkomprimierung ist fehlgeschlagen: "
+"unerwarteter Fehler %u."
+
+#: ../src/common/lzmastream.cpp:179
+msgid "input is not in XZ format"
+msgstr "Eingabe ist nicht im XZ-Format"
+
+#: ../src/common/lzmastream.cpp:183
+msgid "input compressed using unknown XZ option"
+msgstr "Die Eingabe wurde mit einer unbekannten XZ-Option komprimiert"
+
+#: ../src/common/lzmastream.cpp:188
+msgid "input is corrupted"
+msgstr "Eingabe ist beschädigt"
+
+#: ../src/common/lzmastream.cpp:192
+msgid "unknown decompression error"
+msgstr "Unbekannter Fehler beim Entpacken"
+
+#: ../src/common/lzmastream.cpp:196
+#, c-format
+msgid "LZMA decompression error: %s"
+msgstr "LZMA Fehler beim Entpacken: %s"
+
+#: ../src/common/lzmastream.cpp:231
+msgid "Failed to allocate memory for LZMA compression."
+msgstr "Speicheranforderung für LZMA-Komprimierung fehlgeschlagen."
+
+#: ../src/common/lzmastream.cpp:235
+#, c-format
+msgid "Failed to initialize LZMA compression: unexpected error %u."
+msgstr ""
+"Die Initialisierung der LZMA-Komprimierung ist fehlgeschlagen: unerwarteter "
+"Fehler %u."
+
+#: ../src/common/lzmastream.cpp:267 ../src/common/lzmastream.cpp:342
+#: ../src/html/chm.cpp:336
+msgid "out of memory"
+msgstr "nicht genug Speicher"
+
+#: ../src/common/lzmastream.cpp:276 ../src/common/lzmastream.cpp:346
+msgid "unknown compression error"
+msgstr "Unbekannter Fehler beim Komprimieren"
+
+#: ../src/common/lzmastream.cpp:280
+#, c-format
+msgid "LZMA compression error: %s"
+msgstr "LZMA Komprimierungsfehler: %s"
+
+#: ../src/common/lzmastream.cpp:350
+#, c-format
+msgid "LZMA compression error when flushing output: %s"
+msgstr ""
+"EIn LZMA-Komprimierungsfehler ist aufgetreten beim Leeren der Ausgabe: %s"
+
+#: ../src/common/mimecmn.cpp:167
+#, c-format
+msgid "Unmatched '{' in an entry for mime type %s."
+msgstr "Unzutreffendes „{“-Zeichen in einem Eintrag des MIME-Typs %s."
+
+#: ../src/common/module.cpp:76
+#, c-format
+msgid "Circular dependency involving module \"%s\" detected."
+msgstr "Zirkuläre Abhängigkeit betreffend das Modul „%s“ erkannt."
+
+#: ../src/common/module.cpp:128
+#, c-format
+msgid "Dependency \"%s\" of module \"%s\" doesn't exist."
+msgstr "Abhängigkeit „%s“ des Moduls „%s“ existiert nicht."
+
+#: ../src/common/module.cpp:137
+#, c-format
+msgid "Module \"%s\" initialization failed"
+msgstr "Initialisierung von Modul „%s“ fehlgeschlagen"
+
+#: ../src/common/msgout.cpp:96
+msgid "Message"
+msgstr "Nachricht"
+
+#: ../src/common/paper.cpp:70
+msgid "Letter, 8 1/2 x 11 in"
+msgstr "Letter, 8 1/2 × 11 Zoll"
+
+#: ../src/common/paper.cpp:71
+msgid "Legal, 8 1/2 x 14 in"
+msgstr "Legal, 8 1/2 × 14 Zoll"
+
+#: ../src/common/paper.cpp:72
+msgid "A4 sheet, 210 x 297 mm"
+msgstr "A4 Blatt, 210 × 297 mm"
+
+#: ../src/common/paper.cpp:73
+msgid "C sheet, 17 x 22 in"
+msgstr "C Blatt, 17 × 22 Zoll"
+
+#: ../src/common/paper.cpp:74
+msgid "D sheet, 22 x 34 in"
+msgstr "D Blatt, 22 × 34 Zoll"
+
+#: ../src/common/paper.cpp:75
+msgid "E sheet, 34 x 44 in"
+msgstr "E Blatt, 34 × 44 Zoll"
+
+#: ../src/common/paper.cpp:76
+msgid "Letter Small, 8 1/2 x 11 in"
+msgstr "Letter Small, 8 1/2 × 11 Zoll"
+
+#: ../src/common/paper.cpp:77
+msgid "Tabloid, 11 x 17 in"
+msgstr "Tabloid, 11 × 17 Zoll"
+
+#: ../src/common/paper.cpp:78
+msgid "Ledger, 17 x 11 in"
+msgstr "Ledger, 17 × 11 Zoll"
+
+#: ../src/common/paper.cpp:79
+msgid "Statement, 5 1/2 x 8 1/2 in"
+msgstr "Statement, 5 1/2 × 8 1/2 Zoll"
+
+#: ../src/common/paper.cpp:80
+msgid "Executive, 7 1/4 x 10 1/2 in"
+msgstr "Executive, 7 1/4 × 10 1/2 Zoll"
+
+#: ../src/common/paper.cpp:81
+msgid "A3 sheet, 297 x 420 mm"
+msgstr "A3 Blatt, 297 × 420 mm"
+
+#: ../src/common/paper.cpp:82
+msgid "A4 small sheet, 210 x 297 mm"
+msgstr "A4 klein Blatt, 210 × 297 mm"
+
+#: ../src/common/paper.cpp:83
+msgid "A5 sheet, 148 x 210 mm"
+msgstr "A5 Blatt, 148 × 210 mm"
+
+#: ../src/common/paper.cpp:84
+msgid "B4 sheet, 250 x 354 mm"
+msgstr "B4 Blatt, 250 × 354 mm"
+
+#: ../src/common/paper.cpp:85
+msgid "B5 sheet, 182 x 257 millimeter"
+msgstr "B5 Blatt, 182 × 257 mm"
+
+#: ../src/common/paper.cpp:86
+msgid "Folio, 8 1/2 x 13 in"
+msgstr "Folio, 8 1/2 × 13 Zoll"
+
+#: ../src/common/paper.cpp:87
+msgid "Quarto, 215 x 275 mm"
+msgstr "Quarto, 215 × 275 mm"
+
+#: ../src/common/paper.cpp:88
+msgid "10 x 14 in"
+msgstr "10 × 14 Zoll"
+
+#: ../src/common/paper.cpp:89
+msgid "11 x 17 in"
+msgstr "11 × 17 Zoll"
+
+#: ../src/common/paper.cpp:90
+msgid "Note, 8 1/2 x 11 in"
+msgstr "Note, 8 1/2 × 11 Zoll"
+
+#: ../src/common/paper.cpp:91
+msgid "#9 Envelope, 3 7/8 x 8 7/8 in"
+msgstr "#9 Umschlag, 3 7/8 × 8 7/8 Zoll"
+
+#: ../src/common/paper.cpp:92
+msgid "#10 Envelope, 4 1/8 x 9 1/2 in"
+msgstr "#10 Umschlag, 4 1/8 × 9 1/2 Zoll"
+
+#: ../src/common/paper.cpp:93
+msgid "#11 Envelope, 4 1/2 x 10 3/8 in"
+msgstr "#11 Umschlag, 4 1/2 × 10 3/8 Zoll"
+
+#: ../src/common/paper.cpp:94
+msgid "#12 Envelope, 4 3/4 x 11 in"
+msgstr "#12 Umschlag, 4 3/4 × 11 Zoll"
+
+#: ../src/common/paper.cpp:95
+msgid "#14 Envelope, 5 x 11 1/2 in"
+msgstr "#14 Umschlag, 5 × 11 1/2 Zoll"
+
+#: ../src/common/paper.cpp:96
+msgid "DL Envelope, 110 x 220 mm"
+msgstr "DL Umschlag, 110 × 220 mm"
+
+#: ../src/common/paper.cpp:97
+msgid "C5 Envelope, 162 x 229 mm"
+msgstr "C5 Umschlag, 162 × 229 mm"
+
+#: ../src/common/paper.cpp:98
+msgid "C3 Envelope, 324 x 458 mm"
+msgstr "C3 Umschlag, 324 × 458 mm"
+
+#: ../src/common/paper.cpp:99
+msgid "C4 Envelope, 229 x 324 mm"
+msgstr "C4 Umschlag, 229 × 324 mm"
+
+#: ../src/common/paper.cpp:100
+msgid "C6 Envelope, 114 x 162 mm"
+msgstr "C6 Umschlag, 114 × 162 mm"
+
+#: ../src/common/paper.cpp:101
+msgid "C65 Envelope, 114 x 229 mm"
+msgstr "C65 Umschlag, 114 × 229 mm"
+
+#: ../src/common/paper.cpp:102
+msgid "B4 Envelope, 250 x 353 mm"
+msgstr "B4 Umschlag, 250 × 353 mm"
+
+#: ../src/common/paper.cpp:103
+msgid "B5 Envelope, 176 x 250 mm"
+msgstr "B5 Umschlag, 176 × 250 mm"
+
+#: ../src/common/paper.cpp:104
+msgid "B6 Envelope, 176 x 125 mm"
+msgstr "B6 Umschlag, 176 × 125 mm"
+
+#: ../src/common/paper.cpp:105
+msgid "Italy Envelope, 110 x 230 mm"
+msgstr "Italy Umschlag, 110 × 230 mm"
+
+#: ../src/common/paper.cpp:106
+msgid "Monarch Envelope, 3 7/8 x 7 1/2 in"
+msgstr "Monarch Envelope, 3 7/8 × 7 1/2 Zoll"
+
+#: ../src/common/paper.cpp:107
+msgid "6 3/4 Envelope, 3 5/8 x 6 1/2 in"
+msgstr "6 3/4 Umschlag, 3 5/8 × 6 1/2 Zoll"
+
+#: ../src/common/paper.cpp:108
+msgid "US Std Fanfold, 14 7/8 x 11 in"
+msgstr "US Std Endlospapier, 14 7/8 × 11 Zoll"
+
+#: ../src/common/paper.cpp:109
+msgid "German Std Fanfold, 8 1/2 x 12 in"
+msgstr "German Std Endlospapier, 8 1/2 × 12 Zoll"
+
+#: ../src/common/paper.cpp:110
+msgid "German Legal Fanfold, 8 1/2 x 13 in"
+msgstr "German Legal Endlospapier, 21,59 × 33,02 cm"
+
+#: ../src/common/paper.cpp:112
+msgid "B4 (ISO) 250 x 353 mm"
+msgstr "B4 (ISO) 250 × 353 mm"
+
+#: ../src/common/paper.cpp:113
+msgid "Japanese Postcard 100 x 148 mm"
+msgstr "Japanische Postkarte 100 × 148 mm"
+
+#: ../src/common/paper.cpp:114
+msgid "9 x 11 in"
+msgstr "9 × 11 Zoll"
+
+#: ../src/common/paper.cpp:115
+msgid "10 x 11 in"
+msgstr "10 × 11 Zoll"
+
+#: ../src/common/paper.cpp:116
+msgid "15 x 11 in"
+msgstr "15 × 11 Zoll"
+
+#: ../src/common/paper.cpp:117
+msgid "Envelope Invite 220 x 220 mm"
+msgstr "Umschlag Einladung 220 × 220 mm"
+
+#: ../src/common/paper.cpp:118
+msgid "Letter Extra 9 1/2 x 12 in"
+msgstr "Letter Extra 9 1/2 × 12 Zoll"
+
+#: ../src/common/paper.cpp:119
+msgid "Legal Extra 9 1/2 x 15 in"
+msgstr "Legal Extra 9 1/2 × 15 Zoll"
+
+#: ../src/common/paper.cpp:120
+msgid "Tabloid Extra 11.69 x 18 in"
+msgstr "Tabloid Extra 11.69 × 18 Zoll"
+
+#: ../src/common/paper.cpp:121
+msgid "A4 Extra 9.27 x 12.69 in"
+msgstr "A4 Extra 9.27 × 12.69 Zoll"
+
+#: ../src/common/paper.cpp:122
+msgid "Letter Transverse 8 1/2 x 11 in"
+msgstr "Brief Quer 8 1/2 × 11 Zoll"
+
+#: ../src/common/paper.cpp:123
+msgid "A4 Transverse 210 x 297 mm"
+msgstr "A4 Quer 210 × 297 mm"
+
+#: ../src/common/paper.cpp:124
+msgid "Letter Extra Transverse 9.275 x 12 in"
+msgstr "Brief Extra Quer 9.275 × 12 Zoll"
+
+#: ../src/common/paper.cpp:125
+msgid "SuperA/SuperA/A4 227 x 356 mm"
+msgstr "SuperA/SuperA/A4 227 × 356 mm"
+
+#: ../src/common/paper.cpp:126
+msgid "SuperB/SuperB/A3 305 x 487 mm"
+msgstr "SuperB/SuperB/A3 305 × 487 mm"
+
+#: ../src/common/paper.cpp:127
+msgid "Letter Plus 8 1/2 x 12.69 in"
+msgstr "Brief Plus 8 1/2 × 12.69 Zoll"
+
+#: ../src/common/paper.cpp:128
+msgid "A4 Plus 210 x 330 mm"
+msgstr "A4 Plus 210 × 330 mm"
+
+#: ../src/common/paper.cpp:129
+msgid "A5 Transverse 148 x 210 mm"
+msgstr "A5 Quer 148 × 210 mm"
+
+#: ../src/common/paper.cpp:130
+msgid "B5 (JIS) Transverse 182 x 257 mm"
+msgstr "B5 (JIS) Quer 182 × 257 mm"
+
+#: ../src/common/paper.cpp:131
+msgid "A3 Extra 322 x 445 mm"
+msgstr "A3 Extra 322 × 445 mm"
+
+#: ../src/common/paper.cpp:132
+msgid "A5 Extra 174 x 235 mm"
+msgstr "A5 Extra 174 × 235 mm"
+
+#: ../src/common/paper.cpp:133
+msgid "B5 (ISO) Extra 201 x 276 mm"
+msgstr "B5 (ISO) Extra 201 × 276 mm"
+
+#: ../src/common/paper.cpp:134
+msgid "A2 420 x 594 mm"
+msgstr "A2 420 × 594 mm"
+
+#: ../src/common/paper.cpp:135
+msgid "A3 Transverse 297 x 420 mm"
+msgstr "A3 Quer 297 × 420 mm"
+
+#: ../src/common/paper.cpp:136
+msgid "A3 Extra Transverse 322 x 445 mm"
+msgstr "A3 Extra Quer 322 × 445 mm"
+
+#: ../src/common/paper.cpp:138
+msgid "Japanese Double Postcard 200 x 148 mm"
+msgstr "Japanische Doppelte Postkarte 200 × 148 mm"
+
+#: ../src/common/paper.cpp:139
+msgid "A6 105 x 148 mm"
+msgstr "A6 105 × 148 mm"
+
+#: ../src/common/paper.cpp:140
+msgid "Japanese Envelope Kaku #2"
+msgstr "Japanischer Briefumschlag Kaku #2"
+
+#: ../src/common/paper.cpp:141
+msgid "Japanese Envelope Kaku #3"
+msgstr "Japanischer Briefumschlag Kaku #3"
+
+#: ../src/common/paper.cpp:142
+msgid "Japanese Envelope Chou #3"
+msgstr "Japanischer Briefumschlag Chou #3"
+
+#: ../src/common/paper.cpp:143
+msgid "Japanese Envelope Chou #4"
+msgstr "Japanischer Briefumschlag Chou #4"
+
+#: ../src/common/paper.cpp:144
+msgid "Letter Rotated 11 x 8 1/2 in"
+msgstr "Brief Rotiert 11 × 8 1/2 Zoll"
+
+#: ../src/common/paper.cpp:145
+msgid "A3 Rotated 420 x 297 mm"
+msgstr "A3 Rotiert 420 × 297 mm"
+
+#: ../src/common/paper.cpp:146
+msgid "A4 Rotated 297 x 210 mm"
+msgstr "A4 Rotiert 297 × 210 mm"
+
+#: ../src/common/paper.cpp:147
+msgid "A5 Rotated 210 x 148 mm"
+msgstr "A5 Rotiert 210 × 148 mm"
+
+#: ../src/common/paper.cpp:148
+msgid "B4 (JIS) Rotated 364 x 257 mm"
+msgstr "B4 (JIS) Rotiert 364 × 257 mm"
+
+#: ../src/common/paper.cpp:149
+msgid "B5 (JIS) Rotated 257 x 182 mm"
+msgstr "B5 (JIS) Rotiert 257 × 182 mm"
+
+#: ../src/common/paper.cpp:150
+msgid "Japanese Postcard Rotated 148 x 100 mm"
+msgstr "Japanische Postkarte Rotiert 100 × 148 mm"
+
+#: ../src/common/paper.cpp:151
+msgid "Double Japanese Postcard Rotated 148 x 200 mm"
+msgstr "Doppelte Japanische Postkarte Rotiert 148 × 200 mm"
+
+#: ../src/common/paper.cpp:152
+msgid "A6 Rotated 148 x 105 mm"
+msgstr "A6 Rotiert 148 × 105 mm"
+
+#: ../src/common/paper.cpp:153
+msgid "Japanese Envelope Kaku #2 Rotated"
+msgstr "Japanischer Briefumschlag Kaku #2 Rotiert"
+
+#: ../src/common/paper.cpp:154
+msgid "Japanese Envelope Kaku #3 Rotated"
+msgstr "Japanischer Briefumschlag Kaku #3 Rotiert"
+
+#: ../src/common/paper.cpp:155
+msgid "Japanese Envelope Chou #3 Rotated"
+msgstr "Japanischer Briefumschlag Chou #3 Rotiert"
+
+#: ../src/common/paper.cpp:156
+msgid "Japanese Envelope Chou #4 Rotated"
+msgstr "Japanischer Briefumschlag Chou #4 Rotiert"
+
+#: ../src/common/paper.cpp:157
+msgid "B6 (JIS) 128 x 182 mm"
+msgstr "B6 (JIS) 128 × 182 mm"
+
+#: ../src/common/paper.cpp:158
+msgid "B6 (JIS) Rotated 182 x 128 mm"
+msgstr "B6 (JIS) Rotiert 182 × 128 mm"
+
+#: ../src/common/paper.cpp:159
+msgid "12 x 11 in"
+msgstr "12 × 11 Zoll"
+
+#: ../src/common/paper.cpp:160
+msgid "Japanese Envelope You #4"
+msgstr "Japanischer Briefumschlag You #4"
+
+#: ../src/common/paper.cpp:161
+msgid "Japanese Envelope You #4 Rotated"
+msgstr "Japanischer Briefumschlag You #4 Rotiert"
+
+#: ../src/common/paper.cpp:162
+msgid "PRC 16K 146 x 215 mm"
+msgstr "PRC 16K 146 × 215 mm"
+
+#: ../src/common/paper.cpp:163
+msgid "PRC 32K 97 x 151 mm"
+msgstr "PRC 32K 97 × 151 mm"
+
+#: ../src/common/paper.cpp:164
+msgid "PRC 32K(Big) 97 x 151 mm"
+msgstr "PRC 32K(Groß) 97 × 151 mm"
+
+#: ../src/common/paper.cpp:165
+msgid "PRC Envelope #1 102 x 165 mm"
+msgstr "PRC Umschlag #1 102 × 165 mm"
+
+#: ../src/common/paper.cpp:166
+msgid "PRC Envelope #2 102 x 176 mm"
+msgstr "PRC Umschlag #2 102 × 176 mm"
+
+#: ../src/common/paper.cpp:167
+msgid "PRC Envelope #3 125 x 176 mm"
+msgstr "PRC Umschlag #3 125 × 176 mm"
+
+#: ../src/common/paper.cpp:168
+msgid "PRC Envelope #4 110 x 208 mm"
+msgstr "PRC Umschlag #4 110 × 208 mm"
+
+#: ../src/common/paper.cpp:169
+msgid "PRC Envelope #5 110 x 220 mm"
+msgstr "PRC Umschlag #5 110 × 220 mm"
+
+#: ../src/common/paper.cpp:170
+msgid "PRC Envelope #6 120 x 230 mm"
+msgstr "PRC Umschlag #6 120 × 230 mm"
+
+#: ../src/common/paper.cpp:171
+msgid "PRC Envelope #7 160 x 230 mm"
+msgstr "PRC Umschlag #7 160 × 230 mm"
+
+#: ../src/common/paper.cpp:172
+msgid "PRC Envelope #8 120 x 309 mm"
+msgstr "PRC Umschlag #8 120 × 309 mm"
+
+#: ../src/common/paper.cpp:173
+msgid "PRC Envelope #9 229 x 324 mm"
+msgstr "PRC Umschlag #9 229 × 324 mm"
+
+#: ../src/common/paper.cpp:174
+msgid "PRC Envelope #10 324 x 458 mm"
+msgstr "PRC Umschlag #10 324 × 458 mm"
+
+#: ../src/common/paper.cpp:175
+msgid "PRC 16K Rotated"
+msgstr "PRC 16K Rotiert"
+
+#: ../src/common/paper.cpp:176
+msgid "PRC 32K Rotated"
+msgstr "PRC 32K Rotiert"
+
+#: ../src/common/paper.cpp:177
+msgid "PRC 32K(Big) Rotated"
+msgstr "PRC 32K(Groß) Rotiert"
+
+#: ../src/common/paper.cpp:178
+msgid "PRC Envelope #1 Rotated 165 x 102 mm"
+msgstr "PRC Umschlag #1 Rotated 165 × 102 mm"
+
+#: ../src/common/paper.cpp:179
+msgid "PRC Envelope #2 Rotated 176 x 102 mm"
+msgstr "PRC Umschlag #2 Rotiert 176 × 102 mm"
+
+#: ../src/common/paper.cpp:180
+msgid "PRC Envelope #3 Rotated 176 x 125 mm"
+msgstr "PRC Umschlag #3 Rotiert 176 × 125 mm"
+
+#: ../src/common/paper.cpp:181
+msgid "PRC Envelope #4 Rotated 208 x 110 mm"
+msgstr "PRC Umschlag #4 Rotiert 208 × 110 mm"
+
+#: ../src/common/paper.cpp:182
+msgid "PRC Envelope #5 Rotated 220 x 110 mm"
+msgstr "PRC Umschlag #5 Rotiert 220 × 110 mm"
+
+#: ../src/common/paper.cpp:183
+msgid "PRC Envelope #6 Rotated 230 x 120 mm"
+msgstr "PRC Umschlag #6 Rotiert 230 × 120 mm"
+
+#: ../src/common/paper.cpp:184
+msgid "PRC Envelope #7 Rotated 230 x 160 mm"
+msgstr "PRC Umschlag #7 Rotiert 230 × 160 mm"
+
+#: ../src/common/paper.cpp:185
+msgid "PRC Envelope #8 Rotated 309 x 120 mm"
+msgstr "PRC Umschlag #8 Rotiert 309 × 120 mm"
+
+#: ../src/common/paper.cpp:186
+msgid "PRC Envelope #9 Rotated 324 x 229 mm"
+msgstr "PRC Umschlag #9 Rotiert 324 × 229 mm"
+
+#: ../src/common/paper.cpp:187
+msgid "PRC Envelope #10 Rotated 458 x 324 mm"
+msgstr "PRC Umschlag #10 Rotiert 458 × 324 mm"
+
+#: ../src/common/paper.cpp:192
+msgid "A0 sheet, 841 x 1189 mm"
+msgstr "A0 Blatt, 841 × 1189 mm"
+
+#: ../src/common/paper.cpp:193
+msgid "A1 sheet, 594 x 841 mm"
+msgstr "A1 Blatt, 594 × 841 mm"
+
+#: ../src/common/preferencescmn.cpp:37
+msgid "General"
+msgstr "Allgemein"
+
+#: ../src/common/preferencescmn.cpp:40
+msgid "Advanced"
+msgstr "Erweitert"
+
+#: ../src/common/prntbase.cpp:245
+msgid "Generic PostScript"
+msgstr "Generisches PostScript"
+
+#: ../src/common/prntbase.cpp:259
+msgid "Ready"
+msgstr "Bereit"
+
+#: ../src/common/prntbase.cpp:331
+msgid "Printing Error"
+msgstr "Fehler beim Drucken"
+
+#: ../src/common/prntbase.cpp:413 ../src/common/prntbase.cpp:1597
+#: ../src/generic/prntdlgg.cpp:135 ../src/generic/prntdlgg.cpp:149
+#: ../src/gtk/print.cpp:628 ../src/gtk/print.cpp:646
+msgid "Print"
+msgstr "Drucken"
+
+#: ../src/common/prntbase.cpp:471 ../src/generic/prntdlgg.cpp:809
+msgid "Page setup"
+msgstr "Seiten-Einstellungen"
+
+#: ../src/common/prntbase.cpp:525
+msgid "Please wait while printing..."
+msgstr "Bitte warten Sie während gedruckt wird …"
+
+#: ../src/common/prntbase.cpp:529
+msgid "Document:"
+msgstr "Dokument:"
+
+#: ../src/common/prntbase.cpp:532
+msgid "Progress:"
+msgstr "Fortschritt:"
+
+#: ../src/common/prntbase.cpp:533
+msgid "Preparing"
+msgstr "Vorbereitung"
+
+#: ../src/common/prntbase.cpp:552
+#, c-format
+msgid "Printing page %d"
+msgstr "Seite %d wird gedruckt"
+
+#: ../src/common/prntbase.cpp:557
+#, c-format
+msgid "Printing page %d of %d"
+msgstr "Drucke Seite %d von %d"
+
+#: ../src/common/prntbase.cpp:560
+#, c-format
+msgid " (copy %d of %d)"
+msgstr " (Kopie %d von %d)"
+
+#: ../src/common/prntbase.cpp:1604
+msgid "First page"
+msgstr "Erste Seite"
+
+#: ../src/common/prntbase.cpp:1609 ../src/html/helpwnd.cpp:659
+msgid "Previous page"
+msgstr "Vorherige Seite"
+
+#: ../src/common/prntbase.cpp:1623 ../src/html/helpwnd.cpp:660
+msgid "Next page"
+msgstr "Nächste Seite"
+
+#: ../src/common/prntbase.cpp:1628
+msgid "Last page"
+msgstr "Letzte Seite"
+
+#: ../src/common/prntbase.cpp:1636 ../src/common/stockitem.cpp:215
+msgid "Zoom Out"
+msgstr "Verkleinern"
+
+#: ../src/common/prntbase.cpp:1650 ../src/common/stockitem.cpp:214
+msgid "Zoom In"
+msgstr "Vergrößern"
+
+#: ../src/common/prntbase.cpp:1656 ../src/common/stockitem.cpp:153
+#: ../src/generic/logg.cpp:553 ../src/univ/themes/win32.cpp:3752
+msgid "&Close"
+msgstr "&Schließen"
+
+#: ../src/common/prntbase.cpp:2085
+msgid "Could not start document preview."
+msgstr "Kann Druckvorschau nicht starten."
+
+#: ../src/common/prntbase.cpp:2085 ../src/common/prntbase.cpp:2129
+#: ../src/common/prntbase.cpp:2137
+msgid "Print Preview Failure"
+msgstr "Fehler bei der Druckvorschau"
+
+#: ../src/common/prntbase.cpp:2129 ../src/common/prntbase.cpp:2137
+msgid "Sorry, not enough memory to create a preview."
+msgstr "Nicht genug Speicher für Vorschau."
+
+#: ../src/common/prntbase.cpp:2144
+#, c-format
+msgid "Page %d of %d"
+msgstr "Seite %d von %d"
+
+#: ../src/common/prntbase.cpp:2146
+#, c-format
+msgid "Page %d"
+msgstr "Seite %d"
+
+#: ../src/common/regex.cpp:382 ../src/html/chm.cpp:348
+msgid "unknown error"
+msgstr "unbekannter Fehler"
+
+#: ../src/common/regex.cpp:995
+#, c-format
+msgid "Invalid regular expression '%s': %s"
+msgstr "Ungültiger regulärer Ausdruck „%s“: %s"
+
+#: ../src/common/regex.cpp:1059
+#, c-format
+msgid "Failed to find match for regular expression: %s"
+msgstr "Konnte keine Übereinstimmung mit regulärem Ausdruck %s finden"
+
+#: ../src/common/rendcmn.cpp:188
+#, c-format
+msgid "Renderer \"%s\" has incompatible version %d.%d and couldn't be loaded."
+msgstr ""
+"Renderer „%s“ hat eine ungültige Version %d.%d und kann nicht geladen werden."
+
+#: ../src/common/secretstore.cpp:162
+msgid "Not available for this platform"
+msgstr "Nicht verfügbar für diese Platform"
+
+#: ../src/common/secretstore.cpp:183
+#, c-format
+msgid "Saving password for \"%s\" failed: %s."
+msgstr "Speichern des Passwortes für „%s“ fehlgeschlagen: %s."
+
+#: ../src/common/secretstore.cpp:205
+#, c-format
+msgid "Reading password for \"%s\" failed: %s."
+msgstr "Lesen des Passwortes für „%s“ fehlgeschlagen: %s."
+
+#: ../src/common/secretstore.cpp:228
+#, c-format
+msgid "Deleting password for \"%s\" failed: %s."
+msgstr "Löschen des Passwortes für „%s“ fehlgeschlagen: %s."
+
+#: ../src/common/selectdispatcher.cpp:254
+msgid "Failed to monitor I/O channels"
+msgstr "Die Überwachung der I/O Kanäle ist fehlgeschlagen"
+
+#: ../src/common/sizer.cpp:3054 ../src/common/stockitem.cpp:195
+msgid "Save"
+msgstr "Speichern"
+
+#: ../src/common/sizer.cpp:3056
+msgid "Don't Save"
+msgstr "Nicht speichern"
+
+#: ../src/common/socket.cpp:870
+msgid "Cannot initialize sockets"
+msgstr "Kann Sockets nicht initialisieren"
+
+#: ../src/common/stockitem.cpp:127
+msgctxt "standard Windows menu"
+msgid "&Help"
+msgstr "&Hilfe"
+
+#: ../src/common/stockitem.cpp:144
+msgid "&About"
+msgstr "Übe&r"
+
+#: ../src/common/stockitem.cpp:144
+msgid "About"
+msgstr "Über"
+
+#: ../src/common/stockitem.cpp:145
+msgid "Add"
+msgstr "Hinzufügen"
+
+#: ../src/common/stockitem.cpp:146
+msgid "&Apply"
+msgstr "Ü&bernehmen"
+
+#: ../src/common/stockitem.cpp:146
+msgid "Apply"
+msgstr "Übernehmen"
+
+#: ../src/common/stockitem.cpp:147
+msgid "&Back"
+msgstr "&Zurück"
+
+#: ../src/common/stockitem.cpp:147
+msgid "Back"
+msgstr "Zurück"
+
+#: ../src/common/stockitem.cpp:148
+msgid "&Bold"
+msgstr "&Fett"
+
+#: ../src/common/stockitem.cpp:148 ../src/generic/fontdlgg.cpp:326
+#: ../src/richtext/richtextfontpage.cpp:354
+msgid "Bold"
+msgstr "Fett"
+
+#: ../src/common/stockitem.cpp:149
+msgid "&Bottom"
+msgstr "&Unten"
+
+#: ../src/common/stockitem.cpp:149 ../src/richtext/richtextsizepage.cpp:287
+msgid "Bottom"
+msgstr "Unten"
+
+#: ../src/common/stockitem.cpp:150 ../src/generic/fontdlgg.cpp:462
+#: ../src/generic/fontdlgg.cpp:481 ../src/generic/wizard.cpp:415
+msgid "&Cancel"
+msgstr "Ab&brechen"
+
+#: ../src/common/stockitem.cpp:151
+msgid "&CD-ROM"
+msgstr "&CD-ROM"
+
+#: ../src/common/stockitem.cpp:151
+msgid "CD-ROM"
+msgstr "CD-ROM"
+
+#: ../src/common/stockitem.cpp:152
+msgid "&Clear"
+msgstr "&Löschen"
+
+#: ../src/common/stockitem.cpp:152
+msgid "Clear"
+msgstr "Löschen"
+
+#: ../src/common/stockitem.cpp:153 ../src/generic/dbgrptg.cpp:93
+#: ../src/generic/progdlgg.cpp:778 ../src/html/helpdlg.cpp:86
+#: ../src/msw/progdlg.cpp:209 ../src/msw/progdlg.cpp:890
+#: ../src/richtext/richtextstyledlg.cpp:272
+#: ../src/richtext/richtextsymboldlg.cpp:448
+msgid "Close"
+msgstr "Schließen"
+
+#: ../src/common/stockitem.cpp:154
+msgid "&Convert"
+msgstr "&Konvertieren"
+
+#: ../src/common/stockitem.cpp:154
+msgid "Convert"
+msgstr "Konvertieren"
+
+#: ../src/common/stockitem.cpp:155 ../src/msw/textctrl.cpp:2884
+#: ../src/osx/textctrl_osx.cpp:653 ../src/richtext/richtextctrl.cpp:331
+msgid "&Copy"
+msgstr "&Kopieren"
+
+#: ../src/common/stockitem.cpp:155 ../src/stc/stc_i18n.cpp:18
+msgid "Copy"
+msgstr "Kopieren"
+
+#: ../src/common/stockitem.cpp:156 ../src/msw/textctrl.cpp:2883
+#: ../src/osx/textctrl_osx.cpp:652 ../src/richtext/richtextctrl.cpp:330
+msgid "Cu&t"
+msgstr "&Ausschneiden"
+
+#: ../src/common/stockitem.cpp:156 ../src/stc/stc_i18n.cpp:17
+msgid "Cut"
+msgstr "Ausschneiden"
+
+#: ../src/common/stockitem.cpp:157 ../src/msw/textctrl.cpp:2886
+#: ../src/osx/textctrl_osx.cpp:655 ../src/richtext/richtextctrl.cpp:333
+#: ../src/richtext/richtexttabspage.cpp:137
+msgid "&Delete"
+msgstr "&Löschen"
+
+#: ../src/common/stockitem.cpp:157 ../src/richtext/richtextbuffer.cpp:8266
+#: ../src/stc/stc_i18n.cpp:20
+msgid "Delete"
+msgstr "Löschen"
+
+#: ../src/common/stockitem.cpp:158
+msgid "&Down"
+msgstr "&Runter"
+
+#: ../src/common/stockitem.cpp:158 ../src/generic/fdrepdlg.cpp:148
+msgid "Down"
+msgstr "Herunter"
+
+#: ../src/common/stockitem.cpp:159
+msgid "&Edit"
+msgstr "&Bearbeiten"
+
+#: ../src/common/stockitem.cpp:159
+msgid "Edit"
+msgstr "Bearbeiten"
+
+#: ../src/common/stockitem.cpp:160
+msgid "&Execute"
+msgstr "&Ausführen"
+
+#: ../src/common/stockitem.cpp:160
+msgid "Execute"
+msgstr "Ausführen"
+
+#: ../src/common/stockitem.cpp:161
+msgid "&Quit"
+msgstr "&Beenden"
+
+#: ../src/common/stockitem.cpp:161
+msgid "Quit"
+msgstr "Beenden"
+
+#: ../src/common/stockitem.cpp:162
+msgid "&File"
+msgstr "&Datei"
+
+#: ../src/common/stockitem.cpp:162
+msgid "File"
+msgstr "Datei"
+
+#: ../src/common/stockitem.cpp:163
+msgid "&Find..."
+msgstr "&Suchen..."
+
+#: ../src/common/stockitem.cpp:163
+msgid "Find..."
+msgstr "Suchen..."
+
+#: ../src/common/stockitem.cpp:164
+msgid "&First"
+msgstr "&Erste"
+
+#: ../src/common/stockitem.cpp:164
+msgid "First"
+msgstr "Erste(r)"
+
+#: ../src/common/stockitem.cpp:165
+msgid "&Floppy"
+msgstr "&Diskette"
+
+#: ../src/common/stockitem.cpp:165
+msgid "Floppy"
+msgstr "Diskette"
+
+#: ../src/common/stockitem.cpp:166
+msgid "&Forward"
+msgstr "&Vorwärts"
+
+#: ../src/common/stockitem.cpp:166
+msgid "Forward"
+msgstr "Vorwärts"
+
+#: ../src/common/stockitem.cpp:167
+msgid "&Harddisk"
+msgstr "&Festplatte"
+
+#: ../src/common/stockitem.cpp:167
+msgid "Harddisk"
+msgstr "Festplatte"
+
+#: ../src/common/stockitem.cpp:168 ../src/generic/wizard.cpp:418
+#: ../src/osx/cocoa/menu.mm:225 ../src/richtext/richtextstyledlg.cpp:298
+#: ../src/richtext/richtextsymboldlg.cpp:451
+msgid "&Help"
+msgstr "&Hilfe"
+
+#: ../src/common/stockitem.cpp:169
+msgid "&Home"
+msgstr "&Start"
+
+#: ../src/common/stockitem.cpp:169
+msgid "Home"
+msgstr "Start"
+
+#: ../src/common/stockitem.cpp:170
+msgid "Indent"
+msgstr "Einrücken"
+
+#: ../src/common/stockitem.cpp:171
+msgid "&Index"
+msgstr "&Index"
+
+#: ../src/common/stockitem.cpp:171 ../src/html/helpwnd.cpp:510
+msgid "Index"
+msgstr "Index"
+
+#: ../src/common/stockitem.cpp:172
+msgid "&Info"
+msgstr "&Information"
+
+#: ../src/common/stockitem.cpp:172
+msgid "Info"
+msgstr "Info"
+
+#: ../src/common/stockitem.cpp:173
+msgid "&Italic"
+msgstr "&Kursiv"
+
+#: ../src/common/stockitem.cpp:173 ../src/generic/fontdlgg.cpp:322
+#: ../src/richtext/richtextfontpage.cpp:350
+msgid "Italic"
+msgstr "Kursiv"
+
+#: ../src/common/stockitem.cpp:174
+msgid "&Jump to"
+msgstr "&Springen zu"
+
+#: ../src/common/stockitem.cpp:174
+msgid "Jump to"
+msgstr "Springen zu"
+
+#: ../src/common/stockitem.cpp:175
+msgid "Centered"
+msgstr "Zentriert"
+
+#: ../src/common/stockitem.cpp:176
+msgid "Justified"
+msgstr "Blocksatz"
+
+#: ../src/common/stockitem.cpp:177
+msgid "Align Left"
+msgstr "Linksbündig"
+
+#: ../src/common/stockitem.cpp:178
+msgid "Align Right"
+msgstr "Rechtsbündig"
+
+#: ../src/common/stockitem.cpp:179
+msgid "&Last"
+msgstr "&Letztes"
+
+#: ../src/common/stockitem.cpp:179
+msgid "Last"
+msgstr "Letzte(r)"
+
+#: ../src/common/stockitem.cpp:180
+msgid "&Network"
+msgstr "&Netzwerk"
+
+#: ../src/common/stockitem.cpp:180
+msgid "Network"
+msgstr "Netzwerk"
+
+#: ../src/common/stockitem.cpp:181 ../src/richtext/richtexttabspage.cpp:131
+msgid "&New"
+msgstr "&Neu"
+
+#: ../src/common/stockitem.cpp:181
+msgid "New"
+msgstr "Neu"
+
+#: ../src/common/stockitem.cpp:182 ../src/msw/msgdlg.cpp:417
+msgid "&No"
+msgstr "&Nein"
+
+#: ../src/common/stockitem.cpp:183 ../src/generic/fontdlgg.cpp:467
+#: ../src/generic/fontdlgg.cpp:474
+msgid "&OK"
+msgstr "&OK"
+
+#: ../src/common/stockitem.cpp:184 ../src/generic/dbgrptg.cpp:341
+msgid "&Open..."
+msgstr "Ö&ffnen …"
+
+#: ../src/common/stockitem.cpp:184
+msgid "Open..."
+msgstr "Öffnen …"
+
+#: ../src/common/stockitem.cpp:185 ../src/msw/textctrl.cpp:2885
+#: ../src/osx/textctrl_osx.cpp:654 ../src/richtext/richtextctrl.cpp:332
+msgid "&Paste"
+msgstr "Ein&fügen"
+
+#: ../src/common/stockitem.cpp:185 ../src/richtext/richtextctrl.cpp:3484
+#: ../src/stc/stc_i18n.cpp:19
+msgid "Paste"
+msgstr "Einfügen"
+
+#: ../src/common/stockitem.cpp:186
+msgid "&Preferences"
+msgstr "&Einstellungen"
+
+#: ../src/common/stockitem.cpp:186 ../src/osx/cocoa/preferences.mm:304
+msgid "Preferences"
+msgstr "Einstellungen"
+
+#: ../src/common/stockitem.cpp:187
+msgid "Print previe&w..."
+msgstr "Druck&vorschau …"
+
+#: ../src/common/stockitem.cpp:187
+msgid "Print preview..."
+msgstr "Druckvorschau …"
+
+#: ../src/common/stockitem.cpp:188
+msgid "&Print..."
+msgstr "&Drucken …"
+
+#: ../src/common/stockitem.cpp:188
+msgid "Print..."
+msgstr "Drucken …"
+
+#: ../src/common/stockitem.cpp:189 ../src/richtext/richtextctrl.cpp:337
+#: ../src/richtext/richtextctrl.cpp:5479
+msgid "&Properties"
+msgstr "&Eigenschaften"
+
+#: ../src/common/stockitem.cpp:189
+msgid "Properties"
+msgstr "Eigenschaften"
+
+#: ../src/common/stockitem.cpp:190 ../src/stc/stc_i18n.cpp:16
+msgid "Redo"
+msgstr "Wiederholen"
+
+#: ../src/common/stockitem.cpp:191
+msgid "Refresh"
+msgstr "Aktualisiere"
+
+#: ../src/common/stockitem.cpp:192
+msgid "Remove"
+msgstr "Entfernen"
+
+#: ../src/common/stockitem.cpp:193
+msgid "Rep&lace..."
+msgstr "&Ersetzen..."
+
+#: ../src/common/stockitem.cpp:193
+msgid "Replace..."
+msgstr "Ersetzen..."
+
+#: ../src/common/stockitem.cpp:194
+msgid "Revert to Saved"
+msgstr "Gespeicherte Version wiederherstellen"
+
+#: ../src/common/stockitem.cpp:196 ../src/generic/logg.cpp:549
+msgid "Save &As..."
+msgstr "Speichern &unter …"
+
+#: ../src/common/stockitem.cpp:196
+msgid "Save As..."
+msgstr "Speichern unter…"
+
+#: ../src/common/stockitem.cpp:197 ../src/msw/textctrl.cpp:2888
+#: ../src/osx/textctrl_osx.cpp:657 ../src/richtext/richtextctrl.cpp:335
+msgid "Select &All"
+msgstr "&Alles auswählen"
+
+#: ../src/common/stockitem.cpp:197 ../src/stc/stc_i18n.cpp:21
+msgid "Select All"
+msgstr "Alles auswählen"
+
+#: ../src/common/stockitem.cpp:198
+msgid "&Color"
+msgstr "&Farbe"
+
+#: ../src/common/stockitem.cpp:198
+msgid "Color"
+msgstr "Farbe"
+
+#: ../src/common/stockitem.cpp:199
+msgid "&Font"
+msgstr "&Schriftart"
+
+#: ../src/common/stockitem.cpp:199 ../src/richtext/richtextformatdlg.cpp:336
+msgid "Font"
+msgstr "Schriftart"
+
+#: ../src/common/stockitem.cpp:200
+msgid "&Ascending"
+msgstr "&Aufsteigend"
+
+#: ../src/common/stockitem.cpp:200
+msgid "Ascending"
+msgstr "Absteigend"
+
+#: ../src/common/stockitem.cpp:201
+msgid "&Descending"
+msgstr "&Absteigend"
+
+#: ../src/common/stockitem.cpp:201
+msgid "Descending"
+msgstr "Absteigend"
+
+#: ../src/common/stockitem.cpp:202
+msgid "&Spell Check"
+msgstr "&Rechtschreibprüfung"
+
+#: ../src/common/stockitem.cpp:202
+msgid "Spell Check"
+msgstr "Rechtschreibprüfung"
+
+#: ../src/common/stockitem.cpp:203
+msgid "&Stop"
+msgstr "&Stopp"
+
+#: ../src/common/stockitem.cpp:203
+msgid "Stop"
+msgstr "Stopp"
+
+#: ../src/common/stockitem.cpp:204 ../src/richtext/richtextfontpage.cpp:274
+msgid "&Strikethrough"
+msgstr "&Durchstreichen"
+
+#: ../src/common/stockitem.cpp:204
+msgid "Strikethrough"
+msgstr "Durchstreichen"
+
+#: ../src/common/stockitem.cpp:205
+msgid "&Top"
+msgstr "&Oben"
+
+#: ../src/common/stockitem.cpp:205 ../src/richtext/richtextsizepage.cpp:285
+#: ../src/richtext/richtextsizepage.cpp:289
+msgid "Top"
+msgstr "Oben"
+
+#: ../src/common/stockitem.cpp:206
+msgid "Undelete"
+msgstr "Löschen rückgängig machen"
+
+#: ../src/common/stockitem.cpp:207 ../src/generic/fontdlgg.cpp:437
+msgid "&Underline"
+msgstr "&Unterstreichen"
+
+#: ../src/common/stockitem.cpp:207
+msgid "Underline"
+msgstr "Unterstreichen"
+
+#: ../src/common/stockitem.cpp:208 ../src/stc/stc_i18n.cpp:15
+msgid "Undo"
+msgstr "Rückgängig"
+
+#: ../src/common/stockitem.cpp:209
+msgid "&Unindent"
+msgstr "&Einrückung entfernrn"
+
+#: ../src/common/stockitem.cpp:209
+msgid "Unindent"
+msgstr "Einrücken aufheben"
+
+#: ../src/common/stockitem.cpp:210
+msgid "&Up"
+msgstr "&Hoch"
+
+#: ../src/common/stockitem.cpp:210 ../src/generic/fdrepdlg.cpp:148
+msgid "Up"
+msgstr "Hoch"
+
+#: ../src/common/stockitem.cpp:211 ../src/msw/msgdlg.cpp:417
+msgid "&Yes"
+msgstr "&Ja"
+
+#: ../src/common/stockitem.cpp:212
+msgid "&Actual Size"
+msgstr "T&atsächliche Größe"
+
+#: ../src/common/stockitem.cpp:212
+msgid "Actual Size"
+msgstr "Tatsächliche Größe"
+
+#: ../src/common/stockitem.cpp:213
+msgid "Zoom to &Fit"
+msgstr "&Passende Größe"
+
+#: ../src/common/stockitem.cpp:213
+msgid "Zoom to Fit"
+msgstr "Einpassen"
+
+#: ../src/common/stockitem.cpp:214
+msgid "Zoom &In"
+msgstr "Ver&größern"
+
+#: ../src/common/stockitem.cpp:215
+msgid "Zoom &Out"
+msgstr "Ver&kleinern"
+
+#: ../src/common/stockitem.cpp:262
+msgid "Show about dialog"
+msgstr "Zeige den „Über“-Dialog"
+
+#: ../src/common/stockitem.cpp:263
+msgid "Copy selection"
+msgstr "Auswahl kopieren"
+
+#: ../src/common/stockitem.cpp:264
+msgid "Cut selection"
+msgstr "Auswahl ausschneiden"
+
+#: ../src/common/stockitem.cpp:265
+msgid "Delete selection"
+msgstr "Auswahl löschen"
+
+#: ../src/common/stockitem.cpp:266
+msgid "Find in document"
+msgstr "Suche im Dokument"
+
+#: ../src/common/stockitem.cpp:267
+msgid "Find and replace in document"
+msgstr "Suchen und Ersetzen im Dokument"
+
+#: ../src/common/stockitem.cpp:268
+msgid "Paste selection"
+msgstr "Auswahl einfügen"
+
+#: ../src/common/stockitem.cpp:269
+msgid "Quit this program"
+msgstr "Dieses Programm beenden"
+
+#: ../src/common/stockitem.cpp:270
+msgid "Redo last action"
+msgstr "Letzte Aktion wiederholen"
+
+#: ../src/common/stockitem.cpp:271
+msgid "Undo last action"
+msgstr "Letzte Aktion zurücknehmen"
+
+#: ../src/common/stockitem.cpp:272
+msgid "Create new document"
+msgstr "Neues Dokument anlegen"
+
+#: ../src/common/stockitem.cpp:273
+msgid "Open an existing document"
+msgstr "Öffne ein existierendes Dokument"
+
+#: ../src/common/stockitem.cpp:274
+msgid "Close current document"
+msgstr "Aktuelles Dokument schließen"
+
+#: ../src/common/stockitem.cpp:275
+msgid "Save current document"
+msgstr "Aktuelles Dokument speichern"
+
+#: ../src/common/stockitem.cpp:276
+msgid "Save current document with a different filename"
+msgstr "Aktuelles Dokument mit einen anderen Dateinamen speichern"
+
+#: ../src/common/strconv.cpp:2324
+#, c-format
+msgid "Conversion to charset '%s' doesn't work."
+msgstr "Konvertierung zum Zeichensatz „%s“ funktioniert nicht."
+
+#: ../src/common/tarstrm.cpp:352 ../src/common/tarstrm.cpp:375
+#: ../src/common/tarstrm.cpp:406 ../src/generic/progdlgg.cpp:373
+msgid "unknown"
+msgstr "unbekannt"
+
+#: ../src/common/tarstrm.cpp:774
+msgid "incomplete header block in tar"
+msgstr "unvollständiger Kopfeintrag in tar"
+
+#: ../src/common/tarstrm.cpp:798
+msgid "checksum failure reading tar header block"
+msgstr "Prüfsummenfehler beim Lesen der tar-Kopfeintrages"
+
+#: ../src/common/tarstrm.cpp:971
+msgid "invalid data in extended tar header"
+msgstr "ungültige Daten in erweitertem tar-Kopfeintrag"
+
+#: ../src/common/tarstrm.cpp:981 ../src/common/tarstrm.cpp:1003
+#: ../src/common/tarstrm.cpp:1477 ../src/common/tarstrm.cpp:1499
+msgid "tar entry not open"
+msgstr "tar-Eintrag nicht geöffnet"
+
+#: ../src/common/tarstrm.cpp:1023
+msgid "unexpected end of file"
+msgstr "Unerwartetes Ende der Datei"
+
+#: ../src/common/tarstrm.cpp:1297
+#, c-format
+msgid "%s did not fit the tar header for entry '%s'"
+msgstr "%s passte nicht zum tar Kopfeintrag für den Eintrag „%s“"
+
+#: ../src/common/tarstrm.cpp:1359
+msgid "incorrect size given for tar entry"
+msgstr "Falsche Größe für tar-Eintrag"
+
+#: ../src/common/textbuf.cpp:232
+#, c-format
+msgid "'%s' is probably a binary buffer."
+msgstr "„%s“ ist vermutlich ein Binärpuffer."
+
+#: ../src/common/textcmn.cpp:1006 ../src/richtext/richtextctrl.cpp:3053
+msgid "File couldn't be loaded."
+msgstr "Datei konnte nicht geladen werden."
+
+#: ../src/common/textfile.cpp:95
+#, c-format
+msgid "Failed to read text file \"%s\"."
+msgstr "Konnte Textdatei „%s“ nicht lesen."
+
+#: ../src/common/textfile.cpp:160
+#, c-format
+msgid "can't write buffer '%s' to disk."
+msgstr "Kann den Puffer „%s“ nicht schreiben."
+
+#: ../src/common/time.cpp:212
+msgid "Failed to get the local system time"
+msgstr "Versuch örtliche Systemzeit zu bekommen, fehlgeschlagen"
+
+#: ../src/common/time.cpp:279
+msgid "wxGetTimeOfDay failed."
+msgstr "wxGetTimeOfDay fehlgeschlagen."
+
+#: ../src/common/translation.cpp:929
+#, c-format
+msgid "'%s' is not a valid message catalog."
+msgstr "„%s“ ist kein gültiger Nachrichtenkatalog."
+
+#: ../src/common/translation.cpp:954
+msgid "Invalid message catalog."
+msgstr "Ungültiger Nachrichtenkatalog."
+
+#: ../src/common/translation.cpp:1013
+#, c-format
+msgid "Failed to parse Plural-Forms: '%s'"
+msgstr "Analyse der Pluralformen fehlgeschlagen: „%s“"
+
+#: ../src/common/translation.cpp:1723
+#, c-format
+msgid "using catalog '%s' from '%s'."
+msgstr "Verwende Nachrichtenkatalog „%s“ von „%s“."
+
+#: ../src/common/translation.cpp:1816
+#, c-format
+msgid "Resource '%s' is not a valid message catalog."
+msgstr "Ressource „%s“ ist kein gültiger Nachrichtenkatalog."
+
+#: ../src/common/translation.cpp:1865
+msgid "Couldn't enumerate translations"
+msgstr "Konnte Übersetzungen nicht aufzählen"
+
+#: ../src/common/utilscmn.cpp:1145
+msgid "No default application configured for HTML files."
+msgstr "Keine voreingestellte Anwendung für HTML-Dateien."
+
+#: ../src/common/utilscmn.cpp:1190
+#, c-format
+msgid "Failed to open URL \"%s\" in default browser."
+msgstr "Konnte die URL „%s“ nicht im voreingestellten Browser öffnen."
+
+#: ../src/common/valtext.cpp:144
+msgid "Validation conflict"
+msgstr "Verifizierungs-Konflikt"
+
+#: ../src/common/valtext.cpp:186
+msgid "Required information entry is empty."
+msgstr "Erforderlicher Informationseintrag ist leer."
+
+#: ../src/common/valtext.cpp:188
+#, c-format
+msgid "'%s' is one of the invalid strings"
+msgstr "„%s“ ist eine ungültige Zeichenkette"
+
+#: ../src/common/valtext.cpp:190
+#, c-format
+msgid "'%s' is not one of the valid strings"
+msgstr "„%s“ ist keine gültige Zeichenkette"
+
+#: ../src/common/valtext.cpp:199
+#, c-format
+msgid "'%s' contains invalid character(s)"
+msgstr "„%s“ enthält ungültige(s) Zeichen"
+
+#: ../src/common/webrequest.cpp:139
+#, c-format
+msgid "Error: %s (%d)"
+msgstr "Fehler: %s (%d)"
+
+#: ../src/common/webrequest.cpp:655
+#, c-format
+msgid ""
+"Not enough free disk space for download: %llu needed but only %llu available."
+msgstr ""
+"Nicht genügend freier Festplattenplatz für das Herunterladen vorhanden: %llu "
+"benötigt aber nur %llu verfügbar."
+
+#: ../src/common/webrequest.cpp:669
+#, c-format
+msgid "Failed to create temporary file in %s"
+msgstr "Erzeugen der temporären Datei in %s fehlgeschlagen"
+
+#: ../src/common/webrequest_curl.cpp:1106
+msgid "libcurl could not be initialized"
+msgstr "libcurl konnte nicht initialisiert werden"
+
+#: ../src/common/webview.cpp:392
+msgid "RunScriptAsync not supported"
+msgstr "RunScriptAsync wird nicht unterstützt"
+
+#: ../src/common/webview.cpp:403 ../src/msw/webview_ie.cpp:1073
+#, c-format
+msgid "Error running JavaScript: %s"
+msgstr "Fehler beim Ausführen von JavaScript: %s"
+
+#: ../src/common/webview_chromium.cpp:858
+#, c-format
+msgid "Failed to set proxy \"%s\": %s"
+msgstr "Konnte den Proxy „%s“: %s nicht setzen"
+
+#: ../src/common/webview_chromium.cpp:989
+msgid ""
+"Chromium can't be used because libcef.so wasn't loaded early enough; please "
+"relink the application or use LD_PRELOAD to load it earlier."
+msgstr ""
+"Chromium kann nicht benutzt werden weil libcef.so nicht früh genug geladen "
+"wurde; bitte die Anwendung neu binden oder LD_PRELOAD benutzen, um sie "
+"früher zu laden."
+
+#: ../src/common/webview_chromium.cpp:1108
+msgid "Could not initialize Chromium"
+msgstr "Konnte Chromium nicht initialisieren"
+
+#: ../src/common/webview_chromium.cpp:1616
+msgid "Show DevTools"
+msgstr "Zeige die Entwicklungswerkzeuge"
+
+#: ../src/common/webview_chromium.cpp:1617
+msgid "Close DevTools"
+msgstr "Entwicklungswerkzeuge Schließen"
+
+#: ../src/common/webview_chromium.cpp:1623
+msgid "Inspect"
+msgstr "Überprüfen"
+
+#: ../src/common/wincmn.cpp:1628
+msgid "This platform does not support background transparency."
+msgstr "Diese Plattform unterstützt keine Hintergrundtransparenz."
+
+#: ../src/common/wincmn.cpp:2097
+msgid "Could not transfer data to window"
+msgstr "Kann Daten nicht ins Fenster übertragen"
+
+#: ../src/common/windowid.cpp:240
+msgid "Out of window IDs.  Recommend shutting down application."
+msgstr "Keine Fenster-IDs mehr verfügbar. Bitte Applikation beenden."
+
+#: ../src/common/xpmdecod.cpp:678
+msgid "XPM: incorrect header format!"
+msgstr "XPM: nicht korrektes Kopfformat!"
+
+#: ../src/common/xpmdecod.cpp:703
+#, c-format
+msgid "XPM: incorrect colour description in line %d"
+msgstr "XPM: nicht korrekte Farbbeschreibung in Zeile %d"
+
+#: ../src/common/xpmdecod.cpp:715 ../src/common/xpmdecod.cpp:724
+#, c-format
+msgid "XPM: malformed colour definition '%s' at line %d!"
+msgstr "XPM: ungültige Farbdefinition „%s“ in Zeile %d!"
+
+#: ../src/common/xpmdecod.cpp:754
+msgid "XPM: no colors left to use for mask!"
+msgstr "XPM: keine Farben für die Maske übrig!"
+
+#: ../src/common/xpmdecod.cpp:781
+#, c-format
+msgid "XPM: truncated image data at line %d!"
+msgstr "XPM: abgeschnittene Bilddaten in Zeile %d!"
+
+#: ../src/common/xpmdecod.cpp:795
+msgid "XPM: Malformed pixel data!"
+msgstr "XPM: Ungültige Pixeldaten!"
+
+#: ../src/common/xti.cpp:492
+msgid "Illegal Parameter Count for Create Method"
+msgstr "Ungültige Anzahl Parameter für Create-Methode"
+
+#: ../src/common/xti.cpp:504
+msgid "Illegal Parameter Count for ConstructObject Method"
+msgstr "Ungültige Anzahl Parameter für ConstructObject-Methode"
+
+#: ../src/common/xtistrm.cpp:161
+#, c-format
+msgid "Create Parameter %s not found in declared RTTI Parameters"
+msgstr ""
+"Erzeugungsparameter %s nicht in den deklarierten RTTI-Parametern gefunden"
+
+#: ../src/common/xtistrm.cpp:290
+msgid "Illegal Object Class (Non-wxEvtHandler) as Event Source"
+msgstr "Ungültige Objektklasse (nicht wxEvtHandler) als Ereignisquelle"
+
+#: ../src/common/xtistrm.cpp:313 ../src/common/xtixml.cpp:345
+#: ../src/common/xtixml.cpp:498
+msgid "Type must have enum - long conversion"
+msgstr "Typ muss eine enum-long-Umwandlung haben"
+
+#: ../src/common/xtistrm.cpp:400 ../src/common/xtistrm.cpp:415
+msgid "Invalid or Null Object ID passed to GetObjectClassInfo"
+msgstr "Ungültige oder Null-Objekt-ID an GetObjectClassInfo übergeben"
+
+#: ../src/common/xtistrm.cpp:405
+msgid "Unknown Object passed to GetObjectClassInfo"
+msgstr "Unbekanntes Objekt an GetObjectClassInfo übergeben"
+
+#: ../src/common/xtistrm.cpp:420
+msgid "Already Registered Object passed to SetObjectClassInfo"
+msgstr "Ein bereits registriertes Objekt wurde an SetObjectClassInfo übergeben"
+
+#: ../src/common/xtistrm.cpp:430
+msgid "Invalid or Null Object ID passed to HasObjectClassInfo"
+msgstr "Ungültige oder Null-Objekt-ID an HasObjectClassInfo übergeben"
+
+#: ../src/common/xtistrm.cpp:460
+msgid "Passing a already registered object to SetObject"
+msgstr "Ein bereits registriertes Objekt wurde an SetObject übergeben"
+
+#: ../src/common/xtistrm.cpp:471
+msgid "Passing an unknown object to GetObject"
+msgstr "Ein unbekanntes Objekt wurde an GetObject übergeben"
+
+#: ../src/common/xtixml.cpp:229
+msgid "Forward hrefs are not supported"
+msgstr "Forward hrefs werden nicht unterstützt"
+
+#: ../src/common/xtixml.cpp:247
+#, c-format
+msgid "unknown class %s"
+msgstr "Unbekannte Klasse %s"
+
+#: ../src/common/xtixml.cpp:253
+msgid "objects cannot have XML Text Nodes"
+msgstr "Objekte können keine XML-Textknoten haben"
+
+#: ../src/common/xtixml.cpp:258
+msgid "Objects must have an id attribute"
+msgstr "Objekte müssen ein ID-Attribut besitzen"
+
+#: ../src/common/xtixml.cpp:267
+#, c-format
+msgid "Doubly used id : %d"
+msgstr "ID doppelt verwendet: %d"
+
+#: ../src/common/xtixml.cpp:316
+#, c-format
+msgid "Unknown Property %s"
+msgstr "Unbekannte Eigenschaft %s"
+
+#: ../src/common/xtixml.cpp:407
+msgid "A non empty collection must consist of 'element' nodes"
+msgstr "Eine nicht leere Sammlung muss aus „element“-Knoten bestehen"
+
+#: ../src/common/xtixml.cpp:478
+msgid "incorrect event handler string, missing dot"
+msgstr "Event-Handler-Zeichenkette falsch, Punkt fehlt"
+
+#: ../src/common/zipstrm.cpp:559
+msgid "can't re-initialize zlib deflate stream"
+msgstr "Kann den zlib deflate-stream nicht reinitialisieren"
+
+#: ../src/common/zipstrm.cpp:584
+msgid "can't re-initialize zlib inflate stream"
+msgstr "Kann den zlib inflate-stream nicht reinitialisieren"
+
+#: ../src/common/zipstrm.cpp:1023
+msgid "Ignoring malformed extra data record, ZIP file may be corrupted"
+msgstr ""
+"Fehlformatierte Zusatzinformation wird ignoriert, ZIP-Datei ist "
+"möglicherweise beschädigt"
+
+#: ../src/common/zipstrm.cpp:1502
+msgid "assuming this is a multi-part zip concatenated"
+msgstr "Nehme an, dies ist ein mehrteiliges, zusammenhängendes Zip-Archiv"
+
+#: ../src/common/zipstrm.cpp:1664
+msgid "invalid zip file"
+msgstr "Ungültige Zip-Datei"
+
+#: ../src/common/zipstrm.cpp:1723
+msgid "can't find central directory in zip"
+msgstr "kann Zentralverzeichnis im Zip nicht finden"
+
+#: ../src/common/zipstrm.cpp:1812
+msgid "error reading zip central directory"
+msgstr "Fehler beim Lesen des Zentralverzeichnisses im Zip"
+
+#: ../src/common/zipstrm.cpp:1916
+msgid "error reading zip local header"
+msgstr "Fehler beim Lesen des lokalen Headers in Zipdatei"
+
+#: ../src/common/zipstrm.cpp:1964
+msgid "bad zipfile offset to entry"
+msgstr "ungültiges Offset zum Einsprung in der Zipdatei"
+
+#: ../src/common/zipstrm.cpp:2031
+msgid "stored file length not in Zip header"
+msgstr "Gespeicherte Dateilänge nicht in Zip-Header"
+
+#: ../src/common/zipstrm.cpp:2045 ../src/common/zipstrm.cpp:2362
+msgid "unsupported Zip compression method"
+msgstr "nicht unterstütztes Zip-Kompressionsformat"
+
+#: ../src/common/zipstrm.cpp:2126
+#, c-format
+msgid "reading zip stream (entry %s): bad length"
+msgstr "Beim Lesen von Zipstream (Eintrag %s): Falsche Länge"
+
+#: ../src/common/zipstrm.cpp:2131
+#, c-format
+msgid "reading zip stream (entry %s): bad crc"
+msgstr "Beim Lesen von Zipstream (Eintrag %s): Falsche Prüfsumme"
+
+#: ../src/common/zipstrm.cpp:2578
+#, c-format
+msgid "error writing zip entry '%s': file too large without ZIP64"
+msgstr "Fehler beim Schreiben des Zip-Eintrages „%s“: Datei zu groß ohne ZIP64"
+
+#: ../src/common/zipstrm.cpp:2585
+#, c-format
+msgid "error writing zip entry '%s': bad crc or length"
+msgstr ""
+"Fehler beim Schreiben von Zip-Eintrag „%s“: Falsche Prüfsumme oder Länge"
+
+#: ../src/common/zstream.cpp:155 ../src/common/zstream.cpp:315
+msgid "Gzip not supported by this version of zlib"
+msgstr "Gzip wird nicht von dieser zlib-Version unterstützt"
+
+#: ../src/common/zstream.cpp:182
+msgid "Can't initialize zlib inflate stream."
+msgstr "Kann das Komprimieren der zlib-Daten nicht initialisieren."
+
+#: ../src/common/zstream.cpp:241
+msgid "Can't read inflate stream: unexpected EOF in underlying stream."
+msgstr ""
+"Kann den Entkomprimier-Strom nicht lesen: Unerwartetes EOF im "
+"zugrundeliegenden Strom."
+
+#: ../src/common/zstream.cpp:248 ../src/common/zstream.cpp:423
+#, c-format
+msgid "zlib error %d"
+msgstr "zlib-Fehler %d"
+
+#: ../src/common/zstream.cpp:249
+#, c-format
+msgid "Can't read from inflate stream: %s"
+msgstr "Kann nicht vom entpackten Datenstrom lesen:%s"
+
+#: ../src/common/zstream.cpp:343
+msgid "Can't initialize zlib deflate stream."
+msgstr "Kann das Entpacken der zlib-Daten nicht initialisieren."
+
+#: ../src/common/zstream.cpp:424
+#, c-format
+msgid "Can't write to deflate stream: %s"
+msgstr "Kann nicht in den gepackten Datenstrom schreiben: %s"
+
+#: ../src/dfb/bitmap.cpp:633 ../src/dfb/bitmap.cpp:667
+#, c-format
+msgid "No bitmap handler for type %d defined."
+msgstr "Keine Bildbehandlungsroutine für den Typ %d definiert."
+
+#: ../src/dfb/evtloop.cpp:99
+msgid "Failed to read event from DirectFB pipe"
+msgstr "Konnte Ereignis von DirectFB Kanal nicht lesen"
+
+#: ../src/dfb/evtloop.cpp:171
+msgid "Failed to switch DirectFB pipe to non-blocking mode"
+msgstr "Wechsel von DirectFB Pipe in den Nicht blockierenden Modus schlug fehl"
+
+#: ../src/dfb/fontmgr.cpp:171
+#, c-format
+msgid "no fonts found in %s, using builtin font"
+msgstr "Keine Schriftarten in %s, gefunden"
+
+#: ../src/dfb/fontmgr.cpp:177
+msgid "Default font"
+msgstr "Standardschriftart"
+
+#: ../src/dfb/fontmgr.cpp:195
+#, c-format
+msgid "Fonts index file %s disappeared while loading fonts."
+msgstr ""
+"Indexdatei der Schriftarten %s während des Ladens der Schriften verschwunden."
+
+#: ../src/dfb/wrapdfb.cpp:60
+#, c-format
+msgid "DirectFB error %d occurred."
+msgstr "DirectFB-Fehler %d aufgetreten."
+
+#: ../src/generic/aboutdlgg.cpp:69
+msgid "Developed by "
+msgstr "Entwickelt von "
+
+#: ../src/generic/aboutdlgg.cpp:72
+msgid "Documentation by "
+msgstr "Dokumentation von "
+
+#: ../src/generic/aboutdlgg.cpp:75
+msgid "Graphics art by "
+msgstr "Grafikgestaltung von "
+
+#: ../src/generic/aboutdlgg.cpp:78
+msgid "Translations by "
+msgstr "Übersetzungen von "
+
+#: ../src/generic/aboutdlgg.cpp:133 ../src/osx/cocoa/aboutdlg.mm:83
+msgid "Version "
+msgstr "Version "
+
+#. TRANSLATORS: %s is application name
+#: ../src/generic/aboutdlgg.cpp:146 ../src/msw/aboutdlg.cpp:60
+#, c-format
+msgid "About %s"
+msgstr "Über %s"
+
+#: ../src/generic/aboutdlgg.cpp:181
+msgid "License"
+msgstr "Lizenz"
+
+#: ../src/generic/aboutdlgg.cpp:184
+msgid "Developers"
+msgstr "Entwickler"
+
+#: ../src/generic/aboutdlgg.cpp:188
+msgid "Documentation writers"
+msgstr "Autoren der Dokumentation"
+
+#: ../src/generic/aboutdlgg.cpp:192
+msgid "Artists"
+msgstr "Künstler"
+
+#: ../src/generic/aboutdlgg.cpp:196
+msgid "Translators"
+msgstr "Übersetzer"
+
+#: ../src/generic/animateg.cpp:125
+msgid "No handler found for animation type."
+msgstr "Kein Handler für den Animationstyp gefunden."
+
+#: ../src/generic/animateg.cpp:133
+#, c-format
+msgid "No animation handler for type %ld defined."
+msgstr "Kein Animationshandler für Typ %ld definiert."
+
+#: ../src/generic/animateg.cpp:145
+#, c-format
+msgid "Animation file is not of type %ld."
+msgstr "Animationsdatei hat nicht den Typ %ld."
+
+#: ../src/generic/colrdlgg.cpp:154 ../src/gtk/colordlg.cpp:47
+msgid "Choose colour"
+msgstr "Farbe wählen"
+
+#: ../src/generic/colrdlgg.cpp:357
+msgid "Red:"
+msgstr "Rot:"
+
+#: ../src/generic/colrdlgg.cpp:360
+msgid "Green:"
+msgstr "Grün:"
+
+#: ../src/generic/colrdlgg.cpp:363
+msgid "Blue:"
+msgstr "Blau:"
+
+#: ../src/generic/colrdlgg.cpp:372
+msgid "Opacity:"
+msgstr "Deckkraft:"
+
+#: ../src/generic/colrdlgg.cpp:384
+msgid "Add to custom colours"
+msgstr "Zu Benutzerfarben hinzufügen"
+
+#: ../src/generic/creddlgg.cpp:56
+msgid "Username:"
+msgstr "Benutzername:"
+
+#: ../src/generic/creddlgg.cpp:63
+msgid "Password:"
+msgstr "Kennwort:"
+
+#. TRANSLATORS: Name of Boolean true value
+#: ../src/generic/datavgen.cpp:1178
+msgid "true"
+msgstr "wahr"
+
+#. TRANSLATORS: Name of Boolean false value
+#: ../src/generic/datavgen.cpp:1180
+msgid "false"
+msgstr "falsch"
+
+#: ../src/generic/datavgen.cpp:6897
+#, c-format
+msgid "Row %i"
+msgstr "Zeile %i"
+
+#. TRANSLATORS: Action for manipulating a tree control
+#: ../src/generic/datavgen.cpp:6987
+msgid "Collapse"
+msgstr "Zusammenklappen"
+
+#. TRANSLATORS: Action for manipulating a tree control
+#: ../src/generic/datavgen.cpp:6990
+msgid "Expand"
+msgstr "Aufklappen"
+
+#. TRANSLATORS: Name of data view control and number of rows
+#: ../src/generic/datavgen.cpp:7011
+#, c-format
+msgid "%s (%d items)"
+msgstr "%s (%d Elemente)"
+
+#: ../src/generic/datavgen.cpp:7062
+#, c-format
+msgid "Column %u"
+msgstr "Spalte %u"
+
+#. TRANSLATORS: Keystroke for manipulating a tree control
+#: ../src/generic/datavgen.cpp:7131 ../src/richtext/richtextbulletspage.cpp:189
+#: ../src/richtext/richtextbulletspage.cpp:192
+#: ../src/richtext/richtextbulletspage.cpp:193
+#: ../src/richtext/richtextliststylepage.cpp:252
+#: ../src/richtext/richtextliststylepage.cpp:255
+#: ../src/richtext/richtextliststylepage.cpp:256
+#: ../src/richtext/richtextsizepage.cpp:248
+msgid "Left"
+msgstr "Links"
+
+#. TRANSLATORS: Keystroke for manipulating a tree control
+#: ../src/generic/datavgen.cpp:7134 ../src/richtext/richtextbulletspage.cpp:191
+#: ../src/richtext/richtextliststylepage.cpp:254
+#: ../src/richtext/richtextsizepage.cpp:249
+msgid "Right"
+msgstr "Rechts"
+
+#: ../src/generic/datectlg.cpp:90
+#, c-format
+msgid ""
+"\"%s\" is not in the expected date format, please enter it as e.g. \"%s\"."
+msgstr ""
+"\"%s\" liegt nicht im erwarteten Datenformat vor, bitte als z.B. \"%s\" "
+"eingeben."
+
+#: ../src/generic/datectlg.cpp:94
+msgid "Invalid date"
+msgstr "Ungültiges Datum"
+
+#: ../src/generic/dbgrptg.cpp:159
+#, c-format
+msgid "Open file \"%s\""
+msgstr "Öffne Datei „%s“"
+
+#: ../src/generic/dbgrptg.cpp:170
+#, c-format
+msgid "Enter command to open file \"%s\":"
+msgstr "Befehl zum Öffnen von Datei „%s“ eingeben:"
+
+#: ../src/generic/dbgrptg.cpp:230
+msgid "Executable files (*.exe)|*.exe|"
+msgstr "Ausführbare Dateien (*.exe)|*.exe|"
+
+#: ../src/generic/dbgrptg.cpp:300
+#, c-format
+msgid "Debug report \"%s\""
+msgstr "Fehlerbericht „%s“"
+
+#: ../src/generic/dbgrptg.cpp:316
+msgid "A debug report has been generated in the directory\n"
+msgstr "Ein Fehlerbericht wurde erstellt im Verzeichnis\n"
+
+#: ../src/generic/dbgrptg.cpp:317
+msgid "The following debug report will be generated\n"
+msgstr "Die folgende Debugmeldung wird erzeugt\n"
+
+#: ../src/generic/dbgrptg.cpp:321
+msgid ""
+"The report contains the files listed below. If any of these files contain "
+"private information,\n"
+"please uncheck them and they will be removed from the report.\n"
+msgstr ""
+"Der Fehlerbericht enthält die unten aufgelisteten Dateien. Bitte stellen Sie "
+"sicher, dass alle Dateien,\n"
+"die vertrauliche Informationen enthalten, nicht ausgewählt sind; sie werden "
+"dann aus dem Fehlerbericht entfernt.\n"
+
+#: ../src/generic/dbgrptg.cpp:323
+msgid ""
+"If you wish to suppress this debug report completely, please choose the "
+"\"Cancel\" button,\n"
+"but be warned that it may hinder improving the program, so if\n"
+"at all possible please do continue with the report generation.\n"
+msgstr ""
+"Falls Sie diesen Fehlerbericht vollständig unterdrücken möchten, drücken Sie "
+"bitte „Abbrechen“.\n"
+"Bedenken Sie aber bitte, dass dies eventuell die Verbesserung des Programms "
+"behindern kann,\n"
+"nach Möglichkeit sollten Sie also den Fehlerbericht erstellen.\n"
+
+#: ../src/generic/dbgrptg.cpp:325
+msgid "              Thank you and we're sorry for the inconvenience!\n"
+msgstr ""
+"              Vielen Dank, und wir entschuldigen uns für die "
+"Unannehmlichkeiten.\n"
+
+#: ../src/generic/dbgrptg.cpp:333
+msgid "&Debug report preview:"
+msgstr "&Vorschau des Fehlerberichts:"
+
+#: ../src/generic/dbgrptg.cpp:339
+msgid "&View..."
+msgstr "&Ansicht …"
+
+#: ../src/generic/dbgrptg.cpp:359
+msgid "&Notes:"
+msgstr "B&emerkungen:"
+
+#: ../src/generic/dbgrptg.cpp:361
+msgid ""
+"If you have any additional information pertaining to this bug\n"
+"report, please enter it here and it will be joined to it:"
+msgstr ""
+"Falls Sie weitere Informationen betreffend diesen Fehlerberichtes haben, "
+"tragen Sie sie bitte hier ein, um sie zum Bericht hinzuzufügen:"
+
+#: ../src/generic/dcpsg.cpp:1627
+msgid "Cannot open file for PostScript printing!"
+msgstr "Kann Datei für den Postscriptdruck nicht öffnen!"
+
+#: ../src/generic/dirctrlg.cpp:402
+msgid "Computer"
+msgstr "Computer"
+
+#: ../src/generic/dirctrlg.cpp:404
+msgid "Sections"
+msgstr "Abschnitte"
+
+#: ../src/generic/dirctrlg.cpp:482
+msgid "Home directory"
+msgstr "Benutzerverzeichnis"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/generic/dirctrlg.cpp:484 ../src/propgrid/advprops.cpp:811
+msgid "Desktop"
+msgstr "Arbeitsoberfläche"
+
+#: ../src/generic/dirctrlg.cpp:528 ../src/generic/filectrlg.cpp:752
+msgid "Illegal directory name."
+msgstr "Ungültiger Verzeichnisname."
+
+#: ../src/generic/dirctrlg.cpp:528 ../src/generic/dirctrlg.cpp:546
+#: ../src/generic/dirctrlg.cpp:557 ../src/generic/dirdlgg.cpp:317
+#: ../src/generic/filectrlg.cpp:638 ../src/generic/filectrlg.cpp:752
+#: ../src/generic/filectrlg.cpp:766 ../src/generic/filectrlg.cpp:782
+#: ../src/generic/filectrlg.cpp:1356 ../src/generic/filectrlg.cpp:1387
+#: ../src/generic/filedlgg.cpp:362 ../src/gtk/filedlg.cpp:76
+msgid "Error"
+msgstr "Fehler"
+
+#: ../src/generic/dirctrlg.cpp:546 ../src/generic/filectrlg.cpp:766
+msgid "File name exists already."
+msgstr "Dateiname bereits vorhanden."
+
+#: ../src/generic/dirctrlg.cpp:557 ../src/generic/dirdlgg.cpp:317
+#: ../src/generic/filectrlg.cpp:638 ../src/generic/filectrlg.cpp:782
+msgid "Operation not permitted."
+msgstr "Ausführung nicht erlaubt."
+
+#: ../src/generic/dirdlgg.cpp:107 ../src/generic/filedlgg.cpp:207
+msgid "Create new directory"
+msgstr "Neues Verzeichnis anlegen"
+
+#: ../src/generic/dirdlgg.cpp:112 ../src/generic/filedlgg.cpp:203
+msgid "Go to home directory"
+msgstr "Gehe zum Benutzerverzeichnis"
+
+#: ../src/generic/dirdlgg.cpp:143
+msgid "Show &hidden directories"
+msgstr "Versteckte Verzeic&hnisse anzeigen"
+
+#: ../src/generic/dirdlgg.cpp:196
+#, c-format
+msgid ""
+"The directory '%s' does not exist\n"
+"Create it now?"
+msgstr ""
+"Verzeichnis „%s“ existiert nicht.\n"
+"Soll es jetzt erstellt werden?"
+
+#: ../src/generic/dirdlgg.cpp:198
+msgid "Directory does not exist"
+msgstr "Verzeichnis existiert nicht"
+
+#: ../src/generic/dirdlgg.cpp:214
+#, c-format
+msgid ""
+"Failed to create directory '%s'\n"
+"(Do you have the required permissions?)"
+msgstr ""
+"Konnte Verzeichnis „%s“ nicht erstellen\n"
+"(Haben Sie die nötigen Zugriffsrechte?)"
+
+#: ../src/generic/dirdlgg.cpp:216
+msgid "Error creating directory"
+msgstr "Fehler beim Anlegen des Verzeichnisses"
+
+#: ../src/generic/dirdlgg.cpp:281
+msgid "You cannot add a new directory to this section."
+msgstr "Sie können hier kein neues Verzeichnis anlegen."
+
+#: ../src/generic/dirdlgg.cpp:282
+msgid "Create directory"
+msgstr "Verzeichnis anlegen"
+
+#: ../src/generic/dirdlgg.cpp:291 ../src/generic/dirdlgg.cpp:301
+#: ../src/generic/filectrlg.cpp:614 ../src/generic/filectrlg.cpp:623
+msgid "NewName"
+msgstr "NeuerName"
+
+#: ../src/generic/editlbox.cpp:135
+msgid "Edit item"
+msgstr "Element bearbeiten"
+
+#: ../src/generic/editlbox.cpp:143
+msgid "New item"
+msgstr "Neues Element"
+
+#: ../src/generic/editlbox.cpp:151
+msgid "Delete item"
+msgstr "Element löschen"
+
+#: ../src/generic/editlbox.cpp:159
+msgid "Move up"
+msgstr "Nach oben"
+
+#: ../src/generic/editlbox.cpp:164
+msgid "Move down"
+msgstr "Abwärts verschieben"
+
+#: ../src/generic/fdrepdlg.cpp:108
+msgid "Search for:"
+msgstr "Suchen nach:"
+
+#: ../src/generic/fdrepdlg.cpp:120
+msgid "Replace with:"
+msgstr "Ersetzen durch:"
+
+#: ../src/generic/fdrepdlg.cpp:140
+msgid "Whole word"
+msgstr "Ganzes Wort"
+
+#: ../src/generic/fdrepdlg.cpp:143
+msgid "Match case"
+msgstr "Groß- und Kleinschreibung beachten"
+
+#: ../src/generic/fdrepdlg.cpp:156
+msgid "Search direction"
+msgstr "Suchrichtung"
+
+#: ../src/generic/fdrepdlg.cpp:175
+msgid "&Replace"
+msgstr "&Ersetzen"
+
+#: ../src/generic/fdrepdlg.cpp:178
+msgid "Replace &all"
+msgstr "Alle &ersetzen"
+
+#: ../src/generic/filectrlg.cpp:246 ../src/generic/filectrlg.cpp:269
+msgid "<DIR>"
+msgstr "<VERZEICHNIS>"
+
+#: ../src/generic/filectrlg.cpp:248 ../src/generic/filectrlg.cpp:271
+msgid "<LINK>"
+msgstr "<LINK>"
+
+#: ../src/generic/filectrlg.cpp:250 ../src/generic/filectrlg.cpp:273
+msgid "<DRIVE>"
+msgstr "<LAUFWERK>"
+
+#: ../src/generic/filectrlg.cpp:275
+#, c-format
+msgid "%ld byte"
+msgid_plural "%ld bytes"
+msgstr[0] "%ld Byte"
+msgstr[1] "%ld Bytes"
+
+#: ../src/generic/filectrlg.cpp:420
+msgid "Name"
+msgstr "Name"
+
+#: ../src/generic/filectrlg.cpp:421 ../src/richtext/richtextformatdlg.cpp:361
+#: ../src/richtext/richtextsizepage.cpp:298
+msgid "Size"
+msgstr "Größe"
+
+#: ../src/generic/filectrlg.cpp:422
+msgid "Type"
+msgstr "Typ"
+
+#: ../src/generic/filectrlg.cpp:423
+msgid "Modified"
+msgstr "Geändert"
+
+#: ../src/generic/filectrlg.cpp:426
+msgid "Permissions"
+msgstr "Zugriffsrechte"
+
+#: ../src/generic/filectrlg.cpp:429
+msgid "Attributes"
+msgstr "Eigenschaften"
+
+#: ../src/generic/filectrlg.cpp:936
+msgid "Current directory:"
+msgstr "Aktuelles Verzeichnis:"
+
+#: ../src/generic/filectrlg.cpp:979
+msgid "Show &hidden files"
+msgstr "V&ersteckte Dateien anzeigen"
+
+#: ../src/generic/filectrlg.cpp:1355
+msgid "Illegal file specification."
+msgstr "Ungültige Dateiangabe."
+
+#: ../src/generic/filectrlg.cpp:1387
+msgid "Directory doesn't exist."
+msgstr "Verzeichnis existiert nicht."
+
+#: ../src/generic/filedlgg.cpp:195
+msgid "View files as a list view"
+msgstr "Dateien als Liste anzeigen"
+
+#: ../src/generic/filedlgg.cpp:197
+msgid "View files as a detailed view"
+msgstr "Dateien mit Details anzeigen"
+
+#: ../src/generic/filedlgg.cpp:200
+msgid "Go to parent directory"
+msgstr "Gehe zum „Parent“-Verzeichnis"
+
+#: ../src/generic/filedlgg.cpp:351 ../src/gtk/filedlg.cpp:59
+#, c-format
+msgid "File '%s' already exists, do you really want to overwrite it?"
+msgstr ""
+"Datei „%s“ existiert bereits, möchten Sie diese wirklich überschreiben?"
+
+#: ../src/generic/filedlgg.cpp:354 ../src/gtk/filedlg.cpp:62
+msgid "Confirm"
+msgstr "Bestätigen"
+
+#: ../src/generic/filedlgg.cpp:362 ../src/gtk/filedlg.cpp:75
+msgid "Please choose an existing file."
+msgstr "Bitte wählen Sie eine bestehende Datei."
+
+#: ../src/generic/filepickerg.cpp:64
+msgid "..."
+msgstr "…"
+
+#: ../src/generic/fontdlgg.cpp:76 ../src/richtext/richtextformatdlg.cpp:519
+msgid "ABCDEFGabcdefg12345"
+msgstr "ABCDEFGabcdefg12345ÄÖÜßäöü"
+
+#: ../src/generic/fontdlgg.cpp:315
+msgid "Roman"
+msgstr "Roman"
+
+#: ../src/generic/fontdlgg.cpp:316
+msgid "Decorative"
+msgstr "Dekorativ"
+
+#: ../src/generic/fontdlgg.cpp:317
+msgid "Modern"
+msgstr "Modern"
+
+#: ../src/generic/fontdlgg.cpp:318
+msgid "Script"
+msgstr "Skript"
+
+#: ../src/generic/fontdlgg.cpp:319
+msgid "Swiss"
+msgstr "Swiss"
+
+#: ../src/generic/fontdlgg.cpp:320
+msgid "Teletype"
+msgstr "Schreibmaschine"
+
+#: ../src/generic/fontdlgg.cpp:321 ../src/generic/fontdlgg.cpp:324
+msgid "Normal"
+msgstr "Normal"
+
+#: ../src/generic/fontdlgg.cpp:323
+msgid "Slant"
+msgstr "Geneigt"
+
+#: ../src/generic/fontdlgg.cpp:325
+msgid "Light"
+msgstr "Dünn"
+
+#: ../src/generic/fontdlgg.cpp:363
+msgid "&Font family:"
+msgstr "&Schriftart:"
+
+#: ../src/generic/fontdlgg.cpp:367 ../src/generic/fontdlgg.cpp:369
+msgid "The font family."
+msgstr "Die Schriftart."
+
+#: ../src/generic/fontdlgg.cpp:374 ../src/richtext/richtextstylepage.cpp:105
+msgid "&Style:"
+msgstr "&Stil:"
+
+#: ../src/generic/fontdlgg.cpp:378 ../src/generic/fontdlgg.cpp:380
+msgid "The font style."
+msgstr "Der Schriftschnitt."
+
+#: ../src/generic/fontdlgg.cpp:385
+msgid "&Weight:"
+msgstr "&Dicke:"
+
+#: ../src/generic/fontdlgg.cpp:389 ../src/generic/fontdlgg.cpp:391
+msgid "The font weight."
+msgstr "Die Schriftdicke."
+
+#: ../src/generic/fontdlgg.cpp:399
+msgid "C&olour:"
+msgstr "&Farbe:"
+
+#: ../src/generic/fontdlgg.cpp:407 ../src/generic/fontdlgg.cpp:409
+msgid "The font colour."
+msgstr "Die Schriftfarbe."
+
+#: ../src/generic/fontdlgg.cpp:415
+msgid "&Point size:"
+msgstr "Schriftgröße in &Punkt:"
+
+#: ../src/generic/fontdlgg.cpp:420 ../src/generic/fontdlgg.cpp:422
+#: ../src/generic/fontdlgg.cpp:426 ../src/generic/fontdlgg.cpp:428
+msgid "The font point size."
+msgstr "Die Schriftgröße in Punkt."
+
+#: ../src/generic/fontdlgg.cpp:439 ../src/generic/fontdlgg.cpp:441
+msgid "Whether the font is underlined."
+msgstr "Ob der Schrifttyp unterstrichen ist."
+
+#: ../src/generic/fontdlgg.cpp:448 ../src/html/helpwnd.cpp:1215
+msgid "Preview:"
+msgstr "Vorschau:"
+
+#: ../src/generic/fontdlgg.cpp:452 ../src/generic/fontdlgg.cpp:454
+msgid "Shows the font preview."
+msgstr "Zeigt die Schriftvorschau."
+
+#: ../src/generic/fontdlgg.cpp:464 ../src/generic/fontdlgg.cpp:483
+msgid "Click to cancel the font selection."
+msgstr "Klicken um Wahl der Schriftart abzubrechen."
+
+#: ../src/generic/fontdlgg.cpp:469 ../src/generic/fontdlgg.cpp:471
+#: ../src/generic/fontdlgg.cpp:476 ../src/generic/fontdlgg.cpp:478
+msgid "Click to confirm the font selection."
+msgstr "Klicken um Wahl der Schriftart zu bestätigen."
+
+#: ../src/generic/fontpickerg.cpp:50 ../src/gtk/fontdlg.cpp:77
+msgid "Choose font"
+msgstr "Schriftart wählen"
+
+#: ../src/generic/grid.cpp:6542
+msgid ""
+"Error copying grid to the clipboard. Either selected cells were not "
+"contiguous or no cell was selected."
+msgstr ""
+"Fehler beim Kopieren des Rasters in die Zwischenablage. Entweder die Zellen "
+"waren nicht aufeinanderfolgend oder keine Zelle war ausgewählt."
+
+#: ../src/generic/grid.cpp:12739
+msgid "Grid Corner"
+msgstr "Rasterecke"
+
+#: ../src/generic/grid.cpp:12741
+#, c-format
+msgid "Column %s Header"
+msgstr "Spalte %s Kopfzeile"
+
+#: ../src/generic/grid.cpp:12743
+#, c-format
+msgid "Row %s Header"
+msgstr "Zeile %s Kopfzeile"
+
+#: ../src/generic/grid.cpp:12745
+#, c-format
+msgid "Column %s: %s"
+msgstr "Spalte %s: %s"
+
+#: ../src/generic/grid.cpp:12749
+#, c-format
+msgid "Row %s: %s"
+msgstr "Zeile %s: %s"
+
+#: ../src/generic/grid.cpp:12753
+#, c-format
+msgid "Row %s, Column %s: %s"
+msgstr "Zeile %s, Spalte %s: %s"
+
+#: ../src/generic/helpext.cpp:257
+#, c-format
+msgid "Help directory \"%s\" not found."
+msgstr "Hilfeverzeichnis „%s“ nicht gefunden."
+
+#: ../src/generic/helpext.cpp:265
+#, c-format
+msgid "Help file \"%s\" not found."
+msgstr "Hilfedatei „%s“ nicht gefunden."
+
+#: ../src/generic/helpext.cpp:284
+#, c-format
+msgid "Line %lu of map file \"%s\" has invalid syntax, skipped."
+msgstr "Zeile %lu der Abbildungsdatei „%s“ hat ungültige Syntax, übersprungen."
+
+#: ../src/generic/helpext.cpp:292
+#, c-format
+msgid "No valid mappings found in the file \"%s\"."
+msgstr "Keine gültige Abbildung in der Datei „%s“ gefunden."
+
+#: ../src/generic/helpext.cpp:435
+msgid "No entries found."
+msgstr "Keine Einträge gefunden."
+
+#: ../src/generic/helpext.cpp:444 ../src/generic/helpext.cpp:445
+msgid "Help Index"
+msgstr "Hilfeindex"
+
+#: ../src/generic/helpext.cpp:448
+msgid "Relevant entries:"
+msgstr "Relevante Einträge:"
+
+#: ../src/generic/helpext.cpp:449
+msgid "Entries found"
+msgstr "Einträge gefunden"
+
+#: ../src/generic/hyperlinkg.cpp:170
+msgid "&Copy URL"
+msgstr "URL &kopieren"
+
+#: ../src/generic/infobar.cpp:119
+msgid "Hide this notification message."
+msgstr "Diese Meldung ausblenden."
+
+#. TRANSLATORS: %s will be either the application name or "Application"
+#: ../src/generic/logg.cpp:257
+#, c-format
+msgid "%s Error"
+msgstr "%s Fehler"
+
+#. TRANSLATORS: %s will be either the application name or "Application"
+#: ../src/generic/logg.cpp:263
+#, c-format
+msgid "%s Warning"
+msgstr "%s Warnung"
+
+#. TRANSLATORS: %s will be either the application name or "Application"
+#: ../src/generic/logg.cpp:273
+#, c-format
+msgid "%s Information"
+msgstr "%s Information"
+
+#: ../src/generic/logg.cpp:276
+msgid "Application"
+msgstr "Anwendung"
+
+#: ../src/generic/logg.cpp:549
+msgid "Save log contents to file"
+msgstr "Logtexte in Datei speichern"
+
+#: ../src/generic/logg.cpp:551
+msgid "C&lear"
+msgstr "&Löschen"
+
+#: ../src/generic/logg.cpp:551
+msgid "Clear the log contents"
+msgstr "Logtexte löschen"
+
+#: ../src/generic/logg.cpp:553
+msgid "Close this window"
+msgstr "Fenster schließen"
+
+#: ../src/generic/logg.cpp:554
+msgid "&Log"
+msgstr "&Log"
+
+#: ../src/generic/logg.cpp:610 ../src/generic/logg.cpp:992
+msgid "Can't save log contents to file."
+msgstr "Kann Logtexte nicht in Datei speichern."
+
+#: ../src/generic/logg.cpp:613
+#, c-format
+msgid "Log saved to the file '%s'."
+msgstr "Logtext in Datei „%s“ gespeichert."
+
+#: ../src/generic/logg.cpp:719
+msgid "&Details"
+msgstr "&Einzelheiten"
+
+#: ../src/generic/logg.cpp:972
+msgid "Failed to copy dialog contents to the clipboard."
+msgstr "Kopieren des Dialoginhalts in die Zwischenablage fehlgeschlagen."
+
+#: ../src/generic/logg.cpp:1022
+#, c-format
+msgid "Append log to file '%s' (choosing [No] will overwrite it)?"
+msgstr "An Logdatei „%s“ anhängen ([Nein] wird sie ersetzen)?"
+
+#: ../src/generic/logg.cpp:1024
+msgid "Question"
+msgstr "Frage"
+
+#: ../src/generic/logg.cpp:1038
+msgid "invalid message box return value"
+msgstr "ungültiger Rückgabewert des Hinweisfensters"
+
+#: ../src/generic/notifmsgg.cpp:129
+msgid "Notice"
+msgstr "Bemerkung"
+
+#: ../src/generic/preferencesg.cpp:118
+#, c-format
+msgid "%s Preferences"
+msgstr "%s-Einstellungen"
+
+#: ../src/generic/printps.cpp:143
+msgid "Printing..."
+msgstr "Drucke …"
+
+#: ../src/generic/printps.cpp:160 ../src/gtk/print.cpp:1076
+#: ../src/msw/printwin.cpp:235
+msgid "Could not start printing."
+msgstr "Kann Ausdruck nicht beginnen."
+
+#: ../src/generic/printps.cpp:183
+#, c-format
+msgid "Printing page %d..."
+msgstr "Drucke Seite %d …"
+
+#: ../src/generic/prntdlgg.cpp:171
+msgid "Printer options"
+msgstr "Drucker-Einstellungen"
+
+#: ../src/generic/prntdlgg.cpp:176
+msgid "Print to File"
+msgstr "In Datei drucken"
+
+#: ../src/generic/prntdlgg.cpp:179
+msgid "Setup..."
+msgstr "Einstellungen …"
+
+#: ../src/generic/prntdlgg.cpp:187
+msgid "Printer:"
+msgstr "Drucker:"
+
+#: ../src/generic/prntdlgg.cpp:195
+msgid "Status:"
+msgstr "Status:"
+
+#: ../src/generic/prntdlgg.cpp:206
+msgid "All"
+msgstr "Alle"
+
+#: ../src/generic/prntdlgg.cpp:207
+msgid "Pages"
+msgstr "Seiten"
+
+#: ../src/generic/prntdlgg.cpp:215
+msgid "Print Range"
+msgstr "Seitenbereich"
+
+#: ../src/generic/prntdlgg.cpp:229
+msgid "From:"
+msgstr "Von:"
+
+#: ../src/generic/prntdlgg.cpp:233
+msgid "To:"
+msgstr "Bis:"
+
+#: ../src/generic/prntdlgg.cpp:238
+msgid "Copies:"
+msgstr "Kopien:"
+
+#: ../src/generic/prntdlgg.cpp:288
+msgid "PostScript file"
+msgstr "PostScript-Datei"
+
+#: ../src/generic/prntdlgg.cpp:439
+msgid "Print Setup"
+msgstr "Druckereinstellungen"
+
+#: ../src/generic/prntdlgg.cpp:483
+msgid "Printer"
+msgstr "Drucker"
+
+#: ../src/generic/prntdlgg.cpp:501
+msgid "Default printer"
+msgstr "Standarddrucker"
+
+#: ../src/generic/prntdlgg.cpp:595 ../src/generic/prntdlgg.cpp:782
+#: ../src/generic/prntdlgg.cpp:822 ../src/generic/prntdlgg.cpp:835
+#: ../src/generic/prntdlgg.cpp:1031 ../src/generic/prntdlgg.cpp:1036
+msgid "Paper size"
+msgstr "Papierformat"
+
+#: ../src/generic/prntdlgg.cpp:604 ../src/generic/prntdlgg.cpp:847
+msgid "Portrait"
+msgstr "Hochformat"
+
+#: ../src/generic/prntdlgg.cpp:605 ../src/generic/prntdlgg.cpp:848
+msgid "Landscape"
+msgstr "Querformat"
+
+#: ../src/generic/prntdlgg.cpp:607 ../src/generic/prntdlgg.cpp:849
+msgid "Orientation"
+msgstr "Ausrichtung"
+
+#: ../src/generic/prntdlgg.cpp:610
+msgid "Options"
+msgstr "Einstellungen"
+
+#: ../src/generic/prntdlgg.cpp:612
+msgid "Print in colour"
+msgstr "Farbig drucken"
+
+#: ../src/generic/prntdlgg.cpp:621
+msgid "Print spooling"
+msgstr "Druckersteuerung"
+
+#: ../src/generic/prntdlgg.cpp:623
+msgid "Printer command:"
+msgstr "Druckbefehl:"
+
+#: ../src/generic/prntdlgg.cpp:631
+msgid "Printer options:"
+msgstr "Drucker-Einstellungen:"
+
+#: ../src/generic/prntdlgg.cpp:860
+msgid "Left margin (mm):"
+msgstr "Linker Rand (mm):"
+
+#: ../src/generic/prntdlgg.cpp:861
+msgid "Top margin (mm):"
+msgstr "Oberer Rand (mm):"
+
+#: ../src/generic/prntdlgg.cpp:872
+msgid "Right margin (mm):"
+msgstr "Rechter Rand (mm):"
+
+#: ../src/generic/prntdlgg.cpp:873
+msgid "Bottom margin (mm):"
+msgstr "Unterer Rand (mm):"
+
+#: ../src/generic/prntdlgg.cpp:896
+msgid "Printer..."
+msgstr "Drucker …"
+
+#: ../src/generic/progdlgg.cpp:246
+msgid "&Skip"
+msgstr "Ü&berspringen"
+
+#: ../src/generic/progdlgg.cpp:347 ../src/generic/progdlgg.cpp:626
+msgid "Unknown"
+msgstr "Unbekannt"
+
+#: ../src/generic/progdlgg.cpp:451 ../src/msw/progdlg.cpp:526
+msgid "Done."
+msgstr "Fertig."
+
+#: ../src/generic/srchctlg.cpp:55 ../src/gtk/srchctrl.cpp:206
+#: ../src/html/helpwnd.cpp:530 ../src/html/helpwnd.cpp:545
+msgid "Search"
+msgstr "Suchen"
+
+#: ../src/generic/tabg.cpp:1026
+msgid "Could not find tab for id"
+msgstr "Konnte Seite für ID nicht finden"
+
+#: ../src/generic/tipdlg.cpp:136
+msgid "Tips not available, sorry!"
+msgstr "Bedauere, Tipps stehen nicht zur Verfügung!"
+
+#: ../src/generic/tipdlg.cpp:197
+msgid "Tip of the Day"
+msgstr "Tipp des Tages"
+
+#: ../src/generic/tipdlg.cpp:207
+msgid "Did you know..."
+msgstr "Wussten Sie schon …"
+
+#: ../src/generic/tipdlg.cpp:232
+msgid "&Show tips at startup"
+msgstr "&Tipps beim Programmstart zeigen"
+
+#: ../src/generic/tipdlg.cpp:236
+msgid "&Next Tip"
+msgstr "&Nächster Tipp"
+
+#: ../src/generic/wizard.cpp:411
+msgid "&Next >"
+msgstr "&Weiter >"
+
+#: ../src/generic/wizard.cpp:412
+msgid "&Finish"
+msgstr "&Fertigstellen"
+
+#: ../src/generic/wizard.cpp:420
+msgid "< &Back"
+msgstr "< &Zurück"
+
+#: ../src/gtk/aboutdlg.cpp:204
+msgid "translator-credits"
+msgstr "Übersetzer"
+
+#: ../src/gtk/app.cpp:517
+msgid ""
+"WARNING: using XIM input method is unsupported and may result in problems "
+"with input handling and flickering. Consider unsetting GTK_IM_MODULE or "
+"setting to \"ibus\"."
+msgstr ""
+"WARNUNG: Das Benutzen der XIM-Eingabemethode wird nicht unterstützt und kann "
+"zu Problemen mit der Eingabebehandlung und zum Flackern führen. Erwägen Sie "
+"das Zurücksetzen von GTK_IM_MODULE oder das Setzen auf \"ibus\"."
+
+#: ../src/gtk/app.cpp:569
+msgid "Unable to initialize GTK+, is DISPLAY set properly?"
+msgstr "Nicht möglich GTK+ zu initialisieren, ist DISPLAY korrekt gesetzt?"
+
+#: ../src/gtk/filedlg.cpp:89 ../src/gtk/filepicker.cpp:255
+#, c-format
+msgid "Changing current directory to \"%s\" failed"
+msgstr "Wechseln des aktuellen Ordners auf „%s“ fehlgeschlagen"
+
+#: ../src/gtk/font.cpp:548
+msgid ""
+"Using private fonts is not supported on this system: Pango library is too "
+"old, 1.38 or later required."
+msgstr ""
+"Die Benutzung von privaten Schriftarten wird auf diesem System nicht "
+"unterstützt: Die Pango-Bibliothek ist zu alt, die Version 1.38 oder eine "
+"spätere wird dazu benötigt."
+
+#: ../src/gtk/font.cpp:558
+msgid "Failed to create font configuration object."
+msgstr "Erzeugung des Schriftart-Konfigurationsobjektes fehlgeschlagen."
+
+#: ../src/gtk/font.cpp:568
+#, c-format
+msgid "Failed to add custom font \"%s\"."
+msgstr "Konnte benutzerspezifische Schriftart „%s“ nicht hinzufügen."
+
+#: ../src/gtk/font.cpp:576
+msgid "Failed to register font configuration using private fonts."
+msgstr ""
+"Registrierung der Schriftart-Konfiguration mit privaten Schriftarten "
+"fehlgeschlagen."
+
+#: ../src/gtk/glcanvas.cpp:117 ../src/gtk/glcanvas.cpp:132
+msgid "Fatal Error"
+msgstr "Nicht behebbarer Fehler"
+
+#: ../src/gtk/glcanvas.cpp:117
+msgid ""
+"This program wasn't compiled with EGL support required under Wayland, "
+"either\n"
+"install EGL libraries and rebuild or run it under X11 backend by setting\n"
+"environment variable GDK_BACKEND=x11 before starting your program."
+msgstr ""
+"Dieses Programm ist nicht mit EGL-Unterstützung kompiliert worden, die unter "
+"Wayland benötigt wird, entweder\n"
+"installieren Sie die EGL-Bibliotheken and erzeugen sie das Programm neu oder "
+"lassen Sie es unter einem X11 Hintergrund laufen,\n"
+"indem Sie die Umgebungsvariable GDK_BACKEND=x11 setzen, bevor Sie ihr "
+"Programm starten."
+
+#: ../src/gtk/glcanvas.cpp:132
+msgid ""
+"wxGLCanvas is only supported on Wayland and X11 currently.  You may be able "
+"to\n"
+"work around this by setting environment variable GDK_BACKEND=x11 before\n"
+"starting your program."
+msgstr ""
+"wxGLCanvas wird im Moment nur auf Wayland und X11 unterstützt. Sie können "
+"das möglicherweise\n"
+"umgehen, indem Sie die Umgebungsvariable GDK_BACKEND=x11 setzen, bevor\n"
+"Sie ihr Programm starten."
+
+#: ../src/gtk/mdi.cpp:433
+msgid "MDI child"
+msgstr "MDI child"
+
+#: ../src/gtk/power.cpp:188
+#, c-format
+msgid "Failed to open D-Bus connection to the login manager: %s"
+msgstr "Öffnen der D-Bus Verbindung zum Anmeldedienst ist fehlgeschlagen: %s"
+
+#: ../src/gtk/power.cpp:214
+msgid "wxWidgets application"
+msgstr "wxWidgets Anwendung"
+
+#: ../src/gtk/power.cpp:226
+msgid "Application needs to keep running"
+msgstr "Die Anwendung muss weiterhin laufen"
+
+#: ../src/gtk/power.cpp:233
+msgid "Clean up before suspend"
+msgstr "Aufräumen vor dem Suspendieren"
+
+#: ../src/gtk/power.cpp:259
+#, c-format
+msgid "Failed to inhibit sleep: %s"
+msgstr "Das Einschlafen konnte nicht verhindert werden: %s"
+
+#: ../src/gtk/power.cpp:265
+msgid "Unexpected response to D-Bus \"Inhibit\" request."
+msgstr "Unerwartete Antwort auf die D-Bus \"Unterdrücken\"-Anforderung."
+
+#: ../src/gtk/print.cpp:218
+msgid "Custom size"
+msgstr "Angepasste Größe"
+
+#: ../src/gtk/print.cpp:752
+#, c-format
+msgid "Error while printing: %s"
+msgstr "Fehler während des Druckens: %s"
+
+#: ../src/gtk/print.cpp:816
+msgid "Page Setup"
+msgstr "Seiten-Einstellungen"
+
+#: ../src/gtk/webview_webkit.cpp:932
+msgid "Retrieving JavaScript script output is not supported with WebKit v1"
+msgstr ""
+"Das Erhalten einer Ausgabe einer JavaScript Meldung wird mit WebKit v1 nicht "
+"unterstützt"
+
+#: ../src/gtk/webview_webkit2.cpp:1098
+msgid ""
+"Setting proxy is not supported by WebKit, at least version 2.16 is required."
+msgstr ""
+"Das Setzen des Proxy wird vom WebKit nicht unterstützt, mindestens die "
+"Version 2.16 ist nötig."
+
+#: ../src/gtk/webview_webkit2.cpp:1104
+msgid "This program was compiled without support for setting WebKit proxy."
+msgstr ""
+"Dieses Programm wurde ohne Unterstützung zum Setzen des WebKit Proxy "
+"übersetzt."
+
+#: ../src/gtk/window.cpp:6289
+msgid ""
+"GTK+ installed on this machine is too old to support screen compositing, "
+"please install GTK+ 2.12 or later."
+msgstr ""
+"Das GTK+, das auf dieser Maschine installiert ist, ist zu alt um "
+"Bildschirmanordnung zu unterstützen, bitte GTK+ 2.12 oder neuer installieren."
+
+#: ../src/gtk/window.cpp:6307
+msgid ""
+"Compositing not supported by this system, please enable it in your Window "
+"Manager."
+msgstr ""
+"Zusammenfügen wird nicht durch dieses System unterstützt, bitte über den "
+"Fenster Manager einstellen."
+
+#: ../src/gtk/window.cpp:6318
+msgid ""
+"This program was compiled with a too old version of GTK+, please rebuild "
+"with GTK+ 2.12 or newer."
+msgstr ""
+"Dieses Programm wurde mit einer zu alten Version von GTK+ übersetzt, bitte "
+"mit GTK+2.12 oder neuer erstellen."
+
+#: ../src/html/chm.cpp:138
+#, c-format
+msgid "Failed to open CHM archive '%s'."
+msgstr "CHM-Archiv „%s“ lässt sich nicht öffnen."
+
+#: ../src/html/chm.cpp:270
+#, c-format
+msgid "Could not extract %s into %s: %s"
+msgstr "Konnte nicht %s in %s extrahieren: %s"
+
+#: ../src/html/chm.cpp:324
+msgid "no error"
+msgstr "kein Fehler"
+
+#: ../src/html/chm.cpp:326
+msgid "bad arguments to library function"
+msgstr "Ungültige Argumente für die Bibliotheksfunktion"
+
+#: ../src/html/chm.cpp:328
+msgid "error opening file"
+msgstr "Fehler beim Öffnen der Datei"
+
+#: ../src/html/chm.cpp:330
+msgid "read error"
+msgstr "Lesefehler"
+
+#: ../src/html/chm.cpp:332
+msgid "write error"
+msgstr "Schreibfehler"
+
+#: ../src/html/chm.cpp:334
+msgid "seek error"
+msgstr "Seek-Fehler"
+
+#: ../src/html/chm.cpp:338
+msgid "bad signature"
+msgstr "Ungültige Unterschrift"
+
+#: ../src/html/chm.cpp:340
+msgid "error in data format"
+msgstr "Fehler im Datenformat"
+
+#: ../src/html/chm.cpp:342
+msgid "checksum error"
+msgstr "Prüfsummen-Fehler"
+
+#: ../src/html/chm.cpp:344
+msgid "compression error"
+msgstr "Fehler beim Komprimieren"
+
+#: ../src/html/chm.cpp:346
+msgid "decompression error"
+msgstr "Fehler beim Entpacken"
+
+#: ../src/html/chm.cpp:437
+#, c-format
+msgid "Could not locate file '%s'."
+msgstr "Konnte Datei „%s“ nicht finden."
+
+#: ../src/html/chm.cpp:711
+#, c-format
+msgid "Could not create temporary file '%s'"
+msgstr "Konnte temporäre Datei „%s“ nicht erzeugen"
+
+#: ../src/html/chm.cpp:718
+#, c-format
+msgid "Extraction of '%s' into '%s' failed."
+msgstr "Extrahieren von „%s“ in „%s“ schlug fehl."
+
+#: ../src/html/chm.cpp:806 ../src/html/chm.cpp:863
+msgid "CHM handler currently supports only local files!"
+msgstr "CHM-Handler unterstützt derzeit nur lokale Dateien!"
+
+#: ../src/html/chm.cpp:827
+msgid "Link contained '//', converted to absolute link."
+msgstr "Verweis enthielt „//“, in absoluten Link umgewandelt."
+
+#: ../src/html/helpctrl.cpp:59
+#, c-format
+msgid "Help: %s"
+msgstr "Hilfe: %s"
+
+#: ../src/html/helpctrl.cpp:155
+#, c-format
+msgid "Adding book %s"
+msgstr "Buch %s wird hinzugefügt"
+
+#: ../src/html/helpdata.cpp:295
+#, c-format
+msgid "Cannot open contents file: %s"
+msgstr "Kann den Inhalt der Datei %s nicht öffnen"
+
+#: ../src/html/helpdata.cpp:309
+#, c-format
+msgid "Cannot open index file: %s"
+msgstr "Kann Indexdatei %s nicht öffnen"
+
+#: ../src/html/helpdata.cpp:643
+msgid "noname"
+msgstr "namenlos"
+
+#: ../src/html/helpdata.cpp:652
+#, c-format
+msgid "Cannot open HTML help book: %s"
+msgstr "HTML-Hilfebuch %s kann nicht geöffnet werden"
+
+#: ../src/html/helpwnd.cpp:315
+msgid "Displays help as you browse the books on the left."
+msgstr ""
+"Anzeigen bieten Unterstützung beim Navigieren der Bücher auf der linken "
+"Seite."
+
+#: ../src/html/helpwnd.cpp:411 ../src/html/helpwnd.cpp:1100
+#: ../src/html/helpwnd.cpp:1735
+msgid "(bookmarks)"
+msgstr "(Lesezeichen)"
+
+#: ../src/html/helpwnd.cpp:424
+msgid "Add current page to bookmarks"
+msgstr "Aktuelle Seite zu Lesezeichen hinzufügen"
+
+#: ../src/html/helpwnd.cpp:425
+msgid "Remove current page from bookmarks"
+msgstr "Aktuelle Seite aus Lesezeichen entfernen"
+
+#: ../src/html/helpwnd.cpp:470
+msgid "Contents"
+msgstr "Inhalte"
+
+#: ../src/html/helpwnd.cpp:485
+msgid "Find"
+msgstr "Suchen"
+
+#: ../src/html/helpwnd.cpp:487
+msgid "Show all"
+msgstr "Alles zeigen"
+
+#: ../src/html/helpwnd.cpp:497
+msgid ""
+"Display all index items that contain given substring. Search is case "
+"insensitive."
+msgstr ""
+"Alle Indexelemente anzeigen, die den gegebenen Suchbegriff enthalten. Groß-/"
+"Kleinschreibung wird nicht beachtet."
+
+#: ../src/html/helpwnd.cpp:498
+msgid "Show all items in index"
+msgstr "Alle Themen im Index anzeigen"
+
+#: ../src/html/helpwnd.cpp:528
+msgid "Case sensitive"
+msgstr "Groß-/Kleinschreibung"
+
+#: ../src/html/helpwnd.cpp:529
+msgid "Whole words only"
+msgstr "Nur ganze Worte"
+
+#: ../src/html/helpwnd.cpp:532
+msgid ""
+"Search contents of help book(s) for all occurrences of the text you typed "
+"above"
+msgstr ""
+"Den Inhalt der Hilfebücher nach allen Vorkommen des oben eingegebenen "
+"Begriffs durchsuchen"
+
+#: ../src/html/helpwnd.cpp:653
+msgid "Show/hide navigation panel"
+msgstr "Suchbaum ein-/ausblenden"
+
+#: ../src/html/helpwnd.cpp:655
+msgid "Go back"
+msgstr "Zurück"
+
+#: ../src/html/helpwnd.cpp:656
+msgid "Go forward"
+msgstr "Vorwärts"
+
+#: ../src/html/helpwnd.cpp:658
+msgid "Go one level up in document hierarchy"
+msgstr "In die nächste Dokumentebene gehen"
+
+#: ../src/html/helpwnd.cpp:666 ../src/html/helpwnd.cpp:1547
+msgid "Open HTML document"
+msgstr "Öffne HTML-Dokument"
+
+#: ../src/html/helpwnd.cpp:670
+msgid "Print this page"
+msgstr "Diese Seite drucken"
+
+#: ../src/html/helpwnd.cpp:674
+msgid "Display options dialog"
+msgstr "Einstellungen-Dialog anzeigen"
+
+#: ../src/html/helpwnd.cpp:795
+msgid "Please choose the page to display:"
+msgstr "Bitte wählen Sie die darzustellende Seite:"
+
+#: ../src/html/helpwnd.cpp:796
+msgid "Help Topics"
+msgstr "Hilfethemen"
+
+#: ../src/html/helpwnd.cpp:852
+msgid "Searching..."
+msgstr "Suchen …"
+
+#: ../src/html/helpwnd.cpp:853
+msgid "No matching page found yet"
+msgstr "Passende Seite noch nicht gefunden"
+
+#: ../src/html/helpwnd.cpp:870
+#, c-format
+msgid "Found %i matches"
+msgstr "Suchbegriff %i mal gefunden"
+
+#: ../src/html/helpwnd.cpp:958
+msgid "(Help)"
+msgstr "(Hilfe)"
+
+#: ../src/html/helpwnd.cpp:1026
+#, c-format
+msgid "%d of %lu"
+msgstr "%d von %lu"
+
+#: ../src/html/helpwnd.cpp:1028
+#, c-format
+msgid "%lu of %lu"
+msgstr "%lu von %lu"
+
+#: ../src/html/helpwnd.cpp:1047
+msgid "Search in all books"
+msgstr "Alle Bücher durchsuchen"
+
+#: ../src/html/helpwnd.cpp:1193
+msgid "Help Browser Options"
+msgstr "Hilfe zu den Browser-Einstellungen"
+
+#: ../src/html/helpwnd.cpp:1198
+msgid "Normal font:"
+msgstr "Normal Font:"
+
+#: ../src/html/helpwnd.cpp:1199
+msgid "Fixed font:"
+msgstr "Schrift fester Breite:"
+
+#: ../src/html/helpwnd.cpp:1200
+msgid "Font size:"
+msgstr "Schriftgröße:"
+
+#: ../src/html/helpwnd.cpp:1245
+msgid "font size"
+msgstr "Schriftgröße"
+
+#: ../src/html/helpwnd.cpp:1256
+msgid "Normal face<br>and <u>underlined</u>. "
+msgstr "Normale Schrift<br>und <u>unterstrichen</u>. "
+
+#: ../src/html/helpwnd.cpp:1257
+msgid "<i>Italic face.</i> "
+msgstr "<i>Kursive Schrift.</i> "
+
+#: ../src/html/helpwnd.cpp:1258
+msgid "<b>Bold face.</b> "
+msgstr "<b>Fette Schrift.</b> "
+
+#: ../src/html/helpwnd.cpp:1259
+msgid "<b><i>Bold italic face.</i></b><br>"
+msgstr "<b><i>Fette kursive Schrift</i></b><br>"
+
+#: ../src/html/helpwnd.cpp:1262
+msgid "Fixed size face.<br> <b>bold</b> <i>italic</i> "
+msgstr "Schrift fester Breite.<br> <b>fett</b> <i>kursiv</i> "
+
+#: ../src/html/helpwnd.cpp:1263
+msgid "<b><i>bold italic <u>underlined</u></i></b><br>"
+msgstr "<b><i>fett kursiv <u>unterstrichen</u></i></b><br>"
+
+#: ../src/html/helpwnd.cpp:1524
+msgid "Help Printing"
+msgstr "Hilfe drucken"
+
+#: ../src/html/helpwnd.cpp:1527
+msgid "Cannot print empty page."
+msgstr "Leere Seite kann nicht gedruckt werden."
+
+#: ../src/html/helpwnd.cpp:1540
+msgid "HTML files (*.html;*.htm)|*.html;*.htm|"
+msgstr "HTML-Dateien (*.html;*.htm)|*.html;*.htm|"
+
+#: ../src/html/helpwnd.cpp:1541
+msgid "Help books (*.htb)|*.htb|Help books (*.zip)|*.zip|"
+msgstr "Hilfe-Bücher (*.htb)|*.htb|Hilfe-Bücher (*.zip)|*.zip|"
+
+#: ../src/html/helpwnd.cpp:1542
+msgid "HTML Help Project (*.hhp)|*.hhp|"
+msgstr "HTML-Hilfe-Projekt (*.hhp)|*.hhp|"
+
+#: ../src/html/helpwnd.cpp:1544
+msgid "Compressed HTML Help file (*.chm)|*.chm|"
+msgstr "Komprimierte HTML-Hilfedatei (*.chm)|*.chm|"
+
+#: ../src/html/helpwnd.cpp:1671
+#, c-format
+msgid "%i of %u"
+msgstr "%i von %u"
+
+#: ../src/html/helpwnd.cpp:1709
+#, c-format
+msgid "%u of %u"
+msgstr "%u von %u"
+
+#: ../src/html/htmlfilt.cpp:134
+#, c-format
+msgid "Cannot open HTML document: %s"
+msgstr "HTML-Dokument %s kann nicht geöffnet werden"
+
+#: ../src/html/htmlwin.cpp:599
+msgid "Connecting..."
+msgstr "Verbinde …"
+
+#: ../src/html/htmlwin.cpp:616
+#, c-format
+msgid "Unable to open requested HTML document: %s"
+msgstr "Das angeforderte HTML-Dokument konnte nicht geöffnet werden: %s"
+
+#: ../src/html/htmlwin.cpp:630
+msgid "Loading : "
+msgstr "Laden: "
+
+#: ../src/html/htmlwin.cpp:673
+msgid "Done"
+msgstr "Fertig"
+
+#: ../src/html/htmlwin.cpp:723
+#, c-format
+msgid "HTML anchor %s does not exist."
+msgstr "HTML-Anker %s existiert nicht."
+
+#: ../src/html/htmlwin.cpp:1057
+#, c-format
+msgid "Copied to clipboard:\"%s\""
+msgstr "In Zwischenablage kopiert:„%s“"
+
+#: ../src/html/htmprint.cpp:269
+msgid ""
+"This document doesn't fit on the page horizontally and will be truncated "
+"when it is printed."
+msgstr ""
+"Dieses Dokument ist zu breit für die Seite und wird beim Drucken "
+"abgeschnitten."
+
+#: ../src/html/htmprint.cpp:285
+#, c-format
+msgid ""
+"The document \"%s\" doesn't fit on the page horizontally and will be "
+"truncated if printed.\n"
+"\n"
+"Would you like to proceed with printing it nevertheless?"
+msgstr ""
+"Das Dokument „%s“ ist zu breit für die Seite und wird beim Drucken "
+"abgeschnitten.\n"
+"\n"
+"Wollen Sie dennoch mit dem Drucken fortfahren?"
+
+#: ../src/html/htmprint.cpp:296
+msgid ""
+"If possible, try changing the layout parameters to make the printout more "
+"narrow."
+msgstr ""
+"Wenn möglich die Layout-Parameter ändern um den Ausdruck schmaler zu machen."
+
+#: ../src/html/htmprint.cpp:445
+msgid ": file does not exist!"
+msgstr ": Datei existiert nicht!"
+
+#. TRANSLATORS: %s may be a document title.
+#: ../src/html/htmprint.cpp:717
+#, c-format
+msgid "%s Preview"
+msgstr "%s Vorschau"
+
+#: ../src/html/htmprint.cpp:755 ../src/richtext/richtextprint.cpp:618
+msgid ""
+"There was a problem during page setup: you may need to set a default printer."
+msgstr ""
+"Es gab ein Problem bei der Seiteneinrichtung: eventuell müssen Sie einen\n"
+"Standarddrucker einrichten."
+
+#: ../src/msw/clipbrd.cpp:80
+msgid "Failed to open the clipboard."
+msgstr "Konnte Zwischenablage nicht öffnen."
+
+#: ../src/msw/clipbrd.cpp:101
+msgid "Failed to close the clipboard."
+msgstr "Konnte Zwischenablage nicht schließen."
+
+#: ../src/msw/clipbrd.cpp:113
+msgid "Failed to empty the clipboard."
+msgstr "Konnte Zwischenablage nicht leeren."
+
+#: ../src/msw/clipbrd.cpp:284
+msgid "Failed to put data on the clipboard"
+msgstr "Versuch Daten in der Zwischenablage abzulegen, fehlgeschlagen"
+
+#: ../src/msw/clipbrd.cpp:326
+msgid "Failed to get data from the clipboard"
+msgstr "Konnte Daten nicht aus der Zwischenablage kopieren"
+
+#: ../src/msw/clipbrd.cpp:363
+msgid "Failed to retrieve the supported clipboard formats"
+msgstr ""
+"Konnte die von der Zwischenablage unterstützten Formate nicht ermitteln"
+
+#: ../src/msw/colordlg.cpp:228
+#, c-format
+msgid "Colour selection dialog failed with error %0lx."
+msgstr "Farbauswahldialog schlug mit Fehler %0lx fehl."
+
+#: ../src/msw/cursor.cpp:141
+msgid "Failed to create cursor."
+msgstr "Cursor konnte nicht erzeugt werden."
+
+#: ../src/msw/dde.cpp:279
+#, c-format
+msgid "Failed to register DDE server '%s'"
+msgstr "Versuch DDE-Server „%s“ zu registrieren, fehlgeschlagen"
+
+#: ../src/msw/dde.cpp:300
+#, c-format
+msgid "Failed to unregister DDE server '%s'"
+msgstr "Die Registrierung des DDE-Servers „%s“ konnte nicht aufgehoben werden"
+
+#: ../src/msw/dde.cpp:428
+#, c-format
+msgid "Failed to create connection to server '%s' on topic '%s'"
+msgstr "Aufbau der Verbindung zum Server „%s“ „on topic“ „%s“ fehlgeschlagen"
+
+#: ../src/msw/dde.cpp:655
+msgid "DDE poke request failed"
+msgstr "DDE „poke“ Anfrage fehlgeschlagen"
+
+#: ../src/msw/dde.cpp:674
+msgid "Failed to establish an advise loop with DDE server"
+msgstr "Aufbau einer „advise Schleife“ mit dem DDE-Server fehlgeschlagen"
+
+#: ../src/msw/dde.cpp:693
+msgid "Failed to terminate the advise loop with DDE server"
+msgstr ""
+"Versuch fehlgeschlagen, die „advise Schleife“ mit DDE-Server zu beenden"
+
+#: ../src/msw/dde.cpp:768
+msgid "Failed to send DDE advise notification"
+msgstr "Versuch fehlgeschlagen, eine DDE-Benachrichtigung zu schicken"
+
+#: ../src/msw/dde.cpp:1085
+msgid "Failed to create DDE string"
+msgstr "Erstellung der DDE-Zeichenkette fehlgeschlagen"
+
+#: ../src/msw/dde.cpp:1131
+msgid "no DDE error."
+msgstr "kein DDE-Fehler."
+
+#: ../src/msw/dde.cpp:1135
+msgid "a request for a synchronous advise transaction has timed out."
+msgstr ""
+"Eine Anfrage für eine „synchronous advise transaction“ ist fehlgeschlagen "
+"(time-out)"
+
+#: ../src/msw/dde.cpp:1138
+msgid "the response to the transaction caused the DDE_FBUSY bit to be set."
+msgstr "das Ergebnis zur Transaktion hat das „DDE_FBUSY“-Bit gesetzt."
+
+#: ../src/msw/dde.cpp:1141
+msgid "a request for a synchronous data transaction has timed out."
+msgstr ""
+"Eine Anfrage für eine „synchronous data transaction“ ist fehlgeschlagen "
+"(time-out)"
+
+#: ../src/msw/dde.cpp:1144
+msgid ""
+"a DDEML function was called without first calling the DdeInitialize "
+"function,\n"
+"or an invalid instance identifier\n"
+"was passed to a DDEML function."
+msgstr ""
+"Eine DDEML-Funktion wurde aufgerufen, ohne vorher die Deinitialisierungs-"
+"Funktion aufzurufen,\n"
+"oder ein ungültiger „instance identifier“\n"
+"wurde an eine DDEML-Funktion übergeben."
+
+#: ../src/msw/dde.cpp:1147
+msgid ""
+"an application initialized as APPCLASS_MONITOR has\n"
+"attempted to perform a DDE transaction,\n"
+"or an application initialized as APPCMD_CLIENTONLY has \n"
+"attempted to perform server transactions."
+msgstr ""
+"Eine Anwendung, die als ein „APPCLASS_MONITOR“ gestartet wurde, \n"
+"versuchte eine DDE-Transaktion auszuführen,\n"
+"oder eine Anwendung, die als ein „APPCMD_CLIENTONLY“ gestartet wurde, \n"
+"versuchte eine Server-Transaktion auszuführen."
+
+#: ../src/msw/dde.cpp:1150
+msgid "a request for a synchronous execute transaction has timed out."
+msgstr ""
+"Eine Anfrage für eine „synchronous execute transaction“ ist fehlgeschlagen "
+"(time-out)"
+
+#: ../src/msw/dde.cpp:1153
+msgid "a parameter failed to be validated by the DDEML."
+msgstr "Ein Parameter wurde von DDEML nicht verifiziert."
+
+#: ../src/msw/dde.cpp:1156
+msgid "a DDEML application has created a prolonged race condition."
+msgstr "Eine DDEML-Anwendung hat eine „prolonged race condition“ ausgelöst."
+
+#: ../src/msw/dde.cpp:1159
+msgid "a memory allocation failed."
+msgstr "Eine Speicheranforderung ist fehlgeschlagen."
+
+#: ../src/msw/dde.cpp:1162
+msgid "a client's attempt to establish a conversation has failed."
+msgstr ""
+"Der Versuch eines Clients, eine Verbindung herzustellen, ist fehlgeschlagen."
+
+#: ../src/msw/dde.cpp:1165
+msgid "a transaction failed."
+msgstr "Eine Transaktion ist fehlgeschlagen."
+
+#: ../src/msw/dde.cpp:1168
+msgid "a request for a synchronous poke transaction has timed out."
+msgstr ""
+"Eine Anfrage für eine „synchronous poke transaction“ ist fehlgeschlagen "
+"(time-out)"
+
+#: ../src/msw/dde.cpp:1171
+msgid "an internal call to the PostMessage function has failed. "
+msgstr "Ein interner Aufruf zur „PostMessage“-Funktion ist fehlgeschlagen. "
+
+#: ../src/msw/dde.cpp:1174
+msgid "reentrancy problem."
+msgstr "Probleme beim Wiedereintreten."
+
+#: ../src/msw/dde.cpp:1177
+msgid ""
+"a server-side transaction was attempted on a conversation\n"
+"that was terminated by the client, or the server\n"
+"terminated before completing a transaction."
+msgstr ""
+"Ein Verbindungs-Versuch vom Server\n"
+"wurde vom Client unterbrochen, oder der Server\n"
+"beendete bevor die Transaktion vollständig beendet wurde."
+
+#: ../src/msw/dde.cpp:1180
+msgid "an internal error has occurred in the DDEML."
+msgstr "Ein interner Fehler ist im DDEML aufgetreten."
+
+#: ../src/msw/dde.cpp:1183
+msgid "a request to end an advise transaction has timed out."
+msgstr ""
+"Eine Anfrage, eine „advise transaction“ zu beenden ist, fehlgeschlagen (time-"
+"out)"
+
+#: ../src/msw/dde.cpp:1186
+msgid ""
+"an invalid transaction identifier was passed to a DDEML function.\n"
+"Once the application has returned from an XTYP_XACT_COMPLETE callback,\n"
+"the transaction identifier for that callback is no longer valid."
+msgstr ""
+"Eine ungültige Transaktions-Identifizierung wurde an eine DDEML-Funktion "
+"übergeben.\n"
+"Sobald die Anwendung aus einem „XTYP_XACT_COMPLETE“-Callback zurückkehrt,\n"
+"ist die Transaktions-Identifizierung für diesen Callback nicht mehr gültig."
+
+#: ../src/msw/dde.cpp:1189
+#, c-format
+msgid "Unknown DDE error %08x"
+msgstr "Unbekannter DDE-Fehler %08x"
+
+#: ../src/msw/dialup.cpp:343
+msgid ""
+"Dial up functions are unavailable because the remote access service (RAS) is "
+"not installed on this machine. Please install it."
+msgstr ""
+"DFÜ-Verbindungs-Funktionen stehen nicht zur Verfügung, da der RAS-Dienst "
+"(Remote Access Service) auf dieser Maschine nicht installiert ist. Bitte "
+"installieren."
+
+#: ../src/msw/dialup.cpp:402
+#, c-format
+msgid ""
+"The version of remote access service (RAS) installed on this machine is too "
+"old, please upgrade (the following required function is missing: %s)."
+msgstr ""
+"Die Version des auf dieser Maschine installierten RAS-Dienstes ist zu alt. "
+"Bitte auf den neusten Stand bringen (die folgende benötigte Funktion fehlt: "
+"%s)."
+
+#: ../src/msw/dialup.cpp:437
+msgid "Failed to retrieve text of RAS error message"
+msgstr "Versuch den Inhalt der RAS-Fehlernachricht zu holen, fehlgeschlagen"
+
+#: ../src/msw/dialup.cpp:440
+#, c-format
+msgid "unknown error (error code %08x)."
+msgstr "unbekannter Fehler (Fehlercode %08x)."
+
+#: ../src/msw/dialup.cpp:492
+#, c-format
+msgid "Cannot find active dialup connection: %s"
+msgstr "Kann keine aktive DFÜ-Verbindung finden: %s"
+
+#: ../src/msw/dialup.cpp:513
+msgid "Several active dialup connections found, choosing one randomly."
+msgstr ""
+"Mehrere aktive DFÜ-Verbindungen gefunden, eine davon wird zufällig "
+"ausgewählt."
+
+#: ../src/msw/dialup.cpp:598 ../src/msw/dialup.cpp:832
+#, c-format
+msgid "Failed to establish dialup connection: %s"
+msgstr "Aufbau der DFÜ-Verbindung fehlgeschlagen: %s"
+
+#: ../src/msw/dialup.cpp:664
+#, c-format
+msgid "Failed to get ISP names: %s"
+msgstr "Konnte ISP-Namen „%s“ nicht ermitteln"
+
+#: ../src/msw/dialup.cpp:712
+msgid "Failed to connect: no ISP to dial."
+msgstr "Verbindungsversuch fehlgeschlagen: kein anwählbares ISP."
+
+#: ../src/msw/dialup.cpp:732
+msgid "Choose ISP to dial"
+msgstr "Anzuwählenden ISP auswählen"
+
+#: ../src/msw/dialup.cpp:733
+msgid "Please choose which ISP do you want to connect to"
+msgstr "Bitte gewünschte ISP-Verbindung auswählen"
+
+#: ../src/msw/dialup.cpp:766
+msgid "Failed to connect: missing username/password."
+msgstr ""
+"Verbindung fehlgeschlagen: Es fehlt der Benutzername bzw. das Passwort."
+
+#: ../src/msw/dialup.cpp:796
+msgid "Cannot find the location of address book file"
+msgstr "Kann Adressbuchdatei nicht finden"
+
+#: ../src/msw/dialup.cpp:827
+#, c-format
+msgid "Failed to initiate dialup connection: %s"
+msgstr "Versuch fehlgeschlagen, die Einwählverbindung einzuleiten: %s"
+
+#: ../src/msw/dialup.cpp:897
+msgid "Cannot hang up - no active dialup connection."
+msgstr "Kann nicht auflegen - keine aktive DFÜ-Verbindung vorhanden."
+
+#: ../src/msw/dialup.cpp:907
+#, c-format
+msgid "Failed to terminate the dialup connection: %s"
+msgstr "Versuch fehlgeschlagen, die DFÜ-Verbindung zu beenden: %s"
+
+#: ../src/msw/dib.cpp:313
+#, c-format
+msgid "Failed to save the bitmap image to file \"%s\"."
+msgstr "Das Bitmap-Bild konnte nicht in der Datei „%s“ geschrieben werden."
+
+#: ../src/msw/dib.cpp:543
+#, c-format
+msgid "Failed to allocate %luKb of memory for bitmap data."
+msgstr "Anforderung von %lu Kb Speicher für Bitmap fehlgeschlagen."
+
+#: ../src/msw/dir.cpp:241
+#, c-format
+msgid "Cannot enumerate files in directory '%s'"
+msgstr "Kann Dateien in Verzeichnis „%s“ nicht auflisten"
+
+#: ../src/msw/dirdlg.cpp:368
+msgid "Couldn't obtain folder name"
+msgstr "Verzeichnisname konnte nicht ermittelt werden"
+
+#: ../src/msw/dlmsw.cpp:163
+#, c-format
+msgid "(error %d: %s)"
+msgstr "(Fehler %d: %s)"
+
+#: ../src/msw/dragimag.cpp:143 ../src/msw/dragimag.cpp:178
+#: ../src/msw/imaglist.cpp:309 ../src/msw/imaglist.cpp:331
+msgid "Couldn't add an image to the image list."
+msgstr "Kann Bild nicht zur Liste hinzufügen."
+
+#: ../src/msw/enhmeta.cpp:94
+#, c-format
+msgid "Failed to load metafile from file \"%s\"."
+msgstr "Konnte Metadatei aus Datei „%s“ nicht laden."
+
+#: ../src/msw/fdrepdlg.cpp:412
+#, c-format
+msgid "Failed to create the standard find/replace dialog (error code %d)"
+msgstr "Konnte keinen Standard-Finden/Ersetzen-Dialog erstellen (Fehler %d)"
+
+#: ../src/msw/filedlg.cpp:1241
+msgid "Access to the file system is not allowed from secure desktop."
+msgstr ""
+"Zugriff auf das Dateisystem ist vom Sicherheitsschreibtisch aus nicht "
+"erlaubt."
+
+#: ../src/msw/filedlg.cpp:1242
+msgid "Security warning"
+msgstr "Sicherheitswarnung"
+
+#: ../src/msw/filedlg.cpp:1533
+#, c-format
+msgid "File dialog failed with error code %0lx."
+msgstr "Datei Dialog schlug fehl mit dem Fehlercode %0lx."
+
+#: ../src/msw/font.cpp:1120
+#, c-format
+msgid "Font file \"%s\" couldn't be loaded"
+msgstr "Schriftartdatei \"%s\" konnte nicht geladen werden"
+
+#: ../src/msw/fontdlg.cpp:220
+#, c-format
+msgid "Common dialog failed with error code %0lx."
+msgstr "Allgemeiner Dialog schlug fehl mit dem Fehlercode %0lx."
+
+#: ../src/msw/fswatcher.cpp:67
+msgid "Ungraceful worker thread termination"
+msgstr "Unfreundliche Beendigung des Arbeitsthreads"
+
+#: ../src/msw/fswatcher.cpp:81
+msgid "Unable to create IOCP worker thread"
+msgstr "Erzeugen des IOCP-Arbeitsthreads fehlgeschlagen"
+
+#: ../src/msw/fswatcher.cpp:88
+msgid "Unable to start IOCP worker thread"
+msgstr "IOCP-Arbeitsthread konnte nicht gestartet werden"
+
+#: ../src/msw/fswatcher.cpp:140
+msgid "Monitoring individual files for changes is not supported currently."
+msgstr ""
+"Überwachen einzelner Dateien auf Änderungen wird zurzeit nicht unterstützt."
+
+#: ../src/msw/fswatcher.cpp:165
+#, c-format
+msgid "Unable to set up watch for '%s'"
+msgstr "Konnte die Überwachung für „%s“ nicht aufsetzen."
+
+#: ../src/msw/fswatcher.cpp:466
+#, c-format
+msgid "Can't monitor non-existent directory \"%s\" for changes."
+msgstr ""
+"Das nicht vorhandene Verzeichnis „%s“ kann nicht auf Änderungen überwacht "
+"werden."
+
+#: ../src/msw/glcanvas.cpp:577 ../src/unix/glx11.cpp:507
+msgid "OpenGL 3.0 or later is not supported by the OpenGL driver."
+msgstr "OpenGL 3.0 und neuer, wird vom OpenGL-Treiber nicht unterstützt."
+
+#: ../src/msw/glcanvas.cpp:601 ../src/osx/glcanvas_osx.cpp:395
+#: ../src/unix/glegl.cpp:304 ../src/unix/glx11.cpp:553
+msgid "Couldn't create OpenGL context"
+msgstr "Kann keinen OpenGL Inhalt erzeugen"
+
+#: ../src/msw/glcanvas.cpp:1294
+msgid "Failed to initialize OpenGL"
+msgstr "Konnte OpenGL nicht initialisieren"
+
+#: ../src/msw/graphicsd2d.cpp:607
+msgid "Could not register custom DirectWrite font loader."
+msgstr ""
+"Der benutzerspezifische DirectWrite Schriftartlader konnte nicht registriert "
+"werden."
+
+#: ../src/msw/helpchm.cpp:48
+msgid ""
+"MS HTML Help functions are unavailable because the MS HTML Help library is "
+"not installed on this machine. Please install it."
+msgstr ""
+"Die MS-HTML-Hilfe funktioniert nicht, da die MS-HTML-Hilfe-Bibliothek nicht "
+"installiert ist. Bitte installieren Sie diese."
+
+#: ../src/msw/helpchm.cpp:55
+msgid "Failed to initialize MS HTML Help."
+msgstr "Konnte MS-HTML-Hilfe nicht initialisieren."
+
+#: ../src/msw/iniconf.cpp:458
+#, c-format
+msgid "Can't delete the INI file '%s'"
+msgstr "Kann INI-Datei „%s“ nicht löschen"
+
+#: ../src/msw/listctrl.cpp:995
+#, c-format
+msgid "Couldn't retrieve information about list control item %d."
+msgstr "Kann keine Informationen über das Listenelement %d bekommen."
+
+#: ../src/msw/mdi.cpp:170 ../src/qt/mdi.cpp:253
+msgid "&Cascade"
+msgstr "&Kaskadieren"
+
+#: ../src/msw/mdi.cpp:171
+msgid "Tile &Horizontally"
+msgstr "&Horizontal anordnen"
+
+#: ../src/msw/mdi.cpp:172
+msgid "Tile &Vertically"
+msgstr "&Vertikal anordnen"
+
+#: ../src/msw/mdi.cpp:174
+msgid "&Arrange Icons"
+msgstr "&Icons anordnen"
+
+#: ../src/msw/mdi.cpp:621
+msgid "Failed to create MDI parent frame."
+msgstr "Erstellung des MDI-Hauptrahmens fehlgeschlagen."
+
+#: ../src/msw/mimetype.cpp:234
+#, c-format
+msgid "Failed to create registry entry for '%s' files."
+msgstr "Konnte keinen Registrierungseintrag für „%s“-Dateien erstellen."
+
+#: ../src/msw/ole/automtn.cpp:495
+#, c-format
+msgid "Failed to find CLSID of \"%s\""
+msgstr "Konnte CLSID von „%s“ nicht finden"
+
+#: ../src/msw/ole/automtn.cpp:512
+#, c-format
+msgid "Failed to create an instance of \"%s\""
+msgstr "Erzeugen eines Exemplars von „%s“ fehlgeschlagen."
+
+#: ../src/msw/ole/automtn.cpp:552
+#, c-format
+msgid "Cannot get an active instance of \"%s\""
+msgstr "Kann kein aktives Exemplar von „%s“ bekommen"
+
+#: ../src/msw/ole/automtn.cpp:564
+#, c-format
+msgid "Failed to get OLE automation interface for \"%s\""
+msgstr "Konnte die OLE Automatisierungsschnittstelle für „%s“ nicht bekommen"
+
+#: ../src/msw/ole/automtn.cpp:621
+msgid "Unknown name or named argument."
+msgstr "Unbekannter Name oder unbekanntes Argument."
+
+#: ../src/msw/ole/automtn.cpp:625
+msgid "Incorrect number of arguments."
+msgstr "Fehlerhafte Anzahl von Argumenten."
+
+#: ../src/msw/ole/automtn.cpp:637
+msgid "Unknown exception"
+msgstr "Unbekannte Ausnahme"
+
+#: ../src/msw/ole/automtn.cpp:642
+msgid "Method or property not found."
+msgstr "Methode oder Eigenschaft nicht gefunden."
+
+#: ../src/msw/ole/automtn.cpp:646
+msgid "Overflow while coercing argument values."
+msgstr "Überlauf beim Umwandeln der Argumentwerte."
+
+#: ../src/msw/ole/automtn.cpp:650
+msgid "Object implementation does not support named arguments."
+msgstr "Objekt-Umsetzung unterstützt keine benannten Argumente."
+
+#: ../src/msw/ole/automtn.cpp:654
+msgid "The locale ID is unknown."
+msgstr "Die lokale ID ist unbekannt."
+
+#: ../src/msw/ole/automtn.cpp:658
+msgid "Missing a required parameter."
+msgstr "Ein notwendiger Parameter fehlt."
+
+#: ../src/msw/ole/automtn.cpp:662
+#, c-format
+msgid "Argument %u not found."
+msgstr "Hilfeverzeichnis %u nicht gefunden."
+
+#: ../src/msw/ole/automtn.cpp:666
+#, c-format
+msgid "Type mismatch in argument %u."
+msgstr "Typfehler in Argument %u."
+
+#: ../src/msw/ole/automtn.cpp:670
+msgid "The system cannot find the file specified."
+msgstr "Das System kann die angegebene Datei nicht finden."
+
+#: ../src/msw/ole/automtn.cpp:674
+msgid "Class not registered."
+msgstr "Klasse nicht registriert."
+
+#: ../src/msw/ole/automtn.cpp:678
+#, c-format
+msgid "Unknown error %08x"
+msgstr "Unbekannter Fehler %08x"
+
+#: ../src/msw/ole/automtn.cpp:682
+#, c-format
+msgid "OLE Automation error in %s: %s"
+msgstr "OLE-Automatisierungsfehler in %s: %s"
+
+#: ../src/msw/ole/dataobj.cpp:385
+#, c-format
+msgid "Couldn't register clipboard format '%s'."
+msgstr "Konnte Zwischenablage-Format „%s“ nicht registrieren."
+
+#: ../src/msw/ole/dataobj.cpp:402
+#, c-format
+msgid "The clipboard format '%d' doesn't exist."
+msgstr "Das Format „%d“ für die Zwischenablage existiert nicht."
+
+#: ../src/msw/progdlg.cpp:1025
+msgid "Skip"
+msgstr "Überspringen"
+
+#: ../src/msw/registry.cpp:141
+#, c-format
+msgid "unknown (%lu)"
+msgstr "unbekannt (%lu)"
+
+#: ../src/msw/registry.cpp:409
+#, c-format
+msgid "Can't get info about registry key '%s'"
+msgstr "Kann keine Information über den Registrierungsschlüssel „%s“ finden"
+
+#: ../src/msw/registry.cpp:445
+#, c-format
+msgid "Can't open registry key '%s'"
+msgstr "Kann Registrierungsschlüssel „%s“ nicht öffnen"
+
+#: ../src/msw/registry.cpp:478
+#, c-format
+msgid "Can't create registry key '%s'"
+msgstr "Kann Registrierungsschlüssel „%s“ nicht erzeugen."
+
+#: ../src/msw/registry.cpp:497
+#, c-format
+msgid "Can't close registry key '%s'"
+msgstr "Kann Registrierungsschlüssel „%s“ nicht schließen."
+
+#: ../src/msw/registry.cpp:512
+#, c-format
+msgid "Registry value '%s' already exists."
+msgstr "Registrierungswert „%s“ bereits vorhanden."
+
+#: ../src/msw/registry.cpp:520
+#, c-format
+msgid "Failed to rename registry value '%s' to '%s'."
+msgstr "Umbenennen des Registrierungswertes „%s“ in „%s“ fehlgeschlagen."
+
+#: ../src/msw/registry.cpp:575
+#, c-format
+msgid "Can't copy values of unsupported type %d."
+msgstr "Kann Inhalte des nicht unterstützten Typs %d nicht kopieren."
+
+#: ../src/msw/registry.cpp:586
+#, c-format
+msgid "Registry key '%s' does not exist, cannot rename it."
+msgstr ""
+"Registrierungsschlüssel „%s“ existiert nicht, Umbenennung daher nicht "
+"möglich."
+
+#: ../src/msw/registry.cpp:617
+#, c-format
+msgid "Registry key '%s' already exists."
+msgstr "Registrierungsschlüssel „%s“ bereits vorhanden."
+
+#: ../src/msw/registry.cpp:625
+#, c-format
+msgid "Failed to rename the registry key '%s' to '%s'."
+msgstr ""
+"Umbenennen des Registrierungsschlüssels von „%s“ in „%s“ fehlgeschlagen."
+
+#: ../src/msw/registry.cpp:670
+#, c-format
+msgid "Failed to copy the registry subkey '%s' to '%s'."
+msgstr "Kopieren des Registrierungsschlüssels von „%s“ in „%s“ fehlgeschlagen."
+
+#: ../src/msw/registry.cpp:683
+#, c-format
+msgid "Failed to copy registry value '%s'"
+msgstr "Kopieren des Registry-Werts „%s“ fehlgeschlagen"
+
+#: ../src/msw/registry.cpp:692
+#, c-format
+msgid "Failed to copy the contents of registry key '%s' to '%s'."
+msgstr ""
+"Kopieren des Inhalts des Registrierungsschlüssels „%s“ nach „%s“ "
+"fehlgeschlagen."
+
+#: ../src/msw/registry.cpp:718
+#, c-format
+msgid ""
+"Registry key '%s' is needed for normal system operation,\n"
+"deleting it will leave your system in unusable state:\n"
+"operation aborted."
+msgstr ""
+"Registrierungsschlüssel „%s“ wird vom System benötigt,\n"
+"durch seine Entfernung wird das System unbrauchbar:\n"
+"Abbruch."
+
+#: ../src/msw/registry.cpp:754
+#, c-format
+msgid "Can't delete key '%s'"
+msgstr "Kann Schlüssel „%s“ nicht löschen"
+
+#: ../src/msw/registry.cpp:782
+#, c-format
+msgid "Can't delete value '%s' from key '%s'"
+msgstr "Kann Wert „%s“ von Schlüssel „%s“ nicht löschen."
+
+#: ../src/msw/registry.cpp:855 ../src/msw/registry.cpp:887
+#: ../src/msw/registry.cpp:929 ../src/msw/registry.cpp:1000
+#, c-format
+msgid "Can't read value of key '%s'"
+msgstr "Kann Wert von Eintrag „%s“ nicht lesen"
+
+#: ../src/msw/registry.cpp:873 ../src/msw/registry.cpp:915
+#: ../src/msw/registry.cpp:963 ../src/msw/registry.cpp:1106
+#, c-format
+msgid "Can't set value of '%s'"
+msgstr "Kann Wert von „%s“ nicht setzen"
+
+#: ../src/msw/registry.cpp:894 ../src/msw/registry.cpp:943
+#, c-format
+msgid "Registry value \"%s\" is not numeric (but of type %s)"
+msgstr "Registrierungswert „%s“ ist nicht numerisch (ist aber von der Art %s)"
+
+#: ../src/msw/registry.cpp:979
+#, c-format
+msgid "Registry value \"%s\" is not binary (but of type %s)"
+msgstr "Registrierungswert „%s“ ist nicht binär (ist aber von der Art %s)"
+
+#: ../src/msw/registry.cpp:1028
+#, c-format
+msgid "Registry value \"%s\" is not text (but of type %s)"
+msgstr "Registrierungswert „%s“ ist kein Text (ist aber von der Art %s)"
+
+#: ../src/msw/registry.cpp:1089
+#, c-format
+msgid "Can't read value of '%s'"
+msgstr "Kann Wert von „%s“ nicht lesen"
+
+#: ../src/msw/registry.cpp:1157
+#, c-format
+msgid "Can't enumerate values of key '%s'"
+msgstr "Kann Werte von Schlüssel „%s“ nicht auflisten"
+
+#: ../src/msw/registry.cpp:1196
+#, c-format
+msgid "Can't enumerate subkeys of key '%s'"
+msgstr "Kann Unterschlüssel von „%s“ nicht auflisten"
+
+#: ../src/msw/registry.cpp:1262
+#, c-format
+msgid ""
+"Exporting registry key: file \"%s\" already exists and won't be overwritten."
+msgstr ""
+"Exportiere Registrierungsschlüssel: Datei „%s“ besteht bereits und wird "
+"nicht überschrieben."
+
+#: ../src/msw/registry.cpp:1411
+#, c-format
+msgid "Can't export value of unsupported type %d."
+msgstr "Kann Wert des nicht unterstützten Typs %d nicht kopieren."
+
+#: ../src/msw/registry.cpp:1427
+#, c-format
+msgid "Ignoring value \"%s\" of the key \"%s\"."
+msgstr "Ignoriere Wert „%s“ des Schlüssels „%s“."
+
+#: ../src/msw/textctrl.cpp:596
+msgid ""
+"Impossible to create a rich edit control, using simple text control instead. "
+"Please reinstall riched32.dll"
+msgstr ""
+"Versuch eine „rich edit control“ zu erstellen fehlgeschlagen, verwende "
+"stattdessen ein einfaches Text-Control. Bitte „riched32.dll“ neu installieren"
+
+#: ../src/msw/thread.cpp:522 ../src/unix/threadpsx.cpp:850
+msgid "Cannot start thread: error writing TLS."
+msgstr "Kann Thread nicht starten: Fehler beim Beschreiben des TLS."
+
+#: ../src/msw/thread.cpp:613
+msgid "Can't set thread priority"
+msgstr "Kann Thread-Priorität nicht setzen"
+
+#: ../src/msw/thread.cpp:649
+msgid "Can't create thread"
+msgstr "Kann Thread nicht erzeugen"
+
+#: ../src/msw/thread.cpp:668
+msgid "Couldn't terminate thread"
+msgstr "Kann Thread nicht beenden"
+
+#: ../src/msw/thread.cpp:799
+msgid "Cannot wait for thread termination"
+msgstr "Kann nicht auf Threadende warten"
+
+#: ../src/msw/thread.cpp:873
+#, c-format
+msgid "Cannot suspend thread %lx"
+msgstr "Kann Thread %lx nicht anhalten"
+
+#: ../src/msw/thread.cpp:903
+#, c-format
+msgid "Cannot resume thread %lx"
+msgstr "Kann Thread %lx nicht fortsetzen"
+
+#: ../src/msw/thread.cpp:932
+msgid "Couldn't get the current thread pointer"
+msgstr "Kann den aktuellen Threadzeiger nicht bekommen"
+
+#: ../src/msw/thread.cpp:1333
+msgid ""
+"Thread module initialization failed: impossible to allocate index in thread "
+"local storage"
+msgstr ""
+"Thread-Modul-Initialisierung fehlgeschlagen: Index konnte nicht im lokalen "
+"Speicherbereich des Thread allokiert werden"
+
+#: ../src/msw/thread.cpp:1345
+msgid ""
+"Thread module initialization failed: cannot store value in thread local "
+"storage"
+msgstr ""
+"Thread-Modul-Initialisierung fehlgeschlagen: Wert konnte nicht im lokalen "
+"Speicherbereich des Thread gespeichert werden"
+
+#: ../src/msw/timer.cpp:133
+msgid "Couldn't create a timer"
+msgstr "Kann keinen Timer erzeugen"
+
+#: ../src/msw/utils.cpp:372
+msgid "can't find user's HOME, using current directory."
+msgstr "Kann Benutzerverzeichnis nicht finden, verwende aktuelles Verzeichnis."
+
+#: ../src/msw/utils.cpp:662
+#, c-format
+msgid "Failed to kill process %d"
+msgstr "Konnte Prozess %d nicht abbrechen"
+
+#: ../src/msw/utils.cpp:986
+#, c-format
+msgid "Failed to load resource \"%s\"."
+msgstr "Konnte die Ressource „%s“ nicht laden."
+
+#: ../src/msw/utils.cpp:993
+#, c-format
+msgid "Failed to lock resource \"%s\"."
+msgstr "Konnte die Ressource „%s“ nicht sperren."
+
+#. TRANSLATORS: MS Windows build number
+#: ../src/msw/utils.cpp:1209
+#, c-format
+msgid "build %lu"
+msgstr "Erzeugungsversion %lu"
+
+#: ../src/msw/utils.cpp:1218
+msgid ", 64-bit edition"
+msgstr ", 64-bit Edition"
+
+#: ../src/msw/utilsexc.cpp:224
+msgid "Failed to create an anonymous pipe"
+msgstr "Konnte keine anonyme Unix-Pipe erstellen"
+
+#: ../src/msw/utilsexc.cpp:697
+msgid "Failed to redirect the child process IO"
+msgstr "Umleitung der Ein-/Ausgabe des Unterprozesses fehlgeschlagen"
+
+#: ../src/msw/utilsexc.cpp:870
+#, c-format
+msgid "Execution of command '%s' failed"
+msgstr "Befehlsausführung „%s“ schlug fehl"
+
+#: ../src/msw/volume.cpp:337
+msgid "Failed to load mpr.dll."
+msgstr "Konnte mpr.dll nicht laden."
+
+#: ../src/msw/volume.cpp:506
+#, c-format
+msgid "Cannot read typename from '%s'!"
+msgstr "Kann die Typnamen nicht aus „%s“ lesen!"
+
+#: ../src/msw/volume.cpp:615
+#, c-format
+msgid "Cannot load icon from '%s'."
+msgstr "Kann das Icon nicht von „%s“ laden."
+
+#: ../src/msw/webview_edge.cpp:285
+msgid "This program was compiled without support for setting Edge proxy."
+msgstr ""
+"Dieses Programm wurde ohne Unterstützung zum Setzen des Edge Proxy übersetzt."
+
+#: ../src/msw/webview_ie.cpp:1010
+msgid "Failed to find web view emulation level in the registry"
+msgstr ""
+"Der Grad der Web Ansichtnachbildung konnte in der Registratur nicht gefunden "
+"werden"
+
+#: ../src/msw/webview_ie.cpp:1019
+msgid "Failed to set web view to modern emulation level"
+msgstr "Das Setzen der Web Ansicht auf moderne Nachbildung ist fehlgeschlagen"
+
+#: ../src/msw/webview_ie.cpp:1027
+msgid "Failed to reset web view to standard emulation level"
+msgstr ""
+"Das Setzen der Web Ansicht auf den Grad der Standard-Nachbildung ist "
+"fehlgeschlagen"
+
+#: ../src/msw/webview_ie.cpp:1049
+msgid "Can't run JavaScript script without a valid HTML document"
+msgstr ""
+"JavaScript kann nicht ohne ein gültiges HTML-Dokument ausgeführt werden"
+
+#: ../src/msw/webview_ie.cpp:1056
+msgid "Can't get the JavaScript object"
+msgstr "Kann das JavaScript-Objekt nicht erhalten"
+
+#: ../src/msw/webview_ie.cpp:1070
+msgid "failed to evaluate"
+msgstr "Auswertung fehlgeschlagen"
+
+#: ../src/osx/cocoa/filedlg.mm:412
+msgid "File type:"
+msgstr "Dateityp:"
+
+#: ../src/osx/cocoa/menu.mm:242
+msgctxt "macOS menu name"
+msgid "Window"
+msgstr "Fenster"
+
+#: ../src/osx/cocoa/menu.mm:259
+msgctxt "macOS menu name"
+msgid "Help"
+msgstr "Hilfe"
+
+#: ../src/osx/cocoa/menu.mm:298
+msgctxt "macOS menu item"
+msgid "Minimize"
+msgstr "Minimieren"
+
+#: ../src/osx/cocoa/menu.mm:303
+msgctxt "macOS menu item"
+msgid "Zoom"
+msgstr "Zoomen"
+
+#: ../src/osx/cocoa/menu.mm:309
+msgctxt "macOS menu item"
+msgid "Bring All to Front"
+msgstr "Alle nach vorne bringen"
+
+#: ../src/osx/core/sound.cpp:143
+#, c-format
+msgid "Failed to load sound from \"%s\" (error %d)."
+msgstr "Fehler beim Laden des Klangs von „%s“ (Fehler %d)."
+
+#: ../src/osx/fontutil.cpp:80
+#, c-format
+msgid "Font file \"%s\" doesn't exist."
+msgstr "Schriftartdatei \"%s\" existiert nicht."
+
+#: ../src/osx/fontutil.cpp:88
+#, c-format
+msgid ""
+"Font file \"%s\" cannot be used as it is not inside the font directory "
+"\"%s\"."
+msgstr ""
+"Die Schriftartdatei \"%s\" kann nicht verwendet werden, da sie sich nicht im "
+"Schriftartenverzeichnis \"%s\" befindet."
+
+#: ../src/osx/menu_osx.cpp:496
+#, c-format
+msgctxt "macOS menu item"
+msgid "About %s"
+msgstr "Über %s"
+
+#: ../src/osx/menu_osx.cpp:499
+msgctxt "macOS menu item"
+msgid "About..."
+msgstr "Über …"
+
+#: ../src/osx/menu_osx.cpp:508
+msgctxt "macOS menu item"
+msgid "Preferences..."
+msgstr "Einstellungen …"
+
+#: ../src/osx/menu_osx.cpp:512
+msgctxt "macOS menu item"
+msgid "Services"
+msgstr "Dienste"
+
+#: ../src/osx/menu_osx.cpp:519
+#, c-format
+msgctxt "macOS menu item"
+msgid "Hide %s"
+msgstr "%s ausblenden"
+
+#: ../src/osx/menu_osx.cpp:522
+msgctxt "macOS menu item"
+msgid "Hide Application"
+msgstr "Anwendung ausblenden"
+
+#: ../src/osx/menu_osx.cpp:526
+msgctxt "macOS menu item"
+msgid "Hide Others"
+msgstr "Andere ausblenden"
+
+#: ../src/osx/menu_osx.cpp:528
+msgctxt "macOS menu item"
+msgid "Show All"
+msgstr "Alles zeigen"
+
+#: ../src/osx/menu_osx.cpp:534
+#, c-format
+msgctxt "macOS menu item"
+msgid "Quit %s"
+msgstr "%s beenden"
+
+#: ../src/osx/menu_osx.cpp:537
+msgctxt "macOS menu item"
+msgid "Quit Application"
+msgstr "Anwendung beenden"
+
+#: ../src/osx/webview_webkit.mm:444
+msgid "Printing is not supported by the system web control"
+msgstr "Drucken wird vom Web-Kontrollelement des Systems nicht unterstützt"
+
+#: ../src/osx/webview_webkit.mm:453
+msgid "Print operation could not be initialized"
+msgstr "Druckoperation konnte nicht initialisiert werden"
+
+#. TRANSLATORS: Label of font point size
+#: ../src/propgrid/advprops.cpp:605
+msgid "Point Size"
+msgstr "Größe in Punkt"
+
+#. TRANSLATORS: Label of font face name
+#: ../src/propgrid/advprops.cpp:615
+msgid "Face Name"
+msgstr "Schriftname"
+
+#. TRANSLATORS: Label of font style
+#: ../src/propgrid/advprops.cpp:623 ../src/richtext/richtextformatdlg.cpp:331
+msgid "Style"
+msgstr "Stil"
+
+#. TRANSLATORS: Label of font weight
+#: ../src/propgrid/advprops.cpp:628
+msgid "Weight"
+msgstr "Dicke"
+
+#. TRANSLATORS: Label of underlined font
+#: ../src/propgrid/advprops.cpp:633 ../src/richtext/richtextfontpage.cpp:358
+msgid "Underlined"
+msgstr "Unterstrichen"
+
+#. TRANSLATORS: Label of font family
+#: ../src/propgrid/advprops.cpp:637
+msgid "Family"
+msgstr "Familie"
+
+# Original wird verwendet
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:801
+msgid "AppWorkspace"
+msgstr "AppWorkspace"
+
+# Original wird verwendet
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:802
+msgid "ActiveBorder"
+msgstr "ActiveBorder"
+
+# Original wird verwendet
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:803
+msgid "ActiveCaption"
+msgstr "ActiveCaption"
+
+# Original wird verwendet
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:804
+msgid "ButtonFace"
+msgstr "ButtonFace"
+
+# Original wird verwendet
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:805
+msgid "ButtonHighlight"
+msgstr "ButtonHighlight"
+
+# Original wird verwendet
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:806
+msgid "ButtonShadow"
+msgstr "ButtonShadow"
+
+# Original wird verwendet
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:807
+msgid "ButtonText"
+msgstr "ButtonText"
+
+# Original wird verwendet
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:808
+msgid "CaptionText"
+msgstr "CaptionText"
+
+# Original wird verwendet
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:809
+msgid "ControlDark"
+msgstr "ControlDark"
+
+# Original wird verwendet
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:810
+msgid "ControlLight"
+msgstr "ControlLight"
+
+# Original wird verwendet
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:812
+msgid "GrayText"
+msgstr "GrayText"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:813
+msgid "Highlight"
+msgstr "Hervorheben"
+
+# Original wird verwendet
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:814
+msgid "HighlightText"
+msgstr "HighlightText"
+
+# Original wird verwendet
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:815
+msgid "InactiveBorder"
+msgstr "InactiveBorder"
+
+# Original wird verwendet
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:816
+msgid "InactiveCaption"
+msgstr "InactiveCaption"
+
+# Original wird verwendet
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:817
+msgid "InactiveCaptionText"
+msgstr "InactiveCaptionText"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:818
+msgid "Menu"
+msgstr "Menü"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:819
+msgid "Scrollbar"
+msgstr "Bildlaufleiste"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:820
+msgid "Tooltip"
+msgstr "Minihilfe"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:821
+msgid "TooltipText"
+msgstr "Minihilfe-Text"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:822
+msgid "Window"
+msgstr "Fenster"
+
+# Original wird verwendet
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:823
+msgid "WindowFrame"
+msgstr "WindowFrame"
+
+# Original wird verwendet
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:824
+msgid "WindowText"
+msgstr "WindowText"
+
+#. TRANSLATORS: Custom colour choice entry
+#: ../src/propgrid/advprops.cpp:825 ../src/propgrid/advprops.cpp:1532
+#: ../src/propgrid/advprops.cpp:1576
+msgid "Custom"
+msgstr "Benutzerdefiniert"
+
+#: ../src/propgrid/advprops.cpp:1558
+msgid "Black"
+msgstr "Schwarz"
+
+# http://bfw.ac.at/020/farbtabelle.html
+#: ../src/propgrid/advprops.cpp:1559
+msgid "Maroon"
+msgstr "Kastanienbraun"
+
+#: ../src/propgrid/advprops.cpp:1560
+msgid "Navy"
+msgstr "Marineblau"
+
+#: ../src/propgrid/advprops.cpp:1561
+msgid "Purple"
+msgstr "Violett"
+
+# http://bfw.ac.at/020/farbtabelle.html
+#: ../src/propgrid/advprops.cpp:1562
+msgid "Teal"
+msgstr "Entenbraun"
+
+#: ../src/propgrid/advprops.cpp:1563
+msgid "Gray"
+msgstr "Grau"
+
+#: ../src/propgrid/advprops.cpp:1564
+msgid "Green"
+msgstr "Grün"
+
+#: ../src/propgrid/advprops.cpp:1565
+msgid "Olive"
+msgstr "Olivgrün"
+
+#: ../src/propgrid/advprops.cpp:1566
+msgid "Brown"
+msgstr "Braun"
+
+#: ../src/propgrid/advprops.cpp:1567
+msgid "Blue"
+msgstr "Blau"
+
+#: ../src/propgrid/advprops.cpp:1568
+msgid "Fuchsia"
+msgstr "Magenta"
+
+#: ../src/propgrid/advprops.cpp:1569
+msgid "Red"
+msgstr "Rot"
+
+#: ../src/propgrid/advprops.cpp:1570
+msgid "Orange"
+msgstr "Orange"
+
+#: ../src/propgrid/advprops.cpp:1571
+msgid "Silver"
+msgstr "Silber"
+
+#: ../src/propgrid/advprops.cpp:1572
+msgid "Lime"
+msgstr "Zitronengrün"
+
+#: ../src/propgrid/advprops.cpp:1573
+msgid "Aqua"
+msgstr "Cyan"
+
+#: ../src/propgrid/advprops.cpp:1574
+msgid "Yellow"
+msgstr "Gelb"
+
+#: ../src/propgrid/advprops.cpp:1575
+msgid "White"
+msgstr "Weiß"
+
+#: ../src/propgrid/advprops.cpp:1718
+msgctxt "system cursor name"
+msgid "Default"
+msgstr "Standard"
+
+#: ../src/propgrid/advprops.cpp:1719
+msgctxt "system cursor name"
+msgid "Arrow"
+msgstr "Pfeil"
+
+#: ../src/propgrid/advprops.cpp:1720
+msgctxt "system cursor name"
+msgid "Right Arrow"
+msgstr "Rechts-Pfeil"
+
+#: ../src/propgrid/advprops.cpp:1721
+msgctxt "system cursor name"
+msgid "Blank"
+msgstr "Leer"
+
+# Sieht aus wie das innere Feld bei Darts
+#: ../src/propgrid/advprops.cpp:1722
+msgctxt "system cursor name"
+msgid "Bullseye"
+msgstr "Zielscheibe"
+
+#: ../src/propgrid/advprops.cpp:1723
+msgctxt "system cursor name"
+msgid "Character"
+msgstr "Zeichen"
+
+#: ../src/propgrid/advprops.cpp:1724
+msgctxt "system cursor name"
+msgid "Cross"
+msgstr "Kreuz"
+
+#: ../src/propgrid/advprops.cpp:1725
+msgctxt "system cursor name"
+msgid "Hand"
+msgstr "Hand"
+
+#: ../src/propgrid/advprops.cpp:1726
+msgctxt "system cursor name"
+msgid "I-Beam"
+msgstr "Profilstahl"
+
+#: ../src/propgrid/advprops.cpp:1727
+msgctxt "system cursor name"
+msgid "Left Button"
+msgstr "Links-Taste"
+
+#: ../src/propgrid/advprops.cpp:1728
+msgctxt "system cursor name"
+msgid "Magnifier"
+msgstr "Lupe"
+
+#: ../src/propgrid/advprops.cpp:1729
+msgctxt "system cursor name"
+msgid "Middle Button"
+msgstr "Mittlere Taste"
+
+#: ../src/propgrid/advprops.cpp:1730
+msgctxt "system cursor name"
+msgid "No Entry"
+msgstr "Kein Eintrag"
+
+#: ../src/propgrid/advprops.cpp:1731
+msgctxt "system cursor name"
+msgid "Paint Brush"
+msgstr "Pinsel"
+
+#: ../src/propgrid/advprops.cpp:1732
+msgctxt "system cursor name"
+msgid "Pencil"
+msgstr "Stift"
+
+#: ../src/propgrid/advprops.cpp:1733
+msgctxt "system cursor name"
+msgid "Point Left"
+msgstr "Punkt links"
+
+#: ../src/propgrid/advprops.cpp:1734
+msgctxt "system cursor name"
+msgid "Point Right"
+msgstr "Punkt rechts"
+
+#: ../src/propgrid/advprops.cpp:1735
+msgctxt "system cursor name"
+msgid "Question Arrow"
+msgstr "Fragepfeil"
+
+#: ../src/propgrid/advprops.cpp:1736
+msgctxt "system cursor name"
+msgid "Right Button"
+msgstr "Rechts-Taste"
+
+# Ein Cursor für die Größenänderung, dessen Pfeile von NO nach SW zeigen
+#: ../src/propgrid/advprops.cpp:1737
+msgctxt "system cursor name"
+msgid "Sizing NE-SW"
+msgstr "Größenänderung NO-SW"
+
+# Ein Cursor für die Größenänderung, dessen Pfeile von Norden nach Süden zeigen
+#: ../src/propgrid/advprops.cpp:1738
+msgctxt "system cursor name"
+msgid "Sizing N-S"
+msgstr "Größenänderung N-S"
+
+# Ein Cursor für die Größenänderung, dessen Pfeile von NW nach SO zeigen
+#: ../src/propgrid/advprops.cpp:1739
+msgctxt "system cursor name"
+msgid "Sizing NW-SE"
+msgstr "Größenänderung NW-SO"
+
+# Ein Cursor für die Größenänderung, dessen Pfeile von W nach O zeigen
+#: ../src/propgrid/advprops.cpp:1740
+msgctxt "system cursor name"
+msgid "Sizing W-E"
+msgstr "Größenänderung W-O"
+
+#: ../src/propgrid/advprops.cpp:1741
+msgctxt "system cursor name"
+msgid "Sizing"
+msgstr "Größenänderung"
+
+#: ../src/propgrid/advprops.cpp:1742
+msgctxt "system cursor name"
+msgid "Spraycan"
+msgstr "Sprühdose"
+
+#: ../src/propgrid/advprops.cpp:1743
+msgctxt "system cursor name"
+msgid "Wait"
+msgstr "﻿Warten"
+
+#: ../src/propgrid/advprops.cpp:1744
+msgctxt "system cursor name"
+msgid "Watch"
+msgstr "Uhr"
+
+#: ../src/propgrid/advprops.cpp:1745
+msgctxt "system cursor name"
+msgid "Wait Arrow"
+msgstr "Wartepfeil"
+
+#: ../src/propgrid/advprops.cpp:2109
+msgid "Make a selection:"
+msgstr "Bitte auswählen:"
+
+#: ../src/propgrid/manager.cpp:394
+msgid "Property"
+msgstr "Eigenschaft"
+
+#: ../src/propgrid/manager.cpp:395
+msgid "Value"
+msgstr "Wert"
+
+#: ../src/propgrid/manager.cpp:1683
+msgid "Categorized Mode"
+msgstr "Kategorie-Modus"
+
+#: ../src/propgrid/manager.cpp:1709
+msgid "Alphabetic Mode"
+msgstr "Alphabetischer Modus"
+
+#. TRANSLATORS: Name of Boolean false value
+#: ../src/propgrid/propgrid.cpp:230
+msgid "False"
+msgstr "Falsch"
+
+#. TRANSLATORS: Name of Boolean true value
+#: ../src/propgrid/propgrid.cpp:232
+msgid "True"
+msgstr "Wahr"
+
+#. TRANSLATORS: Text  displayed for unspecified value
+#: ../src/propgrid/propgrid.cpp:428
+msgid "Unspecified"
+msgstr "Nicht angegeben"
+
+#. TRANSLATORS: Caption of message box displaying any property error
+#: ../src/propgrid/propgrid.cpp:3145 ../src/propgrid/propgrid.cpp:3282
+msgid "Property Error"
+msgstr "Eigenschaftsfehler"
+
+#: ../src/propgrid/propgrid.cpp:3259
+msgid "You have entered invalid value. Press ESC to cancel editing."
+msgstr ""
+"Sie haben einen ungültigen Wert eingegeben. Drücken Sie ESC um die "
+"Bearbeitung zu beenden."
+
+#: ../src/propgrid/propgrid.cpp:6608
+#, c-format
+msgid "Error in resource: %s"
+msgstr "Fehler in der Ressource: %s"
+
+#: ../src/propgrid/propgridiface.cpp:377
+#, c-format
+msgid ""
+"Type operation \"%s\" failed: Property labeled \"%s\" is of type \"%s\", NOT "
+"\"%s\"."
+msgstr ""
+"Die Typoperation „%s“ ist fehlgeschlagen: Die Eigenschaft bezeichnet mit "
+"„%s“ ist vom Typ „%s“, NICHT „%s“."
+
+#: ../src/propgrid/props.cpp:159
+#, c-format
+msgid "Unknown base %d. Base 10 will be used."
+msgstr "Unbekannte Basis %d. Basis 10 wird verwendet."
+
+#: ../src/propgrid/props.cpp:324
+#, c-format
+msgid "Value must be %s or higher."
+msgstr "Wert muss %s oder höher sein."
+
+#: ../src/propgrid/props.cpp:329 ../src/propgrid/props.cpp:356
+#, c-format
+msgid "Value must be between %s and %s."
+msgstr "Wert muss zwischen %s und %s liegen."
+
+#: ../src/propgrid/props.cpp:351
+#, c-format
+msgid "Value must be %s or less."
+msgstr "Wert muss %s oder kleiner sein."
+
+#: ../src/propgrid/props.cpp:1058
+#, c-format
+msgid "Not %s"
+msgstr "Nicht %s"
+
+#: ../src/propgrid/props.cpp:1770
+msgid "Choose a directory:"
+msgstr "Verzeichnis wählen:"
+
+#: ../src/propgrid/props.cpp:2055
+msgid "Choose a file"
+msgstr "Datei wählen"
+
+#: ../src/qt/mdi.cpp:254
+msgid "&Tile"
+msgstr "&Kachel"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:147
+#: ../src/richtext/richtextformatdlg.cpp:376
+msgid "Background"
+msgstr "Hintergrund"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:159
+msgid "Background &colour:"
+msgstr "Hintergrund&farbe:"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:161
+#: ../src/richtext/richtextbackgroundpage.cpp:163
+msgid "Enables a background colour."
+msgstr "Aktiviert eine Hintergrundfarbe."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:167
+#: ../src/richtext/richtextbackgroundpage.cpp:169
+msgid "The background colour."
+msgstr "Die Hintergrundfarbe."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:178
+msgid "Shadow"
+msgstr "Schatten"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:193
+msgid "Use &shadow"
+msgstr "&Schatten verwenden"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:195
+#: ../src/richtext/richtextbackgroundpage.cpp:197
+msgid "Enables a shadow."
+msgstr "Aktiviert einen Schatten."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:211
+msgid "&Horizontal offset:"
+msgstr "&Horizontaler Versatz:"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:218
+#: ../src/richtext/richtextbackgroundpage.cpp:220
+msgid "The horizontal offset."
+msgstr "Der horizontale Versatz."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:224
+#: ../src/richtext/richtextbackgroundpage.cpp:227
+#: ../src/richtext/richtextbackgroundpage.cpp:228
+#: ../src/richtext/richtextbackgroundpage.cpp:247
+#: ../src/richtext/richtextbackgroundpage.cpp:250
+#: ../src/richtext/richtextbackgroundpage.cpp:251
+#: ../src/richtext/richtextbackgroundpage.cpp:287
+#: ../src/richtext/richtextbackgroundpage.cpp:290
+#: ../src/richtext/richtextbackgroundpage.cpp:291
+#: ../src/richtext/richtextbackgroundpage.cpp:314
+#: ../src/richtext/richtextbackgroundpage.cpp:317
+#: ../src/richtext/richtextbackgroundpage.cpp:318
+#: ../src/richtext/richtextborderspage.cpp:252
+#: ../src/richtext/richtextborderspage.cpp:255
+#: ../src/richtext/richtextborderspage.cpp:256
+#: ../src/richtext/richtextborderspage.cpp:286
+#: ../src/richtext/richtextborderspage.cpp:289
+#: ../src/richtext/richtextborderspage.cpp:290
+#: ../src/richtext/richtextborderspage.cpp:320
+#: ../src/richtext/richtextborderspage.cpp:323
+#: ../src/richtext/richtextborderspage.cpp:324
+#: ../src/richtext/richtextborderspage.cpp:354
+#: ../src/richtext/richtextborderspage.cpp:357
+#: ../src/richtext/richtextborderspage.cpp:358
+#: ../src/richtext/richtextborderspage.cpp:420
+#: ../src/richtext/richtextborderspage.cpp:423
+#: ../src/richtext/richtextborderspage.cpp:424
+#: ../src/richtext/richtextborderspage.cpp:454
+#: ../src/richtext/richtextborderspage.cpp:457
+#: ../src/richtext/richtextborderspage.cpp:458
+#: ../src/richtext/richtextborderspage.cpp:488
+#: ../src/richtext/richtextborderspage.cpp:491
+#: ../src/richtext/richtextborderspage.cpp:492
+#: ../src/richtext/richtextborderspage.cpp:522
+#: ../src/richtext/richtextborderspage.cpp:525
+#: ../src/richtext/richtextborderspage.cpp:526
+#: ../src/richtext/richtextborderspage.cpp:590
+#: ../src/richtext/richtextborderspage.cpp:593
+#: ../src/richtext/richtextborderspage.cpp:594
+#: ../src/richtext/richtextfontpage.cpp:177
+#: ../src/richtext/richtextmarginspage.cpp:199
+#: ../src/richtext/richtextmarginspage.cpp:201
+#: ../src/richtext/richtextmarginspage.cpp:202
+#: ../src/richtext/richtextmarginspage.cpp:224
+#: ../src/richtext/richtextmarginspage.cpp:226
+#: ../src/richtext/richtextmarginspage.cpp:227
+#: ../src/richtext/richtextmarginspage.cpp:247
+#: ../src/richtext/richtextmarginspage.cpp:249
+#: ../src/richtext/richtextmarginspage.cpp:250
+#: ../src/richtext/richtextmarginspage.cpp:272
+#: ../src/richtext/richtextmarginspage.cpp:274
+#: ../src/richtext/richtextmarginspage.cpp:275
+#: ../src/richtext/richtextmarginspage.cpp:313
+#: ../src/richtext/richtextmarginspage.cpp:315
+#: ../src/richtext/richtextmarginspage.cpp:316
+#: ../src/richtext/richtextmarginspage.cpp:338
+#: ../src/richtext/richtextmarginspage.cpp:340
+#: ../src/richtext/richtextmarginspage.cpp:341
+#: ../src/richtext/richtextmarginspage.cpp:361
+#: ../src/richtext/richtextmarginspage.cpp:363
+#: ../src/richtext/richtextmarginspage.cpp:364
+#: ../src/richtext/richtextmarginspage.cpp:386
+#: ../src/richtext/richtextmarginspage.cpp:388
+#: ../src/richtext/richtextmarginspage.cpp:389
+#: ../src/richtext/richtextsizepage.cpp:337
+#: ../src/richtext/richtextsizepage.cpp:340
+#: ../src/richtext/richtextsizepage.cpp:341
+#: ../src/richtext/richtextsizepage.cpp:371
+#: ../src/richtext/richtextsizepage.cpp:374
+#: ../src/richtext/richtextsizepage.cpp:375
+#: ../src/richtext/richtextsizepage.cpp:398
+#: ../src/richtext/richtextsizepage.cpp:401
+#: ../src/richtext/richtextsizepage.cpp:402
+#: ../src/richtext/richtextsizepage.cpp:425
+#: ../src/richtext/richtextsizepage.cpp:428
+#: ../src/richtext/richtextsizepage.cpp:429
+#: ../src/richtext/richtextsizepage.cpp:452
+#: ../src/richtext/richtextsizepage.cpp:455
+#: ../src/richtext/richtextsizepage.cpp:456
+#: ../src/richtext/richtextsizepage.cpp:479
+#: ../src/richtext/richtextsizepage.cpp:482
+#: ../src/richtext/richtextsizepage.cpp:483
+#: ../src/richtext/richtextsizepage.cpp:553
+#: ../src/richtext/richtextsizepage.cpp:556
+#: ../src/richtext/richtextsizepage.cpp:557
+#: ../src/richtext/richtextsizepage.cpp:588
+#: ../src/richtext/richtextsizepage.cpp:591
+#: ../src/richtext/richtextsizepage.cpp:592
+#: ../src/richtext/richtextsizepage.cpp:623
+#: ../src/richtext/richtextsizepage.cpp:626
+#: ../src/richtext/richtextsizepage.cpp:627
+#: ../src/richtext/richtextsizepage.cpp:658
+#: ../src/richtext/richtextsizepage.cpp:661
+#: ../src/richtext/richtextsizepage.cpp:662
+msgid "px"
+msgstr "px"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:225
+#: ../src/richtext/richtextbackgroundpage.cpp:248
+#: ../src/richtext/richtextbackgroundpage.cpp:288
+#: ../src/richtext/richtextbackgroundpage.cpp:315
+#: ../src/richtext/richtextborderspage.cpp:253
+#: ../src/richtext/richtextborderspage.cpp:287
+#: ../src/richtext/richtextborderspage.cpp:321
+#: ../src/richtext/richtextborderspage.cpp:355
+#: ../src/richtext/richtextborderspage.cpp:421
+#: ../src/richtext/richtextborderspage.cpp:455
+#: ../src/richtext/richtextborderspage.cpp:489
+#: ../src/richtext/richtextborderspage.cpp:523
+#: ../src/richtext/richtextborderspage.cpp:591
+#: ../src/richtext/richtextmarginspage.cpp:200
+#: ../src/richtext/richtextmarginspage.cpp:225
+#: ../src/richtext/richtextmarginspage.cpp:248
+#: ../src/richtext/richtextmarginspage.cpp:273
+#: ../src/richtext/richtextmarginspage.cpp:314
+#: ../src/richtext/richtextmarginspage.cpp:339
+#: ../src/richtext/richtextmarginspage.cpp:362
+#: ../src/richtext/richtextmarginspage.cpp:387
+#: ../src/richtext/richtextsizepage.cpp:338
+#: ../src/richtext/richtextsizepage.cpp:372
+#: ../src/richtext/richtextsizepage.cpp:399
+#: ../src/richtext/richtextsizepage.cpp:426
+#: ../src/richtext/richtextsizepage.cpp:453
+#: ../src/richtext/richtextsizepage.cpp:480
+#: ../src/richtext/richtextsizepage.cpp:554
+#: ../src/richtext/richtextsizepage.cpp:589
+#: ../src/richtext/richtextsizepage.cpp:624
+#: ../src/richtext/richtextsizepage.cpp:659
+msgid "cm"
+msgstr "cm"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:226
+#: ../src/richtext/richtextbackgroundpage.cpp:249
+#: ../src/richtext/richtextbackgroundpage.cpp:289
+#: ../src/richtext/richtextbackgroundpage.cpp:316
+#: ../src/richtext/richtextborderspage.cpp:254
+#: ../src/richtext/richtextborderspage.cpp:288
+#: ../src/richtext/richtextborderspage.cpp:322
+#: ../src/richtext/richtextborderspage.cpp:356
+#: ../src/richtext/richtextborderspage.cpp:422
+#: ../src/richtext/richtextborderspage.cpp:456
+#: ../src/richtext/richtextborderspage.cpp:490
+#: ../src/richtext/richtextborderspage.cpp:524
+#: ../src/richtext/richtextborderspage.cpp:592
+#: ../src/richtext/richtextfontpage.cpp:176
+#: ../src/richtext/richtextfontpage.cpp:179
+msgid "pt"
+msgstr "pt"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:229
+#: ../src/richtext/richtextbackgroundpage.cpp:231
+#: ../src/richtext/richtextbackgroundpage.cpp:252
+#: ../src/richtext/richtextbackgroundpage.cpp:254
+#: ../src/richtext/richtextbackgroundpage.cpp:292
+#: ../src/richtext/richtextbackgroundpage.cpp:294
+#: ../src/richtext/richtextbackgroundpage.cpp:319
+#: ../src/richtext/richtextbackgroundpage.cpp:321
+msgid "Units for this value."
+msgstr "Einheiten für diesen Wert."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:234
+msgid "&Vertical offset:"
+msgstr "&Vertikaler Versatz:"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:241
+#: ../src/richtext/richtextbackgroundpage.cpp:243
+msgid "The vertical offset."
+msgstr "Der vertikale Versatz."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:257
+msgid "Shadow c&olour:"
+msgstr "Schattenf&arbe:"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:259
+#: ../src/richtext/richtextbackgroundpage.cpp:261
+msgid "Enables the shadow colour."
+msgstr "Aktiviert die Farbe des Schattens."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:265
+#: ../src/richtext/richtextbackgroundpage.cpp:267
+msgid "The shadow colour."
+msgstr "Die Schattenfarbe."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:270
+msgid "Sh&adow spread:"
+msgstr "Schatten-Ausbreitung:"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:272
+#: ../src/richtext/richtextbackgroundpage.cpp:274
+msgid "Enables the shadow spread."
+msgstr "Aktiviert die Ausbreitung des Schattens."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:281
+#: ../src/richtext/richtextbackgroundpage.cpp:283
+msgid "The shadow spread."
+msgstr "Die Schatten-Ausbreitung."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:297
+msgid "&Blur distance:"
+msgstr "Entfernung der &Weichzeichnung:"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:299
+#: ../src/richtext/richtextbackgroundpage.cpp:301
+msgid "Enables the blur distance."
+msgstr "Aktiviert die Entfernung der Weichzeichnung."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:308
+#: ../src/richtext/richtextbackgroundpage.cpp:310
+msgid "The shadow blur distance."
+msgstr "Die Schatten-Weichzeichnungsentfernung."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:324
+msgid "Opaci&ty:"
+msgstr "Deckkraf&t:"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:326
+#: ../src/richtext/richtextbackgroundpage.cpp:328
+msgid "Enables the shadow opacity."
+msgstr "Aktiviert die Deckkraft des Schattens."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:335
+#: ../src/richtext/richtextbackgroundpage.cpp:337
+msgid "The shadow opacity."
+msgstr "Die Schattendeckkraft."
+
+#. TRANSLATORS: Rich text page units (percentage)
+#: ../src/richtext/richtextbackgroundpage.cpp:340
+#: ../src/richtext/richtextsizepage.cpp:339
+#: ../src/richtext/richtextsizepage.cpp:373
+#: ../src/richtext/richtextsizepage.cpp:400
+#: ../src/richtext/richtextsizepage.cpp:427
+#: ../src/richtext/richtextsizepage.cpp:454
+#: ../src/richtext/richtextsizepage.cpp:481
+#: ../src/richtext/richtextsizepage.cpp:555
+#: ../src/richtext/richtextsizepage.cpp:590
+#: ../src/richtext/richtextsizepage.cpp:625
+#: ../src/richtext/richtextsizepage.cpp:660
+msgid "%"
+msgstr "%"
+
+#: ../src/richtext/richtextborderspage.cpp:229
+#: ../src/richtext/richtextborderspage.cpp:387
+msgid "Border"
+msgstr "Rahmen"
+
+#: ../src/richtext/richtextborderspage.cpp:242
+#: ../src/richtext/richtextborderspage.cpp:410
+#: ../src/richtext/richtextindentspage.cpp:194
+#: ../src/richtext/richtextliststylepage.cpp:384
+#: ../src/richtext/richtextmarginspage.cpp:185
+#: ../src/richtext/richtextmarginspage.cpp:299
+#: ../src/richtext/richtextsizepage.cpp:531
+#: ../src/richtext/richtextsizepage.cpp:538
+msgid "&Left:"
+msgstr "&Links:"
+
+#: ../src/richtext/richtextborderspage.cpp:257
+#: ../src/richtext/richtextborderspage.cpp:259
+msgid "Units for the left border width."
+msgstr "Einheiten für die linke Randbreite."
+
+#: ../src/richtext/richtextborderspage.cpp:266
+#: ../src/richtext/richtextborderspage.cpp:268
+#: ../src/richtext/richtextborderspage.cpp:300
+#: ../src/richtext/richtextborderspage.cpp:302
+#: ../src/richtext/richtextborderspage.cpp:334
+#: ../src/richtext/richtextborderspage.cpp:336
+#: ../src/richtext/richtextborderspage.cpp:368
+#: ../src/richtext/richtextborderspage.cpp:370
+#: ../src/richtext/richtextborderspage.cpp:434
+#: ../src/richtext/richtextborderspage.cpp:436
+#: ../src/richtext/richtextborderspage.cpp:468
+#: ../src/richtext/richtextborderspage.cpp:470
+#: ../src/richtext/richtextborderspage.cpp:502
+#: ../src/richtext/richtextborderspage.cpp:504
+#: ../src/richtext/richtextborderspage.cpp:536
+#: ../src/richtext/richtextborderspage.cpp:538
+msgid "The border line style."
+msgstr "Das Rahmenlinien-Format."
+
+#: ../src/richtext/richtextborderspage.cpp:276
+#: ../src/richtext/richtextborderspage.cpp:444
+#: ../src/richtext/richtextindentspage.cpp:212
+#: ../src/richtext/richtextliststylepage.cpp:402
+#: ../src/richtext/richtextmarginspage.cpp:210
+#: ../src/richtext/richtextmarginspage.cpp:324
+#: ../src/richtext/richtextsizepage.cpp:601
+#: ../src/richtext/richtextsizepage.cpp:608
+msgid "&Right:"
+msgstr "&Rechts:"
+
+#: ../src/richtext/richtextborderspage.cpp:291
+#: ../src/richtext/richtextborderspage.cpp:293
+msgid "Units for the right border width."
+msgstr "Einheiten für die rechte Randbreite."
+
+#: ../src/richtext/richtextborderspage.cpp:310
+#: ../src/richtext/richtextborderspage.cpp:478
+#: ../src/richtext/richtextmarginspage.cpp:233
+#: ../src/richtext/richtextmarginspage.cpp:347
+#: ../src/richtext/richtextsizepage.cpp:566
+#: ../src/richtext/richtextsizepage.cpp:573
+msgid "&Top:"
+msgstr "&Oben:"
+
+#: ../src/richtext/richtextborderspage.cpp:325
+#: ../src/richtext/richtextborderspage.cpp:327
+msgid "Units for the top border width."
+msgstr "Einheit für die Breite des oberen Randes."
+
+#: ../src/richtext/richtextborderspage.cpp:344
+#: ../src/richtext/richtextborderspage.cpp:512
+#: ../src/richtext/richtextmarginspage.cpp:258
+#: ../src/richtext/richtextmarginspage.cpp:372
+#: ../src/richtext/richtextsizepage.cpp:636
+#: ../src/richtext/richtextsizepage.cpp:643
+msgid "&Bottom:"
+msgstr "&Unten:"
+
+#: ../src/richtext/richtextborderspage.cpp:359
+#: ../src/richtext/richtextborderspage.cpp:361
+msgid "Units for the bottom border width."
+msgstr "Einheit für die untere Randbreite."
+
+#: ../src/richtext/richtextborderspage.cpp:380
+#: ../src/richtext/richtextborderspage.cpp:548
+msgid "&Synchronize values"
+msgstr "&Werte synchronisieren"
+
+#: ../src/richtext/richtextborderspage.cpp:382
+#: ../src/richtext/richtextborderspage.cpp:384
+#: ../src/richtext/richtextborderspage.cpp:550
+#: ../src/richtext/richtextborderspage.cpp:552
+msgid "Check to edit all borders simultaneously."
+msgstr "Markieren um alle Ecken gleichzeitig anzupassen."
+
+#: ../src/richtext/richtextborderspage.cpp:397
+#: ../src/richtext/richtextborderspage.cpp:555
+msgid "Outline"
+msgstr "Umrandung"
+
+#: ../src/richtext/richtextborderspage.cpp:425
+#: ../src/richtext/richtextborderspage.cpp:427
+msgid "Units for the left outline width."
+msgstr "Einheiten für die linke Umrissbreite."
+
+#: ../src/richtext/richtextborderspage.cpp:459
+#: ../src/richtext/richtextborderspage.cpp:461
+msgid "Units for the right outline width."
+msgstr "Einheiten für die rechte Umrissbreite."
+
+#: ../src/richtext/richtextborderspage.cpp:493
+#: ../src/richtext/richtextborderspage.cpp:495
+msgid "Units for the top outline width."
+msgstr "Einheit für die Breite des oberen Umrisses."
+
+#: ../src/richtext/richtextborderspage.cpp:527
+#: ../src/richtext/richtextborderspage.cpp:529
+msgid "Units for the bottom outline width."
+msgstr "Einheiten für die untere Umrissbreite."
+
+#: ../src/richtext/richtextborderspage.cpp:565
+#: ../src/richtext/richtextborderspage.cpp:600
+msgid "Corner"
+msgstr "Ecke"
+
+#: ../src/richtext/richtextborderspage.cpp:574
+msgid "Corner &radius:"
+msgstr "Eck&radius:"
+
+#: ../src/richtext/richtextborderspage.cpp:576
+#: ../src/richtext/richtextborderspage.cpp:578
+msgid "An optional corner radius for adding rounded corners."
+msgstr "Optionaler Eckradius, um abgerundete Ecken hinzuzufügen."
+
+#: ../src/richtext/richtextborderspage.cpp:584
+#: ../src/richtext/richtextborderspage.cpp:586
+msgid "The value of the corner radius."
+msgstr "Wert des Eckradius."
+
+#: ../src/richtext/richtextborderspage.cpp:595
+#: ../src/richtext/richtextborderspage.cpp:597
+msgid "Units for the corner radius."
+msgstr "Einheit des Eckradius."
+
+#: ../src/richtext/richtextborderspage.cpp:609
+#: ../src/richtext/richtextsizepage.cpp:247
+#: ../src/richtext/richtextsizepage.cpp:251
+msgid "None"
+msgstr "Kein"
+
+#: ../src/richtext/richtextborderspage.cpp:610
+msgid "Solid"
+msgstr "Fett"
+
+#: ../src/richtext/richtextborderspage.cpp:611
+msgid "Dotted"
+msgstr "Gepunktet"
+
+#: ../src/richtext/richtextborderspage.cpp:612
+msgid "Dashed"
+msgstr "Gestrichelt"
+
+#: ../src/richtext/richtextborderspage.cpp:613
+msgid "Double"
+msgstr "Verdoppeln"
+
+#: ../src/richtext/richtextborderspage.cpp:614
+msgid "Groove"
+msgstr "Groove"
+
+#: ../src/richtext/richtextborderspage.cpp:615
+msgid "Ridge"
+msgstr "Grat"
+
+#: ../src/richtext/richtextborderspage.cpp:616
+msgid "Inset"
+msgstr "Einfügen"
+
+#: ../src/richtext/richtextborderspage.cpp:617
+msgid "Outset"
+msgstr "Beginn"
+
+#: ../src/richtext/richtextbuffer.cpp:3518
+msgid "Change Style"
+msgstr "Stil ändern"
+
+#: ../src/richtext/richtextbuffer.cpp:3701
+msgid "Change Object Style"
+msgstr "Stil des Objektes ändern"
+
+#: ../src/richtext/richtextbuffer.cpp:3974
+#: ../src/richtext/richtextbuffer.cpp:8174
+msgid "Change Properties"
+msgstr "Eigenschaften ändern"
+
+#: ../src/richtext/richtextbuffer.cpp:4346
+msgid "Change List Style"
+msgstr "Stil der Liste ändern"
+
+#: ../src/richtext/richtextbuffer.cpp:4519
+msgid "Renumber List"
+msgstr "Liste neu nummerieren"
+
+#: ../src/richtext/richtextbuffer.cpp:7867
+#: ../src/richtext/richtextbuffer.cpp:7897
+#: ../src/richtext/richtextbuffer.cpp:7939
+#: ../src/richtext/richtextctrl.cpp:1279 ../src/richtext/richtextctrl.cpp:1473
+msgid "Insert Text"
+msgstr "Text einfügen"
+
+#: ../src/richtext/richtextbuffer.cpp:8023
+#: ../src/richtext/richtextbuffer.cpp:8979
+msgid "Insert Image"
+msgstr "Bild einfügen"
+
+#: ../src/richtext/richtextbuffer.cpp:8070
+msgid "Insert Object"
+msgstr "Objekt einfügen"
+
+#: ../src/richtext/richtextbuffer.cpp:8112
+msgid "Insert Field"
+msgstr "Feld einfügen"
+
+#: ../src/richtext/richtextbuffer.cpp:8410
+msgid "Too many EndStyle calls!"
+msgstr "Zu viele EndStyle-Aufrufe!"
+
+#: ../src/richtext/richtextbuffer.cpp:8785
+msgid "files"
+msgstr "Dateien"
+
+#: ../src/richtext/richtextbuffer.cpp:9380
+msgid "standard/circle"
+msgstr "Standard/Kreis"
+
+#: ../src/richtext/richtextbuffer.cpp:9381
+msgid "standard/circle-outline"
+msgstr "Standard/Kreisumriss"
+
+#: ../src/richtext/richtextbuffer.cpp:9382
+msgid "standard/square"
+msgstr "Standard/Quadrat"
+
+#: ../src/richtext/richtextbuffer.cpp:9383
+msgid "standard/diamond"
+msgstr "Standard/Raute"
+
+#: ../src/richtext/richtextbuffer.cpp:9384
+msgid "standard/triangle"
+msgstr "Standard/Dreieck"
+
+#: ../src/richtext/richtextbuffer.cpp:9423
+msgid "Box Properties"
+msgstr "Rahmen-Eigenschaften"
+
+#: ../src/richtext/richtextbuffer.cpp:10006
+msgid "Multiple Cell Properties"
+msgstr "Mehrfache Zelleneigenschaften"
+
+#: ../src/richtext/richtextbuffer.cpp:10008
+msgid "Cell Properties"
+msgstr "Zelleneigenschaften"
+
+#: ../src/richtext/richtextbuffer.cpp:11256
+msgid "Set Cell Style"
+msgstr "Stil der Zelle einstellen"
+
+#: ../src/richtext/richtextbuffer.cpp:11330
+msgid "Delete Row"
+msgstr "Zeile löschen"
+
+#: ../src/richtext/richtextbuffer.cpp:11380
+msgid "Delete Column"
+msgstr "Spalte löschen"
+
+#: ../src/richtext/richtextbuffer.cpp:11431
+msgid "Add Row"
+msgstr "Zeile hinzufügen"
+
+#: ../src/richtext/richtextbuffer.cpp:11494
+msgid "Add Column"
+msgstr "Spalte hinzufügen"
+
+#: ../src/richtext/richtextbuffer.cpp:11537
+msgid "Table Properties"
+msgstr "Tabelleneigenschaften"
+
+#: ../src/richtext/richtextbuffer.cpp:12899
+msgid "Picture Properties"
+msgstr "Bildeigenschaften"
+
+#: ../src/richtext/richtextbuffer.cpp:13169
+#: ../src/richtext/richtextbuffer.cpp:13279
+msgid "image"
+msgstr "Bild"
+
+#: ../src/richtext/richtextbulletspage.cpp:145
+#: ../src/richtext/richtextliststylepage.cpp:209
+msgid "&Bullet style:"
+msgstr "Stil des &Gliederungspunktes:"
+
+#: ../src/richtext/richtextbulletspage.cpp:150
+#: ../src/richtext/richtextbulletspage.cpp:152
+#: ../src/richtext/richtextliststylepage.cpp:214
+#: ../src/richtext/richtextliststylepage.cpp:216
+msgid "The available bullet styles."
+msgstr "Die verfügbaren Gliederungspunktstile."
+
+#: ../src/richtext/richtextbulletspage.cpp:158
+#: ../src/richtext/richtextliststylepage.cpp:221
+msgid "Peri&od"
+msgstr "P&unkt"
+
+#: ../src/richtext/richtextbulletspage.cpp:160
+#: ../src/richtext/richtextbulletspage.cpp:162
+#: ../src/richtext/richtextliststylepage.cpp:223
+#: ../src/richtext/richtextliststylepage.cpp:225
+msgid "Check to add a period after the bullet."
+msgstr "Klicken um einen Punkt nach dem Gliederungspunkt hinzuzufügen."
+
+#. TRANSLATORS: Bullet point in parentheses option
+#: ../src/richtext/richtextbulletspage.cpp:167
+#: ../src/richtext/richtextliststylepage.cpp:230
+msgid "(*)"
+msgstr "(*)"
+
+#: ../src/richtext/richtextbulletspage.cpp:169
+#: ../src/richtext/richtextbulletspage.cpp:171
+#: ../src/richtext/richtextliststylepage.cpp:232
+#: ../src/richtext/richtextliststylepage.cpp:234
+msgid "Check to enclose the bullet in parentheses."
+msgstr "Klicken um den Gliederungspunkt in Klammern zu setzen."
+
+#. TRANSLATORS: Right parenthesis bullet point option
+#: ../src/richtext/richtextbulletspage.cpp:176
+#: ../src/richtext/richtextliststylepage.cpp:239
+msgid "*)"
+msgstr "*)"
+
+#: ../src/richtext/richtextbulletspage.cpp:178
+#: ../src/richtext/richtextbulletspage.cpp:180
+#: ../src/richtext/richtextliststylepage.cpp:241
+#: ../src/richtext/richtextliststylepage.cpp:243
+msgid "Check to add a right parenthesis."
+msgstr "Klicken um eine schließende Klammer hinzuzufügen."
+
+#: ../src/richtext/richtextbulletspage.cpp:185
+#: ../src/richtext/richtextliststylepage.cpp:248
+msgid "Bullet &Alignment:"
+msgstr "&Ausrichtung der Gliederungspunkte:"
+
+#: ../src/richtext/richtextbulletspage.cpp:190
+#: ../src/richtext/richtextliststylepage.cpp:253
+msgid "Centre"
+msgstr "Zentriere"
+
+#: ../src/richtext/richtextbulletspage.cpp:194
+#: ../src/richtext/richtextbulletspage.cpp:196
+#: ../src/richtext/richtextbulletspage.cpp:217
+#: ../src/richtext/richtextbulletspage.cpp:219
+#: ../src/richtext/richtextliststylepage.cpp:257
+#: ../src/richtext/richtextliststylepage.cpp:259
+#: ../src/richtext/richtextliststylepage.cpp:278
+#: ../src/richtext/richtextliststylepage.cpp:280
+msgid "The bullet character."
+msgstr "Die Gliederungspunktzeichen."
+
+#: ../src/richtext/richtextbulletspage.cpp:212
+#: ../src/richtext/richtextliststylepage.cpp:271
+msgid "&Symbol:"
+msgstr "&Symbol:"
+
+#: ../src/richtext/richtextbulletspage.cpp:222
+#: ../src/richtext/richtextliststylepage.cpp:283
+msgid "Ch&oose..."
+msgstr "Wä&hle …"
+
+#: ../src/richtext/richtextbulletspage.cpp:223
+#: ../src/richtext/richtextbulletspage.cpp:225
+#: ../src/richtext/richtextliststylepage.cpp:284
+#: ../src/richtext/richtextliststylepage.cpp:286
+msgid "Click to browse for a symbol."
+msgstr "Klicken um nach einem Symbol zu navigieren."
+
+#: ../src/richtext/richtextbulletspage.cpp:230
+#: ../src/richtext/richtextliststylepage.cpp:291
+msgid "Symbol &font:"
+msgstr "Symbolschri&ftart:"
+
+#: ../src/richtext/richtextbulletspage.cpp:235
+#: ../src/richtext/richtextbulletspage.cpp:237
+#: ../src/richtext/richtextliststylepage.cpp:297
+msgid "Available fonts."
+msgstr "Verfügbare Schriftarten."
+
+#: ../src/richtext/richtextbulletspage.cpp:242
+#: ../src/richtext/richtextliststylepage.cpp:302
+msgid "S&tandard bullet name:"
+msgstr "&Vordefinierter Gliederungspunkt:"
+
+#: ../src/richtext/richtextbulletspage.cpp:247
+#: ../src/richtext/richtextbulletspage.cpp:249
+#: ../src/richtext/richtextliststylepage.cpp:307
+#: ../src/richtext/richtextliststylepage.cpp:309
+msgid "A standard bullet name."
+msgstr "Ein vordefinierter Gliederungspunkt."
+
+#: ../src/richtext/richtextbulletspage.cpp:254
+msgid "&Number:"
+msgstr "&Nummer:"
+
+#: ../src/richtext/richtextbulletspage.cpp:258
+#: ../src/richtext/richtextbulletspage.cpp:260
+msgid "The list item number."
+msgstr "Die Nummer des Listenelements."
+
+#: ../src/richtext/richtextbulletspage.cpp:266
+#: ../src/richtext/richtextbulletspage.cpp:268
+#: ../src/richtext/richtextliststylepage.cpp:475
+#: ../src/richtext/richtextliststylepage.cpp:477
+msgid "Shows a preview of the bullet settings."
+msgstr "Zeigt eine Vorschau der Gliederungspunkteinstellungen."
+
+#: ../src/richtext/richtextbulletspage.cpp:276
+#: ../src/richtext/richtextliststylepage.cpp:484
+msgid "(None)"
+msgstr "(Kein)"
+
+#: ../src/richtext/richtextbulletspage.cpp:277
+#: ../src/richtext/richtextliststylepage.cpp:485
+msgid "Arabic"
+msgstr "Arabisch"
+
+#: ../src/richtext/richtextbulletspage.cpp:278
+#: ../src/richtext/richtextliststylepage.cpp:486
+msgid "Upper case letters"
+msgstr "Großbuchstaben"
+
+#: ../src/richtext/richtextbulletspage.cpp:279
+#: ../src/richtext/richtextliststylepage.cpp:487
+msgid "Lower case letters"
+msgstr "Kleinbuchstaben"
+
+#: ../src/richtext/richtextbulletspage.cpp:280
+#: ../src/richtext/richtextliststylepage.cpp:488
+msgid "Upper case roman numerals"
+msgstr "Römische Ziffern in Großbuchstaben"
+
+#: ../src/richtext/richtextbulletspage.cpp:281
+#: ../src/richtext/richtextliststylepage.cpp:489
+msgid "Lower case roman numerals"
+msgstr "Römische Ziffern in Kleinbuchstaben"
+
+#: ../src/richtext/richtextbulletspage.cpp:282
+#: ../src/richtext/richtextliststylepage.cpp:490
+msgid "Numbered outline"
+msgstr "Nummerierung umrandet"
+
+#: ../src/richtext/richtextbulletspage.cpp:283
+#: ../src/richtext/richtextliststylepage.cpp:491
+msgid "Symbol"
+msgstr "Symbol"
+
+#: ../src/richtext/richtextbulletspage.cpp:284
+#: ../src/richtext/richtextliststylepage.cpp:492
+msgid "Bitmap"
+msgstr "Bitmap"
+
+#: ../src/richtext/richtextbulletspage.cpp:285
+#: ../src/richtext/richtextliststylepage.cpp:493
+msgid "Standard"
+msgstr "Standard"
+
+#: ../src/richtext/richtextbulletspage.cpp:287
+#: ../src/richtext/richtextliststylepage.cpp:495
+msgid "*"
+msgstr "*"
+
+#: ../src/richtext/richtextbulletspage.cpp:288
+#: ../src/richtext/richtextliststylepage.cpp:496
+msgid "-"
+msgstr "-"
+
+#: ../src/richtext/richtextbulletspage.cpp:289
+#: ../src/richtext/richtextliststylepage.cpp:497
+msgid ">"
+msgstr ">"
+
+#: ../src/richtext/richtextbulletspage.cpp:290
+#: ../src/richtext/richtextliststylepage.cpp:498
+msgid "+"
+msgstr "+"
+
+#: ../src/richtext/richtextbulletspage.cpp:291
+#: ../src/richtext/richtextliststylepage.cpp:499
+msgid "~"
+msgstr "~"
+
+#: ../src/richtext/richtextctrl.cpp:859
+msgid "Drag"
+msgstr "Freigeben"
+
+#: ../src/richtext/richtextctrl.cpp:1338 ../src/richtext/richtextctrl.cpp:1559
+msgid "Delete Text"
+msgstr "Text löschen"
+
+#: ../src/richtext/richtextctrl.cpp:1537
+msgid "Remove Bullet"
+msgstr "Gliederungspunkt entfernen"
+
+#: ../src/richtext/richtextctrl.cpp:3070
+msgid "The text couldn't be saved."
+msgstr "Der Text konnte nicht gespeichert werden."
+
+#: ../src/richtext/richtextctrl.cpp:3644
+msgid "Replace"
+msgstr "Ersetzen"
+
+#: ../src/richtext/richtextfontpage.cpp:146
+#: ../src/richtext/richtextsymboldlg.cpp:384
+msgid "&Font:"
+msgstr "&Schriftart:"
+
+#: ../src/richtext/richtextfontpage.cpp:150
+#: ../src/richtext/richtextfontpage.cpp:152
+msgid "Type a font name."
+msgstr "Schriftart eingeben."
+
+#: ../src/richtext/richtextfontpage.cpp:158
+msgid "&Size:"
+msgstr "&Größe:"
+
+#: ../src/richtext/richtextfontpage.cpp:165
+#: ../src/richtext/richtextfontpage.cpp:167
+msgid "Type a size in points."
+msgstr "Größe in Punkt eingeben."
+
+#: ../src/richtext/richtextfontpage.cpp:180
+#: ../src/richtext/richtextfontpage.cpp:182
+msgid "The font size units, points or pixels."
+msgstr "Einheit der Schriftgröße in Punkt oder Pixel."
+
+#: ../src/richtext/richtextfontpage.cpp:189
+#: ../src/richtext/richtextfontpage.cpp:191
+msgid "Lists the available fonts."
+msgstr "Listet die verfügbaren Schriftarten auf."
+
+#: ../src/richtext/richtextfontpage.cpp:196
+#: ../src/richtext/richtextfontpage.cpp:198
+msgid "Lists font sizes in points."
+msgstr "Schriftgröße der Listen in Punkt."
+
+#: ../src/richtext/richtextfontpage.cpp:207
+msgid "Font st&yle:"
+msgstr "Schrifst&il:"
+
+#: ../src/richtext/richtextfontpage.cpp:212
+#: ../src/richtext/richtextfontpage.cpp:214
+msgid "Select regular or italic style."
+msgstr "Normal oder kursiv wählen."
+
+#: ../src/richtext/richtextfontpage.cpp:220
+msgid "Font &weight:"
+msgstr "Schrift&dicke:"
+
+#: ../src/richtext/richtextfontpage.cpp:225
+#: ../src/richtext/richtextfontpage.cpp:227
+msgid "Select regular or bold."
+msgstr "Normal oder fett wählen."
+
+#: ../src/richtext/richtextfontpage.cpp:233
+msgid "&Underlining:"
+msgstr "&Unterstreichen:"
+
+#: ../src/richtext/richtextfontpage.cpp:238
+#: ../src/richtext/richtextfontpage.cpp:240
+msgid "Select underlining or no underlining."
+msgstr "Unterstrichen oder nicht unterstrichen wählen."
+
+#: ../src/richtext/richtextfontpage.cpp:248
+msgid "&Colour:"
+msgstr "&Farbe:"
+
+#: ../src/richtext/richtextfontpage.cpp:253
+#: ../src/richtext/richtextfontpage.cpp:255
+msgid "Click to change the text colour."
+msgstr "Klicken um die Textfarbe zu ändern."
+
+#: ../src/richtext/richtextfontpage.cpp:261
+msgid "&Bg colour:"
+msgstr "&Hg Farbe:"
+
+#: ../src/richtext/richtextfontpage.cpp:266
+#: ../src/richtext/richtextfontpage.cpp:268
+msgid "Click to change the text background colour."
+msgstr "Klicken um die Hintergrundfarbe des Textes zu ändern."
+
+#: ../src/richtext/richtextfontpage.cpp:276
+#: ../src/richtext/richtextfontpage.cpp:278
+msgid "Check to show a line through the text."
+msgstr "Klicken um eine Linie durch den Text zu ziehen."
+
+#: ../src/richtext/richtextfontpage.cpp:281
+msgid "Ca&pitals"
+msgstr "Ka&pitalien"
+
+#: ../src/richtext/richtextfontpage.cpp:283
+#: ../src/richtext/richtextfontpage.cpp:285
+msgid "Check to show the text in capitals."
+msgstr "Markieren um den Text in Großbuchstaben anzuzeigen."
+
+#: ../src/richtext/richtextfontpage.cpp:288
+msgid "Small C&apitals"
+msgstr "Ka&pitälchen"
+
+#: ../src/richtext/richtextfontpage.cpp:290
+#: ../src/richtext/richtextfontpage.cpp:292
+msgid "Check to show the text in small capitals."
+msgstr "Markieren um den Text in Kapitälchen darzustellen."
+
+#: ../src/richtext/richtextfontpage.cpp:295
+msgid "Supe&rscript"
+msgstr "Hochge&stellt"
+
+#: ../src/richtext/richtextfontpage.cpp:297
+#: ../src/richtext/richtextfontpage.cpp:299
+msgid "Check to show the text in superscript."
+msgstr "Klicken um den Text hochgestellt anzuzeigen."
+
+#: ../src/richtext/richtextfontpage.cpp:302
+msgid "Subscrip&t"
+msgstr "Tiefgestell&t"
+
+#: ../src/richtext/richtextfontpage.cpp:304
+#: ../src/richtext/richtextfontpage.cpp:306
+msgid "Check to show the text in subscript."
+msgstr "Klicken um den Text tiefgestellt anzuzeigen."
+
+#: ../src/richtext/richtextfontpage.cpp:312
+msgid "Rig&ht-to-left"
+msgstr "Rec&hts nach links"
+
+#: ../src/richtext/richtextfontpage.cpp:314
+#: ../src/richtext/richtextfontpage.cpp:316
+msgid "Check to indicate right-to-left text layout."
+msgstr "Markieren um rechts-nach-links-Textausrichtung zu aktivieren."
+
+#: ../src/richtext/richtextfontpage.cpp:319
+msgid "Suppress hyphe&nation"
+msgstr "Silbe&ntrennung unterdrücken"
+
+#: ../src/richtext/richtextfontpage.cpp:321
+#: ../src/richtext/richtextfontpage.cpp:323
+msgid "Check to suppress hyphenation."
+msgstr "Markieren um Silbentrennung zu unterdrücken."
+
+#: ../src/richtext/richtextfontpage.cpp:329
+#: ../src/richtext/richtextfontpage.cpp:331
+msgid "Shows a preview of the font settings."
+msgstr "Zeigt eine Vorschau der Schriftarteinstellungen."
+
+#: ../src/richtext/richtextfontpage.cpp:348
+#: ../src/richtext/richtextfontpage.cpp:352
+#: ../src/richtext/richtextfontpage.cpp:356
+#: ../src/richtext/richtextformatdlg.cpp:873
+#: ../src/richtext/richtextindentspage.cpp:273
+#: ../src/richtext/richtextindentspage.cpp:285
+#: ../src/richtext/richtextindentspage.cpp:286
+#: ../src/richtext/richtextindentspage.cpp:310
+#: ../src/richtext/richtextindentspage.cpp:325
+#: ../src/richtext/richtextliststylepage.cpp:451
+#: ../src/richtext/richtextliststylepage.cpp:463
+#: ../src/richtext/richtextliststylepage.cpp:464
+msgid "(none)"
+msgstr "(Kein)"
+
+#: ../src/richtext/richtextfontpage.cpp:349
+#: ../src/richtext/richtextfontpage.cpp:353
+msgid "Regular"
+msgstr "Regulär"
+
+#: ../src/richtext/richtextfontpage.cpp:357
+msgid "Not underlined"
+msgstr "Nicht unterstrichen"
+
+#: ../src/richtext/richtextformatdlg.cpp:341
+msgid "Indents && Spacing"
+msgstr "Einrückungen && Zeichenabstand"
+
+#: ../src/richtext/richtextformatdlg.cpp:346
+msgid "Tabs"
+msgstr "Tabulatoren"
+
+#: ../src/richtext/richtextformatdlg.cpp:351
+msgid "Bullets"
+msgstr "Gliederungspunkte"
+
+#: ../src/richtext/richtextformatdlg.cpp:356
+msgid "List Style"
+msgstr "Listenstil"
+
+#: ../src/richtext/richtextformatdlg.cpp:366
+#: ../src/richtext/richtextmarginspage.cpp:170
+msgid "Margins"
+msgstr "Ränder"
+
+#: ../src/richtext/richtextformatdlg.cpp:371
+msgid "Borders"
+msgstr "Rahmen"
+
+#: ../src/richtext/richtextformatdlg.cpp:765
+msgid "Colour"
+msgstr "Farbe"
+
+#: ../src/richtext/richtextindentspage.cpp:127
+#: ../src/richtext/richtextliststylepage.cpp:322
+msgid "&Alignment"
+msgstr "&Ausrichtung"
+
+#: ../src/richtext/richtextindentspage.cpp:138
+#: ../src/richtext/richtextliststylepage.cpp:331
+msgid "&Left"
+msgstr "&Links"
+
+#: ../src/richtext/richtextindentspage.cpp:140
+#: ../src/richtext/richtextindentspage.cpp:142
+#: ../src/richtext/richtextliststylepage.cpp:333
+#: ../src/richtext/richtextliststylepage.cpp:335
+msgid "Left-align text."
+msgstr "Linksbündiger Text."
+
+#: ../src/richtext/richtextindentspage.cpp:145
+#: ../src/richtext/richtextliststylepage.cpp:338
+msgid "&Right"
+msgstr "&Rechts"
+
+#: ../src/richtext/richtextindentspage.cpp:147
+#: ../src/richtext/richtextindentspage.cpp:149
+#: ../src/richtext/richtextliststylepage.cpp:340
+#: ../src/richtext/richtextliststylepage.cpp:342
+msgid "Right-align text."
+msgstr "Rechtsbündiger Text."
+
+#: ../src/richtext/richtextindentspage.cpp:152
+#: ../src/richtext/richtextliststylepage.cpp:345
+msgid "&Justified"
+msgstr "&Blocksatz"
+
+#: ../src/richtext/richtextindentspage.cpp:154
+#: ../src/richtext/richtextindentspage.cpp:156
+#: ../src/richtext/richtextliststylepage.cpp:347
+#: ../src/richtext/richtextliststylepage.cpp:349
+msgid "Justify text left and right."
+msgstr "Text rechts und links ausrichten."
+
+#: ../src/richtext/richtextindentspage.cpp:159
+#: ../src/richtext/richtextliststylepage.cpp:352
+msgid "Cen&tred"
+msgstr "Zen&triert"
+
+#: ../src/richtext/richtextindentspage.cpp:161
+#: ../src/richtext/richtextindentspage.cpp:163
+#: ../src/richtext/richtextliststylepage.cpp:354
+#: ../src/richtext/richtextliststylepage.cpp:356
+msgid "Centre text."
+msgstr "Zentriere den Text."
+
+#: ../src/richtext/richtextindentspage.cpp:166
+#: ../src/richtext/richtextliststylepage.cpp:359
+msgid "&Indeterminate"
+msgstr "&Unbestimmt"
+
+#: ../src/richtext/richtextindentspage.cpp:168
+#: ../src/richtext/richtextindentspage.cpp:170
+#: ../src/richtext/richtextliststylepage.cpp:361
+#: ../src/richtext/richtextliststylepage.cpp:363
+msgid "Use the current alignment setting."
+msgstr "Benutze die aktuellen Einstellungen für die Ausrichtung."
+
+#: ../src/richtext/richtextindentspage.cpp:183
+#: ../src/richtext/richtextliststylepage.cpp:375
+msgid "&Indentation (tenths of a mm)"
+msgstr "&Einrückung (Zehntel-mm)"
+
+#: ../src/richtext/richtextindentspage.cpp:198
+#: ../src/richtext/richtextindentspage.cpp:200
+#: ../src/richtext/richtextliststylepage.cpp:388
+#: ../src/richtext/richtextliststylepage.cpp:390
+msgid "The left indent."
+msgstr "Der Linkseinzug."
+
+#: ../src/richtext/richtextindentspage.cpp:203
+#: ../src/richtext/richtextliststylepage.cpp:393
+msgid "Left (&first line):"
+msgstr "Links (&erste Zeile):"
+
+#: ../src/richtext/richtextindentspage.cpp:207
+#: ../src/richtext/richtextindentspage.cpp:209
+#: ../src/richtext/richtextliststylepage.cpp:397
+#: ../src/richtext/richtextliststylepage.cpp:399
+msgid "The first line indent."
+msgstr "Der Ersteinzug."
+
+#: ../src/richtext/richtextindentspage.cpp:216
+#: ../src/richtext/richtextindentspage.cpp:218
+#: ../src/richtext/richtextliststylepage.cpp:406
+#: ../src/richtext/richtextliststylepage.cpp:408
+msgid "The right indent."
+msgstr "Der Rechtseinzug."
+
+#: ../src/richtext/richtextindentspage.cpp:221
+msgid "&Outline level:"
+msgstr "&Umrandungsebene:"
+
+#: ../src/richtext/richtextindentspage.cpp:226
+#: ../src/richtext/richtextindentspage.cpp:228
+msgid "The outline level."
+msgstr "Die Umrandungsebene."
+
+#: ../src/richtext/richtextindentspage.cpp:241
+#: ../src/richtext/richtextliststylepage.cpp:420
+msgid "&Spacing (tenths of a mm)"
+msgstr "&Zeichenabstand (Zehntel-mm)"
+
+#: ../src/richtext/richtextindentspage.cpp:252
+msgid "&Before a paragraph:"
+msgstr "&Vor einem Absatz:"
+
+#: ../src/richtext/richtextindentspage.cpp:256
+#: ../src/richtext/richtextindentspage.cpp:258
+#: ../src/richtext/richtextliststylepage.cpp:433
+#: ../src/richtext/richtextliststylepage.cpp:435
+msgid "The spacing before the paragraph."
+msgstr "Der Abstand vor einem Absatz."
+
+#: ../src/richtext/richtextindentspage.cpp:261
+msgid "&After a paragraph:"
+msgstr "&Nach einem Absatz:"
+
+#: ../src/richtext/richtextindentspage.cpp:266
+#: ../src/richtext/richtextliststylepage.cpp:442
+#: ../src/richtext/richtextliststylepage.cpp:444
+msgid "The spacing after the paragraph."
+msgstr "Der Abstand nach einem Absatz."
+
+#: ../src/richtext/richtextindentspage.cpp:269
+msgid "L&ine spacing:"
+msgstr "Ze&ilenabstand:"
+
+#: ../src/richtext/richtextindentspage.cpp:274
+#: ../src/richtext/richtextliststylepage.cpp:452
+msgid "Single"
+msgstr "Einzel"
+
+#: ../src/richtext/richtextindentspage.cpp:275
+#: ../src/richtext/richtextliststylepage.cpp:453
+msgid "1.1"
+msgstr "1.1"
+
+#: ../src/richtext/richtextindentspage.cpp:276
+#: ../src/richtext/richtextliststylepage.cpp:454
+msgid "1.2"
+msgstr "1.2"
+
+#: ../src/richtext/richtextindentspage.cpp:277
+#: ../src/richtext/richtextliststylepage.cpp:455
+msgid "1.3"
+msgstr "1.3"
+
+#: ../src/richtext/richtextindentspage.cpp:278
+#: ../src/richtext/richtextliststylepage.cpp:456
+msgid "1.4"
+msgstr "1.4"
+
+#: ../src/richtext/richtextindentspage.cpp:279
+#: ../src/richtext/richtextliststylepage.cpp:457
+msgid "1.5"
+msgstr "1.5"
+
+#: ../src/richtext/richtextindentspage.cpp:280
+#: ../src/richtext/richtextliststylepage.cpp:458
+msgid "1.6"
+msgstr "1.6"
+
+#: ../src/richtext/richtextindentspage.cpp:281
+#: ../src/richtext/richtextliststylepage.cpp:459
+msgid "1.7"
+msgstr "1.7"
+
+#: ../src/richtext/richtextindentspage.cpp:282
+#: ../src/richtext/richtextliststylepage.cpp:460
+msgid "1.8"
+msgstr "1.8"
+
+#: ../src/richtext/richtextindentspage.cpp:283
+#: ../src/richtext/richtextliststylepage.cpp:461
+msgid "1.9"
+msgstr "1.9"
+
+#: ../src/richtext/richtextindentspage.cpp:284
+#: ../src/richtext/richtextliststylepage.cpp:462
+msgid "2"
+msgstr "2"
+
+#: ../src/richtext/richtextindentspage.cpp:287
+#: ../src/richtext/richtextindentspage.cpp:289
+#: ../src/richtext/richtextliststylepage.cpp:465
+#: ../src/richtext/richtextliststylepage.cpp:467
+msgid "The line spacing."
+msgstr "Der Zeilenabstand."
+
+#: ../src/richtext/richtextindentspage.cpp:292
+msgid "&Page Break"
+msgstr "&Seitenumbruch"
+
+#: ../src/richtext/richtextindentspage.cpp:294
+#: ../src/richtext/richtextindentspage.cpp:296
+msgid "Inserts a page break before the paragraph."
+msgstr "Fügt einen Seitenumbruch vor dem Absatz ein."
+
+#: ../src/richtext/richtextindentspage.cpp:302
+#: ../src/richtext/richtextindentspage.cpp:304
+msgid "Shows a preview of the paragraph settings."
+msgstr "Zeigt eine Vorschau der Absatzeinstellungen."
+
+#: ../src/richtext/richtextliststylepage.cpp:182
+msgid "&List level:"
+msgstr "&Listenebene:"
+
+#: ../src/richtext/richtextliststylepage.cpp:186
+#: ../src/richtext/richtextliststylepage.cpp:188
+msgid "Selects the list level to edit."
+msgstr "Wählt die Listenebene zur Bearbeitung."
+
+#: ../src/richtext/richtextliststylepage.cpp:193
+msgid "&Font for Level..."
+msgstr "&Schriftart für Ebene …"
+
+#: ../src/richtext/richtextliststylepage.cpp:194
+#: ../src/richtext/richtextliststylepage.cpp:196
+msgid "Click to choose the font for this level."
+msgstr "Klicken um die Schriftart für diese Ebene zu wählen."
+
+#: ../src/richtext/richtextliststylepage.cpp:312
+msgid "Bullet style"
+msgstr "Stil der Gliederungspunkte"
+
+#: ../src/richtext/richtextliststylepage.cpp:429
+msgid "Before a paragraph:"
+msgstr "Vor einem Absatz:"
+
+#: ../src/richtext/richtextliststylepage.cpp:438
+msgid "After a paragraph:"
+msgstr "Nach einem Absatz:"
+
+#: ../src/richtext/richtextliststylepage.cpp:447
+msgid "Line spacing:"
+msgstr "Zeilenabstand:"
+
+#: ../src/richtext/richtextliststylepage.cpp:470
+msgid "Spacing"
+msgstr "Zwischenraum"
+
+#: ../src/richtext/richtextmarginspage.cpp:193
+#: ../src/richtext/richtextmarginspage.cpp:195
+msgid "The left margin size."
+msgstr "Der linke Rand."
+
+#: ../src/richtext/richtextmarginspage.cpp:203
+#: ../src/richtext/richtextmarginspage.cpp:205
+msgid "Units for the left margin."
+msgstr "Einheiten für den linken Rand."
+
+#: ../src/richtext/richtextmarginspage.cpp:218
+#: ../src/richtext/richtextmarginspage.cpp:220
+msgid "The right margin size."
+msgstr "Der rechte Rand."
+
+#: ../src/richtext/richtextmarginspage.cpp:228
+#: ../src/richtext/richtextmarginspage.cpp:230
+msgid "Units for the right margin."
+msgstr "Einheiten für den rechten Rand."
+
+#: ../src/richtext/richtextmarginspage.cpp:241
+#: ../src/richtext/richtextmarginspage.cpp:243
+msgid "The top margin size."
+msgstr "Der obere Rand."
+
+#: ../src/richtext/richtextmarginspage.cpp:251
+#: ../src/richtext/richtextmarginspage.cpp:253
+msgid "Units for the top margin."
+msgstr "Einheiten für den oberen Rand."
+
+#: ../src/richtext/richtextmarginspage.cpp:266
+#: ../src/richtext/richtextmarginspage.cpp:268
+msgid "The bottom margin size."
+msgstr "Die untere Randgröße."
+
+#: ../src/richtext/richtextmarginspage.cpp:276
+#: ../src/richtext/richtextmarginspage.cpp:278
+msgid "Units for the bottom margin."
+msgstr "Einheiten für den unteren Rand."
+
+#: ../src/richtext/richtextmarginspage.cpp:284
+msgid "Padding"
+msgstr "Auffüllung"
+
+#: ../src/richtext/richtextmarginspage.cpp:307
+#: ../src/richtext/richtextmarginspage.cpp:309
+msgid "The left padding size."
+msgstr "Die linke Auffüllung."
+
+#: ../src/richtext/richtextmarginspage.cpp:317
+#: ../src/richtext/richtextmarginspage.cpp:319
+msgid "Units for the left padding."
+msgstr "Einheiten für die linke Auffüllung."
+
+#: ../src/richtext/richtextmarginspage.cpp:332
+#: ../src/richtext/richtextmarginspage.cpp:334
+msgid "The right padding size."
+msgstr "Die rechte Auffüllung."
+
+#: ../src/richtext/richtextmarginspage.cpp:342
+#: ../src/richtext/richtextmarginspage.cpp:344
+msgid "Units for the right padding."
+msgstr "Einheit für die Auffüllung rechts."
+
+#: ../src/richtext/richtextmarginspage.cpp:355
+#: ../src/richtext/richtextmarginspage.cpp:357
+msgid "The top padding size."
+msgstr "Die obere Füllung."
+
+#: ../src/richtext/richtextmarginspage.cpp:365
+#: ../src/richtext/richtextmarginspage.cpp:367
+msgid "Units for the top padding."
+msgstr "Einheit für die obere Auffüllung."
+
+#: ../src/richtext/richtextmarginspage.cpp:380
+#: ../src/richtext/richtextmarginspage.cpp:382
+msgid "The bottom padding size."
+msgstr "Die untere Auffüllung."
+
+#: ../src/richtext/richtextmarginspage.cpp:390
+#: ../src/richtext/richtextmarginspage.cpp:392
+msgid "Units for the bottom padding."
+msgstr "Einheiten für die untere Auffüllung."
+
+#: ../src/richtext/richtextprint.cpp:592
+msgid " Preview"
+msgstr " Vorschau"
+
+#: ../src/richtext/richtextsizepage.cpp:228
+msgid "Floating"
+msgstr "Schwebend"
+
+#: ../src/richtext/richtextsizepage.cpp:243
+msgid "&Floating mode:"
+msgstr "&Schwebemodus:"
+
+#: ../src/richtext/richtextsizepage.cpp:252
+#: ../src/richtext/richtextsizepage.cpp:254
+msgid "How the object will float relative to the text."
+msgstr "Wie das Objekt relativ zum Text angeordnet wird."
+
+#: ../src/richtext/richtextsizepage.cpp:265
+msgid "Alignment"
+msgstr "Ausrichtung"
+
+#: ../src/richtext/richtextsizepage.cpp:277
+msgid "&Vertical alignment:"
+msgstr "&Vertikale Ausrichtung:"
+
+#: ../src/richtext/richtextsizepage.cpp:279
+#: ../src/richtext/richtextsizepage.cpp:281
+msgid "Enable vertical alignment."
+msgstr "Vertikale Ausrichtung einschalten."
+
+#: ../src/richtext/richtextsizepage.cpp:286
+msgid "Centred"
+msgstr "Zentriert"
+
+#: ../src/richtext/richtextsizepage.cpp:290
+#: ../src/richtext/richtextsizepage.cpp:292
+msgid "Vertical alignment."
+msgstr "Vertikale Ausrichtung."
+
+#: ../src/richtext/richtextsizepage.cpp:316
+#: ../src/richtext/richtextsizepage.cpp:323
+msgid "&Width:"
+msgstr "&Breite:"
+
+#: ../src/richtext/richtextsizepage.cpp:318
+#: ../src/richtext/richtextsizepage.cpp:320
+msgid "Enable the width value."
+msgstr "Breitenwert einschalten."
+
+#: ../src/richtext/richtextsizepage.cpp:331
+#: ../src/richtext/richtextsizepage.cpp:333
+msgid "The object width."
+msgstr "Die Objektbreite."
+
+#: ../src/richtext/richtextsizepage.cpp:342
+#: ../src/richtext/richtextsizepage.cpp:344
+msgid "Units for the object width."
+msgstr "Einheiten für die Objektbreite."
+
+#: ../src/richtext/richtextsizepage.cpp:350
+#: ../src/richtext/richtextsizepage.cpp:357
+msgid "&Height:"
+msgstr "&Höhe:"
+
+#: ../src/richtext/richtextsizepage.cpp:352
+#: ../src/richtext/richtextsizepage.cpp:354
+#: ../src/richtext/richtextsizepage.cpp:464
+#: ../src/richtext/richtextsizepage.cpp:466
+msgid "Enable the height value."
+msgstr "Höhenwert einschalten."
+
+#: ../src/richtext/richtextsizepage.cpp:365
+#: ../src/richtext/richtextsizepage.cpp:367
+msgid "The object height."
+msgstr "Die Objekthöhe."
+
+#: ../src/richtext/richtextsizepage.cpp:376
+#: ../src/richtext/richtextsizepage.cpp:378
+msgid "Units for the object height."
+msgstr "Einheiten für die Objekthöhe."
+
+#: ../src/richtext/richtextsizepage.cpp:381
+msgid "Min width:"
+msgstr "Minimale Breite:"
+
+#: ../src/richtext/richtextsizepage.cpp:383
+#: ../src/richtext/richtextsizepage.cpp:385
+msgid "Enable the minimum width value."
+msgstr "Minimalen Breitenwert einschalten."
+
+#: ../src/richtext/richtextsizepage.cpp:392
+#: ../src/richtext/richtextsizepage.cpp:394
+msgid "The object minimum width."
+msgstr "Die minimale Objektbreite."
+
+#: ../src/richtext/richtextsizepage.cpp:403
+#: ../src/richtext/richtextsizepage.cpp:405
+msgid "Units for the minimum object width."
+msgstr "Einheiten für die minimale Objektbreite."
+
+#: ../src/richtext/richtextsizepage.cpp:408
+msgid "Min height:"
+msgstr "Minimale Höhe:"
+
+#: ../src/richtext/richtextsizepage.cpp:410
+#: ../src/richtext/richtextsizepage.cpp:412
+msgid "Enable the minimum height value."
+msgstr "Minimalen Höhenwert einschalten."
+
+#: ../src/richtext/richtextsizepage.cpp:419
+#: ../src/richtext/richtextsizepage.cpp:421
+msgid "The object minimum height."
+msgstr "Die minimale Objekthöhe."
+
+#: ../src/richtext/richtextsizepage.cpp:430
+#: ../src/richtext/richtextsizepage.cpp:432
+msgid "Units for the minimum object height."
+msgstr "Einheiten für die minimale Objekthöhe."
+
+#: ../src/richtext/richtextsizepage.cpp:435
+msgid "Max width:"
+msgstr "Maximale Breite:"
+
+#: ../src/richtext/richtextsizepage.cpp:437
+#: ../src/richtext/richtextsizepage.cpp:439
+msgid "Enable the maximum width value."
+msgstr "Maximalen Breitenwert einschalten."
+
+#: ../src/richtext/richtextsizepage.cpp:446
+#: ../src/richtext/richtextsizepage.cpp:448
+msgid "The object maximum width."
+msgstr "Die maximale Objektbreite."
+
+#: ../src/richtext/richtextsizepage.cpp:457
+#: ../src/richtext/richtextsizepage.cpp:459
+msgid "Units for the maximum object width."
+msgstr "Einheiten für die maximale Objektbreite."
+
+#: ../src/richtext/richtextsizepage.cpp:462
+msgid "Max height:"
+msgstr "Maximale Höhe:"
+
+#: ../src/richtext/richtextsizepage.cpp:473
+#: ../src/richtext/richtextsizepage.cpp:475
+msgid "The object maximum height."
+msgstr "Die maximale Objekthöhe."
+
+#: ../src/richtext/richtextsizepage.cpp:484
+#: ../src/richtext/richtextsizepage.cpp:486
+msgid "Units for the maximum object height."
+msgstr "Einheiten für die maximale Objekthöhe."
+
+#: ../src/richtext/richtextsizepage.cpp:495
+msgid "Position"
+msgstr "Position"
+
+#: ../src/richtext/richtextsizepage.cpp:513
+msgid "&Position mode:"
+msgstr "&Positionierungs-Modus:"
+
+#: ../src/richtext/richtextsizepage.cpp:517
+#: ../src/richtext/richtextsizepage.cpp:522
+msgid "Static"
+msgstr "Statisch"
+
+#: ../src/richtext/richtextsizepage.cpp:518
+msgid "Relative"
+msgstr "Relativ"
+
+#: ../src/richtext/richtextsizepage.cpp:519
+msgid "Absolute"
+msgstr "Absolut"
+
+#: ../src/richtext/richtextsizepage.cpp:520
+msgid "Fixed"
+msgstr "Festgesetzt"
+
+#: ../src/richtext/richtextsizepage.cpp:533
+#: ../src/richtext/richtextsizepage.cpp:535
+#: ../src/richtext/richtextsizepage.cpp:547
+#: ../src/richtext/richtextsizepage.cpp:549
+msgid "The left position."
+msgstr "Abstand nach links."
+
+#: ../src/richtext/richtextsizepage.cpp:558
+#: ../src/richtext/richtextsizepage.cpp:560
+msgid "Units for the left position."
+msgstr "Einheit für den Abstand nach links."
+
+#: ../src/richtext/richtextsizepage.cpp:568
+#: ../src/richtext/richtextsizepage.cpp:570
+#: ../src/richtext/richtextsizepage.cpp:582
+#: ../src/richtext/richtextsizepage.cpp:584
+msgid "The top position."
+msgstr "Abstand nach oben."
+
+#: ../src/richtext/richtextsizepage.cpp:593
+#: ../src/richtext/richtextsizepage.cpp:595
+msgid "Units for the top position."
+msgstr "Einheit des Abstands nach oben."
+
+#: ../src/richtext/richtextsizepage.cpp:603
+#: ../src/richtext/richtextsizepage.cpp:605
+#: ../src/richtext/richtextsizepage.cpp:617
+#: ../src/richtext/richtextsizepage.cpp:619
+msgid "The right position."
+msgstr "Abstand nach rechts."
+
+#: ../src/richtext/richtextsizepage.cpp:628
+#: ../src/richtext/richtextsizepage.cpp:630
+msgid "Units for the right position."
+msgstr "Einheit des Abstands nach rechts."
+
+#: ../src/richtext/richtextsizepage.cpp:638
+#: ../src/richtext/richtextsizepage.cpp:640
+#: ../src/richtext/richtextsizepage.cpp:652
+#: ../src/richtext/richtextsizepage.cpp:654
+msgid "The bottom position."
+msgstr "Abstand nach unten."
+
+#: ../src/richtext/richtextsizepage.cpp:663
+#: ../src/richtext/richtextsizepage.cpp:665
+msgid "Units for the bottom position."
+msgstr "Einheit für den Abstand nach unten."
+
+#: ../src/richtext/richtextsizepage.cpp:671
+msgid "&Move the object to:"
+msgstr "&Bewege das Objekt zu:"
+
+#: ../src/richtext/richtextsizepage.cpp:674
+msgid "&Previous Paragraph"
+msgstr "&Vorheriger Absatz"
+
+#: ../src/richtext/richtextsizepage.cpp:675
+#: ../src/richtext/richtextsizepage.cpp:677
+msgid "Moves the object to the previous paragraph."
+msgstr "Verschiebt das Objekt in den vorherigen Absatz."
+
+#: ../src/richtext/richtextsizepage.cpp:680
+msgid "&Next Paragraph"
+msgstr "&Nächster Absatz"
+
+#: ../src/richtext/richtextsizepage.cpp:681
+#: ../src/richtext/richtextsizepage.cpp:683
+msgid "Moves the object to the next paragraph."
+msgstr "Verschiebt das Objekt zum nächsten Absatz."
+
+#: ../src/richtext/richtextstyledlg.cpp:193
+msgid "&Styles:"
+msgstr "&Stile:"
+
+#: ../src/richtext/richtextstyledlg.cpp:197
+#: ../src/richtext/richtextstyledlg.cpp:199
+msgid "The available styles."
+msgstr "Die verfügbaren Schriftarten."
+
+#: ../src/richtext/richtextstyledlg.cpp:205
+#: ../src/richtext/richtextstyledlg.cpp:217
+msgid " "
+msgstr " "
+
+#: ../src/richtext/richtextstyledlg.cpp:209
+#: ../src/richtext/richtextstyledlg.cpp:211
+msgid "The style preview."
+msgstr "Die Schriftvorschau."
+
+#: ../src/richtext/richtextstyledlg.cpp:220
+msgid "New &Character Style..."
+msgstr "Neuer &Zeichenstil …"
+
+#: ../src/richtext/richtextstyledlg.cpp:221
+#: ../src/richtext/richtextstyledlg.cpp:223
+msgid "Click to create a new character style."
+msgstr "Klicken um einen neuen Zeichenstil zu erzeugen."
+
+#: ../src/richtext/richtextstyledlg.cpp:226
+msgid "New &Paragraph Style..."
+msgstr "Neuer &Absatzstil …"
+
+#: ../src/richtext/richtextstyledlg.cpp:227
+#: ../src/richtext/richtextstyledlg.cpp:229
+msgid "Click to create a new paragraph style."
+msgstr "Klicken um einen neuen Absatzstil zu erzeugen."
+
+#: ../src/richtext/richtextstyledlg.cpp:232
+msgid "New &List Style..."
+msgstr "Neuer &Listenstil …"
+
+#: ../src/richtext/richtextstyledlg.cpp:233
+#: ../src/richtext/richtextstyledlg.cpp:235
+msgid "Click to create a new list style."
+msgstr "Klicken um einen neuen Listenstil zu erzeugen."
+
+#: ../src/richtext/richtextstyledlg.cpp:238
+msgid "New &Box Style..."
+msgstr "Neuer &Rahmenstil …"
+
+#: ../src/richtext/richtextstyledlg.cpp:239
+#: ../src/richtext/richtextstyledlg.cpp:241
+msgid "Click to create a new box style."
+msgstr "Klicken um einen neuen Rahmen-Stil zu erzeugen."
+
+#: ../src/richtext/richtextstyledlg.cpp:246
+msgid "&Apply Style"
+msgstr "&Stil anwenden"
+
+#: ../src/richtext/richtextstyledlg.cpp:247
+#: ../src/richtext/richtextstyledlg.cpp:249
+msgid "Click to apply the selected style."
+msgstr "Klicken um den ausgewählten Stil anzuwenden."
+
+#: ../src/richtext/richtextstyledlg.cpp:252
+msgid "&Rename Style..."
+msgstr "Stil &umbenennen …"
+
+#: ../src/richtext/richtextstyledlg.cpp:253
+#: ../src/richtext/richtextstyledlg.cpp:255
+msgid "Click to rename the selected style."
+msgstr "Klicken um den ausgewählten Stil umzubenennen."
+
+#: ../src/richtext/richtextstyledlg.cpp:258
+msgid "&Edit Style..."
+msgstr "Stil &bearbeiten …"
+
+#: ../src/richtext/richtextstyledlg.cpp:259
+#: ../src/richtext/richtextstyledlg.cpp:261
+msgid "Click to edit the selected style."
+msgstr "Klicken um den ausgewählten Stil zu bearbeiten."
+
+#: ../src/richtext/richtextstyledlg.cpp:264
+msgid "&Delete Style..."
+msgstr "Stil &löschen …"
+
+#: ../src/richtext/richtextstyledlg.cpp:265
+#: ../src/richtext/richtextstyledlg.cpp:267
+msgid "Click to delete the selected style."
+msgstr "Klicken um den ausgewählten Stil zu löschen."
+
+#: ../src/richtext/richtextstyledlg.cpp:274
+#: ../src/richtext/richtextstyledlg.cpp:276
+msgid "Click to close this window."
+msgstr "Klicken um dieses Fenster zu schließen."
+
+#: ../src/richtext/richtextstyledlg.cpp:282
+msgid "&Restart numbering"
+msgstr "&Starte Nummerierung erneut"
+
+#: ../src/richtext/richtextstyledlg.cpp:284
+#: ../src/richtext/richtextstyledlg.cpp:286
+msgid "Check to restart numbering."
+msgstr "Klicken um die Nummerierung neu zu starten."
+
+#: ../src/richtext/richtextstyledlg.cpp:601
+msgid "Enter a character style name"
+msgstr "Name des Zeichenstils eintragen"
+
+#: ../src/richtext/richtextstyledlg.cpp:601
+#: ../src/richtext/richtextstyledlg.cpp:606
+#: ../src/richtext/richtextstyledlg.cpp:649
+#: ../src/richtext/richtextstyledlg.cpp:654
+#: ../src/richtext/richtextstyledlg.cpp:815
+#: ../src/richtext/richtextstyledlg.cpp:820
+#: ../src/richtext/richtextstyledlg.cpp:888
+#: ../src/richtext/richtextstyledlg.cpp:896
+#: ../src/richtext/richtextstyledlg.cpp:929
+#: ../src/richtext/richtextstyledlg.cpp:934
+msgid "New Style"
+msgstr "Neuer Stil"
+
+#: ../src/richtext/richtextstyledlg.cpp:606
+#: ../src/richtext/richtextstyledlg.cpp:654
+#: ../src/richtext/richtextstyledlg.cpp:820
+#: ../src/richtext/richtextstyledlg.cpp:896
+#: ../src/richtext/richtextstyledlg.cpp:934
+msgid "Sorry, that name is taken. Please choose another."
+msgstr "Name bereits vergeben. Bitte anderen auswählen."
+
+#: ../src/richtext/richtextstyledlg.cpp:649
+msgid "Enter a paragraph style name"
+msgstr "Name des Absatzstils eintragen"
+
+#: ../src/richtext/richtextstyledlg.cpp:777
+#, c-format
+msgid "Delete style %s?"
+msgstr "Stil %s löschen?"
+
+#: ../src/richtext/richtextstyledlg.cpp:777
+msgid "Delete Style"
+msgstr "Stil löschen"
+
+#: ../src/richtext/richtextstyledlg.cpp:815
+msgid "Enter a list style name"
+msgstr "Name des Listenstils eintragen"
+
+#: ../src/richtext/richtextstyledlg.cpp:888
+msgid "Enter a new style name"
+msgstr "Neuen Stilnamen eintragen"
+
+#: ../src/richtext/richtextstyledlg.cpp:929
+msgid "Enter a box style name"
+msgstr "Namen für den Rahmen-Stil eintragen"
+
+#: ../src/richtext/richtextstylepage.cpp:109
+#: ../src/richtext/richtextstylepage.cpp:111
+msgid "The style name."
+msgstr "Der Stilname."
+
+#: ../src/richtext/richtextstylepage.cpp:114
+msgid "&Based on:"
+msgstr "&Basierend auf:"
+
+#: ../src/richtext/richtextstylepage.cpp:119
+#: ../src/richtext/richtextstylepage.cpp:121
+msgid "The style on which this style is based."
+msgstr "Der Stil auf dem dieser Stil basiert."
+
+#: ../src/richtext/richtextstylepage.cpp:124
+msgid "&Next style:"
+msgstr "&Nächster Stil:"
+
+#: ../src/richtext/richtextstylepage.cpp:129
+#: ../src/richtext/richtextstylepage.cpp:131
+msgid "The default style for the next paragraph."
+msgstr "Der voreingestellte Stil für den nächsten Absatz."
+
+#: ../src/richtext/richtextstyles.cpp:1057
+msgid "All styles"
+msgstr "Alle Stile"
+
+#: ../src/richtext/richtextstyles.cpp:1058
+msgid "Paragraph styles"
+msgstr "Absatzstile"
+
+#: ../src/richtext/richtextstyles.cpp:1059
+msgid "Character styles"
+msgstr "Zeichenstil"
+
+#: ../src/richtext/richtextstyles.cpp:1060
+msgid "List styles"
+msgstr "Listenstile"
+
+#: ../src/richtext/richtextstyles.cpp:1061
+msgid "Box styles"
+msgstr "Rahmen-Stile"
+
+#: ../src/richtext/richtextsymboldlg.cpp:389
+#: ../src/richtext/richtextsymboldlg.cpp:391
+msgid "The font from which to take the symbol."
+msgstr "Die Schriftart aus der das Symbol entnommen wurde."
+
+#: ../src/richtext/richtextsymboldlg.cpp:396
+msgid "&Subset:"
+msgstr "&Teilsatz:"
+
+#: ../src/richtext/richtextsymboldlg.cpp:401
+#: ../src/richtext/richtextsymboldlg.cpp:403
+msgid "Shows a Unicode subset."
+msgstr "Zeigt einen Unicode-Teilzeichensatz."
+
+#: ../src/richtext/richtextsymboldlg.cpp:412
+msgid "xxxx"
+msgstr "xxxx"
+
+#: ../src/richtext/richtextsymboldlg.cpp:417
+msgid "&Character code:"
+msgstr "&Zeichencode:"
+
+#: ../src/richtext/richtextsymboldlg.cpp:421
+#: ../src/richtext/richtextsymboldlg.cpp:423
+msgid "The character code."
+msgstr "Der Zeichencode."
+
+#: ../src/richtext/richtextsymboldlg.cpp:428
+msgid "&From:"
+msgstr "&Von:"
+
+#: ../src/richtext/richtextsymboldlg.cpp:433
+#: ../src/richtext/richtextsymboldlg.cpp:434
+#: ../src/richtext/richtextsymboldlg.cpp:435
+msgid "Unicode"
+msgstr "Unicode"
+
+#: ../src/richtext/richtextsymboldlg.cpp:436
+#: ../src/richtext/richtextsymboldlg.cpp:438
+msgid "The range to show."
+msgstr "Der anzuzeigende Bereich."
+
+#: ../src/richtext/richtextsymboldlg.cpp:444
+msgid "Insert"
+msgstr "Einfügen"
+
+#: ../src/richtext/richtextsymboldlg.cpp:478
+msgid "(Normal text)"
+msgstr "(Normaler Text)"
+
+#: ../src/richtext/richtexttabspage.cpp:109
+msgid "&Position (tenths of a mm):"
+msgstr "&Position (Zehntel-mm):"
+
+#: ../src/richtext/richtexttabspage.cpp:113
+#: ../src/richtext/richtexttabspage.cpp:115
+msgid "The tab position."
+msgstr "Die Tabulatorposition."
+
+#: ../src/richtext/richtexttabspage.cpp:119
+msgid "The tab positions."
+msgstr "Die Tabulatorpositionen."
+
+#: ../src/richtext/richtexttabspage.cpp:132
+#: ../src/richtext/richtexttabspage.cpp:134
+msgid "Click to create a new tab position."
+msgstr "Klicken um eine neue Tabulatorposition zu erzeugen."
+
+#: ../src/richtext/richtexttabspage.cpp:138
+#: ../src/richtext/richtexttabspage.cpp:140
+msgid "Click to delete the selected tab position."
+msgstr "Klicken um die ausgewählte Tabulatorposition zu löschen."
+
+#: ../src/richtext/richtexttabspage.cpp:143
+msgid "Delete A&ll"
+msgstr "A&lles löschen"
+
+#: ../src/richtext/richtexttabspage.cpp:144
+#: ../src/richtext/richtexttabspage.cpp:146
+msgid "Click to delete all tab positions."
+msgstr "Klicken um alle Tabulatorpositionen zu löschen."
+
+#: ../src/univ/theme.cpp:110
+msgid "Failed to initialize GUI: no built-in themes found."
+msgstr "Konnte GUI nicht initialisieren: kein Thema gefunden."
+
+#: ../src/univ/themes/gtk.cpp:521
+msgid "GTK+ theme"
+msgstr "GTK+ Thema"
+
+#: ../src/univ/themes/metal.cpp:164
+msgid "Metal theme"
+msgstr "Metal-Thema"
+
+#: ../src/univ/themes/mono.cpp:512
+msgid "Simple monochrome theme"
+msgstr "Einfaches einfarbiges Thema"
+
+#: ../src/univ/themes/win32.cpp:1098
+msgid "Win32 theme"
+msgstr "Win32-Thema"
+
+#: ../src/univ/themes/win32.cpp:3743
+msgid "&Restore"
+msgstr "&Wiederherstellen"
+
+#: ../src/univ/themes/win32.cpp:3744
+msgid "&Move"
+msgstr "&Bewegen"
+
+#: ../src/univ/themes/win32.cpp:3746
+msgid "&Size"
+msgstr "&Größe"
+
+#: ../src/univ/themes/win32.cpp:3748
+msgid "Mi&nimize"
+msgstr "Mi&nimieren"
+
+#: ../src/univ/themes/win32.cpp:3750
+msgid "Ma&ximize"
+msgstr "Ma&ximieren"
+
+#: ../src/univ/themes/win32.cpp:3752
+msgid "Alt+"
+msgstr "Alt+"
+
+#: ../src/unix/appunix.cpp:178
+msgid "Failed to install signal handler"
+msgstr "Konnte Signalbearbeitung nicht installieren"
+
+#: ../src/unix/dialup.cpp:351
+msgid "Already dialling ISP."
+msgstr "ISP wird bereits angewählt."
+
+#: ../src/unix/dlunix.cpp:93
+msgid "Failed to unload shared library"
+msgstr "Entladen der dynamischen Bibliothek fehlgeschlagen"
+
+#: ../src/unix/dlunix.cpp:121
+msgid "Unknown dynamic library error"
+msgstr "Unbekannter Fehler bei Behandlung dynamischer Bibliothek"
+
+#: ../src/unix/epolldispatcher.cpp:84
+msgid "Failed to create epoll descriptor"
+msgstr "Epoll Beschreibungselement konnte nicht erstellt werden"
+
+#: ../src/unix/epolldispatcher.cpp:103
+msgid "Error closing epoll descriptor"
+msgstr "Fehler beim Schließen des epol Bezeichners"
+
+#: ../src/unix/epolldispatcher.cpp:116
+#, c-format
+msgid "Failed to add descriptor %d to epoll descriptor %d"
+msgstr "Das Hinzufügen des Bezeichners %d zum epoll Bezeichner %d schlug fehl"
+
+#: ../src/unix/epolldispatcher.cpp:136
+#, c-format
+msgid "Failed to modify descriptor %d in epoll descriptor %d"
+msgstr "Wechsel von Beschreibung %d in Epoll Beschreibung %d fehlgeschlagen"
+
+#: ../src/unix/epolldispatcher.cpp:155
+#, c-format
+msgid "Failed to unregister descriptor %d from epoll descriptor %d"
+msgstr "Konnte Descriptor %d vom Epoll Descriptor nicht %d austragen"
+
+#: ../src/unix/epolldispatcher.cpp:213
+#, c-format
+msgid "Waiting for IO on epoll descriptor %d failed"
+msgstr ""
+"Warten auf Eingabe-/Ausgabe-Epoll-Beschreibungselement %d fehlgeschlagen"
+
+#: ../src/unix/fswatcher_inotify.cpp:71
+msgid "Unable to create inotify instance"
+msgstr "Erzeugen der Inotify-Instanz fehlgeschlagen"
+
+#: ../src/unix/fswatcher_inotify.cpp:94
+msgid "Unable to close inotify instance"
+msgstr "Inotify-Instanz konnte nicht geschlossen werden"
+
+#: ../src/unix/fswatcher_inotify.cpp:106
+msgid "Unable to add inotify watch"
+msgstr "Inotify-Überwachung konnte nicht hinzugefügt werden"
+
+#: ../src/unix/fswatcher_inotify.cpp:138
+#, c-format
+msgid "Unable to remove inotify watch %i"
+msgstr "Zurücksetzen der inotify-Überwachung nicht möglich %i"
+
+#: ../src/unix/fswatcher_inotify.cpp:271
+#, c-format
+msgid "Unexpected event for \"%s\": no matching watch descriptor."
+msgstr ""
+"Unerwartetes Ereignis für „%s“: Kein passender Überwachungs-Deskriptor."
+
+#: ../src/unix/fswatcher_inotify.cpp:320
+#, c-format
+msgid "Invalid inotify event for \"%s\""
+msgstr "Ungültiges inotify-Ereignis für „%s“"
+
+#: ../src/unix/fswatcher_inotify.cpp:553
+msgid "Unable to read from inotify descriptor"
+msgstr "Konnte nicht vom Inotify-Beschreibungselement lesen"
+
+#: ../src/unix/fswatcher_inotify.cpp:558
+msgid "EOF while reading from inotify descriptor"
+msgstr "EOF beim Lesen vom inotify Bezeichner"
+
+#: ../src/unix/fswatcher_kqueue.cpp:114
+msgid "Unable to create kqueue instance"
+msgstr "Erzeugen der Kqueue-Instanz fehlgeschlagen"
+
+#: ../src/unix/fswatcher_kqueue.cpp:131
+msgid "Error closing kqueue instance"
+msgstr "Fehler schließt kqueue Vorgang"
+
+#: ../src/unix/fswatcher_kqueue.cpp:153
+msgid "Unable to add kqueue watch"
+msgstr "Kqueue-Überwachung konnte nicht hinzugefügt werden"
+
+#: ../src/unix/fswatcher_kqueue.cpp:170
+msgid "Unable to remove kqueue watch"
+msgstr "Zurücksetzen der kqueue-Überwachung nicht möglich"
+
+#: ../src/unix/fswatcher_kqueue.cpp:202
+msgid "Unable to get events from kqueue"
+msgstr "Ereignisse von Kqueue zu erhalten fehlgeschlagen"
+
+#: ../src/unix/mediactrl.cpp:966
+#, c-format
+msgid "Media playback error: %s"
+msgstr "Medienwiedergabe-Fehler: %s"
+
+#: ../src/unix/mediactrl.cpp:1228
+#, c-format
+msgid "Failed to prepare playing \"%s\"."
+msgstr "Fehler bei der Vorbereitung zum Abspielen von „%s“."
+
+#: ../src/unix/snglinst.cpp:164
+#, c-format
+msgid "Failed to write to lock file '%s'"
+msgstr "Konnte Sperr-Datei „%s“ nicht schreiben"
+
+#: ../src/unix/snglinst.cpp:177
+#, c-format
+msgid "Failed to set permissions on lock file '%s'"
+msgstr "Konnte die Zugriffsrechte für Datei „%s“ nicht setzen"
+
+#: ../src/unix/snglinst.cpp:194
+#, c-format
+msgid "Failed to lock the lock file '%s'"
+msgstr "Konnte die Sperr-Datei „%s“ nicht sperren"
+
+#: ../src/unix/snglinst.cpp:237
+#, c-format
+msgid "Failed to inspect the lock file '%s'"
+msgstr "Konnte die Sperr-Datei „%s“ nicht lesen"
+
+#: ../src/unix/snglinst.cpp:242
+#, c-format
+msgid "Lock file '%s' has incorrect owner."
+msgstr "Sperr-Datei „%s“ hat falschen Besitzer."
+
+#: ../src/unix/snglinst.cpp:247
+#, c-format
+msgid "Lock file '%s' has incorrect permissions."
+msgstr "Sperr-Datei „%s“ hat falsche Zugriffsrechte."
+
+#: ../src/unix/snglinst.cpp:265
+msgid "Failed to access lock file."
+msgstr "Fehler beim Zugriff auf Sperr-Datei."
+
+#: ../src/unix/snglinst.cpp:274
+msgid "Failed to read PID from lock file."
+msgstr "Konnte keine PID von Sperr-Datei lesen."
+
+#: ../src/unix/snglinst.cpp:284
+#, c-format
+msgid "Failed to remove stale lock file '%s'."
+msgstr "Konnte unbenutzte Sperr-Datei „%s“ nicht entfernen."
+
+#: ../src/unix/snglinst.cpp:297
+#, c-format
+msgid "Deleted stale lock file '%s'."
+msgstr "Ungenutzte Sperr-Datei „%s“ wurde gelöscht."
+
+#: ../src/unix/snglinst.cpp:308
+#, c-format
+msgid "Invalid lock file '%s'."
+msgstr "Ungültige Sperr-Datei „%s“."
+
+#: ../src/unix/snglinst.cpp:324
+#, c-format
+msgid "Failed to remove lock file '%s'"
+msgstr "Konnte Sperr-Datei „%s“ nicht löschen."
+
+#: ../src/unix/snglinst.cpp:330
+#, c-format
+msgid "Failed to unlock lock file '%s'"
+msgstr "Konnte die Sperrung von Datei „%s“ nicht aufheben"
+
+#: ../src/unix/snglinst.cpp:336
+#, c-format
+msgid "Failed to close lock file '%s'"
+msgstr "Konnte Sperr-Datei „%s“ nicht schließen"
+
+#: ../src/unix/sound.cpp:77
+msgid "No sound"
+msgstr "Kein Ton"
+
+#: ../src/unix/sound.cpp:364
+msgid "Unable to play sound asynchronously."
+msgstr "Der Klang kann nicht asynchron abgespielt werden."
+
+#: ../src/unix/sound.cpp:458
+#, c-format
+msgid "Couldn't load sound data from '%s'."
+msgstr "Klangdaten konnten nicht von „%s“ geladen werden."
+
+#: ../src/unix/sound.cpp:465
+#, c-format
+msgid "Sound file '%s' is in unsupported format."
+msgstr "Klangdatei „%s“ besitzt ein nicht unterstütztes Format."
+
+#: ../src/unix/sound.cpp:480
+msgid "Sound data are in unsupported format."
+msgstr "Klangdaten haben ein nicht unterstütztes Format."
+
+#: ../src/unix/sound_sdl.cpp:226
+#, c-format
+msgid "Couldn't open audio: %s"
+msgstr "Fehler beim Öffnen der Audiodatei: %s"
+
+#: ../src/unix/threadpsx.cpp:1033
+msgid "Cannot retrieve thread scheduling policy."
+msgstr "Kann Scheduling-Verfahren der Threads nicht ermitteln."
+
+#: ../src/unix/threadpsx.cpp:1058
+#, c-format
+msgid "Cannot get priority range for scheduling policy %d."
+msgstr "Kein Prioritätsbereich für Scheduling-Verfahren %d ermittelbar."
+
+#: ../src/unix/threadpsx.cpp:1066
+msgid "Thread priority setting is ignored."
+msgstr "Thread-Prioritätseinstellung wird ignoriert."
+
+#: ../src/unix/threadpsx.cpp:1221
+msgid ""
+"Failed to join a thread, potential memory leak detected - please restart the "
+"program"
+msgstr ""
+"Thread-Verbindung fehlgeschlagen. Dies ist ein mögliches Speicherleck - "
+"Bitte Programm neu starten"
+
+#: ../src/unix/threadpsx.cpp:1352
+#, c-format
+msgid "Failed to set thread concurrency level to %lu"
+msgstr ""
+"Versuch fehlgeschlagen, die Thread-Nebenläufigkeit auf Stufe %lu zu setzen"
+
+#: ../src/unix/threadpsx.cpp:1481
+#, c-format
+msgid "Failed to set thread priority %d."
+msgstr "Versuch fehlgeschlagen, die Thread-Priorität %d zu setzen."
+
+#: ../src/unix/threadpsx.cpp:1666
+msgid "Failed to terminate a thread."
+msgstr "Versuch den Thread zu beenden, fehlgeschlagen."
+
+#: ../src/unix/threadpsx.cpp:1893
+msgid "Thread module initialization failed: failed to create thread key"
+msgstr ""
+"Thread-Modul-Initialisierung fehlgeschlagen: Thread-Schlüssel konnte nicht "
+"erstellt werden"
+
+#: ../src/unix/utilsunx.cpp:340
+msgid "Impossible to get child process input"
+msgstr "Es war nicht möglich, die Eingabe des Unterprozesses zu verarbeiten"
+
+#: ../src/unix/utilsunx.cpp:390
+msgid "Can't write to child process's stdin"
+msgstr "Kann nicht in den Standard-Eingabekanal des Kindprozesses schreiben"
+
+#: ../src/unix/utilsunx.cpp:644
+#, c-format
+msgid "Failed to execute '%s'\n"
+msgstr "Kann „%s“ nicht ausführen\n"
+
+#: ../src/unix/utilsunx.cpp:678
+msgid "Fork failed"
+msgstr "„Fork“ fehlgeschlagen"
+
+#: ../src/unix/utilsunx.cpp:701
+msgid "Failed to set process priority"
+msgstr "Versuch fehlgeschlagen, die Prozess-Priorität zu setzen"
+
+#: ../src/unix/utilsunx.cpp:712
+msgid "Failed to redirect child process input/output"
+msgstr "Umleitung der Ein-/Ausgabe des Unterprozesses fehlgeschlagen"
+
+#: ../src/unix/utilsunx.cpp:816
+msgid "Failed to set up non-blocking pipe, the program might hang."
+msgstr ""
+"Das Erzeugen einer nicht blockierenden Pipe ist fehlgeschlagen, das Programm "
+"könnte stehen bleiben."
+
+#: ../src/unix/utilsunx.cpp:1023
+msgid "Cannot get the hostname"
+msgstr "Hostnamen nicht ermittelbar"
+
+#: ../src/unix/utilsunx.cpp:1059
+msgid "Cannot get the official hostname"
+msgstr "Offizieller Hostname nicht ermittelbar"
+
+#: ../src/unix/wakeuppipe.cpp:49
+msgid "Failed to create wake up pipe used by event loop."
+msgstr "Erzeugung der Weckleitung für die Ereignisschleife fehlgeschlagen."
+
+#: ../src/unix/wakeuppipe.cpp:56
+msgid "Failed to switch wake up pipe to non-blocking mode"
+msgstr ""
+"Aufweck-Pipe in den nicht blockierenden Modus umzuschalten ist fehlgeschlagen"
+
+#: ../src/unix/wakeuppipe.cpp:117
+msgid "Failed to read from wake-up pipe"
+msgstr "Konnte nicht aus dem Weckkanal lesen"
+
+#: ../src/x11/app.cpp:124
+#, c-format
+msgid "Invalid geometry specification '%s'"
+msgstr "Ungültige Angabe „%s“ der Fenstergröße"
+
+#: ../src/x11/app.cpp:167
+msgid "wxWidgets could not open display. Exiting."
+msgstr "wxWidgets konnte Display nicht öffnen. Abbruch."
+
+#: ../src/x11/utils.cpp:169
+#, c-format
+msgid "Failed to close the display \"%s\""
+msgstr "Konnte das Display „%s“ nicht schließen"
+
+#: ../src/x11/utils.cpp:188
+#, c-format
+msgid "Failed to open display \"%s\"."
+msgstr "Öffnen des Displays „%s“ fehlgeschlagen."
+
+#: ../src/xml/xml.cpp:868
+#, c-format
+msgid "XML parsing error: '%s' at line %d"
+msgstr "Fehler beim Lesen des XML: „%s“ in Zeile %d"
+
+#: ../src/xrc/xh_propgrid.cpp:239
+#, c-format
+msgid "Page %i"
+msgstr "Seite %i"
+
+#: ../src/xrc/xmlres.cpp:448
+#, c-format
+msgid "Cannot load resources from '%s'."
+msgstr "Kann die Ressourcen nicht aus „%s“ laden."
+
+#: ../src/xrc/xmlres.cpp:799
+#, c-format
+msgid "Cannot open resources file '%s'."
+msgstr "Kann die Ressourcendatei „%s“ nicht öffnen."
+
+#: ../src/xrc/xmlres.cpp:806
+#, c-format
+msgid "Cannot load resources from file '%s'."
+msgstr "Kann die Ressourcen nicht aus der Datei „%s“ laden."
+
+#: ../src/xrc/xmlres.cpp:2767
+#, c-format
+msgid "Creating %s \"%s\" failed."
+msgstr "Erstellung von %s „%s“ fehlgeschlagen."
+
+#, c-format
+#~ msgid "BMP: header has biClrUsed=%d when biBitCount=%d."
+#~ msgstr ""
+#~ "BMP: Kopfeintrag hat das Attribut biClrUsed=%d wobei Attribut "
+#~ "biBitCount=%d ist."
+
+#~ msgctxt "keyboard key"
+#~ msgid "Alt+"
+#~ msgstr "Alt+"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Ctrl+"
+#~ msgstr "Strg+"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Shift+"
+#~ msgstr "Umschalt+"
+
+#~ msgctxt "keyboard key"
+#~ msgid "RawCtrl+"
+#~ msgstr "RawCtrl+"
+
+#~ msgid "Copying more than one selected block to clipboard is not supported."
+#~ msgstr ""
+#~ "Das Kopieren von mehr als einem ausgewählten Block in die Zwischenablage "
+#~ "wird nicht unterstützt."
+
+#~ msgid "Unsupported clipboard format."
+#~ msgstr "Nicht unterstütztes Format in der Zwischenablage."
+
+#~ msgid "Background colour"
+#~ msgstr "Hintergrundfarbe"
+
+#~ msgid "Font:"
+#~ msgstr "Schrift:"
+
+#~ msgid "Size:"
+#~ msgstr "Größe:"
+
+#~ msgid "The font size in points."
+#~ msgstr "Die Schriftgröße in Punkt."
+
+#~ msgid "Style:"
+#~ msgstr "Stil:"
+
+#~ msgid "Check to make the font bold."
+#~ msgstr "Klicken um die Schriftart auf fett zu stellen."
+
+#~ msgid "Check to make the font italic."
+#~ msgstr "Klicken um die Schriftart auf kursiv zu stellen."
+
+#~ msgid "Check to make the font underlined."
+#~ msgstr "Klicken um die Schriftart auf unterstrichen zu stellen."
+
+#~ msgid "Colour:"
+#~ msgstr "Farbe:"
+
+#~ msgid "Click to change the font colour."
+#~ msgstr "Klicken um die Farbe der Schriftart zu ändern."
+
+#~ msgid "Shows a preview of the font."
+#~ msgstr "Zeigt eine Vorschau der Schriftart."
+
+#~ msgid "Click to cancel changes to the font."
+#~ msgstr "Klicken um die Änderungen der Schriftart zu verwerfen."
+
+#~ msgid "Click to confirm changes to the font."
+#~ msgstr "Klicken um die Änderungen der Schriftart zu bestätigen."
+
+#~ msgid "<Any>"
+#~ msgstr "<Beliebig>"
+
+#~ msgid "<Any Roman>"
+#~ msgstr "<Beliebige Serifenschrift>"
+
+#~ msgid "<Any Decorative>"
+#~ msgstr "<Beliebige Dekorative>"
+
+#~ msgid "<Any Modern>"
+#~ msgstr "<Beliebige Moderne>"
+
+#~ msgid "<Any Script>"
+#~ msgstr "<Beliebige Schreibschrift>"
+
+#~ msgid "<Any Swiss>"
+#~ msgstr "<Beliebige Serifenlose>"
+
+#~ msgid "<Any Teletype>"
+#~ msgstr "<Beliebige Schreibmaschinen-Schrift>"
+
+#~ msgid "Printing "
+#~ msgstr "Drucken von "
+
+#~ msgid "Failed to insert text in the control."
+#~ msgstr "Einfügen von Text in das Steuerelement fehlgeschlagen."
+
+#~ msgid "Please choose a valid font."
+#~ msgstr "Bitte wählen Sie eine gültige Schriftart."
+
+#, c-format
+#~ msgid "Failed to display HTML document in %s encoding"
+#~ msgstr "Konnte HTML-Dokument nicht in der Kodierung %s anzeigen"
+
+#, c-format
+#~ msgid "wxWidgets could not open display for '%s': exiting."
+#~ msgstr "wxWidgets konnte „open display“ nicht ausführen für „%s“: Abbruch."
+
+#~ msgid "Filter"
+#~ msgstr "Filter"
+
+#~ msgid "Directories"
+#~ msgstr "Verzeichnisse"
+
+#~ msgid "Files"
+#~ msgstr "Dateien"
+
+#~ msgid "Selection"
+#~ msgstr "Auswahl"
+
+#~ msgid "conversion to 8-bit encoding failed"
+#~ msgstr "Umwandlung in 8-Bit-Kodierung fehlgeschlagen"
+
+#~ msgid "failed to retrieve execution result"
+#~ msgstr "Versuch das Ergebnis der Ausführung abzurufen, fehlgeschlagen"
+
+#~ msgid " (while overwriting an existing item)"
+#~ msgstr " (während ein Element überschrieben wird)"
+
+#~ msgid "&Save as"
+#~ msgstr "Speichern &unter"
+
+#~ msgid "'%s' doesn't consist only of valid characters"
+#~ msgstr "„%s“ enthält nicht nur gültige Zeichen"
+
+#~ msgid "'%s' should be numeric."
+#~ msgstr "„%s“ sollte numerisch sein."
+
+#~ msgid "'%s' should only contain ASCII characters."
+#~ msgstr "„%s“ sollte ausschließlich ASCII-Zeichen enthalten."
+
+#~ msgid "'%s' should only contain alphabetic characters."
+#~ msgstr "„%s“ sollte nur alphabetische Zeichen enthalten."
+
+#~ msgid "'%s' should only contain alphabetic or numeric characters."
+#~ msgstr "„%s“ sollte nur alphanumerische Zeichen enthalten."
+
+#~ msgid "'%s' should only contain digits."
+#~ msgstr "„%s“ sollte ausschließlich Ziffern enthalten."
+
+#~ msgid "Can't create window of class %s"
+#~ msgstr "Kann kein Fenster der Klasse „%s“ anlegen"
+
+#~ msgid "Couldn't create the overlay window"
+#~ msgstr "Konnte das überlagerte Fenster nicht erzeugen"
+
+#~ msgid "Couldn't init the context on the overlay window"
+#~ msgstr ""
+#~ "Konnte den Kontext auf dem überlagerten Fenster nicht initialisieren"
+
+#~ msgid "Failed to convert file \"%s\" to Unicode."
+#~ msgstr "Konnte die Datei „%s“ nicht nach Unicode konvertieren."
+
+#~ msgid "Failed to set text in the text control."
+#~ msgstr "Setzen von Text in das Text-Steuerelement fehlgeschlagen."
+
+#~ msgid "Invalid GTK+ command line option, use \"%s --help\""
+#~ msgstr "Ungültige GTK+ Kommentarzeile, benutzen Sie „%s --help“"
+
+#~ msgid "No unused colour in image."
+#~ msgstr "Keine unbenutzte Farbe im Bild."
+
+#~ msgid "Not available"
+#~ msgstr "Nicht verfügbar"
+
+#~ msgid "Replace selection"
+#~ msgstr "Auswahl ersetzen"
+
+#~ msgid "Save as"
+#~ msgstr "Speichern unter"
+
+#~ msgid "Style Organiser"
+#~ msgstr "Stil-Organisator"
+
+#~ msgid "The following standard GTK+ options are also supported:\n"
+#~ msgstr ""
+#~ "Die nachfolgenden Standard GTK+ Optionen werden ebenfalls unterstützt:\n"
+
+#~ msgid "You cannot Clear an overlay that is not inited"
+#~ msgstr ""
+#~ "Sie können keine Überlagerung löschen, die nicht initialisiert wurde"
+
+#~ msgid "You cannot Init an overlay twice"
+#~ msgstr "Eine Überlagerung kann nicht zweimal initialisiert werden"
+
+#~ msgid "locale '%s' cannot be set."
+#~ msgstr "Lokale Umgebung „%s“ kann nicht gesetzt werden."
+
+#~ msgid "Adding flavor TEXT failed"
+#~ msgstr "Das Hinzufügen der Variante TEXT schlug fehl"
+
+#~ msgid "Adding flavor utxt failed"
+#~ msgstr "Das Hinzufügen der Variante utxt schlug fehl"
+
+#~ msgid "Bitmap renderer cannot render value; value type: "
+#~ msgstr "Bitmapdarsteller kann den Wert nicht wiedergeben; Typ des Werts: "
+
+#~ msgid ""
+#~ "Cannot create new column's ID. Probably max. number of columns reached."
+#~ msgstr ""
+#~ "Es konnte keine neue Spalten-ID angelegt werden. Wahrscheinlich ist die "
+#~ "maximale Anzahl an Spalten erreicht."
+
+#~ msgid "Column could not be added."
+#~ msgstr "Spalte konnte nicht hinzugefügt werden."
+
+#~ msgid "Column index not found."
+#~ msgstr "Spaltenindex nicht gefunden."
+
+#~ msgid "Column width could not be determined"
+#~ msgstr "Spaltenbreite kann nicht bestimmt werden"
+
+#~ msgid "Column width could not be set."
+#~ msgstr "Spaltenbreite kann nicht gesetzt werden."
+
+#~ msgid "Confirm registry update"
+#~ msgstr "Aktualisierung der Registry bestätigen"
+
+#~ msgid "Could not determine column index."
+#~ msgstr "Konnte Spaltenindex nicht bestimmen."
+
+#~ msgid "Could not determine column's position"
+#~ msgstr "Spaltenposition kann nicht bestimmt werden"
+
+#~ msgid "Could not determine number of columns."
+#~ msgstr "Anzahl an Spalten konnte nicht ermittelt werden."
+
+#~ msgid "Could not determine number of items"
+#~ msgstr "Konnte Anzahl der Elemente nicht bestimmen"
+
+#~ msgid "Could not get header description."
+#~ msgstr "Konnte Kopfzeilenbeschreibung nicht erhalten."
+
+#~ msgid "Could not get items."
+#~ msgstr "Konnte die Elemente nicht erhalten."
+
+#~ msgid "Could not get property flags."
+#~ msgstr "Konnte die Eigenschaftsflags nicht erhalten."
+
+#~ msgid "Could not get selected items."
+#~ msgstr "Konnte die ausgewählten Elemente nicht erhalten."
+
+#~ msgid "Could not remove column."
+#~ msgstr "Konnte die Spalte nicht entfernen."
+
+#~ msgid "Could not retrieve number of items"
+#~ msgstr "Konnte die Anzahl der Elemente nicht erhalten."
+
+#~ msgid "Could not set column width."
+#~ msgstr "Konnte die Spaltenbreite nicht setzen."
+
+#~ msgid "Could not set header description."
+#~ msgstr "Konnte die Kopfzeilenbeschreibung nicht setzen."
+
+#~ msgid "Could not set icon."
+#~ msgstr "Konnte Icon nicht setzen."
+
+#~ msgid "Could not set maximum width."
+#~ msgstr "Konnte die maximale Breite nicht setzen."
+
+#~ msgid "Could not set minimum width."
+#~ msgstr "Minimale Breite kann nicht gesetzt werden."
+
+#~ msgid "Could not set property flags."
+#~ msgstr "Konnte Eigenschaftsflags nicht setzen."
+
+#~ msgid "Data object has invalid data format"
+#~ msgstr "Dateiobjekt hat ein ungültiges Dateiformat"
+
+#~ msgid "Date renderer cannot render value; value type: "
+#~ msgstr "Datums-Renderer kann den Wert nicht darstellen; Werttyp: "
+
+#~ msgid ""
+#~ "Do you want to overwrite the command used to %s files with extension "
+#~ "\"%s\" ?\n"
+#~ "Current value is \n"
+#~ "%s, \n"
+#~ "New value is \n"
+#~ "%s %1"
+#~ msgstr ""
+#~ "Wollen Sie den Befehl zum %s von Dateien mit der Erweiterung »%s« "
+#~ "ändern?\n"
+#~ "Aktueller Wert ist\n"
+#~ "%s,\n"
+#~ "Neuer Wert ist\n"
+#~ "%s %1"
+
+#~ msgid "Failed to retrieve data from the clipboard."
+#~ msgstr "Konnte Daten von der Zwischenablage nicht bekommen."
+
+#~ msgid "GIF: Invalid gif index."
+#~ msgstr "GIF: Ungültiger Index."
+
+#~ msgid "GIF: unknown error!!!"
+#~ msgstr "GIF: unbekannter Fehler!"
+
+#~ msgid "Icon & text renderer cannot render value; value type: "
+#~ msgstr "Bild- & Text-Renderer kann den Wert nicht darstellen; Werttyp: "
+
+#~ msgid "New directory"
+#~ msgstr "Verzeichnis anlegen"
+
+#~ msgid "Next"
+#~ msgstr "Weiter"
+
+#~ msgid "No column existing."
+#~ msgstr "Es existiert keine Spalte"
+
+#~ msgid "No column for the specified column existing."
+#~ msgstr "Die ausgewählte Spalte existiert nicht."
+
+#~ msgid "No column for the specified column position existing."
+#~ msgstr "Spalte für ausgewählte Position existiert nicht."
+
+#~ msgid ""
+#~ "No renderer or invalid renderer type specified for custom data column."
+#~ msgstr ""
+#~ "Kein Renderer oder ungültiger Renderer-Typ für die benutzte Datenspalte "
+#~ "aufgeführt"
+
+#~ msgid "No renderer specified for column."
+#~ msgstr "Kein Renderer für diese Spalte festgelegt."
+
+#~ msgid "Number of columns could not be determined."
+#~ msgstr "Anzahl an Spalten konnte nicht bestimmt werden."
+
+#~ msgid "OpenGL function \"%s\" failed: %s (error %d)"
+#~ msgstr "OpenGL-Funktion »%s« schlug fehl: %s (Fehler %d)"
+
+#~ msgid ""
+#~ "Please install a newer version of comctl32.dll\n"
+#~ "(at least version 4.70 is required but you have %d.%02d)\n"
+#~ "or this program won't operate correctly."
+#~ msgstr ""
+#~ "Bitte installieren Sie eine neuere Version von comctl32.dll\n"
+#~ "(mindestens Version 4.70 wird benötigt, aber Sie haben nur\n"
+#~ "Version %d.%02d)."
+
+#~ msgid "Pointer to data view control not set correctly."
+#~ msgstr "Zeiger wurde nicht korrekt auf das Kontrollelement gesetzt."
+
+#~ msgid "Pointer to model not set correctly."
+#~ msgstr "Zeiger wurde nicht korrekt auf das Modell gesetzt."
+
+#~ msgid "Progress renderer cannot render value type; value type: "
+#~ msgstr "Prozess-Renderer konnte den Wert nicht darstellen; Werttyp: "
+
+#~ msgid "Rendering failed."
+#~ msgstr "Darstellung fehlgeschlagen."
+
+#~ msgid ""
+#~ "Setting directory access times is not supported under this OS version"
+#~ msgstr ""
+#~ "Das Setzen der Verzeichniszugriffszeit wird auf dieser "
+#~ "Betriebssystemversion nicht unterstützt"
+
+#~ msgid "Show hidden directories"
+#~ msgstr "Versteckte Verzeichnisse anzeigen"
+
+#~ msgid "Text renderer cannot render value; value type: "
+#~ msgstr "Text-Renderer kann Wert nicht darstellen; Werttyp: "
+
+#~ msgid "There is no column or renderer for the specified column index."
+#~ msgstr "Keine Spalte oder Renderer für angegebenen Spaltenindex vorhanden."
+
+#~ msgid ""
+#~ "This system doesn't support date controls, please upgrade your version of "
+#~ "comctl32.dll"
+#~ msgstr ""
+#~ "Dieses System unterstützt die Komponente zur Darstellung der "
+#~ "Datumsauswahl nicht. Installieren Sie bitte eine neuere Version der "
+#~ "comctl32.dll."
+
+#~ msgid "Toggle renderer cannot render value; value type: "
+#~ msgstr "Umschalt-Renderer konnte den Wert nicht darstellen; Werttyp: "
+
+#~ msgid "Too many colours in PNG, the image may be slightly blurred."
+#~ msgstr ""
+#~ "Zu viele Farben in PNG; das Bild wird vielleicht verschwommen angezeigt."
+
+#~ msgid "Unable to handle native drag&drop data"
+#~ msgstr "Native Drag&Drop-Daten können nicht verarbeitet werden"
+
+#~ msgid "Unable to initialize Hildon program"
+#~ msgstr "Konnte das Hildon-Programm nicht initialisieren"
+
+#~ msgid "Unknown data format"
+#~ msgstr "Unbekanntes Datenformat"
+
+#~ msgid "Valid pointer to native data view control does not exist"
+#~ msgstr ""
+#~ "Es existiert kein gültiger Zeiger auf das native DataView-Steuerelement"
+
+#~ msgid "Win32s on Windows 3.1"
+#~ msgstr "Win32s on Windows 3.1"
+
+#~ msgid "Windows 10"
+#~ msgstr "Windows 10"
+
+#~ msgid "Windows 2000"
+#~ msgstr "Windows 2000"
+
+#~ msgid "Windows 7"
+#~ msgstr "Windows 7"
+
+#~ msgid "Windows 8"
+#~ msgstr "Windows 8"
+
+#~ msgid "Windows 8.1"
+#~ msgstr "Windows 8.1"
+
+#~ msgid "Windows 95"
+#~ msgstr "Windows 95"
+
+#~ msgid "Windows 95 OSR2"
+#~ msgstr "Windows 95 OSR2"
+
+#~ msgid "Windows 98"
+#~ msgstr "Windows 98"
+
+#~ msgid "Windows 98 SE"
+#~ msgstr "Windows 98 SE"
+
+#~ msgid "Windows 9x (%d.%d)"
+#~ msgstr "Windows 9x (%d.%d)"
+
+#~ msgid "Windows CE (%d.%d)"
+#~ msgstr "Windows CE (%d.%d)"
+
+#~ msgid "Windows ME"
+#~ msgstr "Windows ME"
+
+#~ msgid "Windows NT %lu.%lu"
+#~ msgstr "Windows NT %lu.%lu"
+
+#~ msgid "Windows Server 10"
+#~ msgstr "Windows Server 10"
+
+#~ msgid "Windows Server 2003"
+#~ msgstr "Windows Server 2003"
+
+#~ msgid "Windows Server 2008"
+#~ msgstr "Windows Server 2008"
+
+#~ msgid "Windows Server 2008 R2"
+#~ msgstr "Windows Server 2008 R2"
+
+#~ msgid "Windows Server 2012"
+#~ msgstr "Windows Server 2012"
+
+#~ msgid "Windows Server 2012 R2"
+#~ msgstr "Windows Server 2012 R2"
+
+#~ msgid "Windows Vista"
+#~ msgstr "Windows Vista"
+
+#~ msgid "Windows XP"
+#~ msgstr "Windows XP"
+
+#~ msgid "can't execute '%s'"
+#~ msgstr "Kann »%s« nicht ausführen"
+
+#~ msgid "error opening '%s'"
+#~ msgstr "Fehler beim Öffnen von »%s«"
+
+#~ msgid "unknown seek origin"
+#~ msgstr "Unbekannte Suchposition"
+
+#~ msgid "wxWidget control pointer is not a data view pointer"
+#~ msgstr ""
+#~ "Zeiger auf ein wxWidget Kontrollelement ist kein Zeiger auf eine "
+#~ "Datenanzeige"
+
+#~ msgid "wxWidget's control not initialized."
+#~ msgstr "wxWidget Kontrollelement nicht initialisiert."
+
+#, fuzzy
+#~ msgid "'%s' is invalid"
+#~ msgstr "»%s« ist eine ungültige Zeichenkette"
+
+#~ msgid "Cannot create mutex."
+#~ msgstr "Kann Mutex nicht anlegen."
+
+#~ msgid "Cannot resume thread %lu"
+#~ msgstr "Kann Thread %lu nicht fortsetzen."
+
+#~ msgid "Cannot suspend thread %lu"
+#~ msgstr "Kann Thread %lu nicht anhalten."
+
+#~ msgid "Couldn't acquire a mutex lock"
+#~ msgstr "Konnte Mutex-Sperre nicht bekommen"
+
+#~ msgid "Couldn't release a mutex"
+#~ msgstr "Konnte einen Mutex nicht freigeben."
+
+#~ msgid "Execution of command '%s' failed with error: %ul"
+#~ msgstr "Befehlsausführung »%s« schlug fehl mit Fehler: %ul"
+
+#~ msgid ""
+#~ "File '%s' already exists.\n"
+#~ "Do you want to replace it?"
+#~ msgstr ""
+#~ "Datei »%s« existiert bereits.\n"
+#~ "Möchten Sie diese wirklich überschreiben?"
+
+#~ msgid "Timer creation failed."
+#~ msgstr "Konnte Zeitgeber nicht anlegen."
+
+#~ msgid "buffer is too small for Windows directory."
+#~ msgstr "Puffer zu klein für Windows-Verzeichnis."
+
+#~ msgid "ADD"
+#~ msgstr "HINZUFÜGEN"
+
+#~ msgid "BACK"
+#~ msgstr "ZURÜCK"
+
+#~ msgid "CANCEL"
+#~ msgstr "ABBRECHEN"
+
+#~ msgid "CAPITAL"
+#~ msgstr "GROSSBUCHSTABEN"
+
+#~ msgid "CLEAR"
+#~ msgstr "LÖSCHEN"
+
+#~ msgid "COMMAND"
+#~ msgstr "BEFEHL"
+
+#~ msgid "Couldn't get hatch style from wxBrush."
+#~ msgstr "Konnte den Schraffurstil von wxBrush nicht erfragen."
+
+#~ msgid "DECIMAL"
+#~ msgstr "DEZIMAL"
+
+#~ msgid "DEL"
+#~ msgstr "ENTF"
+
+#~ msgid "DELETE"
+#~ msgstr "ENTFERNEN"
+
+#~ msgid "DIVIDE"
+#~ msgstr "TEILE"
+
+#~ msgid "DOWN"
+#~ msgstr "RUNTER"
+
+#~ msgid "END"
+#~ msgstr "ENDE"
+
+#~ msgid "ENTER"
+#~ msgstr "EINGABE"
+
+#~ msgid "ESC"
+#~ msgstr "ESC"
+
+#~ msgid "ESCAPE"
+#~ msgstr "ESCAPE"
+
+#~ msgid "EXECUTE"
+#~ msgstr "AUSFÜHREN"
+
+#~ msgid "HELP"
+#~ msgstr "HILFE"
+
+#~ msgid "HOME"
+#~ msgstr "POS 1"
+
+#~ msgid "INS"
+#~ msgstr "EINFG"
+
+#~ msgid "INSERT"
+#~ msgstr "EINFÜGEN"
+
+#~ msgid "KP_BEGIN"
+#~ msgstr "Num_Anfang"
+
+#~ msgid "KP_DECIMAL"
+#~ msgstr "Num_Dezimal"
+
+#~ msgid "KP_DELETE"
+#~ msgstr "Num_Entf"
+
+#~ msgid "KP_DIVIDE"
+#~ msgstr "Num_Division"
+
+#~ msgid "KP_DOWN"
+#~ msgstr "Num_Runter"
+
+#~ msgid "KP_ENTER"
+#~ msgstr "Num_Eingabe"
+
+#~ msgid "KP_EQUAL"
+#~ msgstr "Num_Gleich"
+
+#~ msgid "KP_HOME"
+#~ msgstr "Num_Pos 1"
+
+#~ msgid "KP_INSERT"
+#~ msgstr "Num_Einfg"
+
+#~ msgid "KP_LEFT"
+#~ msgstr "Num_Links"
+
+#~ msgid "KP_MULTIPLY"
+#~ msgstr "Num_Mal"
+
+#~ msgid "KP_NEXT"
+#~ msgstr "Num_Nächster"
+
+#~ msgid "KP_PAGEDOWN"
+#~ msgstr "Num_Bild Runter"
+
+#~ msgid "KP_PAGEUP"
+#~ msgstr "Num_Bild Hoch"
+
+#~ msgid "KP_PRIOR"
+#~ msgstr "Num_Voriger"
+
+#~ msgid "KP_RIGHT"
+#~ msgstr "Num_Rechts"
+
+#~ msgid "KP_SEPARATOR"
+#~ msgstr "Num_Trennzeichen"
+
+#~ msgid "KP_SPACE"
+#~ msgstr "Num_Leertaste"
+
+#~ msgid "KP_SUBTRACT"
+#~ msgstr "Num_Minus"
+
+#~ msgid "LEFT"
+#~ msgstr "LINKS"
+
+#~ msgid "MENU"
+#~ msgstr "MENÜ"
+
+#~ msgid "NUM_LOCK"
+#~ msgstr "Num_LOCK"
+
+#~ msgid "PAGEDOWN"
+#~ msgstr "BILD RUNTER"
+
+#~ msgid "PAGEUP"
+#~ msgstr "BILD HOCH"
+
+#~ msgid "PAUSE"
+#~ msgstr "PAUSE"
+
+#~ msgid "PGDN"
+#~ msgstr "BILD HOCH"
+
+#~ msgid "PGUP"
+#~ msgstr "BILD RUNTER"
+
+#~ msgid "PRINT"
+#~ msgstr "DRUCKEN"
+
+#~ msgid "RETURN"
+#~ msgstr "EINGABE"
+
+#~ msgid "RIGHT"
+#~ msgstr "RECHTS"
+
+#~ msgid "SCROLL_LOCK"
+#~ msgstr "ROLLEN_LOCK"
+
+#~ msgid "SELECT"
+#~ msgstr "AUSWAHL"
+
+#~ msgid "SEPARATOR"
+#~ msgstr "TRENNER"
+
+#~ msgid "SNAPSHOT"
+#~ msgstr "S-Abf"
+
+#~ msgid "SPACE"
+#~ msgstr "Leertaste"
+
+#~ msgid "SUBTRACT"
+#~ msgstr "Subtrahieren"
+
+#~ msgid "TAB"
+#~ msgstr "Tabulator"
+
+#~ msgid "The print dialog returned an error."
+#~ msgstr "Der Druckdialog hat einen Fehler zurückgegeben."
+
+#~ msgid "The wxGtkPrinterDC cannot be used."
+#~ msgstr "wxGtkPrinterDC kann nicht benutzt werden."
+
+#~ msgid "UP"
+#~ msgstr "HOCH"
+
+#~ msgid "WINDOWS_LEFT"
+#~ msgstr "WINDOWS_LINKS"
+
+#~ msgid "WINDOWS_MENU"
+#~ msgstr "WINDOWS_MENÜ"
+
+#~ msgid "WINDOWS_RIGHT"
+#~ msgstr "WINDOWS_RECHTS"
+
+#~ msgid "not implemented"
+#~ msgstr "nicht ausgeführt"
+
+#~ msgid "wxPrintout::GetPageInfo gives a null maxPage."
+#~ msgstr "wxPrintout::GetPageInfo liefert eine NULL maximale Seitengröße."
+
+#~ msgid "Event queue overflowed"
+#~ msgstr "Überlauf der Ereigniswarteschlange"
+
+#~ msgid "percent"
+#~ msgstr "Prozent"
+
+#~ msgid "Print preview"
+#~ msgstr "Druck&vorschau"
+
+#~ msgid "'"
+#~ msgstr "'"
+
+#~ msgid "1"
+#~ msgstr "1"
+
+#~ msgid "10"
+#~ msgstr "10"
+
+#~ msgid "3"
+#~ msgstr "3"
+
+#~ msgid "4"
+#~ msgstr "4"
+
+#~ msgid "5"
+#~ msgstr "5"
+
+#~ msgid "6"
+#~ msgstr "6"
+
+#~ msgid "7"
+#~ msgstr "7"
+
+#~ msgid "8"
+#~ msgstr "8"
+
+#~ msgid "9"
+#~ msgstr "9"
+
+#~ msgid "Can't monitor non-existent path \"%s\" for changes."
+#~ msgstr ""
+#~ "Der nicht vorhandene Pfad »%s« kann nicht nach Änderungen durchsucht "
+#~ "werden."
+
+#~ msgid "File system containing watched object was unmounted"
+#~ msgstr ""
+#~ "Das Dateisystem das die beobachteten Objekte enthält wurde ausgehängt"
+
+#~ msgid "&Preview..."
+#~ msgstr "& Vorschau..."
+
+#~ msgid "Preview..."
+#~ msgstr "Vorschau..."
+
+#~ msgid "The vertical offset relative to the paragraph."
+#~ msgstr "Der vertikale Abstand relativ zum Absatz."
+
+#~ msgid "Units for the object offset."
+#~ msgstr "Einheiten für den Objektabsatz."
+
+#~ msgid "&Save..."
+#~ msgstr "&Speichern..."
+
+#~ msgid "About "
+#~ msgstr "Über "
+
+#~ msgid "All files (*.*)|*"
+#~ msgstr "Alle Dateien (*.\")|*"
+
+#~ msgid "Cannot initialize SciTech MGL!"
+#~ msgstr "Kann SciTech MGL nicht initialisieren!"
+
+#~ msgid "Cannot initialize display."
+#~ msgstr "Kann das Display nicht initialisieren."
+
+#~ msgid "Cannot start thread: error writing TLS"
+#~ msgstr "Kann Thread nicht starten: Fehler beim TLS-Schreiben"
+
+#~ msgid "Close\tAlt-F4"
+#~ msgstr "Schließen\tAlt-F4"
+
+#~ msgid "Couldn't create cursor."
+#~ msgstr "Konnte Cursor nicht erzeugen."
+
+#~ msgid "Directory '%s' doesn't exist!"
+#~ msgstr "Verzeichnis »%s« existiert nicht."
+
+#~ msgid "Mode %ix%i-%i not available."
+#~ msgstr "Darstellung %is%i-%i ist nicht vorhanden"
+
+#~ msgid "Paper Size"
+#~ msgstr "Papierformat"
+
+#~ msgid " Couldn't create the UnicodeConverter"
+#~ msgstr "Konnte den UnicodeConverter nicht erzeugen"
+
+#~ msgid "#define %s must be an integer."
+#~ msgstr "#define %s muss eine Ganzzahl sein"
+
+#~ msgid "%.*f GB"
+#~ msgstr "%.*f GB"
+
+#~ msgid "%.*f MB"
+#~ msgstr "%.*f MB"
+
+#~ msgid "%.*f TB"
+#~ msgstr "%.*f TB"
+
+#~ msgid "%.*f kB"
+#~ msgstr "%.*f kB"
+
+#~ msgid "%s B"
+#~ msgstr "%s B"
+
+#~ msgid "%s not a bitmap resource specification."
+#~ msgstr "%s gibt keine Quelle für eine Bitmap-Grafik an."
+
+#~ msgid "%s not an icon resource specification."
+#~ msgstr "%s gibt keine Quelle für eine Icon-Grafik an."
+
+#~ msgid "%s: ill-formed resource file syntax."
+#~ msgstr "%s: unkorrekte Syntax der Ressourcendatei."
+
+#~ msgid "&Goto..."
+#~ msgstr "&Gehe zu ..."
+
+#~ msgid "&Open"
+#~ msgstr "&Öffnen"
+
+#~ msgid "&Print"
+#~ msgstr "&Drucken"
+
+#~ msgid ""
+#~ ", expected static, #include or #define\n"
+#~ "while parsing resource."
+#~ msgstr ""
+#~ ", Erwartete static, #include or #define\n"
+#~ "beim Parsen der Ressource."
+
+#~ msgid "<<"
+#~ msgstr "<<"
+
+#~ msgid ">>"
+#~ msgstr ">>"
+
+#~ msgid ">>|"
+#~ msgstr ">>|"
+
+#~ msgid "Archive doesnt contain #SYSTEM file"
+#~ msgstr "Archiv enthält keine Datei #SYSTEM"
+
+#~ msgid "BIG5"
+#~ msgstr "BIG5"
+
+#~ msgid "Bitmap resource specification %s not found."
+#~ msgstr "Ressourcenspezifikation %s für Bitmap nicht gefunden."
+
+#~ msgid "Can't check image format of file '%s': file does not exist."
+#~ msgstr ""
+#~ "Kann Bildformat nicht überprüfen bei Datei »%s«: Datei nicht vorhanden."
+
+#~ msgid "Can't load image from file '%s': file does not exist."
+#~ msgstr "Kann Bild aus Datei »%s« nicht laden: Datei ist nicht vorhanden."
+
+#~ msgid "Cannot convert dialog units: dialog unknown."
+#~ msgstr "Kann Dialog-Einheiten nicht konvertieren: Dialog unbekannt."
+
+#~ msgid "Cannot convert from the charset '%s'!"
+#~ msgstr "Kann nicht von Kodierung (%s) konvertieren"
+
+#~ msgid "Cannot find container for unknown control '%s'."
+#~ msgstr "Kann keinen Container für unbekanntes Steuerelement »%s« finden."
+
+#~ msgid "Cannot find font node '%s'."
+#~ msgstr "Kann keinen Font-Knoten »%s« finden."
+
+#~ msgid "Cannot open file '%s'."
+#~ msgstr "Konnte Datei »%s« nicht öffnen"
+
+#~ msgid "Cannot parse coordinates from '%s'."
+#~ msgstr "Kann die Koordinaten nicht aus »%s« lesen."
+
+#~ msgid "Cannot parse dimension from '%s'."
+#~ msgstr "Kann die Dimensionen nicht aus »%s« lesen."
+
+#~ msgid "Cant create the thread event queue"
+#~ msgstr "Kann Ereignis-Warteschlange des Threads nicht erzeugen"
+
+#~ msgid "Click to cancel this window."
+#~ msgstr "Klicken um dieses Fenster zu schließen."
+
+#~ msgid "Click to confirm your selection."
+#~ msgstr "Klicken um die Auswahl zu bestätigen."
+
+#~ msgid "Closes the dialog without inserting a symbol."
+#~ msgstr "Schließt das Dokument ohne ein Symbol einzufügen."
+
+#~ msgid ""
+#~ "Could not resolve control class or id '%s'. Use (non-zero) integer "
+#~ "instead\n"
+#~ " or provide #define (see manual for caveats)"
+#~ msgstr ""
+#~ "Konnte Steuerelement-Klasse oder -Kennziffer »%s« nicht auflösen.\n"
+#~ "Ganzzahl (ungleich Null) verwenden, oder #define angeben (siehe Handbuch "
+#~ "bei Problemen)"
+
+#~ msgid ""
+#~ "Could not resolve menu id '%s'. Use (non-zero) integer instead\n"
+#~ "or provide #define (see manual for caveats)"
+#~ msgstr ""
+#~ "Konnte Menü-Id »%s« nicht auflösen. Benutzen Sie stattdessen Integer "
+#~ "(ungleich Null)\n"
+#~ "oder ein #define (s.a. Handbuch für mögliche Probleme damit)"
+
+#~ msgid "Could not unlock mutex"
+#~ msgstr "Konnte Mutex nicht freigeben"
+
+#~ msgid "Couldn't end the context on the overlay window"
+#~ msgstr "Konnte den Kontext auf dem überlagerten Fenster nicht beenden."
+
+#~ msgid "Expected '*' while parsing resource."
+#~ msgstr "Erwartete '*' beim Parsen der Ressource."
+
+#~ msgid "Expected '=' while parsing resource."
+#~ msgstr "Erwartete '=' beim Parsen der Ressource."
+
+#~ msgid "Expected 'char' while parsing resource."
+#~ msgstr "Erwartete 'char' beim Parsen der Ressource."
+
+#~ msgid "Failed to %s dialup connection: %s"
+#~ msgstr "Fehlerhafte %s DFÜ-Verbindung: %s"
+
+#~ msgid ""
+#~ "Failed to find XBM resource %s.\n"
+#~ "Forgot to use wxResourceLoadBitmapData?"
+#~ msgstr ""
+#~ "Konnte XBM-Ressource %s nicht finden.\n"
+#~ "Vergessen wxResourceLoadBitmapData zu benutzen?"
+
+#~ msgid ""
+#~ "Failed to find XBM resource %s.\n"
+#~ "Forgot to use wxResourceLoadIconData?"
+#~ msgstr ""
+#~ "Konnte XBM-Ressource %s nicht finden.\n"
+#~ "Vergessen wxResourceLoadIconData zu benutzen?"
+
+#~ msgid ""
+#~ "Failed to find XPM resource %s.\n"
+#~ "Forgot to use wxResourceLoadBitmapData?"
+#~ msgstr ""
+#~ "Konnte XPM-Ressource %s nicht finden.\n"
+#~ "Vergessen wxResourceLoadBitmapData zu benutzen?"
+
+#~ msgid "Failed to get clipboard data."
+#~ msgstr "Konnte Daten nicht aus der Zwischenablage holen."
+
+#~ msgid "Failed to load shared library '%s' Error '%s'"
+#~ msgstr "Laden der dynamischen Bibliothek »%s« gescheitert: Fehler »%s«"
+
+#~ msgid "Failed to register OpenGL window class."
+#~ msgstr "Konnte OpenGL Fensterklasse nicht registrieren."
+
+#~ msgid "Fatal error: "
+#~ msgstr "Nicht-behebbarer Fehler: "
+
+#~ msgid "Found "
+#~ msgstr "Gefunden "
+
+#~ msgid "GB-2312"
+#~ msgstr "GB-2312"
+
+#~ msgid "Goto Page"
+#~ msgstr "Gehe zur Seite"
+
+#~ msgid ""
+#~ "HTML pagination algorithm generated more than the allowed maximum number "
+#~ "of pages and it can't continue any longer!"
+#~ msgstr ""
+#~ "Der Algorithmus zur HTML-Seitengenerierung hat mehr als die maximal "
+#~ "erlaubten Seiten erzeugt und kann nicht fortfahren!"
+
+#~ msgid "I64"
+#~ msgstr "I64"
+
+#~ msgid "Icon resource specification %s not found."
+#~ msgstr "Ressourcenspezifikation %s des Icons nicht gefunden."
+
+#~ msgid "Ill-formed resource file syntax."
+#~ msgstr "Nicht wohlgeformte Syntax für Ressourcendatei."
+
+#~ msgid "Inserts the chosen symbol."
+#~ msgstr "Fügt das ausgewählte Symbol ein"
+
+#~ msgid "Internal error, illegal wxCustomTypeInfo"
+#~ msgstr "interner Fehler (ungültige wxCustomTypeinfo)"
+
+#~ msgid "Invalid XRC resource '%s': doesn't have root node 'resource'."
+#~ msgstr "Ungültige XRC-Ressource »%s«: Kein Wurzel-Knoten 'resource'."
+
+#~ msgid "Long Conversions not supported"
+#~ msgstr "Umwandlung in long wird nicht unterstützt"
+
+#~ msgid "No XPM icon facility available!"
+#~ msgstr "Keine Möglichkeit mit XPM-Icons umzugehen!"
+
+#~ msgid "No handler found for XML node '%s', class '%s'!"
+#~ msgstr "XML-Knoten »%s«, Klasse »%s« kann nicht bearbeitet werden!\""
+
+#~ msgid "No image handler for type %ld defined."
+#~ msgstr "Kein Bild-Handler für Typ %ld definiert."
+
+#~ msgid "Option '%s' requires a value, '=' expected."
+#~ msgstr "Option »%s« erwartet einen Wert, '=' erwartet."
+
+#~ msgid "Passing a already registered object to SetObjectName"
+#~ msgstr "Ein bereits registriertes Objekt wurde an SetObjectname übergeben"
+
+#~ msgid "Program aborted."
+#~ msgstr "Programm abgebrochen."
+
+#~ msgid "Referenced object node with ref=\"%s\" not found!"
+#~ msgstr "Der angesprochene Objektknoten mit ref=»%s« wurde nicht gefunden!"
+
+#~ msgid "Resource files must have same version number!"
+#~ msgstr "Ressourcen-Datei muss die gleiche Versionsnummer haben!"
+
+#~ msgid "SHIFT-JIS"
+#~ msgstr "Shift-JIS"
+
+#~ msgid "Select a file"
+#~ msgstr "Datei wählen"
+
+#~ msgid "Select all"
+#~ msgstr "Alles auswählen"
+
+#~ msgid "Sorry, could not open this file for saving."
+#~ msgstr "Bedauere, diese Datei konnte zum Speichern nicht geöffnet werden."
+
+#~ msgid "Sorry, could not save this file."
+#~ msgstr "Bedauere, diese Datei konnte nicht gespeichert werden."
+
+#~ msgid ""
+#~ "Sorry, docking is not supported for ports other than wxMSW, wxMac and "
+#~ "wxGTK"
+#~ msgstr ""
+#~ "Entschuldigung, Andocken wird nicht unterstützt für Portierungen außer "
+#~ "wxMSW, wxMac und wxGTK"
+
+#~ msgid "Sorry, print preview needs a printer to be installed."
+#~ msgstr ""
+#~ "Tut mir leid: Die Druck-Vorschau benötigt einen installierten Drucker"
+
+#~ msgid "Status: "
+#~ msgstr "Status: "
+
+#~ msgid ""
+#~ "Streaming delegates for not already streamed objects not yet supported"
+#~ msgstr ""
+#~ "Streaming delegates sind noch nicht unterstützt, wenn es sich nicht "
+#~ "bereits um streaming objects handelt"
+
+#~ msgid "Subclass '%s' not found for resource '%s', not subclassing!"
+#~ msgstr ""
+#~ "Unterklasse »%s« für Ressource »%s« nicht gefunden, keine Unterklasse "
+#~ "erstellt!"
+
+#~ msgid "TIFF library error."
+#~ msgstr "Fehler in TIFF-Bibliothek."
+
+#~ msgid "TIFF library warning."
+#~ msgstr "Warnung in TIFF-Bibliothek."
+
+#~ msgid ""
+#~ "The file '%s' couldn't be opened.\n"
+#~ "It has been removed from the most recently used files list."
+#~ msgstr ""
+#~ "Die Datei »%s« konnte nicht geöffnet werden.\n"
+#~ "Sie wurde aus der Liste kürzlich verwendeter Dateien entfernt."
+
+#~ msgid "The path '%s' contains too many \"..\"!"
+#~ msgstr "Das Verzeichnis »%s« enthält zu viele \"..\"."
+
+#~ msgid "Trying to solve a NULL hostname: giving up"
+#~ msgstr "Auflösen eines NULL-Hostnamens fehlgeschlagen"
+
+#~ msgid "Unexpected end of file while parsing resource."
+#~ msgstr "Unerwartetes Dateiende beim Parsen der Ressource."
+
+#~ msgid "Unknown style flag "
+#~ msgstr "Unbekanntes Stil-Flag "
+
+#~ msgid "Unrecognized style %s while parsing resource."
+#~ msgstr "Unbekannter Stil %s beim Parsen der Ressource."
+
+#~ msgid "Version %s"
+#~ msgstr "Version %s"
+
+#~ msgid "Video Output"
+#~ msgstr "Video-Ausgabe"
+
+#~ msgid "Warning"
+#~ msgstr "Warnung"
+
+#~ msgid "Warning: attempt to remove HTML tag handler from empty stack."
+#~ msgstr ""
+#~ "Warnung: Es wurde versucht, einen 'HTML-Tag-Handler' von einem leeren "
+#~ "Stack zu entfernen."
+
+#~ msgid "Windows 2000 (build %lu"
+#~ msgstr "Windows 2000 (build %lu"
+
+#~ msgid "XRC resource '%s' (class '%s') not found!"
+#~ msgstr "XRC-Ressource »%s« (Klasse »%s«) nicht gefunden!"
+
+#~ msgid "XRC resource: Cannot create animation from '%s'."
+#~ msgstr "XRC-Ressource: Kann aus »%s« keine Animation erstellen."
+
+#~ msgid "XRC resource: Cannot create bitmap from '%s'."
+#~ msgstr "XRC-Ressource: Kann aus »%s« keine Bitmap erstellen."
+
+#~ msgid "XRC resource: Incorrect colour specification '%s' for property '%s'."
+#~ msgstr "XRC-Ressource: Falsche Farb-Angabe »%s« für Eigenschaft »%s«."
+
+#~ msgid "[EMPTY]"
+#~ msgstr "[leer]"
+
+#~ msgid "catalog file for domain '%s' not found."
+#~ msgstr "Nachrichtenkatalog für Sprachbereich »%s« nicht gefunden."
+
+#~ msgid "delegate has no type info"
+#~ msgstr "Delegate hat keine Typ-Info"
+
+#~ msgid "encoding %i"
+#~ msgstr "Kodierung %i"
+
+#~ msgid "establish"
+#~ msgstr "Verbunden"
+
+#~ msgid "initiate"
+#~ msgstr "einleiten"
+
+#~ msgid "invalid eof() return value."
+#~ msgstr "ungültiger 'eof()'-Rückgabewert."
+
+#~ msgid "looking for catalog '%s' in path '%s'."
+#~ msgstr "Suche Nachrichtenkatalog »%s« in Pfad »%s«."
+
+#~ msgid "unknown line terminator"
+#~ msgstr "Unbekanntes Zeilenende"
+
+#~ msgid "writing"
+#~ msgstr "Schreiben"
+
+#~ msgid "wxRichTextBulletsPage"
+#~ msgstr "wxRichTextBulletsPage"
+
+#~ msgid "wxRichTextFontPage"
+#~ msgstr "wxRichTextFontPage"
+
+#~ msgid "wxRichTextListStylePage"
+#~ msgstr "wxRichTextListStylePage"
+
+#~ msgid "wxRichTextStylePage"
+#~ msgstr "wxRichTextStylePage"
+
+#~ msgid "wxSocket: invalid signature in ReadMsg."
+#~ msgstr "wxSocket: ungültige Signatur in ReadMsg."
+
+#~ msgid "wxSocket: unknown event!."
+#~ msgstr "wxSocket: unbekanntes Ereignis!."
+
+#~ msgid "|<<"
+#~ msgstr "|<<"

--- a/po_wxstd/el.po
+++ b/po_wxstd/el.po
@@ -1,0 +1,10801 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: wxWidgets 3.3\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-05-14 20:23+0200\n"
+"PO-Revision-Date: 2005-02-16 09:03+0200\n"
+"Last-Translator: InterZone <info@interzone.gr>\n"
+"Language-Team: Tsolakos Stavros <tsolako1@otenet.gr>, Nassos Yiannopoulos "
+"<nassosy@compulink.gr>\n"
+"Language: el\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: ../include/wx/defs.h:2582
+msgid "All files (*.*)|*.*"
+msgstr "Όλα τα αρχεία (*.*)|*.*"
+
+#: ../include/wx/defs.h:2585
+msgid "All files (*)|*"
+msgstr "Όλα τα αρχεία (*)|*"
+
+#: ../include/wx/generic/progdlgg.h:85
+#, fuzzy
+msgid "Elapsed time:"
+msgstr "Υπολογισθείς χρόνος : "
+
+#: ../include/wx/generic/progdlgg.h:86
+#, fuzzy
+msgid "Estimated time:"
+msgstr "Υπολογισθείς χρόνος : "
+
+#: ../include/wx/generic/progdlgg.h:87
+#, fuzzy
+msgid "Remaining time:"
+msgstr "Xρόνος που απομένει : "
+
+#. TRANSLATORS: HTML printout default title.
+#: ../include/wx/html/htmprint.h:121 ../include/wx/prntbase.h:273
+#: ../include/wx/richtext/richtextprint.h:109 ../src/common/docview.cpp:2161
+#, fuzzy
+msgid "Printout"
+msgstr "Εκτύπωση"
+
+#. TRANSLATORS: HTML easy print default title.
+#: ../include/wx/html/htmprint.h:234 ../include/wx/richtext/richtextprint.h:163
+#: ../src/common/prntbase.cpp:522 ../src/html/htmprint.cpp:291
+#, fuzzy
+msgid "Printing"
+msgstr "Γίνεται εκτύπωση του "
+
+#: ../include/wx/msgdlg.h:277 ../src/common/stockitem.cpp:211
+msgid "Yes"
+msgstr "Ναι"
+
+#: ../include/wx/msgdlg.h:278 ../src/common/stockitem.cpp:182
+msgid "No"
+msgstr "Όχι"
+
+#: ../include/wx/msgdlg.h:279 ../src/common/stockitem.cpp:183
+#: ../src/msw/msgdlg.cpp:430 ../src/msw/msgdlg.cpp:734
+#: ../src/richtext/richtextstyledlg.cpp:292
+msgid "OK"
+msgstr "OK"
+
+#: ../include/wx/msgdlg.h:280 ../src/common/stockitem.cpp:150
+#: ../src/msw/msgdlg.cpp:430 ../src/msw/progdlg.cpp:884
+#: ../src/richtext/richtextstyledlg.cpp:295
+msgid "Cancel"
+msgstr "Ακυρο"
+
+#: ../include/wx/msgdlg.h:281 ../src/common/stockitem.cpp:168
+#: ../src/html/helpdlg.cpp:63 ../src/html/helpfrm.cpp:108
+#: ../src/osx/button_osx.cpp:38
+msgid "Help"
+msgstr "Βοήθεια"
+
+#: ../include/wx/msw/ole/oleutils.h:52
+msgid "Cannot initialize OLE"
+msgstr "Δεν είναι δυνατή η αρχικοποίηση του OLE"
+
+#: ../include/wx/msw/private/fswatcher.h:48
+#, fuzzy, c-format
+msgid "Unable to close the handle for '%s'"
+msgstr "Αποτυχία κλεισίματος του χειριστηρίου του αρχείου(file handle)"
+
+#: ../include/wx/msw/private/fswatcher.h:92
+#, fuzzy, c-format
+msgid "Failed to open directory \"%s\" for monitoring."
+msgstr "Αποτυχία ανοίγματος του '%s' για το '%s'"
+
+#: ../include/wx/msw/private/fswatcher.h:125
+#, fuzzy
+msgid "Unable to close I/O completion port handle"
+msgstr "Αποτυχία κλεισίματος του χειριστηρίου του αρχείου(file handle)"
+
+#: ../include/wx/msw/private/fswatcher.h:142
+msgid "Unable to associate handle with I/O completion port"
+msgstr ""
+
+#: ../include/wx/msw/private/fswatcher.h:148
+msgid "Unexpectedly new I/O completion port was created"
+msgstr ""
+
+#: ../include/wx/msw/private/fswatcher.h:213
+msgid "Unable to post completion status"
+msgstr ""
+
+#: ../include/wx/msw/private/fswatcher.h:262
+msgid "Unable to dequeue completion packet"
+msgstr ""
+
+#: ../include/wx/msw/private/fswatcher.h:273
+#, fuzzy
+msgid "Unable to create I/O completion port"
+msgstr "Αποτυχία δημιουργίας δείκτη."
+
+#: ../include/wx/richmsgdlg.h:29
+#, fuzzy
+msgid "&See details"
+msgstr "&Λεπτομέρειες"
+
+#: ../include/wx/richmsgdlg.h:30
+#, fuzzy
+msgid "&Hide details"
+msgstr "&Λεπτομέρειες"
+
+#: ../include/wx/richtext/richtextbuffer.h:3864
+#, fuzzy
+msgid "&Box"
+msgstr "&Έντονο"
+
+#: ../include/wx/richtext/richtextbuffer.h:5008
+msgid "&Picture"
+msgstr ""
+
+#: ../include/wx/richtext/richtextbuffer.h:5958
+#, fuzzy
+msgid "&Cell"
+msgstr "&Ακυρο"
+
+#: ../include/wx/richtext/richtextbuffer.h:6067
+msgid "&Table"
+msgstr ""
+
+#: ../include/wx/richtext/richtextimagedlg.h:37
+#, fuzzy
+msgid "Object Properties"
+msgstr "&Ιδιότητες"
+
+#: ../include/wx/richtext/richtextsymboldlg.h:39
+#, fuzzy
+msgid "Symbols"
+msgstr "&Στυλ:"
+
+#: ../include/wx/unix/pipe.h:46
+msgid "Pipe creation failed"
+msgstr "Δημιουργία pipe απέτυχε"
+
+#: ../include/wx/unix/private/displayx11.h:65
+msgid "Failed to enumerate video modes"
+msgstr "Απέτυχε η απαρίθμηση των καταστάσεων οθόνης."
+
+#: ../include/wx/unix/private/displayx11.h:89
+msgid "Failed to change video mode"
+msgstr "Αποτυχία αλλαγής της κατάστασης οθόνης"
+
+#: ../include/wx/unix/private/fswatcher_kqueue.h:57
+#, fuzzy, c-format
+msgid "Unable to open path '%s'"
+msgstr "Αποτυχία ανοίγματος του arxe;ioy CHM '%s'."
+
+#: ../include/wx/unix/private/fswatcher_kqueue.h:74
+#, fuzzy, c-format
+msgid "Unable to close path '%s'"
+msgstr "Αποτυχία κλεισίματος του αρχείου 'κλειδωνιά'(lock file) '%s'"
+
+#: ../include/wx/xtiprop.h:175
+msgid "SetProperty called w/o valid setter"
+msgstr "Η SetProperty κλήθηκε χωρίς έγκυρο θέτη"
+
+#: ../include/wx/xtiprop.h:184
+msgid "GetProperty called w/o valid getter"
+msgstr "Η GetProperty κλήθηκε χωρίς έγκυρο getter"
+
+#: ../include/wx/xtiprop.h:193
+msgid "AddToPropertyCollection called w/o valid adder"
+msgstr "AddToPropertyCollection κλήθηκε χωρίς έγκυρο προσθέτη"
+
+#: ../include/wx/xtiprop.h:202
+msgid "GetPropertyCollection called w/o valid collection getter"
+msgstr "Η GetPropertyCollection κλήθηκε χωρίς έγκυρο collection getter"
+
+#: ../include/wx/xtiprop.h:255
+msgid "AddToPropertyCollection called on a generic accessor"
+msgstr "AddToPropertyCollection κλήθηκε σε έναν γενικό accessor"
+
+#: ../include/wx/xtiprop.h:262
+msgid "GetPropertyCollection called on a generic accessor"
+msgstr "Η GetPropertyCollection κλήθηκε σε έναν γενικό accessor"
+
+#: ../src/aui/tabmdi.cpp:106 ../src/generic/mdig.cpp:94
+msgid "Cl&ose"
+msgstr "&Κλείσιμο"
+
+#: ../src/aui/tabmdi.cpp:107 ../src/generic/mdig.cpp:95
+msgid "Close All"
+msgstr "Κλείσιμο"
+
+#: ../src/aui/tabmdi.cpp:109 ../src/generic/mdig.cpp:97 ../src/msw/mdi.cpp:175
+#: ../src/qt/mdi.cpp:258
+msgid "&Next"
+msgstr "&Επόμενο"
+
+#: ../src/aui/tabmdi.cpp:110 ../src/generic/mdig.cpp:98 ../src/msw/mdi.cpp:176
+#: ../src/qt/mdi.cpp:259
+msgid "&Previous"
+msgstr "&Προηγούμενο"
+
+#: ../src/aui/tabmdi.cpp:332 ../src/aui/tabmdi.cpp:348
+#: ../src/aui/tabmdi.cpp:350 ../src/generic/mdig.cpp:291
+#: ../src/generic/mdig.cpp:307 ../src/generic/mdig.cpp:311
+#: ../src/msw/mdi.cpp:337 ../src/qt/mdi.cpp:462
+msgid "&Window"
+msgstr "&Παράθυρο"
+
+#: ../src/common/accelcmn.cpp:47
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Delete"
+msgstr "&Διαγραφή"
+
+#: ../src/common/accelcmn.cpp:48
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Del"
+msgstr "&Διαγραφή"
+
+#: ../src/common/accelcmn.cpp:49
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Back"
+msgstr "&Πίσω"
+
+#: ../src/common/accelcmn.cpp:49
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Backspace"
+msgstr "&Πίσω"
+
+#: ../src/common/accelcmn.cpp:50
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Insert"
+msgstr "Στοίχιση"
+
+#: ../src/common/accelcmn.cpp:51
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Ins"
+msgstr "Στοίχιση"
+
+#: ../src/common/accelcmn.cpp:52
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Enter"
+msgstr "Εκτυπωτής"
+
+#: ../src/common/accelcmn.cpp:53
+msgctxt "keyboard key"
+msgid "Return"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:54
+#, fuzzy
+msgctxt "keyboard key"
+msgid "PageUp"
+msgstr "Σελίδες"
+
+#: ../src/common/accelcmn.cpp:54
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Page Up"
+msgstr "Σελίδα %d"
+
+#: ../src/common/accelcmn.cpp:55
+#, fuzzy
+msgctxt "keyboard key"
+msgid "PageDown"
+msgstr "Κάτω"
+
+#: ../src/common/accelcmn.cpp:55
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Page Down"
+msgstr "Σελίδα %d"
+
+#: ../src/common/accelcmn.cpp:56
+msgctxt "keyboard key"
+msgid "PgUp"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:57
+msgctxt "keyboard key"
+msgid "PgDn"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:58
+msgctxt "keyboard key"
+msgid "Left"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:59
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Right"
+msgstr "Απαλό(light)"
+
+#: ../src/common/accelcmn.cpp:60
+msgctxt "keyboard key"
+msgid "Up"
+msgstr "Επάνω"
+
+#: ../src/common/accelcmn.cpp:61
+msgctxt "keyboard key"
+msgid "Down"
+msgstr "Κάτω"
+
+#: ../src/common/accelcmn.cpp:62
+msgctxt "keyboard key"
+msgid "Home"
+msgstr "Αρχική σελίδα"
+
+#: ../src/common/accelcmn.cpp:63
+msgctxt "keyboard key"
+msgid "End"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:64
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Space"
+msgstr "Γίνεται αναζήτηση..."
+
+#: ../src/common/accelcmn.cpp:65
+msgctxt "keyboard key"
+msgid "Tab"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:66
+msgctxt "keyboard key"
+msgid "Esc"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:67
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Escape"
+msgstr "Τοπίο"
+
+#: ../src/common/accelcmn.cpp:68
+msgctxt "keyboard key"
+msgid "Cancel"
+msgstr "Ακυρο"
+
+#: ../src/common/accelcmn.cpp:69
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Clear"
+msgstr "&Καθαρισμός"
+
+#: ../src/common/accelcmn.cpp:70
+msgctxt "keyboard key"
+msgid "Menu"
+msgstr "Μενού"
+
+#: ../src/common/accelcmn.cpp:71
+msgctxt "keyboard key"
+msgid "Pause"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:72
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Capital"
+msgstr "πλάγιο"
+
+#: ../src/common/accelcmn.cpp:73
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Select"
+msgstr "Τμήματα"
+
+#: ../src/common/accelcmn.cpp:74
+msgctxt "keyboard key"
+msgid "Print"
+msgstr "Εκτύπωση"
+
+#: ../src/common/accelcmn.cpp:75
+msgctxt "keyboard key"
+msgid "Execute"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:76
+msgctxt "keyboard key"
+msgid "Snapshot"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:77
+msgctxt "keyboard key"
+msgid "Help"
+msgstr "Βοήθεια"
+
+#: ../src/common/accelcmn.cpp:78
+msgctxt "keyboard key"
+msgid "Add"
+msgstr "Προσθήκη"
+
+#: ../src/common/accelcmn.cpp:79
+msgctxt "keyboard key"
+msgid "Separator"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:80
+msgctxt "keyboard key"
+msgid "Subtract"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:81
+msgctxt "keyboard key"
+msgid "Decimal"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:82
+msgctxt "keyboard key"
+msgid "Multiply"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:83
+msgctxt "keyboard key"
+msgid "Divide"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:84
+msgctxt "keyboard key"
+msgid "Num_lock"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:84
+msgctxt "keyboard key"
+msgid "Num Lock"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:85
+msgctxt "keyboard key"
+msgid "Scroll_lock"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:85
+msgctxt "keyboard key"
+msgid "Scroll Lock"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:86
+msgctxt "keyboard key"
+msgid "KP_Space"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:86
+msgctxt "keyboard key"
+msgid "Num Space"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:87
+msgctxt "keyboard key"
+msgid "KP_Tab"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:87
+msgctxt "keyboard key"
+msgid "Num Tab"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:88
+#, fuzzy
+msgctxt "keyboard key"
+msgid "KP_Enter"
+msgstr "Εκτυπωτής"
+
+#: ../src/common/accelcmn.cpp:88
+msgctxt "keyboard key"
+msgid "Num Enter"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:89
+#, fuzzy
+msgctxt "keyboard key"
+msgid "KP_Home"
+msgstr "Αρχική σελίδα"
+
+#: ../src/common/accelcmn.cpp:89
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Num Home"
+msgstr "Αρχική σελίδα"
+
+#: ../src/common/accelcmn.cpp:90
+msgctxt "keyboard key"
+msgid "KP_Left"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:90
+msgctxt "keyboard key"
+msgid "Num left"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:91
+msgctxt "keyboard key"
+msgid "KP_Up"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:91
+msgctxt "keyboard key"
+msgid "Num Up"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:92
+#, fuzzy
+msgctxt "keyboard key"
+msgid "KP_Right"
+msgstr "Απαλό(light)"
+
+#: ../src/common/accelcmn.cpp:92
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Num Right"
+msgstr "Απαλό(light)"
+
+#: ../src/common/accelcmn.cpp:93
+#, fuzzy
+msgctxt "keyboard key"
+msgid "KP_Down"
+msgstr "Κάτω"
+
+#: ../src/common/accelcmn.cpp:93
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Num Down"
+msgstr "Κάτω"
+
+#: ../src/common/accelcmn.cpp:94
+msgctxt "keyboard key"
+msgid "KP_PageUp"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:94
+msgctxt "keyboard key"
+msgid "Num Page Up"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:95
+msgctxt "keyboard key"
+msgid "KP_PageDown"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:95
+msgctxt "keyboard key"
+msgid "Num Page Down"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:96
+msgctxt "keyboard key"
+msgid "KP_Prior"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:97
+#, fuzzy
+msgctxt "keyboard key"
+msgid "KP_Next"
+msgstr "Επόμενο"
+
+#: ../src/common/accelcmn.cpp:98
+msgctxt "keyboard key"
+msgid "KP_End"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:98
+msgctxt "keyboard key"
+msgid "Num End"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:99
+msgctxt "keyboard key"
+msgid "KP_Begin"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:99
+msgctxt "keyboard key"
+msgid "Num Begin"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:100
+#, fuzzy
+msgctxt "keyboard key"
+msgid "KP_Insert"
+msgstr "Στοίχιση"
+
+#: ../src/common/accelcmn.cpp:100
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Num Insert"
+msgstr "Στοίχιση"
+
+#: ../src/common/accelcmn.cpp:101
+#, fuzzy
+msgctxt "keyboard key"
+msgid "KP_Delete"
+msgstr "&Διαγραφή"
+
+#: ../src/common/accelcmn.cpp:101
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Num Delete"
+msgstr "&Διαγραφή"
+
+#: ../src/common/accelcmn.cpp:102
+msgctxt "keyboard key"
+msgid "KP_Equal"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:102
+msgctxt "keyboard key"
+msgid "Num ="
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:103
+msgctxt "keyboard key"
+msgid "KP_Multiply"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:103
+msgctxt "keyboard key"
+msgid "Num *"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:104
+msgctxt "keyboard key"
+msgid "KP_Add"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:104
+msgctxt "keyboard key"
+msgid "Num +"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:105
+msgctxt "keyboard key"
+msgid "KP_Separator"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:105
+msgctxt "keyboard key"
+msgid "Num ,"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:106
+msgctxt "keyboard key"
+msgid "KP_Subtract"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:106
+msgctxt "keyboard key"
+msgid "Num -"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:107
+msgctxt "keyboard key"
+msgid "KP_Decimal"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:107
+msgctxt "keyboard key"
+msgid "Num ."
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:108
+msgctxt "keyboard key"
+msgid "KP_Divide"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:108
+msgctxt "keyboard key"
+msgid "Num /"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:109
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Windows_Left"
+msgstr "Windows 95"
+
+#: ../src/common/accelcmn.cpp:110
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Windows_Right"
+msgstr "Windows 95"
+
+#: ../src/common/accelcmn.cpp:111
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Windows_Menu"
+msgstr "Windows ME"
+
+#: ../src/common/accelcmn.cpp:112
+msgctxt "keyboard key"
+msgid "Command"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:186 ../src/common/accelcmn.cpp:359
+msgctxt "keyboard key"
+msgid "Ctrl"
+msgstr "Ctrl"
+
+#: ../src/common/accelcmn.cpp:188 ../src/common/accelcmn.cpp:363
+msgctxt "keyboard key"
+msgid "Alt"
+msgstr "Alt"
+
+#: ../src/common/accelcmn.cpp:190 ../src/common/accelcmn.cpp:361
+msgctxt "keyboard key"
+msgid "Shift"
+msgstr "Shift"
+
+#: ../src/common/accelcmn.cpp:196
+msgctxt "keyboard key"
+msgid "num "
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:260 ../src/common/accelcmn.cpp:382
+msgctxt "keyboard key"
+msgid "F"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:277 ../src/common/accelcmn.cpp:385
+msgctxt "keyboard key"
+msgid "KP_F"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:280 ../src/common/accelcmn.cpp:388
+msgctxt "keyboard key"
+msgid "KP_"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:283 ../src/common/accelcmn.cpp:391
+msgctxt "keyboard key"
+msgid "SPECIAL"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:373
+#, fuzzy
+msgid "Ctrl"
+msgstr "Ctrl"
+
+#: ../src/common/appbase.cpp:786
+msgid "show this help message"
+msgstr "εμφάνιση αυτού του μηνύματος βοηθείας"
+
+#: ../src/common/appbase.cpp:796
+msgid "generate verbose log messages"
+msgstr "δημιουργία αναλυτικών (verbose) μηνυμάτων καταγραφής (log)"
+
+#: ../src/common/appcmn.cpp:256
+msgid "specify the theme to use"
+msgstr "καθορίστε το θέμα που θα χρησιμοποιηθεί"
+
+#: ../src/common/appcmn.cpp:270
+msgid "specify display mode to use (e.g. 640x480-16)"
+msgstr ""
+"διευκρινήστε τον τρόπο απεικόνισης που θα χρησιμοποιηθεί (π.χ. 640x480-16)"
+
+#: ../src/common/appcmn.cpp:292
+#, c-format
+msgid "Unsupported theme '%s'."
+msgstr "Το θέμα '%s' δεν υποστηρίζεται."
+
+#: ../src/common/appcmn.cpp:309
+#, c-format
+msgid "Invalid display mode specification '%s'."
+msgstr ""
+"Λανθασμένος καθορισμός(specification) κατάστασης λειτουργίας(mode) "
+"οθόνης(display) '%s'."
+
+#: ../src/common/cmdline.cpp:875
+#, fuzzy, c-format
+msgid "Option '%s' can't be negated"
+msgstr "Δεν ήταν δυνατή η δημιουργία του καταλόγου '%s'"
+
+#: ../src/common/cmdline.cpp:889
+#, c-format
+msgid "Unknown long option '%s'"
+msgstr "’γνωστη επιλογή long '%s'"
+
+#: ../src/common/cmdline.cpp:904 ../src/common/cmdline.cpp:926
+#, c-format
+msgid "Unknown option '%s'"
+msgstr "’γνωστη επιλογή '%s'"
+
+#: ../src/common/cmdline.cpp:1004
+#, fuzzy, c-format
+msgid "Unexpected characters following option '%s'."
+msgstr "Απροσδόκητη παράμετρος '%s'"
+
+#: ../src/common/cmdline.cpp:1039
+#, c-format
+msgid "Option '%s' requires a value."
+msgstr "Η επιλογή '%s' απαιτεί μια τιμή."
+
+#: ../src/common/cmdline.cpp:1058
+#, c-format
+msgid "Separator expected after the option '%s'."
+msgstr "Αναμενόταν διαχωριστικό μετά την επιλογή '%s'."
+
+#: ../src/common/cmdline.cpp:1088 ../src/common/cmdline.cpp:1106
+#, c-format
+msgid "'%s' is not a correct numeric value for option '%s'."
+msgstr "'%s' δεν είναι μία σωστή αριθμητική τιμή για την επιλογή '%s'."
+
+#: ../src/common/cmdline.cpp:1122
+#, c-format
+msgid "Option '%s': '%s' cannot be converted to a date."
+msgstr "Επιλογή '%s': το '%s' δεν μπροει να μετατραπει σε ημερομηνία."
+
+#: ../src/common/cmdline.cpp:1170
+#, c-format
+msgid "Unexpected parameter '%s'"
+msgstr "Απροσδόκητη παράμετρος '%s'"
+
+#. TRANSLATORS: Short name and long name for a command line option
+#: ../src/common/cmdline.cpp:1197
+#, c-format
+msgid "%s (or %s)"
+msgstr "%s (ή %s)"
+
+#: ../src/common/cmdline.cpp:1208
+#, c-format
+msgid "The value for the option '%s' must be specified."
+msgstr "Η τιμή για την επιλογή '%s' πρέπει να προσδιοριστεί,"
+
+#: ../src/common/cmdline.cpp:1230
+#, c-format
+msgid "The required parameter '%s' was not specified."
+msgstr "Η απαραίτητη παράμετρος '%s' δεν προσδιορίστηκε."
+
+#: ../src/common/cmdline.cpp:1289
+#, c-format
+msgid "Usage: %s"
+msgstr "Χρήση: %s"
+
+#: ../src/common/cmdline.cpp:1498
+msgid "str"
+msgstr "str"
+
+#: ../src/common/cmdline.cpp:1502
+msgid "num"
+msgstr "num"
+
+#: ../src/common/cmdline.cpp:1506
+msgid "double"
+msgstr ""
+
+#: ../src/common/cmdline.cpp:1510
+msgid "date"
+msgstr "ημερομηνία"
+
+#: ../src/common/cmdproc.cpp:250 ../src/common/cmdproc.cpp:276
+#: ../src/common/cmdproc.cpp:296
+msgid "Unnamed command"
+msgstr "Ανώνυμη εντολή"
+
+#: ../src/common/cmdproc.cpp:253
+msgid "&Undo "
+msgstr "&Αναίρεση "
+
+#: ../src/common/cmdproc.cpp:255
+msgid "Can't &Undo "
+msgstr "Δεν είναι δυνατή η αναίρεση"
+
+#: ../src/common/cmdproc.cpp:259 ../src/common/stockitem.cpp:208
+#: ../src/msw/textctrl.cpp:2880 ../src/osx/textctrl_osx.cpp:649
+#: ../src/richtext/richtextctrl.cpp:327
+msgid "&Undo"
+msgstr "&Αναίρεση"
+
+#: ../src/common/cmdproc.cpp:277 ../src/common/cmdproc.cpp:297
+msgid "&Redo "
+msgstr "&Επανάληψη "
+
+#: ../src/common/cmdproc.cpp:281 ../src/common/cmdproc.cpp:288
+#: ../src/common/stockitem.cpp:190 ../src/msw/textctrl.cpp:2881
+#: ../src/osx/textctrl_osx.cpp:650 ../src/richtext/richtextctrl.cpp:328
+msgid "&Redo"
+msgstr "&Επανάληψη"
+
+#: ../src/common/colourcmn.cpp:41
+#, c-format
+msgid "String To Colour : Incorrect colour specification : %s"
+msgstr "String To Colour : Λανθασμένος καθορισμός χρώματος: %s"
+
+#: ../src/common/config.cpp:259
+#, c-format
+msgid "Invalid value %ld for a boolean key \"%s\" in config file."
+msgstr ""
+
+#: ../src/common/config.cpp:526
+#, fuzzy, c-format
+msgid ""
+"Environment variables expansion failed: missing '%c' at position %u in '%s'."
+msgstr ""
+"Η επέκταση μεταβλητών περιβάλλοντος απέτυχε: λείπει το '%c' στην θέση %d στο "
+"'%s'."
+
+#: ../src/common/config.cpp:576 ../src/msw/regconf.cpp:272
+#, c-format
+msgid "'%s' has extra '..', ignored."
+msgstr "'%s' περιέχει επιπλέον '..', αγνοήθηκαν."
+
+#. TRANSLATORS: Checkbox state name
+#: ../src/common/datavcmn.cpp:2166 ../src/generic/datavgen.cpp:1430
+msgid "checked"
+msgstr ""
+
+#. TRANSLATORS: Checkbox state name
+#: ../src/common/datavcmn.cpp:2170 ../src/generic/datavgen.cpp:1432
+msgid "unchecked"
+msgstr ""
+
+#. TRANSLATORS: Checkbox state name
+#: ../src/common/datavcmn.cpp:2174
+#, fuzzy
+msgid "undetermined"
+msgstr "υπογεγραμμένο"
+
+#: ../src/common/datetimefmt.cpp:1875
+msgid "today"
+msgstr "σήμερα"
+
+#: ../src/common/datetimefmt.cpp:1876
+msgid "yesterday"
+msgstr "χθες"
+
+#: ../src/common/datetimefmt.cpp:1877
+msgid "tomorrow"
+msgstr "αύριο"
+
+#: ../src/common/datetimefmt.cpp:2071
+msgid "first"
+msgstr "πρώτο"
+
+#: ../src/common/datetimefmt.cpp:2072
+msgid "second"
+msgstr "δεύτερο"
+
+#: ../src/common/datetimefmt.cpp:2073
+msgid "third"
+msgstr "τρίτο"
+
+#: ../src/common/datetimefmt.cpp:2074
+msgid "fourth"
+msgstr "τέταρτο"
+
+#: ../src/common/datetimefmt.cpp:2075
+msgid "fifth"
+msgstr "πέμπτο"
+
+#: ../src/common/datetimefmt.cpp:2076
+msgid "sixth"
+msgstr "έκτο"
+
+#: ../src/common/datetimefmt.cpp:2077
+msgid "seventh"
+msgstr "έβδομο"
+
+#: ../src/common/datetimefmt.cpp:2078
+msgid "eighth"
+msgstr "όγδοο"
+
+#: ../src/common/datetimefmt.cpp:2079
+msgid "ninth"
+msgstr "ένατο"
+
+#: ../src/common/datetimefmt.cpp:2080
+msgid "tenth"
+msgstr "δέκατο"
+
+#: ../src/common/datetimefmt.cpp:2081
+msgid "eleventh"
+msgstr "έβδομο"
+
+#: ../src/common/datetimefmt.cpp:2082
+msgid "twelfth"
+msgstr "δωδέκατο"
+
+#: ../src/common/datetimefmt.cpp:2083
+msgid "thirteenth"
+msgstr "δέκατο τρίτο"
+
+#: ../src/common/datetimefmt.cpp:2084
+msgid "fourteenth"
+msgstr "δέκατο τέταρτο"
+
+#: ../src/common/datetimefmt.cpp:2085
+msgid "fifteenth"
+msgstr "δέκατο-πέμπτο"
+
+#: ../src/common/datetimefmt.cpp:2086
+msgid "sixteenth"
+msgstr "δέκατο έκτο"
+
+#: ../src/common/datetimefmt.cpp:2087
+msgid "seventeenth"
+msgstr "δέκατο-έβδομο"
+
+#: ../src/common/datetimefmt.cpp:2088
+msgid "eighteenth"
+msgstr "δέκατο όγδοο"
+
+#: ../src/common/datetimefmt.cpp:2089
+msgid "nineteenth"
+msgstr "δέκατο ένατο"
+
+#: ../src/common/datetimefmt.cpp:2090
+msgid "twentieth"
+msgstr "εικοστό"
+
+#: ../src/common/datetimefmt.cpp:2248
+msgid "noon"
+msgstr "μεσημέρι"
+
+#: ../src/common/datetimefmt.cpp:2249
+msgid "midnight"
+msgstr "μεσάνυκτα"
+
+#: ../src/common/debugrpt.cpp:209
+#, fuzzy, c-format
+msgid "Failed to create directory \"%s\""
+msgstr "Απέτυχε η δημιουργία καταλόγου '%s'/.gnome."
+
+#: ../src/common/debugrpt.cpp:210
+#, fuzzy
+msgid "Debug report couldn't be created."
+msgstr "Δεν ήταν δυνατή η δημιουργία του καταλόγου '%s'"
+
+#: ../src/common/debugrpt.cpp:227
+#, fuzzy, c-format
+msgid "Failed to remove debug report file \"%s\""
+msgstr "Αποτυχία απομάκρυνσης του αρχείου 'κλειδωνιά'(lock file) '%s'"
+
+#: ../src/common/debugrpt.cpp:239
+#, fuzzy, c-format
+msgid "Failed to clean up debug report directory \"%s\""
+msgstr "Απέτυχε η δημιουργία καταλόγου '%s'/.gnome."
+
+#: ../src/common/debugrpt.cpp:514
+msgid "process context description"
+msgstr ""
+
+#: ../src/common/debugrpt.cpp:538
+msgid "dump of the process state (binary)"
+msgstr ""
+
+#: ../src/common/debugrpt.cpp:553
+msgid "Debug report generation has failed."
+msgstr ""
+
+#: ../src/common/debugrpt.cpp:560
+#, c-format
+msgid ""
+"Processing debug report has failed, leaving the files in \"%s\" directory."
+msgstr ""
+
+#: ../src/common/debugrpt.cpp:573
+msgid "A debug report has been generated. It can be found in"
+msgstr ""
+
+#: ../src/common/debugrpt.cpp:576
+msgid "And includes the following files:\n"
+msgstr ""
+
+#: ../src/common/debugrpt.cpp:586
+msgid ""
+"\n"
+"Please send this report to the program maintainer, thank you!\n"
+msgstr ""
+
+#: ../src/common/debugrpt.cpp:729
+msgid "Failed to execute curl, please install it in PATH."
+msgstr ""
+
+#: ../src/common/debugrpt.cpp:742
+#, fuzzy, c-format
+msgid "Failed to upload the debug report (error code %d)."
+msgstr ""
+"Απέτυχε η δημιουργία καθιερωμένου παράθυρου διαλόγου εύρεσης/αντικατάστασης "
+"(κωδικός σφάλματος %d)"
+
+#: ../src/common/docview.cpp:366
+msgid "Save As"
+msgstr "Αποθήκευση ως"
+
+#: ../src/common/docview.cpp:457
+msgid "Discard changes and reload the last saved version?"
+msgstr ""
+
+#: ../src/common/docview.cpp:488
+msgid "unnamed"
+msgstr "απροσδιόριστο"
+
+#: ../src/common/docview.cpp:513
+#, fuzzy, c-format
+msgid "Do you want to save changes to %s?"
+msgstr "Θέλετε να αποθηκεύσετε τις αλλαγές στο έγγραφο %s ;"
+
+#: ../src/common/docview.cpp:521 ../src/common/docview.cpp:560
+#: ../src/common/stockitem.cpp:195
+msgid "&Save"
+msgstr "&Αποθήκευση"
+
+#: ../src/common/docview.cpp:522 ../src/common/docview.cpp:560
+msgid "&Discard changes"
+msgstr ""
+
+#: ../src/common/docview.cpp:523
+msgid "Do&n't close"
+msgstr ""
+
+#: ../src/common/docview.cpp:553
+#, fuzzy, c-format
+msgid "Do you want to save changes to %s before closing it?"
+msgstr "Θέλετε να αποθηκεύσετε τις αλλαγές στο έγγραφο %s ;"
+
+#: ../src/common/docview.cpp:559
+#, fuzzy
+msgid "The document must be closed."
+msgstr "Το κείμενο δεν μπόρεσε να αποθυκευτεί."
+
+#: ../src/common/docview.cpp:571
+#, c-format
+msgid "Saving %s failed, would you like to retry?"
+msgstr ""
+
+#: ../src/common/docview.cpp:577
+msgid "Retry"
+msgstr ""
+
+#: ../src/common/docview.cpp:577
+msgid "Discard changes"
+msgstr ""
+
+#: ../src/common/docview.cpp:679
+#, fuzzy, c-format
+msgid "File \"%s\" could not be opened for writing."
+msgstr "Αποτυχία ανοίγματος του '%s' για το '%s'"
+
+#: ../src/common/docview.cpp:685
+#, fuzzy, c-format
+msgid "Failed to save document to the file \"%s\"."
+msgstr "Αποτυχία αποθήκευσης της εικόνας στο αρχείο \"%s\"."
+
+#: ../src/common/docview.cpp:702
+#, fuzzy, c-format
+msgid "File \"%s\" could not be opened for reading."
+msgstr "Αποτυχία ανοίγματος του '%s' για το '%s'"
+
+#: ../src/common/docview.cpp:714
+#, fuzzy, c-format
+msgid "Failed to read document from the file \"%s\"."
+msgstr "Αποτυχία φόρτωσης της μετα-εικόνας από το αρχείο '%s'."
+
+#: ../src/common/docview.cpp:1236
+#, c-format
+msgid ""
+"The file '%s' doesn't exist and couldn't be opened.\n"
+"It has been removed from the most recently used files list."
+msgstr ""
+"Το αρχείο '%s' δεν υπάρχει και δεν μπόρεσε να ανοιχτεί.\n"
+"Αφαιρέθηκε από την λίστα με τα πρόσφατα χρησιμοποιημένα αρχεία."
+
+#: ../src/common/docview.cpp:1296
+#, fuzzy
+msgid "Print preview creation failed."
+msgstr "Δημιουργία pipe απέτυχε"
+
+#: ../src/common/docview.cpp:1302
+msgid "Print Preview"
+msgstr "Προεπισκόπηση Εκτύπωσης"
+
+#: ../src/common/docview.cpp:1517
+#, fuzzy, c-format
+msgid "The format of file '%s' couldn't be determined."
+msgstr "Δεν ήταν δυνατή η δημιουργία του καταλόγου '%s'"
+
+#: ../src/common/docview.cpp:1643
+#, c-format
+msgid "unnamed%d"
+msgstr "απροσδιόριστο%d"
+
+#: ../src/common/docview.cpp:1660
+msgid " - "
+msgstr " - "
+
+#: ../src/common/docview.cpp:1791 ../src/common/docview.cpp:1844
+msgid "Open File"
+msgstr "Ανοιγμα Αρχείου"
+
+#: ../src/common/docview.cpp:1807
+msgid "File error"
+msgstr "Σφάλμα αρχείου"
+
+#: ../src/common/docview.cpp:1809
+msgid "Sorry, could not open this file."
+msgstr "Συγγνώμη, δεν μπόρεσε να ανοιχθεί αυτό το αρχείο."
+
+#: ../src/common/docview.cpp:1843
+msgid "Sorry, the format for this file is unknown."
+msgstr "Συγγνώμη, η μορφή αυτού του αρχείου είναι άγνωστη."
+
+#: ../src/common/docview.cpp:1924
+msgid "Select a document template"
+msgstr "Επιλέξτε ένα πρότυπα εγγράφου"
+
+#: ../src/common/docview.cpp:1925
+msgid "Templates"
+msgstr "Πρότυπα"
+
+#: ../src/common/docview.cpp:1998
+msgid "Select a document view"
+msgstr "Επιλέξτε μια προβολή εγγράφων"
+
+#: ../src/common/docview.cpp:1999
+msgid "Views"
+msgstr "Προβολές"
+
+#: ../src/common/dynlib.cpp:81
+#, c-format
+msgid "Failed to load shared library '%s'"
+msgstr "Αποτυχία φόρτωσης της κοινής βιβλιοθήκης (shared library) '%s'"
+
+#: ../src/common/dynlib.cpp:105
+#, c-format
+msgid "Couldn't find symbol '%s' in a dynamic library"
+msgstr ""
+"Δεν ήταν δυνατός ο εντοπισμός του συμβόλου '%s' σε μια δυναμική βιβλιοθήκη."
+
+#: ../src/common/ffile.cpp:56 ../src/common/file.cpp:215
+#, c-format
+msgid "can't open file '%s'"
+msgstr "δεν είναι δυνατό το άνοιγμα του αρχείου '%s'"
+
+#: ../src/common/ffile.cpp:72
+#, c-format
+msgid "can't close file '%s'"
+msgstr "δεν είναι δυνατό το κλείσιμο του αρχείου '%s'"
+
+#: ../src/common/ffile.cpp:106 ../src/common/ffile.cpp:131
+#, c-format
+msgid "Read error on file '%s'"
+msgstr "Λάθος ανάγνωσης στο αρχείο '%s'"
+
+#: ../src/common/ffile.cpp:148
+#, c-format
+msgid "Write error on file '%s'"
+msgstr "Σφάλμα εγγραφής (write error) στο αρχείο '%s'"
+
+#: ../src/common/ffile.cpp:182
+#, c-format
+msgid "failed to flush the file '%s'"
+msgstr "Αποτυχία αδειάσματος buffer (flush) του αρχείου '%s'"
+
+#: ../src/common/ffile.cpp:222
+#, c-format
+msgid "Seek error on file '%s' (large files not supported by stdio)"
+msgstr ""
+
+#: ../src/common/ffile.cpp:232
+#, c-format
+msgid "Seek error on file '%s'"
+msgstr "Λάθος ανίχνευσης (seek error) στο αρχείο '%s'."
+
+#: ../src/common/ffile.cpp:248
+#, c-format
+msgid "Can't find current position in file '%s'"
+msgstr "Δεν είναι δυνατή η εύρεση της τρέχουσας θέσης στο αρχείου '%s'"
+
+#: ../src/common/ffile.cpp:349 ../src/common/file.cpp:569
+msgid "Failed to set temporary file permissions"
+msgstr "Αποτυχία θέσπισης δικαιωμάτων προσωρινού αρχείου"
+
+#: ../src/common/ffile.cpp:371
+#, c-format
+msgid "can't remove file '%s'"
+msgstr "δεν είναι δυνατό το σβήσιμο του αρχείου '%s'"
+
+#: ../src/common/ffile.cpp:376 ../src/common/file.cpp:591
+#, c-format
+msgid "can't commit changes to file '%s'"
+msgstr "αδύνατη η δέσμευση των αλλαγών στο αρχείο '%s'"
+
+#: ../src/common/ffile.cpp:388 ../src/common/file.cpp:603
+#, c-format
+msgid "can't remove temporary file '%s'"
+msgstr "δεν είναι δυνατό το σβήσιμο του προσωρινού αρχείου '%s'"
+
+#: ../src/common/file.cpp:162
+#, c-format
+msgid "can't create file '%s'"
+msgstr "δεν είναι δυνατή η δημιουργία του αρχείου '%s'"
+
+#: ../src/common/file.cpp:229
+#, c-format
+msgid "can't close file descriptor %d"
+msgstr "αδύνατο το κλείσιμο περιγραφέα (descriptor) αρχείου %d"
+
+#: ../src/common/file.cpp:332
+#, c-format
+msgid "can't read from file descriptor %d"
+msgstr "αδύνατη η ανάγνωση από περiγραφέα (descriptor) αρχείου %d"
+
+#: ../src/common/file.cpp:351
+#, c-format
+msgid "can't write to file descriptor %d"
+msgstr "δεν είναι δυνατή η εγγραφή του περιγραφέα αρχείου(file descriptor) %d"
+
+#: ../src/common/file.cpp:390
+#, c-format
+msgid "can't flush file descriptor %d"
+msgstr ""
+"δεν μπορεί να πραγματοποιηθεί το άδειασμα (flush) του περιγραφέα αρχείου %d"
+
+#: ../src/common/file.cpp:432
+#, c-format
+msgid "can't seek on file descriptor %d"
+msgstr "αδύνατη η αναζήτηση(seek) στον περγραφέα(descriptor) αρχείου %d"
+
+#: ../src/common/file.cpp:446
+#, c-format
+msgid "can't get seek position on file descriptor %d"
+msgstr ""
+"αδύνατη η λήψη θέσης αναζήτησης (seek position) στον περιγραφέα(descriptor) "
+"αρχείου %d"
+
+#: ../src/common/file.cpp:475
+#, c-format
+msgid "can't find length of file on file descriptor %d"
+msgstr ""
+"αδύνατη η εύρεση του μεγέθους αρχείου στον περιγραφέα αρχείου (file "
+"desciptor) %d"
+
+#: ../src/common/file.cpp:505
+#, c-format
+msgid "can't determine if the end of file is reached on descriptor %d"
+msgstr ""
+"αδύνατο να καθοριστεί εαν το τέλος αρχείου του έχει φτάσει στο περιγραφέα "
+"(descriptor) %d"
+
+#: ../src/common/fileconf.cpp:352
+#, c-format
+msgid ""
+" and additionally, the existing configuration file was renamed to \"%s\" and "
+"couldn't be renamed back, please rename it to its original path \"%s\""
+msgstr ""
+
+#: ../src/common/fileconf.cpp:389
+msgid " due to the following error:\n"
+msgstr ""
+
+#: ../src/common/fileconf.cpp:412
+#, fuzzy
+msgid "failed to rename the existing file"
+msgstr "Αποτυχία φόρτωσης της μετα-εικόνας από το αρχείο '%s'."
+
+#: ../src/common/fileconf.cpp:421
+#, fuzzy
+msgid "failed to create the new file directory"
+msgstr "Αποτυχία λήψης καταλόγου εργασίας (working directory)"
+
+#: ../src/common/fileconf.cpp:428
+#, fuzzy
+msgid "failed to move the file to the new location"
+msgstr "Αποτυχία τερματισμού της σύνδεσης μέσω τηλεφώνου : %s"
+
+#: ../src/common/fileconf.cpp:462
+#, c-format
+msgid "can't open global configuration file '%s'."
+msgstr "δεν είναι δυνατό το άνοιγμα του γενικού(global) αρχείου ρυθμίσεων %s"
+
+#: ../src/common/fileconf.cpp:478
+#, c-format
+msgid "can't open user configuration file '%s'."
+msgstr "δεν είναι δυνατό το άνοιγμα του αρχείου ρυθμίσεων '%s' του χρήστη"
+
+#: ../src/common/fileconf.cpp:483
+#, c-format
+msgid "Changes won't be saved to avoid overwriting the existing file \"%s\""
+msgstr ""
+
+#: ../src/common/fileconf.cpp:583
+msgid "Error reading config options."
+msgstr "Σφάλμα κατά την ανάγνωση των ρυθμίσεων."
+
+#: ../src/common/fileconf.cpp:593
+#, fuzzy
+msgid "Failed to read config options."
+msgstr "Σφάλμα κατά την ανάγνωση των ρυθμίσεων."
+
+#: ../src/common/fileconf.cpp:700
+#, fuzzy, c-format
+msgid "file '%s': unexpected character %c at line %zu."
+msgstr "αρχείο '%s': απροσδόκητος χαρακτήρας %c στη γραμμή %d."
+
+#: ../src/common/fileconf.cpp:736
+#, fuzzy, c-format
+msgid "file '%s', line %zu: '%s' ignored after group header."
+msgstr ""
+"αρχείο '%s', γραμμή %d: το '%s' αγνοήθηκε μετά την επικεφαλίδα του γκρούπ."
+
+#: ../src/common/fileconf.cpp:765
+#, fuzzy, c-format
+msgid "file '%s', line %zu: '=' expected."
+msgstr "αρχείο '%s', γραμμή %d: αναμενόταν '=' ."
+
+#: ../src/common/fileconf.cpp:778
+#, fuzzy, c-format
+msgid "file '%s', line %zu: value for immutable key '%s' ignored."
+msgstr "αρχείο '%s', γραμμή %d: τιμή για αμετάβλητο κλειδί '%s' αγνοήθηκε."
+
+#: ../src/common/fileconf.cpp:788
+#, fuzzy, c-format
+msgid "file '%s', line %zu: key '%s' was first found at line %d."
+msgstr ""
+"αρχείο '%s', γραμμή %d: το κλειδί '%s' βρέθηκε για πρώτη φορά στη γραμμή %d."
+
+#: ../src/common/fileconf.cpp:1091
+#, c-format
+msgid "Config entry name cannot start with '%c'."
+msgstr ""
+"Το όνομα εισόδου διαμόρφωσης (Config entry name) δεν μπορεί να αρχίζει με "
+"'%c'"
+
+#: ../src/common/fileconf.cpp:1146
+#, fuzzy
+msgid "Failed to create configuration file directory."
+msgstr "Αποτυχία ανανέωσης του αρχείου ρυθμίσεων του χρήστη."
+
+#: ../src/common/fileconf.cpp:1158
+msgid "can't open user configuration file."
+msgstr "αδύνατο το άνοιγμα αρχείου ρυθμίσεων του χρήστη."
+
+#: ../src/common/fileconf.cpp:1172
+msgid "can't write user configuration file."
+msgstr "Αδύνατη η εγγραφή αρχείου ρυθμίσεων χρήστη."
+
+#: ../src/common/fileconf.cpp:1178
+msgid "Failed to update user configuration file."
+msgstr "Αποτυχία ανανέωσης του αρχείου ρυθμίσεων του χρήστη."
+
+#: ../src/common/fileconf.cpp:1201
+msgid "Error saving user configuration data."
+msgstr "Σφάλμα κατά την εγγραφή των ρυθμίσεων χρήστη."
+
+#: ../src/common/fileconf.cpp:1313
+#, c-format
+msgid "can't delete user configuration file '%s'"
+msgstr "Δεν είναι δυνατή η διαγραφή του αρχείου ρυθμίσεων '%s' του χρήστη"
+
+#: ../src/common/fileconf.cpp:2007
+#, c-format
+msgid "entry '%s' appears more than once in group '%s'"
+msgstr "η εισαγωγή(entry) '%s' εμφανίζεται πάνω από μία φορά στο γκρούπ '%s'"
+
+#: ../src/common/fileconf.cpp:2021
+#, c-format
+msgid "attempt to change immutable key '%s' ignored."
+msgstr "η προσπάθεια αλλαγής αμετάβλητου κλειδιού '%s' αγνοήθηκε."
+
+#: ../src/common/fileconf.cpp:2118
+#, c-format
+msgid "trailing backslash ignored in '%s'"
+msgstr ""
+
+#: ../src/common/fileconf.cpp:2153
+#, c-format
+msgid "unexpected \" at position %d in '%s'."
+msgstr "απροσδόκητο \" στη θέση %d στο '%s'."
+
+#: ../src/common/filefn.cpp:474
+#, c-format
+msgid "Failed to copy the file '%s' to '%s'"
+msgstr "Αποτυχία αντιγραφής του αρχείου '%s' στο '%s'"
+
+#: ../src/common/filefn.cpp:487
+#, c-format
+msgid "Impossible to get permissions for file '%s'"
+msgstr "Αδύνατη η λήψη των δικαιωμάτων για το αρχείο '%s'"
+
+#: ../src/common/filefn.cpp:501
+#, c-format
+msgid "Impossible to overwrite the file '%s'"
+msgstr "Αδύνατη η επικάλυψη του αρχείου '%s'"
+
+#: ../src/common/filefn.cpp:508
+#, fuzzy, c-format
+msgid "Error copying the file '%s' to '%s'."
+msgstr "Αποτυχία αντιγραφής του αρχείου '%s' στο '%s'"
+
+#: ../src/common/filefn.cpp:556
+#, c-format
+msgid "Impossible to set permissions for the file '%s'"
+msgstr "Αδύνατος ο ορισμός των δικαιωμάτων για το αρχείο '%s'"
+
+#: ../src/common/filefn.cpp:606
+#, c-format
+msgid ""
+"Failed to rename the file '%s' to '%s' because the destination file already "
+"exists."
+msgstr ""
+
+#: ../src/common/filefn.cpp:623
+#, fuzzy, c-format
+msgid "File '%s' couldn't be renamed '%s'"
+msgstr "Δεν ήταν δυνατή η δημιουργία του καταλόγου '%s'"
+
+#: ../src/common/filefn.cpp:639
+#, fuzzy, c-format
+msgid "File '%s' couldn't be removed"
+msgstr "Δεν ήταν δυνατή η δημιουργία του καταλόγου '%s'"
+
+#: ../src/common/filefn.cpp:666
+#, c-format
+msgid "Directory '%s' couldn't be created"
+msgstr "Δεν ήταν δυνατή η δημιουργία του καταλόγου '%s'"
+
+#: ../src/common/filefn.cpp:680
+#, fuzzy, c-format
+msgid "Directory '%s' couldn't be deleted"
+msgstr "Δεν ήταν δυνατή η δημιουργία του καταλόγου '%s'"
+
+#: ../src/common/filefn.cpp:714
+#, c-format
+msgid "Cannot enumerate files '%s'"
+msgstr "Δεν είναι δυνατή η απαρίθμηση των αρχείων '%s'"
+
+#: ../src/common/filefn.cpp:798
+msgid "Failed to get the working directory"
+msgstr "Αποτυχία λήψης καταλόγου εργασίας (working directory)"
+
+#: ../src/common/filefn.cpp:843
+#, fuzzy
+msgid "Could not set current working directory"
+msgstr "Αποτυχία λήψης καταλόγου εργασίας (working directory)"
+
+#: ../src/common/filefn.cpp:974
+#, c-format
+msgid "Files (%s)"
+msgstr "Αρχεία (%s)"
+
+#: ../src/common/filename.cpp:182
+#, fuzzy, c-format
+msgid "Failed to open '%s' for reading"
+msgstr "Αποτυχία ανοίγματος του '%s' για το '%s'"
+
+#: ../src/common/filename.cpp:187
+#, fuzzy, c-format
+msgid "Failed to open '%s' for writing"
+msgstr "Αποτυχία ανοίγματος του '%s' για το '%s'"
+
+#: ../src/common/filename.cpp:199
+msgid "Failed to close file handle"
+msgstr "Αποτυχία κλεισίματος του χειριστηρίου του αρχείου(file handle)"
+
+#: ../src/common/filename.cpp:1046
+msgid "Failed to create a temporary file name"
+msgstr "Αποτυχία δημιουργίας ονόματος προσωρινού αρχείου"
+
+#: ../src/common/filename.cpp:1081
+msgid "Failed to open temporary file."
+msgstr "Αποτυχία ανοίγματος προσωρινού αρχείου"
+
+#: ../src/common/filename.cpp:2862
+#, c-format
+msgid "Failed to modify file times for '%s'"
+msgstr "Αποτυχία τροποποίησης ώρας του αρχείου '%s'"
+
+#: ../src/common/filename.cpp:2877
+#, c-format
+msgid "Failed to touch the file '%s'"
+msgstr "Αποτυχία αγγίγματος (touch) του αρχείου '%s'"
+
+#: ../src/common/filename.cpp:2958
+#, c-format
+msgid "Failed to retrieve file times for '%s'"
+msgstr "Αποτυχία λήψης της ώρας του αρχείου '%s'"
+
+#: ../src/common/filepickercmn.cpp:39 ../src/common/filepickercmn.cpp:40
+msgid "Browse"
+msgstr ""
+
+#: ../src/common/fldlgcmn.cpp:792 ../src/generic/filectrlg.cpp:1185
+#, c-format
+msgid "All files (%s)|%s"
+msgstr "Όλα τα αρχεία (%s)|%s"
+
+#. TRANSLATORS: %s are a file extension used to build a file wildcard string
+#: ../src/common/fldlgcmn.cpp:810
+#, c-format
+msgid "%s files (%s)|%s"
+msgstr "%s αρχεία (%s)|%s"
+
+#: ../src/common/fldlgcmn.cpp:1072
+#, c-format
+msgid "Load %s file"
+msgstr "Φόρτωση %s αρχείου"
+
+#: ../src/common/fldlgcmn.cpp:1074
+#, c-format
+msgid "Save %s file"
+msgstr "Αποθήκευση %s αρχείου"
+
+#: ../src/common/fmapbase.cpp:144
+msgid "Western European (ISO-8859-1)"
+msgstr "Δυτικο-Ευρωπαϊκό (ISO-8859-1)"
+
+#: ../src/common/fmapbase.cpp:145
+msgid "Central European (ISO-8859-2)"
+msgstr "Κεντροευρωπαϊκό (ISO-8859-2)"
+
+#: ../src/common/fmapbase.cpp:146
+msgid "Esperanto (ISO-8859-3)"
+msgstr "Εσπεράντο (ISO-8859-3)"
+
+#: ../src/common/fmapbase.cpp:147
+msgid "Baltic (old) (ISO-8859-4)"
+msgstr "Βαλτικό (παλαιό) (ISO-8859-4)"
+
+#: ../src/common/fmapbase.cpp:148
+msgid "Cyrillic (ISO-8859-5)"
+msgstr "Κυριλλικό (ISO-8859-5)"
+
+#: ../src/common/fmapbase.cpp:149
+msgid "Arabic (ISO-8859-6)"
+msgstr "Αραβικό (ISO-8859-6)"
+
+#: ../src/common/fmapbase.cpp:150
+msgid "Greek (ISO-8859-7)"
+msgstr "Ελληνικό (ISO-8859-7)"
+
+#: ../src/common/fmapbase.cpp:151
+msgid "Hebrew (ISO-8859-8)"
+msgstr "Εβραϊκό (ISO-8859-8)"
+
+#: ../src/common/fmapbase.cpp:152
+msgid "Turkish (ISO-8859-9)"
+msgstr "Τουρκικό (ISO-8859-9)"
+
+#: ../src/common/fmapbase.cpp:153
+msgid "Nordic (ISO-8859-10)"
+msgstr "Νορδικό (ISO-8859-10)"
+
+#: ../src/common/fmapbase.cpp:154
+msgid "Thai (ISO-8859-11)"
+msgstr "Ταϋλανδέζικο (ISO-8859-11)"
+
+#: ../src/common/fmapbase.cpp:155
+msgid "Indian (ISO-8859-12)"
+msgstr "Ινδικό (ISO-8859-12)"
+
+#: ../src/common/fmapbase.cpp:156
+msgid "Baltic (ISO-8859-13)"
+msgstr "Βαλτικό (ISO-8859-13)"
+
+#: ../src/common/fmapbase.cpp:157
+msgid "Celtic (ISO-8859-14)"
+msgstr "Κελτικό (ISO-8859-14)"
+
+#: ../src/common/fmapbase.cpp:158
+msgid "Western European with Euro (ISO-8859-15)"
+msgstr "Δυτικο-Ευρωπαϊκό με Euro (ISO-8859-15)"
+
+#: ../src/common/fmapbase.cpp:159
+msgid "KOI8-R"
+msgstr "KOI8-R"
+
+#: ../src/common/fmapbase.cpp:160
+msgid "KOI8-U"
+msgstr "KOI8-U"
+
+#: ../src/common/fmapbase.cpp:161
+#, fuzzy
+msgid "Windows/DOS OEM Cyrillic (CP 866)"
+msgstr "Windows Κυριλικό (CP 1251)"
+
+#: ../src/common/fmapbase.cpp:162
+#, fuzzy
+msgid "Windows Thai (CP 874)"
+msgstr "Windows Βαλτικό (CP 1257)"
+
+#: ../src/common/fmapbase.cpp:163
+#, fuzzy
+msgid "Windows Japanese (CP 932) or Shift-JIS"
+msgstr "Windows Ιαπωνικό (CP 932)"
+
+#: ../src/common/fmapbase.cpp:164
+#, fuzzy
+msgid "Windows Chinese Simplified (CP 936) or GB-2312"
+msgstr "Windows Απλοποιημένο Κινέζικο (CP 936)"
+
+#: ../src/common/fmapbase.cpp:165
+msgid "Windows Korean (CP 949)"
+msgstr "Windows Κορεάτικο (CP 949)"
+
+#: ../src/common/fmapbase.cpp:166
+#, fuzzy
+msgid "Windows Chinese Traditional (CP 950) or Big-5"
+msgstr "Windows Παραδοσιακό Κινέζικο (CP 950)"
+
+#: ../src/common/fmapbase.cpp:167
+msgid "Windows Central European (CP 1250)"
+msgstr "Windows Κεντρο-Ευρωπαϊκό (CP 1250)"
+
+#: ../src/common/fmapbase.cpp:168
+msgid "Windows Cyrillic (CP 1251)"
+msgstr "Windows Κυριλικό (CP 1251)"
+
+#: ../src/common/fmapbase.cpp:169
+msgid "Windows Western European (CP 1252)"
+msgstr "Windows Δυτικο-Ευρωπαϊκό (CP 1252)"
+
+#: ../src/common/fmapbase.cpp:170
+msgid "Windows Greek (CP 1253)"
+msgstr "Windows Ελληνικό (CP 1253)"
+
+#: ../src/common/fmapbase.cpp:171
+msgid "Windows Turkish (CP 1254)"
+msgstr "Windows Τουρκικό (CP 1254)"
+
+#: ../src/common/fmapbase.cpp:172
+msgid "Windows Hebrew (CP 1255)"
+msgstr "Windows Εβραϊκό (CP 1255)"
+
+#: ../src/common/fmapbase.cpp:173
+msgid "Windows Arabic (CP 1256)"
+msgstr "Windows Αραβικό (CP 1256)"
+
+#: ../src/common/fmapbase.cpp:174
+msgid "Windows Baltic (CP 1257)"
+msgstr "Windows Βαλτικό (CP 1257)"
+
+#: ../src/common/fmapbase.cpp:175
+#, fuzzy
+msgid "Windows Vietnamese (CP 1258)"
+msgstr "Windows Ελληνικό (CP 1253)"
+
+#: ../src/common/fmapbase.cpp:176
+#, fuzzy
+msgid "Windows Johab (CP 1361)"
+msgstr "Windows Αραβικό (CP 1256)"
+
+#: ../src/common/fmapbase.cpp:177
+msgid "Windows/DOS OEM (CP 437)"
+msgstr "Windows/DOS OEM (CP 437)"
+
+#: ../src/common/fmapbase.cpp:178
+msgid "Unicode 7 bit (UTF-7)"
+msgstr "Unicode 7 bit (UTF-7)"
+
+#: ../src/common/fmapbase.cpp:179
+msgid "Unicode 8 bit (UTF-8)"
+msgstr "Unicode 8 bit (UTF-8)"
+
+#: ../src/common/fmapbase.cpp:181 ../src/common/fmapbase.cpp:187
+msgid "Unicode 16 bit (UTF-16)"
+msgstr "Unicode 16 bit (UTF-16)"
+
+#: ../src/common/fmapbase.cpp:182
+msgid "Unicode 16 bit Little Endian (UTF-16LE)"
+msgstr "Unicode 16 bit Little Endian (UTF-16LE)"
+
+#: ../src/common/fmapbase.cpp:183 ../src/common/fmapbase.cpp:189
+msgid "Unicode 32 bit (UTF-32)"
+msgstr "Unicode 32 bit (UTF-32)"
+
+#: ../src/common/fmapbase.cpp:184
+msgid "Unicode 32 bit Little Endian (UTF-32LE)"
+msgstr "Unicode 32 bit Little Endian (UTF-32LE)"
+
+#: ../src/common/fmapbase.cpp:186
+msgid "Unicode 16 bit Big Endian (UTF-16BE)"
+msgstr "Unicode 16 bit Big Endian (UTF-16BE)"
+
+#: ../src/common/fmapbase.cpp:188
+msgid "Unicode 32 bit Big Endian (UTF-32BE)"
+msgstr "Unicode 32 bit Big Endian (UTF-32BE)"
+
+#: ../src/common/fmapbase.cpp:191
+msgid "Extended Unix Codepage for Japanese (EUC-JP)"
+msgstr "Εκτεταμένη Κωδικοσελίδα Unix για Ιαπωνικά (EUC-JP)"
+
+#: ../src/common/fmapbase.cpp:192
+#, fuzzy
+msgid "US-ASCII"
+msgstr "ASCII"
+
+#: ../src/common/fmapbase.cpp:193
+msgid "ISO-2022-JP"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:195
+#, fuzzy
+msgid "MacRoman"
+msgstr "Ρωμαϊκό"
+
+#: ../src/common/fmapbase.cpp:196
+msgid "MacJapanese"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:197
+msgid "MacChineseTrad"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:198
+msgid "MacKorean"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:199
+msgid "MacArabic"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:200
+msgid "MacHebrew"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:201
+msgid "MacGreek"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:202
+msgid "MacCyrillic"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:203
+msgid "MacDevanagari"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:204
+msgid "MacGurmukhi"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:205
+msgid "MacGujarati"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:206
+msgid "MacOriya"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:207
+msgid "MacBengali"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:208
+msgid "MacTamil"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:209
+msgid "MacTelugu"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:210
+msgid "MacKannada"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:211
+msgid "MacMalayalam"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:212
+#, fuzzy
+msgid "MacSinhalese"
+msgstr "Ταίριασμα πεζών/κεφαλαίων"
+
+#: ../src/common/fmapbase.cpp:213
+msgid "MacBurmese"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:214
+msgid "MacKhmer"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:215
+msgid "MacThai"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:216
+msgid "MacLaotian"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:217
+msgid "MacGeorgian"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:218
+msgid "MacArmenian"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:219
+msgid "MacChineseSimp"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:220
+msgid "MacTibetan"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:221
+msgid "MacMongolian"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:222
+msgid "MacEthiopic"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:223
+msgid "MacCentralEurRoman"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:224
+msgid "MacVietnamese"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:225
+msgid "MacExtArabic"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:226
+#, fuzzy
+msgid "MacSymbol"
+msgstr "&Στυλ:"
+
+#: ../src/common/fmapbase.cpp:227
+msgid "MacDingbats"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:228
+msgid "MacTurkish"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:229
+msgid "MacCroatian"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:230
+msgid "MacIcelandic"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:231
+#, fuzzy
+msgid "MacRomanian"
+msgstr "Ρωμαϊκό"
+
+#: ../src/common/fmapbase.cpp:232
+msgid "MacCeltic"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:233
+msgid "MacGaelic"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:234
+msgid "MacKeyboardGlyphs"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:791
+msgid "Default encoding"
+msgstr "Προκαθορισμένη κωδικοποίηση"
+
+#: ../src/common/fmapbase.cpp:805
+#, c-format
+msgid "Unknown encoding (%d)"
+msgstr "’γνωστη κωδικοποίηση (%d)"
+
+#: ../src/common/fmapbase.cpp:815 ../src/richtext/richtextstyles.cpp:776
+msgid "default"
+msgstr "προκαθορισμένο"
+
+#: ../src/common/fmapbase.cpp:829
+#, c-format
+msgid "unknown-%d"
+msgstr "άγνωστο-%d"
+
+#: ../src/common/fontcmn.cpp:924 ../src/common/fontcmn.cpp:1130
+msgid "underlined"
+msgstr "υπογεγραμμένο"
+
+#: ../src/common/fontcmn.cpp:929
+msgid " strikethrough"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:942
+msgid " thin"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:946
+#, fuzzy
+msgid " extra light"
+msgstr "απαλό(light)"
+
+#: ../src/common/fontcmn.cpp:950
+#, fuzzy
+msgid " light"
+msgstr "απαλό(light)"
+
+#: ../src/common/fontcmn.cpp:954
+msgid " medium"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:958
+#, fuzzy
+msgid " semi bold"
+msgstr "έντονο"
+
+#: ../src/common/fontcmn.cpp:962
+#, fuzzy
+msgid " bold"
+msgstr "έντονο"
+
+#: ../src/common/fontcmn.cpp:966
+#, fuzzy
+msgid " extra bold"
+msgstr "έντονο"
+
+#: ../src/common/fontcmn.cpp:970
+msgid " heavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:974
+msgid " extra heavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:990
+#, fuzzy
+msgid " italic"
+msgstr "πλάγιο"
+
+#: ../src/common/fontcmn.cpp:1134
+msgid "strikethrough"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1143
+msgid "thin"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1156
+#, fuzzy
+msgid "extralight"
+msgstr "απαλό(light)"
+
+#: ../src/common/fontcmn.cpp:1161
+msgid "light"
+msgstr "απαλό(light)"
+
+#: ../src/common/fontcmn.cpp:1169 ../src/richtext/richtextstyles.cpp:775
+#, fuzzy
+msgid "normal"
+msgstr "Κανονικό"
+
+#: ../src/common/fontcmn.cpp:1174
+msgid "medium"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1179 ../src/common/fontcmn.cpp:1199
+#, fuzzy
+msgid "semibold"
+msgstr "έντονο"
+
+#: ../src/common/fontcmn.cpp:1184
+msgid "bold"
+msgstr "έντονο"
+
+#: ../src/common/fontcmn.cpp:1194
+#, fuzzy
+msgid "extrabold"
+msgstr "έντονο"
+
+#: ../src/common/fontcmn.cpp:1204
+msgid "heavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1212
+msgid "extraheavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1217
+msgid "italic"
+msgstr "πλάγιο"
+
+#: ../src/common/fontmap.cpp:195
+msgid ": unknown charset"
+msgstr ": άγνωστο σετ χαρακτήρων"
+
+#: ../src/common/fontmap.cpp:199
+#, c-format
+msgid ""
+"The charset '%s' is unknown. You may select\n"
+"another charset to replace it with or choose\n"
+"[Cancel] if it cannot be replaced"
+msgstr ""
+"Το σύνολο χαρακτήρων (charset) '%s' είναι άγνωστο. Μπορείτε να επιλέξετε\n"
+"ένα άλλο σύνολο χαρακτήρων να το αντικαταστήσει ή διαλέξτε\n"
+"[Ακύρωση] εάν δεν μπορεί να αντικατασταθεί"
+
+#: ../src/common/fontmap.cpp:241
+#, c-format
+msgid "Failed to remember the encoding for the charset '%s'."
+msgstr ""
+"Αποτυχία ανάμνησης της κωδικοποίησης για το συνολο χαρακτήρων (charset) '%s'."
+
+#: ../src/common/fontmap.cpp:321
+msgid "can't load any font, aborting"
+msgstr "αδύνατη η φόρτωση οποιασδήποτε γραμματοσειράς, γίνεται ματαίωση"
+
+#: ../src/common/fontmap.cpp:409
+msgid ": unknown encoding"
+msgstr ": άγνωστη κωδικοποίηση"
+
+#: ../src/common/fontmap.cpp:417
+#, c-format
+msgid ""
+"No font for displaying text in encoding '%s' found,\n"
+"but an alternative encoding '%s' is available.\n"
+"Do you want to use this encoding (otherwise you will have to choose another "
+"one)?"
+msgstr ""
+"Δεν βρέθηκε γραμματοσειρά (font) για την εμφάνιση κειμένου στην κωδικοποίηση "
+"(encoding) '%s',\n"
+"αλλά μία εναλλακτική κωδικοποίηση '%s' είναι διαθέισμη.\n"
+"Θέλετε να χρησιμοποιήσετε αυτή την κωδικοποίηση (διαφορετικά θα πρέπει να "
+"επιλέξετε μία άλλη) ;"
+
+#: ../src/common/fontmap.cpp:422
+#, c-format
+msgid ""
+"No font for displaying text in encoding '%s' found.\n"
+"Would you like to select a font to be used for this encoding\n"
+"(otherwise the text in this encoding will not be shown correctly)?"
+msgstr ""
+"Δεν βρέθηκε γραμματοσειρά (font) για την εμφάνιση κειμένου για αυτήν την "
+"κωδικοποίηση (encoding) '%s'.\n"
+"Θα θέλατε να επιλέξετε μία γραμματοσειρα για να χρησιμοποιηθεί για αυτή την "
+"κωδικοποίηση(διαφορετικά το κείμενο σε αυτή την κωδικοποίηση δεν θα "
+"εμφανιστεί κανονικά) ;"
+
+#: ../src/common/fs_mem.cpp:169
+#, c-format
+msgid "Memory VFS already contains file '%s'!"
+msgstr "VFS μνήμης ήδη περιέχει το αρχείο '%s'!"
+
+#: ../src/common/fs_mem.cpp:232
+#, c-format
+msgid "Trying to remove file '%s' from memory VFS, but it is not loaded!"
+msgstr ""
+"Προσπάθεια απομάκρυνσης αρχείου '%s' από VFS μνήμης, αλλά δεν είναι "
+"φορτωμένο!"
+
+#: ../src/common/fs_mem.cpp:262
+#, c-format
+msgid "Failed to store image '%s' to memory VFS!"
+msgstr "Αποτυχία αποθήκευσης της εικόνας '%s' στο VFS μνήμης!"
+
+#: ../src/common/ftp.cpp:197
+msgid "Timeout while waiting for FTP server to connect, try passive mode."
+msgstr ""
+"Τέλος χρόνου κατά την αναμονή για την σύνδεση στον διακομιστή FTP, δοκιμάστε "
+"σε passive mode."
+
+#: ../src/common/ftp.cpp:399
+#, c-format
+msgid "Failed to set FTP transfer mode to %s."
+msgstr "Αποτυχία θέσης FTP transfer mode σε '%s'"
+
+#: ../src/common/ftp.cpp:400 ../src/richtext/richtextsymboldlg.cpp:432
+msgid "ASCII"
+msgstr "ASCII"
+
+#: ../src/common/ftp.cpp:400
+msgid "binary"
+msgstr "δυαδικό"
+
+#: ../src/common/ftp.cpp:608
+msgid "The FTP server doesn't support the PORT command."
+msgstr "Ο διακομιστής FTP δεν υποστηρίζει την εντολή PORT."
+
+#: ../src/common/ftp.cpp:622
+msgid "The FTP server doesn't support passive mode."
+msgstr ""
+"Ο διακομιστής FTP δεν υποστηρίζει κατάσταση λειτουργίας(mode) 'passive'."
+
+#: ../src/common/gifdecod.cpp:822
+#, c-format
+msgid "Incorrect GIF frame size (%u, %d) for the frame #%u"
+msgstr ""
+
+#: ../src/common/glcmn.cpp:108
+#, fuzzy
+msgid "Failed to allocate colour for OpenGL"
+msgstr "Αποτυχία δημιουργίας δείκτη."
+
+#: ../src/common/headerctrlcmn.cpp:57
+msgid "Please select the columns to show and define their order:"
+msgstr ""
+
+#: ../src/common/headerctrlcmn.cpp:58
+#, fuzzy
+msgid "Customize Columns"
+msgstr "μέγεθος γραμματοσειράς"
+
+#: ../src/common/headerctrlcmn.cpp:304
+#, fuzzy
+msgid "&Customize..."
+msgstr "μέγεθος γραμματοσειράς"
+
+#: ../src/common/hyperlnkcmn.cpp:132
+#, fuzzy, c-format
+msgid "Failed to open URL \"%s\" in the default browser"
+msgstr "Αποτυχία ανοίγματος του '%s' για το '%s'"
+
+#: ../src/common/iconbndl.cpp:195
+#, fuzzy, c-format
+msgid "Failed to load image %%d from file '%s'."
+msgstr "Αποτυχία φόρτωσης της εικόνας %d από το αρχείο '%s'."
+
+#: ../src/common/iconbndl.cpp:203
+#, fuzzy, c-format
+msgid "Failed to load image %d from stream."
+msgstr "Αποτυχία φόρτωσης της εικόνας %d από το αρχείο '%s'."
+
+#: ../src/common/iconbndl.cpp:221
+#, fuzzy, c-format
+msgid "Failed to load icons from resource '%s'."
+msgstr "Αποτυχία φόρτωσης της εικόνας %d από το αρχείο '%s'."
+
+#: ../src/common/imagbmp.cpp:97
+msgid "BMP: Couldn't save invalid image."
+msgstr "BMP: Δεν είναι δυνατή η αποθήκευση μη έγκυρης εικόνας."
+
+#: ../src/common/imagbmp.cpp:137
+msgid "BMP: wxImage doesn't have own wxPalette."
+msgstr "BMP: Το wxImage δεν κατέχει κάποιο wxPalette."
+
+#: ../src/common/imagbmp.cpp:243
+msgid "BMP: Couldn't write the file (Bitmap) header."
+msgstr "BMP: Δεν ήταν δυνατή η εγγραφή της κεφαλής του αρχείου Bitmap."
+
+#: ../src/common/imagbmp.cpp:266
+msgid "BMP: Couldn't write the file (BitmapInfo) header."
+msgstr "BMP: Δεν ήταν δυνατή η εγγραφή της κεφαλής του αρχείου BitmapInfo."
+
+#: ../src/common/imagbmp.cpp:353
+msgid "BMP: Couldn't write RGB color map."
+msgstr "BMP: Δεν ήταν δυνατή η εγγραφή του χάρτη RGB."
+
+#: ../src/common/imagbmp.cpp:487
+msgid "BMP: Couldn't write data."
+msgstr "BMP: Δεν ήταν δυνατή η εγγραφή δεδομένων."
+
+#: ../src/common/imagbmp.cpp:561 ../src/common/imagbmp.cpp:642
+msgid "BMP: Couldn't allocate memory."
+msgstr "BMP: Δεν ήταν δυνατή η δέσμευση(allocation) μνήμης."
+
+#: ../src/common/imagbmp.cpp:1041
+msgid "DIB Header: Image width > 32767 pixels for file."
+msgstr ""
+"DIB Header: Το πλάτος της εικόνας είναι > 32767 εικονοστοιχεία για το αρχείο."
+
+#: ../src/common/imagbmp.cpp:1049
+msgid "DIB Header: Image height > 32767 pixels for file."
+msgstr ""
+"DIB Header: Το ύψος της εικόνας είναι > 32767 εικονοστοιχεία για το αρχείο."
+
+#: ../src/common/imagbmp.cpp:1081
+msgid "DIB Header: Unknown bitdepth in file."
+msgstr "DIB Header: Αγνωστο βάθος bit στο αρχείο."
+
+#: ../src/common/imagbmp.cpp:1156
+msgid "DIB Header: Unknown encoding in file."
+msgstr "DIB Header: Αγνωστη κωδικοποίηση στο αρχείο."
+
+#: ../src/common/imagbmp.cpp:1165
+msgid "DIB Header: Encoding doesn't match bitdepth."
+msgstr "DIB Header: Η κωδικοποίηση δεν ταιρίζει με το βάθος bit."
+
+#: ../src/common/imagbmp.cpp:1180
+#, c-format
+msgid "BMP Header: Invalid number of colors (%d)."
+msgstr ""
+
+#: ../src/common/imagbmp.cpp:1273
+#, fuzzy
+msgid "Error in reading image DIB."
+msgstr "Σφάλμα κατά την ανάγνωση εικόνας DIB."
+
+#: ../src/common/imagbmp.cpp:1294
+msgid "ICO: Error in reading mask DIB."
+msgstr "ICO: Σφάλμα στην ανάγνωση μάσκας DIB."
+
+#: ../src/common/imagbmp.cpp:1353
+msgid "ICO: Image too tall for an icon."
+msgstr "ICO: Εικόνα πολύ ψηλή για εικονίδιο(icon)."
+
+#: ../src/common/imagbmp.cpp:1361
+msgid "ICO: Image too wide for an icon."
+msgstr "ICO: Εικόνα πολύ πλατιά για εικονίδιο(icon)."
+
+#: ../src/common/imagbmp.cpp:1388 ../src/common/imagbmp.cpp:1488
+#: ../src/common/imagbmp.cpp:1503 ../src/common/imagbmp.cpp:1514
+#: ../src/common/imagbmp.cpp:1528 ../src/common/imagbmp.cpp:1576
+#: ../src/common/imagbmp.cpp:1591 ../src/common/imagbmp.cpp:1605
+#: ../src/common/imagbmp.cpp:1616
+msgid "ICO: Error writing the image file!"
+msgstr "ICO: Σφάλμα κατά την εγγραφή του αρχείου εικόνας!"
+
+#: ../src/common/imagbmp.cpp:1701
+msgid "ICO: Invalid icon index."
+msgstr "ICO: Λανθασμένος δείκτης(index) εικονιδίου(icon)."
+
+#: ../src/common/image.cpp:2410
+msgid "Image and mask have different sizes."
+msgstr "Εικόνα και μάσκα έχουν διαφορετικά μεγέθη."
+
+#: ../src/common/image.cpp:2418 ../src/common/image.cpp:2459
+msgid "No unused colour in image being masked."
+msgstr ""
+"Δεν υπάρχει μη χρησιμοποιούμενο χρώμα στην εικόνα που εφααρμόζεται η μάσκα"
+
+#: ../src/common/image.cpp:2641
+#, fuzzy, c-format
+msgid "Failed to load bitmap \"%s\" from resources."
+msgstr "Αποτυχία φόρτωσης της εικόνας %d από το αρχείο '%s'."
+
+#: ../src/common/image.cpp:2650
+#, fuzzy, c-format
+msgid "Failed to load icon \"%s\" from resources."
+msgstr "Αποτυχία φόρτωσης της εικόνας %d από το αρχείο '%s'."
+
+#: ../src/common/image.cpp:2728 ../src/common/image.cpp:2747
+#, fuzzy, c-format
+msgid "Failed to load image from file \"%s\"."
+msgstr "Αποτυχία φόρτωσης της εικόνας %d από το αρχείο '%s'."
+
+#: ../src/common/image.cpp:2761
+#, c-format
+msgid "Can't save image to file '%s': unknown extension."
+msgstr ""
+"Δεν είναι δυνατή η αποθήκευση της εικόνας στο αρχείο '%s': άγνωστη επέκταση"
+
+#: ../src/common/image.cpp:2869
+msgid "No handler found for image type."
+msgstr "Δεν βρέθηκε χειριστής για τύπο εικόνας."
+
+#: ../src/common/image.cpp:2877 ../src/common/image.cpp:3000
+#: ../src/common/image.cpp:3066
+#, c-format
+msgid "No image handler for type %d defined."
+msgstr "Δεν έχει οριστεί χειριστής εικόνας για τον τύπο %d."
+
+#: ../src/common/image.cpp:2887
+#, fuzzy, c-format
+msgid "Image file is not of type %d."
+msgstr "Αρχείο εικόνας δεν είναι τύπυ %d."
+
+#: ../src/common/image.cpp:2970
+msgid "Can't automatically determine the image format for non-seekable input."
+msgstr ""
+
+#: ../src/common/image.cpp:2988
+#, fuzzy
+msgid "Unknown image data format."
+msgstr "σφάλμα στη μορφή των δεδομένων"
+
+#: ../src/common/image.cpp:3009
+#, fuzzy, c-format
+msgid "This is not a %s."
+msgstr "PCX: αυτό δεν είναι αρχείο PCX."
+
+#: ../src/common/image.cpp:3032 ../src/common/image.cpp:3080
+#, c-format
+msgid "No image handler for type %s defined."
+msgstr "Δεν έχει οριστεί χειριστής εικόνας για τον τύπο %s."
+
+#: ../src/common/image.cpp:3041
+#, fuzzy, c-format
+msgid "Image is not of type %s."
+msgstr "Αρχείο εικόνας δεν είναι τύπυ %d."
+
+#: ../src/common/image.cpp:3509
+#, fuzzy, c-format
+msgid "Failed to check format of image file \"%s\"."
+msgstr "Αποτυχία αποθήκευσης της εικόνας στο αρχείο \"%s\"."
+
+#: ../src/common/imaggif.cpp:124
+msgid "GIF: error in GIF image format."
+msgstr "GIF: σφάλμα στην μορφή εικόνας GIF."
+
+#: ../src/common/imaggif.cpp:129
+msgid "GIF: not enough memory."
+msgstr "GIF: ανεπαρκής μνήμη."
+
+#: ../src/common/imaggif.cpp:134
+msgid "GIF: data stream seems to be truncated."
+msgstr "GIF: το stream δεδομένων μοιάζει να είναι αποκομμένο."
+
+#: ../src/common/imaggif.cpp:240
+#, fuzzy
+msgid "Couldn't initialize GIF hash table."
+msgstr "Δεν είναι δυνατή η αρχικοποίηση της ροής zlib deflate."
+
+#: ../src/common/imagiff.cpp:739
+msgid "IFF: error in IFF image format."
+msgstr "IFF: σφάλμα στη μορφή εικόνας IFF."
+
+#: ../src/common/imagiff.cpp:742
+msgid "IFF: not enough memory."
+msgstr "IFF: ανεπαρκής μνήμη."
+
+#: ../src/common/imagiff.cpp:745
+msgid "IFF: unknown error!!!"
+msgstr "IFF: άγνωστο λάθος!!!"
+
+#: ../src/common/imagiff.cpp:755
+msgid "IFF: data stream seems to be truncated."
+msgstr "IFF: το stream δεδομένων μοιάζει να είναι αποκομμένο."
+
+#: ../src/common/imagjpeg.cpp:258
+msgid "JPEG: Couldn't load - file is probably corrupted."
+msgstr "JPEG: Αδύνατη η φόρτωση - το αρχείο είναι μάλλον φθαρμένο(corrupted)."
+
+#: ../src/common/imagjpeg.cpp:437
+msgid "JPEG: Couldn't save image."
+msgstr "JPEG: Αδύνατη η αποθήκευση της εικόνας."
+
+#: ../src/common/imagpcx.cpp:439
+msgid "PCX: this is not a PCX file."
+msgstr "PCX: αυτό δεν είναι αρχείο PCX."
+
+#: ../src/common/imagpcx.cpp:453
+msgid "PCX: image format unsupported"
+msgstr "PCX: μορφή εικόνας δεν υποστηρίζεται"
+
+#: ../src/common/imagpcx.cpp:454 ../src/common/imagpcx.cpp:477
+msgid "PCX: couldn't allocate memory"
+msgstr "PCX: Δεν ήταν δυνατή η δέσμευση μνήμης"
+
+#: ../src/common/imagpcx.cpp:455
+msgid "PCX: version number too low"
+msgstr "PCX: αριθμός έκδοσης πολύ χαμηλός"
+
+#: ../src/common/imagpcx.cpp:456 ../src/common/imagpcx.cpp:478
+msgid "PCX: unknown error !!!"
+msgstr "PCX: άγνωστο σφάλμα !!!"
+
+#: ../src/common/imagpcx.cpp:476
+msgid "PCX: invalid image"
+msgstr "PCX: λανθασμένη εικόνα"
+
+#: ../src/common/imagpng.cpp:385
+#, fuzzy, c-format
+msgid "Unknown PNG resolution unit %d"
+msgstr "’γνωστη επιλογή '%s'"
+
+#: ../src/common/imagpng.cpp:439
+msgid "Couldn't load a PNG image - file is corrupted or not enough memory."
+msgstr ""
+"Δεν ήταν δυνατή η φόρτωση εικόνας PNG - είτε το αρχείο δεν είναι έγκυρο ή "
+"δεν υπάρχει αρκετή μνήμη."
+
+#: ../src/common/imagpng.cpp:513 ../src/common/imagpng.cpp:524
+#: ../src/common/imagpng.cpp:534
+msgid "Couldn't save PNG image."
+msgstr "Δεν ήταν δυνατή η αποθήκευση εικόνας PNG."
+
+#: ../src/common/imagpnm.cpp:71
+msgid "PNM: File format is not recognized."
+msgstr "PNM: Η μορφή αρχείου δεν αναγνωρίζεται."
+
+#: ../src/common/imagpnm.cpp:89
+msgid "PNM: Couldn't allocate memory."
+msgstr "PNM: Δεν ήταν δυνατή η δέσμευση μνήμης."
+
+#: ../src/common/imagpnm.cpp:111 ../src/common/imagpnm.cpp:134
+#: ../src/common/imagpnm.cpp:156
+msgid "PNM: File seems truncated."
+msgstr "PNM: Το αρχείο μοιάζει να είναι αποκομμένο."
+
+#: ../src/common/imagtiff.cpp:69
+#, fuzzy, c-format
+msgid " (in module \"%s\")"
+msgstr "tiff module: %s"
+
+#: ../src/common/imagtiff.cpp:304
+msgid "TIFF: Error loading image."
+msgstr "TIFF: Λάθος κατά την φόρτωση εικόνας."
+
+#: ../src/common/imagtiff.cpp:314
+msgid "Invalid TIFF image index."
+msgstr "Λανθασμένος δείκτης εικόνας TIFF."
+
+#: ../src/common/imagtiff.cpp:358
+msgid "TIFF: Image size is abnormally big."
+msgstr ""
+
+#: ../src/common/imagtiff.cpp:372 ../src/common/imagtiff.cpp:385
+#: ../src/common/imagtiff.cpp:769
+msgid "TIFF: Couldn't allocate memory."
+msgstr "TIFF: Αδύνατη η δέσμευση μνήμης."
+
+#: ../src/common/imagtiff.cpp:471
+msgid "TIFF: Error reading image."
+msgstr "TIFF: Λάθος κατά την ανάγνωση εικόνας."
+
+#: ../src/common/imagtiff.cpp:532
+#, c-format
+msgid "Unknown TIFF resolution unit %d ignored"
+msgstr ""
+
+#: ../src/common/imagtiff.cpp:611
+msgid "TIFF: Error saving image."
+msgstr "TIFF: Λάθος κατά την αποθήκευση εικόνας."
+
+#: ../src/common/imagtiff.cpp:868
+msgid "TIFF: Error writing image."
+msgstr "TIFF: Λάθος κατα την εγγραφή εικόνας."
+
+#: ../src/common/imagtiff.cpp:881
+#, fuzzy
+msgid "TIFF: Error flushing data."
+msgstr "TIFF: Λάθος κατά την αποθήκευση εικόνας."
+
+#: ../src/common/imagwebp.cpp:56
+msgid "WebP: Invalid data (failed to get features)."
+msgstr ""
+
+#: ../src/common/imagwebp.cpp:65
+msgid "WebP: Allocating image memory failed."
+msgstr ""
+
+#: ../src/common/imagwebp.cpp:82
+msgid "WebP: Decoding RGBA image data failed."
+msgstr ""
+
+#: ../src/common/imagwebp.cpp:98
+msgid "WebP: Decoding RGB image data failed."
+msgstr ""
+
+#: ../src/common/imagwebp.cpp:113 ../src/common/imagwebp.cpp:201
+msgid "WebP: Allocating stream buffer failed."
+msgstr ""
+
+#: ../src/common/imagwebp.cpp:131
+#, fuzzy
+msgid "WebP: Failed to parse container data."
+msgstr "Αποτυχία θέσης δεδομένων προχείρου (clipboard)."
+
+#: ../src/common/imagwebp.cpp:222
+#, fuzzy
+msgid "WebP: Error decoding animation."
+msgstr "Σφάλμα κατά την ανάγνωση των ρυθμίσεων."
+
+#: ../src/common/imagwebp.cpp:240
+msgid "WebP: Error getting next animation frame."
+msgstr ""
+
+#: ../src/common/init.cpp:172
+#, c-format
+msgid ""
+"Command line argument %d couldn't be converted to Unicode and will be "
+"ignored."
+msgstr ""
+
+#: ../src/common/init.cpp:344
+msgid "Initialization failed in post init, aborting."
+msgstr ""
+
+#: ../src/common/intl.cpp:378
+#, c-format
+msgid "Cannot set locale to language \"%s\"."
+msgstr ""
+
+#: ../src/common/log.cpp:232
+msgid "Error: "
+msgstr "Σφάλμα: "
+
+#: ../src/common/log.cpp:236
+msgid "Warning: "
+msgstr "Προειδοποίηση: "
+
+#: ../src/common/log.cpp:284
+msgid "The previous message repeated once."
+msgstr ""
+
+#: ../src/common/log.cpp:291
+#, c-format
+msgid "The previous message repeated %u time."
+msgid_plural "The previous message repeated %u times."
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../src/common/log.cpp:319
+#, c-format
+msgid "Last repeated message (\"%s\", %u time) wasn't output"
+msgid_plural "Last repeated message (\"%s\", %u times) wasn't output"
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../src/common/log.cpp:435
+#, c-format
+msgid " (error %ld: %s)"
+msgstr " (σφάλμα %ld: %s)"
+
+#: ../src/common/lzmastream.cpp:121
+#, fuzzy
+msgid "Failed to allocate memory for LZMA decompression."
+msgstr "Αποτυχία δημιουργίας δείκτη."
+
+#: ../src/common/lzmastream.cpp:125
+#, c-format
+msgid "Failed to initialize LZMA decompression: unexpected error %u."
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:179
+msgid "input is not in XZ format"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:183
+msgid "input compressed using unknown XZ option"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:188
+msgid "input is corrupted"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:192
+#, fuzzy
+msgid "unknown decompression error"
+msgstr "σφάλμα αποσυμπίεσης"
+
+#: ../src/common/lzmastream.cpp:196
+#, fuzzy, c-format
+msgid "LZMA decompression error: %s"
+msgstr "σφάλμα αποσυμπίεσης"
+
+#: ../src/common/lzmastream.cpp:231
+#, fuzzy
+msgid "Failed to allocate memory for LZMA compression."
+msgstr "Αποτυχία δημιουργίας δείκτη."
+
+#: ../src/common/lzmastream.cpp:235
+#, c-format
+msgid "Failed to initialize LZMA compression: unexpected error %u."
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:267 ../src/common/lzmastream.cpp:342
+#: ../src/html/chm.cpp:336
+msgid "out of memory"
+msgstr "ανεπαρκής μνήμη"
+
+#: ../src/common/lzmastream.cpp:276 ../src/common/lzmastream.cpp:346
+#, fuzzy
+msgid "unknown compression error"
+msgstr "σφάλμα συμπίεσης"
+
+#: ../src/common/lzmastream.cpp:280
+#, fuzzy, c-format
+msgid "LZMA compression error: %s"
+msgstr "σφάλμα συμπίεσης"
+
+#: ../src/common/lzmastream.cpp:350
+#, c-format
+msgid "LZMA compression error when flushing output: %s"
+msgstr ""
+
+#: ../src/common/mimecmn.cpp:167
+#, c-format
+msgid "Unmatched '{' in an entry for mime type %s."
+msgstr "Αταίριαστο '{' σε μία είσοδο (entry) για τον τύπο mime %s."
+
+#: ../src/common/module.cpp:76
+#, c-format
+msgid "Circular dependency involving module \"%s\" detected."
+msgstr ""
+
+#: ../src/common/module.cpp:128
+#, c-format
+msgid "Dependency \"%s\" of module \"%s\" doesn't exist."
+msgstr ""
+
+#: ../src/common/module.cpp:137
+#, c-format
+msgid "Module \"%s\" initialization failed"
+msgstr ""
+
+#: ../src/common/msgout.cpp:96
+#, fuzzy
+msgid "Message"
+msgstr "%s μήνυμα"
+
+#: ../src/common/paper.cpp:70
+msgid "Letter, 8 1/2 x 11 in"
+msgstr "Γράμμα, 8 1/2 x 11 ίντσες"
+
+#: ../src/common/paper.cpp:71
+msgid "Legal, 8 1/2 x 14 in"
+msgstr "Νομικό, 8 1/2 x 14 ίντσες"
+
+#: ../src/common/paper.cpp:72
+msgid "A4 sheet, 210 x 297 mm"
+msgstr "Φύλλο A4, 210 x 297 mm"
+
+#: ../src/common/paper.cpp:73
+msgid "C sheet, 17 x 22 in"
+msgstr "Φύλλο C, 17 x 22 ίντσες"
+
+#: ../src/common/paper.cpp:74
+msgid "D sheet, 22 x 34 in"
+msgstr "D sheet, 22 x 34 ίντσες"
+
+#: ../src/common/paper.cpp:75
+msgid "E sheet, 34 x 44 in"
+msgstr "E sheet, 34 x 44 ίντσες"
+
+#: ../src/common/paper.cpp:76
+msgid "Letter Small, 8 1/2 x 11 in"
+msgstr "Γράμμα Μικρό, 8 1/2 x 11 ίντσες"
+
+#: ../src/common/paper.cpp:77
+msgid "Tabloid, 11 x 17 in"
+msgstr "11 x 17 ίντσες"
+
+#: ../src/common/paper.cpp:78
+msgid "Ledger, 17 x 11 in"
+msgstr "Ledger, 17 x 11 ίντσες"
+
+#: ../src/common/paper.cpp:79
+msgid "Statement, 5 1/2 x 8 1/2 in"
+msgstr "Δήλωση, 5 1/2 x 8 1/2 ίντσες"
+
+#: ../src/common/paper.cpp:80
+msgid "Executive, 7 1/4 x 10 1/2 in"
+msgstr "Executive, 7 1/4 x 10 1/2 ίντσες"
+
+#: ../src/common/paper.cpp:81
+msgid "A3 sheet, 297 x 420 mm"
+msgstr "Φύλλο A3, 297 x 420 mm"
+
+#: ../src/common/paper.cpp:82
+msgid "A4 small sheet, 210 x 297 mm"
+msgstr "Μικρό φύλλο A4, 210 x 297 mm"
+
+#: ../src/common/paper.cpp:83
+msgid "A5 sheet, 148 x 210 mm"
+msgstr "Φύλλο A5, 148 x 210 mm"
+
+#: ../src/common/paper.cpp:84
+msgid "B4 sheet, 250 x 354 mm"
+msgstr "Φύλλο B4, 250 x 354 mm"
+
+#: ../src/common/paper.cpp:85
+msgid "B5 sheet, 182 x 257 millimeter"
+msgstr "Φύλλο B5, 182 x 257 mm"
+
+#: ../src/common/paper.cpp:86
+msgid "Folio, 8 1/2 x 13 in"
+msgstr "Folio, 8 1/2 x 13 ίντσες"
+
+#: ../src/common/paper.cpp:87
+msgid "Quarto, 215 x 275 mm"
+msgstr "Quarto, 215 x 275 mm"
+
+#: ../src/common/paper.cpp:88
+msgid "10 x 14 in"
+msgstr "10 x 14 ίντσες"
+
+#: ../src/common/paper.cpp:89
+msgid "11 x 17 in"
+msgstr "11 x 17 ίντσες"
+
+#: ../src/common/paper.cpp:90
+msgid "Note, 8 1/2 x 11 in"
+msgstr "Σημείωμα, 8 1/2 x 11 ίντσες"
+
+#: ../src/common/paper.cpp:91
+msgid "#9 Envelope, 3 7/8 x 8 7/8 in"
+msgstr "#9 Φάκελος, 3 7/8 x 8 7/8 ίντσες"
+
+#: ../src/common/paper.cpp:92
+msgid "#10 Envelope, 4 1/8 x 9 1/2 in"
+msgstr "#10 Φάκελος, 4 1/8 x 9 1/2 ίντσες"
+
+#: ../src/common/paper.cpp:93
+msgid "#11 Envelope, 4 1/2 x 10 3/8 in"
+msgstr "#11 Φάκελος, 4 1/2 x 10 3/8 ίντσες"
+
+#: ../src/common/paper.cpp:94
+msgid "#12 Envelope, 4 3/4 x 11 in"
+msgstr "#12 Φάκελος, 4 3/4 x 11 ίντσες"
+
+#: ../src/common/paper.cpp:95
+msgid "#14 Envelope, 5 x 11 1/2 in"
+msgstr "#14 Φάκελος, 5 x 11 1/2 ίντσες"
+
+#: ../src/common/paper.cpp:96
+msgid "DL Envelope, 110 x 220 mm"
+msgstr "Φάκελος DL, 110 x 220 mm"
+
+#: ../src/common/paper.cpp:97
+msgid "C5 Envelope, 162 x 229 mm"
+msgstr "C5 Φάκελος, 162 x 229 mm"
+
+#: ../src/common/paper.cpp:98
+msgid "C3 Envelope, 324 x 458 mm"
+msgstr "C3 Φάκελος, 324 x 458 mm"
+
+#: ../src/common/paper.cpp:99
+msgid "C4 Envelope, 229 x 324 mm"
+msgstr "C4 Φάκελος, 229 x 324 mm"
+
+#: ../src/common/paper.cpp:100
+msgid "C6 Envelope, 114 x 162 mm"
+msgstr "C6 Φάκελος, 114 x 162 mm"
+
+#: ../src/common/paper.cpp:101
+msgid "C65 Envelope, 114 x 229 mm"
+msgstr "C65 Φάκελος, 114 x 229 mm"
+
+#: ../src/common/paper.cpp:102
+msgid "B4 Envelope, 250 x 353 mm"
+msgstr "B4 Φάκελος, 250 x 353 mm"
+
+#: ../src/common/paper.cpp:103
+msgid "B5 Envelope, 176 x 250 mm"
+msgstr "B5 Φάκελος, 176 x 250 mm"
+
+#: ../src/common/paper.cpp:104
+msgid "B6 Envelope, 176 x 125 mm"
+msgstr "B6 Φάκελος, 176 x 125 mm"
+
+#: ../src/common/paper.cpp:105
+msgid "Italy Envelope, 110 x 230 mm"
+msgstr "Italy Envelope, 110 x 230 mm"
+
+#: ../src/common/paper.cpp:106
+msgid "Monarch Envelope, 3 7/8 x 7 1/2 in"
+msgstr "Φακελος Monarch, 3 7/8 x 7 1/2 ίντσες"
+
+#: ../src/common/paper.cpp:107
+msgid "6 3/4 Envelope, 3 5/8 x 6 1/2 in"
+msgstr "6 3/4 Φάκελος, 3 5/8 x 6 1/2 ίντσες"
+
+#: ../src/common/paper.cpp:108
+msgid "US Std Fanfold, 14 7/8 x 11 in"
+msgstr "US Std Fanfold, 14 7/8 x 11 ίντσες"
+
+#: ../src/common/paper.cpp:109
+msgid "German Std Fanfold, 8 1/2 x 12 in"
+msgstr "German Std Fanfold, 8 1/2 x 12 ίντσες"
+
+#: ../src/common/paper.cpp:110
+msgid "German Legal Fanfold, 8 1/2 x 13 in"
+msgstr "German Legal Fanfold, 8 1/2 x 13 ίντσες"
+
+#: ../src/common/paper.cpp:112
+#, fuzzy
+msgid "B4 (ISO) 250 x 353 mm"
+msgstr "Φύλλο B4, 250 x 354 mm"
+
+#: ../src/common/paper.cpp:113
+msgid "Japanese Postcard 100 x 148 mm"
+msgstr ""
+
+#: ../src/common/paper.cpp:114
+#, fuzzy
+msgid "9 x 11 in"
+msgstr "11 x 17 ίντσες"
+
+#: ../src/common/paper.cpp:115
+#, fuzzy
+msgid "10 x 11 in"
+msgstr "10 x 14 ίντσες"
+
+#: ../src/common/paper.cpp:116
+#, fuzzy
+msgid "15 x 11 in"
+msgstr "10 x 14 ίντσες"
+
+#: ../src/common/paper.cpp:117
+#, fuzzy
+msgid "Envelope Invite 220 x 220 mm"
+msgstr "Φάκελος DL, 110 x 220 mm"
+
+#: ../src/common/paper.cpp:118
+#, fuzzy
+msgid "Letter Extra 9 1/2 x 12 in"
+msgstr "Γράμμα, 8 1/2 x 11 ίντσες"
+
+#: ../src/common/paper.cpp:119
+#, fuzzy
+msgid "Legal Extra 9 1/2 x 15 in"
+msgstr "Νομικό, 8 1/2 x 14 ίντσες"
+
+#: ../src/common/paper.cpp:120
+#, fuzzy
+msgid "Tabloid Extra 11.69 x 18 in"
+msgstr "11 x 17 ίντσες"
+
+#: ../src/common/paper.cpp:121
+msgid "A4 Extra 9.27 x 12.69 in"
+msgstr ""
+
+#: ../src/common/paper.cpp:122
+#, fuzzy
+msgid "Letter Transverse 8 1/2 x 11 in"
+msgstr "Γράμμα, 8 1/2 x 11 ίντσες"
+
+#: ../src/common/paper.cpp:123
+#, fuzzy
+msgid "A4 Transverse 210 x 297 mm"
+msgstr "Φύλλο A4, 210 x 297 mm"
+
+#: ../src/common/paper.cpp:124
+msgid "Letter Extra Transverse 9.275 x 12 in"
+msgstr ""
+
+#: ../src/common/paper.cpp:125
+msgid "SuperA/SuperA/A4 227 x 356 mm"
+msgstr ""
+
+#: ../src/common/paper.cpp:126
+msgid "SuperB/SuperB/A3 305 x 487 mm"
+msgstr ""
+
+#: ../src/common/paper.cpp:127
+#, fuzzy
+msgid "Letter Plus 8 1/2 x 12.69 in"
+msgstr "Γράμμα, 8 1/2 x 11 ίντσες"
+
+#: ../src/common/paper.cpp:128
+#, fuzzy
+msgid "A4 Plus 210 x 330 mm"
+msgstr "Φύλλο A4, 210 x 297 mm"
+
+#: ../src/common/paper.cpp:129
+#, fuzzy
+msgid "A5 Transverse 148 x 210 mm"
+msgstr "Φύλλο A5, 148 x 210 mm"
+
+#: ../src/common/paper.cpp:130
+#, fuzzy
+msgid "B5 (JIS) Transverse 182 x 257 mm"
+msgstr "Φύλλο B5, 182 x 257 mm"
+
+#: ../src/common/paper.cpp:131
+#, fuzzy
+msgid "A3 Extra 322 x 445 mm"
+msgstr "C3 Φάκελος, 324 x 458 mm"
+
+#: ../src/common/paper.cpp:132
+#, fuzzy
+msgid "A5 Extra 174 x 235 mm"
+msgstr "Φύλλο A5, 148 x 210 mm"
+
+#: ../src/common/paper.cpp:133
+msgid "B5 (ISO) Extra 201 x 276 mm"
+msgstr ""
+
+#: ../src/common/paper.cpp:134
+msgid "A2 420 x 594 mm"
+msgstr ""
+
+#: ../src/common/paper.cpp:135
+#, fuzzy
+msgid "A3 Transverse 297 x 420 mm"
+msgstr "Φύλλο A3, 297 x 420 mm"
+
+#: ../src/common/paper.cpp:136
+#, fuzzy
+msgid "A3 Extra Transverse 322 x 445 mm"
+msgstr "C3 Φάκελος, 324 x 458 mm"
+
+#: ../src/common/paper.cpp:138
+msgid "Japanese Double Postcard 200 x 148 mm"
+msgstr ""
+
+#: ../src/common/paper.cpp:139
+#, fuzzy
+msgid "A6 105 x 148 mm"
+msgstr "10 x 14 ίντσες"
+
+#: ../src/common/paper.cpp:140
+msgid "Japanese Envelope Kaku #2"
+msgstr ""
+
+#: ../src/common/paper.cpp:141
+msgid "Japanese Envelope Kaku #3"
+msgstr ""
+
+#: ../src/common/paper.cpp:142
+msgid "Japanese Envelope Chou #3"
+msgstr ""
+
+#: ../src/common/paper.cpp:143
+msgid "Japanese Envelope Chou #4"
+msgstr ""
+
+#: ../src/common/paper.cpp:144
+#, fuzzy
+msgid "Letter Rotated 11 x 8 1/2 in"
+msgstr "Γράμμα, 8 1/2 x 11 ίντσες"
+
+#: ../src/common/paper.cpp:145
+#, fuzzy
+msgid "A3 Rotated 420 x 297 mm"
+msgstr "Φύλλο A4, 210 x 297 mm"
+
+#: ../src/common/paper.cpp:146
+#, fuzzy
+msgid "A4 Rotated 297 x 210 mm"
+msgstr "Φύλλο A3, 297 x 420 mm"
+
+#: ../src/common/paper.cpp:147
+msgid "A5 Rotated 210 x 148 mm"
+msgstr ""
+
+#: ../src/common/paper.cpp:148
+msgid "B4 (JIS) Rotated 364 x 257 mm"
+msgstr ""
+
+#: ../src/common/paper.cpp:149
+msgid "B5 (JIS) Rotated 257 x 182 mm"
+msgstr ""
+
+#: ../src/common/paper.cpp:150
+msgid "Japanese Postcard Rotated 148 x 100 mm"
+msgstr ""
+
+#: ../src/common/paper.cpp:151
+msgid "Double Japanese Postcard Rotated 148 x 200 mm"
+msgstr ""
+
+#: ../src/common/paper.cpp:152
+#, fuzzy
+msgid "A6 Rotated 148 x 105 mm"
+msgstr "Φύλλο A5, 148 x 210 mm"
+
+#: ../src/common/paper.cpp:153
+msgid "Japanese Envelope Kaku #2 Rotated"
+msgstr ""
+
+#: ../src/common/paper.cpp:154
+msgid "Japanese Envelope Kaku #3 Rotated"
+msgstr ""
+
+#: ../src/common/paper.cpp:155
+msgid "Japanese Envelope Chou #3 Rotated"
+msgstr ""
+
+#: ../src/common/paper.cpp:156
+msgid "Japanese Envelope Chou #4 Rotated"
+msgstr ""
+
+#: ../src/common/paper.cpp:157
+msgid "B6 (JIS) 128 x 182 mm"
+msgstr ""
+
+#: ../src/common/paper.cpp:158
+msgid "B6 (JIS) Rotated 182 x 128 mm"
+msgstr ""
+
+#: ../src/common/paper.cpp:159
+#, fuzzy
+msgid "12 x 11 in"
+msgstr "10 x 14 ίντσες"
+
+#: ../src/common/paper.cpp:160
+msgid "Japanese Envelope You #4"
+msgstr ""
+
+#: ../src/common/paper.cpp:161
+msgid "Japanese Envelope You #4 Rotated"
+msgstr ""
+
+#: ../src/common/paper.cpp:162
+msgid "PRC 16K 146 x 215 mm"
+msgstr ""
+
+#: ../src/common/paper.cpp:163
+msgid "PRC 32K 97 x 151 mm"
+msgstr ""
+
+#: ../src/common/paper.cpp:164
+msgid "PRC 32K(Big) 97 x 151 mm"
+msgstr ""
+
+#: ../src/common/paper.cpp:165
+#, fuzzy
+msgid "PRC Envelope #1 102 x 165 mm"
+msgstr "C6 Φάκελος, 114 x 162 mm"
+
+#: ../src/common/paper.cpp:166
+#, fuzzy
+msgid "PRC Envelope #2 102 x 176 mm"
+msgstr "C6 Φάκελος, 114 x 162 mm"
+
+#: ../src/common/paper.cpp:167
+#, fuzzy
+msgid "PRC Envelope #3 125 x 176 mm"
+msgstr "C6 Φάκελος, 114 x 162 mm"
+
+#: ../src/common/paper.cpp:168
+#, fuzzy
+msgid "PRC Envelope #4 110 x 208 mm"
+msgstr "Φάκελος DL, 110 x 220 mm"
+
+#: ../src/common/paper.cpp:169
+#, fuzzy
+msgid "PRC Envelope #5 110 x 220 mm"
+msgstr "Φάκελος DL, 110 x 220 mm"
+
+#: ../src/common/paper.cpp:170
+#, fuzzy
+msgid "PRC Envelope #6 120 x 230 mm"
+msgstr "C5 Φάκελος, 162 x 229 mm"
+
+#: ../src/common/paper.cpp:171
+#, fuzzy
+msgid "PRC Envelope #7 160 x 230 mm"
+msgstr "B5 Φάκελος, 176 x 250 mm"
+
+#: ../src/common/paper.cpp:172
+#, fuzzy
+msgid "PRC Envelope #8 120 x 309 mm"
+msgstr "C5 Φάκελος, 162 x 229 mm"
+
+#: ../src/common/paper.cpp:173
+#, fuzzy
+msgid "PRC Envelope #9 229 x 324 mm"
+msgstr "C4 Φάκελος, 229 x 324 mm"
+
+#: ../src/common/paper.cpp:174
+#, fuzzy
+msgid "PRC Envelope #10 324 x 458 mm"
+msgstr "C3 Φάκελος, 324 x 458 mm"
+
+#: ../src/common/paper.cpp:175
+msgid "PRC 16K Rotated"
+msgstr ""
+
+#: ../src/common/paper.cpp:176
+msgid "PRC 32K Rotated"
+msgstr ""
+
+#: ../src/common/paper.cpp:177
+msgid "PRC 32K(Big) Rotated"
+msgstr ""
+
+#: ../src/common/paper.cpp:178
+#, fuzzy
+msgid "PRC Envelope #1 Rotated 165 x 102 mm"
+msgstr "C6 Φάκελος, 114 x 162 mm"
+
+#: ../src/common/paper.cpp:179
+#, fuzzy
+msgid "PRC Envelope #2 Rotated 176 x 102 mm"
+msgstr "B6 Φάκελος, 176 x 125 mm"
+
+#: ../src/common/paper.cpp:180
+#, fuzzy
+msgid "PRC Envelope #3 Rotated 176 x 125 mm"
+msgstr "B6 Φάκελος, 176 x 125 mm"
+
+#: ../src/common/paper.cpp:181
+#, fuzzy
+msgid "PRC Envelope #4 Rotated 208 x 110 mm"
+msgstr "C6 Φάκελος, 114 x 162 mm"
+
+#: ../src/common/paper.cpp:182
+#, fuzzy
+msgid "PRC Envelope #5 Rotated 220 x 110 mm"
+msgstr "C4 Φάκελος, 229 x 324 mm"
+
+#: ../src/common/paper.cpp:183
+#, fuzzy
+msgid "PRC Envelope #6 Rotated 230 x 120 mm"
+msgstr "C5 Φάκελος, 162 x 229 mm"
+
+#: ../src/common/paper.cpp:184
+#, fuzzy
+msgid "PRC Envelope #7 Rotated 230 x 160 mm"
+msgstr "C6 Φάκελος, 114 x 162 mm"
+
+#: ../src/common/paper.cpp:185
+#, fuzzy
+msgid "PRC Envelope #8 Rotated 309 x 120 mm"
+msgstr "C4 Φάκελος, 229 x 324 mm"
+
+#: ../src/common/paper.cpp:186
+#, fuzzy
+msgid "PRC Envelope #9 Rotated 324 x 229 mm"
+msgstr "C5 Φάκελος, 162 x 229 mm"
+
+#: ../src/common/paper.cpp:187
+#, fuzzy
+msgid "PRC Envelope #10 Rotated 458 x 324 mm"
+msgstr "C4 Φάκελος, 229 x 324 mm"
+
+#: ../src/common/paper.cpp:192
+#, fuzzy
+msgid "A0 sheet, 841 x 1189 mm"
+msgstr "Φύλλο A4, 210 x 297 mm"
+
+#: ../src/common/paper.cpp:193
+#, fuzzy
+msgid "A1 sheet, 594 x 841 mm"
+msgstr "Φύλλο A3, 297 x 420 mm"
+
+#: ../src/common/preferencescmn.cpp:37
+msgid "General"
+msgstr ""
+
+#: ../src/common/preferencescmn.cpp:40
+msgid "Advanced"
+msgstr ""
+
+#: ../src/common/prntbase.cpp:245
+msgid "Generic PostScript"
+msgstr "Γενικό PostScript"
+
+#: ../src/common/prntbase.cpp:259
+msgid "Ready"
+msgstr "Έτοιμο"
+
+#: ../src/common/prntbase.cpp:331
+msgid "Printing Error"
+msgstr "Σφάλμα Εκτύπωσης"
+
+#: ../src/common/prntbase.cpp:413 ../src/common/prntbase.cpp:1597
+#: ../src/generic/prntdlgg.cpp:135 ../src/generic/prntdlgg.cpp:149
+#: ../src/gtk/print.cpp:628 ../src/gtk/print.cpp:646
+msgid "Print"
+msgstr "Εκτύπωση"
+
+#: ../src/common/prntbase.cpp:471 ../src/generic/prntdlgg.cpp:809
+msgid "Page setup"
+msgstr "Ρύθμιση(setup) Σελίδας"
+
+#: ../src/common/prntbase.cpp:525
+#, fuzzy
+msgid "Please wait while printing..."
+msgstr "Παρακαλώ περιμένετε όσο διαρκεί η εκτύπωση\n"
+
+#: ../src/common/prntbase.cpp:529
+msgid "Document:"
+msgstr ""
+
+#: ../src/common/prntbase.cpp:532
+msgid "Progress:"
+msgstr ""
+
+#: ../src/common/prntbase.cpp:533
+msgid "Preparing"
+msgstr ""
+
+#: ../src/common/prntbase.cpp:552
+#, fuzzy, c-format
+msgid "Printing page %d"
+msgstr "Γίνεται εκτύπωση σελίδας %d..."
+
+#: ../src/common/prntbase.cpp:557
+#, fuzzy, c-format
+msgid "Printing page %d of %d"
+msgstr "Γίνεται εκτύπωση σελίδας %d..."
+
+#: ../src/common/prntbase.cpp:560
+#, fuzzy, c-format
+msgid " (copy %d of %d)"
+msgstr "Σελίδα %d από %d"
+
+#: ../src/common/prntbase.cpp:1604
+#, fuzzy
+msgid "First page"
+msgstr "Επόμενη σελίδα"
+
+#: ../src/common/prntbase.cpp:1609 ../src/html/helpwnd.cpp:659
+msgid "Previous page"
+msgstr "Προηγούμενη σελίδα"
+
+#: ../src/common/prntbase.cpp:1623 ../src/html/helpwnd.cpp:660
+msgid "Next page"
+msgstr "Επόμενη σελίδα"
+
+#: ../src/common/prntbase.cpp:1628
+#, fuzzy
+msgid "Last page"
+msgstr "Επόμενη σελίδα"
+
+#: ../src/common/prntbase.cpp:1636 ../src/common/stockitem.cpp:215
+#, fuzzy
+msgid "Zoom Out"
+msgstr "&Ελάττωση ζουμ"
+
+#: ../src/common/prntbase.cpp:1650 ../src/common/stockitem.cpp:214
+#, fuzzy
+msgid "Zoom In"
+msgstr "&Αύξηση ζουμ"
+
+#: ../src/common/prntbase.cpp:1656 ../src/common/stockitem.cpp:153
+#: ../src/generic/logg.cpp:553 ../src/univ/themes/win32.cpp:3752
+msgid "&Close"
+msgstr "&Κλείσιμο"
+
+#: ../src/common/prntbase.cpp:2085
+msgid "Could not start document preview."
+msgstr "Δεν ήταν δυνατή η εκκίνηση της προεπισκόπησης εγγράφου."
+
+#: ../src/common/prntbase.cpp:2085 ../src/common/prntbase.cpp:2129
+#: ../src/common/prntbase.cpp:2137
+msgid "Print Preview Failure"
+msgstr "Αποτυχία Προεπισκόπησης Εκτύπωσης"
+
+#: ../src/common/prntbase.cpp:2129 ../src/common/prntbase.cpp:2137
+msgid "Sorry, not enough memory to create a preview."
+msgstr "Συγγνώμη, δεν υπάρχει αρκετή μνήμη για την δημιουργία προεπισκόπησης."
+
+#: ../src/common/prntbase.cpp:2144
+#, c-format
+msgid "Page %d of %d"
+msgstr "Σελίδα %d από %d"
+
+#: ../src/common/prntbase.cpp:2146
+#, c-format
+msgid "Page %d"
+msgstr "Σελίδα %d"
+
+#: ../src/common/regex.cpp:382 ../src/html/chm.cpp:348
+msgid "unknown error"
+msgstr "άνωστο λάθος"
+
+#: ../src/common/regex.cpp:995
+#, c-format
+msgid "Invalid regular expression '%s': %s"
+msgstr "Λανθασμένη κανονική έκφραση (regular expression) '%s': %s"
+
+#: ../src/common/regex.cpp:1059
+#, fuzzy, c-format
+msgid "Failed to find match for regular expression: %s"
+msgstr ""
+"Αποτυχία στο συνταίριασμα του '%s' στην κανονική έκφραση (regular "
+"expression): %s"
+
+#: ../src/common/rendcmn.cpp:188
+#, c-format
+msgid "Renderer \"%s\" has incompatible version %d.%d and couldn't be loaded."
+msgstr ""
+"Ο Renderer \"%s\" είναι σε ασύμβατη έκδοση %d.%d και δεν μπορεί να φορτωθεί."
+
+#: ../src/common/secretstore.cpp:162
+msgid "Not available for this platform"
+msgstr ""
+
+#: ../src/common/secretstore.cpp:183
+#, fuzzy, c-format
+msgid "Saving password for \"%s\" failed: %s."
+msgstr "Η εξαγωγή του '%s' στο '%s' απέτυχε"
+
+#: ../src/common/secretstore.cpp:205
+#, fuzzy, c-format
+msgid "Reading password for \"%s\" failed: %s."
+msgstr "Η εξαγωγή του '%s' στο '%s' απέτυχε"
+
+#: ../src/common/secretstore.cpp:228
+#, fuzzy, c-format
+msgid "Deleting password for \"%s\" failed: %s."
+msgstr "Η εξαγωγή του '%s' στο '%s' απέτυχε"
+
+#: ../src/common/selectdispatcher.cpp:254
+msgid "Failed to monitor I/O channels"
+msgstr ""
+
+#: ../src/common/sizer.cpp:3054 ../src/common/stockitem.cpp:195
+msgid "Save"
+msgstr "Αποθήκευση"
+
+#: ../src/common/sizer.cpp:3056
+msgid "Don't Save"
+msgstr ""
+
+#: ../src/common/socket.cpp:870
+#, fuzzy
+msgid "Cannot initialize sockets"
+msgstr "Δεν είναι δυνατή η αρχικοποίηση του OLE"
+
+#: ../src/common/stockitem.cpp:127
+#, fuzzy
+msgctxt "standard Windows menu"
+msgid "&Help"
+msgstr "&Βοήθεια"
+
+#: ../src/common/stockitem.cpp:144
+msgid "&About"
+msgstr "&Περί"
+
+#: ../src/common/stockitem.cpp:144
+#, fuzzy
+msgid "About"
+msgstr "&Περί"
+
+#: ../src/common/stockitem.cpp:145
+msgid "Add"
+msgstr "Προσθήκη"
+
+#: ../src/common/stockitem.cpp:146
+msgid "&Apply"
+msgstr "&Εφαρμογή"
+
+#: ../src/common/stockitem.cpp:146
+#, fuzzy
+msgid "Apply"
+msgstr "&Εφαρμογή"
+
+#: ../src/common/stockitem.cpp:147
+msgid "&Back"
+msgstr "&Πίσω"
+
+#: ../src/common/stockitem.cpp:147
+#, fuzzy
+msgid "Back"
+msgstr "&Πίσω"
+
+#: ../src/common/stockitem.cpp:148
+msgid "&Bold"
+msgstr "&Έντονο"
+
+#: ../src/common/stockitem.cpp:148 ../src/generic/fontdlgg.cpp:326
+#: ../src/richtext/richtextfontpage.cpp:354
+msgid "Bold"
+msgstr "Έντονο"
+
+#: ../src/common/stockitem.cpp:149
+msgid "&Bottom"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:149 ../src/richtext/richtextsizepage.cpp:287
+msgid "Bottom"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:150 ../src/generic/fontdlgg.cpp:462
+#: ../src/generic/fontdlgg.cpp:481 ../src/generic/wizard.cpp:415
+msgid "&Cancel"
+msgstr "&Ακυρο"
+
+#: ../src/common/stockitem.cpp:151
+msgid "&CD-ROM"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:151
+msgid "CD-ROM"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:152
+msgid "&Clear"
+msgstr "&Καθαρισμός"
+
+#: ../src/common/stockitem.cpp:152
+#, fuzzy
+msgid "Clear"
+msgstr "&Καθαρισμός"
+
+#: ../src/common/stockitem.cpp:153 ../src/generic/dbgrptg.cpp:93
+#: ../src/generic/progdlgg.cpp:778 ../src/html/helpdlg.cpp:86
+#: ../src/msw/progdlg.cpp:209 ../src/msw/progdlg.cpp:890
+#: ../src/richtext/richtextstyledlg.cpp:272
+#: ../src/richtext/richtextsymboldlg.cpp:448
+msgid "Close"
+msgstr "Κλείσιμο"
+
+#: ../src/common/stockitem.cpp:154
+#, fuzzy
+msgid "&Convert"
+msgstr "Περιεχόμενα"
+
+#: ../src/common/stockitem.cpp:154
+#, fuzzy
+msgid "Convert"
+msgstr "Περιεχόμενα"
+
+#: ../src/common/stockitem.cpp:155 ../src/msw/textctrl.cpp:2884
+#: ../src/osx/textctrl_osx.cpp:653 ../src/richtext/richtextctrl.cpp:331
+msgid "&Copy"
+msgstr "&Αντιγραφή"
+
+#: ../src/common/stockitem.cpp:155 ../src/stc/stc_i18n.cpp:18
+#, fuzzy
+msgid "Copy"
+msgstr "&Αντιγραφή"
+
+#: ../src/common/stockitem.cpp:156 ../src/msw/textctrl.cpp:2883
+#: ../src/osx/textctrl_osx.cpp:652 ../src/richtext/richtextctrl.cpp:330
+msgid "Cu&t"
+msgstr "Απο&κοπή"
+
+#: ../src/common/stockitem.cpp:156 ../src/stc/stc_i18n.cpp:17
+#, fuzzy
+msgid "Cut"
+msgstr "Απο&κοπή"
+
+#: ../src/common/stockitem.cpp:157 ../src/msw/textctrl.cpp:2886
+#: ../src/osx/textctrl_osx.cpp:655 ../src/richtext/richtextctrl.cpp:333
+#: ../src/richtext/richtexttabspage.cpp:137
+msgid "&Delete"
+msgstr "&Διαγραφή"
+
+#: ../src/common/stockitem.cpp:157 ../src/richtext/richtextbuffer.cpp:8266
+#: ../src/stc/stc_i18n.cpp:20
+#, fuzzy
+msgid "Delete"
+msgstr "&Διαγραφή"
+
+#: ../src/common/stockitem.cpp:158
+msgid "&Down"
+msgstr "&Κάτω"
+
+#: ../src/common/stockitem.cpp:158 ../src/generic/fdrepdlg.cpp:148
+msgid "Down"
+msgstr "Κάτω"
+
+#: ../src/common/stockitem.cpp:159
+msgid "&Edit"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:159
+#, fuzzy
+msgid "Edit"
+msgstr "Επεξεργασία στοιχείου"
+
+#: ../src/common/stockitem.cpp:160
+msgid "&Execute"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:160
+msgid "Execute"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:161
+msgid "&Quit"
+msgstr "Έ&ξοδος"
+
+#: ../src/common/stockitem.cpp:161
+#, fuzzy
+msgid "Quit"
+msgstr "Έ&ξοδος"
+
+#: ../src/common/stockitem.cpp:162
+msgid "&File"
+msgstr "&Αρχείο"
+
+#: ../src/common/stockitem.cpp:162
+msgid "File"
+msgstr "Αρχείο"
+
+#: ../src/common/stockitem.cpp:163
+#, fuzzy
+msgid "&Find..."
+msgstr "&Εύρεση"
+
+#: ../src/common/stockitem.cpp:163
+#, fuzzy
+msgid "Find..."
+msgstr "Εύρεση"
+
+#: ../src/common/stockitem.cpp:164
+#, fuzzy
+msgid "&First"
+msgstr "πρώτο"
+
+#: ../src/common/stockitem.cpp:164
+#, fuzzy
+msgid "First"
+msgstr "πρώτο"
+
+#: ../src/common/stockitem.cpp:165
+#, fuzzy
+msgid "&Floppy"
+msgstr "&Αντιγραφή"
+
+#: ../src/common/stockitem.cpp:165
+#, fuzzy
+msgid "Floppy"
+msgstr "&Αντιγραφή"
+
+#: ../src/common/stockitem.cpp:166
+msgid "&Forward"
+msgstr "&Εμπρός"
+
+#: ../src/common/stockitem.cpp:166
+#, fuzzy
+msgid "Forward"
+msgstr "&Εμπρός"
+
+#: ../src/common/stockitem.cpp:167
+msgid "&Harddisk"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:167
+msgid "Harddisk"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:168 ../src/generic/wizard.cpp:418
+#: ../src/osx/cocoa/menu.mm:225 ../src/richtext/richtextstyledlg.cpp:298
+#: ../src/richtext/richtextsymboldlg.cpp:451
+msgid "&Help"
+msgstr "&Βοήθεια"
+
+#: ../src/common/stockitem.cpp:169
+msgid "&Home"
+msgstr "&Αρχική"
+
+#: ../src/common/stockitem.cpp:169
+msgid "Home"
+msgstr "Αρχική σελίδα"
+
+#: ../src/common/stockitem.cpp:170
+msgid "Indent"
+msgstr "Στοίχιση"
+
+#: ../src/common/stockitem.cpp:171
+msgid "&Index"
+msgstr "&Ευρετήριο"
+
+#: ../src/common/stockitem.cpp:171 ../src/html/helpwnd.cpp:510
+msgid "Index"
+msgstr "Ευρετήριο"
+
+#: ../src/common/stockitem.cpp:172
+#, fuzzy
+msgid "&Info"
+msgstr "&Αναίρεση"
+
+#: ../src/common/stockitem.cpp:172
+msgid "Info"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:173
+msgid "&Italic"
+msgstr "&Πλάγια"
+
+#: ../src/common/stockitem.cpp:173 ../src/generic/fontdlgg.cpp:322
+#: ../src/richtext/richtextfontpage.cpp:350
+msgid "Italic"
+msgstr "Πλάγια"
+
+#: ../src/common/stockitem.cpp:174
+msgid "&Jump to"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:174
+msgid "Jump to"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:175
+msgid "Centered"
+msgstr "Στο κέντρο"
+
+#: ../src/common/stockitem.cpp:176
+msgid "Justified"
+msgstr "Ευθυγραμμισμένα"
+
+#: ../src/common/stockitem.cpp:177
+msgid "Align Left"
+msgstr "Στοίχιση Αριστερά"
+
+#: ../src/common/stockitem.cpp:178
+msgid "Align Right"
+msgstr "Στοίχιση Δεξιά"
+
+#: ../src/common/stockitem.cpp:179
+#, fuzzy
+msgid "&Last"
+msgstr "&Επικόληση"
+
+#: ../src/common/stockitem.cpp:179
+#, fuzzy
+msgid "Last"
+msgstr "&Επικόληση"
+
+#: ../src/common/stockitem.cpp:180
+#, fuzzy
+msgid "&Network"
+msgstr "&Νέο"
+
+#: ../src/common/stockitem.cpp:180
+msgid "Network"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:181 ../src/richtext/richtexttabspage.cpp:131
+msgid "&New"
+msgstr "&Νέο"
+
+#: ../src/common/stockitem.cpp:181
+#, fuzzy
+msgid "New"
+msgstr "&Νέο"
+
+#: ../src/common/stockitem.cpp:182 ../src/msw/msgdlg.cpp:417
+msgid "&No"
+msgstr "&Όχι"
+
+#: ../src/common/stockitem.cpp:183 ../src/generic/fontdlgg.cpp:467
+#: ../src/generic/fontdlgg.cpp:474
+msgid "&OK"
+msgstr "&OK"
+
+#: ../src/common/stockitem.cpp:184 ../src/generic/dbgrptg.cpp:341
+msgid "&Open..."
+msgstr "&Ανοιγμα..."
+
+#: ../src/common/stockitem.cpp:184
+#, fuzzy
+msgid "Open..."
+msgstr "&Ανοιγμα..."
+
+#: ../src/common/stockitem.cpp:185 ../src/msw/textctrl.cpp:2885
+#: ../src/osx/textctrl_osx.cpp:654 ../src/richtext/richtextctrl.cpp:332
+msgid "&Paste"
+msgstr "&Επικόληση"
+
+#: ../src/common/stockitem.cpp:185 ../src/richtext/richtextctrl.cpp:3484
+#: ../src/stc/stc_i18n.cpp:19
+#, fuzzy
+msgid "Paste"
+msgstr "&Επικόληση"
+
+#: ../src/common/stockitem.cpp:186
+msgid "&Preferences"
+msgstr "&Προτιμήσεις"
+
+#: ../src/common/stockitem.cpp:186 ../src/osx/cocoa/preferences.mm:304
+#, fuzzy
+msgid "Preferences"
+msgstr "&Προτιμήσεις"
+
+#: ../src/common/stockitem.cpp:187
+#, fuzzy
+msgid "Print previe&w..."
+msgstr "Π&ροεπισκόπηση εκτύπωσης"
+
+#: ../src/common/stockitem.cpp:187
+#, fuzzy
+msgid "Print preview..."
+msgstr "Προεπισκόπηση εκτύπωσης"
+
+#: ../src/common/stockitem.cpp:188
+msgid "&Print..."
+msgstr "&Εκτύπωση..."
+
+#: ../src/common/stockitem.cpp:188
+#, fuzzy
+msgid "Print..."
+msgstr "&Εκτύπωση..."
+
+#: ../src/common/stockitem.cpp:189 ../src/richtext/richtextctrl.cpp:337
+#: ../src/richtext/richtextctrl.cpp:5479
+msgid "&Properties"
+msgstr "&Ιδιότητες"
+
+#: ../src/common/stockitem.cpp:189
+#, fuzzy
+msgid "Properties"
+msgstr "&Ιδιότητες"
+
+#: ../src/common/stockitem.cpp:190 ../src/stc/stc_i18n.cpp:16
+#, fuzzy
+msgid "Redo"
+msgstr "&Επανάληψη"
+
+#: ../src/common/stockitem.cpp:191
+msgid "Refresh"
+msgstr "Ανανέωση"
+
+#: ../src/common/stockitem.cpp:192
+msgid "Remove"
+msgstr "Απομάκρυνση"
+
+#: ../src/common/stockitem.cpp:193
+#, fuzzy
+msgid "Rep&lace..."
+msgstr "&Αντικατάσταση"
+
+#: ../src/common/stockitem.cpp:193
+#, fuzzy
+msgid "Replace..."
+msgstr "&Αντικατάσταση"
+
+#: ../src/common/stockitem.cpp:194
+msgid "Revert to Saved"
+msgstr "Επαναφορά από το αποθηκευμένο"
+
+#: ../src/common/stockitem.cpp:196 ../src/generic/logg.cpp:549
+msgid "Save &As..."
+msgstr "Αποθήκευση &ως..."
+
+#: ../src/common/stockitem.cpp:196
+#, fuzzy
+msgid "Save As..."
+msgstr "Αποθήκευση &ως..."
+
+#: ../src/common/stockitem.cpp:197 ../src/msw/textctrl.cpp:2888
+#: ../src/osx/textctrl_osx.cpp:657 ../src/richtext/richtextctrl.cpp:335
+msgid "Select &All"
+msgstr "Επιλογή &Ολων"
+
+#: ../src/common/stockitem.cpp:197 ../src/stc/stc_i18n.cpp:21
+#, fuzzy
+msgid "Select All"
+msgstr "Επιλογή &Ολων"
+
+#: ../src/common/stockitem.cpp:198
+#, fuzzy
+msgid "&Color"
+msgstr "&Χρώμα:"
+
+#: ../src/common/stockitem.cpp:198
+#, fuzzy
+msgid "Color"
+msgstr "&Χρώμα:"
+
+#: ../src/common/stockitem.cpp:199
+#, fuzzy
+msgid "&Font"
+msgstr "Οικογένεια γραμματοσειράς:"
+
+#: ../src/common/stockitem.cpp:199 ../src/richtext/richtextformatdlg.cpp:336
+msgid "Font"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:200
+msgid "&Ascending"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:200
+#, fuzzy
+msgid "Ascending"
+msgstr "γίνεται ανάγνωση"
+
+#: ../src/common/stockitem.cpp:201
+msgid "&Descending"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:201
+#, fuzzy
+msgid "Descending"
+msgstr "Προκαθορισμένη κωδικοποίηση"
+
+#: ../src/common/stockitem.cpp:202
+msgid "&Spell Check"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:202
+msgid "Spell Check"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:203
+msgid "&Stop"
+msgstr "&Διακοπή"
+
+#: ../src/common/stockitem.cpp:203
+#, fuzzy
+msgid "Stop"
+msgstr "&Διακοπή"
+
+#: ../src/common/stockitem.cpp:204 ../src/richtext/richtextfontpage.cpp:274
+msgid "&Strikethrough"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:204
+msgid "Strikethrough"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:205
+#, fuzzy
+msgid "&Top"
+msgstr "&Αντιγραφή"
+
+#: ../src/common/stockitem.cpp:205 ../src/richtext/richtextsizepage.cpp:285
+#: ../src/richtext/richtextsizepage.cpp:289
+#, fuzzy
+msgid "Top"
+msgstr "Πρός:"
+
+#: ../src/common/stockitem.cpp:206
+msgid "Undelete"
+msgstr "Αναίρεση διαγραφής"
+
+#: ../src/common/stockitem.cpp:207 ../src/generic/fontdlgg.cpp:437
+msgid "&Underline"
+msgstr "&Υπογράμμιση"
+
+#: ../src/common/stockitem.cpp:207
+#, fuzzy
+msgid "Underline"
+msgstr "&Υπογράμμιση"
+
+#: ../src/common/stockitem.cpp:208 ../src/stc/stc_i18n.cpp:15
+#, fuzzy
+msgid "Undo"
+msgstr "&Αναίρεση"
+
+#: ../src/common/stockitem.cpp:209
+msgid "&Unindent"
+msgstr "Α&ποστοίχιση"
+
+#: ../src/common/stockitem.cpp:209
+#, fuzzy
+msgid "Unindent"
+msgstr "Α&ποστοίχιση"
+
+#: ../src/common/stockitem.cpp:210
+msgid "&Up"
+msgstr "&Επάνω"
+
+#: ../src/common/stockitem.cpp:210 ../src/generic/fdrepdlg.cpp:148
+msgid "Up"
+msgstr "Επάνω"
+
+#: ../src/common/stockitem.cpp:211 ../src/msw/msgdlg.cpp:417
+msgid "&Yes"
+msgstr "&Ναι"
+
+#: ../src/common/stockitem.cpp:212
+msgid "&Actual Size"
+msgstr "&Πραγματικό μέγεθος"
+
+#: ../src/common/stockitem.cpp:212
+#, fuzzy
+msgid "Actual Size"
+msgstr "&Πραγματικό μέγεθος"
+
+#: ../src/common/stockitem.cpp:213
+msgid "Zoom to &Fit"
+msgstr "Βέλτιστο ζουμ"
+
+#: ../src/common/stockitem.cpp:213
+#, fuzzy
+msgid "Zoom to Fit"
+msgstr "Βέλτιστο ζουμ"
+
+#: ../src/common/stockitem.cpp:214
+msgid "Zoom &In"
+msgstr "&Αύξηση ζουμ"
+
+#: ../src/common/stockitem.cpp:215
+msgid "Zoom &Out"
+msgstr "&Ελάττωση ζουμ"
+
+#: ../src/common/stockitem.cpp:262
+msgid "Show about dialog"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:263
+#, fuzzy
+msgid "Copy selection"
+msgstr "Τμήματα"
+
+#: ../src/common/stockitem.cpp:264
+#, fuzzy
+msgid "Cut selection"
+msgstr "Τμήματα"
+
+#: ../src/common/stockitem.cpp:265
+#, fuzzy
+msgid "Delete selection"
+msgstr "Τμήματα"
+
+#: ../src/common/stockitem.cpp:266
+#, fuzzy
+msgid "Find in document"
+msgstr "’νοιγμα εγγράφου HTML"
+
+#: ../src/common/stockitem.cpp:267
+msgid "Find and replace in document"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:268
+#, fuzzy
+msgid "Paste selection"
+msgstr "Τμήματα"
+
+#: ../src/common/stockitem.cpp:269
+#, fuzzy
+msgid "Quit this program"
+msgstr "Εκτύπωση αυτής της σελίδας"
+
+#: ../src/common/stockitem.cpp:270
+msgid "Redo last action"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:271
+msgid "Undo last action"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:272
+#, fuzzy
+msgid "Create new document"
+msgstr "Δημιουργία νέου καταλόγου"
+
+#: ../src/common/stockitem.cpp:273
+#, fuzzy
+msgid "Open an existing document"
+msgstr "’νοιγμα εγγράφου HTML"
+
+#: ../src/common/stockitem.cpp:274
+msgid "Close current document"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:275
+#, fuzzy
+msgid "Save current document"
+msgstr "Επιλέξτε μια προβολή εγγράφων"
+
+#: ../src/common/stockitem.cpp:276
+msgid "Save current document with a different filename"
+msgstr ""
+
+#: ../src/common/strconv.cpp:2324
+#, c-format
+msgid "Conversion to charset '%s' doesn't work."
+msgstr "Η μετατροπή στο σετ χαρακτήρων '%s' δεν λειτουργεί"
+
+#: ../src/common/tarstrm.cpp:352 ../src/common/tarstrm.cpp:375
+#: ../src/common/tarstrm.cpp:406 ../src/generic/progdlgg.cpp:373
+msgid "unknown"
+msgstr "άγνωστο"
+
+#: ../src/common/tarstrm.cpp:774
+msgid "incomplete header block in tar"
+msgstr ""
+
+#: ../src/common/tarstrm.cpp:798
+msgid "checksum failure reading tar header block"
+msgstr ""
+
+#: ../src/common/tarstrm.cpp:971
+msgid "invalid data in extended tar header"
+msgstr ""
+
+#: ../src/common/tarstrm.cpp:981 ../src/common/tarstrm.cpp:1003
+#: ../src/common/tarstrm.cpp:1477 ../src/common/tarstrm.cpp:1499
+msgid "tar entry not open"
+msgstr ""
+
+#: ../src/common/tarstrm.cpp:1023
+#, fuzzy
+msgid "unexpected end of file"
+msgstr "Απροσδόκητο τέλος αρχείου κατά την ανάγνωση πόρου."
+
+#: ../src/common/tarstrm.cpp:1297
+#, c-format
+msgid "%s did not fit the tar header for entry '%s'"
+msgstr ""
+
+#: ../src/common/tarstrm.cpp:1359
+msgid "incorrect size given for tar entry"
+msgstr ""
+
+#: ../src/common/textbuf.cpp:232
+#, c-format
+msgid "'%s' is probably a binary buffer."
+msgstr "'%s' είναι πιθανόν ένας δυαδικός ( binary ) buffer"
+
+#: ../src/common/textcmn.cpp:1006 ../src/richtext/richtextctrl.cpp:3053
+msgid "File couldn't be loaded."
+msgstr "Το αρχείο δεν μπόρεσε να φορτωθεί."
+
+#: ../src/common/textfile.cpp:95
+#, fuzzy, c-format
+msgid "Failed to read text file \"%s\"."
+msgstr "Αποτυχία φόρτωσης της μετα-εικόνας από το αρχείο '%s'."
+
+#: ../src/common/textfile.cpp:160
+#, c-format
+msgid "can't write buffer '%s' to disk."
+msgstr "αδύνατη η εγγραφή της προσωρινής μνήμης (buffer) '%s' στο δίσκο."
+
+#: ../src/common/time.cpp:212
+msgid "Failed to get the local system time"
+msgstr "Αποτυχία καθορισμού της ώρας του τοπικού συστήματος"
+
+#: ../src/common/time.cpp:279
+msgid "wxGetTimeOfDay failed."
+msgstr "το wxGetTimeOfDay απέτυχε."
+
+#: ../src/common/translation.cpp:929
+#, c-format
+msgid "'%s' is not a valid message catalog."
+msgstr "'%s' δεν είναι ένας σωστός κατάλογος μηνυμάτων."
+
+#: ../src/common/translation.cpp:954
+#, fuzzy
+msgid "Invalid message catalog."
+msgstr "'%s' δεν είναι ένας σωστός κατάλογος μηνυμάτων."
+
+#: ../src/common/translation.cpp:1013
+#, fuzzy, c-format
+msgid "Failed to parse Plural-Forms: '%s'"
+msgstr "Δεν είναι δυνατή η ανάγνωση Plural-Forms:'%s'."
+
+#: ../src/common/translation.cpp:1723
+#, c-format
+msgid "using catalog '%s' from '%s'."
+msgstr "χρήση καταλόγου '%s' από '%s'"
+
+#: ../src/common/translation.cpp:1816
+#, fuzzy, c-format
+msgid "Resource '%s' is not a valid message catalog."
+msgstr "'%s' δεν είναι ένας σωστός κατάλογος μηνυμάτων."
+
+#: ../src/common/translation.cpp:1865
+#, fuzzy
+msgid "Couldn't enumerate translations"
+msgstr "Δεν ήταν δυνατός ο τερματισμός του thread"
+
+#: ../src/common/utilscmn.cpp:1145
+msgid "No default application configured for HTML files."
+msgstr ""
+
+#: ../src/common/utilscmn.cpp:1190
+#, fuzzy, c-format
+msgid "Failed to open URL \"%s\" in default browser."
+msgstr "Αποτυχία ανοίγματος του '%s' για το '%s'"
+
+#: ../src/common/valtext.cpp:144
+msgid "Validation conflict"
+msgstr "Σύγκρουση επικύρωσης (validation conflict)"
+
+#: ../src/common/valtext.cpp:186
+msgid "Required information entry is empty."
+msgstr ""
+
+#: ../src/common/valtext.cpp:188
+#, fuzzy, c-format
+msgid "'%s' is one of the invalid strings"
+msgstr "'%s' δεν ισχύει"
+
+#: ../src/common/valtext.cpp:190
+#, fuzzy, c-format
+msgid "'%s' is not one of the valid strings"
+msgstr "'%s' δεν είναι ένας σωστός κατάλογος μηνυμάτων."
+
+#: ../src/common/valtext.cpp:199
+#, fuzzy, c-format
+msgid "'%s' contains invalid character(s)"
+msgstr "'%s' πρέπει να περιέχει μόνο αλφαβητικούς χαρακτήρες."
+
+#: ../src/common/webrequest.cpp:139
+#, fuzzy, c-format
+msgid "Error: %s (%d)"
+msgstr "Σφάλμα: "
+
+#: ../src/common/webrequest.cpp:655
+#, c-format
+msgid ""
+"Not enough free disk space for download: %llu needed but only %llu available."
+msgstr ""
+
+#: ../src/common/webrequest.cpp:669
+#, fuzzy, c-format
+msgid "Failed to create temporary file in %s"
+msgstr "Αποτυχία δημιουργίας ονόματος προσωρινού αρχείου"
+
+#: ../src/common/webrequest_curl.cpp:1106
+#, fuzzy
+msgid "libcurl could not be initialized"
+msgstr "Το αρχείο δεν μπόρεσε να φορτωθεί."
+
+#: ../src/common/webview.cpp:392
+#, fuzzy
+msgid "RunScriptAsync not supported"
+msgstr "Οι μετατροπές strings δεν υποστηρίζονται"
+
+#: ../src/common/webview.cpp:403 ../src/msw/webview_ie.cpp:1073
+#, c-format
+msgid "Error running JavaScript: %s"
+msgstr ""
+
+#: ../src/common/webview_chromium.cpp:858
+#, fuzzy, c-format
+msgid "Failed to set proxy \"%s\": %s"
+msgstr "Απέτυχε η δημιουργία καταλόγου '%s'/.gnome."
+
+#: ../src/common/webview_chromium.cpp:989
+msgid ""
+"Chromium can't be used because libcef.so wasn't loaded early enough; please "
+"relink the application or use LD_PRELOAD to load it earlier."
+msgstr ""
+
+#: ../src/common/webview_chromium.cpp:1108
+#, fuzzy
+msgid "Could not initialize Chromium"
+msgstr "Δεν ήταν δυνατή η εκκίνηση της εκτύπωσης."
+
+#: ../src/common/webview_chromium.cpp:1616
+msgid "Show DevTools"
+msgstr ""
+
+#: ../src/common/webview_chromium.cpp:1617
+#, fuzzy
+msgid "Close DevTools"
+msgstr "Κλείσιμο"
+
+#: ../src/common/webview_chromium.cpp:1623
+msgid "Inspect"
+msgstr ""
+
+#: ../src/common/wincmn.cpp:1628
+msgid "This platform does not support background transparency."
+msgstr ""
+
+#: ../src/common/wincmn.cpp:2097
+msgid "Could not transfer data to window"
+msgstr "Δεν ήταν δυνατή η μεταφορά δεδομένων στο παράθυρο."
+
+#: ../src/common/windowid.cpp:240
+msgid "Out of window IDs.  Recommend shutting down application."
+msgstr ""
+
+#: ../src/common/xpmdecod.cpp:678
+msgid "XPM: incorrect header format!"
+msgstr ""
+
+#: ../src/common/xpmdecod.cpp:703
+#, fuzzy, c-format
+msgid "XPM: incorrect colour description in line %d"
+msgstr "XPM: κακοσχηματισμένος ορισμός χρώματος '%s'!"
+
+#: ../src/common/xpmdecod.cpp:715 ../src/common/xpmdecod.cpp:724
+#, fuzzy, c-format
+msgid "XPM: malformed colour definition '%s' at line %d!"
+msgstr "XPM: κακοσχηματισμένος ορισμός χρώματος '%s'!"
+
+#: ../src/common/xpmdecod.cpp:754
+msgid "XPM: no colors left to use for mask!"
+msgstr ""
+
+#: ../src/common/xpmdecod.cpp:781
+#, c-format
+msgid "XPM: truncated image data at line %d!"
+msgstr ""
+
+#: ../src/common/xpmdecod.cpp:795
+msgid "XPM: Malformed pixel data!"
+msgstr "XPM: Κακοσχηματισμένα δεδομένα εικονοστοιχείων (pixel)!"
+
+#: ../src/common/xti.cpp:492
+msgid "Illegal Parameter Count for Create Method"
+msgstr "Εσφαλμένος αριθμός παραμέτρων για μέθοδο Create"
+
+#: ../src/common/xti.cpp:504
+msgid "Illegal Parameter Count for ConstructObject Method"
+msgstr "Εσφαλμένος αριθμός παραμέτρων για μέθοδο ConstructObject"
+
+#: ../src/common/xtistrm.cpp:161
+#, fuzzy, c-format
+msgid "Create Parameter %s not found in declared RTTI Parameters"
+msgstr "Η παράμετρος Create δεν βρέθηκε στις δηλωμένες παραμέτρους RTTI"
+
+#: ../src/common/xtistrm.cpp:290
+msgid "Illegal Object Class (Non-wxEvtHandler) as Event Source"
+msgstr "Εσφαλμένη κλάση αντικειμένου (μη-wxEvtHandler) σαν πηγή Events"
+
+#: ../src/common/xtistrm.cpp:313 ../src/common/xtixml.cpp:345
+#: ../src/common/xtixml.cpp:498
+msgid "Type must have enum - long conversion"
+msgstr "Ο τύπος πρέπει να έχει μετατροπή enum - long"
+
+#: ../src/common/xtistrm.cpp:400 ../src/common/xtistrm.cpp:415
+msgid "Invalid or Null Object ID passed to GetObjectClassInfo"
+msgstr "Μη έγκυρο ή Null ID αντικειμένου δόθηκε στην GetObjectClassInfo"
+
+#: ../src/common/xtistrm.cpp:405
+msgid "Unknown Object passed to GetObjectClassInfo"
+msgstr "’γνωστο αντικείμενο δόθηκε στην GetObjectClassInfo"
+
+#: ../src/common/xtistrm.cpp:420
+msgid "Already Registered Object passed to SetObjectClassInfo"
+msgstr "Ένα ήδη Registered αντικείμενο δόθηκε στην SetObjectClassInfo"
+
+#: ../src/common/xtistrm.cpp:430
+msgid "Invalid or Null Object ID passed to HasObjectClassInfo"
+msgstr "Μη έγκυρο ή Null ID αντικειμένου δόθηκε στην HasObjectClassInfo"
+
+#: ../src/common/xtistrm.cpp:460
+msgid "Passing a already registered object to SetObject"
+msgstr "Δόθηκε ένα ήδη registered αντικείμενο στην SetObject"
+
+#: ../src/common/xtistrm.cpp:471
+#, fuzzy
+msgid "Passing an unknown object to GetObject"
+msgstr "Δόθηκε ένα άγνωστο αντικείμενο στην GetObject"
+
+#: ../src/common/xtixml.cpp:229
+msgid "Forward hrefs are not supported"
+msgstr "Οι forward hrefs δεν υποστηρίζονται"
+
+#: ../src/common/xtixml.cpp:247
+#, c-format
+msgid "unknown class %s"
+msgstr "άγνωστη κλάση %s"
+
+#: ../src/common/xtixml.cpp:253
+msgid "objects cannot have XML Text Nodes"
+msgstr "τα αντικείμενα δεν μπορούν να έχουν XML κόμβους κειμένου"
+
+#: ../src/common/xtixml.cpp:258
+msgid "Objects must have an id attribute"
+msgstr "Τα αντικείμενα πρέπει να έχουν ένα χαρακτηριστικό id"
+
+#: ../src/common/xtixml.cpp:267
+#, c-format
+msgid "Doubly used id : %d"
+msgstr "Id χρησιμοποιούμενο δύο φορές : %d"
+
+#: ../src/common/xtixml.cpp:316
+#, fuzzy, c-format
+msgid "Unknown Property %s"
+msgstr "’γνωστη Ιδιότητα %s"
+
+#: ../src/common/xtixml.cpp:407
+msgid "A non empty collection must consist of 'element' nodes"
+msgstr "Μία μη άδεια συλλογή πρέπει να αποτελείται από κόμβους 'element'"
+
+#: ../src/common/xtixml.cpp:478
+msgid "incorrect event handler string, missing dot"
+msgstr "εσφαλμένο string χειριστή event, λείπει τελεία"
+
+#: ../src/common/zipstrm.cpp:559
+msgid "can't re-initialize zlib deflate stream"
+msgstr "Δεν είναι δυνατή η αρχικοποίηση της ροής zlib deflate."
+
+#: ../src/common/zipstrm.cpp:584
+msgid "can't re-initialize zlib inflate stream"
+msgstr "Δεν είναι δυνατή η αρχικοποίηση της ροής zlib inflate."
+
+#: ../src/common/zipstrm.cpp:1023
+msgid "Ignoring malformed extra data record, ZIP file may be corrupted"
+msgstr ""
+
+#: ../src/common/zipstrm.cpp:1502
+msgid "assuming this is a multi-part zip concatenated"
+msgstr ""
+
+#: ../src/common/zipstrm.cpp:1664
+msgid "invalid zip file"
+msgstr "μη έγκυρο συμπιεσμένο αρχείο"
+
+#: ../src/common/zipstrm.cpp:1723
+msgid "can't find central directory in zip"
+msgstr ""
+"Δεν είναι δυνατή η εύρεση του κεντρικού καταλόγου στο συμπιεσμένο αρχείο"
+
+#: ../src/common/zipstrm.cpp:1812
+msgid "error reading zip central directory"
+msgstr "σφάλμα κατα την ανάγνωση κεντρικού καταλόγου στο συμπιεσμένο αρχείο"
+
+#: ../src/common/zipstrm.cpp:1916
+msgid "error reading zip local header"
+msgstr "σφάλμα κατά την ανάγνωση τοπικής κεφαλίδας του συμπιεσμένου αρχείου"
+
+#: ../src/common/zipstrm.cpp:1964
+msgid "bad zipfile offset to entry"
+msgstr ""
+
+#: ../src/common/zipstrm.cpp:2031
+msgid "stored file length not in Zip header"
+msgstr "το μήκος του αποθκευμένου αρχείου δεν υπάρχει στην κεφαλίδα Zip"
+
+#: ../src/common/zipstrm.cpp:2045 ../src/common/zipstrm.cpp:2362
+msgid "unsupported Zip compression method"
+msgstr "μη υποστηριζόμενη μέθοδος συμπίεσης Zip"
+
+#: ../src/common/zipstrm.cpp:2126
+#, c-format
+msgid "reading zip stream (entry %s): bad length"
+msgstr "ανάγνωση ροής zip (εγγραφή %s): λανθασμένο μήκος"
+
+#: ../src/common/zipstrm.cpp:2131
+#, c-format
+msgid "reading zip stream (entry %s): bad crc"
+msgstr "ανάγνωση ροής zip (εγγραφή %s): εσφαλμένο crc "
+
+#: ../src/common/zipstrm.cpp:2578
+#, fuzzy, c-format
+msgid "error writing zip entry '%s': file too large without ZIP64"
+msgstr "σφάλμα κατά την εγγραφή αρχείου zip '%s': εσφαλμένο crc ή μήκος"
+
+#: ../src/common/zipstrm.cpp:2585
+#, c-format
+msgid "error writing zip entry '%s': bad crc or length"
+msgstr "σφάλμα κατά την εγγραφή αρχείου zip '%s': εσφαλμένο crc ή μήκος"
+
+#: ../src/common/zstream.cpp:155 ../src/common/zstream.cpp:315
+msgid "Gzip not supported by this version of zlib"
+msgstr "Το Gzip δεν υποστηρίζεται από αυτήν την έκδοση της zlib"
+
+#: ../src/common/zstream.cpp:182
+msgid "Can't initialize zlib inflate stream."
+msgstr "Δεν είναι δυνατή η αρχικοποίηση της ροής zlib inflate."
+
+#: ../src/common/zstream.cpp:241
+msgid "Can't read inflate stream: unexpected EOF in underlying stream."
+msgstr ""
+"Αδύνατη η ανάγνωση της ροής inflate: απρόσμενο EOF στην υποκείμενη ροή."
+
+#: ../src/common/zstream.cpp:248 ../src/common/zstream.cpp:423
+#, c-format
+msgid "zlib error %d"
+msgstr "σφάλμα zlib %d"
+
+#: ../src/common/zstream.cpp:249
+#, c-format
+msgid "Can't read from inflate stream: %s"
+msgstr "Αδύνατη η ανάγνωση από την ροή inflate: %s"
+
+#: ../src/common/zstream.cpp:343
+msgid "Can't initialize zlib deflate stream."
+msgstr "Δεν είναι δυνατή η αρχικοποίηση της ροής zlib deflate."
+
+#: ../src/common/zstream.cpp:424
+#, c-format
+msgid "Can't write to deflate stream: %s"
+msgstr "Δεν είναι δυνατή η εγγραφή στην ροή deflate: %s"
+
+#: ../src/dfb/bitmap.cpp:633 ../src/dfb/bitmap.cpp:667
+#, fuzzy, c-format
+msgid "No bitmap handler for type %d defined."
+msgstr "Δεν έχει οριστεί χειριστής εικόνας για τον τύπο %d."
+
+#: ../src/dfb/evtloop.cpp:99
+#, fuzzy
+msgid "Failed to read event from DirectFB pipe"
+msgstr "Απέτυχε η ανάγνωση PID από αρχείο κλειδωνιά(lock file)."
+
+#: ../src/dfb/evtloop.cpp:171
+msgid "Failed to switch DirectFB pipe to non-blocking mode"
+msgstr ""
+
+#: ../src/dfb/fontmgr.cpp:171
+#, c-format
+msgid "no fonts found in %s, using builtin font"
+msgstr ""
+
+#: ../src/dfb/fontmgr.cpp:177
+#, fuzzy
+msgid "Default font"
+msgstr "Προκαθορισμένος εκτυπωτής"
+
+#: ../src/dfb/fontmgr.cpp:195
+#, c-format
+msgid "Fonts index file %s disappeared while loading fonts."
+msgstr ""
+
+#: ../src/dfb/wrapdfb.cpp:60
+#, c-format
+msgid "DirectFB error %d occurred."
+msgstr ""
+
+#: ../src/generic/aboutdlgg.cpp:69
+msgid "Developed by "
+msgstr ""
+
+#: ../src/generic/aboutdlgg.cpp:72
+msgid "Documentation by "
+msgstr ""
+
+#: ../src/generic/aboutdlgg.cpp:75
+msgid "Graphics art by "
+msgstr ""
+
+#: ../src/generic/aboutdlgg.cpp:78
+msgid "Translations by "
+msgstr ""
+
+#: ../src/generic/aboutdlgg.cpp:133 ../src/osx/cocoa/aboutdlg.mm:83
+#, fuzzy
+msgid "Version "
+msgstr "Δικαιώματα"
+
+#. TRANSLATORS: %s is application name
+#: ../src/generic/aboutdlgg.cpp:146 ../src/msw/aboutdlg.cpp:60
+#, fuzzy, c-format
+msgid "About %s"
+msgstr "&Περί..."
+
+#: ../src/generic/aboutdlgg.cpp:181
+msgid "License"
+msgstr ""
+
+#: ../src/generic/aboutdlgg.cpp:184
+msgid "Developers"
+msgstr ""
+
+#: ../src/generic/aboutdlgg.cpp:188
+msgid "Documentation writers"
+msgstr ""
+
+#: ../src/generic/aboutdlgg.cpp:192
+msgid "Artists"
+msgstr ""
+
+#: ../src/generic/aboutdlgg.cpp:196
+msgid "Translators"
+msgstr ""
+
+#: ../src/generic/animateg.cpp:125
+#, fuzzy
+msgid "No handler found for animation type."
+msgstr "Δεν βρέθηκε χειριστής για τύπο εικόνας."
+
+#: ../src/generic/animateg.cpp:133
+#, fuzzy, c-format
+msgid "No animation handler for type %ld defined."
+msgstr "Δεν έχει οριστεί χειριστής εικόνας για τον τύπο %d."
+
+#: ../src/generic/animateg.cpp:145
+#, fuzzy, c-format
+msgid "Animation file is not of type %ld."
+msgstr "Αρχείο εικόνας δεν είναι τύπυ %d."
+
+#: ../src/generic/colrdlgg.cpp:154 ../src/gtk/colordlg.cpp:47
+msgid "Choose colour"
+msgstr "Επιλέξτε χρώμα"
+
+#: ../src/generic/colrdlgg.cpp:357
+msgid "Red:"
+msgstr ""
+
+#: ../src/generic/colrdlgg.cpp:360
+msgid "Green:"
+msgstr ""
+
+#: ../src/generic/colrdlgg.cpp:363
+msgid "Blue:"
+msgstr ""
+
+#: ../src/generic/colrdlgg.cpp:372
+msgid "Opacity:"
+msgstr ""
+
+#: ../src/generic/colrdlgg.cpp:384
+msgid "Add to custom colours"
+msgstr "Προσθήκη στα χρώματα χρήστη"
+
+#: ../src/generic/creddlgg.cpp:56
+msgid "Username:"
+msgstr ""
+
+#: ../src/generic/creddlgg.cpp:63
+msgid "Password:"
+msgstr ""
+
+#. TRANSLATORS: Name of Boolean true value
+#: ../src/generic/datavgen.cpp:1178
+msgid "true"
+msgstr ""
+
+#. TRANSLATORS: Name of Boolean false value
+#: ../src/generic/datavgen.cpp:1180
+#, fuzzy
+msgid "false"
+msgstr "Αρχείο"
+
+#: ../src/generic/datavgen.cpp:6897
+#, c-format
+msgid "Row %i"
+msgstr ""
+
+#. TRANSLATORS: Action for manipulating a tree control
+#: ../src/generic/datavgen.cpp:6987
+msgid "Collapse"
+msgstr ""
+
+#. TRANSLATORS: Action for manipulating a tree control
+#: ../src/generic/datavgen.cpp:6990
+msgid "Expand"
+msgstr ""
+
+#. TRANSLATORS: Name of data view control and number of rows
+#: ../src/generic/datavgen.cpp:7011
+#, fuzzy, c-format
+msgid "%s (%d items)"
+msgstr "%s (ή %s)"
+
+#: ../src/generic/datavgen.cpp:7062
+#, c-format
+msgid "Column %u"
+msgstr ""
+
+#. TRANSLATORS: Keystroke for manipulating a tree control
+#: ../src/generic/datavgen.cpp:7131 ../src/richtext/richtextbulletspage.cpp:189
+#: ../src/richtext/richtextbulletspage.cpp:192
+#: ../src/richtext/richtextbulletspage.cpp:193
+#: ../src/richtext/richtextliststylepage.cpp:252
+#: ../src/richtext/richtextliststylepage.cpp:255
+#: ../src/richtext/richtextliststylepage.cpp:256
+#: ../src/richtext/richtextsizepage.cpp:248
+msgid "Left"
+msgstr ""
+
+#. TRANSLATORS: Keystroke for manipulating a tree control
+#: ../src/generic/datavgen.cpp:7134 ../src/richtext/richtextbulletspage.cpp:191
+#: ../src/richtext/richtextliststylepage.cpp:254
+#: ../src/richtext/richtextsizepage.cpp:249
+#, fuzzy
+msgid "Right"
+msgstr "Απαλό(light)"
+
+#: ../src/generic/datectlg.cpp:90
+#, c-format
+msgid ""
+"\"%s\" is not in the expected date format, please enter it as e.g. \"%s\"."
+msgstr ""
+
+#: ../src/generic/datectlg.cpp:94
+#, fuzzy
+msgid "Invalid date"
+msgstr "PCX: λανθασμένη εικόνα"
+
+#: ../src/generic/dbgrptg.cpp:159
+#, fuzzy, c-format
+msgid "Open file \"%s\""
+msgstr "Ανοιγμα Αρχείου"
+
+#: ../src/generic/dbgrptg.cpp:170
+#, fuzzy, c-format
+msgid "Enter command to open file \"%s\":"
+msgstr "δεν είναι δυνατό το άνοιγμα του αρχείου '%s'"
+
+#: ../src/generic/dbgrptg.cpp:230
+#, fuzzy
+msgid "Executable files (*.exe)|*.exe|"
+msgstr "Όλα τα αρχεία (*.*)|*.*"
+
+#: ../src/generic/dbgrptg.cpp:300
+#, c-format
+msgid "Debug report \"%s\""
+msgstr ""
+
+#: ../src/generic/dbgrptg.cpp:316
+msgid "A debug report has been generated in the directory\n"
+msgstr ""
+
+#: ../src/generic/dbgrptg.cpp:317
+msgid "The following debug report will be generated\n"
+msgstr ""
+
+#: ../src/generic/dbgrptg.cpp:321
+msgid ""
+"The report contains the files listed below. If any of these files contain "
+"private information,\n"
+"please uncheck them and they will be removed from the report.\n"
+msgstr ""
+
+#: ../src/generic/dbgrptg.cpp:323
+msgid ""
+"If you wish to suppress this debug report completely, please choose the "
+"\"Cancel\" button,\n"
+"but be warned that it may hinder improving the program, so if\n"
+"at all possible please do continue with the report generation.\n"
+msgstr ""
+
+#: ../src/generic/dbgrptg.cpp:325
+msgid "              Thank you and we're sorry for the inconvenience!\n"
+msgstr ""
+
+#: ../src/generic/dbgrptg.cpp:333
+msgid "&Debug report preview:"
+msgstr ""
+
+#: ../src/generic/dbgrptg.cpp:339
+#, fuzzy
+msgid "&View..."
+msgstr "&Ανοιγμα..."
+
+#: ../src/generic/dbgrptg.cpp:359
+#, fuzzy
+msgid "&Notes:"
+msgstr "&Όχι"
+
+#: ../src/generic/dbgrptg.cpp:361
+msgid ""
+"If you have any additional information pertaining to this bug\n"
+"report, please enter it here and it will be joined to it:"
+msgstr ""
+
+#: ../src/generic/dcpsg.cpp:1627
+msgid "Cannot open file for PostScript printing!"
+msgstr "Δεν είναι δυνατό το άνοιγμα του αρχείου για εκτύπωση PostScript!"
+
+#: ../src/generic/dirctrlg.cpp:402
+msgid "Computer"
+msgstr "Υπολογιστής"
+
+#: ../src/generic/dirctrlg.cpp:404
+msgid "Sections"
+msgstr "Τμήματα"
+
+#: ../src/generic/dirctrlg.cpp:482
+msgid "Home directory"
+msgstr "Αρχικός κατάλογος"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/generic/dirctrlg.cpp:484 ../src/propgrid/advprops.cpp:811
+msgid "Desktop"
+msgstr ""
+
+#: ../src/generic/dirctrlg.cpp:528 ../src/generic/filectrlg.cpp:752
+msgid "Illegal directory name."
+msgstr "Μη έγκυρο όνομα καταλόγου."
+
+#: ../src/generic/dirctrlg.cpp:528 ../src/generic/dirctrlg.cpp:546
+#: ../src/generic/dirctrlg.cpp:557 ../src/generic/dirdlgg.cpp:317
+#: ../src/generic/filectrlg.cpp:638 ../src/generic/filectrlg.cpp:752
+#: ../src/generic/filectrlg.cpp:766 ../src/generic/filectrlg.cpp:782
+#: ../src/generic/filectrlg.cpp:1356 ../src/generic/filectrlg.cpp:1387
+#: ../src/generic/filedlgg.cpp:362 ../src/gtk/filedlg.cpp:76
+msgid "Error"
+msgstr "Σφάλμα"
+
+#: ../src/generic/dirctrlg.cpp:546 ../src/generic/filectrlg.cpp:766
+msgid "File name exists already."
+msgstr "Το όνομα αρχείου υπάρχει ήδη."
+
+#: ../src/generic/dirctrlg.cpp:557 ../src/generic/dirdlgg.cpp:317
+#: ../src/generic/filectrlg.cpp:638 ../src/generic/filectrlg.cpp:782
+msgid "Operation not permitted."
+msgstr "Λειτουργία δεν ειπιτρέπετε."
+
+#: ../src/generic/dirdlgg.cpp:107 ../src/generic/filedlgg.cpp:207
+msgid "Create new directory"
+msgstr "Δημιουργία νέου καταλόγου"
+
+#: ../src/generic/dirdlgg.cpp:112 ../src/generic/filedlgg.cpp:203
+msgid "Go to home directory"
+msgstr "Προς κεντρικό κατάλογο"
+
+#: ../src/generic/dirdlgg.cpp:143
+#, fuzzy
+msgid "Show &hidden directories"
+msgstr "Εμφάνιση κρυφών καταλόγων"
+
+#: ../src/generic/dirdlgg.cpp:196
+#, c-format
+msgid ""
+"The directory '%s' does not exist\n"
+"Create it now?"
+msgstr ""
+"Ο κατάλογος '%s' δεν υπάρχει\n"
+"Να δημιουργηθεί τώρα;"
+
+#: ../src/generic/dirdlgg.cpp:198
+msgid "Directory does not exist"
+msgstr "Ο κατάλογος δεν υπάρχει"
+
+#: ../src/generic/dirdlgg.cpp:214
+#, c-format
+msgid ""
+"Failed to create directory '%s'\n"
+"(Do you have the required permissions?)"
+msgstr ""
+"Αποτυχία κατά τη δημιουργία υποκαταλόγου '%s'\n"
+"(Έχετε τα απαιτούμενα δικαιώματα(permissions);)"
+
+#: ../src/generic/dirdlgg.cpp:216
+msgid "Error creating directory"
+msgstr "Σφάλμα κατα τη δημιουργία καταλόγου"
+
+#: ../src/generic/dirdlgg.cpp:281
+msgid "You cannot add a new directory to this section."
+msgstr "Δεν μπορείτε να προσθέσετε καινούργιο κατάλογο σε αυτό το τμήμα."
+
+#: ../src/generic/dirdlgg.cpp:282
+msgid "Create directory"
+msgstr "Δημιουργία καταλόγου"
+
+#: ../src/generic/dirdlgg.cpp:291 ../src/generic/dirdlgg.cpp:301
+#: ../src/generic/filectrlg.cpp:614 ../src/generic/filectrlg.cpp:623
+msgid "NewName"
+msgstr "ΝέοΌνομα"
+
+#: ../src/generic/editlbox.cpp:135
+msgid "Edit item"
+msgstr "Επεξεργασία στοιχείου"
+
+#: ../src/generic/editlbox.cpp:143
+msgid "New item"
+msgstr "Νέο στοιχείο"
+
+#: ../src/generic/editlbox.cpp:151
+msgid "Delete item"
+msgstr "Διαγραφή στοιχείου"
+
+#: ../src/generic/editlbox.cpp:159
+msgid "Move up"
+msgstr "Μετακίνηση επάνω"
+
+#: ../src/generic/editlbox.cpp:164
+msgid "Move down"
+msgstr "Μετακίνηση κάτω"
+
+#: ../src/generic/fdrepdlg.cpp:108
+msgid "Search for:"
+msgstr "Αναζήτηση για:"
+
+#: ../src/generic/fdrepdlg.cpp:120
+msgid "Replace with:"
+msgstr "Αντικατάσταση με:"
+
+#: ../src/generic/fdrepdlg.cpp:140
+msgid "Whole word"
+msgstr "Ολόκληρη λέξη"
+
+#: ../src/generic/fdrepdlg.cpp:143
+msgid "Match case"
+msgstr "Ταίριασμα πεζών/κεφαλαίων"
+
+#: ../src/generic/fdrepdlg.cpp:156
+msgid "Search direction"
+msgstr "Κατεύθυνση αναζήτησης"
+
+#: ../src/generic/fdrepdlg.cpp:175
+msgid "&Replace"
+msgstr "&Αντικατάσταση"
+
+#: ../src/generic/fdrepdlg.cpp:178
+msgid "Replace &all"
+msgstr "Αντικατάσταση &Όλων"
+
+#: ../src/generic/filectrlg.cpp:246 ../src/generic/filectrlg.cpp:269
+msgid "<DIR>"
+msgstr "<ΚΑΤΑΛΟΓΟΣ>"
+
+#: ../src/generic/filectrlg.cpp:248 ../src/generic/filectrlg.cpp:271
+msgid "<LINK>"
+msgstr "<ΣΥΝΔΕΣΗ>"
+
+#: ../src/generic/filectrlg.cpp:250 ../src/generic/filectrlg.cpp:273
+msgid "<DRIVE>"
+msgstr "<ΟΔΗΓΟΣ>"
+
+#: ../src/generic/filectrlg.cpp:275
+#, fuzzy, c-format
+msgid "%ld byte"
+msgid_plural "%ld bytes"
+msgstr[0] "%ld bytes"
+msgstr[1] "%ld bytes"
+
+#: ../src/generic/filectrlg.cpp:420
+msgid "Name"
+msgstr "Όνομα"
+
+#: ../src/generic/filectrlg.cpp:421 ../src/richtext/richtextformatdlg.cpp:361
+#: ../src/richtext/richtextsizepage.cpp:298
+msgid "Size"
+msgstr "Μέγεθος"
+
+#: ../src/generic/filectrlg.cpp:422
+msgid "Type"
+msgstr "Τύπος"
+
+#: ../src/generic/filectrlg.cpp:423
+msgid "Modified"
+msgstr "Τροποποιημένο"
+
+#: ../src/generic/filectrlg.cpp:426
+msgid "Permissions"
+msgstr "Δικαιώματα"
+
+#: ../src/generic/filectrlg.cpp:429
+msgid "Attributes"
+msgstr "Χαρακτηριστικά"
+
+#: ../src/generic/filectrlg.cpp:936
+msgid "Current directory:"
+msgstr "Τρέχον κατάλογος:"
+
+#: ../src/generic/filectrlg.cpp:979
+#, fuzzy
+msgid "Show &hidden files"
+msgstr "Εμφάνιση κρυφών αρχείων."
+
+#: ../src/generic/filectrlg.cpp:1355
+msgid "Illegal file specification."
+msgstr "Μη έγκυρος προσδιορισμός αρχείου."
+
+#: ../src/generic/filectrlg.cpp:1387
+msgid "Directory doesn't exist."
+msgstr "Ο κατάλογος δεν υπάρχει."
+
+#: ../src/generic/filedlgg.cpp:195
+msgid "View files as a list view"
+msgstr "Εμφάνιση αρχείων σε προβολή λίστας"
+
+#: ../src/generic/filedlgg.cpp:197
+msgid "View files as a detailed view"
+msgstr "Εμφάνιση αρχείων σε προβολή με λεπτομέρειες"
+
+#: ../src/generic/filedlgg.cpp:200
+msgid "Go to parent directory"
+msgstr "Προς πατρικό κατάλογο"
+
+#: ../src/generic/filedlgg.cpp:351 ../src/gtk/filedlg.cpp:59
+#, c-format
+msgid "File '%s' already exists, do you really want to overwrite it?"
+msgstr "Το αρχείο '%s' υπάρχει ήδη, πραγματικά θέλετε να επικαλυφτεί;"
+
+#: ../src/generic/filedlgg.cpp:354 ../src/gtk/filedlg.cpp:62
+msgid "Confirm"
+msgstr "Επιβεβαίωση"
+
+#: ../src/generic/filedlgg.cpp:362 ../src/gtk/filedlg.cpp:75
+msgid "Please choose an existing file."
+msgstr "Παρακλώ επιλέξτε ένα υπάρχον αρχείο."
+
+#: ../src/generic/filepickerg.cpp:64
+#, fuzzy
+msgid "..."
+msgstr ".."
+
+#: ../src/generic/fontdlgg.cpp:76 ../src/richtext/richtextformatdlg.cpp:519
+msgid "ABCDEFGabcdefg12345"
+msgstr "ΑΒΓΔΕΖαβγδεζ12345"
+
+#: ../src/generic/fontdlgg.cpp:315
+msgid "Roman"
+msgstr "Ρωμαϊκό"
+
+#: ../src/generic/fontdlgg.cpp:316
+msgid "Decorative"
+msgstr "Διακοσμητικός"
+
+#: ../src/generic/fontdlgg.cpp:317
+msgid "Modern"
+msgstr "Μοντέρνο"
+
+#: ../src/generic/fontdlgg.cpp:318
+msgid "Script"
+msgstr "Χειρόγραφο(Script)"
+
+#: ../src/generic/fontdlgg.cpp:319
+msgid "Swiss"
+msgstr "Ελβετικό(Swiss)"
+
+#: ../src/generic/fontdlgg.cpp:320
+msgid "Teletype"
+msgstr "Τηλέτυπο"
+
+#: ../src/generic/fontdlgg.cpp:321 ../src/generic/fontdlgg.cpp:324
+msgid "Normal"
+msgstr "Κανονικό"
+
+#: ../src/generic/fontdlgg.cpp:323
+msgid "Slant"
+msgstr "Κλήση"
+
+#: ../src/generic/fontdlgg.cpp:325
+msgid "Light"
+msgstr "Απαλό(light)"
+
+#: ../src/generic/fontdlgg.cpp:363
+msgid "&Font family:"
+msgstr "Οικογένεια γραμματοσειράς:"
+
+#: ../src/generic/fontdlgg.cpp:367 ../src/generic/fontdlgg.cpp:369
+msgid "The font family."
+msgstr "Η οικογένεια της γραμματοσειρας."
+
+#: ../src/generic/fontdlgg.cpp:374 ../src/richtext/richtextstylepage.cpp:105
+msgid "&Style:"
+msgstr "&Στυλ:"
+
+#: ../src/generic/fontdlgg.cpp:378 ../src/generic/fontdlgg.cpp:380
+msgid "The font style."
+msgstr "Το στυλ της γραμματοσειράς."
+
+#: ../src/generic/fontdlgg.cpp:385
+msgid "&Weight:"
+msgstr "&Βάρος:"
+
+#: ../src/generic/fontdlgg.cpp:389 ../src/generic/fontdlgg.cpp:391
+msgid "The font weight."
+msgstr "Το βάρος της γραμματοσειράς."
+
+#: ../src/generic/fontdlgg.cpp:399
+msgid "C&olour:"
+msgstr "&Χρώμα:"
+
+#: ../src/generic/fontdlgg.cpp:407 ../src/generic/fontdlgg.cpp:409
+msgid "The font colour."
+msgstr "Το χρώμα της γραμματοσειράς."
+
+#: ../src/generic/fontdlgg.cpp:415
+msgid "&Point size:"
+msgstr "Μέγεθος κουκίδας:"
+
+#: ../src/generic/fontdlgg.cpp:420 ../src/generic/fontdlgg.cpp:422
+#: ../src/generic/fontdlgg.cpp:426 ../src/generic/fontdlgg.cpp:428
+msgid "The font point size."
+msgstr "Το μέγεθος κουκίδας γραμματοσειράς"
+
+#: ../src/generic/fontdlgg.cpp:439 ../src/generic/fontdlgg.cpp:441
+msgid "Whether the font is underlined."
+msgstr "Επιλογή εαν η γραμματοσειρά είναι υπογραμμισμένη ή όχι."
+
+#: ../src/generic/fontdlgg.cpp:448 ../src/html/helpwnd.cpp:1215
+msgid "Preview:"
+msgstr "Προεπισκόπηση:"
+
+#: ../src/generic/fontdlgg.cpp:452 ../src/generic/fontdlgg.cpp:454
+msgid "Shows the font preview."
+msgstr "Εμφανίζει την προεπισκόπηση της γραμματοσειράς"
+
+#: ../src/generic/fontdlgg.cpp:464 ../src/generic/fontdlgg.cpp:483
+msgid "Click to cancel the font selection."
+msgstr "Κάνετε κλικ για να ακυρώσετε την επιλογή γραμματοσειράς."
+
+#: ../src/generic/fontdlgg.cpp:469 ../src/generic/fontdlgg.cpp:471
+#: ../src/generic/fontdlgg.cpp:476 ../src/generic/fontdlgg.cpp:478
+msgid "Click to confirm the font selection."
+msgstr "Κάνετε κλικ για να επιβεβαιώσετε την επιλογή γραμματοσειράς."
+
+#: ../src/generic/fontpickerg.cpp:50 ../src/gtk/fontdlg.cpp:77
+msgid "Choose font"
+msgstr "Επιλέξτε γραμματοσειρά"
+
+#: ../src/generic/grid.cpp:6542
+msgid ""
+"Error copying grid to the clipboard. Either selected cells were not "
+"contiguous or no cell was selected."
+msgstr ""
+
+#: ../src/generic/grid.cpp:12739
+msgid "Grid Corner"
+msgstr ""
+
+#: ../src/generic/grid.cpp:12741
+#, c-format
+msgid "Column %s Header"
+msgstr ""
+
+#: ../src/generic/grid.cpp:12743
+#, c-format
+msgid "Row %s Header"
+msgstr ""
+
+#: ../src/generic/grid.cpp:12745
+#, c-format
+msgid "Column %s: %s"
+msgstr ""
+
+#: ../src/generic/grid.cpp:12749
+#, c-format
+msgid "Row %s: %s"
+msgstr ""
+
+#: ../src/generic/grid.cpp:12753
+#, c-format
+msgid "Row %s, Column %s: %s"
+msgstr ""
+
+#: ../src/generic/helpext.cpp:257
+#, c-format
+msgid "Help directory \"%s\" not found."
+msgstr ""
+
+#: ../src/generic/helpext.cpp:265
+#, fuzzy, c-format
+msgid "Help file \"%s\" not found."
+msgstr "αρχείο καταλόγου για την περιοχή (domain) '%s' δεν βρέθηκε."
+
+#: ../src/generic/helpext.cpp:284
+#, c-format
+msgid "Line %lu of map file \"%s\" has invalid syntax, skipped."
+msgstr ""
+
+#: ../src/generic/helpext.cpp:292
+#, c-format
+msgid "No valid mappings found in the file \"%s\"."
+msgstr ""
+
+#: ../src/generic/helpext.cpp:435
+msgid "No entries found."
+msgstr "Δεν βρέθηκαν εισαγωγές(entries)."
+
+#: ../src/generic/helpext.cpp:444 ../src/generic/helpext.cpp:445
+msgid "Help Index"
+msgstr "Ευρετήριο Βοηθείας"
+
+#: ../src/generic/helpext.cpp:448
+msgid "Relevant entries:"
+msgstr "Σχετικές εγγραφές:"
+
+#: ../src/generic/helpext.cpp:449
+msgid "Entries found"
+msgstr "Εισαγωγές(entries) βρέθηκαν"
+
+#: ../src/generic/hyperlinkg.cpp:170
+#, fuzzy
+msgid "&Copy URL"
+msgstr "&Αντιγραφή"
+
+#: ../src/generic/infobar.cpp:119
+msgid "Hide this notification message."
+msgstr ""
+
+#. TRANSLATORS: %s will be either the application name or "Application"
+#: ../src/generic/logg.cpp:257
+#, c-format
+msgid "%s Error"
+msgstr "%s Σφάλμα"
+
+#. TRANSLATORS: %s will be either the application name or "Application"
+#: ../src/generic/logg.cpp:263
+#, c-format
+msgid "%s Warning"
+msgstr "%s Προειδοποίηση"
+
+#. TRANSLATORS: %s will be either the application name or "Application"
+#: ../src/generic/logg.cpp:273
+#, c-format
+msgid "%s Information"
+msgstr "%s Πληροφορίες"
+
+#: ../src/generic/logg.cpp:276
+#, fuzzy
+msgid "Application"
+msgstr "Τμήματα"
+
+#: ../src/generic/logg.cpp:549
+msgid "Save log contents to file"
+msgstr "Αποθήκευση περιεχομένων καταγραφής(log) σε αρχείο"
+
+#: ../src/generic/logg.cpp:551
+msgid "C&lear"
+msgstr "&Καθάρισμα"
+
+#: ../src/generic/logg.cpp:551
+msgid "Clear the log contents"
+msgstr "Καθαρισμός περιεχομένων καταγραφής(log)"
+
+#: ../src/generic/logg.cpp:553
+msgid "Close this window"
+msgstr "Κλείσιμο αυτού του παραθύρου."
+
+#: ../src/generic/logg.cpp:554
+msgid "&Log"
+msgstr "&Καταγραφή"
+
+#: ../src/generic/logg.cpp:610 ../src/generic/logg.cpp:992
+msgid "Can't save log contents to file."
+msgstr ""
+"Δεν είναι δυνατή η αποθήκευση των περιεχομένων της καταγραφής(log) στο "
+"αρχείο."
+
+#: ../src/generic/logg.cpp:613
+#, c-format
+msgid "Log saved to the file '%s'."
+msgstr "Η καταγραφή (log) αποθηκεύτηκε στο αρχείο '%s'"
+
+#: ../src/generic/logg.cpp:719
+msgid "&Details"
+msgstr "&Λεπτομέρειες"
+
+#: ../src/generic/logg.cpp:972
+#, fuzzy
+msgid "Failed to copy dialog contents to the clipboard."
+msgstr "Αποτυχία ανοίγματος του προχείρου (clipboard)."
+
+#: ../src/generic/logg.cpp:1022
+#, c-format
+msgid "Append log to file '%s' (choosing [No] will overwrite it)?"
+msgstr ""
+"Να γίνει προσάρτηση(append) της καταγραφής(log) στο αρχείο '%s' (Επιλέγοντας "
+"[Όχι] θα το επικαλύψει(overwrite));"
+
+#: ../src/generic/logg.cpp:1024
+msgid "Question"
+msgstr "Ερώτημα"
+
+#: ../src/generic/logg.cpp:1038
+msgid "invalid message box return value"
+msgstr "μη αποδεκτή τιμή επιστροφής παράθυρου μηνύματος"
+
+#: ../src/generic/notifmsgg.cpp:129
+#, fuzzy
+msgid "Notice"
+msgstr "&Όχι"
+
+#: ../src/generic/preferencesg.cpp:118
+#, fuzzy, c-format
+msgid "%s Preferences"
+msgstr "&Προτιμήσεις"
+
+#: ../src/generic/printps.cpp:143
+msgid "Printing..."
+msgstr "Γίνεται εκτύπωση..."
+
+#: ../src/generic/printps.cpp:160 ../src/gtk/print.cpp:1076
+#: ../src/msw/printwin.cpp:235
+msgid "Could not start printing."
+msgstr "Δεν ήταν δυνατή η εκκίνηση της εκτύπωσης."
+
+#: ../src/generic/printps.cpp:183
+#, c-format
+msgid "Printing page %d..."
+msgstr "Γίνεται εκτύπωση σελίδας %d..."
+
+#: ../src/generic/prntdlgg.cpp:171
+msgid "Printer options"
+msgstr "Επιλογές εκτυπωτή"
+
+#: ../src/generic/prntdlgg.cpp:176
+msgid "Print to File"
+msgstr "Εκτύπωση σε Αρχείο"
+
+#: ../src/generic/prntdlgg.cpp:179
+msgid "Setup..."
+msgstr "Ρυθμίσεις..."
+
+#: ../src/generic/prntdlgg.cpp:187
+msgid "Printer:"
+msgstr "Εκτυπωτής:"
+
+#: ../src/generic/prntdlgg.cpp:195
+msgid "Status:"
+msgstr "Κατάσταση: "
+
+#: ../src/generic/prntdlgg.cpp:206
+msgid "All"
+msgstr "Όλα"
+
+#: ../src/generic/prntdlgg.cpp:207
+msgid "Pages"
+msgstr "Σελίδες"
+
+#: ../src/generic/prntdlgg.cpp:215
+msgid "Print Range"
+msgstr "Εύρος εκτύπωσης"
+
+#: ../src/generic/prntdlgg.cpp:229
+msgid "From:"
+msgstr "Από:"
+
+#: ../src/generic/prntdlgg.cpp:233
+msgid "To:"
+msgstr "Πρός:"
+
+#: ../src/generic/prntdlgg.cpp:238
+msgid "Copies:"
+msgstr "Αντίγραφα:"
+
+#: ../src/generic/prntdlgg.cpp:288
+msgid "PostScript file"
+msgstr "Αρχείο PostScript"
+
+#: ../src/generic/prntdlgg.cpp:439
+msgid "Print Setup"
+msgstr "Οργάνωση(setup) Εκτύπωσης"
+
+#: ../src/generic/prntdlgg.cpp:483
+msgid "Printer"
+msgstr "Εκτυπωτής"
+
+#: ../src/generic/prntdlgg.cpp:501
+msgid "Default printer"
+msgstr "Προκαθορισμένος εκτυπωτής"
+
+#: ../src/generic/prntdlgg.cpp:595 ../src/generic/prntdlgg.cpp:782
+#: ../src/generic/prntdlgg.cpp:822 ../src/generic/prntdlgg.cpp:835
+#: ../src/generic/prntdlgg.cpp:1031 ../src/generic/prntdlgg.cpp:1036
+msgid "Paper size"
+msgstr "Μέγεθος χαρτιού"
+
+#: ../src/generic/prntdlgg.cpp:604 ../src/generic/prntdlgg.cpp:847
+msgid "Portrait"
+msgstr "Πορτραίτο"
+
+#: ../src/generic/prntdlgg.cpp:605 ../src/generic/prntdlgg.cpp:848
+msgid "Landscape"
+msgstr "Τοπίο"
+
+#: ../src/generic/prntdlgg.cpp:607 ../src/generic/prntdlgg.cpp:849
+msgid "Orientation"
+msgstr "Προσανατολισμός"
+
+#: ../src/generic/prntdlgg.cpp:610
+msgid "Options"
+msgstr "Επιλογές"
+
+#: ../src/generic/prntdlgg.cpp:612
+msgid "Print in colour"
+msgstr "Εγχρωμη εκτύπωση"
+
+#: ../src/generic/prntdlgg.cpp:621
+msgid "Print spooling"
+msgstr "Spooling εκτύπωσης"
+
+#: ../src/generic/prntdlgg.cpp:623
+msgid "Printer command:"
+msgstr "Εντολή εκτυπωτή:"
+
+#: ../src/generic/prntdlgg.cpp:631
+msgid "Printer options:"
+msgstr "Επιλογές εκτυπωτή:"
+
+#: ../src/generic/prntdlgg.cpp:860
+msgid "Left margin (mm):"
+msgstr "Αριστερό περιθώριο (mm)"
+
+#: ../src/generic/prntdlgg.cpp:861
+msgid "Top margin (mm):"
+msgstr "Πάνω περιθώριο (mm)"
+
+#: ../src/generic/prntdlgg.cpp:872
+msgid "Right margin (mm):"
+msgstr "Δεξί περιθώριο (mm):"
+
+#: ../src/generic/prntdlgg.cpp:873
+msgid "Bottom margin (mm):"
+msgstr "Κάτω περιθώριο (mm)"
+
+#: ../src/generic/prntdlgg.cpp:896
+msgid "Printer..."
+msgstr "Εκτυπωτής..."
+
+#: ../src/generic/progdlgg.cpp:246
+#, fuzzy
+msgid "&Skip"
+msgstr "Παράλειψη"
+
+#: ../src/generic/progdlgg.cpp:347 ../src/generic/progdlgg.cpp:626
+#, fuzzy
+msgid "Unknown"
+msgstr "άγνωστο"
+
+#: ../src/generic/progdlgg.cpp:451 ../src/msw/progdlg.cpp:526
+msgid "Done."
+msgstr "Έτοιμο."
+
+#: ../src/generic/srchctlg.cpp:55 ../src/gtk/srchctrl.cpp:206
+#: ../src/html/helpwnd.cpp:530 ../src/html/helpwnd.cpp:545
+msgid "Search"
+msgstr "Αναζήτηση"
+
+#: ../src/generic/tabg.cpp:1026
+msgid "Could not find tab for id"
+msgstr "Δεν ήταν δυνατή η εύρεση tab για το id"
+
+#: ../src/generic/tipdlg.cpp:136
+msgid "Tips not available, sorry!"
+msgstr "Το Tip δεν είναι διαθέσιμο, συγγνώμη!"
+
+#: ../src/generic/tipdlg.cpp:197
+msgid "Tip of the Day"
+msgstr "Tip της Ημέρας"
+
+#: ../src/generic/tipdlg.cpp:207
+msgid "Did you know..."
+msgstr "Γνωρίζατε ότι..."
+
+#: ../src/generic/tipdlg.cpp:232
+msgid "&Show tips at startup"
+msgstr "&Εμφάνιση tips κατά την εκκίνηση"
+
+#: ../src/generic/tipdlg.cpp:236
+msgid "&Next Tip"
+msgstr "&Επόμενο Tip"
+
+#: ../src/generic/wizard.cpp:411
+msgid "&Next >"
+msgstr "&Επόμενο >"
+
+#: ../src/generic/wizard.cpp:412
+msgid "&Finish"
+msgstr "&Τέλος"
+
+#: ../src/generic/wizard.cpp:420
+msgid "< &Back"
+msgstr "< &Πίσω"
+
+#: ../src/gtk/aboutdlg.cpp:204
+msgid "translator-credits"
+msgstr ""
+
+#: ../src/gtk/app.cpp:517
+msgid ""
+"WARNING: using XIM input method is unsupported and may result in problems "
+"with input handling and flickering. Consider unsetting GTK_IM_MODULE or "
+"setting to \"ibus\"."
+msgstr ""
+
+#: ../src/gtk/app.cpp:569
+msgid "Unable to initialize GTK+, is DISPLAY set properly?"
+msgstr ""
+
+#: ../src/gtk/filedlg.cpp:89 ../src/gtk/filepicker.cpp:255
+#, fuzzy, c-format
+msgid "Changing current directory to \"%s\" failed"
+msgstr "Απέτυχε η δημιουργία καταλόγου '%s'/.gnome."
+
+#: ../src/gtk/font.cpp:548
+msgid ""
+"Using private fonts is not supported on this system: Pango library is too "
+"old, 1.38 or later required."
+msgstr ""
+
+#: ../src/gtk/font.cpp:558
+#, fuzzy
+msgid "Failed to create font configuration object."
+msgstr "Αποτυχία ανανέωσης του αρχείου ρυθμίσεων του χρήστη."
+
+#: ../src/gtk/font.cpp:568
+#, fuzzy, c-format
+msgid "Failed to add custom font \"%s\"."
+msgstr "Αποτυχία φόρτωσης της μετα-εικόνας από το αρχείο '%s'."
+
+#: ../src/gtk/font.cpp:576
+#, fuzzy
+msgid "Failed to register font configuration using private fonts."
+msgstr "Αποτυχία ανανέωσης του αρχείου ρυθμίσεων του χρήστη."
+
+#: ../src/gtk/glcanvas.cpp:117 ../src/gtk/glcanvas.cpp:132
+#, fuzzy
+msgid "Fatal Error"
+msgstr "Μοιραίο σφάλμα"
+
+#: ../src/gtk/glcanvas.cpp:117
+msgid ""
+"This program wasn't compiled with EGL support required under Wayland, "
+"either\n"
+"install EGL libraries and rebuild or run it under X11 backend by setting\n"
+"environment variable GDK_BACKEND=x11 before starting your program."
+msgstr ""
+
+#: ../src/gtk/glcanvas.cpp:132
+msgid ""
+"wxGLCanvas is only supported on Wayland and X11 currently.  You may be able "
+"to\n"
+"work around this by setting environment variable GDK_BACKEND=x11 before\n"
+"starting your program."
+msgstr ""
+
+#: ../src/gtk/mdi.cpp:433
+msgid "MDI child"
+msgstr "MDI παιδί"
+
+#: ../src/gtk/power.cpp:188
+#, fuzzy, c-format
+msgid "Failed to open D-Bus connection to the login manager: %s"
+msgstr "Αποτυχία %s της σύνδεσης μέσω τηλεφώνου : %s"
+
+#: ../src/gtk/power.cpp:214
+#, fuzzy
+msgid "wxWidgets application"
+msgstr "Τμήματα"
+
+#: ../src/gtk/power.cpp:226
+msgid "Application needs to keep running"
+msgstr ""
+
+#: ../src/gtk/power.cpp:233
+msgid "Clean up before suspend"
+msgstr ""
+
+#: ../src/gtk/power.cpp:259
+#, fuzzy, c-format
+msgid "Failed to inhibit sleep: %s"
+msgstr "Αποτυχία τερματισμού της σύνδεσης μέσω τηλεφώνου : %s"
+
+#: ../src/gtk/power.cpp:265
+msgid "Unexpected response to D-Bus \"Inhibit\" request."
+msgstr ""
+
+#: ../src/gtk/print.cpp:218
+#, fuzzy
+msgid "Custom size"
+msgstr "μέγεθος γραμματοσειράς"
+
+#: ../src/gtk/print.cpp:752
+#, fuzzy, c-format
+msgid "Error while printing: %s"
+msgstr "Σφάλμα κατά την αναμονή στη σημαφόρο"
+
+#: ../src/gtk/print.cpp:816
+msgid "Page Setup"
+msgstr "Οργάνωση(setup) Σελίδας"
+
+#: ../src/gtk/webview_webkit.cpp:932
+msgid "Retrieving JavaScript script output is not supported with WebKit v1"
+msgstr ""
+
+#: ../src/gtk/webview_webkit2.cpp:1098
+msgid ""
+"Setting proxy is not supported by WebKit, at least version 2.16 is required."
+msgstr ""
+
+#: ../src/gtk/webview_webkit2.cpp:1104
+msgid "This program was compiled without support for setting WebKit proxy."
+msgstr ""
+
+#: ../src/gtk/window.cpp:6289
+msgid ""
+"GTK+ installed on this machine is too old to support screen compositing, "
+"please install GTK+ 2.12 or later."
+msgstr ""
+
+#: ../src/gtk/window.cpp:6307
+msgid ""
+"Compositing not supported by this system, please enable it in your Window "
+"Manager."
+msgstr ""
+
+#: ../src/gtk/window.cpp:6318
+msgid ""
+"This program was compiled with a too old version of GTK+, please rebuild "
+"with GTK+ 2.12 or newer."
+msgstr ""
+
+#: ../src/html/chm.cpp:138
+#, c-format
+msgid "Failed to open CHM archive '%s'."
+msgstr "Αποτυχία ανοίγματος του arxe;ioy CHM '%s'."
+
+#: ../src/html/chm.cpp:270
+#, c-format
+msgid "Could not extract %s into %s: %s"
+msgstr "Δεν ήταν δυνατή η εξαγωγή του %s στο %s: %s"
+
+#: ../src/html/chm.cpp:324
+msgid "no error"
+msgstr "κανένα λάθος"
+
+#: ../src/html/chm.cpp:326
+msgid "bad arguments to library function"
+msgstr "λανθασμένες παράμετροι σε συνάρτηση βιβλιοθήκης"
+
+#: ../src/html/chm.cpp:328
+msgid "error opening file"
+msgstr "σφάλμα κατά το άνοιγμα του αρχείου"
+
+#: ../src/html/chm.cpp:330
+msgid "read error"
+msgstr "σφάλμα ανάγνωσης"
+
+#: ../src/html/chm.cpp:332
+msgid "write error"
+msgstr "σφάλμα εγγραφής"
+
+#: ../src/html/chm.cpp:334
+msgid "seek error"
+msgstr "σφάλμα εντοπισμού"
+
+#: ../src/html/chm.cpp:338
+msgid "bad signature"
+msgstr "κακή σήμανση"
+
+#: ../src/html/chm.cpp:340
+msgid "error in data format"
+msgstr "σφάλμα στη μορφή των δεδομένων"
+
+#: ../src/html/chm.cpp:342
+msgid "checksum error"
+msgstr "σφάλμα checksum"
+
+#: ../src/html/chm.cpp:344
+msgid "compression error"
+msgstr "σφάλμα συμπίεσης"
+
+#: ../src/html/chm.cpp:346
+msgid "decompression error"
+msgstr "σφάλμα αποσυμπίεσης"
+
+#: ../src/html/chm.cpp:437
+#, c-format
+msgid "Could not locate file '%s'."
+msgstr "Δεν είναι δυνατός ο εντοπισμός του αρχείου '%s'."
+
+#: ../src/html/chm.cpp:711
+#, c-format
+msgid "Could not create temporary file '%s'"
+msgstr "Δεν είναι δυνατή η δημιουργία του προσωρινού αρχείου '%s'"
+
+#: ../src/html/chm.cpp:718
+#, c-format
+msgid "Extraction of '%s' into '%s' failed."
+msgstr "Η εξαγωγή του '%s' στο '%s' απέτυχε"
+
+#: ../src/html/chm.cpp:806 ../src/html/chm.cpp:863
+msgid "CHM handler currently supports only local files!"
+msgstr "ο χειριστής CHM προς το παρόν υποστηρίζει μόνο τοπικά αρχεία!"
+
+#: ../src/html/chm.cpp:827
+msgid "Link contained '//', converted to absolute link."
+msgstr "Η σύνδεση που περιείχε '//', μετατράπηκε σε απόλυτη σύνδεση."
+
+#: ../src/html/helpctrl.cpp:59
+#, c-format
+msgid "Help: %s"
+msgstr "Βοήθεια: %s"
+
+#: ../src/html/helpctrl.cpp:155
+#, c-format
+msgid "Adding book %s"
+msgstr "Προσθήκη βιβλίου %s"
+
+#: ../src/html/helpdata.cpp:295
+#, c-format
+msgid "Cannot open contents file: %s"
+msgstr "Δεν είναι δυνατό το άνοιγμα των περιεχομένων του αρχείου: %s"
+
+#: ../src/html/helpdata.cpp:309
+#, c-format
+msgid "Cannot open index file: %s"
+msgstr "Δεν είναι δυνατό το άνοιγμα του αρχείου ευρετηρίου(index): %s"
+
+#: ../src/html/helpdata.cpp:643
+msgid "noname"
+msgstr "ανώνυμο"
+
+#: ../src/html/helpdata.cpp:652
+#, c-format
+msgid "Cannot open HTML help book: %s"
+msgstr "Δεν είναι δυνατό το άνοιγμα βιβλίου βοήθειας HTML: %s"
+
+#: ../src/html/helpwnd.cpp:315
+msgid "Displays help as you browse the books on the left."
+msgstr ""
+
+#: ../src/html/helpwnd.cpp:411 ../src/html/helpwnd.cpp:1100
+#: ../src/html/helpwnd.cpp:1735
+msgid "(bookmarks)"
+msgstr "(σελιδοδείκτες)"
+
+#: ../src/html/helpwnd.cpp:424
+msgid "Add current page to bookmarks"
+msgstr "Προσθήκη της τρέχουσας σελίδας στους σελιδοδείκτες"
+
+#: ../src/html/helpwnd.cpp:425
+msgid "Remove current page from bookmarks"
+msgstr "Αφαίρεση τρέχουσας σελίδας από τους σελιδοδείκτες"
+
+#: ../src/html/helpwnd.cpp:470
+msgid "Contents"
+msgstr "Περιεχόμενα"
+
+#: ../src/html/helpwnd.cpp:485
+msgid "Find"
+msgstr "Εύρεση"
+
+#: ../src/html/helpwnd.cpp:487
+msgid "Show all"
+msgstr "Εμφάνιση όλων"
+
+#: ../src/html/helpwnd.cpp:497
+msgid ""
+"Display all index items that contain given substring. Search is case "
+"insensitive."
+msgstr ""
+"Εμφάνιση όλων των στοιχείων του ευρετηρίου δεδομένου substring. Η αναζήτηση "
+"διακρίνει μεταξύ κεφαλαίων/πεζών."
+
+#: ../src/html/helpwnd.cpp:498
+msgid "Show all items in index"
+msgstr "Εμφάνιση όλων των στοιχείων στο ευρετήριο"
+
+#: ../src/html/helpwnd.cpp:528
+msgid "Case sensitive"
+msgstr "Διάκριση κεφαλαίων-πεζών"
+
+#: ../src/html/helpwnd.cpp:529
+msgid "Whole words only"
+msgstr "Ολόκληρες λέξεις μόνο"
+
+#: ../src/html/helpwnd.cpp:532
+#, fuzzy
+msgid ""
+"Search contents of help book(s) for all occurrences of the text you typed "
+"above"
+msgstr ""
+"Αναζήτηση στα περιεχόμενα του/των βιβλίου/βιβλίων βοηθείας για όλες τις "
+"εμφανίσεις του κειμένου που γράψατε επάνω"
+
+#: ../src/html/helpwnd.cpp:653
+msgid "Show/hide navigation panel"
+msgstr "Εμφλανιση/Κρύψιμο πλαίσιο πλοήγησης (navigation panel)"
+
+#: ../src/html/helpwnd.cpp:655
+msgid "Go back"
+msgstr "Πήγαινε πίσω"
+
+#: ../src/html/helpwnd.cpp:656
+msgid "Go forward"
+msgstr "Πήγαινε εμπρός"
+
+#: ../src/html/helpwnd.cpp:658
+msgid "Go one level up in document hierarchy"
+msgstr "Πήγαινε ένα επίπεδο πάνω στην ιεραρχεία του εγγράφου"
+
+#: ../src/html/helpwnd.cpp:666 ../src/html/helpwnd.cpp:1547
+msgid "Open HTML document"
+msgstr "’νοιγμα εγγράφου HTML"
+
+#: ../src/html/helpwnd.cpp:670
+msgid "Print this page"
+msgstr "Εκτύπωση αυτής της σελίδας"
+
+#: ../src/html/helpwnd.cpp:674
+msgid "Display options dialog"
+msgstr "Εμφάνιση του διαλόγου επιλογών"
+
+#: ../src/html/helpwnd.cpp:795
+msgid "Please choose the page to display:"
+msgstr "Παρακλώ επιλέξτε την σελίδα για απεικόνιση:"
+
+#: ../src/html/helpwnd.cpp:796
+msgid "Help Topics"
+msgstr "Θέματα Βοήθειας"
+
+#: ../src/html/helpwnd.cpp:852
+msgid "Searching..."
+msgstr "Γίνεται αναζήτηση..."
+
+#: ../src/html/helpwnd.cpp:853
+msgid "No matching page found yet"
+msgstr "Δεν βρέθηκε ακόμα σελίδα που να ταιράζει"
+
+#: ../src/html/helpwnd.cpp:870
+#, c-format
+msgid "Found %i matches"
+msgstr "Βρέθηκαν %i αντιστοιχίες"
+
+#: ../src/html/helpwnd.cpp:958
+msgid "(Help)"
+msgstr "(Βοήθεια)"
+
+#: ../src/html/helpwnd.cpp:1026
+#, fuzzy, c-format
+msgid "%d of %lu"
+msgstr "%i από %i"
+
+#: ../src/html/helpwnd.cpp:1028
+#, fuzzy, c-format
+msgid "%lu of %lu"
+msgstr "%i από %i"
+
+#: ../src/html/helpwnd.cpp:1047
+msgid "Search in all books"
+msgstr "Εύρεση σε όλα τα βιβλία"
+
+#: ../src/html/helpwnd.cpp:1193
+msgid "Help Browser Options"
+msgstr "Επιλογές Περιηγητή Βοηθείας"
+
+#: ../src/html/helpwnd.cpp:1198
+msgid "Normal font:"
+msgstr "Κανονική γραμματοσειρά:"
+
+#: ../src/html/helpwnd.cpp:1199
+msgid "Fixed font:"
+msgstr "Γραμματοσειρά σταθερού μεγέθους:"
+
+#: ../src/html/helpwnd.cpp:1200
+msgid "Font size:"
+msgstr "Μέγεθος γραμματοσειράς:"
+
+#: ../src/html/helpwnd.cpp:1245
+msgid "font size"
+msgstr "μέγεθος γραμματοσειράς"
+
+#: ../src/html/helpwnd.cpp:1256
+msgid "Normal face<br>and <u>underlined</u>. "
+msgstr "Κανονική όψη<br>και <u>υπογραμμισμένη</u>."
+
+#: ../src/html/helpwnd.cpp:1257
+msgid "<i>Italic face.</i> "
+msgstr "<i>Πλάγια όψη."
+
+#: ../src/html/helpwnd.cpp:1258
+msgid "<b>Bold face.</b> "
+msgstr "<b>Έντονη όψη</b>"
+
+#: ../src/html/helpwnd.cpp:1259
+msgid "<b><i>Bold italic face.</i></b><br>"
+msgstr "<b><i>Εντονη πλάγια όψη.</i></b><br>"
+
+#: ../src/html/helpwnd.cpp:1262
+msgid "Fixed size face.<br> <b>bold</b> <i>italic</i> "
+msgstr "Όψη σταθερού μεγέθους.<br> <b>έντονη</b> <i>πλάγια</i> "
+
+#: ../src/html/helpwnd.cpp:1263
+msgid "<b><i>bold italic <u>underlined</u></i></b><br>"
+msgstr "<b><i>έντονα πλάγια <u>υπογραμμισμένα</u></i></b><br>"
+
+#: ../src/html/helpwnd.cpp:1524
+msgid "Help Printing"
+msgstr "Βοήθεια Εκτύπωσης"
+
+#: ../src/html/helpwnd.cpp:1527
+msgid "Cannot print empty page."
+msgstr "Δεν είναι δυνατή η εκτύπωση άδειας σελίδας."
+
+#: ../src/html/helpwnd.cpp:1540
+msgid "HTML files (*.html;*.htm)|*.html;*.htm|"
+msgstr "Αρχεία HTML (*.html;*.htm)|*.html;*.htm|"
+
+#: ../src/html/helpwnd.cpp:1541
+msgid "Help books (*.htb)|*.htb|Help books (*.zip)|*.zip|"
+msgstr "Βιβλία βοήθειας (*.htb)|*.htb|Αρχεία βοήθειας (*.zip)|*.zip|"
+
+#: ../src/html/helpwnd.cpp:1542
+msgid "HTML Help Project (*.hhp)|*.hhp|"
+msgstr "Εργασία HTML βοήθειας (*.hhp)|*.hhp|"
+
+#: ../src/html/helpwnd.cpp:1544
+msgid "Compressed HTML Help file (*.chm)|*.chm|"
+msgstr "Αρχείο βοήθειας συμπιεσμένης HTML (*.chm)|*.chm|"
+
+#: ../src/html/helpwnd.cpp:1671
+#, fuzzy, c-format
+msgid "%i of %u"
+msgstr "%i από %i"
+
+#: ../src/html/helpwnd.cpp:1709
+#, fuzzy, c-format
+msgid "%u of %u"
+msgstr "%i από %i"
+
+#: ../src/html/htmlfilt.cpp:134
+#, c-format
+msgid "Cannot open HTML document: %s"
+msgstr "Δεν είναι δυνατό το άνοιγμα εγγράφου HTML: %s"
+
+#: ../src/html/htmlwin.cpp:599
+msgid "Connecting..."
+msgstr "Γίνεται σύνδεση..."
+
+#: ../src/html/htmlwin.cpp:616
+#, c-format
+msgid "Unable to open requested HTML document: %s"
+msgstr "Δεν είναι δυνατό το άνοιγμα εγγράφου HTML: %s"
+
+#: ../src/html/htmlwin.cpp:630
+msgid "Loading : "
+msgstr "Γίνεται φόρτωση : "
+
+#: ../src/html/htmlwin.cpp:673
+msgid "Done"
+msgstr "Έτοιμο"
+
+#: ../src/html/htmlwin.cpp:723
+#, c-format
+msgid "HTML anchor %s does not exist."
+msgstr "Η HTML άγκυρα %s δεν υπάρχει."
+
+#: ../src/html/htmlwin.cpp:1057
+#, c-format
+msgid "Copied to clipboard:\"%s\""
+msgstr "Αντιγράφηκε στο πρόχειρο:\"%s\""
+
+#: ../src/html/htmprint.cpp:269
+msgid ""
+"This document doesn't fit on the page horizontally and will be truncated "
+"when it is printed."
+msgstr ""
+
+#: ../src/html/htmprint.cpp:285
+#, c-format
+msgid ""
+"The document \"%s\" doesn't fit on the page horizontally and will be "
+"truncated if printed.\n"
+"\n"
+"Would you like to proceed with printing it nevertheless?"
+msgstr ""
+
+#: ../src/html/htmprint.cpp:296
+msgid ""
+"If possible, try changing the layout parameters to make the printout more "
+"narrow."
+msgstr ""
+
+#: ../src/html/htmprint.cpp:445
+msgid ": file does not exist!"
+msgstr ": το αρχείο δεν υπάρχει!"
+
+#. TRANSLATORS: %s may be a document title.
+#: ../src/html/htmprint.cpp:717
+#, fuzzy, c-format
+msgid "%s Preview"
+msgstr " Προεπισκόπηση"
+
+#: ../src/html/htmprint.cpp:755 ../src/richtext/richtextprint.cpp:618
+msgid ""
+"There was a problem during page setup: you may need to set a default printer."
+msgstr ""
+"Υπήρξε πρόβλημα κατά την διάρκεια οργάνωσης δελίδας (page setup): ίσως να "
+"χρειαστεί να θέσετε έναν προεπιλεγμένο (default) εκτυπωτή."
+
+#: ../src/msw/clipbrd.cpp:80
+msgid "Failed to open the clipboard."
+msgstr "Αποτυχία ανοίγματος του προχείρου (clipboard)."
+
+#: ../src/msw/clipbrd.cpp:101
+msgid "Failed to close the clipboard."
+msgstr "Αποτυχία κλεισίματος του προχείρου(clipboard)"
+
+#: ../src/msw/clipbrd.cpp:113
+msgid "Failed to empty the clipboard."
+msgstr "Αποτυχία αδειάσματος του προχείρου (clipboard)."
+
+#: ../src/msw/clipbrd.cpp:284
+msgid "Failed to put data on the clipboard"
+msgstr "Αποτυχία τοποθέτησης δεδομένων στο πρόχειρο (clipboard)"
+
+#: ../src/msw/clipbrd.cpp:326
+msgid "Failed to get data from the clipboard"
+msgstr "Αποτυχία λήψης δεδομένων απο το πρόχειρο"
+
+#: ../src/msw/clipbrd.cpp:363
+msgid "Failed to retrieve the supported clipboard formats"
+msgstr ""
+"Αποτυχία στην ανάκτηση των υποστηριζομένων μορφών προχείρου (clipboard "
+"formats)"
+
+#: ../src/msw/colordlg.cpp:228
+#, fuzzy, c-format
+msgid "Colour selection dialog failed with error %0lx."
+msgstr "Η εκτέλεση της εντολής '%s' απέτυχε με σφάλμα: %ul"
+
+#: ../src/msw/cursor.cpp:141
+msgid "Failed to create cursor."
+msgstr "Αποτυχία δημιουργίας δείκτη."
+
+#: ../src/msw/dde.cpp:279
+#, c-format
+msgid "Failed to register DDE server '%s'"
+msgstr "Απέτυχε η καταχώρηση του DDE εξυπηρετητή (server) '%s'"
+
+#: ../src/msw/dde.cpp:300
+#, c-format
+msgid "Failed to unregister DDE server '%s'"
+msgstr ""
+"Αποτυχία απο-καταχώρησης (unregister) του DDE εξυπηρετητή (server) '%s'"
+
+#: ../src/msw/dde.cpp:428
+#, c-format
+msgid "Failed to create connection to server '%s' on topic '%s'"
+msgstr ""
+"Αποτυχία κατά την δημιουργία σύνδεσης με τον εξυπηρετητή (server) '%s' στο "
+"θέμα '%s'"
+
+#: ../src/msw/dde.cpp:655
+msgid "DDE poke request failed"
+msgstr "Η DDE poke αίτηση απέτυχε"
+
+#: ../src/msw/dde.cpp:674
+msgid "Failed to establish an advise loop with DDE server"
+msgstr "Αποτυχία επίτευξης βρόχου advise με τον διακομιστή DDE"
+
+#: ../src/msw/dde.cpp:693
+msgid "Failed to terminate the advise loop with DDE server"
+msgstr "Αποτυχία τερματισμού του advise loop με τον DDE εξυπηρετητή (server)"
+
+#: ../src/msw/dde.cpp:768
+msgid "Failed to send DDE advise notification"
+msgstr "Αποτυχία κατά την αποστολή DDE advise επισήμανσης"
+
+#: ../src/msw/dde.cpp:1085
+msgid "Failed to create DDE string"
+msgstr "Απέτυχε η δημιουργεία ενός DDE αλφαρηθμιτικού (string)"
+
+#: ../src/msw/dde.cpp:1131
+msgid "no DDE error."
+msgstr "κανένα λάθος DDE"
+
+#: ../src/msw/dde.cpp:1135
+msgid "a request for a synchronous advise transaction has timed out."
+msgstr ""
+"μία αίτηση για σύγχρονη(synchronous) ενημερωτική(advise) "
+"συναλλαγή(transaction) ξεπέρασε το χρονικό περιθώριο (timed out)"
+
+#: ../src/msw/dde.cpp:1138
+msgid "the response to the transaction caused the DDE_FBUSY bit to be set."
+msgstr "η απάντηση στη συναλλαγή ανάγκασε το DDE_FBUSY bit να τεθεί."
+
+#: ../src/msw/dde.cpp:1141
+msgid "a request for a synchronous data transaction has timed out."
+msgstr ""
+"μία αίτηση για σύγχρονη(synchronous) συναλλαγή(transaction) δεδομένων(data) "
+"ξεπέρασε το χρονικό περιθώριο (timed out)"
+
+#: ../src/msw/dde.cpp:1144
+msgid ""
+"a DDEML function was called without first calling the DdeInitialize "
+"function,\n"
+"or an invalid instance identifier\n"
+"was passed to a DDEML function."
+msgstr ""
+"μια συνάρτηση(function) DDEML κλήθηκε χώρις πρώτα να καλέσει την "
+"DdeInitialize συνάρτηση(function),\n"
+"ή ένα λανθασμένο αναγνωριστικό(identifier) instance\n"
+"δόθηκε σε μια DDEML συνάρτηση(function)."
+
+#: ../src/msw/dde.cpp:1147
+msgid ""
+"an application initialized as APPCLASS_MONITOR has\n"
+"attempted to perform a DDE transaction,\n"
+"or an application initialized as APPCMD_CLIENTONLY has \n"
+"attempted to perform server transactions."
+msgstr ""
+"μία εφαρμογή που αρχικοποιήθηκε ως APPCLASS_MONITOR\n"
+"προσπάθησε να κάνει μια συναλλαγή (transaction) DDE,\n"
+"ή μία εφαρμογή που αρχικοποιήθηκε ως APPCMD_CLIENTONLY\n"
+"προσπάθησε να κάνει συναλλαγές εξυπηρετητή (server transactions)."
+
+#: ../src/msw/dde.cpp:1150
+msgid "a request for a synchronous execute transaction has timed out."
+msgstr ""
+"μία αίτηση για σύγχρονη(synchronous) συναλλαγή(transaction) "
+"εκτέλεσης(execute) ξεπέρασε το χρονικό περιθώριο (timed out)"
+
+#: ../src/msw/dde.cpp:1153
+msgid "a parameter failed to be validated by the DDEML."
+msgstr "απέτυχε η επικύρωση μιας παραμέτρου από το DDEML."
+
+#: ../src/msw/dde.cpp:1156
+msgid "a DDEML application has created a prolonged race condition."
+msgstr "μια DDEML εφαρμογή έχει δημιουργήσει έναν παρατεταμένο race condition."
+
+#: ../src/msw/dde.cpp:1159
+msgid "a memory allocation failed."
+msgstr "μία προσπάθεια δέσμευσης (allocation) μνήμης απέτυχε."
+
+#: ../src/msw/dde.cpp:1162
+msgid "a client's attempt to establish a conversation has failed."
+msgstr ""
+"η προσπάθεια ενός πελάτη(client) να εδραιώσει(establish) μία "
+"συνδιάλεξη(conversation) απέτυχε."
+
+#: ../src/msw/dde.cpp:1165
+msgid "a transaction failed."
+msgstr "μία συναλλαγή (transaction) απέτυχε."
+
+#: ../src/msw/dde.cpp:1168
+msgid "a request for a synchronous poke transaction has timed out."
+msgstr ""
+"μία αίτηση για σύγχρονη(synchronous) poke συναλλαγή(transaction) ξεπέρασε το "
+"χρονικό περιθώριο (timed out)"
+
+#: ../src/msw/dde.cpp:1171
+msgid "an internal call to the PostMessage function has failed. "
+msgstr "μία εσωτερική κλήση στην συνάρτηση (function) PostMessage απέτυχε."
+
+#: ../src/msw/dde.cpp:1174
+msgid "reentrancy problem."
+msgstr "πρόβλημα επανεισαγωγής (reentrancy problem)."
+
+#: ../src/msw/dde.cpp:1177
+msgid ""
+"a server-side transaction was attempted on a conversation\n"
+"that was terminated by the client, or the server\n"
+"terminated before completing a transaction."
+msgstr ""
+"αποπειράθηκε μια συναλλαγη στη μεριά του εξυπηρετητή (server-side) σε μια "
+"συνδίαλεξη (conversation)\n"
+"που είχε τερματιστεί από τον πελάτη(client), ή ο εξυπηρετητής (server)\n"
+"τερμάτισε πριν ολοκληρωθεί μια συναλλαγή( transaction)."
+
+#: ../src/msw/dde.cpp:1180
+msgid "an internal error has occurred in the DDEML."
+msgstr "ένα εσωτερικό λάθος συνέβη στο DDEML."
+
+#: ../src/msw/dde.cpp:1183
+msgid "a request to end an advise transaction has timed out."
+msgstr ""
+"μία αίτηση για τερματισμό μιας ενημερωτικής(advise) συναλλαγής(transaction) "
+"ξεπέρασε το χρονικό περιθώριο (timed out)"
+
+#: ../src/msw/dde.cpp:1186
+msgid ""
+"an invalid transaction identifier was passed to a DDEML function.\n"
+"Once the application has returned from an XTYP_XACT_COMPLETE callback,\n"
+"the transaction identifier for that callback is no longer valid."
+msgstr ""
+"ένα λανθασμένο αναγνωριστικό(identifier) συναλλαγής(transaction) δώθηκε σε "
+"μία DDEML συνάρτηση(function).\n"
+"Όταν η εφαρμογή επιστρέψει από ένα XTYP_XACT_COMPLETE callback,\n"
+"το αναγνωριστικό συναλλαγής για εκείνο το callback δεν θα είναι πλέον έγκυρο."
+
+#: ../src/msw/dde.cpp:1189
+#, c-format
+msgid "Unknown DDE error %08x"
+msgstr "’γνωστο σφάλμα DDE %08x"
+
+#: ../src/msw/dialup.cpp:343
+msgid ""
+"Dial up functions are unavailable because the remote access service (RAS) is "
+"not installed on this machine. Please install it."
+msgstr ""
+"Συναρτήσεις (functions) τηλεφωνικής σύνδεσης (dialup) δεν είναι διαθέσιμες "
+"γιατί η υπηρεσία απομακρυσμένης πρόσβασης (remote access service, RAS) δεν "
+"είναι εκατεστημένη σε αυτό το μηχάνημα. Παρακαλώ εγκαταστήστε τη."
+
+#: ../src/msw/dialup.cpp:402
+#, fuzzy, c-format
+msgid ""
+"The version of remote access service (RAS) installed on this machine is too "
+"old, please upgrade (the following required function is missing: %s)."
+msgstr ""
+"Η εγκατεστημένη σε αυτό το μηχάνημα υπηρεσία απομακρυσμένης πρόσβασης "
+"(remote access service, RAS) είναι πολύ παλία, παρακαλώ αναβαθμίστε (η "
+"ακόλουθη απαραίτητη συνάρτηση λείπει: %s)."
+
+#: ../src/msw/dialup.cpp:437
+msgid "Failed to retrieve text of RAS error message"
+msgstr "Αποτυχία στη λήψη κειμένου από το μήνυμα σφάλματος RAS"
+
+#: ../src/msw/dialup.cpp:440
+#, c-format
+msgid "unknown error (error code %08x)."
+msgstr "άνωστο λάθος (κωδικός λάθους %08x)"
+
+#: ../src/msw/dialup.cpp:492
+#, c-format
+msgid "Cannot find active dialup connection: %s"
+msgstr "Δεν είναι δυνατή η εύρεση της ενεργού τηλεφωνικής συνδέσεως: %s"
+
+#: ../src/msw/dialup.cpp:513
+msgid "Several active dialup connections found, choosing one randomly."
+msgstr ""
+"Βρέθηκαν πολλαπλές ενεργές τηλεφωνικές συνδέσεις, γίνεται τυχαία επιλογή "
+"μίας."
+
+#: ../src/msw/dialup.cpp:598 ../src/msw/dialup.cpp:832
+#, fuzzy, c-format
+msgid "Failed to establish dialup connection: %s"
+msgstr "Αποτυχία %s της σύνδεσης μέσω τηλεφώνου : %s"
+
+#: ../src/msw/dialup.cpp:664
+#, c-format
+msgid "Failed to get ISP names: %s"
+msgstr "Αποτυχία κατά την λήψη των ονομάτων των ISP: %s"
+
+#: ../src/msw/dialup.cpp:712
+msgid "Failed to connect: no ISP to dial."
+msgstr ""
+"Αποτυχία συνδεσης: κανένας παροχέας υπηρεσιών Internet (ISP) για να καλέσω."
+
+#: ../src/msw/dialup.cpp:732
+msgid "Choose ISP to dial"
+msgstr "Επιλέξτε παροχέα Internet για κλήση"
+
+#: ../src/msw/dialup.cpp:733
+msgid "Please choose which ISP do you want to connect to"
+msgstr ""
+"Παρακαλώ επιλέξτε τον παροχέα υπηρεσιών Internet (ISP) με τον οποίο θέλετε "
+"να συνδεθείτε"
+
+#: ../src/msw/dialup.cpp:766
+msgid "Failed to connect: missing username/password."
+msgstr "Αποτυχία συνδεσης: λείπει το όνομα χρήστη/συνθηματικό"
+
+#: ../src/msw/dialup.cpp:796
+msgid "Cannot find the location of address book file"
+msgstr "Δεν είναι δυνατή η εύρεση της θέσης του αρχείου βιβλίου διευθύνσεων"
+
+#: ../src/msw/dialup.cpp:827
+#, fuzzy, c-format
+msgid "Failed to initiate dialup connection: %s"
+msgstr "Αποτυχία τερματισμού της σύνδεσης μέσω τηλεφώνου : %s"
+
+#: ../src/msw/dialup.cpp:897
+msgid "Cannot hang up - no active dialup connection."
+msgstr ""
+"Δεν είναι δυνατό το κλείσιμο της γραμμής - δεν υπάρχει ενεργός τηλεφωνική "
+"σύνδεση."
+
+#: ../src/msw/dialup.cpp:907
+#, c-format
+msgid "Failed to terminate the dialup connection: %s"
+msgstr "Αποτυχία τερματισμού της σύνδεσης μέσω τηλεφώνου : %s"
+
+#: ../src/msw/dib.cpp:313
+#, c-format
+msgid "Failed to save the bitmap image to file \"%s\"."
+msgstr "Αποτυχία αποθήκευσης της εικόνας στο αρχείο \"%s\"."
+
+#: ../src/msw/dib.cpp:543
+#, fuzzy, c-format
+msgid "Failed to allocate %luKb of memory for bitmap data."
+msgstr "Αποτυχία δέσμευσης %luKb μνήμης για δεδομένα bitmap."
+
+#: ../src/msw/dir.cpp:241
+#, c-format
+msgid "Cannot enumerate files in directory '%s'"
+msgstr "Δεν είναι δυνατή η απαρίθμηση των αρχείων στον κατάλογο '%s'"
+
+#: ../src/msw/dirdlg.cpp:368
+#, fuzzy
+msgid "Couldn't obtain folder name"
+msgstr "Δεν ήταν δυνατή η δημιουργία χρονοδιακόπτη (timer)"
+
+#: ../src/msw/dlmsw.cpp:163
+#, fuzzy, c-format
+msgid "(error %d: %s)"
+msgstr " (σφάλμα %ld: %s)"
+
+#: ../src/msw/dragimag.cpp:143 ../src/msw/dragimag.cpp:178
+#: ../src/msw/imaglist.cpp:309 ../src/msw/imaglist.cpp:331
+msgid "Couldn't add an image to the image list."
+msgstr "Δεν ήταν δυνατή η προσθήκη μιας εικόνας στην λίστα εικόνων."
+
+#: ../src/msw/enhmeta.cpp:94
+#, c-format
+msgid "Failed to load metafile from file \"%s\"."
+msgstr "Αποτυχία φόρτωσης της μετα-εικόνας από το αρχείο '%s'."
+
+#: ../src/msw/fdrepdlg.cpp:412
+#, c-format
+msgid "Failed to create the standard find/replace dialog (error code %d)"
+msgstr ""
+"Απέτυχε η δημιουργία καθιερωμένου παράθυρου διαλόγου εύρεσης/αντικατάστασης "
+"(κωδικός σφάλματος %d)"
+
+#: ../src/msw/filedlg.cpp:1241
+msgid "Access to the file system is not allowed from secure desktop."
+msgstr ""
+
+#: ../src/msw/filedlg.cpp:1242
+msgid "Security warning"
+msgstr ""
+
+#: ../src/msw/filedlg.cpp:1533
+#, fuzzy, c-format
+msgid "File dialog failed with error code %0lx."
+msgstr "Η εκτέλεση της εντολής '%s' απέτυχε με σφάλμα: %ul"
+
+#: ../src/msw/font.cpp:1120
+#, fuzzy, c-format
+msgid "Font file \"%s\" couldn't be loaded"
+msgstr "Το αρχείο δεν μπόρεσε να φορτωθεί."
+
+#: ../src/msw/fontdlg.cpp:220
+#, fuzzy, c-format
+msgid "Common dialog failed with error code %0lx."
+msgstr "Η εκτέλεση της εντολής '%s' απέτυχε με σφάλμα: %ul"
+
+#: ../src/msw/fswatcher.cpp:67
+#, fuzzy
+msgid "Ungraceful worker thread termination"
+msgstr ""
+"Δεν είναι δυνατή η αναμονή(wait) για τον τερματισμό του νήματος "
+"εκτέλεσης(thread)"
+
+#: ../src/msw/fswatcher.cpp:81
+#, fuzzy
+msgid "Unable to create IOCP worker thread"
+msgstr "Αποτυχία δημιουργίας ενός γονεικού περιγράμματος (parent frame) MDI."
+
+#: ../src/msw/fswatcher.cpp:88
+msgid "Unable to start IOCP worker thread"
+msgstr ""
+
+#: ../src/msw/fswatcher.cpp:140
+msgid "Monitoring individual files for changes is not supported currently."
+msgstr ""
+
+#: ../src/msw/fswatcher.cpp:165
+#, fuzzy, c-format
+msgid "Unable to set up watch for '%s'"
+msgstr "Αποτυχία αγγίγματος (touch) του αρχείου '%s'"
+
+#: ../src/msw/fswatcher.cpp:466
+#, c-format
+msgid "Can't monitor non-existent directory \"%s\" for changes."
+msgstr ""
+
+#: ../src/msw/glcanvas.cpp:577 ../src/unix/glx11.cpp:507
+msgid "OpenGL 3.0 or later is not supported by the OpenGL driver."
+msgstr ""
+
+#: ../src/msw/glcanvas.cpp:601 ../src/osx/glcanvas_osx.cpp:395
+#: ../src/unix/glegl.cpp:304 ../src/unix/glx11.cpp:553
+#, fuzzy
+msgid "Couldn't create OpenGL context"
+msgstr "Δεν ήταν δυνατή η δημιουργία χρονοδιακόπτη (timer)"
+
+#: ../src/msw/glcanvas.cpp:1294
+msgid "Failed to initialize OpenGL"
+msgstr "Απέτυχε η αρχικοποίηση του OpenGL"
+
+#: ../src/msw/graphicsd2d.cpp:607
+msgid "Could not register custom DirectWrite font loader."
+msgstr ""
+
+#: ../src/msw/helpchm.cpp:48
+msgid ""
+"MS HTML Help functions are unavailable because the MS HTML Help library is "
+"not installed on this machine. Please install it."
+msgstr ""
+"Οι συναρτήσεις (functions) της MS HTML Help δεν είναι διαθέσιμες γιατί η "
+"βιβλιοθήκη MS HTML Help δεν είναι εγκατεστημένη. Παρακαλώ εγκαταστήστε την."
+
+#: ../src/msw/helpchm.cpp:55
+msgid "Failed to initialize MS HTML Help."
+msgstr "Αποτυχία στην αρχικοποίηση του MS HTML Help."
+
+#: ../src/msw/iniconf.cpp:458
+#, c-format
+msgid "Can't delete the INI file '%s'"
+msgstr "Δεν είναι δυνατή η διαγραφή του αρχείου INI '%s'"
+
+#: ../src/msw/listctrl.cpp:995
+#, c-format
+msgid "Couldn't retrieve information about list control item %d."
+msgstr ""
+"Δεν ήταν δυνατή η ανάκτηση πληροφοριών σχετικά με το στοιχείο λίστας %d."
+
+#: ../src/msw/mdi.cpp:170 ../src/qt/mdi.cpp:253
+msgid "&Cascade"
+msgstr "&Επικάλυψη"
+
+#: ../src/msw/mdi.cpp:171
+msgid "Tile &Horizontally"
+msgstr "Οριζόντια παράθεση"
+
+#: ../src/msw/mdi.cpp:172
+msgid "Tile &Vertically"
+msgstr "Κατακόρυφη παράθεση"
+
+#: ../src/msw/mdi.cpp:174
+msgid "&Arrange Icons"
+msgstr "&Τακτοποίηση εικονιδίων"
+
+#: ../src/msw/mdi.cpp:621
+msgid "Failed to create MDI parent frame."
+msgstr "Αποτυχία δημιουργίας ενός γονεικού περιγράμματος (parent frame) MDI."
+
+#: ../src/msw/mimetype.cpp:234
+#, c-format
+msgid "Failed to create registry entry for '%s' files."
+msgstr ""
+"Απέτυχε η δημιουργία εγγραφής μητρώου (registry entry) για '%s' αρχεία."
+
+#: ../src/msw/ole/automtn.cpp:495
+#, fuzzy, c-format
+msgid "Failed to find CLSID of \"%s\""
+msgstr "Αποτυχία ανοίγματος του '%s' για το '%s'"
+
+#: ../src/msw/ole/automtn.cpp:512
+#, fuzzy, c-format
+msgid "Failed to create an instance of \"%s\""
+msgstr "Απέτυχε η δημιουργία καταλόγου '%s'/.gnome."
+
+#: ../src/msw/ole/automtn.cpp:552
+#, fuzzy, c-format
+msgid "Cannot get an active instance of \"%s\""
+msgstr "Δεν είναι δυνατή η εύρεση της ενεργού τηλεφωνικής συνδέσεως: %s"
+
+#: ../src/msw/ole/automtn.cpp:564
+#, fuzzy, c-format
+msgid "Failed to get OLE automation interface for \"%s\""
+msgstr "Απέτυχε η δημιουργία καταλόγου '%s'/.gnome."
+
+#: ../src/msw/ole/automtn.cpp:621
+msgid "Unknown name or named argument."
+msgstr ""
+
+#: ../src/msw/ole/automtn.cpp:625
+msgid "Incorrect number of arguments."
+msgstr ""
+
+#: ../src/msw/ole/automtn.cpp:637
+#, fuzzy
+msgid "Unknown exception"
+msgstr "’γνωστη επιλογή '%s'"
+
+#: ../src/msw/ole/automtn.cpp:642
+msgid "Method or property not found."
+msgstr ""
+
+#: ../src/msw/ole/automtn.cpp:646
+msgid "Overflow while coercing argument values."
+msgstr ""
+
+#: ../src/msw/ole/automtn.cpp:650
+msgid "Object implementation does not support named arguments."
+msgstr ""
+
+#: ../src/msw/ole/automtn.cpp:654
+msgid "The locale ID is unknown."
+msgstr ""
+
+#: ../src/msw/ole/automtn.cpp:658
+msgid "Missing a required parameter."
+msgstr ""
+
+#: ../src/msw/ole/automtn.cpp:662
+#, fuzzy, c-format
+msgid "Argument %u not found."
+msgstr "αρχείο καταλόγου για την περιοχή (domain) '%s' δεν βρέθηκε."
+
+#: ../src/msw/ole/automtn.cpp:666
+#, c-format
+msgid "Type mismatch in argument %u."
+msgstr ""
+
+#: ../src/msw/ole/automtn.cpp:670
+msgid "The system cannot find the file specified."
+msgstr ""
+
+#: ../src/msw/ole/automtn.cpp:674
+#, fuzzy
+msgid "Class not registered."
+msgstr "Δεν είναι δυνατή η δημιουργία του νήματος εκτέλεσης (thread)"
+
+#: ../src/msw/ole/automtn.cpp:678
+#, fuzzy, c-format
+msgid "Unknown error %08x"
+msgstr "’γνωστο σφάλμα DDE %08x"
+
+#: ../src/msw/ole/automtn.cpp:682
+#, c-format
+msgid "OLE Automation error in %s: %s"
+msgstr ""
+
+#: ../src/msw/ole/dataobj.cpp:385
+#, c-format
+msgid "Couldn't register clipboard format '%s'."
+msgstr ""
+"Δεν ήταν δυνατή η καταχώρηση του τύπου προχείρου(clipboard format) '%s'"
+
+#: ../src/msw/ole/dataobj.cpp:402
+#, c-format
+msgid "The clipboard format '%d' doesn't exist."
+msgstr "O τύπος προχείρου(clipboard format) '%d' δεν υπάρχει."
+
+#: ../src/msw/progdlg.cpp:1025
+msgid "Skip"
+msgstr "Παράλειψη"
+
+#: ../src/msw/registry.cpp:141
+#, fuzzy, c-format
+msgid "unknown (%lu)"
+msgstr "άγνωστο"
+
+#: ../src/msw/registry.cpp:409
+#, c-format
+msgid "Can't get info about registry key '%s'"
+msgstr ""
+"Δεν είναι δυνατή η συλλογή πληροφοριών για το κλειδί μητρώου(registry) '%s'"
+
+#: ../src/msw/registry.cpp:445
+#, c-format
+msgid "Can't open registry key '%s'"
+msgstr "Δεν είναι δυνατό το άνοιγμα του κλειδιού μητρώου(registry) '%s'"
+
+#: ../src/msw/registry.cpp:478
+#, c-format
+msgid "Can't create registry key '%s'"
+msgstr "Δεν είναι δυνατή η δημιουργία του κλειδιού μητρώου(registry key) '%s'"
+
+#: ../src/msw/registry.cpp:497
+#, c-format
+msgid "Can't close registry key '%s'"
+msgstr "Δεν είναι δυνατό το κλείσιμο του κλειδιού μητρώου(registry key) '%s'"
+
+#: ../src/msw/registry.cpp:512
+#, c-format
+msgid "Registry value '%s' already exists."
+msgstr "Η τιμή μητρώου '%s' υπάρχει ήδη."
+
+#: ../src/msw/registry.cpp:520
+#, c-format
+msgid "Failed to rename registry value '%s' to '%s'."
+msgstr "Αποτυχία της μετονομασίας της τιμής μητρώου '%s' σε '%s'."
+
+#: ../src/msw/registry.cpp:575
+#, c-format
+msgid "Can't copy values of unsupported type %d."
+msgstr "Δεν είναι δυνατή η αντιγραφή τιμών μη υποστηριζομένου τύπου %d."
+
+#: ../src/msw/registry.cpp:586
+#, c-format
+msgid "Registry key '%s' does not exist, cannot rename it."
+msgstr "Το κλειδί μητρώου '%s' δεν υπάρχει, αδύνατη η μετονομασία του."
+
+#: ../src/msw/registry.cpp:617
+#, c-format
+msgid "Registry key '%s' already exists."
+msgstr "Το κλειδί μητρώου '%s' υπάρχει ήδη."
+
+#: ../src/msw/registry.cpp:625
+#, c-format
+msgid "Failed to rename the registry key '%s' to '%s'."
+msgstr "Αποτυχία της μετονομασίας του κλειδιού μητρώου '%s' σε '%s'."
+
+#: ../src/msw/registry.cpp:670
+#, c-format
+msgid "Failed to copy the registry subkey '%s' to '%s'."
+msgstr "Αποτυχία της αντιγραφής του υποκλειδιού μητρώου '%s' σε '%s'."
+
+#: ../src/msw/registry.cpp:683
+#, c-format
+msgid "Failed to copy registry value '%s'"
+msgstr "Αποτυχία αντιγραφής της τιμής μητρώου '%s'"
+
+#: ../src/msw/registry.cpp:692
+#, c-format
+msgid "Failed to copy the contents of registry key '%s' to '%s'."
+msgstr ""
+"Αποτυχία αντιγραφής των περιεχομένων του κλειδιού μητρώου '%s' στο '%s'."
+
+#: ../src/msw/registry.cpp:718
+#, c-format
+msgid ""
+"Registry key '%s' is needed for normal system operation,\n"
+"deleting it will leave your system in unusable state:\n"
+"operation aborted."
+msgstr ""
+"Το αρχείο μητρώου '%s' χρειάζεται για την κανονική λειτουργία του "
+"συστήματος,\n"
+"διαγράφοντάς το θα αφήσει το σύστημά σας σε κατάσταση αχρηστίας:\n"
+"η λειτουργία ματαιώθηκε."
+
+#: ../src/msw/registry.cpp:754
+#, c-format
+msgid "Can't delete key '%s'"
+msgstr "Δεν είναι δυνατή η διαγραφή του κλειδιού '%s'"
+
+#: ../src/msw/registry.cpp:782
+#, c-format
+msgid "Can't delete value '%s' from key '%s'"
+msgstr "Δεν είναι δυνατή η διαγραφή της τιμής '%s' από το κλειδί '%s'"
+
+#: ../src/msw/registry.cpp:855 ../src/msw/registry.cpp:887
+#: ../src/msw/registry.cpp:929 ../src/msw/registry.cpp:1000
+#, c-format
+msgid "Can't read value of key '%s'"
+msgstr "Δεν είναι δυνατή η ανάγνωση της τιμής του κλειδιού '%s'"
+
+#: ../src/msw/registry.cpp:873 ../src/msw/registry.cpp:915
+#: ../src/msw/registry.cpp:963 ../src/msw/registry.cpp:1106
+#, c-format
+msgid "Can't set value of '%s'"
+msgstr "Δεν είναι δυνατή η ανάθεση τιμής του '%s'"
+
+#: ../src/msw/registry.cpp:894 ../src/msw/registry.cpp:943
+#, c-format
+msgid "Registry value \"%s\" is not numeric (but of type %s)"
+msgstr ""
+
+#: ../src/msw/registry.cpp:979
+#, c-format
+msgid "Registry value \"%s\" is not binary (but of type %s)"
+msgstr ""
+
+#: ../src/msw/registry.cpp:1028
+#, c-format
+msgid "Registry value \"%s\" is not text (but of type %s)"
+msgstr ""
+
+#: ../src/msw/registry.cpp:1089
+#, c-format
+msgid "Can't read value of '%s'"
+msgstr "Δεν είναι δυνατή η ανάγνωση της τιμής του '%s'"
+
+#: ../src/msw/registry.cpp:1157
+#, c-format
+msgid "Can't enumerate values of key '%s'"
+msgstr "Δεν είναι δυνατή η απαρίθμηση των τιμών του κλειδιού '%s'"
+
+#: ../src/msw/registry.cpp:1196
+#, c-format
+msgid "Can't enumerate subkeys of key '%s'"
+msgstr "Δεν είναι δυνατή η απαρίθμηση των υποκλειδιών του '%s'"
+
+#: ../src/msw/registry.cpp:1262
+#, c-format
+msgid ""
+"Exporting registry key: file \"%s\" already exists and won't be overwritten."
+msgstr ""
+
+#: ../src/msw/registry.cpp:1411
+#, c-format
+msgid "Can't export value of unsupported type %d."
+msgstr "Δεν είναι δυνατή η εξαγωγή τιμών μη υποστηριζομένου τύπου %d."
+
+#: ../src/msw/registry.cpp:1427
+#, c-format
+msgid "Ignoring value \"%s\" of the key \"%s\"."
+msgstr ""
+
+#: ../src/msw/textctrl.cpp:596
+msgid ""
+"Impossible to create a rich edit control, using simple text control instead. "
+"Please reinstall riched32.dll"
+msgstr ""
+"Αδύνατη η δημουργία ενός στοιχείου ελέγχου(control) rich edit, αντι αυτού "
+"γίνεται χρήση του simpe text στοιχείου ελέγχου. Παρακαλώ επανεγκαταστήστε το "
+"riched32.dll"
+
+#: ../src/msw/thread.cpp:522 ../src/unix/threadpsx.cpp:850
+msgid "Cannot start thread: error writing TLS."
+msgstr ""
+"Δεν είναι δυνατή η εκκίνηση του νήματος(thread): Σφάλμα κατά την εγγραφή του "
+"TLS"
+
+#: ../src/msw/thread.cpp:613
+msgid "Can't set thread priority"
+msgstr "Δεν είναι δυνατή η θέση προτεραιότητας του νήματος εκτέλεσης (thread)"
+
+#: ../src/msw/thread.cpp:649
+msgid "Can't create thread"
+msgstr "Δεν είναι δυνατή η δημιουργία του νήματος εκτέλεσης (thread)"
+
+#: ../src/msw/thread.cpp:668
+msgid "Couldn't terminate thread"
+msgstr "Δεν ήταν δυνατός ο τερματισμός του thread"
+
+#: ../src/msw/thread.cpp:799
+msgid "Cannot wait for thread termination"
+msgstr ""
+"Δεν είναι δυνατή η αναμονή(wait) για τον τερματισμό του νήματος "
+"εκτέλεσης(thread)"
+
+#: ../src/msw/thread.cpp:873
+#, fuzzy, c-format
+msgid "Cannot suspend thread %lx"
+msgstr "Δεν είναι δυνατή η αναστολή εκτέλεσης(suspend) του νήματος(thread) %x"
+
+#: ../src/msw/thread.cpp:903
+#, fuzzy, c-format
+msgid "Cannot resume thread %lx"
+msgstr "Δεν είναι δυνατή η συνέχιση(resume) του νήματος(thread) %x"
+
+#: ../src/msw/thread.cpp:932
+msgid "Couldn't get the current thread pointer"
+msgstr ""
+"Δεν ήταν δυνατή η ανάκτηση toy τρέχοντος δείκτη νήματος εκτέλεσης(thread)"
+
+#: ../src/msw/thread.cpp:1333
+msgid ""
+"Thread module initialization failed: impossible to allocate index in thread "
+"local storage"
+msgstr ""
+"Η αρχικοποίηση μονάδας νήματος εκτέλεσης (thread module) απέτυχε: αδύνατο να "
+"δεσμευτεί (allocate) δείκτης (index) στην στην τοπική αποθήκευση νήματος "
+"(thread local storage)"
+
+#: ../src/msw/thread.cpp:1345
+msgid ""
+"Thread module initialization failed: cannot store value in thread local "
+"storage"
+msgstr ""
+"Η αρχικοποίηση μονάδας νήματος εκτέλεσης (thread module) απέτυχε: αδύνατη η "
+"αποθήκευση τιμής στην τοπική αποθήκευση νήματος (thread local storage)"
+
+#: ../src/msw/timer.cpp:133
+msgid "Couldn't create a timer"
+msgstr "Δεν ήταν δυνατή η δημιουργία χρονοδιακόπτη (timer)"
+
+#: ../src/msw/utils.cpp:372
+msgid "can't find user's HOME, using current directory."
+msgstr ""
+"αδύνατη η εύρεση του HOME του χρήστη, γίνεται χρήση τρέχοντος καταλόγου."
+
+#: ../src/msw/utils.cpp:662
+#, c-format
+msgid "Failed to kill process %d"
+msgstr "Αποτυχία θανάτωσης της διαδικασίας(process) %d"
+
+#: ../src/msw/utils.cpp:986
+#, fuzzy, c-format
+msgid "Failed to load resource \"%s\"."
+msgstr "Αποτυχία φόρτωσης της μετα-εικόνας από το αρχείο '%s'."
+
+#: ../src/msw/utils.cpp:993
+#, fuzzy, c-format
+msgid "Failed to lock resource \"%s\"."
+msgstr "Αποτυχία κλειδώματος του αρχείου 'κλειδωνιά'(lock file) '%s'"
+
+#. TRANSLATORS: MS Windows build number
+#: ../src/msw/utils.cpp:1209
+#, c-format
+msgid "build %lu"
+msgstr ""
+
+#: ../src/msw/utils.cpp:1218
+msgid ", 64-bit edition"
+msgstr ""
+
+#: ../src/msw/utilsexc.cpp:224
+msgid "Failed to create an anonymous pipe"
+msgstr "Αποτυχία δημιουργίας ενός ανώνυμου pipe"
+
+#: ../src/msw/utilsexc.cpp:697
+msgid "Failed to redirect the child process IO"
+msgstr ""
+"Αποτυχία στην ανακατεύθυνση του IO διεργασίας απογόνου (child process IO)"
+
+#: ../src/msw/utilsexc.cpp:870
+#, c-format
+msgid "Execution of command '%s' failed"
+msgstr "Η εκτέλεση της εντολής '%s' απέτυχε"
+
+#: ../src/msw/volume.cpp:337
+msgid "Failed to load mpr.dll."
+msgstr "Αποτυχία φόρτωσης του mpr.dll."
+
+#: ../src/msw/volume.cpp:506
+#, c-format
+msgid "Cannot read typename from '%s'!"
+msgstr "Δεν είναι δυνατή η ανάγνωση ονομάτων τύπων(typenames) από το '%s'"
+
+#: ../src/msw/volume.cpp:615
+#, c-format
+msgid "Cannot load icon from '%s'."
+msgstr "Δεν είναι δυνατή η φόρτωση εικονιδίου από το '%s'"
+
+#: ../src/msw/webview_edge.cpp:285
+msgid "This program was compiled without support for setting Edge proxy."
+msgstr ""
+
+#: ../src/msw/webview_ie.cpp:1010
+msgid "Failed to find web view emulation level in the registry"
+msgstr ""
+
+#: ../src/msw/webview_ie.cpp:1019
+msgid "Failed to set web view to modern emulation level"
+msgstr ""
+
+#: ../src/msw/webview_ie.cpp:1027
+msgid "Failed to reset web view to standard emulation level"
+msgstr ""
+
+#: ../src/msw/webview_ie.cpp:1049
+msgid "Can't run JavaScript script without a valid HTML document"
+msgstr ""
+
+#: ../src/msw/webview_ie.cpp:1056
+#, fuzzy
+msgid "Can't get the JavaScript object"
+msgstr "Δεν είναι δυνατή η θέση προτεραιότητας του νήματος εκτέλεσης (thread)"
+
+#: ../src/msw/webview_ie.cpp:1070
+#, fuzzy
+msgid "failed to evaluate"
+msgstr "Αποτυχία εκτέλεσης του '%s'\n"
+
+#: ../src/osx/cocoa/filedlg.mm:412
+#, fuzzy
+msgid "File type:"
+msgstr "Τηλέτυπο"
+
+#: ../src/osx/cocoa/menu.mm:242
+#, fuzzy
+msgctxt "macOS menu name"
+msgid "Window"
+msgstr "&Παράθυρο"
+
+#: ../src/osx/cocoa/menu.mm:259
+#, fuzzy
+msgctxt "macOS menu name"
+msgid "Help"
+msgstr "Βοήθεια"
+
+#: ../src/osx/cocoa/menu.mm:298
+#, fuzzy
+msgctxt "macOS menu item"
+msgid "Minimize"
+msgstr "Ελα&χιστοποίηση"
+
+#: ../src/osx/cocoa/menu.mm:303
+#, fuzzy
+msgctxt "macOS menu item"
+msgid "Zoom"
+msgstr "&Αύξηση ζουμ"
+
+#: ../src/osx/cocoa/menu.mm:309
+msgctxt "macOS menu item"
+msgid "Bring All to Front"
+msgstr ""
+
+#: ../src/osx/core/sound.cpp:143
+#, fuzzy, c-format
+msgid "Failed to load sound from \"%s\" (error %d)."
+msgstr "Αποτυχία φόρτωσης της μετα-εικόνας από το αρχείο '%s'."
+
+#: ../src/osx/fontutil.cpp:80
+#, fuzzy, c-format
+msgid "Font file \"%s\" doesn't exist."
+msgstr "Το αρχείο %s δεν υπάρχει."
+
+#: ../src/osx/fontutil.cpp:88
+#, c-format
+msgid ""
+"Font file \"%s\" cannot be used as it is not inside the font directory "
+"\"%s\"."
+msgstr ""
+
+#: ../src/osx/menu_osx.cpp:496
+#, fuzzy, c-format
+msgctxt "macOS menu item"
+msgid "About %s"
+msgstr "&Περί..."
+
+#: ../src/osx/menu_osx.cpp:499
+#, fuzzy
+msgctxt "macOS menu item"
+msgid "About..."
+msgstr "&Περί"
+
+#: ../src/osx/menu_osx.cpp:508
+#, fuzzy
+msgctxt "macOS menu item"
+msgid "Preferences..."
+msgstr "&Προτιμήσεις"
+
+#: ../src/osx/menu_osx.cpp:512
+msgctxt "macOS menu item"
+msgid "Services"
+msgstr ""
+
+#: ../src/osx/menu_osx.cpp:519
+#, fuzzy, c-format
+msgctxt "macOS menu item"
+msgid "Hide %s"
+msgstr "Βοήθεια: %s"
+
+#: ../src/osx/menu_osx.cpp:522
+#, fuzzy
+msgctxt "macOS menu item"
+msgid "Hide Application"
+msgstr "Τμήματα"
+
+#: ../src/osx/menu_osx.cpp:526
+msgctxt "macOS menu item"
+msgid "Hide Others"
+msgstr ""
+
+#: ../src/osx/menu_osx.cpp:528
+#, fuzzy
+msgctxt "macOS menu item"
+msgid "Show All"
+msgstr "Εμφάνιση όλων"
+
+#: ../src/osx/menu_osx.cpp:534
+#, fuzzy, c-format
+msgctxt "macOS menu item"
+msgid "Quit %s"
+msgstr "Έ&ξοδος"
+
+#: ../src/osx/menu_osx.cpp:537
+#, fuzzy
+msgctxt "macOS menu item"
+msgid "Quit Application"
+msgstr "Τμήματα"
+
+#: ../src/osx/webview_webkit.mm:444
+#, fuzzy
+msgid "Printing is not supported by the system web control"
+msgstr "Το Gzip δεν υποστηρίζεται από αυτήν την έκδοση της zlib"
+
+#: ../src/osx/webview_webkit.mm:453
+#, fuzzy
+msgid "Print operation could not be initialized"
+msgstr "Δεν είναι δυνατή η αρχικοποίηση απεικόνησης."
+
+#. TRANSLATORS: Label of font point size
+#: ../src/propgrid/advprops.cpp:605
+#, fuzzy
+msgid "Point Size"
+msgstr "Μέγεθος κουκίδας:"
+
+#. TRANSLATORS: Label of font face name
+#: ../src/propgrid/advprops.cpp:615
+#, fuzzy
+msgid "Face Name"
+msgstr "ΝέοΌνομα"
+
+#. TRANSLATORS: Label of font style
+#: ../src/propgrid/advprops.cpp:623 ../src/richtext/richtextformatdlg.cpp:331
+#, fuzzy
+msgid "Style"
+msgstr "&Στυλ:"
+
+#. TRANSLATORS: Label of font weight
+#: ../src/propgrid/advprops.cpp:628
+#, fuzzy
+msgid "Weight"
+msgstr "&Βάρος:"
+
+#. TRANSLATORS: Label of underlined font
+#: ../src/propgrid/advprops.cpp:633 ../src/richtext/richtextfontpage.cpp:358
+#, fuzzy
+msgid "Underlined"
+msgstr "&Υπογράμμιση"
+
+#. TRANSLATORS: Label of font family
+#: ../src/propgrid/advprops.cpp:637
+#, fuzzy
+msgid "Family"
+msgstr "Οικογένεια γραμματοσειράς:"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:801
+msgid "AppWorkspace"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:802
+#, fuzzy
+msgid "ActiveBorder"
+msgstr "Μοντέρνο"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:803
+msgid "ActiveCaption"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:804
+msgid "ButtonFace"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:805
+msgid "ButtonHighlight"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:806
+msgid "ButtonShadow"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:807
+msgid "ButtonText"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:808
+msgid "CaptionText"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:809
+msgid "ControlDark"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:810
+msgid "ControlLight"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:812
+msgid "GrayText"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:813
+#, fuzzy
+msgid "Highlight"
+msgstr "απαλό(light)"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:814
+msgid "HighlightText"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:815
+#, fuzzy
+msgid "InactiveBorder"
+msgstr "Μοντέρνο"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:816
+msgid "InactiveCaption"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:817
+msgid "InactiveCaptionText"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:818
+msgid "Menu"
+msgstr "Μενού"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:819
+msgid "Scrollbar"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:820
+msgid "Tooltip"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:821
+msgid "TooltipText"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:822
+#, fuzzy
+msgid "Window"
+msgstr "&Παράθυρο"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:823
+#, fuzzy
+msgid "WindowFrame"
+msgstr "&Παράθυρο"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:824
+#, fuzzy
+msgid "WindowText"
+msgstr "&Παράθυρο"
+
+#. TRANSLATORS: Custom colour choice entry
+#: ../src/propgrid/advprops.cpp:825 ../src/propgrid/advprops.cpp:1532
+#: ../src/propgrid/advprops.cpp:1576
+#, fuzzy
+msgid "Custom"
+msgstr "μέγεθος γραμματοσειράς"
+
+#: ../src/propgrid/advprops.cpp:1558
+msgid "Black"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1559
+msgid "Maroon"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1560
+msgid "Navy"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1561
+msgid "Purple"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1562
+msgid "Teal"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1563
+msgid "Gray"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1564
+msgid "Green"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1565
+msgid "Olive"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1566
+msgid "Brown"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1567
+msgid "Blue"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1568
+msgid "Fuchsia"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1569
+#, fuzzy
+msgid "Red"
+msgstr "&Επανάληψη"
+
+#: ../src/propgrid/advprops.cpp:1570
+msgid "Orange"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1571
+msgid "Silver"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1572
+msgid "Lime"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1573
+msgid "Aqua"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1574
+msgid "Yellow"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1575
+msgid "White"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1718
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Default"
+msgstr "προκαθορισμένο"
+
+#: ../src/propgrid/advprops.cpp:1719
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Arrow"
+msgstr "αύριο"
+
+#: ../src/propgrid/advprops.cpp:1720
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Right Arrow"
+msgstr "Απαλό(light)"
+
+#: ../src/propgrid/advprops.cpp:1721
+msgctxt "system cursor name"
+msgid "Blank"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1722
+msgctxt "system cursor name"
+msgid "Bullseye"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1723
+msgctxt "system cursor name"
+msgid "Character"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1724
+msgctxt "system cursor name"
+msgid "Cross"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1725
+msgctxt "system cursor name"
+msgid "Hand"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1726
+msgctxt "system cursor name"
+msgid "I-Beam"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1727
+msgctxt "system cursor name"
+msgid "Left Button"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1728
+msgctxt "system cursor name"
+msgid "Magnifier"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1729
+msgctxt "system cursor name"
+msgid "Middle Button"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1730
+msgctxt "system cursor name"
+msgid "No Entry"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1731
+msgctxt "system cursor name"
+msgid "Paint Brush"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1732
+msgctxt "system cursor name"
+msgid "Pencil"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1733
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Point Left"
+msgstr "Μέγεθος κουκίδας:"
+
+#: ../src/propgrid/advprops.cpp:1734
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Point Right"
+msgstr "Στοίχιση Δεξιά"
+
+#: ../src/propgrid/advprops.cpp:1735
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Question Arrow"
+msgstr "Ερώτημα"
+
+#: ../src/propgrid/advprops.cpp:1736
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Right Button"
+msgstr "Απαλό(light)"
+
+#: ../src/propgrid/advprops.cpp:1737
+msgctxt "system cursor name"
+msgid "Sizing NE-SW"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1738
+msgctxt "system cursor name"
+msgid "Sizing N-S"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1739
+msgctxt "system cursor name"
+msgid "Sizing NW-SE"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1740
+msgctxt "system cursor name"
+msgid "Sizing W-E"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1741
+msgctxt "system cursor name"
+msgid "Sizing"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1742
+msgctxt "system cursor name"
+msgid "Spraycan"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1743
+msgctxt "system cursor name"
+msgid "Wait"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1744
+msgctxt "system cursor name"
+msgid "Watch"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1745
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Wait Arrow"
+msgstr "Απαλό(light)"
+
+#: ../src/propgrid/advprops.cpp:2109
+#, fuzzy
+msgid "Make a selection:"
+msgstr "Τμήματα"
+
+#: ../src/propgrid/manager.cpp:394
+#, fuzzy
+msgid "Property"
+msgstr "&Ιδιότητες"
+
+#: ../src/propgrid/manager.cpp:395
+msgid "Value"
+msgstr ""
+
+#: ../src/propgrid/manager.cpp:1683
+msgid "Categorized Mode"
+msgstr ""
+
+#: ../src/propgrid/manager.cpp:1709
+msgid "Alphabetic Mode"
+msgstr ""
+
+#. TRANSLATORS: Name of Boolean false value
+#: ../src/propgrid/propgrid.cpp:230
+#, fuzzy
+msgid "False"
+msgstr "Αρχείο"
+
+#. TRANSLATORS: Name of Boolean true value
+#: ../src/propgrid/propgrid.cpp:232
+msgid "True"
+msgstr ""
+
+#. TRANSLATORS: Text  displayed for unspecified value
+#: ../src/propgrid/propgrid.cpp:428
+#, fuzzy
+msgid "Unspecified"
+msgstr "Ευθυγραμμισμένα"
+
+#. TRANSLATORS: Caption of message box displaying any property error
+#: ../src/propgrid/propgrid.cpp:3145 ../src/propgrid/propgrid.cpp:3282
+#, fuzzy
+msgid "Property Error"
+msgstr "Σφάλμα Εκτύπωσης"
+
+#: ../src/propgrid/propgrid.cpp:3259
+msgid "You have entered invalid value. Press ESC to cancel editing."
+msgstr ""
+
+#: ../src/propgrid/propgrid.cpp:6608
+#, c-format
+msgid "Error in resource: %s"
+msgstr ""
+
+#: ../src/propgrid/propgridiface.cpp:377
+#, c-format
+msgid ""
+"Type operation \"%s\" failed: Property labeled \"%s\" is of type \"%s\", NOT "
+"\"%s\"."
+msgstr ""
+
+#: ../src/propgrid/props.cpp:159
+#, c-format
+msgid "Unknown base %d. Base 10 will be used."
+msgstr ""
+
+#: ../src/propgrid/props.cpp:324
+#, c-format
+msgid "Value must be %s or higher."
+msgstr ""
+
+#: ../src/propgrid/props.cpp:329 ../src/propgrid/props.cpp:356
+#, fuzzy, c-format
+msgid "Value must be between %s and %s."
+msgstr "Δώστε έναν αριθμό σελίδας μεταξύ %d και %d:"
+
+#: ../src/propgrid/props.cpp:351
+#, c-format
+msgid "Value must be %s or less."
+msgstr ""
+
+#: ../src/propgrid/props.cpp:1058
+#, fuzzy, c-format
+msgid "Not %s"
+msgstr "&Περί..."
+
+#: ../src/propgrid/props.cpp:1770
+#, fuzzy
+msgid "Choose a directory:"
+msgstr "Δημιουργία καταλόγου"
+
+#: ../src/propgrid/props.cpp:2055
+#, fuzzy
+msgid "Choose a file"
+msgstr "Επιλέξτε γραμματοσειρά"
+
+#: ../src/qt/mdi.cpp:254
+msgid "&Tile"
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:147
+#: ../src/richtext/richtextformatdlg.cpp:376
+#, fuzzy
+msgid "Background"
+msgstr "Πίσω"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:159
+msgid "Background &colour:"
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:161
+#: ../src/richtext/richtextbackgroundpage.cpp:163
+msgid "Enables a background colour."
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:167
+#: ../src/richtext/richtextbackgroundpage.cpp:169
+#, fuzzy
+msgid "The background colour."
+msgstr "Το χρώμα της γραμματοσειράς."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:178
+msgid "Shadow"
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:193
+msgid "Use &shadow"
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:195
+#: ../src/richtext/richtextbackgroundpage.cpp:197
+msgid "Enables a shadow."
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:211
+msgid "&Horizontal offset:"
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:218
+#: ../src/richtext/richtextbackgroundpage.cpp:220
+#, fuzzy
+msgid "The horizontal offset."
+msgstr "Οριζόντια παράθεση"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:224
+#: ../src/richtext/richtextbackgroundpage.cpp:227
+#: ../src/richtext/richtextbackgroundpage.cpp:228
+#: ../src/richtext/richtextbackgroundpage.cpp:247
+#: ../src/richtext/richtextbackgroundpage.cpp:250
+#: ../src/richtext/richtextbackgroundpage.cpp:251
+#: ../src/richtext/richtextbackgroundpage.cpp:287
+#: ../src/richtext/richtextbackgroundpage.cpp:290
+#: ../src/richtext/richtextbackgroundpage.cpp:291
+#: ../src/richtext/richtextbackgroundpage.cpp:314
+#: ../src/richtext/richtextbackgroundpage.cpp:317
+#: ../src/richtext/richtextbackgroundpage.cpp:318
+#: ../src/richtext/richtextborderspage.cpp:252
+#: ../src/richtext/richtextborderspage.cpp:255
+#: ../src/richtext/richtextborderspage.cpp:256
+#: ../src/richtext/richtextborderspage.cpp:286
+#: ../src/richtext/richtextborderspage.cpp:289
+#: ../src/richtext/richtextborderspage.cpp:290
+#: ../src/richtext/richtextborderspage.cpp:320
+#: ../src/richtext/richtextborderspage.cpp:323
+#: ../src/richtext/richtextborderspage.cpp:324
+#: ../src/richtext/richtextborderspage.cpp:354
+#: ../src/richtext/richtextborderspage.cpp:357
+#: ../src/richtext/richtextborderspage.cpp:358
+#: ../src/richtext/richtextborderspage.cpp:420
+#: ../src/richtext/richtextborderspage.cpp:423
+#: ../src/richtext/richtextborderspage.cpp:424
+#: ../src/richtext/richtextborderspage.cpp:454
+#: ../src/richtext/richtextborderspage.cpp:457
+#: ../src/richtext/richtextborderspage.cpp:458
+#: ../src/richtext/richtextborderspage.cpp:488
+#: ../src/richtext/richtextborderspage.cpp:491
+#: ../src/richtext/richtextborderspage.cpp:492
+#: ../src/richtext/richtextborderspage.cpp:522
+#: ../src/richtext/richtextborderspage.cpp:525
+#: ../src/richtext/richtextborderspage.cpp:526
+#: ../src/richtext/richtextborderspage.cpp:590
+#: ../src/richtext/richtextborderspage.cpp:593
+#: ../src/richtext/richtextborderspage.cpp:594
+#: ../src/richtext/richtextfontpage.cpp:177
+#: ../src/richtext/richtextmarginspage.cpp:199
+#: ../src/richtext/richtextmarginspage.cpp:201
+#: ../src/richtext/richtextmarginspage.cpp:202
+#: ../src/richtext/richtextmarginspage.cpp:224
+#: ../src/richtext/richtextmarginspage.cpp:226
+#: ../src/richtext/richtextmarginspage.cpp:227
+#: ../src/richtext/richtextmarginspage.cpp:247
+#: ../src/richtext/richtextmarginspage.cpp:249
+#: ../src/richtext/richtextmarginspage.cpp:250
+#: ../src/richtext/richtextmarginspage.cpp:272
+#: ../src/richtext/richtextmarginspage.cpp:274
+#: ../src/richtext/richtextmarginspage.cpp:275
+#: ../src/richtext/richtextmarginspage.cpp:313
+#: ../src/richtext/richtextmarginspage.cpp:315
+#: ../src/richtext/richtextmarginspage.cpp:316
+#: ../src/richtext/richtextmarginspage.cpp:338
+#: ../src/richtext/richtextmarginspage.cpp:340
+#: ../src/richtext/richtextmarginspage.cpp:341
+#: ../src/richtext/richtextmarginspage.cpp:361
+#: ../src/richtext/richtextmarginspage.cpp:363
+#: ../src/richtext/richtextmarginspage.cpp:364
+#: ../src/richtext/richtextmarginspage.cpp:386
+#: ../src/richtext/richtextmarginspage.cpp:388
+#: ../src/richtext/richtextmarginspage.cpp:389
+#: ../src/richtext/richtextsizepage.cpp:337
+#: ../src/richtext/richtextsizepage.cpp:340
+#: ../src/richtext/richtextsizepage.cpp:341
+#: ../src/richtext/richtextsizepage.cpp:371
+#: ../src/richtext/richtextsizepage.cpp:374
+#: ../src/richtext/richtextsizepage.cpp:375
+#: ../src/richtext/richtextsizepage.cpp:398
+#: ../src/richtext/richtextsizepage.cpp:401
+#: ../src/richtext/richtextsizepage.cpp:402
+#: ../src/richtext/richtextsizepage.cpp:425
+#: ../src/richtext/richtextsizepage.cpp:428
+#: ../src/richtext/richtextsizepage.cpp:429
+#: ../src/richtext/richtextsizepage.cpp:452
+#: ../src/richtext/richtextsizepage.cpp:455
+#: ../src/richtext/richtextsizepage.cpp:456
+#: ../src/richtext/richtextsizepage.cpp:479
+#: ../src/richtext/richtextsizepage.cpp:482
+#: ../src/richtext/richtextsizepage.cpp:483
+#: ../src/richtext/richtextsizepage.cpp:553
+#: ../src/richtext/richtextsizepage.cpp:556
+#: ../src/richtext/richtextsizepage.cpp:557
+#: ../src/richtext/richtextsizepage.cpp:588
+#: ../src/richtext/richtextsizepage.cpp:591
+#: ../src/richtext/richtextsizepage.cpp:592
+#: ../src/richtext/richtextsizepage.cpp:623
+#: ../src/richtext/richtextsizepage.cpp:626
+#: ../src/richtext/richtextsizepage.cpp:627
+#: ../src/richtext/richtextsizepage.cpp:658
+#: ../src/richtext/richtextsizepage.cpp:661
+#: ../src/richtext/richtextsizepage.cpp:662
+msgid "px"
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:225
+#: ../src/richtext/richtextbackgroundpage.cpp:248
+#: ../src/richtext/richtextbackgroundpage.cpp:288
+#: ../src/richtext/richtextbackgroundpage.cpp:315
+#: ../src/richtext/richtextborderspage.cpp:253
+#: ../src/richtext/richtextborderspage.cpp:287
+#: ../src/richtext/richtextborderspage.cpp:321
+#: ../src/richtext/richtextborderspage.cpp:355
+#: ../src/richtext/richtextborderspage.cpp:421
+#: ../src/richtext/richtextborderspage.cpp:455
+#: ../src/richtext/richtextborderspage.cpp:489
+#: ../src/richtext/richtextborderspage.cpp:523
+#: ../src/richtext/richtextborderspage.cpp:591
+#: ../src/richtext/richtextmarginspage.cpp:200
+#: ../src/richtext/richtextmarginspage.cpp:225
+#: ../src/richtext/richtextmarginspage.cpp:248
+#: ../src/richtext/richtextmarginspage.cpp:273
+#: ../src/richtext/richtextmarginspage.cpp:314
+#: ../src/richtext/richtextmarginspage.cpp:339
+#: ../src/richtext/richtextmarginspage.cpp:362
+#: ../src/richtext/richtextmarginspage.cpp:387
+#: ../src/richtext/richtextsizepage.cpp:338
+#: ../src/richtext/richtextsizepage.cpp:372
+#: ../src/richtext/richtextsizepage.cpp:399
+#: ../src/richtext/richtextsizepage.cpp:426
+#: ../src/richtext/richtextsizepage.cpp:453
+#: ../src/richtext/richtextsizepage.cpp:480
+#: ../src/richtext/richtextsizepage.cpp:554
+#: ../src/richtext/richtextsizepage.cpp:589
+#: ../src/richtext/richtextsizepage.cpp:624
+#: ../src/richtext/richtextsizepage.cpp:659
+msgid "cm"
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:226
+#: ../src/richtext/richtextbackgroundpage.cpp:249
+#: ../src/richtext/richtextbackgroundpage.cpp:289
+#: ../src/richtext/richtextbackgroundpage.cpp:316
+#: ../src/richtext/richtextborderspage.cpp:254
+#: ../src/richtext/richtextborderspage.cpp:288
+#: ../src/richtext/richtextborderspage.cpp:322
+#: ../src/richtext/richtextborderspage.cpp:356
+#: ../src/richtext/richtextborderspage.cpp:422
+#: ../src/richtext/richtextborderspage.cpp:456
+#: ../src/richtext/richtextborderspage.cpp:490
+#: ../src/richtext/richtextborderspage.cpp:524
+#: ../src/richtext/richtextborderspage.cpp:592
+#: ../src/richtext/richtextfontpage.cpp:176
+#: ../src/richtext/richtextfontpage.cpp:179
+msgid "pt"
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:229
+#: ../src/richtext/richtextbackgroundpage.cpp:231
+#: ../src/richtext/richtextbackgroundpage.cpp:252
+#: ../src/richtext/richtextbackgroundpage.cpp:254
+#: ../src/richtext/richtextbackgroundpage.cpp:292
+#: ../src/richtext/richtextbackgroundpage.cpp:294
+#: ../src/richtext/richtextbackgroundpage.cpp:319
+#: ../src/richtext/richtextbackgroundpage.cpp:321
+#, fuzzy
+msgid "Units for this value."
+msgstr ""
+"Δεν είναι δυνατή η αναμονή(wait) για τον τερματισμό του νήματος "
+"εκτέλεσης(thread)"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:234
+#, fuzzy
+msgid "&Vertical offset:"
+msgstr "Στοίχιση Αριστερά"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:241
+#: ../src/richtext/richtextbackgroundpage.cpp:243
+#, fuzzy
+msgid "The vertical offset."
+msgstr "Δεν ήταν δυνατή η εκκίνηση της εκτύπωσης."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:257
+#, fuzzy
+msgid "Shadow c&olour:"
+msgstr "Επιλέξτε χρώμα"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:259
+#: ../src/richtext/richtextbackgroundpage.cpp:261
+msgid "Enables the shadow colour."
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:265
+#: ../src/richtext/richtextbackgroundpage.cpp:267
+#, fuzzy
+msgid "The shadow colour."
+msgstr "Το χρώμα της γραμματοσειράς."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:270
+msgid "Sh&adow spread:"
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:272
+#: ../src/richtext/richtextbackgroundpage.cpp:274
+msgid "Enables the shadow spread."
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:281
+#: ../src/richtext/richtextbackgroundpage.cpp:283
+msgid "The shadow spread."
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:297
+msgid "&Blur distance:"
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:299
+#: ../src/richtext/richtextbackgroundpage.cpp:301
+#, fuzzy
+msgid "Enables the blur distance."
+msgstr "Δεν ήταν δυνατή η εκκίνηση της εκτύπωσης."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:308
+#: ../src/richtext/richtextbackgroundpage.cpp:310
+msgid "The shadow blur distance."
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:324
+msgid "Opaci&ty:"
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:326
+#: ../src/richtext/richtextbackgroundpage.cpp:328
+msgid "Enables the shadow opacity."
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:335
+#: ../src/richtext/richtextbackgroundpage.cpp:337
+msgid "The shadow opacity."
+msgstr ""
+
+#. TRANSLATORS: Rich text page units (percentage)
+#: ../src/richtext/richtextbackgroundpage.cpp:340
+#: ../src/richtext/richtextsizepage.cpp:339
+#: ../src/richtext/richtextsizepage.cpp:373
+#: ../src/richtext/richtextsizepage.cpp:400
+#: ../src/richtext/richtextsizepage.cpp:427
+#: ../src/richtext/richtextsizepage.cpp:454
+#: ../src/richtext/richtextsizepage.cpp:481
+#: ../src/richtext/richtextsizepage.cpp:555
+#: ../src/richtext/richtextsizepage.cpp:590
+#: ../src/richtext/richtextsizepage.cpp:625
+#: ../src/richtext/richtextsizepage.cpp:660
+#, fuzzy
+msgid "%"
+msgstr "%d"
+
+#: ../src/richtext/richtextborderspage.cpp:229
+#: ../src/richtext/richtextborderspage.cpp:387
+#, fuzzy
+msgid "Border"
+msgstr "Μοντέρνο"
+
+#: ../src/richtext/richtextborderspage.cpp:242
+#: ../src/richtext/richtextborderspage.cpp:410
+#: ../src/richtext/richtextindentspage.cpp:194
+#: ../src/richtext/richtextliststylepage.cpp:384
+#: ../src/richtext/richtextmarginspage.cpp:185
+#: ../src/richtext/richtextmarginspage.cpp:299
+#: ../src/richtext/richtextsizepage.cpp:531
+#: ../src/richtext/richtextsizepage.cpp:538
+msgid "&Left:"
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:257
+#: ../src/richtext/richtextborderspage.cpp:259
+msgid "Units for the left border width."
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:266
+#: ../src/richtext/richtextborderspage.cpp:268
+#: ../src/richtext/richtextborderspage.cpp:300
+#: ../src/richtext/richtextborderspage.cpp:302
+#: ../src/richtext/richtextborderspage.cpp:334
+#: ../src/richtext/richtextborderspage.cpp:336
+#: ../src/richtext/richtextborderspage.cpp:368
+#: ../src/richtext/richtextborderspage.cpp:370
+#: ../src/richtext/richtextborderspage.cpp:434
+#: ../src/richtext/richtextborderspage.cpp:436
+#: ../src/richtext/richtextborderspage.cpp:468
+#: ../src/richtext/richtextborderspage.cpp:470
+#: ../src/richtext/richtextborderspage.cpp:502
+#: ../src/richtext/richtextborderspage.cpp:504
+#: ../src/richtext/richtextborderspage.cpp:536
+#: ../src/richtext/richtextborderspage.cpp:538
+#, fuzzy
+msgid "The border line style."
+msgstr "Το στυλ της γραμματοσειράς."
+
+#: ../src/richtext/richtextborderspage.cpp:276
+#: ../src/richtext/richtextborderspage.cpp:444
+#: ../src/richtext/richtextindentspage.cpp:212
+#: ../src/richtext/richtextliststylepage.cpp:402
+#: ../src/richtext/richtextmarginspage.cpp:210
+#: ../src/richtext/richtextmarginspage.cpp:324
+#: ../src/richtext/richtextsizepage.cpp:601
+#: ../src/richtext/richtextsizepage.cpp:608
+#, fuzzy
+msgid "&Right:"
+msgstr "&Βάρος:"
+
+#: ../src/richtext/richtextborderspage.cpp:291
+#: ../src/richtext/richtextborderspage.cpp:293
+msgid "Units for the right border width."
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:310
+#: ../src/richtext/richtextborderspage.cpp:478
+#: ../src/richtext/richtextmarginspage.cpp:233
+#: ../src/richtext/richtextmarginspage.cpp:347
+#: ../src/richtext/richtextsizepage.cpp:566
+#: ../src/richtext/richtextsizepage.cpp:573
+#, fuzzy
+msgid "&Top:"
+msgstr "Πρός:"
+
+#: ../src/richtext/richtextborderspage.cpp:325
+#: ../src/richtext/richtextborderspage.cpp:327
+msgid "Units for the top border width."
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:344
+#: ../src/richtext/richtextborderspage.cpp:512
+#: ../src/richtext/richtextmarginspage.cpp:258
+#: ../src/richtext/richtextmarginspage.cpp:372
+#: ../src/richtext/richtextsizepage.cpp:636
+#: ../src/richtext/richtextsizepage.cpp:643
+msgid "&Bottom:"
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:359
+#: ../src/richtext/richtextborderspage.cpp:361
+msgid "Units for the bottom border width."
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:380
+#: ../src/richtext/richtextborderspage.cpp:548
+msgid "&Synchronize values"
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:382
+#: ../src/richtext/richtextborderspage.cpp:384
+#: ../src/richtext/richtextborderspage.cpp:550
+#: ../src/richtext/richtextborderspage.cpp:552
+msgid "Check to edit all borders simultaneously."
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:397
+#: ../src/richtext/richtextborderspage.cpp:555
+msgid "Outline"
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:425
+#: ../src/richtext/richtextborderspage.cpp:427
+msgid "Units for the left outline width."
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:459
+#: ../src/richtext/richtextborderspage.cpp:461
+msgid "Units for the right outline width."
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:493
+#: ../src/richtext/richtextborderspage.cpp:495
+msgid "Units for the top outline width."
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:527
+#: ../src/richtext/richtextborderspage.cpp:529
+msgid "Units for the bottom outline width."
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:565
+#: ../src/richtext/richtextborderspage.cpp:600
+msgid "Corner"
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:574
+msgid "Corner &radius:"
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:576
+#: ../src/richtext/richtextborderspage.cpp:578
+msgid "An optional corner radius for adding rounded corners."
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:584
+#: ../src/richtext/richtextborderspage.cpp:586
+msgid "The value of the corner radius."
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:595
+#: ../src/richtext/richtextborderspage.cpp:597
+#, fuzzy
+msgid "Units for the corner radius."
+msgstr ""
+"Δεν είναι δυνατή η αναμονή(wait) για τον τερματισμό του νήματος "
+"εκτέλεσης(thread)"
+
+#: ../src/richtext/richtextborderspage.cpp:609
+#: ../src/richtext/richtextsizepage.cpp:247
+#: ../src/richtext/richtextsizepage.cpp:251
+#, fuzzy
+msgid "None"
+msgstr "Έτοιμο"
+
+#: ../src/richtext/richtextborderspage.cpp:610
+#, fuzzy
+msgid "Solid"
+msgstr "Έντονο"
+
+#: ../src/richtext/richtextborderspage.cpp:611
+#, fuzzy
+msgid "Dotted"
+msgstr "Έτοιμο"
+
+#: ../src/richtext/richtextborderspage.cpp:612
+#, fuzzy
+msgid "Dashed"
+msgstr "Ημερομηνία"
+
+#: ../src/richtext/richtextborderspage.cpp:613
+#, fuzzy
+msgid "Double"
+msgstr "Έτοιμο"
+
+#: ../src/richtext/richtextborderspage.cpp:614
+msgid "Groove"
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:615
+#, fuzzy
+msgid "Ridge"
+msgstr "Απαλό(light)"
+
+#: ../src/richtext/richtextborderspage.cpp:616
+#, fuzzy
+msgid "Inset"
+msgstr "Στοίχιση"
+
+#: ../src/richtext/richtextborderspage.cpp:617
+msgid "Outset"
+msgstr ""
+
+#: ../src/richtext/richtextbuffer.cpp:3518
+msgid "Change Style"
+msgstr ""
+
+#: ../src/richtext/richtextbuffer.cpp:3701
+msgid "Change Object Style"
+msgstr ""
+
+#: ../src/richtext/richtextbuffer.cpp:3974
+#: ../src/richtext/richtextbuffer.cpp:8174
+#, fuzzy
+msgid "Change Properties"
+msgstr "&Ιδιότητες"
+
+#: ../src/richtext/richtextbuffer.cpp:4346
+msgid "Change List Style"
+msgstr ""
+
+#: ../src/richtext/richtextbuffer.cpp:4519
+msgid "Renumber List"
+msgstr ""
+
+#: ../src/richtext/richtextbuffer.cpp:7867
+#: ../src/richtext/richtextbuffer.cpp:7897
+#: ../src/richtext/richtextbuffer.cpp:7939
+#: ../src/richtext/richtextctrl.cpp:1279 ../src/richtext/richtextctrl.cpp:1473
+msgid "Insert Text"
+msgstr ""
+
+#: ../src/richtext/richtextbuffer.cpp:8023
+#: ../src/richtext/richtextbuffer.cpp:8979
+msgid "Insert Image"
+msgstr ""
+
+#: ../src/richtext/richtextbuffer.cpp:8070
+#, fuzzy
+msgid "Insert Object"
+msgstr "Στοίχιση"
+
+#: ../src/richtext/richtextbuffer.cpp:8112
+#, fuzzy
+msgid "Insert Field"
+msgstr "Στοίχιση"
+
+#: ../src/richtext/richtextbuffer.cpp:8410
+msgid "Too many EndStyle calls!"
+msgstr ""
+
+#: ../src/richtext/richtextbuffer.cpp:8785
+#, fuzzy
+msgid "files"
+msgstr "Αρχείο"
+
+#: ../src/richtext/richtextbuffer.cpp:9380
+msgid "standard/circle"
+msgstr ""
+
+#: ../src/richtext/richtextbuffer.cpp:9381
+msgid "standard/circle-outline"
+msgstr ""
+
+#: ../src/richtext/richtextbuffer.cpp:9382
+msgid "standard/square"
+msgstr ""
+
+#: ../src/richtext/richtextbuffer.cpp:9383
+msgid "standard/diamond"
+msgstr ""
+
+#: ../src/richtext/richtextbuffer.cpp:9384
+msgid "standard/triangle"
+msgstr ""
+
+#: ../src/richtext/richtextbuffer.cpp:9423
+#, fuzzy
+msgid "Box Properties"
+msgstr "&Ιδιότητες"
+
+#: ../src/richtext/richtextbuffer.cpp:10006
+msgid "Multiple Cell Properties"
+msgstr ""
+
+#: ../src/richtext/richtextbuffer.cpp:10008
+#, fuzzy
+msgid "Cell Properties"
+msgstr "&Ιδιότητες"
+
+#: ../src/richtext/richtextbuffer.cpp:11256
+#, fuzzy
+msgid "Set Cell Style"
+msgstr "Διαγραφή στοιχείου"
+
+#: ../src/richtext/richtextbuffer.cpp:11330
+#, fuzzy
+msgid "Delete Row"
+msgstr "&Διαγραφή"
+
+#: ../src/richtext/richtextbuffer.cpp:11380
+#, fuzzy
+msgid "Delete Column"
+msgstr "Τμήματα"
+
+#: ../src/richtext/richtextbuffer.cpp:11431
+msgid "Add Row"
+msgstr ""
+
+#: ../src/richtext/richtextbuffer.cpp:11494
+msgid "Add Column"
+msgstr ""
+
+#: ../src/richtext/richtextbuffer.cpp:11537
+#, fuzzy
+msgid "Table Properties"
+msgstr "&Ιδιότητες"
+
+#: ../src/richtext/richtextbuffer.cpp:12899
+#, fuzzy
+msgid "Picture Properties"
+msgstr "&Ιδιότητες"
+
+#: ../src/richtext/richtextbuffer.cpp:13169
+#: ../src/richtext/richtextbuffer.cpp:13279
+#, fuzzy
+msgid "image"
+msgstr "Ώρα"
+
+#: ../src/richtext/richtextbulletspage.cpp:145
+#: ../src/richtext/richtextliststylepage.cpp:209
+msgid "&Bullet style:"
+msgstr ""
+
+#: ../src/richtext/richtextbulletspage.cpp:150
+#: ../src/richtext/richtextbulletspage.cpp:152
+#: ../src/richtext/richtextliststylepage.cpp:214
+#: ../src/richtext/richtextliststylepage.cpp:216
+msgid "The available bullet styles."
+msgstr ""
+
+#: ../src/richtext/richtextbulletspage.cpp:158
+#: ../src/richtext/richtextliststylepage.cpp:221
+msgid "Peri&od"
+msgstr ""
+
+#: ../src/richtext/richtextbulletspage.cpp:160
+#: ../src/richtext/richtextbulletspage.cpp:162
+#: ../src/richtext/richtextliststylepage.cpp:223
+#: ../src/richtext/richtextliststylepage.cpp:225
+msgid "Check to add a period after the bullet."
+msgstr ""
+
+#. TRANSLATORS: Bullet point in parentheses option
+#: ../src/richtext/richtextbulletspage.cpp:167
+#: ../src/richtext/richtextliststylepage.cpp:230
+msgid "(*)"
+msgstr ""
+
+#: ../src/richtext/richtextbulletspage.cpp:169
+#: ../src/richtext/richtextbulletspage.cpp:171
+#: ../src/richtext/richtextliststylepage.cpp:232
+#: ../src/richtext/richtextliststylepage.cpp:234
+msgid "Check to enclose the bullet in parentheses."
+msgstr ""
+
+#. TRANSLATORS: Right parenthesis bullet point option
+#: ../src/richtext/richtextbulletspage.cpp:176
+#: ../src/richtext/richtextliststylepage.cpp:239
+msgid "*)"
+msgstr ""
+
+#: ../src/richtext/richtextbulletspage.cpp:178
+#: ../src/richtext/richtextbulletspage.cpp:180
+#: ../src/richtext/richtextliststylepage.cpp:241
+#: ../src/richtext/richtextliststylepage.cpp:243
+msgid "Check to add a right parenthesis."
+msgstr ""
+
+#: ../src/richtext/richtextbulletspage.cpp:185
+#: ../src/richtext/richtextliststylepage.cpp:248
+msgid "Bullet &Alignment:"
+msgstr ""
+
+#: ../src/richtext/richtextbulletspage.cpp:190
+#: ../src/richtext/richtextliststylepage.cpp:253
+#, fuzzy
+msgid "Centre"
+msgstr "Στο κέντρο"
+
+#: ../src/richtext/richtextbulletspage.cpp:194
+#: ../src/richtext/richtextbulletspage.cpp:196
+#: ../src/richtext/richtextbulletspage.cpp:217
+#: ../src/richtext/richtextbulletspage.cpp:219
+#: ../src/richtext/richtextliststylepage.cpp:257
+#: ../src/richtext/richtextliststylepage.cpp:259
+#: ../src/richtext/richtextliststylepage.cpp:278
+#: ../src/richtext/richtextliststylepage.cpp:280
+msgid "The bullet character."
+msgstr ""
+
+#: ../src/richtext/richtextbulletspage.cpp:212
+#: ../src/richtext/richtextliststylepage.cpp:271
+#, fuzzy
+msgid "&Symbol:"
+msgstr "&Στυλ:"
+
+#: ../src/richtext/richtextbulletspage.cpp:222
+#: ../src/richtext/richtextliststylepage.cpp:283
+#, fuzzy
+msgid "Ch&oose..."
+msgstr "&Μετάβαση..."
+
+#: ../src/richtext/richtextbulletspage.cpp:223
+#: ../src/richtext/richtextbulletspage.cpp:225
+#: ../src/richtext/richtextliststylepage.cpp:284
+#: ../src/richtext/richtextliststylepage.cpp:286
+msgid "Click to browse for a symbol."
+msgstr ""
+
+#: ../src/richtext/richtextbulletspage.cpp:230
+#: ../src/richtext/richtextliststylepage.cpp:291
+#, fuzzy
+msgid "Symbol &font:"
+msgstr "Κανονική γραμματοσειρά:"
+
+#: ../src/richtext/richtextbulletspage.cpp:235
+#: ../src/richtext/richtextbulletspage.cpp:237
+#: ../src/richtext/richtextliststylepage.cpp:297
+msgid "Available fonts."
+msgstr ""
+
+#: ../src/richtext/richtextbulletspage.cpp:242
+#: ../src/richtext/richtextliststylepage.cpp:302
+msgid "S&tandard bullet name:"
+msgstr ""
+
+#: ../src/richtext/richtextbulletspage.cpp:247
+#: ../src/richtext/richtextbulletspage.cpp:249
+#: ../src/richtext/richtextliststylepage.cpp:307
+#: ../src/richtext/richtextliststylepage.cpp:309
+msgid "A standard bullet name."
+msgstr ""
+
+#: ../src/richtext/richtextbulletspage.cpp:254
+msgid "&Number:"
+msgstr ""
+
+#: ../src/richtext/richtextbulletspage.cpp:258
+#: ../src/richtext/richtextbulletspage.cpp:260
+msgid "The list item number."
+msgstr ""
+
+#: ../src/richtext/richtextbulletspage.cpp:266
+#: ../src/richtext/richtextbulletspage.cpp:268
+#: ../src/richtext/richtextliststylepage.cpp:475
+#: ../src/richtext/richtextliststylepage.cpp:477
+msgid "Shows a preview of the bullet settings."
+msgstr ""
+
+#: ../src/richtext/richtextbulletspage.cpp:276
+#: ../src/richtext/richtextliststylepage.cpp:484
+msgid "(None)"
+msgstr ""
+
+#: ../src/richtext/richtextbulletspage.cpp:277
+#: ../src/richtext/richtextliststylepage.cpp:485
+msgid "Arabic"
+msgstr ""
+
+#: ../src/richtext/richtextbulletspage.cpp:278
+#: ../src/richtext/richtextliststylepage.cpp:486
+msgid "Upper case letters"
+msgstr ""
+
+#: ../src/richtext/richtextbulletspage.cpp:279
+#: ../src/richtext/richtextliststylepage.cpp:487
+msgid "Lower case letters"
+msgstr ""
+
+#: ../src/richtext/richtextbulletspage.cpp:280
+#: ../src/richtext/richtextliststylepage.cpp:488
+msgid "Upper case roman numerals"
+msgstr ""
+
+#: ../src/richtext/richtextbulletspage.cpp:281
+#: ../src/richtext/richtextliststylepage.cpp:489
+msgid "Lower case roman numerals"
+msgstr ""
+
+#: ../src/richtext/richtextbulletspage.cpp:282
+#: ../src/richtext/richtextliststylepage.cpp:490
+msgid "Numbered outline"
+msgstr ""
+
+#: ../src/richtext/richtextbulletspage.cpp:283
+#: ../src/richtext/richtextliststylepage.cpp:491
+msgid "Symbol"
+msgstr ""
+
+#: ../src/richtext/richtextbulletspage.cpp:284
+#: ../src/richtext/richtextliststylepage.cpp:492
+msgid "Bitmap"
+msgstr ""
+
+#: ../src/richtext/richtextbulletspage.cpp:285
+#: ../src/richtext/richtextliststylepage.cpp:493
+msgid "Standard"
+msgstr ""
+
+#: ../src/richtext/richtextbulletspage.cpp:287
+#: ../src/richtext/richtextliststylepage.cpp:495
+msgid "*"
+msgstr ""
+
+#: ../src/richtext/richtextbulletspage.cpp:288
+#: ../src/richtext/richtextliststylepage.cpp:496
+msgid "-"
+msgstr ""
+
+#: ../src/richtext/richtextbulletspage.cpp:289
+#: ../src/richtext/richtextliststylepage.cpp:497
+#, fuzzy
+msgid ">"
+msgstr ">>"
+
+#: ../src/richtext/richtextbulletspage.cpp:290
+#: ../src/richtext/richtextliststylepage.cpp:498
+msgid "+"
+msgstr ""
+
+#: ../src/richtext/richtextbulletspage.cpp:291
+#: ../src/richtext/richtextliststylepage.cpp:499
+msgid "~"
+msgstr ""
+
+#: ../src/richtext/richtextctrl.cpp:859
+msgid "Drag"
+msgstr ""
+
+#: ../src/richtext/richtextctrl.cpp:1338 ../src/richtext/richtextctrl.cpp:1559
+#, fuzzy
+msgid "Delete Text"
+msgstr "Διαγραφή στοιχείου"
+
+#: ../src/richtext/richtextctrl.cpp:1537
+#, fuzzy
+msgid "Remove Bullet"
+msgstr "Απομάκρυνση"
+
+#: ../src/richtext/richtextctrl.cpp:3070
+msgid "The text couldn't be saved."
+msgstr "Το κείμενο δεν μπόρεσε να αποθυκευτεί."
+
+#: ../src/richtext/richtextctrl.cpp:3644
+#, fuzzy
+msgid "Replace"
+msgstr "&Αντικατάσταση"
+
+#: ../src/richtext/richtextfontpage.cpp:146
+#: ../src/richtext/richtextsymboldlg.cpp:384
+#, fuzzy
+msgid "&Font:"
+msgstr "Οικογένεια γραμματοσειράς:"
+
+#: ../src/richtext/richtextfontpage.cpp:150
+#: ../src/richtext/richtextfontpage.cpp:152
+#, fuzzy
+msgid "Type a font name."
+msgstr "Η οικογένεια της γραμματοσειρας."
+
+#: ../src/richtext/richtextfontpage.cpp:158
+#, fuzzy
+msgid "&Size:"
+msgstr "&Μέγεθος"
+
+#: ../src/richtext/richtextfontpage.cpp:165
+#: ../src/richtext/richtextfontpage.cpp:167
+msgid "Type a size in points."
+msgstr ""
+
+#: ../src/richtext/richtextfontpage.cpp:180
+#: ../src/richtext/richtextfontpage.cpp:182
+#, fuzzy
+msgid "The font size units, points or pixels."
+msgstr "Το μέγεθος κουκίδας γραμματοσειράς"
+
+#: ../src/richtext/richtextfontpage.cpp:189
+#: ../src/richtext/richtextfontpage.cpp:191
+#, fuzzy
+msgid "Lists the available fonts."
+msgstr "Το Tip δεν είναι διαθέσιμο, συγγνώμη!"
+
+#: ../src/richtext/richtextfontpage.cpp:196
+#: ../src/richtext/richtextfontpage.cpp:198
+msgid "Lists font sizes in points."
+msgstr ""
+
+#: ../src/richtext/richtextfontpage.cpp:207
+#, fuzzy
+msgid "Font st&yle:"
+msgstr "Μέγεθος γραμματοσειράς:"
+
+#: ../src/richtext/richtextfontpage.cpp:212
+#: ../src/richtext/richtextfontpage.cpp:214
+msgid "Select regular or italic style."
+msgstr ""
+
+#: ../src/richtext/richtextfontpage.cpp:220
+#, fuzzy
+msgid "Font &weight:"
+msgstr "Το βάρος της γραμματοσειράς."
+
+#: ../src/richtext/richtextfontpage.cpp:225
+#: ../src/richtext/richtextfontpage.cpp:227
+msgid "Select regular or bold."
+msgstr ""
+
+#: ../src/richtext/richtextfontpage.cpp:233
+#, fuzzy
+msgid "&Underlining:"
+msgstr "&Υπογράμμιση"
+
+#: ../src/richtext/richtextfontpage.cpp:238
+#: ../src/richtext/richtextfontpage.cpp:240
+msgid "Select underlining or no underlining."
+msgstr ""
+
+#: ../src/richtext/richtextfontpage.cpp:248
+#, fuzzy
+msgid "&Colour:"
+msgstr "&Χρώμα:"
+
+#: ../src/richtext/richtextfontpage.cpp:253
+#: ../src/richtext/richtextfontpage.cpp:255
+#, fuzzy
+msgid "Click to change the text colour."
+msgstr "Κάνετε κλικ για να ακυρώσετε την επιλογή γραμματοσειράς."
+
+#: ../src/richtext/richtextfontpage.cpp:261
+#, fuzzy
+msgid "&Bg colour:"
+msgstr "&Χρώμα:"
+
+#: ../src/richtext/richtextfontpage.cpp:266
+#: ../src/richtext/richtextfontpage.cpp:268
+#, fuzzy
+msgid "Click to change the text background colour."
+msgstr "Κάνετε κλικ για να ακυρώσετε την επιλογή γραμματοσειράς."
+
+#: ../src/richtext/richtextfontpage.cpp:276
+#: ../src/richtext/richtextfontpage.cpp:278
+#, fuzzy
+msgid "Check to show a line through the text."
+msgstr "Κάνετε κλικ για να ακυρώσετε την επιλογή γραμματοσειράς."
+
+#: ../src/richtext/richtextfontpage.cpp:281
+msgid "Ca&pitals"
+msgstr ""
+
+#: ../src/richtext/richtextfontpage.cpp:283
+#: ../src/richtext/richtextfontpage.cpp:285
+#, fuzzy
+msgid "Check to show the text in capitals."
+msgstr "Κάνετε κλικ για να ακυρώσετε την επιλογή γραμματοσειράς."
+
+#: ../src/richtext/richtextfontpage.cpp:288
+msgid "Small C&apitals"
+msgstr ""
+
+#: ../src/richtext/richtextfontpage.cpp:290
+#: ../src/richtext/richtextfontpage.cpp:292
+#, fuzzy
+msgid "Check to show the text in small capitals."
+msgstr "Κάνετε κλικ για να ακυρώσετε την επιλογή γραμματοσειράς."
+
+#: ../src/richtext/richtextfontpage.cpp:295
+#, fuzzy
+msgid "Supe&rscript"
+msgstr "Χειρόγραφο(Script)"
+
+#: ../src/richtext/richtextfontpage.cpp:297
+#: ../src/richtext/richtextfontpage.cpp:299
+#, fuzzy
+msgid "Check to show the text in superscript."
+msgstr "Κάνετε κλικ για να ακυρώσετε την επιλογή γραμματοσειράς."
+
+#: ../src/richtext/richtextfontpage.cpp:302
+#, fuzzy
+msgid "Subscrip&t"
+msgstr "Χειρόγραφο(Script)"
+
+#: ../src/richtext/richtextfontpage.cpp:304
+#: ../src/richtext/richtextfontpage.cpp:306
+#, fuzzy
+msgid "Check to show the text in subscript."
+msgstr "Κάνετε κλικ για να ακυρώσετε την επιλογή γραμματοσειράς."
+
+#: ../src/richtext/richtextfontpage.cpp:312
+msgid "Rig&ht-to-left"
+msgstr ""
+
+#: ../src/richtext/richtextfontpage.cpp:314
+#: ../src/richtext/richtextfontpage.cpp:316
+#, fuzzy
+msgid "Check to indicate right-to-left text layout."
+msgstr "Κάνετε κλικ για να ακυρώσετε την επιλογή γραμματοσειράς."
+
+#: ../src/richtext/richtextfontpage.cpp:319
+msgid "Suppress hyphe&nation"
+msgstr ""
+
+#: ../src/richtext/richtextfontpage.cpp:321
+#: ../src/richtext/richtextfontpage.cpp:323
+msgid "Check to suppress hyphenation."
+msgstr ""
+
+#: ../src/richtext/richtextfontpage.cpp:329
+#: ../src/richtext/richtextfontpage.cpp:331
+msgid "Shows a preview of the font settings."
+msgstr ""
+
+#: ../src/richtext/richtextfontpage.cpp:348
+#: ../src/richtext/richtextfontpage.cpp:352
+#: ../src/richtext/richtextfontpage.cpp:356
+#: ../src/richtext/richtextformatdlg.cpp:873
+#: ../src/richtext/richtextindentspage.cpp:273
+#: ../src/richtext/richtextindentspage.cpp:285
+#: ../src/richtext/richtextindentspage.cpp:286
+#: ../src/richtext/richtextindentspage.cpp:310
+#: ../src/richtext/richtextindentspage.cpp:325
+#: ../src/richtext/richtextliststylepage.cpp:451
+#: ../src/richtext/richtextliststylepage.cpp:463
+#: ../src/richtext/richtextliststylepage.cpp:464
+#, fuzzy
+msgid "(none)"
+msgstr "ανώνυμο"
+
+#: ../src/richtext/richtextfontpage.cpp:349
+#: ../src/richtext/richtextfontpage.cpp:353
+msgid "Regular"
+msgstr ""
+
+#: ../src/richtext/richtextfontpage.cpp:357
+#, fuzzy
+msgid "Not underlined"
+msgstr "υπογεγραμμένο"
+
+#: ../src/richtext/richtextformatdlg.cpp:341
+msgid "Indents && Spacing"
+msgstr ""
+
+#: ../src/richtext/richtextformatdlg.cpp:346
+msgid "Tabs"
+msgstr ""
+
+#: ../src/richtext/richtextformatdlg.cpp:351
+msgid "Bullets"
+msgstr ""
+
+#: ../src/richtext/richtextformatdlg.cpp:356
+msgid "List Style"
+msgstr ""
+
+#: ../src/richtext/richtextformatdlg.cpp:366
+#: ../src/richtext/richtextmarginspage.cpp:170
+msgid "Margins"
+msgstr ""
+
+#: ../src/richtext/richtextformatdlg.cpp:371
+#, fuzzy
+msgid "Borders"
+msgstr "Μοντέρνο"
+
+#: ../src/richtext/richtextformatdlg.cpp:765
+#, fuzzy
+msgid "Colour"
+msgstr "&Χρώμα:"
+
+#: ../src/richtext/richtextindentspage.cpp:127
+#: ../src/richtext/richtextliststylepage.cpp:322
+#, fuzzy
+msgid "&Alignment"
+msgstr "Στοίχιση Αριστερά"
+
+#: ../src/richtext/richtextindentspage.cpp:138
+#: ../src/richtext/richtextliststylepage.cpp:331
+msgid "&Left"
+msgstr ""
+
+#: ../src/richtext/richtextindentspage.cpp:140
+#: ../src/richtext/richtextindentspage.cpp:142
+#: ../src/richtext/richtextliststylepage.cpp:333
+#: ../src/richtext/richtextliststylepage.cpp:335
+msgid "Left-align text."
+msgstr ""
+
+#: ../src/richtext/richtextindentspage.cpp:145
+#: ../src/richtext/richtextliststylepage.cpp:338
+#, fuzzy
+msgid "&Right"
+msgstr "Απαλό(light)"
+
+#: ../src/richtext/richtextindentspage.cpp:147
+#: ../src/richtext/richtextindentspage.cpp:149
+#: ../src/richtext/richtextliststylepage.cpp:340
+#: ../src/richtext/richtextliststylepage.cpp:342
+msgid "Right-align text."
+msgstr ""
+
+#: ../src/richtext/richtextindentspage.cpp:152
+#: ../src/richtext/richtextliststylepage.cpp:345
+#, fuzzy
+msgid "&Justified"
+msgstr "Ευθυγραμμισμένα"
+
+#: ../src/richtext/richtextindentspage.cpp:154
+#: ../src/richtext/richtextindentspage.cpp:156
+#: ../src/richtext/richtextliststylepage.cpp:347
+#: ../src/richtext/richtextliststylepage.cpp:349
+msgid "Justify text left and right."
+msgstr ""
+
+#: ../src/richtext/richtextindentspage.cpp:159
+#: ../src/richtext/richtextliststylepage.cpp:352
+#, fuzzy
+msgid "Cen&tred"
+msgstr "Στο κέντρο"
+
+#: ../src/richtext/richtextindentspage.cpp:161
+#: ../src/richtext/richtextindentspage.cpp:163
+#: ../src/richtext/richtextliststylepage.cpp:354
+#: ../src/richtext/richtextliststylepage.cpp:356
+#, fuzzy
+msgid "Centre text."
+msgstr "Δεν είναι δυνατή η δημιουργία του mutex."
+
+#: ../src/richtext/richtextindentspage.cpp:166
+#: ../src/richtext/richtextliststylepage.cpp:359
+#, fuzzy
+msgid "&Indeterminate"
+msgstr "&Υπογράμμιση"
+
+#: ../src/richtext/richtextindentspage.cpp:168
+#: ../src/richtext/richtextindentspage.cpp:170
+#: ../src/richtext/richtextliststylepage.cpp:361
+#: ../src/richtext/richtextliststylepage.cpp:363
+msgid "Use the current alignment setting."
+msgstr ""
+
+#: ../src/richtext/richtextindentspage.cpp:183
+#: ../src/richtext/richtextliststylepage.cpp:375
+msgid "&Indentation (tenths of a mm)"
+msgstr ""
+
+#: ../src/richtext/richtextindentspage.cpp:198
+#: ../src/richtext/richtextindentspage.cpp:200
+#: ../src/richtext/richtextliststylepage.cpp:388
+#: ../src/richtext/richtextliststylepage.cpp:390
+#, fuzzy
+msgid "The left indent."
+msgstr "Το βάρος της γραμματοσειράς."
+
+#: ../src/richtext/richtextindentspage.cpp:203
+#: ../src/richtext/richtextliststylepage.cpp:393
+msgid "Left (&first line):"
+msgstr ""
+
+#: ../src/richtext/richtextindentspage.cpp:207
+#: ../src/richtext/richtextindentspage.cpp:209
+#: ../src/richtext/richtextliststylepage.cpp:397
+#: ../src/richtext/richtextliststylepage.cpp:399
+#, fuzzy
+msgid "The first line indent."
+msgstr "Το μέγεθος κουκίδας γραμματοσειράς"
+
+#: ../src/richtext/richtextindentspage.cpp:216
+#: ../src/richtext/richtextindentspage.cpp:218
+#: ../src/richtext/richtextliststylepage.cpp:406
+#: ../src/richtext/richtextliststylepage.cpp:408
+msgid "The right indent."
+msgstr ""
+
+#: ../src/richtext/richtextindentspage.cpp:221
+msgid "&Outline level:"
+msgstr ""
+
+#: ../src/richtext/richtextindentspage.cpp:226
+#: ../src/richtext/richtextindentspage.cpp:228
+#, fuzzy
+msgid "The outline level."
+msgstr "Εμφανίζει την προεπισκόπηση της γραμματοσειράς"
+
+#: ../src/richtext/richtextindentspage.cpp:241
+#: ../src/richtext/richtextliststylepage.cpp:420
+msgid "&Spacing (tenths of a mm)"
+msgstr ""
+
+#: ../src/richtext/richtextindentspage.cpp:252
+msgid "&Before a paragraph:"
+msgstr ""
+
+#: ../src/richtext/richtextindentspage.cpp:256
+#: ../src/richtext/richtextindentspage.cpp:258
+#: ../src/richtext/richtextliststylepage.cpp:433
+#: ../src/richtext/richtextliststylepage.cpp:435
+msgid "The spacing before the paragraph."
+msgstr ""
+
+#: ../src/richtext/richtextindentspage.cpp:261
+msgid "&After a paragraph:"
+msgstr ""
+
+#: ../src/richtext/richtextindentspage.cpp:266
+#: ../src/richtext/richtextliststylepage.cpp:442
+#: ../src/richtext/richtextliststylepage.cpp:444
+msgid "The spacing after the paragraph."
+msgstr ""
+
+#: ../src/richtext/richtextindentspage.cpp:269
+msgid "L&ine spacing:"
+msgstr ""
+
+#: ../src/richtext/richtextindentspage.cpp:274
+#: ../src/richtext/richtextliststylepage.cpp:452
+msgid "Single"
+msgstr ""
+
+#: ../src/richtext/richtextindentspage.cpp:275
+#: ../src/richtext/richtextliststylepage.cpp:453
+msgid "1.1"
+msgstr ""
+
+#: ../src/richtext/richtextindentspage.cpp:276
+#: ../src/richtext/richtextliststylepage.cpp:454
+msgid "1.2"
+msgstr ""
+
+#: ../src/richtext/richtextindentspage.cpp:277
+#: ../src/richtext/richtextliststylepage.cpp:455
+msgid "1.3"
+msgstr ""
+
+#: ../src/richtext/richtextindentspage.cpp:278
+#: ../src/richtext/richtextliststylepage.cpp:456
+msgid "1.4"
+msgstr ""
+
+#: ../src/richtext/richtextindentspage.cpp:279
+#: ../src/richtext/richtextliststylepage.cpp:457
+msgid "1.5"
+msgstr ""
+
+#: ../src/richtext/richtextindentspage.cpp:280
+#: ../src/richtext/richtextliststylepage.cpp:458
+msgid "1.6"
+msgstr ""
+
+#: ../src/richtext/richtextindentspage.cpp:281
+#: ../src/richtext/richtextliststylepage.cpp:459
+msgid "1.7"
+msgstr ""
+
+#: ../src/richtext/richtextindentspage.cpp:282
+#: ../src/richtext/richtextliststylepage.cpp:460
+msgid "1.8"
+msgstr ""
+
+#: ../src/richtext/richtextindentspage.cpp:283
+#: ../src/richtext/richtextliststylepage.cpp:461
+msgid "1.9"
+msgstr ""
+
+#: ../src/richtext/richtextindentspage.cpp:284
+#: ../src/richtext/richtextliststylepage.cpp:462
+msgid "2"
+msgstr ""
+
+#: ../src/richtext/richtextindentspage.cpp:287
+#: ../src/richtext/richtextindentspage.cpp:289
+#: ../src/richtext/richtextliststylepage.cpp:465
+#: ../src/richtext/richtextliststylepage.cpp:467
+msgid "The line spacing."
+msgstr ""
+
+#: ../src/richtext/richtextindentspage.cpp:292
+msgid "&Page Break"
+msgstr ""
+
+#: ../src/richtext/richtextindentspage.cpp:294
+#: ../src/richtext/richtextindentspage.cpp:296
+msgid "Inserts a page break before the paragraph."
+msgstr ""
+
+#: ../src/richtext/richtextindentspage.cpp:302
+#: ../src/richtext/richtextindentspage.cpp:304
+msgid "Shows a preview of the paragraph settings."
+msgstr ""
+
+#: ../src/richtext/richtextliststylepage.cpp:182
+msgid "&List level:"
+msgstr ""
+
+#: ../src/richtext/richtextliststylepage.cpp:186
+#: ../src/richtext/richtextliststylepage.cpp:188
+msgid "Selects the list level to edit."
+msgstr ""
+
+#: ../src/richtext/richtextliststylepage.cpp:193
+msgid "&Font for Level..."
+msgstr ""
+
+#: ../src/richtext/richtextliststylepage.cpp:194
+#: ../src/richtext/richtextliststylepage.cpp:196
+#, fuzzy
+msgid "Click to choose the font for this level."
+msgstr "Κάνετε κλικ για να ακυρώσετε την επιλογή γραμματοσειράς."
+
+#: ../src/richtext/richtextliststylepage.cpp:312
+msgid "Bullet style"
+msgstr ""
+
+#: ../src/richtext/richtextliststylepage.cpp:429
+msgid "Before a paragraph:"
+msgstr ""
+
+#: ../src/richtext/richtextliststylepage.cpp:438
+msgid "After a paragraph:"
+msgstr ""
+
+#: ../src/richtext/richtextliststylepage.cpp:447
+msgid "Line spacing:"
+msgstr ""
+
+#: ../src/richtext/richtextliststylepage.cpp:470
+#, fuzzy
+msgid "Spacing"
+msgstr "Γίνεται αναζήτηση..."
+
+#: ../src/richtext/richtextmarginspage.cpp:193
+#: ../src/richtext/richtextmarginspage.cpp:195
+#, fuzzy
+msgid "The left margin size."
+msgstr "Το μέγεθος κουκίδας γραμματοσειράς"
+
+#: ../src/richtext/richtextmarginspage.cpp:203
+#: ../src/richtext/richtextmarginspage.cpp:205
+msgid "Units for the left margin."
+msgstr ""
+
+#: ../src/richtext/richtextmarginspage.cpp:218
+#: ../src/richtext/richtextmarginspage.cpp:220
+#, fuzzy
+msgid "The right margin size."
+msgstr "Το μέγεθος κουκίδας γραμματοσειράς"
+
+#: ../src/richtext/richtextmarginspage.cpp:228
+#: ../src/richtext/richtextmarginspage.cpp:230
+msgid "Units for the right margin."
+msgstr ""
+
+#: ../src/richtext/richtextmarginspage.cpp:241
+#: ../src/richtext/richtextmarginspage.cpp:243
+#, fuzzy
+msgid "The top margin size."
+msgstr "Το μέγεθος κουκίδας γραμματοσειράς"
+
+#: ../src/richtext/richtextmarginspage.cpp:251
+#: ../src/richtext/richtextmarginspage.cpp:253
+#, fuzzy
+msgid "Units for the top margin."
+msgstr ""
+"Δεν είναι δυνατή η αναμονή(wait) για τον τερματισμό του νήματος "
+"εκτέλεσης(thread)"
+
+#: ../src/richtext/richtextmarginspage.cpp:266
+#: ../src/richtext/richtextmarginspage.cpp:268
+#, fuzzy
+msgid "The bottom margin size."
+msgstr "Το μέγεθος κουκίδας γραμματοσειράς"
+
+#: ../src/richtext/richtextmarginspage.cpp:276
+#: ../src/richtext/richtextmarginspage.cpp:278
+msgid "Units for the bottom margin."
+msgstr ""
+
+#: ../src/richtext/richtextmarginspage.cpp:284
+#, fuzzy
+msgid "Padding"
+msgstr "γίνεται ανάγνωση"
+
+#: ../src/richtext/richtextmarginspage.cpp:307
+#: ../src/richtext/richtextmarginspage.cpp:309
+#, fuzzy
+msgid "The left padding size."
+msgstr "Το μέγεθος κουκίδας γραμματοσειράς"
+
+#: ../src/richtext/richtextmarginspage.cpp:317
+#: ../src/richtext/richtextmarginspage.cpp:319
+msgid "Units for the left padding."
+msgstr ""
+
+#: ../src/richtext/richtextmarginspage.cpp:332
+#: ../src/richtext/richtextmarginspage.cpp:334
+#, fuzzy
+msgid "The right padding size."
+msgstr "Το μέγεθος κουκίδας γραμματοσειράς"
+
+#: ../src/richtext/richtextmarginspage.cpp:342
+#: ../src/richtext/richtextmarginspage.cpp:344
+msgid "Units for the right padding."
+msgstr ""
+
+#: ../src/richtext/richtextmarginspage.cpp:355
+#: ../src/richtext/richtextmarginspage.cpp:357
+#, fuzzy
+msgid "The top padding size."
+msgstr "Το μέγεθος κουκίδας γραμματοσειράς"
+
+#: ../src/richtext/richtextmarginspage.cpp:365
+#: ../src/richtext/richtextmarginspage.cpp:367
+msgid "Units for the top padding."
+msgstr ""
+
+#: ../src/richtext/richtextmarginspage.cpp:380
+#: ../src/richtext/richtextmarginspage.cpp:382
+#, fuzzy
+msgid "The bottom padding size."
+msgstr "Το μέγεθος κουκίδας γραμματοσειράς"
+
+#: ../src/richtext/richtextmarginspage.cpp:390
+#: ../src/richtext/richtextmarginspage.cpp:392
+msgid "Units for the bottom padding."
+msgstr ""
+
+#: ../src/richtext/richtextprint.cpp:592
+msgid " Preview"
+msgstr " Προεπισκόπηση"
+
+#: ../src/richtext/richtextsizepage.cpp:228
+msgid "Floating"
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:243
+msgid "&Floating mode:"
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:252
+#: ../src/richtext/richtextsizepage.cpp:254
+msgid "How the object will float relative to the text."
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:265
+#, fuzzy
+msgid "Alignment"
+msgstr "Στοίχιση Αριστερά"
+
+#: ../src/richtext/richtextsizepage.cpp:277
+#, fuzzy
+msgid "&Vertical alignment:"
+msgstr "Στοίχιση Αριστερά"
+
+#: ../src/richtext/richtextsizepage.cpp:279
+#: ../src/richtext/richtextsizepage.cpp:281
+#, fuzzy
+msgid "Enable vertical alignment."
+msgstr "Δεν ήταν δυνατή η εκκίνηση της εκτύπωσης."
+
+#: ../src/richtext/richtextsizepage.cpp:286
+#, fuzzy
+msgid "Centred"
+msgstr "Στο κέντρο"
+
+#: ../src/richtext/richtextsizepage.cpp:290
+#: ../src/richtext/richtextsizepage.cpp:292
+#, fuzzy
+msgid "Vertical alignment."
+msgstr "Δεν ήταν δυνατή η εκκίνηση της εκτύπωσης."
+
+#: ../src/richtext/richtextsizepage.cpp:316
+#: ../src/richtext/richtextsizepage.cpp:323
+#, fuzzy
+msgid "&Width:"
+msgstr "&Βάρος:"
+
+#: ../src/richtext/richtextsizepage.cpp:318
+#: ../src/richtext/richtextsizepage.cpp:320
+msgid "Enable the width value."
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:331
+#: ../src/richtext/richtextsizepage.cpp:333
+#, fuzzy
+msgid "The object width."
+msgstr "Το βάρος της γραμματοσειράς."
+
+#: ../src/richtext/richtextsizepage.cpp:342
+#: ../src/richtext/richtextsizepage.cpp:344
+msgid "Units for the object width."
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:350
+#: ../src/richtext/richtextsizepage.cpp:357
+#, fuzzy
+msgid "&Height:"
+msgstr "&Βάρος:"
+
+#: ../src/richtext/richtextsizepage.cpp:352
+#: ../src/richtext/richtextsizepage.cpp:354
+#: ../src/richtext/richtextsizepage.cpp:464
+#: ../src/richtext/richtextsizepage.cpp:466
+msgid "Enable the height value."
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:365
+#: ../src/richtext/richtextsizepage.cpp:367
+#, fuzzy
+msgid "The object height."
+msgstr "Το βάρος της γραμματοσειράς."
+
+#: ../src/richtext/richtextsizepage.cpp:376
+#: ../src/richtext/richtextsizepage.cpp:378
+msgid "Units for the object height."
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:381
+msgid "Min width:"
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:383
+#: ../src/richtext/richtextsizepage.cpp:385
+#, fuzzy
+msgid "Enable the minimum width value."
+msgstr "Δεν ήταν δυνατή η εκκίνηση της εκτύπωσης."
+
+#: ../src/richtext/richtextsizepage.cpp:392
+#: ../src/richtext/richtextsizepage.cpp:394
+#, fuzzy
+msgid "The object minimum width."
+msgstr "Το βάρος της γραμματοσειράς."
+
+#: ../src/richtext/richtextsizepage.cpp:403
+#: ../src/richtext/richtextsizepage.cpp:405
+#, fuzzy
+msgid "Units for the minimum object width."
+msgstr "Το βάρος της γραμματοσειράς."
+
+#: ../src/richtext/richtextsizepage.cpp:408
+#, fuzzy
+msgid "Min height:"
+msgstr "Το βάρος της γραμματοσειράς."
+
+#: ../src/richtext/richtextsizepage.cpp:410
+#: ../src/richtext/richtextsizepage.cpp:412
+msgid "Enable the minimum height value."
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:419
+#: ../src/richtext/richtextsizepage.cpp:421
+#, fuzzy
+msgid "The object minimum height."
+msgstr "Το βάρος της γραμματοσειράς."
+
+#: ../src/richtext/richtextsizepage.cpp:430
+#: ../src/richtext/richtextsizepage.cpp:432
+#, fuzzy
+msgid "Units for the minimum object height."
+msgstr "Το βάρος της γραμματοσειράς."
+
+#: ../src/richtext/richtextsizepage.cpp:435
+#, fuzzy
+msgid "Max width:"
+msgstr "Αντικατάσταση με:"
+
+#: ../src/richtext/richtextsizepage.cpp:437
+#: ../src/richtext/richtextsizepage.cpp:439
+#, fuzzy
+msgid "Enable the maximum width value."
+msgstr "Δεν ήταν δυνατή η εκκίνηση της εκτύπωσης."
+
+#: ../src/richtext/richtextsizepage.cpp:446
+#: ../src/richtext/richtextsizepage.cpp:448
+#, fuzzy
+msgid "The object maximum width."
+msgstr "Το βάρος της γραμματοσειράς."
+
+#: ../src/richtext/richtextsizepage.cpp:457
+#: ../src/richtext/richtextsizepage.cpp:459
+#, fuzzy
+msgid "Units for the maximum object width."
+msgstr "Το βάρος της γραμματοσειράς."
+
+#: ../src/richtext/richtextsizepage.cpp:462
+#, fuzzy
+msgid "Max height:"
+msgstr "&Βάρος:"
+
+#: ../src/richtext/richtextsizepage.cpp:473
+#: ../src/richtext/richtextsizepage.cpp:475
+#, fuzzy
+msgid "The object maximum height."
+msgstr "Το βάρος της γραμματοσειράς."
+
+#: ../src/richtext/richtextsizepage.cpp:484
+#: ../src/richtext/richtextsizepage.cpp:486
+#, fuzzy
+msgid "Units for the maximum object height."
+msgstr "Το βάρος της γραμματοσειράς."
+
+#: ../src/richtext/richtextsizepage.cpp:495
+#, fuzzy
+msgid "Position"
+msgstr "Ερώτημα"
+
+#: ../src/richtext/richtextsizepage.cpp:513
+#, fuzzy
+msgid "&Position mode:"
+msgstr "Ερώτημα"
+
+#: ../src/richtext/richtextsizepage.cpp:517
+#: ../src/richtext/richtextsizepage.cpp:522
+#, fuzzy
+msgid "Static"
+msgstr "Κατάσταση: "
+
+#: ../src/richtext/richtextsizepage.cpp:518
+#, fuzzy
+msgid "Relative"
+msgstr "Διακοσμητικός"
+
+#: ../src/richtext/richtextsizepage.cpp:519
+msgid "Absolute"
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:520
+#, fuzzy
+msgid "Fixed"
+msgstr "Γραμματοσειρά σταθερού μεγέθους:"
+
+#: ../src/richtext/richtextsizepage.cpp:533
+#: ../src/richtext/richtextsizepage.cpp:535
+#: ../src/richtext/richtextsizepage.cpp:547
+#: ../src/richtext/richtextsizepage.cpp:549
+#, fuzzy
+msgid "The left position."
+msgstr "Το μέγεθος κουκίδας γραμματοσειράς"
+
+#: ../src/richtext/richtextsizepage.cpp:558
+#: ../src/richtext/richtextsizepage.cpp:560
+#, fuzzy
+msgid "Units for the left position."
+msgstr ""
+"Δεν είναι δυνατή η αναμονή(wait) για τον τερματισμό του νήματος "
+"εκτέλεσης(thread)"
+
+#: ../src/richtext/richtextsizepage.cpp:568
+#: ../src/richtext/richtextsizepage.cpp:570
+#: ../src/richtext/richtextsizepage.cpp:582
+#: ../src/richtext/richtextsizepage.cpp:584
+#, fuzzy
+msgid "The top position."
+msgstr "Το μέγεθος κουκίδας γραμματοσειράς"
+
+#: ../src/richtext/richtextsizepage.cpp:593
+#: ../src/richtext/richtextsizepage.cpp:595
+#, fuzzy
+msgid "Units for the top position."
+msgstr ""
+"Δεν είναι δυνατή η αναμονή(wait) για τον τερματισμό του νήματος "
+"εκτέλεσης(thread)"
+
+#: ../src/richtext/richtextsizepage.cpp:603
+#: ../src/richtext/richtextsizepage.cpp:605
+#: ../src/richtext/richtextsizepage.cpp:617
+#: ../src/richtext/richtextsizepage.cpp:619
+#, fuzzy
+msgid "The right position."
+msgstr "Το μέγεθος κουκίδας γραμματοσειράς"
+
+#: ../src/richtext/richtextsizepage.cpp:628
+#: ../src/richtext/richtextsizepage.cpp:630
+#, fuzzy
+msgid "Units for the right position."
+msgstr ""
+"Δεν είναι δυνατή η αναμονή(wait) για τον τερματισμό του νήματος "
+"εκτέλεσης(thread)"
+
+#: ../src/richtext/richtextsizepage.cpp:638
+#: ../src/richtext/richtextsizepage.cpp:640
+#: ../src/richtext/richtextsizepage.cpp:652
+#: ../src/richtext/richtextsizepage.cpp:654
+#, fuzzy
+msgid "The bottom position."
+msgstr "Το μέγεθος κουκίδας γραμματοσειράς"
+
+#: ../src/richtext/richtextsizepage.cpp:663
+#: ../src/richtext/richtextsizepage.cpp:665
+#, fuzzy
+msgid "Units for the bottom position."
+msgstr ""
+"Δεν είναι δυνατή η αναμονή(wait) για τον τερματισμό του νήματος "
+"εκτέλεσης(thread)"
+
+#: ../src/richtext/richtextsizepage.cpp:671
+msgid "&Move the object to:"
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:674
+#, fuzzy
+msgid "&Previous Paragraph"
+msgstr "Προηγούμενη σελίδα"
+
+#: ../src/richtext/richtextsizepage.cpp:675
+#: ../src/richtext/richtextsizepage.cpp:677
+msgid "Moves the object to the previous paragraph."
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:680
+msgid "&Next Paragraph"
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:681
+#: ../src/richtext/richtextsizepage.cpp:683
+msgid "Moves the object to the next paragraph."
+msgstr ""
+
+#: ../src/richtext/richtextstyledlg.cpp:193
+#, fuzzy
+msgid "&Styles:"
+msgstr "&Στυλ:"
+
+#: ../src/richtext/richtextstyledlg.cpp:197
+#: ../src/richtext/richtextstyledlg.cpp:199
+#, fuzzy
+msgid "The available styles."
+msgstr "Το στυλ της γραμματοσειράς."
+
+#: ../src/richtext/richtextstyledlg.cpp:205
+#: ../src/richtext/richtextstyledlg.cpp:217
+msgid " "
+msgstr " "
+
+#: ../src/richtext/richtextstyledlg.cpp:209
+#: ../src/richtext/richtextstyledlg.cpp:211
+#, fuzzy
+msgid "The style preview."
+msgstr "Εμφανίζει την προεπισκόπηση της γραμματοσειράς"
+
+#: ../src/richtext/richtextstyledlg.cpp:220
+msgid "New &Character Style..."
+msgstr ""
+
+#: ../src/richtext/richtextstyledlg.cpp:221
+#: ../src/richtext/richtextstyledlg.cpp:223
+msgid "Click to create a new character style."
+msgstr ""
+
+#: ../src/richtext/richtextstyledlg.cpp:226
+msgid "New &Paragraph Style..."
+msgstr ""
+
+#: ../src/richtext/richtextstyledlg.cpp:227
+#: ../src/richtext/richtextstyledlg.cpp:229
+msgid "Click to create a new paragraph style."
+msgstr ""
+
+#: ../src/richtext/richtextstyledlg.cpp:232
+msgid "New &List Style..."
+msgstr ""
+
+#: ../src/richtext/richtextstyledlg.cpp:233
+#: ../src/richtext/richtextstyledlg.cpp:235
+#, fuzzy
+msgid "Click to create a new list style."
+msgstr "Κάνετε κλικ για να ακυρώσετε την επιλογή γραμματοσειράς."
+
+#: ../src/richtext/richtextstyledlg.cpp:238
+#, fuzzy
+msgid "New &Box Style..."
+msgstr "Νέο στοιχείο"
+
+#: ../src/richtext/richtextstyledlg.cpp:239
+#: ../src/richtext/richtextstyledlg.cpp:241
+#, fuzzy
+msgid "Click to create a new box style."
+msgstr "Κάνετε κλικ για να ακυρώσετε την επιλογή γραμματοσειράς."
+
+#: ../src/richtext/richtextstyledlg.cpp:246
+#, fuzzy
+msgid "&Apply Style"
+msgstr "&Εφαρμογή"
+
+#: ../src/richtext/richtextstyledlg.cpp:247
+#: ../src/richtext/richtextstyledlg.cpp:249
+#, fuzzy
+msgid "Click to apply the selected style."
+msgstr "Κάνετε κλικ για να ακυρώσετε την επιλογή γραμματοσειράς."
+
+#: ../src/richtext/richtextstyledlg.cpp:252
+msgid "&Rename Style..."
+msgstr ""
+
+#: ../src/richtext/richtextstyledlg.cpp:253
+#: ../src/richtext/richtextstyledlg.cpp:255
+#, fuzzy
+msgid "Click to rename the selected style."
+msgstr "Κάνετε κλικ για να ακυρώσετε την επιλογή γραμματοσειράς."
+
+#: ../src/richtext/richtextstyledlg.cpp:258
+#, fuzzy
+msgid "&Edit Style..."
+msgstr "Επεξεργασία στοιχείου"
+
+#: ../src/richtext/richtextstyledlg.cpp:259
+#: ../src/richtext/richtextstyledlg.cpp:261
+#, fuzzy
+msgid "Click to edit the selected style."
+msgstr "Κάνετε κλικ για να ακυρώσετε την επιλογή γραμματοσειράς."
+
+#: ../src/richtext/richtextstyledlg.cpp:264
+#, fuzzy
+msgid "&Delete Style..."
+msgstr "Διαγραφή στοιχείου"
+
+#: ../src/richtext/richtextstyledlg.cpp:265
+#: ../src/richtext/richtextstyledlg.cpp:267
+#, fuzzy
+msgid "Click to delete the selected style."
+msgstr "Κάνετε κλικ για να ακυρώσετε την επιλογή γραμματοσειράς."
+
+#: ../src/richtext/richtextstyledlg.cpp:274
+#: ../src/richtext/richtextstyledlg.cpp:276
+#, fuzzy
+msgid "Click to close this window."
+msgstr "Κλείσιμο αυτού του παραθύρου."
+
+#: ../src/richtext/richtextstyledlg.cpp:282
+msgid "&Restart numbering"
+msgstr ""
+
+#: ../src/richtext/richtextstyledlg.cpp:284
+#: ../src/richtext/richtextstyledlg.cpp:286
+msgid "Check to restart numbering."
+msgstr ""
+
+#: ../src/richtext/richtextstyledlg.cpp:601
+msgid "Enter a character style name"
+msgstr ""
+
+#: ../src/richtext/richtextstyledlg.cpp:601
+#: ../src/richtext/richtextstyledlg.cpp:606
+#: ../src/richtext/richtextstyledlg.cpp:649
+#: ../src/richtext/richtextstyledlg.cpp:654
+#: ../src/richtext/richtextstyledlg.cpp:815
+#: ../src/richtext/richtextstyledlg.cpp:820
+#: ../src/richtext/richtextstyledlg.cpp:888
+#: ../src/richtext/richtextstyledlg.cpp:896
+#: ../src/richtext/richtextstyledlg.cpp:929
+#: ../src/richtext/richtextstyledlg.cpp:934
+#, fuzzy
+msgid "New Style"
+msgstr "Νέο στοιχείο"
+
+#: ../src/richtext/richtextstyledlg.cpp:606
+#: ../src/richtext/richtextstyledlg.cpp:654
+#: ../src/richtext/richtextstyledlg.cpp:820
+#: ../src/richtext/richtextstyledlg.cpp:896
+#: ../src/richtext/richtextstyledlg.cpp:934
+msgid "Sorry, that name is taken. Please choose another."
+msgstr ""
+
+#: ../src/richtext/richtextstyledlg.cpp:649
+msgid "Enter a paragraph style name"
+msgstr ""
+
+#: ../src/richtext/richtextstyledlg.cpp:777
+#, fuzzy, c-format
+msgid "Delete style %s?"
+msgstr "Διαγραφή στοιχείου"
+
+#: ../src/richtext/richtextstyledlg.cpp:777
+#, fuzzy
+msgid "Delete Style"
+msgstr "Διαγραφή στοιχείου"
+
+#: ../src/richtext/richtextstyledlg.cpp:815
+msgid "Enter a list style name"
+msgstr ""
+
+#: ../src/richtext/richtextstyledlg.cpp:888
+#, fuzzy
+msgid "Enter a new style name"
+msgstr "Το στυλ της γραμματοσειράς."
+
+#: ../src/richtext/richtextstyledlg.cpp:929
+#, fuzzy
+msgid "Enter a box style name"
+msgstr "Το στυλ της γραμματοσειράς."
+
+#: ../src/richtext/richtextstylepage.cpp:109
+#: ../src/richtext/richtextstylepage.cpp:111
+#, fuzzy
+msgid "The style name."
+msgstr "Το στυλ της γραμματοσειράς."
+
+#: ../src/richtext/richtextstylepage.cpp:114
+msgid "&Based on:"
+msgstr ""
+
+#: ../src/richtext/richtextstylepage.cpp:119
+#: ../src/richtext/richtextstylepage.cpp:121
+msgid "The style on which this style is based."
+msgstr ""
+
+#: ../src/richtext/richtextstylepage.cpp:124
+#, fuzzy
+msgid "&Next style:"
+msgstr "&Επόμενο >"
+
+#: ../src/richtext/richtextstylepage.cpp:129
+#: ../src/richtext/richtextstylepage.cpp:131
+msgid "The default style for the next paragraph."
+msgstr ""
+
+#: ../src/richtext/richtextstyles.cpp:1057
+msgid "All styles"
+msgstr ""
+
+#: ../src/richtext/richtextstyles.cpp:1058
+msgid "Paragraph styles"
+msgstr ""
+
+#: ../src/richtext/richtextstyles.cpp:1059
+msgid "Character styles"
+msgstr ""
+
+#: ../src/richtext/richtextstyles.cpp:1060
+msgid "List styles"
+msgstr ""
+
+#: ../src/richtext/richtextstyles.cpp:1061
+#, fuzzy
+msgid "Box styles"
+msgstr "&Επόμενο >"
+
+#: ../src/richtext/richtextsymboldlg.cpp:389
+#: ../src/richtext/richtextsymboldlg.cpp:391
+msgid "The font from which to take the symbol."
+msgstr ""
+
+#: ../src/richtext/richtextsymboldlg.cpp:396
+msgid "&Subset:"
+msgstr ""
+
+#: ../src/richtext/richtextsymboldlg.cpp:401
+#: ../src/richtext/richtextsymboldlg.cpp:403
+msgid "Shows a Unicode subset."
+msgstr ""
+
+#: ../src/richtext/richtextsymboldlg.cpp:412
+msgid "xxxx"
+msgstr ""
+
+#: ../src/richtext/richtextsymboldlg.cpp:417
+msgid "&Character code:"
+msgstr ""
+
+#: ../src/richtext/richtextsymboldlg.cpp:421
+#: ../src/richtext/richtextsymboldlg.cpp:423
+msgid "The character code."
+msgstr ""
+
+#: ../src/richtext/richtextsymboldlg.cpp:428
+#, fuzzy
+msgid "&From:"
+msgstr "Από:"
+
+#: ../src/richtext/richtextsymboldlg.cpp:433
+#: ../src/richtext/richtextsymboldlg.cpp:434
+#: ../src/richtext/richtextsymboldlg.cpp:435
+#, fuzzy
+msgid "Unicode"
+msgstr "Α&ποστοίχιση"
+
+#: ../src/richtext/richtextsymboldlg.cpp:436
+#: ../src/richtext/richtextsymboldlg.cpp:438
+msgid "The range to show."
+msgstr ""
+
+#: ../src/richtext/richtextsymboldlg.cpp:444
+#, fuzzy
+msgid "Insert"
+msgstr "Στοίχιση"
+
+#: ../src/richtext/richtextsymboldlg.cpp:478
+#, fuzzy
+msgid "(Normal text)"
+msgstr "Κανονική γραμματοσειρά:"
+
+#: ../src/richtext/richtexttabspage.cpp:109
+msgid "&Position (tenths of a mm):"
+msgstr ""
+
+#: ../src/richtext/richtexttabspage.cpp:113
+#: ../src/richtext/richtexttabspage.cpp:115
+#, fuzzy
+msgid "The tab position."
+msgstr "Το μέγεθος κουκίδας γραμματοσειράς"
+
+#: ../src/richtext/richtexttabspage.cpp:119
+#, fuzzy
+msgid "The tab positions."
+msgstr "Το μέγεθος κουκίδας γραμματοσειράς"
+
+#: ../src/richtext/richtexttabspage.cpp:132
+#: ../src/richtext/richtexttabspage.cpp:134
+#, fuzzy
+msgid "Click to create a new tab position."
+msgstr "Κάνετε κλικ για να ακυρώσετε την επιλογή γραμματοσειράς."
+
+#: ../src/richtext/richtexttabspage.cpp:138
+#: ../src/richtext/richtexttabspage.cpp:140
+#, fuzzy
+msgid "Click to delete the selected tab position."
+msgstr "Κάνετε κλικ για να ακυρώσετε την επιλογή γραμματοσειράς."
+
+#: ../src/richtext/richtexttabspage.cpp:143
+#, fuzzy
+msgid "Delete A&ll"
+msgstr "Επιλογή &Ολων"
+
+#: ../src/richtext/richtexttabspage.cpp:144
+#: ../src/richtext/richtexttabspage.cpp:146
+#, fuzzy
+msgid "Click to delete all tab positions."
+msgstr "Κάνετε κλικ για να ακυρώσετε την επιλογή γραμματοσειράς."
+
+#: ../src/univ/theme.cpp:110
+msgid "Failed to initialize GUI: no built-in themes found."
+msgstr "Αποτυχία αρχικοποίησης του GUI: δεν βρέθηκαν ενσωματωμένα θέματα."
+
+#: ../src/univ/themes/gtk.cpp:521
+msgid "GTK+ theme"
+msgstr "Θέμα GTK+"
+
+#: ../src/univ/themes/metal.cpp:164
+msgid "Metal theme"
+msgstr "Μεταλλικό θέμα"
+
+#: ../src/univ/themes/mono.cpp:512
+msgid "Simple monochrome theme"
+msgstr ""
+
+#: ../src/univ/themes/win32.cpp:1098
+msgid "Win32 theme"
+msgstr "Win32 θέμα"
+
+#: ../src/univ/themes/win32.cpp:3743
+msgid "&Restore"
+msgstr "&Επαναφορά"
+
+#: ../src/univ/themes/win32.cpp:3744
+msgid "&Move"
+msgstr "&Μετακίνηση"
+
+#: ../src/univ/themes/win32.cpp:3746
+msgid "&Size"
+msgstr "&Μέγεθος"
+
+#: ../src/univ/themes/win32.cpp:3748
+msgid "Mi&nimize"
+msgstr "Ελα&χιστοποίηση"
+
+#: ../src/univ/themes/win32.cpp:3750
+msgid "Ma&ximize"
+msgstr "Με&γιστοποίηση"
+
+#: ../src/univ/themes/win32.cpp:3752
+msgid "Alt+"
+msgstr ""
+
+#: ../src/unix/appunix.cpp:178
+#, fuzzy
+msgid "Failed to install signal handler"
+msgstr "Αποτυχία κλεισίματος του χειριστηρίου του αρχείου(file handle)"
+
+#: ../src/unix/dialup.cpp:351
+msgid "Already dialling ISP."
+msgstr "Γίνεται ήδη κλήση προς τον παροχέα Internet(ISP)."
+
+#: ../src/unix/dlunix.cpp:93
+#, fuzzy
+msgid "Failed to unload shared library"
+msgstr "Αποτυχία φόρτωσης της κοινής βιβλιοθήκης (shared library) '%s'"
+
+#: ../src/unix/dlunix.cpp:121
+msgid "Unknown dynamic library error"
+msgstr ""
+
+#: ../src/unix/epolldispatcher.cpp:84
+#, fuzzy
+msgid "Failed to create epoll descriptor"
+msgstr "Αποτυχία δημιουργίας δείκτη."
+
+#: ../src/unix/epolldispatcher.cpp:103
+#, fuzzy
+msgid "Error closing epoll descriptor"
+msgstr "Σφάλμα κατα τη δημιουργία καταλόγου"
+
+#: ../src/unix/epolldispatcher.cpp:116
+#, fuzzy, c-format
+msgid "Failed to add descriptor %d to epoll descriptor %d"
+msgstr "δεν είναι δυνατή η εγγραφή του περιγραφέα αρχείου(file descriptor) %d"
+
+#: ../src/unix/epolldispatcher.cpp:136
+#, c-format
+msgid "Failed to modify descriptor %d in epoll descriptor %d"
+msgstr ""
+
+#: ../src/unix/epolldispatcher.cpp:155
+#, fuzzy, c-format
+msgid "Failed to unregister descriptor %d from epoll descriptor %d"
+msgstr "Αποτυχία κατά την ανάκτηση δεδομένων από το πρόχειρο (clipboard)."
+
+#: ../src/unix/epolldispatcher.cpp:213
+#, fuzzy, c-format
+msgid "Waiting for IO on epoll descriptor %d failed"
+msgstr "Η αναμονή για τον τερματισμό υπο-διεργασίας (subprocess) απέτυχε"
+
+#: ../src/unix/fswatcher_inotify.cpp:71
+#, fuzzy
+msgid "Unable to create inotify instance"
+msgstr "Απέτυχε η δημιουργεία ενός DDE αλφαρηθμιτικού (string)"
+
+#: ../src/unix/fswatcher_inotify.cpp:94
+#, fuzzy
+msgid "Unable to close inotify instance"
+msgstr "Αποτυχία κλεισίματος του χειριστηρίου του αρχείου(file handle)"
+
+#: ../src/unix/fswatcher_inotify.cpp:106
+msgid "Unable to add inotify watch"
+msgstr ""
+
+#: ../src/unix/fswatcher_inotify.cpp:138
+#, fuzzy, c-format
+msgid "Unable to remove inotify watch %i"
+msgstr "Απέτυχε η δημιουργεία ενός DDE αλφαρηθμιτικού (string)"
+
+#: ../src/unix/fswatcher_inotify.cpp:271
+#, c-format
+msgid "Unexpected event for \"%s\": no matching watch descriptor."
+msgstr ""
+
+#: ../src/unix/fswatcher_inotify.cpp:320
+#, c-format
+msgid "Invalid inotify event for \"%s\""
+msgstr ""
+
+#: ../src/unix/fswatcher_inotify.cpp:553
+#, fuzzy
+msgid "Unable to read from inotify descriptor"
+msgstr "αδύνατη η ανάγνωση από περiγραφέα (descriptor) αρχείου %d"
+
+#: ../src/unix/fswatcher_inotify.cpp:558
+#, fuzzy
+msgid "EOF while reading from inotify descriptor"
+msgstr "αδύνατη η ανάγνωση από περiγραφέα (descriptor) αρχείου %d"
+
+#: ../src/unix/fswatcher_kqueue.cpp:114
+#, fuzzy
+msgid "Unable to create kqueue instance"
+msgstr "Απέτυχε η δημιουργεία ενός DDE αλφαρηθμιτικού (string)"
+
+#: ../src/unix/fswatcher_kqueue.cpp:131
+#, fuzzy
+msgid "Error closing kqueue instance"
+msgstr "Σφάλμα κατα τη δημιουργία καταλόγου"
+
+#: ../src/unix/fswatcher_kqueue.cpp:153
+msgid "Unable to add kqueue watch"
+msgstr ""
+
+#: ../src/unix/fswatcher_kqueue.cpp:170
+msgid "Unable to remove kqueue watch"
+msgstr ""
+
+#: ../src/unix/fswatcher_kqueue.cpp:202
+msgid "Unable to get events from kqueue"
+msgstr ""
+
+#: ../src/unix/mediactrl.cpp:966
+#, c-format
+msgid "Media playback error: %s"
+msgstr ""
+
+#: ../src/unix/mediactrl.cpp:1228
+#, fuzzy, c-format
+msgid "Failed to prepare playing \"%s\"."
+msgstr "Αποτυχία ανοίγματος του '%s' για το '%s'"
+
+#: ../src/unix/snglinst.cpp:164
+#, c-format
+msgid "Failed to write to lock file '%s'"
+msgstr "Αποτυχία εγγραφής του αρχείου 'κλειδωνιά'(lock file) '%s'"
+
+#: ../src/unix/snglinst.cpp:177
+#, c-format
+msgid "Failed to set permissions on lock file '%s'"
+msgstr "Αδύνατος ο ορισμός των δικαιωμάτων για το αρχείο 'κλειδωνιά' '%s'"
+
+#: ../src/unix/snglinst.cpp:194
+#, c-format
+msgid "Failed to lock the lock file '%s'"
+msgstr "Αποτυχία κλειδώματος του αρχείου 'κλειδωνιά'(lock file) '%s'"
+
+#: ../src/unix/snglinst.cpp:237
+#, c-format
+msgid "Failed to inspect the lock file '%s'"
+msgstr "Αποτυχία επιθεώρησης του αρχείου 'κλειδωνιά'(lock file) '%s'"
+
+#: ../src/unix/snglinst.cpp:242
+#, c-format
+msgid "Lock file '%s' has incorrect owner."
+msgstr "Το αρχείο 'κλειδωνιά' '%s' έχει λανθασμένο ιδιοκτήτη."
+
+#: ../src/unix/snglinst.cpp:247
+#, c-format
+msgid "Lock file '%s' has incorrect permissions."
+msgstr "Το αρχείο 'κλειδωνιά' '%s' έχει λανθασμένα δικαιώματα."
+
+#: ../src/unix/snglinst.cpp:265
+msgid "Failed to access lock file."
+msgstr "Αποτυχία πρόσβασης στο αρχείο 'κλειδωνιά'(lock file)."
+
+#: ../src/unix/snglinst.cpp:274
+msgid "Failed to read PID from lock file."
+msgstr "Απέτυχε η ανάγνωση PID από αρχείο κλειδωνιά(lock file)."
+
+#: ../src/unix/snglinst.cpp:284
+#, c-format
+msgid "Failed to remove stale lock file '%s'."
+msgstr ""
+"Αποτυχία απομάκρυνσης του απαρχειομένου(stale) αρχείου 'κλειδωνιά'(lock "
+"file) '%s'"
+
+#: ../src/unix/snglinst.cpp:297
+#, c-format
+msgid "Deleted stale lock file '%s'."
+msgstr "Διεγράφη το απαρχειομένο(stale) αρχείο κλειδαριά (lock file) '%s'"
+
+#: ../src/unix/snglinst.cpp:308
+#, c-format
+msgid "Invalid lock file '%s'."
+msgstr "Λανθασμένο αρχείο κλειδαριά (lock file) '%s'."
+
+#: ../src/unix/snglinst.cpp:324
+#, c-format
+msgid "Failed to remove lock file '%s'"
+msgstr "Αποτυχία απομάκρυνσης του αρχείου 'κλειδωνιά'(lock file) '%s'"
+
+#: ../src/unix/snglinst.cpp:330
+#, c-format
+msgid "Failed to unlock lock file '%s'"
+msgstr "Αποτυχία ξεκλείδωματος του αρχείου 'κλειδωνιά'(lock file) '%s'"
+
+#: ../src/unix/snglinst.cpp:336
+#, c-format
+msgid "Failed to close lock file '%s'"
+msgstr "Αποτυχία κλεισίματος του αρχείου 'κλειδωνιά'(lock file) '%s'"
+
+#: ../src/unix/sound.cpp:77
+msgid "No sound"
+msgstr "Χωρίς ήχο"
+
+#: ../src/unix/sound.cpp:364
+msgid "Unable to play sound asynchronously."
+msgstr "Αδύνατη η ασύγχρονη αναπαραγωγή ήχου."
+
+#: ../src/unix/sound.cpp:458
+#, c-format
+msgid "Couldn't load sound data from '%s'."
+msgstr "Δεν ήταν δυνατή η φόρτωση δεδομένων ήχου από το '%s'"
+
+#: ../src/unix/sound.cpp:465
+#, c-format
+msgid "Sound file '%s' is in unsupported format."
+msgstr "Το αρχείο '%s' είναι σε μη υποστηριζόμενη μορφή."
+
+#: ../src/unix/sound.cpp:480
+msgid "Sound data are in unsupported format."
+msgstr "Τα δεδομένα ήχου είναι σε μη υποστηριζόμενη μορφή."
+
+#: ../src/unix/sound_sdl.cpp:226
+#, c-format
+msgid "Couldn't open audio: %s"
+msgstr "Δεν είναι δυνατό το άνοιγμα του ήχου: %s"
+
+#: ../src/unix/threadpsx.cpp:1033
+msgid "Cannot retrieve thread scheduling policy."
+msgstr "Δεν είναι δυνατή η ανάκτηση της thread scheduling policy."
+
+#: ../src/unix/threadpsx.cpp:1058
+#, fuzzy, c-format
+msgid "Cannot get priority range for scheduling policy %d."
+msgstr "Δεν είναι δυνατή η ανάγνωση του εύρους προτεραιοτήτων"
+
+#: ../src/unix/threadpsx.cpp:1066
+msgid "Thread priority setting is ignored."
+msgstr "Η ρύθμιση προτεραιότητας του νήματος εκτέλεσης (thread) αγνοήθηκε. "
+
+#: ../src/unix/threadpsx.cpp:1221
+msgid ""
+"Failed to join a thread, potential memory leak detected - please restart the "
+"program"
+msgstr ""
+"Απέτυχε η συνένωση(join) ενός νήματος εκτέλεσης (thread), πιθανή διαρροή "
+"μνήμης εντοπίστηκε - παρακαλώ επανεκκινήστε το πρόγραμμα"
+
+#: ../src/unix/threadpsx.cpp:1352
+#, fuzzy, c-format
+msgid "Failed to set thread concurrency level to %lu"
+msgstr "Δεν είναι δυνατή η θέση προτεραιότητας του thread"
+
+#: ../src/unix/threadpsx.cpp:1481
+#, fuzzy, c-format
+msgid "Failed to set thread priority %d."
+msgstr "Δεν είναι δυνατή η θέση προτεραιότητας του thread"
+
+#: ../src/unix/threadpsx.cpp:1666
+msgid "Failed to terminate a thread."
+msgstr "Αποτυχία τερματισμού του thread"
+
+#: ../src/unix/threadpsx.cpp:1893
+msgid "Thread module initialization failed: failed to create thread key"
+msgstr ""
+"Η αρχικοποίηση μονάδας νήματος εκτέλεσης (thread module) απέτυχε: αποτυχία "
+"δημιουργίας κλειδιού νήματος (thread key)"
+
+#: ../src/unix/utilsunx.cpp:340
+msgid "Impossible to get child process input"
+msgstr "Αδύνατη η λήψη της εισόδου της διεργασίας (process) απογόνου(child)"
+
+#: ../src/unix/utilsunx.cpp:390
+#, fuzzy
+msgid "Can't write to child process's stdin"
+msgstr "Αποτυχία θανάτωσης της διαδικασίας(process) %d"
+
+#: ../src/unix/utilsunx.cpp:644
+#, c-format
+msgid "Failed to execute '%s'\n"
+msgstr "Αποτυχία εκτέλεσης του '%s'\n"
+
+#: ../src/unix/utilsunx.cpp:678
+msgid "Fork failed"
+msgstr "Fork απέτυχε"
+
+#: ../src/unix/utilsunx.cpp:701
+#, fuzzy
+msgid "Failed to set process priority"
+msgstr "Δεν είναι δυνατή η θέση προτεραιότητας του thread"
+
+#: ../src/unix/utilsunx.cpp:712
+msgid "Failed to redirect child process input/output"
+msgstr ""
+"Αποτυχία στην ανακατεύθυνση της εισόδου/εξόδου διεργασίας απογόνου (child "
+"process input/output)"
+
+#: ../src/unix/utilsunx.cpp:816
+msgid "Failed to set up non-blocking pipe, the program might hang."
+msgstr ""
+
+#: ../src/unix/utilsunx.cpp:1023
+msgid "Cannot get the hostname"
+msgstr "Δεν είναι δυνατή η ανάγνωση του ονόματος διακομιστή(hostname)"
+
+#: ../src/unix/utilsunx.cpp:1059
+msgid "Cannot get the official hostname"
+msgstr ""
+"Δεν είναι δυνατή η ανάγνωση του επισήμου ονόματος διακομιστή(official "
+"hostname)"
+
+#: ../src/unix/wakeuppipe.cpp:49
+#, fuzzy
+msgid "Failed to create wake up pipe used by event loop."
+msgstr "Αποτυχία δημιουργίας μιας μπάρας κατάστασης (status bar)"
+
+#: ../src/unix/wakeuppipe.cpp:56
+msgid "Failed to switch wake up pipe to non-blocking mode"
+msgstr ""
+
+#: ../src/unix/wakeuppipe.cpp:117
+#, fuzzy
+msgid "Failed to read from wake-up pipe"
+msgstr "Απέτυχε η ανάγνωση PID από αρχείο κλειδωνιά(lock file)."
+
+#: ../src/x11/app.cpp:124
+#, c-format
+msgid "Invalid geometry specification '%s'"
+msgstr "Λανθασμένος γεωμετρικός καθορισμός(specification) '%s'"
+
+#: ../src/x11/app.cpp:167
+msgid "wxWidgets could not open display. Exiting."
+msgstr "Η βιλιοθήκη wxWidgets δεν μπορεί να ανοίξει την απεικόνιση. 'Εξοδος..."
+
+#: ../src/x11/utils.cpp:169
+#, fuzzy, c-format
+msgid "Failed to close the display \"%s\""
+msgstr "Αποτυχία κλεισίματος του προχείρου(clipboard)"
+
+#: ../src/x11/utils.cpp:188
+#, fuzzy, c-format
+msgid "Failed to open display \"%s\"."
+msgstr "Αποτυχία ανοίγματος του '%s' για το '%s'"
+
+#: ../src/xml/xml.cpp:868
+#, c-format
+msgid "XML parsing error: '%s' at line %d"
+msgstr "XML σφάλμα ανάγνωσης (parsing error): '%s' στη γραμμή %d"
+
+#: ../src/xrc/xh_propgrid.cpp:239
+#, fuzzy, c-format
+msgid "Page %i"
+msgstr "Σελίδα %d"
+
+#: ../src/xrc/xmlres.cpp:448
+#, fuzzy, c-format
+msgid "Cannot load resources from '%s'."
+msgstr "Δεν είναι δυνατή η φόρτωση πόρων(resources) από το αρχείο '%s'"
+
+#: ../src/xrc/xmlres.cpp:799
+#, fuzzy, c-format
+msgid "Cannot open resources file '%s'."
+msgstr "Δεν είναι δυνατή η φόρτωση πόρων(resources) από το αρχείο '%s'"
+
+#: ../src/xrc/xmlres.cpp:806
+#, c-format
+msgid "Cannot load resources from file '%s'."
+msgstr "Δεν είναι δυνατή η φόρτωση πόρων(resources) από το αρχείο '%s'"
+
+#: ../src/xrc/xmlres.cpp:2767
+#, fuzzy, c-format
+msgid "Creating %s \"%s\" failed."
+msgstr "Η εξαγωγή του '%s' στο '%s' απέτυχε"
+
+#, fuzzy
+#~ msgctxt "keyboard key"
+#~ msgid "Ctrl+"
+#~ msgstr "ctrl"
+
+#, fuzzy
+#~ msgctxt "keyboard key"
+#~ msgid "Shift+"
+#~ msgstr "shift"
+
+#, fuzzy
+#~ msgctxt "keyboard key"
+#~ msgid "RawCtrl+"
+#~ msgstr "ctrl"
+
+#~ msgid "Unsupported clipboard format."
+#~ msgstr "Δεν υποστηρίζεται ο τύπος προχείρου(clipboard format)."
+
+#, fuzzy
+#~ msgid "Font:"
+#~ msgstr "Μέγεθος γραμματοσειράς:"
+
+#, fuzzy
+#~ msgid "Size:"
+#~ msgstr "Μέγεθος"
+
+#, fuzzy
+#~ msgid "The font size in points."
+#~ msgstr "Το μέγεθος κουκίδας γραμματοσειράς"
+
+#, fuzzy
+#~ msgid "Style:"
+#~ msgstr "&Στυλ:"
+
+#, fuzzy
+#~ msgid "Check to make the font bold."
+#~ msgstr "Κάνετε κλικ για να ακυρώσετε την επιλογή γραμματοσειράς."
+
+#, fuzzy
+#~ msgid "Check to make the font italic."
+#~ msgstr "Κάνετε κλικ για να ακυρώσετε την επιλογή γραμματοσειράς."
+
+#, fuzzy
+#~ msgid "Check to make the font underlined."
+#~ msgstr "Επιλογή εαν η γραμματοσειρά είναι υπογραμμισμένη ή όχι."
+
+#, fuzzy
+#~ msgid "Colour:"
+#~ msgstr "&Χρώμα:"
+
+#, fuzzy
+#~ msgid "Click to change the font colour."
+#~ msgstr "Κάνετε κλικ για να ακυρώσετε την επιλογή γραμματοσειράς."
+
+#, fuzzy
+#~ msgid "Click to cancel changes to the font."
+#~ msgstr "Κάνετε κλικ για να ακυρώσετε την επιλογή γραμματοσειράς."
+
+#, fuzzy
+#~ msgid "Click to confirm changes to the font."
+#~ msgstr "Κάνετε κλικ για να επιβεβαιώσετε την επιλογή γραμματοσειράς."
+
+#, fuzzy
+#~ msgid "<Any Roman>"
+#~ msgstr "Ρωμαϊκό"
+
+#, fuzzy
+#~ msgid "<Any Decorative>"
+#~ msgstr "Διακοσμητικός"
+
+#, fuzzy
+#~ msgid "<Any Modern>"
+#~ msgstr "Μοντέρνο"
+
+#, fuzzy
+#~ msgid "<Any Script>"
+#~ msgstr "Χειρόγραφο(Script)"
+
+#, fuzzy
+#~ msgid "<Any Swiss>"
+#~ msgstr "Ελβετικό(Swiss)"
+
+#, fuzzy
+#~ msgid "<Any Teletype>"
+#~ msgstr "Τηλέτυπο"
+
+#~ msgid "Printing "
+#~ msgstr "Γίνεται εκτύπωση του "
+
+#, fuzzy
+#~ msgid "Failed to insert text in the control."
+#~ msgstr "Αποτυχία λήψης καταλόγου εργασίας (working directory)"
+
+#~ msgid "Please choose a valid font."
+#~ msgstr "Παρακαλώ επιλέξτε μία αποδεκτή γραμματοσειρά."
+
+#, c-format
+#~ msgid "Failed to display HTML document in %s encoding"
+#~ msgstr "Απέτυχε η προβολή του εγγράφου HTML στην κωδικοποίηση %s"
+
+#, c-format
+#~ msgid "wxWidgets could not open display for '%s': exiting."
+#~ msgstr ""
+#~ "Η βιλιοθήκη wxWidgets δεν μπορεί να ανοίξει την απεικόνιση για το '%s': "
+#~ "έξοδος..."
+
+#, fuzzy
+#~ msgid "Filter"
+#~ msgstr "Αρχείο"
+
+#, fuzzy
+#~ msgid "Directories"
+#~ msgstr "Διακοσμητικός"
+
+#, fuzzy
+#~ msgid "Files"
+#~ msgstr "Αρχείο"
+
+#, fuzzy
+#~ msgid "Selection"
+#~ msgstr "Τμήματα"
+
+#~ msgid "conversion to 8-bit encoding failed"
+#~ msgstr "η μετατροπή σε 8-bit κωδικοποίηση απέτυχε"
+
+#, fuzzy
+#~ msgid "failed to retrieve execution result"
+#~ msgstr "Αποτυχία στη λήψη κειμένου από το μήνυμα σφάλματος RAS"
+
+#, fuzzy
+#~ msgid "&Save as"
+#~ msgstr "Αποθήκευση ως"
+
+#, fuzzy
+#~ msgid "'%s' doesn't consist only of valid characters"
+#~ msgstr "'%s' πρέπει να περιέχει μόνο αλφαβητικούς χαρακτήρες."
+
+#~ msgid "'%s' should be numeric."
+#~ msgstr "'%s' πρέπει να είναι αριθμητικό."
+
+#~ msgid "'%s' should only contain ASCII characters."
+#~ msgstr "'%s' πρέπει να περιέχει ASCII χαρακτήρες."
+
+#~ msgid "'%s' should only contain alphabetic characters."
+#~ msgstr "'%s' πρέπει να περιέχει μόνο αλφαβητικούς χαρακτήρες."
+
+#~ msgid "'%s' should only contain alphabetic or numeric characters."
+#~ msgstr ""
+#~ "'%s' πρέπει να περιέχει μόνο αλφαβητικούς ή αριθμητικούς χαρακτήρες."
+
+#, fuzzy
+#~ msgid "'%s' should only contain digits."
+#~ msgstr "'%s' πρέπει να περιέχει ASCII χαρακτήρες."
+
+#~ msgid "Can't create window of class %s"
+#~ msgstr "Δεν είναι δυνατή η δημιουργία παραθύρου τάξεως %s"
+
+#, fuzzy
+#~ msgid "Couldn't create the overlay window"
+#~ msgstr "Δεν ήταν δυνατή η δημιουργία χρονοδιακόπτη (timer)"
+
+#, fuzzy
+#~ msgid "Couldn't init the context on the overlay window"
+#~ msgstr ""
+#~ "Δεν ήταν δυνατή η ανάκτηση toy τρέχοντος δείκτη νήματος εκτέλεσης(thread)"
+
+#, fuzzy
+#~ msgid "Failed to convert file \"%s\" to Unicode."
+#~ msgstr "Αποτυχία κλεισίματος του χειριστηρίου του αρχείου(file handle)"
+
+#, fuzzy
+#~ msgid "Failed to set text in the text control."
+#~ msgstr "Αποτυχία καθορισμού της ώρας του UTC συστήματος"
+
+#~ msgid "No unused colour in image."
+#~ msgstr "Δεν υπάρχει μη χρησιμοποιούμενο χρώμα στην εικόνα"
+
+#, fuzzy
+#~ msgid "Not available"
+#~ msgstr "Δεν υπάρχει μονάδα(facility) XBM διαθέσιμη!"
+
+#, fuzzy
+#~ msgid "Replace selection"
+#~ msgstr "Αντικατάσταση &Όλων"
+
+#, fuzzy
+#~ msgid "Save as"
+#~ msgstr "Αποθήκευση ως"
+
+#, fuzzy
+#~ msgid "You cannot Clear an overlay that is not inited"
+#~ msgstr "Δεν μπορείτε να προσθέσετε καινούργιο κατάλογο σε αυτό το τμήμα."
+
+#~ msgid "locale '%s' cannot be set."
+#~ msgstr "η γλώσσα '%s' δεν μπορει να οριστεί"
+
+#, fuzzy
+#~ msgid "Column index not found."
+#~ msgstr "αρχείο καταλόγου για την περιοχή (domain) '%s' δεν βρέθηκε."
+
+#~ msgid "Confirm registry update"
+#~ msgstr "Επιβεβαίωση ενημέρωσης μητρώου(registry update)"
+
+#, fuzzy
+#~ msgid "Could not determine column index."
+#~ msgstr "Δεν ήταν δυνατή η εκκίνηση της προεπισκόπησης εγγράφου."
+
+#, fuzzy
+#~ msgid "Could not determine number of columns."
+#~ msgstr "Δεν βρέθηκε το αρχείο συμπερήληψης πόρων(resource include file) %s."
+
+#, fuzzy
+#~ msgid "Could not determine number of items"
+#~ msgstr "Δεν βρέθηκε το αρχείο συμπερήληψης πόρων(resource include file) %s."
+
+#, fuzzy
+#~ msgid "Could not get header description."
+#~ msgstr "Δεν ήταν δυνατή η εκκίνηση της εκτύπωσης."
+
+#, fuzzy
+#~ msgid "Could not get items."
+#~ msgstr "Δεν είναι δυνατός ο εντοπισμός του αρχείου '%s'."
+
+#, fuzzy
+#~ msgid "Could not get property flags."
+#~ msgstr "Δεν είναι δυνατή η δημιουργία του προσωρινού αρχείου '%s'"
+
+#, fuzzy
+#~ msgid "Could not get selected items."
+#~ msgstr "Δεν είναι δυνατός ο εντοπισμός του αρχείου '%s'."
+
+#, fuzzy
+#~ msgid "Could not remove column."
+#~ msgstr "Δεν ήταν δυνατή η δημιουργία δείκτη ποντικιού."
+
+#, fuzzy
+#~ msgid "Could not retrieve number of items"
+#~ msgstr "Δεν είναι δυνατή η δημιουργία του προσωρινού αρχείου '%s'"
+
+#, fuzzy
+#~ msgid "Could not set column width."
+#~ msgstr "Δεν ήταν δυνατή η εκκίνηση της προεπισκόπησης εγγράφου."
+
+#, fuzzy
+#~ msgid "Could not set header description."
+#~ msgstr "Δεν ήταν δυνατή η εκκίνηση της εκτύπωσης."
+
+#, fuzzy
+#~ msgid "Could not set icon."
+#~ msgstr "Δεν ήταν δυνατή η εκκίνηση της εκτύπωσης."
+
+#, fuzzy
+#~ msgid "Could not set maximum width."
+#~ msgstr "Δεν ήταν δυνατή η εκκίνηση της εκτύπωσης."
+
+#, fuzzy
+#~ msgid "Could not set minimum width."
+#~ msgstr "Δεν ήταν δυνατή η εκκίνηση της εκτύπωσης."
+
+#, fuzzy
+#~ msgid "Could not set property flags."
+#~ msgstr "Δεν ήταν δυνατή η εκκίνηση της εκτύπωσης."
+
+#~ msgid ""
+#~ "Do you want to overwrite the command used to %s files with extension "
+#~ "\"%s\" ?\n"
+#~ "Current value is \n"
+#~ "%s, \n"
+#~ "New value is \n"
+#~ "%s %1"
+#~ msgstr ""
+#~ "Θέλετε να επικαλύψετε την εντολή που χρησιμοποιήθηκε για να %s τα αρχεία "
+#~ "με επέκταση \"%s\" ?\n"
+#~ "Η τρέχουσα τιμή είναι \n"
+#~ "%s, \n"
+#~ "Η νέα τιμή είναι \n"
+#~ "%s %1"
+
+#~ msgid "Failed to retrieve data from the clipboard."
+#~ msgstr "Αποτυχία κατά την ανάκτηση δεδομένων από το πρόχειρο (clipboard)."
+
+#~ msgid "GIF: Invalid gif index."
+#~ msgstr "GIF: Λάθος gif index."
+
+#~ msgid "GIF: unknown error!!!"
+#~ msgstr "GIF: άγνωστο λάθος!!!"
+
+#~ msgid "New directory"
+#~ msgstr "Νέος κατάλογος"
+
+#~ msgid "Next"
+#~ msgstr "Επόμενο"
+
+#, fuzzy
+#~ msgid "Number of columns could not be determined."
+#~ msgstr "Το αρχείο δεν μπόρεσε να φορτωθεί."
+
+#~ msgid ""
+#~ "Please install a newer version of comctl32.dll\n"
+#~ "(at least version 4.70 is required but you have %d.%02d)\n"
+#~ "or this program won't operate correctly."
+#~ msgstr ""
+#~ "Παρακαλώ εγκαταστήστε μια νεότερη έκδοση του comctl32.dll\n"
+#~ "(η ελάχιστη απαραίτητη έκδοση είναι η 4.70 αλλά εσείς έχετε την %d.%02d)\n"
+#~ "διαφορετικά αυτό το πρόγραμμα δεν θα λειτουργήσει κανονικά."
+
+#, fuzzy
+#~ msgid "Rendering failed."
+#~ msgstr "Η δημιουργία timer απέτυχε."
+
+#~ msgid "Show hidden directories"
+#~ msgstr "Εμφάνιση κρυφών καταλόγων"
+
+#~ msgid "Too many colours in PNG, the image may be slightly blurred."
+#~ msgstr "Πάρα πολλά χρώματα στο PNG, η εικόνα μπορεί να είναι λίγο θολή."
+
+#, fuzzy
+#~ msgid "Unable to initialize Hildon program"
+#~ msgstr "Απέτυχε η αρχικοποίηση του OpenGL"
+
+#, fuzzy
+#~ msgid "Unknown data format"
+#~ msgstr "σφάλμα στη μορφή των δεδομένων"
+
+#~ msgid "Win32s on Windows 3.1"
+#~ msgstr "Win32s σε Windows 3.1"
+
+#, fuzzy
+#~ msgid "Windows 10"
+#~ msgstr "Windows 98"
+
+#, fuzzy
+#~ msgid "Windows 2000"
+#~ msgstr "Windows 95"
+
+#, fuzzy
+#~ msgid "Windows 7"
+#~ msgstr "Windows 95"
+
+#, fuzzy
+#~ msgid "Windows 8"
+#~ msgstr "Windows 98"
+
+#, fuzzy
+#~ msgid "Windows 8.1"
+#~ msgstr "Windows 98"
+
+#~ msgid "Windows 95"
+#~ msgstr "Windows 95"
+
+#~ msgid "Windows 95 OSR2"
+#~ msgstr "Windows 95 OSR2"
+
+#~ msgid "Windows 98"
+#~ msgstr "Windows 98"
+
+#~ msgid "Windows 98 SE"
+#~ msgstr "Windows 98 SE"
+
+#~ msgid "Windows 9x (%d.%d)"
+#~ msgstr "Windows 9x (%d.%d)"
+
+#, fuzzy
+#~ msgid "Windows CE (%d.%d)"
+#~ msgstr "Windows 9x (%d.%d)"
+
+#~ msgid "Windows ME"
+#~ msgstr "Windows ME"
+
+#, fuzzy
+#~ msgid "Windows NT %lu.%lu"
+#~ msgstr "Windows 9x (%d.%d)"
+
+#, fuzzy
+#~ msgid "Windows Server 10"
+#~ msgstr "Windows Ελληνικό (CP 1253)"
+
+#, fuzzy
+#~ msgid "Windows Server 2003"
+#~ msgstr "Windows Ελληνικό (CP 1253)"
+
+#, fuzzy
+#~ msgid "Windows Server 2008"
+#~ msgstr "Windows 98"
+
+#, fuzzy
+#~ msgid "Windows Server 2008 R2"
+#~ msgstr "Windows Εβραϊκό (CP 1255)"
+
+#, fuzzy
+#~ msgid "Windows Server 2012"
+#~ msgstr "Windows Ελληνικό (CP 1253)"
+
+#, fuzzy
+#~ msgid "Windows Server 2012 R2"
+#~ msgstr "Windows Εβραϊκό (CP 1255)"
+
+#, fuzzy
+#~ msgid "Windows Vista"
+#~ msgstr "Windows 95"
+
+#, fuzzy
+#~ msgid "Windows XP"
+#~ msgstr "Windows 95"
+
+#, fuzzy
+#~ msgid "can't execute '%s'"
+#~ msgstr "Αποτυχία εκτέλεσης του '%s'\n"
+
+#, fuzzy
+#~ msgid "error opening '%s'"
+#~ msgstr "σφάλμα κατά το άνοιγμα του αρχείου"
+
+#~ msgid "unknown seek origin"
+#~ msgstr "άγνωστη αφετηρία(origin) αναζήτησης(seek)"
+
+#~ msgid "Cannot create mutex."
+#~ msgstr "Δεν είναι δυνατή η δημιουργία του mutex."
+
+#~ msgid "Cannot resume thread %lu"
+#~ msgstr "Δεν είναι δυνατή η συνέχιση(resume) του νήματος(thread) %lu"
+
+#~ msgid "Cannot suspend thread %lu"
+#~ msgstr ""
+#~ "Δεν είναι δυνατή η αναστολή εκτέλεσης(suspend) του νήματος(thread) %lu"
+
+#~ msgid "Couldn't acquire a mutex lock"
+#~ msgstr "Δεν ήταν δυνατή η κτήση μιας κλειδαριάς mutex"
+
+#~ msgid "Couldn't release a mutex"
+#~ msgstr "Δεν ήταν δυνατή η απελευθέρωση ενός mutex"
+
+#, fuzzy
+#~ msgid "DIVIDE"
+#~ msgstr "<ΟΔΗΓΟΣ>"
+
+#~ msgid "Execution of command '%s' failed with error: %ul"
+#~ msgstr "Η εκτέλεση της εντολής '%s' απέτυχε με σφάλμα: %ul"
+
+#~ msgid ""
+#~ "File '%s' already exists.\n"
+#~ "Do you want to replace it?"
+#~ msgstr ""
+#~ "Το αρχείο '%s' υπάρχει ήδη.\n"
+#~ "Θέλετε να αντικατασταθεί;"
+
+#~ msgid "Timer creation failed."
+#~ msgstr "Η δημιουργία timer απέτυχε."
+
+#~ msgid "Print preview"
+#~ msgstr "Προεπισκόπηση εκτύπωσης"
+
+#, fuzzy
+#~ msgid "&Preview..."
+#~ msgstr " Προεπισκόπηση"
+
+#, fuzzy
+#~ msgid "Preview..."
+#~ msgstr " Προεπισκόπηση"
+
+#~ msgid "&Save..."
+#~ msgstr "&Αποθήκευση..."
+
+#, fuzzy
+#~ msgid "About "
+#~ msgstr "&Περί..."
+
+#~ msgid "All files (*.*)|*"
+#~ msgstr "Όλα τα αρχεία (*.*)|*"
+
+#~ msgid "Cannot initialize SciTech MGL!"
+#~ msgstr "Δεν είναι δυνατή η αρχικοποίηση του SciTech MGL"
+
+#~ msgid "Cannot initialize display."
+#~ msgstr "Δεν είναι δυνατή η αρχικοποίηση απεικόνησης."
+
+#~ msgid "Cannot start thread: error writing TLS"
+#~ msgstr ""
+#~ "Δεν είναι δυνατή η εκκίνηση του ΄νηματος εκτέλεσης (thread): σφάλμα κατά "
+#~ "την εγγραφή του TLS"
+
+#~ msgid "Close\tAlt-F4"
+#~ msgstr "Κλείσιμο\tAlt-F4"
+
+#~ msgid "Couldn't create cursor."
+#~ msgstr "Δεν ήταν δυνατή η δημιουργία δείκτη ποντικιού."
+
+#~ msgid "Directory '%s' doesn't exist!"
+#~ msgstr "Ο κατάλογος '%s' δεν υπάρχει!"
+
+#~ msgid "Mode %ix%i-%i not available."
+#~ msgstr "Η κατάσταση λειτουργίας (mode) %ix%i-%i δεν είναι διαθέσιμη."
+
+#~ msgid "Paper Size"
+#~ msgstr "Μέγεθος Χαρτιού"
+
+#~ msgid "&Goto..."
+#~ msgstr "&Μετάβαση..."
+
+#~ msgid "<<"
+#~ msgstr "<<"
+
+#~ msgid ">>"
+#~ msgstr ">>"
+
+#~ msgid ">>|"
+#~ msgstr ">>|"
+
+#~ msgid "Archive doesnt contain #SYSTEM file"
+#~ msgstr "Το αρχείο δεν περιέχει αρχείο #SYSTEM"
+
+#~ msgid "Can't check image format of file '%s': file does not exist."
+#~ msgstr ""
+#~ "Δεν είναι δυνατή η εξακρίβωση του τύπου του αρχείου %s: το αρχείο δεν "
+#~ "υπάρχει."
+
+#~ msgid "Can't load image from file '%s': file does not exist."
+#~ msgstr ""
+#~ "Δεν είναι δυνατή η ανάγνωση της εικόνας από το αρχείο '%s': Το αρχείο δεν "
+#~ "υπάρχει."
+
+#~ msgid "Cannot convert dialog units: dialog unknown."
+#~ msgstr ""
+#~ "Δεν είναι δυνατή η μετατροπή των μονάδων διαλόγου(dialog units): άγνωστο "
+#~ "παράθυρο διαλόγου."
+
+#~ msgid "Cannot convert from the charset '%s'!"
+#~ msgstr "Δεν είναι δυνατή η μετατροπη από το σύνολο χαρακτήρων '%s'!"
+
+#~ msgid "Cannot find container for unknown control '%s'."
+#~ msgstr ""
+#~ "Δεν είναι δυνατή η εύρεση φορέα(container) για άγνωστο στοιχείο "
+#~ "ελέγχου(control) '%s'."
+
+#~ msgid "Cannot find font node '%s'."
+#~ msgstr ""
+#~ "Δεν είναι δυνατή η εύρεση καταστάσεως γραμματοσειράς(font mode) '%s'."
+
+#~ msgid "Cannot open file '%s'."
+#~ msgstr "Δεν είναι δυνατό το άνοιγμα του αρχείου '%s'."
+
+#~ msgid "Cannot parse coordinates from '%s'."
+#~ msgstr "Δεν είναι δυνατή η ανάγνωση συντεταγμένων από '%s'."
+
+#~ msgid "Cannot parse dimension from '%s'."
+#~ msgstr "Δεν είναι δυνατή η ανάγνωση διαστάσεων από '%s'."
+
+#~ msgid "Cant create the thread event queue"
+#~ msgstr "Δεν είναι δυνατή η δημιουργία της ουράς συμβάντων των νημάτων"
+
+#, fuzzy
+#~ msgid "Click to cancel this window."
+#~ msgstr "Κλείσιμο αυτού του παραθύρου."
+
+#, fuzzy
+#~ msgid "Click to confirm your selection."
+#~ msgstr "Κάνετε κλικ για να επιβεβαιώσετε την επιλογή γραμματοσειράς."
+
+#~ msgid "Could not unlock mutex"
+#~ msgstr "Δεν ήταν δυνατό το ξεκλείδωμα του mutex"
+
+#~ msgid "Error while waiting on semaphore"
+#~ msgstr "Σφάλμα κατά την αναμονή στη σημαφόρο"
+
+#~ msgid "Failed to create a status bar."
+#~ msgstr "Αποτυχία δημιουργίας μιας μπάρας κατάστασης (status bar)"
+
+#~ msgid "Failed to register OpenGL window class."
+#~ msgstr "Απέτυχε η θέση της κλάσης του παραθύρου OpenGL"
+
+#~ msgid "Fatal error: "
+#~ msgstr "Μοιραίο σφάλμα: "
+
+#~ msgid "Goto Page"
+#~ msgstr "Μετάβαση στη Σελίδα"
+
+#, fuzzy
+#~ msgid "Help : %s"
+#~ msgstr "Βοήθεια: %s"
+
+#~ msgid "I64"
+#~ msgstr "I64"
+
+#~ msgid "Internal error, illegal wxCustomTypeInfo"
+#~ msgstr "Εσωτερικό σφάλμα, μη έγκυρο wxCustomTypeInfo"
+
+#~ msgid "Invalid XRC resource '%s': doesn't have root node 'resource'."
+#~ msgstr ""
+#~ "Λανθασμένος XRC πόρος '%s': δεν έχει ριζικό(root) κόμβο(node) 'resource'."
+
+#~ msgid "No handler found for XML node '%s', class '%s'!"
+#~ msgstr ""
+#~ "Δεν βρέθηκε κανένας χειριστής (handler) για τον XML κόμβο(node) '%s', "
+#~ "τάξη(class) '%s'!"
+
+#, fuzzy
+#~ msgid "No image handler for type %ld defined."
+#~ msgstr "Δεν έχει οριστεί χειριστής εικόνας για τον τύπο %d."
+
+#, fuzzy
+#~ msgid "Owner not initialized."
+#~ msgstr "Δεν είναι δυνατή η αρχικοποίηση απεικόνησης."
+
+#, fuzzy
+#~ msgid "Passed item is invalid."
+#~ msgstr "'%s' δεν ισχύει"
+
+#~ msgid "Passing a already registered object to SetObjectName"
+#~ msgstr "Δόθηκε ένα ήδη registered αντικείμενο στην SetObjectName"
+
+#~ msgid "Program aborted."
+#~ msgstr "Το πρόγραμμα ματαιώθηκε."
+
+#~ msgid "Referenced object node with ref=\"%s\" not found!"
+#~ msgstr "Ο αναφερόμενος κομβος αντικειμένου με ref=\"%s\" δεν βρέθηκε!"
+
+#~ msgid "Resource files must have same version number!"
+#~ msgstr "Τα αρχεία πόρων πρέπει να έχουν τον ίδιο αριθμό έκδοσης!"
+
+#, fuzzy
+#~ msgid "Search!"
+#~ msgstr "Αναζήτηση"
+
+#~ msgid "Sorry, could not open this file for saving."
+#~ msgstr ""
+#~ "Συγγνώμη, είναι αδύνατο το άνοιγμα αυτού του αρχείου για αποθήκευση."
+
+#~ msgid "Sorry, could not save this file."
+#~ msgstr "Συγγνώμη, δεν μπόρεσε να αποθηκευθεί αυτό το αρχείο."
+
+#~ msgid "Sorry, print preview needs a printer to be installed."
+#~ msgstr ""
+#~ "Συγγνώμη, η προεπισκόπηση εκτύπωσης χρειάζεται έναν εγκατεστημένο "
+#~ "εκτυπωτή."
+
+#~ msgid "Status: "
+#~ msgstr "Κατάσταση: "
+
+#~ msgid ""
+#~ "Streaming delegates for not already streamed objects not yet supported"
+#~ msgstr ""
+#~ "Οι εκπροσωπήσεις ροών για μη ροοποιημένα αντικείμενα δεν υποστηρίζονται "
+#~ "ακόμα"
+
+#~ msgid "Subclass '%s' not found for resource '%s', not subclassing!"
+#~ msgstr ""
+#~ "Η υπο-κλάση '%s' δεν βρέθηκε για τον πόρο '%s', δεν θα γίνει subclassing!"
+
+#~ msgid ""
+#~ "The file '%s' couldn't be opened.\n"
+#~ "It has been removed from the most recently used files list."
+#~ msgstr ""
+#~ "Το αρχείο '%s' δεν μπόρεσε να ανοιχτεί.\n"
+#~ "Αφαιρέθηκε από την λίστα με τα πρόσφατα χρησιμοποιημένα αρχεία."
+
+#~ msgid "The path '%s' contains too many \"..\"!"
+#~ msgstr "Η διαδρομή '%s' περιέχει πάρα πολλά \"..\"!"
+
+#~ msgid "Trying to solve a NULL hostname: giving up"
+#~ msgstr ""
+#~ "Προσπάθεια διαλεύκανσης ενός NULL ονόματος διακομιστή(hostname): γίνεται "
+#~ "παραίτηση"
+
+#~ msgid "Unknown style flag "
+#~ msgstr "’γνωστη σημαία στύλ (style flag)."
+
+#~ msgid "Warning"
+#~ msgstr "Προειδοποίηση"
+
+#~ msgid "XRC resource '%s' (class '%s') not found!"
+#~ msgstr "XRC resource '%s' (τάξη(class) '%s') δεν βρέθηκε!"
+
+#, fuzzy
+#~ msgid "XRC resource: Cannot create animation from '%s'."
+#~ msgstr "XRC resource: Δεν είναι δυνατή η δημιουργία bitmap από '%s'."
+
+#~ msgid "XRC resource: Cannot create bitmap from '%s'."
+#~ msgstr "XRC resource: Δεν είναι δυνατή η δημιουργία bitmap από '%s'."
+
+#, fuzzy
+#~ msgid ""
+#~ "XRC resource: Incorrect colour specification '%s' for attribute '%s'."
+#~ msgstr ""
+#~ "XRC resource: Λανθασμένος καθορισμός χρώματος '%s' για την ιδιότητα '%s'."
+
+#~ msgid "[EMPTY]"
+#~ msgstr "[ΚΕΝΟ]"
+
+#~ msgid "catalog file for domain '%s' not found."
+#~ msgstr "αρχείο καταλόγου για την περιοχή (domain) '%s' δεν βρέθηκε."
+
+#~ msgid "delegate has no type info"
+#~ msgstr "ο εκπρόσωπος(delegate) δεν έχει πληροφορίες τύπου"
+
+#, fuzzy
+#~ msgid "encoding %i"
+#~ msgstr "κωδικοποίηση %s"
+
+#~ msgid "looking for catalog '%s' in path '%s'."
+#~ msgstr "γίνεται εύρεση του καταλόγου '%s' στο μονοπάτι '%s'."
+
+#~ msgid "wxSocket: invalid signature in ReadMsg."
+#~ msgstr "wxSocket: λανθασμένη υπογραφή (invalid signature) στο ReadMsg."
+
+#~ msgid "wxSocket: unknown event!."
+#~ msgstr "wxSocket: άγνωστο γεγονός (event)!"
+
+#~ msgid "|<<"
+#~ msgstr "|<<"
+
+#, fuzzy
+#~ msgid " Couldn't create the UnicodeConverter"
+#~ msgstr "Δεν ήταν δυνατή η δημιουργία χρονοδιακόπτη (timer)"
+
+#~ msgid "#define %s must be an integer."
+#~ msgstr "#define %s πρέπει να είναι ακέραιος (integer)."
+
+#~ msgid "%s not a bitmap resource specification."
+#~ msgstr "%s δεν είναι καθορισμός πόρου τύπου bitmap ( bitmap resource )"
+
+#~ msgid "%s not an icon resource specification."
+#~ msgstr "%s δεν είναι καθορισμός πόρου τύπου εικονιδίου ( icon resource )"
+
+#~ msgid "%s: ill-formed resource file syntax."
+#~ msgstr "%s: κακή (ill-formed) σύνταξη αρχείου πόρων. ( resource file )"
+
+#~ msgid "&Open"
+#~ msgstr "&Ανοιγμα"
+
+#~ msgid "&Print"
+#~ msgstr "&Εκτύπωση"
+
+#~ msgid ""
+#~ ", expected static, #include or #define\n"
+#~ "while parsing resource."
+#~ msgstr ""
+#~ ", αναμενόταν static, #include ή #define\n"
+#~ "κατά την ανάγνωση του πόρου."
+
+#~ msgid "Bitmap resource specification %s not found."
+#~ msgstr "Δεν βρέθηκε ο καθοριμός πόρου bitmap %s"
+
+#~ msgid ""
+#~ "Could not resolve control class or id '%s'. Use (non-zero) integer "
+#~ "instead\n"
+#~ " or provide #define (see manual for caveats)"
+#~ msgstr ""
+#~ "Δεν ήταν δυνατή η αντιστοίχηση της κλάσης ελέγχου ή του id '%s'. "
+#~ "Χρησιμοποιήστε (μη-μηδενικό) ακέραιο\n"
+#~ " ή μία οδηγία #define (ανατρέξατε στο εγχειρίδιο για λεπτομέρειες)"
+
+#~ msgid ""
+#~ "Could not resolve menu id '%s'. Use (non-zero) integer instead\n"
+#~ "or provide #define (see manual for caveats)"
+#~ msgstr ""
+#~ "Δεν ήταν δυνατή η αντιστοίχηση του menu id '%s'. Χρησιμοποιήστε (μη-"
+#~ "μηδενικό) ακέραιο\n"
+#~ "ή μία οδηγία #define (ανατρέξατε στο εγχειρίδιο για λεπτομέρειες)"
+
+#, fuzzy
+#~ msgid "Couldn't end the context on the overlay window"
+#~ msgstr ""
+#~ "Δεν ήταν δυνατή η ανάκτηση toy τρέχοντος δείκτη νήματος εκτέλεσης(thread)"
+
+#~ msgid "Expected '*' while parsing resource."
+#~ msgstr "Αναμενόταν '*' κατά την ανάγνωση του πόρου(resource)."
+
+#~ msgid "Expected '=' while parsing resource."
+#~ msgstr "Αναμενόταν '=' κατά την ανάγνωση του πόρου(resource)."
+
+#~ msgid "Expected 'char' while parsing resource."
+#~ msgstr "Αναμενόταν 'char' κατά την ανάγνωση του πόρου(resource)."
+
+#~ msgid ""
+#~ "Failed to find XBM resource %s.\n"
+#~ "Forgot to use wxResourceLoadBitmapData?"
+#~ msgstr ""
+#~ "Απέτυχε η έυρεση XBM πόρου %s.\n"
+#~ "Ξεχάσατε να χρησιμοποιήσετε το wxResourceLoadBitmapData ;"
+
+#~ msgid ""
+#~ "Failed to find XBM resource %s.\n"
+#~ "Forgot to use wxResourceLoadIconData?"
+#~ msgstr ""
+#~ "Απέτυχε η έυρεση XBM πόρου %s.\n"
+#~ "Ξεχάσατε να χρησιμοποιήσετε το wxResourceLoadIconData ;"
+
+#~ msgid ""
+#~ "Failed to find XPM resource %s.\n"
+#~ "Forgot to use wxResourceLoadBitmapData?"
+#~ msgstr ""
+#~ "Απέτυχε η έυρεση XPM πόρου %s.\n"
+#~ "Ξεχάσατε να χρησιμοποιήσετε το wxResourceLoadBitmapData ;"
+
+#~ msgid "Failed to get clipboard data."
+#~ msgstr "Αποτυχία λήψης των δεδομένων του προχείρου (clipboard)."
+
+#~ msgid "Failed to load shared library '%s' Error '%s'"
+#~ msgstr ""
+#~ "Αποτυχία φόρτωσης της κοινής βιβλιοθήκης (shared library) '%s' Σφάλμα '%s'"
+
+#~ msgid "Found "
+#~ msgstr "Βρέθηκαν "
+
+#~ msgid "Icon resource specification %s not found."
+#~ msgstr "Δεν βρέθηκε ο καθοριμός πόρου bitmap %s"
+
+#~ msgid "Ill-formed resource file syntax."
+#~ msgstr "Λανθασμένη συνταξη αρχείου πόρου."
+
+#~ msgid "Long Conversions not supported"
+#~ msgstr "Οι μετατροπές Long δεν υποστηρίζονται"
+
+#~ msgid "No XPM icon facility available!"
+#~ msgstr "Δεν υπάρχει μονάδα(facility) εικονιδίων XPM διαθέσιμη!"
+
+#~ msgid "Option '%s' requires a value, '=' expected."
+#~ msgstr "Η επιλογή '%s' απαιτεί μια τιμή, αναμενόταν '='."
+
+#, fuzzy
+#~ msgid "Select all"
+#~ msgstr "Επιλογή &Ολων"
+
+#~ msgid "Unexpected end of file while parsing resource."
+#~ msgstr "Απροσδόκητο τέλος αρχείου κατά την ανάγνωση πόρου."
+
+#~ msgid "Unrecognized style %s while parsing resource."
+#~ msgstr "Μη-αναγνωρίσιμο στύλ %s κατα την ανάγνωση πόρου."
+
+#~ msgid "Video Output"
+#~ msgstr "Έξοδος Εικόνας"
+
+#~ msgid "Warning: attempt to remove HTML tag handler from empty stack."
+#~ msgstr ""
+#~ "Προειδοποίηση: προσπάθεια απομάκρυνσης διαχειριστή ετικετών (tag handler) "
+#~ "HTML από άδεια στοίβα (stack)."
+
+#~ msgid "establish"
+#~ msgstr "εδραίωσε"
+
+#~ msgid "initiate"
+#~ msgstr "αρχικοποίησε"
+
+#~ msgid "invalid eof() return value."
+#~ msgstr "λανθασμένη τιμή επιστροφής του eof()."
+
+#~ msgid "unknown line terminator"
+#~ msgstr "άγνωστο τερματικό γραμμής"
+
+#~ msgid "writing"
+#~ msgstr "γίνεται εγγραφή"
+
+#~ msgid "."
+#~ msgstr "."
+
+#~ msgid "Cannot open URL '%s'"
+#~ msgstr "Δεν είναι δυνατό to άνοιγμα του URL '%s'"
+
+#~ msgid "Error "
+#~ msgstr "Σφάλμα "
+
+#~ msgid "Failed to create directory %s/.gnome."
+#~ msgstr "Απέτυχε η δημιουργία καταλόγου '%s'/.gnome."
+
+#~ msgid "Failed to create directory %s/mime-info."
+#~ msgstr "Απέτυχε η δημιουργία καταλόγου '%s'/mime-info."
+
+#~ msgid "MP Thread Support is not available on this System"
+#~ msgstr "Η υποστήριξη MP νημάτων δεν είναι διαθέσιμη σε αυτό το σύστημα"
+
+#~ msgid "Mailcap file %s, line %d: incomplete entry ignored."
+#~ msgstr "Mailcap αρχείο %s, γραμμή %d: ημιτελής εγγραφή αγνοήθηκε."
+
+#~ msgid "Mime.types file %s, line %d: unterminated quoted string."
+#~ msgstr "Mime.types αρχείο %s, γραμμή %d: μη τερματιζόμενο quoted string."
+
+#~ msgid "Unknown field in file %s, line %d: '%s'."
+#~ msgstr "’γνωστο πεδίο στο αρχείο %s, γραμμή %d: '%s'."
+
+#~ msgid "bold "
+#~ msgstr "έντονο "
+
+#~ msgid "can't query for GUI plugins name in console applications"
+#~ msgstr ""
+#~ "δεν είναι δυνατή η αναζήτηση για επεκτάσεις GUI σε εφαρμογές κονσόλας"
+
+#~ msgid "light "
+#~ msgstr "απαλό(light) "
+
+#~ msgid "underlined "
+#~ msgstr "υπογεγραμμένο "
+
+#~ msgid "unsupported zip archive"
+#~ msgstr "Μη υποστηριζόμενο συμπιεσμένο αρχείο zip"
+
+#, fuzzy
+#~ msgid ""
+#~ "Failed to get stack backtrace:\n"
+#~ "%s"
+#~ msgstr "Αποτυχία λήψης πορείας στοίβας"
+
+#~ msgid "Loading Grey Ascii PNM image is not yet implemented."
+#~ msgstr "Η φόρτωση εικόνας Grey Ascii PNM δεν έχει υλοποιηθεί ακόμα."
+
+#~ msgid "Loading Grey Raw PNM image is not yet implemented."
+#~ msgstr "Η φόρτωση εικόνας Grey Raw PNM δεν έχει υλοποιηθεί ακόμα."
+
+#~ msgid "Cannot wait on thread to exit."
+#~ msgstr "Δεν είναι δυνατή η αναμονή για τον τερματισμό του νήματος."
+
+#~ msgid "Could not load Rich Edit DLL '%s'"
+#~ msgstr "Δεν ήταν δυνατή η φόρτωση του Rich DLL '%s'"
+
+#~ msgid "ZIP handler currently supports only local files!"
+#~ msgstr "ο χειριστής ZIP προς το παρόν υποστηρίζει μόνο τοπικά αρχεία!"
+
+#~ msgid ""
+#~ "can't seek on file descriptor %d, large files support is not enabled."
+#~ msgstr ""
+#~ "αδύνατη η αναζήτηση(seek) στον περιγραφέα(descriptor) αρχείου %d, η "
+#~ "υποστήριξη μεγάλων αρχείων δεν είναι ενεργοποιημένη."
+
+#~ msgid "More..."
+#~ msgstr "Περισσότερα..."
+
+#~ msgid "Setup"
+#~ msgstr "Οργάνωση(Setup)"
+
+#~ msgid "/#SYSTEM"
+#~ msgstr "/#SYSTEM"
+
+#~ msgid "GetUnusedColour:: No Unused Color in image "
+#~ msgstr "GetUnusedColour:: Κανένα Αχρησιμοποίητο Χρώμα στην εικόνα "
+
+#~ msgid ""
+#~ "Can't create list control window, check that comctl32.dll is installed."
+#~ msgstr ""
+#~ "Δεν είναι δυνατή η δημιουργία του στοιχείου ελέγχου λίστας (list "
+#~ "control). Ελέγξτε ότι το comctl32.dll είναι εγατεστημένο."
+
+#~ msgid "Can't delete value of key '%s'"
+#~ msgstr "Δεν είναι δυνατή η διαγρσφή του κλειδιού '%s'"
+
+#~ msgid "gmtime() failed"
+#~ msgstr "το gmtime() απέτυχε"
+
+#~ msgid "mktime() failed"
+#~ msgstr "η mktime() απέτυχε"
+
+#~ msgid "%d...%d"
+#~ msgstr "%d...%d"
+
+#~ msgid "Can't create dialog using memory template"
+#~ msgstr ""
+#~ "Δεν είναι δυνατή η δημιουργία του διαλόγου με τη χρήση προτύπου μνήμης. "
+#~ "(memory template)"
+
+#~ msgid "Can't create dialog using template '%ul'"
+#~ msgstr ""
+#~ "Δεν είναι δυνατή η δημιουργία του διαλόγου με τη χρήση του προτύπου '%ul'"
+
+#~ msgid "Did you forget to include wx/os2/wx.rc in your resources?"
+#~ msgstr ""
+#~ "Ξεχάσατε να συμπεριλάβετε (include) το wx/os2/wx.rc στους πόρους σας "
+#~ "(resources) ;"
+
+#~ msgid "Failed to create dialog. Incorrect DLGTEMPLATE?"
+#~ msgstr "Απέτυχε η δημιουργία παράθυρου διαλόγου. Λανθασμένο DLGTEMPLATE ;"
+
+#~ msgid "Fatal error: exiting"
+#~ msgstr "Μοιραίο σφάλμα: έξοδος"
+
+#~ msgid ""
+#~ "HTML files (*.htm)|*.htm|HTML files (*.html)|*.html|Help books (*.htb)|"
+#~ "*.htb|Help books (*.zip)|*.zip|HTML Help Project (*.hhp)|*.hhp|All files "
+#~ "(*.*)|*"
+#~ msgstr ""
+#~ "Αρχεία HTML (*.htm)|*.htm|Αρχεία HTML (*.html)|*.html|Βιβλία βοηθείας "
+#~ "(*.htb)|*.htb|Βιβλία βοηθείας (*.zip)|*.zip|Project HTML βοήθειας (*.hhp)|"
+#~ "*.hhp|Ολα τα αρχεία (*.*)|*"
+
+#~ msgid "Load file"
+#~ msgstr "Φόρτωση αρχείου"
+
+#~ msgid "Save file"
+#~ msgstr "Αποθήκευση αρχείου"
+
+#~ msgid "illegal scrollbar selector %d"
+#~ msgstr "παράνομος επιλογέας(selector) γραμμής κύλισης(scrollbar) %d"
+
+#~ msgid "wxDllLoader failed to GetSymbol '%s'"
+#~ msgstr "Αποτυχία του wxDllLoader να κάνει GetSymbol '%s'"
+
+#~ msgid "wxDynamicLibrary failed to GetSymbol '%s'"
+#~ msgstr "Αποτυχία του wxDynamicLibrary να κάνει GetSymbol '%s'"

--- a/po_wxstd/es.po
+++ b/po_wxstd/es.po
@@ -1,0 +1,9545 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: wxWidgets 3.3\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-05-14 20:23+0200\n"
+"PO-Revision-Date: 2025-05-05 20:11-0400\n"
+"Last-Translator: Blake Madden\n"
+"Language-Team: wxWidgets translators <wx-translators@wxwidgets.org>\n"
+"Language: es\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Poedit-SourceCharset: UTF-8\n"
+"X-Generator: Poedit 3.3.2\n"
+
+#: ../include/wx/defs.h:2582
+msgid "All files (*.*)|*.*"
+msgstr "Todos los archivos (*.*)|*.*"
+
+#: ../include/wx/defs.h:2585
+msgid "All files (*)|*"
+msgstr "Todos los archivos (*)|*"
+
+#: ../include/wx/generic/progdlgg.h:85
+msgid "Elapsed time:"
+msgstr "Tiempo transcurrido:"
+
+#: ../include/wx/generic/progdlgg.h:86
+msgid "Estimated time:"
+msgstr "Tiempo estimado:"
+
+#: ../include/wx/generic/progdlgg.h:87
+msgid "Remaining time:"
+msgstr "Tiempo restante:"
+
+#. TRANSLATORS: HTML printout default title.
+#: ../include/wx/html/htmprint.h:121 ../include/wx/prntbase.h:273
+#: ../include/wx/richtext/richtextprint.h:109 ../src/common/docview.cpp:2161
+msgid "Printout"
+msgstr "Impresión"
+
+#. TRANSLATORS: HTML easy print default title.
+#: ../include/wx/html/htmprint.h:234 ../include/wx/richtext/richtextprint.h:163
+#: ../src/common/prntbase.cpp:522 ../src/html/htmprint.cpp:291
+msgid "Printing"
+msgstr "Imprimiendo"
+
+#: ../include/wx/msgdlg.h:277 ../src/common/stockitem.cpp:211
+msgid "Yes"
+msgstr "Sí"
+
+#: ../include/wx/msgdlg.h:278 ../src/common/stockitem.cpp:182
+msgid "No"
+msgstr "No"
+
+#: ../include/wx/msgdlg.h:279 ../src/common/stockitem.cpp:183
+#: ../src/msw/msgdlg.cpp:430 ../src/msw/msgdlg.cpp:734
+#: ../src/richtext/richtextstyledlg.cpp:292
+msgid "OK"
+msgstr "Aceptar"
+
+#: ../include/wx/msgdlg.h:280 ../src/common/stockitem.cpp:150
+#: ../src/msw/msgdlg.cpp:430 ../src/msw/progdlg.cpp:884
+#: ../src/richtext/richtextstyledlg.cpp:295
+msgid "Cancel"
+msgstr "Cancelar"
+
+#: ../include/wx/msgdlg.h:281 ../src/common/stockitem.cpp:168
+#: ../src/html/helpdlg.cpp:63 ../src/html/helpfrm.cpp:108
+#: ../src/osx/button_osx.cpp:38
+msgid "Help"
+msgstr "Ayuda"
+
+#: ../include/wx/msw/ole/oleutils.h:52
+msgid "Cannot initialize OLE"
+msgstr "No se puede inicializar OLE"
+
+#: ../include/wx/msw/private/fswatcher.h:48
+#, c-format
+msgid "Unable to close the handle for '%s'"
+msgstr "No se pudo cerrar el manejador para '%s'"
+
+#: ../include/wx/msw/private/fswatcher.h:92
+#, c-format
+msgid "Failed to open directory \"%s\" for monitoring."
+msgstr "Falló la apertura del directorio '%s' para su monitorización."
+
+#: ../include/wx/msw/private/fswatcher.h:125
+msgid "Unable to close I/O completion port handle"
+msgstr "Error al cerrar el manejador del puerto de finalización de E/S"
+
+#: ../include/wx/msw/private/fswatcher.h:142
+msgid "Unable to associate handle with I/O completion port"
+msgstr "No se pudo asociar manejador con el puerto de finalización de E/S"
+
+#: ../include/wx/msw/private/fswatcher.h:148
+msgid "Unexpectedly new I/O completion port was created"
+msgstr "Se creó inesperadamente un puerto de finalización de E/S"
+
+#: ../include/wx/msw/private/fswatcher.h:213
+msgid "Unable to post completion status"
+msgstr "No se pudo enviar el estado de finalización"
+
+#: ../include/wx/msw/private/fswatcher.h:262
+msgid "Unable to dequeue completion packet"
+msgstr "No se pudo sacar de la cola el paquete de finalización"
+
+#: ../include/wx/msw/private/fswatcher.h:273
+msgid "Unable to create I/O completion port"
+msgstr "No se pudo crear el puerto de finalización de E/S"
+
+#: ../include/wx/richmsgdlg.h:29
+msgid "&See details"
+msgstr "&Ver detalles"
+
+#: ../include/wx/richmsgdlg.h:30
+msgid "&Hide details"
+msgstr "&Ocultar detalles"
+
+#: ../include/wx/richtext/richtextbuffer.h:3864
+msgid "&Box"
+msgstr "&Caja"
+
+#: ../include/wx/richtext/richtextbuffer.h:5008
+msgid "&Picture"
+msgstr "&Imagen"
+
+#: ../include/wx/richtext/richtextbuffer.h:5958
+msgid "&Cell"
+msgstr "&Celda"
+
+#: ../include/wx/richtext/richtextbuffer.h:6067
+msgid "&Table"
+msgstr "&Tabla"
+
+#: ../include/wx/richtext/richtextimagedlg.h:37
+msgid "Object Properties"
+msgstr "Propiedades del objeto"
+
+#: ../include/wx/richtext/richtextsymboldlg.h:39
+msgid "Symbols"
+msgstr "Símbolos"
+
+#: ../include/wx/unix/pipe.h:46
+msgid "Pipe creation failed"
+msgstr "Error en la creación de la tubería"
+
+#: ../include/wx/unix/private/displayx11.h:65
+msgid "Failed to enumerate video modes"
+msgstr "Falló la enumeración de los modos de vídeo"
+
+#: ../include/wx/unix/private/displayx11.h:89
+msgid "Failed to change video mode"
+msgstr "Error al cambiar el modo de vídeo"
+
+#: ../include/wx/unix/private/fswatcher_kqueue.h:57
+#, c-format
+msgid "Unable to open path '%s'"
+msgstr "No se pudo abrir el caminor '%s'"
+
+#: ../include/wx/unix/private/fswatcher_kqueue.h:74
+#, c-format
+msgid "Unable to close path '%s'"
+msgstr "No se pudo cerrar el camino '%s'"
+
+#: ../include/wx/xtiprop.h:175
+msgid "SetProperty called w/o valid setter"
+msgstr "Se llamó a SetProperty sin un establecedor válido"
+
+#: ../include/wx/xtiprop.h:184
+msgid "GetProperty called w/o valid getter"
+msgstr "Se llamó a GetProperty sin un captador válido"
+
+#: ../include/wx/xtiprop.h:193
+msgid "AddToPropertyCollection called w/o valid adder"
+msgstr "Se llamó a AddToPropertyCollection sin añadidor válido"
+
+#: ../include/wx/xtiprop.h:202
+msgid "GetPropertyCollection called w/o valid collection getter"
+msgstr "Se llamó a GetPropertyCollection sin un captador de colecciones válido"
+
+#: ../include/wx/xtiprop.h:255
+msgid "AddToPropertyCollection called on a generic accessor"
+msgstr "Se llamó a AddToPropertyCollection sobre un accedente genérico"
+
+#: ../include/wx/xtiprop.h:262
+msgid "GetPropertyCollection called on a generic accessor"
+msgstr "Se llamó a GetPropertyCollection sobre un accedente genérico"
+
+#: ../src/aui/tabmdi.cpp:106 ../src/generic/mdig.cpp:94
+msgid "Cl&ose"
+msgstr "&Cerrar"
+
+#: ../src/aui/tabmdi.cpp:107 ../src/generic/mdig.cpp:95
+msgid "Close All"
+msgstr "Cerrar Todo"
+
+#: ../src/aui/tabmdi.cpp:109 ../src/generic/mdig.cpp:97 ../src/msw/mdi.cpp:175
+#: ../src/qt/mdi.cpp:258
+msgid "&Next"
+msgstr "&Siguiente"
+
+#: ../src/aui/tabmdi.cpp:110 ../src/generic/mdig.cpp:98 ../src/msw/mdi.cpp:176
+#: ../src/qt/mdi.cpp:259
+msgid "&Previous"
+msgstr "&Anterior"
+
+#: ../src/aui/tabmdi.cpp:332 ../src/aui/tabmdi.cpp:348
+#: ../src/aui/tabmdi.cpp:350 ../src/generic/mdig.cpp:291
+#: ../src/generic/mdig.cpp:307 ../src/generic/mdig.cpp:311
+#: ../src/msw/mdi.cpp:337 ../src/qt/mdi.cpp:462
+msgid "&Window"
+msgstr "&Ventana"
+
+#: ../src/common/accelcmn.cpp:47
+msgctxt "keyboard key"
+msgid "Delete"
+msgstr "Eliminar"
+
+#: ../src/common/accelcmn.cpp:48
+msgctxt "keyboard key"
+msgid "Del"
+msgstr "Eliminar"
+
+#: ../src/common/accelcmn.cpp:49
+msgctxt "keyboard key"
+msgid "Back"
+msgstr "Atrás"
+
+#: ../src/common/accelcmn.cpp:49
+msgctxt "keyboard key"
+msgid "Backspace"
+msgstr "Retroceso"
+
+#: ../src/common/accelcmn.cpp:50
+msgctxt "keyboard key"
+msgid "Insert"
+msgstr "Insertar"
+
+#: ../src/common/accelcmn.cpp:51
+msgctxt "keyboard key"
+msgid "Ins"
+msgstr "Insertar"
+
+#: ../src/common/accelcmn.cpp:52
+msgctxt "keyboard key"
+msgid "Enter"
+msgstr "Intro"
+
+#: ../src/common/accelcmn.cpp:53
+msgctxt "keyboard key"
+msgid "Return"
+msgstr "Regresar"
+
+#: ../src/common/accelcmn.cpp:54
+msgctxt "keyboard key"
+msgid "PageUp"
+msgstr "RePág"
+
+#: ../src/common/accelcmn.cpp:54
+msgctxt "keyboard key"
+msgid "Page Up"
+msgstr "Página arriba"
+
+#: ../src/common/accelcmn.cpp:55
+msgctxt "keyboard key"
+msgid "PageDown"
+msgstr "AvPág"
+
+#: ../src/common/accelcmn.cpp:55
+msgctxt "keyboard key"
+msgid "Page Down"
+msgstr "Página abajo"
+
+#: ../src/common/accelcmn.cpp:56
+msgctxt "keyboard key"
+msgid "PgUp"
+msgstr "RePg"
+
+#: ../src/common/accelcmn.cpp:57
+msgctxt "keyboard key"
+msgid "PgDn"
+msgstr "AvPg"
+
+#: ../src/common/accelcmn.cpp:58
+msgctxt "keyboard key"
+msgid "Left"
+msgstr "Izquierda"
+
+#: ../src/common/accelcmn.cpp:59
+msgctxt "keyboard key"
+msgid "Right"
+msgstr "Derecha"
+
+#: ../src/common/accelcmn.cpp:60
+msgctxt "keyboard key"
+msgid "Up"
+msgstr "Arriba"
+
+#: ../src/common/accelcmn.cpp:61
+msgctxt "keyboard key"
+msgid "Down"
+msgstr "Abajo"
+
+#: ../src/common/accelcmn.cpp:62
+msgctxt "keyboard key"
+msgid "Home"
+msgstr "Inicio"
+
+#: ../src/common/accelcmn.cpp:63
+msgctxt "keyboard key"
+msgid "End"
+msgstr "Fin"
+
+#: ../src/common/accelcmn.cpp:64
+msgctxt "keyboard key"
+msgid "Space"
+msgstr "Espacio"
+
+#: ../src/common/accelcmn.cpp:65
+msgctxt "keyboard key"
+msgid "Tab"
+msgstr "Tabulador"
+
+#: ../src/common/accelcmn.cpp:66
+msgctxt "keyboard key"
+msgid "Esc"
+msgstr "Esc"
+
+#: ../src/common/accelcmn.cpp:67
+msgctxt "keyboard key"
+msgid "Escape"
+msgstr "Escape"
+
+#: ../src/common/accelcmn.cpp:68
+msgctxt "keyboard key"
+msgid "Cancel"
+msgstr "Cancelar"
+
+#: ../src/common/accelcmn.cpp:69
+msgctxt "keyboard key"
+msgid "Clear"
+msgstr "Limpiar"
+
+#: ../src/common/accelcmn.cpp:70
+msgctxt "keyboard key"
+msgid "Menu"
+msgstr "Menú"
+
+#: ../src/common/accelcmn.cpp:71
+msgctxt "keyboard key"
+msgid "Pause"
+msgstr "Pausa"
+
+#: ../src/common/accelcmn.cpp:72
+msgctxt "keyboard key"
+msgid "Capital"
+msgstr "Mayúscula"
+
+#: ../src/common/accelcmn.cpp:73
+msgctxt "keyboard key"
+msgid "Select"
+msgstr "Seleccione"
+
+#: ../src/common/accelcmn.cpp:74
+msgctxt "keyboard key"
+msgid "Print"
+msgstr "Imprimir"
+
+#: ../src/common/accelcmn.cpp:75
+msgctxt "keyboard key"
+msgid "Execute"
+msgstr "Ejecutar"
+
+#: ../src/common/accelcmn.cpp:76
+msgctxt "keyboard key"
+msgid "Snapshot"
+msgstr "Instantánea"
+
+#: ../src/common/accelcmn.cpp:77
+msgctxt "keyboard key"
+msgid "Help"
+msgstr "Ayuda"
+
+#: ../src/common/accelcmn.cpp:78
+msgctxt "keyboard key"
+msgid "Add"
+msgstr "Añadir"
+
+#: ../src/common/accelcmn.cpp:79
+msgctxt "keyboard key"
+msgid "Separator"
+msgstr "Separador"
+
+#: ../src/common/accelcmn.cpp:80
+msgctxt "keyboard key"
+msgid "Subtract"
+msgstr "Sustraer"
+
+#: ../src/common/accelcmn.cpp:81
+msgctxt "keyboard key"
+msgid "Decimal"
+msgstr "Decimal"
+
+#: ../src/common/accelcmn.cpp:82
+msgctxt "keyboard key"
+msgid "Multiply"
+msgstr "Multiplicar"
+
+#: ../src/common/accelcmn.cpp:83
+msgctxt "keyboard key"
+msgid "Divide"
+msgstr "Dividir"
+
+#: ../src/common/accelcmn.cpp:84
+msgctxt "keyboard key"
+msgid "Num_lock"
+msgstr "Bloq_Num"
+
+#: ../src/common/accelcmn.cpp:84
+msgctxt "keyboard key"
+msgid "Num Lock"
+msgstr "Num Bloq"
+
+#: ../src/common/accelcmn.cpp:85
+msgctxt "keyboard key"
+msgid "Scroll_lock"
+msgstr "Bloq_despl"
+
+#: ../src/common/accelcmn.cpp:85
+msgctxt "keyboard key"
+msgid "Scroll Lock"
+msgstr "Bloq Despl"
+
+#: ../src/common/accelcmn.cpp:86
+msgctxt "keyboard key"
+msgid "KP_Space"
+msgstr "KP_Space"
+
+#: ../src/common/accelcmn.cpp:86
+msgctxt "keyboard key"
+msgid "Num Space"
+msgstr "Num Espacio"
+
+#: ../src/common/accelcmn.cpp:87
+msgctxt "keyboard key"
+msgid "KP_Tab"
+msgstr "KP_Tab"
+
+#: ../src/common/accelcmn.cpp:87
+msgctxt "keyboard key"
+msgid "Num Tab"
+msgstr "Num Tab"
+
+#: ../src/common/accelcmn.cpp:88
+msgctxt "keyboard key"
+msgid "KP_Enter"
+msgstr "KP_Enter"
+
+#: ../src/common/accelcmn.cpp:88
+msgctxt "keyboard key"
+msgid "Num Enter"
+msgstr "Num Intro"
+
+#: ../src/common/accelcmn.cpp:89
+msgctxt "keyboard key"
+msgid "KP_Home"
+msgstr "KP_Home"
+
+#: ../src/common/accelcmn.cpp:89
+msgctxt "keyboard key"
+msgid "Num Home"
+msgstr "Num Inicio"
+
+#: ../src/common/accelcmn.cpp:90
+msgctxt "keyboard key"
+msgid "KP_Left"
+msgstr "KP_Left"
+
+#: ../src/common/accelcmn.cpp:90
+msgctxt "keyboard key"
+msgid "Num left"
+msgstr "Num Izquierda"
+
+#: ../src/common/accelcmn.cpp:91
+msgctxt "keyboard key"
+msgid "KP_Up"
+msgstr "KP_Up"
+
+#: ../src/common/accelcmn.cpp:91
+msgctxt "keyboard key"
+msgid "Num Up"
+msgstr "Num Arriba"
+
+#: ../src/common/accelcmn.cpp:92
+msgctxt "keyboard key"
+msgid "KP_Right"
+msgstr "KP_Right"
+
+#: ../src/common/accelcmn.cpp:92
+msgctxt "keyboard key"
+msgid "Num Right"
+msgstr "Num Derecha"
+
+#: ../src/common/accelcmn.cpp:93
+msgctxt "keyboard key"
+msgid "KP_Down"
+msgstr "KP_Down"
+
+#: ../src/common/accelcmn.cpp:93
+msgctxt "keyboard key"
+msgid "Num Down"
+msgstr "Num Abajo"
+
+#: ../src/common/accelcmn.cpp:94
+msgctxt "keyboard key"
+msgid "KP_PageUp"
+msgstr "KP_PageUp"
+
+#: ../src/common/accelcmn.cpp:94
+msgctxt "keyboard key"
+msgid "Num Page Up"
+msgstr "Num Re Pág"
+
+#: ../src/common/accelcmn.cpp:95
+msgctxt "keyboard key"
+msgid "KP_PageDown"
+msgstr "KP_PageDown"
+
+#: ../src/common/accelcmn.cpp:95
+msgctxt "keyboard key"
+msgid "Num Page Down"
+msgstr "Num Av Pág"
+
+#: ../src/common/accelcmn.cpp:96
+msgctxt "keyboard key"
+msgid "KP_Prior"
+msgstr "KP_Prior"
+
+#: ../src/common/accelcmn.cpp:97
+msgctxt "keyboard key"
+msgid "KP_Next"
+msgstr "KP_Next"
+
+#: ../src/common/accelcmn.cpp:98
+msgctxt "keyboard key"
+msgid "KP_End"
+msgstr "KP_End"
+
+#: ../src/common/accelcmn.cpp:98
+msgctxt "keyboard key"
+msgid "Num End"
+msgstr "Num Fin"
+
+#: ../src/common/accelcmn.cpp:99
+msgctxt "keyboard key"
+msgid "KP_Begin"
+msgstr "KP_Begin"
+
+#: ../src/common/accelcmn.cpp:99
+msgctxt "keyboard key"
+msgid "Num Begin"
+msgstr "Num Inicio"
+
+#: ../src/common/accelcmn.cpp:100
+msgctxt "keyboard key"
+msgid "KP_Insert"
+msgstr "KP_Insert"
+
+#: ../src/common/accelcmn.cpp:100
+msgctxt "keyboard key"
+msgid "Num Insert"
+msgstr "Num Ins"
+
+#: ../src/common/accelcmn.cpp:101
+msgctxt "keyboard key"
+msgid "KP_Delete"
+msgstr "KP_Delete"
+
+#: ../src/common/accelcmn.cpp:101
+msgctxt "keyboard key"
+msgid "Num Delete"
+msgstr "Num Eliminar"
+
+#: ../src/common/accelcmn.cpp:102
+msgctxt "keyboard key"
+msgid "KP_Equal"
+msgstr "KP_Equal"
+
+#: ../src/common/accelcmn.cpp:102
+msgctxt "keyboard key"
+msgid "Num ="
+msgstr "Num ="
+
+#: ../src/common/accelcmn.cpp:103
+msgctxt "keyboard key"
+msgid "KP_Multiply"
+msgstr "KP_Multiply"
+
+#: ../src/common/accelcmn.cpp:103
+msgctxt "keyboard key"
+msgid "Num *"
+msgstr "Num *"
+
+#: ../src/common/accelcmn.cpp:104
+msgctxt "keyboard key"
+msgid "KP_Add"
+msgstr "KP_Add"
+
+#: ../src/common/accelcmn.cpp:104
+msgctxt "keyboard key"
+msgid "Num +"
+msgstr "Num +"
+
+#: ../src/common/accelcmn.cpp:105
+msgctxt "keyboard key"
+msgid "KP_Separator"
+msgstr "KP_Separator"
+
+#: ../src/common/accelcmn.cpp:105
+msgctxt "keyboard key"
+msgid "Num ,"
+msgstr "Num ,"
+
+#: ../src/common/accelcmn.cpp:106
+msgctxt "keyboard key"
+msgid "KP_Subtract"
+msgstr "KP_Subtract"
+
+#: ../src/common/accelcmn.cpp:106
+msgctxt "keyboard key"
+msgid "Num -"
+msgstr "Num -"
+
+#: ../src/common/accelcmn.cpp:107
+msgctxt "keyboard key"
+msgid "KP_Decimal"
+msgstr "KP_Decimal"
+
+#: ../src/common/accelcmn.cpp:107
+msgctxt "keyboard key"
+msgid "Num ."
+msgstr "Num ."
+
+#: ../src/common/accelcmn.cpp:108
+msgctxt "keyboard key"
+msgid "KP_Divide"
+msgstr "KP_Divide"
+
+#: ../src/common/accelcmn.cpp:108
+msgctxt "keyboard key"
+msgid "Num /"
+msgstr "Num /"
+
+#: ../src/common/accelcmn.cpp:109
+msgctxt "keyboard key"
+msgid "Windows_Left"
+msgstr "Windows_Izquierda"
+
+#: ../src/common/accelcmn.cpp:110
+msgctxt "keyboard key"
+msgid "Windows_Right"
+msgstr "Windows_Derecha"
+
+#: ../src/common/accelcmn.cpp:111
+msgctxt "keyboard key"
+msgid "Windows_Menu"
+msgstr "Windows_Menú"
+
+#: ../src/common/accelcmn.cpp:112
+msgctxt "keyboard key"
+msgid "Command"
+msgstr "Orden"
+
+#: ../src/common/accelcmn.cpp:186 ../src/common/accelcmn.cpp:359
+msgctxt "keyboard key"
+msgid "Ctrl"
+msgstr "Ctrl"
+
+#: ../src/common/accelcmn.cpp:188 ../src/common/accelcmn.cpp:363
+msgctxt "keyboard key"
+msgid "Alt"
+msgstr "Alt"
+
+#: ../src/common/accelcmn.cpp:190 ../src/common/accelcmn.cpp:361
+msgctxt "keyboard key"
+msgid "Shift"
+msgstr "Mayúsculas"
+
+#: ../src/common/accelcmn.cpp:196
+msgctxt "keyboard key"
+msgid "num "
+msgstr "num "
+
+#: ../src/common/accelcmn.cpp:260 ../src/common/accelcmn.cpp:382
+msgctxt "keyboard key"
+msgid "F"
+msgstr "F"
+
+#: ../src/common/accelcmn.cpp:277 ../src/common/accelcmn.cpp:385
+msgctxt "keyboard key"
+msgid "KP_F"
+msgstr "KP_F"
+
+#: ../src/common/accelcmn.cpp:280 ../src/common/accelcmn.cpp:388
+msgctxt "keyboard key"
+msgid "KP_"
+msgstr "KP_"
+
+#: ../src/common/accelcmn.cpp:283 ../src/common/accelcmn.cpp:391
+msgctxt "keyboard key"
+msgid "SPECIAL"
+msgstr "ESPECIAL"
+
+#: ../src/common/accelcmn.cpp:373
+#, fuzzy
+msgid "Ctrl"
+msgstr "Ctrl"
+
+#: ../src/common/appbase.cpp:786
+msgid "show this help message"
+msgstr "mostrar este mensaje de ayuda"
+
+#: ../src/common/appbase.cpp:796
+msgid "generate verbose log messages"
+msgstr "generar mensajes de log explicativos"
+
+#: ../src/common/appcmn.cpp:256
+msgid "specify the theme to use"
+msgstr "especifique el tema a usar"
+
+#: ../src/common/appcmn.cpp:270
+msgid "specify display mode to use (e.g. 640x480-16)"
+msgstr "especifique el modo de pantalla a usar (ej.: 640x480-16)"
+
+#: ../src/common/appcmn.cpp:292
+#, c-format
+msgid "Unsupported theme '%s'."
+msgstr "No se admite el tema '%s'."
+
+#: ../src/common/appcmn.cpp:309
+#, c-format
+msgid "Invalid display mode specification '%s'."
+msgstr "Especificación de modo de pantalla no válida: '%s'."
+
+#: ../src/common/cmdline.cpp:875
+#, c-format
+msgid "Option '%s' can't be negated"
+msgstr "La opción «%s» no puede negarse"
+
+#: ../src/common/cmdline.cpp:889
+#, c-format
+msgid "Unknown long option '%s'"
+msgstr "El parámetro '%s' de entero largo es desconocido"
+
+#: ../src/common/cmdline.cpp:904 ../src/common/cmdline.cpp:926
+#, c-format
+msgid "Unknown option '%s'"
+msgstr "La opción «%s» es desconocida"
+
+#: ../src/common/cmdline.cpp:1004
+#, c-format
+msgid "Unexpected characters following option '%s'."
+msgstr "Caracteres inesperados tras la opción '%s'."
+
+#: ../src/common/cmdline.cpp:1039
+#, c-format
+msgid "Option '%s' requires a value."
+msgstr "La opción «%s» exige un valor."
+
+#: ../src/common/cmdline.cpp:1058
+#, c-format
+msgid "Separator expected after the option '%s'."
+msgstr "Se esperaba un separador después de la opción «%s»."
+
+#: ../src/common/cmdline.cpp:1088 ../src/common/cmdline.cpp:1106
+#, c-format
+msgid "'%s' is not a correct numeric value for option '%s'."
+msgstr "'%s' no es un valor numérico correcto para el parámetro '%s'."
+
+#: ../src/common/cmdline.cpp:1122
+#, c-format
+msgid "Option '%s': '%s' cannot be converted to a date."
+msgstr "Parámetro «%s»: «%s» no puede convertirse en fecha."
+
+#: ../src/common/cmdline.cpp:1170
+#, c-format
+msgid "Unexpected parameter '%s'"
+msgstr "Parámetro «%s» inesperado"
+
+#. TRANSLATORS: Short name and long name for a command line option
+#: ../src/common/cmdline.cpp:1197
+#, c-format
+msgid "%s (or %s)"
+msgstr "%s (o %s)"
+
+#: ../src/common/cmdline.cpp:1208
+#, c-format
+msgid "The value for the option '%s' must be specified."
+msgstr "El valor para la opción '%s' debe especificarse."
+
+#: ../src/common/cmdline.cpp:1230
+#, c-format
+msgid "The required parameter '%s' was not specified."
+msgstr "El parámetro requerido '%s' no fue especificado."
+
+#: ../src/common/cmdline.cpp:1289
+#, c-format
+msgid "Usage: %s"
+msgstr "Uso: %s"
+
+#: ../src/common/cmdline.cpp:1498
+msgid "str"
+msgstr "cad"
+
+#: ../src/common/cmdline.cpp:1502
+msgid "num"
+msgstr "núm"
+
+#: ../src/common/cmdline.cpp:1506
+msgid "double"
+msgstr "doble"
+
+#: ../src/common/cmdline.cpp:1510
+msgid "date"
+msgstr "fecha"
+
+#: ../src/common/cmdproc.cpp:250 ../src/common/cmdproc.cpp:276
+#: ../src/common/cmdproc.cpp:296
+msgid "Unnamed command"
+msgstr "Orden sin nombre"
+
+#: ../src/common/cmdproc.cpp:253
+msgid "&Undo "
+msgstr "&Deshacer "
+
+#: ../src/common/cmdproc.cpp:255
+msgid "Can't &Undo "
+msgstr "No se puede &deshacer "
+
+#: ../src/common/cmdproc.cpp:259 ../src/common/stockitem.cpp:208
+#: ../src/msw/textctrl.cpp:2880 ../src/osx/textctrl_osx.cpp:649
+#: ../src/richtext/richtextctrl.cpp:327
+msgid "&Undo"
+msgstr "&Deshacer"
+
+#: ../src/common/cmdproc.cpp:277 ../src/common/cmdproc.cpp:297
+msgid "&Redo "
+msgstr "&Rehacer "
+
+#: ../src/common/cmdproc.cpp:281 ../src/common/cmdproc.cpp:288
+#: ../src/common/stockitem.cpp:190 ../src/msw/textctrl.cpp:2881
+#: ../src/osx/textctrl_osx.cpp:650 ../src/richtext/richtextctrl.cpp:328
+msgid "&Redo"
+msgstr "&Rehacer"
+
+#: ../src/common/colourcmn.cpp:41
+#, c-format
+msgid "String To Colour : Incorrect colour specification : %s"
+msgstr "String To Colour: especificación de color incorrecta: %s"
+
+#: ../src/common/config.cpp:259
+#, c-format
+msgid "Invalid value %ld for a boolean key \"%s\" in config file."
+msgstr ""
+"Valor %ld no válido para una clave booleana «%s» en el archivo de "
+"configuración."
+
+#: ../src/common/config.cpp:526
+#, c-format
+msgid ""
+"Environment variables expansion failed: missing '%c' at position %u in '%s'."
+msgstr ""
+"Fallo en expansión de variable de entorno: falta '%c' en la posición %u en "
+"'%s'."
+
+#: ../src/common/config.cpp:576 ../src/msw/regconf.cpp:272
+#, c-format
+msgid "'%s' has extra '..', ignored."
+msgstr "'%s' tiene '..' adicional, se ignora."
+
+#. TRANSLATORS: Checkbox state name
+#: ../src/common/datavcmn.cpp:2166 ../src/generic/datavgen.cpp:1430
+msgid "checked"
+msgstr "activada"
+
+#. TRANSLATORS: Checkbox state name
+#: ../src/common/datavcmn.cpp:2170 ../src/generic/datavgen.cpp:1432
+msgid "unchecked"
+msgstr "desactivada"
+
+#. TRANSLATORS: Checkbox state name
+#: ../src/common/datavcmn.cpp:2174
+msgid "undetermined"
+msgstr "sin determinar"
+
+#: ../src/common/datetimefmt.cpp:1875
+msgid "today"
+msgstr "hoy"
+
+#: ../src/common/datetimefmt.cpp:1876
+msgid "yesterday"
+msgstr "ayer"
+
+#: ../src/common/datetimefmt.cpp:1877
+msgid "tomorrow"
+msgstr "mañana"
+
+#: ../src/common/datetimefmt.cpp:2071
+msgid "first"
+msgstr "primero"
+
+#: ../src/common/datetimefmt.cpp:2072
+msgid "second"
+msgstr "segundo"
+
+#: ../src/common/datetimefmt.cpp:2073
+msgid "third"
+msgstr "tercero"
+
+#: ../src/common/datetimefmt.cpp:2074
+msgid "fourth"
+msgstr "cuarto"
+
+#: ../src/common/datetimefmt.cpp:2075
+msgid "fifth"
+msgstr "quinto"
+
+#: ../src/common/datetimefmt.cpp:2076
+msgid "sixth"
+msgstr "sexto"
+
+#: ../src/common/datetimefmt.cpp:2077
+msgid "seventh"
+msgstr "séptimo"
+
+#: ../src/common/datetimefmt.cpp:2078
+msgid "eighth"
+msgstr "octavo"
+
+#: ../src/common/datetimefmt.cpp:2079
+msgid "ninth"
+msgstr "noveno"
+
+#: ../src/common/datetimefmt.cpp:2080
+msgid "tenth"
+msgstr "décimo"
+
+#: ../src/common/datetimefmt.cpp:2081
+msgid "eleventh"
+msgstr "undécimo"
+
+#: ../src/common/datetimefmt.cpp:2082
+msgid "twelfth"
+msgstr "duodécimo"
+
+#: ../src/common/datetimefmt.cpp:2083
+msgid "thirteenth"
+msgstr "decimotercero"
+
+#: ../src/common/datetimefmt.cpp:2084
+msgid "fourteenth"
+msgstr "decimocuarto"
+
+#: ../src/common/datetimefmt.cpp:2085
+msgid "fifteenth"
+msgstr "decimoquinto"
+
+#: ../src/common/datetimefmt.cpp:2086
+msgid "sixteenth"
+msgstr "decimosexto"
+
+#: ../src/common/datetimefmt.cpp:2087
+msgid "seventeenth"
+msgstr "decimoséptimo"
+
+#: ../src/common/datetimefmt.cpp:2088
+msgid "eighteenth"
+msgstr "decimoctavo"
+
+#: ../src/common/datetimefmt.cpp:2089
+msgid "nineteenth"
+msgstr "decimonoveno"
+
+#: ../src/common/datetimefmt.cpp:2090
+msgid "twentieth"
+msgstr "vigésimo"
+
+#: ../src/common/datetimefmt.cpp:2248
+msgid "noon"
+msgstr "mediodía"
+
+#: ../src/common/datetimefmt.cpp:2249
+msgid "midnight"
+msgstr "medianoche"
+
+#: ../src/common/debugrpt.cpp:209
+#, c-format
+msgid "Failed to create directory \"%s\""
+msgstr "Falló la creación del directorio «%s»"
+
+#: ../src/common/debugrpt.cpp:210
+msgid "Debug report couldn't be created."
+msgstr "No se pudo crear el informe de depuración."
+
+#: ../src/common/debugrpt.cpp:227
+#, c-format
+msgid "Failed to remove debug report file \"%s\""
+msgstr "No se pudo eliminar el archivo de informe de depuración '%s'"
+
+#: ../src/common/debugrpt.cpp:239
+#, c-format
+msgid "Failed to clean up debug report directory \"%s\""
+msgstr "No se pudo vaciar el directorio de informe de depuración \"%s\""
+
+#: ../src/common/debugrpt.cpp:514
+msgid "process context description"
+msgstr "descripción del contexto de proceso"
+
+#: ../src/common/debugrpt.cpp:538
+msgid "dump of the process state (binary)"
+msgstr "volcado de estado de proceso (binario)"
+
+#: ../src/common/debugrpt.cpp:553
+msgid "Debug report generation has failed."
+msgstr "No se pudo generar el informe de depuración."
+
+#: ../src/common/debugrpt.cpp:560
+#, c-format
+msgid ""
+"Processing debug report has failed, leaving the files in \"%s\" directory."
+msgstr ""
+"Falló el procesamiento del informe de depuración; se han dejado los archivos "
+"en el directorio «%s»."
+
+#: ../src/common/debugrpt.cpp:573
+msgid "A debug report has been generated. It can be found in"
+msgstr "Se ha generado un informe de depuración en"
+
+#: ../src/common/debugrpt.cpp:576
+msgid "And includes the following files:\n"
+msgstr "E incluye los siguientes archivos:\n"
+
+#: ../src/common/debugrpt.cpp:586
+msgid ""
+"\n"
+"Please send this report to the program maintainer, thank you!\n"
+msgstr ""
+"\n"
+"Envíe este informe al responsable del programa. ¡Gracias!\n"
+
+#: ../src/common/debugrpt.cpp:729
+msgid "Failed to execute curl, please install it in PATH."
+msgstr "Fallo al ejecutar curl, por favor instálelo en el PATH."
+
+#: ../src/common/debugrpt.cpp:742
+#, c-format
+msgid "Failed to upload the debug report (error code %d)."
+msgstr "Fallo al enviar el informe de depuración (código error %d)"
+
+#: ../src/common/docview.cpp:366
+msgid "Save As"
+msgstr "Guardar como"
+
+#: ../src/common/docview.cpp:457
+msgid "Discard changes and reload the last saved version?"
+msgstr "¿Descartar los cambios y recargar la última versión guardada?"
+
+#: ../src/common/docview.cpp:488
+msgid "unnamed"
+msgstr "anónimo"
+
+#: ../src/common/docview.cpp:513
+#, c-format
+msgid "Do you want to save changes to %s?"
+msgstr "¿Desea guardar los cambios hechos a %s?"
+
+#: ../src/common/docview.cpp:521 ../src/common/docview.cpp:560
+#: ../src/common/stockitem.cpp:195
+msgid "&Save"
+msgstr "&Guardar"
+
+#: ../src/common/docview.cpp:522 ../src/common/docview.cpp:560
+msgid "&Discard changes"
+msgstr "&Descartar cambios"
+
+#: ../src/common/docview.cpp:523
+msgid "Do&n't close"
+msgstr "&No cerrar"
+
+#: ../src/common/docview.cpp:553
+#, c-format
+msgid "Do you want to save changes to %s before closing it?"
+msgstr "¿Desea guardar los cambios hechos a %s antes de cerrarlo?"
+
+#: ../src/common/docview.cpp:559
+msgid "The document must be closed."
+msgstr "El documento debe cerrarse."
+
+#: ../src/common/docview.cpp:571
+#, c-format
+msgid "Saving %s failed, would you like to retry?"
+msgstr "Fallo al guardar %s, ¿quiere reintentarlo?"
+
+#: ../src/common/docview.cpp:577
+msgid "Retry"
+msgstr "Reintentar"
+
+#: ../src/common/docview.cpp:577
+msgid "Discard changes"
+msgstr "Descartar cambios"
+
+#: ../src/common/docview.cpp:679
+#, c-format
+msgid "File \"%s\" could not be opened for writing."
+msgstr "No se pudo abrir el archivo «%s» para su escritura."
+
+#: ../src/common/docview.cpp:685
+#, c-format
+msgid "Failed to save document to the file \"%s\"."
+msgstr "Falló el guardado del documento en el archivo «%s»."
+
+#: ../src/common/docview.cpp:702
+#, c-format
+msgid "File \"%s\" could not be opened for reading."
+msgstr "No se pudo abrir el archivo «%s» para su lectura."
+
+#: ../src/common/docview.cpp:714
+#, c-format
+msgid "Failed to read document from the file \"%s\"."
+msgstr "Falló la lectura del documento a partir del archivo «%s»."
+
+#: ../src/common/docview.cpp:1236
+#, c-format
+msgid ""
+"The file '%s' doesn't exist and couldn't be opened.\n"
+"It has been removed from the most recently used files list."
+msgstr ""
+"El archivo '%s' no existe y no puede abrirse.\n"
+"También ha sido eliminado de la lista de archivos recientes."
+
+#: ../src/common/docview.cpp:1296
+msgid "Print preview creation failed."
+msgstr "Error al crear la previsualización de impresión."
+
+#: ../src/common/docview.cpp:1302
+msgid "Print Preview"
+msgstr "Previsualización de la impresión"
+
+#: ../src/common/docview.cpp:1517
+#, c-format
+msgid "The format of file '%s' couldn't be determined."
+msgstr "No se pudo determinar el formato del archivo «%s»."
+
+#: ../src/common/docview.cpp:1643
+#, c-format
+msgid "unnamed%d"
+msgstr "anónimo%d"
+
+#: ../src/common/docview.cpp:1660
+msgid " - "
+msgstr " - "
+
+#: ../src/common/docview.cpp:1791 ../src/common/docview.cpp:1844
+msgid "Open File"
+msgstr "Abrir archivo"
+
+#: ../src/common/docview.cpp:1807
+msgid "File error"
+msgstr "Error de archivo"
+
+#: ../src/common/docview.cpp:1809
+msgid "Sorry, could not open this file."
+msgstr "No pudo abrirse este archivo."
+
+#: ../src/common/docview.cpp:1843
+msgid "Sorry, the format for this file is unknown."
+msgstr "Se desconoce el formato de este archivo."
+
+#: ../src/common/docview.cpp:1924
+msgid "Select a document template"
+msgstr "Seleccionar una plantilla de documento"
+
+#: ../src/common/docview.cpp:1925
+msgid "Templates"
+msgstr "Plantillas"
+
+#: ../src/common/docview.cpp:1998
+msgid "Select a document view"
+msgstr "Seleccionar una vista de documento"
+
+#: ../src/common/docview.cpp:1999
+msgid "Views"
+msgstr "Vistas"
+
+#: ../src/common/dynlib.cpp:81
+#, c-format
+msgid "Failed to load shared library '%s'"
+msgstr "Falló la carga de la biblioteca compartida «%s»"
+
+#: ../src/common/dynlib.cpp:105
+#, c-format
+msgid "Couldn't find symbol '%s' in a dynamic library"
+msgstr "No se pudo encontrar el símbolo «%s» en la biblioteca dinámica"
+
+#: ../src/common/ffile.cpp:56 ../src/common/file.cpp:215
+#, c-format
+msgid "can't open file '%s'"
+msgstr "no se puede abrir el archivo '%s'"
+
+#: ../src/common/ffile.cpp:72
+#, c-format
+msgid "can't close file '%s'"
+msgstr "no se puede cerrar el archivo '%s'"
+
+#: ../src/common/ffile.cpp:106 ../src/common/ffile.cpp:131
+#, c-format
+msgid "Read error on file '%s'"
+msgstr "Error de lectura en el archivo '%s'"
+
+#: ../src/common/ffile.cpp:148
+#, c-format
+msgid "Write error on file '%s'"
+msgstr "Error de escritura en el archivo '%s'"
+
+#: ../src/common/ffile.cpp:182
+#, c-format
+msgid "failed to flush the file '%s'"
+msgstr "no se pudo limpiar el archivo '%s'"
+
+#: ../src/common/ffile.cpp:222
+#, c-format
+msgid "Seek error on file '%s' (large files not supported by stdio)"
+msgstr ""
+"Error de búsqueda en el archivo «%s» (stdio no admite los archivos grandes)"
+
+#: ../src/common/ffile.cpp:232
+#, c-format
+msgid "Seek error on file '%s'"
+msgstr "Error de búsqueda en el archivo «%s»"
+
+#: ../src/common/ffile.cpp:248
+#, c-format
+msgid "Can't find current position in file '%s'"
+msgstr "No se puede encontrar la posición actual en el archivo «%s»"
+
+#: ../src/common/ffile.cpp:349 ../src/common/file.cpp:569
+msgid "Failed to set temporary file permissions"
+msgstr "No se pudieron cambiar permisos del archivo temporal"
+
+#: ../src/common/ffile.cpp:371
+#, c-format
+msgid "can't remove file '%s'"
+msgstr "no se puede eliminar el archivo '%s'"
+
+#: ../src/common/ffile.cpp:376 ../src/common/file.cpp:591
+#, c-format
+msgid "can't commit changes to file '%s'"
+msgstr "no se pueden hacer efectivos los cambios en archivo '%s'"
+
+#: ../src/common/ffile.cpp:388 ../src/common/file.cpp:603
+#, c-format
+msgid "can't remove temporary file '%s'"
+msgstr "no se puede eliminar el archivo temporal '%s'"
+
+#: ../src/common/file.cpp:162
+#, c-format
+msgid "can't create file '%s'"
+msgstr "no se puede crear el archivo '%s'"
+
+#: ../src/common/file.cpp:229
+#, c-format
+msgid "can't close file descriptor %d"
+msgstr "no se puede cerrar el descriptor de archivo %d"
+
+#: ../src/common/file.cpp:332
+#, c-format
+msgid "can't read from file descriptor %d"
+msgstr "no se puede leer desde el descriptor de archivo %d"
+
+#: ../src/common/file.cpp:351
+#, c-format
+msgid "can't write to file descriptor %d"
+msgstr "no se puede escribir el descriptor de archivo %d"
+
+#: ../src/common/file.cpp:390
+#, c-format
+msgid "can't flush file descriptor %d"
+msgstr "no se puede vaciar el descriptor de archivo %d"
+
+#: ../src/common/file.cpp:432
+#, c-format
+msgid "can't seek on file descriptor %d"
+msgstr "no se puede buscar en el descriptor de archivo %d"
+
+#: ../src/common/file.cpp:446
+#, c-format
+msgid "can't get seek position on file descriptor %d"
+msgstr ""
+"no se puede alcanzar posición de búsqueda en el descriptor de archivo %d"
+
+#: ../src/common/file.cpp:475
+#, c-format
+msgid "can't find length of file on file descriptor %d"
+msgstr "no se puede obtener el tamaño del archivo con descriptor %d"
+
+#: ../src/common/file.cpp:505
+#, c-format
+msgid "can't determine if the end of file is reached on descriptor %d"
+msgstr ""
+"no se puede determinar si el final del archivo con descriptor %d se ha "
+"alcanzado"
+
+#: ../src/common/fileconf.cpp:352
+#, c-format
+msgid ""
+" and additionally, the existing configuration file was renamed to \"%s\" and "
+"couldn't be renamed back, please rename it to its original path \"%s\""
+msgstr ""
+" Y además, el archivo de configuración existente fue renombrado a \"%s\" y "
+"no se pudo volver a nombrar, por favor cámbiele el nombre a su ruta original "
+"\"%s\""
+
+#: ../src/common/fileconf.cpp:389
+msgid " due to the following error:\n"
+msgstr " debido al siguiente error:\n"
+
+#: ../src/common/fileconf.cpp:412
+msgid "failed to rename the existing file"
+msgstr "no se pudo cambiar el nombre del archivo existente"
+
+#: ../src/common/fileconf.cpp:421
+msgid "failed to create the new file directory"
+msgstr "no se pudo crear el nuevo directorio de archivos"
+
+#: ../src/common/fileconf.cpp:428
+msgid "failed to move the file to the new location"
+msgstr "no se pudo mover el archivo a la nueva ubicación"
+
+#: ../src/common/fileconf.cpp:462
+#, c-format
+msgid "can't open global configuration file '%s'."
+msgstr "no se puede abrir el archivo de configuración global '%s'."
+
+#: ../src/common/fileconf.cpp:478
+#, c-format
+msgid "can't open user configuration file '%s'."
+msgstr "no se puede abrir el archivo de configuración de usuario '%s'."
+
+#: ../src/common/fileconf.cpp:483
+#, c-format
+msgid "Changes won't be saved to avoid overwriting the existing file \"%s\""
+msgstr ""
+"Los cambios no se guardarán para evitar sobrescribir el archivo existente "
+"«%s»"
+
+#: ../src/common/fileconf.cpp:583
+msgid "Error reading config options."
+msgstr "Error al leer las opciones de configuración."
+
+#: ../src/common/fileconf.cpp:593
+msgid "Failed to read config options."
+msgstr "Falló la lectura de las opciones de configuración."
+
+#: ../src/common/fileconf.cpp:700
+#, c-format
+msgid "file '%s': unexpected character %c at line %zu."
+msgstr "archivo «%s»: carácter %c inesperado en el renglón %zu."
+
+#: ../src/common/fileconf.cpp:736
+#, c-format
+msgid "file '%s', line %zu: '%s' ignored after group header."
+msgstr "archivo «%s», renglón %zu: «%s» ignorado después de cabecera de grupo."
+
+#: ../src/common/fileconf.cpp:765
+#, c-format
+msgid "file '%s', line %zu: '=' expected."
+msgstr "archivo «%s», renglón %zu: se esperaba «=»."
+
+#: ../src/common/fileconf.cpp:778
+#, c-format
+msgid "file '%s', line %zu: value for immutable key '%s' ignored."
+msgstr ""
+"archivo «%s», renglón %zu: se ignoró el valor para la clave inmutable «%s»."
+
+#: ../src/common/fileconf.cpp:788
+#, c-format
+msgid "file '%s', line %zu: key '%s' was first found at line %d."
+msgstr ""
+"archivo «%s», renglón %zu: se encontró la clave «%s» por primera vez en el "
+"renglón %d."
+
+#: ../src/common/fileconf.cpp:1091
+#, c-format
+msgid "Config entry name cannot start with '%c'."
+msgstr "Un nombre de entrada de configuración no puede empezar por «%c»."
+
+#: ../src/common/fileconf.cpp:1146
+msgid "Failed to create configuration file directory."
+msgstr "Error al crear la carpeta de configuración del archivo."
+
+#: ../src/common/fileconf.cpp:1158
+msgid "can't open user configuration file."
+msgstr "no puede abrirse el archivo de configuración de usuario."
+
+#: ../src/common/fileconf.cpp:1172
+msgid "can't write user configuration file."
+msgstr "no puede escribirse el archivo de configuración de usuario."
+
+#: ../src/common/fileconf.cpp:1178
+msgid "Failed to update user configuration file."
+msgstr "No se pudo actualizar el archivo de configuración de usuario."
+
+#: ../src/common/fileconf.cpp:1201
+msgid "Error saving user configuration data."
+msgstr "Error al guardar los datos de configuración del usuario."
+
+#: ../src/common/fileconf.cpp:1313
+#, c-format
+msgid "can't delete user configuration file '%s'"
+msgstr "no se puede eliminar el archivo de configuración de usuario '%s'"
+
+#: ../src/common/fileconf.cpp:2007
+#, c-format
+msgid "entry '%s' appears more than once in group '%s'"
+msgstr "la entrada '%s' aparece más de una vez en el grupo '%s'"
+
+#: ../src/common/fileconf.cpp:2021
+#, c-format
+msgid "attempt to change immutable key '%s' ignored."
+msgstr "intento de cambiar clave inmutable '%s', ignorado."
+
+#: ../src/common/fileconf.cpp:2118
+#, c-format
+msgid "trailing backslash ignored in '%s'"
+msgstr "ignorada la barra inversa al final de '%s'."
+
+#: ../src/common/fileconf.cpp:2153
+#, c-format
+msgid "unexpected \" at position %d in '%s'."
+msgstr "\" inesperada en la posición %d en '%s'."
+
+#: ../src/common/filefn.cpp:474
+#, c-format
+msgid "Failed to copy the file '%s' to '%s'"
+msgstr "No se pudo copiar el archivo '%s' a '%s'"
+
+#: ../src/common/filefn.cpp:487
+#, c-format
+msgid "Impossible to get permissions for file '%s'"
+msgstr "Imposible obtener permisos para el archivo '%s'"
+
+#: ../src/common/filefn.cpp:501
+#, c-format
+msgid "Impossible to overwrite the file '%s'"
+msgstr "Imposible sobrescribir el archivo «%s»"
+
+#: ../src/common/filefn.cpp:508
+#, c-format
+msgid "Error copying the file '%s' to '%s'."
+msgstr "Falló la copia del archivo «%s» en «%s»."
+
+#: ../src/common/filefn.cpp:556
+#, c-format
+msgid "Impossible to set permissions for the file '%s'"
+msgstr "Imposible establecer los permisos del archivo «%s»"
+
+#: ../src/common/filefn.cpp:606
+#, c-format
+msgid ""
+"Failed to rename the file '%s' to '%s' because the destination file already "
+"exists."
+msgstr ""
+"No se pudo renombrar el archivo '%s' a '%s' porque el archivo de destino ya "
+"existe."
+
+#: ../src/common/filefn.cpp:623
+#, c-format
+msgid "File '%s' couldn't be renamed '%s'"
+msgstr "No se pudo cambiar el nombre del archivo «%s» como «%s»"
+
+#: ../src/common/filefn.cpp:639
+#, c-format
+msgid "File '%s' couldn't be removed"
+msgstr "No se pudo quitar el archivo «%s»"
+
+#: ../src/common/filefn.cpp:666
+#, c-format
+msgid "Directory '%s' couldn't be created"
+msgstr "No se pudo crear el directorio «%s»"
+
+#: ../src/common/filefn.cpp:680
+#, c-format
+msgid "Directory '%s' couldn't be deleted"
+msgstr "No se pudo eliminar el directorio «%s»"
+
+#: ../src/common/filefn.cpp:714
+#, c-format
+msgid "Cannot enumerate files '%s'"
+msgstr "No se pueden enumerar los archivos «%s»"
+
+#: ../src/common/filefn.cpp:798
+msgid "Failed to get the working directory"
+msgstr "Error al obtener el directorio de trabajo"
+
+#: ../src/common/filefn.cpp:843
+msgid "Could not set current working directory"
+msgstr "No se pudo establecer la carpeta de trabajo actual"
+
+#: ../src/common/filefn.cpp:974
+#, c-format
+msgid "Files (%s)"
+msgstr "Archivos (%s)"
+
+#: ../src/common/filename.cpp:182
+#, c-format
+msgid "Failed to open '%s' for reading"
+msgstr "Falló la apertura del archivo «%s» para su lectura"
+
+#: ../src/common/filename.cpp:187
+#, c-format
+msgid "Failed to open '%s' for writing"
+msgstr "Falló la apertura del archivo «%s» para su escritura"
+
+#: ../src/common/filename.cpp:199
+msgid "Failed to close file handle"
+msgstr "Error al cerrar el manejador del archivo"
+
+#: ../src/common/filename.cpp:1046
+msgid "Failed to create a temporary file name"
+msgstr "No se pudo crear un nombre temporal de archivo"
+
+#: ../src/common/filename.cpp:1081
+msgid "Failed to open temporary file."
+msgstr "Falló la apertura del archivo temporal."
+
+#: ../src/common/filename.cpp:2862
+#, c-format
+msgid "Failed to modify file times for '%s'"
+msgstr "No se pudo modificar la hora del archivo para '%s'"
+
+#: ../src/common/filename.cpp:2877
+#, c-format
+msgid "Failed to touch the file '%s'"
+msgstr "No se pudo  retocar' el archivo '%s'"
+
+#: ../src/common/filename.cpp:2958
+#, c-format
+msgid "Failed to retrieve file times for '%s'"
+msgstr "No se pudo obtener horas del archivo para '%s'"
+
+#: ../src/common/filepickercmn.cpp:39 ../src/common/filepickercmn.cpp:40
+msgid "Browse"
+msgstr "Navegar"
+
+#: ../src/common/fldlgcmn.cpp:792 ../src/generic/filectrlg.cpp:1185
+#, c-format
+msgid "All files (%s)|%s"
+msgstr "Todos los archivos (%s)|%s"
+
+#. TRANSLATORS: %s are a file extension used to build a file wildcard string
+#: ../src/common/fldlgcmn.cpp:810
+#, c-format
+msgid "%s files (%s)|%s"
+msgstr "archivos %s (%s)|%s"
+
+#: ../src/common/fldlgcmn.cpp:1072
+#, c-format
+msgid "Load %s file"
+msgstr "Cargar el archivo %s"
+
+#: ../src/common/fldlgcmn.cpp:1074
+#, c-format
+msgid "Save %s file"
+msgstr "Guardar el archivo %s"
+
+#: ../src/common/fmapbase.cpp:144
+msgid "Western European (ISO-8859-1)"
+msgstr "Europa Occidental (ISO-8859-1)"
+
+#: ../src/common/fmapbase.cpp:145
+msgid "Central European (ISO-8859-2)"
+msgstr "Europa Central (ISO-8859-2)"
+
+#: ../src/common/fmapbase.cpp:146
+msgid "Esperanto (ISO-8859-3)"
+msgstr "Esperanto (ISO-8859-3)"
+
+#: ../src/common/fmapbase.cpp:147
+msgid "Baltic (old) (ISO-8859-4)"
+msgstr "Báltico (antiguo) (ISO-8859-4)"
+
+#: ../src/common/fmapbase.cpp:148
+msgid "Cyrillic (ISO-8859-5)"
+msgstr "Cirílico (ISO-8859-5)"
+
+#: ../src/common/fmapbase.cpp:149
+msgid "Arabic (ISO-8859-6)"
+msgstr "Arábigo (ISO-8859-6)"
+
+#: ../src/common/fmapbase.cpp:150
+msgid "Greek (ISO-8859-7)"
+msgstr "Griego (ISO-8859-7)"
+
+#: ../src/common/fmapbase.cpp:151
+msgid "Hebrew (ISO-8859-8)"
+msgstr "Hebreo (ISO-8859-8)"
+
+#: ../src/common/fmapbase.cpp:152
+msgid "Turkish (ISO-8859-9)"
+msgstr "Turco (ISO-8859-9)"
+
+#: ../src/common/fmapbase.cpp:153
+msgid "Nordic (ISO-8859-10)"
+msgstr "Nórdico (ISO-8859-10)"
+
+#: ../src/common/fmapbase.cpp:154
+msgid "Thai (ISO-8859-11)"
+msgstr "Tailandés (ISO-8859-11)"
+
+#: ../src/common/fmapbase.cpp:155
+msgid "Indian (ISO-8859-12)"
+msgstr "India (ISO-8859-12)"
+
+#: ../src/common/fmapbase.cpp:156
+msgid "Baltic (ISO-8859-13)"
+msgstr "Báltico (ISO-8859-13)"
+
+#: ../src/common/fmapbase.cpp:157
+msgid "Celtic (ISO-8859-14)"
+msgstr "Céltico (ISO-8859-14)"
+
+#: ../src/common/fmapbase.cpp:158
+msgid "Western European with Euro (ISO-8859-15)"
+msgstr "Europa Occidental con Euro (ISO-8859-15)"
+
+#: ../src/common/fmapbase.cpp:159
+msgid "KOI8-R"
+msgstr "KOI8-R"
+
+#: ../src/common/fmapbase.cpp:160
+msgid "KOI8-U"
+msgstr "KOI8-U"
+
+#: ../src/common/fmapbase.cpp:161
+msgid "Windows/DOS OEM Cyrillic (CP 866)"
+msgstr "Windows/DOS OEM Cirílico (CP 866)"
+
+#: ../src/common/fmapbase.cpp:162
+msgid "Windows Thai (CP 874)"
+msgstr "Windows Tailandés (CP 874)"
+
+#: ../src/common/fmapbase.cpp:163
+msgid "Windows Japanese (CP 932) or Shift-JIS"
+msgstr "Windows Japonés (CP 932) o Shift-JIS"
+
+#: ../src/common/fmapbase.cpp:164
+msgid "Windows Chinese Simplified (CP 936) or GB-2312"
+msgstr "Windows Chino simplificado (CP 936) or GB-2312"
+
+#: ../src/common/fmapbase.cpp:165
+msgid "Windows Korean (CP 949)"
+msgstr "Windows Coreano (CP 949)"
+
+#: ../src/common/fmapbase.cpp:166
+msgid "Windows Chinese Traditional (CP 950) or Big-5"
+msgstr "Windows Chino tradicional (CP 950) o Big-5"
+
+#: ../src/common/fmapbase.cpp:167
+msgid "Windows Central European (CP 1250)"
+msgstr "Windows Centro Europeo (CP 1250)"
+
+#: ../src/common/fmapbase.cpp:168
+msgid "Windows Cyrillic (CP 1251)"
+msgstr "Windows Cirílico (CP 1251)"
+
+#: ../src/common/fmapbase.cpp:169
+msgid "Windows Western European (CP 1252)"
+msgstr "Windows European Occidental (CP 1252)"
+
+#: ../src/common/fmapbase.cpp:170
+msgid "Windows Greek (CP 1253)"
+msgstr "Windows Griego (CP 1253)"
+
+#: ../src/common/fmapbase.cpp:171
+msgid "Windows Turkish (CP 1254)"
+msgstr "Windows Turco (CP 1254)"
+
+#: ../src/common/fmapbase.cpp:172
+msgid "Windows Hebrew (CP 1255)"
+msgstr "Windows Hebreo (CP 1255)"
+
+#: ../src/common/fmapbase.cpp:173
+msgid "Windows Arabic (CP 1256)"
+msgstr "Windows Árabe (CP 1256)"
+
+#: ../src/common/fmapbase.cpp:174
+msgid "Windows Baltic (CP 1257)"
+msgstr "Windows Báltico (CP 1257)"
+
+#: ../src/common/fmapbase.cpp:175
+msgid "Windows Vietnamese (CP 1258)"
+msgstr "Windows Vietnamita (CP 1258)"
+
+#: ../src/common/fmapbase.cpp:176
+msgid "Windows Johab (CP 1361)"
+msgstr "Windows Johab (CP 1361)"
+
+#: ../src/common/fmapbase.cpp:177
+msgid "Windows/DOS OEM (CP 437)"
+msgstr "Windows/DOS OEM (CP 437)"
+
+#: ../src/common/fmapbase.cpp:178
+msgid "Unicode 7 bit (UTF-7)"
+msgstr "Unicode 7 bit (UTF-7)"
+
+#: ../src/common/fmapbase.cpp:179
+msgid "Unicode 8 bit (UTF-8)"
+msgstr "Unicode 8 bit (UTF-8)"
+
+#: ../src/common/fmapbase.cpp:181 ../src/common/fmapbase.cpp:187
+msgid "Unicode 16 bit (UTF-16)"
+msgstr "Unicode 16 bits (UTF-16)"
+
+#: ../src/common/fmapbase.cpp:182
+msgid "Unicode 16 bit Little Endian (UTF-16LE)"
+msgstr "Unicode 16 bits Endian Pequeña (UTF-16LE)"
+
+#: ../src/common/fmapbase.cpp:183 ../src/common/fmapbase.cpp:189
+msgid "Unicode 32 bit (UTF-32)"
+msgstr "Unicode 32 bits (UTF-32)"
+
+#: ../src/common/fmapbase.cpp:184
+msgid "Unicode 32 bit Little Endian (UTF-32LE)"
+msgstr "Unicode 32 bits Endian Pequeña (UTF-32LE)"
+
+#: ../src/common/fmapbase.cpp:186
+msgid "Unicode 16 bit Big Endian (UTF-16BE)"
+msgstr "Unicode 16 bits Endian Grande (UTF-16BE)"
+
+#: ../src/common/fmapbase.cpp:188
+msgid "Unicode 32 bit Big Endian (UTF-32BE)"
+msgstr "Unicode 32 bits Endian Grande (UTF-32BE)"
+
+#: ../src/common/fmapbase.cpp:191
+msgid "Extended Unix Codepage for Japanese (EUC-JP)"
+msgstr "Página de códigos extendidad Unix para japonés (EUC-JP)"
+
+#: ../src/common/fmapbase.cpp:192
+msgid "US-ASCII"
+msgstr "US-ASCII"
+
+#: ../src/common/fmapbase.cpp:193
+msgid "ISO-2022-JP"
+msgstr "ISO-2022-JP"
+
+#: ../src/common/fmapbase.cpp:195
+msgid "MacRoman"
+msgstr "MacRoman"
+
+#: ../src/common/fmapbase.cpp:196
+msgid "MacJapanese"
+msgstr "MacJapanese"
+
+#: ../src/common/fmapbase.cpp:197
+msgid "MacChineseTrad"
+msgstr "MacChineseTrad"
+
+#: ../src/common/fmapbase.cpp:198
+msgid "MacKorean"
+msgstr "MacKorean"
+
+#: ../src/common/fmapbase.cpp:199
+msgid "MacArabic"
+msgstr "MacArabic"
+
+#: ../src/common/fmapbase.cpp:200
+msgid "MacHebrew"
+msgstr "MacHebrew"
+
+#: ../src/common/fmapbase.cpp:201
+msgid "MacGreek"
+msgstr "MacGreek"
+
+#: ../src/common/fmapbase.cpp:202
+msgid "MacCyrillic"
+msgstr "MacCyrillic"
+
+#: ../src/common/fmapbase.cpp:203
+msgid "MacDevanagari"
+msgstr "MacDevanagari"
+
+#: ../src/common/fmapbase.cpp:204
+msgid "MacGurmukhi"
+msgstr "MacGurmukhi"
+
+#: ../src/common/fmapbase.cpp:205
+msgid "MacGujarati"
+msgstr "MacGujarati"
+
+#: ../src/common/fmapbase.cpp:206
+msgid "MacOriya"
+msgstr "MacOriya"
+
+#: ../src/common/fmapbase.cpp:207
+msgid "MacBengali"
+msgstr "MacBengali"
+
+#: ../src/common/fmapbase.cpp:208
+msgid "MacTamil"
+msgstr "MacTamil"
+
+#: ../src/common/fmapbase.cpp:209
+msgid "MacTelugu"
+msgstr "MacTelugu"
+
+#: ../src/common/fmapbase.cpp:210
+msgid "MacKannada"
+msgstr "MacKannada"
+
+#: ../src/common/fmapbase.cpp:211
+msgid "MacMalayalam"
+msgstr "MacMalayalam"
+
+#: ../src/common/fmapbase.cpp:212
+msgid "MacSinhalese"
+msgstr "MacSinhalese"
+
+#: ../src/common/fmapbase.cpp:213
+msgid "MacBurmese"
+msgstr "MacBurmese"
+
+#: ../src/common/fmapbase.cpp:214
+msgid "MacKhmer"
+msgstr "MacKhmer"
+
+#: ../src/common/fmapbase.cpp:215
+msgid "MacThai"
+msgstr "MacThai"
+
+#: ../src/common/fmapbase.cpp:216
+msgid "MacLaotian"
+msgstr "MacLaotian"
+
+#: ../src/common/fmapbase.cpp:217
+msgid "MacGeorgian"
+msgstr "MacGeorgian"
+
+#: ../src/common/fmapbase.cpp:218
+msgid "MacArmenian"
+msgstr "MacArmenian"
+
+#: ../src/common/fmapbase.cpp:219
+msgid "MacChineseSimp"
+msgstr "MacChineseSimp"
+
+#: ../src/common/fmapbase.cpp:220
+msgid "MacTibetan"
+msgstr "MacTibetan"
+
+#: ../src/common/fmapbase.cpp:221
+msgid "MacMongolian"
+msgstr "MacMongolian"
+
+#: ../src/common/fmapbase.cpp:222
+msgid "MacEthiopic"
+msgstr "MacEthiopic"
+
+#: ../src/common/fmapbase.cpp:223
+msgid "MacCentralEurRoman"
+msgstr "MacCentralEurRoman"
+
+#: ../src/common/fmapbase.cpp:224
+msgid "MacVietnamese"
+msgstr "MacVietnamese"
+
+#: ../src/common/fmapbase.cpp:225
+msgid "MacExtArabic"
+msgstr "MacExtArabic"
+
+#: ../src/common/fmapbase.cpp:226
+msgid "MacSymbol"
+msgstr "MacSymbol"
+
+#: ../src/common/fmapbase.cpp:227
+msgid "MacDingbats"
+msgstr "MacDingbats"
+
+#: ../src/common/fmapbase.cpp:228
+msgid "MacTurkish"
+msgstr "MacTurkish"
+
+#: ../src/common/fmapbase.cpp:229
+msgid "MacCroatian"
+msgstr "MacCroatian"
+
+#: ../src/common/fmapbase.cpp:230
+msgid "MacIcelandic"
+msgstr "MacIcelandic"
+
+#: ../src/common/fmapbase.cpp:231
+msgid "MacRomanian"
+msgstr "MacRomanian"
+
+#: ../src/common/fmapbase.cpp:232
+msgid "MacCeltic"
+msgstr "MacCeltic"
+
+#: ../src/common/fmapbase.cpp:233
+msgid "MacGaelic"
+msgstr "MacGaelic"
+
+#: ../src/common/fmapbase.cpp:234
+msgid "MacKeyboardGlyphs"
+msgstr "MacKeyboardGlyphs"
+
+#: ../src/common/fmapbase.cpp:791
+msgid "Default encoding"
+msgstr "Codificación predeterminada"
+
+#: ../src/common/fmapbase.cpp:805
+#, c-format
+msgid "Unknown encoding (%d)"
+msgstr "Codificación desconocida (%d)"
+
+#: ../src/common/fmapbase.cpp:815 ../src/richtext/richtextstyles.cpp:776
+msgid "default"
+msgstr "predeterminado"
+
+#: ../src/common/fmapbase.cpp:829
+#, c-format
+msgid "unknown-%d"
+msgstr "desconocido-%d"
+
+#: ../src/common/fontcmn.cpp:924 ../src/common/fontcmn.cpp:1130
+msgid "underlined"
+msgstr "subrayado"
+
+#: ../src/common/fontcmn.cpp:929
+msgid " strikethrough"
+msgstr " tachado"
+
+#: ../src/common/fontcmn.cpp:942
+msgid " thin"
+msgstr " fina"
+
+#: ../src/common/fontcmn.cpp:946
+msgid " extra light"
+msgstr " extraligera"
+
+#: ../src/common/fontcmn.cpp:950
+msgid " light"
+msgstr " ligera"
+
+#: ../src/common/fontcmn.cpp:954
+msgid " medium"
+msgstr " media"
+
+#: ../src/common/fontcmn.cpp:958
+msgid " semi bold"
+msgstr " negrita media"
+
+#: ../src/common/fontcmn.cpp:962
+msgid " bold"
+msgstr " negrita"
+
+#: ../src/common/fontcmn.cpp:966
+msgid " extra bold"
+msgstr " negrita extra"
+
+#: ../src/common/fontcmn.cpp:970
+msgid " heavy"
+msgstr " pesada"
+
+#: ../src/common/fontcmn.cpp:974
+msgid " extra heavy"
+msgstr " extrapesada"
+
+#: ../src/common/fontcmn.cpp:990
+msgid " italic"
+msgstr " cursiva"
+
+#: ../src/common/fontcmn.cpp:1134
+msgid "strikethrough"
+msgstr "tachado"
+
+#: ../src/common/fontcmn.cpp:1143
+msgid "thin"
+msgstr "fina"
+
+#: ../src/common/fontcmn.cpp:1156
+msgid "extralight"
+msgstr "extraligera"
+
+#: ../src/common/fontcmn.cpp:1161
+msgid "light"
+msgstr "ligera"
+
+#: ../src/common/fontcmn.cpp:1169 ../src/richtext/richtextstyles.cpp:775
+msgid "normal"
+msgstr "normal"
+
+#: ../src/common/fontcmn.cpp:1174
+msgid "medium"
+msgstr "media"
+
+#: ../src/common/fontcmn.cpp:1179 ../src/common/fontcmn.cpp:1199
+msgid "semibold"
+msgstr "negrita media"
+
+#: ../src/common/fontcmn.cpp:1184
+msgid "bold"
+msgstr "negrita"
+
+#: ../src/common/fontcmn.cpp:1194
+msgid "extrabold"
+msgstr "negrita extra"
+
+#: ../src/common/fontcmn.cpp:1204
+msgid "heavy"
+msgstr "pesada"
+
+#: ../src/common/fontcmn.cpp:1212
+msgid "extraheavy"
+msgstr "extrapesada"
+
+#: ../src/common/fontcmn.cpp:1217
+msgid "italic"
+msgstr "cursiva"
+
+#: ../src/common/fontmap.cpp:195
+msgid ": unknown charset"
+msgstr ": conjunto de caracteres desconocido"
+
+#: ../src/common/fontmap.cpp:199
+#, c-format
+msgid ""
+"The charset '%s' is unknown. You may select\n"
+"another charset to replace it with or choose\n"
+"[Cancel] if it cannot be replaced"
+msgstr ""
+"El conjunto de caracteres «%s» es desconocido. Puede\n"
+"seleccionar otro conjunto para reemplazarlo o elegir\n"
+"[Cancelar] si no puede reemplazarse"
+
+#: ../src/common/fontmap.cpp:241
+#, c-format
+msgid "Failed to remember the encoding for the charset '%s'."
+msgstr "Error al recordar la codificación para el conjunto de caracteres '%s'."
+
+#: ../src/common/fontmap.cpp:321
+msgid "can't load any font, aborting"
+msgstr "no se puede cargar ninguna fuente, abortando"
+
+#: ../src/common/fontmap.cpp:409
+msgid ": unknown encoding"
+msgstr ": codificación desconocida"
+
+#: ../src/common/fontmap.cpp:417
+#, c-format
+msgid ""
+"No font for displaying text in encoding '%s' found,\n"
+"but an alternative encoding '%s' is available.\n"
+"Do you want to use this encoding (otherwise you will have to choose another "
+"one)?"
+msgstr ""
+"No hay un tipo de letra para la codificación «%s»,\n"
+"pero existe una codificación alternativa, «%s».\n"
+"¿Le gustaría usar esta codificación (de otra forma deberá elegir otra)?"
+
+#: ../src/common/fontmap.cpp:422
+#, c-format
+msgid ""
+"No font for displaying text in encoding '%s' found.\n"
+"Would you like to select a font to be used for this encoding\n"
+"(otherwise the text in this encoding will not be shown correctly)?"
+msgstr ""
+"No existe un tipo de letra para la codificación «%s».\n"
+"¿Le gustaría seleccionar un tipo de letra para usarse con esta codificación\n"
+"(de otra forma el texto con esta codificación no se mostrará correctamente)?"
+
+#: ../src/common/fs_mem.cpp:169
+#, c-format
+msgid "Memory VFS already contains file '%s'!"
+msgstr "¡El VFS en memoria ya contiene el archivo '%s'!"
+
+#: ../src/common/fs_mem.cpp:232
+#, c-format
+msgid "Trying to remove file '%s' from memory VFS, but it is not loaded!"
+msgstr ""
+"¡Intentando eliminar el archivo '%s' de VFS de memoria, pero no está abierto!"
+
+#: ../src/common/fs_mem.cpp:262
+#, c-format
+msgid "Failed to store image '%s' to memory VFS!"
+msgstr "¡Falló el almacenamiento de la imagen '%s' en el VFS de memoria!"
+
+#: ../src/common/ftp.cpp:197
+msgid "Timeout while waiting for FTP server to connect, try passive mode."
+msgstr ""
+"Tiempo de espera de la conexión del servidor FTP excedido, pruebe a "
+"establecer el modo pasivo."
+
+#: ../src/common/ftp.cpp:399
+#, c-format
+msgid "Failed to set FTP transfer mode to %s."
+msgstr "Falló la definición del modo de transferencia FTP a %s."
+
+#: ../src/common/ftp.cpp:400 ../src/richtext/richtextsymboldlg.cpp:432
+msgid "ASCII"
+msgstr "ASCII"
+
+#: ../src/common/ftp.cpp:400
+msgid "binary"
+msgstr "binario"
+
+#: ../src/common/ftp.cpp:608
+msgid "The FTP server doesn't support the PORT command."
+msgstr "El servidor FTP no admite la orden PORT."
+
+#: ../src/common/ftp.cpp:622
+msgid "The FTP server doesn't support passive mode."
+msgstr "El servidor FTP no admite el modo pasivo."
+
+#: ../src/common/gifdecod.cpp:822
+#, c-format
+msgid "Incorrect GIF frame size (%u, %d) for the frame #%u"
+msgstr ""
+"Tamaño de fotograma incorrecto en el GIF (%u, %d) para el fotograma #%u"
+
+#: ../src/common/glcmn.cpp:108
+msgid "Failed to allocate colour for OpenGL"
+msgstr "Fallo al reservar un color para OpenGL"
+
+#: ../src/common/headerctrlcmn.cpp:57
+msgid "Please select the columns to show and define their order:"
+msgstr "Seleccione las columnas que se mostrarán y defina su orden:"
+
+#: ../src/common/headerctrlcmn.cpp:58
+msgid "Customize Columns"
+msgstr "Personalizar columnas"
+
+#: ../src/common/headerctrlcmn.cpp:304
+msgid "&Customize..."
+msgstr "&Personalizar…"
+
+#: ../src/common/hyperlnkcmn.cpp:132
+#, c-format
+msgid "Failed to open URL \"%s\" in the default browser"
+msgstr "Falló la apertura de la URL '%s' en el navegador predeterminado"
+
+#: ../src/common/iconbndl.cpp:195
+#, c-format
+msgid "Failed to load image %%d from file '%s'."
+msgstr "No se pudo abrir la imagen %%d desde el archivo '%s'."
+
+#: ../src/common/iconbndl.cpp:203
+#, c-format
+msgid "Failed to load image %d from stream."
+msgstr "No se pudo abrir la imagen %d desde el flujo."
+
+#: ../src/common/iconbndl.cpp:221
+#, c-format
+msgid "Failed to load icons from resource '%s'."
+msgstr "Falló la carga de los iconos a partir del recurso «%s»."
+
+#: ../src/common/imagbmp.cpp:97
+msgid "BMP: Couldn't save invalid image."
+msgstr "BMP: no se pudo guardar una imagen no válida."
+
+#: ../src/common/imagbmp.cpp:137
+msgid "BMP: wxImage doesn't have own wxPalette."
+msgstr "BMP: wxImage no tiene su propia wxPalette."
+
+#: ../src/common/imagbmp.cpp:243
+msgid "BMP: Couldn't write the file (Bitmap) header."
+msgstr "BMP: no se pudo escribir la cabecera (Bitmap) del archivo."
+
+#: ../src/common/imagbmp.cpp:266
+msgid "BMP: Couldn't write the file (BitmapInfo) header."
+msgstr "BMP: no se pudo escribir la cabecera (BitmapInfo) del archivo."
+
+#: ../src/common/imagbmp.cpp:353
+msgid "BMP: Couldn't write RGB color map."
+msgstr "BMP: no se pudo escribir el mapa de color RGB."
+
+#: ../src/common/imagbmp.cpp:487
+msgid "BMP: Couldn't write data."
+msgstr "BMP: no se pudieron escribir los datos."
+
+#: ../src/common/imagbmp.cpp:561 ../src/common/imagbmp.cpp:642
+msgid "BMP: Couldn't allocate memory."
+msgstr "BMP: no se pudo reservar memoria."
+
+#: ../src/common/imagbmp.cpp:1041
+msgid "DIB Header: Image width > 32767 pixels for file."
+msgstr "Cabecera DIB: Anchura de imagen > 32767 pixels por archivo."
+
+#: ../src/common/imagbmp.cpp:1049
+msgid "DIB Header: Image height > 32767 pixels for file."
+msgstr "Cabecera DIB: Altura de la imagen > 32767 pixels por archivo."
+
+#: ../src/common/imagbmp.cpp:1081
+msgid "DIB Header: Unknown bitdepth in file."
+msgstr "Cabecera DIB: Profundidad de color desconocida en archivo."
+
+#: ../src/common/imagbmp.cpp:1156
+msgid "DIB Header: Unknown encoding in file."
+msgstr "Cabecera DIB: Codificación desconocida en archivo."
+
+#: ../src/common/imagbmp.cpp:1165
+msgid "DIB Header: Encoding doesn't match bitdepth."
+msgstr "Cabecera DIB: La codificación no coincide con la profundidad de bits."
+
+#: ../src/common/imagbmp.cpp:1180
+#, c-format
+msgid "BMP Header: Invalid number of colors (%d)."
+msgstr ""
+
+#: ../src/common/imagbmp.cpp:1273
+msgid "Error in reading image DIB."
+msgstr "Error al leer la imagen DIB."
+
+#: ../src/common/imagbmp.cpp:1294
+msgid "ICO: Error in reading mask DIB."
+msgstr "ICO: Error al leer máscara DIB."
+
+#: ../src/common/imagbmp.cpp:1353
+msgid "ICO: Image too tall for an icon."
+msgstr "ICO: Imagen demasiado alta para un icono."
+
+#: ../src/common/imagbmp.cpp:1361
+msgid "ICO: Image too wide for an icon."
+msgstr "ICO: Imagen demasiado ancha para un icono."
+
+#: ../src/common/imagbmp.cpp:1388 ../src/common/imagbmp.cpp:1488
+#: ../src/common/imagbmp.cpp:1503 ../src/common/imagbmp.cpp:1514
+#: ../src/common/imagbmp.cpp:1528 ../src/common/imagbmp.cpp:1576
+#: ../src/common/imagbmp.cpp:1591 ../src/common/imagbmp.cpp:1605
+#: ../src/common/imagbmp.cpp:1616
+msgid "ICO: Error writing the image file!"
+msgstr "ICO: ¡Error al escribir el archivo de imagen!"
+
+#: ../src/common/imagbmp.cpp:1701
+msgid "ICO: Invalid icon index."
+msgstr "ICO: Indice de icono no válido."
+
+#: ../src/common/image.cpp:2410
+msgid "Image and mask have different sizes."
+msgstr "La imagen y la máscara son de tamaños distintos."
+
+#: ../src/common/image.cpp:2418 ../src/common/image.cpp:2459
+msgid "No unused colour in image being masked."
+msgstr ""
+"No hay ningún color sin utilizar en la imagen que se está enmascarando."
+
+#: ../src/common/image.cpp:2641
+#, c-format
+msgid "Failed to load bitmap \"%s\" from resources."
+msgstr "No se pudo cargar la imagen \"%s\" desde los recursos."
+
+#: ../src/common/image.cpp:2650
+#, c-format
+msgid "Failed to load icon \"%s\" from resources."
+msgstr "No se pudo cargar el icono \"%s\"  desde los recursos."
+
+#: ../src/common/image.cpp:2728 ../src/common/image.cpp:2747
+#, c-format
+msgid "Failed to load image from file \"%s\"."
+msgstr "No se pudo abrir la imagen desde el archivo \"'%s\"."
+
+#: ../src/common/image.cpp:2761
+#, c-format
+msgid "Can't save image to file '%s': unknown extension."
+msgstr ""
+"No se puede guardar la imagen en el archivo «%s»: extensión desconocida."
+
+#: ../src/common/image.cpp:2869
+msgid "No handler found for image type."
+msgstr "No se ha encontrado ningún manipulador para el tipo de imagen."
+
+#: ../src/common/image.cpp:2877 ../src/common/image.cpp:3000
+#: ../src/common/image.cpp:3066
+#, c-format
+msgid "No image handler for type %d defined."
+msgstr "No hay definido ningún manipulador de imagen para tipo %d."
+
+#: ../src/common/image.cpp:2887
+#, c-format
+msgid "Image file is not of type %d."
+msgstr "El archivo de imagen no es del tipo %d."
+
+#: ../src/common/image.cpp:2970
+msgid "Can't automatically determine the image format for non-seekable input."
+msgstr ""
+"No se puede determinar automáticamente el formato de imagen en entradas "
+"secuenciales."
+
+#: ../src/common/image.cpp:2988
+msgid "Unknown image data format."
+msgstr "Formato de imagen desconocido."
+
+#: ../src/common/image.cpp:3009
+#, c-format
+msgid "This is not a %s."
+msgstr "Esto no es un %s."
+
+#: ../src/common/image.cpp:3032 ../src/common/image.cpp:3080
+#, c-format
+msgid "No image handler for type %s defined."
+msgstr "No hay definido ningún manipulador de imagen para tipo %s."
+
+#: ../src/common/image.cpp:3041
+#, c-format
+msgid "Image is not of type %s."
+msgstr "La imagen no es del tipo %s."
+
+#: ../src/common/image.cpp:3509
+#, c-format
+msgid "Failed to check format of image file \"%s\"."
+msgstr "Fallo comprobando el formato del archivo de imagen \"%s\"."
+
+#: ../src/common/imaggif.cpp:124
+msgid "GIF: error in GIF image format."
+msgstr "GIF: error en formato de imagen GIF."
+
+#: ../src/common/imaggif.cpp:129
+msgid "GIF: not enough memory."
+msgstr "GIF: memoria insuficiente."
+
+#: ../src/common/imaggif.cpp:134
+msgid "GIF: data stream seems to be truncated."
+msgstr "GIF: el flujo de datos parece haberse truncado."
+
+#: ../src/common/imaggif.cpp:240
+msgid "Couldn't initialize GIF hash table."
+msgstr "No se pudo inicializar la tabla hash del GIF."
+
+#: ../src/common/imagiff.cpp:739
+msgid "IFF: error in IFF image format."
+msgstr "IFF: error en formato de imagen IFF."
+
+#: ../src/common/imagiff.cpp:742
+msgid "IFF: not enough memory."
+msgstr "IFF: memoria insuficiente."
+
+#: ../src/common/imagiff.cpp:745
+msgid "IFF: unknown error!!!"
+msgstr "IFF: ¡¡¡error desconocido!!!"
+
+#: ../src/common/imagiff.cpp:755
+msgid "IFF: data stream seems to be truncated."
+msgstr "IFF: el flujo de datos parece truncado."
+
+#: ../src/common/imagjpeg.cpp:258
+msgid "JPEG: Couldn't load - file is probably corrupted."
+msgstr "JPEG: no se pudo cargar: quizás el archivo está dañado."
+
+#: ../src/common/imagjpeg.cpp:437
+msgid "JPEG: Couldn't save image."
+msgstr "JPEG: No pudo guardarse imagen."
+
+#: ../src/common/imagpcx.cpp:439
+msgid "PCX: this is not a PCX file."
+msgstr "PCX: este no es un archivo PCX."
+
+#: ../src/common/imagpcx.cpp:453
+msgid "PCX: image format unsupported"
+msgstr "PCX: formato de imagen no admitido"
+
+#: ../src/common/imagpcx.cpp:454 ../src/common/imagpcx.cpp:477
+msgid "PCX: couldn't allocate memory"
+msgstr "PCX: no pudo reservarse memoria"
+
+#: ../src/common/imagpcx.cpp:455
+msgid "PCX: version number too low"
+msgstr "PCX: número de versión demasiado antiguo"
+
+#: ../src/common/imagpcx.cpp:456 ../src/common/imagpcx.cpp:478
+msgid "PCX: unknown error !!!"
+msgstr "PCX: ¡error desconocido!"
+
+#: ../src/common/imagpcx.cpp:476
+msgid "PCX: invalid image"
+msgstr "PCX: imagen no válida"
+
+#: ../src/common/imagpng.cpp:385
+#, c-format
+msgid "Unknown PNG resolution unit %d"
+msgstr "Resolución de la unidad %d de PNG desconocida"
+
+#: ../src/common/imagpng.cpp:439
+msgid "Couldn't load a PNG image - file is corrupted or not enough memory."
+msgstr ""
+"No se pudo abrir la imagen PNG: el archivo está dañado o no hay memoria "
+"suficiente."
+
+#: ../src/common/imagpng.cpp:513 ../src/common/imagpng.cpp:524
+#: ../src/common/imagpng.cpp:534
+msgid "Couldn't save PNG image."
+msgstr "No se pudo guardar la imagen PNG."
+
+#: ../src/common/imagpnm.cpp:71
+msgid "PNM: File format is not recognized."
+msgstr "PNM: no se reconoce el formato de archivo."
+
+#: ../src/common/imagpnm.cpp:89
+msgid "PNM: Couldn't allocate memory."
+msgstr "PNM: no se pudo reservar memoria."
+
+#: ../src/common/imagpnm.cpp:111 ../src/common/imagpnm.cpp:134
+#: ../src/common/imagpnm.cpp:156
+msgid "PNM: File seems truncated."
+msgstr "PNM: el archivo parece estar truncado."
+
+#: ../src/common/imagtiff.cpp:69
+#, c-format
+msgid " (in module \"%s\")"
+msgstr " (en el módulo «%s»)"
+
+#: ../src/common/imagtiff.cpp:304
+msgid "TIFF: Error loading image."
+msgstr "TIFF: error al cargar la imagen."
+
+#: ../src/common/imagtiff.cpp:314
+msgid "Invalid TIFF image index."
+msgstr "Índice de imagen TIFF no válido."
+
+#: ../src/common/imagtiff.cpp:358
+msgid "TIFF: Image size is abnormally big."
+msgstr "TIFF: el tamaño de la imagen es anormalmente grande."
+
+#: ../src/common/imagtiff.cpp:372 ../src/common/imagtiff.cpp:385
+#: ../src/common/imagtiff.cpp:769
+msgid "TIFF: Couldn't allocate memory."
+msgstr "TIFF: no se pudo reservar memoria."
+
+#: ../src/common/imagtiff.cpp:471
+msgid "TIFF: Error reading image."
+msgstr "TIFF: error al leer la imagen."
+
+#: ../src/common/imagtiff.cpp:532
+#, c-format
+msgid "Unknown TIFF resolution unit %d ignored"
+msgstr "Ignorada la unidad desconocida de resolución TIFF %d"
+
+#: ../src/common/imagtiff.cpp:611
+msgid "TIFF: Error saving image."
+msgstr "TIFF: error al guardar la imagen."
+
+#: ../src/common/imagtiff.cpp:868
+msgid "TIFF: Error writing image."
+msgstr "TIFF: error al escribir la imagen."
+
+#: ../src/common/imagtiff.cpp:881
+msgid "TIFF: Error flushing data."
+msgstr "TIFF: Error al vaciar los datos."
+
+#: ../src/common/imagwebp.cpp:56
+msgid "WebP: Invalid data (failed to get features)."
+msgstr ""
+
+#: ../src/common/imagwebp.cpp:65
+msgid "WebP: Allocating image memory failed."
+msgstr ""
+
+#: ../src/common/imagwebp.cpp:82
+msgid "WebP: Decoding RGBA image data failed."
+msgstr ""
+
+#: ../src/common/imagwebp.cpp:98
+msgid "WebP: Decoding RGB image data failed."
+msgstr ""
+
+#: ../src/common/imagwebp.cpp:113 ../src/common/imagwebp.cpp:201
+msgid "WebP: Allocating stream buffer failed."
+msgstr ""
+
+#: ../src/common/imagwebp.cpp:131
+#, fuzzy
+msgid "WebP: Failed to parse container data."
+msgstr "Error al colocar datos en el portapapeles."
+
+#: ../src/common/imagwebp.cpp:222
+#, fuzzy
+msgid "WebP: Error decoding animation."
+msgstr "Error al leer las opciones de configuración."
+
+#: ../src/common/imagwebp.cpp:240
+msgid "WebP: Error getting next animation frame."
+msgstr ""
+
+#: ../src/common/init.cpp:172
+#, c-format
+msgid ""
+"Command line argument %d couldn't be converted to Unicode and will be "
+"ignored."
+msgstr ""
+"No se pudo convertir el argumento de consola %d en Unicode y se ignorará."
+
+#: ../src/common/init.cpp:344
+msgid "Initialization failed in post init, aborting."
+msgstr "Falló la inicialización en la fase «post init»; se ha interrumpido."
+
+#: ../src/common/intl.cpp:378
+#, c-format
+msgid "Cannot set locale to language \"%s\"."
+msgstr "No se puede cambiar la configuración regional al idioma «%s»."
+
+#: ../src/common/log.cpp:232
+msgid "Error: "
+msgstr "Error: "
+
+#: ../src/common/log.cpp:236
+msgid "Warning: "
+msgstr "Alerta: "
+
+#: ../src/common/log.cpp:284
+msgid "The previous message repeated once."
+msgstr "El mensaje anterior repetido una vez."
+
+#: ../src/common/log.cpp:291
+#, c-format
+msgid "The previous message repeated %u time."
+msgid_plural "The previous message repeated %u times."
+msgstr[0] "El mensaje anterior repetido %u vez."
+msgstr[1] "El mensaje anterior repetido %u veces."
+
+#: ../src/common/log.cpp:319
+#, c-format
+msgid "Last repeated message (\"%s\", %u time) wasn't output"
+msgid_plural "Last repeated message (\"%s\", %u times) wasn't output"
+msgstr[0] "No se mostró el último mensaje repetido («%s», %u vez)"
+msgstr[1] "No se mostró el último mensaje repetido («%s», %u veces)"
+
+#: ../src/common/log.cpp:435
+#, c-format
+msgid " (error %ld: %s)"
+msgstr " (error %ld: %s)"
+
+#: ../src/common/lzmastream.cpp:121
+msgid "Failed to allocate memory for LZMA decompression."
+msgstr "Fallo al reservar memoria para la descompresión LZMA."
+
+#: ../src/common/lzmastream.cpp:125
+#, c-format
+msgid "Failed to initialize LZMA decompression: unexpected error %u."
+msgstr "Fallo al inicializar la descompresión LZMA: error inesperado %u."
+
+#: ../src/common/lzmastream.cpp:179
+msgid "input is not in XZ format"
+msgstr "la entrada no está en formato XZ"
+
+#: ../src/common/lzmastream.cpp:183
+msgid "input compressed using unknown XZ option"
+msgstr "entrada comprimida usando una opción XZ desconocida"
+
+#: ../src/common/lzmastream.cpp:188
+msgid "input is corrupted"
+msgstr "la entrada está corrompida"
+
+#: ../src/common/lzmastream.cpp:192
+msgid "unknown decompression error"
+msgstr "error de descompresión desconocido"
+
+#: ../src/common/lzmastream.cpp:196
+#, c-format
+msgid "LZMA decompression error: %s"
+msgstr "Error de descompresión LZMA %s"
+
+#: ../src/common/lzmastream.cpp:231
+msgid "Failed to allocate memory for LZMA compression."
+msgstr "Fallo al reservar memoria para la compresión LZMA."
+
+#: ../src/common/lzmastream.cpp:235
+#, c-format
+msgid "Failed to initialize LZMA compression: unexpected error %u."
+msgstr "Fallo al inicializar la compresión LZMA: error inesperado %u."
+
+#: ../src/common/lzmastream.cpp:267 ../src/common/lzmastream.cpp:342
+#: ../src/html/chm.cpp:336
+msgid "out of memory"
+msgstr "memoria agotada"
+
+#: ../src/common/lzmastream.cpp:276 ../src/common/lzmastream.cpp:346
+msgid "unknown compression error"
+msgstr "error de compresión desconocido"
+
+#: ../src/common/lzmastream.cpp:280
+#, c-format
+msgid "LZMA compression error: %s"
+msgstr "Error de compresión LZMA %s"
+
+#: ../src/common/lzmastream.cpp:350
+#, c-format
+msgid "LZMA compression error when flushing output: %s"
+msgstr "Error de compresión LZMA al vaciar la salida: %s"
+
+#: ../src/common/mimecmn.cpp:167
+#, c-format
+msgid "Unmatched '{' in an entry for mime type %s."
+msgstr "Llave abierta no emparejada en una entrada para tipo mime %s."
+
+#: ../src/common/module.cpp:76
+#, c-format
+msgid "Circular dependency involving module \"%s\" detected."
+msgstr "Se ha detectado una dependencia circular concerniente al módulo «%s»."
+
+#: ../src/common/module.cpp:128
+#, c-format
+msgid "Dependency \"%s\" of module \"%s\" doesn't exist."
+msgstr "No existe la dependencia \"%s\" del módulo \"%s\"."
+
+#: ../src/common/module.cpp:137
+#, c-format
+msgid "Module \"%s\" initialization failed"
+msgstr "Falló la inicialización del módulo «%s»"
+
+#: ../src/common/msgout.cpp:96
+msgid "Message"
+msgstr "Mensaje"
+
+#: ../src/common/paper.cpp:70
+msgid "Letter, 8 1/2 x 11 in"
+msgstr "Carta, 8 1/2 × 11 in"
+
+#: ../src/common/paper.cpp:71
+msgid "Legal, 8 1/2 x 14 in"
+msgstr "Legal, 8 1/2 × 14 in"
+
+#: ../src/common/paper.cpp:72
+msgid "A4 sheet, 210 x 297 mm"
+msgstr "Hoja A4, 210 × 297 mm"
+
+#: ../src/common/paper.cpp:73
+msgid "C sheet, 17 x 22 in"
+msgstr "Hoja C, 17 × 22 in"
+
+#: ../src/common/paper.cpp:74
+msgid "D sheet, 22 x 34 in"
+msgstr "Hoja D, 22 x 34 in"
+
+#: ../src/common/paper.cpp:75
+msgid "E sheet, 34 x 44 in"
+msgstr "Hoja E, 34 x 44 in"
+
+#: ../src/common/paper.cpp:76
+msgid "Letter Small, 8 1/2 x 11 in"
+msgstr "Carta Pequeña, 8 1/2 × 11 in"
+
+#: ../src/common/paper.cpp:77
+msgid "Tabloid, 11 x 17 in"
+msgstr "Tabloide, 11 × 17 in"
+
+#: ../src/common/paper.cpp:78
+msgid "Ledger, 17 x 11 in"
+msgstr "Libro mayor, 17 × 11 in"
+
+#: ../src/common/paper.cpp:79
+msgid "Statement, 5 1/2 x 8 1/2 in"
+msgstr "Declaración, 5 1/2 × 8 1/2 in"
+
+#: ../src/common/paper.cpp:80
+msgid "Executive, 7 1/4 x 10 1/2 in"
+msgstr "Ejecutivo, 7 1/4 x 10 1/2 pulgadas"
+
+#: ../src/common/paper.cpp:81
+msgid "A3 sheet, 297 x 420 mm"
+msgstr "Hoja A3, 297 × 420 mm"
+
+#: ../src/common/paper.cpp:82
+msgid "A4 small sheet, 210 x 297 mm"
+msgstr "Hoja pequeña A4, 210 × 297 mm"
+
+#: ../src/common/paper.cpp:83
+msgid "A5 sheet, 148 x 210 mm"
+msgstr "Hoja A5, 148 × 210 mm"
+
+#: ../src/common/paper.cpp:84
+msgid "B4 sheet, 250 x 354 mm"
+msgstr "Hoja B4, 250 × 354 mm"
+
+#: ../src/common/paper.cpp:85
+msgid "B5 sheet, 182 x 257 millimeter"
+msgstr "Hoja B5, 182 × 257 mm"
+
+#: ../src/common/paper.cpp:86
+msgid "Folio, 8 1/2 x 13 in"
+msgstr "Folio, 8 1/2 × 13 in"
+
+#: ../src/common/paper.cpp:87
+msgid "Quarto, 215 x 275 mm"
+msgstr "Quarto, 215 x 275 mm"
+
+#: ../src/common/paper.cpp:88
+msgid "10 x 14 in"
+msgstr "10 x 14 pulgadas"
+
+#: ../src/common/paper.cpp:89
+msgid "11 x 17 in"
+msgstr "11 x 17 pulgadas"
+
+#: ../src/common/paper.cpp:90
+msgid "Note, 8 1/2 x 11 in"
+msgstr "Nota, 8 1/2 × 11 in"
+
+#: ../src/common/paper.cpp:91
+msgid "#9 Envelope, 3 7/8 x 8 7/8 in"
+msgstr "Sobre n.º 9, 3 7/8 × 8 7/8 in"
+
+#: ../src/common/paper.cpp:92
+msgid "#10 Envelope, 4 1/8 x 9 1/2 in"
+msgstr "Sobre n.º 10, 4 1/8 × 9 1/2 in"
+
+#: ../src/common/paper.cpp:93
+msgid "#11 Envelope, 4 1/2 x 10 3/8 in"
+msgstr "Sobre n.º 11, 4 1/2 × 10 3/8 in"
+
+#: ../src/common/paper.cpp:94
+msgid "#12 Envelope, 4 3/4 x 11 in"
+msgstr "Sobre n.º 12, 4 3/4 × 11 in"
+
+#: ../src/common/paper.cpp:95
+msgid "#14 Envelope, 5 x 11 1/2 in"
+msgstr "Sobre n.º 14, 5 × 11 1/2 in"
+
+#: ../src/common/paper.cpp:96
+msgid "DL Envelope, 110 x 220 mm"
+msgstr "Sobre DL, 110 x 220 mm"
+
+#: ../src/common/paper.cpp:97
+msgid "C5 Envelope, 162 x 229 mm"
+msgstr "Sobre C5, 162 × 229 mm"
+
+#: ../src/common/paper.cpp:98
+msgid "C3 Envelope, 324 x 458 mm"
+msgstr "Sobre C3, 324 × 458 mm"
+
+#: ../src/common/paper.cpp:99
+msgid "C4 Envelope, 229 x 324 mm"
+msgstr "Sobre C4, 229 × 324 mm"
+
+#: ../src/common/paper.cpp:100
+msgid "C6 Envelope, 114 x 162 mm"
+msgstr "Sobre C6, 114 × 162 mm"
+
+#: ../src/common/paper.cpp:101
+msgid "C65 Envelope, 114 x 229 mm"
+msgstr "Sobre C65, 114 × 229 mm"
+
+#: ../src/common/paper.cpp:102
+msgid "B4 Envelope, 250 x 353 mm"
+msgstr "Sobre B4, 250 × 353 mm"
+
+#: ../src/common/paper.cpp:103
+msgid "B5 Envelope, 176 x 250 mm"
+msgstr "Sobre B5, 176 × 250 mm"
+
+#: ../src/common/paper.cpp:104
+msgid "B6 Envelope, 176 x 125 mm"
+msgstr "Sobre B6, 176 × 125 mm"
+
+#: ../src/common/paper.cpp:105
+msgid "Italy Envelope, 110 x 230 mm"
+msgstr "Sobre Italy, 110 × 230 mm"
+
+#: ../src/common/paper.cpp:106
+msgid "Monarch Envelope, 3 7/8 x 7 1/2 in"
+msgstr "Sobre Monarch, 3 7/8 × 7 1/2 in"
+
+#: ../src/common/paper.cpp:107
+msgid "6 3/4 Envelope, 3 5/8 x 6 1/2 in"
+msgstr "Sobre 6 3/4, 3 5/8 x 6 1/2 pulgadas"
+
+#: ../src/common/paper.cpp:108
+msgid "US Std Fanfold, 14 7/8 x 11 in"
+msgstr "US Std Fanfold, 14 7/8 x 11 pulgadas"
+
+#: ../src/common/paper.cpp:109
+msgid "German Std Fanfold, 8 1/2 x 12 in"
+msgstr "German Std Fanfold, 8 1/2 × 12 in"
+
+#: ../src/common/paper.cpp:110
+msgid "German Legal Fanfold, 8 1/2 x 13 in"
+msgstr "German Legal Fanfold, 8 1/2 × 13 in"
+
+#: ../src/common/paper.cpp:112
+msgid "B4 (ISO) 250 x 353 mm"
+msgstr "B4 (ISO) 250 × 353 mm"
+
+#: ../src/common/paper.cpp:113
+msgid "Japanese Postcard 100 x 148 mm"
+msgstr "Tarjeta japonesa 100 × 148 mm"
+
+#: ../src/common/paper.cpp:114
+msgid "9 x 11 in"
+msgstr "9 x 11 pulgadas"
+
+#: ../src/common/paper.cpp:115
+msgid "10 x 11 in"
+msgstr "10 x 11 pulgadas"
+
+#: ../src/common/paper.cpp:116
+msgid "15 x 11 in"
+msgstr "15 x 11 pulgadas"
+
+#: ../src/common/paper.cpp:117
+msgid "Envelope Invite 220 x 220 mm"
+msgstr "Envelope Invite 220 x 220 mm"
+
+#: ../src/common/paper.cpp:118
+msgid "Letter Extra 9 1/2 x 12 in"
+msgstr "Carta Extra 9 1/2 × 12 in"
+
+#: ../src/common/paper.cpp:119
+msgid "Legal Extra 9 1/2 x 15 in"
+msgstr "Legal Extra 9 1/2 × 15 in"
+
+#: ../src/common/paper.cpp:120
+msgid "Tabloid Extra 11.69 x 18 in"
+msgstr "Tabloide Extra 11,69 × 18 in"
+
+#: ../src/common/paper.cpp:121
+msgid "A4 Extra 9.27 x 12.69 in"
+msgstr "A4 Extra 9.27 × 12.69 in"
+
+#: ../src/common/paper.cpp:122
+msgid "Letter Transverse 8 1/2 x 11 in"
+msgstr "Carta Transversal 8 1/2 × 11 in"
+
+#: ../src/common/paper.cpp:123
+msgid "A4 Transverse 210 x 297 mm"
+msgstr "A4 Transversal 210 × 297 mm"
+
+#: ../src/common/paper.cpp:124
+msgid "Letter Extra Transverse 9.275 x 12 in"
+msgstr "Carta Extra Transversal 9,275 × 12 in"
+
+#: ../src/common/paper.cpp:125
+msgid "SuperA/SuperA/A4 227 x 356 mm"
+msgstr "SuperA/SuperA/A4 227 × 356 mm"
+
+#: ../src/common/paper.cpp:126
+msgid "SuperB/SuperB/A3 305 x 487 mm"
+msgstr "SuperB/SuperB/A3 305 × 487 mm"
+
+#: ../src/common/paper.cpp:127
+msgid "Letter Plus 8 1/2 x 12.69 in"
+msgstr "Carta Plus 8 1/2 × 12,69 in"
+
+#: ../src/common/paper.cpp:128
+msgid "A4 Plus 210 x 330 mm"
+msgstr "A4 Plus 210 × 330 mm"
+
+#: ../src/common/paper.cpp:129
+msgid "A5 Transverse 148 x 210 mm"
+msgstr "A5 Transversal 148 × 210 mm"
+
+#: ../src/common/paper.cpp:130
+msgid "B5 (JIS) Transverse 182 x 257 mm"
+msgstr "B5 (JIS) Transversal 182 × 257 mm"
+
+#: ../src/common/paper.cpp:131
+msgid "A3 Extra 322 x 445 mm"
+msgstr "A3 Extra 322 × 445 mm"
+
+#: ../src/common/paper.cpp:132
+msgid "A5 Extra 174 x 235 mm"
+msgstr "A5 Extra 174 × 235 mm"
+
+#: ../src/common/paper.cpp:133
+msgid "B5 (ISO) Extra 201 x 276 mm"
+msgstr "B5 (ISO) Extra 201 × 276 mm"
+
+#: ../src/common/paper.cpp:134
+msgid "A2 420 x 594 mm"
+msgstr "A2 420 × 594 mm"
+
+#: ../src/common/paper.cpp:135
+msgid "A3 Transverse 297 x 420 mm"
+msgstr "A3 Transversal 297 × 420 mm"
+
+#: ../src/common/paper.cpp:136
+msgid "A3 Extra Transverse 322 x 445 mm"
+msgstr "A3 Extra Transversal 322 × 445 mm"
+
+#: ../src/common/paper.cpp:138
+msgid "Japanese Double Postcard 200 x 148 mm"
+msgstr "Tarjeta Japonesa Doble 200 x 148 mm"
+
+#: ../src/common/paper.cpp:139
+msgid "A6 105 x 148 mm"
+msgstr "A6 105 × 148 mm"
+
+#: ../src/common/paper.cpp:140
+msgid "Japanese Envelope Kaku #2"
+msgstr "Sobre japonés Kaku n.º 2"
+
+#: ../src/common/paper.cpp:141
+msgid "Japanese Envelope Kaku #3"
+msgstr "Sobre japonés Kaku n.º 3"
+
+#: ../src/common/paper.cpp:142
+msgid "Japanese Envelope Chou #3"
+msgstr "Sobre japonés Chou n.º 3"
+
+#: ../src/common/paper.cpp:143
+msgid "Japanese Envelope Chou #4"
+msgstr "Sobre japonés Chou n.º 4"
+
+#: ../src/common/paper.cpp:144
+msgid "Letter Rotated 11 x 8 1/2 in"
+msgstr "Carta Girada 11 × 8 1/2 in"
+
+#: ../src/common/paper.cpp:145
+msgid "A3 Rotated 420 x 297 mm"
+msgstr "A3 Girada 420 × 297 mm"
+
+#: ../src/common/paper.cpp:146
+msgid "A4 Rotated 297 x 210 mm"
+msgstr "A4 Girada 297 × 210 mm"
+
+#: ../src/common/paper.cpp:147
+msgid "A5 Rotated 210 x 148 mm"
+msgstr "A5 Girado 210 × 148 mm"
+
+#: ../src/common/paper.cpp:148
+msgid "B4 (JIS) Rotated 364 x 257 mm"
+msgstr "B4 (JIS) Girado 364 × 257 mm"
+
+#: ../src/common/paper.cpp:149
+msgid "B5 (JIS) Rotated 257 x 182 mm"
+msgstr "B5 (JIS) Girado 257 × 182 mm"
+
+#: ../src/common/paper.cpp:150
+msgid "Japanese Postcard Rotated 148 x 100 mm"
+msgstr "Tarjeta japonesa Girada 148 × 100 mm"
+
+#: ../src/common/paper.cpp:151
+msgid "Double Japanese Postcard Rotated 148 x 200 mm"
+msgstr "Tarjeta Japonesa Doble Girada 148 x 200 mm"
+
+#: ../src/common/paper.cpp:152
+msgid "A6 Rotated 148 x 105 mm"
+msgstr "A6 Girada 148 × 105 mm"
+
+#: ../src/common/paper.cpp:153
+msgid "Japanese Envelope Kaku #2 Rotated"
+msgstr "Sobre japonés Kaku n.º 2 Girado"
+
+#: ../src/common/paper.cpp:154
+msgid "Japanese Envelope Kaku #3 Rotated"
+msgstr "Sobre japonés Kaku n.º 3 Girado"
+
+#: ../src/common/paper.cpp:155
+msgid "Japanese Envelope Chou #3 Rotated"
+msgstr "Sobre japonés Chou n.º 3 Girado"
+
+#: ../src/common/paper.cpp:156
+msgid "Japanese Envelope Chou #4 Rotated"
+msgstr "Sobre japonés Chou n.º 4 Girado"
+
+#: ../src/common/paper.cpp:157
+msgid "B6 (JIS) 128 x 182 mm"
+msgstr "B6 (JIS) 128 × 182 mm"
+
+#: ../src/common/paper.cpp:158
+msgid "B6 (JIS) Rotated 182 x 128 mm"
+msgstr "B6 (JIS) Girado 182 × 128 mm"
+
+#: ../src/common/paper.cpp:159
+msgid "12 x 11 in"
+msgstr "12 x 11 pulgadas"
+
+#: ../src/common/paper.cpp:160
+msgid "Japanese Envelope You #4"
+msgstr "Sobre japonés You n.º 4"
+
+#: ../src/common/paper.cpp:161
+msgid "Japanese Envelope You #4 Rotated"
+msgstr "Sobre japonés You n.º 4 Girado"
+
+#: ../src/common/paper.cpp:162
+msgid "PRC 16K 146 x 215 mm"
+msgstr "PRC 16K 146 × 215 mm"
+
+#: ../src/common/paper.cpp:163
+msgid "PRC 32K 97 x 151 mm"
+msgstr "PRC 32K 97 × 151 mm"
+
+#: ../src/common/paper.cpp:164
+msgid "PRC 32K(Big) 97 x 151 mm"
+msgstr "PRC 32K(Grande) 97 × 151 mm"
+
+#: ../src/common/paper.cpp:165
+msgid "PRC Envelope #1 102 x 165 mm"
+msgstr "Sobre PRC n.º 1 102 × 165 mm"
+
+#: ../src/common/paper.cpp:166
+msgid "PRC Envelope #2 102 x 176 mm"
+msgstr "Sobre PRC n.º 2 102 × 176 mm"
+
+#: ../src/common/paper.cpp:167
+msgid "PRC Envelope #3 125 x 176 mm"
+msgstr "Sobre PRC n.º 3 125 × 176 mm"
+
+#: ../src/common/paper.cpp:168
+msgid "PRC Envelope #4 110 x 208 mm"
+msgstr "Sobre PRC n.º 4 110 × 208 mm"
+
+#: ../src/common/paper.cpp:169
+msgid "PRC Envelope #5 110 x 220 mm"
+msgstr "Sobre PRC n.º 5 110 × 220 mm"
+
+#: ../src/common/paper.cpp:170
+msgid "PRC Envelope #6 120 x 230 mm"
+msgstr "Sobre PRC n.º 6 120 × 230 mm"
+
+#: ../src/common/paper.cpp:171
+msgid "PRC Envelope #7 160 x 230 mm"
+msgstr "Sobre PRC n.º 7 160 × 230 mm"
+
+#: ../src/common/paper.cpp:172
+msgid "PRC Envelope #8 120 x 309 mm"
+msgstr "Sobre PRC n.º 8 120 × 309 mm"
+
+#: ../src/common/paper.cpp:173
+msgid "PRC Envelope #9 229 x 324 mm"
+msgstr "Sobre PRC n.º 9 229 × 324 mm"
+
+#: ../src/common/paper.cpp:174
+msgid "PRC Envelope #10 324 x 458 mm"
+msgstr "Sobre PRC n.º 10 324 × 458 mm"
+
+#: ../src/common/paper.cpp:175
+msgid "PRC 16K Rotated"
+msgstr "PRC 16K Girado"
+
+#: ../src/common/paper.cpp:176
+msgid "PRC 32K Rotated"
+msgstr "PRC 32K Girado"
+
+#: ../src/common/paper.cpp:177
+msgid "PRC 32K(Big) Rotated"
+msgstr "PRC 32K(Grande) Girado"
+
+#: ../src/common/paper.cpp:178
+msgid "PRC Envelope #1 Rotated 165 x 102 mm"
+msgstr "Sobre PRC n.º1 Girado 165 × 102 mm"
+
+#: ../src/common/paper.cpp:179
+msgid "PRC Envelope #2 Rotated 176 x 102 mm"
+msgstr "Sobre PRC n.º 2 Girado 176 × 102 mm"
+
+#: ../src/common/paper.cpp:180
+msgid "PRC Envelope #3 Rotated 176 x 125 mm"
+msgstr "Sobre PRC n.º 3 Girado 176 × 125 mm"
+
+#: ../src/common/paper.cpp:181
+msgid "PRC Envelope #4 Rotated 208 x 110 mm"
+msgstr "Sobre PRC n.º 4 Girado 208 × 110 mm"
+
+#: ../src/common/paper.cpp:182
+msgid "PRC Envelope #5 Rotated 220 x 110 mm"
+msgstr "Sobre PRC n.º 5 Girado 220 × 110 mm"
+
+#: ../src/common/paper.cpp:183
+msgid "PRC Envelope #6 Rotated 230 x 120 mm"
+msgstr "Sobre PRC n.º 6 Girado 230 × 120 mm"
+
+#: ../src/common/paper.cpp:184
+msgid "PRC Envelope #7 Rotated 230 x 160 mm"
+msgstr "Sobre PRC n.º 7 Girado 230 × 160 mm"
+
+#: ../src/common/paper.cpp:185
+msgid "PRC Envelope #8 Rotated 309 x 120 mm"
+msgstr "Sobre PRC n.º 8 Girado 309 × 120 mm"
+
+#: ../src/common/paper.cpp:186
+msgid "PRC Envelope #9 Rotated 324 x 229 mm"
+msgstr "Sobre PRC n.º 9 Girado 324 × 229 mm"
+
+#: ../src/common/paper.cpp:187
+msgid "PRC Envelope #10 Rotated 458 x 324 mm"
+msgstr "Sobre PRC n.º 10 Girado 458 × 324 mm"
+
+#: ../src/common/paper.cpp:192
+msgid "A0 sheet, 841 x 1189 mm"
+msgstr "Hoja A0, 841 × 1189 mm"
+
+#: ../src/common/paper.cpp:193
+msgid "A1 sheet, 594 x 841 mm"
+msgstr "Hoja A1, 594 × 841 mm"
+
+#: ../src/common/preferencescmn.cpp:37
+msgid "General"
+msgstr "General"
+
+#: ../src/common/preferencescmn.cpp:40
+msgid "Advanced"
+msgstr "Avanzado"
+
+#: ../src/common/prntbase.cpp:245
+msgid "Generic PostScript"
+msgstr "PostScript genérico"
+
+#: ../src/common/prntbase.cpp:259
+msgid "Ready"
+msgstr "Listo"
+
+#: ../src/common/prntbase.cpp:331
+msgid "Printing Error"
+msgstr "Error de impresión"
+
+#: ../src/common/prntbase.cpp:413 ../src/common/prntbase.cpp:1597
+#: ../src/generic/prntdlgg.cpp:135 ../src/generic/prntdlgg.cpp:149
+#: ../src/gtk/print.cpp:628 ../src/gtk/print.cpp:646
+msgid "Print"
+msgstr "Imprimir"
+
+#: ../src/common/prntbase.cpp:471 ../src/generic/prntdlgg.cpp:809
+msgid "Page setup"
+msgstr "Configurar página"
+
+#: ../src/common/prntbase.cpp:525
+msgid "Please wait while printing..."
+msgstr "Imprimiendo; espere un momento…"
+
+#: ../src/common/prntbase.cpp:529
+msgid "Document:"
+msgstr "Documento:"
+
+#: ../src/common/prntbase.cpp:532
+msgid "Progress:"
+msgstr "Progreso:"
+
+#: ../src/common/prntbase.cpp:533
+msgid "Preparing"
+msgstr "Preparando"
+
+#: ../src/common/prntbase.cpp:552
+#, c-format
+msgid "Printing page %d"
+msgstr "Imprimiendo página %d"
+
+#: ../src/common/prntbase.cpp:557
+#, c-format
+msgid "Printing page %d of %d"
+msgstr "Imprimiendo página %d de %d"
+
+#: ../src/common/prntbase.cpp:560
+#, c-format
+msgid " (copy %d of %d)"
+msgstr " (copia %d de %d)"
+
+#: ../src/common/prntbase.cpp:1604
+msgid "First page"
+msgstr "Primera página"
+
+#: ../src/common/prntbase.cpp:1609 ../src/html/helpwnd.cpp:659
+msgid "Previous page"
+msgstr "Página anterior"
+
+#: ../src/common/prntbase.cpp:1623 ../src/html/helpwnd.cpp:660
+msgid "Next page"
+msgstr "Página siguiente"
+
+#: ../src/common/prntbase.cpp:1628
+msgid "Last page"
+msgstr "Última página"
+
+#: ../src/common/prntbase.cpp:1636 ../src/common/stockitem.cpp:215
+msgid "Zoom Out"
+msgstr "Alejar"
+
+#: ../src/common/prntbase.cpp:1650 ../src/common/stockitem.cpp:214
+msgid "Zoom In"
+msgstr "Acercar"
+
+#: ../src/common/prntbase.cpp:1656 ../src/common/stockitem.cpp:153
+#: ../src/generic/logg.cpp:553 ../src/univ/themes/win32.cpp:3752
+msgid "&Close"
+msgstr "&Cerrar"
+
+#: ../src/common/prntbase.cpp:2085
+msgid "Could not start document preview."
+msgstr "No se pudo iniciar la previsualización del documento."
+
+#: ../src/common/prntbase.cpp:2085 ../src/common/prntbase.cpp:2129
+#: ../src/common/prntbase.cpp:2137
+msgid "Print Preview Failure"
+msgstr "Error en previsualización de impresión"
+
+#: ../src/common/prntbase.cpp:2129 ../src/common/prntbase.cpp:2137
+msgid "Sorry, not enough memory to create a preview."
+msgstr "No se pudo abrir este archivo."
+
+#: ../src/common/prntbase.cpp:2144
+#, c-format
+msgid "Page %d of %d"
+msgstr "Página %d de %d"
+
+#: ../src/common/prntbase.cpp:2146
+#, c-format
+msgid "Page %d"
+msgstr "Página %d"
+
+#: ../src/common/regex.cpp:382 ../src/html/chm.cpp:348
+msgid "unknown error"
+msgstr "error desconocido"
+
+#: ../src/common/regex.cpp:995
+#, c-format
+msgid "Invalid regular expression '%s': %s"
+msgstr "Expresión regular no válida «%s»: %s"
+
+#: ../src/common/regex.cpp:1059
+#, c-format
+msgid "Failed to find match for regular expression: %s"
+msgstr "Failed to find match for regular expression: %s"
+
+#: ../src/common/rendcmn.cpp:188
+#, c-format
+msgid "Renderer \"%s\" has incompatible version %d.%d and couldn't be loaded."
+msgstr ""
+"El renderizador \"%s\" tiene una versión %d.%d incompatible y no se ha "
+"podido abrir."
+
+#: ../src/common/secretstore.cpp:162
+msgid "Not available for this platform"
+msgstr "No disponible para esta plataforma"
+
+#: ../src/common/secretstore.cpp:183
+#, c-format
+msgid "Saving password for \"%s\" failed: %s."
+msgstr "Fallo al guardar la contaseña para \"%s\": %s."
+
+#: ../src/common/secretstore.cpp:205
+#, c-format
+msgid "Reading password for \"%s\" failed: %s."
+msgstr "Fallo al leer la contraseña para \"%s\": %s."
+
+#: ../src/common/secretstore.cpp:228
+#, c-format
+msgid "Deleting password for \"%s\" failed: %s."
+msgstr "Fallo al borrar la contraseña para \"%s\": %s."
+
+#: ../src/common/selectdispatcher.cpp:254
+msgid "Failed to monitor I/O channels"
+msgstr "Fallo al monitorizar los canales de E/S"
+
+#: ../src/common/sizer.cpp:3054 ../src/common/stockitem.cpp:195
+msgid "Save"
+msgstr "Guardar"
+
+#: ../src/common/sizer.cpp:3056
+msgid "Don't Save"
+msgstr "No guardar"
+
+#: ../src/common/socket.cpp:870
+msgid "Cannot initialize sockets"
+msgstr "No se pueden inicializar los sockets"
+
+#: ../src/common/stockitem.cpp:127
+msgctxt "standard Windows menu"
+msgid "&Help"
+msgstr "Ay&uda"
+
+#: ../src/common/stockitem.cpp:144
+msgid "&About"
+msgstr "&Acerca de"
+
+#: ../src/common/stockitem.cpp:144
+msgid "About"
+msgstr "Acerca de"
+
+#: ../src/common/stockitem.cpp:145
+msgid "Add"
+msgstr "Añadir"
+
+#: ../src/common/stockitem.cpp:146
+msgid "&Apply"
+msgstr "&Aplicar"
+
+#: ../src/common/stockitem.cpp:146
+msgid "Apply"
+msgstr "Aplicar"
+
+#: ../src/common/stockitem.cpp:147
+msgid "&Back"
+msgstr "&Atrás"
+
+#: ../src/common/stockitem.cpp:147
+msgid "Back"
+msgstr "Atrás"
+
+#: ../src/common/stockitem.cpp:148
+msgid "&Bold"
+msgstr "&Negrita"
+
+#: ../src/common/stockitem.cpp:148 ../src/generic/fontdlgg.cpp:326
+#: ../src/richtext/richtextfontpage.cpp:354
+msgid "Bold"
+msgstr "Negrita"
+
+#: ../src/common/stockitem.cpp:149
+msgid "&Bottom"
+msgstr "&Inferior"
+
+#: ../src/common/stockitem.cpp:149 ../src/richtext/richtextsizepage.cpp:287
+msgid "Bottom"
+msgstr "Inferior"
+
+#: ../src/common/stockitem.cpp:150 ../src/generic/fontdlgg.cpp:462
+#: ../src/generic/fontdlgg.cpp:481 ../src/generic/wizard.cpp:415
+msgid "&Cancel"
+msgstr "&Cancelar"
+
+#: ../src/common/stockitem.cpp:151
+msgid "&CD-ROM"
+msgstr "&CD-ROM"
+
+#: ../src/common/stockitem.cpp:151
+msgid "CD-ROM"
+msgstr "CD-ROM"
+
+#: ../src/common/stockitem.cpp:152
+msgid "&Clear"
+msgstr "&Limpiar"
+
+#: ../src/common/stockitem.cpp:152
+msgid "Clear"
+msgstr "Limpiar"
+
+#: ../src/common/stockitem.cpp:153 ../src/generic/dbgrptg.cpp:93
+#: ../src/generic/progdlgg.cpp:778 ../src/html/helpdlg.cpp:86
+#: ../src/msw/progdlg.cpp:209 ../src/msw/progdlg.cpp:890
+#: ../src/richtext/richtextstyledlg.cpp:272
+#: ../src/richtext/richtextsymboldlg.cpp:448
+msgid "Close"
+msgstr "Cerrar"
+
+#: ../src/common/stockitem.cpp:154
+msgid "&Convert"
+msgstr "&Convertir"
+
+#: ../src/common/stockitem.cpp:154
+msgid "Convert"
+msgstr "Convertir"
+
+#: ../src/common/stockitem.cpp:155 ../src/msw/textctrl.cpp:2884
+#: ../src/osx/textctrl_osx.cpp:653 ../src/richtext/richtextctrl.cpp:331
+msgid "&Copy"
+msgstr "&Copiar"
+
+#: ../src/common/stockitem.cpp:155 ../src/stc/stc_i18n.cpp:18
+msgid "Copy"
+msgstr "Copiar"
+
+#: ../src/common/stockitem.cpp:156 ../src/msw/textctrl.cpp:2883
+#: ../src/osx/textctrl_osx.cpp:652 ../src/richtext/richtextctrl.cpp:330
+msgid "Cu&t"
+msgstr "Cor&tar"
+
+#: ../src/common/stockitem.cpp:156 ../src/stc/stc_i18n.cpp:17
+msgid "Cut"
+msgstr "Cortar"
+
+#: ../src/common/stockitem.cpp:157 ../src/msw/textctrl.cpp:2886
+#: ../src/osx/textctrl_osx.cpp:655 ../src/richtext/richtextctrl.cpp:333
+#: ../src/richtext/richtexttabspage.cpp:137
+msgid "&Delete"
+msgstr "&Eliminar"
+
+#: ../src/common/stockitem.cpp:157 ../src/richtext/richtextbuffer.cpp:8266
+#: ../src/stc/stc_i18n.cpp:20
+msgid "Delete"
+msgstr "Eliminar"
+
+#: ../src/common/stockitem.cpp:158
+msgid "&Down"
+msgstr "A&bajo"
+
+#: ../src/common/stockitem.cpp:158 ../src/generic/fdrepdlg.cpp:148
+msgid "Down"
+msgstr "Abajo"
+
+#: ../src/common/stockitem.cpp:159
+msgid "&Edit"
+msgstr "&Editar"
+
+#: ../src/common/stockitem.cpp:159
+msgid "Edit"
+msgstr "Editar"
+
+#: ../src/common/stockitem.cpp:160
+msgid "&Execute"
+msgstr "&Ejecutar"
+
+#: ../src/common/stockitem.cpp:160
+msgid "Execute"
+msgstr "Ejecutar"
+
+#: ../src/common/stockitem.cpp:161
+msgid "&Quit"
+msgstr "&Salir"
+
+#: ../src/common/stockitem.cpp:161
+msgid "Quit"
+msgstr "Salir"
+
+#: ../src/common/stockitem.cpp:162
+msgid "&File"
+msgstr "&Archivo"
+
+#: ../src/common/stockitem.cpp:162
+msgid "File"
+msgstr "Archivo"
+
+#: ../src/common/stockitem.cpp:163
+msgid "&Find..."
+msgstr "&Buscar..."
+
+#: ../src/common/stockitem.cpp:163
+msgid "Find..."
+msgstr "Buscar..."
+
+#: ../src/common/stockitem.cpp:164
+msgid "&First"
+msgstr "&Primero"
+
+#: ../src/common/stockitem.cpp:164
+msgid "First"
+msgstr "Primero"
+
+#: ../src/common/stockitem.cpp:165
+msgid "&Floppy"
+msgstr "&Disco flexible"
+
+#: ../src/common/stockitem.cpp:165
+msgid "Floppy"
+msgstr "Disco flexible"
+
+#: ../src/common/stockitem.cpp:166
+msgid "&Forward"
+msgstr "Adelante"
+
+#: ../src/common/stockitem.cpp:166
+msgid "Forward"
+msgstr "Adelante"
+
+#: ../src/common/stockitem.cpp:167
+msgid "&Harddisk"
+msgstr "&Disco duro"
+
+#: ../src/common/stockitem.cpp:167
+msgid "Harddisk"
+msgstr "Disco duro"
+
+#: ../src/common/stockitem.cpp:168 ../src/generic/wizard.cpp:418
+#: ../src/osx/cocoa/menu.mm:225 ../src/richtext/richtextstyledlg.cpp:298
+#: ../src/richtext/richtextsymboldlg.cpp:451
+msgid "&Help"
+msgstr "Ay&uda"
+
+#: ../src/common/stockitem.cpp:169
+msgid "&Home"
+msgstr "&Inicio"
+
+#: ../src/common/stockitem.cpp:169
+msgid "Home"
+msgstr "Inicio"
+
+#: ../src/common/stockitem.cpp:170
+msgid "Indent"
+msgstr "Sangría"
+
+#: ../src/common/stockitem.cpp:171
+msgid "&Index"
+msgstr "Índ&ice"
+
+#: ../src/common/stockitem.cpp:171 ../src/html/helpwnd.cpp:510
+msgid "Index"
+msgstr "Índice"
+
+#: ../src/common/stockitem.cpp:172
+msgid "&Info"
+msgstr "&Información"
+
+#: ../src/common/stockitem.cpp:172
+msgid "Info"
+msgstr "Información"
+
+#: ../src/common/stockitem.cpp:173
+msgid "&Italic"
+msgstr "Curs&iva"
+
+#: ../src/common/stockitem.cpp:173 ../src/generic/fontdlgg.cpp:322
+#: ../src/richtext/richtextfontpage.cpp:350
+msgid "Italic"
+msgstr "Cursiva"
+
+#: ../src/common/stockitem.cpp:174
+msgid "&Jump to"
+msgstr "&Ir a"
+
+#: ../src/common/stockitem.cpp:174
+msgid "Jump to"
+msgstr "Ir a"
+
+#: ../src/common/stockitem.cpp:175
+msgid "Centered"
+msgstr "Centrado"
+
+#: ../src/common/stockitem.cpp:176
+msgid "Justified"
+msgstr "Justificado"
+
+#: ../src/common/stockitem.cpp:177
+msgid "Align Left"
+msgstr "Alinear a la izquierda"
+
+#: ../src/common/stockitem.cpp:178
+msgid "Align Right"
+msgstr "Alinear a la derecha"
+
+#: ../src/common/stockitem.cpp:179
+msgid "&Last"
+msgstr "&Último"
+
+#: ../src/common/stockitem.cpp:179
+msgid "Last"
+msgstr "Último"
+
+#: ../src/common/stockitem.cpp:180
+msgid "&Network"
+msgstr "&Red"
+
+#: ../src/common/stockitem.cpp:180
+msgid "Network"
+msgstr "Red"
+
+#: ../src/common/stockitem.cpp:181 ../src/richtext/richtexttabspage.cpp:131
+msgid "&New"
+msgstr "&Nuevo"
+
+#: ../src/common/stockitem.cpp:181
+msgid "New"
+msgstr "Nuevo"
+
+#: ../src/common/stockitem.cpp:182 ../src/msw/msgdlg.cpp:417
+msgid "&No"
+msgstr "&No"
+
+#: ../src/common/stockitem.cpp:183 ../src/generic/fontdlgg.cpp:467
+#: ../src/generic/fontdlgg.cpp:474
+msgid "&OK"
+msgstr "&Aceptar"
+
+#: ../src/common/stockitem.cpp:184 ../src/generic/dbgrptg.cpp:341
+msgid "&Open..."
+msgstr "A&brir…"
+
+#: ../src/common/stockitem.cpp:184
+msgid "Open..."
+msgstr "Abrir…"
+
+#: ../src/common/stockitem.cpp:185 ../src/msw/textctrl.cpp:2885
+#: ../src/osx/textctrl_osx.cpp:654 ../src/richtext/richtextctrl.cpp:332
+msgid "&Paste"
+msgstr "&Pegar"
+
+#: ../src/common/stockitem.cpp:185 ../src/richtext/richtextctrl.cpp:3484
+#: ../src/stc/stc_i18n.cpp:19
+msgid "Paste"
+msgstr "Pegar"
+
+#: ../src/common/stockitem.cpp:186
+msgid "&Preferences"
+msgstr "&Preferencias"
+
+#: ../src/common/stockitem.cpp:186 ../src/osx/cocoa/preferences.mm:304
+msgid "Preferences"
+msgstr "Preferencias"
+
+#: ../src/common/stockitem.cpp:187
+msgid "Print previe&w..."
+msgstr "&Vista previa de impresión..."
+
+#: ../src/common/stockitem.cpp:187
+msgid "Print preview..."
+msgstr "Vista previa de impresión..."
+
+#: ../src/common/stockitem.cpp:188
+msgid "&Print..."
+msgstr "&Imprimir…"
+
+#: ../src/common/stockitem.cpp:188
+msgid "Print..."
+msgstr "Imprimir..."
+
+#: ../src/common/stockitem.cpp:189 ../src/richtext/richtextctrl.cpp:337
+#: ../src/richtext/richtextctrl.cpp:5479
+msgid "&Properties"
+msgstr "&Propiedades"
+
+#: ../src/common/stockitem.cpp:189
+msgid "Properties"
+msgstr "Propiedades"
+
+#: ../src/common/stockitem.cpp:190 ../src/stc/stc_i18n.cpp:16
+msgid "Redo"
+msgstr "Rehacer"
+
+#: ../src/common/stockitem.cpp:191
+msgid "Refresh"
+msgstr "Refrescar"
+
+#: ../src/common/stockitem.cpp:192
+msgid "Remove"
+msgstr "Eliminar"
+
+#: ../src/common/stockitem.cpp:193
+msgid "Rep&lace..."
+msgstr "Su&stituir..."
+
+#: ../src/common/stockitem.cpp:193
+msgid "Replace..."
+msgstr "Sustituir..."
+
+#: ../src/common/stockitem.cpp:194
+msgid "Revert to Saved"
+msgstr "Recuperar versión guardada"
+
+#: ../src/common/stockitem.cpp:196 ../src/generic/logg.cpp:549
+msgid "Save &As..."
+msgstr "G&uardar como…"
+
+#: ../src/common/stockitem.cpp:196
+msgid "Save As..."
+msgstr "Guardar como…"
+
+#: ../src/common/stockitem.cpp:197 ../src/msw/textctrl.cpp:2888
+#: ../src/osx/textctrl_osx.cpp:657 ../src/richtext/richtextctrl.cpp:335
+msgid "Select &All"
+msgstr "Seleccionar &todo"
+
+#: ../src/common/stockitem.cpp:197 ../src/stc/stc_i18n.cpp:21
+msgid "Select All"
+msgstr "Seleccionar todo"
+
+#: ../src/common/stockitem.cpp:198
+msgid "&Color"
+msgstr "&Color"
+
+#: ../src/common/stockitem.cpp:198
+msgid "Color"
+msgstr "Color"
+
+#: ../src/common/stockitem.cpp:199
+msgid "&Font"
+msgstr "&Tipo de letra"
+
+#: ../src/common/stockitem.cpp:199 ../src/richtext/richtextformatdlg.cpp:336
+msgid "Font"
+msgstr "Tipo de letra"
+
+#: ../src/common/stockitem.cpp:200
+msgid "&Ascending"
+msgstr "&Ascendente"
+
+#: ../src/common/stockitem.cpp:200
+msgid "Ascending"
+msgstr "Ascendente"
+
+#: ../src/common/stockitem.cpp:201
+msgid "&Descending"
+msgstr "&Descendente"
+
+#: ../src/common/stockitem.cpp:201
+msgid "Descending"
+msgstr "Descendente"
+
+#: ../src/common/stockitem.cpp:202
+msgid "&Spell Check"
+msgstr "&Comprobar ortografía"
+
+#: ../src/common/stockitem.cpp:202
+msgid "Spell Check"
+msgstr "Comprobar ortografía"
+
+#: ../src/common/stockitem.cpp:203
+msgid "&Stop"
+msgstr "&Detener"
+
+#: ../src/common/stockitem.cpp:203
+msgid "Stop"
+msgstr "Detener"
+
+#: ../src/common/stockitem.cpp:204 ../src/richtext/richtextfontpage.cpp:274
+msgid "&Strikethrough"
+msgstr "&Tachado"
+
+#: ../src/common/stockitem.cpp:204
+msgid "Strikethrough"
+msgstr "Tachado"
+
+#: ../src/common/stockitem.cpp:205
+msgid "&Top"
+msgstr "&Arriba"
+
+#: ../src/common/stockitem.cpp:205 ../src/richtext/richtextsizepage.cpp:285
+#: ../src/richtext/richtextsizepage.cpp:289
+msgid "Top"
+msgstr "Arriba"
+
+#: ../src/common/stockitem.cpp:206
+msgid "Undelete"
+msgstr "Restaurar"
+
+#: ../src/common/stockitem.cpp:207 ../src/generic/fontdlgg.cpp:437
+msgid "&Underline"
+msgstr "Subrayar"
+
+#: ../src/common/stockitem.cpp:207
+msgid "Underline"
+msgstr "Subrayar"
+
+#: ../src/common/stockitem.cpp:208 ../src/stc/stc_i18n.cpp:15
+msgid "Undo"
+msgstr "Deshacer"
+
+#: ../src/common/stockitem.cpp:209
+msgid "&Unindent"
+msgstr "&Quitar sangría"
+
+#: ../src/common/stockitem.cpp:209
+msgid "Unindent"
+msgstr "Quitar sangría"
+
+#: ../src/common/stockitem.cpp:210
+msgid "&Up"
+msgstr "&Arriba"
+
+#: ../src/common/stockitem.cpp:210 ../src/generic/fdrepdlg.cpp:148
+msgid "Up"
+msgstr "Arriba"
+
+#: ../src/common/stockitem.cpp:211 ../src/msw/msgdlg.cpp:417
+msgid "&Yes"
+msgstr "&Sí"
+
+#: ../src/common/stockitem.cpp:212
+msgid "&Actual Size"
+msgstr "Tamaño re&al"
+
+#: ../src/common/stockitem.cpp:212
+msgid "Actual Size"
+msgstr "Tamaño real"
+
+#: ../src/common/stockitem.cpp:213
+msgid "Zoom to &Fit"
+msgstr "&Ajustar al tamaño"
+
+#: ../src/common/stockitem.cpp:213
+msgid "Zoom to Fit"
+msgstr "Ajustar al tamaño"
+
+#: ../src/common/stockitem.cpp:214
+msgid "Zoom &In"
+msgstr "A&cercar"
+
+#: ../src/common/stockitem.cpp:215
+msgid "Zoom &Out"
+msgstr "A&lejar"
+
+#: ../src/common/stockitem.cpp:262
+msgid "Show about dialog"
+msgstr "Muestra el diálogo Acerca de"
+
+#: ../src/common/stockitem.cpp:263
+msgid "Copy selection"
+msgstr "Copiar selección"
+
+#: ../src/common/stockitem.cpp:264
+msgid "Cut selection"
+msgstr "Cortar selección"
+
+#: ../src/common/stockitem.cpp:265
+msgid "Delete selection"
+msgstr "Borrar selección"
+
+#: ../src/common/stockitem.cpp:266
+msgid "Find in document"
+msgstr "Buscar en el documento"
+
+#: ../src/common/stockitem.cpp:267
+msgid "Find and replace in document"
+msgstr "Buscar y reemplazar en el documento"
+
+#: ../src/common/stockitem.cpp:268
+msgid "Paste selection"
+msgstr "Pegar selección"
+
+#: ../src/common/stockitem.cpp:269
+msgid "Quit this program"
+msgstr "Salir de este programa"
+
+#: ../src/common/stockitem.cpp:270
+msgid "Redo last action"
+msgstr "Rehacer la última acción"
+
+#: ../src/common/stockitem.cpp:271
+msgid "Undo last action"
+msgstr "Deshacer la última acción"
+
+#: ../src/common/stockitem.cpp:272
+msgid "Create new document"
+msgstr "Crear nuevo documento"
+
+#: ../src/common/stockitem.cpp:273
+msgid "Open an existing document"
+msgstr "Abre un documento existente"
+
+#: ../src/common/stockitem.cpp:274
+msgid "Close current document"
+msgstr "Cerrar el documento actual"
+
+#: ../src/common/stockitem.cpp:275
+msgid "Save current document"
+msgstr "Guardar documento actual"
+
+#: ../src/common/stockitem.cpp:276
+msgid "Save current document with a different filename"
+msgstr "Guardar el documento actual con otro nombre"
+
+#: ../src/common/strconv.cpp:2324
+#, c-format
+msgid "Conversion to charset '%s' doesn't work."
+msgstr "Conversión a juego de caracteres '%s' no funciona."
+
+#: ../src/common/tarstrm.cpp:352 ../src/common/tarstrm.cpp:375
+#: ../src/common/tarstrm.cpp:406 ../src/generic/progdlgg.cpp:373
+msgid "unknown"
+msgstr "desconocido"
+
+#: ../src/common/tarstrm.cpp:774
+msgid "incomplete header block in tar"
+msgstr "bloque de cabecera incompleto en tar"
+
+#: ../src/common/tarstrm.cpp:798
+msgid "checksum failure reading tar header block"
+msgstr "fallo de suma de comprobación leyendo bloque de cabecera de tar"
+
+#: ../src/common/tarstrm.cpp:971
+msgid "invalid data in extended tar header"
+msgstr "datos no válidos en la cabecera de TAR extendida"
+
+#: ../src/common/tarstrm.cpp:981 ../src/common/tarstrm.cpp:1003
+#: ../src/common/tarstrm.cpp:1477 ../src/common/tarstrm.cpp:1499
+msgid "tar entry not open"
+msgstr "elemento tar no abierto"
+
+#: ../src/common/tarstrm.cpp:1023
+msgid "unexpected end of file"
+msgstr "fin de archivo inesperado"
+
+#: ../src/common/tarstrm.cpp:1297
+#, c-format
+msgid "%s did not fit the tar header for entry '%s'"
+msgstr "%s no se ajustó a la cabecera tar para la entrada '%s'"
+
+#: ../src/common/tarstrm.cpp:1359
+msgid "incorrect size given for tar entry"
+msgstr "tamaño incorrecto para elemento de TAR"
+
+#: ../src/common/textbuf.cpp:232
+#, c-format
+msgid "'%s' is probably a binary buffer."
+msgstr "'%s' es probablemente un buffer binario."
+
+#: ../src/common/textcmn.cpp:1006 ../src/richtext/richtextctrl.cpp:3053
+msgid "File couldn't be loaded."
+msgstr "No se pudo abrir el archivo."
+
+#: ../src/common/textfile.cpp:95
+#, c-format
+msgid "Failed to read text file \"%s\"."
+msgstr "Falló la lectura del archivo de texto  '%s'."
+
+#: ../src/common/textfile.cpp:160
+#, c-format
+msgid "can't write buffer '%s' to disk."
+msgstr "no se puede guardar el buffer '%s' al disco."
+
+#: ../src/common/time.cpp:212
+msgid "Failed to get the local system time"
+msgstr "Error al obtener el sistema horario local"
+
+#: ../src/common/time.cpp:279
+msgid "wxGetTimeOfDay failed."
+msgstr "wxGetTimeOfDay falló."
+
+#: ../src/common/translation.cpp:929
+#, c-format
+msgid "'%s' is not a valid message catalog."
+msgstr "'%s' no es un catálogo de mensajes válido."
+
+#: ../src/common/translation.cpp:954
+msgid "Invalid message catalog."
+msgstr "Catálogo de mensajes no válido."
+
+#: ../src/common/translation.cpp:1013
+#, c-format
+msgid "Failed to parse Plural-Forms: '%s'"
+msgstr "No se pudieron analizar las formas plurales: «%s»"
+
+#: ../src/common/translation.cpp:1723
+#, c-format
+msgid "using catalog '%s' from '%s'."
+msgstr "se usa el catálogo «%s» de «%s»."
+
+#: ../src/common/translation.cpp:1816
+#, c-format
+msgid "Resource '%s' is not a valid message catalog."
+msgstr "El recurso '%s' no es un catálogo de mensajes válido."
+
+#: ../src/common/translation.cpp:1865
+msgid "Couldn't enumerate translations"
+msgstr "No se pudieron enumerar las traducciones"
+
+#: ../src/common/utilscmn.cpp:1145
+msgid "No default application configured for HTML files."
+msgstr "No se ha configurado la aplicación predeterminada para archivos HTML."
+
+#: ../src/common/utilscmn.cpp:1190
+#, c-format
+msgid "Failed to open URL \"%s\" in default browser."
+msgstr "Falló la apertura del URL «%s» en el navegador predeterminado."
+
+#: ../src/common/valtext.cpp:144
+msgid "Validation conflict"
+msgstr "Conflicto de validación"
+
+#: ../src/common/valtext.cpp:186
+msgid "Required information entry is empty."
+msgstr "La entrada de información requerida está vacía."
+
+#: ../src/common/valtext.cpp:188
+#, c-format
+msgid "'%s' is one of the invalid strings"
+msgstr "'%s' es una de las cadenas no válidas"
+
+#: ../src/common/valtext.cpp:190
+#, c-format
+msgid "'%s' is not one of the valid strings"
+msgstr "'%s' no es una de las cadenas válidas"
+
+#: ../src/common/valtext.cpp:199
+#, c-format
+msgid "'%s' contains invalid character(s)"
+msgstr "'%s' contiene caracteres no permitidos"
+
+#: ../src/common/webrequest.cpp:139
+#, c-format
+msgid "Error: %s (%d)"
+msgstr "Error: %s (%d)"
+
+#: ../src/common/webrequest.cpp:655
+#, fuzzy, c-format
+msgid ""
+"Not enough free disk space for download: %llu needed but only %llu available."
+msgstr "No hay espacio suficiente en el disco para la descarga."
+
+#: ../src/common/webrequest.cpp:669
+#, c-format
+msgid "Failed to create temporary file in %s"
+msgstr "No se pudo crear un archivo temporal en %s"
+
+#: ../src/common/webrequest_curl.cpp:1106
+msgid "libcurl could not be initialized"
+msgstr "no se pudo inicializar libcurl"
+
+#: ../src/common/webview.cpp:392
+msgid "RunScriptAsync not supported"
+msgstr "RunScriptAsync no soportado"
+
+#: ../src/common/webview.cpp:403 ../src/msw/webview_ie.cpp:1073
+#, c-format
+msgid "Error running JavaScript: %s"
+msgstr "Error ejecutando JavaScript: %s"
+
+#: ../src/common/webview_chromium.cpp:858
+#, c-format
+msgid "Failed to set proxy \"%s\": %s"
+msgstr "No se pudo establecer el proxy «%s»: %s"
+
+#: ../src/common/webview_chromium.cpp:989
+msgid ""
+"Chromium can't be used because libcef.so wasn't loaded early enough; please "
+"relink the application or use LD_PRELOAD to load it earlier."
+msgstr ""
+
+#: ../src/common/webview_chromium.cpp:1108
+msgid "Could not initialize Chromium"
+msgstr "No se pudo inicializar Chromium"
+
+#: ../src/common/webview_chromium.cpp:1616
+msgid "Show DevTools"
+msgstr ""
+
+#: ../src/common/webview_chromium.cpp:1617
+msgid "Close DevTools"
+msgstr "Cerrar DevTools"
+
+#: ../src/common/webview_chromium.cpp:1623
+msgid "Inspect"
+msgstr ""
+
+#: ../src/common/wincmn.cpp:1628
+msgid "This platform does not support background transparency."
+msgstr "Esta plataforma no admite transparencias de fondo."
+
+#: ../src/common/wincmn.cpp:2097
+msgid "Could not transfer data to window"
+msgstr "No se pudieron transferir datos a la ventana"
+
+#: ../src/common/windowid.cpp:240
+msgid "Out of window IDs.  Recommend shutting down application."
+msgstr "Se agotaron los ids. de ventana. Se recomienda cerrar la aplicación."
+
+#: ../src/common/xpmdecod.cpp:678
+msgid "XPM: incorrect header format!"
+msgstr "XPM: ¡formato de cabecera incorrecto!"
+
+#: ../src/common/xpmdecod.cpp:703
+#, c-format
+msgid "XPM: incorrect colour description in line %d"
+msgstr "XPM: definición de color incorrecta en línea %d"
+
+#: ../src/common/xpmdecod.cpp:715 ../src/common/xpmdecod.cpp:724
+#, c-format
+msgid "XPM: malformed colour definition '%s' at line %d!"
+msgstr "XPM: ¡definición de color '%s' incorrecta en línea %d!"
+
+#: ../src/common/xpmdecod.cpp:754
+msgid "XPM: no colors left to use for mask!"
+msgstr "XPM: ¡no quedan colores para la máscara!"
+
+#: ../src/common/xpmdecod.cpp:781
+#, c-format
+msgid "XPM: truncated image data at line %d!"
+msgstr "XPM: ¡datos de imagen truncados en la línea %d!"
+
+#: ../src/common/xpmdecod.cpp:795
+msgid "XPM: Malformed pixel data!"
+msgstr "XPM: ¡Datos de píxel erróneos!"
+
+#: ../src/common/xti.cpp:492
+msgid "Illegal Parameter Count for Create Method"
+msgstr "Número incorrecto de parámetros para el método Create"
+
+#: ../src/common/xti.cpp:504
+msgid "Illegal Parameter Count for ConstructObject Method"
+msgstr "Número incorrecto de parámetros para el método ConstructObject"
+
+#: ../src/common/xtistrm.cpp:161
+#, c-format
+msgid "Create Parameter %s not found in declared RTTI Parameters"
+msgstr ""
+"No se encontró el parámetro de Create %s en los parámetros RTTI declarados"
+
+#: ../src/common/xtistrm.cpp:290
+msgid "Illegal Object Class (Non-wxEvtHandler) as Event Source"
+msgstr "Clase de objeto no permitida (Non-wxEvtHandler) como origen de sucesos"
+
+#: ../src/common/xtistrm.cpp:313 ../src/common/xtixml.cpp:345
+#: ../src/common/xtixml.cpp:498
+msgid "Type must have enum - long conversion"
+msgstr "El tipo debe tener conversión de enum a long"
+
+#: ../src/common/xtistrm.cpp:400 ../src/common/xtistrm.cpp:415
+msgid "Invalid or Null Object ID passed to GetObjectClassInfo"
+msgstr "Identificador de objeto pasado a GetObjectClassInfo nulo o no válido"
+
+#: ../src/common/xtistrm.cpp:405
+msgid "Unknown Object passed to GetObjectClassInfo"
+msgstr "Objeto desconocido pasado a GetObjectClassInfo"
+
+#: ../src/common/xtistrm.cpp:420
+msgid "Already Registered Object passed to SetObjectClassInfo"
+msgstr "Se pasó un objeto ya registrado a SetObjectClassInfo"
+
+#: ../src/common/xtistrm.cpp:430
+msgid "Invalid or Null Object ID passed to HasObjectClassInfo"
+msgstr "Identificador de objeto pasado a HasObjectClassInfo nulo o no válido"
+
+#: ../src/common/xtistrm.cpp:460
+msgid "Passing a already registered object to SetObject"
+msgstr "Paso de un objeto ya registrado a SetObject"
+
+#: ../src/common/xtistrm.cpp:471
+msgid "Passing an unknown object to GetObject"
+msgstr "Paso de un objeto desconocido a GetObject"
+
+#: ../src/common/xtixml.cpp:229
+msgid "Forward hrefs are not supported"
+msgstr "No se admiten los HREF de reenvío"
+
+#: ../src/common/xtixml.cpp:247
+#, c-format
+msgid "unknown class %s"
+msgstr "clase %s desconocida"
+
+#: ../src/common/xtixml.cpp:253
+msgid "objects cannot have XML Text Nodes"
+msgstr "los objetos no pueden tener nodos XML de texto"
+
+#: ../src/common/xtixml.cpp:258
+msgid "Objects must have an id attribute"
+msgstr "Los objetos deben tener un atributo de identificación"
+
+#: ../src/common/xtixml.cpp:267
+#, c-format
+msgid "Doubly used id : %d"
+msgstr "Identificador usado dos veces: %d"
+
+#: ../src/common/xtixml.cpp:316
+#, c-format
+msgid "Unknown Property %s"
+msgstr "Propiedad %s desconocida"
+
+#: ../src/common/xtixml.cpp:407
+msgid "A non empty collection must consist of 'element' nodes"
+msgstr "Una colección no vacía debe consistir en nodos del tipo «element»"
+
+#: ../src/common/xtixml.cpp:478
+msgid "incorrect event handler string, missing dot"
+msgstr "cadena de identificador de suceso incorrecta; falta el punto"
+
+#: ../src/common/zipstrm.cpp:559
+msgid "can't re-initialize zlib deflate stream"
+msgstr "no se puede reinicializar el flujo de compresión de zlib"
+
+#: ../src/common/zipstrm.cpp:584
+msgid "can't re-initialize zlib inflate stream"
+msgstr "no se puede reinicializar el flujo de descompresión de zlib"
+
+#: ../src/common/zipstrm.cpp:1023
+msgid "Ignoring malformed extra data record, ZIP file may be corrupted"
+msgstr ""
+"Ignorando regiatro de datgos extra mal formado, el archivo ZIP puede estar "
+"corrompido"
+
+#: ../src/common/zipstrm.cpp:1502
+msgid "assuming this is a multi-part zip concatenated"
+msgstr "suponemos que es un archivo zip multiparte concatenado"
+
+#: ../src/common/zipstrm.cpp:1664
+msgid "invalid zip file"
+msgstr "archivo ZIP no válido"
+
+#: ../src/common/zipstrm.cpp:1723
+msgid "can't find central directory in zip"
+msgstr "no se puede encontrar el directorio central del ZIP"
+
+#: ../src/common/zipstrm.cpp:1812
+msgid "error reading zip central directory"
+msgstr "error al leer el directorio central del ZIP"
+
+#: ../src/common/zipstrm.cpp:1916
+msgid "error reading zip local header"
+msgstr "error al leer la cabecera local del archivo zip"
+
+#: ../src/common/zipstrm.cpp:1964
+msgid "bad zipfile offset to entry"
+msgstr "desplazamiento erróneo al elemento del archivo zip"
+
+#: ../src/common/zipstrm.cpp:2031
+msgid "stored file length not in Zip header"
+msgstr "longitud del archivo almacenada no está en la cabecera del Zip"
+
+#: ../src/common/zipstrm.cpp:2045 ../src/common/zipstrm.cpp:2362
+msgid "unsupported Zip compression method"
+msgstr "no se admite el método de compresión ZIP"
+
+#: ../src/common/zipstrm.cpp:2126
+#, c-format
+msgid "reading zip stream (entry %s): bad length"
+msgstr "al leer flujo de zip (elemento %s): longitud errónea"
+
+#: ../src/common/zipstrm.cpp:2131
+#, c-format
+msgid "reading zip stream (entry %s): bad crc"
+msgstr "al leer flujo de zip (elemento %s): crc erróneo"
+
+#: ../src/common/zipstrm.cpp:2578
+#, c-format
+msgid "error writing zip entry '%s': file too large without ZIP64"
+msgstr ""
+"error escribiendo la entrada zip '%s': el archivo es demasiado grande, "
+"necesita ZIP64"
+
+#: ../src/common/zipstrm.cpp:2585
+#, c-format
+msgid "error writing zip entry '%s': bad crc or length"
+msgstr "error al escribir el elemento de zip '%s': crc o longitud erróneos"
+
+#: ../src/common/zstream.cpp:155 ../src/common/zstream.cpp:315
+msgid "Gzip not supported by this version of zlib"
+msgstr "Esta versión de zlib no admite GZIP"
+
+#: ../src/common/zstream.cpp:182
+msgid "Can't initialize zlib inflate stream."
+msgstr "No se puede inicializar el flujo de descompresión de zlib."
+
+#: ../src/common/zstream.cpp:241
+msgid "Can't read inflate stream: unexpected EOF in underlying stream."
+msgstr ""
+"No se puede leer el flujo de descompresión: EOF inesperado en el flujo "
+"subyacente."
+
+#: ../src/common/zstream.cpp:248 ../src/common/zstream.cpp:423
+#, c-format
+msgid "zlib error %d"
+msgstr "error de zlib %d"
+
+#: ../src/common/zstream.cpp:249
+#, c-format
+msgid "Can't read from inflate stream: %s"
+msgstr "No se puede leer desde el flujo de descompresión %s"
+
+#: ../src/common/zstream.cpp:343
+msgid "Can't initialize zlib deflate stream."
+msgstr "No se puede inicializar el flujo de compresión de zlib."
+
+#: ../src/common/zstream.cpp:424
+#, c-format
+msgid "Can't write to deflate stream: %s"
+msgstr "No se puede escribir en el flujo de compresión: %s"
+
+#: ../src/dfb/bitmap.cpp:633 ../src/dfb/bitmap.cpp:667
+#, c-format
+msgid "No bitmap handler for type %d defined."
+msgstr "No hay manipulador de imagen para el tipo %d."
+
+#: ../src/dfb/evtloop.cpp:99
+msgid "Failed to read event from DirectFB pipe"
+msgstr "Falló la lectura del suceso a partir de la tubería DirectFB"
+
+#: ../src/dfb/evtloop.cpp:171
+msgid "Failed to switch DirectFB pipe to non-blocking mode"
+msgstr "Fallo al cambiar la tubería DirectFB a modo no bloqueante"
+
+#: ../src/dfb/fontmgr.cpp:171
+#, c-format
+msgid "no fonts found in %s, using builtin font"
+msgstr "no se han encontrado tipos de letra en %s; se usa el tipo incorporado"
+
+#: ../src/dfb/fontmgr.cpp:177
+msgid "Default font"
+msgstr "Tipo de letra predeterminado"
+
+#: ../src/dfb/fontmgr.cpp:195
+#, c-format
+msgid "Fonts index file %s disappeared while loading fonts."
+msgstr ""
+"El archivo de índice tipográfico %s desapareció mientras se cargaban los "
+"tipos de letra."
+
+#: ../src/dfb/wrapdfb.cpp:60
+#, c-format
+msgid "DirectFB error %d occurred."
+msgstr "Ha ocurrido un error DirectFB %d."
+
+#: ../src/generic/aboutdlgg.cpp:69
+msgid "Developed by "
+msgstr "Desarrollado por "
+
+#: ../src/generic/aboutdlgg.cpp:72
+msgid "Documentation by "
+msgstr "Documentación por "
+
+#: ../src/generic/aboutdlgg.cpp:75
+msgid "Graphics art by "
+msgstr "Arte gráfico por "
+
+#: ../src/generic/aboutdlgg.cpp:78
+msgid "Translations by "
+msgstr "Traducciones por "
+
+#: ../src/generic/aboutdlgg.cpp:133 ../src/osx/cocoa/aboutdlg.mm:83
+msgid "Version "
+msgstr "Versión "
+
+#. TRANSLATORS: %s is application name
+#: ../src/generic/aboutdlgg.cpp:146 ../src/msw/aboutdlg.cpp:60
+#, c-format
+msgid "About %s"
+msgstr "Acerca de %s"
+
+#: ../src/generic/aboutdlgg.cpp:181
+msgid "License"
+msgstr "Licencia"
+
+#: ../src/generic/aboutdlgg.cpp:184
+msgid "Developers"
+msgstr "Desarrolladores"
+
+#: ../src/generic/aboutdlgg.cpp:188
+msgid "Documentation writers"
+msgstr "Redactores de documentación"
+
+#: ../src/generic/aboutdlgg.cpp:192
+msgid "Artists"
+msgstr "Artistas"
+
+#: ../src/generic/aboutdlgg.cpp:196
+msgid "Translators"
+msgstr "Traductores"
+
+#: ../src/generic/animateg.cpp:125
+msgid "No handler found for animation type."
+msgstr "No se ha encontrado ningún manipulador para el tipo de animación."
+
+#: ../src/generic/animateg.cpp:133
+#, c-format
+msgid "No animation handler for type %ld defined."
+msgstr "No hay definido ningún manipulador de animación para tipo %ld."
+
+#: ../src/generic/animateg.cpp:145
+#, c-format
+msgid "Animation file is not of type %ld."
+msgstr "El archivo de animación no es del tipo %ld."
+
+#: ../src/generic/colrdlgg.cpp:154 ../src/gtk/colordlg.cpp:47
+msgid "Choose colour"
+msgstr "Elija un color"
+
+#: ../src/generic/colrdlgg.cpp:357
+msgid "Red:"
+msgstr "Rojo:"
+
+#: ../src/generic/colrdlgg.cpp:360
+msgid "Green:"
+msgstr "Verde:"
+
+#: ../src/generic/colrdlgg.cpp:363
+msgid "Blue:"
+msgstr "Azul:"
+
+#: ../src/generic/colrdlgg.cpp:372
+msgid "Opacity:"
+msgstr "Opacidad:"
+
+#: ../src/generic/colrdlgg.cpp:384
+msgid "Add to custom colours"
+msgstr "Añadir a colores personalizados"
+
+#: ../src/generic/creddlgg.cpp:56
+msgid "Username:"
+msgstr "Usuario:"
+
+#: ../src/generic/creddlgg.cpp:63
+msgid "Password:"
+msgstr "Contraseña:"
+
+#. TRANSLATORS: Name of Boolean true value
+#: ../src/generic/datavgen.cpp:1178
+msgid "true"
+msgstr "verdadero"
+
+#. TRANSLATORS: Name of Boolean false value
+#: ../src/generic/datavgen.cpp:1180
+msgid "false"
+msgstr "falso"
+
+#: ../src/generic/datavgen.cpp:6897
+#, c-format
+msgid "Row %i"
+msgstr "Fila %i"
+
+#. TRANSLATORS: Action for manipulating a tree control
+#: ../src/generic/datavgen.cpp:6987
+msgid "Collapse"
+msgstr "Contraer"
+
+#. TRANSLATORS: Action for manipulating a tree control
+#: ../src/generic/datavgen.cpp:6990
+msgid "Expand"
+msgstr "Expandir"
+
+#. TRANSLATORS: Name of data view control and number of rows
+#: ../src/generic/datavgen.cpp:7011
+#, c-format
+msgid "%s (%d items)"
+msgstr "%s (%d elementos)"
+
+#: ../src/generic/datavgen.cpp:7062
+#, c-format
+msgid "Column %u"
+msgstr "Columna %u"
+
+#. TRANSLATORS: Keystroke for manipulating a tree control
+#: ../src/generic/datavgen.cpp:7131 ../src/richtext/richtextbulletspage.cpp:189
+#: ../src/richtext/richtextbulletspage.cpp:192
+#: ../src/richtext/richtextbulletspage.cpp:193
+#: ../src/richtext/richtextliststylepage.cpp:252
+#: ../src/richtext/richtextliststylepage.cpp:255
+#: ../src/richtext/richtextliststylepage.cpp:256
+#: ../src/richtext/richtextsizepage.cpp:248
+msgid "Left"
+msgstr "Izquierda"
+
+#. TRANSLATORS: Keystroke for manipulating a tree control
+#: ../src/generic/datavgen.cpp:7134 ../src/richtext/richtextbulletspage.cpp:191
+#: ../src/richtext/richtextliststylepage.cpp:254
+#: ../src/richtext/richtextsizepage.cpp:249
+msgid "Right"
+msgstr "Derecha"
+
+#: ../src/generic/datectlg.cpp:90
+#, c-format
+msgid ""
+"\"%s\" is not in the expected date format, please enter it as e.g. \"%s\"."
+msgstr ""
+
+#: ../src/generic/datectlg.cpp:94
+msgid "Invalid date"
+msgstr "Fecha no válida"
+
+#: ../src/generic/dbgrptg.cpp:159
+#, c-format
+msgid "Open file \"%s\""
+msgstr "Abrir archivo «%s»"
+
+#: ../src/generic/dbgrptg.cpp:170
+#, c-format
+msgid "Enter command to open file \"%s\":"
+msgstr "Escriba la orden para abrir el archivo «%s»:"
+
+#: ../src/generic/dbgrptg.cpp:230
+msgid "Executable files (*.exe)|*.exe|"
+msgstr "Archivos ejecutables (*.exe)|*.exe|"
+
+#: ../src/generic/dbgrptg.cpp:300
+#, c-format
+msgid "Debug report \"%s\""
+msgstr "Informe de depuración «%s»"
+
+#: ../src/generic/dbgrptg.cpp:316
+msgid "A debug report has been generated in the directory\n"
+msgstr "Se ha generado un informe de depuración en el directorio\n"
+
+#: ../src/generic/dbgrptg.cpp:317
+msgid "The following debug report will be generated\n"
+msgstr "Se generará el siguiente informe de depuración\n"
+
+#: ../src/generic/dbgrptg.cpp:321
+msgid ""
+"The report contains the files listed below. If any of these files contain "
+"private information,\n"
+"please uncheck them and they will be removed from the report.\n"
+msgstr ""
+"El informe contiene los archivos mostrados abajo. Si alguno de estos "
+"archivos contiene información privada,\n"
+"por favor desmárquelos y serán eliminados del informe.\n"
+
+#: ../src/generic/dbgrptg.cpp:323
+msgid ""
+"If you wish to suppress this debug report completely, please choose the "
+"\"Cancel\" button,\n"
+"but be warned that it may hinder improving the program, so if\n"
+"at all possible please do continue with the report generation.\n"
+msgstr ""
+"Si desea eliminar este informe de depuración completamente, por favor, elija "
+"el botón \"Cancelar\",\n"
+"pero sepa que ésto no ayuda a la mejora del programa, por tanto, si\n"
+"es posible, por favor, continue con la generación del informe.\n"
+
+#: ../src/generic/dbgrptg.cpp:325
+msgid "              Thank you and we're sorry for the inconvenience!\n"
+msgstr "              Gracias. Sentimos las molestias.\n"
+
+#: ../src/generic/dbgrptg.cpp:333
+msgid "&Debug report preview:"
+msgstr "&Vista previa del informe de depuración:"
+
+#: ../src/generic/dbgrptg.cpp:339
+msgid "&View..."
+msgstr "&Ver…"
+
+#: ../src/generic/dbgrptg.cpp:359
+msgid "&Notes:"
+msgstr "&Notas:"
+
+#: ../src/generic/dbgrptg.cpp:361
+msgid ""
+"If you have any additional information pertaining to this bug\n"
+"report, please enter it here and it will be joined to it:"
+msgstr ""
+"Si tiene alguna información adicional concerniente a este informe\n"
+"de error, por favor, introdúzcalo aquí y será adjuntado:"
+
+#: ../src/generic/dcpsg.cpp:1627
+msgid "Cannot open file for PostScript printing!"
+msgstr "¡No se puede abrir el archivo para impresión PostScript!"
+
+#: ../src/generic/dirctrlg.cpp:402
+msgid "Computer"
+msgstr "Equipo"
+
+#: ../src/generic/dirctrlg.cpp:404
+msgid "Sections"
+msgstr "Secciones"
+
+#: ../src/generic/dirctrlg.cpp:482
+msgid "Home directory"
+msgstr "Directorio de usuario"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/generic/dirctrlg.cpp:484 ../src/propgrid/advprops.cpp:811
+msgid "Desktop"
+msgstr "Escritorio"
+
+#: ../src/generic/dirctrlg.cpp:528 ../src/generic/filectrlg.cpp:752
+msgid "Illegal directory name."
+msgstr "El nombre del directorio no está permitido."
+
+#: ../src/generic/dirctrlg.cpp:528 ../src/generic/dirctrlg.cpp:546
+#: ../src/generic/dirctrlg.cpp:557 ../src/generic/dirdlgg.cpp:317
+#: ../src/generic/filectrlg.cpp:638 ../src/generic/filectrlg.cpp:752
+#: ../src/generic/filectrlg.cpp:766 ../src/generic/filectrlg.cpp:782
+#: ../src/generic/filectrlg.cpp:1356 ../src/generic/filectrlg.cpp:1387
+#: ../src/generic/filedlgg.cpp:362 ../src/gtk/filedlg.cpp:76
+msgid "Error"
+msgstr "Error"
+
+#: ../src/generic/dirctrlg.cpp:546 ../src/generic/filectrlg.cpp:766
+msgid "File name exists already."
+msgstr "Ya existe un archivo con el mismo nombre."
+
+#: ../src/generic/dirctrlg.cpp:557 ../src/generic/dirdlgg.cpp:317
+#: ../src/generic/filectrlg.cpp:638 ../src/generic/filectrlg.cpp:782
+msgid "Operation not permitted."
+msgstr "Operación no permitida."
+
+#: ../src/generic/dirdlgg.cpp:107 ../src/generic/filedlgg.cpp:207
+msgid "Create new directory"
+msgstr "Crear directorio nuevo"
+
+#: ../src/generic/dirdlgg.cpp:112 ../src/generic/filedlgg.cpp:203
+msgid "Go to home directory"
+msgstr "Ir al directorio de usuario"
+
+#: ../src/generic/dirdlgg.cpp:143
+msgid "Show &hidden directories"
+msgstr "Mostrar directorios &ocultos"
+
+#: ../src/generic/dirdlgg.cpp:196
+#, c-format
+msgid ""
+"The directory '%s' does not exist\n"
+"Create it now?"
+msgstr ""
+"El directorio «%s» no existe.\n"
+"¿Quiere crearlo ahora?"
+
+#: ../src/generic/dirdlgg.cpp:198
+msgid "Directory does not exist"
+msgstr "El directorio no existe"
+
+#: ../src/generic/dirdlgg.cpp:214
+#, c-format
+msgid ""
+"Failed to create directory '%s'\n"
+"(Do you have the required permissions?)"
+msgstr ""
+"Falló la creación del directorio «%s»\n"
+"(¿Tiene los permisos necesarios?)"
+
+#: ../src/generic/dirdlgg.cpp:216
+msgid "Error creating directory"
+msgstr "Error al crear el directorio"
+
+#: ../src/generic/dirdlgg.cpp:281
+msgid "You cannot add a new directory to this section."
+msgstr "No puede añadir un directorio nuevo a esta sección."
+
+#: ../src/generic/dirdlgg.cpp:282
+msgid "Create directory"
+msgstr "Crear directorio"
+
+#: ../src/generic/dirdlgg.cpp:291 ../src/generic/dirdlgg.cpp:301
+#: ../src/generic/filectrlg.cpp:614 ../src/generic/filectrlg.cpp:623
+msgid "NewName"
+msgstr "NewName"
+
+#: ../src/generic/editlbox.cpp:135
+msgid "Edit item"
+msgstr "Editar elemento"
+
+#: ../src/generic/editlbox.cpp:143
+msgid "New item"
+msgstr "Elemento nuevo"
+
+#: ../src/generic/editlbox.cpp:151
+msgid "Delete item"
+msgstr "Eliminar elemento"
+
+#: ../src/generic/editlbox.cpp:159
+msgid "Move up"
+msgstr "Subir"
+
+#: ../src/generic/editlbox.cpp:164
+msgid "Move down"
+msgstr "Bajar"
+
+#: ../src/generic/fdrepdlg.cpp:108
+msgid "Search for:"
+msgstr "Buscar:"
+
+#: ../src/generic/fdrepdlg.cpp:120
+msgid "Replace with:"
+msgstr "Sustituir por:"
+
+#: ../src/generic/fdrepdlg.cpp:140
+msgid "Whole word"
+msgstr "Palabra completa"
+
+#: ../src/generic/fdrepdlg.cpp:143
+msgid "Match case"
+msgstr "Distinguir mayúsculas y minúsculas"
+
+#: ../src/generic/fdrepdlg.cpp:156
+msgid "Search direction"
+msgstr "Dirección de búsqueda"
+
+#: ../src/generic/fdrepdlg.cpp:175
+msgid "&Replace"
+msgstr "&Sustituir"
+
+#: ../src/generic/fdrepdlg.cpp:178
+msgid "Replace &all"
+msgstr "Sustituir &todo"
+
+#: ../src/generic/filectrlg.cpp:246 ../src/generic/filectrlg.cpp:269
+msgid "<DIR>"
+msgstr "<DIR>"
+
+#: ../src/generic/filectrlg.cpp:248 ../src/generic/filectrlg.cpp:271
+msgid "<LINK>"
+msgstr "<ENLACE>"
+
+#: ../src/generic/filectrlg.cpp:250 ../src/generic/filectrlg.cpp:273
+msgid "<DRIVE>"
+msgstr "<UNIDAD>"
+
+#: ../src/generic/filectrlg.cpp:275
+#, c-format
+msgid "%ld byte"
+msgid_plural "%ld bytes"
+msgstr[0] "%ld byte"
+msgstr[1] "%ld bytes"
+
+#: ../src/generic/filectrlg.cpp:420
+msgid "Name"
+msgstr "Nombre"
+
+#: ../src/generic/filectrlg.cpp:421 ../src/richtext/richtextformatdlg.cpp:361
+#: ../src/richtext/richtextsizepage.cpp:298
+msgid "Size"
+msgstr "Tamaño"
+
+#: ../src/generic/filectrlg.cpp:422
+msgid "Type"
+msgstr "Tipo"
+
+#: ../src/generic/filectrlg.cpp:423
+msgid "Modified"
+msgstr "Modificado"
+
+#: ../src/generic/filectrlg.cpp:426
+msgid "Permissions"
+msgstr "Permisos"
+
+#: ../src/generic/filectrlg.cpp:429
+msgid "Attributes"
+msgstr "Atributos"
+
+#: ../src/generic/filectrlg.cpp:936
+msgid "Current directory:"
+msgstr "Directorio actual:"
+
+#: ../src/generic/filectrlg.cpp:979
+msgid "Show &hidden files"
+msgstr "Mostrar archivos &ocultos"
+
+#: ../src/generic/filectrlg.cpp:1355
+msgid "Illegal file specification."
+msgstr "Especificación de archivo incorrecta."
+
+#: ../src/generic/filectrlg.cpp:1387
+msgid "Directory doesn't exist."
+msgstr "La carpeta no existe."
+
+#: ../src/generic/filedlgg.cpp:195
+msgid "View files as a list view"
+msgstr "Ver archivos como lista"
+
+#: ../src/generic/filedlgg.cpp:197
+msgid "View files as a detailed view"
+msgstr "Ver archivos como vista detallada"
+
+#: ../src/generic/filedlgg.cpp:200
+msgid "Go to parent directory"
+msgstr "Ir al directorio contenedor"
+
+#: ../src/generic/filedlgg.cpp:351 ../src/gtk/filedlg.cpp:59
+#, c-format
+msgid "File '%s' already exists, do you really want to overwrite it?"
+msgstr "El archivo «%s» ya existe; ¿realmente quiere sobrescribirlo?"
+
+#: ../src/generic/filedlgg.cpp:354 ../src/gtk/filedlg.cpp:62
+msgid "Confirm"
+msgstr "Confirmar"
+
+#: ../src/generic/filedlgg.cpp:362 ../src/gtk/filedlg.cpp:75
+msgid "Please choose an existing file."
+msgstr "Elija un archivo existente."
+
+#: ../src/generic/filepickerg.cpp:64
+msgid "..."
+msgstr "…"
+
+#: ../src/generic/fontdlgg.cpp:76 ../src/richtext/richtextformatdlg.cpp:519
+msgid "ABCDEFGabcdefg12345"
+msgstr "ABCDEFGabcdefg12345"
+
+#: ../src/generic/fontdlgg.cpp:315
+msgid "Roman"
+msgstr "Roman"
+
+#: ../src/generic/fontdlgg.cpp:316
+msgid "Decorative"
+msgstr "Decorativo"
+
+#: ../src/generic/fontdlgg.cpp:317
+msgid "Modern"
+msgstr "Moderna"
+
+#: ../src/generic/fontdlgg.cpp:318
+msgid "Script"
+msgstr "Script"
+
+#: ../src/generic/fontdlgg.cpp:319
+msgid "Swiss"
+msgstr "Swiss"
+
+#: ../src/generic/fontdlgg.cpp:320
+msgid "Teletype"
+msgstr "Teletipo"
+
+#: ../src/generic/fontdlgg.cpp:321 ../src/generic/fontdlgg.cpp:324
+msgid "Normal"
+msgstr "Normal"
+
+#: ../src/generic/fontdlgg.cpp:323
+msgid "Slant"
+msgstr "Cursiva"
+
+#: ../src/generic/fontdlgg.cpp:325
+msgid "Light"
+msgstr "Ligera"
+
+#: ../src/generic/fontdlgg.cpp:363
+msgid "&Font family:"
+msgstr "&Familia tipográfica:"
+
+#: ../src/generic/fontdlgg.cpp:367 ../src/generic/fontdlgg.cpp:369
+msgid "The font family."
+msgstr "La familia tipográfica."
+
+#: ../src/generic/fontdlgg.cpp:374 ../src/richtext/richtextstylepage.cpp:105
+msgid "&Style:"
+msgstr "E&stilo:"
+
+#: ../src/generic/fontdlgg.cpp:378 ../src/generic/fontdlgg.cpp:380
+msgid "The font style."
+msgstr "El estilo del tipo de letra."
+
+#: ../src/generic/fontdlgg.cpp:385
+msgid "&Weight:"
+msgstr "&Peso:"
+
+#: ../src/generic/fontdlgg.cpp:389 ../src/generic/fontdlgg.cpp:391
+msgid "The font weight."
+msgstr "El peso del tipo de letra."
+
+#: ../src/generic/fontdlgg.cpp:399
+msgid "C&olour:"
+msgstr "C&olor:"
+
+#: ../src/generic/fontdlgg.cpp:407 ../src/generic/fontdlgg.cpp:409
+msgid "The font colour."
+msgstr "El color del tipo de letra."
+
+#: ../src/generic/fontdlgg.cpp:415
+msgid "&Point size:"
+msgstr "Tamaño de &punto:"
+
+#: ../src/generic/fontdlgg.cpp:420 ../src/generic/fontdlgg.cpp:422
+#: ../src/generic/fontdlgg.cpp:426 ../src/generic/fontdlgg.cpp:428
+msgid "The font point size."
+msgstr "El tamaño en puntos del tipo de letra."
+
+#: ../src/generic/fontdlgg.cpp:439 ../src/generic/fontdlgg.cpp:441
+msgid "Whether the font is underlined."
+msgstr "Si la fuente está subrayada."
+
+#: ../src/generic/fontdlgg.cpp:448 ../src/html/helpwnd.cpp:1215
+msgid "Preview:"
+msgstr "Previsualización:"
+
+#: ../src/generic/fontdlgg.cpp:452 ../src/generic/fontdlgg.cpp:454
+msgid "Shows the font preview."
+msgstr "Muestra la vista previa de la fuente."
+
+#: ../src/generic/fontdlgg.cpp:464 ../src/generic/fontdlgg.cpp:483
+msgid "Click to cancel the font selection."
+msgstr "Pulse para cancelar la selección del tipo de letra."
+
+#: ../src/generic/fontdlgg.cpp:469 ../src/generic/fontdlgg.cpp:471
+#: ../src/generic/fontdlgg.cpp:476 ../src/generic/fontdlgg.cpp:478
+msgid "Click to confirm the font selection."
+msgstr "Pulse para confirmar la selección del tipo de letra."
+
+#: ../src/generic/fontpickerg.cpp:50 ../src/gtk/fontdlg.cpp:77
+msgid "Choose font"
+msgstr "Elija un tipo de letra"
+
+#: ../src/generic/grid.cpp:6542
+msgid ""
+"Error copying grid to the clipboard. Either selected cells were not "
+"contiguous or no cell was selected."
+msgstr ""
+
+#: ../src/generic/grid.cpp:12739
+msgid "Grid Corner"
+msgstr "Esquina de la cuadrícula"
+
+#: ../src/generic/grid.cpp:12741
+#, c-format
+msgid "Column %s Header"
+msgstr "Encabezado de Columna %s"
+
+#: ../src/generic/grid.cpp:12743
+#, c-format
+msgid "Row %s Header"
+msgstr ""
+
+#: ../src/generic/grid.cpp:12745
+#, c-format
+msgid "Column %s: %s"
+msgstr "Columna %s: %s"
+
+#: ../src/generic/grid.cpp:12749
+#, c-format
+msgid "Row %s: %s"
+msgstr "Fila %s: %s"
+
+#: ../src/generic/grid.cpp:12753
+#, c-format
+msgid "Row %s, Column %s: %s"
+msgstr ""
+
+#: ../src/generic/helpext.cpp:257
+#, c-format
+msgid "Help directory \"%s\" not found."
+msgstr "No se encontró el directorio de ayuda «%s»."
+
+#: ../src/generic/helpext.cpp:265
+#, c-format
+msgid "Help file \"%s\" not found."
+msgstr "No se encontró el archivo de ayuda «%s»."
+
+#: ../src/generic/helpext.cpp:284
+#, c-format
+msgid "Line %lu of map file \"%s\" has invalid syntax, skipped."
+msgstr ""
+"El renglón %lu del archivo de mapa «%s» tiene sintaxis no válida; se omite."
+
+#: ../src/generic/helpext.cpp:292
+#, c-format
+msgid "No valid mappings found in the file \"%s\"."
+msgstr "No se han encontrado asignaciones válidas en el archivo «%s»."
+
+#: ../src/generic/helpext.cpp:435
+msgid "No entries found."
+msgstr "No se han encontrado documentos."
+
+#: ../src/generic/helpext.cpp:444 ../src/generic/helpext.cpp:445
+msgid "Help Index"
+msgstr "Contenido de la ayuda"
+
+#: ../src/generic/helpext.cpp:448
+msgid "Relevant entries:"
+msgstr "Entradas relevantes:"
+
+#: ../src/generic/helpext.cpp:449
+msgid "Entries found"
+msgstr "Entradas encontradas"
+
+#: ../src/generic/hyperlinkg.cpp:170
+msgid "&Copy URL"
+msgstr "&Copiar URL"
+
+#: ../src/generic/infobar.cpp:119
+msgid "Hide this notification message."
+msgstr "Ocultar esta notificación."
+
+#. TRANSLATORS: %s will be either the application name or "Application"
+#: ../src/generic/logg.cpp:257
+#, c-format
+msgid "%s Error"
+msgstr "Error de %s"
+
+#. TRANSLATORS: %s will be either the application name or "Application"
+#: ../src/generic/logg.cpp:263
+#, c-format
+msgid "%s Warning"
+msgstr "Alerta de %s"
+
+#. TRANSLATORS: %s will be either the application name or "Application"
+#: ../src/generic/logg.cpp:273
+#, c-format
+msgid "%s Information"
+msgstr "Información de %s"
+
+#: ../src/generic/logg.cpp:276
+msgid "Application"
+msgstr "Aplicación"
+
+#: ../src/generic/logg.cpp:549
+msgid "Save log contents to file"
+msgstr "Guardar los contenidos del log en un archivo"
+
+#: ../src/generic/logg.cpp:551
+msgid "C&lear"
+msgstr "&Limpiar"
+
+#: ../src/generic/logg.cpp:551
+msgid "Clear the log contents"
+msgstr "Eliminar el contenido del log"
+
+#: ../src/generic/logg.cpp:553
+msgid "Close this window"
+msgstr "Cerrar esta ventana"
+
+#: ../src/generic/logg.cpp:554
+msgid "&Log"
+msgstr "&Registro"
+
+#: ../src/generic/logg.cpp:610 ../src/generic/logg.cpp:992
+msgid "Can't save log contents to file."
+msgstr "No se puede guardar el contenido del registro en un archivo."
+
+#: ../src/generic/logg.cpp:613
+#, c-format
+msgid "Log saved to the file '%s'."
+msgstr "Registro guardado en el archivo «%s»."
+
+#: ../src/generic/logg.cpp:719
+msgid "&Details"
+msgstr "&Detalles"
+
+#: ../src/generic/logg.cpp:972
+msgid "Failed to copy dialog contents to the clipboard."
+msgstr "Error al copiar el contenido del diálogo al portapapeles."
+
+#: ../src/generic/logg.cpp:1022
+#, c-format
+msgid "Append log to file '%s' (choosing [No] will overwrite it)?"
+msgstr ""
+"¿Quiere añadir el registro al archivo «%s»? (elegir [No] lo sobrescribirá)"
+
+#: ../src/generic/logg.cpp:1024
+msgid "Question"
+msgstr "Pregunta"
+
+#: ../src/generic/logg.cpp:1038
+msgid "invalid message box return value"
+msgstr "valor de retorno de bandeja de entrada no válido"
+
+#: ../src/generic/notifmsgg.cpp:129
+msgid "Notice"
+msgstr "Aviso"
+
+#: ../src/generic/preferencesg.cpp:118
+#, c-format
+msgid "%s Preferences"
+msgstr "Preferencias de %s"
+
+#: ../src/generic/printps.cpp:143
+msgid "Printing..."
+msgstr "Imprimiendo..."
+
+#: ../src/generic/printps.cpp:160 ../src/gtk/print.cpp:1076
+#: ../src/msw/printwin.cpp:235
+msgid "Could not start printing."
+msgstr "No se pudo iniciar la impresión."
+
+#: ../src/generic/printps.cpp:183
+#, c-format
+msgid "Printing page %d..."
+msgstr "Imprimiendo página %d..."
+
+#: ../src/generic/prntdlgg.cpp:171
+msgid "Printer options"
+msgstr "Opciones de impresión"
+
+#: ../src/generic/prntdlgg.cpp:176
+msgid "Print to File"
+msgstr "Imprimir a archivo"
+
+#: ../src/generic/prntdlgg.cpp:179
+msgid "Setup..."
+msgstr "Configuración…"
+
+#: ../src/generic/prntdlgg.cpp:187
+msgid "Printer:"
+msgstr "Impresora:"
+
+#: ../src/generic/prntdlgg.cpp:195
+msgid "Status:"
+msgstr "Estado:"
+
+#: ../src/generic/prntdlgg.cpp:206
+msgid "All"
+msgstr "Todo"
+
+#: ../src/generic/prntdlgg.cpp:207
+msgid "Pages"
+msgstr "Páginas"
+
+#: ../src/generic/prntdlgg.cpp:215
+msgid "Print Range"
+msgstr "Intervalo de impresión"
+
+#: ../src/generic/prntdlgg.cpp:229
+msgid "From:"
+msgstr "De:"
+
+#: ../src/generic/prntdlgg.cpp:233
+msgid "To:"
+msgstr "Hasta:"
+
+#: ../src/generic/prntdlgg.cpp:238
+msgid "Copies:"
+msgstr "Copias:"
+
+#: ../src/generic/prntdlgg.cpp:288
+msgid "PostScript file"
+msgstr "Archivo PostScript"
+
+#: ../src/generic/prntdlgg.cpp:439
+msgid "Print Setup"
+msgstr "Configuración de impresión"
+
+#: ../src/generic/prntdlgg.cpp:483
+msgid "Printer"
+msgstr "Impresora"
+
+#: ../src/generic/prntdlgg.cpp:501
+msgid "Default printer"
+msgstr "Impresora predeterminada"
+
+#: ../src/generic/prntdlgg.cpp:595 ../src/generic/prntdlgg.cpp:782
+#: ../src/generic/prntdlgg.cpp:822 ../src/generic/prntdlgg.cpp:835
+#: ../src/generic/prntdlgg.cpp:1031 ../src/generic/prntdlgg.cpp:1036
+msgid "Paper size"
+msgstr "Tamaño del papel"
+
+#: ../src/generic/prntdlgg.cpp:604 ../src/generic/prntdlgg.cpp:847
+msgid "Portrait"
+msgstr "Vertical"
+
+#: ../src/generic/prntdlgg.cpp:605 ../src/generic/prntdlgg.cpp:848
+msgid "Landscape"
+msgstr "Horizontal"
+
+#: ../src/generic/prntdlgg.cpp:607 ../src/generic/prntdlgg.cpp:849
+msgid "Orientation"
+msgstr "Orientación"
+
+#: ../src/generic/prntdlgg.cpp:610
+msgid "Options"
+msgstr "Opciones"
+
+#: ../src/generic/prntdlgg.cpp:612
+msgid "Print in colour"
+msgstr "Impresión en color"
+
+#: ../src/generic/prntdlgg.cpp:621
+msgid "Print spooling"
+msgstr "Cola de impresión"
+
+#: ../src/generic/prntdlgg.cpp:623
+msgid "Printer command:"
+msgstr "Orden de la impresora:"
+
+#: ../src/generic/prntdlgg.cpp:631
+msgid "Printer options:"
+msgstr "Opciones de impresión:"
+
+#: ../src/generic/prntdlgg.cpp:860
+msgid "Left margin (mm):"
+msgstr "Margen izquierdo (mm):"
+
+#: ../src/generic/prntdlgg.cpp:861
+msgid "Top margin (mm):"
+msgstr "Margen superior (mm):"
+
+#: ../src/generic/prntdlgg.cpp:872
+msgid "Right margin (mm):"
+msgstr "Margen derecho (mm):"
+
+#: ../src/generic/prntdlgg.cpp:873
+msgid "Bottom margin (mm):"
+msgstr "Margen inferior (mm):"
+
+#: ../src/generic/prntdlgg.cpp:896
+msgid "Printer..."
+msgstr "Impresora..."
+
+#: ../src/generic/progdlgg.cpp:246
+msgid "&Skip"
+msgstr "&Saltar"
+
+#: ../src/generic/progdlgg.cpp:347 ../src/generic/progdlgg.cpp:626
+msgid "Unknown"
+msgstr "Desconocido"
+
+#: ../src/generic/progdlgg.cpp:451 ../src/msw/progdlg.cpp:526
+msgid "Done."
+msgstr "Hecho."
+
+#: ../src/generic/srchctlg.cpp:55 ../src/gtk/srchctrl.cpp:206
+#: ../src/html/helpwnd.cpp:530 ../src/html/helpwnd.cpp:545
+msgid "Search"
+msgstr "Buscar"
+
+#: ../src/generic/tabg.cpp:1026
+msgid "Could not find tab for id"
+msgstr "No se pudo encontrar pestaña para id"
+
+#: ../src/generic/tipdlg.cpp:136
+msgid "Tips not available, sorry!"
+msgstr "Sugerencias no disponibles, ¡lástima!"
+
+#: ../src/generic/tipdlg.cpp:197
+msgid "Tip of the Day"
+msgstr "Sugerencia del día"
+
+#: ../src/generic/tipdlg.cpp:207
+msgid "Did you know..."
+msgstr "¿Sabía que…"
+
+#: ../src/generic/tipdlg.cpp:232
+msgid "&Show tips at startup"
+msgstr "&Mostrar sugerencias al inicio"
+
+#: ../src/generic/tipdlg.cpp:236
+msgid "&Next Tip"
+msgstr "&Siguiente Sugerencia"
+
+#: ../src/generic/wizard.cpp:411
+msgid "&Next >"
+msgstr "&Siguiente >"
+
+#: ../src/generic/wizard.cpp:412
+msgid "&Finish"
+msgstr "&Finalizar"
+
+#: ../src/generic/wizard.cpp:420
+msgid "< &Back"
+msgstr "< &Atrás"
+
+#: ../src/gtk/aboutdlg.cpp:204
+msgid "translator-credits"
+msgstr "Miguel Giménez, Andriy Byelikov https://github.com/andriybyelikov"
+
+#: ../src/gtk/app.cpp:517
+msgid ""
+"WARNING: using XIM input method is unsupported and may result in problems "
+"with input handling and flickering. Consider unsetting GTK_IM_MODULE or "
+"setting to \"ibus\"."
+msgstr ""
+"AVISO: el uso del método de entrada XIM no está soportado y puede provocar "
+"problemas con la gestión de la entrada y parpadeos. Le recomendamos borrar "
+"el contenido de GTK_IM_MODULE o configurarlo como \"ibus\"."
+
+#: ../src/gtk/app.cpp:569
+msgid "Unable to initialize GTK+, is DISPLAY set properly?"
+msgstr "No se pudo inicializar GTK+, ¿está DISPLAY configurada correctamente?"
+
+#: ../src/gtk/filedlg.cpp:89 ../src/gtk/filepicker.cpp:255
+#, c-format
+msgid "Changing current directory to \"%s\" failed"
+msgstr "Falló el cambio del directorio actual a «%s»"
+
+#: ../src/gtk/font.cpp:548
+msgid ""
+"Using private fonts is not supported on this system: Pango library is too "
+"old, 1.38 or later required."
+msgstr ""
+"El uso de fuentes privadas no está sportado en este sistema: la librería "
+"Pango es demasiado antigua, se requiere 1.38 o posterior."
+
+#: ../src/gtk/font.cpp:558
+msgid "Failed to create font configuration object."
+msgstr "Fallo creando el objeto de configuración de fuente."
+
+#: ../src/gtk/font.cpp:568
+#, c-format
+msgid "Failed to add custom font \"%s\"."
+msgstr "No se pudo añadir la fuente modificada \"%s\"."
+
+#: ../src/gtk/font.cpp:576
+msgid "Failed to register font configuration using private fonts."
+msgstr ""
+"No se pudo registrar la configuración de la fuente usando fuentes privadas."
+
+#: ../src/gtk/glcanvas.cpp:117 ../src/gtk/glcanvas.cpp:132
+msgid "Fatal Error"
+msgstr "Error fatal"
+
+#: ../src/gtk/glcanvas.cpp:117
+msgid ""
+"This program wasn't compiled with EGL support required under Wayland, "
+"either\n"
+"install EGL libraries and rebuild or run it under X11 backend by setting\n"
+"environment variable GDK_BACKEND=x11 before starting your program."
+msgstr ""
+"Este programa no se compiló con soporte para EGL requerido bajo Wayland,\n"
+"puede instalar las librerías EGL y recompilar o correrlo bajo X11 "
+"modificando la\n"
+"variable de entorno GDK_BACKEND=x11 antes de arrancar su programa."
+
+#: ../src/gtk/glcanvas.cpp:132
+msgid ""
+"wxGLCanvas is only supported on Wayland and X11 currently.  You may be able "
+"to\n"
+"work around this by setting environment variable GDK_BACKEND=x11 before\n"
+"starting your program."
+msgstr ""
+"wxGLCanvas está soportado actualmente sólo en Wayland y X11. Puede\n"
+"solucionarlo modificando la variable de entorno GDK_BACKEND=x11 antes\n"
+"de iniciar su programa."
+
+#: ../src/gtk/mdi.cpp:433
+msgid "MDI child"
+msgstr "Ventana hija MDI"
+
+#: ../src/gtk/power.cpp:188
+#, fuzzy, c-format
+msgid "Failed to open D-Bus connection to the login manager: %s"
+msgstr "Falló la creación de la conexión con el servidor «%s» en «%s»"
+
+#: ../src/gtk/power.cpp:214
+#, fuzzy
+msgid "wxWidgets application"
+msgstr "Ocultar aplicación"
+
+#: ../src/gtk/power.cpp:226
+msgid "Application needs to keep running"
+msgstr ""
+
+#: ../src/gtk/power.cpp:233
+msgid "Clean up before suspend"
+msgstr ""
+
+#: ../src/gtk/power.cpp:259
+#, fuzzy, c-format
+msgid "Failed to inhibit sleep: %s"
+msgstr "Error al iniciar la conexión de marcado: %s"
+
+#: ../src/gtk/power.cpp:265
+msgid "Unexpected response to D-Bus \"Inhibit\" request."
+msgstr ""
+
+#: ../src/gtk/print.cpp:218
+msgid "Custom size"
+msgstr "Tamaño personalizado"
+
+#: ../src/gtk/print.cpp:752
+#, c-format
+msgid "Error while printing: %s"
+msgstr "Error al imprimir: %s"
+
+#: ../src/gtk/print.cpp:816
+msgid "Page Setup"
+msgstr "Configurar página"
+
+#: ../src/gtk/webview_webkit.cpp:932
+msgid "Retrieving JavaScript script output is not supported with WebKit v1"
+msgstr "No se puede obtener la salida de un guión JavaScript usando WebKit v1"
+
+#: ../src/gtk/webview_webkit2.cpp:1098
+msgid ""
+"Setting proxy is not supported by WebKit, at least version 2.16 is required."
+msgstr ""
+
+#: ../src/gtk/webview_webkit2.cpp:1104
+msgid "This program was compiled without support for setting WebKit proxy."
+msgstr ""
+
+#: ../src/gtk/window.cpp:6289
+msgid ""
+"GTK+ installed on this machine is too old to support screen compositing, "
+"please install GTK+ 2.12 or later."
+msgstr ""
+"El GTK+ instalado en esta máquina es demasiado antiguo para admitir la "
+"composición de pantallas; instale GTK+ 2.12 o posterior."
+
+#: ../src/gtk/window.cpp:6307
+msgid ""
+"Compositing not supported by this system, please enable it in your Window "
+"Manager."
+msgstr ""
+"El sistema no admite la composición. Actívela en su gestor de ventanas."
+
+#: ../src/gtk/window.cpp:6318
+msgid ""
+"This program was compiled with a too old version of GTK+, please rebuild "
+"with GTK+ 2.12 or newer."
+msgstr ""
+"Este programa se compiló con una versión muy antigua de GTK+. Recompílelo "
+"con GTK+ 2.12 o posterior."
+
+#: ../src/html/chm.cpp:138
+#, c-format
+msgid "Failed to open CHM archive '%s'."
+msgstr "Falló la apertura del archivador CHM «%s»."
+
+#: ../src/html/chm.cpp:270
+#, c-format
+msgid "Could not extract %s into %s: %s"
+msgstr "No se pudo extraer %s en %s: %s"
+
+#: ../src/html/chm.cpp:324
+msgid "no error"
+msgstr "no hay error"
+
+#: ../src/html/chm.cpp:326
+msgid "bad arguments to library function"
+msgstr "argumentos erróneos a la función de biblioteca"
+
+#: ../src/html/chm.cpp:328
+msgid "error opening file"
+msgstr "error al abrir el archivo"
+
+#: ../src/html/chm.cpp:330
+msgid "read error"
+msgstr "error de lectura"
+
+#: ../src/html/chm.cpp:332
+msgid "write error"
+msgstr "error de escritura"
+
+#: ../src/html/chm.cpp:334
+msgid "seek error"
+msgstr "error de búsqueda"
+
+#: ../src/html/chm.cpp:338
+msgid "bad signature"
+msgstr "firma errónea"
+
+#: ../src/html/chm.cpp:340
+msgid "error in data format"
+msgstr "error en formato de datos"
+
+#: ../src/html/chm.cpp:342
+msgid "checksum error"
+msgstr "error de suma de comprobación"
+
+#: ../src/html/chm.cpp:344
+msgid "compression error"
+msgstr "error de compresión"
+
+#: ../src/html/chm.cpp:346
+msgid "decompression error"
+msgstr "error de descompresión"
+
+#: ../src/html/chm.cpp:437
+#, c-format
+msgid "Could not locate file '%s'."
+msgstr "No se pudo encontrar el archivo '%s'."
+
+#: ../src/html/chm.cpp:711
+#, c-format
+msgid "Could not create temporary file '%s'"
+msgstr "No se pudo crear el archivo temporal '%s'"
+
+#: ../src/html/chm.cpp:718
+#, c-format
+msgid "Extraction of '%s' into '%s' failed."
+msgstr "Falló la extracción de «%s» en «%s»."
+
+#: ../src/html/chm.cpp:806 ../src/html/chm.cpp:863
+msgid "CHM handler currently supports only local files!"
+msgstr "¡El manipulador de CHM actualmente admite únicamente archivos locales!"
+
+#: ../src/html/chm.cpp:827
+msgid "Link contained '//', converted to absolute link."
+msgstr "El enlace contiene «//»; se ha convertido en enlace absoluto."
+
+#: ../src/html/helpctrl.cpp:59
+#, c-format
+msgid "Help: %s"
+msgstr "Ayuda: %s"
+
+#: ../src/html/helpctrl.cpp:155
+#, c-format
+msgid "Adding book %s"
+msgstr "Añadiendo libro %s"
+
+#: ../src/html/helpdata.cpp:295
+#, c-format
+msgid "Cannot open contents file: %s"
+msgstr "No se puede abrir el archivo de contenidos: %s"
+
+#: ../src/html/helpdata.cpp:309
+#, c-format
+msgid "Cannot open index file: %s"
+msgstr "No se puede abrir el archivo de índice: %s"
+
+#: ../src/html/helpdata.cpp:643
+msgid "noname"
+msgstr "anónimo"
+
+#: ../src/html/helpdata.cpp:652
+#, c-format
+msgid "Cannot open HTML help book: %s"
+msgstr "No se puede abrir el libro de ayuda HTML: %s"
+
+#: ../src/html/helpwnd.cpp:315
+msgid "Displays help as you browse the books on the left."
+msgstr "Muestra la ayuda mientras revisa los libros a la izquierda."
+
+#: ../src/html/helpwnd.cpp:411 ../src/html/helpwnd.cpp:1100
+#: ../src/html/helpwnd.cpp:1735
+msgid "(bookmarks)"
+msgstr "(favoritos)"
+
+#: ../src/html/helpwnd.cpp:424
+msgid "Add current page to bookmarks"
+msgstr "Añadir página actual a Marcadores"
+
+#: ../src/html/helpwnd.cpp:425
+msgid "Remove current page from bookmarks"
+msgstr "Eliminar la página actual de favoritos"
+
+#: ../src/html/helpwnd.cpp:470
+msgid "Contents"
+msgstr "Contenidos"
+
+#: ../src/html/helpwnd.cpp:485
+msgid "Find"
+msgstr "Buscar"
+
+#: ../src/html/helpwnd.cpp:487
+msgid "Show all"
+msgstr "Mostrar todo"
+
+#: ../src/html/helpwnd.cpp:497
+msgid ""
+"Display all index items that contain given substring. Search is case "
+"insensitive."
+msgstr ""
+"Mostrar todos los elementos del índice que contengan la subcadena dada. La "
+"búsqueda es Insensitiva."
+
+#: ../src/html/helpwnd.cpp:498
+msgid "Show all items in index"
+msgstr "Mostrar todos los datos en el índice"
+
+#: ../src/html/helpwnd.cpp:528
+msgid "Case sensitive"
+msgstr "Distingue mayúsculas y minúsculas"
+
+#: ../src/html/helpwnd.cpp:529
+msgid "Whole words only"
+msgstr "Sólo palabras completas"
+
+#: ../src/html/helpwnd.cpp:532
+msgid ""
+"Search contents of help book(s) for all occurrences of the text you typed "
+"above"
+msgstr ""
+"Buscar en los libros de ayuda todas las apariciones del texto que ha escrito"
+
+#: ../src/html/helpwnd.cpp:653
+msgid "Show/hide navigation panel"
+msgstr "Mostrar/ocultar panel de navegación"
+
+#: ../src/html/helpwnd.cpp:655
+msgid "Go back"
+msgstr "Retroceder"
+
+#: ../src/html/helpwnd.cpp:656
+msgid "Go forward"
+msgstr "Avanzar"
+
+#: ../src/html/helpwnd.cpp:658
+msgid "Go one level up in document hierarchy"
+msgstr "Subir un nivel en la jerarquía del documento"
+
+#: ../src/html/helpwnd.cpp:666 ../src/html/helpwnd.cpp:1547
+msgid "Open HTML document"
+msgstr "Abrir documento HTML"
+
+#: ../src/html/helpwnd.cpp:670
+msgid "Print this page"
+msgstr "Imprimir esta página"
+
+#: ../src/html/helpwnd.cpp:674
+msgid "Display options dialog"
+msgstr "Mostrar el diálogo de opciones"
+
+#: ../src/html/helpwnd.cpp:795
+msgid "Please choose the page to display:"
+msgstr "Elija la página que quiera mostrar:"
+
+#: ../src/html/helpwnd.cpp:796
+msgid "Help Topics"
+msgstr "Temas de ayuda"
+
+#: ../src/html/helpwnd.cpp:852
+msgid "Searching..."
+msgstr "Buscando…"
+
+#: ../src/html/helpwnd.cpp:853
+msgid "No matching page found yet"
+msgstr "Todavía no se ha encontrado una página con coincidencias"
+
+#: ../src/html/helpwnd.cpp:870
+#, c-format
+msgid "Found %i matches"
+msgstr "Se encontraron %i coincidencias"
+
+#: ../src/html/helpwnd.cpp:958
+msgid "(Help)"
+msgstr "(Ayuda)"
+
+#: ../src/html/helpwnd.cpp:1026
+#, c-format
+msgid "%d of %lu"
+msgstr "%d de %lu"
+
+#: ../src/html/helpwnd.cpp:1028
+#, c-format
+msgid "%lu of %lu"
+msgstr "%lu de %lu"
+
+#: ../src/html/helpwnd.cpp:1047
+msgid "Search in all books"
+msgstr "Buscar en todos los libros"
+
+#: ../src/html/helpwnd.cpp:1193
+msgid "Help Browser Options"
+msgstr "Opciones del Navegador de ayuda"
+
+#: ../src/html/helpwnd.cpp:1198
+msgid "Normal font:"
+msgstr "Tipo de letra normal:"
+
+#: ../src/html/helpwnd.cpp:1199
+msgid "Fixed font:"
+msgstr "Tipo monoespaciado:"
+
+#: ../src/html/helpwnd.cpp:1200
+msgid "Font size:"
+msgstr "Tamaño de letra:"
+
+#: ../src/html/helpwnd.cpp:1245
+msgid "font size"
+msgstr "tamaño de fuente"
+
+#: ../src/html/helpwnd.cpp:1256
+msgid "Normal face<br>and <u>underlined</u>. "
+msgstr "Tipo de letra normal<br>y <u>subrayado</u>. "
+
+#: ../src/html/helpwnd.cpp:1257
+msgid "<i>Italic face.</i> "
+msgstr "<i>Cursiva.</i> "
+
+#: ../src/html/helpwnd.cpp:1258
+msgid "<b>Bold face.</b> "
+msgstr "<b>Negrita.</b> "
+
+#: ../src/html/helpwnd.cpp:1259
+msgid "<b><i>Bold italic face.</i></b><br>"
+msgstr "<b><i>Negrita cursiva.</i></b><br>"
+
+#: ../src/html/helpwnd.cpp:1262
+msgid "Fixed size face.<br> <b>bold</b> <i>italic</i> "
+msgstr "Tipo de letra de tamaño fijo.<br> <b>negrita</b> <i>cursiva</i> "
+
+#: ../src/html/helpwnd.cpp:1263
+msgid "<b><i>bold italic <u>underlined</u></i></b><br>"
+msgstr "<b><i>negrita cursiva <u>subrayada</u></i></b><br>"
+
+#: ../src/html/helpwnd.cpp:1524
+msgid "Help Printing"
+msgstr "Ayuda de impresión"
+
+#: ../src/html/helpwnd.cpp:1527
+msgid "Cannot print empty page."
+msgstr "No se puede imprimir una página vacía."
+
+#: ../src/html/helpwnd.cpp:1540
+msgid "HTML files (*.html;*.htm)|*.html;*.htm|"
+msgstr "Archivos HTML (*.html;*.htm)|*.html;*.htm|"
+
+#: ../src/html/helpwnd.cpp:1541
+msgid "Help books (*.htb)|*.htb|Help books (*.zip)|*.zip|"
+msgstr "Libros de ayuda (*.htb)|*.htb|Libros de ayuda (*.zip)|*.zip|"
+
+#: ../src/html/helpwnd.cpp:1542
+msgid "HTML Help Project (*.hhp)|*.hhp|"
+msgstr "Proyecto de ayuda HTML (*.hhp)|*.hhp|"
+
+#: ../src/html/helpwnd.cpp:1544
+msgid "Compressed HTML Help file (*.chm)|*.chm|"
+msgstr "Archivo de ayuda HTML comprimido (*.chm)|*.chm|"
+
+#: ../src/html/helpwnd.cpp:1671
+#, c-format
+msgid "%i of %u"
+msgstr "%i de %u"
+
+#: ../src/html/helpwnd.cpp:1709
+#, c-format
+msgid "%u of %u"
+msgstr "%u de %u"
+
+#: ../src/html/htmlfilt.cpp:134
+#, c-format
+msgid "Cannot open HTML document: %s"
+msgstr "No se puede abrir el documento HTML: %s"
+
+#: ../src/html/htmlwin.cpp:599
+msgid "Connecting..."
+msgstr "Conectando…"
+
+#: ../src/html/htmlwin.cpp:616
+#, c-format
+msgid "Unable to open requested HTML document: %s"
+msgstr "Incapaz de abrir el docuemento HTML pedido: %s"
+
+#: ../src/html/htmlwin.cpp:630
+msgid "Loading : "
+msgstr "Cargando: "
+
+#: ../src/html/htmlwin.cpp:673
+msgid "Done"
+msgstr "Hecho"
+
+#: ../src/html/htmlwin.cpp:723
+#, c-format
+msgid "HTML anchor %s does not exist."
+msgstr "El anclaje HTML %s no existe."
+
+#: ../src/html/htmlwin.cpp:1057
+#, c-format
+msgid "Copied to clipboard:\"%s\""
+msgstr "Copiado en el portapapeles:\"%s\""
+
+#: ../src/html/htmprint.cpp:269
+msgid ""
+"This document doesn't fit on the page horizontally and will be truncated "
+"when it is printed."
+msgstr ""
+"Este documento no cabe horizontalmente en la página y será truncado al "
+"imprimirlo."
+
+#: ../src/html/htmprint.cpp:285
+#, c-format
+msgid ""
+"The document \"%s\" doesn't fit on the page horizontally and will be "
+"truncated if printed.\n"
+"\n"
+"Would you like to proceed with printing it nevertheless?"
+msgstr ""
+"El documento \"%s\" no cabe horizontalmente en la página y será truncado si "
+"se imprime.\n"
+"\n"
+"¿Quiere imprimirlo de todas formas?"
+
+#: ../src/html/htmprint.cpp:296
+msgid ""
+"If possible, try changing the layout parameters to make the printout more "
+"narrow."
+msgstr ""
+"Si es posible, intente cambiar los parámetros para hacer la impresión más "
+"estrecha."
+
+#: ../src/html/htmprint.cpp:445
+msgid ": file does not exist!"
+msgstr ": ¡el archivo no existe!"
+
+#. TRANSLATORS: %s may be a document title.
+#: ../src/html/htmprint.cpp:717
+#, fuzzy, c-format
+msgid "%s Preview"
+msgstr " Previsualización"
+
+#: ../src/html/htmprint.cpp:755 ../src/richtext/richtextprint.cpp:618
+msgid ""
+"There was a problem during page setup: you may need to set a default printer."
+msgstr ""
+"Hubo un problema al configurar la página: se necesita una impresora "
+"predeterminada."
+
+#: ../src/msw/clipbrd.cpp:80
+msgid "Failed to open the clipboard."
+msgstr "Falló la apertura del portapapeles."
+
+#: ../src/msw/clipbrd.cpp:101
+msgid "Failed to close the clipboard."
+msgstr "Error al cerrar el portapapeles."
+
+#: ../src/msw/clipbrd.cpp:113
+msgid "Failed to empty the clipboard."
+msgstr "Fallo al vaciar el portapapeles."
+
+#: ../src/msw/clipbrd.cpp:284
+msgid "Failed to put data on the clipboard"
+msgstr "Falló la transferencia de datos al portapapeles"
+
+#: ../src/msw/clipbrd.cpp:326
+msgid "Failed to get data from the clipboard"
+msgstr "Error al obtener datos del portapapeles"
+
+#: ../src/msw/clipbrd.cpp:363
+msgid "Failed to retrieve the supported clipboard formats"
+msgstr "Falló la recuperación de los formatos admitidos del portapapeles"
+
+#: ../src/msw/colordlg.cpp:228
+#, c-format
+msgid "Colour selection dialog failed with error %0lx."
+msgstr "El diálogo de selección de color falló con error %0lx."
+
+#: ../src/msw/cursor.cpp:141
+msgid "Failed to create cursor."
+msgstr "Falló la creación del cursor."
+
+#: ../src/msw/dde.cpp:279
+#, c-format
+msgid "Failed to register DDE server '%s'"
+msgstr "Error al registrar el servidor DDE '%s'"
+
+#: ../src/msw/dde.cpp:300
+#, c-format
+msgid "Failed to unregister DDE server '%s'"
+msgstr "Error al desregistrar el servidor DDE '%s'"
+
+#: ../src/msw/dde.cpp:428
+#, c-format
+msgid "Failed to create connection to server '%s' on topic '%s'"
+msgstr "Falló la creación de la conexión con el servidor «%s» en «%s»"
+
+#: ../src/msw/dde.cpp:655
+msgid "DDE poke request failed"
+msgstr "Falló la petición de rastreo DDE"
+
+#: ../src/msw/dde.cpp:674
+msgid "Failed to establish an advise loop with DDE server"
+msgstr "Fallo al establecer un lazo de aviso con el servidor DDE"
+
+#: ../src/msw/dde.cpp:693
+msgid "Failed to terminate the advise loop with DDE server"
+msgstr "Error al terminar el bucle de aviso con el servidor DDE"
+
+#: ../src/msw/dde.cpp:768
+msgid "Failed to send DDE advise notification"
+msgstr "Fallo al enviar notificación de aviso DDE"
+
+#: ../src/msw/dde.cpp:1085
+msgid "Failed to create DDE string"
+msgstr "Fallo al crear cadena DDE"
+
+#: ../src/msw/dde.cpp:1131
+msgid "no DDE error."
+msgstr "no hay error DDE."
+
+#: ../src/msw/dde.cpp:1135
+msgid "a request for a synchronous advise transaction has timed out."
+msgstr "una petición para una transación síncrona ha finalizado."
+
+#: ../src/msw/dde.cpp:1138
+msgid "the response to the transaction caused the DDE_FBUSY bit to be set."
+msgstr "la respuesta a la transacción causó que se activase el bit DDE_FBUSY."
+
+#: ../src/msw/dde.cpp:1141
+msgid "a request for a synchronous data transaction has timed out."
+msgstr "una petición para una transacción de datos síncrona ha finalizado."
+
+#: ../src/msw/dde.cpp:1144
+msgid ""
+"a DDEML function was called without first calling the DdeInitialize "
+"function,\n"
+"or an invalid instance identifier\n"
+"was passed to a DDEML function."
+msgstr ""
+"una función DDEML fue llamada sin llamar primero a la función "
+"DdeInitialize,\n"
+"o se pasó un identificador de instancia no válido\n"
+"a una función DDEML."
+
+#: ../src/msw/dde.cpp:1147
+msgid ""
+"an application initialized as APPCLASS_MONITOR has\n"
+"attempted to perform a DDE transaction,\n"
+"or an application initialized as APPCMD_CLIENTONLY has \n"
+"attempted to perform server transactions."
+msgstr ""
+"una aplicación inicializada como APPCLASS_MONITOR ha\n"
+"intentado llevar a cabo una transacción DDE,\n"
+"o una aplicación inicializada como APPCMD_CLIENTONLY ha\n"
+"intentado realizar transacciones de servidor."
+
+#: ../src/msw/dde.cpp:1150
+msgid "a request for a synchronous execute transaction has timed out."
+msgstr "una petición para una transación de ejecución síncrona ha finalizado."
+
+#: ../src/msw/dde.cpp:1153
+msgid "a parameter failed to be validated by the DDEML."
+msgstr "fallo al validar un parémetro por DDEML."
+
+#: ../src/msw/dde.cpp:1156
+msgid "a DDEML application has created a prolonged race condition."
+msgstr "una aplicación DDEML ha creado una condición acelerada prolongada."
+
+#: ../src/msw/dde.cpp:1159
+msgid "a memory allocation failed."
+msgstr "fallo al reservar memoria."
+
+#: ../src/msw/dde.cpp:1162
+msgid "a client's attempt to establish a conversation has failed."
+msgstr "el intento de un cliente de establece conversación falló."
+
+#: ../src/msw/dde.cpp:1165
+msgid "a transaction failed."
+msgstr "fallo en la transacción."
+
+#: ../src/msw/dde.cpp:1168
+msgid "a request for a synchronous poke transaction has timed out."
+msgstr "una petición para una transacción síncrona de revisión ha finalizado."
+
+#: ../src/msw/dde.cpp:1171
+msgid "an internal call to the PostMessage function has failed. "
+msgstr "ha fallado una llamada interna a la función PostMessage. "
+
+#: ../src/msw/dde.cpp:1174
+msgid "reentrancy problem."
+msgstr "problema de reentrada."
+
+#: ../src/msw/dde.cpp:1177
+msgid ""
+"a server-side transaction was attempted on a conversation\n"
+"that was terminated by the client, or the server\n"
+"terminated before completing a transaction."
+msgstr ""
+"se intentó una transacción de servidor en una conversación\n"
+"que fue finalizada por el cliente, o el servidor\n"
+"terminó antes de completar una transacción."
+
+#: ../src/msw/dde.cpp:1180
+msgid "an internal error has occurred in the DDEML."
+msgstr "ha ocurrido un error interno en DDEML."
+
+#: ../src/msw/dde.cpp:1183
+msgid "a request to end an advise transaction has timed out."
+msgstr "una petición para una transacción síncrona de auditoría ha finalizado."
+
+#: ../src/msw/dde.cpp:1186
+msgid ""
+"an invalid transaction identifier was passed to a DDEML function.\n"
+"Once the application has returned from an XTYP_XACT_COMPLETE callback,\n"
+"the transaction identifier for that callback is no longer valid."
+msgstr ""
+"se pasó un identificador de transacción no válido a la función DDEML.\n"
+"Una vez que la aplicación haya retornado desde una llamada "
+"XTYP_XACT_COMPLETE,\n"
+"el identificador de la transacción para esa llamada deja de ser válido."
+
+#: ../src/msw/dde.cpp:1189
+#, c-format
+msgid "Unknown DDE error %08x"
+msgstr "Error DDE desconocido %08x"
+
+#: ../src/msw/dialup.cpp:343
+msgid ""
+"Dial up functions are unavailable because the remote access service (RAS) is "
+"not installed on this machine. Please install it."
+msgstr ""
+"Las funciones de marcado no están disponibles porque los servicios de acceso "
+"remoto (RAS) no están instalados. Por favor instálelos."
+
+#: ../src/msw/dialup.cpp:402
+#, c-format
+msgid ""
+"The version of remote access service (RAS) installed on this machine is too "
+"old, please upgrade (the following required function is missing: %s)."
+msgstr ""
+"La versión del servicio de acceso remoto (RAS) instalada en esta máquina es "
+"demasiado vieja, por favor actualícela (la función requerida no está "
+"disponible: %s)."
+
+#: ../src/msw/dialup.cpp:437
+msgid "Failed to retrieve text of RAS error message"
+msgstr "Fallo al recuperar el mensaje de error de RAS"
+
+#: ../src/msw/dialup.cpp:440
+#, c-format
+msgid "unknown error (error code %08x)."
+msgstr "error desconocido (código %08x)."
+
+#: ../src/msw/dialup.cpp:492
+#, c-format
+msgid "Cannot find active dialup connection: %s"
+msgstr "No se puede encontrar ninguna conexión telefónica activa: %s"
+
+#: ../src/msw/dialup.cpp:513
+msgid "Several active dialup connections found, choosing one randomly."
+msgstr ""
+"Se han encontrado varias conexiones activas, eligiendo una aleatoriamente."
+
+#: ../src/msw/dialup.cpp:598 ../src/msw/dialup.cpp:832
+#, c-format
+msgid "Failed to establish dialup connection: %s"
+msgstr "Fallo al establecer la conexión: %s"
+
+#: ../src/msw/dialup.cpp:664
+#, c-format
+msgid "Failed to get ISP names: %s"
+msgstr "Error al obtener nombres de ISP: %s"
+
+#: ../src/msw/dialup.cpp:712
+msgid "Failed to connect: no ISP to dial."
+msgstr "Fallo al conectar: no hay ISP al que llamar."
+
+#: ../src/msw/dialup.cpp:732
+msgid "Choose ISP to dial"
+msgstr "Elija un ISP al que conectar"
+
+#: ../src/msw/dialup.cpp:733
+msgid "Please choose which ISP do you want to connect to"
+msgstr "Elija el ISP con el que se quiera conectar"
+
+#: ../src/msw/dialup.cpp:766
+msgid "Failed to connect: missing username/password."
+msgstr "Fallo al conectar: faltan usuario/contraseña."
+
+#: ../src/msw/dialup.cpp:796
+msgid "Cannot find the location of address book file"
+msgstr "No se puede encontrar el archivo de libreta de direcciones"
+
+#: ../src/msw/dialup.cpp:827
+#, c-format
+msgid "Failed to initiate dialup connection: %s"
+msgstr "Error al iniciar la conexión de marcado: %s"
+
+#: ../src/msw/dialup.cpp:897
+msgid "Cannot hang up - no active dialup connection."
+msgstr "No se puede colgar: no hay ninguna conexión telefónica activa."
+
+#: ../src/msw/dialup.cpp:907
+#, c-format
+msgid "Failed to terminate the dialup connection: %s"
+msgstr "Error al terminar la conexión: %s"
+
+#: ../src/msw/dib.cpp:313
+#, c-format
+msgid "Failed to save the bitmap image to file \"%s\"."
+msgstr "Falló el guardado de la imagen de mapa de bits en el archivo «%s»."
+
+#: ../src/msw/dib.cpp:543
+#, c-format
+msgid "Failed to allocate %luKb of memory for bitmap data."
+msgstr ""
+"No se pudieron reservar %lu kb de memoria para los datos del mapa de bits."
+
+#: ../src/msw/dir.cpp:241
+#, c-format
+msgid "Cannot enumerate files in directory '%s'"
+msgstr "No se pueden enumerar los archivos en el directorio «%s»"
+
+#: ../src/msw/dirdlg.cpp:368
+msgid "Couldn't obtain folder name"
+msgstr "No se pudo obtener el nombre la carpeta"
+
+#: ../src/msw/dlmsw.cpp:163
+#, c-format
+msgid "(error %d: %s)"
+msgstr "(error %d: %s)"
+
+#: ../src/msw/dragimag.cpp:143 ../src/msw/dragimag.cpp:178
+#: ../src/msw/imaglist.cpp:309 ../src/msw/imaglist.cpp:331
+msgid "Couldn't add an image to the image list."
+msgstr "No se pudo añadir una imagen a la lista de imágenes."
+
+#: ../src/msw/enhmeta.cpp:94
+#, c-format
+msgid "Failed to load metafile from file \"%s\"."
+msgstr "No se pudo abrir el metaarchivo desde el archivo \"%s\"."
+
+#: ../src/msw/fdrepdlg.cpp:412
+#, c-format
+msgid "Failed to create the standard find/replace dialog (error code %d)"
+msgstr ""
+"Fallo al crear el diálogo estándar de buscar/reemplazar (código de error %d)"
+
+#: ../src/msw/filedlg.cpp:1241
+msgid "Access to the file system is not allowed from secure desktop."
+msgstr ""
+
+#: ../src/msw/filedlg.cpp:1242
+msgid "Security warning"
+msgstr "Advertencia de seguridad"
+
+#: ../src/msw/filedlg.cpp:1533
+#, c-format
+msgid "File dialog failed with error code %0lx."
+msgstr "El diálogo de archivo falló con código de error %0lx."
+
+#: ../src/msw/font.cpp:1120
+#, c-format
+msgid "Font file \"%s\" couldn't be loaded"
+msgstr "No se pudo cargar el archivo de fuente \"%s\""
+
+#: ../src/msw/fontdlg.cpp:220
+#, c-format
+msgid "Common dialog failed with error code %0lx."
+msgstr "El diálogo común falló con error %0lx."
+
+#: ../src/msw/fswatcher.cpp:67
+msgid "Ungraceful worker thread termination"
+msgstr "Terminación del hilo inapropiada"
+
+#: ../src/msw/fswatcher.cpp:81
+msgid "Unable to create IOCP worker thread"
+msgstr "No se pudo crear el hilo IOCP"
+
+#: ../src/msw/fswatcher.cpp:88
+msgid "Unable to start IOCP worker thread"
+msgstr "No se pudo iniciar el hilo IOCP"
+
+#: ../src/msw/fswatcher.cpp:140
+msgid "Monitoring individual files for changes is not supported currently."
+msgstr ""
+"Actualmente no se admite la monitorización de cambios en archivos "
+"individuales."
+
+#: ../src/msw/fswatcher.cpp:165
+#, c-format
+msgid "Unable to set up watch for '%s'"
+msgstr "No se pudo activar la vista para '%s'"
+
+#: ../src/msw/fswatcher.cpp:466
+#, c-format
+msgid "Can't monitor non-existent directory \"%s\" for changes."
+msgstr "No se pueden monitorizar los cambios del directorio inexistente «%s»."
+
+#: ../src/msw/glcanvas.cpp:577 ../src/unix/glx11.cpp:507
+msgid "OpenGL 3.0 or later is not supported by the OpenGL driver."
+msgstr "El controlador de OpenGL no admite OpenGL 3.0 o más reciente."
+
+#: ../src/msw/glcanvas.cpp:601 ../src/osx/glcanvas_osx.cpp:395
+#: ../src/unix/glegl.cpp:304 ../src/unix/glx11.cpp:553
+msgid "Couldn't create OpenGL context"
+msgstr "No se pudo crear el contexto OpenGL"
+
+#: ../src/msw/glcanvas.cpp:1294
+msgid "Failed to initialize OpenGL"
+msgstr "Falló la inicialización de OpenGL"
+
+#: ../src/msw/graphicsd2d.cpp:607
+msgid "Could not register custom DirectWrite font loader."
+msgstr "No se pudo registrar el cargador modificado de fuentes DirectWrite."
+
+#: ../src/msw/helpchm.cpp:48
+msgid ""
+"MS HTML Help functions are unavailable because the MS HTML Help library is "
+"not installed on this machine. Please install it."
+msgstr ""
+"La funciones de Ayuda MS HTML no están disponibles porque la biblioteca de "
+"Ayuda MS HTML no está instalada. Instálela."
+
+#: ../src/msw/helpchm.cpp:55
+msgid "Failed to initialize MS HTML Help."
+msgstr "Fallo al inicializar la ayuda MS HTML."
+
+#: ../src/msw/iniconf.cpp:458
+#, c-format
+msgid "Can't delete the INI file '%s'"
+msgstr "No se puede elimininar el archivo INI «%s»"
+
+#: ../src/msw/listctrl.cpp:995
+#, c-format
+msgid "Couldn't retrieve information about list control item %d."
+msgstr ""
+"No se pudo obtener información sobre el elemento de control de la lista %d."
+
+#: ../src/msw/mdi.cpp:170 ../src/qt/mdi.cpp:253
+msgid "&Cascade"
+msgstr "&Cascada"
+
+#: ../src/msw/mdi.cpp:171
+msgid "Tile &Horizontally"
+msgstr "Mosaico &horizontal"
+
+#: ../src/msw/mdi.cpp:172
+msgid "Tile &Vertically"
+msgstr "Mosaico &vertical"
+
+#: ../src/msw/mdi.cpp:174
+msgid "&Arrange Icons"
+msgstr "&Organizar iconos"
+
+#: ../src/msw/mdi.cpp:621
+msgid "Failed to create MDI parent frame."
+msgstr "Falló la creación del panel MDI padre."
+
+#: ../src/msw/mimetype.cpp:234
+#, c-format
+msgid "Failed to create registry entry for '%s' files."
+msgstr "Falló la creación de la entrada del Registro para los archivos «%s»."
+
+#: ../src/msw/ole/automtn.cpp:495
+#, c-format
+msgid "Failed to find CLSID of \"%s\""
+msgstr "No se encontró el CLSID de «%s»"
+
+#: ../src/msw/ole/automtn.cpp:512
+#, c-format
+msgid "Failed to create an instance of \"%s\""
+msgstr "Error creando una instancia de \"%s\""
+
+#: ../src/msw/ole/automtn.cpp:552
+#, c-format
+msgid "Cannot get an active instance of \"%s\""
+msgstr "No se puede obtener una instancia activa de «%s»"
+
+#: ../src/msw/ole/automtn.cpp:564
+#, c-format
+msgid "Failed to get OLE automation interface for \"%s\""
+msgstr "No se pudo obtener la interfaz de automatización OLE para \"%s\""
+
+#: ../src/msw/ole/automtn.cpp:621
+msgid "Unknown name or named argument."
+msgstr "Nombre o argumento con nombre desconocido."
+
+#: ../src/msw/ole/automtn.cpp:625
+msgid "Incorrect number of arguments."
+msgstr "Número de argumentos incorrecto."
+
+#: ../src/msw/ole/automtn.cpp:637
+msgid "Unknown exception"
+msgstr "Excepción desconocida"
+
+#: ../src/msw/ole/automtn.cpp:642
+msgid "Method or property not found."
+msgstr "No se encontró el método o la propiedad."
+
+#: ../src/msw/ole/automtn.cpp:646
+msgid "Overflow while coercing argument values."
+msgstr "Desbordamiento durante el forzado de los valores de argumentos."
+
+#: ../src/msw/ole/automtn.cpp:650
+msgid "Object implementation does not support named arguments."
+msgstr "La implementación del objeto no admite argumentos con nombre."
+
+#: ../src/msw/ole/automtn.cpp:654
+msgid "The locale ID is unknown."
+msgstr "La ID del local es desconocida."
+
+#: ../src/msw/ole/automtn.cpp:658
+msgid "Missing a required parameter."
+msgstr "Falta un parámetro requerido."
+
+#: ../src/msw/ole/automtn.cpp:662
+#, c-format
+msgid "Argument %u not found."
+msgstr "No se encontró el argumento %u."
+
+#: ../src/msw/ole/automtn.cpp:666
+#, c-format
+msgid "Type mismatch in argument %u."
+msgstr "No coincide el tipo del argumento %u."
+
+#: ../src/msw/ole/automtn.cpp:670
+msgid "The system cannot find the file specified."
+msgstr "El sistema no puede encontrar el archivo indicado."
+
+#: ../src/msw/ole/automtn.cpp:674
+msgid "Class not registered."
+msgstr "Clase no registrada."
+
+#: ../src/msw/ole/automtn.cpp:678
+#, c-format
+msgid "Unknown error %08x"
+msgstr "Error desconocido %08x"
+
+#: ../src/msw/ole/automtn.cpp:682
+#, c-format
+msgid "OLE Automation error in %s: %s"
+msgstr "Error de automatización OLE en %s: %s"
+
+#: ../src/msw/ole/dataobj.cpp:385
+#, c-format
+msgid "Couldn't register clipboard format '%s'."
+msgstr "No se pudo registrar el formato del portapapeles «%s»."
+
+#: ../src/msw/ole/dataobj.cpp:402
+#, c-format
+msgid "The clipboard format '%d' doesn't exist."
+msgstr "El formato %d del portapapeles no existe."
+
+#: ../src/msw/progdlg.cpp:1025
+msgid "Skip"
+msgstr "Saltar"
+
+#: ../src/msw/registry.cpp:141
+#, c-format
+msgid "unknown (%lu)"
+msgstr "desconocido (%lu)"
+
+#: ../src/msw/registry.cpp:409
+#, c-format
+msgid "Can't get info about registry key '%s'"
+msgstr "No se puede obtener información de la clave del Registro «%s»"
+
+#: ../src/msw/registry.cpp:445
+#, c-format
+msgid "Can't open registry key '%s'"
+msgstr "No se puede abrir la clave del registro «%s»"
+
+#: ../src/msw/registry.cpp:478
+#, c-format
+msgid "Can't create registry key '%s'"
+msgstr "No se puede crear la clave del Registro «%s»"
+
+#: ../src/msw/registry.cpp:497
+#, c-format
+msgid "Can't close registry key '%s'"
+msgstr "No se puede cerrar la clave del Registro «%s»"
+
+#: ../src/msw/registry.cpp:512
+#, c-format
+msgid "Registry value '%s' already exists."
+msgstr "La clave del registro '%s' ya existe."
+
+#: ../src/msw/registry.cpp:520
+#, c-format
+msgid "Failed to rename registry value '%s' to '%s'."
+msgstr "Fallo al renombrar valor del registro '%s' a '%s'."
+
+#: ../src/msw/registry.cpp:575
+#, c-format
+msgid "Can't copy values of unsupported type %d."
+msgstr "No se pueden copiar valores del tipo no admitido %d."
+
+#: ../src/msw/registry.cpp:586
+#, c-format
+msgid "Registry key '%s' does not exist, cannot rename it."
+msgstr "La clave del registro '%s' no existe, no se puede renombrar."
+
+#: ../src/msw/registry.cpp:617
+#, c-format
+msgid "Registry key '%s' already exists."
+msgstr "La clave del registro '%s' ya existe."
+
+#: ../src/msw/registry.cpp:625
+#, c-format
+msgid "Failed to rename the registry key '%s' to '%s'."
+msgstr "Error al renombrar la clave del registro '%s' a '%s'."
+
+#: ../src/msw/registry.cpp:670
+#, c-format
+msgid "Failed to copy the registry subkey '%s' to '%s'."
+msgstr "Error al copiar la subclave del registro '%s' en '%s'."
+
+#: ../src/msw/registry.cpp:683
+#, c-format
+msgid "Failed to copy registry value '%s'"
+msgstr "Falló la copia del valor del Registro «%s»"
+
+#: ../src/msw/registry.cpp:692
+#, c-format
+msgid "Failed to copy the contents of registry key '%s' to '%s'."
+msgstr "Fallo al copiar los contenidos de la clave del registro '%s' a '%s'."
+
+#: ../src/msw/registry.cpp:718
+#, c-format
+msgid ""
+"Registry key '%s' is needed for normal system operation,\n"
+"deleting it will leave your system in unusable state:\n"
+"operation aborted."
+msgstr ""
+"La clave del registro '%s' se necesita para el funcionamiento normal del "
+"sistema,\n"
+"si se elimina puede dejar el sistema en un estado inestable:\n"
+"operación abortada."
+
+#: ../src/msw/registry.cpp:754
+#, c-format
+msgid "Can't delete key '%s'"
+msgstr "No se puede eliminar la clave «%s»"
+
+#: ../src/msw/registry.cpp:782
+#, c-format
+msgid "Can't delete value '%s' from key '%s'"
+msgstr "No se puede eliminar el valor «%s» de la clave «%s»"
+
+#: ../src/msw/registry.cpp:855 ../src/msw/registry.cpp:887
+#: ../src/msw/registry.cpp:929 ../src/msw/registry.cpp:1000
+#, c-format
+msgid "Can't read value of key '%s'"
+msgstr "No se puede leer el valor de la clave «%s»"
+
+#: ../src/msw/registry.cpp:873 ../src/msw/registry.cpp:915
+#: ../src/msw/registry.cpp:963 ../src/msw/registry.cpp:1106
+#, c-format
+msgid "Can't set value of '%s'"
+msgstr "No se puede establecer el valor de «%s»"
+
+#: ../src/msw/registry.cpp:894 ../src/msw/registry.cpp:943
+#, c-format
+msgid "Registry value \"%s\" is not numeric (but of type %s)"
+msgstr "El valor del Registro «%s» no es numérico (sino del tipo %s)"
+
+#: ../src/msw/registry.cpp:979
+#, c-format
+msgid "Registry value \"%s\" is not binary (but of type %s)"
+msgstr "El valor del Registro «%s» no es binario (sino del tipo %s)"
+
+#: ../src/msw/registry.cpp:1028
+#, c-format
+msgid "Registry value \"%s\" is not text (but of type %s)"
+msgstr "El valor del Registro «%s» no es de texto (sino del tipo %s)"
+
+#: ../src/msw/registry.cpp:1089
+#, c-format
+msgid "Can't read value of '%s'"
+msgstr "No se puede leer el valor de «%s»"
+
+#: ../src/msw/registry.cpp:1157
+#, c-format
+msgid "Can't enumerate values of key '%s'"
+msgstr "No se pueden enumerar los valores de la clave «%s»"
+
+#: ../src/msw/registry.cpp:1196
+#, c-format
+msgid "Can't enumerate subkeys of key '%s'"
+msgstr "No se pueden enumerar las subclaves de la clave «%s»"
+
+#: ../src/msw/registry.cpp:1262
+#, c-format
+msgid ""
+"Exporting registry key: file \"%s\" already exists and won't be overwritten."
+msgstr ""
+"Exportando clave de Registro: el archivo «%s» ya existe y no se "
+"sobrescribirá."
+
+#: ../src/msw/registry.cpp:1411
+#, c-format
+msgid "Can't export value of unsupported type %d."
+msgstr "No se puede exportar el valor del tipo no admitido %d."
+
+#: ../src/msw/registry.cpp:1427
+#, c-format
+msgid "Ignoring value \"%s\" of the key \"%s\"."
+msgstr "Se ignora el valor «%s» de la clave «%s»."
+
+#: ../src/msw/textctrl.cpp:596
+msgid ""
+"Impossible to create a rich edit control, using simple text control instead. "
+"Please reinstall riched32.dll"
+msgstr ""
+"Imposible crear control 'rich edit', se usará el control de texto simple. "
+"Por favor instale riched32.dll"
+
+#: ../src/msw/thread.cpp:522 ../src/unix/threadpsx.cpp:850
+msgid "Cannot start thread: error writing TLS."
+msgstr "No se puede iniciar el hilo de ejecución: error al escribir TLS."
+
+#: ../src/msw/thread.cpp:613
+msgid "Can't set thread priority"
+msgstr "No se puede establecer la prioridad del hilo de ejecución"
+
+#: ../src/msw/thread.cpp:649
+msgid "Can't create thread"
+msgstr "No se puede crear el hilo de ejecución"
+
+#: ../src/msw/thread.cpp:668
+msgid "Couldn't terminate thread"
+msgstr "No se pudo finalizar el hilo de ejecución"
+
+#: ../src/msw/thread.cpp:799
+msgid "Cannot wait for thread termination"
+msgstr "No se puede esperar a la finalización del hilo de ejecución"
+
+#: ../src/msw/thread.cpp:873
+#, c-format
+msgid "Cannot suspend thread %lx"
+msgstr "No se puede suspender el hilo de ejecución %lx"
+
+#: ../src/msw/thread.cpp:903
+#, c-format
+msgid "Cannot resume thread %lx"
+msgstr "No se puede reanudar el hilo de ejecución %lx"
+
+#: ../src/msw/thread.cpp:932
+msgid "Couldn't get the current thread pointer"
+msgstr "No se pudo obtener el puntero al hilo de ejecución actual"
+
+#: ../src/msw/thread.cpp:1333
+msgid ""
+"Thread module initialization failed: impossible to allocate index in thread "
+"local storage"
+msgstr ""
+"Error en la inicialización del módulo de hilos de ejecución: imposible "
+"reservar índice en el almacen local de hilos"
+
+#: ../src/msw/thread.cpp:1345
+msgid ""
+"Thread module initialization failed: cannot store value in thread local "
+"storage"
+msgstr ""
+"Error en la inicialización del módulo de hilos de ejecución: no se pudo "
+"almacenar valor en el almacén local de hilos"
+
+#: ../src/msw/timer.cpp:133
+msgid "Couldn't create a timer"
+msgstr "No se pudo crear un temporizador"
+
+#: ../src/msw/utils.cpp:372
+msgid "can't find user's HOME, using current directory."
+msgstr ""
+"no se encontró el directorio HOME del usuario; se usa el directorio actual."
+
+#: ../src/msw/utils.cpp:662
+#, c-format
+msgid "Failed to kill process %d"
+msgstr "No se pudo matar el proceso %d"
+
+#: ../src/msw/utils.cpp:986
+#, c-format
+msgid "Failed to load resource \"%s\"."
+msgstr "Falló la carga del recurso «%s»."
+
+#: ../src/msw/utils.cpp:993
+#, c-format
+msgid "Failed to lock resource \"%s\"."
+msgstr "Falló el bloqueo del recurso «%s»."
+
+#. TRANSLATORS: MS Windows build number
+#: ../src/msw/utils.cpp:1209
+#, c-format
+msgid "build %lu"
+msgstr "compilación %lu"
+
+#: ../src/msw/utils.cpp:1218
+msgid ", 64-bit edition"
+msgstr ", edición de 64 bits"
+
+#: ../src/msw/utilsexc.cpp:224
+msgid "Failed to create an anonymous pipe"
+msgstr "Fallo al crear tubería anónima"
+
+#: ../src/msw/utilsexc.cpp:697
+msgid "Failed to redirect the child process IO"
+msgstr "Error en la redirección de la entrada/salida del proceso hijo"
+
+#: ../src/msw/utilsexc.cpp:870
+#, c-format
+msgid "Execution of command '%s' failed"
+msgstr "Falló la ejecución de la orden «%s»"
+
+#: ../src/msw/volume.cpp:337
+msgid "Failed to load mpr.dll."
+msgstr "No se pudo cargar mpr.dll."
+
+#: ../src/msw/volume.cpp:506
+#, c-format
+msgid "Cannot read typename from '%s'!"
+msgstr "¡No se puede leer el nombre del tipo desde '%s'!"
+
+#: ../src/msw/volume.cpp:615
+#, c-format
+msgid "Cannot load icon from '%s'."
+msgstr "No se puede cargar el icono desde «%s»."
+
+#: ../src/msw/webview_edge.cpp:285
+msgid "This program was compiled without support for setting Edge proxy."
+msgstr ""
+
+#: ../src/msw/webview_ie.cpp:1010
+msgid "Failed to find web view emulation level in the registry"
+msgstr ""
+"No se pudo encontrar el nivel de emulación de la vista web en el registro"
+
+#: ../src/msw/webview_ie.cpp:1019
+msgid "Failed to set web view to modern emulation level"
+msgstr "No se pudo cambiar el nivel moderno de emuilación web"
+
+#: ../src/msw/webview_ie.cpp:1027
+msgid "Failed to reset web view to standard emulation level"
+msgstr "No se pudo restaurar el nivel estándar de emulación web"
+
+#: ../src/msw/webview_ie.cpp:1049
+msgid "Can't run JavaScript script without a valid HTML document"
+msgstr "No se puede ejecutar un guión JavaScript sin un documento HTML válido"
+
+#: ../src/msw/webview_ie.cpp:1056
+msgid "Can't get the JavaScript object"
+msgstr "No se puede obtener el objeto JavaScript"
+
+#: ../src/msw/webview_ie.cpp:1070
+msgid "failed to evaluate"
+msgstr "fallo al evaluar"
+
+#: ../src/osx/cocoa/filedlg.mm:412
+msgid "File type:"
+msgstr "Tipo de archivo:"
+
+#: ../src/osx/cocoa/menu.mm:242
+msgctxt "macOS menu name"
+msgid "Window"
+msgstr "Ventana"
+
+#: ../src/osx/cocoa/menu.mm:259
+msgctxt "macOS menu name"
+msgid "Help"
+msgstr "Ayuda"
+
+#: ../src/osx/cocoa/menu.mm:298
+msgctxt "macOS menu item"
+msgid "Minimize"
+msgstr "Minimizar"
+
+#: ../src/osx/cocoa/menu.mm:303
+msgctxt "macOS menu item"
+msgid "Zoom"
+msgstr "Acercar"
+
+#: ../src/osx/cocoa/menu.mm:309
+msgctxt "macOS menu item"
+msgid "Bring All to Front"
+msgstr "Traer todo al primer plano"
+
+#: ../src/osx/core/sound.cpp:143
+#, c-format
+msgid "Failed to load sound from \"%s\" (error %d)."
+msgstr "No se pudo cargar el sonido de \"%s\" (error %d)."
+
+#: ../src/osx/fontutil.cpp:80
+#, c-format
+msgid "Font file \"%s\" doesn't exist."
+msgstr "El archivo de fuente \"%s\" no existe."
+
+#: ../src/osx/fontutil.cpp:88
+#, c-format
+msgid ""
+"Font file \"%s\" cannot be used as it is not inside the font directory "
+"\"%s\"."
+msgstr ""
+"No se puede usar el archivo de fuente \"%s\" porque no está en la carpeta de "
+"fuentes \"%s\"."
+
+#: ../src/osx/menu_osx.cpp:496
+#, c-format
+msgctxt "macOS menu item"
+msgid "About %s"
+msgstr "Acerca de %s"
+
+#: ../src/osx/menu_osx.cpp:499
+msgctxt "macOS menu item"
+msgid "About..."
+msgstr "Acerca de…"
+
+#: ../src/osx/menu_osx.cpp:508
+msgctxt "macOS menu item"
+msgid "Preferences..."
+msgstr "Preferencias..."
+
+#: ../src/osx/menu_osx.cpp:512
+msgctxt "macOS menu item"
+msgid "Services"
+msgstr "Servicios"
+
+#: ../src/osx/menu_osx.cpp:519
+#, c-format
+msgctxt "macOS menu item"
+msgid "Hide %s"
+msgstr "Ocultar %s"
+
+#: ../src/osx/menu_osx.cpp:522
+msgctxt "macOS menu item"
+msgid "Hide Application"
+msgstr "Ocultar aplicación"
+
+#: ../src/osx/menu_osx.cpp:526
+msgctxt "macOS menu item"
+msgid "Hide Others"
+msgstr "Ocultar otros"
+
+#: ../src/osx/menu_osx.cpp:528
+msgctxt "macOS menu item"
+msgid "Show All"
+msgstr "Mostrar todo"
+
+#: ../src/osx/menu_osx.cpp:534
+#, c-format
+msgctxt "macOS menu item"
+msgid "Quit %s"
+msgstr "Salir de %s"
+
+#: ../src/osx/menu_osx.cpp:537
+msgctxt "macOS menu item"
+msgid "Quit Application"
+msgstr "Salir de la aplicación"
+
+#: ../src/osx/webview_webkit.mm:444
+msgid "Printing is not supported by the system web control"
+msgstr "El control web no soporta la impresión"
+
+#: ../src/osx/webview_webkit.mm:453
+msgid "Print operation could not be initialized"
+msgstr "No se pudo inicializar la operación de impresión"
+
+#. TRANSLATORS: Label of font point size
+#: ../src/propgrid/advprops.cpp:605
+msgid "Point Size"
+msgstr "Tamaño de punto"
+
+#. TRANSLATORS: Label of font face name
+#: ../src/propgrid/advprops.cpp:615
+msgid "Face Name"
+msgstr "Nombre del tipo de letra"
+
+#. TRANSLATORS: Label of font style
+#: ../src/propgrid/advprops.cpp:623 ../src/richtext/richtextformatdlg.cpp:331
+msgid "Style"
+msgstr "Estilo"
+
+#. TRANSLATORS: Label of font weight
+#: ../src/propgrid/advprops.cpp:628
+msgid "Weight"
+msgstr "Peso"
+
+#. TRANSLATORS: Label of underlined font
+#: ../src/propgrid/advprops.cpp:633 ../src/richtext/richtextfontpage.cpp:358
+msgid "Underlined"
+msgstr "Subrayado"
+
+#. TRANSLATORS: Label of font family
+#: ../src/propgrid/advprops.cpp:637
+msgid "Family"
+msgstr "Familia"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:801
+msgid "AppWorkspace"
+msgstr "AppWorkspace"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:802
+msgid "ActiveBorder"
+msgstr "ActiveBorder"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:803
+msgid "ActiveCaption"
+msgstr "ActiveCaption"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:804
+msgid "ButtonFace"
+msgstr "ButtonFace"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:805
+msgid "ButtonHighlight"
+msgstr "ButtonHighlight"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:806
+msgid "ButtonShadow"
+msgstr "ButtonShadow"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:807
+msgid "ButtonText"
+msgstr "ButtonText"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:808
+msgid "CaptionText"
+msgstr "CaptionText"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:809
+msgid "ControlDark"
+msgstr "ControlDark"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:810
+msgid "ControlLight"
+msgstr "ControlLight"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:812
+msgid "GrayText"
+msgstr "GrayText"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:813
+msgid "Highlight"
+msgstr "Highlight"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:814
+msgid "HighlightText"
+msgstr "HighlightText"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:815
+msgid "InactiveBorder"
+msgstr "InactiveBorder"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:816
+msgid "InactiveCaption"
+msgstr "InactiveCaption"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:817
+msgid "InactiveCaptionText"
+msgstr "InactiveCaptionText"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:818
+msgid "Menu"
+msgstr "Menú"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:819
+msgid "Scrollbar"
+msgstr "Barra de desplazamiento"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:820
+msgid "Tooltip"
+msgstr "Pista"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:821
+msgid "TooltipText"
+msgstr "TooltipText"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:822
+msgid "Window"
+msgstr "Ventana"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:823
+msgid "WindowFrame"
+msgstr "WindowFrame"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:824
+msgid "WindowText"
+msgstr "WindowText"
+
+#. TRANSLATORS: Custom colour choice entry
+#: ../src/propgrid/advprops.cpp:825 ../src/propgrid/advprops.cpp:1532
+#: ../src/propgrid/advprops.cpp:1576
+msgid "Custom"
+msgstr "Personalizado"
+
+#: ../src/propgrid/advprops.cpp:1558
+msgid "Black"
+msgstr "Negro"
+
+#: ../src/propgrid/advprops.cpp:1559
+msgid "Maroon"
+msgstr "Marrón"
+
+#: ../src/propgrid/advprops.cpp:1560
+msgid "Navy"
+msgstr "Azul marino"
+
+#: ../src/propgrid/advprops.cpp:1561
+msgid "Purple"
+msgstr "Morado"
+
+#: ../src/propgrid/advprops.cpp:1562
+msgid "Teal"
+msgstr "Turquesa"
+
+#: ../src/propgrid/advprops.cpp:1563
+msgid "Gray"
+msgstr "Gris"
+
+#: ../src/propgrid/advprops.cpp:1564
+msgid "Green"
+msgstr "Verde"
+
+#: ../src/propgrid/advprops.cpp:1565
+msgid "Olive"
+msgstr "Aceituna"
+
+#: ../src/propgrid/advprops.cpp:1566
+msgid "Brown"
+msgstr "Marrón"
+
+#: ../src/propgrid/advprops.cpp:1567
+msgid "Blue"
+msgstr "Azul"
+
+#: ../src/propgrid/advprops.cpp:1568
+msgid "Fuchsia"
+msgstr "Fucsia"
+
+#: ../src/propgrid/advprops.cpp:1569
+msgid "Red"
+msgstr "Rojo"
+
+#: ../src/propgrid/advprops.cpp:1570
+msgid "Orange"
+msgstr "Naranja"
+
+#: ../src/propgrid/advprops.cpp:1571
+msgid "Silver"
+msgstr "Plata"
+
+#: ../src/propgrid/advprops.cpp:1572
+msgid "Lime"
+msgstr "Lima"
+
+#: ../src/propgrid/advprops.cpp:1573
+msgid "Aqua"
+msgstr "Aguamarina"
+
+#: ../src/propgrid/advprops.cpp:1574
+msgid "Yellow"
+msgstr "Amarillo"
+
+#: ../src/propgrid/advprops.cpp:1575
+msgid "White"
+msgstr "Blanco"
+
+#: ../src/propgrid/advprops.cpp:1718
+msgctxt "system cursor name"
+msgid "Default"
+msgstr "Predeterminado"
+
+#: ../src/propgrid/advprops.cpp:1719
+msgctxt "system cursor name"
+msgid "Arrow"
+msgstr "Flecha"
+
+#: ../src/propgrid/advprops.cpp:1720
+msgctxt "system cursor name"
+msgid "Right Arrow"
+msgstr "Flecha derecha"
+
+#: ../src/propgrid/advprops.cpp:1721
+msgctxt "system cursor name"
+msgid "Blank"
+msgstr "Vacío"
+
+#: ../src/propgrid/advprops.cpp:1722
+msgctxt "system cursor name"
+msgid "Bullseye"
+msgstr "Diana"
+
+#: ../src/propgrid/advprops.cpp:1723
+msgctxt "system cursor name"
+msgid "Character"
+msgstr "Carácter"
+
+#: ../src/propgrid/advprops.cpp:1724
+msgctxt "system cursor name"
+msgid "Cross"
+msgstr "Cruz"
+
+#: ../src/propgrid/advprops.cpp:1725
+msgctxt "system cursor name"
+msgid "Hand"
+msgstr "Mano"
+
+#: ../src/propgrid/advprops.cpp:1726
+msgctxt "system cursor name"
+msgid "I-Beam"
+msgstr "I-Beam"
+
+#: ../src/propgrid/advprops.cpp:1727
+msgctxt "system cursor name"
+msgid "Left Button"
+msgstr "Botón izquierdo"
+
+#: ../src/propgrid/advprops.cpp:1728
+msgctxt "system cursor name"
+msgid "Magnifier"
+msgstr "Lupa"
+
+#: ../src/propgrid/advprops.cpp:1729
+msgctxt "system cursor name"
+msgid "Middle Button"
+msgstr "Botón central"
+
+#: ../src/propgrid/advprops.cpp:1730
+msgctxt "system cursor name"
+msgid "No Entry"
+msgstr "No hay entrada"
+
+#: ../src/propgrid/advprops.cpp:1731
+msgctxt "system cursor name"
+msgid "Paint Brush"
+msgstr "Brocha"
+
+#: ../src/propgrid/advprops.cpp:1732
+msgctxt "system cursor name"
+msgid "Pencil"
+msgstr "Lápiz"
+
+#: ../src/propgrid/advprops.cpp:1733
+msgctxt "system cursor name"
+msgid "Point Left"
+msgstr "Apuntar a la izquierda"
+
+#: ../src/propgrid/advprops.cpp:1734
+msgctxt "system cursor name"
+msgid "Point Right"
+msgstr "Apuntar a la derecha"
+
+#: ../src/propgrid/advprops.cpp:1735
+msgctxt "system cursor name"
+msgid "Question Arrow"
+msgstr "Pregunta Flecha"
+
+#: ../src/propgrid/advprops.cpp:1736
+msgctxt "system cursor name"
+msgid "Right Button"
+msgstr "Botón derecho"
+
+#: ../src/propgrid/advprops.cpp:1737
+msgctxt "system cursor name"
+msgid "Sizing NE-SW"
+msgstr "Dimensionado NE-SO"
+
+#: ../src/propgrid/advprops.cpp:1738
+msgctxt "system cursor name"
+msgid "Sizing N-S"
+msgstr "Dimensionado N-S"
+
+#: ../src/propgrid/advprops.cpp:1739
+msgctxt "system cursor name"
+msgid "Sizing NW-SE"
+msgstr "Dimensionado NO-SE"
+
+#: ../src/propgrid/advprops.cpp:1740
+msgctxt "system cursor name"
+msgid "Sizing W-E"
+msgstr "Dimensionado O-E"
+
+#: ../src/propgrid/advprops.cpp:1741
+msgctxt "system cursor name"
+msgid "Sizing"
+msgstr "Dimensionado"
+
+#: ../src/propgrid/advprops.cpp:1742
+msgctxt "system cursor name"
+msgid "Spraycan"
+msgstr "Aerosol"
+
+#: ../src/propgrid/advprops.cpp:1743
+msgctxt "system cursor name"
+msgid "Wait"
+msgstr "Espere"
+
+#: ../src/propgrid/advprops.cpp:1744
+msgctxt "system cursor name"
+msgid "Watch"
+msgstr "Mirar"
+
+#: ../src/propgrid/advprops.cpp:1745
+msgctxt "system cursor name"
+msgid "Wait Arrow"
+msgstr "Espera Flecha"
+
+#: ../src/propgrid/advprops.cpp:2109
+msgid "Make a selection:"
+msgstr "Hacer una selección:"
+
+#: ../src/propgrid/manager.cpp:394
+msgid "Property"
+msgstr "Propiedad"
+
+#: ../src/propgrid/manager.cpp:395
+msgid "Value"
+msgstr "Valor"
+
+#: ../src/propgrid/manager.cpp:1683
+msgid "Categorized Mode"
+msgstr "Modo categorizado"
+
+#: ../src/propgrid/manager.cpp:1709
+msgid "Alphabetic Mode"
+msgstr "Modo alfabético"
+
+#. TRANSLATORS: Name of Boolean false value
+#: ../src/propgrid/propgrid.cpp:230
+msgid "False"
+msgstr "Falso"
+
+#. TRANSLATORS: Name of Boolean true value
+#: ../src/propgrid/propgrid.cpp:232
+msgid "True"
+msgstr "Verdadero"
+
+#. TRANSLATORS: Text  displayed for unspecified value
+#: ../src/propgrid/propgrid.cpp:428
+msgid "Unspecified"
+msgstr "No especificado"
+
+#. TRANSLATORS: Caption of message box displaying any property error
+#: ../src/propgrid/propgrid.cpp:3145 ../src/propgrid/propgrid.cpp:3282
+msgid "Property Error"
+msgstr "Error de propiedad"
+
+#: ../src/propgrid/propgrid.cpp:3259
+msgid "You have entered invalid value. Press ESC to cancel editing."
+msgstr ""
+"Ha introducido un valor incorrecto. Pulse ESC para cancelar la edición."
+
+#: ../src/propgrid/propgrid.cpp:6608
+#, c-format
+msgid "Error in resource: %s"
+msgstr "Error en recurso: %s"
+
+#: ../src/propgrid/propgridiface.cpp:377
+#, c-format
+msgid ""
+"Type operation \"%s\" failed: Property labeled \"%s\" is of type \"%s\", NOT "
+"\"%s\"."
+msgstr ""
+"La operación de tipos \"%s\" falló: la propiedad etiquetada \"%s\" es del "
+"tipo \"%s\", NO \"%s\"."
+
+#: ../src/propgrid/props.cpp:159
+#, c-format
+msgid "Unknown base %d. Base 10 will be used."
+msgstr "Base %d desconocida, se usará base 10."
+
+#: ../src/propgrid/props.cpp:324
+#, c-format
+msgid "Value must be %s or higher."
+msgstr "El valor debe ser %s o mayor."
+
+#: ../src/propgrid/props.cpp:329 ../src/propgrid/props.cpp:356
+#, c-format
+msgid "Value must be between %s and %s."
+msgstr "El valor debe estar entre %s y %s."
+
+#: ../src/propgrid/props.cpp:351
+#, c-format
+msgid "Value must be %s or less."
+msgstr "El valor debe ser %s o inferior."
+
+#: ../src/propgrid/props.cpp:1058
+#, c-format
+msgid "Not %s"
+msgstr "No %s"
+
+#: ../src/propgrid/props.cpp:1770
+msgid "Choose a directory:"
+msgstr "Elija un directorio:"
+
+#: ../src/propgrid/props.cpp:2055
+msgid "Choose a file"
+msgstr "Elija un archivo"
+
+#: ../src/qt/mdi.cpp:254
+msgid "&Tile"
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:147
+#: ../src/richtext/richtextformatdlg.cpp:376
+msgid "Background"
+msgstr "Fondo"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:159
+msgid "Background &colour:"
+msgstr "&Color de fondo:"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:161
+#: ../src/richtext/richtextbackgroundpage.cpp:163
+msgid "Enables a background colour."
+msgstr "Activa el color de fondo."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:167
+#: ../src/richtext/richtextbackgroundpage.cpp:169
+msgid "The background colour."
+msgstr "El color de fondo."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:178
+msgid "Shadow"
+msgstr "Sombra"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:193
+msgid "Use &shadow"
+msgstr "Usar &sombra"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:195
+#: ../src/richtext/richtextbackgroundpage.cpp:197
+msgid "Enables a shadow."
+msgstr "Activa una sombra."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:211
+msgid "&Horizontal offset:"
+msgstr "Desplazamiento &horizontal:"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:218
+#: ../src/richtext/richtextbackgroundpage.cpp:220
+msgid "The horizontal offset."
+msgstr "El desplazamiento horizontal."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:224
+#: ../src/richtext/richtextbackgroundpage.cpp:227
+#: ../src/richtext/richtextbackgroundpage.cpp:228
+#: ../src/richtext/richtextbackgroundpage.cpp:247
+#: ../src/richtext/richtextbackgroundpage.cpp:250
+#: ../src/richtext/richtextbackgroundpage.cpp:251
+#: ../src/richtext/richtextbackgroundpage.cpp:287
+#: ../src/richtext/richtextbackgroundpage.cpp:290
+#: ../src/richtext/richtextbackgroundpage.cpp:291
+#: ../src/richtext/richtextbackgroundpage.cpp:314
+#: ../src/richtext/richtextbackgroundpage.cpp:317
+#: ../src/richtext/richtextbackgroundpage.cpp:318
+#: ../src/richtext/richtextborderspage.cpp:252
+#: ../src/richtext/richtextborderspage.cpp:255
+#: ../src/richtext/richtextborderspage.cpp:256
+#: ../src/richtext/richtextborderspage.cpp:286
+#: ../src/richtext/richtextborderspage.cpp:289
+#: ../src/richtext/richtextborderspage.cpp:290
+#: ../src/richtext/richtextborderspage.cpp:320
+#: ../src/richtext/richtextborderspage.cpp:323
+#: ../src/richtext/richtextborderspage.cpp:324
+#: ../src/richtext/richtextborderspage.cpp:354
+#: ../src/richtext/richtextborderspage.cpp:357
+#: ../src/richtext/richtextborderspage.cpp:358
+#: ../src/richtext/richtextborderspage.cpp:420
+#: ../src/richtext/richtextborderspage.cpp:423
+#: ../src/richtext/richtextborderspage.cpp:424
+#: ../src/richtext/richtextborderspage.cpp:454
+#: ../src/richtext/richtextborderspage.cpp:457
+#: ../src/richtext/richtextborderspage.cpp:458
+#: ../src/richtext/richtextborderspage.cpp:488
+#: ../src/richtext/richtextborderspage.cpp:491
+#: ../src/richtext/richtextborderspage.cpp:492
+#: ../src/richtext/richtextborderspage.cpp:522
+#: ../src/richtext/richtextborderspage.cpp:525
+#: ../src/richtext/richtextborderspage.cpp:526
+#: ../src/richtext/richtextborderspage.cpp:590
+#: ../src/richtext/richtextborderspage.cpp:593
+#: ../src/richtext/richtextborderspage.cpp:594
+#: ../src/richtext/richtextfontpage.cpp:177
+#: ../src/richtext/richtextmarginspage.cpp:199
+#: ../src/richtext/richtextmarginspage.cpp:201
+#: ../src/richtext/richtextmarginspage.cpp:202
+#: ../src/richtext/richtextmarginspage.cpp:224
+#: ../src/richtext/richtextmarginspage.cpp:226
+#: ../src/richtext/richtextmarginspage.cpp:227
+#: ../src/richtext/richtextmarginspage.cpp:247
+#: ../src/richtext/richtextmarginspage.cpp:249
+#: ../src/richtext/richtextmarginspage.cpp:250
+#: ../src/richtext/richtextmarginspage.cpp:272
+#: ../src/richtext/richtextmarginspage.cpp:274
+#: ../src/richtext/richtextmarginspage.cpp:275
+#: ../src/richtext/richtextmarginspage.cpp:313
+#: ../src/richtext/richtextmarginspage.cpp:315
+#: ../src/richtext/richtextmarginspage.cpp:316
+#: ../src/richtext/richtextmarginspage.cpp:338
+#: ../src/richtext/richtextmarginspage.cpp:340
+#: ../src/richtext/richtextmarginspage.cpp:341
+#: ../src/richtext/richtextmarginspage.cpp:361
+#: ../src/richtext/richtextmarginspage.cpp:363
+#: ../src/richtext/richtextmarginspage.cpp:364
+#: ../src/richtext/richtextmarginspage.cpp:386
+#: ../src/richtext/richtextmarginspage.cpp:388
+#: ../src/richtext/richtextmarginspage.cpp:389
+#: ../src/richtext/richtextsizepage.cpp:337
+#: ../src/richtext/richtextsizepage.cpp:340
+#: ../src/richtext/richtextsizepage.cpp:341
+#: ../src/richtext/richtextsizepage.cpp:371
+#: ../src/richtext/richtextsizepage.cpp:374
+#: ../src/richtext/richtextsizepage.cpp:375
+#: ../src/richtext/richtextsizepage.cpp:398
+#: ../src/richtext/richtextsizepage.cpp:401
+#: ../src/richtext/richtextsizepage.cpp:402
+#: ../src/richtext/richtextsizepage.cpp:425
+#: ../src/richtext/richtextsizepage.cpp:428
+#: ../src/richtext/richtextsizepage.cpp:429
+#: ../src/richtext/richtextsizepage.cpp:452
+#: ../src/richtext/richtextsizepage.cpp:455
+#: ../src/richtext/richtextsizepage.cpp:456
+#: ../src/richtext/richtextsizepage.cpp:479
+#: ../src/richtext/richtextsizepage.cpp:482
+#: ../src/richtext/richtextsizepage.cpp:483
+#: ../src/richtext/richtextsizepage.cpp:553
+#: ../src/richtext/richtextsizepage.cpp:556
+#: ../src/richtext/richtextsizepage.cpp:557
+#: ../src/richtext/richtextsizepage.cpp:588
+#: ../src/richtext/richtextsizepage.cpp:591
+#: ../src/richtext/richtextsizepage.cpp:592
+#: ../src/richtext/richtextsizepage.cpp:623
+#: ../src/richtext/richtextsizepage.cpp:626
+#: ../src/richtext/richtextsizepage.cpp:627
+#: ../src/richtext/richtextsizepage.cpp:658
+#: ../src/richtext/richtextsizepage.cpp:661
+#: ../src/richtext/richtextsizepage.cpp:662
+msgid "px"
+msgstr "px"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:225
+#: ../src/richtext/richtextbackgroundpage.cpp:248
+#: ../src/richtext/richtextbackgroundpage.cpp:288
+#: ../src/richtext/richtextbackgroundpage.cpp:315
+#: ../src/richtext/richtextborderspage.cpp:253
+#: ../src/richtext/richtextborderspage.cpp:287
+#: ../src/richtext/richtextborderspage.cpp:321
+#: ../src/richtext/richtextborderspage.cpp:355
+#: ../src/richtext/richtextborderspage.cpp:421
+#: ../src/richtext/richtextborderspage.cpp:455
+#: ../src/richtext/richtextborderspage.cpp:489
+#: ../src/richtext/richtextborderspage.cpp:523
+#: ../src/richtext/richtextborderspage.cpp:591
+#: ../src/richtext/richtextmarginspage.cpp:200
+#: ../src/richtext/richtextmarginspage.cpp:225
+#: ../src/richtext/richtextmarginspage.cpp:248
+#: ../src/richtext/richtextmarginspage.cpp:273
+#: ../src/richtext/richtextmarginspage.cpp:314
+#: ../src/richtext/richtextmarginspage.cpp:339
+#: ../src/richtext/richtextmarginspage.cpp:362
+#: ../src/richtext/richtextmarginspage.cpp:387
+#: ../src/richtext/richtextsizepage.cpp:338
+#: ../src/richtext/richtextsizepage.cpp:372
+#: ../src/richtext/richtextsizepage.cpp:399
+#: ../src/richtext/richtextsizepage.cpp:426
+#: ../src/richtext/richtextsizepage.cpp:453
+#: ../src/richtext/richtextsizepage.cpp:480
+#: ../src/richtext/richtextsizepage.cpp:554
+#: ../src/richtext/richtextsizepage.cpp:589
+#: ../src/richtext/richtextsizepage.cpp:624
+#: ../src/richtext/richtextsizepage.cpp:659
+msgid "cm"
+msgstr "cm"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:226
+#: ../src/richtext/richtextbackgroundpage.cpp:249
+#: ../src/richtext/richtextbackgroundpage.cpp:289
+#: ../src/richtext/richtextbackgroundpage.cpp:316
+#: ../src/richtext/richtextborderspage.cpp:254
+#: ../src/richtext/richtextborderspage.cpp:288
+#: ../src/richtext/richtextborderspage.cpp:322
+#: ../src/richtext/richtextborderspage.cpp:356
+#: ../src/richtext/richtextborderspage.cpp:422
+#: ../src/richtext/richtextborderspage.cpp:456
+#: ../src/richtext/richtextborderspage.cpp:490
+#: ../src/richtext/richtextborderspage.cpp:524
+#: ../src/richtext/richtextborderspage.cpp:592
+#: ../src/richtext/richtextfontpage.cpp:176
+#: ../src/richtext/richtextfontpage.cpp:179
+msgid "pt"
+msgstr "pt"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:229
+#: ../src/richtext/richtextbackgroundpage.cpp:231
+#: ../src/richtext/richtextbackgroundpage.cpp:252
+#: ../src/richtext/richtextbackgroundpage.cpp:254
+#: ../src/richtext/richtextbackgroundpage.cpp:292
+#: ../src/richtext/richtextbackgroundpage.cpp:294
+#: ../src/richtext/richtextbackgroundpage.cpp:319
+#: ../src/richtext/richtextbackgroundpage.cpp:321
+msgid "Units for this value."
+msgstr "Unidades para este valor."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:234
+msgid "&Vertical offset:"
+msgstr "Desplazamiento &vertical:"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:241
+#: ../src/richtext/richtextbackgroundpage.cpp:243
+msgid "The vertical offset."
+msgstr "El desplazamiento vertical."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:257
+msgid "Shadow c&olour:"
+msgstr "C&olor de la sombra:"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:259
+#: ../src/richtext/richtextbackgroundpage.cpp:261
+msgid "Enables the shadow colour."
+msgstr "Activa el color de sombra."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:265
+#: ../src/richtext/richtextbackgroundpage.cpp:267
+msgid "The shadow colour."
+msgstr "El color de la sombra."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:270
+msgid "Sh&adow spread:"
+msgstr "Difusión de la sombr&a:"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:272
+#: ../src/richtext/richtextbackgroundpage.cpp:274
+msgid "Enables the shadow spread."
+msgstr "Activa la difusión de la sombra."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:281
+#: ../src/richtext/richtextbackgroundpage.cpp:283
+msgid "The shadow spread."
+msgstr "La difusión de la sombra."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:297
+msgid "&Blur distance:"
+msgstr "Distancia de &difuminado:"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:299
+#: ../src/richtext/richtextbackgroundpage.cpp:301
+msgid "Enables the blur distance."
+msgstr "Activa la distancia de difuminado."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:308
+#: ../src/richtext/richtextbackgroundpage.cpp:310
+msgid "The shadow blur distance."
+msgstr "La distancia de difuminado de la sombra."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:324
+msgid "Opaci&ty:"
+msgstr "Opaci&dad:"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:326
+#: ../src/richtext/richtextbackgroundpage.cpp:328
+msgid "Enables the shadow opacity."
+msgstr "Activa la opacidad de la sombra."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:335
+#: ../src/richtext/richtextbackgroundpage.cpp:337
+msgid "The shadow opacity."
+msgstr "La opacidad de la sombra."
+
+#. TRANSLATORS: Rich text page units (percentage)
+#: ../src/richtext/richtextbackgroundpage.cpp:340
+#: ../src/richtext/richtextsizepage.cpp:339
+#: ../src/richtext/richtextsizepage.cpp:373
+#: ../src/richtext/richtextsizepage.cpp:400
+#: ../src/richtext/richtextsizepage.cpp:427
+#: ../src/richtext/richtextsizepage.cpp:454
+#: ../src/richtext/richtextsizepage.cpp:481
+#: ../src/richtext/richtextsizepage.cpp:555
+#: ../src/richtext/richtextsizepage.cpp:590
+#: ../src/richtext/richtextsizepage.cpp:625
+#: ../src/richtext/richtextsizepage.cpp:660
+msgid "%"
+msgstr "%"
+
+#: ../src/richtext/richtextborderspage.cpp:229
+#: ../src/richtext/richtextborderspage.cpp:387
+msgid "Border"
+msgstr "Borde"
+
+#: ../src/richtext/richtextborderspage.cpp:242
+#: ../src/richtext/richtextborderspage.cpp:410
+#: ../src/richtext/richtextindentspage.cpp:194
+#: ../src/richtext/richtextliststylepage.cpp:384
+#: ../src/richtext/richtextmarginspage.cpp:185
+#: ../src/richtext/richtextmarginspage.cpp:299
+#: ../src/richtext/richtextsizepage.cpp:531
+#: ../src/richtext/richtextsizepage.cpp:538
+msgid "&Left:"
+msgstr "&Izquierda:"
+
+#: ../src/richtext/richtextborderspage.cpp:257
+#: ../src/richtext/richtextborderspage.cpp:259
+msgid "Units for the left border width."
+msgstr "Unidades para el ancho del borde izquierdo."
+
+#: ../src/richtext/richtextborderspage.cpp:266
+#: ../src/richtext/richtextborderspage.cpp:268
+#: ../src/richtext/richtextborderspage.cpp:300
+#: ../src/richtext/richtextborderspage.cpp:302
+#: ../src/richtext/richtextborderspage.cpp:334
+#: ../src/richtext/richtextborderspage.cpp:336
+#: ../src/richtext/richtextborderspage.cpp:368
+#: ../src/richtext/richtextborderspage.cpp:370
+#: ../src/richtext/richtextborderspage.cpp:434
+#: ../src/richtext/richtextborderspage.cpp:436
+#: ../src/richtext/richtextborderspage.cpp:468
+#: ../src/richtext/richtextborderspage.cpp:470
+#: ../src/richtext/richtextborderspage.cpp:502
+#: ../src/richtext/richtextborderspage.cpp:504
+#: ../src/richtext/richtextborderspage.cpp:536
+#: ../src/richtext/richtextborderspage.cpp:538
+msgid "The border line style."
+msgstr "El estilo del borde."
+
+#: ../src/richtext/richtextborderspage.cpp:276
+#: ../src/richtext/richtextborderspage.cpp:444
+#: ../src/richtext/richtextindentspage.cpp:212
+#: ../src/richtext/richtextliststylepage.cpp:402
+#: ../src/richtext/richtextmarginspage.cpp:210
+#: ../src/richtext/richtextmarginspage.cpp:324
+#: ../src/richtext/richtextsizepage.cpp:601
+#: ../src/richtext/richtextsizepage.cpp:608
+msgid "&Right:"
+msgstr "&Derecha:"
+
+#: ../src/richtext/richtextborderspage.cpp:291
+#: ../src/richtext/richtextborderspage.cpp:293
+msgid "Units for the right border width."
+msgstr "Unidades para el ancho del borde derecho."
+
+#: ../src/richtext/richtextborderspage.cpp:310
+#: ../src/richtext/richtextborderspage.cpp:478
+#: ../src/richtext/richtextmarginspage.cpp:233
+#: ../src/richtext/richtextmarginspage.cpp:347
+#: ../src/richtext/richtextsizepage.cpp:566
+#: ../src/richtext/richtextsizepage.cpp:573
+msgid "&Top:"
+msgstr "&Arriba:"
+
+#: ../src/richtext/richtextborderspage.cpp:325
+#: ../src/richtext/richtextborderspage.cpp:327
+msgid "Units for the top border width."
+msgstr "Unidades para el ancho del borde superior."
+
+#: ../src/richtext/richtextborderspage.cpp:344
+#: ../src/richtext/richtextborderspage.cpp:512
+#: ../src/richtext/richtextmarginspage.cpp:258
+#: ../src/richtext/richtextmarginspage.cpp:372
+#: ../src/richtext/richtextsizepage.cpp:636
+#: ../src/richtext/richtextsizepage.cpp:643
+msgid "&Bottom:"
+msgstr "&Inferior:"
+
+#: ../src/richtext/richtextborderspage.cpp:359
+#: ../src/richtext/richtextborderspage.cpp:361
+msgid "Units for the bottom border width."
+msgstr "Unidades para el ancho del borde inferior."
+
+#: ../src/richtext/richtextborderspage.cpp:380
+#: ../src/richtext/richtextborderspage.cpp:548
+msgid "&Synchronize values"
+msgstr "&Sincronizar valores"
+
+#: ../src/richtext/richtextborderspage.cpp:382
+#: ../src/richtext/richtextborderspage.cpp:384
+#: ../src/richtext/richtextborderspage.cpp:550
+#: ../src/richtext/richtextborderspage.cpp:552
+msgid "Check to edit all borders simultaneously."
+msgstr "Active para editar todos los bordes a la vez."
+
+#: ../src/richtext/richtextborderspage.cpp:397
+#: ../src/richtext/richtextborderspage.cpp:555
+msgid "Outline"
+msgstr "Contorno"
+
+#: ../src/richtext/richtextborderspage.cpp:425
+#: ../src/richtext/richtextborderspage.cpp:427
+msgid "Units for the left outline width."
+msgstr "Unidades para el ancho del contorno izquierdo."
+
+#: ../src/richtext/richtextborderspage.cpp:459
+#: ../src/richtext/richtextborderspage.cpp:461
+msgid "Units for the right outline width."
+msgstr "Unidades para el ancho del contorno derecho."
+
+#: ../src/richtext/richtextborderspage.cpp:493
+#: ../src/richtext/richtextborderspage.cpp:495
+msgid "Units for the top outline width."
+msgstr "Unidades para el ancho del contorno superior."
+
+#: ../src/richtext/richtextborderspage.cpp:527
+#: ../src/richtext/richtextborderspage.cpp:529
+msgid "Units for the bottom outline width."
+msgstr "Unidades para el ancho del contorno inferior."
+
+#: ../src/richtext/richtextborderspage.cpp:565
+#: ../src/richtext/richtextborderspage.cpp:600
+msgid "Corner"
+msgstr "Esquina"
+
+#: ../src/richtext/richtextborderspage.cpp:574
+msgid "Corner &radius:"
+msgstr "&Radio de la esquina:"
+
+#: ../src/richtext/richtextborderspage.cpp:576
+#: ../src/richtext/richtextborderspage.cpp:578
+msgid "An optional corner radius for adding rounded corners."
+msgstr "Un radio de esquina opcional para añadir esquinas redondeadas."
+
+#: ../src/richtext/richtextborderspage.cpp:584
+#: ../src/richtext/richtextborderspage.cpp:586
+msgid "The value of the corner radius."
+msgstr "El valor del radio de la esquina."
+
+#: ../src/richtext/richtextborderspage.cpp:595
+#: ../src/richtext/richtextborderspage.cpp:597
+msgid "Units for the corner radius."
+msgstr "Unidades para el radio de la esquina."
+
+#: ../src/richtext/richtextborderspage.cpp:609
+#: ../src/richtext/richtextsizepage.cpp:247
+#: ../src/richtext/richtextsizepage.cpp:251
+msgid "None"
+msgstr "Ninguno"
+
+#: ../src/richtext/richtextborderspage.cpp:610
+msgid "Solid"
+msgstr "Sólida"
+
+#: ../src/richtext/richtextborderspage.cpp:611
+msgid "Dotted"
+msgstr "Punteado"
+
+#: ../src/richtext/richtextborderspage.cpp:612
+msgid "Dashed"
+msgstr "Barrado"
+
+#: ../src/richtext/richtextborderspage.cpp:613
+msgid "Double"
+msgstr "Doble"
+
+#: ../src/richtext/richtextborderspage.cpp:614
+msgid "Groove"
+msgstr "Ranura"
+
+#: ../src/richtext/richtextborderspage.cpp:615
+msgid "Ridge"
+msgstr "Arrugar"
+
+#: ../src/richtext/richtextborderspage.cpp:616
+msgid "Inset"
+msgstr "Recuadro"
+
+#: ../src/richtext/richtextborderspage.cpp:617
+msgid "Outset"
+msgstr "Comienzo"
+
+#: ../src/richtext/richtextbuffer.cpp:3518
+msgid "Change Style"
+msgstr "Cambiar estilo"
+
+#: ../src/richtext/richtextbuffer.cpp:3701
+msgid "Change Object Style"
+msgstr "Cambiar estilo de objeto"
+
+#: ../src/richtext/richtextbuffer.cpp:3974
+#: ../src/richtext/richtextbuffer.cpp:8174
+msgid "Change Properties"
+msgstr "Cambiar propiedades"
+
+#: ../src/richtext/richtextbuffer.cpp:4346
+msgid "Change List Style"
+msgstr "Cambiar estilo de lista"
+
+#: ../src/richtext/richtextbuffer.cpp:4519
+msgid "Renumber List"
+msgstr "Renumerar Lista"
+
+#: ../src/richtext/richtextbuffer.cpp:7867
+#: ../src/richtext/richtextbuffer.cpp:7897
+#: ../src/richtext/richtextbuffer.cpp:7939
+#: ../src/richtext/richtextctrl.cpp:1279 ../src/richtext/richtextctrl.cpp:1473
+msgid "Insert Text"
+msgstr "Insertar texto"
+
+#: ../src/richtext/richtextbuffer.cpp:8023
+#: ../src/richtext/richtextbuffer.cpp:8979
+msgid "Insert Image"
+msgstr "Insertar imagen"
+
+#: ../src/richtext/richtextbuffer.cpp:8070
+msgid "Insert Object"
+msgstr "Insertar objeto"
+
+#: ../src/richtext/richtextbuffer.cpp:8112
+msgid "Insert Field"
+msgstr "Insertar campo"
+
+#: ../src/richtext/richtextbuffer.cpp:8410
+msgid "Too many EndStyle calls!"
+msgstr "¡Demasiadas llamadas a EndStyle!"
+
+#: ../src/richtext/richtextbuffer.cpp:8785
+msgid "files"
+msgstr "archivos"
+
+#: ../src/richtext/richtextbuffer.cpp:9380
+msgid "standard/circle"
+msgstr "estándar/círculo"
+
+#: ../src/richtext/richtextbuffer.cpp:9381
+msgid "standard/circle-outline"
+msgstr "estándar/circunferencia"
+
+#: ../src/richtext/richtextbuffer.cpp:9382
+msgid "standard/square"
+msgstr "estándar/cuadrado"
+
+#: ../src/richtext/richtextbuffer.cpp:9383
+msgid "standard/diamond"
+msgstr "estándar/diamante"
+
+#: ../src/richtext/richtextbuffer.cpp:9384
+msgid "standard/triangle"
+msgstr "estándar/triángulo"
+
+#: ../src/richtext/richtextbuffer.cpp:9423
+msgid "Box Properties"
+msgstr "Propiedades de caja"
+
+#: ../src/richtext/richtextbuffer.cpp:10006
+msgid "Multiple Cell Properties"
+msgstr "Múltiples propiedades de celda"
+
+#: ../src/richtext/richtextbuffer.cpp:10008
+msgid "Cell Properties"
+msgstr "Propiedades de celda"
+
+#: ../src/richtext/richtextbuffer.cpp:11256
+msgid "Set Cell Style"
+msgstr "Cambiar estilo de celda"
+
+#: ../src/richtext/richtextbuffer.cpp:11330
+msgid "Delete Row"
+msgstr "Eliminar fila"
+
+#: ../src/richtext/richtextbuffer.cpp:11380
+msgid "Delete Column"
+msgstr "Eliminar columna"
+
+#: ../src/richtext/richtextbuffer.cpp:11431
+msgid "Add Row"
+msgstr "Añadir fila"
+
+#: ../src/richtext/richtextbuffer.cpp:11494
+msgid "Add Column"
+msgstr "Añadir columna"
+
+#: ../src/richtext/richtextbuffer.cpp:11537
+msgid "Table Properties"
+msgstr "Propiedades de tabla"
+
+#: ../src/richtext/richtextbuffer.cpp:12899
+msgid "Picture Properties"
+msgstr "Propiedades de la imagen"
+
+#: ../src/richtext/richtextbuffer.cpp:13169
+#: ../src/richtext/richtextbuffer.cpp:13279
+msgid "image"
+msgstr "imagen"
+
+#: ../src/richtext/richtextbulletspage.cpp:145
+#: ../src/richtext/richtextliststylepage.cpp:209
+msgid "&Bullet style:"
+msgstr "Estilo de &viñeta:"
+
+#: ../src/richtext/richtextbulletspage.cpp:150
+#: ../src/richtext/richtextbulletspage.cpp:152
+#: ../src/richtext/richtextliststylepage.cpp:214
+#: ../src/richtext/richtextliststylepage.cpp:216
+msgid "The available bullet styles."
+msgstr "Los estilos de viñeta disponibles."
+
+#: ../src/richtext/richtextbulletspage.cpp:158
+#: ../src/richtext/richtextliststylepage.cpp:221
+msgid "Peri&od"
+msgstr "Peri&odo"
+
+#: ../src/richtext/richtextbulletspage.cpp:160
+#: ../src/richtext/richtextbulletspage.cpp:162
+#: ../src/richtext/richtextliststylepage.cpp:223
+#: ../src/richtext/richtextliststylepage.cpp:225
+msgid "Check to add a period after the bullet."
+msgstr "Active para añadir un punto después de la viñeta."
+
+#. TRANSLATORS: Bullet point in parentheses option
+#: ../src/richtext/richtextbulletspage.cpp:167
+#: ../src/richtext/richtextliststylepage.cpp:230
+msgid "(*)"
+msgstr "(*)"
+
+#: ../src/richtext/richtextbulletspage.cpp:169
+#: ../src/richtext/richtextbulletspage.cpp:171
+#: ../src/richtext/richtextliststylepage.cpp:232
+#: ../src/richtext/richtextliststylepage.cpp:234
+msgid "Check to enclose the bullet in parentheses."
+msgstr "Active para encerrar la viñeta entre paréntesis."
+
+#. TRANSLATORS: Right parenthesis bullet point option
+#: ../src/richtext/richtextbulletspage.cpp:176
+#: ../src/richtext/richtextliststylepage.cpp:239
+msgid "*)"
+msgstr "*)"
+
+#: ../src/richtext/richtextbulletspage.cpp:178
+#: ../src/richtext/richtextbulletspage.cpp:180
+#: ../src/richtext/richtextliststylepage.cpp:241
+#: ../src/richtext/richtextliststylepage.cpp:243
+msgid "Check to add a right parenthesis."
+msgstr "Active para añadir un paréntesis derecho."
+
+#: ../src/richtext/richtextbulletspage.cpp:185
+#: ../src/richtext/richtextliststylepage.cpp:248
+msgid "Bullet &Alignment:"
+msgstr "&Alineación de viñeta:"
+
+#: ../src/richtext/richtextbulletspage.cpp:190
+#: ../src/richtext/richtextliststylepage.cpp:253
+msgid "Centre"
+msgstr "Centrar"
+
+#: ../src/richtext/richtextbulletspage.cpp:194
+#: ../src/richtext/richtextbulletspage.cpp:196
+#: ../src/richtext/richtextbulletspage.cpp:217
+#: ../src/richtext/richtextbulletspage.cpp:219
+#: ../src/richtext/richtextliststylepage.cpp:257
+#: ../src/richtext/richtextliststylepage.cpp:259
+#: ../src/richtext/richtextliststylepage.cpp:278
+#: ../src/richtext/richtextliststylepage.cpp:280
+msgid "The bullet character."
+msgstr "El carácter de viñeta."
+
+#: ../src/richtext/richtextbulletspage.cpp:212
+#: ../src/richtext/richtextliststylepage.cpp:271
+msgid "&Symbol:"
+msgstr "&Símbolo:"
+
+#: ../src/richtext/richtextbulletspage.cpp:222
+#: ../src/richtext/richtextliststylepage.cpp:283
+msgid "Ch&oose..."
+msgstr "&Elegir…"
+
+#: ../src/richtext/richtextbulletspage.cpp:223
+#: ../src/richtext/richtextbulletspage.cpp:225
+#: ../src/richtext/richtextliststylepage.cpp:284
+#: ../src/richtext/richtextliststylepage.cpp:286
+msgid "Click to browse for a symbol."
+msgstr "Pulse click para buscar un símbolo."
+
+#: ../src/richtext/richtextbulletspage.cpp:230
+#: ../src/richtext/richtextliststylepage.cpp:291
+msgid "Symbol &font:"
+msgstr "&Tipo de letra de símbolos:"
+
+#: ../src/richtext/richtextbulletspage.cpp:235
+#: ../src/richtext/richtextbulletspage.cpp:237
+#: ../src/richtext/richtextliststylepage.cpp:297
+msgid "Available fonts."
+msgstr "Tipos de letra disponibles."
+
+#: ../src/richtext/richtextbulletspage.cpp:242
+#: ../src/richtext/richtextliststylepage.cpp:302
+msgid "S&tandard bullet name:"
+msgstr "Nombre de viñeta es&tándar:"
+
+#: ../src/richtext/richtextbulletspage.cpp:247
+#: ../src/richtext/richtextbulletspage.cpp:249
+#: ../src/richtext/richtextliststylepage.cpp:307
+#: ../src/richtext/richtextliststylepage.cpp:309
+msgid "A standard bullet name."
+msgstr "Un nombre de viñeta estándar."
+
+#: ../src/richtext/richtextbulletspage.cpp:254
+msgid "&Number:"
+msgstr "&Número:"
+
+#: ../src/richtext/richtextbulletspage.cpp:258
+#: ../src/richtext/richtextbulletspage.cpp:260
+msgid "The list item number."
+msgstr "El número de elemento de la lista."
+
+#: ../src/richtext/richtextbulletspage.cpp:266
+#: ../src/richtext/richtextbulletspage.cpp:268
+#: ../src/richtext/richtextliststylepage.cpp:475
+#: ../src/richtext/richtextliststylepage.cpp:477
+msgid "Shows a preview of the bullet settings."
+msgstr "Muestra una previsualización de las opciones de la viñeta."
+
+#: ../src/richtext/richtextbulletspage.cpp:276
+#: ../src/richtext/richtextliststylepage.cpp:484
+msgid "(None)"
+msgstr "(Ninguno)"
+
+#: ../src/richtext/richtextbulletspage.cpp:277
+#: ../src/richtext/richtextliststylepage.cpp:485
+msgid "Arabic"
+msgstr "Arábigo"
+
+#: ../src/richtext/richtextbulletspage.cpp:278
+#: ../src/richtext/richtextliststylepage.cpp:486
+msgid "Upper case letters"
+msgstr "Letras mayúsculas"
+
+#: ../src/richtext/richtextbulletspage.cpp:279
+#: ../src/richtext/richtextliststylepage.cpp:487
+msgid "Lower case letters"
+msgstr "Letras minúsculas"
+
+#: ../src/richtext/richtextbulletspage.cpp:280
+#: ../src/richtext/richtextliststylepage.cpp:488
+msgid "Upper case roman numerals"
+msgstr "Números romanos en mayúsculas"
+
+#: ../src/richtext/richtextbulletspage.cpp:281
+#: ../src/richtext/richtextliststylepage.cpp:489
+msgid "Lower case roman numerals"
+msgstr "Números romanos en minúscula"
+
+#: ../src/richtext/richtextbulletspage.cpp:282
+#: ../src/richtext/richtextliststylepage.cpp:490
+msgid "Numbered outline"
+msgstr "Esquema numerado"
+
+#: ../src/richtext/richtextbulletspage.cpp:283
+#: ../src/richtext/richtextliststylepage.cpp:491
+msgid "Symbol"
+msgstr "Símbolo"
+
+#: ../src/richtext/richtextbulletspage.cpp:284
+#: ../src/richtext/richtextliststylepage.cpp:492
+msgid "Bitmap"
+msgstr "Mapa de bits"
+
+#: ../src/richtext/richtextbulletspage.cpp:285
+#: ../src/richtext/richtextliststylepage.cpp:493
+msgid "Standard"
+msgstr "Estándar"
+
+#: ../src/richtext/richtextbulletspage.cpp:287
+#: ../src/richtext/richtextliststylepage.cpp:495
+msgid "*"
+msgstr "*"
+
+#: ../src/richtext/richtextbulletspage.cpp:288
+#: ../src/richtext/richtextliststylepage.cpp:496
+msgid "-"
+msgstr "-"
+
+#: ../src/richtext/richtextbulletspage.cpp:289
+#: ../src/richtext/richtextliststylepage.cpp:497
+msgid ">"
+msgstr ">"
+
+#: ../src/richtext/richtextbulletspage.cpp:290
+#: ../src/richtext/richtextliststylepage.cpp:498
+msgid "+"
+msgstr "+"
+
+#: ../src/richtext/richtextbulletspage.cpp:291
+#: ../src/richtext/richtextliststylepage.cpp:499
+msgid "~"
+msgstr "~"
+
+#: ../src/richtext/richtextctrl.cpp:859
+msgid "Drag"
+msgstr "Arrastrar"
+
+#: ../src/richtext/richtextctrl.cpp:1338 ../src/richtext/richtextctrl.cpp:1559
+msgid "Delete Text"
+msgstr "Eliminar texto"
+
+#: ../src/richtext/richtextctrl.cpp:1537
+msgid "Remove Bullet"
+msgstr "Eliminar marca"
+
+#: ../src/richtext/richtextctrl.cpp:3070
+msgid "The text couldn't be saved."
+msgstr "El texto no pudo guardarse."
+
+#: ../src/richtext/richtextctrl.cpp:3644
+msgid "Replace"
+msgstr "Sustituir"
+
+#: ../src/richtext/richtextfontpage.cpp:146
+#: ../src/richtext/richtextsymboldlg.cpp:384
+msgid "&Font:"
+msgstr "&Tipo de letra:"
+
+#: ../src/richtext/richtextfontpage.cpp:150
+#: ../src/richtext/richtextfontpage.cpp:152
+msgid "Type a font name."
+msgstr "Escriba un nombre de fuente."
+
+#: ../src/richtext/richtextfontpage.cpp:158
+msgid "&Size:"
+msgstr "&Tamaño:"
+
+#: ../src/richtext/richtextfontpage.cpp:165
+#: ../src/richtext/richtextfontpage.cpp:167
+msgid "Type a size in points."
+msgstr "Escribir un tamaño en puntos."
+
+#: ../src/richtext/richtextfontpage.cpp:180
+#: ../src/richtext/richtextfontpage.cpp:182
+msgid "The font size units, points or pixels."
+msgstr "Las unidades, puntos o píxeles del tamaño del tipo de letra."
+
+#: ../src/richtext/richtextfontpage.cpp:189
+#: ../src/richtext/richtextfontpage.cpp:191
+msgid "Lists the available fonts."
+msgstr "Muestra los tipos de letra disponibles."
+
+#: ../src/richtext/richtextfontpage.cpp:196
+#: ../src/richtext/richtextfontpage.cpp:198
+msgid "Lists font sizes in points."
+msgstr "Enumera los tamaños de letra en puntos."
+
+#: ../src/richtext/richtextfontpage.cpp:207
+msgid "Font st&yle:"
+msgstr "&Estilo tipográfico:"
+
+#: ../src/richtext/richtextfontpage.cpp:212
+#: ../src/richtext/richtextfontpage.cpp:214
+msgid "Select regular or italic style."
+msgstr "Seleccionar estilo normal o cursiva."
+
+#: ../src/richtext/richtextfontpage.cpp:220
+msgid "Font &weight:"
+msgstr "&Peso tipográfico:"
+
+#: ../src/richtext/richtextfontpage.cpp:225
+#: ../src/richtext/richtextfontpage.cpp:227
+msgid "Select regular or bold."
+msgstr "Seleccionar normal o negrita."
+
+#: ../src/richtext/richtextfontpage.cpp:233
+msgid "&Underlining:"
+msgstr "&Subrayado:"
+
+#: ../src/richtext/richtextfontpage.cpp:238
+#: ../src/richtext/richtextfontpage.cpp:240
+msgid "Select underlining or no underlining."
+msgstr "Seleccionar subrayado o no subrayado."
+
+#: ../src/richtext/richtextfontpage.cpp:248
+msgid "&Colour:"
+msgstr "&Color:"
+
+#: ../src/richtext/richtextfontpage.cpp:253
+#: ../src/richtext/richtextfontpage.cpp:255
+msgid "Click to change the text colour."
+msgstr "Pulse para cambiar el color del texto."
+
+#: ../src/richtext/richtextfontpage.cpp:261
+msgid "&Bg colour:"
+msgstr "Color &fondo:"
+
+#: ../src/richtext/richtextfontpage.cpp:266
+#: ../src/richtext/richtextfontpage.cpp:268
+msgid "Click to change the text background colour."
+msgstr "Pulse para cambiar el color del fondo."
+
+#: ../src/richtext/richtextfontpage.cpp:276
+#: ../src/richtext/richtextfontpage.cpp:278
+msgid "Check to show a line through the text."
+msgstr "Active para mostrar una línea a través del texto."
+
+#: ../src/richtext/richtextfontpage.cpp:281
+msgid "Ca&pitals"
+msgstr "Ma&yúsculas"
+
+#: ../src/richtext/richtextfontpage.cpp:283
+#: ../src/richtext/richtextfontpage.cpp:285
+msgid "Check to show the text in capitals."
+msgstr "Active para mostrar el texto en mayúsculas."
+
+#: ../src/richtext/richtextfontpage.cpp:288
+msgid "Small C&apitals"
+msgstr "M&ayúsculas pequeñas"
+
+#: ../src/richtext/richtextfontpage.cpp:290
+#: ../src/richtext/richtextfontpage.cpp:292
+msgid "Check to show the text in small capitals."
+msgstr "Active para mostrar el texto en versalitas."
+
+#: ../src/richtext/richtextfontpage.cpp:295
+msgid "Supe&rscript"
+msgstr "Supe&rínidice"
+
+#: ../src/richtext/richtextfontpage.cpp:297
+#: ../src/richtext/richtextfontpage.cpp:299
+msgid "Check to show the text in superscript."
+msgstr "Active para mostrar el texto en superíndice."
+
+#: ../src/richtext/richtextfontpage.cpp:302
+msgid "Subscrip&t"
+msgstr "Subín&dice"
+
+#: ../src/richtext/richtextfontpage.cpp:304
+#: ../src/richtext/richtextfontpage.cpp:306
+msgid "Check to show the text in subscript."
+msgstr "Active para mostrar el texto en subíndice."
+
+#: ../src/richtext/richtextfontpage.cpp:312
+msgid "Rig&ht-to-left"
+msgstr "Derec&ha a izquierda"
+
+#: ../src/richtext/richtextfontpage.cpp:314
+#: ../src/richtext/richtextfontpage.cpp:316
+msgid "Check to indicate right-to-left text layout."
+msgstr "Active para indicar texto dispuesto de derecha a izquierda."
+
+#: ../src/richtext/richtextfontpage.cpp:319
+msgid "Suppress hyphe&nation"
+msgstr "Suprimir divisió&n de palabras"
+
+#: ../src/richtext/richtextfontpage.cpp:321
+#: ../src/richtext/richtextfontpage.cpp:323
+msgid "Check to suppress hyphenation."
+msgstr "Active para suprimir la división de palabras."
+
+#: ../src/richtext/richtextfontpage.cpp:329
+#: ../src/richtext/richtextfontpage.cpp:331
+msgid "Shows a preview of the font settings."
+msgstr "Muestra una vista previa de las opciones de la fuente."
+
+#: ../src/richtext/richtextfontpage.cpp:348
+#: ../src/richtext/richtextfontpage.cpp:352
+#: ../src/richtext/richtextfontpage.cpp:356
+#: ../src/richtext/richtextformatdlg.cpp:873
+#: ../src/richtext/richtextindentspage.cpp:273
+#: ../src/richtext/richtextindentspage.cpp:285
+#: ../src/richtext/richtextindentspage.cpp:286
+#: ../src/richtext/richtextindentspage.cpp:310
+#: ../src/richtext/richtextindentspage.cpp:325
+#: ../src/richtext/richtextliststylepage.cpp:451
+#: ../src/richtext/richtextliststylepage.cpp:463
+#: ../src/richtext/richtextliststylepage.cpp:464
+msgid "(none)"
+msgstr "(ninguno)"
+
+#: ../src/richtext/richtextfontpage.cpp:349
+#: ../src/richtext/richtextfontpage.cpp:353
+msgid "Regular"
+msgstr "Normal"
+
+#: ../src/richtext/richtextfontpage.cpp:357
+msgid "Not underlined"
+msgstr "No subrayada"
+
+#: ../src/richtext/richtextformatdlg.cpp:341
+msgid "Indents && Spacing"
+msgstr "Sangrías y espaciado"
+
+#: ../src/richtext/richtextformatdlg.cpp:346
+msgid "Tabs"
+msgstr "Tabulaciones"
+
+#: ../src/richtext/richtextformatdlg.cpp:351
+msgid "Bullets"
+msgstr "Viñetas"
+
+#: ../src/richtext/richtextformatdlg.cpp:356
+msgid "List Style"
+msgstr "Estilo de lista"
+
+#: ../src/richtext/richtextformatdlg.cpp:366
+#: ../src/richtext/richtextmarginspage.cpp:170
+msgid "Margins"
+msgstr "Márgenes"
+
+#: ../src/richtext/richtextformatdlg.cpp:371
+msgid "Borders"
+msgstr "Bordes"
+
+#: ../src/richtext/richtextformatdlg.cpp:765
+msgid "Colour"
+msgstr "Color"
+
+#: ../src/richtext/richtextindentspage.cpp:127
+#: ../src/richtext/richtextliststylepage.cpp:322
+msgid "&Alignment"
+msgstr "&Alinear"
+
+#: ../src/richtext/richtextindentspage.cpp:138
+#: ../src/richtext/richtextliststylepage.cpp:331
+msgid "&Left"
+msgstr "&Izquierda"
+
+#: ../src/richtext/richtextindentspage.cpp:140
+#: ../src/richtext/richtextindentspage.cpp:142
+#: ../src/richtext/richtextliststylepage.cpp:333
+#: ../src/richtext/richtextliststylepage.cpp:335
+msgid "Left-align text."
+msgstr "Texto alineado a la izquierda."
+
+#: ../src/richtext/richtextindentspage.cpp:145
+#: ../src/richtext/richtextliststylepage.cpp:338
+msgid "&Right"
+msgstr "&Derecha"
+
+#: ../src/richtext/richtextindentspage.cpp:147
+#: ../src/richtext/richtextindentspage.cpp:149
+#: ../src/richtext/richtextliststylepage.cpp:340
+#: ../src/richtext/richtextliststylepage.cpp:342
+msgid "Right-align text."
+msgstr "Alinear texto a la derecha."
+
+#: ../src/richtext/richtextindentspage.cpp:152
+#: ../src/richtext/richtextliststylepage.cpp:345
+msgid "&Justified"
+msgstr "&Justificado"
+
+#: ../src/richtext/richtextindentspage.cpp:154
+#: ../src/richtext/richtextindentspage.cpp:156
+#: ../src/richtext/richtextliststylepage.cpp:347
+#: ../src/richtext/richtextliststylepage.cpp:349
+msgid "Justify text left and right."
+msgstr "Justificar texto a izquierda y derecha."
+
+#: ../src/richtext/richtextindentspage.cpp:159
+#: ../src/richtext/richtextliststylepage.cpp:352
+msgid "Cen&tred"
+msgstr "Cen&trado"
+
+#: ../src/richtext/richtextindentspage.cpp:161
+#: ../src/richtext/richtextindentspage.cpp:163
+#: ../src/richtext/richtextliststylepage.cpp:354
+#: ../src/richtext/richtextliststylepage.cpp:356
+msgid "Centre text."
+msgstr "Centrar texto."
+
+#: ../src/richtext/richtextindentspage.cpp:166
+#: ../src/richtext/richtextliststylepage.cpp:359
+msgid "&Indeterminate"
+msgstr "&Indeterminado"
+
+#: ../src/richtext/richtextindentspage.cpp:168
+#: ../src/richtext/richtextindentspage.cpp:170
+#: ../src/richtext/richtextliststylepage.cpp:361
+#: ../src/richtext/richtextliststylepage.cpp:363
+msgid "Use the current alignment setting."
+msgstr "Utilizar el alineamiento actual."
+
+#: ../src/richtext/richtextindentspage.cpp:183
+#: ../src/richtext/richtextliststylepage.cpp:375
+msgid "&Indentation (tenths of a mm)"
+msgstr "&Sangría (décimas de mm)"
+
+#: ../src/richtext/richtextindentspage.cpp:198
+#: ../src/richtext/richtextindentspage.cpp:200
+#: ../src/richtext/richtextliststylepage.cpp:388
+#: ../src/richtext/richtextliststylepage.cpp:390
+msgid "The left indent."
+msgstr "La sangría izquierda."
+
+#: ../src/richtext/richtextindentspage.cpp:203
+#: ../src/richtext/richtextliststylepage.cpp:393
+msgid "Left (&first line):"
+msgstr "Izquierda (&primer renglón):"
+
+#: ../src/richtext/richtextindentspage.cpp:207
+#: ../src/richtext/richtextindentspage.cpp:209
+#: ../src/richtext/richtextliststylepage.cpp:397
+#: ../src/richtext/richtextliststylepage.cpp:399
+msgid "The first line indent."
+msgstr "La sangría del primer renglón."
+
+#: ../src/richtext/richtextindentspage.cpp:216
+#: ../src/richtext/richtextindentspage.cpp:218
+#: ../src/richtext/richtextliststylepage.cpp:406
+#: ../src/richtext/richtextliststylepage.cpp:408
+msgid "The right indent."
+msgstr "La sangría derecha."
+
+#: ../src/richtext/richtextindentspage.cpp:221
+msgid "&Outline level:"
+msgstr "Nivel del c&ontorno:"
+
+#: ../src/richtext/richtextindentspage.cpp:226
+#: ../src/richtext/richtextindentspage.cpp:228
+msgid "The outline level."
+msgstr "El nivel del contorno."
+
+#: ../src/richtext/richtextindentspage.cpp:241
+#: ../src/richtext/richtextliststylepage.cpp:420
+msgid "&Spacing (tenths of a mm)"
+msgstr "&Espaciado (décimas de mm)"
+
+#: ../src/richtext/richtextindentspage.cpp:252
+msgid "&Before a paragraph:"
+msgstr "&Antes de un párrafo:"
+
+#: ../src/richtext/richtextindentspage.cpp:256
+#: ../src/richtext/richtextindentspage.cpp:258
+#: ../src/richtext/richtextliststylepage.cpp:433
+#: ../src/richtext/richtextliststylepage.cpp:435
+msgid "The spacing before the paragraph."
+msgstr "El espaciado antes del párrafo."
+
+#: ../src/richtext/richtextindentspage.cpp:261
+msgid "&After a paragraph:"
+msgstr "&Después de un párrafo:"
+
+#: ../src/richtext/richtextindentspage.cpp:266
+#: ../src/richtext/richtextliststylepage.cpp:442
+#: ../src/richtext/richtextliststylepage.cpp:444
+msgid "The spacing after the paragraph."
+msgstr "El espaciado depués del párrafo."
+
+#: ../src/richtext/richtextindentspage.cpp:269
+msgid "L&ine spacing:"
+msgstr "&Interlineado:"
+
+#: ../src/richtext/richtextindentspage.cpp:274
+#: ../src/richtext/richtextliststylepage.cpp:452
+msgid "Single"
+msgstr "Sencillo"
+
+#: ../src/richtext/richtextindentspage.cpp:275
+#: ../src/richtext/richtextliststylepage.cpp:453
+msgid "1.1"
+msgstr "1.1"
+
+#: ../src/richtext/richtextindentspage.cpp:276
+#: ../src/richtext/richtextliststylepage.cpp:454
+msgid "1.2"
+msgstr "1.2"
+
+#: ../src/richtext/richtextindentspage.cpp:277
+#: ../src/richtext/richtextliststylepage.cpp:455
+msgid "1.3"
+msgstr "1.3"
+
+#: ../src/richtext/richtextindentspage.cpp:278
+#: ../src/richtext/richtextliststylepage.cpp:456
+msgid "1.4"
+msgstr "1.4"
+
+#: ../src/richtext/richtextindentspage.cpp:279
+#: ../src/richtext/richtextliststylepage.cpp:457
+msgid "1.5"
+msgstr "1.5"
+
+#: ../src/richtext/richtextindentspage.cpp:280
+#: ../src/richtext/richtextliststylepage.cpp:458
+msgid "1.6"
+msgstr "1.6"
+
+#: ../src/richtext/richtextindentspage.cpp:281
+#: ../src/richtext/richtextliststylepage.cpp:459
+msgid "1.7"
+msgstr "1.7"
+
+#: ../src/richtext/richtextindentspage.cpp:282
+#: ../src/richtext/richtextliststylepage.cpp:460
+msgid "1.8"
+msgstr "1.8"
+
+#: ../src/richtext/richtextindentspage.cpp:283
+#: ../src/richtext/richtextliststylepage.cpp:461
+msgid "1.9"
+msgstr "1.9"
+
+#: ../src/richtext/richtextindentspage.cpp:284
+#: ../src/richtext/richtextliststylepage.cpp:462
+msgid "2"
+msgstr "2"
+
+#: ../src/richtext/richtextindentspage.cpp:287
+#: ../src/richtext/richtextindentspage.cpp:289
+#: ../src/richtext/richtextliststylepage.cpp:465
+#: ../src/richtext/richtextliststylepage.cpp:467
+msgid "The line spacing."
+msgstr "El espaciado de línea."
+
+#: ../src/richtext/richtextindentspage.cpp:292
+msgid "&Page Break"
+msgstr "Salto de &página"
+
+#: ../src/richtext/richtextindentspage.cpp:294
+#: ../src/richtext/richtextindentspage.cpp:296
+msgid "Inserts a page break before the paragraph."
+msgstr "Inserta un salto de página antes del párrafo."
+
+#: ../src/richtext/richtextindentspage.cpp:302
+#: ../src/richtext/richtextindentspage.cpp:304
+msgid "Shows a preview of the paragraph settings."
+msgstr "Muestra una previsualización de las opciones del párrafo."
+
+#: ../src/richtext/richtextliststylepage.cpp:182
+msgid "&List level:"
+msgstr "Nivel de &lista:"
+
+#: ../src/richtext/richtextliststylepage.cpp:186
+#: ../src/richtext/richtextliststylepage.cpp:188
+msgid "Selects the list level to edit."
+msgstr "Selecciona el nivel de lista a editar."
+
+#: ../src/richtext/richtextliststylepage.cpp:193
+msgid "&Font for Level..."
+msgstr "&Tipo de letra del nivel…"
+
+#: ../src/richtext/richtextliststylepage.cpp:194
+#: ../src/richtext/richtextliststylepage.cpp:196
+msgid "Click to choose the font for this level."
+msgstr "Pulse para elegir el tipo de letra de este nivel."
+
+#: ../src/richtext/richtextliststylepage.cpp:312
+msgid "Bullet style"
+msgstr "Estilo de viñeta"
+
+#: ../src/richtext/richtextliststylepage.cpp:429
+msgid "Before a paragraph:"
+msgstr "Antes de un párrafo:"
+
+#: ../src/richtext/richtextliststylepage.cpp:438
+msgid "After a paragraph:"
+msgstr "Después de un párrafo:"
+
+#: ../src/richtext/richtextliststylepage.cpp:447
+msgid "Line spacing:"
+msgstr "Interlineado:"
+
+#: ../src/richtext/richtextliststylepage.cpp:470
+msgid "Spacing"
+msgstr "Espaciado"
+
+#: ../src/richtext/richtextmarginspage.cpp:193
+#: ../src/richtext/richtextmarginspage.cpp:195
+msgid "The left margin size."
+msgstr "El tamaño del margen izquierdo."
+
+#: ../src/richtext/richtextmarginspage.cpp:203
+#: ../src/richtext/richtextmarginspage.cpp:205
+msgid "Units for the left margin."
+msgstr "Unidades del margen izquierdo."
+
+#: ../src/richtext/richtextmarginspage.cpp:218
+#: ../src/richtext/richtextmarginspage.cpp:220
+msgid "The right margin size."
+msgstr "El tamaño del margen derecho."
+
+#: ../src/richtext/richtextmarginspage.cpp:228
+#: ../src/richtext/richtextmarginspage.cpp:230
+msgid "Units for the right margin."
+msgstr "Unidades del margen derecho."
+
+#: ../src/richtext/richtextmarginspage.cpp:241
+#: ../src/richtext/richtextmarginspage.cpp:243
+msgid "The top margin size."
+msgstr "El tamaño del margen superior."
+
+#: ../src/richtext/richtextmarginspage.cpp:251
+#: ../src/richtext/richtextmarginspage.cpp:253
+msgid "Units for the top margin."
+msgstr "Unidades para el margen superior."
+
+#: ../src/richtext/richtextmarginspage.cpp:266
+#: ../src/richtext/richtextmarginspage.cpp:268
+msgid "The bottom margin size."
+msgstr "El tamaño del margén inferior."
+
+#: ../src/richtext/richtextmarginspage.cpp:276
+#: ../src/richtext/richtextmarginspage.cpp:278
+msgid "Units for the bottom margin."
+msgstr "Unidades para el margen inferior."
+
+#: ../src/richtext/richtextmarginspage.cpp:284
+msgid "Padding"
+msgstr "Relleno"
+
+#: ../src/richtext/richtextmarginspage.cpp:307
+#: ../src/richtext/richtextmarginspage.cpp:309
+msgid "The left padding size."
+msgstr "El tamaño del relleno izquierdo."
+
+#: ../src/richtext/richtextmarginspage.cpp:317
+#: ../src/richtext/richtextmarginspage.cpp:319
+msgid "Units for the left padding."
+msgstr "Unidades para el relleno izquierdo."
+
+#: ../src/richtext/richtextmarginspage.cpp:332
+#: ../src/richtext/richtextmarginspage.cpp:334
+msgid "The right padding size."
+msgstr "El tamaño del relleno derecho."
+
+#: ../src/richtext/richtextmarginspage.cpp:342
+#: ../src/richtext/richtextmarginspage.cpp:344
+msgid "Units for the right padding."
+msgstr "Unidades para el relleno derecho."
+
+#: ../src/richtext/richtextmarginspage.cpp:355
+#: ../src/richtext/richtextmarginspage.cpp:357
+msgid "The top padding size."
+msgstr "El tamaño del relleno superior."
+
+#: ../src/richtext/richtextmarginspage.cpp:365
+#: ../src/richtext/richtextmarginspage.cpp:367
+msgid "Units for the top padding."
+msgstr "Unidades para el relleno superior."
+
+#: ../src/richtext/richtextmarginspage.cpp:380
+#: ../src/richtext/richtextmarginspage.cpp:382
+msgid "The bottom padding size."
+msgstr "El tamaño del relleno inferior."
+
+#: ../src/richtext/richtextmarginspage.cpp:390
+#: ../src/richtext/richtextmarginspage.cpp:392
+msgid "Units for the bottom padding."
+msgstr "Unidades para el relleno inferior."
+
+#: ../src/richtext/richtextprint.cpp:592
+msgid " Preview"
+msgstr " Previsualización"
+
+#: ../src/richtext/richtextsizepage.cpp:228
+msgid "Floating"
+msgstr "Flotante"
+
+#: ../src/richtext/richtextsizepage.cpp:243
+msgid "&Floating mode:"
+msgstr "Modo &flotante:"
+
+#: ../src/richtext/richtextsizepage.cpp:252
+#: ../src/richtext/richtextsizepage.cpp:254
+msgid "How the object will float relative to the text."
+msgstr "Cómo flotará el objeto en relación con el texto."
+
+#: ../src/richtext/richtextsizepage.cpp:265
+msgid "Alignment"
+msgstr "Alineación"
+
+#: ../src/richtext/richtextsizepage.cpp:277
+msgid "&Vertical alignment:"
+msgstr "Alineación &vertical:"
+
+#: ../src/richtext/richtextsizepage.cpp:279
+#: ../src/richtext/richtextsizepage.cpp:281
+msgid "Enable vertical alignment."
+msgstr "Activar la alineación vertical."
+
+#: ../src/richtext/richtextsizepage.cpp:286
+msgid "Centred"
+msgstr "Centrado"
+
+#: ../src/richtext/richtextsizepage.cpp:290
+#: ../src/richtext/richtextsizepage.cpp:292
+msgid "Vertical alignment."
+msgstr "Alineación vertical."
+
+#: ../src/richtext/richtextsizepage.cpp:316
+#: ../src/richtext/richtextsizepage.cpp:323
+msgid "&Width:"
+msgstr "&Ancho:"
+
+#: ../src/richtext/richtextsizepage.cpp:318
+#: ../src/richtext/richtextsizepage.cpp:320
+msgid "Enable the width value."
+msgstr "Activar el valor de anchura."
+
+#: ../src/richtext/richtextsizepage.cpp:331
+#: ../src/richtext/richtextsizepage.cpp:333
+msgid "The object width."
+msgstr "El ancho del objeto."
+
+#: ../src/richtext/richtextsizepage.cpp:342
+#: ../src/richtext/richtextsizepage.cpp:344
+msgid "Units for the object width."
+msgstr "Unidades del ancho del objeto."
+
+#: ../src/richtext/richtextsizepage.cpp:350
+#: ../src/richtext/richtextsizepage.cpp:357
+msgid "&Height:"
+msgstr "&Altura:"
+
+#: ../src/richtext/richtextsizepage.cpp:352
+#: ../src/richtext/richtextsizepage.cpp:354
+#: ../src/richtext/richtextsizepage.cpp:464
+#: ../src/richtext/richtextsizepage.cpp:466
+msgid "Enable the height value."
+msgstr "Activar el valor de altura."
+
+#: ../src/richtext/richtextsizepage.cpp:365
+#: ../src/richtext/richtextsizepage.cpp:367
+msgid "The object height."
+msgstr "La altura del objeto."
+
+#: ../src/richtext/richtextsizepage.cpp:376
+#: ../src/richtext/richtextsizepage.cpp:378
+msgid "Units for the object height."
+msgstr "Unidades del alto del objeto."
+
+#: ../src/richtext/richtextsizepage.cpp:381
+msgid "Min width:"
+msgstr "Anchura mínima:"
+
+#: ../src/richtext/richtextsizepage.cpp:383
+#: ../src/richtext/richtextsizepage.cpp:385
+msgid "Enable the minimum width value."
+msgstr "Activar el ancho mínimo."
+
+#: ../src/richtext/richtextsizepage.cpp:392
+#: ../src/richtext/richtextsizepage.cpp:394
+msgid "The object minimum width."
+msgstr "La anchura mínima del objeto."
+
+#: ../src/richtext/richtextsizepage.cpp:403
+#: ../src/richtext/richtextsizepage.cpp:405
+msgid "Units for the minimum object width."
+msgstr "Unidades para la anchura mínima del objeto."
+
+#: ../src/richtext/richtextsizepage.cpp:408
+msgid "Min height:"
+msgstr "Altura mínima:"
+
+#: ../src/richtext/richtextsizepage.cpp:410
+#: ../src/richtext/richtextsizepage.cpp:412
+msgid "Enable the minimum height value."
+msgstr "Activar el valor de altura mínima."
+
+#: ../src/richtext/richtextsizepage.cpp:419
+#: ../src/richtext/richtextsizepage.cpp:421
+msgid "The object minimum height."
+msgstr "La altura mínima del objeto."
+
+#: ../src/richtext/richtextsizepage.cpp:430
+#: ../src/richtext/richtextsizepage.cpp:432
+msgid "Units for the minimum object height."
+msgstr "Unidades para la altura mínima del objeto."
+
+#: ../src/richtext/richtextsizepage.cpp:435
+msgid "Max width:"
+msgstr "Anchura máxima:"
+
+#: ../src/richtext/richtextsizepage.cpp:437
+#: ../src/richtext/richtextsizepage.cpp:439
+msgid "Enable the maximum width value."
+msgstr "Activar el ancho máximo."
+
+#: ../src/richtext/richtextsizepage.cpp:446
+#: ../src/richtext/richtextsizepage.cpp:448
+msgid "The object maximum width."
+msgstr "La anchura máxima del objeto."
+
+#: ../src/richtext/richtextsizepage.cpp:457
+#: ../src/richtext/richtextsizepage.cpp:459
+msgid "Units for the maximum object width."
+msgstr "Unidades para la anchura máxima del objeto."
+
+#: ../src/richtext/richtextsizepage.cpp:462
+msgid "Max height:"
+msgstr "Altura máxima:"
+
+#: ../src/richtext/richtextsizepage.cpp:473
+#: ../src/richtext/richtextsizepage.cpp:475
+msgid "The object maximum height."
+msgstr "La altura máxima del objeto."
+
+#: ../src/richtext/richtextsizepage.cpp:484
+#: ../src/richtext/richtextsizepage.cpp:486
+msgid "Units for the maximum object height."
+msgstr "Unidades para la altura máxima del objeto."
+
+#: ../src/richtext/richtextsizepage.cpp:495
+msgid "Position"
+msgstr "Posición"
+
+#: ../src/richtext/richtextsizepage.cpp:513
+msgid "&Position mode:"
+msgstr "&Modo de colocar:"
+
+#: ../src/richtext/richtextsizepage.cpp:517
+#: ../src/richtext/richtextsizepage.cpp:522
+msgid "Static"
+msgstr "Estático"
+
+#: ../src/richtext/richtextsizepage.cpp:518
+msgid "Relative"
+msgstr "Relativo"
+
+#: ../src/richtext/richtextsizepage.cpp:519
+msgid "Absolute"
+msgstr "Absoluto"
+
+#: ../src/richtext/richtextsizepage.cpp:520
+msgid "Fixed"
+msgstr "Fija"
+
+#: ../src/richtext/richtextsizepage.cpp:533
+#: ../src/richtext/richtextsizepage.cpp:535
+#: ../src/richtext/richtextsizepage.cpp:547
+#: ../src/richtext/richtextsizepage.cpp:549
+msgid "The left position."
+msgstr "La posición izquierda."
+
+#: ../src/richtext/richtextsizepage.cpp:558
+#: ../src/richtext/richtextsizepage.cpp:560
+msgid "Units for the left position."
+msgstr "Unidades para la posición izquierda."
+
+#: ../src/richtext/richtextsizepage.cpp:568
+#: ../src/richtext/richtextsizepage.cpp:570
+#: ../src/richtext/richtextsizepage.cpp:582
+#: ../src/richtext/richtextsizepage.cpp:584
+msgid "The top position."
+msgstr "La posición superior."
+
+#: ../src/richtext/richtextsizepage.cpp:593
+#: ../src/richtext/richtextsizepage.cpp:595
+msgid "Units for the top position."
+msgstr "Unidades para la posición superior."
+
+#: ../src/richtext/richtextsizepage.cpp:603
+#: ../src/richtext/richtextsizepage.cpp:605
+#: ../src/richtext/richtextsizepage.cpp:617
+#: ../src/richtext/richtextsizepage.cpp:619
+msgid "The right position."
+msgstr "La posición derecha."
+
+#: ../src/richtext/richtextsizepage.cpp:628
+#: ../src/richtext/richtextsizepage.cpp:630
+msgid "Units for the right position."
+msgstr "Unidades para la posición derecha."
+
+#: ../src/richtext/richtextsizepage.cpp:638
+#: ../src/richtext/richtextsizepage.cpp:640
+#: ../src/richtext/richtextsizepage.cpp:652
+#: ../src/richtext/richtextsizepage.cpp:654
+msgid "The bottom position."
+msgstr "La posición inferior."
+
+#: ../src/richtext/richtextsizepage.cpp:663
+#: ../src/richtext/richtextsizepage.cpp:665
+msgid "Units for the bottom position."
+msgstr "Unidades para la posición inferior."
+
+#: ../src/richtext/richtextsizepage.cpp:671
+msgid "&Move the object to:"
+msgstr "&Mover el objeto a:"
+
+#: ../src/richtext/richtextsizepage.cpp:674
+msgid "&Previous Paragraph"
+msgstr "Párrafo &anterior"
+
+#: ../src/richtext/richtextsizepage.cpp:675
+#: ../src/richtext/richtextsizepage.cpp:677
+msgid "Moves the object to the previous paragraph."
+msgstr "Mueve el objeto al párrafo anterior."
+
+#: ../src/richtext/richtextsizepage.cpp:680
+msgid "&Next Paragraph"
+msgstr "Párrafo &siguiente"
+
+#: ../src/richtext/richtextsizepage.cpp:681
+#: ../src/richtext/richtextsizepage.cpp:683
+msgid "Moves the object to the next paragraph."
+msgstr "Mueve el objeto al párrafo siguiente."
+
+#: ../src/richtext/richtextstyledlg.cpp:193
+msgid "&Styles:"
+msgstr "E&stilos:"
+
+#: ../src/richtext/richtextstyledlg.cpp:197
+#: ../src/richtext/richtextstyledlg.cpp:199
+msgid "The available styles."
+msgstr "Los estilos disponibles."
+
+#: ../src/richtext/richtextstyledlg.cpp:205
+#: ../src/richtext/richtextstyledlg.cpp:217
+msgid " "
+msgstr " "
+
+#: ../src/richtext/richtextstyledlg.cpp:209
+#: ../src/richtext/richtextstyledlg.cpp:211
+msgid "The style preview."
+msgstr "La vista previa del estilo."
+
+#: ../src/richtext/richtextstyledlg.cpp:220
+msgid "New &Character Style..."
+msgstr "Estilo de &carácter nuevo…"
+
+#: ../src/richtext/richtextstyledlg.cpp:221
+#: ../src/richtext/richtextstyledlg.cpp:223
+msgid "Click to create a new character style."
+msgstr "Pulse para crear un nuevo estilo de caracter."
+
+#: ../src/richtext/richtextstyledlg.cpp:226
+msgid "New &Paragraph Style..."
+msgstr "Estilo de &párrafo nuevo…"
+
+#: ../src/richtext/richtextstyledlg.cpp:227
+#: ../src/richtext/richtextstyledlg.cpp:229
+msgid "Click to create a new paragraph style."
+msgstr "Pulse para crear un nuevo estilo de párrafo."
+
+#: ../src/richtext/richtextstyledlg.cpp:232
+msgid "New &List Style..."
+msgstr "Estilo de &lista nuevo…"
+
+#: ../src/richtext/richtextstyledlg.cpp:233
+#: ../src/richtext/richtextstyledlg.cpp:235
+msgid "Click to create a new list style."
+msgstr "Pulse para carear una nueva lista de estilo."
+
+#: ../src/richtext/richtextstyledlg.cpp:238
+msgid "New &Box Style..."
+msgstr "Estilo de &caja nuevo…"
+
+#: ../src/richtext/richtextstyledlg.cpp:239
+#: ../src/richtext/richtextstyledlg.cpp:241
+msgid "Click to create a new box style."
+msgstr "Pulse para crear un nuevo estilo de caja."
+
+#: ../src/richtext/richtextstyledlg.cpp:246
+msgid "&Apply Style"
+msgstr "&Aplicar estilo"
+
+#: ../src/richtext/richtextstyledlg.cpp:247
+#: ../src/richtext/richtextstyledlg.cpp:249
+msgid "Click to apply the selected style."
+msgstr "Pulse para aplicar el estilo seleccionado."
+
+#: ../src/richtext/richtextstyledlg.cpp:252
+msgid "&Rename Style..."
+msgstr "&Cambiar nombre de estilo…"
+
+#: ../src/richtext/richtextstyledlg.cpp:253
+#: ../src/richtext/richtextstyledlg.cpp:255
+msgid "Click to rename the selected style."
+msgstr "Pulse para renombrar el estilo seleccionado."
+
+#: ../src/richtext/richtextstyledlg.cpp:258
+msgid "&Edit Style..."
+msgstr "&Editar estilo…"
+
+#: ../src/richtext/richtextstyledlg.cpp:259
+#: ../src/richtext/richtextstyledlg.cpp:261
+msgid "Click to edit the selected style."
+msgstr "Pulse para editar el estilo seleccionado."
+
+#: ../src/richtext/richtextstyledlg.cpp:264
+msgid "&Delete Style..."
+msgstr "&Eliminar estilo…"
+
+#: ../src/richtext/richtextstyledlg.cpp:265
+#: ../src/richtext/richtextstyledlg.cpp:267
+msgid "Click to delete the selected style."
+msgstr "Pulse para borrar el estilo seleccionado."
+
+#: ../src/richtext/richtextstyledlg.cpp:274
+#: ../src/richtext/richtextstyledlg.cpp:276
+msgid "Click to close this window."
+msgstr "Pulse para cerrar esta ventana."
+
+#: ../src/richtext/richtextstyledlg.cpp:282
+msgid "&Restart numbering"
+msgstr "&Recomenzar numeración"
+
+#: ../src/richtext/richtextstyledlg.cpp:284
+#: ../src/richtext/richtextstyledlg.cpp:286
+msgid "Check to restart numbering."
+msgstr "Active para reiniciar la numeración."
+
+#: ../src/richtext/richtextstyledlg.cpp:601
+msgid "Enter a character style name"
+msgstr "Introduzca un nombre de estilo de caracter"
+
+#: ../src/richtext/richtextstyledlg.cpp:601
+#: ../src/richtext/richtextstyledlg.cpp:606
+#: ../src/richtext/richtextstyledlg.cpp:649
+#: ../src/richtext/richtextstyledlg.cpp:654
+#: ../src/richtext/richtextstyledlg.cpp:815
+#: ../src/richtext/richtextstyledlg.cpp:820
+#: ../src/richtext/richtextstyledlg.cpp:888
+#: ../src/richtext/richtextstyledlg.cpp:896
+#: ../src/richtext/richtextstyledlg.cpp:929
+#: ../src/richtext/richtextstyledlg.cpp:934
+msgid "New Style"
+msgstr "Estilo nuevo"
+
+#: ../src/richtext/richtextstyledlg.cpp:606
+#: ../src/richtext/richtextstyledlg.cpp:654
+#: ../src/richtext/richtextstyledlg.cpp:820
+#: ../src/richtext/richtextstyledlg.cpp:896
+#: ../src/richtext/richtextstyledlg.cpp:934
+msgid "Sorry, that name is taken. Please choose another."
+msgstr "Ese nombre ya está en uso. Elija otro."
+
+#: ../src/richtext/richtextstyledlg.cpp:649
+msgid "Enter a paragraph style name"
+msgstr "Introduzca un nombre de estilo de párrafo"
+
+#: ../src/richtext/richtextstyledlg.cpp:777
+#, c-format
+msgid "Delete style %s?"
+msgstr "¿Eliminar estilo %s?"
+
+#: ../src/richtext/richtextstyledlg.cpp:777
+msgid "Delete Style"
+msgstr "Eliminar estilo"
+
+#: ../src/richtext/richtextstyledlg.cpp:815
+msgid "Enter a list style name"
+msgstr "Introduzca un nombre de estilo de lista"
+
+#: ../src/richtext/richtextstyledlg.cpp:888
+msgid "Enter a new style name"
+msgstr "Introduzca un nuevo nombre de estilo"
+
+#: ../src/richtext/richtextstyledlg.cpp:929
+msgid "Enter a box style name"
+msgstr "Introduzca un nombre de estilo de caja"
+
+#: ../src/richtext/richtextstylepage.cpp:109
+#: ../src/richtext/richtextstylepage.cpp:111
+msgid "The style name."
+msgstr "El nombre del estilo."
+
+#: ../src/richtext/richtextstylepage.cpp:114
+msgid "&Based on:"
+msgstr "&Basado en:"
+
+#: ../src/richtext/richtextstylepage.cpp:119
+#: ../src/richtext/richtextstylepage.cpp:121
+msgid "The style on which this style is based."
+msgstr "El estilo en que se basa este estilo."
+
+#: ../src/richtext/richtextstylepage.cpp:124
+msgid "&Next style:"
+msgstr "Estilo &siguiente:"
+
+#: ../src/richtext/richtextstylepage.cpp:129
+#: ../src/richtext/richtextstylepage.cpp:131
+msgid "The default style for the next paragraph."
+msgstr "El estilo predeterminado para el siguiente párrafo."
+
+#: ../src/richtext/richtextstyles.cpp:1057
+msgid "All styles"
+msgstr "Todos los estilos"
+
+#: ../src/richtext/richtextstyles.cpp:1058
+msgid "Paragraph styles"
+msgstr "Estilos de párrafo"
+
+#: ../src/richtext/richtextstyles.cpp:1059
+msgid "Character styles"
+msgstr "Estilos de carácter"
+
+#: ../src/richtext/richtextstyles.cpp:1060
+msgid "List styles"
+msgstr "Estilos de lista"
+
+#: ../src/richtext/richtextstyles.cpp:1061
+msgid "Box styles"
+msgstr "Estilos de caja"
+
+#: ../src/richtext/richtextsymboldlg.cpp:389
+#: ../src/richtext/richtextsymboldlg.cpp:391
+msgid "The font from which to take the symbol."
+msgstr "El tipo de letra del que tomar el símbolo."
+
+#: ../src/richtext/richtextsymboldlg.cpp:396
+msgid "&Subset:"
+msgstr "&Subconjunto:"
+
+#: ../src/richtext/richtextsymboldlg.cpp:401
+#: ../src/richtext/richtextsymboldlg.cpp:403
+msgid "Shows a Unicode subset."
+msgstr "Muestra un subconjunto Unicode."
+
+#: ../src/richtext/richtextsymboldlg.cpp:412
+msgid "xxxx"
+msgstr "xxxx"
+
+#: ../src/richtext/richtextsymboldlg.cpp:417
+msgid "&Character code:"
+msgstr "&Código de carácter:"
+
+#: ../src/richtext/richtextsymboldlg.cpp:421
+#: ../src/richtext/richtextsymboldlg.cpp:423
+msgid "The character code."
+msgstr "El código de carácter."
+
+#: ../src/richtext/richtextsymboldlg.cpp:428
+msgid "&From:"
+msgstr "&Desde:"
+
+#: ../src/richtext/richtextsymboldlg.cpp:433
+#: ../src/richtext/richtextsymboldlg.cpp:434
+#: ../src/richtext/richtextsymboldlg.cpp:435
+msgid "Unicode"
+msgstr "Unicode"
+
+#: ../src/richtext/richtextsymboldlg.cpp:436
+#: ../src/richtext/richtextsymboldlg.cpp:438
+msgid "The range to show."
+msgstr "El intervalo que mostrar."
+
+#: ../src/richtext/richtextsymboldlg.cpp:444
+msgid "Insert"
+msgstr "Insertar"
+
+#: ../src/richtext/richtextsymboldlg.cpp:478
+msgid "(Normal text)"
+msgstr "(Texto normal)"
+
+#: ../src/richtext/richtexttabspage.cpp:109
+msgid "&Position (tenths of a mm):"
+msgstr "&Posición (décimas de mm):"
+
+#: ../src/richtext/richtexttabspage.cpp:113
+#: ../src/richtext/richtexttabspage.cpp:115
+msgid "The tab position."
+msgstr "La posición de tabulación."
+
+#: ../src/richtext/richtexttabspage.cpp:119
+msgid "The tab positions."
+msgstr "Las posiciones de tabulación."
+
+#: ../src/richtext/richtexttabspage.cpp:132
+#: ../src/richtext/richtexttabspage.cpp:134
+msgid "Click to create a new tab position."
+msgstr "Pulse para crear una nueva posición de tabulador."
+
+#: ../src/richtext/richtexttabspage.cpp:138
+#: ../src/richtext/richtexttabspage.cpp:140
+msgid "Click to delete the selected tab position."
+msgstr "Pulse para borrar la posición de tabulador seleccionada."
+
+#: ../src/richtext/richtexttabspage.cpp:143
+msgid "Delete A&ll"
+msgstr "Eliminar &todo"
+
+#: ../src/richtext/richtexttabspage.cpp:144
+#: ../src/richtext/richtexttabspage.cpp:146
+msgid "Click to delete all tab positions."
+msgstr "Pulse para borrar todas las posiciones de tabulación."
+
+#: ../src/univ/theme.cpp:110
+msgid "Failed to initialize GUI: no built-in themes found."
+msgstr "Fallo al inicializar GUI: no se encontraron temas."
+
+#: ../src/univ/themes/gtk.cpp:521
+msgid "GTK+ theme"
+msgstr "Tema de GTK+"
+
+#: ../src/univ/themes/metal.cpp:164
+msgid "Metal theme"
+msgstr "Tema metálico"
+
+#: ../src/univ/themes/mono.cpp:512
+msgid "Simple monochrome theme"
+msgstr "Tema monocromo sencillo"
+
+#: ../src/univ/themes/win32.cpp:1098
+msgid "Win32 theme"
+msgstr "Tema Win32"
+
+#: ../src/univ/themes/win32.cpp:3743
+msgid "&Restore"
+msgstr "&Restaurar"
+
+#: ../src/univ/themes/win32.cpp:3744
+msgid "&Move"
+msgstr "&Mover"
+
+#: ../src/univ/themes/win32.cpp:3746
+msgid "&Size"
+msgstr "&Tamaño"
+
+#: ../src/univ/themes/win32.cpp:3748
+msgid "Mi&nimize"
+msgstr "Mi&nimizar"
+
+#: ../src/univ/themes/win32.cpp:3750
+msgid "Ma&ximize"
+msgstr "Ma&ximizar"
+
+#: ../src/univ/themes/win32.cpp:3752
+msgid "Alt+"
+msgstr "Alt+"
+
+#: ../src/unix/appunix.cpp:178
+msgid "Failed to install signal handler"
+msgstr "Error instalando el manejador de señal"
+
+#: ../src/unix/dialup.cpp:351
+msgid "Already dialling ISP."
+msgstr "Ya está llamando al ISP."
+
+#: ../src/unix/dlunix.cpp:93
+msgid "Failed to unload shared library"
+msgstr "Falló la descarga de la biblioteca compartida"
+
+#: ../src/unix/dlunix.cpp:121
+msgid "Unknown dynamic library error"
+msgstr "Error desconocido de biblioteca dinámica"
+
+#: ../src/unix/epolldispatcher.cpp:84
+msgid "Failed to create epoll descriptor"
+msgstr "Falló la creación del descriptor epoll"
+
+#: ../src/unix/epolldispatcher.cpp:103
+msgid "Error closing epoll descriptor"
+msgstr "Error al cerrar el descriptor epoll"
+
+#: ../src/unix/epolldispatcher.cpp:116
+#, c-format
+msgid "Failed to add descriptor %d to epoll descriptor %d"
+msgstr "Fallo al añadir el descriptor %d al descriptor epoll %d"
+
+#: ../src/unix/epolldispatcher.cpp:136
+#, c-format
+msgid "Failed to modify descriptor %d in epoll descriptor %d"
+msgstr "No se pudo modificar el descriptor %d en el descriptor epoll %d"
+
+#: ../src/unix/epolldispatcher.cpp:155
+#, c-format
+msgid "Failed to unregister descriptor %d from epoll descriptor %d"
+msgstr ""
+"Fallo durante la anulación del registro del descriptor %d del descriptor "
+"epoll %d"
+
+#: ../src/unix/epolldispatcher.cpp:213
+#, c-format
+msgid "Waiting for IO on epoll descriptor %d failed"
+msgstr "Falló la espera de E/S en el descriptor epoll %d"
+
+#: ../src/unix/fswatcher_inotify.cpp:71
+msgid "Unable to create inotify instance"
+msgstr "No se pudo crear la instancia inotify"
+
+#: ../src/unix/fswatcher_inotify.cpp:94
+msgid "Unable to close inotify instance"
+msgstr "No se pudo cerrar la instancia inotify"
+
+#: ../src/unix/fswatcher_inotify.cpp:106
+msgid "Unable to add inotify watch"
+msgstr "No se pudo añadir la vista inotify"
+
+#: ../src/unix/fswatcher_inotify.cpp:138
+#, c-format
+msgid "Unable to remove inotify watch %i"
+msgstr "No se pudo quitar la supervisión inotify %i"
+
+#: ../src/unix/fswatcher_inotify.cpp:271
+#, c-format
+msgid "Unexpected event for \"%s\": no matching watch descriptor."
+msgstr "Suceso inesperado para «%s»: no hay descriptor de vista coincidente."
+
+#: ../src/unix/fswatcher_inotify.cpp:320
+#, c-format
+msgid "Invalid inotify event for \"%s\""
+msgstr "Suceso inotify no válido para «%s»"
+
+#: ../src/unix/fswatcher_inotify.cpp:553
+msgid "Unable to read from inotify descriptor"
+msgstr "No se pudo leer del descriptor inotify"
+
+#: ../src/unix/fswatcher_inotify.cpp:558
+msgid "EOF while reading from inotify descriptor"
+msgstr "EOF mientras se leia del descriptor inotify"
+
+#: ../src/unix/fswatcher_kqueue.cpp:114
+msgid "Unable to create kqueue instance"
+msgstr "No se pudo crear la instancia kqueue"
+
+#: ../src/unix/fswatcher_kqueue.cpp:131
+msgid "Error closing kqueue instance"
+msgstr "Error cerrando la instancia kqueue"
+
+#: ../src/unix/fswatcher_kqueue.cpp:153
+msgid "Unable to add kqueue watch"
+msgstr "No se pudo añadir la vista kqueue"
+
+#: ../src/unix/fswatcher_kqueue.cpp:170
+msgid "Unable to remove kqueue watch"
+msgstr "No se pudo eliminar la vista kqueue"
+
+#: ../src/unix/fswatcher_kqueue.cpp:202
+msgid "Unable to get events from kqueue"
+msgstr "No se pudieron obtener sucesos de kqueue"
+
+#: ../src/unix/mediactrl.cpp:966
+#, c-format
+msgid "Media playback error: %s"
+msgstr "Error de reproducción del medio: %s"
+
+#: ../src/unix/mediactrl.cpp:1228
+#, c-format
+msgid "Failed to prepare playing \"%s\"."
+msgstr "Falló la preparación de la reproducción de «%s»."
+
+#: ../src/unix/snglinst.cpp:164
+#, c-format
+msgid "Failed to write to lock file '%s'"
+msgstr "No se pudo escribir en el archivo de bloqueo «%s»"
+
+#: ../src/unix/snglinst.cpp:177
+#, c-format
+msgid "Failed to set permissions on lock file '%s'"
+msgstr "No se pudieron establecer permisos para el archivo de bloqueo '%s'"
+
+#: ../src/unix/snglinst.cpp:194
+#, c-format
+msgid "Failed to lock the lock file '%s'"
+msgstr "No se pudo bloquear el bloqueo del archivo '%s'"
+
+#: ../src/unix/snglinst.cpp:237
+#, c-format
+msgid "Failed to inspect the lock file '%s'"
+msgstr "Error al inspeccionar el archivo de bloqueo '%s'"
+
+#: ../src/unix/snglinst.cpp:242
+#, c-format
+msgid "Lock file '%s' has incorrect owner."
+msgstr "El archivo de bloqueo «%s» tiene un propietario incorrecto."
+
+#: ../src/unix/snglinst.cpp:247
+#, c-format
+msgid "Lock file '%s' has incorrect permissions."
+msgstr "El archivo de bloqueo «%s» tiene permisos incorrectos."
+
+#: ../src/unix/snglinst.cpp:265
+msgid "Failed to access lock file."
+msgstr "Fallo al acceder al archivo de bloqueo."
+
+#: ../src/unix/snglinst.cpp:274
+msgid "Failed to read PID from lock file."
+msgstr "Falló la lectura del PID a partir del archivo de bloqueo."
+
+#: ../src/unix/snglinst.cpp:284
+#, c-format
+msgid "Failed to remove stale lock file '%s'."
+msgstr "No se pudo eliminar el antiguo archivo de bloqueo '%s'."
+
+#: ../src/unix/snglinst.cpp:297
+#, c-format
+msgid "Deleted stale lock file '%s'."
+msgstr "Archivo antiguo de bloqueo '%s' eliminado."
+
+#: ../src/unix/snglinst.cpp:308
+#, c-format
+msgid "Invalid lock file '%s'."
+msgstr "Archivo de bloqueo «%s» no válido."
+
+#: ../src/unix/snglinst.cpp:324
+#, c-format
+msgid "Failed to remove lock file '%s'"
+msgstr "No se pudo quitar el archivo de bloqueo '%s'"
+
+#: ../src/unix/snglinst.cpp:330
+#, c-format
+msgid "Failed to unlock lock file '%s'"
+msgstr "No se pudo desbloquear el archivo de bloqueo '%s'"
+
+#: ../src/unix/snglinst.cpp:336
+#, c-format
+msgid "Failed to close lock file '%s'"
+msgstr "No se pudo cerrar el archivo de bloqueo '%s'"
+
+#: ../src/unix/sound.cpp:77
+msgid "No sound"
+msgstr "No hay ningún sonido"
+
+#: ../src/unix/sound.cpp:364
+msgid "Unable to play sound asynchronously."
+msgstr "Imposible reproducir el sonido de forma asíncrona."
+
+#: ../src/unix/sound.cpp:458
+#, c-format
+msgid "Couldn't load sound data from '%s'."
+msgstr "No se pudieron cargar los datos de sonido desde «%s»."
+
+#: ../src/unix/sound.cpp:465
+#, c-format
+msgid "Sound file '%s' is in unsupported format."
+msgstr "El archivo de sonido «%s» está en un formato no admitido."
+
+#: ../src/unix/sound.cpp:480
+msgid "Sound data are in unsupported format."
+msgstr "Los datos de sonido están en un formato no admitido."
+
+#: ../src/unix/sound_sdl.cpp:226
+#, c-format
+msgid "Couldn't open audio: %s"
+msgstr "No se pudo abrir el audio: %s"
+
+#: ../src/unix/threadpsx.cpp:1033
+msgid "Cannot retrieve thread scheduling policy."
+msgstr ""
+"No se puede recuperar la normativa de planificación de hilos de ejecución."
+
+#: ../src/unix/threadpsx.cpp:1058
+#, c-format
+msgid "Cannot get priority range for scheduling policy %d."
+msgstr ""
+"No se puede obtener un intervalo de prioridades para la normativa de "
+"planificación %d."
+
+#: ../src/unix/threadpsx.cpp:1066
+msgid "Thread priority setting is ignored."
+msgstr "La configuración de la prioridad del hilo de ejecución es ignorada."
+
+#: ../src/unix/threadpsx.cpp:1221
+msgid ""
+"Failed to join a thread, potential memory leak detected - please restart the "
+"program"
+msgstr ""
+"Error al sincronizar con un hilo de ejecución, pérdida potencial de memoría "
+"detectada - por favor reinicie el programa"
+
+#: ../src/unix/threadpsx.cpp:1352
+#, c-format
+msgid "Failed to set thread concurrency level to %lu"
+msgstr ""
+"Error al establecer el nivel de concurrencia del hilo de ejecución a %lu"
+
+#: ../src/unix/threadpsx.cpp:1481
+#, c-format
+msgid "Failed to set thread priority %d."
+msgstr "Error al establecer la prioridad del hilo de ejecución %d."
+
+#: ../src/unix/threadpsx.cpp:1666
+msgid "Failed to terminate a thread."
+msgstr "Error al terminar un hilo de ejecución."
+
+#: ../src/unix/threadpsx.cpp:1893
+msgid "Thread module initialization failed: failed to create thread key"
+msgstr ""
+"Error en la inicialización del módulo de hilos de ejecución: error al crear "
+"clave de hilo"
+
+#: ../src/unix/utilsunx.cpp:340
+msgid "Impossible to get child process input"
+msgstr "Imposible obtener la entrada del proceso hijo"
+
+#: ../src/unix/utilsunx.cpp:390
+msgid "Can't write to child process's stdin"
+msgstr "No se puede escribir en stdin del proceso hijo"
+
+#: ../src/unix/utilsunx.cpp:644
+#, c-format
+msgid "Failed to execute '%s'\n"
+msgstr "Error al ejecutar '%s'\n"
+
+#: ../src/unix/utilsunx.cpp:678
+msgid "Fork failed"
+msgstr "Error en bifurcación de proceso (fork)"
+
+#: ../src/unix/utilsunx.cpp:701
+msgid "Failed to set process priority"
+msgstr "Error al establecer la prioridad del proceso"
+
+#: ../src/unix/utilsunx.cpp:712
+msgid "Failed to redirect child process input/output"
+msgstr "Error en la redirección de la entrada/salida del proceso hijo"
+
+#: ../src/unix/utilsunx.cpp:816
+msgid "Failed to set up non-blocking pipe, the program might hang."
+msgstr ""
+"Fallo al establecer una tubería no bloqueante, el progrma puede colgarse."
+
+#: ../src/unix/utilsunx.cpp:1023
+msgid "Cannot get the hostname"
+msgstr "No se puede obtener el nombre de la máquina"
+
+#: ../src/unix/utilsunx.cpp:1059
+msgid "Cannot get the official hostname"
+msgstr "No se puede obtener el nombre oficial de la máquina"
+
+#: ../src/unix/wakeuppipe.cpp:49
+msgid "Failed to create wake up pipe used by event loop."
+msgstr ""
+"Falló la creación de la tubería de aviso usada por el bucle de sucesos."
+
+#: ../src/unix/wakeuppipe.cpp:56
+msgid "Failed to switch wake up pipe to non-blocking mode"
+msgstr "Fallo al cambiar la tubería de aviso a modo no bloqueante"
+
+#: ../src/unix/wakeuppipe.cpp:117
+msgid "Failed to read from wake-up pipe"
+msgstr "Fallo leyendo de la tubería de aviso"
+
+#: ../src/x11/app.cpp:124
+#, c-format
+msgid "Invalid geometry specification '%s'"
+msgstr "Especificación de geometría no válida: '%s'"
+
+#: ../src/x11/app.cpp:167
+msgid "wxWidgets could not open display. Exiting."
+msgstr "wxWidgets no pudo abrir el display. Saliendo."
+
+#: ../src/x11/utils.cpp:169
+#, c-format
+msgid "Failed to close the display \"%s\""
+msgstr "No se pudo cerrar el display \"%s\""
+
+#: ../src/x11/utils.cpp:188
+#, c-format
+msgid "Failed to open display \"%s\"."
+msgstr "Falló la apertura de la pantalla «%s»."
+
+#: ../src/xml/xml.cpp:868
+#, c-format
+msgid "XML parsing error: '%s' at line %d"
+msgstr "Error de parseo de XML: '%s' en la línea %d"
+
+#: ../src/xrc/xh_propgrid.cpp:239
+#, c-format
+msgid "Page %i"
+msgstr "Página %i"
+
+#: ../src/xrc/xmlres.cpp:448
+#, c-format
+msgid "Cannot load resources from '%s'."
+msgstr "No se pueden cargar recursos desde «%s»."
+
+#: ../src/xrc/xmlres.cpp:799
+#, c-format
+msgid "Cannot open resources file '%s'."
+msgstr "No se puede cargar el archivo de recursos «%s»."
+
+#: ../src/xrc/xmlres.cpp:806
+#, c-format
+msgid "Cannot load resources from file '%s'."
+msgstr "No se pueden cargar los recursos a partir del archivo «%s»."
+
+#: ../src/xrc/xmlres.cpp:2767
+#, c-format
+msgid "Creating %s \"%s\" failed."
+msgstr "Falló la creación de %s «%s»."
+
+#, c-format
+#~ msgid "BMP: header has biClrUsed=%d when biBitCount=%d."
+#~ msgstr "BMP: la cabecera tiene biClrUsed=%d pero biBitCount=%d."
+
+#~ msgctxt "keyboard key"
+#~ msgid "Alt+"
+#~ msgstr "Alt+"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Ctrl+"
+#~ msgstr "Ctrl+"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Shift+"
+#~ msgstr "Mayúsculas+"
+
+#~ msgctxt "keyboard key"
+#~ msgid "RawCtrl+"
+#~ msgstr "RawCtrl+"
+
+#~ msgid "Copying more than one selected block to clipboard is not supported."
+#~ msgstr "No se puede copiar más de un bloque seleccionado al portapapeles."
+
+#~ msgid "Unsupported clipboard format."
+#~ msgstr "Formato de portapapeles no admitido."
+
+#~ msgid "Background colour"
+#~ msgstr "Color de fondo"
+
+#~ msgid "Font:"
+#~ msgstr "Tipo de letra:"
+
+#~ msgid "Size:"
+#~ msgstr "Tamaño:"
+
+#~ msgid "The font size in points."
+#~ msgstr "El tamaño en puntos del tipo de letra."
+
+#~ msgid "Style:"
+#~ msgstr "Estilo:"
+
+#~ msgid "Check to make the font bold."
+#~ msgstr "Active para definir en negrita el tipo de letra."
+
+#~ msgid "Check to make the font italic."
+#~ msgstr "Active para definir en cursiva el tipo de letra."
+
+#~ msgid "Check to make the font underlined."
+#~ msgstr "Active para definir en subrayado el tipo de letra."
+
+#~ msgid "Colour:"
+#~ msgstr "Color:"
+
+#~ msgid "Click to change the font colour."
+#~ msgstr "Pulse para cambiar el color de letra."
+
+#~ msgid "Shows a preview of the font."
+#~ msgstr "Muestra una vista previa de la fuente."
+
+#~ msgid "Click to cancel changes to the font."
+#~ msgstr "Pulse para cancelar los cambios al tipo de letra."
+
+#~ msgid "Click to confirm changes to the font."
+#~ msgstr "Pulse para confirmar los cambios al tipo de letra."
+
+#~ msgid "<Any>"
+#~ msgstr "<Cualquiera>"
+
+#~ msgid "<Any Roman>"
+#~ msgstr "<Cualquiera Roman>"
+
+#~ msgid "<Any Decorative>"
+#~ msgstr "<Cualquiera Decorativa>"
+
+#~ msgid "<Any Modern>"
+#~ msgstr "<Cualquiera Moderna>"
+
+#~ msgid "<Any Script>"
+#~ msgstr "<Cualquiera Script>"
+
+#~ msgid "<Any Swiss>"
+#~ msgstr "<Cualquiera Swiss>"
+
+#~ msgid "<Any Teletype>"
+#~ msgstr "<Cualquiera Teletipo>"
+
+#~ msgid "Printing "
+#~ msgstr "Imprimiendo "
+
+#~ msgid "Failed to insert text in the control."
+#~ msgstr "No se pudo insertar texto en el control."
+
+#~ msgid "Please choose a valid font."
+#~ msgstr "Elija un tipo de letra válido."
+
+#, c-format
+#~ msgid "Failed to display HTML document in %s encoding"
+#~ msgstr "Error al mostrar el documento HTML con codificación %s"
+
+#, c-format
+#~ msgid "wxWidgets could not open display for '%s': exiting."
+#~ msgstr "wxWidgets no pudo abrir el 'display' para '%s': saliendo."
+
+#~ msgid "Filter"
+#~ msgstr "Filtro"
+
+#~ msgid "Directories"
+#~ msgstr "Directorios"
+
+#~ msgid "Files"
+#~ msgstr "Archivos"
+
+#~ msgid "Selection"
+#~ msgstr "Selección"
+
+#~ msgid "conversion to 8-bit encoding failed"
+#~ msgstr "falló la conversión a codificación de 8 bits"
+
+#, fuzzy
+#~ msgid "failed to retrieve execution result"
+#~ msgstr "Fallo al recuperar el mensaje de error de RAS"
+
+#~ msgid " (while overwriting an existing item)"
+#~ msgstr " (al sobrescribir un elemento existente)"
+
+#~ msgid "&Save as"
+#~ msgstr "&Guardar como"
+
+#~ msgid "'%s' doesn't consist only of valid characters"
+#~ msgstr "'%s' no tiene exclusivamente caracteres válidos"
+
+#~ msgid "'%s' should be numeric."
+#~ msgstr "'%s debería ser numérico."
+
+#~ msgid "'%s' should only contain ASCII characters."
+#~ msgstr "'%s' debería contener sólo caracteres ASCII."
+
+#~ msgid "'%s' should only contain alphabetic characters."
+#~ msgstr "'%s' debería contener sólo caracteres de texto."
+
+#~ msgid "'%s' should only contain alphabetic or numeric characters."
+#~ msgstr "'%s debería contener sólo caracteres alfanuméricos."
+
+#~ msgid "'%s' should only contain digits."
+#~ msgstr "'%s' debería contener solo dígitos."
+
+#~ msgid "Can't create window of class %s"
+#~ msgstr "No se puede crear la ventana de clase %s"
+
+#~ msgid "Couldn't create the overlay window"
+#~ msgstr "No se pudo crear la ventana de superposición"
+
+#~ msgid "Couldn't init the context on the overlay window"
+#~ msgstr "No se pudo inicializar el contexto en la ventana de superposición"
+
+#~ msgid "Failed to convert file \"%s\" to Unicode."
+#~ msgstr "Fallo al convertir el archivo \"%s\" a Unicode."
+
+#~ msgid "Failed to set text in the text control."
+#~ msgstr "No se pudo colocar texto en el control de texto."
+
+#~ msgid "Invalid GTK+ command line option, use \"%s --help\""
+#~ msgstr "La opción de GTK+ de consola no es válida; utilice «%s --help»"
+
+#~ msgid "No unused colour in image."
+#~ msgstr "No hay ningún color sin usar en la imagen."
+
+#~ msgid "Not available"
+#~ msgstr "No disponible"
+
+#~ msgid "Replace selection"
+#~ msgstr "Reemplazar selección"
+
+#~ msgid "Save as"
+#~ msgstr "Guardar como"
+
+#~ msgid "Style Organiser"
+#~ msgstr "Organizador de estilos"
+
+#~ msgid "The following standard GTK+ options are also supported:\n"
+#~ msgstr "También se admiten las siguientes opciones estándares de GTK+:\n"
+
+#~ msgid "You cannot Clear an overlay that is not inited"
+#~ msgstr "No puede quitar una superposición que no ha sido inicializada"
+
+#~ msgid "You cannot Init an overlay twice"
+#~ msgstr "No puede Inicializar una superposición dos veces"
+
+#~ msgid "locale '%s' cannot be set."
+#~ msgstr "no se puede establecer la configuración regional «%s»."

--- a/po_wxstd/eu.po
+++ b/po_wxstd/eu.po
@@ -1,0 +1,10301 @@
+# Xabier Aramendi <azpidatziak@gmail.com>, 2011-2015.
+msgid ""
+msgstr ""
+"Project-Id-Version: wxWidgets 3.3\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-05-14 20:23+0200\n"
+"PO-Revision-Date: 2015-07-18 21:39+0200\n"
+"Last-Translator: Xabier Aramendi <azpidatziak@gmail.com>\n"
+"Language-Team: (EUS_Xabier Aramendi) <azpidatziak@gmail.com>\n"
+"Language: eu\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Poedit 1.8.2\n"
+
+#: ../include/wx/defs.h:2582
+msgid "All files (*.*)|*.*"
+msgstr "Agiri denak (*.*)|*.*"
+
+#: ../include/wx/defs.h:2585
+msgid "All files (*)|*"
+msgstr "Agiri denak (*)|*"
+
+#: ../include/wx/generic/progdlgg.h:85
+msgid "Elapsed time:"
+msgstr "Igarotako denbora:"
+
+#: ../include/wx/generic/progdlgg.h:86
+msgid "Estimated time:"
+msgstr "Ustezko denbora:"
+
+#: ../include/wx/generic/progdlgg.h:87
+msgid "Remaining time:"
+msgstr "Gelditzen den denbora:"
+
+#. TRANSLATORS: HTML printout default title.
+#: ../include/wx/html/htmprint.h:121 ../include/wx/prntbase.h:273
+#: ../include/wx/richtext/richtextprint.h:109 ../src/common/docview.cpp:2161
+msgid "Printout"
+msgstr "Irarketa"
+
+#. TRANSLATORS: HTML easy print default title.
+#: ../include/wx/html/htmprint.h:234 ../include/wx/richtext/richtextprint.h:163
+#: ../src/common/prntbase.cpp:522 ../src/html/htmprint.cpp:291
+msgid "Printing"
+msgstr "Irarkitzen"
+
+#: ../include/wx/msgdlg.h:277 ../src/common/stockitem.cpp:211
+msgid "Yes"
+msgstr "Bai"
+
+#: ../include/wx/msgdlg.h:278 ../src/common/stockitem.cpp:182
+msgid "No"
+msgstr "EZ"
+
+#: ../include/wx/msgdlg.h:279 ../src/common/stockitem.cpp:183
+#: ../src/msw/msgdlg.cpp:430 ../src/msw/msgdlg.cpp:734
+#: ../src/richtext/richtextstyledlg.cpp:292
+msgid "OK"
+msgstr "&Ongi"
+
+#: ../include/wx/msgdlg.h:280 ../src/common/stockitem.cpp:150
+#: ../src/msw/msgdlg.cpp:430 ../src/msw/progdlg.cpp:884
+#: ../src/richtext/richtextstyledlg.cpp:295
+msgid "Cancel"
+msgstr "E&zeztatu"
+
+#: ../include/wx/msgdlg.h:281 ../src/common/stockitem.cpp:168
+#: ../src/html/helpdlg.cpp:63 ../src/html/helpfrm.cpp:108
+#: ../src/osx/button_osx.cpp:38
+msgid "Help"
+msgstr "Laguntza"
+
+#: ../include/wx/msw/ole/oleutils.h:52
+msgid "Cannot initialize OLE"
+msgstr "Ezin da abiatu OLE"
+
+#: ../include/wx/msw/private/fswatcher.h:48
+#, c-format
+msgid "Unable to close the handle for '%s'"
+msgstr "Ezinezkoa '%s'-rako kudeaketa istea"
+
+#: ../include/wx/msw/private/fswatcher.h:92
+#, c-format
+msgid "Failed to open directory \"%s\" for monitoring."
+msgstr "Hutsegitea \"%s\" zuzenbidea monitorizatzeko irekitzerakoan."
+
+#: ../include/wx/msw/private/fswatcher.h:125
+msgid "Unable to close I/O completion port handle"
+msgstr "Ezinezkoa Sar/Irt osaketa ataka kudeaketa istea"
+
+#: ../include/wx/msw/private/fswatcher.h:142
+msgid "Unable to associate handle with I/O completion port"
+msgstr "Ezinezkoa Sar/Irt osaketa atakarekin kudeaketa elkartzea "
+
+#: ../include/wx/msw/private/fswatcher.h:148
+msgid "Unexpectedly new I/O completion port was created"
+msgstr "Ustekabeko S/I osaketa ataka berri bat sortu da"
+
+#: ../include/wx/msw/private/fswatcher.h:213
+msgid "Unable to post completion status"
+msgstr "Ezinezkoa osaketa egoera aurkeztea"
+
+#: ../include/wx/msw/private/fswatcher.h:262
+msgid "Unable to dequeue completion packet"
+msgstr "Ezinezkoa osaketa paketea deslerrotzea"
+
+#: ../include/wx/msw/private/fswatcher.h:273
+msgid "Unable to create I/O completion port"
+msgstr "Ezinezkoa Sar/Irt osaketa ataka sortzea"
+
+#: ../include/wx/richmsgdlg.h:29
+msgid "&See details"
+msgstr "&Ikusi xehetasunak"
+
+#: ../include/wx/richmsgdlg.h:30
+msgid "&Hide details"
+msgstr "E&zkutatu xehetasunak"
+
+#: ../include/wx/richtext/richtextbuffer.h:3864
+msgid "&Box"
+msgstr "&Kutxa"
+
+#: ../include/wx/richtext/richtextbuffer.h:5008
+msgid "&Picture"
+msgstr "&Irudia"
+
+#: ../include/wx/richtext/richtextbuffer.h:5958
+msgid "&Cell"
+msgstr "&Gelaxka"
+
+#: ../include/wx/richtext/richtextbuffer.h:6067
+msgid "&Table"
+msgstr "&Taula"
+
+#: ../include/wx/richtext/richtextimagedlg.h:37
+msgid "Object Properties"
+msgstr "Objetu Ezaugarriak"
+
+#: ../include/wx/richtext/richtextsymboldlg.h:39
+msgid "Symbols"
+msgstr "Sinboloak"
+
+#: ../include/wx/unix/pipe.h:46
+msgid "Pipe creation failed"
+msgstr "Hutsegitea hodia sortzean"
+
+#: ../include/wx/unix/private/displayx11.h:65
+msgid "Failed to enumerate video modes"
+msgstr "Hutsegita bideo moduak zenbakitzerakoan"
+
+#: ../include/wx/unix/private/displayx11.h:89
+msgid "Failed to change video mode"
+msgstr "Hutsegitea bideo modua aldatzerakoan"
+
+#: ../include/wx/unix/private/fswatcher_kqueue.h:57
+#, c-format
+msgid "Unable to open path '%s'"
+msgstr "Ezinezkoa '%s' helburua irekitzea"
+
+#: ../include/wx/unix/private/fswatcher_kqueue.h:74
+#, c-format
+msgid "Unable to close path '%s'"
+msgstr "Ezinezkoa '%s' helburua istea"
+
+#: ../include/wx/xtiprop.h:175
+msgid "SetProperty called w/o valid setter"
+msgstr "SetProperty w/o baliozko ezartzailea deituta"
+
+#: ../include/wx/xtiprop.h:184
+msgid "GetProperty called w/o valid getter"
+msgstr "GetProperty w/o baliozko lortzailea deituta"
+
+#: ../include/wx/xtiprop.h:193
+msgid "AddToPropertyCollection called w/o valid adder"
+msgstr "AddToPropertyCollection w/o baliozko gehitzailea deituta"
+
+#: ../include/wx/xtiprop.h:202
+msgid "GetPropertyCollection called w/o valid collection getter"
+msgstr "GetPropertyCollection w/o baliozko bilduma lortzailea deituta"
+
+#: ../include/wx/xtiprop.h:255
+msgid "AddToPropertyCollection called on a generic accessor"
+msgstr "AddToPropertyCollection deituta sarbideratzaile generiko batean"
+
+#: ../include/wx/xtiprop.h:262
+msgid "GetPropertyCollection called on a generic accessor"
+msgstr "GetPropertyCollection sarbideratzaile generiko batean deituta"
+
+#: ../src/aui/tabmdi.cpp:106 ../src/generic/mdig.cpp:94
+msgid "Cl&ose"
+msgstr "I&txi"
+
+#: ../src/aui/tabmdi.cpp:107 ../src/generic/mdig.cpp:95
+msgid "Close All"
+msgstr "Itxi Denak"
+
+#: ../src/aui/tabmdi.cpp:109 ../src/generic/mdig.cpp:97 ../src/msw/mdi.cpp:175
+#: ../src/qt/mdi.cpp:258
+msgid "&Next"
+msgstr "&Hurrengoa"
+
+#: ../src/aui/tabmdi.cpp:110 ../src/generic/mdig.cpp:98 ../src/msw/mdi.cpp:176
+#: ../src/qt/mdi.cpp:259
+msgid "&Previous"
+msgstr "&Aurrekoa"
+
+#: ../src/aui/tabmdi.cpp:332 ../src/aui/tabmdi.cpp:348
+#: ../src/aui/tabmdi.cpp:350 ../src/generic/mdig.cpp:291
+#: ../src/generic/mdig.cpp:307 ../src/generic/mdig.cpp:311
+#: ../src/msw/mdi.cpp:337 ../src/qt/mdi.cpp:462
+msgid "&Window"
+msgstr "&Leihoa"
+
+#: ../src/common/accelcmn.cpp:47
+msgctxt "keyboard key"
+msgid "Delete"
+msgstr "Ezabatu"
+
+#: ../src/common/accelcmn.cpp:48
+msgctxt "keyboard key"
+msgid "Del"
+msgstr "Ezab"
+
+#: ../src/common/accelcmn.cpp:49
+msgctxt "keyboard key"
+msgid "Back"
+msgstr "Atzera"
+
+#: ../src/common/accelcmn.cpp:49
+msgctxt "keyboard key"
+msgid "Backspace"
+msgstr "Atzera"
+
+#: ../src/common/accelcmn.cpp:50
+msgctxt "keyboard key"
+msgid "Insert"
+msgstr "Sartu"
+
+#: ../src/common/accelcmn.cpp:51
+msgctxt "keyboard key"
+msgid "Ins"
+msgstr "Txert"
+
+#: ../src/common/accelcmn.cpp:52
+msgctxt "keyboard key"
+msgid "Enter"
+msgstr "Sartu"
+
+#: ../src/common/accelcmn.cpp:53
+msgctxt "keyboard key"
+msgid "Return"
+msgstr "Sartu"
+
+#: ../src/common/accelcmn.cpp:54
+msgctxt "keyboard key"
+msgid "PageUp"
+msgstr "OrrGora"
+
+#: ../src/common/accelcmn.cpp:54
+msgctxt "keyboard key"
+msgid "Page Up"
+msgstr "Orrialdean Gora"
+
+#: ../src/common/accelcmn.cpp:55
+msgctxt "keyboard key"
+msgid "PageDown"
+msgstr "OrrBeh"
+
+#: ../src/common/accelcmn.cpp:55
+msgctxt "keyboard key"
+msgid "Page Down"
+msgstr "Orrialdean Behera"
+
+#: ../src/common/accelcmn.cpp:56
+msgctxt "keyboard key"
+msgid "PgUp"
+msgstr "OrrGor"
+
+#: ../src/common/accelcmn.cpp:57
+msgctxt "keyboard key"
+msgid "PgDn"
+msgstr "OrrBeh"
+
+#: ../src/common/accelcmn.cpp:58
+msgctxt "keyboard key"
+msgid "Left"
+msgstr "Ezker"
+
+#: ../src/common/accelcmn.cpp:59
+msgctxt "keyboard key"
+msgid "Right"
+msgstr "Eskuin"
+
+#: ../src/common/accelcmn.cpp:60
+msgctxt "keyboard key"
+msgid "Up"
+msgstr "Gora"
+
+#: ../src/common/accelcmn.cpp:61
+msgctxt "keyboard key"
+msgid "Down"
+msgstr "Behera"
+
+#: ../src/common/accelcmn.cpp:62
+msgctxt "keyboard key"
+msgid "Home"
+msgstr "Hasiera"
+
+#: ../src/common/accelcmn.cpp:63
+msgctxt "keyboard key"
+msgid "End"
+msgstr "Amaiera"
+
+#: ../src/common/accelcmn.cpp:64
+msgctxt "keyboard key"
+msgid "Space"
+msgstr "Tartea"
+
+#: ../src/common/accelcmn.cpp:65
+msgctxt "keyboard key"
+msgid "Tab"
+msgstr "Tab"
+
+#: ../src/common/accelcmn.cpp:66
+msgctxt "keyboard key"
+msgid "Esc"
+msgstr "Irt"
+
+#: ../src/common/accelcmn.cpp:67
+msgctxt "keyboard key"
+msgid "Escape"
+msgstr "Irten"
+
+#: ../src/common/accelcmn.cpp:68
+msgctxt "keyboard key"
+msgid "Cancel"
+msgstr "E&zeztatu"
+
+#: ../src/common/accelcmn.cpp:69
+msgctxt "keyboard key"
+msgid "Clear"
+msgstr "Garbitu"
+
+#: ../src/common/accelcmn.cpp:70
+msgctxt "keyboard key"
+msgid "Menu"
+msgstr "Menua"
+
+#: ../src/common/accelcmn.cpp:71
+msgctxt "keyboard key"
+msgid "Pause"
+msgstr "Pausatu"
+
+#: ../src/common/accelcmn.cpp:72
+msgctxt "keyboard key"
+msgid "Capital"
+msgstr "Larria"
+
+#: ../src/common/accelcmn.cpp:73
+msgctxt "keyboard key"
+msgid "Select"
+msgstr "Hautatu"
+
+#: ../src/common/accelcmn.cpp:74
+msgctxt "keyboard key"
+msgid "Print"
+msgstr "Irarkitu"
+
+#: ../src/common/accelcmn.cpp:75
+msgctxt "keyboard key"
+msgid "Execute"
+msgstr "Exekutatu"
+
+#: ../src/common/accelcmn.cpp:76
+msgctxt "keyboard key"
+msgid "Snapshot"
+msgstr "Berehalakoa"
+
+#: ../src/common/accelcmn.cpp:77
+msgctxt "keyboard key"
+msgid "Help"
+msgstr "Laguntza"
+
+#: ../src/common/accelcmn.cpp:78
+msgctxt "keyboard key"
+msgid "Add"
+msgstr "Gehitu"
+
+#: ../src/common/accelcmn.cpp:79
+msgctxt "keyboard key"
+msgid "Separator"
+msgstr "Banantzailea"
+
+#: ../src/common/accelcmn.cpp:80
+msgctxt "keyboard key"
+msgid "Subtract"
+msgstr "Kenketa"
+
+#: ../src/common/accelcmn.cpp:81
+msgctxt "keyboard key"
+msgid "Decimal"
+msgstr "Hamarrena"
+
+#: ../src/common/accelcmn.cpp:82
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Multiply"
+msgstr "ZP_Biderketa"
+
+#: ../src/common/accelcmn.cpp:83
+msgctxt "keyboard key"
+msgid "Divide"
+msgstr "Zatiketa"
+
+#: ../src/common/accelcmn.cpp:84
+msgctxt "keyboard key"
+msgid "Num_lock"
+msgstr "Zbk_blokeoa"
+
+#: ../src/common/accelcmn.cpp:84
+msgctxt "keyboard key"
+msgid "Num Lock"
+msgstr "Zbk Blokeoa"
+
+#: ../src/common/accelcmn.cpp:85
+msgctxt "keyboard key"
+msgid "Scroll_lock"
+msgstr "Irristari_blokeoa"
+
+#: ../src/common/accelcmn.cpp:85
+msgctxt "keyboard key"
+msgid "Scroll Lock"
+msgstr "Irristari Blokeoa"
+
+#: ../src/common/accelcmn.cpp:86
+msgctxt "keyboard key"
+msgid "KP_Space"
+msgstr "ZP_Tartea"
+
+#: ../src/common/accelcmn.cpp:86
+msgctxt "keyboard key"
+msgid "Num Space"
+msgstr "Zbk Tartea"
+
+#: ../src/common/accelcmn.cpp:87
+msgctxt "keyboard key"
+msgid "KP_Tab"
+msgstr "ZP_Tab"
+
+#: ../src/common/accelcmn.cpp:87
+msgctxt "keyboard key"
+msgid "Num Tab"
+msgstr "Zbk Tab"
+
+#: ../src/common/accelcmn.cpp:88
+msgctxt "keyboard key"
+msgid "KP_Enter"
+msgstr "ZP_Sartu"
+
+#: ../src/common/accelcmn.cpp:88
+msgctxt "keyboard key"
+msgid "Num Enter"
+msgstr "Zbk Sartu"
+
+#: ../src/common/accelcmn.cpp:89
+msgctxt "keyboard key"
+msgid "KP_Home"
+msgstr "ZP_Hasiera"
+
+#: ../src/common/accelcmn.cpp:89
+msgctxt "keyboard key"
+msgid "Num Home"
+msgstr "Zbk Hasiera"
+
+#: ../src/common/accelcmn.cpp:90
+msgctxt "keyboard key"
+msgid "KP_Left"
+msgstr "ZP_Ezker"
+
+#: ../src/common/accelcmn.cpp:90
+msgctxt "keyboard key"
+msgid "Num left"
+msgstr "Zbk ezker"
+
+#: ../src/common/accelcmn.cpp:91
+msgctxt "keyboard key"
+msgid "KP_Up"
+msgstr "ZP_Gora"
+
+#: ../src/common/accelcmn.cpp:91
+msgctxt "keyboard key"
+msgid "Num Up"
+msgstr "Zbk Gora"
+
+#: ../src/common/accelcmn.cpp:92
+msgctxt "keyboard key"
+msgid "KP_Right"
+msgstr "ZP_Eskuin"
+
+#: ../src/common/accelcmn.cpp:92
+msgctxt "keyboard key"
+msgid "Num Right"
+msgstr "Zbk Eskuin"
+
+#: ../src/common/accelcmn.cpp:93
+msgctxt "keyboard key"
+msgid "KP_Down"
+msgstr "ZP_Behera"
+
+#: ../src/common/accelcmn.cpp:93
+msgctxt "keyboard key"
+msgid "Num Down"
+msgstr "Zbk Behera"
+
+#: ../src/common/accelcmn.cpp:94
+msgctxt "keyboard key"
+msgid "KP_PageUp"
+msgstr "ZP_OrrGora"
+
+#: ../src/common/accelcmn.cpp:94
+msgctxt "keyboard key"
+msgid "Num Page Up"
+msgstr "Zbk Orrian Gora"
+
+#: ../src/common/accelcmn.cpp:95
+msgctxt "keyboard key"
+msgid "KP_PageDown"
+msgstr "ZP_OrrBehera"
+
+#: ../src/common/accelcmn.cpp:95
+msgctxt "keyboard key"
+msgid "Num Page Down"
+msgstr "Zbk Orrian Behera"
+
+#: ../src/common/accelcmn.cpp:96
+msgctxt "keyboard key"
+msgid "KP_Prior"
+msgstr "ZP_Prior"
+
+#: ../src/common/accelcmn.cpp:97
+msgctxt "keyboard key"
+msgid "KP_Next"
+msgstr "ZP_Hurrengoa"
+
+#: ../src/common/accelcmn.cpp:98
+msgctxt "keyboard key"
+msgid "KP_End"
+msgstr "ZP_Amaiera"
+
+#: ../src/common/accelcmn.cpp:98
+msgctxt "keyboard key"
+msgid "Num End"
+msgstr "Zbk Amaiera"
+
+#: ../src/common/accelcmn.cpp:99
+msgctxt "keyboard key"
+msgid "KP_Begin"
+msgstr "ZP_Hasi"
+
+#: ../src/common/accelcmn.cpp:99
+msgctxt "keyboard key"
+msgid "Num Begin"
+msgstr "Zbk Hasi"
+
+#: ../src/common/accelcmn.cpp:100
+msgctxt "keyboard key"
+msgid "KP_Insert"
+msgstr "ZP_Txertatu"
+
+#: ../src/common/accelcmn.cpp:100
+msgctxt "keyboard key"
+msgid "Num Insert"
+msgstr "Zbk Txertatu"
+
+#: ../src/common/accelcmn.cpp:101
+msgctxt "keyboard key"
+msgid "KP_Delete"
+msgstr "ZP_Ezabatu"
+
+#: ../src/common/accelcmn.cpp:101
+msgctxt "keyboard key"
+msgid "Num Delete"
+msgstr "Zbk Ezabatu"
+
+#: ../src/common/accelcmn.cpp:102
+msgctxt "keyboard key"
+msgid "KP_Equal"
+msgstr "ZP_Berdin"
+
+#: ../src/common/accelcmn.cpp:102
+msgctxt "keyboard key"
+msgid "Num ="
+msgstr "Zbk ="
+
+#: ../src/common/accelcmn.cpp:103
+msgctxt "keyboard key"
+msgid "KP_Multiply"
+msgstr "ZP_Biderketa"
+
+#: ../src/common/accelcmn.cpp:103
+msgctxt "keyboard key"
+msgid "Num *"
+msgstr "Zbk *"
+
+#: ../src/common/accelcmn.cpp:104
+msgctxt "keyboard key"
+msgid "KP_Add"
+msgstr "ZP_Gehiketa"
+
+#: ../src/common/accelcmn.cpp:104
+msgctxt "keyboard key"
+msgid "Num +"
+msgstr "Zbk +"
+
+#: ../src/common/accelcmn.cpp:105
+msgctxt "keyboard key"
+msgid "KP_Separator"
+msgstr "ZP_Banantzailea"
+
+#: ../src/common/accelcmn.cpp:105
+msgctxt "keyboard key"
+msgid "Num ,"
+msgstr "Zbk ,"
+
+#: ../src/common/accelcmn.cpp:106
+msgctxt "keyboard key"
+msgid "KP_Subtract"
+msgstr "ZP_Kenketa"
+
+#: ../src/common/accelcmn.cpp:106
+msgctxt "keyboard key"
+msgid "Num -"
+msgstr "Zbk -"
+
+#: ../src/common/accelcmn.cpp:107
+msgctxt "keyboard key"
+msgid "KP_Decimal"
+msgstr "ZP_Hamarrena"
+
+#: ../src/common/accelcmn.cpp:107
+msgctxt "keyboard key"
+msgid "Num ."
+msgstr "Zbk ."
+
+#: ../src/common/accelcmn.cpp:108
+msgctxt "keyboard key"
+msgid "KP_Divide"
+msgstr "ZP_Zatiketa"
+
+#: ../src/common/accelcmn.cpp:108
+msgctxt "keyboard key"
+msgid "Num /"
+msgstr "Zbk /"
+
+#: ../src/common/accelcmn.cpp:109
+msgctxt "keyboard key"
+msgid "Windows_Left"
+msgstr "Windows_Ezker"
+
+#: ../src/common/accelcmn.cpp:110
+msgctxt "keyboard key"
+msgid "Windows_Right"
+msgstr "Windows_Eskuin"
+
+#: ../src/common/accelcmn.cpp:111
+msgctxt "keyboard key"
+msgid "Windows_Menu"
+msgstr "Windows_Menua"
+
+#: ../src/common/accelcmn.cpp:112
+msgctxt "keyboard key"
+msgid "Command"
+msgstr "Agindua"
+
+#: ../src/common/accelcmn.cpp:186 ../src/common/accelcmn.cpp:359
+msgctxt "keyboard key"
+msgid "Ctrl"
+msgstr "Ktrl"
+
+#: ../src/common/accelcmn.cpp:188 ../src/common/accelcmn.cpp:363
+msgctxt "keyboard key"
+msgid "Alt"
+msgstr "Alt"
+
+#: ../src/common/accelcmn.cpp:190 ../src/common/accelcmn.cpp:361
+msgctxt "keyboard key"
+msgid "Shift"
+msgstr "Aldatu"
+
+#: ../src/common/accelcmn.cpp:196
+msgctxt "keyboard key"
+msgid "num "
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:260 ../src/common/accelcmn.cpp:382
+msgctxt "keyboard key"
+msgid "F"
+msgstr "F"
+
+#: ../src/common/accelcmn.cpp:277 ../src/common/accelcmn.cpp:385
+msgctxt "keyboard key"
+msgid "KP_F"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:280 ../src/common/accelcmn.cpp:388
+msgctxt "keyboard key"
+msgid "KP_"
+msgstr "ZP_"
+
+#: ../src/common/accelcmn.cpp:283 ../src/common/accelcmn.cpp:391
+msgctxt "keyboard key"
+msgid "SPECIAL"
+msgstr "BEREZIA"
+
+#: ../src/common/accelcmn.cpp:373
+#, fuzzy
+msgid "Ctrl"
+msgstr "Ktrl"
+
+#: ../src/common/appbase.cpp:786
+msgid "show this help message"
+msgstr "erakutsi laguntza mezu hau"
+
+#: ../src/common/appbase.cpp:796
+msgid "generate verbose log messages"
+msgstr "sortu ohar mezu berritsuak"
+
+#: ../src/common/appcmn.cpp:256
+msgid "specify the theme to use"
+msgstr "adierazi erabiltzeko azalgaia"
+
+#: ../src/common/appcmn.cpp:270
+msgid "specify display mode to use (e.g. 640x480-16)"
+msgstr "adierazi erabiltzeko erakus modua (adib. 640x480-16)"
+
+#: ../src/common/appcmn.cpp:292
+#, c-format
+msgid "Unsupported theme '%s'."
+msgstr "Azalgai sostengatu gabea'%s'"
+
+#: ../src/common/appcmn.cpp:309
+#, c-format
+msgid "Invalid display mode specification '%s'."
+msgstr "Erakus modu zehaztapen baliogabea '%s'."
+
+#: ../src/common/cmdline.cpp:875
+#, c-format
+msgid "Option '%s' can't be negated"
+msgstr "'%s' aukera ezin da ukatua izan"
+
+#: ../src/common/cmdline.cpp:889
+#, c-format
+msgid "Unknown long option '%s'"
+msgstr "Aukera luze ezezaguna '%s'"
+
+#: ../src/common/cmdline.cpp:904 ../src/common/cmdline.cpp:926
+#, c-format
+msgid "Unknown option '%s'"
+msgstr "Aukera ezezaguana '%s'"
+
+#: ../src/common/cmdline.cpp:1004
+#, c-format
+msgid "Unexpected characters following option '%s'."
+msgstr "Ustekabeko hizkiak '%s' aukeraren ondoren."
+
+#: ../src/common/cmdline.cpp:1039
+#, c-format
+msgid "Option '%s' requires a value."
+msgstr "'%s' aukerak balio bat behar du."
+
+#: ../src/common/cmdline.cpp:1058
+#, c-format
+msgid "Separator expected after the option '%s'."
+msgstr "Banantzailea '%s' aukeraren ondoren itxaroten da."
+
+#: ../src/common/cmdline.cpp:1088 ../src/common/cmdline.cpp:1106
+#, c-format
+msgid "'%s' is not a correct numeric value for option '%s'."
+msgstr "'%s' ez da zenbaki balio zuzena '%s' aukerarako."
+
+#: ../src/common/cmdline.cpp:1122
+#, c-format
+msgid "Option '%s': '%s' cannot be converted to a date."
+msgstr "'%s' aukera: '%s' ezin du bihurtu data batera."
+
+#: ../src/common/cmdline.cpp:1170
+#, c-format
+msgid "Unexpected parameter '%s'"
+msgstr "Ustekabeko parametroa '%s'"
+
+#. TRANSLATORS: Short name and long name for a command line option
+#: ../src/common/cmdline.cpp:1197
+#, c-format
+msgid "%s (or %s)"
+msgstr "%s (edo %s)"
+
+#: ../src/common/cmdline.cpp:1208
+#, c-format
+msgid "The value for the option '%s' must be specified."
+msgstr "'%s' aukerarentzako balioa adierazi behar da."
+
+#: ../src/common/cmdline.cpp:1230
+#, c-format
+msgid "The required parameter '%s' was not specified."
+msgstr "'%s' beharrezko parametroa ez da adierazi."
+
+#: ../src/common/cmdline.cpp:1289
+#, c-format
+msgid "Usage: %s"
+msgstr "Erabilia: %s"
+
+#: ../src/common/cmdline.cpp:1498
+msgid "str"
+msgstr "str"
+
+#: ../src/common/cmdline.cpp:1502
+msgid "num"
+msgstr "zenb"
+
+#: ../src/common/cmdline.cpp:1506
+msgid "double"
+msgstr "bikoitza"
+
+#: ../src/common/cmdline.cpp:1510
+msgid "date"
+msgstr "eguna"
+
+#: ../src/common/cmdproc.cpp:250 ../src/common/cmdproc.cpp:276
+#: ../src/common/cmdproc.cpp:296
+msgid "Unnamed command"
+msgstr "Izengabeko agindua"
+
+#: ../src/common/cmdproc.cpp:253
+msgid "&Undo "
+msgstr "&Desegin"
+
+#: ../src/common/cmdproc.cpp:255
+msgid "Can't &Undo "
+msgstr "Ezin da De&segin"
+
+#: ../src/common/cmdproc.cpp:259 ../src/common/stockitem.cpp:208
+#: ../src/msw/textctrl.cpp:2880 ../src/osx/textctrl_osx.cpp:649
+#: ../src/richtext/richtextctrl.cpp:327
+msgid "&Undo"
+msgstr "&Desegin"
+
+#: ../src/common/cmdproc.cpp:277 ../src/common/cmdproc.cpp:297
+msgid "&Redo "
+msgstr "&Berregin"
+
+#: ../src/common/cmdproc.cpp:281 ../src/common/cmdproc.cpp:288
+#: ../src/common/stockitem.cpp:190 ../src/msw/textctrl.cpp:2881
+#: ../src/osx/textctrl_osx.cpp:650 ../src/richtext/richtextctrl.cpp:328
+msgid "&Redo"
+msgstr "&Berregin"
+
+#: ../src/common/colourcmn.cpp:41
+#, c-format
+msgid "String To Colour : Incorrect colour specification : %s"
+msgstr "Margoarentzako Katea : margo zehaztapen okerra : %s"
+
+#: ../src/common/config.cpp:259
+#, c-format
+msgid "Invalid value %ld for a boolean key \"%s\" in config file."
+msgstr "Balio baliogabea %ld boolean giltzarakon \"%s\" itxurapen agirian."
+
+#: ../src/common/config.cpp:526
+#, c-format
+msgid ""
+"Environment variables expansion failed: missing '%c' at position %u in '%s'."
+msgstr ""
+"Ingurugiro aldaera hedapen hutsegitea: ez dago '%c'  %u kokapenean, hemen: "
+"'%s'."
+
+#: ../src/common/config.cpp:576 ../src/msw/regconf.cpp:272
+#, c-format
+msgid "'%s' has extra '..', ignored."
+msgstr "'%s' estra '..', ezikusita."
+
+#. TRANSLATORS: Checkbox state name
+#: ../src/common/datavcmn.cpp:2166 ../src/generic/datavgen.cpp:1430
+msgid "checked"
+msgstr ""
+
+#. TRANSLATORS: Checkbox state name
+#: ../src/common/datavcmn.cpp:2170 ../src/generic/datavgen.cpp:1432
+msgid "unchecked"
+msgstr ""
+
+#. TRANSLATORS: Checkbox state name
+#: ../src/common/datavcmn.cpp:2174
+#, fuzzy
+msgid "undetermined"
+msgstr "azpimarratua"
+
+#: ../src/common/datetimefmt.cpp:1875
+msgid "today"
+msgstr "gaur"
+
+#: ../src/common/datetimefmt.cpp:1876
+msgid "yesterday"
+msgstr "atzo"
+
+#: ../src/common/datetimefmt.cpp:1877
+msgid "tomorrow"
+msgstr "atzo"
+
+#: ../src/common/datetimefmt.cpp:2071
+msgid "first"
+msgstr "lehen"
+
+#: ../src/common/datetimefmt.cpp:2072
+msgid "second"
+msgstr "bigarren"
+
+#: ../src/common/datetimefmt.cpp:2073
+msgid "third"
+msgstr "hirugarren"
+
+#: ../src/common/datetimefmt.cpp:2074
+msgid "fourth"
+msgstr "laugarren"
+
+#: ../src/common/datetimefmt.cpp:2075
+msgid "fifth"
+msgstr "bostgarren"
+
+#: ../src/common/datetimefmt.cpp:2076
+msgid "sixth"
+msgstr "seigarren"
+
+#: ../src/common/datetimefmt.cpp:2077
+msgid "seventh"
+msgstr "zazpigarren"
+
+#: ../src/common/datetimefmt.cpp:2078
+msgid "eighth"
+msgstr "zortzigarren"
+
+#: ../src/common/datetimefmt.cpp:2079
+msgid "ninth"
+msgstr "bederatzigarren"
+
+#: ../src/common/datetimefmt.cpp:2080
+msgid "tenth"
+msgstr "hamargarren"
+
+#: ../src/common/datetimefmt.cpp:2081
+msgid "eleventh"
+msgstr "hamaikagarren"
+
+#: ../src/common/datetimefmt.cpp:2082
+msgid "twelfth"
+msgstr "hamabigarren"
+
+#: ../src/common/datetimefmt.cpp:2083
+msgid "thirteenth"
+msgstr "hamahirugarren"
+
+#: ../src/common/datetimefmt.cpp:2084
+msgid "fourteenth"
+msgstr "hamalaugarren"
+
+#: ../src/common/datetimefmt.cpp:2085
+msgid "fifteenth"
+msgstr "hamabostgarren"
+
+#: ../src/common/datetimefmt.cpp:2086
+msgid "sixteenth"
+msgstr "hamaseigarren"
+
+#: ../src/common/datetimefmt.cpp:2087
+msgid "seventeenth"
+msgstr "hemezazpigarren"
+
+#: ../src/common/datetimefmt.cpp:2088
+msgid "eighteenth"
+msgstr "hemezortzigarren"
+
+#: ../src/common/datetimefmt.cpp:2089
+msgid "nineteenth"
+msgstr "hemeretzigarren"
+
+#: ../src/common/datetimefmt.cpp:2090
+msgid "twentieth"
+msgstr "hogeigarren"
+
+#: ../src/common/datetimefmt.cpp:2248
+msgid "noon"
+msgstr "eguerdia"
+
+#: ../src/common/datetimefmt.cpp:2249
+msgid "midnight"
+msgstr "gauerdia"
+
+#: ../src/common/debugrpt.cpp:209
+#, c-format
+msgid "Failed to create directory \"%s\""
+msgstr "Hutsegitea \"%s\" zuzenbidea sortzerakoan"
+
+#: ../src/common/debugrpt.cpp:210
+msgid "Debug report couldn't be created."
+msgstr "Garbiketa jakinarazpena ezin da sortu."
+
+#: ../src/common/debugrpt.cpp:227
+#, c-format
+msgid "Failed to remove debug report file \"%s\""
+msgstr "Hutsegitea \"%s\" garbiketa jakinarazpen agiria kentzerakoan"
+
+#: ../src/common/debugrpt.cpp:239
+#, c-format
+msgid "Failed to clean up debug report directory \"%s\""
+msgstr "Hutsegitea \"%s\" garbiketa jakinarazpen zuzenbidea garbitzerakoan"
+
+#: ../src/common/debugrpt.cpp:514
+msgid "process context description"
+msgstr "garapen hitzinguru azalpena"
+
+#: ../src/common/debugrpt.cpp:538
+msgid "dump of the process state (binary)"
+msgstr "garapen egoeraren erauztea (binarioa)"
+
+#: ../src/common/debugrpt.cpp:553
+msgid "Debug report generation has failed."
+msgstr "Garbiketa jakinarazpena sortzeak huts egin du."
+
+#: ../src/common/debugrpt.cpp:560
+#, c-format
+msgid ""
+"Processing debug report has failed, leaving the files in \"%s\" directory."
+msgstr ""
+"Garbiketa jakinarazpen prozesapenak huts egin du, agiria \"%s\" zuzenbidean "
+"uzten."
+
+#: ../src/common/debugrpt.cpp:573
+msgid "A debug report has been generated. It can be found in"
+msgstr "Garbiketa jakinarazpena sortu da. Aurkitu daiteke hemen"
+
+#: ../src/common/debugrpt.cpp:576
+msgid "And includes the following files:\n"
+msgstr "Eta hurrengo agiriak ditu:\n"
+
+#: ../src/common/debugrpt.cpp:586
+msgid ""
+"\n"
+"Please send this report to the program maintainer, thank you!\n"
+msgstr ""
+"\n"
+"Mesedez bidali jakinarazpen hau programaren arduradunari, mila esker!\n"
+
+#: ../src/common/debugrpt.cpp:729
+msgid "Failed to execute curl, please install it in PATH."
+msgstr "Hutsegitea curl exekutatzerakoan, mesedez ezarri HELBURUAN."
+
+#: ../src/common/debugrpt.cpp:742
+#, c-format
+msgid "Failed to upload the debug report (error code %d)."
+msgstr "Hutsegitea garbiketa jakinarazpena igotzerakoan (akats kodea %d)."
+
+#: ../src/common/docview.cpp:366
+msgid "Save As"
+msgstr "Gorde Honela"
+
+#: ../src/common/docview.cpp:457
+msgid "Discard changes and reload the last saved version?"
+msgstr "Baztertu aldaketak eta gertatu gordetako azken bertsioa?"
+
+#: ../src/common/docview.cpp:488
+msgid "unnamed"
+msgstr "izengabea"
+
+#: ../src/common/docview.cpp:513
+#, c-format
+msgid "Do you want to save changes to %s?"
+msgstr "Nahi duzu %s-ri aldaketak gordetzea?"
+
+#: ../src/common/docview.cpp:521 ../src/common/docview.cpp:560
+#: ../src/common/stockitem.cpp:195
+msgid "&Save"
+msgstr "&Gorde"
+
+#: ../src/common/docview.cpp:522 ../src/common/docview.cpp:560
+msgid "&Discard changes"
+msgstr ""
+
+#: ../src/common/docview.cpp:523
+#, fuzzy
+msgid "Do&n't close"
+msgstr "Ez Gorde"
+
+#: ../src/common/docview.cpp:553
+#, fuzzy, c-format
+msgid "Do you want to save changes to %s before closing it?"
+msgstr "Nahi duzu %s-ri aldaketak gordetzea?"
+
+#: ../src/common/docview.cpp:559
+#, fuzzy
+msgid "The document must be closed."
+msgstr "Idazkia ezin da gorde."
+
+#: ../src/common/docview.cpp:571
+#, c-format
+msgid "Saving %s failed, would you like to retry?"
+msgstr ""
+
+#: ../src/common/docview.cpp:577
+msgid "Retry"
+msgstr ""
+
+#: ../src/common/docview.cpp:577
+msgid "Discard changes"
+msgstr ""
+
+#: ../src/common/docview.cpp:679
+#, c-format
+msgid "File \"%s\" could not be opened for writing."
+msgstr "\"%s\" agiria ezin da idazteko ireki."
+
+#: ../src/common/docview.cpp:685
+#, c-format
+msgid "Failed to save document to the file \"%s\"."
+msgstr "Hutsegitea agiria \"%s\" agirian gordetzerakoan."
+
+#: ../src/common/docview.cpp:702
+#, c-format
+msgid "File \"%s\" could not be opened for reading."
+msgstr "\"%s\" agiria ezin da irakurtzeko ireki."
+
+#: ../src/common/docview.cpp:714
+#, c-format
+msgid "Failed to read document from the file \"%s\"."
+msgstr "Hutsegitea \"%s\" agiritik agiria irakurtzerakoan."
+
+#: ../src/common/docview.cpp:1236
+#, c-format
+msgid ""
+"The file '%s' doesn't exist and couldn't be opened.\n"
+"It has been removed from the most recently used files list."
+msgstr ""
+"'%s' agiria ez dago edo ezin da ireki.\n"
+"Kendua izanda berrikien erabilitako agiri zerrendatik."
+
+#: ../src/common/docview.cpp:1296
+msgid "Print preview creation failed."
+msgstr "Irarketa aurreikuspena sortzeak huts egin du."
+
+#: ../src/common/docview.cpp:1302
+msgid "Print Preview"
+msgstr "Irarketa Aurreikuspena"
+
+#: ../src/common/docview.cpp:1517
+#, c-format
+msgid "The format of file '%s' couldn't be determined."
+msgstr "'%s' agiriaren heuskarria ezin da zehaztu."
+
+#: ../src/common/docview.cpp:1643
+#, c-format
+msgid "unnamed%d"
+msgstr "izengabea%d"
+
+#: ../src/common/docview.cpp:1660
+msgid " - "
+msgstr " -"
+
+#: ../src/common/docview.cpp:1791 ../src/common/docview.cpp:1844
+msgid "Open File"
+msgstr "Ireki Agiria"
+
+#: ../src/common/docview.cpp:1807
+msgid "File error"
+msgstr "Agiri akatsa"
+
+#: ../src/common/docview.cpp:1809
+msgid "Sorry, could not open this file."
+msgstr "Barkatu, ezin da agiria hau ireki."
+
+#: ../src/common/docview.cpp:1843
+msgid "Sorry, the format for this file is unknown."
+msgstr "Barkatu, agiri honentzako heuskarria ezezaguna da."
+
+#: ../src/common/docview.cpp:1924
+msgid "Select a document template"
+msgstr "Hautatu agiri eredu bat"
+
+#: ../src/common/docview.cpp:1925
+msgid "Templates"
+msgstr "Ereduak"
+
+#: ../src/common/docview.cpp:1998
+msgid "Select a document view"
+msgstr "Hautatu agiri ikuspena"
+
+#: ../src/common/docview.cpp:1999
+msgid "Views"
+msgstr "Ikus"
+
+#: ../src/common/dynlib.cpp:81
+#, c-format
+msgid "Failed to load shared library '%s'"
+msgstr "Hutsegitea '%s' partekatze agiria gertatzerakoan"
+
+#: ../src/common/dynlib.cpp:105
+#, c-format
+msgid "Couldn't find symbol '%s' in a dynamic library"
+msgstr "Ezinezkoa '%s' ikurra aurkitzea liburutegi dinamikoan"
+
+#: ../src/common/ffile.cpp:56 ../src/common/file.cpp:215
+#, c-format
+msgid "can't open file '%s'"
+msgstr "ezin da ireki '%s' agiria"
+
+#: ../src/common/ffile.cpp:72
+#, c-format
+msgid "can't close file '%s'"
+msgstr "ezin da itxi '%s' agiria"
+
+#: ../src/common/ffile.cpp:106 ../src/common/ffile.cpp:131
+#, c-format
+msgid "Read error on file '%s'"
+msgstr "Irakurri akatsa '%s' agirian"
+
+#: ../src/common/ffile.cpp:148
+#, c-format
+msgid "Write error on file '%s'"
+msgstr "Idaz akatsa '%s' agirian"
+
+#: ../src/common/ffile.cpp:182
+#, c-format
+msgid "failed to flush the file '%s'"
+msgstr "hutsegitea '%s' agiria jalgitzean "
+
+#: ../src/common/ffile.cpp:222
+#, c-format
+msgid "Seek error on file '%s' (large files not supported by stdio)"
+msgstr ""
+"Bilatu akatsak '%s' agirian (stdiok ez du agiri handiagorik sostengatzen)"
+
+#: ../src/common/ffile.cpp:232
+#, c-format
+msgid "Seek error on file '%s'"
+msgstr "Bilatu akatsak '%s' agirian"
+
+#: ../src/common/ffile.cpp:248
+#, c-format
+msgid "Can't find current position in file '%s'"
+msgstr "Ezin da aurkitu oraingo kokapena '%s' agirian"
+
+#: ../src/common/ffile.cpp:349 ../src/common/file.cpp:569
+msgid "Failed to set temporary file permissions"
+msgstr "Hutsegitea aldibaterako agiri baimenak ezartzerakoan"
+
+#: ../src/common/ffile.cpp:371
+#, c-format
+msgid "can't remove file '%s'"
+msgstr "ezin da kendu '%s' agiria"
+
+#: ../src/common/ffile.cpp:376 ../src/common/file.cpp:591
+#, c-format
+msgid "can't commit changes to file '%s'"
+msgstr "ezin da aldaketarik egin '%s' agirian"
+
+#: ../src/common/ffile.cpp:388 ../src/common/file.cpp:603
+#, c-format
+msgid "can't remove temporary file '%s'"
+msgstr "ezin da kendu '%s' aldibaterako agiria"
+
+#: ../src/common/file.cpp:162
+#, c-format
+msgid "can't create file '%s'"
+msgstr "ezin da '%s' agiria sortu"
+
+#: ../src/common/file.cpp:229
+#, c-format
+msgid "can't close file descriptor %d"
+msgstr "ezin da itxi %d agiri azaltzailea "
+
+#: ../src/common/file.cpp:332
+#, c-format
+msgid "can't read from file descriptor %d"
+msgstr "ezin da irakurri %d agiri azaltzailetik"
+
+#: ../src/common/file.cpp:351
+#, c-format
+msgid "can't write to file descriptor %d"
+msgstr "ezin da idatzi %d agiri azaltzailera"
+
+#: ../src/common/file.cpp:390
+#, c-format
+msgid "can't flush file descriptor %d"
+msgstr "ezin da jaso %d agiri azaltzailea"
+
+#: ../src/common/file.cpp:432
+#, c-format
+msgid "can't seek on file descriptor %d"
+msgstr "ezin da bilatu %d agiri azaltzailean"
+
+#: ../src/common/file.cpp:446
+#, c-format
+msgid "can't get seek position on file descriptor %d"
+msgstr "ezin da bilaketa kokapenik bilatu %d agiri azaltzailean"
+
+#: ../src/common/file.cpp:475
+#, c-format
+msgid "can't find length of file on file descriptor %d"
+msgstr "ezin da aurkitu agiri luzera %d agiri azaltzailean"
+
+#: ../src/common/file.cpp:505
+#, c-format
+msgid "can't determine if the end of file is reached on descriptor %d"
+msgstr "ezin da zehaztu agiriaren amaiera lortu den %d azaltzailean"
+
+#: ../src/common/fileconf.cpp:352
+#, c-format
+msgid ""
+" and additionally, the existing configuration file was renamed to \"%s\" and "
+"couldn't be renamed back, please rename it to its original path \"%s\""
+msgstr ""
+
+#: ../src/common/fileconf.cpp:389
+#, fuzzy
+msgid " due to the following error:\n"
+msgstr "Eta hurrengo agiriak ditu:\n"
+
+#: ../src/common/fileconf.cpp:412
+#, fuzzy
+msgid "failed to rename the existing file"
+msgstr "Hutsegitea \"%s\" agiritik agiria irakurtzerakoan."
+
+#: ../src/common/fileconf.cpp:421
+#, fuzzy
+msgid "failed to create the new file directory"
+msgstr "Hutsegitea lan zuzenbidea lortzerakoan"
+
+#: ../src/common/fileconf.cpp:428
+#, fuzzy
+msgid "failed to move the file to the new location"
+msgstr "Hutsegitea urrutizkin elkarketa amaitzerakoan: %s"
+
+#: ../src/common/fileconf.cpp:462
+#, c-format
+msgid "can't open global configuration file '%s'."
+msgstr "ezin da ireki '%s'  itxurapen globaleko agiria"
+
+#: ../src/common/fileconf.cpp:478
+#, c-format
+msgid "can't open user configuration file '%s'."
+msgstr "ezin da ireki '%s' erabiltzailearen itxurapen agiria ."
+
+#: ../src/common/fileconf.cpp:483
+#, c-format
+msgid "Changes won't be saved to avoid overwriting the existing file \"%s\""
+msgstr ""
+"Aldaketak ez dira gordeko badagoen \"%s\" agiria gainidaztea saihesteko"
+
+#: ../src/common/fileconf.cpp:583
+msgid "Error reading config options."
+msgstr "Akatsa itxurap aukerak irakurtzean."
+
+#: ../src/common/fileconf.cpp:593
+msgid "Failed to read config options."
+msgstr "Hutsegitea itxurap aukerak irakurtzerakoan."
+
+#: ../src/common/fileconf.cpp:700
+#, fuzzy, c-format
+msgid "file '%s': unexpected character %c at line %zu."
+msgstr "'%s' agira: ustekabeko %c hizkia %d lerroan."
+
+#: ../src/common/fileconf.cpp:736
+#, fuzzy, c-format
+msgid "file '%s', line %zu: '%s' ignored after group header."
+msgstr "'%s' agiria, %d lerroa: '%s' baztertua idazburu taldearen ondoren."
+
+#: ../src/common/fileconf.cpp:765
+#, fuzzy, c-format
+msgid "file '%s', line %zu: '=' expected."
+msgstr "'%s' agiria,%d lerroa: '=' ustekoa."
+
+#: ../src/common/fileconf.cpp:778
+#, fuzzy, c-format
+msgid "file '%s', line %zu: value for immutable key '%s' ignored."
+msgstr "'%s' agiria, %d lerroa: '%s' tekla aldaezinarentzako balioa baztertua."
+
+#: ../src/common/fileconf.cpp:788
+#, fuzzy, c-format
+msgid "file '%s', line %zu: key '%s' was first found at line %d."
+msgstr "'%s' agiria, %d lerroa: '%s' tekla  lehenik aurkitu da %d lerroan."
+
+#: ../src/common/fileconf.cpp:1091
+#, c-format
+msgid "Config entry name cannot start with '%c'."
+msgstr "Itxurap sarrera izean ezin da '%c'-rekin hasi."
+
+#: ../src/common/fileconf.cpp:1146
+#, fuzzy
+msgid "Failed to create configuration file directory."
+msgstr "Hutsegitea erabiltzaile itxurapen agiria eguneratzerakoan."
+
+#: ../src/common/fileconf.cpp:1158
+msgid "can't open user configuration file."
+msgstr "ezin da ireki erabiltzailearen itxurapen agiria."
+
+#: ../src/common/fileconf.cpp:1172
+msgid "can't write user configuration file."
+msgstr "ezin da idatzi erabiltzailearen itxurapen agiria."
+
+#: ../src/common/fileconf.cpp:1178
+msgid "Failed to update user configuration file."
+msgstr "Hutsegitea erabiltzaile itxurapen agiria eguneratzerakoan."
+
+#: ../src/common/fileconf.cpp:1201
+msgid "Error saving user configuration data."
+msgstr "Akatsa erabiltzaile itxurapen datuak gordetzean."
+
+#: ../src/common/fileconf.cpp:1313
+#, c-format
+msgid "can't delete user configuration file '%s'"
+msgstr "ezin da ezabatu '%s' erabiltzailearen itxurapen agiria"
+
+#: ../src/common/fileconf.cpp:2007
+#, c-format
+msgid "entry '%s' appears more than once in group '%s'"
+msgstr "'%s' sarrera behin baino gehiagotan agertzen da '%s' taldean"
+
+#: ../src/common/fileconf.cpp:2021
+#, c-format
+msgid "attempt to change immutable key '%s' ignored."
+msgstr "'%s' tekla aldaezina aldatzeko saiakera baztertuta."
+
+#: ../src/common/fileconf.cpp:2118
+#, c-format
+msgid "trailing backslash ignored in '%s'"
+msgstr "amaierako ezkerbarra '%s'-n baztertuta"
+
+#: ../src/common/fileconf.cpp:2153
+#, c-format
+msgid "unexpected \" at position %d in '%s'."
+msgstr "ustekabeko \" kokapena %d '%s'."
+
+#: ../src/common/filefn.cpp:474
+#, c-format
+msgid "Failed to copy the file '%s' to '%s'"
+msgstr "Hutsegitea '%s' agiria '%s'-ra kopiatzerakoan"
+
+#: ../src/common/filefn.cpp:487
+#, c-format
+msgid "Impossible to get permissions for file '%s'"
+msgstr "Ezinezkoa '%s' agiriarentzat baimenak lortzea"
+
+#: ../src/common/filefn.cpp:501
+#, c-format
+msgid "Impossible to overwrite the file '%s'"
+msgstr "Ezinezkoa '%s' agiria gainidaztea"
+
+#: ../src/common/filefn.cpp:508
+#, fuzzy, c-format
+msgid "Error copying the file '%s' to '%s'."
+msgstr "Hutsegitea '%s' agiria '%s'-ra kopiatzerakoan"
+
+#: ../src/common/filefn.cpp:556
+#, c-format
+msgid "Impossible to set permissions for the file '%s'"
+msgstr "Ezinezkoa '%s' agiriarentzako baimenak ezartzea"
+
+#: ../src/common/filefn.cpp:606
+#, c-format
+msgid ""
+"Failed to rename the file '%s' to '%s' because the destination file already "
+"exists."
+msgstr ""
+"Hutsegitea '%s' agiria '%s'-ra birrizendatzean zerezn helmuga agiria jadanik "
+"badago."
+
+#: ../src/common/filefn.cpp:623
+#, c-format
+msgid "File '%s' couldn't be renamed '%s'"
+msgstr "'%s' agiria ezin da berrizendatu '%s'"
+
+#: ../src/common/filefn.cpp:639
+#, c-format
+msgid "File '%s' couldn't be removed"
+msgstr "'%s' agiria ezin da kendu"
+
+#: ../src/common/filefn.cpp:666
+#, c-format
+msgid "Directory '%s' couldn't be created"
+msgstr "'%s' zuzenbidea ezin da sortu"
+
+#: ../src/common/filefn.cpp:680
+#, c-format
+msgid "Directory '%s' couldn't be deleted"
+msgstr "%s' zuzenbidea ezin da ezabatu"
+
+#: ../src/common/filefn.cpp:714
+#, c-format
+msgid "Cannot enumerate files '%s'"
+msgstr "Ezin dira '%s' agiriak zenbakitu"
+
+#: ../src/common/filefn.cpp:798
+msgid "Failed to get the working directory"
+msgstr "Hutsegitea lan zuzenbidea lortzerakoan"
+
+#: ../src/common/filefn.cpp:843
+msgid "Could not set current working directory"
+msgstr "Ezinezkoa oraingo lan zuzenbidea ezartzea"
+
+#: ../src/common/filefn.cpp:974
+#, c-format
+msgid "Files (%s)"
+msgstr "Agiriak (%s)"
+
+#: ../src/common/filename.cpp:182
+#, c-format
+msgid "Failed to open '%s' for reading"
+msgstr "Hutsegitea '%s' irakurtzeko irekitzerakoan"
+
+#: ../src/common/filename.cpp:187
+#, c-format
+msgid "Failed to open '%s' for writing"
+msgstr "Hutsegitea '%s' idazteko irekitzerakoan"
+
+#: ../src/common/filename.cpp:199
+msgid "Failed to close file handle"
+msgstr "Hutsegitea agiri kudeatzailea isterakoan"
+
+#: ../src/common/filename.cpp:1046
+msgid "Failed to create a temporary file name"
+msgstr "Hutsegitea aldibaterako agiri izena sortzerakoan"
+
+#: ../src/common/filename.cpp:1081
+msgid "Failed to open temporary file."
+msgstr "Hutsegitea aldibaterako agiria irekitzerakoan."
+
+#: ../src/common/filename.cpp:2862
+#, c-format
+msgid "Failed to modify file times for '%s'"
+msgstr "Hutsegitea '%s'-rako agiri denborak aldatzerakoan"
+
+#: ../src/common/filename.cpp:2877
+#, c-format
+msgid "Failed to touch the file '%s'"
+msgstr "Hutsegitea '%s' agiria ikutzerakoan"
+
+#: ../src/common/filename.cpp:2958
+#, c-format
+msgid "Failed to retrieve file times for '%s'"
+msgstr "Hutsegitea '%s'-rako agiri denborak berreskuratzerakoan"
+
+#: ../src/common/filepickercmn.cpp:39 ../src/common/filepickercmn.cpp:40
+msgid "Browse"
+msgstr "Bilatu"
+
+#: ../src/common/fldlgcmn.cpp:792 ../src/generic/filectrlg.cpp:1185
+#, c-format
+msgid "All files (%s)|%s"
+msgstr "Agiri denak (%s)|%s"
+
+#. TRANSLATORS: %s are a file extension used to build a file wildcard string
+#: ../src/common/fldlgcmn.cpp:810
+#, c-format
+msgid "%s files (%s)|%s"
+msgstr "%s agiri (%s)|%s"
+
+#: ../src/common/fldlgcmn.cpp:1072
+#, c-format
+msgid "Load %s file"
+msgstr "Gertatu %s agiria"
+
+#: ../src/common/fldlgcmn.cpp:1074
+#, c-format
+msgid "Save %s file"
+msgstr "Gorde %s agiria"
+
+#: ../src/common/fmapbase.cpp:144
+msgid "Western European (ISO-8859-1)"
+msgstr "Europa Mendebaldea (ISO-8859-1)"
+
+#: ../src/common/fmapbase.cpp:145
+msgid "Central European (ISO-8859-2)"
+msgstr "Europa Erdialdea (ISO-8859-2)"
+
+#: ../src/common/fmapbase.cpp:146
+msgid "Esperanto (ISO-8859-3)"
+msgstr "Esperantoera (ISO-8859-3)"
+
+#: ../src/common/fmapbase.cpp:147
+msgid "Baltic (old) (ISO-8859-4)"
+msgstr "Baltikoa (old) (ISO-8859-4)"
+
+#: ../src/common/fmapbase.cpp:148
+msgid "Cyrillic (ISO-8859-5)"
+msgstr "Zirilikoa (ISO-8859-5)"
+
+#: ../src/common/fmapbase.cpp:149
+msgid "Arabic (ISO-8859-6)"
+msgstr "Arabiera (ISO-8859-6)"
+
+#: ../src/common/fmapbase.cpp:150
+msgid "Greek (ISO-8859-7)"
+msgstr "Greziera (ISO-8859-7)"
+
+#: ../src/common/fmapbase.cpp:151
+msgid "Hebrew (ISO-8859-8)"
+msgstr "Hebraiera (ISO-8859-8)"
+
+#: ../src/common/fmapbase.cpp:152
+msgid "Turkish (ISO-8859-9)"
+msgstr "Turkiera (ISO-8859-9)"
+
+#: ../src/common/fmapbase.cpp:153
+msgid "Nordic (ISO-8859-10)"
+msgstr "Nordikoa (ISO-8859-10)"
+
+#: ../src/common/fmapbase.cpp:154
+msgid "Thai (ISO-8859-11)"
+msgstr "Thailandiera (ISO-8859-11)"
+
+#: ../src/common/fmapbase.cpp:155
+msgid "Indian (ISO-8859-12)"
+msgstr "Indian (ISO-8859-12)"
+
+#: ../src/common/fmapbase.cpp:156
+msgid "Baltic (ISO-8859-13)"
+msgstr "Baltikoa (ISO-8859-13)"
+
+#: ../src/common/fmapbase.cpp:157
+msgid "Celtic (ISO-8859-14)"
+msgstr "Zeltiera (ISO-8859-14)"
+
+#: ../src/common/fmapbase.cpp:158
+msgid "Western European with Euro (ISO-8859-15)"
+msgstr "Europa Mendebaldea Euroarekin (ISO-8859-15)"
+
+#: ../src/common/fmapbase.cpp:159
+msgid "KOI8-R"
+msgstr "KOI8-R"
+
+#: ../src/common/fmapbase.cpp:160
+msgid "KOI8-U"
+msgstr "KOI8-U"
+
+#: ../src/common/fmapbase.cpp:161
+msgid "Windows/DOS OEM Cyrillic (CP 866)"
+msgstr "Windows/DOS OEM Zirilikoa (CP 866)"
+
+#: ../src/common/fmapbase.cpp:162
+msgid "Windows Thai (CP 874)"
+msgstr "Windows Thailandiera (CP 874)"
+
+#: ../src/common/fmapbase.cpp:163
+msgid "Windows Japanese (CP 932) or Shift-JIS"
+msgstr "Windows Japoniera (CP 932) edo Shift-JIS"
+
+#: ../src/common/fmapbase.cpp:164
+msgid "Windows Chinese Simplified (CP 936) or GB-2312"
+msgstr "Windows Txinera Arrundua (CP 936) edo GB-2312"
+
+#: ../src/common/fmapbase.cpp:165
+msgid "Windows Korean (CP 949)"
+msgstr "Windows Koreaera (CP 949)"
+
+#: ../src/common/fmapbase.cpp:166
+msgid "Windows Chinese Traditional (CP 950) or Big-5"
+msgstr "Windows Txinera Tradizionala (CP 950) edo Big-5"
+
+#: ../src/common/fmapbase.cpp:167
+msgid "Windows Central European (CP 1250)"
+msgstr "Windows Europa Erdialdea (CP 1250)"
+
+#: ../src/common/fmapbase.cpp:168
+msgid "Windows Cyrillic (CP 1251)"
+msgstr "Windows Zirilikoa (CP 1251)"
+
+#: ../src/common/fmapbase.cpp:169
+msgid "Windows Western European (CP 1252)"
+msgstr "Windows Europa Mendebaldea (CP 1252)"
+
+#: ../src/common/fmapbase.cpp:170
+msgid "Windows Greek (CP 1253)"
+msgstr "Windows Greziera (CP 1253)"
+
+#: ../src/common/fmapbase.cpp:171
+msgid "Windows Turkish (CP 1254)"
+msgstr "Windows Turkiera (CP 1254)"
+
+#: ../src/common/fmapbase.cpp:172
+msgid "Windows Hebrew (CP 1255)"
+msgstr "Windows Hebraiera (CP 1255)"
+
+#: ../src/common/fmapbase.cpp:173
+msgid "Windows Arabic (CP 1256)"
+msgstr "Windows Arabiarra (CP 1256)"
+
+#: ../src/common/fmapbase.cpp:174
+msgid "Windows Baltic (CP 1257)"
+msgstr "Windows Baltikoa (CP 1257)"
+
+#: ../src/common/fmapbase.cpp:175
+msgid "Windows Vietnamese (CP 1258)"
+msgstr "Windows Vietnamiera (CP 1258)"
+
+#: ../src/common/fmapbase.cpp:176
+msgid "Windows Johab (CP 1361)"
+msgstr "Windows Joahb (CP 1361)"
+
+#: ../src/common/fmapbase.cpp:177
+msgid "Windows/DOS OEM (CP 437)"
+msgstr "Windows/DOS OEM (CP 437)"
+
+#: ../src/common/fmapbase.cpp:178
+msgid "Unicode 7 bit (UTF-7)"
+msgstr "Unicode 7 bit (UTF-7)"
+
+#: ../src/common/fmapbase.cpp:179
+msgid "Unicode 8 bit (UTF-8)"
+msgstr "Unicode 8 bit (UTF-8)"
+
+#: ../src/common/fmapbase.cpp:181 ../src/common/fmapbase.cpp:187
+msgid "Unicode 16 bit (UTF-16)"
+msgstr "Unicode 16 bit (UTF-16)"
+
+#: ../src/common/fmapbase.cpp:182
+msgid "Unicode 16 bit Little Endian (UTF-16LE)"
+msgstr "Unicode 16 bit Little Endian (UTF-16LE)"
+
+#: ../src/common/fmapbase.cpp:183 ../src/common/fmapbase.cpp:189
+msgid "Unicode 32 bit (UTF-32)"
+msgstr "Unicode 32 bit (UTF-32)"
+
+#: ../src/common/fmapbase.cpp:184
+msgid "Unicode 32 bit Little Endian (UTF-32LE)"
+msgstr "Unicode 32 bit Little Endian (UTF-32LE)"
+
+#: ../src/common/fmapbase.cpp:186
+msgid "Unicode 16 bit Big Endian (UTF-16BE)"
+msgstr "Unicode 16 bit Big Endian (UTF-16BE)"
+
+#: ../src/common/fmapbase.cpp:188
+msgid "Unicode 32 bit Big Endian (UTF-32BE)"
+msgstr "Unicode 32 bit Big Endian (UTF-32BE)"
+
+#: ../src/common/fmapbase.cpp:191
+msgid "Extended Unix Codepage for Japanese (EUC-JP)"
+msgstr "Unix Kodeorrialde Hedatua Japonierarako (EUC-JP)"
+
+#: ../src/common/fmapbase.cpp:192
+msgid "US-ASCII"
+msgstr "US-ASCII"
+
+#: ../src/common/fmapbase.cpp:193
+msgid "ISO-2022-JP"
+msgstr "ISO-2022-JP"
+
+#: ../src/common/fmapbase.cpp:195
+msgid "MacRoman"
+msgstr "MacErromatarra"
+
+#: ../src/common/fmapbase.cpp:196
+msgid "MacJapanese"
+msgstr "MacJaponiera"
+
+#: ../src/common/fmapbase.cpp:197
+msgid "MacChineseTrad"
+msgstr "MacTxineraTrad"
+
+#: ../src/common/fmapbase.cpp:198
+msgid "MacKorean"
+msgstr "MacKoreaera"
+
+#: ../src/common/fmapbase.cpp:199
+msgid "MacArabic"
+msgstr "MacArabiera"
+
+#: ../src/common/fmapbase.cpp:200
+msgid "MacHebrew"
+msgstr "MacHebraiera"
+
+#: ../src/common/fmapbase.cpp:201
+msgid "MacGreek"
+msgstr "MacGreziera"
+
+#: ../src/common/fmapbase.cpp:202
+msgid "MacCyrillic"
+msgstr "MacZirilikoa"
+
+#: ../src/common/fmapbase.cpp:203
+msgid "MacDevanagari"
+msgstr "MacDevanagariera"
+
+#: ../src/common/fmapbase.cpp:204
+msgid "MacGurmukhi"
+msgstr "MacGurmukhiera"
+
+#: ../src/common/fmapbase.cpp:205
+msgid "MacGujarati"
+msgstr "MacGujaratiera"
+
+#: ../src/common/fmapbase.cpp:206
+msgid "MacOriya"
+msgstr "MacOriyera"
+
+#: ../src/common/fmapbase.cpp:207
+msgid "MacBengali"
+msgstr "MacBengaliera"
+
+#: ../src/common/fmapbase.cpp:208
+msgid "MacTamil"
+msgstr "MacTamilera"
+
+#: ../src/common/fmapbase.cpp:209
+msgid "MacTelugu"
+msgstr "MacTeluguera"
+
+#: ../src/common/fmapbase.cpp:210
+msgid "MacKannada"
+msgstr "MacKannadera"
+
+#: ../src/common/fmapbase.cpp:211
+msgid "MacMalayalam"
+msgstr "MacMalayalera"
+
+#: ../src/common/fmapbase.cpp:212
+msgid "MacSinhalese"
+msgstr "MacSinhalera"
+
+#: ../src/common/fmapbase.cpp:213
+msgid "MacBurmese"
+msgstr "MacBurmesera"
+
+#: ../src/common/fmapbase.cpp:214
+msgid "MacKhmer"
+msgstr "MacKhmerrera"
+
+#: ../src/common/fmapbase.cpp:215
+msgid "MacThai"
+msgstr "MacThailandiera"
+
+#: ../src/common/fmapbase.cpp:216
+msgid "MacLaotian"
+msgstr "MacLaotiera"
+
+#: ../src/common/fmapbase.cpp:217
+msgid "MacGeorgian"
+msgstr "MacGeorgiera"
+
+#: ../src/common/fmapbase.cpp:218
+msgid "MacArmenian"
+msgstr "MacArmeniera"
+
+#: ../src/common/fmapbase.cpp:219
+msgid "MacChineseSimp"
+msgstr "MacTxineraArrun"
+
+#: ../src/common/fmapbase.cpp:220
+msgid "MacTibetan"
+msgstr "MacTibetera"
+
+#: ../src/common/fmapbase.cpp:221
+msgid "MacMongolian"
+msgstr "MacMongoliera"
+
+#: ../src/common/fmapbase.cpp:222
+msgid "MacEthiopic"
+msgstr "MacEtiopiera"
+
+#: ../src/common/fmapbase.cpp:223
+msgid "MacCentralEurRoman"
+msgstr "MacEurErdErrom"
+
+#: ../src/common/fmapbase.cpp:224
+msgid "MacVietnamese"
+msgstr "MacVietnamera"
+
+#: ../src/common/fmapbase.cpp:225
+msgid "MacExtArabic"
+msgstr "MacExtArabiera"
+
+#: ../src/common/fmapbase.cpp:226
+msgid "MacSymbol"
+msgstr "MacSymbol"
+
+#: ../src/common/fmapbase.cpp:227
+msgid "MacDingbats"
+msgstr "MacDingbatsera"
+
+#: ../src/common/fmapbase.cpp:228
+msgid "MacTurkish"
+msgstr "MacTurkiera"
+
+#: ../src/common/fmapbase.cpp:229
+msgid "MacCroatian"
+msgstr "MacKroaziera"
+
+#: ../src/common/fmapbase.cpp:230
+msgid "MacIcelandic"
+msgstr "MacIslandiera"
+
+#: ../src/common/fmapbase.cpp:231
+msgid "MacRomanian"
+msgstr "MacErrumaniera"
+
+#: ../src/common/fmapbase.cpp:232
+msgid "MacCeltic"
+msgstr "MacZeltiera"
+
+#: ../src/common/fmapbase.cpp:233
+msgid "MacGaelic"
+msgstr "MacGaeliera"
+
+#: ../src/common/fmapbase.cpp:234
+msgid "MacKeyboardGlyphs"
+msgstr "MacTeklatuaGlyphs"
+
+#: ../src/common/fmapbase.cpp:791
+msgid "Default encoding"
+msgstr "Berezko kodeaketa"
+
+#: ../src/common/fmapbase.cpp:805
+#, c-format
+msgid "Unknown encoding (%d)"
+msgstr "Kodeaketa ezezaguna (%d)"
+
+#: ../src/common/fmapbase.cpp:815 ../src/richtext/richtextstyles.cpp:776
+msgid "default"
+msgstr "berezkoa"
+
+#: ../src/common/fmapbase.cpp:829
+#, c-format
+msgid "unknown-%d"
+msgstr "ezezaguna-%d"
+
+#: ../src/common/fontcmn.cpp:924 ../src/common/fontcmn.cpp:1130
+msgid "underlined"
+msgstr "azpimarratua"
+
+#: ../src/common/fontcmn.cpp:929
+msgid " strikethrough"
+msgstr "Marratuta"
+
+#: ../src/common/fontcmn.cpp:942
+msgid " thin"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:946
+#, fuzzy
+msgid " extra light"
+msgstr " arina"
+
+#: ../src/common/fontcmn.cpp:950
+msgid " light"
+msgstr " arina"
+
+#: ../src/common/fontcmn.cpp:954
+msgid " medium"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:958
+#, fuzzy
+msgid " semi bold"
+msgstr " lodia"
+
+#: ../src/common/fontcmn.cpp:962
+msgid " bold"
+msgstr " lodia"
+
+#: ../src/common/fontcmn.cpp:966
+#, fuzzy
+msgid " extra bold"
+msgstr " lodia"
+
+#: ../src/common/fontcmn.cpp:970
+msgid " heavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:974
+msgid " extra heavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:990
+msgid " italic"
+msgstr " etzana"
+
+#: ../src/common/fontcmn.cpp:1134
+msgid "strikethrough"
+msgstr "Marratuta"
+
+#: ../src/common/fontcmn.cpp:1143
+msgid "thin"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1156
+#, fuzzy
+msgid "extralight"
+msgstr "arina"
+
+#: ../src/common/fontcmn.cpp:1161
+msgid "light"
+msgstr "arina"
+
+#: ../src/common/fontcmn.cpp:1169 ../src/richtext/richtextstyles.cpp:775
+msgid "normal"
+msgstr "arrunta"
+
+#: ../src/common/fontcmn.cpp:1174
+msgid "medium"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1179 ../src/common/fontcmn.cpp:1199
+#, fuzzy
+msgid "semibold"
+msgstr "lodia"
+
+#: ../src/common/fontcmn.cpp:1184
+msgid "bold"
+msgstr "lodia"
+
+#: ../src/common/fontcmn.cpp:1194
+#, fuzzy
+msgid "extrabold"
+msgstr "lodia"
+
+#: ../src/common/fontcmn.cpp:1204
+msgid "heavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1212
+msgid "extraheavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1217
+msgid "italic"
+msgstr "etzana"
+
+#: ../src/common/fontmap.cpp:195
+msgid ": unknown charset"
+msgstr ": hizki-kode ezezaguna"
+
+#: ../src/common/fontmap.cpp:199
+#, c-format
+msgid ""
+"The charset '%s' is unknown. You may select\n"
+"another charset to replace it with or choose\n"
+"[Cancel] if it cannot be replaced"
+msgstr ""
+"'%s' hizkikodea ezezaguna da. Hautatu dezakezu\n"
+"beste hizkikode bat ordezteko edo hautatu\n"
+"[Ezeztatu] ezin bada ordeztu"
+
+#: ../src/common/fontmap.cpp:241
+#, c-format
+msgid "Failed to remember the encoding for the charset '%s'."
+msgstr "Hutsegitea '%s' hizkikodea kodeatzeaz gogoratzerakoan."
+
+#: ../src/common/fontmap.cpp:321
+msgid "can't load any font, aborting"
+msgstr "ezin da gertatu hizkirik, uzten"
+
+#: ../src/common/fontmap.cpp:409
+msgid ": unknown encoding"
+msgstr ": kodeaketa ezezaguna"
+
+#: ../src/common/fontmap.cpp:417
+#, c-format
+msgid ""
+"No font for displaying text in encoding '%s' found,\n"
+"but an alternative encoding '%s' is available.\n"
+"Do you want to use this encoding (otherwise you will have to choose another "
+"one)?"
+msgstr ""
+"Ez da aurkitu hizkirik idazkia erakusteko '%s' kodeaketan.\n"
+"baina '%s' kodeaketa aukera eskuragarri dago.\n"
+"Nahi duzu kodeaketa hau erabiltzea (bestela beste bat hautatu beharko duzu)?"
+
+#: ../src/common/fontmap.cpp:422
+#, c-format
+msgid ""
+"No font for displaying text in encoding '%s' found.\n"
+"Would you like to select a font to be used for this encoding\n"
+"(otherwise the text in this encoding will not be shown correctly)?"
+msgstr ""
+"Ez da aurkitu hizkirik idazkia erakusteko '%s' kodeaketan.\n"
+"Nahi duzu hautatzea hizki bat kodeaketa honetarako erabitzeko\n"
+"(bestela idazkia kodeaketa honetan ez da zuzen erakutsiko)?"
+
+#: ../src/common/fs_mem.cpp:169
+#, c-format
+msgid "Memory VFS already contains file '%s'!"
+msgstr "VFS oroimenak jadanik badu '%s' agiria!"
+
+#: ../src/common/fs_mem.cpp:232
+#, c-format
+msgid "Trying to remove file '%s' from memory VFS, but it is not loaded!"
+msgstr "Saiatzen '%s' agiria VFS oroimenetik kentzen, baina ez dago gertatuta!"
+
+#: ../src/common/fs_mem.cpp:262
+#, c-format
+msgid "Failed to store image '%s' to memory VFS!"
+msgstr "Hutsegitea '%s' irudia VFS oroimenean biltegiratzerakoan!"
+
+#: ../src/common/ftp.cpp:197
+msgid "Timeout while waiting for FTP server to connect, try passive mode."
+msgstr ""
+"Denboraz kanpo FTP zerbitzariarekin elkarketatzeari itxaroten, saiatu modu "
+"pasiboarekin."
+
+#: ../src/common/ftp.cpp:399
+#, c-format
+msgid "Failed to set FTP transfer mode to %s."
+msgstr "Hutsegitea FTP eskualdaketa modua %s-ra ezartzerakoan."
+
+#: ../src/common/ftp.cpp:400 ../src/richtext/richtextsymboldlg.cpp:432
+msgid "ASCII"
+msgstr "ASCII"
+
+#: ../src/common/ftp.cpp:400
+msgid "binary"
+msgstr "binarioa"
+
+#: ../src/common/ftp.cpp:608
+msgid "The FTP server doesn't support the PORT command."
+msgstr "FTP zerbitzariak ez du ATAKA komandoa sostengatzen."
+
+#: ../src/common/ftp.cpp:622
+msgid "The FTP server doesn't support passive mode."
+msgstr "FTP zerbitzariak ez du modu pasiboa sostengatzen."
+
+#: ../src/common/gifdecod.cpp:822
+#, c-format
+msgid "Incorrect GIF frame size (%u, %d) for the frame #%u"
+msgstr "GIF frame neurri okerra (%u, %d) #%u framean"
+
+#: ../src/common/glcmn.cpp:108
+msgid "Failed to allocate colour for OpenGL"
+msgstr "Hutsegitea OpenGL-rako margoa esleitzerakoan"
+
+#: ../src/common/headerctrlcmn.cpp:57
+msgid "Please select the columns to show and define their order:"
+msgstr "Mesedez hautatu erakusteko zutabeak eta zehaztu beren ordena:"
+
+#: ../src/common/headerctrlcmn.cpp:58
+msgid "Customize Columns"
+msgstr "Norbereraratu Zutabeak"
+
+#: ../src/common/headerctrlcmn.cpp:304
+msgid "&Customize..."
+msgstr "&Norbereratu..."
+
+#: ../src/common/hyperlnkcmn.cpp:132
+#, fuzzy, c-format
+msgid "Failed to open URL \"%s\" in the default browser"
+msgstr "Hutsegitea \"%s\" URL-a berezko bilatzailean irekitzerakoan."
+
+#: ../src/common/iconbndl.cpp:195
+#, c-format
+msgid "Failed to load image %%d from file '%s'."
+msgstr "Hutsegitea %%d irudia '%s' agiritik gertatzerakoan."
+
+#: ../src/common/iconbndl.cpp:203
+#, c-format
+msgid "Failed to load image %d from stream."
+msgstr "Hutsegitea %d irudia jariotik gertatzerakoan."
+
+#: ../src/common/iconbndl.cpp:221
+#, fuzzy, c-format
+msgid "Failed to load icons from resource '%s'."
+msgstr "Hutsegitea \"%s\" ikurra baliabideetatik gertatzerakoan."
+
+#: ../src/common/imagbmp.cpp:97
+msgid "BMP: Couldn't save invalid image."
+msgstr "BMP: Ezinezkoa baliogabeko irudia gordetzea."
+
+#: ../src/common/imagbmp.cpp:137
+msgid "BMP: wxImage doesn't have own wxPalette."
+msgstr "BMP: wxImagek ez du ber wxPalette."
+
+#: ../src/common/imagbmp.cpp:243
+msgid "BMP: Couldn't write the file (Bitmap) header."
+msgstr "BMP: Ezinezkoa agiri idazburua (Bitmapa) idaztea."
+
+#: ../src/common/imagbmp.cpp:266
+msgid "BMP: Couldn't write the file (BitmapInfo) header."
+msgstr "BMP: Ezinezkoa agiri idazburua (BitmapaArgib.) idaztea."
+
+#: ../src/common/imagbmp.cpp:353
+msgid "BMP: Couldn't write RGB color map."
+msgstr "BMP: Ezinezkoa RGB margo mapa idaztea."
+
+#: ../src/common/imagbmp.cpp:487
+msgid "BMP: Couldn't write data."
+msgstr "BMP: Ezinezkoa datuak idaztea."
+
+#: ../src/common/imagbmp.cpp:561 ../src/common/imagbmp.cpp:642
+msgid "BMP: Couldn't allocate memory."
+msgstr "BMP: Ezinezkoa oroimena esleitzea."
+
+#: ../src/common/imagbmp.cpp:1041
+msgid "DIB Header: Image width > 32767 pixels for file."
+msgstr "DIB Idazburua: Irudi zabalera > 32767 pixel agiriko."
+
+#: ../src/common/imagbmp.cpp:1049
+msgid "DIB Header: Image height > 32767 pixels for file."
+msgstr "DIB Idazburua: Irudi garaiera > 32767 pixel agiriko."
+
+#: ../src/common/imagbmp.cpp:1081
+msgid "DIB Header: Unknown bitdepth in file."
+msgstr "DIB Idazburua: Bit-sakonera ezezaguna agirian."
+
+#: ../src/common/imagbmp.cpp:1156
+msgid "DIB Header: Unknown encoding in file."
+msgstr "DIB Idazburua: Kodeaketa ezezaguna agirian."
+
+#: ../src/common/imagbmp.cpp:1165
+msgid "DIB Header: Encoding doesn't match bitdepth."
+msgstr "DIB Idazburua: Kodeaketak ez du bitsakonera."
+
+#: ../src/common/imagbmp.cpp:1180
+#, c-format
+msgid "BMP Header: Invalid number of colors (%d)."
+msgstr ""
+
+#: ../src/common/imagbmp.cpp:1273
+msgid "Error in reading image DIB."
+msgstr "Akatsa DIB irudia irakurtzean."
+
+#: ../src/common/imagbmp.cpp:1294
+msgid "ICO: Error in reading mask DIB."
+msgstr "ICO: Akatsa DIB mozorroa irakurtzerakoan."
+
+#: ../src/common/imagbmp.cpp:1353
+msgid "ICO: Image too tall for an icon."
+msgstr "ICO: Irudi garaiegia ikur batentzat."
+
+#: ../src/common/imagbmp.cpp:1361
+msgid "ICO: Image too wide for an icon."
+msgstr "ICO: Irudi zabalegia ikur batentzat."
+
+#: ../src/common/imagbmp.cpp:1388 ../src/common/imagbmp.cpp:1488
+#: ../src/common/imagbmp.cpp:1503 ../src/common/imagbmp.cpp:1514
+#: ../src/common/imagbmp.cpp:1528 ../src/common/imagbmp.cpp:1576
+#: ../src/common/imagbmp.cpp:1591 ../src/common/imagbmp.cpp:1605
+#: ../src/common/imagbmp.cpp:1616
+msgid "ICO: Error writing the image file!"
+msgstr "ICO: Akatsa irudi agiria idazterakoan!"
+
+#: ../src/common/imagbmp.cpp:1701
+msgid "ICO: Invalid icon index."
+msgstr "ICO: ikur aurkibide baliogabea."
+
+#: ../src/common/image.cpp:2410
+msgid "Image and mask have different sizes."
+msgstr "Irudia eta mozorroak neurri ezberdinak dituzte."
+
+#: ../src/common/image.cpp:2418 ../src/common/image.cpp:2459
+msgid "No unused colour in image being masked."
+msgstr "Ez dago erabiligabeko margorik mozorrotzen den irudian."
+
+#: ../src/common/image.cpp:2641
+#, c-format
+msgid "Failed to load bitmap \"%s\" from resources."
+msgstr "Hutsegitea \"%s\" bitmapa baliabideetatik gertatzerakoan."
+
+#: ../src/common/image.cpp:2650
+#, c-format
+msgid "Failed to load icon \"%s\" from resources."
+msgstr "Hutsegitea \"%s\" ikurra baliabideetatik gertatzerakoan."
+
+#: ../src/common/image.cpp:2728 ../src/common/image.cpp:2747
+#, c-format
+msgid "Failed to load image from file \"%s\"."
+msgstr "Hutsegita irudia \"%s\" agiritik gertatzerakoan."
+
+#: ../src/common/image.cpp:2761
+#, c-format
+msgid "Can't save image to file '%s': unknown extension."
+msgstr "Ezin da irudia '%s' agirian gorde: luzepen ezezaguna."
+
+#: ../src/common/image.cpp:2869
+msgid "No handler found for image type."
+msgstr "Ez da kudeatzailerik aurkitu irudi motarentzat."
+
+#: ../src/common/image.cpp:2877 ../src/common/image.cpp:3000
+#: ../src/common/image.cpp:3066
+#, c-format
+msgid "No image handler for type %d defined."
+msgstr "Ez da irudi kudeatzailerik adierazi %d motarako."
+
+#: ../src/common/image.cpp:2887
+#, c-format
+msgid "Image file is not of type %d."
+msgstr "Irudi agiria ez da %d motakoa."
+
+#: ../src/common/image.cpp:2970
+msgid "Can't automatically determine the image format for non-seekable input."
+msgstr ""
+"Ezin da berezgaitasunez zehaztu irudi heuskarria sarrera ez-"
+"bilagarriarentzat."
+
+#: ../src/common/image.cpp:2988
+msgid "Unknown image data format."
+msgstr "Irudi datu heuskarri ezezaguna"
+
+#: ../src/common/image.cpp:3009
+#, c-format
+msgid "This is not a %s."
+msgstr "Hau ez da %s bat."
+
+#: ../src/common/image.cpp:3032 ../src/common/image.cpp:3080
+#, c-format
+msgid "No image handler for type %s defined."
+msgstr "Ez da irudi kudeatzailerik adierazi %s motarako."
+
+#: ../src/common/image.cpp:3041
+#, c-format
+msgid "Image is not of type %s."
+msgstr "Irudia ez da %s motakoa."
+
+#: ../src/common/image.cpp:3509
+#, c-format
+msgid "Failed to check format of image file \"%s\"."
+msgstr "Hutsegitea \"%s\" irudi agiriaren heuskarria egiaztatzerakoan"
+
+#: ../src/common/imaggif.cpp:124
+msgid "GIF: error in GIF image format."
+msgstr "GIF: akats GIF irudi heuskarrian."
+
+#: ../src/common/imaggif.cpp:129
+msgid "GIF: not enough memory."
+msgstr "GIF: ez dago nahikoa oroimenik."
+
+#: ../src/common/imaggif.cpp:134
+msgid "GIF: data stream seems to be truncated."
+msgstr "GiF: datu jarioa etenda dagoela dirudi."
+
+#: ../src/common/imaggif.cpp:240
+msgid "Couldn't initialize GIF hash table."
+msgstr "Ezinezkoa GIF hash taula abiaraztea."
+
+#: ../src/common/imagiff.cpp:739
+msgid "IFF: error in IFF image format."
+msgstr "IFF: akatsa IFF irudi heuskarrian."
+
+#: ../src/common/imagiff.cpp:742
+msgid "IFF: not enough memory."
+msgstr "IFF: ez dago nahikoa oroimenik."
+
+#: ../src/common/imagiff.cpp:745
+msgid "IFF: unknown error!!!"
+msgstr "IFF: akats ezezaguna!!!"
+
+#: ../src/common/imagiff.cpp:755
+msgid "IFF: data stream seems to be truncated."
+msgstr "IFF: datu jarioa etenda dagoela dirudi."
+
+#: ../src/common/imagjpeg.cpp:258
+msgid "JPEG: Couldn't load - file is probably corrupted."
+msgstr "JPEG: Ezinezkoa gertatzea - agiria zihurrenik hondatuta dago."
+
+#: ../src/common/imagjpeg.cpp:437
+msgid "JPEG: Couldn't save image."
+msgstr "JPEG: Ezinezkoa irudia gordetzea."
+
+#: ../src/common/imagpcx.cpp:439
+msgid "PCX: this is not a PCX file."
+msgstr "PCX: hau ez da PCX agiri bat."
+
+#: ../src/common/imagpcx.cpp:453
+msgid "PCX: image format unsupported"
+msgstr "PCX: irudi heuskarri sostengatu gabea"
+
+#: ../src/common/imagpcx.cpp:454 ../src/common/imagpcx.cpp:477
+msgid "PCX: couldn't allocate memory"
+msgstr "PCX: ezinezkoa oroimena esleitzea"
+
+#: ../src/common/imagpcx.cpp:455
+msgid "PCX: version number too low"
+msgstr "PCX: bertsio zenbaki txikiegia"
+
+#: ../src/common/imagpcx.cpp:456 ../src/common/imagpcx.cpp:478
+msgid "PCX: unknown error !!!"
+msgstr "PCX: akats ezezaguna!!!"
+
+#: ../src/common/imagpcx.cpp:476
+msgid "PCX: invalid image"
+msgstr "PCX: irudi baliogabea"
+
+#: ../src/common/imagpng.cpp:385
+#, c-format
+msgid "Unknown PNG resolution unit %d"
+msgstr "PNG bereizmen unitate ezezaguna %d"
+
+#: ../src/common/imagpng.cpp:439
+msgid "Couldn't load a PNG image - file is corrupted or not enough memory."
+msgstr ""
+"Ezinezkoa PNG irudia gertatzea - agiria hondatuta dago edo ez dago nahikoa "
+"oroimen."
+
+#: ../src/common/imagpng.cpp:513 ../src/common/imagpng.cpp:524
+#: ../src/common/imagpng.cpp:534
+msgid "Couldn't save PNG image."
+msgstr "Ezinezkoa PNG irudia gordetzea."
+
+#: ../src/common/imagpnm.cpp:71
+msgid "PNM: File format is not recognized."
+msgstr "PNM: Agiri heuskarria ezezaguna da."
+
+#: ../src/common/imagpnm.cpp:89
+msgid "PNM: Couldn't allocate memory."
+msgstr "PNM: Ezinezkoa oroimena esleitzea."
+
+#: ../src/common/imagpnm.cpp:111 ../src/common/imagpnm.cpp:134
+#: ../src/common/imagpnm.cpp:156
+msgid "PNM: File seems truncated."
+msgstr "PNM: Agiriak trunkatua dirudi."
+
+#: ../src/common/imagtiff.cpp:69
+#, c-format
+msgid " (in module \"%s\")"
+msgstr " (\"%s\" moduloan)"
+
+#: ../src/common/imagtiff.cpp:304
+msgid "TIFF: Error loading image."
+msgstr "TIFF: Akatsa irudia gertatzen."
+
+#: ../src/common/imagtiff.cpp:314
+msgid "Invalid TIFF image index."
+msgstr "TIFF irudi aurkibide baliogabea."
+
+#: ../src/common/imagtiff.cpp:358
+msgid "TIFF: Image size is abnormally big."
+msgstr "TIFF: Irudi neurria handiegia da."
+
+#: ../src/common/imagtiff.cpp:372 ../src/common/imagtiff.cpp:385
+#: ../src/common/imagtiff.cpp:769
+msgid "TIFF: Couldn't allocate memory."
+msgstr "TIFF: Ezinezkoa oroimena esleitzea."
+
+#: ../src/common/imagtiff.cpp:471
+msgid "TIFF: Error reading image."
+msgstr "TIFF: Akats irudia irakurtzen."
+
+#: ../src/common/imagtiff.cpp:532
+#, c-format
+msgid "Unknown TIFF resolution unit %d ignored"
+msgstr "TIFF bereizmen unitate ezezaguna %d baztertuta"
+
+#: ../src/common/imagtiff.cpp:611
+msgid "TIFF: Error saving image."
+msgstr "TIFF: Akatsa irudia gordetzen."
+
+#: ../src/common/imagtiff.cpp:868
+msgid "TIFF: Error writing image."
+msgstr "TIFF: Akatsa irudia idazterakoan."
+
+#: ../src/common/imagtiff.cpp:881
+#, fuzzy
+msgid "TIFF: Error flushing data."
+msgstr "TIFF: Akatsa irudia gordetzen."
+
+#: ../src/common/imagwebp.cpp:56
+msgid "WebP: Invalid data (failed to get features)."
+msgstr ""
+
+#: ../src/common/imagwebp.cpp:65
+msgid "WebP: Allocating image memory failed."
+msgstr ""
+
+#: ../src/common/imagwebp.cpp:82
+msgid "WebP: Decoding RGBA image data failed."
+msgstr ""
+
+#: ../src/common/imagwebp.cpp:98
+msgid "WebP: Decoding RGB image data failed."
+msgstr ""
+
+#: ../src/common/imagwebp.cpp:113 ../src/common/imagwebp.cpp:201
+msgid "WebP: Allocating stream buffer failed."
+msgstr ""
+
+#: ../src/common/imagwebp.cpp:131
+#, fuzzy
+msgid "WebP: Failed to parse container data."
+msgstr "Hutsegitea gako datua ezartzerakoan."
+
+#: ../src/common/imagwebp.cpp:222
+#, fuzzy
+msgid "WebP: Error decoding animation."
+msgstr "Akatsa itxurap aukerak irakurtzean."
+
+#: ../src/common/imagwebp.cpp:240
+msgid "WebP: Error getting next animation frame."
+msgstr ""
+
+#: ../src/common/init.cpp:172
+#, c-format
+msgid ""
+"Command line argument %d couldn't be converted to Unicode and will be "
+"ignored."
+msgstr ""
+"%d agindu lerro argumentua ezin da Unicodera bihurtu eta ezikusi egingo da."
+
+#: ../src/common/init.cpp:344
+msgid "Initialization failed in post init, aborting."
+msgstr "Abiatzeak huts egin du abiostean, uzten."
+
+#: ../src/common/intl.cpp:378
+#, c-format
+msgid "Cannot set locale to language \"%s\"."
+msgstr "Ezin da ezarri tokikoa \"%s\" hizkuntzari."
+
+#: ../src/common/log.cpp:232
+msgid "Error: "
+msgstr "Akatsa:"
+
+#: ../src/common/log.cpp:236
+msgid "Warning: "
+msgstr "Kontuz:"
+
+#: ../src/common/log.cpp:284
+msgid "The previous message repeated once."
+msgstr "Aurreko mezua behin errepikatuta."
+
+#: ../src/common/log.cpp:291
+#, c-format
+msgid "The previous message repeated %u time."
+msgid_plural "The previous message repeated %u times."
+msgstr[0] "Aurreko mezua %u aldiz errepikatuta."
+msgstr[1] "Aurreko mezua %u aldiz errepikatuta."
+
+#: ../src/common/log.cpp:319
+#, c-format
+msgid "Last repeated message (\"%s\", %u time) wasn't output"
+msgid_plural "Last repeated message (\"%s\", %u times) wasn't output"
+msgstr[0] "Berregindako azken mezua (\"%s\", %u aldiz) ez zen irteera"
+msgstr[1] "Berregindako azken mezua (\"%s\", %u aldiz) ez zen irteera"
+
+#: ../src/common/log.cpp:435
+#, c-format
+msgid " (error %ld: %s)"
+msgstr " (%ld akatsa: %s)"
+
+#: ../src/common/lzmastream.cpp:121
+#, fuzzy
+msgid "Failed to allocate memory for LZMA decompression."
+msgstr "Hutsegitea OpenGL-rako margoa esleitzerakoan"
+
+#: ../src/common/lzmastream.cpp:125
+#, c-format
+msgid "Failed to initialize LZMA decompression: unexpected error %u."
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:179
+msgid "input is not in XZ format"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:183
+msgid "input compressed using unknown XZ option"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:188
+msgid "input is corrupted"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:192
+#, fuzzy
+msgid "unknown decompression error"
+msgstr "deskonpresio akatsa"
+
+#: ../src/common/lzmastream.cpp:196
+#, fuzzy, c-format
+msgid "LZMA decompression error: %s"
+msgstr "deskonpresio akatsa"
+
+#: ../src/common/lzmastream.cpp:231
+#, fuzzy
+msgid "Failed to allocate memory for LZMA compression."
+msgstr "Hutsegitea OpenGL-rako margoa esleitzerakoan"
+
+#: ../src/common/lzmastream.cpp:235
+#, c-format
+msgid "Failed to initialize LZMA compression: unexpected error %u."
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:267 ../src/common/lzmastream.cpp:342
+#: ../src/html/chm.cpp:336
+msgid "out of memory"
+msgstr "oroimenetik kanpo"
+
+#: ../src/common/lzmastream.cpp:276 ../src/common/lzmastream.cpp:346
+#, fuzzy
+msgid "unknown compression error"
+msgstr "konpresio akatsa"
+
+#: ../src/common/lzmastream.cpp:280
+#, fuzzy, c-format
+msgid "LZMA compression error: %s"
+msgstr "konpresio akatsa"
+
+#: ../src/common/lzmastream.cpp:350
+#, c-format
+msgid "LZMA compression error when flushing output: %s"
+msgstr ""
+
+#: ../src/common/mimecmn.cpp:167
+#, c-format
+msgid "Unmatched '{' in an entry for mime type %s."
+msgstr "Alderaezina  '{' mime motako %s sarrera batean."
+
+#: ../src/common/module.cpp:76
+#, c-format
+msgid "Circular dependency involving module \"%s\" detected."
+msgstr "\"%s\" moduloa inguratzen duen elkartoki zirkularra atzeman da."
+
+#: ../src/common/module.cpp:128
+#, c-format
+msgid "Dependency \"%s\" of module \"%s\" doesn't exist."
+msgstr "Elkargunea \"%s\" Moduloa \"%s\" ez dago."
+
+#: ../src/common/module.cpp:137
+#, c-format
+msgid "Module \"%s\" initialization failed"
+msgstr "\"%s\" moduloa abiatzeak huts egin du"
+
+#: ../src/common/msgout.cpp:96
+msgid "Message"
+msgstr "Mezua"
+
+#: ../src/common/paper.cpp:70
+msgid "Letter, 8 1/2 x 11 in"
+msgstr "Gutuna, 8 1/2 x 11 in"
+
+#: ../src/common/paper.cpp:71
+msgid "Legal, 8 1/2 x 14 in"
+msgstr "Legezkoa, 8 1/2 x 14 in"
+
+#: ../src/common/paper.cpp:72
+msgid "A4 sheet, 210 x 297 mm"
+msgstr "A4 orria, 210 x 297 mm"
+
+#: ../src/common/paper.cpp:73
+msgid "C sheet, 17 x 22 in"
+msgstr "C orria, 17 x 22 in"
+
+#: ../src/common/paper.cpp:74
+msgid "D sheet, 22 x 34 in"
+msgstr "D orria, 22 x 34 in"
+
+#: ../src/common/paper.cpp:75
+msgid "E sheet, 34 x 44 in"
+msgstr "E orria, 34 x 44 in"
+
+#: ../src/common/paper.cpp:76
+msgid "Letter Small, 8 1/2 x 11 in"
+msgstr "Gutun Txikia, 8 1/2 x 11 in"
+
+#: ../src/common/paper.cpp:77
+msgid "Tabloid, 11 x 17 in"
+msgstr "Tabloidea, 11 x 17 in"
+
+#: ../src/common/paper.cpp:78
+msgid "Ledger, 17 x 11 in"
+msgstr "Liburu nagusia, 17 x 11 in"
+
+#: ../src/common/paper.cpp:79
+msgid "Statement, 5 1/2 x 8 1/2 in"
+msgstr "Adierazpena, 5 1/2 x 8 1/2 in"
+
+#: ../src/common/paper.cpp:80
+msgid "Executive, 7 1/4 x 10 1/2 in"
+msgstr "Exekutiboa, 7 1/4 x 10 1/2 in"
+
+#: ../src/common/paper.cpp:81
+msgid "A3 sheet, 297 x 420 mm"
+msgstr "A3 orria, 297 x 420 mm"
+
+#: ../src/common/paper.cpp:82
+msgid "A4 small sheet, 210 x 297 mm"
+msgstr "A4 orri txikia, 210 x 297 mm"
+
+#: ../src/common/paper.cpp:83
+msgid "A5 sheet, 148 x 210 mm"
+msgstr "A5 orria, 148 x 210 mm"
+
+#: ../src/common/paper.cpp:84
+msgid "B4 sheet, 250 x 354 mm"
+msgstr "B4 orria, 250 x 354 mm"
+
+#: ../src/common/paper.cpp:85
+msgid "B5 sheet, 182 x 257 millimeter"
+msgstr "B5 orria, 182 x 257 metromilaen"
+
+#: ../src/common/paper.cpp:86
+msgid "Folio, 8 1/2 x 13 in"
+msgstr "Folio, 8 1/2 x 13 in"
+
+#: ../src/common/paper.cpp:87
+msgid "Quarto, 215 x 275 mm"
+msgstr "Quarto, 215 x 275 mm"
+
+#: ../src/common/paper.cpp:88
+msgid "10 x 14 in"
+msgstr "10 x 14 in"
+
+#: ../src/common/paper.cpp:89
+msgid "11 x 17 in"
+msgstr "11 x 17 in"
+
+#: ../src/common/paper.cpp:90
+msgid "Note, 8 1/2 x 11 in"
+msgstr "Oharra, 8 1/2 x 11 in"
+
+#: ../src/common/paper.cpp:91
+msgid "#9 Envelope, 3 7/8 x 8 7/8 in"
+msgstr "#9 Gutunazala, 3 7/8 x 8 7/8 in"
+
+#: ../src/common/paper.cpp:92
+msgid "#10 Envelope, 4 1/8 x 9 1/2 in"
+msgstr "#10 Gutunazala, 4 1/8 x 9 1/2 in"
+
+#: ../src/common/paper.cpp:93
+msgid "#11 Envelope, 4 1/2 x 10 3/8 in"
+msgstr "#11 Gutunazala, 4 1/2 x 10 3/8 in"
+
+#: ../src/common/paper.cpp:94
+msgid "#12 Envelope, 4 3/4 x 11 in"
+msgstr "#12 Gutunazala, 4 3/4 x 11 in"
+
+#: ../src/common/paper.cpp:95
+msgid "#14 Envelope, 5 x 11 1/2 in"
+msgstr "#14 Gutunazala, 5 x 11 1/2 in"
+
+#: ../src/common/paper.cpp:96
+msgid "DL Envelope, 110 x 220 mm"
+msgstr "DL Gutunazala, 110 x 220 mm"
+
+#: ../src/common/paper.cpp:97
+msgid "C5 Envelope, 162 x 229 mm"
+msgstr "C5 Gutunazala, 162 x 229 mm"
+
+#: ../src/common/paper.cpp:98
+msgid "C3 Envelope, 324 x 458 mm"
+msgstr "C3 Gutunazala, 324 x 458 mm"
+
+#: ../src/common/paper.cpp:99
+msgid "C4 Envelope, 229 x 324 mm"
+msgstr "C4 Gutunazala, 229 x 324 mm"
+
+#: ../src/common/paper.cpp:100
+msgid "C6 Envelope, 114 x 162 mm"
+msgstr "C6 Gutunazala, 114 x 162 mm"
+
+#: ../src/common/paper.cpp:101
+msgid "C65 Envelope, 114 x 229 mm"
+msgstr "C65 Gutunazala, 114 x 229 mm"
+
+#: ../src/common/paper.cpp:102
+msgid "B4 Envelope, 250 x 353 mm"
+msgstr "B4 Gutunazala, 250 x 353 mm"
+
+#: ../src/common/paper.cpp:103
+msgid "B5 Envelope, 176 x 250 mm"
+msgstr "B5 Gutunazala, 176 x 250 mm"
+
+#: ../src/common/paper.cpp:104
+msgid "B6 Envelope, 176 x 125 mm"
+msgstr "B6 Gutunazala, 176 x 125 mm"
+
+#: ../src/common/paper.cpp:105
+msgid "Italy Envelope, 110 x 230 mm"
+msgstr "Italiar Gutunazala, 110 x 230 mm"
+
+#: ../src/common/paper.cpp:106
+msgid "Monarch Envelope, 3 7/8 x 7 1/2 in"
+msgstr "Errege Gutunazala, 3 7/8 x 7 1/2 in"
+
+#: ../src/common/paper.cpp:107
+msgid "6 3/4 Envelope, 3 5/8 x 6 1/2 in"
+msgstr "6 3/4 Gutunazala, 3 5/8 x 6 1/2 in"
+
+#: ../src/common/paper.cpp:108
+msgid "US Std Fanfold, 14 7/8 x 11 in"
+msgstr "US Std Fanfold, 14 7/8 x 11 in"
+
+#: ../src/common/paper.cpp:109
+msgid "German Std Fanfold, 8 1/2 x 12 in"
+msgstr "German Std Fanfold, 8 1/2 x 12 in"
+
+#: ../src/common/paper.cpp:110
+msgid "German Legal Fanfold, 8 1/2 x 13 in"
+msgstr "German Legal Fanfold, 8 1/2 x 13 in"
+
+#: ../src/common/paper.cpp:112
+msgid "B4 (ISO) 250 x 353 mm"
+msgstr "B4 (ISO) 250 x 353 mm"
+
+#: ../src/common/paper.cpp:113
+msgid "Japanese Postcard 100 x 148 mm"
+msgstr "Japoniar Bidaitxartela 100 x 148 mm"
+
+#: ../src/common/paper.cpp:114
+msgid "9 x 11 in"
+msgstr "9 x 11 in"
+
+#: ../src/common/paper.cpp:115
+msgid "10 x 11 in"
+msgstr "10 x 11 in"
+
+#: ../src/common/paper.cpp:116
+msgid "15 x 11 in"
+msgstr "15 x 11 in"
+
+#: ../src/common/paper.cpp:117
+msgid "Envelope Invite 220 x 220 mm"
+msgstr "Gonbidapen Gutunazala 220 x 220 mm"
+
+#: ../src/common/paper.cpp:118
+msgid "Letter Extra 9 1/2 x 12 in"
+msgstr "Gutuna Estra 9 1/2 x 12 in"
+
+#: ../src/common/paper.cpp:119
+msgid "Legal Extra 9 1/2 x 15 in"
+msgstr "Legezkoa Estra 9 1/2 x 15 in"
+
+#: ../src/common/paper.cpp:120
+msgid "Tabloid Extra 11.69 x 18 in"
+msgstr "Tabloidea Estra 11.69 x 18 in"
+
+#: ../src/common/paper.cpp:121
+msgid "A4 Extra 9.27 x 12.69 in"
+msgstr "A4 Estra 9.27 x 12.69 in"
+
+#: ../src/common/paper.cpp:122
+msgid "Letter Transverse 8 1/2 x 11 in"
+msgstr "Gutuna Zeharka 8 1/2 x 11 in"
+
+#: ../src/common/paper.cpp:123
+msgid "A4 Transverse 210 x 297 mm"
+msgstr "A4 Zeharka 210 x 297 mm"
+
+#: ../src/common/paper.cpp:124
+msgid "Letter Extra Transverse 9.275 x 12 in"
+msgstr "Gutuna Estra Zeharka 9.275 x 12 in"
+
+#: ../src/common/paper.cpp:125
+msgid "SuperA/SuperA/A4 227 x 356 mm"
+msgstr "SuperA/SuperA/A4 227 x 356 mm"
+
+#: ../src/common/paper.cpp:126
+msgid "SuperB/SuperB/A3 305 x 487 mm"
+msgstr "SuperB/SuperB/A3 305 x 487 mm"
+
+#: ../src/common/paper.cpp:127
+msgid "Letter Plus 8 1/2 x 12.69 in"
+msgstr "Gutuna Plus 8 1/2 x 12.69 in"
+
+#: ../src/common/paper.cpp:128
+msgid "A4 Plus 210 x 330 mm"
+msgstr "A4 Plus 210 x 330 mm"
+
+#: ../src/common/paper.cpp:129
+msgid "A5 Transverse 148 x 210 mm"
+msgstr "A5 Zeharka 148 x 210 mm"
+
+#: ../src/common/paper.cpp:130
+msgid "B5 (JIS) Transverse 182 x 257 mm"
+msgstr "B5 (JIS) Zeharka 182 x 257 mm"
+
+#: ../src/common/paper.cpp:131
+msgid "A3 Extra 322 x 445 mm"
+msgstr "A3 Estra 322 x 445 mm"
+
+#: ../src/common/paper.cpp:132
+msgid "A5 Extra 174 x 235 mm"
+msgstr "A5 Estra 174 x 235 mm"
+
+#: ../src/common/paper.cpp:133
+msgid "B5 (ISO) Extra 201 x 276 mm"
+msgstr "B5 (ISO) Estra 201 x 276 mm"
+
+#: ../src/common/paper.cpp:134
+msgid "A2 420 x 594 mm"
+msgstr "A2 420 x 594 mm"
+
+#: ../src/common/paper.cpp:135
+msgid "A3 Transverse 297 x 420 mm"
+msgstr "A3 Zeharka 297 x 420 mm"
+
+#: ../src/common/paper.cpp:136
+msgid "A3 Extra Transverse 322 x 445 mm"
+msgstr "A3 Estra Zeharka 322 x 445 mm"
+
+#: ../src/common/paper.cpp:138
+msgid "Japanese Double Postcard 200 x 148 mm"
+msgstr "Japoniar Bidaitxartel Bikoitza 200 x 148 mm"
+
+#: ../src/common/paper.cpp:139
+msgid "A6 105 x 148 mm"
+msgstr "A6 105 x 148 mm"
+
+#: ../src/common/paper.cpp:140
+msgid "Japanese Envelope Kaku #2"
+msgstr "Japoniar Gutunazala Kaku #2"
+
+#: ../src/common/paper.cpp:141
+msgid "Japanese Envelope Kaku #3"
+msgstr "Japoniar Gutunazala Kaku #3"
+
+#: ../src/common/paper.cpp:142
+msgid "Japanese Envelope Chou #3"
+msgstr "Japoniar Gutunazala Chou #3"
+
+#: ../src/common/paper.cpp:143
+msgid "Japanese Envelope Chou #4"
+msgstr "Japoniar Gutunazala Chou #4"
+
+#: ../src/common/paper.cpp:144
+msgid "Letter Rotated 11 x 8 1/2 in"
+msgstr "Gutuna Itzulita 11 x 8 1/2 in"
+
+#: ../src/common/paper.cpp:145
+msgid "A3 Rotated 420 x 297 mm"
+msgstr "A3 Itzulita 420 x 297 mm"
+
+#: ../src/common/paper.cpp:146
+msgid "A4 Rotated 297 x 210 mm"
+msgstr "A4 Itzulita 297 x 210 mm"
+
+#: ../src/common/paper.cpp:147
+msgid "A5 Rotated 210 x 148 mm"
+msgstr "A5 Itzulita 210 x 148 mm"
+
+#: ../src/common/paper.cpp:148
+msgid "B4 (JIS) Rotated 364 x 257 mm"
+msgstr "B4 (JIS) Itzulita 364 x 257 mm"
+
+#: ../src/common/paper.cpp:149
+msgid "B5 (JIS) Rotated 257 x 182 mm"
+msgstr "B5 (JIS) Itzulita 257 x 182 mm"
+
+#: ../src/common/paper.cpp:150
+msgid "Japanese Postcard Rotated 148 x 100 mm"
+msgstr "Japoniar Bidaitxartela Itzulita 148 x 100 mm"
+
+#: ../src/common/paper.cpp:151
+msgid "Double Japanese Postcard Rotated 148 x 200 mm"
+msgstr "Japoniar Bidaitxartel Bikoitza Itzulita 148 x 200 mm"
+
+#: ../src/common/paper.cpp:152
+msgid "A6 Rotated 148 x 105 mm"
+msgstr "A6 Itzulita 148 x 105 mm"
+
+#: ../src/common/paper.cpp:153
+msgid "Japanese Envelope Kaku #2 Rotated"
+msgstr "Japoniar Gutunazala Kaku #2 Itzulita"
+
+#: ../src/common/paper.cpp:154
+msgid "Japanese Envelope Kaku #3 Rotated"
+msgstr "Japoniar Gutunazala Kaku #3 Itzulita"
+
+#: ../src/common/paper.cpp:155
+msgid "Japanese Envelope Chou #3 Rotated"
+msgstr "Japoniar Gutunazala Chou #3 Itzulita"
+
+#: ../src/common/paper.cpp:156
+msgid "Japanese Envelope Chou #4 Rotated"
+msgstr "Japoniar Gutunazala Chou #4 Itzulita"
+
+#: ../src/common/paper.cpp:157
+msgid "B6 (JIS) 128 x 182 mm"
+msgstr "B6 (JIS) 128 x 182 mm"
+
+#: ../src/common/paper.cpp:158
+msgid "B6 (JIS) Rotated 182 x 128 mm"
+msgstr "B6 (JIS) Itzulita 182 x 128 mm"
+
+#: ../src/common/paper.cpp:159
+msgid "12 x 11 in"
+msgstr "12 x 11 in"
+
+#: ../src/common/paper.cpp:160
+msgid "Japanese Envelope You #4"
+msgstr "Japoniar Gutunazala You #4"
+
+#: ../src/common/paper.cpp:161
+msgid "Japanese Envelope You #4 Rotated"
+msgstr "Japoniar Gutunazala You #4 Itzulita"
+
+#: ../src/common/paper.cpp:162
+msgid "PRC 16K 146 x 215 mm"
+msgstr "PRC 16K 146 x 215 mm"
+
+#: ../src/common/paper.cpp:163
+msgid "PRC 32K 97 x 151 mm"
+msgstr "PRC 32K 97 x 151 mm"
+
+#: ../src/common/paper.cpp:164
+msgid "PRC 32K(Big) 97 x 151 mm"
+msgstr "PRC 32K(Handia) 97 x 151 mm"
+
+#: ../src/common/paper.cpp:165
+msgid "PRC Envelope #1 102 x 165 mm"
+msgstr "PRC Gutunazala #1 102 x 165 mm"
+
+#: ../src/common/paper.cpp:166
+msgid "PRC Envelope #2 102 x 176 mm"
+msgstr "PRC Gutunazala #2 102 x 176 mm"
+
+#: ../src/common/paper.cpp:167
+msgid "PRC Envelope #3 125 x 176 mm"
+msgstr "PRC Gutunazala #3 125 x 176 mm"
+
+#: ../src/common/paper.cpp:168
+msgid "PRC Envelope #4 110 x 208 mm"
+msgstr "PRC Gutunazala #4 110 x 208 mm"
+
+#: ../src/common/paper.cpp:169
+msgid "PRC Envelope #5 110 x 220 mm"
+msgstr "PRC Gutunazala #5 110 x 220 mm"
+
+#: ../src/common/paper.cpp:170
+msgid "PRC Envelope #6 120 x 230 mm"
+msgstr "PRC Gutunazala #6 120 x 230 mm"
+
+#: ../src/common/paper.cpp:171
+msgid "PRC Envelope #7 160 x 230 mm"
+msgstr "PRC Gutunazala #7 160 x 230 mm"
+
+#: ../src/common/paper.cpp:172
+msgid "PRC Envelope #8 120 x 309 mm"
+msgstr "PRC Gutunazala #8 120 x 309 mm"
+
+#: ../src/common/paper.cpp:173
+msgid "PRC Envelope #9 229 x 324 mm"
+msgstr "PRC Gutunazala #9 229 x 324 mm"
+
+#: ../src/common/paper.cpp:174
+msgid "PRC Envelope #10 324 x 458 mm"
+msgstr "PRC Gutunazala #10 324 x 458 mm"
+
+#: ../src/common/paper.cpp:175
+msgid "PRC 16K Rotated"
+msgstr "PRC 16K Itzulita"
+
+#: ../src/common/paper.cpp:176
+msgid "PRC 32K Rotated"
+msgstr "PRC 32K Itzulita"
+
+#: ../src/common/paper.cpp:177
+msgid "PRC 32K(Big) Rotated"
+msgstr "PRC 32K(Handia) Itzulita"
+
+#: ../src/common/paper.cpp:178
+msgid "PRC Envelope #1 Rotated 165 x 102 mm"
+msgstr "PRC Gutunazala #1 Itzulita 165 x 102 mm"
+
+#: ../src/common/paper.cpp:179
+msgid "PRC Envelope #2 Rotated 176 x 102 mm"
+msgstr "PRC Gutunazala #2 Itzulita 176 x 102 mm"
+
+#: ../src/common/paper.cpp:180
+msgid "PRC Envelope #3 Rotated 176 x 125 mm"
+msgstr "PRC Gutunazala #3 Itzulita 176 x 125 mm"
+
+#: ../src/common/paper.cpp:181
+msgid "PRC Envelope #4 Rotated 208 x 110 mm"
+msgstr "PRC Gutunazala #4 Itzulita 208 x 110 mm"
+
+#: ../src/common/paper.cpp:182
+msgid "PRC Envelope #5 Rotated 220 x 110 mm"
+msgstr "PRC Gutunazala #5 Itzulita 220 x 110 mm"
+
+#: ../src/common/paper.cpp:183
+msgid "PRC Envelope #6 Rotated 230 x 120 mm"
+msgstr "PRC Gutunazala #6 Itzulita 230 x 120 mm"
+
+#: ../src/common/paper.cpp:184
+msgid "PRC Envelope #7 Rotated 230 x 160 mm"
+msgstr "PRC Gutunazala #7 Itzulita 230 x 160 mm"
+
+#: ../src/common/paper.cpp:185
+msgid "PRC Envelope #8 Rotated 309 x 120 mm"
+msgstr "PRC Gutunazala #8 Itzulita 309 x 120 mm"
+
+#: ../src/common/paper.cpp:186
+msgid "PRC Envelope #9 Rotated 324 x 229 mm"
+msgstr "PRC Gutunazala #9 Itzulita 324 x 229 mm"
+
+#: ../src/common/paper.cpp:187
+msgid "PRC Envelope #10 Rotated 458 x 324 mm"
+msgstr "PRC Gutunazala #10 Itzulita 458 x 324 mm"
+
+#: ../src/common/paper.cpp:192
+msgid "A0 sheet, 841 x 1189 mm"
+msgstr "A0 orria, 841 x 1189 mm"
+
+#: ../src/common/paper.cpp:193
+msgid "A1 sheet, 594 x 841 mm"
+msgstr "A1 orria, 594 x 841 mm"
+
+#: ../src/common/preferencescmn.cpp:37
+msgid "General"
+msgstr "Orokorra"
+
+#: ../src/common/preferencescmn.cpp:40
+msgid "Advanced"
+msgstr "Aurreratua"
+
+#: ../src/common/prntbase.cpp:245
+msgid "Generic PostScript"
+msgstr "PostScript Generikoa"
+
+#: ../src/common/prntbase.cpp:259
+msgid "Ready"
+msgstr "Gertu"
+
+#: ../src/common/prntbase.cpp:331
+msgid "Printing Error"
+msgstr "Irarketa Akatsa"
+
+#: ../src/common/prntbase.cpp:413 ../src/common/prntbase.cpp:1597
+#: ../src/generic/prntdlgg.cpp:135 ../src/generic/prntdlgg.cpp:149
+#: ../src/gtk/print.cpp:628 ../src/gtk/print.cpp:646
+msgid "Print"
+msgstr "Irarkitu"
+
+#: ../src/common/prntbase.cpp:471 ../src/generic/prntdlgg.cpp:809
+msgid "Page setup"
+msgstr "Orrialde ezarpena"
+
+#: ../src/common/prntbase.cpp:525
+msgid "Please wait while printing..."
+msgstr "Mesedez itxaron irarkitzen den bitartean..."
+
+#: ../src/common/prntbase.cpp:529
+msgid "Document:"
+msgstr "Agiria:"
+
+#: ../src/common/prntbase.cpp:532
+msgid "Progress:"
+msgstr "Garapena:"
+
+#: ../src/common/prntbase.cpp:533
+msgid "Preparing"
+msgstr "Gertatzen"
+
+#: ../src/common/prntbase.cpp:552
+#, c-format
+msgid "Printing page %d"
+msgstr "Orrialdea irarkitzen %d"
+
+#: ../src/common/prntbase.cpp:557
+#, c-format
+msgid "Printing page %d of %d"
+msgstr "%d orrialdea irarkitzen %d-tik..."
+
+#: ../src/common/prntbase.cpp:560
+#, c-format
+msgid " (copy %d of %d)"
+msgstr " (kopiatu %d --> %d-tik"
+
+#: ../src/common/prntbase.cpp:1604
+msgid "First page"
+msgstr "Lehen orrialdea"
+
+#: ../src/common/prntbase.cpp:1609 ../src/html/helpwnd.cpp:659
+msgid "Previous page"
+msgstr "Aurreko orrialdea"
+
+#: ../src/common/prntbase.cpp:1623 ../src/html/helpwnd.cpp:660
+msgid "Next page"
+msgstr "Hurrengo orrialdea"
+
+#: ../src/common/prntbase.cpp:1628
+msgid "Last page"
+msgstr "Azken orrialdea"
+
+#: ../src/common/prntbase.cpp:1636 ../src/common/stockitem.cpp:215
+msgid "Zoom Out"
+msgstr "Zooma Gutxitu"
+
+#: ../src/common/prntbase.cpp:1650 ../src/common/stockitem.cpp:214
+msgid "Zoom In"
+msgstr "Zooma Handitu"
+
+#: ../src/common/prntbase.cpp:1656 ../src/common/stockitem.cpp:153
+#: ../src/generic/logg.cpp:553 ../src/univ/themes/win32.cpp:3752
+msgid "&Close"
+msgstr "It&xi"
+
+#: ../src/common/prntbase.cpp:2085
+msgid "Could not start document preview."
+msgstr "Ezin da agiriaren aurreikuspena hasi."
+
+#: ../src/common/prntbase.cpp:2085 ../src/common/prntbase.cpp:2129
+#: ../src/common/prntbase.cpp:2137
+msgid "Print Preview Failure"
+msgstr "Aurreikuspen Irarketa Hutsegitea"
+
+#: ../src/common/prntbase.cpp:2129 ../src/common/prntbase.cpp:2137
+msgid "Sorry, not enough memory to create a preview."
+msgstr "Barkatu, ez dago nahikoa oroimenik aurreikuspen bat sortzeko."
+
+#: ../src/common/prntbase.cpp:2144
+#, c-format
+msgid "Page %d of %d"
+msgstr "%d orrialde %d-tik"
+
+#: ../src/common/prntbase.cpp:2146
+#, c-format
+msgid "Page %d"
+msgstr "%d orrialde"
+
+#: ../src/common/regex.cpp:382 ../src/html/chm.cpp:348
+msgid "unknown error"
+msgstr "akats ezezaguna"
+
+#: ../src/common/regex.cpp:995
+#, c-format
+msgid "Invalid regular expression '%s': %s"
+msgstr "Adierazpen arrunt baliogabea '%s': %s"
+
+#: ../src/common/regex.cpp:1059
+#, c-format
+msgid "Failed to find match for regular expression: %s"
+msgstr ""
+"Hutsegitea adierazpen arrunt honentzak bateragarririk aurkitzerakoan: %s"
+
+#: ../src/common/rendcmn.cpp:188
+#, c-format
+msgid "Renderer \"%s\" has incompatible version %d.%d and couldn't be loaded."
+msgstr ""
+"\"%s\" aurkezlea bateraezina da %d bertsioarekin.%d ezinezkoa gertatzea."
+
+#: ../src/common/secretstore.cpp:162
+msgid "Not available for this platform"
+msgstr ""
+
+#: ../src/common/secretstore.cpp:183
+#, fuzzy, c-format
+msgid "Saving password for \"%s\" failed: %s."
+msgstr "Hutsegitea %s \"%s\" sortzerakoan."
+
+#: ../src/common/secretstore.cpp:205
+#, fuzzy, c-format
+msgid "Reading password for \"%s\" failed: %s."
+msgstr "Hutsegitea %s \"%s\" sortzerakoan."
+
+#: ../src/common/secretstore.cpp:228
+#, fuzzy, c-format
+msgid "Deleting password for \"%s\" failed: %s."
+msgstr "Hutsegitea %s \"%s\" sortzerakoan."
+
+#: ../src/common/selectdispatcher.cpp:254
+msgid "Failed to monitor I/O channels"
+msgstr "Hutsegitea Sar/Irt bideak monitorizatzerakoan"
+
+#: ../src/common/sizer.cpp:3054 ../src/common/stockitem.cpp:195
+msgid "Save"
+msgstr "Gorde"
+
+#: ../src/common/sizer.cpp:3056
+msgid "Don't Save"
+msgstr "Ez Gorde"
+
+#: ../src/common/socket.cpp:870
+msgid "Cannot initialize sockets"
+msgstr "Ezinezkoa ahoak abiaraztea"
+
+#: ../src/common/stockitem.cpp:127
+#, fuzzy
+msgctxt "standard Windows menu"
+msgid "&Help"
+msgstr "&Laguntza"
+
+#: ../src/common/stockitem.cpp:144
+msgid "&About"
+msgstr "&Honi buruz"
+
+#: ../src/common/stockitem.cpp:144
+msgid "About"
+msgstr "Honi buruz"
+
+#: ../src/common/stockitem.cpp:145
+msgid "Add"
+msgstr "Gehitu"
+
+#: ../src/common/stockitem.cpp:146
+msgid "&Apply"
+msgstr "&Ezarri"
+
+#: ../src/common/stockitem.cpp:146
+msgid "Apply"
+msgstr "Ezarri"
+
+#: ../src/common/stockitem.cpp:147
+msgid "&Back"
+msgstr "&Atzera"
+
+#: ../src/common/stockitem.cpp:147
+msgid "Back"
+msgstr "Atzera"
+
+#: ../src/common/stockitem.cpp:148
+msgid "&Bold"
+msgstr "&Lodia"
+
+#: ../src/common/stockitem.cpp:148 ../src/generic/fontdlgg.cpp:326
+#: ../src/richtext/richtextfontpage.cpp:354
+msgid "Bold"
+msgstr "Lodia"
+
+#: ../src/common/stockitem.cpp:149
+msgid "&Bottom"
+msgstr "&Behean"
+
+#: ../src/common/stockitem.cpp:149 ../src/richtext/richtextsizepage.cpp:287
+msgid "Bottom"
+msgstr "Behean"
+
+#: ../src/common/stockitem.cpp:150 ../src/generic/fontdlgg.cpp:462
+#: ../src/generic/fontdlgg.cpp:481 ../src/generic/wizard.cpp:415
+msgid "&Cancel"
+msgstr "E&zeztatu"
+
+#: ../src/common/stockitem.cpp:151
+#, fuzzy
+msgid "&CD-ROM"
+msgstr "&CD-Rom"
+
+#: ../src/common/stockitem.cpp:151
+#, fuzzy
+msgid "CD-ROM"
+msgstr "CD-Rom"
+
+#: ../src/common/stockitem.cpp:152
+msgid "&Clear"
+msgstr "&Garbitu"
+
+#: ../src/common/stockitem.cpp:152
+msgid "Clear"
+msgstr "Garbitu"
+
+#: ../src/common/stockitem.cpp:153 ../src/generic/dbgrptg.cpp:93
+#: ../src/generic/progdlgg.cpp:778 ../src/html/helpdlg.cpp:86
+#: ../src/msw/progdlg.cpp:209 ../src/msw/progdlg.cpp:890
+#: ../src/richtext/richtextstyledlg.cpp:272
+#: ../src/richtext/richtextsymboldlg.cpp:448
+msgid "Close"
+msgstr "It&xi"
+
+#: ../src/common/stockitem.cpp:154
+msgid "&Convert"
+msgstr "&Bihurtu"
+
+#: ../src/common/stockitem.cpp:154
+msgid "Convert"
+msgstr "Bihurtu"
+
+#: ../src/common/stockitem.cpp:155 ../src/msw/textctrl.cpp:2884
+#: ../src/osx/textctrl_osx.cpp:653 ../src/richtext/richtextctrl.cpp:331
+msgid "&Copy"
+msgstr "&Kopiatu"
+
+#: ../src/common/stockitem.cpp:155 ../src/stc/stc_i18n.cpp:18
+msgid "Copy"
+msgstr "Kopiatu"
+
+#: ../src/common/stockitem.cpp:156 ../src/msw/textctrl.cpp:2883
+#: ../src/osx/textctrl_osx.cpp:652 ../src/richtext/richtextctrl.cpp:330
+msgid "Cu&t"
+msgstr "Eba&ki"
+
+#: ../src/common/stockitem.cpp:156 ../src/stc/stc_i18n.cpp:17
+msgid "Cut"
+msgstr "Ebaki"
+
+#: ../src/common/stockitem.cpp:157 ../src/msw/textctrl.cpp:2886
+#: ../src/osx/textctrl_osx.cpp:655 ../src/richtext/richtextctrl.cpp:333
+#: ../src/richtext/richtexttabspage.cpp:137
+msgid "&Delete"
+msgstr "Ezabatu"
+
+#: ../src/common/stockitem.cpp:157 ../src/richtext/richtextbuffer.cpp:8266
+#: ../src/stc/stc_i18n.cpp:20
+msgid "Delete"
+msgstr "Ezabatu"
+
+#: ../src/common/stockitem.cpp:158
+msgid "&Down"
+msgstr "&Behera"
+
+#: ../src/common/stockitem.cpp:158 ../src/generic/fdrepdlg.cpp:148
+msgid "Down"
+msgstr "Behera"
+
+#: ../src/common/stockitem.cpp:159
+msgid "&Edit"
+msgstr "&Editatu"
+
+#: ../src/common/stockitem.cpp:159
+msgid "Edit"
+msgstr "Editatu"
+
+#: ../src/common/stockitem.cpp:160
+msgid "&Execute"
+msgstr "&Ekin"
+
+#: ../src/common/stockitem.cpp:160
+msgid "Execute"
+msgstr "Exekutatu"
+
+#: ../src/common/stockitem.cpp:161
+msgid "&Quit"
+msgstr "&Utzi"
+
+#: ../src/common/stockitem.cpp:161
+msgid "Quit"
+msgstr "Utzi"
+
+#: ../src/common/stockitem.cpp:162
+msgid "&File"
+msgstr "&Agiria"
+
+#: ../src/common/stockitem.cpp:162
+msgid "File"
+msgstr "Agiria"
+
+#: ../src/common/stockitem.cpp:163
+#, fuzzy
+msgid "&Find..."
+msgstr "&Bilatu"
+
+#: ../src/common/stockitem.cpp:163
+#, fuzzy
+msgid "Find..."
+msgstr "Bilatu"
+
+#: ../src/common/stockitem.cpp:164
+msgid "&First"
+msgstr "&Lehena"
+
+#: ../src/common/stockitem.cpp:164
+msgid "First"
+msgstr "Lehena"
+
+#: ../src/common/stockitem.cpp:165
+msgid "&Floppy"
+msgstr "&Nasai"
+
+#: ../src/common/stockitem.cpp:165
+msgid "Floppy"
+msgstr "Malgua"
+
+#: ../src/common/stockitem.cpp:166
+msgid "&Forward"
+msgstr "&Aurrera"
+
+#: ../src/common/stockitem.cpp:166
+msgid "Forward"
+msgstr "Aurrera"
+
+#: ../src/common/stockitem.cpp:167
+msgid "&Harddisk"
+msgstr "&Diska gogorra"
+
+#: ../src/common/stockitem.cpp:167
+msgid "Harddisk"
+msgstr "Diska-gogorra"
+
+#: ../src/common/stockitem.cpp:168 ../src/generic/wizard.cpp:418
+#: ../src/osx/cocoa/menu.mm:225 ../src/richtext/richtextstyledlg.cpp:298
+#: ../src/richtext/richtextsymboldlg.cpp:451
+msgid "&Help"
+msgstr "&Laguntza"
+
+#: ../src/common/stockitem.cpp:169
+msgid "&Home"
+msgstr "&Hasiera"
+
+#: ../src/common/stockitem.cpp:169
+msgid "Home"
+msgstr "Hasiera"
+
+#: ../src/common/stockitem.cpp:170
+msgid "Indent"
+msgstr "Elkarmarratxoa"
+
+#: ../src/common/stockitem.cpp:171
+msgid "&Index"
+msgstr "&Aurkibidea"
+
+#: ../src/common/stockitem.cpp:171 ../src/html/helpwnd.cpp:510
+msgid "Index"
+msgstr "Aurkibidea"
+
+#: ../src/common/stockitem.cpp:172
+msgid "&Info"
+msgstr "&Argibideak"
+
+#: ../src/common/stockitem.cpp:172
+msgid "Info"
+msgstr "Argibideak"
+
+#: ../src/common/stockitem.cpp:173
+msgid "&Italic"
+msgstr "&Etzana"
+
+#: ../src/common/stockitem.cpp:173 ../src/generic/fontdlgg.cpp:322
+#: ../src/richtext/richtextfontpage.cpp:350
+msgid "Italic"
+msgstr "Etzana"
+
+#: ../src/common/stockitem.cpp:174
+msgid "&Jump to"
+msgstr "&Jauzi hona"
+
+#: ../src/common/stockitem.cpp:174
+msgid "Jump to"
+msgstr "Jauzi hona"
+
+#: ../src/common/stockitem.cpp:175
+msgid "Centered"
+msgstr "Erdiratuta"
+
+#: ../src/common/stockitem.cpp:176
+msgid "Justified"
+msgstr "Berdinduta"
+
+#: ../src/common/stockitem.cpp:177
+msgid "Align Left"
+msgstr "Lerrokatu Ezkerrera"
+
+#: ../src/common/stockitem.cpp:178
+msgid "Align Right"
+msgstr "Lerrokatu Eskuinera"
+
+#: ../src/common/stockitem.cpp:179
+msgid "&Last"
+msgstr "&Azkena"
+
+#: ../src/common/stockitem.cpp:179
+msgid "Last"
+msgstr "Azkena"
+
+#: ../src/common/stockitem.cpp:180
+msgid "&Network"
+msgstr "&Sarea"
+
+#: ../src/common/stockitem.cpp:180
+msgid "Network"
+msgstr "Sarea"
+
+#: ../src/common/stockitem.cpp:181 ../src/richtext/richtexttabspage.cpp:131
+msgid "&New"
+msgstr "Berria"
+
+#: ../src/common/stockitem.cpp:181
+msgid "New"
+msgstr "Berria"
+
+#: ../src/common/stockitem.cpp:182 ../src/msw/msgdlg.cpp:417
+msgid "&No"
+msgstr "&Ez"
+
+#: ../src/common/stockitem.cpp:183 ../src/generic/fontdlgg.cpp:467
+#: ../src/generic/fontdlgg.cpp:474
+msgid "&OK"
+msgstr "&Ongi"
+
+#: ../src/common/stockitem.cpp:184 ../src/generic/dbgrptg.cpp:341
+msgid "&Open..."
+msgstr "&Ireki..."
+
+#: ../src/common/stockitem.cpp:184
+msgid "Open..."
+msgstr "Ireki..."
+
+#: ../src/common/stockitem.cpp:185 ../src/msw/textctrl.cpp:2885
+#: ../src/osx/textctrl_osx.cpp:654 ../src/richtext/richtextctrl.cpp:332
+msgid "&Paste"
+msgstr "&Itsatsi"
+
+#: ../src/common/stockitem.cpp:185 ../src/richtext/richtextctrl.cpp:3484
+#: ../src/stc/stc_i18n.cpp:19
+msgid "Paste"
+msgstr "Itsatsi"
+
+#: ../src/common/stockitem.cpp:186
+msgid "&Preferences"
+msgstr "&Hobespenak"
+
+#: ../src/common/stockitem.cpp:186 ../src/osx/cocoa/preferences.mm:304
+msgid "Preferences"
+msgstr "Hobespenak"
+
+#: ../src/common/stockitem.cpp:187
+msgid "Print previe&w..."
+msgstr "Irarketa aur&reikuspena..."
+
+#: ../src/common/stockitem.cpp:187
+msgid "Print preview..."
+msgstr "Irarketa aurreikuspena..."
+
+#: ../src/common/stockitem.cpp:188
+msgid "&Print..."
+msgstr "&Irarkitu..."
+
+#: ../src/common/stockitem.cpp:188
+msgid "Print..."
+msgstr "Irarkitu..."
+
+#: ../src/common/stockitem.cpp:189 ../src/richtext/richtextctrl.cpp:337
+#: ../src/richtext/richtextctrl.cpp:5479
+msgid "&Properties"
+msgstr "&Ezaugarriak"
+
+#: ../src/common/stockitem.cpp:189
+msgid "Properties"
+msgstr "Ezaugarriak"
+
+#: ../src/common/stockitem.cpp:190 ../src/stc/stc_i18n.cpp:16
+msgid "Redo"
+msgstr "Berregin"
+
+#: ../src/common/stockitem.cpp:191
+msgid "Refresh"
+msgstr "Berritu"
+
+#: ../src/common/stockitem.cpp:192
+msgid "Remove"
+msgstr "Kendu"
+
+#: ../src/common/stockitem.cpp:193
+#, fuzzy
+msgid "Rep&lace..."
+msgstr "Or&deztu"
+
+#: ../src/common/stockitem.cpp:193
+#, fuzzy
+msgid "Replace..."
+msgstr "Ordeztu"
+
+#: ../src/common/stockitem.cpp:194
+msgid "Revert to Saved"
+msgstr "Itzuli Gordetakora"
+
+#: ../src/common/stockitem.cpp:196 ../src/generic/logg.cpp:549
+msgid "Save &As..."
+msgstr "Gorde &Honela..."
+
+#: ../src/common/stockitem.cpp:196
+#, fuzzy
+msgid "Save As..."
+msgstr "Gorde &Honela..."
+
+#: ../src/common/stockitem.cpp:197 ../src/msw/textctrl.cpp:2888
+#: ../src/osx/textctrl_osx.cpp:657 ../src/richtext/richtextctrl.cpp:335
+msgid "Select &All"
+msgstr "Hautatu &Denak"
+
+#: ../src/common/stockitem.cpp:197 ../src/stc/stc_i18n.cpp:21
+msgid "Select All"
+msgstr "Hautatu Denak"
+
+#: ../src/common/stockitem.cpp:198
+msgid "&Color"
+msgstr "&Margoa"
+
+#: ../src/common/stockitem.cpp:198
+msgid "Color"
+msgstr "Margoa"
+
+#: ../src/common/stockitem.cpp:199
+msgid "&Font"
+msgstr "&Hizkia"
+
+#: ../src/common/stockitem.cpp:199 ../src/richtext/richtextformatdlg.cpp:336
+msgid "Font"
+msgstr "Hizkia"
+
+#: ../src/common/stockitem.cpp:200
+msgid "&Ascending"
+msgstr "&Gorantz"
+
+#: ../src/common/stockitem.cpp:200
+msgid "Ascending"
+msgstr "Gorantz"
+
+#: ../src/common/stockitem.cpp:201
+msgid "&Descending"
+msgstr "&Beherantz"
+
+#: ../src/common/stockitem.cpp:201
+msgid "Descending"
+msgstr "Beherantz"
+
+#: ../src/common/stockitem.cpp:202
+msgid "&Spell Check"
+msgstr "&Idaz Egiaztapena"
+
+#: ../src/common/stockitem.cpp:202
+msgid "Spell Check"
+msgstr "Idaz Egiaztapena"
+
+#: ../src/common/stockitem.cpp:203
+msgid "&Stop"
+msgstr "&Gelditu"
+
+#: ../src/common/stockitem.cpp:203
+msgid "Stop"
+msgstr "Gelditu"
+
+#: ../src/common/stockitem.cpp:204 ../src/richtext/richtextfontpage.cpp:274
+msgid "&Strikethrough"
+msgstr "&Tatxatuta"
+
+#: ../src/common/stockitem.cpp:204
+msgid "Strikethrough"
+msgstr "Marratuta"
+
+#: ../src/common/stockitem.cpp:205
+msgid "&Top"
+msgstr "&Goia"
+
+#: ../src/common/stockitem.cpp:205 ../src/richtext/richtextsizepage.cpp:285
+#: ../src/richtext/richtextsizepage.cpp:289
+msgid "Top"
+msgstr "Goia"
+
+#: ../src/common/stockitem.cpp:206
+msgid "Undelete"
+msgstr "Desezabatu"
+
+#: ../src/common/stockitem.cpp:207 ../src/generic/fontdlgg.cpp:437
+msgid "&Underline"
+msgstr "&Azpimarratuta"
+
+#: ../src/common/stockitem.cpp:207
+msgid "Underline"
+msgstr "Azpimarratua"
+
+#: ../src/common/stockitem.cpp:208 ../src/stc/stc_i18n.cpp:15
+msgid "Undo"
+msgstr "Desegin"
+
+#: ../src/common/stockitem.cpp:209
+msgid "&Unindent"
+msgstr "&Elkarmarratxo gabe"
+
+#: ../src/common/stockitem.cpp:209
+msgid "Unindent"
+msgstr "Hertzgabe"
+
+#: ../src/common/stockitem.cpp:210
+msgid "&Up"
+msgstr "&Igo"
+
+#: ../src/common/stockitem.cpp:210 ../src/generic/fdrepdlg.cpp:148
+msgid "Up"
+msgstr "Gora"
+
+#: ../src/common/stockitem.cpp:211 ../src/msw/msgdlg.cpp:417
+msgid "&Yes"
+msgstr "&Bai"
+
+#: ../src/common/stockitem.cpp:212
+msgid "&Actual Size"
+msgstr "&Oraingo Neurria"
+
+#: ../src/common/stockitem.cpp:212
+msgid "Actual Size"
+msgstr "Oraingo Neurria"
+
+#: ../src/common/stockitem.cpp:213
+msgid "Zoom to &Fit"
+msgstr "Zooma &Zehazteko"
+
+#: ../src/common/stockitem.cpp:213
+msgid "Zoom to Fit"
+msgstr "Zooma Zehazteko"
+
+#: ../src/common/stockitem.cpp:214
+msgid "Zoom &In"
+msgstr "Zooma &Handitu"
+
+#: ../src/common/stockitem.cpp:215
+msgid "Zoom &Out"
+msgstr "Zooma &Gutxitu"
+
+#: ../src/common/stockitem.cpp:262
+msgid "Show about dialog"
+msgstr "Erakutsi elkarrizketari buruz"
+
+#: ../src/common/stockitem.cpp:263
+msgid "Copy selection"
+msgstr "Kopiatu hautapena"
+
+#: ../src/common/stockitem.cpp:264
+msgid "Cut selection"
+msgstr "Ebaki hautapena"
+
+#: ../src/common/stockitem.cpp:265
+msgid "Delete selection"
+msgstr "Ezabatu hautapena"
+
+#: ../src/common/stockitem.cpp:266
+#, fuzzy
+msgid "Find in document"
+msgstr "Ireki HTML agiria"
+
+#: ../src/common/stockitem.cpp:267
+msgid "Find and replace in document"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:268
+msgid "Paste selection"
+msgstr "Itsati hautapena"
+
+#: ../src/common/stockitem.cpp:269
+msgid "Quit this program"
+msgstr "Utzi programa hau"
+
+#: ../src/common/stockitem.cpp:270
+msgid "Redo last action"
+msgstr "Berregin azken ekintza"
+
+#: ../src/common/stockitem.cpp:271
+msgid "Undo last action"
+msgstr "Desegin azken ekintza"
+
+#: ../src/common/stockitem.cpp:272
+#, fuzzy
+msgid "Create new document"
+msgstr "Sortu zuzenbide berria"
+
+#: ../src/common/stockitem.cpp:273
+#, fuzzy
+msgid "Open an existing document"
+msgstr "Ireki HTML agiria"
+
+#: ../src/common/stockitem.cpp:274
+msgid "Close current document"
+msgstr "Itxi oraingo agiria"
+
+#: ../src/common/stockitem.cpp:275
+msgid "Save current document"
+msgstr "Gorde oraingo agiria"
+
+#: ../src/common/stockitem.cpp:276
+msgid "Save current document with a different filename"
+msgstr "Gorde oraingo agiria agirizen ezberdinarekin"
+
+#: ../src/common/strconv.cpp:2324
+#, c-format
+msgid "Conversion to charset '%s' doesn't work."
+msgstr "'%s' hizki-kodera bihurtzeak ez du lanik egiten. "
+
+#: ../src/common/tarstrm.cpp:352 ../src/common/tarstrm.cpp:375
+#: ../src/common/tarstrm.cpp:406 ../src/generic/progdlgg.cpp:373
+msgid "unknown"
+msgstr "ezezaguna"
+
+#: ../src/common/tarstrm.cpp:774
+msgid "incomplete header block in tar"
+msgstr "idazburu bloke osatugabea tar-en"
+
+#: ../src/common/tarstrm.cpp:798
+msgid "checksum failure reading tar header block"
+msgstr "Egiaztapen hutsegitea tar idazburu blokea irakurtzean"
+
+#: ../src/common/tarstrm.cpp:971
+msgid "invalid data in extended tar header"
+msgstr "datu baliogabea tar hedatu idazburuan"
+
+#: ../src/common/tarstrm.cpp:981 ../src/common/tarstrm.cpp:1003
+#: ../src/common/tarstrm.cpp:1477 ../src/common/tarstrm.cpp:1499
+msgid "tar entry not open"
+msgstr "tar sarrera ez dago irekita"
+
+#: ../src/common/tarstrm.cpp:1023
+msgid "unexpected end of file"
+msgstr "ustekabekoa agiri amaiera"
+
+#: ../src/common/tarstrm.cpp:1297
+#, c-format
+msgid "%s did not fit the tar header for entry '%s'"
+msgstr "%s-k ez du finkatzen tar idazburua '%s' sarrerarentzat"
+
+#: ../src/common/tarstrm.cpp:1359
+msgid "incorrect size given for tar entry"
+msgstr "tar sarrereak neurri okerra eman du"
+
+#: ../src/common/textbuf.cpp:232
+#, c-format
+msgid "'%s' is probably a binary buffer."
+msgstr "'%s' zihurrenik buffer binario bat da."
+
+#: ../src/common/textcmn.cpp:1006 ../src/richtext/richtextctrl.cpp:3053
+msgid "File couldn't be loaded."
+msgstr "Agiria ezin da gertatu."
+
+#: ../src/common/textfile.cpp:95
+#, fuzzy, c-format
+msgid "Failed to read text file \"%s\"."
+msgstr "Hutsegitea \"%s\" agiritik agiria irakurtzerakoan."
+
+#: ../src/common/textfile.cpp:160
+#, c-format
+msgid "can't write buffer '%s' to disk."
+msgstr "ezin da idatzi '%s' bufferra diskara"
+
+#: ../src/common/time.cpp:212
+msgid "Failed to get the local system time"
+msgstr "Hutsegitea tokiko sistema ordua lortzerakoan"
+
+#: ../src/common/time.cpp:279
+msgid "wxGetTimeOfDay failed."
+msgstr "wxGetTimeOfDay hutsegitea."
+
+#: ../src/common/translation.cpp:929
+#, c-format
+msgid "'%s' is not a valid message catalog."
+msgstr "'%s' ez da mezu katalogo baliozkoa."
+
+#: ../src/common/translation.cpp:954
+msgid "Invalid message catalog."
+msgstr "Mezu katalogo baliogabea."
+
+#: ../src/common/translation.cpp:1013
+#, c-format
+msgid "Failed to parse Plural-Forms: '%s'"
+msgstr "Hutsegitea Anitz-Erak aztertzerakoan: '%s'"
+
+#: ../src/common/translation.cpp:1723
+#, c-format
+msgid "using catalog '%s' from '%s'."
+msgstr "'%s' katalogoa '%s' hemendik erabiltzen."
+
+#: ../src/common/translation.cpp:1816
+#, c-format
+msgid "Resource '%s' is not a valid message catalog."
+msgstr "'%s' baliabidea ez da baliozko mezu katalogoa."
+
+#: ../src/common/translation.cpp:1865
+msgid "Couldn't enumerate translations"
+msgstr "Ezinezkoa itzulpenak zenbatzea"
+
+#: ../src/common/utilscmn.cpp:1145
+msgid "No default application configured for HTML files."
+msgstr "Ez dago berezko aplikaziorik itxuratuta HTML agirientzat."
+
+#: ../src/common/utilscmn.cpp:1190
+#, c-format
+msgid "Failed to open URL \"%s\" in default browser."
+msgstr "Hutsegitea \"%s\" URL-a berezko bilatzailean irekitzerakoan."
+
+#: ../src/common/valtext.cpp:144
+msgid "Validation conflict"
+msgstr "Balioztapen gatazka"
+
+#: ../src/common/valtext.cpp:186
+msgid "Required information entry is empty."
+msgstr "Beharrezko argibide sarrera hutsik dago."
+
+#: ../src/common/valtext.cpp:188
+#, c-format
+msgid "'%s' is one of the invalid strings"
+msgstr "'%s' kate baliogabeetako bat da"
+
+#: ../src/common/valtext.cpp:190
+#, c-format
+msgid "'%s' is not one of the valid strings"
+msgstr "'%s' ez da kate baliogarrietako bat"
+
+#: ../src/common/valtext.cpp:199
+#, fuzzy, c-format
+msgid "'%s' contains invalid character(s)"
+msgstr "'%s' legezkanpoko hizkiak ditu"
+
+#: ../src/common/webrequest.cpp:139
+#, fuzzy, c-format
+msgid "Error: %s (%d)"
+msgstr "Akatsa:"
+
+#: ../src/common/webrequest.cpp:655
+#, c-format
+msgid ""
+"Not enough free disk space for download: %llu needed but only %llu available."
+msgstr ""
+
+#: ../src/common/webrequest.cpp:669
+#, fuzzy, c-format
+msgid "Failed to create temporary file in %s"
+msgstr "Hutsegitea aldibaterako agiri izena sortzerakoan"
+
+#: ../src/common/webrequest_curl.cpp:1106
+#, fuzzy
+msgid "libcurl could not be initialized"
+msgstr "Zutabe azalpena ezin da abiarazi."
+
+#: ../src/common/webview.cpp:392
+msgid "RunScriptAsync not supported"
+msgstr ""
+
+#: ../src/common/webview.cpp:403 ../src/msw/webview_ie.cpp:1073
+#, c-format
+msgid "Error running JavaScript: %s"
+msgstr ""
+
+#: ../src/common/webview_chromium.cpp:858
+#, fuzzy, c-format
+msgid "Failed to set proxy \"%s\": %s"
+msgstr "Hutsegitea \"%s\" zuzenbidea sortzerakoan"
+
+#: ../src/common/webview_chromium.cpp:989
+msgid ""
+"Chromium can't be used because libcef.so wasn't loaded early enough; please "
+"relink the application or use LD_PRELOAD to load it earlier."
+msgstr ""
+
+#: ../src/common/webview_chromium.cpp:1108
+#, fuzzy
+msgid "Could not initialize Chromium"
+msgstr "Ezin da lerrokapena ezarri."
+
+#: ../src/common/webview_chromium.cpp:1616
+msgid "Show DevTools"
+msgstr ""
+
+#: ../src/common/webview_chromium.cpp:1617
+#, fuzzy
+msgid "Close DevTools"
+msgstr "Itxi Denak"
+
+#: ../src/common/webview_chromium.cpp:1623
+msgid "Inspect"
+msgstr ""
+
+#: ../src/common/wincmn.cpp:1628
+msgid "This platform does not support background transparency."
+msgstr "Plataforma honek ez dut barren gardentasuna sostengatzen."
+
+#: ../src/common/wincmn.cpp:2097
+msgid "Could not transfer data to window"
+msgstr "Ezinezkoa datuak leihora eskualdatzea"
+
+#: ../src/common/windowid.cpp:240
+msgid "Out of window IDs.  Recommend shutting down application."
+msgstr "Leiho ID-tik kanpo. Aplikazioa itzaltzea gomendatzen da."
+
+#: ../src/common/xpmdecod.cpp:678
+msgid "XPM: incorrect header format!"
+msgstr "XPM: idazburu heuskarri okerra!"
+
+#: ../src/common/xpmdecod.cpp:703
+#, c-format
+msgid "XPM: incorrect colour description in line %d"
+msgstr "XPM: margo azalpen okerra %d lerroan"
+
+#: ../src/common/xpmdecod.cpp:715 ../src/common/xpmdecod.cpp:724
+#, c-format
+msgid "XPM: malformed colour definition '%s' at line %d!"
+msgstr "XPM: margo bereizmen okerra '%s' %d lerroan!"
+
+#: ../src/common/xpmdecod.cpp:754
+msgid "XPM: no colors left to use for mask!"
+msgstr "XPM: ez duzu mozorro margoak erabiltzeari utzi!"
+
+#: ../src/common/xpmdecod.cpp:781
+#, c-format
+msgid "XPM: truncated image data at line %d!"
+msgstr "XPM: irudi datuak trunkatuta %d lerroan!"
+
+#: ../src/common/xpmdecod.cpp:795
+msgid "XPM: Malformed pixel data!"
+msgstr "XPM: Pixel datu okerra!"
+
+#: ../src/common/xti.cpp:492
+msgid "Illegal Parameter Count for Create Method"
+msgstr "Legezkanpoko Zenbaketa Parametroa Sortu Metodoarentzat"
+
+#: ../src/common/xti.cpp:504
+msgid "Illegal Parameter Count for ConstructObject Method"
+msgstr "Legezkanpoko Zenbaketa Parametroa Eraiki-Objetua Metodoarentzat"
+
+#: ../src/common/xtistrm.cpp:161
+#, c-format
+msgid "Create Parameter %s not found in declared RTTI Parameters"
+msgstr "%s Sortu Paremetroa ez da aurkitu aitorturiko RTTI Parametroetan"
+
+#: ../src/common/xtistrm.cpp:290
+msgid "Illegal Object Class (Non-wxEvtHandler) as Event Source"
+msgstr "Legezkanpoko Objetu Klasea (Ez-wxEvtHandler) Gertaera Iturubur bezala"
+
+#: ../src/common/xtistrm.cpp:313 ../src/common/xtixml.cpp:345
+#: ../src/common/xtixml.cpp:498
+msgid "Type must have enum - long conversion"
+msgstr "Motak enum- long bihurketa izan behar du"
+
+#: ../src/common/xtistrm.cpp:400 ../src/common/xtistrm.cpp:415
+msgid "Invalid or Null Object ID passed to GetObjectClassInfo"
+msgstr "Baliogabeko edo Nulloa Objetu ID-a igaro da GetObjectClassInfo-ra"
+
+#: ../src/common/xtistrm.cpp:405
+msgid "Unknown Object passed to GetObjectClassInfo"
+msgstr "Objetu ezezaguna igaro da GetObjectClassInfo-ra"
+
+#: ../src/common/xtistrm.cpp:420
+msgid "Already Registered Object passed to SetObjectClassInfo"
+msgstr "Jadanik Erregistraturiko Objetua SetObjectClassInfo-ra pasatuta"
+
+#: ../src/common/xtistrm.cpp:430
+msgid "Invalid or Null Object ID passed to HasObjectClassInfo"
+msgstr "Baliogabeko edo Nuloa den Objetu ID-a igaro da HasObjectClassInfo-ra"
+
+#: ../src/common/xtistrm.cpp:460
+msgid "Passing a already registered object to SetObject"
+msgstr "Jadanik erregistraturiko objetua SetObject-ra pasatzen"
+
+#: ../src/common/xtistrm.cpp:471
+msgid "Passing an unknown object to GetObject"
+msgstr "Objetu ezezaguna igaro da GetObjectClassInfo-ra"
+
+#: ../src/common/xtixml.cpp:229
+msgid "Forward hrefs are not supported"
+msgstr "hrefs bidalketa ez dago sostengaturik"
+
+#: ../src/common/xtixml.cpp:247
+#, c-format
+msgid "unknown class %s"
+msgstr "klase ezezaguna %s"
+
+#: ../src/common/xtixml.cpp:253
+msgid "objects cannot have XML Text Nodes"
+msgstr "objetuek ezin dute XML Testu Nodorik izan"
+
+#: ../src/common/xtixml.cpp:258
+msgid "Objects must have an id attribute"
+msgstr "Objetuek id ezaugarria izan behar dute"
+
+#: ../src/common/xtixml.cpp:267
+#, c-format
+msgid "Doubly used id : %d"
+msgstr "id bikoiztua : %d"
+
+#: ../src/common/xtixml.cpp:316
+#, c-format
+msgid "Unknown Property %s"
+msgstr "Ezaugarri %s ezezaguna"
+
+#: ../src/common/xtixml.cpp:407
+msgid "A non empty collection must consist of 'element' nodes"
+msgstr "Bilduma ez hutsa 'elementu' elkarguneak izan behar da"
+
+#: ../src/common/xtixml.cpp:478
+msgid "incorrect event handler string, missing dot"
+msgstr "gertaera kudeatzaile kate okerra, puntu gabe"
+
+#: ../src/common/zipstrm.cpp:559
+msgid "can't re-initialize zlib deflate stream"
+msgstr "ezin da birrabiarazi zlib deflate jarioa"
+
+#: ../src/common/zipstrm.cpp:584
+msgid "can't re-initialize zlib inflate stream"
+msgstr "ezin da birrabiarazi zlib inflate jarioa "
+
+#: ../src/common/zipstrm.cpp:1023
+msgid "Ignoring malformed extra data record, ZIP file may be corrupted"
+msgstr ""
+
+#: ../src/common/zipstrm.cpp:1502
+msgid "assuming this is a multi-part zip concatenated"
+msgstr "onartzen zip zati-anitz kateatutakoa dela "
+
+#: ../src/common/zipstrm.cpp:1664
+msgid "invalid zip file"
+msgstr "zip agiri baliogabea"
+
+#: ../src/common/zipstrm.cpp:1723
+msgid "can't find central directory in zip"
+msgstr "ezin da aurkitu zuzenbide nagusia zip-ean"
+
+#: ../src/common/zipstrm.cpp:1812
+msgid "error reading zip central directory"
+msgstr "akatsa ziparen zuzenbide nagusia irakurtzean"
+
+#: ../src/common/zipstrm.cpp:1916
+msgid "error reading zip local header"
+msgstr "akatsa ziparen tokiko idazburua irakurtzen"
+
+#: ../src/common/zipstrm.cpp:1964
+msgid "bad zipfile offset to entry"
+msgstr "zipagiri okerra orekatuta sarrerarako"
+
+#: ../src/common/zipstrm.cpp:2031
+msgid "stored file length not in Zip header"
+msgstr "bildutako agiri zabalera ez dago Zip idazburuan"
+
+#: ../src/common/zipstrm.cpp:2045 ../src/common/zipstrm.cpp:2362
+msgid "unsupported Zip compression method"
+msgstr "Zip konpresio metodo sostengatu gabea"
+
+#: ../src/common/zipstrm.cpp:2126
+#, c-format
+msgid "reading zip stream (entry %s): bad length"
+msgstr "zip jario irakurtzen (sarrera %s): luzera okerra"
+
+#: ../src/common/zipstrm.cpp:2131
+#, c-format
+msgid "reading zip stream (entry %s): bad crc"
+msgstr "zip jario irakurtzen (sarrera %s): crc okerra"
+
+#: ../src/common/zipstrm.cpp:2578
+#, fuzzy, c-format
+msgid "error writing zip entry '%s': file too large without ZIP64"
+msgstr "akatsa '%s' zip sarrera irakurtzean: crc okerra edo luzeegia"
+
+#: ../src/common/zipstrm.cpp:2585
+#, c-format
+msgid "error writing zip entry '%s': bad crc or length"
+msgstr "akatsa '%s' zip sarrera irakurtzean: crc okerra edo luzeegia"
+
+#: ../src/common/zstream.cpp:155 ../src/common/zstream.cpp:315
+msgid "Gzip not supported by this version of zlib"
+msgstr "Gzip ez dago sostengaturik zlib bertsio honetarako"
+
+#: ../src/common/zstream.cpp:182
+msgid "Can't initialize zlib inflate stream."
+msgstr "Ezin da zlib puztutako jarioa abiatu."
+
+#: ../src/common/zstream.cpp:241
+msgid "Can't read inflate stream: unexpected EOF in underlying stream."
+msgstr "Ezin da jario puztua irakurri: ustekabeko EOF erdietsitako jarioan."
+
+#: ../src/common/zstream.cpp:248 ../src/common/zstream.cpp:423
+#, c-format
+msgid "zlib error %d"
+msgstr "zlib akatsa %d"
+
+#: ../src/common/zstream.cpp:249
+#, c-format
+msgid "Can't read from inflate stream: %s"
+msgstr "Ezin da irakurri puztutako jariotik: %s"
+
+#: ../src/common/zstream.cpp:343
+msgid "Can't initialize zlib deflate stream."
+msgstr "Ezin da zlib hustutako jarioa abiatu."
+
+#: ../src/common/zstream.cpp:424
+#, c-format
+msgid "Can't write to deflate stream: %s"
+msgstr "Ezin da deflate jariora idatzi : %s"
+
+#: ../src/dfb/bitmap.cpp:633 ../src/dfb/bitmap.cpp:667
+#, c-format
+msgid "No bitmap handler for type %d defined."
+msgstr "Ez da bitmap kudeatzailerik adierazi %d motarako."
+
+#: ../src/dfb/evtloop.cpp:99
+msgid "Failed to read event from DirectFB pipe"
+msgstr "Hutsegitea DirectFB pipe-tik gertaera irakurtzerakoan"
+
+#: ../src/dfb/evtloop.cpp:171
+msgid "Failed to switch DirectFB pipe to non-blocking mode"
+msgstr "Hutsegitea DirectFB hodia ez-blokeatzen modura aldatzerakoan"
+
+#: ../src/dfb/fontmgr.cpp:171
+#, c-format
+msgid "no fonts found in %s, using builtin font"
+msgstr "ez da hizkirik aurkitu hemen: %s, barne hizikia erabiltzen"
+
+#: ../src/dfb/fontmgr.cpp:177
+msgid "Default font"
+msgstr "Berezko hizkia"
+
+#: ../src/dfb/fontmgr.cpp:195
+#, c-format
+msgid "Fonts index file %s disappeared while loading fonts."
+msgstr "%s hizki agiria ezagertu egin da hizkiak gertatzerakoan."
+
+#: ../src/dfb/wrapdfb.cpp:60
+#, c-format
+msgid "DirectFB error %d occurred."
+msgstr "DirectFB %d akatsa gertatu da."
+
+#: ../src/generic/aboutdlgg.cpp:69
+msgid "Developed by "
+msgstr "Garatzaileak"
+
+#: ../src/generic/aboutdlgg.cpp:72
+msgid "Documentation by "
+msgstr "Agirigilea"
+
+#: ../src/generic/aboutdlgg.cpp:75
+msgid "Graphics art by "
+msgstr "Grafiko egilea"
+
+#: ../src/generic/aboutdlgg.cpp:78
+msgid "Translations by "
+msgstr "Itzultzailea"
+
+#: ../src/generic/aboutdlgg.cpp:133 ../src/osx/cocoa/aboutdlg.mm:83
+msgid "Version "
+msgstr "Bertsioa"
+
+#. TRANSLATORS: %s is application name
+#: ../src/generic/aboutdlgg.cpp:146 ../src/msw/aboutdlg.cpp:60
+#, c-format
+msgid "About %s"
+msgstr "%s-ri buruz"
+
+#: ../src/generic/aboutdlgg.cpp:181
+msgid "License"
+msgstr "Baimena"
+
+#: ../src/generic/aboutdlgg.cpp:184
+msgid "Developers"
+msgstr "Garatzaileak"
+
+#: ../src/generic/aboutdlgg.cpp:188
+msgid "Documentation writers"
+msgstr "Agiri idazleak"
+
+#: ../src/generic/aboutdlgg.cpp:192
+msgid "Artists"
+msgstr "Artistak"
+
+#: ../src/generic/aboutdlgg.cpp:196
+msgid "Translators"
+msgstr "Itzultzaileak"
+
+#: ../src/generic/animateg.cpp:125
+msgid "No handler found for animation type."
+msgstr "Ez da kudeatzailerik aurkitu animazio motarentzat."
+
+#: ../src/generic/animateg.cpp:133
+#, c-format
+msgid "No animation handler for type %ld defined."
+msgstr "Ez da animazio kudeatzailerik adierazi %ld motarako."
+
+#: ../src/generic/animateg.cpp:145
+#, c-format
+msgid "Animation file is not of type %ld."
+msgstr "Animazio agiria ez %ld motakoa."
+
+#: ../src/generic/colrdlgg.cpp:154 ../src/gtk/colordlg.cpp:47
+msgid "Choose colour"
+msgstr "Hautatu margoa"
+
+#: ../src/generic/colrdlgg.cpp:357
+msgid "Red:"
+msgstr ""
+
+#: ../src/generic/colrdlgg.cpp:360
+#, fuzzy
+msgid "Green:"
+msgstr "Orlegia"
+
+#: ../src/generic/colrdlgg.cpp:363
+#, fuzzy
+msgid "Blue:"
+msgstr "Urdina"
+
+#: ../src/generic/colrdlgg.cpp:372
+#, fuzzy
+msgid "Opacity:"
+msgstr "A&rgikazitasuna:"
+
+#: ../src/generic/colrdlgg.cpp:384
+msgid "Add to custom colours"
+msgstr "Gehitu egile margoetara"
+
+#: ../src/generic/creddlgg.cpp:56
+msgid "Username:"
+msgstr ""
+
+#: ../src/generic/creddlgg.cpp:63
+msgid "Password:"
+msgstr ""
+
+#. TRANSLATORS: Name of Boolean true value
+#: ../src/generic/datavgen.cpp:1178
+msgid "true"
+msgstr ""
+
+#. TRANSLATORS: Name of Boolean false value
+#: ../src/generic/datavgen.cpp:1180
+#, fuzzy
+msgid "false"
+msgstr "Faltsua"
+
+#: ../src/generic/datavgen.cpp:6897
+#, c-format
+msgid "Row %i"
+msgstr ""
+
+#. TRANSLATORS: Action for manipulating a tree control
+#: ../src/generic/datavgen.cpp:6987
+msgid "Collapse"
+msgstr ""
+
+#. TRANSLATORS: Action for manipulating a tree control
+#: ../src/generic/datavgen.cpp:6990
+msgid "Expand"
+msgstr ""
+
+#. TRANSLATORS: Name of data view control and number of rows
+#: ../src/generic/datavgen.cpp:7011
+#, fuzzy, c-format
+msgid "%s (%d items)"
+msgstr "%s (edo %s)"
+
+#: ../src/generic/datavgen.cpp:7062
+#, fuzzy, c-format
+msgid "Column %u"
+msgstr "Gehitu Zutabea"
+
+#. TRANSLATORS: Keystroke for manipulating a tree control
+#: ../src/generic/datavgen.cpp:7131 ../src/richtext/richtextbulletspage.cpp:189
+#: ../src/richtext/richtextbulletspage.cpp:192
+#: ../src/richtext/richtextbulletspage.cpp:193
+#: ../src/richtext/richtextliststylepage.cpp:252
+#: ../src/richtext/richtextliststylepage.cpp:255
+#: ../src/richtext/richtextliststylepage.cpp:256
+#: ../src/richtext/richtextsizepage.cpp:248
+msgid "Left"
+msgstr "Ezker"
+
+#. TRANSLATORS: Keystroke for manipulating a tree control
+#: ../src/generic/datavgen.cpp:7134 ../src/richtext/richtextbulletspage.cpp:191
+#: ../src/richtext/richtextliststylepage.cpp:254
+#: ../src/richtext/richtextsizepage.cpp:249
+msgid "Right"
+msgstr "Eskuin"
+
+#: ../src/generic/datectlg.cpp:90
+#, c-format
+msgid ""
+"\"%s\" is not in the expected date format, please enter it as e.g. \"%s\"."
+msgstr ""
+
+#: ../src/generic/datectlg.cpp:94
+#, fuzzy
+msgid "Invalid date"
+msgstr "Datu ikus gai baliogabea"
+
+#: ../src/generic/dbgrptg.cpp:159
+#, c-format
+msgid "Open file \"%s\""
+msgstr "Ireki \"%s\" agiria"
+
+#: ../src/generic/dbgrptg.cpp:170
+#, c-format
+msgid "Enter command to open file \"%s\":"
+msgstr "Sartu komandoa \"%s\" agiria irekitzeko:"
+
+#: ../src/generic/dbgrptg.cpp:230
+msgid "Executable files (*.exe)|*.exe|"
+msgstr "Agiri exekutagarriak (*.exe)|*.exe|"
+
+#: ../src/generic/dbgrptg.cpp:300
+#, c-format
+msgid "Debug report \"%s\""
+msgstr " \"%s\" garbikea jakinarazpena"
+
+#: ../src/generic/dbgrptg.cpp:316
+msgid "A debug report has been generated in the directory\n"
+msgstr "Garbiketa jakinarazpena zuzenbidean sortu da\n"
+
+#: ../src/generic/dbgrptg.cpp:317
+msgid "The following debug report will be generated\n"
+msgstr ""
+
+#: ../src/generic/dbgrptg.cpp:321
+msgid ""
+"The report contains the files listed below. If any of these files contain "
+"private information,\n"
+"please uncheck them and they will be removed from the report.\n"
+msgstr ""
+"Jakinarazpenak behean zerrendaturiko agiriak ditu. Agiri hauetakoren batek "
+"argibide pribatuak baditu,\n"
+"mesedez ez hautatu itzazu eta jakinarazpenetik kenduko dira.\n"
+
+#: ../src/generic/dbgrptg.cpp:323
+msgid ""
+"If you wish to suppress this debug report completely, please choose the "
+"\"Cancel\" button,\n"
+"but be warned that it may hinder improving the program, so if\n"
+"at all possible please do continue with the report generation.\n"
+msgstr ""
+"Akats jakinarazpen hau erabat ezabatzea nahi baduzu, mesedez hautatu "
+"\"Ezeztatu\" botoia,\n"
+"baina kontuan izan programaren hobekuntza zaildu dezakeela, hortaz\n"
+"ahal bezain mesedez jarraitu jakinarazpenaren sortzearekin.\n"
+
+#: ../src/generic/dbgrptg.cpp:325
+msgid "              Thank you and we're sorry for the inconvenience!\n"
+msgstr "             Mila esker eta barkatu eragozpenak!\n"
+
+#: ../src/generic/dbgrptg.cpp:333
+msgid "&Debug report preview:"
+msgstr "&Garbiketa jakinarazpen aurreikuspena:"
+
+#: ../src/generic/dbgrptg.cpp:339
+msgid "&View..."
+msgstr "&Ikusi..."
+
+#: ../src/generic/dbgrptg.cpp:359
+msgid "&Notes:"
+msgstr "&Oharrak:"
+
+#: ../src/generic/dbgrptg.cpp:361
+msgid ""
+"If you have any additional information pertaining to this bug\n"
+"report, please enter it here and it will be joined to it:"
+msgstr ""
+"Akats honi buruzko argibide gehigarriren bat baduzu\n"
+"jakinarazi, mesedez sartu hemen eta berari batuko zaio:"
+
+#: ../src/generic/dcpsg.cpp:1627
+msgid "Cannot open file for PostScript printing!"
+msgstr "Ezin da ireki agiria PostScript irarketarako!"
+
+#: ../src/generic/dirctrlg.cpp:402
+msgid "Computer"
+msgstr "Ordenagailua"
+
+#: ../src/generic/dirctrlg.cpp:404
+msgid "Sections"
+msgstr "Atalak"
+
+#: ../src/generic/dirctrlg.cpp:482
+msgid "Home directory"
+msgstr "Hasierako zuzenbidea"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/generic/dirctrlg.cpp:484 ../src/propgrid/advprops.cpp:811
+msgid "Desktop"
+msgstr "Mahigaina"
+
+#: ../src/generic/dirctrlg.cpp:528 ../src/generic/filectrlg.cpp:752
+msgid "Illegal directory name."
+msgstr "Legezkanpoko zuzenbide izena."
+
+#: ../src/generic/dirctrlg.cpp:528 ../src/generic/dirctrlg.cpp:546
+#: ../src/generic/dirctrlg.cpp:557 ../src/generic/dirdlgg.cpp:317
+#: ../src/generic/filectrlg.cpp:638 ../src/generic/filectrlg.cpp:752
+#: ../src/generic/filectrlg.cpp:766 ../src/generic/filectrlg.cpp:782
+#: ../src/generic/filectrlg.cpp:1356 ../src/generic/filectrlg.cpp:1387
+#: ../src/generic/filedlgg.cpp:362 ../src/gtk/filedlg.cpp:76
+msgid "Error"
+msgstr "Akatsa"
+
+#: ../src/generic/dirctrlg.cpp:546 ../src/generic/filectrlg.cpp:766
+msgid "File name exists already."
+msgstr "Agiri izena badago jadanik."
+
+#: ../src/generic/dirctrlg.cpp:557 ../src/generic/dirdlgg.cpp:317
+#: ../src/generic/filectrlg.cpp:638 ../src/generic/filectrlg.cpp:782
+msgid "Operation not permitted."
+msgstr "Eragiketa baimengabea."
+
+#: ../src/generic/dirdlgg.cpp:107 ../src/generic/filedlgg.cpp:207
+msgid "Create new directory"
+msgstr "Sortu zuzenbide berria"
+
+#: ../src/generic/dirdlgg.cpp:112 ../src/generic/filedlgg.cpp:203
+msgid "Go to home directory"
+msgstr "Joan hasierako zuzenbidera"
+
+#: ../src/generic/dirdlgg.cpp:143
+msgid "Show &hidden directories"
+msgstr "Erakutsi e&zkutuko zuzenbideak"
+
+#: ../src/generic/dirdlgg.cpp:196
+#, c-format
+msgid ""
+"The directory '%s' does not exist\n"
+"Create it now?"
+msgstr ""
+"'%s' zuzenbidea ez dago\n"
+"Orain sortu?"
+
+#: ../src/generic/dirdlgg.cpp:198
+msgid "Directory does not exist"
+msgstr "Zuzenbidea ez dago"
+
+#: ../src/generic/dirdlgg.cpp:214
+#, c-format
+msgid ""
+"Failed to create directory '%s'\n"
+"(Do you have the required permissions?)"
+msgstr ""
+"Hutsegitea '%s' zuzenbidea sortzerakoan\n"
+"(Badituzu beharrezko baimenak?)"
+
+#: ../src/generic/dirdlgg.cpp:216
+msgid "Error creating directory"
+msgstr "Akatsa zuzenbidea irakurtzean"
+
+#: ../src/generic/dirdlgg.cpp:281
+msgid "You cannot add a new directory to this section."
+msgstr "Ezin duzu zuzenbide berririk gehitu atal honetara."
+
+#: ../src/generic/dirdlgg.cpp:282
+msgid "Create directory"
+msgstr "Sortu zuzenbidea"
+
+#: ../src/generic/dirdlgg.cpp:291 ../src/generic/dirdlgg.cpp:301
+#: ../src/generic/filectrlg.cpp:614 ../src/generic/filectrlg.cpp:623
+msgid "NewName"
+msgstr "Izen Berria"
+
+#: ../src/generic/editlbox.cpp:135
+msgid "Edit item"
+msgstr "Editatu gaia"
+
+#: ../src/generic/editlbox.cpp:143
+msgid "New item"
+msgstr "Gai berria"
+
+#: ../src/generic/editlbox.cpp:151
+msgid "Delete item"
+msgstr "Ezabatu gaia"
+
+#: ../src/generic/editlbox.cpp:159
+msgid "Move up"
+msgstr "Mugitu gora"
+
+#: ../src/generic/editlbox.cpp:164
+msgid "Move down"
+msgstr "Mugitu behera"
+
+#: ../src/generic/fdrepdlg.cpp:108
+msgid "Search for:"
+msgstr "Bilatu hau:"
+
+#: ../src/generic/fdrepdlg.cpp:120
+msgid "Replace with:"
+msgstr "Ordeztu honekin:"
+
+#: ../src/generic/fdrepdlg.cpp:140
+msgid "Whole word"
+msgstr "Hitz osoa"
+
+#: ../src/generic/fdrepdlg.cpp:143
+msgid "Match case"
+msgstr "Hizki xehe-larriak"
+
+#: ../src/generic/fdrepdlg.cpp:156
+msgid "Search direction"
+msgstr "Bilatu helbidea"
+
+#: ../src/generic/fdrepdlg.cpp:175
+msgid "&Replace"
+msgstr "&Ordeztu"
+
+#: ../src/generic/fdrepdlg.cpp:178
+msgid "Replace &all"
+msgstr "Ordeztu &denak"
+
+#: ../src/generic/filectrlg.cpp:246 ../src/generic/filectrlg.cpp:269
+msgid "<DIR>"
+msgstr "<ZUZ>"
+
+#: ../src/generic/filectrlg.cpp:248 ../src/generic/filectrlg.cpp:271
+msgid "<LINK>"
+msgstr "<LOTURA>"
+
+#: ../src/generic/filectrlg.cpp:250 ../src/generic/filectrlg.cpp:273
+msgid "<DRIVE>"
+msgstr "<GIDAG.>"
+
+#: ../src/generic/filectrlg.cpp:275
+#, c-format
+msgid "%ld byte"
+msgid_plural "%ld bytes"
+msgstr[0] "%ld byte"
+msgstr[1] "%ld byte"
+
+#: ../src/generic/filectrlg.cpp:420
+msgid "Name"
+msgstr "Izena"
+
+#: ../src/generic/filectrlg.cpp:421 ../src/richtext/richtextformatdlg.cpp:361
+#: ../src/richtext/richtextsizepage.cpp:298
+msgid "Size"
+msgstr "Neurria"
+
+#: ../src/generic/filectrlg.cpp:422
+msgid "Type"
+msgstr "Idatzi"
+
+#: ../src/generic/filectrlg.cpp:423
+msgid "Modified"
+msgstr "Aldatuta"
+
+#: ../src/generic/filectrlg.cpp:426
+msgid "Permissions"
+msgstr "Baimenak"
+
+#: ../src/generic/filectrlg.cpp:429
+msgid "Attributes"
+msgstr "Ezaugarriak"
+
+#: ../src/generic/filectrlg.cpp:936
+msgid "Current directory:"
+msgstr "Oraingo zuzenbidea:"
+
+#: ../src/generic/filectrlg.cpp:979
+msgid "Show &hidden files"
+msgstr "Erakutsi &ezkutuko agiriak"
+
+#: ../src/generic/filectrlg.cpp:1355
+msgid "Illegal file specification."
+msgstr "Legezkanpoko agiri zehaztapena"
+
+#: ../src/generic/filectrlg.cpp:1387
+msgid "Directory doesn't exist."
+msgstr "Zuzenbidea ez dago."
+
+#: ../src/generic/filedlgg.cpp:195
+msgid "View files as a list view"
+msgstr "Ikusi agiriak zerrenda bezala"
+
+#: ../src/generic/filedlgg.cpp:197
+msgid "View files as a detailed view"
+msgstr "Ikusi agiriak xehetasunekin"
+
+#: ../src/generic/filedlgg.cpp:200
+msgid "Go to parent directory"
+msgstr "Joan gaineko zuzenbidera"
+
+#: ../src/generic/filedlgg.cpp:351 ../src/gtk/filedlg.cpp:59
+#, c-format
+msgid "File '%s' already exists, do you really want to overwrite it?"
+msgstr "'%s' agiria jadanik badago, egitan nahi duzu gainidaztea?"
+
+#: ../src/generic/filedlgg.cpp:354 ../src/gtk/filedlg.cpp:62
+msgid "Confirm"
+msgstr "Baieztatu"
+
+#: ../src/generic/filedlgg.cpp:362 ../src/gtk/filedlg.cpp:75
+msgid "Please choose an existing file."
+msgstr "Mesedez hautatu dagoen agiri bat."
+
+#: ../src/generic/filepickerg.cpp:64
+msgid "..."
+msgstr "..."
+
+#: ../src/generic/fontdlgg.cpp:76 ../src/richtext/richtextformatdlg.cpp:519
+msgid "ABCDEFGabcdefg12345"
+msgstr "ABCDEFGabcdefg12345"
+
+#: ../src/generic/fontdlgg.cpp:315
+msgid "Roman"
+msgstr "Erromatarra"
+
+#: ../src/generic/fontdlgg.cpp:316
+msgid "Decorative"
+msgstr "Edergarria"
+
+#: ../src/generic/fontdlgg.cpp:317
+msgid "Modern"
+msgstr "Modernoa"
+
+#: ../src/generic/fontdlgg.cpp:318
+msgid "Script"
+msgstr "Eskripta"
+
+#: ../src/generic/fontdlgg.cpp:319
+msgid "Swiss"
+msgstr "Suitzarra"
+
+#: ../src/generic/fontdlgg.cpp:320
+msgid "Teletype"
+msgstr "Teletipoa"
+
+#: ../src/generic/fontdlgg.cpp:321 ../src/generic/fontdlgg.cpp:324
+msgid "Normal"
+msgstr "Normala"
+
+#: ../src/generic/fontdlgg.cpp:323
+msgid "Slant"
+msgstr "Oker"
+
+#: ../src/generic/fontdlgg.cpp:325
+msgid "Light"
+msgstr "Arina"
+
+#: ../src/generic/fontdlgg.cpp:363
+msgid "&Font family:"
+msgstr "&Hizki sendia:"
+
+#: ../src/generic/fontdlgg.cpp:367 ../src/generic/fontdlgg.cpp:369
+msgid "The font family."
+msgstr "Hizki sendia."
+
+#: ../src/generic/fontdlgg.cpp:374 ../src/richtext/richtextstylepage.cpp:105
+msgid "&Style:"
+msgstr "&Estiloa:"
+
+#: ../src/generic/fontdlgg.cpp:378 ../src/generic/fontdlgg.cpp:380
+msgid "The font style."
+msgstr "Hizki estiloa."
+
+#: ../src/generic/fontdlgg.cpp:385
+msgid "&Weight:"
+msgstr "&Zabalera:"
+
+#: ../src/generic/fontdlgg.cpp:389 ../src/generic/fontdlgg.cpp:391
+msgid "The font weight."
+msgstr "Hizkiaren zabalera."
+
+#: ../src/generic/fontdlgg.cpp:399
+msgid "C&olour:"
+msgstr "&Margoa:"
+
+#: ../src/generic/fontdlgg.cpp:407 ../src/generic/fontdlgg.cpp:409
+msgid "The font colour."
+msgstr "Hizki margoa."
+
+#: ../src/generic/fontdlgg.cpp:415
+msgid "&Point size:"
+msgstr "&Puntu neurria:"
+
+#: ../src/generic/fontdlgg.cpp:420 ../src/generic/fontdlgg.cpp:422
+#: ../src/generic/fontdlgg.cpp:426 ../src/generic/fontdlgg.cpp:428
+msgid "The font point size."
+msgstr "Hizkiaren puntu neurria."
+
+#: ../src/generic/fontdlgg.cpp:439 ../src/generic/fontdlgg.cpp:441
+msgid "Whether the font is underlined."
+msgstr "Hizkia azpimarratuta badago."
+
+#: ../src/generic/fontdlgg.cpp:448 ../src/html/helpwnd.cpp:1215
+msgid "Preview:"
+msgstr "Aurreikuspena:"
+
+#: ../src/generic/fontdlgg.cpp:452 ../src/generic/fontdlgg.cpp:454
+msgid "Shows the font preview."
+msgstr "Hizki aurreikuspen bat erakusten du."
+
+#: ../src/generic/fontdlgg.cpp:464 ../src/generic/fontdlgg.cpp:483
+msgid "Click to cancel the font selection."
+msgstr "Klikatu hizki hautapena ezeztatzeko."
+
+#: ../src/generic/fontdlgg.cpp:469 ../src/generic/fontdlgg.cpp:471
+#: ../src/generic/fontdlgg.cpp:476 ../src/generic/fontdlgg.cpp:478
+msgid "Click to confirm the font selection."
+msgstr "Klikatu hizki hautapena baieztatzeko."
+
+#: ../src/generic/fontpickerg.cpp:50 ../src/gtk/fontdlg.cpp:77
+msgid "Choose font"
+msgstr "Hautatu hizkia"
+
+#: ../src/generic/grid.cpp:6542
+msgid ""
+"Error copying grid to the clipboard. Either selected cells were not "
+"contiguous or no cell was selected."
+msgstr ""
+
+#: ../src/generic/grid.cpp:12739
+#, fuzzy
+msgid "Grid Corner"
+msgstr "Bazterrra"
+
+#: ../src/generic/grid.cpp:12741
+#, fuzzy, c-format
+msgid "Column %s Header"
+msgstr "Gehitu Zutabea"
+
+#: ../src/generic/grid.cpp:12743
+#, c-format
+msgid "Row %s Header"
+msgstr ""
+
+#: ../src/generic/grid.cpp:12745
+#, fuzzy, c-format
+msgid "Column %s: %s"
+msgstr "Gehitu Zutabea"
+
+#: ../src/generic/grid.cpp:12749
+#, c-format
+msgid "Row %s: %s"
+msgstr ""
+
+#: ../src/generic/grid.cpp:12753
+#, c-format
+msgid "Row %s, Column %s: %s"
+msgstr ""
+
+#: ../src/generic/helpext.cpp:257
+#, c-format
+msgid "Help directory \"%s\" not found."
+msgstr "\"%s\" laguntza zuzenbidea ez da aurkitu."
+
+#: ../src/generic/helpext.cpp:265
+#, c-format
+msgid "Help file \"%s\" not found."
+msgstr "\"%s\" laguntza agiri ez da aurkitu."
+
+#: ../src/generic/helpext.cpp:284
+#, c-format
+msgid "Line %lu of map file \"%s\" has invalid syntax, skipped."
+msgstr "%lu lerroa \"%s\" mapa agirian joskera baliogabea du, ahaztuta."
+
+#: ../src/generic/helpext.cpp:292
+#, c-format
+msgid "No valid mappings found in the file \"%s\"."
+msgstr "Ez da baliozko mapaketarik aurkitu \"%s\" agirian."
+
+#: ../src/generic/helpext.cpp:435
+msgid "No entries found."
+msgstr "Ez da sarrerarik aurkitu."
+
+#: ../src/generic/helpext.cpp:444 ../src/generic/helpext.cpp:445
+msgid "Help Index"
+msgstr "Laguntza Aurkibidea"
+
+#: ../src/generic/helpext.cpp:448
+msgid "Relevant entries:"
+msgstr "Sarrera nabarmenak:"
+
+#: ../src/generic/helpext.cpp:449
+msgid "Entries found"
+msgstr "Aurkitutako sarrerak"
+
+#: ../src/generic/hyperlinkg.cpp:170
+msgid "&Copy URL"
+msgstr "&Kopiatu URL-a"
+
+#: ../src/generic/infobar.cpp:119
+msgid "Hide this notification message."
+msgstr "Ezkutatu ohar mezu hau."
+
+#. TRANSLATORS: %s will be either the application name or "Application"
+#: ../src/generic/logg.cpp:257
+#, c-format
+msgid "%s Error"
+msgstr "%s Akatsa"
+
+#. TRANSLATORS: %s will be either the application name or "Application"
+#: ../src/generic/logg.cpp:263
+#, c-format
+msgid "%s Warning"
+msgstr "%s Oharra"
+
+#. TRANSLATORS: %s will be either the application name or "Application"
+#: ../src/generic/logg.cpp:273
+#, c-format
+msgid "%s Information"
+msgstr "%s Argibideak"
+
+#: ../src/generic/logg.cpp:276
+msgid "Application"
+msgstr "Aplikazioa"
+
+#: ../src/generic/logg.cpp:549
+msgid "Save log contents to file"
+msgstr "Gorde ohar edukiak agirian"
+
+#: ../src/generic/logg.cpp:551
+msgid "C&lear"
+msgstr "&Garbitu"
+
+#: ../src/generic/logg.cpp:551
+msgid "Clear the log contents"
+msgstr "Garbitu ohar edukiak"
+
+#: ../src/generic/logg.cpp:553
+msgid "Close this window"
+msgstr "Itxi leiho hau"
+
+#: ../src/generic/logg.cpp:554
+msgid "&Log"
+msgstr "&Oharra"
+
+#: ../src/generic/logg.cpp:610 ../src/generic/logg.cpp:992
+msgid "Can't save log contents to file."
+msgstr "Ezin dira ohar edukiak agirian gorde."
+
+#: ../src/generic/logg.cpp:613
+#, c-format
+msgid "Log saved to the file '%s'."
+msgstr "Oharra '%s' agirian gordeta."
+
+#: ../src/generic/logg.cpp:719
+msgid "&Details"
+msgstr "&Xehetasunak"
+
+#: ../src/generic/logg.cpp:972
+msgid "Failed to copy dialog contents to the clipboard."
+msgstr "Hutsegitea elkarrizketa edukiak gakora kopiatzerakoan."
+
+#: ../src/generic/logg.cpp:1022
+#, c-format
+msgid "Append log to file '%s' (choosing [No] will overwrite it)?"
+msgstr "Oharra eransten '%s' agiriari (hautatzen [Ez] gainidatziko da)? "
+
+#: ../src/generic/logg.cpp:1024
+msgid "Question"
+msgstr "Galdera"
+
+#: ../src/generic/logg.cpp:1038
+msgid "invalid message box return value"
+msgstr "mezu kutxa baliogabea balioa itzultzen"
+
+#: ../src/generic/notifmsgg.cpp:129
+msgid "Notice"
+msgstr "Albistea"
+
+#: ../src/generic/preferencesg.cpp:118
+#, c-format
+msgid "%s Preferences"
+msgstr "%s Hobespenak"
+
+#: ../src/generic/printps.cpp:143
+msgid "Printing..."
+msgstr "Irarkitzen..."
+
+#: ../src/generic/printps.cpp:160 ../src/gtk/print.cpp:1076
+#: ../src/msw/printwin.cpp:235
+msgid "Could not start printing."
+msgstr "Ezin da irarketa hasi"
+
+#: ../src/generic/printps.cpp:183
+#, c-format
+msgid "Printing page %d..."
+msgstr "%d orrialdea irarkitzen..."
+
+#: ../src/generic/prntdlgg.cpp:171
+msgid "Printer options"
+msgstr "Irarkailu aukerak"
+
+#: ../src/generic/prntdlgg.cpp:176
+msgid "Print to File"
+msgstr "Irarkitu Agirira"
+
+#: ../src/generic/prntdlgg.cpp:179
+msgid "Setup..."
+msgstr "Ezarpena..."
+
+#: ../src/generic/prntdlgg.cpp:187
+msgid "Printer:"
+msgstr "Irarkailua:"
+
+#: ../src/generic/prntdlgg.cpp:195
+msgid "Status:"
+msgstr "Egoera:"
+
+#: ../src/generic/prntdlgg.cpp:206
+msgid "All"
+msgstr "Denak"
+
+#: ../src/generic/prntdlgg.cpp:207
+msgid "Pages"
+msgstr "Orrialdeak"
+
+#: ../src/generic/prntdlgg.cpp:215
+msgid "Print Range"
+msgstr "Irarketa Maila"
+
+#: ../src/generic/prntdlgg.cpp:229
+msgid "From:"
+msgstr "Hemendik:"
+
+#: ../src/generic/prntdlgg.cpp:233
+msgid "To:"
+msgstr "Hona:"
+
+#: ../src/generic/prntdlgg.cpp:238
+msgid "Copies:"
+msgstr "Kopiak:"
+
+#: ../src/generic/prntdlgg.cpp:288
+msgid "PostScript file"
+msgstr "PostScript agiria"
+
+#: ../src/generic/prntdlgg.cpp:439
+msgid "Print Setup"
+msgstr "Irarketa Ezarpena"
+
+#: ../src/generic/prntdlgg.cpp:483
+msgid "Printer"
+msgstr "Irarkailua"
+
+#: ../src/generic/prntdlgg.cpp:501
+msgid "Default printer"
+msgstr "Berezko irarkailua"
+
+#: ../src/generic/prntdlgg.cpp:595 ../src/generic/prntdlgg.cpp:782
+#: ../src/generic/prntdlgg.cpp:822 ../src/generic/prntdlgg.cpp:835
+#: ../src/generic/prntdlgg.cpp:1031 ../src/generic/prntdlgg.cpp:1036
+msgid "Paper size"
+msgstr "Paper neurria"
+
+#: ../src/generic/prntdlgg.cpp:604 ../src/generic/prntdlgg.cpp:847
+msgid "Portrait"
+msgstr "Argazkia"
+
+#: ../src/generic/prntdlgg.cpp:605 ../src/generic/prntdlgg.cpp:848
+msgid "Landscape"
+msgstr "Etzana"
+
+#: ../src/generic/prntdlgg.cpp:607 ../src/generic/prntdlgg.cpp:849
+msgid "Orientation"
+msgstr "Norantza"
+
+#: ../src/generic/prntdlgg.cpp:610
+msgid "Options"
+msgstr "Aukerak"
+
+#: ../src/generic/prntdlgg.cpp:612
+msgid "Print in colour"
+msgstr "Irarkitu margoekin"
+
+#: ../src/generic/prntdlgg.cpp:621
+msgid "Print spooling"
+msgstr "Irarketa lerrokapena"
+
+#: ../src/generic/prntdlgg.cpp:623
+msgid "Printer command:"
+msgstr "Irarkailu komandoa:"
+
+#: ../src/generic/prntdlgg.cpp:631
+msgid "Printer options:"
+msgstr "Irarkailu aukerak:"
+
+#: ../src/generic/prntdlgg.cpp:860
+msgid "Left margin (mm):"
+msgstr "Ezker bazterra (mm):"
+
+#: ../src/generic/prntdlgg.cpp:861
+msgid "Top margin (mm):"
+msgstr "Goiko bazterra (mm):"
+
+#: ../src/generic/prntdlgg.cpp:872
+msgid "Right margin (mm):"
+msgstr "Eskuin bazterra (mm):"
+
+#: ../src/generic/prntdlgg.cpp:873
+msgid "Bottom margin (mm):"
+msgstr "Beheko bazterra (mm):"
+
+#: ../src/generic/prntdlgg.cpp:896
+msgid "Printer..."
+msgstr "Irarkailua..."
+
+#: ../src/generic/progdlgg.cpp:246
+msgid "&Skip"
+msgstr "&Ahaztu"
+
+#: ../src/generic/progdlgg.cpp:347 ../src/generic/progdlgg.cpp:626
+msgid "Unknown"
+msgstr "Ezezaguna"
+
+#: ../src/generic/progdlgg.cpp:451 ../src/msw/progdlg.cpp:526
+msgid "Done."
+msgstr "Eginda."
+
+#: ../src/generic/srchctlg.cpp:55 ../src/gtk/srchctrl.cpp:206
+#: ../src/html/helpwnd.cpp:530 ../src/html/helpwnd.cpp:545
+msgid "Search"
+msgstr "Bilatu"
+
+#: ../src/generic/tabg.cpp:1026
+msgid "Could not find tab for id"
+msgstr "Ezin da id-arentzako tab aurkitu"
+
+#: ../src/generic/tipdlg.cpp:136
+msgid "Tips not available, sorry!"
+msgstr "Gomendioak ez daude eskuragarri, barkatu!"
+
+#: ../src/generic/tipdlg.cpp:197
+msgid "Tip of the Day"
+msgstr "Eguneko Gomendioa"
+
+#: ../src/generic/tipdlg.cpp:207
+msgid "Did you know..."
+msgstr "Esanahi duzu..."
+
+#: ../src/generic/tipdlg.cpp:232
+msgid "&Show tips at startup"
+msgstr "&Erakutsi idaztziak hasterakoan"
+
+#: ../src/generic/tipdlg.cpp:236
+msgid "&Next Tip"
+msgstr "&Hurrengo Idatzia"
+
+#: ../src/generic/wizard.cpp:411
+msgid "&Next >"
+msgstr "&Hurrengoa >"
+
+#: ../src/generic/wizard.cpp:412
+msgid "&Finish"
+msgstr "&Amaitu"
+
+#: ../src/generic/wizard.cpp:420
+msgid "< &Back"
+msgstr "< &Atzera"
+
+#: ../src/gtk/aboutdlg.cpp:204
+msgid "translator-credits"
+msgstr "itzultzaileak"
+
+#: ../src/gtk/app.cpp:517
+msgid ""
+"WARNING: using XIM input method is unsupported and may result in problems "
+"with input handling and flickering. Consider unsetting GTK_IM_MODULE or "
+"setting to \"ibus\"."
+msgstr ""
+
+#: ../src/gtk/app.cpp:569
+msgid "Unable to initialize GTK+, is DISPLAY set properly?"
+msgstr "Ezinezkoa GTK+ hastea, ERAKUTSI ongi ezarrita dago?"
+
+#: ../src/gtk/filedlg.cpp:89 ../src/gtk/filepicker.cpp:255
+#, c-format
+msgid "Changing current directory to \"%s\" failed"
+msgstr "Hutsegita oraingo zuzenbidea \"%s\"-ra aldatzerakoan"
+
+#: ../src/gtk/font.cpp:548
+msgid ""
+"Using private fonts is not supported on this system: Pango library is too "
+"old, 1.38 or later required."
+msgstr ""
+
+#: ../src/gtk/font.cpp:558
+#, fuzzy
+msgid "Failed to create font configuration object."
+msgstr "Hutsegitea erabiltzaile itxurapen agiria eguneratzerakoan."
+
+#: ../src/gtk/font.cpp:568
+#, fuzzy, c-format
+msgid "Failed to add custom font \"%s\"."
+msgstr "Hutsegitea \"%s\" agiritik agiria irakurtzerakoan."
+
+#: ../src/gtk/font.cpp:576
+#, fuzzy
+msgid "Failed to register font configuration using private fonts."
+msgstr "Hutsegitea erabiltzaile itxurapen agiria eguneratzerakoan."
+
+#: ../src/gtk/glcanvas.cpp:117 ../src/gtk/glcanvas.cpp:132
+#, fuzzy
+msgid "Fatal Error"
+msgstr "Agiri akatsa"
+
+#: ../src/gtk/glcanvas.cpp:117
+msgid ""
+"This program wasn't compiled with EGL support required under Wayland, "
+"either\n"
+"install EGL libraries and rebuild or run it under X11 backend by setting\n"
+"environment variable GDK_BACKEND=x11 before starting your program."
+msgstr ""
+
+#: ../src/gtk/glcanvas.cpp:132
+msgid ""
+"wxGLCanvas is only supported on Wayland and X11 currently.  You may be able "
+"to\n"
+"work around this by setting environment variable GDK_BACKEND=x11 before\n"
+"starting your program."
+msgstr ""
+
+#: ../src/gtk/mdi.cpp:433
+msgid "MDI child"
+msgstr "MDI child"
+
+#: ../src/gtk/power.cpp:188
+#, fuzzy, c-format
+msgid "Failed to open D-Bus connection to the login manager: %s"
+msgstr "Hutsegitea '%s' zerbitzariarekin '%s' gaian elkarketa sortzerakoan"
+
+#: ../src/gtk/power.cpp:214
+#, fuzzy
+msgid "wxWidgets application"
+msgstr "Aplikazioa"
+
+#: ../src/gtk/power.cpp:226
+msgid "Application needs to keep running"
+msgstr ""
+
+#: ../src/gtk/power.cpp:233
+msgid "Clean up before suspend"
+msgstr ""
+
+#: ../src/gtk/power.cpp:259
+#, fuzzy, c-format
+msgid "Failed to inhibit sleep: %s"
+msgstr "Hutsegitea urrutizkin elkarketa hasterakoan: %s"
+
+#: ../src/gtk/power.cpp:265
+msgid "Unexpected response to D-Bus \"Inhibit\" request."
+msgstr ""
+
+#: ../src/gtk/print.cpp:218
+msgid "Custom size"
+msgstr "Norbere neurria"
+
+#: ../src/gtk/print.cpp:752
+#, fuzzy, c-format
+msgid "Error while printing: %s"
+msgstr "Akatsa irarkitzerakoan:"
+
+#: ../src/gtk/print.cpp:816
+msgid "Page Setup"
+msgstr "Orrialde Ezarpena"
+
+#: ../src/gtk/webview_webkit.cpp:932
+msgid "Retrieving JavaScript script output is not supported with WebKit v1"
+msgstr ""
+
+#: ../src/gtk/webview_webkit2.cpp:1098
+msgid ""
+"Setting proxy is not supported by WebKit, at least version 2.16 is required."
+msgstr ""
+
+#: ../src/gtk/webview_webkit2.cpp:1104
+msgid "This program was compiled without support for setting WebKit proxy."
+msgstr ""
+
+#: ../src/gtk/window.cpp:6289
+msgid ""
+"GTK+ installed on this machine is too old to support screen compositing, "
+"please install GTK+ 2.12 or later."
+msgstr ""
+"Gailu honetan ezarritako GTK+ zaharregia da ikusleiho osaketa sostengatzeko, "
+"mesedez ezarri GTK+2.12 edo berriagoa."
+
+#: ../src/gtk/window.cpp:6307
+msgid ""
+"Compositing not supported by this system, please enable it in your Window "
+"Manager."
+msgstr ""
+"Osaketa ez dago sostengaturik sistema honetan, mesedez gaitu ezazu zure "
+"Leiho Kudeatzailean."
+
+#: ../src/gtk/window.cpp:6318
+msgid ""
+"This program was compiled with a too old version of GTK+, please rebuild "
+"with GTK+ 2.12 or newer."
+msgstr ""
+"Plataforma hau GTK+ bertsio zahar batekin bildua da, mesedez berreraiki GTK+ "
+"2.12 edo berriago batekin."
+
+#: ../src/html/chm.cpp:138
+#, c-format
+msgid "Failed to open CHM archive '%s'."
+msgstr "Hutsegitea '%s' CHM agiria irekitzerakoan."
+
+#: ../src/html/chm.cpp:270
+#, c-format
+msgid "Could not extract %s into %s: %s"
+msgstr "Ezin da %s atera %s-n: %s"
+
+#: ../src/html/chm.cpp:324
+msgid "no error"
+msgstr "no akatsa"
+
+#: ../src/html/chm.cpp:326
+msgid "bad arguments to library function"
+msgstr "argumengu okerra liburutegi eginkizunerako"
+
+#: ../src/html/chm.cpp:328
+msgid "error opening file"
+msgstr "akatsa agira irakitzean"
+
+#: ../src/html/chm.cpp:330
+msgid "read error"
+msgstr "irakur akatsa"
+
+#: ../src/html/chm.cpp:332
+msgid "write error"
+msgstr "idaz akatsa"
+
+#: ../src/html/chm.cpp:334
+msgid "seek error"
+msgstr "bilatu akatsa"
+
+#: ../src/html/chm.cpp:338
+msgid "bad signature"
+msgstr "sinadura okerra"
+
+#: ../src/html/chm.cpp:340
+msgid "error in data format"
+msgstr "akatsa datu heuskarrian"
+
+#: ../src/html/chm.cpp:342
+msgid "checksum error"
+msgstr "Egiaztapen hutsegitea"
+
+#: ../src/html/chm.cpp:344
+msgid "compression error"
+msgstr "konpresio akatsa"
+
+#: ../src/html/chm.cpp:346
+msgid "decompression error"
+msgstr "deskonpresio akatsa"
+
+#: ../src/html/chm.cpp:437
+#, c-format
+msgid "Could not locate file '%s'."
+msgstr "Ezin da '%s' agiria kokatu."
+
+#: ../src/html/chm.cpp:711
+#, c-format
+msgid "Could not create temporary file '%s'"
+msgstr "Ezin da '%s' aldibaterako agiria sortu"
+
+#: ../src/html/chm.cpp:718
+#, c-format
+msgid "Extraction of '%s' into '%s' failed."
+msgstr "Hutsegitea '%s' '%s'-ra ateratzerakoan."
+
+#: ../src/html/chm.cpp:806 ../src/html/chm.cpp:863
+msgid "CHM handler currently supports only local files!"
+msgstr "CHM kudeatzaileak orain tokiko agiriak bakarrik sostengatzen ditu!"
+
+#: ../src/html/chm.cpp:827
+msgid "Link contained '//', converted to absolute link."
+msgstr "Loturak  '//' du, lotura osoan bihurtuta."
+
+#: ../src/html/helpctrl.cpp:59
+#, c-format
+msgid "Help: %s"
+msgstr "Laguntza: %s"
+
+#: ../src/html/helpctrl.cpp:155
+#, c-format
+msgid "Adding book %s"
+msgstr "%s liburua gehitzen"
+
+#: ../src/html/helpdata.cpp:295
+#, c-format
+msgid "Cannot open contents file: %s"
+msgstr "Ezin da ireki eduki agiria: %s"
+
+#: ../src/html/helpdata.cpp:309
+#, c-format
+msgid "Cannot open index file: %s"
+msgstr "Ezin da ireki aurkibide agiria: %s"
+
+#: ../src/html/helpdata.cpp:643
+msgid "noname"
+msgstr "izengabe"
+
+#: ../src/html/helpdata.cpp:652
+#, c-format
+msgid "Cannot open HTML help book: %s"
+msgstr "Ezin da ireki HTML laguntza libuura: %s"
+
+#: ../src/html/helpwnd.cpp:315
+msgid "Displays help as you browse the books on the left."
+msgstr "Laguntza erakusten du ezkerreko liburuetan nabigatzean."
+
+#: ../src/html/helpwnd.cpp:411 ../src/html/helpwnd.cpp:1100
+#: ../src/html/helpwnd.cpp:1735
+msgid "(bookmarks)"
+msgstr "(lastermarkak)"
+
+#: ../src/html/helpwnd.cpp:424
+msgid "Add current page to bookmarks"
+msgstr "Gehitu oraingo orrialdea lastermarketara"
+
+#: ../src/html/helpwnd.cpp:425
+msgid "Remove current page from bookmarks"
+msgstr "Kendu oraingo orrialdea lastermarketatik"
+
+#: ../src/html/helpwnd.cpp:470
+msgid "Contents"
+msgstr "Edukiak"
+
+#: ../src/html/helpwnd.cpp:485
+msgid "Find"
+msgstr "Bilatu"
+
+#: ../src/html/helpwnd.cpp:487
+msgid "Show all"
+msgstr "Erakutsi denak"
+
+#: ../src/html/helpwnd.cpp:497
+msgid ""
+"Display all index items that contain given substring. Search is case "
+"insensitive."
+msgstr ""
+"Erakutsi emandako azpikatea duten aurkibideko gai guztiak. Bilaketak hizki "
+"xehe-larriak bereizten ditu."
+
+#: ../src/html/helpwnd.cpp:498
+msgid "Show all items in index"
+msgstr "Erakutsi gai guzitak aurkibidean"
+
+#: ../src/html/helpwnd.cpp:528
+msgid "Case sensitive"
+msgstr "Hizki larri-xeheak"
+
+#: ../src/html/helpwnd.cpp:529
+msgid "Whole words only"
+msgstr "Hitz osoak bakarrik"
+
+#: ../src/html/helpwnd.cpp:532
+msgid ""
+"Search contents of help book(s) for all occurrences of the text you typed "
+"above"
+msgstr ""
+"Bilatu edukiak laguntza liburuan gainean idatzi duzun idazkiaren gertaera "
+"guztientzat"
+
+#: ../src/html/helpwnd.cpp:653
+msgid "Show/hide navigation panel"
+msgstr "Erakusi/ezkutatu nabigazio panela"
+
+#: ../src/html/helpwnd.cpp:655
+msgid "Go back"
+msgstr "Joan atzera"
+
+#: ../src/html/helpwnd.cpp:656
+msgid "Go forward"
+msgstr "Joan aurrera"
+
+#: ../src/html/helpwnd.cpp:658
+msgid "Go one level up in document hierarchy"
+msgstr "Joan maila bat gora agiri hierarkian"
+
+#: ../src/html/helpwnd.cpp:666 ../src/html/helpwnd.cpp:1547
+msgid "Open HTML document"
+msgstr "Ireki HTML agiria"
+
+#: ../src/html/helpwnd.cpp:670
+msgid "Print this page"
+msgstr "Irarkitu orrialde hau"
+
+#: ../src/html/helpwnd.cpp:674
+msgid "Display options dialog"
+msgstr "Erakutsi aukeren elkarrizketa"
+
+#: ../src/html/helpwnd.cpp:795
+msgid "Please choose the page to display:"
+msgstr "Mesedez hautatu erakusteko orrialdea:"
+
+#: ../src/html/helpwnd.cpp:796
+msgid "Help Topics"
+msgstr "Laguntza Gaiak"
+
+#: ../src/html/helpwnd.cpp:852
+msgid "Searching..."
+msgstr "Bilatzen...."
+
+#: ../src/html/helpwnd.cpp:853
+msgid "No matching page found yet"
+msgstr "Ez da bat datorren orrialderik aurkitu oraindik"
+
+#: ../src/html/helpwnd.cpp:870
+#, c-format
+msgid "Found %i matches"
+msgstr "Aurkituta %i bat egite"
+
+#: ../src/html/helpwnd.cpp:958
+msgid "(Help)"
+msgstr "(Laguntza)"
+
+#: ../src/html/helpwnd.cpp:1026
+#, c-format
+msgid "%d of %lu"
+msgstr "%d %lu-tik"
+
+#: ../src/html/helpwnd.cpp:1028
+#, c-format
+msgid "%lu of %lu"
+msgstr "%lu -> %lu-tik"
+
+#: ../src/html/helpwnd.cpp:1047
+msgid "Search in all books"
+msgstr "Bilatu liburu guztietan"
+
+#: ../src/html/helpwnd.cpp:1193
+msgid "Help Browser Options"
+msgstr "Laguntza Bilatzaile Aukerak"
+
+#: ../src/html/helpwnd.cpp:1198
+msgid "Normal font:"
+msgstr "Hizki arrunta:"
+
+#: ../src/html/helpwnd.cpp:1199
+msgid "Fixed font:"
+msgstr "Zuzendutako hizkia:"
+
+#: ../src/html/helpwnd.cpp:1200
+msgid "Font size:"
+msgstr "Hizki neurria:"
+
+#: ../src/html/helpwnd.cpp:1245
+msgid "font size"
+msgstr "hizki neurria"
+
+#: ../src/html/helpwnd.cpp:1256
+msgid "Normal face<br>and <u>underlined</u>. "
+msgstr "Alde arrunta<br>eta <u>azpimarratua</u>. "
+
+#: ../src/html/helpwnd.cpp:1257
+msgid "<i>Italic face.</i> "
+msgstr "<i>Alde etzana.</i> "
+
+#: ../src/html/helpwnd.cpp:1258
+msgid "<b>Bold face.</b> "
+msgstr "<b>Alde lodia..</b> "
+
+#: ../src/html/helpwnd.cpp:1259
+msgid "<b><i>Bold italic face.</i></b><br>"
+msgstr "<b><i>Alde etzan lodia.</i></b><br>"
+
+#: ../src/html/helpwnd.cpp:1262
+msgid "Fixed size face.<br> <b>bold</b> <i>italic</i> "
+msgstr "Zuzendutako neurri aldea.<br> <b>lodia</b> <i>etzana</i> "
+
+#: ../src/html/helpwnd.cpp:1263
+msgid "<b><i>bold italic <u>underlined</u></i></b><br>"
+msgstr "<b><i>lodi etzana <u>azpimarratuta</u></i></b><br>"
+
+#: ../src/html/helpwnd.cpp:1524
+msgid "Help Printing"
+msgstr "Laguntza Irarketa"
+
+#: ../src/html/helpwnd.cpp:1527
+msgid "Cannot print empty page."
+msgstr "Ezin da irarkitu orrialde hutsa."
+
+#: ../src/html/helpwnd.cpp:1540
+msgid "HTML files (*.html;*.htm)|*.html;*.htm|"
+msgstr "HTML agiriak (*.html;*.htm)|*.html;*.htm|"
+
+#: ../src/html/helpwnd.cpp:1541
+msgid "Help books (*.htb)|*.htb|Help books (*.zip)|*.zip|"
+msgstr "Laguntza liburuak (*.htb)|*.htb|Laguntza liburuak (*.zip)|*.zip|"
+
+#: ../src/html/helpwnd.cpp:1542
+msgid "HTML Help Project (*.hhp)|*.hhp|"
+msgstr "HTML Laguntza Egitasmoa (*.hhp)|*.hhp|"
+
+#: ../src/html/helpwnd.cpp:1544
+msgid "Compressed HTML Help file (*.chm)|*.chm|"
+msgstr "Konprimitutako HTML Laguntza agiria (*.chm)|*.chm|"
+
+#: ../src/html/helpwnd.cpp:1671
+#, c-format
+msgid "%i of %u"
+msgstr "%i -> %u-tik"
+
+#: ../src/html/helpwnd.cpp:1709
+#, c-format
+msgid "%u of %u"
+msgstr "%u -> %u-tik"
+
+#: ../src/html/htmlfilt.cpp:134
+#, c-format
+msgid "Cannot open HTML document: %s"
+msgstr "Ezin da ireki HTML agiria: %s"
+
+#: ../src/html/htmlwin.cpp:599
+msgid "Connecting..."
+msgstr "Elkarketatzen..."
+
+#: ../src/html/htmlwin.cpp:616
+#, c-format
+msgid "Unable to open requested HTML document: %s"
+msgstr "Ezinezkoa eskaturiko HTML agira irekitzea: %s"
+
+#: ../src/html/htmlwin.cpp:630
+msgid "Loading : "
+msgstr "Gertatzen :"
+
+#: ../src/html/htmlwin.cpp:673
+msgid "Done"
+msgstr "Eginda"
+
+#: ../src/html/htmlwin.cpp:723
+#, c-format
+msgid "HTML anchor %s does not exist."
+msgstr "HTML %s aingura ez dago."
+
+#: ../src/html/htmlwin.cpp:1057
+#, c-format
+msgid "Copied to clipboard:\"%s\""
+msgstr "Gakora kopiatuta:\"%s\""
+
+#: ../src/html/htmprint.cpp:269
+msgid ""
+"This document doesn't fit on the page horizontally and will be truncated "
+"when it is printed."
+msgstr ""
+"Agiri hau ez da orrialdean etzanka finkatzen eta itzulikatu egingo da "
+"irarkitzerakoan."
+
+#: ../src/html/htmprint.cpp:285
+#, c-format
+msgid ""
+"The document \"%s\" doesn't fit on the page horizontally and will be "
+"truncated if printed.\n"
+"\n"
+"Would you like to proceed with printing it nevertheless?"
+msgstr ""
+"\"%s\" agiria ez da orrialdean etzanka finkatzen eta itzulikatu egingo da "
+"irarkitzerakoan.\n"
+"\n"
+"Horrela ere irarkitzea nahi duzu?"
+
+#: ../src/html/htmprint.cpp:296
+msgid ""
+"If possible, try changing the layout parameters to make the printout more "
+"narrow."
+msgstr ""
+"Ahal bada, saiatu antolakuntza parametroak aldatzen irarketa estuagoa "
+"egiteko."
+
+#: ../src/html/htmprint.cpp:445
+msgid ": file does not exist!"
+msgstr ": agiria ez dago!"
+
+#. TRANSLATORS: %s may be a document title.
+#: ../src/html/htmprint.cpp:717
+#, fuzzy, c-format
+msgid "%s Preview"
+msgstr " Aurreikuspena"
+
+#: ../src/html/htmprint.cpp:755 ../src/richtext/richtextprint.cpp:618
+msgid ""
+"There was a problem during page setup: you may need to set a default printer."
+msgstr ""
+"Arazo bat egon da orrialde ezarpenean: badaiteke berezko irarkailu bat "
+"ezarri behar izatea. "
+
+#: ../src/msw/clipbrd.cpp:80
+msgid "Failed to open the clipboard."
+msgstr "Hutsegitea gakoa irekitzeakoan."
+
+#: ../src/msw/clipbrd.cpp:101
+msgid "Failed to close the clipboard."
+msgstr "Hutsegitea gakoa isterakoan."
+
+#: ../src/msw/clipbrd.cpp:113
+msgid "Failed to empty the clipboard."
+msgstr "Hutsegitea gakoa husterakoan."
+
+#: ../src/msw/clipbrd.cpp:284
+msgid "Failed to put data on the clipboard"
+msgstr "Hutsegitea datua gakoan jartzerakoan"
+
+#: ../src/msw/clipbrd.cpp:326
+msgid "Failed to get data from the clipboard"
+msgstr "Hutsegitea gakotik datuak lortzerakoan"
+
+#: ../src/msw/clipbrd.cpp:363
+msgid "Failed to retrieve the supported clipboard formats"
+msgstr "Hutsegitea gako heuskarri sostengatuak berreskuratzearakoan"
+
+#: ../src/msw/colordlg.cpp:228
+#, c-format
+msgid "Colour selection dialog failed with error %0lx."
+msgstr "Margo hautapen elkarrizketa hutsegitea %0lx akatsarekin."
+
+#: ../src/msw/cursor.cpp:141
+msgid "Failed to create cursor."
+msgstr "Hutsegitea kurtsorea sortzerakoan."
+
+#: ../src/msw/dde.cpp:279
+#, c-format
+msgid "Failed to register DDE server '%s'"
+msgstr "Hutsegitea '%s' DDE zerbitzaria erregistratzerakoan"
+
+#: ../src/msw/dde.cpp:300
+#, c-format
+msgid "Failed to unregister DDE server '%s'"
+msgstr "Hutsegitea '%s' DDE zerbitzaria erregistratu gabetzerakoan"
+
+#: ../src/msw/dde.cpp:428
+#, c-format
+msgid "Failed to create connection to server '%s' on topic '%s'"
+msgstr "Hutsegitea '%s' zerbitzariarekin '%s' gaian elkarketa sortzerakoan"
+
+#: ../src/msw/dde.cpp:655
+msgid "DDE poke request failed"
+msgstr "DDE eskabideak huts egin du"
+
+#: ../src/msw/dde.cpp:674
+msgid "Failed to establish an advise loop with DDE server"
+msgstr "Hutsegitea DDE zerbitzariarekin ohar bigizta ezartzerakoan"
+
+#: ../src/msw/dde.cpp:693
+msgid "Failed to terminate the advise loop with DDE server"
+msgstr "Hutsegitea DDE zerbitzariarekin ohar bigizta amaitzerakoan"
+
+#: ../src/msw/dde.cpp:768
+msgid "Failed to send DDE advise notification"
+msgstr "Hutsegitea DDE ohar jakinarazpena bildaltzerakoan"
+
+#: ../src/msw/dde.cpp:1085
+msgid "Failed to create DDE string"
+msgstr "Hutsegitea DDE katea sortzerakoan"
+
+#: ../src/msw/dde.cpp:1131
+msgid "no DDE error."
+msgstr "no DDE akatsa."
+
+#: ../src/msw/dde.cpp:1135
+msgid "a request for a synchronous advise transaction has timed out."
+msgstr "ohar eskualdaketa sinkrono baterako eskabidea denboraz-kanpo."
+
+#: ../src/msw/dde.cpp:1138
+msgid "the response to the transaction caused the DDE_FBUSY bit to be set."
+msgstr "eragiketaren erantzunak DDE_FBUSY bit zehaztea eragindu."
+
+#: ../src/msw/dde.cpp:1141
+msgid "a request for a synchronous data transaction has timed out."
+msgstr "datu eskualdaketa sinkrono baterako eskabidea denboraz-kanpo."
+
+#: ../src/msw/dde.cpp:1144
+msgid ""
+"a DDEML function was called without first calling the DdeInitialize "
+"function,\n"
+"or an invalid instance identifier\n"
+"was passed to a DDEML function."
+msgstr ""
+"DDEML eginkizun bat deitu da lehenik DdeInitialize eginkizuna deitu gabe,\n"
+"edo ekinbide ezagutarazle baliogabe bat\n"
+"pasatu da DDEML eginkizun batera."
+
+#: ../src/msw/dde.cpp:1147
+msgid ""
+"an application initialized as APPCLASS_MONITOR has\n"
+"attempted to perform a DDE transaction,\n"
+"or an application initialized as APPCMD_CLIENTONLY has \n"
+"attempted to perform server transactions."
+msgstr ""
+"APPCLASS_MONITOR bezala abiatutako aplikazio bat\n"
+"DDE transakzio bat egiten saiatu da,\n"
+"edo APPCMD_CLIENTONLY bezala abiatutako aplikazio bat \n"
+"zerbitzari transakzioak egiten saiatu da."
+
+#: ../src/msw/dde.cpp:1150
+msgid "a request for a synchronous execute transaction has timed out."
+msgstr "exekuzio eskualdaketa sinkrono baterako eskabidea denboraz-kanpo."
+
+#: ../src/msw/dde.cpp:1153
+msgid "a parameter failed to be validated by the DDEML."
+msgstr "paremetro batek huts egin du DDEML-ak balidatzerakoan."
+
+#: ../src/msw/dde.cpp:1156
+msgid "a DDEML application has created a prolonged race condition."
+msgstr "DDEML aplikazio batek lasterketa baldintza luzatu bat sortu du."
+
+#: ../src/msw/dde.cpp:1159
+msgid "a memory allocation failed."
+msgstr "oroimen esleipen hutsegitea."
+
+#: ../src/msw/dde.cpp:1162
+msgid "a client's attempt to establish a conversation has failed."
+msgstr "hutsegitea bezero baten elkarrizketa baten ezartze saiakeran"
+
+#: ../src/msw/dde.cpp:1165
+msgid "a transaction failed."
+msgstr "eskualdaketa hutsegitea."
+
+#: ../src/msw/dde.cpp:1168
+msgid "a request for a synchronous poke transaction has timed out."
+msgstr "sarrera eskualdaketa sinkrono baterako eskabidea denboraz-kanpo."
+
+#: ../src/msw/dde.cpp:1171
+msgid "an internal call to the PostMessage function has failed. "
+msgstr "PostMessage eginkizunerako barne deiak huts egin du."
+
+#: ../src/msw/dde.cpp:1174
+msgid "reentrancy problem."
+msgstr "birsarrera arazoa."
+
+#: ../src/msw/dde.cpp:1177
+msgid ""
+"a server-side transaction was attempted on a conversation\n"
+"that was terminated by the client, or the server\n"
+"terminated before completing a transaction."
+msgstr ""
+"zerbitzari-aldeko eskualdaketa elkarrizketa saiakera bat izan da\n"
+"bezeroak amaitu duena, edo zerbitzariak\n"
+"amaitu du eskualdaketa bat osatu aurretik."
+
+#: ../src/msw/dde.cpp:1180
+msgid "an internal error has occurred in the DDEML."
+msgstr "barne akats bat gertatu da DDEML-an."
+
+#: ../src/msw/dde.cpp:1183
+msgid "a request to end an advise transaction has timed out."
+msgstr "ohar eskualdaketa amaiera eskabidea denboraz-kanpo."
+
+#: ../src/msw/dde.cpp:1186
+msgid ""
+"an invalid transaction identifier was passed to a DDEML function.\n"
+"Once the application has returned from an XTYP_XACT_COMPLETE callback,\n"
+"the transaction identifier for that callback is no longer valid."
+msgstr ""
+"eskualdaketa ezagutarazle baliogabe bat pasatu da DDEML eginkizun batera.\n"
+"Behin aplikazioak XTYP_XACT_COMPLETE irizkizunetik erantzundakoan,\n"
+"irizkizun horretarako ezgutarazlea ez da baliogarria gehiago."
+
+#: ../src/msw/dde.cpp:1189
+#, c-format
+msgid "Unknown DDE error %08x"
+msgstr "DDE akats %08x ezezaguna"
+
+#: ../src/msw/dialup.cpp:343
+msgid ""
+"Dial up functions are unavailable because the remote access service (RAS) is "
+"not installed on this machine. Please install it."
+msgstr ""
+"Dei eginkizunak ez daude eskuragarri hurreneko sarbide zerbitzua (RAS) ez "
+"dagoelako ezarrita makina honetan. Mesedez ezarri ezazu."
+
+#: ../src/msw/dialup.cpp:402
+#, c-format
+msgid ""
+"The version of remote access service (RAS) installed on this machine is too "
+"old, please upgrade (the following required function is missing: %s)."
+msgstr ""
+"Gailu honetan ezarrita dagoen hurruneko sarbide zerbitzuaren (RAS) bertsioa "
+"oso zaharra da, mesedez eguneratu (ez dagoen beharrezkoa den eginkizuna: %s)."
+
+#: ../src/msw/dialup.cpp:437
+msgid "Failed to retrieve text of RAS error message"
+msgstr "Hutsegitea RAS akats mezutik idazkia berreskuratzerakoan"
+
+#: ../src/msw/dialup.cpp:440
+#, c-format
+msgid "unknown error (error code %08x)."
+msgstr "akats ezezaguana (kode akatsa %08x)."
+
+#: ../src/msw/dialup.cpp:492
+#, c-format
+msgid "Cannot find active dialup connection: %s"
+msgstr "Ezin da aurkitu urrutizkin elkarketa eragindua: %s"
+
+#: ../src/msw/dialup.cpp:513
+msgid "Several active dialup connections found, choosing one randomly."
+msgstr "Dei elkarketa ugari aurkitu dira lanean, zorizko bat hautatzen."
+
+#: ../src/msw/dialup.cpp:598 ../src/msw/dialup.cpp:832
+#, c-format
+msgid "Failed to establish dialup connection: %s"
+msgstr "Hutsegitea urrutizkin elkarketa ezartzerakoan: %s"
+
+#: ../src/msw/dialup.cpp:664
+#, c-format
+msgid "Failed to get ISP names: %s"
+msgstr "Hutsegitea ISP izenak lortzerakoan: %s"
+
+#: ../src/msw/dialup.cpp:712
+msgid "Failed to connect: no ISP to dial."
+msgstr "Hutsegitea elkarketatzerakoan:: ez dago ISP deitzeko."
+
+#: ../src/msw/dialup.cpp:732
+msgid "Choose ISP to dial"
+msgstr "Hautatu dialerako ISP-a"
+
+#: ../src/msw/dialup.cpp:733
+msgid "Please choose which ISP do you want to connect to"
+msgstr "Mesedez zein IZH-ra nahi duzun elkarketatzea"
+
+#: ../src/msw/dialup.cpp:766
+msgid "Failed to connect: missing username/password."
+msgstr "Hutsegitea elkarketatzerakoan: ez dago erabiltzaile-izen/sar-hitzik."
+
+#: ../src/msw/dialup.cpp:796
+msgid "Cannot find the location of address book file"
+msgstr "Ezin da aurkitu helbide liburu agiriaren kokalekua"
+
+#: ../src/msw/dialup.cpp:827
+#, c-format
+msgid "Failed to initiate dialup connection: %s"
+msgstr "Hutsegitea urrutizkin elkarketa hasterakoan: %s"
+
+#: ../src/msw/dialup.cpp:897
+msgid "Cannot hang up - no active dialup connection."
+msgstr "Ezinezkoa eskegitzea - ez dago dei elkarketarik lanean."
+
+#: ../src/msw/dialup.cpp:907
+#, c-format
+msgid "Failed to terminate the dialup connection: %s"
+msgstr "Hutsegitea urrutizkin elkarketa amaitzerakoan: %s"
+
+#: ../src/msw/dib.cpp:313
+#, c-format
+msgid "Failed to save the bitmap image to file \"%s\"."
+msgstr "Hutsegitea bitmapa irudia \"%s\" agirian gordetzerakoan."
+
+#: ../src/msw/dib.cpp:543
+#, c-format
+msgid "Failed to allocate %luKb of memory for bitmap data."
+msgstr "Hutsegitea bitmaparako oroimenaren %luKb-a esleitzerakoan."
+
+#: ../src/msw/dir.cpp:241
+#, c-format
+msgid "Cannot enumerate files in directory '%s'"
+msgstr "Ezin dira '%s' zuzenbidean agirak zenbakitu"
+
+#: ../src/msw/dirdlg.cpp:368
+msgid "Couldn't obtain folder name"
+msgstr "Ezinezkoa agiritegi izena lortzea"
+
+#: ../src/msw/dlmsw.cpp:163
+#, fuzzy, c-format
+msgid "(error %d: %s)"
+msgstr " (%ld akatsa: %s)"
+
+#: ../src/msw/dragimag.cpp:143 ../src/msw/dragimag.cpp:178
+#: ../src/msw/imaglist.cpp:309 ../src/msw/imaglist.cpp:331
+msgid "Couldn't add an image to the image list."
+msgstr "Ezinezkoa irudia gehitzea irudi zerrendara."
+
+#: ../src/msw/enhmeta.cpp:94
+#, c-format
+msgid "Failed to load metafile from file \"%s\"."
+msgstr "Hutsegita meta-agiria \"%s\" agiritik gertatzerakoan."
+
+#: ../src/msw/fdrepdlg.cpp:412
+#, c-format
+msgid "Failed to create the standard find/replace dialog (error code %d)"
+msgstr ""
+"Hutsegitea bilaketa estandarra/ordeztu elkarrizketa sortzerakoan (akats "
+"kodea %d)"
+
+#: ../src/msw/filedlg.cpp:1241
+msgid "Access to the file system is not allowed from secure desktop."
+msgstr ""
+
+#: ../src/msw/filedlg.cpp:1242
+msgid "Security warning"
+msgstr ""
+
+#: ../src/msw/filedlg.cpp:1533
+#, c-format
+msgid "File dialog failed with error code %0lx."
+msgstr "Agiri elkarrizketa hutsegitea %0lx akats kodearekin."
+
+#: ../src/msw/font.cpp:1120
+#, fuzzy, c-format
+msgid "Font file \"%s\" couldn't be loaded"
+msgstr "Agiria ezin da gertatu."
+
+#: ../src/msw/fontdlg.cpp:220
+#, c-format
+msgid "Common dialog failed with error code %0lx."
+msgstr "Elkarrizketa arrunt hutsegitea %0lx akats kodearekin."
+
+#: ../src/msw/fswatcher.cpp:67
+msgid "Ungraceful worker thread termination"
+msgstr "Langile hari amaiera zakartua"
+
+#: ../src/msw/fswatcher.cpp:81
+msgid "Unable to create IOCP worker thread"
+msgstr "Ezinezkoa IOCP langile haria sortzea"
+
+#: ../src/msw/fswatcher.cpp:88
+msgid "Unable to start IOCP worker thread"
+msgstr "Ezinezkoa hastea IOCP langile haria"
+
+#: ../src/msw/fswatcher.cpp:140
+msgid "Monitoring individual files for changes is not supported currently."
+msgstr "Banakako agiriak aldatzeko monitorizatzea orain ez dago sostengaturik."
+
+#: ../src/msw/fswatcher.cpp:165
+#, c-format
+msgid "Unable to set up watch for '%s'"
+msgstr "Ezinezkoa Unable to set up watch for '%s'"
+
+#: ../src/msw/fswatcher.cpp:466
+#, c-format
+msgid "Can't monitor non-existent directory \"%s\" for changes."
+msgstr "Ezin da monitorizatu ez-dagoen \"%s\" zuzenbidea aldaketetarako."
+
+#: ../src/msw/glcanvas.cpp:577 ../src/unix/glx11.cpp:507
+#, fuzzy
+msgid "OpenGL 3.0 or later is not supported by the OpenGL driver."
+msgstr "Core OpenGL profila ez dago sostengatuta OpenGL gidatzailean."
+
+#: ../src/msw/glcanvas.cpp:601 ../src/osx/glcanvas_osx.cpp:395
+#: ../src/unix/glegl.cpp:304 ../src/unix/glx11.cpp:553
+#, fuzzy
+msgid "Couldn't create OpenGL context"
+msgstr "Ezinezkoa denboragailu bat sortzea"
+
+#: ../src/msw/glcanvas.cpp:1294
+msgid "Failed to initialize OpenGL"
+msgstr "Hutsegitea OpenGL abiatzerakoan"
+
+#: ../src/msw/graphicsd2d.cpp:607
+msgid "Could not register custom DirectWrite font loader."
+msgstr ""
+
+#: ../src/msw/helpchm.cpp:48
+msgid ""
+"MS HTML Help functions are unavailable because the MS HTML Help library is "
+"not installed on this machine. Please install it."
+msgstr ""
+"MS HTML Laguntza eginkizunak ez daude eskuragarri MS HTML Laguntza "
+"liburutegia ez delako ezarri gailu honetan. Mesedez ezarri ezazu."
+
+#: ../src/msw/helpchm.cpp:55
+msgid "Failed to initialize MS HTML Help."
+msgstr "Hutsegitea MS HTML Laguntza abiatzerakoan."
+
+#: ../src/msw/iniconf.cpp:458
+#, c-format
+msgid "Can't delete the INI file '%s'"
+msgstr "Ezin da '%s' INI agiria ezabatu"
+
+#: ../src/msw/listctrl.cpp:995
+#, c-format
+msgid "Couldn't retrieve information about list control item %d."
+msgstr "Ezinezkoa %d zerrenda aginte gaiari buruzko argibideak berreskuratzea."
+
+#: ../src/msw/mdi.cpp:170 ../src/qt/mdi.cpp:253
+msgid "&Cascade"
+msgstr "&Urjauzia"
+
+#: ../src/msw/mdi.cpp:171
+msgid "Tile &Horizontally"
+msgstr "Teila &Etzana"
+
+#: ../src/msw/mdi.cpp:172
+msgid "Tile &Vertically"
+msgstr "Teila &Zutia"
+
+#: ../src/msw/mdi.cpp:174
+msgid "&Arrange Icons"
+msgstr "&Alderatu Ikurrak"
+
+#: ../src/msw/mdi.cpp:621
+msgid "Failed to create MDI parent frame."
+msgstr "Hutsegitea MDI gaineko framea sortzerakoan."
+
+#: ../src/msw/mimetype.cpp:234
+#, c-format
+msgid "Failed to create registry entry for '%s' files."
+msgstr "Hutsegitea '%s' agirientzak sarrera erregistroa sortzerakoan."
+
+#: ../src/msw/ole/automtn.cpp:495
+#, c-format
+msgid "Failed to find CLSID of \"%s\""
+msgstr "Hutsegitea \"%s\"-ren CLSID bilatzerakoan."
+
+#: ../src/msw/ole/automtn.cpp:512
+#, c-format
+msgid "Failed to create an instance of \"%s\""
+msgstr "Hutsegitea \"%s\" eskabidea sortzerakoan"
+
+#: ../src/msw/ole/automtn.cpp:552
+#, c-format
+msgid "Cannot get an active instance of \"%s\""
+msgstr "Ezinezkoa \"%s\"-ren eskabide aktibo bat lortzea"
+
+#: ../src/msw/ole/automtn.cpp:564
+#, c-format
+msgid "Failed to get OLE automation interface for \"%s\""
+msgstr "Hutsegitea \"%s\"-rentzat OLE berezgaitasun interfazea lortzerakoan"
+
+#: ../src/msw/ole/automtn.cpp:621
+msgid "Unknown name or named argument."
+msgstr "Izen edo izendapen argumentu ezezaguna"
+
+#: ../src/msw/ole/automtn.cpp:625
+msgid "Incorrect number of arguments."
+msgstr "Argumentu zenbateko okerra."
+
+#: ../src/msw/ole/automtn.cpp:637
+msgid "Unknown exception"
+msgstr "Salbuespen ezezaguna"
+
+#: ../src/msw/ole/automtn.cpp:642
+msgid "Method or property not found."
+msgstr "Metodoa edo ezaugarria ez da aurkitu."
+
+#: ../src/msw/ole/automtn.cpp:646
+msgid "Overflow while coercing argument values."
+msgstr "Gainezkatzea argumentu balioak behartzean."
+
+#: ../src/msw/ole/automtn.cpp:650
+msgid "Object implementation does not support named arguments."
+msgstr "Objetu inplementazioak ez du argumendu izendunik sostengatzen."
+
+#: ../src/msw/ole/automtn.cpp:654
+msgid "The locale ID is unknown."
+msgstr "Tokiko ID-a ezezaguna da."
+
+#: ../src/msw/ole/automtn.cpp:658
+msgid "Missing a required parameter."
+msgstr "Beharrezko parametroa ez dago:"
+
+#: ../src/msw/ole/automtn.cpp:662
+#, c-format
+msgid "Argument %u not found."
+msgstr "%u argumentoa ez da aurkitu."
+
+#: ../src/msw/ole/automtn.cpp:666
+#, c-format
+msgid "Type mismatch in argument %u."
+msgstr "Idaz bat ez etortzea %u argumentoan."
+
+#: ../src/msw/ole/automtn.cpp:670
+msgid "The system cannot find the file specified."
+msgstr "Sistemak ezin du adierazitako agiria aurkitu."
+
+#: ../src/msw/ole/automtn.cpp:674
+msgid "Class not registered."
+msgstr "Klase erregistratu gabe."
+
+#: ../src/msw/ole/automtn.cpp:678
+#, c-format
+msgid "Unknown error %08x"
+msgstr "Akats ezezaguna %08x"
+
+#: ../src/msw/ole/automtn.cpp:682
+#, c-format
+msgid "OLE Automation error in %s: %s"
+msgstr "OLE Berezgaitasun akatsa %s: %s"
+
+#: ../src/msw/ole/dataobj.cpp:385
+#, c-format
+msgid "Couldn't register clipboard format '%s'."
+msgstr "Ezinezkoa '%s' gako heuskarrri erregistratzea."
+
+#: ../src/msw/ole/dataobj.cpp:402
+#, c-format
+msgid "The clipboard format '%d' doesn't exist."
+msgstr "'%d' gako heuskarria ez dago."
+
+#: ../src/msw/progdlg.cpp:1025
+msgid "Skip"
+msgstr "Jauzi"
+
+#: ../src/msw/registry.cpp:141
+#, fuzzy, c-format
+msgid "unknown (%lu)"
+msgstr "ezezaguna"
+
+#: ../src/msw/registry.cpp:409
+#, c-format
+msgid "Can't get info about registry key '%s'"
+msgstr "Ezin da lortu '%s' giltzari buruzko argibiderik"
+
+#: ../src/msw/registry.cpp:445
+#, c-format
+msgid "Can't open registry key '%s'"
+msgstr "Ezin da '%s' erregistro giltza ireki"
+
+#: ../src/msw/registry.cpp:478
+#, c-format
+msgid "Can't create registry key '%s'"
+msgstr "Ezin da '%s' erregistro giltza sortu"
+
+#: ../src/msw/registry.cpp:497
+#, c-format
+msgid "Can't close registry key '%s'"
+msgstr "Ezin da '%s' erregistro giltza itxi"
+
+#: ../src/msw/registry.cpp:512
+#, c-format
+msgid "Registry value '%s' already exists."
+msgstr "'%s' erregistro balioa badago jadanik."
+
+#: ../src/msw/registry.cpp:520
+#, c-format
+msgid "Failed to rename registry value '%s' to '%s'."
+msgstr "Hutsegitea '%s' erregistro balioa '%s'-ra birrizendatzerakoan."
+
+#: ../src/msw/registry.cpp:575
+#, c-format
+msgid "Can't copy values of unsupported type %d."
+msgstr "Ezin dira %d hizkimota sostengatugabearen balioak kopiatu"
+
+#: ../src/msw/registry.cpp:586
+#, c-format
+msgid "Registry key '%s' does not exist, cannot rename it."
+msgstr "'%s' erregistro giltza ez dago, ezin da birrizendatu."
+
+#: ../src/msw/registry.cpp:617
+#, c-format
+msgid "Registry key '%s' already exists."
+msgstr "'%s' erregistro giltza jadanik badago."
+
+#: ../src/msw/registry.cpp:625
+#, c-format
+msgid "Failed to rename the registry key '%s' to '%s'."
+msgstr "Hutsegitea '%s' erregistro giltza '%s'-ra birrizendatzerakoan."
+
+#: ../src/msw/registry.cpp:670
+#, c-format
+msgid "Failed to copy the registry subkey '%s' to '%s'."
+msgstr "Hutsegitea '%s' erregistro azpigiltza '%s'-ra  kopiatzerakoan."
+
+#: ../src/msw/registry.cpp:683
+#, c-format
+msgid "Failed to copy registry value '%s'"
+msgstr "Hutsegitea '%s' erregistro balioa kopiatzerakoan"
+
+#: ../src/msw/registry.cpp:692
+#, c-format
+msgid "Failed to copy the contents of registry key '%s' to '%s'."
+msgstr "Hutsegitea '%s' erregistro giltzako edukiak '%s'-ra kopiatzerakoan."
+
+#: ../src/msw/registry.cpp:718
+#, c-format
+msgid ""
+"Registry key '%s' is needed for normal system operation,\n"
+"deleting it will leave your system in unusable state:\n"
+"operation aborted."
+msgstr ""
+"'%s' erregistro giltza beharrezkoa da sistemaren eragiketa normalerako,\n"
+"ezabatzen bada zure sistema erabiltezin geldituko da:\n"
+"eragiketa utzita."
+
+#: ../src/msw/registry.cpp:754
+#, c-format
+msgid "Can't delete key '%s'"
+msgstr "Ezin da '%s' giltza ezabatu"
+
+#: ../src/msw/registry.cpp:782
+#, c-format
+msgid "Can't delete value '%s' from key '%s'"
+msgstr "Ezin da '%s' balioa '%s' giltzatik ezabatu"
+
+#: ../src/msw/registry.cpp:855 ../src/msw/registry.cpp:887
+#: ../src/msw/registry.cpp:929 ../src/msw/registry.cpp:1000
+#, c-format
+msgid "Can't read value of key '%s'"
+msgstr "Ezin da '%s' giltzaren balioa irakurri"
+
+#: ../src/msw/registry.cpp:873 ../src/msw/registry.cpp:915
+#: ../src/msw/registry.cpp:963 ../src/msw/registry.cpp:1106
+#, c-format
+msgid "Can't set value of '%s'"
+msgstr "Ezin da '%s'-ren balioa ezarri"
+
+#: ../src/msw/registry.cpp:894 ../src/msw/registry.cpp:943
+#, c-format
+msgid "Registry value \"%s\" is not numeric (but of type %s)"
+msgstr ""
+
+#: ../src/msw/registry.cpp:979
+#, c-format
+msgid "Registry value \"%s\" is not binary (but of type %s)"
+msgstr ""
+
+#: ../src/msw/registry.cpp:1028
+#, c-format
+msgid "Registry value \"%s\" is not text (but of type %s)"
+msgstr ""
+
+#: ../src/msw/registry.cpp:1089
+#, c-format
+msgid "Can't read value of '%s'"
+msgstr "Ezin da '%s'-ren balioa irakurri"
+
+#: ../src/msw/registry.cpp:1157
+#, c-format
+msgid "Can't enumerate values of key '%s'"
+msgstr "Ezin dira '%s' giltzaren balioak zenbakitu"
+
+#: ../src/msw/registry.cpp:1196
+#, c-format
+msgid "Can't enumerate subkeys of key '%s'"
+msgstr "Ezin '%s' gitzaren azpigiltzak zenbakitu"
+
+#: ../src/msw/registry.cpp:1262
+#, c-format
+msgid ""
+"Exporting registry key: file \"%s\" already exists and won't be overwritten."
+msgstr ""
+"Esportatzen erregistro giltza: \"%s\" agiria jadanik badago eta ezin da "
+"gainidatzi."
+
+#: ../src/msw/registry.cpp:1411
+#, c-format
+msgid "Can't export value of unsupported type %d."
+msgstr "Ezin da %d hizkimota sostengugabetik balioa esportatu."
+
+#: ../src/msw/registry.cpp:1427
+#, c-format
+msgid "Ignoring value \"%s\" of the key \"%s\"."
+msgstr "\"%s\" giltzaren \"%s\" balioa ezikusten."
+
+#: ../src/msw/textctrl.cpp:596
+msgid ""
+"Impossible to create a rich edit control, using simple text control instead. "
+"Please reinstall riched32.dll"
+msgstr ""
+"Ezinezkoa aberastu edizio aginte bat sortzea, idazki arrunt agintea "
+"erabiltzen ordez. Mesedez berrezarri riched32.dll"
+
+#: ../src/msw/thread.cpp:522 ../src/unix/threadpsx.cpp:850
+msgid "Cannot start thread: error writing TLS."
+msgstr "Ezin da haria hasi: akatsa TLS idazterakoan."
+
+#: ../src/msw/thread.cpp:613
+msgid "Can't set thread priority"
+msgstr "Ezin da hari lehentasuna ezarri"
+
+#: ../src/msw/thread.cpp:649
+msgid "Can't create thread"
+msgstr "Ezin da haria sortu"
+
+#: ../src/msw/thread.cpp:668
+msgid "Couldn't terminate thread"
+msgstr "Ezinezkoa haria amaitzea"
+
+#: ../src/msw/thread.cpp:799
+msgid "Cannot wait for thread termination"
+msgstr "Ezin da hari amaiera itxaron"
+
+#: ../src/msw/thread.cpp:873
+#, c-format
+msgid "Cannot suspend thread %lx"
+msgstr "Ezin da %lx haria utzi"
+
+#: ../src/msw/thread.cpp:903
+#, c-format
+msgid "Cannot resume thread %lx"
+msgstr "Ezin da %lx haria kendu"
+
+#: ../src/msw/thread.cpp:932
+msgid "Couldn't get the current thread pointer"
+msgstr "Ezinezkoa oraingo hari puntua lortzea"
+
+#: ../src/msw/thread.cpp:1333
+msgid ""
+"Thread module initialization failed: impossible to allocate index in thread "
+"local storage"
+msgstr ""
+"Hari modulo abiarazpen hutsegitea: ezinezkoa aurkibidea esleitzea hariaren "
+"tokiko biltegian"
+
+#: ../src/msw/thread.cpp:1345
+msgid ""
+"Thread module initialization failed: cannot store value in thread local "
+"storage"
+msgstr ""
+"Hari modulo abiarazpen hutsegitea: ezinezkoa biltegiratzea balioa hariaren "
+"tokiko biltegian "
+
+#: ../src/msw/timer.cpp:133
+msgid "Couldn't create a timer"
+msgstr "Ezinezkoa denboragailu bat sortzea"
+
+#: ../src/msw/utils.cpp:372
+msgid "can't find user's HOME, using current directory."
+msgstr ""
+"ezin da aurkitu erabiltzailearen HASIERA, oraingo zuzenbidea erabiltzen."
+
+#: ../src/msw/utils.cpp:662
+#, c-format
+msgid "Failed to kill process %d"
+msgstr "Hutsegitea %d garapena hiltzerakoan"
+
+#: ../src/msw/utils.cpp:986
+#, c-format
+msgid "Failed to load resource \"%s\"."
+msgstr "Hutsegitea \"%s\" baliabidea gertatzerakoan."
+
+#: ../src/msw/utils.cpp:993
+#, c-format
+msgid "Failed to lock resource \"%s\"."
+msgstr "Hutsegitea \"%s\" baliabidea blokeatzerakoan."
+
+#. TRANSLATORS: MS Windows build number
+#: ../src/msw/utils.cpp:1209
+#, c-format
+msgid "build %lu"
+msgstr "%lu eraiketa"
+
+#: ../src/msw/utils.cpp:1218
+msgid ", 64-bit edition"
+msgstr ", 64-bit edizioa"
+
+#: ../src/msw/utilsexc.cpp:224
+msgid "Failed to create an anonymous pipe"
+msgstr "Hutsegitea izengabeko hodia sortzerakoan"
+
+#: ../src/msw/utilsexc.cpp:697
+msgid "Failed to redirect the child process IO"
+msgstr "Hutsegitea child garapen SI berbideratzerakoan"
+
+#: ../src/msw/utilsexc.cpp:870
+#, c-format
+msgid "Execution of command '%s' failed"
+msgstr "Hutsegitea '%s' komandoa exekutatzerakoan"
+
+#: ../src/msw/volume.cpp:337
+msgid "Failed to load mpr.dll."
+msgstr "Hutsegitea mpr.dll gertatzerakoan."
+
+#: ../src/msw/volume.cpp:506
+#, c-format
+msgid "Cannot read typename from '%s'!"
+msgstr "Ezinezkoa mota-izena '%s'-tik irakurtzea"
+
+#: ../src/msw/volume.cpp:615
+#, c-format
+msgid "Cannot load icon from '%s'."
+msgstr "Ezin da gertatu ikurra '%s'-tik."
+
+#: ../src/msw/webview_edge.cpp:285
+msgid "This program was compiled without support for setting Edge proxy."
+msgstr ""
+
+#: ../src/msw/webview_ie.cpp:1010
+msgid "Failed to find web view emulation level in the registry"
+msgstr ""
+
+#: ../src/msw/webview_ie.cpp:1019
+msgid "Failed to set web view to modern emulation level"
+msgstr ""
+
+#: ../src/msw/webview_ie.cpp:1027
+msgid "Failed to reset web view to standard emulation level"
+msgstr ""
+
+#: ../src/msw/webview_ie.cpp:1049
+msgid "Can't run JavaScript script without a valid HTML document"
+msgstr ""
+
+#: ../src/msw/webview_ie.cpp:1056
+#, fuzzy
+msgid "Can't get the JavaScript object"
+msgstr "Ezin da hari lehentasuna ezarri"
+
+#: ../src/msw/webview_ie.cpp:1070
+#, fuzzy
+msgid "failed to evaluate"
+msgstr "Hutsegitea '%s' exekutatzerakoan\n"
+
+#: ../src/osx/cocoa/filedlg.mm:412
+#, fuzzy
+msgid "File type:"
+msgstr "Teletipoa"
+
+#: ../src/osx/cocoa/menu.mm:242
+#, fuzzy
+msgctxt "macOS menu name"
+msgid "Window"
+msgstr "Leihoa"
+
+#: ../src/osx/cocoa/menu.mm:259
+#, fuzzy
+msgctxt "macOS menu name"
+msgid "Help"
+msgstr "Laguntza"
+
+#: ../src/osx/cocoa/menu.mm:298
+#, fuzzy
+msgctxt "macOS menu item"
+msgid "Minimize"
+msgstr "I&kurtu"
+
+#: ../src/osx/cocoa/menu.mm:303
+#, fuzzy
+msgctxt "macOS menu item"
+msgid "Zoom"
+msgstr "Zooma Handitu"
+
+#: ../src/osx/cocoa/menu.mm:309
+msgctxt "macOS menu item"
+msgid "Bring All to Front"
+msgstr ""
+
+#: ../src/osx/core/sound.cpp:143
+#, c-format
+msgid "Failed to load sound from \"%s\" (error %d)."
+msgstr "Hutsegitea soinua \"%s\"-tik gertatzerakoan (akatsa %d)."
+
+#: ../src/osx/fontutil.cpp:80
+#, fuzzy, c-format
+msgid "Font file \"%s\" doesn't exist."
+msgstr "%s agiria ez dago."
+
+#: ../src/osx/fontutil.cpp:88
+#, c-format
+msgid ""
+"Font file \"%s\" cannot be used as it is not inside the font directory "
+"\"%s\"."
+msgstr ""
+
+#: ../src/osx/menu_osx.cpp:496
+#, c-format
+msgctxt "macOS menu item"
+msgid "About %s"
+msgstr "%s-ri buruz"
+
+#: ../src/osx/menu_osx.cpp:499
+msgctxt "macOS menu item"
+msgid "About..."
+msgstr "Honi buruz..."
+
+#: ../src/osx/menu_osx.cpp:508
+msgctxt "macOS menu item"
+msgid "Preferences..."
+msgstr "Hobespenak..."
+
+#: ../src/osx/menu_osx.cpp:512
+msgctxt "macOS menu item"
+msgid "Services"
+msgstr "Zerbitzuak"
+
+#: ../src/osx/menu_osx.cpp:519
+#, c-format
+msgctxt "macOS menu item"
+msgid "Hide %s"
+msgstr "Ezkutatu %s"
+
+#: ../src/osx/menu_osx.cpp:522
+#, fuzzy
+msgctxt "macOS menu item"
+msgid "Hide Application"
+msgstr "Aplikazioa"
+
+#: ../src/osx/menu_osx.cpp:526
+msgctxt "macOS menu item"
+msgid "Hide Others"
+msgstr "Ezkutatu Besteak"
+
+#: ../src/osx/menu_osx.cpp:528
+msgctxt "macOS menu item"
+msgid "Show All"
+msgstr "Erakutsi Denak"
+
+#: ../src/osx/menu_osx.cpp:534
+#, c-format
+msgctxt "macOS menu item"
+msgid "Quit %s"
+msgstr "Utzi %s"
+
+#: ../src/osx/menu_osx.cpp:537
+#, fuzzy
+msgctxt "macOS menu item"
+msgid "Quit Application"
+msgstr "Aplikazioa"
+
+#: ../src/osx/webview_webkit.mm:444
+#, fuzzy
+msgid "Printing is not supported by the system web control"
+msgstr "Gzip ez dago sostengaturik zlib bertsio honetarako"
+
+#: ../src/osx/webview_webkit.mm:453
+#, fuzzy
+msgid "Print operation could not be initialized"
+msgstr "Zutabe azalpena ezin da abiarazi."
+
+#. TRANSLATORS: Label of font point size
+#: ../src/propgrid/advprops.cpp:605
+msgid "Point Size"
+msgstr "Puntu Neurria"
+
+#. TRANSLATORS: Label of font face name
+#: ../src/propgrid/advprops.cpp:615
+msgid "Face Name"
+msgstr "Aurpegi Izena"
+
+#. TRANSLATORS: Label of font style
+#: ../src/propgrid/advprops.cpp:623 ../src/richtext/richtextformatdlg.cpp:331
+msgid "Style"
+msgstr "Estiloa"
+
+#. TRANSLATORS: Label of font weight
+#: ../src/propgrid/advprops.cpp:628
+msgid "Weight"
+msgstr "Pisua"
+
+#. TRANSLATORS: Label of underlined font
+#: ../src/propgrid/advprops.cpp:633 ../src/richtext/richtextfontpage.cpp:358
+msgid "Underlined"
+msgstr "Azpimarratuta"
+
+#. TRANSLATORS: Label of font family
+#: ../src/propgrid/advprops.cpp:637
+msgid "Family"
+msgstr "Sendia"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:801
+msgid "AppWorkspace"
+msgstr "Aplik-Laningurua"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:802
+msgid "ActiveBorder"
+msgstr "Hertza-Gaituta"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:803
+msgid "ActiveCaption"
+msgstr "Harpena-Gaituta"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:804
+msgid "ButtonFace"
+msgstr "Botoi-Aldea"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:805
+msgid "ButtonHighlight"
+msgstr "Botoi-Nabarmentzea"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:806
+msgid "ButtonShadow"
+msgstr "Botoi-Itzala"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:807
+msgid "ButtonText"
+msgstr "Botoi-Idazkia"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:808
+msgid "CaptionText"
+msgstr "Idazki Larria"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:809
+msgid "ControlDark"
+msgstr "Aginte-Iluna"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:810
+msgid "ControlLight"
+msgstr "Aginte-Argia"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:812
+msgid "GrayText"
+msgstr "Urdainabar-Idazkia"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:813
+msgid "Highlight"
+msgstr "Nabarmendu"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:814
+msgid "HighlightText"
+msgstr "Nabarmendu-Idazkia"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:815
+msgid "InactiveBorder"
+msgstr "Hertza-Ezgaituta"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:816
+msgid "InactiveCaption"
+msgstr "Harpena-Ezgaituta"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:817
+msgid "InactiveCaptionText"
+msgstr "Harpen-Idazkia-Ezgaituta"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:818
+msgid "Menu"
+msgstr "Menua"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:819
+msgid "Scrollbar"
+msgstr "Irristabarra"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:820
+msgid "Tooltip"
+msgstr "Tresnaburu"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:821
+msgid "TooltipText"
+msgstr "Tresnaburu Idazkia"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:822
+msgid "Window"
+msgstr "Leihoa"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:823
+msgid "WindowFrame"
+msgstr "Leiho-Uztaia"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:824
+msgid "WindowText"
+msgstr "Leiho-Idazkia"
+
+#. TRANSLATORS: Custom colour choice entry
+#: ../src/propgrid/advprops.cpp:825 ../src/propgrid/advprops.cpp:1532
+#: ../src/propgrid/advprops.cpp:1576
+msgid "Custom"
+msgstr "Norberea"
+
+#: ../src/propgrid/advprops.cpp:1558
+msgid "Black"
+msgstr "Beltza"
+
+#: ../src/propgrid/advprops.cpp:1559
+msgid "Maroon"
+msgstr "Gorriluna"
+
+#: ../src/propgrid/advprops.cpp:1560
+msgid "Navy"
+msgstr "Itsas-urdina"
+
+#: ../src/propgrid/advprops.cpp:1561
+msgid "Purple"
+msgstr "Purpura"
+
+#: ../src/propgrid/advprops.cpp:1562
+msgid "Teal"
+msgstr "Zertzeta"
+
+#: ../src/propgrid/advprops.cpp:1563
+msgid "Gray"
+msgstr "Urdinabarra"
+
+#: ../src/propgrid/advprops.cpp:1564
+msgid "Green"
+msgstr "Orlegia"
+
+#: ../src/propgrid/advprops.cpp:1565
+msgid "Olive"
+msgstr "Oliba"
+
+#: ../src/propgrid/advprops.cpp:1566
+msgid "Brown"
+msgstr "Marroia"
+
+#: ../src/propgrid/advprops.cpp:1567
+msgid "Blue"
+msgstr "Urdina"
+
+#: ../src/propgrid/advprops.cpp:1568
+msgid "Fuchsia"
+msgstr "Fuksia"
+
+#: ../src/propgrid/advprops.cpp:1569
+msgid "Red"
+msgstr "Gorria"
+
+#: ../src/propgrid/advprops.cpp:1570
+msgid "Orange"
+msgstr "Laranja"
+
+#: ../src/propgrid/advprops.cpp:1571
+msgid "Silver"
+msgstr "Zilarra"
+
+#: ../src/propgrid/advprops.cpp:1572
+msgid "Lime"
+msgstr "Lima"
+
+#: ../src/propgrid/advprops.cpp:1573
+msgid "Aqua"
+msgstr "Ura"
+
+#: ../src/propgrid/advprops.cpp:1574
+msgid "Yellow"
+msgstr "Oria"
+
+#: ../src/propgrid/advprops.cpp:1575
+msgid "White"
+msgstr "Zuria"
+
+#: ../src/propgrid/advprops.cpp:1718
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Default"
+msgstr "Berezkoa"
+
+#: ../src/propgrid/advprops.cpp:1719
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Arrow"
+msgstr "Gezia"
+
+#: ../src/propgrid/advprops.cpp:1720
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Right Arrow"
+msgstr "Eskuin Gezia"
+
+#: ../src/propgrid/advprops.cpp:1721
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Blank"
+msgstr "Hutsik"
+
+#: ../src/propgrid/advprops.cpp:1722
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Bullseye"
+msgstr "Idibegia"
+
+#: ../src/propgrid/advprops.cpp:1723
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Character"
+msgstr "Hizkia"
+
+#: ../src/propgrid/advprops.cpp:1724
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Cross"
+msgstr "Zeharka"
+
+#: ../src/propgrid/advprops.cpp:1725
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Hand"
+msgstr "Eskua"
+
+#: ../src/propgrid/advprops.cpp:1726
+#, fuzzy
+msgctxt "system cursor name"
+msgid "I-Beam"
+msgstr "I-Beam"
+
+#: ../src/propgrid/advprops.cpp:1727
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Left Button"
+msgstr "Ezker Botoia"
+
+#: ../src/propgrid/advprops.cpp:1728
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Magnifier"
+msgstr "Handitzailea"
+
+#: ../src/propgrid/advprops.cpp:1729
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Middle Button"
+msgstr "Erdiko Botoia"
+
+#: ../src/propgrid/advprops.cpp:1730
+#, fuzzy
+msgctxt "system cursor name"
+msgid "No Entry"
+msgstr "Sarrerarik Ez"
+
+#: ../src/propgrid/advprops.cpp:1731
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Paint Brush"
+msgstr "Margoketa Brotxa"
+
+#: ../src/propgrid/advprops.cpp:1732
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Pencil"
+msgstr "Bolaluma"
+
+#: ../src/propgrid/advprops.cpp:1733
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Point Left"
+msgstr "Ezker Puntua"
+
+#: ../src/propgrid/advprops.cpp:1734
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Point Right"
+msgstr "Eskuin Puntua"
+
+#: ../src/propgrid/advprops.cpp:1735
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Question Arrow"
+msgstr "Galdera Gezia"
+
+#: ../src/propgrid/advprops.cpp:1736
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Right Button"
+msgstr "Eskuin Botoia"
+
+#: ../src/propgrid/advprops.cpp:1737
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Sizing NE-SW"
+msgstr "Neurritzen IE-HM"
+
+#: ../src/propgrid/advprops.cpp:1738
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Sizing N-S"
+msgstr "Neurritzen I-H"
+
+#: ../src/propgrid/advprops.cpp:1739
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Sizing NW-SE"
+msgstr "Neurritzen IM-HE"
+
+#: ../src/propgrid/advprops.cpp:1740
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Sizing W-E"
+msgstr "Neurritzen M-E"
+
+#: ../src/propgrid/advprops.cpp:1741
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Sizing"
+msgstr "Neurritzen"
+
+#: ../src/propgrid/advprops.cpp:1742
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Spraycan"
+msgstr "Spraycan"
+
+#: ../src/propgrid/advprops.cpp:1743
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Wait"
+msgstr "Itxaron"
+
+#: ../src/propgrid/advprops.cpp:1744
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Watch"
+msgstr "Behatu"
+
+#: ../src/propgrid/advprops.cpp:1745
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Wait Arrow"
+msgstr "Itxaron Gezia"
+
+#: ../src/propgrid/advprops.cpp:2109
+msgid "Make a selection:"
+msgstr "Egin hautapen bat:"
+
+#: ../src/propgrid/manager.cpp:394
+msgid "Property"
+msgstr "Ezaugarria"
+
+#: ../src/propgrid/manager.cpp:395
+msgid "Value"
+msgstr "Balioa"
+
+#: ../src/propgrid/manager.cpp:1683
+msgid "Categorized Mode"
+msgstr "Kategoriatutako Modua"
+
+#: ../src/propgrid/manager.cpp:1709
+msgid "Alphabetic Mode"
+msgstr "Alfabeto Moduan"
+
+#. TRANSLATORS: Name of Boolean false value
+#: ../src/propgrid/propgrid.cpp:230
+msgid "False"
+msgstr "Faltsua"
+
+#. TRANSLATORS: Name of Boolean true value
+#: ../src/propgrid/propgrid.cpp:232
+msgid "True"
+msgstr "Egia"
+
+#. TRANSLATORS: Text  displayed for unspecified value
+#: ../src/propgrid/propgrid.cpp:428
+msgid "Unspecified"
+msgstr "Zehaztugabea"
+
+#. TRANSLATORS: Caption of message box displaying any property error
+#: ../src/propgrid/propgrid.cpp:3145 ../src/propgrid/propgrid.cpp:3282
+msgid "Property Error"
+msgstr "Ezaugarri Akatsa"
+
+#: ../src/propgrid/propgrid.cpp:3259
+msgid "You have entered invalid value. Press ESC to cancel editing."
+msgstr "Balio okerra sartu duzu. Sakatu IRTEN edizioa ezeztatzeko."
+
+#: ../src/propgrid/propgrid.cpp:6608
+#, c-format
+msgid "Error in resource: %s"
+msgstr "Akatsa baliabidean: %s"
+
+#: ../src/propgrid/propgridiface.cpp:377
+#, c-format
+msgid ""
+"Type operation \"%s\" failed: Property labeled \"%s\" is of type \"%s\", NOT "
+"\"%s\"."
+msgstr ""
+" \"%s\" eragiketa hutsegitea:  \"%s\" ezaugarri etiketatua \"%s\" motakoa "
+"da, EZ \"%s\"."
+
+#: ../src/propgrid/props.cpp:159
+#, c-format
+msgid "Unknown base %d. Base 10 will be used."
+msgstr ""
+
+#: ../src/propgrid/props.cpp:324
+#, c-format
+msgid "Value must be %s or higher."
+msgstr "Baliloa izan behar da %s edo handiagoa."
+
+#: ../src/propgrid/props.cpp:329 ../src/propgrid/props.cpp:356
+#, c-format
+msgid "Value must be between %s and %s."
+msgstr "Balioa izan behar da %s eta %s artekoa."
+
+#: ../src/propgrid/props.cpp:351
+#, c-format
+msgid "Value must be %s or less."
+msgstr "Balioa izan behar da %s edo txikiagoa."
+
+#: ../src/propgrid/props.cpp:1058
+#, c-format
+msgid "Not %s"
+msgstr "Ez %s"
+
+#: ../src/propgrid/props.cpp:1770
+msgid "Choose a directory:"
+msgstr "Hautatu zuzenbide bat:"
+
+#: ../src/propgrid/props.cpp:2055
+msgid "Choose a file"
+msgstr "Hautatu agiri bat"
+
+#: ../src/qt/mdi.cpp:254
+msgid "&Tile"
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:147
+#: ../src/richtext/richtextformatdlg.cpp:376
+msgid "Background"
+msgstr "Barrena"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:159
+msgid "Background &colour:"
+msgstr "Barren &margoa:"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:161
+#: ../src/richtext/richtextbackgroundpage.cpp:163
+msgid "Enables a background colour."
+msgstr "Gaitu barren margoa."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:167
+#: ../src/richtext/richtextbackgroundpage.cpp:169
+msgid "The background colour."
+msgstr "Barren margoa."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:178
+msgid "Shadow"
+msgstr "Itzala"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:193
+msgid "Use &shadow"
+msgstr "Erabili &Itzala"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:195
+#: ../src/richtext/richtextbackgroundpage.cpp:197
+msgid "Enables a shadow."
+msgstr "Itzal bat gaitzen du."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:211
+msgid "&Horizontal offset:"
+msgstr "&Etzeneko oreka:"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:218
+#: ../src/richtext/richtextbackgroundpage.cpp:220
+msgid "The horizontal offset."
+msgstr "Etzaneko oreka."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:224
+#: ../src/richtext/richtextbackgroundpage.cpp:227
+#: ../src/richtext/richtextbackgroundpage.cpp:228
+#: ../src/richtext/richtextbackgroundpage.cpp:247
+#: ../src/richtext/richtextbackgroundpage.cpp:250
+#: ../src/richtext/richtextbackgroundpage.cpp:251
+#: ../src/richtext/richtextbackgroundpage.cpp:287
+#: ../src/richtext/richtextbackgroundpage.cpp:290
+#: ../src/richtext/richtextbackgroundpage.cpp:291
+#: ../src/richtext/richtextbackgroundpage.cpp:314
+#: ../src/richtext/richtextbackgroundpage.cpp:317
+#: ../src/richtext/richtextbackgroundpage.cpp:318
+#: ../src/richtext/richtextborderspage.cpp:252
+#: ../src/richtext/richtextborderspage.cpp:255
+#: ../src/richtext/richtextborderspage.cpp:256
+#: ../src/richtext/richtextborderspage.cpp:286
+#: ../src/richtext/richtextborderspage.cpp:289
+#: ../src/richtext/richtextborderspage.cpp:290
+#: ../src/richtext/richtextborderspage.cpp:320
+#: ../src/richtext/richtextborderspage.cpp:323
+#: ../src/richtext/richtextborderspage.cpp:324
+#: ../src/richtext/richtextborderspage.cpp:354
+#: ../src/richtext/richtextborderspage.cpp:357
+#: ../src/richtext/richtextborderspage.cpp:358
+#: ../src/richtext/richtextborderspage.cpp:420
+#: ../src/richtext/richtextborderspage.cpp:423
+#: ../src/richtext/richtextborderspage.cpp:424
+#: ../src/richtext/richtextborderspage.cpp:454
+#: ../src/richtext/richtextborderspage.cpp:457
+#: ../src/richtext/richtextborderspage.cpp:458
+#: ../src/richtext/richtextborderspage.cpp:488
+#: ../src/richtext/richtextborderspage.cpp:491
+#: ../src/richtext/richtextborderspage.cpp:492
+#: ../src/richtext/richtextborderspage.cpp:522
+#: ../src/richtext/richtextborderspage.cpp:525
+#: ../src/richtext/richtextborderspage.cpp:526
+#: ../src/richtext/richtextborderspage.cpp:590
+#: ../src/richtext/richtextborderspage.cpp:593
+#: ../src/richtext/richtextborderspage.cpp:594
+#: ../src/richtext/richtextfontpage.cpp:177
+#: ../src/richtext/richtextmarginspage.cpp:199
+#: ../src/richtext/richtextmarginspage.cpp:201
+#: ../src/richtext/richtextmarginspage.cpp:202
+#: ../src/richtext/richtextmarginspage.cpp:224
+#: ../src/richtext/richtextmarginspage.cpp:226
+#: ../src/richtext/richtextmarginspage.cpp:227
+#: ../src/richtext/richtextmarginspage.cpp:247
+#: ../src/richtext/richtextmarginspage.cpp:249
+#: ../src/richtext/richtextmarginspage.cpp:250
+#: ../src/richtext/richtextmarginspage.cpp:272
+#: ../src/richtext/richtextmarginspage.cpp:274
+#: ../src/richtext/richtextmarginspage.cpp:275
+#: ../src/richtext/richtextmarginspage.cpp:313
+#: ../src/richtext/richtextmarginspage.cpp:315
+#: ../src/richtext/richtextmarginspage.cpp:316
+#: ../src/richtext/richtextmarginspage.cpp:338
+#: ../src/richtext/richtextmarginspage.cpp:340
+#: ../src/richtext/richtextmarginspage.cpp:341
+#: ../src/richtext/richtextmarginspage.cpp:361
+#: ../src/richtext/richtextmarginspage.cpp:363
+#: ../src/richtext/richtextmarginspage.cpp:364
+#: ../src/richtext/richtextmarginspage.cpp:386
+#: ../src/richtext/richtextmarginspage.cpp:388
+#: ../src/richtext/richtextmarginspage.cpp:389
+#: ../src/richtext/richtextsizepage.cpp:337
+#: ../src/richtext/richtextsizepage.cpp:340
+#: ../src/richtext/richtextsizepage.cpp:341
+#: ../src/richtext/richtextsizepage.cpp:371
+#: ../src/richtext/richtextsizepage.cpp:374
+#: ../src/richtext/richtextsizepage.cpp:375
+#: ../src/richtext/richtextsizepage.cpp:398
+#: ../src/richtext/richtextsizepage.cpp:401
+#: ../src/richtext/richtextsizepage.cpp:402
+#: ../src/richtext/richtextsizepage.cpp:425
+#: ../src/richtext/richtextsizepage.cpp:428
+#: ../src/richtext/richtextsizepage.cpp:429
+#: ../src/richtext/richtextsizepage.cpp:452
+#: ../src/richtext/richtextsizepage.cpp:455
+#: ../src/richtext/richtextsizepage.cpp:456
+#: ../src/richtext/richtextsizepage.cpp:479
+#: ../src/richtext/richtextsizepage.cpp:482
+#: ../src/richtext/richtextsizepage.cpp:483
+#: ../src/richtext/richtextsizepage.cpp:553
+#: ../src/richtext/richtextsizepage.cpp:556
+#: ../src/richtext/richtextsizepage.cpp:557
+#: ../src/richtext/richtextsizepage.cpp:588
+#: ../src/richtext/richtextsizepage.cpp:591
+#: ../src/richtext/richtextsizepage.cpp:592
+#: ../src/richtext/richtextsizepage.cpp:623
+#: ../src/richtext/richtextsizepage.cpp:626
+#: ../src/richtext/richtextsizepage.cpp:627
+#: ../src/richtext/richtextsizepage.cpp:658
+#: ../src/richtext/richtextsizepage.cpp:661
+#: ../src/richtext/richtextsizepage.cpp:662
+msgid "px"
+msgstr "px"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:225
+#: ../src/richtext/richtextbackgroundpage.cpp:248
+#: ../src/richtext/richtextbackgroundpage.cpp:288
+#: ../src/richtext/richtextbackgroundpage.cpp:315
+#: ../src/richtext/richtextborderspage.cpp:253
+#: ../src/richtext/richtextborderspage.cpp:287
+#: ../src/richtext/richtextborderspage.cpp:321
+#: ../src/richtext/richtextborderspage.cpp:355
+#: ../src/richtext/richtextborderspage.cpp:421
+#: ../src/richtext/richtextborderspage.cpp:455
+#: ../src/richtext/richtextborderspage.cpp:489
+#: ../src/richtext/richtextborderspage.cpp:523
+#: ../src/richtext/richtextborderspage.cpp:591
+#: ../src/richtext/richtextmarginspage.cpp:200
+#: ../src/richtext/richtextmarginspage.cpp:225
+#: ../src/richtext/richtextmarginspage.cpp:248
+#: ../src/richtext/richtextmarginspage.cpp:273
+#: ../src/richtext/richtextmarginspage.cpp:314
+#: ../src/richtext/richtextmarginspage.cpp:339
+#: ../src/richtext/richtextmarginspage.cpp:362
+#: ../src/richtext/richtextmarginspage.cpp:387
+#: ../src/richtext/richtextsizepage.cpp:338
+#: ../src/richtext/richtextsizepage.cpp:372
+#: ../src/richtext/richtextsizepage.cpp:399
+#: ../src/richtext/richtextsizepage.cpp:426
+#: ../src/richtext/richtextsizepage.cpp:453
+#: ../src/richtext/richtextsizepage.cpp:480
+#: ../src/richtext/richtextsizepage.cpp:554
+#: ../src/richtext/richtextsizepage.cpp:589
+#: ../src/richtext/richtextsizepage.cpp:624
+#: ../src/richtext/richtextsizepage.cpp:659
+msgid "cm"
+msgstr "me"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:226
+#: ../src/richtext/richtextbackgroundpage.cpp:249
+#: ../src/richtext/richtextbackgroundpage.cpp:289
+#: ../src/richtext/richtextbackgroundpage.cpp:316
+#: ../src/richtext/richtextborderspage.cpp:254
+#: ../src/richtext/richtextborderspage.cpp:288
+#: ../src/richtext/richtextborderspage.cpp:322
+#: ../src/richtext/richtextborderspage.cpp:356
+#: ../src/richtext/richtextborderspage.cpp:422
+#: ../src/richtext/richtextborderspage.cpp:456
+#: ../src/richtext/richtextborderspage.cpp:490
+#: ../src/richtext/richtextborderspage.cpp:524
+#: ../src/richtext/richtextborderspage.cpp:592
+#: ../src/richtext/richtextfontpage.cpp:176
+#: ../src/richtext/richtextfontpage.cpp:179
+msgid "pt"
+msgstr "pt"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:229
+#: ../src/richtext/richtextbackgroundpage.cpp:231
+#: ../src/richtext/richtextbackgroundpage.cpp:252
+#: ../src/richtext/richtextbackgroundpage.cpp:254
+#: ../src/richtext/richtextbackgroundpage.cpp:292
+#: ../src/richtext/richtextbackgroundpage.cpp:294
+#: ../src/richtext/richtextbackgroundpage.cpp:319
+#: ../src/richtext/richtextbackgroundpage.cpp:321
+msgid "Units for this value."
+msgstr "Balio honentzako unitateak."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:234
+msgid "&Vertical offset:"
+msgstr "Z&utikako oreka:"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:241
+#: ../src/richtext/richtextbackgroundpage.cpp:243
+msgid "The vertical offset."
+msgstr "Zutikako oreka."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:257
+msgid "Shadow c&olour:"
+msgstr "Itzal &margoa:"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:259
+#: ../src/richtext/richtextbackgroundpage.cpp:261
+msgid "Enables the shadow colour."
+msgstr "Itzal margoa gaitzen du."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:265
+#: ../src/richtext/richtextbackgroundpage.cpp:267
+msgid "The shadow colour."
+msgstr "Itzal margoa."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:270
+msgid "Sh&adow spread:"
+msgstr "Itzal &barreiapena:"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:272
+#: ../src/richtext/richtextbackgroundpage.cpp:274
+msgid "Enables the shadow spread."
+msgstr "Itzal barreiapena gaitzen du."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:281
+#: ../src/richtext/richtextbackgroundpage.cpp:283
+msgid "The shadow spread."
+msgstr "Itzal barreiapena."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:297
+msgid "&Blur distance:"
+msgstr "&Lausotze hurruntasuna:"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:299
+#: ../src/richtext/richtextbackgroundpage.cpp:301
+msgid "Enables the blur distance."
+msgstr "Lausotze hurruntasuna gaitzen du."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:308
+#: ../src/richtext/richtextbackgroundpage.cpp:310
+msgid "The shadow blur distance."
+msgstr "Itzal lausotze hurruntasuna."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:324
+msgid "Opaci&ty:"
+msgstr "A&rgikazitasuna:"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:326
+#: ../src/richtext/richtextbackgroundpage.cpp:328
+msgid "Enables the shadow opacity."
+msgstr "Itzal argikaiztasuna gaitzen du."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:335
+#: ../src/richtext/richtextbackgroundpage.cpp:337
+msgid "The shadow opacity."
+msgstr "Itzal argikaiztasuna"
+
+#. TRANSLATORS: Rich text page units (percentage)
+#: ../src/richtext/richtextbackgroundpage.cpp:340
+#: ../src/richtext/richtextsizepage.cpp:339
+#: ../src/richtext/richtextsizepage.cpp:373
+#: ../src/richtext/richtextsizepage.cpp:400
+#: ../src/richtext/richtextsizepage.cpp:427
+#: ../src/richtext/richtextsizepage.cpp:454
+#: ../src/richtext/richtextsizepage.cpp:481
+#: ../src/richtext/richtextsizepage.cpp:555
+#: ../src/richtext/richtextsizepage.cpp:590
+#: ../src/richtext/richtextsizepage.cpp:625
+#: ../src/richtext/richtextsizepage.cpp:660
+msgid "%"
+msgstr "%"
+
+#: ../src/richtext/richtextborderspage.cpp:229
+#: ../src/richtext/richtextborderspage.cpp:387
+msgid "Border"
+msgstr "Hertza"
+
+#: ../src/richtext/richtextborderspage.cpp:242
+#: ../src/richtext/richtextborderspage.cpp:410
+#: ../src/richtext/richtextindentspage.cpp:194
+#: ../src/richtext/richtextliststylepage.cpp:384
+#: ../src/richtext/richtextmarginspage.cpp:185
+#: ../src/richtext/richtextmarginspage.cpp:299
+#: ../src/richtext/richtextsizepage.cpp:531
+#: ../src/richtext/richtextsizepage.cpp:538
+msgid "&Left:"
+msgstr "&Ezkerra:"
+
+#: ../src/richtext/richtextborderspage.cpp:257
+#: ../src/richtext/richtextborderspage.cpp:259
+msgid "Units for the left border width."
+msgstr "Ezker hertz zabalera unitateak."
+
+#: ../src/richtext/richtextborderspage.cpp:266
+#: ../src/richtext/richtextborderspage.cpp:268
+#: ../src/richtext/richtextborderspage.cpp:300
+#: ../src/richtext/richtextborderspage.cpp:302
+#: ../src/richtext/richtextborderspage.cpp:334
+#: ../src/richtext/richtextborderspage.cpp:336
+#: ../src/richtext/richtextborderspage.cpp:368
+#: ../src/richtext/richtextborderspage.cpp:370
+#: ../src/richtext/richtextborderspage.cpp:434
+#: ../src/richtext/richtextborderspage.cpp:436
+#: ../src/richtext/richtextborderspage.cpp:468
+#: ../src/richtext/richtextborderspage.cpp:470
+#: ../src/richtext/richtextborderspage.cpp:502
+#: ../src/richtext/richtextborderspage.cpp:504
+#: ../src/richtext/richtextborderspage.cpp:536
+#: ../src/richtext/richtextborderspage.cpp:538
+msgid "The border line style."
+msgstr "Hertzeko lerroaren estiloa."
+
+#: ../src/richtext/richtextborderspage.cpp:276
+#: ../src/richtext/richtextborderspage.cpp:444
+#: ../src/richtext/richtextindentspage.cpp:212
+#: ../src/richtext/richtextliststylepage.cpp:402
+#: ../src/richtext/richtextmarginspage.cpp:210
+#: ../src/richtext/richtextmarginspage.cpp:324
+#: ../src/richtext/richtextsizepage.cpp:601
+#: ../src/richtext/richtextsizepage.cpp:608
+msgid "&Right:"
+msgstr "&Eskuina:"
+
+#: ../src/richtext/richtextborderspage.cpp:291
+#: ../src/richtext/richtextborderspage.cpp:293
+msgid "Units for the right border width."
+msgstr "Eskuin hertz zabalera unitateak."
+
+#: ../src/richtext/richtextborderspage.cpp:310
+#: ../src/richtext/richtextborderspage.cpp:478
+#: ../src/richtext/richtextmarginspage.cpp:233
+#: ../src/richtext/richtextmarginspage.cpp:347
+#: ../src/richtext/richtextsizepage.cpp:566
+#: ../src/richtext/richtextsizepage.cpp:573
+msgid "&Top:"
+msgstr "G&oian:"
+
+#: ../src/richtext/richtextborderspage.cpp:325
+#: ../src/richtext/richtextborderspage.cpp:327
+msgid "Units for the top border width."
+msgstr "Goiko hertz zabalera unitateak."
+
+#: ../src/richtext/richtextborderspage.cpp:344
+#: ../src/richtext/richtextborderspage.cpp:512
+#: ../src/richtext/richtextmarginspage.cpp:258
+#: ../src/richtext/richtextmarginspage.cpp:372
+#: ../src/richtext/richtextsizepage.cpp:636
+#: ../src/richtext/richtextsizepage.cpp:643
+msgid "&Bottom:"
+msgstr "&Behean:"
+
+#: ../src/richtext/richtextborderspage.cpp:359
+#: ../src/richtext/richtextborderspage.cpp:361
+msgid "Units for the bottom border width."
+msgstr "Beheko hertz zabalera unitateak."
+
+#: ../src/richtext/richtextborderspage.cpp:380
+#: ../src/richtext/richtextborderspage.cpp:548
+msgid "&Synchronize values"
+msgstr "&Aldiberetu balioak"
+
+#: ../src/richtext/richtextborderspage.cpp:382
+#: ../src/richtext/richtextborderspage.cpp:384
+#: ../src/richtext/richtextborderspage.cpp:550
+#: ../src/richtext/richtextborderspage.cpp:552
+msgid "Check to edit all borders simultaneously."
+msgstr "Hautatu hertz guztiak aldiberean editatzeko"
+
+#: ../src/richtext/richtextborderspage.cpp:397
+#: ../src/richtext/richtextborderspage.cpp:555
+msgid "Outline"
+msgstr "Ingurua"
+
+#: ../src/richtext/richtextborderspage.cpp:425
+#: ../src/richtext/richtextborderspage.cpp:427
+msgid "Units for the left outline width."
+msgstr "Ezkerreko inguru zabalera unitateak."
+
+#: ../src/richtext/richtextborderspage.cpp:459
+#: ../src/richtext/richtextborderspage.cpp:461
+msgid "Units for the right outline width."
+msgstr "Eskuin inguru zabalera unitateak."
+
+#: ../src/richtext/richtextborderspage.cpp:493
+#: ../src/richtext/richtextborderspage.cpp:495
+msgid "Units for the top outline width."
+msgstr "Goiko inguru zabalera unitateak."
+
+#: ../src/richtext/richtextborderspage.cpp:527
+#: ../src/richtext/richtextborderspage.cpp:529
+msgid "Units for the bottom outline width."
+msgstr "Beheko inguru zabalera unitateak."
+
+#: ../src/richtext/richtextborderspage.cpp:565
+#: ../src/richtext/richtextborderspage.cpp:600
+msgid "Corner"
+msgstr "Bazterrra"
+
+#: ../src/richtext/richtextborderspage.cpp:574
+msgid "Corner &radius:"
+msgstr "Bazter er&radioa:"
+
+#: ../src/richtext/richtextborderspage.cpp:576
+#: ../src/richtext/richtextborderspage.cpp:578
+msgid "An optional corner radius for adding rounded corners."
+msgstr "Aukerazko bazterreko erradio bat inguru bazterrak gehitzeko."
+
+#: ../src/richtext/richtextborderspage.cpp:584
+#: ../src/richtext/richtextborderspage.cpp:586
+msgid "The value of the corner radius."
+msgstr "Bazterreko erradioaren balioa."
+
+#: ../src/richtext/richtextborderspage.cpp:595
+#: ../src/richtext/richtextborderspage.cpp:597
+msgid "Units for the corner radius."
+msgstr "Bazterreko erradiorako unitateak."
+
+#: ../src/richtext/richtextborderspage.cpp:609
+#: ../src/richtext/richtextsizepage.cpp:247
+#: ../src/richtext/richtextsizepage.cpp:251
+msgid "None"
+msgstr "Bat ere ez"
+
+#: ../src/richtext/richtextborderspage.cpp:610
+msgid "Solid"
+msgstr "Solidoa"
+
+#: ../src/richtext/richtextborderspage.cpp:611
+msgid "Dotted"
+msgstr "Puntukatuta"
+
+#: ../src/richtext/richtextborderspage.cpp:612
+msgid "Dashed"
+msgstr "elkar-marratuta"
+
+#: ../src/richtext/richtextborderspage.cpp:613
+msgid "Double"
+msgstr "Bikoitza"
+
+#: ../src/richtext/richtextborderspage.cpp:614
+msgid "Groove"
+msgstr "Groove"
+
+#: ../src/richtext/richtextborderspage.cpp:615
+msgid "Ridge"
+msgstr "Haria"
+
+#: ../src/richtext/richtextborderspage.cpp:616
+msgid "Inset"
+msgstr "Sartu"
+
+#: ../src/richtext/richtextborderspage.cpp:617
+msgid "Outset"
+msgstr "Hasiera"
+
+#: ../src/richtext/richtextbuffer.cpp:3518
+msgid "Change Style"
+msgstr "Aldatu Estiloa"
+
+#: ../src/richtext/richtextbuffer.cpp:3701
+msgid "Change Object Style"
+msgstr "Aldatu Objetu Estiloa"
+
+#: ../src/richtext/richtextbuffer.cpp:3974
+#: ../src/richtext/richtextbuffer.cpp:8174
+msgid "Change Properties"
+msgstr "Aldatu Ezaugarriak"
+
+#: ../src/richtext/richtextbuffer.cpp:4346
+msgid "Change List Style"
+msgstr "Aldatu Zerrenda Estiloa"
+
+#: ../src/richtext/richtextbuffer.cpp:4519
+msgid "Renumber List"
+msgstr "Birzenbakitu Zerrenda"
+
+#: ../src/richtext/richtextbuffer.cpp:7867
+#: ../src/richtext/richtextbuffer.cpp:7897
+#: ../src/richtext/richtextbuffer.cpp:7939
+#: ../src/richtext/richtextctrl.cpp:1279 ../src/richtext/richtextctrl.cpp:1473
+msgid "Insert Text"
+msgstr "Sartu Idazkia"
+
+#: ../src/richtext/richtextbuffer.cpp:8023
+#: ../src/richtext/richtextbuffer.cpp:8979
+msgid "Insert Image"
+msgstr "Sartu Irudia"
+
+#: ../src/richtext/richtextbuffer.cpp:8070
+msgid "Insert Object"
+msgstr "Sartu Objetua"
+
+#: ../src/richtext/richtextbuffer.cpp:8112
+msgid "Insert Field"
+msgstr "Txertatu Eremua"
+
+#: ../src/richtext/richtextbuffer.cpp:8410
+msgid "Too many EndStyle calls!"
+msgstr "EndStyle dei gehiegi!"
+
+#: ../src/richtext/richtextbuffer.cpp:8785
+msgid "files"
+msgstr "agiriak"
+
+#: ../src/richtext/richtextbuffer.cpp:9380
+msgid "standard/circle"
+msgstr "estandarra/borobila"
+
+#: ../src/richtext/richtextbuffer.cpp:9381
+msgid "standard/circle-outline"
+msgstr "estandarra/borobil-ingurua"
+
+#: ../src/richtext/richtextbuffer.cpp:9382
+msgid "standard/square"
+msgstr "estandarra/laukia"
+
+#: ../src/richtext/richtextbuffer.cpp:9383
+msgid "standard/diamond"
+msgstr "estandarra/diamantea"
+
+#: ../src/richtext/richtextbuffer.cpp:9384
+msgid "standard/triangle"
+msgstr "estandarra/hirukia"
+
+#: ../src/richtext/richtextbuffer.cpp:9423
+msgid "Box Properties"
+msgstr "Kutxaren Ezaugarriak"
+
+#: ../src/richtext/richtextbuffer.cpp:10006
+msgid "Multiple Cell Properties"
+msgstr "Gelaxka Anitz Ezaugarriak"
+
+#: ../src/richtext/richtextbuffer.cpp:10008
+msgid "Cell Properties"
+msgstr "Gelaxka Ezaugarriak"
+
+#: ../src/richtext/richtextbuffer.cpp:11256
+msgid "Set Cell Style"
+msgstr "Ezarri Gelaxka estiloa"
+
+#: ../src/richtext/richtextbuffer.cpp:11330
+msgid "Delete Row"
+msgstr "Ezabatu Lerroa"
+
+#: ../src/richtext/richtextbuffer.cpp:11380
+msgid "Delete Column"
+msgstr "Ezabatu Zutabea"
+
+#: ../src/richtext/richtextbuffer.cpp:11431
+msgid "Add Row"
+msgstr "Gehitu Lerroa"
+
+#: ../src/richtext/richtextbuffer.cpp:11494
+msgid "Add Column"
+msgstr "Gehitu Zutabea"
+
+#: ../src/richtext/richtextbuffer.cpp:11537
+msgid "Table Properties"
+msgstr "Taula Ezaugarriak"
+
+#: ../src/richtext/richtextbuffer.cpp:12899
+msgid "Picture Properties"
+msgstr "Irudiaren Ezaugarriak"
+
+#: ../src/richtext/richtextbuffer.cpp:13169
+#: ../src/richtext/richtextbuffer.cpp:13279
+msgid "image"
+msgstr "irudia"
+
+#: ../src/richtext/richtextbulletspage.cpp:145
+#: ../src/richtext/richtextliststylepage.cpp:209
+msgid "&Bullet style:"
+msgstr "&Buleta estiloa:"
+
+#: ../src/richtext/richtextbulletspage.cpp:150
+#: ../src/richtext/richtextbulletspage.cpp:152
+#: ../src/richtext/richtextliststylepage.cpp:214
+#: ../src/richtext/richtextliststylepage.cpp:216
+msgid "The available bullet styles."
+msgstr "Bulet estilo eskuragarriak."
+
+#: ../src/richtext/richtextbulletspage.cpp:158
+#: ../src/richtext/richtextliststylepage.cpp:221
+msgid "Peri&od"
+msgstr "Al&dia"
+
+#: ../src/richtext/richtextbulletspage.cpp:160
+#: ../src/richtext/richtextbulletspage.cpp:162
+#: ../src/richtext/richtextliststylepage.cpp:223
+#: ../src/richtext/richtextliststylepage.cpp:225
+msgid "Check to add a period after the bullet."
+msgstr "Hautatu aldi bat gehitzeko buletaren ondoren."
+
+#. TRANSLATORS: Bullet point in parentheses option
+#: ../src/richtext/richtextbulletspage.cpp:167
+#: ../src/richtext/richtextliststylepage.cpp:230
+msgid "(*)"
+msgstr "(*)"
+
+#: ../src/richtext/richtextbulletspage.cpp:169
+#: ../src/richtext/richtextbulletspage.cpp:171
+#: ../src/richtext/richtextliststylepage.cpp:232
+#: ../src/richtext/richtextliststylepage.cpp:234
+msgid "Check to enclose the bullet in parentheses."
+msgstr "Hautatu buletak hitzartean jartzeko."
+
+#. TRANSLATORS: Right parenthesis bullet point option
+#: ../src/richtext/richtextbulletspage.cpp:176
+#: ../src/richtext/richtextliststylepage.cpp:239
+msgid "*)"
+msgstr "*)"
+
+#: ../src/richtext/richtextbulletspage.cpp:178
+#: ../src/richtext/richtextbulletspage.cpp:180
+#: ../src/richtext/richtextliststylepage.cpp:241
+#: ../src/richtext/richtextliststylepage.cpp:243
+msgid "Check to add a right parenthesis."
+msgstr "Hautatu eskuin hitzarte bat gehitzeko"
+
+#: ../src/richtext/richtextbulletspage.cpp:185
+#: ../src/richtext/richtextliststylepage.cpp:248
+msgid "Bullet &Alignment:"
+msgstr "Buleta &Lerrokapena:"
+
+#: ../src/richtext/richtextbulletspage.cpp:190
+#: ../src/richtext/richtextliststylepage.cpp:253
+msgid "Centre"
+msgstr "Erdian"
+
+#: ../src/richtext/richtextbulletspage.cpp:194
+#: ../src/richtext/richtextbulletspage.cpp:196
+#: ../src/richtext/richtextbulletspage.cpp:217
+#: ../src/richtext/richtextbulletspage.cpp:219
+#: ../src/richtext/richtextliststylepage.cpp:257
+#: ../src/richtext/richtextliststylepage.cpp:259
+#: ../src/richtext/richtextliststylepage.cpp:278
+#: ../src/richtext/richtextliststylepage.cpp:280
+msgid "The bullet character."
+msgstr "Buleta ikurra."
+
+#: ../src/richtext/richtextbulletspage.cpp:212
+#: ../src/richtext/richtextliststylepage.cpp:271
+msgid "&Symbol:"
+msgstr "&Ikurra:"
+
+#: ../src/richtext/richtextbulletspage.cpp:222
+#: ../src/richtext/richtextliststylepage.cpp:283
+msgid "Ch&oose..."
+msgstr "&Hautatu..."
+
+#: ../src/richtext/richtextbulletspage.cpp:223
+#: ../src/richtext/richtextbulletspage.cpp:225
+#: ../src/richtext/richtextliststylepage.cpp:284
+#: ../src/richtext/richtextliststylepage.cpp:286
+msgid "Click to browse for a symbol."
+msgstr "Klikatu ikur bat bilatzeko."
+
+#: ../src/richtext/richtextbulletspage.cpp:230
+#: ../src/richtext/richtextliststylepage.cpp:291
+msgid "Symbol &font:"
+msgstr "Ikur &hizkia:"
+
+#: ../src/richtext/richtextbulletspage.cpp:235
+#: ../src/richtext/richtextbulletspage.cpp:237
+#: ../src/richtext/richtextliststylepage.cpp:297
+msgid "Available fonts."
+msgstr "Hizki eskuragarriak."
+
+#: ../src/richtext/richtextbulletspage.cpp:242
+#: ../src/richtext/richtextliststylepage.cpp:302
+msgid "S&tandard bullet name:"
+msgstr "B&uleta izen estandarra:"
+
+#: ../src/richtext/richtextbulletspage.cpp:247
+#: ../src/richtext/richtextbulletspage.cpp:249
+#: ../src/richtext/richtextliststylepage.cpp:307
+#: ../src/richtext/richtextliststylepage.cpp:309
+msgid "A standard bullet name."
+msgstr "Buleta izen estandarra."
+
+#: ../src/richtext/richtextbulletspage.cpp:254
+msgid "&Number:"
+msgstr "&Zenbakia:"
+
+#: ../src/richtext/richtextbulletspage.cpp:258
+#: ../src/richtext/richtextbulletspage.cpp:260
+msgid "The list item number."
+msgstr "Zerrendaren gai zenbatekoa."
+
+#: ../src/richtext/richtextbulletspage.cpp:266
+#: ../src/richtext/richtextbulletspage.cpp:268
+#: ../src/richtext/richtextliststylepage.cpp:475
+#: ../src/richtext/richtextliststylepage.cpp:477
+msgid "Shows a preview of the bullet settings."
+msgstr "Buleta ezarpenen aurreikuspen bat erakusten du."
+
+#: ../src/richtext/richtextbulletspage.cpp:276
+#: ../src/richtext/richtextliststylepage.cpp:484
+msgid "(None)"
+msgstr "(Bat ere ez)"
+
+#: ../src/richtext/richtextbulletspage.cpp:277
+#: ../src/richtext/richtextliststylepage.cpp:485
+msgid "Arabic"
+msgstr "Arabiera"
+
+#: ../src/richtext/richtextbulletspage.cpp:278
+#: ../src/richtext/richtextliststylepage.cpp:486
+msgid "Upper case letters"
+msgstr "Hizki larriak"
+
+#: ../src/richtext/richtextbulletspage.cpp:279
+#: ../src/richtext/richtextliststylepage.cpp:487
+msgid "Lower case letters"
+msgstr "Hizki xeheak"
+
+#: ../src/richtext/richtextbulletspage.cpp:280
+#: ../src/richtext/richtextliststylepage.cpp:488
+msgid "Upper case roman numerals"
+msgstr "Zenbaki erromatarrak hizki larrietan"
+
+#: ../src/richtext/richtextbulletspage.cpp:281
+#: ../src/richtext/richtextliststylepage.cpp:489
+msgid "Lower case roman numerals"
+msgstr "Zenbaki erromatarrak hizki xehetan"
+
+#: ../src/richtext/richtextbulletspage.cpp:282
+#: ../src/richtext/richtextliststylepage.cpp:490
+msgid "Numbered outline"
+msgstr "Zenbakituriko ingurua"
+
+#: ../src/richtext/richtextbulletspage.cpp:283
+#: ../src/richtext/richtextliststylepage.cpp:491
+msgid "Symbol"
+msgstr "Ikurra"
+
+#: ../src/richtext/richtextbulletspage.cpp:284
+#: ../src/richtext/richtextliststylepage.cpp:492
+msgid "Bitmap"
+msgstr "Bitmapa"
+
+#: ../src/richtext/richtextbulletspage.cpp:285
+#: ../src/richtext/richtextliststylepage.cpp:493
+msgid "Standard"
+msgstr "Estandarra"
+
+#: ../src/richtext/richtextbulletspage.cpp:287
+#: ../src/richtext/richtextliststylepage.cpp:495
+msgid "*"
+msgstr "*"
+
+#: ../src/richtext/richtextbulletspage.cpp:288
+#: ../src/richtext/richtextliststylepage.cpp:496
+msgid "-"
+msgstr "-"
+
+#: ../src/richtext/richtextbulletspage.cpp:289
+#: ../src/richtext/richtextliststylepage.cpp:497
+msgid ">"
+msgstr ">"
+
+#: ../src/richtext/richtextbulletspage.cpp:290
+#: ../src/richtext/richtextliststylepage.cpp:498
+msgid "+"
+msgstr "+"
+
+#: ../src/richtext/richtextbulletspage.cpp:291
+#: ../src/richtext/richtextliststylepage.cpp:499
+msgid "~"
+msgstr "~"
+
+#: ../src/richtext/richtextctrl.cpp:859
+msgid "Drag"
+msgstr "Harrastatu"
+
+#: ../src/richtext/richtextctrl.cpp:1338 ../src/richtext/richtextctrl.cpp:1559
+msgid "Delete Text"
+msgstr "Ezabatu Idazkia"
+
+#: ../src/richtext/richtextctrl.cpp:1537
+msgid "Remove Bullet"
+msgstr "Kendu Buleta"
+
+#: ../src/richtext/richtextctrl.cpp:3070
+msgid "The text couldn't be saved."
+msgstr "Idazkia ezin da gorde."
+
+#: ../src/richtext/richtextctrl.cpp:3644
+msgid "Replace"
+msgstr "Ordeztu"
+
+#: ../src/richtext/richtextfontpage.cpp:146
+#: ../src/richtext/richtextsymboldlg.cpp:384
+msgid "&Font:"
+msgstr "&Hizkia:"
+
+#: ../src/richtext/richtextfontpage.cpp:150
+#: ../src/richtext/richtextfontpage.cpp:152
+msgid "Type a font name."
+msgstr "Idatzi hizki izen bat."
+
+#: ../src/richtext/richtextfontpage.cpp:158
+msgid "&Size:"
+msgstr "&Neurria:"
+
+#: ../src/richtext/richtextfontpage.cpp:165
+#: ../src/richtext/richtextfontpage.cpp:167
+msgid "Type a size in points."
+msgstr "Idatzi neurri bat puntutan."
+
+#: ../src/richtext/richtextfontpage.cpp:180
+#: ../src/richtext/richtextfontpage.cpp:182
+msgid "The font size units, points or pixels."
+msgstr "Hizki neurri batasuna, puntutak edo pixelak."
+
+#: ../src/richtext/richtextfontpage.cpp:189
+#: ../src/richtext/richtextfontpage.cpp:191
+msgid "Lists the available fonts."
+msgstr "Hizki eskuragarrien zerrenda"
+
+#: ../src/richtext/richtextfontpage.cpp:196
+#: ../src/richtext/richtextfontpage.cpp:198
+msgid "Lists font sizes in points."
+msgstr "Hizki neurriak puntutan zerrenda."
+
+#: ../src/richtext/richtextfontpage.cpp:207
+msgid "Font st&yle:"
+msgstr "Hizki es&tiloa:"
+
+#: ../src/richtext/richtextfontpage.cpp:212
+#: ../src/richtext/richtextfontpage.cpp:214
+msgid "Select regular or italic style."
+msgstr "Hautatu arrunt edo etzan estiloa."
+
+#: ../src/richtext/richtextfontpage.cpp:220
+msgid "Font &weight:"
+msgstr "Hizki &zabalera:"
+
+#: ../src/richtext/richtextfontpage.cpp:225
+#: ../src/richtext/richtextfontpage.cpp:227
+msgid "Select regular or bold."
+msgstr "Hautatu arrunt edo lodi."
+
+#: ../src/richtext/richtextfontpage.cpp:233
+msgid "&Underlining:"
+msgstr "&Azpimarraketa:"
+
+#: ../src/richtext/richtextfontpage.cpp:238
+#: ../src/richtext/richtextfontpage.cpp:240
+msgid "Select underlining or no underlining."
+msgstr "Hautatu azpimarratuta edo ez azpimarratuta."
+
+#: ../src/richtext/richtextfontpage.cpp:248
+msgid "&Colour:"
+msgstr "&Margoa:"
+
+#: ../src/richtext/richtextfontpage.cpp:253
+#: ../src/richtext/richtextfontpage.cpp:255
+msgid "Click to change the text colour."
+msgstr "Klikatu idazki margoa aldatzeko."
+
+#: ../src/richtext/richtextfontpage.cpp:261
+msgid "&Bg colour:"
+msgstr "&Br margoa:"
+
+#: ../src/richtext/richtextfontpage.cpp:266
+#: ../src/richtext/richtextfontpage.cpp:268
+msgid "Click to change the text background colour."
+msgstr "Klikatu idazki barren margoa aldatzeko."
+
+#: ../src/richtext/richtextfontpage.cpp:276
+#: ../src/richtext/richtextfontpage.cpp:278
+msgid "Check to show a line through the text."
+msgstr "Hautatu erakusteko lerro bat idazkian zehar."
+
+#: ../src/richtext/richtextfontpage.cpp:281
+msgid "Ca&pitals"
+msgstr "&Larriak"
+
+#: ../src/richtext/richtextfontpage.cpp:283
+#: ../src/richtext/richtextfontpage.cpp:285
+msgid "Check to show the text in capitals."
+msgstr "Hautatu idazkia hizki larritan erakusteko"
+
+#: ../src/richtext/richtextfontpage.cpp:288
+msgid "Small C&apitals"
+msgstr "&Larri Txikiak"
+
+#: ../src/richtext/richtextfontpage.cpp:290
+#: ../src/richtext/richtextfontpage.cpp:292
+msgid "Check to show the text in small capitals."
+msgstr "Hautatu idazkia hizki larrietan erakusteko."
+
+#: ../src/richtext/richtextfontpage.cpp:295
+msgid "Supe&rscript"
+msgstr "Gaine&skripta"
+
+#: ../src/richtext/richtextfontpage.cpp:297
+#: ../src/richtext/richtextfontpage.cpp:299
+msgid "Check to show the text in superscript."
+msgstr "Hautatu erakusteko idazkia gaineskriptean."
+
+#: ../src/richtext/richtextfontpage.cpp:302
+msgid "Subscrip&t"
+msgstr "Azpieskrip&ta"
+
+#: ../src/richtext/richtextfontpage.cpp:304
+#: ../src/richtext/richtextfontpage.cpp:306
+msgid "Check to show the text in subscript."
+msgstr "Hautatu erakusteko idazkia azpieskriptean."
+
+#: ../src/richtext/richtextfontpage.cpp:312
+msgid "Rig&ht-to-left"
+msgstr "E&skuin-ezker"
+
+#: ../src/richtext/richtextfontpage.cpp:314
+#: ../src/richtext/richtextfontpage.cpp:316
+msgid "Check to indicate right-to-left text layout."
+msgstr "Hautatu eskuin-ezker idazketa antolakuntza adierazteko."
+
+#: ../src/richtext/richtextfontpage.cpp:319
+msgid "Suppress hyphe&nation"
+msgstr "Kendu elkar&marratzea"
+
+#: ../src/richtext/richtextfontpage.cpp:321
+#: ../src/richtext/richtextfontpage.cpp:323
+msgid "Check to suppress hyphenation."
+msgstr "Hautatu elkarmarratzea kentzeko."
+
+#: ../src/richtext/richtextfontpage.cpp:329
+#: ../src/richtext/richtextfontpage.cpp:331
+msgid "Shows a preview of the font settings."
+msgstr "Hizki ezarpenen aurreikuspen bat erakusten du."
+
+#: ../src/richtext/richtextfontpage.cpp:348
+#: ../src/richtext/richtextfontpage.cpp:352
+#: ../src/richtext/richtextfontpage.cpp:356
+#: ../src/richtext/richtextformatdlg.cpp:873
+#: ../src/richtext/richtextindentspage.cpp:273
+#: ../src/richtext/richtextindentspage.cpp:285
+#: ../src/richtext/richtextindentspage.cpp:286
+#: ../src/richtext/richtextindentspage.cpp:310
+#: ../src/richtext/richtextindentspage.cpp:325
+#: ../src/richtext/richtextliststylepage.cpp:451
+#: ../src/richtext/richtextliststylepage.cpp:463
+#: ../src/richtext/richtextliststylepage.cpp:464
+msgid "(none)"
+msgstr "(bat ere ez)"
+
+#: ../src/richtext/richtextfontpage.cpp:349
+#: ../src/richtext/richtextfontpage.cpp:353
+msgid "Regular"
+msgstr "Arrunta"
+
+#: ../src/richtext/richtextfontpage.cpp:357
+msgid "Not underlined"
+msgstr "Ez azpimarratua"
+
+#: ../src/richtext/richtextformatdlg.cpp:341
+msgid "Indents && Spacing"
+msgstr "Elkarmarratxoak eta Tarteak"
+
+#: ../src/richtext/richtextformatdlg.cpp:346
+msgid "Tabs"
+msgstr "Hegatsak"
+
+#: ../src/richtext/richtextformatdlg.cpp:351
+msgid "Bullets"
+msgstr "Buletak"
+
+#: ../src/richtext/richtextformatdlg.cpp:356
+msgid "List Style"
+msgstr "Zerrenda Estiloa"
+
+#: ../src/richtext/richtextformatdlg.cpp:366
+#: ../src/richtext/richtextmarginspage.cpp:170
+msgid "Margins"
+msgstr "Bazterrak"
+
+#: ../src/richtext/richtextformatdlg.cpp:371
+msgid "Borders"
+msgstr "Hertzak"
+
+#: ../src/richtext/richtextformatdlg.cpp:765
+msgid "Colour"
+msgstr "Margoa"
+
+#: ../src/richtext/richtextindentspage.cpp:127
+#: ../src/richtext/richtextliststylepage.cpp:322
+msgid "&Alignment"
+msgstr "&Lerrokapena"
+
+#: ../src/richtext/richtextindentspage.cpp:138
+#: ../src/richtext/richtextliststylepage.cpp:331
+msgid "&Left"
+msgstr "&Ezkerra"
+
+#: ../src/richtext/richtextindentspage.cpp:140
+#: ../src/richtext/richtextindentspage.cpp:142
+#: ../src/richtext/richtextliststylepage.cpp:333
+#: ../src/richtext/richtextliststylepage.cpp:335
+msgid "Left-align text."
+msgstr "Idazkiaren ezkerrera lerrokatu."
+
+#: ../src/richtext/richtextindentspage.cpp:145
+#: ../src/richtext/richtextliststylepage.cpp:338
+msgid "&Right"
+msgstr "&Eskuina"
+
+#: ../src/richtext/richtextindentspage.cpp:147
+#: ../src/richtext/richtextindentspage.cpp:149
+#: ../src/richtext/richtextliststylepage.cpp:340
+#: ../src/richtext/richtextliststylepage.cpp:342
+msgid "Right-align text."
+msgstr "Eskuin-lerrokatze idazkia."
+
+#: ../src/richtext/richtextindentspage.cpp:152
+#: ../src/richtext/richtextliststylepage.cpp:345
+msgid "&Justified"
+msgstr "&Berdinduta"
+
+#: ../src/richtext/richtextindentspage.cpp:154
+#: ../src/richtext/richtextindentspage.cpp:156
+#: ../src/richtext/richtextliststylepage.cpp:347
+#: ../src/richtext/richtextliststylepage.cpp:349
+msgid "Justify text left and right."
+msgstr "Berdindu idazkia ezker eta eskuin."
+
+#: ../src/richtext/richtextindentspage.cpp:159
+#: ../src/richtext/richtextliststylepage.cpp:352
+msgid "Cen&tred"
+msgstr "Er&diratuta"
+
+#: ../src/richtext/richtextindentspage.cpp:161
+#: ../src/richtext/richtextindentspage.cpp:163
+#: ../src/richtext/richtextliststylepage.cpp:354
+#: ../src/richtext/richtextliststylepage.cpp:356
+msgid "Centre text."
+msgstr "Erdiratu idazkia."
+
+#: ../src/richtext/richtextindentspage.cpp:166
+#: ../src/richtext/richtextliststylepage.cpp:359
+msgid "&Indeterminate"
+msgstr "&Zehaztugabea"
+
+#: ../src/richtext/richtextindentspage.cpp:168
+#: ../src/richtext/richtextindentspage.cpp:170
+#: ../src/richtext/richtextliststylepage.cpp:361
+#: ../src/richtext/richtextliststylepage.cpp:363
+msgid "Use the current alignment setting."
+msgstr "Erabili oraingo lerrokapen ezarpena."
+
+#: ../src/richtext/richtextindentspage.cpp:183
+#: ../src/richtext/richtextliststylepage.cpp:375
+msgid "&Indentation (tenths of a mm)"
+msgstr "&Nortasuna (mm hamarrena)"
+
+#: ../src/richtext/richtextindentspage.cpp:198
+#: ../src/richtext/richtextindentspage.cpp:200
+#: ../src/richtext/richtextliststylepage.cpp:388
+#: ../src/richtext/richtextliststylepage.cpp:390
+msgid "The left indent."
+msgstr "Ezker elkarmarratxoa."
+
+#: ../src/richtext/richtextindentspage.cpp:203
+#: ../src/richtext/richtextliststylepage.cpp:393
+msgid "Left (&first line):"
+msgstr "Ezkerra (&lehen lerroa):"
+
+#: ../src/richtext/richtextindentspage.cpp:207
+#: ../src/richtext/richtextindentspage.cpp:209
+#: ../src/richtext/richtextliststylepage.cpp:397
+#: ../src/richtext/richtextliststylepage.cpp:399
+msgid "The first line indent."
+msgstr "Lehen lerro elkarmarratxoa."
+
+#: ../src/richtext/richtextindentspage.cpp:216
+#: ../src/richtext/richtextindentspage.cpp:218
+#: ../src/richtext/richtextliststylepage.cpp:406
+#: ../src/richtext/richtextliststylepage.cpp:408
+msgid "The right indent."
+msgstr "Eskuin elkarmarratxoa."
+
+#: ../src/richtext/richtextindentspage.cpp:221
+msgid "&Outline level:"
+msgstr "&Inguru maila:"
+
+#: ../src/richtext/richtextindentspage.cpp:226
+#: ../src/richtext/richtextindentspage.cpp:228
+msgid "The outline level."
+msgstr "Inguru maila."
+
+#: ../src/richtext/richtextindentspage.cpp:241
+#: ../src/richtext/richtextliststylepage.cpp:420
+msgid "&Spacing (tenths of a mm)"
+msgstr "&Tartekatzen (mm hamarrenak)"
+
+#: ../src/richtext/richtextindentspage.cpp:252
+msgid "&Before a paragraph:"
+msgstr "&Esaldi baten aurretik:"
+
+#: ../src/richtext/richtextindentspage.cpp:256
+#: ../src/richtext/richtextindentspage.cpp:258
+#: ../src/richtext/richtextliststylepage.cpp:433
+#: ../src/richtext/richtextliststylepage.cpp:435
+msgid "The spacing before the paragraph."
+msgstr "Tartea esaldiaren aurretik."
+
+#: ../src/richtext/richtextindentspage.cpp:261
+msgid "&After a paragraph:"
+msgstr "&Esaldi baten ondoren:"
+
+#: ../src/richtext/richtextindentspage.cpp:266
+#: ../src/richtext/richtextliststylepage.cpp:442
+#: ../src/richtext/richtextliststylepage.cpp:444
+msgid "The spacing after the paragraph."
+msgstr "Tartea esaldiaren ondoren."
+
+#: ../src/richtext/richtextindentspage.cpp:269
+msgid "L&ine spacing:"
+msgstr "L&erro tartea:"
+
+#: ../src/richtext/richtextindentspage.cpp:274
+#: ../src/richtext/richtextliststylepage.cpp:452
+msgid "Single"
+msgstr "Bakarra"
+
+#: ../src/richtext/richtextindentspage.cpp:275
+#: ../src/richtext/richtextliststylepage.cpp:453
+msgid "1.1"
+msgstr "1.1"
+
+#: ../src/richtext/richtextindentspage.cpp:276
+#: ../src/richtext/richtextliststylepage.cpp:454
+msgid "1.2"
+msgstr "1.2"
+
+#: ../src/richtext/richtextindentspage.cpp:277
+#: ../src/richtext/richtextliststylepage.cpp:455
+msgid "1.3"
+msgstr "1.3"
+
+#: ../src/richtext/richtextindentspage.cpp:278
+#: ../src/richtext/richtextliststylepage.cpp:456
+msgid "1.4"
+msgstr "1.4"
+
+#: ../src/richtext/richtextindentspage.cpp:279
+#: ../src/richtext/richtextliststylepage.cpp:457
+msgid "1.5"
+msgstr "1.5"
+
+#: ../src/richtext/richtextindentspage.cpp:280
+#: ../src/richtext/richtextliststylepage.cpp:458
+msgid "1.6"
+msgstr "1.6"
+
+#: ../src/richtext/richtextindentspage.cpp:281
+#: ../src/richtext/richtextliststylepage.cpp:459
+msgid "1.7"
+msgstr "1.7"
+
+#: ../src/richtext/richtextindentspage.cpp:282
+#: ../src/richtext/richtextliststylepage.cpp:460
+msgid "1.8"
+msgstr "1.8"
+
+#: ../src/richtext/richtextindentspage.cpp:283
+#: ../src/richtext/richtextliststylepage.cpp:461
+msgid "1.9"
+msgstr "1.9"
+
+#: ../src/richtext/richtextindentspage.cpp:284
+#: ../src/richtext/richtextliststylepage.cpp:462
+msgid "2"
+msgstr "2"
+
+#: ../src/richtext/richtextindentspage.cpp:287
+#: ../src/richtext/richtextindentspage.cpp:289
+#: ../src/richtext/richtextliststylepage.cpp:465
+#: ../src/richtext/richtextliststylepage.cpp:467
+msgid "The line spacing."
+msgstr "Lerro tartea."
+
+#: ../src/richtext/richtextindentspage.cpp:292
+msgid "&Page Break"
+msgstr "&Orrialde Haustea"
+
+#: ../src/richtext/richtextindentspage.cpp:294
+#: ../src/richtext/richtextindentspage.cpp:296
+msgid "Inserts a page break before the paragraph."
+msgstr "Orrialde hauste bat txertatzen dut esaldiaren aurretik."
+
+#: ../src/richtext/richtextindentspage.cpp:302
+#: ../src/richtext/richtextindentspage.cpp:304
+msgid "Shows a preview of the paragraph settings."
+msgstr "Esaldi ezarpenen aurreikuspen bat erakusten du."
+
+#: ../src/richtext/richtextliststylepage.cpp:182
+msgid "&List level:"
+msgstr "&Zerrenda maila:"
+
+#: ../src/richtext/richtextliststylepage.cpp:186
+#: ../src/richtext/richtextliststylepage.cpp:188
+msgid "Selects the list level to edit."
+msgstr "Editatzeko zerrenda maila hautatzen du."
+
+#: ../src/richtext/richtextliststylepage.cpp:193
+msgid "&Font for Level..."
+msgstr "&Hizkia Mailarako..."
+
+#: ../src/richtext/richtextliststylepage.cpp:194
+#: ../src/richtext/richtextliststylepage.cpp:196
+msgid "Click to choose the font for this level."
+msgstr "Klikatu maila honentzako hizkia hautatzeko."
+
+#: ../src/richtext/richtextliststylepage.cpp:312
+msgid "Bullet style"
+msgstr "Buleta estiloa"
+
+#: ../src/richtext/richtextliststylepage.cpp:429
+msgid "Before a paragraph:"
+msgstr "Esaldi baten aurretik:"
+
+#: ../src/richtext/richtextliststylepage.cpp:438
+msgid "After a paragraph:"
+msgstr "Esaldi baten ondoren:"
+
+#: ../src/richtext/richtextliststylepage.cpp:447
+msgid "Line spacing:"
+msgstr "Lerro tartea:"
+
+#: ../src/richtext/richtextliststylepage.cpp:470
+msgid "Spacing"
+msgstr "Tartea"
+
+#: ../src/richtext/richtextmarginspage.cpp:193
+#: ../src/richtext/richtextmarginspage.cpp:195
+msgid "The left margin size."
+msgstr "Ezker bazter neurria."
+
+#: ../src/richtext/richtextmarginspage.cpp:203
+#: ../src/richtext/richtextmarginspage.cpp:205
+msgid "Units for the left margin."
+msgstr "Ezker bazter unitateak."
+
+#: ../src/richtext/richtextmarginspage.cpp:218
+#: ../src/richtext/richtextmarginspage.cpp:220
+msgid "The right margin size."
+msgstr "Eskuin bazter neurria."
+
+#: ../src/richtext/richtextmarginspage.cpp:228
+#: ../src/richtext/richtextmarginspage.cpp:230
+msgid "Units for the right margin."
+msgstr "Eskuin bazter unitateak."
+
+#: ../src/richtext/richtextmarginspage.cpp:241
+#: ../src/richtext/richtextmarginspage.cpp:243
+msgid "The top margin size."
+msgstr "Goi bazter neurria."
+
+#: ../src/richtext/richtextmarginspage.cpp:251
+#: ../src/richtext/richtextmarginspage.cpp:253
+msgid "Units for the top margin."
+msgstr "Goiko bazter unitateak."
+
+#: ../src/richtext/richtextmarginspage.cpp:266
+#: ../src/richtext/richtextmarginspage.cpp:268
+msgid "The bottom margin size."
+msgstr "Behe bazter neurria."
+
+#: ../src/richtext/richtextmarginspage.cpp:276
+#: ../src/richtext/richtextmarginspage.cpp:278
+msgid "Units for the bottom margin."
+msgstr "Beheko bazter unitateak."
+
+#: ../src/richtext/richtextmarginspage.cpp:284
+msgid "Padding"
+msgstr "Betegarria"
+
+#: ../src/richtext/richtextmarginspage.cpp:307
+#: ../src/richtext/richtextmarginspage.cpp:309
+msgid "The left padding size."
+msgstr "Ezkerreko betegarri neurria."
+
+#: ../src/richtext/richtextmarginspage.cpp:317
+#: ../src/richtext/richtextmarginspage.cpp:319
+msgid "Units for the left padding."
+msgstr "Ezkerreko betegarriarentzako unitateak."
+
+#: ../src/richtext/richtextmarginspage.cpp:332
+#: ../src/richtext/richtextmarginspage.cpp:334
+msgid "The right padding size."
+msgstr "Eskuineko betegarri neurria."
+
+#: ../src/richtext/richtextmarginspage.cpp:342
+#: ../src/richtext/richtextmarginspage.cpp:344
+msgid "Units for the right padding."
+msgstr "Eskuin betegarriarentzako unitateak."
+
+#: ../src/richtext/richtextmarginspage.cpp:355
+#: ../src/richtext/richtextmarginspage.cpp:357
+msgid "The top padding size."
+msgstr "Goiko betegarri neurria."
+
+#: ../src/richtext/richtextmarginspage.cpp:365
+#: ../src/richtext/richtextmarginspage.cpp:367
+msgid "Units for the top padding."
+msgstr "Goiko betegarriarentzako unitateak."
+
+#: ../src/richtext/richtextmarginspage.cpp:380
+#: ../src/richtext/richtextmarginspage.cpp:382
+msgid "The bottom padding size."
+msgstr "Beheko betegarri neurria."
+
+#: ../src/richtext/richtextmarginspage.cpp:390
+#: ../src/richtext/richtextmarginspage.cpp:392
+msgid "Units for the bottom padding."
+msgstr "Beheko betegarriarentzako unitateak."
+
+#: ../src/richtext/richtextprint.cpp:592
+msgid " Preview"
+msgstr " Aurreikuspena"
+
+#: ../src/richtext/richtextsizepage.cpp:228
+msgid "Floating"
+msgstr "Gain"
+
+#: ../src/richtext/richtextsizepage.cpp:243
+msgid "&Floating mode:"
+msgstr "&Gain modua:"
+
+#: ../src/richtext/richtextsizepage.cpp:252
+#: ../src/richtext/richtextsizepage.cpp:254
+msgid "How the object will float relative to the text."
+msgstr "Objetua idazkiarekiko nola gain ezarriko den."
+
+#: ../src/richtext/richtextsizepage.cpp:265
+msgid "Alignment"
+msgstr "Lerrokapena"
+
+#: ../src/richtext/richtextsizepage.cpp:277
+msgid "&Vertical alignment:"
+msgstr "Zutikako &lerrokapena:"
+
+#: ../src/richtext/richtextsizepage.cpp:279
+#: ../src/richtext/richtextsizepage.cpp:281
+msgid "Enable vertical alignment."
+msgstr "Gaitu zutikako lerrokapena."
+
+#: ../src/richtext/richtextsizepage.cpp:286
+msgid "Centred"
+msgstr "Erdiratuta"
+
+#: ../src/richtext/richtextsizepage.cpp:290
+#: ../src/richtext/richtextsizepage.cpp:292
+msgid "Vertical alignment."
+msgstr "Zutikako lerrokapena."
+
+#: ../src/richtext/richtextsizepage.cpp:316
+#: ../src/richtext/richtextsizepage.cpp:323
+msgid "&Width:"
+msgstr "&Zabalera:"
+
+#: ../src/richtext/richtextsizepage.cpp:318
+#: ../src/richtext/richtextsizepage.cpp:320
+msgid "Enable the width value."
+msgstr "Gaitu zabalera balioa."
+
+#: ../src/richtext/richtextsizepage.cpp:331
+#: ../src/richtext/richtextsizepage.cpp:333
+msgid "The object width."
+msgstr "Objetuaren zabalera."
+
+#: ../src/richtext/richtextsizepage.cpp:342
+#: ../src/richtext/richtextsizepage.cpp:344
+msgid "Units for the object width."
+msgstr "Objetu zabalera unitateak."
+
+#: ../src/richtext/richtextsizepage.cpp:350
+#: ../src/richtext/richtextsizepage.cpp:357
+msgid "&Height:"
+msgstr "&Garaiera:"
+
+#: ../src/richtext/richtextsizepage.cpp:352
+#: ../src/richtext/richtextsizepage.cpp:354
+#: ../src/richtext/richtextsizepage.cpp:464
+#: ../src/richtext/richtextsizepage.cpp:466
+msgid "Enable the height value."
+msgstr "Gaitu garaiera balioa."
+
+#: ../src/richtext/richtextsizepage.cpp:365
+#: ../src/richtext/richtextsizepage.cpp:367
+msgid "The object height."
+msgstr "Objetuaren garaiera."
+
+#: ../src/richtext/richtextsizepage.cpp:376
+#: ../src/richtext/richtextsizepage.cpp:378
+msgid "Units for the object height."
+msgstr "Objetu garaiera unitateak."
+
+#: ../src/richtext/richtextsizepage.cpp:381
+msgid "Min width:"
+msgstr "Gutx. zabalera:"
+
+#: ../src/richtext/richtextsizepage.cpp:383
+#: ../src/richtext/richtextsizepage.cpp:385
+msgid "Enable the minimum width value."
+msgstr "Gaitu gutxieneko zabalera balioa."
+
+#: ../src/richtext/richtextsizepage.cpp:392
+#: ../src/richtext/richtextsizepage.cpp:394
+msgid "The object minimum width."
+msgstr "Objetuaren gutxienezko zabalera."
+
+#: ../src/richtext/richtextsizepage.cpp:403
+#: ../src/richtext/richtextsizepage.cpp:405
+msgid "Units for the minimum object width."
+msgstr "Objetuaren gutxienezko zabalera unitateak."
+
+#: ../src/richtext/richtextsizepage.cpp:408
+msgid "Min height:"
+msgstr "Gutx. garaiera:"
+
+#: ../src/richtext/richtextsizepage.cpp:410
+#: ../src/richtext/richtextsizepage.cpp:412
+msgid "Enable the minimum height value."
+msgstr "Gaitu gutxienezko garaiera balioa."
+
+#: ../src/richtext/richtextsizepage.cpp:419
+#: ../src/richtext/richtextsizepage.cpp:421
+msgid "The object minimum height."
+msgstr "Objetuaren gutxienezko garaiera."
+
+#: ../src/richtext/richtextsizepage.cpp:430
+#: ../src/richtext/richtextsizepage.cpp:432
+msgid "Units for the minimum object height."
+msgstr "Objetuaren gutxienezko garaiera unitateak."
+
+#: ../src/richtext/richtextsizepage.cpp:435
+msgid "Max width:"
+msgstr "Geh. zabalera:"
+
+#: ../src/richtext/richtextsizepage.cpp:437
+#: ../src/richtext/richtextsizepage.cpp:439
+msgid "Enable the maximum width value."
+msgstr "Gaitu gehienezko zabalera balioa."
+
+#: ../src/richtext/richtextsizepage.cpp:446
+#: ../src/richtext/richtextsizepage.cpp:448
+msgid "The object maximum width."
+msgstr "Objetuaren gehienezko zabalera."
+
+#: ../src/richtext/richtextsizepage.cpp:457
+#: ../src/richtext/richtextsizepage.cpp:459
+msgid "Units for the maximum object width."
+msgstr "Objetuaren gehienezko zabalera unitateak."
+
+#: ../src/richtext/richtextsizepage.cpp:462
+msgid "Max height:"
+msgstr "Geh. garaiera:"
+
+#: ../src/richtext/richtextsizepage.cpp:473
+#: ../src/richtext/richtextsizepage.cpp:475
+msgid "The object maximum height."
+msgstr "Objetuaren gehienezko garaiera."
+
+#: ../src/richtext/richtextsizepage.cpp:484
+#: ../src/richtext/richtextsizepage.cpp:486
+msgid "Units for the maximum object height."
+msgstr "Objetuaren gehienezko garaiera unitateak."
+
+#: ../src/richtext/richtextsizepage.cpp:495
+msgid "Position"
+msgstr "Kokapena"
+
+#: ../src/richtext/richtextsizepage.cpp:513
+msgid "&Position mode:"
+msgstr "&Kokapen modua:"
+
+#: ../src/richtext/richtextsizepage.cpp:517
+#: ../src/richtext/richtextsizepage.cpp:522
+msgid "Static"
+msgstr "Estatikoa"
+
+#: ../src/richtext/richtextsizepage.cpp:518
+msgid "Relative"
+msgstr "Erlatiboa"
+
+#: ../src/richtext/richtextsizepage.cpp:519
+msgid "Absolute"
+msgstr "Osoa"
+
+#: ../src/richtext/richtextsizepage.cpp:520
+msgid "Fixed"
+msgstr "Zuzenduta"
+
+#: ../src/richtext/richtextsizepage.cpp:533
+#: ../src/richtext/richtextsizepage.cpp:535
+#: ../src/richtext/richtextsizepage.cpp:547
+#: ../src/richtext/richtextsizepage.cpp:549
+msgid "The left position."
+msgstr "Ezker kokapena."
+
+#: ../src/richtext/richtextsizepage.cpp:558
+#: ../src/richtext/richtextsizepage.cpp:560
+msgid "Units for the left position."
+msgstr "Ezker kokapenerako unitateak."
+
+#: ../src/richtext/richtextsizepage.cpp:568
+#: ../src/richtext/richtextsizepage.cpp:570
+#: ../src/richtext/richtextsizepage.cpp:582
+#: ../src/richtext/richtextsizepage.cpp:584
+msgid "The top position."
+msgstr "Goiko kokapena."
+
+#: ../src/richtext/richtextsizepage.cpp:593
+#: ../src/richtext/richtextsizepage.cpp:595
+msgid "Units for the top position."
+msgstr "Goiko kokapenerako unitateak."
+
+#: ../src/richtext/richtextsizepage.cpp:603
+#: ../src/richtext/richtextsizepage.cpp:605
+#: ../src/richtext/richtextsizepage.cpp:617
+#: ../src/richtext/richtextsizepage.cpp:619
+msgid "The right position."
+msgstr "Eskuin kokapena."
+
+#: ../src/richtext/richtextsizepage.cpp:628
+#: ../src/richtext/richtextsizepage.cpp:630
+msgid "Units for the right position."
+msgstr "Eskuin kokapenerako unitateak."
+
+#: ../src/richtext/richtextsizepage.cpp:638
+#: ../src/richtext/richtextsizepage.cpp:640
+#: ../src/richtext/richtextsizepage.cpp:652
+#: ../src/richtext/richtextsizepage.cpp:654
+msgid "The bottom position."
+msgstr "Beheko kokapena."
+
+#: ../src/richtext/richtextsizepage.cpp:663
+#: ../src/richtext/richtextsizepage.cpp:665
+msgid "Units for the bottom position."
+msgstr "Beheko kokapenerako unitateak."
+
+#: ../src/richtext/richtextsizepage.cpp:671
+msgid "&Move the object to:"
+msgstr "&Mugitu objetua hona:"
+
+#: ../src/richtext/richtextsizepage.cpp:674
+msgid "&Previous Paragraph"
+msgstr "A&urreko Esaldia"
+
+#: ../src/richtext/richtextsizepage.cpp:675
+#: ../src/richtext/richtextsizepage.cpp:677
+msgid "Moves the object to the previous paragraph."
+msgstr "Objetuak aurreko esaldira mugitzen ditu."
+
+#: ../src/richtext/richtextsizepage.cpp:680
+msgid "&Next Paragraph"
+msgstr "&Hurrengo Esaldia"
+
+#: ../src/richtext/richtextsizepage.cpp:681
+#: ../src/richtext/richtextsizepage.cpp:683
+msgid "Moves the object to the next paragraph."
+msgstr "Objetua hurrengo esaldira mugitzen du."
+
+#: ../src/richtext/richtextstyledlg.cpp:193
+msgid "&Styles:"
+msgstr "&Estiloak:"
+
+#: ../src/richtext/richtextstyledlg.cpp:197
+#: ../src/richtext/richtextstyledlg.cpp:199
+msgid "The available styles."
+msgstr "Estilo eskuragarriak."
+
+#: ../src/richtext/richtextstyledlg.cpp:205
+#: ../src/richtext/richtextstyledlg.cpp:217
+msgid " "
+msgstr " "
+
+#: ../src/richtext/richtextstyledlg.cpp:209
+#: ../src/richtext/richtextstyledlg.cpp:211
+msgid "The style preview."
+msgstr "Estiloaren aurreikuspena."
+
+#: ../src/richtext/richtextstyledlg.cpp:220
+msgid "New &Character Style..."
+msgstr "Hizki Estilo &Berria..."
+
+#: ../src/richtext/richtextstyledlg.cpp:221
+#: ../src/richtext/richtextstyledlg.cpp:223
+msgid "Click to create a new character style."
+msgstr "Klikatu hizki-kode estilo berria sortzeko."
+
+#: ../src/richtext/richtextstyledlg.cpp:226
+msgid "New &Paragraph Style..."
+msgstr "Esaldi &Estilo Berria..."
+
+#: ../src/richtext/richtextstyledlg.cpp:227
+#: ../src/richtext/richtextstyledlg.cpp:229
+msgid "Click to create a new paragraph style."
+msgstr "Klikatu esaldi estilo berria sortzeko."
+
+#: ../src/richtext/richtextstyledlg.cpp:232
+msgid "New &List Style..."
+msgstr "Zerrenda E&stilo Berria..."
+
+#: ../src/richtext/richtextstyledlg.cpp:233
+#: ../src/richtext/richtextstyledlg.cpp:235
+msgid "Click to create a new list style."
+msgstr "Klikatu zerrenda estilo berria sortzeko."
+
+#: ../src/richtext/richtextstyledlg.cpp:238
+msgid "New &Box Style..."
+msgstr "Kutxa E&stilo Berria..."
+
+#: ../src/richtext/richtextstyledlg.cpp:239
+#: ../src/richtext/richtextstyledlg.cpp:241
+msgid "Click to create a new box style."
+msgstr "Klikatu kutxa estilo berria sortzeko."
+
+#: ../src/richtext/richtextstyledlg.cpp:246
+msgid "&Apply Style"
+msgstr "&Ezarri Estiloa"
+
+#: ../src/richtext/richtextstyledlg.cpp:247
+#: ../src/richtext/richtextstyledlg.cpp:249
+msgid "Click to apply the selected style."
+msgstr "Klikatu hautatutako estiloa ezartzeko."
+
+#: ../src/richtext/richtextstyledlg.cpp:252
+msgid "&Rename Style..."
+msgstr "&Berrizendatu Estiloa..."
+
+#: ../src/richtext/richtextstyledlg.cpp:253
+#: ../src/richtext/richtextstyledlg.cpp:255
+msgid "Click to rename the selected style."
+msgstr "Klikatu hautatutako estiloa berrizendatzeko."
+
+#: ../src/richtext/richtextstyledlg.cpp:258
+msgid "&Edit Style..."
+msgstr "&Editatu Estiloa..."
+
+#: ../src/richtext/richtextstyledlg.cpp:259
+#: ../src/richtext/richtextstyledlg.cpp:261
+msgid "Click to edit the selected style."
+msgstr "Klikatu hautatutako estiloa editatzeko."
+
+#: ../src/richtext/richtextstyledlg.cpp:264
+msgid "&Delete Style..."
+msgstr "E&zabatu Estiloa..."
+
+#: ../src/richtext/richtextstyledlg.cpp:265
+#: ../src/richtext/richtextstyledlg.cpp:267
+msgid "Click to delete the selected style."
+msgstr "Klikatu hautaturiko estiloa ezabatzeko."
+
+#: ../src/richtext/richtextstyledlg.cpp:274
+#: ../src/richtext/richtextstyledlg.cpp:276
+msgid "Click to close this window."
+msgstr "Klikatu leiho hau isteko."
+
+#: ../src/richtext/richtextstyledlg.cpp:282
+msgid "&Restart numbering"
+msgstr "&Berrabiarazi zenbakiketa"
+
+#: ../src/richtext/richtextstyledlg.cpp:284
+#: ../src/richtext/richtextstyledlg.cpp:286
+msgid "Check to restart numbering."
+msgstr "Hautatu zenbaketa birrabiarazteko."
+
+#: ../src/richtext/richtextstyledlg.cpp:601
+msgid "Enter a character style name"
+msgstr "Sartu hizki estilo izen bat"
+
+#: ../src/richtext/richtextstyledlg.cpp:601
+#: ../src/richtext/richtextstyledlg.cpp:606
+#: ../src/richtext/richtextstyledlg.cpp:649
+#: ../src/richtext/richtextstyledlg.cpp:654
+#: ../src/richtext/richtextstyledlg.cpp:815
+#: ../src/richtext/richtextstyledlg.cpp:820
+#: ../src/richtext/richtextstyledlg.cpp:888
+#: ../src/richtext/richtextstyledlg.cpp:896
+#: ../src/richtext/richtextstyledlg.cpp:929
+#: ../src/richtext/richtextstyledlg.cpp:934
+msgid "New Style"
+msgstr "Estilo Berria"
+
+#: ../src/richtext/richtextstyledlg.cpp:606
+#: ../src/richtext/richtextstyledlg.cpp:654
+#: ../src/richtext/richtextstyledlg.cpp:820
+#: ../src/richtext/richtextstyledlg.cpp:896
+#: ../src/richtext/richtextstyledlg.cpp:934
+msgid "Sorry, that name is taken. Please choose another."
+msgstr "Barkatu, izena hartuta dago. Mesedez hautatu beste bat."
+
+#: ../src/richtext/richtextstyledlg.cpp:649
+msgid "Enter a paragraph style name"
+msgstr "Sartu esaldi estilo izena"
+
+#: ../src/richtext/richtextstyledlg.cpp:777
+#, c-format
+msgid "Delete style %s?"
+msgstr "%s estiloa ezabatu?"
+
+#: ../src/richtext/richtextstyledlg.cpp:777
+msgid "Delete Style"
+msgstr "Ezabatu Estiloa"
+
+#: ../src/richtext/richtextstyledlg.cpp:815
+msgid "Enter a list style name"
+msgstr "Sartu zerrenda estilo izen bat"
+
+#: ../src/richtext/richtextstyledlg.cpp:888
+msgid "Enter a new style name"
+msgstr "Sartu estilo izen berri bat"
+
+#: ../src/richtext/richtextstyledlg.cpp:929
+msgid "Enter a box style name"
+msgstr "Sartu kutxa estilo izen bat"
+
+#: ../src/richtext/richtextstylepage.cpp:109
+#: ../src/richtext/richtextstylepage.cpp:111
+msgid "The style name."
+msgstr "Estilo izena."
+
+#: ../src/richtext/richtextstylepage.cpp:114
+msgid "&Based on:"
+msgstr "&Honetan ohinarrituta:"
+
+#: ../src/richtext/richtextstylepage.cpp:119
+#: ../src/richtext/richtextstylepage.cpp:121
+msgid "The style on which this style is based."
+msgstr "Estilo hau ohinarrituta dagoen estiloa."
+
+#: ../src/richtext/richtextstylepage.cpp:124
+msgid "&Next style:"
+msgstr "&Hurrengo estiloa:"
+
+#: ../src/richtext/richtextstylepage.cpp:129
+#: ../src/richtext/richtextstylepage.cpp:131
+msgid "The default style for the next paragraph."
+msgstr "Berezko estiloa hurrengo esaldirako."
+
+#: ../src/richtext/richtextstyles.cpp:1057
+msgid "All styles"
+msgstr "Estilo guztiak"
+
+#: ../src/richtext/richtextstyles.cpp:1058
+msgid "Paragraph styles"
+msgstr "Esaldi estiloak"
+
+#: ../src/richtext/richtextstyles.cpp:1059
+msgid "Character styles"
+msgstr "Hizki-kode estiloak"
+
+#: ../src/richtext/richtextstyles.cpp:1060
+msgid "List styles"
+msgstr "Zerrenda estiloak"
+
+#: ../src/richtext/richtextstyles.cpp:1061
+msgid "Box styles"
+msgstr "Kutxaren estiloak"
+
+#: ../src/richtext/richtextsymboldlg.cpp:389
+#: ../src/richtext/richtextsymboldlg.cpp:391
+msgid "The font from which to take the symbol."
+msgstr "Sinboloa hartzeko hizki mota."
+
+#: ../src/richtext/richtextsymboldlg.cpp:396
+msgid "&Subset:"
+msgstr "&Azpiezarpena:"
+
+#: ../src/richtext/richtextsymboldlg.cpp:401
+#: ../src/richtext/richtextsymboldlg.cpp:403
+msgid "Shows a Unicode subset."
+msgstr "Unicode azpiezarpena erakusten du."
+
+#: ../src/richtext/richtextsymboldlg.cpp:412
+msgid "xxxx"
+msgstr "xxxx"
+
+#: ../src/richtext/richtextsymboldlg.cpp:417
+msgid "&Character code:"
+msgstr "&Hizki kodea:"
+
+#: ../src/richtext/richtextsymboldlg.cpp:421
+#: ../src/richtext/richtextsymboldlg.cpp:423
+msgid "The character code."
+msgstr "Hizki kodea."
+
+#: ../src/richtext/richtextsymboldlg.cpp:428
+msgid "&From:"
+msgstr "&Hemendik:"
+
+#: ../src/richtext/richtextsymboldlg.cpp:433
+#: ../src/richtext/richtextsymboldlg.cpp:434
+#: ../src/richtext/richtextsymboldlg.cpp:435
+msgid "Unicode"
+msgstr "Unicode"
+
+#: ../src/richtext/richtextsymboldlg.cpp:436
+#: ../src/richtext/richtextsymboldlg.cpp:438
+msgid "The range to show."
+msgstr "Erakusteko maila."
+
+#: ../src/richtext/richtextsymboldlg.cpp:444
+msgid "Insert"
+msgstr "Sartu"
+
+#: ../src/richtext/richtextsymboldlg.cpp:478
+msgid "(Normal text)"
+msgstr "(Idazki arrunta)"
+
+#: ../src/richtext/richtexttabspage.cpp:109
+msgid "&Position (tenths of a mm):"
+msgstr "&Kokapena (mm hamarrenak):"
+
+#: ../src/richtext/richtexttabspage.cpp:113
+#: ../src/richtext/richtexttabspage.cpp:115
+msgid "The tab position."
+msgstr "Hegats kokapena."
+
+#: ../src/richtext/richtexttabspage.cpp:119
+msgid "The tab positions."
+msgstr "Hegats kokapenak."
+
+#: ../src/richtext/richtexttabspage.cpp:132
+#: ../src/richtext/richtexttabspage.cpp:134
+msgid "Click to create a new tab position."
+msgstr "Klikatu tab guztien kokapena sortzeko."
+
+#: ../src/richtext/richtexttabspage.cpp:138
+#: ../src/richtext/richtexttabspage.cpp:140
+msgid "Click to delete the selected tab position."
+msgstr "Klikatu hautatutako tab kokopena ezabatzeko."
+
+#: ../src/richtext/richtexttabspage.cpp:143
+msgid "Delete A&ll"
+msgstr "Ezabatu &Denak"
+
+#: ../src/richtext/richtexttabspage.cpp:144
+#: ../src/richtext/richtexttabspage.cpp:146
+msgid "Click to delete all tab positions."
+msgstr "Klikatu tab guztien kokapena ezabatzeko."
+
+#: ../src/univ/theme.cpp:110
+msgid "Failed to initialize GUI: no built-in themes found."
+msgstr "Hutsegitea EIG abiatzerakoan: ez da barneko azalgairik aurkitu."
+
+#: ../src/univ/themes/gtk.cpp:521
+msgid "GTK+ theme"
+msgstr "GTK+ azalgaia"
+
+#: ../src/univ/themes/metal.cpp:164
+msgid "Metal theme"
+msgstr "Metal azalgaia"
+
+#: ../src/univ/themes/mono.cpp:512
+msgid "Simple monochrome theme"
+msgstr "Azalgai margobakar arrunta"
+
+#: ../src/univ/themes/win32.cpp:1098
+msgid "Win32 theme"
+msgstr "Win32 azalgaia"
+
+#: ../src/univ/themes/win32.cpp:3743
+msgid "&Restore"
+msgstr "&Berrezarri"
+
+#: ../src/univ/themes/win32.cpp:3744
+msgid "&Move"
+msgstr "&Mugitu"
+
+#: ../src/univ/themes/win32.cpp:3746
+msgid "&Size"
+msgstr "&Neurria"
+
+#: ../src/univ/themes/win32.cpp:3748
+msgid "Mi&nimize"
+msgstr "I&kurtu"
+
+#: ../src/univ/themes/win32.cpp:3750
+msgid "Ma&ximize"
+msgstr "Han&ditu"
+
+#: ../src/univ/themes/win32.cpp:3752
+msgid "Alt+"
+msgstr "Alt+"
+
+#: ../src/unix/appunix.cpp:178
+msgid "Failed to install signal handler"
+msgstr "Hutsegitea seinale kudeatzeilea ezartzerakoan"
+
+#: ../src/unix/dialup.cpp:351
+msgid "Already dialling ISP."
+msgstr "Jadanik ISP-a deitzen."
+
+#: ../src/unix/dlunix.cpp:93
+#, fuzzy
+msgid "Failed to unload shared library"
+msgstr "Hutsegitea '%s' partekatze agiria gertatzerakoan"
+
+#: ../src/unix/dlunix.cpp:121
+msgid "Unknown dynamic library error"
+msgstr "Liburutegi dinamiko akats ezezaguna"
+
+#: ../src/unix/epolldispatcher.cpp:84
+msgid "Failed to create epoll descriptor"
+msgstr "Hutsegitea epoll azaltzailea sortzerakoan"
+
+#: ../src/unix/epolldispatcher.cpp:103
+msgid "Error closing epoll descriptor"
+msgstr "Akatsa epoll azaltzailea istean"
+
+#: ../src/unix/epolldispatcher.cpp:116
+#, c-format
+msgid "Failed to add descriptor %d to epoll descriptor %d"
+msgstr "Hutsegitea %d azaltzailea %d epoll azaltzailera gehitzerakoan"
+
+#: ../src/unix/epolldispatcher.cpp:136
+#, c-format
+msgid "Failed to modify descriptor %d in epoll descriptor %d"
+msgstr "Hutsegitea %d azaltzailea %d epoll azaltzailean aldatzerakoan"
+
+#: ../src/unix/epolldispatcher.cpp:155
+#, c-format
+msgid "Failed to unregister descriptor %d from epoll descriptor %d"
+msgstr ""
+"Hutsegitea %d azaltzailea %d epoll azaltzailetik erregistratu gabetzerakoan"
+
+#: ../src/unix/epolldispatcher.cpp:213
+#, c-format
+msgid "Waiting for IO on epoll descriptor %d failed"
+msgstr "Itxaroten IO epoll azaltzailean %d hutsegitea"
+
+#: ../src/unix/fswatcher_inotify.cpp:71
+msgid "Unable to create inotify instance"
+msgstr "Ezinezkoa inotify eskabidea sortzea"
+
+#: ../src/unix/fswatcher_inotify.cpp:94
+msgid "Unable to close inotify instance"
+msgstr "Ezinezkoa inotify eskabidea istea"
+
+#: ../src/unix/fswatcher_inotify.cpp:106
+msgid "Unable to add inotify watch"
+msgstr "Ezinezkoa inotify behatza gehitzea"
+
+#: ../src/unix/fswatcher_inotify.cpp:138
+#, fuzzy, c-format
+msgid "Unable to remove inotify watch %i"
+msgstr "Ezinezkoa inotify behaketa kentzea"
+
+#: ../src/unix/fswatcher_inotify.cpp:271
+#, c-format
+msgid "Unexpected event for \"%s\": no matching watch descriptor."
+msgstr "Ustekabeko gertaera \"%s\": ez dator bat behaketa azaltzailea."
+
+#: ../src/unix/fswatcher_inotify.cpp:320
+#, c-format
+msgid "Invalid inotify event for \"%s\""
+msgstr "Inotify gertaera baliogabea \"%s\""
+
+#: ../src/unix/fswatcher_inotify.cpp:553
+msgid "Unable to read from inotify descriptor"
+msgstr "Ezinezkoa inotify azaltzailetik irakurtzea"
+
+#: ../src/unix/fswatcher_inotify.cpp:558
+msgid "EOF while reading from inotify descriptor"
+msgstr "EOF inotify azaltzailetik irakurtzean"
+
+#: ../src/unix/fswatcher_kqueue.cpp:114
+msgid "Unable to create kqueue instance"
+msgstr "Ezinezkoa kqueue eskabidea sortzea"
+
+#: ../src/unix/fswatcher_kqueue.cpp:131
+msgid "Error closing kqueue instance"
+msgstr "Akats kqueue eskabidea istean"
+
+#: ../src/unix/fswatcher_kqueue.cpp:153
+msgid "Unable to add kqueue watch"
+msgstr "Ezinezkoa kqueue behatzea gehitzea"
+
+#: ../src/unix/fswatcher_kqueue.cpp:170
+msgid "Unable to remove kqueue watch"
+msgstr "Ezinezkoa kqueue behaketa kentzea"
+
+#: ../src/unix/fswatcher_kqueue.cpp:202
+msgid "Unable to get events from kqueue"
+msgstr "Ezinezkoa kqueue-tik gertaera lortzea"
+
+#: ../src/unix/mediactrl.cpp:966
+#, c-format
+msgid "Media playback error: %s"
+msgstr "Multimedia irakurketa akatsa: %s"
+
+#: ../src/unix/mediactrl.cpp:1228
+#, c-format
+msgid "Failed to prepare playing \"%s\"."
+msgstr "Hutsegitea \"%s\" irakurketa gertatzerakoan."
+
+#: ../src/unix/snglinst.cpp:164
+#, c-format
+msgid "Failed to write to lock file '%s'"
+msgstr "Hutsegitea '%s' blokeo agiria idazterakoan"
+
+#: ../src/unix/snglinst.cpp:177
+#, c-format
+msgid "Failed to set permissions on lock file '%s'"
+msgstr "Hutsegitea '%s' blokeo agirian baimenak ezartzerakoan"
+
+#: ../src/unix/snglinst.cpp:194
+#, c-format
+msgid "Failed to lock the lock file '%s'"
+msgstr "Hutsegitea '%s' blokeo agiria blokeatzerakoan"
+
+#: ../src/unix/snglinst.cpp:237
+#, c-format
+msgid "Failed to inspect the lock file '%s'"
+msgstr "Hutsegitea '%s' blokeo agiria ikertzerakoan"
+
+#: ../src/unix/snglinst.cpp:242
+#, c-format
+msgid "Lock file '%s' has incorrect owner."
+msgstr "'%s' blokeo agiriak jabe okerra du."
+
+#: ../src/unix/snglinst.cpp:247
+#, c-format
+msgid "Lock file '%s' has incorrect permissions."
+msgstr "'%s' blokeo agiriak baimen okerrak ditu."
+
+#: ../src/unix/snglinst.cpp:265
+msgid "Failed to access lock file."
+msgstr "Hutsegitea blokeo agirira sartzerakoan."
+
+#: ../src/unix/snglinst.cpp:274
+msgid "Failed to read PID from lock file."
+msgstr "Hutsegitea blokeo agiritik PID-a irakurtzerakoan."
+
+#: ../src/unix/snglinst.cpp:284
+#, c-format
+msgid "Failed to remove stale lock file '%s'."
+msgstr "Hutsegitea '%s' blokeo agiri zaharra kentzerakoan."
+
+#: ../src/unix/snglinst.cpp:297
+#, c-format
+msgid "Deleted stale lock file '%s'."
+msgstr "Ezabatuta hondatutako blokeo agiria '%s'."
+
+#: ../src/unix/snglinst.cpp:308
+#, c-format
+msgid "Invalid lock file '%s'."
+msgstr " '%s' blokeo agiri baliogabea "
+
+#: ../src/unix/snglinst.cpp:324
+#, c-format
+msgid "Failed to remove lock file '%s'"
+msgstr "Hutsegitea '%s' blokeo agiria kentzerakoan"
+
+#: ../src/unix/snglinst.cpp:330
+#, c-format
+msgid "Failed to unlock lock file '%s'"
+msgstr "Hutsegitea '%s' blokeo agiria desblokeatzerakoan"
+
+#: ../src/unix/snglinst.cpp:336
+#, c-format
+msgid "Failed to close lock file '%s'"
+msgstr "Hutsegitea '%s' blokeo agiria isterakoan"
+
+#: ../src/unix/sound.cpp:77
+msgid "No sound"
+msgstr "Soinu gabe"
+
+#: ../src/unix/sound.cpp:364
+msgid "Unable to play sound asynchronously."
+msgstr "Ezinezkoa soinua ezaldiberean irakurtzea."
+
+#: ../src/unix/sound.cpp:458
+#, c-format
+msgid "Couldn't load sound data from '%s'."
+msgstr "Ezinezkoa '%s'-tik soinu datua gertatzea."
+
+#: ../src/unix/sound.cpp:465
+#, c-format
+msgid "Sound file '%s' is in unsupported format."
+msgstr "'%s' soinu agiria heuskarri sostengatu gabean dago"
+
+#: ../src/unix/sound.cpp:480
+msgid "Sound data are in unsupported format."
+msgstr "Soinu datua heuskarri sostengatu gabean dago."
+
+#: ../src/unix/sound_sdl.cpp:226
+#, c-format
+msgid "Couldn't open audio: %s"
+msgstr "Ezinezkoa audioa irekitzea: %s"
+
+#: ../src/unix/threadpsx.cpp:1033
+msgid "Cannot retrieve thread scheduling policy."
+msgstr "Ezinezkoa hari egitaraupen araudia berreskuratzea."
+
+#: ../src/unix/threadpsx.cpp:1058
+#, c-format
+msgid "Cannot get priority range for scheduling policy %d."
+msgstr "Ezin da lortu lehentasun maila %d egitarautzaile itunerako."
+
+#: ../src/unix/threadpsx.cpp:1066
+msgid "Thread priority setting is ignored."
+msgstr "Hari lehentasun ezarpena ezikusia da."
+
+#: ../src/unix/threadpsx.cpp:1221
+msgid ""
+"Failed to join a thread, potential memory leak detected - please restart the "
+"program"
+msgstr ""
+"Hutsegitea harira batzerakoan, oroimen galera potentziala atzeman da - "
+"mesedez berrabiarazi programa"
+
+#: ../src/unix/threadpsx.cpp:1352
+#, c-format
+msgid "Failed to set thread concurrency level to %lu"
+msgstr "Hutsegitea hari lehentasuna %lu ezartzerakoan."
+
+#: ../src/unix/threadpsx.cpp:1481
+#, c-format
+msgid "Failed to set thread priority %d."
+msgstr "Hutsegitea %d hari lehentasuna ezartzerakoan."
+
+#: ../src/unix/threadpsx.cpp:1666
+msgid "Failed to terminate a thread."
+msgstr "Hutsegitea hari bat amaitzerakoan."
+
+#: ../src/unix/threadpsx.cpp:1893
+msgid "Thread module initialization failed: failed to create thread key"
+msgstr "Hari modulo abiarazpen hutsegitea: hutsegitea hari giltza sortzerakoan"
+
+#: ../src/unix/utilsunx.cpp:340
+msgid "Impossible to get child process input"
+msgstr "Ezinezkoa child garapen sarrera lortu"
+
+#: ../src/unix/utilsunx.cpp:390
+msgid "Can't write to child process's stdin"
+msgstr "Ezin da child prozesuaren stdin idatzi"
+
+#: ../src/unix/utilsunx.cpp:644
+#, c-format
+msgid "Failed to execute '%s'\n"
+msgstr "Hutsegitea '%s' exekutatzerakoan\n"
+
+#: ../src/unix/utilsunx.cpp:678
+msgid "Fork failed"
+msgstr "Adar hutsegitea"
+
+#: ../src/unix/utilsunx.cpp:701
+msgid "Failed to set process priority"
+msgstr "Hutsegitea prozesu lehentasuna ezartzerakoan"
+
+#: ../src/unix/utilsunx.cpp:712
+msgid "Failed to redirect child process input/output"
+msgstr "Hutsegitea child garapen sarrera/irteera berbideratzerakoan"
+
+#: ../src/unix/utilsunx.cpp:816
+msgid "Failed to set up non-blocking pipe, the program might hang."
+msgstr ""
+"Hutsegitea ez-blokeo hodia ezartzerakoan, programa blokeatu egin daiteke."
+
+#: ../src/unix/utilsunx.cpp:1023
+msgid "Cannot get the hostname"
+msgstr "Ezin da lortu hostalari-izena"
+
+#: ../src/unix/utilsunx.cpp:1059
+msgid "Cannot get the official hostname"
+msgstr "Ezin da lortu hostalari-izen ofiziala"
+
+#: ../src/unix/wakeuppipe.cpp:49
+msgid "Failed to create wake up pipe used by event loop."
+msgstr ""
+"Hutsegitea gertaera bigiztak erabilitako iratzarpen hodia sortzearakoan."
+
+#: ../src/unix/wakeuppipe.cpp:56
+msgid "Failed to switch wake up pipe to non-blocking mode"
+msgstr "Hutsegitea iratzar hodia ez-blokeatzen modura aldatzerakoan"
+
+#: ../src/unix/wakeuppipe.cpp:117
+msgid "Failed to read from wake-up pipe"
+msgstr "Hutsegitea iratzar hoditik irakurtzerakoan"
+
+#: ../src/x11/app.cpp:124
+#, c-format
+msgid "Invalid geometry specification '%s'"
+msgstr "Geometria zehaztapen baliogabea '%s'"
+
+#: ../src/x11/app.cpp:167
+msgid "wxWidgets could not open display. Exiting."
+msgstr "wxWidget-ek ezin du erakuspena ireki. Irtetzen."
+
+#: ../src/x11/utils.cpp:169
+#, c-format
+msgid "Failed to close the display \"%s\""
+msgstr "Hutsegitea \"%s\" erakuspena isterakoan"
+
+#: ../src/x11/utils.cpp:188
+#, c-format
+msgid "Failed to open display \"%s\"."
+msgstr "Hutsegitea \"%s\" erakustea irekitzerakoan."
+
+#: ../src/xml/xml.cpp:868
+#, c-format
+msgid "XML parsing error: '%s' at line %d"
+msgstr "XML azterketa akatsa : '%s' %d lerroan"
+
+#: ../src/xrc/xh_propgrid.cpp:239
+#, fuzzy, c-format
+msgid "Page %i"
+msgstr "%d orrialde"
+
+#: ../src/xrc/xmlres.cpp:448
+#, c-format
+msgid "Cannot load resources from '%s'."
+msgstr "Ezin dira gertatu baliabideak '%s'-tik."
+
+#: ../src/xrc/xmlres.cpp:799
+#, c-format
+msgid "Cannot open resources file '%s'."
+msgstr "Ezinezkoa '%s' baliabide agiria irekitzea."
+
+#: ../src/xrc/xmlres.cpp:806
+#, c-format
+msgid "Cannot load resources from file '%s'."
+msgstr "Ezin dira gertatu baliabideak '%s' agiritik."
+
+#: ../src/xrc/xmlres.cpp:2767
+#, c-format
+msgid "Creating %s \"%s\" failed."
+msgstr "Hutsegitea %s \"%s\" sortzerakoan."
+
+#~ msgctxt "keyboard key"
+#~ msgid "Alt+"
+#~ msgstr "Alt+"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Ctrl+"
+#~ msgstr "Ktrl+"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Shift+"
+#~ msgstr "Shift+"
+
+#~ msgctxt "keyboard key"
+#~ msgid "RawCtrl+"
+#~ msgstr "RawKtrl+"
+
+#~ msgid "Unsupported clipboard format."
+#~ msgstr "Gako heuskarri sostengatu gabea."
+
+#~ msgid "Background colour"
+#~ msgstr "Barren margoa"
+
+#~ msgid "Font:"
+#~ msgstr "Hizkia:"
+
+#~ msgid "Size:"
+#~ msgstr "Neurria:"
+
+#~ msgid "The font size in points."
+#~ msgstr "Hizki neurria puntutan."
+
+#~ msgid "Style:"
+#~ msgstr "Estiloa:"
+
+#~ msgid "Check to make the font bold."
+#~ msgstr "Hautatu hizkia lodi egiteko."
+
+#~ msgid "Check to make the font italic."
+#~ msgstr "Hautatu hizkia etzana egiteko."
+
+#~ msgid "Check to make the font underlined."
+#~ msgstr "Hautatu hizkia azpimarratua egiteko."
+
+#~ msgid "Colour:"
+#~ msgstr "Margoa:"
+
+#~ msgid "Click to change the font colour."
+#~ msgstr "Klikatu hizki margoa aldatzeko."
+
+#~ msgid "Shows a preview of the font."
+#~ msgstr "Hizkiaren aurreikuspen bat erakusten du."
+
+#~ msgid "Click to cancel changes to the font."
+#~ msgstr "Klikatu hizkian aldaketak ezeztatzeko."
+
+#~ msgid "Click to confirm changes to the font."
+#~ msgstr "Klikatu hizkian aldaketak baieztatzeko."
+
+#~ msgid "<Any>"
+#~ msgstr "<Edozein>"
+
+#~ msgid "<Any Roman>"
+#~ msgstr "<Edozein Erromatar>"
+
+#~ msgid "<Any Decorative>"
+#~ msgstr "<Edozein Apaingarria>"
+
+#~ msgid "<Any Modern>"
+#~ msgstr "<Edozein Modernoa>"
+
+#~ msgid "<Any Script>"
+#~ msgstr "<Eskripten bat>"
+
+#~ msgid "<Any Swiss>"
+#~ msgstr "<Edozein Suitzar>"
+
+#~ msgid "<Any Teletype>"
+#~ msgstr "<Teletiporen bat>"
+
+#~ msgid "Printing "
+#~ msgstr "Irarkitzen"
+
+#~ msgid "Failed to insert text in the control."
+#~ msgstr "Hutsegitea agintean idazkia sartzerakoan."
+
+#~ msgid "Please choose a valid font."
+#~ msgstr "Mesedez hautatu baliozko hizki bat."
+
+#, c-format
+#~ msgid "Failed to display HTML document in %s encoding"
+#~ msgstr "Hutsegitea HTML agiria %s kodeaketan erakusterakoan"
+
+#, c-format
+#~ msgid "wxWidgets could not open display for '%s': exiting."
+#~ msgstr "wxWidget-ek ezin du '%s' erakuspena ireki: irtetzen."
+
+#~ msgid "Filter"
+#~ msgstr "Iragazkia"
+
+#~ msgid "Directories"
+#~ msgstr "Zuzenbideak"
+
+#~ msgid "Files"
+#~ msgstr "Agiriak"
+
+#~ msgid "Selection"
+#~ msgstr "Hautapena"
+
+#~ msgid "conversion to 8-bit encoding failed"
+#~ msgstr "hutsegitea 8-bitera bihurtzerakoan"
+
+#, fuzzy
+#~ msgid "failed to retrieve execution result"
+#~ msgstr "Hutsegitea RAS akats mezutik idazkia berreskuratzerakoan"
+
+#~ msgid "&Save as"
+#~ msgstr "&Gorde honela"
+
+#~ msgid "'%s' doesn't consist only of valid characters"
+#~ msgstr "'%s' ez dago hizki baliogarriz osatuta bakarrik"
+
+#~ msgid "'%s' should be numeric."
+#~ msgstr "'%s' zenbakizkoa izan behar du."
+
+#~ msgid "'%s' should only contain ASCII characters."
+#~ msgstr "'%s' ASCII hizkiak bakarrik izan behar ditu."
+
+#~ msgid "'%s' should only contain alphabetic characters."
+#~ msgstr "'%s' alfabetoko hizkiak bakarrik izan behar ditu."
+
+#~ msgid "'%s' should only contain alphabetic or numeric characters."
+#~ msgstr "'%s' alfabetoko edo zenbakizko hizkiak bakarrik izan behar ditu."
+
+#~ msgid "'%s' should only contain digits."
+#~ msgstr "'%s' zenbakiak bakarrik izan behar ditu."
+
+#~ msgid "Can't create window of class %s"
+#~ msgstr "Ezin da %s klasearen leihoa sortu"
+
+#~ msgid "Couldn't create the overlay window"
+#~ msgstr "Ezinezkoa leiho gainjarria sortzea"
+
+#~ msgid "Couldn't init the context on the overlay window"
+#~ msgstr "Ezinezkoa hastea hitzingurua gainjarritako leihoan"
+
+#~ msgid "Failed to convert file \"%s\" to Unicode."
+#~ msgstr "Hutsegitea \"%s\" agiria Unicodera bihurtzerakoan."
+
+#~ msgid "Failed to set text in the text control."
+#~ msgstr "Hutsegitea idazki agintean idazkia ezartzerakoan."
+
+#~ msgid "Invalid GTK+ command line option, use \"%s --help\""
+#~ msgstr "GTK+ komando lerro aukera baliogabea, erabili \"%s --help\""
+
+#~ msgid "No unused colour in image."
+#~ msgstr "Ez dago erabiligabeko margorik irudian."
+
+#~ msgid "Not available"
+#~ msgstr "Eskuraezina"
+
+#~ msgid "Replace selection"
+#~ msgstr "Ordeztu hautapena"
+
+#~ msgid "Save as"
+#~ msgstr "Gorde honela"
+
+#~ msgid "Style Organiser"
+#~ msgstr "Estilo Antolatzailea"
+
+#~ msgid "The following standard GTK+ options are also supported:\n"
+#~ msgstr "Hurrengo GTK+ estandar aukerak ere sostengatuak dira:\n"
+
+#~ msgid "You cannot Clear an overlay that is not inited"
+#~ msgstr "Ezin duzu Garbitu hasita ez dagoen gainjarpena "
+
+#~ msgid "You cannot Init an overlay twice"
+#~ msgstr "Ezin duzu Hasi bi aldiko gainjarpenean"
+
+#~ msgid "locale '%s' cannot be set."
+#~ msgstr "tokiko '%s' ezin da ezarri."
+
+#~ msgid "Adding flavor TEXT failed"
+#~ msgstr "flavor TEXT gehitze hutsegitea"
+
+#~ msgid "Adding flavor utxt failed"
+#~ msgstr "flavor TEXT gehitze hutsegitea"
+
+#~ msgid "Bitmap renderer cannot render value; value type: "
+#~ msgstr "Bitmap aurkezleak ezin du balioa aurkeztu; balio mota:"
+
+#~ msgid ""
+#~ "Cannot create new column's ID. Probably max. number of columns reached."
+#~ msgstr ""
+#~ "Ezin da zutabe ID berririk. Zihurrenik geh. zutabe zenbatekoa erdietsita."
+
+#~ msgid "Column could not be added."
+#~ msgstr "Zutabea ezin da gehitu."
+
+#~ msgid "Column index not found."
+#~ msgstr "Zutabe aurkibidea ez da aurkitu."
+
+#~ msgid "Column width could not be determined"
+#~ msgstr "Zutabe zabalera ezin da zehaztu"
+
+#~ msgid "Column width could not be set."
+#~ msgstr "Zutabe zabalera ezin da ezarri."
+
+#~ msgid "Confirm registry update"
+#~ msgstr "Baieztatu erregistro eguneraketa"
+
+#~ msgid "Could not determine column index."
+#~ msgstr "Ezin da zutabe aurkibidea zehaztu."
+
+#~ msgid "Could not determine column's position"
+#~ msgstr "Ezin da zutabeen kokapena zehaztu."
+
+#~ msgid "Could not determine number of columns."
+#~ msgstr "Ezin da zutabe zenbatekoa zehaztu."
+
+#~ msgid "Could not determine number of items"
+#~ msgstr "Ezin da gai zenbatekoa zehaztu"
+
+#~ msgid "Could not get header description."
+#~ msgstr "Ezin da idazburu azalpena lortu."
+
+#~ msgid "Could not get items."
+#~ msgstr "Ezin dira gaiak lortu."
+
+#~ msgid "Could not get property flags."
+#~ msgstr "Ezin dira ezaugarri ikurrinak lortu."
+
+#~ msgid "Could not get selected items."
+#~ msgstr "Ezin dira hautatutako gaiak lortu."
+
+#~ msgid "Could not remove column."
+#~ msgstr "Ezin da zutabea kendu."
+
+#~ msgid "Could not retrieve number of items"
+#~ msgstr "Ezin da gai zenbatekoa berreskuratu"
+
+#~ msgid "Could not set column width."
+#~ msgstr "Ezin da zutabe zabalera ezarri."
+
+#~ msgid "Could not set header description."
+#~ msgstr "Ezin da idazburu azalpena ezarri."
+
+#~ msgid "Could not set icon."
+#~ msgstr "Ezin da ikurra ezarri"
+
+#~ msgid "Could not set maximum width."
+#~ msgstr "Ezin da gehienezkoa zabalera ezarri."
+
+#~ msgid "Could not set minimum width."
+#~ msgstr "Ezin da gutxieneko zabalera ezarri."
+
+#~ msgid "Could not set property flags."
+#~ msgstr "Ezin da ezaugarri ikurrinak ezarri."
+
+#~ msgid "Data object has invalid data format"
+#~ msgstr "Datu objetuak baliogabeko datu heuskarria du"
+
+#~ msgid "Date renderer cannot render value; value type: "
+#~ msgstr "Datu aurkezleak ezin du balioa aurkeztu; balio mota:"
+
+#~ msgid ""
+#~ "Do you want to overwrite the command used to %s files with extension "
+#~ "\"%s\" ?\n"
+#~ "Current value is \n"
+#~ "%s, \n"
+#~ "New value is \n"
+#~ "%s %1"
+#~ msgstr ""
+#~ "%s agirientzako erabilitako komandoa gainidaztea nahi duzu \"%s\" "
+#~ "luzapenarekin ?\n"
+#~ "Oraingo balioa da \n"
+#~ "%s, \n"
+#~ "Balio berria da \n"
+#~ "%s %1"
+
+#~ msgid "Failed to retrieve data from the clipboard."
+#~ msgstr "Hutsegitea gakotik datuak berreskuratzerakoan."
+
+#~ msgid "GIF: Invalid gif index."
+#~ msgstr "GIF: gif aurkibide baliogabea."
+
+#~ msgid "GIF: unknown error!!!"
+#~ msgstr "GIF: akats ezezaguna!!!"
+
+#~ msgid "Icon & text renderer cannot render value; value type: "
+#~ msgstr "Ikur eta idazki aurkezleak ezin du balioa aurkeztu; balio mota:"
+
+#~ msgid "New directory"
+#~ msgstr "Zuzenbide berria"
+
+#~ msgid "Next"
+#~ msgstr "Hurrengoa"
+
+#~ msgid "No column existing."
+#~ msgstr "Ez dago zutaberik."
+
+#~ msgid "No column for the specified column existing."
+#~ msgstr "Ez dago zutaberik adierazitako zutabearentzat."
+
+#~ msgid "No column for the specified column position existing."
+#~ msgstr "Ez dago zutaberik adierazitako zutabe kokapenean."
+
+#~ msgid ""
+#~ "No renderer or invalid renderer type specified for custom data column."
+#~ msgstr ""
+#~ "Ez da aurkezlerik edo baliogabeko aurkezle mota adierazi da egile datu "
+#~ "zutaberako."
+
+#~ msgid "No renderer specified for column."
+#~ msgstr "Ez da aurkezlerik adierazi zutaberako."
+
+#~ msgid "Number of columns could not be determined."
+#~ msgstr "Zutabe zenbatekoa ezin da zehaztu."
+
+#~ msgid "OpenGL function \"%s\" failed: %s (error %d)"
+#~ msgstr "\"%s\" GL funzio irekitze hutsegitea: %s (akatsa %d)"
+
+#~ msgid ""
+#~ "Please install a newer version of comctl32.dll\n"
+#~ "(at least version 4.70 is required but you have %d.%02d)\n"
+#~ "or this program won't operate correctly."
+#~ msgstr ""
+#~ "Mesedez ezarri comctl32.dll bertsio berriago bat\n"
+#~ "(gutxienez 4.70 bertsioa behar da baina zuk %d.%02d duzu)\n"
+#~ "edo programa honek ez du zuzen jardungo."
+
+#~ msgid "Pointer to data view control not set correctly."
+#~ msgstr "Datu ikuspen kontrolerako punta ez dago ongi ezarrita."
+
+#~ msgid "Pointer to model not set correctly."
+#~ msgstr "Ereduarentzako puntua ez dago ongi ezarrita."
+
+#~ msgid "Progress renderer cannot render value type; value type: "
+#~ msgstr "Garapen aurkeztzaileak ezin du aurkeztu balio mota; balio mota:"
+
+#~ msgid "Rendering failed."
+#~ msgstr "Aurkezpen hutsegitea."
+
+#~ msgid ""
+#~ "Setting directory access times is not supported under this OS version"
+#~ msgstr ""
+#~ "Zuzenbide sarbide denborak ezartzea ez dago sostengaturik SE bertsio "
+#~ "honetan"
+
+#~ msgid "Show hidden directories"
+#~ msgstr "Erakutsi eztutuko zuzenbideak"
+
+#~ msgid "Text renderer cannot render value; value type: "
+#~ msgstr "Idazki aurkezleak ezin du balioa aurkeztu; balio mota:"
+
+#~ msgid "There is no column or renderer for the specified column index."
+#~ msgstr ""
+#~ "Ez dago zutaberik edo aurkezlerik adierazitako zutabe aurkibidearentzat."
+
+#~ msgid ""
+#~ "This system doesn't support date controls, please upgrade your version of "
+#~ "comctl32.dll"
+#~ msgstr ""
+#~ "Sistemak ez ditu datu aginteak sostengatzen, mesedez eguneratu zure "
+#~ "comctl32.dll bertsioa "
+
+#~ msgid "Toggle renderer cannot render value; value type: "
+#~ msgstr "Aldatutako aurkezleak ezin du balioa aurkeztu; balio mota:"
+
+#~ msgid "Too many colours in PNG, the image may be slightly blurred."
+#~ msgstr "Margo gehiegi PNG-an, irudia apur bat lausotua izan daiteke."
+
+#~ msgid "Unable to handle native drag&drop data"
+#~ msgstr "Ezinezkoa jatorrizko arrastatu-eta-askatu datua kudeatzea"
+
+#~ msgid "Unable to initialize Hildon program"
+#~ msgstr "Ezinezkoa Hildon programa hastea"
+
+#~ msgid "Unknown data format"
+#~ msgstr "Datu heuskarri ezezaguna"
+
+#~ msgid "Valid pointer to native data view control does not exist"
+#~ msgstr "Jatorrizko datu ikuspen kontrolerako baliozko punta ez dago"
+
+#~ msgid "Win32s on Windows 3.1"
+#~ msgstr "Win32s Windows 3.1"
+
+#~ msgid "Windows 10"
+#~ msgstr "Windows 10"
+
+#~ msgid "Windows 2000"
+#~ msgstr "Windows 2000"
+
+#~ msgid "Windows 7"
+#~ msgstr "Windows 7"
+
+#~ msgid "Windows 8"
+#~ msgstr "Windows 8"
+
+#~ msgid "Windows 8.1"
+#~ msgstr "Windows 8.1"
+
+#~ msgid "Windows 95"
+#~ msgstr "Windows 95"
+
+#~ msgid "Windows 95 OSR2"
+#~ msgstr "Windows 95 OSR2"
+
+#~ msgid "Windows 98"
+#~ msgstr "Windows 98"
+
+#~ msgid "Windows 98 SE"
+#~ msgstr "Windows 98 SE"
+
+#~ msgid "Windows 9x (%d.%d)"
+#~ msgstr "Windows 9x (%d.%d)"
+
+#~ msgid "Windows CE (%d.%d)"
+#~ msgstr "Windows CE (%d.%d)"
+
+#~ msgid "Windows ME"
+#~ msgstr "Windows ME"
+
+#~ msgid "Windows NT %lu.%lu"
+#~ msgstr "Windows NT %lu.%lu"
+
+#~ msgid "Windows Server 10"
+#~ msgstr "Windows Server 10"
+
+#~ msgid "Windows Server 2003"
+#~ msgstr "Windows Server 2003"
+
+#~ msgid "Windows Server 2008"
+#~ msgstr "Windows Server 2008"
+
+#~ msgid "Windows Server 2008 R2"
+#~ msgstr "Windows Server 2008 R2"
+
+#~ msgid "Windows Server 2012"
+#~ msgstr "Windows Server 2012"
+
+#~ msgid "Windows Server 2012 R2"
+#~ msgstr "Windows Server 2012 R2"
+
+#~ msgid "Windows Vista"
+#~ msgstr "Windows Vista"
+
+#~ msgid "Windows XP"
+#~ msgstr "Windows XP"
+
+#~ msgid "can't execute '%s'"
+#~ msgstr "ezin da '%s' exekutatu"
+
+#~ msgid "error opening '%s'"
+#~ msgstr "akatsa '%s\" irekitzean"
+
+#~ msgid "unknown seek origin"
+#~ msgstr "bilaketa jatorri ezezaguna"
+
+#~ msgid "wxWidget control pointer is not a data view pointer"
+#~ msgstr "wxWidget-en aginte puntua ez da datu ikus puntua"
+
+#~ msgid "wxWidget's control not initialized."
+#~ msgstr "wxWidget-ren agintea hasi gabe."
+
+#~ msgid "ADD"
+#~ msgstr "ADD"
+
+#~ msgid "BACK"
+#~ msgstr "ATZERA"
+
+#~ msgid "CANCEL"
+#~ msgstr "EZEZTATU"
+
+#~ msgid "CAPITAL"
+#~ msgstr "LARRIA"
+
+#~ msgid "CLEAR"
+#~ msgstr "GARBITU"
+
+#~ msgid "COMMAND"
+#~ msgstr "AGINDUAK"
+
+#~ msgid "Cannot create mutex."
+#~ msgstr "Ezin da mutex sortu."
+
+#~ msgid "Cannot resume thread %lu"
+#~ msgstr "Ezin da %lu haria kendu"
+
+#~ msgid "Cannot suspend thread %lu"
+#~ msgstr "Ezin da %lu haria utzi"
+
+#~ msgid "Couldn't acquire a mutex lock"
+#~ msgstr "Ezinezkoa mutex blokeoa lortzea"
+
+#~ msgid "Couldn't get hatch style from wxBrush."
+#~ msgstr "Ezinezkoa itzal estiloa lortzea wxBrush-tik."
+
+#~ msgid "Couldn't release a mutex"
+#~ msgstr "Ezinezkoa mutex argitaratzea"
+
+#~ msgid "DECIMAL"
+#~ msgstr "HAMARRENA"
+
+#~ msgid "DEL"
+#~ msgstr "EZAB"
+
+#~ msgid "DELETE"
+#~ msgstr "EZABATU"
+
+#~ msgid "DIVIDE"
+#~ msgstr "ZATITU"
+
+#~ msgid "DOWN"
+#~ msgstr "BEHERA"
+
+#~ msgid "END"
+#~ msgstr "AMAIERA"
+
+#~ msgid "ENTER"
+#~ msgstr "SARTU"
+
+#~ msgid "ESC"
+#~ msgstr "IRT"
+
+#~ msgid "ESCAPE"
+#~ msgstr "IRTEN"
+
+#~ msgid "EXECUTE"
+#~ msgstr "EXEKUTATU"
+
+#~ msgid "Execution of command '%s' failed with error: %ul"
+#~ msgstr "Hutsegitea '%s' komandoa exekutatzerakoan, akatsa: %ul"
+
+#~ msgid ""
+#~ "File '%s' already exists.\n"
+#~ "Do you want to replace it?"
+#~ msgstr ""
+#~ "'%s' agiria jadanik badago.\n"
+#~ "Ordeztea nahi duzu?"
+
+#~ msgid "HELP"
+#~ msgstr "LAGUNTZA"
+
+#~ msgid "HOME"
+#~ msgstr "HASIERA"
+
+#~ msgid "INS"
+#~ msgstr "TXER"
+
+#~ msgid "INSERT"
+#~ msgstr "TXERTATU"
+
+#~ msgid "KP_BEGIN"
+#~ msgstr "ZT_HASIERA"
+
+#~ msgid "KP_DECIMAL"
+#~ msgstr "ZT_HAMARRENA"
+
+#~ msgid "KP_DELETE"
+#~ msgstr "ZT_EZABATU"
+
+#~ msgid "KP_DIVIDE"
+#~ msgstr "ZT_ZATITU"
+
+#~ msgid "KP_DOWN"
+#~ msgstr "ZT_BEHERA"
+
+#~ msgid "KP_ENTER"
+#~ msgstr "ZT_SARTU"
+
+#~ msgid "KP_EQUAL"
+#~ msgstr "ZT_BERDIN"
+
+#~ msgid "KP_HOME"
+#~ msgstr "ZT_HASIERA"
+
+#~ msgid "KP_INSERT"
+#~ msgstr "ZT_TXERTATU"
+
+#~ msgid "KP_LEFT"
+#~ msgstr "ZT_EZKER"
+
+#~ msgid "KP_MULTIPLY"
+#~ msgstr "ZT_BIDER"
+
+#~ msgid "KP_NEXT"
+#~ msgstr "ZT_HURRENGOA"
+
+#~ msgid "KP_PAGEDOWN"
+#~ msgstr "ZT_ORRBEHERA"
+
+#~ msgid "KP_PAGEUP"
+#~ msgstr "ZT_ORRGORA"
+
+#~ msgid "KP_PRIOR"
+#~ msgstr "ZT_LEHEN"
+
+#~ msgid "KP_RIGHT"
+#~ msgstr "ZT_ESKUIN"
+
+#~ msgid "KP_SEPARATOR"
+#~ msgstr "ZT_BANANTZAILEA"
+
+#~ msgid "KP_SPACE"
+#~ msgstr "ZT_TARTEA"
+
+#~ msgid "KP_SUBTRACT"
+#~ msgstr "ZT_KENKETA"
+
+#~ msgid "LEFT"
+#~ msgstr "EZKER"
+
+#~ msgid "MENU"
+#~ msgstr "MENUA"
+
+#~ msgid "NUM_LOCK"
+#~ msgstr "ZENB_BLOK"
+
+#~ msgid "PAGEDOWN"
+#~ msgstr "ORRBEHERA"
+
+#~ msgid "PAGEUP"
+#~ msgstr "ORRGORA"
+
+#~ msgid "PAUSE"
+#~ msgstr "PAUSA"
+
+#~ msgid "PGDN"
+#~ msgstr "ORRBEH"
+
+#~ msgid "PGUP"
+#~ msgstr "ORRGOR"
+
+#~ msgid "PRINT"
+#~ msgstr "IRARKITU"
+
+#~ msgid "RETURN"
+#~ msgstr "ITZULI"
+
+#~ msgid "RIGHT"
+#~ msgstr "ESKUIN"
+
+#~ msgid "SCROLL_LOCK"
+#~ msgstr "IRRISTARI_BLOKEOA"
+
+#~ msgid "SELECT"
+#~ msgstr "HAUTATU"
+
+#~ msgid "SEPARATOR"
+#~ msgstr "BANANTZAILEA"
+
+#~ msgid "SNAPSHOT"
+#~ msgstr "BEREHALAKOA"
+
+#~ msgid "SPACE"
+#~ msgstr "TARTEA"
+
+#~ msgid "SUBTRACT"
+#~ msgstr "KENKETA"
+
+#~ msgid "TAB"
+#~ msgstr "TAB"
+
+#~ msgid "The print dialog returned an error."
+#~ msgstr "Irarketa elkarrizketak akats bat itzuli du."
+
+#~ msgid "The wxGtkPrinterDC cannot be used."
+#~ msgstr "wxGtkPrinterDC ezin da erabili."
+
+#~ msgid "Timer creation failed."
+#~ msgstr "Denboragailu sortze hutsegitea."
+
+#~ msgid "UP"
+#~ msgstr "UP"
+
+#~ msgid "WINDOWS_LEFT"
+#~ msgstr "WINDOWS_EZKER"
+
+#~ msgid "WINDOWS_MENU"
+#~ msgstr "WINDOWS_MENUA"
+
+#~ msgid "WINDOWS_RIGHT"
+#~ msgstr "WINDOWS_ESKUIN"
+
+#~ msgid "buffer is too small for Windows directory."
+#~ msgstr "bufferra txikiegia da Windowsen zuzenbiderako."
+
+#~ msgid "not implemented"
+#~ msgstr "ez da egin"
+
+#~ msgid "wxPrintout::GetPageInfo gives a null maxPage."
+#~ msgstr "wxPrintout::GetPageInfok gehOrrialde nuloa ematen du."
+
+#~ msgid "Event queue overflowed"
+#~ msgstr "Gertaera lerroak gainezka eginda"
+
+#~ msgid "Print preview"
+#~ msgstr "Irarketa aurreikuspena"
+
+#~ msgid "percent"
+#~ msgstr "ehuneko"
+
+#~ msgid "'"
+#~ msgstr "'"
+
+#~ msgid "1"
+#~ msgstr "1"
+
+#~ msgid "10"
+#~ msgstr "10"
+
+#~ msgid "3"
+#~ msgstr "3"
+
+#~ msgid "4"
+#~ msgstr "4"
+
+#~ msgid "5"
+#~ msgstr "5"
+
+#~ msgid "6"
+#~ msgstr "6"
+
+#~ msgid "7"
+#~ msgstr "7"
+
+#~ msgid "8"
+#~ msgstr "8"
+
+#~ msgid "9"
+#~ msgstr "9"
+
+#~ msgid "Can't monitor non-existent path \"%s\" for changes."
+#~ msgstr "Ezin da monitorizatu ez-dagoen \"%s\" helburua aldaketetarako."
+
+#~ msgid "&Preview..."
+#~ msgstr "&Aurreikuspena..."
+
+#~ msgid "Preview..."
+#~ msgstr "Aurreikuspena..."
+
+#~ msgid "The vertical offset relative to the paragraph."
+#~ msgstr "Esaliarekiko zutikako antolakuntza erlatiboa."
+
+#~ msgid "Units for the object offset."
+#~ msgstr "Objetu antolakuntza unitateak."
+
+#~ msgid "&Save..."
+#~ msgstr "&Gorde..."
+
+#~ msgid "About "
+#~ msgstr "Honi buruz"
+
+#~ msgid "All files (*.*)|*"
+#~ msgstr "Agiri denak (*.*)|*"
+
+#~ msgid "Cannot initialize SciTech MGL!"
+#~ msgstr "Ezin da abiatu SciTech MGL!"
+
+#~ msgid "Cannot initialize display."
+#~ msgstr "Ezin da abiatu erakuspena."
+
+#~ msgid "Cannot start thread: error writing TLS"
+#~ msgstr "Ezin da haria hasi: akatsa TLS idazterakoan"
+
+#~ msgid "Close\tAlt-F4"
+#~ msgstr "Itxi\tAlt-F4"
+
+#~ msgid "Couldn't create cursor."
+#~ msgstr "Ezinezkoa kurtsorea sortzea."
+
+#~ msgid "Directory '%s' doesn't exist!"
+#~ msgstr "'%s' zuzenbidea ez dago!"
+
+#~ msgid "Mode %ix%i-%i not available."
+#~ msgstr "%ix%i-%i modua ez da eskuragarria."
+
+#~ msgid "Paper Size"
+#~ msgstr "Paper Neurria"
+
+#~ msgid "&Goto..."
+#~ msgstr "&Joan hona..."
+
+#~ msgid "<<"
+#~ msgstr "<<"
+
+#~ msgid ">>"
+#~ msgstr ">>"
+
+#~ msgid ">>|"
+#~ msgstr ">>|"
+
+#~ msgid "Added item is invalid."
+#~ msgstr "Gehitutako gaia baliogabea da."
+
+#~ msgid "BIG5"
+#~ msgstr "BIG5"
+
+#~ msgid "Can't check image format of file '%s': file does not exist."
+#~ msgstr "Ezin da '%s' agiriaren irudi heuskarria egiaztatu: agiria ez dago."
+
+#~ msgid "Can't load image from file '%s': file does not exist."
+#~ msgstr "Ezin da irudia gertatu '%s' agiritik: agiria ez dago."
+
+#~ msgid "Cannot open file '%s'."
+#~ msgstr "Ezinezkoa '%s' agiria irekitzea"
+
+#~ msgid "Changed item is invalid."
+#~ msgstr "Aldatutako gaia baliogabea da."
+
+#~ msgid "Click to cancel this window."
+#~ msgstr "Klikatu leiho hau ezeztatzeko"
+
+#~ msgid "Click to confirm your selection."
+#~ msgstr "Klikatu zure hautapena berresteko."
+
+#~ msgid "Column could not be added to native control."
+#~ msgstr "Zutabea ezin da jatorrizko agintera gehitu."
+
+#~ msgid "Column does not have a renderer."
+#~ msgstr "Zutabeak ez du aurkezlerik."
+
+#~ msgid "Column pointer must not be NULL."
+#~ msgstr "Zutabe puntua ezin da NULL izan."
+
+#~ msgid "Could not add column to internal structures."
+#~ msgstr "Ezin da zutaberik gehitu barneko egiteratara."
+
+#~ msgid "Enter a page number between %d and %d:"
+#~ msgstr "Sartu orrialde zenbaki bat %d eta %d artekoa:"
+
+#~ msgid "Failed to create a status bar."
+#~ msgstr "Hutsegitea egoera barra sortzerakoan."
+
+#~ msgid "GB-2312"
+#~ msgstr "GB-2312"
+
+#~ msgid "Goto Page"
+#~ msgstr "Joan Orrialdera"
+
+#~ msgid "I64"
+#~ msgstr "I64"
+
+#~ msgid "Internal error, illegal wxCustomTypeInfo"
+#~ msgstr "Barne akatsa, legezkanpoko wxCustomTypeInfo"
+
+#~ msgid "Model pointer not initialized."
+#~ msgstr "Modelo puntua ez da hasi."
+
+#~ msgid "No model associated with control."
+#~ msgstr "Ez dago modelorik elkartuta agintearekin."
+
+#~ msgid "SHIFT-JIS"
+#~ msgstr "SHIFT-JIS"
+
+#~ msgid "The path '%s' contains too many \"..\"!"
+#~ msgstr "'%s' helburuak \"..\" gehiegi ditu!"
+
+#~ msgid "To be deleted item is invalid."
+#~ msgstr "Gaia ezabatza baliogabea da."
+
+#~ msgid "Update"
+#~ msgstr "Eguneratu"
+
+#~ msgid "Value must be %lld or higher"
+#~ msgstr "Balioa izan behar da %lld edo handiagoa"
+
+#~ msgid "Value must be %llu or higher"
+#~ msgstr "Balioa izan behar da %llu edo handiagoa"
+
+#~ msgid "Value must be %llu or less"
+#~ msgstr "Balio izan behar da %llu edo txikiagoa"
+
+#~ msgid "Warning"
+#~ msgstr "Kontuz"
+
+#~ msgid "Windows 2000 (build %lu"
+#~ msgstr "Windows 2000 (build %lu"
+
+#~ msgid "delegate has no type info"
+#~ msgstr "ordezkariak ez du mota argibiderik"
+
+#~ msgid "wxSearchEngine::LookFor must be called before scanning!"
+#~ msgstr "wxSearchEngine::LookFor deitua izan behar da mihaketaren aurretik!"
+
+#~ msgid "|<<"
+#~ msgstr "|<<"
+
+#~ msgid "%i of %i"
+#~ msgstr "%i %i-tik"
+
+#~ msgid "KP_ADD"
+#~ msgstr "ZT_GEHITU"
+
+#~ msgid "KP_END"
+#~ msgstr "ZT_AMAIERA"
+
+#~ msgid "KP_TAB"
+#~ msgstr "ZT_TAB"
+
+#~ msgid "KP_UP"
+#~ msgstr "ZT_GORA"
+
+#~ msgid "Last repeated message (\"%s\", %lu time) wasn't output"
+#~ msgid_plural "Last repeated message (\"%s\", %lu times) wasn't output"
+#~ msgstr[0] "Berregindako azken mezua (\"%s\", %lu aldiz) ez zen irteera"
+#~ msgstr[1] "Berregindako azken mezua (\"%s\", %lu aldiz) ez zen irteera"
+
+#~ msgid "The previous message repeated %lu time."
+#~ msgid_plural "The previous message repeated %lu times."
+#~ msgstr[0] "Aurreko mezua %lu aldiz errepikatuta."
+#~ msgstr[1] "Aurreko mezua %lu aldiz errepikatuta."
+
+#~ msgid "Enable vertical offset."
+#~ msgstr "Gaitu zutikako antolakuntza."
+
+#~ msgid "Vertical &Offset:"
+#~ msgstr "Zutikako An&tolakuntza:"

--- a/po_wxstd/fa_IR.po
+++ b/po_wxstd/fa_IR.po
@@ -1,0 +1,9228 @@
+# Persian translations for wxWidgets
+# Copyright (C) 2020 wxWidgets dev team
+msgid ""
+msgstr ""
+"Project-Id-Version: wxWidgets 3.3\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-05-14 20:23+0200\n"
+"PO-Revision-Date: 2020-07-17 12:42+0430\n"
+"Last-Translator: \n"
+"Language-Team: Ali Asadi <ali.asadi@wxwidgets.ir>\n"
+"Language: fa_IR\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n==0 || n==1);\n"
+"X-Generator: Poedit 2.2\n"
+
+#: ../include/wx/defs.h:2582
+msgid "All files (*.*)|*.*"
+msgstr ""
+
+#: ../include/wx/defs.h:2585
+msgid "All files (*)|*"
+msgstr ""
+
+#: ../include/wx/generic/progdlgg.h:85
+msgid "Elapsed time:"
+msgstr ""
+
+#: ../include/wx/generic/progdlgg.h:86
+msgid "Estimated time:"
+msgstr ""
+
+#: ../include/wx/generic/progdlgg.h:87
+msgid "Remaining time:"
+msgstr ""
+
+#. TRANSLATORS: HTML printout default title.
+#: ../include/wx/html/htmprint.h:121 ../include/wx/prntbase.h:273
+#: ../include/wx/richtext/richtextprint.h:109 ../src/common/docview.cpp:2161
+msgid "Printout"
+msgstr ""
+
+#. TRANSLATORS: HTML easy print default title.
+#: ../include/wx/html/htmprint.h:234 ../include/wx/richtext/richtextprint.h:163
+#: ../src/common/prntbase.cpp:522 ../src/html/htmprint.cpp:291
+msgid "Printing"
+msgstr ""
+
+#: ../include/wx/msgdlg.h:277 ../src/common/stockitem.cpp:211
+msgid "Yes"
+msgstr ""
+
+#: ../include/wx/msgdlg.h:278 ../src/common/stockitem.cpp:182
+msgid "No"
+msgstr ""
+
+#: ../include/wx/msgdlg.h:279 ../src/common/stockitem.cpp:183
+#: ../src/msw/msgdlg.cpp:430 ../src/msw/msgdlg.cpp:734
+#: ../src/richtext/richtextstyledlg.cpp:292
+msgid "OK"
+msgstr ""
+
+#: ../include/wx/msgdlg.h:280 ../src/common/stockitem.cpp:150
+#: ../src/msw/msgdlg.cpp:430 ../src/msw/progdlg.cpp:884
+#: ../src/richtext/richtextstyledlg.cpp:295
+msgid "Cancel"
+msgstr ""
+
+#: ../include/wx/msgdlg.h:281 ../src/common/stockitem.cpp:168
+#: ../src/html/helpdlg.cpp:63 ../src/html/helpfrm.cpp:108
+#: ../src/osx/button_osx.cpp:38
+msgid "Help"
+msgstr ""
+
+#: ../include/wx/msw/ole/oleutils.h:52
+msgid "Cannot initialize OLE"
+msgstr ""
+
+#: ../include/wx/msw/private/fswatcher.h:48
+#, c-format
+msgid "Unable to close the handle for '%s'"
+msgstr ""
+
+#: ../include/wx/msw/private/fswatcher.h:92
+#, c-format
+msgid "Failed to open directory \"%s\" for monitoring."
+msgstr ""
+
+#: ../include/wx/msw/private/fswatcher.h:125
+msgid "Unable to close I/O completion port handle"
+msgstr ""
+
+#: ../include/wx/msw/private/fswatcher.h:142
+msgid "Unable to associate handle with I/O completion port"
+msgstr ""
+
+#: ../include/wx/msw/private/fswatcher.h:148
+msgid "Unexpectedly new I/O completion port was created"
+msgstr ""
+
+#: ../include/wx/msw/private/fswatcher.h:213
+msgid "Unable to post completion status"
+msgstr ""
+
+#: ../include/wx/msw/private/fswatcher.h:262
+msgid "Unable to dequeue completion packet"
+msgstr ""
+
+#: ../include/wx/msw/private/fswatcher.h:273
+msgid "Unable to create I/O completion port"
+msgstr ""
+
+#: ../include/wx/richmsgdlg.h:29
+msgid "&See details"
+msgstr ""
+
+#: ../include/wx/richmsgdlg.h:30
+msgid "&Hide details"
+msgstr ""
+
+#: ../include/wx/richtext/richtextbuffer.h:3864
+msgid "&Box"
+msgstr ""
+
+#: ../include/wx/richtext/richtextbuffer.h:5008
+msgid "&Picture"
+msgstr ""
+
+#: ../include/wx/richtext/richtextbuffer.h:5958
+msgid "&Cell"
+msgstr ""
+
+#: ../include/wx/richtext/richtextbuffer.h:6067
+msgid "&Table"
+msgstr ""
+
+#: ../include/wx/richtext/richtextimagedlg.h:37
+msgid "Object Properties"
+msgstr ""
+
+#: ../include/wx/richtext/richtextsymboldlg.h:39
+msgid "Symbols"
+msgstr ""
+
+#: ../include/wx/unix/pipe.h:46
+msgid "Pipe creation failed"
+msgstr ""
+
+#: ../include/wx/unix/private/displayx11.h:65
+msgid "Failed to enumerate video modes"
+msgstr ""
+
+#: ../include/wx/unix/private/displayx11.h:89
+msgid "Failed to change video mode"
+msgstr ""
+
+#: ../include/wx/unix/private/fswatcher_kqueue.h:57
+#, c-format
+msgid "Unable to open path '%s'"
+msgstr ""
+
+#: ../include/wx/unix/private/fswatcher_kqueue.h:74
+#, c-format
+msgid "Unable to close path '%s'"
+msgstr ""
+
+#: ../include/wx/xtiprop.h:175
+msgid "SetProperty called w/o valid setter"
+msgstr ""
+
+#: ../include/wx/xtiprop.h:184
+msgid "GetProperty called w/o valid getter"
+msgstr ""
+
+#: ../include/wx/xtiprop.h:193
+msgid "AddToPropertyCollection called w/o valid adder"
+msgstr ""
+
+#: ../include/wx/xtiprop.h:202
+msgid "GetPropertyCollection called w/o valid collection getter"
+msgstr ""
+
+#: ../include/wx/xtiprop.h:255
+msgid "AddToPropertyCollection called on a generic accessor"
+msgstr ""
+
+#: ../include/wx/xtiprop.h:262
+msgid "GetPropertyCollection called on a generic accessor"
+msgstr ""
+
+#: ../src/aui/tabmdi.cpp:106 ../src/generic/mdig.cpp:94
+msgid "Cl&ose"
+msgstr ""
+
+#: ../src/aui/tabmdi.cpp:107 ../src/generic/mdig.cpp:95
+msgid "Close All"
+msgstr ""
+
+#: ../src/aui/tabmdi.cpp:109 ../src/generic/mdig.cpp:97 ../src/msw/mdi.cpp:175
+#: ../src/qt/mdi.cpp:258
+msgid "&Next"
+msgstr ""
+
+#: ../src/aui/tabmdi.cpp:110 ../src/generic/mdig.cpp:98 ../src/msw/mdi.cpp:176
+#: ../src/qt/mdi.cpp:259
+msgid "&Previous"
+msgstr ""
+
+#: ../src/aui/tabmdi.cpp:332 ../src/aui/tabmdi.cpp:348
+#: ../src/aui/tabmdi.cpp:350 ../src/generic/mdig.cpp:291
+#: ../src/generic/mdig.cpp:307 ../src/generic/mdig.cpp:311
+#: ../src/msw/mdi.cpp:337 ../src/qt/mdi.cpp:462
+msgid "&Window"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:47
+msgctxt "keyboard key"
+msgid "Delete"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:48
+msgctxt "keyboard key"
+msgid "Del"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:49
+msgctxt "keyboard key"
+msgid "Back"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:49
+msgctxt "keyboard key"
+msgid "Backspace"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:50
+msgctxt "keyboard key"
+msgid "Insert"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:51
+msgctxt "keyboard key"
+msgid "Ins"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:52
+msgctxt "keyboard key"
+msgid "Enter"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:53
+msgctxt "keyboard key"
+msgid "Return"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:54
+msgctxt "keyboard key"
+msgid "PageUp"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:54
+msgctxt "keyboard key"
+msgid "Page Up"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:55
+msgctxt "keyboard key"
+msgid "PageDown"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:55
+msgctxt "keyboard key"
+msgid "Page Down"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:56
+msgctxt "keyboard key"
+msgid "PgUp"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:57
+msgctxt "keyboard key"
+msgid "PgDn"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:58
+msgctxt "keyboard key"
+msgid "Left"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:59
+msgctxt "keyboard key"
+msgid "Right"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:60
+msgctxt "keyboard key"
+msgid "Up"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:61
+msgctxt "keyboard key"
+msgid "Down"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:62
+msgctxt "keyboard key"
+msgid "Home"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:63
+msgctxt "keyboard key"
+msgid "End"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:64
+msgctxt "keyboard key"
+msgid "Space"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:65
+msgctxt "keyboard key"
+msgid "Tab"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:66
+msgctxt "keyboard key"
+msgid "Esc"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:67
+msgctxt "keyboard key"
+msgid "Escape"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:68
+msgctxt "keyboard key"
+msgid "Cancel"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:69
+msgctxt "keyboard key"
+msgid "Clear"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:70
+msgctxt "keyboard key"
+msgid "Menu"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:71
+msgctxt "keyboard key"
+msgid "Pause"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:72
+msgctxt "keyboard key"
+msgid "Capital"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:73
+msgctxt "keyboard key"
+msgid "Select"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:74
+msgctxt "keyboard key"
+msgid "Print"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:75
+msgctxt "keyboard key"
+msgid "Execute"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:76
+msgctxt "keyboard key"
+msgid "Snapshot"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:77
+msgctxt "keyboard key"
+msgid "Help"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:78
+msgctxt "keyboard key"
+msgid "Add"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:79
+msgctxt "keyboard key"
+msgid "Separator"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:80
+msgctxt "keyboard key"
+msgid "Subtract"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:81
+msgctxt "keyboard key"
+msgid "Decimal"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:82
+msgctxt "keyboard key"
+msgid "Multiply"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:83
+msgctxt "keyboard key"
+msgid "Divide"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:84
+msgctxt "keyboard key"
+msgid "Num_lock"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:84
+msgctxt "keyboard key"
+msgid "Num Lock"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:85
+msgctxt "keyboard key"
+msgid "Scroll_lock"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:85
+msgctxt "keyboard key"
+msgid "Scroll Lock"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:86
+msgctxt "keyboard key"
+msgid "KP_Space"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:86
+msgctxt "keyboard key"
+msgid "Num Space"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:87
+msgctxt "keyboard key"
+msgid "KP_Tab"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:87
+msgctxt "keyboard key"
+msgid "Num Tab"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:88
+msgctxt "keyboard key"
+msgid "KP_Enter"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:88
+msgctxt "keyboard key"
+msgid "Num Enter"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:89
+msgctxt "keyboard key"
+msgid "KP_Home"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:89
+msgctxt "keyboard key"
+msgid "Num Home"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:90
+msgctxt "keyboard key"
+msgid "KP_Left"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:90
+msgctxt "keyboard key"
+msgid "Num left"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:91
+msgctxt "keyboard key"
+msgid "KP_Up"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:91
+msgctxt "keyboard key"
+msgid "Num Up"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:92
+msgctxt "keyboard key"
+msgid "KP_Right"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:92
+msgctxt "keyboard key"
+msgid "Num Right"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:93
+msgctxt "keyboard key"
+msgid "KP_Down"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:93
+msgctxt "keyboard key"
+msgid "Num Down"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:94
+msgctxt "keyboard key"
+msgid "KP_PageUp"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:94
+msgctxt "keyboard key"
+msgid "Num Page Up"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:95
+msgctxt "keyboard key"
+msgid "KP_PageDown"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:95
+msgctxt "keyboard key"
+msgid "Num Page Down"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:96
+msgctxt "keyboard key"
+msgid "KP_Prior"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:97
+msgctxt "keyboard key"
+msgid "KP_Next"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:98
+msgctxt "keyboard key"
+msgid "KP_End"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:98
+msgctxt "keyboard key"
+msgid "Num End"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:99
+msgctxt "keyboard key"
+msgid "KP_Begin"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:99
+msgctxt "keyboard key"
+msgid "Num Begin"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:100
+msgctxt "keyboard key"
+msgid "KP_Insert"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:100
+msgctxt "keyboard key"
+msgid "Num Insert"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:101
+msgctxt "keyboard key"
+msgid "KP_Delete"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:101
+msgctxt "keyboard key"
+msgid "Num Delete"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:102
+msgctxt "keyboard key"
+msgid "KP_Equal"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:102
+msgctxt "keyboard key"
+msgid "Num ="
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:103
+msgctxt "keyboard key"
+msgid "KP_Multiply"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:103
+msgctxt "keyboard key"
+msgid "Num *"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:104
+msgctxt "keyboard key"
+msgid "KP_Add"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:104
+msgctxt "keyboard key"
+msgid "Num +"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:105
+msgctxt "keyboard key"
+msgid "KP_Separator"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:105
+msgctxt "keyboard key"
+msgid "Num ,"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:106
+msgctxt "keyboard key"
+msgid "KP_Subtract"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:106
+msgctxt "keyboard key"
+msgid "Num -"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:107
+msgctxt "keyboard key"
+msgid "KP_Decimal"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:107
+msgctxt "keyboard key"
+msgid "Num ."
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:108
+msgctxt "keyboard key"
+msgid "KP_Divide"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:108
+msgctxt "keyboard key"
+msgid "Num /"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:109
+msgctxt "keyboard key"
+msgid "Windows_Left"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:110
+msgctxt "keyboard key"
+msgid "Windows_Right"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:111
+msgctxt "keyboard key"
+msgid "Windows_Menu"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:112
+msgctxt "keyboard key"
+msgid "Command"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:186 ../src/common/accelcmn.cpp:359
+msgctxt "keyboard key"
+msgid "Ctrl"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:188 ../src/common/accelcmn.cpp:363
+msgctxt "keyboard key"
+msgid "Alt"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:190 ../src/common/accelcmn.cpp:361
+msgctxt "keyboard key"
+msgid "Shift"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:196
+msgctxt "keyboard key"
+msgid "num "
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:260 ../src/common/accelcmn.cpp:382
+msgctxt "keyboard key"
+msgid "F"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:277 ../src/common/accelcmn.cpp:385
+msgctxt "keyboard key"
+msgid "KP_F"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:280 ../src/common/accelcmn.cpp:388
+msgctxt "keyboard key"
+msgid "KP_"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:283 ../src/common/accelcmn.cpp:391
+msgctxt "keyboard key"
+msgid "SPECIAL"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:373
+msgid "Ctrl"
+msgstr ""
+
+#: ../src/common/appbase.cpp:786
+msgid "show this help message"
+msgstr ""
+
+#: ../src/common/appbase.cpp:796
+msgid "generate verbose log messages"
+msgstr ""
+
+#: ../src/common/appcmn.cpp:256
+msgid "specify the theme to use"
+msgstr ""
+
+#: ../src/common/appcmn.cpp:270
+msgid "specify display mode to use (e.g. 640x480-16)"
+msgstr ""
+
+#: ../src/common/appcmn.cpp:292
+#, c-format
+msgid "Unsupported theme '%s'."
+msgstr ""
+
+#: ../src/common/appcmn.cpp:309
+#, c-format
+msgid "Invalid display mode specification '%s'."
+msgstr ""
+
+#: ../src/common/cmdline.cpp:875
+#, c-format
+msgid "Option '%s' can't be negated"
+msgstr ""
+
+#: ../src/common/cmdline.cpp:889
+#, c-format
+msgid "Unknown long option '%s'"
+msgstr ""
+
+#: ../src/common/cmdline.cpp:904 ../src/common/cmdline.cpp:926
+#, c-format
+msgid "Unknown option '%s'"
+msgstr ""
+
+#: ../src/common/cmdline.cpp:1004
+#, c-format
+msgid "Unexpected characters following option '%s'."
+msgstr ""
+
+#: ../src/common/cmdline.cpp:1039
+#, c-format
+msgid "Option '%s' requires a value."
+msgstr ""
+
+#: ../src/common/cmdline.cpp:1058
+#, c-format
+msgid "Separator expected after the option '%s'."
+msgstr ""
+
+#: ../src/common/cmdline.cpp:1088 ../src/common/cmdline.cpp:1106
+#, c-format
+msgid "'%s' is not a correct numeric value for option '%s'."
+msgstr ""
+
+#: ../src/common/cmdline.cpp:1122
+#, c-format
+msgid "Option '%s': '%s' cannot be converted to a date."
+msgstr ""
+
+#: ../src/common/cmdline.cpp:1170
+#, c-format
+msgid "Unexpected parameter '%s'"
+msgstr ""
+
+#. TRANSLATORS: Short name and long name for a command line option
+#: ../src/common/cmdline.cpp:1197
+#, c-format
+msgid "%s (or %s)"
+msgstr "%s (or %s)"
+
+#: ../src/common/cmdline.cpp:1208
+#, c-format
+msgid "The value for the option '%s' must be specified."
+msgstr ""
+
+#: ../src/common/cmdline.cpp:1230
+#, c-format
+msgid "The required parameter '%s' was not specified."
+msgstr ""
+
+#: ../src/common/cmdline.cpp:1289
+#, c-format
+msgid "Usage: %s"
+msgstr ""
+
+#: ../src/common/cmdline.cpp:1498
+msgid "str"
+msgstr "رشته"
+
+#: ../src/common/cmdline.cpp:1502
+msgid "num"
+msgstr ""
+
+#: ../src/common/cmdline.cpp:1506
+msgid "double"
+msgstr ""
+
+#: ../src/common/cmdline.cpp:1510
+msgid "date"
+msgstr ""
+
+#: ../src/common/cmdproc.cpp:250 ../src/common/cmdproc.cpp:276
+#: ../src/common/cmdproc.cpp:296
+msgid "Unnamed command"
+msgstr ""
+
+#: ../src/common/cmdproc.cpp:253
+msgid "&Undo "
+msgstr ""
+
+#: ../src/common/cmdproc.cpp:255
+msgid "Can't &Undo "
+msgstr ""
+
+#: ../src/common/cmdproc.cpp:259 ../src/common/stockitem.cpp:208
+#: ../src/msw/textctrl.cpp:2880 ../src/osx/textctrl_osx.cpp:649
+#: ../src/richtext/richtextctrl.cpp:327
+msgid "&Undo"
+msgstr ""
+
+#: ../src/common/cmdproc.cpp:277 ../src/common/cmdproc.cpp:297
+msgid "&Redo "
+msgstr ""
+
+#: ../src/common/cmdproc.cpp:281 ../src/common/cmdproc.cpp:288
+#: ../src/common/stockitem.cpp:190 ../src/msw/textctrl.cpp:2881
+#: ../src/osx/textctrl_osx.cpp:650 ../src/richtext/richtextctrl.cpp:328
+msgid "&Redo"
+msgstr ""
+
+#: ../src/common/colourcmn.cpp:41
+#, c-format
+msgid "String To Colour : Incorrect colour specification : %s"
+msgstr ""
+
+#: ../src/common/config.cpp:259
+#, c-format
+msgid "Invalid value %ld for a boolean key \"%s\" in config file."
+msgstr ""
+
+#: ../src/common/config.cpp:526
+#, c-format
+msgid ""
+"Environment variables expansion failed: missing '%c' at position %u in '%s'."
+msgstr ""
+
+#: ../src/common/config.cpp:576 ../src/msw/regconf.cpp:272
+#, c-format
+msgid "'%s' has extra '..', ignored."
+msgstr ""
+
+#. TRANSLATORS: Checkbox state name
+#: ../src/common/datavcmn.cpp:2166 ../src/generic/datavgen.cpp:1430
+msgid "checked"
+msgstr ""
+
+#. TRANSLATORS: Checkbox state name
+#: ../src/common/datavcmn.cpp:2170 ../src/generic/datavgen.cpp:1432
+msgid "unchecked"
+msgstr ""
+
+#. TRANSLATORS: Checkbox state name
+#: ../src/common/datavcmn.cpp:2174
+msgid "undetermined"
+msgstr "نامشخص"
+
+#: ../src/common/datetimefmt.cpp:1875
+msgid "today"
+msgstr "امروز"
+
+#: ../src/common/datetimefmt.cpp:1876
+msgid "yesterday"
+msgstr "دیروز"
+
+#: ../src/common/datetimefmt.cpp:1877
+msgid "tomorrow"
+msgstr "فردا"
+
+#: ../src/common/datetimefmt.cpp:2071
+msgid "first"
+msgstr ""
+
+#: ../src/common/datetimefmt.cpp:2072
+msgid "second"
+msgstr ""
+
+#: ../src/common/datetimefmt.cpp:2073
+msgid "third"
+msgstr "سومین"
+
+#: ../src/common/datetimefmt.cpp:2074
+msgid "fourth"
+msgstr ""
+
+#: ../src/common/datetimefmt.cpp:2075
+msgid "fifth"
+msgstr ""
+
+#: ../src/common/datetimefmt.cpp:2076
+msgid "sixth"
+msgstr ""
+
+#: ../src/common/datetimefmt.cpp:2077
+msgid "seventh"
+msgstr ""
+
+#: ../src/common/datetimefmt.cpp:2078
+msgid "eighth"
+msgstr ""
+
+#: ../src/common/datetimefmt.cpp:2079
+msgid "ninth"
+msgstr ""
+
+#: ../src/common/datetimefmt.cpp:2080
+msgid "tenth"
+msgstr "دهم"
+
+#: ../src/common/datetimefmt.cpp:2081
+msgid "eleventh"
+msgstr ""
+
+#: ../src/common/datetimefmt.cpp:2082
+msgid "twelfth"
+msgstr "دوازدهم"
+
+#: ../src/common/datetimefmt.cpp:2083
+msgid "thirteenth"
+msgstr "سیزدهم"
+
+#: ../src/common/datetimefmt.cpp:2084
+msgid "fourteenth"
+msgstr ""
+
+#: ../src/common/datetimefmt.cpp:2085
+msgid "fifteenth"
+msgstr ""
+
+#: ../src/common/datetimefmt.cpp:2086
+msgid "sixteenth"
+msgstr ""
+
+#: ../src/common/datetimefmt.cpp:2087
+msgid "seventeenth"
+msgstr ""
+
+#: ../src/common/datetimefmt.cpp:2088
+msgid "eighteenth"
+msgstr ""
+
+#: ../src/common/datetimefmt.cpp:2089
+msgid "nineteenth"
+msgstr ""
+
+#: ../src/common/datetimefmt.cpp:2090
+msgid "twentieth"
+msgstr "بیستم"
+
+#: ../src/common/datetimefmt.cpp:2248
+msgid "noon"
+msgstr ""
+
+#: ../src/common/datetimefmt.cpp:2249
+msgid "midnight"
+msgstr ""
+
+#: ../src/common/debugrpt.cpp:209
+#, c-format
+msgid "Failed to create directory \"%s\""
+msgstr ""
+
+#: ../src/common/debugrpt.cpp:210
+msgid "Debug report couldn't be created."
+msgstr ""
+
+#: ../src/common/debugrpt.cpp:227
+#, c-format
+msgid "Failed to remove debug report file \"%s\""
+msgstr ""
+
+#: ../src/common/debugrpt.cpp:239
+#, c-format
+msgid "Failed to clean up debug report directory \"%s\""
+msgstr ""
+
+#: ../src/common/debugrpt.cpp:514
+msgid "process context description"
+msgstr ""
+
+#: ../src/common/debugrpt.cpp:538
+msgid "dump of the process state (binary)"
+msgstr ""
+
+#: ../src/common/debugrpt.cpp:553
+msgid "Debug report generation has failed."
+msgstr ""
+
+#: ../src/common/debugrpt.cpp:560
+#, c-format
+msgid ""
+"Processing debug report has failed, leaving the files in \"%s\" directory."
+msgstr ""
+
+#: ../src/common/debugrpt.cpp:573
+msgid "A debug report has been generated. It can be found in"
+msgstr ""
+
+#: ../src/common/debugrpt.cpp:576
+msgid "And includes the following files:\n"
+msgstr ""
+
+#: ../src/common/debugrpt.cpp:586
+msgid ""
+"\n"
+"Please send this report to the program maintainer, thank you!\n"
+msgstr ""
+"\n"
+"لطفا این گزارش را به نگهدار برنامه ارسال کنید ، متشکرم!\n"
+
+#: ../src/common/debugrpt.cpp:729
+msgid "Failed to execute curl, please install it in PATH."
+msgstr ""
+
+#: ../src/common/debugrpt.cpp:742
+#, c-format
+msgid "Failed to upload the debug report (error code %d)."
+msgstr ""
+
+#: ../src/common/docview.cpp:366
+msgid "Save As"
+msgstr ""
+
+#: ../src/common/docview.cpp:457
+msgid "Discard changes and reload the last saved version?"
+msgstr ""
+
+#: ../src/common/docview.cpp:488
+msgid "unnamed"
+msgstr "بی نام"
+
+#: ../src/common/docview.cpp:513
+#, c-format
+msgid "Do you want to save changes to %s?"
+msgstr ""
+
+#: ../src/common/docview.cpp:521 ../src/common/docview.cpp:560
+#: ../src/common/stockitem.cpp:195
+msgid "&Save"
+msgstr ""
+
+#: ../src/common/docview.cpp:522 ../src/common/docview.cpp:560
+msgid "&Discard changes"
+msgstr ""
+
+#: ../src/common/docview.cpp:523
+msgid "Do&n't close"
+msgstr ""
+
+#: ../src/common/docview.cpp:553
+#, c-format
+msgid "Do you want to save changes to %s before closing it?"
+msgstr ""
+
+#: ../src/common/docview.cpp:559
+msgid "The document must be closed."
+msgstr ""
+
+#: ../src/common/docview.cpp:571
+#, c-format
+msgid "Saving %s failed, would you like to retry?"
+msgstr ""
+
+#: ../src/common/docview.cpp:577
+msgid "Retry"
+msgstr ""
+
+#: ../src/common/docview.cpp:577
+msgid "Discard changes"
+msgstr ""
+
+#: ../src/common/docview.cpp:679
+#, c-format
+msgid "File \"%s\" could not be opened for writing."
+msgstr ""
+
+#: ../src/common/docview.cpp:685
+#, c-format
+msgid "Failed to save document to the file \"%s\"."
+msgstr ""
+
+#: ../src/common/docview.cpp:702
+#, c-format
+msgid "File \"%s\" could not be opened for reading."
+msgstr ""
+
+#: ../src/common/docview.cpp:714
+#, c-format
+msgid "Failed to read document from the file \"%s\"."
+msgstr ""
+
+#: ../src/common/docview.cpp:1236
+#, c-format
+msgid ""
+"The file '%s' doesn't exist and couldn't be opened.\n"
+"It has been removed from the most recently used files list."
+msgstr ""
+
+#: ../src/common/docview.cpp:1296
+msgid "Print preview creation failed."
+msgstr ""
+
+#: ../src/common/docview.cpp:1302
+msgid "Print Preview"
+msgstr ""
+
+#: ../src/common/docview.cpp:1517
+#, c-format
+msgid "The format of file '%s' couldn't be determined."
+msgstr ""
+
+#: ../src/common/docview.cpp:1643
+#, c-format
+msgid "unnamed%d"
+msgstr ""
+
+#: ../src/common/docview.cpp:1660
+msgid " - "
+msgstr ""
+
+#: ../src/common/docview.cpp:1791 ../src/common/docview.cpp:1844
+msgid "Open File"
+msgstr ""
+
+#: ../src/common/docview.cpp:1807
+msgid "File error"
+msgstr ""
+
+#: ../src/common/docview.cpp:1809
+msgid "Sorry, could not open this file."
+msgstr ""
+
+#: ../src/common/docview.cpp:1843
+msgid "Sorry, the format for this file is unknown."
+msgstr ""
+
+#: ../src/common/docview.cpp:1924
+msgid "Select a document template"
+msgstr ""
+
+#: ../src/common/docview.cpp:1925
+msgid "Templates"
+msgstr ""
+
+#: ../src/common/docview.cpp:1998
+msgid "Select a document view"
+msgstr ""
+
+#: ../src/common/docview.cpp:1999
+msgid "Views"
+msgstr ""
+
+#: ../src/common/dynlib.cpp:81
+#, c-format
+msgid "Failed to load shared library '%s'"
+msgstr ""
+
+#: ../src/common/dynlib.cpp:105
+#, c-format
+msgid "Couldn't find symbol '%s' in a dynamic library"
+msgstr ""
+
+#: ../src/common/ffile.cpp:56 ../src/common/file.cpp:215
+#, c-format
+msgid "can't open file '%s'"
+msgstr ""
+
+#: ../src/common/ffile.cpp:72
+#, c-format
+msgid "can't close file '%s'"
+msgstr ""
+
+#: ../src/common/ffile.cpp:106 ../src/common/ffile.cpp:131
+#, c-format
+msgid "Read error on file '%s'"
+msgstr ""
+
+#: ../src/common/ffile.cpp:148
+#, c-format
+msgid "Write error on file '%s'"
+msgstr ""
+
+#: ../src/common/ffile.cpp:182
+#, c-format
+msgid "failed to flush the file '%s'"
+msgstr ""
+
+#: ../src/common/ffile.cpp:222
+#, c-format
+msgid "Seek error on file '%s' (large files not supported by stdio)"
+msgstr ""
+
+#: ../src/common/ffile.cpp:232
+#, c-format
+msgid "Seek error on file '%s'"
+msgstr ""
+
+#: ../src/common/ffile.cpp:248
+#, c-format
+msgid "Can't find current position in file '%s'"
+msgstr ""
+
+#: ../src/common/ffile.cpp:349 ../src/common/file.cpp:569
+msgid "Failed to set temporary file permissions"
+msgstr ""
+
+#: ../src/common/ffile.cpp:371
+#, c-format
+msgid "can't remove file '%s'"
+msgstr ""
+
+#: ../src/common/ffile.cpp:376 ../src/common/file.cpp:591
+#, c-format
+msgid "can't commit changes to file '%s'"
+msgstr ""
+
+#: ../src/common/ffile.cpp:388 ../src/common/file.cpp:603
+#, c-format
+msgid "can't remove temporary file '%s'"
+msgstr ""
+
+#: ../src/common/file.cpp:162
+#, c-format
+msgid "can't create file '%s'"
+msgstr ""
+
+#: ../src/common/file.cpp:229
+#, c-format
+msgid "can't close file descriptor %d"
+msgstr ""
+
+#: ../src/common/file.cpp:332
+#, c-format
+msgid "can't read from file descriptor %d"
+msgstr ""
+
+#: ../src/common/file.cpp:351
+#, c-format
+msgid "can't write to file descriptor %d"
+msgstr ""
+
+#: ../src/common/file.cpp:390
+#, c-format
+msgid "can't flush file descriptor %d"
+msgstr ""
+
+#: ../src/common/file.cpp:432
+#, c-format
+msgid "can't seek on file descriptor %d"
+msgstr ""
+
+#: ../src/common/file.cpp:446
+#, c-format
+msgid "can't get seek position on file descriptor %d"
+msgstr ""
+
+#: ../src/common/file.cpp:475
+#, c-format
+msgid "can't find length of file on file descriptor %d"
+msgstr ""
+
+#: ../src/common/file.cpp:505
+#, c-format
+msgid "can't determine if the end of file is reached on descriptor %d"
+msgstr ""
+
+#: ../src/common/fileconf.cpp:352
+#, c-format
+msgid ""
+" and additionally, the existing configuration file was renamed to \"%s\" and "
+"couldn't be renamed back, please rename it to its original path \"%s\""
+msgstr ""
+
+#: ../src/common/fileconf.cpp:389
+msgid " due to the following error:\n"
+msgstr ""
+
+#: ../src/common/fileconf.cpp:412
+msgid "failed to rename the existing file"
+msgstr ""
+
+#: ../src/common/fileconf.cpp:421
+msgid "failed to create the new file directory"
+msgstr ""
+
+#: ../src/common/fileconf.cpp:428
+msgid "failed to move the file to the new location"
+msgstr ""
+
+#: ../src/common/fileconf.cpp:462
+#, c-format
+msgid "can't open global configuration file '%s'."
+msgstr ""
+
+#: ../src/common/fileconf.cpp:478
+#, c-format
+msgid "can't open user configuration file '%s'."
+msgstr ""
+
+#: ../src/common/fileconf.cpp:483
+#, c-format
+msgid "Changes won't be saved to avoid overwriting the existing file \"%s\""
+msgstr ""
+
+#: ../src/common/fileconf.cpp:583
+msgid "Error reading config options."
+msgstr ""
+
+#: ../src/common/fileconf.cpp:593
+msgid "Failed to read config options."
+msgstr ""
+
+#: ../src/common/fileconf.cpp:700
+#, c-format
+msgid "file '%s': unexpected character %c at line %zu."
+msgstr ""
+
+#: ../src/common/fileconf.cpp:736
+#, c-format
+msgid "file '%s', line %zu: '%s' ignored after group header."
+msgstr ""
+
+#: ../src/common/fileconf.cpp:765
+#, c-format
+msgid "file '%s', line %zu: '=' expected."
+msgstr ""
+
+#: ../src/common/fileconf.cpp:778
+#, c-format
+msgid "file '%s', line %zu: value for immutable key '%s' ignored."
+msgstr ""
+
+#: ../src/common/fileconf.cpp:788
+#, c-format
+msgid "file '%s', line %zu: key '%s' was first found at line %d."
+msgstr ""
+
+#: ../src/common/fileconf.cpp:1091
+#, c-format
+msgid "Config entry name cannot start with '%c'."
+msgstr ""
+
+#: ../src/common/fileconf.cpp:1146
+msgid "Failed to create configuration file directory."
+msgstr ""
+
+#: ../src/common/fileconf.cpp:1158
+msgid "can't open user configuration file."
+msgstr ""
+
+#: ../src/common/fileconf.cpp:1172
+msgid "can't write user configuration file."
+msgstr ""
+
+#: ../src/common/fileconf.cpp:1178
+msgid "Failed to update user configuration file."
+msgstr ""
+
+#: ../src/common/fileconf.cpp:1201
+msgid "Error saving user configuration data."
+msgstr ""
+
+#: ../src/common/fileconf.cpp:1313
+#, c-format
+msgid "can't delete user configuration file '%s'"
+msgstr ""
+
+#: ../src/common/fileconf.cpp:2007
+#, c-format
+msgid "entry '%s' appears more than once in group '%s'"
+msgstr ""
+
+#: ../src/common/fileconf.cpp:2021
+#, c-format
+msgid "attempt to change immutable key '%s' ignored."
+msgstr ""
+
+#: ../src/common/fileconf.cpp:2118
+#, c-format
+msgid "trailing backslash ignored in '%s'"
+msgstr ""
+
+#: ../src/common/fileconf.cpp:2153
+#, c-format
+msgid "unexpected \" at position %d in '%s'."
+msgstr ""
+
+#: ../src/common/filefn.cpp:474
+#, c-format
+msgid "Failed to copy the file '%s' to '%s'"
+msgstr ""
+
+#: ../src/common/filefn.cpp:487
+#, c-format
+msgid "Impossible to get permissions for file '%s'"
+msgstr ""
+
+#: ../src/common/filefn.cpp:501
+#, c-format
+msgid "Impossible to overwrite the file '%s'"
+msgstr ""
+
+#: ../src/common/filefn.cpp:508
+#, c-format
+msgid "Error copying the file '%s' to '%s'."
+msgstr ""
+
+#: ../src/common/filefn.cpp:556
+#, c-format
+msgid "Impossible to set permissions for the file '%s'"
+msgstr ""
+
+#: ../src/common/filefn.cpp:606
+#, c-format
+msgid ""
+"Failed to rename the file '%s' to '%s' because the destination file already "
+"exists."
+msgstr ""
+
+#: ../src/common/filefn.cpp:623
+#, c-format
+msgid "File '%s' couldn't be renamed '%s'"
+msgstr ""
+
+#: ../src/common/filefn.cpp:639
+#, c-format
+msgid "File '%s' couldn't be removed"
+msgstr ""
+
+#: ../src/common/filefn.cpp:666
+#, c-format
+msgid "Directory '%s' couldn't be created"
+msgstr ""
+
+#: ../src/common/filefn.cpp:680
+#, c-format
+msgid "Directory '%s' couldn't be deleted"
+msgstr ""
+
+#: ../src/common/filefn.cpp:714
+#, c-format
+msgid "Cannot enumerate files '%s'"
+msgstr ""
+
+#: ../src/common/filefn.cpp:798
+msgid "Failed to get the working directory"
+msgstr ""
+
+#: ../src/common/filefn.cpp:843
+msgid "Could not set current working directory"
+msgstr ""
+
+#: ../src/common/filefn.cpp:974
+#, c-format
+msgid "Files (%s)"
+msgstr ""
+
+#: ../src/common/filename.cpp:182
+#, c-format
+msgid "Failed to open '%s' for reading"
+msgstr ""
+
+#: ../src/common/filename.cpp:187
+#, c-format
+msgid "Failed to open '%s' for writing"
+msgstr ""
+
+#: ../src/common/filename.cpp:199
+msgid "Failed to close file handle"
+msgstr ""
+
+#: ../src/common/filename.cpp:1046
+msgid "Failed to create a temporary file name"
+msgstr ""
+
+#: ../src/common/filename.cpp:1081
+msgid "Failed to open temporary file."
+msgstr ""
+
+#: ../src/common/filename.cpp:2862
+#, c-format
+msgid "Failed to modify file times for '%s'"
+msgstr ""
+
+#: ../src/common/filename.cpp:2877
+#, c-format
+msgid "Failed to touch the file '%s'"
+msgstr ""
+
+#: ../src/common/filename.cpp:2958
+#, c-format
+msgid "Failed to retrieve file times for '%s'"
+msgstr ""
+
+#: ../src/common/filepickercmn.cpp:39 ../src/common/filepickercmn.cpp:40
+msgid "Browse"
+msgstr ""
+
+#: ../src/common/fldlgcmn.cpp:792 ../src/generic/filectrlg.cpp:1185
+#, c-format
+msgid "All files (%s)|%s"
+msgstr ""
+
+#. TRANSLATORS: %s are a file extension used to build a file wildcard string
+#: ../src/common/fldlgcmn.cpp:810
+#, c-format
+msgid "%s files (%s)|%s"
+msgstr "%s files (%s)|%s"
+
+#: ../src/common/fldlgcmn.cpp:1072
+#, c-format
+msgid "Load %s file"
+msgstr ""
+
+#: ../src/common/fldlgcmn.cpp:1074
+#, c-format
+msgid "Save %s file"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:144
+msgid "Western European (ISO-8859-1)"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:145
+msgid "Central European (ISO-8859-2)"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:146
+msgid "Esperanto (ISO-8859-3)"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:147
+msgid "Baltic (old) (ISO-8859-4)"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:148
+msgid "Cyrillic (ISO-8859-5)"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:149
+msgid "Arabic (ISO-8859-6)"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:150
+msgid "Greek (ISO-8859-7)"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:151
+msgid "Hebrew (ISO-8859-8)"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:152
+msgid "Turkish (ISO-8859-9)"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:153
+msgid "Nordic (ISO-8859-10)"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:154
+msgid "Thai (ISO-8859-11)"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:155
+msgid "Indian (ISO-8859-12)"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:156
+msgid "Baltic (ISO-8859-13)"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:157
+msgid "Celtic (ISO-8859-14)"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:158
+msgid "Western European with Euro (ISO-8859-15)"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:159
+msgid "KOI8-R"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:160
+msgid "KOI8-U"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:161
+msgid "Windows/DOS OEM Cyrillic (CP 866)"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:162
+msgid "Windows Thai (CP 874)"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:163
+msgid "Windows Japanese (CP 932) or Shift-JIS"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:164
+msgid "Windows Chinese Simplified (CP 936) or GB-2312"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:165
+msgid "Windows Korean (CP 949)"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:166
+msgid "Windows Chinese Traditional (CP 950) or Big-5"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:167
+msgid "Windows Central European (CP 1250)"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:168
+msgid "Windows Cyrillic (CP 1251)"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:169
+msgid "Windows Western European (CP 1252)"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:170
+msgid "Windows Greek (CP 1253)"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:171
+msgid "Windows Turkish (CP 1254)"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:172
+msgid "Windows Hebrew (CP 1255)"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:173
+msgid "Windows Arabic (CP 1256)"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:174
+msgid "Windows Baltic (CP 1257)"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:175
+msgid "Windows Vietnamese (CP 1258)"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:176
+msgid "Windows Johab (CP 1361)"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:177
+msgid "Windows/DOS OEM (CP 437)"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:178
+msgid "Unicode 7 bit (UTF-7)"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:179
+msgid "Unicode 8 bit (UTF-8)"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:181 ../src/common/fmapbase.cpp:187
+msgid "Unicode 16 bit (UTF-16)"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:182
+msgid "Unicode 16 bit Little Endian (UTF-16LE)"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:183 ../src/common/fmapbase.cpp:189
+msgid "Unicode 32 bit (UTF-32)"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:184
+msgid "Unicode 32 bit Little Endian (UTF-32LE)"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:186
+msgid "Unicode 16 bit Big Endian (UTF-16BE)"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:188
+msgid "Unicode 32 bit Big Endian (UTF-32BE)"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:191
+msgid "Extended Unix Codepage for Japanese (EUC-JP)"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:192
+msgid "US-ASCII"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:193
+msgid "ISO-2022-JP"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:195
+msgid "MacRoman"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:196
+msgid "MacJapanese"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:197
+msgid "MacChineseTrad"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:198
+msgid "MacKorean"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:199
+msgid "MacArabic"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:200
+msgid "MacHebrew"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:201
+msgid "MacGreek"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:202
+msgid "MacCyrillic"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:203
+msgid "MacDevanagari"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:204
+msgid "MacGurmukhi"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:205
+msgid "MacGujarati"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:206
+msgid "MacOriya"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:207
+msgid "MacBengali"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:208
+msgid "MacTamil"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:209
+msgid "MacTelugu"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:210
+msgid "MacKannada"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:211
+msgid "MacMalayalam"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:212
+msgid "MacSinhalese"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:213
+msgid "MacBurmese"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:214
+msgid "MacKhmer"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:215
+msgid "MacThai"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:216
+msgid "MacLaotian"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:217
+msgid "MacGeorgian"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:218
+msgid "MacArmenian"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:219
+msgid "MacChineseSimp"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:220
+msgid "MacTibetan"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:221
+msgid "MacMongolian"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:222
+msgid "MacEthiopic"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:223
+msgid "MacCentralEurRoman"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:224
+msgid "MacVietnamese"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:225
+msgid "MacExtArabic"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:226
+msgid "MacSymbol"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:227
+msgid "MacDingbats"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:228
+msgid "MacTurkish"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:229
+msgid "MacCroatian"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:230
+msgid "MacIcelandic"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:231
+msgid "MacRomanian"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:232
+msgid "MacCeltic"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:233
+msgid "MacGaelic"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:234
+msgid "MacKeyboardGlyphs"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:791
+msgid "Default encoding"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:805
+#, c-format
+msgid "Unknown encoding (%d)"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:815 ../src/richtext/richtextstyles.cpp:776
+msgid "default"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:829
+#, c-format
+msgid "unknown-%d"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:924 ../src/common/fontcmn.cpp:1130
+msgid "underlined"
+msgstr "زیر خط دار"
+
+#: ../src/common/fontcmn.cpp:929
+msgid " strikethrough"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:942
+msgid " thin"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:946
+#, fuzzy
+msgid " extra light"
+msgstr " سبک"
+
+#: ../src/common/fontcmn.cpp:950
+msgid " light"
+msgstr " سبک"
+
+#: ../src/common/fontcmn.cpp:954
+msgid " medium"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:958
+#, fuzzy
+msgid " semi bold"
+msgstr " پررنگ"
+
+#: ../src/common/fontcmn.cpp:962
+msgid " bold"
+msgstr " پررنگ"
+
+#: ../src/common/fontcmn.cpp:966
+#, fuzzy
+msgid " extra bold"
+msgstr " پررنگ"
+
+#: ../src/common/fontcmn.cpp:970
+msgid " heavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:974
+msgid " extra heavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:990
+msgid " italic"
+msgstr " مایل"
+
+#: ../src/common/fontcmn.cpp:1134
+msgid "strikethrough"
+msgstr "متن برجسته"
+
+#: ../src/common/fontcmn.cpp:1143
+msgid "thin"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1156
+#, fuzzy
+msgid "extralight"
+msgstr " سبک"
+
+#: ../src/common/fontcmn.cpp:1161
+msgid "light"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1169 ../src/richtext/richtextstyles.cpp:775
+msgid "normal"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1174
+msgid "medium"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1179 ../src/common/fontcmn.cpp:1199
+#, fuzzy
+msgid "semibold"
+msgstr " پررنگ"
+
+#: ../src/common/fontcmn.cpp:1184
+msgid "bold"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1194
+msgid "extrabold"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1204
+msgid "heavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1212
+msgid "extraheavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1217
+msgid "italic"
+msgstr ""
+
+#: ../src/common/fontmap.cpp:195
+msgid ": unknown charset"
+msgstr ": مجموعه کاراکتر ناشناس"
+
+#: ../src/common/fontmap.cpp:199
+#, c-format
+msgid ""
+"The charset '%s' is unknown. You may select\n"
+"another charset to replace it with or choose\n"
+"[Cancel] if it cannot be replaced"
+msgstr ""
+
+#: ../src/common/fontmap.cpp:241
+#, c-format
+msgid "Failed to remember the encoding for the charset '%s'."
+msgstr ""
+
+#: ../src/common/fontmap.cpp:321
+msgid "can't load any font, aborting"
+msgstr ""
+
+#: ../src/common/fontmap.cpp:409
+msgid ": unknown encoding"
+msgstr ": رمزگذاری ناشناخته"
+
+#: ../src/common/fontmap.cpp:417
+#, c-format
+msgid ""
+"No font for displaying text in encoding '%s' found,\n"
+"but an alternative encoding '%s' is available.\n"
+"Do you want to use this encoding (otherwise you will have to choose another "
+"one)?"
+msgstr ""
+
+#: ../src/common/fontmap.cpp:422
+#, c-format
+msgid ""
+"No font for displaying text in encoding '%s' found.\n"
+"Would you like to select a font to be used for this encoding\n"
+"(otherwise the text in this encoding will not be shown correctly)?"
+msgstr ""
+
+#: ../src/common/fs_mem.cpp:169
+#, c-format
+msgid "Memory VFS already contains file '%s'!"
+msgstr ""
+
+#: ../src/common/fs_mem.cpp:232
+#, c-format
+msgid "Trying to remove file '%s' from memory VFS, but it is not loaded!"
+msgstr ""
+
+#: ../src/common/fs_mem.cpp:262
+#, c-format
+msgid "Failed to store image '%s' to memory VFS!"
+msgstr ""
+
+#: ../src/common/ftp.cpp:197
+msgid "Timeout while waiting for FTP server to connect, try passive mode."
+msgstr ""
+
+#: ../src/common/ftp.cpp:399
+#, c-format
+msgid "Failed to set FTP transfer mode to %s."
+msgstr ""
+
+#: ../src/common/ftp.cpp:400 ../src/richtext/richtextsymboldlg.cpp:432
+msgid "ASCII"
+msgstr ""
+
+#: ../src/common/ftp.cpp:400
+msgid "binary"
+msgstr ""
+
+#: ../src/common/ftp.cpp:608
+msgid "The FTP server doesn't support the PORT command."
+msgstr ""
+
+#: ../src/common/ftp.cpp:622
+msgid "The FTP server doesn't support passive mode."
+msgstr ""
+
+#: ../src/common/gifdecod.cpp:822
+#, c-format
+msgid "Incorrect GIF frame size (%u, %d) for the frame #%u"
+msgstr ""
+
+#: ../src/common/glcmn.cpp:108
+msgid "Failed to allocate colour for OpenGL"
+msgstr ""
+
+#: ../src/common/headerctrlcmn.cpp:57
+msgid "Please select the columns to show and define their order:"
+msgstr ""
+
+#: ../src/common/headerctrlcmn.cpp:58
+msgid "Customize Columns"
+msgstr ""
+
+#: ../src/common/headerctrlcmn.cpp:304
+msgid "&Customize..."
+msgstr ""
+
+#: ../src/common/hyperlnkcmn.cpp:132
+#, c-format
+msgid "Failed to open URL \"%s\" in the default browser"
+msgstr ""
+
+#: ../src/common/iconbndl.cpp:195
+#, c-format
+msgid "Failed to load image %%d from file '%s'."
+msgstr ""
+
+#: ../src/common/iconbndl.cpp:203
+#, c-format
+msgid "Failed to load image %d from stream."
+msgstr ""
+
+#: ../src/common/iconbndl.cpp:221
+#, c-format
+msgid "Failed to load icons from resource '%s'."
+msgstr ""
+
+#: ../src/common/imagbmp.cpp:97
+msgid "BMP: Couldn't save invalid image."
+msgstr ""
+
+#: ../src/common/imagbmp.cpp:137
+msgid "BMP: wxImage doesn't have own wxPalette."
+msgstr ""
+
+#: ../src/common/imagbmp.cpp:243
+msgid "BMP: Couldn't write the file (Bitmap) header."
+msgstr ""
+
+#: ../src/common/imagbmp.cpp:266
+msgid "BMP: Couldn't write the file (BitmapInfo) header."
+msgstr ""
+
+#: ../src/common/imagbmp.cpp:353
+msgid "BMP: Couldn't write RGB color map."
+msgstr ""
+
+#: ../src/common/imagbmp.cpp:487
+msgid "BMP: Couldn't write data."
+msgstr ""
+
+#: ../src/common/imagbmp.cpp:561 ../src/common/imagbmp.cpp:642
+msgid "BMP: Couldn't allocate memory."
+msgstr ""
+
+#: ../src/common/imagbmp.cpp:1041
+msgid "DIB Header: Image width > 32767 pixels for file."
+msgstr ""
+
+#: ../src/common/imagbmp.cpp:1049
+msgid "DIB Header: Image height > 32767 pixels for file."
+msgstr ""
+
+#: ../src/common/imagbmp.cpp:1081
+msgid "DIB Header: Unknown bitdepth in file."
+msgstr ""
+
+#: ../src/common/imagbmp.cpp:1156
+msgid "DIB Header: Unknown encoding in file."
+msgstr ""
+
+#: ../src/common/imagbmp.cpp:1165
+msgid "DIB Header: Encoding doesn't match bitdepth."
+msgstr ""
+
+#: ../src/common/imagbmp.cpp:1180
+#, c-format
+msgid "BMP Header: Invalid number of colors (%d)."
+msgstr ""
+
+#: ../src/common/imagbmp.cpp:1273
+msgid "Error in reading image DIB."
+msgstr ""
+
+#: ../src/common/imagbmp.cpp:1294
+msgid "ICO: Error in reading mask DIB."
+msgstr ""
+
+#: ../src/common/imagbmp.cpp:1353
+msgid "ICO: Image too tall for an icon."
+msgstr ""
+
+#: ../src/common/imagbmp.cpp:1361
+msgid "ICO: Image too wide for an icon."
+msgstr ""
+
+#: ../src/common/imagbmp.cpp:1388 ../src/common/imagbmp.cpp:1488
+#: ../src/common/imagbmp.cpp:1503 ../src/common/imagbmp.cpp:1514
+#: ../src/common/imagbmp.cpp:1528 ../src/common/imagbmp.cpp:1576
+#: ../src/common/imagbmp.cpp:1591 ../src/common/imagbmp.cpp:1605
+#: ../src/common/imagbmp.cpp:1616
+msgid "ICO: Error writing the image file!"
+msgstr ""
+
+#: ../src/common/imagbmp.cpp:1701
+msgid "ICO: Invalid icon index."
+msgstr ""
+
+#: ../src/common/image.cpp:2410
+msgid "Image and mask have different sizes."
+msgstr ""
+
+#: ../src/common/image.cpp:2418 ../src/common/image.cpp:2459
+msgid "No unused colour in image being masked."
+msgstr ""
+
+#: ../src/common/image.cpp:2641
+#, c-format
+msgid "Failed to load bitmap \"%s\" from resources."
+msgstr ""
+
+#: ../src/common/image.cpp:2650
+#, c-format
+msgid "Failed to load icon \"%s\" from resources."
+msgstr ""
+
+#: ../src/common/image.cpp:2728 ../src/common/image.cpp:2747
+#, c-format
+msgid "Failed to load image from file \"%s\"."
+msgstr ""
+
+#: ../src/common/image.cpp:2761
+#, c-format
+msgid "Can't save image to file '%s': unknown extension."
+msgstr ""
+
+#: ../src/common/image.cpp:2869
+msgid "No handler found for image type."
+msgstr ""
+
+#: ../src/common/image.cpp:2877 ../src/common/image.cpp:3000
+#: ../src/common/image.cpp:3066
+#, c-format
+msgid "No image handler for type %d defined."
+msgstr ""
+
+#: ../src/common/image.cpp:2887
+#, c-format
+msgid "Image file is not of type %d."
+msgstr ""
+
+#: ../src/common/image.cpp:2970
+msgid "Can't automatically determine the image format for non-seekable input."
+msgstr ""
+
+#: ../src/common/image.cpp:2988
+msgid "Unknown image data format."
+msgstr ""
+
+#: ../src/common/image.cpp:3009
+#, c-format
+msgid "This is not a %s."
+msgstr ""
+
+#: ../src/common/image.cpp:3032 ../src/common/image.cpp:3080
+#, c-format
+msgid "No image handler for type %s defined."
+msgstr ""
+
+#: ../src/common/image.cpp:3041
+#, c-format
+msgid "Image is not of type %s."
+msgstr ""
+
+#: ../src/common/image.cpp:3509
+#, c-format
+msgid "Failed to check format of image file \"%s\"."
+msgstr ""
+
+#: ../src/common/imaggif.cpp:124
+msgid "GIF: error in GIF image format."
+msgstr ""
+
+#: ../src/common/imaggif.cpp:129
+msgid "GIF: not enough memory."
+msgstr ""
+
+#: ../src/common/imaggif.cpp:134
+msgid "GIF: data stream seems to be truncated."
+msgstr ""
+
+#: ../src/common/imaggif.cpp:240
+msgid "Couldn't initialize GIF hash table."
+msgstr ""
+
+#: ../src/common/imagiff.cpp:739
+msgid "IFF: error in IFF image format."
+msgstr ""
+
+#: ../src/common/imagiff.cpp:742
+msgid "IFF: not enough memory."
+msgstr ""
+
+#: ../src/common/imagiff.cpp:745
+msgid "IFF: unknown error!!!"
+msgstr ""
+
+#: ../src/common/imagiff.cpp:755
+msgid "IFF: data stream seems to be truncated."
+msgstr ""
+
+#: ../src/common/imagjpeg.cpp:258
+msgid "JPEG: Couldn't load - file is probably corrupted."
+msgstr ""
+
+#: ../src/common/imagjpeg.cpp:437
+msgid "JPEG: Couldn't save image."
+msgstr ""
+
+#: ../src/common/imagpcx.cpp:439
+msgid "PCX: this is not a PCX file."
+msgstr ""
+
+#: ../src/common/imagpcx.cpp:453
+msgid "PCX: image format unsupported"
+msgstr ""
+
+#: ../src/common/imagpcx.cpp:454 ../src/common/imagpcx.cpp:477
+msgid "PCX: couldn't allocate memory"
+msgstr ""
+
+#: ../src/common/imagpcx.cpp:455
+msgid "PCX: version number too low"
+msgstr ""
+
+#: ../src/common/imagpcx.cpp:456 ../src/common/imagpcx.cpp:478
+msgid "PCX: unknown error !!!"
+msgstr ""
+
+#: ../src/common/imagpcx.cpp:476
+msgid "PCX: invalid image"
+msgstr ""
+
+#: ../src/common/imagpng.cpp:385
+#, c-format
+msgid "Unknown PNG resolution unit %d"
+msgstr ""
+
+#: ../src/common/imagpng.cpp:439
+msgid "Couldn't load a PNG image - file is corrupted or not enough memory."
+msgstr ""
+
+#: ../src/common/imagpng.cpp:513 ../src/common/imagpng.cpp:524
+#: ../src/common/imagpng.cpp:534
+msgid "Couldn't save PNG image."
+msgstr ""
+
+#: ../src/common/imagpnm.cpp:71
+msgid "PNM: File format is not recognized."
+msgstr ""
+
+#: ../src/common/imagpnm.cpp:89
+msgid "PNM: Couldn't allocate memory."
+msgstr ""
+
+#: ../src/common/imagpnm.cpp:111 ../src/common/imagpnm.cpp:134
+#: ../src/common/imagpnm.cpp:156
+msgid "PNM: File seems truncated."
+msgstr ""
+
+#: ../src/common/imagtiff.cpp:69
+#, c-format
+msgid " (in module \"%s\")"
+msgstr ""
+
+#: ../src/common/imagtiff.cpp:304
+msgid "TIFF: Error loading image."
+msgstr ""
+
+#: ../src/common/imagtiff.cpp:314
+msgid "Invalid TIFF image index."
+msgstr ""
+
+#: ../src/common/imagtiff.cpp:358
+msgid "TIFF: Image size is abnormally big."
+msgstr ""
+
+#: ../src/common/imagtiff.cpp:372 ../src/common/imagtiff.cpp:385
+#: ../src/common/imagtiff.cpp:769
+msgid "TIFF: Couldn't allocate memory."
+msgstr ""
+
+#: ../src/common/imagtiff.cpp:471
+msgid "TIFF: Error reading image."
+msgstr ""
+
+#: ../src/common/imagtiff.cpp:532
+#, c-format
+msgid "Unknown TIFF resolution unit %d ignored"
+msgstr ""
+
+#: ../src/common/imagtiff.cpp:611
+msgid "TIFF: Error saving image."
+msgstr ""
+
+#: ../src/common/imagtiff.cpp:868
+msgid "TIFF: Error writing image."
+msgstr ""
+
+#: ../src/common/imagtiff.cpp:881
+msgid "TIFF: Error flushing data."
+msgstr ""
+
+#: ../src/common/imagwebp.cpp:56
+msgid "WebP: Invalid data (failed to get features)."
+msgstr ""
+
+#: ../src/common/imagwebp.cpp:65
+msgid "WebP: Allocating image memory failed."
+msgstr ""
+
+#: ../src/common/imagwebp.cpp:82
+msgid "WebP: Decoding RGBA image data failed."
+msgstr ""
+
+#: ../src/common/imagwebp.cpp:98
+msgid "WebP: Decoding RGB image data failed."
+msgstr ""
+
+#: ../src/common/imagwebp.cpp:113 ../src/common/imagwebp.cpp:201
+msgid "WebP: Allocating stream buffer failed."
+msgstr ""
+
+#: ../src/common/imagwebp.cpp:131
+msgid "WebP: Failed to parse container data."
+msgstr ""
+
+#: ../src/common/imagwebp.cpp:222
+msgid "WebP: Error decoding animation."
+msgstr ""
+
+#: ../src/common/imagwebp.cpp:240
+msgid "WebP: Error getting next animation frame."
+msgstr ""
+
+#: ../src/common/init.cpp:172
+#, c-format
+msgid ""
+"Command line argument %d couldn't be converted to Unicode and will be "
+"ignored."
+msgstr ""
+
+#: ../src/common/init.cpp:344
+msgid "Initialization failed in post init, aborting."
+msgstr ""
+
+#: ../src/common/intl.cpp:378
+#, c-format
+msgid "Cannot set locale to language \"%s\"."
+msgstr ""
+
+#: ../src/common/log.cpp:232
+msgid "Error: "
+msgstr ""
+
+#: ../src/common/log.cpp:236
+msgid "Warning: "
+msgstr ""
+
+#: ../src/common/log.cpp:284
+msgid "The previous message repeated once."
+msgstr ""
+
+#: ../src/common/log.cpp:291
+#, c-format
+msgid "The previous message repeated %u time."
+msgid_plural "The previous message repeated %u times."
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../src/common/log.cpp:319
+#, c-format
+msgid "Last repeated message (\"%s\", %u time) wasn't output"
+msgid_plural "Last repeated message (\"%s\", %u times) wasn't output"
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../src/common/log.cpp:435
+#, c-format
+msgid " (error %ld: %s)"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:121
+msgid "Failed to allocate memory for LZMA decompression."
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:125
+#, c-format
+msgid "Failed to initialize LZMA decompression: unexpected error %u."
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:179
+msgid "input is not in XZ format"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:183
+msgid "input compressed using unknown XZ option"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:188
+msgid "input is corrupted"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:192
+#, fuzzy
+msgid "unknown decompression error"
+msgstr "خطای ناشناخته"
+
+#: ../src/common/lzmastream.cpp:196
+#, c-format
+msgid "LZMA decompression error: %s"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:231
+msgid "Failed to allocate memory for LZMA compression."
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:235
+#, c-format
+msgid "Failed to initialize LZMA compression: unexpected error %u."
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:267 ../src/common/lzmastream.cpp:342
+#: ../src/html/chm.cpp:336
+msgid "out of memory"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:276 ../src/common/lzmastream.cpp:346
+#, fuzzy
+msgid "unknown compression error"
+msgstr "خطای ناشناخته"
+
+#: ../src/common/lzmastream.cpp:280
+#, c-format
+msgid "LZMA compression error: %s"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:350
+#, c-format
+msgid "LZMA compression error when flushing output: %s"
+msgstr ""
+
+#: ../src/common/mimecmn.cpp:167
+#, c-format
+msgid "Unmatched '{' in an entry for mime type %s."
+msgstr ""
+
+#: ../src/common/module.cpp:76
+#, c-format
+msgid "Circular dependency involving module \"%s\" detected."
+msgstr ""
+
+#: ../src/common/module.cpp:128
+#, c-format
+msgid "Dependency \"%s\" of module \"%s\" doesn't exist."
+msgstr ""
+
+#: ../src/common/module.cpp:137
+#, c-format
+msgid "Module \"%s\" initialization failed"
+msgstr ""
+
+#: ../src/common/msgout.cpp:96
+msgid "Message"
+msgstr ""
+
+#: ../src/common/paper.cpp:70
+msgid "Letter, 8 1/2 x 11 in"
+msgstr ""
+
+#: ../src/common/paper.cpp:71
+msgid "Legal, 8 1/2 x 14 in"
+msgstr ""
+
+#: ../src/common/paper.cpp:72
+msgid "A4 sheet, 210 x 297 mm"
+msgstr ""
+
+#: ../src/common/paper.cpp:73
+msgid "C sheet, 17 x 22 in"
+msgstr ""
+
+#: ../src/common/paper.cpp:74
+msgid "D sheet, 22 x 34 in"
+msgstr ""
+
+#: ../src/common/paper.cpp:75
+msgid "E sheet, 34 x 44 in"
+msgstr ""
+
+#: ../src/common/paper.cpp:76
+msgid "Letter Small, 8 1/2 x 11 in"
+msgstr ""
+
+#: ../src/common/paper.cpp:77
+msgid "Tabloid, 11 x 17 in"
+msgstr ""
+
+#: ../src/common/paper.cpp:78
+msgid "Ledger, 17 x 11 in"
+msgstr ""
+
+#: ../src/common/paper.cpp:79
+msgid "Statement, 5 1/2 x 8 1/2 in"
+msgstr ""
+
+#: ../src/common/paper.cpp:80
+msgid "Executive, 7 1/4 x 10 1/2 in"
+msgstr ""
+
+#: ../src/common/paper.cpp:81
+msgid "A3 sheet, 297 x 420 mm"
+msgstr ""
+
+#: ../src/common/paper.cpp:82
+msgid "A4 small sheet, 210 x 297 mm"
+msgstr ""
+
+#: ../src/common/paper.cpp:83
+msgid "A5 sheet, 148 x 210 mm"
+msgstr ""
+
+#: ../src/common/paper.cpp:84
+msgid "B4 sheet, 250 x 354 mm"
+msgstr ""
+
+#: ../src/common/paper.cpp:85
+msgid "B5 sheet, 182 x 257 millimeter"
+msgstr ""
+
+#: ../src/common/paper.cpp:86
+msgid "Folio, 8 1/2 x 13 in"
+msgstr ""
+
+#: ../src/common/paper.cpp:87
+msgid "Quarto, 215 x 275 mm"
+msgstr ""
+
+#: ../src/common/paper.cpp:88
+msgid "10 x 14 in"
+msgstr "10 x 14 in"
+
+#: ../src/common/paper.cpp:89
+msgid "11 x 17 in"
+msgstr "11 x 17 in"
+
+#: ../src/common/paper.cpp:90
+msgid "Note, 8 1/2 x 11 in"
+msgstr ""
+
+#: ../src/common/paper.cpp:91
+msgid "#9 Envelope, 3 7/8 x 8 7/8 in"
+msgstr "#9 Envelope, 3 7/8 x 8 7/8 in"
+
+#: ../src/common/paper.cpp:92
+msgid "#10 Envelope, 4 1/8 x 9 1/2 in"
+msgstr "#10 Envelope, 4 1/8 x 9 1/2 in"
+
+#: ../src/common/paper.cpp:93
+msgid "#11 Envelope, 4 1/2 x 10 3/8 in"
+msgstr "#11 Envelope, 4 1/2 x 10 3/8 in"
+
+#: ../src/common/paper.cpp:94
+msgid "#12 Envelope, 4 3/4 x 11 in"
+msgstr "#12 Envelope, 4 3/4 x 11 in"
+
+#: ../src/common/paper.cpp:95
+msgid "#14 Envelope, 5 x 11 1/2 in"
+msgstr "#14 Envelope, 5 x 11 1/2 in"
+
+#: ../src/common/paper.cpp:96
+msgid "DL Envelope, 110 x 220 mm"
+msgstr ""
+
+#: ../src/common/paper.cpp:97
+msgid "C5 Envelope, 162 x 229 mm"
+msgstr ""
+
+#: ../src/common/paper.cpp:98
+msgid "C3 Envelope, 324 x 458 mm"
+msgstr ""
+
+#: ../src/common/paper.cpp:99
+msgid "C4 Envelope, 229 x 324 mm"
+msgstr ""
+
+#: ../src/common/paper.cpp:100
+msgid "C6 Envelope, 114 x 162 mm"
+msgstr ""
+
+#: ../src/common/paper.cpp:101
+msgid "C65 Envelope, 114 x 229 mm"
+msgstr ""
+
+#: ../src/common/paper.cpp:102
+msgid "B4 Envelope, 250 x 353 mm"
+msgstr ""
+
+#: ../src/common/paper.cpp:103
+msgid "B5 Envelope, 176 x 250 mm"
+msgstr ""
+
+#: ../src/common/paper.cpp:104
+msgid "B6 Envelope, 176 x 125 mm"
+msgstr ""
+
+#: ../src/common/paper.cpp:105
+msgid "Italy Envelope, 110 x 230 mm"
+msgstr ""
+
+#: ../src/common/paper.cpp:106
+msgid "Monarch Envelope, 3 7/8 x 7 1/2 in"
+msgstr ""
+
+#: ../src/common/paper.cpp:107
+msgid "6 3/4 Envelope, 3 5/8 x 6 1/2 in"
+msgstr "6 3/4 Envelope, 3 5/8 x 6 1/2 in"
+
+#: ../src/common/paper.cpp:108
+msgid "US Std Fanfold, 14 7/8 x 11 in"
+msgstr ""
+
+#: ../src/common/paper.cpp:109
+msgid "German Std Fanfold, 8 1/2 x 12 in"
+msgstr ""
+
+#: ../src/common/paper.cpp:110
+msgid "German Legal Fanfold, 8 1/2 x 13 in"
+msgstr ""
+
+#: ../src/common/paper.cpp:112
+msgid "B4 (ISO) 250 x 353 mm"
+msgstr ""
+
+#: ../src/common/paper.cpp:113
+msgid "Japanese Postcard 100 x 148 mm"
+msgstr ""
+
+#: ../src/common/paper.cpp:114
+msgid "9 x 11 in"
+msgstr "9 x 11 in"
+
+#: ../src/common/paper.cpp:115
+msgid "10 x 11 in"
+msgstr "10 x 11 in"
+
+#: ../src/common/paper.cpp:116
+msgid "15 x 11 in"
+msgstr "15 x 11 in"
+
+#: ../src/common/paper.cpp:117
+msgid "Envelope Invite 220 x 220 mm"
+msgstr ""
+
+#: ../src/common/paper.cpp:118
+msgid "Letter Extra 9 1/2 x 12 in"
+msgstr ""
+
+#: ../src/common/paper.cpp:119
+msgid "Legal Extra 9 1/2 x 15 in"
+msgstr ""
+
+#: ../src/common/paper.cpp:120
+msgid "Tabloid Extra 11.69 x 18 in"
+msgstr ""
+
+#: ../src/common/paper.cpp:121
+msgid "A4 Extra 9.27 x 12.69 in"
+msgstr ""
+
+#: ../src/common/paper.cpp:122
+msgid "Letter Transverse 8 1/2 x 11 in"
+msgstr ""
+
+#: ../src/common/paper.cpp:123
+msgid "A4 Transverse 210 x 297 mm"
+msgstr ""
+
+#: ../src/common/paper.cpp:124
+msgid "Letter Extra Transverse 9.275 x 12 in"
+msgstr ""
+
+#: ../src/common/paper.cpp:125
+msgid "SuperA/SuperA/A4 227 x 356 mm"
+msgstr ""
+
+#: ../src/common/paper.cpp:126
+msgid "SuperB/SuperB/A3 305 x 487 mm"
+msgstr ""
+
+#: ../src/common/paper.cpp:127
+msgid "Letter Plus 8 1/2 x 12.69 in"
+msgstr ""
+
+#: ../src/common/paper.cpp:128
+msgid "A4 Plus 210 x 330 mm"
+msgstr ""
+
+#: ../src/common/paper.cpp:129
+msgid "A5 Transverse 148 x 210 mm"
+msgstr ""
+
+#: ../src/common/paper.cpp:130
+msgid "B5 (JIS) Transverse 182 x 257 mm"
+msgstr ""
+
+#: ../src/common/paper.cpp:131
+msgid "A3 Extra 322 x 445 mm"
+msgstr ""
+
+#: ../src/common/paper.cpp:132
+msgid "A5 Extra 174 x 235 mm"
+msgstr ""
+
+#: ../src/common/paper.cpp:133
+msgid "B5 (ISO) Extra 201 x 276 mm"
+msgstr ""
+
+#: ../src/common/paper.cpp:134
+msgid "A2 420 x 594 mm"
+msgstr ""
+
+#: ../src/common/paper.cpp:135
+msgid "A3 Transverse 297 x 420 mm"
+msgstr ""
+
+#: ../src/common/paper.cpp:136
+msgid "A3 Extra Transverse 322 x 445 mm"
+msgstr ""
+
+#: ../src/common/paper.cpp:138
+msgid "Japanese Double Postcard 200 x 148 mm"
+msgstr ""
+
+#: ../src/common/paper.cpp:139
+msgid "A6 105 x 148 mm"
+msgstr ""
+
+#: ../src/common/paper.cpp:140
+msgid "Japanese Envelope Kaku #2"
+msgstr ""
+
+#: ../src/common/paper.cpp:141
+msgid "Japanese Envelope Kaku #3"
+msgstr ""
+
+#: ../src/common/paper.cpp:142
+msgid "Japanese Envelope Chou #3"
+msgstr ""
+
+#: ../src/common/paper.cpp:143
+msgid "Japanese Envelope Chou #4"
+msgstr ""
+
+#: ../src/common/paper.cpp:144
+msgid "Letter Rotated 11 x 8 1/2 in"
+msgstr ""
+
+#: ../src/common/paper.cpp:145
+msgid "A3 Rotated 420 x 297 mm"
+msgstr ""
+
+#: ../src/common/paper.cpp:146
+msgid "A4 Rotated 297 x 210 mm"
+msgstr ""
+
+#: ../src/common/paper.cpp:147
+msgid "A5 Rotated 210 x 148 mm"
+msgstr ""
+
+#: ../src/common/paper.cpp:148
+msgid "B4 (JIS) Rotated 364 x 257 mm"
+msgstr ""
+
+#: ../src/common/paper.cpp:149
+msgid "B5 (JIS) Rotated 257 x 182 mm"
+msgstr ""
+
+#: ../src/common/paper.cpp:150
+msgid "Japanese Postcard Rotated 148 x 100 mm"
+msgstr ""
+
+#: ../src/common/paper.cpp:151
+msgid "Double Japanese Postcard Rotated 148 x 200 mm"
+msgstr ""
+
+#: ../src/common/paper.cpp:152
+msgid "A6 Rotated 148 x 105 mm"
+msgstr ""
+
+#: ../src/common/paper.cpp:153
+msgid "Japanese Envelope Kaku #2 Rotated"
+msgstr ""
+
+#: ../src/common/paper.cpp:154
+msgid "Japanese Envelope Kaku #3 Rotated"
+msgstr ""
+
+#: ../src/common/paper.cpp:155
+msgid "Japanese Envelope Chou #3 Rotated"
+msgstr ""
+
+#: ../src/common/paper.cpp:156
+msgid "Japanese Envelope Chou #4 Rotated"
+msgstr ""
+
+#: ../src/common/paper.cpp:157
+msgid "B6 (JIS) 128 x 182 mm"
+msgstr ""
+
+#: ../src/common/paper.cpp:158
+msgid "B6 (JIS) Rotated 182 x 128 mm"
+msgstr ""
+
+#: ../src/common/paper.cpp:159
+msgid "12 x 11 in"
+msgstr "12 x 11 in"
+
+#: ../src/common/paper.cpp:160
+msgid "Japanese Envelope You #4"
+msgstr ""
+
+#: ../src/common/paper.cpp:161
+msgid "Japanese Envelope You #4 Rotated"
+msgstr ""
+
+#: ../src/common/paper.cpp:162
+msgid "PRC 16K 146 x 215 mm"
+msgstr ""
+
+#: ../src/common/paper.cpp:163
+msgid "PRC 32K 97 x 151 mm"
+msgstr ""
+
+#: ../src/common/paper.cpp:164
+msgid "PRC 32K(Big) 97 x 151 mm"
+msgstr ""
+
+#: ../src/common/paper.cpp:165
+msgid "PRC Envelope #1 102 x 165 mm"
+msgstr ""
+
+#: ../src/common/paper.cpp:166
+msgid "PRC Envelope #2 102 x 176 mm"
+msgstr ""
+
+#: ../src/common/paper.cpp:167
+msgid "PRC Envelope #3 125 x 176 mm"
+msgstr ""
+
+#: ../src/common/paper.cpp:168
+msgid "PRC Envelope #4 110 x 208 mm"
+msgstr ""
+
+#: ../src/common/paper.cpp:169
+msgid "PRC Envelope #5 110 x 220 mm"
+msgstr ""
+
+#: ../src/common/paper.cpp:170
+msgid "PRC Envelope #6 120 x 230 mm"
+msgstr ""
+
+#: ../src/common/paper.cpp:171
+msgid "PRC Envelope #7 160 x 230 mm"
+msgstr ""
+
+#: ../src/common/paper.cpp:172
+msgid "PRC Envelope #8 120 x 309 mm"
+msgstr ""
+
+#: ../src/common/paper.cpp:173
+msgid "PRC Envelope #9 229 x 324 mm"
+msgstr ""
+
+#: ../src/common/paper.cpp:174
+msgid "PRC Envelope #10 324 x 458 mm"
+msgstr ""
+
+#: ../src/common/paper.cpp:175
+msgid "PRC 16K Rotated"
+msgstr ""
+
+#: ../src/common/paper.cpp:176
+msgid "PRC 32K Rotated"
+msgstr ""
+
+#: ../src/common/paper.cpp:177
+msgid "PRC 32K(Big) Rotated"
+msgstr ""
+
+#: ../src/common/paper.cpp:178
+msgid "PRC Envelope #1 Rotated 165 x 102 mm"
+msgstr ""
+
+#: ../src/common/paper.cpp:179
+msgid "PRC Envelope #2 Rotated 176 x 102 mm"
+msgstr ""
+
+#: ../src/common/paper.cpp:180
+msgid "PRC Envelope #3 Rotated 176 x 125 mm"
+msgstr ""
+
+#: ../src/common/paper.cpp:181
+msgid "PRC Envelope #4 Rotated 208 x 110 mm"
+msgstr ""
+
+#: ../src/common/paper.cpp:182
+msgid "PRC Envelope #5 Rotated 220 x 110 mm"
+msgstr ""
+
+#: ../src/common/paper.cpp:183
+msgid "PRC Envelope #6 Rotated 230 x 120 mm"
+msgstr ""
+
+#: ../src/common/paper.cpp:184
+msgid "PRC Envelope #7 Rotated 230 x 160 mm"
+msgstr ""
+
+#: ../src/common/paper.cpp:185
+msgid "PRC Envelope #8 Rotated 309 x 120 mm"
+msgstr ""
+
+#: ../src/common/paper.cpp:186
+msgid "PRC Envelope #9 Rotated 324 x 229 mm"
+msgstr ""
+
+#: ../src/common/paper.cpp:187
+msgid "PRC Envelope #10 Rotated 458 x 324 mm"
+msgstr ""
+
+#: ../src/common/paper.cpp:192
+msgid "A0 sheet, 841 x 1189 mm"
+msgstr ""
+
+#: ../src/common/paper.cpp:193
+msgid "A1 sheet, 594 x 841 mm"
+msgstr ""
+
+#: ../src/common/preferencescmn.cpp:37
+msgid "General"
+msgstr ""
+
+#: ../src/common/preferencescmn.cpp:40
+msgid "Advanced"
+msgstr ""
+
+#: ../src/common/prntbase.cpp:245
+msgid "Generic PostScript"
+msgstr ""
+
+#: ../src/common/prntbase.cpp:259
+msgid "Ready"
+msgstr ""
+
+#: ../src/common/prntbase.cpp:331
+msgid "Printing Error"
+msgstr ""
+
+#: ../src/common/prntbase.cpp:413 ../src/common/prntbase.cpp:1597
+#: ../src/generic/prntdlgg.cpp:135 ../src/generic/prntdlgg.cpp:149
+#: ../src/gtk/print.cpp:628 ../src/gtk/print.cpp:646
+msgid "Print"
+msgstr ""
+
+#: ../src/common/prntbase.cpp:471 ../src/generic/prntdlgg.cpp:809
+msgid "Page setup"
+msgstr ""
+
+#: ../src/common/prntbase.cpp:525
+msgid "Please wait while printing..."
+msgstr ""
+
+#: ../src/common/prntbase.cpp:529
+msgid "Document:"
+msgstr ""
+
+#: ../src/common/prntbase.cpp:532
+msgid "Progress:"
+msgstr ""
+
+#: ../src/common/prntbase.cpp:533
+msgid "Preparing"
+msgstr ""
+
+#: ../src/common/prntbase.cpp:552
+#, c-format
+msgid "Printing page %d"
+msgstr ""
+
+#: ../src/common/prntbase.cpp:557
+#, c-format
+msgid "Printing page %d of %d"
+msgstr ""
+
+#: ../src/common/prntbase.cpp:560
+#, c-format
+msgid " (copy %d of %d)"
+msgstr ""
+
+#: ../src/common/prntbase.cpp:1604
+msgid "First page"
+msgstr ""
+
+#: ../src/common/prntbase.cpp:1609 ../src/html/helpwnd.cpp:659
+msgid "Previous page"
+msgstr ""
+
+#: ../src/common/prntbase.cpp:1623 ../src/html/helpwnd.cpp:660
+msgid "Next page"
+msgstr ""
+
+#: ../src/common/prntbase.cpp:1628
+msgid "Last page"
+msgstr ""
+
+#: ../src/common/prntbase.cpp:1636 ../src/common/stockitem.cpp:215
+msgid "Zoom Out"
+msgstr ""
+
+#: ../src/common/prntbase.cpp:1650 ../src/common/stockitem.cpp:214
+msgid "Zoom In"
+msgstr ""
+
+#: ../src/common/prntbase.cpp:1656 ../src/common/stockitem.cpp:153
+#: ../src/generic/logg.cpp:553 ../src/univ/themes/win32.cpp:3752
+msgid "&Close"
+msgstr ""
+
+#: ../src/common/prntbase.cpp:2085
+msgid "Could not start document preview."
+msgstr ""
+
+#: ../src/common/prntbase.cpp:2085 ../src/common/prntbase.cpp:2129
+#: ../src/common/prntbase.cpp:2137
+msgid "Print Preview Failure"
+msgstr ""
+
+#: ../src/common/prntbase.cpp:2129 ../src/common/prntbase.cpp:2137
+msgid "Sorry, not enough memory to create a preview."
+msgstr ""
+
+#: ../src/common/prntbase.cpp:2144
+#, c-format
+msgid "Page %d of %d"
+msgstr ""
+
+#: ../src/common/prntbase.cpp:2146
+#, c-format
+msgid "Page %d"
+msgstr ""
+
+#: ../src/common/regex.cpp:382 ../src/html/chm.cpp:348
+msgid "unknown error"
+msgstr "خطای ناشناخته"
+
+#: ../src/common/regex.cpp:995
+#, c-format
+msgid "Invalid regular expression '%s': %s"
+msgstr ""
+
+#: ../src/common/regex.cpp:1059
+#, c-format
+msgid "Failed to find match for regular expression: %s"
+msgstr ""
+
+#: ../src/common/rendcmn.cpp:188
+#, c-format
+msgid "Renderer \"%s\" has incompatible version %d.%d and couldn't be loaded."
+msgstr ""
+
+#: ../src/common/secretstore.cpp:162
+msgid "Not available for this platform"
+msgstr ""
+
+#: ../src/common/secretstore.cpp:183
+#, c-format
+msgid "Saving password for \"%s\" failed: %s."
+msgstr ""
+
+#: ../src/common/secretstore.cpp:205
+#, c-format
+msgid "Reading password for \"%s\" failed: %s."
+msgstr ""
+
+#: ../src/common/secretstore.cpp:228
+#, c-format
+msgid "Deleting password for \"%s\" failed: %s."
+msgstr ""
+
+#: ../src/common/selectdispatcher.cpp:254
+msgid "Failed to monitor I/O channels"
+msgstr ""
+
+#: ../src/common/sizer.cpp:3054 ../src/common/stockitem.cpp:195
+msgid "Save"
+msgstr ""
+
+#: ../src/common/sizer.cpp:3056
+msgid "Don't Save"
+msgstr ""
+
+#: ../src/common/socket.cpp:870
+msgid "Cannot initialize sockets"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:127
+#, fuzzy
+msgctxt "standard Windows menu"
+msgid "&Help"
+msgstr "(راهنما)"
+
+#: ../src/common/stockitem.cpp:144
+msgid "&About"
+msgstr "&در باره"
+
+#: ../src/common/stockitem.cpp:144
+msgid "About"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:145
+msgid "Add"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:146
+msgid "&Apply"
+msgstr "اع&مال"
+
+#: ../src/common/stockitem.cpp:146
+msgid "Apply"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:147
+msgid "&Back"
+msgstr "&عقب"
+
+#: ../src/common/stockitem.cpp:147
+msgid "Back"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:148
+msgid "&Bold"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:148 ../src/generic/fontdlgg.cpp:326
+#: ../src/richtext/richtextfontpage.cpp:354
+msgid "Bold"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:149
+msgid "&Bottom"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:149 ../src/richtext/richtextsizepage.cpp:287
+msgid "Bottom"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:150 ../src/generic/fontdlgg.cpp:462
+#: ../src/generic/fontdlgg.cpp:481 ../src/generic/wizard.cpp:415
+msgid "&Cancel"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:151
+msgid "&CD-ROM"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:151
+msgid "CD-ROM"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:152
+msgid "&Clear"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:152
+msgid "Clear"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:153 ../src/generic/dbgrptg.cpp:93
+#: ../src/generic/progdlgg.cpp:778 ../src/html/helpdlg.cpp:86
+#: ../src/msw/progdlg.cpp:209 ../src/msw/progdlg.cpp:890
+#: ../src/richtext/richtextstyledlg.cpp:272
+#: ../src/richtext/richtextsymboldlg.cpp:448
+msgid "Close"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:154
+msgid "&Convert"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:154
+msgid "Convert"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:155 ../src/msw/textctrl.cpp:2884
+#: ../src/osx/textctrl_osx.cpp:653 ../src/richtext/richtextctrl.cpp:331
+msgid "&Copy"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:155 ../src/stc/stc_i18n.cpp:18
+msgid "Copy"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:156 ../src/msw/textctrl.cpp:2883
+#: ../src/osx/textctrl_osx.cpp:652 ../src/richtext/richtextctrl.cpp:330
+msgid "Cu&t"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:156 ../src/stc/stc_i18n.cpp:17
+msgid "Cut"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:157 ../src/msw/textctrl.cpp:2886
+#: ../src/osx/textctrl_osx.cpp:655 ../src/richtext/richtextctrl.cpp:333
+#: ../src/richtext/richtexttabspage.cpp:137
+msgid "&Delete"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:157 ../src/richtext/richtextbuffer.cpp:8266
+#: ../src/stc/stc_i18n.cpp:20
+msgid "Delete"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:158
+msgid "&Down"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:158 ../src/generic/fdrepdlg.cpp:148
+msgid "Down"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:159
+msgid "&Edit"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:159
+msgid "Edit"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:160
+msgid "&Execute"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:160
+msgid "Execute"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:161
+msgid "&Quit"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:161
+msgid "Quit"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:162
+msgid "&File"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:162
+msgid "File"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:163
+msgid "&Find..."
+msgstr ""
+
+#: ../src/common/stockitem.cpp:163
+msgid "Find..."
+msgstr ""
+
+#: ../src/common/stockitem.cpp:164
+msgid "&First"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:164
+msgid "First"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:165
+msgid "&Floppy"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:165
+msgid "Floppy"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:166
+msgid "&Forward"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:166
+msgid "Forward"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:167
+msgid "&Harddisk"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:167
+msgid "Harddisk"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:168 ../src/generic/wizard.cpp:418
+#: ../src/osx/cocoa/menu.mm:225 ../src/richtext/richtextstyledlg.cpp:298
+#: ../src/richtext/richtextsymboldlg.cpp:451
+msgid "&Help"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:169
+msgid "&Home"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:169
+msgid "Home"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:170
+msgid "Indent"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:171
+msgid "&Index"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:171 ../src/html/helpwnd.cpp:510
+msgid "Index"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:172
+msgid "&Info"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:172
+msgid "Info"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:173
+msgid "&Italic"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:173 ../src/generic/fontdlgg.cpp:322
+#: ../src/richtext/richtextfontpage.cpp:350
+msgid "Italic"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:174
+msgid "&Jump to"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:174
+msgid "Jump to"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:175
+msgid "Centered"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:176
+msgid "Justified"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:177
+msgid "Align Left"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:178
+msgid "Align Right"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:179
+msgid "&Last"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:179
+msgid "Last"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:180
+msgid "&Network"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:180
+msgid "Network"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:181 ../src/richtext/richtexttabspage.cpp:131
+msgid "&New"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:181
+msgid "New"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:182 ../src/msw/msgdlg.cpp:417
+msgid "&No"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:183 ../src/generic/fontdlgg.cpp:467
+#: ../src/generic/fontdlgg.cpp:474
+msgid "&OK"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:184 ../src/generic/dbgrptg.cpp:341
+msgid "&Open..."
+msgstr ""
+
+#: ../src/common/stockitem.cpp:184
+msgid "Open..."
+msgstr ""
+
+#: ../src/common/stockitem.cpp:185 ../src/msw/textctrl.cpp:2885
+#: ../src/osx/textctrl_osx.cpp:654 ../src/richtext/richtextctrl.cpp:332
+msgid "&Paste"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:185 ../src/richtext/richtextctrl.cpp:3484
+#: ../src/stc/stc_i18n.cpp:19
+msgid "Paste"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:186
+msgid "&Preferences"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:186 ../src/osx/cocoa/preferences.mm:304
+msgid "Preferences"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:187
+msgid "Print previe&w..."
+msgstr ""
+
+#: ../src/common/stockitem.cpp:187
+msgid "Print preview..."
+msgstr ""
+
+#: ../src/common/stockitem.cpp:188
+msgid "&Print..."
+msgstr ""
+
+#: ../src/common/stockitem.cpp:188
+msgid "Print..."
+msgstr ""
+
+#: ../src/common/stockitem.cpp:189 ../src/richtext/richtextctrl.cpp:337
+#: ../src/richtext/richtextctrl.cpp:5479
+msgid "&Properties"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:189
+msgid "Properties"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:190 ../src/stc/stc_i18n.cpp:16
+msgid "Redo"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:191
+msgid "Refresh"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:192
+msgid "Remove"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:193
+msgid "Rep&lace..."
+msgstr ""
+
+#: ../src/common/stockitem.cpp:193
+msgid "Replace..."
+msgstr ""
+
+#: ../src/common/stockitem.cpp:194
+msgid "Revert to Saved"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:196 ../src/generic/logg.cpp:549
+msgid "Save &As..."
+msgstr ""
+
+#: ../src/common/stockitem.cpp:196
+msgid "Save As..."
+msgstr ""
+
+#: ../src/common/stockitem.cpp:197 ../src/msw/textctrl.cpp:2888
+#: ../src/osx/textctrl_osx.cpp:657 ../src/richtext/richtextctrl.cpp:335
+msgid "Select &All"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:197 ../src/stc/stc_i18n.cpp:21
+msgid "Select All"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:198
+msgid "&Color"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:198
+msgid "Color"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:199
+msgid "&Font"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:199 ../src/richtext/richtextformatdlg.cpp:336
+msgid "Font"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:200
+msgid "&Ascending"
+msgstr "صعودی"
+
+#: ../src/common/stockitem.cpp:200
+msgid "Ascending"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:201
+msgid "&Descending"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:201
+msgid "Descending"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:202
+msgid "&Spell Check"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:202
+msgid "Spell Check"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:203
+msgid "&Stop"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:203
+msgid "Stop"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:204 ../src/richtext/richtextfontpage.cpp:274
+msgid "&Strikethrough"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:204
+msgid "Strikethrough"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:205
+msgid "&Top"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:205 ../src/richtext/richtextsizepage.cpp:285
+#: ../src/richtext/richtextsizepage.cpp:289
+msgid "Top"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:206
+msgid "Undelete"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:207 ../src/generic/fontdlgg.cpp:437
+msgid "&Underline"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:207
+msgid "Underline"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:208 ../src/stc/stc_i18n.cpp:15
+msgid "Undo"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:209
+msgid "&Unindent"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:209
+msgid "Unindent"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:210
+msgid "&Up"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:210 ../src/generic/fdrepdlg.cpp:148
+msgid "Up"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:211 ../src/msw/msgdlg.cpp:417
+msgid "&Yes"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:212
+msgid "&Actual Size"
+msgstr "ا&ندازه واقعی"
+
+#: ../src/common/stockitem.cpp:212
+msgid "Actual Size"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:213
+msgid "Zoom to &Fit"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:213
+msgid "Zoom to Fit"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:214
+msgid "Zoom &In"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:215
+msgid "Zoom &Out"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:262
+msgid "Show about dialog"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:263
+msgid "Copy selection"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:264
+msgid "Cut selection"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:265
+msgid "Delete selection"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:266
+msgid "Find in document"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:267
+msgid "Find and replace in document"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:268
+msgid "Paste selection"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:269
+msgid "Quit this program"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:270
+msgid "Redo last action"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:271
+msgid "Undo last action"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:272
+msgid "Create new document"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:273
+msgid "Open an existing document"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:274
+msgid "Close current document"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:275
+msgid "Save current document"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:276
+msgid "Save current document with a different filename"
+msgstr ""
+
+#: ../src/common/strconv.cpp:2324
+#, c-format
+msgid "Conversion to charset '%s' doesn't work."
+msgstr ""
+
+#: ../src/common/tarstrm.cpp:352 ../src/common/tarstrm.cpp:375
+#: ../src/common/tarstrm.cpp:406 ../src/generic/progdlgg.cpp:373
+msgid "unknown"
+msgstr "ناشناخته"
+
+#: ../src/common/tarstrm.cpp:774
+msgid "incomplete header block in tar"
+msgstr ""
+
+#: ../src/common/tarstrm.cpp:798
+msgid "checksum failure reading tar header block"
+msgstr ""
+
+#: ../src/common/tarstrm.cpp:971
+msgid "invalid data in extended tar header"
+msgstr ""
+
+#: ../src/common/tarstrm.cpp:981 ../src/common/tarstrm.cpp:1003
+#: ../src/common/tarstrm.cpp:1477 ../src/common/tarstrm.cpp:1499
+msgid "tar entry not open"
+msgstr "ورودی تار باز نیست"
+
+#: ../src/common/tarstrm.cpp:1023
+msgid "unexpected end of file"
+msgstr "پایان غیر منتظره فایل"
+
+#: ../src/common/tarstrm.cpp:1297
+#, c-format
+msgid "%s did not fit the tar header for entry '%s'"
+msgstr "%s did not fit the tar header for entry '%s'"
+
+#: ../src/common/tarstrm.cpp:1359
+msgid "incorrect size given for tar entry"
+msgstr ""
+
+#: ../src/common/textbuf.cpp:232
+#, c-format
+msgid "'%s' is probably a binary buffer."
+msgstr ""
+
+#: ../src/common/textcmn.cpp:1006 ../src/richtext/richtextctrl.cpp:3053
+msgid "File couldn't be loaded."
+msgstr ""
+
+#: ../src/common/textfile.cpp:95
+#, c-format
+msgid "Failed to read text file \"%s\"."
+msgstr ""
+
+#: ../src/common/textfile.cpp:160
+#, c-format
+msgid "can't write buffer '%s' to disk."
+msgstr ""
+
+#: ../src/common/time.cpp:212
+msgid "Failed to get the local system time"
+msgstr ""
+
+#: ../src/common/time.cpp:279
+msgid "wxGetTimeOfDay failed."
+msgstr "wxGetTimeOfDay انجام نشد."
+
+#: ../src/common/translation.cpp:929
+#, c-format
+msgid "'%s' is not a valid message catalog."
+msgstr ""
+
+#: ../src/common/translation.cpp:954
+msgid "Invalid message catalog."
+msgstr ""
+
+#: ../src/common/translation.cpp:1013
+#, c-format
+msgid "Failed to parse Plural-Forms: '%s'"
+msgstr ""
+
+#: ../src/common/translation.cpp:1723
+#, c-format
+msgid "using catalog '%s' from '%s'."
+msgstr ""
+
+#: ../src/common/translation.cpp:1816
+#, c-format
+msgid "Resource '%s' is not a valid message catalog."
+msgstr ""
+
+#: ../src/common/translation.cpp:1865
+msgid "Couldn't enumerate translations"
+msgstr ""
+
+#: ../src/common/utilscmn.cpp:1145
+msgid "No default application configured for HTML files."
+msgstr ""
+
+#: ../src/common/utilscmn.cpp:1190
+#, c-format
+msgid "Failed to open URL \"%s\" in default browser."
+msgstr ""
+
+#: ../src/common/valtext.cpp:144
+msgid "Validation conflict"
+msgstr ""
+
+#: ../src/common/valtext.cpp:186
+msgid "Required information entry is empty."
+msgstr ""
+
+#: ../src/common/valtext.cpp:188
+#, c-format
+msgid "'%s' is one of the invalid strings"
+msgstr ""
+
+#: ../src/common/valtext.cpp:190
+#, c-format
+msgid "'%s' is not one of the valid strings"
+msgstr ""
+
+#: ../src/common/valtext.cpp:199
+#, c-format
+msgid "'%s' contains invalid character(s)"
+msgstr ""
+
+#: ../src/common/webrequest.cpp:139
+#, c-format
+msgid "Error: %s (%d)"
+msgstr ""
+
+#: ../src/common/webrequest.cpp:655
+#, c-format
+msgid ""
+"Not enough free disk space for download: %llu needed but only %llu available."
+msgstr ""
+
+#: ../src/common/webrequest.cpp:669
+#, c-format
+msgid "Failed to create temporary file in %s"
+msgstr ""
+
+#: ../src/common/webrequest_curl.cpp:1106
+msgid "libcurl could not be initialized"
+msgstr ""
+
+#: ../src/common/webview.cpp:392
+msgid "RunScriptAsync not supported"
+msgstr ""
+
+#: ../src/common/webview.cpp:403 ../src/msw/webview_ie.cpp:1073
+#, c-format
+msgid "Error running JavaScript: %s"
+msgstr ""
+
+#: ../src/common/webview_chromium.cpp:858
+#, c-format
+msgid "Failed to set proxy \"%s\": %s"
+msgstr ""
+
+#: ../src/common/webview_chromium.cpp:989
+msgid ""
+"Chromium can't be used because libcef.so wasn't loaded early enough; please "
+"relink the application or use LD_PRELOAD to load it earlier."
+msgstr ""
+
+#: ../src/common/webview_chromium.cpp:1108
+msgid "Could not initialize Chromium"
+msgstr ""
+
+#: ../src/common/webview_chromium.cpp:1616
+msgid "Show DevTools"
+msgstr ""
+
+#: ../src/common/webview_chromium.cpp:1617
+msgid "Close DevTools"
+msgstr ""
+
+#: ../src/common/webview_chromium.cpp:1623
+msgid "Inspect"
+msgstr ""
+
+#: ../src/common/wincmn.cpp:1628
+msgid "This platform does not support background transparency."
+msgstr ""
+
+#: ../src/common/wincmn.cpp:2097
+msgid "Could not transfer data to window"
+msgstr ""
+
+#: ../src/common/windowid.cpp:240
+msgid "Out of window IDs.  Recommend shutting down application."
+msgstr ""
+
+#: ../src/common/xpmdecod.cpp:678
+msgid "XPM: incorrect header format!"
+msgstr ""
+
+#: ../src/common/xpmdecod.cpp:703
+#, c-format
+msgid "XPM: incorrect colour description in line %d"
+msgstr ""
+
+#: ../src/common/xpmdecod.cpp:715 ../src/common/xpmdecod.cpp:724
+#, c-format
+msgid "XPM: malformed colour definition '%s' at line %d!"
+msgstr ""
+
+#: ../src/common/xpmdecod.cpp:754
+msgid "XPM: no colors left to use for mask!"
+msgstr ""
+
+#: ../src/common/xpmdecod.cpp:781
+#, c-format
+msgid "XPM: truncated image data at line %d!"
+msgstr ""
+
+#: ../src/common/xpmdecod.cpp:795
+msgid "XPM: Malformed pixel data!"
+msgstr ""
+
+#: ../src/common/xti.cpp:492
+msgid "Illegal Parameter Count for Create Method"
+msgstr ""
+
+#: ../src/common/xti.cpp:504
+msgid "Illegal Parameter Count for ConstructObject Method"
+msgstr ""
+
+#: ../src/common/xtistrm.cpp:161
+#, c-format
+msgid "Create Parameter %s not found in declared RTTI Parameters"
+msgstr ""
+
+#: ../src/common/xtistrm.cpp:290
+msgid "Illegal Object Class (Non-wxEvtHandler) as Event Source"
+msgstr ""
+
+#: ../src/common/xtistrm.cpp:313 ../src/common/xtixml.cpp:345
+#: ../src/common/xtixml.cpp:498
+msgid "Type must have enum - long conversion"
+msgstr ""
+
+#: ../src/common/xtistrm.cpp:400 ../src/common/xtistrm.cpp:415
+msgid "Invalid or Null Object ID passed to GetObjectClassInfo"
+msgstr ""
+
+#: ../src/common/xtistrm.cpp:405
+msgid "Unknown Object passed to GetObjectClassInfo"
+msgstr ""
+
+#: ../src/common/xtistrm.cpp:420
+msgid "Already Registered Object passed to SetObjectClassInfo"
+msgstr ""
+
+#: ../src/common/xtistrm.cpp:430
+msgid "Invalid or Null Object ID passed to HasObjectClassInfo"
+msgstr ""
+
+#: ../src/common/xtistrm.cpp:460
+msgid "Passing a already registered object to SetObject"
+msgstr ""
+
+#: ../src/common/xtistrm.cpp:471
+msgid "Passing an unknown object to GetObject"
+msgstr ""
+
+#: ../src/common/xtixml.cpp:229
+msgid "Forward hrefs are not supported"
+msgstr ""
+
+#: ../src/common/xtixml.cpp:247
+#, c-format
+msgid "unknown class %s"
+msgstr ""
+
+#: ../src/common/xtixml.cpp:253
+msgid "objects cannot have XML Text Nodes"
+msgstr ""
+
+#: ../src/common/xtixml.cpp:258
+msgid "Objects must have an id attribute"
+msgstr ""
+
+#: ../src/common/xtixml.cpp:267
+#, c-format
+msgid "Doubly used id : %d"
+msgstr ""
+
+#: ../src/common/xtixml.cpp:316
+#, c-format
+msgid "Unknown Property %s"
+msgstr ""
+
+#: ../src/common/xtixml.cpp:407
+msgid "A non empty collection must consist of 'element' nodes"
+msgstr ""
+
+#: ../src/common/xtixml.cpp:478
+msgid "incorrect event handler string, missing dot"
+msgstr ""
+
+#: ../src/common/zipstrm.cpp:559
+msgid "can't re-initialize zlib deflate stream"
+msgstr ""
+
+#: ../src/common/zipstrm.cpp:584
+msgid "can't re-initialize zlib inflate stream"
+msgstr ""
+
+#: ../src/common/zipstrm.cpp:1023
+msgid "Ignoring malformed extra data record, ZIP file may be corrupted"
+msgstr ""
+
+#: ../src/common/zipstrm.cpp:1502
+msgid "assuming this is a multi-part zip concatenated"
+msgstr ""
+
+#: ../src/common/zipstrm.cpp:1664
+msgid "invalid zip file"
+msgstr ""
+
+#: ../src/common/zipstrm.cpp:1723
+msgid "can't find central directory in zip"
+msgstr ""
+
+#: ../src/common/zipstrm.cpp:1812
+msgid "error reading zip central directory"
+msgstr ""
+
+#: ../src/common/zipstrm.cpp:1916
+msgid "error reading zip local header"
+msgstr ""
+
+#: ../src/common/zipstrm.cpp:1964
+msgid "bad zipfile offset to entry"
+msgstr ""
+
+#: ../src/common/zipstrm.cpp:2031
+msgid "stored file length not in Zip header"
+msgstr "طول پرونده ذخیره شده در سربرگ Zip نیست"
+
+#: ../src/common/zipstrm.cpp:2045 ../src/common/zipstrm.cpp:2362
+msgid "unsupported Zip compression method"
+msgstr "روش فشرده سازی فایل های فشرده پشتیبانی نمی شود"
+
+#: ../src/common/zipstrm.cpp:2126
+#, c-format
+msgid "reading zip stream (entry %s): bad length"
+msgstr ""
+
+#: ../src/common/zipstrm.cpp:2131
+#, c-format
+msgid "reading zip stream (entry %s): bad crc"
+msgstr ""
+
+#: ../src/common/zipstrm.cpp:2578
+#, c-format
+msgid "error writing zip entry '%s': file too large without ZIP64"
+msgstr ""
+
+#: ../src/common/zipstrm.cpp:2585
+#, c-format
+msgid "error writing zip entry '%s': bad crc or length"
+msgstr ""
+
+#: ../src/common/zstream.cpp:155 ../src/common/zstream.cpp:315
+msgid "Gzip not supported by this version of zlib"
+msgstr ""
+
+#: ../src/common/zstream.cpp:182
+msgid "Can't initialize zlib inflate stream."
+msgstr ""
+
+#: ../src/common/zstream.cpp:241
+msgid "Can't read inflate stream: unexpected EOF in underlying stream."
+msgstr ""
+
+#: ../src/common/zstream.cpp:248 ../src/common/zstream.cpp:423
+#, c-format
+msgid "zlib error %d"
+msgstr ""
+
+#: ../src/common/zstream.cpp:249
+#, c-format
+msgid "Can't read from inflate stream: %s"
+msgstr ""
+
+#: ../src/common/zstream.cpp:343
+msgid "Can't initialize zlib deflate stream."
+msgstr ""
+
+#: ../src/common/zstream.cpp:424
+#, c-format
+msgid "Can't write to deflate stream: %s"
+msgstr ""
+
+#: ../src/dfb/bitmap.cpp:633 ../src/dfb/bitmap.cpp:667
+#, c-format
+msgid "No bitmap handler for type %d defined."
+msgstr ""
+
+#: ../src/dfb/evtloop.cpp:99
+msgid "Failed to read event from DirectFB pipe"
+msgstr ""
+
+#: ../src/dfb/evtloop.cpp:171
+msgid "Failed to switch DirectFB pipe to non-blocking mode"
+msgstr ""
+
+#: ../src/dfb/fontmgr.cpp:171
+#, c-format
+msgid "no fonts found in %s, using builtin font"
+msgstr ""
+
+#: ../src/dfb/fontmgr.cpp:177
+msgid "Default font"
+msgstr ""
+
+#: ../src/dfb/fontmgr.cpp:195
+#, c-format
+msgid "Fonts index file %s disappeared while loading fonts."
+msgstr ""
+
+#: ../src/dfb/wrapdfb.cpp:60
+#, c-format
+msgid "DirectFB error %d occurred."
+msgstr ""
+
+#: ../src/generic/aboutdlgg.cpp:69
+msgid "Developed by "
+msgstr ""
+
+#: ../src/generic/aboutdlgg.cpp:72
+msgid "Documentation by "
+msgstr ""
+
+#: ../src/generic/aboutdlgg.cpp:75
+msgid "Graphics art by "
+msgstr ""
+
+#: ../src/generic/aboutdlgg.cpp:78
+msgid "Translations by "
+msgstr ""
+
+#: ../src/generic/aboutdlgg.cpp:133 ../src/osx/cocoa/aboutdlg.mm:83
+msgid "Version "
+msgstr ""
+
+#. TRANSLATORS: %s is application name
+#: ../src/generic/aboutdlgg.cpp:146 ../src/msw/aboutdlg.cpp:60
+#, c-format
+msgid "About %s"
+msgstr ""
+
+#: ../src/generic/aboutdlgg.cpp:181
+msgid "License"
+msgstr ""
+
+#: ../src/generic/aboutdlgg.cpp:184
+msgid "Developers"
+msgstr ""
+
+#: ../src/generic/aboutdlgg.cpp:188
+msgid "Documentation writers"
+msgstr ""
+
+#: ../src/generic/aboutdlgg.cpp:192
+msgid "Artists"
+msgstr ""
+
+#: ../src/generic/aboutdlgg.cpp:196
+msgid "Translators"
+msgstr ""
+
+#: ../src/generic/animateg.cpp:125
+msgid "No handler found for animation type."
+msgstr ""
+
+#: ../src/generic/animateg.cpp:133
+#, c-format
+msgid "No animation handler for type %ld defined."
+msgstr ""
+
+#: ../src/generic/animateg.cpp:145
+#, c-format
+msgid "Animation file is not of type %ld."
+msgstr ""
+
+#: ../src/generic/colrdlgg.cpp:154 ../src/gtk/colordlg.cpp:47
+msgid "Choose colour"
+msgstr ""
+
+#: ../src/generic/colrdlgg.cpp:357
+msgid "Red:"
+msgstr ""
+
+#: ../src/generic/colrdlgg.cpp:360
+msgid "Green:"
+msgstr ""
+
+#: ../src/generic/colrdlgg.cpp:363
+msgid "Blue:"
+msgstr ""
+
+#: ../src/generic/colrdlgg.cpp:372
+msgid "Opacity:"
+msgstr ""
+
+#: ../src/generic/colrdlgg.cpp:384
+msgid "Add to custom colours"
+msgstr ""
+
+#: ../src/generic/creddlgg.cpp:56
+msgid "Username:"
+msgstr ""
+
+#: ../src/generic/creddlgg.cpp:63
+msgid "Password:"
+msgstr ""
+
+#. TRANSLATORS: Name of Boolean true value
+#: ../src/generic/datavgen.cpp:1178
+msgid "true"
+msgstr "درست"
+
+#. TRANSLATORS: Name of Boolean false value
+#: ../src/generic/datavgen.cpp:1180
+msgid "false"
+msgstr ""
+
+#: ../src/generic/datavgen.cpp:6897
+#, c-format
+msgid "Row %i"
+msgstr ""
+
+#. TRANSLATORS: Action for manipulating a tree control
+#: ../src/generic/datavgen.cpp:6987
+msgid "Collapse"
+msgstr ""
+
+#. TRANSLATORS: Action for manipulating a tree control
+#: ../src/generic/datavgen.cpp:6990
+msgid "Expand"
+msgstr ""
+
+#. TRANSLATORS: Name of data view control and number of rows
+#: ../src/generic/datavgen.cpp:7011
+#, c-format
+msgid "%s (%d items)"
+msgstr "%s (%d items)"
+
+#: ../src/generic/datavgen.cpp:7062
+#, c-format
+msgid "Column %u"
+msgstr ""
+
+#. TRANSLATORS: Keystroke for manipulating a tree control
+#: ../src/generic/datavgen.cpp:7131 ../src/richtext/richtextbulletspage.cpp:189
+#: ../src/richtext/richtextbulletspage.cpp:192
+#: ../src/richtext/richtextbulletspage.cpp:193
+#: ../src/richtext/richtextliststylepage.cpp:252
+#: ../src/richtext/richtextliststylepage.cpp:255
+#: ../src/richtext/richtextliststylepage.cpp:256
+#: ../src/richtext/richtextsizepage.cpp:248
+msgid "Left"
+msgstr ""
+
+#. TRANSLATORS: Keystroke for manipulating a tree control
+#: ../src/generic/datavgen.cpp:7134 ../src/richtext/richtextbulletspage.cpp:191
+#: ../src/richtext/richtextliststylepage.cpp:254
+#: ../src/richtext/richtextsizepage.cpp:249
+msgid "Right"
+msgstr ""
+
+#: ../src/generic/datectlg.cpp:90
+#, c-format
+msgid ""
+"\"%s\" is not in the expected date format, please enter it as e.g. \"%s\"."
+msgstr ""
+
+#: ../src/generic/datectlg.cpp:94
+msgid "Invalid date"
+msgstr ""
+
+#: ../src/generic/dbgrptg.cpp:159
+#, c-format
+msgid "Open file \"%s\""
+msgstr ""
+
+#: ../src/generic/dbgrptg.cpp:170
+#, c-format
+msgid "Enter command to open file \"%s\":"
+msgstr ""
+
+#: ../src/generic/dbgrptg.cpp:230
+msgid "Executable files (*.exe)|*.exe|"
+msgstr ""
+
+#: ../src/generic/dbgrptg.cpp:300
+#, c-format
+msgid "Debug report \"%s\""
+msgstr ""
+
+#: ../src/generic/dbgrptg.cpp:316
+msgid "A debug report has been generated in the directory\n"
+msgstr ""
+
+#: ../src/generic/dbgrptg.cpp:317
+msgid "The following debug report will be generated\n"
+msgstr ""
+
+#: ../src/generic/dbgrptg.cpp:321
+msgid ""
+"The report contains the files listed below. If any of these files contain "
+"private information,\n"
+"please uncheck them and they will be removed from the report.\n"
+msgstr ""
+
+#: ../src/generic/dbgrptg.cpp:323
+msgid ""
+"If you wish to suppress this debug report completely, please choose the "
+"\"Cancel\" button,\n"
+"but be warned that it may hinder improving the program, so if\n"
+"at all possible please do continue with the report generation.\n"
+msgstr ""
+
+#: ../src/generic/dbgrptg.cpp:325
+msgid "              Thank you and we're sorry for the inconvenience!\n"
+msgstr " با تشکر از شما و ما برای ناراحتی پوزش می طلبیم!\n"
+
+#: ../src/generic/dbgrptg.cpp:333
+msgid "&Debug report preview:"
+msgstr ""
+
+#: ../src/generic/dbgrptg.cpp:339
+msgid "&View..."
+msgstr ""
+
+#: ../src/generic/dbgrptg.cpp:359
+msgid "&Notes:"
+msgstr ""
+
+#: ../src/generic/dbgrptg.cpp:361
+msgid ""
+"If you have any additional information pertaining to this bug\n"
+"report, please enter it here and it will be joined to it:"
+msgstr ""
+
+#: ../src/generic/dcpsg.cpp:1627
+msgid "Cannot open file for PostScript printing!"
+msgstr ""
+
+#: ../src/generic/dirctrlg.cpp:402
+msgid "Computer"
+msgstr ""
+
+#: ../src/generic/dirctrlg.cpp:404
+msgid "Sections"
+msgstr ""
+
+#: ../src/generic/dirctrlg.cpp:482
+msgid "Home directory"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/generic/dirctrlg.cpp:484 ../src/propgrid/advprops.cpp:811
+msgid "Desktop"
+msgstr ""
+
+#: ../src/generic/dirctrlg.cpp:528 ../src/generic/filectrlg.cpp:752
+msgid "Illegal directory name."
+msgstr ""
+
+#: ../src/generic/dirctrlg.cpp:528 ../src/generic/dirctrlg.cpp:546
+#: ../src/generic/dirctrlg.cpp:557 ../src/generic/dirdlgg.cpp:317
+#: ../src/generic/filectrlg.cpp:638 ../src/generic/filectrlg.cpp:752
+#: ../src/generic/filectrlg.cpp:766 ../src/generic/filectrlg.cpp:782
+#: ../src/generic/filectrlg.cpp:1356 ../src/generic/filectrlg.cpp:1387
+#: ../src/generic/filedlgg.cpp:362 ../src/gtk/filedlg.cpp:76
+msgid "Error"
+msgstr ""
+
+#: ../src/generic/dirctrlg.cpp:546 ../src/generic/filectrlg.cpp:766
+msgid "File name exists already."
+msgstr ""
+
+#: ../src/generic/dirctrlg.cpp:557 ../src/generic/dirdlgg.cpp:317
+#: ../src/generic/filectrlg.cpp:638 ../src/generic/filectrlg.cpp:782
+msgid "Operation not permitted."
+msgstr ""
+
+#: ../src/generic/dirdlgg.cpp:107 ../src/generic/filedlgg.cpp:207
+msgid "Create new directory"
+msgstr ""
+
+#: ../src/generic/dirdlgg.cpp:112 ../src/generic/filedlgg.cpp:203
+msgid "Go to home directory"
+msgstr ""
+
+#: ../src/generic/dirdlgg.cpp:143
+msgid "Show &hidden directories"
+msgstr ""
+
+#: ../src/generic/dirdlgg.cpp:196
+#, c-format
+msgid ""
+"The directory '%s' does not exist\n"
+"Create it now?"
+msgstr ""
+
+#: ../src/generic/dirdlgg.cpp:198
+msgid "Directory does not exist"
+msgstr ""
+
+#: ../src/generic/dirdlgg.cpp:214
+#, c-format
+msgid ""
+"Failed to create directory '%s'\n"
+"(Do you have the required permissions?)"
+msgstr ""
+
+#: ../src/generic/dirdlgg.cpp:216
+msgid "Error creating directory"
+msgstr ""
+
+#: ../src/generic/dirdlgg.cpp:281
+msgid "You cannot add a new directory to this section."
+msgstr ""
+
+#: ../src/generic/dirdlgg.cpp:282
+msgid "Create directory"
+msgstr ""
+
+#: ../src/generic/dirdlgg.cpp:291 ../src/generic/dirdlgg.cpp:301
+#: ../src/generic/filectrlg.cpp:614 ../src/generic/filectrlg.cpp:623
+msgid "NewName"
+msgstr ""
+
+#: ../src/generic/editlbox.cpp:135
+msgid "Edit item"
+msgstr ""
+
+#: ../src/generic/editlbox.cpp:143
+msgid "New item"
+msgstr ""
+
+#: ../src/generic/editlbox.cpp:151
+msgid "Delete item"
+msgstr ""
+
+#: ../src/generic/editlbox.cpp:159
+msgid "Move up"
+msgstr ""
+
+#: ../src/generic/editlbox.cpp:164
+msgid "Move down"
+msgstr ""
+
+#: ../src/generic/fdrepdlg.cpp:108
+msgid "Search for:"
+msgstr ""
+
+#: ../src/generic/fdrepdlg.cpp:120
+msgid "Replace with:"
+msgstr ""
+
+#: ../src/generic/fdrepdlg.cpp:140
+msgid "Whole word"
+msgstr ""
+
+#: ../src/generic/fdrepdlg.cpp:143
+msgid "Match case"
+msgstr ""
+
+#: ../src/generic/fdrepdlg.cpp:156
+msgid "Search direction"
+msgstr ""
+
+#: ../src/generic/fdrepdlg.cpp:175
+msgid "&Replace"
+msgstr ""
+
+#: ../src/generic/fdrepdlg.cpp:178
+msgid "Replace &all"
+msgstr ""
+
+#: ../src/generic/filectrlg.cpp:246 ../src/generic/filectrlg.cpp:269
+msgid "<DIR>"
+msgstr "<DIR>"
+
+#: ../src/generic/filectrlg.cpp:248 ../src/generic/filectrlg.cpp:271
+msgid "<LINK>"
+msgstr "<LINK>"
+
+#: ../src/generic/filectrlg.cpp:250 ../src/generic/filectrlg.cpp:273
+msgid "<DRIVE>"
+msgstr "<DRIVE>"
+
+#: ../src/generic/filectrlg.cpp:275
+#, c-format
+msgid "%ld byte"
+msgid_plural "%ld bytes"
+msgstr[0] "%ld byte"
+msgstr[1] "%ld bytes"
+
+#: ../src/generic/filectrlg.cpp:420
+msgid "Name"
+msgstr ""
+
+#: ../src/generic/filectrlg.cpp:421 ../src/richtext/richtextformatdlg.cpp:361
+#: ../src/richtext/richtextsizepage.cpp:298
+msgid "Size"
+msgstr ""
+
+#: ../src/generic/filectrlg.cpp:422
+msgid "Type"
+msgstr ""
+
+#: ../src/generic/filectrlg.cpp:423
+msgid "Modified"
+msgstr ""
+
+#: ../src/generic/filectrlg.cpp:426
+msgid "Permissions"
+msgstr ""
+
+#: ../src/generic/filectrlg.cpp:429
+msgid "Attributes"
+msgstr ""
+
+#: ../src/generic/filectrlg.cpp:936
+msgid "Current directory:"
+msgstr ""
+
+#: ../src/generic/filectrlg.cpp:979
+msgid "Show &hidden files"
+msgstr ""
+
+#: ../src/generic/filectrlg.cpp:1355
+msgid "Illegal file specification."
+msgstr ""
+
+#: ../src/generic/filectrlg.cpp:1387
+msgid "Directory doesn't exist."
+msgstr ""
+
+#: ../src/generic/filedlgg.cpp:195
+msgid "View files as a list view"
+msgstr ""
+
+#: ../src/generic/filedlgg.cpp:197
+msgid "View files as a detailed view"
+msgstr ""
+
+#: ../src/generic/filedlgg.cpp:200
+msgid "Go to parent directory"
+msgstr ""
+
+#: ../src/generic/filedlgg.cpp:351 ../src/gtk/filedlg.cpp:59
+#, c-format
+msgid "File '%s' already exists, do you really want to overwrite it?"
+msgstr ""
+
+#: ../src/generic/filedlgg.cpp:354 ../src/gtk/filedlg.cpp:62
+msgid "Confirm"
+msgstr ""
+
+#: ../src/generic/filedlgg.cpp:362 ../src/gtk/filedlg.cpp:75
+msgid "Please choose an existing file."
+msgstr ""
+
+#: ../src/generic/filepickerg.cpp:64
+msgid "..."
+msgstr "..."
+
+#: ../src/generic/fontdlgg.cpp:76 ../src/richtext/richtextformatdlg.cpp:519
+msgid "ABCDEFGabcdefg12345"
+msgstr ""
+
+#: ../src/generic/fontdlgg.cpp:315
+msgid "Roman"
+msgstr ""
+
+#: ../src/generic/fontdlgg.cpp:316
+msgid "Decorative"
+msgstr ""
+
+#: ../src/generic/fontdlgg.cpp:317
+msgid "Modern"
+msgstr ""
+
+#: ../src/generic/fontdlgg.cpp:318
+msgid "Script"
+msgstr ""
+
+#: ../src/generic/fontdlgg.cpp:319
+msgid "Swiss"
+msgstr ""
+
+#: ../src/generic/fontdlgg.cpp:320
+msgid "Teletype"
+msgstr ""
+
+#: ../src/generic/fontdlgg.cpp:321 ../src/generic/fontdlgg.cpp:324
+msgid "Normal"
+msgstr ""
+
+#: ../src/generic/fontdlgg.cpp:323
+msgid "Slant"
+msgstr ""
+
+#: ../src/generic/fontdlgg.cpp:325
+msgid "Light"
+msgstr ""
+
+#: ../src/generic/fontdlgg.cpp:363
+msgid "&Font family:"
+msgstr ""
+
+#: ../src/generic/fontdlgg.cpp:367 ../src/generic/fontdlgg.cpp:369
+msgid "The font family."
+msgstr ""
+
+#: ../src/generic/fontdlgg.cpp:374 ../src/richtext/richtextstylepage.cpp:105
+msgid "&Style:"
+msgstr ""
+
+#: ../src/generic/fontdlgg.cpp:378 ../src/generic/fontdlgg.cpp:380
+msgid "The font style."
+msgstr ""
+
+#: ../src/generic/fontdlgg.cpp:385
+msgid "&Weight:"
+msgstr ""
+
+#: ../src/generic/fontdlgg.cpp:389 ../src/generic/fontdlgg.cpp:391
+msgid "The font weight."
+msgstr ""
+
+#: ../src/generic/fontdlgg.cpp:399
+msgid "C&olour:"
+msgstr ""
+
+#: ../src/generic/fontdlgg.cpp:407 ../src/generic/fontdlgg.cpp:409
+msgid "The font colour."
+msgstr ""
+
+#: ../src/generic/fontdlgg.cpp:415
+msgid "&Point size:"
+msgstr ""
+
+#: ../src/generic/fontdlgg.cpp:420 ../src/generic/fontdlgg.cpp:422
+#: ../src/generic/fontdlgg.cpp:426 ../src/generic/fontdlgg.cpp:428
+msgid "The font point size."
+msgstr ""
+
+#: ../src/generic/fontdlgg.cpp:439 ../src/generic/fontdlgg.cpp:441
+msgid "Whether the font is underlined."
+msgstr ""
+
+#: ../src/generic/fontdlgg.cpp:448 ../src/html/helpwnd.cpp:1215
+msgid "Preview:"
+msgstr ""
+
+#: ../src/generic/fontdlgg.cpp:452 ../src/generic/fontdlgg.cpp:454
+msgid "Shows the font preview."
+msgstr ""
+
+#: ../src/generic/fontdlgg.cpp:464 ../src/generic/fontdlgg.cpp:483
+msgid "Click to cancel the font selection."
+msgstr ""
+
+#: ../src/generic/fontdlgg.cpp:469 ../src/generic/fontdlgg.cpp:471
+#: ../src/generic/fontdlgg.cpp:476 ../src/generic/fontdlgg.cpp:478
+msgid "Click to confirm the font selection."
+msgstr ""
+
+#: ../src/generic/fontpickerg.cpp:50 ../src/gtk/fontdlg.cpp:77
+msgid "Choose font"
+msgstr ""
+
+#: ../src/generic/grid.cpp:6542
+msgid ""
+"Error copying grid to the clipboard. Either selected cells were not "
+"contiguous or no cell was selected."
+msgstr ""
+
+#: ../src/generic/grid.cpp:12739
+msgid "Grid Corner"
+msgstr ""
+
+#: ../src/generic/grid.cpp:12741
+#, c-format
+msgid "Column %s Header"
+msgstr ""
+
+#: ../src/generic/grid.cpp:12743
+#, c-format
+msgid "Row %s Header"
+msgstr ""
+
+#: ../src/generic/grid.cpp:12745
+#, c-format
+msgid "Column %s: %s"
+msgstr ""
+
+#: ../src/generic/grid.cpp:12749
+#, c-format
+msgid "Row %s: %s"
+msgstr ""
+
+#: ../src/generic/grid.cpp:12753
+#, c-format
+msgid "Row %s, Column %s: %s"
+msgstr ""
+
+#: ../src/generic/helpext.cpp:257
+#, c-format
+msgid "Help directory \"%s\" not found."
+msgstr ""
+
+#: ../src/generic/helpext.cpp:265
+#, c-format
+msgid "Help file \"%s\" not found."
+msgstr ""
+
+#: ../src/generic/helpext.cpp:284
+#, c-format
+msgid "Line %lu of map file \"%s\" has invalid syntax, skipped."
+msgstr ""
+
+#: ../src/generic/helpext.cpp:292
+#, c-format
+msgid "No valid mappings found in the file \"%s\"."
+msgstr ""
+
+#: ../src/generic/helpext.cpp:435
+msgid "No entries found."
+msgstr ""
+
+#: ../src/generic/helpext.cpp:444 ../src/generic/helpext.cpp:445
+msgid "Help Index"
+msgstr ""
+
+#: ../src/generic/helpext.cpp:448
+msgid "Relevant entries:"
+msgstr ""
+
+#: ../src/generic/helpext.cpp:449
+msgid "Entries found"
+msgstr ""
+
+#: ../src/generic/hyperlinkg.cpp:170
+msgid "&Copy URL"
+msgstr ""
+
+#: ../src/generic/infobar.cpp:119
+msgid "Hide this notification message."
+msgstr ""
+
+#. TRANSLATORS: %s will be either the application name or "Application"
+#: ../src/generic/logg.cpp:257
+#, c-format
+msgid "%s Error"
+msgstr "%s Error"
+
+#. TRANSLATORS: %s will be either the application name or "Application"
+#: ../src/generic/logg.cpp:263
+#, c-format
+msgid "%s Warning"
+msgstr "%s Warning"
+
+#. TRANSLATORS: %s will be either the application name or "Application"
+#: ../src/generic/logg.cpp:273
+#, c-format
+msgid "%s Information"
+msgstr "%s Information"
+
+#: ../src/generic/logg.cpp:276
+msgid "Application"
+msgstr ""
+
+#: ../src/generic/logg.cpp:549
+msgid "Save log contents to file"
+msgstr ""
+
+#: ../src/generic/logg.cpp:551
+msgid "C&lear"
+msgstr ""
+
+#: ../src/generic/logg.cpp:551
+msgid "Clear the log contents"
+msgstr ""
+
+#: ../src/generic/logg.cpp:553
+msgid "Close this window"
+msgstr ""
+
+#: ../src/generic/logg.cpp:554
+msgid "&Log"
+msgstr ""
+
+#: ../src/generic/logg.cpp:610 ../src/generic/logg.cpp:992
+msgid "Can't save log contents to file."
+msgstr ""
+
+#: ../src/generic/logg.cpp:613
+#, c-format
+msgid "Log saved to the file '%s'."
+msgstr ""
+
+#: ../src/generic/logg.cpp:719
+msgid "&Details"
+msgstr ""
+
+#: ../src/generic/logg.cpp:972
+msgid "Failed to copy dialog contents to the clipboard."
+msgstr ""
+
+#: ../src/generic/logg.cpp:1022
+#, c-format
+msgid "Append log to file '%s' (choosing [No] will overwrite it)?"
+msgstr ""
+
+#: ../src/generic/logg.cpp:1024
+msgid "Question"
+msgstr ""
+
+#: ../src/generic/logg.cpp:1038
+msgid "invalid message box return value"
+msgstr ""
+
+#: ../src/generic/notifmsgg.cpp:129
+msgid "Notice"
+msgstr ""
+
+#: ../src/generic/preferencesg.cpp:118
+#, c-format
+msgid "%s Preferences"
+msgstr "%s Preferences"
+
+#: ../src/generic/printps.cpp:143
+msgid "Printing..."
+msgstr ""
+
+#: ../src/generic/printps.cpp:160 ../src/gtk/print.cpp:1076
+#: ../src/msw/printwin.cpp:235
+msgid "Could not start printing."
+msgstr ""
+
+#: ../src/generic/printps.cpp:183
+#, c-format
+msgid "Printing page %d..."
+msgstr ""
+
+#: ../src/generic/prntdlgg.cpp:171
+msgid "Printer options"
+msgstr ""
+
+#: ../src/generic/prntdlgg.cpp:176
+msgid "Print to File"
+msgstr ""
+
+#: ../src/generic/prntdlgg.cpp:179
+msgid "Setup..."
+msgstr ""
+
+#: ../src/generic/prntdlgg.cpp:187
+msgid "Printer:"
+msgstr ""
+
+#: ../src/generic/prntdlgg.cpp:195
+msgid "Status:"
+msgstr ""
+
+#: ../src/generic/prntdlgg.cpp:206
+msgid "All"
+msgstr ""
+
+#: ../src/generic/prntdlgg.cpp:207
+msgid "Pages"
+msgstr ""
+
+#: ../src/generic/prntdlgg.cpp:215
+msgid "Print Range"
+msgstr ""
+
+#: ../src/generic/prntdlgg.cpp:229
+msgid "From:"
+msgstr ""
+
+#: ../src/generic/prntdlgg.cpp:233
+msgid "To:"
+msgstr ""
+
+#: ../src/generic/prntdlgg.cpp:238
+msgid "Copies:"
+msgstr ""
+
+#: ../src/generic/prntdlgg.cpp:288
+msgid "PostScript file"
+msgstr ""
+
+#: ../src/generic/prntdlgg.cpp:439
+msgid "Print Setup"
+msgstr ""
+
+#: ../src/generic/prntdlgg.cpp:483
+msgid "Printer"
+msgstr ""
+
+#: ../src/generic/prntdlgg.cpp:501
+msgid "Default printer"
+msgstr ""
+
+#: ../src/generic/prntdlgg.cpp:595 ../src/generic/prntdlgg.cpp:782
+#: ../src/generic/prntdlgg.cpp:822 ../src/generic/prntdlgg.cpp:835
+#: ../src/generic/prntdlgg.cpp:1031 ../src/generic/prntdlgg.cpp:1036
+msgid "Paper size"
+msgstr ""
+
+#: ../src/generic/prntdlgg.cpp:604 ../src/generic/prntdlgg.cpp:847
+msgid "Portrait"
+msgstr ""
+
+#: ../src/generic/prntdlgg.cpp:605 ../src/generic/prntdlgg.cpp:848
+msgid "Landscape"
+msgstr ""
+
+#: ../src/generic/prntdlgg.cpp:607 ../src/generic/prntdlgg.cpp:849
+msgid "Orientation"
+msgstr ""
+
+#: ../src/generic/prntdlgg.cpp:610
+msgid "Options"
+msgstr ""
+
+#: ../src/generic/prntdlgg.cpp:612
+msgid "Print in colour"
+msgstr ""
+
+#: ../src/generic/prntdlgg.cpp:621
+msgid "Print spooling"
+msgstr ""
+
+#: ../src/generic/prntdlgg.cpp:623
+msgid "Printer command:"
+msgstr ""
+
+#: ../src/generic/prntdlgg.cpp:631
+msgid "Printer options:"
+msgstr ""
+
+#: ../src/generic/prntdlgg.cpp:860
+msgid "Left margin (mm):"
+msgstr ""
+
+#: ../src/generic/prntdlgg.cpp:861
+msgid "Top margin (mm):"
+msgstr ""
+
+#: ../src/generic/prntdlgg.cpp:872
+msgid "Right margin (mm):"
+msgstr ""
+
+#: ../src/generic/prntdlgg.cpp:873
+msgid "Bottom margin (mm):"
+msgstr ""
+
+#: ../src/generic/prntdlgg.cpp:896
+msgid "Printer..."
+msgstr ""
+
+#: ../src/generic/progdlgg.cpp:246
+msgid "&Skip"
+msgstr ""
+
+#: ../src/generic/progdlgg.cpp:347 ../src/generic/progdlgg.cpp:626
+msgid "Unknown"
+msgstr ""
+
+#: ../src/generic/progdlgg.cpp:451 ../src/msw/progdlg.cpp:526
+msgid "Done."
+msgstr ""
+
+#: ../src/generic/srchctlg.cpp:55 ../src/gtk/srchctrl.cpp:206
+#: ../src/html/helpwnd.cpp:530 ../src/html/helpwnd.cpp:545
+msgid "Search"
+msgstr ""
+
+#: ../src/generic/tabg.cpp:1026
+msgid "Could not find tab for id"
+msgstr ""
+
+#: ../src/generic/tipdlg.cpp:136
+msgid "Tips not available, sorry!"
+msgstr ""
+
+#: ../src/generic/tipdlg.cpp:197
+msgid "Tip of the Day"
+msgstr ""
+
+#: ../src/generic/tipdlg.cpp:207
+msgid "Did you know..."
+msgstr ""
+
+#: ../src/generic/tipdlg.cpp:232
+msgid "&Show tips at startup"
+msgstr ""
+
+#: ../src/generic/tipdlg.cpp:236
+msgid "&Next Tip"
+msgstr ""
+
+#: ../src/generic/wizard.cpp:411
+msgid "&Next >"
+msgstr ""
+
+#: ../src/generic/wizard.cpp:412
+msgid "&Finish"
+msgstr ""
+
+#: ../src/generic/wizard.cpp:420
+msgid "< &Back"
+msgstr "< &Back"
+
+#: ../src/gtk/aboutdlg.cpp:204
+msgid "translator-credits"
+msgstr "مترجم-اعتبارات"
+
+#: ../src/gtk/app.cpp:517
+msgid ""
+"WARNING: using XIM input method is unsupported and may result in problems "
+"with input handling and flickering. Consider unsetting GTK_IM_MODULE or "
+"setting to \"ibus\"."
+msgstr ""
+
+#: ../src/gtk/app.cpp:569
+msgid "Unable to initialize GTK+, is DISPLAY set properly?"
+msgstr ""
+
+#: ../src/gtk/filedlg.cpp:89 ../src/gtk/filepicker.cpp:255
+#, c-format
+msgid "Changing current directory to \"%s\" failed"
+msgstr ""
+
+#: ../src/gtk/font.cpp:548
+msgid ""
+"Using private fonts is not supported on this system: Pango library is too "
+"old, 1.38 or later required."
+msgstr ""
+
+#: ../src/gtk/font.cpp:558
+msgid "Failed to create font configuration object."
+msgstr ""
+
+#: ../src/gtk/font.cpp:568
+#, c-format
+msgid "Failed to add custom font \"%s\"."
+msgstr ""
+
+#: ../src/gtk/font.cpp:576
+msgid "Failed to register font configuration using private fonts."
+msgstr ""
+
+#: ../src/gtk/glcanvas.cpp:117 ../src/gtk/glcanvas.cpp:132
+#, fuzzy
+msgid "Fatal Error"
+msgstr "%s Error"
+
+#: ../src/gtk/glcanvas.cpp:117
+msgid ""
+"This program wasn't compiled with EGL support required under Wayland, "
+"either\n"
+"install EGL libraries and rebuild or run it under X11 backend by setting\n"
+"environment variable GDK_BACKEND=x11 before starting your program."
+msgstr ""
+
+#: ../src/gtk/glcanvas.cpp:132
+msgid ""
+"wxGLCanvas is only supported on Wayland and X11 currently.  You may be able "
+"to\n"
+"work around this by setting environment variable GDK_BACKEND=x11 before\n"
+"starting your program."
+msgstr ""
+
+#: ../src/gtk/mdi.cpp:433
+msgid "MDI child"
+msgstr ""
+
+#: ../src/gtk/power.cpp:188
+#, c-format
+msgid "Failed to open D-Bus connection to the login manager: %s"
+msgstr ""
+
+#: ../src/gtk/power.cpp:214
+msgid "wxWidgets application"
+msgstr ""
+
+#: ../src/gtk/power.cpp:226
+msgid "Application needs to keep running"
+msgstr ""
+
+#: ../src/gtk/power.cpp:233
+msgid "Clean up before suspend"
+msgstr ""
+
+#: ../src/gtk/power.cpp:259
+#, c-format
+msgid "Failed to inhibit sleep: %s"
+msgstr ""
+
+#: ../src/gtk/power.cpp:265
+msgid "Unexpected response to D-Bus \"Inhibit\" request."
+msgstr ""
+
+#: ../src/gtk/print.cpp:218
+msgid "Custom size"
+msgstr ""
+
+#: ../src/gtk/print.cpp:752
+#, c-format
+msgid "Error while printing: %s"
+msgstr ""
+
+#: ../src/gtk/print.cpp:816
+msgid "Page Setup"
+msgstr ""
+
+#: ../src/gtk/webview_webkit.cpp:932
+msgid "Retrieving JavaScript script output is not supported with WebKit v1"
+msgstr ""
+
+#: ../src/gtk/webview_webkit2.cpp:1098
+msgid ""
+"Setting proxy is not supported by WebKit, at least version 2.16 is required."
+msgstr ""
+
+#: ../src/gtk/webview_webkit2.cpp:1104
+msgid "This program was compiled without support for setting WebKit proxy."
+msgstr ""
+
+#: ../src/gtk/window.cpp:6289
+msgid ""
+"GTK+ installed on this machine is too old to support screen compositing, "
+"please install GTK+ 2.12 or later."
+msgstr ""
+
+#: ../src/gtk/window.cpp:6307
+msgid ""
+"Compositing not supported by this system, please enable it in your Window "
+"Manager."
+msgstr ""
+
+#: ../src/gtk/window.cpp:6318
+msgid ""
+"This program was compiled with a too old version of GTK+, please rebuild "
+"with GTK+ 2.12 or newer."
+msgstr ""
+
+#: ../src/html/chm.cpp:138
+#, c-format
+msgid "Failed to open CHM archive '%s'."
+msgstr ""
+
+#: ../src/html/chm.cpp:270
+#, c-format
+msgid "Could not extract %s into %s: %s"
+msgstr ""
+
+#: ../src/html/chm.cpp:324
+msgid "no error"
+msgstr ""
+
+#: ../src/html/chm.cpp:326
+msgid "bad arguments to library function"
+msgstr ""
+
+#: ../src/html/chm.cpp:328
+msgid "error opening file"
+msgstr ""
+
+#: ../src/html/chm.cpp:330
+msgid "read error"
+msgstr ""
+
+#: ../src/html/chm.cpp:332
+msgid "write error"
+msgstr "خطا در نوشتن"
+
+#: ../src/html/chm.cpp:334
+msgid "seek error"
+msgstr ""
+
+#: ../src/html/chm.cpp:338
+msgid "bad signature"
+msgstr ""
+
+#: ../src/html/chm.cpp:340
+msgid "error in data format"
+msgstr ""
+
+#: ../src/html/chm.cpp:342
+msgid "checksum error"
+msgstr ""
+
+#: ../src/html/chm.cpp:344
+msgid "compression error"
+msgstr ""
+
+#: ../src/html/chm.cpp:346
+msgid "decompression error"
+msgstr ""
+
+#: ../src/html/chm.cpp:437
+#, c-format
+msgid "Could not locate file '%s'."
+msgstr ""
+
+#: ../src/html/chm.cpp:711
+#, c-format
+msgid "Could not create temporary file '%s'"
+msgstr ""
+
+#: ../src/html/chm.cpp:718
+#, c-format
+msgid "Extraction of '%s' into '%s' failed."
+msgstr ""
+
+#: ../src/html/chm.cpp:806 ../src/html/chm.cpp:863
+msgid "CHM handler currently supports only local files!"
+msgstr ""
+
+#: ../src/html/chm.cpp:827
+msgid "Link contained '//', converted to absolute link."
+msgstr ""
+
+#: ../src/html/helpctrl.cpp:59
+#, c-format
+msgid "Help: %s"
+msgstr ""
+
+#: ../src/html/helpctrl.cpp:155
+#, c-format
+msgid "Adding book %s"
+msgstr ""
+
+#: ../src/html/helpdata.cpp:295
+#, c-format
+msgid "Cannot open contents file: %s"
+msgstr ""
+
+#: ../src/html/helpdata.cpp:309
+#, c-format
+msgid "Cannot open index file: %s"
+msgstr ""
+
+#: ../src/html/helpdata.cpp:643
+msgid "noname"
+msgstr ""
+
+#: ../src/html/helpdata.cpp:652
+#, c-format
+msgid "Cannot open HTML help book: %s"
+msgstr ""
+
+#: ../src/html/helpwnd.cpp:315
+msgid "Displays help as you browse the books on the left."
+msgstr ""
+
+#: ../src/html/helpwnd.cpp:411 ../src/html/helpwnd.cpp:1100
+#: ../src/html/helpwnd.cpp:1735
+msgid "(bookmarks)"
+msgstr "(نشانک)"
+
+#: ../src/html/helpwnd.cpp:424
+msgid "Add current page to bookmarks"
+msgstr ""
+
+#: ../src/html/helpwnd.cpp:425
+msgid "Remove current page from bookmarks"
+msgstr ""
+
+#: ../src/html/helpwnd.cpp:470
+msgid "Contents"
+msgstr ""
+
+#: ../src/html/helpwnd.cpp:485
+msgid "Find"
+msgstr ""
+
+#: ../src/html/helpwnd.cpp:487
+msgid "Show all"
+msgstr ""
+
+#: ../src/html/helpwnd.cpp:497
+msgid ""
+"Display all index items that contain given substring. Search is case "
+"insensitive."
+msgstr ""
+
+#: ../src/html/helpwnd.cpp:498
+msgid "Show all items in index"
+msgstr ""
+
+#: ../src/html/helpwnd.cpp:528
+msgid "Case sensitive"
+msgstr ""
+
+#: ../src/html/helpwnd.cpp:529
+msgid "Whole words only"
+msgstr ""
+
+#: ../src/html/helpwnd.cpp:532
+msgid ""
+"Search contents of help book(s) for all occurrences of the text you typed "
+"above"
+msgstr ""
+
+#: ../src/html/helpwnd.cpp:653
+msgid "Show/hide navigation panel"
+msgstr ""
+
+#: ../src/html/helpwnd.cpp:655
+msgid "Go back"
+msgstr ""
+
+#: ../src/html/helpwnd.cpp:656
+msgid "Go forward"
+msgstr ""
+
+#: ../src/html/helpwnd.cpp:658
+msgid "Go one level up in document hierarchy"
+msgstr ""
+
+#: ../src/html/helpwnd.cpp:666 ../src/html/helpwnd.cpp:1547
+msgid "Open HTML document"
+msgstr ""
+
+#: ../src/html/helpwnd.cpp:670
+msgid "Print this page"
+msgstr ""
+
+#: ../src/html/helpwnd.cpp:674
+msgid "Display options dialog"
+msgstr ""
+
+#: ../src/html/helpwnd.cpp:795
+msgid "Please choose the page to display:"
+msgstr ""
+
+#: ../src/html/helpwnd.cpp:796
+msgid "Help Topics"
+msgstr ""
+
+#: ../src/html/helpwnd.cpp:852
+msgid "Searching..."
+msgstr ""
+
+#: ../src/html/helpwnd.cpp:853
+msgid "No matching page found yet"
+msgstr ""
+
+#: ../src/html/helpwnd.cpp:870
+#, c-format
+msgid "Found %i matches"
+msgstr ""
+
+#: ../src/html/helpwnd.cpp:958
+msgid "(Help)"
+msgstr "(راهنما)"
+
+#: ../src/html/helpwnd.cpp:1026
+#, c-format
+msgid "%d of %lu"
+msgstr "%d of %lu"
+
+#: ../src/html/helpwnd.cpp:1028
+#, c-format
+msgid "%lu of %lu"
+msgstr "%lu of %lu"
+
+#: ../src/html/helpwnd.cpp:1047
+msgid "Search in all books"
+msgstr ""
+
+#: ../src/html/helpwnd.cpp:1193
+msgid "Help Browser Options"
+msgstr ""
+
+#: ../src/html/helpwnd.cpp:1198
+msgid "Normal font:"
+msgstr ""
+
+#: ../src/html/helpwnd.cpp:1199
+msgid "Fixed font:"
+msgstr ""
+
+#: ../src/html/helpwnd.cpp:1200
+msgid "Font size:"
+msgstr ""
+
+#: ../src/html/helpwnd.cpp:1245
+msgid "font size"
+msgstr ""
+
+#: ../src/html/helpwnd.cpp:1256
+msgid "Normal face<br>and <u>underlined</u>. "
+msgstr ""
+
+#: ../src/html/helpwnd.cpp:1257
+msgid "<i>Italic face.</i> "
+msgstr "<i>Italic face.</i> "
+
+#: ../src/html/helpwnd.cpp:1258
+msgid "<b>Bold face.</b> "
+msgstr "<b>Bold face.</b> "
+
+#: ../src/html/helpwnd.cpp:1259
+msgid "<b><i>Bold italic face.</i></b><br>"
+msgstr "<b><i>Bold italic face.</i></b><br>"
+
+#: ../src/html/helpwnd.cpp:1262
+msgid "Fixed size face.<br> <b>bold</b> <i>italic</i> "
+msgstr ""
+
+#: ../src/html/helpwnd.cpp:1263
+msgid "<b><i>bold italic <u>underlined</u></i></b><br>"
+msgstr "<b><i>bold italic <u>underlined</u></i></b><br>"
+
+#: ../src/html/helpwnd.cpp:1524
+msgid "Help Printing"
+msgstr ""
+
+#: ../src/html/helpwnd.cpp:1527
+msgid "Cannot print empty page."
+msgstr ""
+
+#: ../src/html/helpwnd.cpp:1540
+msgid "HTML files (*.html;*.htm)|*.html;*.htm|"
+msgstr ""
+
+#: ../src/html/helpwnd.cpp:1541
+msgid "Help books (*.htb)|*.htb|Help books (*.zip)|*.zip|"
+msgstr ""
+
+#: ../src/html/helpwnd.cpp:1542
+msgid "HTML Help Project (*.hhp)|*.hhp|"
+msgstr ""
+
+#: ../src/html/helpwnd.cpp:1544
+msgid "Compressed HTML Help file (*.chm)|*.chm|"
+msgstr ""
+
+#: ../src/html/helpwnd.cpp:1671
+#, c-format
+msgid "%i of %u"
+msgstr "%i of %u"
+
+#: ../src/html/helpwnd.cpp:1709
+#, c-format
+msgid "%u of %u"
+msgstr "%u of %u"
+
+#: ../src/html/htmlfilt.cpp:134
+#, c-format
+msgid "Cannot open HTML document: %s"
+msgstr ""
+
+#: ../src/html/htmlwin.cpp:599
+msgid "Connecting..."
+msgstr ""
+
+#: ../src/html/htmlwin.cpp:616
+#, c-format
+msgid "Unable to open requested HTML document: %s"
+msgstr ""
+
+#: ../src/html/htmlwin.cpp:630
+msgid "Loading : "
+msgstr ""
+
+#: ../src/html/htmlwin.cpp:673
+msgid "Done"
+msgstr ""
+
+#: ../src/html/htmlwin.cpp:723
+#, c-format
+msgid "HTML anchor %s does not exist."
+msgstr ""
+
+#: ../src/html/htmlwin.cpp:1057
+#, c-format
+msgid "Copied to clipboard:\"%s\""
+msgstr ""
+
+#: ../src/html/htmprint.cpp:269
+msgid ""
+"This document doesn't fit on the page horizontally and will be truncated "
+"when it is printed."
+msgstr ""
+
+#: ../src/html/htmprint.cpp:285
+#, c-format
+msgid ""
+"The document \"%s\" doesn't fit on the page horizontally and will be "
+"truncated if printed.\n"
+"\n"
+"Would you like to proceed with printing it nevertheless?"
+msgstr ""
+
+#: ../src/html/htmprint.cpp:296
+msgid ""
+"If possible, try changing the layout parameters to make the printout more "
+"narrow."
+msgstr ""
+
+#: ../src/html/htmprint.cpp:445
+msgid ": file does not exist!"
+msgstr ": فایل موجود نیست!"
+
+#. TRANSLATORS: %s may be a document title.
+#: ../src/html/htmprint.cpp:717
+#, fuzzy, c-format
+msgid "%s Preview"
+msgstr " پیش نمایش"
+
+#: ../src/html/htmprint.cpp:755 ../src/richtext/richtextprint.cpp:618
+msgid ""
+"There was a problem during page setup: you may need to set a default printer."
+msgstr ""
+
+#: ../src/msw/clipbrd.cpp:80
+msgid "Failed to open the clipboard."
+msgstr ""
+
+#: ../src/msw/clipbrd.cpp:101
+msgid "Failed to close the clipboard."
+msgstr ""
+
+#: ../src/msw/clipbrd.cpp:113
+msgid "Failed to empty the clipboard."
+msgstr ""
+
+#: ../src/msw/clipbrd.cpp:284
+msgid "Failed to put data on the clipboard"
+msgstr ""
+
+#: ../src/msw/clipbrd.cpp:326
+msgid "Failed to get data from the clipboard"
+msgstr ""
+
+#: ../src/msw/clipbrd.cpp:363
+msgid "Failed to retrieve the supported clipboard formats"
+msgstr ""
+
+#: ../src/msw/colordlg.cpp:228
+#, c-format
+msgid "Colour selection dialog failed with error %0lx."
+msgstr ""
+
+#: ../src/msw/cursor.cpp:141
+msgid "Failed to create cursor."
+msgstr ""
+
+#: ../src/msw/dde.cpp:279
+#, c-format
+msgid "Failed to register DDE server '%s'"
+msgstr ""
+
+#: ../src/msw/dde.cpp:300
+#, c-format
+msgid "Failed to unregister DDE server '%s'"
+msgstr ""
+
+#: ../src/msw/dde.cpp:428
+#, c-format
+msgid "Failed to create connection to server '%s' on topic '%s'"
+msgstr ""
+
+#: ../src/msw/dde.cpp:655
+msgid "DDE poke request failed"
+msgstr ""
+
+#: ../src/msw/dde.cpp:674
+msgid "Failed to establish an advise loop with DDE server"
+msgstr ""
+
+#: ../src/msw/dde.cpp:693
+msgid "Failed to terminate the advise loop with DDE server"
+msgstr ""
+
+#: ../src/msw/dde.cpp:768
+msgid "Failed to send DDE advise notification"
+msgstr ""
+
+#: ../src/msw/dde.cpp:1085
+msgid "Failed to create DDE string"
+msgstr ""
+
+#: ../src/msw/dde.cpp:1131
+msgid "no DDE error."
+msgstr ""
+
+#: ../src/msw/dde.cpp:1135
+msgid "a request for a synchronous advise transaction has timed out."
+msgstr ""
+
+#: ../src/msw/dde.cpp:1138
+msgid "the response to the transaction caused the DDE_FBUSY bit to be set."
+msgstr "پاسخ به ترکنش باعث شد بیت DDE_FBUSY تنظیم شود."
+
+#: ../src/msw/dde.cpp:1141
+msgid "a request for a synchronous data transaction has timed out."
+msgstr ""
+
+#: ../src/msw/dde.cpp:1144
+msgid ""
+"a DDEML function was called without first calling the DdeInitialize "
+"function,\n"
+"or an invalid instance identifier\n"
+"was passed to a DDEML function."
+msgstr ""
+
+#: ../src/msw/dde.cpp:1147
+msgid ""
+"an application initialized as APPCLASS_MONITOR has\n"
+"attempted to perform a DDE transaction,\n"
+"or an application initialized as APPCMD_CLIENTONLY has \n"
+"attempted to perform server transactions."
+msgstr ""
+
+#: ../src/msw/dde.cpp:1150
+msgid "a request for a synchronous execute transaction has timed out."
+msgstr ""
+
+#: ../src/msw/dde.cpp:1153
+msgid "a parameter failed to be validated by the DDEML."
+msgstr ""
+
+#: ../src/msw/dde.cpp:1156
+msgid "a DDEML application has created a prolonged race condition."
+msgstr ""
+
+#: ../src/msw/dde.cpp:1159
+msgid "a memory allocation failed."
+msgstr ""
+
+#: ../src/msw/dde.cpp:1162
+msgid "a client's attempt to establish a conversation has failed."
+msgstr ""
+
+#: ../src/msw/dde.cpp:1165
+msgid "a transaction failed."
+msgstr ""
+
+#: ../src/msw/dde.cpp:1168
+msgid "a request for a synchronous poke transaction has timed out."
+msgstr ""
+
+#: ../src/msw/dde.cpp:1171
+msgid "an internal call to the PostMessage function has failed. "
+msgstr ""
+
+#: ../src/msw/dde.cpp:1174
+msgid "reentrancy problem."
+msgstr ""
+
+#: ../src/msw/dde.cpp:1177
+msgid ""
+"a server-side transaction was attempted on a conversation\n"
+"that was terminated by the client, or the server\n"
+"terminated before completing a transaction."
+msgstr ""
+
+#: ../src/msw/dde.cpp:1180
+msgid "an internal error has occurred in the DDEML."
+msgstr ""
+
+#: ../src/msw/dde.cpp:1183
+msgid "a request to end an advise transaction has timed out."
+msgstr ""
+
+#: ../src/msw/dde.cpp:1186
+msgid ""
+"an invalid transaction identifier was passed to a DDEML function.\n"
+"Once the application has returned from an XTYP_XACT_COMPLETE callback,\n"
+"the transaction identifier for that callback is no longer valid."
+msgstr ""
+
+#: ../src/msw/dde.cpp:1189
+#, c-format
+msgid "Unknown DDE error %08x"
+msgstr ""
+
+#: ../src/msw/dialup.cpp:343
+msgid ""
+"Dial up functions are unavailable because the remote access service (RAS) is "
+"not installed on this machine. Please install it."
+msgstr ""
+
+#: ../src/msw/dialup.cpp:402
+#, c-format
+msgid ""
+"The version of remote access service (RAS) installed on this machine is too "
+"old, please upgrade (the following required function is missing: %s)."
+msgstr ""
+
+#: ../src/msw/dialup.cpp:437
+msgid "Failed to retrieve text of RAS error message"
+msgstr ""
+
+#: ../src/msw/dialup.cpp:440
+#, c-format
+msgid "unknown error (error code %08x)."
+msgstr ""
+
+#: ../src/msw/dialup.cpp:492
+#, c-format
+msgid "Cannot find active dialup connection: %s"
+msgstr ""
+
+#: ../src/msw/dialup.cpp:513
+msgid "Several active dialup connections found, choosing one randomly."
+msgstr ""
+
+#: ../src/msw/dialup.cpp:598 ../src/msw/dialup.cpp:832
+#, c-format
+msgid "Failed to establish dialup connection: %s"
+msgstr ""
+
+#: ../src/msw/dialup.cpp:664
+#, c-format
+msgid "Failed to get ISP names: %s"
+msgstr ""
+
+#: ../src/msw/dialup.cpp:712
+msgid "Failed to connect: no ISP to dial."
+msgstr ""
+
+#: ../src/msw/dialup.cpp:732
+msgid "Choose ISP to dial"
+msgstr ""
+
+#: ../src/msw/dialup.cpp:733
+msgid "Please choose which ISP do you want to connect to"
+msgstr ""
+
+#: ../src/msw/dialup.cpp:766
+msgid "Failed to connect: missing username/password."
+msgstr ""
+
+#: ../src/msw/dialup.cpp:796
+msgid "Cannot find the location of address book file"
+msgstr ""
+
+#: ../src/msw/dialup.cpp:827
+#, c-format
+msgid "Failed to initiate dialup connection: %s"
+msgstr ""
+
+#: ../src/msw/dialup.cpp:897
+msgid "Cannot hang up - no active dialup connection."
+msgstr ""
+
+#: ../src/msw/dialup.cpp:907
+#, c-format
+msgid "Failed to terminate the dialup connection: %s"
+msgstr ""
+
+#: ../src/msw/dib.cpp:313
+#, c-format
+msgid "Failed to save the bitmap image to file \"%s\"."
+msgstr ""
+
+#: ../src/msw/dib.cpp:543
+#, c-format
+msgid "Failed to allocate %luKb of memory for bitmap data."
+msgstr ""
+
+#: ../src/msw/dir.cpp:241
+#, c-format
+msgid "Cannot enumerate files in directory '%s'"
+msgstr ""
+
+#: ../src/msw/dirdlg.cpp:368
+msgid "Couldn't obtain folder name"
+msgstr ""
+
+#: ../src/msw/dlmsw.cpp:163
+#, c-format
+msgid "(error %d: %s)"
+msgstr ""
+
+#: ../src/msw/dragimag.cpp:143 ../src/msw/dragimag.cpp:178
+#: ../src/msw/imaglist.cpp:309 ../src/msw/imaglist.cpp:331
+msgid "Couldn't add an image to the image list."
+msgstr ""
+
+#: ../src/msw/enhmeta.cpp:94
+#, c-format
+msgid "Failed to load metafile from file \"%s\"."
+msgstr ""
+
+#: ../src/msw/fdrepdlg.cpp:412
+#, c-format
+msgid "Failed to create the standard find/replace dialog (error code %d)"
+msgstr ""
+
+#: ../src/msw/filedlg.cpp:1241
+msgid "Access to the file system is not allowed from secure desktop."
+msgstr ""
+
+#: ../src/msw/filedlg.cpp:1242
+msgid "Security warning"
+msgstr ""
+
+#: ../src/msw/filedlg.cpp:1533
+#, c-format
+msgid "File dialog failed with error code %0lx."
+msgstr ""
+
+#: ../src/msw/font.cpp:1120
+#, c-format
+msgid "Font file \"%s\" couldn't be loaded"
+msgstr ""
+
+#: ../src/msw/fontdlg.cpp:220
+#, c-format
+msgid "Common dialog failed with error code %0lx."
+msgstr ""
+
+#: ../src/msw/fswatcher.cpp:67
+msgid "Ungraceful worker thread termination"
+msgstr ""
+
+#: ../src/msw/fswatcher.cpp:81
+msgid "Unable to create IOCP worker thread"
+msgstr ""
+
+#: ../src/msw/fswatcher.cpp:88
+msgid "Unable to start IOCP worker thread"
+msgstr ""
+
+#: ../src/msw/fswatcher.cpp:140
+msgid "Monitoring individual files for changes is not supported currently."
+msgstr ""
+
+#: ../src/msw/fswatcher.cpp:165
+#, c-format
+msgid "Unable to set up watch for '%s'"
+msgstr ""
+
+#: ../src/msw/fswatcher.cpp:466
+#, c-format
+msgid "Can't monitor non-existent directory \"%s\" for changes."
+msgstr ""
+
+#: ../src/msw/glcanvas.cpp:577 ../src/unix/glx11.cpp:507
+msgid "OpenGL 3.0 or later is not supported by the OpenGL driver."
+msgstr ""
+
+#: ../src/msw/glcanvas.cpp:601 ../src/osx/glcanvas_osx.cpp:395
+#: ../src/unix/glegl.cpp:304 ../src/unix/glx11.cpp:553
+msgid "Couldn't create OpenGL context"
+msgstr ""
+
+#: ../src/msw/glcanvas.cpp:1294
+msgid "Failed to initialize OpenGL"
+msgstr ""
+
+#: ../src/msw/graphicsd2d.cpp:607
+msgid "Could not register custom DirectWrite font loader."
+msgstr ""
+
+#: ../src/msw/helpchm.cpp:48
+msgid ""
+"MS HTML Help functions are unavailable because the MS HTML Help library is "
+"not installed on this machine. Please install it."
+msgstr ""
+
+#: ../src/msw/helpchm.cpp:55
+msgid "Failed to initialize MS HTML Help."
+msgstr ""
+
+#: ../src/msw/iniconf.cpp:458
+#, c-format
+msgid "Can't delete the INI file '%s'"
+msgstr ""
+
+#: ../src/msw/listctrl.cpp:995
+#, c-format
+msgid "Couldn't retrieve information about list control item %d."
+msgstr ""
+
+#: ../src/msw/mdi.cpp:170 ../src/qt/mdi.cpp:253
+msgid "&Cascade"
+msgstr ""
+
+#: ../src/msw/mdi.cpp:171
+msgid "Tile &Horizontally"
+msgstr ""
+
+#: ../src/msw/mdi.cpp:172
+msgid "Tile &Vertically"
+msgstr ""
+
+#: ../src/msw/mdi.cpp:174
+msgid "&Arrange Icons"
+msgstr "مرتب کردن نشانه ها"
+
+#: ../src/msw/mdi.cpp:621
+msgid "Failed to create MDI parent frame."
+msgstr ""
+
+#: ../src/msw/mimetype.cpp:234
+#, c-format
+msgid "Failed to create registry entry for '%s' files."
+msgstr ""
+
+#: ../src/msw/ole/automtn.cpp:495
+#, c-format
+msgid "Failed to find CLSID of \"%s\""
+msgstr ""
+
+#: ../src/msw/ole/automtn.cpp:512
+#, c-format
+msgid "Failed to create an instance of \"%s\""
+msgstr ""
+
+#: ../src/msw/ole/automtn.cpp:552
+#, c-format
+msgid "Cannot get an active instance of \"%s\""
+msgstr ""
+
+#: ../src/msw/ole/automtn.cpp:564
+#, c-format
+msgid "Failed to get OLE automation interface for \"%s\""
+msgstr ""
+
+#: ../src/msw/ole/automtn.cpp:621
+msgid "Unknown name or named argument."
+msgstr ""
+
+#: ../src/msw/ole/automtn.cpp:625
+msgid "Incorrect number of arguments."
+msgstr ""
+
+#: ../src/msw/ole/automtn.cpp:637
+msgid "Unknown exception"
+msgstr ""
+
+#: ../src/msw/ole/automtn.cpp:642
+msgid "Method or property not found."
+msgstr ""
+
+#: ../src/msw/ole/automtn.cpp:646
+msgid "Overflow while coercing argument values."
+msgstr ""
+
+#: ../src/msw/ole/automtn.cpp:650
+msgid "Object implementation does not support named arguments."
+msgstr ""
+
+#: ../src/msw/ole/automtn.cpp:654
+msgid "The locale ID is unknown."
+msgstr ""
+
+#: ../src/msw/ole/automtn.cpp:658
+msgid "Missing a required parameter."
+msgstr ""
+
+#: ../src/msw/ole/automtn.cpp:662
+#, c-format
+msgid "Argument %u not found."
+msgstr ""
+
+#: ../src/msw/ole/automtn.cpp:666
+#, c-format
+msgid "Type mismatch in argument %u."
+msgstr ""
+
+#: ../src/msw/ole/automtn.cpp:670
+msgid "The system cannot find the file specified."
+msgstr ""
+
+#: ../src/msw/ole/automtn.cpp:674
+msgid "Class not registered."
+msgstr ""
+
+#: ../src/msw/ole/automtn.cpp:678
+#, c-format
+msgid "Unknown error %08x"
+msgstr ""
+
+#: ../src/msw/ole/automtn.cpp:682
+#, c-format
+msgid "OLE Automation error in %s: %s"
+msgstr ""
+
+#: ../src/msw/ole/dataobj.cpp:385
+#, c-format
+msgid "Couldn't register clipboard format '%s'."
+msgstr ""
+
+#: ../src/msw/ole/dataobj.cpp:402
+#, c-format
+msgid "The clipboard format '%d' doesn't exist."
+msgstr ""
+
+#: ../src/msw/progdlg.cpp:1025
+msgid "Skip"
+msgstr ""
+
+#: ../src/msw/registry.cpp:141
+#, c-format
+msgid "unknown (%lu)"
+msgstr ""
+
+#: ../src/msw/registry.cpp:409
+#, c-format
+msgid "Can't get info about registry key '%s'"
+msgstr ""
+
+#: ../src/msw/registry.cpp:445
+#, c-format
+msgid "Can't open registry key '%s'"
+msgstr ""
+
+#: ../src/msw/registry.cpp:478
+#, c-format
+msgid "Can't create registry key '%s'"
+msgstr ""
+
+#: ../src/msw/registry.cpp:497
+#, c-format
+msgid "Can't close registry key '%s'"
+msgstr ""
+
+#: ../src/msw/registry.cpp:512
+#, c-format
+msgid "Registry value '%s' already exists."
+msgstr ""
+
+#: ../src/msw/registry.cpp:520
+#, c-format
+msgid "Failed to rename registry value '%s' to '%s'."
+msgstr ""
+
+#: ../src/msw/registry.cpp:575
+#, c-format
+msgid "Can't copy values of unsupported type %d."
+msgstr ""
+
+#: ../src/msw/registry.cpp:586
+#, c-format
+msgid "Registry key '%s' does not exist, cannot rename it."
+msgstr ""
+
+#: ../src/msw/registry.cpp:617
+#, c-format
+msgid "Registry key '%s' already exists."
+msgstr ""
+
+#: ../src/msw/registry.cpp:625
+#, c-format
+msgid "Failed to rename the registry key '%s' to '%s'."
+msgstr ""
+
+#: ../src/msw/registry.cpp:670
+#, c-format
+msgid "Failed to copy the registry subkey '%s' to '%s'."
+msgstr ""
+
+#: ../src/msw/registry.cpp:683
+#, c-format
+msgid "Failed to copy registry value '%s'"
+msgstr ""
+
+#: ../src/msw/registry.cpp:692
+#, c-format
+msgid "Failed to copy the contents of registry key '%s' to '%s'."
+msgstr ""
+
+#: ../src/msw/registry.cpp:718
+#, c-format
+msgid ""
+"Registry key '%s' is needed for normal system operation,\n"
+"deleting it will leave your system in unusable state:\n"
+"operation aborted."
+msgstr ""
+
+#: ../src/msw/registry.cpp:754
+#, c-format
+msgid "Can't delete key '%s'"
+msgstr ""
+
+#: ../src/msw/registry.cpp:782
+#, c-format
+msgid "Can't delete value '%s' from key '%s'"
+msgstr ""
+
+#: ../src/msw/registry.cpp:855 ../src/msw/registry.cpp:887
+#: ../src/msw/registry.cpp:929 ../src/msw/registry.cpp:1000
+#, c-format
+msgid "Can't read value of key '%s'"
+msgstr ""
+
+#: ../src/msw/registry.cpp:873 ../src/msw/registry.cpp:915
+#: ../src/msw/registry.cpp:963 ../src/msw/registry.cpp:1106
+#, c-format
+msgid "Can't set value of '%s'"
+msgstr ""
+
+#: ../src/msw/registry.cpp:894 ../src/msw/registry.cpp:943
+#, c-format
+msgid "Registry value \"%s\" is not numeric (but of type %s)"
+msgstr ""
+
+#: ../src/msw/registry.cpp:979
+#, c-format
+msgid "Registry value \"%s\" is not binary (but of type %s)"
+msgstr ""
+
+#: ../src/msw/registry.cpp:1028
+#, c-format
+msgid "Registry value \"%s\" is not text (but of type %s)"
+msgstr ""
+
+#: ../src/msw/registry.cpp:1089
+#, c-format
+msgid "Can't read value of '%s'"
+msgstr ""
+
+#: ../src/msw/registry.cpp:1157
+#, c-format
+msgid "Can't enumerate values of key '%s'"
+msgstr ""
+
+#: ../src/msw/registry.cpp:1196
+#, c-format
+msgid "Can't enumerate subkeys of key '%s'"
+msgstr ""
+
+#: ../src/msw/registry.cpp:1262
+#, c-format
+msgid ""
+"Exporting registry key: file \"%s\" already exists and won't be overwritten."
+msgstr ""
+
+#: ../src/msw/registry.cpp:1411
+#, c-format
+msgid "Can't export value of unsupported type %d."
+msgstr ""
+
+#: ../src/msw/registry.cpp:1427
+#, c-format
+msgid "Ignoring value \"%s\" of the key \"%s\"."
+msgstr ""
+
+#: ../src/msw/textctrl.cpp:596
+msgid ""
+"Impossible to create a rich edit control, using simple text control instead. "
+"Please reinstall riched32.dll"
+msgstr ""
+
+#: ../src/msw/thread.cpp:522 ../src/unix/threadpsx.cpp:850
+msgid "Cannot start thread: error writing TLS."
+msgstr ""
+
+#: ../src/msw/thread.cpp:613
+msgid "Can't set thread priority"
+msgstr ""
+
+#: ../src/msw/thread.cpp:649
+msgid "Can't create thread"
+msgstr ""
+
+#: ../src/msw/thread.cpp:668
+msgid "Couldn't terminate thread"
+msgstr ""
+
+#: ../src/msw/thread.cpp:799
+msgid "Cannot wait for thread termination"
+msgstr ""
+
+#: ../src/msw/thread.cpp:873
+#, c-format
+msgid "Cannot suspend thread %lx"
+msgstr ""
+
+#: ../src/msw/thread.cpp:903
+#, c-format
+msgid "Cannot resume thread %lx"
+msgstr ""
+
+#: ../src/msw/thread.cpp:932
+msgid "Couldn't get the current thread pointer"
+msgstr ""
+
+#: ../src/msw/thread.cpp:1333
+msgid ""
+"Thread module initialization failed: impossible to allocate index in thread "
+"local storage"
+msgstr ""
+
+#: ../src/msw/thread.cpp:1345
+msgid ""
+"Thread module initialization failed: cannot store value in thread local "
+"storage"
+msgstr ""
+
+#: ../src/msw/timer.cpp:133
+msgid "Couldn't create a timer"
+msgstr ""
+
+#: ../src/msw/utils.cpp:372
+msgid "can't find user's HOME, using current directory."
+msgstr ""
+
+#: ../src/msw/utils.cpp:662
+#, c-format
+msgid "Failed to kill process %d"
+msgstr ""
+
+#: ../src/msw/utils.cpp:986
+#, c-format
+msgid "Failed to load resource \"%s\"."
+msgstr ""
+
+#: ../src/msw/utils.cpp:993
+#, c-format
+msgid "Failed to lock resource \"%s\"."
+msgstr ""
+
+#. TRANSLATORS: MS Windows build number
+#: ../src/msw/utils.cpp:1209
+#, c-format
+msgid "build %lu"
+msgstr ""
+
+#: ../src/msw/utils.cpp:1218
+msgid ", 64-bit edition"
+msgstr ""
+
+#: ../src/msw/utilsexc.cpp:224
+msgid "Failed to create an anonymous pipe"
+msgstr ""
+
+#: ../src/msw/utilsexc.cpp:697
+msgid "Failed to redirect the child process IO"
+msgstr ""
+
+#: ../src/msw/utilsexc.cpp:870
+#, c-format
+msgid "Execution of command '%s' failed"
+msgstr ""
+
+#: ../src/msw/volume.cpp:337
+msgid "Failed to load mpr.dll."
+msgstr ""
+
+#: ../src/msw/volume.cpp:506
+#, c-format
+msgid "Cannot read typename from '%s'!"
+msgstr ""
+
+#: ../src/msw/volume.cpp:615
+#, c-format
+msgid "Cannot load icon from '%s'."
+msgstr ""
+
+#: ../src/msw/webview_edge.cpp:285
+msgid "This program was compiled without support for setting Edge proxy."
+msgstr ""
+
+#: ../src/msw/webview_ie.cpp:1010
+msgid "Failed to find web view emulation level in the registry"
+msgstr ""
+
+#: ../src/msw/webview_ie.cpp:1019
+msgid "Failed to set web view to modern emulation level"
+msgstr ""
+
+#: ../src/msw/webview_ie.cpp:1027
+msgid "Failed to reset web view to standard emulation level"
+msgstr ""
+
+#: ../src/msw/webview_ie.cpp:1049
+msgid "Can't run JavaScript script without a valid HTML document"
+msgstr ""
+
+#: ../src/msw/webview_ie.cpp:1056
+msgid "Can't get the JavaScript object"
+msgstr ""
+
+#: ../src/msw/webview_ie.cpp:1070
+msgid "failed to evaluate"
+msgstr ""
+
+#: ../src/osx/cocoa/filedlg.mm:412
+msgid "File type:"
+msgstr ""
+
+#: ../src/osx/cocoa/menu.mm:242
+msgctxt "macOS menu name"
+msgid "Window"
+msgstr ""
+
+#: ../src/osx/cocoa/menu.mm:259
+#, fuzzy
+msgctxt "macOS menu name"
+msgid "Help"
+msgstr "(راهنما)"
+
+#: ../src/osx/cocoa/menu.mm:298
+msgctxt "macOS menu item"
+msgid "Minimize"
+msgstr ""
+
+#: ../src/osx/cocoa/menu.mm:303
+msgctxt "macOS menu item"
+msgid "Zoom"
+msgstr ""
+
+#: ../src/osx/cocoa/menu.mm:309
+msgctxt "macOS menu item"
+msgid "Bring All to Front"
+msgstr ""
+
+#: ../src/osx/core/sound.cpp:143
+#, c-format
+msgid "Failed to load sound from \"%s\" (error %d)."
+msgstr ""
+
+#: ../src/osx/fontutil.cpp:80
+#, fuzzy, c-format
+msgid "Font file \"%s\" doesn't exist."
+msgstr ": فایل موجود نیست!"
+
+#: ../src/osx/fontutil.cpp:88
+#, c-format
+msgid ""
+"Font file \"%s\" cannot be used as it is not inside the font directory "
+"\"%s\"."
+msgstr ""
+
+#: ../src/osx/menu_osx.cpp:496
+#, c-format
+msgctxt "macOS menu item"
+msgid "About %s"
+msgstr ""
+
+#: ../src/osx/menu_osx.cpp:499
+msgctxt "macOS menu item"
+msgid "About..."
+msgstr ""
+
+#: ../src/osx/menu_osx.cpp:508
+msgctxt "macOS menu item"
+msgid "Preferences..."
+msgstr ""
+
+#: ../src/osx/menu_osx.cpp:512
+msgctxt "macOS menu item"
+msgid "Services"
+msgstr ""
+
+#: ../src/osx/menu_osx.cpp:519
+#, c-format
+msgctxt "macOS menu item"
+msgid "Hide %s"
+msgstr ""
+
+#: ../src/osx/menu_osx.cpp:522
+msgctxt "macOS menu item"
+msgid "Hide Application"
+msgstr ""
+
+#: ../src/osx/menu_osx.cpp:526
+msgctxt "macOS menu item"
+msgid "Hide Others"
+msgstr ""
+
+#: ../src/osx/menu_osx.cpp:528
+msgctxt "macOS menu item"
+msgid "Show All"
+msgstr ""
+
+#: ../src/osx/menu_osx.cpp:534
+#, c-format
+msgctxt "macOS menu item"
+msgid "Quit %s"
+msgstr ""
+
+#: ../src/osx/menu_osx.cpp:537
+msgctxt "macOS menu item"
+msgid "Quit Application"
+msgstr ""
+
+#: ../src/osx/webview_webkit.mm:444
+msgid "Printing is not supported by the system web control"
+msgstr ""
+
+#: ../src/osx/webview_webkit.mm:453
+msgid "Print operation could not be initialized"
+msgstr ""
+
+#. TRANSLATORS: Label of font point size
+#: ../src/propgrid/advprops.cpp:605
+msgid "Point Size"
+msgstr ""
+
+#. TRANSLATORS: Label of font face name
+#: ../src/propgrid/advprops.cpp:615
+msgid "Face Name"
+msgstr ""
+
+#. TRANSLATORS: Label of font style
+#: ../src/propgrid/advprops.cpp:623 ../src/richtext/richtextformatdlg.cpp:331
+msgid "Style"
+msgstr ""
+
+#. TRANSLATORS: Label of font weight
+#: ../src/propgrid/advprops.cpp:628
+msgid "Weight"
+msgstr ""
+
+#. TRANSLATORS: Label of underlined font
+#: ../src/propgrid/advprops.cpp:633 ../src/richtext/richtextfontpage.cpp:358
+msgid "Underlined"
+msgstr ""
+
+#. TRANSLATORS: Label of font family
+#: ../src/propgrid/advprops.cpp:637
+msgid "Family"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:801
+msgid "AppWorkspace"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:802
+msgid "ActiveBorder"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:803
+msgid "ActiveCaption"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:804
+msgid "ButtonFace"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:805
+msgid "ButtonHighlight"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:806
+msgid "ButtonShadow"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:807
+msgid "ButtonText"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:808
+msgid "CaptionText"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:809
+msgid "ControlDark"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:810
+msgid "ControlLight"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:812
+msgid "GrayText"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:813
+msgid "Highlight"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:814
+msgid "HighlightText"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:815
+msgid "InactiveBorder"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:816
+msgid "InactiveCaption"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:817
+msgid "InactiveCaptionText"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:818
+msgid "Menu"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:819
+msgid "Scrollbar"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:820
+msgid "Tooltip"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:821
+msgid "TooltipText"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:822
+msgid "Window"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:823
+msgid "WindowFrame"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:824
+msgid "WindowText"
+msgstr ""
+
+#. TRANSLATORS: Custom colour choice entry
+#: ../src/propgrid/advprops.cpp:825 ../src/propgrid/advprops.cpp:1532
+#: ../src/propgrid/advprops.cpp:1576
+msgid "Custom"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1558
+msgid "Black"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1559
+msgid "Maroon"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1560
+msgid "Navy"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1561
+msgid "Purple"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1562
+msgid "Teal"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1563
+msgid "Gray"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1564
+msgid "Green"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1565
+msgid "Olive"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1566
+msgid "Brown"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1567
+msgid "Blue"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1568
+msgid "Fuchsia"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1569
+msgid "Red"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1570
+msgid "Orange"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1571
+msgid "Silver"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1572
+msgid "Lime"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1573
+msgid "Aqua"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1574
+msgid "Yellow"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1575
+msgid "White"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1718
+msgctxt "system cursor name"
+msgid "Default"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1719
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Arrow"
+msgstr "فردا"
+
+#: ../src/propgrid/advprops.cpp:1720
+msgctxt "system cursor name"
+msgid "Right Arrow"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1721
+msgctxt "system cursor name"
+msgid "Blank"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1722
+msgctxt "system cursor name"
+msgid "Bullseye"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1723
+msgctxt "system cursor name"
+msgid "Character"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1724
+msgctxt "system cursor name"
+msgid "Cross"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1725
+msgctxt "system cursor name"
+msgid "Hand"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1726
+msgctxt "system cursor name"
+msgid "I-Beam"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1727
+msgctxt "system cursor name"
+msgid "Left Button"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1728
+msgctxt "system cursor name"
+msgid "Magnifier"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1729
+msgctxt "system cursor name"
+msgid "Middle Button"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1730
+msgctxt "system cursor name"
+msgid "No Entry"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1731
+msgctxt "system cursor name"
+msgid "Paint Brush"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1732
+msgctxt "system cursor name"
+msgid "Pencil"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1733
+msgctxt "system cursor name"
+msgid "Point Left"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1734
+msgctxt "system cursor name"
+msgid "Point Right"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1735
+msgctxt "system cursor name"
+msgid "Question Arrow"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1736
+msgctxt "system cursor name"
+msgid "Right Button"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1737
+msgctxt "system cursor name"
+msgid "Sizing NE-SW"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1738
+msgctxt "system cursor name"
+msgid "Sizing N-S"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1739
+msgctxt "system cursor name"
+msgid "Sizing NW-SE"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1740
+msgctxt "system cursor name"
+msgid "Sizing W-E"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1741
+msgctxt "system cursor name"
+msgid "Sizing"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1742
+msgctxt "system cursor name"
+msgid "Spraycan"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1743
+msgctxt "system cursor name"
+msgid "Wait"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1744
+msgctxt "system cursor name"
+msgid "Watch"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1745
+msgctxt "system cursor name"
+msgid "Wait Arrow"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:2109
+msgid "Make a selection:"
+msgstr ""
+
+#: ../src/propgrid/manager.cpp:394
+msgid "Property"
+msgstr ""
+
+#: ../src/propgrid/manager.cpp:395
+msgid "Value"
+msgstr ""
+
+#: ../src/propgrid/manager.cpp:1683
+msgid "Categorized Mode"
+msgstr ""
+
+#: ../src/propgrid/manager.cpp:1709
+msgid "Alphabetic Mode"
+msgstr ""
+
+#. TRANSLATORS: Name of Boolean false value
+#: ../src/propgrid/propgrid.cpp:230
+msgid "False"
+msgstr ""
+
+#. TRANSLATORS: Name of Boolean true value
+#: ../src/propgrid/propgrid.cpp:232
+msgid "True"
+msgstr ""
+
+#. TRANSLATORS: Text  displayed for unspecified value
+#: ../src/propgrid/propgrid.cpp:428
+msgid "Unspecified"
+msgstr ""
+
+#. TRANSLATORS: Caption of message box displaying any property error
+#: ../src/propgrid/propgrid.cpp:3145 ../src/propgrid/propgrid.cpp:3282
+msgid "Property Error"
+msgstr ""
+
+#: ../src/propgrid/propgrid.cpp:3259
+msgid "You have entered invalid value. Press ESC to cancel editing."
+msgstr ""
+
+#: ../src/propgrid/propgrid.cpp:6608
+#, c-format
+msgid "Error in resource: %s"
+msgstr ""
+
+#: ../src/propgrid/propgridiface.cpp:377
+#, c-format
+msgid ""
+"Type operation \"%s\" failed: Property labeled \"%s\" is of type \"%s\", NOT "
+"\"%s\"."
+msgstr ""
+
+#: ../src/propgrid/props.cpp:159
+#, c-format
+msgid "Unknown base %d. Base 10 will be used."
+msgstr ""
+
+#: ../src/propgrid/props.cpp:324
+#, c-format
+msgid "Value must be %s or higher."
+msgstr ""
+
+#: ../src/propgrid/props.cpp:329 ../src/propgrid/props.cpp:356
+#, c-format
+msgid "Value must be between %s and %s."
+msgstr ""
+
+#: ../src/propgrid/props.cpp:351
+#, c-format
+msgid "Value must be %s or less."
+msgstr ""
+
+#: ../src/propgrid/props.cpp:1058
+#, c-format
+msgid "Not %s"
+msgstr ""
+
+#: ../src/propgrid/props.cpp:1770
+msgid "Choose a directory:"
+msgstr ""
+
+#: ../src/propgrid/props.cpp:2055
+msgid "Choose a file"
+msgstr ""
+
+#: ../src/qt/mdi.cpp:254
+msgid "&Tile"
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:147
+#: ../src/richtext/richtextformatdlg.cpp:376
+msgid "Background"
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:159
+msgid "Background &colour:"
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:161
+#: ../src/richtext/richtextbackgroundpage.cpp:163
+msgid "Enables a background colour."
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:167
+#: ../src/richtext/richtextbackgroundpage.cpp:169
+msgid "The background colour."
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:178
+msgid "Shadow"
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:193
+msgid "Use &shadow"
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:195
+#: ../src/richtext/richtextbackgroundpage.cpp:197
+msgid "Enables a shadow."
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:211
+msgid "&Horizontal offset:"
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:218
+#: ../src/richtext/richtextbackgroundpage.cpp:220
+msgid "The horizontal offset."
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:224
+#: ../src/richtext/richtextbackgroundpage.cpp:227
+#: ../src/richtext/richtextbackgroundpage.cpp:228
+#: ../src/richtext/richtextbackgroundpage.cpp:247
+#: ../src/richtext/richtextbackgroundpage.cpp:250
+#: ../src/richtext/richtextbackgroundpage.cpp:251
+#: ../src/richtext/richtextbackgroundpage.cpp:287
+#: ../src/richtext/richtextbackgroundpage.cpp:290
+#: ../src/richtext/richtextbackgroundpage.cpp:291
+#: ../src/richtext/richtextbackgroundpage.cpp:314
+#: ../src/richtext/richtextbackgroundpage.cpp:317
+#: ../src/richtext/richtextbackgroundpage.cpp:318
+#: ../src/richtext/richtextborderspage.cpp:252
+#: ../src/richtext/richtextborderspage.cpp:255
+#: ../src/richtext/richtextborderspage.cpp:256
+#: ../src/richtext/richtextborderspage.cpp:286
+#: ../src/richtext/richtextborderspage.cpp:289
+#: ../src/richtext/richtextborderspage.cpp:290
+#: ../src/richtext/richtextborderspage.cpp:320
+#: ../src/richtext/richtextborderspage.cpp:323
+#: ../src/richtext/richtextborderspage.cpp:324
+#: ../src/richtext/richtextborderspage.cpp:354
+#: ../src/richtext/richtextborderspage.cpp:357
+#: ../src/richtext/richtextborderspage.cpp:358
+#: ../src/richtext/richtextborderspage.cpp:420
+#: ../src/richtext/richtextborderspage.cpp:423
+#: ../src/richtext/richtextborderspage.cpp:424
+#: ../src/richtext/richtextborderspage.cpp:454
+#: ../src/richtext/richtextborderspage.cpp:457
+#: ../src/richtext/richtextborderspage.cpp:458
+#: ../src/richtext/richtextborderspage.cpp:488
+#: ../src/richtext/richtextborderspage.cpp:491
+#: ../src/richtext/richtextborderspage.cpp:492
+#: ../src/richtext/richtextborderspage.cpp:522
+#: ../src/richtext/richtextborderspage.cpp:525
+#: ../src/richtext/richtextborderspage.cpp:526
+#: ../src/richtext/richtextborderspage.cpp:590
+#: ../src/richtext/richtextborderspage.cpp:593
+#: ../src/richtext/richtextborderspage.cpp:594
+#: ../src/richtext/richtextfontpage.cpp:177
+#: ../src/richtext/richtextmarginspage.cpp:199
+#: ../src/richtext/richtextmarginspage.cpp:201
+#: ../src/richtext/richtextmarginspage.cpp:202
+#: ../src/richtext/richtextmarginspage.cpp:224
+#: ../src/richtext/richtextmarginspage.cpp:226
+#: ../src/richtext/richtextmarginspage.cpp:227
+#: ../src/richtext/richtextmarginspage.cpp:247
+#: ../src/richtext/richtextmarginspage.cpp:249
+#: ../src/richtext/richtextmarginspage.cpp:250
+#: ../src/richtext/richtextmarginspage.cpp:272
+#: ../src/richtext/richtextmarginspage.cpp:274
+#: ../src/richtext/richtextmarginspage.cpp:275
+#: ../src/richtext/richtextmarginspage.cpp:313
+#: ../src/richtext/richtextmarginspage.cpp:315
+#: ../src/richtext/richtextmarginspage.cpp:316
+#: ../src/richtext/richtextmarginspage.cpp:338
+#: ../src/richtext/richtextmarginspage.cpp:340
+#: ../src/richtext/richtextmarginspage.cpp:341
+#: ../src/richtext/richtextmarginspage.cpp:361
+#: ../src/richtext/richtextmarginspage.cpp:363
+#: ../src/richtext/richtextmarginspage.cpp:364
+#: ../src/richtext/richtextmarginspage.cpp:386
+#: ../src/richtext/richtextmarginspage.cpp:388
+#: ../src/richtext/richtextmarginspage.cpp:389
+#: ../src/richtext/richtextsizepage.cpp:337
+#: ../src/richtext/richtextsizepage.cpp:340
+#: ../src/richtext/richtextsizepage.cpp:341
+#: ../src/richtext/richtextsizepage.cpp:371
+#: ../src/richtext/richtextsizepage.cpp:374
+#: ../src/richtext/richtextsizepage.cpp:375
+#: ../src/richtext/richtextsizepage.cpp:398
+#: ../src/richtext/richtextsizepage.cpp:401
+#: ../src/richtext/richtextsizepage.cpp:402
+#: ../src/richtext/richtextsizepage.cpp:425
+#: ../src/richtext/richtextsizepage.cpp:428
+#: ../src/richtext/richtextsizepage.cpp:429
+#: ../src/richtext/richtextsizepage.cpp:452
+#: ../src/richtext/richtextsizepage.cpp:455
+#: ../src/richtext/richtextsizepage.cpp:456
+#: ../src/richtext/richtextsizepage.cpp:479
+#: ../src/richtext/richtextsizepage.cpp:482
+#: ../src/richtext/richtextsizepage.cpp:483
+#: ../src/richtext/richtextsizepage.cpp:553
+#: ../src/richtext/richtextsizepage.cpp:556
+#: ../src/richtext/richtextsizepage.cpp:557
+#: ../src/richtext/richtextsizepage.cpp:588
+#: ../src/richtext/richtextsizepage.cpp:591
+#: ../src/richtext/richtextsizepage.cpp:592
+#: ../src/richtext/richtextsizepage.cpp:623
+#: ../src/richtext/richtextsizepage.cpp:626
+#: ../src/richtext/richtextsizepage.cpp:627
+#: ../src/richtext/richtextsizepage.cpp:658
+#: ../src/richtext/richtextsizepage.cpp:661
+#: ../src/richtext/richtextsizepage.cpp:662
+msgid "px"
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:225
+#: ../src/richtext/richtextbackgroundpage.cpp:248
+#: ../src/richtext/richtextbackgroundpage.cpp:288
+#: ../src/richtext/richtextbackgroundpage.cpp:315
+#: ../src/richtext/richtextborderspage.cpp:253
+#: ../src/richtext/richtextborderspage.cpp:287
+#: ../src/richtext/richtextborderspage.cpp:321
+#: ../src/richtext/richtextborderspage.cpp:355
+#: ../src/richtext/richtextborderspage.cpp:421
+#: ../src/richtext/richtextborderspage.cpp:455
+#: ../src/richtext/richtextborderspage.cpp:489
+#: ../src/richtext/richtextborderspage.cpp:523
+#: ../src/richtext/richtextborderspage.cpp:591
+#: ../src/richtext/richtextmarginspage.cpp:200
+#: ../src/richtext/richtextmarginspage.cpp:225
+#: ../src/richtext/richtextmarginspage.cpp:248
+#: ../src/richtext/richtextmarginspage.cpp:273
+#: ../src/richtext/richtextmarginspage.cpp:314
+#: ../src/richtext/richtextmarginspage.cpp:339
+#: ../src/richtext/richtextmarginspage.cpp:362
+#: ../src/richtext/richtextmarginspage.cpp:387
+#: ../src/richtext/richtextsizepage.cpp:338
+#: ../src/richtext/richtextsizepage.cpp:372
+#: ../src/richtext/richtextsizepage.cpp:399
+#: ../src/richtext/richtextsizepage.cpp:426
+#: ../src/richtext/richtextsizepage.cpp:453
+#: ../src/richtext/richtextsizepage.cpp:480
+#: ../src/richtext/richtextsizepage.cpp:554
+#: ../src/richtext/richtextsizepage.cpp:589
+#: ../src/richtext/richtextsizepage.cpp:624
+#: ../src/richtext/richtextsizepage.cpp:659
+msgid "cm"
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:226
+#: ../src/richtext/richtextbackgroundpage.cpp:249
+#: ../src/richtext/richtextbackgroundpage.cpp:289
+#: ../src/richtext/richtextbackgroundpage.cpp:316
+#: ../src/richtext/richtextborderspage.cpp:254
+#: ../src/richtext/richtextborderspage.cpp:288
+#: ../src/richtext/richtextborderspage.cpp:322
+#: ../src/richtext/richtextborderspage.cpp:356
+#: ../src/richtext/richtextborderspage.cpp:422
+#: ../src/richtext/richtextborderspage.cpp:456
+#: ../src/richtext/richtextborderspage.cpp:490
+#: ../src/richtext/richtextborderspage.cpp:524
+#: ../src/richtext/richtextborderspage.cpp:592
+#: ../src/richtext/richtextfontpage.cpp:176
+#: ../src/richtext/richtextfontpage.cpp:179
+msgid "pt"
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:229
+#: ../src/richtext/richtextbackgroundpage.cpp:231
+#: ../src/richtext/richtextbackgroundpage.cpp:252
+#: ../src/richtext/richtextbackgroundpage.cpp:254
+#: ../src/richtext/richtextbackgroundpage.cpp:292
+#: ../src/richtext/richtextbackgroundpage.cpp:294
+#: ../src/richtext/richtextbackgroundpage.cpp:319
+#: ../src/richtext/richtextbackgroundpage.cpp:321
+msgid "Units for this value."
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:234
+msgid "&Vertical offset:"
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:241
+#: ../src/richtext/richtextbackgroundpage.cpp:243
+msgid "The vertical offset."
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:257
+msgid "Shadow c&olour:"
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:259
+#: ../src/richtext/richtextbackgroundpage.cpp:261
+msgid "Enables the shadow colour."
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:265
+#: ../src/richtext/richtextbackgroundpage.cpp:267
+msgid "The shadow colour."
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:270
+msgid "Sh&adow spread:"
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:272
+#: ../src/richtext/richtextbackgroundpage.cpp:274
+msgid "Enables the shadow spread."
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:281
+#: ../src/richtext/richtextbackgroundpage.cpp:283
+msgid "The shadow spread."
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:297
+msgid "&Blur distance:"
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:299
+#: ../src/richtext/richtextbackgroundpage.cpp:301
+msgid "Enables the blur distance."
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:308
+#: ../src/richtext/richtextbackgroundpage.cpp:310
+msgid "The shadow blur distance."
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:324
+msgid "Opaci&ty:"
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:326
+#: ../src/richtext/richtextbackgroundpage.cpp:328
+msgid "Enables the shadow opacity."
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:335
+#: ../src/richtext/richtextbackgroundpage.cpp:337
+msgid "The shadow opacity."
+msgstr ""
+
+#. TRANSLATORS: Rich text page units (percentage)
+#: ../src/richtext/richtextbackgroundpage.cpp:340
+#: ../src/richtext/richtextsizepage.cpp:339
+#: ../src/richtext/richtextsizepage.cpp:373
+#: ../src/richtext/richtextsizepage.cpp:400
+#: ../src/richtext/richtextsizepage.cpp:427
+#: ../src/richtext/richtextsizepage.cpp:454
+#: ../src/richtext/richtextsizepage.cpp:481
+#: ../src/richtext/richtextsizepage.cpp:555
+#: ../src/richtext/richtextsizepage.cpp:590
+#: ../src/richtext/richtextsizepage.cpp:625
+#: ../src/richtext/richtextsizepage.cpp:660
+msgid "%"
+msgstr "%"
+
+#: ../src/richtext/richtextborderspage.cpp:229
+#: ../src/richtext/richtextborderspage.cpp:387
+msgid "Border"
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:242
+#: ../src/richtext/richtextborderspage.cpp:410
+#: ../src/richtext/richtextindentspage.cpp:194
+#: ../src/richtext/richtextliststylepage.cpp:384
+#: ../src/richtext/richtextmarginspage.cpp:185
+#: ../src/richtext/richtextmarginspage.cpp:299
+#: ../src/richtext/richtextsizepage.cpp:531
+#: ../src/richtext/richtextsizepage.cpp:538
+msgid "&Left:"
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:257
+#: ../src/richtext/richtextborderspage.cpp:259
+msgid "Units for the left border width."
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:266
+#: ../src/richtext/richtextborderspage.cpp:268
+#: ../src/richtext/richtextborderspage.cpp:300
+#: ../src/richtext/richtextborderspage.cpp:302
+#: ../src/richtext/richtextborderspage.cpp:334
+#: ../src/richtext/richtextborderspage.cpp:336
+#: ../src/richtext/richtextborderspage.cpp:368
+#: ../src/richtext/richtextborderspage.cpp:370
+#: ../src/richtext/richtextborderspage.cpp:434
+#: ../src/richtext/richtextborderspage.cpp:436
+#: ../src/richtext/richtextborderspage.cpp:468
+#: ../src/richtext/richtextborderspage.cpp:470
+#: ../src/richtext/richtextborderspage.cpp:502
+#: ../src/richtext/richtextborderspage.cpp:504
+#: ../src/richtext/richtextborderspage.cpp:536
+#: ../src/richtext/richtextborderspage.cpp:538
+msgid "The border line style."
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:276
+#: ../src/richtext/richtextborderspage.cpp:444
+#: ../src/richtext/richtextindentspage.cpp:212
+#: ../src/richtext/richtextliststylepage.cpp:402
+#: ../src/richtext/richtextmarginspage.cpp:210
+#: ../src/richtext/richtextmarginspage.cpp:324
+#: ../src/richtext/richtextsizepage.cpp:601
+#: ../src/richtext/richtextsizepage.cpp:608
+msgid "&Right:"
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:291
+#: ../src/richtext/richtextborderspage.cpp:293
+msgid "Units for the right border width."
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:310
+#: ../src/richtext/richtextborderspage.cpp:478
+#: ../src/richtext/richtextmarginspage.cpp:233
+#: ../src/richtext/richtextmarginspage.cpp:347
+#: ../src/richtext/richtextsizepage.cpp:566
+#: ../src/richtext/richtextsizepage.cpp:573
+msgid "&Top:"
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:325
+#: ../src/richtext/richtextborderspage.cpp:327
+msgid "Units for the top border width."
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:344
+#: ../src/richtext/richtextborderspage.cpp:512
+#: ../src/richtext/richtextmarginspage.cpp:258
+#: ../src/richtext/richtextmarginspage.cpp:372
+#: ../src/richtext/richtextsizepage.cpp:636
+#: ../src/richtext/richtextsizepage.cpp:643
+msgid "&Bottom:"
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:359
+#: ../src/richtext/richtextborderspage.cpp:361
+msgid "Units for the bottom border width."
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:380
+#: ../src/richtext/richtextborderspage.cpp:548
+msgid "&Synchronize values"
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:382
+#: ../src/richtext/richtextborderspage.cpp:384
+#: ../src/richtext/richtextborderspage.cpp:550
+#: ../src/richtext/richtextborderspage.cpp:552
+msgid "Check to edit all borders simultaneously."
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:397
+#: ../src/richtext/richtextborderspage.cpp:555
+msgid "Outline"
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:425
+#: ../src/richtext/richtextborderspage.cpp:427
+msgid "Units for the left outline width."
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:459
+#: ../src/richtext/richtextborderspage.cpp:461
+msgid "Units for the right outline width."
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:493
+#: ../src/richtext/richtextborderspage.cpp:495
+msgid "Units for the top outline width."
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:527
+#: ../src/richtext/richtextborderspage.cpp:529
+msgid "Units for the bottom outline width."
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:565
+#: ../src/richtext/richtextborderspage.cpp:600
+msgid "Corner"
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:574
+msgid "Corner &radius:"
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:576
+#: ../src/richtext/richtextborderspage.cpp:578
+msgid "An optional corner radius for adding rounded corners."
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:584
+#: ../src/richtext/richtextborderspage.cpp:586
+msgid "The value of the corner radius."
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:595
+#: ../src/richtext/richtextborderspage.cpp:597
+msgid "Units for the corner radius."
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:609
+#: ../src/richtext/richtextsizepage.cpp:247
+#: ../src/richtext/richtextsizepage.cpp:251
+msgid "None"
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:610
+msgid "Solid"
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:611
+msgid "Dotted"
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:612
+msgid "Dashed"
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:613
+msgid "Double"
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:614
+msgid "Groove"
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:615
+msgid "Ridge"
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:616
+msgid "Inset"
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:617
+msgid "Outset"
+msgstr ""
+
+#: ../src/richtext/richtextbuffer.cpp:3518
+msgid "Change Style"
+msgstr ""
+
+#: ../src/richtext/richtextbuffer.cpp:3701
+msgid "Change Object Style"
+msgstr ""
+
+#: ../src/richtext/richtextbuffer.cpp:3974
+#: ../src/richtext/richtextbuffer.cpp:8174
+msgid "Change Properties"
+msgstr ""
+
+#: ../src/richtext/richtextbuffer.cpp:4346
+msgid "Change List Style"
+msgstr ""
+
+#: ../src/richtext/richtextbuffer.cpp:4519
+msgid "Renumber List"
+msgstr ""
+
+#: ../src/richtext/richtextbuffer.cpp:7867
+#: ../src/richtext/richtextbuffer.cpp:7897
+#: ../src/richtext/richtextbuffer.cpp:7939
+#: ../src/richtext/richtextctrl.cpp:1279 ../src/richtext/richtextctrl.cpp:1473
+msgid "Insert Text"
+msgstr ""
+
+#: ../src/richtext/richtextbuffer.cpp:8023
+#: ../src/richtext/richtextbuffer.cpp:8979
+msgid "Insert Image"
+msgstr ""
+
+#: ../src/richtext/richtextbuffer.cpp:8070
+msgid "Insert Object"
+msgstr ""
+
+#: ../src/richtext/richtextbuffer.cpp:8112
+msgid "Insert Field"
+msgstr ""
+
+#: ../src/richtext/richtextbuffer.cpp:8410
+msgid "Too many EndStyle calls!"
+msgstr ""
+
+#: ../src/richtext/richtextbuffer.cpp:8785
+msgid "files"
+msgstr ""
+
+#: ../src/richtext/richtextbuffer.cpp:9380
+msgid "standard/circle"
+msgstr "استاندارد / دایره"
+
+#: ../src/richtext/richtextbuffer.cpp:9381
+msgid "standard/circle-outline"
+msgstr "طرح کلی / دایره"
+
+#: ../src/richtext/richtextbuffer.cpp:9382
+msgid "standard/square"
+msgstr "استاندارد / مربع"
+
+#: ../src/richtext/richtextbuffer.cpp:9383
+msgid "standard/diamond"
+msgstr "استاندارد / الماس"
+
+#: ../src/richtext/richtextbuffer.cpp:9384
+msgid "standard/triangle"
+msgstr "استاندارد / مثلث"
+
+#: ../src/richtext/richtextbuffer.cpp:9423
+msgid "Box Properties"
+msgstr ""
+
+#: ../src/richtext/richtextbuffer.cpp:10006
+msgid "Multiple Cell Properties"
+msgstr ""
+
+#: ../src/richtext/richtextbuffer.cpp:10008
+msgid "Cell Properties"
+msgstr ""
+
+#: ../src/richtext/richtextbuffer.cpp:11256
+msgid "Set Cell Style"
+msgstr ""
+
+#: ../src/richtext/richtextbuffer.cpp:11330
+msgid "Delete Row"
+msgstr ""
+
+#: ../src/richtext/richtextbuffer.cpp:11380
+msgid "Delete Column"
+msgstr ""
+
+#: ../src/richtext/richtextbuffer.cpp:11431
+msgid "Add Row"
+msgstr ""
+
+#: ../src/richtext/richtextbuffer.cpp:11494
+msgid "Add Column"
+msgstr ""
+
+#: ../src/richtext/richtextbuffer.cpp:11537
+msgid "Table Properties"
+msgstr ""
+
+#: ../src/richtext/richtextbuffer.cpp:12899
+msgid "Picture Properties"
+msgstr ""
+
+#: ../src/richtext/richtextbuffer.cpp:13169
+#: ../src/richtext/richtextbuffer.cpp:13279
+msgid "image"
+msgstr ""
+
+#: ../src/richtext/richtextbulletspage.cpp:145
+#: ../src/richtext/richtextliststylepage.cpp:209
+msgid "&Bullet style:"
+msgstr ""
+
+#: ../src/richtext/richtextbulletspage.cpp:150
+#: ../src/richtext/richtextbulletspage.cpp:152
+#: ../src/richtext/richtextliststylepage.cpp:214
+#: ../src/richtext/richtextliststylepage.cpp:216
+msgid "The available bullet styles."
+msgstr ""
+
+#: ../src/richtext/richtextbulletspage.cpp:158
+#: ../src/richtext/richtextliststylepage.cpp:221
+msgid "Peri&od"
+msgstr ""
+
+#: ../src/richtext/richtextbulletspage.cpp:160
+#: ../src/richtext/richtextbulletspage.cpp:162
+#: ../src/richtext/richtextliststylepage.cpp:223
+#: ../src/richtext/richtextliststylepage.cpp:225
+msgid "Check to add a period after the bullet."
+msgstr ""
+
+#. TRANSLATORS: Bullet point in parentheses option
+#: ../src/richtext/richtextbulletspage.cpp:167
+#: ../src/richtext/richtextliststylepage.cpp:230
+msgid "(*)"
+msgstr "(*)"
+
+#: ../src/richtext/richtextbulletspage.cpp:169
+#: ../src/richtext/richtextbulletspage.cpp:171
+#: ../src/richtext/richtextliststylepage.cpp:232
+#: ../src/richtext/richtextliststylepage.cpp:234
+msgid "Check to enclose the bullet in parentheses."
+msgstr ""
+
+#. TRANSLATORS: Right parenthesis bullet point option
+#: ../src/richtext/richtextbulletspage.cpp:176
+#: ../src/richtext/richtextliststylepage.cpp:239
+msgid "*)"
+msgstr ""
+
+#: ../src/richtext/richtextbulletspage.cpp:178
+#: ../src/richtext/richtextbulletspage.cpp:180
+#: ../src/richtext/richtextliststylepage.cpp:241
+#: ../src/richtext/richtextliststylepage.cpp:243
+msgid "Check to add a right parenthesis."
+msgstr ""
+
+#: ../src/richtext/richtextbulletspage.cpp:185
+#: ../src/richtext/richtextliststylepage.cpp:248
+msgid "Bullet &Alignment:"
+msgstr ""
+
+#: ../src/richtext/richtextbulletspage.cpp:190
+#: ../src/richtext/richtextliststylepage.cpp:253
+msgid "Centre"
+msgstr ""
+
+#: ../src/richtext/richtextbulletspage.cpp:194
+#: ../src/richtext/richtextbulletspage.cpp:196
+#: ../src/richtext/richtextbulletspage.cpp:217
+#: ../src/richtext/richtextbulletspage.cpp:219
+#: ../src/richtext/richtextliststylepage.cpp:257
+#: ../src/richtext/richtextliststylepage.cpp:259
+#: ../src/richtext/richtextliststylepage.cpp:278
+#: ../src/richtext/richtextliststylepage.cpp:280
+msgid "The bullet character."
+msgstr ""
+
+#: ../src/richtext/richtextbulletspage.cpp:212
+#: ../src/richtext/richtextliststylepage.cpp:271
+msgid "&Symbol:"
+msgstr ""
+
+#: ../src/richtext/richtextbulletspage.cpp:222
+#: ../src/richtext/richtextliststylepage.cpp:283
+msgid "Ch&oose..."
+msgstr ""
+
+#: ../src/richtext/richtextbulletspage.cpp:223
+#: ../src/richtext/richtextbulletspage.cpp:225
+#: ../src/richtext/richtextliststylepage.cpp:284
+#: ../src/richtext/richtextliststylepage.cpp:286
+msgid "Click to browse for a symbol."
+msgstr ""
+
+#: ../src/richtext/richtextbulletspage.cpp:230
+#: ../src/richtext/richtextliststylepage.cpp:291
+msgid "Symbol &font:"
+msgstr ""
+
+#: ../src/richtext/richtextbulletspage.cpp:235
+#: ../src/richtext/richtextbulletspage.cpp:237
+#: ../src/richtext/richtextliststylepage.cpp:297
+msgid "Available fonts."
+msgstr ""
+
+#: ../src/richtext/richtextbulletspage.cpp:242
+#: ../src/richtext/richtextliststylepage.cpp:302
+msgid "S&tandard bullet name:"
+msgstr ""
+
+#: ../src/richtext/richtextbulletspage.cpp:247
+#: ../src/richtext/richtextbulletspage.cpp:249
+#: ../src/richtext/richtextliststylepage.cpp:307
+#: ../src/richtext/richtextliststylepage.cpp:309
+msgid "A standard bullet name."
+msgstr ""
+
+#: ../src/richtext/richtextbulletspage.cpp:254
+msgid "&Number:"
+msgstr ""
+
+#: ../src/richtext/richtextbulletspage.cpp:258
+#: ../src/richtext/richtextbulletspage.cpp:260
+msgid "The list item number."
+msgstr ""
+
+#: ../src/richtext/richtextbulletspage.cpp:266
+#: ../src/richtext/richtextbulletspage.cpp:268
+#: ../src/richtext/richtextliststylepage.cpp:475
+#: ../src/richtext/richtextliststylepage.cpp:477
+msgid "Shows a preview of the bullet settings."
+msgstr ""
+
+#: ../src/richtext/richtextbulletspage.cpp:276
+#: ../src/richtext/richtextliststylepage.cpp:484
+msgid "(None)"
+msgstr "(هیچ)"
+
+#: ../src/richtext/richtextbulletspage.cpp:277
+#: ../src/richtext/richtextliststylepage.cpp:485
+msgid "Arabic"
+msgstr ""
+
+#: ../src/richtext/richtextbulletspage.cpp:278
+#: ../src/richtext/richtextliststylepage.cpp:486
+msgid "Upper case letters"
+msgstr ""
+
+#: ../src/richtext/richtextbulletspage.cpp:279
+#: ../src/richtext/richtextliststylepage.cpp:487
+msgid "Lower case letters"
+msgstr ""
+
+#: ../src/richtext/richtextbulletspage.cpp:280
+#: ../src/richtext/richtextliststylepage.cpp:488
+msgid "Upper case roman numerals"
+msgstr ""
+
+#: ../src/richtext/richtextbulletspage.cpp:281
+#: ../src/richtext/richtextliststylepage.cpp:489
+msgid "Lower case roman numerals"
+msgstr ""
+
+#: ../src/richtext/richtextbulletspage.cpp:282
+#: ../src/richtext/richtextliststylepage.cpp:490
+msgid "Numbered outline"
+msgstr ""
+
+#: ../src/richtext/richtextbulletspage.cpp:283
+#: ../src/richtext/richtextliststylepage.cpp:491
+msgid "Symbol"
+msgstr ""
+
+#: ../src/richtext/richtextbulletspage.cpp:284
+#: ../src/richtext/richtextliststylepage.cpp:492
+msgid "Bitmap"
+msgstr ""
+
+#: ../src/richtext/richtextbulletspage.cpp:285
+#: ../src/richtext/richtextliststylepage.cpp:493
+msgid "Standard"
+msgstr ""
+
+#: ../src/richtext/richtextbulletspage.cpp:287
+#: ../src/richtext/richtextliststylepage.cpp:495
+msgid "*"
+msgstr ""
+
+#: ../src/richtext/richtextbulletspage.cpp:288
+#: ../src/richtext/richtextliststylepage.cpp:496
+msgid "-"
+msgstr "-"
+
+#: ../src/richtext/richtextbulletspage.cpp:289
+#: ../src/richtext/richtextliststylepage.cpp:497
+msgid ">"
+msgstr ">"
+
+#: ../src/richtext/richtextbulletspage.cpp:290
+#: ../src/richtext/richtextliststylepage.cpp:498
+msgid "+"
+msgstr ""
+
+#: ../src/richtext/richtextbulletspage.cpp:291
+#: ../src/richtext/richtextliststylepage.cpp:499
+msgid "~"
+msgstr ""
+
+#: ../src/richtext/richtextctrl.cpp:859
+msgid "Drag"
+msgstr ""
+
+#: ../src/richtext/richtextctrl.cpp:1338 ../src/richtext/richtextctrl.cpp:1559
+msgid "Delete Text"
+msgstr ""
+
+#: ../src/richtext/richtextctrl.cpp:1537
+msgid "Remove Bullet"
+msgstr ""
+
+#: ../src/richtext/richtextctrl.cpp:3070
+msgid "The text couldn't be saved."
+msgstr ""
+
+#: ../src/richtext/richtextctrl.cpp:3644
+msgid "Replace"
+msgstr ""
+
+#: ../src/richtext/richtextfontpage.cpp:146
+#: ../src/richtext/richtextsymboldlg.cpp:384
+msgid "&Font:"
+msgstr ""
+
+#: ../src/richtext/richtextfontpage.cpp:150
+#: ../src/richtext/richtextfontpage.cpp:152
+msgid "Type a font name."
+msgstr ""
+
+#: ../src/richtext/richtextfontpage.cpp:158
+msgid "&Size:"
+msgstr ""
+
+#: ../src/richtext/richtextfontpage.cpp:165
+#: ../src/richtext/richtextfontpage.cpp:167
+msgid "Type a size in points."
+msgstr ""
+
+#: ../src/richtext/richtextfontpage.cpp:180
+#: ../src/richtext/richtextfontpage.cpp:182
+msgid "The font size units, points or pixels."
+msgstr ""
+
+#: ../src/richtext/richtextfontpage.cpp:189
+#: ../src/richtext/richtextfontpage.cpp:191
+msgid "Lists the available fonts."
+msgstr ""
+
+#: ../src/richtext/richtextfontpage.cpp:196
+#: ../src/richtext/richtextfontpage.cpp:198
+msgid "Lists font sizes in points."
+msgstr ""
+
+#: ../src/richtext/richtextfontpage.cpp:207
+msgid "Font st&yle:"
+msgstr ""
+
+#: ../src/richtext/richtextfontpage.cpp:212
+#: ../src/richtext/richtextfontpage.cpp:214
+msgid "Select regular or italic style."
+msgstr ""
+
+#: ../src/richtext/richtextfontpage.cpp:220
+msgid "Font &weight:"
+msgstr ""
+
+#: ../src/richtext/richtextfontpage.cpp:225
+#: ../src/richtext/richtextfontpage.cpp:227
+msgid "Select regular or bold."
+msgstr ""
+
+#: ../src/richtext/richtextfontpage.cpp:233
+msgid "&Underlining:"
+msgstr ""
+
+#: ../src/richtext/richtextfontpage.cpp:238
+#: ../src/richtext/richtextfontpage.cpp:240
+msgid "Select underlining or no underlining."
+msgstr ""
+
+#: ../src/richtext/richtextfontpage.cpp:248
+msgid "&Colour:"
+msgstr ""
+
+#: ../src/richtext/richtextfontpage.cpp:253
+#: ../src/richtext/richtextfontpage.cpp:255
+msgid "Click to change the text colour."
+msgstr ""
+
+#: ../src/richtext/richtextfontpage.cpp:261
+msgid "&Bg colour:"
+msgstr ""
+
+#: ../src/richtext/richtextfontpage.cpp:266
+#: ../src/richtext/richtextfontpage.cpp:268
+msgid "Click to change the text background colour."
+msgstr ""
+
+#: ../src/richtext/richtextfontpage.cpp:276
+#: ../src/richtext/richtextfontpage.cpp:278
+msgid "Check to show a line through the text."
+msgstr ""
+
+#: ../src/richtext/richtextfontpage.cpp:281
+msgid "Ca&pitals"
+msgstr ""
+
+#: ../src/richtext/richtextfontpage.cpp:283
+#: ../src/richtext/richtextfontpage.cpp:285
+msgid "Check to show the text in capitals."
+msgstr ""
+
+#: ../src/richtext/richtextfontpage.cpp:288
+msgid "Small C&apitals"
+msgstr ""
+
+#: ../src/richtext/richtextfontpage.cpp:290
+#: ../src/richtext/richtextfontpage.cpp:292
+msgid "Check to show the text in small capitals."
+msgstr ""
+
+#: ../src/richtext/richtextfontpage.cpp:295
+msgid "Supe&rscript"
+msgstr ""
+
+#: ../src/richtext/richtextfontpage.cpp:297
+#: ../src/richtext/richtextfontpage.cpp:299
+msgid "Check to show the text in superscript."
+msgstr ""
+
+#: ../src/richtext/richtextfontpage.cpp:302
+msgid "Subscrip&t"
+msgstr ""
+
+#: ../src/richtext/richtextfontpage.cpp:304
+#: ../src/richtext/richtextfontpage.cpp:306
+msgid "Check to show the text in subscript."
+msgstr ""
+
+#: ../src/richtext/richtextfontpage.cpp:312
+msgid "Rig&ht-to-left"
+msgstr ""
+
+#: ../src/richtext/richtextfontpage.cpp:314
+#: ../src/richtext/richtextfontpage.cpp:316
+msgid "Check to indicate right-to-left text layout."
+msgstr ""
+
+#: ../src/richtext/richtextfontpage.cpp:319
+msgid "Suppress hyphe&nation"
+msgstr ""
+
+#: ../src/richtext/richtextfontpage.cpp:321
+#: ../src/richtext/richtextfontpage.cpp:323
+msgid "Check to suppress hyphenation."
+msgstr ""
+
+#: ../src/richtext/richtextfontpage.cpp:329
+#: ../src/richtext/richtextfontpage.cpp:331
+msgid "Shows a preview of the font settings."
+msgstr ""
+
+#: ../src/richtext/richtextfontpage.cpp:348
+#: ../src/richtext/richtextfontpage.cpp:352
+#: ../src/richtext/richtextfontpage.cpp:356
+#: ../src/richtext/richtextformatdlg.cpp:873
+#: ../src/richtext/richtextindentspage.cpp:273
+#: ../src/richtext/richtextindentspage.cpp:285
+#: ../src/richtext/richtextindentspage.cpp:286
+#: ../src/richtext/richtextindentspage.cpp:310
+#: ../src/richtext/richtextindentspage.cpp:325
+#: ../src/richtext/richtextliststylepage.cpp:451
+#: ../src/richtext/richtextliststylepage.cpp:463
+#: ../src/richtext/richtextliststylepage.cpp:464
+msgid "(none)"
+msgstr "(هیچ)"
+
+#: ../src/richtext/richtextfontpage.cpp:349
+#: ../src/richtext/richtextfontpage.cpp:353
+msgid "Regular"
+msgstr ""
+
+#: ../src/richtext/richtextfontpage.cpp:357
+msgid "Not underlined"
+msgstr ""
+
+#: ../src/richtext/richtextformatdlg.cpp:341
+msgid "Indents && Spacing"
+msgstr ""
+
+#: ../src/richtext/richtextformatdlg.cpp:346
+msgid "Tabs"
+msgstr ""
+
+#: ../src/richtext/richtextformatdlg.cpp:351
+msgid "Bullets"
+msgstr ""
+
+#: ../src/richtext/richtextformatdlg.cpp:356
+msgid "List Style"
+msgstr ""
+
+#: ../src/richtext/richtextformatdlg.cpp:366
+#: ../src/richtext/richtextmarginspage.cpp:170
+msgid "Margins"
+msgstr ""
+
+#: ../src/richtext/richtextformatdlg.cpp:371
+msgid "Borders"
+msgstr ""
+
+#: ../src/richtext/richtextformatdlg.cpp:765
+msgid "Colour"
+msgstr ""
+
+#: ../src/richtext/richtextindentspage.cpp:127
+#: ../src/richtext/richtextliststylepage.cpp:322
+msgid "&Alignment"
+msgstr "&هم ترازی"
+
+#: ../src/richtext/richtextindentspage.cpp:138
+#: ../src/richtext/richtextliststylepage.cpp:331
+msgid "&Left"
+msgstr ""
+
+#: ../src/richtext/richtextindentspage.cpp:140
+#: ../src/richtext/richtextindentspage.cpp:142
+#: ../src/richtext/richtextliststylepage.cpp:333
+#: ../src/richtext/richtextliststylepage.cpp:335
+msgid "Left-align text."
+msgstr ""
+
+#: ../src/richtext/richtextindentspage.cpp:145
+#: ../src/richtext/richtextliststylepage.cpp:338
+msgid "&Right"
+msgstr ""
+
+#: ../src/richtext/richtextindentspage.cpp:147
+#: ../src/richtext/richtextindentspage.cpp:149
+#: ../src/richtext/richtextliststylepage.cpp:340
+#: ../src/richtext/richtextliststylepage.cpp:342
+msgid "Right-align text."
+msgstr ""
+
+#: ../src/richtext/richtextindentspage.cpp:152
+#: ../src/richtext/richtextliststylepage.cpp:345
+msgid "&Justified"
+msgstr ""
+
+#: ../src/richtext/richtextindentspage.cpp:154
+#: ../src/richtext/richtextindentspage.cpp:156
+#: ../src/richtext/richtextliststylepage.cpp:347
+#: ../src/richtext/richtextliststylepage.cpp:349
+msgid "Justify text left and right."
+msgstr ""
+
+#: ../src/richtext/richtextindentspage.cpp:159
+#: ../src/richtext/richtextliststylepage.cpp:352
+msgid "Cen&tred"
+msgstr ""
+
+#: ../src/richtext/richtextindentspage.cpp:161
+#: ../src/richtext/richtextindentspage.cpp:163
+#: ../src/richtext/richtextliststylepage.cpp:354
+#: ../src/richtext/richtextliststylepage.cpp:356
+msgid "Centre text."
+msgstr ""
+
+#: ../src/richtext/richtextindentspage.cpp:166
+#: ../src/richtext/richtextliststylepage.cpp:359
+msgid "&Indeterminate"
+msgstr ""
+
+#: ../src/richtext/richtextindentspage.cpp:168
+#: ../src/richtext/richtextindentspage.cpp:170
+#: ../src/richtext/richtextliststylepage.cpp:361
+#: ../src/richtext/richtextliststylepage.cpp:363
+msgid "Use the current alignment setting."
+msgstr ""
+
+#: ../src/richtext/richtextindentspage.cpp:183
+#: ../src/richtext/richtextliststylepage.cpp:375
+msgid "&Indentation (tenths of a mm)"
+msgstr ""
+
+#: ../src/richtext/richtextindentspage.cpp:198
+#: ../src/richtext/richtextindentspage.cpp:200
+#: ../src/richtext/richtextliststylepage.cpp:388
+#: ../src/richtext/richtextliststylepage.cpp:390
+msgid "The left indent."
+msgstr ""
+
+#: ../src/richtext/richtextindentspage.cpp:203
+#: ../src/richtext/richtextliststylepage.cpp:393
+msgid "Left (&first line):"
+msgstr ""
+
+#: ../src/richtext/richtextindentspage.cpp:207
+#: ../src/richtext/richtextindentspage.cpp:209
+#: ../src/richtext/richtextliststylepage.cpp:397
+#: ../src/richtext/richtextliststylepage.cpp:399
+msgid "The first line indent."
+msgstr ""
+
+#: ../src/richtext/richtextindentspage.cpp:216
+#: ../src/richtext/richtextindentspage.cpp:218
+#: ../src/richtext/richtextliststylepage.cpp:406
+#: ../src/richtext/richtextliststylepage.cpp:408
+msgid "The right indent."
+msgstr ""
+
+#: ../src/richtext/richtextindentspage.cpp:221
+msgid "&Outline level:"
+msgstr ""
+
+#: ../src/richtext/richtextindentspage.cpp:226
+#: ../src/richtext/richtextindentspage.cpp:228
+msgid "The outline level."
+msgstr ""
+
+#: ../src/richtext/richtextindentspage.cpp:241
+#: ../src/richtext/richtextliststylepage.cpp:420
+msgid "&Spacing (tenths of a mm)"
+msgstr ""
+
+#: ../src/richtext/richtextindentspage.cpp:252
+msgid "&Before a paragraph:"
+msgstr "& قبل از پاراگراف:"
+
+#: ../src/richtext/richtextindentspage.cpp:256
+#: ../src/richtext/richtextindentspage.cpp:258
+#: ../src/richtext/richtextliststylepage.cpp:433
+#: ../src/richtext/richtextliststylepage.cpp:435
+msgid "The spacing before the paragraph."
+msgstr ""
+
+#: ../src/richtext/richtextindentspage.cpp:261
+msgid "&After a paragraph:"
+msgstr "&بعد از یک پاراگراف:"
+
+#: ../src/richtext/richtextindentspage.cpp:266
+#: ../src/richtext/richtextliststylepage.cpp:442
+#: ../src/richtext/richtextliststylepage.cpp:444
+msgid "The spacing after the paragraph."
+msgstr ""
+
+#: ../src/richtext/richtextindentspage.cpp:269
+msgid "L&ine spacing:"
+msgstr ""
+
+#: ../src/richtext/richtextindentspage.cpp:274
+#: ../src/richtext/richtextliststylepage.cpp:452
+msgid "Single"
+msgstr ""
+
+#: ../src/richtext/richtextindentspage.cpp:275
+#: ../src/richtext/richtextliststylepage.cpp:453
+msgid "1.1"
+msgstr "1.1"
+
+#: ../src/richtext/richtextindentspage.cpp:276
+#: ../src/richtext/richtextliststylepage.cpp:454
+msgid "1.2"
+msgstr "1.2"
+
+#: ../src/richtext/richtextindentspage.cpp:277
+#: ../src/richtext/richtextliststylepage.cpp:455
+msgid "1.3"
+msgstr "1.3"
+
+#: ../src/richtext/richtextindentspage.cpp:278
+#: ../src/richtext/richtextliststylepage.cpp:456
+msgid "1.4"
+msgstr "1.4"
+
+#: ../src/richtext/richtextindentspage.cpp:279
+#: ../src/richtext/richtextliststylepage.cpp:457
+msgid "1.5"
+msgstr "1.5"
+
+#: ../src/richtext/richtextindentspage.cpp:280
+#: ../src/richtext/richtextliststylepage.cpp:458
+msgid "1.6"
+msgstr "1.6"
+
+#: ../src/richtext/richtextindentspage.cpp:281
+#: ../src/richtext/richtextliststylepage.cpp:459
+msgid "1.7"
+msgstr "1.7"
+
+#: ../src/richtext/richtextindentspage.cpp:282
+#: ../src/richtext/richtextliststylepage.cpp:460
+msgid "1.8"
+msgstr "1.8"
+
+#: ../src/richtext/richtextindentspage.cpp:283
+#: ../src/richtext/richtextliststylepage.cpp:461
+msgid "1.9"
+msgstr "1.9"
+
+#: ../src/richtext/richtextindentspage.cpp:284
+#: ../src/richtext/richtextliststylepage.cpp:462
+msgid "2"
+msgstr "2"
+
+#: ../src/richtext/richtextindentspage.cpp:287
+#: ../src/richtext/richtextindentspage.cpp:289
+#: ../src/richtext/richtextliststylepage.cpp:465
+#: ../src/richtext/richtextliststylepage.cpp:467
+msgid "The line spacing."
+msgstr ""
+
+#: ../src/richtext/richtextindentspage.cpp:292
+msgid "&Page Break"
+msgstr ""
+
+#: ../src/richtext/richtextindentspage.cpp:294
+#: ../src/richtext/richtextindentspage.cpp:296
+msgid "Inserts a page break before the paragraph."
+msgstr ""
+
+#: ../src/richtext/richtextindentspage.cpp:302
+#: ../src/richtext/richtextindentspage.cpp:304
+msgid "Shows a preview of the paragraph settings."
+msgstr ""
+
+#: ../src/richtext/richtextliststylepage.cpp:182
+msgid "&List level:"
+msgstr ""
+
+#: ../src/richtext/richtextliststylepage.cpp:186
+#: ../src/richtext/richtextliststylepage.cpp:188
+msgid "Selects the list level to edit."
+msgstr ""
+
+#: ../src/richtext/richtextliststylepage.cpp:193
+msgid "&Font for Level..."
+msgstr ""
+
+#: ../src/richtext/richtextliststylepage.cpp:194
+#: ../src/richtext/richtextliststylepage.cpp:196
+msgid "Click to choose the font for this level."
+msgstr ""
+
+#: ../src/richtext/richtextliststylepage.cpp:312
+msgid "Bullet style"
+msgstr ""
+
+#: ../src/richtext/richtextliststylepage.cpp:429
+msgid "Before a paragraph:"
+msgstr ""
+
+#: ../src/richtext/richtextliststylepage.cpp:438
+msgid "After a paragraph:"
+msgstr ""
+
+#: ../src/richtext/richtextliststylepage.cpp:447
+msgid "Line spacing:"
+msgstr ""
+
+#: ../src/richtext/richtextliststylepage.cpp:470
+msgid "Spacing"
+msgstr ""
+
+#: ../src/richtext/richtextmarginspage.cpp:193
+#: ../src/richtext/richtextmarginspage.cpp:195
+msgid "The left margin size."
+msgstr ""
+
+#: ../src/richtext/richtextmarginspage.cpp:203
+#: ../src/richtext/richtextmarginspage.cpp:205
+msgid "Units for the left margin."
+msgstr ""
+
+#: ../src/richtext/richtextmarginspage.cpp:218
+#: ../src/richtext/richtextmarginspage.cpp:220
+msgid "The right margin size."
+msgstr ""
+
+#: ../src/richtext/richtextmarginspage.cpp:228
+#: ../src/richtext/richtextmarginspage.cpp:230
+msgid "Units for the right margin."
+msgstr ""
+
+#: ../src/richtext/richtextmarginspage.cpp:241
+#: ../src/richtext/richtextmarginspage.cpp:243
+msgid "The top margin size."
+msgstr ""
+
+#: ../src/richtext/richtextmarginspage.cpp:251
+#: ../src/richtext/richtextmarginspage.cpp:253
+msgid "Units for the top margin."
+msgstr ""
+
+#: ../src/richtext/richtextmarginspage.cpp:266
+#: ../src/richtext/richtextmarginspage.cpp:268
+msgid "The bottom margin size."
+msgstr ""
+
+#: ../src/richtext/richtextmarginspage.cpp:276
+#: ../src/richtext/richtextmarginspage.cpp:278
+msgid "Units for the bottom margin."
+msgstr ""
+
+#: ../src/richtext/richtextmarginspage.cpp:284
+msgid "Padding"
+msgstr ""
+
+#: ../src/richtext/richtextmarginspage.cpp:307
+#: ../src/richtext/richtextmarginspage.cpp:309
+msgid "The left padding size."
+msgstr ""
+
+#: ../src/richtext/richtextmarginspage.cpp:317
+#: ../src/richtext/richtextmarginspage.cpp:319
+msgid "Units for the left padding."
+msgstr ""
+
+#: ../src/richtext/richtextmarginspage.cpp:332
+#: ../src/richtext/richtextmarginspage.cpp:334
+msgid "The right padding size."
+msgstr ""
+
+#: ../src/richtext/richtextmarginspage.cpp:342
+#: ../src/richtext/richtextmarginspage.cpp:344
+msgid "Units for the right padding."
+msgstr ""
+
+#: ../src/richtext/richtextmarginspage.cpp:355
+#: ../src/richtext/richtextmarginspage.cpp:357
+msgid "The top padding size."
+msgstr ""
+
+#: ../src/richtext/richtextmarginspage.cpp:365
+#: ../src/richtext/richtextmarginspage.cpp:367
+msgid "Units for the top padding."
+msgstr ""
+
+#: ../src/richtext/richtextmarginspage.cpp:380
+#: ../src/richtext/richtextmarginspage.cpp:382
+msgid "The bottom padding size."
+msgstr ""
+
+#: ../src/richtext/richtextmarginspage.cpp:390
+#: ../src/richtext/richtextmarginspage.cpp:392
+msgid "Units for the bottom padding."
+msgstr ""
+
+#: ../src/richtext/richtextprint.cpp:592
+msgid " Preview"
+msgstr " پیش نمایش"
+
+#: ../src/richtext/richtextsizepage.cpp:228
+msgid "Floating"
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:243
+msgid "&Floating mode:"
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:252
+#: ../src/richtext/richtextsizepage.cpp:254
+msgid "How the object will float relative to the text."
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:265
+msgid "Alignment"
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:277
+msgid "&Vertical alignment:"
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:279
+#: ../src/richtext/richtextsizepage.cpp:281
+msgid "Enable vertical alignment."
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:286
+msgid "Centred"
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:290
+#: ../src/richtext/richtextsizepage.cpp:292
+msgid "Vertical alignment."
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:316
+#: ../src/richtext/richtextsizepage.cpp:323
+msgid "&Width:"
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:318
+#: ../src/richtext/richtextsizepage.cpp:320
+msgid "Enable the width value."
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:331
+#: ../src/richtext/richtextsizepage.cpp:333
+msgid "The object width."
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:342
+#: ../src/richtext/richtextsizepage.cpp:344
+msgid "Units for the object width."
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:350
+#: ../src/richtext/richtextsizepage.cpp:357
+msgid "&Height:"
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:352
+#: ../src/richtext/richtextsizepage.cpp:354
+#: ../src/richtext/richtextsizepage.cpp:464
+#: ../src/richtext/richtextsizepage.cpp:466
+msgid "Enable the height value."
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:365
+#: ../src/richtext/richtextsizepage.cpp:367
+msgid "The object height."
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:376
+#: ../src/richtext/richtextsizepage.cpp:378
+msgid "Units for the object height."
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:381
+msgid "Min width:"
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:383
+#: ../src/richtext/richtextsizepage.cpp:385
+msgid "Enable the minimum width value."
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:392
+#: ../src/richtext/richtextsizepage.cpp:394
+msgid "The object minimum width."
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:403
+#: ../src/richtext/richtextsizepage.cpp:405
+msgid "Units for the minimum object width."
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:408
+msgid "Min height:"
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:410
+#: ../src/richtext/richtextsizepage.cpp:412
+msgid "Enable the minimum height value."
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:419
+#: ../src/richtext/richtextsizepage.cpp:421
+msgid "The object minimum height."
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:430
+#: ../src/richtext/richtextsizepage.cpp:432
+msgid "Units for the minimum object height."
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:435
+msgid "Max width:"
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:437
+#: ../src/richtext/richtextsizepage.cpp:439
+msgid "Enable the maximum width value."
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:446
+#: ../src/richtext/richtextsizepage.cpp:448
+msgid "The object maximum width."
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:457
+#: ../src/richtext/richtextsizepage.cpp:459
+msgid "Units for the maximum object width."
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:462
+msgid "Max height:"
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:473
+#: ../src/richtext/richtextsizepage.cpp:475
+msgid "The object maximum height."
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:484
+#: ../src/richtext/richtextsizepage.cpp:486
+msgid "Units for the maximum object height."
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:495
+msgid "Position"
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:513
+msgid "&Position mode:"
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:517
+#: ../src/richtext/richtextsizepage.cpp:522
+msgid "Static"
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:518
+msgid "Relative"
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:519
+msgid "Absolute"
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:520
+msgid "Fixed"
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:533
+#: ../src/richtext/richtextsizepage.cpp:535
+#: ../src/richtext/richtextsizepage.cpp:547
+#: ../src/richtext/richtextsizepage.cpp:549
+msgid "The left position."
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:558
+#: ../src/richtext/richtextsizepage.cpp:560
+msgid "Units for the left position."
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:568
+#: ../src/richtext/richtextsizepage.cpp:570
+#: ../src/richtext/richtextsizepage.cpp:582
+#: ../src/richtext/richtextsizepage.cpp:584
+msgid "The top position."
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:593
+#: ../src/richtext/richtextsizepage.cpp:595
+msgid "Units for the top position."
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:603
+#: ../src/richtext/richtextsizepage.cpp:605
+#: ../src/richtext/richtextsizepage.cpp:617
+#: ../src/richtext/richtextsizepage.cpp:619
+msgid "The right position."
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:628
+#: ../src/richtext/richtextsizepage.cpp:630
+msgid "Units for the right position."
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:638
+#: ../src/richtext/richtextsizepage.cpp:640
+#: ../src/richtext/richtextsizepage.cpp:652
+#: ../src/richtext/richtextsizepage.cpp:654
+msgid "The bottom position."
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:663
+#: ../src/richtext/richtextsizepage.cpp:665
+msgid "Units for the bottom position."
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:671
+msgid "&Move the object to:"
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:674
+msgid "&Previous Paragraph"
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:675
+#: ../src/richtext/richtextsizepage.cpp:677
+msgid "Moves the object to the previous paragraph."
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:680
+msgid "&Next Paragraph"
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:681
+#: ../src/richtext/richtextsizepage.cpp:683
+msgid "Moves the object to the next paragraph."
+msgstr ""
+
+#: ../src/richtext/richtextstyledlg.cpp:193
+msgid "&Styles:"
+msgstr ""
+
+#: ../src/richtext/richtextstyledlg.cpp:197
+#: ../src/richtext/richtextstyledlg.cpp:199
+msgid "The available styles."
+msgstr ""
+
+#: ../src/richtext/richtextstyledlg.cpp:205
+#: ../src/richtext/richtextstyledlg.cpp:217
+msgid " "
+msgstr ""
+
+#: ../src/richtext/richtextstyledlg.cpp:209
+#: ../src/richtext/richtextstyledlg.cpp:211
+msgid "The style preview."
+msgstr ""
+
+#: ../src/richtext/richtextstyledlg.cpp:220
+msgid "New &Character Style..."
+msgstr ""
+
+#: ../src/richtext/richtextstyledlg.cpp:221
+#: ../src/richtext/richtextstyledlg.cpp:223
+msgid "Click to create a new character style."
+msgstr ""
+
+#: ../src/richtext/richtextstyledlg.cpp:226
+msgid "New &Paragraph Style..."
+msgstr ""
+
+#: ../src/richtext/richtextstyledlg.cpp:227
+#: ../src/richtext/richtextstyledlg.cpp:229
+msgid "Click to create a new paragraph style."
+msgstr ""
+
+#: ../src/richtext/richtextstyledlg.cpp:232
+msgid "New &List Style..."
+msgstr ""
+
+#: ../src/richtext/richtextstyledlg.cpp:233
+#: ../src/richtext/richtextstyledlg.cpp:235
+msgid "Click to create a new list style."
+msgstr ""
+
+#: ../src/richtext/richtextstyledlg.cpp:238
+msgid "New &Box Style..."
+msgstr ""
+
+#: ../src/richtext/richtextstyledlg.cpp:239
+#: ../src/richtext/richtextstyledlg.cpp:241
+msgid "Click to create a new box style."
+msgstr ""
+
+#: ../src/richtext/richtextstyledlg.cpp:246
+msgid "&Apply Style"
+msgstr "اعمال سبک"
+
+#: ../src/richtext/richtextstyledlg.cpp:247
+#: ../src/richtext/richtextstyledlg.cpp:249
+msgid "Click to apply the selected style."
+msgstr ""
+
+#: ../src/richtext/richtextstyledlg.cpp:252
+msgid "&Rename Style..."
+msgstr ""
+
+#: ../src/richtext/richtextstyledlg.cpp:253
+#: ../src/richtext/richtextstyledlg.cpp:255
+msgid "Click to rename the selected style."
+msgstr ""
+
+#: ../src/richtext/richtextstyledlg.cpp:258
+msgid "&Edit Style..."
+msgstr ""
+
+#: ../src/richtext/richtextstyledlg.cpp:259
+#: ../src/richtext/richtextstyledlg.cpp:261
+msgid "Click to edit the selected style."
+msgstr ""
+
+#: ../src/richtext/richtextstyledlg.cpp:264
+msgid "&Delete Style..."
+msgstr ""
+
+#: ../src/richtext/richtextstyledlg.cpp:265
+#: ../src/richtext/richtextstyledlg.cpp:267
+msgid "Click to delete the selected style."
+msgstr ""
+
+#: ../src/richtext/richtextstyledlg.cpp:274
+#: ../src/richtext/richtextstyledlg.cpp:276
+msgid "Click to close this window."
+msgstr ""
+
+#: ../src/richtext/richtextstyledlg.cpp:282
+msgid "&Restart numbering"
+msgstr ""
+
+#: ../src/richtext/richtextstyledlg.cpp:284
+#: ../src/richtext/richtextstyledlg.cpp:286
+msgid "Check to restart numbering."
+msgstr ""
+
+#: ../src/richtext/richtextstyledlg.cpp:601
+msgid "Enter a character style name"
+msgstr ""
+
+#: ../src/richtext/richtextstyledlg.cpp:601
+#: ../src/richtext/richtextstyledlg.cpp:606
+#: ../src/richtext/richtextstyledlg.cpp:649
+#: ../src/richtext/richtextstyledlg.cpp:654
+#: ../src/richtext/richtextstyledlg.cpp:815
+#: ../src/richtext/richtextstyledlg.cpp:820
+#: ../src/richtext/richtextstyledlg.cpp:888
+#: ../src/richtext/richtextstyledlg.cpp:896
+#: ../src/richtext/richtextstyledlg.cpp:929
+#: ../src/richtext/richtextstyledlg.cpp:934
+msgid "New Style"
+msgstr ""
+
+#: ../src/richtext/richtextstyledlg.cpp:606
+#: ../src/richtext/richtextstyledlg.cpp:654
+#: ../src/richtext/richtextstyledlg.cpp:820
+#: ../src/richtext/richtextstyledlg.cpp:896
+#: ../src/richtext/richtextstyledlg.cpp:934
+msgid "Sorry, that name is taken. Please choose another."
+msgstr ""
+
+#: ../src/richtext/richtextstyledlg.cpp:649
+msgid "Enter a paragraph style name"
+msgstr ""
+
+#: ../src/richtext/richtextstyledlg.cpp:777
+#, c-format
+msgid "Delete style %s?"
+msgstr ""
+
+#: ../src/richtext/richtextstyledlg.cpp:777
+msgid "Delete Style"
+msgstr ""
+
+#: ../src/richtext/richtextstyledlg.cpp:815
+msgid "Enter a list style name"
+msgstr ""
+
+#: ../src/richtext/richtextstyledlg.cpp:888
+msgid "Enter a new style name"
+msgstr ""
+
+#: ../src/richtext/richtextstyledlg.cpp:929
+msgid "Enter a box style name"
+msgstr ""
+
+#: ../src/richtext/richtextstylepage.cpp:109
+#: ../src/richtext/richtextstylepage.cpp:111
+msgid "The style name."
+msgstr ""
+
+#: ../src/richtext/richtextstylepage.cpp:114
+msgid "&Based on:"
+msgstr "&بر اساس:"
+
+#: ../src/richtext/richtextstylepage.cpp:119
+#: ../src/richtext/richtextstylepage.cpp:121
+msgid "The style on which this style is based."
+msgstr ""
+
+#: ../src/richtext/richtextstylepage.cpp:124
+msgid "&Next style:"
+msgstr ""
+
+#: ../src/richtext/richtextstylepage.cpp:129
+#: ../src/richtext/richtextstylepage.cpp:131
+msgid "The default style for the next paragraph."
+msgstr ""
+
+#: ../src/richtext/richtextstyles.cpp:1057
+msgid "All styles"
+msgstr ""
+
+#: ../src/richtext/richtextstyles.cpp:1058
+msgid "Paragraph styles"
+msgstr ""
+
+#: ../src/richtext/richtextstyles.cpp:1059
+msgid "Character styles"
+msgstr ""
+
+#: ../src/richtext/richtextstyles.cpp:1060
+msgid "List styles"
+msgstr ""
+
+#: ../src/richtext/richtextstyles.cpp:1061
+msgid "Box styles"
+msgstr ""
+
+#: ../src/richtext/richtextsymboldlg.cpp:389
+#: ../src/richtext/richtextsymboldlg.cpp:391
+msgid "The font from which to take the symbol."
+msgstr ""
+
+#: ../src/richtext/richtextsymboldlg.cpp:396
+msgid "&Subset:"
+msgstr ""
+
+#: ../src/richtext/richtextsymboldlg.cpp:401
+#: ../src/richtext/richtextsymboldlg.cpp:403
+msgid "Shows a Unicode subset."
+msgstr ""
+
+#: ../src/richtext/richtextsymboldlg.cpp:412
+msgid "xxxx"
+msgstr ""
+
+#: ../src/richtext/richtextsymboldlg.cpp:417
+msgid "&Character code:"
+msgstr ""
+
+#: ../src/richtext/richtextsymboldlg.cpp:421
+#: ../src/richtext/richtextsymboldlg.cpp:423
+msgid "The character code."
+msgstr ""
+
+#: ../src/richtext/richtextsymboldlg.cpp:428
+msgid "&From:"
+msgstr ""
+
+#: ../src/richtext/richtextsymboldlg.cpp:433
+#: ../src/richtext/richtextsymboldlg.cpp:434
+#: ../src/richtext/richtextsymboldlg.cpp:435
+msgid "Unicode"
+msgstr ""
+
+#: ../src/richtext/richtextsymboldlg.cpp:436
+#: ../src/richtext/richtextsymboldlg.cpp:438
+msgid "The range to show."
+msgstr ""
+
+#: ../src/richtext/richtextsymboldlg.cpp:444
+msgid "Insert"
+msgstr ""
+
+#: ../src/richtext/richtextsymboldlg.cpp:478
+msgid "(Normal text)"
+msgstr "(متن عادی)"
+
+#: ../src/richtext/richtexttabspage.cpp:109
+msgid "&Position (tenths of a mm):"
+msgstr ""
+
+#: ../src/richtext/richtexttabspage.cpp:113
+#: ../src/richtext/richtexttabspage.cpp:115
+msgid "The tab position."
+msgstr ""
+
+#: ../src/richtext/richtexttabspage.cpp:119
+msgid "The tab positions."
+msgstr ""
+
+#: ../src/richtext/richtexttabspage.cpp:132
+#: ../src/richtext/richtexttabspage.cpp:134
+msgid "Click to create a new tab position."
+msgstr ""
+
+#: ../src/richtext/richtexttabspage.cpp:138
+#: ../src/richtext/richtexttabspage.cpp:140
+msgid "Click to delete the selected tab position."
+msgstr ""
+
+#: ../src/richtext/richtexttabspage.cpp:143
+msgid "Delete A&ll"
+msgstr ""
+
+#: ../src/richtext/richtexttabspage.cpp:144
+#: ../src/richtext/richtexttabspage.cpp:146
+msgid "Click to delete all tab positions."
+msgstr ""
+
+#: ../src/univ/theme.cpp:110
+msgid "Failed to initialize GUI: no built-in themes found."
+msgstr ""
+
+#: ../src/univ/themes/gtk.cpp:521
+msgid "GTK+ theme"
+msgstr ""
+
+#: ../src/univ/themes/metal.cpp:164
+msgid "Metal theme"
+msgstr ""
+
+#: ../src/univ/themes/mono.cpp:512
+msgid "Simple monochrome theme"
+msgstr ""
+
+#: ../src/univ/themes/win32.cpp:1098
+msgid "Win32 theme"
+msgstr ""
+
+#: ../src/univ/themes/win32.cpp:3743
+msgid "&Restore"
+msgstr ""
+
+#: ../src/univ/themes/win32.cpp:3744
+msgid "&Move"
+msgstr ""
+
+#: ../src/univ/themes/win32.cpp:3746
+msgid "&Size"
+msgstr ""
+
+#: ../src/univ/themes/win32.cpp:3748
+msgid "Mi&nimize"
+msgstr ""
+
+#: ../src/univ/themes/win32.cpp:3750
+msgid "Ma&ximize"
+msgstr ""
+
+#: ../src/univ/themes/win32.cpp:3752
+msgid "Alt+"
+msgstr ""
+
+#: ../src/unix/appunix.cpp:178
+msgid "Failed to install signal handler"
+msgstr ""
+
+#: ../src/unix/dialup.cpp:351
+msgid "Already dialling ISP."
+msgstr ""
+
+#: ../src/unix/dlunix.cpp:93
+msgid "Failed to unload shared library"
+msgstr ""
+
+#: ../src/unix/dlunix.cpp:121
+msgid "Unknown dynamic library error"
+msgstr ""
+
+#: ../src/unix/epolldispatcher.cpp:84
+msgid "Failed to create epoll descriptor"
+msgstr ""
+
+#: ../src/unix/epolldispatcher.cpp:103
+msgid "Error closing epoll descriptor"
+msgstr ""
+
+#: ../src/unix/epolldispatcher.cpp:116
+#, c-format
+msgid "Failed to add descriptor %d to epoll descriptor %d"
+msgstr ""
+
+#: ../src/unix/epolldispatcher.cpp:136
+#, c-format
+msgid "Failed to modify descriptor %d in epoll descriptor %d"
+msgstr ""
+
+#: ../src/unix/epolldispatcher.cpp:155
+#, c-format
+msgid "Failed to unregister descriptor %d from epoll descriptor %d"
+msgstr ""
+
+#: ../src/unix/epolldispatcher.cpp:213
+#, c-format
+msgid "Waiting for IO on epoll descriptor %d failed"
+msgstr ""
+
+#: ../src/unix/fswatcher_inotify.cpp:71
+msgid "Unable to create inotify instance"
+msgstr ""
+
+#: ../src/unix/fswatcher_inotify.cpp:94
+msgid "Unable to close inotify instance"
+msgstr ""
+
+#: ../src/unix/fswatcher_inotify.cpp:106
+msgid "Unable to add inotify watch"
+msgstr ""
+
+#: ../src/unix/fswatcher_inotify.cpp:138
+#, c-format
+msgid "Unable to remove inotify watch %i"
+msgstr ""
+
+#: ../src/unix/fswatcher_inotify.cpp:271
+#, c-format
+msgid "Unexpected event for \"%s\": no matching watch descriptor."
+msgstr ""
+
+#: ../src/unix/fswatcher_inotify.cpp:320
+#, c-format
+msgid "Invalid inotify event for \"%s\""
+msgstr ""
+
+#: ../src/unix/fswatcher_inotify.cpp:553
+msgid "Unable to read from inotify descriptor"
+msgstr ""
+
+#: ../src/unix/fswatcher_inotify.cpp:558
+msgid "EOF while reading from inotify descriptor"
+msgstr ""
+
+#: ../src/unix/fswatcher_kqueue.cpp:114
+msgid "Unable to create kqueue instance"
+msgstr ""
+
+#: ../src/unix/fswatcher_kqueue.cpp:131
+msgid "Error closing kqueue instance"
+msgstr ""
+
+#: ../src/unix/fswatcher_kqueue.cpp:153
+msgid "Unable to add kqueue watch"
+msgstr ""
+
+#: ../src/unix/fswatcher_kqueue.cpp:170
+msgid "Unable to remove kqueue watch"
+msgstr ""
+
+#: ../src/unix/fswatcher_kqueue.cpp:202
+msgid "Unable to get events from kqueue"
+msgstr ""
+
+#: ../src/unix/mediactrl.cpp:966
+#, c-format
+msgid "Media playback error: %s"
+msgstr ""
+
+#: ../src/unix/mediactrl.cpp:1228
+#, c-format
+msgid "Failed to prepare playing \"%s\"."
+msgstr ""
+
+#: ../src/unix/snglinst.cpp:164
+#, c-format
+msgid "Failed to write to lock file '%s'"
+msgstr ""
+
+#: ../src/unix/snglinst.cpp:177
+#, c-format
+msgid "Failed to set permissions on lock file '%s'"
+msgstr ""
+
+#: ../src/unix/snglinst.cpp:194
+#, c-format
+msgid "Failed to lock the lock file '%s'"
+msgstr ""
+
+#: ../src/unix/snglinst.cpp:237
+#, c-format
+msgid "Failed to inspect the lock file '%s'"
+msgstr ""
+
+#: ../src/unix/snglinst.cpp:242
+#, c-format
+msgid "Lock file '%s' has incorrect owner."
+msgstr ""
+
+#: ../src/unix/snglinst.cpp:247
+#, c-format
+msgid "Lock file '%s' has incorrect permissions."
+msgstr ""
+
+#: ../src/unix/snglinst.cpp:265
+msgid "Failed to access lock file."
+msgstr ""
+
+#: ../src/unix/snglinst.cpp:274
+msgid "Failed to read PID from lock file."
+msgstr ""
+
+#: ../src/unix/snglinst.cpp:284
+#, c-format
+msgid "Failed to remove stale lock file '%s'."
+msgstr ""
+
+#: ../src/unix/snglinst.cpp:297
+#, c-format
+msgid "Deleted stale lock file '%s'."
+msgstr ""
+
+#: ../src/unix/snglinst.cpp:308
+#, c-format
+msgid "Invalid lock file '%s'."
+msgstr ""
+
+#: ../src/unix/snglinst.cpp:324
+#, c-format
+msgid "Failed to remove lock file '%s'"
+msgstr ""
+
+#: ../src/unix/snglinst.cpp:330
+#, c-format
+msgid "Failed to unlock lock file '%s'"
+msgstr ""
+
+#: ../src/unix/snglinst.cpp:336
+#, c-format
+msgid "Failed to close lock file '%s'"
+msgstr ""
+
+#: ../src/unix/sound.cpp:77
+msgid "No sound"
+msgstr ""
+
+#: ../src/unix/sound.cpp:364
+msgid "Unable to play sound asynchronously."
+msgstr ""
+
+#: ../src/unix/sound.cpp:458
+#, c-format
+msgid "Couldn't load sound data from '%s'."
+msgstr ""
+
+#: ../src/unix/sound.cpp:465
+#, c-format
+msgid "Sound file '%s' is in unsupported format."
+msgstr ""
+
+#: ../src/unix/sound.cpp:480
+msgid "Sound data are in unsupported format."
+msgstr ""
+
+#: ../src/unix/sound_sdl.cpp:226
+#, c-format
+msgid "Couldn't open audio: %s"
+msgstr ""
+
+#: ../src/unix/threadpsx.cpp:1033
+msgid "Cannot retrieve thread scheduling policy."
+msgstr ""
+
+#: ../src/unix/threadpsx.cpp:1058
+#, c-format
+msgid "Cannot get priority range for scheduling policy %d."
+msgstr ""
+
+#: ../src/unix/threadpsx.cpp:1066
+msgid "Thread priority setting is ignored."
+msgstr ""
+
+#: ../src/unix/threadpsx.cpp:1221
+msgid ""
+"Failed to join a thread, potential memory leak detected - please restart the "
+"program"
+msgstr ""
+
+#: ../src/unix/threadpsx.cpp:1352
+#, c-format
+msgid "Failed to set thread concurrency level to %lu"
+msgstr ""
+
+#: ../src/unix/threadpsx.cpp:1481
+#, c-format
+msgid "Failed to set thread priority %d."
+msgstr ""
+
+#: ../src/unix/threadpsx.cpp:1666
+msgid "Failed to terminate a thread."
+msgstr ""
+
+#: ../src/unix/threadpsx.cpp:1893
+msgid "Thread module initialization failed: failed to create thread key"
+msgstr ""
+
+#: ../src/unix/utilsunx.cpp:340
+msgid "Impossible to get child process input"
+msgstr ""
+
+#: ../src/unix/utilsunx.cpp:390
+msgid "Can't write to child process's stdin"
+msgstr ""
+
+#: ../src/unix/utilsunx.cpp:644
+#, c-format
+msgid "Failed to execute '%s'\n"
+msgstr ""
+
+#: ../src/unix/utilsunx.cpp:678
+msgid "Fork failed"
+msgstr ""
+
+#: ../src/unix/utilsunx.cpp:701
+msgid "Failed to set process priority"
+msgstr ""
+
+#: ../src/unix/utilsunx.cpp:712
+msgid "Failed to redirect child process input/output"
+msgstr ""
+
+#: ../src/unix/utilsunx.cpp:816
+msgid "Failed to set up non-blocking pipe, the program might hang."
+msgstr ""
+
+#: ../src/unix/utilsunx.cpp:1023
+msgid "Cannot get the hostname"
+msgstr ""
+
+#: ../src/unix/utilsunx.cpp:1059
+msgid "Cannot get the official hostname"
+msgstr ""
+
+#: ../src/unix/wakeuppipe.cpp:49
+msgid "Failed to create wake up pipe used by event loop."
+msgstr ""
+
+#: ../src/unix/wakeuppipe.cpp:56
+msgid "Failed to switch wake up pipe to non-blocking mode"
+msgstr ""
+
+#: ../src/unix/wakeuppipe.cpp:117
+msgid "Failed to read from wake-up pipe"
+msgstr ""
+
+#: ../src/x11/app.cpp:124
+#, c-format
+msgid "Invalid geometry specification '%s'"
+msgstr ""
+
+#: ../src/x11/app.cpp:167
+msgid "wxWidgets could not open display. Exiting."
+msgstr "wxWidgets نمی تواند نمایش را باز کند. خارج شدن."
+
+#: ../src/x11/utils.cpp:169
+#, c-format
+msgid "Failed to close the display \"%s\""
+msgstr ""
+
+#: ../src/x11/utils.cpp:188
+#, c-format
+msgid "Failed to open display \"%s\"."
+msgstr ""
+
+#: ../src/xml/xml.cpp:868
+#, c-format
+msgid "XML parsing error: '%s' at line %d"
+msgstr ""
+
+#: ../src/xrc/xh_propgrid.cpp:239
+#, c-format
+msgid "Page %i"
+msgstr ""
+
+#: ../src/xrc/xmlres.cpp:448
+#, c-format
+msgid "Cannot load resources from '%s'."
+msgstr ""
+
+#: ../src/xrc/xmlres.cpp:799
+#, c-format
+msgid "Cannot open resources file '%s'."
+msgstr ""
+
+#: ../src/xrc/xmlres.cpp:806
+#, c-format
+msgid "Cannot load resources from file '%s'."
+msgstr ""
+
+#: ../src/xrc/xmlres.cpp:2767
+#, c-format
+msgid "Creating %s \"%s\" failed."
+msgstr ""
+
+#~ msgid "<Any>"
+#~ msgstr "<Any>"
+
+#~ msgid "<Any Roman>"
+#~ msgstr "<هر رومان>"
+
+#~ msgid "<Any Decorative>"
+#~ msgstr "<هر تزئینی>"
+
+#~ msgid "<Any Modern>"
+#~ msgstr "<هر مدرن>"
+
+#~ msgid "<Any Script>"
+#~ msgstr "<هر اسکریپتی>"
+
+#~ msgid "<Any Swiss>"
+#~ msgstr "<هر سوئیسی>"
+
+#~ msgid "<Any Teletype>"
+#~ msgstr "<هرگونه Teletype>"
+
+#~ msgid " (while overwriting an existing item)"
+#~ msgstr " (درحال رونویسی  یک مورد موجود)"

--- a/po_wxstd/fi.po
+++ b/po_wxstd/fi.po
@@ -1,0 +1,10524 @@
+# wxWidgets Finnish translation.
+# Jani Kinnunen <jani.kinnunen@wippies.fi>, 2012.
+# Elias Julkunen <eliasjulkunen@gmail.com>, 2008
+# Jaakko Salli <jmsalli79@hotmail.com>, 2005.
+# Lauri Nurmi <lanurmi@iki.fi>, 2004.
+# Kaj G Backas <kgb@compart.fi>, 2000.
+#
+# HUOM! Jos jatkat suomennosta, ÄLÄ käytä fuzzy-merkittyjä kohtia
+#       lukematta niitä läpi hyvin tarkasti! Niissä voi olla mitä vain.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: wxWidgets 3.3\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-05-14 20:23+0200\n"
+"PO-Revision-Date: 2023-02-02 22:04+0200\n"
+"Last-Translator: Lauri Nurmi <lanurmi@iki.fi>\n"
+"Language-Team: \n"
+"Language: fi\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1)\n"
+
+#: ../include/wx/defs.h:2582
+msgid "All files (*.*)|*.*"
+msgstr "Kaikki tiedostot (*.*)|*.*"
+
+#: ../include/wx/defs.h:2585
+msgid "All files (*)|*"
+msgstr "Kaikki tiedostot (*)|*"
+
+#: ../include/wx/generic/progdlgg.h:85
+msgid "Elapsed time:"
+msgstr "Käytetty aika:"
+
+#: ../include/wx/generic/progdlgg.h:86
+msgid "Estimated time:"
+msgstr "Arvioitu aika:"
+
+#: ../include/wx/generic/progdlgg.h:87
+msgid "Remaining time:"
+msgstr "Jäljellä oleva aika:"
+
+#. TRANSLATORS: HTML printout default title.
+#: ../include/wx/html/htmprint.h:121 ../include/wx/prntbase.h:273
+#: ../include/wx/richtext/richtextprint.h:109 ../src/common/docview.cpp:2161
+#, fuzzy
+msgid "Printout"
+msgstr "Tulosta"
+
+#. TRANSLATORS: HTML easy print default title.
+#: ../include/wx/html/htmprint.h:234 ../include/wx/richtext/richtextprint.h:163
+#: ../src/common/prntbase.cpp:522 ../src/html/htmprint.cpp:291
+#, fuzzy
+msgid "Printing"
+msgstr "Tulostetaan "
+
+#: ../include/wx/msgdlg.h:277 ../src/common/stockitem.cpp:211
+msgid "Yes"
+msgstr "Kyllä"
+
+#: ../include/wx/msgdlg.h:278 ../src/common/stockitem.cpp:182
+msgid "No"
+msgstr "Ei"
+
+#: ../include/wx/msgdlg.h:279 ../src/common/stockitem.cpp:183
+#: ../src/msw/msgdlg.cpp:430 ../src/msw/msgdlg.cpp:734
+#: ../src/richtext/richtextstyledlg.cpp:292
+msgid "OK"
+msgstr "OK"
+
+#: ../include/wx/msgdlg.h:280 ../src/common/stockitem.cpp:150
+#: ../src/msw/msgdlg.cpp:430 ../src/msw/progdlg.cpp:884
+#: ../src/richtext/richtextstyledlg.cpp:295
+msgid "Cancel"
+msgstr "Peruuta"
+
+#: ../include/wx/msgdlg.h:281 ../src/common/stockitem.cpp:168
+#: ../src/html/helpdlg.cpp:63 ../src/html/helpfrm.cpp:108
+#: ../src/osx/button_osx.cpp:38
+msgid "Help"
+msgstr "Ohje"
+
+#: ../include/wx/msw/ole/oleutils.h:52
+msgid "Cannot initialize OLE"
+msgstr "OLE:n alustus epäonnistui"
+
+#: ../include/wx/msw/private/fswatcher.h:48
+#, fuzzy, c-format
+msgid "Unable to close the handle for '%s'"
+msgstr "Tiedostokahvan sulkeminen epäonnistui"
+
+#: ../include/wx/msw/private/fswatcher.h:92
+#, fuzzy, c-format
+msgid "Failed to open directory \"%s\" for monitoring."
+msgstr "Kohteen ”%s” avaaminen kirjoittamista varten epäonnistui"
+
+#: ../include/wx/msw/private/fswatcher.h:125
+#, fuzzy
+msgid "Unable to close I/O completion port handle"
+msgstr "Tiedostokahvan sulkeminen epäonnistui"
+
+#: ../include/wx/msw/private/fswatcher.h:142
+msgid "Unable to associate handle with I/O completion port"
+msgstr ""
+
+#: ../include/wx/msw/private/fswatcher.h:148
+msgid "Unexpectedly new I/O completion port was created"
+msgstr ""
+
+#: ../include/wx/msw/private/fswatcher.h:213
+msgid "Unable to post completion status"
+msgstr ""
+
+#: ../include/wx/msw/private/fswatcher.h:262
+msgid "Unable to dequeue completion packet"
+msgstr ""
+
+#: ../include/wx/msw/private/fswatcher.h:273
+#, fuzzy
+msgid "Unable to create I/O completion port"
+msgstr "Osoittimen luonti epäonnistui."
+
+#: ../include/wx/richmsgdlg.h:29
+msgid "&See details"
+msgstr "&Tiedot"
+
+#: ../include/wx/richmsgdlg.h:30
+msgid "&Hide details"
+msgstr "&Piilota tiedot"
+
+#: ../include/wx/richtext/richtextbuffer.h:3864
+#, fuzzy
+msgid "&Box"
+msgstr "&Lihavoitu"
+
+#: ../include/wx/richtext/richtextbuffer.h:5008
+msgid "&Picture"
+msgstr "&Kuva"
+
+#: ../include/wx/richtext/richtextbuffer.h:5958
+msgid "&Cell"
+msgstr "&Solu"
+
+#: ../include/wx/richtext/richtextbuffer.h:6067
+msgid "&Table"
+msgstr "&Taulukko"
+
+#: ../include/wx/richtext/richtextimagedlg.h:37
+#, fuzzy
+msgid "Object Properties"
+msgstr "&Ominaisuudet"
+
+#: ../include/wx/richtext/richtextsymboldlg.h:39
+msgid "Symbols"
+msgstr "Symbolit"
+
+#: ../include/wx/unix/pipe.h:46
+msgid "Pipe creation failed"
+msgstr "Putken luonti epäonnistui"
+
+#: ../include/wx/unix/private/displayx11.h:65
+msgid "Failed to enumerate video modes"
+msgstr "Näyttötilojen luettelointi ei onnistu"
+
+#: ../include/wx/unix/private/displayx11.h:89
+msgid "Failed to change video mode"
+msgstr "Näyttötilan vaihto epäonnistui"
+
+#: ../include/wx/unix/private/fswatcher_kqueue.h:57
+#, fuzzy, c-format
+msgid "Unable to open path '%s'"
+msgstr "CHM arkiston ”%s” avaaminen epäonnistui."
+
+#: ../include/wx/unix/private/fswatcher_kqueue.h:74
+#, fuzzy, c-format
+msgid "Unable to close path '%s'"
+msgstr "Lukkotiedoston ”%s” sulkeminen epäonnistui"
+
+#: ../include/wx/xtiprop.h:175
+msgid "SetProperty called w/o valid setter"
+msgstr ""
+
+#: ../include/wx/xtiprop.h:184
+msgid "GetProperty called w/o valid getter"
+msgstr "GetProperty-funktiota kutsuttiin ilman kelvollista hakijaa"
+
+#: ../include/wx/xtiprop.h:193
+msgid "AddToPropertyCollection called w/o valid adder"
+msgstr "AddToPropertyCollection kutsuttu ilman kelvollista lisääjää"
+
+#: ../include/wx/xtiprop.h:202
+msgid "GetPropertyCollection called w/o valid collection getter"
+msgstr ""
+"GetPropertyCollection-funktiota kutsuttu ilman kelvollista kokoelman hakijaa"
+
+#: ../include/wx/xtiprop.h:255
+msgid "AddToPropertyCollection called on a generic accessor"
+msgstr "Funktiota AddToPropertyCollection kutsuttu yleisellä haulla"
+
+#: ../include/wx/xtiprop.h:262
+msgid "GetPropertyCollection called on a generic accessor"
+msgstr "Funktiota GetPropertyCollection kutsuttu yleisellä haulla"
+
+#: ../src/aui/tabmdi.cpp:106 ../src/generic/mdig.cpp:94
+msgid "Cl&ose"
+msgstr "&Sulje"
+
+#: ../src/aui/tabmdi.cpp:107 ../src/generic/mdig.cpp:95
+msgid "Close All"
+msgstr "Sulje kaikki"
+
+#: ../src/aui/tabmdi.cpp:109 ../src/generic/mdig.cpp:97 ../src/msw/mdi.cpp:175
+#: ../src/qt/mdi.cpp:258
+msgid "&Next"
+msgstr "&Seuraava"
+
+#: ../src/aui/tabmdi.cpp:110 ../src/generic/mdig.cpp:98 ../src/msw/mdi.cpp:176
+#: ../src/qt/mdi.cpp:259
+msgid "&Previous"
+msgstr "&Edellinen"
+
+#: ../src/aui/tabmdi.cpp:332 ../src/aui/tabmdi.cpp:348
+#: ../src/aui/tabmdi.cpp:350 ../src/generic/mdig.cpp:291
+#: ../src/generic/mdig.cpp:307 ../src/generic/mdig.cpp:311
+#: ../src/msw/mdi.cpp:337 ../src/qt/mdi.cpp:462
+msgid "&Window"
+msgstr "&Ikkuna"
+
+#: ../src/common/accelcmn.cpp:47
+msgctxt "keyboard key"
+msgid "Delete"
+msgstr "Delete"
+
+#: ../src/common/accelcmn.cpp:48
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Del"
+msgstr "Poista"
+
+#: ../src/common/accelcmn.cpp:49
+msgctxt "keyboard key"
+msgid "Back"
+msgstr "Takaisin"
+
+#: ../src/common/accelcmn.cpp:49
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Backspace"
+msgstr "Takaisin"
+
+#: ../src/common/accelcmn.cpp:50
+msgctxt "keyboard key"
+msgid "Insert"
+msgstr "Insert"
+
+#: ../src/common/accelcmn.cpp:51
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Ins"
+msgstr "Lisää"
+
+#: ../src/common/accelcmn.cpp:52
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Enter"
+msgstr "Tulostin"
+
+#: ../src/common/accelcmn.cpp:53
+msgctxt "keyboard key"
+msgid "Return"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:54
+#, fuzzy
+msgctxt "keyboard key"
+msgid "PageUp"
+msgstr "Sivut"
+
+#: ../src/common/accelcmn.cpp:54
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Page Up"
+msgstr "Sivu %d"
+
+#: ../src/common/accelcmn.cpp:55
+#, fuzzy
+msgctxt "keyboard key"
+msgid "PageDown"
+msgstr "Alas"
+
+#: ../src/common/accelcmn.cpp:55
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Page Down"
+msgstr "Sivu %d"
+
+#: ../src/common/accelcmn.cpp:56
+msgctxt "keyboard key"
+msgid "PgUp"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:57
+msgctxt "keyboard key"
+msgid "PgDn"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:58
+msgctxt "keyboard key"
+msgid "Left"
+msgstr "Vasen"
+
+#: ../src/common/accelcmn.cpp:59
+msgctxt "keyboard key"
+msgid "Right"
+msgstr "Oikea"
+
+#: ../src/common/accelcmn.cpp:60
+msgctxt "keyboard key"
+msgid "Up"
+msgstr "Ylös"
+
+#: ../src/common/accelcmn.cpp:61
+msgctxt "keyboard key"
+msgid "Down"
+msgstr "Alas"
+
+#: ../src/common/accelcmn.cpp:62
+msgctxt "keyboard key"
+msgid "Home"
+msgstr "Home"
+
+#: ../src/common/accelcmn.cpp:63
+msgctxt "keyboard key"
+msgid "End"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:64
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Space"
+msgstr "Etsitään..."
+
+#: ../src/common/accelcmn.cpp:65
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Tab"
+msgstr "Välilehdet"
+
+#: ../src/common/accelcmn.cpp:66
+msgctxt "keyboard key"
+msgid "Esc"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:67
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Escape"
+msgstr "Vaakasuunta"
+
+#: ../src/common/accelcmn.cpp:68
+msgctxt "keyboard key"
+msgid "Cancel"
+msgstr "Cancel"
+
+#: ../src/common/accelcmn.cpp:69
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Clear"
+msgstr "&Tyhjennä"
+
+#: ../src/common/accelcmn.cpp:70
+msgctxt "keyboard key"
+msgid "Menu"
+msgstr "Valikko"
+
+#: ../src/common/accelcmn.cpp:71
+msgctxt "keyboard key"
+msgid "Pause"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:72
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Capital"
+msgstr "&Suuraakkoset"
+
+#: ../src/common/accelcmn.cpp:73
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Select"
+msgstr "Valinta"
+
+#: ../src/common/accelcmn.cpp:74
+msgctxt "keyboard key"
+msgid "Print"
+msgstr "Tulosta"
+
+#: ../src/common/accelcmn.cpp:75
+msgctxt "keyboard key"
+msgid "Execute"
+msgstr "Suorita"
+
+#: ../src/common/accelcmn.cpp:76
+msgctxt "keyboard key"
+msgid "Snapshot"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:77
+msgctxt "keyboard key"
+msgid "Help"
+msgstr "Ohje"
+
+#: ../src/common/accelcmn.cpp:78
+msgctxt "keyboard key"
+msgid "Add"
+msgstr "Lisää"
+
+#: ../src/common/accelcmn.cpp:79
+msgctxt "keyboard key"
+msgid "Separator"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:80
+msgctxt "keyboard key"
+msgid "Subtract"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:81
+msgctxt "keyboard key"
+msgid "Decimal"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:82
+msgctxt "keyboard key"
+msgid "Multiply"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:83
+msgctxt "keyboard key"
+msgid "Divide"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:84
+msgctxt "keyboard key"
+msgid "Num_lock"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:84
+msgctxt "keyboard key"
+msgid "Num Lock"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:85
+msgctxt "keyboard key"
+msgid "Scroll_lock"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:85
+msgctxt "keyboard key"
+msgid "Scroll Lock"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:86
+msgctxt "keyboard key"
+msgid "KP_Space"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:86
+msgctxt "keyboard key"
+msgid "Num Space"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:87
+#, fuzzy
+msgctxt "keyboard key"
+msgid "KP_Tab"
+msgstr "KP_SARKAIN"
+
+#: ../src/common/accelcmn.cpp:87
+msgctxt "keyboard key"
+msgid "Num Tab"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:88
+#, fuzzy
+msgctxt "keyboard key"
+msgid "KP_Enter"
+msgstr "Tulostin"
+
+#: ../src/common/accelcmn.cpp:88
+msgctxt "keyboard key"
+msgid "Num Enter"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:89
+#, fuzzy
+msgctxt "keyboard key"
+msgid "KP_Home"
+msgstr "Koti"
+
+#: ../src/common/accelcmn.cpp:89
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Num Home"
+msgstr "Koti"
+
+#: ../src/common/accelcmn.cpp:90
+#, fuzzy
+msgctxt "keyboard key"
+msgid "KP_Left"
+msgstr "Vasen"
+
+#: ../src/common/accelcmn.cpp:90
+msgctxt "keyboard key"
+msgid "Num left"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:91
+#, fuzzy
+msgctxt "keyboard key"
+msgid "KP_Up"
+msgstr "KP_YLÖS"
+
+#: ../src/common/accelcmn.cpp:91
+msgctxt "keyboard key"
+msgid "Num Up"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:92
+#, fuzzy
+msgctxt "keyboard key"
+msgid "KP_Right"
+msgstr "Oikealle"
+
+#: ../src/common/accelcmn.cpp:92
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Num Right"
+msgstr "Oikealle"
+
+#: ../src/common/accelcmn.cpp:93
+#, fuzzy
+msgctxt "keyboard key"
+msgid "KP_Down"
+msgstr "Alas"
+
+#: ../src/common/accelcmn.cpp:93
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Num Down"
+msgstr "Alas"
+
+#: ../src/common/accelcmn.cpp:94
+msgctxt "keyboard key"
+msgid "KP_PageUp"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:94
+msgctxt "keyboard key"
+msgid "Num Page Up"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:95
+msgctxt "keyboard key"
+msgid "KP_PageDown"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:95
+msgctxt "keyboard key"
+msgid "Num Page Down"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:96
+msgctxt "keyboard key"
+msgid "KP_Prior"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:97
+#, fuzzy
+msgctxt "keyboard key"
+msgid "KP_Next"
+msgstr "Seuraava"
+
+#: ../src/common/accelcmn.cpp:98
+#, fuzzy
+msgctxt "keyboard key"
+msgid "KP_End"
+msgstr "KP_END"
+
+#: ../src/common/accelcmn.cpp:98
+msgctxt "keyboard key"
+msgid "Num End"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:99
+msgctxt "keyboard key"
+msgid "KP_Begin"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:99
+msgctxt "keyboard key"
+msgid "Num Begin"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:100
+#, fuzzy
+msgctxt "keyboard key"
+msgid "KP_Insert"
+msgstr "Lisää"
+
+#: ../src/common/accelcmn.cpp:100
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Num Insert"
+msgstr "Lisää"
+
+#: ../src/common/accelcmn.cpp:101
+#, fuzzy
+msgctxt "keyboard key"
+msgid "KP_Delete"
+msgstr "Poista"
+
+#: ../src/common/accelcmn.cpp:101
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Num Delete"
+msgstr "Poista"
+
+#: ../src/common/accelcmn.cpp:102
+msgctxt "keyboard key"
+msgid "KP_Equal"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:102
+msgctxt "keyboard key"
+msgid "Num ="
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:103
+msgctxt "keyboard key"
+msgid "KP_Multiply"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:103
+msgctxt "keyboard key"
+msgid "Num *"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:104
+#, fuzzy
+msgctxt "keyboard key"
+msgid "KP_Add"
+msgstr "KP_LISÄÄ"
+
+#: ../src/common/accelcmn.cpp:104
+msgctxt "keyboard key"
+msgid "Num +"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:105
+msgctxt "keyboard key"
+msgid "KP_Separator"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:105
+msgctxt "keyboard key"
+msgid "Num ,"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:106
+msgctxt "keyboard key"
+msgid "KP_Subtract"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:106
+msgctxt "keyboard key"
+msgid "Num -"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:107
+msgctxt "keyboard key"
+msgid "KP_Decimal"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:107
+msgctxt "keyboard key"
+msgid "Num ."
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:108
+msgctxt "keyboard key"
+msgid "KP_Divide"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:108
+msgctxt "keyboard key"
+msgid "Num /"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:109
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Windows_Left"
+msgstr "Windows 7"
+
+#: ../src/common/accelcmn.cpp:110
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Windows_Right"
+msgstr "Windows Vista"
+
+#: ../src/common/accelcmn.cpp:111
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Windows_Menu"
+msgstr "Windows ME"
+
+#: ../src/common/accelcmn.cpp:112
+msgctxt "keyboard key"
+msgid "Command"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:186 ../src/common/accelcmn.cpp:359
+msgctxt "keyboard key"
+msgid "Ctrl"
+msgstr "Ctrl"
+
+#: ../src/common/accelcmn.cpp:188 ../src/common/accelcmn.cpp:363
+msgctxt "keyboard key"
+msgid "Alt"
+msgstr "Alt"
+
+#: ../src/common/accelcmn.cpp:190 ../src/common/accelcmn.cpp:361
+msgctxt "keyboard key"
+msgid "Shift"
+msgstr "Vaihto"
+
+#: ../src/common/accelcmn.cpp:196
+msgctxt "keyboard key"
+msgid "num "
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:260 ../src/common/accelcmn.cpp:382
+msgctxt "keyboard key"
+msgid "F"
+msgstr "F"
+
+#: ../src/common/accelcmn.cpp:277 ../src/common/accelcmn.cpp:385
+msgctxt "keyboard key"
+msgid "KP_F"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:280 ../src/common/accelcmn.cpp:388
+msgctxt "keyboard key"
+msgid "KP_"
+msgstr "KP_"
+
+#: ../src/common/accelcmn.cpp:283 ../src/common/accelcmn.cpp:391
+msgctxt "keyboard key"
+msgid "SPECIAL"
+msgstr "ERIKOIS"
+
+#: ../src/common/accelcmn.cpp:373
+#, fuzzy
+msgid "Ctrl"
+msgstr "Ctrl"
+
+#: ../src/common/appbase.cpp:786
+msgid "show this help message"
+msgstr "näytä tämä ohjeviesti"
+
+#: ../src/common/appbase.cpp:796
+msgid "generate verbose log messages"
+msgstr "luo yksityiskohtaiset lokiviestit"
+
+#: ../src/common/appcmn.cpp:256
+msgid "specify the theme to use"
+msgstr "määritä käytettävä teema"
+
+#: ../src/common/appcmn.cpp:270
+msgid "specify display mode to use (e.g. 640x480-16)"
+msgstr "määritä käytettävä näyttötila (esim. 640x480-16)"
+
+#: ../src/common/appcmn.cpp:292
+#, c-format
+msgid "Unsupported theme '%s'."
+msgstr "Teemaa ”%s” ei tueta."
+
+#: ../src/common/appcmn.cpp:309
+#, c-format
+msgid "Invalid display mode specification '%s'."
+msgstr "Virheellinen näyttötilamääritelmä ”%s”."
+
+#: ../src/common/cmdline.cpp:875
+#, fuzzy, c-format
+msgid "Option '%s' can't be negated"
+msgstr "Hakemistoa ”%s” ei voitu luoda"
+
+#: ../src/common/cmdline.cpp:889
+#, c-format
+msgid "Unknown long option '%s'"
+msgstr "Tuntematon pitkä valitsin ”%s”"
+
+#: ../src/common/cmdline.cpp:904 ../src/common/cmdline.cpp:926
+#, c-format
+msgid "Unknown option '%s'"
+msgstr "Tuntematon valitsin ”%s”"
+
+#: ../src/common/cmdline.cpp:1004
+#, fuzzy, c-format
+msgid "Unexpected characters following option '%s'."
+msgstr "Odottamaton parametri ”%s”"
+
+#: ../src/common/cmdline.cpp:1039
+#, c-format
+msgid "Option '%s' requires a value."
+msgstr "Valinta ”%s” vaatii arvon."
+
+#: ../src/common/cmdline.cpp:1058
+#, c-format
+msgid "Separator expected after the option '%s'."
+msgstr "Erotinmerkki tarvitaan option ”%s” jälkeen."
+
+#: ../src/common/cmdline.cpp:1088 ../src/common/cmdline.cpp:1106
+#, c-format
+msgid "'%s' is not a correct numeric value for option '%s'."
+msgstr "”%s” ei ole oikea numeerinen arvo valitsimelle ”%s”."
+
+#: ../src/common/cmdline.cpp:1122
+#, c-format
+msgid "Option '%s': '%s' cannot be converted to a date."
+msgstr "Valinta ”%s”: ”%s” ei voida muuntua päiväykseksi."
+
+#: ../src/common/cmdline.cpp:1170
+#, c-format
+msgid "Unexpected parameter '%s'"
+msgstr "Odottamaton parametri ”%s”"
+
+#. TRANSLATORS: Short name and long name for a command line option
+#: ../src/common/cmdline.cpp:1197
+#, c-format
+msgid "%s (or %s)"
+msgstr "%s (tai %s)"
+
+#: ../src/common/cmdline.cpp:1208
+#, c-format
+msgid "The value for the option '%s' must be specified."
+msgstr "Valinnan ”%s” arvo täyty olla määritelty."
+
+#: ../src/common/cmdline.cpp:1230
+#, c-format
+msgid "The required parameter '%s' was not specified."
+msgstr "Tarvittavaa parametria ”%s” ei ole määritelty."
+
+#: ../src/common/cmdline.cpp:1289
+#, c-format
+msgid "Usage: %s"
+msgstr "Käyttö: %s"
+
+#: ../src/common/cmdline.cpp:1498
+msgid "str"
+msgstr "merkkijono"
+
+#: ../src/common/cmdline.cpp:1502
+msgid "num"
+msgstr "num."
+
+#: ../src/common/cmdline.cpp:1506
+msgid "double"
+msgstr ""
+
+#: ../src/common/cmdline.cpp:1510
+msgid "date"
+msgstr "päiväys"
+
+#: ../src/common/cmdproc.cpp:250 ../src/common/cmdproc.cpp:276
+#: ../src/common/cmdproc.cpp:296
+msgid "Unnamed command"
+msgstr "Nimeämätän komento"
+
+#: ../src/common/cmdproc.cpp:253
+msgid "&Undo "
+msgstr "&Kumoa "
+
+#: ../src/common/cmdproc.cpp:255
+msgid "Can't &Undo "
+msgstr "Ei voi &Kumota "
+
+#: ../src/common/cmdproc.cpp:259 ../src/common/stockitem.cpp:208
+#: ../src/msw/textctrl.cpp:2880 ../src/osx/textctrl_osx.cpp:649
+#: ../src/richtext/richtextctrl.cpp:327
+msgid "&Undo"
+msgstr "&Kumoa"
+
+#: ../src/common/cmdproc.cpp:277 ../src/common/cmdproc.cpp:297
+msgid "&Redo "
+msgstr "&Tee uudelleen "
+
+#: ../src/common/cmdproc.cpp:281 ../src/common/cmdproc.cpp:288
+#: ../src/common/stockitem.cpp:190 ../src/msw/textctrl.cpp:2881
+#: ../src/osx/textctrl_osx.cpp:650 ../src/richtext/richtextctrl.cpp:328
+msgid "&Redo"
+msgstr "&Toista"
+
+#: ../src/common/colourcmn.cpp:41
+#, c-format
+msgid "String To Colour : Incorrect colour specification : %s"
+msgstr ""
+
+#: ../src/common/config.cpp:259
+#, c-format
+msgid "Invalid value %ld for a boolean key \"%s\" in config file."
+msgstr "Virheellinen arvo %ld totuusavaimelle \"%s\" asetustiedostossa."
+
+#: ../src/common/config.cpp:526
+#, fuzzy, c-format
+msgid ""
+"Environment variables expansion failed: missing '%c' at position %u in '%s'."
+msgstr ""
+"Ympäristömuuttujien laajennus epäonnistui: puuttuva ”%1$c” muuttujan ”%3$s” "
+"kohdassa %2$d."
+
+#: ../src/common/config.cpp:576 ../src/msw/regconf.cpp:272
+#, c-format
+msgid "'%s' has extra '..', ignored."
+msgstr "”%s” sisältää ylimääräisen ”..”, ohitettu."
+
+#. TRANSLATORS: Checkbox state name
+#: ../src/common/datavcmn.cpp:2166 ../src/generic/datavgen.cpp:1430
+msgid "checked"
+msgstr ""
+
+#. TRANSLATORS: Checkbox state name
+#: ../src/common/datavcmn.cpp:2170 ../src/generic/datavgen.cpp:1432
+msgid "unchecked"
+msgstr ""
+
+#. TRANSLATORS: Checkbox state name
+#: ../src/common/datavcmn.cpp:2174
+#, fuzzy
+msgid "undetermined"
+msgstr "alleviivattu"
+
+#: ../src/common/datetimefmt.cpp:1875
+msgid "today"
+msgstr "tänään"
+
+#: ../src/common/datetimefmt.cpp:1876
+msgid "yesterday"
+msgstr "eilen"
+
+#: ../src/common/datetimefmt.cpp:1877
+msgid "tomorrow"
+msgstr "huomenna"
+
+#: ../src/common/datetimefmt.cpp:2071
+msgid "first"
+msgstr "ensimmäinen"
+
+#: ../src/common/datetimefmt.cpp:2072
+msgid "second"
+msgstr "toinen"
+
+#: ../src/common/datetimefmt.cpp:2073
+msgid "third"
+msgstr "kolmas"
+
+#: ../src/common/datetimefmt.cpp:2074
+msgid "fourth"
+msgstr "neljäs"
+
+#: ../src/common/datetimefmt.cpp:2075
+msgid "fifth"
+msgstr "viides"
+
+#: ../src/common/datetimefmt.cpp:2076
+msgid "sixth"
+msgstr "kuudes"
+
+#: ../src/common/datetimefmt.cpp:2077
+msgid "seventh"
+msgstr "seitsemäs"
+
+#: ../src/common/datetimefmt.cpp:2078
+msgid "eighth"
+msgstr "kahdeksas"
+
+#: ../src/common/datetimefmt.cpp:2079
+msgid "ninth"
+msgstr "yhdeksäs"
+
+#: ../src/common/datetimefmt.cpp:2080
+msgid "tenth"
+msgstr "kymmenes"
+
+#: ../src/common/datetimefmt.cpp:2081
+msgid "eleventh"
+msgstr "yhdestoista"
+
+#: ../src/common/datetimefmt.cpp:2082
+msgid "twelfth"
+msgstr "kahdestoista"
+
+#: ../src/common/datetimefmt.cpp:2083
+msgid "thirteenth"
+msgstr "kolmastoista"
+
+#: ../src/common/datetimefmt.cpp:2084
+msgid "fourteenth"
+msgstr "neljästoista"
+
+#: ../src/common/datetimefmt.cpp:2085
+msgid "fifteenth"
+msgstr "viidestoista"
+
+#: ../src/common/datetimefmt.cpp:2086
+msgid "sixteenth"
+msgstr "kuudestoista"
+
+#: ../src/common/datetimefmt.cpp:2087
+msgid "seventeenth"
+msgstr "seitsemästoista"
+
+#: ../src/common/datetimefmt.cpp:2088
+msgid "eighteenth"
+msgstr "kahdeksastoista"
+
+#: ../src/common/datetimefmt.cpp:2089
+msgid "nineteenth"
+msgstr "yhdeksästoista"
+
+#: ../src/common/datetimefmt.cpp:2090
+msgid "twentieth"
+msgstr "kahdeskymmenes"
+
+#: ../src/common/datetimefmt.cpp:2248
+msgid "noon"
+msgstr "keskipäivä"
+
+#: ../src/common/datetimefmt.cpp:2249
+msgid "midnight"
+msgstr "keskiyö"
+
+#: ../src/common/debugrpt.cpp:209
+#, fuzzy, c-format
+msgid "Failed to create directory \"%s\""
+msgstr "Hakemiston ”%s” luonti epäonnistui."
+
+#: ../src/common/debugrpt.cpp:210
+msgid "Debug report couldn't be created."
+msgstr "Ohjelmavirheilmoitusta ei voitu luoda."
+
+#: ../src/common/debugrpt.cpp:227
+#, fuzzy, c-format
+msgid "Failed to remove debug report file \"%s\""
+msgstr "Ohjelmavirhetiedostoa ”%s” ei voitu poistaa."
+
+#: ../src/common/debugrpt.cpp:239
+#, fuzzy, c-format
+msgid "Failed to clean up debug report directory \"%s\""
+msgstr "Ohjelmavirheiden ilmoituskansion ”%s” tyhjentäminen epäonnistui."
+
+#: ../src/common/debugrpt.cpp:514
+msgid "process context description"
+msgstr ""
+
+#: ../src/common/debugrpt.cpp:538
+msgid "dump of the process state (binary)"
+msgstr ""
+
+#: ../src/common/debugrpt.cpp:553
+msgid "Debug report generation has failed."
+msgstr "Ohjelmavirheilmoituksen luonti epäonnistui."
+
+#: ../src/common/debugrpt.cpp:560
+#, fuzzy, c-format
+msgid ""
+"Processing debug report has failed, leaving the files in \"%s\" directory."
+msgstr ""
+"Ohjelmavirheilmoituksen valmistelu epäonnistui, tiedostot jätetään "
+"hakemistoon ”%s”."
+
+#: ../src/common/debugrpt.cpp:573
+msgid "A debug report has been generated. It can be found in"
+msgstr "Virheraportti on luotu. Se löytyy kohteesta"
+
+#: ../src/common/debugrpt.cpp:576
+msgid "And includes the following files:\n"
+msgstr "Ja sisällytä seuraavat tiedostot:\n"
+
+#: ../src/common/debugrpt.cpp:586
+msgid ""
+"\n"
+"Please send this report to the program maintainer, thank you!\n"
+msgstr ""
+"\n"
+"Lähetä tämä ilmoitus ohjelman ylläpitäjälle, kiitos!\n"
+
+#: ../src/common/debugrpt.cpp:729
+msgid "Failed to execute curl, please install it in PATH."
+msgstr ""
+"curl:in suorittaminen epäonnistui. Asenna se johonkin PATH-määrityksessä "
+"olevaan hakemistoon."
+
+#: ../src/common/debugrpt.cpp:742
+#, c-format
+msgid "Failed to upload the debug report (error code %d)."
+msgstr "Ohjelmavirheilmoitusta ei voitu lähettää (virhekoodi %d)."
+
+#: ../src/common/docview.cpp:366
+msgid "Save As"
+msgstr "Tallenna nimellä"
+
+#: ../src/common/docview.cpp:457
+msgid "Discard changes and reload the last saved version?"
+msgstr ""
+"Hylätäänkö muutokset ja ladataanko uudelleen viimeisin tallennettu versio?"
+
+#: ../src/common/docview.cpp:488
+msgid "unnamed"
+msgstr "nimetön"
+
+#: ../src/common/docview.cpp:513
+#, c-format
+msgid "Do you want to save changes to %s?"
+msgstr "Haluatko tallentaa muutokset asiakirjaan %s?"
+
+#: ../src/common/docview.cpp:521 ../src/common/docview.cpp:560
+#: ../src/common/stockitem.cpp:195
+msgid "&Save"
+msgstr "&Tallenna"
+
+#: ../src/common/docview.cpp:522 ../src/common/docview.cpp:560
+msgid "&Discard changes"
+msgstr ""
+
+#: ../src/common/docview.cpp:523
+#, fuzzy
+msgid "Do&n't close"
+msgstr "älä tallenna"
+
+#: ../src/common/docview.cpp:553
+#, fuzzy, c-format
+msgid "Do you want to save changes to %s before closing it?"
+msgstr "Haluatko tallentaa muutokset asiakirjaan %s?"
+
+#: ../src/common/docview.cpp:559
+#, fuzzy
+msgid "The document must be closed."
+msgstr "Tekstiä ei voitu tallentaa."
+
+#: ../src/common/docview.cpp:571
+#, c-format
+msgid "Saving %s failed, would you like to retry?"
+msgstr ""
+
+#: ../src/common/docview.cpp:577
+msgid "Retry"
+msgstr ""
+
+#: ../src/common/docview.cpp:577
+msgid "Discard changes"
+msgstr ""
+
+#: ../src/common/docview.cpp:679
+#, fuzzy, c-format
+msgid "File \"%s\" could not be opened for writing."
+msgstr "Kohteen ”%s” avaaminen kirjoittamista varten epäonnistui"
+
+#: ../src/common/docview.cpp:685
+#, fuzzy, c-format
+msgid "Failed to save document to the file \"%s\"."
+msgstr "Touch epäonnistui tiedostolle ”%s”"
+
+#: ../src/common/docview.cpp:702
+#, fuzzy, c-format
+msgid "File \"%s\" could not be opened for reading."
+msgstr "Kohteen ”%s” avaaminen lukemista varten epäonnistui"
+
+#: ../src/common/docview.cpp:714
+#, fuzzy, c-format
+msgid "Failed to read document from the file \"%s\"."
+msgstr "Kuvaa %d ei voi ladata tiedostosta ”%s”."
+
+#: ../src/common/docview.cpp:1236
+#, c-format
+msgid ""
+"The file '%s' doesn't exist and couldn't be opened.\n"
+"It has been removed from the most recently used files list."
+msgstr ""
+"Tiedosto ”%s” ei ole olemassa ja eikä sitä voi avata.\n"
+"Se on myös poistettu MRU-tiedostojen luettelosta"
+
+#: ../src/common/docview.cpp:1296
+#, fuzzy
+msgid "Print preview creation failed."
+msgstr "Putken luonti epäonnistui"
+
+#: ../src/common/docview.cpp:1302
+msgid "Print Preview"
+msgstr "Tulostuksen esikatselu"
+
+#: ../src/common/docview.cpp:1517
+#, fuzzy, c-format
+msgid "The format of file '%s' couldn't be determined."
+msgstr "Sarakkeen leveyttä ei voitu määritellä"
+
+#: ../src/common/docview.cpp:1643
+#, c-format
+msgid "unnamed%d"
+msgstr "nimetön%d"
+
+#: ../src/common/docview.cpp:1660
+msgid " - "
+msgstr " - "
+
+#: ../src/common/docview.cpp:1791 ../src/common/docview.cpp:1844
+msgid "Open File"
+msgstr "Valitse Tiedosto"
+
+#: ../src/common/docview.cpp:1807
+msgid "File error"
+msgstr "Tiedostovirhe"
+
+#: ../src/common/docview.cpp:1809
+msgid "Sorry, could not open this file."
+msgstr "Tätä tiedostoa ei voi avata."
+
+#: ../src/common/docview.cpp:1843
+msgid "Sorry, the format for this file is unknown."
+msgstr "Tämän tiedoston muoto on tuntematon."
+
+#: ../src/common/docview.cpp:1924
+msgid "Select a document template"
+msgstr "Valitse asiakirjamalli"
+
+#: ../src/common/docview.cpp:1925
+msgid "Templates"
+msgstr "Asiakirjamallit"
+
+#: ../src/common/docview.cpp:1998
+msgid "Select a document view"
+msgstr "Valitse asiakirjanäkymä"
+
+#: ../src/common/docview.cpp:1999
+msgid "Views"
+msgstr "Näkymät"
+
+#: ../src/common/dynlib.cpp:81
+#, c-format
+msgid "Failed to load shared library '%s'"
+msgstr "Jaetun kirjaston ”%s” lataaminen epäonnistui"
+
+#: ../src/common/dynlib.cpp:105
+#, c-format
+msgid "Couldn't find symbol '%s' in a dynamic library"
+msgstr "Symbolia ”%s” ei löydy dynaamisesta kirjastosta"
+
+#: ../src/common/ffile.cpp:56 ../src/common/file.cpp:215
+#, c-format
+msgid "can't open file '%s'"
+msgstr "tiedostoa ”%s” ei voi avata"
+
+#: ../src/common/ffile.cpp:72
+#, c-format
+msgid "can't close file '%s'"
+msgstr "tiedostoa ”%s” ei voi sulkea"
+
+#: ../src/common/ffile.cpp:106 ../src/common/ffile.cpp:131
+#, c-format
+msgid "Read error on file '%s'"
+msgstr "Lukuvirhe tiedostossa ”%s”"
+
+#: ../src/common/ffile.cpp:148
+#, c-format
+msgid "Write error on file '%s'"
+msgstr "Tiedostoon ”%s” ei voi kirjoittaa"
+
+#: ../src/common/ffile.cpp:182
+#, c-format
+msgid "failed to flush the file '%s'"
+msgstr "tiedostoa ”%s” ei voitu kirjoittaa"
+
+#: ../src/common/ffile.cpp:222
+#, c-format
+msgid "Seek error on file '%s' (large files not supported by stdio)"
+msgstr "Hakuvirhe tiedostossa ”%s” (stdio ei tue suuria tiedostoja)"
+
+#: ../src/common/ffile.cpp:232
+#, c-format
+msgid "Seek error on file '%s'"
+msgstr "Hakuvirhe tiedostossa ”%s”"
+
+#: ../src/common/ffile.cpp:248
+#, c-format
+msgid "Can't find current position in file '%s'"
+msgstr "Tiedoston ”%s” nykyistä kohtaa ei löydy"
+
+#: ../src/common/ffile.cpp:349 ../src/common/file.cpp:569
+msgid "Failed to set temporary file permissions"
+msgstr "Tilapäistiedoston oikeuksia ei voitu asettaa."
+
+#: ../src/common/ffile.cpp:371
+#, c-format
+msgid "can't remove file '%s'"
+msgstr "tiedostoa ”%s” ei voi poistaa"
+
+#: ../src/common/ffile.cpp:376 ../src/common/file.cpp:591
+#, c-format
+msgid "can't commit changes to file '%s'"
+msgstr "ei voi toimittaa muutoksia tiedostoon ”%s”"
+
+#: ../src/common/ffile.cpp:388 ../src/common/file.cpp:603
+#, c-format
+msgid "can't remove temporary file '%s'"
+msgstr "väliaikaistiedostoa ”%s” ei voi poistaa"
+
+#: ../src/common/file.cpp:162
+#, c-format
+msgid "can't create file '%s'"
+msgstr "tiedoston ”%s” luonti ei onnistu"
+
+#: ../src/common/file.cpp:229
+#, c-format
+msgid "can't close file descriptor %d"
+msgstr "tiedoston kuvaajaa %d ei voida sulkea"
+
+#: ../src/common/file.cpp:332
+#, c-format
+msgid "can't read from file descriptor %d"
+msgstr "tiedoston kuvauksen %d luku epäonnistui"
+
+#: ../src/common/file.cpp:351
+#, c-format
+msgid "can't write to file descriptor %d"
+msgstr "kirjoittaminen epäonnistui tiedoston kuvaukseen %d"
+
+#: ../src/common/file.cpp:390
+#, c-format
+msgid "can't flush file descriptor %d"
+msgstr "tiedoston kuvausta %d ei voida tyhjentää"
+
+#: ../src/common/file.cpp:432
+#, c-format
+msgid "can't seek on file descriptor %d"
+msgstr ""
+
+#: ../src/common/file.cpp:446
+#, c-format
+msgid "can't get seek position on file descriptor %d"
+msgstr "paikanmääritys tiedoston kuvauksessa %d ei onnistu"
+
+#: ../src/common/file.cpp:475
+#, c-format
+msgid "can't find length of file on file descriptor %d"
+msgstr "tiedoston koko ei löydy tiedoston kuvauksesta %d"
+
+#: ../src/common/file.cpp:505
+#, c-format
+msgid "can't determine if the end of file is reached on descriptor %d"
+msgstr "ei voida päätellä tuliko kuvaajan %d loppu vastaan"
+
+#: ../src/common/fileconf.cpp:352
+#, c-format
+msgid ""
+" and additionally, the existing configuration file was renamed to \"%s\" and "
+"couldn't be renamed back, please rename it to its original path \"%s\""
+msgstr ""
+
+#: ../src/common/fileconf.cpp:389
+#, fuzzy
+msgid " due to the following error:\n"
+msgstr "Ja sisällytä seuraavat tiedostot:\n"
+
+#: ../src/common/fileconf.cpp:412
+#, fuzzy
+msgid "failed to rename the existing file"
+msgstr "Kuvaa %d ei voi ladata tiedostosta ”%s”."
+
+#: ../src/common/fileconf.cpp:421
+#, fuzzy
+msgid "failed to create the new file directory"
+msgstr "Työhakemistoa ei saatu"
+
+#: ../src/common/fileconf.cpp:428
+#, fuzzy
+msgid "failed to move the file to the new location"
+msgstr "Puhelinyhteyden ”%s” keskeytys ei onnistunut."
+
+#: ../src/common/fileconf.cpp:462
+#, c-format
+msgid "can't open global configuration file '%s'."
+msgstr "globaalin asetustiedoston ”%s” avaus ei onnistu."
+
+#: ../src/common/fileconf.cpp:478
+#, c-format
+msgid "can't open user configuration file '%s'."
+msgstr "käyttäjän asetustiedoston ”%s” avaus ei onnistu."
+
+#: ../src/common/fileconf.cpp:483
+#, c-format
+msgid "Changes won't be saved to avoid overwriting the existing file \"%s\""
+msgstr ""
+"Muutoksia ei tallenneta, jotta vältetään jo olemassa olevan tiedoston ”%s” "
+"korvaus"
+
+#: ../src/common/fileconf.cpp:583
+msgid "Error reading config options."
+msgstr "Virhe asetusten lukemisessa."
+
+#: ../src/common/fileconf.cpp:593
+msgid "Failed to read config options."
+msgstr "Asetuksia ei voitu lukea."
+
+#: ../src/common/fileconf.cpp:700
+#, fuzzy, c-format
+msgid "file '%s': unexpected character %c at line %zu."
+msgstr "tiedosto ”%s”: odottamaton merkki %c rivillä %d."
+
+#: ../src/common/fileconf.cpp:736
+#, fuzzy, c-format
+msgid "file '%s', line %zu: '%s' ignored after group header."
+msgstr "tiedosto ”%s”, rivi %d: ”%s” ohitettu ryhmäotsikon jälkeen."
+
+#: ../src/common/fileconf.cpp:765
+#, fuzzy, c-format
+msgid "file '%s', line %zu: '=' expected."
+msgstr "tiedosto ”%s”, rivi %d: ”=” odotettu."
+
+#: ../src/common/fileconf.cpp:778
+#, fuzzy, c-format
+msgid "file '%s', line %zu: value for immutable key '%s' ignored."
+msgstr "tiedosto ”%s”, rivi %d: muuttamattoman avaimen ”%s” arvo ohitettu."
+
+#: ../src/common/fileconf.cpp:788
+#, fuzzy, c-format
+msgid "file '%s', line %zu: key '%s' was first found at line %d."
+msgstr "tiedosto ”%s”, rivi %d: avain ”%s” löytyi ensiksi riviltä %d."
+
+#: ../src/common/fileconf.cpp:1091
+#, c-format
+msgid "Config entry name cannot start with '%c'."
+msgstr "Asetuskohdan nimi ei voi alkaa merkillä ”%c”."
+
+#: ../src/common/fileconf.cpp:1146
+#, fuzzy
+msgid "Failed to create configuration file directory."
+msgstr "Käyttäjän asetustiedoston päivitys ei onnistu."
+
+#: ../src/common/fileconf.cpp:1158
+msgid "can't open user configuration file."
+msgstr "käyttäjän asetustiedoston avaus ei onnistu."
+
+#: ../src/common/fileconf.cpp:1172
+msgid "can't write user configuration file."
+msgstr "käyttäjän asetustiedoston kirjoitus epäonnistui."
+
+#: ../src/common/fileconf.cpp:1178
+msgid "Failed to update user configuration file."
+msgstr "Käyttäjän asetustiedoston päivitys ei onnistu."
+
+#: ../src/common/fileconf.cpp:1201
+msgid "Error saving user configuration data."
+msgstr "Virhe käyttäjän asetusten tallentamisessa."
+
+#: ../src/common/fileconf.cpp:1313
+#, c-format
+msgid "can't delete user configuration file '%s'"
+msgstr "käyttäjän asetustiedostoa ”%s” ei voi poistaa"
+
+#: ../src/common/fileconf.cpp:2007
+#, c-format
+msgid "entry '%s' appears more than once in group '%s'"
+msgstr "kohta ”%s” ilmenee useammin kuin kerran ryhmässä ”%s”"
+
+#: ../src/common/fileconf.cpp:2021
+#, c-format
+msgid "attempt to change immutable key '%s' ignored."
+msgstr "muuttumattoman avaimen ”%s” muutosyritys ohitettu."
+
+#: ../src/common/fileconf.cpp:2118
+#, c-format
+msgid "trailing backslash ignored in '%s'"
+msgstr ""
+
+#: ../src/common/fileconf.cpp:2153
+#, c-format
+msgid "unexpected \" at position %d in '%s'."
+msgstr "Odottamaton \"-merkki kohdassa %d tiedostossa '%s'."
+
+#: ../src/common/filefn.cpp:474
+#, c-format
+msgid "Failed to copy the file '%s' to '%s'"
+msgstr "Tiedoston ”%s” kopiointi kohteeseen ”%s” epäonnistui."
+
+#: ../src/common/filefn.cpp:487
+#, c-format
+msgid "Impossible to get permissions for file '%s'"
+msgstr "Tiedoston ”%s” oikeuksien saanti on mahdotonta"
+
+#: ../src/common/filefn.cpp:501
+#, c-format
+msgid "Impossible to overwrite the file '%s'"
+msgstr "Tiedostoa ”%s” ei voida korvata"
+
+#: ../src/common/filefn.cpp:508
+#, fuzzy, c-format
+msgid "Error copying the file '%s' to '%s'."
+msgstr "Tiedoston ”%s” kopiointi kohteeseen ”%s” epäonnistui."
+
+#: ../src/common/filefn.cpp:556
+#, c-format
+msgid "Impossible to set permissions for the file '%s'"
+msgstr "Lupien asetus tiedostolle ”%s” on mahdotonta"
+
+#: ../src/common/filefn.cpp:606
+#, c-format
+msgid ""
+"Failed to rename the file '%s' to '%s' because the destination file already "
+"exists."
+msgstr ""
+"Tiedoston '%s' uudelleennimeäminen tiedostoksi '%s' epäonnistui, koska "
+"kohdetiedosto on jo olemassa."
+
+#: ../src/common/filefn.cpp:623
+#, fuzzy, c-format
+msgid "File '%s' couldn't be renamed '%s'"
+msgstr "Hakemistoa ”%s” ei voitu luoda"
+
+#: ../src/common/filefn.cpp:639
+#, fuzzy, c-format
+msgid "File '%s' couldn't be removed"
+msgstr "Hakemistoa ”%s” ei voitu luoda"
+
+#: ../src/common/filefn.cpp:666
+#, c-format
+msgid "Directory '%s' couldn't be created"
+msgstr "Hakemistoa ”%s” ei voitu luoda"
+
+#: ../src/common/filefn.cpp:680
+#, fuzzy, c-format
+msgid "Directory '%s' couldn't be deleted"
+msgstr "Hakemistoa ”%s” ei voitu luoda"
+
+#: ../src/common/filefn.cpp:714
+#, c-format
+msgid "Cannot enumerate files '%s'"
+msgstr "Tiedostojen ”%s” luettelointi epäonnistui"
+
+#: ../src/common/filefn.cpp:798
+msgid "Failed to get the working directory"
+msgstr "Työhakemistoa ei saatu"
+
+#: ../src/common/filefn.cpp:843
+#, fuzzy
+msgid "Could not set current working directory"
+msgstr "Työhakemistoa ei saatu"
+
+#: ../src/common/filefn.cpp:974
+#, c-format
+msgid "Files (%s)"
+msgstr "Tiedostot (%s)"
+
+#: ../src/common/filename.cpp:182
+#, c-format
+msgid "Failed to open '%s' for reading"
+msgstr "Kohteen ”%s” avaaminen lukemista varten epäonnistui"
+
+#: ../src/common/filename.cpp:187
+#, c-format
+msgid "Failed to open '%s' for writing"
+msgstr "Kohteen ”%s” avaaminen kirjoittamista varten epäonnistui"
+
+#: ../src/common/filename.cpp:199
+msgid "Failed to close file handle"
+msgstr "Tiedostokahvan sulkeminen epäonnistui"
+
+#: ../src/common/filename.cpp:1046
+msgid "Failed to create a temporary file name"
+msgstr "Tilapäistiedoston nimen luonti epäonnistui."
+
+#: ../src/common/filename.cpp:1081
+msgid "Failed to open temporary file."
+msgstr "Tilapäistiedoston avaus epäonnistui."
+
+#: ../src/common/filename.cpp:2862
+#, fuzzy, c-format
+msgid "Failed to modify file times for '%s'"
+msgstr "Tiedoston ”%s” aikoja ei voitu muuttaa"
+
+#: ../src/common/filename.cpp:2877
+#, c-format
+msgid "Failed to touch the file '%s'"
+msgstr "Touch epäonnistui tiedostolle ”%s”"
+
+#: ../src/common/filename.cpp:2958
+#, fuzzy, c-format
+msgid "Failed to retrieve file times for '%s'"
+msgstr "Tiedoston ”%s” aikoja ei voida hakea"
+
+#: ../src/common/filepickercmn.cpp:39 ../src/common/filepickercmn.cpp:40
+msgid "Browse"
+msgstr "Selaa"
+
+#: ../src/common/fldlgcmn.cpp:792 ../src/generic/filectrlg.cpp:1185
+#, c-format
+msgid "All files (%s)|%s"
+msgstr "Kaikki tiedostot (%s)|%s"
+
+#. TRANSLATORS: %s are a file extension used to build a file wildcard string
+#: ../src/common/fldlgcmn.cpp:810
+#, c-format
+msgid "%s files (%s)|%s"
+msgstr "%s-tiedostot (%s)|%s"
+
+#: ../src/common/fldlgcmn.cpp:1072
+#, c-format
+msgid "Load %s file"
+msgstr "Lataa %s tiedosto"
+
+#: ../src/common/fldlgcmn.cpp:1074
+#, c-format
+msgid "Save %s file"
+msgstr "Tallenna %s tiedosto"
+
+#: ../src/common/fmapbase.cpp:144
+msgid "Western European (ISO-8859-1)"
+msgstr "Länsi-Eurooppa (ISO-8859-1/Latin 1)"
+
+#: ../src/common/fmapbase.cpp:145
+msgid "Central European (ISO-8859-2)"
+msgstr "keskieurooppalainen (ISO-8859-2)"
+
+#: ../src/common/fmapbase.cpp:146
+msgid "Esperanto (ISO-8859-3)"
+msgstr "esperanto (ISO-8859-3)"
+
+#: ../src/common/fmapbase.cpp:147
+#, fuzzy
+msgid "Baltic (old) (ISO-8859-4)"
+msgstr "Vanha baltti (ISO-8859-4)"
+
+#: ../src/common/fmapbase.cpp:148
+msgid "Cyrillic (ISO-8859-5)"
+msgstr "kyrillinen (ISO-8859-5)"
+
+#: ../src/common/fmapbase.cpp:149
+msgid "Arabic (ISO-8859-6)"
+msgstr "Arabialainen (ISO-8859-6)"
+
+#: ../src/common/fmapbase.cpp:150
+msgid "Greek (ISO-8859-7)"
+msgstr "kreikkalainen (ISO-8859-7)"
+
+#: ../src/common/fmapbase.cpp:151
+msgid "Hebrew (ISO-8859-8)"
+msgstr "heprea (ISO-8859-8)"
+
+#: ../src/common/fmapbase.cpp:152
+msgid "Turkish (ISO-8859-9)"
+msgstr "turkki (ISO-8859-9)"
+
+#: ../src/common/fmapbase.cpp:153
+msgid "Nordic (ISO-8859-10)"
+msgstr "pohjoismainen (ISO-8859-10)"
+
+#: ../src/common/fmapbase.cpp:154
+msgid "Thai (ISO-8859-11)"
+msgstr "Thaimaalainen (ISO-8859-11)"
+
+#: ../src/common/fmapbase.cpp:155
+msgid "Indian (ISO-8859-12)"
+msgstr "intialainen (ISO-8859-12)"
+
+#: ../src/common/fmapbase.cpp:156
+#, fuzzy
+msgid "Baltic (ISO-8859-13)"
+msgstr "Baltti (ISO-8859-13)"
+
+#: ../src/common/fmapbase.cpp:157
+msgid "Celtic (ISO-8859-14)"
+msgstr "kelttiläinen (ISO-8859-14)"
+
+#: ../src/common/fmapbase.cpp:158
+msgid "Western European with Euro (ISO-8859-15)"
+msgstr "Länsieurooppalainen euro:lla (ISO-8859-15)"
+
+#: ../src/common/fmapbase.cpp:159
+msgid "KOI8-R"
+msgstr "KOI8-R"
+
+#: ../src/common/fmapbase.cpp:160
+msgid "KOI8-U"
+msgstr "KOI8-U"
+
+#: ../src/common/fmapbase.cpp:161
+msgid "Windows/DOS OEM Cyrillic (CP 866)"
+msgstr "Windows/DOS OEM kyrillinen (CP 866)"
+
+#: ../src/common/fmapbase.cpp:162
+msgid "Windows Thai (CP 874)"
+msgstr "Windows thai (CP 874)"
+
+#: ../src/common/fmapbase.cpp:163
+msgid "Windows Japanese (CP 932) or Shift-JIS"
+msgstr "Windows japanilainen (CP 932) tai Shift-JIS"
+
+#: ../src/common/fmapbase.cpp:164
+msgid "Windows Chinese Simplified (CP 936) or GB-2312"
+msgstr "Windows yksinkertaistettu kiina (CP 936) tai GB-2312"
+
+#: ../src/common/fmapbase.cpp:165
+msgid "Windows Korean (CP 949)"
+msgstr "Windows, korea (CP 949)"
+
+#: ../src/common/fmapbase.cpp:166
+msgid "Windows Chinese Traditional (CP 950) or Big-5"
+msgstr "Windows kiinalainen perinteinen (CP 950) tai Big-5"
+
+#: ../src/common/fmapbase.cpp:167
+msgid "Windows Central European (CP 1250)"
+msgstr "Windows, Keski-Eurooppa (CP 1250)"
+
+#: ../src/common/fmapbase.cpp:168
+msgid "Windows Cyrillic (CP 1251)"
+msgstr "Windows, kyrillinen (CP 1251)"
+
+#: ../src/common/fmapbase.cpp:169
+msgid "Windows Western European (CP 1252)"
+msgstr "Windows, Länsi-Eurooppa (CP 1252)"
+
+#: ../src/common/fmapbase.cpp:170
+msgid "Windows Greek (CP 1253)"
+msgstr "Windows, kreikka (CP 1253)"
+
+#: ../src/common/fmapbase.cpp:171
+msgid "Windows Turkish (CP 1254)"
+msgstr "Windows, turkki (CP 1254)"
+
+#: ../src/common/fmapbase.cpp:172
+msgid "Windows Hebrew (CP 1255)"
+msgstr "Windows, heprea (CP 1255)"
+
+#: ../src/common/fmapbase.cpp:173
+msgid "Windows Arabic (CP 1256)"
+msgstr "Windows, arabia (CP 1256)"
+
+#: ../src/common/fmapbase.cpp:174
+msgid "Windows Baltic (CP 1257)"
+msgstr "Windows baltialainen (CP 1257)"
+
+#: ../src/common/fmapbase.cpp:175
+#, fuzzy
+msgid "Windows Vietnamese (CP 1258)"
+msgstr "Windows, kreikka (CP 1253)"
+
+#: ../src/common/fmapbase.cpp:176
+#, fuzzy
+msgid "Windows Johab (CP 1361)"
+msgstr "Windows, arabia (CP 1256)"
+
+#: ../src/common/fmapbase.cpp:177
+msgid "Windows/DOS OEM (CP 437)"
+msgstr "Windows/DOS OEM (CP 437)"
+
+#: ../src/common/fmapbase.cpp:178
+msgid "Unicode 7 bit (UTF-7)"
+msgstr "Unicode 7 bit (UTF-7)"
+
+#: ../src/common/fmapbase.cpp:179
+msgid "Unicode 8 bit (UTF-8)"
+msgstr "Unicode 8 bit (UTF-8)"
+
+#: ../src/common/fmapbase.cpp:181 ../src/common/fmapbase.cpp:187
+msgid "Unicode 16 bit (UTF-16)"
+msgstr "Unicode 16 bit (UTF-16)"
+
+#: ../src/common/fmapbase.cpp:182
+msgid "Unicode 16 bit Little Endian (UTF-16LE)"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:183 ../src/common/fmapbase.cpp:189
+msgid "Unicode 32 bit (UTF-32)"
+msgstr "Unicode 32 bit (UTF-32)"
+
+#: ../src/common/fmapbase.cpp:184
+msgid "Unicode 32 bit Little Endian (UTF-32LE)"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:186
+msgid "Unicode 16 bit Big Endian (UTF-16BE)"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:188
+msgid "Unicode 32 bit Big Endian (UTF-32BE)"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:191
+msgid "Extended Unix Codepage for Japanese (EUC-JP)"
+msgstr "Laajennettu japanilainen Unix-koodisivu (EUC-JP)"
+
+#: ../src/common/fmapbase.cpp:192
+msgid "US-ASCII"
+msgstr "US-ASCII"
+
+#: ../src/common/fmapbase.cpp:193
+msgid "ISO-2022-JP"
+msgstr "ISO-2022-JP"
+
+#: ../src/common/fmapbase.cpp:195
+#, fuzzy
+msgid "MacRoman"
+msgstr "Roman"
+
+#: ../src/common/fmapbase.cpp:196
+msgid "MacJapanese"
+msgstr "Mac (japanilainen)"
+
+#: ../src/common/fmapbase.cpp:197
+msgid "MacChineseTrad"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:198
+msgid "MacKorean"
+msgstr "Mac (korealainen)"
+
+#: ../src/common/fmapbase.cpp:199
+#, fuzzy
+msgid "MacArabic"
+msgstr "Arabialainen"
+
+#: ../src/common/fmapbase.cpp:200
+msgid "MacHebrew"
+msgstr "Mac (heprealainen)"
+
+#: ../src/common/fmapbase.cpp:201
+msgid "MacGreek"
+msgstr "Mac (kreikkalainen)"
+
+#: ../src/common/fmapbase.cpp:202
+msgid "MacCyrillic"
+msgstr "Mac (kyrillinen)"
+
+#: ../src/common/fmapbase.cpp:203
+msgid "MacDevanagari"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:204
+msgid "MacGurmukhi"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:205
+msgid "MacGujarati"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:206
+msgid "MacOriya"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:207
+msgid "MacBengali"
+msgstr "Mac (bengalilainen)"
+
+#: ../src/common/fmapbase.cpp:208
+msgid "MacTamil"
+msgstr "Mac (tamililainen)"
+
+#: ../src/common/fmapbase.cpp:209
+msgid "MacTelugu"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:210
+msgid "MacKannada"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:211
+msgid "MacMalayalam"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:212
+#, fuzzy
+msgid "MacSinhalese"
+msgstr "Sama kirjainkoko"
+
+#: ../src/common/fmapbase.cpp:213
+msgid "MacBurmese"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:214
+msgid "MacKhmer"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:215
+msgid "MacThai"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:216
+msgid "MacLaotian"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:217
+msgid "MacGeorgian"
+msgstr "Mac (georgialainen)"
+
+#: ../src/common/fmapbase.cpp:218
+msgid "MacArmenian"
+msgstr "Mac (armenialainen)"
+
+#: ../src/common/fmapbase.cpp:219
+msgid "MacChineseSimp"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:220
+msgid "MacTibetan"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:221
+msgid "MacMongolian"
+msgstr "Mac (mongolialainen)"
+
+#: ../src/common/fmapbase.cpp:222
+msgid "MacEthiopic"
+msgstr "Mac (etiopialainen)"
+
+#: ../src/common/fmapbase.cpp:223
+msgid "MacCentralEurRoman"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:224
+msgid "MacVietnamese"
+msgstr "Mac (vietnamilainen)"
+
+#: ../src/common/fmapbase.cpp:225
+#, fuzzy
+msgid "MacExtArabic"
+msgstr "Arabialainen"
+
+#: ../src/common/fmapbase.cpp:226
+#, fuzzy
+msgid "MacSymbol"
+msgstr "Symboli"
+
+#: ../src/common/fmapbase.cpp:227
+msgid "MacDingbats"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:228
+msgid "MacTurkish"
+msgstr "Mac (turkkilainen)"
+
+#: ../src/common/fmapbase.cpp:229
+msgid "MacCroatian"
+msgstr "Mac (kroatialainen)"
+
+#: ../src/common/fmapbase.cpp:230
+msgid "MacIcelandic"
+msgstr "Mac (islantilainen)"
+
+#: ../src/common/fmapbase.cpp:231
+#, fuzzy
+msgid "MacRomanian"
+msgstr "Roman"
+
+#: ../src/common/fmapbase.cpp:232
+msgid "MacCeltic"
+msgstr "Mac (kelttiläinen)"
+
+#: ../src/common/fmapbase.cpp:233
+msgid "MacGaelic"
+msgstr "MacGaelic"
+
+#: ../src/common/fmapbase.cpp:234
+msgid "MacKeyboardGlyphs"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:791
+msgid "Default encoding"
+msgstr "Oletuskoodaus"
+
+#: ../src/common/fmapbase.cpp:805
+#, c-format
+msgid "Unknown encoding (%d)"
+msgstr "Tuntematon koodaus (%d)"
+
+#: ../src/common/fmapbase.cpp:815 ../src/richtext/richtextstyles.cpp:776
+msgid "default"
+msgstr "oletus"
+
+#: ../src/common/fmapbase.cpp:829
+#, c-format
+msgid "unknown-%d"
+msgstr "tuntematon-%d"
+
+#: ../src/common/fontcmn.cpp:924 ../src/common/fontcmn.cpp:1130
+msgid "underlined"
+msgstr "alleviivattu"
+
+#: ../src/common/fontcmn.cpp:929
+msgid " strikethrough"
+msgstr " yliviivaus"
+
+#: ../src/common/fontcmn.cpp:942
+msgid " thin"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:946
+#, fuzzy
+msgid " extra light"
+msgstr " heikko"
+
+#: ../src/common/fontcmn.cpp:950
+msgid " light"
+msgstr " heikko"
+
+#: ../src/common/fontcmn.cpp:954
+msgid " medium"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:958
+#, fuzzy
+msgid " semi bold"
+msgstr " lihavoitu"
+
+#: ../src/common/fontcmn.cpp:962
+msgid " bold"
+msgstr " lihavoitu"
+
+#: ../src/common/fontcmn.cpp:966
+#, fuzzy
+msgid " extra bold"
+msgstr " lihavoitu"
+
+#: ../src/common/fontcmn.cpp:970
+msgid " heavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:974
+msgid " extra heavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:990
+msgid " italic"
+msgstr " kursivoitu"
+
+#: ../src/common/fontcmn.cpp:1134
+#, fuzzy
+msgid "strikethrough"
+msgstr "Yliviivaus"
+
+#: ../src/common/fontcmn.cpp:1143
+msgid "thin"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1156
+#, fuzzy
+msgid "extralight"
+msgstr "heikko"
+
+#: ../src/common/fontcmn.cpp:1161
+msgid "light"
+msgstr "heikko"
+
+#: ../src/common/fontcmn.cpp:1169 ../src/richtext/richtextstyles.cpp:775
+msgid "normal"
+msgstr "tavallinen"
+
+#: ../src/common/fontcmn.cpp:1174
+msgid "medium"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1179 ../src/common/fontcmn.cpp:1199
+#, fuzzy
+msgid "semibold"
+msgstr "lihavoitu"
+
+#: ../src/common/fontcmn.cpp:1184
+msgid "bold"
+msgstr "lihavoitu"
+
+#: ../src/common/fontcmn.cpp:1194
+#, fuzzy
+msgid "extrabold"
+msgstr "lihavoitu"
+
+#: ../src/common/fontcmn.cpp:1204
+msgid "heavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1212
+msgid "extraheavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1217
+msgid "italic"
+msgstr "kursivoitu"
+
+#: ../src/common/fontmap.cpp:195
+msgid ": unknown charset"
+msgstr ": tuntematon merkistö"
+
+#: ../src/common/fontmap.cpp:199
+#, c-format
+msgid ""
+"The charset '%s' is unknown. You may select\n"
+"another charset to replace it with or choose\n"
+"[Cancel] if it cannot be replaced"
+msgstr ""
+"Merkistö ”%s” on tuntematon. Sen tilalle\n"
+"voi valita toisen merkistön. Ellei korvaavaa\n"
+"merkistöä ole, valitse [Peruuta]."
+
+#: ../src/common/fontmap.cpp:241
+#, c-format
+msgid "Failed to remember the encoding for the charset '%s'."
+msgstr "Merkistön ”%s” koodaus on unohtunut."
+
+#: ../src/common/fontmap.cpp:321
+msgid "can't load any font, aborting"
+msgstr "ei voi ladata yhtäkään fonttia, lopetetaan"
+
+#: ../src/common/fontmap.cpp:409
+msgid ": unknown encoding"
+msgstr ": tuntematon koodaus"
+
+#: ../src/common/fontmap.cpp:417
+#, fuzzy, c-format
+msgid ""
+"No font for displaying text in encoding '%s' found,\n"
+"but an alternative encoding '%s' is available.\n"
+"Do you want to use this encoding (otherwise you will have to choose another "
+"one)?"
+msgstr ""
+"Koodaus ”%s” on tuntematon, mutta vaihtoehtoinen\n"
+"koodaus ”%s” on saatavilla.\n"
+"Haluatko käyttää tätä koodausta (muutoin joudut valitsemaan toisen)?"
+
+#: ../src/common/fontmap.cpp:422
+#, fuzzy, c-format
+msgid ""
+"No font for displaying text in encoding '%s' found.\n"
+"Would you like to select a font to be used for this encoding\n"
+"(otherwise the text in this encoding will not be shown correctly)?"
+msgstr ""
+"Koodaus ”%s” on tuntematon.\n"
+"Haluatko valita kirjasintyypin, jota käytetään tähän?\n"
+"(Muutoin tällä koodauksella olevaa teksiä ei näytetä oikein)"
+
+#: ../src/common/fs_mem.cpp:169
+#, c-format
+msgid "Memory VFS already contains file '%s'!"
+msgstr "Muisti-VFS sisältää jo tiedoston ”%s”!"
+
+#: ../src/common/fs_mem.cpp:232
+#, c-format
+msgid "Trying to remove file '%s' from memory VFS, but it is not loaded!"
+msgstr ""
+"Tiedosto ”%s” yritettiin poistaa Muisti-VFS:stä, mutta se ei ole ladattu!"
+
+#: ../src/common/fs_mem.cpp:262
+#, c-format
+msgid "Failed to store image '%s' to memory VFS!"
+msgstr "Kuvan ”%s” tallennus Muisti-VFS:ään epäonnistui!"
+
+#: ../src/common/ftp.cpp:197
+msgid "Timeout while waiting for FTP server to connect, try passive mode."
+msgstr ""
+"Aikakatkaisu tapahtui yhteydenotossa FTP-palvelimeen, kokeile passiivista "
+"tilaa."
+
+#: ../src/common/ftp.cpp:399
+#, c-format
+msgid "Failed to set FTP transfer mode to %s."
+msgstr "FTP:n siirtotilan %s asetus epäonnistui."
+
+#: ../src/common/ftp.cpp:400 ../src/richtext/richtextsymboldlg.cpp:432
+msgid "ASCII"
+msgstr "ASCII"
+
+#: ../src/common/ftp.cpp:400
+msgid "binary"
+msgstr "binääri"
+
+#: ../src/common/ftp.cpp:608
+msgid "The FTP server doesn't support the PORT command."
+msgstr "FTP-palvelin ei tue komentoa PORT."
+
+#: ../src/common/ftp.cpp:622
+msgid "The FTP server doesn't support passive mode."
+msgstr "FTP-palvelin ei tue passiivista tilaa."
+
+#: ../src/common/gifdecod.cpp:822
+#, c-format
+msgid "Incorrect GIF frame size (%u, %d) for the frame #%u"
+msgstr "Virheellinen GIF-kehyksen koko (%u, %d) kehykselle #%u"
+
+#: ../src/common/glcmn.cpp:108
+#, fuzzy
+msgid "Failed to allocate colour for OpenGL"
+msgstr "Osoittimen luonti epäonnistui."
+
+#: ../src/common/headerctrlcmn.cpp:57
+msgid "Please select the columns to show and define their order:"
+msgstr "Valitse näytettävät sarakkeet ja määritä niiden järjestys:"
+
+#: ../src/common/headerctrlcmn.cpp:58
+#, fuzzy
+msgid "Customize Columns"
+msgstr "Valinnainen koko"
+
+#: ../src/common/headerctrlcmn.cpp:304
+msgid "&Customize..."
+msgstr "&Mukauta..."
+
+#: ../src/common/hyperlnkcmn.cpp:132
+#, fuzzy, c-format
+msgid "Failed to open URL \"%s\" in the default browser"
+msgstr "URL-osoitetta ”%s” ei voitu avata oletusselaimessa."
+
+#: ../src/common/iconbndl.cpp:195
+#, fuzzy, c-format
+msgid "Failed to load image %%d from file '%s'."
+msgstr "Kuvaa %d ei voi ladata tiedostosta ”%s”."
+
+#: ../src/common/iconbndl.cpp:203
+#, fuzzy, c-format
+msgid "Failed to load image %d from stream."
+msgstr "Kuvaa %d ei voi ladata tiedostosta ”%s”."
+
+#: ../src/common/iconbndl.cpp:221
+#, fuzzy, c-format
+msgid "Failed to load icons from resource '%s'."
+msgstr "Kuvaa %d ei voi ladata tiedostosta ”%s”."
+
+#: ../src/common/imagbmp.cpp:97
+msgid "BMP: Couldn't save invalid image."
+msgstr "BMP: Virheellistä kuvaa ei voitu tallentaa."
+
+#: ../src/common/imagbmp.cpp:137
+msgid "BMP: wxImage doesn't have own wxPalette."
+msgstr "BMP: wxImage:lla ei ole omaa wxPalette:a."
+
+#: ../src/common/imagbmp.cpp:243
+msgid "BMP: Couldn't write the file (Bitmap) header."
+msgstr "BMP: Tiedoston otsaketta (Bitmap) ei voitu kirjoittaa."
+
+#: ../src/common/imagbmp.cpp:266
+msgid "BMP: Couldn't write the file (BitmapInfo) header."
+msgstr "BMP: En voinut kirjoittaa tiedoston (BitmapInfo) otsaketta."
+
+#: ../src/common/imagbmp.cpp:353
+msgid "BMP: Couldn't write RGB color map."
+msgstr "BMP: RGB-värikarttaa ei voitu kirjoittaa."
+
+#: ../src/common/imagbmp.cpp:487
+msgid "BMP: Couldn't write data."
+msgstr "BMP: Dataa ei voitu kirjoittaa."
+
+#: ../src/common/imagbmp.cpp:561 ../src/common/imagbmp.cpp:642
+msgid "BMP: Couldn't allocate memory."
+msgstr "BMP: Muistin varaaminen epäonnistui."
+
+#: ../src/common/imagbmp.cpp:1041
+msgid "DIB Header: Image width > 32767 pixels for file."
+msgstr "DIB Otsake: Kuvan leveys > 32767 pikseliä."
+
+#: ../src/common/imagbmp.cpp:1049
+msgid "DIB Header: Image height > 32767 pixels for file."
+msgstr "DIB Otsake: Kuvan korkeus > 32767 pikseliä."
+
+#: ../src/common/imagbmp.cpp:1081
+msgid "DIB Header: Unknown bitdepth in file."
+msgstr "DIB Otsake: tuntematon bittisyvyys."
+
+#: ../src/common/imagbmp.cpp:1156
+msgid "DIB Header: Unknown encoding in file."
+msgstr "DIB Otsake: Tiedostolla tuntematon koodaus."
+
+#: ../src/common/imagbmp.cpp:1165
+msgid "DIB Header: Encoding doesn't match bitdepth."
+msgstr "DIB Otsake: Koodaus ei vastaa bittisyvyyttä."
+
+#: ../src/common/imagbmp.cpp:1180
+#, c-format
+msgid "BMP Header: Invalid number of colors (%d)."
+msgstr ""
+
+#: ../src/common/imagbmp.cpp:1273
+msgid "Error in reading image DIB."
+msgstr "DIB: virhe kuvan lukemisessa ."
+
+#: ../src/common/imagbmp.cpp:1294
+msgid "ICO: Error in reading mask DIB."
+msgstr "ICO: Virhe DIB peitteen lukemisessa."
+
+#: ../src/common/imagbmp.cpp:1353
+msgid "ICO: Image too tall for an icon."
+msgstr "ICO: Kuva liian suuri kuvakkeeksi."
+
+#: ../src/common/imagbmp.cpp:1361
+msgid "ICO: Image too wide for an icon."
+msgstr "ICO: Kuva liian leveä kuvakkeeksi."
+
+#: ../src/common/imagbmp.cpp:1388 ../src/common/imagbmp.cpp:1488
+#: ../src/common/imagbmp.cpp:1503 ../src/common/imagbmp.cpp:1514
+#: ../src/common/imagbmp.cpp:1528 ../src/common/imagbmp.cpp:1576
+#: ../src/common/imagbmp.cpp:1591 ../src/common/imagbmp.cpp:1605
+#: ../src/common/imagbmp.cpp:1616
+msgid "ICO: Error writing the image file!"
+msgstr "ICO: Virhe kuvatiedoston kirjoittamisessa."
+
+#: ../src/common/imagbmp.cpp:1701
+msgid "ICO: Invalid icon index."
+msgstr "ICO: Väärä kuvake-indeksi."
+
+#: ../src/common/image.cpp:2410
+msgid "Image and mask have different sizes."
+msgstr "Kuvan ja peitteen koot ovat erisuuruiset."
+
+#: ../src/common/image.cpp:2418 ../src/common/image.cpp:2459
+msgid "No unused colour in image being masked."
+msgstr ""
+
+#: ../src/common/image.cpp:2641
+#, fuzzy, c-format
+msgid "Failed to load bitmap \"%s\" from resources."
+msgstr "Kuvaa %d ei voi ladata tiedostosta ”%s”."
+
+#: ../src/common/image.cpp:2650
+#, fuzzy, c-format
+msgid "Failed to load icon \"%s\" from resources."
+msgstr "Kuvaa %d ei voi ladata tiedostosta ”%s”."
+
+#: ../src/common/image.cpp:2728 ../src/common/image.cpp:2747
+#, fuzzy, c-format
+msgid "Failed to load image from file \"%s\"."
+msgstr "Kuvaa %d ei voi ladata tiedostosta ”%s”."
+
+#: ../src/common/image.cpp:2761
+#, c-format
+msgid "Can't save image to file '%s': unknown extension."
+msgstr "Tiedostoon ”%s” ei voi tallentaa kuvaa: tuntematon tiedostopääte."
+
+#: ../src/common/image.cpp:2869
+msgid "No handler found for image type."
+msgstr "Kuvatyypin käsittelijää ei löytynyt."
+
+#: ../src/common/image.cpp:2877 ../src/common/image.cpp:3000
+#: ../src/common/image.cpp:3066
+#, fuzzy, c-format
+msgid "No image handler for type %d defined."
+msgstr "Kuvatyypin %d käsittelijää ei määritelty."
+
+#: ../src/common/image.cpp:2887
+#, fuzzy, c-format
+msgid "Image file is not of type %d."
+msgstr "Kuvatiedoston tyyppi ei ole %ld."
+
+#: ../src/common/image.cpp:2970
+msgid "Can't automatically determine the image format for non-seekable input."
+msgstr ""
+"Kuvamuotoa ei voi määrittää automaattisesti syötteelle, joka ei ole "
+"haettavissa."
+
+#: ../src/common/image.cpp:2988
+#, fuzzy
+msgid "Unknown image data format."
+msgstr "virhe dataformaatissa"
+
+#: ../src/common/image.cpp:3009
+#, fuzzy, c-format
+msgid "This is not a %s."
+msgstr "PCX: tämä ei ole PCX tiedosto."
+
+#: ../src/common/image.cpp:3032 ../src/common/image.cpp:3080
+#, fuzzy, c-format
+msgid "No image handler for type %s defined."
+msgstr "Kuvatyypin %s käsittelyohjelmaa ei määritelty."
+
+#: ../src/common/image.cpp:3041
+#, fuzzy, c-format
+msgid "Image is not of type %s."
+msgstr "Kuvatiedoston tyyppi ei ole %s."
+
+#: ../src/common/image.cpp:3509
+#, fuzzy, c-format
+msgid "Failed to check format of image file \"%s\"."
+msgstr "Kuvaa %d ei voi ladata tiedostosta ”%s”."
+
+#: ../src/common/imaggif.cpp:124
+msgid "GIF: error in GIF image format."
+msgstr "GIF: virhe GIF-kuvamuodossa."
+
+#: ../src/common/imaggif.cpp:129
+msgid "GIF: not enough memory."
+msgstr "GIF: ei riittävästi muistia."
+
+#: ../src/common/imaggif.cpp:134
+msgid "GIF: data stream seems to be truncated."
+msgstr "GIF: datan virta typistetty."
+
+#: ../src/common/imaggif.cpp:240
+#, fuzzy
+msgid "Couldn't initialize GIF hash table."
+msgstr "Zlib deflate -virtaa ei pystytä alustamaan."
+
+#: ../src/common/imagiff.cpp:739
+msgid "IFF: error in IFF image format."
+msgstr "IFF: virhe IFF-kuvamuodossa."
+
+#: ../src/common/imagiff.cpp:742
+msgid "IFF: not enough memory."
+msgstr "IFF: ei riittävästi muistia."
+
+#: ../src/common/imagiff.cpp:745
+msgid "IFF: unknown error!!!"
+msgstr "IFF: tuntematon virhe!!!"
+
+#: ../src/common/imagiff.cpp:755
+msgid "IFF: data stream seems to be truncated."
+msgstr "IFF: datavirta on typistetty."
+
+#: ../src/common/imagjpeg.cpp:258
+msgid "JPEG: Couldn't load - file is probably corrupted."
+msgstr "JPEG-kuvan lataus ei onnistu - tiedosto ehkä korruptoitunut."
+
+#: ../src/common/imagjpeg.cpp:437
+msgid "JPEG: Couldn't save image."
+msgstr "JPEG: Ei voinut tallentaa kuvaa"
+
+#: ../src/common/imagpcx.cpp:439
+msgid "PCX: this is not a PCX file."
+msgstr "PCX: tämä ei ole PCX tiedosto."
+
+#: ../src/common/imagpcx.cpp:453
+msgid "PCX: image format unsupported"
+msgstr "PCX: kuva-muotoa ei tuettu"
+
+#: ../src/common/imagpcx.cpp:454 ../src/common/imagpcx.cpp:477
+msgid "PCX: couldn't allocate memory"
+msgstr "PCX: muistia ei voitu varata"
+
+#: ../src/common/imagpcx.cpp:455
+msgid "PCX: version number too low"
+msgstr "PCX: Liian pieni versionumero"
+
+#: ../src/common/imagpcx.cpp:456 ../src/common/imagpcx.cpp:478
+msgid "PCX: unknown error !!!"
+msgstr "PCX: tuntematon virhe !!!"
+
+#: ../src/common/imagpcx.cpp:476
+msgid "PCX: invalid image"
+msgstr "PCX: virheellinen kuva"
+
+#: ../src/common/imagpng.cpp:385
+#, fuzzy, c-format
+msgid "Unknown PNG resolution unit %d"
+msgstr "Tuntematon valitsin ”%s”"
+
+#: ../src/common/imagpng.cpp:439
+msgid "Couldn't load a PNG image - file is corrupted or not enough memory."
+msgstr ""
+"PNG-kuvan lataus ei onnistunut - tiedosto korruptoitunut tai ei tarpeeksi "
+"muistia."
+
+#: ../src/common/imagpng.cpp:513 ../src/common/imagpng.cpp:524
+#: ../src/common/imagpng.cpp:534
+msgid "Couldn't save PNG image."
+msgstr "JPEG: Ei voinut tallentaa kuvaa"
+
+#: ../src/common/imagpnm.cpp:71
+msgid "PNM: File format is not recognized."
+msgstr "PNM: Tuntematon tiedostomuoto."
+
+#: ../src/common/imagpnm.cpp:89
+msgid "PNM: Couldn't allocate memory."
+msgstr "PNM: Muistin varaaminen epäonnistui."
+
+#: ../src/common/imagpnm.cpp:111 ../src/common/imagpnm.cpp:134
+#: ../src/common/imagpnm.cpp:156
+msgid "PNM: File seems truncated."
+msgstr "PNM: Tiedosto on ehkä typistetty."
+
+#: ../src/common/imagtiff.cpp:69
+#, fuzzy, c-format
+msgid " (in module \"%s\")"
+msgstr "tiff-moduuli: %s"
+
+#: ../src/common/imagtiff.cpp:304
+msgid "TIFF: Error loading image."
+msgstr "TIFF: Virhe kuvan latauksessa."
+
+#: ../src/common/imagtiff.cpp:314
+msgid "Invalid TIFF image index."
+msgstr "Virheellinen TIFF-kuvaindeksi."
+
+#: ../src/common/imagtiff.cpp:358
+msgid "TIFF: Image size is abnormally big."
+msgstr ""
+
+#: ../src/common/imagtiff.cpp:372 ../src/common/imagtiff.cpp:385
+#: ../src/common/imagtiff.cpp:769
+msgid "TIFF: Couldn't allocate memory."
+msgstr "TIFF: Muistinvaraus epäonnistui."
+
+#: ../src/common/imagtiff.cpp:471
+msgid "TIFF: Error reading image."
+msgstr "TIFF: Virhe kuvan lukemisessa ."
+
+#: ../src/common/imagtiff.cpp:532
+#, c-format
+msgid "Unknown TIFF resolution unit %d ignored"
+msgstr ""
+
+#: ../src/common/imagtiff.cpp:611
+msgid "TIFF: Error saving image."
+msgstr "TIFF: Virhe kuvan tallennuksesa."
+
+#: ../src/common/imagtiff.cpp:868
+msgid "TIFF: Error writing image."
+msgstr "TIFF: Virhe kuvan kirjoituksessa."
+
+#: ../src/common/imagtiff.cpp:881
+#, fuzzy
+msgid "TIFF: Error flushing data."
+msgstr "TIFF: Virhe kuvan tallennuksesa."
+
+#: ../src/common/imagwebp.cpp:56
+msgid "WebP: Invalid data (failed to get features)."
+msgstr ""
+
+#: ../src/common/imagwebp.cpp:65
+msgid "WebP: Allocating image memory failed."
+msgstr ""
+
+#: ../src/common/imagwebp.cpp:82
+msgid "WebP: Decoding RGBA image data failed."
+msgstr ""
+
+#: ../src/common/imagwebp.cpp:98
+msgid "WebP: Decoding RGB image data failed."
+msgstr ""
+
+#: ../src/common/imagwebp.cpp:113 ../src/common/imagwebp.cpp:201
+msgid "WebP: Allocating stream buffer failed."
+msgstr ""
+
+#: ../src/common/imagwebp.cpp:131
+#, fuzzy
+msgid "WebP: Failed to parse container data."
+msgstr "Leikepöydän datan asetus epäonnistui."
+
+#: ../src/common/imagwebp.cpp:222
+#, fuzzy
+msgid "WebP: Error decoding animation."
+msgstr "Virhe asetusten lukemisessa."
+
+#: ../src/common/imagwebp.cpp:240
+msgid "WebP: Error getting next animation frame."
+msgstr ""
+
+#: ../src/common/init.cpp:172
+#, c-format
+msgid ""
+"Command line argument %d couldn't be converted to Unicode and will be "
+"ignored."
+msgstr ""
+"Komentoriviparametria %d ei voitu muuntaa Unicode-merkistöön, joten se "
+"ohitetaan ."
+
+#: ../src/common/init.cpp:344
+msgid "Initialization failed in post init, aborting."
+msgstr "Alustus epäonnistui jälkialustuksessa, keskeytetään."
+
+#: ../src/common/intl.cpp:378
+#, fuzzy, c-format
+msgid "Cannot set locale to language \"%s\"."
+msgstr "Kieliasetusta ei voida asettaa kieleen ”%s”"
+
+#: ../src/common/log.cpp:232
+msgid "Error: "
+msgstr "Virhe: "
+
+#: ../src/common/log.cpp:236
+msgid "Warning: "
+msgstr "Varoitus: "
+
+#: ../src/common/log.cpp:284
+msgid "The previous message repeated once."
+msgstr ""
+
+#: ../src/common/log.cpp:291
+#, c-format
+msgid "The previous message repeated %u time."
+msgid_plural "The previous message repeated %u times."
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../src/common/log.cpp:319
+#, c-format
+msgid "Last repeated message (\"%s\", %u time) wasn't output"
+msgid_plural "Last repeated message (\"%s\", %u times) wasn't output"
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../src/common/log.cpp:435
+#, c-format
+msgid " (error %ld: %s)"
+msgstr " (virhe %ld: %s)"
+
+#: ../src/common/lzmastream.cpp:121
+#, fuzzy
+msgid "Failed to allocate memory for LZMA decompression."
+msgstr "Osoittimen luonti epäonnistui."
+
+#: ../src/common/lzmastream.cpp:125
+#, c-format
+msgid "Failed to initialize LZMA decompression: unexpected error %u."
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:179
+msgid "input is not in XZ format"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:183
+msgid "input compressed using unknown XZ option"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:188
+msgid "input is corrupted"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:192
+#, fuzzy
+msgid "unknown decompression error"
+msgstr "purkamisvirhe"
+
+#: ../src/common/lzmastream.cpp:196
+#, fuzzy, c-format
+msgid "LZMA decompression error: %s"
+msgstr "purkamisvirhe"
+
+#: ../src/common/lzmastream.cpp:231
+#, fuzzy
+msgid "Failed to allocate memory for LZMA compression."
+msgstr "Osoittimen luonti epäonnistui."
+
+#: ../src/common/lzmastream.cpp:235
+#, c-format
+msgid "Failed to initialize LZMA compression: unexpected error %u."
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:267 ../src/common/lzmastream.cpp:342
+#: ../src/html/chm.cpp:336
+msgid "out of memory"
+msgstr "muisti loppu"
+
+#: ../src/common/lzmastream.cpp:276 ../src/common/lzmastream.cpp:346
+#, fuzzy
+msgid "unknown compression error"
+msgstr "pakkausvirhe"
+
+#: ../src/common/lzmastream.cpp:280
+#, fuzzy, c-format
+msgid "LZMA compression error: %s"
+msgstr "pakkausvirhe"
+
+#: ../src/common/lzmastream.cpp:350
+#, c-format
+msgid "LZMA compression error when flushing output: %s"
+msgstr ""
+
+#: ../src/common/mimecmn.cpp:167
+#, c-format
+msgid "Unmatched '{' in an entry for mime type %s."
+msgstr "Pariton ”{” mime-tyyppi-merkinnässä %s."
+
+#: ../src/common/module.cpp:76
+#, c-format
+msgid "Circular dependency involving module \"%s\" detected."
+msgstr "Moduulin \"%s\" sisältävä kiertoriippuvuus havaittu."
+
+#: ../src/common/module.cpp:128
+#, fuzzy, c-format
+msgid "Dependency \"%s\" of module \"%s\" doesn't exist."
+msgstr "Riippuvuutta ”%s” moduulille ”%s” ei ole."
+
+#: ../src/common/module.cpp:137
+#, fuzzy, c-format
+msgid "Module \"%s\" initialization failed"
+msgstr "Moduulin ”%s” alustus epäonnistui"
+
+#: ../src/common/msgout.cpp:96
+#, fuzzy
+msgid "Message"
+msgstr "%s-viesti"
+
+#: ../src/common/paper.cpp:70
+#, fuzzy
+msgid "Letter, 8 1/2 x 11 in"
+msgstr "Letter 8 1/2 x 11” "
+
+#: ../src/common/paper.cpp:71
+#, fuzzy
+msgid "Legal, 8 1/2 x 14 in"
+msgstr "Legal 8 1/2 x 14” "
+
+#: ../src/common/paper.cpp:72
+msgid "A4 sheet, 210 x 297 mm"
+msgstr "A4-paperi, 210 ä 297 mm"
+
+#: ../src/common/paper.cpp:73
+msgid "C sheet, 17 x 22 in"
+msgstr "C-arkki, 17″ x 22″"
+
+#: ../src/common/paper.cpp:74
+msgid "D sheet, 22 x 34 in"
+msgstr "D-arkki, 22″ x 34″"
+
+#: ../src/common/paper.cpp:75
+msgid "E sheet, 34 x 44 in"
+msgstr "E-arkki, 34″ x 44″"
+
+#: ../src/common/paper.cpp:76
+#, fuzzy
+msgid "Letter Small, 8 1/2 x 11 in"
+msgstr "Letter (pieni) 8 1/2 x 11” "
+
+#: ../src/common/paper.cpp:77
+#, fuzzy
+msgid "Tabloid, 11 x 17 in"
+msgstr "Tabloid, 11 x 17” "
+
+#: ../src/common/paper.cpp:78
+#, fuzzy
+msgid "Ledger, 17 x 11 in"
+msgstr "Ledger, 17 x 11” "
+
+#: ../src/common/paper.cpp:79
+#, fuzzy
+msgid "Statement, 5 1/2 x 8 1/2 in"
+msgstr "Statement, 5 1/2 x 8 1/2” "
+
+#: ../src/common/paper.cpp:80
+#, fuzzy
+msgid "Executive, 7 1/4 x 10 1/2 in"
+msgstr "Executive, 7 1/4 x 10 1/2” "
+
+#: ../src/common/paper.cpp:81
+msgid "A3 sheet, 297 x 420 mm"
+msgstr "A3-paperi 297 ä 420 mm"
+
+#: ../src/common/paper.cpp:82
+msgid "A4 small sheet, 210 x 297 mm"
+msgstr "A4 pieni arkki, 210 x 297 mm"
+
+#: ../src/common/paper.cpp:83
+msgid "A5 sheet, 148 x 210 mm"
+msgstr "A5-arkki, 148 x 210 mm"
+
+#: ../src/common/paper.cpp:84
+msgid "B4 sheet, 250 x 354 mm"
+msgstr "B4-paperi, 250 ä 354 mm"
+
+#: ../src/common/paper.cpp:85
+msgid "B5 sheet, 182 x 257 millimeter"
+msgstr "B5-paperi, 182 ä 257 mm"
+
+#: ../src/common/paper.cpp:86
+msgid "Folio, 8 1/2 x 13 in"
+msgstr "Folio, 8 1/2″ x 13″"
+
+#: ../src/common/paper.cpp:87
+#, fuzzy
+msgid "Quarto, 215 x 275 mm"
+msgstr "Quarto, 215 x 275 mm"
+
+#: ../src/common/paper.cpp:88
+msgid "10 x 14 in"
+msgstr "10″ x 14″"
+
+#: ../src/common/paper.cpp:89
+msgid "11 x 17 in"
+msgstr "11″ x 17″"
+
+#: ../src/common/paper.cpp:90
+#, fuzzy
+msgid "Note, 8 1/2 x 11 in"
+msgstr "Note, 8 1/2 x 11” "
+
+#: ../src/common/paper.cpp:91
+msgid "#9 Envelope, 3 7/8 x 8 7/8 in"
+msgstr "#9 kirjekuori, 3 7/8″ x 8 7/8″"
+
+#: ../src/common/paper.cpp:92
+msgid "#10 Envelope, 4 1/8 x 9 1/2 in"
+msgstr "#10 kirjekuori, 4 1/8″ x 9 1/2″"
+
+#: ../src/common/paper.cpp:93
+msgid "#11 Envelope, 4 1/2 x 10 3/8 in"
+msgstr "#11 kirjekuori, 4 1/2″ x 10 3/8″"
+
+#: ../src/common/paper.cpp:94
+msgid "#12 Envelope, 4 3/4 x 11 in"
+msgstr "#12 kirjekuori, 4 3/4″ x 11″"
+
+#: ../src/common/paper.cpp:95
+msgid "#14 Envelope, 5 x 11 1/2 in"
+msgstr "#14 kirjekuori, 5″ x 11 1/2″"
+
+#: ../src/common/paper.cpp:96
+msgid "DL Envelope, 110 x 220 mm"
+msgstr "DL kirjekuori, 110 x 220 mm"
+
+#: ../src/common/paper.cpp:97
+msgid "C5 Envelope, 162 x 229 mm"
+msgstr "C5 kirjekuori, 162 x 229 mm"
+
+#: ../src/common/paper.cpp:98
+msgid "C3 Envelope, 324 x 458 mm"
+msgstr "C3 kirjekuori, 324 x 458 mm"
+
+#: ../src/common/paper.cpp:99
+msgid "C4 Envelope, 229 x 324 mm"
+msgstr "C4 kirjekuori, 229 x 324 mm"
+
+#: ../src/common/paper.cpp:100
+msgid "C6 Envelope, 114 x 162 mm"
+msgstr "C6 kirjekuori, 114 x 162 mm"
+
+#: ../src/common/paper.cpp:101
+msgid "C65 Envelope, 114 x 229 mm"
+msgstr "C65 kirjekuori, 114 x 229 mm"
+
+#: ../src/common/paper.cpp:102
+msgid "B4 Envelope, 250 x 353 mm"
+msgstr "B4 kirjekuori, 250 x 353 mm"
+
+#: ../src/common/paper.cpp:103
+msgid "B5 Envelope, 176 x 250 mm"
+msgstr "B5 kirjekuori, 176 x 250 mm"
+
+#: ../src/common/paper.cpp:104
+msgid "B6 Envelope, 176 x 125 mm"
+msgstr "B6 kirjekuori, 176 x 125 mm"
+
+#: ../src/common/paper.cpp:105
+msgid "Italy Envelope, 110 x 230 mm"
+msgstr "Italialainen kirjekuori, 110 x 230 mm"
+
+#: ../src/common/paper.cpp:106
+#, fuzzy
+msgid "Monarch Envelope, 3 7/8 x 7 1/2 in"
+msgstr "Monarch Envelope, 3 7/8 x 7 1/2” "
+
+#: ../src/common/paper.cpp:107
+msgid "6 3/4 Envelope, 3 5/8 x 6 1/2 in"
+msgstr "6 3/4 kirjekuori, 3 5/8″ x 6 1/2″"
+
+#: ../src/common/paper.cpp:108
+#, fuzzy
+msgid "US Std Fanfold, 14 7/8 x 11 in"
+msgstr "Vakio traktoriveto, 14 7/8 x 11” "
+
+#: ../src/common/paper.cpp:109
+#, fuzzy
+msgid "German Std Fanfold, 8 1/2 x 12 in"
+msgstr "Eurooppalainen traktoriveto, 8 1/2 x 12” "
+
+#: ../src/common/paper.cpp:110
+#, fuzzy
+msgid "German Legal Fanfold, 8 1/2 x 13 in"
+msgstr "Saksalainen traktoriveto, 8 1/2 x 13” "
+
+#: ../src/common/paper.cpp:112
+msgid "B4 (ISO) 250 x 353 mm"
+msgstr "B4 (ISO) 250 x 353 mm"
+
+#: ../src/common/paper.cpp:113
+msgid "Japanese Postcard 100 x 148 mm"
+msgstr ""
+
+#: ../src/common/paper.cpp:114
+msgid "9 x 11 in"
+msgstr "9″ x 11″"
+
+#: ../src/common/paper.cpp:115
+msgid "10 x 11 in"
+msgstr "10″ x 11″"
+
+#: ../src/common/paper.cpp:116
+msgid "15 x 11 in"
+msgstr "15″ x 11″"
+
+#: ../src/common/paper.cpp:117
+#, fuzzy
+msgid "Envelope Invite 220 x 220 mm"
+msgstr "DL Kirjekuori, 110 x 220 mm"
+
+#: ../src/common/paper.cpp:118
+#, fuzzy
+msgid "Letter Extra 9 1/2 x 12 in"
+msgstr "Letter 8 1/2 x 11” "
+
+#: ../src/common/paper.cpp:119
+#, fuzzy
+msgid "Legal Extra 9 1/2 x 15 in"
+msgstr "Legal 8 1/2 x 14” "
+
+#: ../src/common/paper.cpp:120
+#, fuzzy
+msgid "Tabloid Extra 11.69 x 18 in"
+msgstr "Tabloid, 11 x 17” "
+
+#: ../src/common/paper.cpp:121
+msgid "A4 Extra 9.27 x 12.69 in"
+msgstr "A4 Extra 9.27″ x 12.69″"
+
+#: ../src/common/paper.cpp:122
+#, fuzzy
+msgid "Letter Transverse 8 1/2 x 11 in"
+msgstr "Letter 8 1/2 x 11” "
+
+#: ../src/common/paper.cpp:123
+msgid "A4 Transverse 210 x 297 mm"
+msgstr "A4 poikittain 210 x 297 mm"
+
+#: ../src/common/paper.cpp:124
+msgid "Letter Extra Transverse 9.275 x 12 in"
+msgstr ""
+
+#: ../src/common/paper.cpp:125
+msgid "SuperA/SuperA/A4 227 x 356 mm"
+msgstr "SuperA/SuperA/A4 227 x 356 mm"
+
+#: ../src/common/paper.cpp:126
+msgid "SuperB/SuperB/A3 305 x 487 mm"
+msgstr "SuperB/SuperB/A3 305 x 487 mm"
+
+#: ../src/common/paper.cpp:127
+#, fuzzy
+msgid "Letter Plus 8 1/2 x 12.69 in"
+msgstr "Letter 8 1/2 x 11” "
+
+#: ../src/common/paper.cpp:128
+msgid "A4 Plus 210 x 330 mm"
+msgstr "A4 Plus 210 x 330 mm"
+
+#: ../src/common/paper.cpp:129
+msgid "A5 Transverse 148 x 210 mm"
+msgstr "A5 poikittain 148 x 210 mm"
+
+#: ../src/common/paper.cpp:130
+msgid "B5 (JIS) Transverse 182 x 257 mm"
+msgstr "B5 (JIS) poikittain 182 x 257 mm"
+
+#: ../src/common/paper.cpp:131
+msgid "A3 Extra 322 x 445 mm"
+msgstr "A3 extra 322 x 445 mm"
+
+#: ../src/common/paper.cpp:132
+msgid "A5 Extra 174 x 235 mm"
+msgstr "A5 extra 174 x 235 mm"
+
+#: ../src/common/paper.cpp:133
+msgid "B5 (ISO) Extra 201 x 276 mm"
+msgstr "B5 (ISO) Extra 201 x 276 mm"
+
+#: ../src/common/paper.cpp:134
+msgid "A2 420 x 594 mm"
+msgstr "A2 420 x 594 mm"
+
+#: ../src/common/paper.cpp:135
+msgid "A3 Transverse 297 x 420 mm"
+msgstr "A3 poikittain 297 x 420 mm"
+
+#: ../src/common/paper.cpp:136
+msgid "A3 Extra Transverse 322 x 445 mm"
+msgstr "A3 extra poikittain 322 x 445 mm"
+
+#: ../src/common/paper.cpp:138
+msgid "Japanese Double Postcard 200 x 148 mm"
+msgstr ""
+
+#: ../src/common/paper.cpp:139
+msgid "A6 105 x 148 mm"
+msgstr "A6 105 x 148 mm"
+
+#: ../src/common/paper.cpp:140
+msgid "Japanese Envelope Kaku #2"
+msgstr ""
+
+#: ../src/common/paper.cpp:141
+msgid "Japanese Envelope Kaku #3"
+msgstr ""
+
+#: ../src/common/paper.cpp:142
+msgid "Japanese Envelope Chou #3"
+msgstr ""
+
+#: ../src/common/paper.cpp:143
+msgid "Japanese Envelope Chou #4"
+msgstr ""
+
+#: ../src/common/paper.cpp:144
+#, fuzzy
+msgid "Letter Rotated 11 x 8 1/2 in"
+msgstr "Letter 8 1/2 x 11” "
+
+#: ../src/common/paper.cpp:145
+msgid "A3 Rotated 420 x 297 mm"
+msgstr "A3 käännetty 420 x 297 mm"
+
+#: ../src/common/paper.cpp:146
+msgid "A4 Rotated 297 x 210 mm"
+msgstr "A4 käännetty 297 x 210 mm"
+
+#: ../src/common/paper.cpp:147
+msgid "A5 Rotated 210 x 148 mm"
+msgstr "A5 käännetty 210 x 148 mm"
+
+#: ../src/common/paper.cpp:148
+msgid "B4 (JIS) Rotated 364 x 257 mm"
+msgstr "B4 (JIS) käännetty 364 x 257 mm"
+
+#: ../src/common/paper.cpp:149
+msgid "B5 (JIS) Rotated 257 x 182 mm"
+msgstr "B5 (JIS) käännetty 257 x 182 mm"
+
+#: ../src/common/paper.cpp:150
+msgid "Japanese Postcard Rotated 148 x 100 mm"
+msgstr ""
+
+#: ../src/common/paper.cpp:151
+msgid "Double Japanese Postcard Rotated 148 x 200 mm"
+msgstr "Kaksinkertainen japanilainen postikortti käännetty 148 x 200 mm"
+
+#: ../src/common/paper.cpp:152
+msgid "A6 Rotated 148 x 105 mm"
+msgstr "A6 käännetty 148 x 105 mm"
+
+#: ../src/common/paper.cpp:153
+msgid "Japanese Envelope Kaku #2 Rotated"
+msgstr ""
+
+#: ../src/common/paper.cpp:154
+msgid "Japanese Envelope Kaku #3 Rotated"
+msgstr ""
+
+#: ../src/common/paper.cpp:155
+msgid "Japanese Envelope Chou #3 Rotated"
+msgstr ""
+
+#: ../src/common/paper.cpp:156
+msgid "Japanese Envelope Chou #4 Rotated"
+msgstr ""
+
+#: ../src/common/paper.cpp:157
+msgid "B6 (JIS) 128 x 182 mm"
+msgstr "B6 (JIS) 128 x 182 mm"
+
+#: ../src/common/paper.cpp:158
+msgid "B6 (JIS) Rotated 182 x 128 mm"
+msgstr "B6 (JIS) käännetty 182 x 128 mm"
+
+#: ../src/common/paper.cpp:159
+msgid "12 x 11 in"
+msgstr "12″ x 11″"
+
+#: ../src/common/paper.cpp:160
+msgid "Japanese Envelope You #4"
+msgstr ""
+
+#: ../src/common/paper.cpp:161
+msgid "Japanese Envelope You #4 Rotated"
+msgstr ""
+
+#: ../src/common/paper.cpp:162
+msgid "PRC 16K 146 x 215 mm"
+msgstr "PRC 16K 146 x 215 mm"
+
+#: ../src/common/paper.cpp:163
+msgid "PRC 32K 97 x 151 mm"
+msgstr "PRC 32K 97 x 151 mm"
+
+#: ../src/common/paper.cpp:164
+msgid "PRC 32K(Big) 97 x 151 mm"
+msgstr "PRC 32K(iso) 97 x 151 mm"
+
+#: ../src/common/paper.cpp:165
+msgid "PRC Envelope #1 102 x 165 mm"
+msgstr "PRC-kirjekori #1 102 x 165 mm"
+
+#: ../src/common/paper.cpp:166
+msgid "PRC Envelope #2 102 x 176 mm"
+msgstr "PRC-kirjekuori #2 102 x 176 mm"
+
+#: ../src/common/paper.cpp:167
+msgid "PRC Envelope #3 125 x 176 mm"
+msgstr "PRC-kirjekuori #3 125 x 176 mm"
+
+#: ../src/common/paper.cpp:168
+msgid "PRC Envelope #4 110 x 208 mm"
+msgstr "PRC-kirjekuori #4 110 x 208 mm"
+
+#: ../src/common/paper.cpp:169
+msgid "PRC Envelope #5 110 x 220 mm"
+msgstr "PRC-kirjekuori#5 110 x 220 mm"
+
+#: ../src/common/paper.cpp:170
+msgid "PRC Envelope #6 120 x 230 mm"
+msgstr "PRC-kirjekuori #6 120 x 230 mm"
+
+#: ../src/common/paper.cpp:171
+msgid "PRC Envelope #7 160 x 230 mm"
+msgstr "PRC-kirjekuori #7 160 x 230 mm"
+
+#: ../src/common/paper.cpp:172
+msgid "PRC Envelope #8 120 x 309 mm"
+msgstr "PRC-kirjekuori #8 120 x 309 mm"
+
+#: ../src/common/paper.cpp:173
+msgid "PRC Envelope #9 229 x 324 mm"
+msgstr "PRC-kirjekuori #9 229 x 324 mm"
+
+#: ../src/common/paper.cpp:174
+msgid "PRC Envelope #10 324 x 458 mm"
+msgstr "PRC-kirjekuori #10 324 x 458 mm"
+
+#: ../src/common/paper.cpp:175
+msgid "PRC 16K Rotated"
+msgstr "PRC 16K käännetty"
+
+#: ../src/common/paper.cpp:176
+msgid "PRC 32K Rotated"
+msgstr "PRC 32K käännetty"
+
+#: ../src/common/paper.cpp:177
+msgid "PRC 32K(Big) Rotated"
+msgstr "PRC 32K(iso) käännetty"
+
+#: ../src/common/paper.cpp:178
+msgid "PRC Envelope #1 Rotated 165 x 102 mm"
+msgstr "PRC-kirjekuori #1 käännetty 165 x 102 mm"
+
+#: ../src/common/paper.cpp:179
+msgid "PRC Envelope #2 Rotated 176 x 102 mm"
+msgstr "PRC-kirjekuori #2 käännetty 176 x 102 mm"
+
+#: ../src/common/paper.cpp:180
+msgid "PRC Envelope #3 Rotated 176 x 125 mm"
+msgstr "PRC-kirjekuori #3 käännetty 176 x 125 mm"
+
+#: ../src/common/paper.cpp:181
+msgid "PRC Envelope #4 Rotated 208 x 110 mm"
+msgstr "PRC-kirjekuori #4 käännetty 208 x 110 mm"
+
+#: ../src/common/paper.cpp:182
+msgid "PRC Envelope #5 Rotated 220 x 110 mm"
+msgstr "PRC-kirjekuori #5 käännetty 220 x 110 mm"
+
+#: ../src/common/paper.cpp:183
+msgid "PRC Envelope #6 Rotated 230 x 120 mm"
+msgstr "PRC-kirjekuori #6 käännetty 230 x 120 mm"
+
+#: ../src/common/paper.cpp:184
+msgid "PRC Envelope #7 Rotated 230 x 160 mm"
+msgstr "PRC-kirjekuori #7 käännetty 230 x 160 mm"
+
+#: ../src/common/paper.cpp:185
+msgid "PRC Envelope #8 Rotated 309 x 120 mm"
+msgstr "PRC-kirjekuori #8 käännetty 309 x 120 mm"
+
+#: ../src/common/paper.cpp:186
+msgid "PRC Envelope #9 Rotated 324 x 229 mm"
+msgstr "PRC-kirjekuori #9 käännetty 324 x 229 mm"
+
+#: ../src/common/paper.cpp:187
+msgid "PRC Envelope #10 Rotated 458 x 324 mm"
+msgstr "PRC-kirjekuori #10 käännetty 458 x 324 mm"
+
+#: ../src/common/paper.cpp:192
+msgid "A0 sheet, 841 x 1189 mm"
+msgstr "A0-lomake, 841 x 1189 mm"
+
+#: ../src/common/paper.cpp:193
+msgid "A1 sheet, 594 x 841 mm"
+msgstr "A1lomake, 594 x 841 mm"
+
+#: ../src/common/preferencescmn.cpp:37
+msgid "General"
+msgstr ""
+
+#: ../src/common/preferencescmn.cpp:40
+msgid "Advanced"
+msgstr ""
+
+#: ../src/common/prntbase.cpp:245
+msgid "Generic PostScript"
+msgstr "Generic PostScript"
+
+#: ../src/common/prntbase.cpp:259
+msgid "Ready"
+msgstr "Valmis"
+
+#: ../src/common/prntbase.cpp:331
+msgid "Printing Error"
+msgstr "Tulostusvirhe"
+
+#: ../src/common/prntbase.cpp:413 ../src/common/prntbase.cpp:1597
+#: ../src/generic/prntdlgg.cpp:135 ../src/generic/prntdlgg.cpp:149
+#: ../src/gtk/print.cpp:628 ../src/gtk/print.cpp:646
+msgid "Print"
+msgstr "Tulosta"
+
+#: ../src/common/prntbase.cpp:471 ../src/generic/prntdlgg.cpp:809
+msgid "Page setup"
+msgstr "Sivun asetukset"
+
+#: ../src/common/prntbase.cpp:525
+#, fuzzy
+msgid "Please wait while printing..."
+msgstr "Odota kunnes tulostus loppuu\n"
+
+#: ../src/common/prntbase.cpp:529
+#, fuzzy
+msgid "Document:"
+msgstr "Dokumentaatio:"
+
+#: ../src/common/prntbase.cpp:532
+msgid "Progress:"
+msgstr ""
+
+#: ../src/common/prntbase.cpp:533
+msgid "Preparing"
+msgstr ""
+
+#: ../src/common/prntbase.cpp:552
+#, fuzzy, c-format
+msgid "Printing page %d"
+msgstr "Tulostetaan sivua %d..."
+
+#: ../src/common/prntbase.cpp:557
+#, fuzzy, c-format
+msgid "Printing page %d of %d"
+msgstr "Tulostetaan sivua %d..."
+
+#: ../src/common/prntbase.cpp:560
+#, fuzzy, c-format
+msgid " (copy %d of %d)"
+msgstr "Sivu %d / %d"
+
+#: ../src/common/prntbase.cpp:1604
+#, fuzzy
+msgid "First page"
+msgstr "Seuraava sivu"
+
+#: ../src/common/prntbase.cpp:1609 ../src/html/helpwnd.cpp:659
+msgid "Previous page"
+msgstr "Edellinen sivu"
+
+#: ../src/common/prntbase.cpp:1623 ../src/html/helpwnd.cpp:660
+msgid "Next page"
+msgstr "Seuraava sivu"
+
+#: ../src/common/prntbase.cpp:1628
+#, fuzzy
+msgid "Last page"
+msgstr "Seuraava sivu"
+
+#: ../src/common/prntbase.cpp:1636 ../src/common/stockitem.cpp:215
+#, fuzzy
+msgid "Zoom Out"
+msgstr "Lo&itonna"
+
+#: ../src/common/prntbase.cpp:1650 ../src/common/stockitem.cpp:214
+#, fuzzy
+msgid "Zoom In"
+msgstr "&Lähennä"
+
+#: ../src/common/prntbase.cpp:1656 ../src/common/stockitem.cpp:153
+#: ../src/generic/logg.cpp:553 ../src/univ/themes/win32.cpp:3752
+msgid "&Close"
+msgstr "&Sulje"
+
+#: ../src/common/prntbase.cpp:2085
+msgid "Could not start document preview."
+msgstr "Dokumentin esikatselu epäonnistui."
+
+#: ../src/common/prntbase.cpp:2085 ../src/common/prntbase.cpp:2129
+#: ../src/common/prntbase.cpp:2137
+msgid "Print Preview Failure"
+msgstr "Tulostuksen esikatselu epäonnistui"
+
+#: ../src/common/prntbase.cpp:2129 ../src/common/prntbase.cpp:2137
+msgid "Sorry, not enough memory to create a preview."
+msgstr "Liian vähän muistia esikatseluun."
+
+#: ../src/common/prntbase.cpp:2144
+#, c-format
+msgid "Page %d of %d"
+msgstr "Sivu %d / %d"
+
+#: ../src/common/prntbase.cpp:2146
+#, c-format
+msgid "Page %d"
+msgstr "Sivu %d"
+
+#: ../src/common/regex.cpp:382 ../src/html/chm.cpp:348
+msgid "unknown error"
+msgstr "tuntematon virhe"
+
+#: ../src/common/regex.cpp:995
+#, c-format
+msgid "Invalid regular expression '%s': %s"
+msgstr "Virheellinen säännösetellinen lauseke ”%s”: %s"
+
+#: ../src/common/regex.cpp:1059
+#, c-format
+msgid "Failed to find match for regular expression: %s"
+msgstr "Ei voitu löytää osumia säännölliselle lausekkeelle: %s"
+
+#: ../src/common/rendcmn.cpp:188
+#, c-format
+msgid "Renderer \"%s\" has incompatible version %d.%d and couldn't be loaded."
+msgstr ""
+
+#: ../src/common/secretstore.cpp:162
+msgid "Not available for this platform"
+msgstr ""
+
+#: ../src/common/secretstore.cpp:183
+#, fuzzy, c-format
+msgid "Saving password for \"%s\" failed: %s."
+msgstr "Ei voitu purkaa ”%s”:aa kohteeseen ”%s”."
+
+#: ../src/common/secretstore.cpp:205
+#, fuzzy, c-format
+msgid "Reading password for \"%s\" failed: %s."
+msgstr "Ei voitu purkaa ”%s”:aa kohteeseen ”%s”."
+
+#: ../src/common/secretstore.cpp:228
+#, fuzzy, c-format
+msgid "Deleting password for \"%s\" failed: %s."
+msgstr "Ei voitu purkaa ”%s”:aa kohteeseen ”%s”."
+
+#: ../src/common/selectdispatcher.cpp:254
+msgid "Failed to monitor I/O channels"
+msgstr "I/O-kanavien seuraaminen epäonnistui"
+
+#: ../src/common/sizer.cpp:3054 ../src/common/stockitem.cpp:195
+msgid "Save"
+msgstr "Tallenna"
+
+#: ../src/common/sizer.cpp:3056
+msgid "Don't Save"
+msgstr "älä tallenna"
+
+#: ../src/common/socket.cpp:870
+#, fuzzy
+msgid "Cannot initialize sockets"
+msgstr "OLE:n alustus epäonnistui"
+
+#: ../src/common/stockitem.cpp:127
+#, fuzzy
+msgctxt "standard Windows menu"
+msgid "&Help"
+msgstr "&Ohje"
+
+#: ../src/common/stockitem.cpp:144
+msgid "&About"
+msgstr "&Tietoja"
+
+#: ../src/common/stockitem.cpp:144
+msgid "About"
+msgstr "Tietoja"
+
+#: ../src/common/stockitem.cpp:145
+msgid "Add"
+msgstr "Lisää"
+
+#: ../src/common/stockitem.cpp:146
+msgid "&Apply"
+msgstr "&Käytä"
+
+#: ../src/common/stockitem.cpp:146
+msgid "Apply"
+msgstr "Käytä"
+
+#: ../src/common/stockitem.cpp:147
+msgid "&Back"
+msgstr "&Takaisin"
+
+#: ../src/common/stockitem.cpp:147
+msgid "Back"
+msgstr "Takaisin"
+
+#: ../src/common/stockitem.cpp:148
+msgid "&Bold"
+msgstr "&Lihavoitu"
+
+#: ../src/common/stockitem.cpp:148 ../src/generic/fontdlgg.cpp:326
+#: ../src/richtext/richtextfontpage.cpp:354
+msgid "Bold"
+msgstr "Lihavoitu"
+
+#: ../src/common/stockitem.cpp:149
+msgid "&Bottom"
+msgstr "&Alaosa"
+
+#: ../src/common/stockitem.cpp:149 ../src/richtext/richtextsizepage.cpp:287
+msgid "Bottom"
+msgstr "Alaosa"
+
+#: ../src/common/stockitem.cpp:150 ../src/generic/fontdlgg.cpp:462
+#: ../src/generic/fontdlgg.cpp:481 ../src/generic/wizard.cpp:415
+msgid "&Cancel"
+msgstr "&Peruuta"
+
+#: ../src/common/stockitem.cpp:151
+#, fuzzy
+msgid "&CD-ROM"
+msgstr "&CD-ROM"
+
+#: ../src/common/stockitem.cpp:151
+#, fuzzy
+msgid "CD-ROM"
+msgstr "CD-ROM"
+
+#: ../src/common/stockitem.cpp:152
+msgid "&Clear"
+msgstr "&Tyhjennä"
+
+#: ../src/common/stockitem.cpp:152
+#, fuzzy
+msgid "Clear"
+msgstr "&Tyhjennä"
+
+#: ../src/common/stockitem.cpp:153 ../src/generic/dbgrptg.cpp:93
+#: ../src/generic/progdlgg.cpp:778 ../src/html/helpdlg.cpp:86
+#: ../src/msw/progdlg.cpp:209 ../src/msw/progdlg.cpp:890
+#: ../src/richtext/richtextstyledlg.cpp:272
+#: ../src/richtext/richtextsymboldlg.cpp:448
+msgid "Close"
+msgstr "Sulje"
+
+#: ../src/common/stockitem.cpp:154
+msgid "&Convert"
+msgstr "&Muunna"
+
+#: ../src/common/stockitem.cpp:154
+#, fuzzy
+msgid "Convert"
+msgstr "Sisältä"
+
+#: ../src/common/stockitem.cpp:155 ../src/msw/textctrl.cpp:2884
+#: ../src/osx/textctrl_osx.cpp:653 ../src/richtext/richtextctrl.cpp:331
+msgid "&Copy"
+msgstr "K&opioi"
+
+#: ../src/common/stockitem.cpp:155 ../src/stc/stc_i18n.cpp:18
+msgid "Copy"
+msgstr "Kopioi"
+
+#: ../src/common/stockitem.cpp:156 ../src/msw/textctrl.cpp:2883
+#: ../src/osx/textctrl_osx.cpp:652 ../src/richtext/richtextctrl.cpp:330
+msgid "Cu&t"
+msgstr "&Leikkaa"
+
+#: ../src/common/stockitem.cpp:156 ../src/stc/stc_i18n.cpp:17
+msgid "Cut"
+msgstr "Leikkaa"
+
+#: ../src/common/stockitem.cpp:157 ../src/msw/textctrl.cpp:2886
+#: ../src/osx/textctrl_osx.cpp:655 ../src/richtext/richtextctrl.cpp:333
+#: ../src/richtext/richtexttabspage.cpp:137
+msgid "&Delete"
+msgstr "&Poista"
+
+#: ../src/common/stockitem.cpp:157 ../src/richtext/richtextbuffer.cpp:8266
+#: ../src/stc/stc_i18n.cpp:20
+msgid "Delete"
+msgstr "Poista"
+
+#: ../src/common/stockitem.cpp:158
+msgid "&Down"
+msgstr "&Alas"
+
+#: ../src/common/stockitem.cpp:158 ../src/generic/fdrepdlg.cpp:148
+msgid "Down"
+msgstr "Alas"
+
+#: ../src/common/stockitem.cpp:159
+msgid "&Edit"
+msgstr "&Muokkaa"
+
+#: ../src/common/stockitem.cpp:159
+msgid "Edit"
+msgstr "Muokkaa"
+
+#: ../src/common/stockitem.cpp:160
+msgid "&Execute"
+msgstr "&Suorita"
+
+#: ../src/common/stockitem.cpp:160
+msgid "Execute"
+msgstr "Suorita"
+
+#: ../src/common/stockitem.cpp:161
+msgid "&Quit"
+msgstr "&Poistu"
+
+#: ../src/common/stockitem.cpp:161
+#, fuzzy
+msgid "Quit"
+msgstr "&Poistu"
+
+#: ../src/common/stockitem.cpp:162
+msgid "&File"
+msgstr "&Tiedosto"
+
+#: ../src/common/stockitem.cpp:162
+msgid "File"
+msgstr "Tiedosto"
+
+#: ../src/common/stockitem.cpp:163
+#, fuzzy
+msgid "&Find..."
+msgstr "&Etsi"
+
+#: ../src/common/stockitem.cpp:163
+#, fuzzy
+msgid "Find..."
+msgstr "Etsi"
+
+#: ../src/common/stockitem.cpp:164
+msgid "&First"
+msgstr "&Ensimmäinen"
+
+#: ../src/common/stockitem.cpp:164
+#, fuzzy
+msgid "First"
+msgstr "ensimmäinen"
+
+#: ../src/common/stockitem.cpp:165
+#, fuzzy
+msgid "&Floppy"
+msgstr "K&opioi"
+
+#: ../src/common/stockitem.cpp:165
+#, fuzzy
+msgid "Floppy"
+msgstr "Kopioi"
+
+#: ../src/common/stockitem.cpp:166
+msgid "&Forward"
+msgstr "&Eteenpäin"
+
+#: ../src/common/stockitem.cpp:166
+#, fuzzy
+msgid "Forward"
+msgstr "&Eteenpäin"
+
+#: ../src/common/stockitem.cpp:167
+msgid "&Harddisk"
+msgstr "&Kiintolevy"
+
+#: ../src/common/stockitem.cpp:167
+msgid "Harddisk"
+msgstr "Kiintolevy"
+
+#: ../src/common/stockitem.cpp:168 ../src/generic/wizard.cpp:418
+#: ../src/osx/cocoa/menu.mm:225 ../src/richtext/richtextstyledlg.cpp:298
+#: ../src/richtext/richtextsymboldlg.cpp:451
+msgid "&Help"
+msgstr "&Ohje"
+
+#: ../src/common/stockitem.cpp:169
+msgid "&Home"
+msgstr "&Koti"
+
+#: ../src/common/stockitem.cpp:169
+msgid "Home"
+msgstr "Koti"
+
+#: ../src/common/stockitem.cpp:170
+msgid "Indent"
+msgstr "Sisennys"
+
+#: ../src/common/stockitem.cpp:171
+msgid "&Index"
+msgstr "&Indeksi"
+
+#: ../src/common/stockitem.cpp:171 ../src/html/helpwnd.cpp:510
+msgid "Index"
+msgstr "Sisältä"
+
+#: ../src/common/stockitem.cpp:172
+msgid "&Info"
+msgstr "&Tiedot"
+
+#: ../src/common/stockitem.cpp:172
+msgid "Info"
+msgstr "Tiedot"
+
+#: ../src/common/stockitem.cpp:173
+msgid "&Italic"
+msgstr "&Kursivoitu"
+
+#: ../src/common/stockitem.cpp:173 ../src/generic/fontdlgg.cpp:322
+#: ../src/richtext/richtextfontpage.cpp:350
+msgid "Italic"
+msgstr "Kursivoitu"
+
+#: ../src/common/stockitem.cpp:174
+msgid "&Jump to"
+msgstr "&Hyppää kohteeseen"
+
+#: ../src/common/stockitem.cpp:174
+msgid "Jump to"
+msgstr "Hyppää kohteeseen"
+
+#: ../src/common/stockitem.cpp:175
+msgid "Centered"
+msgstr "Keskitetty"
+
+#: ../src/common/stockitem.cpp:176
+msgid "Justified"
+msgstr "Tasattu"
+
+#: ../src/common/stockitem.cpp:177
+msgid "Align Left"
+msgstr "Tasaa vasemmalle"
+
+#: ../src/common/stockitem.cpp:178
+msgid "Align Right"
+msgstr "Tasaa oikealle"
+
+#: ../src/common/stockitem.cpp:179
+msgid "&Last"
+msgstr "&Viimeinen"
+
+#: ../src/common/stockitem.cpp:179
+#, fuzzy
+msgid "Last"
+msgstr "Liitä"
+
+#: ../src/common/stockitem.cpp:180
+msgid "&Network"
+msgstr "&Verkko"
+
+#: ../src/common/stockitem.cpp:180
+msgid "Network"
+msgstr "Verkko"
+
+#: ../src/common/stockitem.cpp:181 ../src/richtext/richtexttabspage.cpp:131
+msgid "&New"
+msgstr "&Uusi"
+
+#: ../src/common/stockitem.cpp:181
+#, fuzzy
+msgid "New"
+msgstr "&Uusi"
+
+#: ../src/common/stockitem.cpp:182 ../src/msw/msgdlg.cpp:417
+msgid "&No"
+msgstr "&Ei"
+
+#: ../src/common/stockitem.cpp:183 ../src/generic/fontdlgg.cpp:467
+#: ../src/generic/fontdlgg.cpp:474
+msgid "&OK"
+msgstr "&OK"
+
+#: ../src/common/stockitem.cpp:184 ../src/generic/dbgrptg.cpp:341
+msgid "&Open..."
+msgstr "&Avaa..."
+
+#: ../src/common/stockitem.cpp:184
+#, fuzzy
+msgid "Open..."
+msgstr "&Avaa..."
+
+#: ../src/common/stockitem.cpp:185 ../src/msw/textctrl.cpp:2885
+#: ../src/osx/textctrl_osx.cpp:654 ../src/richtext/richtextctrl.cpp:332
+msgid "&Paste"
+msgstr "L&iitä"
+
+#: ../src/common/stockitem.cpp:185 ../src/richtext/richtextctrl.cpp:3484
+#: ../src/stc/stc_i18n.cpp:19
+msgid "Paste"
+msgstr "Liitä"
+
+#: ../src/common/stockitem.cpp:186
+msgid "&Preferences"
+msgstr "&Asetukset"
+
+#: ../src/common/stockitem.cpp:186 ../src/osx/cocoa/preferences.mm:304
+#, fuzzy
+msgid "Preferences"
+msgstr "&Asetukset"
+
+#: ../src/common/stockitem.cpp:187
+#, fuzzy
+msgid "Print previe&w..."
+msgstr "Tulostuksen &esikatselu"
+
+#: ../src/common/stockitem.cpp:187
+#, fuzzy
+msgid "Print preview..."
+msgstr "Tulostuksen esikatselu"
+
+#: ../src/common/stockitem.cpp:188
+msgid "&Print..."
+msgstr "&Tulosta..."
+
+#: ../src/common/stockitem.cpp:188
+#, fuzzy
+msgid "Print..."
+msgstr "&Tulosta..."
+
+#: ../src/common/stockitem.cpp:189 ../src/richtext/richtextctrl.cpp:337
+#: ../src/richtext/richtextctrl.cpp:5479
+msgid "&Properties"
+msgstr "&Ominaisuudet"
+
+#: ../src/common/stockitem.cpp:189
+#, fuzzy
+msgid "Properties"
+msgstr "&Ominaisuudet"
+
+#: ../src/common/stockitem.cpp:190 ../src/stc/stc_i18n.cpp:16
+msgid "Redo"
+msgstr "Toista"
+
+#: ../src/common/stockitem.cpp:191
+msgid "Refresh"
+msgstr "Päivitä"
+
+#: ../src/common/stockitem.cpp:192
+msgid "Remove"
+msgstr "Poista"
+
+#: ../src/common/stockitem.cpp:193
+#, fuzzy
+msgid "Rep&lace..."
+msgstr "&Korvaa"
+
+#: ../src/common/stockitem.cpp:193
+#, fuzzy
+msgid "Replace..."
+msgstr "Korvaa"
+
+#: ../src/common/stockitem.cpp:194
+msgid "Revert to Saved"
+msgstr "Palauta tallennettuun"
+
+#: ../src/common/stockitem.cpp:196 ../src/generic/logg.cpp:549
+msgid "Save &As..."
+msgstr "Tallenna &nimellä..."
+
+#: ../src/common/stockitem.cpp:196
+#, fuzzy
+msgid "Save As..."
+msgstr "Tallenna &nimellä..."
+
+#: ../src/common/stockitem.cpp:197 ../src/msw/textctrl.cpp:2888
+#: ../src/osx/textctrl_osx.cpp:657 ../src/richtext/richtextctrl.cpp:335
+msgid "Select &All"
+msgstr "Valitse k&aikki"
+
+#: ../src/common/stockitem.cpp:197 ../src/stc/stc_i18n.cpp:21
+msgid "Select All"
+msgstr "Valitse kaikki"
+
+#: ../src/common/stockitem.cpp:198
+msgid "&Color"
+msgstr "&Väri"
+
+#: ../src/common/stockitem.cpp:198
+#, fuzzy
+msgid "Color"
+msgstr "Väri"
+
+#: ../src/common/stockitem.cpp:199
+msgid "&Font"
+msgstr "&Kirjasin"
+
+#: ../src/common/stockitem.cpp:199 ../src/richtext/richtextformatdlg.cpp:336
+msgid "Font"
+msgstr "Kirjasin"
+
+#: ../src/common/stockitem.cpp:200
+msgid "&Ascending"
+msgstr "&Nouseva"
+
+#: ../src/common/stockitem.cpp:200
+msgid "Ascending"
+msgstr "Nouseva"
+
+#: ../src/common/stockitem.cpp:201
+msgid "&Descending"
+msgstr "&Laskeva"
+
+#: ../src/common/stockitem.cpp:201
+#, fuzzy
+msgid "Descending"
+msgstr "Oletuskoodaus"
+
+#: ../src/common/stockitem.cpp:202
+msgid "&Spell Check"
+msgstr "&Oikeinkirjoituksen tarkistus"
+
+#: ../src/common/stockitem.cpp:202
+msgid "Spell Check"
+msgstr "Oikeinkirjoituksen tarkistus"
+
+#: ../src/common/stockitem.cpp:203
+msgid "&Stop"
+msgstr "&Pysäytä"
+
+#: ../src/common/stockitem.cpp:203
+#, fuzzy
+msgid "Stop"
+msgstr "&Pysäytä"
+
+#: ../src/common/stockitem.cpp:204 ../src/richtext/richtextfontpage.cpp:274
+msgid "&Strikethrough"
+msgstr "&Yliviivaus"
+
+#: ../src/common/stockitem.cpp:204
+msgid "Strikethrough"
+msgstr "Yliviivaus"
+
+#: ../src/common/stockitem.cpp:205
+msgid "&Top"
+msgstr "&Yläosa"
+
+#: ../src/common/stockitem.cpp:205 ../src/richtext/richtextsizepage.cpp:285
+#: ../src/richtext/richtextsizepage.cpp:289
+#, fuzzy
+msgid "Top"
+msgstr "Vastaanottaja:"
+
+#: ../src/common/stockitem.cpp:206
+msgid "Undelete"
+msgstr "Kumoa poisto"
+
+#: ../src/common/stockitem.cpp:207 ../src/generic/fontdlgg.cpp:437
+msgid "&Underline"
+msgstr "&Alleviivaus"
+
+#: ../src/common/stockitem.cpp:207
+#, fuzzy
+msgid "Underline"
+msgstr "&Alleviivaus"
+
+#: ../src/common/stockitem.cpp:208 ../src/stc/stc_i18n.cpp:15
+msgid "Undo"
+msgstr "Kumoa"
+
+#: ../src/common/stockitem.cpp:209
+msgid "&Unindent"
+msgstr "&Vähennä sisennystä"
+
+#: ../src/common/stockitem.cpp:209
+#, fuzzy
+msgid "Unindent"
+msgstr "&Vähennä sisennystä"
+
+#: ../src/common/stockitem.cpp:210
+msgid "&Up"
+msgstr "&Ylös"
+
+#: ../src/common/stockitem.cpp:210 ../src/generic/fdrepdlg.cpp:148
+msgid "Up"
+msgstr "Ylös"
+
+#: ../src/common/stockitem.cpp:211 ../src/msw/msgdlg.cpp:417
+msgid "&Yes"
+msgstr "&Kyllä"
+
+#: ../src/common/stockitem.cpp:212
+msgid "&Actual Size"
+msgstr "&Oikea koko"
+
+#: ../src/common/stockitem.cpp:212
+msgid "Actual Size"
+msgstr "Oikea koko"
+
+#: ../src/common/stockitem.cpp:213
+msgid "Zoom to &Fit"
+msgstr "&Sovita"
+
+#: ../src/common/stockitem.cpp:213
+#, fuzzy
+msgid "Zoom to Fit"
+msgstr "&Sovita"
+
+#: ../src/common/stockitem.cpp:214
+msgid "Zoom &In"
+msgstr "&Lähennä"
+
+#: ../src/common/stockitem.cpp:215
+msgid "Zoom &Out"
+msgstr "Lo&itonna"
+
+#: ../src/common/stockitem.cpp:262
+msgid "Show about dialog"
+msgstr "Näytä tietoja-valintaikkuna"
+
+#: ../src/common/stockitem.cpp:263
+msgid "Copy selection"
+msgstr "Kopioi valinta"
+
+#: ../src/common/stockitem.cpp:264
+msgid "Cut selection"
+msgstr "Leikkaa valinta"
+
+#: ../src/common/stockitem.cpp:265
+msgid "Delete selection"
+msgstr "Poista valinta"
+
+#: ../src/common/stockitem.cpp:266
+#, fuzzy
+msgid "Find in document"
+msgstr "Avaa HTML-asiakirja"
+
+#: ../src/common/stockitem.cpp:267
+msgid "Find and replace in document"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:268
+msgid "Paste selection"
+msgstr "Liitä valinta"
+
+#: ../src/common/stockitem.cpp:269
+msgid "Quit this program"
+msgstr "Poistu tästä sovelluksesta"
+
+#: ../src/common/stockitem.cpp:270
+msgid "Redo last action"
+msgstr "Toista viimeisin toimenpide"
+
+#: ../src/common/stockitem.cpp:271
+msgid "Undo last action"
+msgstr "Kumoa viimeisin toiminto"
+
+#: ../src/common/stockitem.cpp:272
+#, fuzzy
+msgid "Create new document"
+msgstr "Luo uusi hakemisto"
+
+#: ../src/common/stockitem.cpp:273
+#, fuzzy
+msgid "Open an existing document"
+msgstr "Avaa HTML-asiakirja"
+
+#: ../src/common/stockitem.cpp:274
+msgid "Close current document"
+msgstr "Sulje nykyinen asiakirja"
+
+#: ../src/common/stockitem.cpp:275
+msgid "Save current document"
+msgstr "Tallenna nykyinen asiakirja"
+
+#: ../src/common/stockitem.cpp:276
+msgid "Save current document with a different filename"
+msgstr "Tallenna nykyinen asiakirja eri nimellä"
+
+#: ../src/common/strconv.cpp:2324
+#, c-format
+msgid "Conversion to charset '%s' doesn't work."
+msgstr "Muunnos merkistöön ”%s” ei toimi."
+
+#: ../src/common/tarstrm.cpp:352 ../src/common/tarstrm.cpp:375
+#: ../src/common/tarstrm.cpp:406 ../src/generic/progdlgg.cpp:373
+msgid "unknown"
+msgstr "tuntematon"
+
+#: ../src/common/tarstrm.cpp:774
+msgid "incomplete header block in tar"
+msgstr ""
+
+#: ../src/common/tarstrm.cpp:798
+msgid "checksum failure reading tar header block"
+msgstr ""
+
+#: ../src/common/tarstrm.cpp:971
+msgid "invalid data in extended tar header"
+msgstr ""
+
+#: ../src/common/tarstrm.cpp:981 ../src/common/tarstrm.cpp:1003
+#: ../src/common/tarstrm.cpp:1477 ../src/common/tarstrm.cpp:1499
+msgid "tar entry not open"
+msgstr ""
+
+#: ../src/common/tarstrm.cpp:1023
+msgid "unexpected end of file"
+msgstr "odottamaton tiedoston loppu"
+
+#: ../src/common/tarstrm.cpp:1297
+#, c-format
+msgid "%s did not fit the tar header for entry '%s'"
+msgstr "%s ei mahtunut kohteen '%s' tar-otsakkeeseen"
+
+#: ../src/common/tarstrm.cpp:1359
+msgid "incorrect size given for tar entry"
+msgstr ""
+
+#: ../src/common/textbuf.cpp:232
+#, c-format
+msgid "'%s' is probably a binary buffer."
+msgstr "”%s” on todennäköisesti binääripuskuri."
+
+#: ../src/common/textcmn.cpp:1006 ../src/richtext/richtextctrl.cpp:3053
+msgid "File couldn't be loaded."
+msgstr "Tiedostoa ei voitu ladata."
+
+#: ../src/common/textfile.cpp:95
+#, fuzzy, c-format
+msgid "Failed to read text file \"%s\"."
+msgstr "Kuvaa %d ei voi ladata tiedostosta ”%s”."
+
+#: ../src/common/textfile.cpp:160
+#, c-format
+msgid "can't write buffer '%s' to disk."
+msgstr "puskuria ”%s” ei voida kirjoittaa levylle."
+
+#: ../src/common/time.cpp:212
+msgid "Failed to get the local system time"
+msgstr "Paikallista systeemiaikaa ei saatu"
+
+#: ../src/common/time.cpp:279
+msgid "wxGetTimeOfDay failed."
+msgstr "wxGetTimeOfDay epäonnistui."
+
+#: ../src/common/translation.cpp:929
+#, c-format
+msgid "'%s' is not a valid message catalog."
+msgstr "”%s” ei ole kelvollinen viestiluettelo."
+
+#: ../src/common/translation.cpp:954
+#, fuzzy
+msgid "Invalid message catalog."
+msgstr "”%s” ei ole kelvollinen viestiluettelo."
+
+#: ../src/common/translation.cpp:1013
+#, fuzzy, c-format
+msgid "Failed to parse Plural-Forms: '%s'"
+msgstr "Monikkomuotoja ”%s” ei voida käsitellä"
+
+#: ../src/common/translation.cpp:1723
+#, c-format
+msgid "using catalog '%s' from '%s'."
+msgstr "käytössä luettelo ”%s” ”%s”sta."
+
+#: ../src/common/translation.cpp:1816
+#, fuzzy, c-format
+msgid "Resource '%s' is not a valid message catalog."
+msgstr "”%s” ei ole kelvollinen viestiluettelo."
+
+#: ../src/common/translation.cpp:1865
+#, fuzzy
+msgid "Couldn't enumerate translations"
+msgstr "Säiettä ei voi päättää"
+
+#: ../src/common/utilscmn.cpp:1145
+msgid "No default application configured for HTML files."
+msgstr "Oletusohjelmaa HTML-tiedostojen hallintaan ei ole asetettu."
+
+#: ../src/common/utilscmn.cpp:1190
+#, fuzzy, c-format
+msgid "Failed to open URL \"%s\" in default browser."
+msgstr "URL-osoitetta ”%s” ei voitu avata oletusselaimessa."
+
+#: ../src/common/valtext.cpp:144
+msgid "Validation conflict"
+msgstr "Validointiristiriita"
+
+#: ../src/common/valtext.cpp:186
+msgid "Required information entry is empty."
+msgstr ""
+
+#: ../src/common/valtext.cpp:188
+#, fuzzy, c-format
+msgid "'%s' is one of the invalid strings"
+msgstr "”%s” on virheellinen"
+
+#: ../src/common/valtext.cpp:190
+#, fuzzy, c-format
+msgid "'%s' is not one of the valid strings"
+msgstr "”%s” ei ole kelvollinen viestiluettelo."
+
+#: ../src/common/valtext.cpp:199
+#, fuzzy, c-format
+msgid "'%s' contains invalid character(s)"
+msgstr "”%s” saa sisältää vain kirjaimia."
+
+#: ../src/common/webrequest.cpp:139
+#, fuzzy, c-format
+msgid "Error: %s (%d)"
+msgstr "Virhe: "
+
+#: ../src/common/webrequest.cpp:655
+#, c-format
+msgid ""
+"Not enough free disk space for download: %llu needed but only %llu available."
+msgstr ""
+
+#: ../src/common/webrequest.cpp:669
+#, fuzzy, c-format
+msgid "Failed to create temporary file in %s"
+msgstr "Tilapäistiedoston nimen luonti epäonnistui."
+
+#: ../src/common/webrequest_curl.cpp:1106
+#, fuzzy
+msgid "libcurl could not be initialized"
+msgstr "Sarakkeen kuvausta ei voitu alustaa."
+
+#: ../src/common/webview.cpp:392
+msgid "RunScriptAsync not supported"
+msgstr ""
+
+#: ../src/common/webview.cpp:403 ../src/msw/webview_ie.cpp:1073
+#, c-format
+msgid "Error running JavaScript: %s"
+msgstr ""
+
+#: ../src/common/webview_chromium.cpp:858
+#, fuzzy, c-format
+msgid "Failed to set proxy \"%s\": %s"
+msgstr "Hakemiston ”%s” luonti epäonnistui."
+
+#: ../src/common/webview_chromium.cpp:989
+msgid ""
+"Chromium can't be used because libcef.so wasn't loaded early enough; please "
+"relink the application or use LD_PRELOAD to load it earlier."
+msgstr ""
+
+#: ../src/common/webview_chromium.cpp:1108
+#, fuzzy
+msgid "Could not initialize Chromium"
+msgstr "Tasausta ei voitu asettaa."
+
+#: ../src/common/webview_chromium.cpp:1616
+msgid "Show DevTools"
+msgstr ""
+
+#: ../src/common/webview_chromium.cpp:1617
+#, fuzzy
+msgid "Close DevTools"
+msgstr "Sulje kaikki"
+
+#: ../src/common/webview_chromium.cpp:1623
+msgid "Inspect"
+msgstr ""
+
+#: ../src/common/wincmn.cpp:1628
+msgid "This platform does not support background transparency."
+msgstr ""
+
+#: ../src/common/wincmn.cpp:2097
+msgid "Could not transfer data to window"
+msgstr "Tiedonsiirto ikkunaan ei onnistu"
+
+#: ../src/common/windowid.cpp:240
+msgid "Out of window IDs.  Recommend shutting down application."
+msgstr ""
+
+#: ../src/common/xpmdecod.cpp:678
+msgid "XPM: incorrect header format!"
+msgstr "XPM: virheellinen otsikkomuoto"
+
+#: ../src/common/xpmdecod.cpp:703
+#, c-format
+msgid "XPM: incorrect colour description in line %d"
+msgstr "XPM: virheellinen värikuvaus rivillä %d"
+
+#: ../src/common/xpmdecod.cpp:715 ../src/common/xpmdecod.cpp:724
+#, c-format
+msgid "XPM: malformed colour definition '%s' at line %d!"
+msgstr "XPM: virheellinen värimääritys ”%s” rivillä %d!"
+
+#: ../src/common/xpmdecod.cpp:754
+msgid "XPM: no colors left to use for mask!"
+msgstr "XPM: värejä ei ole jäljellä maskin käytettäväksi"
+
+#: ../src/common/xpmdecod.cpp:781
+#, c-format
+msgid "XPM: truncated image data at line %d!"
+msgstr "XPM: katkennut kuvatieto rivillä %d"
+
+#: ../src/common/xpmdecod.cpp:795
+msgid "XPM: Malformed pixel data!"
+msgstr "XPM: virheellinen pikselitieto"
+
+#: ../src/common/xti.cpp:492
+msgid "Illegal Parameter Count for Create Method"
+msgstr ""
+
+#: ../src/common/xti.cpp:504
+msgid "Illegal Parameter Count for ConstructObject Method"
+msgstr ""
+
+#: ../src/common/xtistrm.cpp:161
+#, c-format
+msgid "Create Parameter %s not found in declared RTTI Parameters"
+msgstr "Parametrin %s luontia ei löydy ilmoitetuista RTTI-parametreista"
+
+#: ../src/common/xtistrm.cpp:290
+msgid "Illegal Object Class (Non-wxEvtHandler) as Event Source"
+msgstr ""
+
+#: ../src/common/xtistrm.cpp:313 ../src/common/xtixml.cpp:345
+#: ../src/common/xtixml.cpp:498
+msgid "Type must have enum - long conversion"
+msgstr ""
+
+#: ../src/common/xtistrm.cpp:400 ../src/common/xtistrm.cpp:415
+msgid "Invalid or Null Object ID passed to GetObjectClassInfo"
+msgstr ""
+"Virheellinen tai nollaobjektitunnus välitetty kohteelle GetObjectClassInfo"
+
+#: ../src/common/xtistrm.cpp:405
+msgid "Unknown Object passed to GetObjectClassInfo"
+msgstr ""
+
+#: ../src/common/xtistrm.cpp:420
+msgid "Already Registered Object passed to SetObjectClassInfo"
+msgstr "Jo rekisteröity objekti välitetty kohteelle SetObjectClassInfo"
+
+#: ../src/common/xtistrm.cpp:430
+msgid "Invalid or Null Object ID passed to HasObjectClassInfo"
+msgstr ""
+"Virheellinen tai nollaobjektitunnus välitetty kohteelle HasObjectClassInfo"
+
+#: ../src/common/xtistrm.cpp:460
+msgid "Passing a already registered object to SetObject"
+msgstr ""
+
+#: ../src/common/xtistrm.cpp:471
+msgid "Passing an unknown object to GetObject"
+msgstr ""
+
+#: ../src/common/xtixml.cpp:229
+msgid "Forward hrefs are not supported"
+msgstr "Eteenpäin osoittavia href-viittauksia ei tueta"
+
+#: ../src/common/xtixml.cpp:247
+#, c-format
+msgid "unknown class %s"
+msgstr "tuntematon luokka %s"
+
+#: ../src/common/xtixml.cpp:253
+msgid "objects cannot have XML Text Nodes"
+msgstr "Objekteilla ei voi olla XML-tekstisolmuja"
+
+#: ../src/common/xtixml.cpp:258
+msgid "Objects must have an id attribute"
+msgstr "Objekteilla täytyy olla id-määre"
+
+#: ../src/common/xtixml.cpp:267
+#, c-format
+msgid "Doubly used id : %d"
+msgstr "Kahteen kertaan käytetty id : %d"
+
+#: ../src/common/xtixml.cpp:316
+#, c-format
+msgid "Unknown Property %s"
+msgstr "Tuntematon ominaisuus %s"
+
+#: ../src/common/xtixml.cpp:407
+msgid "A non empty collection must consist of 'element' nodes"
+msgstr "Muun kuin tyhjän kokoelman tulee muodostua 'element'-solmuista"
+
+#: ../src/common/xtixml.cpp:478
+msgid "incorrect event handler string, missing dot"
+msgstr ""
+
+#: ../src/common/zipstrm.cpp:559
+msgid "can't re-initialize zlib deflate stream"
+msgstr ""
+
+#: ../src/common/zipstrm.cpp:584
+msgid "can't re-initialize zlib inflate stream"
+msgstr ""
+
+#: ../src/common/zipstrm.cpp:1023
+msgid "Ignoring malformed extra data record, ZIP file may be corrupted"
+msgstr ""
+
+#: ../src/common/zipstrm.cpp:1502
+msgid "assuming this is a multi-part zip concatenated"
+msgstr ""
+
+#: ../src/common/zipstrm.cpp:1664
+msgid "invalid zip file"
+msgstr "virheellinen zip-tiedosto"
+
+#: ../src/common/zipstrm.cpp:1723
+msgid "can't find central directory in zip"
+msgstr ""
+
+#: ../src/common/zipstrm.cpp:1812
+msgid "error reading zip central directory"
+msgstr ""
+
+#: ../src/common/zipstrm.cpp:1916
+msgid "error reading zip local header"
+msgstr ""
+
+#: ../src/common/zipstrm.cpp:1964
+msgid "bad zipfile offset to entry"
+msgstr ""
+
+#: ../src/common/zipstrm.cpp:2031
+msgid "stored file length not in Zip header"
+msgstr ""
+
+#: ../src/common/zipstrm.cpp:2045 ../src/common/zipstrm.cpp:2362
+msgid "unsupported Zip compression method"
+msgstr "ei-tuettu Zip-pakkaustyyppi"
+
+#: ../src/common/zipstrm.cpp:2126
+#, c-format
+msgid "reading zip stream (entry %s): bad length"
+msgstr "luetaan zip-virtaa (kohta %s): virheellinen pituus"
+
+#: ../src/common/zipstrm.cpp:2131
+#, c-format
+msgid "reading zip stream (entry %s): bad crc"
+msgstr "luetaan zip-virtaa (kohta %s): virheellinen crc"
+
+#: ../src/common/zipstrm.cpp:2578
+#, c-format
+msgid "error writing zip entry '%s': file too large without ZIP64"
+msgstr ""
+
+#: ../src/common/zipstrm.cpp:2585
+#, c-format
+msgid "error writing zip entry '%s': bad crc or length"
+msgstr ""
+
+#: ../src/common/zstream.cpp:155 ../src/common/zstream.cpp:315
+msgid "Gzip not supported by this version of zlib"
+msgstr "Gzip:iä ei tueta zlib:in tässä versiossa"
+
+#: ../src/common/zstream.cpp:182
+msgid "Can't initialize zlib inflate stream."
+msgstr "Zlib inflate -virtaa ei pystytä alustamaan."
+
+#: ../src/common/zstream.cpp:241
+msgid "Can't read inflate stream: unexpected EOF in underlying stream."
+msgstr "Ei voi lukea inflate-virtaa: odottamaton EOF käytetyssä virrassa."
+
+#: ../src/common/zstream.cpp:248 ../src/common/zstream.cpp:423
+#, c-format
+msgid "zlib error %d"
+msgstr "zlib-virhe %d"
+
+#: ../src/common/zstream.cpp:249
+#, c-format
+msgid "Can't read from inflate stream: %s"
+msgstr "Ei voi lukea inflate-irrasta: %s"
+
+#: ../src/common/zstream.cpp:343
+msgid "Can't initialize zlib deflate stream."
+msgstr "Zlib deflate -virtaa ei pystytä alustamaan."
+
+#: ../src/common/zstream.cpp:424
+#, c-format
+msgid "Can't write to deflate stream: %s"
+msgstr "Ei voi kirjoittaa deflate-virtaan: %s"
+
+#: ../src/dfb/bitmap.cpp:633 ../src/dfb/bitmap.cpp:667
+#, fuzzy, c-format
+msgid "No bitmap handler for type %d defined."
+msgstr "Kuvatyypin %d käsittelijää ei määritelty."
+
+#: ../src/dfb/evtloop.cpp:99
+#, fuzzy
+msgid "Failed to read event from DirectFB pipe"
+msgstr "PID:iä ei voitu lukea lukkotiedostosta."
+
+#: ../src/dfb/evtloop.cpp:171
+msgid "Failed to switch DirectFB pipe to non-blocking mode"
+msgstr ""
+
+#: ../src/dfb/fontmgr.cpp:171
+#, c-format
+msgid "no fonts found in %s, using builtin font"
+msgstr "Kirjasimia ei löytynyt kohteesta %s, käytetään sisäänrakennettua"
+
+#: ../src/dfb/fontmgr.cpp:177
+msgid "Default font"
+msgstr "Oletuskirjasin"
+
+#: ../src/dfb/fontmgr.cpp:195
+#, c-format
+msgid "Fonts index file %s disappeared while loading fonts."
+msgstr "Kirjasinten indeksitiedosto %s katosi kirjasimia ladattaessa."
+
+#: ../src/dfb/wrapdfb.cpp:60
+#, fuzzy, c-format
+msgid "DirectFB error %d occurred."
+msgstr "DirectFB-virhe %d tapahtui."
+
+#: ../src/generic/aboutdlgg.cpp:69
+msgid "Developed by "
+msgstr "Kehittänyt:"
+
+#: ../src/generic/aboutdlgg.cpp:72
+msgid "Documentation by "
+msgstr "Dokumentaatio:"
+
+#: ../src/generic/aboutdlgg.cpp:75
+msgid "Graphics art by "
+msgstr "Graafisen taiteen tekijä:"
+
+#: ../src/generic/aboutdlgg.cpp:78
+msgid "Translations by "
+msgstr "Suomentajat:"
+
+#: ../src/generic/aboutdlgg.cpp:133 ../src/osx/cocoa/aboutdlg.mm:83
+#, fuzzy
+msgid "Version "
+msgstr "Versio %s"
+
+#. TRANSLATORS: %s is application name
+#: ../src/generic/aboutdlgg.cpp:146 ../src/msw/aboutdlg.cpp:60
+#, c-format
+msgid "About %s"
+msgstr "Tietoja ohjelmasta %s"
+
+#: ../src/generic/aboutdlgg.cpp:181
+msgid "License"
+msgstr "Lisenssi"
+
+#: ../src/generic/aboutdlgg.cpp:184
+msgid "Developers"
+msgstr "Kehittäjät"
+
+#: ../src/generic/aboutdlgg.cpp:188
+msgid "Documentation writers"
+msgstr "Dokumentaation kirjoittajat"
+
+#: ../src/generic/aboutdlgg.cpp:192
+msgid "Artists"
+msgstr "Artistit"
+
+#: ../src/generic/aboutdlgg.cpp:196
+msgid "Translators"
+msgstr "Suomentajat"
+
+#: ../src/generic/animateg.cpp:125
+#, fuzzy
+msgid "No handler found for animation type."
+msgstr "Kuvatyypin käsittelijää ei löytynyt."
+
+#: ../src/generic/animateg.cpp:133
+#, fuzzy, c-format
+msgid "No animation handler for type %ld defined."
+msgstr "Kuvatyypin %d käsittelijää ei määritelty."
+
+#: ../src/generic/animateg.cpp:145
+#, c-format
+msgid "Animation file is not of type %ld."
+msgstr "Animaatiotiedosto ei ole tyyppiä %ld."
+
+#: ../src/generic/colrdlgg.cpp:154 ../src/gtk/colordlg.cpp:47
+msgid "Choose colour"
+msgstr "Valitse väri"
+
+#: ../src/generic/colrdlgg.cpp:357
+msgid "Red:"
+msgstr ""
+
+#: ../src/generic/colrdlgg.cpp:360
+#, fuzzy
+msgid "Green:"
+msgstr "Mac (kreikkalainen)"
+
+#: ../src/generic/colrdlgg.cpp:363
+msgid "Blue:"
+msgstr ""
+
+#: ../src/generic/colrdlgg.cpp:372
+msgid "Opacity:"
+msgstr ""
+
+#: ../src/generic/colrdlgg.cpp:384
+msgid "Add to custom colours"
+msgstr "Lisää muokattuihin väreihin"
+
+#: ../src/generic/creddlgg.cpp:56
+msgid "Username:"
+msgstr ""
+
+#: ../src/generic/creddlgg.cpp:63
+msgid "Password:"
+msgstr ""
+
+#. TRANSLATORS: Name of Boolean true value
+#: ../src/generic/datavgen.cpp:1178
+msgid "true"
+msgstr ""
+
+#. TRANSLATORS: Name of Boolean false value
+#: ../src/generic/datavgen.cpp:1180
+#, fuzzy
+msgid "false"
+msgstr "Tiedosto"
+
+#: ../src/generic/datavgen.cpp:6897
+#, c-format
+msgid "Row %i"
+msgstr ""
+
+#. TRANSLATORS: Action for manipulating a tree control
+#: ../src/generic/datavgen.cpp:6987
+msgid "Collapse"
+msgstr ""
+
+#. TRANSLATORS: Action for manipulating a tree control
+#: ../src/generic/datavgen.cpp:6990
+msgid "Expand"
+msgstr ""
+
+#. TRANSLATORS: Name of data view control and number of rows
+#: ../src/generic/datavgen.cpp:7011
+#, fuzzy, c-format
+msgid "%s (%d items)"
+msgstr "%s (tai %s)"
+
+#: ../src/generic/datavgen.cpp:7062
+#, c-format
+msgid "Column %u"
+msgstr ""
+
+#. TRANSLATORS: Keystroke for manipulating a tree control
+#: ../src/generic/datavgen.cpp:7131 ../src/richtext/richtextbulletspage.cpp:189
+#: ../src/richtext/richtextbulletspage.cpp:192
+#: ../src/richtext/richtextbulletspage.cpp:193
+#: ../src/richtext/richtextliststylepage.cpp:252
+#: ../src/richtext/richtextliststylepage.cpp:255
+#: ../src/richtext/richtextliststylepage.cpp:256
+#: ../src/richtext/richtextsizepage.cpp:248
+msgid "Left"
+msgstr "Vasen"
+
+#. TRANSLATORS: Keystroke for manipulating a tree control
+#: ../src/generic/datavgen.cpp:7134 ../src/richtext/richtextbulletspage.cpp:191
+#: ../src/richtext/richtextliststylepage.cpp:254
+#: ../src/richtext/richtextsizepage.cpp:249
+msgid "Right"
+msgstr "Oikealle"
+
+#: ../src/generic/datectlg.cpp:90
+#, c-format
+msgid ""
+"\"%s\" is not in the expected date format, please enter it as e.g. \"%s\"."
+msgstr ""
+
+#: ../src/generic/datectlg.cpp:94
+#, fuzzy
+msgid "Invalid date"
+msgstr "Virheellinen tietonäkymän kohde"
+
+#: ../src/generic/dbgrptg.cpp:159
+#, fuzzy, c-format
+msgid "Open file \"%s\""
+msgstr "Avaa tiedosto ”%s”"
+
+#: ../src/generic/dbgrptg.cpp:170
+#, fuzzy, c-format
+msgid "Enter command to open file \"%s\":"
+msgstr "Anna komento tiedoston ”%s” avaamiseksi:"
+
+#: ../src/generic/dbgrptg.cpp:230
+#, fuzzy
+msgid "Executable files (*.exe)|*.exe|"
+msgstr "Suoritettavat tiedostot (*.exe)|*.exe|Kaikki tiedostot (*.*)|*.*||"
+
+#: ../src/generic/dbgrptg.cpp:300
+#, fuzzy, c-format
+msgid "Debug report \"%s\""
+msgstr "Ohjelmavirheilmoitus ”%s”"
+
+#: ../src/generic/dbgrptg.cpp:316
+msgid "A debug report has been generated in the directory\n"
+msgstr "Virheraportti on luotu hakemistoon\n"
+
+#: ../src/generic/dbgrptg.cpp:317
+msgid "The following debug report will be generated\n"
+msgstr ""
+
+#: ../src/generic/dbgrptg.cpp:321
+msgid ""
+"The report contains the files listed below. If any of these files contain "
+"private information,\n"
+"please uncheck them and they will be removed from the report.\n"
+msgstr ""
+
+#: ../src/generic/dbgrptg.cpp:323
+msgid ""
+"If you wish to suppress this debug report completely, please choose the "
+"\"Cancel\" button,\n"
+"but be warned that it may hinder improving the program, so if\n"
+"at all possible please do continue with the report generation.\n"
+msgstr ""
+
+#: ../src/generic/dbgrptg.cpp:325
+msgid "              Thank you and we're sorry for the inconvenience!\n"
+msgstr "              Kiitos, ja olemme pahoillamme kaikista hankaluuksista!\n"
+
+#: ../src/generic/dbgrptg.cpp:333
+msgid "&Debug report preview:"
+msgstr "&Ohjelmavirheilmoituksen esikatselu:"
+
+#: ../src/generic/dbgrptg.cpp:339
+msgid "&View..."
+msgstr "&Näytä..."
+
+#: ../src/generic/dbgrptg.cpp:359
+msgid "&Notes:"
+msgstr "&Huomiot:"
+
+#: ../src/generic/dbgrptg.cpp:361
+msgid ""
+"If you have any additional information pertaining to this bug\n"
+"report, please enter it here and it will be joined to it:"
+msgstr ""
+
+#: ../src/generic/dcpsg.cpp:1627
+msgid "Cannot open file for PostScript printing!"
+msgstr "Tiedoston avaaminen PostScript-tulostusta varten epäonnistui!"
+
+#: ../src/generic/dirctrlg.cpp:402
+msgid "Computer"
+msgstr "Tietokone"
+
+#: ../src/generic/dirctrlg.cpp:404
+msgid "Sections"
+msgstr "Lohkot"
+
+#: ../src/generic/dirctrlg.cpp:482
+msgid "Home directory"
+msgstr "Kotihakemisto"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/generic/dirctrlg.cpp:484 ../src/propgrid/advprops.cpp:811
+msgid "Desktop"
+msgstr "Työpöytä"
+
+#: ../src/generic/dirctrlg.cpp:528 ../src/generic/filectrlg.cpp:752
+msgid "Illegal directory name."
+msgstr "Virheellinen hakemiston nimi."
+
+#: ../src/generic/dirctrlg.cpp:528 ../src/generic/dirctrlg.cpp:546
+#: ../src/generic/dirctrlg.cpp:557 ../src/generic/dirdlgg.cpp:317
+#: ../src/generic/filectrlg.cpp:638 ../src/generic/filectrlg.cpp:752
+#: ../src/generic/filectrlg.cpp:766 ../src/generic/filectrlg.cpp:782
+#: ../src/generic/filectrlg.cpp:1356 ../src/generic/filectrlg.cpp:1387
+#: ../src/generic/filedlgg.cpp:362 ../src/gtk/filedlg.cpp:76
+msgid "Error"
+msgstr "Virhe"
+
+#: ../src/generic/dirctrlg.cpp:546 ../src/generic/filectrlg.cpp:766
+msgid "File name exists already."
+msgstr "Tiedostonimi on jo olemassa."
+
+#: ../src/generic/dirctrlg.cpp:557 ../src/generic/dirdlgg.cpp:317
+#: ../src/generic/filectrlg.cpp:638 ../src/generic/filectrlg.cpp:782
+msgid "Operation not permitted."
+msgstr "Ei sallittu toimenpide."
+
+#: ../src/generic/dirdlgg.cpp:107 ../src/generic/filedlgg.cpp:207
+msgid "Create new directory"
+msgstr "Luo uusi hakemisto"
+
+#: ../src/generic/dirdlgg.cpp:112 ../src/generic/filedlgg.cpp:203
+msgid "Go to home directory"
+msgstr "Siirry kotihakemistoon"
+
+#: ../src/generic/dirdlgg.cpp:143
+msgid "Show &hidden directories"
+msgstr "Näytä piilo&hakemistot"
+
+#: ../src/generic/dirdlgg.cpp:196
+#, c-format
+msgid ""
+"The directory '%s' does not exist\n"
+"Create it now?"
+msgstr ""
+"Hakemisto ”%s” ei ole olemassa.\n"
+"Luodaanko se nyt?"
+
+#: ../src/generic/dirdlgg.cpp:198
+msgid "Directory does not exist"
+msgstr "Hakemistoa ei ole olemassa"
+
+#: ../src/generic/dirdlgg.cpp:214
+#, c-format
+msgid ""
+"Failed to create directory '%s'\n"
+"(Do you have the required permissions?)"
+msgstr ""
+"Hakemiston ”%s” luonti epäonnistui\n"
+"(Onko sinulla vaadittavat oikeudet?)"
+
+#: ../src/generic/dirdlgg.cpp:216
+msgid "Error creating directory"
+msgstr "Virhe hakemistoa luotaessa"
+
+#: ../src/generic/dirdlgg.cpp:281
+msgid "You cannot add a new directory to this section."
+msgstr "Et voi lisätä uutta hakemistoa tähän kohtaan."
+
+#: ../src/generic/dirdlgg.cpp:282
+msgid "Create directory"
+msgstr "Luo hakemisto"
+
+#: ../src/generic/dirdlgg.cpp:291 ../src/generic/dirdlgg.cpp:301
+#: ../src/generic/filectrlg.cpp:614 ../src/generic/filectrlg.cpp:623
+msgid "NewName"
+msgstr "UusiNimi"
+
+#: ../src/generic/editlbox.cpp:135
+msgid "Edit item"
+msgstr "Muokkaa"
+
+#: ../src/generic/editlbox.cpp:143
+#, fuzzy
+msgid "New item"
+msgstr "Uusi kohta"
+
+#: ../src/generic/editlbox.cpp:151
+msgid "Delete item"
+msgstr "Poista kohta"
+
+#: ../src/generic/editlbox.cpp:159
+msgid "Move up"
+msgstr "Siirrä ylös"
+
+#: ../src/generic/editlbox.cpp:164
+msgid "Move down"
+msgstr "Siirrä alas"
+
+#: ../src/generic/fdrepdlg.cpp:108
+msgid "Search for:"
+msgstr "Etsi:"
+
+#: ../src/generic/fdrepdlg.cpp:120
+msgid "Replace with:"
+msgstr "Korvaa kohteella:"
+
+#: ../src/generic/fdrepdlg.cpp:140
+msgid "Whole word"
+msgstr "Vain kokonaiset sanat"
+
+#: ../src/generic/fdrepdlg.cpp:143
+msgid "Match case"
+msgstr "Sama kirjainkoko"
+
+#: ../src/generic/fdrepdlg.cpp:156
+msgid "Search direction"
+msgstr "Hakusuunta"
+
+#: ../src/generic/fdrepdlg.cpp:175
+msgid "&Replace"
+msgstr "&Korvaa"
+
+#: ../src/generic/fdrepdlg.cpp:178
+msgid "Replace &all"
+msgstr "Korvaa k&aikki"
+
+#: ../src/generic/filectrlg.cpp:246 ../src/generic/filectrlg.cpp:269
+msgid "<DIR>"
+msgstr "<HAK>"
+
+#: ../src/generic/filectrlg.cpp:248 ../src/generic/filectrlg.cpp:271
+msgid "<LINK>"
+msgstr "<LINKKI>"
+
+#: ../src/generic/filectrlg.cpp:250 ../src/generic/filectrlg.cpp:273
+msgid "<DRIVE>"
+msgstr "<ASEMA>"
+
+#: ../src/generic/filectrlg.cpp:275
+#, c-format
+msgid "%ld byte"
+msgid_plural "%ld bytes"
+msgstr[0] "%ld tavu"
+msgstr[1] "%ld tavua"
+
+#: ../src/generic/filectrlg.cpp:420
+msgid "Name"
+msgstr "Nimi"
+
+#: ../src/generic/filectrlg.cpp:421 ../src/richtext/richtextformatdlg.cpp:361
+#: ../src/richtext/richtextsizepage.cpp:298
+msgid "Size"
+msgstr "Koko"
+
+#: ../src/generic/filectrlg.cpp:422
+msgid "Type"
+msgstr "Tyyppi"
+
+#: ../src/generic/filectrlg.cpp:423
+msgid "Modified"
+msgstr "Muokattu"
+
+#: ../src/generic/filectrlg.cpp:426
+msgid "Permissions"
+msgstr "Oikeudet"
+
+#: ../src/generic/filectrlg.cpp:429
+msgid "Attributes"
+msgstr "Ominaisuudet"
+
+#: ../src/generic/filectrlg.cpp:936
+msgid "Current directory:"
+msgstr "Nykyinen hakemisto:"
+
+#: ../src/generic/filectrlg.cpp:979
+msgid "Show &hidden files"
+msgstr "Näytä piilo&tiedostot"
+
+#: ../src/generic/filectrlg.cpp:1355
+msgid "Illegal file specification."
+msgstr "Virheellinen tiedostomääritelmä."
+
+#: ../src/generic/filectrlg.cpp:1387
+msgid "Directory doesn't exist."
+msgstr "Hakemistoa ei ole olemassa."
+
+#: ../src/generic/filedlgg.cpp:195
+msgid "View files as a list view"
+msgstr "Näytä tiedostot luettelona"
+
+#: ../src/generic/filedlgg.cpp:197
+msgid "View files as a detailed view"
+msgstr "Näytä tiedostot lisätiedoilla"
+
+#: ../src/generic/filedlgg.cpp:200
+msgid "Go to parent directory"
+msgstr "Mene ylähakemistoon"
+
+#: ../src/generic/filedlgg.cpp:351 ../src/gtk/filedlg.cpp:59
+#, c-format
+msgid "File '%s' already exists, do you really want to overwrite it?"
+msgstr "Tiedosto ”%s” on jo olemassa, korvataanko se varmasti?"
+
+#: ../src/generic/filedlgg.cpp:354 ../src/gtk/filedlg.cpp:62
+msgid "Confirm"
+msgstr "Varmista"
+
+#: ../src/generic/filedlgg.cpp:362 ../src/gtk/filedlg.cpp:75
+msgid "Please choose an existing file."
+msgstr "Valitse olemassa oleva tiedosto."
+
+#: ../src/generic/filepickerg.cpp:64
+msgid "..."
+msgstr "..."
+
+#: ../src/generic/fontdlgg.cpp:76 ../src/richtext/richtextformatdlg.cpp:519
+msgid "ABCDEFGabcdefg12345"
+msgstr "ABCDEFGabcdefg12345"
+
+#: ../src/generic/fontdlgg.cpp:315
+msgid "Roman"
+msgstr "Roman"
+
+#: ../src/generic/fontdlgg.cpp:316
+msgid "Decorative"
+msgstr "Koristeellinen"
+
+#: ../src/generic/fontdlgg.cpp:317
+msgid "Modern"
+msgstr "Moderni"
+
+#: ../src/generic/fontdlgg.cpp:318
+msgid "Script"
+msgstr "Script"
+
+#: ../src/generic/fontdlgg.cpp:319
+msgid "Swiss"
+msgstr "Swiss"
+
+#: ../src/generic/fontdlgg.cpp:320
+msgid "Teletype"
+msgstr "Teletype"
+
+#: ../src/generic/fontdlgg.cpp:321 ../src/generic/fontdlgg.cpp:324
+msgid "Normal"
+msgstr "Tavallinen"
+
+#: ../src/generic/fontdlgg.cpp:323
+msgid "Slant"
+msgstr "Kalteva"
+
+#: ../src/generic/fontdlgg.cpp:325
+msgid "Light"
+msgstr "Kevyt"
+
+#: ../src/generic/fontdlgg.cpp:363
+msgid "&Font family:"
+msgstr "&Kirjasinperhe:"
+
+#: ../src/generic/fontdlgg.cpp:367 ../src/generic/fontdlgg.cpp:369
+msgid "The font family."
+msgstr "Kirjasinperhe."
+
+#: ../src/generic/fontdlgg.cpp:374 ../src/richtext/richtextstylepage.cpp:105
+msgid "&Style:"
+msgstr "&Tyyli:"
+
+#: ../src/generic/fontdlgg.cpp:378 ../src/generic/fontdlgg.cpp:380
+msgid "The font style."
+msgstr "Kirjasimen tyyli."
+
+#: ../src/generic/fontdlgg.cpp:385
+msgid "&Weight:"
+msgstr "&Paino:"
+
+#: ../src/generic/fontdlgg.cpp:389 ../src/generic/fontdlgg.cpp:391
+msgid "The font weight."
+msgstr "Kirjasimen paino."
+
+#: ../src/generic/fontdlgg.cpp:399
+msgid "C&olour:"
+msgstr "&Väri:"
+
+#: ../src/generic/fontdlgg.cpp:407 ../src/generic/fontdlgg.cpp:409
+msgid "The font colour."
+msgstr "Kirjasimen väri."
+
+#: ../src/generic/fontdlgg.cpp:415
+msgid "&Point size:"
+msgstr "K&irjasinkoko:"
+
+#: ../src/generic/fontdlgg.cpp:420 ../src/generic/fontdlgg.cpp:422
+#: ../src/generic/fontdlgg.cpp:426 ../src/generic/fontdlgg.cpp:428
+msgid "The font point size."
+msgstr "Kirjasinkoko."
+
+#: ../src/generic/fontdlgg.cpp:439 ../src/generic/fontdlgg.cpp:441
+msgid "Whether the font is underlined."
+msgstr "Onko kirjasin alleviivattu."
+
+#: ../src/generic/fontdlgg.cpp:448 ../src/html/helpwnd.cpp:1215
+msgid "Preview:"
+msgstr "Esikatselu:"
+
+#: ../src/generic/fontdlgg.cpp:452 ../src/generic/fontdlgg.cpp:454
+msgid "Shows the font preview."
+msgstr "Näytä kirjasimen esikatselu."
+
+#: ../src/generic/fontdlgg.cpp:464 ../src/generic/fontdlgg.cpp:483
+msgid "Click to cancel the font selection."
+msgstr "Napsauta peruuttaaksesi kirjasimen valinnan."
+
+#: ../src/generic/fontdlgg.cpp:469 ../src/generic/fontdlgg.cpp:471
+#: ../src/generic/fontdlgg.cpp:476 ../src/generic/fontdlgg.cpp:478
+msgid "Click to confirm the font selection."
+msgstr "Napsauta varmistaaksesi fontin valinnan."
+
+#: ../src/generic/fontpickerg.cpp:50 ../src/gtk/fontdlg.cpp:77
+msgid "Choose font"
+msgstr "Valitse kirjasinlaji"
+
+#: ../src/generic/grid.cpp:6542
+msgid ""
+"Error copying grid to the clipboard. Either selected cells were not "
+"contiguous or no cell was selected."
+msgstr ""
+
+#: ../src/generic/grid.cpp:12739
+msgid "Grid Corner"
+msgstr ""
+
+#: ../src/generic/grid.cpp:12741
+#, c-format
+msgid "Column %s Header"
+msgstr ""
+
+#: ../src/generic/grid.cpp:12743
+#, c-format
+msgid "Row %s Header"
+msgstr ""
+
+#: ../src/generic/grid.cpp:12745
+#, c-format
+msgid "Column %s: %s"
+msgstr ""
+
+#: ../src/generic/grid.cpp:12749
+#, c-format
+msgid "Row %s: %s"
+msgstr ""
+
+#: ../src/generic/grid.cpp:12753
+#, c-format
+msgid "Row %s, Column %s: %s"
+msgstr ""
+
+#: ../src/generic/helpext.cpp:257
+#, fuzzy, c-format
+msgid "Help directory \"%s\" not found."
+msgstr "Ohjehakemistoa ”%s” ei löytynyt."
+
+#: ../src/generic/helpext.cpp:265
+#, fuzzy, c-format
+msgid "Help file \"%s\" not found."
+msgstr "Ohjetiedostoa ”%s” ei löytynyt."
+
+#: ../src/generic/helpext.cpp:284
+#, c-format
+msgid "Line %lu of map file \"%s\" has invalid syntax, skipped."
+msgstr ""
+"Rivillä %lu karttatiedostossa \"%s\" on virheellinen syntaksi, ohitettu."
+
+#: ../src/generic/helpext.cpp:292
+#, c-format
+msgid "No valid mappings found in the file \"%s\"."
+msgstr ""
+
+#: ../src/generic/helpext.cpp:435
+msgid "No entries found."
+msgstr "Kohtia ei löytynyt."
+
+#: ../src/generic/helpext.cpp:444 ../src/generic/helpext.cpp:445
+msgid "Help Index"
+msgstr "Ohjeen sisältä"
+
+#: ../src/generic/helpext.cpp:448
+msgid "Relevant entries:"
+msgstr "Tähdelliset kohdat:"
+
+#: ../src/generic/helpext.cpp:449
+msgid "Entries found"
+msgstr "Löydetyt kohdat"
+
+#: ../src/generic/hyperlinkg.cpp:170
+msgid "&Copy URL"
+msgstr "&Kopioi URL-osoite"
+
+#: ../src/generic/infobar.cpp:119
+msgid "Hide this notification message."
+msgstr "Piilota tämä huomautus."
+
+#. TRANSLATORS: %s will be either the application name or "Application"
+#: ../src/generic/logg.cpp:257
+#, c-format
+msgid "%s Error"
+msgstr "%s-virhe"
+
+#. TRANSLATORS: %s will be either the application name or "Application"
+#: ../src/generic/logg.cpp:263
+#, c-format
+msgid "%s Warning"
+msgstr "%s-varoitus"
+
+#. TRANSLATORS: %s will be either the application name or "Application"
+#: ../src/generic/logg.cpp:273
+#, c-format
+msgid "%s Information"
+msgstr "%s-tiedotus"
+
+#: ../src/generic/logg.cpp:276
+#, fuzzy
+msgid "Application"
+msgstr "Valinta"
+
+#: ../src/generic/logg.cpp:549
+msgid "Save log contents to file"
+msgstr "Tallenna lokin sisältä tiedostoon"
+
+#: ../src/generic/logg.cpp:551
+msgid "C&lear"
+msgstr "&Tyhjennä"
+
+#: ../src/generic/logg.cpp:551
+msgid "Clear the log contents"
+msgstr "Tyhjennä lokin sisältä"
+
+#: ../src/generic/logg.cpp:553
+msgid "Close this window"
+msgstr "Sulje tämä ikkuna"
+
+#: ../src/generic/logg.cpp:554
+msgid "&Log"
+msgstr "&Loki"
+
+#: ../src/generic/logg.cpp:610 ../src/generic/logg.cpp:992
+msgid "Can't save log contents to file."
+msgstr "Lokisisällön tallennus tiedostoon epäonnistui."
+
+#: ../src/generic/logg.cpp:613
+#, c-format
+msgid "Log saved to the file '%s'."
+msgstr "Loki tallennettu tiedostoon ”%s”."
+
+#: ../src/generic/logg.cpp:719
+msgid "&Details"
+msgstr "&Yksityiskohdat"
+
+#: ../src/generic/logg.cpp:972
+#, fuzzy
+msgid "Failed to copy dialog contents to the clipboard."
+msgstr "Leikepöydän avaus ei onnistunut."
+
+#: ../src/generic/logg.cpp:1022
+#, c-format
+msgid "Append log to file '%s' (choosing [No] will overwrite it)?"
+msgstr "Lisää loki tiedostoon ”%s” (valitse [Ei] korvataksesi tiedoston)?"
+
+#: ../src/generic/logg.cpp:1024
+msgid "Question"
+msgstr "Kysymys"
+
+#: ../src/generic/logg.cpp:1038
+msgid "invalid message box return value"
+msgstr "virheellinen viestilaatikon (message box) palautusarvo"
+
+#: ../src/generic/notifmsgg.cpp:129
+msgid "Notice"
+msgstr "Huomio"
+
+#: ../src/generic/preferencesg.cpp:118
+#, fuzzy, c-format
+msgid "%s Preferences"
+msgstr "&Asetukset"
+
+#: ../src/generic/printps.cpp:143
+msgid "Printing..."
+msgstr "Tulostetaan..."
+
+#: ../src/generic/printps.cpp:160 ../src/gtk/print.cpp:1076
+#: ../src/msw/printwin.cpp:235
+msgid "Could not start printing."
+msgstr "Tulostus epäonnistui."
+
+#: ../src/generic/printps.cpp:183
+#, c-format
+msgid "Printing page %d..."
+msgstr "Tulostetaan sivua %d..."
+
+#: ../src/generic/prntdlgg.cpp:171
+msgid "Printer options"
+msgstr "Tulostimen valinnat"
+
+#: ../src/generic/prntdlgg.cpp:176
+msgid "Print to File"
+msgstr "Tulosta tiedostoon"
+
+#: ../src/generic/prntdlgg.cpp:179
+msgid "Setup..."
+msgstr "Asetukset..."
+
+#: ../src/generic/prntdlgg.cpp:187
+msgid "Printer:"
+msgstr "Tulostin:"
+
+#: ../src/generic/prntdlgg.cpp:195
+msgid "Status:"
+msgstr "Tila:"
+
+#: ../src/generic/prntdlgg.cpp:206
+msgid "All"
+msgstr "Kaikki"
+
+#: ../src/generic/prntdlgg.cpp:207
+msgid "Pages"
+msgstr "Sivut"
+
+#: ../src/generic/prntdlgg.cpp:215
+msgid "Print Range"
+msgstr "Tulostusalue"
+
+#: ../src/generic/prntdlgg.cpp:229
+msgid "From:"
+msgstr "Lähettäjä:"
+
+#: ../src/generic/prntdlgg.cpp:233
+msgid "To:"
+msgstr "Vastaanottaja:"
+
+#: ../src/generic/prntdlgg.cpp:238
+msgid "Copies:"
+msgstr "Kopiot:"
+
+#: ../src/generic/prntdlgg.cpp:288
+msgid "PostScript file"
+msgstr "PostScript-tiedosto"
+
+#: ../src/generic/prntdlgg.cpp:439
+msgid "Print Setup"
+msgstr "Tulostusasetukset"
+
+#: ../src/generic/prntdlgg.cpp:483
+msgid "Printer"
+msgstr "Tulostin"
+
+#: ../src/generic/prntdlgg.cpp:501
+msgid "Default printer"
+msgstr "Oletustulostin"
+
+#: ../src/generic/prntdlgg.cpp:595 ../src/generic/prntdlgg.cpp:782
+#: ../src/generic/prntdlgg.cpp:822 ../src/generic/prntdlgg.cpp:835
+#: ../src/generic/prntdlgg.cpp:1031 ../src/generic/prntdlgg.cpp:1036
+msgid "Paper size"
+msgstr "Paperin koko"
+
+#: ../src/generic/prntdlgg.cpp:604 ../src/generic/prntdlgg.cpp:847
+msgid "Portrait"
+msgstr "Pystysuunta"
+
+#: ../src/generic/prntdlgg.cpp:605 ../src/generic/prntdlgg.cpp:848
+msgid "Landscape"
+msgstr "Vaakasuunta"
+
+#: ../src/generic/prntdlgg.cpp:607 ../src/generic/prntdlgg.cpp:849
+msgid "Orientation"
+msgstr "Suunta"
+
+#: ../src/generic/prntdlgg.cpp:610
+msgid "Options"
+msgstr "Valinnat"
+
+#: ../src/generic/prntdlgg.cpp:612
+msgid "Print in colour"
+msgstr "Väritulostus"
+
+#: ../src/generic/prntdlgg.cpp:621
+#, fuzzy
+msgid "Print spooling"
+msgstr "Tulostuksen sivuajo"
+
+#: ../src/generic/prntdlgg.cpp:623
+msgid "Printer command:"
+msgstr "Tulostinkomento:"
+
+#: ../src/generic/prntdlgg.cpp:631
+msgid "Printer options:"
+msgstr "Tulostimen valinnat:"
+
+#: ../src/generic/prntdlgg.cpp:860
+msgid "Left margin (mm):"
+msgstr "Vasen marginaali (mm):"
+
+#: ../src/generic/prntdlgg.cpp:861
+msgid "Top margin (mm):"
+msgstr "Ylämarginaali (mm):"
+
+#: ../src/generic/prntdlgg.cpp:872
+msgid "Right margin (mm):"
+msgstr "Oikea marginaali (mm):"
+
+#: ../src/generic/prntdlgg.cpp:873
+msgid "Bottom margin (mm):"
+msgstr "Alamarginaali (mm):"
+
+#: ../src/generic/prntdlgg.cpp:896
+msgid "Printer..."
+msgstr "Tulostin..."
+
+#: ../src/generic/progdlgg.cpp:246
+msgid "&Skip"
+msgstr "Ohita"
+
+#: ../src/generic/progdlgg.cpp:347 ../src/generic/progdlgg.cpp:626
+msgid "Unknown"
+msgstr "Tuntematon"
+
+#: ../src/generic/progdlgg.cpp:451 ../src/msw/progdlg.cpp:526
+msgid "Done."
+msgstr "Valmis."
+
+#: ../src/generic/srchctlg.cpp:55 ../src/gtk/srchctrl.cpp:206
+#: ../src/html/helpwnd.cpp:530 ../src/html/helpwnd.cpp:545
+msgid "Search"
+msgstr "Etsi"
+
+#: ../src/generic/tabg.cpp:1026
+msgid "Could not find tab for id"
+msgstr "Ei löydetty sisennystä tunnukselle"
+
+#: ../src/generic/tipdlg.cpp:136
+msgid "Tips not available, sorry!"
+msgstr "Valitettavasti vihjeitä ei ole!"
+
+#: ../src/generic/tipdlg.cpp:197
+msgid "Tip of the Day"
+msgstr "Päivän vihje"
+
+#: ../src/generic/tipdlg.cpp:207
+msgid "Did you know..."
+msgstr "Tiesitkö..."
+
+#: ../src/generic/tipdlg.cpp:232
+msgid "&Show tips at startup"
+msgstr "&Näytä vihjeet käynnistyksessä"
+
+#: ../src/generic/tipdlg.cpp:236
+msgid "&Next Tip"
+msgstr "&Seuraava vihje"
+
+#: ../src/generic/wizard.cpp:411
+msgid "&Next >"
+msgstr "&Seuraava >"
+
+#: ../src/generic/wizard.cpp:412
+msgid "&Finish"
+msgstr "&Lopeta"
+
+#: ../src/generic/wizard.cpp:420
+msgid "< &Back"
+msgstr "< &Takaisin"
+
+#: ../src/gtk/aboutdlg.cpp:204
+msgid "translator-credits"
+msgstr ""
+"Elias Julkunen <elias.julkunen@gmail.com>, 2008.Jaakko Salli "
+"<jmsalli79@hotmail.com>, 2005.Lauri Nurmi <lanurmi@iki.fi>, 2004.Kaj G "
+"Backas <kgb@compart.fi>, 2000."
+
+#: ../src/gtk/app.cpp:517
+msgid ""
+"WARNING: using XIM input method is unsupported and may result in problems "
+"with input handling and flickering. Consider unsetting GTK_IM_MODULE or "
+"setting to \"ibus\"."
+msgstr ""
+
+#: ../src/gtk/app.cpp:569
+msgid "Unable to initialize GTK+, is DISPLAY set properly?"
+msgstr ""
+
+#: ../src/gtk/filedlg.cpp:89 ../src/gtk/filepicker.cpp:255
+#, fuzzy, c-format
+msgid "Changing current directory to \"%s\" failed"
+msgstr "Hakemiston ”%s” luonti epäonnistui."
+
+#: ../src/gtk/font.cpp:548
+msgid ""
+"Using private fonts is not supported on this system: Pango library is too "
+"old, 1.38 or later required."
+msgstr ""
+
+#: ../src/gtk/font.cpp:558
+#, fuzzy
+msgid "Failed to create font configuration object."
+msgstr "Käyttäjän asetustiedoston päivitys ei onnistu."
+
+#: ../src/gtk/font.cpp:568
+#, fuzzy, c-format
+msgid "Failed to add custom font \"%s\"."
+msgstr "Kuvaa %d ei voi ladata tiedostosta ”%s”."
+
+#: ../src/gtk/font.cpp:576
+#, fuzzy
+msgid "Failed to register font configuration using private fonts."
+msgstr "Käyttäjän asetustiedoston päivitys ei onnistu."
+
+#: ../src/gtk/glcanvas.cpp:117 ../src/gtk/glcanvas.cpp:132
+#, fuzzy
+msgid "Fatal Error"
+msgstr "Tuhoisa virhe"
+
+#: ../src/gtk/glcanvas.cpp:117
+msgid ""
+"This program wasn't compiled with EGL support required under Wayland, "
+"either\n"
+"install EGL libraries and rebuild or run it under X11 backend by setting\n"
+"environment variable GDK_BACKEND=x11 before starting your program."
+msgstr ""
+
+#: ../src/gtk/glcanvas.cpp:132
+msgid ""
+"wxGLCanvas is only supported on Wayland and X11 currently.  You may be able "
+"to\n"
+"work around this by setting environment variable GDK_BACKEND=x11 before\n"
+"starting your program."
+msgstr ""
+
+#: ../src/gtk/mdi.cpp:433
+msgid "MDI child"
+msgstr "MDI lapsi"
+
+#: ../src/gtk/power.cpp:188
+#, fuzzy, c-format
+msgid "Failed to open D-Bus connection to the login manager: %s"
+msgstr "Istunnonhallintaan ei voitu yhdistää: %s"
+
+#: ../src/gtk/power.cpp:214
+#, fuzzy
+msgid "wxWidgets application"
+msgstr "Kätke Appi"
+
+#: ../src/gtk/power.cpp:226
+msgid "Application needs to keep running"
+msgstr ""
+
+#: ../src/gtk/power.cpp:233
+msgid "Clean up before suspend"
+msgstr ""
+
+#: ../src/gtk/power.cpp:259
+#, fuzzy, c-format
+msgid "Failed to inhibit sleep: %s"
+msgstr "Puhelinyhteyden ”%s” keskeytys ei onnistunut."
+
+#: ../src/gtk/power.cpp:265
+msgid "Unexpected response to D-Bus \"Inhibit\" request."
+msgstr ""
+
+#: ../src/gtk/print.cpp:218
+msgid "Custom size"
+msgstr "Valinnainen koko"
+
+#: ../src/gtk/print.cpp:752
+#, fuzzy, c-format
+msgid "Error while printing: %s"
+msgstr "Virhe tulostettaessa: "
+
+#: ../src/gtk/print.cpp:816
+msgid "Page Setup"
+msgstr "Sivun asetukset"
+
+#: ../src/gtk/webview_webkit.cpp:932
+msgid "Retrieving JavaScript script output is not supported with WebKit v1"
+msgstr ""
+
+#: ../src/gtk/webview_webkit2.cpp:1098
+msgid ""
+"Setting proxy is not supported by WebKit, at least version 2.16 is required."
+msgstr ""
+
+#: ../src/gtk/webview_webkit2.cpp:1104
+msgid "This program was compiled without support for setting WebKit proxy."
+msgstr ""
+
+#: ../src/gtk/window.cpp:6289
+msgid ""
+"GTK+ installed on this machine is too old to support screen compositing, "
+"please install GTK+ 2.12 or later."
+msgstr ""
+
+#: ../src/gtk/window.cpp:6307
+msgid ""
+"Compositing not supported by this system, please enable it in your Window "
+"Manager."
+msgstr ""
+
+#: ../src/gtk/window.cpp:6318
+msgid ""
+"This program was compiled with a too old version of GTK+, please rebuild "
+"with GTK+ 2.12 or newer."
+msgstr ""
+
+#: ../src/html/chm.cpp:138
+#, c-format
+msgid "Failed to open CHM archive '%s'."
+msgstr "CHM arkiston ”%s” avaaminen epäonnistui."
+
+#: ../src/html/chm.cpp:270
+#, c-format
+msgid "Could not extract %s into %s: %s"
+msgstr "Ei voitu purkaa kohdetta %s kansioon %s: %s"
+
+#: ../src/html/chm.cpp:324
+msgid "no error"
+msgstr "ei virhettä"
+
+#: ../src/html/chm.cpp:326
+msgid "bad arguments to library function"
+msgstr "virheelliset argumentit kirjastofunktioon"
+
+#: ../src/html/chm.cpp:328
+msgid "error opening file"
+msgstr "virhe avattaessa tiedostoa"
+
+#: ../src/html/chm.cpp:330
+msgid "read error"
+msgstr "lukuvirhe"
+
+#: ../src/html/chm.cpp:332
+msgid "write error"
+msgstr "kirjoitusvirhe"
+
+#: ../src/html/chm.cpp:334
+msgid "seek error"
+msgstr "hakuvirhe"
+
+#: ../src/html/chm.cpp:338
+msgid "bad signature"
+msgstr "väärä allekirjoitus"
+
+#: ../src/html/chm.cpp:340
+msgid "error in data format"
+msgstr "virhe dataformaatissa"
+
+#: ../src/html/chm.cpp:342
+msgid "checksum error"
+msgstr "tarkistussummavirhe"
+
+#: ../src/html/chm.cpp:344
+msgid "compression error"
+msgstr "pakkausvirhe"
+
+#: ../src/html/chm.cpp:346
+msgid "decompression error"
+msgstr "purkamisvirhe"
+
+#: ../src/html/chm.cpp:437
+#, c-format
+msgid "Could not locate file '%s'."
+msgstr "Tiedostoa ”%s” ei löydy"
+
+#: ../src/html/chm.cpp:711
+#, c-format
+msgid "Could not create temporary file '%s'"
+msgstr "Väliaikaistiedoston ”%s” luonti ei onnistu"
+
+#: ../src/html/chm.cpp:718
+#, c-format
+msgid "Extraction of '%s' into '%s' failed."
+msgstr "Ei voitu purkaa ”%s”:aa kohteeseen ”%s”."
+
+#: ../src/html/chm.cpp:806 ../src/html/chm.cpp:863
+msgid "CHM handler currently supports only local files!"
+msgstr "CHM käsittelijä tukee vain paikallisia tiedostoja!"
+
+#: ../src/html/chm.cpp:827
+msgid "Link contained '//', converted to absolute link."
+msgstr "'//'-määrityksen sisältävä linkki muunnettu absoluuttiseksi."
+
+#: ../src/html/helpctrl.cpp:59
+#, c-format
+msgid "Help: %s"
+msgstr "Ohje: %s"
+
+#: ../src/html/helpctrl.cpp:155
+#, c-format
+msgid "Adding book %s"
+msgstr "Lisätään kirja %s"
+
+#: ../src/html/helpdata.cpp:295
+#, c-format
+msgid "Cannot open contents file: %s"
+msgstr "Sisällysluettelotiedostoa %s ei voi avata"
+
+#: ../src/html/helpdata.cpp:309
+#, c-format
+msgid "Cannot open index file: %s"
+msgstr "Indeksitiedostoa %s ei voi avata!"
+
+#: ../src/html/helpdata.cpp:643
+msgid "noname"
+msgstr "nimeämätön"
+
+#: ../src/html/helpdata.cpp:652
+#, c-format
+msgid "Cannot open HTML help book: %s"
+msgstr "HTML-ohjekirjaa ei voi avata: %s"
+
+#: ../src/html/helpwnd.cpp:315
+msgid "Displays help as you browse the books on the left."
+msgstr "Näyttää ohjeen selatessasi kirjoja vasemmalla."
+
+#: ../src/html/helpwnd.cpp:411 ../src/html/helpwnd.cpp:1100
+#: ../src/html/helpwnd.cpp:1735
+msgid "(bookmarks)"
+msgstr "(kirjanmerkit)"
+
+#: ../src/html/helpwnd.cpp:424
+msgid "Add current page to bookmarks"
+msgstr "Lisää tämä sivu kirjanmerkkeihin"
+
+#: ../src/html/helpwnd.cpp:425
+msgid "Remove current page from bookmarks"
+msgstr "Poista nykyinen sivu kirjanmerkeistä"
+
+#: ../src/html/helpwnd.cpp:470
+msgid "Contents"
+msgstr "Sisältä"
+
+#: ../src/html/helpwnd.cpp:485
+msgid "Find"
+msgstr "Etsi"
+
+#: ../src/html/helpwnd.cpp:487
+msgid "Show all"
+msgstr "Näytä kaikki"
+
+#: ../src/html/helpwnd.cpp:497
+msgid ""
+"Display all index items that contain given substring. Search is case "
+"insensitive."
+msgstr ""
+"Näytä sisällysluettelosta kaikki kohdat, jotka sisältävät annetun "
+"osatekstin. Haku on merkkikoosta riippumaton."
+
+#: ../src/html/helpwnd.cpp:498
+msgid "Show all items in index"
+msgstr "Näytä kaikki indeksissä"
+
+#: ../src/html/helpwnd.cpp:528
+msgid "Case sensitive"
+msgstr "Sama merkkikoko"
+
+#: ../src/html/helpwnd.cpp:529
+msgid "Whole words only"
+msgstr "Vain kokonaiset sanat"
+
+#: ../src/html/helpwnd.cpp:532
+#, fuzzy
+msgid ""
+"Search contents of help book(s) for all occurrences of the text you typed "
+"above"
+msgstr ""
+"Hae ohjekirjojen sisällöstä kaikki tapaukset, jossa on yllä antamasi teksti"
+
+#: ../src/html/helpwnd.cpp:653
+msgid "Show/hide navigation panel"
+msgstr "Näytä/piilota suunnistustaulu"
+
+#: ../src/html/helpwnd.cpp:655
+msgid "Go back"
+msgstr "Takaisin"
+
+#: ../src/html/helpwnd.cpp:656
+msgid "Go forward"
+msgstr "Eteenpäin"
+
+#: ../src/html/helpwnd.cpp:658
+msgid "Go one level up in document hierarchy"
+msgstr "Mene ylös asiakirjahierarkiassa"
+
+#: ../src/html/helpwnd.cpp:666 ../src/html/helpwnd.cpp:1547
+msgid "Open HTML document"
+msgstr "Avaa HTML-asiakirja"
+
+#: ../src/html/helpwnd.cpp:670
+msgid "Print this page"
+msgstr "Tulosta tämä sivu"
+
+#: ../src/html/helpwnd.cpp:674
+msgid "Display options dialog"
+msgstr "Näytä asetusikkuna"
+
+#: ../src/html/helpwnd.cpp:795
+msgid "Please choose the page to display:"
+msgstr "Valitse näytettävä sivu:"
+
+#: ../src/html/helpwnd.cpp:796
+msgid "Help Topics"
+msgstr "Ohjeen aiheet"
+
+#: ../src/html/helpwnd.cpp:852
+msgid "Searching..."
+msgstr "Etsitään..."
+
+#: ../src/html/helpwnd.cpp:853
+msgid "No matching page found yet"
+msgstr "Täsmääviä sivuja ei vielä löydetty"
+
+#: ../src/html/helpwnd.cpp:870
+#, c-format
+msgid "Found %i matches"
+msgstr "Löytyi %i täsmäävää"
+
+#: ../src/html/helpwnd.cpp:958
+msgid "(Help)"
+msgstr "(Ohje)"
+
+#: ../src/html/helpwnd.cpp:1026
+#, c-format
+msgid "%d of %lu"
+msgstr "%d / %lu"
+
+#: ../src/html/helpwnd.cpp:1028
+#, c-format
+msgid "%lu of %lu"
+msgstr "%lu / %lu"
+
+#: ../src/html/helpwnd.cpp:1047
+msgid "Search in all books"
+msgstr "Hae kaikista kirjoista"
+
+#: ../src/html/helpwnd.cpp:1193
+msgid "Help Browser Options"
+msgstr "Ohjeselaimen valinnat"
+
+#: ../src/html/helpwnd.cpp:1198
+msgid "Normal font:"
+msgstr "Tavallinen fontti:"
+
+#: ../src/html/helpwnd.cpp:1199
+msgid "Fixed font:"
+msgstr "Kiinteälevyinen fontti:"
+
+#: ../src/html/helpwnd.cpp:1200
+msgid "Font size:"
+msgstr "Kirjasinkoko:"
+
+#: ../src/html/helpwnd.cpp:1245
+msgid "font size"
+msgstr "kirjasinkoko"
+
+#: ../src/html/helpwnd.cpp:1256
+msgid "Normal face<br>and <u>underlined</u>. "
+msgstr "Normaali kirjasin<br>ja <u>alleviivattu</u>. "
+
+#: ../src/html/helpwnd.cpp:1257
+msgid "<i>Italic face.</i> "
+msgstr "<i>Kursivoitu kirjasin.</i> "
+
+#: ../src/html/helpwnd.cpp:1258
+msgid "<b>Bold face.</b> "
+msgstr "<b>Lihavoitu kirjasin.</b> "
+
+#: ../src/html/helpwnd.cpp:1259
+msgid "<b><i>Bold italic face.</i></b><br>"
+msgstr "<b><i>Lihavoitu kursivoitu kirjasin.</i></b><br>"
+
+#: ../src/html/helpwnd.cpp:1262
+msgid "Fixed size face.<br> <b>bold</b> <i>italic</i> "
+msgstr "Kiinteäkokoinen kirjasin.<br> <b>lihavoitu</b> <i>kursivoitu</i> "
+
+#: ../src/html/helpwnd.cpp:1263
+msgid "<b><i>bold italic <u>underlined</u></i></b><br>"
+msgstr "<b><i>lihavoitu kursivoitu <u>alleviivattu</u></i></b><br>"
+
+#: ../src/html/helpwnd.cpp:1524
+msgid "Help Printing"
+msgstr "Ohjeen tulostus"
+
+#: ../src/html/helpwnd.cpp:1527
+msgid "Cannot print empty page."
+msgstr "Tyhjää sivua ei voi tulostaa."
+
+#: ../src/html/helpwnd.cpp:1540
+msgid "HTML files (*.html;*.htm)|*.html;*.htm|"
+msgstr "HTML-tiedostot (*.html;*.htm)|*.html;*.htm|"
+
+#: ../src/html/helpwnd.cpp:1541
+msgid "Help books (*.htb)|*.htb|Help books (*.zip)|*.zip|"
+msgstr "Ohjekirjat (*.htb)|*.htb|Ohjekirjat (*.zip)|*.zip|"
+
+#: ../src/html/helpwnd.cpp:1542
+msgid "HTML Help Project (*.hhp)|*.hhp|"
+msgstr "HTML Ohjeprojekti (*.hhp)|*.hhp|"
+
+#: ../src/html/helpwnd.cpp:1544
+msgid "Compressed HTML Help file (*.chm)|*.chm|"
+msgstr "Tiivistetty HTML-ohjetiedosto (*.chm)|*.chm|"
+
+#: ../src/html/helpwnd.cpp:1671
+#, fuzzy, c-format
+msgid "%i of %u"
+msgstr "%i / %i"
+
+#: ../src/html/helpwnd.cpp:1709
+#, fuzzy, c-format
+msgid "%u of %u"
+msgstr "%lu / %lu"
+
+#: ../src/html/htmlfilt.cpp:134
+#, c-format
+msgid "Cannot open HTML document: %s"
+msgstr "HTML-asiakirjaa ei voi avata: %s"
+
+#: ../src/html/htmlwin.cpp:599
+msgid "Connecting..."
+msgstr "Yhdistetään..."
+
+#: ../src/html/htmlwin.cpp:616
+#, c-format
+msgid "Unable to open requested HTML document: %s"
+msgstr "Vaadittua HTML-asiakirjaa ei voi avata: %s"
+
+#: ../src/html/htmlwin.cpp:630
+msgid "Loading : "
+msgstr "Ladataan : "
+
+#: ../src/html/htmlwin.cpp:673
+msgid "Done"
+msgstr "Valmis"
+
+#: ../src/html/htmlwin.cpp:723
+#, c-format
+msgid "HTML anchor %s does not exist."
+msgstr "HTML-ankkuria %s ei ole olemassa."
+
+#: ../src/html/htmlwin.cpp:1057
+#, fuzzy, c-format
+msgid "Copied to clipboard:\"%s\""
+msgstr "Kopioitu leikepöydälle: ”%s”"
+
+#: ../src/html/htmprint.cpp:269
+msgid ""
+"This document doesn't fit on the page horizontally and will be truncated "
+"when it is printed."
+msgstr ""
+
+#: ../src/html/htmprint.cpp:285
+#, c-format
+msgid ""
+"The document \"%s\" doesn't fit on the page horizontally and will be "
+"truncated if printed.\n"
+"\n"
+"Would you like to proceed with printing it nevertheless?"
+msgstr ""
+
+#: ../src/html/htmprint.cpp:296
+msgid ""
+"If possible, try changing the layout parameters to make the printout more "
+"narrow."
+msgstr ""
+
+#: ../src/html/htmprint.cpp:445
+msgid ": file does not exist!"
+msgstr ": tiedostoa ei ole!"
+
+#. TRANSLATORS: %s may be a document title.
+#: ../src/html/htmprint.cpp:717
+#, fuzzy, c-format
+msgid "%s Preview"
+msgstr " Esikatselu"
+
+#: ../src/html/htmprint.cpp:755 ../src/richtext/richtextprint.cpp:618
+msgid ""
+"There was a problem during page setup: you may need to set a default printer."
+msgstr ""
+"Sivun asetusten kanssa oli ongelma: voit joutua asettamaan oletustulostimen."
+
+#: ../src/msw/clipbrd.cpp:80
+msgid "Failed to open the clipboard."
+msgstr "Leikepöydän avaus ei onnistunut."
+
+#: ../src/msw/clipbrd.cpp:101
+msgid "Failed to close the clipboard."
+msgstr "Leikepöydän sulkeminen epäonnistui."
+
+#: ../src/msw/clipbrd.cpp:113
+msgid "Failed to empty the clipboard."
+msgstr "Leikepöydän tyhjennys epäonnistui."
+
+#: ../src/msw/clipbrd.cpp:284
+msgid "Failed to put data on the clipboard"
+msgstr "Dataa ei voida siirtää leikepöydälle."
+
+#: ../src/msw/clipbrd.cpp:326
+msgid "Failed to get data from the clipboard"
+msgstr "Dataa ei voida hakea leikepöydältä"
+
+#: ../src/msw/clipbrd.cpp:363
+msgid "Failed to retrieve the supported clipboard formats"
+msgstr "Ei voi hakea tuettuja leikepöytämuotoja"
+
+#: ../src/msw/colordlg.cpp:228
+#, c-format
+msgid "Colour selection dialog failed with error %0lx."
+msgstr "Värin valintaikkuna epäonnistui virheellä %0lx."
+
+#: ../src/msw/cursor.cpp:141
+msgid "Failed to create cursor."
+msgstr "Osoittimen luonti epäonnistui."
+
+#: ../src/msw/dde.cpp:279
+#, c-format
+msgid "Failed to register DDE server '%s'"
+msgstr "DDE-palvelimen ”%s” rekisteröinti epäonnistui"
+
+#: ../src/msw/dde.cpp:300
+#, c-format
+msgid "Failed to unregister DDE server '%s'"
+msgstr "DDE-serverin ”%s” poisto rekisteröinnistä epäonnistui"
+
+#: ../src/msw/dde.cpp:428
+#, c-format
+msgid "Failed to create connection to server '%s' on topic '%s'"
+msgstr "Ei voitu yhdistää palvelimeen ”%s” asiassa %s"
+
+#: ../src/msw/dde.cpp:655
+#, fuzzy
+msgid "DDE poke request failed"
+msgstr "DDE-kirjoituspyyntö epäonnistui"
+
+#: ../src/msw/dde.cpp:674
+#, fuzzy
+msgid "Failed to establish an advise loop with DDE server"
+msgstr "DDE-serverin ohjeistuspiiriä ei aikaansaatu"
+
+#: ../src/msw/dde.cpp:693
+msgid "Failed to terminate the advise loop with DDE server"
+msgstr "DDE ohjeistuspiirin (advise loop) keskeytys ei onnistunut"
+
+#: ../src/msw/dde.cpp:768
+msgid "Failed to send DDE advise notification"
+msgstr "DDE:n ohjeistustiedotuksen lähetys epäonnistui"
+
+#: ../src/msw/dde.cpp:1085
+msgid "Failed to create DDE string"
+msgstr "DDE-merkkijonoa ei voitu luoda"
+
+#: ../src/msw/dde.cpp:1131
+msgid "no DDE error."
+msgstr "ei DDE-virhettä."
+
+#: ../src/msw/dde.cpp:1135
+msgid "a request for a synchronous advise transaction has timed out."
+msgstr "synkronisen ohjeistustapahtuman pyynnön sallittu aika ylittyi."
+
+#: ../src/msw/dde.cpp:1138
+msgid "the response to the transaction caused the DDE_FBUSY bit to be set."
+msgstr "tapahtuman vastaus aiheutti DDE_FBUSY-bitin asettumisen."
+
+#: ../src/msw/dde.cpp:1141
+msgid "a request for a synchronous data transaction has timed out."
+msgstr "synkronisen datasiirron pyynnön sallittu aika ylittyi."
+
+#: ../src/msw/dde.cpp:1144
+msgid ""
+"a DDEML function was called without first calling the DdeInitialize "
+"function,\n"
+"or an invalid instance identifier\n"
+"was passed to a DDEML function."
+msgstr ""
+"DDEML funktio kutsuttiin ilman edeltävää DDE-initialisointia, \n"
+"tai epäkelpo instanssin tunniste annetiin DDEML funktiolle."
+
+#: ../src/msw/dde.cpp:1147
+#, fuzzy
+msgid ""
+"an application initialized as APPCLASS_MONITOR has\n"
+"attempted to perform a DDE transaction,\n"
+"or an application initialized as APPCMD_CLIENTONLY has \n"
+"attempted to perform server transactions."
+msgstr ""
+"APCLASS_MONITOR käynnistämä sovellus on yrittänyt\n"
+"tehdä DDE tapahtuman tai APPCMD_CLIENTONLY on yrittänyt \n"
+"tehdä palvelimen tapahtuman."
+
+#: ../src/msw/dde.cpp:1150
+msgid "a request for a synchronous execute transaction has timed out."
+msgstr "synkronisen ohjelmapyynnön sallittu aika ylittyi."
+
+#: ../src/msw/dde.cpp:1153
+#, fuzzy
+msgid "a parameter failed to be validated by the DDEML."
+msgstr "DDEML ei voinut varmistaa parametria."
+
+#: ../src/msw/dde.cpp:1156
+#, fuzzy
+msgid "a DDEML application has created a prolonged race condition."
+msgstr "DDEML-sovellus on luonut pitkän kilpailutilanteen."
+
+#: ../src/msw/dde.cpp:1159
+msgid "a memory allocation failed."
+msgstr "muistin varaus epäonnistui."
+
+#: ../src/msw/dde.cpp:1162
+msgid "a client's attempt to establish a conversation has failed."
+msgstr "asiakkaan yritys aloittaa keskustelu epäonnistui."
+
+#: ../src/msw/dde.cpp:1165
+msgid "a transaction failed."
+msgstr "tapahtuma epäonnistui."
+
+#: ../src/msw/dde.cpp:1168
+#, fuzzy
+msgid "a request for a synchronous poke transaction has timed out."
+msgstr "synkronisen datakirjoitustapahtuman pyynnön sallittu aika ylittyi."
+
+#: ../src/msw/dde.cpp:1171
+msgid "an internal call to the PostMessage function has failed. "
+msgstr "sisäinen kutsu ”PostMessage”-funktion epäonnistui. "
+
+#: ../src/msw/dde.cpp:1174
+msgid "reentrancy problem."
+msgstr "vaikeuksia uudelleen palaamisessa."
+
+#: ../src/msw/dde.cpp:1177
+msgid ""
+"a server-side transaction was attempted on a conversation\n"
+"that was terminated by the client, or the server\n"
+"terminated before completing a transaction."
+msgstr ""
+"palvelinpuolella tapahtuma yritettiin keskustelussa,\n"
+"joka pysäytettiin asiakkaan taholla, tai palvelin\n"
+"keskeytti ennen tapahtuman valmistumista."
+
+#: ../src/msw/dde.cpp:1180
+msgid "an internal error has occurred in the DDEML."
+msgstr "sisäinen virhe tapahtui DDEML:ssä."
+
+#: ../src/msw/dde.cpp:1183
+msgid "a request to end an advise transaction has timed out."
+msgstr "ohjeistustapahtuman lopettamisen pyynnön sallittu aika ylittyi."
+
+#: ../src/msw/dde.cpp:1186
+msgid ""
+"an invalid transaction identifier was passed to a DDEML function.\n"
+"Once the application has returned from an XTYP_XACT_COMPLETE callback,\n"
+"the transaction identifier for that callback is no longer valid."
+msgstr ""
+"virheellinen tapahtumatunnus on siirretty DDEML funktiolle.\n"
+"Kun sovellus on palannut XTYP_XACT_COMPLETE vastakutsusta, \n"
+"tapahtuman tunnus tälle vastakutsulle ei päde enää."
+
+#: ../src/msw/dde.cpp:1189
+#, c-format
+msgid "Unknown DDE error %08x"
+msgstr "Tuntematon DDE-virhe %08x"
+
+#: ../src/msw/dialup.cpp:343
+msgid ""
+"Dial up functions are unavailable because the remote access service (RAS) is "
+"not installed on this machine. Please install it."
+msgstr ""
+"Puhelinsoittomahdollisuutta ei ole koska RAS (remote access service)\n"
+"ei ole asennettu tälle koneelle. Ole hyvä asenna se."
+
+#: ../src/msw/dialup.cpp:402
+#, fuzzy, c-format
+msgid ""
+"The version of remote access service (RAS) installed on this machine is too "
+"old, please upgrade (the following required function is missing: %s)."
+msgstr ""
+"Tälle koneelle asennetun RAS (remote access server) komponentin versio on "
+"liian vanha, ole hyvä ja päivitä se (vaadittua funktiota %s ei löytynyt)."
+
+#: ../src/msw/dialup.cpp:437
+msgid "Failed to retrieve text of RAS error message"
+msgstr "RAS-virheilmoitusta ei saatu."
+
+#: ../src/msw/dialup.cpp:440
+#, c-format
+msgid "unknown error (error code %08x)."
+msgstr "tuntematon virhe (virhekoodi %08x)."
+
+#: ../src/msw/dialup.cpp:492
+#, c-format
+msgid "Cannot find active dialup connection: %s"
+msgstr "Aktiivista puhelinyhteyttä ei löydy: %s"
+
+#: ../src/msw/dialup.cpp:513
+msgid "Several active dialup connections found, choosing one randomly."
+msgstr ""
+"Monta aktiivista puhelinvalintaikkunaa auki, valitsen yhden satunnaisesti."
+
+#: ../src/msw/dialup.cpp:598 ../src/msw/dialup.cpp:832
+#, c-format
+msgid "Failed to establish dialup connection: %s"
+msgstr "Soittoyhteyttä %s ei voitu luoda"
+
+#: ../src/msw/dialup.cpp:664
+#, c-format
+msgid "Failed to get ISP names: %s"
+msgstr "Palveluntarjoajien nimeä ei saatu: %s"
+
+#: ../src/msw/dialup.cpp:712
+msgid "Failed to connect: no ISP to dial."
+msgstr "Yhdistäminen epäonnistui: ei soitettavissa olevaa palveluntarjoajaa."
+
+#: ../src/msw/dialup.cpp:732
+msgid "Choose ISP to dial"
+msgstr "Valitse palveluntarjoaja jolle soitetaan"
+
+#: ../src/msw/dialup.cpp:733
+msgid "Please choose which ISP do you want to connect to"
+msgstr "Valitse palveluntarjoaja, johon haluat kytkeytyä"
+
+#: ../src/msw/dialup.cpp:766
+msgid "Failed to connect: missing username/password."
+msgstr "Yhdistäminen epäonnistui: käyttäjätunnus/salasana puutui."
+
+#: ../src/msw/dialup.cpp:796
+msgid "Cannot find the location of address book file"
+msgstr "Osoitekirjatiedoston sijaintia ei löydy"
+
+#: ../src/msw/dialup.cpp:827
+#, fuzzy, c-format
+msgid "Failed to initiate dialup connection: %s"
+msgstr "Puhelinyhteyden ”%s” keskeytys ei onnistunut."
+
+#: ../src/msw/dialup.cpp:897
+msgid "Cannot hang up - no active dialup connection."
+msgstr "Puhelua ei voi lopettaa - ei aktiivista yhteyttä."
+
+#: ../src/msw/dialup.cpp:907
+#, c-format
+msgid "Failed to terminate the dialup connection: %s"
+msgstr "Puhelinyhteyden ”%s” keskeytys ei onnistunut."
+
+#: ../src/msw/dib.cpp:313
+#, fuzzy, c-format
+msgid "Failed to save the bitmap image to file \"%s\"."
+msgstr "Kuvatiedostoa ”%s” ei voitu tallentaa."
+
+#: ../src/msw/dib.cpp:543
+#, fuzzy, c-format
+msgid "Failed to allocate %luKb of memory for bitmap data."
+msgstr "Osoittimen luonti epäonnistui."
+
+#: ../src/msw/dir.cpp:241
+#, c-format
+msgid "Cannot enumerate files in directory '%s'"
+msgstr "Hakemiston ”%s” tiedostojen luettelointi epäonnistui"
+
+#: ../src/msw/dirdlg.cpp:368
+#, fuzzy
+msgid "Couldn't obtain folder name"
+msgstr "Ajastimen luonti epäonnistui"
+
+#: ../src/msw/dlmsw.cpp:163
+#, fuzzy, c-format
+msgid "(error %d: %s)"
+msgstr " (virhe %ld: %s)"
+
+#: ../src/msw/dragimag.cpp:143 ../src/msw/dragimag.cpp:178
+#: ../src/msw/imaglist.cpp:309 ../src/msw/imaglist.cpp:331
+msgid "Couldn't add an image to the image list."
+msgstr "Kuvan lisäys kuvalistaan epäonnistui."
+
+#: ../src/msw/enhmeta.cpp:94
+#, fuzzy, c-format
+msgid "Failed to load metafile from file \"%s\"."
+msgstr "Metatiedostoa ei voitu ladata tiedostosta ”%s”."
+
+#: ../src/msw/fdrepdlg.cpp:412
+#, c-format
+msgid "Failed to create the standard find/replace dialog (error code %d)"
+msgstr "Standardin etsi/korvaa ikkunan luonti epäonnistui (virhekoodi %d)"
+
+#: ../src/msw/filedlg.cpp:1241
+msgid "Access to the file system is not allowed from secure desktop."
+msgstr ""
+
+#: ../src/msw/filedlg.cpp:1242
+msgid "Security warning"
+msgstr ""
+
+#: ../src/msw/filedlg.cpp:1533
+#, fuzzy, c-format
+msgid "File dialog failed with error code %0lx."
+msgstr "Värin valintaikkuna epäonnistui virheellä %0lx."
+
+#: ../src/msw/font.cpp:1120
+#, fuzzy, c-format
+msgid "Font file \"%s\" couldn't be loaded"
+msgstr "Tiedostoa ei voitu ladata."
+
+#: ../src/msw/fontdlg.cpp:220
+#, fuzzy, c-format
+msgid "Common dialog failed with error code %0lx."
+msgstr "Värin valintaikkuna epäonnistui virheellä %0lx."
+
+#: ../src/msw/fswatcher.cpp:67
+#, fuzzy
+msgid "Ungraceful worker thread termination"
+msgstr "Ei voi odottaa säikeen keskeytystä"
+
+#: ../src/msw/fswatcher.cpp:81
+#, fuzzy
+msgid "Unable to create IOCP worker thread"
+msgstr "MDI-isäntäkehystä ei voitu luoda."
+
+#: ../src/msw/fswatcher.cpp:88
+msgid "Unable to start IOCP worker thread"
+msgstr ""
+
+#: ../src/msw/fswatcher.cpp:140
+msgid "Monitoring individual files for changes is not supported currently."
+msgstr "Yksittäisten tiedostojen muutosten tarkkailua ei tueta tällä hetkellä."
+
+#: ../src/msw/fswatcher.cpp:165
+#, fuzzy, c-format
+msgid "Unable to set up watch for '%s'"
+msgstr "Touch epäonnistui tiedostolle ”%s”"
+
+#: ../src/msw/fswatcher.cpp:466
+#, c-format
+msgid "Can't monitor non-existent directory \"%s\" for changes."
+msgstr ""
+"Hakemiston \"%s\" muutoksia ei voida tarkkailla, koska sitä ei ole olemassa."
+
+#: ../src/msw/glcanvas.cpp:577 ../src/unix/glx11.cpp:507
+msgid "OpenGL 3.0 or later is not supported by the OpenGL driver."
+msgstr ""
+
+#: ../src/msw/glcanvas.cpp:601 ../src/osx/glcanvas_osx.cpp:395
+#: ../src/unix/glegl.cpp:304 ../src/unix/glx11.cpp:553
+#, fuzzy
+msgid "Couldn't create OpenGL context"
+msgstr "Ajastimen luonti epäonnistui"
+
+#: ../src/msw/glcanvas.cpp:1294
+msgid "Failed to initialize OpenGL"
+msgstr "OpenGL:n alustus epäonnistui"
+
+#: ../src/msw/graphicsd2d.cpp:607
+msgid "Could not register custom DirectWrite font loader."
+msgstr ""
+
+#: ../src/msw/helpchm.cpp:48
+msgid ""
+"MS HTML Help functions are unavailable because the MS HTML Help library is "
+"not installed on this machine. Please install it."
+msgstr ""
+"MS HTML Ohjetoiminnot eivät ole saatavilla koska MS HTML Help kirjastoa ei "
+"ole asennettu tälle koneelle. Ole hyvä ja asenna se."
+
+#: ../src/msw/helpchm.cpp:55
+msgid "Failed to initialize MS HTML Help."
+msgstr "MS HTML Ohjeen alustus epäonnistui."
+
+#: ../src/msw/iniconf.cpp:458
+#, c-format
+msgid "Can't delete the INI file '%s'"
+msgstr "INI-tiedoston ”%s” poisto epäonnistui"
+
+#: ../src/msw/listctrl.cpp:995
+#, fuzzy, c-format
+msgid "Couldn't retrieve information about list control item %d."
+msgstr "Ei voi hakea tietoja list-kontrollin jäsenestä indeksissä %d."
+
+#: ../src/msw/mdi.cpp:170 ../src/qt/mdi.cpp:253
+msgid "&Cascade"
+msgstr "&Limitä"
+
+#: ../src/msw/mdi.cpp:171
+msgid "Tile &Horizontally"
+msgstr "Järjestä &vaakasuoraan"
+
+#: ../src/msw/mdi.cpp:172
+msgid "Tile &Vertically"
+msgstr "Järjestä &pystysuoraan"
+
+#: ../src/msw/mdi.cpp:174
+msgid "&Arrange Icons"
+msgstr "&Järjestä kuvakkeet"
+
+#: ../src/msw/mdi.cpp:621
+msgid "Failed to create MDI parent frame."
+msgstr "MDI-isäntäkehystä ei voitu luoda."
+
+#: ../src/msw/mimetype.cpp:234
+#, c-format
+msgid "Failed to create registry entry for '%s' files."
+msgstr "Rekisteriavaimen luonti ”%s” tyypin tiedostoille ei onnistu."
+
+#: ../src/msw/ole/automtn.cpp:495
+#, c-format
+msgid "Failed to find CLSID of \"%s\""
+msgstr "Kohteen \"%s\" CLSID:n haku epäonnistui"
+
+#: ../src/msw/ole/automtn.cpp:512
+#, fuzzy, c-format
+msgid "Failed to create an instance of \"%s\""
+msgstr "Tilarivin luonti epäonnistui."
+
+#: ../src/msw/ole/automtn.cpp:552
+#, fuzzy, c-format
+msgid "Cannot get an active instance of \"%s\""
+msgstr "Aktiivista puhelinyhteyttä ei löydy: %s"
+
+#: ../src/msw/ole/automtn.cpp:564
+#, c-format
+msgid "Failed to get OLE automation interface for \"%s\""
+msgstr "Kohteen \"%s\" OLE -automaatiorajapinnan selvittäminen epäonnistui"
+
+#: ../src/msw/ole/automtn.cpp:621
+msgid "Unknown name or named argument."
+msgstr ""
+
+#: ../src/msw/ole/automtn.cpp:625
+msgid "Incorrect number of arguments."
+msgstr "Virheellinen argumenttien määrä."
+
+#: ../src/msw/ole/automtn.cpp:637
+#, fuzzy
+msgid "Unknown exception"
+msgstr "Tuntematon valitsin ”%s”"
+
+#: ../src/msw/ole/automtn.cpp:642
+msgid "Method or property not found."
+msgstr ""
+
+#: ../src/msw/ole/automtn.cpp:646
+msgid "Overflow while coercing argument values."
+msgstr ""
+
+#: ../src/msw/ole/automtn.cpp:650
+msgid "Object implementation does not support named arguments."
+msgstr "Objektin toteutus ei tue nimettyjä argumentteja."
+
+#: ../src/msw/ole/automtn.cpp:654
+msgid "The locale ID is unknown."
+msgstr ""
+
+#: ../src/msw/ole/automtn.cpp:658
+msgid "Missing a required parameter."
+msgstr "Pakollinen parametri puuttuu."
+
+#: ../src/msw/ole/automtn.cpp:662
+#, c-format
+msgid "Argument %u not found."
+msgstr "Parametria %u ei löydy."
+
+#: ../src/msw/ole/automtn.cpp:666
+#, c-format
+msgid "Type mismatch in argument %u."
+msgstr ""
+
+#: ../src/msw/ole/automtn.cpp:670
+msgid "The system cannot find the file specified."
+msgstr "Järjestelmä ei löydä määritettyä tiedostoa."
+
+#: ../src/msw/ole/automtn.cpp:674
+#, fuzzy
+msgid "Class not registered."
+msgstr "Säiettä ei voi luoda"
+
+#: ../src/msw/ole/automtn.cpp:678
+#, fuzzy, c-format
+msgid "Unknown error %08x"
+msgstr "Tuntematon DDE-virhe %08x"
+
+#: ../src/msw/ole/automtn.cpp:682
+#, c-format
+msgid "OLE Automation error in %s: %s"
+msgstr "OLE-automaatiovirhe kohteessa %s: %s"
+
+#: ../src/msw/ole/dataobj.cpp:385
+#, c-format
+msgid "Couldn't register clipboard format '%s'."
+msgstr "Ei voi rekisteröidä leikepöytämuotoa ”%s”."
+
+#: ../src/msw/ole/dataobj.cpp:402
+#, c-format
+msgid "The clipboard format '%d' doesn't exist."
+msgstr "Leikepöydän muotoa ”%d” ei ole olemassa."
+
+#: ../src/msw/progdlg.cpp:1025
+msgid "Skip"
+msgstr "Ohita"
+
+#: ../src/msw/registry.cpp:141
+#, fuzzy, c-format
+msgid "unknown (%lu)"
+msgstr "tuntematon"
+
+#: ../src/msw/registry.cpp:409
+#, c-format
+msgid "Can't get info about registry key '%s'"
+msgstr "Tiedon saanti rekisteriavaimesta ”%s” ei onnistu"
+
+#: ../src/msw/registry.cpp:445
+#, c-format
+msgid "Can't open registry key '%s'"
+msgstr "Rekisteriavaimen ”%s” avaaminen ei onnistu"
+
+#: ../src/msw/registry.cpp:478
+#, c-format
+msgid "Can't create registry key '%s'"
+msgstr "Rekisteriavaimen ”%s” luonti ei onnistu"
+
+#: ../src/msw/registry.cpp:497
+#, c-format
+msgid "Can't close registry key '%s'"
+msgstr "Rekisteriavainta ”%s” ei voida sulkea"
+
+#: ../src/msw/registry.cpp:512
+#, c-format
+msgid "Registry value '%s' already exists."
+msgstr "Rekisterin arvo ”%s” on jo olemassa."
+
+#: ../src/msw/registry.cpp:520
+#, c-format
+msgid "Failed to rename registry value '%s' to '%s'."
+msgstr "Rekisteriavaimen ”%s” nimeäminen ”%s”:ksi ei onnistu."
+
+#: ../src/msw/registry.cpp:575
+#, c-format
+msgid "Can't copy values of unsupported type %d."
+msgstr "En voi kopioida arvoja, joiden tyyppiä %d ei ole tuettu."
+
+#: ../src/msw/registry.cpp:586
+#, c-format
+msgid "Registry key '%s' does not exist, cannot rename it."
+msgstr "Rekisteriavain ”%s” ei ole olemassa, sitä ei voi uudelleennimetä."
+
+#: ../src/msw/registry.cpp:617
+#, c-format
+msgid "Registry key '%s' already exists."
+msgstr "Rekisteriavain ”%s” on jo olemassa."
+
+#: ../src/msw/registry.cpp:625
+#, c-format
+msgid "Failed to rename the registry key '%s' to '%s'."
+msgstr "Rekisteriavaimen ”%s” nimeäminen ”%s”:ksi ei onnistu."
+
+#: ../src/msw/registry.cpp:670
+#, fuzzy, c-format
+msgid "Failed to copy the registry subkey '%s' to '%s'."
+msgstr "Ali-rekisteriavaimen ”%s” kopiointi ”%s”:ksi ei onnistu."
+
+#: ../src/msw/registry.cpp:683
+#, c-format
+msgid "Failed to copy registry value '%s'"
+msgstr "Rekisteriarvon ”%s” kopiointi ei onnistu"
+
+#: ../src/msw/registry.cpp:692
+#, c-format
+msgid "Failed to copy the contents of registry key '%s' to '%s'."
+msgstr "Ei voi kopioida rekisteriavaimen ”%s” sisältää avaimeen ”%s”."
+
+#: ../src/msw/registry.cpp:718
+#, c-format
+msgid ""
+"Registry key '%s' is needed for normal system operation,\n"
+"deleting it will leave your system in unusable state:\n"
+"operation aborted."
+msgstr ""
+"Rekisteriavainta ”%s” tarvitaan järjestelmän normaaliin\n"
+"toimintaan. Avaimen poistaminen jättää järjestelmän\n"
+"epävakaaseen tilaan: toiminto keskeytetty."
+
+#: ../src/msw/registry.cpp:754
+#, c-format
+msgid "Can't delete key '%s'"
+msgstr "Avainta ”%s” ei voi poistaa"
+
+#: ../src/msw/registry.cpp:782
+#, c-format
+msgid "Can't delete value '%s' from key '%s'"
+msgstr "Arvon ”%s” poisto avaimesta ”%s” ei onnistu"
+
+#: ../src/msw/registry.cpp:855 ../src/msw/registry.cpp:887
+#: ../src/msw/registry.cpp:929 ../src/msw/registry.cpp:1000
+#, c-format
+msgid "Can't read value of key '%s'"
+msgstr "Ei voida lukea arvoa avaimesta ”%s”"
+
+#: ../src/msw/registry.cpp:873 ../src/msw/registry.cpp:915
+#: ../src/msw/registry.cpp:963 ../src/msw/registry.cpp:1106
+#, c-format
+msgid "Can't set value of '%s'"
+msgstr "Ei voida asettaa arvoa ”%s”"
+
+#: ../src/msw/registry.cpp:894 ../src/msw/registry.cpp:943
+#, c-format
+msgid "Registry value \"%s\" is not numeric (but of type %s)"
+msgstr ""
+
+#: ../src/msw/registry.cpp:979
+#, c-format
+msgid "Registry value \"%s\" is not binary (but of type %s)"
+msgstr ""
+
+#: ../src/msw/registry.cpp:1028
+#, c-format
+msgid "Registry value \"%s\" is not text (but of type %s)"
+msgstr ""
+
+#: ../src/msw/registry.cpp:1089
+#, c-format
+msgid "Can't read value of '%s'"
+msgstr "”%s”:n arvoa ei voida lukea"
+
+#: ../src/msw/registry.cpp:1157
+#, c-format
+msgid "Can't enumerate values of key '%s'"
+msgstr "Avaimen ”%s” arvoja ei voi luetella"
+
+#: ../src/msw/registry.cpp:1196
+#, c-format
+msgid "Can't enumerate subkeys of key '%s'"
+msgstr "Avaimen ”%s” aliavaimia ei voi luetella"
+
+#: ../src/msw/registry.cpp:1262
+#, fuzzy, c-format
+msgid ""
+"Exporting registry key: file \"%s\" already exists and won't be overwritten."
+msgstr "Viety rekisteriavain: tiedosto ”%s” on jo olemassa eikä sitä korvata."
+
+#: ../src/msw/registry.cpp:1411
+#, c-format
+msgid "Can't export value of unsupported type %d."
+msgstr "Tukemattoman tyypin %d arvoja ei voida viedä."
+
+#: ../src/msw/registry.cpp:1427
+#, fuzzy, c-format
+msgid "Ignoring value \"%s\" of the key \"%s\"."
+msgstr "Ohitetaan arvo ”%s” avaimessa ”%s”."
+
+#: ../src/msw/textctrl.cpp:596
+msgid ""
+"Impossible to create a rich edit control, using simple text control instead. "
+"Please reinstall riched32.dll"
+msgstr ""
+"Rich Edit tekstimuokkaus on mahdotonta, käytetään tavanomaista "
+"tekstimuokkausta.Asenna riched32.dll uudestaan."
+
+#: ../src/msw/thread.cpp:522 ../src/unix/threadpsx.cpp:850
+msgid "Cannot start thread: error writing TLS."
+msgstr "Säikeen käynnistys epäonnistui: virhe TLS-kirjoituksessa."
+
+#: ../src/msw/thread.cpp:613
+msgid "Can't set thread priority"
+msgstr "Säikeen prioriteetin asetus epäonnistui"
+
+#: ../src/msw/thread.cpp:649
+msgid "Can't create thread"
+msgstr "Säiettä ei voi luoda"
+
+#: ../src/msw/thread.cpp:668
+msgid "Couldn't terminate thread"
+msgstr "Säiettä ei voi päättää"
+
+#: ../src/msw/thread.cpp:799
+msgid "Cannot wait for thread termination"
+msgstr "Ei voi odottaa säikeen keskeytystä"
+
+#: ../src/msw/thread.cpp:873
+#, fuzzy, c-format
+msgid "Cannot suspend thread %lx"
+msgstr "Säikeen %x keskeytys epäonnistui"
+
+#: ../src/msw/thread.cpp:903
+#, fuzzy, c-format
+msgid "Cannot resume thread %lx"
+msgstr "Säikeen %x jatko epäonnistui"
+
+#: ../src/msw/thread.cpp:932
+msgid "Couldn't get the current thread pointer"
+msgstr "Säikeen osoittimen haku epäonnistui"
+
+#: ../src/msw/thread.cpp:1333
+msgid ""
+"Thread module initialization failed: impossible to allocate index in thread "
+"local storage"
+msgstr ""
+"Säiemoduulin käynnistys epäonnistui: indeksin varaus säikeen muistiin "
+"mahdotonta"
+
+#: ../src/msw/thread.cpp:1345
+msgid ""
+"Thread module initialization failed: cannot store value in thread local "
+"storage"
+msgstr ""
+"Säiemoduulin käynnistys epäonnistui: arvoa ei voi tallentaa säikeen muistiin"
+
+#: ../src/msw/timer.cpp:133
+msgid "Couldn't create a timer"
+msgstr "Ajastimen luonti epäonnistui"
+
+#: ../src/msw/utils.cpp:372
+msgid "can't find user's HOME, using current directory."
+msgstr "käyttäjän kotihakemistoa ei löydy, käytetään nykyistä hakemistoa."
+
+#: ../src/msw/utils.cpp:662
+#, c-format
+msgid "Failed to kill process %d"
+msgstr "Prosessia %d ei voitu lopettaa."
+
+#: ../src/msw/utils.cpp:986
+#, fuzzy, c-format
+msgid "Failed to load resource \"%s\"."
+msgstr "Prosessia %d ei voitu lopettaa."
+
+#: ../src/msw/utils.cpp:993
+#, fuzzy, c-format
+msgid "Failed to lock resource \"%s\"."
+msgstr "Lukkotiedostoa ”%s” ei voitu lukita"
+
+#. TRANSLATORS: MS Windows build number
+#: ../src/msw/utils.cpp:1209
+#, c-format
+msgid "build %lu"
+msgstr "käännös %lu"
+
+#: ../src/msw/utils.cpp:1218
+msgid ", 64-bit edition"
+msgstr ", 64-bittinen versio"
+
+#: ../src/msw/utilsexc.cpp:224
+msgid "Failed to create an anonymous pipe"
+msgstr "Anonyymin putken luonti epäonnistui"
+
+#: ../src/msw/utilsexc.cpp:697
+msgid "Failed to redirect the child process IO"
+msgstr "Lapsiprosessin I/O:n uudelleenohjaus epäonnistui"
+
+#: ../src/msw/utilsexc.cpp:870
+#, c-format
+msgid "Execution of command '%s' failed"
+msgstr "Komennon ”%s” käynnistäminen epäonnistui"
+
+#: ../src/msw/volume.cpp:337
+msgid "Failed to load mpr.dll."
+msgstr "Tiedoston mpr.dll lataus epäonnistui."
+
+#: ../src/msw/volume.cpp:506
+#, c-format
+msgid "Cannot read typename from '%s'!"
+msgstr "Tyyppinimeä ei voi lukea: ”%s”"
+
+#: ../src/msw/volume.cpp:615
+#, c-format
+msgid "Cannot load icon from '%s'."
+msgstr "Ei voitu ladata kuvaketta tiedostosta ”%s”."
+
+#: ../src/msw/webview_edge.cpp:285
+msgid "This program was compiled without support for setting Edge proxy."
+msgstr ""
+
+#: ../src/msw/webview_ie.cpp:1010
+msgid "Failed to find web view emulation level in the registry"
+msgstr ""
+
+#: ../src/msw/webview_ie.cpp:1019
+msgid "Failed to set web view to modern emulation level"
+msgstr ""
+
+#: ../src/msw/webview_ie.cpp:1027
+msgid "Failed to reset web view to standard emulation level"
+msgstr ""
+
+#: ../src/msw/webview_ie.cpp:1049
+msgid "Can't run JavaScript script without a valid HTML document"
+msgstr ""
+
+#: ../src/msw/webview_ie.cpp:1056
+#, fuzzy
+msgid "Can't get the JavaScript object"
+msgstr "Säikeen prioriteetin asetus epäonnistui"
+
+#: ../src/msw/webview_ie.cpp:1070
+#, fuzzy
+msgid "failed to evaluate"
+msgstr "Ei voitu ajaa kohdetta ”%s”\n"
+
+#: ../src/osx/cocoa/filedlg.mm:412
+#, fuzzy
+msgid "File type:"
+msgstr "Teletype"
+
+#: ../src/osx/cocoa/menu.mm:242
+msgctxt "macOS menu name"
+msgid "Window"
+msgstr "Ikkuna"
+
+#: ../src/osx/cocoa/menu.mm:259
+msgctxt "macOS menu name"
+msgid "Help"
+msgstr "Ohje"
+
+#: ../src/osx/cocoa/menu.mm:298
+msgctxt "macOS menu item"
+msgid "Minimize"
+msgstr "Pienennä"
+
+#: ../src/osx/cocoa/menu.mm:303
+msgctxt "macOS menu item"
+msgid "Zoom"
+msgstr "Zoomaa"
+
+#: ../src/osx/cocoa/menu.mm:309
+msgctxt "macOS menu item"
+msgid "Bring All to Front"
+msgstr ""
+
+#: ../src/osx/core/sound.cpp:143
+#, fuzzy, c-format
+msgid "Failed to load sound from \"%s\" (error %d)."
+msgstr "Prosessia %d ei voitu lopettaa."
+
+#: ../src/osx/fontutil.cpp:80
+#, fuzzy, c-format
+msgid "Font file \"%s\" doesn't exist."
+msgstr "Tiedosto %s ei ole olemassa."
+
+#: ../src/osx/fontutil.cpp:88
+#, c-format
+msgid ""
+"Font file \"%s\" cannot be used as it is not inside the font directory "
+"\"%s\"."
+msgstr ""
+
+#: ../src/osx/menu_osx.cpp:496
+#, c-format
+msgctxt "macOS menu item"
+msgid "About %s"
+msgstr "Tietoja: %s"
+
+#: ../src/osx/menu_osx.cpp:499
+msgctxt "macOS menu item"
+msgid "About..."
+msgstr "Tietoja..."
+
+#: ../src/osx/menu_osx.cpp:508
+msgctxt "macOS menu item"
+msgid "Preferences..."
+msgstr "Asetukset..."
+
+#: ../src/osx/menu_osx.cpp:512
+msgctxt "macOS menu item"
+msgid "Services"
+msgstr "Palvelut"
+
+#: ../src/osx/menu_osx.cpp:519
+#, c-format
+msgctxt "macOS menu item"
+msgid "Hide %s"
+msgstr "Kätke %s"
+
+#: ../src/osx/menu_osx.cpp:522
+msgctxt "macOS menu item"
+msgid "Hide Application"
+msgstr "Kätke Appi"
+
+#: ../src/osx/menu_osx.cpp:526
+msgctxt "macOS menu item"
+msgid "Hide Others"
+msgstr "Kätke muut"
+
+#: ../src/osx/menu_osx.cpp:528
+msgctxt "macOS menu item"
+msgid "Show All"
+msgstr "Näytä kaikki"
+
+#: ../src/osx/menu_osx.cpp:534
+#, c-format
+msgctxt "macOS menu item"
+msgid "Quit %s"
+msgstr "Lopeta %s"
+
+#: ../src/osx/menu_osx.cpp:537
+msgctxt "macOS menu item"
+msgid "Quit Application"
+msgstr "Lopeta Appi"
+
+#: ../src/osx/webview_webkit.mm:444
+#, fuzzy
+msgid "Printing is not supported by the system web control"
+msgstr "Gzip:iä ei tueta zlib:in tässä versiossa"
+
+#: ../src/osx/webview_webkit.mm:453
+#, fuzzy
+msgid "Print operation could not be initialized"
+msgstr "Sarakkeen kuvausta ei voitu alustaa."
+
+#. TRANSLATORS: Label of font point size
+#: ../src/propgrid/advprops.cpp:605
+#, fuzzy
+msgid "Point Size"
+msgstr "K&irjasinkoko:"
+
+#. TRANSLATORS: Label of font face name
+#: ../src/propgrid/advprops.cpp:615
+#, fuzzy
+msgid "Face Name"
+msgstr "UusiNimi"
+
+#. TRANSLATORS: Label of font style
+#: ../src/propgrid/advprops.cpp:623 ../src/richtext/richtextformatdlg.cpp:331
+msgid "Style"
+msgstr "Tyyli"
+
+#. TRANSLATORS: Label of font weight
+#: ../src/propgrid/advprops.cpp:628
+msgid "Weight"
+msgstr "Paino"
+
+#. TRANSLATORS: Label of underlined font
+#: ../src/propgrid/advprops.cpp:633 ../src/richtext/richtextfontpage.cpp:358
+msgid "Underlined"
+msgstr "Alleviivattu"
+
+#. TRANSLATORS: Label of font family
+#: ../src/propgrid/advprops.cpp:637
+#, fuzzy
+msgid "Family"
+msgstr "&Kirjasinperhe:"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:801
+msgid "AppWorkspace"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:802
+#, fuzzy
+msgid "ActiveBorder"
+msgstr "Moderni"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:803
+msgid "ActiveCaption"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:804
+msgid "ButtonFace"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:805
+msgid "ButtonHighlight"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:806
+msgid "ButtonShadow"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:807
+msgid "ButtonText"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:808
+msgid "CaptionText"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:809
+msgid "ControlDark"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:810
+msgid "ControlLight"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:812
+msgid "GrayText"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:813
+#, fuzzy
+msgid "Highlight"
+msgstr "heikko"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:814
+#, fuzzy
+msgid "HighlightText"
+msgstr "Tasaa teksti oikealle."
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:815
+#, fuzzy
+msgid "InactiveBorder"
+msgstr "Moderni"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:816
+msgid "InactiveCaption"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:817
+msgid "InactiveCaptionText"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:818
+msgid "Menu"
+msgstr "Valikko"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:819
+msgid "Scrollbar"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:820
+msgid "Tooltip"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:821
+msgid "TooltipText"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:822
+#, fuzzy
+msgid "Window"
+msgstr "&Ikkuna"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:823
+#, fuzzy
+msgid "WindowFrame"
+msgstr "&Ikkuna"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:824
+#, fuzzy
+msgid "WindowText"
+msgstr "&Ikkuna"
+
+#. TRANSLATORS: Custom colour choice entry
+#: ../src/propgrid/advprops.cpp:825 ../src/propgrid/advprops.cpp:1532
+#: ../src/propgrid/advprops.cpp:1576
+#, fuzzy
+msgid "Custom"
+msgstr "Valinnainen koko"
+
+#: ../src/propgrid/advprops.cpp:1558
+msgid "Black"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1559
+msgid "Maroon"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1560
+msgid "Navy"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1561
+msgid "Purple"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1562
+msgid "Teal"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1563
+msgid "Gray"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1564
+#, fuzzy
+msgid "Green"
+msgstr "Mac (kreikkalainen)"
+
+#: ../src/propgrid/advprops.cpp:1565
+msgid "Olive"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1566
+#, fuzzy
+msgid "Brown"
+msgstr "Selaa"
+
+#: ../src/propgrid/advprops.cpp:1567
+msgid "Blue"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1568
+msgid "Fuchsia"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1569
+#, fuzzy
+msgid "Red"
+msgstr "Toista"
+
+#: ../src/propgrid/advprops.cpp:1570
+msgid "Orange"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1571
+msgid "Silver"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1572
+msgid "Lime"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1573
+msgid "Aqua"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1574
+msgid "Yellow"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1575
+msgid "White"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1718
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Default"
+msgstr "oletus"
+
+#: ../src/propgrid/advprops.cpp:1719
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Arrow"
+msgstr "huomenna"
+
+#: ../src/propgrid/advprops.cpp:1720
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Right Arrow"
+msgstr "Oikealle"
+
+#: ../src/propgrid/advprops.cpp:1721
+msgctxt "system cursor name"
+msgid "Blank"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1722
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Bullseye"
+msgstr "Luettelomerkkityyli"
+
+#: ../src/propgrid/advprops.cpp:1723
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Character"
+msgstr "&Merkkikoodi:"
+
+#: ../src/propgrid/advprops.cpp:1724
+msgctxt "system cursor name"
+msgid "Cross"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1725
+msgctxt "system cursor name"
+msgid "Hand"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1726
+msgctxt "system cursor name"
+msgid "I-Beam"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1727
+msgctxt "system cursor name"
+msgid "Left Button"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1728
+msgctxt "system cursor name"
+msgid "Magnifier"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1729
+msgctxt "system cursor name"
+msgid "Middle Button"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1730
+msgctxt "system cursor name"
+msgid "No Entry"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1731
+msgctxt "system cursor name"
+msgid "Paint Brush"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1732
+msgctxt "system cursor name"
+msgid "Pencil"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1733
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Point Left"
+msgstr "K&irjasinkoko:"
+
+#: ../src/propgrid/advprops.cpp:1734
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Point Right"
+msgstr "Tasaa oikealle"
+
+#: ../src/propgrid/advprops.cpp:1735
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Question Arrow"
+msgstr "Kysymys"
+
+#: ../src/propgrid/advprops.cpp:1736
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Right Button"
+msgstr "Oikealle"
+
+#: ../src/propgrid/advprops.cpp:1737
+msgctxt "system cursor name"
+msgid "Sizing NE-SW"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1738
+msgctxt "system cursor name"
+msgid "Sizing N-S"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1739
+msgctxt "system cursor name"
+msgid "Sizing NW-SE"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1740
+msgctxt "system cursor name"
+msgid "Sizing W-E"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1741
+msgctxt "system cursor name"
+msgid "Sizing"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1742
+msgctxt "system cursor name"
+msgid "Spraycan"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1743
+msgctxt "system cursor name"
+msgid "Wait"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1744
+msgctxt "system cursor name"
+msgid "Watch"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1745
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Wait Arrow"
+msgstr "Oikealle"
+
+#: ../src/propgrid/advprops.cpp:2109
+#, fuzzy
+msgid "Make a selection:"
+msgstr "Liitä valinta"
+
+#: ../src/propgrid/manager.cpp:394
+#, fuzzy
+msgid "Property"
+msgstr "&Ominaisuudet"
+
+#: ../src/propgrid/manager.cpp:395
+msgid "Value"
+msgstr ""
+
+#: ../src/propgrid/manager.cpp:1683
+msgid "Categorized Mode"
+msgstr "Kategorisoitu tila"
+
+#: ../src/propgrid/manager.cpp:1709
+msgid "Alphabetic Mode"
+msgstr "Aakkosnumeerinen tila"
+
+#. TRANSLATORS: Name of Boolean false value
+#: ../src/propgrid/propgrid.cpp:230
+#, fuzzy
+msgid "False"
+msgstr "Tiedosto"
+
+#. TRANSLATORS: Name of Boolean true value
+#: ../src/propgrid/propgrid.cpp:232
+msgid "True"
+msgstr "Tosi"
+
+#. TRANSLATORS: Text  displayed for unspecified value
+#: ../src/propgrid/propgrid.cpp:428
+#, fuzzy
+msgid "Unspecified"
+msgstr "Tasattu"
+
+#. TRANSLATORS: Caption of message box displaying any property error
+#: ../src/propgrid/propgrid.cpp:3145 ../src/propgrid/propgrid.cpp:3282
+#, fuzzy
+msgid "Property Error"
+msgstr "Tulostusvirhe"
+
+#: ../src/propgrid/propgrid.cpp:3259
+msgid "You have entered invalid value. Press ESC to cancel editing."
+msgstr ""
+
+#: ../src/propgrid/propgrid.cpp:6608
+#, c-format
+msgid "Error in resource: %s"
+msgstr "Virhe resurssissa: %s"
+
+#: ../src/propgrid/propgridiface.cpp:377
+#, c-format
+msgid ""
+"Type operation \"%s\" failed: Property labeled \"%s\" is of type \"%s\", NOT "
+"\"%s\"."
+msgstr ""
+
+#: ../src/propgrid/props.cpp:159
+#, c-format
+msgid "Unknown base %d. Base 10 will be used."
+msgstr ""
+
+#: ../src/propgrid/props.cpp:324
+#, c-format
+msgid "Value must be %s or higher."
+msgstr ""
+
+#: ../src/propgrid/props.cpp:329 ../src/propgrid/props.cpp:356
+#, fuzzy, c-format
+msgid "Value must be between %s and %s."
+msgstr "Anna sivunumero väliltä %d ja %d:"
+
+#: ../src/propgrid/props.cpp:351
+#, c-format
+msgid "Value must be %s or less."
+msgstr ""
+
+#: ../src/propgrid/props.cpp:1058
+#, fuzzy, c-format
+msgid "Not %s"
+msgstr "Tietoja %s"
+
+#: ../src/propgrid/props.cpp:1770
+#, fuzzy
+msgid "Choose a directory:"
+msgstr "Luo hakemisto"
+
+#: ../src/propgrid/props.cpp:2055
+#, fuzzy
+msgid "Choose a file"
+msgstr "Valitse kirjasinlaji"
+
+#: ../src/qt/mdi.cpp:254
+msgid "&Tile"
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:147
+#: ../src/richtext/richtextformatdlg.cpp:376
+msgid "Background"
+msgstr "Tausta"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:159
+msgid "Background &colour:"
+msgstr "Tausta&väri:"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:161
+#: ../src/richtext/richtextbackgroundpage.cpp:163
+#, fuzzy
+msgid "Enables a background colour."
+msgstr "Taustaväri"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:167
+#: ../src/richtext/richtextbackgroundpage.cpp:169
+#, fuzzy
+msgid "The background colour."
+msgstr "Taustaväri"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:178
+msgid "Shadow"
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:193
+msgid "Use &shadow"
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:195
+#: ../src/richtext/richtextbackgroundpage.cpp:197
+#, fuzzy
+msgid "Enables a shadow."
+msgstr "Taustaväri"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:211
+msgid "&Horizontal offset:"
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:218
+#: ../src/richtext/richtextbackgroundpage.cpp:220
+#, fuzzy
+msgid "The horizontal offset."
+msgstr "Ota käyttöön pysty-offset."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:224
+#: ../src/richtext/richtextbackgroundpage.cpp:227
+#: ../src/richtext/richtextbackgroundpage.cpp:228
+#: ../src/richtext/richtextbackgroundpage.cpp:247
+#: ../src/richtext/richtextbackgroundpage.cpp:250
+#: ../src/richtext/richtextbackgroundpage.cpp:251
+#: ../src/richtext/richtextbackgroundpage.cpp:287
+#: ../src/richtext/richtextbackgroundpage.cpp:290
+#: ../src/richtext/richtextbackgroundpage.cpp:291
+#: ../src/richtext/richtextbackgroundpage.cpp:314
+#: ../src/richtext/richtextbackgroundpage.cpp:317
+#: ../src/richtext/richtextbackgroundpage.cpp:318
+#: ../src/richtext/richtextborderspage.cpp:252
+#: ../src/richtext/richtextborderspage.cpp:255
+#: ../src/richtext/richtextborderspage.cpp:256
+#: ../src/richtext/richtextborderspage.cpp:286
+#: ../src/richtext/richtextborderspage.cpp:289
+#: ../src/richtext/richtextborderspage.cpp:290
+#: ../src/richtext/richtextborderspage.cpp:320
+#: ../src/richtext/richtextborderspage.cpp:323
+#: ../src/richtext/richtextborderspage.cpp:324
+#: ../src/richtext/richtextborderspage.cpp:354
+#: ../src/richtext/richtextborderspage.cpp:357
+#: ../src/richtext/richtextborderspage.cpp:358
+#: ../src/richtext/richtextborderspage.cpp:420
+#: ../src/richtext/richtextborderspage.cpp:423
+#: ../src/richtext/richtextborderspage.cpp:424
+#: ../src/richtext/richtextborderspage.cpp:454
+#: ../src/richtext/richtextborderspage.cpp:457
+#: ../src/richtext/richtextborderspage.cpp:458
+#: ../src/richtext/richtextborderspage.cpp:488
+#: ../src/richtext/richtextborderspage.cpp:491
+#: ../src/richtext/richtextborderspage.cpp:492
+#: ../src/richtext/richtextborderspage.cpp:522
+#: ../src/richtext/richtextborderspage.cpp:525
+#: ../src/richtext/richtextborderspage.cpp:526
+#: ../src/richtext/richtextborderspage.cpp:590
+#: ../src/richtext/richtextborderspage.cpp:593
+#: ../src/richtext/richtextborderspage.cpp:594
+#: ../src/richtext/richtextfontpage.cpp:177
+#: ../src/richtext/richtextmarginspage.cpp:199
+#: ../src/richtext/richtextmarginspage.cpp:201
+#: ../src/richtext/richtextmarginspage.cpp:202
+#: ../src/richtext/richtextmarginspage.cpp:224
+#: ../src/richtext/richtextmarginspage.cpp:226
+#: ../src/richtext/richtextmarginspage.cpp:227
+#: ../src/richtext/richtextmarginspage.cpp:247
+#: ../src/richtext/richtextmarginspage.cpp:249
+#: ../src/richtext/richtextmarginspage.cpp:250
+#: ../src/richtext/richtextmarginspage.cpp:272
+#: ../src/richtext/richtextmarginspage.cpp:274
+#: ../src/richtext/richtextmarginspage.cpp:275
+#: ../src/richtext/richtextmarginspage.cpp:313
+#: ../src/richtext/richtextmarginspage.cpp:315
+#: ../src/richtext/richtextmarginspage.cpp:316
+#: ../src/richtext/richtextmarginspage.cpp:338
+#: ../src/richtext/richtextmarginspage.cpp:340
+#: ../src/richtext/richtextmarginspage.cpp:341
+#: ../src/richtext/richtextmarginspage.cpp:361
+#: ../src/richtext/richtextmarginspage.cpp:363
+#: ../src/richtext/richtextmarginspage.cpp:364
+#: ../src/richtext/richtextmarginspage.cpp:386
+#: ../src/richtext/richtextmarginspage.cpp:388
+#: ../src/richtext/richtextmarginspage.cpp:389
+#: ../src/richtext/richtextsizepage.cpp:337
+#: ../src/richtext/richtextsizepage.cpp:340
+#: ../src/richtext/richtextsizepage.cpp:341
+#: ../src/richtext/richtextsizepage.cpp:371
+#: ../src/richtext/richtextsizepage.cpp:374
+#: ../src/richtext/richtextsizepage.cpp:375
+#: ../src/richtext/richtextsizepage.cpp:398
+#: ../src/richtext/richtextsizepage.cpp:401
+#: ../src/richtext/richtextsizepage.cpp:402
+#: ../src/richtext/richtextsizepage.cpp:425
+#: ../src/richtext/richtextsizepage.cpp:428
+#: ../src/richtext/richtextsizepage.cpp:429
+#: ../src/richtext/richtextsizepage.cpp:452
+#: ../src/richtext/richtextsizepage.cpp:455
+#: ../src/richtext/richtextsizepage.cpp:456
+#: ../src/richtext/richtextsizepage.cpp:479
+#: ../src/richtext/richtextsizepage.cpp:482
+#: ../src/richtext/richtextsizepage.cpp:483
+#: ../src/richtext/richtextsizepage.cpp:553
+#: ../src/richtext/richtextsizepage.cpp:556
+#: ../src/richtext/richtextsizepage.cpp:557
+#: ../src/richtext/richtextsizepage.cpp:588
+#: ../src/richtext/richtextsizepage.cpp:591
+#: ../src/richtext/richtextsizepage.cpp:592
+#: ../src/richtext/richtextsizepage.cpp:623
+#: ../src/richtext/richtextsizepage.cpp:626
+#: ../src/richtext/richtextsizepage.cpp:627
+#: ../src/richtext/richtextsizepage.cpp:658
+#: ../src/richtext/richtextsizepage.cpp:661
+#: ../src/richtext/richtextsizepage.cpp:662
+msgid "px"
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:225
+#: ../src/richtext/richtextbackgroundpage.cpp:248
+#: ../src/richtext/richtextbackgroundpage.cpp:288
+#: ../src/richtext/richtextbackgroundpage.cpp:315
+#: ../src/richtext/richtextborderspage.cpp:253
+#: ../src/richtext/richtextborderspage.cpp:287
+#: ../src/richtext/richtextborderspage.cpp:321
+#: ../src/richtext/richtextborderspage.cpp:355
+#: ../src/richtext/richtextborderspage.cpp:421
+#: ../src/richtext/richtextborderspage.cpp:455
+#: ../src/richtext/richtextborderspage.cpp:489
+#: ../src/richtext/richtextborderspage.cpp:523
+#: ../src/richtext/richtextborderspage.cpp:591
+#: ../src/richtext/richtextmarginspage.cpp:200
+#: ../src/richtext/richtextmarginspage.cpp:225
+#: ../src/richtext/richtextmarginspage.cpp:248
+#: ../src/richtext/richtextmarginspage.cpp:273
+#: ../src/richtext/richtextmarginspage.cpp:314
+#: ../src/richtext/richtextmarginspage.cpp:339
+#: ../src/richtext/richtextmarginspage.cpp:362
+#: ../src/richtext/richtextmarginspage.cpp:387
+#: ../src/richtext/richtextsizepage.cpp:338
+#: ../src/richtext/richtextsizepage.cpp:372
+#: ../src/richtext/richtextsizepage.cpp:399
+#: ../src/richtext/richtextsizepage.cpp:426
+#: ../src/richtext/richtextsizepage.cpp:453
+#: ../src/richtext/richtextsizepage.cpp:480
+#: ../src/richtext/richtextsizepage.cpp:554
+#: ../src/richtext/richtextsizepage.cpp:589
+#: ../src/richtext/richtextsizepage.cpp:624
+#: ../src/richtext/richtextsizepage.cpp:659
+msgid "cm"
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:226
+#: ../src/richtext/richtextbackgroundpage.cpp:249
+#: ../src/richtext/richtextbackgroundpage.cpp:289
+#: ../src/richtext/richtextbackgroundpage.cpp:316
+#: ../src/richtext/richtextborderspage.cpp:254
+#: ../src/richtext/richtextborderspage.cpp:288
+#: ../src/richtext/richtextborderspage.cpp:322
+#: ../src/richtext/richtextborderspage.cpp:356
+#: ../src/richtext/richtextborderspage.cpp:422
+#: ../src/richtext/richtextborderspage.cpp:456
+#: ../src/richtext/richtextborderspage.cpp:490
+#: ../src/richtext/richtextborderspage.cpp:524
+#: ../src/richtext/richtextborderspage.cpp:592
+#: ../src/richtext/richtextfontpage.cpp:176
+#: ../src/richtext/richtextfontpage.cpp:179
+msgid "pt"
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:229
+#: ../src/richtext/richtextbackgroundpage.cpp:231
+#: ../src/richtext/richtextbackgroundpage.cpp:252
+#: ../src/richtext/richtextbackgroundpage.cpp:254
+#: ../src/richtext/richtextbackgroundpage.cpp:292
+#: ../src/richtext/richtextbackgroundpage.cpp:294
+#: ../src/richtext/richtextbackgroundpage.cpp:319
+#: ../src/richtext/richtextbackgroundpage.cpp:321
+#, fuzzy
+msgid "Units for this value."
+msgstr "Ei voi odottaa säikeen keskeytystä"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:234
+#, fuzzy
+msgid "&Vertical offset:"
+msgstr "&Tasaus pystysuunnassa:"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:241
+#: ../src/richtext/richtextbackgroundpage.cpp:243
+#, fuzzy
+msgid "The vertical offset."
+msgstr "Ota käyttöön pysty-offset."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:257
+#, fuzzy
+msgid "Shadow c&olour:"
+msgstr "Valitse väri"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:259
+#: ../src/richtext/richtextbackgroundpage.cpp:261
+#, fuzzy
+msgid "Enables the shadow colour."
+msgstr "Taustaväri"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:265
+#: ../src/richtext/richtextbackgroundpage.cpp:267
+#, fuzzy
+msgid "The shadow colour."
+msgstr "Kirjasimen väri."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:270
+msgid "Sh&adow spread:"
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:272
+#: ../src/richtext/richtextbackgroundpage.cpp:274
+#, fuzzy
+msgid "Enables the shadow spread."
+msgstr "Käytä leveysarvoa."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:281
+#: ../src/richtext/richtextbackgroundpage.cpp:283
+msgid "The shadow spread."
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:297
+msgid "&Blur distance:"
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:299
+#: ../src/richtext/richtextbackgroundpage.cpp:301
+#, fuzzy
+msgid "Enables the blur distance."
+msgstr "Käytä leveysarvoa."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:308
+#: ../src/richtext/richtextbackgroundpage.cpp:310
+msgid "The shadow blur distance."
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:324
+msgid "Opaci&ty:"
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:326
+#: ../src/richtext/richtextbackgroundpage.cpp:328
+#, fuzzy
+msgid "Enables the shadow opacity."
+msgstr "Käytä leveysarvoa."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:335
+#: ../src/richtext/richtextbackgroundpage.cpp:337
+msgid "The shadow opacity."
+msgstr ""
+
+#. TRANSLATORS: Rich text page units (percentage)
+#: ../src/richtext/richtextbackgroundpage.cpp:340
+#: ../src/richtext/richtextsizepage.cpp:339
+#: ../src/richtext/richtextsizepage.cpp:373
+#: ../src/richtext/richtextsizepage.cpp:400
+#: ../src/richtext/richtextsizepage.cpp:427
+#: ../src/richtext/richtextsizepage.cpp:454
+#: ../src/richtext/richtextsizepage.cpp:481
+#: ../src/richtext/richtextsizepage.cpp:555
+#: ../src/richtext/richtextsizepage.cpp:590
+#: ../src/richtext/richtextsizepage.cpp:625
+#: ../src/richtext/richtextsizepage.cpp:660
+#, fuzzy
+msgid "%"
+msgstr "%s"
+
+#: ../src/richtext/richtextborderspage.cpp:229
+#: ../src/richtext/richtextborderspage.cpp:387
+#, fuzzy
+msgid "Border"
+msgstr "Moderni"
+
+#: ../src/richtext/richtextborderspage.cpp:242
+#: ../src/richtext/richtextborderspage.cpp:410
+#: ../src/richtext/richtextindentspage.cpp:194
+#: ../src/richtext/richtextliststylepage.cpp:384
+#: ../src/richtext/richtextmarginspage.cpp:185
+#: ../src/richtext/richtextmarginspage.cpp:299
+#: ../src/richtext/richtextsizepage.cpp:531
+#: ../src/richtext/richtextsizepage.cpp:538
+msgid "&Left:"
+msgstr "&Vasemmalle:"
+
+#: ../src/richtext/richtextborderspage.cpp:257
+#: ../src/richtext/richtextborderspage.cpp:259
+msgid "Units for the left border width."
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:266
+#: ../src/richtext/richtextborderspage.cpp:268
+#: ../src/richtext/richtextborderspage.cpp:300
+#: ../src/richtext/richtextborderspage.cpp:302
+#: ../src/richtext/richtextborderspage.cpp:334
+#: ../src/richtext/richtextborderspage.cpp:336
+#: ../src/richtext/richtextborderspage.cpp:368
+#: ../src/richtext/richtextborderspage.cpp:370
+#: ../src/richtext/richtextborderspage.cpp:434
+#: ../src/richtext/richtextborderspage.cpp:436
+#: ../src/richtext/richtextborderspage.cpp:468
+#: ../src/richtext/richtextborderspage.cpp:470
+#: ../src/richtext/richtextborderspage.cpp:502
+#: ../src/richtext/richtextborderspage.cpp:504
+#: ../src/richtext/richtextborderspage.cpp:536
+#: ../src/richtext/richtextborderspage.cpp:538
+#, fuzzy
+msgid "The border line style."
+msgstr "Kirjasimen tyyli."
+
+#: ../src/richtext/richtextborderspage.cpp:276
+#: ../src/richtext/richtextborderspage.cpp:444
+#: ../src/richtext/richtextindentspage.cpp:212
+#: ../src/richtext/richtextliststylepage.cpp:402
+#: ../src/richtext/richtextmarginspage.cpp:210
+#: ../src/richtext/richtextmarginspage.cpp:324
+#: ../src/richtext/richtextsizepage.cpp:601
+#: ../src/richtext/richtextsizepage.cpp:608
+msgid "&Right:"
+msgstr "&Oikealle:"
+
+#: ../src/richtext/richtextborderspage.cpp:291
+#: ../src/richtext/richtextborderspage.cpp:293
+msgid "Units for the right border width."
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:310
+#: ../src/richtext/richtextborderspage.cpp:478
+#: ../src/richtext/richtextmarginspage.cpp:233
+#: ../src/richtext/richtextmarginspage.cpp:347
+#: ../src/richtext/richtextsizepage.cpp:566
+#: ../src/richtext/richtextsizepage.cpp:573
+msgid "&Top:"
+msgstr "&Yläosa:"
+
+#: ../src/richtext/richtextborderspage.cpp:325
+#: ../src/richtext/richtextborderspage.cpp:327
+msgid "Units for the top border width."
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:344
+#: ../src/richtext/richtextborderspage.cpp:512
+#: ../src/richtext/richtextmarginspage.cpp:258
+#: ../src/richtext/richtextmarginspage.cpp:372
+#: ../src/richtext/richtextsizepage.cpp:636
+#: ../src/richtext/richtextsizepage.cpp:643
+msgid "&Bottom:"
+msgstr "&Alaosa:"
+
+#: ../src/richtext/richtextborderspage.cpp:359
+#: ../src/richtext/richtextborderspage.cpp:361
+msgid "Units for the bottom border width."
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:380
+#: ../src/richtext/richtextborderspage.cpp:548
+msgid "&Synchronize values"
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:382
+#: ../src/richtext/richtextborderspage.cpp:384
+#: ../src/richtext/richtextborderspage.cpp:550
+#: ../src/richtext/richtextborderspage.cpp:552
+msgid "Check to edit all borders simultaneously."
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:397
+#: ../src/richtext/richtextborderspage.cpp:555
+msgid "Outline"
+msgstr "Jäsennys"
+
+#: ../src/richtext/richtextborderspage.cpp:425
+#: ../src/richtext/richtextborderspage.cpp:427
+msgid "Units for the left outline width."
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:459
+#: ../src/richtext/richtextborderspage.cpp:461
+msgid "Units for the right outline width."
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:493
+#: ../src/richtext/richtextborderspage.cpp:495
+msgid "Units for the top outline width."
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:527
+#: ../src/richtext/richtextborderspage.cpp:529
+msgid "Units for the bottom outline width."
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:565
+#: ../src/richtext/richtextborderspage.cpp:600
+msgid "Corner"
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:574
+msgid "Corner &radius:"
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:576
+#: ../src/richtext/richtextborderspage.cpp:578
+msgid "An optional corner radius for adding rounded corners."
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:584
+#: ../src/richtext/richtextborderspage.cpp:586
+msgid "The value of the corner radius."
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:595
+#: ../src/richtext/richtextborderspage.cpp:597
+#, fuzzy
+msgid "Units for the corner radius."
+msgstr "Ei voi odottaa säikeen keskeytystä"
+
+#: ../src/richtext/richtextborderspage.cpp:609
+#: ../src/richtext/richtextsizepage.cpp:247
+#: ../src/richtext/richtextsizepage.cpp:251
+#, fuzzy
+msgid "None"
+msgstr "(Ei mitään)"
+
+#: ../src/richtext/richtextborderspage.cpp:610
+#, fuzzy
+msgid "Solid"
+msgstr "Lihavoitu"
+
+#: ../src/richtext/richtextborderspage.cpp:611
+#, fuzzy
+msgid "Dotted"
+msgstr "Valmis"
+
+#: ../src/richtext/richtextborderspage.cpp:612
+msgid "Dashed"
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:613
+#, fuzzy
+msgid "Double"
+msgstr "Valmis"
+
+#: ../src/richtext/richtextborderspage.cpp:614
+msgid "Groove"
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:615
+#, fuzzy
+msgid "Ridge"
+msgstr "Oikealle"
+
+#: ../src/richtext/richtextborderspage.cpp:616
+#, fuzzy
+msgid "Inset"
+msgstr "Lisää"
+
+#: ../src/richtext/richtextborderspage.cpp:617
+msgid "Outset"
+msgstr ""
+
+#: ../src/richtext/richtextbuffer.cpp:3518
+msgid "Change Style"
+msgstr "Muuta tyyli"
+
+#: ../src/richtext/richtextbuffer.cpp:3701
+#, fuzzy
+msgid "Change Object Style"
+msgstr "Muuta luettelotyyli"
+
+#: ../src/richtext/richtextbuffer.cpp:3974
+#: ../src/richtext/richtextbuffer.cpp:8174
+#, fuzzy
+msgid "Change Properties"
+msgstr "&Ominaisuudet"
+
+#: ../src/richtext/richtextbuffer.cpp:4346
+msgid "Change List Style"
+msgstr "Muuta luettelotyyli"
+
+#: ../src/richtext/richtextbuffer.cpp:4519
+msgid "Renumber List"
+msgstr "Numeroi luettelo uudelleen"
+
+#: ../src/richtext/richtextbuffer.cpp:7867
+#: ../src/richtext/richtextbuffer.cpp:7897
+#: ../src/richtext/richtextbuffer.cpp:7939
+#: ../src/richtext/richtextctrl.cpp:1279 ../src/richtext/richtextctrl.cpp:1473
+msgid "Insert Text"
+msgstr "Lisää teksti"
+
+#: ../src/richtext/richtextbuffer.cpp:8023
+#: ../src/richtext/richtextbuffer.cpp:8979
+msgid "Insert Image"
+msgstr "Lisää kuva"
+
+#: ../src/richtext/richtextbuffer.cpp:8070
+#, fuzzy
+msgid "Insert Object"
+msgstr "Lisää teksti"
+
+#: ../src/richtext/richtextbuffer.cpp:8112
+#, fuzzy
+msgid "Insert Field"
+msgstr "Lisää teksti"
+
+#: ../src/richtext/richtextbuffer.cpp:8410
+msgid "Too many EndStyle calls!"
+msgstr "Liian monta EndStyle-kutsua!"
+
+#: ../src/richtext/richtextbuffer.cpp:8785
+msgid "files"
+msgstr "tiedostot"
+
+#: ../src/richtext/richtextbuffer.cpp:9380
+msgid "standard/circle"
+msgstr "perus/ympyrä"
+
+#: ../src/richtext/richtextbuffer.cpp:9381
+msgid "standard/circle-outline"
+msgstr ""
+
+#: ../src/richtext/richtextbuffer.cpp:9382
+msgid "standard/square"
+msgstr "perus/neliö"
+
+#: ../src/richtext/richtextbuffer.cpp:9383
+msgid "standard/diamond"
+msgstr ""
+
+#: ../src/richtext/richtextbuffer.cpp:9384
+msgid "standard/triangle"
+msgstr ""
+
+#: ../src/richtext/richtextbuffer.cpp:9423
+#, fuzzy
+msgid "Box Properties"
+msgstr "&Ominaisuudet"
+
+#: ../src/richtext/richtextbuffer.cpp:10006
+msgid "Multiple Cell Properties"
+msgstr "Usean solun ominaisuudet"
+
+#: ../src/richtext/richtextbuffer.cpp:10008
+#, fuzzy
+msgid "Cell Properties"
+msgstr "&Ominaisuudet"
+
+#: ../src/richtext/richtextbuffer.cpp:11256
+#, fuzzy
+msgid "Set Cell Style"
+msgstr "Poista tyyli"
+
+#: ../src/richtext/richtextbuffer.cpp:11330
+#, fuzzy
+msgid "Delete Row"
+msgstr "Poista"
+
+#: ../src/richtext/richtextbuffer.cpp:11380
+#, fuzzy
+msgid "Delete Column"
+msgstr "Poista valinta"
+
+#: ../src/richtext/richtextbuffer.cpp:11431
+msgid "Add Row"
+msgstr ""
+
+#: ../src/richtext/richtextbuffer.cpp:11494
+msgid "Add Column"
+msgstr ""
+
+#: ../src/richtext/richtextbuffer.cpp:11537
+#, fuzzy
+msgid "Table Properties"
+msgstr "&Ominaisuudet"
+
+#: ../src/richtext/richtextbuffer.cpp:12899
+#, fuzzy
+msgid "Picture Properties"
+msgstr "&Ominaisuudet"
+
+#: ../src/richtext/richtextbuffer.cpp:13169
+#: ../src/richtext/richtextbuffer.cpp:13279
+msgid "image"
+msgstr "kuva"
+
+#: ../src/richtext/richtextbulletspage.cpp:145
+#: ../src/richtext/richtextliststylepage.cpp:209
+msgid "&Bullet style:"
+msgstr "&Luettelomerkkityyli:"
+
+#: ../src/richtext/richtextbulletspage.cpp:150
+#: ../src/richtext/richtextbulletspage.cpp:152
+#: ../src/richtext/richtextliststylepage.cpp:214
+#: ../src/richtext/richtextliststylepage.cpp:216
+msgid "The available bullet styles."
+msgstr ""
+
+#: ../src/richtext/richtextbulletspage.cpp:158
+#: ../src/richtext/richtextliststylepage.cpp:221
+msgid "Peri&od"
+msgstr "P&iste"
+
+#: ../src/richtext/richtextbulletspage.cpp:160
+#: ../src/richtext/richtextbulletspage.cpp:162
+#: ../src/richtext/richtextliststylepage.cpp:223
+#: ../src/richtext/richtextliststylepage.cpp:225
+msgid "Check to add a period after the bullet."
+msgstr "Valitse lisätäksesi pisteen luettelomerkin jälkeen."
+
+#. TRANSLATORS: Bullet point in parentheses option
+#: ../src/richtext/richtextbulletspage.cpp:167
+#: ../src/richtext/richtextliststylepage.cpp:230
+msgid "(*)"
+msgstr "(*)"
+
+#: ../src/richtext/richtextbulletspage.cpp:169
+#: ../src/richtext/richtextbulletspage.cpp:171
+#: ../src/richtext/richtextliststylepage.cpp:232
+#: ../src/richtext/richtextliststylepage.cpp:234
+msgid "Check to enclose the bullet in parentheses."
+msgstr "Valitse sulkeaksesi luettelomerkin heittomerkkien sisään."
+
+#. TRANSLATORS: Right parenthesis bullet point option
+#: ../src/richtext/richtextbulletspage.cpp:176
+#: ../src/richtext/richtextliststylepage.cpp:239
+msgid "*)"
+msgstr "*)"
+
+#: ../src/richtext/richtextbulletspage.cpp:178
+#: ../src/richtext/richtextbulletspage.cpp:180
+#: ../src/richtext/richtextliststylepage.cpp:241
+#: ../src/richtext/richtextliststylepage.cpp:243
+msgid "Check to add a right parenthesis."
+msgstr "Valitse lisätäksesi loppusulun."
+
+#: ../src/richtext/richtextbulletspage.cpp:185
+#: ../src/richtext/richtextliststylepage.cpp:248
+msgid "Bullet &Alignment:"
+msgstr "Luettelon &tasaus:"
+
+#: ../src/richtext/richtextbulletspage.cpp:190
+#: ../src/richtext/richtextliststylepage.cpp:253
+msgid "Centre"
+msgstr "Keskitetty"
+
+#: ../src/richtext/richtextbulletspage.cpp:194
+#: ../src/richtext/richtextbulletspage.cpp:196
+#: ../src/richtext/richtextbulletspage.cpp:217
+#: ../src/richtext/richtextbulletspage.cpp:219
+#: ../src/richtext/richtextliststylepage.cpp:257
+#: ../src/richtext/richtextliststylepage.cpp:259
+#: ../src/richtext/richtextliststylepage.cpp:278
+#: ../src/richtext/richtextliststylepage.cpp:280
+msgid "The bullet character."
+msgstr ""
+
+#: ../src/richtext/richtextbulletspage.cpp:212
+#: ../src/richtext/richtextliststylepage.cpp:271
+msgid "&Symbol:"
+msgstr "&Symbolit:"
+
+#: ../src/richtext/richtextbulletspage.cpp:222
+#: ../src/richtext/richtextliststylepage.cpp:283
+msgid "Ch&oose..."
+msgstr "&Valitse..."
+
+#: ../src/richtext/richtextbulletspage.cpp:223
+#: ../src/richtext/richtextbulletspage.cpp:225
+#: ../src/richtext/richtextliststylepage.cpp:284
+#: ../src/richtext/richtextliststylepage.cpp:286
+msgid "Click to browse for a symbol."
+msgstr "Napsauta etsiäksesi symbolin."
+
+#: ../src/richtext/richtextbulletspage.cpp:230
+#: ../src/richtext/richtextliststylepage.cpp:291
+msgid "Symbol &font:"
+msgstr "&Symbolikirjasin:"
+
+#: ../src/richtext/richtextbulletspage.cpp:235
+#: ../src/richtext/richtextbulletspage.cpp:237
+#: ../src/richtext/richtextliststylepage.cpp:297
+msgid "Available fonts."
+msgstr "Käytettävät kirjasimet."
+
+#: ../src/richtext/richtextbulletspage.cpp:242
+#: ../src/richtext/richtextliststylepage.cpp:302
+msgid "S&tandard bullet name:"
+msgstr "&Oletus luettelomerkin nimi:"
+
+#: ../src/richtext/richtextbulletspage.cpp:247
+#: ../src/richtext/richtextbulletspage.cpp:249
+#: ../src/richtext/richtextliststylepage.cpp:307
+#: ../src/richtext/richtextliststylepage.cpp:309
+msgid "A standard bullet name."
+msgstr "Oletus luettelomerkin nimi."
+
+#: ../src/richtext/richtextbulletspage.cpp:254
+msgid "&Number:"
+msgstr "&Numero:"
+
+#: ../src/richtext/richtextbulletspage.cpp:258
+#: ../src/richtext/richtextbulletspage.cpp:260
+msgid "The list item number."
+msgstr "Luettelokohdan numero."
+
+#: ../src/richtext/richtextbulletspage.cpp:266
+#: ../src/richtext/richtextbulletspage.cpp:268
+#: ../src/richtext/richtextliststylepage.cpp:475
+#: ../src/richtext/richtextliststylepage.cpp:477
+msgid "Shows a preview of the bullet settings."
+msgstr ""
+
+#: ../src/richtext/richtextbulletspage.cpp:276
+#: ../src/richtext/richtextliststylepage.cpp:484
+msgid "(None)"
+msgstr "(Ei mitään)"
+
+#: ../src/richtext/richtextbulletspage.cpp:277
+#: ../src/richtext/richtextliststylepage.cpp:485
+msgid "Arabic"
+msgstr "Arabialainen"
+
+#: ../src/richtext/richtextbulletspage.cpp:278
+#: ../src/richtext/richtextliststylepage.cpp:486
+msgid "Upper case letters"
+msgstr "Suuraakkoskirjaimet"
+
+#: ../src/richtext/richtextbulletspage.cpp:279
+#: ../src/richtext/richtextliststylepage.cpp:487
+msgid "Lower case letters"
+msgstr "Pienoisaakkoskirjaimet"
+
+#: ../src/richtext/richtextbulletspage.cpp:280
+#: ../src/richtext/richtextliststylepage.cpp:488
+msgid "Upper case roman numerals"
+msgstr "Suurakkos romaaniset numeraalit"
+
+#: ../src/richtext/richtextbulletspage.cpp:281
+#: ../src/richtext/richtextliststylepage.cpp:489
+msgid "Lower case roman numerals"
+msgstr "Pienoisaakkos romaaniset numeraalit"
+
+#: ../src/richtext/richtextbulletspage.cpp:282
+#: ../src/richtext/richtextliststylepage.cpp:490
+msgid "Numbered outline"
+msgstr "Numeroitu jäsennys"
+
+#: ../src/richtext/richtextbulletspage.cpp:283
+#: ../src/richtext/richtextliststylepage.cpp:491
+msgid "Symbol"
+msgstr "Symboli"
+
+#: ../src/richtext/richtextbulletspage.cpp:284
+#: ../src/richtext/richtextliststylepage.cpp:492
+msgid "Bitmap"
+msgstr "Värikartta"
+
+#: ../src/richtext/richtextbulletspage.cpp:285
+#: ../src/richtext/richtextliststylepage.cpp:493
+msgid "Standard"
+msgstr "Perus"
+
+#: ../src/richtext/richtextbulletspage.cpp:287
+#: ../src/richtext/richtextliststylepage.cpp:495
+msgid "*"
+msgstr "*"
+
+#: ../src/richtext/richtextbulletspage.cpp:288
+#: ../src/richtext/richtextliststylepage.cpp:496
+msgid "-"
+msgstr "-"
+
+#: ../src/richtext/richtextbulletspage.cpp:289
+#: ../src/richtext/richtextliststylepage.cpp:497
+msgid ">"
+msgstr ">"
+
+#: ../src/richtext/richtextbulletspage.cpp:290
+#: ../src/richtext/richtextliststylepage.cpp:498
+msgid "+"
+msgstr "+"
+
+#: ../src/richtext/richtextbulletspage.cpp:291
+#: ../src/richtext/richtextliststylepage.cpp:499
+msgid "~"
+msgstr "~"
+
+#: ../src/richtext/richtextctrl.cpp:859
+msgid "Drag"
+msgstr ""
+
+#: ../src/richtext/richtextctrl.cpp:1338 ../src/richtext/richtextctrl.cpp:1559
+msgid "Delete Text"
+msgstr "Poista teksti"
+
+#: ../src/richtext/richtextctrl.cpp:1537
+#, fuzzy
+msgid "Remove Bullet"
+msgstr "Poista"
+
+#: ../src/richtext/richtextctrl.cpp:3070
+msgid "The text couldn't be saved."
+msgstr "Tekstiä ei voitu tallentaa."
+
+#: ../src/richtext/richtextctrl.cpp:3644
+msgid "Replace"
+msgstr "Korvaa"
+
+#: ../src/richtext/richtextfontpage.cpp:146
+#: ../src/richtext/richtextsymboldlg.cpp:384
+msgid "&Font:"
+msgstr "&Kirjasin:"
+
+#: ../src/richtext/richtextfontpage.cpp:150
+#: ../src/richtext/richtextfontpage.cpp:152
+msgid "Type a font name."
+msgstr "Anna kirjasimen nimi."
+
+#: ../src/richtext/richtextfontpage.cpp:158
+msgid "&Size:"
+msgstr "&Koko:"
+
+#: ../src/richtext/richtextfontpage.cpp:165
+#: ../src/richtext/richtextfontpage.cpp:167
+msgid "Type a size in points."
+msgstr "Anna koko pisteinä."
+
+#: ../src/richtext/richtextfontpage.cpp:180
+#: ../src/richtext/richtextfontpage.cpp:182
+#, fuzzy
+msgid "The font size units, points or pixels."
+msgstr "Kirjasinkoko pisteinä."
+
+#: ../src/richtext/richtextfontpage.cpp:189
+#: ../src/richtext/richtextfontpage.cpp:191
+msgid "Lists the available fonts."
+msgstr "Luetteloi käytettävissä olevat kirjasimet."
+
+#: ../src/richtext/richtextfontpage.cpp:196
+#: ../src/richtext/richtextfontpage.cpp:198
+msgid "Lists font sizes in points."
+msgstr "Luetteloi kirjasinkoot pisteinä."
+
+#: ../src/richtext/richtextfontpage.cpp:207
+msgid "Font st&yle:"
+msgstr "Kirjasimen &tyyli:"
+
+#: ../src/richtext/richtextfontpage.cpp:212
+#: ../src/richtext/richtextfontpage.cpp:214
+msgid "Select regular or italic style."
+msgstr "Valitse tavallinen tai kursivoitu."
+
+#: ../src/richtext/richtextfontpage.cpp:220
+msgid "Font &weight:"
+msgstr "Kirjasimen &paino:"
+
+#: ../src/richtext/richtextfontpage.cpp:225
+#: ../src/richtext/richtextfontpage.cpp:227
+msgid "Select regular or bold."
+msgstr "Valitse tavallinen tai lihavoitu."
+
+#: ../src/richtext/richtextfontpage.cpp:233
+msgid "&Underlining:"
+msgstr "&Alleviivaus:"
+
+#: ../src/richtext/richtextfontpage.cpp:238
+#: ../src/richtext/richtextfontpage.cpp:240
+msgid "Select underlining or no underlining."
+msgstr "Valitse alleviivaus tai ei alleviivausta."
+
+#: ../src/richtext/richtextfontpage.cpp:248
+msgid "&Colour:"
+msgstr "&Väri:"
+
+#: ../src/richtext/richtextfontpage.cpp:253
+#: ../src/richtext/richtextfontpage.cpp:255
+msgid "Click to change the text colour."
+msgstr "Napsauta muuttaaksesi tekstin värin."
+
+#: ../src/richtext/richtextfontpage.cpp:261
+msgid "&Bg colour:"
+msgstr "&Taustaväri:"
+
+#: ../src/richtext/richtextfontpage.cpp:266
+#: ../src/richtext/richtextfontpage.cpp:268
+#, fuzzy
+msgid "Click to change the text background colour."
+msgstr "Napsauta muuttaaksesi tekstin värin."
+
+#: ../src/richtext/richtextfontpage.cpp:276
+#: ../src/richtext/richtextfontpage.cpp:278
+msgid "Check to show a line through the text."
+msgstr "Valitse näyttääksesi viivan tekstin päällä."
+
+#: ../src/richtext/richtextfontpage.cpp:281
+msgid "Ca&pitals"
+msgstr "&Suuraakkoset"
+
+#: ../src/richtext/richtextfontpage.cpp:283
+#: ../src/richtext/richtextfontpage.cpp:285
+msgid "Check to show the text in capitals."
+msgstr "Valitse käyttääksesi suuraakkosia."
+
+#: ../src/richtext/richtextfontpage.cpp:288
+#, fuzzy
+msgid "Small C&apitals"
+msgstr "&Suuraakkoset"
+
+#: ../src/richtext/richtextfontpage.cpp:290
+#: ../src/richtext/richtextfontpage.cpp:292
+#, fuzzy
+msgid "Check to show the text in small capitals."
+msgstr "Valitse käyttääksesi suuraakkosia."
+
+#: ../src/richtext/richtextfontpage.cpp:295
+#, fuzzy
+msgid "Supe&rscript"
+msgstr "Script"
+
+#: ../src/richtext/richtextfontpage.cpp:297
+#: ../src/richtext/richtextfontpage.cpp:299
+#, fuzzy
+msgid "Check to show the text in superscript."
+msgstr "Napsauta peruuttaaksesi fontin valinnan."
+
+#: ../src/richtext/richtextfontpage.cpp:302
+#, fuzzy
+msgid "Subscrip&t"
+msgstr "Script"
+
+#: ../src/richtext/richtextfontpage.cpp:304
+#: ../src/richtext/richtextfontpage.cpp:306
+#, fuzzy
+msgid "Check to show the text in subscript."
+msgstr "Napsauta peruuttaaksesi fontin valinnan."
+
+#: ../src/richtext/richtextfontpage.cpp:312
+msgid "Rig&ht-to-left"
+msgstr ""
+
+#: ../src/richtext/richtextfontpage.cpp:314
+#: ../src/richtext/richtextfontpage.cpp:316
+#, fuzzy
+msgid "Check to indicate right-to-left text layout."
+msgstr "Napsauta muuttaaksesi tekstin värin."
+
+#: ../src/richtext/richtextfontpage.cpp:319
+msgid "Suppress hyphe&nation"
+msgstr ""
+
+#: ../src/richtext/richtextfontpage.cpp:321
+#: ../src/richtext/richtextfontpage.cpp:323
+msgid "Check to suppress hyphenation."
+msgstr ""
+
+#: ../src/richtext/richtextfontpage.cpp:329
+#: ../src/richtext/richtextfontpage.cpp:331
+msgid "Shows a preview of the font settings."
+msgstr "Näyttää kirjasinasetusten esikatselun."
+
+#: ../src/richtext/richtextfontpage.cpp:348
+#: ../src/richtext/richtextfontpage.cpp:352
+#: ../src/richtext/richtextfontpage.cpp:356
+#: ../src/richtext/richtextformatdlg.cpp:873
+#: ../src/richtext/richtextindentspage.cpp:273
+#: ../src/richtext/richtextindentspage.cpp:285
+#: ../src/richtext/richtextindentspage.cpp:286
+#: ../src/richtext/richtextindentspage.cpp:310
+#: ../src/richtext/richtextindentspage.cpp:325
+#: ../src/richtext/richtextliststylepage.cpp:451
+#: ../src/richtext/richtextliststylepage.cpp:463
+#: ../src/richtext/richtextliststylepage.cpp:464
+msgid "(none)"
+msgstr "(ei mitään)"
+
+#: ../src/richtext/richtextfontpage.cpp:349
+#: ../src/richtext/richtextfontpage.cpp:353
+msgid "Regular"
+msgstr "Tavallinen"
+
+#: ../src/richtext/richtextfontpage.cpp:357
+msgid "Not underlined"
+msgstr "Ei alleviivattu"
+
+#: ../src/richtext/richtextformatdlg.cpp:341
+msgid "Indents && Spacing"
+msgstr "Sisennys && välit"
+
+#: ../src/richtext/richtextformatdlg.cpp:346
+msgid "Tabs"
+msgstr "Välilehdet"
+
+#: ../src/richtext/richtextformatdlg.cpp:351
+msgid "Bullets"
+msgstr "Luettelomerkit"
+
+#: ../src/richtext/richtextformatdlg.cpp:356
+msgid "List Style"
+msgstr "Luettelotyyli"
+
+#: ../src/richtext/richtextformatdlg.cpp:366
+#: ../src/richtext/richtextmarginspage.cpp:170
+msgid "Margins"
+msgstr "Marginaalit"
+
+#: ../src/richtext/richtextformatdlg.cpp:371
+#, fuzzy
+msgid "Borders"
+msgstr "Moderni"
+
+#: ../src/richtext/richtextformatdlg.cpp:765
+msgid "Colour"
+msgstr "Väri"
+
+#: ../src/richtext/richtextindentspage.cpp:127
+#: ../src/richtext/richtextliststylepage.cpp:322
+msgid "&Alignment"
+msgstr "&Tasaus"
+
+#: ../src/richtext/richtextindentspage.cpp:138
+#: ../src/richtext/richtextliststylepage.cpp:331
+msgid "&Left"
+msgstr "&Vasemmalle"
+
+#: ../src/richtext/richtextindentspage.cpp:140
+#: ../src/richtext/richtextindentspage.cpp:142
+#: ../src/richtext/richtextliststylepage.cpp:333
+#: ../src/richtext/richtextliststylepage.cpp:335
+msgid "Left-align text."
+msgstr "Vasemmalle tasattu teksti:"
+
+#: ../src/richtext/richtextindentspage.cpp:145
+#: ../src/richtext/richtextliststylepage.cpp:338
+msgid "&Right"
+msgstr "&Oikealle"
+
+#: ../src/richtext/richtextindentspage.cpp:147
+#: ../src/richtext/richtextindentspage.cpp:149
+#: ../src/richtext/richtextliststylepage.cpp:340
+#: ../src/richtext/richtextliststylepage.cpp:342
+msgid "Right-align text."
+msgstr "Tasaa teksti oikealle."
+
+#: ../src/richtext/richtextindentspage.cpp:152
+#: ../src/richtext/richtextliststylepage.cpp:345
+msgid "&Justified"
+msgstr "Tasattu"
+
+#: ../src/richtext/richtextindentspage.cpp:154
+#: ../src/richtext/richtextindentspage.cpp:156
+#: ../src/richtext/richtextliststylepage.cpp:347
+#: ../src/richtext/richtextliststylepage.cpp:349
+msgid "Justify text left and right."
+msgstr "Tasaa teksti vasemmalle ja oikealle."
+
+#: ../src/richtext/richtextindentspage.cpp:159
+#: ../src/richtext/richtextliststylepage.cpp:352
+msgid "Cen&tred"
+msgstr "&Keskitetty"
+
+#: ../src/richtext/richtextindentspage.cpp:161
+#: ../src/richtext/richtextindentspage.cpp:163
+#: ../src/richtext/richtextliststylepage.cpp:354
+#: ../src/richtext/richtextliststylepage.cpp:356
+msgid "Centre text."
+msgstr "Keskitä teksti."
+
+#: ../src/richtext/richtextindentspage.cpp:166
+#: ../src/richtext/richtextliststylepage.cpp:359
+#, fuzzy
+msgid "&Indeterminate"
+msgstr "&Alleviivaus"
+
+#: ../src/richtext/richtextindentspage.cpp:168
+#: ../src/richtext/richtextindentspage.cpp:170
+#: ../src/richtext/richtextliststylepage.cpp:361
+#: ../src/richtext/richtextliststylepage.cpp:363
+msgid "Use the current alignment setting."
+msgstr ""
+
+#: ../src/richtext/richtextindentspage.cpp:183
+#: ../src/richtext/richtextliststylepage.cpp:375
+msgid "&Indentation (tenths of a mm)"
+msgstr "&Sisennys (millimetrin kymmenyksiä)"
+
+#: ../src/richtext/richtextindentspage.cpp:198
+#: ../src/richtext/richtextindentspage.cpp:200
+#: ../src/richtext/richtextliststylepage.cpp:388
+#: ../src/richtext/richtextliststylepage.cpp:390
+msgid "The left indent."
+msgstr "Vasen sisennys."
+
+#: ../src/richtext/richtextindentspage.cpp:203
+#: ../src/richtext/richtextliststylepage.cpp:393
+msgid "Left (&first line):"
+msgstr "Vasen (&ensimmäinen rivi):"
+
+#: ../src/richtext/richtextindentspage.cpp:207
+#: ../src/richtext/richtextindentspage.cpp:209
+#: ../src/richtext/richtextliststylepage.cpp:397
+#: ../src/richtext/richtextliststylepage.cpp:399
+msgid "The first line indent."
+msgstr "Ensimmäisen rivin sisennys."
+
+#: ../src/richtext/richtextindentspage.cpp:216
+#: ../src/richtext/richtextindentspage.cpp:218
+#: ../src/richtext/richtextliststylepage.cpp:406
+#: ../src/richtext/richtextliststylepage.cpp:408
+msgid "The right indent."
+msgstr "Oikea sisennys."
+
+#: ../src/richtext/richtextindentspage.cpp:221
+msgid "&Outline level:"
+msgstr "&Jäsennyksen taso:"
+
+#: ../src/richtext/richtextindentspage.cpp:226
+#: ../src/richtext/richtextindentspage.cpp:228
+#, fuzzy
+msgid "The outline level."
+msgstr "Näytä kirjasimen esikatselu."
+
+#: ../src/richtext/richtextindentspage.cpp:241
+#: ../src/richtext/richtextliststylepage.cpp:420
+msgid "&Spacing (tenths of a mm)"
+msgstr "&Riviväli (millimetrin kymmenyksiä)"
+
+#: ../src/richtext/richtextindentspage.cpp:252
+msgid "&Before a paragraph:"
+msgstr "&Ennen kappaletta:"
+
+#: ../src/richtext/richtextindentspage.cpp:256
+#: ../src/richtext/richtextindentspage.cpp:258
+#: ../src/richtext/richtextliststylepage.cpp:433
+#: ../src/richtext/richtextliststylepage.cpp:435
+msgid "The spacing before the paragraph."
+msgstr "Tyhjä tila ennen kappaletta."
+
+#: ../src/richtext/richtextindentspage.cpp:261
+msgid "&After a paragraph:"
+msgstr "&Kappaleen jälkeen:"
+
+#: ../src/richtext/richtextindentspage.cpp:266
+#: ../src/richtext/richtextliststylepage.cpp:442
+#: ../src/richtext/richtextliststylepage.cpp:444
+msgid "The spacing after the paragraph."
+msgstr "Tyhjä tila kappaleen jälkeen."
+
+#: ../src/richtext/richtextindentspage.cpp:269
+msgid "L&ine spacing:"
+msgstr "&Riviväli:"
+
+#: ../src/richtext/richtextindentspage.cpp:274
+#: ../src/richtext/richtextliststylepage.cpp:452
+msgid "Single"
+msgstr ""
+
+#: ../src/richtext/richtextindentspage.cpp:275
+#: ../src/richtext/richtextliststylepage.cpp:453
+msgid "1.1"
+msgstr "1.1"
+
+#: ../src/richtext/richtextindentspage.cpp:276
+#: ../src/richtext/richtextliststylepage.cpp:454
+msgid "1.2"
+msgstr "1.2"
+
+#: ../src/richtext/richtextindentspage.cpp:277
+#: ../src/richtext/richtextliststylepage.cpp:455
+msgid "1.3"
+msgstr "1.3"
+
+#: ../src/richtext/richtextindentspage.cpp:278
+#: ../src/richtext/richtextliststylepage.cpp:456
+msgid "1.4"
+msgstr "1.4"
+
+#: ../src/richtext/richtextindentspage.cpp:279
+#: ../src/richtext/richtextliststylepage.cpp:457
+msgid "1.5"
+msgstr "1.5"
+
+#: ../src/richtext/richtextindentspage.cpp:280
+#: ../src/richtext/richtextliststylepage.cpp:458
+msgid "1.6"
+msgstr "1.6"
+
+#: ../src/richtext/richtextindentspage.cpp:281
+#: ../src/richtext/richtextliststylepage.cpp:459
+msgid "1.7"
+msgstr "1.7"
+
+#: ../src/richtext/richtextindentspage.cpp:282
+#: ../src/richtext/richtextliststylepage.cpp:460
+msgid "1.8"
+msgstr "1.8"
+
+#: ../src/richtext/richtextindentspage.cpp:283
+#: ../src/richtext/richtextliststylepage.cpp:461
+msgid "1.9"
+msgstr "1.9"
+
+#: ../src/richtext/richtextindentspage.cpp:284
+#: ../src/richtext/richtextliststylepage.cpp:462
+msgid "2"
+msgstr "2"
+
+#: ../src/richtext/richtextindentspage.cpp:287
+#: ../src/richtext/richtextindentspage.cpp:289
+#: ../src/richtext/richtextliststylepage.cpp:465
+#: ../src/richtext/richtextliststylepage.cpp:467
+msgid "The line spacing."
+msgstr "Riviväli"
+
+#: ../src/richtext/richtextindentspage.cpp:292
+msgid "&Page Break"
+msgstr "&Sivunvaihto"
+
+#: ../src/richtext/richtextindentspage.cpp:294
+#: ../src/richtext/richtextindentspage.cpp:296
+#, fuzzy
+msgid "Inserts a page break before the paragraph."
+msgstr "Tyhjä tila ennen kappaletta."
+
+#: ../src/richtext/richtextindentspage.cpp:302
+#: ../src/richtext/richtextindentspage.cpp:304
+msgid "Shows a preview of the paragraph settings."
+msgstr "Näyttää  kappaleen asetuksien esikatselun."
+
+#: ../src/richtext/richtextliststylepage.cpp:182
+msgid "&List level:"
+msgstr "&Luettelotaso:"
+
+#: ../src/richtext/richtextliststylepage.cpp:186
+#: ../src/richtext/richtextliststylepage.cpp:188
+msgid "Selects the list level to edit."
+msgstr "Valitse muokattava luettelotaso."
+
+#: ../src/richtext/richtextliststylepage.cpp:193
+msgid "&Font for Level..."
+msgstr "&Kirjasin tasolle..."
+
+#: ../src/richtext/richtextliststylepage.cpp:194
+#: ../src/richtext/richtextliststylepage.cpp:196
+msgid "Click to choose the font for this level."
+msgstr "Napsauta valitaksesi kirjasimen tälle tasolle."
+
+#: ../src/richtext/richtextliststylepage.cpp:312
+msgid "Bullet style"
+msgstr "Luettelomerkkityyli"
+
+#: ../src/richtext/richtextliststylepage.cpp:429
+msgid "Before a paragraph:"
+msgstr "Ennen kappaletta:"
+
+#: ../src/richtext/richtextliststylepage.cpp:438
+msgid "After a paragraph:"
+msgstr "Kappaleen jälkeen:"
+
+#: ../src/richtext/richtextliststylepage.cpp:447
+msgid "Line spacing:"
+msgstr "Riviväli:"
+
+#: ../src/richtext/richtextliststylepage.cpp:470
+#, fuzzy
+msgid "Spacing"
+msgstr "Etsitään..."
+
+#: ../src/richtext/richtextmarginspage.cpp:193
+#: ../src/richtext/richtextmarginspage.cpp:195
+#, fuzzy
+msgid "The left margin size."
+msgstr "Kirjasinkoko."
+
+#: ../src/richtext/richtextmarginspage.cpp:203
+#: ../src/richtext/richtextmarginspage.cpp:205
+msgid "Units for the left margin."
+msgstr ""
+
+#: ../src/richtext/richtextmarginspage.cpp:218
+#: ../src/richtext/richtextmarginspage.cpp:220
+#, fuzzy
+msgid "The right margin size."
+msgstr "Oikea sisennys."
+
+#: ../src/richtext/richtextmarginspage.cpp:228
+#: ../src/richtext/richtextmarginspage.cpp:230
+msgid "Units for the right margin."
+msgstr ""
+
+#: ../src/richtext/richtextmarginspage.cpp:241
+#: ../src/richtext/richtextmarginspage.cpp:243
+#, fuzzy
+msgid "The top margin size."
+msgstr "Kirjasinkoko."
+
+#: ../src/richtext/richtextmarginspage.cpp:251
+#: ../src/richtext/richtextmarginspage.cpp:253
+#, fuzzy
+msgid "Units for the top margin."
+msgstr "Ei voi odottaa säikeen keskeytystä"
+
+#: ../src/richtext/richtextmarginspage.cpp:266
+#: ../src/richtext/richtextmarginspage.cpp:268
+#, fuzzy
+msgid "The bottom margin size."
+msgstr "Kirjasinkoko."
+
+#: ../src/richtext/richtextmarginspage.cpp:276
+#: ../src/richtext/richtextmarginspage.cpp:278
+msgid "Units for the bottom margin."
+msgstr ""
+
+#: ../src/richtext/richtextmarginspage.cpp:284
+msgid "Padding"
+msgstr ""
+
+#: ../src/richtext/richtextmarginspage.cpp:307
+#: ../src/richtext/richtextmarginspage.cpp:309
+#, fuzzy
+msgid "The left padding size."
+msgstr "Kirjasinkoko."
+
+#: ../src/richtext/richtextmarginspage.cpp:317
+#: ../src/richtext/richtextmarginspage.cpp:319
+msgid "Units for the left padding."
+msgstr ""
+
+#: ../src/richtext/richtextmarginspage.cpp:332
+#: ../src/richtext/richtextmarginspage.cpp:334
+#, fuzzy
+msgid "The right padding size."
+msgstr "Oikea sisennys."
+
+#: ../src/richtext/richtextmarginspage.cpp:342
+#: ../src/richtext/richtextmarginspage.cpp:344
+msgid "Units for the right padding."
+msgstr ""
+
+#: ../src/richtext/richtextmarginspage.cpp:355
+#: ../src/richtext/richtextmarginspage.cpp:357
+#, fuzzy
+msgid "The top padding size."
+msgstr "Kirjasinkoko."
+
+#: ../src/richtext/richtextmarginspage.cpp:365
+#: ../src/richtext/richtextmarginspage.cpp:367
+msgid "Units for the top padding."
+msgstr ""
+
+#: ../src/richtext/richtextmarginspage.cpp:380
+#: ../src/richtext/richtextmarginspage.cpp:382
+#, fuzzy
+msgid "The bottom padding size."
+msgstr "Kirjasinkoko."
+
+#: ../src/richtext/richtextmarginspage.cpp:390
+#: ../src/richtext/richtextmarginspage.cpp:392
+msgid "Units for the bottom padding."
+msgstr ""
+
+#: ../src/richtext/richtextprint.cpp:592
+msgid " Preview"
+msgstr " Esikatselu"
+
+#: ../src/richtext/richtextsizepage.cpp:228
+msgid "Floating"
+msgstr "Liukuva"
+
+#: ../src/richtext/richtextsizepage.cpp:243
+msgid "&Floating mode:"
+msgstr "&Liukuva tila:"
+
+#: ../src/richtext/richtextsizepage.cpp:252
+#: ../src/richtext/richtextsizepage.cpp:254
+msgid "How the object will float relative to the text."
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:265
+msgid "Alignment"
+msgstr "Tasaus"
+
+#: ../src/richtext/richtextsizepage.cpp:277
+msgid "&Vertical alignment:"
+msgstr "&Tasaus pystysuunnassa:"
+
+#: ../src/richtext/richtextsizepage.cpp:279
+#: ../src/richtext/richtextsizepage.cpp:281
+#, fuzzy
+msgid "Enable vertical alignment."
+msgstr "Tasausta ei voitu asettaa."
+
+#: ../src/richtext/richtextsizepage.cpp:286
+#, fuzzy
+msgid "Centred"
+msgstr "&Keskitetty"
+
+#: ../src/richtext/richtextsizepage.cpp:290
+#: ../src/richtext/richtextsizepage.cpp:292
+#, fuzzy
+msgid "Vertical alignment."
+msgstr "Tasausta ei voitu asettaa."
+
+#: ../src/richtext/richtextsizepage.cpp:316
+#: ../src/richtext/richtextsizepage.cpp:323
+msgid "&Width:"
+msgstr "&Leveys:"
+
+#: ../src/richtext/richtextsizepage.cpp:318
+#: ../src/richtext/richtextsizepage.cpp:320
+msgid "Enable the width value."
+msgstr "Käytä leveysarvoa."
+
+#: ../src/richtext/richtextsizepage.cpp:331
+#: ../src/richtext/richtextsizepage.cpp:333
+#, fuzzy
+msgid "The object width."
+msgstr "Kirjasimen paino."
+
+#: ../src/richtext/richtextsizepage.cpp:342
+#: ../src/richtext/richtextsizepage.cpp:344
+msgid "Units for the object width."
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:350
+#: ../src/richtext/richtextsizepage.cpp:357
+msgid "&Height:"
+msgstr "&Korkeus:"
+
+#: ../src/richtext/richtextsizepage.cpp:352
+#: ../src/richtext/richtextsizepage.cpp:354
+#: ../src/richtext/richtextsizepage.cpp:464
+#: ../src/richtext/richtextsizepage.cpp:466
+msgid "Enable the height value."
+msgstr "Käytä korkeusarvoa."
+
+#: ../src/richtext/richtextsizepage.cpp:365
+#: ../src/richtext/richtextsizepage.cpp:367
+#, fuzzy
+msgid "The object height."
+msgstr "Kirjasimen paino."
+
+#: ../src/richtext/richtextsizepage.cpp:376
+#: ../src/richtext/richtextsizepage.cpp:378
+msgid "Units for the object height."
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:381
+msgid "Min width:"
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:383
+#: ../src/richtext/richtextsizepage.cpp:385
+#, fuzzy
+msgid "Enable the minimum width value."
+msgstr "Käytä leveysarvoa."
+
+#: ../src/richtext/richtextsizepage.cpp:392
+#: ../src/richtext/richtextsizepage.cpp:394
+#, fuzzy
+msgid "The object minimum width."
+msgstr "Kirjasimen paino."
+
+#: ../src/richtext/richtextsizepage.cpp:403
+#: ../src/richtext/richtextsizepage.cpp:405
+#, fuzzy
+msgid "Units for the minimum object width."
+msgstr "Kirjasimen paino."
+
+#: ../src/richtext/richtextsizepage.cpp:408
+#, fuzzy
+msgid "Min height:"
+msgstr "Kirjasimen &paino:"
+
+#: ../src/richtext/richtextsizepage.cpp:410
+#: ../src/richtext/richtextsizepage.cpp:412
+#, fuzzy
+msgid "Enable the minimum height value."
+msgstr "Käytä korkeusarvoa."
+
+#: ../src/richtext/richtextsizepage.cpp:419
+#: ../src/richtext/richtextsizepage.cpp:421
+#, fuzzy
+msgid "The object minimum height."
+msgstr "Kirjasimen paino."
+
+#: ../src/richtext/richtextsizepage.cpp:430
+#: ../src/richtext/richtextsizepage.cpp:432
+#, fuzzy
+msgid "Units for the minimum object height."
+msgstr "Kirjasimen paino."
+
+#: ../src/richtext/richtextsizepage.cpp:435
+msgid "Max width:"
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:437
+#: ../src/richtext/richtextsizepage.cpp:439
+#, fuzzy
+msgid "Enable the maximum width value."
+msgstr "Käytä leveysarvoa."
+
+#: ../src/richtext/richtextsizepage.cpp:446
+#: ../src/richtext/richtextsizepage.cpp:448
+#, fuzzy
+msgid "The object maximum width."
+msgstr "Kirjasimen paino."
+
+#: ../src/richtext/richtextsizepage.cpp:457
+#: ../src/richtext/richtextsizepage.cpp:459
+#, fuzzy
+msgid "Units for the maximum object width."
+msgstr "Kirjasimen paino."
+
+#: ../src/richtext/richtextsizepage.cpp:462
+#, fuzzy
+msgid "Max height:"
+msgstr "&Korkeus:"
+
+#: ../src/richtext/richtextsizepage.cpp:473
+#: ../src/richtext/richtextsizepage.cpp:475
+#, fuzzy
+msgid "The object maximum height."
+msgstr "Kirjasimen paino."
+
+#: ../src/richtext/richtextsizepage.cpp:484
+#: ../src/richtext/richtextsizepage.cpp:486
+#, fuzzy
+msgid "Units for the maximum object height."
+msgstr "Kirjasimen paino."
+
+#: ../src/richtext/richtextsizepage.cpp:495
+#, fuzzy
+msgid "Position"
+msgstr "Kysymys"
+
+#: ../src/richtext/richtextsizepage.cpp:513
+#, fuzzy
+msgid "&Position mode:"
+msgstr "&Liukuva tila:"
+
+#: ../src/richtext/richtextsizepage.cpp:517
+#: ../src/richtext/richtextsizepage.cpp:522
+#, fuzzy
+msgid "Static"
+msgstr "Tila:"
+
+#: ../src/richtext/richtextsizepage.cpp:518
+#, fuzzy
+msgid "Relative"
+msgstr "Koristeellinen"
+
+#: ../src/richtext/richtextsizepage.cpp:519
+msgid "Absolute"
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:520
+#, fuzzy
+msgid "Fixed"
+msgstr "Kiinteälevyinen fontti:"
+
+#: ../src/richtext/richtextsizepage.cpp:533
+#: ../src/richtext/richtextsizepage.cpp:535
+#: ../src/richtext/richtextsizepage.cpp:547
+#: ../src/richtext/richtextsizepage.cpp:549
+#, fuzzy
+msgid "The left position."
+msgstr "Välilehden sijainti."
+
+#: ../src/richtext/richtextsizepage.cpp:558
+#: ../src/richtext/richtextsizepage.cpp:560
+#, fuzzy
+msgid "Units for the left position."
+msgstr "Ei voi odottaa säikeen keskeytystä"
+
+#: ../src/richtext/richtextsizepage.cpp:568
+#: ../src/richtext/richtextsizepage.cpp:570
+#: ../src/richtext/richtextsizepage.cpp:582
+#: ../src/richtext/richtextsizepage.cpp:584
+#, fuzzy
+msgid "The top position."
+msgstr "Välilehden sijainti."
+
+#: ../src/richtext/richtextsizepage.cpp:593
+#: ../src/richtext/richtextsizepage.cpp:595
+#, fuzzy
+msgid "Units for the top position."
+msgstr "Ei voi odottaa säikeen keskeytystä"
+
+#: ../src/richtext/richtextsizepage.cpp:603
+#: ../src/richtext/richtextsizepage.cpp:605
+#: ../src/richtext/richtextsizepage.cpp:617
+#: ../src/richtext/richtextsizepage.cpp:619
+#, fuzzy
+msgid "The right position."
+msgstr "Välilehden sijainti."
+
+#: ../src/richtext/richtextsizepage.cpp:628
+#: ../src/richtext/richtextsizepage.cpp:630
+#, fuzzy
+msgid "Units for the right position."
+msgstr "Ei voi odottaa säikeen keskeytystä"
+
+#: ../src/richtext/richtextsizepage.cpp:638
+#: ../src/richtext/richtextsizepage.cpp:640
+#: ../src/richtext/richtextsizepage.cpp:652
+#: ../src/richtext/richtextsizepage.cpp:654
+#, fuzzy
+msgid "The bottom position."
+msgstr "Välilehden sijainti."
+
+#: ../src/richtext/richtextsizepage.cpp:663
+#: ../src/richtext/richtextsizepage.cpp:665
+#, fuzzy
+msgid "Units for the bottom position."
+msgstr "Ei voi odottaa säikeen keskeytystä"
+
+#: ../src/richtext/richtextsizepage.cpp:671
+msgid "&Move the object to:"
+msgstr "&Siirrä objekti kohteeseen:"
+
+#: ../src/richtext/richtextsizepage.cpp:674
+msgid "&Previous Paragraph"
+msgstr "&Edellinen kappale"
+
+#: ../src/richtext/richtextsizepage.cpp:675
+#: ../src/richtext/richtextsizepage.cpp:677
+msgid "Moves the object to the previous paragraph."
+msgstr "Siirtää objektin edelliseen kappaleeseen."
+
+#: ../src/richtext/richtextsizepage.cpp:680
+msgid "&Next Paragraph"
+msgstr "&Seuraava kappale"
+
+#: ../src/richtext/richtextsizepage.cpp:681
+#: ../src/richtext/richtextsizepage.cpp:683
+msgid "Moves the object to the next paragraph."
+msgstr "Siirtää objektin seuraavaan kappaleeseen."
+
+#: ../src/richtext/richtextstyledlg.cpp:193
+msgid "&Styles:"
+msgstr "&Tyylit:"
+
+#: ../src/richtext/richtextstyledlg.cpp:197
+#: ../src/richtext/richtextstyledlg.cpp:199
+msgid "The available styles."
+msgstr "Käytettävissä olevat tyylit."
+
+#: ../src/richtext/richtextstyledlg.cpp:205
+#: ../src/richtext/richtextstyledlg.cpp:217
+msgid " "
+msgstr " "
+
+#: ../src/richtext/richtextstyledlg.cpp:209
+#: ../src/richtext/richtextstyledlg.cpp:211
+msgid "The style preview."
+msgstr "Tyylin esikatselu."
+
+#: ../src/richtext/richtextstyledlg.cpp:220
+msgid "New &Character Style..."
+msgstr "Uusi &merkkityyli..."
+
+#: ../src/richtext/richtextstyledlg.cpp:221
+#: ../src/richtext/richtextstyledlg.cpp:223
+msgid "Click to create a new character style."
+msgstr "Napsauta luodaksesi uuden merkkityylin."
+
+#: ../src/richtext/richtextstyledlg.cpp:226
+msgid "New &Paragraph Style..."
+msgstr "Uusi &kappaletyyli..."
+
+#: ../src/richtext/richtextstyledlg.cpp:227
+#: ../src/richtext/richtextstyledlg.cpp:229
+msgid "Click to create a new paragraph style."
+msgstr "Napsauta luodaksesi uuden kappaletyylin."
+
+#: ../src/richtext/richtextstyledlg.cpp:232
+msgid "New &List Style..."
+msgstr "Uusi &luettelotyyli"
+
+#: ../src/richtext/richtextstyledlg.cpp:233
+#: ../src/richtext/richtextstyledlg.cpp:235
+msgid "Click to create a new list style."
+msgstr "Napsauta luodaksesi uuden luettelotyylin."
+
+#: ../src/richtext/richtextstyledlg.cpp:238
+#, fuzzy
+msgid "New &Box Style..."
+msgstr "Uusi &luettelotyyli"
+
+#: ../src/richtext/richtextstyledlg.cpp:239
+#: ../src/richtext/richtextstyledlg.cpp:241
+#, fuzzy
+msgid "Click to create a new box style."
+msgstr "Napsauta luodaksesi uuden luettelotyylin."
+
+#: ../src/richtext/richtextstyledlg.cpp:246
+msgid "&Apply Style"
+msgstr "&Käytä tyyliä"
+
+#: ../src/richtext/richtextstyledlg.cpp:247
+#: ../src/richtext/richtextstyledlg.cpp:249
+msgid "Click to apply the selected style."
+msgstr "Napsauta käyttääksesi valittua tyyliä."
+
+#: ../src/richtext/richtextstyledlg.cpp:252
+msgid "&Rename Style..."
+msgstr "&Nimeä tyyli uudelleen"
+
+#: ../src/richtext/richtextstyledlg.cpp:253
+#: ../src/richtext/richtextstyledlg.cpp:255
+msgid "Click to rename the selected style."
+msgstr "Napsauta nimetäksesi valitun tyylin uudelleen."
+
+#: ../src/richtext/richtextstyledlg.cpp:258
+msgid "&Edit Style..."
+msgstr "&Muokkaa tyyliä..."
+
+#: ../src/richtext/richtextstyledlg.cpp:259
+#: ../src/richtext/richtextstyledlg.cpp:261
+msgid "Click to edit the selected style."
+msgstr "Napsauta muokataksesi valittua tyyliä."
+
+#: ../src/richtext/richtextstyledlg.cpp:264
+msgid "&Delete Style..."
+msgstr "&Poista tyyli..."
+
+#: ../src/richtext/richtextstyledlg.cpp:265
+#: ../src/richtext/richtextstyledlg.cpp:267
+msgid "Click to delete the selected style."
+msgstr "Napsauta poistaaksesi valitun tyylin."
+
+#: ../src/richtext/richtextstyledlg.cpp:274
+#: ../src/richtext/richtextstyledlg.cpp:276
+msgid "Click to close this window."
+msgstr "Napsauta sulkeaksesi tämä ikkuna."
+
+#: ../src/richtext/richtextstyledlg.cpp:282
+msgid "&Restart numbering"
+msgstr "&Aloita numerointi uudelleen"
+
+#: ../src/richtext/richtextstyledlg.cpp:284
+#: ../src/richtext/richtextstyledlg.cpp:286
+msgid "Check to restart numbering."
+msgstr "Napsauta aloittaaksesi numeroinnin uudelleen."
+
+#: ../src/richtext/richtextstyledlg.cpp:601
+msgid "Enter a character style name"
+msgstr "Anna merkkityylin nimi"
+
+#: ../src/richtext/richtextstyledlg.cpp:601
+#: ../src/richtext/richtextstyledlg.cpp:606
+#: ../src/richtext/richtextstyledlg.cpp:649
+#: ../src/richtext/richtextstyledlg.cpp:654
+#: ../src/richtext/richtextstyledlg.cpp:815
+#: ../src/richtext/richtextstyledlg.cpp:820
+#: ../src/richtext/richtextstyledlg.cpp:888
+#: ../src/richtext/richtextstyledlg.cpp:896
+#: ../src/richtext/richtextstyledlg.cpp:929
+#: ../src/richtext/richtextstyledlg.cpp:934
+msgid "New Style"
+msgstr "Uusi tyyli"
+
+#: ../src/richtext/richtextstyledlg.cpp:606
+#: ../src/richtext/richtextstyledlg.cpp:654
+#: ../src/richtext/richtextstyledlg.cpp:820
+#: ../src/richtext/richtextstyledlg.cpp:896
+#: ../src/richtext/richtextstyledlg.cpp:934
+msgid "Sorry, that name is taken. Please choose another."
+msgstr "Nimi on jo käytössä. Valitse toinen."
+
+#: ../src/richtext/richtextstyledlg.cpp:649
+msgid "Enter a paragraph style name"
+msgstr "Anna kappaletyylin nimi"
+
+#: ../src/richtext/richtextstyledlg.cpp:777
+#, c-format
+msgid "Delete style %s?"
+msgstr "Poistetaanko tyyli %s?"
+
+#: ../src/richtext/richtextstyledlg.cpp:777
+msgid "Delete Style"
+msgstr "Poista tyyli"
+
+#: ../src/richtext/richtextstyledlg.cpp:815
+msgid "Enter a list style name"
+msgstr "Anna luettelotyylin nimi"
+
+#: ../src/richtext/richtextstyledlg.cpp:888
+msgid "Enter a new style name"
+msgstr "Anna uuden tyylin nimi"
+
+#: ../src/richtext/richtextstyledlg.cpp:929
+#, fuzzy
+msgid "Enter a box style name"
+msgstr "Anna uuden tyylin nimi"
+
+#: ../src/richtext/richtextstylepage.cpp:109
+#: ../src/richtext/richtextstylepage.cpp:111
+msgid "The style name."
+msgstr "Tyylin nimi."
+
+#: ../src/richtext/richtextstylepage.cpp:114
+msgid "&Based on:"
+msgstr "&Pohjautuu:"
+
+#: ../src/richtext/richtextstylepage.cpp:119
+#: ../src/richtext/richtextstylepage.cpp:121
+msgid "The style on which this style is based."
+msgstr "Tyyli, johon tämä tyyli perustuu."
+
+#: ../src/richtext/richtextstylepage.cpp:124
+msgid "&Next style:"
+msgstr "&Uusi tyyli:"
+
+#: ../src/richtext/richtextstylepage.cpp:129
+#: ../src/richtext/richtextstylepage.cpp:131
+msgid "The default style for the next paragraph."
+msgstr "Oletustyyli seuraavalle kappaleelle."
+
+#: ../src/richtext/richtextstyles.cpp:1057
+msgid "All styles"
+msgstr "Kaikki tyylit"
+
+#: ../src/richtext/richtextstyles.cpp:1058
+msgid "Paragraph styles"
+msgstr "Kappaletyylit"
+
+#: ../src/richtext/richtextstyles.cpp:1059
+msgid "Character styles"
+msgstr "Merkkityylit"
+
+#: ../src/richtext/richtextstyles.cpp:1060
+msgid "List styles"
+msgstr "Luettelotyylit"
+
+#: ../src/richtext/richtextstyles.cpp:1061
+#, fuzzy
+msgid "Box styles"
+msgstr "Kaikki tyylit"
+
+#: ../src/richtext/richtextsymboldlg.cpp:389
+#: ../src/richtext/richtextsymboldlg.cpp:391
+msgid "The font from which to take the symbol."
+msgstr "Kirjasin, josta symboli otetaan."
+
+#: ../src/richtext/richtextsymboldlg.cpp:396
+msgid "&Subset:"
+msgstr "&Osajoukko:"
+
+#: ../src/richtext/richtextsymboldlg.cpp:401
+#: ../src/richtext/richtextsymboldlg.cpp:403
+msgid "Shows a Unicode subset."
+msgstr "Näyttää Unicode-osajoukon"
+
+#: ../src/richtext/richtextsymboldlg.cpp:412
+msgid "xxxx"
+msgstr "xxxx"
+
+#: ../src/richtext/richtextsymboldlg.cpp:417
+msgid "&Character code:"
+msgstr "&Merkkikoodi:"
+
+#: ../src/richtext/richtextsymboldlg.cpp:421
+#: ../src/richtext/richtextsymboldlg.cpp:423
+msgid "The character code."
+msgstr "Merkkikoodi."
+
+#: ../src/richtext/richtextsymboldlg.cpp:428
+msgid "&From:"
+msgstr "&Lähettäjä:"
+
+#: ../src/richtext/richtextsymboldlg.cpp:433
+#: ../src/richtext/richtextsymboldlg.cpp:434
+#: ../src/richtext/richtextsymboldlg.cpp:435
+msgid "Unicode"
+msgstr "Unicode"
+
+#: ../src/richtext/richtextsymboldlg.cpp:436
+#: ../src/richtext/richtextsymboldlg.cpp:438
+msgid "The range to show."
+msgstr "Näytettävä alue."
+
+#: ../src/richtext/richtextsymboldlg.cpp:444
+msgid "Insert"
+msgstr "Lisää"
+
+#: ../src/richtext/richtextsymboldlg.cpp:478
+msgid "(Normal text)"
+msgstr "(Tavallinen teksti)"
+
+#: ../src/richtext/richtexttabspage.cpp:109
+msgid "&Position (tenths of a mm):"
+msgstr "&Sijainti (millimetrin kymmenyksiä):"
+
+#: ../src/richtext/richtexttabspage.cpp:113
+#: ../src/richtext/richtexttabspage.cpp:115
+msgid "The tab position."
+msgstr "Välilehden sijainti."
+
+#: ../src/richtext/richtexttabspage.cpp:119
+msgid "The tab positions."
+msgstr "Välilehtien sijainnit."
+
+#: ../src/richtext/richtexttabspage.cpp:132
+#: ../src/richtext/richtexttabspage.cpp:134
+msgid "Click to create a new tab position."
+msgstr "Napsauta luodaksesi uuden välilehden sijainnin."
+
+#: ../src/richtext/richtexttabspage.cpp:138
+#: ../src/richtext/richtexttabspage.cpp:140
+msgid "Click to delete the selected tab position."
+msgstr "Napsauta poistaaksesi valitun välilehden sijainnin."
+
+#: ../src/richtext/richtexttabspage.cpp:143
+msgid "Delete A&ll"
+msgstr "Poista &kaikki"
+
+#: ../src/richtext/richtexttabspage.cpp:144
+#: ../src/richtext/richtexttabspage.cpp:146
+msgid "Click to delete all tab positions."
+msgstr "Napsauta poistaaksesi kaikki välilehtien sijainnit."
+
+#: ../src/univ/theme.cpp:110
+msgid "Failed to initialize GUI: no built-in themes found."
+msgstr "GUI:n alustus epäonnistui: ei teemoja mukana."
+
+#: ../src/univ/themes/gtk.cpp:521
+msgid "GTK+ theme"
+msgstr "GTK+-teema"
+
+#: ../src/univ/themes/metal.cpp:164
+msgid "Metal theme"
+msgstr ""
+
+#: ../src/univ/themes/mono.cpp:512
+msgid "Simple monochrome theme"
+msgstr "Yksinkertainen yksivärinen teema"
+
+#: ../src/univ/themes/win32.cpp:1098
+msgid "Win32 theme"
+msgstr "Win32-teema"
+
+#: ../src/univ/themes/win32.cpp:3743
+msgid "&Restore"
+msgstr "&Palauta"
+
+#: ../src/univ/themes/win32.cpp:3744
+msgid "&Move"
+msgstr "&Siirrä"
+
+#: ../src/univ/themes/win32.cpp:3746
+msgid "&Size"
+msgstr "&Koko"
+
+#: ../src/univ/themes/win32.cpp:3748
+msgid "Mi&nimize"
+msgstr "P&ienennä"
+
+#: ../src/univ/themes/win32.cpp:3750
+msgid "Ma&ximize"
+msgstr "S&uurenna"
+
+#: ../src/univ/themes/win32.cpp:3752
+msgid "Alt+"
+msgstr "Alt+"
+
+#: ../src/unix/appunix.cpp:178
+#, fuzzy
+msgid "Failed to install signal handler"
+msgstr "Tiedostokahvan sulkeminen epäonnistui"
+
+#: ../src/unix/dialup.cpp:351
+msgid "Already dialling ISP."
+msgstr "Palveluntarjoajalle soitetaan jo."
+
+#: ../src/unix/dlunix.cpp:93
+#, fuzzy
+msgid "Failed to unload shared library"
+msgstr "Jaetun kirjaston ”%s” lataaminen epäonnistui"
+
+#: ../src/unix/dlunix.cpp:121
+msgid "Unknown dynamic library error"
+msgstr "Tuntematon dynamic library virhe"
+
+#: ../src/unix/epolldispatcher.cpp:84
+#, fuzzy
+msgid "Failed to create epoll descriptor"
+msgstr "Osoittimen luonti epäonnistui."
+
+#: ../src/unix/epolldispatcher.cpp:103
+#, fuzzy
+msgid "Error closing epoll descriptor"
+msgstr "Virhe hakemistoa luotaessa"
+
+#: ../src/unix/epolldispatcher.cpp:116
+#, fuzzy, c-format
+msgid "Failed to add descriptor %d to epoll descriptor %d"
+msgstr "kirjoittaminen epäonnistui tiedoston kuvaukseen %d"
+
+#: ../src/unix/epolldispatcher.cpp:136
+#, c-format
+msgid "Failed to modify descriptor %d in epoll descriptor %d"
+msgstr "Kuvaajan %d muokkaus epäonnistui epoll-kuvaajassa %d"
+
+#: ../src/unix/epolldispatcher.cpp:155
+#, fuzzy, c-format
+msgid "Failed to unregister descriptor %d from epoll descriptor %d"
+msgstr "Dataa ei voida hakea leikepöydältä."
+
+#: ../src/unix/epolldispatcher.cpp:213
+#, fuzzy, c-format
+msgid "Waiting for IO on epoll descriptor %d failed"
+msgstr "Aliprosessin keskeytymisen odotus epäonnistui"
+
+#: ../src/unix/fswatcher_inotify.cpp:71
+#, fuzzy
+msgid "Unable to create inotify instance"
+msgstr "DDE-merkkijonoa ei voitu luoda"
+
+#: ../src/unix/fswatcher_inotify.cpp:94
+#, fuzzy
+msgid "Unable to close inotify instance"
+msgstr "Tiedostokahvan sulkeminen epäonnistui"
+
+#: ../src/unix/fswatcher_inotify.cpp:106
+msgid "Unable to add inotify watch"
+msgstr ""
+
+#: ../src/unix/fswatcher_inotify.cpp:138
+#, fuzzy, c-format
+msgid "Unable to remove inotify watch %i"
+msgstr "DDE-merkkijonoa ei voitu luoda"
+
+#: ../src/unix/fswatcher_inotify.cpp:271
+#, c-format
+msgid "Unexpected event for \"%s\": no matching watch descriptor."
+msgstr ""
+
+#: ../src/unix/fswatcher_inotify.cpp:320
+#, c-format
+msgid "Invalid inotify event for \"%s\""
+msgstr ""
+
+#: ../src/unix/fswatcher_inotify.cpp:553
+#, fuzzy
+msgid "Unable to read from inotify descriptor"
+msgstr "tiedoston kuvauksen %d luku epäonnistui"
+
+#: ../src/unix/fswatcher_inotify.cpp:558
+#, fuzzy
+msgid "EOF while reading from inotify descriptor"
+msgstr "tiedoston kuvauksen %d luku epäonnistui"
+
+#: ../src/unix/fswatcher_kqueue.cpp:114
+#, fuzzy
+msgid "Unable to create kqueue instance"
+msgstr "DDE-merkkijonoa ei voitu luoda"
+
+#: ../src/unix/fswatcher_kqueue.cpp:131
+#, fuzzy
+msgid "Error closing kqueue instance"
+msgstr "Virhe hakemistoa luotaessa"
+
+#: ../src/unix/fswatcher_kqueue.cpp:153
+msgid "Unable to add kqueue watch"
+msgstr ""
+
+#: ../src/unix/fswatcher_kqueue.cpp:170
+msgid "Unable to remove kqueue watch"
+msgstr ""
+
+#: ../src/unix/fswatcher_kqueue.cpp:202
+msgid "Unable to get events from kqueue"
+msgstr ""
+
+#: ../src/unix/mediactrl.cpp:966
+#, c-format
+msgid "Media playback error: %s"
+msgstr ""
+
+#: ../src/unix/mediactrl.cpp:1228
+#, fuzzy, c-format
+msgid "Failed to prepare playing \"%s\"."
+msgstr "Näyttöä ”%s” ei voitu avata."
+
+#: ../src/unix/snglinst.cpp:164
+#, c-format
+msgid "Failed to write to lock file '%s'"
+msgstr "Lukkotiedoston ”%s” kirjoitus epäonnistui"
+
+#: ../src/unix/snglinst.cpp:177
+#, c-format
+msgid "Failed to set permissions on lock file '%s'"
+msgstr "Oikeuksia ei voitu asettaa lukkotiedostolle ”%s”"
+
+#: ../src/unix/snglinst.cpp:194
+#, c-format
+msgid "Failed to lock the lock file '%s'"
+msgstr "Lukkotiedostoa ”%s” ei voitu lukita"
+
+#: ../src/unix/snglinst.cpp:237
+#, c-format
+msgid "Failed to inspect the lock file '%s'"
+msgstr "Lukkotiedostoa ”%s” ei voitu tutkia"
+
+#: ../src/unix/snglinst.cpp:242
+#, c-format
+msgid "Lock file '%s' has incorrect owner."
+msgstr "Lukkotiedostolla ”%s” on virheellinen omista."
+
+#: ../src/unix/snglinst.cpp:247
+#, c-format
+msgid "Lock file '%s' has incorrect permissions."
+msgstr "Lukkotiedostolla ”%s” on virheelliset oikeudet."
+
+#: ../src/unix/snglinst.cpp:265
+msgid "Failed to access lock file."
+msgstr "Lukkotiedostoon ei päästy käsiksi."
+
+#: ../src/unix/snglinst.cpp:274
+msgid "Failed to read PID from lock file."
+msgstr "PID:iä ei voitu lukea lukkotiedostosta."
+
+#: ../src/unix/snglinst.cpp:284
+#, c-format
+msgid "Failed to remove stale lock file '%s'."
+msgstr "Vanhan lukitustiedoston '%s' poisto epäonnistui."
+
+#: ../src/unix/snglinst.cpp:297
+#, c-format
+msgid "Deleted stale lock file '%s'."
+msgstr "Vanha lukitustiedosto '%s' poistettu."
+
+#: ../src/unix/snglinst.cpp:308
+#, c-format
+msgid "Invalid lock file '%s'."
+msgstr "Virheellinen lukkotiedosto ”%s”."
+
+#: ../src/unix/snglinst.cpp:324
+#, c-format
+msgid "Failed to remove lock file '%s'"
+msgstr "Lukkotiedoston ”%s” poisto ei onnistu"
+
+#: ../src/unix/snglinst.cpp:330
+#, c-format
+msgid "Failed to unlock lock file '%s'"
+msgstr "Lukkotiedoston ”%s” lukitusta ei voitu purkaa"
+
+#: ../src/unix/snglinst.cpp:336
+#, c-format
+msgid "Failed to close lock file '%s'"
+msgstr "Lukkotiedoston ”%s” sulkeminen epäonnistui"
+
+#: ../src/unix/sound.cpp:77
+msgid "No sound"
+msgstr "Ei ääntä"
+
+#: ../src/unix/sound.cpp:364
+msgid "Unable to play sound asynchronously."
+msgstr ""
+
+#: ../src/unix/sound.cpp:458
+#, c-format
+msgid "Couldn't load sound data from '%s'."
+msgstr "Ei voi ladata äänidataa kohteesta ”%s”"
+
+#: ../src/unix/sound.cpp:465
+#, c-format
+msgid "Sound file '%s' is in unsupported format."
+msgstr "äänitiedoston ”%s” muotoa ei tueta."
+
+#: ../src/unix/sound.cpp:480
+msgid "Sound data are in unsupported format."
+msgstr "äänidatan muotoa ei tueta."
+
+#: ../src/unix/sound_sdl.cpp:226
+#, c-format
+msgid "Couldn't open audio: %s"
+msgstr "ääntä ei voi avata: %s"
+
+#: ../src/unix/threadpsx.cpp:1033
+msgid "Cannot retrieve thread scheduling policy."
+msgstr "Säikeen järjestyspolitiikka ei löydettävissä."
+
+#: ../src/unix/threadpsx.cpp:1058
+#, c-format
+msgid "Cannot get priority range for scheduling policy %d."
+msgstr "Järjestyspolitiikan %d priorisointialue ei ole tiedossa."
+
+#: ../src/unix/threadpsx.cpp:1066
+msgid "Thread priority setting is ignored."
+msgstr "Säikeen prioriteettiasetus jätetään huomiotta."
+
+#: ../src/unix/threadpsx.cpp:1221
+msgid ""
+"Failed to join a thread, potential memory leak detected - please restart the "
+"program"
+msgstr ""
+"Säikeen kytkentä epäonnistui, todennäköisesti muistivuoto - ole hyvä ja "
+"käynnistä ohjelma uudestaan"
+
+#: ../src/unix/threadpsx.cpp:1352
+#, fuzzy, c-format
+msgid "Failed to set thread concurrency level to %lu"
+msgstr "Säikeen prioriteetin %d asetus epäonnistui."
+
+#: ../src/unix/threadpsx.cpp:1481
+#, c-format
+msgid "Failed to set thread priority %d."
+msgstr "Säikeen prioriteetin %d asetus epäonnistui."
+
+#: ../src/unix/threadpsx.cpp:1666
+msgid "Failed to terminate a thread."
+msgstr "Säikeen päättäminen epäonnistui."
+
+#: ../src/unix/threadpsx.cpp:1893
+msgid "Thread module initialization failed: failed to create thread key"
+msgstr "Säiemoduulin käynnistys epäonnistui: säieavainta ei voi luoda"
+
+#: ../src/unix/utilsunx.cpp:340
+msgid "Impossible to get child process input"
+msgstr "Lapsiprosessin syötteen saanti on mahdotonta"
+
+#: ../src/unix/utilsunx.cpp:390
+#, fuzzy
+msgid "Can't write to child process's stdin"
+msgstr "Prosessia %d ei voitu lopettaa."
+
+#: ../src/unix/utilsunx.cpp:644
+#, c-format
+msgid "Failed to execute '%s'\n"
+msgstr "Ei voitu ajaa kohdetta ”%s”\n"
+
+#: ../src/unix/utilsunx.cpp:678
+msgid "Fork failed"
+msgstr "Haarauttaminen epäonnistui"
+
+#: ../src/unix/utilsunx.cpp:701
+#, fuzzy
+msgid "Failed to set process priority"
+msgstr "Säikeen prioriteetin %d asetus epäonnistui."
+
+#: ../src/unix/utilsunx.cpp:712
+msgid "Failed to redirect child process input/output"
+msgstr "Lapsiprosessin I/O:n uudelleenohjaus epäonnistui"
+
+#: ../src/unix/utilsunx.cpp:816
+msgid "Failed to set up non-blocking pipe, the program might hang."
+msgstr ""
+
+#: ../src/unix/utilsunx.cpp:1023
+msgid "Cannot get the hostname"
+msgstr "Isäntäkoneen nimeä ei onnistuttu saamaan"
+
+#: ../src/unix/utilsunx.cpp:1059
+msgid "Cannot get the official hostname"
+msgstr "Isäntäkoneen virallista nimeä ei onnistuttu saamaan"
+
+#: ../src/unix/wakeuppipe.cpp:49
+#, fuzzy
+msgid "Failed to create wake up pipe used by event loop."
+msgstr "Tilarivin luonti epäonnistui."
+
+#: ../src/unix/wakeuppipe.cpp:56
+msgid "Failed to switch wake up pipe to non-blocking mode"
+msgstr ""
+
+#: ../src/unix/wakeuppipe.cpp:117
+#, fuzzy
+msgid "Failed to read from wake-up pipe"
+msgstr "PID:iä ei voitu lukea lukkotiedostosta."
+
+#: ../src/x11/app.cpp:124
+#, c-format
+msgid "Invalid geometry specification '%s'"
+msgstr "Virheellinen geometry-määritelmä ”%s”"
+
+#: ../src/x11/app.cpp:167
+msgid "wxWidgets could not open display. Exiting."
+msgstr "wxWidgets ei voi avata näyttöä. Poistutaan."
+
+#: ../src/x11/utils.cpp:169
+#, fuzzy, c-format
+msgid "Failed to close the display \"%s\""
+msgstr "Näytön ”%s” sulkeminen epäonnistui"
+
+#: ../src/x11/utils.cpp:188
+#, fuzzy, c-format
+msgid "Failed to open display \"%s\"."
+msgstr "Näyttöä ”%s” ei voitu avata."
+
+#: ../src/xml/xml.cpp:868
+#, c-format
+msgid "XML parsing error: '%s' at line %d"
+msgstr "XML-jäsennysvirhe: ”%s” rivillä %d"
+
+#: ../src/xrc/xh_propgrid.cpp:239
+#, fuzzy, c-format
+msgid "Page %i"
+msgstr "Sivu %d"
+
+#: ../src/xrc/xmlres.cpp:448
+#, fuzzy, c-format
+msgid "Cannot load resources from '%s'."
+msgstr "Ei voi ladata resursseja tiedostosta ”%s”."
+
+#: ../src/xrc/xmlres.cpp:799
+#, fuzzy, c-format
+msgid "Cannot open resources file '%s'."
+msgstr "Ei voi ladata resursseja tiedostosta ”%s”."
+
+#: ../src/xrc/xmlres.cpp:806
+#, c-format
+msgid "Cannot load resources from file '%s'."
+msgstr "Ei voi ladata resursseja tiedostosta ”%s”."
+
+#: ../src/xrc/xmlres.cpp:2767
+#, fuzzy, c-format
+msgid "Creating %s \"%s\" failed."
+msgstr "Ei voitu purkaa ”%s”:aa kohteeseen ”%s”."
+
+#~ msgctxt "keyboard key"
+#~ msgid "Alt+"
+#~ msgstr "Alt+"
+
+#, fuzzy
+#~ msgctxt "keyboard key"
+#~ msgid "Ctrl+"
+#~ msgstr "Ctrl-"
+
+#, fuzzy
+#~ msgctxt "keyboard key"
+#~ msgid "Shift+"
+#~ msgstr "Shift-"
+
+#, fuzzy
+#~ msgctxt "keyboard key"
+#~ msgid "RawCtrl+"
+#~ msgstr "Ctrl-"
+
+#~ msgid "Unsupported clipboard format."
+#~ msgstr "Leikepöydän muoto ei ole tuettu."
+
+#~ msgid "Background colour"
+#~ msgstr "Taustaväri"
+
+#~ msgid "Font:"
+#~ msgstr "Kirjasin:"
+
+#~ msgid "Size:"
+#~ msgstr "Koko:"
+
+#~ msgid "The font size in points."
+#~ msgstr "Kirjasinkoko pisteinä."
+
+#~ msgid "Style:"
+#~ msgstr "Tyyli:"
+
+#~ msgid "Check to make the font bold."
+#~ msgstr "Valitse tehdäksesi kirjasimesta lihavoidun."
+
+#~ msgid "Check to make the font italic."
+#~ msgstr "Valitse tehdäksesi kirjasimesta kursivoidun."
+
+#~ msgid "Check to make the font underlined."
+#~ msgstr "Valitse alleviivataksesi kirjasimen."
+
+#~ msgid "Colour:"
+#~ msgstr "Väri:"
+
+#~ msgid "Click to change the font colour."
+#~ msgstr "Napsauta muuttaaksesi kirjasimen värin."
+
+#~ msgid "Shows a preview of the font."
+#~ msgstr "Näyttää kirjasimen esikatselun."
+
+#~ msgid "Click to cancel changes to the font."
+#~ msgstr "Napsauta peruuttaaksesi muutokset kirjasimeen."
+
+#~ msgid "Click to confirm changes to the font."
+#~ msgstr "Napsauta varmistaaksesi muutokset kirjasimeen."
+
+#~ msgid "<Any>"
+#~ msgstr "<Mikä tahansa>"
+
+#~ msgid "<Any Roman>"
+#~ msgstr "<Roman>"
+
+#~ msgid "<Any Decorative>"
+#~ msgstr "<Koristeellinen>"
+
+#~ msgid "<Any Modern>"
+#~ msgstr "<Moderni>"
+
+#~ msgid "<Any Script>"
+#~ msgstr "<Script>"
+
+#~ msgid "<Any Swiss>"
+#~ msgstr "<Swiss>"
+
+#~ msgid "<Any Teletype>"
+#~ msgstr "<Teletype>"
+
+#~ msgid "Printing "
+#~ msgstr "Tulostetaan "
+
+#, fuzzy
+#~ msgid "Failed to insert text in the control."
+#~ msgstr "Työhakemistoa ei saatu"
+
+#~ msgid "Please choose a valid font."
+#~ msgstr "Valitse kelvollinen fontti."
+
+#, c-format
+#~ msgid "Failed to display HTML document in %s encoding"
+#~ msgstr "HTML %s-koodattua asiakirjaa ei voi näyttää"
+
+#, c-format
+#~ msgid "wxWidgets could not open display for '%s': exiting."
+#~ msgstr "wxWidgets ei voi avata näyttöä prosessille ”%s”: poistutaan."
+
+#~ msgid "Filter"
+#~ msgstr "Suodatin"
+
+#~ msgid "Directories"
+#~ msgstr "Hakemistot"
+
+#~ msgid "Files"
+#~ msgstr "Tiedostot"
+
+#~ msgid "Selection"
+#~ msgstr "Valinta"
+
+#~ msgid "conversion to 8-bit encoding failed"
+#~ msgstr "muunnos 8-bittiseksi koodaukseksi epäonnistui"
+
+#, fuzzy
+#~ msgid "failed to retrieve execution result"
+#~ msgstr "RAS-virheilmoitusta ei saatu."
+
+#~ msgid "&Save as"
+#~ msgstr "&Tallenna nimellä"
+
+#, fuzzy
+#~ msgid "'%s' doesn't consist only of valid characters"
+#~ msgstr "”%s” saa sisältää vain kirjaimia."
+
+#~ msgid "'%s' should be numeric."
+#~ msgstr "”%s” on oltava numeerinen."
+
+#~ msgid "'%s' should only contain ASCII characters."
+#~ msgstr "”%s” saa sisältää vain ASCII-merkkejä."
+
+#~ msgid "'%s' should only contain alphabetic characters."
+#~ msgstr "”%s” saa sisältää vain kirjaimia."
+
+#~ msgid "'%s' should only contain alphabetic or numeric characters."
+#~ msgstr "”%s” saa sisältää vain kirjaimia ja numeroita."
+
+#~ msgid "'%s' should only contain digits."
+#~ msgstr "”%s” saa sisältää vain ASCII-merkkejä."
+
+#~ msgid "Can't create window of class %s"
+#~ msgstr "Luokan ”%s” ikkunan luonti epäonnistui"
+
+#, fuzzy
+#~ msgid "Couldn't create the overlay window"
+#~ msgstr "Ajastimen luonti epäonnistui"
+
+#, fuzzy
+#~ msgid "Couldn't init the context on the overlay window"
+#~ msgstr "Säikeen osoittimen haku epäonnistui"
+
+#, fuzzy
+#~ msgid "Failed to convert file \"%s\" to Unicode."
+#~ msgstr "Tiedostoa ”%s” ei voitu muuntaa Unicode-muotoon."
+
+#, fuzzy
+#~ msgid "Failed to set text in the text control."
+#~ msgstr "Työhakemistoa ei saatu"
+
+#, fuzzy
+#~ msgid "Invalid GTK+ command line option, use \"%s --help\""
+#~ msgstr "Virheellinen GTK+-komentorivivalinta, kokeile ”%s --help”"
+
+#~ msgid "No unused colour in image."
+#~ msgstr "Ei käyttämättömiä värejä kuvassa"
+
+#, fuzzy
+#~ msgid "Not available"
+#~ msgstr "Valitettavasti vihjeitä ei ole!"
+
+#~ msgid "Replace selection"
+#~ msgstr "Korvaa valinta"
+
+#, fuzzy
+#~ msgid "Save as"
+#~ msgstr "Tallenna nimellä"
+
+#~ msgid "Style Organiser"
+#~ msgstr "Tyylien hallitsija"
+
+#~ msgid "The following standard GTK+ options are also supported:\n"
+#~ msgstr "Seuraavat standardit GTK+-valinnat ovat myös tuettuina:\n"
+
+#, fuzzy
+#~ msgid "You cannot Clear an overlay that is not inited"
+#~ msgstr "Et voi lisätä uutta hakemistoa tähän kohtaan."
+
+#~ msgid "locale '%s' cannot be set."
+#~ msgstr "maa-arvoa ”%s” ei voida asettaa."
+
+#~ msgid "Adding flavor TEXT failed"
+#~ msgstr "TEXT-kerroksen lisääminen epäonnistui"
+
+#~ msgid "Adding flavor utxt failed"
+#~ msgstr "Utxt-kerroksen lisääminen epäonnistui"
+
+#~ msgid "Bitmap renderer cannot render value; value type: "
+#~ msgstr "Värikartan piirtäjä ei voi piirtää arvoa; arvon tyyppi:"
+
+#~ msgid ""
+#~ "Cannot create new column's ID. Probably max. number of columns reached."
+#~ msgstr ""
+#~ "Uutta saraketunnusta ei voi luoda. Mahdollisesti sarakkeiden "
+#~ "enimmäismäärä saavutettu."
+
+#~ msgid "Column could not be added."
+#~ msgstr "Saraketta ei voitu lisätä."
+
+#~ msgid "Column index not found."
+#~ msgstr "Sarakeindeksiä ei löytynyt."
+
+#~ msgid "Column width could not be determined"
+#~ msgstr "Sarakkeen leveyttä ei voitu määritellä"
+
+#~ msgid "Column width could not be set."
+#~ msgstr "Sarakkeen leveyttä ei voitu asettaa."
+
+#~ msgid "Confirm registry update"
+#~ msgstr "Varmista järjestelmärekisterin päivitys"
+
+#~ msgid "Could not determine column index."
+#~ msgstr "Sarakeindeksiä ei voitu määrittää."
+
+#~ msgid "Could not determine column's position"
+#~ msgstr "Ei voitu määritellä sarakkeen paikkaa"
+
+#, fuzzy
+#~ msgid "Could not determine number of columns."
+#~ msgstr "Kohteiden lukumäärää ei voitu määritellä"
+
+#~ msgid "Could not determine number of items"
+#~ msgstr "Kohteiden lukumäärää ei voitu määritellä"
+
+#~ msgid "Could not get header description."
+#~ msgstr "Otsikon kuvausta ei saatu."
+
+#~ msgid "Could not get items."
+#~ msgstr "Kohteita ei saatu."
+
+#~ msgid "Could not get property flags."
+#~ msgstr "Oikeita lippuja ei saatu."
+
+#~ msgid "Could not get selected items."
+#~ msgstr "Valittuja kohteita ei saatu."
+
+#~ msgid "Could not remove column."
+#~ msgstr "Saraketta ei voitu poistaa."
+
+#~ msgid "Could not retrieve number of items"
+#~ msgstr "Kohtien lukumäärää ei voitu vastaanottaa"
+
+#~ msgid "Could not set column width."
+#~ msgstr "Sarakkeen leveyttä ei voitu asettaa."
+
+#~ msgid "Could not set header description."
+#~ msgstr "Otsikon kuvausta ei voitu asettaa."
+
+#~ msgid "Could not set icon."
+#~ msgstr "Kuvaketta ei voitu asettaa"
+
+#~ msgid "Could not set maximum width."
+#~ msgstr "Enimmäisleveyttä ei voitu asettaa"
+
+#~ msgid "Could not set minimum width."
+#~ msgstr "Vähimmäisleveyttä ei voitu asettaa."
+
+#~ msgid "Could not set property flags."
+#~ msgstr "Oikeita lippuja ei voitu asettaa."
+
+#~ msgid "Data object has invalid data format"
+#~ msgstr "Tieto-objektilla on virheellinen datamuoto"
+
+#~ msgid "Date renderer cannot render value; value type: "
+#~ msgstr "Päivämäärän hahmontaja ei voi hahmontaa arvoa; arvon tyyppi: "
+
+#, fuzzy
+#~ msgid ""
+#~ "Do you want to overwrite the command used to %s files with extension "
+#~ "\"%s\" ?\n"
+#~ "Current value is \n"
+#~ "%s, \n"
+#~ "New value is \n"
+#~ "%s %1"
+#~ msgstr ""
+#~ "Haluatko korvata komennon jota käytetään %s-tiedostoille joilla on pääte "
+#~ "”%s” ?\n"
+#~ "Nykyinen arvo on \n"
+#~ "%s, \n"
+#~ "Uusi arvo on \n"
+#~ "%s %1"
+
+#~ msgid "Failed to retrieve data from the clipboard."
+#~ msgstr "Dataa ei voida hakea leikepöydältä."
+
+#~ msgid "GIF: Invalid gif index."
+#~ msgstr "GIF: Virheellinen GIF-indeksi."
+
+#~ msgid "GIF: unknown error!!!"
+#~ msgstr "GIF: tuntematon virhe!!!"
+
+#~ msgid "Icon & text renderer cannot render value; value type: "
+#~ msgstr ""
+#~ "Kuvakkeen ja tekstin hahmontaja ei voi hahmontaa arvoa; arvon tyyppi: "
+
+#~ msgid "New directory"
+#~ msgstr "Uusi hakemisto"
+
+#~ msgid "Next"
+#~ msgstr "Seuraava"
+
+#~ msgid "No column existing."
+#~ msgstr "Saraketta ei ole."
+
+#, fuzzy
+#~ msgid "No column for the specified column existing."
+#~ msgstr "Saraketta ei ole."
+
+#, fuzzy
+#~ msgid "Number of columns could not be determined."
+#~ msgstr "Sarakkeen leveyttä ei voitu määritellä"
+
+#, fuzzy
+#~ msgid "OpenGL function \"%s\" failed: %s (error %d)"
+#~ msgstr "OpenGL-toiminto ”%s” epäonnistui: %s (virhe %d)"
+
+#~ msgid ""
+#~ "Please install a newer version of comctl32.dll\n"
+#~ "(at least version 4.70 is required but you have %d.%02d)\n"
+#~ "or this program won't operate correctly."
+#~ msgstr ""
+#~ "Ole hyvä ja asenna uudempi versio tiedostosta comctl32.dll\n"
+#~ "(version 4.70 vaaditaan mutta sinulla on %d.%02d)\n"
+#~ "tai tämä ohjelma ei toimi kunnolla."
+
+#~ msgid "Rendering failed."
+#~ msgstr "Piirtäminen epäonnistui."
+
+#~ msgid "Show hidden directories"
+#~ msgstr "Näytä piilohakemistot"
+
+#, fuzzy
+#~ msgid ""
+#~ "This system doesn't support date controls, please upgrade your version of "
+#~ "comctl32.dll"
+#~ msgstr ""
+#~ "Tämä järjestelmä ei tue date picker kontrollia, ole hyvä ja päivitä "
+#~ "comctl32.dll"
+
+#~ msgid "Too many colours in PNG, the image may be slightly blurred."
+#~ msgstr "Liian monta väri PNG:ssä, kuva saattaa olla hieman sumea."
+
+#~ msgid "Unable to initialize Hildon program"
+#~ msgstr "Hildon-sovellusta ei voida alustaa"
+
+#, fuzzy
+#~ msgid "Unknown data format"
+#~ msgstr "virhe dataformaatissa"
+
+#~ msgid "Win32s on Windows 3.1"
+#~ msgstr "Win32s, Windows 3.1-alustalla"
+
+#, fuzzy
+#~ msgid "Windows 10"
+#~ msgstr "Windows 98"
+
+#~ msgid "Windows 2000"
+#~ msgstr "Windows 2000"
+
+#~ msgid "Windows 7"
+#~ msgstr "Windows 7"
+
+#, fuzzy
+#~ msgid "Windows 8"
+#~ msgstr "Windows 98"
+
+#, fuzzy
+#~ msgid "Windows 8.1"
+#~ msgstr "Windows 98"
+
+#~ msgid "Windows 95"
+#~ msgstr "Windows 95"
+
+#~ msgid "Windows 95 OSR2"
+#~ msgstr "Windows 95 OSR2"
+
+#~ msgid "Windows 98"
+#~ msgstr "Windows 98"
+
+#~ msgid "Windows 98 SE"
+#~ msgstr "Windows 98 SE"
+
+#~ msgid "Windows 9x (%d.%d)"
+#~ msgstr "Windows 9x (%d.%d)"
+
+#~ msgid "Windows CE (%d.%d)"
+#~ msgstr "Windows CE (%d.%d)"
+
+#~ msgid "Windows ME"
+#~ msgstr "Windows ME"
+
+#~ msgid "Windows NT %lu.%lu"
+#~ msgstr "Windows NT %lu.%lu"
+
+#, fuzzy
+#~ msgid "Windows Server 10"
+#~ msgstr "Windows Server 2003"
+
+#~ msgid "Windows Server 2003"
+#~ msgstr "Windows Server 2003"
+
+#~ msgid "Windows Server 2008"
+#~ msgstr "Windows Server 2008"
+
+#~ msgid "Windows Server 2008 R2"
+#~ msgstr "Windows Server 2008 R2"
+
+#, fuzzy
+#~ msgid "Windows Server 2012"
+#~ msgstr "Windows Server 2003"
+
+#, fuzzy
+#~ msgid "Windows Server 2012 R2"
+#~ msgstr "Windows Server 2008 R2"
+
+#~ msgid "Windows Vista"
+#~ msgstr "Windows Vista"
+
+#~ msgid "Windows XP"
+#~ msgstr "Windows XP"
+
+#~ msgid "can't execute '%s'"
+#~ msgstr "ei voida suorittaa kohdetta ”%s”"
+
+#~ msgid "error opening '%s'"
+#~ msgstr "virhe avattaessa kohdetta ”%s”"
+
+#~ msgid "unknown seek origin"
+#~ msgstr "tuntematon haun alku"
+
+#~ msgid "wxWidget's control not initialized."
+#~ msgstr "wxWidgetin säädintä ei alustettu."
+
+#~ msgid "ADD"
+#~ msgstr "LISÄÄ"
+
+#~ msgid "BACK"
+#~ msgstr "TAKAISIN"
+
+#~ msgid "CANCEL"
+#~ msgstr "PERUUTA"
+
+#~ msgid "CAPITAL"
+#~ msgstr "SUURAAKKOSET"
+
+#~ msgid "CLEAR"
+#~ msgstr "TYHJENNÄ"
+
+#~ msgid "COMMAND"
+#~ msgstr "KOMENTO"
+
+#~ msgid "Cannot create mutex."
+#~ msgstr "Mutexin luonti epäonnistui"
+
+#~ msgid "Cannot resume thread %lu"
+#~ msgstr "Säikeen %lu jatko epäonnistui"
+
+#~ msgid "Cannot suspend thread %lu"
+#~ msgstr "Säikeen %lu keskeytys epäonnistui"
+
+#~ msgid "Couldn't acquire a mutex lock"
+#~ msgstr "Mutex lukon saanti epäonnistui"
+
+#~ msgid "Couldn't get hatch style from wxBrush."
+#~ msgstr "Varjostustyyliä ei voitu noutaa wxBrush-funktiosta."
+
+#~ msgid "Couldn't release a mutex"
+#~ msgstr "Mutexin vapautus ei onnistu"
+
+#~ msgid "DECIMAL"
+#~ msgstr "DESIMAALI"
+
+#~ msgid "DELETE"
+#~ msgstr "POISTA"
+
+#~ msgid "DIVIDE"
+#~ msgstr "JAA"
+
+#~ msgid "DOWN"
+#~ msgstr "ALAS"
+
+#~ msgid "ENTER"
+#~ msgstr "ENTER"
+
+#~ msgid "ESC"
+#~ msgstr "ESC"
+
+#~ msgid "ESCAPE"
+#~ msgstr "ESCAPE"
+
+#~ msgid "EXECUTE"
+#~ msgstr "SUORITA"
+
+#~ msgid "Execution of command '%s' failed with error: %ul"
+#~ msgstr "Komennon ”%s” ajo epäonnistui virheellä: %ul"
+
+#~ msgid ""
+#~ "File '%s' already exists.\n"
+#~ "Do you want to replace it?"
+#~ msgstr ""
+#~ "Tiedosto ”%s” on jo olemassa.\n"
+#~ "Korvataanko se?"
+
+#~ msgid "HELP"
+#~ msgstr "OHJE"
+
+#~ msgid "HOME"
+#~ msgstr "KOTI"
+
+#~ msgid "INS"
+#~ msgstr "INS"
+
+#~ msgid "INSERT"
+#~ msgstr "LISÄÄ"
+
+#~ msgid "KP_BEGIN"
+#~ msgstr "KP_ALOITA"
+
+#~ msgid "KP_DECIMAL"
+#~ msgstr "KP_DESIMAALI"
+
+#~ msgid "KP_DELETE"
+#~ msgstr "KP_POISTA"
+
+#~ msgid "KP_DIVIDE"
+#~ msgstr "KP_JAKOMERKKI"
+
+#~ msgid "KP_DOWN"
+#~ msgstr "KP_ALAS"
+
+#~ msgid "KP_ENTER"
+#~ msgstr "KP_ENTER"
+
+#~ msgid "KP_EQUAL"
+#~ msgstr "KP_YHTÄSUURI"
+
+#~ msgid "KP_HOME"
+#~ msgstr "KP_HOME"
+
+#~ msgid "KP_INSERT"
+#~ msgstr "KP_INSERT"
+
+#~ msgid "KP_LEFT"
+#~ msgstr "KP_VASEN"
+
+#~ msgid "KP_MULTIPLY"
+#~ msgstr "KP_KERTOMERKKI"
+
+#~ msgid "KP_NEXT"
+#~ msgstr "KP_SEURAAVA"
+
+#~ msgid "KP_PAGEDOWN"
+#~ msgstr "KP_PAGEDOWN"
+
+#~ msgid "KP_PAGEUP"
+#~ msgstr "KP_PAGEUP"
+
+#~ msgid "KP_PRIOR"
+#~ msgstr "KP_EDELLINEN"
+
+#~ msgid "KP_RIGHT"
+#~ msgstr "KP_OIKEA"
+
+#~ msgid "KP_SEPARATOR"
+#~ msgstr "KP_EROTIN"
+
+#~ msgid "KP_SPACE"
+#~ msgstr "KP_SPACE"
+
+#~ msgid "KP_SUBTRACT"
+#~ msgstr "KP_VÄHENNÄ"
+
+#~ msgid "LEFT"
+#~ msgstr "VASEN"
+
+#~ msgid "MENU"
+#~ msgstr "VALIKKO"
+
+#~ msgid "NUM_LOCK"
+#~ msgstr "NUM_LOCK"
+
+#~ msgid "PAGEDOWN"
+#~ msgstr "PAGEDOWN"
+
+#~ msgid "PAGEUP"
+#~ msgstr "PAGEUP"
+
+#~ msgid "PAUSE"
+#~ msgstr "PAUSE"
+
+#~ msgid "PGDN"
+#~ msgstr "PGDN"
+
+#~ msgid "PGUP"
+#~ msgstr "PGUP"
+
+#~ msgid "PRINT"
+#~ msgstr "TULOSTA"
+
+#~ msgid "RETURN"
+#~ msgstr "ENTER"
+
+#~ msgid "RIGHT"
+#~ msgstr "OIKEA"
+
+#~ msgid "SCROLL_LOCK"
+#~ msgstr "SCROLL_LOCK"
+
+#~ msgid "SELECT"
+#~ msgstr "VALITSE"
+
+#~ msgid "SEPARATOR"
+#~ msgstr "EROTIN"
+
+#~ msgid "SPACE"
+#~ msgstr "VÄLI"
+
+#~ msgid "SUBTRACT"
+#~ msgstr "VÄHENNÄ"
+
+#~ msgid "TAB"
+#~ msgstr "TAB"
+
+#~ msgid "The print dialog returned an error."
+#~ msgstr "Tulostusvalintaikkuna palautti virheen."
+
+#~ msgid "The wxGtkPrinterDC cannot be used."
+#~ msgstr "Toimintoa wxGtkPrinterDC ei voida käyttää."
+
+#~ msgid "Timer creation failed."
+#~ msgstr "Ajastimen luonti epäonnistui"
+
+#~ msgid "UP"
+#~ msgstr "UP"
+
+#~ msgid "not implemented"
+#~ msgstr "Ei toteutettu"
+
+#~ msgid "Event queue overflowed"
+#~ msgstr "Ylivuoto tapahtumajonossa"
+
+#~ msgid "percent"
+#~ msgstr "prosentti"
+
+#~ msgid "Print preview"
+#~ msgstr "Tulostuksen esikatselu"
+
+#~ msgid "'"
+#~ msgstr "'"
+
+#~ msgid "1"
+#~ msgstr "1"
+
+#~ msgid "10"
+#~ msgstr "10"
+
+#~ msgid "3"
+#~ msgstr "3"
+
+#~ msgid "4"
+#~ msgstr "4"
+
+#~ msgid "5"
+#~ msgstr "5"
+
+#~ msgid "6"
+#~ msgstr "6"
+
+#~ msgid "7"
+#~ msgstr "7"
+
+#~ msgid "8"
+#~ msgstr "8"
+
+#~ msgid "9"
+#~ msgstr "9"
+
+#~ msgid "Can't monitor non-existent path \"%s\" for changes."
+#~ msgstr ""
+#~ "Polun \"%s\" muutoksia ei voida tarkkailla, koska sitä ei ole olemassa."
+
+#~ msgid "File system containing watched object was unmounted"
+#~ msgstr ""
+#~ "Vahditun objektin sisältävän tiedostojärjestelmän liitos on poistettu"
+
+#~ msgid "&Preview..."
+#~ msgstr "&Esikatselu..."
+
+#~ msgid "&Save..."
+#~ msgstr "&Tallenna..."
+
+#~ msgid "About "
+#~ msgstr "Tietoja"
+
+#~ msgid "All files (*.*)|*"
+#~ msgstr "Kaikki tiedostot (*.*)|*"
+
+#~ msgid "Cannot initialize SciTech MGL!"
+#~ msgstr "SciTech MGL:n alustus epäonnistui!"
+
+#~ msgid "Cannot initialize display."
+#~ msgstr "Näytön alustus epäonnistui."
+
+#~ msgid "Cannot start thread: error writing TLS"
+#~ msgstr "Säiettä ei voi käynnistää: virhe TLS:n kirjoituksessa"
+
+#~ msgid "Close\tAlt-F4"
+#~ msgstr "Sulje\tAlt-F4"
+
+#~ msgid "Couldn't create cursor."
+#~ msgstr "Kohdistimen luonti epäonnistui."
+
+#~ msgid "Directory '%s' doesn't exist!"
+#~ msgstr "Hakemistoa ”%s” ei ole olemassa!"
+
+#~ msgid "Mode %ix%i-%i not available."
+#~ msgstr "Tila %ix%i-%i ei käytettävissä."
+
+#~ msgid "Paper Size"
+#~ msgstr "Paperin koko"
+
+#, fuzzy
+#~ msgid "Preview..."
+#~ msgstr " Esikatselu"
+
+#, fuzzy
+#~ msgid "The vertical offset relative to the paragraph."
+#~ msgstr "Oletustyyli seuraavalle kappaleelle."
+
+#~ msgid "%.*f GB"
+#~ msgstr "%.*f GB"
+
+#~ msgid "%.*f MB"
+#~ msgstr "%.*f MB"
+
+#~ msgid "%.*f TB"
+#~ msgstr "%.*f TB"
+
+#~ msgid "%.*f kB"
+#~ msgstr "%.*f kB"
+
+#~ msgid "%s B"
+#~ msgstr "%s B"
+
+#~ msgid "&Goto..."
+#~ msgstr "&Siirry..."
+
+#~ msgid "<<"
+#~ msgstr "<<"
+
+#~ msgid ">>"
+#~ msgstr ">>"
+
+#~ msgid ">>|"
+#~ msgstr ">>|"
+
+#~ msgid "Added item is invalid."
+#~ msgstr "Lisätty kohta on epäkelpo."
+
+#~ msgid "Archive doesnt contain #SYSTEM file"
+#~ msgstr "Arkisto ei sisällä #SYSTEM tiedostoa"
+
+#~ msgid "Can't check image format of file '%s': file does not exist."
+#~ msgstr "En voi tarkistaa kuvatiedoston ”%s” muotoa: tiedostoa ei ole."
+
+#~ msgid "Can't load image from file '%s': file does not exist."
+#~ msgstr "Tiedostosta ”%s” ei voi ladata kuvaa: tiedosto ei ole olemassa."
+
+#~ msgid "Cannot convert from the charset '%s'!"
+#~ msgstr "Ei voida muuttaa merkistöstä ”%s”!"
+
+#~ msgid "Cannot find font node '%s'."
+#~ msgstr "Kirjasinsolmua ”%s” ei löydy."
+
+#~ msgid "Cannot open file '%s'."
+#~ msgstr "Tiedostoa ”%s” ei voi avata."
+
+#~ msgid "Cannot parse coordinates from '%s'."
+#~ msgstr "Koordinaatteja ei voida saada: ”%s”"
+
+#~ msgid "Cannot parse dimension from '%s'."
+#~ msgstr "Mittoja ei voida saada: ”%s”"
+
+#~ msgid "Cant create the thread event queue"
+#~ msgstr "Säikeen tapahtumajonoa ei voida luoda"
+
+#~ msgid "Changed item is invalid."
+#~ msgstr "Muutettu kohde on epäkelpo."
+
+#~ msgid "Click to cancel this window."
+#~ msgstr "Napsauta peruuttaaksesi tämä ikkuna."
+
+#~ msgid "Click to confirm your selection."
+#~ msgstr "Napsauta varmistaaksesi valintasi."
+
+#~ msgid "Column does not have a renderer."
+#~ msgstr "Sarakkeella ei ole piirtäjää."
+
+#~ msgid "Could not unlock mutex"
+#~ msgstr "Mutexin vapautus ei onnistu"
+
+#~ msgid "Failed to register OpenGL window class."
+#~ msgstr "OpenGL-ikkunaluokan rekisteröinti epäonnistui."
+
+#~ msgid "Fatal error: "
+#~ msgstr "Tuhoisa virhe: "
+
+#~ msgid "GB-2312"
+#~ msgstr "GB-2312"
+
+#~ msgid "Go forward to the next HTML page"
+#~ msgstr "Siirry eteenpäin seuraavalle HTML-sivulle"
+
+#~ msgid "Goto Page"
+#~ msgstr "Mene sivulle"
+
+#~ msgid "Help : %s"
+#~ msgstr "Ohje: %s"
+
+#~ msgid "I64"
+#~ msgstr "I64"
+
+#~ msgid "Internal error, illegal wxCustomTypeInfo"
+#~ msgstr "Sisäinen virhe, epäkelpo wxCustomTypeInfo"
+
+#, fuzzy
+#~ msgid "No image handler for type %ld defined."
+#~ msgstr "Kuvatyypin %d käsittelijää ei määritelty."
+
+#~ msgid "Owner not initialized."
+#~ msgstr "Omistajaa ei ole asetettu."
+
+#~ msgid "Passed item is invalid."
+#~ msgstr "Ohitettu kohta on epäkelpo."
+
+#~ msgid "Preparing help window..."
+#~ msgstr "Valmistellaan ohje-ikkunaa"
+
+#~ msgid "Program aborted."
+#~ msgstr "Ohjelma keskeytetty."
+
+#~ msgid "Resource files must have same version number!"
+#~ msgstr "Resurssitiedostoilla pitää olla sama versionumero!"
+
+#~ msgid "SHIFT-JIS"
+#~ msgstr "SHIFT-JIS"
+
+#~ msgid "Search!"
+#~ msgstr "Etsi"
+
+#~ msgid "Sorry, could not open this file for saving."
+#~ msgstr "Ei voi avata tiedostoa tallennettavaksi."
+
+#~ msgid "Sorry, could not save this file."
+#~ msgstr "Tätä tiedostoa ei voi tallentaa."
+
+#~ msgid "Sorry, print preview needs a printer to be installed."
+#~ msgstr "Tulostuksen esikatselu vaatii asennetun tulostimen."
+
+#~ msgid "Status: "
+#~ msgstr "Tila: "
+
+#~ msgid "TIFF library error."
+#~ msgstr "TIFF-kirjastovirhe."
+
+#~ msgid "TIFF library warning."
+#~ msgstr "TIFF-kirjastovaroitus."
+
+#~ msgid ""
+#~ "The file '%s' couldn't be opened.\n"
+#~ "It has been removed from the most recently used files list."
+#~ msgstr ""
+#~ "Tiedostoa ”%s” ei voitu avata.\n"
+#~ "Se on myös poistettu MRU-tiedostojen luettelosta"
+
+#~ msgid "The path '%s' contains too many ”..”!"
+#~ msgstr "Polku ”%s” sisältää liian monta ”..”!"
+
+#~ msgid "Trying to solve a NULL hostname: giving up"
+#~ msgstr "Tyhjää isäntänimeä yritettiin selvittää: luovutan"
+
+#~ msgid "Unknown style flag "
+#~ msgstr "Tuntemattoman tyylinen lippu"
+
+#~ msgid "Warning"
+#~ msgstr "Varoitus"
+
+#~ msgid "Windows 2000 (build %lu"
+#~ msgstr "Windows 2000 (käännös %lu"
+
+#~ msgid "XRC resource '%s' (class '%s') not found!"
+#~ msgstr "XRC resurssia ”%s” (luokka ”%s”) ei löydy!"
+
+#, fuzzy
+#~ msgid "XRC resource: Cannot create animation from '%s'."
+#~ msgstr "XRC resurssi: Ei voida luoda kuvaa ”%s”."
+
+#~ msgid "XRC resource: Cannot create bitmap from '%s'."
+#~ msgstr "XRC resurssi: Ei voida luoda kuvaa ”%s”."
+
+#, fuzzy
+#~ msgid ""
+#~ "XRC resource: Incorrect colour specification '%s' for attribute '%s'."
+#~ msgstr "XRC resurssi: Väärä värimääritelmä ”%s” ominaisuudelle ”%s”."
+
+#~ msgid "[EMPTY]"
+#~ msgstr "[TYHJÄ]"
+
+#~ msgid "catalog file for domain '%s' not found."
+#~ msgstr "luettelotiedostoa verkkoalueelle ”%s” ei löydy."
+
+#~ msgid "looking for catalog '%s' in path '%s'."
+#~ msgstr "etsitään luetteloa ”%s” polussa ”%s”."
+
+#~ msgid "wxSocket: invalid signature in ReadMsg."
+#~ msgstr "wxSocket: virheellinen allekirjoitus ReadMsg:ssä."
+
+#~ msgid "wxSocket: unknown event!."
+#~ msgstr "wxSocket: tuntematon tapahtuma!."
+
+#~ msgid "|<<"
+#~ msgstr "|<<"

--- a/po_wxstd/fr.po
+++ b/po_wxstd/fr.po
@@ -1,0 +1,9394 @@
+# Initial translation by Stephane Junique <pttlapinblanc@chez.com>
+# Updated by Nicolas Velin <nsv@fr.st>, TMTisFree (tmtisfree@free.fr)
+msgid ""
+msgstr ""
+"Project-Id-Version: wxWidgets 3.3\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-05-14 20:23+0200\n"
+"PO-Revision-Date: 2022-04-10 12:52+0200\n"
+"Last-Translator: Gérard DURAND <gerard-florence.durand@orange.fr>\n"
+"Language-Team: French <debian-l10n-french@lists.debian.org>\n"
+"Language: fr\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+"plural-forms: nplurals=2; plural=n > 1\n"
+"X-Generator: Poedit 3.0.1\n"
+
+#: ../include/wx/defs.h:2582
+msgid "All files (*.*)|*.*"
+msgstr "Tous les fichiers (*.*)|*.*"
+
+#: ../include/wx/defs.h:2585
+msgid "All files (*)|*"
+msgstr "Tous les fichiers (*)|*"
+
+#: ../include/wx/generic/progdlgg.h:85
+msgid "Elapsed time:"
+msgstr "Temps écoulé :"
+
+#: ../include/wx/generic/progdlgg.h:86
+msgid "Estimated time:"
+msgstr "Temps estimé :"
+
+#: ../include/wx/generic/progdlgg.h:87
+msgid "Remaining time:"
+msgstr "Temps restant :"
+
+#. TRANSLATORS: HTML printout default title.
+#: ../include/wx/html/htmprint.h:121 ../include/wx/prntbase.h:273
+#: ../include/wx/richtext/richtextprint.h:109 ../src/common/docview.cpp:2161
+msgid "Printout"
+msgstr "Impression"
+
+#. TRANSLATORS: HTML easy print default title.
+#: ../include/wx/html/htmprint.h:234 ../include/wx/richtext/richtextprint.h:163
+#: ../src/common/prntbase.cpp:522 ../src/html/htmprint.cpp:291
+msgid "Printing"
+msgstr "Impression"
+
+#: ../include/wx/msgdlg.h:277 ../src/common/stockitem.cpp:211
+msgid "Yes"
+msgstr "Oui"
+
+#: ../include/wx/msgdlg.h:278 ../src/common/stockitem.cpp:182
+msgid "No"
+msgstr "Non"
+
+#: ../include/wx/msgdlg.h:279 ../src/common/stockitem.cpp:183
+#: ../src/msw/msgdlg.cpp:430 ../src/msw/msgdlg.cpp:734
+#: ../src/richtext/richtextstyledlg.cpp:292
+msgid "OK"
+msgstr "Ok"
+
+#: ../include/wx/msgdlg.h:280 ../src/common/stockitem.cpp:150
+#: ../src/msw/msgdlg.cpp:430 ../src/msw/progdlg.cpp:884
+#: ../src/richtext/richtextstyledlg.cpp:295
+msgid "Cancel"
+msgstr "Annuler"
+
+#: ../include/wx/msgdlg.h:281 ../src/common/stockitem.cpp:168
+#: ../src/html/helpdlg.cpp:63 ../src/html/helpfrm.cpp:108
+#: ../src/osx/button_osx.cpp:38
+msgid "Help"
+msgstr "Aide"
+
+#: ../include/wx/msw/ole/oleutils.h:52
+msgid "Cannot initialize OLE"
+msgstr "Impossible d'initialiser l'OLE"
+
+#: ../include/wx/msw/private/fswatcher.h:48
+#, c-format
+msgid "Unable to close the handle for '%s'"
+msgstr "Impossible de fermer le gestionnaire pour « %s »"
+
+#: ../include/wx/msw/private/fswatcher.h:92
+#, c-format
+msgid "Failed to open directory \"%s\" for monitoring."
+msgstr "Échec de l'ouverture du répertoire « %s » pour surveillance."
+
+#: ../include/wx/msw/private/fswatcher.h:125
+msgid "Unable to close I/O completion port handle"
+msgstr "Impossible de fermer le gestionnaire de port de terminaison d'E/S"
+
+#: ../include/wx/msw/private/fswatcher.h:142
+msgid "Unable to associate handle with I/O completion port"
+msgstr ""
+"Impossible d'associer un gestionnaire avec un port de terminaison d'E/S"
+
+#: ../include/wx/msw/private/fswatcher.h:148
+msgid "Unexpectedly new I/O completion port was created"
+msgstr "Un nouveau port de terminaison d'E/S a été créé de manière inopinée"
+
+#: ../include/wx/msw/private/fswatcher.h:213
+msgid "Unable to post completion status"
+msgstr "Impossible d'envoyer l'état de terminaison"
+
+#: ../include/wx/msw/private/fswatcher.h:262
+msgid "Unable to dequeue completion packet"
+msgstr "Impossible d'extraire de la file d'attente le paquet de terminaison"
+
+#: ../include/wx/msw/private/fswatcher.h:273
+msgid "Unable to create I/O completion port"
+msgstr "Impossible de créer un port de terminaison d'E/S"
+
+#: ../include/wx/richmsgdlg.h:29
+msgid "&See details"
+msgstr "Voir les détail&s"
+
+#: ../include/wx/richmsgdlg.h:30
+msgid "&Hide details"
+msgstr "Cac&her les détails"
+
+#: ../include/wx/richtext/richtextbuffer.h:3864
+msgid "&Box"
+msgstr "&Boîte"
+
+#: ../include/wx/richtext/richtextbuffer.h:5008
+msgid "&Picture"
+msgstr "&Image"
+
+#: ../include/wx/richtext/richtextbuffer.h:5958
+msgid "&Cell"
+msgstr "&Cellule"
+
+#: ../include/wx/richtext/richtextbuffer.h:6067
+msgid "&Table"
+msgstr "&Table"
+
+#: ../include/wx/richtext/richtextimagedlg.h:37
+msgid "Object Properties"
+msgstr "Propriétés de l'Objet"
+
+#: ../include/wx/richtext/richtextsymboldlg.h:39
+msgid "Symbols"
+msgstr "Symboles"
+
+#: ../include/wx/unix/pipe.h:46
+msgid "Pipe creation failed"
+msgstr "Échec de la création du tube (pipe)"
+
+#: ../include/wx/unix/private/displayx11.h:65
+msgid "Failed to enumerate video modes"
+msgstr "Échec de l'énumération des modes vidéo"
+
+#: ../include/wx/unix/private/displayx11.h:89
+msgid "Failed to change video mode"
+msgstr "Échec du changement de mode vidéo"
+
+#: ../include/wx/unix/private/fswatcher_kqueue.h:57
+#, c-format
+msgid "Unable to open path '%s'"
+msgstr "Impossible d'ouvrir le chemin « %s »"
+
+#: ../include/wx/unix/private/fswatcher_kqueue.h:74
+#, c-format
+msgid "Unable to close path '%s'"
+msgstr "Impossible de fermer le chemin « %s »"
+
+#: ../include/wx/xtiprop.h:175
+msgid "SetProperty called w/o valid setter"
+msgstr "SetProperty appelé sans monteur valable"
+
+#: ../include/wx/xtiprop.h:184
+msgid "GetProperty called w/o valid getter"
+msgstr "GetProperty appelé sans récupérateur valable"
+
+#: ../include/wx/xtiprop.h:193
+msgid "AddToPropertyCollection called w/o valid adder"
+msgstr "AddToPropertyCollection appelé sans additionneur valable"
+
+#: ../include/wx/xtiprop.h:202
+msgid "GetPropertyCollection called w/o valid collection getter"
+msgstr "GetPropertyCollection appelé sans récupérateur de collection valable"
+
+#: ../include/wx/xtiprop.h:255
+msgid "AddToPropertyCollection called on a generic accessor"
+msgstr "AddToPropertyCollection appelé sur un assesseur générique"
+
+#: ../include/wx/xtiprop.h:262
+msgid "GetPropertyCollection called on a generic accessor"
+msgstr "GetPropertyCollection appelé sur un assesseur générique"
+
+#: ../src/aui/tabmdi.cpp:106 ../src/generic/mdig.cpp:94
+msgid "Cl&ose"
+msgstr "&Fermer"
+
+#: ../src/aui/tabmdi.cpp:107 ../src/generic/mdig.cpp:95
+msgid "Close All"
+msgstr "Fermer tout"
+
+#: ../src/aui/tabmdi.cpp:109 ../src/generic/mdig.cpp:97 ../src/msw/mdi.cpp:175
+#: ../src/qt/mdi.cpp:258
+msgid "&Next"
+msgstr "&Suivant"
+
+#: ../src/aui/tabmdi.cpp:110 ../src/generic/mdig.cpp:98 ../src/msw/mdi.cpp:176
+#: ../src/qt/mdi.cpp:259
+msgid "&Previous"
+msgstr "&Précédent"
+
+#: ../src/aui/tabmdi.cpp:332 ../src/aui/tabmdi.cpp:348
+#: ../src/aui/tabmdi.cpp:350 ../src/generic/mdig.cpp:291
+#: ../src/generic/mdig.cpp:307 ../src/generic/mdig.cpp:311
+#: ../src/msw/mdi.cpp:337 ../src/qt/mdi.cpp:462
+msgid "&Window"
+msgstr "&Fenêtre"
+
+#: ../src/common/accelcmn.cpp:47
+msgctxt "keyboard key"
+msgid "Delete"
+msgstr "Supprimer"
+
+#: ../src/common/accelcmn.cpp:48
+msgctxt "keyboard key"
+msgid "Del"
+msgstr "Suppr"
+
+#: ../src/common/accelcmn.cpp:49
+msgctxt "keyboard key"
+msgid "Back"
+msgstr "Retour"
+
+#: ../src/common/accelcmn.cpp:49
+msgctxt "keyboard key"
+msgid "Backspace"
+msgstr "Retour arrière"
+
+#: ../src/common/accelcmn.cpp:50
+msgctxt "keyboard key"
+msgid "Insert"
+msgstr "Insérer"
+
+#: ../src/common/accelcmn.cpp:51
+msgctxt "keyboard key"
+msgid "Ins"
+msgstr "Inser"
+
+#: ../src/common/accelcmn.cpp:52
+msgctxt "keyboard key"
+msgid "Enter"
+msgstr "Entrée"
+
+#: ../src/common/accelcmn.cpp:53
+msgctxt "keyboard key"
+msgid "Return"
+msgstr "Retour"
+
+#: ../src/common/accelcmn.cpp:54
+msgctxt "keyboard key"
+msgid "PageUp"
+msgstr "PageUp"
+
+#: ../src/common/accelcmn.cpp:54
+msgctxt "keyboard key"
+msgid "Page Up"
+msgstr "Page Préc"
+
+#: ../src/common/accelcmn.cpp:55
+msgctxt "keyboard key"
+msgid "PageDown"
+msgstr "PageDown"
+
+#: ../src/common/accelcmn.cpp:55
+msgctxt "keyboard key"
+msgid "Page Down"
+msgstr "Page Suiv"
+
+#: ../src/common/accelcmn.cpp:56
+msgctxt "keyboard key"
+msgid "PgUp"
+msgstr "PgPc"
+
+#: ../src/common/accelcmn.cpp:57
+msgctxt "keyboard key"
+msgid "PgDn"
+msgstr "PgSv"
+
+#: ../src/common/accelcmn.cpp:58
+msgctxt "keyboard key"
+msgid "Left"
+msgstr "Gauche"
+
+#: ../src/common/accelcmn.cpp:59
+msgctxt "keyboard key"
+msgid "Right"
+msgstr "Droite"
+
+#: ../src/common/accelcmn.cpp:60
+msgctxt "keyboard key"
+msgid "Up"
+msgstr "Haut"
+
+#: ../src/common/accelcmn.cpp:61
+msgctxt "keyboard key"
+msgid "Down"
+msgstr "Bas"
+
+#: ../src/common/accelcmn.cpp:62
+msgctxt "keyboard key"
+msgid "Home"
+msgstr "Dossier personnel"
+
+#: ../src/common/accelcmn.cpp:63
+msgctxt "keyboard key"
+msgid "End"
+msgstr "Fin"
+
+#: ../src/common/accelcmn.cpp:64
+msgctxt "keyboard key"
+msgid "Space"
+msgstr "Espace"
+
+#: ../src/common/accelcmn.cpp:65
+msgctxt "keyboard key"
+msgid "Tab"
+msgstr "Tab"
+
+#: ../src/common/accelcmn.cpp:66
+msgctxt "keyboard key"
+msgid "Esc"
+msgstr "Échapp"
+
+#: ../src/common/accelcmn.cpp:67
+msgctxt "keyboard key"
+msgid "Escape"
+msgstr "Echapp"
+
+#: ../src/common/accelcmn.cpp:68
+msgctxt "keyboard key"
+msgid "Cancel"
+msgstr "Annuler"
+
+#: ../src/common/accelcmn.cpp:69
+msgctxt "keyboard key"
+msgid "Clear"
+msgstr "Effacer"
+
+#: ../src/common/accelcmn.cpp:70
+msgctxt "keyboard key"
+msgid "Menu"
+msgstr "Menu"
+
+#: ../src/common/accelcmn.cpp:71
+msgctxt "keyboard key"
+msgid "Pause"
+msgstr "Pause"
+
+#: ../src/common/accelcmn.cpp:72
+msgctxt "keyboard key"
+msgid "Capital"
+msgstr "Majuscule"
+
+#: ../src/common/accelcmn.cpp:73
+msgctxt "keyboard key"
+msgid "Select"
+msgstr "Sélectioner"
+
+#: ../src/common/accelcmn.cpp:74
+msgctxt "keyboard key"
+msgid "Print"
+msgstr "Imprimer"
+
+#: ../src/common/accelcmn.cpp:75
+msgctxt "keyboard key"
+msgid "Execute"
+msgstr "Exécuter"
+
+#: ../src/common/accelcmn.cpp:76
+msgctxt "keyboard key"
+msgid "Snapshot"
+msgstr "Instantané"
+
+#: ../src/common/accelcmn.cpp:77
+msgctxt "keyboard key"
+msgid "Help"
+msgstr "Aide"
+
+#: ../src/common/accelcmn.cpp:78
+msgctxt "keyboard key"
+msgid "Add"
+msgstr "Ajouter"
+
+#: ../src/common/accelcmn.cpp:79
+msgctxt "keyboard key"
+msgid "Separator"
+msgstr "Séparateur"
+
+#: ../src/common/accelcmn.cpp:80
+msgctxt "keyboard key"
+msgid "Subtract"
+msgstr "Soustraire"
+
+#: ../src/common/accelcmn.cpp:81
+msgctxt "keyboard key"
+msgid "Decimal"
+msgstr "Décimale"
+
+#: ../src/common/accelcmn.cpp:82
+msgctxt "keyboard key"
+msgid "Multiply"
+msgstr "Multiplier"
+
+#: ../src/common/accelcmn.cpp:83
+msgctxt "keyboard key"
+msgid "Divide"
+msgstr "Diviser"
+
+#: ../src/common/accelcmn.cpp:84
+msgctxt "keyboard key"
+msgid "Num_lock"
+msgstr "Verr_num"
+
+#: ../src/common/accelcmn.cpp:84
+msgctxt "keyboard key"
+msgid "Num Lock"
+msgstr "Verr Num"
+
+#: ../src/common/accelcmn.cpp:85
+msgctxt "keyboard key"
+msgid "Scroll_lock"
+msgstr "Verr_défil"
+
+#: ../src/common/accelcmn.cpp:85
+msgctxt "keyboard key"
+msgid "Scroll Lock"
+msgstr "Verr Défil"
+
+#: ../src/common/accelcmn.cpp:86
+msgctxt "keyboard key"
+msgid "KP_Space"
+msgstr "KP_Space"
+
+#: ../src/common/accelcmn.cpp:86
+msgctxt "keyboard key"
+msgid "Num Space"
+msgstr "Num Espace"
+
+#: ../src/common/accelcmn.cpp:87
+msgctxt "keyboard key"
+msgid "KP_Tab"
+msgstr "KP_Tab"
+
+#: ../src/common/accelcmn.cpp:87
+msgctxt "keyboard key"
+msgid "Num Tab"
+msgstr "Num Tab"
+
+#: ../src/common/accelcmn.cpp:88
+msgctxt "keyboard key"
+msgid "KP_Enter"
+msgstr "KP_Enter"
+
+#: ../src/common/accelcmn.cpp:88
+msgctxt "keyboard key"
+msgid "Num Enter"
+msgstr "Num Entrée"
+
+#: ../src/common/accelcmn.cpp:89
+msgctxt "keyboard key"
+msgid "KP_Home"
+msgstr "KP_Home"
+
+#: ../src/common/accelcmn.cpp:89
+msgctxt "keyboard key"
+msgid "Num Home"
+msgstr "Num Début"
+
+#: ../src/common/accelcmn.cpp:90
+msgctxt "keyboard key"
+msgid "KP_Left"
+msgstr "KP_Left"
+
+#: ../src/common/accelcmn.cpp:90
+msgctxt "keyboard key"
+msgid "Num left"
+msgstr "Num Gauche"
+
+#: ../src/common/accelcmn.cpp:91
+msgctxt "keyboard key"
+msgid "KP_Up"
+msgstr "KP_Up"
+
+#: ../src/common/accelcmn.cpp:91
+msgctxt "keyboard key"
+msgid "Num Up"
+msgstr "Num Préc"
+
+#: ../src/common/accelcmn.cpp:92
+msgctxt "keyboard key"
+msgid "KP_Right"
+msgstr "KP_Right"
+
+#: ../src/common/accelcmn.cpp:92
+msgctxt "keyboard key"
+msgid "Num Right"
+msgstr "Num Droite"
+
+#: ../src/common/accelcmn.cpp:93
+msgctxt "keyboard key"
+msgid "KP_Down"
+msgstr "KP_Down"
+
+#: ../src/common/accelcmn.cpp:93
+msgctxt "keyboard key"
+msgid "Num Down"
+msgstr "Num Bas"
+
+#: ../src/common/accelcmn.cpp:94
+msgctxt "keyboard key"
+msgid "KP_PageUp"
+msgstr "KP_PageUp"
+
+#: ../src/common/accelcmn.cpp:94
+msgctxt "keyboard key"
+msgid "Num Page Up"
+msgstr "Num Page Préc"
+
+#: ../src/common/accelcmn.cpp:95
+msgctxt "keyboard key"
+msgid "KP_PageDown"
+msgstr "KP_PageDown"
+
+#: ../src/common/accelcmn.cpp:95
+msgctxt "keyboard key"
+msgid "Num Page Down"
+msgstr "Num Page Suiv"
+
+#: ../src/common/accelcmn.cpp:96
+msgctxt "keyboard key"
+msgid "KP_Prior"
+msgstr "KP_Prior"
+
+#: ../src/common/accelcmn.cpp:97
+msgctxt "keyboard key"
+msgid "KP_Next"
+msgstr "KP_Next"
+
+#: ../src/common/accelcmn.cpp:98
+msgctxt "keyboard key"
+msgid "KP_End"
+msgstr "KP_End"
+
+#: ../src/common/accelcmn.cpp:98
+msgctxt "keyboard key"
+msgid "Num End"
+msgstr "Num Fin"
+
+#: ../src/common/accelcmn.cpp:99
+msgctxt "keyboard key"
+msgid "KP_Begin"
+msgstr "KP_Begin"
+
+#: ../src/common/accelcmn.cpp:99
+msgctxt "keyboard key"
+msgid "Num Begin"
+msgstr "Num Début"
+
+#: ../src/common/accelcmn.cpp:100
+msgctxt "keyboard key"
+msgid "KP_Insert"
+msgstr "KP_Insert"
+
+#: ../src/common/accelcmn.cpp:100
+msgctxt "keyboard key"
+msgid "Num Insert"
+msgstr "Num Inser"
+
+#: ../src/common/accelcmn.cpp:101
+msgctxt "keyboard key"
+msgid "KP_Delete"
+msgstr "KP_Delete"
+
+#: ../src/common/accelcmn.cpp:101
+msgctxt "keyboard key"
+msgid "Num Delete"
+msgstr "Num Suppr"
+
+#: ../src/common/accelcmn.cpp:102
+msgctxt "keyboard key"
+msgid "KP_Equal"
+msgstr "KP_Equal"
+
+#: ../src/common/accelcmn.cpp:102
+msgctxt "keyboard key"
+msgid "Num ="
+msgstr "Num ="
+
+#: ../src/common/accelcmn.cpp:103
+msgctxt "keyboard key"
+msgid "KP_Multiply"
+msgstr "KP_Multiply"
+
+#: ../src/common/accelcmn.cpp:103
+msgctxt "keyboard key"
+msgid "Num *"
+msgstr "Num *"
+
+#: ../src/common/accelcmn.cpp:104
+msgctxt "keyboard key"
+msgid "KP_Add"
+msgstr "KP_Add"
+
+#: ../src/common/accelcmn.cpp:104
+msgctxt "keyboard key"
+msgid "Num +"
+msgstr "Num +"
+
+#: ../src/common/accelcmn.cpp:105
+msgctxt "keyboard key"
+msgid "KP_Separator"
+msgstr "KP_Separator"
+
+#: ../src/common/accelcmn.cpp:105
+msgctxt "keyboard key"
+msgid "Num ,"
+msgstr "Num ,"
+
+#: ../src/common/accelcmn.cpp:106
+msgctxt "keyboard key"
+msgid "KP_Subtract"
+msgstr "KP_Subtract"
+
+#: ../src/common/accelcmn.cpp:106
+msgctxt "keyboard key"
+msgid "Num -"
+msgstr "Num -"
+
+#: ../src/common/accelcmn.cpp:107
+msgctxt "keyboard key"
+msgid "KP_Decimal"
+msgstr "KP_Decimal"
+
+#: ../src/common/accelcmn.cpp:107
+msgctxt "keyboard key"
+msgid "Num ."
+msgstr "Num ."
+
+#: ../src/common/accelcmn.cpp:108
+msgctxt "keyboard key"
+msgid "KP_Divide"
+msgstr "KP_Divide"
+
+#: ../src/common/accelcmn.cpp:108
+msgctxt "keyboard key"
+msgid "Num /"
+msgstr "Num /"
+
+#: ../src/common/accelcmn.cpp:109
+msgctxt "keyboard key"
+msgid "Windows_Left"
+msgstr "Windows_Left"
+
+#: ../src/common/accelcmn.cpp:110
+msgctxt "keyboard key"
+msgid "Windows_Right"
+msgstr "Windows_Right"
+
+#: ../src/common/accelcmn.cpp:111
+msgctxt "keyboard key"
+msgid "Windows_Menu"
+msgstr "Windows_Menu"
+
+#: ../src/common/accelcmn.cpp:112
+msgctxt "keyboard key"
+msgid "Command"
+msgstr "Commande"
+
+#: ../src/common/accelcmn.cpp:186 ../src/common/accelcmn.cpp:359
+msgctxt "keyboard key"
+msgid "Ctrl"
+msgstr "Ctrl"
+
+#: ../src/common/accelcmn.cpp:188 ../src/common/accelcmn.cpp:363
+msgctxt "keyboard key"
+msgid "Alt"
+msgstr "Alt"
+
+#: ../src/common/accelcmn.cpp:190 ../src/common/accelcmn.cpp:361
+msgctxt "keyboard key"
+msgid "Shift"
+msgstr "Majuscule"
+
+#: ../src/common/accelcmn.cpp:196
+msgctxt "keyboard key"
+msgid "num "
+msgstr "num "
+
+#: ../src/common/accelcmn.cpp:260 ../src/common/accelcmn.cpp:382
+msgctxt "keyboard key"
+msgid "F"
+msgstr "F"
+
+#: ../src/common/accelcmn.cpp:277 ../src/common/accelcmn.cpp:385
+msgctxt "keyboard key"
+msgid "KP_F"
+msgstr "KP_F"
+
+#: ../src/common/accelcmn.cpp:280 ../src/common/accelcmn.cpp:388
+msgctxt "keyboard key"
+msgid "KP_"
+msgstr "KP_"
+
+#: ../src/common/accelcmn.cpp:283 ../src/common/accelcmn.cpp:391
+msgctxt "keyboard key"
+msgid "SPECIAL"
+msgstr "SPECIAL"
+
+#: ../src/common/accelcmn.cpp:373
+msgid "Ctrl"
+msgstr "Ctrl"
+
+#: ../src/common/appbase.cpp:786
+msgid "show this help message"
+msgstr "montrer ce message d'aide"
+
+#: ../src/common/appbase.cpp:796
+msgid "generate verbose log messages"
+msgstr "créer des messages de journalisation verbeux"
+
+#: ../src/common/appcmn.cpp:256
+msgid "specify the theme to use"
+msgstr "spécifier le thème à utiliser"
+
+#: ../src/common/appcmn.cpp:270
+msgid "specify display mode to use (e.g. 640x480-16)"
+msgstr "spécifier le mode d'affichage à utiliser (par ex. 640x480-16)"
+
+#: ../src/common/appcmn.cpp:292
+#, c-format
+msgid "Unsupported theme '%s'."
+msgstr "Thème « %s » non reconnu."
+
+#: ../src/common/appcmn.cpp:309
+#, c-format
+msgid "Invalid display mode specification '%s'."
+msgstr "Spécification du mode d'affichage « %s » non valable."
+
+#: ../src/common/cmdline.cpp:875
+#, c-format
+msgid "Option '%s' can't be negated"
+msgstr "L'option « %s » ne peut pas être inversée"
+
+#: ../src/common/cmdline.cpp:889
+#, c-format
+msgid "Unknown long option '%s'"
+msgstr "Option longue « %s » inconnue"
+
+#: ../src/common/cmdline.cpp:904 ../src/common/cmdline.cpp:926
+#, c-format
+msgid "Unknown option '%s'"
+msgstr "Option « %s » inconnue"
+
+#: ../src/common/cmdline.cpp:1004
+#, c-format
+msgid "Unexpected characters following option '%s'."
+msgstr "Caractères non attendus suivant l'option « %s »."
+
+#: ../src/common/cmdline.cpp:1039
+#, c-format
+msgid "Option '%s' requires a value."
+msgstr "L'option « %s » nécessite une valeur."
+
+#: ../src/common/cmdline.cpp:1058
+#, c-format
+msgid "Separator expected after the option '%s'."
+msgstr "Séparateur attendu après l'option « %s »."
+
+#: ../src/common/cmdline.cpp:1088 ../src/common/cmdline.cpp:1106
+#, c-format
+msgid "'%s' is not a correct numeric value for option '%s'."
+msgstr "« %s » n'est pas une valeur numérique correcte pour l'option « %s »."
+
+#: ../src/common/cmdline.cpp:1122
+#, c-format
+msgid "Option '%s': '%s' cannot be converted to a date."
+msgstr "Option « %s » : « %s » ne peut pas être converti en date."
+
+#: ../src/common/cmdline.cpp:1170
+#, c-format
+msgid "Unexpected parameter '%s'"
+msgstr "Paramètre « %s » inattendu"
+
+#. TRANSLATORS: Short name and long name for a command line option
+#: ../src/common/cmdline.cpp:1197
+#, c-format
+msgid "%s (or %s)"
+msgstr "%s (ou %s)"
+
+#: ../src/common/cmdline.cpp:1208
+#, c-format
+msgid "The value for the option '%s' must be specified."
+msgstr "La valeur de l'option « %s » doit être précisée."
+
+#: ../src/common/cmdline.cpp:1230
+#, c-format
+msgid "The required parameter '%s' was not specified."
+msgstr "Paramètre nécessaire « %s » non fourni."
+
+#: ../src/common/cmdline.cpp:1289
+#, c-format
+msgid "Usage: %s"
+msgstr "Utilisation : %s"
+
+#: ../src/common/cmdline.cpp:1498
+msgid "str"
+msgstr "str"
+
+#: ../src/common/cmdline.cpp:1502
+msgid "num"
+msgstr "num"
+
+#: ../src/common/cmdline.cpp:1506
+msgid "double"
+msgstr "double"
+
+#: ../src/common/cmdline.cpp:1510
+msgid "date"
+msgstr "date"
+
+#: ../src/common/cmdproc.cpp:250 ../src/common/cmdproc.cpp:276
+#: ../src/common/cmdproc.cpp:296
+msgid "Unnamed command"
+msgstr "Commande sans nom"
+
+#: ../src/common/cmdproc.cpp:253
+msgid "&Undo "
+msgstr "&Annuler "
+
+#: ../src/common/cmdproc.cpp:255
+msgid "Can't &Undo "
+msgstr "Impossible d'&annuler "
+
+#: ../src/common/cmdproc.cpp:259 ../src/common/stockitem.cpp:208
+#: ../src/msw/textctrl.cpp:2880 ../src/osx/textctrl_osx.cpp:649
+#: ../src/richtext/richtextctrl.cpp:327
+msgid "&Undo"
+msgstr "&Annuler"
+
+#: ../src/common/cmdproc.cpp:277 ../src/common/cmdproc.cpp:297
+msgid "&Redo "
+msgstr "&Refaire "
+
+#: ../src/common/cmdproc.cpp:281 ../src/common/cmdproc.cpp:288
+#: ../src/common/stockitem.cpp:190 ../src/msw/textctrl.cpp:2881
+#: ../src/osx/textctrl_osx.cpp:650 ../src/richtext/richtextctrl.cpp:328
+msgid "&Redo"
+msgstr "&Refaire"
+
+#: ../src/common/colourcmn.cpp:41
+#, c-format
+msgid "String To Colour : Incorrect colour specification : %s"
+msgstr ""
+"Conversion de chaîne en couleur : spécification non valable de la couleur : "
+"%s"
+
+#: ../src/common/config.cpp:259
+#, c-format
+msgid "Invalid value %ld for a boolean key \"%s\" in config file."
+msgstr ""
+"Valeur %ld incorrecte pour une clé booléenne « %s » dans le fichier de "
+"configuration."
+
+#: ../src/common/config.cpp:526
+#, c-format
+msgid ""
+"Environment variables expansion failed: missing '%c' at position %u in '%s'."
+msgstr ""
+"Échec de l'expansion des variables d'environnement : « %c » manquant à la "
+"position %u dans « %s »."
+
+#: ../src/common/config.cpp:576 ../src/msw/regconf.cpp:272
+#, c-format
+msgid "'%s' has extra '..', ignored."
+msgstr "« %s » a trop de « .. » : ils sont ignorés."
+
+#. TRANSLATORS: Checkbox state name
+#: ../src/common/datavcmn.cpp:2166 ../src/generic/datavgen.cpp:1430
+msgid "checked"
+msgstr "coché"
+
+#. TRANSLATORS: Checkbox state name
+#: ../src/common/datavcmn.cpp:2170 ../src/generic/datavgen.cpp:1432
+msgid "unchecked"
+msgstr "décoché"
+
+#. TRANSLATORS: Checkbox state name
+#: ../src/common/datavcmn.cpp:2174
+msgid "undetermined"
+msgstr "indéterminé"
+
+#: ../src/common/datetimefmt.cpp:1875
+msgid "today"
+msgstr "aujourd'hui"
+
+#: ../src/common/datetimefmt.cpp:1876
+msgid "yesterday"
+msgstr "hier"
+
+#: ../src/common/datetimefmt.cpp:1877
+msgid "tomorrow"
+msgstr "demain"
+
+#: ../src/common/datetimefmt.cpp:2071
+msgid "first"
+msgstr "premier"
+
+#: ../src/common/datetimefmt.cpp:2072
+msgid "second"
+msgstr "deuxième"
+
+#: ../src/common/datetimefmt.cpp:2073
+msgid "third"
+msgstr "troisième"
+
+#: ../src/common/datetimefmt.cpp:2074
+msgid "fourth"
+msgstr "quatrième"
+
+#: ../src/common/datetimefmt.cpp:2075
+msgid "fifth"
+msgstr "cinquième"
+
+#: ../src/common/datetimefmt.cpp:2076
+msgid "sixth"
+msgstr "sixième"
+
+#: ../src/common/datetimefmt.cpp:2077
+msgid "seventh"
+msgstr "septième"
+
+#: ../src/common/datetimefmt.cpp:2078
+msgid "eighth"
+msgstr "huitième"
+
+#: ../src/common/datetimefmt.cpp:2079
+msgid "ninth"
+msgstr "neuvième"
+
+#: ../src/common/datetimefmt.cpp:2080
+msgid "tenth"
+msgstr "dixième"
+
+#: ../src/common/datetimefmt.cpp:2081
+msgid "eleventh"
+msgstr "onzième"
+
+#: ../src/common/datetimefmt.cpp:2082
+msgid "twelfth"
+msgstr "douzième"
+
+#: ../src/common/datetimefmt.cpp:2083
+msgid "thirteenth"
+msgstr "treizième"
+
+#: ../src/common/datetimefmt.cpp:2084
+msgid "fourteenth"
+msgstr "quatorzième"
+
+#: ../src/common/datetimefmt.cpp:2085
+msgid "fifteenth"
+msgstr "quinzième"
+
+#: ../src/common/datetimefmt.cpp:2086
+msgid "sixteenth"
+msgstr "seizième"
+
+#: ../src/common/datetimefmt.cpp:2087
+msgid "seventeenth"
+msgstr "dix-septième"
+
+#: ../src/common/datetimefmt.cpp:2088
+msgid "eighteenth"
+msgstr "dix-huitième"
+
+#: ../src/common/datetimefmt.cpp:2089
+msgid "nineteenth"
+msgstr "dix-neuvième"
+
+#: ../src/common/datetimefmt.cpp:2090
+msgid "twentieth"
+msgstr "vingtième"
+
+#: ../src/common/datetimefmt.cpp:2248
+msgid "noon"
+msgstr "midi"
+
+#: ../src/common/datetimefmt.cpp:2249
+msgid "midnight"
+msgstr "minuit"
+
+#: ../src/common/debugrpt.cpp:209
+#, c-format
+msgid "Failed to create directory \"%s\""
+msgstr "Échec de la création du répertoire « %s »"
+
+#: ../src/common/debugrpt.cpp:210
+msgid "Debug report couldn't be created."
+msgstr "Échec de la création du rapport de débogage."
+
+#: ../src/common/debugrpt.cpp:227
+#, c-format
+msgid "Failed to remove debug report file \"%s\""
+msgstr "Échec de la suppression du fichier de rapport de débogage « %s »"
+
+#: ../src/common/debugrpt.cpp:239
+#, c-format
+msgid "Failed to clean up debug report directory \"%s\""
+msgstr "Échec du nettoyage du répertoire « %s » des rapports de débogage"
+
+#: ../src/common/debugrpt.cpp:514
+msgid "process context description"
+msgstr "description du contexte du processus"
+
+#: ../src/common/debugrpt.cpp:538
+msgid "dump of the process state (binary)"
+msgstr "décharger l'état du processus (binaire)"
+
+#: ../src/common/debugrpt.cpp:553
+msgid "Debug report generation has failed."
+msgstr "Échec de la génération du rapport de débogage."
+
+#: ../src/common/debugrpt.cpp:560
+#, c-format
+msgid ""
+"Processing debug report has failed, leaving the files in \"%s\" directory."
+msgstr ""
+"Échec du traitement du rapport de débogage, les fichiers sont maintenus dans "
+"le répertoire « %s »."
+
+#: ../src/common/debugrpt.cpp:573
+msgid "A debug report has been generated. It can be found in"
+msgstr "Un rapport de débogage a été généré. Il peut être trouvé dans"
+
+#: ../src/common/debugrpt.cpp:576
+msgid "And includes the following files:\n"
+msgstr "Et inclut les fichiers suivants :\n"
+
+#: ../src/common/debugrpt.cpp:586
+msgid ""
+"\n"
+"Please send this report to the program maintainer, thank you!\n"
+msgstr ""
+"\n"
+"Merci d'envoyer ce rapport au responsable du programme !\n"
+
+#: ../src/common/debugrpt.cpp:729
+msgid "Failed to execute curl, please install it in PATH."
+msgstr "Échec de l'exécution de curl, veuillez l'installer dans le PATH."
+
+#: ../src/common/debugrpt.cpp:742
+#, c-format
+msgid "Failed to upload the debug report (error code %d)."
+msgstr "Échec de l'envoi du rapport de bogue (code d'erreur %d)."
+
+#: ../src/common/docview.cpp:366
+msgid "Save As"
+msgstr "Enregistrer Sous"
+
+#: ../src/common/docview.cpp:457
+msgid "Discard changes and reload the last saved version?"
+msgstr ""
+"Ignorer les modifications et recharger la dernière version enregistrée ?"
+
+#: ../src/common/docview.cpp:488
+msgid "unnamed"
+msgstr "sans nom"
+
+#: ../src/common/docview.cpp:513
+#, c-format
+msgid "Do you want to save changes to %s?"
+msgstr "Faut-il enregistrer les modifications vers %s ?"
+
+#: ../src/common/docview.cpp:521 ../src/common/docview.cpp:560
+#: ../src/common/stockitem.cpp:195
+msgid "&Save"
+msgstr "&Enregistrer"
+
+#: ../src/common/docview.cpp:522 ../src/common/docview.cpp:560
+msgid "&Discard changes"
+msgstr "&Ne pas enregistrer"
+
+#: ../src/common/docview.cpp:523
+msgid "Do&n't close"
+msgstr "Ne p&as fermer"
+
+#: ../src/common/docview.cpp:553
+#, c-format
+msgid "Do you want to save changes to %s before closing it?"
+msgstr "Voulez-vous enregistrer les modifications vers %s ?"
+
+#: ../src/common/docview.cpp:559
+msgid "The document must be closed."
+msgstr "Le document doit être fermé."
+
+#: ../src/common/docview.cpp:571
+#, c-format
+msgid "Saving %s failed, would you like to retry?"
+msgstr "L'enregistrement de %s a échoué, voulez-vous réessayer ?"
+
+#: ../src/common/docview.cpp:577
+msgid "Retry"
+msgstr "Réessayer"
+
+#: ../src/common/docview.cpp:577
+msgid "Discard changes"
+msgstr "Ne pas enregistrer"
+
+#: ../src/common/docview.cpp:679
+#, c-format
+msgid "File \"%s\" could not be opened for writing."
+msgstr "Le fichier « %s » n'a pas pu être ouvert en écriture."
+
+#: ../src/common/docview.cpp:685
+#, c-format
+msgid "Failed to save document to the file \"%s\"."
+msgstr "Échec de l'enregistrement du document dans le fichier « %s »."
+
+#: ../src/common/docview.cpp:702
+#, c-format
+msgid "File \"%s\" could not be opened for reading."
+msgstr "Le fichier « %s » n'a pas pu être ouvert en lecture."
+
+#: ../src/common/docview.cpp:714
+#, c-format
+msgid "Failed to read document from the file \"%s\"."
+msgstr "Échec de la lecture du document depuis le fichier « %s »."
+
+#: ../src/common/docview.cpp:1236
+#, c-format
+msgid ""
+"The file '%s' doesn't exist and couldn't be opened.\n"
+"It has been removed from the most recently used files list."
+msgstr ""
+"Le fichier « %s » n'existe pas et n'a pas pu être ouvert.\n"
+"Il a été retiré de la liste des fichiers récemment utilisés."
+
+#: ../src/common/docview.cpp:1296
+msgid "Print preview creation failed."
+msgstr "Échec de la création de l'aperçu avant impression."
+
+#: ../src/common/docview.cpp:1302
+msgid "Print Preview"
+msgstr "Aperçu avant impression"
+
+#: ../src/common/docview.cpp:1517
+#, c-format
+msgid "The format of file '%s' couldn't be determined."
+msgstr "Le format du fichier « %s » n'a pas pu être déterminé."
+
+#: ../src/common/docview.cpp:1643
+#, c-format
+msgid "unnamed%d"
+msgstr "sans nom %d"
+
+#: ../src/common/docview.cpp:1660
+msgid " - "
+msgstr " - "
+
+#: ../src/common/docview.cpp:1791 ../src/common/docview.cpp:1844
+msgid "Open File"
+msgstr "Ouvrir un Fichier"
+
+#: ../src/common/docview.cpp:1807
+msgid "File error"
+msgstr "Erreur fichier"
+
+#: ../src/common/docview.cpp:1809
+msgid "Sorry, could not open this file."
+msgstr "Impossible d'ouvrir ce fichier."
+
+#: ../src/common/docview.cpp:1843
+msgid "Sorry, the format for this file is unknown."
+msgstr "Format de fichier inconnu."
+
+#: ../src/common/docview.cpp:1924
+msgid "Select a document template"
+msgstr "Sélectionner un modèle de document"
+
+#: ../src/common/docview.cpp:1925
+msgid "Templates"
+msgstr "Modèles"
+
+#: ../src/common/docview.cpp:1998
+msgid "Select a document view"
+msgstr "Sélectionner une vue du document"
+
+#: ../src/common/docview.cpp:1999
+msgid "Views"
+msgstr "Vues"
+
+#: ../src/common/dynlib.cpp:81
+#, c-format
+msgid "Failed to load shared library '%s'"
+msgstr "Échec du chargement de la bibliothèque partagée « %s »"
+
+#: ../src/common/dynlib.cpp:105
+#, c-format
+msgid "Couldn't find symbol '%s' in a dynamic library"
+msgstr "Impossible de trouver le symbole « %s » dans la bibliothèque dynamique"
+
+#: ../src/common/ffile.cpp:56 ../src/common/file.cpp:215
+#, c-format
+msgid "can't open file '%s'"
+msgstr "impossible d'ouvrir le fichier « %s »"
+
+#: ../src/common/ffile.cpp:72
+#, c-format
+msgid "can't close file '%s'"
+msgstr "impossible de fermer le fichier « %s »"
+
+#: ../src/common/ffile.cpp:106 ../src/common/ffile.cpp:131
+#, c-format
+msgid "Read error on file '%s'"
+msgstr "Erreur de lecture dans le fichier « %s »"
+
+#: ../src/common/ffile.cpp:148
+#, c-format
+msgid "Write error on file '%s'"
+msgstr "Erreur d'écriture dans le fichier « %s »"
+
+#: ../src/common/ffile.cpp:182
+#, c-format
+msgid "failed to flush the file '%s'"
+msgstr "échec de la mise à jour du fichier « %s »"
+
+#: ../src/common/ffile.cpp:222
+#, c-format
+msgid "Seek error on file '%s' (large files not supported by stdio)"
+msgstr ""
+"Erreur de recherche dans le fichier « %s » (les fichiers importants ne sont "
+"pas gérés par stdio)"
+
+#: ../src/common/ffile.cpp:232
+#, c-format
+msgid "Seek error on file '%s'"
+msgstr "Erreur de recherche dans le fichier « %s »"
+
+#: ../src/common/ffile.cpp:248
+#, c-format
+msgid "Can't find current position in file '%s'"
+msgstr "Impossible de trouver la position courante dans le fichier « %s »"
+
+#: ../src/common/ffile.cpp:349 ../src/common/file.cpp:569
+msgid "Failed to set temporary file permissions"
+msgstr "Échec de la configuration des permissions du fichier temporaire"
+
+#: ../src/common/ffile.cpp:371
+#, c-format
+msgid "can't remove file '%s'"
+msgstr "impossible de supprimer le fichier « %s »"
+
+#: ../src/common/ffile.cpp:376 ../src/common/file.cpp:591
+#, c-format
+msgid "can't commit changes to file '%s'"
+msgstr "impossible d'appliquer les changements au fichier « %s »"
+
+#: ../src/common/ffile.cpp:388 ../src/common/file.cpp:603
+#, c-format
+msgid "can't remove temporary file '%s'"
+msgstr "impossible de supprimer le fichier temporaire « %s »"
+
+#: ../src/common/file.cpp:162
+#, c-format
+msgid "can't create file '%s'"
+msgstr "impossible de créer le fichier « %s »"
+
+#: ../src/common/file.cpp:229
+#, c-format
+msgid "can't close file descriptor %d"
+msgstr "impossible de fermer le descripteur de fichier %d"
+
+#: ../src/common/file.cpp:332
+#, c-format
+msgid "can't read from file descriptor %d"
+msgstr "impossible de lire le descripteur de fichier %d"
+
+#: ../src/common/file.cpp:351
+#, c-format
+msgid "can't write to file descriptor %d"
+msgstr "impossible d'écrire dans le descripteur de fichier %d"
+
+#: ../src/common/file.cpp:390
+#, c-format
+msgid "can't flush file descriptor %d"
+msgstr ""
+"impossible de forcer l'écriture sur disque du descripteur de fichier %d"
+
+#: ../src/common/file.cpp:432
+#, c-format
+msgid "can't seek on file descriptor %d"
+msgstr "recherche impossible sur le descripteur de fichier %d"
+
+#: ../src/common/file.cpp:446
+#, c-format
+msgid "can't get seek position on file descriptor %d"
+msgstr ""
+"impossible de trouver la position de recherche sur le descripteur de fichier "
+"%d"
+
+#: ../src/common/file.cpp:475
+#, c-format
+msgid "can't find length of file on file descriptor %d"
+msgstr ""
+"impossible de trouver la taille du fichier dans le descripteur de fichier %d"
+
+#: ../src/common/file.cpp:505
+#, c-format
+msgid "can't determine if the end of file is reached on descriptor %d"
+msgstr ""
+"impossible de déterminer si la fin du fichier est atteinte dans le "
+"descripteur %d"
+
+#: ../src/common/fileconf.cpp:352
+#, c-format
+msgid ""
+" and additionally, the existing configuration file was renamed to \"%s\" and "
+"couldn't be renamed back, please rename it to its original path \"%s\""
+msgstr ""
+" et de plus, le fichier de configuration existant a été renommé en « %s » "
+"et son nom n'a pas pu être rétablie, veuillez le renommer vers son chemin "
+"d'origine « %s »"
+
+#: ../src/common/fileconf.cpp:389
+msgid " due to the following error:\n"
+msgstr " à cause de l'erreur suivante:\n"
+
+#: ../src/common/fileconf.cpp:412
+msgid "failed to rename the existing file"
+msgstr "échec de la tentative de renommer le fichier existant"
+
+#: ../src/common/fileconf.cpp:421
+msgid "failed to create the new file directory"
+msgstr "échec de la création du répertoire du nouveau fichier"
+
+#: ../src/common/fileconf.cpp:428
+msgid "failed to move the file to the new location"
+msgstr "échec du déplacement du fichier vers le nouvel emplacement"
+
+#: ../src/common/fileconf.cpp:462
+#, c-format
+msgid "can't open global configuration file '%s'."
+msgstr "impossible d'ouvrir le fichier de configuration global « %s »."
+
+#: ../src/common/fileconf.cpp:478
+#, c-format
+msgid "can't open user configuration file '%s'."
+msgstr "impossible d'ouvrir le fichier de configuration utilisateur « %s »."
+
+#: ../src/common/fileconf.cpp:483
+#, c-format
+msgid "Changes won't be saved to avoid overwriting the existing file \"%s\""
+msgstr ""
+"Les modifications ne seront pas sauvegardées afin d'éviter l'écrasement du "
+"fichier existant « %s »"
+
+#: ../src/common/fileconf.cpp:583
+msgid "Error reading config options."
+msgstr "Erreur lors de la lecture des options de configuration."
+
+#: ../src/common/fileconf.cpp:593
+msgid "Failed to read config options."
+msgstr "Échec de la lecture des options de configuration."
+
+#: ../src/common/fileconf.cpp:700
+#, c-format
+msgid "file '%s': unexpected character %c at line %zu."
+msgstr "fichier '%s' : caractère %c inattendu à la ligne %zu."
+
+#: ../src/common/fileconf.cpp:736
+#, c-format
+msgid "file '%s', line %zu: '%s' ignored after group header."
+msgstr ""
+"fichier « %s », ligne %zu : « %s » est ignoré après l'en-tête de groupe."
+
+#: ../src/common/fileconf.cpp:765
+#, c-format
+msgid "file '%s', line %zu: '=' expected."
+msgstr "fichier « %s », ligne %zu : symbole « = » attendu."
+
+#: ../src/common/fileconf.cpp:778
+#, c-format
+msgid "file '%s', line %zu: value for immutable key '%s' ignored."
+msgstr ""
+"fichier « %s », ligne %zu : valeur pour la touche non configurable « %s » "
+"ignorée."
+
+#: ../src/common/fileconf.cpp:788
+#, c-format
+msgid "file '%s', line %zu: key '%s' was first found at line %d."
+msgstr ""
+"fichier « %s », ligne %zu : première occurrence de la clé %s à la ligne %d."
+
+#: ../src/common/fileconf.cpp:1091
+#, c-format
+msgid "Config entry name cannot start with '%c'."
+msgstr "Le nom d'entrée de configuration ne peut pas commencer par « %c »."
+
+#: ../src/common/fileconf.cpp:1146
+msgid "Failed to create configuration file directory."
+msgstr "Échec de la création du répertoire pour le fichier de configuration."
+
+#: ../src/common/fileconf.cpp:1158
+msgid "can't open user configuration file."
+msgstr "impossible d'ouvrir le fichier de configuration utilisateur."
+
+#: ../src/common/fileconf.cpp:1172
+msgid "can't write user configuration file."
+msgstr "impossible d'écrire le fichier de configuration utilisateur."
+
+#: ../src/common/fileconf.cpp:1178
+msgid "Failed to update user configuration file."
+msgstr "Échec de la mise à jour du fichier de configuration utilisateur."
+
+#: ../src/common/fileconf.cpp:1201
+msgid "Error saving user configuration data."
+msgstr ""
+"Erreur lors de l'enregistrement des données de configuration de "
+"l'utilisateur."
+
+#: ../src/common/fileconf.cpp:1313
+#, c-format
+msgid "can't delete user configuration file '%s'"
+msgstr "impossible d'effacer le fichier de configuration utilisateur « %s »"
+
+#: ../src/common/fileconf.cpp:2007
+#, c-format
+msgid "entry '%s' appears more than once in group '%s'"
+msgstr "l'entrée « %s » apparaît plus d'une fois dans le groupe « %s »"
+
+#: ../src/common/fileconf.cpp:2021
+#, c-format
+msgid "attempt to change immutable key '%s' ignored."
+msgstr "tentative de modifier la touche non configurable « %s » ignorée."
+
+#: ../src/common/fileconf.cpp:2118
+#, c-format
+msgid "trailing backslash ignored in '%s'"
+msgstr "anti-slash de fin ignoré dans '%s'"
+
+#: ../src/common/fileconf.cpp:2153
+#, c-format
+msgid "unexpected \" at position %d in '%s'."
+msgstr "symbole \" inattendu à la position %d dans « %s »."
+
+#: ../src/common/filefn.cpp:474
+#, c-format
+msgid "Failed to copy the file '%s' to '%s'"
+msgstr "Échec de la copie du fichier « %s » vers « %s »"
+
+#: ../src/common/filefn.cpp:487
+#, c-format
+msgid "Impossible to get permissions for file '%s'"
+msgstr "Impossible d'obtenir les permissions du fichier « %s »"
+
+#: ../src/common/filefn.cpp:501
+#, c-format
+msgid "Impossible to overwrite the file '%s'"
+msgstr "Impossible d'écraser le fichier « %s »"
+
+#: ../src/common/filefn.cpp:508
+#, c-format
+msgid "Error copying the file '%s' to '%s'."
+msgstr "Erreur à la copie du fichier '%s' vers '%s'."
+
+#: ../src/common/filefn.cpp:556
+#, c-format
+msgid "Impossible to set permissions for the file '%s'"
+msgstr "Impossible de configurer les permissions du fichier « %s »"
+
+#: ../src/common/filefn.cpp:606
+#, c-format
+msgid ""
+"Failed to rename the file '%s' to '%s' because the destination file already "
+"exists."
+msgstr ""
+"Erreur lors du changement de nom de « %s » en « %s » : il existe déjà un "
+"fichier avec le nom de destination."
+
+#: ../src/common/filefn.cpp:623
+#, c-format
+msgid "File '%s' couldn't be renamed '%s'"
+msgstr "Le fichier « %s » n'a pas pu être renommé en « %s »"
+
+#: ../src/common/filefn.cpp:639
+#, c-format
+msgid "File '%s' couldn't be removed"
+msgstr "Le fichier « %s » n'a pas pu être supprimé"
+
+#: ../src/common/filefn.cpp:666
+#, c-format
+msgid "Directory '%s' couldn't be created"
+msgstr "Le dossier « %s » n'a pas pu être créé"
+
+#: ../src/common/filefn.cpp:680
+#, c-format
+msgid "Directory '%s' couldn't be deleted"
+msgstr "Le dossier « %s » n'a pas pu être supprimé"
+
+#: ../src/common/filefn.cpp:714
+#, c-format
+msgid "Cannot enumerate files '%s'"
+msgstr "Impossible d'énumérer les fichiers « %s »"
+
+#: ../src/common/filefn.cpp:798
+msgid "Failed to get the working directory"
+msgstr "Échec de l'obtention du répertoire courant"
+
+#: ../src/common/filefn.cpp:843
+msgid "Could not set current working directory"
+msgstr "Impossible de définir le répertoire de travail courant"
+
+#: ../src/common/filefn.cpp:974
+#, c-format
+msgid "Files (%s)"
+msgstr "Fichiers (%s)"
+
+#: ../src/common/filename.cpp:182
+#, c-format
+msgid "Failed to open '%s' for reading"
+msgstr "Échec de l'ouverture de « %s » en lecture"
+
+#: ../src/common/filename.cpp:187
+#, c-format
+msgid "Failed to open '%s' for writing"
+msgstr "Échec de l'ouverture de « %s » en écriture"
+
+#: ../src/common/filename.cpp:199
+msgid "Failed to close file handle"
+msgstr "Échec de la fermeture du gestionnaire de fichier"
+
+#: ../src/common/filename.cpp:1046
+msgid "Failed to create a temporary file name"
+msgstr "Échec de la création d'un nom de fichier temporaire"
+
+#: ../src/common/filename.cpp:1081
+msgid "Failed to open temporary file."
+msgstr "Échec de l'ouverture d'un fichier temporaire."
+
+#: ../src/common/filename.cpp:2862
+#, c-format
+msgid "Failed to modify file times for '%s'"
+msgstr "Échec de la modification de la date du fichier « %s »"
+
+#: ../src/common/filename.cpp:2877
+#, c-format
+msgid "Failed to touch the file '%s'"
+msgstr "Échec de la mise à jour de la date du fichier « %s »"
+
+#: ../src/common/filename.cpp:2958
+#, c-format
+msgid "Failed to retrieve file times for '%s'"
+msgstr "Échec de la récupération de la date du fichier « %s »"
+
+#: ../src/common/filepickercmn.cpp:39 ../src/common/filepickercmn.cpp:40
+msgid "Browse"
+msgstr "Parcourir"
+
+#: ../src/common/fldlgcmn.cpp:792 ../src/generic/filectrlg.cpp:1185
+#, c-format
+msgid "All files (%s)|%s"
+msgstr "Tous les fichiers (%s)|%s"
+
+#. TRANSLATORS: %s are a file extension used to build a file wildcard string
+#: ../src/common/fldlgcmn.cpp:810
+#, c-format
+msgid "%s files (%s)|%s"
+msgstr "%s fichiers (%s)|%s"
+
+#: ../src/common/fldlgcmn.cpp:1072
+#, c-format
+msgid "Load %s file"
+msgstr "Charger le fichier %s"
+
+#: ../src/common/fldlgcmn.cpp:1074
+#, c-format
+msgid "Save %s file"
+msgstr "Enregistrer le fichier %s"
+
+#: ../src/common/fmapbase.cpp:144
+msgid "Western European (ISO-8859-1)"
+msgstr "Europe de l'Ouest (ISO-8859-1)"
+
+#: ../src/common/fmapbase.cpp:145
+msgid "Central European (ISO-8859-2)"
+msgstr "Europe centrale (ISO-8859-2)"
+
+#: ../src/common/fmapbase.cpp:146
+msgid "Esperanto (ISO-8859-3)"
+msgstr "Espéranto (ISO-8859-3)"
+
+#: ../src/common/fmapbase.cpp:147
+msgid "Baltic (old) (ISO-8859-4)"
+msgstr "Balte (ancien) (ISO-8859-4)"
+
+#: ../src/common/fmapbase.cpp:148
+msgid "Cyrillic (ISO-8859-5)"
+msgstr "Cyrillique (ISO-8859-5)"
+
+#: ../src/common/fmapbase.cpp:149
+msgid "Arabic (ISO-8859-6)"
+msgstr "Arabe (ISO-8859-6)"
+
+#: ../src/common/fmapbase.cpp:150
+msgid "Greek (ISO-8859-7)"
+msgstr "Grec (ISO-8859-7)"
+
+#: ../src/common/fmapbase.cpp:151
+msgid "Hebrew (ISO-8859-8)"
+msgstr "Hébreu (ISO-8859-8)"
+
+#: ../src/common/fmapbase.cpp:152
+msgid "Turkish (ISO-8859-9)"
+msgstr "Turc (ISO-8859-9)"
+
+#: ../src/common/fmapbase.cpp:153
+msgid "Nordic (ISO-8859-10)"
+msgstr "Nordique (ISO-8859-10)"
+
+#: ../src/common/fmapbase.cpp:154
+msgid "Thai (ISO-8859-11)"
+msgstr "Thaï (ISO-8859-11)"
+
+#: ../src/common/fmapbase.cpp:155
+msgid "Indian (ISO-8859-12)"
+msgstr "Indien (ISO-8859-12)"
+
+#: ../src/common/fmapbase.cpp:156
+msgid "Baltic (ISO-8859-13)"
+msgstr "Balte (ISO-8859-13)"
+
+#: ../src/common/fmapbase.cpp:157
+msgid "Celtic (ISO-8859-14)"
+msgstr "Celtique (ISO-8859-14)"
+
+#: ../src/common/fmapbase.cpp:158
+msgid "Western European with Euro (ISO-8859-15)"
+msgstr "Europe de l'Ouest avec l'Euro (ISO-8859-15)"
+
+#: ../src/common/fmapbase.cpp:159
+msgid "KOI8-R"
+msgstr "KOI8-R"
+
+#: ../src/common/fmapbase.cpp:160
+msgid "KOI8-U"
+msgstr "KOI8-U"
+
+#: ../src/common/fmapbase.cpp:161
+msgid "Windows/DOS OEM Cyrillic (CP 866)"
+msgstr "Cyrillique OEM Windows/DOS (CP 866)"
+
+#: ../src/common/fmapbase.cpp:162
+msgid "Windows Thai (CP 874)"
+msgstr "Windows Thai (CP 874)"
+
+#: ../src/common/fmapbase.cpp:163
+msgid "Windows Japanese (CP 932) or Shift-JIS"
+msgstr "Japonais Windows (CP 932) ou Shift-JIS"
+
+#: ../src/common/fmapbase.cpp:164
+msgid "Windows Chinese Simplified (CP 936) or GB-2312"
+msgstr "Chinois Simplifié Windows (CP 936) ou GB-2312"
+
+#: ../src/common/fmapbase.cpp:165
+msgid "Windows Korean (CP 949)"
+msgstr "Coréen limité à Windows (CP 949)"
+
+#: ../src/common/fmapbase.cpp:166
+msgid "Windows Chinese Traditional (CP 950) or Big-5"
+msgstr "Chinois Traditionnel Windows (CP 950) ou Big-5"
+
+#: ../src/common/fmapbase.cpp:167
+msgid "Windows Central European (CP 1250)"
+msgstr "Européen central limité à Windows (CP 1250)"
+
+#: ../src/common/fmapbase.cpp:168
+msgid "Windows Cyrillic (CP 1251)"
+msgstr "Cyrillique limité à Windows (CP 1251)"
+
+#: ../src/common/fmapbase.cpp:169
+msgid "Windows Western European (CP 1252)"
+msgstr "Européen occidental limité à Windows (CP 1252 )"
+
+#: ../src/common/fmapbase.cpp:170
+msgid "Windows Greek (CP 1253)"
+msgstr "Grec limité à Windows (CP 1253)"
+
+#: ../src/common/fmapbase.cpp:171
+msgid "Windows Turkish (CP 1254)"
+msgstr "Turc limité à Windows (CP 1254)"
+
+#: ../src/common/fmapbase.cpp:172
+msgid "Windows Hebrew (CP 1255)"
+msgstr "Hébreu limité à Windows (CP 1255)"
+
+#: ../src/common/fmapbase.cpp:173
+msgid "Windows Arabic (CP 1256)"
+msgstr "Arabe limité à Windows (CP 1256)"
+
+#: ../src/common/fmapbase.cpp:174
+msgid "Windows Baltic (CP 1257)"
+msgstr "Balte limité à Windows (CP 1257)"
+
+#: ../src/common/fmapbase.cpp:175
+msgid "Windows Vietnamese (CP 1258)"
+msgstr "Vietnamien Windows (CP 1258)"
+
+#: ../src/common/fmapbase.cpp:176
+msgid "Windows Johab (CP 1361)"
+msgstr "Johab Windows (CP 1361)"
+
+#: ../src/common/fmapbase.cpp:177
+msgid "Windows/DOS OEM (CP 437)"
+msgstr "Windows/DOS OEM (CP 437)"
+
+#: ../src/common/fmapbase.cpp:178
+msgid "Unicode 7 bit (UTF-7)"
+msgstr "Unicode 7 bit (UTF-7)"
+
+#: ../src/common/fmapbase.cpp:179
+msgid "Unicode 8 bit (UTF-8)"
+msgstr "Unicode 8 bit (UTF-8)"
+
+#: ../src/common/fmapbase.cpp:181 ../src/common/fmapbase.cpp:187
+msgid "Unicode 16 bit (UTF-16)"
+msgstr "Unicode 16 bit (UTF-16)"
+
+#: ../src/common/fmapbase.cpp:182
+msgid "Unicode 16 bit Little Endian (UTF-16LE)"
+msgstr "Unicode 16 bit petit-boutiste (UTF-16LE)"
+
+#: ../src/common/fmapbase.cpp:183 ../src/common/fmapbase.cpp:189
+msgid "Unicode 32 bit (UTF-32)"
+msgstr "Unicode 32 bit (UTF-32)"
+
+#: ../src/common/fmapbase.cpp:184
+msgid "Unicode 32 bit Little Endian (UTF-32LE)"
+msgstr "Unicode 32 bit petit-boutiste (UTF-32LE)"
+
+#: ../src/common/fmapbase.cpp:186
+msgid "Unicode 16 bit Big Endian (UTF-16BE)"
+msgstr "Unicode 16 bit gros-boutiste (UTF-16BE)"
+
+#: ../src/common/fmapbase.cpp:188
+msgid "Unicode 32 bit Big Endian (UTF-32BE)"
+msgstr "Unicode 32 bit gros-boutiste (UTF-32BE)"
+
+#: ../src/common/fmapbase.cpp:191
+msgid "Extended Unix Codepage for Japanese (EUC-JP)"
+msgstr "Codepage Unix étendu pour le japonais (EUC-JP)"
+
+#: ../src/common/fmapbase.cpp:192
+msgid "US-ASCII"
+msgstr "US-ASCII"
+
+#: ../src/common/fmapbase.cpp:193
+msgid "ISO-2022-JP"
+msgstr "ISO-2022-JP"
+
+#: ../src/common/fmapbase.cpp:195
+msgid "MacRoman"
+msgstr "MacRoman"
+
+#: ../src/common/fmapbase.cpp:196
+msgid "MacJapanese"
+msgstr "MacJaponais"
+
+#: ../src/common/fmapbase.cpp:197
+msgid "MacChineseTrad"
+msgstr "MacChinoisTrad"
+
+#: ../src/common/fmapbase.cpp:198
+msgid "MacKorean"
+msgstr "MacCoréen"
+
+#: ../src/common/fmapbase.cpp:199
+msgid "MacArabic"
+msgstr "MacArabe"
+
+#: ../src/common/fmapbase.cpp:200
+msgid "MacHebrew"
+msgstr "MacHébreu"
+
+#: ../src/common/fmapbase.cpp:201
+msgid "MacGreek"
+msgstr "MacGrec"
+
+#: ../src/common/fmapbase.cpp:202
+msgid "MacCyrillic"
+msgstr "MacCyrillique"
+
+#: ../src/common/fmapbase.cpp:203
+msgid "MacDevanagari"
+msgstr "MacDevanagari"
+
+#: ../src/common/fmapbase.cpp:204
+msgid "MacGurmukhi"
+msgstr "MacGurmukhi"
+
+#: ../src/common/fmapbase.cpp:205
+msgid "MacGujarati"
+msgstr "MacGujarati"
+
+#: ../src/common/fmapbase.cpp:206
+msgid "MacOriya"
+msgstr "MacOriya"
+
+#: ../src/common/fmapbase.cpp:207
+msgid "MacBengali"
+msgstr "MacBengali"
+
+#: ../src/common/fmapbase.cpp:208
+msgid "MacTamil"
+msgstr "MacTamoul"
+
+#: ../src/common/fmapbase.cpp:209
+msgid "MacTelugu"
+msgstr "MacTelugu"
+
+#: ../src/common/fmapbase.cpp:210
+msgid "MacKannada"
+msgstr "MacKannada"
+
+#: ../src/common/fmapbase.cpp:211
+msgid "MacMalayalam"
+msgstr "MacMalayalam"
+
+#: ../src/common/fmapbase.cpp:212
+msgid "MacSinhalese"
+msgstr "MacCingalais"
+
+#: ../src/common/fmapbase.cpp:213
+msgid "MacBurmese"
+msgstr "MacBirman"
+
+#: ../src/common/fmapbase.cpp:214
+msgid "MacKhmer"
+msgstr "MacKhmer"
+
+#: ../src/common/fmapbase.cpp:215
+msgid "MacThai"
+msgstr "MacThaï"
+
+#: ../src/common/fmapbase.cpp:216
+msgid "MacLaotian"
+msgstr "MacLaotien"
+
+#: ../src/common/fmapbase.cpp:217
+msgid "MacGeorgian"
+msgstr "MacGéorgien"
+
+#: ../src/common/fmapbase.cpp:218
+msgid "MacArmenian"
+msgstr "MacArménien"
+
+#: ../src/common/fmapbase.cpp:219
+msgid "MacChineseSimp"
+msgstr "MacChinoisSimp"
+
+#: ../src/common/fmapbase.cpp:220
+msgid "MacTibetan"
+msgstr "MacTibétain"
+
+#: ../src/common/fmapbase.cpp:221
+msgid "MacMongolian"
+msgstr "MacMongol"
+
+#: ../src/common/fmapbase.cpp:222
+msgid "MacEthiopic"
+msgstr "MacÉthiopien"
+
+#: ../src/common/fmapbase.cpp:223
+msgid "MacCentralEurRoman"
+msgstr "MacRomanEuropeCentrale"
+
+#: ../src/common/fmapbase.cpp:224
+msgid "MacVietnamese"
+msgstr "MacVietnamien"
+
+#: ../src/common/fmapbase.cpp:225
+msgid "MacExtArabic"
+msgstr "MacArabeÉtendu"
+
+#: ../src/common/fmapbase.cpp:226
+msgid "MacSymbol"
+msgstr "MacSymbole"
+
+#: ../src/common/fmapbase.cpp:227
+msgid "MacDingbats"
+msgstr "MacDingbats"
+
+#: ../src/common/fmapbase.cpp:228
+msgid "MacTurkish"
+msgstr "MacTurque"
+
+#: ../src/common/fmapbase.cpp:229
+msgid "MacCroatian"
+msgstr "MacCroate"
+
+#: ../src/common/fmapbase.cpp:230
+msgid "MacIcelandic"
+msgstr "MacIslandais"
+
+#: ../src/common/fmapbase.cpp:231
+msgid "MacRomanian"
+msgstr "MacRoumain"
+
+#: ../src/common/fmapbase.cpp:232
+msgid "MacCeltic"
+msgstr "MacCelte"
+
+#: ../src/common/fmapbase.cpp:233
+msgid "MacGaelic"
+msgstr "MacGaélic"
+
+#: ../src/common/fmapbase.cpp:234
+msgid "MacKeyboardGlyphs"
+msgstr "MacKeyboardGlyphs"
+
+#: ../src/common/fmapbase.cpp:791
+msgid "Default encoding"
+msgstr "Codage par défaut"
+
+#: ../src/common/fmapbase.cpp:805
+#, c-format
+msgid "Unknown encoding (%d)"
+msgstr "Codage inconnu (%d)"
+
+#: ../src/common/fmapbase.cpp:815 ../src/richtext/richtextstyles.cpp:776
+msgid "default"
+msgstr "défaut"
+
+#: ../src/common/fmapbase.cpp:829
+#, c-format
+msgid "unknown-%d"
+msgstr "inconnu-%d"
+
+#: ../src/common/fontcmn.cpp:924 ../src/common/fontcmn.cpp:1130
+msgid "underlined"
+msgstr "souligné"
+
+#: ../src/common/fontcmn.cpp:929
+msgid " strikethrough"
+msgstr " barré"
+
+#: ../src/common/fontcmn.cpp:942
+msgid " thin"
+msgstr " mince"
+
+#: ../src/common/fontcmn.cpp:946
+msgid " extra light"
+msgstr " extra léger"
+
+#: ../src/common/fontcmn.cpp:950
+msgid " light"
+msgstr " léger"
+
+#: ../src/common/fontcmn.cpp:954
+msgid " medium"
+msgstr " moyen"
+
+#: ../src/common/fontcmn.cpp:958
+msgid " semi bold"
+msgstr " semi-gras"
+
+#: ../src/common/fontcmn.cpp:962
+msgid " bold"
+msgstr " gras"
+
+#: ../src/common/fontcmn.cpp:966
+msgid " extra bold"
+msgstr " extra gras"
+
+#: ../src/common/fontcmn.cpp:970
+msgid " heavy"
+msgstr " lourd"
+
+#: ../src/common/fontcmn.cpp:974
+msgid " extra heavy"
+msgstr " extra lourd"
+
+#: ../src/common/fontcmn.cpp:990
+msgid " italic"
+msgstr " italique"
+
+#: ../src/common/fontcmn.cpp:1134
+msgid "strikethrough"
+msgstr "barré"
+
+#: ../src/common/fontcmn.cpp:1143
+msgid "thin"
+msgstr "fin"
+
+#: ../src/common/fontcmn.cpp:1156
+msgid "extralight"
+msgstr "extra-léger"
+
+#: ../src/common/fontcmn.cpp:1161
+msgid "light"
+msgstr "léger"
+
+#: ../src/common/fontcmn.cpp:1169 ../src/richtext/richtextstyles.cpp:775
+msgid "normal"
+msgstr "normal"
+
+#: ../src/common/fontcmn.cpp:1174
+msgid "medium"
+msgstr "moyen"
+
+#: ../src/common/fontcmn.cpp:1179 ../src/common/fontcmn.cpp:1199
+msgid "semibold"
+msgstr "semi-gras"
+
+#: ../src/common/fontcmn.cpp:1184
+msgid "bold"
+msgstr "gras"
+
+#: ../src/common/fontcmn.cpp:1194
+msgid "extrabold"
+msgstr "extra-gras"
+
+#: ../src/common/fontcmn.cpp:1204
+msgid "heavy"
+msgstr "lourd"
+
+#: ../src/common/fontcmn.cpp:1212
+msgid "extraheavy"
+msgstr "extra lourd"
+
+#: ../src/common/fontcmn.cpp:1217
+msgid "italic"
+msgstr "italique"
+
+#: ../src/common/fontmap.cpp:195
+msgid ": unknown charset"
+msgstr ": jeu de caractères inconnu"
+
+#: ../src/common/fontmap.cpp:199
+#, c-format
+msgid ""
+"The charset '%s' is unknown. You may select\n"
+"another charset to replace it with or choose\n"
+"[Cancel] if it cannot be replaced"
+msgstr ""
+"Jeu de caractères « %s » inconnu. Sélectionner un autre en remplacement\n"
+"ou [Annuler] s'il ne peut pas être remplacé"
+
+#: ../src/common/fontmap.cpp:241
+#, c-format
+msgid "Failed to remember the encoding for the charset '%s'."
+msgstr "Échec du rappel du codage du jeu de caractères « %s »."
+
+#: ../src/common/fontmap.cpp:321
+msgid "can't load any font, aborting"
+msgstr "impossible de charger une police de caractères - abandon"
+
+#: ../src/common/fontmap.cpp:409
+msgid ": unknown encoding"
+msgstr ": codage inconnu"
+
+#: ../src/common/fontmap.cpp:417
+#, c-format
+msgid ""
+"No font for displaying text in encoding '%s' found,\n"
+"but an alternative encoding '%s' is available.\n"
+"Do you want to use this encoding (otherwise you will have to choose another "
+"one)?"
+msgstr ""
+"Aucune police trouvée pour afficher du texte avec le codage « %s »,\n"
+"mais le codage similaire « %s » est disponible.\n"
+"Faut-il l'utiliser (sinon, en choisir un autre) ?"
+
+#: ../src/common/fontmap.cpp:422
+#, c-format
+msgid ""
+"No font for displaying text in encoding '%s' found.\n"
+"Would you like to select a font to be used for this encoding\n"
+"(otherwise the text in this encoding will not be shown correctly)?"
+msgstr ""
+"Aucune police trouvée pour afficher du texte avec le codage « %s ».\n"
+"Faut-il choisir une police à utiliser pour ce codage\n"
+"(sinon le texte avec ce codage n'apparaîtra pas correctement) ?"
+
+#: ../src/common/fs_mem.cpp:169
+#, c-format
+msgid "Memory VFS already contains file '%s'!"
+msgstr "La mémoire VFS contient déjà le fichier « %s » !"
+
+#: ../src/common/fs_mem.cpp:232
+#, c-format
+msgid "Trying to remove file '%s' from memory VFS, but it is not loaded!"
+msgstr ""
+"Tentative de suppression du fichier « %s » de la mémoire VFS, mais il n'est "
+"pas chargé !"
+
+#: ../src/common/fs_mem.cpp:262
+#, c-format
+msgid "Failed to store image '%s' to memory VFS!"
+msgstr "Échec du stockage de l'image « %s » dans la mémoire VFS !"
+
+#: ../src/common/ftp.cpp:197
+msgid "Timeout while waiting for FTP server to connect, try passive mode."
+msgstr ""
+"Temps dépassé lors de la connexion du serveur FTP, essai du mode passif."
+
+#: ../src/common/ftp.cpp:399
+#, c-format
+msgid "Failed to set FTP transfer mode to %s."
+msgstr "Échec de la configuration du mode de transfert FTP en %s."
+
+#: ../src/common/ftp.cpp:400 ../src/richtext/richtextsymboldlg.cpp:432
+msgid "ASCII"
+msgstr "ASCII"
+
+#: ../src/common/ftp.cpp:400
+msgid "binary"
+msgstr "binaire"
+
+#: ../src/common/ftp.cpp:608
+msgid "The FTP server doesn't support the PORT command."
+msgstr "Commande PORT non reconnue par le serveur FTP."
+
+#: ../src/common/ftp.cpp:622
+msgid "The FTP server doesn't support passive mode."
+msgstr "Mode passif non reconnu par le serveur FTP."
+
+#: ../src/common/gifdecod.cpp:822
+#, c-format
+msgid "Incorrect GIF frame size (%u, %d) for the frame #%u"
+msgstr "Taille d'image GIF incorrecte (%u, %d) for l'image #%u"
+
+#: ../src/common/glcmn.cpp:108
+msgid "Failed to allocate colour for OpenGL"
+msgstr "Échec de l'allocation de couleur pour OpenGL"
+
+#: ../src/common/headerctrlcmn.cpp:57
+msgid "Please select the columns to show and define their order:"
+msgstr "Sélectionner les colonnes à afficher et définir leur ordre :"
+
+#: ../src/common/headerctrlcmn.cpp:58
+msgid "Customize Columns"
+msgstr "Personnaliser les Colonnes"
+
+#: ../src/common/headerctrlcmn.cpp:304
+msgid "&Customize..."
+msgstr "&Personnaliser..."
+
+#: ../src/common/hyperlnkcmn.cpp:132
+#, c-format
+msgid "Failed to open URL \"%s\" in the default browser"
+msgstr "Échec de l'ouverture de l'URL « %s » avec le navigateur par défaut"
+
+#: ../src/common/iconbndl.cpp:195
+#, c-format
+msgid "Failed to load image %%d from file '%s'."
+msgstr "Échec du chargement de l'image %%d depuis le fichier « %s »."
+
+#: ../src/common/iconbndl.cpp:203
+#, c-format
+msgid "Failed to load image %d from stream."
+msgstr "Échec du chargement de l'image %d depuis le flux."
+
+#: ../src/common/iconbndl.cpp:221
+#, c-format
+msgid "Failed to load icons from resource '%s'."
+msgstr "Échec du chargement des icônes depuis les ressources '%s'."
+
+#: ../src/common/imagbmp.cpp:97
+msgid "BMP: Couldn't save invalid image."
+msgstr "BMP : impossible de sauvegarder une image non valable."
+
+#: ../src/common/imagbmp.cpp:137
+msgid "BMP: wxImage doesn't have own wxPalette."
+msgstr "BMP : wxImage n'a pas sa propre wxPalette."
+
+#: ../src/common/imagbmp.cpp:243
+msgid "BMP: Couldn't write the file (Bitmap) header."
+msgstr "BMP : impossible d'écrire l'entête du fichier (Bitmap)."
+
+#: ../src/common/imagbmp.cpp:266
+msgid "BMP: Couldn't write the file (BitmapInfo) header."
+msgstr "BMP : impossible d'écrire l'entête du fichier (BitmapInfo)."
+
+#: ../src/common/imagbmp.cpp:353
+msgid "BMP: Couldn't write RGB color map."
+msgstr "BMP : impossible d'écrire la palette de couleurs RGB."
+
+#: ../src/common/imagbmp.cpp:487
+msgid "BMP: Couldn't write data."
+msgstr "BMP : impossible d'écrire les données."
+
+#: ../src/common/imagbmp.cpp:561 ../src/common/imagbmp.cpp:642
+msgid "BMP: Couldn't allocate memory."
+msgstr "BMP : impossible d'allouer de la mémoire."
+
+#: ../src/common/imagbmp.cpp:1041
+msgid "DIB Header: Image width > 32767 pixels for file."
+msgstr ""
+"En-tête DIB : largeur de l'image supérieure à 32 767 pixels pour le fichier."
+
+#: ../src/common/imagbmp.cpp:1049
+msgid "DIB Header: Image height > 32767 pixels for file."
+msgstr ""
+"En-tête DIB : hauteur de l'image supérieure à 32 767 pixels pour le fichier."
+
+#: ../src/common/imagbmp.cpp:1081
+msgid "DIB Header: Unknown bitdepth in file."
+msgstr "En-tête DIB : nombre de bits par pixel inconnu dans le fichier."
+
+#: ../src/common/imagbmp.cpp:1156
+msgid "DIB Header: Unknown encoding in file."
+msgstr "En-tête DIB : codage inconnu dans le fichier."
+
+#: ../src/common/imagbmp.cpp:1165
+msgid "DIB Header: Encoding doesn't match bitdepth."
+msgstr "En-tête DIB : le codage ne correspond pas au nombre de bits par pixel."
+
+#: ../src/common/imagbmp.cpp:1180
+#, c-format
+msgid "BMP Header: Invalid number of colors (%d)."
+msgstr "En-tête BMP : nombre de couleurs non valable (%d)."
+
+#: ../src/common/imagbmp.cpp:1273
+msgid "Error in reading image DIB."
+msgstr "Erreur lors de la lecture d'une image DIB."
+
+#: ../src/common/imagbmp.cpp:1294
+msgid "ICO: Error in reading mask DIB."
+msgstr "ICO : erreur à la lecture du masque DIB."
+
+#: ../src/common/imagbmp.cpp:1353
+msgid "ICO: Image too tall for an icon."
+msgstr "ICO : image trop grande pour une icône."
+
+#: ../src/common/imagbmp.cpp:1361
+msgid "ICO: Image too wide for an icon."
+msgstr "ICO : image trop large pour une icône."
+
+#: ../src/common/imagbmp.cpp:1388 ../src/common/imagbmp.cpp:1488
+#: ../src/common/imagbmp.cpp:1503 ../src/common/imagbmp.cpp:1514
+#: ../src/common/imagbmp.cpp:1528 ../src/common/imagbmp.cpp:1576
+#: ../src/common/imagbmp.cpp:1591 ../src/common/imagbmp.cpp:1605
+#: ../src/common/imagbmp.cpp:1616
+msgid "ICO: Error writing the image file!"
+msgstr "ICO : erreur à l'écriture du fichier image !"
+
+#: ../src/common/imagbmp.cpp:1701
+msgid "ICO: Invalid icon index."
+msgstr "ICO : index de l'icône non valable."
+
+#: ../src/common/image.cpp:2410
+msgid "Image and mask have different sizes."
+msgstr "L'image et le masque sont de tailles différentes."
+
+#: ../src/common/image.cpp:2418 ../src/common/image.cpp:2459
+msgid "No unused colour in image being masked."
+msgstr "Aucune couleur n'est disponible dans l'image en cours de masquage."
+
+#: ../src/common/image.cpp:2641
+#, c-format
+msgid "Failed to load bitmap \"%s\" from resources."
+msgstr "Échec du chargement du bitmap « %s » depuis les ressources."
+
+#: ../src/common/image.cpp:2650
+#, c-format
+msgid "Failed to load icon \"%s\" from resources."
+msgstr "Échec du chargement de l'icône « %s » depuis les ressources."
+
+#: ../src/common/image.cpp:2728 ../src/common/image.cpp:2747
+#, c-format
+msgid "Failed to load image from file \"%s\"."
+msgstr "Échec du chargement de l'image depuis le fichier « %s »."
+
+#: ../src/common/image.cpp:2761
+#, c-format
+msgid "Can't save image to file '%s': unknown extension."
+msgstr ""
+"Impossible d'enregistrer l'image dans le fichier « %s » : extension inconnue."
+
+#: ../src/common/image.cpp:2869
+msgid "No handler found for image type."
+msgstr "Aucun gestionnaire trouvé pour le type d'image."
+
+#: ../src/common/image.cpp:2877 ../src/common/image.cpp:3000
+#: ../src/common/image.cpp:3066
+#, c-format
+msgid "No image handler for type %d defined."
+msgstr "Aucun gestionnaire d'image défini pour le type %d."
+
+#: ../src/common/image.cpp:2887
+#, c-format
+msgid "Image file is not of type %d."
+msgstr "Le fichier image n'est pas du type %d."
+
+#: ../src/common/image.cpp:2970
+msgid "Can't automatically determine the image format for non-seekable input."
+msgstr ""
+"Impossible de déterminer le format d'image pour une entrée non positionnable."
+
+#: ../src/common/image.cpp:2988
+msgid "Unknown image data format."
+msgstr "Format de données d'image inconnu."
+
+#: ../src/common/image.cpp:3009
+#, c-format
+msgid "This is not a %s."
+msgstr "Ceci n'est pas un %s."
+
+#: ../src/common/image.cpp:3032 ../src/common/image.cpp:3080
+#, c-format
+msgid "No image handler for type %s defined."
+msgstr "Aucun gestionnaire d'image défini pour le type %s."
+
+#: ../src/common/image.cpp:3041
+#, c-format
+msgid "Image is not of type %s."
+msgstr "Le fichier image n'est pas du type %s."
+
+#: ../src/common/image.cpp:3509
+#, c-format
+msgid "Failed to check format of image file \"%s\"."
+msgstr "Échec de la vérification de format du fichier image « %s »."
+
+#: ../src/common/imaggif.cpp:124
+msgid "GIF: error in GIF image format."
+msgstr "GIF : erreur dans le format de l'image GIF."
+
+#: ../src/common/imaggif.cpp:129
+msgid "GIF: not enough memory."
+msgstr "GIF : mémoire insuffisante."
+
+#: ../src/common/imaggif.cpp:134
+msgid "GIF: data stream seems to be truncated."
+msgstr "GIF : le flux des données semble être tronqué."
+
+#: ../src/common/imaggif.cpp:240
+msgid "Couldn't initialize GIF hash table."
+msgstr "Impossible d'initialiser la table de hachage GIF."
+
+#: ../src/common/imagiff.cpp:739
+msgid "IFF: error in IFF image format."
+msgstr "IFF : erreur dans le format de l'image IFF."
+
+#: ../src/common/imagiff.cpp:742
+msgid "IFF: not enough memory."
+msgstr "IFF : mémoire insuffisante."
+
+#: ../src/common/imagiff.cpp:745
+msgid "IFF: unknown error!!!"
+msgstr "IFF : erreur inconnue !!!"
+
+#: ../src/common/imagiff.cpp:755
+msgid "IFF: data stream seems to be truncated."
+msgstr "IFF : le flux de données semble être tronqué."
+
+#: ../src/common/imagjpeg.cpp:258
+msgid "JPEG: Couldn't load - file is probably corrupted."
+msgstr "JPEG : échec du chargement - le fichier est probablement corrompu."
+
+#: ../src/common/imagjpeg.cpp:437
+msgid "JPEG: Couldn't save image."
+msgstr "JPEG : échec de la sauvegarde de l'image."
+
+#: ../src/common/imagpcx.cpp:439
+msgid "PCX: this is not a PCX file."
+msgstr "PCX : ce n'est pas un fichier PCX."
+
+#: ../src/common/imagpcx.cpp:453
+msgid "PCX: image format unsupported"
+msgstr "PCX : format d'image non reconnu"
+
+#: ../src/common/imagpcx.cpp:454 ../src/common/imagpcx.cpp:477
+msgid "PCX: couldn't allocate memory"
+msgstr "PCX : impossible d'allouer de la mémoire"
+
+#: ../src/common/imagpcx.cpp:455
+msgid "PCX: version number too low"
+msgstr "PCX : numéro de version trop petit"
+
+#: ../src/common/imagpcx.cpp:456 ../src/common/imagpcx.cpp:478
+msgid "PCX: unknown error !!!"
+msgstr "PCX : erreur inconnue !!!"
+
+#: ../src/common/imagpcx.cpp:476
+msgid "PCX: invalid image"
+msgstr "PCX : image non valable"
+
+#: ../src/common/imagpng.cpp:385
+#, c-format
+msgid "Unknown PNG resolution unit %d"
+msgstr "Unité %d de résolution PNG inconnue"
+
+#: ../src/common/imagpng.cpp:439
+msgid "Couldn't load a PNG image - file is corrupted or not enough memory."
+msgstr ""
+"Impossible de charger une image PNG - fichier corrompu ou mémoire "
+"insuffisante."
+
+#: ../src/common/imagpng.cpp:513 ../src/common/imagpng.cpp:524
+#: ../src/common/imagpng.cpp:534
+msgid "Couldn't save PNG image."
+msgstr "Impossible de sauvegarder l'image PNG."
+
+#: ../src/common/imagpnm.cpp:71
+msgid "PNM: File format is not recognized."
+msgstr "PNM : le format de fichier n'est pas reconnu."
+
+#: ../src/common/imagpnm.cpp:89
+msgid "PNM: Couldn't allocate memory."
+msgstr "PNM : impossible d'allouer de la mémoire."
+
+#: ../src/common/imagpnm.cpp:111 ../src/common/imagpnm.cpp:134
+#: ../src/common/imagpnm.cpp:156
+msgid "PNM: File seems truncated."
+msgstr "PNM : le fichier semble tronqué."
+
+#: ../src/common/imagtiff.cpp:69
+#, c-format
+msgid " (in module \"%s\")"
+msgstr " (dans le module « %s »)"
+
+#: ../src/common/imagtiff.cpp:304
+msgid "TIFF: Error loading image."
+msgstr "TIFF : erreur au chargement de l'image."
+
+#: ../src/common/imagtiff.cpp:314
+msgid "Invalid TIFF image index."
+msgstr "Index d'image TIFF non valable."
+
+#: ../src/common/imagtiff.cpp:358
+msgid "TIFF: Image size is abnormally big."
+msgstr "TIFF : La taille de l'image est anormalement grande."
+
+#: ../src/common/imagtiff.cpp:372 ../src/common/imagtiff.cpp:385
+#: ../src/common/imagtiff.cpp:769
+msgid "TIFF: Couldn't allocate memory."
+msgstr "TIFF : allocation de mémoire impossible."
+
+#: ../src/common/imagtiff.cpp:471
+msgid "TIFF: Error reading image."
+msgstr "TIFF : erreur à la lecture de l'image."
+
+#: ../src/common/imagtiff.cpp:532
+#, c-format
+msgid "Unknown TIFF resolution unit %d ignored"
+msgstr "Unité %d de résolution TIFF inconnue et ignorée"
+
+#: ../src/common/imagtiff.cpp:611
+msgid "TIFF: Error saving image."
+msgstr "TIFF : erreur à la sauvegarde de l'image."
+
+#: ../src/common/imagtiff.cpp:868
+msgid "TIFF: Error writing image."
+msgstr "TIFF : erreur à l'écriture de l'image."
+
+#: ../src/common/imagtiff.cpp:881
+msgid "TIFF: Error flushing data."
+msgstr "TIFF : erreur à la vidange des données."
+
+#: ../src/common/imagwebp.cpp:56
+msgid "WebP: Invalid data (failed to get features)."
+msgstr "WebP : données non valables (échec de la récupération des caractéristiques)."
+
+#: ../src/common/imagwebp.cpp:65
+msgid "WebP: Allocating image memory failed."
+msgstr "WebP : échec d'allocation de mémoire pour l'image."
+
+#: ../src/common/imagwebp.cpp:82
+msgid "WebP: Decoding RGBA image data failed."
+msgstr "WebP : échec du décodage des données d'image RGBA."
+
+#: ../src/common/imagwebp.cpp:98
+msgid "WebP: Decoding RGB image data failed."
+msgstr "WebP : échec du décodage des données d'image RGB."
+
+#: ../src/common/imagwebp.cpp:113 ../src/common/imagwebp.cpp:201
+msgid "WebP: Allocating stream buffer failed."
+msgstr "WebP : échec d'allocation du tampon de flux."
+
+#: ../src/common/imagwebp.cpp:131
+msgid "WebP: Failed to parse container data."
+msgstr "WebP : échec de l'analyse des données du conteneur."
+
+#: ../src/common/imagwebp.cpp:222
+msgid "WebP: Error decoding animation."
+msgstr "WebP : erreur de décodage de l'animation."
+
+#: ../src/common/imagwebp.cpp:240
+msgid "WebP: Error getting next animation frame."
+msgstr "WebP : erreur à la récupération de la trame d'animation suivante."
+
+#: ../src/common/init.cpp:172
+#, c-format
+msgid ""
+"Command line argument %d couldn't be converted to Unicode and will be "
+"ignored."
+msgstr ""
+"L'argument %d de la ligne de commande n'a pas pu être converti en Unicode et "
+"sera ignoré."
+
+#: ../src/common/init.cpp:344
+msgid "Initialization failed in post init, aborting."
+msgstr "L'initialisation a échoué dans post init, abandon."
+
+#: ../src/common/intl.cpp:378
+#, c-format
+msgid "Cannot set locale to language \"%s\"."
+msgstr "Impossible d'établir la localisation pour la langue « %s »."
+
+#: ../src/common/log.cpp:232
+msgid "Error: "
+msgstr "Erreur : "
+
+#: ../src/common/log.cpp:236
+msgid "Warning: "
+msgstr "Avertissement : "
+
+#: ../src/common/log.cpp:284
+msgid "The previous message repeated once."
+msgstr "Le message précédent répété une fois."
+
+#: ../src/common/log.cpp:291
+#, c-format
+msgid "The previous message repeated %u time."
+msgid_plural "The previous message repeated %u times."
+msgstr[0] "Le message précédent répété %u fois."
+msgstr[1] "Le message précédent répété %u fois."
+
+#: ../src/common/log.cpp:319
+#, c-format
+msgid "Last repeated message (\"%s\", %u time) wasn't output"
+msgid_plural "Last repeated message (\"%s\", %u times) wasn't output"
+msgstr[0] "Le dernier message répété (« %s », %u fois) n'a pas été affiché"
+msgstr[1] "Le dernier message répété (« %s », %u fois) n'a pas été affiché"
+
+#: ../src/common/log.cpp:435
+#, c-format
+msgid " (error %ld: %s)"
+msgstr " (erreur %ld : %s)"
+
+#: ../src/common/lzmastream.cpp:121
+msgid "Failed to allocate memory for LZMA decompression."
+msgstr "Échec d'allocation de mémoire pour la décompression LZMA."
+
+#: ../src/common/lzmastream.cpp:125
+#, c-format
+msgid "Failed to initialize LZMA decompression: unexpected error %u."
+msgstr "Échec d'initialisation de décompression LZMA : erreur inconnue %u."
+
+#: ../src/common/lzmastream.cpp:179
+msgid "input is not in XZ format"
+msgstr "l'entrée n'est pas au format XZ"
+
+#: ../src/common/lzmastream.cpp:183
+msgid "input compressed using unknown XZ option"
+msgstr "entrée compressée utilisant l'option XZ inconnue"
+
+#: ../src/common/lzmastream.cpp:188
+msgid "input is corrupted"
+msgstr "l'entrée est corrompue"
+
+#: ../src/common/lzmastream.cpp:192
+msgid "unknown decompression error"
+msgstr "erreur inconnue de décompression"
+
+#: ../src/common/lzmastream.cpp:196
+#, c-format
+msgid "LZMA decompression error: %s"
+msgstr "Erreur de décompression LZMA : %s"
+
+#: ../src/common/lzmastream.cpp:231
+msgid "Failed to allocate memory for LZMA compression."
+msgstr "Échec d'allocation de mémoire pour la compression LZMA."
+
+#: ../src/common/lzmastream.cpp:235
+#, c-format
+msgid "Failed to initialize LZMA compression: unexpected error %u."
+msgstr "Échec d'initialisation de compression LZMA : erreur inconnue %u."
+
+#: ../src/common/lzmastream.cpp:267 ../src/common/lzmastream.cpp:342
+#: ../src/html/chm.cpp:336
+msgid "out of memory"
+msgstr "capacité mémoire dépassée"
+
+#: ../src/common/lzmastream.cpp:276 ../src/common/lzmastream.cpp:346
+msgid "unknown compression error"
+msgstr "erreur inconnue de compression"
+
+#: ../src/common/lzmastream.cpp:280
+#, c-format
+msgid "LZMA compression error: %s"
+msgstr "Erreur de compression LZMA : %s"
+
+#: ../src/common/lzmastream.cpp:350
+#, c-format
+msgid "LZMA compression error when flushing output: %s"
+msgstr "Erreur de compression LZMA pendant l'écriture : %s"
+
+#: ../src/common/mimecmn.cpp:167
+#, c-format
+msgid "Unmatched '{' in an entry for mime type %s."
+msgstr "Symbole « { » non assorti dans une entrée pour le type mime %s."
+
+#: ../src/common/module.cpp:76
+#, c-format
+msgid "Circular dependency involving module \"%s\" detected."
+msgstr "Dépendance en boucle détectée, impliquant le module \"%s\"."
+
+#: ../src/common/module.cpp:128
+#, c-format
+msgid "Dependency \"%s\" of module \"%s\" doesn't exist."
+msgstr "La dépendance « %s » du module « %s » n'existe pas."
+
+#: ../src/common/module.cpp:137
+#, c-format
+msgid "Module \"%s\" initialization failed"
+msgstr "L'initialisation du module « %s » a échoué"
+
+#: ../src/common/msgout.cpp:96
+msgid "Message"
+msgstr "Message"
+
+#: ../src/common/paper.cpp:70
+msgid "Letter, 8 1/2 x 11 in"
+msgstr "Lettre (8,5 x 11 pouces)"
+
+#: ../src/common/paper.cpp:71
+msgid "Legal, 8 1/2 x 14 in"
+msgstr "Légal (8,5 x 14 pouces)"
+
+#: ../src/common/paper.cpp:72
+msgid "A4 sheet, 210 x 297 mm"
+msgstr "Feuille A4, 210 x 297 mm"
+
+#: ../src/common/paper.cpp:73
+msgid "C sheet, 17 x 22 in"
+msgstr "Feuille C, 17 x 22 mm"
+
+#: ../src/common/paper.cpp:74
+msgid "D sheet, 22 x 34 in"
+msgstr "Feuille D, 22 x 34 mm"
+
+#: ../src/common/paper.cpp:75
+msgid "E sheet, 34 x 44 in"
+msgstr "Feuille E (34 x 44 pouces)"
+
+#: ../src/common/paper.cpp:76
+msgid "Letter Small, 8 1/2 x 11 in"
+msgstr "Lettre réduite (8,5 x 11 pouces)"
+
+#: ../src/common/paper.cpp:77
+msgid "Tabloid, 11 x 17 in"
+msgstr "Tabloïde (11 x 17 pouces)"
+
+#: ../src/common/paper.cpp:78
+msgid "Ledger, 17 x 11 in"
+msgstr "Grand livre (17 x 11 pouces)"
+
+#: ../src/common/paper.cpp:79
+msgid "Statement, 5 1/2 x 8 1/2 in"
+msgstr "Communiqué (5,5 x 8,5 pouces)"
+
+#: ../src/common/paper.cpp:80
+msgid "Executive, 7 1/4 x 10 1/2 in"
+msgstr "Executive (7,25 x 10,5 pouces)"
+
+#: ../src/common/paper.cpp:81
+msgid "A3 sheet, 297 x 420 mm"
+msgstr "Feuille A3, 297 x 420 mm"
+
+#: ../src/common/paper.cpp:82
+msgid "A4 small sheet, 210 x 297 mm"
+msgstr "Petite feuille A4, 210 x 297 mm"
+
+#: ../src/common/paper.cpp:83
+msgid "A5 sheet, 148 x 210 mm"
+msgstr "Feuille A5, 148 x 210 mm"
+
+#: ../src/common/paper.cpp:84
+msgid "B4 sheet, 250 x 354 mm"
+msgstr "Feuille B4, 250 x 354 mm"
+
+#: ../src/common/paper.cpp:85
+msgid "B5 sheet, 182 x 257 millimeter"
+msgstr "Feuille B5, 182 x 257 mm"
+
+#: ../src/common/paper.cpp:86
+msgid "Folio, 8 1/2 x 13 in"
+msgstr "Folio (8,5 x 13 pouces)"
+
+#: ../src/common/paper.cpp:87
+msgid "Quarto, 215 x 275 mm"
+msgstr "Quarto, 215 x 275 mm"
+
+#: ../src/common/paper.cpp:88
+msgid "10 x 14 in"
+msgstr "10 x 14 pouces"
+
+#: ../src/common/paper.cpp:89
+msgid "11 x 17 in"
+msgstr "11 x 17 pouces"
+
+#: ../src/common/paper.cpp:90
+msgid "Note, 8 1/2 x 11 in"
+msgstr "Note (8,5 x 11 pouces)"
+
+#: ../src/common/paper.cpp:91
+msgid "#9 Envelope, 3 7/8 x 8 7/8 in"
+msgstr "Enveloppe n° 9 (3,875 x 8,875 pouces)"
+
+#: ../src/common/paper.cpp:92
+msgid "#10 Envelope, 4 1/8 x 9 1/2 in"
+msgstr "Enveloppe n° 10 (4,125 x 9,5 pouces)"
+
+#: ../src/common/paper.cpp:93
+msgid "#11 Envelope, 4 1/2 x 10 3/8 in"
+msgstr "Enveloppe n° 11 (4,5 x 10,375 pouces)"
+
+#: ../src/common/paper.cpp:94
+msgid "#12 Envelope, 4 3/4 x 11 in"
+msgstr "Enveloppe n° 12 (4,75 x 11 pouces)"
+
+#: ../src/common/paper.cpp:95
+msgid "#14 Envelope, 5 x 11 1/2 in"
+msgstr "Enveloppe n° 14 (5 x 11,5 pouces)"
+
+#: ../src/common/paper.cpp:96
+msgid "DL Envelope, 110 x 220 mm"
+msgstr "Enveloppe DL, 110 x 220 mm"
+
+#: ../src/common/paper.cpp:97
+msgid "C5 Envelope, 162 x 229 mm"
+msgstr "Enveloppe C5, 162 x 229 mm"
+
+#: ../src/common/paper.cpp:98
+msgid "C3 Envelope, 324 x 458 mm"
+msgstr "Enveloppe C3, 324 x 458 mm"
+
+#: ../src/common/paper.cpp:99
+msgid "C4 Envelope, 229 x 324 mm"
+msgstr "Enveloppe C4, 229 x 324 mm"
+
+#: ../src/common/paper.cpp:100
+msgid "C6 Envelope, 114 x 162 mm"
+msgstr "Enveloppe C6, 114 x 162 mm"
+
+#: ../src/common/paper.cpp:101
+msgid "C65 Envelope, 114 x 229 mm"
+msgstr "Enveloppe C65, 114 x 229 mm"
+
+#: ../src/common/paper.cpp:102
+msgid "B4 Envelope, 250 x 353 mm"
+msgstr "Enveloppe B4, 250 x 353 mm"
+
+#: ../src/common/paper.cpp:103
+msgid "B5 Envelope, 176 x 250 mm"
+msgstr "Enveloppe B5, 176 x 250 mm"
+
+#: ../src/common/paper.cpp:104
+msgid "B6 Envelope, 176 x 125 mm"
+msgstr "Enveloppe B6, 176 x 125 mm"
+
+#: ../src/common/paper.cpp:105
+msgid "Italy Envelope, 110 x 230 mm"
+msgstr "Enveloppe italienne, 110 x 230 mm"
+
+#: ../src/common/paper.cpp:106
+msgid "Monarch Envelope, 3 7/8 x 7 1/2 in"
+msgstr "Enveloppe monarchique (3,875 x 7,5 pouces)"
+
+#: ../src/common/paper.cpp:107
+msgid "6 3/4 Envelope, 3 5/8 x 6 1/2 in"
+msgstr "Enveloppe 6 3/4 (3,625 x 6,5 pouces)"
+
+#: ../src/common/paper.cpp:108
+msgid "US Std Fanfold, 14 7/8 x 11 in"
+msgstr "Standard US en accordéon (14,875 x 11 pouces)"
+
+#: ../src/common/paper.cpp:109
+msgid "German Std Fanfold, 8 1/2 x 12 in"
+msgstr "Standard allemand en accordéon (8,5 x 12 pouces)"
+
+#: ../src/common/paper.cpp:110
+msgid "German Legal Fanfold, 8 1/2 x 13 in"
+msgstr "Légal allemand en accordéon (8,5 x 13 pouces)"
+
+#: ../src/common/paper.cpp:112
+msgid "B4 (ISO) 250 x 353 mm"
+msgstr "B4 (ISO) 250 x 353 mm"
+
+#: ../src/common/paper.cpp:113
+msgid "Japanese Postcard 100 x 148 mm"
+msgstr "Enveloppe japonaise 100 x 148 mm"
+
+#: ../src/common/paper.cpp:114
+msgid "9 x 11 in"
+msgstr "9 x 11 pouces"
+
+#: ../src/common/paper.cpp:115
+msgid "10 x 11 in"
+msgstr "10 x 11 pouces"
+
+#: ../src/common/paper.cpp:116
+msgid "15 x 11 in"
+msgstr "15 x 11 pouces"
+
+#: ../src/common/paper.cpp:117
+msgid "Envelope Invite 220 x 220 mm"
+msgstr "Enveloppe Invite 220 x 220 mm"
+
+#: ../src/common/paper.cpp:118
+msgid "Letter Extra 9 1/2 x 12 in"
+msgstr "Lettre Extra 9.5 x 12 pouces"
+
+#: ../src/common/paper.cpp:119
+msgid "Legal Extra 9 1/2 x 15 in"
+msgstr "Légal Extra 9,5 x 15 pouces"
+
+#: ../src/common/paper.cpp:120
+msgid "Tabloid Extra 11.69 x 18 in"
+msgstr "Tabloïde Extra 11.69 x 18 pouces"
+
+#: ../src/common/paper.cpp:121
+msgid "A4 Extra 9.27 x 12.69 in"
+msgstr "A4 Extra 9.27 x 12.69 pouces"
+
+#: ../src/common/paper.cpp:122
+msgid "Letter Transverse 8 1/2 x 11 in"
+msgstr "Lettre 8,5 x 11 pouces"
+
+#: ../src/common/paper.cpp:123
+msgid "A4 Transverse 210 x 297 mm"
+msgstr "A4 Portrait 210 x 297 mm"
+
+#: ../src/common/paper.cpp:124
+msgid "Letter Extra Transverse 9.275 x 12 in"
+msgstr "Lettre Extra Portrait 9.275 x 12 pouces"
+
+#: ../src/common/paper.cpp:125
+msgid "SuperA/SuperA/A4 227 x 356 mm"
+msgstr "SuperA/SuperA/A4 227 x 356 mm"
+
+#: ../src/common/paper.cpp:126
+msgid "SuperB/SuperB/A3 305 x 487 mm"
+msgstr "SuperB/SuperB/A3 305 x 487 mm"
+
+#: ../src/common/paper.cpp:127
+msgid "Letter Plus 8 1/2 x 12.69 in"
+msgstr "Lettre Plus 8,5 x 12.69 pouces"
+
+#: ../src/common/paper.cpp:128
+msgid "A4 Plus 210 x 330 mm"
+msgstr "A4 Plus 210 x 330 mm"
+
+#: ../src/common/paper.cpp:129
+msgid "A5 Transverse 148 x 210 mm"
+msgstr "A5 Portrait 148 x 210 mm"
+
+#: ../src/common/paper.cpp:130
+msgid "B5 (JIS) Transverse 182 x 257 mm"
+msgstr "B5 (JIS), Paysage, 182 x 257 mm"
+
+#: ../src/common/paper.cpp:131
+msgid "A3 Extra 322 x 445 mm"
+msgstr "A3 Extra 322 x 445 mm"
+
+#: ../src/common/paper.cpp:132
+msgid "A5 Extra 174 x 235 mm"
+msgstr "A5 Extra 174 x 235 mm"
+
+#: ../src/common/paper.cpp:133
+msgid "B5 (ISO) Extra 201 x 276 mm"
+msgstr "B5 (ISO) Extra 201 x 276 mm"
+
+#: ../src/common/paper.cpp:134
+msgid "A2 420 x 594 mm"
+msgstr "A2 420 x 594 mm"
+
+#: ../src/common/paper.cpp:135
+msgid "A3 Transverse 297 x 420 mm"
+msgstr "A3 Portrait 297 x 420 mm"
+
+#: ../src/common/paper.cpp:136
+msgid "A3 Extra Transverse 322 x 445 mm"
+msgstr "A3 Extra, Paysage, 322 x 445 mm"
+
+#: ../src/common/paper.cpp:138
+msgid "Japanese Double Postcard 200 x 148 mm"
+msgstr "Carte postale double japonaise 200 x148 mm"
+
+#: ../src/common/paper.cpp:139
+msgid "A6 105 x 148 mm"
+msgstr "A6 105 x 148 mm"
+
+#: ../src/common/paper.cpp:140
+msgid "Japanese Envelope Kaku #2"
+msgstr "Enveloppe japonaise Kaky  n. 2"
+
+#: ../src/common/paper.cpp:141
+msgid "Japanese Envelope Kaku #3"
+msgstr "Enveloppe japonaise Kaky  n. 3"
+
+#: ../src/common/paper.cpp:142
+msgid "Japanese Envelope Chou #3"
+msgstr "Enveloppe japonaise Chou n. 3"
+
+#: ../src/common/paper.cpp:143
+msgid "Japanese Envelope Chou #4"
+msgstr "Enveloppe japonaise Chou n. 4"
+
+#: ../src/common/paper.cpp:144
+msgid "Letter Rotated 11 x 8 1/2 in"
+msgstr "Lettre paysage 11 x 8.5 pouces"
+
+#: ../src/common/paper.cpp:145
+msgid "A3 Rotated 420 x 297 mm"
+msgstr "A3 Paysage 420 x 297 mm"
+
+#: ../src/common/paper.cpp:146
+msgid "A4 Rotated 297 x 210 mm"
+msgstr "A4 Paysage 297 x 210 mm"
+
+#: ../src/common/paper.cpp:147
+msgid "A5 Rotated 210 x 148 mm"
+msgstr "A5 Paysage 210 x 148 mm"
+
+#: ../src/common/paper.cpp:148
+msgid "B4 (JIS) Rotated 364 x 257 mm"
+msgstr "B4 (JIS) Paysage 364 x 257 mm"
+
+#: ../src/common/paper.cpp:149
+msgid "B5 (JIS) Rotated 257 x 182 mm"
+msgstr "B5 (JIS) Paysage 257 x 182 mm"
+
+#: ../src/common/paper.cpp:150
+msgid "Japanese Postcard Rotated 148 x 100 mm"
+msgstr "Enveloppe japonaise Paysage 148 x 100 mm"
+
+#: ../src/common/paper.cpp:151
+msgid "Double Japanese Postcard Rotated 148 x 200 mm"
+msgstr "Carte postale japonaise double Paysage 148 x 200 mm"
+
+#: ../src/common/paper.cpp:152
+msgid "A6 Rotated 148 x 105 mm"
+msgstr "A6 Paysage 148 x 105 mm"
+
+#: ../src/common/paper.cpp:153
+msgid "Japanese Envelope Kaku #2 Rotated"
+msgstr "Enveloppe japonaise Kaky  n. 2 Paysage"
+
+#: ../src/common/paper.cpp:154
+msgid "Japanese Envelope Kaku #3 Rotated"
+msgstr "Enveloppe japonaise Kaky  n. 3 Paysage"
+
+#: ../src/common/paper.cpp:155
+msgid "Japanese Envelope Chou #3 Rotated"
+msgstr "Enveloppe japonaise Chou n. 3 Paysage"
+
+#: ../src/common/paper.cpp:156
+msgid "Japanese Envelope Chou #4 Rotated"
+msgstr "Enveloppe japonaise Chou n. 4 Paysage"
+
+#: ../src/common/paper.cpp:157
+msgid "B6 (JIS) 128 x 182 mm"
+msgstr "B6 (JIS) 128 x 182 mm"
+
+#: ../src/common/paper.cpp:158
+msgid "B6 (JIS) Rotated 182 x 128 mm"
+msgstr "B6 (JIS) Paysage 182 x 128 mm"
+
+#: ../src/common/paper.cpp:159
+msgid "12 x 11 in"
+msgstr "12 x 11 pouces"
+
+#: ../src/common/paper.cpp:160
+msgid "Japanese Envelope You #4"
+msgstr "Enveloppe japonaise Kaky  n. 4"
+
+#: ../src/common/paper.cpp:161
+msgid "Japanese Envelope You #4 Rotated"
+msgstr "Enveloppe japonaise Kaky  n. 4 Paysage"
+
+#: ../src/common/paper.cpp:162
+msgid "PRC 16K 146 x 215 mm"
+msgstr "PRC 16K 146 x 215 mm"
+
+#: ../src/common/paper.cpp:163
+msgid "PRC 32K 97 x 151 mm"
+msgstr "PRC 32K 97 x 151 mm"
+
+#: ../src/common/paper.cpp:164
+msgid "PRC 32K(Big) 97 x 151 mm"
+msgstr "Format PRC 32K (Large), 97 x 151 mm"
+
+#: ../src/common/paper.cpp:165
+msgid "PRC Envelope #1 102 x 165 mm"
+msgstr "Enveloppe PRC n. 1, 102 x 165 mm"
+
+#: ../src/common/paper.cpp:166
+msgid "PRC Envelope #2 102 x 176 mm"
+msgstr "Enveloppe PRC n. 2, 102 x 176 mm"
+
+#: ../src/common/paper.cpp:167
+msgid "PRC Envelope #3 125 x 176 mm"
+msgstr "Enveloppe PRC n. 3, 125 x 176 mm"
+
+#: ../src/common/paper.cpp:168
+msgid "PRC Envelope #4 110 x 208 mm"
+msgstr "Enveloppe PRC n. 4, 110 x 208 mm"
+
+#: ../src/common/paper.cpp:169
+msgid "PRC Envelope #5 110 x 220 mm"
+msgstr "Enveloppe PRC n. 5, 110 x 220 mm"
+
+#: ../src/common/paper.cpp:170
+msgid "PRC Envelope #6 120 x 230 mm"
+msgstr "Enveloppe PRC n. 6, 120 x 230 mm"
+
+#: ../src/common/paper.cpp:171
+msgid "PRC Envelope #7 160 x 230 mm"
+msgstr "Enveloppe PRC n. 7, 160 x 230 mm"
+
+#: ../src/common/paper.cpp:172
+msgid "PRC Envelope #8 120 x 309 mm"
+msgstr "Enveloppe PRC n. 8, 120 x 309 mm"
+
+#: ../src/common/paper.cpp:173
+msgid "PRC Envelope #9 229 x 324 mm"
+msgstr "Enveloppe PRC n. 9, 229 x 324 mm"
+
+#: ../src/common/paper.cpp:174
+msgid "PRC Envelope #10 324 x 458 mm"
+msgstr "Enveloppe PRC n. 10, 324 x 458 mm"
+
+#: ../src/common/paper.cpp:175
+msgid "PRC 16K Rotated"
+msgstr "PRC 16K Paysage"
+
+#: ../src/common/paper.cpp:176
+msgid "PRC 32K Rotated"
+msgstr "PRC 32K Paysage"
+
+#: ../src/common/paper.cpp:177
+msgid "PRC 32K(Big) Rotated"
+msgstr "Format PRC 32K (Large), Paysage"
+
+#: ../src/common/paper.cpp:178
+msgid "PRC Envelope #1 Rotated 165 x 102 mm"
+msgstr "Enveloppe PRC n. 1, Paysage, 165 x 102 mm"
+
+#: ../src/common/paper.cpp:179
+msgid "PRC Envelope #2 Rotated 176 x 102 mm"
+msgstr "Enveloppe PRC n. 2, Paysage, 176 x 102 mm"
+
+#: ../src/common/paper.cpp:180
+msgid "PRC Envelope #3 Rotated 176 x 125 mm"
+msgstr "Enveloppe PRC n. 3, Paysage, 176 x 125 mm"
+
+#: ../src/common/paper.cpp:181
+msgid "PRC Envelope #4 Rotated 208 x 110 mm"
+msgstr "Enveloppe PRC n. 4, Paysage, 208 x 110 mm"
+
+#: ../src/common/paper.cpp:182
+msgid "PRC Envelope #5 Rotated 220 x 110 mm"
+msgstr "Enveloppe PRC n. 5, Paysage, 220 x 110 mm"
+
+#: ../src/common/paper.cpp:183
+msgid "PRC Envelope #6 Rotated 230 x 120 mm"
+msgstr "Enveloppe PRC n. 6, Paysage, 230 x 120 mm"
+
+#: ../src/common/paper.cpp:184
+msgid "PRC Envelope #7 Rotated 230 x 160 mm"
+msgstr "Enveloppe PRC n. 7, Paysage, 230 x 160 mm"
+
+#: ../src/common/paper.cpp:185
+msgid "PRC Envelope #8 Rotated 309 x 120 mm"
+msgstr "Enveloppe PRC n. 8, Paysage, 309 x 120 mm"
+
+#: ../src/common/paper.cpp:186
+msgid "PRC Envelope #9 Rotated 324 x 229 mm"
+msgstr "Enveloppe PRC n. 9, Paysage, 324 x 229 mm"
+
+#: ../src/common/paper.cpp:187
+msgid "PRC Envelope #10 Rotated 458 x 324 mm"
+msgstr "Enveloppe PRC n. 10, Paysage, 458 x 324 mm"
+
+#: ../src/common/paper.cpp:192
+msgid "A0 sheet, 841 x 1189 mm"
+msgstr "Feuille A0, 841 x 1189 mm"
+
+#: ../src/common/paper.cpp:193
+msgid "A1 sheet, 594 x 841 mm"
+msgstr "Feuille A1, 594 x 841 mm"
+
+#: ../src/common/preferencescmn.cpp:37
+msgid "General"
+msgstr "Général"
+
+#: ../src/common/preferencescmn.cpp:40
+msgid "Advanced"
+msgstr "Avancé"
+
+#: ../src/common/prntbase.cpp:245
+msgid "Generic PostScript"
+msgstr "Fichier PostScript"
+
+#: ../src/common/prntbase.cpp:259
+msgid "Ready"
+msgstr "Prêt"
+
+#: ../src/common/prntbase.cpp:331
+msgid "Printing Error"
+msgstr "Erreur d'impression"
+
+#: ../src/common/prntbase.cpp:413 ../src/common/prntbase.cpp:1597
+#: ../src/generic/prntdlgg.cpp:135 ../src/generic/prntdlgg.cpp:149
+#: ../src/gtk/print.cpp:628 ../src/gtk/print.cpp:646
+msgid "Print"
+msgstr "Imprimer"
+
+#: ../src/common/prntbase.cpp:471 ../src/generic/prntdlgg.cpp:809
+msgid "Page setup"
+msgstr "Mise en page"
+
+#: ../src/common/prntbase.cpp:525
+msgid "Please wait while printing..."
+msgstr "Impression en cours..."
+
+#: ../src/common/prntbase.cpp:529
+msgid "Document:"
+msgstr "Document :"
+
+#: ../src/common/prntbase.cpp:532
+msgid "Progress:"
+msgstr "Progression :"
+
+#: ../src/common/prntbase.cpp:533
+msgid "Preparing"
+msgstr "Préparation"
+
+#: ../src/common/prntbase.cpp:552
+#, c-format
+msgid "Printing page %d"
+msgstr "Impression de la page %d"
+
+#: ../src/common/prntbase.cpp:557
+#, c-format
+msgid "Printing page %d of %d"
+msgstr "Impression de la page %d sur %d"
+
+#: ../src/common/prntbase.cpp:560
+#, c-format
+msgid " (copy %d of %d)"
+msgstr " (copie %d sur %d)"
+
+#: ../src/common/prntbase.cpp:1604
+msgid "First page"
+msgstr "Première page"
+
+#: ../src/common/prntbase.cpp:1609 ../src/html/helpwnd.cpp:659
+msgid "Previous page"
+msgstr "Page précédente"
+
+#: ../src/common/prntbase.cpp:1623 ../src/html/helpwnd.cpp:660
+msgid "Next page"
+msgstr "Page suivante"
+
+#: ../src/common/prntbase.cpp:1628
+msgid "Last page"
+msgstr "Dernière page"
+
+#: ../src/common/prntbase.cpp:1636 ../src/common/stockitem.cpp:215
+msgid "Zoom Out"
+msgstr "Zoom Arrière"
+
+#: ../src/common/prntbase.cpp:1650 ../src/common/stockitem.cpp:214
+msgid "Zoom In"
+msgstr "Zoom Avant"
+
+#: ../src/common/prntbase.cpp:1656 ../src/common/stockitem.cpp:153
+#: ../src/generic/logg.cpp:553 ../src/univ/themes/win32.cpp:3752
+msgid "&Close"
+msgstr "&Fermer"
+
+#: ../src/common/prntbase.cpp:2085
+msgid "Could not start document preview."
+msgstr "Impossible de lancer l'aperçu du document."
+
+#: ../src/common/prntbase.cpp:2085 ../src/common/prntbase.cpp:2129
+#: ../src/common/prntbase.cpp:2137
+msgid "Print Preview Failure"
+msgstr "Erreur de l'aperçu avant impression"
+
+#: ../src/common/prntbase.cpp:2129 ../src/common/prntbase.cpp:2137
+msgid "Sorry, not enough memory to create a preview."
+msgstr "Mémoire insuffisante pour créer un aperçu."
+
+#: ../src/common/prntbase.cpp:2144
+#, c-format
+msgid "Page %d of %d"
+msgstr "Page %d de %d"
+
+#: ../src/common/prntbase.cpp:2146
+#, c-format
+msgid "Page %d"
+msgstr "Page %d"
+
+#: ../src/common/regex.cpp:382 ../src/html/chm.cpp:348
+msgid "unknown error"
+msgstr "erreur inconnue"
+
+#: ../src/common/regex.cpp:995
+#, c-format
+msgid "Invalid regular expression '%s': %s"
+msgstr "Expression rationnelle « %s » non valable : %s"
+
+#: ../src/common/regex.cpp:1059
+#, c-format
+msgid "Failed to find match for regular expression: %s"
+msgstr ""
+"Aucune correspondance pour l'expression régulière « %s » n'a été trouvée"
+
+#: ../src/common/rendcmn.cpp:188
+#, c-format
+msgid "Renderer \"%s\" has incompatible version %d.%d and couldn't be loaded."
+msgstr ""
+"Le moteur de rendu « %s » a une version %d.%d incompatible et n'a pas pu "
+"être chargé."
+
+#: ../src/common/secretstore.cpp:162
+msgid "Not available for this platform"
+msgstr "Non disponible sur cette plateforme"
+
+#: ../src/common/secretstore.cpp:183
+#, c-format
+msgid "Saving password for \"%s\" failed: %s."
+msgstr "Enregistrement de mot de passe pour \"%s\" en erreur : %s."
+
+#: ../src/common/secretstore.cpp:205
+#, c-format
+msgid "Reading password for \"%s\" failed: %s."
+msgstr "Lecture de mot de passe pour \"%s\" en erreur : %s."
+
+#: ../src/common/secretstore.cpp:228
+#, c-format
+msgid "Deleting password for \"%s\" failed: %s."
+msgstr "Suppression du mot de passe pour \"%s\" en erreur : %s."
+
+#: ../src/common/selectdispatcher.cpp:254
+msgid "Failed to monitor I/O channels"
+msgstr "Impossible de contrôler les canaux d'E/S"
+
+#: ../src/common/sizer.cpp:3054 ../src/common/stockitem.cpp:195
+msgid "Save"
+msgstr "Enregistrer"
+
+#: ../src/common/sizer.cpp:3056
+msgid "Don't Save"
+msgstr "Ne pas enregistrer"
+
+#: ../src/common/socket.cpp:870
+msgid "Cannot initialize sockets"
+msgstr "Impossible d'initialiser les sockets"
+
+#: ../src/common/stockitem.cpp:127
+msgctxt "standard Windows menu"
+msgid "&Help"
+msgstr "&Aide"
+
+#: ../src/common/stockitem.cpp:144
+msgid "&About"
+msgstr "À &propos"
+
+#: ../src/common/stockitem.cpp:144
+msgid "About"
+msgstr "À propos"
+
+#: ../src/common/stockitem.cpp:145
+msgid "Add"
+msgstr "Ajouter"
+
+#: ../src/common/stockitem.cpp:146
+msgid "&Apply"
+msgstr "&Appliquer"
+
+#: ../src/common/stockitem.cpp:146
+msgid "Apply"
+msgstr "Appliquer"
+
+#: ../src/common/stockitem.cpp:147
+msgid "&Back"
+msgstr "&Retour"
+
+#: ../src/common/stockitem.cpp:147
+msgid "Back"
+msgstr "Retour"
+
+#: ../src/common/stockitem.cpp:148
+msgid "&Bold"
+msgstr "&Gras"
+
+#: ../src/common/stockitem.cpp:148 ../src/generic/fontdlgg.cpp:326
+#: ../src/richtext/richtextfontpage.cpp:354
+msgid "Bold"
+msgstr "Gras"
+
+#: ../src/common/stockitem.cpp:149
+msgid "&Bottom"
+msgstr "&Bas"
+
+#: ../src/common/stockitem.cpp:149 ../src/richtext/richtextsizepage.cpp:287
+msgid "Bottom"
+msgstr "Bas"
+
+#: ../src/common/stockitem.cpp:150 ../src/generic/fontdlgg.cpp:462
+#: ../src/generic/fontdlgg.cpp:481 ../src/generic/wizard.cpp:415
+msgid "&Cancel"
+msgstr "&Annuler"
+
+#: ../src/common/stockitem.cpp:151
+msgid "&CD-ROM"
+msgstr "&CD-ROM"
+
+#: ../src/common/stockitem.cpp:151
+msgid "CD-ROM"
+msgstr "CD-ROM"
+
+#: ../src/common/stockitem.cpp:152
+msgid "&Clear"
+msgstr "&Supprimer"
+
+#: ../src/common/stockitem.cpp:152
+msgid "Clear"
+msgstr "Effacer"
+
+#: ../src/common/stockitem.cpp:153 ../src/generic/dbgrptg.cpp:93
+#: ../src/generic/progdlgg.cpp:778 ../src/html/helpdlg.cpp:86
+#: ../src/msw/progdlg.cpp:209 ../src/msw/progdlg.cpp:890
+#: ../src/richtext/richtextstyledlg.cpp:272
+#: ../src/richtext/richtextsymboldlg.cpp:448
+msgid "Close"
+msgstr "Fermer"
+
+#: ../src/common/stockitem.cpp:154
+msgid "&Convert"
+msgstr "&Convertir"
+
+#: ../src/common/stockitem.cpp:154
+msgid "Convert"
+msgstr "Convertir"
+
+#: ../src/common/stockitem.cpp:155 ../src/msw/textctrl.cpp:2884
+#: ../src/osx/textctrl_osx.cpp:653 ../src/richtext/richtextctrl.cpp:331
+msgid "&Copy"
+msgstr "&Copier"
+
+#: ../src/common/stockitem.cpp:155 ../src/stc/stc_i18n.cpp:18
+msgid "Copy"
+msgstr "Copier"
+
+#: ../src/common/stockitem.cpp:156 ../src/msw/textctrl.cpp:2883
+#: ../src/osx/textctrl_osx.cpp:652 ../src/richtext/richtextctrl.cpp:330
+msgid "Cu&t"
+msgstr "Cou&per"
+
+#: ../src/common/stockitem.cpp:156 ../src/stc/stc_i18n.cpp:17
+msgid "Cut"
+msgstr "Couper"
+
+#: ../src/common/stockitem.cpp:157 ../src/msw/textctrl.cpp:2886
+#: ../src/osx/textctrl_osx.cpp:655 ../src/richtext/richtextctrl.cpp:333
+#: ../src/richtext/richtexttabspage.cpp:137
+msgid "&Delete"
+msgstr "&Supprimer"
+
+#: ../src/common/stockitem.cpp:157 ../src/richtext/richtextbuffer.cpp:8266
+#: ../src/stc/stc_i18n.cpp:20
+msgid "Delete"
+msgstr "Supprimer"
+
+#: ../src/common/stockitem.cpp:158
+msgid "&Down"
+msgstr "&Bas"
+
+#: ../src/common/stockitem.cpp:158 ../src/generic/fdrepdlg.cpp:148
+msgid "Down"
+msgstr "Bas"
+
+#: ../src/common/stockitem.cpp:159
+msgid "&Edit"
+msgstr "&Edition"
+
+#: ../src/common/stockitem.cpp:159
+msgid "Edit"
+msgstr "Édition"
+
+#: ../src/common/stockitem.cpp:160
+msgid "&Execute"
+msgstr "&Exécuter"
+
+#: ../src/common/stockitem.cpp:160
+msgid "Execute"
+msgstr "Exécuter"
+
+#: ../src/common/stockitem.cpp:161
+msgid "&Quit"
+msgstr "&Quitter"
+
+#: ../src/common/stockitem.cpp:161
+msgid "Quit"
+msgstr "Quitter"
+
+#: ../src/common/stockitem.cpp:162
+msgid "&File"
+msgstr "&Fichier"
+
+#: ../src/common/stockitem.cpp:162
+msgid "File"
+msgstr "Fichier"
+
+#: ../src/common/stockitem.cpp:163
+msgid "&Find..."
+msgstr "&Rechercher..."
+
+#: ../src/common/stockitem.cpp:163
+msgid "Find..."
+msgstr "Rechercher..."
+
+#: ../src/common/stockitem.cpp:164
+msgid "&First"
+msgstr "&Premier"
+
+#: ../src/common/stockitem.cpp:164
+msgid "First"
+msgstr "Premier"
+
+#: ../src/common/stockitem.cpp:165
+msgid "&Floppy"
+msgstr "&Disquette"
+
+#: ../src/common/stockitem.cpp:165
+msgid "Floppy"
+msgstr "Disquette"
+
+#: ../src/common/stockitem.cpp:166
+msgid "&Forward"
+msgstr "&Suivant"
+
+#: ../src/common/stockitem.cpp:166
+msgid "Forward"
+msgstr "Suivant"
+
+#: ../src/common/stockitem.cpp:167
+msgid "&Harddisk"
+msgstr "&Disque dur"
+
+#: ../src/common/stockitem.cpp:167
+msgid "Harddisk"
+msgstr "Disque dur"
+
+#: ../src/common/stockitem.cpp:168 ../src/generic/wizard.cpp:418
+#: ../src/osx/cocoa/menu.mm:225 ../src/richtext/richtextstyledlg.cpp:298
+#: ../src/richtext/richtextsymboldlg.cpp:451
+msgid "&Help"
+msgstr "&Aide"
+
+#: ../src/common/stockitem.cpp:169
+msgid "&Home"
+msgstr "&Dossier personnel"
+
+#: ../src/common/stockitem.cpp:169
+msgid "Home"
+msgstr "Dossier personnel"
+
+#: ../src/common/stockitem.cpp:170
+msgid "Indent"
+msgstr "Indenter"
+
+#: ../src/common/stockitem.cpp:171
+msgid "&Index"
+msgstr "&Index"
+
+#: ../src/common/stockitem.cpp:171 ../src/html/helpwnd.cpp:510
+msgid "Index"
+msgstr "Index"
+
+#: ../src/common/stockitem.cpp:172
+msgid "&Info"
+msgstr "&Info"
+
+#: ../src/common/stockitem.cpp:172
+msgid "Info"
+msgstr "Infos"
+
+#: ../src/common/stockitem.cpp:173
+msgid "&Italic"
+msgstr "&Italique"
+
+#: ../src/common/stockitem.cpp:173 ../src/generic/fontdlgg.cpp:322
+#: ../src/richtext/richtextfontpage.cpp:350
+msgid "Italic"
+msgstr "Italique"
+
+#: ../src/common/stockitem.cpp:174
+msgid "&Jump to"
+msgstr "&Aller à"
+
+#: ../src/common/stockitem.cpp:174
+msgid "Jump to"
+msgstr "Aller à"
+
+#: ../src/common/stockitem.cpp:175
+msgid "Centered"
+msgstr "Centré"
+
+#: ../src/common/stockitem.cpp:176
+msgid "Justified"
+msgstr "Justifié"
+
+#: ../src/common/stockitem.cpp:177
+msgid "Align Left"
+msgstr "Aligner à gauche"
+
+#: ../src/common/stockitem.cpp:178
+msgid "Align Right"
+msgstr "Aligner à droite"
+
+#: ../src/common/stockitem.cpp:179
+msgid "&Last"
+msgstr "&Dernier"
+
+#: ../src/common/stockitem.cpp:179
+msgid "Last"
+msgstr "Dernier"
+
+#: ../src/common/stockitem.cpp:180
+msgid "&Network"
+msgstr "&Reseau"
+
+#: ../src/common/stockitem.cpp:180
+msgid "Network"
+msgstr "Réseau"
+
+#: ../src/common/stockitem.cpp:181 ../src/richtext/richtexttabspage.cpp:131
+msgid "&New"
+msgstr "&Nouveau"
+
+#: ../src/common/stockitem.cpp:181
+msgid "New"
+msgstr "Nouveau"
+
+#: ../src/common/stockitem.cpp:182 ../src/msw/msgdlg.cpp:417
+msgid "&No"
+msgstr "&Non"
+
+#: ../src/common/stockitem.cpp:183 ../src/generic/fontdlgg.cpp:467
+#: ../src/generic/fontdlgg.cpp:474
+msgid "&OK"
+msgstr "&Accepter"
+
+#: ../src/common/stockitem.cpp:184 ../src/generic/dbgrptg.cpp:341
+msgid "&Open..."
+msgstr "&Ouvrir..."
+
+#: ../src/common/stockitem.cpp:184
+msgid "Open..."
+msgstr "Ouvrir..."
+
+#: ../src/common/stockitem.cpp:185 ../src/msw/textctrl.cpp:2885
+#: ../src/osx/textctrl_osx.cpp:654 ../src/richtext/richtextctrl.cpp:332
+msgid "&Paste"
+msgstr "&Coller"
+
+#: ../src/common/stockitem.cpp:185 ../src/richtext/richtextctrl.cpp:3484
+#: ../src/stc/stc_i18n.cpp:19
+msgid "Paste"
+msgstr "Coller"
+
+#: ../src/common/stockitem.cpp:186
+msgid "&Preferences"
+msgstr "&Préférences"
+
+#: ../src/common/stockitem.cpp:186 ../src/osx/cocoa/preferences.mm:304
+msgid "Preferences"
+msgstr "Préférences"
+
+#: ../src/common/stockitem.cpp:187
+msgid "Print previe&w..."
+msgstr "&Aperçu avant impression..."
+
+#: ../src/common/stockitem.cpp:187
+msgid "Print preview..."
+msgstr "Aperçu avant impression..."
+
+#: ../src/common/stockitem.cpp:188
+msgid "&Print..."
+msgstr "&Imprimer..."
+
+#: ../src/common/stockitem.cpp:188
+msgid "Print..."
+msgstr "&Imprimer..."
+
+#: ../src/common/stockitem.cpp:189 ../src/richtext/richtextctrl.cpp:337
+#: ../src/richtext/richtextctrl.cpp:5479
+msgid "&Properties"
+msgstr "&Propriétés"
+
+#: ../src/common/stockitem.cpp:189
+msgid "Properties"
+msgstr "Propriétés"
+
+#: ../src/common/stockitem.cpp:190 ../src/stc/stc_i18n.cpp:16
+msgid "Redo"
+msgstr "Refaire"
+
+#: ../src/common/stockitem.cpp:191
+msgid "Refresh"
+msgstr "Actualiser"
+
+#: ../src/common/stockitem.cpp:192
+msgid "Remove"
+msgstr "Supprimer"
+
+#: ../src/common/stockitem.cpp:193
+msgid "Rep&lace..."
+msgstr "Remp&lacer..."
+
+#: ../src/common/stockitem.cpp:193
+msgid "Replace..."
+msgstr "Remplacer..."
+
+#: ../src/common/stockitem.cpp:194
+msgid "Revert to Saved"
+msgstr "Changer en enregistré"
+
+#: ../src/common/stockitem.cpp:196 ../src/generic/logg.cpp:549
+msgid "Save &As..."
+msgstr "Enregistrer &sous..."
+
+#: ../src/common/stockitem.cpp:196
+msgid "Save As..."
+msgstr "Enregistrer sous..."
+
+#: ../src/common/stockitem.cpp:197 ../src/msw/textctrl.cpp:2888
+#: ../src/osx/textctrl_osx.cpp:657 ../src/richtext/richtextctrl.cpp:335
+msgid "Select &All"
+msgstr "&Tout sélectionner"
+
+#: ../src/common/stockitem.cpp:197 ../src/stc/stc_i18n.cpp:21
+msgid "Select All"
+msgstr "Tout sélectionner"
+
+#: ../src/common/stockitem.cpp:198
+msgid "&Color"
+msgstr "&Couleur"
+
+#: ../src/common/stockitem.cpp:198
+msgid "Color"
+msgstr "Couleur"
+
+#: ../src/common/stockitem.cpp:199
+msgid "&Font"
+msgstr "&Police"
+
+#: ../src/common/stockitem.cpp:199 ../src/richtext/richtextformatdlg.cpp:336
+msgid "Font"
+msgstr "Police de caractères"
+
+#: ../src/common/stockitem.cpp:200
+msgid "&Ascending"
+msgstr "Croiss&ant"
+
+#: ../src/common/stockitem.cpp:200
+msgid "Ascending"
+msgstr "Croissant"
+
+#: ../src/common/stockitem.cpp:201
+msgid "&Descending"
+msgstr "&Décroissant"
+
+#: ../src/common/stockitem.cpp:201
+msgid "Descending"
+msgstr "Décroissant"
+
+#: ../src/common/stockitem.cpp:202
+msgid "&Spell Check"
+msgstr "&Vérification Orthographique"
+
+#: ../src/common/stockitem.cpp:202
+msgid "Spell Check"
+msgstr "Vérification Orthographique"
+
+#: ../src/common/stockitem.cpp:203
+msgid "&Stop"
+msgstr "&Arrêter"
+
+#: ../src/common/stockitem.cpp:203
+msgid "Stop"
+msgstr "Arrêter"
+
+#: ../src/common/stockitem.cpp:204 ../src/richtext/richtextfontpage.cpp:274
+msgid "&Strikethrough"
+msgstr "&Barré"
+
+#: ../src/common/stockitem.cpp:204
+msgid "Strikethrough"
+msgstr "Barré"
+
+#: ../src/common/stockitem.cpp:205
+msgid "&Top"
+msgstr "Hau&t"
+
+#: ../src/common/stockitem.cpp:205 ../src/richtext/richtextsizepage.cpp:285
+#: ../src/richtext/richtextsizepage.cpp:289
+msgid "Top"
+msgstr "Haut"
+
+#: ../src/common/stockitem.cpp:206
+msgid "Undelete"
+msgstr "Rétablir"
+
+#: ../src/common/stockitem.cpp:207 ../src/generic/fontdlgg.cpp:437
+msgid "&Underline"
+msgstr "&Souligner"
+
+#: ../src/common/stockitem.cpp:207
+msgid "Underline"
+msgstr "Souligner"
+
+#: ../src/common/stockitem.cpp:208 ../src/stc/stc_i18n.cpp:15
+msgid "Undo"
+msgstr "Annuler"
+
+#: ../src/common/stockitem.cpp:209
+msgid "&Unindent"
+msgstr "&Désindenter"
+
+#: ../src/common/stockitem.cpp:209
+msgid "Unindent"
+msgstr "Désindenter"
+
+#: ../src/common/stockitem.cpp:210
+msgid "&Up"
+msgstr "&Haut"
+
+#: ../src/common/stockitem.cpp:210 ../src/generic/fdrepdlg.cpp:148
+msgid "Up"
+msgstr "Haut"
+
+#: ../src/common/stockitem.cpp:211 ../src/msw/msgdlg.cpp:417
+msgid "&Yes"
+msgstr "&Oui"
+
+#: ../src/common/stockitem.cpp:212
+msgid "&Actual Size"
+msgstr "&Taille actuelle"
+
+#: ../src/common/stockitem.cpp:212
+msgid "Actual Size"
+msgstr "Taille Actuelle"
+
+#: ../src/common/stockitem.cpp:213
+msgid "Zoom to &Fit"
+msgstr "Zoom a&justé"
+
+#: ../src/common/stockitem.cpp:213
+msgid "Zoom to Fit"
+msgstr "Zoom Ajusté"
+
+#: ../src/common/stockitem.cpp:214
+msgid "Zoom &In"
+msgstr "Zoom &avant"
+
+#: ../src/common/stockitem.cpp:215
+msgid "Zoom &Out"
+msgstr "Zoom a&rrière"
+
+#: ../src/common/stockitem.cpp:262
+msgid "Show about dialog"
+msgstr "Montrer la fenêtre d'à propos"
+
+#: ../src/common/stockitem.cpp:263
+msgid "Copy selection"
+msgstr "Copier la sélection"
+
+#: ../src/common/stockitem.cpp:264
+msgid "Cut selection"
+msgstr "Couper la sélection"
+
+#: ../src/common/stockitem.cpp:265
+msgid "Delete selection"
+msgstr "Effacer la sélection"
+
+#: ../src/common/stockitem.cpp:266
+msgid "Find in document"
+msgstr "Rechercher dans le document"
+
+#: ../src/common/stockitem.cpp:267
+msgid "Find and replace in document"
+msgstr "Rechercher et remplacer dans le document"
+
+#: ../src/common/stockitem.cpp:268
+msgid "Paste selection"
+msgstr "Coller la sélection"
+
+#: ../src/common/stockitem.cpp:269
+msgid "Quit this program"
+msgstr "Quitter ce programme"
+
+#: ../src/common/stockitem.cpp:270
+msgid "Redo last action"
+msgstr "Exécuter à nouveau la dernière action"
+
+#: ../src/common/stockitem.cpp:271
+msgid "Undo last action"
+msgstr "Annuler la dernière action"
+
+#: ../src/common/stockitem.cpp:272
+msgid "Create new document"
+msgstr "Créer un nouveau document"
+
+#: ../src/common/stockitem.cpp:273
+msgid "Open an existing document"
+msgstr "Ouvrir un document existant"
+
+#: ../src/common/stockitem.cpp:274
+msgid "Close current document"
+msgstr "Fermer le document courant"
+
+#: ../src/common/stockitem.cpp:275
+msgid "Save current document"
+msgstr "Enregistrer le document courant"
+
+#: ../src/common/stockitem.cpp:276
+msgid "Save current document with a different filename"
+msgstr "Enregistrer le document courant avec un nouveau nom"
+
+#: ../src/common/strconv.cpp:2324
+#, c-format
+msgid "Conversion to charset '%s' doesn't work."
+msgstr "La conversion vers le jeu de caractères « %s » ne fonctionne pas."
+
+#: ../src/common/tarstrm.cpp:352 ../src/common/tarstrm.cpp:375
+#: ../src/common/tarstrm.cpp:406 ../src/generic/progdlgg.cpp:373
+msgid "unknown"
+msgstr "inconnu"
+
+#: ../src/common/tarstrm.cpp:774
+msgid "incomplete header block in tar"
+msgstr "le bloc d'entête de tar est incomplet"
+
+#: ../src/common/tarstrm.cpp:798
+msgid "checksum failure reading tar header block"
+msgstr ""
+"erreur de la somme de contrôle lors de la lecture du bloc d'entête de tar"
+
+#: ../src/common/tarstrm.cpp:971
+msgid "invalid data in extended tar header"
+msgstr "donnée incorrectes dans l'entête étendu de tar"
+
+#: ../src/common/tarstrm.cpp:981 ../src/common/tarstrm.cpp:1003
+#: ../src/common/tarstrm.cpp:1477 ../src/common/tarstrm.cpp:1499
+msgid "tar entry not open"
+msgstr "l'entrée tar n'est pas ouverte"
+
+#: ../src/common/tarstrm.cpp:1023
+msgid "unexpected end of file"
+msgstr "fin de fichier inattendue"
+
+#: ../src/common/tarstrm.cpp:1297
+#, c-format
+msgid "%s did not fit the tar header for entry '%s'"
+msgstr "%s ne rentre pas dans l'entête tar pour l'entrée « %s »"
+
+#: ../src/common/tarstrm.cpp:1359
+msgid "incorrect size given for tar entry"
+msgstr "la taille fournie pour l'entrée tar est incorrecte"
+
+#: ../src/common/textbuf.cpp:232
+#, c-format
+msgid "'%s' is probably a binary buffer."
+msgstr "« %s » est probablement un tampon binaire."
+
+#: ../src/common/textcmn.cpp:1006 ../src/richtext/richtextctrl.cpp:3053
+msgid "File couldn't be loaded."
+msgstr "Le fichier n'a pas pu être chargé."
+
+#: ../src/common/textfile.cpp:95
+#, c-format
+msgid "Failed to read text file \"%s\"."
+msgstr "Échec de la lecture du fichier texte \"%s\"."
+
+#: ../src/common/textfile.cpp:160
+#, c-format
+msgid "can't write buffer '%s' to disk."
+msgstr "impossible d'écrire le tampon « %s » sur le disque."
+
+#: ../src/common/time.cpp:212
+msgid "Failed to get the local system time"
+msgstr "Échec de l'obtention de l'heure locale du système"
+
+#: ../src/common/time.cpp:279
+msgid "wxGetTimeOfDay failed."
+msgstr "wxGetTimeOfDay a échoué."
+
+#: ../src/common/translation.cpp:929
+#, c-format
+msgid "'%s' is not a valid message catalog."
+msgstr "« %s » n'est pas un catalogue valable de messages."
+
+#: ../src/common/translation.cpp:954
+msgid "Invalid message catalog."
+msgstr "Catalogue de message non valable."
+
+#: ../src/common/translation.cpp:1013
+#, c-format
+msgid "Failed to parse Plural-Forms: '%s'"
+msgstr "Écher de l'analyse des formes plurielles  : « %s »"
+
+#: ../src/common/translation.cpp:1723
+#, c-format
+msgid "using catalog '%s' from '%s'."
+msgstr "utilisation du catalogue « %s » de « %s »."
+
+#: ../src/common/translation.cpp:1816
+#, c-format
+msgid "Resource '%s' is not a valid message catalog."
+msgstr "La ressource « %s » n'est pas un catalogue messages valable."
+
+#: ../src/common/translation.cpp:1865
+msgid "Couldn't enumerate translations"
+msgstr "Impossible d'énumérer les traductions"
+
+#: ../src/common/utilscmn.cpp:1145
+msgid "No default application configured for HTML files."
+msgstr "Pas d'application configurée pour les fichiers HTML."
+
+#: ../src/common/utilscmn.cpp:1190
+#, c-format
+msgid "Failed to open URL \"%s\" in default browser."
+msgstr "Échec de l'ouverture de l'URL « %s » avec le navigateur par défaut."
+
+#: ../src/common/valtext.cpp:144
+msgid "Validation conflict"
+msgstr "Conflit de validation"
+
+#: ../src/common/valtext.cpp:186
+msgid "Required information entry is empty."
+msgstr "L'entrée d'information requise est vide."
+
+#: ../src/common/valtext.cpp:188
+#, c-format
+msgid "'%s' is one of the invalid strings"
+msgstr "« %s » est l'une des chaînes non valables"
+
+#: ../src/common/valtext.cpp:190
+#, c-format
+msgid "'%s' is not one of the valid strings"
+msgstr "« %s » n'est pas l'une des chaînes non valables"
+
+#: ../src/common/valtext.cpp:199
+#, c-format
+msgid "'%s' contains invalid character(s)"
+msgstr "'%s' contient un(des) caractère(s) invalide(s)"
+
+#: ../src/common/webrequest.cpp:139
+#, c-format
+msgid "Error: %s (%d)"
+msgstr "Erreur : %s (%d)"
+
+#: ../src/common/webrequest.cpp:655
+#, c-format
+msgid ""
+"Not enough free disk space for download: %llu needed but only %llu available."
+msgstr "Pas assez d'espace disque libre pour le téléchargement : %llu requis mais seulement %llu disponible."
+
+#: ../src/common/webrequest.cpp:669
+#, c-format
+msgid "Failed to create temporary file in %s"
+msgstr "Échec de la création d'un fichier temporaire dans %s"
+
+#: ../src/common/webrequest_curl.cpp:1106
+msgid "libcurl could not be initialized"
+msgstr "libcurl n'a pas pu être initialisé"
+
+#: ../src/common/webview.cpp:392
+msgid "RunScriptAsync not supported"
+msgstr "RunScriptAsync non supporté"
+
+#: ../src/common/webview.cpp:403 ../src/msw/webview_ie.cpp:1073
+#, c-format
+msgid "Error running JavaScript: %s"
+msgstr "Erreur à l'exécution du JavaScript : %s"
+
+#: ../src/common/webview_chromium.cpp:858
+#, c-format
+msgid "Failed to set proxy \"%s\": %s"
+msgstr "Échec de la définition du proxy « %s » : %s"
+
+#: ../src/common/webview_chromium.cpp:989
+msgid ""
+"Chromium can't be used because libcef.so wasn't loaded early enough; please "
+"relink the application or use LD_PRELOAD to load it earlier."
+msgstr ""
+"Chromium ne peut pas être utilisé car libcef.so n'a pas été chargé assez "
+"tôt ; veuillez relier l'application ou utiliser LD_PRELOAD pour le charger "
+"plus tôt."
+
+#: ../src/common/webview_chromium.cpp:1108
+msgid "Could not initialize Chromium"
+msgstr "Impossible d'initialiser Chromium"
+
+#: ../src/common/webview_chromium.cpp:1616
+msgid "Show DevTools"
+msgstr "Afficher DevTools"
+
+#: ../src/common/webview_chromium.cpp:1617
+msgid "Close DevTools"
+msgstr "Fermer DevTools"
+
+#: ../src/common/webview_chromium.cpp:1623
+msgid "Inspect"
+msgstr "Inspecter"
+
+#: ../src/common/wincmn.cpp:1628
+msgid "This platform does not support background transparency."
+msgstr "Cette plateforme ne supporte pas la transparence d'arrière plan."
+
+#: ../src/common/wincmn.cpp:2097
+msgid "Could not transfer data to window"
+msgstr "Impossible de transférer les données à la fenêtre"
+
+#: ../src/common/windowid.cpp:240
+msgid "Out of window IDs.  Recommend shutting down application."
+msgstr "Plus d'IDs de fenêtre. Il est recommandé de fermer l'application."
+
+#: ../src/common/xpmdecod.cpp:678
+msgid "XPM: incorrect header format!"
+msgstr "XPM : format de l'entête incorrect !"
+
+#: ../src/common/xpmdecod.cpp:703
+#, c-format
+msgid "XPM: incorrect colour description in line %d"
+msgstr "XPM : définition de couleur incorrecte à la ligne %d"
+
+#: ../src/common/xpmdecod.cpp:715 ../src/common/xpmdecod.cpp:724
+#, c-format
+msgid "XPM: malformed colour definition '%s' at line %d!"
+msgstr "XPM : définition de couleur « %s » malformée à la ligne %d !"
+
+#: ../src/common/xpmdecod.cpp:754
+msgid "XPM: no colors left to use for mask!"
+msgstr "XPM : pas de couleur restant à utiliser comme masque !"
+
+#: ../src/common/xpmdecod.cpp:781
+#, c-format
+msgid "XPM: truncated image data at line %d!"
+msgstr "XPM : les données de l'image sont tronquées à la ligne %d !"
+
+#: ../src/common/xpmdecod.cpp:795
+msgid "XPM: Malformed pixel data!"
+msgstr "XPM : données de pixel malformées !"
+
+#: ../src/common/xti.cpp:492
+msgid "Illegal Parameter Count for Create Method"
+msgstr "Nombre de paramètres illégal pour la méthode Create"
+
+#: ../src/common/xti.cpp:504
+msgid "Illegal Parameter Count for ConstructObject Method"
+msgstr "Nombre de paramètres illégal pour la méthode ConstructObject"
+
+#: ../src/common/xtistrm.cpp:161
+#, c-format
+msgid "Create Parameter %s not found in declared RTTI Parameters"
+msgstr "Paramètre de création %s non trouvé dans les Paramètres RTTI déclarés"
+
+#: ../src/common/xtistrm.cpp:290
+msgid "Illegal Object Class (Non-wxEvtHandler) as Event Source"
+msgstr ""
+"Classe d'objet non valable en tant que source d'événement (Non-wxEvtHandler)"
+
+#: ../src/common/xtistrm.cpp:313 ../src/common/xtixml.cpp:345
+#: ../src/common/xtixml.cpp:498
+msgid "Type must have enum - long conversion"
+msgstr "Le type doit être énumérable - conversion longue"
+
+#: ../src/common/xtistrm.cpp:400 ../src/common/xtistrm.cpp:415
+msgid "Invalid or Null Object ID passed to GetObjectClassInfo"
+msgstr "Identifiant d'objet non valable ou vide indiqué à GetObjectClassInfo"
+
+#: ../src/common/xtistrm.cpp:405
+msgid "Unknown Object passed to GetObjectClassInfo"
+msgstr "Objet inconnu indiqué à GetObjectClassInfo"
+
+#: ../src/common/xtistrm.cpp:420
+msgid "Already Registered Object passed to SetObjectClassInfo"
+msgstr "Objet déjà enregistré envoyé à SetObjectClassInfo"
+
+#: ../src/common/xtistrm.cpp:430
+msgid "Invalid or Null Object ID passed to HasObjectClassInfo"
+msgstr "Identifiant d'objet non valable ou vide indiqué à HasObjectClassInfo"
+
+#: ../src/common/xtistrm.cpp:460
+msgid "Passing a already registered object to SetObject"
+msgstr "Objet déjà enregistré indiqué à SetObject"
+
+#: ../src/common/xtistrm.cpp:471
+msgid "Passing an unknown object to GetObject"
+msgstr "Objet inconnu passé à GetObject"
+
+#: ../src/common/xtixml.cpp:229
+msgid "Forward hrefs are not supported"
+msgstr "Transferts href non reconnus"
+
+#: ../src/common/xtixml.cpp:247
+#, c-format
+msgid "unknown class %s"
+msgstr "classe « %s » inconnue"
+
+#: ../src/common/xtixml.cpp:253
+msgid "objects cannot have XML Text Nodes"
+msgstr "les objets ne peuvent pas avoir de noeuds texte XML"
+
+#: ../src/common/xtixml.cpp:258
+msgid "Objects must have an id attribute"
+msgstr "Les objets doivent avoir un attribut id"
+
+#: ../src/common/xtixml.cpp:267
+#, c-format
+msgid "Doubly used id : %d"
+msgstr "Identifiant utilisé deux fois : %d"
+
+#: ../src/common/xtixml.cpp:316
+#, c-format
+msgid "Unknown Property %s"
+msgstr "Propriété « %s » inconnue"
+
+#: ../src/common/xtixml.cpp:407
+msgid "A non empty collection must consist of 'element' nodes"
+msgstr "Une collection non vide doit comprendre des noeuds « éléments »"
+
+#: ../src/common/xtixml.cpp:478
+msgid "incorrect event handler string, missing dot"
+msgstr "chaîne de gestion des événements non valable, point manquant"
+
+#: ../src/common/zipstrm.cpp:559
+msgid "can't re-initialize zlib deflate stream"
+msgstr "impossible de réinitialiser le flux de déchargement de zlib"
+
+#: ../src/common/zipstrm.cpp:584
+msgid "can't re-initialize zlib inflate stream"
+msgstr "impossible de réinitialiser le flux de chargement de zlib"
+
+#: ../src/common/zipstrm.cpp:1023
+msgid "Ignoring malformed extra data record, ZIP file may be corrupted"
+msgstr ""
+"Ignorant l'enregistrement mal formé de données supplémentaires, le fichier "
+"ZIP peut être corrompu"
+
+#: ../src/common/zipstrm.cpp:1502
+msgid "assuming this is a multi-part zip concatenated"
+msgstr "suppose qu'il s'agit d'un zip recombiné"
+
+#: ../src/common/zipstrm.cpp:1664
+msgid "invalid zip file"
+msgstr "fichier zip non valable"
+
+#: ../src/common/zipstrm.cpp:1723
+msgid "can't find central directory in zip"
+msgstr "impossible de trouver le répertoire principale dans le zip"
+
+#: ../src/common/zipstrm.cpp:1812
+msgid "error reading zip central directory"
+msgstr "erreur à la lecture du répertoire principale du zip"
+
+#: ../src/common/zipstrm.cpp:1916
+msgid "error reading zip local header"
+msgstr "erreur à la lecture de l'en-tête local du zip"
+
+#: ../src/common/zipstrm.cpp:1964
+msgid "bad zipfile offset to entry"
+msgstr "mauvais décalage de fichier zip dans l'entrée"
+
+#: ../src/common/zipstrm.cpp:2031
+msgid "stored file length not in Zip header"
+msgstr "longueur du fichier enregistré absente de l'entête du Zip"
+
+#: ../src/common/zipstrm.cpp:2045 ../src/common/zipstrm.cpp:2362
+msgid "unsupported Zip compression method"
+msgstr "méthode de compression zip non gérée"
+
+#: ../src/common/zipstrm.cpp:2126
+#, c-format
+msgid "reading zip stream (entry %s): bad length"
+msgstr "lecture du flux zip (entrée %s) : mauvaise longueur"
+
+#: ../src/common/zipstrm.cpp:2131
+#, c-format
+msgid "reading zip stream (entry %s): bad crc"
+msgstr "lecture du flux zip (entrée %s) : mauvaise crc"
+
+#: ../src/common/zipstrm.cpp:2578
+#, c-format
+msgid "error writing zip entry '%s': file too large without ZIP64"
+msgstr ""
+"erreur à l'écriture de l'entrée zip '%s' : fichier trop gros sans ZIP64"
+
+#: ../src/common/zipstrm.cpp:2585
+#, c-format
+msgid "error writing zip entry '%s': bad crc or length"
+msgstr "erreur à l'écriture de l'entrée zip « %s » : mauvaise crc ou longueur"
+
+#: ../src/common/zstream.cpp:155 ../src/common/zstream.cpp:315
+msgid "Gzip not supported by this version of zlib"
+msgstr "Gzip n'est pas géré par cette version de zlib"
+
+#: ../src/common/zstream.cpp:182
+msgid "Can't initialize zlib inflate stream."
+msgstr "Impossible d'initialiser le flux de chargement de zlib."
+
+#: ../src/common/zstream.cpp:241
+msgid "Can't read inflate stream: unexpected EOF in underlying stream."
+msgstr ""
+"Impossible de lire le flux de chargement : EOF inattendu dans le flux "
+"inférieur."
+
+#: ../src/common/zstream.cpp:248 ../src/common/zstream.cpp:423
+#, c-format
+msgid "zlib error %d"
+msgstr "erreur zlib %d"
+
+#: ../src/common/zstream.cpp:249
+#, c-format
+msgid "Can't read from inflate stream: %s"
+msgstr "Impossible de lire le flux de chargement : %s"
+
+#: ../src/common/zstream.cpp:343
+msgid "Can't initialize zlib deflate stream."
+msgstr "Impossible d'initialiser le flux de déchargement de zlib."
+
+#: ../src/common/zstream.cpp:424
+#, c-format
+msgid "Can't write to deflate stream: %s"
+msgstr "Impossible d'écrire pour décharger le flux : %s"
+
+#: ../src/dfb/bitmap.cpp:633 ../src/dfb/bitmap.cpp:667
+#, c-format
+msgid "No bitmap handler for type %d defined."
+msgstr "Aucun gestionnaire d'image défini pour le type %d."
+
+#: ../src/dfb/evtloop.cpp:99
+msgid "Failed to read event from DirectFB pipe"
+msgstr "Échec de la lecture d'évènement depuis un tube (pipe) DirectFB"
+
+#: ../src/dfb/evtloop.cpp:171
+msgid "Failed to switch DirectFB pipe to non-blocking mode"
+msgstr "Échec du basculement du tube (pipe) DirectFB vers le mode non bloquant"
+
+#: ../src/dfb/fontmgr.cpp:171
+#, c-format
+msgid "no fonts found in %s, using builtin font"
+msgstr "aucune police trouvée dans %s, utilisation d'une police interne"
+
+#: ../src/dfb/fontmgr.cpp:177
+msgid "Default font"
+msgstr "Police par défaut"
+
+#: ../src/dfb/fontmgr.cpp:195
+#, c-format
+msgid "Fonts index file %s disappeared while loading fonts."
+msgstr ""
+"Le fichier d'index de polices %s a disparu lors du chargement des polices."
+
+#: ../src/dfb/wrapdfb.cpp:60
+#, c-format
+msgid "DirectFB error %d occurred."
+msgstr "L'erreur DirectFB %d est survenue."
+
+#: ../src/generic/aboutdlgg.cpp:69
+msgid "Developed by "
+msgstr "Développé par "
+
+#: ../src/generic/aboutdlgg.cpp:72
+msgid "Documentation by "
+msgstr "Documentation par "
+
+#: ../src/generic/aboutdlgg.cpp:75
+msgid "Graphics art by "
+msgstr "Graphismes par "
+
+#: ../src/generic/aboutdlgg.cpp:78
+msgid "Translations by "
+msgstr "Traductions par "
+
+#: ../src/generic/aboutdlgg.cpp:133 ../src/osx/cocoa/aboutdlg.mm:83
+msgid "Version "
+msgstr "Version "
+
+#. TRANSLATORS: %s is application name
+#: ../src/generic/aboutdlgg.cpp:146 ../src/msw/aboutdlg.cpp:60
+#, c-format
+msgid "About %s"
+msgstr "À propos de %s"
+
+#: ../src/generic/aboutdlgg.cpp:181
+msgid "License"
+msgstr "Licence"
+
+#: ../src/generic/aboutdlgg.cpp:184
+msgid "Developers"
+msgstr "Développeurs"
+
+#: ../src/generic/aboutdlgg.cpp:188
+msgid "Documentation writers"
+msgstr "Rédacteurs de la documentation"
+
+#: ../src/generic/aboutdlgg.cpp:192
+msgid "Artists"
+msgstr "Artistes"
+
+#: ../src/generic/aboutdlgg.cpp:196
+msgid "Translators"
+msgstr "Traducteurs"
+
+#: ../src/generic/animateg.cpp:125
+msgid "No handler found for animation type."
+msgstr "Aucun gestionnaire trouvé pour le type d'animation."
+
+#: ../src/generic/animateg.cpp:133
+#, c-format
+msgid "No animation handler for type %ld defined."
+msgstr "Aucun gestionnaire d'animation n'est défini pour le type %ld."
+
+#: ../src/generic/animateg.cpp:145
+#, c-format
+msgid "Animation file is not of type %ld."
+msgstr "Le fichier animé n'est pas du type %ld."
+
+#: ../src/generic/colrdlgg.cpp:154 ../src/gtk/colordlg.cpp:47
+msgid "Choose colour"
+msgstr "Choisir la couleur"
+
+#: ../src/generic/colrdlgg.cpp:357
+msgid "Red:"
+msgstr "Rouge :"
+
+#: ../src/generic/colrdlgg.cpp:360
+msgid "Green:"
+msgstr "Vert :"
+
+#: ../src/generic/colrdlgg.cpp:363
+msgid "Blue:"
+msgstr "Bleu :"
+
+#: ../src/generic/colrdlgg.cpp:372
+msgid "Opacity:"
+msgstr "Opacité :"
+
+#: ../src/generic/colrdlgg.cpp:384
+msgid "Add to custom colours"
+msgstr "Ajouter aux couleurs personnalisées"
+
+#: ../src/generic/creddlgg.cpp:56
+msgid "Username:"
+msgstr "Nom utilisateur :"
+
+#: ../src/generic/creddlgg.cpp:63
+msgid "Password:"
+msgstr "Mot de passe :"
+
+#. TRANSLATORS: Name of Boolean true value
+#: ../src/generic/datavgen.cpp:1178
+msgid "true"
+msgstr "vrai"
+
+#. TRANSLATORS: Name of Boolean false value
+#: ../src/generic/datavgen.cpp:1180
+msgid "false"
+msgstr "faux"
+
+#: ../src/generic/datavgen.cpp:6897
+#, c-format
+msgid "Row %i"
+msgstr "Ligne %i"
+
+#. TRANSLATORS: Action for manipulating a tree control
+#: ../src/generic/datavgen.cpp:6987
+msgid "Collapse"
+msgstr "Compacter"
+
+#. TRANSLATORS: Action for manipulating a tree control
+#: ../src/generic/datavgen.cpp:6990
+msgid "Expand"
+msgstr "Étendre"
+
+#. TRANSLATORS: Name of data view control and number of rows
+#: ../src/generic/datavgen.cpp:7011
+#, c-format
+msgid "%s (%d items)"
+msgstr "%s (%d éléments)"
+
+#: ../src/generic/datavgen.cpp:7062
+#, c-format
+msgid "Column %u"
+msgstr "Colonne %u"
+
+#. TRANSLATORS: Keystroke for manipulating a tree control
+#: ../src/generic/datavgen.cpp:7131 ../src/richtext/richtextbulletspage.cpp:189
+#: ../src/richtext/richtextbulletspage.cpp:192
+#: ../src/richtext/richtextbulletspage.cpp:193
+#: ../src/richtext/richtextliststylepage.cpp:252
+#: ../src/richtext/richtextliststylepage.cpp:255
+#: ../src/richtext/richtextliststylepage.cpp:256
+#: ../src/richtext/richtextsizepage.cpp:248
+msgid "Left"
+msgstr "Gauche"
+
+#. TRANSLATORS: Keystroke for manipulating a tree control
+#: ../src/generic/datavgen.cpp:7134 ../src/richtext/richtextbulletspage.cpp:191
+#: ../src/richtext/richtextliststylepage.cpp:254
+#: ../src/richtext/richtextsizepage.cpp:249
+msgid "Right"
+msgstr "Droite"
+
+#: ../src/generic/datectlg.cpp:90
+#, c-format
+msgid ""
+"\"%s\" is not in the expected date format, please enter it as e.g. \"%s\"."
+msgstr ""
+"« %s » n'est pas au format de date attendu, veuillez l'indiquer comme "
+"par exemple « %s »."
+
+#: ../src/generic/datectlg.cpp:94
+msgid "Invalid date"
+msgstr "Date non valable"
+
+#: ../src/generic/dbgrptg.cpp:159
+#, c-format
+msgid "Open file \"%s\""
+msgstr "Ouvrir le fichier « %s »"
+
+#: ../src/generic/dbgrptg.cpp:170
+#, c-format
+msgid "Enter command to open file \"%s\":"
+msgstr "Entrer la commande pour ouvrir le fichier « %s » :"
+
+#: ../src/generic/dbgrptg.cpp:230
+msgid "Executable files (*.exe)|*.exe|"
+msgstr "Fichiers exécutables (*.exe)|*.exe|"
+
+#: ../src/generic/dbgrptg.cpp:300
+#, c-format
+msgid "Debug report \"%s\""
+msgstr "Rapport de débogage « %s »"
+
+#: ../src/generic/dbgrptg.cpp:316
+msgid "A debug report has been generated in the directory\n"
+msgstr "Un rapport de débogage a été créé dans le dossier\n"
+
+#: ../src/generic/dbgrptg.cpp:317
+msgid "The following debug report will be generated\n"
+msgstr "Le rapport de débogage suivant va être créé\n"
+
+#: ../src/generic/dbgrptg.cpp:321
+msgid ""
+"The report contains the files listed below. If any of these files contain "
+"private information,\n"
+"please uncheck them and they will be removed from the report.\n"
+msgstr ""
+"Le rapport contient les fichiers listés ci-dessous. Si l'un de ces\n"
+"fichiers contient des informations sensibles, le décocher pour le\n"
+"retirer de ce rapport.\n"
+
+#: ../src/generic/dbgrptg.cpp:323
+msgid ""
+"If you wish to suppress this debug report completely, please choose the "
+"\"Cancel\" button,\n"
+"but be warned that it may hinder improving the program, so if\n"
+"at all possible please do continue with the report generation.\n"
+msgstr ""
+"Pour supprimer totalement ce rapport de débogage, choisir\n"
+"le bouton « Annuler », mais cela peut empêcher l'amélioration du\n"
+"programme, donc si possible continuer la création de ce rapport.\n"
+
+#: ../src/generic/dbgrptg.cpp:325
+msgid "              Thank you and we're sorry for the inconvenience!\n"
+msgstr "              Merci et désolé pour le dérangement !\n"
+
+#: ../src/generic/dbgrptg.cpp:333
+msgid "&Debug report preview:"
+msgstr "Aperçu du rapport de &débogage :"
+
+#: ../src/generic/dbgrptg.cpp:339
+msgid "&View..."
+msgstr "&Affichage..."
+
+#: ../src/generic/dbgrptg.cpp:359
+msgid "&Notes:"
+msgstr "&Notes :"
+
+#: ../src/generic/dbgrptg.cpp:361
+msgid ""
+"If you have any additional information pertaining to this bug\n"
+"report, please enter it here and it will be joined to it:"
+msgstr ""
+"En cas d'informations supplémentaires concernant ce rapport\n"
+"de bogue, les saisir ici pour qu'elles soient incluses :"
+
+#: ../src/generic/dcpsg.cpp:1627
+msgid "Cannot open file for PostScript printing!"
+msgstr "Impossible d'ouvrir le fichier pour une impression PostScript !"
+
+#: ../src/generic/dirctrlg.cpp:402
+msgid "Computer"
+msgstr "L'ordinateur"
+
+#: ../src/generic/dirctrlg.cpp:404
+msgid "Sections"
+msgstr "Sections"
+
+#: ../src/generic/dirctrlg.cpp:482
+msgid "Home directory"
+msgstr "Dossier personnel"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/generic/dirctrlg.cpp:484 ../src/propgrid/advprops.cpp:811
+msgid "Desktop"
+msgstr "Bureau"
+
+#: ../src/generic/dirctrlg.cpp:528 ../src/generic/filectrlg.cpp:752
+msgid "Illegal directory name."
+msgstr "Nom de répertoire illégal."
+
+#: ../src/generic/dirctrlg.cpp:528 ../src/generic/dirctrlg.cpp:546
+#: ../src/generic/dirctrlg.cpp:557 ../src/generic/dirdlgg.cpp:317
+#: ../src/generic/filectrlg.cpp:638 ../src/generic/filectrlg.cpp:752
+#: ../src/generic/filectrlg.cpp:766 ../src/generic/filectrlg.cpp:782
+#: ../src/generic/filectrlg.cpp:1356 ../src/generic/filectrlg.cpp:1387
+#: ../src/generic/filedlgg.cpp:362 ../src/gtk/filedlg.cpp:76
+msgid "Error"
+msgstr "Erreur"
+
+#: ../src/generic/dirctrlg.cpp:546 ../src/generic/filectrlg.cpp:766
+msgid "File name exists already."
+msgstr "Nom de fichier existant."
+
+#: ../src/generic/dirctrlg.cpp:557 ../src/generic/dirdlgg.cpp:317
+#: ../src/generic/filectrlg.cpp:638 ../src/generic/filectrlg.cpp:782
+msgid "Operation not permitted."
+msgstr "Opération interdite."
+
+#: ../src/generic/dirdlgg.cpp:107 ../src/generic/filedlgg.cpp:207
+msgid "Create new directory"
+msgstr "Créer un nouveau dossier"
+
+#: ../src/generic/dirdlgg.cpp:112 ../src/generic/filedlgg.cpp:203
+msgid "Go to home directory"
+msgstr "Aller au dossier personnel"
+
+#: ../src/generic/dirdlgg.cpp:143
+msgid "Show &hidden directories"
+msgstr "Montrer les répertoires cac&hés"
+
+#: ../src/generic/dirdlgg.cpp:196
+#, c-format
+msgid ""
+"The directory '%s' does not exist\n"
+"Create it now?"
+msgstr ""
+"Le dossier « %s » est inexistant.\n"
+"Faut-il le créer maintenant ?"
+
+#: ../src/generic/dirdlgg.cpp:198
+msgid "Directory does not exist"
+msgstr "Dossier inexistant"
+
+#: ../src/generic/dirdlgg.cpp:214
+#, c-format
+msgid ""
+"Failed to create directory '%s'\n"
+"(Do you have the required permissions?)"
+msgstr ""
+"Échec de la création du répertoire « %s »\n"
+"(pas les permissions requises ?)"
+
+#: ../src/generic/dirdlgg.cpp:216
+msgid "Error creating directory"
+msgstr "Erreur lors de la création du répertoire"
+
+#: ../src/generic/dirdlgg.cpp:281
+msgid "You cannot add a new directory to this section."
+msgstr "Il n'est pas possible d'ajouter un nouveau dossier à cette section."
+
+#: ../src/generic/dirdlgg.cpp:282
+msgid "Create directory"
+msgstr "Créer le dossier"
+
+#: ../src/generic/dirdlgg.cpp:291 ../src/generic/dirdlgg.cpp:301
+#: ../src/generic/filectrlg.cpp:614 ../src/generic/filectrlg.cpp:623
+msgid "NewName"
+msgstr "NouveauNom"
+
+#: ../src/generic/editlbox.cpp:135
+msgid "Edit item"
+msgstr "Éditer l'élément"
+
+#: ../src/generic/editlbox.cpp:143
+msgid "New item"
+msgstr "Nouvel élément"
+
+#: ../src/generic/editlbox.cpp:151
+msgid "Delete item"
+msgstr "Supprimer l'élément"
+
+#: ../src/generic/editlbox.cpp:159
+msgid "Move up"
+msgstr "Monter"
+
+#: ../src/generic/editlbox.cpp:164
+msgid "Move down"
+msgstr "Descendre"
+
+#: ../src/generic/fdrepdlg.cpp:108
+msgid "Search for:"
+msgstr "Chercher :"
+
+#: ../src/generic/fdrepdlg.cpp:120
+msgid "Replace with:"
+msgstr "Remplacer par :"
+
+#: ../src/generic/fdrepdlg.cpp:140
+msgid "Whole word"
+msgstr "Mot complet"
+
+#: ../src/generic/fdrepdlg.cpp:143
+msgid "Match case"
+msgstr "Respecter la casse"
+
+#: ../src/generic/fdrepdlg.cpp:156
+msgid "Search direction"
+msgstr "Direction de la recherche"
+
+#: ../src/generic/fdrepdlg.cpp:175
+msgid "&Replace"
+msgstr "&Remplacer"
+
+#: ../src/generic/fdrepdlg.cpp:178
+msgid "Replace &all"
+msgstr "Rempl&acer tout"
+
+#: ../src/generic/filectrlg.cpp:246 ../src/generic/filectrlg.cpp:269
+msgid "<DIR>"
+msgstr "<DOSSIER>"
+
+#: ../src/generic/filectrlg.cpp:248 ../src/generic/filectrlg.cpp:271
+msgid "<LINK>"
+msgstr "<LIEN>"
+
+#: ../src/generic/filectrlg.cpp:250 ../src/generic/filectrlg.cpp:273
+msgid "<DRIVE>"
+msgstr "<DISQUE>"
+
+#: ../src/generic/filectrlg.cpp:275
+#, c-format
+msgid "%ld byte"
+msgid_plural "%ld bytes"
+msgstr[0] "%ld octet"
+msgstr[1] "%ld octets"
+
+#: ../src/generic/filectrlg.cpp:420
+msgid "Name"
+msgstr "Nom"
+
+#: ../src/generic/filectrlg.cpp:421 ../src/richtext/richtextformatdlg.cpp:361
+#: ../src/richtext/richtextsizepage.cpp:298
+msgid "Size"
+msgstr "Taille"
+
+#: ../src/generic/filectrlg.cpp:422
+msgid "Type"
+msgstr "Type"
+
+#: ../src/generic/filectrlg.cpp:423
+msgid "Modified"
+msgstr "Modifié"
+
+#: ../src/generic/filectrlg.cpp:426
+msgid "Permissions"
+msgstr "Permissions"
+
+#: ../src/generic/filectrlg.cpp:429
+msgid "Attributes"
+msgstr "Attributs"
+
+#: ../src/generic/filectrlg.cpp:936
+msgid "Current directory:"
+msgstr "Dossier courant :"
+
+#: ../src/generic/filectrlg.cpp:979
+msgid "Show &hidden files"
+msgstr "Montrer les fichiers cac&hés"
+
+#: ../src/generic/filectrlg.cpp:1355
+msgid "Illegal file specification."
+msgstr "Spécification de fichier illégale."
+
+#: ../src/generic/filectrlg.cpp:1387
+msgid "Directory doesn't exist."
+msgstr "Dossier inexistant."
+
+#: ../src/generic/filedlgg.cpp:195
+msgid "View files as a list view"
+msgstr "Voir les fichiers en liste"
+
+#: ../src/generic/filedlgg.cpp:197
+msgid "View files as a detailed view"
+msgstr "Voir les fichiers en vue détaillée"
+
+#: ../src/generic/filedlgg.cpp:200
+msgid "Go to parent directory"
+msgstr "Aller au dossier parent"
+
+#: ../src/generic/filedlgg.cpp:351 ../src/gtk/filedlg.cpp:59
+#, c-format
+msgid "File '%s' already exists, do you really want to overwrite it?"
+msgstr "Le fichier « %s » existe déjà, faut-il vraiment l'écraser ?"
+
+#: ../src/generic/filedlgg.cpp:354 ../src/gtk/filedlg.cpp:62
+msgid "Confirm"
+msgstr "Confirmer"
+
+#: ../src/generic/filedlgg.cpp:362 ../src/gtk/filedlg.cpp:75
+msgid "Please choose an existing file."
+msgstr "Choisir un fichier existant."
+
+#: ../src/generic/filepickerg.cpp:64
+msgid "..."
+msgstr "..."
+
+#: ../src/generic/fontdlgg.cpp:76 ../src/richtext/richtextformatdlg.cpp:519
+msgid "ABCDEFGabcdefg12345"
+msgstr "ABCDEFGabcdefg12345"
+
+#: ../src/generic/fontdlgg.cpp:315
+msgid "Roman"
+msgstr "Roman"
+
+#: ../src/generic/fontdlgg.cpp:316
+msgid "Decorative"
+msgstr "Décoratif"
+
+#: ../src/generic/fontdlgg.cpp:317
+msgid "Modern"
+msgstr "Moderne"
+
+#: ../src/generic/fontdlgg.cpp:318
+msgid "Script"
+msgstr "Script"
+
+#: ../src/generic/fontdlgg.cpp:319
+msgid "Swiss"
+msgstr "Suisse"
+
+#: ../src/generic/fontdlgg.cpp:320
+msgid "Teletype"
+msgstr "Télétype"
+
+#: ../src/generic/fontdlgg.cpp:321 ../src/generic/fontdlgg.cpp:324
+msgid "Normal"
+msgstr "Normal"
+
+#: ../src/generic/fontdlgg.cpp:323
+msgid "Slant"
+msgstr "Incliné"
+
+#: ../src/generic/fontdlgg.cpp:325
+msgid "Light"
+msgstr "Léger"
+
+#: ../src/generic/fontdlgg.cpp:363
+msgid "&Font family:"
+msgstr "&Famille de polices :"
+
+#: ../src/generic/fontdlgg.cpp:367 ../src/generic/fontdlgg.cpp:369
+msgid "The font family."
+msgstr "Famille de police."
+
+#: ../src/generic/fontdlgg.cpp:374 ../src/richtext/richtextstylepage.cpp:105
+msgid "&Style:"
+msgstr "&Style :"
+
+#: ../src/generic/fontdlgg.cpp:378 ../src/generic/fontdlgg.cpp:380
+msgid "The font style."
+msgstr "Style de police."
+
+#: ../src/generic/fontdlgg.cpp:385
+msgid "&Weight:"
+msgstr "&Largeur :"
+
+#: ../src/generic/fontdlgg.cpp:389 ../src/generic/fontdlgg.cpp:391
+msgid "The font weight."
+msgstr "Largeur de police."
+
+#: ../src/generic/fontdlgg.cpp:399
+msgid "C&olour:"
+msgstr "C&ouleur :"
+
+#: ../src/generic/fontdlgg.cpp:407 ../src/generic/fontdlgg.cpp:409
+msgid "The font colour."
+msgstr "Couleur de police."
+
+#: ../src/generic/fontdlgg.cpp:415
+msgid "&Point size:"
+msgstr "Taille de &point :"
+
+#: ../src/generic/fontdlgg.cpp:420 ../src/generic/fontdlgg.cpp:422
+#: ../src/generic/fontdlgg.cpp:426 ../src/generic/fontdlgg.cpp:428
+msgid "The font point size."
+msgstr "Taille du point de la police."
+
+#: ../src/generic/fontdlgg.cpp:439 ../src/generic/fontdlgg.cpp:441
+msgid "Whether the font is underlined."
+msgstr "Si la police est soulignée."
+
+#: ../src/generic/fontdlgg.cpp:448 ../src/html/helpwnd.cpp:1215
+msgid "Preview:"
+msgstr "Aperçu :"
+
+#: ../src/generic/fontdlgg.cpp:452 ../src/generic/fontdlgg.cpp:454
+msgid "Shows the font preview."
+msgstr "Montrer un aperçu des polices."
+
+#: ../src/generic/fontdlgg.cpp:464 ../src/generic/fontdlgg.cpp:483
+msgid "Click to cancel the font selection."
+msgstr "Cliquer pour annuler la sélection de la police."
+
+#: ../src/generic/fontdlgg.cpp:469 ../src/generic/fontdlgg.cpp:471
+#: ../src/generic/fontdlgg.cpp:476 ../src/generic/fontdlgg.cpp:478
+msgid "Click to confirm the font selection."
+msgstr "Cliquer pour confirmer la sélection de la police."
+
+#: ../src/generic/fontpickerg.cpp:50 ../src/gtk/fontdlg.cpp:77
+msgid "Choose font"
+msgstr "Choisir la police"
+
+#: ../src/generic/grid.cpp:6542
+msgid ""
+"Error copying grid to the clipboard. Either selected cells were not "
+"contiguous or no cell was selected."
+msgstr ""
+"Erreur à la copie de la grille dans le presse-papiers. Soit les cellules "
+"sélectionnées ne sont pas contiguës, soit aucune cellule n'a été "
+"sélectionnée."
+
+#: ../src/generic/grid.cpp:12739
+msgid "Grid Corner"
+msgstr "Coin de la grille"
+
+#: ../src/generic/grid.cpp:12741
+#, c-format
+msgid "Column %s Header"
+msgstr "En-tête de colonne %s"
+
+#: ../src/generic/grid.cpp:12743
+#, c-format
+msgid "Row %s Header"
+msgstr "En-tête de ligne %s"
+
+#: ../src/generic/grid.cpp:12745
+#, c-format
+msgid "Column %s: %s"
+msgstr "Colonne %s : %s"
+
+#: ../src/generic/grid.cpp:12749
+#, c-format
+msgid "Row %s: %s"
+msgstr "Ligne %s : %s"
+
+#: ../src/generic/grid.cpp:12753
+#, c-format
+msgid "Row %s, Column %s: %s"
+msgstr "Ligne %s, colonne %s : %s"
+
+#: ../src/generic/helpext.cpp:257
+#, c-format
+msgid "Help directory \"%s\" not found."
+msgstr "Dossier d'aide « %s » non trouvé."
+
+#: ../src/generic/helpext.cpp:265
+#, c-format
+msgid "Help file \"%s\" not found."
+msgstr "Fichier d'aide « %s » non trouvé."
+
+#: ../src/generic/helpext.cpp:284
+#, c-format
+msgid "Line %lu of map file \"%s\" has invalid syntax, skipped."
+msgstr ""
+"La ligne %lu du fichier carte « %s » a une syntaxe incorrecte et a été "
+"sautée."
+
+#: ../src/generic/helpext.cpp:292
+#, c-format
+msgid "No valid mappings found in the file \"%s\"."
+msgstr ""
+"Aucune table de correspondance valable n'a été trouvée dans le fichier "
+"« %s »."
+
+#: ../src/generic/helpext.cpp:435
+msgid "No entries found."
+msgstr "Aucune entrée trouvée."
+
+#: ../src/generic/helpext.cpp:444 ../src/generic/helpext.cpp:445
+msgid "Help Index"
+msgstr "Aide Index"
+
+#: ../src/generic/helpext.cpp:448
+msgid "Relevant entries:"
+msgstr "Entrées pertinentes :"
+
+#: ../src/generic/helpext.cpp:449
+msgid "Entries found"
+msgstr "Entrées trouvées"
+
+#: ../src/generic/hyperlinkg.cpp:170
+msgid "&Copy URL"
+msgstr "&Copier l'adresse"
+
+#: ../src/generic/infobar.cpp:119
+msgid "Hide this notification message."
+msgstr "Cacher ce message de notification."
+
+#. TRANSLATORS: %s will be either the application name or "Application"
+#: ../src/generic/logg.cpp:257
+#, c-format
+msgid "%s Error"
+msgstr "%s Erreur"
+
+#. TRANSLATORS: %s will be either the application name or "Application"
+#: ../src/generic/logg.cpp:263
+#, c-format
+msgid "%s Warning"
+msgstr "%s Avertissement"
+
+#. TRANSLATORS: %s will be either the application name or "Application"
+#: ../src/generic/logg.cpp:273
+#, c-format
+msgid "%s Information"
+msgstr "%s Informations"
+
+#: ../src/generic/logg.cpp:276
+msgid "Application"
+msgstr "Application"
+
+#: ../src/generic/logg.cpp:549
+msgid "Save log contents to file"
+msgstr "Enregistrer le contenu du journal dans un fichier"
+
+#: ../src/generic/logg.cpp:551
+msgid "C&lear"
+msgstr "&Effacer"
+
+#: ../src/generic/logg.cpp:551
+msgid "Clear the log contents"
+msgstr "Effacer le contenu du journal"
+
+#: ../src/generic/logg.cpp:553
+msgid "Close this window"
+msgstr "Fermer cette fenêtre"
+
+#: ../src/generic/logg.cpp:554
+msgid "&Log"
+msgstr "&Journal"
+
+#: ../src/generic/logg.cpp:610 ../src/generic/logg.cpp:992
+msgid "Can't save log contents to file."
+msgstr "Impossible d'enregistrer le contenu du journal dans le fichier."
+
+#: ../src/generic/logg.cpp:613
+#, c-format
+msgid "Log saved to the file '%s'."
+msgstr "Journal sauvé dans le fichier « %s »."
+
+#: ../src/generic/logg.cpp:719
+msgid "&Details"
+msgstr "&Détails"
+
+#: ../src/generic/logg.cpp:972
+msgid "Failed to copy dialog contents to the clipboard."
+msgstr "Échec à la copie du contenu du dialogue vers le presse-papiers."
+
+#: ../src/generic/logg.cpp:1022
+#, c-format
+msgid "Append log to file '%s' (choosing [No] will overwrite it)?"
+msgstr ""
+"Faut-il ajouter le journal au fichier « %s » (choisir [Non] l'écrasera) ?"
+
+#: ../src/generic/logg.cpp:1024
+msgid "Question"
+msgstr "Question"
+
+#: ../src/generic/logg.cpp:1038
+msgid "invalid message box return value"
+msgstr "la boîte de message a renvoyé une valeur non valable"
+
+#: ../src/generic/notifmsgg.cpp:129
+msgid "Notice"
+msgstr "Note"
+
+#: ../src/generic/preferencesg.cpp:118
+#, c-format
+msgid "%s Preferences"
+msgstr "Préférences %s"
+
+#: ../src/generic/printps.cpp:143
+msgid "Printing..."
+msgstr "Impression en cours..."
+
+#: ../src/generic/printps.cpp:160 ../src/gtk/print.cpp:1076
+#: ../src/msw/printwin.cpp:235
+msgid "Could not start printing."
+msgstr "Impossible de lancer l'impression."
+
+#: ../src/generic/printps.cpp:183
+#, c-format
+msgid "Printing page %d..."
+msgstr "Impression de la page %d..."
+
+#: ../src/generic/prntdlgg.cpp:171
+msgid "Printer options"
+msgstr "Options de l'imprimante"
+
+#: ../src/generic/prntdlgg.cpp:176
+msgid "Print to File"
+msgstr "Imprimer dans un fichier"
+
+#: ../src/generic/prntdlgg.cpp:179
+msgid "Setup..."
+msgstr "Configurer..."
+
+#: ../src/generic/prntdlgg.cpp:187
+msgid "Printer:"
+msgstr "Imprimante :"
+
+#: ../src/generic/prntdlgg.cpp:195
+msgid "Status:"
+msgstr "État :"
+
+#: ../src/generic/prntdlgg.cpp:206
+msgid "All"
+msgstr "Tout"
+
+#: ../src/generic/prntdlgg.cpp:207
+msgid "Pages"
+msgstr "Pages"
+
+#: ../src/generic/prntdlgg.cpp:215
+msgid "Print Range"
+msgstr "Pages à imprimer"
+
+#: ../src/generic/prntdlgg.cpp:229
+msgid "From:"
+msgstr "De :"
+
+#: ../src/generic/prntdlgg.cpp:233
+msgid "To:"
+msgstr "À :"
+
+#: ../src/generic/prntdlgg.cpp:238
+msgid "Copies:"
+msgstr "Copies :"
+
+#: ../src/generic/prntdlgg.cpp:288
+msgid "PostScript file"
+msgstr "Fichier PostScript"
+
+#: ../src/generic/prntdlgg.cpp:439
+msgid "Print Setup"
+msgstr "Configuration de l'impression"
+
+#: ../src/generic/prntdlgg.cpp:483
+msgid "Printer"
+msgstr "Imprimante"
+
+#: ../src/generic/prntdlgg.cpp:501
+msgid "Default printer"
+msgstr "Imprimante par défaut"
+
+#: ../src/generic/prntdlgg.cpp:595 ../src/generic/prntdlgg.cpp:782
+#: ../src/generic/prntdlgg.cpp:822 ../src/generic/prntdlgg.cpp:835
+#: ../src/generic/prntdlgg.cpp:1031 ../src/generic/prntdlgg.cpp:1036
+msgid "Paper size"
+msgstr "Taille de la page"
+
+#: ../src/generic/prntdlgg.cpp:604 ../src/generic/prntdlgg.cpp:847
+msgid "Portrait"
+msgstr "Portrait"
+
+#: ../src/generic/prntdlgg.cpp:605 ../src/generic/prntdlgg.cpp:848
+msgid "Landscape"
+msgstr "Paysage"
+
+#: ../src/generic/prntdlgg.cpp:607 ../src/generic/prntdlgg.cpp:849
+msgid "Orientation"
+msgstr "Orientation"
+
+#: ../src/generic/prntdlgg.cpp:610
+msgid "Options"
+msgstr "Options"
+
+#: ../src/generic/prntdlgg.cpp:612
+msgid "Print in colour"
+msgstr "Imprimer en couleur"
+
+#: ../src/generic/prntdlgg.cpp:621
+msgid "Print spooling"
+msgstr "File d'attente d'impression"
+
+#: ../src/generic/prntdlgg.cpp:623
+msgid "Printer command:"
+msgstr "Commande pour l'imprimante :"
+
+#: ../src/generic/prntdlgg.cpp:631
+msgid "Printer options:"
+msgstr "Options de l'imprimante :"
+
+#: ../src/generic/prntdlgg.cpp:860
+msgid "Left margin (mm):"
+msgstr "Marge gauche (mm) :"
+
+#: ../src/generic/prntdlgg.cpp:861
+msgid "Top margin (mm):"
+msgstr "Marge de haut de page (mm) :"
+
+#: ../src/generic/prntdlgg.cpp:872
+msgid "Right margin (mm):"
+msgstr "Marge droite (mm) :"
+
+#: ../src/generic/prntdlgg.cpp:873
+msgid "Bottom margin (mm):"
+msgstr "Marge de bas de page (mm) :"
+
+#: ../src/generic/prntdlgg.cpp:896
+msgid "Printer..."
+msgstr "Imprimante..."
+
+#: ../src/generic/progdlgg.cpp:246
+msgid "&Skip"
+msgstr "Pa&sser"
+
+#: ../src/generic/progdlgg.cpp:347 ../src/generic/progdlgg.cpp:626
+msgid "Unknown"
+msgstr "Inconnu"
+
+#: ../src/generic/progdlgg.cpp:451 ../src/msw/progdlg.cpp:526
+msgid "Done."
+msgstr "Terminé."
+
+#: ../src/generic/srchctlg.cpp:55 ../src/gtk/srchctrl.cpp:206
+#: ../src/html/helpwnd.cpp:530 ../src/html/helpwnd.cpp:545
+msgid "Search"
+msgstr "Chercher"
+
+#: ../src/generic/tabg.cpp:1026
+msgid "Could not find tab for id"
+msgstr "Impossible de trouver l'onglet pour l'identifiant"
+
+#: ../src/generic/tipdlg.cpp:136
+msgid "Tips not available, sorry!"
+msgstr "Astuces non disponibles, désolé !"
+
+#: ../src/generic/tipdlg.cpp:197
+msgid "Tip of the Day"
+msgstr "Astuce du Jour"
+
+#: ../src/generic/tipdlg.cpp:207
+msgid "Did you know..."
+msgstr "Saviez-vous que..."
+
+#: ../src/generic/tipdlg.cpp:232
+msgid "&Show tips at startup"
+msgstr "&Afficher les astuces au démarrage"
+
+#: ../src/generic/tipdlg.cpp:236
+msgid "&Next Tip"
+msgstr "&Astuce Suivante"
+
+#: ../src/generic/wizard.cpp:411
+msgid "&Next >"
+msgstr "&Suivant >"
+
+#: ../src/generic/wizard.cpp:412
+msgid "&Finish"
+msgstr "&Finir"
+
+#: ../src/generic/wizard.cpp:420
+msgid "< &Back"
+msgstr "< &Retour"
+
+#: ../src/gtk/aboutdlg.cpp:204
+msgid "translator-credits"
+msgstr "liste des traducteurs"
+
+#: ../src/gtk/app.cpp:517
+msgid ""
+"WARNING: using XIM input method is unsupported and may result in problems "
+"with input handling and flickering. Consider unsetting GTK_IM_MODULE or "
+"setting to \"ibus\"."
+msgstr ""
+"AVERTISSEMENT : l’utilisation de la méthode d’entrée XIM n’est pas prise en "
+"charge et peut entraîner des problèmes de gestion et de scintillement des "
+"entrées. Envisagez de désactiver GTK_IM_MODULE ou de définir sur « ibus »."
+
+#: ../src/gtk/app.cpp:569
+msgid "Unable to initialize GTK+, is DISPLAY set properly?"
+msgstr "Impossible d'initialiser GTK+, l'AFFICHAGE est-il correctement réglé ?"
+
+#: ../src/gtk/filedlg.cpp:89 ../src/gtk/filepicker.cpp:255
+#, c-format
+msgid "Changing current directory to \"%s\" failed"
+msgstr "Échec de la modification du dossier courant en « %s »"
+
+#: ../src/gtk/font.cpp:548
+msgid ""
+"Using private fonts is not supported on this system: Pango library is too "
+"old, 1.38 or later required."
+msgstr ""
+"L’utilisation de polices privées n’est pas prise en charge sur ce système : "
+"la bibliothèque Pango est trop ancienne, version 1.38 ou ultérieure requise."
+
+#: ../src/gtk/font.cpp:558
+msgid "Failed to create font configuration object."
+msgstr "Échec de création d'un objet de configuration de police."
+
+#: ../src/gtk/font.cpp:568
+#, c-format
+msgid "Failed to add custom font \"%s\"."
+msgstr "Échec d'ajout de police utilisateur \"%s\"."
+
+#: ../src/gtk/font.cpp:576
+msgid "Failed to register font configuration using private fonts."
+msgstr "Échec d'enregistrement de configuration utilisant des polices privées."
+
+#: ../src/gtk/glcanvas.cpp:117 ../src/gtk/glcanvas.cpp:132
+msgid "Fatal Error"
+msgstr "Erreur fatale"
+
+#: ../src/gtk/glcanvas.cpp:117
+msgid ""
+"This program wasn't compiled with EGL support required under Wayland, "
+"either\n"
+"install EGL libraries and rebuild or run it under X11 backend by setting\n"
+"environment variable GDK_BACKEND=x11 before starting your program."
+msgstr ""
+"Ce programme n’a pas été compilé avec le support EGL requis sous Wayland, "
+"donc soit\n"
+"installer les bibliothèques EGL et les reconstruire soit les exécuter sous "
+"le \"backend\" X11 en définissant\n"
+"variable d’environnement GDK_BACKEND=x11 avant de démarrer votre programme."
+
+#: ../src/gtk/glcanvas.cpp:132
+msgid ""
+"wxGLCanvas is only supported on Wayland and X11 currently.  You may be able "
+"to\n"
+"work around this by setting environment variable GDK_BACKEND=x11 before\n"
+"starting your program."
+msgstr ""
+"wxGLCanvas n’est actuellement pris en charge que sur Wayland et X11.  Vous "
+"pourrez peut-être\n"
+"contourner ce problème en définissant la variable d’environnement "
+"GDK_BACKEND=x11 avant\n"
+"de démarrer votre programme."
+
+#: ../src/gtk/mdi.cpp:433
+msgid "MDI child"
+msgstr "Fils MDI"
+
+#: ../src/gtk/power.cpp:188
+#, c-format
+msgid "Failed to open D-Bus connection to the login manager: %s"
+msgstr "Échec de l'ouverture de la connexion D-Bus au gestionnaire de connexion : %s"
+
+#: ../src/gtk/power.cpp:214
+msgid "wxWidgets application"
+msgstr "Application wxWidgets"
+
+#: ../src/gtk/power.cpp:226
+msgid "Application needs to keep running"
+msgstr "L'application doit continuer à s'exécuter"
+
+#: ../src/gtk/power.cpp:233
+msgid "Clean up before suspend"
+msgstr "Nettoyer avant la mise en veille"
+
+#: ../src/gtk/power.cpp:259
+#, c-format
+msgid "Failed to inhibit sleep: %s"
+msgstr "Échec de l'inhibition de la mise en veille : %s"
+
+#: ../src/gtk/power.cpp:265
+msgid "Unexpected response to D-Bus \"Inhibit\" request."
+msgstr "Réponse inattendue à la demande D-Bus \"Inhiber\"."
+
+#: ../src/gtk/print.cpp:218
+msgid "Custom size"
+msgstr "Taille personnalisée"
+
+#: ../src/gtk/print.cpp:752
+#, c-format
+msgid "Error while printing: %s"
+msgstr "Erreur lors de l'impression : %s"
+
+#: ../src/gtk/print.cpp:816
+msgid "Page Setup"
+msgstr "Mise en Page"
+
+#: ../src/gtk/webview_webkit.cpp:932
+msgid "Retrieving JavaScript script output is not supported with WebKit v1"
+msgstr ""
+"Récupérer la sortie du script JavaScript n'est pas supportée sous WebKit v1"
+
+#: ../src/gtk/webview_webkit2.cpp:1098
+msgid ""
+"Setting proxy is not supported by WebKit, at least version 2.16 is required."
+msgstr ""
+"Définition du proxy n'est pas supporté par WebKit, au moins la version 2.16 "
+"est requise."
+
+#: ../src/gtk/webview_webkit2.cpp:1104
+msgid "This program was compiled without support for setting WebKit proxy."
+msgstr ""
+"Ce programme a été compilé sans le support de la définition du proxy WebKit."
+
+#: ../src/gtk/window.cpp:6289
+msgid ""
+"GTK+ installed on this machine is too old to support screen compositing, "
+"please install GTK+ 2.12 or later."
+msgstr ""
+"La version de GTK+ installée sur cette machine est trop ancienne pour "
+"reconnaitre la composition d'écran, il faut installer GTK+ 2.12 ou plus "
+"récent."
+
+#: ../src/gtk/window.cpp:6307
+msgid ""
+"Compositing not supported by this system, please enable it in your Window "
+"Manager."
+msgstr ""
+"La composition d'écran n'est pas reconnue par ce système, il faut l'activer "
+"dans le Gestionnaire de Fenêtre."
+
+#: ../src/gtk/window.cpp:6318
+msgid ""
+"This program was compiled with a too old version of GTK+, please rebuild "
+"with GTK+ 2.12 or newer."
+msgstr ""
+"Ce programme a été compilé avec une version trop ancienne de GTK+, "
+"recompiler avec GTK+ 2.12 ou plus récent."
+
+#: ../src/html/chm.cpp:138
+#, c-format
+msgid "Failed to open CHM archive '%s'."
+msgstr "Échec de l'ouverture de l'archive CHM « %s »."
+
+#: ../src/html/chm.cpp:270
+#, c-format
+msgid "Could not extract %s into %s: %s"
+msgstr "Impossible d'extraire %s de %s : %s"
+
+#: ../src/html/chm.cpp:324
+msgid "no error"
+msgstr "aucune erreur"
+
+#: ../src/html/chm.cpp:326
+msgid "bad arguments to library function"
+msgstr "mauvais paramètres à la fonction de bibliothèque"
+
+#: ../src/html/chm.cpp:328
+msgid "error opening file"
+msgstr "erreur à l'ouverture du fichier"
+
+#: ../src/html/chm.cpp:330
+msgid "read error"
+msgstr "erreur de lecture"
+
+#: ../src/html/chm.cpp:332
+msgid "write error"
+msgstr "erreur d'écriture"
+
+#: ../src/html/chm.cpp:334
+msgid "seek error"
+msgstr "erreur de recherche"
+
+#: ../src/html/chm.cpp:338
+msgid "bad signature"
+msgstr "mauvaise signature"
+
+#: ../src/html/chm.cpp:340
+msgid "error in data format"
+msgstr "erreur dans le format des données"
+
+#: ../src/html/chm.cpp:342
+msgid "checksum error"
+msgstr "erreur de la somme de contrôle"
+
+#: ../src/html/chm.cpp:344
+msgid "compression error"
+msgstr "erreur de compression"
+
+#: ../src/html/chm.cpp:346
+msgid "decompression error"
+msgstr "erreur de décompression"
+
+#: ../src/html/chm.cpp:437
+#, c-format
+msgid "Could not locate file '%s'."
+msgstr "Impossible de localiser le fichier « %s »."
+
+#: ../src/html/chm.cpp:711
+#, c-format
+msgid "Could not create temporary file '%s'"
+msgstr "Impossible de créer le fichier temporaire « %s »"
+
+#: ../src/html/chm.cpp:718
+#, c-format
+msgid "Extraction of '%s' into '%s' failed."
+msgstr "Échec de l'extraction de « %s » de « %s »."
+
+#: ../src/html/chm.cpp:806 ../src/html/chm.cpp:863
+msgid "CHM handler currently supports only local files!"
+msgstr "Le gestionnaire CHM ne gère actuellement que les fichiers locaux !"
+
+#: ../src/html/chm.cpp:827
+msgid "Link contained '//', converted to absolute link."
+msgstr "Le lien contenait « // » et a été converti en lien absolu."
+
+#: ../src/html/helpctrl.cpp:59
+#, c-format
+msgid "Help: %s"
+msgstr "Aide : %s"
+
+#: ../src/html/helpctrl.cpp:155
+#, c-format
+msgid "Adding book %s"
+msgstr "Ajouter le manuel %s"
+
+#: ../src/html/helpdata.cpp:295
+#, c-format
+msgid "Cannot open contents file: %s"
+msgstr "Impossible d'ouvrir le fichier de table des matières : %s"
+
+#: ../src/html/helpdata.cpp:309
+#, c-format
+msgid "Cannot open index file: %s"
+msgstr "Impossible d'ouvrir le fichier d'index : %s"
+
+#: ../src/html/helpdata.cpp:643
+msgid "noname"
+msgstr "pas de nom"
+
+#: ../src/html/helpdata.cpp:652
+#, c-format
+msgid "Cannot open HTML help book: %s"
+msgstr "Impossible d'ouvrir le manuel d'aide HTML : %s"
+
+#: ../src/html/helpwnd.cpp:315
+msgid "Displays help as you browse the books on the left."
+msgstr "Affiche l'aide pendant que le parcours des livres sur la gauche."
+
+#: ../src/html/helpwnd.cpp:411 ../src/html/helpwnd.cpp:1100
+#: ../src/html/helpwnd.cpp:1735
+msgid "(bookmarks)"
+msgstr "(marque-pages)"
+
+#: ../src/html/helpwnd.cpp:424
+msgid "Add current page to bookmarks"
+msgstr "Ajouter la page courante aux marque-pages"
+
+#: ../src/html/helpwnd.cpp:425
+msgid "Remove current page from bookmarks"
+msgstr "Retirer la page courante des marque-pages"
+
+#: ../src/html/helpwnd.cpp:470
+msgid "Contents"
+msgstr "Table des matières"
+
+#: ../src/html/helpwnd.cpp:485
+msgid "Find"
+msgstr "Trouver"
+
+#: ../src/html/helpwnd.cpp:487
+msgid "Show all"
+msgstr "Tout montrer"
+
+#: ../src/html/helpwnd.cpp:497
+msgid ""
+"Display all index items that contain given substring. Search is case "
+"insensitive."
+msgstr ""
+"Afficher tous les éléments de l'index qui contiennent une sous-chaîne "
+"donnée. Recherche non sensible à la casse."
+
+#: ../src/html/helpwnd.cpp:498
+msgid "Show all items in index"
+msgstr "Montrer tous les éléments de l'index"
+
+#: ../src/html/helpwnd.cpp:528
+msgid "Case sensitive"
+msgstr "Sensible à la casse"
+
+#: ../src/html/helpwnd.cpp:529
+msgid "Whole words only"
+msgstr "Mots complets seulement"
+
+#: ../src/html/helpwnd.cpp:532
+msgid ""
+"Search contents of help book(s) for all occurrences of the text you typed "
+"above"
+msgstr ""
+"Rechercher dans le contenu du/des manuel(s) d'aide toutes les occurrences du "
+"texte tapé ci-dessus"
+
+#: ../src/html/helpwnd.cpp:653
+msgid "Show/hide navigation panel"
+msgstr "Montrer/cacher le panneau de navigation"
+
+#: ../src/html/helpwnd.cpp:655
+msgid "Go back"
+msgstr "Revenir"
+
+#: ../src/html/helpwnd.cpp:656
+msgid "Go forward"
+msgstr "Continuer"
+
+#: ../src/html/helpwnd.cpp:658
+msgid "Go one level up in document hierarchy"
+msgstr "Monter au niveau supérieur dans la hiérarchie du document"
+
+#: ../src/html/helpwnd.cpp:666 ../src/html/helpwnd.cpp:1547
+msgid "Open HTML document"
+msgstr "Ouvrir un document HTML"
+
+#: ../src/html/helpwnd.cpp:670
+msgid "Print this page"
+msgstr "Imprimer cette page"
+
+#: ../src/html/helpwnd.cpp:674
+msgid "Display options dialog"
+msgstr "Dialogue d'options de l'affichage"
+
+#: ../src/html/helpwnd.cpp:795
+msgid "Please choose the page to display:"
+msgstr "Choisir la page à afficher :"
+
+#: ../src/html/helpwnd.cpp:796
+msgid "Help Topics"
+msgstr "Sujets Aide"
+
+#: ../src/html/helpwnd.cpp:852
+msgid "Searching..."
+msgstr "Recherche..."
+
+#: ../src/html/helpwnd.cpp:853
+msgid "No matching page found yet"
+msgstr "Aucune page correspondante n'a encore été trouvée"
+
+#: ../src/html/helpwnd.cpp:870
+#, c-format
+msgid "Found %i matches"
+msgstr "%i correspondances trouvées"
+
+#: ../src/html/helpwnd.cpp:958
+msgid "(Help)"
+msgstr "(Aide)"
+
+#: ../src/html/helpwnd.cpp:1026
+#, c-format
+msgid "%d of %lu"
+msgstr "%d sur %lu"
+
+#: ../src/html/helpwnd.cpp:1028
+#, c-format
+msgid "%lu of %lu"
+msgstr "%lu sur %lu"
+
+#: ../src/html/helpwnd.cpp:1047
+msgid "Search in all books"
+msgstr "Chercher dans tous les manuels"
+
+#: ../src/html/helpwnd.cpp:1193
+msgid "Help Browser Options"
+msgstr "Aide Options Navigateur"
+
+#: ../src/html/helpwnd.cpp:1198
+msgid "Normal font:"
+msgstr "Police normale :"
+
+#: ../src/html/helpwnd.cpp:1199
+msgid "Fixed font:"
+msgstr "Police de taille fixe :"
+
+#: ../src/html/helpwnd.cpp:1200
+msgid "Font size:"
+msgstr "Taille de la police :"
+
+#: ../src/html/helpwnd.cpp:1245
+msgid "font size"
+msgstr "taille de police"
+
+#: ../src/html/helpwnd.cpp:1256
+msgid "Normal face<br>and <u>underlined</u>. "
+msgstr "Normal<br>et <u>souligné</u>. "
+
+#: ../src/html/helpwnd.cpp:1257
+msgid "<i>Italic face.</i> "
+msgstr "<i>Italique.</i> "
+
+#: ../src/html/helpwnd.cpp:1258
+msgid "<b>Bold face.</b> "
+msgstr "<b>Gras.</b> "
+
+#: ../src/html/helpwnd.cpp:1259
+msgid "<b><i>Bold italic face.</i></b><br>"
+msgstr "<b><i>Gras italique.</i></b><br>"
+
+#: ../src/html/helpwnd.cpp:1262
+msgid "Fixed size face.<br> <b>bold</b> <i>italic</i> "
+msgstr "Police de taille fixe. <br> <b>gras</b> <i>italique</i> "
+
+#: ../src/html/helpwnd.cpp:1263
+msgid "<b><i>bold italic <u>underlined</u></i></b><br>"
+msgstr "<b><i>gras italique <u>souligné</u></i></b><br>"
+
+#: ../src/html/helpwnd.cpp:1524
+msgid "Help Printing"
+msgstr "Aide Impression"
+
+#: ../src/html/helpwnd.cpp:1527
+msgid "Cannot print empty page."
+msgstr "Impossible d'imprimer une page vide."
+
+#: ../src/html/helpwnd.cpp:1540
+msgid "HTML files (*.html;*.htm)|*.html;*.htm|"
+msgstr "Fichiers HTML (*.html;*.htm)|*.html;*.htm|"
+
+#: ../src/html/helpwnd.cpp:1541
+msgid "Help books (*.htb)|*.htb|Help books (*.zip)|*.zip|"
+msgstr "Livres d'aide (*.htb)|*.htb|Help books (*.zip)|*.zip|"
+
+#: ../src/html/helpwnd.cpp:1542
+msgid "HTML Help Project (*.hhp)|*.hhp|"
+msgstr "Projet d'aide HTML (*.hhp)|*.hhp|"
+
+#: ../src/html/helpwnd.cpp:1544
+msgid "Compressed HTML Help file (*.chm)|*.chm|"
+msgstr "Fichier HTML compilé (*.chm)|*.chm|"
+
+#: ../src/html/helpwnd.cpp:1671
+#, c-format
+msgid "%i of %u"
+msgstr "%i de %u"
+
+#: ../src/html/helpwnd.cpp:1709
+#, c-format
+msgid "%u of %u"
+msgstr "%u sur %u"
+
+#: ../src/html/htmlfilt.cpp:134
+#, c-format
+msgid "Cannot open HTML document: %s"
+msgstr "Impossible d'ouvrir le document HTML : %s"
+
+#: ../src/html/htmlwin.cpp:599
+msgid "Connecting..."
+msgstr "Connexion en cours..."
+
+#: ../src/html/htmlwin.cpp:616
+#, c-format
+msgid "Unable to open requested HTML document: %s"
+msgstr "Impossible d'ouvrir le document HTML demandé : %s"
+
+#: ../src/html/htmlwin.cpp:630
+msgid "Loading : "
+msgstr "Chargement : "
+
+#: ../src/html/htmlwin.cpp:673
+msgid "Done"
+msgstr "Terminé"
+
+#: ../src/html/htmlwin.cpp:723
+#, c-format
+msgid "HTML anchor %s does not exist."
+msgstr "Ancre HTML %s inexistante."
+
+#: ../src/html/htmlwin.cpp:1057
+#, c-format
+msgid "Copied to clipboard:\"%s\""
+msgstr "Copié dans le presse-papiers « %s »"
+
+#: ../src/html/htmprint.cpp:269
+msgid ""
+"This document doesn't fit on the page horizontally and will be truncated "
+"when it is printed."
+msgstr ""
+"Ce document ne tient pas sur la page horizontalement et sera tronqué lors de "
+"l'impression."
+
+#: ../src/html/htmprint.cpp:285
+#, c-format
+msgid ""
+"The document \"%s\" doesn't fit on the page horizontally and will be "
+"truncated if printed.\n"
+"\n"
+"Would you like to proceed with printing it nevertheless?"
+msgstr ""
+"Le document « %s » ne tient pas sur la page horizontalement et sera tronqué "
+"s'il est imprimé.\n"
+"\n"
+"Faut-il néanmoins procéder à l'impression ?"
+
+#: ../src/html/htmprint.cpp:296
+msgid ""
+"If possible, try changing the layout parameters to make the printout more "
+"narrow."
+msgstr ""
+"Si possible, essayer de modifier les paramètres de mise en page pour rendre "
+"l'imprimé plus étroit."
+
+#: ../src/html/htmprint.cpp:445
+msgid ": file does not exist!"
+msgstr ": le fichier n'existe pas !"
+
+#. TRANSLATORS: %s may be a document title.
+#: ../src/html/htmprint.cpp:717
+#, c-format
+msgid "%s Preview"
+msgstr "Aperçu de %s"
+
+#: ../src/html/htmprint.cpp:755 ../src/richtext/richtextprint.cpp:618
+msgid ""
+"There was a problem during page setup: you may need to set a default printer."
+msgstr ""
+"Un problème est apparu lors de la mise en page : la configuration d'une "
+"imprimante par défaut peut être nécessaire."
+
+#: ../src/msw/clipbrd.cpp:80
+msgid "Failed to open the clipboard."
+msgstr "Échec de l'ouverture du presse-papiers."
+
+#: ../src/msw/clipbrd.cpp:101
+msgid "Failed to close the clipboard."
+msgstr "Échec de la fermeture du presse-papiers."
+
+#: ../src/msw/clipbrd.cpp:113
+msgid "Failed to empty the clipboard."
+msgstr "Échec du vidage du presse-papiers."
+
+#: ../src/msw/clipbrd.cpp:284
+msgid "Failed to put data on the clipboard"
+msgstr "Échec de l'ajout de données dans le presse-papiers"
+
+#: ../src/msw/clipbrd.cpp:326
+msgid "Failed to get data from the clipboard"
+msgstr "Échec de l'obtention des données du presse-papiers"
+
+#: ../src/msw/clipbrd.cpp:363
+msgid "Failed to retrieve the supported clipboard formats"
+msgstr "Échec de la récupération des formats de presse-papiers reconnus"
+
+#: ../src/msw/colordlg.cpp:228
+#, c-format
+msgid "Colour selection dialog failed with error %0lx."
+msgstr "Échec du dialogue de sélection de couleur avec l'erreur %0lx."
+
+#: ../src/msw/cursor.cpp:141
+msgid "Failed to create cursor."
+msgstr "Échec de la création d'un curseur."
+
+#: ../src/msw/dde.cpp:279
+#, c-format
+msgid "Failed to register DDE server '%s'"
+msgstr "Échec de l'enregistrement du serveur DDE « %s »"
+
+#: ../src/msw/dde.cpp:300
+#, c-format
+msgid "Failed to unregister DDE server '%s'"
+msgstr "Échec du désenregistrement du serveur DDE « %s »"
+
+#: ../src/msw/dde.cpp:428
+#, c-format
+msgid "Failed to create connection to server '%s' on topic '%s'"
+msgstr ""
+"Échec de la création d'une connexion au serveur « %s » sur le sujet « %s »"
+
+#: ../src/msw/dde.cpp:655
+msgid "DDE poke request failed"
+msgstr "Échec de la demande de transfert DDE"
+
+#: ../src/msw/dde.cpp:674
+msgid "Failed to establish an advise loop with DDE server"
+msgstr ""
+"Échec de l'établissement d'une boucle d'instructions avec le serveur DDE"
+
+#: ../src/msw/dde.cpp:693
+msgid "Failed to terminate the advise loop with DDE server"
+msgstr ""
+"Échec de la terminaison de la boucle d'instructions avec le serveur DDE"
+
+#: ../src/msw/dde.cpp:768
+msgid "Failed to send DDE advise notification"
+msgstr "Échec de l'envoi d'une notification d'instructions au DDE"
+
+#: ../src/msw/dde.cpp:1085
+msgid "Failed to create DDE string"
+msgstr "Échec de la création de la chaîne DDE"
+
+#: ../src/msw/dde.cpp:1131
+msgid "no DDE error."
+msgstr "erreur - pas de DDE."
+
+#: ../src/msw/dde.cpp:1135
+msgid "a request for a synchronous advise transaction has timed out."
+msgstr "une demande de transaction synchrone d'instructions a expiré."
+
+#: ../src/msw/dde.cpp:1138
+msgid "the response to the transaction caused the DDE_FBUSY bit to be set."
+msgstr ""
+"la réponse à la transaction a provoqué la spécification du bit DDE_FBUSY."
+
+#: ../src/msw/dde.cpp:1141
+msgid "a request for a synchronous data transaction has timed out."
+msgstr "une demande de transaction synchrone de données a expiré."
+
+#: ../src/msw/dde.cpp:1144
+msgid ""
+"a DDEML function was called without first calling the DdeInitialize "
+"function,\n"
+"or an invalid instance identifier\n"
+"was passed to a DDEML function."
+msgstr ""
+"une fonction DDEML a été appelée sans appel préalable à la fonction\n"
+"DdeInitialize, ou un identifiant non valable a été fourni à la fonction\n"
+"DDEML."
+
+#: ../src/msw/dde.cpp:1147
+msgid ""
+"an application initialized as APPCLASS_MONITOR has\n"
+"attempted to perform a DDE transaction,\n"
+"or an application initialized as APPCMD_CLIENTONLY has \n"
+"attempted to perform server transactions."
+msgstr ""
+"une application initialisée en tant que APPCLASS_MONITOR a tenté\n"
+"d'effectuer une transaction DDE, ou une application initialisée en tant\n"
+"que APPCMD_CLIENTONLY a tenté d'effectuer des transactions serveur."
+
+#: ../src/msw/dde.cpp:1150
+msgid "a request for a synchronous execute transaction has timed out."
+msgstr "une demande de transaction synchrone d'exécutions a expiré."
+
+#: ../src/msw/dde.cpp:1153
+msgid "a parameter failed to be validated by the DDEML."
+msgstr "un paramètre n'a pas pu être validé par la DDEML."
+
+#: ../src/msw/dde.cpp:1156
+msgid "a DDEML application has created a prolonged race condition."
+msgstr "une application DDEML a créé une situation de concurrence prolongée."
+
+#: ../src/msw/dde.cpp:1159
+msgid "a memory allocation failed."
+msgstr "une allocation de mémoire a échoué."
+
+#: ../src/msw/dde.cpp:1162
+msgid "a client's attempt to establish a conversation has failed."
+msgstr "une tentative d'un client pour établir une conversation a échoué."
+
+#: ../src/msw/dde.cpp:1165
+msgid "a transaction failed."
+msgstr "une transaction a échoué."
+
+#: ../src/msw/dde.cpp:1168
+msgid "a request for a synchronous poke transaction has timed out."
+msgstr "une demande de transaction synchrone de stockage a expiré."
+
+#: ../src/msw/dde.cpp:1171
+msgid "an internal call to the PostMessage function has failed. "
+msgstr "un appel interne à la fonction PostMessage a échoué. "
+
+#: ../src/msw/dde.cpp:1174
+msgid "reentrancy problem."
+msgstr "problème de double entrée."
+
+#: ../src/msw/dde.cpp:1177
+msgid ""
+"a server-side transaction was attempted on a conversation\n"
+"that was terminated by the client, or the server\n"
+"terminated before completing a transaction."
+msgstr ""
+"une transaction a été tentée du côté serveur lors d'une conversation déjà\n"
+"terminée par le client, ou le serveur a achevé la transaction avant la fin."
+
+#: ../src/msw/dde.cpp:1180
+msgid "an internal error has occurred in the DDEML."
+msgstr "une erreur interne s'est produite dans le DDEML."
+
+#: ../src/msw/dde.cpp:1183
+msgid "a request to end an advise transaction has timed out."
+msgstr "une demande pour terminer une transaction d'instructions a expiré."
+
+#: ../src/msw/dde.cpp:1186
+msgid ""
+"an invalid transaction identifier was passed to a DDEML function.\n"
+"Once the application has returned from an XTYP_XACT_COMPLETE callback,\n"
+"the transaction identifier for that callback is no longer valid."
+msgstr ""
+"un identifiant de transaction non valable a été fourni à la fonction DDEML.\n"
+"Quand l'application sort d'un rappel XTYP_XACT_COMPLETE, l'identifiant de\n"
+"transaction pour ce rappel n'est plus valable."
+
+#: ../src/msw/dde.cpp:1189
+#, c-format
+msgid "Unknown DDE error %08x"
+msgstr "Erreur DDE inconnue : %08x"
+
+#: ../src/msw/dialup.cpp:343
+msgid ""
+"Dial up functions are unavailable because the remote access service (RAS) is "
+"not installed on this machine. Please install it."
+msgstr ""
+"Les fonctions d'appel ne sont pas disponibles car le service d'accès à "
+"distance (RAS) n'est pas installé sur cet ordinateur. L'installer."
+
+#: ../src/msw/dialup.cpp:402
+#, c-format
+msgid ""
+"The version of remote access service (RAS) installed on this machine is too "
+"old, please upgrade (the following required function is missing: %s)."
+msgstr ""
+"La version du service d'accès distant (RAS) installée sur cette machine est "
+"trop ancienne. Le mettre à niveau (la fonction suivante manque : %s)."
+
+#: ../src/msw/dialup.cpp:437
+msgid "Failed to retrieve text of RAS error message"
+msgstr "Échec de la récupération du texte du message d'erreur RAS"
+
+#: ../src/msw/dialup.cpp:440
+#, c-format
+msgid "unknown error (error code %08x)."
+msgstr "erreur inconnue (code d'erreur %08x)."
+
+#: ../src/msw/dialup.cpp:492
+#, c-format
+msgid "Cannot find active dialup connection: %s"
+msgstr "Impossible de trouver une connexion active : %s"
+
+#: ../src/msw/dialup.cpp:513
+msgid "Several active dialup connections found, choosing one randomly."
+msgstr "Plusieurs connexions actives trouvées, sélection unique aléatoire."
+
+#: ../src/msw/dialup.cpp:598 ../src/msw/dialup.cpp:832
+#, c-format
+msgid "Failed to establish dialup connection: %s"
+msgstr "Échec de l'établissement d'une connexion : %s"
+
+#: ../src/msw/dialup.cpp:664
+#, c-format
+msgid "Failed to get ISP names: %s"
+msgstr "Échec de l'obtention des noms des FAI : %s"
+
+#: ../src/msw/dialup.cpp:712
+msgid "Failed to connect: no ISP to dial."
+msgstr "Échec de la connexion : pas de FAI à appeler."
+
+#: ../src/msw/dialup.cpp:732
+msgid "Choose ISP to dial"
+msgstr "Choisir le FAI à appeler"
+
+#: ../src/msw/dialup.cpp:733
+msgid "Please choose which ISP do you want to connect to"
+msgstr "Choisir à quel FAI se connecter"
+
+#: ../src/msw/dialup.cpp:766
+msgid "Failed to connect: missing username/password."
+msgstr "Échec de la connexion : nom d'utilisateur ou mot de passe manquant."
+
+#: ../src/msw/dialup.cpp:796
+msgid "Cannot find the location of address book file"
+msgstr "Impossible de trouver l'emplacement du fichier du manuel des adresses"
+
+#: ../src/msw/dialup.cpp:827
+#, c-format
+msgid "Failed to initiate dialup connection: %s"
+msgstr "Échec de l'initialisation de la connexion modem : %s"
+
+#: ../src/msw/dialup.cpp:897
+msgid "Cannot hang up - no active dialup connection."
+msgstr "Impossible de raccrocher - pas de connexion active."
+
+#: ../src/msw/dialup.cpp:907
+#, c-format
+msgid "Failed to terminate the dialup connection: %s"
+msgstr "Échec de la terminaison de la connexion : %s"
+
+#: ../src/msw/dib.cpp:313
+#, c-format
+msgid "Failed to save the bitmap image to file \"%s\"."
+msgstr "Échec de l'enregistrement de l'image bitmap dans le fichier « %s »."
+
+#: ../src/msw/dib.cpp:543
+#, c-format
+msgid "Failed to allocate %luKb of memory for bitmap data."
+msgstr "Échec de l'allocation de %lu Ko de mémoire pour les données bitmap."
+
+#: ../src/msw/dir.cpp:241
+#, c-format
+msgid "Cannot enumerate files in directory '%s'"
+msgstr "Impossible d'énumérer les fichiers dans le répertoire « %s »"
+
+#: ../src/msw/dirdlg.cpp:368
+msgid "Couldn't obtain folder name"
+msgstr "Impossible d'obtenir le nom du dossier"
+
+#: ../src/msw/dlmsw.cpp:163
+#, c-format
+msgid "(error %d: %s)"
+msgstr "(erreur %d : %s)"
+
+#: ../src/msw/dragimag.cpp:143 ../src/msw/dragimag.cpp:178
+#: ../src/msw/imaglist.cpp:309 ../src/msw/imaglist.cpp:331
+msgid "Couldn't add an image to the image list."
+msgstr "Impossible d'ajouter une image à la liste des images."
+
+#: ../src/msw/enhmeta.cpp:94
+#, c-format
+msgid "Failed to load metafile from file \"%s\"."
+msgstr "Échec du chargement du métafichier depuis le fichier « %s »."
+
+#: ../src/msw/fdrepdlg.cpp:412
+#, c-format
+msgid "Failed to create the standard find/replace dialog (error code %d)"
+msgstr ""
+"Échec de la création de la boîte de dialogue standard rechercher/remplacer "
+"(code d'erreur %d)"
+
+#: ../src/msw/filedlg.cpp:1241
+msgid "Access to the file system is not allowed from secure desktop."
+msgstr ""
+"L'accès au système de fichiers n'est pas autorisé depuis le bureau sécurisé."
+
+#: ../src/msw/filedlg.cpp:1242
+msgid "Security warning"
+msgstr "Avertissement de sécurité"
+
+#: ../src/msw/filedlg.cpp:1533
+#, c-format
+msgid "File dialog failed with error code %0lx."
+msgstr "Échec du dialogue de fichier avec le code d'erreur %0lx."
+
+#: ../src/msw/font.cpp:1120
+#, c-format
+msgid "Font file \"%s\" couldn't be loaded"
+msgstr "Le fichier de police \"%s\" n'a pas pu être chargé"
+
+#: ../src/msw/fontdlg.cpp:220
+#, c-format
+msgid "Common dialog failed with error code %0lx."
+msgstr "Échec du dialogue commun avec le code d'erreur %0lx."
+
+#: ../src/msw/fswatcher.cpp:67
+msgid "Ungraceful worker thread termination"
+msgstr "Fin inopinée du processus de travailleur (worker)"
+
+#: ../src/msw/fswatcher.cpp:81
+msgid "Unable to create IOCP worker thread"
+msgstr "Impossible de créer un processus de travailleur (worker) IOCP"
+
+#: ../src/msw/fswatcher.cpp:88
+msgid "Unable to start IOCP worker thread"
+msgstr "Impossible de démarrer le processus de travailleur (worker) IOCP"
+
+#: ../src/msw/fswatcher.cpp:140
+msgid "Monitoring individual files for changes is not supported currently."
+msgstr ""
+"La surveillance des modifications de fichiers individuels n'est actuellement "
+"pas supporté."
+
+#: ../src/msw/fswatcher.cpp:165
+#, c-format
+msgid "Unable to set up watch for '%s'"
+msgstr "Impossible d'établir un scrutateur pour « %s »"
+
+#: ../src/msw/fswatcher.cpp:466
+#, c-format
+msgid "Can't monitor non-existent directory \"%s\" for changes."
+msgstr "Impossible de surveiller les changements du dossier inexistant « %s »."
+
+#: ../src/msw/glcanvas.cpp:577 ../src/unix/glx11.cpp:507
+msgid "OpenGL 3.0 or later is not supported by the OpenGL driver."
+msgstr "OpenGL 3.0 et au-dessus n'est pas reconnu par le pilote OpenGL."
+
+#: ../src/msw/glcanvas.cpp:601 ../src/osx/glcanvas_osx.cpp:395
+#: ../src/unix/glegl.cpp:304 ../src/unix/glx11.cpp:553
+msgid "Couldn't create OpenGL context"
+msgstr "N'a pas pu créer le contexte OpenGL"
+
+#: ../src/msw/glcanvas.cpp:1294
+msgid "Failed to initialize OpenGL"
+msgstr "Échec de l'initialisation d'OpenGL"
+
+#: ../src/msw/graphicsd2d.cpp:607
+msgid "Could not register custom DirectWrite font loader."
+msgstr "N'a pas pu enregistrer le chargeur de police DirectWrite."
+
+#: ../src/msw/helpchm.cpp:48
+msgid ""
+"MS HTML Help functions are unavailable because the MS HTML Help library is "
+"not installed on this machine. Please install it."
+msgstr ""
+"Les fonctions de l'aide MS HTML ne sont pas disponibles car la bibliothèque "
+"MS HTML Help n'est pas présente sur cette machine. Il faut l'installer."
+
+#: ../src/msw/helpchm.cpp:55
+msgid "Failed to initialize MS HTML Help."
+msgstr "Échec de l'initialisation de l'aide MS HTML."
+
+#: ../src/msw/iniconf.cpp:458
+#, c-format
+msgid "Can't delete the INI file '%s'"
+msgstr "Impossible d'effacer le fichier INI « %s »"
+
+#: ../src/msw/listctrl.cpp:995
+#, c-format
+msgid "Couldn't retrieve information about list control item %d."
+msgstr ""
+"Impossible de récupérer des informations sur l'élément « %d » de contrôle "
+"des listes."
+
+#: ../src/msw/mdi.cpp:170 ../src/qt/mdi.cpp:253
+msgid "&Cascade"
+msgstr "&Cascade"
+
+#: ../src/msw/mdi.cpp:171
+msgid "Tile &Horizontally"
+msgstr "Répartir &horizontalement"
+
+#: ../src/msw/mdi.cpp:172
+msgid "Tile &Vertically"
+msgstr "Répartir &verticalement"
+
+#: ../src/msw/mdi.cpp:174
+msgid "&Arrange Icons"
+msgstr "&Arranger les icônes"
+
+#: ../src/msw/mdi.cpp:621
+msgid "Failed to create MDI parent frame."
+msgstr "Échec de la création du cadre parent MDI."
+
+#: ../src/msw/mimetype.cpp:234
+#, c-format
+msgid "Failed to create registry entry for '%s' files."
+msgstr ""
+"Échec de la création d'une entrée dans le registre pour les fichiers « %s »."
+
+#: ../src/msw/ole/automtn.cpp:495
+#, c-format
+msgid "Failed to find CLSID of \"%s\""
+msgstr "Échec de la recherche du CLSID de « %s »"
+
+#: ../src/msw/ole/automtn.cpp:512
+#, c-format
+msgid "Failed to create an instance of \"%s\""
+msgstr "Échec de la création d'une instance de « %s »"
+
+#: ../src/msw/ole/automtn.cpp:552
+#, c-format
+msgid "Cannot get an active instance of \"%s\""
+msgstr "Impossible d'obtenir une instance active de : « %s »"
+
+#: ../src/msw/ole/automtn.cpp:564
+#, c-format
+msgid "Failed to get OLE automation interface for \"%s\""
+msgstr "Échec de l'obtention de l'interface OLE Automation pour « %s »"
+
+#: ../src/msw/ole/automtn.cpp:621
+msgid "Unknown name or named argument."
+msgstr "Nom ou argument nommé inconnu."
+
+#: ../src/msw/ole/automtn.cpp:625
+msgid "Incorrect number of arguments."
+msgstr "Nombre d'arguments incorrect."
+
+#: ../src/msw/ole/automtn.cpp:637
+msgid "Unknown exception"
+msgstr "Exception inconnue"
+
+#: ../src/msw/ole/automtn.cpp:642
+msgid "Method or property not found."
+msgstr "Méthode ou propriété non trouvée."
+
+#: ../src/msw/ole/automtn.cpp:646
+msgid "Overflow while coercing argument values."
+msgstr "Dépassement lors de la contrainte des valeurs d'arguments."
+
+#: ../src/msw/ole/automtn.cpp:650
+msgid "Object implementation does not support named arguments."
+msgstr "L'implémentation de l'objet ne supporte pas les arguments nommés."
+
+#: ../src/msw/ole/automtn.cpp:654
+msgid "The locale ID is unknown."
+msgstr "L'identifiant de la localisation est inconnu."
+
+#: ../src/msw/ole/automtn.cpp:658
+msgid "Missing a required parameter."
+msgstr "Un paramètre requis est manquant."
+
+#: ../src/msw/ole/automtn.cpp:662
+#, c-format
+msgid "Argument %u not found."
+msgstr "Argument %u non trouvé."
+
+#: ../src/msw/ole/automtn.cpp:666
+#, c-format
+msgid "Type mismatch in argument %u."
+msgstr "Incompatibilité de type pour l'argument %u."
+
+#: ../src/msw/ole/automtn.cpp:670
+msgid "The system cannot find the file specified."
+msgstr "Le système ne peut pas trouver le fichier spécifié."
+
+#: ../src/msw/ole/automtn.cpp:674
+msgid "Class not registered."
+msgstr "Classe non enregistrée."
+
+#: ../src/msw/ole/automtn.cpp:678
+#, c-format
+msgid "Unknown error %08x"
+msgstr "Erreur inconnue %08x"
+
+#: ../src/msw/ole/automtn.cpp:682
+#, c-format
+msgid "OLE Automation error in %s: %s"
+msgstr "Erreur OLE Automation dans %s : %s"
+
+#: ../src/msw/ole/dataobj.cpp:385
+#, c-format
+msgid "Couldn't register clipboard format '%s'."
+msgstr "Impossible d'enregistrer le format de presse-papiers « %s »."
+
+#: ../src/msw/ole/dataobj.cpp:402
+#, c-format
+msgid "The clipboard format '%d' doesn't exist."
+msgstr "Format « %d » de presse-papiers inexistant."
+
+#: ../src/msw/progdlg.cpp:1025
+msgid "Skip"
+msgstr "Sauter"
+
+#: ../src/msw/registry.cpp:141
+#, c-format
+msgid "unknown (%lu)"
+msgstr "inconnu (%lu)"
+
+#: ../src/msw/registry.cpp:409
+#, c-format
+msgid "Can't get info about registry key '%s'"
+msgstr "Impossible d'obtenir des informations sur la clé de registre « %s »"
+
+#: ../src/msw/registry.cpp:445
+#, c-format
+msgid "Can't open registry key '%s'"
+msgstr "Impossible d'ouvrir la clé de registre « %s »"
+
+#: ../src/msw/registry.cpp:478
+#, c-format
+msgid "Can't create registry key '%s'"
+msgstr "Impossible de créer la clé de registre « %s »"
+
+#: ../src/msw/registry.cpp:497
+#, c-format
+msgid "Can't close registry key '%s'"
+msgstr "Impossible de fermer la clé de registre « %s »"
+
+#: ../src/msw/registry.cpp:512
+#, c-format
+msgid "Registry value '%s' already exists."
+msgstr "La valeur de registre « %s » existe déjà."
+
+#: ../src/msw/registry.cpp:520
+#, c-format
+msgid "Failed to rename registry value '%s' to '%s'."
+msgstr "Échec du renommage de la valeur de registre « %s » en « %s »."
+
+#: ../src/msw/registry.cpp:575
+#, c-format
+msgid "Can't copy values of unsupported type %d."
+msgstr "Impossible de copier les valeurs de type %d non reconnu."
+
+#: ../src/msw/registry.cpp:586
+#, c-format
+msgid "Registry key '%s' does not exist, cannot rename it."
+msgstr ""
+"Impossible de renommer la clé de registre « %s », celle-ci n'existe pas."
+
+#: ../src/msw/registry.cpp:617
+#, c-format
+msgid "Registry key '%s' already exists."
+msgstr "La clé de registre « %s » existe déjà."
+
+#: ../src/msw/registry.cpp:625
+#, c-format
+msgid "Failed to rename the registry key '%s' to '%s'."
+msgstr "Échec du renommage de la clé de registre « %s » en « %s »."
+
+#: ../src/msw/registry.cpp:670
+#, c-format
+msgid "Failed to copy the registry subkey '%s' to '%s'."
+msgstr "Échec de la copie de la sous-clé de registre « %s » vers « %s »."
+
+#: ../src/msw/registry.cpp:683
+#, c-format
+msgid "Failed to copy registry value '%s'"
+msgstr "Échec de la copie de la valeur de registre « %s »"
+
+#: ../src/msw/registry.cpp:692
+#, c-format
+msgid "Failed to copy the contents of registry key '%s' to '%s'."
+msgstr "Échec de la copie du contenu de la clé de registre « %s » vers « %s »."
+
+#: ../src/msw/registry.cpp:718
+#, c-format
+msgid ""
+"Registry key '%s' is needed for normal system operation,\n"
+"deleting it will leave your system in unusable state:\n"
+"operation aborted."
+msgstr ""
+"La clé de registre « %s » est nécessaire pour un fonctionnement correct\n"
+"du système ; sa suppression laisserait ce système inutilisable :\n"
+"opération abandonnée."
+
+#: ../src/msw/registry.cpp:754
+#, c-format
+msgid "Can't delete key '%s'"
+msgstr "Impossible d'effacer la clé « %s »"
+
+#: ../src/msw/registry.cpp:782
+#, c-format
+msgid "Can't delete value '%s' from key '%s'"
+msgstr "Impossible d'effacer la valeur « %s » de la clé « %s »"
+
+#: ../src/msw/registry.cpp:855 ../src/msw/registry.cpp:887
+#: ../src/msw/registry.cpp:929 ../src/msw/registry.cpp:1000
+#, c-format
+msgid "Can't read value of key '%s'"
+msgstr "Impossible de lire la valeur de la clé « %s »"
+
+#: ../src/msw/registry.cpp:873 ../src/msw/registry.cpp:915
+#: ../src/msw/registry.cpp:963 ../src/msw/registry.cpp:1106
+#, c-format
+msgid "Can't set value of '%s'"
+msgstr "Impossible de spécifier la valeur de « %s »"
+
+#: ../src/msw/registry.cpp:894 ../src/msw/registry.cpp:943
+#, c-format
+msgid "Registry value \"%s\" is not numeric (but of type %s)"
+msgstr "La valeur de registre \"%s\" n'est pas numérique (mais de type %s)"
+
+#: ../src/msw/registry.cpp:979
+#, c-format
+msgid "Registry value \"%s\" is not binary (but of type %s)"
+msgstr "La valeur de registre \"%s\" n'est pas binaire (mais de type %s)"
+
+#: ../src/msw/registry.cpp:1028
+#, c-format
+msgid "Registry value \"%s\" is not text (but of type %s)"
+msgstr "La valeur de registre \"%s\" n'est pas du texte (mais de type %s)"
+
+#: ../src/msw/registry.cpp:1089
+#, c-format
+msgid "Can't read value of '%s'"
+msgstr "Impossible de lire la valeur de « %s »"
+
+#: ../src/msw/registry.cpp:1157
+#, c-format
+msgid "Can't enumerate values of key '%s'"
+msgstr "Impossible d'énumérer les valeurs de la clé « %s »"
+
+#: ../src/msw/registry.cpp:1196
+#, c-format
+msgid "Can't enumerate subkeys of key '%s'"
+msgstr "Impossible d'énumérer les sous-clés de la clé « %s »"
+
+#: ../src/msw/registry.cpp:1262
+#, c-format
+msgid ""
+"Exporting registry key: file \"%s\" already exists and won't be overwritten."
+msgstr ""
+"Exportation de la clé de registre : le fichier « %s » existe déjà et ne sera "
+"pas écrasé."
+
+#: ../src/msw/registry.cpp:1411
+#, c-format
+msgid "Can't export value of unsupported type %d."
+msgstr "Impossible d'exporter les valeurs de type non reconnu %d."
+
+#: ../src/msw/registry.cpp:1427
+#, c-format
+msgid "Ignoring value \"%s\" of the key \"%s\"."
+msgstr "Valeur « %s » de la clé « %s » ignorée."
+
+#: ../src/msw/textctrl.cpp:596
+msgid ""
+"Impossible to create a rich edit control, using simple text control instead. "
+"Please reinstall riched32.dll"
+msgstr ""
+"Impossible de créer un contrôle d'édition riche, utilisation d'un contrôle "
+"de texte simple à la place. Réinstaller riched32.dll"
+
+#: ../src/msw/thread.cpp:522 ../src/unix/threadpsx.cpp:850
+msgid "Cannot start thread: error writing TLS."
+msgstr "Impossible de lancer le processus : erreur lors de l'écriture de TLS."
+
+#: ../src/msw/thread.cpp:613
+msgid "Can't set thread priority"
+msgstr "Impossible de spécifier la priorité du processus"
+
+#: ../src/msw/thread.cpp:649
+msgid "Can't create thread"
+msgstr "Impossible de créer le processus"
+
+#: ../src/msw/thread.cpp:668
+msgid "Couldn't terminate thread"
+msgstr "Impossible d'arrêter le processus"
+
+#: ../src/msw/thread.cpp:799
+msgid "Cannot wait for thread termination"
+msgstr "Impossible d'attendre la fin du processus"
+
+#: ../src/msw/thread.cpp:873
+#, c-format
+msgid "Cannot suspend thread %lx"
+msgstr "Impossible de suspendre le thread %lx"
+
+#: ../src/msw/thread.cpp:903
+#, c-format
+msgid "Cannot resume thread %lx"
+msgstr "Impossible de reprendre le thread %lx"
+
+#: ../src/msw/thread.cpp:932
+msgid "Couldn't get the current thread pointer"
+msgstr "Impossible d'obtenir le pointeur du processus actuel"
+
+#: ../src/msw/thread.cpp:1333
+msgid ""
+"Thread module initialization failed: impossible to allocate index in thread "
+"local storage"
+msgstr ""
+"Échec de l'initialisation du module du processus : impossible d'allouer un "
+"index dans le stockage local des processus"
+
+#: ../src/msw/thread.cpp:1345
+msgid ""
+"Thread module initialization failed: cannot store value in thread local "
+"storage"
+msgstr ""
+"Échec de l'initialisation du module du processus : enregistrement impossible "
+"de la valeur dans le stockage local des processus"
+
+#: ../src/msw/timer.cpp:133
+msgid "Couldn't create a timer"
+msgstr "Impossible de créer un minuteur"
+
+#: ../src/msw/utils.cpp:372
+msgid "can't find user's HOME, using current directory."
+msgstr ""
+"impossible de trouver le répertoire HOME de l'utilisateur - utilisation du "
+"répertoire courant."
+
+#: ../src/msw/utils.cpp:662
+#, c-format
+msgid "Failed to kill process %d"
+msgstr "Échec de l'arrêt du processus %d"
+
+#: ../src/msw/utils.cpp:986
+#, c-format
+msgid "Failed to load resource \"%s\"."
+msgstr "Échec du chargement de la ressource « %s »."
+
+#: ../src/msw/utils.cpp:993
+#, c-format
+msgid "Failed to lock resource \"%s\"."
+msgstr "Échec du verrouillage de la ressource « %s »."
+
+#. TRANSLATORS: MS Windows build number
+#: ../src/msw/utils.cpp:1209
+#, c-format
+msgid "build %lu"
+msgstr "version %lu"
+
+#: ../src/msw/utils.cpp:1218
+msgid ", 64-bit edition"
+msgstr ", édition 64-bit"
+
+#: ../src/msw/utilsexc.cpp:224
+msgid "Failed to create an anonymous pipe"
+msgstr "Échec de la création d'un tube (pipe) anonyme"
+
+#: ../src/msw/utilsexc.cpp:697
+msgid "Failed to redirect the child process IO"
+msgstr "Échec de la redirection des entrées et sorties du processus fils"
+
+#: ../src/msw/utilsexc.cpp:870
+#, c-format
+msgid "Execution of command '%s' failed"
+msgstr "Échec de l'exécution de la commande « %s »"
+
+#: ../src/msw/volume.cpp:337
+msgid "Failed to load mpr.dll."
+msgstr "Échec du chargement de mpr.dll."
+
+#: ../src/msw/volume.cpp:506
+#, c-format
+msgid "Cannot read typename from '%s'!"
+msgstr "Impossible de lire le nom de type de « %s » !"
+
+#: ../src/msw/volume.cpp:615
+#, c-format
+msgid "Cannot load icon from '%s'."
+msgstr "Impossible de charger l'icône depuis « %s »."
+
+#: ../src/msw/webview_edge.cpp:285
+msgid "This program was compiled without support for setting Edge proxy."
+msgstr ""
+"Ce programme a été compilé sans support pour la configuration du proxy Edge."
+
+#: ../src/msw/webview_ie.cpp:1010
+msgid "Failed to find web view emulation level in the registry"
+msgstr ""
+"Impossible de trouver le niveau d’émulation de la vue Web dans le Registre"
+
+#: ../src/msw/webview_ie.cpp:1019
+msgid "Failed to set web view to modern emulation level"
+msgstr "Impossible de définir la vue Web avec un niveau d’émulation moderne"
+
+#: ../src/msw/webview_ie.cpp:1027
+msgid "Failed to reset web view to standard emulation level"
+msgstr ""
+"Impossible de réinitialiser l’affichage Web avec un niveau d’émulation "
+"standard"
+
+#: ../src/msw/webview_ie.cpp:1049
+msgid "Can't run JavaScript script without a valid HTML document"
+msgstr "Ne peut lancer un script JavaScript sans document HTML valide"
+
+#: ../src/msw/webview_ie.cpp:1056
+msgid "Can't get the JavaScript object"
+msgstr "Ne peut pas accéder à l'objet JavaScript"
+
+#: ../src/msw/webview_ie.cpp:1070
+msgid "failed to evaluate"
+msgstr "échec de l'évaluation"
+
+#: ../src/osx/cocoa/filedlg.mm:412
+msgid "File type:"
+msgstr "Type de fichier :"
+
+#: ../src/osx/cocoa/menu.mm:242
+msgctxt "macOS menu name"
+msgid "Window"
+msgstr "Fenêtre"
+
+#: ../src/osx/cocoa/menu.mm:259
+msgctxt "macOS menu name"
+msgid "Help"
+msgstr "Aide"
+
+#: ../src/osx/cocoa/menu.mm:298
+msgctxt "macOS menu item"
+msgid "Minimize"
+msgstr "Réduire"
+
+#: ../src/osx/cocoa/menu.mm:303
+msgctxt "macOS menu item"
+msgid "Zoom"
+msgstr "Agrandir"
+
+#: ../src/osx/cocoa/menu.mm:309
+msgctxt "macOS menu item"
+msgid "Bring All to Front"
+msgstr "Tout mettre au premier plan"
+
+#: ../src/osx/core/sound.cpp:143
+#, c-format
+msgid "Failed to load sound from \"%s\" (error %d)."
+msgstr "Échec du chargement du son depuis « %s » (erreur %d)."
+
+#: ../src/osx/fontutil.cpp:80
+#, c-format
+msgid "Font file \"%s\" doesn't exist."
+msgstr "Le fichier de police \"%s\" n'existe pas."
+
+#: ../src/osx/fontutil.cpp:88
+#, c-format
+msgid ""
+"Font file \"%s\" cannot be used as it is not inside the font directory "
+"\"%s\"."
+msgstr ""
+"Le fichier de police \"%s\" ne peut pas être utilisé s'il n'est pas dans le "
+"répertoire de polices \"%s\"."
+
+#: ../src/osx/menu_osx.cpp:496
+#, c-format
+msgctxt "macOS menu item"
+msgid "About %s"
+msgstr "À propos de %s"
+
+#: ../src/osx/menu_osx.cpp:499
+msgctxt "macOS menu item"
+msgid "About..."
+msgstr "À propos..."
+
+#: ../src/osx/menu_osx.cpp:508
+msgctxt "macOS menu item"
+msgid "Preferences..."
+msgstr "Préférences..."
+
+#: ../src/osx/menu_osx.cpp:512
+msgctxt "macOS menu item"
+msgid "Services"
+msgstr "Services"
+
+#: ../src/osx/menu_osx.cpp:519
+#, c-format
+msgctxt "macOS menu item"
+msgid "Hide %s"
+msgstr "Cacher %s"
+
+#: ../src/osx/menu_osx.cpp:522
+msgctxt "macOS menu item"
+msgid "Hide Application"
+msgstr "Cacher l'Application"
+
+#: ../src/osx/menu_osx.cpp:526
+msgctxt "macOS menu item"
+msgid "Hide Others"
+msgstr "Cacher les Autres"
+
+#: ../src/osx/menu_osx.cpp:528
+msgctxt "macOS menu item"
+msgid "Show All"
+msgstr "Tout Montrer"
+
+#: ../src/osx/menu_osx.cpp:534
+#, c-format
+msgctxt "macOS menu item"
+msgid "Quit %s"
+msgstr "Quitter %s"
+
+#: ../src/osx/menu_osx.cpp:537
+msgctxt "macOS menu item"
+msgid "Quit Application"
+msgstr "Quitter l'Application"
+
+#: ../src/osx/webview_webkit.mm:444
+msgid "Printing is not supported by the system web control"
+msgstr "Impression non supportée par le système de contrôle web"
+
+#: ../src/osx/webview_webkit.mm:453
+msgid "Print operation could not be initialized"
+msgstr "L'impression n'a pas pu être initialisée"
+
+#. TRANSLATORS: Label of font point size
+#: ../src/propgrid/advprops.cpp:605
+msgid "Point Size"
+msgstr "Taille de Point"
+
+#. TRANSLATORS: Label of font face name
+#: ../src/propgrid/advprops.cpp:615
+msgid "Face Name"
+msgstr "Nom"
+
+#. TRANSLATORS: Label of font style
+#: ../src/propgrid/advprops.cpp:623 ../src/richtext/richtextformatdlg.cpp:331
+msgid "Style"
+msgstr "Style"
+
+#. TRANSLATORS: Label of font weight
+#: ../src/propgrid/advprops.cpp:628
+msgid "Weight"
+msgstr "Poids"
+
+#. TRANSLATORS: Label of underlined font
+#: ../src/propgrid/advprops.cpp:633 ../src/richtext/richtextfontpage.cpp:358
+msgid "Underlined"
+msgstr "Souligné"
+
+#. TRANSLATORS: Label of font family
+#: ../src/propgrid/advprops.cpp:637
+msgid "Family"
+msgstr "Famille"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:801
+msgid "AppWorkspace"
+msgstr "AppWorkspace"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:802
+msgid "ActiveBorder"
+msgstr "ActiveBorder"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:803
+msgid "ActiveCaption"
+msgstr "ActiveCaption"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:804
+msgid "ButtonFace"
+msgstr "ButtonFace"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:805
+msgid "ButtonHighlight"
+msgstr "ButtonHighlight"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:806
+msgid "ButtonShadow"
+msgstr "ButtonShadow"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:807
+msgid "ButtonText"
+msgstr "ButtonText"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:808
+msgid "CaptionText"
+msgstr "CaptionText"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:809
+msgid "ControlDark"
+msgstr "ControlDark"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:810
+msgid "ControlLight"
+msgstr "ControlLight"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:812
+msgid "GrayText"
+msgstr "GrayText"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:813
+msgid "Highlight"
+msgstr "Surlignage"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:814
+msgid "HighlightText"
+msgstr "HighlightText"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:815
+msgid "InactiveBorder"
+msgstr "InactiveBorder"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:816
+msgid "InactiveCaption"
+msgstr "InactiveCaption"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:817
+msgid "InactiveCaptionText"
+msgstr "InactiveCaptionText"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:818
+msgid "Menu"
+msgstr "Menu"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:819
+msgid "Scrollbar"
+msgstr "Barre de défilement"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:820
+msgid "Tooltip"
+msgstr "Infobulle"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:821
+msgid "TooltipText"
+msgstr "InfobulleTexte"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:822
+msgid "Window"
+msgstr "Fenêtre"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:823
+msgid "WindowFrame"
+msgstr "WindowFrame"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:824
+msgid "WindowText"
+msgstr "WindowText"
+
+#. TRANSLATORS: Custom colour choice entry
+#: ../src/propgrid/advprops.cpp:825 ../src/propgrid/advprops.cpp:1532
+#: ../src/propgrid/advprops.cpp:1576
+msgid "Custom"
+msgstr "Personnalisé"
+
+#: ../src/propgrid/advprops.cpp:1558
+msgid "Black"
+msgstr "Noir"
+
+#: ../src/propgrid/advprops.cpp:1559
+msgid "Maroon"
+msgstr "Marron"
+
+#: ../src/propgrid/advprops.cpp:1560
+msgid "Navy"
+msgstr "Bleu marine"
+
+#: ../src/propgrid/advprops.cpp:1561
+msgid "Purple"
+msgstr "Pourpre"
+
+#: ../src/propgrid/advprops.cpp:1562
+msgid "Teal"
+msgstr "Bleu sarcelle"
+
+#: ../src/propgrid/advprops.cpp:1563
+msgid "Gray"
+msgstr "Gris"
+
+#: ../src/propgrid/advprops.cpp:1564
+msgid "Green"
+msgstr "Vert"
+
+#: ../src/propgrid/advprops.cpp:1565
+msgid "Olive"
+msgstr "Olive"
+
+#: ../src/propgrid/advprops.cpp:1566
+msgid "Brown"
+msgstr "Brun"
+
+#: ../src/propgrid/advprops.cpp:1567
+msgid "Blue"
+msgstr "Bleu"
+
+#: ../src/propgrid/advprops.cpp:1568
+msgid "Fuchsia"
+msgstr "Fuchia"
+
+#: ../src/propgrid/advprops.cpp:1569
+msgid "Red"
+msgstr "Rouge"
+
+#: ../src/propgrid/advprops.cpp:1570
+msgid "Orange"
+msgstr "Orange"
+
+#: ../src/propgrid/advprops.cpp:1571
+msgid "Silver"
+msgstr "Argent"
+
+#: ../src/propgrid/advprops.cpp:1572
+msgid "Lime"
+msgstr "Citron"
+
+#: ../src/propgrid/advprops.cpp:1573
+msgid "Aqua"
+msgstr "Aqua"
+
+#: ../src/propgrid/advprops.cpp:1574
+msgid "Yellow"
+msgstr "Jaune"
+
+#: ../src/propgrid/advprops.cpp:1575
+msgid "White"
+msgstr "Blanc"
+
+#: ../src/propgrid/advprops.cpp:1718
+msgctxt "system cursor name"
+msgid "Default"
+msgstr "Défaut"
+
+#: ../src/propgrid/advprops.cpp:1719
+msgctxt "system cursor name"
+msgid "Arrow"
+msgstr "Flèche"
+
+#: ../src/propgrid/advprops.cpp:1720
+msgctxt "system cursor name"
+msgid "Right Arrow"
+msgstr "Flèche Droite"
+
+#: ../src/propgrid/advprops.cpp:1721
+msgctxt "system cursor name"
+msgid "Blank"
+msgstr "Vide"
+
+#: ../src/propgrid/advprops.cpp:1722
+msgctxt "system cursor name"
+msgid "Bullseye"
+msgstr "Cible"
+
+#: ../src/propgrid/advprops.cpp:1723
+msgctxt "system cursor name"
+msgid "Character"
+msgstr "Caractère"
+
+#: ../src/propgrid/advprops.cpp:1724
+msgctxt "system cursor name"
+msgid "Cross"
+msgstr "Croix"
+
+#: ../src/propgrid/advprops.cpp:1725
+msgctxt "system cursor name"
+msgid "Hand"
+msgstr "Main"
+
+#: ../src/propgrid/advprops.cpp:1726
+msgctxt "system cursor name"
+msgid "I-Beam"
+msgstr "I-Beam"
+
+#: ../src/propgrid/advprops.cpp:1727
+msgctxt "system cursor name"
+msgid "Left Button"
+msgstr "Bouton gauche"
+
+#: ../src/propgrid/advprops.cpp:1728
+msgctxt "system cursor name"
+msgid "Magnifier"
+msgstr "Loupe"
+
+#: ../src/propgrid/advprops.cpp:1729
+msgctxt "system cursor name"
+msgid "Middle Button"
+msgstr "Bouton du milieu"
+
+#: ../src/propgrid/advprops.cpp:1730
+msgctxt "system cursor name"
+msgid "No Entry"
+msgstr "Pas d'entrée"
+
+#: ../src/propgrid/advprops.cpp:1731
+msgctxt "system cursor name"
+msgid "Paint Brush"
+msgstr "Brosse à peinture"
+
+#: ../src/propgrid/advprops.cpp:1732
+msgctxt "system cursor name"
+msgid "Pencil"
+msgstr "Crayon"
+
+#: ../src/propgrid/advprops.cpp:1733
+msgctxt "system cursor name"
+msgid "Point Left"
+msgstr "À Gauche"
+
+#: ../src/propgrid/advprops.cpp:1734
+msgctxt "system cursor name"
+msgid "Point Right"
+msgstr "À Droite"
+
+#: ../src/propgrid/advprops.cpp:1735
+msgctxt "system cursor name"
+msgid "Question Arrow"
+msgstr "Flèche d'interrogation"
+
+#: ../src/propgrid/advprops.cpp:1736
+msgctxt "system cursor name"
+msgid "Right Button"
+msgstr "Bouton droit"
+
+#: ../src/propgrid/advprops.cpp:1737
+msgctxt "system cursor name"
+msgid "Sizing NE-SW"
+msgstr "Dimensionnement NE-SO"
+
+#: ../src/propgrid/advprops.cpp:1738
+msgctxt "system cursor name"
+msgid "Sizing N-S"
+msgstr "Dimensionnement N-S"
+
+#: ../src/propgrid/advprops.cpp:1739
+msgctxt "system cursor name"
+msgid "Sizing NW-SE"
+msgstr "Dimensionnement NW-SE"
+
+#: ../src/propgrid/advprops.cpp:1740
+msgctxt "system cursor name"
+msgid "Sizing W-E"
+msgstr "Dimensionnement O-E"
+
+#: ../src/propgrid/advprops.cpp:1741
+msgctxt "system cursor name"
+msgid "Sizing"
+msgstr "Dimensionnement"
+
+#: ../src/propgrid/advprops.cpp:1742
+msgctxt "system cursor name"
+msgid "Spraycan"
+msgstr "Aérosol"
+
+#: ../src/propgrid/advprops.cpp:1743
+msgctxt "system cursor name"
+msgid "Wait"
+msgstr "Attendre"
+
+#: ../src/propgrid/advprops.cpp:1744
+msgctxt "system cursor name"
+msgid "Watch"
+msgstr "Montre"
+
+#: ../src/propgrid/advprops.cpp:1745
+msgctxt "system cursor name"
+msgid "Wait Arrow"
+msgstr "Flèche d'attente"
+
+#: ../src/propgrid/advprops.cpp:2109
+msgid "Make a selection:"
+msgstr "Créer une sélection :"
+
+#: ../src/propgrid/manager.cpp:394
+msgid "Property"
+msgstr "Propriété"
+
+#: ../src/propgrid/manager.cpp:395
+msgid "Value"
+msgstr "Valeur"
+
+#: ../src/propgrid/manager.cpp:1683
+msgid "Categorized Mode"
+msgstr "Mode Catégories"
+
+#: ../src/propgrid/manager.cpp:1709
+msgid "Alphabetic Mode"
+msgstr "Mode Alphabétique"
+
+#. TRANSLATORS: Name of Boolean false value
+#: ../src/propgrid/propgrid.cpp:230
+msgid "False"
+msgstr "Faux"
+
+#. TRANSLATORS: Name of Boolean true value
+#: ../src/propgrid/propgrid.cpp:232
+msgid "True"
+msgstr "Vrai"
+
+#. TRANSLATORS: Text  displayed for unspecified value
+#: ../src/propgrid/propgrid.cpp:428
+msgid "Unspecified"
+msgstr "Non spécifié"
+
+#. TRANSLATORS: Caption of message box displaying any property error
+#: ../src/propgrid/propgrid.cpp:3145 ../src/propgrid/propgrid.cpp:3282
+msgid "Property Error"
+msgstr "Erreur de Propriété"
+
+#: ../src/propgrid/propgrid.cpp:3259
+msgid "You have entered invalid value. Press ESC to cancel editing."
+msgstr ""
+"Une valeur incorrecte a été saisie. Presser ESC pour annuler l'édition."
+
+#: ../src/propgrid/propgrid.cpp:6608
+#, c-format
+msgid "Error in resource: %s"
+msgstr "Erreur dans la ressource : %s"
+
+#: ../src/propgrid/propgridiface.cpp:377
+#, c-format
+msgid ""
+"Type operation \"%s\" failed: Property labeled \"%s\" is of type \"%s\", NOT "
+"\"%s\"."
+msgstr ""
+"Échec du type d'operation « %s » : la propriété désignée par « %s » est du "
+"type « %s », et NON « %s »."
+
+#: ../src/propgrid/props.cpp:159
+#, c-format
+msgid "Unknown base %d. Base 10 will be used."
+msgstr "Base inconnue %d. La base 10 sera utilisée."
+
+#: ../src/propgrid/props.cpp:324
+#, c-format
+msgid "Value must be %s or higher."
+msgstr "La valeur doit être %s ou plus."
+
+#: ../src/propgrid/props.cpp:329 ../src/propgrid/props.cpp:356
+#, c-format
+msgid "Value must be between %s and %s."
+msgstr "La valeur doit être entre %s et %s."
+
+#: ../src/propgrid/props.cpp:351
+#, c-format
+msgid "Value must be %s or less."
+msgstr "La valeur doit être %s ou moins."
+
+#: ../src/propgrid/props.cpp:1058
+#, c-format
+msgid "Not %s"
+msgstr "Pas %s"
+
+#: ../src/propgrid/props.cpp:1770
+msgid "Choose a directory:"
+msgstr "Choisir un dossier :"
+
+#: ../src/propgrid/props.cpp:2055
+msgid "Choose a file"
+msgstr "Choisir un fichier"
+
+#: ../src/qt/mdi.cpp:254
+msgid "&Tile"
+msgstr "&Répartir"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:147
+#: ../src/richtext/richtextformatdlg.cpp:376
+msgid "Background"
+msgstr "Arrière plan"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:159
+msgid "Background &colour:"
+msgstr "&Couleur d'arrière plan :"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:161
+#: ../src/richtext/richtextbackgroundpage.cpp:163
+msgid "Enables a background colour."
+msgstr "Active une couleur d'arrière plan."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:167
+#: ../src/richtext/richtextbackgroundpage.cpp:169
+msgid "The background colour."
+msgstr "La couleur d'arrière plan."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:178
+msgid "Shadow"
+msgstr "Ombre"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:193
+msgid "Use &shadow"
+msgstr "Utiliser une o&mbre"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:195
+#: ../src/richtext/richtextbackgroundpage.cpp:197
+msgid "Enables a shadow."
+msgstr "Active une ombre."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:211
+msgid "&Horizontal offset:"
+msgstr "Décalage &horizontal :"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:218
+#: ../src/richtext/richtextbackgroundpage.cpp:220
+msgid "The horizontal offset."
+msgstr "Le décalage horizontal."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:224
+#: ../src/richtext/richtextbackgroundpage.cpp:227
+#: ../src/richtext/richtextbackgroundpage.cpp:228
+#: ../src/richtext/richtextbackgroundpage.cpp:247
+#: ../src/richtext/richtextbackgroundpage.cpp:250
+#: ../src/richtext/richtextbackgroundpage.cpp:251
+#: ../src/richtext/richtextbackgroundpage.cpp:287
+#: ../src/richtext/richtextbackgroundpage.cpp:290
+#: ../src/richtext/richtextbackgroundpage.cpp:291
+#: ../src/richtext/richtextbackgroundpage.cpp:314
+#: ../src/richtext/richtextbackgroundpage.cpp:317
+#: ../src/richtext/richtextbackgroundpage.cpp:318
+#: ../src/richtext/richtextborderspage.cpp:252
+#: ../src/richtext/richtextborderspage.cpp:255
+#: ../src/richtext/richtextborderspage.cpp:256
+#: ../src/richtext/richtextborderspage.cpp:286
+#: ../src/richtext/richtextborderspage.cpp:289
+#: ../src/richtext/richtextborderspage.cpp:290
+#: ../src/richtext/richtextborderspage.cpp:320
+#: ../src/richtext/richtextborderspage.cpp:323
+#: ../src/richtext/richtextborderspage.cpp:324
+#: ../src/richtext/richtextborderspage.cpp:354
+#: ../src/richtext/richtextborderspage.cpp:357
+#: ../src/richtext/richtextborderspage.cpp:358
+#: ../src/richtext/richtextborderspage.cpp:420
+#: ../src/richtext/richtextborderspage.cpp:423
+#: ../src/richtext/richtextborderspage.cpp:424
+#: ../src/richtext/richtextborderspage.cpp:454
+#: ../src/richtext/richtextborderspage.cpp:457
+#: ../src/richtext/richtextborderspage.cpp:458
+#: ../src/richtext/richtextborderspage.cpp:488
+#: ../src/richtext/richtextborderspage.cpp:491
+#: ../src/richtext/richtextborderspage.cpp:492
+#: ../src/richtext/richtextborderspage.cpp:522
+#: ../src/richtext/richtextborderspage.cpp:525
+#: ../src/richtext/richtextborderspage.cpp:526
+#: ../src/richtext/richtextborderspage.cpp:590
+#: ../src/richtext/richtextborderspage.cpp:593
+#: ../src/richtext/richtextborderspage.cpp:594
+#: ../src/richtext/richtextfontpage.cpp:177
+#: ../src/richtext/richtextmarginspage.cpp:199
+#: ../src/richtext/richtextmarginspage.cpp:201
+#: ../src/richtext/richtextmarginspage.cpp:202
+#: ../src/richtext/richtextmarginspage.cpp:224
+#: ../src/richtext/richtextmarginspage.cpp:226
+#: ../src/richtext/richtextmarginspage.cpp:227
+#: ../src/richtext/richtextmarginspage.cpp:247
+#: ../src/richtext/richtextmarginspage.cpp:249
+#: ../src/richtext/richtextmarginspage.cpp:250
+#: ../src/richtext/richtextmarginspage.cpp:272
+#: ../src/richtext/richtextmarginspage.cpp:274
+#: ../src/richtext/richtextmarginspage.cpp:275
+#: ../src/richtext/richtextmarginspage.cpp:313
+#: ../src/richtext/richtextmarginspage.cpp:315
+#: ../src/richtext/richtextmarginspage.cpp:316
+#: ../src/richtext/richtextmarginspage.cpp:338
+#: ../src/richtext/richtextmarginspage.cpp:340
+#: ../src/richtext/richtextmarginspage.cpp:341
+#: ../src/richtext/richtextmarginspage.cpp:361
+#: ../src/richtext/richtextmarginspage.cpp:363
+#: ../src/richtext/richtextmarginspage.cpp:364
+#: ../src/richtext/richtextmarginspage.cpp:386
+#: ../src/richtext/richtextmarginspage.cpp:388
+#: ../src/richtext/richtextmarginspage.cpp:389
+#: ../src/richtext/richtextsizepage.cpp:337
+#: ../src/richtext/richtextsizepage.cpp:340
+#: ../src/richtext/richtextsizepage.cpp:341
+#: ../src/richtext/richtextsizepage.cpp:371
+#: ../src/richtext/richtextsizepage.cpp:374
+#: ../src/richtext/richtextsizepage.cpp:375
+#: ../src/richtext/richtextsizepage.cpp:398
+#: ../src/richtext/richtextsizepage.cpp:401
+#: ../src/richtext/richtextsizepage.cpp:402
+#: ../src/richtext/richtextsizepage.cpp:425
+#: ../src/richtext/richtextsizepage.cpp:428
+#: ../src/richtext/richtextsizepage.cpp:429
+#: ../src/richtext/richtextsizepage.cpp:452
+#: ../src/richtext/richtextsizepage.cpp:455
+#: ../src/richtext/richtextsizepage.cpp:456
+#: ../src/richtext/richtextsizepage.cpp:479
+#: ../src/richtext/richtextsizepage.cpp:482
+#: ../src/richtext/richtextsizepage.cpp:483
+#: ../src/richtext/richtextsizepage.cpp:553
+#: ../src/richtext/richtextsizepage.cpp:556
+#: ../src/richtext/richtextsizepage.cpp:557
+#: ../src/richtext/richtextsizepage.cpp:588
+#: ../src/richtext/richtextsizepage.cpp:591
+#: ../src/richtext/richtextsizepage.cpp:592
+#: ../src/richtext/richtextsizepage.cpp:623
+#: ../src/richtext/richtextsizepage.cpp:626
+#: ../src/richtext/richtextsizepage.cpp:627
+#: ../src/richtext/richtextsizepage.cpp:658
+#: ../src/richtext/richtextsizepage.cpp:661
+#: ../src/richtext/richtextsizepage.cpp:662
+msgid "px"
+msgstr "px"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:225
+#: ../src/richtext/richtextbackgroundpage.cpp:248
+#: ../src/richtext/richtextbackgroundpage.cpp:288
+#: ../src/richtext/richtextbackgroundpage.cpp:315
+#: ../src/richtext/richtextborderspage.cpp:253
+#: ../src/richtext/richtextborderspage.cpp:287
+#: ../src/richtext/richtextborderspage.cpp:321
+#: ../src/richtext/richtextborderspage.cpp:355
+#: ../src/richtext/richtextborderspage.cpp:421
+#: ../src/richtext/richtextborderspage.cpp:455
+#: ../src/richtext/richtextborderspage.cpp:489
+#: ../src/richtext/richtextborderspage.cpp:523
+#: ../src/richtext/richtextborderspage.cpp:591
+#: ../src/richtext/richtextmarginspage.cpp:200
+#: ../src/richtext/richtextmarginspage.cpp:225
+#: ../src/richtext/richtextmarginspage.cpp:248
+#: ../src/richtext/richtextmarginspage.cpp:273
+#: ../src/richtext/richtextmarginspage.cpp:314
+#: ../src/richtext/richtextmarginspage.cpp:339
+#: ../src/richtext/richtextmarginspage.cpp:362
+#: ../src/richtext/richtextmarginspage.cpp:387
+#: ../src/richtext/richtextsizepage.cpp:338
+#: ../src/richtext/richtextsizepage.cpp:372
+#: ../src/richtext/richtextsizepage.cpp:399
+#: ../src/richtext/richtextsizepage.cpp:426
+#: ../src/richtext/richtextsizepage.cpp:453
+#: ../src/richtext/richtextsizepage.cpp:480
+#: ../src/richtext/richtextsizepage.cpp:554
+#: ../src/richtext/richtextsizepage.cpp:589
+#: ../src/richtext/richtextsizepage.cpp:624
+#: ../src/richtext/richtextsizepage.cpp:659
+msgid "cm"
+msgstr "cm"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:226
+#: ../src/richtext/richtextbackgroundpage.cpp:249
+#: ../src/richtext/richtextbackgroundpage.cpp:289
+#: ../src/richtext/richtextbackgroundpage.cpp:316
+#: ../src/richtext/richtextborderspage.cpp:254
+#: ../src/richtext/richtextborderspage.cpp:288
+#: ../src/richtext/richtextborderspage.cpp:322
+#: ../src/richtext/richtextborderspage.cpp:356
+#: ../src/richtext/richtextborderspage.cpp:422
+#: ../src/richtext/richtextborderspage.cpp:456
+#: ../src/richtext/richtextborderspage.cpp:490
+#: ../src/richtext/richtextborderspage.cpp:524
+#: ../src/richtext/richtextborderspage.cpp:592
+#: ../src/richtext/richtextfontpage.cpp:176
+#: ../src/richtext/richtextfontpage.cpp:179
+msgid "pt"
+msgstr "pt"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:229
+#: ../src/richtext/richtextbackgroundpage.cpp:231
+#: ../src/richtext/richtextbackgroundpage.cpp:252
+#: ../src/richtext/richtextbackgroundpage.cpp:254
+#: ../src/richtext/richtextbackgroundpage.cpp:292
+#: ../src/richtext/richtextbackgroundpage.cpp:294
+#: ../src/richtext/richtextbackgroundpage.cpp:319
+#: ../src/richtext/richtextbackgroundpage.cpp:321
+msgid "Units for this value."
+msgstr "Unités pour cette valeur."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:234
+msgid "&Vertical offset:"
+msgstr "Décalage &vertical :"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:241
+#: ../src/richtext/richtextbackgroundpage.cpp:243
+msgid "The vertical offset."
+msgstr "Le décalage vertical."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:257
+msgid "Shadow c&olour:"
+msgstr "&Couleur de l'ombre :"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:259
+#: ../src/richtext/richtextbackgroundpage.cpp:261
+msgid "Enables the shadow colour."
+msgstr "Active la couleur de l'ombre."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:265
+#: ../src/richtext/richtextbackgroundpage.cpp:267
+msgid "The shadow colour."
+msgstr "La couleur de l'ombre."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:270
+msgid "Sh&adow spread:"
+msgstr "Dispersion de l'&ombre :"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:272
+#: ../src/richtext/richtextbackgroundpage.cpp:274
+msgid "Enables the shadow spread."
+msgstr "Active la dispersion de l'ombre."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:281
+#: ../src/richtext/richtextbackgroundpage.cpp:283
+msgid "The shadow spread."
+msgstr "La dispersion de l'ombre."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:297
+msgid "&Blur distance:"
+msgstr "Distance de &flou :"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:299
+#: ../src/richtext/richtextbackgroundpage.cpp:301
+msgid "Enables the blur distance."
+msgstr "Active la distance de flou."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:308
+#: ../src/richtext/richtextbackgroundpage.cpp:310
+msgid "The shadow blur distance."
+msgstr "La distance de flou de l'ombre."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:324
+msgid "Opaci&ty:"
+msgstr "Opaci&té :"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:326
+#: ../src/richtext/richtextbackgroundpage.cpp:328
+msgid "Enables the shadow opacity."
+msgstr "Active l'opacité de l'ombre."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:335
+#: ../src/richtext/richtextbackgroundpage.cpp:337
+msgid "The shadow opacity."
+msgstr "L'opacité de l'ombre."
+
+#. TRANSLATORS: Rich text page units (percentage)
+#: ../src/richtext/richtextbackgroundpage.cpp:340
+#: ../src/richtext/richtextsizepage.cpp:339
+#: ../src/richtext/richtextsizepage.cpp:373
+#: ../src/richtext/richtextsizepage.cpp:400
+#: ../src/richtext/richtextsizepage.cpp:427
+#: ../src/richtext/richtextsizepage.cpp:454
+#: ../src/richtext/richtextsizepage.cpp:481
+#: ../src/richtext/richtextsizepage.cpp:555
+#: ../src/richtext/richtextsizepage.cpp:590
+#: ../src/richtext/richtextsizepage.cpp:625
+#: ../src/richtext/richtextsizepage.cpp:660
+msgid "%"
+msgstr "%"
+
+#: ../src/richtext/richtextborderspage.cpp:229
+#: ../src/richtext/richtextborderspage.cpp:387
+msgid "Border"
+msgstr "Bord"
+
+#: ../src/richtext/richtextborderspage.cpp:242
+#: ../src/richtext/richtextborderspage.cpp:410
+#: ../src/richtext/richtextindentspage.cpp:194
+#: ../src/richtext/richtextliststylepage.cpp:384
+#: ../src/richtext/richtextmarginspage.cpp:185
+#: ../src/richtext/richtextmarginspage.cpp:299
+#: ../src/richtext/richtextsizepage.cpp:531
+#: ../src/richtext/richtextsizepage.cpp:538
+msgid "&Left:"
+msgstr "&Gauche:"
+
+#: ../src/richtext/richtextborderspage.cpp:257
+#: ../src/richtext/richtextborderspage.cpp:259
+msgid "Units for the left border width."
+msgstr "Unités pour l'épaisseur du bord gauche."
+
+#: ../src/richtext/richtextborderspage.cpp:266
+#: ../src/richtext/richtextborderspage.cpp:268
+#: ../src/richtext/richtextborderspage.cpp:300
+#: ../src/richtext/richtextborderspage.cpp:302
+#: ../src/richtext/richtextborderspage.cpp:334
+#: ../src/richtext/richtextborderspage.cpp:336
+#: ../src/richtext/richtextborderspage.cpp:368
+#: ../src/richtext/richtextborderspage.cpp:370
+#: ../src/richtext/richtextborderspage.cpp:434
+#: ../src/richtext/richtextborderspage.cpp:436
+#: ../src/richtext/richtextborderspage.cpp:468
+#: ../src/richtext/richtextborderspage.cpp:470
+#: ../src/richtext/richtextborderspage.cpp:502
+#: ../src/richtext/richtextborderspage.cpp:504
+#: ../src/richtext/richtextborderspage.cpp:536
+#: ../src/richtext/richtextborderspage.cpp:538
+msgid "The border line style."
+msgstr "Le style de ligne du bord."
+
+#: ../src/richtext/richtextborderspage.cpp:276
+#: ../src/richtext/richtextborderspage.cpp:444
+#: ../src/richtext/richtextindentspage.cpp:212
+#: ../src/richtext/richtextliststylepage.cpp:402
+#: ../src/richtext/richtextmarginspage.cpp:210
+#: ../src/richtext/richtextmarginspage.cpp:324
+#: ../src/richtext/richtextsizepage.cpp:601
+#: ../src/richtext/richtextsizepage.cpp:608
+msgid "&Right:"
+msgstr "&Droite :"
+
+#: ../src/richtext/richtextborderspage.cpp:291
+#: ../src/richtext/richtextborderspage.cpp:293
+msgid "Units for the right border width."
+msgstr "Unités pour l'épaisseur du bord droit."
+
+#: ../src/richtext/richtextborderspage.cpp:310
+#: ../src/richtext/richtextborderspage.cpp:478
+#: ../src/richtext/richtextmarginspage.cpp:233
+#: ../src/richtext/richtextmarginspage.cpp:347
+#: ../src/richtext/richtextsizepage.cpp:566
+#: ../src/richtext/richtextsizepage.cpp:573
+msgid "&Top:"
+msgstr "Hau&t :"
+
+#: ../src/richtext/richtextborderspage.cpp:325
+#: ../src/richtext/richtextborderspage.cpp:327
+msgid "Units for the top border width."
+msgstr "Unités pour l'épaisseur du bord supérieur."
+
+#: ../src/richtext/richtextborderspage.cpp:344
+#: ../src/richtext/richtextborderspage.cpp:512
+#: ../src/richtext/richtextmarginspage.cpp:258
+#: ../src/richtext/richtextmarginspage.cpp:372
+#: ../src/richtext/richtextsizepage.cpp:636
+#: ../src/richtext/richtextsizepage.cpp:643
+msgid "&Bottom:"
+msgstr "&Bas :"
+
+#: ../src/richtext/richtextborderspage.cpp:359
+#: ../src/richtext/richtextborderspage.cpp:361
+msgid "Units for the bottom border width."
+msgstr "Unités pour l'épaisseur du bord inférieur."
+
+#: ../src/richtext/richtextborderspage.cpp:380
+#: ../src/richtext/richtextborderspage.cpp:548
+msgid "&Synchronize values"
+msgstr "&Synchroniser les valeurs"
+
+#: ../src/richtext/richtextborderspage.cpp:382
+#: ../src/richtext/richtextborderspage.cpp:384
+#: ../src/richtext/richtextborderspage.cpp:550
+#: ../src/richtext/richtextborderspage.cpp:552
+msgid "Check to edit all borders simultaneously."
+msgstr "Cocher pour éditer toutes les bordures à la fois."
+
+#: ../src/richtext/richtextborderspage.cpp:397
+#: ../src/richtext/richtextborderspage.cpp:555
+msgid "Outline"
+msgstr "Contour"
+
+#: ../src/richtext/richtextborderspage.cpp:425
+#: ../src/richtext/richtextborderspage.cpp:427
+msgid "Units for the left outline width."
+msgstr "Unités pour l'épaisseur du contour gauche."
+
+#: ../src/richtext/richtextborderspage.cpp:459
+#: ../src/richtext/richtextborderspage.cpp:461
+msgid "Units for the right outline width."
+msgstr "Unités pour l'épaisseur du contour droit."
+
+#: ../src/richtext/richtextborderspage.cpp:493
+#: ../src/richtext/richtextborderspage.cpp:495
+msgid "Units for the top outline width."
+msgstr "Unités pour l'épaisseur du contour supérieur."
+
+#: ../src/richtext/richtextborderspage.cpp:527
+#: ../src/richtext/richtextborderspage.cpp:529
+msgid "Units for the bottom outline width."
+msgstr "Unités pour l'épaisseur du contour inférieur."
+
+#: ../src/richtext/richtextborderspage.cpp:565
+#: ../src/richtext/richtextborderspage.cpp:600
+msgid "Corner"
+msgstr "Coin"
+
+#: ../src/richtext/richtextborderspage.cpp:574
+msgid "Corner &radius:"
+msgstr "Rayon de courbure des &coins :"
+
+#: ../src/richtext/richtextborderspage.cpp:576
+#: ../src/richtext/richtextborderspage.cpp:578
+msgid "An optional corner radius for adding rounded corners."
+msgstr "Un rayon de courbure optionnel pour ajouter des coins arrondis."
+
+#: ../src/richtext/richtextborderspage.cpp:584
+#: ../src/richtext/richtextborderspage.cpp:586
+msgid "The value of the corner radius."
+msgstr "La valeur du rayon de courbure des coins."
+
+#: ../src/richtext/richtextborderspage.cpp:595
+#: ../src/richtext/richtextborderspage.cpp:597
+msgid "Units for the corner radius."
+msgstr "Unités pour le rayon de courbure de coin."
+
+#: ../src/richtext/richtextborderspage.cpp:609
+#: ../src/richtext/richtextsizepage.cpp:247
+#: ../src/richtext/richtextsizepage.cpp:251
+msgid "None"
+msgstr "Aucun"
+
+#: ../src/richtext/richtextborderspage.cpp:610
+msgid "Solid"
+msgstr "Solide"
+
+#: ../src/richtext/richtextborderspage.cpp:611
+msgid "Dotted"
+msgstr "Pointillé"
+
+#: ../src/richtext/richtextborderspage.cpp:612
+msgid "Dashed"
+msgstr "Tirets"
+
+#: ../src/richtext/richtextborderspage.cpp:613
+msgid "Double"
+msgstr "Double"
+
+#: ../src/richtext/richtextborderspage.cpp:614
+msgid "Groove"
+msgstr "Groove"
+
+#: ../src/richtext/richtextborderspage.cpp:615
+msgid "Ridge"
+msgstr "Arête"
+
+#: ../src/richtext/richtextborderspage.cpp:616
+msgid "Inset"
+msgstr "Intérieur"
+
+#: ../src/richtext/richtextborderspage.cpp:617
+msgid "Outset"
+msgstr "Extérieur"
+
+#: ../src/richtext/richtextbuffer.cpp:3518
+msgid "Change Style"
+msgstr "Modifier le style"
+
+#: ../src/richtext/richtextbuffer.cpp:3701
+msgid "Change Object Style"
+msgstr "Modifier le Style de l'Objet"
+
+#: ../src/richtext/richtextbuffer.cpp:3974
+#: ../src/richtext/richtextbuffer.cpp:8174
+msgid "Change Properties"
+msgstr "Modifier les Propriétés"
+
+#: ../src/richtext/richtextbuffer.cpp:4346
+msgid "Change List Style"
+msgstr "Modifier la liste de styles"
+
+#: ../src/richtext/richtextbuffer.cpp:4519
+msgid "Renumber List"
+msgstr "Renuméroter la liste"
+
+#: ../src/richtext/richtextbuffer.cpp:7867
+#: ../src/richtext/richtextbuffer.cpp:7897
+#: ../src/richtext/richtextbuffer.cpp:7939
+#: ../src/richtext/richtextctrl.cpp:1279 ../src/richtext/richtextctrl.cpp:1473
+msgid "Insert Text"
+msgstr "Insérer du texte"
+
+#: ../src/richtext/richtextbuffer.cpp:8023
+#: ../src/richtext/richtextbuffer.cpp:8979
+msgid "Insert Image"
+msgstr "Insérer une image"
+
+#: ../src/richtext/richtextbuffer.cpp:8070
+msgid "Insert Object"
+msgstr "Insérer un objet"
+
+#: ../src/richtext/richtextbuffer.cpp:8112
+msgid "Insert Field"
+msgstr "Insérer un champ"
+
+#: ../src/richtext/richtextbuffer.cpp:8410
+msgid "Too many EndStyle calls!"
+msgstr "Trop d'appels à EndStyle !"
+
+#: ../src/richtext/richtextbuffer.cpp:8785
+msgid "files"
+msgstr "fichiers"
+
+#: ../src/richtext/richtextbuffer.cpp:9380
+msgid "standard/circle"
+msgstr "standard/circulaire"
+
+#: ../src/richtext/richtextbuffer.cpp:9381
+msgid "standard/circle-outline"
+msgstr "standard/contour circulaire"
+
+#: ../src/richtext/richtextbuffer.cpp:9382
+msgid "standard/square"
+msgstr "standard/carré"
+
+#: ../src/richtext/richtextbuffer.cpp:9383
+msgid "standard/diamond"
+msgstr "standard/diamant"
+
+#: ../src/richtext/richtextbuffer.cpp:9384
+msgid "standard/triangle"
+msgstr "standard/triangle"
+
+#: ../src/richtext/richtextbuffer.cpp:9423
+msgid "Box Properties"
+msgstr "Propriétés de la boîte"
+
+#: ../src/richtext/richtextbuffer.cpp:10006
+msgid "Multiple Cell Properties"
+msgstr "Propriétés de Plusieurs Cellules"
+
+#: ../src/richtext/richtextbuffer.cpp:10008
+msgid "Cell Properties"
+msgstr "Propriétés de Cellule"
+
+#: ../src/richtext/richtextbuffer.cpp:11256
+msgid "Set Cell Style"
+msgstr "Définir le Style de Cellule"
+
+#: ../src/richtext/richtextbuffer.cpp:11330
+msgid "Delete Row"
+msgstr "Supprimer la ligne"
+
+#: ../src/richtext/richtextbuffer.cpp:11380
+msgid "Delete Column"
+msgstr "Supprimer la colonne"
+
+#: ../src/richtext/richtextbuffer.cpp:11431
+msgid "Add Row"
+msgstr "Ajouter une ligne"
+
+#: ../src/richtext/richtextbuffer.cpp:11494
+msgid "Add Column"
+msgstr "Ajouter une colonne"
+
+#: ../src/richtext/richtextbuffer.cpp:11537
+msgid "Table Properties"
+msgstr "Propriétés du Tableau"
+
+#: ../src/richtext/richtextbuffer.cpp:12899
+msgid "Picture Properties"
+msgstr "Propriétés de l'Image"
+
+#: ../src/richtext/richtextbuffer.cpp:13169
+#: ../src/richtext/richtextbuffer.cpp:13279
+msgid "image"
+msgstr "image"
+
+#: ../src/richtext/richtextbulletspage.cpp:145
+#: ../src/richtext/richtextliststylepage.cpp:209
+msgid "&Bullet style:"
+msgstr "Style de ti&ret :"
+
+#: ../src/richtext/richtextbulletspage.cpp:150
+#: ../src/richtext/richtextbulletspage.cpp:152
+#: ../src/richtext/richtextliststylepage.cpp:214
+#: ../src/richtext/richtextliststylepage.cpp:216
+msgid "The available bullet styles."
+msgstr "Les styles de tirets disponibles."
+
+#: ../src/richtext/richtextbulletspage.cpp:158
+#: ../src/richtext/richtextliststylepage.cpp:221
+msgid "Peri&od"
+msgstr "&Virgule"
+
+#: ../src/richtext/richtextbulletspage.cpp:160
+#: ../src/richtext/richtextbulletspage.cpp:162
+#: ../src/richtext/richtextliststylepage.cpp:223
+#: ../src/richtext/richtextliststylepage.cpp:225
+msgid "Check to add a period after the bullet."
+msgstr "Cocher pour ajouter un point après le tiret."
+
+#. TRANSLATORS: Bullet point in parentheses option
+#: ../src/richtext/richtextbulletspage.cpp:167
+#: ../src/richtext/richtextliststylepage.cpp:230
+msgid "(*)"
+msgstr "(*)"
+
+#: ../src/richtext/richtextbulletspage.cpp:169
+#: ../src/richtext/richtextbulletspage.cpp:171
+#: ../src/richtext/richtextliststylepage.cpp:232
+#: ../src/richtext/richtextliststylepage.cpp:234
+msgid "Check to enclose the bullet in parentheses."
+msgstr "Cocher pour mettre le tiret entre parenthèses."
+
+#. TRANSLATORS: Right parenthesis bullet point option
+#: ../src/richtext/richtextbulletspage.cpp:176
+#: ../src/richtext/richtextliststylepage.cpp:239
+msgid "*)"
+msgstr "*)"
+
+#: ../src/richtext/richtextbulletspage.cpp:178
+#: ../src/richtext/richtextbulletspage.cpp:180
+#: ../src/richtext/richtextliststylepage.cpp:241
+#: ../src/richtext/richtextliststylepage.cpp:243
+msgid "Check to add a right parenthesis."
+msgstr "Cocher pour ajouter une parenthèse à droite."
+
+#: ../src/richtext/richtextbulletspage.cpp:185
+#: ../src/richtext/richtextliststylepage.cpp:248
+msgid "Bullet &Alignment:"
+msgstr "&Alignement des tirets:"
+
+#: ../src/richtext/richtextbulletspage.cpp:190
+#: ../src/richtext/richtextliststylepage.cpp:253
+msgid "Centre"
+msgstr "Centre"
+
+#: ../src/richtext/richtextbulletspage.cpp:194
+#: ../src/richtext/richtextbulletspage.cpp:196
+#: ../src/richtext/richtextbulletspage.cpp:217
+#: ../src/richtext/richtextbulletspage.cpp:219
+#: ../src/richtext/richtextliststylepage.cpp:257
+#: ../src/richtext/richtextliststylepage.cpp:259
+#: ../src/richtext/richtextliststylepage.cpp:278
+#: ../src/richtext/richtextliststylepage.cpp:280
+msgid "The bullet character."
+msgstr "Le caractère de tiret."
+
+#: ../src/richtext/richtextbulletspage.cpp:212
+#: ../src/richtext/richtextliststylepage.cpp:271
+msgid "&Symbol:"
+msgstr "&Symbole :"
+
+#: ../src/richtext/richtextbulletspage.cpp:222
+#: ../src/richtext/richtextliststylepage.cpp:283
+msgid "Ch&oose..."
+msgstr "&Choisir..."
+
+#: ../src/richtext/richtextbulletspage.cpp:223
+#: ../src/richtext/richtextbulletspage.cpp:225
+#: ../src/richtext/richtextliststylepage.cpp:284
+#: ../src/richtext/richtextliststylepage.cpp:286
+msgid "Click to browse for a symbol."
+msgstr "Cliquer pour rechercher un symbole."
+
+#: ../src/richtext/richtextbulletspage.cpp:230
+#: ../src/richtext/richtextliststylepage.cpp:291
+msgid "Symbol &font:"
+msgstr "Police du symbole:"
+
+#: ../src/richtext/richtextbulletspage.cpp:235
+#: ../src/richtext/richtextbulletspage.cpp:237
+#: ../src/richtext/richtextliststylepage.cpp:297
+msgid "Available fonts."
+msgstr "Polices de caractères disponibles."
+
+#: ../src/richtext/richtextbulletspage.cpp:242
+#: ../src/richtext/richtextliststylepage.cpp:302
+msgid "S&tandard bullet name:"
+msgstr "Nom s&tandard de tiret :"
+
+#: ../src/richtext/richtextbulletspage.cpp:247
+#: ../src/richtext/richtextbulletspage.cpp:249
+#: ../src/richtext/richtextliststylepage.cpp:307
+#: ../src/richtext/richtextliststylepage.cpp:309
+msgid "A standard bullet name."
+msgstr "Un nom de tiret standard."
+
+#: ../src/richtext/richtextbulletspage.cpp:254
+msgid "&Number:"
+msgstr "&Numéro :"
+
+#: ../src/richtext/richtextbulletspage.cpp:258
+#: ../src/richtext/richtextbulletspage.cpp:260
+msgid "The list item number."
+msgstr "Le numéro de l'élément de la liste."
+
+#: ../src/richtext/richtextbulletspage.cpp:266
+#: ../src/richtext/richtextbulletspage.cpp:268
+#: ../src/richtext/richtextliststylepage.cpp:475
+#: ../src/richtext/richtextliststylepage.cpp:477
+msgid "Shows a preview of the bullet settings."
+msgstr "Affiche un aperçu des réglages pour les tirets."
+
+#: ../src/richtext/richtextbulletspage.cpp:276
+#: ../src/richtext/richtextliststylepage.cpp:484
+msgid "(None)"
+msgstr "(Aucun)"
+
+#: ../src/richtext/richtextbulletspage.cpp:277
+#: ../src/richtext/richtextliststylepage.cpp:485
+msgid "Arabic"
+msgstr "Arabe"
+
+#: ../src/richtext/richtextbulletspage.cpp:278
+#: ../src/richtext/richtextliststylepage.cpp:486
+msgid "Upper case letters"
+msgstr "Lettres majuscules"
+
+#: ../src/richtext/richtextbulletspage.cpp:279
+#: ../src/richtext/richtextliststylepage.cpp:487
+msgid "Lower case letters"
+msgstr "Lettres minuscules"
+
+#: ../src/richtext/richtextbulletspage.cpp:280
+#: ../src/richtext/richtextliststylepage.cpp:488
+msgid "Upper case roman numerals"
+msgstr "Chiffres romains majuscules"
+
+#: ../src/richtext/richtextbulletspage.cpp:281
+#: ../src/richtext/richtextliststylepage.cpp:489
+msgid "Lower case roman numerals"
+msgstr "Chiffres romains minuscules"
+
+#: ../src/richtext/richtextbulletspage.cpp:282
+#: ../src/richtext/richtextliststylepage.cpp:490
+msgid "Numbered outline"
+msgstr "Table des matières numérotée"
+
+#: ../src/richtext/richtextbulletspage.cpp:283
+#: ../src/richtext/richtextliststylepage.cpp:491
+msgid "Symbol"
+msgstr "Symbole"
+
+#: ../src/richtext/richtextbulletspage.cpp:284
+#: ../src/richtext/richtextliststylepage.cpp:492
+msgid "Bitmap"
+msgstr "Image bitmap"
+
+#: ../src/richtext/richtextbulletspage.cpp:285
+#: ../src/richtext/richtextliststylepage.cpp:493
+msgid "Standard"
+msgstr "Standard"
+
+#: ../src/richtext/richtextbulletspage.cpp:287
+#: ../src/richtext/richtextliststylepage.cpp:495
+msgid "*"
+msgstr "*"
+
+#: ../src/richtext/richtextbulletspage.cpp:288
+#: ../src/richtext/richtextliststylepage.cpp:496
+msgid "-"
+msgstr "-"
+
+#: ../src/richtext/richtextbulletspage.cpp:289
+#: ../src/richtext/richtextliststylepage.cpp:497
+msgid ">"
+msgstr ">"
+
+#: ../src/richtext/richtextbulletspage.cpp:290
+#: ../src/richtext/richtextliststylepage.cpp:498
+msgid "+"
+msgstr "+"
+
+#: ../src/richtext/richtextbulletspage.cpp:291
+#: ../src/richtext/richtextliststylepage.cpp:499
+msgid "~"
+msgstr "~"
+
+#: ../src/richtext/richtextctrl.cpp:859
+msgid "Drag"
+msgstr "Glisser"
+
+#: ../src/richtext/richtextctrl.cpp:1338 ../src/richtext/richtextctrl.cpp:1559
+msgid "Delete Text"
+msgstr "Supprimer le texte"
+
+#: ../src/richtext/richtextctrl.cpp:1537
+msgid "Remove Bullet"
+msgstr "Retirer le tiret"
+
+#: ../src/richtext/richtextctrl.cpp:3070
+msgid "The text couldn't be saved."
+msgstr "Le texte n'a pas pu être enregistré."
+
+#: ../src/richtext/richtextctrl.cpp:3644
+msgid "Replace"
+msgstr "Remplacer"
+
+#: ../src/richtext/richtextfontpage.cpp:146
+#: ../src/richtext/richtextsymboldlg.cpp:384
+msgid "&Font:"
+msgstr "&Police :"
+
+#: ../src/richtext/richtextfontpage.cpp:150
+#: ../src/richtext/richtextfontpage.cpp:152
+msgid "Type a font name."
+msgstr "Taper le nom d'une police de caractères."
+
+#: ../src/richtext/richtextfontpage.cpp:158
+msgid "&Size:"
+msgstr "&Taille :"
+
+#: ../src/richtext/richtextfontpage.cpp:165
+#: ../src/richtext/richtextfontpage.cpp:167
+msgid "Type a size in points."
+msgstr "Saisir une taille en points."
+
+#: ../src/richtext/richtextfontpage.cpp:180
+#: ../src/richtext/richtextfontpage.cpp:182
+msgid "The font size units, points or pixels."
+msgstr "Les unités de taille de police, points ou pixels."
+
+#: ../src/richtext/richtextfontpage.cpp:189
+#: ../src/richtext/richtextfontpage.cpp:191
+msgid "Lists the available fonts."
+msgstr "Liste des polices de caractères disponibles."
+
+#: ../src/richtext/richtextfontpage.cpp:196
+#: ../src/richtext/richtextfontpage.cpp:198
+msgid "Lists font sizes in points."
+msgstr "Liste des tailles de polices en points."
+
+#: ../src/richtext/richtextfontpage.cpp:207
+msgid "Font st&yle:"
+msgstr "St&yle de la police :"
+
+#: ../src/richtext/richtextfontpage.cpp:212
+#: ../src/richtext/richtextfontpage.cpp:214
+msgid "Select regular or italic style."
+msgstr "Choisir normal ou italique."
+
+#: ../src/richtext/richtextfontpage.cpp:220
+msgid "Font &weight:"
+msgstr "Lar&geur de police :"
+
+#: ../src/richtext/richtextfontpage.cpp:225
+#: ../src/richtext/richtextfontpage.cpp:227
+msgid "Select regular or bold."
+msgstr "Choisir normal ou gras."
+
+#: ../src/richtext/richtextfontpage.cpp:233
+msgid "&Underlining:"
+msgstr "So&uligner:"
+
+#: ../src/richtext/richtextfontpage.cpp:238
+#: ../src/richtext/richtextfontpage.cpp:240
+msgid "Select underlining or no underlining."
+msgstr "Choisir normal ou souligné."
+
+#: ../src/richtext/richtextfontpage.cpp:248
+msgid "&Colour:"
+msgstr "C&ouleur :"
+
+#: ../src/richtext/richtextfontpage.cpp:253
+#: ../src/richtext/richtextfontpage.cpp:255
+msgid "Click to change the text colour."
+msgstr "Cliquer pour changer la couleur du texte."
+
+#: ../src/richtext/richtextfontpage.cpp:261
+msgid "&Bg colour:"
+msgstr "Couleur de &fond :"
+
+#: ../src/richtext/richtextfontpage.cpp:266
+#: ../src/richtext/richtextfontpage.cpp:268
+msgid "Click to change the text background colour."
+msgstr "Cliquer pour changer la couleur d'arrière-plan du texte."
+
+#: ../src/richtext/richtextfontpage.cpp:276
+#: ../src/richtext/richtextfontpage.cpp:278
+msgid "Check to show a line through the text."
+msgstr "Cocher pour afficher une ligne à travers le texte."
+
+#: ../src/richtext/richtextfontpage.cpp:281
+msgid "Ca&pitals"
+msgstr "Majuscules"
+
+#: ../src/richtext/richtextfontpage.cpp:283
+#: ../src/richtext/richtextfontpage.cpp:285
+msgid "Check to show the text in capitals."
+msgstr "Cocher pour afficher le texte en majuscules."
+
+#: ../src/richtext/richtextfontpage.cpp:288
+msgid "Small C&apitals"
+msgstr "Petites M&ajuscules"
+
+#: ../src/richtext/richtextfontpage.cpp:290
+#: ../src/richtext/richtextfontpage.cpp:292
+msgid "Check to show the text in small capitals."
+msgstr "Cocher pour afficher le texte en petites majuscules."
+
+#: ../src/richtext/richtextfontpage.cpp:295
+msgid "Supe&rscript"
+msgstr "Exposant"
+
+#: ../src/richtext/richtextfontpage.cpp:297
+#: ../src/richtext/richtextfontpage.cpp:299
+msgid "Check to show the text in superscript."
+msgstr "Cocher pour afficher le texte en exposant."
+
+#: ../src/richtext/richtextfontpage.cpp:302
+msgid "Subscrip&t"
+msgstr "Indice"
+
+#: ../src/richtext/richtextfontpage.cpp:304
+#: ../src/richtext/richtextfontpage.cpp:306
+msgid "Check to show the text in subscript."
+msgstr "Cocher pour afficher le texte en indice."
+
+#: ../src/richtext/richtextfontpage.cpp:312
+msgid "Rig&ht-to-left"
+msgstr "Droite-à-gauche"
+
+#: ../src/richtext/richtextfontpage.cpp:314
+#: ../src/richtext/richtextfontpage.cpp:316
+msgid "Check to indicate right-to-left text layout."
+msgstr "Cocher pour indiquer une disposition de texte de droite-à-gauche."
+
+#: ../src/richtext/richtextfontpage.cpp:319
+msgid "Suppress hyphe&nation"
+msgstr "Supprimer l'hyphé&nation"
+
+#: ../src/richtext/richtextfontpage.cpp:321
+#: ../src/richtext/richtextfontpage.cpp:323
+msgid "Check to suppress hyphenation."
+msgstr "Cocher pour supprimer l'hyphénation."
+
+#: ../src/richtext/richtextfontpage.cpp:329
+#: ../src/richtext/richtextfontpage.cpp:331
+msgid "Shows a preview of the font settings."
+msgstr "Affiche un aperçu de réglages de la police."
+
+#: ../src/richtext/richtextfontpage.cpp:348
+#: ../src/richtext/richtextfontpage.cpp:352
+#: ../src/richtext/richtextfontpage.cpp:356
+#: ../src/richtext/richtextformatdlg.cpp:873
+#: ../src/richtext/richtextindentspage.cpp:273
+#: ../src/richtext/richtextindentspage.cpp:285
+#: ../src/richtext/richtextindentspage.cpp:286
+#: ../src/richtext/richtextindentspage.cpp:310
+#: ../src/richtext/richtextindentspage.cpp:325
+#: ../src/richtext/richtextliststylepage.cpp:451
+#: ../src/richtext/richtextliststylepage.cpp:463
+#: ../src/richtext/richtextliststylepage.cpp:464
+msgid "(none)"
+msgstr "(aucun)"
+
+#: ../src/richtext/richtextfontpage.cpp:349
+#: ../src/richtext/richtextfontpage.cpp:353
+msgid "Regular"
+msgstr "Régulier"
+
+#: ../src/richtext/richtextfontpage.cpp:357
+msgid "Not underlined"
+msgstr "Non souligné"
+
+#: ../src/richtext/richtextformatdlg.cpp:341
+msgid "Indents && Spacing"
+msgstr "Indentations && Espacements"
+
+#: ../src/richtext/richtextformatdlg.cpp:346
+msgid "Tabs"
+msgstr "Tabulations"
+
+#: ../src/richtext/richtextformatdlg.cpp:351
+msgid "Bullets"
+msgstr "Tirets"
+
+#: ../src/richtext/richtextformatdlg.cpp:356
+msgid "List Style"
+msgstr "Style de liste"
+
+#: ../src/richtext/richtextformatdlg.cpp:366
+#: ../src/richtext/richtextmarginspage.cpp:170
+msgid "Margins"
+msgstr "Marges"
+
+#: ../src/richtext/richtextformatdlg.cpp:371
+msgid "Borders"
+msgstr "Bords"
+
+#: ../src/richtext/richtextformatdlg.cpp:765
+msgid "Colour"
+msgstr "Couleur"
+
+#: ../src/richtext/richtextindentspage.cpp:127
+#: ../src/richtext/richtextliststylepage.cpp:322
+msgid "&Alignment"
+msgstr "&Alignement"
+
+#: ../src/richtext/richtextindentspage.cpp:138
+#: ../src/richtext/richtextliststylepage.cpp:331
+msgid "&Left"
+msgstr "&Gauche"
+
+#: ../src/richtext/richtextindentspage.cpp:140
+#: ../src/richtext/richtextindentspage.cpp:142
+#: ../src/richtext/richtextliststylepage.cpp:333
+#: ../src/richtext/richtextliststylepage.cpp:335
+msgid "Left-align text."
+msgstr "Aligne le texte à gauche."
+
+#: ../src/richtext/richtextindentspage.cpp:145
+#: ../src/richtext/richtextliststylepage.cpp:338
+msgid "&Right"
+msgstr "&Droite"
+
+#: ../src/richtext/richtextindentspage.cpp:147
+#: ../src/richtext/richtextindentspage.cpp:149
+#: ../src/richtext/richtextliststylepage.cpp:340
+#: ../src/richtext/richtextliststylepage.cpp:342
+msgid "Right-align text."
+msgstr "Alignement à droite du texte."
+
+#: ../src/richtext/richtextindentspage.cpp:152
+#: ../src/richtext/richtextliststylepage.cpp:345
+msgid "&Justified"
+msgstr "&Justifié"
+
+#: ../src/richtext/richtextindentspage.cpp:154
+#: ../src/richtext/richtextindentspage.cpp:156
+#: ../src/richtext/richtextliststylepage.cpp:347
+#: ../src/richtext/richtextliststylepage.cpp:349
+msgid "Justify text left and right."
+msgstr "Justifier le texte."
+
+#: ../src/richtext/richtextindentspage.cpp:159
+#: ../src/richtext/richtextliststylepage.cpp:352
+msgid "Cen&tred"
+msgstr "Cen&tré"
+
+#: ../src/richtext/richtextindentspage.cpp:161
+#: ../src/richtext/richtextindentspage.cpp:163
+#: ../src/richtext/richtextliststylepage.cpp:354
+#: ../src/richtext/richtextliststylepage.cpp:356
+msgid "Centre text."
+msgstr "Centrer le texte."
+
+#: ../src/richtext/richtextindentspage.cpp:166
+#: ../src/richtext/richtextliststylepage.cpp:359
+msgid "&Indeterminate"
+msgstr "&Indeterminé"
+
+#: ../src/richtext/richtextindentspage.cpp:168
+#: ../src/richtext/richtextindentspage.cpp:170
+#: ../src/richtext/richtextliststylepage.cpp:361
+#: ../src/richtext/richtextliststylepage.cpp:363
+msgid "Use the current alignment setting."
+msgstr "Utiliser les réglages courants d'alignement."
+
+#: ../src/richtext/richtextindentspage.cpp:183
+#: ../src/richtext/richtextliststylepage.cpp:375
+msgid "&Indentation (tenths of a mm)"
+msgstr "&Indentation (dixièmes de mm)"
+
+#: ../src/richtext/richtextindentspage.cpp:198
+#: ../src/richtext/richtextindentspage.cpp:200
+#: ../src/richtext/richtextliststylepage.cpp:388
+#: ../src/richtext/richtextliststylepage.cpp:390
+msgid "The left indent."
+msgstr "L'indentation de gauche."
+
+#: ../src/richtext/richtextindentspage.cpp:203
+#: ../src/richtext/richtextliststylepage.cpp:393
+msgid "Left (&first line):"
+msgstr "Gauche (&Première ligne):"
+
+#: ../src/richtext/richtextindentspage.cpp:207
+#: ../src/richtext/richtextindentspage.cpp:209
+#: ../src/richtext/richtextliststylepage.cpp:397
+#: ../src/richtext/richtextliststylepage.cpp:399
+msgid "The first line indent."
+msgstr "Indentation de la première ligne."
+
+#: ../src/richtext/richtextindentspage.cpp:216
+#: ../src/richtext/richtextindentspage.cpp:218
+#: ../src/richtext/richtextliststylepage.cpp:406
+#: ../src/richtext/richtextliststylepage.cpp:408
+msgid "The right indent."
+msgstr "L'indentation à droite."
+
+#: ../src/richtext/richtextindentspage.cpp:221
+msgid "&Outline level:"
+msgstr "Niveau de C&ontour :"
+
+#: ../src/richtext/richtextindentspage.cpp:226
+#: ../src/richtext/richtextindentspage.cpp:228
+msgid "The outline level."
+msgstr "Le niveau du contour."
+
+#: ../src/richtext/richtextindentspage.cpp:241
+#: ../src/richtext/richtextliststylepage.cpp:420
+msgid "&Spacing (tenths of a mm)"
+msgstr "E&spacement (dixièmes de mm)"
+
+#: ../src/richtext/richtextindentspage.cpp:252
+msgid "&Before a paragraph:"
+msgstr "Avant un paragraphe :"
+
+#: ../src/richtext/richtextindentspage.cpp:256
+#: ../src/richtext/richtextindentspage.cpp:258
+#: ../src/richtext/richtextliststylepage.cpp:433
+#: ../src/richtext/richtextliststylepage.cpp:435
+msgid "The spacing before the paragraph."
+msgstr "L'espacement avant le paragraphe."
+
+#: ../src/richtext/richtextindentspage.cpp:261
+msgid "&After a paragraph:"
+msgstr "&Après un paragraphe :"
+
+#: ../src/richtext/richtextindentspage.cpp:266
+#: ../src/richtext/richtextliststylepage.cpp:442
+#: ../src/richtext/richtextliststylepage.cpp:444
+msgid "The spacing after the paragraph."
+msgstr "L'espacement après le paragraphe."
+
+#: ../src/richtext/richtextindentspage.cpp:269
+msgid "L&ine spacing:"
+msgstr "Interligne :"
+
+#: ../src/richtext/richtextindentspage.cpp:274
+#: ../src/richtext/richtextliststylepage.cpp:452
+msgid "Single"
+msgstr "Simple"
+
+#: ../src/richtext/richtextindentspage.cpp:275
+#: ../src/richtext/richtextliststylepage.cpp:453
+msgid "1.1"
+msgstr "1.1"
+
+#: ../src/richtext/richtextindentspage.cpp:276
+#: ../src/richtext/richtextliststylepage.cpp:454
+msgid "1.2"
+msgstr "1.2"
+
+#: ../src/richtext/richtextindentspage.cpp:277
+#: ../src/richtext/richtextliststylepage.cpp:455
+msgid "1.3"
+msgstr "1.3"
+
+#: ../src/richtext/richtextindentspage.cpp:278
+#: ../src/richtext/richtextliststylepage.cpp:456
+msgid "1.4"
+msgstr "1.4"
+
+#: ../src/richtext/richtextindentspage.cpp:279
+#: ../src/richtext/richtextliststylepage.cpp:457
+msgid "1.5"
+msgstr "1,5"
+
+#: ../src/richtext/richtextindentspage.cpp:280
+#: ../src/richtext/richtextliststylepage.cpp:458
+msgid "1.6"
+msgstr "1.6"
+
+#: ../src/richtext/richtextindentspage.cpp:281
+#: ../src/richtext/richtextliststylepage.cpp:459
+msgid "1.7"
+msgstr "1.7"
+
+#: ../src/richtext/richtextindentspage.cpp:282
+#: ../src/richtext/richtextliststylepage.cpp:460
+msgid "1.8"
+msgstr "1.8"
+
+#: ../src/richtext/richtextindentspage.cpp:283
+#: ../src/richtext/richtextliststylepage.cpp:461
+msgid "1.9"
+msgstr "1.9"
+
+#: ../src/richtext/richtextindentspage.cpp:284
+#: ../src/richtext/richtextliststylepage.cpp:462
+msgid "2"
+msgstr "2"
+
+#: ../src/richtext/richtextindentspage.cpp:287
+#: ../src/richtext/richtextindentspage.cpp:289
+#: ../src/richtext/richtextliststylepage.cpp:465
+#: ../src/richtext/richtextliststylepage.cpp:467
+msgid "The line spacing."
+msgstr "L'espacement d'interligne."
+
+#: ../src/richtext/richtextindentspage.cpp:292
+msgid "&Page Break"
+msgstr "Saut de &Page"
+
+#: ../src/richtext/richtextindentspage.cpp:294
+#: ../src/richtext/richtextindentspage.cpp:296
+msgid "Inserts a page break before the paragraph."
+msgstr "Insère un saut de page avant le paragraphe."
+
+#: ../src/richtext/richtextindentspage.cpp:302
+#: ../src/richtext/richtextindentspage.cpp:304
+msgid "Shows a preview of the paragraph settings."
+msgstr "Affiche un aperçu des réglages de paragraphe."
+
+#: ../src/richtext/richtextliststylepage.cpp:182
+msgid "&List level:"
+msgstr "Niveau de &Liste:"
+
+#: ../src/richtext/richtextliststylepage.cpp:186
+#: ../src/richtext/richtextliststylepage.cpp:188
+msgid "Selects the list level to edit."
+msgstr "Choisir le niveau de liste à éditer."
+
+#: ../src/richtext/richtextliststylepage.cpp:193
+msgid "&Font for Level..."
+msgstr "&Police de caractères pour le Niveau..."
+
+#: ../src/richtext/richtextliststylepage.cpp:194
+#: ../src/richtext/richtextliststylepage.cpp:196
+msgid "Click to choose the font for this level."
+msgstr "Cliquer pour choisir la police de ce niveau."
+
+#: ../src/richtext/richtextliststylepage.cpp:312
+msgid "Bullet style"
+msgstr "Style des tirets"
+
+#: ../src/richtext/richtextliststylepage.cpp:429
+msgid "Before a paragraph:"
+msgstr "Avant un paragraphe:"
+
+#: ../src/richtext/richtextliststylepage.cpp:438
+msgid "After a paragraph:"
+msgstr "Après un paragraphe:"
+
+#: ../src/richtext/richtextliststylepage.cpp:447
+msgid "Line spacing:"
+msgstr "Espacement interligne:"
+
+#: ../src/richtext/richtextliststylepage.cpp:470
+msgid "Spacing"
+msgstr "Espacement"
+
+#: ../src/richtext/richtextmarginspage.cpp:193
+#: ../src/richtext/richtextmarginspage.cpp:195
+msgid "The left margin size."
+msgstr "La taille de la marge gauche."
+
+#: ../src/richtext/richtextmarginspage.cpp:203
+#: ../src/richtext/richtextmarginspage.cpp:205
+msgid "Units for the left margin."
+msgstr "Unités pour la marge gauche."
+
+#: ../src/richtext/richtextmarginspage.cpp:218
+#: ../src/richtext/richtextmarginspage.cpp:220
+msgid "The right margin size."
+msgstr "La taille de la marge droite."
+
+#: ../src/richtext/richtextmarginspage.cpp:228
+#: ../src/richtext/richtextmarginspage.cpp:230
+msgid "Units for the right margin."
+msgstr "Unités pour la marge droite."
+
+#: ../src/richtext/richtextmarginspage.cpp:241
+#: ../src/richtext/richtextmarginspage.cpp:243
+msgid "The top margin size."
+msgstr "La taille de la marge supérieure."
+
+#: ../src/richtext/richtextmarginspage.cpp:251
+#: ../src/richtext/richtextmarginspage.cpp:253
+msgid "Units for the top margin."
+msgstr "Unités pour la marge supérieure."
+
+#: ../src/richtext/richtextmarginspage.cpp:266
+#: ../src/richtext/richtextmarginspage.cpp:268
+msgid "The bottom margin size."
+msgstr "La taille de la marge inférieure."
+
+#: ../src/richtext/richtextmarginspage.cpp:276
+#: ../src/richtext/richtextmarginspage.cpp:278
+msgid "Units for the bottom margin."
+msgstr "Unités pour la marge inférieure."
+
+#: ../src/richtext/richtextmarginspage.cpp:284
+msgid "Padding"
+msgstr "Espacement"
+
+#: ../src/richtext/richtextmarginspage.cpp:307
+#: ../src/richtext/richtextmarginspage.cpp:309
+msgid "The left padding size."
+msgstr "La taille de l'espacement gauche."
+
+#: ../src/richtext/richtextmarginspage.cpp:317
+#: ../src/richtext/richtextmarginspage.cpp:319
+msgid "Units for the left padding."
+msgstr "Unités pour l'espacement gauche."
+
+#: ../src/richtext/richtextmarginspage.cpp:332
+#: ../src/richtext/richtextmarginspage.cpp:334
+msgid "The right padding size."
+msgstr "La taille de l'espacement droit."
+
+#: ../src/richtext/richtextmarginspage.cpp:342
+#: ../src/richtext/richtextmarginspage.cpp:344
+msgid "Units for the right padding."
+msgstr "Unités pour l'espacement droit."
+
+#: ../src/richtext/richtextmarginspage.cpp:355
+#: ../src/richtext/richtextmarginspage.cpp:357
+msgid "The top padding size."
+msgstr "La taille de l'espacement supérieur."
+
+#: ../src/richtext/richtextmarginspage.cpp:365
+#: ../src/richtext/richtextmarginspage.cpp:367
+msgid "Units for the top padding."
+msgstr "Unités pour l'espacement supérieur."
+
+#: ../src/richtext/richtextmarginspage.cpp:380
+#: ../src/richtext/richtextmarginspage.cpp:382
+msgid "The bottom padding size."
+msgstr "La taille de l'espacement inférieur."
+
+#: ../src/richtext/richtextmarginspage.cpp:390
+#: ../src/richtext/richtextmarginspage.cpp:392
+msgid "Units for the bottom padding."
+msgstr "Unités pour l'espacement inférieur."
+
+#: ../src/richtext/richtextprint.cpp:592
+msgid " Preview"
+msgstr " Aperçu"
+
+#: ../src/richtext/richtextsizepage.cpp:228
+msgid "Floating"
+msgstr "Flottant"
+
+#: ../src/richtext/richtextsizepage.cpp:243
+msgid "&Floating mode:"
+msgstr "Mode &flottant :"
+
+#: ../src/richtext/richtextsizepage.cpp:252
+#: ../src/richtext/richtextsizepage.cpp:254
+msgid "How the object will float relative to the text."
+msgstr "Comment l'objet flottera par rapport au texte."
+
+#: ../src/richtext/richtextsizepage.cpp:265
+msgid "Alignment"
+msgstr "Alignement"
+
+#: ../src/richtext/richtextsizepage.cpp:277
+msgid "&Vertical alignment:"
+msgstr "Alignement &vertical :"
+
+#: ../src/richtext/richtextsizepage.cpp:279
+#: ../src/richtext/richtextsizepage.cpp:281
+msgid "Enable vertical alignment."
+msgstr "Activer l'alignement vertical."
+
+#: ../src/richtext/richtextsizepage.cpp:286
+msgid "Centred"
+msgstr "Centré"
+
+#: ../src/richtext/richtextsizepage.cpp:290
+#: ../src/richtext/richtextsizepage.cpp:292
+msgid "Vertical alignment."
+msgstr "Alignement vertical."
+
+#: ../src/richtext/richtextsizepage.cpp:316
+#: ../src/richtext/richtextsizepage.cpp:323
+msgid "&Width:"
+msgstr "&Largeur :"
+
+#: ../src/richtext/richtextsizepage.cpp:318
+#: ../src/richtext/richtextsizepage.cpp:320
+msgid "Enable the width value."
+msgstr "Activer la valeur de largeur."
+
+#: ../src/richtext/richtextsizepage.cpp:331
+#: ../src/richtext/richtextsizepage.cpp:333
+msgid "The object width."
+msgstr "La largeur de l'objet."
+
+#: ../src/richtext/richtextsizepage.cpp:342
+#: ../src/richtext/richtextsizepage.cpp:344
+msgid "Units for the object width."
+msgstr "Unités pour la largeur de l'objet."
+
+#: ../src/richtext/richtextsizepage.cpp:350
+#: ../src/richtext/richtextsizepage.cpp:357
+msgid "&Height:"
+msgstr "&Hauteur :"
+
+#: ../src/richtext/richtextsizepage.cpp:352
+#: ../src/richtext/richtextsizepage.cpp:354
+#: ../src/richtext/richtextsizepage.cpp:464
+#: ../src/richtext/richtextsizepage.cpp:466
+msgid "Enable the height value."
+msgstr "Activer la valeur de hauteur."
+
+#: ../src/richtext/richtextsizepage.cpp:365
+#: ../src/richtext/richtextsizepage.cpp:367
+msgid "The object height."
+msgstr "La hauteur de l'objet."
+
+#: ../src/richtext/richtextsizepage.cpp:376
+#: ../src/richtext/richtextsizepage.cpp:378
+msgid "Units for the object height."
+msgstr "Unités pour la hauteur de l'objet."
+
+#: ../src/richtext/richtextsizepage.cpp:381
+msgid "Min width:"
+msgstr "Largeur min. :"
+
+#: ../src/richtext/richtextsizepage.cpp:383
+#: ../src/richtext/richtextsizepage.cpp:385
+msgid "Enable the minimum width value."
+msgstr "Activer la valeur minimale de largeur."
+
+#: ../src/richtext/richtextsizepage.cpp:392
+#: ../src/richtext/richtextsizepage.cpp:394
+msgid "The object minimum width."
+msgstr "La largeur minimum de l'objet."
+
+#: ../src/richtext/richtextsizepage.cpp:403
+#: ../src/richtext/richtextsizepage.cpp:405
+msgid "Units for the minimum object width."
+msgstr "Unités pour la largeur minimum de l'objet."
+
+#: ../src/richtext/richtextsizepage.cpp:408
+msgid "Min height:"
+msgstr "Hauteur min. :"
+
+#: ../src/richtext/richtextsizepage.cpp:410
+#: ../src/richtext/richtextsizepage.cpp:412
+msgid "Enable the minimum height value."
+msgstr "Activer la valeur minimale de hauteur."
+
+#: ../src/richtext/richtextsizepage.cpp:419
+#: ../src/richtext/richtextsizepage.cpp:421
+msgid "The object minimum height."
+msgstr "La hauteur minimum de l'objet."
+
+#: ../src/richtext/richtextsizepage.cpp:430
+#: ../src/richtext/richtextsizepage.cpp:432
+msgid "Units for the minimum object height."
+msgstr "Unités pour la hauteur minimum de l'objet."
+
+#: ../src/richtext/richtextsizepage.cpp:435
+msgid "Max width:"
+msgstr "Largeur max. :"
+
+#: ../src/richtext/richtextsizepage.cpp:437
+#: ../src/richtext/richtextsizepage.cpp:439
+msgid "Enable the maximum width value."
+msgstr "Activer la valeur maximale de largeur."
+
+#: ../src/richtext/richtextsizepage.cpp:446
+#: ../src/richtext/richtextsizepage.cpp:448
+msgid "The object maximum width."
+msgstr "La largeur maximum de l'objet."
+
+#: ../src/richtext/richtextsizepage.cpp:457
+#: ../src/richtext/richtextsizepage.cpp:459
+msgid "Units for the maximum object width."
+msgstr "Unités pour la largeurmaximum de l'objet."
+
+#: ../src/richtext/richtextsizepage.cpp:462
+msgid "Max height:"
+msgstr "Hauteur max. :"
+
+#: ../src/richtext/richtextsizepage.cpp:473
+#: ../src/richtext/richtextsizepage.cpp:475
+msgid "The object maximum height."
+msgstr "La hauteur maximum de l'objet."
+
+#: ../src/richtext/richtextsizepage.cpp:484
+#: ../src/richtext/richtextsizepage.cpp:486
+msgid "Units for the maximum object height."
+msgstr "Unités pour la hauteur maximum de l'objet."
+
+#: ../src/richtext/richtextsizepage.cpp:495
+msgid "Position"
+msgstr "Position"
+
+#: ../src/richtext/richtextsizepage.cpp:513
+msgid "&Position mode:"
+msgstr "Mode de &position :"
+
+#: ../src/richtext/richtextsizepage.cpp:517
+#: ../src/richtext/richtextsizepage.cpp:522
+msgid "Static"
+msgstr "Statique"
+
+#: ../src/richtext/richtextsizepage.cpp:518
+msgid "Relative"
+msgstr "Relatif"
+
+#: ../src/richtext/richtextsizepage.cpp:519
+msgid "Absolute"
+msgstr "Absolue"
+
+#: ../src/richtext/richtextsizepage.cpp:520
+msgid "Fixed"
+msgstr "Fixe"
+
+#: ../src/richtext/richtextsizepage.cpp:533
+#: ../src/richtext/richtextsizepage.cpp:535
+#: ../src/richtext/richtextsizepage.cpp:547
+#: ../src/richtext/richtextsizepage.cpp:549
+msgid "The left position."
+msgstr "La position gauche."
+
+#: ../src/richtext/richtextsizepage.cpp:558
+#: ../src/richtext/richtextsizepage.cpp:560
+msgid "Units for the left position."
+msgstr "Unités pour la position gauche."
+
+#: ../src/richtext/richtextsizepage.cpp:568
+#: ../src/richtext/richtextsizepage.cpp:570
+#: ../src/richtext/richtextsizepage.cpp:582
+#: ../src/richtext/richtextsizepage.cpp:584
+msgid "The top position."
+msgstr "La position supérieure."
+
+#: ../src/richtext/richtextsizepage.cpp:593
+#: ../src/richtext/richtextsizepage.cpp:595
+msgid "Units for the top position."
+msgstr "Unités pour la position supérieure."
+
+#: ../src/richtext/richtextsizepage.cpp:603
+#: ../src/richtext/richtextsizepage.cpp:605
+#: ../src/richtext/richtextsizepage.cpp:617
+#: ../src/richtext/richtextsizepage.cpp:619
+msgid "The right position."
+msgstr "La position droite."
+
+#: ../src/richtext/richtextsizepage.cpp:628
+#: ../src/richtext/richtextsizepage.cpp:630
+msgid "Units for the right position."
+msgstr "Unités pour la position droite."
+
+#: ../src/richtext/richtextsizepage.cpp:638
+#: ../src/richtext/richtextsizepage.cpp:640
+#: ../src/richtext/richtextsizepage.cpp:652
+#: ../src/richtext/richtextsizepage.cpp:654
+msgid "The bottom position."
+msgstr "La position inférieure."
+
+#: ../src/richtext/richtextsizepage.cpp:663
+#: ../src/richtext/richtextsizepage.cpp:665
+msgid "Units for the bottom position."
+msgstr "Unités pour la position inférieure."
+
+#: ../src/richtext/richtextsizepage.cpp:671
+msgid "&Move the object to:"
+msgstr "&Déplacer l'objet vers :"
+
+#: ../src/richtext/richtextsizepage.cpp:674
+msgid "&Previous Paragraph"
+msgstr "Paragraphe &Précédent"
+
+#: ../src/richtext/richtextsizepage.cpp:675
+#: ../src/richtext/richtextsizepage.cpp:677
+msgid "Moves the object to the previous paragraph."
+msgstr "Déplacer l'objet vers le paragraphe précédent."
+
+#: ../src/richtext/richtextsizepage.cpp:680
+msgid "&Next Paragraph"
+msgstr "Paragraphe Suiva&nt"
+
+#: ../src/richtext/richtextsizepage.cpp:681
+#: ../src/richtext/richtextsizepage.cpp:683
+msgid "Moves the object to the next paragraph."
+msgstr "Déplacer l'objet vers le paragraphe suivant."
+
+#: ../src/richtext/richtextstyledlg.cpp:193
+msgid "&Styles:"
+msgstr "&Style :"
+
+#: ../src/richtext/richtextstyledlg.cpp:197
+#: ../src/richtext/richtextstyledlg.cpp:199
+msgid "The available styles."
+msgstr "Les styles disponibles."
+
+#: ../src/richtext/richtextstyledlg.cpp:205
+#: ../src/richtext/richtextstyledlg.cpp:217
+msgid " "
+msgstr " "
+
+#: ../src/richtext/richtextstyledlg.cpp:209
+#: ../src/richtext/richtextstyledlg.cpp:211
+msgid "The style preview."
+msgstr "Aperçu des styles."
+
+#: ../src/richtext/richtextstyledlg.cpp:220
+msgid "New &Character Style..."
+msgstr "Nouveau Style de &Caractères..."
+
+#: ../src/richtext/richtextstyledlg.cpp:221
+#: ../src/richtext/richtextstyledlg.cpp:223
+msgid "Click to create a new character style."
+msgstr "Cliquer pour créer un nouveau style de caractère."
+
+#: ../src/richtext/richtextstyledlg.cpp:226
+msgid "New &Paragraph Style..."
+msgstr "Nouveau Style de &Paragraphe..."
+
+#: ../src/richtext/richtextstyledlg.cpp:227
+#: ../src/richtext/richtextstyledlg.cpp:229
+msgid "Click to create a new paragraph style."
+msgstr "Cliquer pour créer un nouveau style de paragraphe."
+
+#: ../src/richtext/richtextstyledlg.cpp:232
+msgid "New &List Style..."
+msgstr "Nouveau Style de &Liste..."
+
+#: ../src/richtext/richtextstyledlg.cpp:233
+#: ../src/richtext/richtextstyledlg.cpp:235
+msgid "Click to create a new list style."
+msgstr "Cliquer pour créer un nouveau style de liste."
+
+#: ../src/richtext/richtextstyledlg.cpp:238
+msgid "New &Box Style..."
+msgstr "Nouveau Style de &Boîte..."
+
+#: ../src/richtext/richtextstyledlg.cpp:239
+#: ../src/richtext/richtextstyledlg.cpp:241
+msgid "Click to create a new box style."
+msgstr "Cliquer pour créer un nouveau style de boîte."
+
+#: ../src/richtext/richtextstyledlg.cpp:246
+msgid "&Apply Style"
+msgstr "&Appliquer le style"
+
+#: ../src/richtext/richtextstyledlg.cpp:247
+#: ../src/richtext/richtextstyledlg.cpp:249
+msgid "Click to apply the selected style."
+msgstr "Cliquer pour appliquer le style sélectionné."
+
+#: ../src/richtext/richtextstyledlg.cpp:252
+msgid "&Rename Style..."
+msgstr "&Renommer le style..."
+
+#: ../src/richtext/richtextstyledlg.cpp:253
+#: ../src/richtext/richtextstyledlg.cpp:255
+msgid "Click to rename the selected style."
+msgstr "Cliquer pour renommer le style sélectionné."
+
+#: ../src/richtext/richtextstyledlg.cpp:258
+msgid "&Edit Style..."
+msgstr "Édit&er le style..."
+
+#: ../src/richtext/richtextstyledlg.cpp:259
+#: ../src/richtext/richtextstyledlg.cpp:261
+msgid "Click to edit the selected style."
+msgstr "Cliquer pour éditer le style sélectionné."
+
+#: ../src/richtext/richtextstyledlg.cpp:264
+msgid "&Delete Style..."
+msgstr "Su&pprimer le style..."
+
+#: ../src/richtext/richtextstyledlg.cpp:265
+#: ../src/richtext/richtextstyledlg.cpp:267
+msgid "Click to delete the selected style."
+msgstr "Cliquer pour suprimer le style sélectionné."
+
+#: ../src/richtext/richtextstyledlg.cpp:274
+#: ../src/richtext/richtextstyledlg.cpp:276
+msgid "Click to close this window."
+msgstr "Cliquer pour fermer cette fenêtre."
+
+#: ../src/richtext/richtextstyledlg.cpp:282
+msgid "&Restart numbering"
+msgstr "&Recommencer la numérotation"
+
+#: ../src/richtext/richtextstyledlg.cpp:284
+#: ../src/richtext/richtextstyledlg.cpp:286
+msgid "Check to restart numbering."
+msgstr "Cocher pour recommencer la numérotation."
+
+#: ../src/richtext/richtextstyledlg.cpp:601
+msgid "Enter a character style name"
+msgstr "Entrer le nom d'un style de caractère"
+
+#: ../src/richtext/richtextstyledlg.cpp:601
+#: ../src/richtext/richtextstyledlg.cpp:606
+#: ../src/richtext/richtextstyledlg.cpp:649
+#: ../src/richtext/richtextstyledlg.cpp:654
+#: ../src/richtext/richtextstyledlg.cpp:815
+#: ../src/richtext/richtextstyledlg.cpp:820
+#: ../src/richtext/richtextstyledlg.cpp:888
+#: ../src/richtext/richtextstyledlg.cpp:896
+#: ../src/richtext/richtextstyledlg.cpp:929
+#: ../src/richtext/richtextstyledlg.cpp:934
+msgid "New Style"
+msgstr "Nouveau style"
+
+#: ../src/richtext/richtextstyledlg.cpp:606
+#: ../src/richtext/richtextstyledlg.cpp:654
+#: ../src/richtext/richtextstyledlg.cpp:820
+#: ../src/richtext/richtextstyledlg.cpp:896
+#: ../src/richtext/richtextstyledlg.cpp:934
+msgid "Sorry, that name is taken. Please choose another."
+msgstr "Ce nom est déjà pris, en choisir un autre."
+
+#: ../src/richtext/richtextstyledlg.cpp:649
+msgid "Enter a paragraph style name"
+msgstr "Entrer le nom d'un style de paragraphe"
+
+#: ../src/richtext/richtextstyledlg.cpp:777
+#, c-format
+msgid "Delete style %s?"
+msgstr "Faut-il supprimer le style %s ?"
+
+#: ../src/richtext/richtextstyledlg.cpp:777
+msgid "Delete Style"
+msgstr "Supprimer le style"
+
+#: ../src/richtext/richtextstyledlg.cpp:815
+msgid "Enter a list style name"
+msgstr "Entrer le nom d'un style de liste"
+
+#: ../src/richtext/richtextstyledlg.cpp:888
+msgid "Enter a new style name"
+msgstr "Entrer le nom d'un nouveau style"
+
+#: ../src/richtext/richtextstyledlg.cpp:929
+msgid "Enter a box style name"
+msgstr "Entrer le nom d'un style de boîte"
+
+#: ../src/richtext/richtextstylepage.cpp:109
+#: ../src/richtext/richtextstylepage.cpp:111
+msgid "The style name."
+msgstr "Le nom du style."
+
+#: ../src/richtext/richtextstylepage.cpp:114
+msgid "&Based on:"
+msgstr "&Basé sur:"
+
+#: ../src/richtext/richtextstylepage.cpp:119
+#: ../src/richtext/richtextstylepage.cpp:121
+msgid "The style on which this style is based."
+msgstr "Le style sur lequel ce style est basé."
+
+#: ../src/richtext/richtextstylepage.cpp:124
+msgid "&Next style:"
+msgstr "&Style Suivant :"
+
+#: ../src/richtext/richtextstylepage.cpp:129
+#: ../src/richtext/richtextstylepage.cpp:131
+msgid "The default style for the next paragraph."
+msgstr "Le style par défaut pour le paragraphe suivant."
+
+#: ../src/richtext/richtextstyles.cpp:1057
+msgid "All styles"
+msgstr "Tous les styles"
+
+#: ../src/richtext/richtextstyles.cpp:1058
+msgid "Paragraph styles"
+msgstr "Styles de paragraphe"
+
+#: ../src/richtext/richtextstyles.cpp:1059
+msgid "Character styles"
+msgstr "Styles de caractères"
+
+#: ../src/richtext/richtextstyles.cpp:1060
+msgid "List styles"
+msgstr "Styles de liste"
+
+#: ../src/richtext/richtextstyles.cpp:1061
+msgid "Box styles"
+msgstr "Styles de boîte"
+
+#: ../src/richtext/richtextsymboldlg.cpp:389
+#: ../src/richtext/richtextsymboldlg.cpp:391
+msgid "The font from which to take the symbol."
+msgstr "La police de laquelle prendre le symbole."
+
+#: ../src/richtext/richtextsymboldlg.cpp:396
+msgid "&Subset:"
+msgstr "&Sous-ensemble:"
+
+#: ../src/richtext/richtextsymboldlg.cpp:401
+#: ../src/richtext/richtextsymboldlg.cpp:403
+msgid "Shows a Unicode subset."
+msgstr "Affiche un échantillon d'Unicode."
+
+#: ../src/richtext/richtextsymboldlg.cpp:412
+msgid "xxxx"
+msgstr "xxxx"
+
+#: ../src/richtext/richtextsymboldlg.cpp:417
+msgid "&Character code:"
+msgstr "&Code caractère :"
+
+#: ../src/richtext/richtextsymboldlg.cpp:421
+#: ../src/richtext/richtextsymboldlg.cpp:423
+msgid "The character code."
+msgstr "Le code caractère."
+
+#: ../src/richtext/richtextsymboldlg.cpp:428
+msgid "&From:"
+msgstr "De :"
+
+#: ../src/richtext/richtextsymboldlg.cpp:433
+#: ../src/richtext/richtextsymboldlg.cpp:434
+#: ../src/richtext/richtextsymboldlg.cpp:435
+msgid "Unicode"
+msgstr "Unicode"
+
+#: ../src/richtext/richtextsymboldlg.cpp:436
+#: ../src/richtext/richtextsymboldlg.cpp:438
+msgid "The range to show."
+msgstr "L'intervalle à afficher."
+
+#: ../src/richtext/richtextsymboldlg.cpp:444
+msgid "Insert"
+msgstr "Insérer"
+
+#: ../src/richtext/richtextsymboldlg.cpp:478
+msgid "(Normal text)"
+msgstr "(Texte normal)"
+
+#: ../src/richtext/richtexttabspage.cpp:109
+msgid "&Position (tenths of a mm):"
+msgstr "&Position (dizièmes de mm):"
+
+#: ../src/richtext/richtexttabspage.cpp:113
+#: ../src/richtext/richtexttabspage.cpp:115
+msgid "The tab position."
+msgstr "La position du taquet de tabulation."
+
+#: ../src/richtext/richtexttabspage.cpp:119
+msgid "The tab positions."
+msgstr "La position des taquets de tabulation."
+
+#: ../src/richtext/richtexttabspage.cpp:132
+#: ../src/richtext/richtexttabspage.cpp:134
+msgid "Click to create a new tab position."
+msgstr "Cliquer pour créer une nouvelle position de tabulation."
+
+#: ../src/richtext/richtexttabspage.cpp:138
+#: ../src/richtext/richtexttabspage.cpp:140
+msgid "Click to delete the selected tab position."
+msgstr "Cliquer pour supprimer la position de tabulation sélectionnée."
+
+#: ../src/richtext/richtexttabspage.cpp:143
+msgid "Delete A&ll"
+msgstr "&Tout supprimer"
+
+#: ../src/richtext/richtexttabspage.cpp:144
+#: ../src/richtext/richtexttabspage.cpp:146
+msgid "Click to delete all tab positions."
+msgstr "Cliquer pour supprimer toutes les positions de tabulation."
+
+#: ../src/univ/theme.cpp:110
+msgid "Failed to initialize GUI: no built-in themes found."
+msgstr ""
+"Échec de l'initialisation de l'interface graphique : aucun thème préfabriqué "
+"n'a été trouvé."
+
+#: ../src/univ/themes/gtk.cpp:521
+msgid "GTK+ theme"
+msgstr "Thème GTK+"
+
+#: ../src/univ/themes/metal.cpp:164
+msgid "Metal theme"
+msgstr "Thème métallique"
+
+#: ../src/univ/themes/mono.cpp:512
+msgid "Simple monochrome theme"
+msgstr "Simple thème monochrome"
+
+#: ../src/univ/themes/win32.cpp:1098
+msgid "Win32 theme"
+msgstr "Thème Win32"
+
+#: ../src/univ/themes/win32.cpp:3743
+msgid "&Restore"
+msgstr "&Restaurer"
+
+#: ../src/univ/themes/win32.cpp:3744
+msgid "&Move"
+msgstr "&Déplacer"
+
+#: ../src/univ/themes/win32.cpp:3746
+msgid "&Size"
+msgstr "&Taille"
+
+#: ../src/univ/themes/win32.cpp:3748
+msgid "Mi&nimize"
+msgstr "Mi&nimiser"
+
+#: ../src/univ/themes/win32.cpp:3750
+msgid "Ma&ximize"
+msgstr "Ma&ximiser"
+
+#: ../src/univ/themes/win32.cpp:3752
+msgid "Alt+"
+msgstr "Alt+"
+
+#: ../src/unix/appunix.cpp:178
+msgid "Failed to install signal handler"
+msgstr "Échec de l'installation du gestionnaire de signal"
+
+#: ../src/unix/dialup.cpp:351
+msgid "Already dialling ISP."
+msgstr "FAI déjà en cours d'appel."
+
+#: ../src/unix/dlunix.cpp:93
+msgid "Failed to unload shared library"
+msgstr "Échec au déchargement de la bibliothèque partagée"
+
+#: ../src/unix/dlunix.cpp:121
+msgid "Unknown dynamic library error"
+msgstr "Erreur de bibliothèque dynamique inconnue"
+
+#: ../src/unix/epolldispatcher.cpp:84
+msgid "Failed to create epoll descriptor"
+msgstr "Échec de la création du descripteur epoll"
+
+#: ../src/unix/epolldispatcher.cpp:103
+msgid "Error closing epoll descriptor"
+msgstr "Erreur lors de la fermeture du descripteur epoll"
+
+#: ../src/unix/epolldispatcher.cpp:116
+#, c-format
+msgid "Failed to add descriptor %d to epoll descriptor %d"
+msgstr "Échec de l'ajout du descripteur %d au descripteur epoll %d"
+
+#: ../src/unix/epolldispatcher.cpp:136
+#, c-format
+msgid "Failed to modify descriptor %d in epoll descriptor %d"
+msgstr ""
+"Échec de la modification du descripteur %d dans le descripteur epoll %d"
+
+#: ../src/unix/epolldispatcher.cpp:155
+#, c-format
+msgid "Failed to unregister descriptor %d from epoll descriptor %d"
+msgstr ""
+"Échec de la désinscription du descripteur %d depuis le descripteur epoll %d"
+
+#: ../src/unix/epolldispatcher.cpp:213
+#, c-format
+msgid "Waiting for IO on epoll descriptor %d failed"
+msgstr "Échec de l'attente de l'E/S sur le descriptoeur epoll %d"
+
+#: ../src/unix/fswatcher_inotify.cpp:71
+msgid "Unable to create inotify instance"
+msgstr "Impossible de créer une instance inotify"
+
+#: ../src/unix/fswatcher_inotify.cpp:94
+msgid "Unable to close inotify instance"
+msgstr "Impossible de fermer une instance inotify"
+
+#: ../src/unix/fswatcher_inotify.cpp:106
+msgid "Unable to add inotify watch"
+msgstr "Impossible d'ajouter un scrutateur inotify"
+
+#: ../src/unix/fswatcher_inotify.cpp:138
+#, c-format
+msgid "Unable to remove inotify watch %i"
+msgstr "Impossible de retirer un scrutateur inotify %i"
+
+#: ../src/unix/fswatcher_inotify.cpp:271
+#, c-format
+msgid "Unexpected event for \"%s\": no matching watch descriptor."
+msgstr ""
+"Évènement inattendu pour « %s » : pas de descripteur de surveillance "
+"correspondant."
+
+#: ../src/unix/fswatcher_inotify.cpp:320
+#, c-format
+msgid "Invalid inotify event for \"%s\""
+msgstr "Évènement inotify pour « %s » non valable"
+
+#: ../src/unix/fswatcher_inotify.cpp:553
+msgid "Unable to read from inotify descriptor"
+msgstr "Impossible de lire depuis le descripteur inotify"
+
+#: ../src/unix/fswatcher_inotify.cpp:558
+msgid "EOF while reading from inotify descriptor"
+msgstr ""
+"Fin de fichier (EOF) atteinte lors de la lecture depuis le descripteur "
+"inotify"
+
+#: ../src/unix/fswatcher_kqueue.cpp:114
+msgid "Unable to create kqueue instance"
+msgstr "Impossible de créer une instance kqueue"
+
+#: ../src/unix/fswatcher_kqueue.cpp:131
+msgid "Error closing kqueue instance"
+msgstr "Erreur lors de la fermeture de l'instance kqueue"
+
+#: ../src/unix/fswatcher_kqueue.cpp:153
+msgid "Unable to add kqueue watch"
+msgstr "Impossible d'ajouter un scrutateur kqueue"
+
+#: ../src/unix/fswatcher_kqueue.cpp:170
+msgid "Unable to remove kqueue watch"
+msgstr "Impossible de retirer un scrutateur kqueue"
+
+#: ../src/unix/fswatcher_kqueue.cpp:202
+msgid "Unable to get events from kqueue"
+msgstr "Impossible d'obtenir les évènements depuis kqueue"
+
+#: ../src/unix/mediactrl.cpp:966
+#, c-format
+msgid "Media playback error: %s"
+msgstr "Erreur du lecteur de média : %s"
+
+#: ../src/unix/mediactrl.cpp:1228
+#, c-format
+msgid "Failed to prepare playing \"%s\"."
+msgstr "Échec de la préparation à la lecture « %s »."
+
+#: ../src/unix/snglinst.cpp:164
+#, c-format
+msgid "Failed to write to lock file '%s'"
+msgstr "Échec de l'écriture dans le fichier verrou « %s »"
+
+#: ../src/unix/snglinst.cpp:177
+#, c-format
+msgid "Failed to set permissions on lock file '%s'"
+msgstr "Échec de la configuration des permissions du fichier verrou « %s »"
+
+#: ../src/unix/snglinst.cpp:194
+#, c-format
+msgid "Failed to lock the lock file '%s'"
+msgstr "Échec du verrouillage du fichier verrou « %s »"
+
+#: ../src/unix/snglinst.cpp:237
+#, c-format
+msgid "Failed to inspect the lock file '%s'"
+msgstr "Échec de l'inspection du fichier verrou « %s »"
+
+#: ../src/unix/snglinst.cpp:242
+#, c-format
+msgid "Lock file '%s' has incorrect owner."
+msgstr "Le fichier verrou « %s » a un propriétaire incorrect."
+
+#: ../src/unix/snglinst.cpp:247
+#, c-format
+msgid "Lock file '%s' has incorrect permissions."
+msgstr "Le fichier verrou « %s » a des permissions incorrectes."
+
+#: ../src/unix/snglinst.cpp:265
+msgid "Failed to access lock file."
+msgstr "Échec de l'accès au fichier verrou."
+
+#: ../src/unix/snglinst.cpp:274
+msgid "Failed to read PID from lock file."
+msgstr ""
+"Échec de la lecture du numéro de processus (PID) depuis le fichier verrou."
+
+#: ../src/unix/snglinst.cpp:284
+#, c-format
+msgid "Failed to remove stale lock file '%s'."
+msgstr "Échec de la suppression du fichier verrou périmé « %s »."
+
+#: ../src/unix/snglinst.cpp:297
+#, c-format
+msgid "Deleted stale lock file '%s'."
+msgstr "Suppression du fichier verrou périmé « %s »."
+
+#: ../src/unix/snglinst.cpp:308
+#, c-format
+msgid "Invalid lock file '%s'."
+msgstr "Fichier verrou « %s » non valable."
+
+#: ../src/unix/snglinst.cpp:324
+#, c-format
+msgid "Failed to remove lock file '%s'"
+msgstr "Échec de la suppression du fichier verrou « %s »"
+
+#: ../src/unix/snglinst.cpp:330
+#, c-format
+msgid "Failed to unlock lock file '%s'"
+msgstr "Échec du déverrouillage du fichier verrou « %s »"
+
+#: ../src/unix/snglinst.cpp:336
+#, c-format
+msgid "Failed to close lock file '%s'"
+msgstr "Échec de la fermeture du fichier verrou « %s »"
+
+#: ../src/unix/sound.cpp:77
+msgid "No sound"
+msgstr "Pas de son"
+
+#: ../src/unix/sound.cpp:364
+msgid "Unable to play sound asynchronously."
+msgstr "Impossible de jouer les sons de manière non synchrone."
+
+#: ../src/unix/sound.cpp:458
+#, c-format
+msgid "Couldn't load sound data from '%s'."
+msgstr "Impossible de charger les données sonores depuis « %s »."
+
+#: ../src/unix/sound.cpp:465
+#, c-format
+msgid "Sound file '%s' is in unsupported format."
+msgstr "Format du fichier sonore « %s » non reconnu."
+
+#: ../src/unix/sound.cpp:480
+msgid "Sound data are in unsupported format."
+msgstr "Format des données sonores non reconnu."
+
+#: ../src/unix/sound_sdl.cpp:226
+#, c-format
+msgid "Couldn't open audio: %s"
+msgstr "Impossible d'ouvrir le fichier audio : %s"
+
+#: ../src/unix/threadpsx.cpp:1033
+msgid "Cannot retrieve thread scheduling policy."
+msgstr "Impossible de récupérer la charte de planification des processus."
+
+#: ../src/unix/threadpsx.cpp:1058
+#, c-format
+msgid "Cannot get priority range for scheduling policy %d."
+msgstr ""
+"Impossible d'obtenir une gamme de priorités pour la stratégie de "
+"planification %d."
+
+#: ../src/unix/threadpsx.cpp:1066
+msgid "Thread priority setting is ignored."
+msgstr "La priorité donnée au processus est ignorée."
+
+#: ../src/unix/threadpsx.cpp:1221
+msgid ""
+"Failed to join a thread, potential memory leak detected - please restart the "
+"program"
+msgstr ""
+"Échec de l'adjonction d'un processus : fuite potentielle de mémoire "
+"détectée, redémarrer le programme"
+
+#: ../src/unix/threadpsx.cpp:1352
+#, c-format
+msgid "Failed to set thread concurrency level to %lu"
+msgstr "Échec de l'établissement du niveau de concurrence de processus à %lu"
+
+#: ../src/unix/threadpsx.cpp:1481
+#, c-format
+msgid "Failed to set thread priority %d."
+msgstr "Échec de la configuration de la priorité %d du processus."
+
+#: ../src/unix/threadpsx.cpp:1666
+msgid "Failed to terminate a thread."
+msgstr "Échec de la terminaison d'un processus."
+
+#: ../src/unix/threadpsx.cpp:1893
+msgid "Thread module initialization failed: failed to create thread key"
+msgstr ""
+"Échec de l'initialisation du module du processus : échec de la création de "
+"la clé du processus"
+
+#: ../src/unix/utilsunx.cpp:340
+msgid "Impossible to get child process input"
+msgstr "Impossible d'obtenir l'entrée du processus fils"
+
+#: ../src/unix/utilsunx.cpp:390
+msgid "Can't write to child process's stdin"
+msgstr "Impossible d'écrire sur l'entrée du processus enfant"
+
+#: ../src/unix/utilsunx.cpp:644
+#, c-format
+msgid "Failed to execute '%s'\n"
+msgstr "Échec de l'exécution de « %s »\n"
+
+#: ../src/unix/utilsunx.cpp:678
+msgid "Fork failed"
+msgstr "Échec du clonage"
+
+#: ../src/unix/utilsunx.cpp:701
+msgid "Failed to set process priority"
+msgstr "Échec de la définition de la priorité du processus"
+
+#: ../src/unix/utilsunx.cpp:712
+msgid "Failed to redirect child process input/output"
+msgstr "Échec de la redirection des entrées et sorties du processus fils"
+
+#: ../src/unix/utilsunx.cpp:816
+msgid "Failed to set up non-blocking pipe, the program might hang."
+msgstr ""
+"Échec de l'établissement du tube (pipe) non bloquant, le prgramme pourrait "
+"s'arrêter inopinément."
+
+#: ../src/unix/utilsunx.cpp:1023
+msgid "Cannot get the hostname"
+msgstr "Impossible d'obtenir le nom d'hôte"
+
+#: ../src/unix/utilsunx.cpp:1059
+msgid "Cannot get the official hostname"
+msgstr "Impossible d'obtenir le nom d'hôte officiel"
+
+#: ../src/unix/wakeuppipe.cpp:49
+msgid "Failed to create wake up pipe used by event loop."
+msgstr ""
+"Échec de la création d'un tube (pipe) de réveil utilisé par la boucle "
+"d'évènements."
+
+#: ../src/unix/wakeuppipe.cpp:56
+msgid "Failed to switch wake up pipe to non-blocking mode"
+msgstr ""
+"Échec du basculement du tube (pipe) de réveil vers le mode non bloquant"
+
+#: ../src/unix/wakeuppipe.cpp:117
+msgid "Failed to read from wake-up pipe"
+msgstr "Échec de la lecture du tube (pipe) de réveil"
+
+#: ../src/x11/app.cpp:124
+#, c-format
+msgid "Invalid geometry specification '%s'"
+msgstr "Spécification géométrique « %s » non valable"
+
+#: ../src/x11/app.cpp:167
+msgid "wxWidgets could not open display. Exiting."
+msgstr "wxWidgets n'a pas pu ouvrir d'affichage : abandon."
+
+#: ../src/x11/utils.cpp:169
+#, c-format
+msgid "Failed to close the display \"%s\""
+msgstr "Échec de la fermeture de l'écran « %s »."
+
+#: ../src/x11/utils.cpp:188
+#, c-format
+msgid "Failed to open display \"%s\"."
+msgstr "Échec de l'ouverture de l'écran « %s »."
+
+#: ../src/xml/xml.cpp:868
+#, c-format
+msgid "XML parsing error: '%s' at line %d"
+msgstr "Erreur d'analyse XML : « %s » à la ligne %d"
+
+#: ../src/xrc/xh_propgrid.cpp:239
+#, c-format
+msgid "Page %i"
+msgstr "Page %i"
+
+#: ../src/xrc/xmlres.cpp:448
+#, c-format
+msgid "Cannot load resources from '%s'."
+msgstr "Impossible de charger les ressources depuis « %s »."
+
+#: ../src/xrc/xmlres.cpp:799
+#, c-format
+msgid "Cannot open resources file '%s'."
+msgstr "Impossible d'ouvrir le fichier de ressources « %s »."
+
+#: ../src/xrc/xmlres.cpp:806
+#, c-format
+msgid "Cannot load resources from file '%s'."
+msgstr "Impossible de charger les ressources du fichier « %s »."
+
+#: ../src/xrc/xmlres.cpp:2767
+#, c-format
+msgid "Creating %s \"%s\" failed."
+msgstr "Échec de la création de %s « %s »."

--- a/po_wxstd/gl_ES.po
+++ b/po_wxstd/gl_ES.po
@@ -1,0 +1,10657 @@
+# translation of wxstd_gl_ES.po to Galician
+# Leandro Regueiro <leandro.regueiro@gmail.com>, 2006.
+# Nuria Andión <nandiez@gmail.com>, 2013.
+msgid ""
+msgstr ""
+"Project-Id-Version: wxWidgets 3.3\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-05-14 20:23+0200\n"
+"PO-Revision-Date: 2013-11-01 21:34+0100\n"
+"Last-Translator: Nuria Andión <nandiez@gmail.com>\n"
+"Language-Team: Proxecto Trasno <proxecto@trasno.net>\n"
+"Language: gl\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Poedit 1.5.7\n"
+"X-Poedit-SourceCharset: UTF-8\n"
+
+#: ../include/wx/defs.h:2582
+msgid "All files (*.*)|*.*"
+msgstr "Todos os ficheiros (*.*)|*.*"
+
+#: ../include/wx/defs.h:2585
+msgid "All files (*)|*"
+msgstr "Todos os ficheiros (*)|*"
+
+#: ../include/wx/generic/progdlgg.h:85
+msgid "Elapsed time:"
+msgstr "Tempo transcorrido:"
+
+#: ../include/wx/generic/progdlgg.h:86
+msgid "Estimated time:"
+msgstr "Tempo estimado:"
+
+#: ../include/wx/generic/progdlgg.h:87
+msgid "Remaining time:"
+msgstr "Tempo restante:"
+
+#. TRANSLATORS: HTML printout default title.
+#: ../include/wx/html/htmprint.h:121 ../include/wx/prntbase.h:273
+#: ../include/wx/richtext/richtextprint.h:109 ../src/common/docview.cpp:2161
+msgid "Printout"
+msgstr "Saída de impresión"
+
+#. TRANSLATORS: HTML easy print default title.
+#: ../include/wx/html/htmprint.h:234 ../include/wx/richtext/richtextprint.h:163
+#: ../src/common/prntbase.cpp:522 ../src/html/htmprint.cpp:291
+msgid "Printing"
+msgstr "Imprimindo"
+
+#: ../include/wx/msgdlg.h:277 ../src/common/stockitem.cpp:211
+msgid "Yes"
+msgstr "Si"
+
+#: ../include/wx/msgdlg.h:278 ../src/common/stockitem.cpp:182
+msgid "No"
+msgstr "Non"
+
+#: ../include/wx/msgdlg.h:279 ../src/common/stockitem.cpp:183
+#: ../src/msw/msgdlg.cpp:430 ../src/msw/msgdlg.cpp:734
+#: ../src/richtext/richtextstyledlg.cpp:292
+msgid "OK"
+msgstr "Aceptar"
+
+#: ../include/wx/msgdlg.h:280 ../src/common/stockitem.cpp:150
+#: ../src/msw/msgdlg.cpp:430 ../src/msw/progdlg.cpp:884
+#: ../src/richtext/richtextstyledlg.cpp:295
+msgid "Cancel"
+msgstr "Cancelar"
+
+#: ../include/wx/msgdlg.h:281 ../src/common/stockitem.cpp:168
+#: ../src/html/helpdlg.cpp:63 ../src/html/helpfrm.cpp:108
+#: ../src/osx/button_osx.cpp:38
+msgid "Help"
+msgstr "Axuda"
+
+#: ../include/wx/msw/ole/oleutils.h:52
+msgid "Cannot initialize OLE"
+msgstr "Non se puido inicializar OLE"
+
+#: ../include/wx/msw/private/fswatcher.h:48
+#, c-format
+msgid "Unable to close the handle for '%s'"
+msgstr "Non se puido pechar o manexador para '%s'"
+
+#: ../include/wx/msw/private/fswatcher.h:92
+#, c-format
+msgid "Failed to open directory \"%s\" for monitoring."
+msgstr "Erro ao abrir cartafol \"%s\" para monitorización."
+
+#: ../include/wx/msw/private/fswatcher.h:125
+msgid "Unable to close I/O completion port handle"
+msgstr "Non é posíbel pechar manexador de porto E/S"
+
+#: ../include/wx/msw/private/fswatcher.h:142
+msgid "Unable to associate handle with I/O completion port"
+msgstr "Non é posíbel asociar manexador con porto E/S"
+
+#: ../include/wx/msw/private/fswatcher.h:148
+msgid "Unexpectedly new I/O completion port was created"
+msgstr "Creouse inesperadamente un novo porto E/S"
+
+#: ../include/wx/msw/private/fswatcher.h:213
+msgid "Unable to post completion status"
+msgstr "Non se puido enviar o estatus de terminación"
+
+#: ../include/wx/msw/private/fswatcher.h:262
+msgid "Unable to dequeue completion packet"
+msgstr "Non se puido retirar da cola o paquete de completado"
+
+#: ../include/wx/msw/private/fswatcher.h:273
+msgid "Unable to create I/O completion port"
+msgstr "Fallo ao crear un porto de E/S"
+
+#: ../include/wx/richmsgdlg.h:29
+msgid "&See details"
+msgstr "Ver &detalles"
+
+#: ../include/wx/richmsgdlg.h:30
+msgid "&Hide details"
+msgstr "&Ocultar detalles"
+
+#: ../include/wx/richtext/richtextbuffer.h:3864
+msgid "&Box"
+msgstr "&Caixa"
+
+#: ../include/wx/richtext/richtextbuffer.h:5008
+msgid "&Picture"
+msgstr "&Imaxe"
+
+#: ../include/wx/richtext/richtextbuffer.h:5958
+msgid "&Cell"
+msgstr "&Cela"
+
+#: ../include/wx/richtext/richtextbuffer.h:6067
+msgid "&Table"
+msgstr "&Táboa"
+
+#: ../include/wx/richtext/richtextimagedlg.h:37
+msgid "Object Properties"
+msgstr "Propiedades do obxecto"
+
+#: ../include/wx/richtext/richtextsymboldlg.h:39
+msgid "Symbols"
+msgstr "Símbolos"
+
+#: ../include/wx/unix/pipe.h:46
+msgid "Pipe creation failed"
+msgstr "Erro ao crear a canalización"
+
+#: ../include/wx/unix/private/displayx11.h:65
+msgid "Failed to enumerate video modes"
+msgstr "Erro ao enumerar os modos de vídeo"
+
+#: ../include/wx/unix/private/displayx11.h:89
+msgid "Failed to change video mode"
+msgstr "Erro ao cambiar o modo de vídeo"
+
+#: ../include/wx/unix/private/fswatcher_kqueue.h:57
+#, c-format
+msgid "Unable to open path '%s'"
+msgstr "Erro ao abrir a ruta '%s'"
+
+#: ../include/wx/unix/private/fswatcher_kqueue.h:74
+#, c-format
+msgid "Unable to close path '%s'"
+msgstr "Non se puido pechar a ruta '%s'"
+
+#: ../include/wx/xtiprop.h:175
+msgid "SetProperty called w/o valid setter"
+msgstr "SetProperty chamado sen un setter axeitado"
+
+#: ../include/wx/xtiprop.h:184
+msgid "GetProperty called w/o valid getter"
+msgstr "GetProperty chamado sen un getter axeitado"
+
+#: ../include/wx/xtiprop.h:193
+msgid "AddToPropertyCollection called w/o valid adder"
+msgstr "AddToPropertyCollection chamado sen un adder axeitado"
+
+#: ../include/wx/xtiprop.h:202
+msgid "GetPropertyCollection called w/o valid collection getter"
+msgstr "GetPropertyCollection chamado sen un getter axeitado"
+
+#: ../include/wx/xtiprop.h:255
+msgid "AddToPropertyCollection called on a generic accessor"
+msgstr "AddToPropertyCollection chamou a un método de acceso xenérico"
+
+#: ../include/wx/xtiprop.h:262
+msgid "GetPropertyCollection called on a generic accessor"
+msgstr "GetPropertyCollection chamou a un método de acceso xenérico"
+
+#: ../src/aui/tabmdi.cpp:106 ../src/generic/mdig.cpp:94
+msgid "Cl&ose"
+msgstr "&Pechar"
+
+#: ../src/aui/tabmdi.cpp:107 ../src/generic/mdig.cpp:95
+msgid "Close All"
+msgstr "Pechar todo"
+
+#: ../src/aui/tabmdi.cpp:109 ../src/generic/mdig.cpp:97 ../src/msw/mdi.cpp:175
+#: ../src/qt/mdi.cpp:258
+msgid "&Next"
+msgstr "&Seguinte"
+
+#: ../src/aui/tabmdi.cpp:110 ../src/generic/mdig.cpp:98 ../src/msw/mdi.cpp:176
+#: ../src/qt/mdi.cpp:259
+msgid "&Previous"
+msgstr "&Anterior"
+
+#: ../src/aui/tabmdi.cpp:332 ../src/aui/tabmdi.cpp:348
+#: ../src/aui/tabmdi.cpp:350 ../src/generic/mdig.cpp:291
+#: ../src/generic/mdig.cpp:307 ../src/generic/mdig.cpp:311
+#: ../src/msw/mdi.cpp:337 ../src/qt/mdi.cpp:462
+msgid "&Window"
+msgstr "&Xanela"
+
+#: ../src/common/accelcmn.cpp:47
+msgctxt "keyboard key"
+msgid "Delete"
+msgstr "Eliminar"
+
+#: ../src/common/accelcmn.cpp:48
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Del"
+msgstr "Eliminar"
+
+#: ../src/common/accelcmn.cpp:49
+msgctxt "keyboard key"
+msgid "Back"
+msgstr "Atrás"
+
+#: ../src/common/accelcmn.cpp:49
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Backspace"
+msgstr "Atrás"
+
+#: ../src/common/accelcmn.cpp:50
+msgctxt "keyboard key"
+msgid "Insert"
+msgstr "Inserir"
+
+#: ../src/common/accelcmn.cpp:51
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Ins"
+msgstr "Inserido"
+
+#: ../src/common/accelcmn.cpp:52
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Enter"
+msgstr "Impresora"
+
+#: ../src/common/accelcmn.cpp:53
+msgctxt "keyboard key"
+msgid "Return"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:54
+#, fuzzy
+msgctxt "keyboard key"
+msgid "PageUp"
+msgstr "Páxinas"
+
+#: ../src/common/accelcmn.cpp:54
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Page Up"
+msgstr "Páxina %d"
+
+#: ../src/common/accelcmn.cpp:55
+#, fuzzy
+msgctxt "keyboard key"
+msgid "PageDown"
+msgstr "Abaixo"
+
+#: ../src/common/accelcmn.cpp:55
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Page Down"
+msgstr "Páxina %d"
+
+#: ../src/common/accelcmn.cpp:56
+msgctxt "keyboard key"
+msgid "PgUp"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:57
+msgctxt "keyboard key"
+msgid "PgDn"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:58
+msgctxt "keyboard key"
+msgid "Left"
+msgstr "Esquerda"
+
+#: ../src/common/accelcmn.cpp:59
+msgctxt "keyboard key"
+msgid "Right"
+msgstr "Clara"
+
+#: ../src/common/accelcmn.cpp:60
+msgctxt "keyboard key"
+msgid "Up"
+msgstr "Arriba"
+
+#: ../src/common/accelcmn.cpp:61
+msgctxt "keyboard key"
+msgid "Down"
+msgstr "Abaixo"
+
+#: ../src/common/accelcmn.cpp:62
+msgctxt "keyboard key"
+msgid "Home"
+msgstr "Inicio"
+
+#: ../src/common/accelcmn.cpp:63
+msgctxt "keyboard key"
+msgid "End"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:64
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Space"
+msgstr "Espazamento"
+
+#: ../src/common/accelcmn.cpp:65
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Tab"
+msgstr "Lapelas"
+
+#: ../src/common/accelcmn.cpp:66
+msgctxt "keyboard key"
+msgid "Esc"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:67
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Escape"
+msgstr "Horizontal"
+
+#: ../src/common/accelcmn.cpp:68
+msgctxt "keyboard key"
+msgid "Cancel"
+msgstr "Cancelar"
+
+#: ../src/common/accelcmn.cpp:69
+msgctxt "keyboard key"
+msgid "Clear"
+msgstr "Borrar"
+
+#: ../src/common/accelcmn.cpp:70
+msgctxt "keyboard key"
+msgid "Menu"
+msgstr "Menú"
+
+#: ../src/common/accelcmn.cpp:71
+msgctxt "keyboard key"
+msgid "Pause"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:72
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Capital"
+msgstr "Ma&iúsculas"
+
+#: ../src/common/accelcmn.cpp:73
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Select"
+msgstr "Selección"
+
+#: ../src/common/accelcmn.cpp:74
+msgctxt "keyboard key"
+msgid "Print"
+msgstr "Imprimir"
+
+#: ../src/common/accelcmn.cpp:75
+msgctxt "keyboard key"
+msgid "Execute"
+msgstr "Executar"
+
+#: ../src/common/accelcmn.cpp:76
+msgctxt "keyboard key"
+msgid "Snapshot"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:77
+msgctxt "keyboard key"
+msgid "Help"
+msgstr "Axuda"
+
+#: ../src/common/accelcmn.cpp:78
+msgctxt "keyboard key"
+msgid "Add"
+msgstr "Engadir"
+
+#: ../src/common/accelcmn.cpp:79
+msgctxt "keyboard key"
+msgid "Separator"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:80
+msgctxt "keyboard key"
+msgid "Subtract"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:81
+msgctxt "keyboard key"
+msgid "Decimal"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:82
+msgctxt "keyboard key"
+msgid "Multiply"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:83
+msgctxt "keyboard key"
+msgid "Divide"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:84
+msgctxt "keyboard key"
+msgid "Num_lock"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:84
+msgctxt "keyboard key"
+msgid "Num Lock"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:85
+msgctxt "keyboard key"
+msgid "Scroll_lock"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:85
+msgctxt "keyboard key"
+msgid "Scroll Lock"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:86
+msgctxt "keyboard key"
+msgid "KP_Space"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:86
+msgctxt "keyboard key"
+msgid "Num Space"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:87
+#, fuzzy
+msgctxt "keyboard key"
+msgid "KP_Tab"
+msgstr "KP_TAB"
+
+#: ../src/common/accelcmn.cpp:87
+msgctxt "keyboard key"
+msgid "Num Tab"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:88
+#, fuzzy
+msgctxt "keyboard key"
+msgid "KP_Enter"
+msgstr "Impresora"
+
+#: ../src/common/accelcmn.cpp:88
+msgctxt "keyboard key"
+msgid "Num Enter"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:89
+#, fuzzy
+msgctxt "keyboard key"
+msgid "KP_Home"
+msgstr "Inicio"
+
+#: ../src/common/accelcmn.cpp:89
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Num Home"
+msgstr "Inicio"
+
+#: ../src/common/accelcmn.cpp:90
+#, fuzzy
+msgctxt "keyboard key"
+msgid "KP_Left"
+msgstr "Esquerda"
+
+#: ../src/common/accelcmn.cpp:90
+msgctxt "keyboard key"
+msgid "Num left"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:91
+#, fuzzy
+msgctxt "keyboard key"
+msgid "KP_Up"
+msgstr "KP_UP"
+
+#: ../src/common/accelcmn.cpp:91
+msgctxt "keyboard key"
+msgid "Num Up"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:92
+#, fuzzy
+msgctxt "keyboard key"
+msgid "KP_Right"
+msgstr "Clara"
+
+#: ../src/common/accelcmn.cpp:92
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Num Right"
+msgstr "Clara"
+
+#: ../src/common/accelcmn.cpp:93
+#, fuzzy
+msgctxt "keyboard key"
+msgid "KP_Down"
+msgstr "Abaixo"
+
+#: ../src/common/accelcmn.cpp:93
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Num Down"
+msgstr "Abaixo"
+
+#: ../src/common/accelcmn.cpp:94
+msgctxt "keyboard key"
+msgid "KP_PageUp"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:94
+msgctxt "keyboard key"
+msgid "Num Page Up"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:95
+msgctxt "keyboard key"
+msgid "KP_PageDown"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:95
+msgctxt "keyboard key"
+msgid "Num Page Down"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:96
+msgctxt "keyboard key"
+msgid "KP_Prior"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:97
+#, fuzzy
+msgctxt "keyboard key"
+msgid "KP_Next"
+msgstr "Seguinte"
+
+#: ../src/common/accelcmn.cpp:98
+#, fuzzy
+msgctxt "keyboard key"
+msgid "KP_End"
+msgstr "KP_END"
+
+#: ../src/common/accelcmn.cpp:98
+msgctxt "keyboard key"
+msgid "Num End"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:99
+msgctxt "keyboard key"
+msgid "KP_Begin"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:99
+msgctxt "keyboard key"
+msgid "Num Begin"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:100
+#, fuzzy
+msgctxt "keyboard key"
+msgid "KP_Insert"
+msgstr "Inserir"
+
+#: ../src/common/accelcmn.cpp:100
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Num Insert"
+msgstr "Inserir"
+
+#: ../src/common/accelcmn.cpp:101
+#, fuzzy
+msgctxt "keyboard key"
+msgid "KP_Delete"
+msgstr "Eliminar"
+
+#: ../src/common/accelcmn.cpp:101
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Num Delete"
+msgstr "Eliminar"
+
+#: ../src/common/accelcmn.cpp:102
+msgctxt "keyboard key"
+msgid "KP_Equal"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:102
+msgctxt "keyboard key"
+msgid "Num ="
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:103
+msgctxt "keyboard key"
+msgid "KP_Multiply"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:103
+msgctxt "keyboard key"
+msgid "Num *"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:104
+#, fuzzy
+msgctxt "keyboard key"
+msgid "KP_Add"
+msgstr "KP_ADD"
+
+#: ../src/common/accelcmn.cpp:104
+msgctxt "keyboard key"
+msgid "Num +"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:105
+msgctxt "keyboard key"
+msgid "KP_Separator"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:105
+msgctxt "keyboard key"
+msgid "Num ,"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:106
+msgctxt "keyboard key"
+msgid "KP_Subtract"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:106
+msgctxt "keyboard key"
+msgid "Num -"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:107
+msgctxt "keyboard key"
+msgid "KP_Decimal"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:107
+msgctxt "keyboard key"
+msgid "Num ."
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:108
+msgctxt "keyboard key"
+msgid "KP_Divide"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:108
+msgctxt "keyboard key"
+msgid "Num /"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:109
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Windows_Left"
+msgstr "Windows 7"
+
+#: ../src/common/accelcmn.cpp:110
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Windows_Right"
+msgstr "Windows Vista"
+
+#: ../src/common/accelcmn.cpp:111
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Windows_Menu"
+msgstr "Windows ME"
+
+#: ../src/common/accelcmn.cpp:112
+msgctxt "keyboard key"
+msgid "Command"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:186 ../src/common/accelcmn.cpp:359
+msgctxt "keyboard key"
+msgid "Ctrl"
+msgstr "Ctrl"
+
+#: ../src/common/accelcmn.cpp:188 ../src/common/accelcmn.cpp:363
+msgctxt "keyboard key"
+msgid "Alt"
+msgstr "Alt"
+
+#: ../src/common/accelcmn.cpp:190 ../src/common/accelcmn.cpp:361
+msgctxt "keyboard key"
+msgid "Shift"
+msgstr "Maiús."
+
+#: ../src/common/accelcmn.cpp:196
+msgctxt "keyboard key"
+msgid "num "
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:260 ../src/common/accelcmn.cpp:382
+msgctxt "keyboard key"
+msgid "F"
+msgstr "F"
+
+#: ../src/common/accelcmn.cpp:277 ../src/common/accelcmn.cpp:385
+msgctxt "keyboard key"
+msgid "KP_F"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:280 ../src/common/accelcmn.cpp:388
+msgctxt "keyboard key"
+msgid "KP_"
+msgstr "KP_"
+
+#: ../src/common/accelcmn.cpp:283 ../src/common/accelcmn.cpp:391
+msgctxt "keyboard key"
+msgid "SPECIAL"
+msgstr "ESPECIAL"
+
+#: ../src/common/accelcmn.cpp:373
+#, fuzzy
+msgid "Ctrl"
+msgstr "Ctrl"
+
+#: ../src/common/appbase.cpp:786
+msgid "show this help message"
+msgstr "amosar esta mensaxe de axuda"
+
+#: ../src/common/appbase.cpp:796
+msgid "generate verbose log messages"
+msgstr "xerar mensaxes de rexistro detalladas"
+
+#: ../src/common/appcmn.cpp:256
+msgid "specify the theme to use"
+msgstr "especifique o tema que vai usar"
+
+#: ../src/common/appcmn.cpp:270
+msgid "specify display mode to use (e.g. 640x480-16)"
+msgstr "especifique a resolución da pantalla (ex.: 640x480-16)"
+
+#: ../src/common/appcmn.cpp:292
+#, c-format
+msgid "Unsupported theme '%s'."
+msgstr "Tema '%s' non compatíbel."
+
+#: ../src/common/appcmn.cpp:309
+#, c-format
+msgid "Invalid display mode specification '%s'."
+msgstr "Especificación de modo de visor incorrecta: '%s'."
+
+#: ../src/common/cmdline.cpp:875
+#, c-format
+msgid "Option '%s' can't be negated"
+msgstr "A opción '%s' non se pode contrarrestar"
+
+#: ../src/common/cmdline.cpp:889
+#, c-format
+msgid "Unknown long option '%s'"
+msgstr "Opción longa '%s' descoñecida"
+
+#: ../src/common/cmdline.cpp:904 ../src/common/cmdline.cpp:926
+#, c-format
+msgid "Unknown option '%s'"
+msgstr "Opción descoñecida '%s'"
+
+#: ../src/common/cmdline.cpp:1004
+#, c-format
+msgid "Unexpected characters following option '%s'."
+msgstr "Caracteres inesperados despois da opción '%s'."
+
+#: ../src/common/cmdline.cpp:1039
+#, c-format
+msgid "Option '%s' requires a value."
+msgstr "A opción '%s' require un valor."
+
+#: ../src/common/cmdline.cpp:1058
+#, c-format
+msgid "Separator expected after the option '%s'."
+msgstr "Esperábase un separador despois da opción '%s'."
+
+#: ../src/common/cmdline.cpp:1088 ../src/common/cmdline.cpp:1106
+#, c-format
+msgid "'%s' is not a correct numeric value for option '%s'."
+msgstr "'%s' non é un valor numérico correcto para a opción '%s'."
+
+#: ../src/common/cmdline.cpp:1122
+#, c-format
+msgid "Option '%s': '%s' cannot be converted to a date."
+msgstr "Opción '%s': '%s' non se pode converter en data."
+
+#: ../src/common/cmdline.cpp:1170
+#, c-format
+msgid "Unexpected parameter '%s'"
+msgstr "Parámetro '%s' inesperado"
+
+#. TRANSLATORS: Short name and long name for a command line option
+#: ../src/common/cmdline.cpp:1197
+#, c-format
+msgid "%s (or %s)"
+msgstr "%s (ou %s)"
+
+#: ../src/common/cmdline.cpp:1208
+#, c-format
+msgid "The value for the option '%s' must be specified."
+msgstr "Debe especificarse o valor para a opción '%s'."
+
+#: ../src/common/cmdline.cpp:1230
+#, c-format
+msgid "The required parameter '%s' was not specified."
+msgstr "Non se especificou o parámetro requirido '%s'."
+
+#: ../src/common/cmdline.cpp:1289
+#, c-format
+msgid "Usage: %s"
+msgstr "Uso: %s"
+
+#: ../src/common/cmdline.cpp:1498
+msgid "str"
+msgstr "cadea"
+
+#: ../src/common/cmdline.cpp:1502
+msgid "num"
+msgstr "núm"
+
+#: ../src/common/cmdline.cpp:1506
+msgid "double"
+msgstr "dobre"
+
+#: ../src/common/cmdline.cpp:1510
+msgid "date"
+msgstr "data"
+
+#: ../src/common/cmdproc.cpp:250 ../src/common/cmdproc.cpp:276
+#: ../src/common/cmdproc.cpp:296
+msgid "Unnamed command"
+msgstr "Comando sen nome"
+
+#: ../src/common/cmdproc.cpp:253
+msgid "&Undo "
+msgstr "&Desfacer "
+
+#: ../src/common/cmdproc.cpp:255
+msgid "Can't &Undo "
+msgstr "Non se puido &desfacer "
+
+#: ../src/common/cmdproc.cpp:259 ../src/common/stockitem.cpp:208
+#: ../src/msw/textctrl.cpp:2880 ../src/osx/textctrl_osx.cpp:649
+#: ../src/richtext/richtextctrl.cpp:327
+msgid "&Undo"
+msgstr "&Desfacer"
+
+#: ../src/common/cmdproc.cpp:277 ../src/common/cmdproc.cpp:297
+msgid "&Redo "
+msgstr "&Refacer "
+
+#: ../src/common/cmdproc.cpp:281 ../src/common/cmdproc.cpp:288
+#: ../src/common/stockitem.cpp:190 ../src/msw/textctrl.cpp:2881
+#: ../src/osx/textctrl_osx.cpp:650 ../src/richtext/richtextctrl.cpp:328
+msgid "&Redo"
+msgstr "&Refacer"
+
+#: ../src/common/colourcmn.cpp:41
+#, c-format
+msgid "String To Colour : Incorrect colour specification : %s"
+msgstr "Cadea para cor: Especificación de cor incorrecta: %s"
+
+#: ../src/common/config.cpp:259
+#, c-format
+msgid "Invalid value %ld for a boolean key \"%s\" in config file."
+msgstr ""
+"Valor %ld incorrecto para a clave booleana \"%s\" no ficheiro de "
+"configuración."
+
+#: ../src/common/config.cpp:526
+#, c-format
+msgid ""
+"Environment variables expansion failed: missing '%c' at position %u in '%s'."
+msgstr ""
+"Erro na ampliación das variábeis de entorno: falla '%c' na posición %u en "
+"'%s'."
+
+#: ../src/common/config.cpp:576 ../src/msw/regconf.cpp:272
+#, c-format
+msgid "'%s' has extra '..', ignored."
+msgstr "'%s' ten '..' adicional, ignórase."
+
+#. TRANSLATORS: Checkbox state name
+#: ../src/common/datavcmn.cpp:2166 ../src/generic/datavgen.cpp:1430
+msgid "checked"
+msgstr ""
+
+#. TRANSLATORS: Checkbox state name
+#: ../src/common/datavcmn.cpp:2170 ../src/generic/datavgen.cpp:1432
+msgid "unchecked"
+msgstr ""
+
+#. TRANSLATORS: Checkbox state name
+#: ../src/common/datavcmn.cpp:2174
+#, fuzzy
+msgid "undetermined"
+msgstr "subliñado"
+
+#: ../src/common/datetimefmt.cpp:1875
+msgid "today"
+msgstr "hoxe"
+
+#: ../src/common/datetimefmt.cpp:1876
+msgid "yesterday"
+msgstr "onte"
+
+#: ../src/common/datetimefmt.cpp:1877
+msgid "tomorrow"
+msgstr "mañá"
+
+#: ../src/common/datetimefmt.cpp:2071
+msgid "first"
+msgstr "primeiro"
+
+#: ../src/common/datetimefmt.cpp:2072
+msgid "second"
+msgstr "segundo"
+
+#: ../src/common/datetimefmt.cpp:2073
+msgid "third"
+msgstr "terceiro"
+
+#: ../src/common/datetimefmt.cpp:2074
+msgid "fourth"
+msgstr "cuarto"
+
+#: ../src/common/datetimefmt.cpp:2075
+msgid "fifth"
+msgstr "quinto"
+
+#: ../src/common/datetimefmt.cpp:2076
+msgid "sixth"
+msgstr "sexto"
+
+#: ../src/common/datetimefmt.cpp:2077
+msgid "seventh"
+msgstr "sétimo"
+
+#: ../src/common/datetimefmt.cpp:2078
+msgid "eighth"
+msgstr "oitavo"
+
+#: ../src/common/datetimefmt.cpp:2079
+msgid "ninth"
+msgstr "noveno"
+
+#: ../src/common/datetimefmt.cpp:2080
+msgid "tenth"
+msgstr "décimo"
+
+#: ../src/common/datetimefmt.cpp:2081
+msgid "eleventh"
+msgstr "décimo primeiro"
+
+#: ../src/common/datetimefmt.cpp:2082
+msgid "twelfth"
+msgstr "décimo segundo"
+
+#: ../src/common/datetimefmt.cpp:2083
+msgid "thirteenth"
+msgstr "décimo terceiro"
+
+#: ../src/common/datetimefmt.cpp:2084
+msgid "fourteenth"
+msgstr "décimo cuarto"
+
+#: ../src/common/datetimefmt.cpp:2085
+msgid "fifteenth"
+msgstr "décimo quinto"
+
+#: ../src/common/datetimefmt.cpp:2086
+msgid "sixteenth"
+msgstr "décimo sexto"
+
+#: ../src/common/datetimefmt.cpp:2087
+msgid "seventeenth"
+msgstr "décimo sétimo"
+
+#: ../src/common/datetimefmt.cpp:2088
+msgid "eighteenth"
+msgstr "décimo oitavo"
+
+#: ../src/common/datetimefmt.cpp:2089
+msgid "nineteenth"
+msgstr "décimo noveno"
+
+#: ../src/common/datetimefmt.cpp:2090
+msgid "twentieth"
+msgstr "vixésimo"
+
+#: ../src/common/datetimefmt.cpp:2248
+msgid "noon"
+msgstr "mediodía"
+
+#: ../src/common/datetimefmt.cpp:2249
+msgid "midnight"
+msgstr "media noite"
+
+#: ../src/common/debugrpt.cpp:209
+#, c-format
+msgid "Failed to create directory \"%s\""
+msgstr "Erro ao crear o cartafol \"%s\""
+
+#: ../src/common/debugrpt.cpp:210
+msgid "Debug report couldn't be created."
+msgstr "Non se puido crear o informe de depuración."
+
+#: ../src/common/debugrpt.cpp:227
+#, c-format
+msgid "Failed to remove debug report file \"%s\""
+msgstr "Fallo ao eliminar o ficheiro de informe de depuración \"%s\""
+
+#: ../src/common/debugrpt.cpp:239
+#, c-format
+msgid "Failed to clean up debug report directory \"%s\""
+msgstr "Erro ao limpar o cartafol de depuración \"%s\""
+
+#: ../src/common/debugrpt.cpp:514
+msgid "process context description"
+msgstr "descrición do contexto do proceso"
+
+#: ../src/common/debugrpt.cpp:538
+msgid "dump of the process state (binary)"
+msgstr "envorcado do estado do proceso (binario)"
+
+#: ../src/common/debugrpt.cpp:553
+msgid "Debug report generation has failed."
+msgstr "Fallou a xeración do informe de depuración."
+
+#: ../src/common/debugrpt.cpp:560
+#, c-format
+msgid ""
+"Processing debug report has failed, leaving the files in \"%s\" directory."
+msgstr ""
+"Houbo un fallo de proceso do informe de deputación, os ficheiros fican no "
+"cartafol\"%s\"."
+
+#: ../src/common/debugrpt.cpp:573
+msgid "A debug report has been generated. It can be found in"
+msgstr "Xerouse un informe de depuración que se atopa en"
+
+#: ../src/common/debugrpt.cpp:576
+msgid "And includes the following files:\n"
+msgstr "E inclúe os seguintes ficheiros:\n"
+
+#: ../src/common/debugrpt.cpp:586
+msgid ""
+"\n"
+"Please send this report to the program maintainer, thank you!\n"
+msgstr ""
+"\n"
+"Por favor, envíe este informe ao mantedor do programa, grazas!\n"
+
+#: ../src/common/debugrpt.cpp:729
+msgid "Failed to execute curl, please install it in PATH."
+msgstr "Erro ao executar curl, por favor, instáleo no PATH."
+
+#: ../src/common/debugrpt.cpp:742
+#, c-format
+msgid "Failed to upload the debug report (error code %d)."
+msgstr "Erro ao enviar o informe de depuración (código de erro %d)."
+
+#: ../src/common/docview.cpp:366
+msgid "Save As"
+msgstr "Gardar como"
+
+#: ../src/common/docview.cpp:457
+msgid "Discard changes and reload the last saved version?"
+msgstr "Omitir os cambios e cargar a última versión gardada?"
+
+#: ../src/common/docview.cpp:488
+msgid "unnamed"
+msgstr "sen nome"
+
+#: ../src/common/docview.cpp:513
+#, c-format
+msgid "Do you want to save changes to %s?"
+msgstr "Quere gardar os cambios en %s?"
+
+#: ../src/common/docview.cpp:521 ../src/common/docview.cpp:560
+#: ../src/common/stockitem.cpp:195
+msgid "&Save"
+msgstr "&Gardar"
+
+#: ../src/common/docview.cpp:522 ../src/common/docview.cpp:560
+msgid "&Discard changes"
+msgstr ""
+
+#: ../src/common/docview.cpp:523
+#, fuzzy
+msgid "Do&n't close"
+msgstr "Non gardar"
+
+#: ../src/common/docview.cpp:553
+#, fuzzy, c-format
+msgid "Do you want to save changes to %s before closing it?"
+msgstr "Quere gardar os cambios en %s?"
+
+#: ../src/common/docview.cpp:559
+#, fuzzy
+msgid "The document must be closed."
+msgstr "Non se puido gardar o texto."
+
+#: ../src/common/docview.cpp:571
+#, c-format
+msgid "Saving %s failed, would you like to retry?"
+msgstr ""
+
+#: ../src/common/docview.cpp:577
+msgid "Retry"
+msgstr ""
+
+#: ../src/common/docview.cpp:577
+msgid "Discard changes"
+msgstr ""
+
+#: ../src/common/docview.cpp:679
+#, c-format
+msgid "File \"%s\" could not be opened for writing."
+msgstr "Non foi posíbel abrir o ficheiro \"%s\" para escritura."
+
+#: ../src/common/docview.cpp:685
+#, c-format
+msgid "Failed to save document to the file \"%s\"."
+msgstr "Erro ao gardar a imaxe de mapa de bits no ficheiro \"%s\"."
+
+#: ../src/common/docview.cpp:702
+#, c-format
+msgid "File \"%s\" could not be opened for reading."
+msgstr "Non foi posíbel abrir o ficheiro \"%s\" para lectura."
+
+#: ../src/common/docview.cpp:714
+#, c-format
+msgid "Failed to read document from the file \"%s\"."
+msgstr "Erro ao cargar documento dende o ficheiro \"%s\"."
+
+#: ../src/common/docview.cpp:1236
+#, c-format
+msgid ""
+"The file '%s' doesn't exist and couldn't be opened.\n"
+"It has been removed from the most recently used files list."
+msgstr ""
+"O ficheiro '%s' non existe e non se puido abrir.\n"
+"Foi eliminado da lista de ficheiros recentes."
+
+#: ../src/common/docview.cpp:1296
+msgid "Print preview creation failed."
+msgstr "Fallo na previsualización de impresión."
+
+#: ../src/common/docview.cpp:1302
+msgid "Print Preview"
+msgstr "Previsualización de impresión"
+
+#: ../src/common/docview.cpp:1517
+#, c-format
+msgid "The format of file '%s' couldn't be determined."
+msgstr "Non se puido determinar o formato do ficheiro '%s'."
+
+#: ../src/common/docview.cpp:1643
+#, c-format
+msgid "unnamed%d"
+msgstr "sen nome%d"
+
+#: ../src/common/docview.cpp:1660
+msgid " - "
+msgstr " - "
+
+#: ../src/common/docview.cpp:1791 ../src/common/docview.cpp:1844
+msgid "Open File"
+msgstr "Abrir ficheiro"
+
+#: ../src/common/docview.cpp:1807
+msgid "File error"
+msgstr "Erro de ficheiro"
+
+#: ../src/common/docview.cpp:1809
+msgid "Sorry, could not open this file."
+msgstr "Non se puido abrir este ficheiro."
+
+#: ../src/common/docview.cpp:1843
+msgid "Sorry, the format for this file is unknown."
+msgstr "O formato deste ficheiro é descoñecido."
+
+#: ../src/common/docview.cpp:1924
+msgid "Select a document template"
+msgstr "Seleccione un patrón de documento"
+
+#: ../src/common/docview.cpp:1925
+msgid "Templates"
+msgstr "Patróns"
+
+#: ../src/common/docview.cpp:1998
+msgid "Select a document view"
+msgstr "Seleccionar unha vista de documento"
+
+#: ../src/common/docview.cpp:1999
+msgid "Views"
+msgstr "Vistas"
+
+#: ../src/common/dynlib.cpp:81
+#, c-format
+msgid "Failed to load shared library '%s'"
+msgstr "Erro ao cargar a biblioteca compartida '%s'"
+
+#: ../src/common/dynlib.cpp:105
+#, c-format
+msgid "Couldn't find symbol '%s' in a dynamic library"
+msgstr "Non se puido atopar o símbolo '%s' nunha biblioteca dinámica"
+
+#: ../src/common/ffile.cpp:56 ../src/common/file.cpp:215
+#, c-format
+msgid "can't open file '%s'"
+msgstr "non se puido abrir o ficheiro '%s'"
+
+#: ../src/common/ffile.cpp:72
+#, c-format
+msgid "can't close file '%s'"
+msgstr "non se puido pechar o ficheiro '%s'"
+
+#: ../src/common/ffile.cpp:106 ../src/common/ffile.cpp:131
+#, c-format
+msgid "Read error on file '%s'"
+msgstr "Erro de lectura no ficheiro '%s'"
+
+#: ../src/common/ffile.cpp:148
+#, c-format
+msgid "Write error on file '%s'"
+msgstr "Erro de escritura no ficheiro '%s'"
+
+#: ../src/common/ffile.cpp:182
+#, c-format
+msgid "failed to flush the file '%s'"
+msgstr "erro ao baleirar a memoria do ficheiro '%s'"
+
+#: ../src/common/ffile.cpp:222
+#, c-format
+msgid "Seek error on file '%s' (large files not supported by stdio)"
+msgstr ""
+"Erro de busca no ficheiro '%s' (os ficheiros grandes non son compatíbeis con "
+"stdio)"
+
+#: ../src/common/ffile.cpp:232
+#, c-format
+msgid "Seek error on file '%s'"
+msgstr "Erro de busca no ficheiro '%s'"
+
+#: ../src/common/ffile.cpp:248
+#, c-format
+msgid "Can't find current position in file '%s'"
+msgstr "Non se puido atopar a posición actual no ficheiro '%s'"
+
+#: ../src/common/ffile.cpp:349 ../src/common/file.cpp:569
+msgid "Failed to set temporary file permissions"
+msgstr "Erro ao estabelecer os permisos do ficheiro temporal"
+
+#: ../src/common/ffile.cpp:371
+#, c-format
+msgid "can't remove file '%s'"
+msgstr "non se puido eliminar o ficheiro '%s'"
+
+#: ../src/common/ffile.cpp:376 ../src/common/file.cpp:591
+#, c-format
+msgid "can't commit changes to file '%s'"
+msgstr "non se poden remitir os cambios ao ficheiro '%s'"
+
+#: ../src/common/ffile.cpp:388 ../src/common/file.cpp:603
+#, c-format
+msgid "can't remove temporary file '%s'"
+msgstr "non se puido eliminar o ficheiro temporal '%s'"
+
+#: ../src/common/file.cpp:162
+#, c-format
+msgid "can't create file '%s'"
+msgstr "non se puido crear o ficheiro '%s'"
+
+#: ../src/common/file.cpp:229
+#, c-format
+msgid "can't close file descriptor %d"
+msgstr "non se pode pechar descritor de ficheiro %d"
+
+#: ../src/common/file.cpp:332
+#, c-format
+msgid "can't read from file descriptor %d"
+msgstr "non é posíbel ler dende o descritor de ficheiro %d"
+
+#: ../src/common/file.cpp:351
+#, c-format
+msgid "can't write to file descriptor %d"
+msgstr "non é posíbel escribir no descritor de ficheiro %d"
+
+#: ../src/common/file.cpp:390
+#, c-format
+msgid "can't flush file descriptor %d"
+msgstr "non é posíbel baleirar o descritor de ficheiro %d"
+
+#: ../src/common/file.cpp:432
+#, c-format
+msgid "can't seek on file descriptor %d"
+msgstr "non é posíbel buscar no descritor de ficheiro %d"
+
+#: ../src/common/file.cpp:446
+#, c-format
+msgid "can't get seek position on file descriptor %d"
+msgstr "non se pode atopar a posición do descritor de ficheiro %d"
+
+#: ../src/common/file.cpp:475
+#, c-format
+msgid "can't find length of file on file descriptor %d"
+msgstr "non se atopa lonxitude do ficheiro no descritor %d"
+
+#: ../src/common/file.cpp:505
+#, c-format
+msgid "can't determine if the end of file is reached on descriptor %d"
+msgstr ""
+"non se pode determinar se se chegou ao final do ficheiro no descritor %d"
+
+#: ../src/common/fileconf.cpp:352
+#, c-format
+msgid ""
+" and additionally, the existing configuration file was renamed to \"%s\" and "
+"couldn't be renamed back, please rename it to its original path \"%s\""
+msgstr ""
+
+#: ../src/common/fileconf.cpp:389
+#, fuzzy
+msgid " due to the following error:\n"
+msgstr "E inclúe os seguintes ficheiros:\n"
+
+#: ../src/common/fileconf.cpp:412
+#, fuzzy
+msgid "failed to rename the existing file"
+msgstr "Erro ao cargar documento dende o ficheiro \"%s\"."
+
+#: ../src/common/fileconf.cpp:421
+#, fuzzy
+msgid "failed to create the new file directory"
+msgstr "Erro ao obter o cartafol de traballo"
+
+#: ../src/common/fileconf.cpp:428
+#, fuzzy
+msgid "failed to move the file to the new location"
+msgstr "Non se puido terminar a conexión telefónica: %s"
+
+#: ../src/common/fileconf.cpp:462
+#, c-format
+msgid "can't open global configuration file '%s'."
+msgstr "non se puido abrir o ficheiro de configuración global '%s'."
+
+#: ../src/common/fileconf.cpp:478
+#, c-format
+msgid "can't open user configuration file '%s'."
+msgstr "non se puido abrir o ficheiro de configuración de usuario '%s'."
+
+#: ../src/common/fileconf.cpp:483
+#, c-format
+msgid "Changes won't be saved to avoid overwriting the existing file \"%s\""
+msgstr ""
+"Non se gardarán os cambios para non sobreescribir o ficheiro actual \"%s\""
+
+#: ../src/common/fileconf.cpp:583
+msgid "Error reading config options."
+msgstr "Erro ao ler as opcións de configuración."
+
+#: ../src/common/fileconf.cpp:593
+msgid "Failed to read config options."
+msgstr "Erro ao ler as opcións da configuración."
+
+#: ../src/common/fileconf.cpp:700
+#, fuzzy, c-format
+msgid "file '%s': unexpected character %c at line %zu."
+msgstr "ficheiro '%s': caracter inesperado %c na liña %d."
+
+#: ../src/common/fileconf.cpp:736
+#, fuzzy, c-format
+msgid "file '%s', line %zu: '%s' ignored after group header."
+msgstr "ficheiro '%s', liña %d: '%s' ignorada despois de cabeceira de grupo."
+
+#: ../src/common/fileconf.cpp:765
+#, fuzzy, c-format
+msgid "file '%s', line %zu: '=' expected."
+msgstr "ficheiro '%s', liña %d: '=' esperado."
+
+#: ../src/common/fileconf.cpp:778
+#, fuzzy, c-format
+msgid "file '%s', line %zu: value for immutable key '%s' ignored."
+msgstr "ficheiro '%s', liña %d: valor para clave inmutábel '%s' ignorado."
+
+#: ../src/common/fileconf.cpp:788
+#, fuzzy, c-format
+msgid "file '%s', line %zu: key '%s' was first found at line %d."
+msgstr ""
+"ficheiro '%s', liña %d: clave '%s' foi atopada por primeira vez na liña %d."
+
+#: ../src/common/fileconf.cpp:1091
+#, c-format
+msgid "Config entry name cannot start with '%c'."
+msgstr "O nome da entrada de configuración non pode comezar por '%c'."
+
+#: ../src/common/fileconf.cpp:1146
+#, fuzzy
+msgid "Failed to create configuration file directory."
+msgstr "Erro ao actualizar o ficheiro de configuración de usuario."
+
+#: ../src/common/fileconf.cpp:1158
+msgid "can't open user configuration file."
+msgstr "non se puido abrir o ficheiro de configuración de usuario."
+
+#: ../src/common/fileconf.cpp:1172
+msgid "can't write user configuration file."
+msgstr "non se puido escribir o ficheiro de configuración do usuario."
+
+#: ../src/common/fileconf.cpp:1178
+msgid "Failed to update user configuration file."
+msgstr "Erro ao actualizar o ficheiro de configuración de usuario."
+
+#: ../src/common/fileconf.cpp:1201
+msgid "Error saving user configuration data."
+msgstr "Erro ao gardar os datos de configuración do usuario."
+
+#: ../src/common/fileconf.cpp:1313
+#, c-format
+msgid "can't delete user configuration file '%s'"
+msgstr "non se puido eliminar o ficheiro de configuración de usuario '%s'"
+
+#: ../src/common/fileconf.cpp:2007
+#, c-format
+msgid "entry '%s' appears more than once in group '%s'"
+msgstr "a entrada '%s' aparece máis de unha vez no grupo '%s'"
+
+#: ../src/common/fileconf.cpp:2021
+#, c-format
+msgid "attempt to change immutable key '%s' ignored."
+msgstr "intento de cambiar a clave inmutábel '%s', ignorado."
+
+#: ../src/common/fileconf.cpp:2118
+#, c-format
+msgid "trailing backslash ignored in '%s'"
+msgstr "ignorouse a barra invertida sobrante en '%s'"
+
+#: ../src/common/fileconf.cpp:2153
+#, c-format
+msgid "unexpected \" at position %d in '%s'."
+msgstr "\" inesperado na posición %d en '%s'."
+
+#: ../src/common/filefn.cpp:474
+#, c-format
+msgid "Failed to copy the file '%s' to '%s'"
+msgstr "Fallo ao copiar o ficheiro '%s' a '%s'"
+
+#: ../src/common/filefn.cpp:487
+#, c-format
+msgid "Impossible to get permissions for file '%s'"
+msgstr "Non é posíbel obter permisos para o ficheiro '%s'"
+
+#: ../src/common/filefn.cpp:501
+#, c-format
+msgid "Impossible to overwrite the file '%s'"
+msgstr "É imposíbel sobreescribir o ficheiro '%s'"
+
+#: ../src/common/filefn.cpp:508
+#, fuzzy, c-format
+msgid "Error copying the file '%s' to '%s'."
+msgstr "Fallo ao copiar o ficheiro '%s' a '%s'"
+
+#: ../src/common/filefn.cpp:556
+#, c-format
+msgid "Impossible to set permissions for the file '%s'"
+msgstr "Foi imposíbel estabelecer os permisos para o ficheiro '%s'"
+
+#: ../src/common/filefn.cpp:606
+#, c-format
+msgid ""
+"Failed to rename the file '%s' to '%s' because the destination file already "
+"exists."
+msgstr ""
+"Non se puido cambiar o nome do ficheiro de '%s' a '%s' porque o ficheiro de "
+"destino xa existe."
+
+#: ../src/common/filefn.cpp:623
+#, c-format
+msgid "File '%s' couldn't be renamed '%s'"
+msgstr "Non se puido renomear o ficheiro '%s' a '%s'"
+
+#: ../src/common/filefn.cpp:639
+#, c-format
+msgid "File '%s' couldn't be removed"
+msgstr "Non foi posíbel eliminar o ficheiro '%s'"
+
+#: ../src/common/filefn.cpp:666
+#, c-format
+msgid "Directory '%s' couldn't be created"
+msgstr "Non se puido crear o cartafol '%s'"
+
+#: ../src/common/filefn.cpp:680
+#, c-format
+msgid "Directory '%s' couldn't be deleted"
+msgstr "Non se puido eliminar o cartafol '%s'"
+
+#: ../src/common/filefn.cpp:714
+#, c-format
+msgid "Cannot enumerate files '%s'"
+msgstr "Non se puideron enumerar os ficheiros '%s'"
+
+#: ../src/common/filefn.cpp:798
+msgid "Failed to get the working directory"
+msgstr "Erro ao obter o cartafol de traballo"
+
+#: ../src/common/filefn.cpp:843
+msgid "Could not set current working directory"
+msgstr "Non se atopou o cartafol de traballo actual"
+
+#: ../src/common/filefn.cpp:974
+#, c-format
+msgid "Files (%s)"
+msgstr "Ficheiros (%s)"
+
+#: ../src/common/filename.cpp:182
+#, c-format
+msgid "Failed to open '%s' for reading"
+msgstr "Erro ao abrir '%s' para lectura"
+
+#: ../src/common/filename.cpp:187
+#, c-format
+msgid "Failed to open '%s' for writing"
+msgstr "Erro ao abrir '%s' para escritura"
+
+#: ../src/common/filename.cpp:199
+msgid "Failed to close file handle"
+msgstr "Erro ao pechar manexador de ficheiros"
+
+#: ../src/common/filename.cpp:1046
+msgid "Failed to create a temporary file name"
+msgstr "Erro ao crear un nome de ficheiro temporal"
+
+#: ../src/common/filename.cpp:1081
+msgid "Failed to open temporary file."
+msgstr "Erro ao abrir o ficheiro temporal."
+
+#: ../src/common/filename.cpp:2862
+#, c-format
+msgid "Failed to modify file times for '%s'"
+msgstr "Erro ao modificar o ficheiro de tempos para '%s'"
+
+#: ../src/common/filename.cpp:2877
+#, c-format
+msgid "Failed to touch the file '%s'"
+msgstr "Erro ao tocar o ficheiro '%s'"
+
+#: ../src/common/filename.cpp:2958
+#, c-format
+msgid "Failed to retrieve file times for '%s'"
+msgstr "Erro ao obter tempos de ficheiro para '%s'"
+
+#: ../src/common/filepickercmn.cpp:39 ../src/common/filepickercmn.cpp:40
+msgid "Browse"
+msgstr "Explorar"
+
+#: ../src/common/fldlgcmn.cpp:792 ../src/generic/filectrlg.cpp:1185
+#, c-format
+msgid "All files (%s)|%s"
+msgstr "Todos os ficheiros (%s)|%s"
+
+#. TRANSLATORS: %s are a file extension used to build a file wildcard string
+#: ../src/common/fldlgcmn.cpp:810
+#, c-format
+msgid "%s files (%s)|%s"
+msgstr "%s ficheiros (%s)|%s"
+
+#: ../src/common/fldlgcmn.cpp:1072
+#, c-format
+msgid "Load %s file"
+msgstr "Cargar o ficheiro %s"
+
+#: ../src/common/fldlgcmn.cpp:1074
+#, c-format
+msgid "Save %s file"
+msgstr "Gardar o ficheiro %s"
+
+#: ../src/common/fmapbase.cpp:144
+msgid "Western European (ISO-8859-1)"
+msgstr "Europeo occidental (ISO-8859-1)"
+
+#: ../src/common/fmapbase.cpp:145
+msgid "Central European (ISO-8859-2)"
+msgstr "Centroeuropeo (ISO-8859-2)"
+
+#: ../src/common/fmapbase.cpp:146
+msgid "Esperanto (ISO-8859-3)"
+msgstr "Esperanto (ISO-8859-3)"
+
+#: ../src/common/fmapbase.cpp:147
+msgid "Baltic (old) (ISO-8859-4)"
+msgstr "Báltico (antigo) (ISO-8859-4)"
+
+#: ../src/common/fmapbase.cpp:148
+msgid "Cyrillic (ISO-8859-5)"
+msgstr "Cirílico (ISO-8859-5)"
+
+#: ../src/common/fmapbase.cpp:149
+msgid "Arabic (ISO-8859-6)"
+msgstr "Árabe (ISO-8859-6)"
+
+#: ../src/common/fmapbase.cpp:150
+msgid "Greek (ISO-8859-7)"
+msgstr "Grego (ISO-8859-7)"
+
+#: ../src/common/fmapbase.cpp:151
+msgid "Hebrew (ISO-8859-8)"
+msgstr "Hebreo (ISO-8859-8)"
+
+#: ../src/common/fmapbase.cpp:152
+msgid "Turkish (ISO-8859-9)"
+msgstr "Turco (ISO-8859-9)"
+
+#: ../src/common/fmapbase.cpp:153
+msgid "Nordic (ISO-8859-10)"
+msgstr "Nórdico (ISO-8859-10)"
+
+#: ../src/common/fmapbase.cpp:154
+msgid "Thai (ISO-8859-11)"
+msgstr "Tailandés (ISO-8859-11)"
+
+#: ../src/common/fmapbase.cpp:155
+msgid "Indian (ISO-8859-12)"
+msgstr "Indio (ISO-8859-12)"
+
+#: ../src/common/fmapbase.cpp:156
+msgid "Baltic (ISO-8859-13)"
+msgstr "Báltico (ISO-8859-13)"
+
+#: ../src/common/fmapbase.cpp:157
+msgid "Celtic (ISO-8859-14)"
+msgstr "Céltico (ISO-8859-14)"
+
+#: ../src/common/fmapbase.cpp:158
+msgid "Western European with Euro (ISO-8859-15)"
+msgstr "Europeo occidental con euro (ISO-8859-15)"
+
+#: ../src/common/fmapbase.cpp:159
+msgid "KOI8-R"
+msgstr "KOI8-R"
+
+#: ../src/common/fmapbase.cpp:160
+msgid "KOI8-U"
+msgstr "KOI8-U"
+
+#: ../src/common/fmapbase.cpp:161
+msgid "Windows/DOS OEM Cyrillic (CP 866)"
+msgstr "Windows/DOS OEM cirílico (CP 866)"
+
+#: ../src/common/fmapbase.cpp:162
+msgid "Windows Thai (CP 874)"
+msgstr "Windows tailandés (CP 874)"
+
+#: ../src/common/fmapbase.cpp:163
+msgid "Windows Japanese (CP 932) or Shift-JIS"
+msgstr "Windows xaponés (CP 932)"
+
+#: ../src/common/fmapbase.cpp:164
+msgid "Windows Chinese Simplified (CP 936) or GB-2312"
+msgstr "Windows chinés simplificado (CP 936) ou GB-2312"
+
+#: ../src/common/fmapbase.cpp:165
+msgid "Windows Korean (CP 949)"
+msgstr "Windows coreano (CP 949)"
+
+#: ../src/common/fmapbase.cpp:166
+msgid "Windows Chinese Traditional (CP 950) or Big-5"
+msgstr "Windows chinés tradicional (CP 950) ou Big-5"
+
+#: ../src/common/fmapbase.cpp:167
+msgid "Windows Central European (CP 1250)"
+msgstr "Windows Europa Central (CP 1250)"
+
+#: ../src/common/fmapbase.cpp:168
+msgid "Windows Cyrillic (CP 1251)"
+msgstr "Windows cirílico (CP 1251)"
+
+#: ../src/common/fmapbase.cpp:169
+msgid "Windows Western European (CP 1252)"
+msgstr "Windows Europa occidental (CP 1252)"
+
+#: ../src/common/fmapbase.cpp:170
+msgid "Windows Greek (CP 1253)"
+msgstr "Windows grego (CP 1253)"
+
+#: ../src/common/fmapbase.cpp:171
+msgid "Windows Turkish (CP 1254)"
+msgstr "Windows turco (CP 1254)"
+
+#: ../src/common/fmapbase.cpp:172
+msgid "Windows Hebrew (CP 1255)"
+msgstr "Windows hebreo (CP 1255)"
+
+#: ../src/common/fmapbase.cpp:173
+msgid "Windows Arabic (CP 1256)"
+msgstr "Windows árabe (CP 1256)"
+
+#: ../src/common/fmapbase.cpp:174
+msgid "Windows Baltic (CP 1257)"
+msgstr "Windows báltico (CP 1257)"
+
+#: ../src/common/fmapbase.cpp:175
+msgid "Windows Vietnamese (CP 1258)"
+msgstr "Windows vietnamita (CP 1258)"
+
+#: ../src/common/fmapbase.cpp:176
+msgid "Windows Johab (CP 1361)"
+msgstr "Windows johab (CP 1361)"
+
+#: ../src/common/fmapbase.cpp:177
+msgid "Windows/DOS OEM (CP 437)"
+msgstr "Windows/DOS OEM (CP 437)"
+
+#: ../src/common/fmapbase.cpp:178
+msgid "Unicode 7 bit (UTF-7)"
+msgstr "Unicode de 7 bits (UTF-7)"
+
+#: ../src/common/fmapbase.cpp:179
+msgid "Unicode 8 bit (UTF-8)"
+msgstr "Unicode de 8 bits (UTF-8)"
+
+#: ../src/common/fmapbase.cpp:181 ../src/common/fmapbase.cpp:187
+msgid "Unicode 16 bit (UTF-16)"
+msgstr "Unicode de 16 bits (UTF-16)"
+
+#: ../src/common/fmapbase.cpp:182
+msgid "Unicode 16 bit Little Endian (UTF-16LE)"
+msgstr "Unicode 16 bits Little Endian (UTF-16LE)"
+
+#: ../src/common/fmapbase.cpp:183 ../src/common/fmapbase.cpp:189
+msgid "Unicode 32 bit (UTF-32)"
+msgstr "Unicode de 32 bits (UTF-32)"
+
+#: ../src/common/fmapbase.cpp:184
+msgid "Unicode 32 bit Little Endian (UTF-32LE)"
+msgstr "Unicode 32 bits Little Endian (UTF-32LE)"
+
+#: ../src/common/fmapbase.cpp:186
+msgid "Unicode 16 bit Big Endian (UTF-16BE)"
+msgstr "Unicode 16 bits Big Endian (UTF-16BE)"
+
+#: ../src/common/fmapbase.cpp:188
+msgid "Unicode 32 bit Big Endian (UTF-32BE)"
+msgstr "Unicode 32 bits Big Endian (UTF-32BE)"
+
+#: ../src/common/fmapbase.cpp:191
+msgid "Extended Unix Codepage for Japanese (EUC-JP)"
+msgstr "Páxina de códigos Unix estendidos para o xaponés (EUC-JP)"
+
+#: ../src/common/fmapbase.cpp:192
+msgid "US-ASCII"
+msgstr "ASCII"
+
+#: ../src/common/fmapbase.cpp:193
+msgid "ISO-2022-JP"
+msgstr "ISO-2022-JP"
+
+#: ../src/common/fmapbase.cpp:195
+msgid "MacRoman"
+msgstr "Mac ASCII"
+
+#: ../src/common/fmapbase.cpp:196
+msgid "MacJapanese"
+msgstr "Mac xaponés"
+
+#: ../src/common/fmapbase.cpp:197
+msgid "MacChineseTrad"
+msgstr "Mac chinés tradicional"
+
+#: ../src/common/fmapbase.cpp:198
+msgid "MacKorean"
+msgstr "Mac coreano"
+
+#: ../src/common/fmapbase.cpp:199
+msgid "MacArabic"
+msgstr "Mac árabe"
+
+#: ../src/common/fmapbase.cpp:200
+msgid "MacHebrew"
+msgstr "Mac hebreo"
+
+#: ../src/common/fmapbase.cpp:201
+msgid "MacGreek"
+msgstr "Mac grego"
+
+#: ../src/common/fmapbase.cpp:202
+msgid "MacCyrillic"
+msgstr "Mac cirílico"
+
+#: ../src/common/fmapbase.cpp:203
+msgid "MacDevanagari"
+msgstr "Mac devanágari"
+
+#: ../src/common/fmapbase.cpp:204
+msgid "MacGurmukhi"
+msgstr "Mac gurmukhi"
+
+#: ../src/common/fmapbase.cpp:205
+msgid "MacGujarati"
+msgstr "Mac gujarati"
+
+#: ../src/common/fmapbase.cpp:206
+msgid "MacOriya"
+msgstr "Mac orissa"
+
+#: ../src/common/fmapbase.cpp:207
+msgid "MacBengali"
+msgstr "Mac bengalí"
+
+#: ../src/common/fmapbase.cpp:208
+msgid "MacTamil"
+msgstr "Mac támil"
+
+#: ../src/common/fmapbase.cpp:209
+msgid "MacTelugu"
+msgstr "Mac telugu"
+
+#: ../src/common/fmapbase.cpp:210
+msgid "MacKannada"
+msgstr "Mac kanada"
+
+#: ../src/common/fmapbase.cpp:211
+msgid "MacMalayalam"
+msgstr "Mac malaialam"
+
+#: ../src/common/fmapbase.cpp:212
+msgid "MacSinhalese"
+msgstr "Mac cingalés"
+
+#: ../src/common/fmapbase.cpp:213
+msgid "MacBurmese"
+msgstr "Mac birmano"
+
+#: ../src/common/fmapbase.cpp:214
+msgid "MacKhmer"
+msgstr "Mac cambodjano"
+
+#: ../src/common/fmapbase.cpp:215
+msgid "MacThai"
+msgstr "Mac tai"
+
+#: ../src/common/fmapbase.cpp:216
+msgid "MacLaotian"
+msgstr "Mac laosiano"
+
+#: ../src/common/fmapbase.cpp:217
+msgid "MacGeorgian"
+msgstr "Mac xeorxiano"
+
+#: ../src/common/fmapbase.cpp:218
+msgid "MacArmenian"
+msgstr "Mac armenio"
+
+#: ../src/common/fmapbase.cpp:219
+msgid "MacChineseSimp"
+msgstr "Mac chinés simple"
+
+#: ../src/common/fmapbase.cpp:220
+msgid "MacTibetan"
+msgstr "Mac tibetano"
+
+#: ../src/common/fmapbase.cpp:221
+msgid "MacMongolian"
+msgstr "Mac mongol"
+
+#: ../src/common/fmapbase.cpp:222
+msgid "MacEthiopic"
+msgstr "Mac etíope"
+
+#: ../src/common/fmapbase.cpp:223
+msgid "MacCentralEurRoman"
+msgstr "Mac ASCII Europa Central"
+
+#: ../src/common/fmapbase.cpp:224
+msgid "MacVietnamese"
+msgstr "Mac vietnamita"
+
+#: ../src/common/fmapbase.cpp:225
+msgid "MacExtArabic"
+msgstr "Mac árabe est."
+
+#: ../src/common/fmapbase.cpp:226
+msgid "MacSymbol"
+msgstr "Mac símbolos"
+
+#: ../src/common/fmapbase.cpp:227
+msgid "MacDingbats"
+msgstr "Mac pictogramas"
+
+#: ../src/common/fmapbase.cpp:228
+msgid "MacTurkish"
+msgstr "Mac turco"
+
+#: ../src/common/fmapbase.cpp:229
+msgid "MacCroatian"
+msgstr "Mac croata"
+
+#: ../src/common/fmapbase.cpp:230
+msgid "MacIcelandic"
+msgstr "Mac islandés"
+
+#: ../src/common/fmapbase.cpp:231
+msgid "MacRomanian"
+msgstr "Mac romanés"
+
+#: ../src/common/fmapbase.cpp:232
+msgid "MacCeltic"
+msgstr "Mac céltico"
+
+#: ../src/common/fmapbase.cpp:233
+msgid "MacGaelic"
+msgstr "Mac gaélico"
+
+#: ../src/common/fmapbase.cpp:234
+msgid "MacKeyboardGlyphs"
+msgstr "Mac caracteres especiais"
+
+#: ../src/common/fmapbase.cpp:791
+msgid "Default encoding"
+msgstr "Codificación predeterminada"
+
+#: ../src/common/fmapbase.cpp:805
+#, c-format
+msgid "Unknown encoding (%d)"
+msgstr "Codificación descoñecida (%d)"
+
+#: ../src/common/fmapbase.cpp:815 ../src/richtext/richtextstyles.cpp:776
+msgid "default"
+msgstr "predeterminado"
+
+#: ../src/common/fmapbase.cpp:829
+#, c-format
+msgid "unknown-%d"
+msgstr "descoñecido-%d"
+
+#: ../src/common/fontcmn.cpp:924 ../src/common/fontcmn.cpp:1130
+msgid "underlined"
+msgstr "subliñado"
+
+#: ../src/common/fontcmn.cpp:929
+msgid " strikethrough"
+msgstr " riscado"
+
+#: ../src/common/fontcmn.cpp:942
+msgid " thin"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:946
+#, fuzzy
+msgid " extra light"
+msgstr " clara"
+
+#: ../src/common/fontcmn.cpp:950
+msgid " light"
+msgstr " clara"
+
+#: ../src/common/fontcmn.cpp:954
+msgid " medium"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:958
+#, fuzzy
+msgid " semi bold"
+msgstr " grosa"
+
+#: ../src/common/fontcmn.cpp:962
+msgid " bold"
+msgstr " grosa"
+
+#: ../src/common/fontcmn.cpp:966
+#, fuzzy
+msgid " extra bold"
+msgstr " grosa"
+
+#: ../src/common/fontcmn.cpp:970
+msgid " heavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:974
+msgid " extra heavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:990
+msgid " italic"
+msgstr " cursiva"
+
+#: ../src/common/fontcmn.cpp:1134
+msgid "strikethrough"
+msgstr "riscado"
+
+#: ../src/common/fontcmn.cpp:1143
+msgid "thin"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1156
+#, fuzzy
+msgid "extralight"
+msgstr "clara"
+
+#: ../src/common/fontcmn.cpp:1161
+msgid "light"
+msgstr "clara"
+
+#: ../src/common/fontcmn.cpp:1169 ../src/richtext/richtextstyles.cpp:775
+msgid "normal"
+msgstr "normal"
+
+#: ../src/common/fontcmn.cpp:1174
+msgid "medium"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1179 ../src/common/fontcmn.cpp:1199
+#, fuzzy
+msgid "semibold"
+msgstr "grosa"
+
+#: ../src/common/fontcmn.cpp:1184
+msgid "bold"
+msgstr "grosa"
+
+#: ../src/common/fontcmn.cpp:1194
+#, fuzzy
+msgid "extrabold"
+msgstr "grosa"
+
+#: ../src/common/fontcmn.cpp:1204
+msgid "heavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1212
+msgid "extraheavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1217
+msgid "italic"
+msgstr "cursiva"
+
+#: ../src/common/fontmap.cpp:195
+msgid ": unknown charset"
+msgstr ": xogo de caracteres descoñecido"
+
+#: ../src/common/fontmap.cpp:199
+#, c-format
+msgid ""
+"The charset '%s' is unknown. You may select\n"
+"another charset to replace it with or choose\n"
+"[Cancel] if it cannot be replaced"
+msgstr ""
+"O xogo de caracteres '%s' é descoñecido.\n"
+"Debe seleccionar outro xogo de caracteres\n"
+"para substituílo ou premer en [Cancelar] se\n"
+"non se pode substituír"
+
+#: ../src/common/fontmap.cpp:241
+#, c-format
+msgid "Failed to remember the encoding for the charset '%s'."
+msgstr "Erro ao recordar a codificación para o conxunto de caracteres '%s'."
+
+#: ../src/common/fontmap.cpp:321
+msgid "can't load any font, aborting"
+msgstr "non se pode cargar ningún tipo de letra, cancelando"
+
+#: ../src/common/fontmap.cpp:409
+msgid ": unknown encoding"
+msgstr ": codificación descoñecida"
+
+#: ../src/common/fontmap.cpp:417
+#, c-format
+msgid ""
+"No font for displaying text in encoding '%s' found,\n"
+"but an alternative encoding '%s' is available.\n"
+"Do you want to use this encoding (otherwise you will have to choose another "
+"one)?"
+msgstr ""
+"Non existe un tipo de letra para a codificación '%s',\n"
+"pero a codificación alternativa '%s' está dispoñíbel.\n"
+"Quere utilizar esta configuración? (Se non é así deberá elixir outra)"
+
+#: ../src/common/fontmap.cpp:422
+#, c-format
+msgid ""
+"No font for displaying text in encoding '%s' found.\n"
+"Would you like to select a font to be used for this encoding\n"
+"(otherwise the text in this encoding will not be shown correctly)?"
+msgstr ""
+"Non existe un tipo de letra para a codificación '%s'.\n"
+"Quere seleccionar un tipo de letra para usar con esta codificación?\n"
+"(Doutro modo o texto non se verá correctamente)"
+
+#: ../src/common/fs_mem.cpp:169
+#, c-format
+msgid "Memory VFS already contains file '%s'!"
+msgstr "A memoria VFS xa contén o ficheiro '%s'!"
+
+#: ../src/common/fs_mem.cpp:232
+#, c-format
+msgid "Trying to remove file '%s' from memory VFS, but it is not loaded!"
+msgstr ""
+"Tentouse eliminar o ficheiro '%s' da memoria VFS, pero non está cargado!"
+
+#: ../src/common/fs_mem.cpp:262
+#, c-format
+msgid "Failed to store image '%s' to memory VFS!"
+msgstr "Non se puido almacenar imaxe '%s' na memoria VFS!"
+
+#: ../src/common/ftp.cpp:197
+msgid "Timeout while waiting for FTP server to connect, try passive mode."
+msgstr ""
+"Superouse o tempo de espera para a conexión ao servidor FTP, inténteo co "
+"modo pasivo."
+
+#: ../src/common/ftp.cpp:399
+#, c-format
+msgid "Failed to set FTP transfer mode to %s."
+msgstr "Fallo ao estabelecer o modo de tranferencia FTP como %s."
+
+#: ../src/common/ftp.cpp:400 ../src/richtext/richtextsymboldlg.cpp:432
+msgid "ASCII"
+msgstr "ASCII"
+
+#: ../src/common/ftp.cpp:400
+msgid "binary"
+msgstr "binario"
+
+#: ../src/common/ftp.cpp:608
+msgid "The FTP server doesn't support the PORT command."
+msgstr "O servidor FTP non é compatíbel co comando PORT."
+
+#: ../src/common/ftp.cpp:622
+msgid "The FTP server doesn't support passive mode."
+msgstr "O servidor FTP non é compatíbel co modo pasivo."
+
+#: ../src/common/gifdecod.cpp:822
+#, c-format
+msgid "Incorrect GIF frame size (%u, %d) for the frame #%u"
+msgstr "Tamaño de marco de GIF incorrecto (%u, %d) para o marco #%u"
+
+#: ../src/common/glcmn.cpp:108
+msgid "Failed to allocate colour for OpenGL"
+msgstr "Erro ao asignar cor para OpenGL"
+
+#: ../src/common/headerctrlcmn.cpp:57
+msgid "Please select the columns to show and define their order:"
+msgstr "Por favor, seleccione as columnas para amosar e defina a súa orde:"
+
+#: ../src/common/headerctrlcmn.cpp:58
+msgid "Customize Columns"
+msgstr "Columnas personalizadas"
+
+#: ../src/common/headerctrlcmn.cpp:304
+msgid "&Customize..."
+msgstr "&Personalizar..."
+
+#: ../src/common/hyperlnkcmn.cpp:132
+#, fuzzy, c-format
+msgid "Failed to open URL \"%s\" in the default browser"
+msgstr "Erro ao abrir URL \"%s\" no navegador predeterminado."
+
+#: ../src/common/iconbndl.cpp:195
+#, c-format
+msgid "Failed to load image %%d from file '%s'."
+msgstr "Non foi posíbel cargar a imaxe %%d do ficheiro '%s'."
+
+#: ../src/common/iconbndl.cpp:203
+#, c-format
+msgid "Failed to load image %d from stream."
+msgstr "Non foi posíbel cargar a imaxe %d do fluxo."
+
+#: ../src/common/iconbndl.cpp:221
+#, fuzzy, c-format
+msgid "Failed to load icons from resource '%s'."
+msgstr "Non foi posíbel cargar a icona \"%s\" dos recursos."
+
+#: ../src/common/imagbmp.cpp:97
+msgid "BMP: Couldn't save invalid image."
+msgstr "BMP: Non se puido gardar imaxe non válida."
+
+#: ../src/common/imagbmp.cpp:137
+msgid "BMP: wxImage doesn't have own wxPalette."
+msgstr "BMP: wxImage non ten a súa propia wxPalette."
+
+#: ../src/common/imagbmp.cpp:243
+msgid "BMP: Couldn't write the file (Bitmap) header."
+msgstr "BMP: Non se puido escribir a cabeceira (Bitmap) do arquito."
+
+#: ../src/common/imagbmp.cpp:266
+msgid "BMP: Couldn't write the file (BitmapInfo) header."
+msgstr "BMP: Non se puido escribir a cabeceira (BitmapInfo) do ficheiro."
+
+#: ../src/common/imagbmp.cpp:353
+msgid "BMP: Couldn't write RGB color map."
+msgstr "BMP: No se puido escribir o mapa de cor RGB."
+
+#: ../src/common/imagbmp.cpp:487
+msgid "BMP: Couldn't write data."
+msgstr "BMP: Non se puideron escribir os datos."
+
+#: ../src/common/imagbmp.cpp:561 ../src/common/imagbmp.cpp:642
+msgid "BMP: Couldn't allocate memory."
+msgstr "BMP: Non se puido asignar memoria."
+
+#: ../src/common/imagbmp.cpp:1041
+msgid "DIB Header: Image width > 32767 pixels for file."
+msgstr "Cabeceira DIB: Ancho da imaxe > 32767 píxeles por ficheiro."
+
+#: ../src/common/imagbmp.cpp:1049
+msgid "DIB Header: Image height > 32767 pixels for file."
+msgstr "Cabeceira DIB: Altura da imaxe > 32767 píxeles por ficheiro."
+
+#: ../src/common/imagbmp.cpp:1081
+msgid "DIB Header: Unknown bitdepth in file."
+msgstr "Cabeceira DIB: Número de bits por píxel descoñecido no ficheiro."
+
+#: ../src/common/imagbmp.cpp:1156
+msgid "DIB Header: Unknown encoding in file."
+msgstr "Cabeceira DIB: Codificación descoñecida en ficheiro."
+
+#: ../src/common/imagbmp.cpp:1165
+msgid "DIB Header: Encoding doesn't match bitdepth."
+msgstr ""
+"Cabeceira DIB: A codificación non coincide co número de bits por píxel."
+
+#: ../src/common/imagbmp.cpp:1180
+#, c-format
+msgid "BMP Header: Invalid number of colors (%d)."
+msgstr ""
+
+#: ../src/common/imagbmp.cpp:1273
+msgid "Error in reading image DIB."
+msgstr "Erro ao ler a imaxe DIB."
+
+#: ../src/common/imagbmp.cpp:1294
+msgid "ICO: Error in reading mask DIB."
+msgstr "ICO: Erro ao ler máscara DIB."
+
+#: ../src/common/imagbmp.cpp:1353
+msgid "ICO: Image too tall for an icon."
+msgstr "ICO: A imaxe é alta de máis para unha icona."
+
+#: ../src/common/imagbmp.cpp:1361
+msgid "ICO: Image too wide for an icon."
+msgstr "ICO: A imaxe é ancha de máis para unha icona."
+
+#: ../src/common/imagbmp.cpp:1388 ../src/common/imagbmp.cpp:1488
+#: ../src/common/imagbmp.cpp:1503 ../src/common/imagbmp.cpp:1514
+#: ../src/common/imagbmp.cpp:1528 ../src/common/imagbmp.cpp:1576
+#: ../src/common/imagbmp.cpp:1591 ../src/common/imagbmp.cpp:1605
+#: ../src/common/imagbmp.cpp:1616
+msgid "ICO: Error writing the image file!"
+msgstr "ICO: Erro ao escribir o ficheiro de imaxe!"
+
+#: ../src/common/imagbmp.cpp:1701
+msgid "ICO: Invalid icon index."
+msgstr "ICO: Índice de iconas incorrecto."
+
+#: ../src/common/image.cpp:2410
+msgid "Image and mask have different sizes."
+msgstr "A imaxe e a máscara teñen tamaños diferentes."
+
+#: ../src/common/image.cpp:2418 ../src/common/image.cpp:2459
+msgid "No unused colour in image being masked."
+msgstr "Non se enmascarou ningunha cor non utilizada na imaxe."
+
+#: ../src/common/image.cpp:2641
+#, c-format
+msgid "Failed to load bitmap \"%s\" from resources."
+msgstr "Non foi posíbel cargar o mapa de bits \"%s\" dos recursos."
+
+#: ../src/common/image.cpp:2650
+#, c-format
+msgid "Failed to load icon \"%s\" from resources."
+msgstr "Non foi posíbel cargar a icona \"%s\" dos recursos."
+
+#: ../src/common/image.cpp:2728 ../src/common/image.cpp:2747
+#, c-format
+msgid "Failed to load image from file \"%s\"."
+msgstr "Non foi posíbel cargar a imaxe dende o ficheiro \"%s\"."
+
+#: ../src/common/image.cpp:2761
+#, c-format
+msgid "Can't save image to file '%s': unknown extension."
+msgstr "Non se puido gardar a imaxe no ficheiro '%s': extensión descoñecida."
+
+#: ../src/common/image.cpp:2869
+msgid "No handler found for image type."
+msgstr "Non se atopou un manexador para o tipo de imaxe."
+
+#: ../src/common/image.cpp:2877 ../src/common/image.cpp:3000
+#: ../src/common/image.cpp:3066
+#, c-format
+msgid "No image handler for type %d defined."
+msgstr "Non se definiu ningún manexador para o tipo %d."
+
+#: ../src/common/image.cpp:2887
+#, c-format
+msgid "Image file is not of type %d."
+msgstr "O ficheiro de imaxe non é do tipo %d."
+
+#: ../src/common/image.cpp:2970
+msgid "Can't automatically determine the image format for non-seekable input."
+msgstr ""
+"Non é posíbel determinar automaticamente o formato da imaxe debido a unha "
+"entrada non localizábel."
+
+#: ../src/common/image.cpp:2988
+msgid "Unknown image data format."
+msgstr "Formato de datos de imaxe descoñecido."
+
+#: ../src/common/image.cpp:3009
+#, c-format
+msgid "This is not a %s."
+msgstr "Isto non é un %s."
+
+#: ../src/common/image.cpp:3032 ../src/common/image.cpp:3080
+#, c-format
+msgid "No image handler for type %s defined."
+msgstr "Non se definiu ningún manexador para o tipo %s."
+
+#: ../src/common/image.cpp:3041
+#, c-format
+msgid "Image is not of type %s."
+msgstr "A imaxe non é do tipo %s."
+
+#: ../src/common/image.cpp:3509
+#, c-format
+msgid "Failed to check format of image file \"%s\"."
+msgstr "Erro ao comprobar o formato do ficheiro de imaxe \"%s\"."
+
+#: ../src/common/imaggif.cpp:124
+msgid "GIF: error in GIF image format."
+msgstr "GIF: erro no formato da imaxe GIF."
+
+#: ../src/common/imaggif.cpp:129
+msgid "GIF: not enough memory."
+msgstr "GIF: memoria insuficiente."
+
+#: ../src/common/imaggif.cpp:134
+msgid "GIF: data stream seems to be truncated."
+msgstr "GIF: o fluxo de datos semella truncado."
+
+#: ../src/common/imaggif.cpp:240
+msgid "Couldn't initialize GIF hash table."
+msgstr "Non se puido inicializar a táboa hash de GIF."
+
+#: ../src/common/imagiff.cpp:739
+msgid "IFF: error in IFF image format."
+msgstr "IFF: erro no formato da imaxe IFF."
+
+#: ../src/common/imagiff.cpp:742
+msgid "IFF: not enough memory."
+msgstr "IFF: memoria insuficiente."
+
+#: ../src/common/imagiff.cpp:745
+msgid "IFF: unknown error!!!"
+msgstr "IFF: erro descoñecido!!!"
+
+#: ../src/common/imagiff.cpp:755
+msgid "IFF: data stream seems to be truncated."
+msgstr "IFF: o fluxo de datos semella truncado."
+
+#: ../src/common/imagjpeg.cpp:258
+msgid "JPEG: Couldn't load - file is probably corrupted."
+msgstr "JPEG: Non se puido cargar - probabelmente o ficheiro estea danado."
+
+#: ../src/common/imagjpeg.cpp:437
+msgid "JPEG: Couldn't save image."
+msgstr "JPEG: Non se puido gardar a imaxe."
+
+#: ../src/common/imagpcx.cpp:439
+msgid "PCX: this is not a PCX file."
+msgstr "PCX: isto non é un ficheiro PCX."
+
+#: ../src/common/imagpcx.cpp:453
+msgid "PCX: image format unsupported"
+msgstr "PCX: formato de imaxe non compatíbel"
+
+#: ../src/common/imagpcx.cpp:454 ../src/common/imagpcx.cpp:477
+msgid "PCX: couldn't allocate memory"
+msgstr "PCX: non se puido asignar memoria"
+
+#: ../src/common/imagpcx.cpp:455
+msgid "PCX: version number too low"
+msgstr "PCX: número de versión demasiado baixo"
+
+#: ../src/common/imagpcx.cpp:456 ../src/common/imagpcx.cpp:478
+msgid "PCX: unknown error !!!"
+msgstr "PCX: erro descoñecido !!!"
+
+#: ../src/common/imagpcx.cpp:476
+msgid "PCX: invalid image"
+msgstr "PCX: imaxe incorrecta"
+
+#: ../src/common/imagpng.cpp:385
+#, c-format
+msgid "Unknown PNG resolution unit %d"
+msgstr "Unidade de resolución de PNG %d descoñecida"
+
+#: ../src/common/imagpng.cpp:439
+msgid "Couldn't load a PNG image - file is corrupted or not enough memory."
+msgstr ""
+"Non se puido cargar unha imaxe PNG - o ficheiro está danado ou non hai "
+"memoria dabondo."
+
+#: ../src/common/imagpng.cpp:513 ../src/common/imagpng.cpp:524
+#: ../src/common/imagpng.cpp:534
+msgid "Couldn't save PNG image."
+msgstr "Non se puido gardar a imaxe PNG."
+
+#: ../src/common/imagpnm.cpp:71
+msgid "PNM: File format is not recognized."
+msgstr "PNM: Non se recoñeceu o formato do ficheiro."
+
+#: ../src/common/imagpnm.cpp:89
+msgid "PNM: Couldn't allocate memory."
+msgstr "PNM: Non se puido asignar memoria."
+
+#: ../src/common/imagpnm.cpp:111 ../src/common/imagpnm.cpp:134
+#: ../src/common/imagpnm.cpp:156
+msgid "PNM: File seems truncated."
+msgstr "PNM: O ficheiro semella truncado."
+
+#: ../src/common/imagtiff.cpp:69
+#, c-format
+msgid " (in module \"%s\")"
+msgstr " (en módulo \"%s\")"
+
+#: ../src/common/imagtiff.cpp:304
+msgid "TIFF: Error loading image."
+msgstr "TIFF: Erro ao cargar a imaxe."
+
+#: ../src/common/imagtiff.cpp:314
+msgid "Invalid TIFF image index."
+msgstr "Índice de imaxe TIFF incorrecto."
+
+#: ../src/common/imagtiff.cpp:358
+msgid "TIFF: Image size is abnormally big."
+msgstr "TIFF: A imaxe ten un tamaño anormalmente grande."
+
+#: ../src/common/imagtiff.cpp:372 ../src/common/imagtiff.cpp:385
+#: ../src/common/imagtiff.cpp:769
+msgid "TIFF: Couldn't allocate memory."
+msgstr "TIFF: Non se puido asignar memoria."
+
+#: ../src/common/imagtiff.cpp:471
+msgid "TIFF: Error reading image."
+msgstr "TIFF: Erro ao ler a imaxe."
+
+#: ../src/common/imagtiff.cpp:532
+#, c-format
+msgid "Unknown TIFF resolution unit %d ignored"
+msgstr "A unidade de resolución de TIFF %d descoñecida foi ignorada"
+
+#: ../src/common/imagtiff.cpp:611
+msgid "TIFF: Error saving image."
+msgstr "TIFF: Erro ao gardar a imaxe."
+
+#: ../src/common/imagtiff.cpp:868
+msgid "TIFF: Error writing image."
+msgstr "TIFF: Erro ao escribir na imaxe."
+
+#: ../src/common/imagtiff.cpp:881
+#, fuzzy
+msgid "TIFF: Error flushing data."
+msgstr "TIFF: Erro ao gardar a imaxe."
+
+#: ../src/common/imagwebp.cpp:56
+msgid "WebP: Invalid data (failed to get features)."
+msgstr ""
+
+#: ../src/common/imagwebp.cpp:65
+msgid "WebP: Allocating image memory failed."
+msgstr ""
+
+#: ../src/common/imagwebp.cpp:82
+msgid "WebP: Decoding RGBA image data failed."
+msgstr ""
+
+#: ../src/common/imagwebp.cpp:98
+msgid "WebP: Decoding RGB image data failed."
+msgstr ""
+
+#: ../src/common/imagwebp.cpp:113 ../src/common/imagwebp.cpp:201
+msgid "WebP: Allocating stream buffer failed."
+msgstr ""
+
+#: ../src/common/imagwebp.cpp:131
+#, fuzzy
+msgid "WebP: Failed to parse container data."
+msgstr "Erro ao estabelecer datos do portapapeis."
+
+#: ../src/common/imagwebp.cpp:222
+#, fuzzy
+msgid "WebP: Error decoding animation."
+msgstr "Erro ao ler as opcións de configuración."
+
+#: ../src/common/imagwebp.cpp:240
+msgid "WebP: Error getting next animation frame."
+msgstr ""
+
+#: ../src/common/init.cpp:172
+#, c-format
+msgid ""
+"Command line argument %d couldn't be converted to Unicode and will be "
+"ignored."
+msgstr ""
+"O argumento %d da liña de comandos non se puido converter a Unicode e "
+"ignorarase."
+
+#: ../src/common/init.cpp:344
+msgid "Initialization failed in post init, aborting."
+msgstr "Erro ao inicializar post init, cancelando."
+
+#: ../src/common/intl.cpp:378
+#, c-format
+msgid "Cannot set locale to language \"%s\"."
+msgstr "Non se pode configurar o idioma \"%s\"."
+
+#: ../src/common/log.cpp:232
+msgid "Error: "
+msgstr "Erro: "
+
+#: ../src/common/log.cpp:236
+msgid "Warning: "
+msgstr "Aviso: "
+
+#: ../src/common/log.cpp:284
+msgid "The previous message repeated once."
+msgstr "A mensaxe anterior repetida unha vez."
+
+#: ../src/common/log.cpp:291
+#, fuzzy, c-format
+msgid "The previous message repeated %u time."
+msgid_plural "The previous message repeated %u times."
+msgstr[0] "A mensaxe anterior repetida %lu vez."
+msgstr[1] "A mensaxe anterior repetida %lu veces."
+
+#: ../src/common/log.cpp:319
+#, fuzzy, c-format
+msgid "Last repeated message (\"%s\", %u time) wasn't output"
+msgid_plural "Last repeated message (\"%s\", %u times) wasn't output"
+msgstr[0] "A última mensaxe repetida (\"%s\", %lu vez) non se enviou á saída"
+msgstr[1] "A última mensaxe repetida (\"%s\", %lu veces) non se enviou á saída"
+
+#: ../src/common/log.cpp:435
+#, c-format
+msgid " (error %ld: %s)"
+msgstr " (erro %ld: %s)"
+
+#: ../src/common/lzmastream.cpp:121
+#, fuzzy
+msgid "Failed to allocate memory for LZMA decompression."
+msgstr "Erro ao asignar cor para OpenGL"
+
+#: ../src/common/lzmastream.cpp:125
+#, c-format
+msgid "Failed to initialize LZMA decompression: unexpected error %u."
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:179
+msgid "input is not in XZ format"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:183
+msgid "input compressed using unknown XZ option"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:188
+msgid "input is corrupted"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:192
+#, fuzzy
+msgid "unknown decompression error"
+msgstr "erro de descompresión"
+
+#: ../src/common/lzmastream.cpp:196
+#, fuzzy, c-format
+msgid "LZMA decompression error: %s"
+msgstr "erro de descompresión"
+
+#: ../src/common/lzmastream.cpp:231
+#, fuzzy
+msgid "Failed to allocate memory for LZMA compression."
+msgstr "Erro ao asignar cor para OpenGL"
+
+#: ../src/common/lzmastream.cpp:235
+#, c-format
+msgid "Failed to initialize LZMA compression: unexpected error %u."
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:267 ../src/common/lzmastream.cpp:342
+#: ../src/html/chm.cpp:336
+msgid "out of memory"
+msgstr "sen memoria"
+
+#: ../src/common/lzmastream.cpp:276 ../src/common/lzmastream.cpp:346
+#, fuzzy
+msgid "unknown compression error"
+msgstr "erro de compresión"
+
+#: ../src/common/lzmastream.cpp:280
+#, fuzzy, c-format
+msgid "LZMA compression error: %s"
+msgstr "erro de compresión"
+
+#: ../src/common/lzmastream.cpp:350
+#, c-format
+msgid "LZMA compression error when flushing output: %s"
+msgstr ""
+
+#: ../src/common/mimecmn.cpp:167
+#, c-format
+msgid "Unmatched '{' in an entry for mime type %s."
+msgstr "'{' non emparellado nunha entrada para o tipo mime %s."
+
+#: ../src/common/module.cpp:76
+#, c-format
+msgid "Circular dependency involving module \"%s\" detected."
+msgstr "Detectada dependencia circular relacionada co módulo \"%s\"."
+
+#: ../src/common/module.cpp:128
+#, c-format
+msgid "Dependency \"%s\" of module \"%s\" doesn't exist."
+msgstr "A dependencia \"%s\" do módulo \"%s\" non existe."
+
+#: ../src/common/module.cpp:137
+#, c-format
+msgid "Module \"%s\" initialization failed"
+msgstr "Fallou a inicialización do módulo \"%s\""
+
+#: ../src/common/msgout.cpp:96
+msgid "Message"
+msgstr "Mensaxe"
+
+#: ../src/common/paper.cpp:70
+msgid "Letter, 8 1/2 x 11 in"
+msgstr "Carta, 8 1/2 x 11 polgadas"
+
+#: ../src/common/paper.cpp:71
+msgid "Legal, 8 1/2 x 14 in"
+msgstr "Legal, 8 1/2 x 14 polgadas"
+
+#: ../src/common/paper.cpp:72
+msgid "A4 sheet, 210 x 297 mm"
+msgstr "Folla A4, 210 x 297 mm"
+
+#: ../src/common/paper.cpp:73
+msgid "C sheet, 17 x 22 in"
+msgstr "Folla C, 17 x 22 polgadas"
+
+#: ../src/common/paper.cpp:74
+msgid "D sheet, 22 x 34 in"
+msgstr "Folla D, 22 x 34 polgadas"
+
+#: ../src/common/paper.cpp:75
+msgid "E sheet, 34 x 44 in"
+msgstr "Folla E, 34 x 44 polgadas"
+
+#: ../src/common/paper.cpp:76
+msgid "Letter Small, 8 1/2 x 11 in"
+msgstr "Sobre pequeno, 8 1/2 x 11 polgadas"
+
+#: ../src/common/paper.cpp:77
+msgid "Tabloid, 11 x 17 in"
+msgstr "Tabloide, 11 x 17 polgadas"
+
+#: ../src/common/paper.cpp:78
+msgid "Ledger, 17 x 11 in"
+msgstr "Libro maior, 17 x 11 polgadas"
+
+#: ../src/common/paper.cpp:79
+msgid "Statement, 5 1/2 x 8 1/2 in"
+msgstr "Media carta, 5 1/2 x 8 1/2 polgadas"
+
+#: ../src/common/paper.cpp:80
+msgid "Executive, 7 1/4 x 10 1/2 in"
+msgstr "Executivo, 7 1/4 x 10 1/2 polgadas"
+
+#: ../src/common/paper.cpp:81
+msgid "A3 sheet, 297 x 420 mm"
+msgstr "Folla A3, 297 x 420 mm"
+
+#: ../src/common/paper.cpp:82
+msgid "A4 small sheet, 210 x 297 mm"
+msgstr "Folla pequena A4, 210 x 297 mm"
+
+#: ../src/common/paper.cpp:83
+msgid "A5 sheet, 148 x 210 mm"
+msgstr "Folla A5, 148 x 210 mm"
+
+#: ../src/common/paper.cpp:84
+msgid "B4 sheet, 250 x 354 mm"
+msgstr "Folla B4, 250 x 354 mm"
+
+#: ../src/common/paper.cpp:85
+msgid "B5 sheet, 182 x 257 millimeter"
+msgstr "Folla B5, 182 x 257 millimetros"
+
+#: ../src/common/paper.cpp:86
+msgid "Folio, 8 1/2 x 13 in"
+msgstr "Folio, 8 1/2 x 13 polgadas"
+
+#: ../src/common/paper.cpp:87
+msgid "Quarto, 215 x 275 mm"
+msgstr "Quarto, 215 x 275 mm"
+
+#: ../src/common/paper.cpp:88
+msgid "10 x 14 in"
+msgstr "10 x 14 polgadas"
+
+#: ../src/common/paper.cpp:89
+msgid "11 x 17 in"
+msgstr "11 x 17 polgadas"
+
+#: ../src/common/paper.cpp:90
+msgid "Note, 8 1/2 x 11 in"
+msgstr "Nota, 8 1/2 x 11 polgadas"
+
+#: ../src/common/paper.cpp:91
+msgid "#9 Envelope, 3 7/8 x 8 7/8 in"
+msgstr "Sobre #9, 3 7/8 x 8 7/8 in"
+
+#: ../src/common/paper.cpp:92
+msgid "#10 Envelope, 4 1/8 x 9 1/2 in"
+msgstr "Sobre #10, 4 1/8 x 9 1/2 polgadas"
+
+#: ../src/common/paper.cpp:93
+msgid "#11 Envelope, 4 1/2 x 10 3/8 in"
+msgstr "Sobre #11, 4 1/2 x 10 3/8 in"
+
+#: ../src/common/paper.cpp:94
+msgid "#12 Envelope, 4 3/4 x 11 in"
+msgstr "Sobre #12, 4 3/4 x 11 in"
+
+#: ../src/common/paper.cpp:95
+msgid "#14 Envelope, 5 x 11 1/2 in"
+msgstr "Sobre #14, 5 x 11 1/2 in"
+
+#: ../src/common/paper.cpp:96
+msgid "DL Envelope, 110 x 220 mm"
+msgstr "Sobre DL, 110 x 220 mm"
+
+#: ../src/common/paper.cpp:97
+msgid "C5 Envelope, 162 x 229 mm"
+msgstr "Sobre C5, 162 x 229 mm"
+
+#: ../src/common/paper.cpp:98
+msgid "C3 Envelope, 324 x 458 mm"
+msgstr "Sobre C3, 324 x 458 mm"
+
+#: ../src/common/paper.cpp:99
+msgid "C4 Envelope, 229 x 324 mm"
+msgstr "Sobre C4, 229 x 324 mm"
+
+#: ../src/common/paper.cpp:100
+msgid "C6 Envelope, 114 x 162 mm"
+msgstr "Sobre C6, 114 x 162 mm"
+
+#: ../src/common/paper.cpp:101
+msgid "C65 Envelope, 114 x 229 mm"
+msgstr "Sobre C65, 114 x 229 mm"
+
+#: ../src/common/paper.cpp:102
+msgid "B4 Envelope, 250 x 353 mm"
+msgstr "Sobre B4, 250 x 353 mm"
+
+#: ../src/common/paper.cpp:103
+msgid "B5 Envelope, 176 x 250 mm"
+msgstr "Sobre B5, 176 x 250 mm"
+
+#: ../src/common/paper.cpp:104
+msgid "B6 Envelope, 176 x 125 mm"
+msgstr "Sobre B6, 176 x 125 mm"
+
+#: ../src/common/paper.cpp:105
+msgid "Italy Envelope, 110 x 230 mm"
+msgstr "Sobre italiano, 110 x 230 mm"
+
+#: ../src/common/paper.cpp:106
+msgid "Monarch Envelope, 3 7/8 x 7 1/2 in"
+msgstr "Sobre Monarca, 3 7/8 x 7 1/2 polgadas"
+
+#: ../src/common/paper.cpp:107
+msgid "6 3/4 Envelope, 3 5/8 x 6 1/2 in"
+msgstr "Sobre 6 3/4, 3 5/8 x 6 1/2 in"
+
+#: ../src/common/paper.cpp:108
+msgid "US Std Fanfold, 14 7/8 x 11 in"
+msgstr "US Std Fanfold, 14 7/8 x 11 polgadas"
+
+#: ../src/common/paper.cpp:109
+msgid "German Std Fanfold, 8 1/2 x 12 in"
+msgstr "FanFold alemán estándar, 8 1/2 x 12 polgadas"
+
+#: ../src/common/paper.cpp:110
+msgid "German Legal Fanfold, 8 1/2 x 13 in"
+msgstr "FanFold alemán legal, 8 1/2 x 13 polgadas"
+
+#: ../src/common/paper.cpp:112
+msgid "B4 (ISO) 250 x 353 mm"
+msgstr "B4 (ISO) 250 x 353 mm"
+
+#: ../src/common/paper.cpp:113
+msgid "Japanese Postcard 100 x 148 mm"
+msgstr "Postal xaponesa 100 x 148 mm"
+
+#: ../src/common/paper.cpp:114
+msgid "9 x 11 in"
+msgstr "9 x 11 polgadas"
+
+#: ../src/common/paper.cpp:115
+msgid "10 x 11 in"
+msgstr "10 x 11 polgadas"
+
+#: ../src/common/paper.cpp:116
+msgid "15 x 11 in"
+msgstr "15 x 11 polgadas"
+
+#: ../src/common/paper.cpp:117
+msgid "Envelope Invite 220 x 220 mm"
+msgstr "Sobre de invitación 220 x 220 mm"
+
+#: ../src/common/paper.cpp:118
+msgid "Letter Extra 9 1/2 x 12 in"
+msgstr "Carta extra 9 1/2 x 12 polgadas"
+
+#: ../src/common/paper.cpp:119
+msgid "Legal Extra 9 1/2 x 15 in"
+msgstr "Legal extra 9 1/2 x 15 polgadas"
+
+#: ../src/common/paper.cpp:120
+msgid "Tabloid Extra 11.69 x 18 in"
+msgstr "Tabloide Extra 11,69 x 18 polgadas"
+
+#: ../src/common/paper.cpp:121
+msgid "A4 Extra 9.27 x 12.69 in"
+msgstr "A4 Extra 9,27 x 12,69 polgadas"
+
+#: ../src/common/paper.cpp:122
+msgid "Letter Transverse 8 1/2 x 11 in"
+msgstr "Sobre transversal, 8 1/2 x 11 polgadas"
+
+#: ../src/common/paper.cpp:123
+msgid "A4 Transverse 210 x 297 mm"
+msgstr "A4 Transversal, 210 x 297 mm"
+
+#: ../src/common/paper.cpp:124
+msgid "Letter Extra Transverse 9.275 x 12 in"
+msgstr "Carta extra transversal 9,275 x 12 polgadas"
+
+#: ../src/common/paper.cpp:125
+msgid "SuperA/SuperA/A4 227 x 356 mm"
+msgstr "SuperA/SuperA/A4 227 x 356 mm"
+
+#: ../src/common/paper.cpp:126
+msgid "SuperB/SuperB/A3 305 x 487 mm"
+msgstr "SuperB/SuperB/A3 305 x 487 mm"
+
+#: ../src/common/paper.cpp:127
+msgid "Letter Plus 8 1/2 x 12.69 in"
+msgstr "Carta Plus 8 1/2 x 12,69 polgadas"
+
+#: ../src/common/paper.cpp:128
+msgid "A4 Plus 210 x 330 mm"
+msgstr "A4 Plus 210 x 330 mm"
+
+#: ../src/common/paper.cpp:129
+msgid "A5 Transverse 148 x 210 mm"
+msgstr "A5 Transversal, 148 x 210 mm"
+
+#: ../src/common/paper.cpp:130
+msgid "B5 (JIS) Transverse 182 x 257 mm"
+msgstr "B5 (JIS) Transversal 182 x 257 mm"
+
+#: ../src/common/paper.cpp:131
+msgid "A3 Extra 322 x 445 mm"
+msgstr "A3 Extra 322 x 445 mm"
+
+#: ../src/common/paper.cpp:132
+msgid "A5 Extra 174 x 235 mm"
+msgstr "A5 Extra 174 x 235 mm"
+
+#: ../src/common/paper.cpp:133
+msgid "B5 (ISO) Extra 201 x 276 mm"
+msgstr "B5 (ISO) Extra 201 x 276 mm"
+
+#: ../src/common/paper.cpp:134
+msgid "A2 420 x 594 mm"
+msgstr "A2 420 x 594 mm"
+
+#: ../src/common/paper.cpp:135
+msgid "A3 Transverse 297 x 420 mm"
+msgstr "A3 Transversal 297 x 420 mm"
+
+#: ../src/common/paper.cpp:136
+msgid "A3 Extra Transverse 322 x 445 mm"
+msgstr "A3 Extra Transversal 322 x 445 mm"
+
+#: ../src/common/paper.cpp:138
+msgid "Japanese Double Postcard 200 x 148 mm"
+msgstr "Postal dobre xaponesa 200 x 148 mm"
+
+#: ../src/common/paper.cpp:139
+msgid "A6 105 x 148 mm"
+msgstr "A6 105 x 148 mm"
+
+#: ../src/common/paper.cpp:140
+msgid "Japanese Envelope Kaku #2"
+msgstr "Sobre xaponés Kaku #2"
+
+#: ../src/common/paper.cpp:141
+msgid "Japanese Envelope Kaku #3"
+msgstr "Sobre xaponés Kaku #3"
+
+#: ../src/common/paper.cpp:142
+msgid "Japanese Envelope Chou #3"
+msgstr "Sobre xaponés Chou #3"
+
+#: ../src/common/paper.cpp:143
+msgid "Japanese Envelope Chou #4"
+msgstr "Sobre xaponés Chou #4"
+
+#: ../src/common/paper.cpp:144
+msgid "Letter Rotated 11 x 8 1/2 in"
+msgstr "Sobre apaisado, 11 x 8 1/2 in"
+
+#: ../src/common/paper.cpp:145
+msgid "A3 Rotated 420 x 297 mm"
+msgstr "A3 Apaisado 420 x 297 mm"
+
+#: ../src/common/paper.cpp:146
+msgid "A4 Rotated 297 x 210 mm"
+msgstr "A4 Apaisada 297 x 210 mm"
+
+#: ../src/common/paper.cpp:147
+msgid "A5 Rotated 210 x 148 mm"
+msgstr "A5 Apaisada, 210 x 148 mm"
+
+#: ../src/common/paper.cpp:148
+msgid "B4 (JIS) Rotated 364 x 257 mm"
+msgstr "B4 (JIS) Apaisada 364 x 257 mm"
+
+#: ../src/common/paper.cpp:149
+msgid "B5 (JIS) Rotated 257 x 182 mm"
+msgstr "B5 (JIS) Apaisada 257 x 182 mm"
+
+#: ../src/common/paper.cpp:150
+msgid "Japanese Postcard Rotated 148 x 100 mm"
+msgstr "Postal xaponesa apaisada 148 x 100 mm"
+
+#: ../src/common/paper.cpp:151
+msgid "Double Japanese Postcard Rotated 148 x 200 mm"
+msgstr "Postal xaponesa dobre apaisada 148 x 200 mm"
+
+#: ../src/common/paper.cpp:152
+msgid "A6 Rotated 148 x 105 mm"
+msgstr "A6 Apaisada 148 x 105 mm"
+
+#: ../src/common/paper.cpp:153
+msgid "Japanese Envelope Kaku #2 Rotated"
+msgstr "Sobre xaponés Kaku #2 apaisado"
+
+#: ../src/common/paper.cpp:154
+msgid "Japanese Envelope Kaku #3 Rotated"
+msgstr "Sobre xaponés Kaku #3 apaisado"
+
+#: ../src/common/paper.cpp:155
+msgid "Japanese Envelope Chou #3 Rotated"
+msgstr "Sobre xaponés Chou #3 apaisado"
+
+#: ../src/common/paper.cpp:156
+msgid "Japanese Envelope Chou #4 Rotated"
+msgstr "Sobre xaponés Chou #4 apaisado"
+
+#: ../src/common/paper.cpp:157
+msgid "B6 (JIS) 128 x 182 mm"
+msgstr "B6 (JIS) 128 x 182 mm"
+
+#: ../src/common/paper.cpp:158
+msgid "B6 (JIS) Rotated 182 x 128 mm"
+msgstr "B6 (JIS) Apaisada 182 x 128 mm"
+
+#: ../src/common/paper.cpp:159
+msgid "12 x 11 in"
+msgstr "12 x 11 polgadas"
+
+#: ../src/common/paper.cpp:160
+msgid "Japanese Envelope You #4"
+msgstr "Sobre xaponés You #4"
+
+#: ../src/common/paper.cpp:161
+msgid "Japanese Envelope You #4 Rotated"
+msgstr "Sobre xaponés You #4 apaisado"
+
+#: ../src/common/paper.cpp:162
+msgid "PRC 16K 146 x 215 mm"
+msgstr "PRC 16K 146 x 215 mm"
+
+#: ../src/common/paper.cpp:163
+msgid "PRC 32K 97 x 151 mm"
+msgstr "PRC 32K 97 x 151 mm"
+
+#: ../src/common/paper.cpp:164
+msgid "PRC 32K(Big) 97 x 151 mm"
+msgstr "PRC 32K(Grande) 97 x 151 mm"
+
+#: ../src/common/paper.cpp:165
+msgid "PRC Envelope #1 102 x 165 mm"
+msgstr "Sobre PRC #1 102 x 165 mm"
+
+#: ../src/common/paper.cpp:166
+msgid "PRC Envelope #2 102 x 176 mm"
+msgstr "Sobre PRC #2 102 x 176 mm"
+
+#: ../src/common/paper.cpp:167
+msgid "PRC Envelope #3 125 x 176 mm"
+msgstr "Sobre PRC #3 125 x 176 mm"
+
+#: ../src/common/paper.cpp:168
+msgid "PRC Envelope #4 110 x 208 mm"
+msgstr "Sobre PRC #4 110 x 208 mm"
+
+#: ../src/common/paper.cpp:169
+msgid "PRC Envelope #5 110 x 220 mm"
+msgstr "Sobre PRC #5 110 x 220 mm"
+
+#: ../src/common/paper.cpp:170
+msgid "PRC Envelope #6 120 x 230 mm"
+msgstr "Sobre PRC #6 120 x 230 mm"
+
+#: ../src/common/paper.cpp:171
+msgid "PRC Envelope #7 160 x 230 mm"
+msgstr "Sobre PRC #7 160 x 230 mm"
+
+#: ../src/common/paper.cpp:172
+msgid "PRC Envelope #8 120 x 309 mm"
+msgstr "Sobre PRC #8 120 x 309 mm"
+
+#: ../src/common/paper.cpp:173
+msgid "PRC Envelope #9 229 x 324 mm"
+msgstr "Sobre PRC #9 229 x 324 mm"
+
+#: ../src/common/paper.cpp:174
+msgid "PRC Envelope #10 324 x 458 mm"
+msgstr "Sobre PRC #10 324 x 458 mm"
+
+#: ../src/common/paper.cpp:175
+msgid "PRC 16K Rotated"
+msgstr "PRC 16K apaisado"
+
+#: ../src/common/paper.cpp:176
+msgid "PRC 32K Rotated"
+msgstr "PRC 32K apaisado"
+
+#: ../src/common/paper.cpp:177
+msgid "PRC 32K(Big) Rotated"
+msgstr "PRC 32K(Grande) apaisado"
+
+#: ../src/common/paper.cpp:178
+msgid "PRC Envelope #1 Rotated 165 x 102 mm"
+msgstr "Sobre PRC #1 apaisado 165 x 102 mm"
+
+#: ../src/common/paper.cpp:179
+msgid "PRC Envelope #2 Rotated 176 x 102 mm"
+msgstr "Sobre PRC #2 apaisado 176 x 102 mm"
+
+#: ../src/common/paper.cpp:180
+msgid "PRC Envelope #3 Rotated 176 x 125 mm"
+msgstr "Sobre PRC #3 apaisado 176 x 125 mm"
+
+#: ../src/common/paper.cpp:181
+msgid "PRC Envelope #4 Rotated 208 x 110 mm"
+msgstr "Sobre PRC #4 apaisado 208 x 110 mm"
+
+#: ../src/common/paper.cpp:182
+msgid "PRC Envelope #5 Rotated 220 x 110 mm"
+msgstr "Sobre PRC #5 apaisado 220 x 110 mm"
+
+#: ../src/common/paper.cpp:183
+msgid "PRC Envelope #6 Rotated 230 x 120 mm"
+msgstr "Sobre PRC #6 apaisado 230 x 120 mm"
+
+#: ../src/common/paper.cpp:184
+msgid "PRC Envelope #7 Rotated 230 x 160 mm"
+msgstr "Sobre PRC #7 apaisado 230 x 160 mm"
+
+#: ../src/common/paper.cpp:185
+msgid "PRC Envelope #8 Rotated 309 x 120 mm"
+msgstr "Sobre PRC #8 apaisado 309 x 120 mm"
+
+#: ../src/common/paper.cpp:186
+msgid "PRC Envelope #9 Rotated 324 x 229 mm"
+msgstr "Cobertura PRC #9 Rotada 324 x 229 mm"
+
+#: ../src/common/paper.cpp:187
+msgid "PRC Envelope #10 Rotated 458 x 324 mm"
+msgstr "Sobre PRC #10 apaisado 458 x 324 mm"
+
+#: ../src/common/paper.cpp:192
+msgid "A0 sheet, 841 x 1189 mm"
+msgstr "Folla A0, 841 x 1189 mm"
+
+#: ../src/common/paper.cpp:193
+msgid "A1 sheet, 594 x 841 mm"
+msgstr "Folla A1, 594 x 841 mm"
+
+#: ../src/common/preferencescmn.cpp:37
+msgid "General"
+msgstr "Xeral"
+
+#: ../src/common/preferencescmn.cpp:40
+msgid "Advanced"
+msgstr "Avanzado"
+
+#: ../src/common/prntbase.cpp:245
+msgid "Generic PostScript"
+msgstr "PostScript xenérico"
+
+#: ../src/common/prntbase.cpp:259
+msgid "Ready"
+msgstr "Preparado"
+
+#: ../src/common/prntbase.cpp:331
+msgid "Printing Error"
+msgstr "Erro de impresión"
+
+#: ../src/common/prntbase.cpp:413 ../src/common/prntbase.cpp:1597
+#: ../src/generic/prntdlgg.cpp:135 ../src/generic/prntdlgg.cpp:149
+#: ../src/gtk/print.cpp:628 ../src/gtk/print.cpp:646
+msgid "Print"
+msgstr "Imprimir"
+
+#: ../src/common/prntbase.cpp:471 ../src/generic/prntdlgg.cpp:809
+msgid "Page setup"
+msgstr "Configuración de páxina"
+
+#: ../src/common/prntbase.cpp:525
+msgid "Please wait while printing..."
+msgstr "Por favor, agarde mentre se imprime..."
+
+#: ../src/common/prntbase.cpp:529
+msgid "Document:"
+msgstr "Documento:"
+
+#: ../src/common/prntbase.cpp:532
+msgid "Progress:"
+msgstr "Progreso:"
+
+#: ../src/common/prntbase.cpp:533
+msgid "Preparing"
+msgstr "Preparando"
+
+#: ../src/common/prntbase.cpp:552
+#, fuzzy, c-format
+msgid "Printing page %d"
+msgstr "Imprimindo a páxina %d..."
+
+#: ../src/common/prntbase.cpp:557
+#, c-format
+msgid "Printing page %d of %d"
+msgstr "Imprimindo páxina %d de %d"
+
+#: ../src/common/prntbase.cpp:560
+#, c-format
+msgid " (copy %d of %d)"
+msgstr " (copiar %d de %d)"
+
+#: ../src/common/prntbase.cpp:1604
+msgid "First page"
+msgstr "Primeira páxina"
+
+#: ../src/common/prntbase.cpp:1609 ../src/html/helpwnd.cpp:659
+msgid "Previous page"
+msgstr "Páxina anterior"
+
+#: ../src/common/prntbase.cpp:1623 ../src/html/helpwnd.cpp:660
+msgid "Next page"
+msgstr "Seguinte páxina"
+
+#: ../src/common/prntbase.cpp:1628
+msgid "Last page"
+msgstr "Última páxina"
+
+#: ../src/common/prntbase.cpp:1636 ../src/common/stockitem.cpp:215
+msgid "Zoom Out"
+msgstr "Afastar"
+
+#: ../src/common/prntbase.cpp:1650 ../src/common/stockitem.cpp:214
+msgid "Zoom In"
+msgstr "Achegar"
+
+#: ../src/common/prntbase.cpp:1656 ../src/common/stockitem.cpp:153
+#: ../src/generic/logg.cpp:553 ../src/univ/themes/win32.cpp:3752
+msgid "&Close"
+msgstr "&Pechar"
+
+#: ../src/common/prntbase.cpp:2085
+msgid "Could not start document preview."
+msgstr "Non se puido iniciar a previsualización do documento."
+
+#: ../src/common/prntbase.cpp:2085 ../src/common/prntbase.cpp:2129
+#: ../src/common/prntbase.cpp:2137
+msgid "Print Preview Failure"
+msgstr "Fallo na previsualización de impresión"
+
+#: ../src/common/prntbase.cpp:2129 ../src/common/prntbase.cpp:2137
+msgid "Sorry, not enough memory to create a preview."
+msgstr "Non hai memoria dabondo para crear unha previsualización."
+
+#: ../src/common/prntbase.cpp:2144
+#, c-format
+msgid "Page %d of %d"
+msgstr "Páxina %d de %d"
+
+#: ../src/common/prntbase.cpp:2146
+#, c-format
+msgid "Page %d"
+msgstr "Páxina %d"
+
+#: ../src/common/regex.cpp:382 ../src/html/chm.cpp:348
+msgid "unknown error"
+msgstr "erro descoñecido"
+
+#: ../src/common/regex.cpp:995
+#, c-format
+msgid "Invalid regular expression '%s': %s"
+msgstr "Expresión regular incorrecta '%s': %s"
+
+#: ../src/common/regex.cpp:1059
+#, c-format
+msgid "Failed to find match for regular expression: %s"
+msgstr "Non se atopou correspondencia para a expresión regular: %s"
+
+#: ../src/common/rendcmn.cpp:188
+#, c-format
+msgid "Renderer \"%s\" has incompatible version %d.%d and couldn't be loaded."
+msgstr ""
+"O renderizador \"%s\" ten unha versión incompatíbel, %d.%d e non se puido "
+"cargar."
+
+#: ../src/common/secretstore.cpp:162
+msgid "Not available for this platform"
+msgstr ""
+
+#: ../src/common/secretstore.cpp:183
+#, fuzzy, c-format
+msgid "Saving password for \"%s\" failed: %s."
+msgstr "Fallou a extración de '%s' a '%s'."
+
+#: ../src/common/secretstore.cpp:205
+#, fuzzy, c-format
+msgid "Reading password for \"%s\" failed: %s."
+msgstr "Fallou a extración de '%s' a '%s'."
+
+#: ../src/common/secretstore.cpp:228
+#, fuzzy, c-format
+msgid "Deleting password for \"%s\" failed: %s."
+msgstr "Fallou a extración de '%s' a '%s'."
+
+#: ../src/common/selectdispatcher.cpp:254
+msgid "Failed to monitor I/O channels"
+msgstr "Non se puido monitorizar as canles I/O"
+
+#: ../src/common/sizer.cpp:3054 ../src/common/stockitem.cpp:195
+msgid "Save"
+msgstr "Gardar"
+
+#: ../src/common/sizer.cpp:3056
+msgid "Don't Save"
+msgstr "Non gardar"
+
+#: ../src/common/socket.cpp:870
+msgid "Cannot initialize sockets"
+msgstr "Non se poden inicializar os sockets"
+
+#: ../src/common/stockitem.cpp:127
+#, fuzzy
+msgctxt "standard Windows menu"
+msgid "&Help"
+msgstr "A&xuda"
+
+#: ../src/common/stockitem.cpp:144
+msgid "&About"
+msgstr "&Sobre"
+
+#: ../src/common/stockitem.cpp:144
+msgid "About"
+msgstr "Sobre"
+
+#: ../src/common/stockitem.cpp:145
+msgid "Add"
+msgstr "Engadir"
+
+#: ../src/common/stockitem.cpp:146
+msgid "&Apply"
+msgstr "&Aplicar"
+
+#: ../src/common/stockitem.cpp:146
+msgid "Apply"
+msgstr "Aplicar"
+
+#: ../src/common/stockitem.cpp:147
+msgid "&Back"
+msgstr "&Atrás"
+
+#: ../src/common/stockitem.cpp:147
+msgid "Back"
+msgstr "Atrás"
+
+#: ../src/common/stockitem.cpp:148
+msgid "&Bold"
+msgstr "&Grosa"
+
+#: ../src/common/stockitem.cpp:148 ../src/generic/fontdlgg.cpp:326
+#: ../src/richtext/richtextfontpage.cpp:354
+msgid "Bold"
+msgstr "Grosa"
+
+#: ../src/common/stockitem.cpp:149
+msgid "&Bottom"
+msgstr "&Abaixo"
+
+#: ../src/common/stockitem.cpp:149 ../src/richtext/richtextsizepage.cpp:287
+msgid "Bottom"
+msgstr "Abaixo"
+
+#: ../src/common/stockitem.cpp:150 ../src/generic/fontdlgg.cpp:462
+#: ../src/generic/fontdlgg.cpp:481 ../src/generic/wizard.cpp:415
+msgid "&Cancel"
+msgstr "&Cancelar"
+
+#: ../src/common/stockitem.cpp:151
+#, fuzzy
+msgid "&CD-ROM"
+msgstr "&CD-Rom"
+
+#: ../src/common/stockitem.cpp:151
+#, fuzzy
+msgid "CD-ROM"
+msgstr "CD-Rom"
+
+#: ../src/common/stockitem.cpp:152
+msgid "&Clear"
+msgstr "&Limpar"
+
+#: ../src/common/stockitem.cpp:152
+msgid "Clear"
+msgstr "Borrar"
+
+#: ../src/common/stockitem.cpp:153 ../src/generic/dbgrptg.cpp:93
+#: ../src/generic/progdlgg.cpp:778 ../src/html/helpdlg.cpp:86
+#: ../src/msw/progdlg.cpp:209 ../src/msw/progdlg.cpp:890
+#: ../src/richtext/richtextstyledlg.cpp:272
+#: ../src/richtext/richtextsymboldlg.cpp:448
+msgid "Close"
+msgstr "Pechar"
+
+#: ../src/common/stockitem.cpp:154
+msgid "&Convert"
+msgstr "&Con&verter"
+
+#: ../src/common/stockitem.cpp:154
+msgid "Convert"
+msgstr "Converter"
+
+#: ../src/common/stockitem.cpp:155 ../src/msw/textctrl.cpp:2884
+#: ../src/osx/textctrl_osx.cpp:653 ../src/richtext/richtextctrl.cpp:331
+msgid "&Copy"
+msgstr "&Copiar"
+
+#: ../src/common/stockitem.cpp:155 ../src/stc/stc_i18n.cpp:18
+msgid "Copy"
+msgstr "Copiar"
+
+#: ../src/common/stockitem.cpp:156 ../src/msw/textctrl.cpp:2883
+#: ../src/osx/textctrl_osx.cpp:652 ../src/richtext/richtextctrl.cpp:330
+msgid "Cu&t"
+msgstr "Cor&tar"
+
+#: ../src/common/stockitem.cpp:156 ../src/stc/stc_i18n.cpp:17
+msgid "Cut"
+msgstr "Cortar"
+
+#: ../src/common/stockitem.cpp:157 ../src/msw/textctrl.cpp:2886
+#: ../src/osx/textctrl_osx.cpp:655 ../src/richtext/richtextctrl.cpp:333
+#: ../src/richtext/richtexttabspage.cpp:137
+msgid "&Delete"
+msgstr "&Eliminar"
+
+#: ../src/common/stockitem.cpp:157 ../src/richtext/richtextbuffer.cpp:8266
+#: ../src/stc/stc_i18n.cpp:20
+msgid "Delete"
+msgstr "Eliminar"
+
+#: ../src/common/stockitem.cpp:158
+msgid "&Down"
+msgstr "A&baixo"
+
+#: ../src/common/stockitem.cpp:158 ../src/generic/fdrepdlg.cpp:148
+msgid "Down"
+msgstr "Abaixo"
+
+#: ../src/common/stockitem.cpp:159
+msgid "&Edit"
+msgstr "&Editar"
+
+#: ../src/common/stockitem.cpp:159
+msgid "Edit"
+msgstr "Editar"
+
+#: ../src/common/stockitem.cpp:160
+msgid "&Execute"
+msgstr "&Executar"
+
+#: ../src/common/stockitem.cpp:160
+msgid "Execute"
+msgstr "Executar"
+
+#: ../src/common/stockitem.cpp:161
+msgid "&Quit"
+msgstr "&Saír"
+
+#: ../src/common/stockitem.cpp:161
+msgid "Quit"
+msgstr "Saír"
+
+#: ../src/common/stockitem.cpp:162
+msgid "&File"
+msgstr "&Ficheiro"
+
+#: ../src/common/stockitem.cpp:162
+msgid "File"
+msgstr "Ficheiro"
+
+#: ../src/common/stockitem.cpp:163
+#, fuzzy
+msgid "&Find..."
+msgstr "&Buscar"
+
+#: ../src/common/stockitem.cpp:163
+#, fuzzy
+msgid "Find..."
+msgstr "Buscar"
+
+#: ../src/common/stockitem.cpp:164
+msgid "&First"
+msgstr "&Primeiro"
+
+#: ../src/common/stockitem.cpp:164
+msgid "First"
+msgstr "Primeiro"
+
+#: ../src/common/stockitem.cpp:165
+msgid "&Floppy"
+msgstr "&Disquete"
+
+#: ../src/common/stockitem.cpp:165
+msgid "Floppy"
+msgstr "Disquete"
+
+#: ../src/common/stockitem.cpp:166
+msgid "&Forward"
+msgstr "&Adiante"
+
+#: ../src/common/stockitem.cpp:166
+msgid "Forward"
+msgstr "Adiante"
+
+#: ../src/common/stockitem.cpp:167
+msgid "&Harddisk"
+msgstr "&Disco duro"
+
+#: ../src/common/stockitem.cpp:167
+msgid "Harddisk"
+msgstr "Disco duro"
+
+#: ../src/common/stockitem.cpp:168 ../src/generic/wizard.cpp:418
+#: ../src/osx/cocoa/menu.mm:225 ../src/richtext/richtextstyledlg.cpp:298
+#: ../src/richtext/richtextsymboldlg.cpp:451
+msgid "&Help"
+msgstr "A&xuda"
+
+#: ../src/common/stockitem.cpp:169
+msgid "&Home"
+msgstr "&Inicio"
+
+#: ../src/common/stockitem.cpp:169
+msgid "Home"
+msgstr "Inicio"
+
+#: ../src/common/stockitem.cpp:170
+msgid "Indent"
+msgstr "Sangrar"
+
+#: ../src/common/stockitem.cpp:171
+msgid "&Index"
+msgstr "&Índice"
+
+#: ../src/common/stockitem.cpp:171 ../src/html/helpwnd.cpp:510
+msgid "Index"
+msgstr "Índice"
+
+#: ../src/common/stockitem.cpp:172
+msgid "&Info"
+msgstr "&Información"
+
+#: ../src/common/stockitem.cpp:172
+msgid "Info"
+msgstr "Info"
+
+#: ../src/common/stockitem.cpp:173
+msgid "&Italic"
+msgstr "&Cursiva"
+
+#: ../src/common/stockitem.cpp:173 ../src/generic/fontdlgg.cpp:322
+#: ../src/richtext/richtextfontpage.cpp:350
+msgid "Italic"
+msgstr "Cursiva"
+
+#: ../src/common/stockitem.cpp:174
+msgid "&Jump to"
+msgstr "&Ir a"
+
+#: ../src/common/stockitem.cpp:174
+msgid "Jump to"
+msgstr "Ir a"
+
+#: ../src/common/stockitem.cpp:175
+msgid "Centered"
+msgstr "Centrado"
+
+#: ../src/common/stockitem.cpp:176
+msgid "Justified"
+msgstr "Xustificado"
+
+#: ../src/common/stockitem.cpp:177
+msgid "Align Left"
+msgstr "Aliñar á Esquerda"
+
+#: ../src/common/stockitem.cpp:178
+msgid "Align Right"
+msgstr "Aliñar á Dereita"
+
+#: ../src/common/stockitem.cpp:179
+msgid "&Last"
+msgstr "Ú&ltimo"
+
+#: ../src/common/stockitem.cpp:179
+msgid "Last"
+msgstr "Último"
+
+#: ../src/common/stockitem.cpp:180
+msgid "&Network"
+msgstr "&Rede"
+
+#: ../src/common/stockitem.cpp:180
+msgid "Network"
+msgstr "Rede"
+
+#: ../src/common/stockitem.cpp:181 ../src/richtext/richtexttabspage.cpp:131
+msgid "&New"
+msgstr "&Novo"
+
+#: ../src/common/stockitem.cpp:181
+msgid "New"
+msgstr "Novo"
+
+#: ../src/common/stockitem.cpp:182 ../src/msw/msgdlg.cpp:417
+msgid "&No"
+msgstr "&Non"
+
+#: ../src/common/stockitem.cpp:183 ../src/generic/fontdlgg.cpp:467
+#: ../src/generic/fontdlgg.cpp:474
+msgid "&OK"
+msgstr "&Aceptar"
+
+#: ../src/common/stockitem.cpp:184 ../src/generic/dbgrptg.cpp:341
+msgid "&Open..."
+msgstr "&Abrir..."
+
+#: ../src/common/stockitem.cpp:184
+msgid "Open..."
+msgstr "Abrir..."
+
+#: ../src/common/stockitem.cpp:185 ../src/msw/textctrl.cpp:2885
+#: ../src/osx/textctrl_osx.cpp:654 ../src/richtext/richtextctrl.cpp:332
+msgid "&Paste"
+msgstr "&Pegar"
+
+#: ../src/common/stockitem.cpp:185 ../src/richtext/richtextctrl.cpp:3484
+#: ../src/stc/stc_i18n.cpp:19
+msgid "Paste"
+msgstr "Pegar"
+
+#: ../src/common/stockitem.cpp:186
+msgid "&Preferences"
+msgstr "&Preferencias"
+
+#: ../src/common/stockitem.cpp:186 ../src/osx/cocoa/preferences.mm:304
+msgid "Preferences"
+msgstr "Preferencias"
+
+#: ../src/common/stockitem.cpp:187
+msgid "Print previe&w..."
+msgstr "Pre&visualización de impresión..."
+
+#: ../src/common/stockitem.cpp:187
+msgid "Print preview..."
+msgstr "Previsualización de impresión..."
+
+#: ../src/common/stockitem.cpp:188
+msgid "&Print..."
+msgstr "&Imprimir..."
+
+#: ../src/common/stockitem.cpp:188
+msgid "Print..."
+msgstr "Imprimir..."
+
+#: ../src/common/stockitem.cpp:189 ../src/richtext/richtextctrl.cpp:337
+#: ../src/richtext/richtextctrl.cpp:5479
+msgid "&Properties"
+msgstr "&Propiedades"
+
+#: ../src/common/stockitem.cpp:189
+msgid "Properties"
+msgstr "Propiedades"
+
+#: ../src/common/stockitem.cpp:190 ../src/stc/stc_i18n.cpp:16
+msgid "Redo"
+msgstr "Refacer"
+
+#: ../src/common/stockitem.cpp:191
+msgid "Refresh"
+msgstr "Actualizar"
+
+#: ../src/common/stockitem.cpp:192
+msgid "Remove"
+msgstr "Eliminar"
+
+#: ../src/common/stockitem.cpp:193
+#, fuzzy
+msgid "Rep&lace..."
+msgstr "Su&bstituír"
+
+#: ../src/common/stockitem.cpp:193
+#, fuzzy
+msgid "Replace..."
+msgstr "Substituír"
+
+#: ../src/common/stockitem.cpp:194
+msgid "Revert to Saved"
+msgstr "Volver á versión gardada"
+
+#: ../src/common/stockitem.cpp:196 ../src/generic/logg.cpp:549
+msgid "Save &As..."
+msgstr "Gardar &como..."
+
+#: ../src/common/stockitem.cpp:196
+#, fuzzy
+msgid "Save As..."
+msgstr "Gardar &como..."
+
+#: ../src/common/stockitem.cpp:197 ../src/msw/textctrl.cpp:2888
+#: ../src/osx/textctrl_osx.cpp:657 ../src/richtext/richtextctrl.cpp:335
+msgid "Select &All"
+msgstr "Seleccionar &todo"
+
+#: ../src/common/stockitem.cpp:197 ../src/stc/stc_i18n.cpp:21
+msgid "Select All"
+msgstr "Seleccionar todo"
+
+#: ../src/common/stockitem.cpp:198
+msgid "&Color"
+msgstr "C&or"
+
+#: ../src/common/stockitem.cpp:198
+msgid "Color"
+msgstr "Cor"
+
+#: ../src/common/stockitem.cpp:199
+msgid "&Font"
+msgstr "&Tipo de letra"
+
+#: ../src/common/stockitem.cpp:199 ../src/richtext/richtextformatdlg.cpp:336
+msgid "Font"
+msgstr "Tipo de letra"
+
+#: ../src/common/stockitem.cpp:200
+msgid "&Ascending"
+msgstr "&Ascendente"
+
+#: ../src/common/stockitem.cpp:200
+msgid "Ascending"
+msgstr "Ascendente"
+
+#: ../src/common/stockitem.cpp:201
+msgid "&Descending"
+msgstr "&Descendente"
+
+#: ../src/common/stockitem.cpp:201
+msgid "Descending"
+msgstr "Descendente"
+
+#: ../src/common/stockitem.cpp:202
+msgid "&Spell Check"
+msgstr "&Revisar ortografía"
+
+#: ../src/common/stockitem.cpp:202
+msgid "Spell Check"
+msgstr "Revisión ortográfica"
+
+#: ../src/common/stockitem.cpp:203
+msgid "&Stop"
+msgstr "&Parar"
+
+#: ../src/common/stockitem.cpp:203
+msgid "Stop"
+msgstr "Parar"
+
+#: ../src/common/stockitem.cpp:204 ../src/richtext/richtextfontpage.cpp:274
+msgid "&Strikethrough"
+msgstr "&Riscado"
+
+#: ../src/common/stockitem.cpp:204
+msgid "Strikethrough"
+msgstr "Riscado"
+
+#: ../src/common/stockitem.cpp:205
+msgid "&Top"
+msgstr "&Arriba"
+
+#: ../src/common/stockitem.cpp:205 ../src/richtext/richtextsizepage.cpp:285
+#: ../src/richtext/richtextsizepage.cpp:289
+msgid "Top"
+msgstr "Arriba"
+
+#: ../src/common/stockitem.cpp:206
+msgid "Undelete"
+msgstr "Deshacer eliminar"
+
+#: ../src/common/stockitem.cpp:207 ../src/generic/fontdlgg.cpp:437
+msgid "&Underline"
+msgstr "&Subliñar"
+
+#: ../src/common/stockitem.cpp:207
+msgid "Underline"
+msgstr "Subliñar"
+
+#: ../src/common/stockitem.cpp:208 ../src/stc/stc_i18n.cpp:15
+msgid "Undo"
+msgstr "Desfacer"
+
+#: ../src/common/stockitem.cpp:209
+msgid "&Unindent"
+msgstr "&Eliminar sangría"
+
+#: ../src/common/stockitem.cpp:209
+msgid "Unindent"
+msgstr "Eliminar sangría"
+
+#: ../src/common/stockitem.cpp:210
+msgid "&Up"
+msgstr "&Arriba"
+
+#: ../src/common/stockitem.cpp:210 ../src/generic/fdrepdlg.cpp:148
+msgid "Up"
+msgstr "Arriba"
+
+#: ../src/common/stockitem.cpp:211 ../src/msw/msgdlg.cpp:417
+msgid "&Yes"
+msgstr "&Si"
+
+#: ../src/common/stockitem.cpp:212
+msgid "&Actual Size"
+msgstr "Tamaño &Actual"
+
+#: ../src/common/stockitem.cpp:212
+msgid "Actual Size"
+msgstr "Tamaño &Actual"
+
+#: ../src/common/stockitem.cpp:213
+msgid "Zoom to &Fit"
+msgstr "Axustar &zoom"
+
+#: ../src/common/stockitem.cpp:213
+msgid "Zoom to Fit"
+msgstr "Axustar zoom"
+
+#: ../src/common/stockitem.cpp:214
+msgid "Zoom &In"
+msgstr "A&chegar"
+
+#: ../src/common/stockitem.cpp:215
+msgid "Zoom &Out"
+msgstr "A&fastar"
+
+#: ../src/common/stockitem.cpp:262
+msgid "Show about dialog"
+msgstr "Amosar diálogo Sobre"
+
+#: ../src/common/stockitem.cpp:263
+msgid "Copy selection"
+msgstr "Copiar selección"
+
+#: ../src/common/stockitem.cpp:264
+msgid "Cut selection"
+msgstr "Cortar selección"
+
+#: ../src/common/stockitem.cpp:265
+msgid "Delete selection"
+msgstr "Eliminar selección"
+
+#: ../src/common/stockitem.cpp:266
+#, fuzzy
+msgid "Find in document"
+msgstr "Abrir documento HTML"
+
+#: ../src/common/stockitem.cpp:267
+msgid "Find and replace in document"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:268
+msgid "Paste selection"
+msgstr "Pegar selección"
+
+#: ../src/common/stockitem.cpp:269
+msgid "Quit this program"
+msgstr "Saír deste aplicativo"
+
+#: ../src/common/stockitem.cpp:270
+msgid "Redo last action"
+msgstr "Desfacer a acción anterior"
+
+#: ../src/common/stockitem.cpp:271
+msgid "Undo last action"
+msgstr "Desfacer a acción anterior"
+
+#: ../src/common/stockitem.cpp:272
+#, fuzzy
+msgid "Create new document"
+msgstr "Crear novo cartafol"
+
+#: ../src/common/stockitem.cpp:273
+#, fuzzy
+msgid "Open an existing document"
+msgstr "Abrir documento HTML"
+
+#: ../src/common/stockitem.cpp:274
+msgid "Close current document"
+msgstr "Pechar o documento actual"
+
+#: ../src/common/stockitem.cpp:275
+msgid "Save current document"
+msgstr "Gardar o documento actual"
+
+#: ../src/common/stockitem.cpp:276
+msgid "Save current document with a different filename"
+msgstr "Gardar o documento actual cun nome de ficheiro diferente"
+
+#: ../src/common/strconv.cpp:2324
+#, c-format
+msgid "Conversion to charset '%s' doesn't work."
+msgstr "Non funciona a conversión ao xogo de caracteres '%s'."
+
+#: ../src/common/tarstrm.cpp:352 ../src/common/tarstrm.cpp:375
+#: ../src/common/tarstrm.cpp:406 ../src/generic/progdlgg.cpp:373
+msgid "unknown"
+msgstr "descoñecido"
+
+#: ../src/common/tarstrm.cpp:774
+msgid "incomplete header block in tar"
+msgstr "bloque de cabeceira incompleto en tar"
+
+#: ../src/common/tarstrm.cpp:798
+msgid "checksum failure reading tar header block"
+msgstr "erro na suma de comprobación ao ler o bloque de cabeceira de tar"
+
+#: ../src/common/tarstrm.cpp:971
+msgid "invalid data in extended tar header"
+msgstr "datos incorrectos na cabeceira extendida de tar"
+
+#: ../src/common/tarstrm.cpp:981 ../src/common/tarstrm.cpp:1003
+#: ../src/common/tarstrm.cpp:1477 ../src/common/tarstrm.cpp:1499
+msgid "tar entry not open"
+msgstr "non se abríu a entrada tar"
+
+#: ../src/common/tarstrm.cpp:1023
+msgid "unexpected end of file"
+msgstr "fin de ficheiro inesperado"
+
+#: ../src/common/tarstrm.cpp:1297
+#, c-format
+msgid "%s did not fit the tar header for entry '%s'"
+msgstr "%s non se axeitou á cabeceira de ficheiro tar na entrada '%s'"
+
+#: ../src/common/tarstrm.cpp:1359
+msgid "incorrect size given for tar entry"
+msgstr "tamaño de entrada tar incorrecto"
+
+#: ../src/common/textbuf.cpp:232
+#, c-format
+msgid "'%s' is probably a binary buffer."
+msgstr "'%s' é probábelmente un búfer binario."
+
+#: ../src/common/textcmn.cpp:1006 ../src/richtext/richtextctrl.cpp:3053
+msgid "File couldn't be loaded."
+msgstr "Non foi posíbel cargar o ficheiro."
+
+#: ../src/common/textfile.cpp:95
+#, fuzzy, c-format
+msgid "Failed to read text file \"%s\"."
+msgstr "Erro ao cargar documento dende o ficheiro \"%s\"."
+
+#: ../src/common/textfile.cpp:160
+#, c-format
+msgid "can't write buffer '%s' to disk."
+msgstr "non se pode escribir o búfer '%s' no disco."
+
+#: ../src/common/time.cpp:212
+msgid "Failed to get the local system time"
+msgstr "Erro ao obter a hora local do sistema"
+
+#: ../src/common/time.cpp:279
+msgid "wxGetTimeOfDay failed."
+msgstr "Fallou wxGetTimeOfDay."
+
+#: ../src/common/translation.cpp:929
+#, c-format
+msgid "'%s' is not a valid message catalog."
+msgstr "'%s' non é un catálogo de mensaxes correcto."
+
+#: ../src/common/translation.cpp:954
+msgid "Invalid message catalog."
+msgstr "Catálogo de mensaxes incorrecto."
+
+#: ../src/common/translation.cpp:1013
+#, c-format
+msgid "Failed to parse Plural-Forms: '%s'"
+msgstr "Erro ao analizar formas plurais: '%s'"
+
+#: ../src/common/translation.cpp:1723
+#, c-format
+msgid "using catalog '%s' from '%s'."
+msgstr "empregando catálogo '%s' de '%s'."
+
+#: ../src/common/translation.cpp:1816
+#, c-format
+msgid "Resource '%s' is not a valid message catalog."
+msgstr "O recurso '%s' non é un catálogo de mensaxes correcto."
+
+#: ../src/common/translation.cpp:1865
+msgid "Couldn't enumerate translations"
+msgstr "Non se puideron enumerar traducións"
+
+#: ../src/common/utilscmn.cpp:1145
+msgid "No default application configured for HTML files."
+msgstr "Non hai aplicación predeterminada para ficheiros HTML."
+
+#: ../src/common/utilscmn.cpp:1190
+#, c-format
+msgid "Failed to open URL \"%s\" in default browser."
+msgstr "Erro ao abrir URL \"%s\" no navegador predeterminado."
+
+#: ../src/common/valtext.cpp:144
+msgid "Validation conflict"
+msgstr "Conflito de validación"
+
+#: ../src/common/valtext.cpp:186
+msgid "Required information entry is empty."
+msgstr "A entrada da información requirida está baleira."
+
+#: ../src/common/valtext.cpp:188
+#, fuzzy, c-format
+msgid "'%s' is one of the invalid strings"
+msgstr "'%s' é incorrecto"
+
+#: ../src/common/valtext.cpp:190
+#, fuzzy, c-format
+msgid "'%s' is not one of the valid strings"
+msgstr "'%s' non é un catálogo de mensaxes correcto."
+
+#: ../src/common/valtext.cpp:199
+#, fuzzy, c-format
+msgid "'%s' contains invalid character(s)"
+msgstr "'%s' debe conter só caracteres alfabéticos."
+
+#: ../src/common/webrequest.cpp:139
+#, fuzzy, c-format
+msgid "Error: %s (%d)"
+msgstr "Erro: "
+
+#: ../src/common/webrequest.cpp:655
+#, c-format
+msgid ""
+"Not enough free disk space for download: %llu needed but only %llu available."
+msgstr ""
+
+#: ../src/common/webrequest.cpp:669
+#, fuzzy, c-format
+msgid "Failed to create temporary file in %s"
+msgstr "Erro ao crear un nome de ficheiro temporal"
+
+#: ../src/common/webrequest_curl.cpp:1106
+#, fuzzy
+msgid "libcurl could not be initialized"
+msgstr "Non se puido inicializar a descrición da columna."
+
+#: ../src/common/webview.cpp:392
+#, fuzzy
+msgid "RunScriptAsync not supported"
+msgstr "Conersiones de cadena no soportadas"
+
+#: ../src/common/webview.cpp:403 ../src/msw/webview_ie.cpp:1073
+#, c-format
+msgid "Error running JavaScript: %s"
+msgstr ""
+
+#: ../src/common/webview_chromium.cpp:858
+#, fuzzy, c-format
+msgid "Failed to set proxy \"%s\": %s"
+msgstr "Erro ao crear o cartafol \"%s\""
+
+#: ../src/common/webview_chromium.cpp:989
+msgid ""
+"Chromium can't be used because libcef.so wasn't loaded early enough; please "
+"relink the application or use LD_PRELOAD to load it earlier."
+msgstr ""
+
+#: ../src/common/webview_chromium.cpp:1108
+#, fuzzy
+msgid "Could not initialize Chromium"
+msgstr "Non se puido estabelecer o aliñamento."
+
+#: ../src/common/webview_chromium.cpp:1616
+msgid "Show DevTools"
+msgstr ""
+
+#: ../src/common/webview_chromium.cpp:1617
+#, fuzzy
+msgid "Close DevTools"
+msgstr "Pechar todo"
+
+#: ../src/common/webview_chromium.cpp:1623
+msgid "Inspect"
+msgstr ""
+
+#: ../src/common/wincmn.cpp:1628
+msgid "This platform does not support background transparency."
+msgstr "Esta plataforma non admite a transparencia de fondo."
+
+#: ../src/common/wincmn.cpp:2097
+msgid "Could not transfer data to window"
+msgstr "Non se puideron transferir os datos á xanela"
+
+#: ../src/common/windowid.cpp:240
+msgid "Out of window IDs.  Recommend shutting down application."
+msgstr "Non hai IDs de xanela. Recoméndase pechar o aplicativo."
+
+#: ../src/common/xpmdecod.cpp:678
+msgid "XPM: incorrect header format!"
+msgstr "XPM: formato de cabeceira incorrecto!"
+
+#: ../src/common/xpmdecod.cpp:703
+#, c-format
+msgid "XPM: incorrect colour description in line %d"
+msgstr "XPM: Descrición de cor incorrecta na liña %d"
+
+#: ../src/common/xpmdecod.cpp:715 ../src/common/xpmdecod.cpp:724
+#, c-format
+msgid "XPM: malformed colour definition '%s' at line %d!"
+msgstr "XPM: Definición de cor '%s' incorrecta na liña %d!"
+
+#: ../src/common/xpmdecod.cpp:754
+msgid "XPM: no colors left to use for mask!"
+msgstr "XPM: non se deixaron cores para usar na máscara!"
+
+#: ../src/common/xpmdecod.cpp:781
+#, c-format
+msgid "XPM: truncated image data at line %d!"
+msgstr "XPM: datos de imaxe truncados na liña %d!"
+
+#: ../src/common/xpmdecod.cpp:795
+msgid "XPM: Malformed pixel data!"
+msgstr "XPM: Datos de píxel incorrectos!"
+
+#: ../src/common/xti.cpp:492
+msgid "Illegal Parameter Count for Create Method"
+msgstr "Número de parámetros inaceptábel para o método Create"
+
+#: ../src/common/xti.cpp:504
+msgid "Illegal Parameter Count for ConstructObject Method"
+msgstr "Número de parámetros inaceptábel para o método ConstructObject"
+
+#: ../src/common/xtistrm.cpp:161
+#, c-format
+msgid "Create Parameter %s not found in declared RTTI Parameters"
+msgstr ""
+"Non se atopou o parámetro de creación %s nos parámetros RTTI declarados"
+
+#: ../src/common/xtistrm.cpp:290
+msgid "Illegal Object Class (Non-wxEvtHandler) as Event Source"
+msgstr "Clase de obxecto inaceptábel como orixe do evento (non-wxEvtHandler)"
+
+#: ../src/common/xtistrm.cpp:313 ../src/common/xtixml.cpp:345
+#: ../src/common/xtixml.cpp:498
+msgid "Type must have enum - long conversion"
+msgstr "O tipo debe ter un conversor enum - long"
+
+#: ../src/common/xtistrm.cpp:400 ../src/common/xtistrm.cpp:415
+msgid "Invalid or Null Object ID passed to GetObjectClassInfo"
+msgstr "ID de obxecto incorrecto ou nulo pasada a GetObjectClassInfo"
+
+#: ../src/common/xtistrm.cpp:405
+msgid "Unknown Object passed to GetObjectClassInfo"
+msgstr "Obxecto descoñecido pasado a GetObjectClassInfo"
+
+#: ../src/common/xtistrm.cpp:420
+msgid "Already Registered Object passed to SetObjectClassInfo"
+msgstr "Pasouse obxecto xa rexistrado a SetObjectClassInfo"
+
+#: ../src/common/xtistrm.cpp:430
+msgid "Invalid or Null Object ID passed to HasObjectClassInfo"
+msgstr "ID de obxecto incorrrecto ou nulo pasada a HasObjectClassInfo"
+
+#: ../src/common/xtistrm.cpp:460
+msgid "Passing a already registered object to SetObject"
+msgstr "Paso dun obxecto xa rexistrado a SetObject"
+
+#: ../src/common/xtistrm.cpp:471
+msgid "Passing an unknown object to GetObject"
+msgstr "Paso dun obxecto descoñecido a GetObject"
+
+#: ../src/common/xtixml.cpp:229
+msgid "Forward hrefs are not supported"
+msgstr "Redirección de hrefs non é compatíbel"
+
+#: ../src/common/xtixml.cpp:247
+#, c-format
+msgid "unknown class %s"
+msgstr "clase %s descoñecida"
+
+#: ../src/common/xtixml.cpp:253
+msgid "objects cannot have XML Text Nodes"
+msgstr "os obxectos non poden ter nodos de texto XML"
+
+#: ../src/common/xtixml.cpp:258
+msgid "Objects must have an id attribute"
+msgstr "Os obxectos deben ter un atributo id"
+
+#: ../src/common/xtixml.cpp:267
+#, c-format
+msgid "Doubly used id : %d"
+msgstr "ID usado dúas veces: %d"
+
+#: ../src/common/xtixml.cpp:316
+#, c-format
+msgid "Unknown Property %s"
+msgstr "Propiedade descoñecida %s"
+
+#: ../src/common/xtixml.cpp:407
+msgid "A non empty collection must consist of 'element' nodes"
+msgstr "Unha colección non baleara debe consistir en nodos do tipo \"element\""
+
+#: ../src/common/xtixml.cpp:478
+msgid "incorrect event handler string, missing dot"
+msgstr "cadea manexadora de evento incorrecta, falta o punto"
+
+#: ../src/common/zipstrm.cpp:559
+msgid "can't re-initialize zlib deflate stream"
+msgstr "non é posíbel reinicializar o fluxo de compresión de zlib"
+
+#: ../src/common/zipstrm.cpp:584
+msgid "can't re-initialize zlib inflate stream"
+msgstr "non é posíbel reinicializar o fluxo de descompresión de zlib"
+
+#: ../src/common/zipstrm.cpp:1023
+msgid "Ignoring malformed extra data record, ZIP file may be corrupted"
+msgstr ""
+
+#: ../src/common/zipstrm.cpp:1502
+msgid "assuming this is a multi-part zip concatenated"
+msgstr "supoñendo que isto é un ficheiro zip con varias partes concatenadas"
+
+#: ../src/common/zipstrm.cpp:1664
+msgid "invalid zip file"
+msgstr "ficheiro zip incorrecto"
+
+#: ../src/common/zipstrm.cpp:1723
+msgid "can't find central directory in zip"
+msgstr "non é posíbel atopar o cartafol central en zip"
+
+#: ../src/common/zipstrm.cpp:1812
+msgid "error reading zip central directory"
+msgstr "erro ao ler o cartafol central de zip"
+
+#: ../src/common/zipstrm.cpp:1916
+msgid "error reading zip local header"
+msgstr "erro ao ler a cabeceira local de zip"
+
+#: ../src/common/zipstrm.cpp:1964
+msgid "bad zipfile offset to entry"
+msgstr "desprazamento incorrecto de ficheiro zip á entrada"
+
+#: ../src/common/zipstrm.cpp:2031
+msgid "stored file length not in Zip header"
+msgstr "a lonxitude do ficheiro almacenado non está na cabeceira de zip"
+
+#: ../src/common/zipstrm.cpp:2045 ../src/common/zipstrm.cpp:2362
+msgid "unsupported Zip compression method"
+msgstr "método de compresión Zip non compatíbel"
+
+#: ../src/common/zipstrm.cpp:2126
+#, c-format
+msgid "reading zip stream (entry %s): bad length"
+msgstr "lendo o fluxo de zip (entrada %s): lonxitude incorrecta"
+
+#: ../src/common/zipstrm.cpp:2131
+#, c-format
+msgid "reading zip stream (entry %s): bad crc"
+msgstr "lendo o fluxo de zip (entrada %s): crc incorrecto"
+
+#: ../src/common/zipstrm.cpp:2578
+#, fuzzy, c-format
+msgid "error writing zip entry '%s': file too large without ZIP64"
+msgstr "erro ao escribir a entrada de zip '%s': crc ou lonxitude incorrectos"
+
+#: ../src/common/zipstrm.cpp:2585
+#, c-format
+msgid "error writing zip entry '%s': bad crc or length"
+msgstr "erro ao escribir a entrada de zip '%s': crc ou lonxitude incorrectos"
+
+#: ../src/common/zstream.cpp:155 ../src/common/zstream.cpp:315
+msgid "Gzip not supported by this version of zlib"
+msgstr "Gzip non é compatíbel con esta versión de zlib"
+
+#: ../src/common/zstream.cpp:182
+msgid "Can't initialize zlib inflate stream."
+msgstr "Non se pode inicializar o fluxo de descompresión de zlib."
+
+#: ../src/common/zstream.cpp:241
+msgid "Can't read inflate stream: unexpected EOF in underlying stream."
+msgstr ""
+"Non se pode ler o fluxo de descompresión: EOF inesperado no fluxo subxacente."
+
+#: ../src/common/zstream.cpp:248 ../src/common/zstream.cpp:423
+#, c-format
+msgid "zlib error %d"
+msgstr "erro de zlib %d"
+
+#: ../src/common/zstream.cpp:249
+#, c-format
+msgid "Can't read from inflate stream: %s"
+msgstr "Non se pode ler dende o fluxo de descompresión: %s"
+
+#: ../src/common/zstream.cpp:343
+msgid "Can't initialize zlib deflate stream."
+msgstr "Non se pode inicar o fluxo de compresión de zlib."
+
+#: ../src/common/zstream.cpp:424
+#, c-format
+msgid "Can't write to deflate stream: %s"
+msgstr "Non se pode escribir no fluxo de compresión: %s"
+
+#: ../src/dfb/bitmap.cpp:633 ../src/dfb/bitmap.cpp:667
+#, c-format
+msgid "No bitmap handler for type %d defined."
+msgstr "Non hai manexador de mapa de bits para o tipo %d definido."
+
+#: ../src/dfb/evtloop.cpp:99
+msgid "Failed to read event from DirectFB pipe"
+msgstr "Erro ao ler evento dende a canalización DirectFB"
+
+#: ../src/dfb/evtloop.cpp:171
+msgid "Failed to switch DirectFB pipe to non-blocking mode"
+msgstr ""
+"Non foi posíbel conectar a canalización DirectFB ao modo non bloqueante"
+
+#: ../src/dfb/fontmgr.cpp:171
+#, c-format
+msgid "no fonts found in %s, using builtin font"
+msgstr ""
+"non se atoparon tipos de letra en %s, utilizarase un tipo de letra integrado"
+
+#: ../src/dfb/fontmgr.cpp:177
+msgid "Default font"
+msgstr "Tipo de letra predeterminado"
+
+#: ../src/dfb/fontmgr.cpp:195
+#, c-format
+msgid "Fonts index file %s disappeared while loading fonts."
+msgstr "Desapareceu o arquivo de índice de tipos de letra %s mentres cargaba."
+
+#: ../src/dfb/wrapdfb.cpp:60
+#, c-format
+msgid "DirectFB error %d occurred."
+msgstr "Error %d en DirectFB."
+
+#: ../src/generic/aboutdlgg.cpp:69
+msgid "Developed by "
+msgstr "Desenvolvido por "
+
+#: ../src/generic/aboutdlgg.cpp:72
+msgid "Documentation by "
+msgstr "Documentación de "
+
+#: ../src/generic/aboutdlgg.cpp:75
+msgid "Graphics art by "
+msgstr "Gráficos de "
+
+#: ../src/generic/aboutdlgg.cpp:78
+msgid "Translations by "
+msgstr "Traducións de "
+
+#: ../src/generic/aboutdlgg.cpp:133 ../src/osx/cocoa/aboutdlg.mm:83
+msgid "Version "
+msgstr "Versión "
+
+#. TRANSLATORS: %s is application name
+#: ../src/generic/aboutdlgg.cpp:146 ../src/msw/aboutdlg.cpp:60
+#, c-format
+msgid "About %s"
+msgstr "Sobre %s"
+
+#: ../src/generic/aboutdlgg.cpp:181
+msgid "License"
+msgstr "Licencia"
+
+#: ../src/generic/aboutdlgg.cpp:184
+msgid "Developers"
+msgstr "Desenvolvedores"
+
+#: ../src/generic/aboutdlgg.cpp:188
+msgid "Documentation writers"
+msgstr "Autores da documentación"
+
+#: ../src/generic/aboutdlgg.cpp:192
+msgid "Artists"
+msgstr "Artistas"
+
+#: ../src/generic/aboutdlgg.cpp:196
+msgid "Translators"
+msgstr "Tradutores/as"
+
+#: ../src/generic/animateg.cpp:125
+msgid "No handler found for animation type."
+msgstr "Non se atopou un manexador para o tipo de animación."
+
+#: ../src/generic/animateg.cpp:133
+#, c-format
+msgid "No animation handler for type %ld defined."
+msgstr "Non hai manexador de animación para o tipo %ld definido."
+
+#: ../src/generic/animateg.cpp:145
+#, c-format
+msgid "Animation file is not of type %ld."
+msgstr "O fichero de animación non é do tipo %ld."
+
+#: ../src/generic/colrdlgg.cpp:154 ../src/gtk/colordlg.cpp:47
+msgid "Choose colour"
+msgstr "Elixa unha cor"
+
+#: ../src/generic/colrdlgg.cpp:357
+msgid "Red:"
+msgstr ""
+
+#: ../src/generic/colrdlgg.cpp:360
+#, fuzzy
+msgid "Green:"
+msgstr "Mac grego"
+
+#: ../src/generic/colrdlgg.cpp:363
+msgid "Blue:"
+msgstr ""
+
+#: ../src/generic/colrdlgg.cpp:372
+msgid "Opacity:"
+msgstr ""
+
+#: ../src/generic/colrdlgg.cpp:384
+msgid "Add to custom colours"
+msgstr "Engadir ás cores personalizadas"
+
+#: ../src/generic/creddlgg.cpp:56
+msgid "Username:"
+msgstr ""
+
+#: ../src/generic/creddlgg.cpp:63
+msgid "Password:"
+msgstr ""
+
+#. TRANSLATORS: Name of Boolean true value
+#: ../src/generic/datavgen.cpp:1178
+msgid "true"
+msgstr ""
+
+#. TRANSLATORS: Name of Boolean false value
+#: ../src/generic/datavgen.cpp:1180
+#, fuzzy
+msgid "false"
+msgstr "Falso"
+
+#: ../src/generic/datavgen.cpp:6897
+#, c-format
+msgid "Row %i"
+msgstr ""
+
+#. TRANSLATORS: Action for manipulating a tree control
+#: ../src/generic/datavgen.cpp:6987
+msgid "Collapse"
+msgstr ""
+
+#. TRANSLATORS: Action for manipulating a tree control
+#: ../src/generic/datavgen.cpp:6990
+msgid "Expand"
+msgstr ""
+
+#. TRANSLATORS: Name of data view control and number of rows
+#: ../src/generic/datavgen.cpp:7011
+#, fuzzy, c-format
+msgid "%s (%d items)"
+msgstr "%s (ou %s)"
+
+#: ../src/generic/datavgen.cpp:7062
+#, fuzzy, c-format
+msgid "Column %u"
+msgstr "Engadir columna"
+
+#. TRANSLATORS: Keystroke for manipulating a tree control
+#: ../src/generic/datavgen.cpp:7131 ../src/richtext/richtextbulletspage.cpp:189
+#: ../src/richtext/richtextbulletspage.cpp:192
+#: ../src/richtext/richtextbulletspage.cpp:193
+#: ../src/richtext/richtextliststylepage.cpp:252
+#: ../src/richtext/richtextliststylepage.cpp:255
+#: ../src/richtext/richtextliststylepage.cpp:256
+#: ../src/richtext/richtextsizepage.cpp:248
+msgid "Left"
+msgstr "Esquerda"
+
+#. TRANSLATORS: Keystroke for manipulating a tree control
+#: ../src/generic/datavgen.cpp:7134 ../src/richtext/richtextbulletspage.cpp:191
+#: ../src/richtext/richtextliststylepage.cpp:254
+#: ../src/richtext/richtextsizepage.cpp:249
+msgid "Right"
+msgstr "Clara"
+
+#: ../src/generic/datectlg.cpp:90
+#, c-format
+msgid ""
+"\"%s\" is not in the expected date format, please enter it as e.g. \"%s\"."
+msgstr ""
+
+#: ../src/generic/datectlg.cpp:94
+#, fuzzy
+msgid "Invalid date"
+msgstr "Elemento de visualización de datos incorrecto"
+
+#: ../src/generic/dbgrptg.cpp:159
+#, c-format
+msgid "Open file \"%s\""
+msgstr "Abrir o ficheiro \"%s\""
+
+#: ../src/generic/dbgrptg.cpp:170
+#, c-format
+msgid "Enter command to open file \"%s\":"
+msgstr "Inserir o comando para abrir o ficheiro \"%s\":"
+
+#: ../src/generic/dbgrptg.cpp:230
+msgid "Executable files (*.exe)|*.exe|"
+msgstr "Ficheiros executábeis (*.exe)|*.exe|"
+
+#: ../src/generic/dbgrptg.cpp:300
+#, c-format
+msgid "Debug report \"%s\""
+msgstr "Informe de depuración \"%s\""
+
+#: ../src/generic/dbgrptg.cpp:316
+msgid "A debug report has been generated in the directory\n"
+msgstr "Xerouse un informe de depuración no cartafol\n"
+
+#: ../src/generic/dbgrptg.cpp:317
+#, fuzzy
+msgid "The following debug report will be generated\n"
+msgstr "*** Xerouse un informe de depuración\n"
+
+#: ../src/generic/dbgrptg.cpp:321
+msgid ""
+"The report contains the files listed below. If any of these files contain "
+"private information,\n"
+"please uncheck them and they will be removed from the report.\n"
+msgstr ""
+"O informe contén os ficheiros listados embaixo. Se algún destes ficheiros "
+"contén\n"
+"información privada, desmárqueo e quedará eliminado do informe.\n"
+
+#: ../src/generic/dbgrptg.cpp:323
+msgid ""
+"If you wish to suppress this debug report completely, please choose the "
+"\"Cancel\" button,\n"
+"but be warned that it may hinder improving the program, so if\n"
+"at all possible please do continue with the report generation.\n"
+msgstr ""
+"Se desexa eliminar completamente este informe de depuración, por favor prema "
+"no botón \"Cancelar\",\n"
+" pero informámoslle que isto pode dificultar a mellora do aplicativo , así "
+"que,\n"
+"se é posíbel continúe coa xeración do informe.\n"
+
+#: ../src/generic/dbgrptg.cpp:325
+msgid "              Thank you and we're sorry for the inconvenience!\n"
+msgstr "              Grazas e sentimos a molestia!\n"
+
+#: ../src/generic/dbgrptg.cpp:333
+msgid "&Debug report preview:"
+msgstr "Previsualización do informe de &depuración:"
+
+#: ../src/generic/dbgrptg.cpp:339
+msgid "&View..."
+msgstr "&Ver…"
+
+#: ../src/generic/dbgrptg.cpp:359
+msgid "&Notes:"
+msgstr "&Notas:"
+
+#: ../src/generic/dbgrptg.cpp:361
+msgid ""
+"If you have any additional information pertaining to this bug\n"
+"report, please enter it here and it will be joined to it:"
+msgstr ""
+"Se ten algunha información adicional sobre este informe de erros,\n"
+"por favor, insíraa aquí e se engadirá:"
+
+#: ../src/generic/dcpsg.cpp:1627
+msgid "Cannot open file for PostScript printing!"
+msgstr "Non se pode abrir o ficheiro para a impresión PostScript!"
+
+#: ../src/generic/dirctrlg.cpp:402
+msgid "Computer"
+msgstr "Ordenador"
+
+#: ../src/generic/dirctrlg.cpp:404
+msgid "Sections"
+msgstr "Seccións"
+
+#: ../src/generic/dirctrlg.cpp:482
+msgid "Home directory"
+msgstr "Cartafol inicial"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/generic/dirctrlg.cpp:484 ../src/propgrid/advprops.cpp:811
+msgid "Desktop"
+msgstr "Escritorio"
+
+#: ../src/generic/dirctrlg.cpp:528 ../src/generic/filectrlg.cpp:752
+msgid "Illegal directory name."
+msgstr "Nome de cartafol inaceptábel."
+
+#: ../src/generic/dirctrlg.cpp:528 ../src/generic/dirctrlg.cpp:546
+#: ../src/generic/dirctrlg.cpp:557 ../src/generic/dirdlgg.cpp:317
+#: ../src/generic/filectrlg.cpp:638 ../src/generic/filectrlg.cpp:752
+#: ../src/generic/filectrlg.cpp:766 ../src/generic/filectrlg.cpp:782
+#: ../src/generic/filectrlg.cpp:1356 ../src/generic/filectrlg.cpp:1387
+#: ../src/generic/filedlgg.cpp:362 ../src/gtk/filedlg.cpp:76
+msgid "Error"
+msgstr "Erro"
+
+#: ../src/generic/dirctrlg.cpp:546 ../src/generic/filectrlg.cpp:766
+msgid "File name exists already."
+msgstr "O nome de ficheiro xa existe."
+
+#: ../src/generic/dirctrlg.cpp:557 ../src/generic/dirdlgg.cpp:317
+#: ../src/generic/filectrlg.cpp:638 ../src/generic/filectrlg.cpp:782
+msgid "Operation not permitted."
+msgstr "Operación non permitida."
+
+#: ../src/generic/dirdlgg.cpp:107 ../src/generic/filedlgg.cpp:207
+msgid "Create new directory"
+msgstr "Crear novo cartafol"
+
+#: ../src/generic/dirdlgg.cpp:112 ../src/generic/filedlgg.cpp:203
+msgid "Go to home directory"
+msgstr "Ir ao cartafol inicial"
+
+#: ../src/generic/dirdlgg.cpp:143
+msgid "Show &hidden directories"
+msgstr "Amosar os cartafoles &agochados"
+
+#: ../src/generic/dirdlgg.cpp:196
+#, c-format
+msgid ""
+"The directory '%s' does not exist\n"
+"Create it now?"
+msgstr ""
+"O cartafol '%s' non existe\n"
+"Desexa crealo agora?"
+
+#: ../src/generic/dirdlgg.cpp:198
+msgid "Directory does not exist"
+msgstr "O cartafol non existe"
+
+#: ../src/generic/dirdlgg.cpp:214
+#, c-format
+msgid ""
+"Failed to create directory '%s'\n"
+"(Do you have the required permissions?)"
+msgstr ""
+"Erro ao crear o cartafol '%s'\n"
+"(Ten os permisos necesarios?)"
+
+#: ../src/generic/dirdlgg.cpp:216
+msgid "Error creating directory"
+msgstr "Erro ao crear o cartafol"
+
+#: ../src/generic/dirdlgg.cpp:281
+msgid "You cannot add a new directory to this section."
+msgstr "Non pode engadir un novo cartafol a esta sección."
+
+#: ../src/generic/dirdlgg.cpp:282
+msgid "Create directory"
+msgstr "Crear cartafol"
+
+#: ../src/generic/dirdlgg.cpp:291 ../src/generic/dirdlgg.cpp:301
+#: ../src/generic/filectrlg.cpp:614 ../src/generic/filectrlg.cpp:623
+msgid "NewName"
+msgstr "NovoNome"
+
+#: ../src/generic/editlbox.cpp:135
+msgid "Edit item"
+msgstr "Editar elemento"
+
+#: ../src/generic/editlbox.cpp:143
+msgid "New item"
+msgstr "Novo elemento"
+
+#: ../src/generic/editlbox.cpp:151
+msgid "Delete item"
+msgstr "Eliminar elemento"
+
+#: ../src/generic/editlbox.cpp:159
+msgid "Move up"
+msgstr "Mover arriba"
+
+#: ../src/generic/editlbox.cpp:164
+msgid "Move down"
+msgstr "Mover abaixo"
+
+#: ../src/generic/fdrepdlg.cpp:108
+msgid "Search for:"
+msgstr "Buscar:"
+
+#: ../src/generic/fdrepdlg.cpp:120
+msgid "Replace with:"
+msgstr "Substituír por:"
+
+#: ../src/generic/fdrepdlg.cpp:140
+msgid "Whole word"
+msgstr "Palabra completa"
+
+#: ../src/generic/fdrepdlg.cpp:143
+msgid "Match case"
+msgstr "Coincidir Maiúsculas/Minúsculas"
+
+#: ../src/generic/fdrepdlg.cpp:156
+msgid "Search direction"
+msgstr "Dirección de busca"
+
+#: ../src/generic/fdrepdlg.cpp:175
+msgid "&Replace"
+msgstr "&Substituír"
+
+#: ../src/generic/fdrepdlg.cpp:178
+msgid "Replace &all"
+msgstr "Substituír &todo"
+
+#: ../src/generic/filectrlg.cpp:246 ../src/generic/filectrlg.cpp:269
+msgid "<DIR>"
+msgstr "<DIR>"
+
+#: ../src/generic/filectrlg.cpp:248 ../src/generic/filectrlg.cpp:271
+msgid "<LINK>"
+msgstr "<ENLACE>"
+
+#: ../src/generic/filectrlg.cpp:250 ../src/generic/filectrlg.cpp:273
+msgid "<DRIVE>"
+msgstr "<UNIDADE>"
+
+#: ../src/generic/filectrlg.cpp:275
+#, c-format
+msgid "%ld byte"
+msgid_plural "%ld bytes"
+msgstr[0] "%ld byte"
+msgstr[1] "%ld bytes"
+
+#: ../src/generic/filectrlg.cpp:420
+msgid "Name"
+msgstr "Nome"
+
+#: ../src/generic/filectrlg.cpp:421 ../src/richtext/richtextformatdlg.cpp:361
+#: ../src/richtext/richtextsizepage.cpp:298
+msgid "Size"
+msgstr "Tamaño"
+
+#: ../src/generic/filectrlg.cpp:422
+msgid "Type"
+msgstr "Tipo"
+
+#: ../src/generic/filectrlg.cpp:423
+msgid "Modified"
+msgstr "Modificado"
+
+#: ../src/generic/filectrlg.cpp:426
+msgid "Permissions"
+msgstr "Permisos"
+
+#: ../src/generic/filectrlg.cpp:429
+msgid "Attributes"
+msgstr "Atributos"
+
+#: ../src/generic/filectrlg.cpp:936
+msgid "Current directory:"
+msgstr "Cartafol actual:"
+
+#: ../src/generic/filectrlg.cpp:979
+msgid "Show &hidden files"
+msgstr "Amosar os ficheiros &agochados"
+
+#: ../src/generic/filectrlg.cpp:1355
+msgid "Illegal file specification."
+msgstr "Especificación de ficheiro inaceptábel."
+
+#: ../src/generic/filectrlg.cpp:1387
+msgid "Directory doesn't exist."
+msgstr "O cartafol non existe."
+
+#: ../src/generic/filedlgg.cpp:195
+msgid "View files as a list view"
+msgstr "Ver os ficheiros coma unha lista"
+
+#: ../src/generic/filedlgg.cpp:197
+msgid "View files as a detailed view"
+msgstr "Ver os ficheiros coma unha lista detallada"
+
+#: ../src/generic/filedlgg.cpp:200
+msgid "Go to parent directory"
+msgstr "Ir ao cartafol superior"
+
+#: ../src/generic/filedlgg.cpp:351 ../src/gtk/filedlg.cpp:59
+#, c-format
+msgid "File '%s' already exists, do you really want to overwrite it?"
+msgstr "O ficheiro '%s' xa existe, desexa sobreescribilo?"
+
+#: ../src/generic/filedlgg.cpp:354 ../src/gtk/filedlg.cpp:62
+msgid "Confirm"
+msgstr "Confirmar"
+
+#: ../src/generic/filedlgg.cpp:362 ../src/gtk/filedlg.cpp:75
+msgid "Please choose an existing file."
+msgstr "Escolla un ficheiro existente."
+
+#: ../src/generic/filepickerg.cpp:64
+msgid "..."
+msgstr "..."
+
+#: ../src/generic/fontdlgg.cpp:76 ../src/richtext/richtextformatdlg.cpp:519
+msgid "ABCDEFGabcdefg12345"
+msgstr "ABCDEFGabcdefg12345"
+
+#: ../src/generic/fontdlgg.cpp:315
+msgid "Roman"
+msgstr "Redonda"
+
+#: ../src/generic/fontdlgg.cpp:316
+msgid "Decorative"
+msgstr "Decorativo"
+
+#: ../src/generic/fontdlgg.cpp:317
+msgid "Modern"
+msgstr "Moderno"
+
+#: ../src/generic/fontdlgg.cpp:318
+msgid "Script"
+msgstr "Script"
+
+#: ../src/generic/fontdlgg.cpp:319
+msgid "Swiss"
+msgstr "Suízo"
+
+#: ../src/generic/fontdlgg.cpp:320
+msgid "Teletype"
+msgstr "Teletipo"
+
+#: ../src/generic/fontdlgg.cpp:321 ../src/generic/fontdlgg.cpp:324
+msgid "Normal"
+msgstr "Normal"
+
+#: ../src/generic/fontdlgg.cpp:323
+msgid "Slant"
+msgstr "Inclinación"
+
+#: ../src/generic/fontdlgg.cpp:325
+msgid "Light"
+msgstr "Clara"
+
+#: ../src/generic/fontdlgg.cpp:363
+msgid "&Font family:"
+msgstr "&Familia de tipo de letra:"
+
+#: ../src/generic/fontdlgg.cpp:367 ../src/generic/fontdlgg.cpp:369
+msgid "The font family."
+msgstr "A familia do tipo de letra."
+
+#: ../src/generic/fontdlgg.cpp:374 ../src/richtext/richtextstylepage.cpp:105
+msgid "&Style:"
+msgstr "&Estilo:"
+
+#: ../src/generic/fontdlgg.cpp:378 ../src/generic/fontdlgg.cpp:380
+msgid "The font style."
+msgstr "Estilo do tipo de letra."
+
+#: ../src/generic/fontdlgg.cpp:385
+msgid "&Weight:"
+msgstr "&Grosor:"
+
+#: ../src/generic/fontdlgg.cpp:389 ../src/generic/fontdlgg.cpp:391
+msgid "The font weight."
+msgstr "O peso do tipo de letra."
+
+#: ../src/generic/fontdlgg.cpp:399
+msgid "C&olour:"
+msgstr "C&or:"
+
+#: ../src/generic/fontdlgg.cpp:407 ../src/generic/fontdlgg.cpp:409
+msgid "The font colour."
+msgstr "A cor do tipo de letra."
+
+#: ../src/generic/fontdlgg.cpp:415
+msgid "&Point size:"
+msgstr "Tamaño do &punto:"
+
+#: ../src/generic/fontdlgg.cpp:420 ../src/generic/fontdlgg.cpp:422
+#: ../src/generic/fontdlgg.cpp:426 ../src/generic/fontdlgg.cpp:428
+msgid "The font point size."
+msgstr "O tamaño de letra."
+
+#: ../src/generic/fontdlgg.cpp:439 ../src/generic/fontdlgg.cpp:441
+msgid "Whether the font is underlined."
+msgstr "Se a letra está subliñada."
+
+#: ../src/generic/fontdlgg.cpp:448 ../src/html/helpwnd.cpp:1215
+msgid "Preview:"
+msgstr "Previsualización:"
+
+#: ../src/generic/fontdlgg.cpp:452 ../src/generic/fontdlgg.cpp:454
+msgid "Shows the font preview."
+msgstr "Amosa unha previsualización do tipo de letra."
+
+#: ../src/generic/fontdlgg.cpp:464 ../src/generic/fontdlgg.cpp:483
+msgid "Click to cancel the font selection."
+msgstr "Clique para cancelar a selección de tipo de letra."
+
+#: ../src/generic/fontdlgg.cpp:469 ../src/generic/fontdlgg.cpp:471
+#: ../src/generic/fontdlgg.cpp:476 ../src/generic/fontdlgg.cpp:478
+msgid "Click to confirm the font selection."
+msgstr "Prema para confirmar a selección de tipo de letra."
+
+#: ../src/generic/fontpickerg.cpp:50 ../src/gtk/fontdlg.cpp:77
+msgid "Choose font"
+msgstr "Elixa un tipo de letra"
+
+#: ../src/generic/grid.cpp:6542
+msgid ""
+"Error copying grid to the clipboard. Either selected cells were not "
+"contiguous or no cell was selected."
+msgstr ""
+
+#: ../src/generic/grid.cpp:12739
+msgid "Grid Corner"
+msgstr ""
+
+#: ../src/generic/grid.cpp:12741
+#, fuzzy, c-format
+msgid "Column %s Header"
+msgstr "Engadir columna"
+
+#: ../src/generic/grid.cpp:12743
+#, c-format
+msgid "Row %s Header"
+msgstr ""
+
+#: ../src/generic/grid.cpp:12745
+#, fuzzy, c-format
+msgid "Column %s: %s"
+msgstr "Engadir columna"
+
+#: ../src/generic/grid.cpp:12749
+#, fuzzy, c-format
+msgid "Row %s: %s"
+msgstr "\t%s: %s\n"
+
+#: ../src/generic/grid.cpp:12753
+#, c-format
+msgid "Row %s, Column %s: %s"
+msgstr ""
+
+#: ../src/generic/helpext.cpp:257
+#, c-format
+msgid "Help directory \"%s\" not found."
+msgstr "Non se atopou o cartafol de axuda \"%s\"."
+
+#: ../src/generic/helpext.cpp:265
+#, c-format
+msgid "Help file \"%s\" not found."
+msgstr "Non se atopou o ficheiro de axuda \"%s\"."
+
+#: ../src/generic/helpext.cpp:284
+#, c-format
+msgid "Line %lu of map file \"%s\" has invalid syntax, skipped."
+msgstr ""
+"A liña %lu do arquivo de mapa \"%s\" ten unha sintaxe incorrecta e foi "
+"omitida."
+
+#: ../src/generic/helpext.cpp:292
+#, c-format
+msgid "No valid mappings found in the file \"%s\"."
+msgstr "Non se atoparon asociacións no ficheiro \"%s\"."
+
+#: ../src/generic/helpext.cpp:435
+msgid "No entries found."
+msgstr "Non se atoparon entradas."
+
+#: ../src/generic/helpext.cpp:444 ../src/generic/helpext.cpp:445
+msgid "Help Index"
+msgstr "Índice da axuda"
+
+#: ../src/generic/helpext.cpp:448
+msgid "Relevant entries:"
+msgstr "Entradas significativas:"
+
+#: ../src/generic/helpext.cpp:449
+msgid "Entries found"
+msgstr "Entradas atopadas"
+
+#: ../src/generic/hyperlinkg.cpp:170
+msgid "&Copy URL"
+msgstr "&Copiar URL"
+
+#: ../src/generic/infobar.cpp:119
+msgid "Hide this notification message."
+msgstr "Agochar esta mensaxe de notificación."
+
+#. TRANSLATORS: %s will be either the application name or "Application"
+#: ../src/generic/logg.cpp:257
+#, c-format
+msgid "%s Error"
+msgstr "%s Erro"
+
+#. TRANSLATORS: %s will be either the application name or "Application"
+#: ../src/generic/logg.cpp:263
+#, c-format
+msgid "%s Warning"
+msgstr "%s Aviso"
+
+#. TRANSLATORS: %s will be either the application name or "Application"
+#: ../src/generic/logg.cpp:273
+#, c-format
+msgid "%s Information"
+msgstr "%s Información"
+
+#: ../src/generic/logg.cpp:276
+msgid "Application"
+msgstr "Aplicativo"
+
+#: ../src/generic/logg.cpp:549
+msgid "Save log contents to file"
+msgstr "Gardar o contido do rexistro nun ficheiro"
+
+#: ../src/generic/logg.cpp:551
+msgid "C&lear"
+msgstr "&Borrar"
+
+#: ../src/generic/logg.cpp:551
+msgid "Clear the log contents"
+msgstr "Borrar o contido do rexistro"
+
+#: ../src/generic/logg.cpp:553
+msgid "Close this window"
+msgstr "Pechar esta xanela"
+
+#: ../src/generic/logg.cpp:554
+msgid "&Log"
+msgstr "&Rexistro"
+
+#: ../src/generic/logg.cpp:610 ../src/generic/logg.cpp:992
+msgid "Can't save log contents to file."
+msgstr "Non se puido gardar o contido do rexistro nun ficheiro."
+
+#: ../src/generic/logg.cpp:613
+#, c-format
+msgid "Log saved to the file '%s'."
+msgstr "O rexistro gardouse no ficheiro '%s'."
+
+#: ../src/generic/logg.cpp:719
+msgid "&Details"
+msgstr "&Detalles"
+
+#: ../src/generic/logg.cpp:972
+msgid "Failed to copy dialog contents to the clipboard."
+msgstr "Erro ao copiar o contido do diálogo no portapapeis."
+
+#: ../src/generic/logg.cpp:1022
+#, c-format
+msgid "Append log to file '%s' (choosing [No] will overwrite it)?"
+msgstr "Engadir rexistro ao ficheiro '%s'? (Se elixe [Non] sobreescribirase)"
+
+#: ../src/generic/logg.cpp:1024
+msgid "Question"
+msgstr "Pregunta"
+
+#: ../src/generic/logg.cpp:1038
+msgid "invalid message box return value"
+msgstr "valor de retorno incorrecto da caixa de correo"
+
+#: ../src/generic/notifmsgg.cpp:129
+msgid "Notice"
+msgstr "Aviso"
+
+#: ../src/generic/preferencesg.cpp:118
+#, c-format
+msgid "%s Preferences"
+msgstr "%s preferencias"
+
+#: ../src/generic/printps.cpp:143
+msgid "Printing..."
+msgstr "Imprimindo..."
+
+#: ../src/generic/printps.cpp:160 ../src/gtk/print.cpp:1076
+#: ../src/msw/printwin.cpp:235
+msgid "Could not start printing."
+msgstr "Non se puido comezar a impresión."
+
+#: ../src/generic/printps.cpp:183
+#, c-format
+msgid "Printing page %d..."
+msgstr "Imprimindo a páxina %d..."
+
+#: ../src/generic/prntdlgg.cpp:171
+msgid "Printer options"
+msgstr "Opcións da impresora"
+
+#: ../src/generic/prntdlgg.cpp:176
+msgid "Print to File"
+msgstr "Imprimir a un ficheiro"
+
+#: ../src/generic/prntdlgg.cpp:179
+msgid "Setup..."
+msgstr "Configuración..."
+
+#: ../src/generic/prntdlgg.cpp:187
+msgid "Printer:"
+msgstr "Impresora:"
+
+#: ../src/generic/prntdlgg.cpp:195
+msgid "Status:"
+msgstr "Estado:"
+
+#: ../src/generic/prntdlgg.cpp:206
+msgid "All"
+msgstr "Todos"
+
+#: ../src/generic/prntdlgg.cpp:207
+msgid "Pages"
+msgstr "Páxinas"
+
+#: ../src/generic/prntdlgg.cpp:215
+msgid "Print Range"
+msgstr "Rango de impresión"
+
+#: ../src/generic/prntdlgg.cpp:229
+msgid "From:"
+msgstr "Dende:"
+
+#: ../src/generic/prntdlgg.cpp:233
+msgid "To:"
+msgstr "Para:"
+
+#: ../src/generic/prntdlgg.cpp:238
+msgid "Copies:"
+msgstr "Copias:"
+
+#: ../src/generic/prntdlgg.cpp:288
+msgid "PostScript file"
+msgstr "Ficheiro PostScript"
+
+#: ../src/generic/prntdlgg.cpp:439
+msgid "Print Setup"
+msgstr "Configuración da impresión"
+
+#: ../src/generic/prntdlgg.cpp:483
+msgid "Printer"
+msgstr "Impresora"
+
+#: ../src/generic/prntdlgg.cpp:501
+msgid "Default printer"
+msgstr "Impresora predeterminada"
+
+#: ../src/generic/prntdlgg.cpp:595 ../src/generic/prntdlgg.cpp:782
+#: ../src/generic/prntdlgg.cpp:822 ../src/generic/prntdlgg.cpp:835
+#: ../src/generic/prntdlgg.cpp:1031 ../src/generic/prntdlgg.cpp:1036
+msgid "Paper size"
+msgstr "Tamaño do papel"
+
+#: ../src/generic/prntdlgg.cpp:604 ../src/generic/prntdlgg.cpp:847
+msgid "Portrait"
+msgstr "Vertical"
+
+#: ../src/generic/prntdlgg.cpp:605 ../src/generic/prntdlgg.cpp:848
+msgid "Landscape"
+msgstr "Horizontal"
+
+#: ../src/generic/prntdlgg.cpp:607 ../src/generic/prntdlgg.cpp:849
+msgid "Orientation"
+msgstr "Orientación"
+
+#: ../src/generic/prntdlgg.cpp:610
+msgid "Options"
+msgstr "Opcións"
+
+#: ../src/generic/prntdlgg.cpp:612
+msgid "Print in colour"
+msgstr "Imprimir a cor"
+
+#: ../src/generic/prntdlgg.cpp:621
+msgid "Print spooling"
+msgstr "Cola de impresión"
+
+#: ../src/generic/prntdlgg.cpp:623
+msgid "Printer command:"
+msgstr "Comando de impresión:"
+
+#: ../src/generic/prntdlgg.cpp:631
+msgid "Printer options:"
+msgstr "Opcións da impresora:"
+
+#: ../src/generic/prntdlgg.cpp:860
+msgid "Left margin (mm):"
+msgstr "Marxe esquerda (mm):"
+
+#: ../src/generic/prntdlgg.cpp:861
+msgid "Top margin (mm):"
+msgstr "Marxe superior (mm):"
+
+#: ../src/generic/prntdlgg.cpp:872
+msgid "Right margin (mm):"
+msgstr "Marxe dereita (mm):"
+
+#: ../src/generic/prntdlgg.cpp:873
+msgid "Bottom margin (mm):"
+msgstr "Marxe inferior (mm):"
+
+#: ../src/generic/prntdlgg.cpp:896
+msgid "Printer..."
+msgstr "Impresora..."
+
+#: ../src/generic/progdlgg.cpp:246
+msgid "&Skip"
+msgstr "&Omitir"
+
+#: ../src/generic/progdlgg.cpp:347 ../src/generic/progdlgg.cpp:626
+msgid "Unknown"
+msgstr "Descoñecido"
+
+#: ../src/generic/progdlgg.cpp:451 ../src/msw/progdlg.cpp:526
+msgid "Done."
+msgstr "Feito."
+
+#: ../src/generic/srchctlg.cpp:55 ../src/gtk/srchctrl.cpp:206
+#: ../src/html/helpwnd.cpp:530 ../src/html/helpwnd.cpp:545
+msgid "Search"
+msgstr "Buscar"
+
+#: ../src/generic/tabg.cpp:1026
+msgid "Could not find tab for id"
+msgstr "Non se atopou lapela para id"
+
+#: ../src/generic/tipdlg.cpp:136
+msgid "Tips not available, sorry!"
+msgstr "Os consellos non están dispoñíbeis!"
+
+#: ../src/generic/tipdlg.cpp:197
+msgid "Tip of the Day"
+msgstr "Consello do día"
+
+#: ../src/generic/tipdlg.cpp:207
+msgid "Did you know..."
+msgstr "Sabía..."
+
+#: ../src/generic/tipdlg.cpp:232
+msgid "&Show tips at startup"
+msgstr "&Amosar os consellos ao comezo"
+
+#: ../src/generic/tipdlg.cpp:236
+msgid "&Next Tip"
+msgstr "&Seguinte Consello"
+
+#: ../src/generic/wizard.cpp:411
+msgid "&Next >"
+msgstr "&Seguinte >"
+
+#: ../src/generic/wizard.cpp:412
+msgid "&Finish"
+msgstr "&Finalizar"
+
+#: ../src/generic/wizard.cpp:420
+msgid "< &Back"
+msgstr "< &Atrás"
+
+#: ../src/gtk/aboutdlg.cpp:204
+msgid "translator-credits"
+msgstr "traducción - créditos"
+
+#: ../src/gtk/app.cpp:517
+msgid ""
+"WARNING: using XIM input method is unsupported and may result in problems "
+"with input handling and flickering. Consider unsetting GTK_IM_MODULE or "
+"setting to \"ibus\"."
+msgstr ""
+
+#: ../src/gtk/app.cpp:569
+msgid "Unable to initialize GTK+, is DISPLAY set properly?"
+msgstr "Non se puido inicializar GTK+, está instalado DISPLAY correctamente?"
+
+#: ../src/gtk/filedlg.cpp:89 ../src/gtk/filepicker.cpp:255
+#, fuzzy, c-format
+msgid "Changing current directory to \"%s\" failed"
+msgstr "Erro ao crear o cartafol \"%s\""
+
+#: ../src/gtk/font.cpp:548
+msgid ""
+"Using private fonts is not supported on this system: Pango library is too "
+"old, 1.38 or later required."
+msgstr ""
+
+#: ../src/gtk/font.cpp:558
+#, fuzzy
+msgid "Failed to create font configuration object."
+msgstr "Erro ao actualizar o ficheiro de configuración de usuario."
+
+#: ../src/gtk/font.cpp:568
+#, fuzzy, c-format
+msgid "Failed to add custom font \"%s\"."
+msgstr "Erro ao cargar documento dende o ficheiro \"%s\"."
+
+#: ../src/gtk/font.cpp:576
+#, fuzzy
+msgid "Failed to register font configuration using private fonts."
+msgstr "Erro ao actualizar o ficheiro de configuración de usuario."
+
+#: ../src/gtk/glcanvas.cpp:117 ../src/gtk/glcanvas.cpp:132
+#, fuzzy
+msgid "Fatal Error"
+msgstr "Erro moi grave"
+
+#: ../src/gtk/glcanvas.cpp:117
+msgid ""
+"This program wasn't compiled with EGL support required under Wayland, "
+"either\n"
+"install EGL libraries and rebuild or run it under X11 backend by setting\n"
+"environment variable GDK_BACKEND=x11 before starting your program."
+msgstr ""
+
+#: ../src/gtk/glcanvas.cpp:132
+msgid ""
+"wxGLCanvas is only supported on Wayland and X11 currently.  You may be able "
+"to\n"
+"work around this by setting environment variable GDK_BACKEND=x11 before\n"
+"starting your program."
+msgstr ""
+
+#: ../src/gtk/mdi.cpp:433
+msgid "MDI child"
+msgstr "Fillo MDI"
+
+#: ../src/gtk/power.cpp:188
+#, fuzzy, c-format
+msgid "Failed to open D-Bus connection to the login manager: %s"
+msgstr "Error %s en la conexión telefónica: %s"
+
+#: ../src/gtk/power.cpp:214
+#, fuzzy
+msgid "wxWidgets application"
+msgstr "Aplicativo"
+
+#: ../src/gtk/power.cpp:226
+msgid "Application needs to keep running"
+msgstr ""
+
+#: ../src/gtk/power.cpp:233
+msgid "Clean up before suspend"
+msgstr ""
+
+#: ../src/gtk/power.cpp:259
+#, fuzzy, c-format
+msgid "Failed to inhibit sleep: %s"
+msgstr "Erro ao iniciar conexión telefónica: %s"
+
+#: ../src/gtk/power.cpp:265
+msgid "Unexpected response to D-Bus \"Inhibit\" request."
+msgstr ""
+
+#: ../src/gtk/print.cpp:218
+msgid "Custom size"
+msgstr "Tamaño personalizado"
+
+#: ../src/gtk/print.cpp:752
+#, fuzzy, c-format
+msgid "Error while printing: %s"
+msgstr "Erro ao imprimir:"
+
+#: ../src/gtk/print.cpp:816
+msgid "Page Setup"
+msgstr "Configuración de páxina"
+
+#: ../src/gtk/webview_webkit.cpp:932
+msgid "Retrieving JavaScript script output is not supported with WebKit v1"
+msgstr ""
+
+#: ../src/gtk/webview_webkit2.cpp:1098
+msgid ""
+"Setting proxy is not supported by WebKit, at least version 2.16 is required."
+msgstr ""
+
+#: ../src/gtk/webview_webkit2.cpp:1104
+msgid "This program was compiled without support for setting WebKit proxy."
+msgstr ""
+
+#: ../src/gtk/window.cpp:6289
+msgid ""
+"GTK+ installed on this machine is too old to support screen compositing, "
+"please install GTK+ 2.12 or later."
+msgstr ""
+"A versión de GTK+ instalado nesta máquina é demasiado antiga para ser "
+"compatíbel coa composición de pantalla. Por favor, instale GTK+ 2.12 ou "
+"posterior."
+
+#: ../src/gtk/window.cpp:6307
+msgid ""
+"Compositing not supported by this system, please enable it in your Window "
+"Manager."
+msgstr ""
+"Este sistema non admite a composición, por favor, actívea no seu xestor de "
+"xanelas."
+
+#: ../src/gtk/window.cpp:6318
+msgid ""
+"This program was compiled with a too old version of GTK+, please rebuild "
+"with GTK+ 2.12 or newer."
+msgstr ""
+"Este programa compilouse cunha versión moi antiga de GTK+. Por favor, "
+"utilice GTK+ 2.12 ou posterior."
+
+#: ../src/html/chm.cpp:138
+#, c-format
+msgid "Failed to open CHM archive '%s'."
+msgstr "Erro ao abrir o arquivo CHM '%s'."
+
+#: ../src/html/chm.cpp:270
+#, c-format
+msgid "Could not extract %s into %s: %s"
+msgstr "Non se puido extraer %s a %s: %s"
+
+#: ../src/html/chm.cpp:324
+msgid "no error"
+msgstr "sen erros"
+
+#: ../src/html/chm.cpp:326
+msgid "bad arguments to library function"
+msgstr "argumentos incorrectos para a función de biblioteca"
+
+#: ../src/html/chm.cpp:328
+msgid "error opening file"
+msgstr "erro ao abrir o ficheiro"
+
+#: ../src/html/chm.cpp:330
+msgid "read error"
+msgstr "erro de lectura"
+
+#: ../src/html/chm.cpp:332
+msgid "write error"
+msgstr "erro de escritura"
+
+#: ../src/html/chm.cpp:334
+msgid "seek error"
+msgstr "erro de busca"
+
+#: ../src/html/chm.cpp:338
+msgid "bad signature"
+msgstr "sinatura incorrecta"
+
+#: ../src/html/chm.cpp:340
+msgid "error in data format"
+msgstr "erro no formato dos datos"
+
+#: ../src/html/chm.cpp:342
+msgid "checksum error"
+msgstr "erro na suma de verificación"
+
+#: ../src/html/chm.cpp:344
+msgid "compression error"
+msgstr "erro de compresión"
+
+#: ../src/html/chm.cpp:346
+msgid "decompression error"
+msgstr "erro de descompresión"
+
+#: ../src/html/chm.cpp:437
+#, c-format
+msgid "Could not locate file '%s'."
+msgstr "Non se puido localizar o ficheiro '%s'."
+
+#: ../src/html/chm.cpp:711
+#, c-format
+msgid "Could not create temporary file '%s'"
+msgstr "Non se puido crear o ficheiro temporal '%s'"
+
+#: ../src/html/chm.cpp:718
+#, c-format
+msgid "Extraction of '%s' into '%s' failed."
+msgstr "Fallou a extración de '%s' a '%s'."
+
+#: ../src/html/chm.cpp:806 ../src/html/chm.cpp:863
+msgid "CHM handler currently supports only local files!"
+msgstr "O manexador CHM só admite ficheiros locais!"
+
+#: ../src/html/chm.cpp:827
+msgid "Link contained '//', converted to absolute link."
+msgstr "O enlace contiña '//', convertido a enlace absoluto."
+
+#: ../src/html/helpctrl.cpp:59
+#, c-format
+msgid "Help: %s"
+msgstr "Axuda: %s"
+
+#: ../src/html/helpctrl.cpp:155
+#, c-format
+msgid "Adding book %s"
+msgstr "Engadindo o libro %s"
+
+#: ../src/html/helpdata.cpp:295
+#, c-format
+msgid "Cannot open contents file: %s"
+msgstr "Non se pode abrir o ficheiro de contido: %s"
+
+#: ../src/html/helpdata.cpp:309
+#, c-format
+msgid "Cannot open index file: %s"
+msgstr "Non se puido abrir o ficheiro de índice: %s"
+
+#: ../src/html/helpdata.cpp:643
+msgid "noname"
+msgstr "sen nome"
+
+#: ../src/html/helpdata.cpp:652
+#, c-format
+msgid "Cannot open HTML help book: %s"
+msgstr "Non se puido abrir o libro de axuda HTML: %s"
+
+#: ../src/html/helpwnd.cpp:315
+msgid "Displays help as you browse the books on the left."
+msgstr "Amosa a axuda cando explora os libros da esquerda."
+
+#: ../src/html/helpwnd.cpp:411 ../src/html/helpwnd.cpp:1100
+#: ../src/html/helpwnd.cpp:1735
+msgid "(bookmarks)"
+msgstr "(marcadores)"
+
+#: ../src/html/helpwnd.cpp:424
+msgid "Add current page to bookmarks"
+msgstr "Engadir a páxina actual aos marcadores"
+
+#: ../src/html/helpwnd.cpp:425
+msgid "Remove current page from bookmarks"
+msgstr "Eliminar a páxina actual dos marcadores"
+
+#: ../src/html/helpwnd.cpp:470
+msgid "Contents"
+msgstr "Contidos"
+
+#: ../src/html/helpwnd.cpp:485
+msgid "Find"
+msgstr "Buscar"
+
+#: ../src/html/helpwnd.cpp:487
+msgid "Show all"
+msgstr "Amosar todo"
+
+#: ../src/html/helpwnd.cpp:497
+msgid ""
+"Display all index items that contain given substring. Search is case "
+"insensitive."
+msgstr ""
+"Amosar todo os elementos do índice que conteñen esta subcadea. A busca non é "
+"sensíbel a maiúsculas/minúsculas."
+
+#: ../src/html/helpwnd.cpp:498
+msgid "Show all items in index"
+msgstr "Amosar todos os elementos do índice"
+
+#: ../src/html/helpwnd.cpp:528
+msgid "Case sensitive"
+msgstr "Sensíbel a maiúsculas/minúsculas"
+
+#: ../src/html/helpwnd.cpp:529
+msgid "Whole words only"
+msgstr "Só palabras completas"
+
+#: ../src/html/helpwnd.cpp:532
+msgid ""
+"Search contents of help book(s) for all occurrences of the text you typed "
+"above"
+msgstr ""
+"Busca nos contidos do(s) libro(s) de axuda todas as aparicións do texto que "
+"escribiu enriba"
+
+#: ../src/html/helpwnd.cpp:653
+msgid "Show/hide navigation panel"
+msgstr "Amosar/agochar o panel de navegación"
+
+#: ../src/html/helpwnd.cpp:655
+msgid "Go back"
+msgstr "Volver"
+
+#: ../src/html/helpwnd.cpp:656
+msgid "Go forward"
+msgstr "Continuar"
+
+#: ../src/html/helpwnd.cpp:658
+msgid "Go one level up in document hierarchy"
+msgstr "Subir un nivel na xerarquía do documento"
+
+#: ../src/html/helpwnd.cpp:666 ../src/html/helpwnd.cpp:1547
+msgid "Open HTML document"
+msgstr "Abrir documento HTML"
+
+#: ../src/html/helpwnd.cpp:670
+msgid "Print this page"
+msgstr "Imprimir esta páxina"
+
+#: ../src/html/helpwnd.cpp:674
+msgid "Display options dialog"
+msgstr "Amosar o diálogo de opcións"
+
+#: ../src/html/helpwnd.cpp:795
+msgid "Please choose the page to display:"
+msgstr "Por favor, elixa a páxina que quere amosar:"
+
+#: ../src/html/helpwnd.cpp:796
+msgid "Help Topics"
+msgstr "Temas da axuda"
+
+#: ../src/html/helpwnd.cpp:852
+msgid "Searching..."
+msgstr "Buscando..."
+
+#: ../src/html/helpwnd.cpp:853
+msgid "No matching page found yet"
+msgstr "Aínda non se atopou ningunha páxina que concorde"
+
+#: ../src/html/helpwnd.cpp:870
+#, c-format
+msgid "Found %i matches"
+msgstr "Atopáronse %i coincidencias"
+
+#: ../src/html/helpwnd.cpp:958
+msgid "(Help)"
+msgstr "(Axuda)"
+
+#: ../src/html/helpwnd.cpp:1026
+#, c-format
+msgid "%d of %lu"
+msgstr "%d de %lu"
+
+#: ../src/html/helpwnd.cpp:1028
+#, c-format
+msgid "%lu of %lu"
+msgstr "%lu de %lu"
+
+#: ../src/html/helpwnd.cpp:1047
+msgid "Search in all books"
+msgstr "Buscar en todos os libros"
+
+#: ../src/html/helpwnd.cpp:1193
+msgid "Help Browser Options"
+msgstr "Opcións do navegador de axuda"
+
+#: ../src/html/helpwnd.cpp:1198
+msgid "Normal font:"
+msgstr "Letra normal:"
+
+#: ../src/html/helpwnd.cpp:1199
+msgid "Fixed font:"
+msgstr "Tipo de letra estabelecido:"
+
+#: ../src/html/helpwnd.cpp:1200
+msgid "Font size:"
+msgstr "Tamaño da letra:"
+
+#: ../src/html/helpwnd.cpp:1245
+msgid "font size"
+msgstr "tamaño de letra"
+
+#: ../src/html/helpwnd.cpp:1256
+msgid "Normal face<br>and <u>underlined</u>. "
+msgstr "Normal<br>e <u>subliñado</u>. "
+
+#: ../src/html/helpwnd.cpp:1257
+msgid "<i>Italic face.</i> "
+msgstr "<i>Cursiva.</i> "
+
+#: ../src/html/helpwnd.cpp:1258
+msgid "<b>Bold face.</b> "
+msgstr "<b>Grosa.</b> "
+
+#: ../src/html/helpwnd.cpp:1259
+msgid "<b><i>Bold italic face.</i></b><br>"
+msgstr "<b><i>Cursiva grosa.</i></b><br>"
+
+#: ../src/html/helpwnd.cpp:1262
+msgid "Fixed size face.<br> <b>bold</b> <i>italic</i> "
+msgstr "Tamaño estabelecido.<br> <b>grosa</b> <i>cursiva</i> "
+
+#: ../src/html/helpwnd.cpp:1263
+msgid "<b><i>bold italic <u>underlined</u></i></b><br>"
+msgstr "<b><i>cursiva grosa<u>subliñado</u></i></b><br>"
+
+#: ../src/html/helpwnd.cpp:1524
+msgid "Help Printing"
+msgstr "Axuda de impresión"
+
+#: ../src/html/helpwnd.cpp:1527
+msgid "Cannot print empty page."
+msgstr "Non se pode imprimir unha páxina en branco."
+
+#: ../src/html/helpwnd.cpp:1540
+msgid "HTML files (*.html;*.htm)|*.html;*.htm|"
+msgstr "Ficheiros HTML (*.html;*.htm)|*.html;*.htm|"
+
+#: ../src/html/helpwnd.cpp:1541
+msgid "Help books (*.htb)|*.htb|Help books (*.zip)|*.zip|"
+msgstr "Libros de axuda (*.htb)|*.htb|Libros de axuda (*.zip)|*.zip|"
+
+#: ../src/html/helpwnd.cpp:1542
+msgid "HTML Help Project (*.hhp)|*.hhp|"
+msgstr "Proxecto de Axuda HTML (*.hhp)|*.hhp|"
+
+#: ../src/html/helpwnd.cpp:1544
+msgid "Compressed HTML Help file (*.chm)|*.chm|"
+msgstr "Ficheiro de Axuda HTML Comprimido (*.chm)|*.chm|"
+
+#: ../src/html/helpwnd.cpp:1671
+#, fuzzy, c-format
+msgid "%i of %u"
+msgstr "%i de %i"
+
+#: ../src/html/helpwnd.cpp:1709
+#, fuzzy, c-format
+msgid "%u of %u"
+msgstr "%lu de %lu"
+
+#: ../src/html/htmlfilt.cpp:134
+#, c-format
+msgid "Cannot open HTML document: %s"
+msgstr "Non se puido abrir o documento HTML: %s"
+
+#: ../src/html/htmlwin.cpp:599
+msgid "Connecting..."
+msgstr "Conectando..."
+
+#: ../src/html/htmlwin.cpp:616
+#, c-format
+msgid "Unable to open requested HTML document: %s"
+msgstr "Non foi posíbel abrir o documento HTML solicitado: %s"
+
+#: ../src/html/htmlwin.cpp:630
+msgid "Loading : "
+msgstr "Cargando: "
+
+#: ../src/html/htmlwin.cpp:673
+msgid "Done"
+msgstr "Feito"
+
+#: ../src/html/htmlwin.cpp:723
+#, c-format
+msgid "HTML anchor %s does not exist."
+msgstr "A áncora de HTML %s non existe."
+
+#: ../src/html/htmlwin.cpp:1057
+#, c-format
+msgid "Copied to clipboard:\"%s\""
+msgstr "Copiouse no portapapeis:\"%s\""
+
+#: ../src/html/htmprint.cpp:269
+msgid ""
+"This document doesn't fit on the page horizontally and will be truncated "
+"when it is printed."
+msgstr ""
+"Este documento non se axeita horizontalmente á páxina e cortarase cando se "
+"imprima."
+
+#: ../src/html/htmprint.cpp:285
+#, c-format
+msgid ""
+"The document \"%s\" doesn't fit on the page horizontally and will be "
+"truncated if printed.\n"
+"\n"
+"Would you like to proceed with printing it nevertheless?"
+msgstr ""
+"O documento \"%s\" non se axeita horizontalmente á páxina e cortarase cando "
+"se imprima.\n"
+"\n"
+"Quere continuar coa impresión en calquera caso?"
+
+#: ../src/html/htmprint.cpp:296
+msgid ""
+"If possible, try changing the layout parameters to make the printout more "
+"narrow."
+msgstr ""
+"Se é posíbel, intente cambiar os parámetros de deseño para facer a impresión "
+"máis estreita."
+
+#: ../src/html/htmprint.cpp:445
+msgid ": file does not exist!"
+msgstr ": o ficheiro non existe!"
+
+#. TRANSLATORS: %s may be a document title.
+#: ../src/html/htmprint.cpp:717
+#, fuzzy, c-format
+msgid "%s Preview"
+msgstr " Previsualización"
+
+#: ../src/html/htmprint.cpp:755 ../src/richtext/richtextprint.cpp:618
+msgid ""
+"There was a problem during page setup: you may need to set a default printer."
+msgstr ""
+"Houbo un problema mentres se configuraba a páxina: cómpre estabelecer unha "
+"impresora predeterminada."
+
+#: ../src/msw/clipbrd.cpp:80
+msgid "Failed to open the clipboard."
+msgstr "Fallo ao abrir o portapapeis."
+
+#: ../src/msw/clipbrd.cpp:101
+msgid "Failed to close the clipboard."
+msgstr "Fallo ao pechar o portapapeis."
+
+#: ../src/msw/clipbrd.cpp:113
+msgid "Failed to empty the clipboard."
+msgstr "Fallo ao baleirar o portapapeis."
+
+#: ../src/msw/clipbrd.cpp:284
+msgid "Failed to put data on the clipboard"
+msgstr "Fallo ao poñer datos no portapapeis"
+
+#: ../src/msw/clipbrd.cpp:326
+msgid "Failed to get data from the clipboard"
+msgstr "Fallo ao obter datos do portapapeis"
+
+#: ../src/msw/clipbrd.cpp:363
+msgid "Failed to retrieve the supported clipboard formats"
+msgstr "Erro ao recuperar os formatos de portapapeis compatíbeis"
+
+#: ../src/msw/colordlg.cpp:228
+#, c-format
+msgid "Colour selection dialog failed with error %0lx."
+msgstr "Fallou o diálogo de selección de cor co erro %0lx."
+
+#: ../src/msw/cursor.cpp:141
+msgid "Failed to create cursor."
+msgstr "Fallo ao crear un cursor."
+
+#: ../src/msw/dde.cpp:279
+#, c-format
+msgid "Failed to register DDE server '%s'"
+msgstr "Erro ao rexistrar servidor DDE '%s'"
+
+#: ../src/msw/dde.cpp:300
+#, c-format
+msgid "Failed to unregister DDE server '%s'"
+msgstr "Non foi posíbel cancelar o rexistro do servidor '%s'"
+
+#: ../src/msw/dde.cpp:428
+#, c-format
+msgid "Failed to create connection to server '%s' on topic '%s'"
+msgstr "Erro ao crear a conexión co servidor '%s' co tema '%s'"
+
+#: ../src/msw/dde.cpp:655
+msgid "DDE poke request failed"
+msgstr "Erro na soicitude de envío de DDE"
+
+#: ../src/msw/dde.cpp:674
+msgid "Failed to establish an advise loop with DDE server"
+msgstr "Erro ao estabelecer un bucle de aviso co servidor DDE"
+
+#: ../src/msw/dde.cpp:693
+msgid "Failed to terminate the advise loop with DDE server"
+msgstr "Non se puido terminar o bucle de aviso co servidor DDE"
+
+#: ../src/msw/dde.cpp:768
+msgid "Failed to send DDE advise notification"
+msgstr "Erro ao enviar notificación de recomendación de DDE"
+
+#: ../src/msw/dde.cpp:1085
+msgid "Failed to create DDE string"
+msgstr "Erro ao crear cadea DDE"
+
+#: ../src/msw/dde.cpp:1131
+msgid "no DDE error."
+msgstr "non hai erro DDE."
+
+#: ../src/msw/dde.cpp:1135
+msgid "a request for a synchronous advise transaction has timed out."
+msgstr "expirou unha solicitude de transacción síncrona de recomendación."
+
+#: ../src/msw/dde.cpp:1138
+msgid "the response to the transaction caused the DDE_FBUSY bit to be set."
+msgstr "a resposta á transacción causou que se activase o bit de DDE_FBUSY."
+
+#: ../src/msw/dde.cpp:1141
+msgid "a request for a synchronous data transaction has timed out."
+msgstr "expirou unha solicitude de transacción síncrona de datos."
+
+#: ../src/msw/dde.cpp:1144
+msgid ""
+"a DDEML function was called without first calling the DdeInitialize "
+"function,\n"
+"or an invalid instance identifier\n"
+"was passed to a DDEML function."
+msgstr ""
+"chamouse a unha función DDEML sen chamar primeiro á función DdeInitialize,\n"
+"ou un identificador de instancia incorrecto\n"
+"pasouse a unha función DDEML."
+
+#: ../src/msw/dde.cpp:1147
+msgid ""
+"an application initialized as APPCLASS_MONITOR has\n"
+"attempted to perform a DDE transaction,\n"
+"or an application initialized as APPCMD_CLIENTONLY has \n"
+"attempted to perform server transactions."
+msgstr ""
+"un aplicativo inicializado como APPCLASS_MONITOR tentou\n"
+"levar a cabo unha transacción DDE,\n"
+"ou un aplicativo inicializado como APPCMD_CLIENTONLY tentou\n"
+"realizar transaccións de servidor."
+
+#: ../src/msw/dde.cpp:1150
+msgid "a request for a synchronous execute transaction has timed out."
+msgstr "expirou unha solicitude de transacción de execución síncrona."
+
+#: ../src/msw/dde.cpp:1153
+msgid "a parameter failed to be validated by the DDEML."
+msgstr "erro ao validar un parámetro polo DDEML."
+
+#: ../src/msw/dde.cpp:1156
+msgid "a DDEML application has created a prolonged race condition."
+msgstr "un aplicativo DDEML creou unha situación de posíbel inconsistencia."
+
+#: ../src/msw/dde.cpp:1159
+msgid "a memory allocation failed."
+msgstr "erro ao asignar memoria."
+
+#: ../src/msw/dde.cpp:1162
+msgid "a client's attempt to establish a conversation has failed."
+msgstr "fallou o intento de estabelecemento de conversación dun cliente."
+
+#: ../src/msw/dde.cpp:1165
+msgid "a transaction failed."
+msgstr "erro nunha transacción."
+
+#: ../src/msw/dde.cpp:1168
+msgid "a request for a synchronous poke transaction has timed out."
+msgstr "expirou unha solicitude de transacción síncrona de asignación."
+
+#: ../src/msw/dde.cpp:1171
+msgid "an internal call to the PostMessage function has failed. "
+msgstr "erro nunha chamada interna á función PostMessage. "
+
+#: ../src/msw/dde.cpp:1174
+msgid "reentrancy problem."
+msgstr "problema de reentrada."
+
+#: ../src/msw/dde.cpp:1177
+msgid ""
+"a server-side transaction was attempted on a conversation\n"
+"that was terminated by the client, or the server\n"
+"terminated before completing a transaction."
+msgstr ""
+"intentouse unha transacción no lado do servidor nunha conversa\n"
+"que foi finalizada polo cliente, ou o servidor finalizou\n"
+"antes de completar a transacción."
+
+#: ../src/msw/dde.cpp:1180
+msgid "an internal error has occurred in the DDEML."
+msgstr "ocorreu un erro interno no DDEML."
+
+#: ../src/msw/dde.cpp:1183
+msgid "a request to end an advise transaction has timed out."
+msgstr "expirou unha solicitude de fin de transacción de aviso."
+
+#: ../src/msw/dde.cpp:1186
+msgid ""
+"an invalid transaction identifier was passed to a DDEML function.\n"
+"Once the application has returned from an XTYP_XACT_COMPLETE callback,\n"
+"the transaction identifier for that callback is no longer valid."
+msgstr ""
+"un identificador de transacción incorrecto pasou a unha función DDEML.\n"
+"Unha vez que o aplicativo volva dende unha chamada XTYP_XACT_COMPLETE,\n"
+"o identificador da transacción para esa chamada deixa de ser válido."
+
+#: ../src/msw/dde.cpp:1189
+#, c-format
+msgid "Unknown DDE error %08x"
+msgstr "Erro DDE descoñecido %08x"
+
+#: ../src/msw/dialup.cpp:343
+msgid ""
+"Dial up functions are unavailable because the remote access service (RAS) is "
+"not installed on this machine. Please install it."
+msgstr ""
+"As funcións de marcado non están dispoñíbeis porque o servidor de acceso "
+"remoto (SAR) non está instalado nesta máquina. Por favor, instáleo."
+
+#: ../src/msw/dialup.cpp:402
+#, c-format
+msgid ""
+"The version of remote access service (RAS) installed on this machine is too "
+"old, please upgrade (the following required function is missing: %s)."
+msgstr ""
+"A versión do servizo de acceso remoto (SAR) instalada nesta máquina é antiga "
+"de máis. Por favor, actualícea (a seguinte función requerida non está "
+"dispoñíbel: %s)."
+
+#: ../src/msw/dialup.cpp:437
+msgid "Failed to retrieve text of RAS error message"
+msgstr "Erro ao recuperar texto de mensaxe de erro RAS"
+
+#: ../src/msw/dialup.cpp:440
+#, c-format
+msgid "unknown error (error code %08x)."
+msgstr "erro descoñecido (código de erro %08x)."
+
+#: ../src/msw/dialup.cpp:492
+#, c-format
+msgid "Cannot find active dialup connection: %s"
+msgstr "Non se atopa conexión telefónica activa: %s"
+
+#: ../src/msw/dialup.cpp:513
+msgid "Several active dialup connections found, choosing one randomly."
+msgstr "Atopáronse varias conexións activas e elixíuse unha ao chou."
+
+#: ../src/msw/dialup.cpp:598 ../src/msw/dialup.cpp:832
+#, c-format
+msgid "Failed to establish dialup connection: %s"
+msgstr "Erro ao estabelecer conexión telefónica: %s"
+
+#: ../src/msw/dialup.cpp:664
+#, c-format
+msgid "Failed to get ISP names: %s"
+msgstr "Erro ao obter nomes de ISP: %s"
+
+#: ../src/msw/dialup.cpp:712
+msgid "Failed to connect: no ISP to dial."
+msgstr "Erro de conexión: non hai ISP ao que chamar."
+
+#: ../src/msw/dialup.cpp:732
+msgid "Choose ISP to dial"
+msgstr "Elixir ISP ao que conectar"
+
+#: ../src/msw/dialup.cpp:733
+msgid "Please choose which ISP do you want to connect to"
+msgstr "Por favor, elixa o provedor de Internet ao que desexa conectarse"
+
+#: ../src/msw/dialup.cpp:766
+msgid "Failed to connect: missing username/password."
+msgstr "Erro ao conectar: falta o nome de usuario/contrasinal."
+
+#: ../src/msw/dialup.cpp:796
+msgid "Cannot find the location of address book file"
+msgstr "Non se puido atopar a localización do ficheiro de axenda"
+
+#: ../src/msw/dialup.cpp:827
+#, c-format
+msgid "Failed to initiate dialup connection: %s"
+msgstr "Erro ao iniciar conexión telefónica: %s"
+
+#: ../src/msw/dialup.cpp:897
+msgid "Cannot hang up - no active dialup connection."
+msgstr "Non se pode colgar - non hai conexión telefónica."
+
+#: ../src/msw/dialup.cpp:907
+#, c-format
+msgid "Failed to terminate the dialup connection: %s"
+msgstr "Non se puido terminar a conexión telefónica: %s"
+
+#: ../src/msw/dib.cpp:313
+#, c-format
+msgid "Failed to save the bitmap image to file \"%s\"."
+msgstr "Erro ao gardar a imaxe de mapa de bits no ficheiro \"%s\"."
+
+#: ../src/msw/dib.cpp:543
+#, c-format
+msgid "Failed to allocate %luKb of memory for bitmap data."
+msgstr "Erro ao asignar %luKb de memoria aos datos do mapa de bits."
+
+#: ../src/msw/dir.cpp:241
+#, c-format
+msgid "Cannot enumerate files in directory '%s'"
+msgstr "Non se puideron enumerar os ficheiros do cartafol '%s'"
+
+#: ../src/msw/dirdlg.cpp:368
+msgid "Couldn't obtain folder name"
+msgstr "Non se puido obter o nome do cartafol"
+
+#: ../src/msw/dlmsw.cpp:163
+#, fuzzy, c-format
+msgid "(error %d: %s)"
+msgstr " (erro %ld: %s)"
+
+#: ../src/msw/dragimag.cpp:143 ../src/msw/dragimag.cpp:178
+#: ../src/msw/imaglist.cpp:309 ../src/msw/imaglist.cpp:331
+msgid "Couldn't add an image to the image list."
+msgstr "Non se puido engadir unha imaxe á lista de imaxes."
+
+#: ../src/msw/enhmeta.cpp:94
+#, c-format
+msgid "Failed to load metafile from file \"%s\"."
+msgstr "Erro ao cargar metaficheiro do ficheiro \"%s\"."
+
+#: ../src/msw/fdrepdlg.cpp:412
+#, c-format
+msgid "Failed to create the standard find/replace dialog (error code %d)"
+msgstr "Erro ao crear o diálogo estándar buscar/substituír (código de erro %d)"
+
+#: ../src/msw/filedlg.cpp:1241
+msgid "Access to the file system is not allowed from secure desktop."
+msgstr ""
+
+#: ../src/msw/filedlg.cpp:1242
+msgid "Security warning"
+msgstr ""
+
+#: ../src/msw/filedlg.cpp:1533
+#, c-format
+msgid "File dialog failed with error code %0lx."
+msgstr "Houbo un erro no ficheiro de diálogo co código %0lx."
+
+#: ../src/msw/font.cpp:1120
+#, fuzzy, c-format
+msgid "Font file \"%s\" couldn't be loaded"
+msgstr "Non foi posíbel cargar o ficheiro."
+
+#: ../src/msw/fontdlg.cpp:220
+#, c-format
+msgid "Common dialog failed with error code %0lx."
+msgstr "Fallo no diálogo común co código de erro %0lx."
+
+#: ../src/msw/fswatcher.cpp:67
+msgid "Ungraceful worker thread termination"
+msgstr "Finalización do fíos de execución efectivos incorrecta"
+
+#: ../src/msw/fswatcher.cpp:81
+msgid "Unable to create IOCP worker thread"
+msgstr "Non se puido crear fío de traballo de IOCP"
+
+#: ../src/msw/fswatcher.cpp:88
+msgid "Unable to start IOCP worker thread"
+msgstr "Non se puido iniciar o fío de traballo de IOCP"
+
+#: ../src/msw/fswatcher.cpp:140
+msgid "Monitoring individual files for changes is not supported currently."
+msgstr "Non é posíbel neste momento monitorizar ficheiros na busca de cambios."
+
+#: ../src/msw/fswatcher.cpp:165
+#, c-format
+msgid "Unable to set up watch for '%s'"
+msgstr "Non foi posíbel estabelecer monitorización para '%s'"
+
+#: ../src/msw/fswatcher.cpp:466
+#, c-format
+msgid "Can't monitor non-existent directory \"%s\" for changes."
+msgstr "Non se poden monitorizar os cambios no cartafol inexistente \"%s\"."
+
+#: ../src/msw/glcanvas.cpp:577 ../src/unix/glx11.cpp:507
+msgid "OpenGL 3.0 or later is not supported by the OpenGL driver."
+msgstr ""
+
+#: ../src/msw/glcanvas.cpp:601 ../src/osx/glcanvas_osx.cpp:395
+#: ../src/unix/glegl.cpp:304 ../src/unix/glx11.cpp:553
+#, fuzzy
+msgid "Couldn't create OpenGL context"
+msgstr "Non se puido crear un temporizador"
+
+#: ../src/msw/glcanvas.cpp:1294
+msgid "Failed to initialize OpenGL"
+msgstr "Erro ao inicializar OpenGL"
+
+#: ../src/msw/graphicsd2d.cpp:607
+msgid "Could not register custom DirectWrite font loader."
+msgstr ""
+
+#: ../src/msw/helpchm.cpp:48
+msgid ""
+"MS HTML Help functions are unavailable because the MS HTML Help library is "
+"not installed on this machine. Please install it."
+msgstr ""
+"As funcións de axuda HTML de MS non están dispoñíbeis porque non está "
+"instalada nesta máquina a biblioteca de Axuda HTML de MS. Por favor, "
+"instálea."
+
+#: ../src/msw/helpchm.cpp:55
+msgid "Failed to initialize MS HTML Help."
+msgstr "Erro ao inicializar a axuda HTML de MS."
+
+#: ../src/msw/iniconf.cpp:458
+#, c-format
+msgid "Can't delete the INI file '%s'"
+msgstr "Non se puido eliminar o ficheiro INI '%s'"
+
+#: ../src/msw/listctrl.cpp:995
+#, c-format
+msgid "Couldn't retrieve information about list control item %d."
+msgstr ""
+"Non se puido recuperar información sobre o elemento %d de control de listas."
+
+#: ../src/msw/mdi.cpp:170 ../src/qt/mdi.cpp:253
+msgid "&Cascade"
+msgstr "En &cadoiro"
+
+#: ../src/msw/mdi.cpp:171
+msgid "Tile &Horizontally"
+msgstr "Mosaico &horizontal"
+
+#: ../src/msw/mdi.cpp:172
+msgid "Tile &Vertically"
+msgstr "Mosaico &vertical"
+
+#: ../src/msw/mdi.cpp:174
+msgid "&Arrange Icons"
+msgstr "&Ordenar iconas"
+
+#: ../src/msw/mdi.cpp:621
+msgid "Failed to create MDI parent frame."
+msgstr "Erro ao crear marco pai MDI."
+
+#: ../src/msw/mimetype.cpp:234
+#, c-format
+msgid "Failed to create registry entry for '%s' files."
+msgstr "Erro ao crear entrada de rexistro para os ficheiros '%s'."
+
+#: ../src/msw/ole/automtn.cpp:495
+#, c-format
+msgid "Failed to find CLSID of \"%s\""
+msgstr "Non se atopou o CLSID de \"%s\""
+
+#: ../src/msw/ole/automtn.cpp:512
+#, c-format
+msgid "Failed to create an instance of \"%s\""
+msgstr "Erro ao crear unha instancia de \"%s\""
+
+#: ../src/msw/ole/automtn.cpp:552
+#, c-format
+msgid "Cannot get an active instance of \"%s\""
+msgstr "Non se pode atopar unha instancia activa de \"%s\""
+
+#: ../src/msw/ole/automtn.cpp:564
+#, c-format
+msgid "Failed to get OLE automation interface for \"%s\""
+msgstr "Erro ao crear o cartafol \"%s\""
+
+#: ../src/msw/ole/automtn.cpp:621
+msgid "Unknown name or named argument."
+msgstr "Nome ou argumento citado descoñecido."
+
+#: ../src/msw/ole/automtn.cpp:625
+msgid "Incorrect number of arguments."
+msgstr "Número de argumentos incorrecto."
+
+#: ../src/msw/ole/automtn.cpp:637
+msgid "Unknown exception"
+msgstr "Excepción descoñecida"
+
+#: ../src/msw/ole/automtn.cpp:642
+msgid "Method or property not found."
+msgstr "Non se atopou o método ou propiedade."
+
+#: ../src/msw/ole/automtn.cpp:646
+msgid "Overflow while coercing argument values."
+msgstr "Desbordamento ao forzar valores de argumentos."
+
+#: ../src/msw/ole/automtn.cpp:650
+msgid "Object implementation does not support named arguments."
+msgstr "A implementación do obxecto non admite os argumentos citados."
+
+#: ../src/msw/ole/automtn.cpp:654
+msgid "The locale ID is unknown."
+msgstr "A ID local non se coñece."
+
+#: ../src/msw/ole/automtn.cpp:658
+msgid "Missing a required parameter."
+msgstr "Falta un parámetro requerido."
+
+#: ../src/msw/ole/automtn.cpp:662
+#, c-format
+msgid "Argument %u not found."
+msgstr "Non se atopou o argumento %u."
+
+#: ../src/msw/ole/automtn.cpp:666
+#, c-format
+msgid "Type mismatch in argument %u."
+msgstr "Os tipos non coinciden no argumento %u."
+
+#: ../src/msw/ole/automtn.cpp:670
+msgid "The system cannot find the file specified."
+msgstr "O sistema non atopa o ficheiro especificado."
+
+#: ../src/msw/ole/automtn.cpp:674
+msgid "Class not registered."
+msgstr "Clase non rexistrada."
+
+#: ../src/msw/ole/automtn.cpp:678
+#, c-format
+msgid "Unknown error %08x"
+msgstr "Erro desconocido %08x"
+
+#: ../src/msw/ole/automtn.cpp:682
+#, c-format
+msgid "OLE Automation error in %s: %s"
+msgstr "Erro de automatización de OLE en %s: %s"
+
+#: ../src/msw/ole/dataobj.cpp:385
+#, c-format
+msgid "Couldn't register clipboard format '%s'."
+msgstr "Non se puido rexistrar o formato do portapapeis '%s'."
+
+#: ../src/msw/ole/dataobj.cpp:402
+#, c-format
+msgid "The clipboard format '%d' doesn't exist."
+msgstr "O formato '%d' do portapapeis non existe."
+
+#: ../src/msw/progdlg.cpp:1025
+msgid "Skip"
+msgstr "Omitir"
+
+#: ../src/msw/registry.cpp:141
+#, fuzzy, c-format
+msgid "unknown (%lu)"
+msgstr "descoñecido"
+
+#: ../src/msw/registry.cpp:409
+#, c-format
+msgid "Can't get info about registry key '%s'"
+msgstr "Non se puido obter información sobre a clave do rexistro '%s'"
+
+#: ../src/msw/registry.cpp:445
+#, c-format
+msgid "Can't open registry key '%s'"
+msgstr "Non se puido abrir a clave '%s' do rexistro"
+
+#: ../src/msw/registry.cpp:478
+#, c-format
+msgid "Can't create registry key '%s'"
+msgstr "Non se puido crear a clave do rexistro '%s'"
+
+#: ../src/msw/registry.cpp:497
+#, c-format
+msgid "Can't close registry key '%s'"
+msgstr "Non se puido pechar a clave '%s' do rexistro"
+
+#: ../src/msw/registry.cpp:512
+#, c-format
+msgid "Registry value '%s' already exists."
+msgstr "A clave do rexistro '%s' xa existe."
+
+#: ../src/msw/registry.cpp:520
+#, c-format
+msgid "Failed to rename registry value '%s' to '%s'."
+msgstr "Erro ao renomear o valor de rexistro '%s' a '%s'."
+
+#: ../src/msw/registry.cpp:575
+#, c-format
+msgid "Can't copy values of unsupported type %d."
+msgstr "Non se poden copiar valores do tipo non admitido %d."
+
+#: ../src/msw/registry.cpp:586
+#, c-format
+msgid "Registry key '%s' does not exist, cannot rename it."
+msgstr "A clave do rexistro '%s' non existe, non se puido renomear."
+
+#: ../src/msw/registry.cpp:617
+#, c-format
+msgid "Registry key '%s' already exists."
+msgstr "A clave do rexistro '%s' xa existe."
+
+#: ../src/msw/registry.cpp:625
+#, c-format
+msgid "Failed to rename the registry key '%s' to '%s'."
+msgstr "Fallo ao renomear a clave do rexistro '%s' a '%s'."
+
+#: ../src/msw/registry.cpp:670
+#, c-format
+msgid "Failed to copy the registry subkey '%s' to '%s'."
+msgstr "Fallo ao copiar a subclave do rexistro '%s' a '%s'."
+
+#: ../src/msw/registry.cpp:683
+#, c-format
+msgid "Failed to copy registry value '%s'"
+msgstr "Fallo ao copiar o valor do rexistro '%s'"
+
+#: ../src/msw/registry.cpp:692
+#, c-format
+msgid "Failed to copy the contents of registry key '%s' to '%s'."
+msgstr "Fallo ao copiar o contido da clave do rexistro '%s' a '%s'."
+
+#: ../src/msw/registry.cpp:718
+#, c-format
+msgid ""
+"Registry key '%s' is needed for normal system operation,\n"
+"deleting it will leave your system in unusable state:\n"
+"operation aborted."
+msgstr ""
+"A clave do rexistro '%s' é precisa para o funcionamiento normal do sistema,\n"
+"se se borra pode deixar o sistema inutilizábel:\n"
+"operación cancelada."
+
+#: ../src/msw/registry.cpp:754
+#, c-format
+msgid "Can't delete key '%s'"
+msgstr "Non se puido eliminar a clave '%s'"
+
+#: ../src/msw/registry.cpp:782
+#, c-format
+msgid "Can't delete value '%s' from key '%s'"
+msgstr "Non se puido eliminar o valor '%s' da clave '%s'"
+
+#: ../src/msw/registry.cpp:855 ../src/msw/registry.cpp:887
+#: ../src/msw/registry.cpp:929 ../src/msw/registry.cpp:1000
+#, c-format
+msgid "Can't read value of key '%s'"
+msgstr "Non se puido ler o valor da clave '%s'"
+
+#: ../src/msw/registry.cpp:873 ../src/msw/registry.cpp:915
+#: ../src/msw/registry.cpp:963 ../src/msw/registry.cpp:1106
+#, c-format
+msgid "Can't set value of '%s'"
+msgstr "Non se puido estabelecer o valor de '%s'"
+
+#: ../src/msw/registry.cpp:894 ../src/msw/registry.cpp:943
+#, c-format
+msgid "Registry value \"%s\" is not numeric (but of type %s)"
+msgstr ""
+
+#: ../src/msw/registry.cpp:979
+#, c-format
+msgid "Registry value \"%s\" is not binary (but of type %s)"
+msgstr ""
+
+#: ../src/msw/registry.cpp:1028
+#, c-format
+msgid "Registry value \"%s\" is not text (but of type %s)"
+msgstr ""
+
+#: ../src/msw/registry.cpp:1089
+#, c-format
+msgid "Can't read value of '%s'"
+msgstr "Non se puido ler o valor de '%s'"
+
+#: ../src/msw/registry.cpp:1157
+#, c-format
+msgid "Can't enumerate values of key '%s'"
+msgstr "Non se puido enumerar os valores da clave '%s'"
+
+#: ../src/msw/registry.cpp:1196
+#, c-format
+msgid "Can't enumerate subkeys of key '%s'"
+msgstr "Non se puido enumerar as subclaves da clave '%s'"
+
+#: ../src/msw/registry.cpp:1262
+#, c-format
+msgid ""
+"Exporting registry key: file \"%s\" already exists and won't be overwritten."
+msgstr ""
+"Exportando a clave do rexistro: o ficheiro \"%s\" xa existe e non se vai "
+"sobreescribir."
+
+#: ../src/msw/registry.cpp:1411
+#, c-format
+msgid "Can't export value of unsupported type %d."
+msgstr "Non se pode exportar o valor do tipo non admitido %d."
+
+#: ../src/msw/registry.cpp:1427
+#, c-format
+msgid "Ignoring value \"%s\" of the key \"%s\"."
+msgstr "Ignorando o valor \"%s\" da clave \"%s\"."
+
+#: ../src/msw/textctrl.cpp:596
+msgid ""
+"Impossible to create a rich edit control, using simple text control instead. "
+"Please reinstall riched32.dll"
+msgstr ""
+"Non é posíbel crear un control do editor visual, no seu lugar usouse un "
+"control de texto simple. Por favor, instale riched32.dll"
+
+#: ../src/msw/thread.cpp:522 ../src/unix/threadpsx.cpp:850
+msgid "Cannot start thread: error writing TLS."
+msgstr "Non se pode iniciar o fío de execución: erro ao escribit TLS."
+
+#: ../src/msw/thread.cpp:613
+msgid "Can't set thread priority"
+msgstr "Non se pode especificar a prioridade dos fíos de execución"
+
+#: ../src/msw/thread.cpp:649
+msgid "Can't create thread"
+msgstr "Non se pode crear o fío de execución"
+
+#: ../src/msw/thread.cpp:668
+msgid "Couldn't terminate thread"
+msgstr "Non se puido finalizar o fío de execución"
+
+#: ../src/msw/thread.cpp:799
+msgid "Cannot wait for thread termination"
+msgstr "Non se pode agardar pola finalización do fío de execución"
+
+#: ../src/msw/thread.cpp:873
+#, c-format
+msgid "Cannot suspend thread %lx"
+msgstr "Non se pode suspender o fío de execución %lx"
+
+#: ../src/msw/thread.cpp:903
+#, c-format
+msgid "Cannot resume thread %lx"
+msgstr "Non se pode retomar o fío de execución %lx"
+
+#: ../src/msw/thread.cpp:932
+msgid "Couldn't get the current thread pointer"
+msgstr "Non se atopou o punteiro do fío de execución actual"
+
+#: ../src/msw/thread.cpp:1333
+msgid ""
+"Thread module initialization failed: impossible to allocate index in thread "
+"local storage"
+msgstr ""
+"Erro ao inicar o módulo de fíos de execución: imposíbel asignar índice no "
+"almacén local de fíos"
+
+#: ../src/msw/thread.cpp:1345
+msgid ""
+"Thread module initialization failed: cannot store value in thread local "
+"storage"
+msgstr ""
+"Erro ao inicializar o módulo de fíos de execución: non se pode almacenar o "
+"valor no almacén local de fíos"
+
+#: ../src/msw/timer.cpp:133
+msgid "Couldn't create a timer"
+msgstr "Non se puido crear un temporizador"
+
+#: ../src/msw/utils.cpp:372
+msgid "can't find user's HOME, using current directory."
+msgstr ""
+"non se puido atopar o CARTAFOL INICIAL do usuario, usarase o cartafol actual."
+
+#: ../src/msw/utils.cpp:662
+#, c-format
+msgid "Failed to kill process %d"
+msgstr "Erro ao matar o proceso %d"
+
+#: ../src/msw/utils.cpp:986
+#, c-format
+msgid "Failed to load resource \"%s\"."
+msgstr "Erro ao cargar recurso \"%s\"."
+
+#: ../src/msw/utils.cpp:993
+#, c-format
+msgid "Failed to lock resource \"%s\"."
+msgstr "Erro ao bloquear recurso \"%s\"."
+
+#. TRANSLATORS: MS Windows build number
+#: ../src/msw/utils.cpp:1209
+#, c-format
+msgid "build %lu"
+msgstr "compilar %lu"
+
+#: ../src/msw/utils.cpp:1218
+msgid ", 64-bit edition"
+msgstr ", edición de 64 bits"
+
+#: ../src/msw/utilsexc.cpp:224
+msgid "Failed to create an anonymous pipe"
+msgstr "Erro ao crear canalización anónima"
+
+#: ../src/msw/utilsexc.cpp:697
+msgid "Failed to redirect the child process IO"
+msgstr "Erro ao redirecionar E/S do proceso fillo"
+
+#: ../src/msw/utilsexc.cpp:870
+#, c-format
+msgid "Execution of command '%s' failed"
+msgstr "Fallou a execución do comando '%s'"
+
+#: ../src/msw/volume.cpp:337
+msgid "Failed to load mpr.dll."
+msgstr "Erro ao cargar mpr.dll."
+
+#: ../src/msw/volume.cpp:506
+#, c-format
+msgid "Cannot read typename from '%s'!"
+msgstr "Non se pode ler a clase de '%s'!"
+
+#: ../src/msw/volume.cpp:615
+#, c-format
+msgid "Cannot load icon from '%s'."
+msgstr "Non se puido cargar a icona dende '%s'."
+
+#: ../src/msw/webview_edge.cpp:285
+msgid "This program was compiled without support for setting Edge proxy."
+msgstr ""
+
+#: ../src/msw/webview_ie.cpp:1010
+msgid "Failed to find web view emulation level in the registry"
+msgstr ""
+
+#: ../src/msw/webview_ie.cpp:1019
+msgid "Failed to set web view to modern emulation level"
+msgstr ""
+
+#: ../src/msw/webview_ie.cpp:1027
+msgid "Failed to reset web view to standard emulation level"
+msgstr ""
+
+#: ../src/msw/webview_ie.cpp:1049
+msgid "Can't run JavaScript script without a valid HTML document"
+msgstr ""
+
+#: ../src/msw/webview_ie.cpp:1056
+#, fuzzy
+msgid "Can't get the JavaScript object"
+msgstr "Non se pode especificar a prioridade dos fíos de execución"
+
+#: ../src/msw/webview_ie.cpp:1070
+#, fuzzy
+msgid "failed to evaluate"
+msgstr "Erro ao executar '%s'\n"
+
+#: ../src/osx/cocoa/filedlg.mm:412
+#, fuzzy
+msgid "File type:"
+msgstr "Teletipo"
+
+#: ../src/osx/cocoa/menu.mm:242
+#, fuzzy
+msgctxt "macOS menu name"
+msgid "Window"
+msgstr "&Xanela"
+
+#: ../src/osx/cocoa/menu.mm:259
+#, fuzzy
+msgctxt "macOS menu name"
+msgid "Help"
+msgstr "Axuda"
+
+#: ../src/osx/cocoa/menu.mm:298
+#, fuzzy
+msgctxt "macOS menu item"
+msgid "Minimize"
+msgstr "Mi&nimizar"
+
+#: ../src/osx/cocoa/menu.mm:303
+#, fuzzy
+msgctxt "macOS menu item"
+msgid "Zoom"
+msgstr "Achegar"
+
+#: ../src/osx/cocoa/menu.mm:309
+msgctxt "macOS menu item"
+msgid "Bring All to Front"
+msgstr ""
+
+#: ../src/osx/core/sound.cpp:143
+#, fuzzy, c-format
+msgid "Failed to load sound from \"%s\" (error %d)."
+msgstr "Erro ao cargar recurso \"%s\"."
+
+#: ../src/osx/fontutil.cpp:80
+#, fuzzy, c-format
+msgid "Font file \"%s\" doesn't exist."
+msgstr "O ficheiro %s non existe."
+
+#: ../src/osx/fontutil.cpp:88
+#, c-format
+msgid ""
+"Font file \"%s\" cannot be used as it is not inside the font directory "
+"\"%s\"."
+msgstr ""
+
+#: ../src/osx/menu_osx.cpp:496
+#, c-format
+msgctxt "macOS menu item"
+msgid "About %s"
+msgstr "Sobre %s"
+
+#: ../src/osx/menu_osx.cpp:499
+#, fuzzy
+msgctxt "macOS menu item"
+msgid "About..."
+msgstr "Sobre"
+
+#: ../src/osx/menu_osx.cpp:508
+msgctxt "macOS menu item"
+msgid "Preferences..."
+msgstr "Preferencias..."
+
+#: ../src/osx/menu_osx.cpp:512
+msgctxt "macOS menu item"
+msgid "Services"
+msgstr ""
+
+#: ../src/osx/menu_osx.cpp:519
+#, c-format
+msgctxt "macOS menu item"
+msgid "Hide %s"
+msgstr "Agochar %s"
+
+#: ../src/osx/menu_osx.cpp:522
+#, fuzzy
+msgctxt "macOS menu item"
+msgid "Hide Application"
+msgstr "Aplicativo"
+
+#: ../src/osx/menu_osx.cpp:526
+msgctxt "macOS menu item"
+msgid "Hide Others"
+msgstr "Agochar outros"
+
+#: ../src/osx/menu_osx.cpp:528
+msgctxt "macOS menu item"
+msgid "Show All"
+msgstr "Amosar todo"
+
+#: ../src/osx/menu_osx.cpp:534
+#, c-format
+msgctxt "macOS menu item"
+msgid "Quit %s"
+msgstr "Saír de %s"
+
+#: ../src/osx/menu_osx.cpp:537
+#, fuzzy
+msgctxt "macOS menu item"
+msgid "Quit Application"
+msgstr "Aplicativo"
+
+#: ../src/osx/webview_webkit.mm:444
+#, fuzzy
+msgid "Printing is not supported by the system web control"
+msgstr "Gzip non é compatíbel con esta versión de zlib"
+
+#: ../src/osx/webview_webkit.mm:453
+#, fuzzy
+msgid "Print operation could not be initialized"
+msgstr "Non se puido inicializar a descrición da columna."
+
+#. TRANSLATORS: Label of font point size
+#: ../src/propgrid/advprops.cpp:605
+msgid "Point Size"
+msgstr "Tamaño do punto"
+
+#. TRANSLATORS: Label of font face name
+#: ../src/propgrid/advprops.cpp:615
+msgid "Face Name"
+msgstr "Nome da faz"
+
+#. TRANSLATORS: Label of font style
+#: ../src/propgrid/advprops.cpp:623 ../src/richtext/richtextformatdlg.cpp:331
+msgid "Style"
+msgstr "Estilo"
+
+#. TRANSLATORS: Label of font weight
+#: ../src/propgrid/advprops.cpp:628
+msgid "Weight"
+msgstr "Peso"
+
+#. TRANSLATORS: Label of underlined font
+#: ../src/propgrid/advprops.cpp:633 ../src/richtext/richtextfontpage.cpp:358
+msgid "Underlined"
+msgstr "Subliñado"
+
+#. TRANSLATORS: Label of font family
+#: ../src/propgrid/advprops.cpp:637
+msgid "Family"
+msgstr "Familia"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:801
+msgid "AppWorkspace"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:802
+#, fuzzy
+msgid "ActiveBorder"
+msgstr "Bordo"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:803
+msgid "ActiveCaption"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:804
+msgid "ButtonFace"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:805
+msgid "ButtonHighlight"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:806
+msgid "ButtonShadow"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:807
+msgid "ButtonText"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:808
+msgid "CaptionText"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:809
+msgid "ControlDark"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:810
+msgid "ControlLight"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:812
+msgid "GrayText"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:813
+#, fuzzy
+msgid "Highlight"
+msgstr "clara"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:814
+#, fuzzy
+msgid "HighlightText"
+msgstr "Aliñar texto á dereita."
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:815
+#, fuzzy
+msgid "InactiveBorder"
+msgstr "Bordo"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:816
+msgid "InactiveCaption"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:817
+msgid "InactiveCaptionText"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:818
+msgid "Menu"
+msgstr "Menú"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:819
+msgid "Scrollbar"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:820
+msgid "Tooltip"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:821
+msgid "TooltipText"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:822
+#, fuzzy
+msgid "Window"
+msgstr "&Xanela"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:823
+#, fuzzy
+msgid "WindowFrame"
+msgstr "&Xanela"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:824
+#, fuzzy
+msgid "WindowText"
+msgstr "&Xanela"
+
+#. TRANSLATORS: Custom colour choice entry
+#: ../src/propgrid/advprops.cpp:825 ../src/propgrid/advprops.cpp:1532
+#: ../src/propgrid/advprops.cpp:1576
+#, fuzzy
+msgid "Custom"
+msgstr "Tamaño personalizado"
+
+#: ../src/propgrid/advprops.cpp:1558
+msgid "Black"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1559
+msgid "Maroon"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1560
+msgid "Navy"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1561
+msgid "Purple"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1562
+msgid "Teal"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1563
+msgid "Gray"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1564
+#, fuzzy
+msgid "Green"
+msgstr "Mac grego"
+
+#: ../src/propgrid/advprops.cpp:1565
+msgid "Olive"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1566
+#, fuzzy
+msgid "Brown"
+msgstr "Explorar"
+
+#: ../src/propgrid/advprops.cpp:1567
+msgid "Blue"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1568
+msgid "Fuchsia"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1569
+#, fuzzy
+msgid "Red"
+msgstr "Refacer"
+
+#: ../src/propgrid/advprops.cpp:1570
+msgid "Orange"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1571
+msgid "Silver"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1572
+msgid "Lime"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1573
+msgid "Aqua"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1574
+msgid "Yellow"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1575
+msgid "White"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1718
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Default"
+msgstr "predeterminado"
+
+#: ../src/propgrid/advprops.cpp:1719
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Arrow"
+msgstr "mañá"
+
+#: ../src/propgrid/advprops.cpp:1720
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Right Arrow"
+msgstr "Clara"
+
+#: ../src/propgrid/advprops.cpp:1721
+msgctxt "system cursor name"
+msgid "Blank"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1722
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Bullseye"
+msgstr "Estilo de viñetas"
+
+#: ../src/propgrid/advprops.cpp:1723
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Character"
+msgstr "&Código de caracter:"
+
+#: ../src/propgrid/advprops.cpp:1724
+msgctxt "system cursor name"
+msgid "Cross"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1725
+msgctxt "system cursor name"
+msgid "Hand"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1726
+msgctxt "system cursor name"
+msgid "I-Beam"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1727
+msgctxt "system cursor name"
+msgid "Left Button"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1728
+msgctxt "system cursor name"
+msgid "Magnifier"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1729
+msgctxt "system cursor name"
+msgid "Middle Button"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1730
+msgctxt "system cursor name"
+msgid "No Entry"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1731
+msgctxt "system cursor name"
+msgid "Paint Brush"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1732
+msgctxt "system cursor name"
+msgid "Pencil"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1733
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Point Left"
+msgstr "Tamaño do punto"
+
+#: ../src/propgrid/advprops.cpp:1734
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Point Right"
+msgstr "Aliñar á Dereita"
+
+#: ../src/propgrid/advprops.cpp:1735
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Question Arrow"
+msgstr "Pregunta"
+
+#: ../src/propgrid/advprops.cpp:1736
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Right Button"
+msgstr "Clara"
+
+#: ../src/propgrid/advprops.cpp:1737
+msgctxt "system cursor name"
+msgid "Sizing NE-SW"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1738
+msgctxt "system cursor name"
+msgid "Sizing N-S"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1739
+msgctxt "system cursor name"
+msgid "Sizing NW-SE"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1740
+msgctxt "system cursor name"
+msgid "Sizing W-E"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1741
+msgctxt "system cursor name"
+msgid "Sizing"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1742
+msgctxt "system cursor name"
+msgid "Spraycan"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1743
+msgctxt "system cursor name"
+msgid "Wait"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1744
+msgctxt "system cursor name"
+msgid "Watch"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1745
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Wait Arrow"
+msgstr "Clara"
+
+#: ../src/propgrid/advprops.cpp:2109
+msgid "Make a selection:"
+msgstr "Seleccionar:"
+
+#: ../src/propgrid/manager.cpp:394
+msgid "Property"
+msgstr "Propiedade"
+
+#: ../src/propgrid/manager.cpp:395
+msgid "Value"
+msgstr "Valor"
+
+#: ../src/propgrid/manager.cpp:1683
+msgid "Categorized Mode"
+msgstr "Modo categorizado"
+
+#: ../src/propgrid/manager.cpp:1709
+msgid "Alphabetic Mode"
+msgstr "Modo alfabético"
+
+#. TRANSLATORS: Name of Boolean false value
+#: ../src/propgrid/propgrid.cpp:230
+msgid "False"
+msgstr "Falso"
+
+#. TRANSLATORS: Name of Boolean true value
+#: ../src/propgrid/propgrid.cpp:232
+msgid "True"
+msgstr "Certo"
+
+#. TRANSLATORS: Text  displayed for unspecified value
+#: ../src/propgrid/propgrid.cpp:428
+msgid "Unspecified"
+msgstr "Non especificado"
+
+#. TRANSLATORS: Caption of message box displaying any property error
+#: ../src/propgrid/propgrid.cpp:3145 ../src/propgrid/propgrid.cpp:3282
+msgid "Property Error"
+msgstr "Erro de propiedade"
+
+#: ../src/propgrid/propgrid.cpp:3259
+msgid "You have entered invalid value. Press ESC to cancel editing."
+msgstr "Introduciu un valor non válido. Pulse ESC para cacear a edición."
+
+#: ../src/propgrid/propgrid.cpp:6608
+#, c-format
+msgid "Error in resource: %s"
+msgstr "Erro no recurso: %s"
+
+#: ../src/propgrid/propgridiface.cpp:377
+#, c-format
+msgid ""
+"Type operation \"%s\" failed: Property labeled \"%s\" is of type \"%s\", NOT "
+"\"%s\"."
+msgstr ""
+"O tipo de operación \"%s\" fallou: A propiedade coa etiqueta \"%s\" é de "
+"tipo \"%s\", NON \"%s\"."
+
+#: ../src/propgrid/props.cpp:159
+#, c-format
+msgid "Unknown base %d. Base 10 will be used."
+msgstr ""
+
+#: ../src/propgrid/props.cpp:324
+#, c-format
+msgid "Value must be %s or higher."
+msgstr "O valor debe ser %s ou superior."
+
+#: ../src/propgrid/props.cpp:329 ../src/propgrid/props.cpp:356
+#, c-format
+msgid "Value must be between %s and %s."
+msgstr "O valor debe estar entre %s e %s."
+
+#: ../src/propgrid/props.cpp:351
+#, c-format
+msgid "Value must be %s or less."
+msgstr "O valor debe ser %s ou inferior."
+
+#: ../src/propgrid/props.cpp:1058
+#, c-format
+msgid "Not %s"
+msgstr "Non %s"
+
+#: ../src/propgrid/props.cpp:1770
+msgid "Choose a directory:"
+msgstr "Elixir un cartafol:"
+
+#: ../src/propgrid/props.cpp:2055
+msgid "Choose a file"
+msgstr "Elixir un ficheiro"
+
+#: ../src/qt/mdi.cpp:254
+msgid "&Tile"
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:147
+#: ../src/richtext/richtextformatdlg.cpp:376
+msgid "Background"
+msgstr "Fondo"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:159
+msgid "Background &colour:"
+msgstr "Cor de fondo:"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:161
+#: ../src/richtext/richtextbackgroundpage.cpp:163
+msgid "Enables a background colour."
+msgstr "Activa unha cor de fondo."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:167
+#: ../src/richtext/richtextbackgroundpage.cpp:169
+msgid "The background colour."
+msgstr "A cor do tipo de letra."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:178
+msgid "Shadow"
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:193
+msgid "Use &shadow"
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:195
+#: ../src/richtext/richtextbackgroundpage.cpp:197
+#, fuzzy
+msgid "Enables a shadow."
+msgstr "Activa unha cor de fondo."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:211
+msgid "&Horizontal offset:"
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:218
+#: ../src/richtext/richtextbackgroundpage.cpp:220
+#, fuzzy
+msgid "The horizontal offset."
+msgstr "Mosaico &horizontal"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:224
+#: ../src/richtext/richtextbackgroundpage.cpp:227
+#: ../src/richtext/richtextbackgroundpage.cpp:228
+#: ../src/richtext/richtextbackgroundpage.cpp:247
+#: ../src/richtext/richtextbackgroundpage.cpp:250
+#: ../src/richtext/richtextbackgroundpage.cpp:251
+#: ../src/richtext/richtextbackgroundpage.cpp:287
+#: ../src/richtext/richtextbackgroundpage.cpp:290
+#: ../src/richtext/richtextbackgroundpage.cpp:291
+#: ../src/richtext/richtextbackgroundpage.cpp:314
+#: ../src/richtext/richtextbackgroundpage.cpp:317
+#: ../src/richtext/richtextbackgroundpage.cpp:318
+#: ../src/richtext/richtextborderspage.cpp:252
+#: ../src/richtext/richtextborderspage.cpp:255
+#: ../src/richtext/richtextborderspage.cpp:256
+#: ../src/richtext/richtextborderspage.cpp:286
+#: ../src/richtext/richtextborderspage.cpp:289
+#: ../src/richtext/richtextborderspage.cpp:290
+#: ../src/richtext/richtextborderspage.cpp:320
+#: ../src/richtext/richtextborderspage.cpp:323
+#: ../src/richtext/richtextborderspage.cpp:324
+#: ../src/richtext/richtextborderspage.cpp:354
+#: ../src/richtext/richtextborderspage.cpp:357
+#: ../src/richtext/richtextborderspage.cpp:358
+#: ../src/richtext/richtextborderspage.cpp:420
+#: ../src/richtext/richtextborderspage.cpp:423
+#: ../src/richtext/richtextborderspage.cpp:424
+#: ../src/richtext/richtextborderspage.cpp:454
+#: ../src/richtext/richtextborderspage.cpp:457
+#: ../src/richtext/richtextborderspage.cpp:458
+#: ../src/richtext/richtextborderspage.cpp:488
+#: ../src/richtext/richtextborderspage.cpp:491
+#: ../src/richtext/richtextborderspage.cpp:492
+#: ../src/richtext/richtextborderspage.cpp:522
+#: ../src/richtext/richtextborderspage.cpp:525
+#: ../src/richtext/richtextborderspage.cpp:526
+#: ../src/richtext/richtextborderspage.cpp:590
+#: ../src/richtext/richtextborderspage.cpp:593
+#: ../src/richtext/richtextborderspage.cpp:594
+#: ../src/richtext/richtextfontpage.cpp:177
+#: ../src/richtext/richtextmarginspage.cpp:199
+#: ../src/richtext/richtextmarginspage.cpp:201
+#: ../src/richtext/richtextmarginspage.cpp:202
+#: ../src/richtext/richtextmarginspage.cpp:224
+#: ../src/richtext/richtextmarginspage.cpp:226
+#: ../src/richtext/richtextmarginspage.cpp:227
+#: ../src/richtext/richtextmarginspage.cpp:247
+#: ../src/richtext/richtextmarginspage.cpp:249
+#: ../src/richtext/richtextmarginspage.cpp:250
+#: ../src/richtext/richtextmarginspage.cpp:272
+#: ../src/richtext/richtextmarginspage.cpp:274
+#: ../src/richtext/richtextmarginspage.cpp:275
+#: ../src/richtext/richtextmarginspage.cpp:313
+#: ../src/richtext/richtextmarginspage.cpp:315
+#: ../src/richtext/richtextmarginspage.cpp:316
+#: ../src/richtext/richtextmarginspage.cpp:338
+#: ../src/richtext/richtextmarginspage.cpp:340
+#: ../src/richtext/richtextmarginspage.cpp:341
+#: ../src/richtext/richtextmarginspage.cpp:361
+#: ../src/richtext/richtextmarginspage.cpp:363
+#: ../src/richtext/richtextmarginspage.cpp:364
+#: ../src/richtext/richtextmarginspage.cpp:386
+#: ../src/richtext/richtextmarginspage.cpp:388
+#: ../src/richtext/richtextmarginspage.cpp:389
+#: ../src/richtext/richtextsizepage.cpp:337
+#: ../src/richtext/richtextsizepage.cpp:340
+#: ../src/richtext/richtextsizepage.cpp:341
+#: ../src/richtext/richtextsizepage.cpp:371
+#: ../src/richtext/richtextsizepage.cpp:374
+#: ../src/richtext/richtextsizepage.cpp:375
+#: ../src/richtext/richtextsizepage.cpp:398
+#: ../src/richtext/richtextsizepage.cpp:401
+#: ../src/richtext/richtextsizepage.cpp:402
+#: ../src/richtext/richtextsizepage.cpp:425
+#: ../src/richtext/richtextsizepage.cpp:428
+#: ../src/richtext/richtextsizepage.cpp:429
+#: ../src/richtext/richtextsizepage.cpp:452
+#: ../src/richtext/richtextsizepage.cpp:455
+#: ../src/richtext/richtextsizepage.cpp:456
+#: ../src/richtext/richtextsizepage.cpp:479
+#: ../src/richtext/richtextsizepage.cpp:482
+#: ../src/richtext/richtextsizepage.cpp:483
+#: ../src/richtext/richtextsizepage.cpp:553
+#: ../src/richtext/richtextsizepage.cpp:556
+#: ../src/richtext/richtextsizepage.cpp:557
+#: ../src/richtext/richtextsizepage.cpp:588
+#: ../src/richtext/richtextsizepage.cpp:591
+#: ../src/richtext/richtextsizepage.cpp:592
+#: ../src/richtext/richtextsizepage.cpp:623
+#: ../src/richtext/richtextsizepage.cpp:626
+#: ../src/richtext/richtextsizepage.cpp:627
+#: ../src/richtext/richtextsizepage.cpp:658
+#: ../src/richtext/richtextsizepage.cpp:661
+#: ../src/richtext/richtextsizepage.cpp:662
+msgid "px"
+msgstr "px"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:225
+#: ../src/richtext/richtextbackgroundpage.cpp:248
+#: ../src/richtext/richtextbackgroundpage.cpp:288
+#: ../src/richtext/richtextbackgroundpage.cpp:315
+#: ../src/richtext/richtextborderspage.cpp:253
+#: ../src/richtext/richtextborderspage.cpp:287
+#: ../src/richtext/richtextborderspage.cpp:321
+#: ../src/richtext/richtextborderspage.cpp:355
+#: ../src/richtext/richtextborderspage.cpp:421
+#: ../src/richtext/richtextborderspage.cpp:455
+#: ../src/richtext/richtextborderspage.cpp:489
+#: ../src/richtext/richtextborderspage.cpp:523
+#: ../src/richtext/richtextborderspage.cpp:591
+#: ../src/richtext/richtextmarginspage.cpp:200
+#: ../src/richtext/richtextmarginspage.cpp:225
+#: ../src/richtext/richtextmarginspage.cpp:248
+#: ../src/richtext/richtextmarginspage.cpp:273
+#: ../src/richtext/richtextmarginspage.cpp:314
+#: ../src/richtext/richtextmarginspage.cpp:339
+#: ../src/richtext/richtextmarginspage.cpp:362
+#: ../src/richtext/richtextmarginspage.cpp:387
+#: ../src/richtext/richtextsizepage.cpp:338
+#: ../src/richtext/richtextsizepage.cpp:372
+#: ../src/richtext/richtextsizepage.cpp:399
+#: ../src/richtext/richtextsizepage.cpp:426
+#: ../src/richtext/richtextsizepage.cpp:453
+#: ../src/richtext/richtextsizepage.cpp:480
+#: ../src/richtext/richtextsizepage.cpp:554
+#: ../src/richtext/richtextsizepage.cpp:589
+#: ../src/richtext/richtextsizepage.cpp:624
+#: ../src/richtext/richtextsizepage.cpp:659
+msgid "cm"
+msgstr "cm"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:226
+#: ../src/richtext/richtextbackgroundpage.cpp:249
+#: ../src/richtext/richtextbackgroundpage.cpp:289
+#: ../src/richtext/richtextbackgroundpage.cpp:316
+#: ../src/richtext/richtextborderspage.cpp:254
+#: ../src/richtext/richtextborderspage.cpp:288
+#: ../src/richtext/richtextborderspage.cpp:322
+#: ../src/richtext/richtextborderspage.cpp:356
+#: ../src/richtext/richtextborderspage.cpp:422
+#: ../src/richtext/richtextborderspage.cpp:456
+#: ../src/richtext/richtextborderspage.cpp:490
+#: ../src/richtext/richtextborderspage.cpp:524
+#: ../src/richtext/richtextborderspage.cpp:592
+#: ../src/richtext/richtextfontpage.cpp:176
+#: ../src/richtext/richtextfontpage.cpp:179
+msgid "pt"
+msgstr "pt"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:229
+#: ../src/richtext/richtextbackgroundpage.cpp:231
+#: ../src/richtext/richtextbackgroundpage.cpp:252
+#: ../src/richtext/richtextbackgroundpage.cpp:254
+#: ../src/richtext/richtextbackgroundpage.cpp:292
+#: ../src/richtext/richtextbackgroundpage.cpp:294
+#: ../src/richtext/richtextbackgroundpage.cpp:319
+#: ../src/richtext/richtextbackgroundpage.cpp:321
+#, fuzzy
+msgid "Units for this value."
+msgstr "Unidades para a marxe esquerda."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:234
+#, fuzzy
+msgid "&Vertical offset:"
+msgstr "Aliñamento &vertical:"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:241
+#: ../src/richtext/richtextbackgroundpage.cpp:243
+#, fuzzy
+msgid "The vertical offset."
+msgstr "Activar aliñamento vertical."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:257
+#, fuzzy
+msgid "Shadow c&olour:"
+msgstr "Elixa unha cor"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:259
+#: ../src/richtext/richtextbackgroundpage.cpp:261
+#, fuzzy
+msgid "Enables the shadow colour."
+msgstr "Activa unha cor de fondo."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:265
+#: ../src/richtext/richtextbackgroundpage.cpp:267
+#, fuzzy
+msgid "The shadow colour."
+msgstr "A cor do tipo de letra."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:270
+msgid "Sh&adow spread:"
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:272
+#: ../src/richtext/richtextbackgroundpage.cpp:274
+#, fuzzy
+msgid "Enables the shadow spread."
+msgstr "Activar valor de anchura."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:281
+#: ../src/richtext/richtextbackgroundpage.cpp:283
+msgid "The shadow spread."
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:297
+msgid "&Blur distance:"
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:299
+#: ../src/richtext/richtextbackgroundpage.cpp:301
+#, fuzzy
+msgid "Enables the blur distance."
+msgstr "Activar valor de anchura."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:308
+#: ../src/richtext/richtextbackgroundpage.cpp:310
+msgid "The shadow blur distance."
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:324
+msgid "Opaci&ty:"
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:326
+#: ../src/richtext/richtextbackgroundpage.cpp:328
+#, fuzzy
+msgid "Enables the shadow opacity."
+msgstr "Activar valor de anchura."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:335
+#: ../src/richtext/richtextbackgroundpage.cpp:337
+msgid "The shadow opacity."
+msgstr ""
+
+#. TRANSLATORS: Rich text page units (percentage)
+#: ../src/richtext/richtextbackgroundpage.cpp:340
+#: ../src/richtext/richtextsizepage.cpp:339
+#: ../src/richtext/richtextsizepage.cpp:373
+#: ../src/richtext/richtextsizepage.cpp:400
+#: ../src/richtext/richtextsizepage.cpp:427
+#: ../src/richtext/richtextsizepage.cpp:454
+#: ../src/richtext/richtextsizepage.cpp:481
+#: ../src/richtext/richtextsizepage.cpp:555
+#: ../src/richtext/richtextsizepage.cpp:590
+#: ../src/richtext/richtextsizepage.cpp:625
+#: ../src/richtext/richtextsizepage.cpp:660
+msgid "%"
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:229
+#: ../src/richtext/richtextborderspage.cpp:387
+msgid "Border"
+msgstr "Bordo"
+
+#: ../src/richtext/richtextborderspage.cpp:242
+#: ../src/richtext/richtextborderspage.cpp:410
+#: ../src/richtext/richtextindentspage.cpp:194
+#: ../src/richtext/richtextliststylepage.cpp:384
+#: ../src/richtext/richtextmarginspage.cpp:185
+#: ../src/richtext/richtextmarginspage.cpp:299
+#: ../src/richtext/richtextsizepage.cpp:531
+#: ../src/richtext/richtextsizepage.cpp:538
+msgid "&Left:"
+msgstr "&Esquerda:"
+
+#: ../src/richtext/richtextborderspage.cpp:257
+#: ../src/richtext/richtextborderspage.cpp:259
+msgid "Units for the left border width."
+msgstr "Unidades para o ancho do bordo esquerdo."
+
+#: ../src/richtext/richtextborderspage.cpp:266
+#: ../src/richtext/richtextborderspage.cpp:268
+#: ../src/richtext/richtextborderspage.cpp:300
+#: ../src/richtext/richtextborderspage.cpp:302
+#: ../src/richtext/richtextborderspage.cpp:334
+#: ../src/richtext/richtextborderspage.cpp:336
+#: ../src/richtext/richtextborderspage.cpp:368
+#: ../src/richtext/richtextborderspage.cpp:370
+#: ../src/richtext/richtextborderspage.cpp:434
+#: ../src/richtext/richtextborderspage.cpp:436
+#: ../src/richtext/richtextborderspage.cpp:468
+#: ../src/richtext/richtextborderspage.cpp:470
+#: ../src/richtext/richtextborderspage.cpp:502
+#: ../src/richtext/richtextborderspage.cpp:504
+#: ../src/richtext/richtextborderspage.cpp:536
+#: ../src/richtext/richtextborderspage.cpp:538
+#, fuzzy
+msgid "The border line style."
+msgstr "Estilo do tipo de letra."
+
+#: ../src/richtext/richtextborderspage.cpp:276
+#: ../src/richtext/richtextborderspage.cpp:444
+#: ../src/richtext/richtextindentspage.cpp:212
+#: ../src/richtext/richtextliststylepage.cpp:402
+#: ../src/richtext/richtextmarginspage.cpp:210
+#: ../src/richtext/richtextmarginspage.cpp:324
+#: ../src/richtext/richtextsizepage.cpp:601
+#: ../src/richtext/richtextsizepage.cpp:608
+msgid "&Right:"
+msgstr "&Dereita:"
+
+#: ../src/richtext/richtextborderspage.cpp:291
+#: ../src/richtext/richtextborderspage.cpp:293
+msgid "Units for the right border width."
+msgstr "Unidades para o ancho do bordo dereito."
+
+#: ../src/richtext/richtextborderspage.cpp:310
+#: ../src/richtext/richtextborderspage.cpp:478
+#: ../src/richtext/richtextmarginspage.cpp:233
+#: ../src/richtext/richtextmarginspage.cpp:347
+#: ../src/richtext/richtextsizepage.cpp:566
+#: ../src/richtext/richtextsizepage.cpp:573
+msgid "&Top:"
+msgstr "&Arriba:"
+
+#: ../src/richtext/richtextborderspage.cpp:325
+#: ../src/richtext/richtextborderspage.cpp:327
+msgid "Units for the top border width."
+msgstr "Unidades para o ancho do bordo superior."
+
+#: ../src/richtext/richtextborderspage.cpp:344
+#: ../src/richtext/richtextborderspage.cpp:512
+#: ../src/richtext/richtextmarginspage.cpp:258
+#: ../src/richtext/richtextmarginspage.cpp:372
+#: ../src/richtext/richtextsizepage.cpp:636
+#: ../src/richtext/richtextsizepage.cpp:643
+msgid "&Bottom:"
+msgstr "&Abaixo:"
+
+#: ../src/richtext/richtextborderspage.cpp:359
+#: ../src/richtext/richtextborderspage.cpp:361
+msgid "Units for the bottom border width."
+msgstr "Unidades para o ancho do bordo inferior."
+
+#: ../src/richtext/richtextborderspage.cpp:380
+#: ../src/richtext/richtextborderspage.cpp:548
+msgid "&Synchronize values"
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:382
+#: ../src/richtext/richtextborderspage.cpp:384
+#: ../src/richtext/richtextborderspage.cpp:550
+#: ../src/richtext/richtextborderspage.cpp:552
+msgid "Check to edit all borders simultaneously."
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:397
+#: ../src/richtext/richtextborderspage.cpp:555
+msgid "Outline"
+msgstr "Esquema"
+
+#: ../src/richtext/richtextborderspage.cpp:425
+#: ../src/richtext/richtextborderspage.cpp:427
+msgid "Units for the left outline width."
+msgstr "Unidades para o ancho do esquema esquerdo."
+
+#: ../src/richtext/richtextborderspage.cpp:459
+#: ../src/richtext/richtextborderspage.cpp:461
+msgid "Units for the right outline width."
+msgstr "Unidades para o ancho do esquema dereito."
+
+#: ../src/richtext/richtextborderspage.cpp:493
+#: ../src/richtext/richtextborderspage.cpp:495
+msgid "Units for the top outline width."
+msgstr "Unidades para o ancho do esquema superior."
+
+#: ../src/richtext/richtextborderspage.cpp:527
+#: ../src/richtext/richtextborderspage.cpp:529
+msgid "Units for the bottom outline width."
+msgstr "Unidades para o ancho do esquema inferior."
+
+#: ../src/richtext/richtextborderspage.cpp:565
+#: ../src/richtext/richtextborderspage.cpp:600
+msgid "Corner"
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:574
+msgid "Corner &radius:"
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:576
+#: ../src/richtext/richtextborderspage.cpp:578
+msgid "An optional corner radius for adding rounded corners."
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:584
+#: ../src/richtext/richtextborderspage.cpp:586
+msgid "The value of the corner radius."
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:595
+#: ../src/richtext/richtextborderspage.cpp:597
+#, fuzzy
+msgid "Units for the corner radius."
+msgstr "Unidades para o recheo superior."
+
+#: ../src/richtext/richtextborderspage.cpp:609
+#: ../src/richtext/richtextsizepage.cpp:247
+#: ../src/richtext/richtextsizepage.cpp:251
+msgid "None"
+msgstr "Ningún"
+
+#: ../src/richtext/richtextborderspage.cpp:610
+msgid "Solid"
+msgstr "Sólido"
+
+#: ../src/richtext/richtextborderspage.cpp:611
+msgid "Dotted"
+msgstr "Punteado"
+
+#: ../src/richtext/richtextborderspage.cpp:612
+msgid "Dashed"
+msgstr "A trazos"
+
+#: ../src/richtext/richtextborderspage.cpp:613
+msgid "Double"
+msgstr "Dobre"
+
+#: ../src/richtext/richtextborderspage.cpp:614
+msgid "Groove"
+msgstr "Con suco"
+
+#: ../src/richtext/richtextborderspage.cpp:615
+msgid "Ridge"
+msgstr "Crista"
+
+#: ../src/richtext/richtextborderspage.cpp:616
+msgid "Inset"
+msgstr "Inserido"
+
+#: ../src/richtext/richtextborderspage.cpp:617
+msgid "Outset"
+msgstr "Externo"
+
+#: ../src/richtext/richtextbuffer.cpp:3518
+msgid "Change Style"
+msgstr "Cambiar estilo"
+
+#: ../src/richtext/richtextbuffer.cpp:3701
+msgid "Change Object Style"
+msgstr "Cambiar estilo de obxecto"
+
+#: ../src/richtext/richtextbuffer.cpp:3974
+#: ../src/richtext/richtextbuffer.cpp:8174
+msgid "Change Properties"
+msgstr "Cambiar propiedades"
+
+#: ../src/richtext/richtextbuffer.cpp:4346
+msgid "Change List Style"
+msgstr "Cambiar estilo de lista"
+
+#: ../src/richtext/richtextbuffer.cpp:4519
+msgid "Renumber List"
+msgstr "Renumerar lista"
+
+#: ../src/richtext/richtextbuffer.cpp:7867
+#: ../src/richtext/richtextbuffer.cpp:7897
+#: ../src/richtext/richtextbuffer.cpp:7939
+#: ../src/richtext/richtextctrl.cpp:1279 ../src/richtext/richtextctrl.cpp:1473
+msgid "Insert Text"
+msgstr "Inserir texto"
+
+#: ../src/richtext/richtextbuffer.cpp:8023
+#: ../src/richtext/richtextbuffer.cpp:8979
+msgid "Insert Image"
+msgstr "Inserir imaxe"
+
+#: ../src/richtext/richtextbuffer.cpp:8070
+msgid "Insert Object"
+msgstr "Inserir obxecto"
+
+#: ../src/richtext/richtextbuffer.cpp:8112
+msgid "Insert Field"
+msgstr "Inserir campo"
+
+#: ../src/richtext/richtextbuffer.cpp:8410
+msgid "Too many EndStyle calls!"
+msgstr "Demasiadas chamadas a EndStyle!"
+
+#: ../src/richtext/richtextbuffer.cpp:8785
+msgid "files"
+msgstr "ficheiros"
+
+#: ../src/richtext/richtextbuffer.cpp:9380
+msgid "standard/circle"
+msgstr "estándar/círculo"
+
+#: ../src/richtext/richtextbuffer.cpp:9381
+msgid "standard/circle-outline"
+msgstr "estándar/contorno circular"
+
+#: ../src/richtext/richtextbuffer.cpp:9382
+msgid "standard/square"
+msgstr "estándar/cadrado"
+
+#: ../src/richtext/richtextbuffer.cpp:9383
+msgid "standard/diamond"
+msgstr "estándar/rombo"
+
+#: ../src/richtext/richtextbuffer.cpp:9384
+msgid "standard/triangle"
+msgstr "estándar/triángulo"
+
+#: ../src/richtext/richtextbuffer.cpp:9423
+msgid "Box Properties"
+msgstr "Propiedades da caixa"
+
+#: ../src/richtext/richtextbuffer.cpp:10006
+msgid "Multiple Cell Properties"
+msgstr "Propiedades múltiples de cela"
+
+#: ../src/richtext/richtextbuffer.cpp:10008
+msgid "Cell Properties"
+msgstr "Propiedades de &cela"
+
+#: ../src/richtext/richtextbuffer.cpp:11256
+msgid "Set Cell Style"
+msgstr "Estabelecer estilo de celas"
+
+#: ../src/richtext/richtextbuffer.cpp:11330
+msgid "Delete Row"
+msgstr "Eliminar fila"
+
+#: ../src/richtext/richtextbuffer.cpp:11380
+msgid "Delete Column"
+msgstr "Eliminar columna"
+
+#: ../src/richtext/richtextbuffer.cpp:11431
+msgid "Add Row"
+msgstr "Engadir fila"
+
+#: ../src/richtext/richtextbuffer.cpp:11494
+msgid "Add Column"
+msgstr "Engadir columna"
+
+#: ../src/richtext/richtextbuffer.cpp:11537
+msgid "Table Properties"
+msgstr "Propiedades de táboa"
+
+#: ../src/richtext/richtextbuffer.cpp:12899
+msgid "Picture Properties"
+msgstr "Propiedades do debuxo"
+
+#: ../src/richtext/richtextbuffer.cpp:13169
+#: ../src/richtext/richtextbuffer.cpp:13279
+msgid "image"
+msgstr "imaxe"
+
+#: ../src/richtext/richtextbulletspage.cpp:145
+#: ../src/richtext/richtextliststylepage.cpp:209
+msgid "&Bullet style:"
+msgstr "&Estilo de viñeta:"
+
+#: ../src/richtext/richtextbulletspage.cpp:150
+#: ../src/richtext/richtextbulletspage.cpp:152
+#: ../src/richtext/richtextliststylepage.cpp:214
+#: ../src/richtext/richtextliststylepage.cpp:216
+msgid "The available bullet styles."
+msgstr "Os estilos de viñeta dispoñíbeis."
+
+#: ../src/richtext/richtextbulletspage.cpp:158
+#: ../src/richtext/richtextliststylepage.cpp:221
+msgid "Peri&od"
+msgstr "Perí&odo"
+
+#: ../src/richtext/richtextbulletspage.cpp:160
+#: ../src/richtext/richtextbulletspage.cpp:162
+#: ../src/richtext/richtextliststylepage.cpp:223
+#: ../src/richtext/richtextliststylepage.cpp:225
+msgid "Check to add a period after the bullet."
+msgstr "Marque para engadir un período despois da viñeta."
+
+#. TRANSLATORS: Bullet point in parentheses option
+#: ../src/richtext/richtextbulletspage.cpp:167
+#: ../src/richtext/richtextliststylepage.cpp:230
+msgid "(*)"
+msgstr "(*)"
+
+#: ../src/richtext/richtextbulletspage.cpp:169
+#: ../src/richtext/richtextbulletspage.cpp:171
+#: ../src/richtext/richtextliststylepage.cpp:232
+#: ../src/richtext/richtextliststylepage.cpp:234
+msgid "Check to enclose the bullet in parentheses."
+msgstr "Marcar para meter a viñeta entre parénteses."
+
+#. TRANSLATORS: Right parenthesis bullet point option
+#: ../src/richtext/richtextbulletspage.cpp:176
+#: ../src/richtext/richtextliststylepage.cpp:239
+msgid "*)"
+msgstr "*)"
+
+#: ../src/richtext/richtextbulletspage.cpp:178
+#: ../src/richtext/richtextbulletspage.cpp:180
+#: ../src/richtext/richtextliststylepage.cpp:241
+#: ../src/richtext/richtextliststylepage.cpp:243
+msgid "Check to add a right parenthesis."
+msgstr "Marque para engadir unha paréntese dereita."
+
+#: ../src/richtext/richtextbulletspage.cpp:185
+#: ../src/richtext/richtextliststylepage.cpp:248
+msgid "Bullet &Alignment:"
+msgstr "&Aliñamento de viñetas:"
+
+#: ../src/richtext/richtextbulletspage.cpp:190
+#: ../src/richtext/richtextliststylepage.cpp:253
+msgid "Centre"
+msgstr "Centrar"
+
+#: ../src/richtext/richtextbulletspage.cpp:194
+#: ../src/richtext/richtextbulletspage.cpp:196
+#: ../src/richtext/richtextbulletspage.cpp:217
+#: ../src/richtext/richtextbulletspage.cpp:219
+#: ../src/richtext/richtextliststylepage.cpp:257
+#: ../src/richtext/richtextliststylepage.cpp:259
+#: ../src/richtext/richtextliststylepage.cpp:278
+#: ../src/richtext/richtextliststylepage.cpp:280
+msgid "The bullet character."
+msgstr "O caracter das viñetas."
+
+#: ../src/richtext/richtextbulletspage.cpp:212
+#: ../src/richtext/richtextliststylepage.cpp:271
+msgid "&Symbol:"
+msgstr "&Símbolo:"
+
+#: ../src/richtext/richtextbulletspage.cpp:222
+#: ../src/richtext/richtextliststylepage.cpp:283
+msgid "Ch&oose..."
+msgstr "&Elixir..."
+
+#: ../src/richtext/richtextbulletspage.cpp:223
+#: ../src/richtext/richtextbulletspage.cpp:225
+#: ../src/richtext/richtextliststylepage.cpp:284
+#: ../src/richtext/richtextliststylepage.cpp:286
+msgid "Click to browse for a symbol."
+msgstr "Prema para atopar un símbolo."
+
+#: ../src/richtext/richtextbulletspage.cpp:230
+#: ../src/richtext/richtextliststylepage.cpp:291
+msgid "Symbol &font:"
+msgstr "&Símbolos:"
+
+#: ../src/richtext/richtextbulletspage.cpp:235
+#: ../src/richtext/richtextbulletspage.cpp:237
+#: ../src/richtext/richtextliststylepage.cpp:297
+msgid "Available fonts."
+msgstr "Tipos de letra dispoñíbeis."
+
+#: ../src/richtext/richtextbulletspage.cpp:242
+#: ../src/richtext/richtextliststylepage.cpp:302
+msgid "S&tandard bullet name:"
+msgstr "Nome estándar de viñeta:"
+
+#: ../src/richtext/richtextbulletspage.cpp:247
+#: ../src/richtext/richtextbulletspage.cpp:249
+#: ../src/richtext/richtextliststylepage.cpp:307
+#: ../src/richtext/richtextliststylepage.cpp:309
+msgid "A standard bullet name."
+msgstr "Un nome de viñeta estándar."
+
+#: ../src/richtext/richtextbulletspage.cpp:254
+msgid "&Number:"
+msgstr "&Número:"
+
+#: ../src/richtext/richtextbulletspage.cpp:258
+#: ../src/richtext/richtextbulletspage.cpp:260
+msgid "The list item number."
+msgstr "O número de ítem da lista."
+
+#: ../src/richtext/richtextbulletspage.cpp:266
+#: ../src/richtext/richtextbulletspage.cpp:268
+#: ../src/richtext/richtextliststylepage.cpp:475
+#: ../src/richtext/richtextliststylepage.cpp:477
+msgid "Shows a preview of the bullet settings."
+msgstr "Amosa unha vista previa da configuración das viñetas."
+
+#: ../src/richtext/richtextbulletspage.cpp:276
+#: ../src/richtext/richtextliststylepage.cpp:484
+msgid "(None)"
+msgstr "(Ningún)"
+
+#: ../src/richtext/richtextbulletspage.cpp:277
+#: ../src/richtext/richtextliststylepage.cpp:485
+msgid "Arabic"
+msgstr "Árabe"
+
+#: ../src/richtext/richtextbulletspage.cpp:278
+#: ../src/richtext/richtextliststylepage.cpp:486
+msgid "Upper case letters"
+msgstr "Maiúsculas"
+
+#: ../src/richtext/richtextbulletspage.cpp:279
+#: ../src/richtext/richtextliststylepage.cpp:487
+msgid "Lower case letters"
+msgstr "Letras minúsculas"
+
+#: ../src/richtext/richtextbulletspage.cpp:280
+#: ../src/richtext/richtextliststylepage.cpp:488
+msgid "Upper case roman numerals"
+msgstr "Números romanos en maiúscula"
+
+#: ../src/richtext/richtextbulletspage.cpp:281
+#: ../src/richtext/richtextliststylepage.cpp:489
+msgid "Lower case roman numerals"
+msgstr "Núeros romanos en minúscula"
+
+#: ../src/richtext/richtextbulletspage.cpp:282
+#: ../src/richtext/richtextliststylepage.cpp:490
+msgid "Numbered outline"
+msgstr "Esquema numerado"
+
+#: ../src/richtext/richtextbulletspage.cpp:283
+#: ../src/richtext/richtextliststylepage.cpp:491
+msgid "Symbol"
+msgstr "Símbolo"
+
+#: ../src/richtext/richtextbulletspage.cpp:284
+#: ../src/richtext/richtextliststylepage.cpp:492
+msgid "Bitmap"
+msgstr "Mapa de bits"
+
+#: ../src/richtext/richtextbulletspage.cpp:285
+#: ../src/richtext/richtextliststylepage.cpp:493
+msgid "Standard"
+msgstr "Estándar"
+
+#: ../src/richtext/richtextbulletspage.cpp:287
+#: ../src/richtext/richtextliststylepage.cpp:495
+msgid "*"
+msgstr "*"
+
+#: ../src/richtext/richtextbulletspage.cpp:288
+#: ../src/richtext/richtextliststylepage.cpp:496
+msgid "-"
+msgstr "-"
+
+#: ../src/richtext/richtextbulletspage.cpp:289
+#: ../src/richtext/richtextliststylepage.cpp:497
+msgid ">"
+msgstr ">"
+
+#: ../src/richtext/richtextbulletspage.cpp:290
+#: ../src/richtext/richtextliststylepage.cpp:498
+msgid "+"
+msgstr "+"
+
+#: ../src/richtext/richtextbulletspage.cpp:291
+#: ../src/richtext/richtextliststylepage.cpp:499
+msgid "~"
+msgstr "~"
+
+#: ../src/richtext/richtextctrl.cpp:859
+msgid "Drag"
+msgstr "Arrastrar"
+
+#: ../src/richtext/richtextctrl.cpp:1338 ../src/richtext/richtextctrl.cpp:1559
+msgid "Delete Text"
+msgstr "Eliminar texto"
+
+#: ../src/richtext/richtextctrl.cpp:1537
+msgid "Remove Bullet"
+msgstr "Eliminar viñeta"
+
+#: ../src/richtext/richtextctrl.cpp:3070
+msgid "The text couldn't be saved."
+msgstr "Non se puido gardar o texto."
+
+#: ../src/richtext/richtextctrl.cpp:3644
+msgid "Replace"
+msgstr "Substituír"
+
+#: ../src/richtext/richtextfontpage.cpp:146
+#: ../src/richtext/richtextsymboldlg.cpp:384
+msgid "&Font:"
+msgstr "&Tipo de letra:"
+
+#: ../src/richtext/richtextfontpage.cpp:150
+#: ../src/richtext/richtextfontpage.cpp:152
+msgid "Type a font name."
+msgstr "Inserir unha familia de tipo de letra."
+
+#: ../src/richtext/richtextfontpage.cpp:158
+msgid "&Size:"
+msgstr "&Tamaño:"
+
+#: ../src/richtext/richtextfontpage.cpp:165
+#: ../src/richtext/richtextfontpage.cpp:167
+msgid "Type a size in points."
+msgstr "Inserir un tamaño en puntos."
+
+#: ../src/richtext/richtextfontpage.cpp:180
+#: ../src/richtext/richtextfontpage.cpp:182
+msgid "The font size units, points or pixels."
+msgstr "As unidades de tamaño de letra: puntos ou píxeles."
+
+#: ../src/richtext/richtextfontpage.cpp:189
+#: ../src/richtext/richtextfontpage.cpp:191
+msgid "Lists the available fonts."
+msgstr "Enumera os tipos de letra dispoñíbeis."
+
+#: ../src/richtext/richtextfontpage.cpp:196
+#: ../src/richtext/richtextfontpage.cpp:198
+msgid "Lists font sizes in points."
+msgstr "Fai un listado de tamaños de letra en puntos."
+
+#: ../src/richtext/richtextfontpage.cpp:207
+msgid "Font st&yle:"
+msgstr "&Estilo de tipo de letra:"
+
+#: ../src/richtext/richtextfontpage.cpp:212
+#: ../src/richtext/richtextfontpage.cpp:214
+msgid "Select regular or italic style."
+msgstr "Seleccionar normal ou itálica."
+
+#: ../src/richtext/richtextfontpage.cpp:220
+msgid "Font &weight:"
+msgstr "&Grosor do tipo de letra:"
+
+#: ../src/richtext/richtextfontpage.cpp:225
+#: ../src/richtext/richtextfontpage.cpp:227
+msgid "Select regular or bold."
+msgstr "Seleccionar normal ou negriña."
+
+#: ../src/richtext/richtextfontpage.cpp:233
+msgid "&Underlining:"
+msgstr "&Subliñado:"
+
+#: ../src/richtext/richtextfontpage.cpp:238
+#: ../src/richtext/richtextfontpage.cpp:240
+msgid "Select underlining or no underlining."
+msgstr "Seleccionar subliñado ou non subliñado."
+
+#: ../src/richtext/richtextfontpage.cpp:248
+msgid "&Colour:"
+msgstr "C&or:"
+
+#: ../src/richtext/richtextfontpage.cpp:253
+#: ../src/richtext/richtextfontpage.cpp:255
+msgid "Click to change the text colour."
+msgstr "Prema para cambiar a cor do texto."
+
+#: ../src/richtext/richtextfontpage.cpp:261
+msgid "&Bg colour:"
+msgstr "Cor de &fondo:"
+
+#: ../src/richtext/richtextfontpage.cpp:266
+#: ../src/richtext/richtextfontpage.cpp:268
+msgid "Click to change the text background colour."
+msgstr "Prema para cambiar a cor de fondo."
+
+#: ../src/richtext/richtextfontpage.cpp:276
+#: ../src/richtext/richtextfontpage.cpp:278
+msgid "Check to show a line through the text."
+msgstr "Marcar para riscado."
+
+#: ../src/richtext/richtextfontpage.cpp:281
+msgid "Ca&pitals"
+msgstr "Ma&iúsculas"
+
+#: ../src/richtext/richtextfontpage.cpp:283
+#: ../src/richtext/richtextfontpage.cpp:285
+msgid "Check to show the text in capitals."
+msgstr "Marcar para letras maiúsculas."
+
+#: ../src/richtext/richtextfontpage.cpp:288
+msgid "Small C&apitals"
+msgstr "Versaletas"
+
+#: ../src/richtext/richtextfontpage.cpp:290
+#: ../src/richtext/richtextfontpage.cpp:292
+msgid "Check to show the text in small capitals."
+msgstr "Marcar para versaletas."
+
+#: ../src/richtext/richtextfontpage.cpp:295
+msgid "Supe&rscript"
+msgstr "Supe&ríndice"
+
+#: ../src/richtext/richtextfontpage.cpp:297
+#: ../src/richtext/richtextfontpage.cpp:299
+msgid "Check to show the text in superscript."
+msgstr "Marcar para amosar superíndices."
+
+#: ../src/richtext/richtextfontpage.cpp:302
+msgid "Subscrip&t"
+msgstr "Su&bíndice"
+
+#: ../src/richtext/richtextfontpage.cpp:304
+#: ../src/richtext/richtextfontpage.cpp:306
+msgid "Check to show the text in subscript."
+msgstr "Marcar para amosar subíndices."
+
+#: ../src/richtext/richtextfontpage.cpp:312
+msgid "Rig&ht-to-left"
+msgstr ""
+
+#: ../src/richtext/richtextfontpage.cpp:314
+#: ../src/richtext/richtextfontpage.cpp:316
+#, fuzzy
+msgid "Check to indicate right-to-left text layout."
+msgstr "Prema para cambiar a cor do texto."
+
+#: ../src/richtext/richtextfontpage.cpp:319
+msgid "Suppress hyphe&nation"
+msgstr ""
+
+#: ../src/richtext/richtextfontpage.cpp:321
+#: ../src/richtext/richtextfontpage.cpp:323
+msgid "Check to suppress hyphenation."
+msgstr ""
+
+#: ../src/richtext/richtextfontpage.cpp:329
+#: ../src/richtext/richtextfontpage.cpp:331
+msgid "Shows a preview of the font settings."
+msgstr "Amosa unha vista previa da configuración de tipos de letra."
+
+#: ../src/richtext/richtextfontpage.cpp:348
+#: ../src/richtext/richtextfontpage.cpp:352
+#: ../src/richtext/richtextfontpage.cpp:356
+#: ../src/richtext/richtextformatdlg.cpp:873
+#: ../src/richtext/richtextindentspage.cpp:273
+#: ../src/richtext/richtextindentspage.cpp:285
+#: ../src/richtext/richtextindentspage.cpp:286
+#: ../src/richtext/richtextindentspage.cpp:310
+#: ../src/richtext/richtextindentspage.cpp:325
+#: ../src/richtext/richtextliststylepage.cpp:451
+#: ../src/richtext/richtextliststylepage.cpp:463
+#: ../src/richtext/richtextliststylepage.cpp:464
+msgid "(none)"
+msgstr "(ningún)"
+
+#: ../src/richtext/richtextfontpage.cpp:349
+#: ../src/richtext/richtextfontpage.cpp:353
+msgid "Regular"
+msgstr "Regular"
+
+#: ../src/richtext/richtextfontpage.cpp:357
+msgid "Not underlined"
+msgstr "Non subliñado"
+
+#: ../src/richtext/richtextformatdlg.cpp:341
+msgid "Indents && Spacing"
+msgstr "Sangría && Espazamento"
+
+#: ../src/richtext/richtextformatdlg.cpp:346
+msgid "Tabs"
+msgstr "Lapelas"
+
+#: ../src/richtext/richtextformatdlg.cpp:351
+msgid "Bullets"
+msgstr "Viñetas"
+
+#: ../src/richtext/richtextformatdlg.cpp:356
+msgid "List Style"
+msgstr "Estilo de lista"
+
+#: ../src/richtext/richtextformatdlg.cpp:366
+#: ../src/richtext/richtextmarginspage.cpp:170
+msgid "Margins"
+msgstr "Marxes"
+
+#: ../src/richtext/richtextformatdlg.cpp:371
+msgid "Borders"
+msgstr "Bordos"
+
+#: ../src/richtext/richtextformatdlg.cpp:765
+msgid "Colour"
+msgstr "Cor"
+
+#: ../src/richtext/richtextindentspage.cpp:127
+#: ../src/richtext/richtextliststylepage.cpp:322
+msgid "&Alignment"
+msgstr "&Aliñamento"
+
+#: ../src/richtext/richtextindentspage.cpp:138
+#: ../src/richtext/richtextliststylepage.cpp:331
+msgid "&Left"
+msgstr "&Esquerda"
+
+#: ../src/richtext/richtextindentspage.cpp:140
+#: ../src/richtext/richtextindentspage.cpp:142
+#: ../src/richtext/richtextliststylepage.cpp:333
+#: ../src/richtext/richtextliststylepage.cpp:335
+msgid "Left-align text."
+msgstr "Aliñar o texto á esquerda."
+
+#: ../src/richtext/richtextindentspage.cpp:145
+#: ../src/richtext/richtextliststylepage.cpp:338
+msgid "&Right"
+msgstr "&Dereita"
+
+#: ../src/richtext/richtextindentspage.cpp:147
+#: ../src/richtext/richtextindentspage.cpp:149
+#: ../src/richtext/richtextliststylepage.cpp:340
+#: ../src/richtext/richtextliststylepage.cpp:342
+msgid "Right-align text."
+msgstr "Aliñar texto á dereita."
+
+#: ../src/richtext/richtextindentspage.cpp:152
+#: ../src/richtext/richtextliststylepage.cpp:345
+msgid "&Justified"
+msgstr "&Xustificado"
+
+#: ../src/richtext/richtextindentspage.cpp:154
+#: ../src/richtext/richtextindentspage.cpp:156
+#: ../src/richtext/richtextliststylepage.cpp:347
+#: ../src/richtext/richtextliststylepage.cpp:349
+msgid "Justify text left and right."
+msgstr "Xustificar texto á esquerda e á dereita."
+
+#: ../src/richtext/richtextindentspage.cpp:159
+#: ../src/richtext/richtextliststylepage.cpp:352
+msgid "Cen&tred"
+msgstr "Cen&trado"
+
+#: ../src/richtext/richtextindentspage.cpp:161
+#: ../src/richtext/richtextindentspage.cpp:163
+#: ../src/richtext/richtextliststylepage.cpp:354
+#: ../src/richtext/richtextliststylepage.cpp:356
+msgid "Centre text."
+msgstr "Centrar texto."
+
+#: ../src/richtext/richtextindentspage.cpp:166
+#: ../src/richtext/richtextliststylepage.cpp:359
+msgid "&Indeterminate"
+msgstr "&Indeterminado"
+
+#: ../src/richtext/richtextindentspage.cpp:168
+#: ../src/richtext/richtextindentspage.cpp:170
+#: ../src/richtext/richtextliststylepage.cpp:361
+#: ../src/richtext/richtextliststylepage.cpp:363
+msgid "Use the current alignment setting."
+msgstr "Usar a configuración de aliñamento actual."
+
+#: ../src/richtext/richtextindentspage.cpp:183
+#: ../src/richtext/richtextliststylepage.cpp:375
+msgid "&Indentation (tenths of a mm)"
+msgstr "&Sangría (décimas de mm)"
+
+#: ../src/richtext/richtextindentspage.cpp:198
+#: ../src/richtext/richtextindentspage.cpp:200
+#: ../src/richtext/richtextliststylepage.cpp:388
+#: ../src/richtext/richtextliststylepage.cpp:390
+msgid "The left indent."
+msgstr "A sangría esquerda."
+
+#: ../src/richtext/richtextindentspage.cpp:203
+#: ../src/richtext/richtextliststylepage.cpp:393
+msgid "Left (&first line):"
+msgstr "Esquerda (&primeira liña):"
+
+#: ../src/richtext/richtextindentspage.cpp:207
+#: ../src/richtext/richtextindentspage.cpp:209
+#: ../src/richtext/richtextliststylepage.cpp:397
+#: ../src/richtext/richtextliststylepage.cpp:399
+msgid "The first line indent."
+msgstr "A sangría de primeira liña."
+
+#: ../src/richtext/richtextindentspage.cpp:216
+#: ../src/richtext/richtextindentspage.cpp:218
+#: ../src/richtext/richtextliststylepage.cpp:406
+#: ../src/richtext/richtextliststylepage.cpp:408
+msgid "The right indent."
+msgstr "A sangría dereita."
+
+#: ../src/richtext/richtextindentspage.cpp:221
+msgid "&Outline level:"
+msgstr "&Nivel do esquema:"
+
+#: ../src/richtext/richtextindentspage.cpp:226
+#: ../src/richtext/richtextindentspage.cpp:228
+msgid "The outline level."
+msgstr "O nivel de esquema."
+
+#: ../src/richtext/richtextindentspage.cpp:241
+#: ../src/richtext/richtextliststylepage.cpp:420
+msgid "&Spacing (tenths of a mm)"
+msgstr "&Espazamento (décimas de mm)"
+
+#: ../src/richtext/richtextindentspage.cpp:252
+msgid "&Before a paragraph:"
+msgstr "&Antes dun parágrafo:"
+
+#: ../src/richtext/richtextindentspage.cpp:256
+#: ../src/richtext/richtextindentspage.cpp:258
+#: ../src/richtext/richtextliststylepage.cpp:433
+#: ../src/richtext/richtextliststylepage.cpp:435
+msgid "The spacing before the paragraph."
+msgstr "O espazamento antes do parágrafo."
+
+#: ../src/richtext/richtextindentspage.cpp:261
+msgid "&After a paragraph:"
+msgstr "&Despois dun parágrafo:"
+
+#: ../src/richtext/richtextindentspage.cpp:266
+#: ../src/richtext/richtextliststylepage.cpp:442
+#: ../src/richtext/richtextliststylepage.cpp:444
+msgid "The spacing after the paragraph."
+msgstr "O espazamento despois do parágrafo."
+
+#: ../src/richtext/richtextindentspage.cpp:269
+msgid "L&ine spacing:"
+msgstr "Espazamento entre &liñas:"
+
+#: ../src/richtext/richtextindentspage.cpp:274
+#: ../src/richtext/richtextliststylepage.cpp:452
+msgid "Single"
+msgstr "Simple"
+
+#: ../src/richtext/richtextindentspage.cpp:275
+#: ../src/richtext/richtextliststylepage.cpp:453
+msgid "1.1"
+msgstr "1.1"
+
+#: ../src/richtext/richtextindentspage.cpp:276
+#: ../src/richtext/richtextliststylepage.cpp:454
+msgid "1.2"
+msgstr "1.2"
+
+#: ../src/richtext/richtextindentspage.cpp:277
+#: ../src/richtext/richtextliststylepage.cpp:455
+msgid "1.3"
+msgstr "1.3"
+
+#: ../src/richtext/richtextindentspage.cpp:278
+#: ../src/richtext/richtextliststylepage.cpp:456
+msgid "1.4"
+msgstr "1.4"
+
+#: ../src/richtext/richtextindentspage.cpp:279
+#: ../src/richtext/richtextliststylepage.cpp:457
+msgid "1.5"
+msgstr "1.5"
+
+#: ../src/richtext/richtextindentspage.cpp:280
+#: ../src/richtext/richtextliststylepage.cpp:458
+msgid "1.6"
+msgstr "1.6"
+
+#: ../src/richtext/richtextindentspage.cpp:281
+#: ../src/richtext/richtextliststylepage.cpp:459
+msgid "1.7"
+msgstr "1.7"
+
+#: ../src/richtext/richtextindentspage.cpp:282
+#: ../src/richtext/richtextliststylepage.cpp:460
+msgid "1.8"
+msgstr "1.8"
+
+#: ../src/richtext/richtextindentspage.cpp:283
+#: ../src/richtext/richtextliststylepage.cpp:461
+msgid "1.9"
+msgstr "1.9"
+
+#: ../src/richtext/richtextindentspage.cpp:284
+#: ../src/richtext/richtextliststylepage.cpp:462
+msgid "2"
+msgstr "2"
+
+#: ../src/richtext/richtextindentspage.cpp:287
+#: ../src/richtext/richtextindentspage.cpp:289
+#: ../src/richtext/richtextliststylepage.cpp:465
+#: ../src/richtext/richtextliststylepage.cpp:467
+msgid "The line spacing."
+msgstr "O espazamento de liñas."
+
+#: ../src/richtext/richtextindentspage.cpp:292
+msgid "&Page Break"
+msgstr "&Quebra de páxina"
+
+#: ../src/richtext/richtextindentspage.cpp:294
+#: ../src/richtext/richtextindentspage.cpp:296
+msgid "Inserts a page break before the paragraph."
+msgstr "Insire un salto de páxina antes do parágrafo."
+
+#: ../src/richtext/richtextindentspage.cpp:302
+#: ../src/richtext/richtextindentspage.cpp:304
+msgid "Shows a preview of the paragraph settings."
+msgstr "Amosa unha vista previa da configuración dos parágrafos."
+
+#: ../src/richtext/richtextliststylepage.cpp:182
+msgid "&List level:"
+msgstr "&Nivel de lista:"
+
+#: ../src/richtext/richtextliststylepage.cpp:186
+#: ../src/richtext/richtextliststylepage.cpp:188
+msgid "Selects the list level to edit."
+msgstr "Selecciona o nivel de lista para editar."
+
+#: ../src/richtext/richtextliststylepage.cpp:193
+msgid "&Font for Level..."
+msgstr "&Tipo de letra para nivel..."
+
+#: ../src/richtext/richtextliststylepage.cpp:194
+#: ../src/richtext/richtextliststylepage.cpp:196
+msgid "Click to choose the font for this level."
+msgstr "Prema para elixir o tipo de letra para este nivel."
+
+#: ../src/richtext/richtextliststylepage.cpp:312
+msgid "Bullet style"
+msgstr "Estilo de viñetas"
+
+#: ../src/richtext/richtextliststylepage.cpp:429
+msgid "Before a paragraph:"
+msgstr "Antes dun parágrafo:"
+
+#: ../src/richtext/richtextliststylepage.cpp:438
+msgid "After a paragraph:"
+msgstr "Despois dun parágrafo:"
+
+#: ../src/richtext/richtextliststylepage.cpp:447
+msgid "Line spacing:"
+msgstr "Espazamento entre liñas:"
+
+#: ../src/richtext/richtextliststylepage.cpp:470
+msgid "Spacing"
+msgstr "Espazamento"
+
+#: ../src/richtext/richtextmarginspage.cpp:193
+#: ../src/richtext/richtextmarginspage.cpp:195
+msgid "The left margin size."
+msgstr "A marxe esquerda."
+
+#: ../src/richtext/richtextmarginspage.cpp:203
+#: ../src/richtext/richtextmarginspage.cpp:205
+msgid "Units for the left margin."
+msgstr "Unidades para a marxe esquerda."
+
+#: ../src/richtext/richtextmarginspage.cpp:218
+#: ../src/richtext/richtextmarginspage.cpp:220
+msgid "The right margin size."
+msgstr "A marxe dereita."
+
+#: ../src/richtext/richtextmarginspage.cpp:228
+#: ../src/richtext/richtextmarginspage.cpp:230
+msgid "Units for the right margin."
+msgstr "Unidades para a marxe dereita."
+
+#: ../src/richtext/richtextmarginspage.cpp:241
+#: ../src/richtext/richtextmarginspage.cpp:243
+msgid "The top margin size."
+msgstr "A marxe superior."
+
+#: ../src/richtext/richtextmarginspage.cpp:251
+#: ../src/richtext/richtextmarginspage.cpp:253
+msgid "Units for the top margin."
+msgstr "Unidades para a marxe superior."
+
+#: ../src/richtext/richtextmarginspage.cpp:266
+#: ../src/richtext/richtextmarginspage.cpp:268
+msgid "The bottom margin size."
+msgstr "A marxe inferior."
+
+#: ../src/richtext/richtextmarginspage.cpp:276
+#: ../src/richtext/richtextmarginspage.cpp:278
+msgid "Units for the bottom margin."
+msgstr "Unidades para a marxe inferior."
+
+#: ../src/richtext/richtextmarginspage.cpp:284
+msgid "Padding"
+msgstr "Recheo"
+
+#: ../src/richtext/richtextmarginspage.cpp:307
+#: ../src/richtext/richtextmarginspage.cpp:309
+msgid "The left padding size."
+msgstr "O recheo esquerdo."
+
+#: ../src/richtext/richtextmarginspage.cpp:317
+#: ../src/richtext/richtextmarginspage.cpp:319
+msgid "Units for the left padding."
+msgstr "Unidades para o recheo esquerdo."
+
+#: ../src/richtext/richtextmarginspage.cpp:332
+#: ../src/richtext/richtextmarginspage.cpp:334
+msgid "The right padding size."
+msgstr "O recheo dereito."
+
+#: ../src/richtext/richtextmarginspage.cpp:342
+#: ../src/richtext/richtextmarginspage.cpp:344
+msgid "Units for the right padding."
+msgstr "Unidades para o recheo dereito."
+
+#: ../src/richtext/richtextmarginspage.cpp:355
+#: ../src/richtext/richtextmarginspage.cpp:357
+msgid "The top padding size."
+msgstr "O recheo superior."
+
+#: ../src/richtext/richtextmarginspage.cpp:365
+#: ../src/richtext/richtextmarginspage.cpp:367
+msgid "Units for the top padding."
+msgstr "Unidades para o recheo superior."
+
+#: ../src/richtext/richtextmarginspage.cpp:380
+#: ../src/richtext/richtextmarginspage.cpp:382
+msgid "The bottom padding size."
+msgstr "O recheo inferior."
+
+#: ../src/richtext/richtextmarginspage.cpp:390
+#: ../src/richtext/richtextmarginspage.cpp:392
+msgid "Units for the bottom padding."
+msgstr "Unidades para o recheo inferior."
+
+#: ../src/richtext/richtextprint.cpp:592
+msgid " Preview"
+msgstr " Previsualización"
+
+#: ../src/richtext/richtextsizepage.cpp:228
+msgid "Floating"
+msgstr "Flotante"
+
+#: ../src/richtext/richtextsizepage.cpp:243
+msgid "&Floating mode:"
+msgstr "&Modo flotante:"
+
+#: ../src/richtext/richtextsizepage.cpp:252
+#: ../src/richtext/richtextsizepage.cpp:254
+msgid "How the object will float relative to the text."
+msgstr "Como debe flotar o obxecto con relación ao texto."
+
+#: ../src/richtext/richtextsizepage.cpp:265
+msgid "Alignment"
+msgstr "Aliñado"
+
+#: ../src/richtext/richtextsizepage.cpp:277
+msgid "&Vertical alignment:"
+msgstr "Aliñamento &vertical:"
+
+#: ../src/richtext/richtextsizepage.cpp:279
+#: ../src/richtext/richtextsizepage.cpp:281
+msgid "Enable vertical alignment."
+msgstr "Activar aliñamento vertical."
+
+#: ../src/richtext/richtextsizepage.cpp:286
+msgid "Centred"
+msgstr "Centrado"
+
+#: ../src/richtext/richtextsizepage.cpp:290
+#: ../src/richtext/richtextsizepage.cpp:292
+msgid "Vertical alignment."
+msgstr "Aliñamento vertical."
+
+#: ../src/richtext/richtextsizepage.cpp:316
+#: ../src/richtext/richtextsizepage.cpp:323
+msgid "&Width:"
+msgstr "&Anchura:"
+
+#: ../src/richtext/richtextsizepage.cpp:318
+#: ../src/richtext/richtextsizepage.cpp:320
+msgid "Enable the width value."
+msgstr "Activar valor de anchura."
+
+#: ../src/richtext/richtextsizepage.cpp:331
+#: ../src/richtext/richtextsizepage.cpp:333
+msgid "The object width."
+msgstr "O ancho do obxecto."
+
+#: ../src/richtext/richtextsizepage.cpp:342
+#: ../src/richtext/richtextsizepage.cpp:344
+msgid "Units for the object width."
+msgstr "Unidades para o ancho do obxecto."
+
+#: ../src/richtext/richtextsizepage.cpp:350
+#: ../src/richtext/richtextsizepage.cpp:357
+msgid "&Height:"
+msgstr "&Altura:"
+
+#: ../src/richtext/richtextsizepage.cpp:352
+#: ../src/richtext/richtextsizepage.cpp:354
+#: ../src/richtext/richtextsizepage.cpp:464
+#: ../src/richtext/richtextsizepage.cpp:466
+msgid "Enable the height value."
+msgstr "Activar valor de altura."
+
+#: ../src/richtext/richtextsizepage.cpp:365
+#: ../src/richtext/richtextsizepage.cpp:367
+msgid "The object height."
+msgstr "A altura do obxecto."
+
+#: ../src/richtext/richtextsizepage.cpp:376
+#: ../src/richtext/richtextsizepage.cpp:378
+msgid "Units for the object height."
+msgstr "Unidades para a altura do obxecto."
+
+#: ../src/richtext/richtextsizepage.cpp:381
+msgid "Min width:"
+msgstr "Ancho mínimo:"
+
+#: ../src/richtext/richtextsizepage.cpp:383
+#: ../src/richtext/richtextsizepage.cpp:385
+msgid "Enable the minimum width value."
+msgstr "Activar o ancho mínimo."
+
+#: ../src/richtext/richtextsizepage.cpp:392
+#: ../src/richtext/richtextsizepage.cpp:394
+msgid "The object minimum width."
+msgstr "O ancho mínimo do obxecto."
+
+#: ../src/richtext/richtextsizepage.cpp:403
+#: ../src/richtext/richtextsizepage.cpp:405
+msgid "Units for the minimum object width."
+msgstr "Unidades para o ancho mínimo de obxecto."
+
+#: ../src/richtext/richtextsizepage.cpp:408
+msgid "Min height:"
+msgstr "Altura mín.:"
+
+#: ../src/richtext/richtextsizepage.cpp:410
+#: ../src/richtext/richtextsizepage.cpp:412
+msgid "Enable the minimum height value."
+msgstr "Activar o valor mínimo de altura."
+
+#: ../src/richtext/richtextsizepage.cpp:419
+#: ../src/richtext/richtextsizepage.cpp:421
+msgid "The object minimum height."
+msgstr "A altura mínima do obxecto."
+
+#: ../src/richtext/richtextsizepage.cpp:430
+#: ../src/richtext/richtextsizepage.cpp:432
+msgid "Units for the minimum object height."
+msgstr "Unidades para a altura mínima de obxecto."
+
+#: ../src/richtext/richtextsizepage.cpp:435
+msgid "Max width:"
+msgstr "Ancho máx.:"
+
+#: ../src/richtext/richtextsizepage.cpp:437
+#: ../src/richtext/richtextsizepage.cpp:439
+msgid "Enable the maximum width value."
+msgstr "Activar o ancho máximo."
+
+#: ../src/richtext/richtextsizepage.cpp:446
+#: ../src/richtext/richtextsizepage.cpp:448
+msgid "The object maximum width."
+msgstr "O ancho máximo do obxecto."
+
+#: ../src/richtext/richtextsizepage.cpp:457
+#: ../src/richtext/richtextsizepage.cpp:459
+msgid "Units for the maximum object width."
+msgstr "Unidades para o ancho máximo de obxecto."
+
+#: ../src/richtext/richtextsizepage.cpp:462
+msgid "Max height:"
+msgstr "Altura máx.:"
+
+#: ../src/richtext/richtextsizepage.cpp:473
+#: ../src/richtext/richtextsizepage.cpp:475
+msgid "The object maximum height."
+msgstr "A altura máxima do obxecto."
+
+#: ../src/richtext/richtextsizepage.cpp:484
+#: ../src/richtext/richtextsizepage.cpp:486
+msgid "Units for the maximum object height."
+msgstr "Unidades para a altura máxima de obxecto."
+
+#: ../src/richtext/richtextsizepage.cpp:495
+msgid "Position"
+msgstr "Posición"
+
+#: ../src/richtext/richtextsizepage.cpp:513
+msgid "&Position mode:"
+msgstr "Modo de &posición:"
+
+#: ../src/richtext/richtextsizepage.cpp:517
+#: ../src/richtext/richtextsizepage.cpp:522
+msgid "Static"
+msgstr "Estático"
+
+#: ../src/richtext/richtextsizepage.cpp:518
+msgid "Relative"
+msgstr "Relativo"
+
+#: ../src/richtext/richtextsizepage.cpp:519
+msgid "Absolute"
+msgstr "Absoluto"
+
+#: ../src/richtext/richtextsizepage.cpp:520
+msgid "Fixed"
+msgstr "Fixo"
+
+#: ../src/richtext/richtextsizepage.cpp:533
+#: ../src/richtext/richtextsizepage.cpp:535
+#: ../src/richtext/richtextsizepage.cpp:547
+#: ../src/richtext/richtextsizepage.cpp:549
+msgid "The left position."
+msgstr "A posición esquerda."
+
+#: ../src/richtext/richtextsizepage.cpp:558
+#: ../src/richtext/richtextsizepage.cpp:560
+msgid "Units for the left position."
+msgstr "Unidades para a posición esquerda."
+
+#: ../src/richtext/richtextsizepage.cpp:568
+#: ../src/richtext/richtextsizepage.cpp:570
+#: ../src/richtext/richtextsizepage.cpp:582
+#: ../src/richtext/richtextsizepage.cpp:584
+msgid "The top position."
+msgstr "A posición superior."
+
+#: ../src/richtext/richtextsizepage.cpp:593
+#: ../src/richtext/richtextsizepage.cpp:595
+msgid "Units for the top position."
+msgstr "Unidades para a posición superior."
+
+#: ../src/richtext/richtextsizepage.cpp:603
+#: ../src/richtext/richtextsizepage.cpp:605
+#: ../src/richtext/richtextsizepage.cpp:617
+#: ../src/richtext/richtextsizepage.cpp:619
+msgid "The right position."
+msgstr "A posición dereita."
+
+#: ../src/richtext/richtextsizepage.cpp:628
+#: ../src/richtext/richtextsizepage.cpp:630
+msgid "Units for the right position."
+msgstr "Unidades para a posición dereita."
+
+#: ../src/richtext/richtextsizepage.cpp:638
+#: ../src/richtext/richtextsizepage.cpp:640
+#: ../src/richtext/richtextsizepage.cpp:652
+#: ../src/richtext/richtextsizepage.cpp:654
+msgid "The bottom position."
+msgstr "A posición inferior."
+
+#: ../src/richtext/richtextsizepage.cpp:663
+#: ../src/richtext/richtextsizepage.cpp:665
+msgid "Units for the bottom position."
+msgstr "Unidades para a posición inferior."
+
+#: ../src/richtext/richtextsizepage.cpp:671
+msgid "&Move the object to:"
+msgstr "&Mover o obxecto a:"
+
+#: ../src/richtext/richtextsizepage.cpp:674
+msgid "&Previous Paragraph"
+msgstr "&Parágrafo anterior"
+
+#: ../src/richtext/richtextsizepage.cpp:675
+#: ../src/richtext/richtextsizepage.cpp:677
+msgid "Moves the object to the previous paragraph."
+msgstr "Move o obxecto ao parágrafo anterior."
+
+#: ../src/richtext/richtextsizepage.cpp:680
+msgid "&Next Paragraph"
+msgstr "&Parágrafo seguinte"
+
+#: ../src/richtext/richtextsizepage.cpp:681
+#: ../src/richtext/richtextsizepage.cpp:683
+msgid "Moves the object to the next paragraph."
+msgstr "Move o obxecto ao seguinte parágrafo."
+
+#: ../src/richtext/richtextstyledlg.cpp:193
+msgid "&Styles:"
+msgstr "&Estilos:"
+
+#: ../src/richtext/richtextstyledlg.cpp:197
+#: ../src/richtext/richtextstyledlg.cpp:199
+msgid "The available styles."
+msgstr "Os estilos dispoñíbeis."
+
+#: ../src/richtext/richtextstyledlg.cpp:205
+#: ../src/richtext/richtextstyledlg.cpp:217
+msgid " "
+msgstr " "
+
+#: ../src/richtext/richtextstyledlg.cpp:209
+#: ../src/richtext/richtextstyledlg.cpp:211
+msgid "The style preview."
+msgstr "A previsualización do estilo."
+
+#: ../src/richtext/richtextstyledlg.cpp:220
+msgid "New &Character Style..."
+msgstr "Novo estilo de &caracter..."
+
+#: ../src/richtext/richtextstyledlg.cpp:221
+#: ../src/richtext/richtextstyledlg.cpp:223
+msgid "Click to create a new character style."
+msgstr "Prema para crear un novo estilo de caracteres."
+
+#: ../src/richtext/richtextstyledlg.cpp:226
+msgid "New &Paragraph Style..."
+msgstr "Novo estilo de &parágrafo..."
+
+#: ../src/richtext/richtextstyledlg.cpp:227
+#: ../src/richtext/richtextstyledlg.cpp:229
+msgid "Click to create a new paragraph style."
+msgstr "Prema para crear un novo estilo de parágrafo."
+
+#: ../src/richtext/richtextstyledlg.cpp:232
+msgid "New &List Style..."
+msgstr "Novo estilo de &lista..."
+
+#: ../src/richtext/richtextstyledlg.cpp:233
+#: ../src/richtext/richtextstyledlg.cpp:235
+msgid "Click to create a new list style."
+msgstr "Prema para crear un novo estilo de lista."
+
+#: ../src/richtext/richtextstyledlg.cpp:238
+msgid "New &Box Style..."
+msgstr "Novo estilo de &caixa..."
+
+#: ../src/richtext/richtextstyledlg.cpp:239
+#: ../src/richtext/richtextstyledlg.cpp:241
+msgid "Click to create a new box style."
+msgstr "Prema para crear un novo estilo de caixa."
+
+#: ../src/richtext/richtextstyledlg.cpp:246
+msgid "&Apply Style"
+msgstr "&Aplicar estilo"
+
+#: ../src/richtext/richtextstyledlg.cpp:247
+#: ../src/richtext/richtextstyledlg.cpp:249
+msgid "Click to apply the selected style."
+msgstr "Prema para aplicar o estilo seleccionado."
+
+#: ../src/richtext/richtextstyledlg.cpp:252
+msgid "&Rename Style..."
+msgstr "&Renomear estilo..."
+
+#: ../src/richtext/richtextstyledlg.cpp:253
+#: ../src/richtext/richtextstyledlg.cpp:255
+msgid "Click to rename the selected style."
+msgstr "Prema para renomear o estilo seleccionado."
+
+#: ../src/richtext/richtextstyledlg.cpp:258
+msgid "&Edit Style..."
+msgstr "&Editar estilo..."
+
+#: ../src/richtext/richtextstyledlg.cpp:259
+#: ../src/richtext/richtextstyledlg.cpp:261
+msgid "Click to edit the selected style."
+msgstr "Prema para editar o estilo seleccionado."
+
+#: ../src/richtext/richtextstyledlg.cpp:264
+msgid "&Delete Style..."
+msgstr "&Eliminar estilo..."
+
+#: ../src/richtext/richtextstyledlg.cpp:265
+#: ../src/richtext/richtextstyledlg.cpp:267
+msgid "Click to delete the selected style."
+msgstr "Prema para eliminar o estilo seleccionado."
+
+#: ../src/richtext/richtextstyledlg.cpp:274
+#: ../src/richtext/richtextstyledlg.cpp:276
+msgid "Click to close this window."
+msgstr "Prema para pechar esta xanela."
+
+#: ../src/richtext/richtextstyledlg.cpp:282
+msgid "&Restart numbering"
+msgstr "&Reiniciar numeración"
+
+#: ../src/richtext/richtextstyledlg.cpp:284
+#: ../src/richtext/richtextstyledlg.cpp:286
+msgid "Check to restart numbering."
+msgstr "Marcar para reiniciar numeración."
+
+#: ../src/richtext/richtextstyledlg.cpp:601
+msgid "Enter a character style name"
+msgstr "Inserir un nome de estilo de caracter"
+
+#: ../src/richtext/richtextstyledlg.cpp:601
+#: ../src/richtext/richtextstyledlg.cpp:606
+#: ../src/richtext/richtextstyledlg.cpp:649
+#: ../src/richtext/richtextstyledlg.cpp:654
+#: ../src/richtext/richtextstyledlg.cpp:815
+#: ../src/richtext/richtextstyledlg.cpp:820
+#: ../src/richtext/richtextstyledlg.cpp:888
+#: ../src/richtext/richtextstyledlg.cpp:896
+#: ../src/richtext/richtextstyledlg.cpp:929
+#: ../src/richtext/richtextstyledlg.cpp:934
+msgid "New Style"
+msgstr "Novo estilo"
+
+#: ../src/richtext/richtextstyledlg.cpp:606
+#: ../src/richtext/richtextstyledlg.cpp:654
+#: ../src/richtext/richtextstyledlg.cpp:820
+#: ../src/richtext/richtextstyledlg.cpp:896
+#: ../src/richtext/richtextstyledlg.cpp:934
+msgid "Sorry, that name is taken. Please choose another."
+msgstr "Ese nome xa existe. Por favor, elixa outro."
+
+#: ../src/richtext/richtextstyledlg.cpp:649
+msgid "Enter a paragraph style name"
+msgstr "Inserir un nome de estilos de parágrafo"
+
+#: ../src/richtext/richtextstyledlg.cpp:777
+#, c-format
+msgid "Delete style %s?"
+msgstr "Eliminar estilo %s?"
+
+#: ../src/richtext/richtextstyledlg.cpp:777
+msgid "Delete Style"
+msgstr "Eliminar estilo"
+
+#: ../src/richtext/richtextstyledlg.cpp:815
+msgid "Enter a list style name"
+msgstr "Inserir un nome de estilos de lista"
+
+#: ../src/richtext/richtextstyledlg.cpp:888
+msgid "Enter a new style name"
+msgstr "Inserir un novo nome de estilo"
+
+#: ../src/richtext/richtextstyledlg.cpp:929
+msgid "Enter a box style name"
+msgstr "Inserir un nome de estilo de caixa"
+
+#: ../src/richtext/richtextstylepage.cpp:109
+#: ../src/richtext/richtextstylepage.cpp:111
+msgid "The style name."
+msgstr "O nome do estilo."
+
+#: ../src/richtext/richtextstylepage.cpp:114
+msgid "&Based on:"
+msgstr "&Baseado en:"
+
+#: ../src/richtext/richtextstylepage.cpp:119
+#: ../src/richtext/richtextstylepage.cpp:121
+msgid "The style on which this style is based."
+msgstr "O estilo no que se basea este estilo."
+
+#: ../src/richtext/richtextstylepage.cpp:124
+msgid "&Next style:"
+msgstr "&Seguinte estilo:"
+
+#: ../src/richtext/richtextstylepage.cpp:129
+#: ../src/richtext/richtextstylepage.cpp:131
+msgid "The default style for the next paragraph."
+msgstr "O estilo predeterminado para o seguinte parágrafo."
+
+#: ../src/richtext/richtextstyles.cpp:1057
+msgid "All styles"
+msgstr "Todos os estilos"
+
+#: ../src/richtext/richtextstyles.cpp:1058
+msgid "Paragraph styles"
+msgstr "Estilos de parágrafo"
+
+#: ../src/richtext/richtextstyles.cpp:1059
+msgid "Character styles"
+msgstr "Estilos de caracter"
+
+#: ../src/richtext/richtextstyles.cpp:1060
+msgid "List styles"
+msgstr "Estilos de lista"
+
+#: ../src/richtext/richtextstyles.cpp:1061
+msgid "Box styles"
+msgstr "Estilos de caixa"
+
+#: ../src/richtext/richtextsymboldlg.cpp:389
+#: ../src/richtext/richtextsymboldlg.cpp:391
+msgid "The font from which to take the symbol."
+msgstr "O tipo de letra do que tomar o símbolo."
+
+#: ../src/richtext/richtextsymboldlg.cpp:396
+msgid "&Subset:"
+msgstr "&Subconxunto:"
+
+#: ../src/richtext/richtextsymboldlg.cpp:401
+#: ../src/richtext/richtextsymboldlg.cpp:403
+msgid "Shows a Unicode subset."
+msgstr "Amosa un subconxunto de Unicode."
+
+#: ../src/richtext/richtextsymboldlg.cpp:412
+msgid "xxxx"
+msgstr "xxxx"
+
+#: ../src/richtext/richtextsymboldlg.cpp:417
+msgid "&Character code:"
+msgstr "&Código de caracter:"
+
+#: ../src/richtext/richtextsymboldlg.cpp:421
+#: ../src/richtext/richtextsymboldlg.cpp:423
+msgid "The character code."
+msgstr "O código do caracter."
+
+#: ../src/richtext/richtextsymboldlg.cpp:428
+msgid "&From:"
+msgstr "&Dende:"
+
+#: ../src/richtext/richtextsymboldlg.cpp:433
+#: ../src/richtext/richtextsymboldlg.cpp:434
+#: ../src/richtext/richtextsymboldlg.cpp:435
+msgid "Unicode"
+msgstr "Unicode"
+
+#: ../src/richtext/richtextsymboldlg.cpp:436
+#: ../src/richtext/richtextsymboldlg.cpp:438
+msgid "The range to show."
+msgstr "O rango para amosar."
+
+#: ../src/richtext/richtextsymboldlg.cpp:444
+msgid "Insert"
+msgstr "Inserir"
+
+#: ../src/richtext/richtextsymboldlg.cpp:478
+msgid "(Normal text)"
+msgstr "(Texto normal)"
+
+#: ../src/richtext/richtexttabspage.cpp:109
+msgid "&Position (tenths of a mm):"
+msgstr "&Posición (décimas de mm):"
+
+#: ../src/richtext/richtexttabspage.cpp:113
+#: ../src/richtext/richtexttabspage.cpp:115
+msgid "The tab position."
+msgstr "A posición da lapela."
+
+#: ../src/richtext/richtexttabspage.cpp:119
+msgid "The tab positions."
+msgstr "As posicións das lapelas."
+
+#: ../src/richtext/richtexttabspage.cpp:132
+#: ../src/richtext/richtexttabspage.cpp:134
+msgid "Click to create a new tab position."
+msgstr "Prema para crear unha nova tabulación."
+
+#: ../src/richtext/richtexttabspage.cpp:138
+#: ../src/richtext/richtexttabspage.cpp:140
+msgid "Click to delete the selected tab position."
+msgstr "Prema para eliminar a tabulación seleccionada."
+
+#: ../src/richtext/richtexttabspage.cpp:143
+msgid "Delete A&ll"
+msgstr "Eliminar &todo"
+
+#: ../src/richtext/richtexttabspage.cpp:144
+#: ../src/richtext/richtexttabspage.cpp:146
+msgid "Click to delete all tab positions."
+msgstr "Prema para eliminar todas as tabulacións."
+
+#: ../src/univ/theme.cpp:110
+msgid "Failed to initialize GUI: no built-in themes found."
+msgstr ""
+"Erro ao inicializar interface gráfica de usuario: non se atoparon temas "
+"incorporados."
+
+#: ../src/univ/themes/gtk.cpp:521
+msgid "GTK+ theme"
+msgstr "Tema GTK+"
+
+#: ../src/univ/themes/metal.cpp:164
+msgid "Metal theme"
+msgstr "Presentación Metal"
+
+#: ../src/univ/themes/mono.cpp:512
+msgid "Simple monochrome theme"
+msgstr "Tema simple monocromo"
+
+#: ../src/univ/themes/win32.cpp:1098
+msgid "Win32 theme"
+msgstr "Tema de Win32"
+
+#: ../src/univ/themes/win32.cpp:3743
+msgid "&Restore"
+msgstr "&Restabelecer"
+
+#: ../src/univ/themes/win32.cpp:3744
+msgid "&Move"
+msgstr "&Mover"
+
+#: ../src/univ/themes/win32.cpp:3746
+msgid "&Size"
+msgstr "&Tamaño"
+
+#: ../src/univ/themes/win32.cpp:3748
+msgid "Mi&nimize"
+msgstr "Mi&nimizar"
+
+#: ../src/univ/themes/win32.cpp:3750
+msgid "Ma&ximize"
+msgstr "Ma&ximizar"
+
+#: ../src/univ/themes/win32.cpp:3752
+msgid "Alt+"
+msgstr "Alt+"
+
+#: ../src/unix/appunix.cpp:178
+msgid "Failed to install signal handler"
+msgstr "Erro ao instalar manexador de sinal"
+
+#: ../src/unix/dialup.cpp:351
+msgid "Already dialling ISP."
+msgstr "Chamando ao provedor de internet."
+
+#: ../src/unix/dlunix.cpp:93
+#, fuzzy
+msgid "Failed to unload shared library"
+msgstr "Erro ao cargar a biblioteca compartida '%s'"
+
+#: ../src/unix/dlunix.cpp:121
+msgid "Unknown dynamic library error"
+msgstr "Erro descoñecido de biblioteca dinámica"
+
+#: ../src/unix/epolldispatcher.cpp:84
+msgid "Failed to create epoll descriptor"
+msgstr "Erro ao crear descritor epoll"
+
+#: ../src/unix/epolldispatcher.cpp:103
+msgid "Error closing epoll descriptor"
+msgstr "Erro ao pechar o descritor epoll"
+
+#: ../src/unix/epolldispatcher.cpp:116
+#, c-format
+msgid "Failed to add descriptor %d to epoll descriptor %d"
+msgstr "Erro ao engadir descritor %d ao descritor epoll %d"
+
+#: ../src/unix/epolldispatcher.cpp:136
+#, c-format
+msgid "Failed to modify descriptor %d in epoll descriptor %d"
+msgstr "Erro ao modificar o descritor %d no descritor epoll %d"
+
+#: ../src/unix/epolldispatcher.cpp:155
+#, c-format
+msgid "Failed to unregister descriptor %d from epoll descriptor %d"
+msgstr ""
+"Non foi posíbel cancelar o rexistro do descritor %d dende o descritor epoll "
+"%d"
+
+#: ../src/unix/epolldispatcher.cpp:213
+#, c-format
+msgid "Waiting for IO on epoll descriptor %d failed"
+msgstr "Houbo un erro na espera de E/S no descritor epoll %d"
+
+#: ../src/unix/fswatcher_inotify.cpp:71
+msgid "Unable to create inotify instance"
+msgstr "Non se puido crear instancia de inotify"
+
+#: ../src/unix/fswatcher_inotify.cpp:94
+msgid "Unable to close inotify instance"
+msgstr "Non se puido pechar instancia de inotify"
+
+#: ../src/unix/fswatcher_inotify.cpp:106
+msgid "Unable to add inotify watch"
+msgstr "Non se puido engadir monitorización de inotify"
+
+#: ../src/unix/fswatcher_inotify.cpp:138
+#, fuzzy, c-format
+msgid "Unable to remove inotify watch %i"
+msgstr "Non é posíbel eliminar monitorización de inotify"
+
+#: ../src/unix/fswatcher_inotify.cpp:271
+#, c-format
+msgid "Unexpected event for \"%s\": no matching watch descriptor."
+msgstr ""
+"Evento non esperado para \"%s\" non hai descritor de vixilancia que concorde."
+
+#: ../src/unix/fswatcher_inotify.cpp:320
+#, c-format
+msgid "Invalid inotify event for \"%s\""
+msgstr "Evento de inotify incorrecto para \"%s\""
+
+#: ../src/unix/fswatcher_inotify.cpp:553
+msgid "Unable to read from inotify descriptor"
+msgstr "Non foi posíbel ler dende o descritor de inotify"
+
+#: ../src/unix/fswatcher_inotify.cpp:558
+msgid "EOF while reading from inotify descriptor"
+msgstr "EOF ao ler dende descritor inotify"
+
+#: ../src/unix/fswatcher_kqueue.cpp:114
+msgid "Unable to create kqueue instance"
+msgstr "Non se puido crear instancia de kqueue"
+
+#: ../src/unix/fswatcher_kqueue.cpp:131
+msgid "Error closing kqueue instance"
+msgstr "Erro ao pechar instancia de kqueue"
+
+#: ../src/unix/fswatcher_kqueue.cpp:153
+msgid "Unable to add kqueue watch"
+msgstr "Non se puido engadir monitorización de kqueue"
+
+#: ../src/unix/fswatcher_kqueue.cpp:170
+msgid "Unable to remove kqueue watch"
+msgstr "Non se puido eliminar a monitorización de kqueue"
+
+#: ../src/unix/fswatcher_kqueue.cpp:202
+msgid "Unable to get events from kqueue"
+msgstr "Non se puideron tomar eventos do kqueue"
+
+#: ../src/unix/mediactrl.cpp:966
+#, c-format
+msgid "Media playback error: %s"
+msgstr "Erro na reprodución multimedia: %s"
+
+#: ../src/unix/mediactrl.cpp:1228
+#, c-format
+msgid "Failed to prepare playing \"%s\"."
+msgstr "Erro ao preparar reprodución \"%s\"."
+
+#: ../src/unix/snglinst.cpp:164
+#, c-format
+msgid "Failed to write to lock file '%s'"
+msgstr "Non se puido escribir no ficheiro de bloqueo '%s'"
+
+#: ../src/unix/snglinst.cpp:177
+#, c-format
+msgid "Failed to set permissions on lock file '%s'"
+msgstr "Erro ao estabelecer permisos no ficheiro de bloqueo '%s'"
+
+#: ../src/unix/snglinst.cpp:194
+#, c-format
+msgid "Failed to lock the lock file '%s'"
+msgstr "Erro ao bloquear o ficheiro de bloqueo '%s'"
+
+#: ../src/unix/snglinst.cpp:237
+#, c-format
+msgid "Failed to inspect the lock file '%s'"
+msgstr "Erro ao inspeccionar ficheiro de bloqueo '%s'"
+
+#: ../src/unix/snglinst.cpp:242
+#, c-format
+msgid "Lock file '%s' has incorrect owner."
+msgstr "O ficheiro de bloqueo '%s' ten un propietario incorrecto."
+
+#: ../src/unix/snglinst.cpp:247
+#, c-format
+msgid "Lock file '%s' has incorrect permissions."
+msgstr "O ficheiro de bloqueo '%s' ten permisos incorrectos."
+
+#: ../src/unix/snglinst.cpp:265
+msgid "Failed to access lock file."
+msgstr "Erro ao acceder ao ficheiro de bloqueo."
+
+#: ../src/unix/snglinst.cpp:274
+msgid "Failed to read PID from lock file."
+msgstr "Erro ao ler PID dende o ficheiro de bloqueo."
+
+#: ../src/unix/snglinst.cpp:284
+#, c-format
+msgid "Failed to remove stale lock file '%s'."
+msgstr "Erro ao eliminar o ficheiro de bloqueo obsoleto '%s'."
+
+#: ../src/unix/snglinst.cpp:297
+#, c-format
+msgid "Deleted stale lock file '%s'."
+msgstr "Fichero de bloqueo antiguo '%s' eliminado."
+
+#: ../src/unix/snglinst.cpp:308
+#, c-format
+msgid "Invalid lock file '%s'."
+msgstr "Ficheiro de bloqueo '%s' incorrecto."
+
+#: ../src/unix/snglinst.cpp:324
+#, c-format
+msgid "Failed to remove lock file '%s'"
+msgstr "Erro ao eliminar o ficheiro de bloqueo '%s'"
+
+#: ../src/unix/snglinst.cpp:330
+#, c-format
+msgid "Failed to unlock lock file '%s'"
+msgstr "Non se puido desbloquear o ficheiro de bloqueo '%s'"
+
+#: ../src/unix/snglinst.cpp:336
+#, c-format
+msgid "Failed to close lock file '%s'"
+msgstr "Erro ao pechar o ficheiro de bloqueo '%s'"
+
+#: ../src/unix/sound.cpp:77
+msgid "No sound"
+msgstr "Sen son"
+
+#: ../src/unix/sound.cpp:364
+msgid "Unable to play sound asynchronously."
+msgstr "Non se puido reproducir o son de xeito asíncrono."
+
+#: ../src/unix/sound.cpp:458
+#, c-format
+msgid "Couldn't load sound data from '%s'."
+msgstr "Non se puideron cargar os datos de son dende '%s'."
+
+#: ../src/unix/sound.cpp:465
+#, c-format
+msgid "Sound file '%s' is in unsupported format."
+msgstr "O ficheiro de son '%s' está nun formato non compatíbel."
+
+#: ../src/unix/sound.cpp:480
+msgid "Sound data are in unsupported format."
+msgstr "Os datos de son están nun formato non compatíbel."
+
+#: ../src/unix/sound_sdl.cpp:226
+#, c-format
+msgid "Couldn't open audio: %s"
+msgstr "Non se puido abrir o audio: %s"
+
+#: ../src/unix/threadpsx.cpp:1033
+msgid "Cannot retrieve thread scheduling policy."
+msgstr ""
+"Non se pode recuperar a política de planificación de fíos de execución."
+
+#: ../src/unix/threadpsx.cpp:1058
+#, c-format
+msgid "Cannot get priority range for scheduling policy %d."
+msgstr ""
+"Non se pode obter un rango de prioridade para a política de planificación %d."
+
+#: ../src/unix/threadpsx.cpp:1066
+msgid "Thread priority setting is ignored."
+msgstr "Ignorouse a configuración de prioridade de fíos de execución."
+
+#: ../src/unix/threadpsx.cpp:1221
+msgid ""
+"Failed to join a thread, potential memory leak detected - please restart the "
+"program"
+msgstr ""
+"Erro ao conectar cun fío de execución, detectada perda potencial de memoria. "
+"Por favor, reinicie o programa"
+
+#: ../src/unix/threadpsx.cpp:1352
+#, c-format
+msgid "Failed to set thread concurrency level to %lu"
+msgstr "Erro ao estabelecer nivel de concurrencia de fíos de execución en %lu"
+
+#: ../src/unix/threadpsx.cpp:1481
+#, c-format
+msgid "Failed to set thread priority %d."
+msgstr "Non se puido estabelecer a prioridade de fíos de execución %d."
+
+#: ../src/unix/threadpsx.cpp:1666
+msgid "Failed to terminate a thread."
+msgstr "Non se puido terminar un fío de execución."
+
+#: ../src/unix/threadpsx.cpp:1893
+msgid "Thread module initialization failed: failed to create thread key"
+msgstr ""
+"Erro ao inicar o módulo de fíos de execución: non se puido crear clave de "
+"fíos"
+
+#: ../src/unix/utilsunx.cpp:340
+msgid "Impossible to get child process input"
+msgstr "Non é posíbel obter a entrada do proceso fillo"
+
+#: ../src/unix/utilsunx.cpp:390
+msgid "Can't write to child process's stdin"
+msgstr "Non se pode escribir na entrada estándar do proceso fillo"
+
+#: ../src/unix/utilsunx.cpp:644
+#, c-format
+msgid "Failed to execute '%s'\n"
+msgstr "Erro ao executar '%s'\n"
+
+#: ../src/unix/utilsunx.cpp:678
+msgid "Fork failed"
+msgstr "Erro ao facer fork"
+
+#: ../src/unix/utilsunx.cpp:701
+msgid "Failed to set process priority"
+msgstr "Erro ao estabelecer prioridade de procesos"
+
+#: ../src/unix/utilsunx.cpp:712
+msgid "Failed to redirect child process input/output"
+msgstr "Erro ao redirecionar proceso fillo de entrada/saída"
+
+#: ../src/unix/utilsunx.cpp:816
+msgid "Failed to set up non-blocking pipe, the program might hang."
+msgstr ""
+"Non foi posíbel configurar canalización non bloqueante, o programa pode "
+"ficar trabado."
+
+#: ../src/unix/utilsunx.cpp:1023
+msgid "Cannot get the hostname"
+msgstr "Non se puido obter o nome de máquina"
+
+#: ../src/unix/utilsunx.cpp:1059
+msgid "Cannot get the official hostname"
+msgstr "Non se puido obter o nome oficial da máquina"
+
+#: ../src/unix/wakeuppipe.cpp:49
+msgid "Failed to create wake up pipe used by event loop."
+msgstr "Erro ao crear canalización de activación usada por bucle de eventos."
+
+#: ../src/unix/wakeuppipe.cpp:56
+msgid "Failed to switch wake up pipe to non-blocking mode"
+msgstr "Erro ao cambiar canalización de activación a modo non bloqueante"
+
+#: ../src/unix/wakeuppipe.cpp:117
+msgid "Failed to read from wake-up pipe"
+msgstr "Erro ao ler dende a canalización de activación"
+
+#: ../src/x11/app.cpp:124
+#, c-format
+msgid "Invalid geometry specification '%s'"
+msgstr "Especificación de xeometría incorrecta: '%s'"
+
+#: ../src/x11/app.cpp:167
+msgid "wxWidgets could not open display. Exiting."
+msgstr "wxWidgets non puido abrir a visualización. Saíndo."
+
+#: ../src/x11/utils.cpp:169
+#, c-format
+msgid "Failed to close the display \"%s\""
+msgstr "Erro ao pechar a presentación \"%s\""
+
+#: ../src/x11/utils.cpp:188
+#, c-format
+msgid "Failed to open display \"%s\"."
+msgstr "Erro ao abrir a presentación \"%s\"."
+
+#: ../src/xml/xml.cpp:868
+#, c-format
+msgid "XML parsing error: '%s' at line %d"
+msgstr "Erro de análise de XML: '%s' na liña %d"
+
+#: ../src/xrc/xh_propgrid.cpp:239
+#, fuzzy, c-format
+msgid "Page %i"
+msgstr "Páxina %d"
+
+#: ../src/xrc/xmlres.cpp:448
+#, c-format
+msgid "Cannot load resources from '%s'."
+msgstr "Non se poden cargar os recursos de '%s'."
+
+#: ../src/xrc/xmlres.cpp:799
+#, c-format
+msgid "Cannot open resources file '%s'."
+msgstr "Non se pode abrir o ficheiro de recursos '%s'."
+
+#: ../src/xrc/xmlres.cpp:806
+#, c-format
+msgid "Cannot load resources from file '%s'."
+msgstr "Non se poden cargar os recursos dende o ficheiro '%s'."
+
+#: ../src/xrc/xmlres.cpp:2767
+#, fuzzy, c-format
+msgid "Creating %s \"%s\" failed."
+msgstr "Fallou a extración de '%s' a '%s'."
+
+#~ msgctxt "keyboard key"
+#~ msgid "Alt+"
+#~ msgstr "Alt+"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Ctrl+"
+#~ msgstr "Ctrl+"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Shift+"
+#~ msgstr "Shift+"
+
+#~ msgctxt "keyboard key"
+#~ msgid "RawCtrl+"
+#~ msgstr "Ctrl+"
+
+#~ msgid "Unsupported clipboard format."
+#~ msgstr "Formato de portapapeis non compatíbel."
+
+#~ msgid "Background colour"
+#~ msgstr "Cor de fondo"
+
+#~ msgid "Font:"
+#~ msgstr "Tipo de letra:"
+
+#~ msgid "Size:"
+#~ msgstr "Tamaño:"
+
+#~ msgid "The font size in points."
+#~ msgstr "O tamaño en puntos."
+
+#~ msgid "Style:"
+#~ msgstr "Estilo:"
+
+#~ msgid "Check to make the font bold."
+#~ msgstr "Marcar para letra grosa."
+
+#~ msgid "Check to make the font italic."
+#~ msgstr "Marcar para letra cursiva."
+
+#~ msgid "Check to make the font underlined."
+#~ msgstr "Marcar para subliñado."
+
+#~ msgid "Colour:"
+#~ msgstr "Cor:"
+
+#~ msgid "Click to change the font colour."
+#~ msgstr "Prema para cambiar a cor da letra."
+
+#~ msgid "Shows a preview of the font."
+#~ msgstr "Amosa unha vista previa do tipo de letra."
+
+#~ msgid "Click to cancel changes to the font."
+#~ msgstr "Prema para cancelar cambios no tipo de letra."
+
+#~ msgid "Click to confirm changes to the font."
+#~ msgstr "Prema para confirmar cambios no tipo de letra."
+
+#~ msgid "<Any>"
+#~ msgstr "<Calquera>"
+
+#~ msgid "<Any Roman>"
+#~ msgstr "<Any Roman>"
+
+#~ msgid "<Any Decorative>"
+#~ msgstr "<Any Decorative>"
+
+#~ msgid "<Any Modern>"
+#~ msgstr "<Any Modern>"
+
+#~ msgid "<Any Script>"
+#~ msgstr "<Any Script>"
+
+#~ msgid "<Any Swiss>"
+#~ msgstr "<Any Swiss>"
+
+#~ msgid "<Any Teletype>"
+#~ msgstr "<Any Teletype>"
+
+#~ msgid "Printing "
+#~ msgstr "Imprimindo "
+
+#~ msgid "Failed to insert text in the control."
+#~ msgstr "Erro ao obter o cartafol de traballo."
+
+#~ msgid "Please choose a valid font."
+#~ msgstr "Escolla un tipo de letra correcto."
+
+#, c-format
+#~ msgid "Failed to display HTML document in %s encoding"
+#~ msgstr "Erro ao amosar o documento HTML coa codificación %s"
+
+#, c-format
+#~ msgid "wxWidgets could not open display for '%s': exiting."
+#~ msgstr "wxWidgets non puido abrir a visualización para '%s': saíndo."
+
+#~ msgid "Filter"
+#~ msgstr "Filtro"
+
+#~ msgid "Directories"
+#~ msgstr "Cartafoles"
+
+#~ msgid "Files"
+#~ msgstr "Ficheiros"
+
+#~ msgid "Selection"
+#~ msgstr "Selección"
+
+#~ msgid "conversion to 8-bit encoding failed"
+#~ msgstr "fallou a conversión á codificación de 8 bits"
+
+#, fuzzy
+#~ msgid "failed to retrieve execution result"
+#~ msgstr "Erro ao recuperar texto de mensaxe de erro RAS"
+
+#~ msgid "&Save as"
+#~ msgstr "Gardar &como"
+
+#, fuzzy
+#~ msgid "'%s' doesn't consist only of valid characters"
+#~ msgstr "'%s' debe conter só caracteres alfabéticos."
+
+#~ msgid "'%s' should be numeric."
+#~ msgstr "'%s' debe ser numérico."
+
+#~ msgid "'%s' should only contain ASCII characters."
+#~ msgstr "'%s' debe conter só caracteres ASCII."
+
+#~ msgid "'%s' should only contain alphabetic characters."
+#~ msgstr "'%s' debe conter só caracteres alfabéticos."
+
+#~ msgid "'%s' should only contain alphabetic or numeric characters."
+#~ msgstr "'%s' debe conter só caracteres alfanuméricos."
+
+#~ msgid "'%s' should only contain digits."
+#~ msgstr "'%s' debe conter díxitos unicamente."
+
+#~ msgid "Can't create window of class %s"
+#~ msgstr "Non se puido crear unha xanela de clase %s"
+
+#~ msgid "Couldn't create the overlay window"
+#~ msgstr "Non se puido crear a xanela de superposición"
+
+#~ msgid "Couldn't init the context on the overlay window"
+#~ msgstr "Non se puido inicializar o contexto na xanela superposta"
+
+#~ msgid "Failed to convert file \"%s\" to Unicode."
+#~ msgstr "Erro ao converter ficheiro \"%s\" a Unicode."
+
+#~ msgid "Failed to set text in the text control."
+#~ msgstr "Non se puido fixar texto no control de texto."
+
+#~ msgid "Invalid GTK+ command line option, use \"%s --help\""
+#~ msgstr "Opción de liña de comando de GTK+ incorrecta, utilice \"%s --help\""
+
+#~ msgid "No unused colour in image."
+#~ msgstr "Non hai cores sen usar na imaxe."
+
+#~ msgid "Not available"
+#~ msgstr "Non está dispoñíbel"
+
+#~ msgid "Replace selection"
+#~ msgstr "Substituír selección"
+
+#~ msgid "Save as"
+#~ msgstr "Gardar como"
+
+#~ msgid "Style Organiser"
+#~ msgstr "Organizador de estilos"
+
+#~ msgid "The following standard GTK+ options are also supported:\n"
+#~ msgstr "As seguintes opcións do estándar GTK+ tamén se admiten:\n"
+
+#~ msgid "You cannot Clear an overlay that is not inited"
+#~ msgstr "Non se pode eliminar unha superposición que non se iniciou"
+
+#~ msgid "You cannot Init an overlay twice"
+#~ msgstr "Non se pode iniciar unha superposición dúas veces"
+
+#~ msgid "locale '%s' cannot be set."
+#~ msgstr "non se pode estabelecer configuración rexional '%s'."
+
+#~ msgid "Adding flavor TEXT failed"
+#~ msgstr "Erro ao engadir decoración de TEXT"
+
+#~ msgid "Adding flavor utxt failed"
+#~ msgstr "Erro ao engadir decoración de utxt"
+
+#~ msgid "Bitmap renderer cannot render value; value type: "
+#~ msgstr "O renderizador do mapa de bits non pode xerar valor; tipo de valor:"
+
+#~ msgid ""
+#~ "Cannot create new column's ID. Probably max. number of columns reached."
+#~ msgstr ""
+#~ "Non se pode crear nova columna. Probabelmente acadouse o número máximo."
+
+#~ msgid "Column could not be added."
+#~ msgstr "Non se puido engadir a columna."
+
+#~ msgid "Column index not found."
+#~ msgstr "Índece de columnas non atopado."
+
+#~ msgid "Column width could not be determined"
+#~ msgstr "Non se puido determinar o ancho de columna"
+
+#~ msgid "Column width could not be set."
+#~ msgstr "Non se puido estabelecer o ancho de columna."
+
+#~ msgid "Confirm registry update"
+#~ msgstr "Confirmar a actualización do rexistro"
+
+#~ msgid "Could not determine column index."
+#~ msgstr "Non se puido determinar o índice de columnas."
+
+#~ msgid "Could not determine column's position"
+#~ msgstr "Non se puido determinar a posición da columna"
+
+#~ msgid "Could not determine number of columns."
+#~ msgstr "Non se puido determinar o número de columnas."
+
+#~ msgid "Could not determine number of items"
+#~ msgstr "Non se puido determinar o número de elementos"
+
+#~ msgid "Could not get header description."
+#~ msgstr "Non se atopou a descrición da cabeceira."
+
+#~ msgid "Could not get items."
+#~ msgstr "Non se atoparon elementos."
+
+#~ msgid "Could not get property flags."
+#~ msgstr "Non se atoparon marcas de propiedade."
+
+#~ msgid "Could not get selected items."
+#~ msgstr "Non se atoparon os elementos seleccionados."
+
+#~ msgid "Could not remove column."
+#~ msgstr "Non se puideron eliminar as columnas."
+
+#~ msgid "Could not retrieve number of items"
+#~ msgstr "Non se recuperou o número de elementos"
+
+#~ msgid "Could not set column width."
+#~ msgstr "Non se puido estabelecer o ancho de columna."
+
+#~ msgid "Could not set header description."
+#~ msgstr "Non se puido estabelecer a descrición da cabeceira."
+
+#~ msgid "Could not set icon."
+#~ msgstr "Non se puido estabelecer icona."
+
+#~ msgid "Could not set maximum width."
+#~ msgstr "Non se puido estabelecer o ancho máximo."
+
+#~ msgid "Could not set minimum width."
+#~ msgstr "Non se puido estabelecer o ancho mínimo."
+
+#~ msgid "Could not set property flags."
+#~ msgstr "Non se puideron estabelecer marcas de propiedade."
+
+#~ msgid "Data object has invalid data format"
+#~ msgstr "O obxecto de datos ten un formato incorrecto"
+
+#~ msgid "Date renderer cannot render value; value type: "
+#~ msgstr "O renderizador de datos non pode xerar valor; tipo de valor:"
+
+#~ msgid ""
+#~ "Do you want to overwrite the command used to %s files with extension "
+#~ "\"%s\" ?\n"
+#~ "Current value is \n"
+#~ "%s, \n"
+#~ "New value is \n"
+#~ "%s %1"
+#~ msgstr ""
+#~ "Quere sobreescribir o comando utilizado nos ficheiros %s coa extensión "
+#~ "\"%s\"? \n"
+#~ "O valor actual é \n"
+#~ "%s, \n"
+#~ "Novo valor é \n"
+#~ "%s %1"
+
+#~ msgid "Failed to retrieve data from the clipboard."
+#~ msgstr "Fallo ao recuperar datos do portapapeis."
+
+#~ msgid "GIF: Invalid gif index."
+#~ msgstr "GIF: Índice gif incorrecto."
+
+#~ msgid "GIF: unknown error!!!"
+#~ msgstr "GIF: erro descoñecido!!!"
+
+#~ msgid "Icon & text renderer cannot render value; value type: "
+#~ msgstr ""
+#~ "O renderizador de icona & texto non pode xerar valor; tipo de valor:"
+
+#~ msgid "New directory"
+#~ msgstr "Novo cartafol"
+
+#~ msgid "Next"
+#~ msgstr "Seguinte"
+
+#~ msgid "No column existing."
+#~ msgstr "Non existe columna."
+
+#~ msgid "No column for the specified column existing."
+#~ msgstr "Non hai columna para a coluna existente especificada."
+
+#~ msgid "No column for the specified column position existing."
+#~ msgstr "Non hai columna para a posición de columna existente especificada."
+
+#~ msgid ""
+#~ "No renderer or invalid renderer type specified for custom data column."
+#~ msgstr ""
+#~ "Non hai renderizador ou non é válido para a columna de datos "
+#~ "personalizados."
+
+#~ msgid "No renderer specified for column."
+#~ msgstr "Non se especificou un renderizador para a columna."
+
+#~ msgid "Number of columns could not be determined."
+#~ msgstr "Non se puido determinar o número de columnas."
+
+#~ msgid "OpenGL function \"%s\" failed: %s (error %d)"
+#~ msgstr "Función \"%s\" de OpenGL fallou: %s (erro %d)"
+
+#~ msgid ""
+#~ "Please install a newer version of comctl32.dll\n"
+#~ "(at least version 4.70 is required but you have %d.%02d)\n"
+#~ "or this program won't operate correctly."
+#~ msgstr ""
+#~ "Por favor, instale unha versión máis nova de comctl32.dll\n"
+#~ "(precisa polo menos a versión 4.70 pero Vd. ten %d.%02d)\n"
+#~ "ou este programa non funcionará correctamente."
+
+#~ msgid "Pointer to data view control not set correctly."
+#~ msgstr ""
+#~ "O punteiro ao control de vista de datos non está correctamente situado."
+
+#~ msgid "Pointer to model not set correctly."
+#~ msgstr "O punteiro ao modelo non se colocou correctamente."
+
+#~ msgid "Progress renderer cannot render value type; value type: "
+#~ msgstr "O renderizador de progreso non pode xerar valor; tipo de valor: "
+
+#~ msgid "Rendering failed."
+#~ msgstr "Erro de renderización."
+
+#~ msgid ""
+#~ "Setting directory access times is not supported under this OS version"
+#~ msgstr ""
+#~ "Estabelecer os tempos de acceso do cartafol non está permitido nesta "
+#~ "versión de OS"
+
+#~ msgid "Show hidden directories"
+#~ msgstr "Amosar os cartafoles agochados"
+
+#~ msgid "Text renderer cannot render value; value type: "
+#~ msgstr "O renderizador de texto non pode xerar valor; tipo de valor:"
+
+#~ msgid "There is no column or renderer for the specified column index."
+#~ msgstr ""
+#~ "Non hai columna nin renderizador para o índice de columnas especificado."
+
+#~ msgid ""
+#~ "This system doesn't support date controls, please upgrade your version of "
+#~ "comctl32.dll"
+#~ msgstr ""
+#~ "O sistema non é compatíbel co control de datas. Por favor, actualice a "
+#~ "versión de comctl32.dll"
+
+#~ msgid "Toggle renderer cannot render value; value type: "
+#~ msgstr "O renderizador activado non pode xerar valor; tipo de valor:"
+
+#~ msgid "Too many colours in PNG, the image may be slightly blurred."
+#~ msgstr "Hai demasiadas cores no PNG, a imaxe pode verse algo borrosa."
+
+#~ msgid "Unable to handle native drag&drop data"
+#~ msgstr "Non é posíbel manexar os datos nativos de arrastrar/soltar"
+
+#~ msgid "Unable to initialize Hildon program"
+#~ msgstr "Erro ao inicializar OpenGL"
+
+#~ msgid "Unknown data format"
+#~ msgstr "Formato de datos descoñecido"
+
+#~ msgid "Valid pointer to native data view control does not exist"
+#~ msgstr "Non hai un punteiro válido ao control de vista de datos nativos"
+
+#~ msgid "Win32s on Windows 3.1"
+#~ msgstr "Win32s en Windows 3.1"
+
+#, fuzzy
+#~ msgid "Windows 10"
+#~ msgstr "Windows 98"
+
+#~ msgid "Windows 2000"
+#~ msgstr "Windows 2000"
+
+#~ msgid "Windows 7"
+#~ msgstr "Windows 7"
+
+#, fuzzy
+#~ msgid "Windows 8"
+#~ msgstr "Windows 98"
+
+#, fuzzy
+#~ msgid "Windows 8.1"
+#~ msgstr "Windows 98"
+
+#~ msgid "Windows 95"
+#~ msgstr "Windows 95"
+
+#~ msgid "Windows 95 OSR2"
+#~ msgstr "Windows 95 OSR2"
+
+#~ msgid "Windows 98"
+#~ msgstr "Windows 98"
+
+#~ msgid "Windows 98 SE"
+#~ msgstr "Windows 98 SE"
+
+#~ msgid "Windows 9x (%d.%d)"
+#~ msgstr "Windows 9x (%d.%d)"
+
+#~ msgid "Windows CE (%d.%d)"
+#~ msgstr "Windows CE (%d.%d)"
+
+#~ msgid "Windows ME"
+#~ msgstr "Windows ME"
+
+#~ msgid "Windows NT %lu.%lu"
+#~ msgstr "Windows NT %lu.%lu"
+
+#, fuzzy
+#~ msgid "Windows Server 10"
+#~ msgstr "Windows Server 2003"
+
+#~ msgid "Windows Server 2003"
+#~ msgstr "Windows Server 2003"
+
+#~ msgid "Windows Server 2008"
+#~ msgstr "Windows Server 2008"
+
+#~ msgid "Windows Server 2008 R2"
+#~ msgstr "Windows Server 2008 R2"
+
+#, fuzzy
+#~ msgid "Windows Server 2012"
+#~ msgstr "Windows Server 2003"
+
+#, fuzzy
+#~ msgid "Windows Server 2012 R2"
+#~ msgstr "Windows Server 2008 R2"
+
+#~ msgid "Windows Vista"
+#~ msgstr "Windows Vista"
+
+#~ msgid "Windows XP"
+#~ msgstr "Windows XP"
+
+#~ msgid "can't execute '%s'"
+#~ msgstr "non se puido executar '%s'"
+
+#~ msgid "error opening '%s'"
+#~ msgstr "erro ao abrir '%s'"
+
+#~ msgid "unknown seek origin"
+#~ msgstr "orixe de busca descoñecido"
+
+#~ msgid "wxWidget control pointer is not a data view pointer"
+#~ msgstr ""
+#~ "o punteiro de contol de wxWidget non é un punteiro de vista de datos"
+
+#~ msgid "wxWidget's control not initialized."
+#~ msgstr "Non se iniciou o control de wxWidget."
+
+#~ msgid "ADD"
+#~ msgstr "ENGADIR"
+
+#~ msgid "BACK"
+#~ msgstr "ATRÁS"
+
+#~ msgid "CANCEL"
+#~ msgstr "CANCELAR"
+
+#~ msgid "CAPITAL"
+#~ msgstr "MAIÚSCULAS"
+
+#~ msgid "CLEAR"
+#~ msgstr "LIMPAR"
+
+#~ msgid "COMMAND"
+#~ msgstr "COMANDO"
+
+#~ msgid "Cannot create mutex."
+#~ msgstr "Non se pode crear o mutex."
+
+#~ msgid "Cannot resume thread %lu"
+#~ msgstr "Non se pode retomar o fío de execución %lu"
+
+#~ msgid "Cannot suspend thread %lu"
+#~ msgstr "Non se pode suspender o fío de execución %lu"
+
+#~ msgid "Couldn't acquire a mutex lock"
+#~ msgstr "Non se puido conseguir un bloqueo de mutex"
+
+#~ msgid "Couldn't get hatch style from wxBrush."
+#~ msgstr "Non se puido obter estilo de patrón de wxBrush."
+
+#~ msgid "Couldn't release a mutex"
+#~ msgstr "Non se puido liberar un mutex"
+
+#~ msgid "DECIMAL"
+#~ msgstr "DECIMAL"
+
+#~ msgid "DEL"
+#~ msgstr "DEL"
+
+#~ msgid "DELETE"
+#~ msgstr "ELIMINAR"
+
+#~ msgid "DIVIDE"
+#~ msgstr "DIVIDIR"
+
+#~ msgid "DOWN"
+#~ msgstr "ABAIXO"
+
+#~ msgid "END"
+#~ msgstr "FIN"
+
+#~ msgid "ENTER"
+#~ msgstr "ACEPTAR"
+
+#~ msgid "ESC"
+#~ msgstr "ESC"
+
+#~ msgid "ESCAPE"
+#~ msgstr "ESCAPE"
+
+#~ msgid "EXECUTE"
+#~ msgstr "EXECUTAR"
+
+#~ msgid "Execution of command '%s' failed with error: %ul"
+#~ msgstr "Fallou a execución do comando '%s' co erro: %ul"
+
+#~ msgid ""
+#~ "File '%s' already exists.\n"
+#~ "Do you want to replace it?"
+#~ msgstr ""
+#~ "O ficheiro '%s' xa existe.\n"
+#~ "Desexa substituílo?"
+
+#~ msgid "HELP"
+#~ msgstr "AXUDA"
+
+#~ msgid "HOME"
+#~ msgstr "INICIO"
+
+#~ msgid "INS"
+#~ msgstr "INS"
+
+#~ msgid "INSERT"
+#~ msgstr "INSERIR"
+
+#~ msgid "KP_BEGIN"
+#~ msgstr "KP_BEGIN"
+
+#~ msgid "KP_DECIMAL"
+#~ msgstr "KP_DECIMAL"
+
+#~ msgid "KP_DELETE"
+#~ msgstr "KP_DELETE"
+
+#~ msgid "KP_DIVIDE"
+#~ msgstr "KP_DIVIDE"
+
+#~ msgid "KP_DOWN"
+#~ msgstr "KP_DOWN"
+
+#~ msgid "KP_ENTER"
+#~ msgstr "KP_ENTER"
+
+#~ msgid "KP_EQUAL"
+#~ msgstr "KP_EQUAL"
+
+#~ msgid "KP_HOME"
+#~ msgstr "KP_HOME"
+
+#~ msgid "KP_INSERT"
+#~ msgstr "KP_INSERT"
+
+#~ msgid "KP_LEFT"
+#~ msgstr "KP_LEFT"
+
+#~ msgid "KP_MULTIPLY"
+#~ msgstr "KP_MULTIPLY"
+
+#~ msgid "KP_NEXT"
+#~ msgstr "KP_NEXT"
+
+#~ msgid "KP_PAGEDOWN"
+#~ msgstr "KP_PAGEDOWN"
+
+#~ msgid "KP_PAGEUP"
+#~ msgstr "KP_PAGEUP"
+
+#~ msgid "KP_PRIOR"
+#~ msgstr "KP_PRIOR"
+
+#~ msgid "KP_RIGHT"
+#~ msgstr "KP_RIGHT"
+
+#~ msgid "KP_SEPARATOR"
+#~ msgstr "KP_SEPARATOR"
+
+#~ msgid "KP_SPACE"
+#~ msgstr "KP_SPACE"
+
+#~ msgid "KP_SUBTRACT"
+#~ msgstr "KP_SUBTRACT"
+
+#~ msgid "LEFT"
+#~ msgstr "ESQUERDA"
+
+#~ msgid "MENU"
+#~ msgstr "MENÚ"
+
+#~ msgid "NUM_LOCK"
+#~ msgstr "BLOQ_NÚM"
+
+#~ msgid "PAGEDOWN"
+#~ msgstr "AV. PÁX."
+
+#~ msgid "PAGEUP"
+#~ msgstr "RE. PÁX."
+
+#~ msgid "PAUSE"
+#~ msgstr "PAUSA"
+
+#~ msgid "PGDN"
+#~ msgstr "AVPX"
+
+#~ msgid "PGUP"
+#~ msgstr "REPX"
+
+#~ msgid "PRINT"
+#~ msgstr "IMPRIMIR"
+
+#~ msgid "RETURN"
+#~ msgstr "RETORNO"
+
+#~ msgid "RIGHT"
+#~ msgstr "DEREITA"
+
+#~ msgid "SCROLL_LOCK"
+#~ msgstr "BLOQ_DESPR"
+
+#~ msgid "SELECT"
+#~ msgstr "SELECCIONAR"
+
+#~ msgid "SEPARATOR"
+#~ msgstr "SEPARADOR"
+
+#~ msgid "SNAPSHOT"
+#~ msgstr "CAPTURA"
+
+#~ msgid "SPACE"
+#~ msgstr "ESPAZO"
+
+#~ msgid "SUBTRACT"
+#~ msgstr "SUBTRAER"
+
+#~ msgid "TAB"
+#~ msgstr "TAB"
+
+#~ msgid "The print dialog returned an error."
+#~ msgstr "O diálogo de impresión devolveu un erro."
+
+#~ msgid "The wxGtkPrinterDC cannot be used."
+#~ msgstr "Non se pode usar o wxGtkPrinterDC."
+
+#~ msgid "Timer creation failed."
+#~ msgstr "Erro na creación do temporizador."
+
+#~ msgid "UP"
+#~ msgstr "ARRIBA"
+
+#~ msgid "WINDOWS_LEFT"
+#~ msgstr "WINDOWS_LEFT"
+
+#~ msgid "WINDOWS_MENU"
+#~ msgstr "WINDOWS_MENU"
+
+#~ msgid "WINDOWS_RIGHT"
+#~ msgstr "WINDOWS_RIGHT"
+
+#~ msgid "buffer is too small for Windows directory."
+#~ msgstr "o búfer é pequeno de máis para o cartafol de Windows."
+
+#~ msgid "not implemented"
+#~ msgstr "sen implementar"
+
+#~ msgid "wxPrintout::GetPageInfo gives a null maxPage."
+#~ msgstr "wxPrintout::GetPageInfo dá un valor nulo de maxPage."
+
+#~ msgid "Event queue overflowed"
+#~ msgstr "Cola de actividades desbordada"
+
+#~ msgid "percent"
+#~ msgstr "por cento"
+
+#~ msgid "Print preview"
+#~ msgstr "Previsualización de impresión"
+
+#, fuzzy
+#~ msgid "&Preview..."
+#~ msgstr " Previsualización"
+
+#, fuzzy
+#~ msgid "Preview..."
+#~ msgstr " Previsualización"
+
+#~ msgid "&Save..."
+#~ msgstr "&Gardar..."
+
+#, fuzzy
+#~ msgid "About "
+#~ msgstr "&Acerca de..."
+
+#~ msgid "All files (*.*)|*"
+#~ msgstr "Tódolos ficheiros (*.*)|*"
+
+#, fuzzy
+#~ msgid "Cannot initialize SciTech MGL!"
+#~ msgstr "¡No se puede inicialzar SciTech MGL!"
+
+#, fuzzy
+#~ msgid "Cannot initialize display."
+#~ msgstr "No se puede inicializar la pantalla."
+
+#, fuzzy
+#~ msgid "Cannot start thread: error writing TLS"
+#~ msgstr "No se puede empezar el hilo de ejecución: error al escribir TLS"
+
+#~ msgid "Close\tAlt-F4"
+#~ msgstr "Pechar\tAlt-F4"
+
+#~ msgid "Couldn't create cursor."
+#~ msgstr "Non se puido crear un cursor."
+
+#~ msgid "Directory '%s' doesn't exist!"
+#~ msgstr "O directorio '%s' non existe!"
+
+#, fuzzy
+#~ msgid "Mode %ix%i-%i not available."
+#~ msgstr "Modo %ix%i-%i no disponible."
+
+#~ msgid "Paper Size"
+#~ msgstr "Tamaño do Papel"
+
+#~ msgid "&Goto..."
+#~ msgstr "&Ir a..."
+
+#~ msgid "<<"
+#~ msgstr "<<"
+
+#~ msgid ">>"
+#~ msgstr ">>"
+
+#~ msgid ">>|"
+#~ msgstr ">>|"
+
+#~ msgid "Archive doesnt contain #SYSTEM file"
+#~ msgstr "O arquivo non contén un ficheiro #SYSTEM"
+
+#~ msgid "Can't check image format of file '%s': file does not exist."
+#~ msgstr ""
+#~ "Non se puido verificar o formato de imaxe do ficheiro '%s': o ficheiro "
+#~ "non existe."
+
+#~ msgid "Can't load image from file '%s': file does not exist."
+#~ msgstr ""
+#~ "Non se puido cargar a imaxe dende o ficheiro '%s': o ficheiro non existe."
+
+#, fuzzy
+#~ msgid "Cannot convert dialog units: dialog unknown."
+#~ msgstr "No se pueden convertir unidades: diálogo desconocido."
+
+#~ msgid "Cannot convert from the charset '%s'!"
+#~ msgstr "Non se puido converter dende o xogo de caracteres '%s'!"
+
+#, fuzzy
+#~ msgid "Cannot find container for unknown control '%s'."
+#~ msgstr ""
+#~ "No se puede encontrar el contenedor para el control desconocido '%s'."
+
+#, fuzzy
+#~ msgid "Cannot find font node '%s'."
+#~ msgstr "No se puede encontrar nodo de fuente '%s'."
+
+#~ msgid "Cannot open file '%s'."
+#~ msgstr "Non se puido abrir o ficheiro '%s'."
+
+#, fuzzy
+#~ msgid "Cannot parse coordinates from '%s'."
+#~ msgstr "No se pueden analizar coordenadas desde '%s'."
+
+#, fuzzy
+#~ msgid "Cannot parse dimension from '%s'."
+#~ msgstr "No se puede analizar la dimensión desde '%s'."
+
+#, fuzzy
+#~ msgid "Cant create the thread event queue"
+#~ msgstr "No se puede crear la cola de eventos del hilo de ejecución"
+
+#, fuzzy
+#~ msgid "Click to cancel this window."
+#~ msgstr "Pechar esta ventá"
+
+#, fuzzy
+#~ msgid "Click to confirm your selection."
+#~ msgstr "Clique para confirmar a selección de fonte."
+
+#, fuzzy
+#~ msgid "Could not unlock mutex"
+#~ msgstr "No se pudo desbloquear el mutex"
+
+#, fuzzy
+#~ msgid "Error while waiting on semaphore"
+#~ msgstr "Error mientras esperaba en el semáforo"
+
+#~ msgid "Failed to create a status bar."
+#~ msgstr "Erro ó crear unha barra de estado."
+
+#, fuzzy
+#~ msgid "Failed to register OpenGL window class."
+#~ msgstr "Fallo al registrar la clase de ventana OpenGL."
+
+#~ msgid "Fatal error: "
+#~ msgstr "Erro moi grave: "
+
+#~ msgid "Goto Page"
+#~ msgstr "Ir á Páxina"
+
+#, fuzzy
+#~ msgid "Help : %s"
+#~ msgstr "Axuda: %s"
+
+#, fuzzy
+#~ msgid "I64"
+#~ msgstr "I64"
+
+#, fuzzy
+#~ msgid "Internal error, illegal wxCustomTypeInfo"
+#~ msgstr "Error interno, wxCustomTypeInfo no permitido"
+
+#, fuzzy
+#~ msgid "Invalid XRC resource '%s': doesn't have root node 'resource'."
+#~ msgstr "Recurso XRC inválido '%s': no tiene el nodo raíz 'resource'."
+
+#, fuzzy
+#~ msgid "No handler found for XML node '%s', class '%s'!"
+#~ msgstr "¡No se encontró manejador para el nodo XML '%s', clase '%s'!"
+
+#, fuzzy
+#~ msgid "No image handler for type %ld defined."
+#~ msgstr "No hay definido ningún manejador de imagen para tipo %d."
+
+#, fuzzy
+#~ msgid "Owner not initialized."
+#~ msgstr "No se puede inicializar la pantalla."
+
+#, fuzzy
+#~ msgid "Passed item is invalid."
+#~ msgstr "'%s' é incorrecto"
+
+#, fuzzy
+#~ msgid "Passing a already registered object to SetObjectName"
+#~ msgstr "Paso de un objeto ya registrado a SetObjectName"
+
+#, fuzzy
+#~ msgid "Program aborted."
+#~ msgstr "Programa cancelado."
+
+#, fuzzy
+#~ msgid "Referenced object node with ref=\"%s\" not found!"
+#~ msgstr "¡No se ha encontrado nodo de objeto referenciado con ref=\"%s\"!"
+
+#, fuzzy
+#~ msgid "Resource files must have same version number!"
+#~ msgstr "¡Los ficheros de recursos deben ser de la misma versión!"
+
+#, fuzzy
+#~ msgid "Search!"
+#~ msgstr "Buscar"
+
+#~ msgid "Sorry, could not open this file for saving."
+#~ msgstr "Síntoo, non se puido abrir este ficheiro para gardar."
+
+#~ msgid "Sorry, could not save this file."
+#~ msgstr "Síntoo, non se puido gardar este ficheiro."
+
+#~ msgid "Sorry, print preview needs a printer to be installed."
+#~ msgstr ""
+#~ "Síntoo, a previsualización de impresión necesita que haxa unha impresora "
+#~ "instalada."
+
+#~ msgid "Status: "
+#~ msgstr "Estado: "
+
+#, fuzzy
+#~ msgid "Subclass '%s' not found for resource '%s', not subclassing!"
+#~ msgstr "¡No se encontró la subclase '%s' para el recurso '%s'!"
+
+#~ msgid "TIFF library error."
+#~ msgstr "Erro da librería TIFF."
+
+#~ msgid "TIFF library warning."
+#~ msgstr "Advertencia da librería TIFF."
+
+#, fuzzy
+#~ msgid ""
+#~ "The file '%s' couldn't be opened.\n"
+#~ "It has been removed from the most recently used files list."
+#~ msgstr ""
+#~ "El fichero '%s' no pudo abrirse.\n"
+#~ "Ha sido borrado de la lista de archivos recientes."
+
+#, fuzzy
+#~ msgid "The path '%s' contains too many \"..\"!"
+#~ msgstr "¡La ruta '%s' contiene demasiados \"..\"!"
+
+#, fuzzy
+#~ msgid "Trying to solve a NULL hostname: giving up"
+#~ msgstr ""
+#~ "Intentando resolver un nombre de servidor (hostname) nulo: imposible de "
+#~ "resolver"
+
+#, fuzzy
+#~ msgid "Unknown style flag "
+#~ msgstr "Indicador(flag) de estilo desconocido"
+
+#~ msgid "Warning"
+#~ msgstr "Advertencia"
+
+#, fuzzy
+#~ msgid "Windows 2000 (build %lu"
+#~ msgstr "Windows 2000 (build %lu"
+
+#, fuzzy
+#~ msgid "XRC resource '%s' (class '%s') not found!"
+#~ msgstr "¡Recurso XRC '%s' (clase '%s') no encontrado!"
+
+#, fuzzy
+#~ msgid "XRC resource: Cannot create animation from '%s'."
+#~ msgstr "Recurso XRC: No se puede crear el mapa de bits de '%s'."
+
+#, fuzzy
+#~ msgid "XRC resource: Cannot create bitmap from '%s'."
+#~ msgstr "Recurso XRC: No se puede crear el mapa de bits de '%s'."
+
+#, fuzzy
+#~ msgid ""
+#~ "XRC resource: Incorrect colour specification '%s' for attribute '%s'."
+#~ msgstr ""
+#~ "Recurso XRC: Especificación de color '%s' incorrecta para la propiedad "
+#~ "'%s'."
+
+#, fuzzy
+#~ msgid "[EMPTY]"
+#~ msgstr "[VACÍO]"
+
+#~ msgid "catalog file for domain '%s' not found."
+#~ msgstr "ficheiro de catálogo para o dominio '%s' non atopado."
+
+#, fuzzy
+#~ msgid "delegate has no type info"
+#~ msgstr "el delegado no tiene información de tipo"
+
+#, fuzzy
+#~ msgid "encoding %i"
+#~ msgstr "codificación %s"
+
+#, fuzzy
+#~ msgid "looking for catalog '%s' in path '%s'."
+#~ msgstr "buscando catálogo '%s' en ruta '%s'."
+
+#~ msgid "wxSocket: invalid signature in ReadMsg."
+#~ msgstr "wxSocket: sinatura inválida no ReadMsg"
+
+#~ msgid "wxSocket: unknown event!."
+#~ msgstr "wxSocket: evento descoñecido!."
+
+#~ msgid "|<<"
+#~ msgstr "|<<"
+
+#, fuzzy
+#~ msgid " Couldn't create the UnicodeConverter"
+#~ msgstr "No se pudo crear un temporizador"
+
+#, fuzzy
+#~ msgid "#define %s must be an integer."
+#~ msgstr "#define %s debe ser un entero"
+
+#, fuzzy
+#~ msgid "%s not a bitmap resource specification."
+#~ msgstr "%s no es una especificacion de recurso de mapa de bits"
+
+#, fuzzy
+#~ msgid "%s not an icon resource specification."
+#~ msgstr "%s no es una especificación de recurso de icono"
+
+#, fuzzy
+#~ msgid "%s: ill-formed resource file syntax."
+#~ msgstr "%s: sintaxis incorrecta del fichero fuente"
+
+#~ msgid "&Open"
+#~ msgstr "&Abrir"
+
+#~ msgid "&Print"
+#~ msgstr "&Imprimir"
+
+#~ msgid "*** It can be found in \"%s\"\n"
+#~ msgstr "*** Pode atoparse en \"%s\"\n"
+
+#, fuzzy
+#~ msgid ""
+#~ ", expected static, #include or #define\n"
+#~ "while parsing resource."
+#~ msgstr ""
+#~ ", se esperaba estático, #include o #define\n"
+#~ "al analizar recurso."
+
+#, fuzzy
+#~ msgid "Bitmap resource specification %s not found."
+#~ msgstr "Especificación de recurso de mapa de bits %s no encontrada."
+
+#, fuzzy
+#~ msgid ""
+#~ "Could not resolve control class or id '%s'. Use (non-zero) integer "
+#~ "instead\n"
+#~ " or provide #define (see manual for caveats)"
+#~ msgstr ""
+#~ "No se pudo resolver la clase de control o el id '%s'. Use un entero "
+#~ "distinto de cero\n"
+#~ " o proporcione el #define (vea las advertencias del manual)"
+
+#, fuzzy
+#~ msgid ""
+#~ "Could not resolve menu id '%s'. Use (non-zero) integer instead\n"
+#~ "or provide #define (see manual for caveats)"
+#~ msgstr ""
+#~ "No se pudo resolver el id de menú '%s'. Use un entero distinto de cero\n"
+#~ " o proporcione el #define (vea las advertencias del manual)"
+
+#, fuzzy
+#~ msgid "Couldn't end the context on the overlay window"
+#~ msgstr "No se pudo obtener el puntero del hilo de ejecución actual"
+
+#~ msgid "Expected '*' while parsing resource."
+#~ msgstr "Esperábase '*' mentres se analizaba o recurso."
+
+#~ msgid "Expected '=' while parsing resource."
+#~ msgstr "Esperábase '=' mentres se analizaba o recurso."
+
+#~ msgid "Expected 'char' while parsing resource."
+#~ msgstr "Esperábase 'char' mentres se analizaba o recurso."
+
+#, fuzzy
+#~ msgid ""
+#~ "Failed to find XBM resource %s.\n"
+#~ "Forgot to use wxResourceLoadBitmapData?"
+#~ msgstr ""
+#~ "Error al buscar el recurso XBM %s. \n"
+#~ "¿Olvidó usar xwResourceLoadBitmapData?"
+
+#, fuzzy
+#~ msgid ""
+#~ "Failed to find XBM resource %s.\n"
+#~ "Forgot to use wxResourceLoadIconData?"
+#~ msgstr ""
+#~ "Error al buscar el recurso XBM %s. \n"
+#~ "¿Olvidó usar wxResourceLoadIconData?"
+
+#, fuzzy
+#~ msgid ""
+#~ "Failed to find XPM resource %s.\n"
+#~ "Forgot to use wxResourceLoadBitmapData?"
+#~ msgstr ""
+#~ "Error al buscar el recurso XPM %s. \n"
+#~ "¿Olvidó usar wxResourceLoadBitmapData?"
+
+#~ msgid "Failed to get clipboard data."
+#~ msgstr "Fallo ó obter os datos do portapapeis."
+
+#~ msgid "Failed to load shared library '%s' Error '%s'"
+#~ msgstr "Erro ó cargar a librería compartida '%s' Erro '%s'"
+
+#, fuzzy
+#~ msgid "Found "
+#~ msgstr "Encontrado "
+
+#, fuzzy
+#~ msgid "Icon resource specification %s not found."
+#~ msgstr "Especificación de recursos de icono %s no encontrada."
+
+#, fuzzy
+#~ msgid "Ill-formed resource file syntax."
+#~ msgstr "Sintaxis incorrecta del archivo de recursos."
+
+#, fuzzy
+#~ msgid "Long Conversions not supported"
+#~ msgstr "Las conversiones Long no están soportadas"
+
+#, fuzzy
+#~ msgid "No XPM icon facility available!"
+#~ msgstr "¡No está disponible el soporte para iconos XPM!"
+
+#, fuzzy
+#~ msgid "Option '%s' requires a value, '=' expected."
+#~ msgstr "El parámetro '%s' necesita un valor, falta '='."
+
+#, fuzzy
+#~ msgid "Select all"
+#~ msgstr "Seleccionar &Todo"
+
+#, fuzzy
+#~ msgid "Unexpected end of file while parsing resource."
+#~ msgstr "Fin de fichero inesperado al analizar el recurso."
+
+#, fuzzy
+#~ msgid "Unrecognized style %s while parsing resource."
+#~ msgstr "Estilo %s desconocido al analizar el recurso."
+
+#~ msgid "Video Output"
+#~ msgstr "Saída de Video"
+
+#, fuzzy
+#~ msgid "Warning: attempt to remove HTML tag handler from empty stack."
+#~ msgstr ""
+#~ "Atención: intento de eliminar un manipulador de etiquetas HTML de una "
+#~ "pila vacía."
+
+#, fuzzy
+#~ msgid "establish"
+#~ msgstr "establecer"
+
+#~ msgid "initiate"
+#~ msgstr "iniciar"
+
+#~ msgid "invalid eof() return value."
+#~ msgstr "valor de retorno de eof() incorrecto."
+
+#, fuzzy
+#~ msgid "unknown line terminator"
+#~ msgstr "final de línea desconocido"
+
+#~ msgid "writing"
+#~ msgstr "escribindo"
+
+#~ msgid "."
+#~ msgstr "."
+
+#~ msgid "Cannot open URL '%s'"
+#~ msgstr "Non se puido abrir o URL '%s'"
+
+#~ msgid "Error "
+#~ msgstr "Erro "
+
+#~ msgid "Failed to create directory %s/.gnome."
+#~ msgstr "Erro ó crear o directorio %s/.gnome."
+
+#~ msgid "Failed to create directory %s/mime-info."
+#~ msgstr "Erro ó crear o directorio %s/mime-info."
+
+#, fuzzy
+#~ msgid "MP Thread Support is not available on this System"
+#~ msgstr "El soporte para hilos MP no está disponible en este sistema"
+
+#, fuzzy
+#~ msgid "Mailcap file %s, line %d: incomplete entry ignored."
+#~ msgstr "Fichero Mailcap %s, línea %d: entrada incompleta ignorada."
+
+#, fuzzy
+#~ msgid "Mime.types file %s, line %d: unterminated quoted string."
+#~ msgstr ""
+#~ "Tipos Mime del fichero %s, linea %d: cadena entrecomillada no terminada."
+
+#~ msgid "Unknown field in file %s, line %d: '%s'."
+#~ msgstr "Campo descoñecido no ficheiro %s, liña %d: '%s'."
+
+#~ msgid "bold "
+#~ msgstr "negriña"
+
+#, fuzzy
+#~ msgid "can't query for GUI plugins name in console applications"
+#~ msgstr ""
+#~ "no se puede solicitar el nombre complemento (plugins) del GUI en las "
+#~ "aplicaciones de consola"
+
+#, fuzzy
+#~ msgid "light "
+#~ msgstr "ligera"
+
+#~ msgid "underlined "
+#~ msgstr "subraiado "
+
+#~ msgid "unsupported zip archive"
+#~ msgstr "arquivo zip non soportado"

--- a/po_wxstd/hi.po
+++ b/po_wxstd/hi.po
@@ -1,0 +1,10691 @@
+# translation of wxstd-hi.po to हिन्दी (Hindi)
+# This file is distributed under the same license as the wxWidgets package.
+# Copyright (C) 2008 wxWidgets development team
+# प्रियंक बोल्या (Priyank Bolia) <priyank.bolia@gmail.com>, 2008.
+# धनञ्जय शर्मा (Dhananjaya Sharma) <dysxhi@yahoo.co.in>, 2004.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: wxWidgets 3.3\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-05-14 20:23+0200\n"
+"PO-Revision-Date: 2008-07-28 23:09+0530\n"
+"Last-Translator: Priyank Bolia <priyank.bolia@gmail.com>\n"
+"Language-Team: हिन्दी (Hindi) <dysxhi@yahoo.co.in>\n"
+"Language: hi\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"plural-forms: nplurals=2; plural=n > 1\n"
+"X-Poedit-Language: Hindi\n"
+"X-Poedit-Country: INDIA\n"
+
+#: ../include/wx/defs.h:2582
+msgid "All files (*.*)|*.*"
+msgstr "सभी फ़ाइलें (*.*)|*.*"
+
+#: ../include/wx/defs.h:2585
+msgid "All files (*)|*"
+msgstr "सभी फ़ाइलें (*)|*"
+
+#: ../include/wx/generic/progdlgg.h:85
+#, fuzzy
+msgid "Elapsed time:"
+msgstr "बीता हुआ समय : "
+
+#: ../include/wx/generic/progdlgg.h:86
+#, fuzzy
+msgid "Estimated time:"
+msgstr "अनुमानित समय : "
+
+#: ../include/wx/generic/progdlgg.h:87
+#, fuzzy
+msgid "Remaining time:"
+msgstr "शेष समय : "
+
+#. TRANSLATORS: HTML printout default title.
+#: ../include/wx/html/htmprint.h:121 ../include/wx/prntbase.h:273
+#: ../include/wx/richtext/richtextprint.h:109 ../src/common/docview.cpp:2161
+#, fuzzy
+msgid "Printout"
+msgstr "मुद्रण"
+
+#. TRANSLATORS: HTML easy print default title.
+#: ../include/wx/html/htmprint.h:234 ../include/wx/richtext/richtextprint.h:163
+#: ../src/common/prntbase.cpp:522 ../src/html/htmprint.cpp:291
+#, fuzzy
+msgid "Printing"
+msgstr "मुद्रण हो रहा है "
+
+#: ../include/wx/msgdlg.h:277 ../src/common/stockitem.cpp:211
+msgid "Yes"
+msgstr "हाँ"
+
+#: ../include/wx/msgdlg.h:278 ../src/common/stockitem.cpp:182
+msgid "No"
+msgstr "नहीं"
+
+#: ../include/wx/msgdlg.h:279 ../src/common/stockitem.cpp:183
+#: ../src/msw/msgdlg.cpp:430 ../src/msw/msgdlg.cpp:734
+#: ../src/richtext/richtextstyledlg.cpp:292
+msgid "OK"
+msgstr "ठीक"
+
+#: ../include/wx/msgdlg.h:280 ../src/common/stockitem.cpp:150
+#: ../src/msw/msgdlg.cpp:430 ../src/msw/progdlg.cpp:884
+#: ../src/richtext/richtextstyledlg.cpp:295
+msgid "Cancel"
+msgstr "निरस्त"
+
+#: ../include/wx/msgdlg.h:281 ../src/common/stockitem.cpp:168
+#: ../src/html/helpdlg.cpp:63 ../src/html/helpfrm.cpp:108
+#: ../src/osx/button_osx.cpp:38
+msgid "Help"
+msgstr "सहायता"
+
+#: ../include/wx/msw/ole/oleutils.h:52
+msgid "Cannot initialize OLE"
+msgstr "ओएलई का आरम्भीकरण नहीं किया जा सकता है"
+
+#: ../include/wx/msw/private/fswatcher.h:48
+#, fuzzy, c-format
+msgid "Unable to close the handle for '%s'"
+msgstr "फ़ाइल हैन्डल को बन्द करने में असफ़ल"
+
+#: ../include/wx/msw/private/fswatcher.h:92
+#, fuzzy, c-format
+msgid "Failed to open directory \"%s\" for monitoring."
+msgstr "\"%s\" निर्देशिका का निर्माण करने में असफ़ल।"
+
+#: ../include/wx/msw/private/fswatcher.h:125
+#, fuzzy
+msgid "Unable to close I/O completion port handle"
+msgstr "फ़ाइल हैन्डल को बन्द करने में असफ़ल"
+
+#: ../include/wx/msw/private/fswatcher.h:142
+msgid "Unable to associate handle with I/O completion port"
+msgstr ""
+
+#: ../include/wx/msw/private/fswatcher.h:148
+msgid "Unexpectedly new I/O completion port was created"
+msgstr ""
+
+#: ../include/wx/msw/private/fswatcher.h:213
+msgid "Unable to post completion status"
+msgstr ""
+
+#: ../include/wx/msw/private/fswatcher.h:262
+msgid "Unable to dequeue completion packet"
+msgstr ""
+
+#: ../include/wx/msw/private/fswatcher.h:273
+#, fuzzy
+msgid "Unable to create I/O completion port"
+msgstr "एमडीआई मूल खाके का निर्माण करने में असफ़ल।"
+
+#: ../include/wx/richmsgdlg.h:29
+#, fuzzy
+msgid "&See details"
+msgstr "विवरण (&D)"
+
+#: ../include/wx/richmsgdlg.h:30
+#, fuzzy
+msgid "&Hide details"
+msgstr "विवरण (&D)"
+
+#: ../include/wx/richtext/richtextbuffer.h:3864
+#, fuzzy
+msgid "&Box"
+msgstr "गहरा"
+
+#: ../include/wx/richtext/richtextbuffer.h:5008
+msgid "&Picture"
+msgstr ""
+
+#: ../include/wx/richtext/richtextbuffer.h:5958
+#, fuzzy
+msgid "&Cell"
+msgstr "निरस्त करें (&C)"
+
+#: ../include/wx/richtext/richtextbuffer.h:6067
+#, fuzzy
+msgid "&Table"
+msgstr "टेब्स"
+
+#: ../include/wx/richtext/richtextimagedlg.h:37
+#, fuzzy
+msgid "Object Properties"
+msgstr "गुणधर्म (&P)"
+
+#: ../include/wx/richtext/richtextsymboldlg.h:39
+msgid "Symbols"
+msgstr "प्रतीकों"
+
+#: ../include/wx/unix/pipe.h:46
+msgid "Pipe creation failed"
+msgstr "पाइप का निर्माण असफ़ल रहा"
+
+#: ../include/wx/unix/private/displayx11.h:65
+msgid "Failed to enumerate video modes"
+msgstr "विडियो विधाओं की परिगणना करने में असफ़ल"
+
+#: ../include/wx/unix/private/displayx11.h:89
+msgid "Failed to change video mode"
+msgstr "विडियो विधा को परिवर्तित करने में असफ़ल"
+
+#: ../include/wx/unix/private/fswatcher_kqueue.h:57
+#, fuzzy, c-format
+msgid "Unable to open path '%s'"
+msgstr "'%s' सीएचएम लेखागार को खोलने में असफ़ल।"
+
+#: ../include/wx/unix/private/fswatcher_kqueue.h:74
+#, fuzzy, c-format
+msgid "Unable to close path '%s'"
+msgstr "'%s' लॉक फ़ाइल को बन्द करने में असफ़ल"
+
+#: ../include/wx/xtiprop.h:175
+msgid "SetProperty called w/o valid setter"
+msgstr "SetProperty को बिना किसी वैध सेटर के बुलाया गया"
+
+#: ../include/wx/xtiprop.h:184
+msgid "GetProperty called w/o valid getter"
+msgstr "GetProperty को बिना किसी वैध गेटर के बुलाया गया"
+
+#: ../include/wx/xtiprop.h:193
+msgid "AddToPropertyCollection called w/o valid adder"
+msgstr "AddToPropertyCollection को बिना वैध ऐडर के कॉल किया गया"
+
+#: ../include/wx/xtiprop.h:202
+msgid "GetPropertyCollection called w/o valid collection getter"
+msgstr "GetPropertyCollection को बिना किसी वैध कलेक्शन गेटर के बुलाया गया"
+
+#: ../include/wx/xtiprop.h:255
+msgid "AddToPropertyCollection called on a generic accessor"
+msgstr "AddToPropertyCollection को एक सामान्य ऐसेसर पर कॉल किया गया"
+
+#: ../include/wx/xtiprop.h:262
+msgid "GetPropertyCollection called on a generic accessor"
+msgstr "GetPropertyCollection ने एक सामान्य ऐसेसर को बुलाया"
+
+#: ../src/aui/tabmdi.cpp:106 ../src/generic/mdig.cpp:94
+msgid "Cl&ose"
+msgstr "समाप्त करें (&o)"
+
+#: ../src/aui/tabmdi.cpp:107 ../src/generic/mdig.cpp:95
+msgid "Close All"
+msgstr "सभी समाप्त"
+
+#: ../src/aui/tabmdi.cpp:109 ../src/generic/mdig.cpp:97 ../src/msw/mdi.cpp:175
+#: ../src/qt/mdi.cpp:258
+msgid "&Next"
+msgstr "अगला (&N)"
+
+#: ../src/aui/tabmdi.cpp:110 ../src/generic/mdig.cpp:98 ../src/msw/mdi.cpp:176
+#: ../src/qt/mdi.cpp:259
+msgid "&Previous"
+msgstr "पिछला (&P)"
+
+#: ../src/aui/tabmdi.cpp:332 ../src/aui/tabmdi.cpp:348
+#: ../src/aui/tabmdi.cpp:350 ../src/generic/mdig.cpp:291
+#: ../src/generic/mdig.cpp:307 ../src/generic/mdig.cpp:311
+#: ../src/msw/mdi.cpp:337 ../src/qt/mdi.cpp:462
+msgid "&Window"
+msgstr "खिड़की (&W)"
+
+#: ../src/common/accelcmn.cpp:47
+msgctxt "keyboard key"
+msgid "Delete"
+msgstr "मिटाएँं"
+
+#: ../src/common/accelcmn.cpp:48
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Del"
+msgstr "मिटाएँं"
+
+#: ../src/common/accelcmn.cpp:49
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Back"
+msgstr "पीछे (&B)"
+
+#: ../src/common/accelcmn.cpp:49
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Backspace"
+msgstr "पीछे (&B)"
+
+#: ../src/common/accelcmn.cpp:50
+msgctxt "keyboard key"
+msgid "Insert"
+msgstr "डाले"
+
+#: ../src/common/accelcmn.cpp:51
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Ins"
+msgstr "डाले"
+
+#: ../src/common/accelcmn.cpp:52
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Enter"
+msgstr "मुद्रक"
+
+#: ../src/common/accelcmn.cpp:53
+msgctxt "keyboard key"
+msgid "Return"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:54
+#, fuzzy
+msgctxt "keyboard key"
+msgid "PageUp"
+msgstr "अनेक पृष्ट"
+
+#: ../src/common/accelcmn.cpp:54
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Page Up"
+msgstr "पृष्ट %d"
+
+#: ../src/common/accelcmn.cpp:55
+#, fuzzy
+msgctxt "keyboard key"
+msgid "PageDown"
+msgstr "नीचे"
+
+#: ../src/common/accelcmn.cpp:55
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Page Down"
+msgstr "पृष्ट %d"
+
+#: ../src/common/accelcmn.cpp:56
+msgctxt "keyboard key"
+msgid "PgUp"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:57
+msgctxt "keyboard key"
+msgid "PgDn"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:58
+msgctxt "keyboard key"
+msgid "Left"
+msgstr "बायें"
+
+#: ../src/common/accelcmn.cpp:59
+msgctxt "keyboard key"
+msgid "Right"
+msgstr "दायें"
+
+#: ../src/common/accelcmn.cpp:60
+msgctxt "keyboard key"
+msgid "Up"
+msgstr "ऊपर"
+
+#: ../src/common/accelcmn.cpp:61
+msgctxt "keyboard key"
+msgid "Down"
+msgstr "नीचे"
+
+#: ../src/common/accelcmn.cpp:62
+msgctxt "keyboard key"
+msgid "Home"
+msgstr "गृह"
+
+#: ../src/common/accelcmn.cpp:63
+msgctxt "keyboard key"
+msgid "End"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:64
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Space"
+msgstr "अन्तराल"
+
+#: ../src/common/accelcmn.cpp:65
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Tab"
+msgstr "टेब्स"
+
+#: ../src/common/accelcmn.cpp:66
+msgctxt "keyboard key"
+msgid "Esc"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:67
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Escape"
+msgstr "लैडस्केप"
+
+#: ../src/common/accelcmn.cpp:68
+msgctxt "keyboard key"
+msgid "Cancel"
+msgstr "निरस्त"
+
+#: ../src/common/accelcmn.cpp:69
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Clear"
+msgstr "साफ़ करें (&C)"
+
+#: ../src/common/accelcmn.cpp:70
+msgctxt "keyboard key"
+msgid "Menu"
+msgstr "विकल्प सूची"
+
+#: ../src/common/accelcmn.cpp:71
+msgctxt "keyboard key"
+msgid "Pause"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:72
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Capital"
+msgstr "बड़े अक्षर (&P)"
+
+#: ../src/common/accelcmn.cpp:73
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Select"
+msgstr "चयन"
+
+#: ../src/common/accelcmn.cpp:74
+msgctxt "keyboard key"
+msgid "Print"
+msgstr "मुद्रण"
+
+#: ../src/common/accelcmn.cpp:75
+msgctxt "keyboard key"
+msgid "Execute"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:76
+msgctxt "keyboard key"
+msgid "Snapshot"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:77
+msgctxt "keyboard key"
+msgid "Help"
+msgstr "सहायता"
+
+#: ../src/common/accelcmn.cpp:78
+msgctxt "keyboard key"
+msgid "Add"
+msgstr "जोड़ें"
+
+#: ../src/common/accelcmn.cpp:79
+msgctxt "keyboard key"
+msgid "Separator"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:80
+msgctxt "keyboard key"
+msgid "Subtract"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:81
+msgctxt "keyboard key"
+msgid "Decimal"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:82
+msgctxt "keyboard key"
+msgid "Multiply"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:83
+msgctxt "keyboard key"
+msgid "Divide"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:84
+msgctxt "keyboard key"
+msgid "Num_lock"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:84
+msgctxt "keyboard key"
+msgid "Num Lock"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:85
+msgctxt "keyboard key"
+msgid "Scroll_lock"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:85
+msgctxt "keyboard key"
+msgid "Scroll Lock"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:86
+msgctxt "keyboard key"
+msgid "KP_Space"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:86
+msgctxt "keyboard key"
+msgid "Num Space"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:87
+#, fuzzy
+msgctxt "keyboard key"
+msgid "KP_Tab"
+msgstr "KP_TAB"
+
+#: ../src/common/accelcmn.cpp:87
+msgctxt "keyboard key"
+msgid "Num Tab"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:88
+#, fuzzy
+msgctxt "keyboard key"
+msgid "KP_Enter"
+msgstr "मुद्रक"
+
+#: ../src/common/accelcmn.cpp:88
+msgctxt "keyboard key"
+msgid "Num Enter"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:89
+#, fuzzy
+msgctxt "keyboard key"
+msgid "KP_Home"
+msgstr "गृह"
+
+#: ../src/common/accelcmn.cpp:89
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Num Home"
+msgstr "गृह"
+
+#: ../src/common/accelcmn.cpp:90
+#, fuzzy
+msgctxt "keyboard key"
+msgid "KP_Left"
+msgstr "बायें"
+
+#: ../src/common/accelcmn.cpp:90
+msgctxt "keyboard key"
+msgid "Num left"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:91
+#, fuzzy
+msgctxt "keyboard key"
+msgid "KP_Up"
+msgstr "KP_UP"
+
+#: ../src/common/accelcmn.cpp:91
+msgctxt "keyboard key"
+msgid "Num Up"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:92
+#, fuzzy
+msgctxt "keyboard key"
+msgid "KP_Right"
+msgstr "दायें"
+
+#: ../src/common/accelcmn.cpp:92
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Num Right"
+msgstr "दायें"
+
+#: ../src/common/accelcmn.cpp:93
+#, fuzzy
+msgctxt "keyboard key"
+msgid "KP_Down"
+msgstr "नीचे"
+
+#: ../src/common/accelcmn.cpp:93
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Num Down"
+msgstr "नीचे"
+
+#: ../src/common/accelcmn.cpp:94
+msgctxt "keyboard key"
+msgid "KP_PageUp"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:94
+msgctxt "keyboard key"
+msgid "Num Page Up"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:95
+msgctxt "keyboard key"
+msgid "KP_PageDown"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:95
+msgctxt "keyboard key"
+msgid "Num Page Down"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:96
+msgctxt "keyboard key"
+msgid "KP_Prior"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:97
+#, fuzzy
+msgctxt "keyboard key"
+msgid "KP_Next"
+msgstr "अगला"
+
+#: ../src/common/accelcmn.cpp:98
+#, fuzzy
+msgctxt "keyboard key"
+msgid "KP_End"
+msgstr "KP_END"
+
+#: ../src/common/accelcmn.cpp:98
+msgctxt "keyboard key"
+msgid "Num End"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:99
+msgctxt "keyboard key"
+msgid "KP_Begin"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:99
+msgctxt "keyboard key"
+msgid "Num Begin"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:100
+#, fuzzy
+msgctxt "keyboard key"
+msgid "KP_Insert"
+msgstr "डाले"
+
+#: ../src/common/accelcmn.cpp:100
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Num Insert"
+msgstr "डाले"
+
+#: ../src/common/accelcmn.cpp:101
+#, fuzzy
+msgctxt "keyboard key"
+msgid "KP_Delete"
+msgstr "मिटाएँं"
+
+#: ../src/common/accelcmn.cpp:101
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Num Delete"
+msgstr "मिटाएँं"
+
+#: ../src/common/accelcmn.cpp:102
+msgctxt "keyboard key"
+msgid "KP_Equal"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:102
+msgctxt "keyboard key"
+msgid "Num ="
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:103
+msgctxt "keyboard key"
+msgid "KP_Multiply"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:103
+msgctxt "keyboard key"
+msgid "Num *"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:104
+#, fuzzy
+msgctxt "keyboard key"
+msgid "KP_Add"
+msgstr "KP_ADD"
+
+#: ../src/common/accelcmn.cpp:104
+msgctxt "keyboard key"
+msgid "Num +"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:105
+msgctxt "keyboard key"
+msgid "KP_Separator"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:105
+msgctxt "keyboard key"
+msgid "Num ,"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:106
+msgctxt "keyboard key"
+msgid "KP_Subtract"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:106
+msgctxt "keyboard key"
+msgid "Num -"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:107
+msgctxt "keyboard key"
+msgid "KP_Decimal"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:107
+msgctxt "keyboard key"
+msgid "Num ."
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:108
+msgctxt "keyboard key"
+msgid "KP_Divide"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:108
+msgctxt "keyboard key"
+msgid "Num /"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:109
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Windows_Left"
+msgstr "विण्डो 95"
+
+#: ../src/common/accelcmn.cpp:110
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Windows_Right"
+msgstr "विण्डो 95"
+
+#: ../src/common/accelcmn.cpp:111
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Windows_Menu"
+msgstr "विण्डो एम ई"
+
+#: ../src/common/accelcmn.cpp:112
+msgctxt "keyboard key"
+msgid "Command"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:186 ../src/common/accelcmn.cpp:359
+msgctxt "keyboard key"
+msgid "Ctrl"
+msgstr "Ctrl"
+
+#: ../src/common/accelcmn.cpp:188 ../src/common/accelcmn.cpp:363
+msgctxt "keyboard key"
+msgid "Alt"
+msgstr "Alt"
+
+#: ../src/common/accelcmn.cpp:190 ../src/common/accelcmn.cpp:361
+msgctxt "keyboard key"
+msgid "Shift"
+msgstr "Shift"
+
+#: ../src/common/accelcmn.cpp:196
+msgctxt "keyboard key"
+msgid "num "
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:260 ../src/common/accelcmn.cpp:382
+msgctxt "keyboard key"
+msgid "F"
+msgstr "F"
+
+#: ../src/common/accelcmn.cpp:277 ../src/common/accelcmn.cpp:385
+msgctxt "keyboard key"
+msgid "KP_F"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:280 ../src/common/accelcmn.cpp:388
+msgctxt "keyboard key"
+msgid "KP_"
+msgstr "KP_"
+
+#: ../src/common/accelcmn.cpp:283 ../src/common/accelcmn.cpp:391
+msgctxt "keyboard key"
+msgid "SPECIAL"
+msgstr "SPECIAL"
+
+#: ../src/common/accelcmn.cpp:373
+#, fuzzy
+msgid "Ctrl"
+msgstr "Ctrl"
+
+#: ../src/common/appbase.cpp:786
+msgid "show this help message"
+msgstr "इस सहायता संदेश को दिखाएँ"
+
+#: ../src/common/appbase.cpp:796
+msgid "generate verbose log messages"
+msgstr "वर्णनात्मक लॉग संदेशो का जनन करें"
+
+#: ../src/common/appcmn.cpp:256
+msgid "specify the theme to use"
+msgstr "उपयोगार्थ थीम को निर्दिष्ट करें"
+
+#: ../src/common/appcmn.cpp:270
+msgid "specify display mode to use (e.g. 640x480-16)"
+msgstr "उपयोगार्थ अवलोकन विधा को निर्दिष्ट करें (उदाहरण हेतु ६४०x४८०-१६)"
+
+#: ../src/common/appcmn.cpp:292
+#, c-format
+msgid "Unsupported theme '%s'."
+msgstr "असमर्थित थीम '%s' ।"
+
+#: ../src/common/appcmn.cpp:309
+#, fuzzy, c-format
+msgid "Invalid display mode specification '%s'."
+msgstr "अवैध जयामिति विशिष्टतायें '%s'"
+
+#: ../src/common/cmdline.cpp:875
+#, fuzzy, c-format
+msgid "Option '%s' can't be negated"
+msgstr "'%s' निर्देशिका का निर्माण नहीं किया जा सकता था"
+
+#: ../src/common/cmdline.cpp:889
+#, c-format
+msgid "Unknown long option '%s'"
+msgstr "अज्ञात लंबा विकल्प '%s'"
+
+#: ../src/common/cmdline.cpp:904 ../src/common/cmdline.cpp:926
+#, c-format
+msgid "Unknown option '%s'"
+msgstr "अज्ञात विकल्प '%s'"
+
+#: ../src/common/cmdline.cpp:1004
+#, c-format
+msgid "Unexpected characters following option '%s'."
+msgstr "विकल्प के पश्चात अप्रत्याशित संप्रतीक '%s'।"
+
+#: ../src/common/cmdline.cpp:1039
+#, c-format
+msgid "Option '%s' requires a value."
+msgstr "'%s' विकल्प को एक वैल्यू की आवश्यकता है।"
+
+#: ../src/common/cmdline.cpp:1058
+#, c-format
+msgid "Separator expected after the option '%s'."
+msgstr "'%s' के बाद एक पृथककारी चिह्न की आशा की जाती है।"
+
+#: ../src/common/cmdline.cpp:1088 ../src/common/cmdline.cpp:1106
+#, c-format
+msgid "'%s' is not a correct numeric value for option '%s'."
+msgstr "'%s' एक सही सांख्यानिक मूल्य '%s' विकल्प के लिए नहीं है।"
+
+#: ../src/common/cmdline.cpp:1122
+#, c-format
+msgid "Option '%s': '%s' cannot be converted to a date."
+msgstr "विकल्प '%s': '%s' को एक तिथि में नहीं बदला जा सका।"
+
+#: ../src/common/cmdline.cpp:1170
+#, c-format
+msgid "Unexpected parameter '%s'"
+msgstr "अप्रत्याशित पैरामीटर '%s'"
+
+#. TRANSLATORS: Short name and long name for a command line option
+#: ../src/common/cmdline.cpp:1197
+#, c-format
+msgid "%s (or %s)"
+msgstr "%s (या %s)"
+
+#: ../src/common/cmdline.cpp:1208
+#, c-format
+msgid "The value for the option '%s' must be specified."
+msgstr "'%s' विकल्प के लिए इस मूल्य को निर्दिष्ट करना अनिवार्य है।"
+
+#: ../src/common/cmdline.cpp:1230
+#, c-format
+msgid "The required parameter '%s' was not specified."
+msgstr "आवश्यक पैरामीटर '%s' को निर्दिष्ट नहीं किया गया था।"
+
+#: ../src/common/cmdline.cpp:1289
+#, c-format
+msgid "Usage: %s"
+msgstr "उपयोगिता: %s"
+
+#: ../src/common/cmdline.cpp:1498
+msgid "str"
+msgstr "str"
+
+#: ../src/common/cmdline.cpp:1502
+msgid "num"
+msgstr "num"
+
+#: ../src/common/cmdline.cpp:1506
+msgid "double"
+msgstr ""
+
+#: ../src/common/cmdline.cpp:1510
+msgid "date"
+msgstr "तिथि"
+
+#: ../src/common/cmdproc.cpp:250 ../src/common/cmdproc.cpp:276
+#: ../src/common/cmdproc.cpp:296
+msgid "Unnamed command"
+msgstr "बेनाम निर्देश"
+
+#: ../src/common/cmdproc.cpp:253
+msgid "&Undo "
+msgstr "पहिले जैसा करें (&U) "
+
+#: ../src/common/cmdproc.cpp:255
+msgid "Can't &Undo "
+msgstr "पहिले जैसा नहीं किया जा सकता है (&U)"
+
+#: ../src/common/cmdproc.cpp:259 ../src/common/stockitem.cpp:208
+#: ../src/msw/textctrl.cpp:2880 ../src/osx/textctrl_osx.cpp:649
+#: ../src/richtext/richtextctrl.cpp:327
+msgid "&Undo"
+msgstr "पहिले जैसा करें (&U)"
+
+#: ../src/common/cmdproc.cpp:277 ../src/common/cmdproc.cpp:297
+msgid "&Redo "
+msgstr "पुनःकरें (&R)"
+
+#: ../src/common/cmdproc.cpp:281 ../src/common/cmdproc.cpp:288
+#: ../src/common/stockitem.cpp:190 ../src/msw/textctrl.cpp:2881
+#: ../src/osx/textctrl_osx.cpp:650 ../src/richtext/richtextctrl.cpp:328
+msgid "&Redo"
+msgstr "पुनःकरें (&R)"
+
+#: ../src/common/colourcmn.cpp:41
+#, c-format
+msgid "String To Colour : Incorrect colour specification : %s"
+msgstr "स्ट्रींग से रंग : अमान्य रंग विशिष्टतायें : %s"
+
+#: ../src/common/config.cpp:259
+#, c-format
+msgid "Invalid value %ld for a boolean key \"%s\" in config file."
+msgstr ""
+
+#: ../src/common/config.cpp:526
+#, c-format
+msgid ""
+"Environment variables expansion failed: missing '%c' at position %u in '%s'."
+msgstr "वातावरण चरों का विस्तार असफ़ल रहा: '%c' विलुप्त %u स्थान पर '%s' में।"
+
+#: ../src/common/config.cpp:576 ../src/msw/regconf.cpp:272
+#, c-format
+msgid "'%s' has extra '..', ignored."
+msgstr "'%s' में अतिरिक्त '..' है, ध्यान नहीं दिया गया।"
+
+#. TRANSLATORS: Checkbox state name
+#: ../src/common/datavcmn.cpp:2166 ../src/generic/datavgen.cpp:1430
+msgid "checked"
+msgstr ""
+
+#. TRANSLATORS: Checkbox state name
+#: ../src/common/datavcmn.cpp:2170 ../src/generic/datavgen.cpp:1432
+msgid "unchecked"
+msgstr ""
+
+#. TRANSLATORS: Checkbox state name
+#: ../src/common/datavcmn.cpp:2174
+#, fuzzy
+msgid "undetermined"
+msgstr "रेखांकित"
+
+#: ../src/common/datetimefmt.cpp:1875
+msgid "today"
+msgstr "आज"
+
+#: ../src/common/datetimefmt.cpp:1876
+msgid "yesterday"
+msgstr "बीताहुआकल"
+
+#: ../src/common/datetimefmt.cpp:1877
+msgid "tomorrow"
+msgstr "कल"
+
+#: ../src/common/datetimefmt.cpp:2071
+msgid "first"
+msgstr "प्रथम"
+
+#: ../src/common/datetimefmt.cpp:2072
+msgid "second"
+msgstr "सेकन्ड"
+
+#: ../src/common/datetimefmt.cpp:2073
+msgid "third"
+msgstr "तीसरा"
+
+#: ../src/common/datetimefmt.cpp:2074
+msgid "fourth"
+msgstr "चौथा"
+
+#: ../src/common/datetimefmt.cpp:2075
+msgid "fifth"
+msgstr "पाँचवाँ"
+
+#: ../src/common/datetimefmt.cpp:2076
+msgid "sixth"
+msgstr "छठवाँ"
+
+#: ../src/common/datetimefmt.cpp:2077
+msgid "seventh"
+msgstr "सातवाँ"
+
+#: ../src/common/datetimefmt.cpp:2078
+msgid "eighth"
+msgstr "आठवाँ"
+
+#: ../src/common/datetimefmt.cpp:2079
+msgid "ninth"
+msgstr "नौवाँ"
+
+#: ../src/common/datetimefmt.cpp:2080
+msgid "tenth"
+msgstr "दसवाँ"
+
+#: ../src/common/datetimefmt.cpp:2081
+msgid "eleventh"
+msgstr "ग्यारहवाँ"
+
+#: ../src/common/datetimefmt.cpp:2082
+msgid "twelfth"
+msgstr "बारहवाँ"
+
+#: ../src/common/datetimefmt.cpp:2083
+msgid "thirteenth"
+msgstr "तेरहवाँ"
+
+#: ../src/common/datetimefmt.cpp:2084
+msgid "fourteenth"
+msgstr "चौदहवाँ"
+
+#: ../src/common/datetimefmt.cpp:2085
+msgid "fifteenth"
+msgstr "पन्द्रहवाँ"
+
+#: ../src/common/datetimefmt.cpp:2086
+msgid "sixteenth"
+msgstr "सोलहवाँ"
+
+#: ../src/common/datetimefmt.cpp:2087
+msgid "seventeenth"
+msgstr "सत्रहवाँ"
+
+#: ../src/common/datetimefmt.cpp:2088
+msgid "eighteenth"
+msgstr "अठारहवाँ"
+
+#: ../src/common/datetimefmt.cpp:2089
+msgid "nineteenth"
+msgstr "उन्नीसवाँ"
+
+#: ../src/common/datetimefmt.cpp:2090
+msgid "twentieth"
+msgstr "बीसवाँ"
+
+#: ../src/common/datetimefmt.cpp:2248
+msgid "noon"
+msgstr "दोपहर"
+
+#: ../src/common/datetimefmt.cpp:2249
+msgid "midnight"
+msgstr "अर्धरात्रि"
+
+#: ../src/common/debugrpt.cpp:209
+#, c-format
+msgid "Failed to create directory \"%s\""
+msgstr "\"%s\" निर्देशिका का निर्माण करने में असफ़ल।"
+
+#: ../src/common/debugrpt.cpp:210
+msgid "Debug report couldn't be created."
+msgstr "दोषमार्जन विवरण नहीं बनाया जा सका।"
+
+#: ../src/common/debugrpt.cpp:227
+#, c-format
+msgid "Failed to remove debug report file \"%s\""
+msgstr "दोषमार्जन विवरण फ़ाइल \"%s\" को हटाने में असफ़ल"
+
+#: ../src/common/debugrpt.cpp:239
+#, c-format
+msgid "Failed to clean up debug report directory \"%s\""
+msgstr "दोषमार्जन विवरण निर्देशिका \"%s\" को साफ करने में असफ़ल।"
+
+#: ../src/common/debugrpt.cpp:514
+msgid "process context description"
+msgstr "प्रक्रम संदर्भ वर्णन"
+
+#: ../src/common/debugrpt.cpp:538
+msgid "dump of the process state (binary)"
+msgstr ""
+
+#: ../src/common/debugrpt.cpp:553
+msgid "Debug report generation has failed."
+msgstr "दोषमार्जन विवरण बनाने में असफ़ल।"
+
+#: ../src/common/debugrpt.cpp:560
+#, c-format
+msgid ""
+"Processing debug report has failed, leaving the files in \"%s\" directory."
+msgstr ""
+"दोषमार्जन विवरण संसाधित करने में असफ़ल, फ़ाइलों को \"%s\" निर्देशिका में ही छोड़ा जा रहा "
+"हें।"
+
+#: ../src/common/debugrpt.cpp:573
+msgid "A debug report has been generated. It can be found in"
+msgstr "एक दोषमार्जन विवरण बन गया हें। ये इस निर्देशिका में पाया जा सकता हें: "
+
+#: ../src/common/debugrpt.cpp:576
+msgid "And includes the following files:\n"
+msgstr "और नीचे दी गयी फ़ाइलें सम्मिलित हें:\n"
+
+#: ../src/common/debugrpt.cpp:586
+msgid ""
+"\n"
+"Please send this report to the program maintainer, thank you!\n"
+msgstr ""
+"\n"
+"आपका धन्यवाद, कृपया इस विवरण को प्रोग्राम संरक्षक को भेजे।\n"
+
+#: ../src/common/debugrpt.cpp:729
+msgid "Failed to execute curl, please install it in PATH."
+msgstr ""
+
+#: ../src/common/debugrpt.cpp:742
+#, c-format
+msgid "Failed to upload the debug report (error code %d)."
+msgstr "दोषमार्जन विवरण को अपलोड करने में असफ़ल (त्रुटि कूट %d)।"
+
+#: ../src/common/docview.cpp:366
+#, fuzzy
+msgid "Save As"
+msgstr "जैसा सुरक्षित करें"
+
+#: ../src/common/docview.cpp:457
+msgid "Discard changes and reload the last saved version?"
+msgstr ""
+
+#: ../src/common/docview.cpp:488
+msgid "unnamed"
+msgstr "बिनानामदियाहुआ"
+
+#: ../src/common/docview.cpp:513
+#, fuzzy, c-format
+msgid "Do you want to save changes to %s?"
+msgstr "क्या आप %s प्रलेख पर परिवर्तनों को सुरक्षित करना चाहते है?"
+
+#: ../src/common/docview.cpp:521 ../src/common/docview.cpp:560
+#: ../src/common/stockitem.cpp:195
+msgid "&Save"
+msgstr "सुरक्षित करें (&S)"
+
+#: ../src/common/docview.cpp:522 ../src/common/docview.cpp:560
+msgid "&Discard changes"
+msgstr ""
+
+#: ../src/common/docview.cpp:523
+#, fuzzy
+msgid "Do&n't close"
+msgstr "सुरक्षित न करें"
+
+#: ../src/common/docview.cpp:553
+#, fuzzy, c-format
+msgid "Do you want to save changes to %s before closing it?"
+msgstr "क्या आप %s प्रलेख पर परिवर्तनों को सुरक्षित करना चाहते है?"
+
+#: ../src/common/docview.cpp:559
+#, fuzzy
+msgid "The document must be closed."
+msgstr "इस पाठ को सुरक्षित किया जा सका।"
+
+#: ../src/common/docview.cpp:571
+#, c-format
+msgid "Saving %s failed, would you like to retry?"
+msgstr ""
+
+#: ../src/common/docview.cpp:577
+msgid "Retry"
+msgstr ""
+
+#: ../src/common/docview.cpp:577
+msgid "Discard changes"
+msgstr ""
+
+#: ../src/common/docview.cpp:679
+#, fuzzy, c-format
+msgid "File \"%s\" could not be opened for writing."
+msgstr "wxWidgets '%s' के लिए अवलोकन को खोल नहीं पाया: बाहर निकल रहा है।"
+
+#: ../src/common/docview.cpp:685
+#, fuzzy, c-format
+msgid "Failed to save document to the file \"%s\"."
+msgstr "बिट्मैप आकॄति को \"%s\" फ़ाइल पर सुरक्षित करने में असफ़ल।"
+
+#: ../src/common/docview.cpp:702
+#, fuzzy, c-format
+msgid "File \"%s\" could not be opened for reading."
+msgstr "फ़ाइल को लोड नहीं किया जा सका।"
+
+#: ../src/common/docview.cpp:714
+#, fuzzy, c-format
+msgid "Failed to read document from the file \"%s\"."
+msgstr "%d आकॄति को '%s' फ़ाइल से लोड करने में असफ़ल।"
+
+#: ../src/common/docview.cpp:1236
+#, c-format
+msgid ""
+"The file '%s' doesn't exist and couldn't be opened.\n"
+"It has been removed from the most recently used files list."
+msgstr ""
+"'%s' यह निर्देशिका विद्यमान नहीं है और इसे खोला नहीं जा सका।\n"
+"इसे हाल ही में उपयोग में लायी गयी हुई फ़ाइलों की सूची में से हटा दिया गया है।"
+
+#: ../src/common/docview.cpp:1296
+#, fuzzy
+msgid "Print preview creation failed."
+msgstr "पाइप का निर्माण असफ़ल रहा"
+
+#: ../src/common/docview.cpp:1302
+msgid "Print Preview"
+msgstr "मुद्रण पूर्वालोकन"
+
+#: ../src/common/docview.cpp:1517
+#, fuzzy, c-format
+msgid "The format of file '%s' couldn't be determined."
+msgstr "'%s' निर्देशिका का निर्माण नहीं किया जा सकता था"
+
+#: ../src/common/docview.cpp:1643
+#, c-format
+msgid "unnamed%d"
+msgstr "बिनानामदियाहुआ %d"
+
+#: ../src/common/docview.cpp:1660
+msgid " - "
+msgstr " - "
+
+#: ../src/common/docview.cpp:1791 ../src/common/docview.cpp:1844
+msgid "Open File"
+msgstr "फ़ाइल खोलें"
+
+#: ../src/common/docview.cpp:1807
+msgid "File error"
+msgstr "फ़ाइल त्रुटि"
+
+#: ../src/common/docview.cpp:1809
+msgid "Sorry, could not open this file."
+msgstr "क्षमा करें, इस फ़ाइल को खोला नहीं जा सका।"
+
+#: ../src/common/docview.cpp:1843
+msgid "Sorry, the format for this file is unknown."
+msgstr "क्षमा करें, इस फ़ाइल का प्रारूप अज्ञात है।"
+
+#: ../src/common/docview.cpp:1924
+msgid "Select a document template"
+msgstr "एक प्रलेख टेम्पलेट का चयन करें"
+
+#: ../src/common/docview.cpp:1925
+msgid "Templates"
+msgstr "टेम्पलेट्स"
+
+#: ../src/common/docview.cpp:1998
+msgid "Select a document view"
+msgstr "एक प्रलेख व्यू का चयन करें"
+
+#: ../src/common/docview.cpp:1999
+msgid "Views"
+msgstr "अवलोकन"
+
+#: ../src/common/dynlib.cpp:81
+#, c-format
+msgid "Failed to load shared library '%s'"
+msgstr "'%s' साझा लायबरी को लोड करने में असफ़ल"
+
+#: ../src/common/dynlib.cpp:105
+#, c-format
+msgid "Couldn't find symbol '%s' in a dynamic library"
+msgstr "एक गतिक लेखागार में '%s' चिह्न को नहीं खोजा जा सका"
+
+#: ../src/common/ffile.cpp:56 ../src/common/file.cpp:215
+#, c-format
+msgid "can't open file '%s'"
+msgstr "'%s' फ़ाइल को खोला नहीं जा सकता है"
+
+#: ../src/common/ffile.cpp:72
+#, c-format
+msgid "can't close file '%s'"
+msgstr "'%s' फ़ाइल को बन्द नहीं किया जा सकता है"
+
+#: ../src/common/ffile.cpp:106 ../src/common/ffile.cpp:131
+#, c-format
+msgid "Read error on file '%s'"
+msgstr "'%s' फ़ाइल पर पठन त्रुटि"
+
+#: ../src/common/ffile.cpp:148
+#, c-format
+msgid "Write error on file '%s'"
+msgstr "'%s' फ़ाइल पर लेखन त्रुटि"
+
+#: ../src/common/ffile.cpp:182
+#, c-format
+msgid "failed to flush the file '%s'"
+msgstr "'%s' फ़ाइल को फ़्लैश करने में असफ़लता"
+
+#: ../src/common/ffile.cpp:222
+#, c-format
+msgid "Seek error on file '%s' (large files not supported by stdio)"
+msgstr ""
+
+#: ../src/common/ffile.cpp:232
+#, c-format
+msgid "Seek error on file '%s'"
+msgstr "'%s' फ़ाइल पर खोज त्रुटि"
+
+#: ../src/common/ffile.cpp:248
+#, c-format
+msgid "Can't find current position in file '%s'"
+msgstr " '%s' फ़ाइल में वर्तमान स्थिति नहीं खोजी जा सकती है"
+
+#: ../src/common/ffile.cpp:349 ../src/common/file.cpp:569
+msgid "Failed to set temporary file permissions"
+msgstr "अस्थायी फ़ाइल अनुमतियों को स्थापित करने में असफ़ल"
+
+#: ../src/common/ffile.cpp:371
+#, c-format
+msgid "can't remove file '%s'"
+msgstr "'%s' फ़ाइल को हटाया नहीं जा सकता है"
+
+#: ../src/common/ffile.cpp:376 ../src/common/file.cpp:591
+#, c-format
+msgid "can't commit changes to file '%s'"
+msgstr "'%s' फ़ाइल पर परिवर्तनों को प्रतिबद्धित नहीं किया जा सकता है"
+
+#: ../src/common/ffile.cpp:388 ../src/common/file.cpp:603
+#, c-format
+msgid "can't remove temporary file '%s'"
+msgstr "'%s' अस्थायी फ़ाइल को हटाया नहीं जा सकता है"
+
+#: ../src/common/file.cpp:162
+#, c-format
+msgid "can't create file '%s'"
+msgstr "'%s' फ़ाइल का निर्माण किया जा सकता है"
+
+#: ../src/common/file.cpp:229
+#, c-format
+msgid "can't close file descriptor %d"
+msgstr "फ़ाइल विवरणकर्ता %d को बन्द नहीं किया जा सकता है"
+
+#: ../src/common/file.cpp:332
+#, c-format
+msgid "can't read from file descriptor %d"
+msgstr "फ़ाइल विवरणकर्ता %d से पढ़ा नहीं जा सकता है"
+
+#: ../src/common/file.cpp:351
+#, c-format
+msgid "can't write to file descriptor %d"
+msgstr "फ़ाइल विवरणकर्ता %d पर लिखा नहीं जा सकता है"
+
+#: ../src/common/file.cpp:390
+#, c-format
+msgid "can't flush file descriptor %d"
+msgstr "फ़ाइल विवरणकर्ता %d को फ़्लैश नहीं किया जा सकता है"
+
+#: ../src/common/file.cpp:432
+#, c-format
+msgid "can't seek on file descriptor %d"
+msgstr "फ़ाइल विवरणकर्ता %d पर खोज नहीं की जा सकती है"
+
+#: ../src/common/file.cpp:446
+#, c-format
+msgid "can't get seek position on file descriptor %d"
+msgstr "फ़ाइल विवरणकर्ता %d पर स्थिति को खोजा नहीं जा सकता है"
+
+#: ../src/common/file.cpp:475
+#, c-format
+msgid "can't find length of file on file descriptor %d"
+msgstr "%d फ़ाइल विवरणकर्ता पर फ़ाइल की लंबाई को पाया नहीं जा सकता है"
+
+#: ../src/common/file.cpp:505
+#, c-format
+msgid "can't determine if the end of file is reached on descriptor %d"
+msgstr "निश्चय नहीं किया जा सकता है कि %d विवरणकर्ता पर फ़ाइल की समाप्ति पहुँच गयी है"
+
+#: ../src/common/fileconf.cpp:352
+#, c-format
+msgid ""
+" and additionally, the existing configuration file was renamed to \"%s\" and "
+"couldn't be renamed back, please rename it to its original path \"%s\""
+msgstr ""
+
+#: ../src/common/fileconf.cpp:389
+#, fuzzy
+msgid " due to the following error:\n"
+msgstr "और नीचे दी गयी फ़ाइलें सम्मिलित हें:\n"
+
+#: ../src/common/fileconf.cpp:412
+#, fuzzy
+msgid "failed to rename the existing file"
+msgstr "%d आकॄति को '%s' फ़ाइल से लोड करने में असफ़ल।"
+
+#: ../src/common/fileconf.cpp:421
+#, fuzzy
+msgid "failed to create the new file directory"
+msgstr "कार्यशील निर्देशिका को प्राप्त करने में असफ़ल"
+
+#: ../src/common/fileconf.cpp:428
+#, fuzzy
+msgid "failed to move the file to the new location"
+msgstr "डायल-अप कनेक्शन को समाप्त करने में असफ़ल: %s"
+
+#: ../src/common/fileconf.cpp:462
+#, c-format
+msgid "can't open global configuration file '%s'."
+msgstr "विश्वव्यापी संरचना फ़ाइल '%s' को खोला नहीं जा सकता है।"
+
+#: ../src/common/fileconf.cpp:478
+#, c-format
+msgid "can't open user configuration file '%s'."
+msgstr "उपयोगकर्ता संरचना फ़ाइल '%s' को खोला नहीं जा सकता है।"
+
+#: ../src/common/fileconf.cpp:483
+#, c-format
+msgid "Changes won't be saved to avoid overwriting the existing file \"%s\""
+msgstr ""
+
+#: ../src/common/fileconf.cpp:583
+msgid "Error reading config options."
+msgstr "संरचना के विकल्पों को पढ़नें में त्रुटि।"
+
+#: ../src/common/fileconf.cpp:593
+msgid "Failed to read config options."
+msgstr "संरचना के विकल्पों को पढ़नें में त्रुटि।"
+
+#: ../src/common/fileconf.cpp:700
+#, fuzzy, c-format
+msgid "file '%s': unexpected character %c at line %zu."
+msgstr "फ़ाइल '%s': अप्रत्याशित %c शब्द %d पंक्ति पर।"
+
+#: ../src/common/fileconf.cpp:736
+#, fuzzy, c-format
+msgid "file '%s', line %zu: '%s' ignored after group header."
+msgstr "फ़ाइल '%s', पंक्ति %d: समूह शीर्ष के उपरान्त '%s' पर ध्यान नहीं दिया गया।"
+
+#: ../src/common/fileconf.cpp:765
+#, fuzzy, c-format
+msgid "file '%s', line %zu: '=' expected."
+msgstr "फ़ाइल '%s', पंक्ति %d: '=' की आशा की जाती है।"
+
+#: ../src/common/fileconf.cpp:778
+#, fuzzy, c-format
+msgid "file '%s', line %zu: value for immutable key '%s' ignored."
+msgstr "फ़ाइल '%s', पंक्ति %d: निर्विकल्प कुँजी '%s' के लिए मूल्य पर ध्यान नहीं दिया गया।"
+
+#: ../src/common/fileconf.cpp:788
+#, fuzzy, c-format
+msgid "file '%s', line %zu: key '%s' was first found at line %d."
+msgstr "फ़ाइल '%s', पंक्ति %d: '%s' कुँजी को सर्वप्रथम %d पंक्ति पर पाया गया था।"
+
+#: ../src/common/fileconf.cpp:1091
+#, c-format
+msgid "Config entry name cannot start with '%c'."
+msgstr "संरचना प्रविष्टी नाम '%c' से आरम्भ नहीं हो सकता है।"
+
+#: ../src/common/fileconf.cpp:1146
+#, fuzzy
+msgid "Failed to create configuration file directory."
+msgstr "उपयोगकर्ता संरचना फ़ाइल को अपडेट करने में असफ़ल।"
+
+#: ../src/common/fileconf.cpp:1158
+msgid "can't open user configuration file."
+msgstr "विश्वव्यापी संरचना फ़ाइल को खोला नहीं जा सकता है।"
+
+#: ../src/common/fileconf.cpp:1172
+msgid "can't write user configuration file."
+msgstr "उपयोगकर्ता संरचना फ़ाइल को लिखा नहीं जा सकता है।"
+
+#: ../src/common/fileconf.cpp:1178
+msgid "Failed to update user configuration file."
+msgstr "उपयोगकर्ता संरचना फ़ाइल को अपडेट करने में असफ़ल।"
+
+#: ../src/common/fileconf.cpp:1201
+msgid "Error saving user configuration data."
+msgstr "प्रयोक्ता की संरचना के विकल्पों को सुरक्षित करने में त्रुटि।"
+
+#: ../src/common/fileconf.cpp:1313
+#, c-format
+msgid "can't delete user configuration file '%s'"
+msgstr "'%s' उपयोगकर्ता संरचना फ़ाइल को मिटाय नहीं जा सकता है"
+
+#: ../src/common/fileconf.cpp:2007
+#, c-format
+msgid "entry '%s' appears more than once in group '%s'"
+msgstr "'%s' प्रविष्टी '%s' समूह में एक से अधिक बार आयी है"
+
+#: ../src/common/fileconf.cpp:2021
+#, c-format
+msgid "attempt to change immutable key '%s' ignored."
+msgstr "निर्विकल्प कुँजी '%s' को परिवर्तित करने के प्रयास पर ध्यान नहीं दिया गया। "
+
+#: ../src/common/fileconf.cpp:2118
+#, c-format
+msgid "trailing backslash ignored in '%s'"
+msgstr ""
+
+#: ../src/common/fileconf.cpp:2153
+#, c-format
+msgid "unexpected \" at position %d in '%s'."
+msgstr "अप्रत्याशित \" %d पर '%s' में ।"
+
+#: ../src/common/filefn.cpp:474
+#, c-format
+msgid "Failed to copy the file '%s' to '%s'"
+msgstr "'%s' फ़ाइल की '%s' पर प्रतिलिपि बनाने में असफ़ल"
+
+#: ../src/common/filefn.cpp:487
+#, c-format
+msgid "Impossible to get permissions for file '%s'"
+msgstr "'%s' फ़ाइले के लिए अनुमतियों को प्राप्त करना असम्भव"
+
+#: ../src/common/filefn.cpp:501
+#, c-format
+msgid "Impossible to overwrite the file '%s'"
+msgstr "'%s' फ़ाइल को पुनः आरम्भ से लिखना असम्भव"
+
+#: ../src/common/filefn.cpp:508
+#, fuzzy, c-format
+msgid "Error copying the file '%s' to '%s'."
+msgstr "'%s' फ़ाइल की '%s' पर प्रतिलिपि बनाने में असफ़ल"
+
+#: ../src/common/filefn.cpp:556
+#, c-format
+msgid "Impossible to set permissions for the file '%s'"
+msgstr "'%s' फ़ाइल के लिए अनुमतियों को स्थापित करना असम्भव"
+
+#: ../src/common/filefn.cpp:606
+#, c-format
+msgid ""
+"Failed to rename the file '%s' to '%s' because the destination file already "
+"exists."
+msgstr ""
+
+#: ../src/common/filefn.cpp:623
+#, fuzzy, c-format
+msgid "File '%s' couldn't be renamed '%s'"
+msgstr "'%s' निर्देशिका का निर्माण नहीं किया जा सकता था"
+
+#: ../src/common/filefn.cpp:639
+#, fuzzy, c-format
+msgid "File '%s' couldn't be removed"
+msgstr "'%s' निर्देशिका का निर्माण नहीं किया जा सकता था"
+
+#: ../src/common/filefn.cpp:666
+#, c-format
+msgid "Directory '%s' couldn't be created"
+msgstr "'%s' निर्देशिका का निर्माण नहीं किया जा सकता था"
+
+#: ../src/common/filefn.cpp:680
+#, fuzzy, c-format
+msgid "Directory '%s' couldn't be deleted"
+msgstr "'%s' निर्देशिका का निर्माण नहीं किया जा सकता था"
+
+#: ../src/common/filefn.cpp:714
+#, c-format
+msgid "Cannot enumerate files '%s'"
+msgstr "'%s' फ़ाइलों की परिगणना नहीं की जा सकती है"
+
+#: ../src/common/filefn.cpp:798
+msgid "Failed to get the working directory"
+msgstr "कार्यशील निर्देशिका को प्राप्त करने में असफ़ल"
+
+#: ../src/common/filefn.cpp:843
+#, fuzzy
+msgid "Could not set current working directory"
+msgstr "कार्यशील निर्देशिका को प्राप्त करने में असफ़ल"
+
+#: ../src/common/filefn.cpp:974
+#, c-format
+msgid "Files (%s)"
+msgstr "फ़ाइलें (%s)"
+
+#: ../src/common/filename.cpp:182
+#, fuzzy, c-format
+msgid "Failed to open '%s' for reading"
+msgstr "'%s' को %s के लिए खोलने में असफ़ल"
+
+#: ../src/common/filename.cpp:187
+#, fuzzy, c-format
+msgid "Failed to open '%s' for writing"
+msgstr "'%s' को %s के लिए खोलने में असफ़ल"
+
+#: ../src/common/filename.cpp:199
+msgid "Failed to close file handle"
+msgstr "फ़ाइल हैन्डल को बन्द करने में असफ़ल"
+
+#: ../src/common/filename.cpp:1046
+msgid "Failed to create a temporary file name"
+msgstr "एक अस्थायी फ़ाइल नाम का निर्माण करने में असफ़ल"
+
+#: ../src/common/filename.cpp:1081
+msgid "Failed to open temporary file."
+msgstr "अस्थायी फ़ाइल को खोलने में असफ़ल।"
+
+#: ../src/common/filename.cpp:2862
+#, c-format
+msgid "Failed to modify file times for '%s'"
+msgstr " '%s' के लिए फ़ाइल टाइम्स को परिवर्तित करने में असफ़ल"
+
+#: ../src/common/filename.cpp:2877
+#, c-format
+msgid "Failed to touch the file '%s'"
+msgstr "'%s' फ़ाइल को छूने में असफ़ल"
+
+#: ../src/common/filename.cpp:2958
+#, c-format
+msgid "Failed to retrieve file times for '%s'"
+msgstr "'%s' के लिए फ़ाइल टाइम्स को पुनःप्राप्त करने में असफ़ल"
+
+#: ../src/common/filepickercmn.cpp:39 ../src/common/filepickercmn.cpp:40
+msgid "Browse"
+msgstr ""
+
+#: ../src/common/fldlgcmn.cpp:792 ../src/generic/filectrlg.cpp:1185
+#, c-format
+msgid "All files (%s)|%s"
+msgstr "सभी फ़ाइलें (%s)|%s"
+
+#. TRANSLATORS: %s are a file extension used to build a file wildcard string
+#: ../src/common/fldlgcmn.cpp:810
+#, c-format
+msgid "%s files (%s)|%s"
+msgstr "%s फ़ाइलें (%s)|%s"
+
+#: ../src/common/fldlgcmn.cpp:1072
+#, c-format
+msgid "Load %s file"
+msgstr "%s फ़ाइल को लोड करें"
+
+#: ../src/common/fldlgcmn.cpp:1074
+#, c-format
+msgid "Save %s file"
+msgstr "%s फ़ाइल को सुरक्षित करें"
+
+#: ../src/common/fmapbase.cpp:144
+msgid "Western European (ISO-8859-1)"
+msgstr "वेस्टर्न यूरोपियन (आईसो-८८५९-१)"
+
+#: ../src/common/fmapbase.cpp:145
+msgid "Central European (ISO-8859-2)"
+msgstr "केन्द्रीय यूरोपियन (आईसो-८८५९-२)"
+
+#: ../src/common/fmapbase.cpp:146
+msgid "Esperanto (ISO-8859-3)"
+msgstr "ऐस्पेरान्तो (आईसो-८८५९-३)"
+
+#: ../src/common/fmapbase.cpp:147
+msgid "Baltic (old) (ISO-8859-4)"
+msgstr "बाल्टिक (प्राचीन) (आईसो-८८५९-४)"
+
+#: ../src/common/fmapbase.cpp:148
+msgid "Cyrillic (ISO-8859-5)"
+msgstr "सायरिलिक (आईसो-८८५९-५)"
+
+#: ../src/common/fmapbase.cpp:149
+msgid "Arabic (ISO-8859-6)"
+msgstr "अरबी (आईसो-८८५९-६)"
+
+#: ../src/common/fmapbase.cpp:150
+msgid "Greek (ISO-8859-7)"
+msgstr "ग्रीक (आईओ-८८५९-७)"
+
+#: ../src/common/fmapbase.cpp:151
+msgid "Hebrew (ISO-8859-8)"
+msgstr "हिब्रू (आईसो-८८५९-८)"
+
+#: ../src/common/fmapbase.cpp:152
+msgid "Turkish (ISO-8859-9)"
+msgstr "टर्क्रिश (आईओ-८८५९-९)"
+
+#: ../src/common/fmapbase.cpp:153
+msgid "Nordic (ISO-8859-10)"
+msgstr "नोर्डिक (आईसो-८८५९-१०)"
+
+#: ../src/common/fmapbase.cpp:154
+msgid "Thai (ISO-8859-11)"
+msgstr "थाई (आईसो-८८५९-११)"
+
+#: ../src/common/fmapbase.cpp:155
+msgid "Indian (ISO-8859-12)"
+msgstr "भारतीय (आईसो-८८५९-१२)"
+
+#: ../src/common/fmapbase.cpp:156
+msgid "Baltic (ISO-8859-13)"
+msgstr "बाल्टिक (आईसो-८८५९-१३)"
+
+#: ../src/common/fmapbase.cpp:157
+msgid "Celtic (ISO-8859-14)"
+msgstr "सेल्टिक (आईसो-८८५९-१४)"
+
+#: ../src/common/fmapbase.cpp:158
+msgid "Western European with Euro (ISO-8859-15)"
+msgstr "वेस्टर्न यूरोपियन यूरो सहित (आईसो-८८५९-१५)"
+
+#: ../src/common/fmapbase.cpp:159
+msgid "KOI8-R"
+msgstr "केओआई८-आर"
+
+#: ../src/common/fmapbase.cpp:160
+msgid "KOI8-U"
+msgstr "केओआई८-यू"
+
+#: ../src/common/fmapbase.cpp:161
+#, fuzzy
+msgid "Windows/DOS OEM Cyrillic (CP 866)"
+msgstr "विण्डो सायरिलिक (सीपी १२५१)"
+
+#: ../src/common/fmapbase.cpp:162
+msgid "Windows Thai (CP 874)"
+msgstr "विण्डो थाई (सीपी ८७४)"
+
+#: ../src/common/fmapbase.cpp:163
+#, fuzzy
+msgid "Windows Japanese (CP 932) or Shift-JIS"
+msgstr "विण्डो जापानी (सीपी ९३२)"
+
+#: ../src/common/fmapbase.cpp:164
+#, fuzzy
+msgid "Windows Chinese Simplified (CP 936) or GB-2312"
+msgstr "विण्डो चीनी सरलीकॄत (सीपी ९३६)"
+
+#: ../src/common/fmapbase.cpp:165
+msgid "Windows Korean (CP 949)"
+msgstr "विण्डो कोरियन (सीपी ९४९)"
+
+#: ../src/common/fmapbase.cpp:166
+#, fuzzy
+msgid "Windows Chinese Traditional (CP 950) or Big-5"
+msgstr "विण्डो चीनी पारम्परिक (सीपी ९५०)"
+
+#: ../src/common/fmapbase.cpp:167
+msgid "Windows Central European (CP 1250)"
+msgstr "विण्डो सेन्ट्रल यूरोपियन (सीपी १२५०)"
+
+#: ../src/common/fmapbase.cpp:168
+msgid "Windows Cyrillic (CP 1251)"
+msgstr "विण्डो सायरिलिक (सीपी १२५१)"
+
+#: ../src/common/fmapbase.cpp:169
+msgid "Windows Western European (CP 1252)"
+msgstr "विण्डो वेस्टर्न यूरोपियन (सीपी १२५२)"
+
+#: ../src/common/fmapbase.cpp:170
+msgid "Windows Greek (CP 1253)"
+msgstr "विण्डो ग्रीक (सीपी १२५३)"
+
+#: ../src/common/fmapbase.cpp:171
+msgid "Windows Turkish (CP 1254)"
+msgstr "विण्डो टर्किस (सीपी १२५४)"
+
+#: ../src/common/fmapbase.cpp:172
+msgid "Windows Hebrew (CP 1255)"
+msgstr "विण्डो हिब्रू (सीपी १२५५)"
+
+#: ../src/common/fmapbase.cpp:173
+msgid "Windows Arabic (CP 1256)"
+msgstr "विण्डो अरबी (सीपी १२५६)"
+
+#: ../src/common/fmapbase.cpp:174
+msgid "Windows Baltic (CP 1257)"
+msgstr "विण्डो बाल्टिक (सीपी १२५७)"
+
+#: ../src/common/fmapbase.cpp:175
+#, fuzzy
+msgid "Windows Vietnamese (CP 1258)"
+msgstr "विण्डो ग्रीक (सीपी १२५३)"
+
+#: ../src/common/fmapbase.cpp:176
+#, fuzzy
+msgid "Windows Johab (CP 1361)"
+msgstr "विण्डो अरबी (सीपी १२५६)"
+
+#: ../src/common/fmapbase.cpp:177
+msgid "Windows/DOS OEM (CP 437)"
+msgstr "विण्डो/डास ओईएम (सीपी ४३७)"
+
+#: ../src/common/fmapbase.cpp:178
+msgid "Unicode 7 bit (UTF-7)"
+msgstr "यूनीकोड ७ बिट् (यूटीएफ़-७)"
+
+#: ../src/common/fmapbase.cpp:179
+msgid "Unicode 8 bit (UTF-8)"
+msgstr "यूनीकोड ८ बिट् (यूटीएफ़-८)"
+
+#: ../src/common/fmapbase.cpp:181 ../src/common/fmapbase.cpp:187
+msgid "Unicode 16 bit (UTF-16)"
+msgstr "यूनीकोड १६ बिट् (यूटीएफ़-१६)"
+
+#: ../src/common/fmapbase.cpp:182
+msgid "Unicode 16 bit Little Endian (UTF-16LE)"
+msgstr "यूनीकोड १६ बिट् छोटा इंडीयन (यूटीएफ़-१६एलई)"
+
+#: ../src/common/fmapbase.cpp:183 ../src/common/fmapbase.cpp:189
+msgid "Unicode 32 bit (UTF-32)"
+msgstr "यूनीकोड ३२ बिट् (यूटीएफ़-३२)"
+
+#: ../src/common/fmapbase.cpp:184
+msgid "Unicode 32 bit Little Endian (UTF-32LE)"
+msgstr "यूनीकोड ३२ बिट् छोटा इंडीयन (यूटीएफ़-३२एलई)"
+
+#: ../src/common/fmapbase.cpp:186
+msgid "Unicode 16 bit Big Endian (UTF-16BE)"
+msgstr "यूनीकोड १६ बिट् बड़ा इंडीयन (यूटीएफ़-१६बीई)"
+
+#: ../src/common/fmapbase.cpp:188
+msgid "Unicode 32 bit Big Endian (UTF-32BE)"
+msgstr "यूनीकोड ३२ बिट् बड़ा इंडीयन (यूटीएफ़-३२बीई)"
+
+#: ../src/common/fmapbase.cpp:191
+msgid "Extended Unix Codepage for Japanese (EUC-JP)"
+msgstr "जापानी (ईयूसी-जेपी) के लिए विस्तॄत यूनिक्स कूटपृष्ट"
+
+#: ../src/common/fmapbase.cpp:192
+msgid "US-ASCII"
+msgstr "यू स-आस्की (ASCII)"
+
+#: ../src/common/fmapbase.cpp:193
+msgid "ISO-2022-JP"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:195
+#, fuzzy
+msgid "MacRoman"
+msgstr "रोमन"
+
+#: ../src/common/fmapbase.cpp:196
+msgid "MacJapanese"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:197
+msgid "MacChineseTrad"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:198
+msgid "MacKorean"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:199
+#, fuzzy
+msgid "MacArabic"
+msgstr "अरबी"
+
+#: ../src/common/fmapbase.cpp:200
+msgid "MacHebrew"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:201
+msgid "MacGreek"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:202
+msgid "MacCyrillic"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:203
+msgid "MacDevanagari"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:204
+msgid "MacGurmukhi"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:205
+msgid "MacGujarati"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:206
+msgid "MacOriya"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:207
+msgid "MacBengali"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:208
+msgid "MacTamil"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:209
+msgid "MacTelugu"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:210
+msgid "MacKannada"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:211
+msgid "MacMalayalam"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:212
+#, fuzzy
+msgid "MacSinhalese"
+msgstr "बड़ा-छोटा का मिलान करें"
+
+#: ../src/common/fmapbase.cpp:213
+msgid "MacBurmese"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:214
+msgid "MacKhmer"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:215
+msgid "MacThai"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:216
+msgid "MacLaotian"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:217
+msgid "MacGeorgian"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:218
+msgid "MacArmenian"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:219
+msgid "MacChineseSimp"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:220
+msgid "MacTibetan"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:221
+msgid "MacMongolian"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:222
+msgid "MacEthiopic"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:223
+msgid "MacCentralEurRoman"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:224
+msgid "MacVietnamese"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:225
+#, fuzzy
+msgid "MacExtArabic"
+msgstr "अरबी"
+
+#: ../src/common/fmapbase.cpp:226
+#, fuzzy
+msgid "MacSymbol"
+msgstr "चिह्न"
+
+#: ../src/common/fmapbase.cpp:227
+msgid "MacDingbats"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:228
+msgid "MacTurkish"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:229
+msgid "MacCroatian"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:230
+msgid "MacIcelandic"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:231
+#, fuzzy
+msgid "MacRomanian"
+msgstr "रोमन"
+
+#: ../src/common/fmapbase.cpp:232
+msgid "MacCeltic"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:233
+msgid "MacGaelic"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:234
+msgid "MacKeyboardGlyphs"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:791
+msgid "Default encoding"
+msgstr "डिफ़ाल्ट एन्कोडिंग"
+
+#: ../src/common/fmapbase.cpp:805
+#, c-format
+msgid "Unknown encoding (%d)"
+msgstr "अज्ञात एन्कोडिंग (%d)"
+
+#: ../src/common/fmapbase.cpp:815 ../src/richtext/richtextstyles.cpp:776
+msgid "default"
+msgstr "डिफ़ाल्ट"
+
+#: ../src/common/fmapbase.cpp:829
+#, c-format
+msgid "unknown-%d"
+msgstr "अज्ञात-%d"
+
+#: ../src/common/fontcmn.cpp:924 ../src/common/fontcmn.cpp:1130
+msgid "underlined"
+msgstr "रेखांकित"
+
+#: ../src/common/fontcmn.cpp:929
+#, fuzzy
+msgid " strikethrough"
+msgstr " स्ट्राइक थुःरु"
+
+#: ../src/common/fontcmn.cpp:942
+msgid " thin"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:946
+#, fuzzy
+msgid " extra light"
+msgstr "हल्का"
+
+#: ../src/common/fontcmn.cpp:950
+msgid " light"
+msgstr "हल्का"
+
+#: ../src/common/fontcmn.cpp:954
+msgid " medium"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:958
+#, fuzzy
+msgid " semi bold"
+msgstr "गहरा"
+
+#: ../src/common/fontcmn.cpp:962
+msgid " bold"
+msgstr "गहरा"
+
+#: ../src/common/fontcmn.cpp:966
+#, fuzzy
+msgid " extra bold"
+msgstr "गहरा"
+
+#: ../src/common/fontcmn.cpp:970
+msgid " heavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:974
+msgid " extra heavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:990
+msgid " italic"
+msgstr "तिरछा"
+
+#: ../src/common/fontcmn.cpp:1134
+#, fuzzy
+msgid "strikethrough"
+msgstr "स्ट्राइक थुःरु (S)"
+
+#: ../src/common/fontcmn.cpp:1143
+msgid "thin"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1156
+#, fuzzy
+msgid "extralight"
+msgstr "हल्का"
+
+#: ../src/common/fontcmn.cpp:1161
+msgid "light"
+msgstr "हल्का"
+
+#: ../src/common/fontcmn.cpp:1169 ../src/richtext/richtextstyles.cpp:775
+#, fuzzy
+msgid "normal"
+msgstr "सामान्य"
+
+#: ../src/common/fontcmn.cpp:1174
+msgid "medium"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1179 ../src/common/fontcmn.cpp:1199
+#, fuzzy
+msgid "semibold"
+msgstr "गहरा"
+
+#: ../src/common/fontcmn.cpp:1184
+msgid "bold"
+msgstr "गहरा"
+
+#: ../src/common/fontcmn.cpp:1194
+#, fuzzy
+msgid "extrabold"
+msgstr "गहरा"
+
+#: ../src/common/fontcmn.cpp:1204
+msgid "heavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1212
+msgid "extraheavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1217
+msgid "italic"
+msgstr "तिरछा"
+
+#: ../src/common/fontmap.cpp:195
+msgid ": unknown charset"
+msgstr ": अज्ञात शब्दसमुच्चय"
+
+#: ../src/common/fontmap.cpp:199
+#, c-format
+msgid ""
+"The charset '%s' is unknown. You may select\n"
+"another charset to replace it with or choose\n"
+"[Cancel] if it cannot be replaced"
+msgstr ""
+"यह '%s' शब्दसमुच्चय अज्ञात है। इसे बदलने के लिए\n"
+"आपको अन्य शब्दसमुच्चय का चयन या यदि यह बदला\n"
+"नहीं जा सकता है, तो [निरस्त] का चयन करना चाहिए"
+
+#: ../src/common/fontmap.cpp:241
+#, c-format
+msgid "Failed to remember the encoding for the charset '%s'."
+msgstr "'%s' शब्दसमुच्चय के लिए एन्कोडिंग को याद रखने में असफ़ल।"
+
+#: ../src/common/fontmap.cpp:321
+msgid "can't load any font, aborting"
+msgstr "किसी फ़ॉन्ट को लोड नहीं किया जा सकता है, निरस्त किया जा रहा है"
+
+#: ../src/common/fontmap.cpp:409
+msgid ": unknown encoding"
+msgstr ": अज्ञात एन्कोडिंग"
+
+#: ../src/common/fontmap.cpp:417
+#, c-format
+msgid ""
+"No font for displaying text in encoding '%s' found,\n"
+"but an alternative encoding '%s' is available.\n"
+"Do you want to use this encoding (otherwise you will have to choose another "
+"one)?"
+msgstr ""
+"'%s' एन्कोडिंग में पाठ को दिखाने के लिए कोई फ़ॉन्ट नहीं मिला,\n"
+"परन्तु एक वैकल्पिक एन्कोडिंग '%s' उपलब्ध है।\n"
+"क्या आप इस एन्कोडिंग को उपयोग करना चाहते है (अन्यथा आपकोएक अन्य का चयन करना पड़ेगा)?"
+
+#: ../src/common/fontmap.cpp:422
+#, c-format
+msgid ""
+"No font for displaying text in encoding '%s' found.\n"
+"Would you like to select a font to be used for this encoding\n"
+"(otherwise the text in this encoding will not be shown correctly)?"
+msgstr ""
+"'%s' एन्कोडिंग में पाठ को दिखाने के लिए कोई फ़ॉन्ट नहीं मिला,\n"
+"क्या आप इस एन्कोडिंग के लिए एक फ़ॉन्ट का चयन करना चाहेगें\n"
+"(अन्यथा यह पाठ इस एन्कोडिंग में भली-भांति नहीं दिखेगा)?"
+
+#: ../src/common/fs_mem.cpp:169
+#, c-format
+msgid "Memory VFS already contains file '%s'!"
+msgstr "स्मृति वीएफ़एस में पहिले से '%s' फ़ाइल शामिल है!"
+
+#: ../src/common/fs_mem.cpp:232
+#, c-format
+msgid "Trying to remove file '%s' from memory VFS, but it is not loaded!"
+msgstr ""
+"वीएफ़एस स्मॄति से  '%s' फ़ाइल को हटाने का प्रयास किया जा रहा है, परन्तु यह लोड नहीं है!"
+
+#: ../src/common/fs_mem.cpp:262
+#, c-format
+msgid "Failed to store image '%s' to memory VFS!"
+msgstr "'%s' आकॄति को वीएफ़एस स्मॄति में सुरक्षित करने में असफ़ल!"
+
+#: ../src/common/ftp.cpp:197
+#, fuzzy
+msgid "Timeout while waiting for FTP server to connect, try passive mode."
+msgstr "यह एफ़टीपी सर्वर निश्चेष्ट विधा का समर्थन नहीं करता है।"
+
+#: ../src/common/ftp.cpp:399
+#, c-format
+msgid "Failed to set FTP transfer mode to %s."
+msgstr "एफ़टीपी स्थानान्तरण विधा को %s पर स्थापित करने में असफ़ल।"
+
+#: ../src/common/ftp.cpp:400 ../src/richtext/richtextsymboldlg.cpp:432
+msgid "ASCII"
+msgstr "आस्की (ASCII)"
+
+#: ../src/common/ftp.cpp:400
+msgid "binary"
+msgstr "बायनरी"
+
+#: ../src/common/ftp.cpp:608
+msgid "The FTP server doesn't support the PORT command."
+msgstr "यह एफ़टीपी सर्वर पोर्ट समादेश को समर्थन नहीं करता है।"
+
+#: ../src/common/ftp.cpp:622
+msgid "The FTP server doesn't support passive mode."
+msgstr "यह एफ़टीपी सर्वर निश्चेष्ट विधा का समर्थन नहीं करता है।"
+
+#: ../src/common/gifdecod.cpp:822
+#, c-format
+msgid "Incorrect GIF frame size (%u, %d) for the frame #%u"
+msgstr ""
+
+#: ../src/common/glcmn.cpp:108
+#, fuzzy
+msgid "Failed to allocate colour for OpenGL"
+msgstr "कर्सर का निर्माण करने में असफ़ल।"
+
+#: ../src/common/headerctrlcmn.cpp:57
+msgid "Please select the columns to show and define their order:"
+msgstr ""
+
+#: ../src/common/headerctrlcmn.cpp:58
+msgid "Customize Columns"
+msgstr ""
+
+#: ../src/common/headerctrlcmn.cpp:304
+msgid "&Customize..."
+msgstr ""
+
+#: ../src/common/hyperlnkcmn.cpp:132
+#, fuzzy, c-format
+msgid "Failed to open URL \"%s\" in the default browser"
+msgstr "'%s' को %s के लिए खोलने में असफ़ल"
+
+#: ../src/common/iconbndl.cpp:195
+#, fuzzy, c-format
+msgid "Failed to load image %%d from file '%s'."
+msgstr "%d आकॄति को '%s' फ़ाइल से लोड करने में असफ़ल।"
+
+#: ../src/common/iconbndl.cpp:203
+#, fuzzy, c-format
+msgid "Failed to load image %d from stream."
+msgstr "%d आकॄति को '%s' फ़ाइल से लोड करने में असफ़ल।"
+
+#: ../src/common/iconbndl.cpp:221
+#, fuzzy, c-format
+msgid "Failed to load icons from resource '%s'."
+msgstr "%d आकॄति को '%s' फ़ाइल से लोड करने में असफ़ल।"
+
+#: ../src/common/imagbmp.cpp:97
+msgid "BMP: Couldn't save invalid image."
+msgstr "बीएमपी: अवैध आकॄति को सुरक्षित नहीं किया जा सका।"
+
+#: ../src/common/imagbmp.cpp:137
+msgid "BMP: wxImage doesn't have own wxPalette."
+msgstr "बीएमपी: डब्लूएक्सइमेज के पास स्वंम का डब्लूएक्सपैलेट नहीं है।"
+
+#: ../src/common/imagbmp.cpp:243
+msgid "BMP: Couldn't write the file (Bitmap) header."
+msgstr "बीएमपी: इस फ़ाइल के (बिट्मैप) शीर्षक को नहीं लिखा जा सका।"
+
+#: ../src/common/imagbmp.cpp:266
+msgid "BMP: Couldn't write the file (BitmapInfo) header."
+msgstr "बीएमपी: इस फ़ाइल के (बिट्मैपइन्फ़ो) शीर्षक को नहीं लिखा जा सका।"
+
+#: ../src/common/imagbmp.cpp:353
+msgid "BMP: Couldn't write RGB color map."
+msgstr "बीएमपी: आरजीबी रंग मानचित्र को नहीं लिखा जा सका।"
+
+#: ../src/common/imagbmp.cpp:487
+msgid "BMP: Couldn't write data."
+msgstr "बीएमपी: सूचना को नहीं लिखा जा सका।"
+
+#: ../src/common/imagbmp.cpp:561 ../src/common/imagbmp.cpp:642
+msgid "BMP: Couldn't allocate memory."
+msgstr "बीएमपी: स्मॄति का आवंटन नहीं हो सका।"
+
+#: ../src/common/imagbmp.cpp:1041
+msgid "DIB Header: Image width > 32767 pixels for file."
+msgstr "डीआईबी शीर्ष: फ़ाइल के लिए आकॄति की चौड़ाई > ३२७६७ पिक्सेल।"
+
+#: ../src/common/imagbmp.cpp:1049
+msgid "DIB Header: Image height > 32767 pixels for file."
+msgstr "डीआईबी शीर्ष: फ़ाइल के लिए आकॄति की ऊचाँई > ३२७६७ पिक्सेल।"
+
+#: ../src/common/imagbmp.cpp:1081
+msgid "DIB Header: Unknown bitdepth in file."
+msgstr "डीआईबी शीर्ष: फ़ाइल में अज्ञात बिट्गहराई।"
+
+#: ../src/common/imagbmp.cpp:1156
+msgid "DIB Header: Unknown encoding in file."
+msgstr "डीआईबी शीर्ष: फ़ाइल में अज्ञात एन्कोडिंग।"
+
+#: ../src/common/imagbmp.cpp:1165
+msgid "DIB Header: Encoding doesn't match bitdepth."
+msgstr "डीआईबी शीर्ष: एन्कोडिंग बिटगहराई से मेल नहीं खाती है।"
+
+#: ../src/common/imagbmp.cpp:1180
+#, c-format
+msgid "BMP Header: Invalid number of colors (%d)."
+msgstr ""
+
+#: ../src/common/imagbmp.cpp:1273
+msgid "Error in reading image DIB."
+msgstr "आकॄति डीआईबी को पढ़ने में त्रुटि।"
+
+#: ../src/common/imagbmp.cpp:1294
+msgid "ICO: Error in reading mask DIB."
+msgstr "आईसीओ: मास्क डीआईबी को पढ़ने में त्रुटि।"
+
+#: ../src/common/imagbmp.cpp:1353
+msgid "ICO: Image too tall for an icon."
+msgstr "आईसीओ: आकॄति एक आईकॉन के लिए बहुत बड़ी है।"
+
+#: ../src/common/imagbmp.cpp:1361
+msgid "ICO: Image too wide for an icon."
+msgstr "आईसीओ: आकॄति एक आईकॉन के लिए बहुत चौड़ी है।"
+
+#: ../src/common/imagbmp.cpp:1388 ../src/common/imagbmp.cpp:1488
+#: ../src/common/imagbmp.cpp:1503 ../src/common/imagbmp.cpp:1514
+#: ../src/common/imagbmp.cpp:1528 ../src/common/imagbmp.cpp:1576
+#: ../src/common/imagbmp.cpp:1591 ../src/common/imagbmp.cpp:1605
+#: ../src/common/imagbmp.cpp:1616
+msgid "ICO: Error writing the image file!"
+msgstr "आईसीओ: आकॄति फ़ाइल को लिखने में त्रुटि!"
+
+#: ../src/common/imagbmp.cpp:1701
+msgid "ICO: Invalid icon index."
+msgstr "ICO: अवैध आईकॉन इंडेक्स।"
+
+#: ../src/common/image.cpp:2410
+msgid "Image and mask have different sizes."
+msgstr "आकृति और मास्क के आकार भिन्न है।"
+
+#: ../src/common/image.cpp:2418 ../src/common/image.cpp:2459
+#, fuzzy
+msgid "No unused colour in image being masked."
+msgstr "आकृति में कोई बिना उपयोग किया हुआ रंग छुपाया गया"
+
+#: ../src/common/image.cpp:2641
+#, fuzzy, c-format
+msgid "Failed to load bitmap \"%s\" from resources."
+msgstr "%d आकॄति को '%s' फ़ाइल से लोड करने में असफ़ल।"
+
+#: ../src/common/image.cpp:2650
+#, fuzzy, c-format
+msgid "Failed to load icon \"%s\" from resources."
+msgstr "%d आकॄति को '%s' फ़ाइल से लोड करने में असफ़ल।"
+
+#: ../src/common/image.cpp:2728 ../src/common/image.cpp:2747
+#, fuzzy, c-format
+msgid "Failed to load image from file \"%s\"."
+msgstr "%d आकॄति को '%s' फ़ाइल से लोड करने में असफ़ल।"
+
+#: ../src/common/image.cpp:2761
+#, c-format
+msgid "Can't save image to file '%s': unknown extension."
+msgstr "आकॄति को '%s' फ़ाइले में सुरक्षित नहीं किया जा सकता है: अज्ञात उपनाम।"
+
+#: ../src/common/image.cpp:2869
+msgid "No handler found for image type."
+msgstr "आकृति प्रकार के लिए कोई हैन्डलर नहीं मिला।"
+
+#: ../src/common/image.cpp:2877 ../src/common/image.cpp:3000
+#: ../src/common/image.cpp:3066
+#, c-format
+msgid "No image handler for type %d defined."
+msgstr "%d प्रकार के लिए कोई आकृति हैन्डलर परिभाषित नहीं।"
+
+#: ../src/common/image.cpp:2887
+#, fuzzy, c-format
+msgid "Image file is not of type %d."
+msgstr "आकृति फ़ाइल %ld प्रकार की नहीं है।"
+
+#: ../src/common/image.cpp:2970
+msgid "Can't automatically determine the image format for non-seekable input."
+msgstr ""
+
+#: ../src/common/image.cpp:2988
+#, fuzzy
+msgid "Unknown image data format."
+msgstr "डाटा प्रारूप में त्रुटि"
+
+#: ../src/common/image.cpp:3009
+#, fuzzy, c-format
+msgid "This is not a %s."
+msgstr "पीसीएक्स: यह एक पीसीएक्स फ़ाइल नहीं है।"
+
+#: ../src/common/image.cpp:3032 ../src/common/image.cpp:3080
+#, c-format
+msgid "No image handler for type %s defined."
+msgstr "%s प्रकार के लिए कोई आकृति हैन्डलर परिभाषित नहीं।"
+
+#: ../src/common/image.cpp:3041
+#, fuzzy, c-format
+msgid "Image is not of type %s."
+msgstr "आकृति फ़ाइल %s प्रकार की नहीं है।"
+
+#: ../src/common/image.cpp:3509
+#, fuzzy, c-format
+msgid "Failed to check format of image file \"%s\"."
+msgstr "बिट्मैप आकॄति को \"%s\" फ़ाइल पर सुरक्षित करने में असफ़ल।"
+
+#: ../src/common/imaggif.cpp:124
+msgid "GIF: error in GIF image format."
+msgstr "जीआईएफ़: जीआईएफ़ आकॄति प्रारूप में त्रुटि।"
+
+#: ../src/common/imaggif.cpp:129
+msgid "GIF: not enough memory."
+msgstr "जीआईएफ़: आवश्यकतानुसार स्मॄति अनुपलब्ध"
+
+#: ../src/common/imaggif.cpp:134
+msgid "GIF: data stream seems to be truncated."
+msgstr "जीआईएफ़:  डाटा धारा सम्भवता टूटी-फ़ूटी लगती है।"
+
+#: ../src/common/imaggif.cpp:240
+#, fuzzy
+msgid "Couldn't initialize GIF hash table."
+msgstr "जेडलिब् डीफ़्लेट धारा का आरम्भीकरण नहीं किया जा सकता है।"
+
+#: ../src/common/imagiff.cpp:739
+msgid "IFF: error in IFF image format."
+msgstr "आईएफ़एफ़: आईएफ़एफ़ आकॄति प्रारूप में त्रुटि।"
+
+#: ../src/common/imagiff.cpp:742
+msgid "IFF: not enough memory."
+msgstr "आईएफ़एफ़: आवश्यकतानुसार स्मॄति का अभाव।"
+
+#: ../src/common/imagiff.cpp:745
+msgid "IFF: unknown error!!!"
+msgstr "आईएफ़एफ़: अज्ञात त्रुटि!!!"
+
+#: ../src/common/imagiff.cpp:755
+msgid "IFF: data stream seems to be truncated."
+msgstr "आईएफ़एफ़: डाटा धारा लगता है कि टूट गई है।"
+
+#: ../src/common/imagjpeg.cpp:258
+msgid "JPEG: Couldn't load - file is probably corrupted."
+msgstr "जेपीईजी: लोड नहीं किया जा सका - सम्भवता फ़ाइल निकॄष्ट है।"
+
+#: ../src/common/imagjpeg.cpp:437
+msgid "JPEG: Couldn't save image."
+msgstr "जेपीईजी: आकॄति को सुरक्षित नहीं किया जा सका।"
+
+#: ../src/common/imagpcx.cpp:439
+msgid "PCX: this is not a PCX file."
+msgstr "पीसीएक्स: यह एक पीसीएक्स फ़ाइल नहीं है।"
+
+#: ../src/common/imagpcx.cpp:453
+msgid "PCX: image format unsupported"
+msgstr "पीसीएक्स: आकृति प्रारूप असमर्थित है"
+
+#: ../src/common/imagpcx.cpp:454 ../src/common/imagpcx.cpp:477
+msgid "PCX: couldn't allocate memory"
+msgstr "पीसीएक्स: स्मृति का आवंटन नहीं किया जा सका"
+
+#: ../src/common/imagpcx.cpp:455
+msgid "PCX: version number too low"
+msgstr "पीसीएक्स: संस्मरण संख्या अति निम्न है"
+
+#: ../src/common/imagpcx.cpp:456 ../src/common/imagpcx.cpp:478
+msgid "PCX: unknown error !!!"
+msgstr "पीसीएक्स: अज्ञात त्रुटि !!!"
+
+#: ../src/common/imagpcx.cpp:476
+msgid "PCX: invalid image"
+msgstr "पीसीएक्स: अवैध आकृति"
+
+#: ../src/common/imagpng.cpp:385
+#, fuzzy, c-format
+msgid "Unknown PNG resolution unit %d"
+msgstr "अज्ञात विकल्प '%s'"
+
+#: ../src/common/imagpng.cpp:439
+msgid "Couldn't load a PNG image - file is corrupted or not enough memory."
+msgstr ""
+"एक पीएनजी आकॄति को लोड नहीं किया जा सका - या तो फ़ाइल निकृष्ट है या फ़िर आवश्यक स्मॄति "
+"का अभाव है।"
+
+#: ../src/common/imagpng.cpp:513 ../src/common/imagpng.cpp:524
+#: ../src/common/imagpng.cpp:534
+msgid "Couldn't save PNG image."
+msgstr "पीएनजी आकॄति को सुरक्षित नहीं किया जा सका।"
+
+#: ../src/common/imagpnm.cpp:71
+msgid "PNM: File format is not recognized."
+msgstr "पीएनएम: फ़ाइल प्रारूप को पहचाना नहीं जा सका।"
+
+#: ../src/common/imagpnm.cpp:89
+msgid "PNM: Couldn't allocate memory."
+msgstr "पीएनएम: स्मृति का आवंटन नहीं किया जा सका।"
+
+#: ../src/common/imagpnm.cpp:111 ../src/common/imagpnm.cpp:134
+#: ../src/common/imagpnm.cpp:156
+msgid "PNM: File seems truncated."
+msgstr "पीएनएम: फ़ाइल लगता है टूट गई है।"
+
+#: ../src/common/imagtiff.cpp:69
+#, fuzzy, c-format
+msgid " (in module \"%s\")"
+msgstr "टिफ़्फ़ माड्यूल: %s"
+
+#: ../src/common/imagtiff.cpp:304
+msgid "TIFF: Error loading image."
+msgstr "टीआईएफ़एफ़: आकॄति को लोड करने में त्रुटि।"
+
+#: ../src/common/imagtiff.cpp:314
+msgid "Invalid TIFF image index."
+msgstr "अवैध टीआईएफ़एफ़ आकॄति इंडेक्स।"
+
+#: ../src/common/imagtiff.cpp:358
+msgid "TIFF: Image size is abnormally big."
+msgstr ""
+
+#: ../src/common/imagtiff.cpp:372 ../src/common/imagtiff.cpp:385
+#: ../src/common/imagtiff.cpp:769
+msgid "TIFF: Couldn't allocate memory."
+msgstr "टीआईएफ़एफ़: स्मॄति का आवंटन महीं किया जा सका।"
+
+#: ../src/common/imagtiff.cpp:471
+msgid "TIFF: Error reading image."
+msgstr "टीआईएफ़एफ़: आकॄति को पढ़ने में त्रुटि।"
+
+#: ../src/common/imagtiff.cpp:532
+#, c-format
+msgid "Unknown TIFF resolution unit %d ignored"
+msgstr ""
+
+#: ../src/common/imagtiff.cpp:611
+msgid "TIFF: Error saving image."
+msgstr "टीआईएफ़एफ़: आकॄति को सुरक्षित करने में त्रुटि।"
+
+#: ../src/common/imagtiff.cpp:868
+msgid "TIFF: Error writing image."
+msgstr "टीआईएफ़एफ़: आकॄति को लिखने में त्रुटि।"
+
+#: ../src/common/imagtiff.cpp:881
+#, fuzzy
+msgid "TIFF: Error flushing data."
+msgstr "टीआईएफ़एफ़: आकॄति को सुरक्षित करने में त्रुटि।"
+
+#: ../src/common/imagwebp.cpp:56
+msgid "WebP: Invalid data (failed to get features)."
+msgstr ""
+
+#: ../src/common/imagwebp.cpp:65
+msgid "WebP: Allocating image memory failed."
+msgstr ""
+
+#: ../src/common/imagwebp.cpp:82
+msgid "WebP: Decoding RGBA image data failed."
+msgstr ""
+
+#: ../src/common/imagwebp.cpp:98
+msgid "WebP: Decoding RGB image data failed."
+msgstr ""
+
+#: ../src/common/imagwebp.cpp:113 ../src/common/imagwebp.cpp:201
+msgid "WebP: Allocating stream buffer failed."
+msgstr ""
+
+#: ../src/common/imagwebp.cpp:131
+#, fuzzy
+msgid "WebP: Failed to parse container data."
+msgstr "क्लिपबोर्ड डाटा को स्थापित करने में असफ़ल।"
+
+#: ../src/common/imagwebp.cpp:222
+#, fuzzy
+msgid "WebP: Error decoding animation."
+msgstr "संरचना के विकल्पों को पढ़नें में त्रुटि।"
+
+#: ../src/common/imagwebp.cpp:240
+msgid "WebP: Error getting next animation frame."
+msgstr ""
+
+#: ../src/common/init.cpp:172
+#, c-format
+msgid ""
+"Command line argument %d couldn't be converted to Unicode and will be "
+"ignored."
+msgstr ""
+
+#: ../src/common/init.cpp:344
+msgid "Initialization failed in post init, aborting."
+msgstr ""
+
+#: ../src/common/intl.cpp:378
+#, c-format
+msgid "Cannot set locale to language \"%s\"."
+msgstr ""
+
+#: ../src/common/log.cpp:232
+msgid "Error: "
+msgstr "त्रुटि: "
+
+#: ../src/common/log.cpp:236
+msgid "Warning: "
+msgstr "चेतावनी: "
+
+#: ../src/common/log.cpp:284
+msgid "The previous message repeated once."
+msgstr ""
+
+#: ../src/common/log.cpp:291
+#, c-format
+msgid "The previous message repeated %u time."
+msgid_plural "The previous message repeated %u times."
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../src/common/log.cpp:319
+#, c-format
+msgid "Last repeated message (\"%s\", %u time) wasn't output"
+msgid_plural "Last repeated message (\"%s\", %u times) wasn't output"
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../src/common/log.cpp:435
+#, c-format
+msgid " (error %ld: %s)"
+msgstr "(त्रुटि %ld: %s)"
+
+#: ../src/common/lzmastream.cpp:121
+#, fuzzy
+msgid "Failed to allocate memory for LZMA decompression."
+msgstr "कर्सर का निर्माण करने में असफ़ल।"
+
+#: ../src/common/lzmastream.cpp:125
+#, c-format
+msgid "Failed to initialize LZMA decompression: unexpected error %u."
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:179
+msgid "input is not in XZ format"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:183
+msgid "input compressed using unknown XZ option"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:188
+msgid "input is corrupted"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:192
+#, fuzzy
+msgid "unknown decompression error"
+msgstr "फ़ैलाव त्रुटि"
+
+#: ../src/common/lzmastream.cpp:196
+#, fuzzy, c-format
+msgid "LZMA decompression error: %s"
+msgstr "फ़ैलाव त्रुटि"
+
+#: ../src/common/lzmastream.cpp:231
+#, fuzzy
+msgid "Failed to allocate memory for LZMA compression."
+msgstr "कर्सर का निर्माण करने में असफ़ल।"
+
+#: ../src/common/lzmastream.cpp:235
+#, c-format
+msgid "Failed to initialize LZMA compression: unexpected error %u."
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:267 ../src/common/lzmastream.cpp:342
+#: ../src/html/chm.cpp:336
+msgid "out of memory"
+msgstr "स्मॄति समाप्त"
+
+#: ../src/common/lzmastream.cpp:276 ../src/common/lzmastream.cpp:346
+#, fuzzy
+msgid "unknown compression error"
+msgstr "संकुचन त्रुटि"
+
+#: ../src/common/lzmastream.cpp:280
+#, fuzzy, c-format
+msgid "LZMA compression error: %s"
+msgstr "संकुचन त्रुटि"
+
+#: ../src/common/lzmastream.cpp:350
+#, c-format
+msgid "LZMA compression error when flushing output: %s"
+msgstr ""
+
+#: ../src/common/mimecmn.cpp:167
+#, c-format
+msgid "Unmatched '{' in an entry for mime type %s."
+msgstr "माइम प्रकार %s के लिए एक प्रविष्टी में बेमेल '{' ।"
+
+#: ../src/common/module.cpp:76
+#, c-format
+msgid "Circular dependency involving module \"%s\" detected."
+msgstr ""
+
+#: ../src/common/module.cpp:128
+#, c-format
+msgid "Dependency \"%s\" of module \"%s\" doesn't exist."
+msgstr ""
+
+#: ../src/common/module.cpp:137
+#, c-format
+msgid "Module \"%s\" initialization failed"
+msgstr ""
+
+#: ../src/common/msgout.cpp:96
+#, fuzzy
+msgid "Message"
+msgstr "%s संदेश"
+
+#: ../src/common/paper.cpp:70
+msgid "Letter, 8 1/2 x 11 in"
+msgstr "लेटर, ८ १/२ x ११ इंच"
+
+#: ../src/common/paper.cpp:71
+msgid "Legal, 8 1/2 x 14 in"
+msgstr "लीगल, ८ १/२ x १४ इंच"
+
+#: ../src/common/paper.cpp:72
+msgid "A4 sheet, 210 x 297 mm"
+msgstr "ऐ४ पत्र २१० x २९७ मिलीमीटर"
+
+#: ../src/common/paper.cpp:73
+msgid "C sheet, 17 x 22 in"
+msgstr "सी पत्र, १७ x २२ इंच"
+
+#: ../src/common/paper.cpp:74
+msgid "D sheet, 22 x 34 in"
+msgstr "डी पत्र, २२ x 34 इंच"
+
+#: ../src/common/paper.cpp:75
+msgid "E sheet, 34 x 44 in"
+msgstr "ई पत्र, ३४ x ४४ इंच"
+
+#: ../src/common/paper.cpp:76
+msgid "Letter Small, 8 1/2 x 11 in"
+msgstr "लेटर छोटा, ८ १/२ x ११ इंच"
+
+#: ../src/common/paper.cpp:77
+msgid "Tabloid, 11 x 17 in"
+msgstr "टैब्लायड, ११ x १७ इंच"
+
+#: ../src/common/paper.cpp:78
+msgid "Ledger, 17 x 11 in"
+msgstr "लेजर, १७ x ११ इंच"
+
+#: ../src/common/paper.cpp:79
+msgid "Statement, 5 1/2 x 8 1/2 in"
+msgstr "स्टेटमेन्ट, ५ १/२ x ८ १/२ इंच"
+
+#: ../src/common/paper.cpp:80
+msgid "Executive, 7 1/4 x 10 1/2 in"
+msgstr "कार्यकारी, ७ १/४ x १० १/२ इंच"
+
+#: ../src/common/paper.cpp:81
+msgid "A3 sheet, 297 x 420 mm"
+msgstr "ऐ३ पत्र २९७ x ४२० मिलीमीटर"
+
+#: ../src/common/paper.cpp:82
+msgid "A4 small sheet, 210 x 297 mm"
+msgstr "ऐ४ लघु पत्र २१० x  २९७ मिलीमीटर"
+
+#: ../src/common/paper.cpp:83
+msgid "A5 sheet, 148 x 210 mm"
+msgstr "ऐ५ पत्र १४८ x २१० मिलीमीटर"
+
+#: ../src/common/paper.cpp:84
+msgid "B4 sheet, 250 x 354 mm"
+msgstr "बी४ पत्र, २५० x ३५४ मिलीमीटर"
+
+#: ../src/common/paper.cpp:85
+msgid "B5 sheet, 182 x 257 millimeter"
+msgstr "बी५ पत्र, १८२ x २५७ मिलीमीटर"
+
+#: ../src/common/paper.cpp:86
+msgid "Folio, 8 1/2 x 13 in"
+msgstr "फ़ोलियो, ८ १/२ x १३ इंच"
+
+#: ../src/common/paper.cpp:87
+msgid "Quarto, 215 x 275 mm"
+msgstr "क्वार्टो, २१५ x २७५ मिलीमीटर"
+
+#: ../src/common/paper.cpp:88
+msgid "10 x 14 in"
+msgstr "१० x १४ इंच"
+
+#: ../src/common/paper.cpp:89
+msgid "11 x 17 in"
+msgstr "११ x १७ इंच"
+
+#: ../src/common/paper.cpp:90
+msgid "Note, 8 1/2 x 11 in"
+msgstr "नोट, ८ १/२ x ११ इंच"
+
+#: ../src/common/paper.cpp:91
+msgid "#9 Envelope, 3 7/8 x 8 7/8 in"
+msgstr "#९ लिफ़ाफ़ा, ३ ७/८ x ८ ७/८ इंच"
+
+#: ../src/common/paper.cpp:92
+msgid "#10 Envelope, 4 1/8 x 9 1/2 in"
+msgstr "#१० लिफ़ाफ़ा, ४ १/८ x 9 1/2 इंच"
+
+#: ../src/common/paper.cpp:93
+msgid "#11 Envelope, 4 1/2 x 10 3/8 in"
+msgstr "#११ लिफ़ाफ़ा, ४ १/२ x १० ३/८ इंच"
+
+#: ../src/common/paper.cpp:94
+msgid "#12 Envelope, 4 3/4 x 11 in"
+msgstr "#१२ लिफ़ाफ़ा, ४ ३/४ x ११ इंच"
+
+#: ../src/common/paper.cpp:95
+msgid "#14 Envelope, 5 x 11 1/2 in"
+msgstr "#१४ लिफ़ाफ़ा, ५ x ११ 1/2 इंच"
+
+#: ../src/common/paper.cpp:96
+msgid "DL Envelope, 110 x 220 mm"
+msgstr "डीएल लिफ़ाफ़ा, ११० x २२० मिलीमीटर"
+
+#: ../src/common/paper.cpp:97
+msgid "C5 Envelope, 162 x 229 mm"
+msgstr "सी५ लिफ़ाफ़ा, १६२ x २२९ मिलीमीटर"
+
+#: ../src/common/paper.cpp:98
+msgid "C3 Envelope, 324 x 458 mm"
+msgstr "सी३ लिफ़ाफ़ा, ३२४ x ४५८ मिलीमीटर"
+
+#: ../src/common/paper.cpp:99
+msgid "C4 Envelope, 229 x 324 mm"
+msgstr "सी४ लिफ़ाफ़ा, २२९ x ३२४ मिलीमीटर"
+
+#: ../src/common/paper.cpp:100
+msgid "C6 Envelope, 114 x 162 mm"
+msgstr "सी६ लिफ़ाफ़ा, ११४ x १६२ मिलीमीटर"
+
+#: ../src/common/paper.cpp:101
+msgid "C65 Envelope, 114 x 229 mm"
+msgstr "सी६५ लिफ़ाफ़ा, ११४ x 229 मिलीमीटर"
+
+#: ../src/common/paper.cpp:102
+msgid "B4 Envelope, 250 x 353 mm"
+msgstr "बी४ लिफ़ाफ़ा, २५० x ३५३ मिलीमीटर"
+
+#: ../src/common/paper.cpp:103
+msgid "B5 Envelope, 176 x 250 mm"
+msgstr "बी५ लिफ़ाफ़ा, १७६ x 250 मिलीमीटर"
+
+#: ../src/common/paper.cpp:104
+msgid "B6 Envelope, 176 x 125 mm"
+msgstr "बी६ लिफ़ाफ़ा, १७६ x १२५ मिलीमीटर"
+
+#: ../src/common/paper.cpp:105
+msgid "Italy Envelope, 110 x 230 mm"
+msgstr "इटली लिफ़ाफ़ा, ११० x २३० मिलीमीटर"
+
+#: ../src/common/paper.cpp:106
+msgid "Monarch Envelope, 3 7/8 x 7 1/2 in"
+msgstr "मोनार्च लिफ़ाफ़ा, ३ ७/८ x ७ १/२ इंच"
+
+#: ../src/common/paper.cpp:107
+msgid "6 3/4 Envelope, 3 5/8 x 6 1/2 in"
+msgstr "६ ३/४ लिफ़ाफ़ा, ३ ५/८ x ६ १/२ इंच"
+
+#: ../src/common/paper.cpp:108
+msgid "US Std Fanfold, 14 7/8 x 11 in"
+msgstr "यूएस सामान्य फ़ैनफ़ोल्ड, १४ ७/८ x ११ इंच"
+
+#: ../src/common/paper.cpp:109
+msgid "German Std Fanfold, 8 1/2 x 12 in"
+msgstr "जर्मन मानक फ़ैनफ़ोल्ड, ८ १/२ x १२ इंच"
+
+#: ../src/common/paper.cpp:110
+msgid "German Legal Fanfold, 8 1/2 x 13 in"
+msgstr "जर्मन लीगल फ़ैनफ़ोल्ड, ८ १/२ x १३ इंच"
+
+#: ../src/common/paper.cpp:112
+#, fuzzy
+msgid "B4 (ISO) 250 x 353 mm"
+msgstr "बी४ पत्र, २५० x ३५४ मिलीमीटर"
+
+#: ../src/common/paper.cpp:113
+msgid "Japanese Postcard 100 x 148 mm"
+msgstr ""
+
+#: ../src/common/paper.cpp:114
+msgid "9 x 11 in"
+msgstr "९ x ११ इंच"
+
+#: ../src/common/paper.cpp:115
+msgid "10 x 11 in"
+msgstr "१२ x १४ इंच"
+
+#: ../src/common/paper.cpp:116
+msgid "15 x 11 in"
+msgstr "१५ x ११ इंच"
+
+#: ../src/common/paper.cpp:117
+#, fuzzy
+msgid "Envelope Invite 220 x 220 mm"
+msgstr "डीएल लिफ़ाफ़ा, ११० x २२० मिलीमीटर"
+
+#: ../src/common/paper.cpp:118
+#, fuzzy
+msgid "Letter Extra 9 1/2 x 12 in"
+msgstr "लेटर, ८ १/२ x ११ इंच"
+
+#: ../src/common/paper.cpp:119
+#, fuzzy
+msgid "Legal Extra 9 1/2 x 15 in"
+msgstr "लीगल, ८ १/२ x १४ इंच"
+
+#: ../src/common/paper.cpp:120
+#, fuzzy
+msgid "Tabloid Extra 11.69 x 18 in"
+msgstr "टैब्लायड, ११ x १७ इंच"
+
+#: ../src/common/paper.cpp:121
+msgid "A4 Extra 9.27 x 12.69 in"
+msgstr ""
+
+#: ../src/common/paper.cpp:122
+#, fuzzy
+msgid "Letter Transverse 8 1/2 x 11 in"
+msgstr "लेटर, ८ १/२ x ११ इंच"
+
+#: ../src/common/paper.cpp:123
+#, fuzzy
+msgid "A4 Transverse 210 x 297 mm"
+msgstr "ऐ४ पत्र २१० x २९७ मिलीमीटर"
+
+#: ../src/common/paper.cpp:124
+msgid "Letter Extra Transverse 9.275 x 12 in"
+msgstr ""
+
+#: ../src/common/paper.cpp:125
+msgid "SuperA/SuperA/A4 227 x 356 mm"
+msgstr ""
+
+#: ../src/common/paper.cpp:126
+msgid "SuperB/SuperB/A3 305 x 487 mm"
+msgstr ""
+
+#: ../src/common/paper.cpp:127
+#, fuzzy
+msgid "Letter Plus 8 1/2 x 12.69 in"
+msgstr "लेटर, ८ १/२ x ११ इंच"
+
+#: ../src/common/paper.cpp:128
+#, fuzzy
+msgid "A4 Plus 210 x 330 mm"
+msgstr "ऐ४ पत्र २१० x २९७ मिलीमीटर"
+
+#: ../src/common/paper.cpp:129
+#, fuzzy
+msgid "A5 Transverse 148 x 210 mm"
+msgstr "ऐ५ पत्र १४८ x २१० मिलीमीटर"
+
+#: ../src/common/paper.cpp:130
+#, fuzzy
+msgid "B5 (JIS) Transverse 182 x 257 mm"
+msgstr "बी५ पत्र, १८२ x २५७ मिलीमीटर"
+
+#: ../src/common/paper.cpp:131
+#, fuzzy
+msgid "A3 Extra 322 x 445 mm"
+msgstr "सी३ लिफ़ाफ़ा, ३२४ x ४५८ मिलीमीटर"
+
+#: ../src/common/paper.cpp:132
+#, fuzzy
+msgid "A5 Extra 174 x 235 mm"
+msgstr "ऐ५ पत्र १४८ x २१० मिलीमीटर"
+
+#: ../src/common/paper.cpp:133
+msgid "B5 (ISO) Extra 201 x 276 mm"
+msgstr ""
+
+#: ../src/common/paper.cpp:134
+msgid "A2 420 x 594 mm"
+msgstr "ऐ२ 420 x 594 मिलीमीटर"
+
+#: ../src/common/paper.cpp:135
+#, fuzzy
+msgid "A3 Transverse 297 x 420 mm"
+msgstr "ऐ३ पत्र २९७ x ४२० मिलीमीटर"
+
+#: ../src/common/paper.cpp:136
+#, fuzzy
+msgid "A3 Extra Transverse 322 x 445 mm"
+msgstr "सी३ लिफ़ाफ़ा, ३२४ x ४५८ मिलीमीटर"
+
+#: ../src/common/paper.cpp:138
+msgid "Japanese Double Postcard 200 x 148 mm"
+msgstr ""
+
+#: ../src/common/paper.cpp:139
+msgid "A6 105 x 148 mm"
+msgstr "ऐ६ 105 x 148 मिलीमीटर"
+
+#: ../src/common/paper.cpp:140
+msgid "Japanese Envelope Kaku #2"
+msgstr ""
+
+#: ../src/common/paper.cpp:141
+msgid "Japanese Envelope Kaku #3"
+msgstr ""
+
+#: ../src/common/paper.cpp:142
+msgid "Japanese Envelope Chou #3"
+msgstr ""
+
+#: ../src/common/paper.cpp:143
+msgid "Japanese Envelope Chou #4"
+msgstr ""
+
+#: ../src/common/paper.cpp:144
+#, fuzzy
+msgid "Letter Rotated 11 x 8 1/2 in"
+msgstr "लेटर, ८ १/२ x ११ इंच"
+
+#: ../src/common/paper.cpp:145
+#, fuzzy
+msgid "A3 Rotated 420 x 297 mm"
+msgstr "ऐ४ पत्र २१० x २९७ मिलीमीटर"
+
+#: ../src/common/paper.cpp:146
+#, fuzzy
+msgid "A4 Rotated 297 x 210 mm"
+msgstr "ऐ३ पत्र २९७ x ४२० मिलीमीटर"
+
+#: ../src/common/paper.cpp:147
+msgid "A5 Rotated 210 x 148 mm"
+msgstr ""
+
+#: ../src/common/paper.cpp:148
+msgid "B4 (JIS) Rotated 364 x 257 mm"
+msgstr ""
+
+#: ../src/common/paper.cpp:149
+msgid "B5 (JIS) Rotated 257 x 182 mm"
+msgstr ""
+
+#: ../src/common/paper.cpp:150
+msgid "Japanese Postcard Rotated 148 x 100 mm"
+msgstr ""
+
+#: ../src/common/paper.cpp:151
+msgid "Double Japanese Postcard Rotated 148 x 200 mm"
+msgstr ""
+
+#: ../src/common/paper.cpp:152
+#, fuzzy
+msgid "A6 Rotated 148 x 105 mm"
+msgstr "ऐ५ पत्र १४८ x २१० मिलीमीटर"
+
+#: ../src/common/paper.cpp:153
+msgid "Japanese Envelope Kaku #2 Rotated"
+msgstr ""
+
+#: ../src/common/paper.cpp:154
+msgid "Japanese Envelope Kaku #3 Rotated"
+msgstr ""
+
+#: ../src/common/paper.cpp:155
+msgid "Japanese Envelope Chou #3 Rotated"
+msgstr ""
+
+#: ../src/common/paper.cpp:156
+msgid "Japanese Envelope Chou #4 Rotated"
+msgstr ""
+
+#: ../src/common/paper.cpp:157
+msgid "B6 (JIS) 128 x 182 mm"
+msgstr ""
+
+#: ../src/common/paper.cpp:158
+msgid "B6 (JIS) Rotated 182 x 128 mm"
+msgstr ""
+
+#: ../src/common/paper.cpp:159
+msgid "12 x 11 in"
+msgstr "१२ x ११ इंच"
+
+#: ../src/common/paper.cpp:160
+msgid "Japanese Envelope You #4"
+msgstr ""
+
+#: ../src/common/paper.cpp:161
+msgid "Japanese Envelope You #4 Rotated"
+msgstr ""
+
+#: ../src/common/paper.cpp:162
+msgid "PRC 16K 146 x 215 mm"
+msgstr ""
+
+#: ../src/common/paper.cpp:163
+msgid "PRC 32K 97 x 151 mm"
+msgstr ""
+
+#: ../src/common/paper.cpp:164
+msgid "PRC 32K(Big) 97 x 151 mm"
+msgstr ""
+
+#: ../src/common/paper.cpp:165
+msgid "PRC Envelope #1 102 x 165 mm"
+msgstr "पीआरसी  लिफ़ाफ़ा #1 102 x 165 मिलीमीटर"
+
+#: ../src/common/paper.cpp:166
+msgid "PRC Envelope #2 102 x 176 mm"
+msgstr "पीआरसी  लिफ़ाफ़ा #2 102 x 176 मिलीमीटर"
+
+#: ../src/common/paper.cpp:167
+msgid "PRC Envelope #3 125 x 176 mm"
+msgstr "पीआरसी  लिफ़ाफ़ा #3 125 x 176 मिलीमीटर"
+
+#: ../src/common/paper.cpp:168
+msgid "PRC Envelope #4 110 x 208 mm"
+msgstr "पीआरसी  लिफ़ाफ़ा #4 110 x 208 मिलीमीटर"
+
+#: ../src/common/paper.cpp:169
+msgid "PRC Envelope #5 110 x 220 mm"
+msgstr "पीआरसी  लिफ़ाफ़ा #5 110 x 220 मिलीमीटर"
+
+#: ../src/common/paper.cpp:170
+msgid "PRC Envelope #6 120 x 230 mm"
+msgstr "पीआरसी  लिफ़ाफ़ा #6 120 x 230 मिलीमीटर"
+
+#: ../src/common/paper.cpp:171
+msgid "PRC Envelope #7 160 x 230 mm"
+msgstr "पीआरसी  लिफ़ाफ़ा #7 160 x 230 मिलीमीटर"
+
+#: ../src/common/paper.cpp:172
+msgid "PRC Envelope #8 120 x 309 mm"
+msgstr "पीआरसी  लिफ़ाफ़ा #8 120 x 309 मिलीमीटर"
+
+#: ../src/common/paper.cpp:173
+msgid "PRC Envelope #9 229 x 324 mm"
+msgstr "पीआरसी  लिफ़ाफ़ा #9 229 x 324 मिलीमीटर"
+
+#: ../src/common/paper.cpp:174
+msgid "PRC Envelope #10 324 x 458 mm"
+msgstr "पीआरसी  लिफ़ाफ़ा #10 324 x 458 मिलीमीटर"
+
+#: ../src/common/paper.cpp:175
+msgid "PRC 16K Rotated"
+msgstr ""
+
+#: ../src/common/paper.cpp:176
+msgid "PRC 32K Rotated"
+msgstr ""
+
+#: ../src/common/paper.cpp:177
+msgid "PRC 32K(Big) Rotated"
+msgstr ""
+
+#: ../src/common/paper.cpp:178
+#, fuzzy
+msgid "PRC Envelope #1 Rotated 165 x 102 mm"
+msgstr "सी६ लिफ़ाफ़ा, ११४ x १६२ मिलीमीटर"
+
+#: ../src/common/paper.cpp:179
+#, fuzzy
+msgid "PRC Envelope #2 Rotated 176 x 102 mm"
+msgstr "बी६ लिफ़ाफ़ा, १७६ x १२५ मिलीमीटर"
+
+#: ../src/common/paper.cpp:180
+#, fuzzy
+msgid "PRC Envelope #3 Rotated 176 x 125 mm"
+msgstr "बी६ लिफ़ाफ़ा, १७६ x १२५ मिलीमीटर"
+
+#: ../src/common/paper.cpp:181
+#, fuzzy
+msgid "PRC Envelope #4 Rotated 208 x 110 mm"
+msgstr "सी६ लिफ़ाफ़ा, ११४ x १६२ मिलीमीटर"
+
+#: ../src/common/paper.cpp:182
+#, fuzzy
+msgid "PRC Envelope #5 Rotated 220 x 110 mm"
+msgstr "सी४ लिफ़ाफ़ा, २२९ x ३२४ मिलीमीटर"
+
+#: ../src/common/paper.cpp:183
+#, fuzzy
+msgid "PRC Envelope #6 Rotated 230 x 120 mm"
+msgstr "सी५ लिफ़ाफ़ा, १६२ x २२९ मिलीमीटर"
+
+#: ../src/common/paper.cpp:184
+#, fuzzy
+msgid "PRC Envelope #7 Rotated 230 x 160 mm"
+msgstr "सी६ लिफ़ाफ़ा, ११४ x १६२ मिलीमीटर"
+
+#: ../src/common/paper.cpp:185
+#, fuzzy
+msgid "PRC Envelope #8 Rotated 309 x 120 mm"
+msgstr "सी४ लिफ़ाफ़ा, २२९ x ३२४ मिलीमीटर"
+
+#: ../src/common/paper.cpp:186
+#, fuzzy
+msgid "PRC Envelope #9 Rotated 324 x 229 mm"
+msgstr "सी५ लिफ़ाफ़ा, १६२ x २२९ मिलीमीटर"
+
+#: ../src/common/paper.cpp:187
+#, fuzzy
+msgid "PRC Envelope #10 Rotated 458 x 324 mm"
+msgstr "सी४ लिफ़ाफ़ा, २२९ x ३२४ मिलीमीटर"
+
+#: ../src/common/paper.cpp:192
+#, fuzzy
+msgid "A0 sheet, 841 x 1189 mm"
+msgstr "ऐ४ पत्र २१० x २९७ मिलीमीटर"
+
+#: ../src/common/paper.cpp:193
+#, fuzzy
+msgid "A1 sheet, 594 x 841 mm"
+msgstr "ऐ३ पत्र २९७ x ४२० मिलीमीटर"
+
+#: ../src/common/preferencescmn.cpp:37
+msgid "General"
+msgstr ""
+
+#: ../src/common/preferencescmn.cpp:40
+msgid "Advanced"
+msgstr ""
+
+#: ../src/common/prntbase.cpp:245
+msgid "Generic PostScript"
+msgstr "सामान्य पोस्टस्क्रिप्ट"
+
+#: ../src/common/prntbase.cpp:259
+msgid "Ready"
+msgstr "तैयार"
+
+#: ../src/common/prntbase.cpp:331
+msgid "Printing Error"
+msgstr "मुद्रण त्रुटि"
+
+#: ../src/common/prntbase.cpp:413 ../src/common/prntbase.cpp:1597
+#: ../src/generic/prntdlgg.cpp:135 ../src/generic/prntdlgg.cpp:149
+#: ../src/gtk/print.cpp:628 ../src/gtk/print.cpp:646
+msgid "Print"
+msgstr "मुद्रण"
+
+#: ../src/common/prntbase.cpp:471 ../src/generic/prntdlgg.cpp:809
+msgid "Page setup"
+msgstr "पॄष्ट स्थापना"
+
+#: ../src/common/prntbase.cpp:525
+#, fuzzy
+msgid "Please wait while printing..."
+msgstr "कॄपया प्रतीक्षा करें जबतक कि प्रिंटींग हो रही है\n"
+
+#: ../src/common/prntbase.cpp:529
+#, fuzzy
+msgid "Document:"
+msgstr "द्वारा प्रलेखन"
+
+#: ../src/common/prntbase.cpp:532
+msgid "Progress:"
+msgstr ""
+
+#: ../src/common/prntbase.cpp:533
+msgid "Preparing"
+msgstr ""
+
+#: ../src/common/prntbase.cpp:552
+#, fuzzy, c-format
+msgid "Printing page %d"
+msgstr "%d पृष्ट को मुद्रित किया जा रहा है..."
+
+#: ../src/common/prntbase.cpp:557
+#, fuzzy, c-format
+msgid "Printing page %d of %d"
+msgstr "%d पृष्ट को मुद्रित किया जा रहा है..."
+
+#: ../src/common/prntbase.cpp:560
+#, fuzzy, c-format
+msgid " (copy %d of %d)"
+msgstr "पृष्ट %d / %d"
+
+#: ../src/common/prntbase.cpp:1604
+#, fuzzy
+msgid "First page"
+msgstr "अगला पृष्ट"
+
+#: ../src/common/prntbase.cpp:1609 ../src/html/helpwnd.cpp:659
+msgid "Previous page"
+msgstr "पिछला पॄष्ट"
+
+#: ../src/common/prntbase.cpp:1623 ../src/html/helpwnd.cpp:660
+msgid "Next page"
+msgstr "अगला पृष्ट"
+
+#: ../src/common/prntbase.cpp:1628
+#, fuzzy
+msgid "Last page"
+msgstr "अगला पृष्ट"
+
+#: ../src/common/prntbase.cpp:1636 ../src/common/stockitem.cpp:215
+#, fuzzy
+msgid "Zoom Out"
+msgstr "छोटा करें (&O)"
+
+#: ../src/common/prntbase.cpp:1650 ../src/common/stockitem.cpp:214
+#, fuzzy
+msgid "Zoom In"
+msgstr "बड़ा करें (&I)"
+
+#: ../src/common/prntbase.cpp:1656 ../src/common/stockitem.cpp:153
+#: ../src/generic/logg.cpp:553 ../src/univ/themes/win32.cpp:3752
+msgid "&Close"
+msgstr "बन्द करे (&C)"
+
+#: ../src/common/prntbase.cpp:2085
+msgid "Could not start document preview."
+msgstr "प्रलेख पूर्वालोकन को आरम्भ नहीं किया जा सका।"
+
+#: ../src/common/prntbase.cpp:2085 ../src/common/prntbase.cpp:2129
+#: ../src/common/prntbase.cpp:2137
+msgid "Print Preview Failure"
+msgstr "मुद्रण पूर्वालोकन असफ़लता"
+
+#: ../src/common/prntbase.cpp:2129 ../src/common/prntbase.cpp:2137
+msgid "Sorry, not enough memory to create a preview."
+msgstr "क्षमा करें, एक पूर्वालोकन को निर्माण करने के लिए आवश्यकतानुसार स्मॄति नहीं है।"
+
+#: ../src/common/prntbase.cpp:2144
+#, c-format
+msgid "Page %d of %d"
+msgstr "पृष्ट %d / %d"
+
+#: ../src/common/prntbase.cpp:2146
+#, c-format
+msgid "Page %d"
+msgstr "पृष्ट %d"
+
+#: ../src/common/regex.cpp:382 ../src/html/chm.cpp:348
+msgid "unknown error"
+msgstr "अज्ञात त्रुटि"
+
+#: ../src/common/regex.cpp:995
+#, c-format
+msgid "Invalid regular expression '%s': %s"
+msgstr "'%s' अवैध सामान्य व्यंजक: %s"
+
+#: ../src/common/regex.cpp:1059
+#, fuzzy, c-format
+msgid "Failed to find match for regular expression: %s"
+msgstr "'%s' को सामान्य व्यंजक में मिलाने में असफ़ल: %s"
+
+#: ../src/common/rendcmn.cpp:188
+#, c-format
+msgid "Renderer \"%s\" has incompatible version %d.%d and couldn't be loaded."
+msgstr "\"%s\" रेन्डर्र का %d.%d संस्मरण असुसंगत है और लोड नहीं किया जा सका।"
+
+#: ../src/common/secretstore.cpp:162
+msgid "Not available for this platform"
+msgstr ""
+
+#: ../src/common/secretstore.cpp:183
+#, fuzzy, c-format
+msgid "Saving password for \"%s\" failed: %s."
+msgstr "'%s' का निष्कर्षण '%s' में असफ़ल रहा।"
+
+#: ../src/common/secretstore.cpp:205
+#, fuzzy, c-format
+msgid "Reading password for \"%s\" failed: %s."
+msgstr "'%s' का निष्कर्षण '%s' में असफ़ल रहा।"
+
+#: ../src/common/secretstore.cpp:228
+#, fuzzy, c-format
+msgid "Deleting password for \"%s\" failed: %s."
+msgstr "'%s' का निष्कर्षण '%s' में असफ़ल रहा।"
+
+#: ../src/common/selectdispatcher.cpp:254
+msgid "Failed to monitor I/O channels"
+msgstr ""
+
+#: ../src/common/sizer.cpp:3054 ../src/common/stockitem.cpp:195
+msgid "Save"
+msgstr "सुरक्षित करें"
+
+#: ../src/common/sizer.cpp:3056
+msgid "Don't Save"
+msgstr "सुरक्षित न करें"
+
+#: ../src/common/socket.cpp:870
+#, fuzzy
+msgid "Cannot initialize sockets"
+msgstr "ओएलई का आरम्भीकरण नहीं किया जा सकता है"
+
+#: ../src/common/stockitem.cpp:127
+#, fuzzy
+msgctxt "standard Windows menu"
+msgid "&Help"
+msgstr "सहायता (&H)"
+
+#: ../src/common/stockitem.cpp:144
+msgid "&About"
+msgstr "के बारे में (&A)"
+
+#: ../src/common/stockitem.cpp:144
+#, fuzzy
+msgid "About"
+msgstr "के बारे में (&A)"
+
+#: ../src/common/stockitem.cpp:145
+msgid "Add"
+msgstr "जोड़ें"
+
+#: ../src/common/stockitem.cpp:146
+msgid "&Apply"
+msgstr "लागु करें (&A)"
+
+#: ../src/common/stockitem.cpp:146
+#, fuzzy
+msgid "Apply"
+msgstr "लागु करें (&A)"
+
+#: ../src/common/stockitem.cpp:147
+msgid "&Back"
+msgstr "पीछे (&B)"
+
+#: ../src/common/stockitem.cpp:147
+#, fuzzy
+msgid "Back"
+msgstr "पीछे (&B)"
+
+#: ../src/common/stockitem.cpp:148
+msgid "&Bold"
+msgstr "गहरा"
+
+#: ../src/common/stockitem.cpp:148 ../src/generic/fontdlgg.cpp:326
+#: ../src/richtext/richtextfontpage.cpp:354
+msgid "Bold"
+msgstr "गहरा"
+
+#: ../src/common/stockitem.cpp:149
+msgid "&Bottom"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:149 ../src/richtext/richtextsizepage.cpp:287
+msgid "Bottom"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:150 ../src/generic/fontdlgg.cpp:462
+#: ../src/generic/fontdlgg.cpp:481 ../src/generic/wizard.cpp:415
+msgid "&Cancel"
+msgstr "निरस्त करें (&C)"
+
+#: ../src/common/stockitem.cpp:151
+msgid "&CD-ROM"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:151
+msgid "CD-ROM"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:152
+msgid "&Clear"
+msgstr "साफ़ करें (&C)"
+
+#: ../src/common/stockitem.cpp:152
+#, fuzzy
+msgid "Clear"
+msgstr "साफ़ करें (&C)"
+
+#: ../src/common/stockitem.cpp:153 ../src/generic/dbgrptg.cpp:93
+#: ../src/generic/progdlgg.cpp:778 ../src/html/helpdlg.cpp:86
+#: ../src/msw/progdlg.cpp:209 ../src/msw/progdlg.cpp:890
+#: ../src/richtext/richtextstyledlg.cpp:272
+#: ../src/richtext/richtextsymboldlg.cpp:448
+msgid "Close"
+msgstr "समाप्त"
+
+#: ../src/common/stockitem.cpp:154
+#, fuzzy
+msgid "&Convert"
+msgstr "विषय-वस्तु"
+
+#: ../src/common/stockitem.cpp:154
+#, fuzzy
+msgid "Convert"
+msgstr "विषय-वस्तु"
+
+#: ../src/common/stockitem.cpp:155 ../src/msw/textctrl.cpp:2884
+#: ../src/osx/textctrl_osx.cpp:653 ../src/richtext/richtextctrl.cpp:331
+msgid "&Copy"
+msgstr "प्रतिलिपि बनाएँ (&C)"
+
+#: ../src/common/stockitem.cpp:155 ../src/stc/stc_i18n.cpp:18
+#, fuzzy
+msgid "Copy"
+msgstr "प्रतिलिपि बनाएँ (&C)"
+
+#: ../src/common/stockitem.cpp:156 ../src/msw/textctrl.cpp:2883
+#: ../src/osx/textctrl_osx.cpp:652 ../src/richtext/richtextctrl.cpp:330
+msgid "Cu&t"
+msgstr "काटें (&t)"
+
+#: ../src/common/stockitem.cpp:156 ../src/stc/stc_i18n.cpp:17
+#, fuzzy
+msgid "Cut"
+msgstr "काटें (&t)"
+
+#: ../src/common/stockitem.cpp:157 ../src/msw/textctrl.cpp:2886
+#: ../src/osx/textctrl_osx.cpp:655 ../src/richtext/richtextctrl.cpp:333
+#: ../src/richtext/richtexttabspage.cpp:137
+msgid "&Delete"
+msgstr "मिटाएँं (&D)"
+
+#: ../src/common/stockitem.cpp:157 ../src/richtext/richtextbuffer.cpp:8266
+#: ../src/stc/stc_i18n.cpp:20
+msgid "Delete"
+msgstr "मिटाएँं"
+
+#: ../src/common/stockitem.cpp:158
+msgid "&Down"
+msgstr "नीचे (&D)"
+
+#: ../src/common/stockitem.cpp:158 ../src/generic/fdrepdlg.cpp:148
+msgid "Down"
+msgstr "नीचे"
+
+#: ../src/common/stockitem.cpp:159
+msgid "&Edit"
+msgstr "संपादन (&E)"
+
+#: ../src/common/stockitem.cpp:159
+#, fuzzy
+msgid "Edit"
+msgstr "संपादन (&E)"
+
+#: ../src/common/stockitem.cpp:160
+msgid "&Execute"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:160
+msgid "Execute"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:161
+msgid "&Quit"
+msgstr "छोड़ दे (&Q)"
+
+#: ../src/common/stockitem.cpp:161
+#, fuzzy
+msgid "Quit"
+msgstr "छोड़ दे (&Q)"
+
+#: ../src/common/stockitem.cpp:162
+msgid "&File"
+msgstr "फ़ाइल (&F)"
+
+#: ../src/common/stockitem.cpp:162
+msgid "File"
+msgstr "फ़ाइल"
+
+#: ../src/common/stockitem.cpp:163
+#, fuzzy
+msgid "&Find..."
+msgstr "खोजें (&F)"
+
+#: ../src/common/stockitem.cpp:163
+#, fuzzy
+msgid "Find..."
+msgstr "खोज"
+
+#: ../src/common/stockitem.cpp:164
+#, fuzzy
+msgid "&First"
+msgstr "प्रथम"
+
+#: ../src/common/stockitem.cpp:164
+#, fuzzy
+msgid "First"
+msgstr "प्रथम"
+
+#: ../src/common/stockitem.cpp:165
+#, fuzzy
+msgid "&Floppy"
+msgstr "प्रतिलिपि बनाएँ (&C)"
+
+#: ../src/common/stockitem.cpp:165
+msgid "Floppy"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:166
+msgid "&Forward"
+msgstr "आगे (&F)"
+
+#: ../src/common/stockitem.cpp:166
+#, fuzzy
+msgid "Forward"
+msgstr "आगे (&F)"
+
+#: ../src/common/stockitem.cpp:167
+msgid "&Harddisk"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:167
+msgid "Harddisk"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:168 ../src/generic/wizard.cpp:418
+#: ../src/osx/cocoa/menu.mm:225 ../src/richtext/richtextstyledlg.cpp:298
+#: ../src/richtext/richtextsymboldlg.cpp:451
+msgid "&Help"
+msgstr "सहायता (&H)"
+
+#: ../src/common/stockitem.cpp:169
+msgid "&Home"
+msgstr "गृह (&H)"
+
+#: ../src/common/stockitem.cpp:169
+msgid "Home"
+msgstr "गृह"
+
+#: ../src/common/stockitem.cpp:170
+msgid "Indent"
+msgstr "जगह छोड़ कर लिखें"
+
+#: ../src/common/stockitem.cpp:171
+msgid "&Index"
+msgstr "अनुक्रमणिका (&I)"
+
+#: ../src/common/stockitem.cpp:171 ../src/html/helpwnd.cpp:510
+msgid "Index"
+msgstr "इंडेक्स"
+
+#: ../src/common/stockitem.cpp:172
+#, fuzzy
+msgid "&Info"
+msgstr "पहिले जैसा करें (&U)"
+
+#: ../src/common/stockitem.cpp:172
+msgid "Info"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:173
+msgid "&Italic"
+msgstr "तिरछा"
+
+#: ../src/common/stockitem.cpp:173 ../src/generic/fontdlgg.cpp:322
+#: ../src/richtext/richtextfontpage.cpp:350
+msgid "Italic"
+msgstr "इटैलिक"
+
+#: ../src/common/stockitem.cpp:174
+msgid "&Jump to"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:174
+msgid "Jump to"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:175
+msgid "Centered"
+msgstr "केन्द्रित करें"
+
+#: ../src/common/stockitem.cpp:176
+msgid "Justified"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:177
+msgid "Align Left"
+msgstr "बायें पंक्तिबद्ध करें"
+
+#: ../src/common/stockitem.cpp:178
+msgid "Align Right"
+msgstr "दायें पंक्तिबद्ध करें"
+
+#: ../src/common/stockitem.cpp:179
+#, fuzzy
+msgid "&Last"
+msgstr "चिपकाएँ (&P)"
+
+#: ../src/common/stockitem.cpp:179
+#, fuzzy
+msgid "Last"
+msgstr "चिपकाएँ"
+
+#: ../src/common/stockitem.cpp:180
+#, fuzzy
+msgid "&Network"
+msgstr "नया (&N)"
+
+#: ../src/common/stockitem.cpp:180
+msgid "Network"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:181 ../src/richtext/richtexttabspage.cpp:131
+msgid "&New"
+msgstr "नया (&N)"
+
+#: ../src/common/stockitem.cpp:181
+#, fuzzy
+msgid "New"
+msgstr "नया (&N)"
+
+#: ../src/common/stockitem.cpp:182 ../src/msw/msgdlg.cpp:417
+msgid "&No"
+msgstr "नहीं (&N)"
+
+#: ../src/common/stockitem.cpp:183 ../src/generic/fontdlgg.cpp:467
+#: ../src/generic/fontdlgg.cpp:474
+msgid "&OK"
+msgstr "ठीक (&O)"
+
+#: ../src/common/stockitem.cpp:184 ../src/generic/dbgrptg.cpp:341
+msgid "&Open..."
+msgstr "खोलें (&O)..."
+
+#: ../src/common/stockitem.cpp:184
+#, fuzzy
+msgid "Open..."
+msgstr "खोलें (&O)..."
+
+#: ../src/common/stockitem.cpp:185 ../src/msw/textctrl.cpp:2885
+#: ../src/osx/textctrl_osx.cpp:654 ../src/richtext/richtextctrl.cpp:332
+msgid "&Paste"
+msgstr "चिपकाएँ (&P)"
+
+#: ../src/common/stockitem.cpp:185 ../src/richtext/richtextctrl.cpp:3484
+#: ../src/stc/stc_i18n.cpp:19
+msgid "Paste"
+msgstr "चिपकाएँ"
+
+#: ../src/common/stockitem.cpp:186
+msgid "&Preferences"
+msgstr "प्राथमिकता (&P)"
+
+#: ../src/common/stockitem.cpp:186 ../src/osx/cocoa/preferences.mm:304
+#, fuzzy
+msgid "Preferences"
+msgstr "प्राथमिकता (&P)"
+
+#: ../src/common/stockitem.cpp:187
+#, fuzzy
+msgid "Print previe&w..."
+msgstr "मुद्रण पूर्वालोकन (&w)"
+
+#: ../src/common/stockitem.cpp:187
+#, fuzzy
+msgid "Print preview..."
+msgstr "मुद्रण पूर्वालोकन"
+
+#: ../src/common/stockitem.cpp:188
+msgid "&Print..."
+msgstr "मुद्रण (&P)..."
+
+#: ../src/common/stockitem.cpp:188
+#, fuzzy
+msgid "Print..."
+msgstr "मुद्रण (&P)..."
+
+#: ../src/common/stockitem.cpp:189 ../src/richtext/richtextctrl.cpp:337
+#: ../src/richtext/richtextctrl.cpp:5479
+msgid "&Properties"
+msgstr "गुणधर्म (&P)"
+
+#: ../src/common/stockitem.cpp:189
+#, fuzzy
+msgid "Properties"
+msgstr "गुणधर्म (&P)"
+
+#: ../src/common/stockitem.cpp:190 ../src/stc/stc_i18n.cpp:16
+#, fuzzy
+msgid "Redo"
+msgstr "पुनःकरें (&R)"
+
+#: ../src/common/stockitem.cpp:191
+msgid "Refresh"
+msgstr "ताज़ा करें"
+
+#: ../src/common/stockitem.cpp:192
+msgid "Remove"
+msgstr "निकाल दें"
+
+#: ../src/common/stockitem.cpp:193
+#, fuzzy
+msgid "Rep&lace..."
+msgstr "बदलें (&l)"
+
+#: ../src/common/stockitem.cpp:193
+#, fuzzy
+msgid "Replace..."
+msgstr "बदलें"
+
+#: ../src/common/stockitem.cpp:194
+msgid "Revert to Saved"
+msgstr "संरक्षित पर लौटे"
+
+#: ../src/common/stockitem.cpp:196 ../src/generic/logg.cpp:549
+msgid "Save &As..."
+msgstr "इस जैसा सुरक्षित करें (&A)..."
+
+#: ../src/common/stockitem.cpp:196
+#, fuzzy
+msgid "Save As..."
+msgstr "इस जैसा सुरक्षित करें (&A)..."
+
+#: ../src/common/stockitem.cpp:197 ../src/msw/textctrl.cpp:2888
+#: ../src/osx/textctrl_osx.cpp:657 ../src/richtext/richtextctrl.cpp:335
+msgid "Select &All"
+msgstr "सभी का चयन (&A)"
+
+#: ../src/common/stockitem.cpp:197 ../src/stc/stc_i18n.cpp:21
+#, fuzzy
+msgid "Select All"
+msgstr "सभी का चयन (&A)"
+
+#: ../src/common/stockitem.cpp:198
+#, fuzzy
+msgid "&Color"
+msgstr "रंग (&C):"
+
+#: ../src/common/stockitem.cpp:198
+#, fuzzy
+msgid "Color"
+msgstr "रंग"
+
+#: ../src/common/stockitem.cpp:199
+#, fuzzy
+msgid "&Font"
+msgstr "फ़ॉन्ट: (&F)"
+
+#: ../src/common/stockitem.cpp:199 ../src/richtext/richtextformatdlg.cpp:336
+msgid "Font"
+msgstr "फ़ॉन्ट"
+
+#: ../src/common/stockitem.cpp:200
+msgid "&Ascending"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:200
+#, fuzzy
+msgid "Ascending"
+msgstr "पढ़ा जा रहा है"
+
+#: ../src/common/stockitem.cpp:201
+msgid "&Descending"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:201
+#, fuzzy
+msgid "Descending"
+msgstr "डिफ़ाल्ट एन्कोडिंग"
+
+#: ../src/common/stockitem.cpp:202
+msgid "&Spell Check"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:202
+msgid "Spell Check"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:203
+msgid "&Stop"
+msgstr "रोक दें (&S)"
+
+#: ../src/common/stockitem.cpp:203
+#, fuzzy
+msgid "Stop"
+msgstr "रोक दें (&S)"
+
+#: ../src/common/stockitem.cpp:204 ../src/richtext/richtextfontpage.cpp:274
+msgid "&Strikethrough"
+msgstr "स्ट्राइक थुःरु (S)"
+
+#: ../src/common/stockitem.cpp:204
+#, fuzzy
+msgid "Strikethrough"
+msgstr "स्ट्राइक थुःरु (S)"
+
+#: ../src/common/stockitem.cpp:205
+#, fuzzy
+msgid "&Top"
+msgstr "प्रतिलिपि बनाएँ (&C)"
+
+#: ../src/common/stockitem.cpp:205 ../src/richtext/richtextsizepage.cpp:285
+#: ../src/richtext/richtextsizepage.cpp:289
+#, fuzzy
+msgid "Top"
+msgstr "प्राप्तकर्ता:"
+
+#: ../src/common/stockitem.cpp:206
+msgid "Undelete"
+msgstr "अविलोप"
+
+#: ../src/common/stockitem.cpp:207 ../src/generic/fontdlgg.cpp:437
+msgid "&Underline"
+msgstr "रेखांकित (&U)"
+
+#: ../src/common/stockitem.cpp:207
+#, fuzzy
+msgid "Underline"
+msgstr "रेखांकित (&U)"
+
+#: ../src/common/stockitem.cpp:208 ../src/stc/stc_i18n.cpp:15
+#, fuzzy
+msgid "Undo"
+msgstr "पहिले जैसा करें (&U)"
+
+#: ../src/common/stockitem.cpp:209
+msgid "&Unindent"
+msgstr "अन-इंडेंट (&U)"
+
+#: ../src/common/stockitem.cpp:209
+#, fuzzy
+msgid "Unindent"
+msgstr "अन-इंडेंट (&U)"
+
+#: ../src/common/stockitem.cpp:210
+msgid "&Up"
+msgstr "ऊपर (&U)"
+
+#: ../src/common/stockitem.cpp:210 ../src/generic/fdrepdlg.cpp:148
+msgid "Up"
+msgstr "ऊपर"
+
+#: ../src/common/stockitem.cpp:211 ../src/msw/msgdlg.cpp:417
+msgid "&Yes"
+msgstr "हाँ (&Y)"
+
+#: ../src/common/stockitem.cpp:212
+msgid "&Actual Size"
+msgstr "वास्तविक आकार (&A)"
+
+#: ../src/common/stockitem.cpp:212
+#, fuzzy
+msgid "Actual Size"
+msgstr "वास्तविक आकार (&A)"
+
+#: ../src/common/stockitem.cpp:213
+msgid "Zoom to &Fit"
+msgstr "अनुरूप आकार करें (&F)"
+
+#: ../src/common/stockitem.cpp:213
+#, fuzzy
+msgid "Zoom to Fit"
+msgstr "अनुरूप आकार करें (&F)"
+
+#: ../src/common/stockitem.cpp:214
+msgid "Zoom &In"
+msgstr "बड़ा करें (&I)"
+
+#: ../src/common/stockitem.cpp:215
+msgid "Zoom &Out"
+msgstr "छोटा करें (&O)"
+
+#: ../src/common/stockitem.cpp:262
+msgid "Show about dialog"
+msgstr "प्रोग्राम के बारे में वाला संवाद दिखाएँ"
+
+#: ../src/common/stockitem.cpp:263
+msgid "Copy selection"
+msgstr "चयन की प्रतिलिपि बनाएँ"
+
+#: ../src/common/stockitem.cpp:264
+msgid "Cut selection"
+msgstr "चयन काटें"
+
+#: ../src/common/stockitem.cpp:265
+msgid "Delete selection"
+msgstr "चयन मिटाएँ"
+
+#: ../src/common/stockitem.cpp:266
+#, fuzzy
+msgid "Find in document"
+msgstr "एचटीएमएल प्रलेख को खोलें"
+
+#: ../src/common/stockitem.cpp:267
+msgid "Find and replace in document"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:268
+msgid "Paste selection"
+msgstr "चयन चिपकाएँ"
+
+#: ../src/common/stockitem.cpp:269
+msgid "Quit this program"
+msgstr "प्रोग्राम बंद करें"
+
+#: ../src/common/stockitem.cpp:270
+msgid "Redo last action"
+msgstr "पिछला कार्य फिर से करें"
+
+#: ../src/common/stockitem.cpp:271
+msgid "Undo last action"
+msgstr "पिछला कार्य रद्द करें"
+
+#: ../src/common/stockitem.cpp:272
+#, fuzzy
+msgid "Create new document"
+msgstr "नयी निर्देशिका का निर्माण करें"
+
+#: ../src/common/stockitem.cpp:273
+#, fuzzy
+msgid "Open an existing document"
+msgstr "एचटीएमएल प्रलेख को खोलें"
+
+#: ../src/common/stockitem.cpp:274
+msgid "Close current document"
+msgstr "वर्तमान प्रलेख बंद करें"
+
+#: ../src/common/stockitem.cpp:275
+msgid "Save current document"
+msgstr "वर्तमान प्रलेख को सुरक्षित करें"
+
+#: ../src/common/stockitem.cpp:276
+msgid "Save current document with a different filename"
+msgstr "वर्तमान प्रलेख को अलग नाम से सुरक्षित करें"
+
+#: ../src/common/strconv.cpp:2324
+#, c-format
+msgid "Conversion to charset '%s' doesn't work."
+msgstr "'%s' शब्दसमुच्चय में रूपांतरण ने कार्य नहीं किया।"
+
+#: ../src/common/tarstrm.cpp:352 ../src/common/tarstrm.cpp:375
+#: ../src/common/tarstrm.cpp:406 ../src/generic/progdlgg.cpp:373
+msgid "unknown"
+msgstr "अज्ञात"
+
+#: ../src/common/tarstrm.cpp:774
+msgid "incomplete header block in tar"
+msgstr ""
+
+#: ../src/common/tarstrm.cpp:798
+msgid "checksum failure reading tar header block"
+msgstr ""
+
+#: ../src/common/tarstrm.cpp:971
+msgid "invalid data in extended tar header"
+msgstr ""
+
+#: ../src/common/tarstrm.cpp:981 ../src/common/tarstrm.cpp:1003
+#: ../src/common/tarstrm.cpp:1477 ../src/common/tarstrm.cpp:1499
+msgid "tar entry not open"
+msgstr ""
+
+#: ../src/common/tarstrm.cpp:1023
+msgid "unexpected end of file"
+msgstr "अनपेक्षित फ़ाइल अंत"
+
+#: ../src/common/tarstrm.cpp:1297
+#, c-format
+msgid "%s did not fit the tar header for entry '%s'"
+msgstr ""
+
+#: ../src/common/tarstrm.cpp:1359
+msgid "incorrect size given for tar entry"
+msgstr ""
+
+#: ../src/common/textbuf.cpp:232
+#, c-format
+msgid "'%s' is probably a binary buffer."
+msgstr "'%s' सम्भवता एक बायनरी बफ़र है।"
+
+#: ../src/common/textcmn.cpp:1006 ../src/richtext/richtextctrl.cpp:3053
+msgid "File couldn't be loaded."
+msgstr "फ़ाइल को लोड नहीं किया जा सका।"
+
+#: ../src/common/textfile.cpp:95
+#, fuzzy, c-format
+msgid "Failed to read text file \"%s\"."
+msgstr "%d आकॄति को '%s' फ़ाइल से लोड करने में असफ़ल।"
+
+#: ../src/common/textfile.cpp:160
+#, c-format
+msgid "can't write buffer '%s' to disk."
+msgstr "'%s' बफ़र को डिस्क पर नहीं लिखा जा सकता है।"
+
+#: ../src/common/time.cpp:212
+msgid "Failed to get the local system time"
+msgstr "स्थानीय तंत्र समय प्राप्त करने में असफ़ल"
+
+#: ../src/common/time.cpp:279
+msgid "wxGetTimeOfDay failed."
+msgstr "wxGetTimeOfDay असफ़ल रहा।"
+
+#: ../src/common/translation.cpp:929
+#, c-format
+msgid "'%s' is not a valid message catalog."
+msgstr "'%s' एक वैध संदेश सूचीपत्र नहीं है।"
+
+#: ../src/common/translation.cpp:954
+#, fuzzy
+msgid "Invalid message catalog."
+msgstr "'%s' एक वैध संदेश सूचीपत्र नहीं है।"
+
+#: ../src/common/translation.cpp:1013
+#, fuzzy, c-format
+msgid "Failed to parse Plural-Forms: '%s'"
+msgstr "प्ल्यूलर-फ़ार्मों का पदभंजन नहीं किया जा सका:'%s'"
+
+#: ../src/common/translation.cpp:1723
+#, c-format
+msgid "using catalog '%s' from '%s'."
+msgstr "'%s' से '%s' तक सूचीपत्र का उपयोग किया जा रहा है।"
+
+#: ../src/common/translation.cpp:1816
+#, fuzzy, c-format
+msgid "Resource '%s' is not a valid message catalog."
+msgstr "'%s' एक वैध संदेश सूचीपत्र नहीं है।"
+
+#: ../src/common/translation.cpp:1865
+#, fuzzy
+msgid "Couldn't enumerate translations"
+msgstr "थ्रेड को समाप्त नहीं किया जा सका"
+
+#: ../src/common/utilscmn.cpp:1145
+msgid "No default application configured for HTML files."
+msgstr ""
+
+#: ../src/common/utilscmn.cpp:1190
+#, fuzzy, c-format
+msgid "Failed to open URL \"%s\" in default browser."
+msgstr "'%s' को %s के लिए खोलने में असफ़ल"
+
+#: ../src/common/valtext.cpp:144
+msgid "Validation conflict"
+msgstr "सत्यापन टकराव"
+
+#: ../src/common/valtext.cpp:186
+msgid "Required information entry is empty."
+msgstr ""
+
+#: ../src/common/valtext.cpp:188
+#, fuzzy, c-format
+msgid "'%s' is one of the invalid strings"
+msgstr "'%s' अवैध है"
+
+#: ../src/common/valtext.cpp:190
+#, fuzzy, c-format
+msgid "'%s' is not one of the valid strings"
+msgstr "'%s' एक वैध संदेश सूचीपत्र नहीं है।"
+
+#: ../src/common/valtext.cpp:199
+#, fuzzy, c-format
+msgid "'%s' contains invalid character(s)"
+msgstr "'%s' में सिर्फ़ आल्फ़ाबेटिक अक्षरों को ही सम्मिलित होना चाहिए।"
+
+#: ../src/common/webrequest.cpp:139
+#, fuzzy, c-format
+msgid "Error: %s (%d)"
+msgstr "त्रुटि: "
+
+#: ../src/common/webrequest.cpp:655
+#, c-format
+msgid ""
+"Not enough free disk space for download: %llu needed but only %llu available."
+msgstr ""
+
+#: ../src/common/webrequest.cpp:669
+#, fuzzy, c-format
+msgid "Failed to create temporary file in %s"
+msgstr "एक अस्थायी फ़ाइल नाम का निर्माण करने में असफ़ल"
+
+#: ../src/common/webrequest_curl.cpp:1106
+#, fuzzy
+msgid "libcurl could not be initialized"
+msgstr "फ़ाइल को लोड नहीं किया जा सका।"
+
+#: ../src/common/webview.cpp:392
+#, fuzzy
+msgid "RunScriptAsync not supported"
+msgstr "श्रेणीयों का रूपांतरण समर्थित नहीं है"
+
+#: ../src/common/webview.cpp:403 ../src/msw/webview_ie.cpp:1073
+#, c-format
+msgid "Error running JavaScript: %s"
+msgstr ""
+
+#: ../src/common/webview_chromium.cpp:858
+#, fuzzy, c-format
+msgid "Failed to set proxy \"%s\": %s"
+msgstr "\"%s\" निर्देशिका का निर्माण करने में असफ़ल।"
+
+#: ../src/common/webview_chromium.cpp:989
+msgid ""
+"Chromium can't be used because libcef.so wasn't loaded early enough; please "
+"relink the application or use LD_PRELOAD to load it earlier."
+msgstr ""
+
+#: ../src/common/webview_chromium.cpp:1108
+#, fuzzy
+msgid "Could not initialize Chromium"
+msgstr "मुद्रण को आरम्भ नहीं किया जा सका।"
+
+#: ../src/common/webview_chromium.cpp:1616
+msgid "Show DevTools"
+msgstr ""
+
+#: ../src/common/webview_chromium.cpp:1617
+#, fuzzy
+msgid "Close DevTools"
+msgstr "सभी समाप्त"
+
+#: ../src/common/webview_chromium.cpp:1623
+msgid "Inspect"
+msgstr ""
+
+#: ../src/common/wincmn.cpp:1628
+msgid "This platform does not support background transparency."
+msgstr ""
+
+#: ../src/common/wincmn.cpp:2097
+msgid "Could not transfer data to window"
+msgstr "डाटा को खिड़की पर स्थानान्तरित किया जा सका"
+
+#: ../src/common/windowid.cpp:240
+msgid "Out of window IDs.  Recommend shutting down application."
+msgstr ""
+
+#: ../src/common/xpmdecod.cpp:678
+msgid "XPM: incorrect header format!"
+msgstr "एक्सपीएम: गलत शीर्ष प्रारूप!"
+
+#: ../src/common/xpmdecod.cpp:703
+#, c-format
+msgid "XPM: incorrect colour description in line %d"
+msgstr "एक्सपीएम: पंक्ति %d में गलत रूप से निर्मित रंग परिभाषा"
+
+#: ../src/common/xpmdecod.cpp:715 ../src/common/xpmdecod.cpp:724
+#, c-format
+msgid "XPM: malformed colour definition '%s' at line %d!"
+msgstr "एक्सपीएम: विकृत रंग परिभाषा '%s' पंक्ति %d में!"
+
+#: ../src/common/xpmdecod.cpp:754
+#, fuzzy
+msgid "XPM: no colors left to use for mask!"
+msgstr "एक्सपीएम: गलत शीर्ष प्रारूप!"
+
+#: ../src/common/xpmdecod.cpp:781
+#, c-format
+msgid "XPM: truncated image data at line %d!"
+msgstr ""
+
+#: ../src/common/xpmdecod.cpp:795
+msgid "XPM: Malformed pixel data!"
+msgstr "एक्सपीएम: गलत रूप से निर्मित पीक्सेल डाटा!"
+
+#: ../src/common/xti.cpp:492
+msgid "Illegal Parameter Count for Create Method"
+msgstr "निर्माण विधि के लिए अवैध पैरामीटर गणक"
+
+#: ../src/common/xti.cpp:504
+msgid "Illegal Parameter Count for ConstructObject Method"
+msgstr "ConstructObject विधि के लिए अवैध पैरामीटर गणक"
+
+#: ../src/common/xtistrm.cpp:161
+#, fuzzy, c-format
+msgid "Create Parameter %s not found in declared RTTI Parameters"
+msgstr "घोषित आरटीटीआई पैरामीटरों में निर्माण पैरामीटर नहीं मिला"
+
+#: ../src/common/xtistrm.cpp:290
+msgid "Illegal Object Class (Non-wxEvtHandler) as Event Source"
+msgstr "घटना स्रोत की भांति अवैध ऑबजेक्ट वर्ग (Non-wxEvtHandler)"
+
+#: ../src/common/xtistrm.cpp:313 ../src/common/xtixml.cpp:345
+#: ../src/common/xtixml.cpp:498
+msgid "Type must have enum - long conversion"
+msgstr "प्रकार के पास ईनम - लंबा रूपांतरण अवश्य होना चाहिए"
+
+#: ../src/common/xtistrm.cpp:400 ../src/common/xtistrm.cpp:415
+msgid "Invalid or Null Object ID passed to GetObjectClassInfo"
+msgstr "GetObjectClassInfo को अवैध या रिक्त ऑबजेक्ट आईडी दी गयी"
+
+#: ../src/common/xtistrm.cpp:405
+msgid "Unknown Object passed to GetObjectClassInfo"
+msgstr "GetObjectClassInfo को अज्ञात ऑबजेक्ट दिया किया गया"
+
+#: ../src/common/xtistrm.cpp:420
+msgid "Already Registered Object passed to SetObjectClassInfo"
+msgstr "SetObjectClassInfo को पहिले से पंजीकॄत ऑब्जेक्ट पास कर दिये गये है"
+
+#: ../src/common/xtistrm.cpp:430
+msgid "Invalid or Null Object ID passed to HasObjectClassInfo"
+msgstr "HasObjectClassInfo को अवैध या रिक्त ऑबजेक्ट आईडी दी गयी"
+
+#: ../src/common/xtistrm.cpp:460
+msgid "Passing a already registered object to SetObject"
+msgstr "SetObject को एक पहिले से पंजीकॄत ऑबजेक्ट को दिया जा रहा है"
+
+#: ../src/common/xtistrm.cpp:471
+#, fuzzy
+msgid "Passing an unknown object to GetObject"
+msgstr "GetObject को एक अज्ञात ऑबजेक्ट को दिया जा रहा है"
+
+#: ../src/common/xtixml.cpp:229
+msgid "Forward hrefs are not supported"
+msgstr "अग्र एचरेफ़्स समर्थित नहीं है"
+
+#: ../src/common/xtixml.cpp:247
+#, c-format
+msgid "unknown class %s"
+msgstr "अज्ञात वर्ग %s"
+
+#: ../src/common/xtixml.cpp:253
+msgid "objects cannot have XML Text Nodes"
+msgstr "एक्सएमएल पाठ नोडो को ऑबजेक्ट नहीं रख सकते है"
+
+#: ../src/common/xtixml.cpp:258
+msgid "Objects must have an id attribute"
+msgstr "ऑबजेक्टों के पास एक पहचान-संख्या विशेषता होनी चाहिए"
+
+#: ../src/common/xtixml.cpp:267
+#, c-format
+msgid "Doubly used id : %d"
+msgstr "दोहरी उपयोग में लायी गयी पहचानसंख्या : %d"
+
+#: ../src/common/xtixml.cpp:316
+#, fuzzy, c-format
+msgid "Unknown Property %s"
+msgstr "अज्ञात विशेषतायें %s"
+
+#: ../src/common/xtixml.cpp:407
+msgid "A non empty collection must consist of 'element' nodes"
+msgstr "एक भरे हुए संग्रह को 'तत्व' नोडो से मिलकर बना होना चाहिए"
+
+#: ../src/common/xtixml.cpp:478
+msgid "incorrect event handler string, missing dot"
+msgstr "गलत घटना हैन्डलर स्ट्रीनिंग, विलुप्त डॉट"
+
+#: ../src/common/zipstrm.cpp:559
+msgid "can't re-initialize zlib deflate stream"
+msgstr "जेडलिब् डीफ़्लेट धारा का आरम्भीकरण नहीं किया जा सकता है"
+
+#: ../src/common/zipstrm.cpp:584
+msgid "can't re-initialize zlib inflate stream"
+msgstr "जेडलिब् इनफ़्लेट धारा का आरम्भीकरण नहीं किया जा सकता है"
+
+#: ../src/common/zipstrm.cpp:1023
+msgid "Ignoring malformed extra data record, ZIP file may be corrupted"
+msgstr ""
+
+#: ../src/common/zipstrm.cpp:1502
+msgid "assuming this is a multi-part zip concatenated"
+msgstr ""
+
+#: ../src/common/zipstrm.cpp:1664
+msgid "invalid zip file"
+msgstr "अवैध जीज़िप फ़ाइल"
+
+#: ../src/common/zipstrm.cpp:1723
+msgid "can't find central directory in zip"
+msgstr "केन्द्र निर्देशिका को जीज़िप में खोजा नहीं जा सका"
+
+#: ../src/common/zipstrm.cpp:1812
+msgid "error reading zip central directory"
+msgstr "जीज़िप केन्द्र निर्देशिका को पढ़नें में त्रुटि"
+
+#: ../src/common/zipstrm.cpp:1916
+msgid "error reading zip local header"
+msgstr "जीज़िप स्थानीय शीर्ष को पढ़नें में त्रुटि"
+
+#: ../src/common/zipstrm.cpp:1964
+msgid "bad zipfile offset to entry"
+msgstr ""
+
+#: ../src/common/zipstrm.cpp:2031
+msgid "stored file length not in Zip header"
+msgstr "सुरक्षित फ़ाइल की लंबाई जीज़िप शीर्ष में नहीं है"
+
+#: ../src/common/zipstrm.cpp:2045 ../src/common/zipstrm.cpp:2362
+msgid "unsupported Zip compression method"
+msgstr "असमर्थित जीज़िप संकुचन विधि"
+
+#: ../src/common/zipstrm.cpp:2126
+#, c-format
+msgid "reading zip stream (entry %s): bad length"
+msgstr "जीज़िप धारा को पढ़ा जा रहा है (प्रविष्टी  %s): गलत लंबाई"
+
+#: ../src/common/zipstrm.cpp:2131
+#, c-format
+msgid "reading zip stream (entry %s): bad crc"
+msgstr "जीज़िप धारा को पढ़ा जा रहा है (प्रविष्टी %s): निकृष्ट सीआरसी"
+
+#: ../src/common/zipstrm.cpp:2578
+#, fuzzy, c-format
+msgid "error writing zip entry '%s': file too large without ZIP64"
+msgstr "जीज़िप प्रविष्टी '%s' के लेखन में त्रुटि: निकृष्ट सीआरसी या गलत लंबाई"
+
+#: ../src/common/zipstrm.cpp:2585
+#, c-format
+msgid "error writing zip entry '%s': bad crc or length"
+msgstr "जीज़िप प्रविष्टी '%s' के लेखन में त्रुटि: निकृष्ट सीआरसी या गलत लंबाई"
+
+#: ../src/common/zstream.cpp:155 ../src/common/zstream.cpp:315
+msgid "Gzip not supported by this version of zlib"
+msgstr ""
+
+#: ../src/common/zstream.cpp:182
+msgid "Can't initialize zlib inflate stream."
+msgstr "जेडलिब् इनफ़्लेट धारा का आरम्भीकरण नहीं किया जा सकता है।"
+
+#: ../src/common/zstream.cpp:241
+msgid "Can't read inflate stream: unexpected EOF in underlying stream."
+msgstr "इनफ़्लेट धारा को पढ़ा नहीं जा सकता है: नीचेवाली स्ट्रीम में आकस्मिक फ़ाइल का अंत।"
+
+#: ../src/common/zstream.cpp:248 ../src/common/zstream.cpp:423
+#, c-format
+msgid "zlib error %d"
+msgstr "ज़ेडलिब त्रुटि  %d"
+
+#: ../src/common/zstream.cpp:249
+#, c-format
+msgid "Can't read from inflate stream: %s"
+msgstr "इनफ़्लेट धारा से पढ़ा नहीं जा सकता है: %s"
+
+#: ../src/common/zstream.cpp:343
+msgid "Can't initialize zlib deflate stream."
+msgstr "जेडलिब् डीफ़्लेट धारा का आरम्भीकरण नहीं किया जा सकता है।"
+
+#: ../src/common/zstream.cpp:424
+#, c-format
+msgid "Can't write to deflate stream: %s"
+msgstr "डीफ़्लेट धारा पर लिखा नहीं जा सकता है: %s"
+
+#: ../src/dfb/bitmap.cpp:633 ../src/dfb/bitmap.cpp:667
+#, fuzzy, c-format
+msgid "No bitmap handler for type %d defined."
+msgstr "%d प्रकार के लिए कोई आकृति हैन्डलर परिभाषित नहीं।"
+
+#: ../src/dfb/evtloop.cpp:99
+#, fuzzy
+msgid "Failed to read event from DirectFB pipe"
+msgstr "लॉक फ़ाइल से पीआईडी को पढ़ने में असफ़ल।"
+
+#: ../src/dfb/evtloop.cpp:171
+msgid "Failed to switch DirectFB pipe to non-blocking mode"
+msgstr ""
+
+#: ../src/dfb/fontmgr.cpp:171
+#, fuzzy, c-format
+msgid "no fonts found in %s, using builtin font"
+msgstr "कोई फ़ॉन्ट %s में नहीं मिले।"
+
+#: ../src/dfb/fontmgr.cpp:177
+#, fuzzy
+msgid "Default font"
+msgstr "डिफ़ाल्ट मुद्रक"
+
+#: ../src/dfb/fontmgr.cpp:195
+#, c-format
+msgid "Fonts index file %s disappeared while loading fonts."
+msgstr ""
+
+#: ../src/dfb/wrapdfb.cpp:60
+#, c-format
+msgid "DirectFB error %d occurred."
+msgstr ""
+
+#: ../src/generic/aboutdlgg.cpp:69
+msgid "Developed by "
+msgstr "द्वारा विकसित"
+
+#: ../src/generic/aboutdlgg.cpp:72
+msgid "Documentation by "
+msgstr "द्वारा प्रलेखन"
+
+#: ../src/generic/aboutdlgg.cpp:75
+msgid "Graphics art by "
+msgstr "आलेख कला के द्वारा"
+
+#: ../src/generic/aboutdlgg.cpp:78
+msgid "Translations by "
+msgstr "द्वारा अनुवाद"
+
+#: ../src/generic/aboutdlgg.cpp:133 ../src/osx/cocoa/aboutdlg.mm:83
+#, fuzzy
+msgid "Version "
+msgstr "संस्मरण"
+
+#. TRANSLATORS: %s is application name
+#: ../src/generic/aboutdlgg.cpp:146 ../src/msw/aboutdlg.cpp:60
+#, fuzzy, c-format
+msgid "About %s"
+msgstr "के बारे में"
+
+#: ../src/generic/aboutdlgg.cpp:181
+msgid "License"
+msgstr "लाइसेंस"
+
+#: ../src/generic/aboutdlgg.cpp:184
+msgid "Developers"
+msgstr "विकासक"
+
+#: ../src/generic/aboutdlgg.cpp:188
+msgid "Documentation writers"
+msgstr "प्रलेख लेखक"
+
+#: ../src/generic/aboutdlgg.cpp:192
+msgid "Artists"
+msgstr "कलाकार"
+
+#: ../src/generic/aboutdlgg.cpp:196
+msgid "Translators"
+msgstr "अनुवादक"
+
+#: ../src/generic/animateg.cpp:125
+msgid "No handler found for animation type."
+msgstr "सजीवन आकृति प्रकार के लिए कोई हैन्डलर नहीं मिला।"
+
+#: ../src/generic/animateg.cpp:133
+#, c-format
+msgid "No animation handler for type %ld defined."
+msgstr "%ld प्रकार के लिए कोई सजीवन आकृति हैन्डलर परिभाषित नहीं।"
+
+#: ../src/generic/animateg.cpp:145
+#, c-format
+msgid "Animation file is not of type %ld."
+msgstr "सजीवन आकृति फ़ाइल %ld प्रकार की नहीं है।"
+
+#: ../src/generic/colrdlgg.cpp:154 ../src/gtk/colordlg.cpp:47
+msgid "Choose colour"
+msgstr "रंग का चयन करें"
+
+#: ../src/generic/colrdlgg.cpp:357
+msgid "Red:"
+msgstr ""
+
+#: ../src/generic/colrdlgg.cpp:360
+msgid "Green:"
+msgstr ""
+
+#: ../src/generic/colrdlgg.cpp:363
+msgid "Blue:"
+msgstr ""
+
+#: ../src/generic/colrdlgg.cpp:372
+msgid "Opacity:"
+msgstr ""
+
+#: ../src/generic/colrdlgg.cpp:384
+msgid "Add to custom colours"
+msgstr "ऐच्छिक रंगों में जोड़ें"
+
+#: ../src/generic/creddlgg.cpp:56
+msgid "Username:"
+msgstr ""
+
+#: ../src/generic/creddlgg.cpp:63
+msgid "Password:"
+msgstr ""
+
+#. TRANSLATORS: Name of Boolean true value
+#: ../src/generic/datavgen.cpp:1178
+msgid "true"
+msgstr ""
+
+#. TRANSLATORS: Name of Boolean false value
+#: ../src/generic/datavgen.cpp:1180
+#, fuzzy
+msgid "false"
+msgstr "फ़ाइल"
+
+#: ../src/generic/datavgen.cpp:6897
+#, c-format
+msgid "Row %i"
+msgstr ""
+
+#. TRANSLATORS: Action for manipulating a tree control
+#: ../src/generic/datavgen.cpp:6987
+msgid "Collapse"
+msgstr ""
+
+#. TRANSLATORS: Action for manipulating a tree control
+#: ../src/generic/datavgen.cpp:6990
+msgid "Expand"
+msgstr ""
+
+#. TRANSLATORS: Name of data view control and number of rows
+#: ../src/generic/datavgen.cpp:7011
+#, fuzzy, c-format
+msgid "%s (%d items)"
+msgstr "%s (या %s)"
+
+#: ../src/generic/datavgen.cpp:7062
+#, c-format
+msgid "Column %u"
+msgstr ""
+
+#. TRANSLATORS: Keystroke for manipulating a tree control
+#: ../src/generic/datavgen.cpp:7131 ../src/richtext/richtextbulletspage.cpp:189
+#: ../src/richtext/richtextbulletspage.cpp:192
+#: ../src/richtext/richtextbulletspage.cpp:193
+#: ../src/richtext/richtextliststylepage.cpp:252
+#: ../src/richtext/richtextliststylepage.cpp:255
+#: ../src/richtext/richtextliststylepage.cpp:256
+#: ../src/richtext/richtextsizepage.cpp:248
+msgid "Left"
+msgstr "बायें"
+
+#. TRANSLATORS: Keystroke for manipulating a tree control
+#: ../src/generic/datavgen.cpp:7134 ../src/richtext/richtextbulletspage.cpp:191
+#: ../src/richtext/richtextliststylepage.cpp:254
+#: ../src/richtext/richtextsizepage.cpp:249
+msgid "Right"
+msgstr "दायें"
+
+#: ../src/generic/datectlg.cpp:90
+#, c-format
+msgid ""
+"\"%s\" is not in the expected date format, please enter it as e.g. \"%s\"."
+msgstr ""
+
+#: ../src/generic/datectlg.cpp:94
+#, fuzzy
+msgid "Invalid date"
+msgstr "पीसीएक्स: अवैध आकृति"
+
+#: ../src/generic/dbgrptg.cpp:159
+#, c-format
+msgid "Open file \"%s\""
+msgstr "फ़ाइल खोलें \"%s\""
+
+#: ../src/generic/dbgrptg.cpp:170
+#, c-format
+msgid "Enter command to open file \"%s\":"
+msgstr "फ़ाइल \"%s\" को खोलने के लिए निर्देश बताएँ:"
+
+#: ../src/generic/dbgrptg.cpp:230
+#, fuzzy
+msgid "Executable files (*.exe)|*.exe|"
+msgstr "निष्पाद्य फ़ाइलें (*.exe)|*.exe|सभी फ़ाइलें (*.*)|*.*||"
+
+#: ../src/generic/dbgrptg.cpp:300
+#, c-format
+msgid "Debug report \"%s\""
+msgstr "दोषमार्जन विवरण \"%s\""
+
+#: ../src/generic/dbgrptg.cpp:316
+msgid "A debug report has been generated in the directory\n"
+msgstr "एक दोषमार्जन विवरण इस निर्देशिका में बन गया हें\n"
+
+#: ../src/generic/dbgrptg.cpp:317
+msgid "The following debug report will be generated\n"
+msgstr ""
+
+#: ../src/generic/dbgrptg.cpp:321
+msgid ""
+"The report contains the files listed below. If any of these files contain "
+"private information,\n"
+"please uncheck them and they will be removed from the report.\n"
+msgstr ""
+"नीचे दी गयी फ़ाइलें इस विवरण में सम्मिलित हें। अगर इन में से किसी भी फ़ाइल में व्यक्तिगत "
+"जानकारी हें तो,\n"
+"कृपया उन्हें अन्चेक कर दे और वे इस विवरण से हटा दी जायेंगी।\n"
+
+#: ../src/generic/dbgrptg.cpp:323
+msgid ""
+"If you wish to suppress this debug report completely, please choose the "
+"\"Cancel\" button,\n"
+"but be warned that it may hinder improving the program, so if\n"
+"at all possible please do continue with the report generation.\n"
+msgstr ""
+"अगर आप इस दोषमार्जन विवरण को पूरी तरह से छिपा देना चाहते हें तो, कृपया \"निरस्त\" बटन "
+"चुने,\n"
+"लेकिन ध्यान रखे, यह इस प्रोग्राम को उत्कृष्ट बनाने में बाधा पहुँचायेंगी,\n"
+"इसलिए जब तक हो सके कृपया विवरण निर्माण जारी रखे।\n"
+
+#: ../src/generic/dbgrptg.cpp:325
+msgid "              Thank you and we're sorry for the inconvenience!\n"
+msgstr "              आपका धन्यवाद, कृपया असुविधा के लिए क्षमा करें।\n"
+
+#: ../src/generic/dbgrptg.cpp:333
+msgid "&Debug report preview:"
+msgstr "दोषमार्जन विवरण पूर्वालोकन (&D):"
+
+#: ../src/generic/dbgrptg.cpp:339
+#, fuzzy
+msgid "&View..."
+msgstr "खोलें (&O)..."
+
+#: ../src/generic/dbgrptg.cpp:359
+msgid "&Notes:"
+msgstr "टिप्पणी (&N)"
+
+#: ../src/generic/dbgrptg.cpp:361
+msgid ""
+"If you have any additional information pertaining to this bug\n"
+"report, please enter it here and it will be joined to it:"
+msgstr ""
+
+#: ../src/generic/dcpsg.cpp:1627
+msgid "Cannot open file for PostScript printing!"
+msgstr "पोस्टस्क्रिप्ट मुद्रण के लिए फ़ाइल को खोला नहीं जा सका!"
+
+#: ../src/generic/dirctrlg.cpp:402
+msgid "Computer"
+msgstr "कम्प्यूटर"
+
+#: ../src/generic/dirctrlg.cpp:404
+msgid "Sections"
+msgstr "विभाग"
+
+#: ../src/generic/dirctrlg.cpp:482
+msgid "Home directory"
+msgstr "गृह निर्देशिका"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/generic/dirctrlg.cpp:484 ../src/propgrid/advprops.cpp:811
+msgid "Desktop"
+msgstr "डेस्कटॉप"
+
+#: ../src/generic/dirctrlg.cpp:528 ../src/generic/filectrlg.cpp:752
+msgid "Illegal directory name."
+msgstr "अवैध निर्देशिका नाम।"
+
+#: ../src/generic/dirctrlg.cpp:528 ../src/generic/dirctrlg.cpp:546
+#: ../src/generic/dirctrlg.cpp:557 ../src/generic/dirdlgg.cpp:317
+#: ../src/generic/filectrlg.cpp:638 ../src/generic/filectrlg.cpp:752
+#: ../src/generic/filectrlg.cpp:766 ../src/generic/filectrlg.cpp:782
+#: ../src/generic/filectrlg.cpp:1356 ../src/generic/filectrlg.cpp:1387
+#: ../src/generic/filedlgg.cpp:362 ../src/gtk/filedlg.cpp:76
+msgid "Error"
+msgstr "त्रुटि"
+
+#: ../src/generic/dirctrlg.cpp:546 ../src/generic/filectrlg.cpp:766
+msgid "File name exists already."
+msgstr "फ़ाइल नाम पहिले से विद्यमान है।"
+
+#: ../src/generic/dirctrlg.cpp:557 ../src/generic/dirdlgg.cpp:317
+#: ../src/generic/filectrlg.cpp:638 ../src/generic/filectrlg.cpp:782
+msgid "Operation not permitted."
+msgstr "संक्रिया को अनुमति नहीं है।"
+
+#: ../src/generic/dirdlgg.cpp:107 ../src/generic/filedlgg.cpp:207
+msgid "Create new directory"
+msgstr "नयी निर्देशिका का निर्माण करें"
+
+#: ../src/generic/dirdlgg.cpp:112 ../src/generic/filedlgg.cpp:203
+msgid "Go to home directory"
+msgstr "गॄह निर्देशिका पर जाएँ"
+
+#: ../src/generic/dirdlgg.cpp:143
+msgid "Show &hidden directories"
+msgstr "छुपी हुई निर्देशिकाओं को दिखाएँ (&H)"
+
+#: ../src/generic/dirdlgg.cpp:196
+#, c-format
+msgid ""
+"The directory '%s' does not exist\n"
+"Create it now?"
+msgstr ""
+"'%s' यह निर्देशिका विद्यमान नहीं है\n"
+"अभी इसका निर्माण किया जाएँ?"
+
+#: ../src/generic/dirdlgg.cpp:198
+msgid "Directory does not exist"
+msgstr "निर्देशिका विद्यमान नहीं है"
+
+#: ../src/generic/dirdlgg.cpp:214
+#, c-format
+msgid ""
+"Failed to create directory '%s'\n"
+"(Do you have the required permissions?)"
+msgstr ""
+"'%s' निर्देशिका का निर्माण करने में असफ़ल\n"
+"(क्या आपके पास आवश्यक अनुमतियां है?)"
+
+#: ../src/generic/dirdlgg.cpp:216
+msgid "Error creating directory"
+msgstr "निर्देशिका निर्माण में त्रुटि"
+
+#: ../src/generic/dirdlgg.cpp:281
+msgid "You cannot add a new directory to this section."
+msgstr "आप इस भाग में एक नयी निर्देशिका को जोड़ नहीं सकते है।"
+
+#: ../src/generic/dirdlgg.cpp:282
+msgid "Create directory"
+msgstr "निर्देशिका का निर्माण करें"
+
+#: ../src/generic/dirdlgg.cpp:291 ../src/generic/dirdlgg.cpp:301
+#: ../src/generic/filectrlg.cpp:614 ../src/generic/filectrlg.cpp:623
+msgid "NewName"
+msgstr "नयानाम"
+
+#: ../src/generic/editlbox.cpp:135
+msgid "Edit item"
+msgstr "आयट्म को संपादित करें"
+
+#: ../src/generic/editlbox.cpp:143
+msgid "New item"
+msgstr "नया आयट्म"
+
+#: ../src/generic/editlbox.cpp:151
+msgid "Delete item"
+msgstr "आयट्म को हटाएँ"
+
+#: ../src/generic/editlbox.cpp:159
+msgid "Move up"
+msgstr "ऊपर लाएँ"
+
+#: ../src/generic/editlbox.cpp:164
+msgid "Move down"
+msgstr "नीचे लाएँ"
+
+#: ../src/generic/fdrepdlg.cpp:108
+msgid "Search for:"
+msgstr "के लिए खोज: "
+
+#: ../src/generic/fdrepdlg.cpp:120
+msgid "Replace with:"
+msgstr "से बदलें:"
+
+#: ../src/generic/fdrepdlg.cpp:140
+msgid "Whole word"
+msgstr "पूर्ण शब्द"
+
+#: ../src/generic/fdrepdlg.cpp:143
+msgid "Match case"
+msgstr "बड़ा-छोटा का मिलान करें"
+
+#: ../src/generic/fdrepdlg.cpp:156
+msgid "Search direction"
+msgstr "खोज की दिशा"
+
+#: ../src/generic/fdrepdlg.cpp:175
+msgid "&Replace"
+msgstr "बदलें (&R)"
+
+#: ../src/generic/fdrepdlg.cpp:178
+msgid "Replace &all"
+msgstr "सभी को बदलें (&a)"
+
+#: ../src/generic/filectrlg.cpp:246 ../src/generic/filectrlg.cpp:269
+msgid "<DIR>"
+msgstr "<निर्देशिका> (<DIR>"
+
+#: ../src/generic/filectrlg.cpp:248 ../src/generic/filectrlg.cpp:271
+msgid "<LINK>"
+msgstr "<कड़ी>"
+
+#: ../src/generic/filectrlg.cpp:250 ../src/generic/filectrlg.cpp:273
+msgid "<DRIVE>"
+msgstr "<ड्राइव>"
+
+#: ../src/generic/filectrlg.cpp:275
+#, c-format
+msgid "%ld byte"
+msgid_plural "%ld bytes"
+msgstr[0] "%ld बाईट"
+msgstr[1] "%ld बाईट्स"
+
+#: ../src/generic/filectrlg.cpp:420
+msgid "Name"
+msgstr "नाम"
+
+#: ../src/generic/filectrlg.cpp:421 ../src/richtext/richtextformatdlg.cpp:361
+#: ../src/richtext/richtextsizepage.cpp:298
+msgid "Size"
+msgstr "आकार"
+
+#: ../src/generic/filectrlg.cpp:422
+msgid "Type"
+msgstr "प्रकार"
+
+#: ../src/generic/filectrlg.cpp:423
+msgid "Modified"
+msgstr "परिवर्तित"
+
+#: ../src/generic/filectrlg.cpp:426
+msgid "Permissions"
+msgstr "अनुमतियां"
+
+#: ../src/generic/filectrlg.cpp:429
+msgid "Attributes"
+msgstr "विशेषतायें"
+
+#: ../src/generic/filectrlg.cpp:936
+msgid "Current directory:"
+msgstr "वर्तमान निर्देशिका:"
+
+#: ../src/generic/filectrlg.cpp:979
+msgid "Show &hidden files"
+msgstr "छुपी हुई फ़ाइलों को दिखाएँ (&H)"
+
+#: ../src/generic/filectrlg.cpp:1355
+msgid "Illegal file specification."
+msgstr "अवैध फ़ाइल विशिष्टता"
+
+#: ../src/generic/filectrlg.cpp:1387
+msgid "Directory doesn't exist."
+msgstr "निर्देशिका विद्यमान नहीं है।"
+
+#: ../src/generic/filedlgg.cpp:195
+msgid "View files as a list view"
+msgstr "फ़ाइलों को एक अवलोकन सूची की भांति देखें"
+
+#: ../src/generic/filedlgg.cpp:197
+msgid "View files as a detailed view"
+msgstr "फ़ाइलों को एक विस्तॄत अवलोकन की भांति देखें"
+
+#: ../src/generic/filedlgg.cpp:200
+msgid "Go to parent directory"
+msgstr "मूल निर्देशिका पर जाएँ"
+
+#: ../src/generic/filedlgg.cpp:351 ../src/gtk/filedlg.cpp:59
+#, c-format
+msgid "File '%s' already exists, do you really want to overwrite it?"
+msgstr "'%s' फ़ाइल पहिले से विद्यमान है, क्या आप वास्तव में इसके ऊपर फ़िर से लिखना चाहते है?"
+
+#: ../src/generic/filedlgg.cpp:354 ../src/gtk/filedlg.cpp:62
+msgid "Confirm"
+msgstr "संपुष्टी दें"
+
+#: ../src/generic/filedlgg.cpp:362 ../src/gtk/filedlg.cpp:75
+msgid "Please choose an existing file."
+msgstr "कॄपया एक विद्यमान फ़ाइल का चयन करें।"
+
+#: ../src/generic/filepickerg.cpp:64
+#, fuzzy
+msgid "..."
+msgstr ".."
+
+#: ../src/generic/fontdlgg.cpp:76 ../src/richtext/richtextformatdlg.cpp:519
+msgid "ABCDEFGabcdefg12345"
+msgstr "ABCDEFGabcdefg12345"
+
+#: ../src/generic/fontdlgg.cpp:315
+msgid "Roman"
+msgstr "रोमन"
+
+#: ../src/generic/fontdlgg.cpp:316
+msgid "Decorative"
+msgstr "साज-सजावट"
+
+#: ../src/generic/fontdlgg.cpp:317
+msgid "Modern"
+msgstr "आधुनिक"
+
+#: ../src/generic/fontdlgg.cpp:318
+msgid "Script"
+msgstr "लिपि"
+
+#: ../src/generic/fontdlgg.cpp:319
+msgid "Swiss"
+msgstr "स्वीस"
+
+#: ../src/generic/fontdlgg.cpp:320
+msgid "Teletype"
+msgstr "टेलीटाइप"
+
+#: ../src/generic/fontdlgg.cpp:321 ../src/generic/fontdlgg.cpp:324
+msgid "Normal"
+msgstr "सामान्य"
+
+#: ../src/generic/fontdlgg.cpp:323
+msgid "Slant"
+msgstr "स्लॉट"
+
+#: ../src/generic/fontdlgg.cpp:325
+msgid "Light"
+msgstr "हल्का"
+
+#: ../src/generic/fontdlgg.cpp:363
+msgid "&Font family:"
+msgstr "फ़ॉन्ट वंश:"
+
+#: ../src/generic/fontdlgg.cpp:367 ../src/generic/fontdlgg.cpp:369
+msgid "The font family."
+msgstr "फ़ॉन्ट का वंश"
+
+#: ../src/generic/fontdlgg.cpp:374 ../src/richtext/richtextstylepage.cpp:105
+msgid "&Style:"
+msgstr "शैली: (&S)"
+
+#: ../src/generic/fontdlgg.cpp:378 ../src/generic/fontdlgg.cpp:380
+msgid "The font style."
+msgstr "फ़ॉन्ट की शैली"
+
+#: ../src/generic/fontdlgg.cpp:385
+msgid "&Weight:"
+msgstr "भार (&W):"
+
+#: ../src/generic/fontdlgg.cpp:389 ../src/generic/fontdlgg.cpp:391
+msgid "The font weight."
+msgstr "फ़ॉन्ट का भार"
+
+#: ../src/generic/fontdlgg.cpp:399
+msgid "C&olour:"
+msgstr "रंग (&o):"
+
+#: ../src/generic/fontdlgg.cpp:407 ../src/generic/fontdlgg.cpp:409
+msgid "The font colour."
+msgstr "फ़ॉन्ट का रंग"
+
+#: ../src/generic/fontdlgg.cpp:415
+msgid "&Point size:"
+msgstr "फ़ॉन्ट आकार (&P):"
+
+#: ../src/generic/fontdlgg.cpp:420 ../src/generic/fontdlgg.cpp:422
+#: ../src/generic/fontdlgg.cpp:426 ../src/generic/fontdlgg.cpp:428
+msgid "The font point size."
+msgstr "फ़ॉन्ट बिन्दु का आकार।"
+
+#: ../src/generic/fontdlgg.cpp:439 ../src/generic/fontdlgg.cpp:441
+msgid "Whether the font is underlined."
+msgstr ""
+
+#: ../src/generic/fontdlgg.cpp:448 ../src/html/helpwnd.cpp:1215
+msgid "Preview:"
+msgstr "पूर्वालोकन:"
+
+#: ../src/generic/fontdlgg.cpp:452 ../src/generic/fontdlgg.cpp:454
+msgid "Shows the font preview."
+msgstr "फ़ॉन्ट का पूर्वालोकन दिखाएँ।"
+
+#: ../src/generic/fontdlgg.cpp:464 ../src/generic/fontdlgg.cpp:483
+msgid "Click to cancel the font selection."
+msgstr ""
+
+#: ../src/generic/fontdlgg.cpp:469 ../src/generic/fontdlgg.cpp:471
+#: ../src/generic/fontdlgg.cpp:476 ../src/generic/fontdlgg.cpp:478
+msgid "Click to confirm the font selection."
+msgstr ""
+
+#: ../src/generic/fontpickerg.cpp:50 ../src/gtk/fontdlg.cpp:77
+msgid "Choose font"
+msgstr "फ़ॉन्ट का चयन करें"
+
+#: ../src/generic/grid.cpp:6542
+msgid ""
+"Error copying grid to the clipboard. Either selected cells were not "
+"contiguous or no cell was selected."
+msgstr ""
+
+#: ../src/generic/grid.cpp:12739
+msgid "Grid Corner"
+msgstr ""
+
+#: ../src/generic/grid.cpp:12741
+#, c-format
+msgid "Column %s Header"
+msgstr ""
+
+#: ../src/generic/grid.cpp:12743
+#, c-format
+msgid "Row %s Header"
+msgstr ""
+
+#: ../src/generic/grid.cpp:12745
+#, c-format
+msgid "Column %s: %s"
+msgstr ""
+
+#: ../src/generic/grid.cpp:12749
+#, fuzzy, c-format
+msgid "Row %s: %s"
+msgstr "\t%s: %s\n"
+
+#: ../src/generic/grid.cpp:12753
+#, c-format
+msgid "Row %s, Column %s: %s"
+msgstr ""
+
+#: ../src/generic/helpext.cpp:257
+#, c-format
+msgid "Help directory \"%s\" not found."
+msgstr "सहायता निर्देशिका \"%s\" नहीं मिली।"
+
+#: ../src/generic/helpext.cpp:265
+#, c-format
+msgid "Help file \"%s\" not found."
+msgstr "सहायता फ़ाइल \"%s\" नहीं मिली।"
+
+#: ../src/generic/helpext.cpp:284
+#, c-format
+msgid "Line %lu of map file \"%s\" has invalid syntax, skipped."
+msgstr ""
+
+#: ../src/generic/helpext.cpp:292
+#, c-format
+msgid "No valid mappings found in the file \"%s\"."
+msgstr ""
+
+#: ../src/generic/helpext.cpp:435
+msgid "No entries found."
+msgstr "कोई प्रविष्टियां नहीं मिली।"
+
+#: ../src/generic/helpext.cpp:444 ../src/generic/helpext.cpp:445
+msgid "Help Index"
+msgstr "सहायता इंडेक्स"
+
+#: ../src/generic/helpext.cpp:448
+msgid "Relevant entries:"
+msgstr "संबंधित प्रविष्टियां:"
+
+#: ../src/generic/helpext.cpp:449
+msgid "Entries found"
+msgstr "प्रविष्टियां मिली"
+
+#: ../src/generic/hyperlinkg.cpp:170
+msgid "&Copy URL"
+msgstr "URL की प्रतिलिपि बनाएँ (&C)"
+
+#: ../src/generic/infobar.cpp:119
+msgid "Hide this notification message."
+msgstr ""
+
+#. TRANSLATORS: %s will be either the application name or "Application"
+#: ../src/generic/logg.cpp:257
+#, c-format
+msgid "%s Error"
+msgstr "%s त्रुटि"
+
+#. TRANSLATORS: %s will be either the application name or "Application"
+#: ../src/generic/logg.cpp:263
+#, c-format
+msgid "%s Warning"
+msgstr "%s चेतावनी"
+
+#. TRANSLATORS: %s will be either the application name or "Application"
+#: ../src/generic/logg.cpp:273
+#, c-format
+msgid "%s Information"
+msgstr "%s सूचना"
+
+#: ../src/generic/logg.cpp:276
+#, fuzzy
+msgid "Application"
+msgstr "चयन"
+
+#: ../src/generic/logg.cpp:549
+msgid "Save log contents to file"
+msgstr "लॉग विषयवस्तुओं को फ़ाइल पर सुरक्षित करें"
+
+#: ../src/generic/logg.cpp:551
+msgid "C&lear"
+msgstr "साफ़ करें (&l)"
+
+#: ../src/generic/logg.cpp:551
+msgid "Clear the log contents"
+msgstr "लॉग विषय-वस्तुओं को साफ़ करें"
+
+#: ../src/generic/logg.cpp:553
+msgid "Close this window"
+msgstr "इस खिड़की को बन्द करें"
+
+#: ../src/generic/logg.cpp:554
+msgid "&Log"
+msgstr "लॉग (&L)"
+
+#: ../src/generic/logg.cpp:610 ../src/generic/logg.cpp:992
+msgid "Can't save log contents to file."
+msgstr "लॉग विषयवस्तुओं को फ़ाइल में सुरक्षित नहीं किया जा सकता है। "
+
+#: ../src/generic/logg.cpp:613
+#, c-format
+msgid "Log saved to the file '%s'."
+msgstr "लॉग को '%s' पर सुरक्षित किया गया।"
+
+#: ../src/generic/logg.cpp:719
+msgid "&Details"
+msgstr "विवरण (&D)"
+
+#: ../src/generic/logg.cpp:972
+#, fuzzy
+msgid "Failed to copy dialog contents to the clipboard."
+msgstr "क्लिपबोर्ड को खोलने में असफ़ल।"
+
+#: ../src/generic/logg.cpp:1022
+#, c-format
+msgid "Append log to file '%s' (choosing [No] will overwrite it)?"
+msgstr ""
+"लॉग को '%s' फ़ाइल के अंत में जोड़ें ([नहीं] का चयन करने से इस पर मिटाकर लिख दिया जायेगा)?"
+
+#: ../src/generic/logg.cpp:1024
+msgid "Question"
+msgstr "प्रश्न"
+
+#: ../src/generic/logg.cpp:1038
+msgid "invalid message box return value"
+msgstr "अवैध संदेश बॉक्स रीटर्न वैल्यू"
+
+#: ../src/generic/notifmsgg.cpp:129
+#, fuzzy
+msgid "Notice"
+msgstr "टिप्पणी (&N)"
+
+#: ../src/generic/preferencesg.cpp:118
+#, fuzzy, c-format
+msgid "%s Preferences"
+msgstr "प्राथमिकता (&P)"
+
+#: ../src/generic/printps.cpp:143
+msgid "Printing..."
+msgstr "मुद्रण किया जा रहा है..."
+
+#: ../src/generic/printps.cpp:160 ../src/gtk/print.cpp:1076
+#: ../src/msw/printwin.cpp:235
+msgid "Could not start printing."
+msgstr "मुद्रण को आरम्भ नहीं किया जा सका।"
+
+#: ../src/generic/printps.cpp:183
+#, c-format
+msgid "Printing page %d..."
+msgstr "%d पृष्ट को मुद्रित किया जा रहा है..."
+
+#: ../src/generic/prntdlgg.cpp:171
+msgid "Printer options"
+msgstr "प्रिंटर के विकल्प"
+
+#: ../src/generic/prntdlgg.cpp:176
+msgid "Print to File"
+msgstr "फ़ाइल पर मुद्रित करें"
+
+#: ../src/generic/prntdlgg.cpp:179
+msgid "Setup..."
+msgstr "स्थापना..."
+
+#: ../src/generic/prntdlgg.cpp:187
+msgid "Printer:"
+msgstr "प्रिंटर:"
+
+#: ../src/generic/prntdlgg.cpp:195
+msgid "Status:"
+msgstr "अवस्था:"
+
+#: ../src/generic/prntdlgg.cpp:206
+msgid "All"
+msgstr "सभी"
+
+#: ../src/generic/prntdlgg.cpp:207
+msgid "Pages"
+msgstr "अनेक पृष्ट"
+
+#: ../src/generic/prntdlgg.cpp:215
+msgid "Print Range"
+msgstr "मुद्रण सीमा"
+
+#: ../src/generic/prntdlgg.cpp:229
+msgid "From:"
+msgstr "प्रेषणकर्ता:"
+
+#: ../src/generic/prntdlgg.cpp:233
+msgid "To:"
+msgstr "प्राप्तकर्ता:"
+
+#: ../src/generic/prntdlgg.cpp:238
+msgid "Copies:"
+msgstr "प्रतिलिपियां:"
+
+#: ../src/generic/prntdlgg.cpp:288
+msgid "PostScript file"
+msgstr "पोस्टस्क्रिप्ट फ़ाइल"
+
+#: ../src/generic/prntdlgg.cpp:439
+msgid "Print Setup"
+msgstr "मुद्रण स्थापना"
+
+#: ../src/generic/prntdlgg.cpp:483
+msgid "Printer"
+msgstr "मुद्रक"
+
+#: ../src/generic/prntdlgg.cpp:501
+msgid "Default printer"
+msgstr "डिफ़ाल्ट मुद्रक"
+
+#: ../src/generic/prntdlgg.cpp:595 ../src/generic/prntdlgg.cpp:782
+#: ../src/generic/prntdlgg.cpp:822 ../src/generic/prntdlgg.cpp:835
+#: ../src/generic/prntdlgg.cpp:1031 ../src/generic/prntdlgg.cpp:1036
+msgid "Paper size"
+msgstr "पृष्ट आकार"
+
+#: ../src/generic/prntdlgg.cpp:604 ../src/generic/prntdlgg.cpp:847
+msgid "Portrait"
+msgstr "पोर्ट्रेट"
+
+#: ../src/generic/prntdlgg.cpp:605 ../src/generic/prntdlgg.cpp:848
+msgid "Landscape"
+msgstr "लैडस्केप"
+
+#: ../src/generic/prntdlgg.cpp:607 ../src/generic/prntdlgg.cpp:849
+msgid "Orientation"
+msgstr "अभिविन्यास"
+
+#: ../src/generic/prntdlgg.cpp:610
+msgid "Options"
+msgstr "विकल्प"
+
+#: ../src/generic/prntdlgg.cpp:612
+msgid "Print in colour"
+msgstr "मुद्रण रंगों में"
+
+#: ../src/generic/prntdlgg.cpp:621
+msgid "Print spooling"
+msgstr "मुद्रण स्पूलिंग"
+
+#: ../src/generic/prntdlgg.cpp:623
+msgid "Printer command:"
+msgstr "प्रिंटर निर्देश:"
+
+#: ../src/generic/prntdlgg.cpp:631
+msgid "Printer options:"
+msgstr "प्रिंटर के विकल्प:"
+
+#: ../src/generic/prntdlgg.cpp:860
+msgid "Left margin (mm):"
+msgstr "बायाँ हाशिया (मिलीमीटर):"
+
+#: ../src/generic/prntdlgg.cpp:861
+msgid "Top margin (mm):"
+msgstr "ऊपरी हाशिया (मिलीमीटर):"
+
+#: ../src/generic/prntdlgg.cpp:872
+msgid "Right margin (mm):"
+msgstr "दायाँ हाशिया (मिलीमीटर):"
+
+#: ../src/generic/prntdlgg.cpp:873
+msgid "Bottom margin (mm):"
+msgstr "तल मार्जिन (मिलीमीटर):"
+
+#: ../src/generic/prntdlgg.cpp:896
+msgid "Printer..."
+msgstr "प्रिंटर..."
+
+#: ../src/generic/progdlgg.cpp:246
+#, fuzzy
+msgid "&Skip"
+msgstr "छोड़ दे"
+
+#: ../src/generic/progdlgg.cpp:347 ../src/generic/progdlgg.cpp:626
+msgid "Unknown"
+msgstr "अज्ञात"
+
+#: ../src/generic/progdlgg.cpp:451 ../src/msw/progdlg.cpp:526
+msgid "Done."
+msgstr "किया गया।"
+
+#: ../src/generic/srchctlg.cpp:55 ../src/gtk/srchctrl.cpp:206
+#: ../src/html/helpwnd.cpp:530 ../src/html/helpwnd.cpp:545
+msgid "Search"
+msgstr "खोजें"
+
+#: ../src/generic/tabg.cpp:1026
+msgid "Could not find tab for id"
+msgstr "आईडी के लिए टैब को नहीं पाया जा सका"
+
+#: ../src/generic/tipdlg.cpp:136
+msgid "Tips not available, sorry!"
+msgstr "संकेत उपलब्ध नहीं हैं, क्षमा करें!"
+
+#: ../src/generic/tipdlg.cpp:197
+msgid "Tip of the Day"
+msgstr "आज का संकेत"
+
+#: ../src/generic/tipdlg.cpp:207
+msgid "Did you know..."
+msgstr "क्या आप जानते है..."
+
+#: ../src/generic/tipdlg.cpp:232
+msgid "&Show tips at startup"
+msgstr "संकेतो को शुरूवात में दिखाएँ (&S)"
+
+#: ../src/generic/tipdlg.cpp:236
+msgid "&Next Tip"
+msgstr "अगला संकेत (&N)"
+
+#: ../src/generic/wizard.cpp:411
+msgid "&Next >"
+msgstr "अगला (&N) >"
+
+#: ../src/generic/wizard.cpp:412
+msgid "&Finish"
+msgstr "समाप्त करें (&F)"
+
+#: ../src/generic/wizard.cpp:420
+msgid "< &Back"
+msgstr "< पीछे (&B)"
+
+#: ../src/gtk/aboutdlg.cpp:204
+msgid "translator-credits"
+msgstr "अनुवाद श्रेय"
+
+#: ../src/gtk/app.cpp:517
+msgid ""
+"WARNING: using XIM input method is unsupported and may result in problems "
+"with input handling and flickering. Consider unsetting GTK_IM_MODULE or "
+"setting to \"ibus\"."
+msgstr ""
+
+#: ../src/gtk/app.cpp:569
+msgid "Unable to initialize GTK+, is DISPLAY set properly?"
+msgstr ""
+
+#: ../src/gtk/filedlg.cpp:89 ../src/gtk/filepicker.cpp:255
+#, fuzzy, c-format
+msgid "Changing current directory to \"%s\" failed"
+msgstr "\"%s\" निर्देशिका का निर्माण करने में असफ़ल।"
+
+#: ../src/gtk/font.cpp:548
+msgid ""
+"Using private fonts is not supported on this system: Pango library is too "
+"old, 1.38 or later required."
+msgstr ""
+
+#: ../src/gtk/font.cpp:558
+#, fuzzy
+msgid "Failed to create font configuration object."
+msgstr "उपयोगकर्ता संरचना फ़ाइल को अपडेट करने में असफ़ल।"
+
+#: ../src/gtk/font.cpp:568
+#, fuzzy, c-format
+msgid "Failed to add custom font \"%s\"."
+msgstr "%d आकॄति को '%s' फ़ाइल से लोड करने में असफ़ल।"
+
+#: ../src/gtk/font.cpp:576
+#, fuzzy
+msgid "Failed to register font configuration using private fonts."
+msgstr "उपयोगकर्ता संरचना फ़ाइल को अपडेट करने में असफ़ल।"
+
+#: ../src/gtk/glcanvas.cpp:117 ../src/gtk/glcanvas.cpp:132
+#, fuzzy
+msgid "Fatal Error"
+msgstr "घातक त्रुटि"
+
+#: ../src/gtk/glcanvas.cpp:117
+msgid ""
+"This program wasn't compiled with EGL support required under Wayland, "
+"either\n"
+"install EGL libraries and rebuild or run it under X11 backend by setting\n"
+"environment variable GDK_BACKEND=x11 before starting your program."
+msgstr ""
+
+#: ../src/gtk/glcanvas.cpp:132
+msgid ""
+"wxGLCanvas is only supported on Wayland and X11 currently.  You may be able "
+"to\n"
+"work around this by setting environment variable GDK_BACKEND=x11 before\n"
+"starting your program."
+msgstr ""
+
+#: ../src/gtk/mdi.cpp:433
+msgid "MDI child"
+msgstr "एमडीआई चाइल्ड"
+
+#: ../src/gtk/power.cpp:188
+#, fuzzy, c-format
+msgid "Failed to open D-Bus connection to the login manager: %s"
+msgstr "'%s' सर्वर से '%s' विषय पर कनेक्शन जोड़ने में असफ़ल"
+
+#: ../src/gtk/power.cpp:214
+#, fuzzy
+msgid "wxWidgets application"
+msgstr "चयन"
+
+#: ../src/gtk/power.cpp:226
+msgid "Application needs to keep running"
+msgstr ""
+
+#: ../src/gtk/power.cpp:233
+msgid "Clean up before suspend"
+msgstr ""
+
+#: ../src/gtk/power.cpp:259
+#, fuzzy, c-format
+msgid "Failed to inhibit sleep: %s"
+msgstr "डायल-अप कनेक्शन को समाप्त करने में असफ़ल: %s"
+
+#: ../src/gtk/power.cpp:265
+msgid "Unexpected response to D-Bus \"Inhibit\" request."
+msgstr ""
+
+#: ../src/gtk/print.cpp:218
+#, fuzzy
+msgid "Custom size"
+msgstr "फ़ॉन्ट आकार"
+
+#: ../src/gtk/print.cpp:752
+#, fuzzy, c-format
+msgid "Error while printing: %s"
+msgstr "कॄपया प्रतीक्षा करें जबतक कि प्रिंटींग हो रही है\n"
+
+#: ../src/gtk/print.cpp:816
+msgid "Page Setup"
+msgstr "पॄष्ट स्थापना"
+
+#: ../src/gtk/webview_webkit.cpp:932
+msgid "Retrieving JavaScript script output is not supported with WebKit v1"
+msgstr ""
+
+#: ../src/gtk/webview_webkit2.cpp:1098
+msgid ""
+"Setting proxy is not supported by WebKit, at least version 2.16 is required."
+msgstr ""
+
+#: ../src/gtk/webview_webkit2.cpp:1104
+msgid "This program was compiled without support for setting WebKit proxy."
+msgstr ""
+
+#: ../src/gtk/window.cpp:6289
+msgid ""
+"GTK+ installed on this machine is too old to support screen compositing, "
+"please install GTK+ 2.12 or later."
+msgstr ""
+
+#: ../src/gtk/window.cpp:6307
+msgid ""
+"Compositing not supported by this system, please enable it in your Window "
+"Manager."
+msgstr ""
+
+#: ../src/gtk/window.cpp:6318
+msgid ""
+"This program was compiled with a too old version of GTK+, please rebuild "
+"with GTK+ 2.12 or newer."
+msgstr ""
+
+#: ../src/html/chm.cpp:138
+#, c-format
+msgid "Failed to open CHM archive '%s'."
+msgstr "'%s' सीएचएम लेखागार को खोलने में असफ़ल।"
+
+#: ../src/html/chm.cpp:270
+#, c-format
+msgid "Could not extract %s into %s: %s"
+msgstr "%s का %s में निष्कर्षण नहीं किया जा सका: %s"
+
+#: ../src/html/chm.cpp:324
+msgid "no error"
+msgstr "कोई त्रुटि नहीं"
+
+#: ../src/html/chm.cpp:326
+msgid "bad arguments to library function"
+msgstr "लायबरी फ़लन को निकॄष्ट आरग्य़ूमेन्ट"
+
+#: ../src/html/chm.cpp:328
+msgid "error opening file"
+msgstr "फ़ाइल खोलने में त्रुटि"
+
+#: ../src/html/chm.cpp:330
+msgid "read error"
+msgstr "पठन त्रुटि"
+
+#: ../src/html/chm.cpp:332
+msgid "write error"
+msgstr "लेखन त्रुटि"
+
+#: ../src/html/chm.cpp:334
+msgid "seek error"
+msgstr "खोज त्रुटि"
+
+#: ../src/html/chm.cpp:338
+msgid "bad signature"
+msgstr "खराब हस्ताक्षर"
+
+#: ../src/html/chm.cpp:340
+msgid "error in data format"
+msgstr "डाटा प्रारूप में त्रुटि"
+
+#: ../src/html/chm.cpp:342
+msgid "checksum error"
+msgstr "चेकसम त्रुटि"
+
+#: ../src/html/chm.cpp:344
+msgid "compression error"
+msgstr "संकुचन त्रुटि"
+
+#: ../src/html/chm.cpp:346
+msgid "decompression error"
+msgstr "फ़ैलाव त्रुटि"
+
+#: ../src/html/chm.cpp:437
+#, c-format
+msgid "Could not locate file '%s'."
+msgstr "'%s' फ़ाइल का स्थान नहीं खोजा जा सका।"
+
+#: ../src/html/chm.cpp:711
+#, c-format
+msgid "Could not create temporary file '%s'"
+msgstr "'%s' अस्थायी फ़ाइल का निर्माण नहीं हो सका"
+
+#: ../src/html/chm.cpp:718
+#, c-format
+msgid "Extraction of '%s' into '%s' failed."
+msgstr "'%s' का निष्कर्षण '%s' में असफ़ल रहा।"
+
+#: ../src/html/chm.cpp:806 ../src/html/chm.cpp:863
+msgid "CHM handler currently supports only local files!"
+msgstr "सीएचएम हैन्डलर वर्तमान में सिर्फ़ स्थानीय फ़ाइलों को ही समर्थन देता है!"
+
+#: ../src/html/chm.cpp:827
+msgid "Link contained '//', converted to absolute link."
+msgstr "कड़ी में '//' शामिल है, निरपेक्ष कड़ी में बदल दिया गया।"
+
+#: ../src/html/helpctrl.cpp:59
+#, c-format
+msgid "Help: %s"
+msgstr "सहायता: %s"
+
+#: ../src/html/helpctrl.cpp:155
+#, c-format
+msgid "Adding book %s"
+msgstr "%s बुक को जोड़ा जा रहा है"
+
+#: ../src/html/helpdata.cpp:295
+#, c-format
+msgid "Cannot open contents file: %s"
+msgstr "विषयवस्तु फ़ाइल को नहीं खोला जा सका: %s"
+
+#: ../src/html/helpdata.cpp:309
+#, c-format
+msgid "Cannot open index file: %s"
+msgstr "इंडेक्स फ़ाइल को खोला नहीं जा सका: %s"
+
+#: ../src/html/helpdata.cpp:643
+msgid "noname"
+msgstr "कोईनामनहीं"
+
+#: ../src/html/helpdata.cpp:652
+#, c-format
+msgid "Cannot open HTML help book: %s"
+msgstr "एचटीएमएल सहायता प्रलेख को नहीं खोला जा सका: %s"
+
+#: ../src/html/helpwnd.cpp:315
+msgid "Displays help as you browse the books on the left."
+msgstr "सहायता दिखाएँ जब आप सरसरी नजर से बायें में किताबें देखे।"
+
+#: ../src/html/helpwnd.cpp:411 ../src/html/helpwnd.cpp:1100
+#: ../src/html/helpwnd.cpp:1735
+msgid "(bookmarks)"
+msgstr "(बुकमार्क)"
+
+#: ../src/html/helpwnd.cpp:424
+msgid "Add current page to bookmarks"
+msgstr "वर्तमान पृष्ट को बुकमार्कों में जोड़ें"
+
+#: ../src/html/helpwnd.cpp:425
+msgid "Remove current page from bookmarks"
+msgstr "बुकमार्कों से वर्तमान पृष्ट को हटाएँ"
+
+#: ../src/html/helpwnd.cpp:470
+msgid "Contents"
+msgstr "विषय-वस्तु"
+
+#: ../src/html/helpwnd.cpp:485
+msgid "Find"
+msgstr "खोज"
+
+#: ../src/html/helpwnd.cpp:487
+msgid "Show all"
+msgstr "सभी को दिखाएँ"
+
+#: ../src/html/helpwnd.cpp:497
+msgid ""
+"Display all index items that contain given substring. Search is case "
+"insensitive."
+msgstr ""
+"सभी इंडेक्स आयट्मों को दिखाएँ जिनमें दी गयी उपश्रेणी शामिल हो।खोज छोटा-बड़ा संवेदी है।"
+
+#: ../src/html/helpwnd.cpp:498
+msgid "Show all items in index"
+msgstr "इंडेक्स में सभी आयट्मों को दिखाएँ"
+
+#: ../src/html/helpwnd.cpp:528
+msgid "Case sensitive"
+msgstr "छोटा-बड़ा संवेदी"
+
+#: ../src/html/helpwnd.cpp:529
+msgid "Whole words only"
+msgstr "सिर्फ़ पूर्ण शब्द "
+
+#: ../src/html/helpwnd.cpp:532
+#, fuzzy
+msgid ""
+"Search contents of help book(s) for all occurrences of the text you typed "
+"above"
+msgstr ""
+"सहायक पुस्तक(पुस्तकों) के विषयवस्तु में आपके द्वारा बताया हुआ उपरोक्त पाठ  जितनी बार आया "
+"हो खोजें "
+
+#: ../src/html/helpwnd.cpp:653
+msgid "Show/hide navigation panel"
+msgstr "नैवीगेशन पैनल को दिखाएँ/छुपाएँ"
+
+#: ../src/html/helpwnd.cpp:655
+msgid "Go back"
+msgstr "पीछे जाएँ"
+
+#: ../src/html/helpwnd.cpp:656
+msgid "Go forward"
+msgstr "आगे जाएँ"
+
+#: ../src/html/helpwnd.cpp:658
+msgid "Go one level up in document hierarchy"
+msgstr "प्रलेख पदानुक्रम में एक स्तर ऊपर जाएँ"
+
+#: ../src/html/helpwnd.cpp:666 ../src/html/helpwnd.cpp:1547
+msgid "Open HTML document"
+msgstr "एचटीएमएल प्रलेख को खोलें"
+
+#: ../src/html/helpwnd.cpp:670
+msgid "Print this page"
+msgstr "इस पृष्ट को मुद्रित करें"
+
+#: ../src/html/helpwnd.cpp:674
+msgid "Display options dialog"
+msgstr "विकल्पों का संवाद दिखाएँ"
+
+#: ../src/html/helpwnd.cpp:795
+msgid "Please choose the page to display:"
+msgstr "कॄपया एक विद्यमान फ़ाइल का चयन करें:"
+
+#: ../src/html/helpwnd.cpp:796
+msgid "Help Topics"
+msgstr "सहायता विषयवस्तु"
+
+#: ../src/html/helpwnd.cpp:852
+msgid "Searching..."
+msgstr "खोजा जा रहा है..."
+
+#: ../src/html/helpwnd.cpp:853
+msgid "No matching page found yet"
+msgstr "कोई मिलता-जुलता पृष्ट अभी तक नहीं मिला"
+
+#: ../src/html/helpwnd.cpp:870
+#, c-format
+msgid "Found %i matches"
+msgstr "%i मेल मिलें"
+
+#: ../src/html/helpwnd.cpp:958
+msgid "(Help)"
+msgstr "(सहायता)"
+
+#: ../src/html/helpwnd.cpp:1026
+#, fuzzy, c-format
+msgid "%d of %lu"
+msgstr "%i का %i"
+
+#: ../src/html/helpwnd.cpp:1028
+#, fuzzy, c-format
+msgid "%lu of %lu"
+msgstr "%i का %i"
+
+#: ../src/html/helpwnd.cpp:1047
+msgid "Search in all books"
+msgstr "सभी पुस्तकों में खोजें"
+
+#: ../src/html/helpwnd.cpp:1193
+msgid "Help Browser Options"
+msgstr "सहायता ब्राउजर के विकल्प"
+
+#: ../src/html/helpwnd.cpp:1198
+msgid "Normal font:"
+msgstr "सामान्य फ़ॉन्ट: "
+
+#: ../src/html/helpwnd.cpp:1199
+msgid "Fixed font:"
+msgstr "नियत फ़ॉन्ट:"
+
+#: ../src/html/helpwnd.cpp:1200
+msgid "Font size:"
+msgstr "फ़ॉन्ट आकार:"
+
+#: ../src/html/helpwnd.cpp:1245
+msgid "font size"
+msgstr "फ़ॉन्ट आकार"
+
+#: ../src/html/helpwnd.cpp:1256
+msgid "Normal face<br>and <u>underlined</u>. "
+msgstr "सामान्य फ़ेस<br>और <u>रेखांकित</u>। "
+
+#: ../src/html/helpwnd.cpp:1257
+msgid "<i>Italic face.</i> "
+msgstr "<i>इटैलिक फ़ेस।</i> "
+
+#: ../src/html/helpwnd.cpp:1258
+msgid "<b>Bold face.</b> "
+msgstr "<b>गहरा फ़ेस।</b> "
+
+#: ../src/html/helpwnd.cpp:1259
+msgid "<b><i>Bold italic face.</i></b><br>"
+msgstr "<b><i>गहरा इटैलिक फ़ेस।</i></b><br>"
+
+#: ../src/html/helpwnd.cpp:1262
+msgid "Fixed size face.<br> <b>bold</b> <i>italic</i> "
+msgstr "नियत आकार फ़ेस<br> <b>गहरा</b> <i>इटैलिक</i> "
+
+#: ../src/html/helpwnd.cpp:1263
+msgid "<b><i>bold italic <u>underlined</u></i></b><br>"
+msgstr "<b><i>गहरा इटैलिक <u>रेखांकित</u></i></b><br>"
+
+#: ../src/html/helpwnd.cpp:1524
+msgid "Help Printing"
+msgstr "सहायता मुद्रण"
+
+#: ../src/html/helpwnd.cpp:1527
+msgid "Cannot print empty page."
+msgstr "खाली पृष्ट को मुद्रित नहीं किया जा सकता है।"
+
+#: ../src/html/helpwnd.cpp:1540
+msgid "HTML files (*.html;*.htm)|*.html;*.htm|"
+msgstr "एचटीएमएल फ़ाइलें (*.html;*.htm)|*.html;*.htm|"
+
+#: ../src/html/helpwnd.cpp:1541
+msgid "Help books (*.htb)|*.htb|Help books (*.zip)|*.zip|"
+msgstr "सहायता पुस्तकें (*.htb)|*.htb|सहायता पुस्तकें (*.zip)|*.zip|"
+
+#: ../src/html/helpwnd.cpp:1542
+msgid "HTML Help Project (*.hhp)|*.hhp|"
+msgstr "एचटीएमएल सहायता परियोजना (*.hhp)|*.hhp|"
+
+#: ../src/html/helpwnd.cpp:1544
+msgid "Compressed HTML Help file (*.chm)|*.chm|"
+msgstr "संकुचित एचटीएमएल सहायता फ़ाइल (*.chm)|*.chm|"
+
+#: ../src/html/helpwnd.cpp:1671
+#, fuzzy, c-format
+msgid "%i of %u"
+msgstr "%i का %i"
+
+#: ../src/html/helpwnd.cpp:1709
+#, fuzzy, c-format
+msgid "%u of %u"
+msgstr "%i का %i"
+
+#: ../src/html/htmlfilt.cpp:134
+#, c-format
+msgid "Cannot open HTML document: %s"
+msgstr "एचटीएमएल प्रलेख को नहीं खोला जा सका: %s"
+
+#: ../src/html/htmlwin.cpp:599
+msgid "Connecting..."
+msgstr "जुड़ा जा रहा है..."
+
+#: ../src/html/htmlwin.cpp:616
+#, c-format
+msgid "Unable to open requested HTML document: %s"
+msgstr "निवेदित एचटीएमएल प्रलेख को खोलने में असमर्थ: %s"
+
+#: ../src/html/htmlwin.cpp:630
+msgid "Loading : "
+msgstr "लोड किया जा रहा है : "
+
+#: ../src/html/htmlwin.cpp:673
+msgid "Done"
+msgstr "किया गया"
+
+#: ../src/html/htmlwin.cpp:723
+#, c-format
+msgid "HTML anchor %s does not exist."
+msgstr "%s एचटीएमएल एंकर विद्यमान नहीं है।"
+
+#: ../src/html/htmlwin.cpp:1057
+#, c-format
+msgid "Copied to clipboard:\"%s\""
+msgstr "क्लिपबोर्ड में प्रतिलिपि बनायी गयी:\"%s\""
+
+#: ../src/html/htmprint.cpp:269
+msgid ""
+"This document doesn't fit on the page horizontally and will be truncated "
+"when it is printed."
+msgstr ""
+
+#: ../src/html/htmprint.cpp:285
+#, c-format
+msgid ""
+"The document \"%s\" doesn't fit on the page horizontally and will be "
+"truncated if printed.\n"
+"\n"
+"Would you like to proceed with printing it nevertheless?"
+msgstr ""
+
+#: ../src/html/htmprint.cpp:296
+msgid ""
+"If possible, try changing the layout parameters to make the printout more "
+"narrow."
+msgstr ""
+
+#: ../src/html/htmprint.cpp:445
+msgid ": file does not exist!"
+msgstr ": फ़ाइल विद्यमान नहीं है! "
+
+#. TRANSLATORS: %s may be a document title.
+#: ../src/html/htmprint.cpp:717
+#, fuzzy, c-format
+msgid "%s Preview"
+msgstr " पूर्वालोकन"
+
+#: ../src/html/htmprint.cpp:755 ../src/richtext/richtextprint.cpp:618
+msgid ""
+"There was a problem during page setup: you may need to set a default printer."
+msgstr ""
+"पॄष्ट स्थापना के दौरान एक समस्या थी: आपको एक डिफ़ाल्ट प्रिंटर को स्थापित करने की "
+"आवश्यकता है।"
+
+#: ../src/msw/clipbrd.cpp:80
+msgid "Failed to open the clipboard."
+msgstr "क्लिपबोर्ड को खोलने में असफ़ल।"
+
+#: ../src/msw/clipbrd.cpp:101
+msgid "Failed to close the clipboard."
+msgstr "क्लिपबोर्ड को बन्द करने में असफ़ल।"
+
+#: ../src/msw/clipbrd.cpp:113
+msgid "Failed to empty the clipboard."
+msgstr "क्लिपबोर्ड को खाली करने में असफ़ल।"
+
+#: ../src/msw/clipbrd.cpp:284
+msgid "Failed to put data on the clipboard"
+msgstr "क्लिपबोर्ड पर डाटा डालने में असफ़ल"
+
+#: ../src/msw/clipbrd.cpp:326
+msgid "Failed to get data from the clipboard"
+msgstr "क्लिपबोर्ड से डाटा प्राप्त करने में असफ़ल"
+
+#: ../src/msw/clipbrd.cpp:363
+msgid "Failed to retrieve the supported clipboard formats"
+msgstr "मैट्स के लिए समर्थित क्लिपबोर्ड को पुनःप्राप्त करने में असफ़ल"
+
+#: ../src/msw/colordlg.cpp:228
+#, fuzzy, c-format
+msgid "Colour selection dialog failed with error %0lx."
+msgstr "'%s' निर्देश का निष्पादन त्रुटि के साथ असफ़ल रहा: %ul"
+
+#: ../src/msw/cursor.cpp:141
+msgid "Failed to create cursor."
+msgstr "कर्सर का निर्माण करने में असफ़ल।"
+
+#: ../src/msw/dde.cpp:279
+#, c-format
+msgid "Failed to register DDE server '%s'"
+msgstr "'%s' डीडीई सर्वर को पंजीकॄत करने में असफ़ल"
+
+#: ../src/msw/dde.cpp:300
+#, c-format
+msgid "Failed to unregister DDE server '%s'"
+msgstr "'%s' डीडीई सर्वर को अपंजीकॄत करने में असफ़ल"
+
+#: ../src/msw/dde.cpp:428
+#, c-format
+msgid "Failed to create connection to server '%s' on topic '%s'"
+msgstr "'%s' सर्वर से '%s' विषय पर कनेक्शन जोड़ने में असफ़ल"
+
+#: ../src/msw/dde.cpp:655
+msgid "DDE poke request failed"
+msgstr "डीडीई पोक निवेदन असफ़ल रहा"
+
+#: ../src/msw/dde.cpp:674
+msgid "Failed to establish an advise loop with DDE server"
+msgstr "डीडीई सर्वर के साथ एक परामर्श लूप को स्थापित करने में असफ़ल"
+
+#: ../src/msw/dde.cpp:693
+msgid "Failed to terminate the advise loop with DDE server"
+msgstr "डीडीई सर्वर के साथ परामर्श लूप को समाप्त करने में असफ़ल"
+
+#: ../src/msw/dde.cpp:768
+msgid "Failed to send DDE advise notification"
+msgstr "डीडीई परामर्श घोषणा को प्रेषित करने में असफ़ल"
+
+#: ../src/msw/dde.cpp:1085
+msgid "Failed to create DDE string"
+msgstr "डीडीई श्रेणी का निर्माण करने में असफ़ल"
+
+#: ../src/msw/dde.cpp:1131
+msgid "no DDE error."
+msgstr "कोई डीडीई नहीं त्रुटि।"
+
+#: ../src/msw/dde.cpp:1135
+msgid "a request for a synchronous advise transaction has timed out."
+msgstr "एक तुल्यकालिक परामर्श कार्यसंपादन हेतु एक निवेदन की समय-सीमा समाप्त हो चुकी है।"
+
+#: ../src/msw/dde.cpp:1138
+msgid "the response to the transaction caused the DDE_FBUSY bit to be set."
+msgstr "इस कार्य संपादन को दिये हुए उत्तर ने DDE_FBUSY बिट् को स्थापित कर दिया।"
+
+#: ../src/msw/dde.cpp:1141
+msgid "a request for a synchronous data transaction has timed out."
+msgstr "एक तुल्यकालिक डाटा कार्यसंपादन हेतु एक निवेदन की समय-सीमा समाप्त हो चुकी है।"
+
+#: ../src/msw/dde.cpp:1144
+msgid ""
+"a DDEML function was called without first calling the DdeInitialize "
+"function,\n"
+"or an invalid instance identifier\n"
+"was passed to a DDEML function."
+msgstr ""
+"एक डीडीईएमएल संक्रिया को बिना डीडीईआरम्भीकरण संक्रिया को पुकारे हुएपुकारा गया है,\n"
+"या फ़िर एक डीडीईएमएल संक्रिया को एक अवैध दॄष्टांत आइडेन्टीफ़ायरदिया गया है।"
+
+#: ../src/msw/dde.cpp:1147
+msgid ""
+"an application initialized as APPCLASS_MONITOR has\n"
+"attempted to perform a DDE transaction,\n"
+"or an application initialized as APPCMD_CLIENTONLY has \n"
+"attempted to perform server transactions."
+msgstr ""
+"एक कार्यक्रम जिसका आरम्भीकरण APPCLASS_MONITOR की भांति किया गया था, \n"
+"ने एक डीडीई कार्यसंपादन का प्रयास किया,\n"
+"या एक कार्यक्रम जिसका आरम्भीकरण APPCMD_CLIENTONLY की भांति किया गया था, \n"
+"सर्वर कार्यसंपादनों को करने का प्रयास कर चुका है।"
+
+#: ../src/msw/dde.cpp:1150
+msgid "a request for a synchronous execute transaction has timed out."
+msgstr "एक तुल्यकालिक निष्पादन कार्यसंपादन हेतु एक निवेदन की समय-सीमा समाप्त हो चुकी है।"
+
+#: ../src/msw/dde.cpp:1153
+msgid "a parameter failed to be validated by the DDEML."
+msgstr "डीडीईएमएल द्वारा एक पैरामीटर का सत्यापन करना असफ़ल रहा।"
+
+#: ../src/msw/dde.cpp:1156
+msgid "a DDEML application has created a prolonged race condition."
+msgstr "एक डीडीईएमएल कार्यक्रम ने एक बहुत लंबी रेस दशा का निर्माण कर दिया है।"
+
+#: ../src/msw/dde.cpp:1159
+msgid "a memory allocation failed."
+msgstr "एक स्मृति आवंटन असफ़ल रहा।"
+
+#: ../src/msw/dde.cpp:1162
+msgid "a client's attempt to establish a conversation has failed."
+msgstr "एक ग्राहक का एक संवाद स्थापित करने का प्रयास असफ़ल रहा।"
+
+#: ../src/msw/dde.cpp:1165
+msgid "a transaction failed."
+msgstr "एक कार्यसंपादन असफ़ल रहा।"
+
+#: ../src/msw/dde.cpp:1168
+msgid "a request for a synchronous poke transaction has timed out."
+msgstr "एक तुल्यकालिक पोक कार्यसंपादन हेतु एक निवेदन की समय-सीमा समाप्त हो चुकी है।"
+
+#: ../src/msw/dde.cpp:1171
+msgid "an internal call to the PostMessage function has failed. "
+msgstr "PostMessage चलन को एक आंतरिक कॉल असफ़ल रही। "
+
+#: ../src/msw/dde.cpp:1174
+msgid "reentrancy problem."
+msgstr "पुनःअन्दर आने की समस्या।"
+
+#: ../src/msw/dde.cpp:1177
+msgid ""
+"a server-side transaction was attempted on a conversation\n"
+"that was terminated by the client, or the server\n"
+"terminated before completing a transaction."
+msgstr ""
+"एक संवाद पर जिसे या तो एक ग्राहक द्वारा अचानक समाप्त कर दिया गया था\n"
+"या फ़िर सर्वर ने एक कार्यसंपादन के खत्म होने के पहिले अचानक समाप्त कर दिया  था,\n"
+"एक सर्वर की तरफ़ से एक कार्यसंपादन का प्रयास किया गया था।"
+
+#: ../src/msw/dde.cpp:1180
+msgid "an internal error has occurred in the DDEML."
+msgstr "डीडीईएमएल में एक आंतरिक त्रुटि उत्पन्न हो गयी है।"
+
+#: ../src/msw/dde.cpp:1183
+msgid "a request to end an advise transaction has timed out."
+msgstr ""
+"एक परामर्श कार्यसंपादन को समाप्त करने हेतु एक निवेदन की समय-सीमा समाप्त हो चुकी है।"
+
+#: ../src/msw/dde.cpp:1186
+msgid ""
+"an invalid transaction identifier was passed to a DDEML function.\n"
+"Once the application has returned from an XTYP_XACT_COMPLETE callback,\n"
+"the transaction identifier for that callback is no longer valid."
+msgstr ""
+"एक डीडीईएमएल फ़लन को एक अमान्य कार्य संपादन पहचानकर्ता दिया गया था।\n"
+"जब यह कार्यक्रम एक XTYP_XACT_COMPLETE कॉलबैक से वापस आ चुका होगा,\n"
+"इस कॉलबैक के लिए यह कार्य संपादन पहचानकर्ता मान्य नहीं रह जायेगा।"
+
+#: ../src/msw/dde.cpp:1189
+#, c-format
+msgid "Unknown DDE error %08x"
+msgstr "अज्ञात डीडीई त्रुटि %08x"
+
+#: ../src/msw/dialup.cpp:343
+msgid ""
+"Dial up functions are unavailable because the remote access service (RAS) is "
+"not installed on this machine. Please install it."
+msgstr ""
+"डायल-अप क्रियाऐं अनुपलब्ध है क्योंकि इस मशीन पर सुदूर पहुँच सेवा (आरऐएस)संसाधित नहीं है। "
+"कॄपया इसे संसाधित करें।"
+
+#: ../src/msw/dialup.cpp:402
+#, fuzzy, c-format
+msgid ""
+"The version of remote access service (RAS) installed on this machine is too "
+"old, please upgrade (the following required function is missing: %s)."
+msgstr ""
+"इस मशीन पर संसाधित सुदूर पहुँच सेवा (आरऐएस) का यह संस्मरण अति प्राचीन है, कृपया इसे "
+"अपग्रेड करें(निम्न आवश्यक चलन विलुप्त है:  %s)।"
+
+#: ../src/msw/dialup.cpp:437
+msgid "Failed to retrieve text of RAS error message"
+msgstr "आरऐएस त्रुटि संदेश के पाठ को पुनःप्राप्त करने में असफ़ल"
+
+#: ../src/msw/dialup.cpp:440
+#, c-format
+msgid "unknown error (error code %08x)."
+msgstr "अज्ञात त्रुटि (त्रुटि कूट %08x)।"
+
+#: ../src/msw/dialup.cpp:492
+#, c-format
+msgid "Cannot find active dialup connection: %s"
+msgstr "सक्रिय डायल-अप कनेक्शन को खोजा नहीं जा सका: %s"
+
+#: ../src/msw/dialup.cpp:513
+msgid "Several active dialup connections found, choosing one randomly."
+msgstr "अनेकों सक्रिय डायल-अप कनेक्श मिलें, बेतरतीब से एक का चयन किया जा रहा है।"
+
+#: ../src/msw/dialup.cpp:598 ../src/msw/dialup.cpp:832
+#, c-format
+msgid "Failed to establish dialup connection: %s"
+msgstr "डायल-अप कनेक्शन को स्थापित करने में असफ़ल: %s"
+
+#: ../src/msw/dialup.cpp:664
+#, c-format
+msgid "Failed to get ISP names: %s"
+msgstr "आईएसपी नामों को प्राप्त करने में असफ़ल: %s"
+
+#: ../src/msw/dialup.cpp:712
+msgid "Failed to connect: no ISP to dial."
+msgstr "कनेक्ट करने में असफ़ल: डायल करने के लिए कोई आईएसपी नहीं।"
+
+#: ../src/msw/dialup.cpp:732
+msgid "Choose ISP to dial"
+msgstr "डायल करने के लिए आईएसपी का चयन करें"
+
+#: ../src/msw/dialup.cpp:733
+msgid "Please choose which ISP do you want to connect to"
+msgstr "कॄपया उस आईएसपी का चयन करें जिससे आप जुड़ना चाहते है"
+
+#: ../src/msw/dialup.cpp:766
+msgid "Failed to connect: missing username/password."
+msgstr "कनेक्ट करने में असफ़ल: विलुप्त उपयोगकर्तानाम/कूटशब्द।"
+
+#: ../src/msw/dialup.cpp:796
+msgid "Cannot find the location of address book file"
+msgstr "पता पुस्तिका फ़ाइल के स्थान को नहीं खोजा जा सका"
+
+#: ../src/msw/dialup.cpp:827
+#, fuzzy, c-format
+msgid "Failed to initiate dialup connection: %s"
+msgstr "डायल-अप कनेक्शन को समाप्त करने में असफ़ल: %s"
+
+#: ../src/msw/dialup.cpp:897
+msgid "Cannot hang up - no active dialup connection."
+msgstr "संबंध-विच्छेद नहीं किया जा सका - कोई सक्रिय डायल-अप कनेक्शन नहीं।"
+
+#: ../src/msw/dialup.cpp:907
+#, c-format
+msgid "Failed to terminate the dialup connection: %s"
+msgstr "डायल-अप कनेक्शन को समाप्त करने में असफ़ल: %s"
+
+#: ../src/msw/dib.cpp:313
+#, c-format
+msgid "Failed to save the bitmap image to file \"%s\"."
+msgstr "बिट्मैप आकॄति को \"%s\" फ़ाइल पर सुरक्षित करने में असफ़ल।"
+
+#: ../src/msw/dib.cpp:543
+#, fuzzy, c-format
+msgid "Failed to allocate %luKb of memory for bitmap data."
+msgstr "बिट्मैप डाटा के लिए %lu केबी स्मृति का आवंटन करने में असफ़ल।"
+
+#: ../src/msw/dir.cpp:241
+#, c-format
+msgid "Cannot enumerate files in directory '%s'"
+msgstr "'%s' निर्देशिका में फ़ाइलों की परिगणना नहीं की जा सकती है"
+
+#: ../src/msw/dirdlg.cpp:368
+#, fuzzy
+msgid "Couldn't obtain folder name"
+msgstr "एक समय-सचेतक का निर्माण नहीं किया जा सका"
+
+#: ../src/msw/dlmsw.cpp:163
+#, fuzzy, c-format
+msgid "(error %d: %s)"
+msgstr "(त्रुटि %ld: %s)"
+
+#: ../src/msw/dragimag.cpp:143 ../src/msw/dragimag.cpp:178
+#: ../src/msw/imaglist.cpp:309 ../src/msw/imaglist.cpp:331
+msgid "Couldn't add an image to the image list."
+msgstr "आकॄतियों की सूची में एक आकॄति को जोड़ा नहीं जा सका।"
+
+#: ../src/msw/enhmeta.cpp:94
+#, fuzzy, c-format
+msgid "Failed to load metafile from file \"%s\"."
+msgstr "%d आकॄति को '%s' फ़ाइल से लोड करने में असफ़ल।"
+
+#: ../src/msw/fdrepdlg.cpp:412
+#, c-format
+msgid "Failed to create the standard find/replace dialog (error code %d)"
+msgstr "मानक खोज/बदलाव संवाद का निर्माण करने में असफ़ल (त्रुटि कूट %d)"
+
+#: ../src/msw/filedlg.cpp:1241
+msgid "Access to the file system is not allowed from secure desktop."
+msgstr ""
+
+#: ../src/msw/filedlg.cpp:1242
+msgid "Security warning"
+msgstr ""
+
+#: ../src/msw/filedlg.cpp:1533
+#, c-format
+msgid "File dialog failed with error code %0lx."
+msgstr ""
+
+#: ../src/msw/font.cpp:1120
+#, fuzzy, c-format
+msgid "Font file \"%s\" couldn't be loaded"
+msgstr "फ़ाइल को लोड नहीं किया जा सका।"
+
+#: ../src/msw/fontdlg.cpp:220
+#, c-format
+msgid "Common dialog failed with error code %0lx."
+msgstr ""
+
+#: ../src/msw/fswatcher.cpp:67
+#, fuzzy
+msgid "Ungraceful worker thread termination"
+msgstr "थ्रेड समाप्ति की प्रतीक्षा नहीं की जा सकती है"
+
+#: ../src/msw/fswatcher.cpp:81
+#, fuzzy
+msgid "Unable to create IOCP worker thread"
+msgstr "एमडीआई मूल खाके का निर्माण करने में असफ़ल।"
+
+#: ../src/msw/fswatcher.cpp:88
+msgid "Unable to start IOCP worker thread"
+msgstr ""
+
+#: ../src/msw/fswatcher.cpp:140
+msgid "Monitoring individual files for changes is not supported currently."
+msgstr ""
+
+#: ../src/msw/fswatcher.cpp:165
+#, fuzzy, c-format
+msgid "Unable to set up watch for '%s'"
+msgstr "'%s' फ़ाइल को छूने में असफ़ल"
+
+#: ../src/msw/fswatcher.cpp:466
+#, c-format
+msgid "Can't monitor non-existent directory \"%s\" for changes."
+msgstr ""
+
+#: ../src/msw/glcanvas.cpp:577 ../src/unix/glx11.cpp:507
+msgid "OpenGL 3.0 or later is not supported by the OpenGL driver."
+msgstr ""
+
+#: ../src/msw/glcanvas.cpp:601 ../src/osx/glcanvas_osx.cpp:395
+#: ../src/unix/glegl.cpp:304 ../src/unix/glx11.cpp:553
+#, fuzzy
+msgid "Couldn't create OpenGL context"
+msgstr "एक समय-सचेतक का निर्माण नहीं किया जा सका"
+
+#: ../src/msw/glcanvas.cpp:1294
+msgid "Failed to initialize OpenGL"
+msgstr "ओपनजीएल का आरम्भीकरण करने में असफ़ल।"
+
+#: ../src/msw/graphicsd2d.cpp:607
+msgid "Could not register custom DirectWrite font loader."
+msgstr ""
+
+#: ../src/msw/helpchm.cpp:48
+msgid ""
+"MS HTML Help functions are unavailable because the MS HTML Help library is "
+"not installed on this machine. Please install it."
+msgstr ""
+"एमएस एचटीएमएल सहायता क्रियाऐं अनुपलब्ध है क्योंकि एमएस एचटीएमएल सहायता लायबरी इस "
+"मशीन परसंसाधित नहीं है। कॄपया इसे संसाधित करें।"
+
+#: ../src/msw/helpchm.cpp:55
+msgid "Failed to initialize MS HTML Help."
+msgstr "एमएस एचटीएमएल सहायता का आरम्भीकरण करने में असफ़ल।"
+
+#: ../src/msw/iniconf.cpp:458
+#, c-format
+msgid "Can't delete the INI file '%s'"
+msgstr " '%s' आईएनआई फ़ाइल को हटाया नहीं जा सकता है"
+
+#: ../src/msw/listctrl.cpp:995
+#, c-format
+msgid "Couldn't retrieve information about list control item %d."
+msgstr "%d सूची नियंत्रण आयट्म के बारे में सूचना प्राप्त नहीं की जा सकी।"
+
+#: ../src/msw/mdi.cpp:170 ../src/qt/mdi.cpp:253
+msgid "&Cascade"
+msgstr "कास्केड करें (&C)"
+
+#: ../src/msw/mdi.cpp:171
+msgid "Tile &Horizontally"
+msgstr "क्षैतिज रूप से टाइल (&H)"
+
+#: ../src/msw/mdi.cpp:172
+msgid "Tile &Vertically"
+msgstr "खड़े रूप से टाइल (&V)"
+
+#: ../src/msw/mdi.cpp:174
+msgid "&Arrange Icons"
+msgstr "आइकॉनों को व्यवस्थित करें (&A)"
+
+#: ../src/msw/mdi.cpp:621
+msgid "Failed to create MDI parent frame."
+msgstr "एमडीआई मूल खाके का निर्माण करने में असफ़ल।"
+
+#: ../src/msw/mimetype.cpp:234
+#, c-format
+msgid "Failed to create registry entry for '%s' files."
+msgstr "'%s' फ़ाइलों के लिए रजिस्ट्री प्रविष्टी का निर्माण करने में असफ़ल।"
+
+#: ../src/msw/ole/automtn.cpp:495
+#, fuzzy, c-format
+msgid "Failed to find CLSID of \"%s\""
+msgstr "'%s' को %s के लिए खोलने में असफ़ल"
+
+#: ../src/msw/ole/automtn.cpp:512
+#, fuzzy, c-format
+msgid "Failed to create an instance of \"%s\""
+msgstr "\"%s\" निर्देशिका का निर्माण करने में असफ़ल।"
+
+#: ../src/msw/ole/automtn.cpp:552
+#, fuzzy, c-format
+msgid "Cannot get an active instance of \"%s\""
+msgstr "सक्रिय डायल-अप कनेक्शन को खोजा नहीं जा सका: %s"
+
+#: ../src/msw/ole/automtn.cpp:564
+#, fuzzy, c-format
+msgid "Failed to get OLE automation interface for \"%s\""
+msgstr "\"%s\" निर्देशिका का निर्माण करने में असफ़ल।"
+
+#: ../src/msw/ole/automtn.cpp:621
+msgid "Unknown name or named argument."
+msgstr ""
+
+#: ../src/msw/ole/automtn.cpp:625
+msgid "Incorrect number of arguments."
+msgstr ""
+
+#: ../src/msw/ole/automtn.cpp:637
+#, fuzzy
+msgid "Unknown exception"
+msgstr "अज्ञात विकल्प '%s'"
+
+#: ../src/msw/ole/automtn.cpp:642
+msgid "Method or property not found."
+msgstr ""
+
+#: ../src/msw/ole/automtn.cpp:646
+msgid "Overflow while coercing argument values."
+msgstr ""
+
+#: ../src/msw/ole/automtn.cpp:650
+msgid "Object implementation does not support named arguments."
+msgstr ""
+
+#: ../src/msw/ole/automtn.cpp:654
+msgid "The locale ID is unknown."
+msgstr ""
+
+#: ../src/msw/ole/automtn.cpp:658
+msgid "Missing a required parameter."
+msgstr ""
+
+#: ../src/msw/ole/automtn.cpp:662
+#, fuzzy, c-format
+msgid "Argument %u not found."
+msgstr "सहायता निर्देशिका \"%s\" नहीं मिली।"
+
+#: ../src/msw/ole/automtn.cpp:666
+#, c-format
+msgid "Type mismatch in argument %u."
+msgstr ""
+
+#: ../src/msw/ole/automtn.cpp:670
+msgid "The system cannot find the file specified."
+msgstr ""
+
+#: ../src/msw/ole/automtn.cpp:674
+#, fuzzy
+msgid "Class not registered."
+msgstr "थ्रेड का निर्माण नहीं किया जा सकता है"
+
+#: ../src/msw/ole/automtn.cpp:678
+#, fuzzy, c-format
+msgid "Unknown error %08x"
+msgstr "अज्ञात डीडीई त्रुटि %08x"
+
+#: ../src/msw/ole/automtn.cpp:682
+#, c-format
+msgid "OLE Automation error in %s: %s"
+msgstr ""
+
+#: ../src/msw/ole/dataobj.cpp:385
+#, c-format
+msgid "Couldn't register clipboard format '%s'."
+msgstr "'%s' क्लिपबोर्ड प्रारूप को पंजीकृत नहीं किया जा सका।"
+
+#: ../src/msw/ole/dataobj.cpp:402
+#, c-format
+msgid "The clipboard format '%d' doesn't exist."
+msgstr "क्लिपबोर्ड प्रारूप '%d' विद्यमान नहीं है।"
+
+#: ../src/msw/progdlg.cpp:1025
+msgid "Skip"
+msgstr "छोड़ दे"
+
+#: ../src/msw/registry.cpp:141
+#, fuzzy, c-format
+msgid "unknown (%lu)"
+msgstr "अज्ञात"
+
+#: ../src/msw/registry.cpp:409
+#, c-format
+msgid "Can't get info about registry key '%s'"
+msgstr "'%s' पंजीकरण कुँजी के बारे में सूचना प्राप्त नहीं की जा सकती है"
+
+#: ../src/msw/registry.cpp:445
+#, c-format
+msgid "Can't open registry key '%s'"
+msgstr "'%s' पंजीकरण कुँजी को खोला नहीं जा सकता है"
+
+#: ../src/msw/registry.cpp:478
+#, c-format
+msgid "Can't create registry key '%s'"
+msgstr "'%s' रजिस्ट्री कुँजी का निर्माण नहीं किया जा सकता है"
+
+#: ../src/msw/registry.cpp:497
+#, c-format
+msgid "Can't close registry key '%s'"
+msgstr "'%s' रजिस्ट्री कुँजी को बन्द नहीं किया जा सकता है"
+
+#: ../src/msw/registry.cpp:512
+#, c-format
+msgid "Registry value '%s' already exists."
+msgstr "'%s' रजिस्ट्री वैल्यू पहिले से विद्यमान है।"
+
+#: ../src/msw/registry.cpp:520
+#, c-format
+msgid "Failed to rename registry value '%s' to '%s'."
+msgstr "'%s' रजिस्ट्री वैल्यू को नाम बदल कर '%s' करने में असफ़ल।"
+
+#: ../src/msw/registry.cpp:575
+#, c-format
+msgid "Can't copy values of unsupported type %d."
+msgstr "%d असमर्थित प्रकार के मूल्यों की प्रतिलिपि नहीं बनायी जा सकती है।"
+
+#: ../src/msw/registry.cpp:586
+#, c-format
+msgid "Registry key '%s' does not exist, cannot rename it."
+msgstr "'%s' रजिस्ट्री कुँजी विद्यमान नहीं है, इसका नाम नहीं बदला जा सकता है।"
+
+#: ../src/msw/registry.cpp:617
+#, c-format
+msgid "Registry key '%s' already exists."
+msgstr "'%s' रजिस्ट्री कुँजी पहिले से विद्यमान है।"
+
+#: ../src/msw/registry.cpp:625
+#, c-format
+msgid "Failed to rename the registry key '%s' to '%s'."
+msgstr "'%s' रजिस्ट्री कुँजी को नाम बदल कर '%s' करने में असफ़ल।"
+
+#: ../src/msw/registry.cpp:670
+#, c-format
+msgid "Failed to copy the registry subkey '%s' to '%s'."
+msgstr "'%s' रजिस्ट्री कुँजी की प्रतिलिपि '%s' करने में असफ़ल।"
+
+#: ../src/msw/registry.cpp:683
+#, c-format
+msgid "Failed to copy registry value '%s'"
+msgstr "'%s' रजिस्ट्री वैल्यू की प्रतिलिपि बनाने में असफ़ल"
+
+#: ../src/msw/registry.cpp:692
+#, c-format
+msgid "Failed to copy the contents of registry key '%s' to '%s'."
+msgstr "'%s' रजिस्ट्री कुँजी के विषयवस्तुओं को प्रतिलिपि '%s' पर बनाने में असफ़ल।"
+
+#: ../src/msw/registry.cpp:718
+#, c-format
+msgid ""
+"Registry key '%s' is needed for normal system operation,\n"
+"deleting it will leave your system in unusable state:\n"
+"operation aborted."
+msgstr ""
+"सामान्य तंत्र संक्रिया के लिए, '%s' रजिस्ट्री कुँजी की आवश्यकता है,\n"
+"इसको हटाने से आपका तंत्र कार्य ना करने की अवस्था में रह जायेगा:\n"
+"संक्रिया को निरस्त किया गया।"
+
+#: ../src/msw/registry.cpp:754
+#, c-format
+msgid "Can't delete key '%s'"
+msgstr "'%s' कुँजी को हटाया नहीं जा सकता है"
+
+#: ../src/msw/registry.cpp:782
+#, c-format
+msgid "Can't delete value '%s' from key '%s'"
+msgstr "'%s' मूल्य को '%s' कुँजी से हटाया नहीं जा सकता है"
+
+#: ../src/msw/registry.cpp:855 ../src/msw/registry.cpp:887
+#: ../src/msw/registry.cpp:929 ../src/msw/registry.cpp:1000
+#, c-format
+msgid "Can't read value of key '%s'"
+msgstr "'%s' कुँजी के मूल्य को पढ़ा नहीं जा सकता है"
+
+#: ../src/msw/registry.cpp:873 ../src/msw/registry.cpp:915
+#: ../src/msw/registry.cpp:963 ../src/msw/registry.cpp:1106
+#, c-format
+msgid "Can't set value of '%s'"
+msgstr "'%s' के मूल्य की स्थापना नहीं की जा सकती है"
+
+#: ../src/msw/registry.cpp:894 ../src/msw/registry.cpp:943
+#, c-format
+msgid "Registry value \"%s\" is not numeric (but of type %s)"
+msgstr ""
+
+#: ../src/msw/registry.cpp:979
+#, c-format
+msgid "Registry value \"%s\" is not binary (but of type %s)"
+msgstr ""
+
+#: ../src/msw/registry.cpp:1028
+#, c-format
+msgid "Registry value \"%s\" is not text (but of type %s)"
+msgstr ""
+
+#: ../src/msw/registry.cpp:1089
+#, c-format
+msgid "Can't read value of '%s'"
+msgstr "'%s' के मूल्य को पढ़ा नहीं जा सकता है"
+
+#: ../src/msw/registry.cpp:1157
+#, c-format
+msgid "Can't enumerate values of key '%s'"
+msgstr "'%s' कुँजी के मूल्यों की परिगणना नहीं की जा सकती है"
+
+#: ../src/msw/registry.cpp:1196
+#, c-format
+msgid "Can't enumerate subkeys of key '%s'"
+msgstr "'%s' कुँजी की उपकुँजियों की परिगणना नहीं की जा सकती है"
+
+#: ../src/msw/registry.cpp:1262
+#, c-format
+msgid ""
+"Exporting registry key: file \"%s\" already exists and won't be overwritten."
+msgstr ""
+
+#: ../src/msw/registry.cpp:1411
+#, c-format
+msgid "Can't export value of unsupported type %d."
+msgstr "%d असमर्थित प्रकार के मूल्यों की प्रतिलिपि नहीं बनायी जा सकती है।"
+
+#: ../src/msw/registry.cpp:1427
+#, c-format
+msgid "Ignoring value \"%s\" of the key \"%s\"."
+msgstr ""
+
+#: ../src/msw/textctrl.cpp:596
+msgid ""
+"Impossible to create a rich edit control, using simple text control instead. "
+"Please reinstall riched32.dll"
+msgstr ""
+"एक रिच ऐडीट कन्ट्रोल का निर्माण असम्भव है, इसके बज़ाय सामान्य पाठ कन्ट्रोल का उपयोग "
+"किया जा रहा है। कृपया riched32.dll को पुनः संसाधित करें"
+
+#: ../src/msw/thread.cpp:522 ../src/unix/threadpsx.cpp:850
+msgid "Cannot start thread: error writing TLS."
+msgstr "थ्रेड को आरम्भ नहीं किया जा सकता है: टीएलएस लेखन में त्रुटि"
+
+#: ../src/msw/thread.cpp:613
+msgid "Can't set thread priority"
+msgstr "थ्रेड की वरीयता की स्थापना नहीं की जा सकती है"
+
+#: ../src/msw/thread.cpp:649
+msgid "Can't create thread"
+msgstr "थ्रेड का निर्माण नहीं किया जा सकता है"
+
+#: ../src/msw/thread.cpp:668
+msgid "Couldn't terminate thread"
+msgstr "थ्रेड को समाप्त नहीं किया जा सका"
+
+#: ../src/msw/thread.cpp:799
+msgid "Cannot wait for thread termination"
+msgstr "थ्रेड समाप्ति की प्रतीक्षा नहीं की जा सकती है"
+
+#: ../src/msw/thread.cpp:873
+#, fuzzy, c-format
+msgid "Cannot suspend thread %lx"
+msgstr "%x थ्रेड को अधर में नहीं छोड़ा जा सकता है"
+
+#: ../src/msw/thread.cpp:903
+#, fuzzy, c-format
+msgid "Cannot resume thread %lx"
+msgstr "%x थ्रेड को समान-बिन्दु से पुनः आरम्भ नहीं किया जा सकता है"
+
+#: ../src/msw/thread.cpp:932
+msgid "Couldn't get the current thread pointer"
+msgstr "वर्तमान थ्रेड सूचक को प्राप्त नहीं किया जा सका"
+
+#: ../src/msw/thread.cpp:1333
+msgid ""
+"Thread module initialization failed: impossible to allocate index in thread "
+"local storage"
+msgstr "थ्रेड माड्यूल आरम्भीकरण असफ़ल रहा: स्थानीय थ्रेड भंडार में इंडेक्स का आवंटन असम्भव"
+
+#: ../src/msw/thread.cpp:1345
+msgid ""
+"Thread module initialization failed: cannot store value in thread local "
+"storage"
+msgstr ""
+"थ्रेड माड्यूल आरम्भीकरण असफ़ल रहा: स्थानीय थ्रेड में मूल्य को सुरक्षित नहीं किया जा सका "
+
+#: ../src/msw/timer.cpp:133
+msgid "Couldn't create a timer"
+msgstr "एक समय-सचेतक का निर्माण नहीं किया जा सका"
+
+#: ../src/msw/utils.cpp:372
+msgid "can't find user's HOME, using current directory."
+msgstr ""
+"वर्तमान निर्देशिका का उपयोग करके, उपयोगकर्ता के गॄह (HOME) को पाया नहीं जा सकता है।"
+
+#: ../src/msw/utils.cpp:662
+#, c-format
+msgid "Failed to kill process %d"
+msgstr "%d प्रोसेस को खत्म करने में असफ़ल"
+
+#: ../src/msw/utils.cpp:986
+#, fuzzy, c-format
+msgid "Failed to load resource \"%s\"."
+msgstr "%d आकॄति को '%s' फ़ाइल से लोड करने में असफ़ल।"
+
+#: ../src/msw/utils.cpp:993
+#, fuzzy, c-format
+msgid "Failed to lock resource \"%s\"."
+msgstr "'%s' फ़ाइल को लॉक करने में असफ़ल"
+
+#. TRANSLATORS: MS Windows build number
+#: ../src/msw/utils.cpp:1209
+#, fuzzy, c-format
+msgid "build %lu"
+msgstr "विण्डो एक्स पी (निर्माण %lu"
+
+#: ../src/msw/utils.cpp:1218
+msgid ", 64-bit edition"
+msgstr ""
+
+#: ../src/msw/utilsexc.cpp:224
+msgid "Failed to create an anonymous pipe"
+msgstr "एक अज्ञात पाइप का निर्माण करने में असफ़ल"
+
+#: ../src/msw/utilsexc.cpp:697
+msgid "Failed to redirect the child process IO"
+msgstr "बाल प्रोसेस आईओ को दिशानिर्देश देने में असफ़ल"
+
+#: ../src/msw/utilsexc.cpp:870
+#, c-format
+msgid "Execution of command '%s' failed"
+msgstr "'%s' निर्देश का निष्पादन असफ़ल रहा"
+
+#: ../src/msw/volume.cpp:337
+msgid "Failed to load mpr.dll."
+msgstr "mpr.dll को लोड करने में असफ़ल।"
+
+#: ../src/msw/volume.cpp:506
+#, c-format
+msgid "Cannot read typename from '%s'!"
+msgstr "'%s' से टाइपनाम को पढ़ा नहीं जा सका!"
+
+#: ../src/msw/volume.cpp:615
+#, c-format
+msgid "Cannot load icon from '%s'."
+msgstr "'%s' से आइकॉन को लाया नहीं जा सकता है।"
+
+#: ../src/msw/webview_edge.cpp:285
+msgid "This program was compiled without support for setting Edge proxy."
+msgstr ""
+
+#: ../src/msw/webview_ie.cpp:1010
+msgid "Failed to find web view emulation level in the registry"
+msgstr ""
+
+#: ../src/msw/webview_ie.cpp:1019
+msgid "Failed to set web view to modern emulation level"
+msgstr ""
+
+#: ../src/msw/webview_ie.cpp:1027
+msgid "Failed to reset web view to standard emulation level"
+msgstr ""
+
+#: ../src/msw/webview_ie.cpp:1049
+msgid "Can't run JavaScript script without a valid HTML document"
+msgstr ""
+
+#: ../src/msw/webview_ie.cpp:1056
+#, fuzzy
+msgid "Can't get the JavaScript object"
+msgstr "थ्रेड की वरीयता की स्थापना नहीं की जा सकती है"
+
+#: ../src/msw/webview_ie.cpp:1070
+#, fuzzy
+msgid "failed to evaluate"
+msgstr "'%s' का निष्पादन करने में असफ़ल\n"
+
+#: ../src/osx/cocoa/filedlg.mm:412
+#, fuzzy
+msgid "File type:"
+msgstr "टेलीटाइप"
+
+#: ../src/osx/cocoa/menu.mm:242
+#, fuzzy
+msgctxt "macOS menu name"
+msgid "Window"
+msgstr "खिड़की (&W)"
+
+#: ../src/osx/cocoa/menu.mm:259
+#, fuzzy
+msgctxt "macOS menu name"
+msgid "Help"
+msgstr "सहायता"
+
+#: ../src/osx/cocoa/menu.mm:298
+#, fuzzy
+msgctxt "macOS menu item"
+msgid "Minimize"
+msgstr "छोटा करें (&n)"
+
+#: ../src/osx/cocoa/menu.mm:303
+#, fuzzy
+msgctxt "macOS menu item"
+msgid "Zoom"
+msgstr "बड़ा करें (&I)"
+
+#: ../src/osx/cocoa/menu.mm:309
+msgctxt "macOS menu item"
+msgid "Bring All to Front"
+msgstr ""
+
+#: ../src/osx/core/sound.cpp:143
+#, fuzzy, c-format
+msgid "Failed to load sound from \"%s\" (error %d)."
+msgstr "%d आकॄति को '%s' फ़ाइल से लोड करने में असफ़ल।"
+
+#: ../src/osx/fontutil.cpp:80
+#, fuzzy, c-format
+msgid "Font file \"%s\" doesn't exist."
+msgstr " %s फ़ाइल विद्यमान नहीं है।"
+
+#: ../src/osx/fontutil.cpp:88
+#, c-format
+msgid ""
+"Font file \"%s\" cannot be used as it is not inside the font directory "
+"\"%s\"."
+msgstr ""
+
+#: ../src/osx/menu_osx.cpp:496
+#, fuzzy, c-format
+msgctxt "macOS menu item"
+msgid "About %s"
+msgstr "के बारे में"
+
+#: ../src/osx/menu_osx.cpp:499
+#, fuzzy
+msgctxt "macOS menu item"
+msgid "About..."
+msgstr "के बारे में (&A)"
+
+#: ../src/osx/menu_osx.cpp:508
+#, fuzzy
+msgctxt "macOS menu item"
+msgid "Preferences..."
+msgstr "प्राथमिकता (&P)"
+
+#: ../src/osx/menu_osx.cpp:512
+msgctxt "macOS menu item"
+msgid "Services"
+msgstr ""
+
+#: ../src/osx/menu_osx.cpp:519
+#, fuzzy, c-format
+msgctxt "macOS menu item"
+msgid "Hide %s"
+msgstr "सहायता: %s"
+
+#: ../src/osx/menu_osx.cpp:522
+#, fuzzy
+msgctxt "macOS menu item"
+msgid "Hide Application"
+msgstr "चयन"
+
+#: ../src/osx/menu_osx.cpp:526
+msgctxt "macOS menu item"
+msgid "Hide Others"
+msgstr ""
+
+#: ../src/osx/menu_osx.cpp:528
+#, fuzzy
+msgctxt "macOS menu item"
+msgid "Show All"
+msgstr "सभी को दिखाएँ"
+
+#: ../src/osx/menu_osx.cpp:534
+#, fuzzy, c-format
+msgctxt "macOS menu item"
+msgid "Quit %s"
+msgstr "छोड़ दे (&Q)"
+
+#: ../src/osx/menu_osx.cpp:537
+#, fuzzy
+msgctxt "macOS menu item"
+msgid "Quit Application"
+msgstr "चयन"
+
+#: ../src/osx/webview_webkit.mm:444
+msgid "Printing is not supported by the system web control"
+msgstr ""
+
+#: ../src/osx/webview_webkit.mm:453
+msgid "Print operation could not be initialized"
+msgstr ""
+
+#. TRANSLATORS: Label of font point size
+#: ../src/propgrid/advprops.cpp:605
+#, fuzzy
+msgid "Point Size"
+msgstr "फ़ॉन्ट आकार (&P):"
+
+#. TRANSLATORS: Label of font face name
+#: ../src/propgrid/advprops.cpp:615
+#, fuzzy
+msgid "Face Name"
+msgstr "नयानाम"
+
+#. TRANSLATORS: Label of font style
+#: ../src/propgrid/advprops.cpp:623 ../src/richtext/richtextformatdlg.cpp:331
+msgid "Style"
+msgstr "शैली"
+
+#. TRANSLATORS: Label of font weight
+#: ../src/propgrid/advprops.cpp:628
+#, fuzzy
+msgid "Weight"
+msgstr "भार (&W):"
+
+#. TRANSLATORS: Label of underlined font
+#: ../src/propgrid/advprops.cpp:633 ../src/richtext/richtextfontpage.cpp:358
+msgid "Underlined"
+msgstr "रेखांकित"
+
+#. TRANSLATORS: Label of font family
+#: ../src/propgrid/advprops.cpp:637
+#, fuzzy
+msgid "Family"
+msgstr "फ़ॉन्ट वंश:"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:801
+msgid "AppWorkspace"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:802
+#, fuzzy
+msgid "ActiveBorder"
+msgstr "आधुनिक"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:803
+msgid "ActiveCaption"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:804
+msgid "ButtonFace"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:805
+msgid "ButtonHighlight"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:806
+msgid "ButtonShadow"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:807
+msgid "ButtonText"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:808
+msgid "CaptionText"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:809
+msgid "ControlDark"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:810
+msgid "ControlLight"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:812
+msgid "GrayText"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:813
+#, fuzzy
+msgid "Highlight"
+msgstr "हल्का"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:814
+#, fuzzy
+msgid "HighlightText"
+msgstr "पाठ को दायें पंक्तिबद्ध करें।"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:815
+#, fuzzy
+msgid "InactiveBorder"
+msgstr "आधुनिक"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:816
+msgid "InactiveCaption"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:817
+msgid "InactiveCaptionText"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:818
+msgid "Menu"
+msgstr "विकल्प सूची"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:819
+msgid "Scrollbar"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:820
+msgid "Tooltip"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:821
+msgid "TooltipText"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:822
+#, fuzzy
+msgid "Window"
+msgstr "खिड़की (&W)"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:823
+#, fuzzy
+msgid "WindowFrame"
+msgstr "खिड़की (&W)"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:824
+#, fuzzy
+msgid "WindowText"
+msgstr "खिड़की (&W)"
+
+#. TRANSLATORS: Custom colour choice entry
+#: ../src/propgrid/advprops.cpp:825 ../src/propgrid/advprops.cpp:1532
+#: ../src/propgrid/advprops.cpp:1576
+#, fuzzy
+msgid "Custom"
+msgstr "फ़ॉन्ट आकार"
+
+#: ../src/propgrid/advprops.cpp:1558
+msgid "Black"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1559
+msgid "Maroon"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1560
+msgid "Navy"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1561
+msgid "Purple"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1562
+msgid "Teal"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1563
+msgid "Gray"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1564
+msgid "Green"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1565
+msgid "Olive"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1566
+msgid "Brown"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1567
+msgid "Blue"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1568
+msgid "Fuchsia"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1569
+#, fuzzy
+msgid "Red"
+msgstr "पुनःकरें (&R)"
+
+#: ../src/propgrid/advprops.cpp:1570
+msgid "Orange"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1571
+msgid "Silver"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1572
+msgid "Lime"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1573
+msgid "Aqua"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1574
+msgid "Yellow"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1575
+msgid "White"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1718
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Default"
+msgstr "डिफ़ाल्ट"
+
+#: ../src/propgrid/advprops.cpp:1719
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Arrow"
+msgstr "कल"
+
+#: ../src/propgrid/advprops.cpp:1720
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Right Arrow"
+msgstr "दायें"
+
+#: ../src/propgrid/advprops.cpp:1721
+msgctxt "system cursor name"
+msgid "Blank"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1722
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Bullseye"
+msgstr "बुल्लेट शैली"
+
+#: ../src/propgrid/advprops.cpp:1723
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Character"
+msgstr "संप्रतीक कूट (&C):"
+
+#: ../src/propgrid/advprops.cpp:1724
+msgctxt "system cursor name"
+msgid "Cross"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1725
+msgctxt "system cursor name"
+msgid "Hand"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1726
+msgctxt "system cursor name"
+msgid "I-Beam"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1727
+msgctxt "system cursor name"
+msgid "Left Button"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1728
+msgctxt "system cursor name"
+msgid "Magnifier"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1729
+msgctxt "system cursor name"
+msgid "Middle Button"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1730
+msgctxt "system cursor name"
+msgid "No Entry"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1731
+msgctxt "system cursor name"
+msgid "Paint Brush"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1732
+msgctxt "system cursor name"
+msgid "Pencil"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1733
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Point Left"
+msgstr "फ़ॉन्ट आकार (&P):"
+
+#: ../src/propgrid/advprops.cpp:1734
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Point Right"
+msgstr "दायें पंक्तिबद्ध करें"
+
+#: ../src/propgrid/advprops.cpp:1735
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Question Arrow"
+msgstr "प्रश्न"
+
+#: ../src/propgrid/advprops.cpp:1736
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Right Button"
+msgstr "दायें"
+
+#: ../src/propgrid/advprops.cpp:1737
+msgctxt "system cursor name"
+msgid "Sizing NE-SW"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1738
+msgctxt "system cursor name"
+msgid "Sizing N-S"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1739
+msgctxt "system cursor name"
+msgid "Sizing NW-SE"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1740
+msgctxt "system cursor name"
+msgid "Sizing W-E"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1741
+msgctxt "system cursor name"
+msgid "Sizing"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1742
+msgctxt "system cursor name"
+msgid "Spraycan"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1743
+msgctxt "system cursor name"
+msgid "Wait"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1744
+msgctxt "system cursor name"
+msgid "Watch"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1745
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Wait Arrow"
+msgstr "दायें"
+
+#: ../src/propgrid/advprops.cpp:2109
+#, fuzzy
+msgid "Make a selection:"
+msgstr "चयन चिपकाएँ"
+
+#: ../src/propgrid/manager.cpp:394
+#, fuzzy
+msgid "Property"
+msgstr "गुणधर्म (&P)"
+
+#: ../src/propgrid/manager.cpp:395
+msgid "Value"
+msgstr ""
+
+#: ../src/propgrid/manager.cpp:1683
+msgid "Categorized Mode"
+msgstr ""
+
+#: ../src/propgrid/manager.cpp:1709
+msgid "Alphabetic Mode"
+msgstr ""
+
+#. TRANSLATORS: Name of Boolean false value
+#: ../src/propgrid/propgrid.cpp:230
+#, fuzzy
+msgid "False"
+msgstr "फ़ाइल"
+
+#. TRANSLATORS: Name of Boolean true value
+#: ../src/propgrid/propgrid.cpp:232
+msgid "True"
+msgstr ""
+
+#. TRANSLATORS: Text  displayed for unspecified value
+#: ../src/propgrid/propgrid.cpp:428
+msgid "Unspecified"
+msgstr ""
+
+#. TRANSLATORS: Caption of message box displaying any property error
+#: ../src/propgrid/propgrid.cpp:3145 ../src/propgrid/propgrid.cpp:3282
+#, fuzzy
+msgid "Property Error"
+msgstr "मुद्रण त्रुटि"
+
+#: ../src/propgrid/propgrid.cpp:3259
+msgid "You have entered invalid value. Press ESC to cancel editing."
+msgstr ""
+
+#: ../src/propgrid/propgrid.cpp:6608
+#, c-format
+msgid "Error in resource: %s"
+msgstr ""
+
+#: ../src/propgrid/propgridiface.cpp:377
+#, c-format
+msgid ""
+"Type operation \"%s\" failed: Property labeled \"%s\" is of type \"%s\", NOT "
+"\"%s\"."
+msgstr ""
+
+#: ../src/propgrid/props.cpp:159
+#, c-format
+msgid "Unknown base %d. Base 10 will be used."
+msgstr ""
+
+#: ../src/propgrid/props.cpp:324
+#, c-format
+msgid "Value must be %s or higher."
+msgstr ""
+
+#: ../src/propgrid/props.cpp:329 ../src/propgrid/props.cpp:356
+#, fuzzy, c-format
+msgid "Value must be between %s and %s."
+msgstr "%d से %d के मध्य में एक पृष्ट संख्या बताएँ:"
+
+#: ../src/propgrid/props.cpp:351
+#, c-format
+msgid "Value must be %s or less."
+msgstr ""
+
+#: ../src/propgrid/props.cpp:1058
+#, fuzzy, c-format
+msgid "Not %s"
+msgstr "टिप्पणी (&N)"
+
+#: ../src/propgrid/props.cpp:1770
+#, fuzzy
+msgid "Choose a directory:"
+msgstr "निर्देशिका का निर्माण करें"
+
+#: ../src/propgrid/props.cpp:2055
+#, fuzzy
+msgid "Choose a file"
+msgstr "फ़ॉन्ट का चयन करें"
+
+#: ../src/qt/mdi.cpp:254
+msgid "&Tile"
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:147
+#: ../src/richtext/richtextformatdlg.cpp:376
+#, fuzzy
+msgid "Background"
+msgstr "पृष्टभूमि रंग"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:159
+#, fuzzy
+msgid "Background &colour:"
+msgstr "पृष्टभूमि रंग"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:161
+#: ../src/richtext/richtextbackgroundpage.cpp:163
+#, fuzzy
+msgid "Enables a background colour."
+msgstr "पृष्टभूमि रंग"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:167
+#: ../src/richtext/richtextbackgroundpage.cpp:169
+#, fuzzy
+msgid "The background colour."
+msgstr "पृष्टभूमि रंग"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:178
+msgid "Shadow"
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:193
+msgid "Use &shadow"
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:195
+#: ../src/richtext/richtextbackgroundpage.cpp:197
+#, fuzzy
+msgid "Enables a shadow."
+msgstr "पृष्टभूमि रंग"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:211
+msgid "&Horizontal offset:"
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:218
+#: ../src/richtext/richtextbackgroundpage.cpp:220
+#, fuzzy
+msgid "The horizontal offset."
+msgstr "क्षैतिज रूप से टाइल (&H)"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:224
+#: ../src/richtext/richtextbackgroundpage.cpp:227
+#: ../src/richtext/richtextbackgroundpage.cpp:228
+#: ../src/richtext/richtextbackgroundpage.cpp:247
+#: ../src/richtext/richtextbackgroundpage.cpp:250
+#: ../src/richtext/richtextbackgroundpage.cpp:251
+#: ../src/richtext/richtextbackgroundpage.cpp:287
+#: ../src/richtext/richtextbackgroundpage.cpp:290
+#: ../src/richtext/richtextbackgroundpage.cpp:291
+#: ../src/richtext/richtextbackgroundpage.cpp:314
+#: ../src/richtext/richtextbackgroundpage.cpp:317
+#: ../src/richtext/richtextbackgroundpage.cpp:318
+#: ../src/richtext/richtextborderspage.cpp:252
+#: ../src/richtext/richtextborderspage.cpp:255
+#: ../src/richtext/richtextborderspage.cpp:256
+#: ../src/richtext/richtextborderspage.cpp:286
+#: ../src/richtext/richtextborderspage.cpp:289
+#: ../src/richtext/richtextborderspage.cpp:290
+#: ../src/richtext/richtextborderspage.cpp:320
+#: ../src/richtext/richtextborderspage.cpp:323
+#: ../src/richtext/richtextborderspage.cpp:324
+#: ../src/richtext/richtextborderspage.cpp:354
+#: ../src/richtext/richtextborderspage.cpp:357
+#: ../src/richtext/richtextborderspage.cpp:358
+#: ../src/richtext/richtextborderspage.cpp:420
+#: ../src/richtext/richtextborderspage.cpp:423
+#: ../src/richtext/richtextborderspage.cpp:424
+#: ../src/richtext/richtextborderspage.cpp:454
+#: ../src/richtext/richtextborderspage.cpp:457
+#: ../src/richtext/richtextborderspage.cpp:458
+#: ../src/richtext/richtextborderspage.cpp:488
+#: ../src/richtext/richtextborderspage.cpp:491
+#: ../src/richtext/richtextborderspage.cpp:492
+#: ../src/richtext/richtextborderspage.cpp:522
+#: ../src/richtext/richtextborderspage.cpp:525
+#: ../src/richtext/richtextborderspage.cpp:526
+#: ../src/richtext/richtextborderspage.cpp:590
+#: ../src/richtext/richtextborderspage.cpp:593
+#: ../src/richtext/richtextborderspage.cpp:594
+#: ../src/richtext/richtextfontpage.cpp:177
+#: ../src/richtext/richtextmarginspage.cpp:199
+#: ../src/richtext/richtextmarginspage.cpp:201
+#: ../src/richtext/richtextmarginspage.cpp:202
+#: ../src/richtext/richtextmarginspage.cpp:224
+#: ../src/richtext/richtextmarginspage.cpp:226
+#: ../src/richtext/richtextmarginspage.cpp:227
+#: ../src/richtext/richtextmarginspage.cpp:247
+#: ../src/richtext/richtextmarginspage.cpp:249
+#: ../src/richtext/richtextmarginspage.cpp:250
+#: ../src/richtext/richtextmarginspage.cpp:272
+#: ../src/richtext/richtextmarginspage.cpp:274
+#: ../src/richtext/richtextmarginspage.cpp:275
+#: ../src/richtext/richtextmarginspage.cpp:313
+#: ../src/richtext/richtextmarginspage.cpp:315
+#: ../src/richtext/richtextmarginspage.cpp:316
+#: ../src/richtext/richtextmarginspage.cpp:338
+#: ../src/richtext/richtextmarginspage.cpp:340
+#: ../src/richtext/richtextmarginspage.cpp:341
+#: ../src/richtext/richtextmarginspage.cpp:361
+#: ../src/richtext/richtextmarginspage.cpp:363
+#: ../src/richtext/richtextmarginspage.cpp:364
+#: ../src/richtext/richtextmarginspage.cpp:386
+#: ../src/richtext/richtextmarginspage.cpp:388
+#: ../src/richtext/richtextmarginspage.cpp:389
+#: ../src/richtext/richtextsizepage.cpp:337
+#: ../src/richtext/richtextsizepage.cpp:340
+#: ../src/richtext/richtextsizepage.cpp:341
+#: ../src/richtext/richtextsizepage.cpp:371
+#: ../src/richtext/richtextsizepage.cpp:374
+#: ../src/richtext/richtextsizepage.cpp:375
+#: ../src/richtext/richtextsizepage.cpp:398
+#: ../src/richtext/richtextsizepage.cpp:401
+#: ../src/richtext/richtextsizepage.cpp:402
+#: ../src/richtext/richtextsizepage.cpp:425
+#: ../src/richtext/richtextsizepage.cpp:428
+#: ../src/richtext/richtextsizepage.cpp:429
+#: ../src/richtext/richtextsizepage.cpp:452
+#: ../src/richtext/richtextsizepage.cpp:455
+#: ../src/richtext/richtextsizepage.cpp:456
+#: ../src/richtext/richtextsizepage.cpp:479
+#: ../src/richtext/richtextsizepage.cpp:482
+#: ../src/richtext/richtextsizepage.cpp:483
+#: ../src/richtext/richtextsizepage.cpp:553
+#: ../src/richtext/richtextsizepage.cpp:556
+#: ../src/richtext/richtextsizepage.cpp:557
+#: ../src/richtext/richtextsizepage.cpp:588
+#: ../src/richtext/richtextsizepage.cpp:591
+#: ../src/richtext/richtextsizepage.cpp:592
+#: ../src/richtext/richtextsizepage.cpp:623
+#: ../src/richtext/richtextsizepage.cpp:626
+#: ../src/richtext/richtextsizepage.cpp:627
+#: ../src/richtext/richtextsizepage.cpp:658
+#: ../src/richtext/richtextsizepage.cpp:661
+#: ../src/richtext/richtextsizepage.cpp:662
+msgid "px"
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:225
+#: ../src/richtext/richtextbackgroundpage.cpp:248
+#: ../src/richtext/richtextbackgroundpage.cpp:288
+#: ../src/richtext/richtextbackgroundpage.cpp:315
+#: ../src/richtext/richtextborderspage.cpp:253
+#: ../src/richtext/richtextborderspage.cpp:287
+#: ../src/richtext/richtextborderspage.cpp:321
+#: ../src/richtext/richtextborderspage.cpp:355
+#: ../src/richtext/richtextborderspage.cpp:421
+#: ../src/richtext/richtextborderspage.cpp:455
+#: ../src/richtext/richtextborderspage.cpp:489
+#: ../src/richtext/richtextborderspage.cpp:523
+#: ../src/richtext/richtextborderspage.cpp:591
+#: ../src/richtext/richtextmarginspage.cpp:200
+#: ../src/richtext/richtextmarginspage.cpp:225
+#: ../src/richtext/richtextmarginspage.cpp:248
+#: ../src/richtext/richtextmarginspage.cpp:273
+#: ../src/richtext/richtextmarginspage.cpp:314
+#: ../src/richtext/richtextmarginspage.cpp:339
+#: ../src/richtext/richtextmarginspage.cpp:362
+#: ../src/richtext/richtextmarginspage.cpp:387
+#: ../src/richtext/richtextsizepage.cpp:338
+#: ../src/richtext/richtextsizepage.cpp:372
+#: ../src/richtext/richtextsizepage.cpp:399
+#: ../src/richtext/richtextsizepage.cpp:426
+#: ../src/richtext/richtextsizepage.cpp:453
+#: ../src/richtext/richtextsizepage.cpp:480
+#: ../src/richtext/richtextsizepage.cpp:554
+#: ../src/richtext/richtextsizepage.cpp:589
+#: ../src/richtext/richtextsizepage.cpp:624
+#: ../src/richtext/richtextsizepage.cpp:659
+msgid "cm"
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:226
+#: ../src/richtext/richtextbackgroundpage.cpp:249
+#: ../src/richtext/richtextbackgroundpage.cpp:289
+#: ../src/richtext/richtextbackgroundpage.cpp:316
+#: ../src/richtext/richtextborderspage.cpp:254
+#: ../src/richtext/richtextborderspage.cpp:288
+#: ../src/richtext/richtextborderspage.cpp:322
+#: ../src/richtext/richtextborderspage.cpp:356
+#: ../src/richtext/richtextborderspage.cpp:422
+#: ../src/richtext/richtextborderspage.cpp:456
+#: ../src/richtext/richtextborderspage.cpp:490
+#: ../src/richtext/richtextborderspage.cpp:524
+#: ../src/richtext/richtextborderspage.cpp:592
+#: ../src/richtext/richtextfontpage.cpp:176
+#: ../src/richtext/richtextfontpage.cpp:179
+msgid "pt"
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:229
+#: ../src/richtext/richtextbackgroundpage.cpp:231
+#: ../src/richtext/richtextbackgroundpage.cpp:252
+#: ../src/richtext/richtextbackgroundpage.cpp:254
+#: ../src/richtext/richtextbackgroundpage.cpp:292
+#: ../src/richtext/richtextbackgroundpage.cpp:294
+#: ../src/richtext/richtextbackgroundpage.cpp:319
+#: ../src/richtext/richtextbackgroundpage.cpp:321
+#, fuzzy
+msgid "Units for this value."
+msgstr "थ्रेड समाप्ति की प्रतीक्षा नहीं की जा सकती है।"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:234
+#, fuzzy
+msgid "&Vertical offset:"
+msgstr "बुल्लेट सरेखण (&A):"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:241
+#: ../src/richtext/richtextbackgroundpage.cpp:243
+#, fuzzy
+msgid "The vertical offset."
+msgstr "अगले अनुच्छेद के लिए डिफ़ाल्ट शैली।"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:257
+#, fuzzy
+msgid "Shadow c&olour:"
+msgstr "रंग का चयन करें"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:259
+#: ../src/richtext/richtextbackgroundpage.cpp:261
+#, fuzzy
+msgid "Enables the shadow colour."
+msgstr "पृष्टभूमि रंग"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:265
+#: ../src/richtext/richtextbackgroundpage.cpp:267
+#, fuzzy
+msgid "The shadow colour."
+msgstr "फ़ॉन्ट का रंग"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:270
+msgid "Sh&adow spread:"
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:272
+#: ../src/richtext/richtextbackgroundpage.cpp:274
+msgid "Enables the shadow spread."
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:281
+#: ../src/richtext/richtextbackgroundpage.cpp:283
+msgid "The shadow spread."
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:297
+msgid "&Blur distance:"
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:299
+#: ../src/richtext/richtextbackgroundpage.cpp:301
+#, fuzzy
+msgid "Enables the blur distance."
+msgstr "मुद्रण को आरम्भ नहीं किया जा सका।"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:308
+#: ../src/richtext/richtextbackgroundpage.cpp:310
+msgid "The shadow blur distance."
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:324
+msgid "Opaci&ty:"
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:326
+#: ../src/richtext/richtextbackgroundpage.cpp:328
+msgid "Enables the shadow opacity."
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:335
+#: ../src/richtext/richtextbackgroundpage.cpp:337
+msgid "The shadow opacity."
+msgstr ""
+
+#. TRANSLATORS: Rich text page units (percentage)
+#: ../src/richtext/richtextbackgroundpage.cpp:340
+#: ../src/richtext/richtextsizepage.cpp:339
+#: ../src/richtext/richtextsizepage.cpp:373
+#: ../src/richtext/richtextsizepage.cpp:400
+#: ../src/richtext/richtextsizepage.cpp:427
+#: ../src/richtext/richtextsizepage.cpp:454
+#: ../src/richtext/richtextsizepage.cpp:481
+#: ../src/richtext/richtextsizepage.cpp:555
+#: ../src/richtext/richtextsizepage.cpp:590
+#: ../src/richtext/richtextsizepage.cpp:625
+#: ../src/richtext/richtextsizepage.cpp:660
+msgid "%"
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:229
+#: ../src/richtext/richtextborderspage.cpp:387
+#, fuzzy
+msgid "Border"
+msgstr "आधुनिक"
+
+#: ../src/richtext/richtextborderspage.cpp:242
+#: ../src/richtext/richtextborderspage.cpp:410
+#: ../src/richtext/richtextindentspage.cpp:194
+#: ../src/richtext/richtextliststylepage.cpp:384
+#: ../src/richtext/richtextmarginspage.cpp:185
+#: ../src/richtext/richtextmarginspage.cpp:299
+#: ../src/richtext/richtextsizepage.cpp:531
+#: ../src/richtext/richtextsizepage.cpp:538
+msgid "&Left:"
+msgstr "बायें: (&L)"
+
+#: ../src/richtext/richtextborderspage.cpp:257
+#: ../src/richtext/richtextborderspage.cpp:259
+msgid "Units for the left border width."
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:266
+#: ../src/richtext/richtextborderspage.cpp:268
+#: ../src/richtext/richtextborderspage.cpp:300
+#: ../src/richtext/richtextborderspage.cpp:302
+#: ../src/richtext/richtextborderspage.cpp:334
+#: ../src/richtext/richtextborderspage.cpp:336
+#: ../src/richtext/richtextborderspage.cpp:368
+#: ../src/richtext/richtextborderspage.cpp:370
+#: ../src/richtext/richtextborderspage.cpp:434
+#: ../src/richtext/richtextborderspage.cpp:436
+#: ../src/richtext/richtextborderspage.cpp:468
+#: ../src/richtext/richtextborderspage.cpp:470
+#: ../src/richtext/richtextborderspage.cpp:502
+#: ../src/richtext/richtextborderspage.cpp:504
+#: ../src/richtext/richtextborderspage.cpp:536
+#: ../src/richtext/richtextborderspage.cpp:538
+#, fuzzy
+msgid "The border line style."
+msgstr "फ़ॉन्ट की शैली"
+
+#: ../src/richtext/richtextborderspage.cpp:276
+#: ../src/richtext/richtextborderspage.cpp:444
+#: ../src/richtext/richtextindentspage.cpp:212
+#: ../src/richtext/richtextliststylepage.cpp:402
+#: ../src/richtext/richtextmarginspage.cpp:210
+#: ../src/richtext/richtextmarginspage.cpp:324
+#: ../src/richtext/richtextsizepage.cpp:601
+#: ../src/richtext/richtextsizepage.cpp:608
+msgid "&Right:"
+msgstr "दायें (&R):"
+
+#: ../src/richtext/richtextborderspage.cpp:291
+#: ../src/richtext/richtextborderspage.cpp:293
+msgid "Units for the right border width."
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:310
+#: ../src/richtext/richtextborderspage.cpp:478
+#: ../src/richtext/richtextmarginspage.cpp:233
+#: ../src/richtext/richtextmarginspage.cpp:347
+#: ../src/richtext/richtextsizepage.cpp:566
+#: ../src/richtext/richtextsizepage.cpp:573
+#, fuzzy
+msgid "&Top:"
+msgstr "प्राप्तकर्ता:"
+
+#: ../src/richtext/richtextborderspage.cpp:325
+#: ../src/richtext/richtextborderspage.cpp:327
+msgid "Units for the top border width."
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:344
+#: ../src/richtext/richtextborderspage.cpp:512
+#: ../src/richtext/richtextmarginspage.cpp:258
+#: ../src/richtext/richtextmarginspage.cpp:372
+#: ../src/richtext/richtextsizepage.cpp:636
+#: ../src/richtext/richtextsizepage.cpp:643
+msgid "&Bottom:"
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:359
+#: ../src/richtext/richtextborderspage.cpp:361
+msgid "Units for the bottom border width."
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:380
+#: ../src/richtext/richtextborderspage.cpp:548
+msgid "&Synchronize values"
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:382
+#: ../src/richtext/richtextborderspage.cpp:384
+#: ../src/richtext/richtextborderspage.cpp:550
+#: ../src/richtext/richtextborderspage.cpp:552
+msgid "Check to edit all borders simultaneously."
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:397
+#: ../src/richtext/richtextborderspage.cpp:555
+#, fuzzy
+msgid "Outline"
+msgstr "रूपरेखा स्तर (&O):"
+
+#: ../src/richtext/richtextborderspage.cpp:425
+#: ../src/richtext/richtextborderspage.cpp:427
+msgid "Units for the left outline width."
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:459
+#: ../src/richtext/richtextborderspage.cpp:461
+msgid "Units for the right outline width."
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:493
+#: ../src/richtext/richtextborderspage.cpp:495
+msgid "Units for the top outline width."
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:527
+#: ../src/richtext/richtextborderspage.cpp:529
+msgid "Units for the bottom outline width."
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:565
+#: ../src/richtext/richtextborderspage.cpp:600
+msgid "Corner"
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:574
+msgid "Corner &radius:"
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:576
+#: ../src/richtext/richtextborderspage.cpp:578
+msgid "An optional corner radius for adding rounded corners."
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:584
+#: ../src/richtext/richtextborderspage.cpp:586
+msgid "The value of the corner radius."
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:595
+#: ../src/richtext/richtextborderspage.cpp:597
+#, fuzzy
+msgid "Units for the corner radius."
+msgstr "थ्रेड समाप्ति की प्रतीक्षा नहीं की जा सकती है।"
+
+#: ../src/richtext/richtextborderspage.cpp:609
+#: ../src/richtext/richtextsizepage.cpp:247
+#: ../src/richtext/richtextsizepage.cpp:251
+#, fuzzy
+msgid "None"
+msgstr "(कुछ नहीं)"
+
+#: ../src/richtext/richtextborderspage.cpp:610
+#, fuzzy
+msgid "Solid"
+msgstr "गहरा"
+
+#: ../src/richtext/richtextborderspage.cpp:611
+#, fuzzy
+msgid "Dotted"
+msgstr "किया गया"
+
+#: ../src/richtext/richtextborderspage.cpp:612
+msgid "Dashed"
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:613
+#, fuzzy
+msgid "Double"
+msgstr "किया गया"
+
+#: ../src/richtext/richtextborderspage.cpp:614
+msgid "Groove"
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:615
+#, fuzzy
+msgid "Ridge"
+msgstr "दायें"
+
+#: ../src/richtext/richtextborderspage.cpp:616
+#, fuzzy
+msgid "Inset"
+msgstr "डाले"
+
+#: ../src/richtext/richtextborderspage.cpp:617
+msgid "Outset"
+msgstr ""
+
+#: ../src/richtext/richtextbuffer.cpp:3518
+msgid "Change Style"
+msgstr "शैली बदले"
+
+#: ../src/richtext/richtextbuffer.cpp:3701
+#, fuzzy
+msgid "Change Object Style"
+msgstr "सूची शैली बदले"
+
+#: ../src/richtext/richtextbuffer.cpp:3974
+#: ../src/richtext/richtextbuffer.cpp:8174
+#, fuzzy
+msgid "Change Properties"
+msgstr "गुणधर्म (&P)"
+
+#: ../src/richtext/richtextbuffer.cpp:4346
+msgid "Change List Style"
+msgstr "सूची शैली बदले"
+
+#: ../src/richtext/richtextbuffer.cpp:4519
+msgid "Renumber List"
+msgstr "सूची पुनः संख्यांकन करें"
+
+#: ../src/richtext/richtextbuffer.cpp:7867
+#: ../src/richtext/richtextbuffer.cpp:7897
+#: ../src/richtext/richtextbuffer.cpp:7939
+#: ../src/richtext/richtextctrl.cpp:1279 ../src/richtext/richtextctrl.cpp:1473
+msgid "Insert Text"
+msgstr "पाठ डाले"
+
+#: ../src/richtext/richtextbuffer.cpp:8023
+#: ../src/richtext/richtextbuffer.cpp:8979
+msgid "Insert Image"
+msgstr "आकृति डाले"
+
+#: ../src/richtext/richtextbuffer.cpp:8070
+#, fuzzy
+msgid "Insert Object"
+msgstr "पाठ डाले"
+
+#: ../src/richtext/richtextbuffer.cpp:8112
+#, fuzzy
+msgid "Insert Field"
+msgstr "पाठ डाले"
+
+#: ../src/richtext/richtextbuffer.cpp:8410
+msgid "Too many EndStyle calls!"
+msgstr ""
+
+#: ../src/richtext/richtextbuffer.cpp:8785
+msgid "files"
+msgstr "फ़ाइलें"
+
+#: ../src/richtext/richtextbuffer.cpp:9380
+#, fuzzy
+msgid "standard/circle"
+msgstr "मानक"
+
+#: ../src/richtext/richtextbuffer.cpp:9381
+msgid "standard/circle-outline"
+msgstr ""
+
+#: ../src/richtext/richtextbuffer.cpp:9382
+#, fuzzy
+msgid "standard/square"
+msgstr "मानक"
+
+#: ../src/richtext/richtextbuffer.cpp:9383
+msgid "standard/diamond"
+msgstr ""
+
+#: ../src/richtext/richtextbuffer.cpp:9384
+msgid "standard/triangle"
+msgstr ""
+
+#: ../src/richtext/richtextbuffer.cpp:9423
+#, fuzzy
+msgid "Box Properties"
+msgstr "गुणधर्म (&P)"
+
+#: ../src/richtext/richtextbuffer.cpp:10006
+msgid "Multiple Cell Properties"
+msgstr ""
+
+#: ../src/richtext/richtextbuffer.cpp:10008
+#, fuzzy
+msgid "Cell Properties"
+msgstr "गुणधर्म (&P)"
+
+#: ../src/richtext/richtextbuffer.cpp:11256
+#, fuzzy
+msgid "Set Cell Style"
+msgstr "शैली हटाएँ"
+
+#: ../src/richtext/richtextbuffer.cpp:11330
+#, fuzzy
+msgid "Delete Row"
+msgstr "मिटाएँं"
+
+#: ../src/richtext/richtextbuffer.cpp:11380
+#, fuzzy
+msgid "Delete Column"
+msgstr "चयन मिटाएँ"
+
+#: ../src/richtext/richtextbuffer.cpp:11431
+msgid "Add Row"
+msgstr ""
+
+#: ../src/richtext/richtextbuffer.cpp:11494
+msgid "Add Column"
+msgstr ""
+
+#: ../src/richtext/richtextbuffer.cpp:11537
+#, fuzzy
+msgid "Table Properties"
+msgstr "गुणधर्म (&P)"
+
+#: ../src/richtext/richtextbuffer.cpp:12899
+#, fuzzy
+msgid "Picture Properties"
+msgstr "गुणधर्म (&P)"
+
+#: ../src/richtext/richtextbuffer.cpp:13169
+#: ../src/richtext/richtextbuffer.cpp:13279
+msgid "image"
+msgstr "आकृति"
+
+#: ../src/richtext/richtextbulletspage.cpp:145
+#: ../src/richtext/richtextliststylepage.cpp:209
+msgid "&Bullet style:"
+msgstr "बुल्लेट शैली (&B):"
+
+#: ../src/richtext/richtextbulletspage.cpp:150
+#: ../src/richtext/richtextbulletspage.cpp:152
+#: ../src/richtext/richtextliststylepage.cpp:214
+#: ../src/richtext/richtextliststylepage.cpp:216
+msgid "The available bullet styles."
+msgstr "उपलब्ध बुल्लेट शैलियाँ।"
+
+#: ../src/richtext/richtextbulletspage.cpp:158
+#: ../src/richtext/richtextliststylepage.cpp:221
+msgid "Peri&od"
+msgstr "पूर्णविराम (&O)"
+
+#: ../src/richtext/richtextbulletspage.cpp:160
+#: ../src/richtext/richtextbulletspage.cpp:162
+#: ../src/richtext/richtextliststylepage.cpp:223
+#: ../src/richtext/richtextliststylepage.cpp:225
+msgid "Check to add a period after the bullet."
+msgstr ""
+
+#. TRANSLATORS: Bullet point in parentheses option
+#: ../src/richtext/richtextbulletspage.cpp:167
+#: ../src/richtext/richtextliststylepage.cpp:230
+msgid "(*)"
+msgstr "(*)"
+
+#: ../src/richtext/richtextbulletspage.cpp:169
+#: ../src/richtext/richtextbulletspage.cpp:171
+#: ../src/richtext/richtextliststylepage.cpp:232
+#: ../src/richtext/richtextliststylepage.cpp:234
+msgid "Check to enclose the bullet in parentheses."
+msgstr ""
+
+#. TRANSLATORS: Right parenthesis bullet point option
+#: ../src/richtext/richtextbulletspage.cpp:176
+#: ../src/richtext/richtextliststylepage.cpp:239
+msgid "*)"
+msgstr "*)"
+
+#: ../src/richtext/richtextbulletspage.cpp:178
+#: ../src/richtext/richtextbulletspage.cpp:180
+#: ../src/richtext/richtextliststylepage.cpp:241
+#: ../src/richtext/richtextliststylepage.cpp:243
+msgid "Check to add a right parenthesis."
+msgstr ""
+
+#: ../src/richtext/richtextbulletspage.cpp:185
+#: ../src/richtext/richtextliststylepage.cpp:248
+msgid "Bullet &Alignment:"
+msgstr "बुल्लेट सरेखण (&A):"
+
+#: ../src/richtext/richtextbulletspage.cpp:190
+#: ../src/richtext/richtextliststylepage.cpp:253
+msgid "Centre"
+msgstr "केन्द्रित करें"
+
+#: ../src/richtext/richtextbulletspage.cpp:194
+#: ../src/richtext/richtextbulletspage.cpp:196
+#: ../src/richtext/richtextbulletspage.cpp:217
+#: ../src/richtext/richtextbulletspage.cpp:219
+#: ../src/richtext/richtextliststylepage.cpp:257
+#: ../src/richtext/richtextliststylepage.cpp:259
+#: ../src/richtext/richtextliststylepage.cpp:278
+#: ../src/richtext/richtextliststylepage.cpp:280
+msgid "The bullet character."
+msgstr "बुल्लेट संप्रतीक।"
+
+#: ../src/richtext/richtextbulletspage.cpp:212
+#: ../src/richtext/richtextliststylepage.cpp:271
+msgid "&Symbol:"
+msgstr "चिह्न: (&S)"
+
+#: ../src/richtext/richtextbulletspage.cpp:222
+#: ../src/richtext/richtextliststylepage.cpp:283
+msgid "Ch&oose..."
+msgstr "चयन करें (&O)..."
+
+#: ../src/richtext/richtextbulletspage.cpp:223
+#: ../src/richtext/richtextbulletspage.cpp:225
+#: ../src/richtext/richtextliststylepage.cpp:284
+#: ../src/richtext/richtextliststylepage.cpp:286
+msgid "Click to browse for a symbol."
+msgstr ""
+
+#: ../src/richtext/richtextbulletspage.cpp:230
+#: ../src/richtext/richtextliststylepage.cpp:291
+msgid "Symbol &font:"
+msgstr "चिह्न फ़ॉन्ट: (&F)"
+
+#: ../src/richtext/richtextbulletspage.cpp:235
+#: ../src/richtext/richtextbulletspage.cpp:237
+#: ../src/richtext/richtextliststylepage.cpp:297
+msgid "Available fonts."
+msgstr "उपलब्ध फ़ॉन्ट"
+
+#: ../src/richtext/richtextbulletspage.cpp:242
+#: ../src/richtext/richtextliststylepage.cpp:302
+msgid "S&tandard bullet name:"
+msgstr "मानक बुल्लेट नाम (&T):"
+
+#: ../src/richtext/richtextbulletspage.cpp:247
+#: ../src/richtext/richtextbulletspage.cpp:249
+#: ../src/richtext/richtextliststylepage.cpp:307
+#: ../src/richtext/richtextliststylepage.cpp:309
+msgid "A standard bullet name."
+msgstr "एक मानक बुल्लेट का नाम।"
+
+#: ../src/richtext/richtextbulletspage.cpp:254
+msgid "&Number:"
+msgstr "अंक (&N):"
+
+#: ../src/richtext/richtextbulletspage.cpp:258
+#: ../src/richtext/richtextbulletspage.cpp:260
+msgid "The list item number."
+msgstr "सूची की पद संख्या।"
+
+#: ../src/richtext/richtextbulletspage.cpp:266
+#: ../src/richtext/richtextbulletspage.cpp:268
+#: ../src/richtext/richtextliststylepage.cpp:475
+#: ../src/richtext/richtextliststylepage.cpp:477
+msgid "Shows a preview of the bullet settings."
+msgstr ""
+
+#: ../src/richtext/richtextbulletspage.cpp:276
+#: ../src/richtext/richtextliststylepage.cpp:484
+msgid "(None)"
+msgstr "(कुछ नहीं)"
+
+#: ../src/richtext/richtextbulletspage.cpp:277
+#: ../src/richtext/richtextliststylepage.cpp:485
+msgid "Arabic"
+msgstr "अरबी"
+
+#: ../src/richtext/richtextbulletspage.cpp:278
+#: ../src/richtext/richtextliststylepage.cpp:486
+msgid "Upper case letters"
+msgstr "बड़े आकार के अक्षर"
+
+#: ../src/richtext/richtextbulletspage.cpp:279
+#: ../src/richtext/richtextliststylepage.cpp:487
+msgid "Lower case letters"
+msgstr "छोटे आकार के अक्षर"
+
+#: ../src/richtext/richtextbulletspage.cpp:280
+#: ../src/richtext/richtextliststylepage.cpp:488
+msgid "Upper case roman numerals"
+msgstr ""
+
+#: ../src/richtext/richtextbulletspage.cpp:281
+#: ../src/richtext/richtextliststylepage.cpp:489
+msgid "Lower case roman numerals"
+msgstr ""
+
+#: ../src/richtext/richtextbulletspage.cpp:282
+#: ../src/richtext/richtextliststylepage.cpp:490
+msgid "Numbered outline"
+msgstr "संख्यांकित रूपरेखा"
+
+#: ../src/richtext/richtextbulletspage.cpp:283
+#: ../src/richtext/richtextliststylepage.cpp:491
+msgid "Symbol"
+msgstr "चिह्न"
+
+#: ../src/richtext/richtextbulletspage.cpp:284
+#: ../src/richtext/richtextliststylepage.cpp:492
+msgid "Bitmap"
+msgstr "बिट्मैप"
+
+#: ../src/richtext/richtextbulletspage.cpp:285
+#: ../src/richtext/richtextliststylepage.cpp:493
+msgid "Standard"
+msgstr "मानक"
+
+#: ../src/richtext/richtextbulletspage.cpp:287
+#: ../src/richtext/richtextliststylepage.cpp:495
+msgid "*"
+msgstr "*"
+
+#: ../src/richtext/richtextbulletspage.cpp:288
+#: ../src/richtext/richtextliststylepage.cpp:496
+msgid "-"
+msgstr "-"
+
+#: ../src/richtext/richtextbulletspage.cpp:289
+#: ../src/richtext/richtextliststylepage.cpp:497
+msgid ">"
+msgstr ">"
+
+#: ../src/richtext/richtextbulletspage.cpp:290
+#: ../src/richtext/richtextliststylepage.cpp:498
+msgid "+"
+msgstr "+"
+
+#: ../src/richtext/richtextbulletspage.cpp:291
+#: ../src/richtext/richtextliststylepage.cpp:499
+msgid "~"
+msgstr "~"
+
+#: ../src/richtext/richtextctrl.cpp:859
+msgid "Drag"
+msgstr ""
+
+#: ../src/richtext/richtextctrl.cpp:1338 ../src/richtext/richtextctrl.cpp:1559
+msgid "Delete Text"
+msgstr "पाठ मिटाएँ"
+
+#: ../src/richtext/richtextctrl.cpp:1537
+#, fuzzy
+msgid "Remove Bullet"
+msgstr "निकाल दें"
+
+#: ../src/richtext/richtextctrl.cpp:3070
+msgid "The text couldn't be saved."
+msgstr "इस पाठ को सुरक्षित किया जा सका।"
+
+#: ../src/richtext/richtextctrl.cpp:3644
+msgid "Replace"
+msgstr "बदलें"
+
+#: ../src/richtext/richtextfontpage.cpp:146
+#: ../src/richtext/richtextsymboldlg.cpp:384
+msgid "&Font:"
+msgstr "फ़ॉन्ट: (&F)"
+
+#: ../src/richtext/richtextfontpage.cpp:150
+#: ../src/richtext/richtextfontpage.cpp:152
+msgid "Type a font name."
+msgstr "फ़ॉन्ट का नाम टाइप करें"
+
+#: ../src/richtext/richtextfontpage.cpp:158
+msgid "&Size:"
+msgstr "आकार: (&S)"
+
+#: ../src/richtext/richtextfontpage.cpp:165
+#: ../src/richtext/richtextfontpage.cpp:167
+msgid "Type a size in points."
+msgstr "आकार बिंदुओं में टाइप करें।"
+
+#: ../src/richtext/richtextfontpage.cpp:180
+#: ../src/richtext/richtextfontpage.cpp:182
+#, fuzzy
+msgid "The font size units, points or pixels."
+msgstr "फ़ॉन्ट का आकार बिंदुओं में।"
+
+#: ../src/richtext/richtextfontpage.cpp:189
+#: ../src/richtext/richtextfontpage.cpp:191
+msgid "Lists the available fonts."
+msgstr "उपलब्ध फ़ॉन्ट की सूची दिखाएँ।"
+
+#: ../src/richtext/richtextfontpage.cpp:196
+#: ../src/richtext/richtextfontpage.cpp:198
+msgid "Lists font sizes in points."
+msgstr "फ़ॉन्ट का आकार बिंदुओं में दिखाएँ।"
+
+#: ../src/richtext/richtextfontpage.cpp:207
+msgid "Font st&yle:"
+msgstr "फ़ॉन्ट शैली: (&Y)"
+
+#: ../src/richtext/richtextfontpage.cpp:212
+#: ../src/richtext/richtextfontpage.cpp:214
+msgid "Select regular or italic style."
+msgstr "चुने नियमित या तिरछी शैली।"
+
+#: ../src/richtext/richtextfontpage.cpp:220
+msgid "Font &weight:"
+msgstr "फ़ॉन्ट भार (&W):"
+
+#: ../src/richtext/richtextfontpage.cpp:225
+#: ../src/richtext/richtextfontpage.cpp:227
+msgid "Select regular or bold."
+msgstr "चुने नियमित या गहरा।"
+
+#: ../src/richtext/richtextfontpage.cpp:233
+msgid "&Underlining:"
+msgstr "रेखांकन (&U):"
+
+#: ../src/richtext/richtextfontpage.cpp:238
+#: ../src/richtext/richtextfontpage.cpp:240
+msgid "Select underlining or no underlining."
+msgstr ""
+
+#: ../src/richtext/richtextfontpage.cpp:248
+msgid "&Colour:"
+msgstr "रंग (&C):"
+
+#: ../src/richtext/richtextfontpage.cpp:253
+#: ../src/richtext/richtextfontpage.cpp:255
+msgid "Click to change the text colour."
+msgstr ""
+
+#: ../src/richtext/richtextfontpage.cpp:261
+#, fuzzy
+msgid "&Bg colour:"
+msgstr "रंग (&C):"
+
+#: ../src/richtext/richtextfontpage.cpp:266
+#: ../src/richtext/richtextfontpage.cpp:268
+msgid "Click to change the text background colour."
+msgstr ""
+
+#: ../src/richtext/richtextfontpage.cpp:276
+#: ../src/richtext/richtextfontpage.cpp:278
+msgid "Check to show a line through the text."
+msgstr ""
+
+#: ../src/richtext/richtextfontpage.cpp:281
+msgid "Ca&pitals"
+msgstr "बड़े अक्षर (&P)"
+
+#: ../src/richtext/richtextfontpage.cpp:283
+#: ../src/richtext/richtextfontpage.cpp:285
+msgid "Check to show the text in capitals."
+msgstr ""
+
+#: ../src/richtext/richtextfontpage.cpp:288
+#, fuzzy
+msgid "Small C&apitals"
+msgstr "बड़े अक्षर (&P)"
+
+#: ../src/richtext/richtextfontpage.cpp:290
+#: ../src/richtext/richtextfontpage.cpp:292
+msgid "Check to show the text in small capitals."
+msgstr ""
+
+#: ../src/richtext/richtextfontpage.cpp:295
+#, fuzzy
+msgid "Supe&rscript"
+msgstr "लिपि"
+
+#: ../src/richtext/richtextfontpage.cpp:297
+#: ../src/richtext/richtextfontpage.cpp:299
+msgid "Check to show the text in superscript."
+msgstr ""
+
+#: ../src/richtext/richtextfontpage.cpp:302
+#, fuzzy
+msgid "Subscrip&t"
+msgstr "लिपि"
+
+#: ../src/richtext/richtextfontpage.cpp:304
+#: ../src/richtext/richtextfontpage.cpp:306
+msgid "Check to show the text in subscript."
+msgstr ""
+
+#: ../src/richtext/richtextfontpage.cpp:312
+msgid "Rig&ht-to-left"
+msgstr ""
+
+#: ../src/richtext/richtextfontpage.cpp:314
+#: ../src/richtext/richtextfontpage.cpp:316
+msgid "Check to indicate right-to-left text layout."
+msgstr ""
+
+#: ../src/richtext/richtextfontpage.cpp:319
+msgid "Suppress hyphe&nation"
+msgstr ""
+
+#: ../src/richtext/richtextfontpage.cpp:321
+#: ../src/richtext/richtextfontpage.cpp:323
+msgid "Check to suppress hyphenation."
+msgstr ""
+
+#: ../src/richtext/richtextfontpage.cpp:329
+#: ../src/richtext/richtextfontpage.cpp:331
+msgid "Shows a preview of the font settings."
+msgstr ""
+
+#: ../src/richtext/richtextfontpage.cpp:348
+#: ../src/richtext/richtextfontpage.cpp:352
+#: ../src/richtext/richtextfontpage.cpp:356
+#: ../src/richtext/richtextformatdlg.cpp:873
+#: ../src/richtext/richtextindentspage.cpp:273
+#: ../src/richtext/richtextindentspage.cpp:285
+#: ../src/richtext/richtextindentspage.cpp:286
+#: ../src/richtext/richtextindentspage.cpp:310
+#: ../src/richtext/richtextindentspage.cpp:325
+#: ../src/richtext/richtextliststylepage.cpp:451
+#: ../src/richtext/richtextliststylepage.cpp:463
+#: ../src/richtext/richtextliststylepage.cpp:464
+msgid "(none)"
+msgstr "(कोई नाम नहीं)"
+
+#: ../src/richtext/richtextfontpage.cpp:349
+#: ../src/richtext/richtextfontpage.cpp:353
+msgid "Regular"
+msgstr "नियमित"
+
+#: ../src/richtext/richtextfontpage.cpp:357
+msgid "Not underlined"
+msgstr "रेखांकन नहीं"
+
+#: ../src/richtext/richtextformatdlg.cpp:341
+msgid "Indents && Spacing"
+msgstr ""
+
+#: ../src/richtext/richtextformatdlg.cpp:346
+msgid "Tabs"
+msgstr "टेब्स"
+
+#: ../src/richtext/richtextformatdlg.cpp:351
+msgid "Bullets"
+msgstr "बुल्लेतो"
+
+#: ../src/richtext/richtextformatdlg.cpp:356
+msgid "List Style"
+msgstr "सूची शैली"
+
+#: ../src/richtext/richtextformatdlg.cpp:366
+#: ../src/richtext/richtextmarginspage.cpp:170
+msgid "Margins"
+msgstr ""
+
+#: ../src/richtext/richtextformatdlg.cpp:371
+#, fuzzy
+msgid "Borders"
+msgstr "आधुनिक"
+
+#: ../src/richtext/richtextformatdlg.cpp:765
+msgid "Colour"
+msgstr "रंग"
+
+#: ../src/richtext/richtextindentspage.cpp:127
+#: ../src/richtext/richtextliststylepage.cpp:322
+msgid "&Alignment"
+msgstr "पंक्तिबद्ध करें (&A)"
+
+#: ../src/richtext/richtextindentspage.cpp:138
+#: ../src/richtext/richtextliststylepage.cpp:331
+msgid "&Left"
+msgstr "बायें (&L)"
+
+#: ../src/richtext/richtextindentspage.cpp:140
+#: ../src/richtext/richtextindentspage.cpp:142
+#: ../src/richtext/richtextliststylepage.cpp:333
+#: ../src/richtext/richtextliststylepage.cpp:335
+msgid "Left-align text."
+msgstr "पाठ को बायें पंक्तिबद्ध करें।"
+
+#: ../src/richtext/richtextindentspage.cpp:145
+#: ../src/richtext/richtextliststylepage.cpp:338
+msgid "&Right"
+msgstr "दायें (&R)"
+
+#: ../src/richtext/richtextindentspage.cpp:147
+#: ../src/richtext/richtextindentspage.cpp:149
+#: ../src/richtext/richtextliststylepage.cpp:340
+#: ../src/richtext/richtextliststylepage.cpp:342
+msgid "Right-align text."
+msgstr "पाठ को दायें पंक्तिबद्ध करें।"
+
+#: ../src/richtext/richtextindentspage.cpp:152
+#: ../src/richtext/richtextliststylepage.cpp:345
+msgid "&Justified"
+msgstr ""
+
+#: ../src/richtext/richtextindentspage.cpp:154
+#: ../src/richtext/richtextindentspage.cpp:156
+#: ../src/richtext/richtextliststylepage.cpp:347
+#: ../src/richtext/richtextliststylepage.cpp:349
+msgid "Justify text left and right."
+msgstr ""
+
+#: ../src/richtext/richtextindentspage.cpp:159
+#: ../src/richtext/richtextliststylepage.cpp:352
+msgid "Cen&tred"
+msgstr "केन्द्रित करें (&T)"
+
+#: ../src/richtext/richtextindentspage.cpp:161
+#: ../src/richtext/richtextindentspage.cpp:163
+#: ../src/richtext/richtextliststylepage.cpp:354
+#: ../src/richtext/richtextliststylepage.cpp:356
+msgid "Centre text."
+msgstr "पाठ को केन्द्रित करें।"
+
+#: ../src/richtext/richtextindentspage.cpp:166
+#: ../src/richtext/richtextliststylepage.cpp:359
+msgid "&Indeterminate"
+msgstr "अनिश्चित (&I)"
+
+#: ../src/richtext/richtextindentspage.cpp:168
+#: ../src/richtext/richtextindentspage.cpp:170
+#: ../src/richtext/richtextliststylepage.cpp:361
+#: ../src/richtext/richtextliststylepage.cpp:363
+msgid "Use the current alignment setting."
+msgstr "वर्तमान सरेखण समायोजना को प्रयोग करें।"
+
+#: ../src/richtext/richtextindentspage.cpp:183
+#: ../src/richtext/richtextliststylepage.cpp:375
+msgid "&Indentation (tenths of a mm)"
+msgstr "इंडेंटेशन (मिलीमीटर का दसवाँ भाग) (&I):"
+
+#: ../src/richtext/richtextindentspage.cpp:198
+#: ../src/richtext/richtextindentspage.cpp:200
+#: ../src/richtext/richtextliststylepage.cpp:388
+#: ../src/richtext/richtextliststylepage.cpp:390
+msgid "The left indent."
+msgstr "बायें इंडेंट।"
+
+#: ../src/richtext/richtextindentspage.cpp:203
+#: ../src/richtext/richtextliststylepage.cpp:393
+msgid "Left (&first line):"
+msgstr "बायें (पहली पंक्ति) (&F):"
+
+#: ../src/richtext/richtextindentspage.cpp:207
+#: ../src/richtext/richtextindentspage.cpp:209
+#: ../src/richtext/richtextliststylepage.cpp:397
+#: ../src/richtext/richtextliststylepage.cpp:399
+msgid "The first line indent."
+msgstr "पहली पंक्ति का इंडेंट।"
+
+#: ../src/richtext/richtextindentspage.cpp:216
+#: ../src/richtext/richtextindentspage.cpp:218
+#: ../src/richtext/richtextliststylepage.cpp:406
+#: ../src/richtext/richtextliststylepage.cpp:408
+msgid "The right indent."
+msgstr "दायें इंडेंट।"
+
+#: ../src/richtext/richtextindentspage.cpp:221
+msgid "&Outline level:"
+msgstr "रूपरेखा स्तर (&O):"
+
+#: ../src/richtext/richtextindentspage.cpp:226
+#: ../src/richtext/richtextindentspage.cpp:228
+msgid "The outline level."
+msgstr "रूपरेखा का स्तर।"
+
+#: ../src/richtext/richtextindentspage.cpp:241
+#: ../src/richtext/richtextliststylepage.cpp:420
+msgid "&Spacing (tenths of a mm)"
+msgstr "अन्तराल (मिलीमीटर का दसवाँ भाग) (&S)"
+
+#: ../src/richtext/richtextindentspage.cpp:252
+msgid "&Before a paragraph:"
+msgstr "अनुच्छेद के पहले (&B):"
+
+#: ../src/richtext/richtextindentspage.cpp:256
+#: ../src/richtext/richtextindentspage.cpp:258
+#: ../src/richtext/richtextliststylepage.cpp:433
+#: ../src/richtext/richtextliststylepage.cpp:435
+msgid "The spacing before the paragraph."
+msgstr "अनुच्छेद के पहले का अन्तराल।"
+
+#: ../src/richtext/richtextindentspage.cpp:261
+msgid "&After a paragraph:"
+msgstr "अनुच्छेद के बाद में (&A):"
+
+#: ../src/richtext/richtextindentspage.cpp:266
+#: ../src/richtext/richtextliststylepage.cpp:442
+#: ../src/richtext/richtextliststylepage.cpp:444
+msgid "The spacing after the paragraph."
+msgstr "अनुच्छेद के बाद का अन्तराल।"
+
+#: ../src/richtext/richtextindentspage.cpp:269
+msgid "L&ine spacing:"
+msgstr "पंक्ति अन्तराल (&I):"
+
+#: ../src/richtext/richtextindentspage.cpp:274
+#: ../src/richtext/richtextliststylepage.cpp:452
+msgid "Single"
+msgstr "अकेला"
+
+#: ../src/richtext/richtextindentspage.cpp:275
+#: ../src/richtext/richtextliststylepage.cpp:453
+#, fuzzy
+msgid "1.1"
+msgstr "१.५"
+
+#: ../src/richtext/richtextindentspage.cpp:276
+#: ../src/richtext/richtextliststylepage.cpp:454
+#, fuzzy
+msgid "1.2"
+msgstr "१.५"
+
+#: ../src/richtext/richtextindentspage.cpp:277
+#: ../src/richtext/richtextliststylepage.cpp:455
+#, fuzzy
+msgid "1.3"
+msgstr "१.५"
+
+#: ../src/richtext/richtextindentspage.cpp:278
+#: ../src/richtext/richtextliststylepage.cpp:456
+#, fuzzy
+msgid "1.4"
+msgstr "१.५"
+
+#: ../src/richtext/richtextindentspage.cpp:279
+#: ../src/richtext/richtextliststylepage.cpp:457
+msgid "1.5"
+msgstr "१.५"
+
+#: ../src/richtext/richtextindentspage.cpp:280
+#: ../src/richtext/richtextliststylepage.cpp:458
+#, fuzzy
+msgid "1.6"
+msgstr "१.५"
+
+#: ../src/richtext/richtextindentspage.cpp:281
+#: ../src/richtext/richtextliststylepage.cpp:459
+#, fuzzy
+msgid "1.7"
+msgstr "१.५"
+
+#: ../src/richtext/richtextindentspage.cpp:282
+#: ../src/richtext/richtextliststylepage.cpp:460
+#, fuzzy
+msgid "1.8"
+msgstr "१.५"
+
+#: ../src/richtext/richtextindentspage.cpp:283
+#: ../src/richtext/richtextliststylepage.cpp:461
+#, fuzzy
+msgid "1.9"
+msgstr "१.५"
+
+#: ../src/richtext/richtextindentspage.cpp:284
+#: ../src/richtext/richtextliststylepage.cpp:462
+msgid "2"
+msgstr "२"
+
+#: ../src/richtext/richtextindentspage.cpp:287
+#: ../src/richtext/richtextindentspage.cpp:289
+#: ../src/richtext/richtextliststylepage.cpp:465
+#: ../src/richtext/richtextliststylepage.cpp:467
+msgid "The line spacing."
+msgstr "पंक्ति का अन्तराल।"
+
+#: ../src/richtext/richtextindentspage.cpp:292
+msgid "&Page Break"
+msgstr ""
+
+#: ../src/richtext/richtextindentspage.cpp:294
+#: ../src/richtext/richtextindentspage.cpp:296
+#, fuzzy
+msgid "Inserts a page break before the paragraph."
+msgstr "अनुच्छेद के पहले का अन्तराल।"
+
+#: ../src/richtext/richtextindentspage.cpp:302
+#: ../src/richtext/richtextindentspage.cpp:304
+msgid "Shows a preview of the paragraph settings."
+msgstr ""
+
+#: ../src/richtext/richtextliststylepage.cpp:182
+msgid "&List level:"
+msgstr "सूची स्तर (&L):"
+
+#: ../src/richtext/richtextliststylepage.cpp:186
+#: ../src/richtext/richtextliststylepage.cpp:188
+msgid "Selects the list level to edit."
+msgstr ""
+
+#: ../src/richtext/richtextliststylepage.cpp:193
+msgid "&Font for Level..."
+msgstr "स्तर के लिए फ़ॉन्ट (&F)..."
+
+#: ../src/richtext/richtextliststylepage.cpp:194
+#: ../src/richtext/richtextliststylepage.cpp:196
+msgid "Click to choose the font for this level."
+msgstr ""
+
+#: ../src/richtext/richtextliststylepage.cpp:312
+msgid "Bullet style"
+msgstr "बुल्लेट शैली"
+
+#: ../src/richtext/richtextliststylepage.cpp:429
+msgid "Before a paragraph:"
+msgstr "अनुच्छेद के पहले:"
+
+#: ../src/richtext/richtextliststylepage.cpp:438
+msgid "After a paragraph:"
+msgstr "अनुच्छेद के बाद में:"
+
+#: ../src/richtext/richtextliststylepage.cpp:447
+msgid "Line spacing:"
+msgstr "पंक्ति अन्तराल:"
+
+#: ../src/richtext/richtextliststylepage.cpp:470
+msgid "Spacing"
+msgstr "अन्तराल"
+
+#: ../src/richtext/richtextmarginspage.cpp:193
+#: ../src/richtext/richtextmarginspage.cpp:195
+#, fuzzy
+msgid "The left margin size."
+msgstr "फ़ॉन्ट बिन्दु का आकार।"
+
+#: ../src/richtext/richtextmarginspage.cpp:203
+#: ../src/richtext/richtextmarginspage.cpp:205
+msgid "Units for the left margin."
+msgstr ""
+
+#: ../src/richtext/richtextmarginspage.cpp:218
+#: ../src/richtext/richtextmarginspage.cpp:220
+#, fuzzy
+msgid "The right margin size."
+msgstr "दायें इंडेंट।"
+
+#: ../src/richtext/richtextmarginspage.cpp:228
+#: ../src/richtext/richtextmarginspage.cpp:230
+msgid "Units for the right margin."
+msgstr ""
+
+#: ../src/richtext/richtextmarginspage.cpp:241
+#: ../src/richtext/richtextmarginspage.cpp:243
+#, fuzzy
+msgid "The top margin size."
+msgstr "फ़ॉन्ट बिन्दु का आकार।"
+
+#: ../src/richtext/richtextmarginspage.cpp:251
+#: ../src/richtext/richtextmarginspage.cpp:253
+#, fuzzy
+msgid "Units for the top margin."
+msgstr "थ्रेड समाप्ति की प्रतीक्षा नहीं की जा सकती है।"
+
+#: ../src/richtext/richtextmarginspage.cpp:266
+#: ../src/richtext/richtextmarginspage.cpp:268
+#, fuzzy
+msgid "The bottom margin size."
+msgstr "फ़ॉन्ट बिन्दु का आकार।"
+
+#: ../src/richtext/richtextmarginspage.cpp:276
+#: ../src/richtext/richtextmarginspage.cpp:278
+msgid "Units for the bottom margin."
+msgstr ""
+
+#: ../src/richtext/richtextmarginspage.cpp:284
+#, fuzzy
+msgid "Padding"
+msgstr "पढ़ा जा रहा है"
+
+#: ../src/richtext/richtextmarginspage.cpp:307
+#: ../src/richtext/richtextmarginspage.cpp:309
+#, fuzzy
+msgid "The left padding size."
+msgstr "फ़ॉन्ट बिन्दु का आकार।"
+
+#: ../src/richtext/richtextmarginspage.cpp:317
+#: ../src/richtext/richtextmarginspage.cpp:319
+msgid "Units for the left padding."
+msgstr ""
+
+#: ../src/richtext/richtextmarginspage.cpp:332
+#: ../src/richtext/richtextmarginspage.cpp:334
+#, fuzzy
+msgid "The right padding size."
+msgstr "दायें इंडेंट।"
+
+#: ../src/richtext/richtextmarginspage.cpp:342
+#: ../src/richtext/richtextmarginspage.cpp:344
+msgid "Units for the right padding."
+msgstr ""
+
+#: ../src/richtext/richtextmarginspage.cpp:355
+#: ../src/richtext/richtextmarginspage.cpp:357
+#, fuzzy
+msgid "The top padding size."
+msgstr "फ़ॉन्ट बिन्दु का आकार।"
+
+#: ../src/richtext/richtextmarginspage.cpp:365
+#: ../src/richtext/richtextmarginspage.cpp:367
+msgid "Units for the top padding."
+msgstr ""
+
+#: ../src/richtext/richtextmarginspage.cpp:380
+#: ../src/richtext/richtextmarginspage.cpp:382
+#, fuzzy
+msgid "The bottom padding size."
+msgstr "फ़ॉन्ट बिन्दु का आकार।"
+
+#: ../src/richtext/richtextmarginspage.cpp:390
+#: ../src/richtext/richtextmarginspage.cpp:392
+msgid "Units for the bottom padding."
+msgstr ""
+
+#: ../src/richtext/richtextprint.cpp:592
+msgid " Preview"
+msgstr " पूर्वालोकन"
+
+#: ../src/richtext/richtextsizepage.cpp:228
+msgid "Floating"
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:243
+msgid "&Floating mode:"
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:252
+#: ../src/richtext/richtextsizepage.cpp:254
+msgid "How the object will float relative to the text."
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:265
+#, fuzzy
+msgid "Alignment"
+msgstr "पंक्तिबद्ध करें (&A)"
+
+#: ../src/richtext/richtextsizepage.cpp:277
+#, fuzzy
+msgid "&Vertical alignment:"
+msgstr "बुल्लेट सरेखण (&A):"
+
+#: ../src/richtext/richtextsizepage.cpp:279
+#: ../src/richtext/richtextsizepage.cpp:281
+msgid "Enable vertical alignment."
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:286
+#, fuzzy
+msgid "Centred"
+msgstr "केन्द्रित करें (&T)"
+
+#: ../src/richtext/richtextsizepage.cpp:290
+#: ../src/richtext/richtextsizepage.cpp:292
+msgid "Vertical alignment."
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:316
+#: ../src/richtext/richtextsizepage.cpp:323
+#, fuzzy
+msgid "&Width:"
+msgstr "भार (&W):"
+
+#: ../src/richtext/richtextsizepage.cpp:318
+#: ../src/richtext/richtextsizepage.cpp:320
+msgid "Enable the width value."
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:331
+#: ../src/richtext/richtextsizepage.cpp:333
+#, fuzzy
+msgid "The object width."
+msgstr "फ़ॉन्ट का भार"
+
+#: ../src/richtext/richtextsizepage.cpp:342
+#: ../src/richtext/richtextsizepage.cpp:344
+msgid "Units for the object width."
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:350
+#: ../src/richtext/richtextsizepage.cpp:357
+#, fuzzy
+msgid "&Height:"
+msgstr "भार (&W):"
+
+#: ../src/richtext/richtextsizepage.cpp:352
+#: ../src/richtext/richtextsizepage.cpp:354
+#: ../src/richtext/richtextsizepage.cpp:464
+#: ../src/richtext/richtextsizepage.cpp:466
+msgid "Enable the height value."
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:365
+#: ../src/richtext/richtextsizepage.cpp:367
+#, fuzzy
+msgid "The object height."
+msgstr "फ़ॉन्ट का भार"
+
+#: ../src/richtext/richtextsizepage.cpp:376
+#: ../src/richtext/richtextsizepage.cpp:378
+msgid "Units for the object height."
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:381
+msgid "Min width:"
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:383
+#: ../src/richtext/richtextsizepage.cpp:385
+#, fuzzy
+msgid "Enable the minimum width value."
+msgstr "मुद्रण को आरम्भ नहीं किया जा सका।"
+
+#: ../src/richtext/richtextsizepage.cpp:392
+#: ../src/richtext/richtextsizepage.cpp:394
+#, fuzzy
+msgid "The object minimum width."
+msgstr "फ़ॉन्ट का भार"
+
+#: ../src/richtext/richtextsizepage.cpp:403
+#: ../src/richtext/richtextsizepage.cpp:405
+#, fuzzy
+msgid "Units for the minimum object width."
+msgstr "फ़ॉन्ट का भार"
+
+#: ../src/richtext/richtextsizepage.cpp:408
+#, fuzzy
+msgid "Min height:"
+msgstr "फ़ॉन्ट भार (&W):"
+
+#: ../src/richtext/richtextsizepage.cpp:410
+#: ../src/richtext/richtextsizepage.cpp:412
+msgid "Enable the minimum height value."
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:419
+#: ../src/richtext/richtextsizepage.cpp:421
+#, fuzzy
+msgid "The object minimum height."
+msgstr "फ़ॉन्ट का भार"
+
+#: ../src/richtext/richtextsizepage.cpp:430
+#: ../src/richtext/richtextsizepage.cpp:432
+#, fuzzy
+msgid "Units for the minimum object height."
+msgstr "फ़ॉन्ट का भार"
+
+#: ../src/richtext/richtextsizepage.cpp:435
+#, fuzzy
+msgid "Max width:"
+msgstr "से बदलें:"
+
+#: ../src/richtext/richtextsizepage.cpp:437
+#: ../src/richtext/richtextsizepage.cpp:439
+#, fuzzy
+msgid "Enable the maximum width value."
+msgstr "मुद्रण को आरम्भ नहीं किया जा सका।"
+
+#: ../src/richtext/richtextsizepage.cpp:446
+#: ../src/richtext/richtextsizepage.cpp:448
+#, fuzzy
+msgid "The object maximum width."
+msgstr "फ़ॉन्ट का भार"
+
+#: ../src/richtext/richtextsizepage.cpp:457
+#: ../src/richtext/richtextsizepage.cpp:459
+#, fuzzy
+msgid "Units for the maximum object width."
+msgstr "फ़ॉन्ट का भार"
+
+#: ../src/richtext/richtextsizepage.cpp:462
+#, fuzzy
+msgid "Max height:"
+msgstr "भार (&W):"
+
+#: ../src/richtext/richtextsizepage.cpp:473
+#: ../src/richtext/richtextsizepage.cpp:475
+#, fuzzy
+msgid "The object maximum height."
+msgstr "फ़ॉन्ट का भार"
+
+#: ../src/richtext/richtextsizepage.cpp:484
+#: ../src/richtext/richtextsizepage.cpp:486
+#, fuzzy
+msgid "Units for the maximum object height."
+msgstr "फ़ॉन्ट का भार"
+
+#: ../src/richtext/richtextsizepage.cpp:495
+#, fuzzy
+msgid "Position"
+msgstr "प्रश्न"
+
+#: ../src/richtext/richtextsizepage.cpp:513
+#, fuzzy
+msgid "&Position mode:"
+msgstr "प्रश्न"
+
+#: ../src/richtext/richtextsizepage.cpp:517
+#: ../src/richtext/richtextsizepage.cpp:522
+#, fuzzy
+msgid "Static"
+msgstr "अवस्था:"
+
+#: ../src/richtext/richtextsizepage.cpp:518
+#, fuzzy
+msgid "Relative"
+msgstr "साज-सजावट"
+
+#: ../src/richtext/richtextsizepage.cpp:519
+msgid "Absolute"
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:520
+#, fuzzy
+msgid "Fixed"
+msgstr "नियत फ़ॉन्ट:"
+
+#: ../src/richtext/richtextsizepage.cpp:533
+#: ../src/richtext/richtextsizepage.cpp:535
+#: ../src/richtext/richtextsizepage.cpp:547
+#: ../src/richtext/richtextsizepage.cpp:549
+#, fuzzy
+msgid "The left position."
+msgstr "टैब की स्थिति।"
+
+#: ../src/richtext/richtextsizepage.cpp:558
+#: ../src/richtext/richtextsizepage.cpp:560
+#, fuzzy
+msgid "Units for the left position."
+msgstr "थ्रेड समाप्ति की प्रतीक्षा नहीं की जा सकती है।"
+
+#: ../src/richtext/richtextsizepage.cpp:568
+#: ../src/richtext/richtextsizepage.cpp:570
+#: ../src/richtext/richtextsizepage.cpp:582
+#: ../src/richtext/richtextsizepage.cpp:584
+#, fuzzy
+msgid "The top position."
+msgstr "टैब की स्थिति।"
+
+#: ../src/richtext/richtextsizepage.cpp:593
+#: ../src/richtext/richtextsizepage.cpp:595
+#, fuzzy
+msgid "Units for the top position."
+msgstr "थ्रेड समाप्ति की प्रतीक्षा नहीं की जा सकती है।"
+
+#: ../src/richtext/richtextsizepage.cpp:603
+#: ../src/richtext/richtextsizepage.cpp:605
+#: ../src/richtext/richtextsizepage.cpp:617
+#: ../src/richtext/richtextsizepage.cpp:619
+#, fuzzy
+msgid "The right position."
+msgstr "टैब की स्थिति।"
+
+#: ../src/richtext/richtextsizepage.cpp:628
+#: ../src/richtext/richtextsizepage.cpp:630
+#, fuzzy
+msgid "Units for the right position."
+msgstr "थ्रेड समाप्ति की प्रतीक्षा नहीं की जा सकती है।"
+
+#: ../src/richtext/richtextsizepage.cpp:638
+#: ../src/richtext/richtextsizepage.cpp:640
+#: ../src/richtext/richtextsizepage.cpp:652
+#: ../src/richtext/richtextsizepage.cpp:654
+#, fuzzy
+msgid "The bottom position."
+msgstr "टैब की स्थिति।"
+
+#: ../src/richtext/richtextsizepage.cpp:663
+#: ../src/richtext/richtextsizepage.cpp:665
+#, fuzzy
+msgid "Units for the bottom position."
+msgstr "थ्रेड समाप्ति की प्रतीक्षा नहीं की जा सकती है।"
+
+#: ../src/richtext/richtextsizepage.cpp:671
+msgid "&Move the object to:"
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:674
+#, fuzzy
+msgid "&Previous Paragraph"
+msgstr "पिछला पॄष्ट"
+
+#: ../src/richtext/richtextsizepage.cpp:675
+#: ../src/richtext/richtextsizepage.cpp:677
+msgid "Moves the object to the previous paragraph."
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:680
+#, fuzzy
+msgid "&Next Paragraph"
+msgstr "अनुच्छेद के बाद में (&A):"
+
+#: ../src/richtext/richtextsizepage.cpp:681
+#: ../src/richtext/richtextsizepage.cpp:683
+#, fuzzy
+msgid "Moves the object to the next paragraph."
+msgstr "अगले अनुच्छेद के लिए डिफ़ाल्ट शैली।"
+
+#: ../src/richtext/richtextstyledlg.cpp:193
+msgid "&Styles:"
+msgstr "शैलियाँ (&S):"
+
+#: ../src/richtext/richtextstyledlg.cpp:197
+#: ../src/richtext/richtextstyledlg.cpp:199
+msgid "The available styles."
+msgstr "उपलब्ध शैलियाँ।"
+
+#: ../src/richtext/richtextstyledlg.cpp:205
+#: ../src/richtext/richtextstyledlg.cpp:217
+msgid " "
+msgstr " "
+
+#: ../src/richtext/richtextstyledlg.cpp:209
+#: ../src/richtext/richtextstyledlg.cpp:211
+msgid "The style preview."
+msgstr "शैली का पूर्वालोकन।"
+
+#: ../src/richtext/richtextstyledlg.cpp:220
+msgid "New &Character Style..."
+msgstr "नयी संप्रतीक शैली (&C)..."
+
+#: ../src/richtext/richtextstyledlg.cpp:221
+#: ../src/richtext/richtextstyledlg.cpp:223
+msgid "Click to create a new character style."
+msgstr ""
+
+#: ../src/richtext/richtextstyledlg.cpp:226
+msgid "New &Paragraph Style..."
+msgstr "नयी अनुच्छेद शैली (&P)..."
+
+#: ../src/richtext/richtextstyledlg.cpp:227
+#: ../src/richtext/richtextstyledlg.cpp:229
+msgid "Click to create a new paragraph style."
+msgstr ""
+
+#: ../src/richtext/richtextstyledlg.cpp:232
+msgid "New &List Style..."
+msgstr "नयी सूची शैली (&L)..."
+
+#: ../src/richtext/richtextstyledlg.cpp:233
+#: ../src/richtext/richtextstyledlg.cpp:235
+msgid "Click to create a new list style."
+msgstr ""
+
+#: ../src/richtext/richtextstyledlg.cpp:238
+#, fuzzy
+msgid "New &Box Style..."
+msgstr "नयी सूची शैली (&L)..."
+
+#: ../src/richtext/richtextstyledlg.cpp:239
+#: ../src/richtext/richtextstyledlg.cpp:241
+msgid "Click to create a new box style."
+msgstr ""
+
+#: ../src/richtext/richtextstyledlg.cpp:246
+msgid "&Apply Style"
+msgstr "शैली लागु करें (&A)"
+
+#: ../src/richtext/richtextstyledlg.cpp:247
+#: ../src/richtext/richtextstyledlg.cpp:249
+msgid "Click to apply the selected style."
+msgstr ""
+
+#: ../src/richtext/richtextstyledlg.cpp:252
+msgid "&Rename Style..."
+msgstr "शैली का पुनःनामकरण (&R)..."
+
+#: ../src/richtext/richtextstyledlg.cpp:253
+#: ../src/richtext/richtextstyledlg.cpp:255
+msgid "Click to rename the selected style."
+msgstr ""
+
+#: ../src/richtext/richtextstyledlg.cpp:258
+msgid "&Edit Style..."
+msgstr "शैली संपादन (&E)..."
+
+#: ../src/richtext/richtextstyledlg.cpp:259
+#: ../src/richtext/richtextstyledlg.cpp:261
+msgid "Click to edit the selected style."
+msgstr ""
+
+#: ../src/richtext/richtextstyledlg.cpp:264
+msgid "&Delete Style..."
+msgstr "शैली हटाएँ (&D)..."
+
+#: ../src/richtext/richtextstyledlg.cpp:265
+#: ../src/richtext/richtextstyledlg.cpp:267
+msgid "Click to delete the selected style."
+msgstr ""
+
+#: ../src/richtext/richtextstyledlg.cpp:274
+#: ../src/richtext/richtextstyledlg.cpp:276
+msgid "Click to close this window."
+msgstr "इस खिड़की को बंद करने के लिए क्लिक करें।"
+
+#: ../src/richtext/richtextstyledlg.cpp:282
+msgid "&Restart numbering"
+msgstr "पुनः प्रारम्भन संख्यांकन (&R)"
+
+#: ../src/richtext/richtextstyledlg.cpp:284
+#: ../src/richtext/richtextstyledlg.cpp:286
+msgid "Check to restart numbering."
+msgstr "संख्यांकन पुनः प्रारम्भन करने के लिए चेक करें।"
+
+#: ../src/richtext/richtextstyledlg.cpp:601
+msgid "Enter a character style name"
+msgstr "एक संप्रतीक सूची का नाम बताएँ"
+
+#: ../src/richtext/richtextstyledlg.cpp:601
+#: ../src/richtext/richtextstyledlg.cpp:606
+#: ../src/richtext/richtextstyledlg.cpp:649
+#: ../src/richtext/richtextstyledlg.cpp:654
+#: ../src/richtext/richtextstyledlg.cpp:815
+#: ../src/richtext/richtextstyledlg.cpp:820
+#: ../src/richtext/richtextstyledlg.cpp:888
+#: ../src/richtext/richtextstyledlg.cpp:896
+#: ../src/richtext/richtextstyledlg.cpp:929
+#: ../src/richtext/richtextstyledlg.cpp:934
+msgid "New Style"
+msgstr "नयी शैली"
+
+#: ../src/richtext/richtextstyledlg.cpp:606
+#: ../src/richtext/richtextstyledlg.cpp:654
+#: ../src/richtext/richtextstyledlg.cpp:820
+#: ../src/richtext/richtextstyledlg.cpp:896
+#: ../src/richtext/richtextstyledlg.cpp:934
+msgid "Sorry, that name is taken. Please choose another."
+msgstr "क्षमा करें, यह नाम चुना जा चुका हें। कृपया कोई दूसरा नाम चुने।"
+
+#: ../src/richtext/richtextstyledlg.cpp:649
+msgid "Enter a paragraph style name"
+msgstr "एक अनुच्छेद शैली का नाम बताएँ"
+
+#: ../src/richtext/richtextstyledlg.cpp:777
+#, c-format
+msgid "Delete style %s?"
+msgstr "शैली हटाएँ %s?"
+
+#: ../src/richtext/richtextstyledlg.cpp:777
+msgid "Delete Style"
+msgstr "शैली हटाएँ"
+
+#: ../src/richtext/richtextstyledlg.cpp:815
+msgid "Enter a list style name"
+msgstr "एक सूची शैली का नाम बताएँ"
+
+#: ../src/richtext/richtextstyledlg.cpp:888
+msgid "Enter a new style name"
+msgstr "एक नयी शैली का नाम बताएँ"
+
+#: ../src/richtext/richtextstyledlg.cpp:929
+#, fuzzy
+msgid "Enter a box style name"
+msgstr "एक नयी शैली का नाम बताएँ"
+
+#: ../src/richtext/richtextstylepage.cpp:109
+#: ../src/richtext/richtextstylepage.cpp:111
+msgid "The style name."
+msgstr "शैली का नाम।"
+
+#: ../src/richtext/richtextstylepage.cpp:114
+msgid "&Based on:"
+msgstr "पर आधारित (&B):"
+
+#: ../src/richtext/richtextstylepage.cpp:119
+#: ../src/richtext/richtextstylepage.cpp:121
+msgid "The style on which this style is based."
+msgstr "वो शैली जिस पर ये शैली आधारित हें।"
+
+#: ../src/richtext/richtextstylepage.cpp:124
+msgid "&Next style:"
+msgstr "अगली शैली (&N):"
+
+#: ../src/richtext/richtextstylepage.cpp:129
+#: ../src/richtext/richtextstylepage.cpp:131
+msgid "The default style for the next paragraph."
+msgstr "अगले अनुच्छेद के लिए डिफ़ाल्ट शैली।"
+
+#: ../src/richtext/richtextstyles.cpp:1057
+msgid "All styles"
+msgstr "सभी शैलियाँ"
+
+#: ../src/richtext/richtextstyles.cpp:1058
+msgid "Paragraph styles"
+msgstr "अनुच्छेद शैलियाँ"
+
+#: ../src/richtext/richtextstyles.cpp:1059
+msgid "Character styles"
+msgstr "संप्रतीक शैलियाँ"
+
+#: ../src/richtext/richtextstyles.cpp:1060
+msgid "List styles"
+msgstr "सूची शैलियाँ"
+
+#: ../src/richtext/richtextstyles.cpp:1061
+#, fuzzy
+msgid "Box styles"
+msgstr "सभी शैलियाँ"
+
+#: ../src/richtext/richtextsymboldlg.cpp:389
+#: ../src/richtext/richtextsymboldlg.cpp:391
+msgid "The font from which to take the symbol."
+msgstr ""
+
+#: ../src/richtext/richtextsymboldlg.cpp:396
+msgid "&Subset:"
+msgstr "उप समुच्चय (&S):"
+
+#: ../src/richtext/richtextsymboldlg.cpp:401
+#: ../src/richtext/richtextsymboldlg.cpp:403
+msgid "Shows a Unicode subset."
+msgstr "एक यूनिकोड उप समुच्चय दिखाएँ।"
+
+#: ../src/richtext/richtextsymboldlg.cpp:412
+msgid "xxxx"
+msgstr "xxxx"
+
+#: ../src/richtext/richtextsymboldlg.cpp:417
+msgid "&Character code:"
+msgstr "संप्रतीक कूट (&C):"
+
+#: ../src/richtext/richtextsymboldlg.cpp:421
+#: ../src/richtext/richtextsymboldlg.cpp:423
+msgid "The character code."
+msgstr "का संप्रतीक कूट।"
+
+#: ../src/richtext/richtextsymboldlg.cpp:428
+msgid "&From:"
+msgstr "से (&F):"
+
+#: ../src/richtext/richtextsymboldlg.cpp:433
+#: ../src/richtext/richtextsymboldlg.cpp:434
+#: ../src/richtext/richtextsymboldlg.cpp:435
+msgid "Unicode"
+msgstr "यूनिकोड"
+
+#: ../src/richtext/richtextsymboldlg.cpp:436
+#: ../src/richtext/richtextsymboldlg.cpp:438
+msgid "The range to show."
+msgstr ""
+
+#: ../src/richtext/richtextsymboldlg.cpp:444
+msgid "Insert"
+msgstr "डाले"
+
+#: ../src/richtext/richtextsymboldlg.cpp:478
+msgid "(Normal text)"
+msgstr "(सामान्य पाठ)"
+
+#: ../src/richtext/richtexttabspage.cpp:109
+msgid "&Position (tenths of a mm):"
+msgstr "स्थिति (मिलीमीटर का दसवाँ भाग) (&P):"
+
+#: ../src/richtext/richtexttabspage.cpp:113
+#: ../src/richtext/richtexttabspage.cpp:115
+msgid "The tab position."
+msgstr "टैब की स्थिति।"
+
+#: ../src/richtext/richtexttabspage.cpp:119
+msgid "The tab positions."
+msgstr "टैब की स्थितियाँ।"
+
+#: ../src/richtext/richtexttabspage.cpp:132
+#: ../src/richtext/richtexttabspage.cpp:134
+msgid "Click to create a new tab position."
+msgstr ""
+
+#: ../src/richtext/richtexttabspage.cpp:138
+#: ../src/richtext/richtexttabspage.cpp:140
+msgid "Click to delete the selected tab position."
+msgstr ""
+
+#: ../src/richtext/richtexttabspage.cpp:143
+msgid "Delete A&ll"
+msgstr "सभी मिटाएँ (&L)"
+
+#: ../src/richtext/richtexttabspage.cpp:144
+#: ../src/richtext/richtexttabspage.cpp:146
+msgid "Click to delete all tab positions."
+msgstr ""
+
+#: ../src/univ/theme.cpp:110
+msgid "Failed to initialize GUI: no built-in themes found."
+msgstr "जीयूआई का आरम्भीकरण करने में असफ़ल: कोई अंत-निर्मित थीमें नहीं मिली।"
+
+#: ../src/univ/themes/gtk.cpp:521
+msgid "GTK+ theme"
+msgstr "जीटीके+ थीम"
+
+#: ../src/univ/themes/metal.cpp:164
+msgid "Metal theme"
+msgstr "मेटल थीम"
+
+#: ../src/univ/themes/mono.cpp:512
+msgid "Simple monochrome theme"
+msgstr ""
+
+#: ../src/univ/themes/win32.cpp:1098
+msgid "Win32 theme"
+msgstr "विन३२ थीम"
+
+#: ../src/univ/themes/win32.cpp:3743
+msgid "&Restore"
+msgstr "पुनःस्थापित करें (&R)"
+
+#: ../src/univ/themes/win32.cpp:3744
+msgid "&Move"
+msgstr "इधर-उधर ले जाएँ (&M)"
+
+#: ../src/univ/themes/win32.cpp:3746
+msgid "&Size"
+msgstr "आकार (&S)"
+
+#: ../src/univ/themes/win32.cpp:3748
+msgid "Mi&nimize"
+msgstr "छोटा करें (&n)"
+
+#: ../src/univ/themes/win32.cpp:3750
+msgid "Ma&ximize"
+msgstr "बड़ा करें (&x)"
+
+#: ../src/univ/themes/win32.cpp:3752
+#, fuzzy
+msgid "Alt+"
+msgstr "Alt-"
+
+#: ../src/unix/appunix.cpp:178
+#, fuzzy
+msgid "Failed to install signal handler"
+msgstr "फ़ाइल हैन्डल को बन्द करने में असफ़ल"
+
+#: ../src/unix/dialup.cpp:351
+msgid "Already dialling ISP."
+msgstr "आईएसपी को पहिले से डायल किया जा रहा है।"
+
+#: ../src/unix/dlunix.cpp:93
+#, fuzzy
+msgid "Failed to unload shared library"
+msgstr "'%s' साझा लायबरी को लोड करने में असफ़ल"
+
+#: ../src/unix/dlunix.cpp:121
+msgid "Unknown dynamic library error"
+msgstr "अज्ञात गतिक लेखागार दोष"
+
+#: ../src/unix/epolldispatcher.cpp:84
+#, fuzzy
+msgid "Failed to create epoll descriptor"
+msgstr "कर्सर का निर्माण करने में असफ़ल।"
+
+#: ../src/unix/epolldispatcher.cpp:103
+#, fuzzy
+msgid "Error closing epoll descriptor"
+msgstr "निर्देशिका निर्माण में त्रुटि"
+
+#: ../src/unix/epolldispatcher.cpp:116
+#, fuzzy, c-format
+msgid "Failed to add descriptor %d to epoll descriptor %d"
+msgstr "फ़ाइल विवरणकर्ता %d पर लिखा नहीं जा सकता है"
+
+#: ../src/unix/epolldispatcher.cpp:136
+#, c-format
+msgid "Failed to modify descriptor %d in epoll descriptor %d"
+msgstr ""
+
+#: ../src/unix/epolldispatcher.cpp:155
+#, fuzzy, c-format
+msgid "Failed to unregister descriptor %d from epoll descriptor %d"
+msgstr "क्लिपबोर्ड से डाटा को पुनःप्राप्त करने में असफ़ल।"
+
+#: ../src/unix/epolldispatcher.cpp:213
+#, fuzzy, c-format
+msgid "Waiting for IO on epoll descriptor %d failed"
+msgstr "उपप्रक्रिया के समाप्त होने की प्रतीक्षा असफ़ल रही"
+
+#: ../src/unix/fswatcher_inotify.cpp:71
+#, fuzzy
+msgid "Unable to create inotify instance"
+msgstr "डीडीई श्रेणी का निर्माण करने में असफ़ल"
+
+#: ../src/unix/fswatcher_inotify.cpp:94
+#, fuzzy
+msgid "Unable to close inotify instance"
+msgstr "फ़ाइल हैन्डल को बन्द करने में असफ़ल"
+
+#: ../src/unix/fswatcher_inotify.cpp:106
+msgid "Unable to add inotify watch"
+msgstr ""
+
+#: ../src/unix/fswatcher_inotify.cpp:138
+#, fuzzy, c-format
+msgid "Unable to remove inotify watch %i"
+msgstr "डीडीई श्रेणी का निर्माण करने में असफ़ल"
+
+#: ../src/unix/fswatcher_inotify.cpp:271
+#, c-format
+msgid "Unexpected event for \"%s\": no matching watch descriptor."
+msgstr ""
+
+#: ../src/unix/fswatcher_inotify.cpp:320
+#, c-format
+msgid "Invalid inotify event for \"%s\""
+msgstr ""
+
+#: ../src/unix/fswatcher_inotify.cpp:553
+#, fuzzy
+msgid "Unable to read from inotify descriptor"
+msgstr "फ़ाइल विवरणकर्ता %d से पढ़ा नहीं जा सकता है"
+
+#: ../src/unix/fswatcher_inotify.cpp:558
+#, fuzzy
+msgid "EOF while reading from inotify descriptor"
+msgstr "फ़ाइल विवरणकर्ता %d से पढ़ा नहीं जा सकता है"
+
+#: ../src/unix/fswatcher_kqueue.cpp:114
+#, fuzzy
+msgid "Unable to create kqueue instance"
+msgstr "डीडीई श्रेणी का निर्माण करने में असफ़ल"
+
+#: ../src/unix/fswatcher_kqueue.cpp:131
+msgid "Error closing kqueue instance"
+msgstr ""
+
+#: ../src/unix/fswatcher_kqueue.cpp:153
+msgid "Unable to add kqueue watch"
+msgstr ""
+
+#: ../src/unix/fswatcher_kqueue.cpp:170
+msgid "Unable to remove kqueue watch"
+msgstr ""
+
+#: ../src/unix/fswatcher_kqueue.cpp:202
+msgid "Unable to get events from kqueue"
+msgstr ""
+
+#: ../src/unix/mediactrl.cpp:966
+#, c-format
+msgid "Media playback error: %s"
+msgstr ""
+
+#: ../src/unix/mediactrl.cpp:1228
+#, fuzzy, c-format
+msgid "Failed to prepare playing \"%s\"."
+msgstr "प्रदर्श युक्ति \"%s\" को खोलने में असफ़ल।"
+
+#: ../src/unix/snglinst.cpp:164
+#, c-format
+msgid "Failed to write to lock file '%s'"
+msgstr "'%s' लॉक फ़ाइल पर लिखने में असफ़ल"
+
+#: ../src/unix/snglinst.cpp:177
+#, fuzzy, c-format
+msgid "Failed to set permissions on lock file '%s'"
+msgstr "'%s' फ़ाइल के लिए अनुमतियों को स्थापित करना असम्भव"
+
+#: ../src/unix/snglinst.cpp:194
+#, c-format
+msgid "Failed to lock the lock file '%s'"
+msgstr "'%s' फ़ाइल को लॉक करने में असफ़ल"
+
+#: ../src/unix/snglinst.cpp:237
+#, c-format
+msgid "Failed to inspect the lock file '%s'"
+msgstr "लॉक फ़ाइल '%s' को निरीक्षण करने में असफ़ल"
+
+#: ../src/unix/snglinst.cpp:242
+#, fuzzy, c-format
+msgid "Lock file '%s' has incorrect owner."
+msgstr "साउन्ड फ़ाइल '%s' एक असमर्थित प्रारूप में है।"
+
+#: ../src/unix/snglinst.cpp:247
+#, c-format
+msgid "Lock file '%s' has incorrect permissions."
+msgstr "लॉक फ़ाइल '%s' पे गलत अनुमतियाँ हें।"
+
+#: ../src/unix/snglinst.cpp:265
+msgid "Failed to access lock file."
+msgstr "लॉक फ़ाइल तक पहुँच में असफ़ल।"
+
+#: ../src/unix/snglinst.cpp:274
+msgid "Failed to read PID from lock file."
+msgstr "लॉक फ़ाइल से पीआईडी को पढ़ने में असफ़ल।"
+
+#: ../src/unix/snglinst.cpp:284
+#, c-format
+msgid "Failed to remove stale lock file '%s'."
+msgstr "'%s' स्टेल लॉक फ़ाइल को हटाने में असफ़ल।"
+
+#: ../src/unix/snglinst.cpp:297
+#, c-format
+msgid "Deleted stale lock file '%s'."
+msgstr "हटायी जा चुकी स्टेल लॉक फ़ाइल '%s'।"
+
+#: ../src/unix/snglinst.cpp:308
+#, c-format
+msgid "Invalid lock file '%s'."
+msgstr "'%s' अवैध लॉक फ़ाइल।"
+
+#: ../src/unix/snglinst.cpp:324
+#, c-format
+msgid "Failed to remove lock file '%s'"
+msgstr "'%s' लॉक फ़ाइल को हटाने में असफ़ल"
+
+#: ../src/unix/snglinst.cpp:330
+#, c-format
+msgid "Failed to unlock lock file '%s'"
+msgstr "'%s' लॉक फ़ाइल को अन-लॉक करने में असफ़ल"
+
+#: ../src/unix/snglinst.cpp:336
+#, c-format
+msgid "Failed to close lock file '%s'"
+msgstr "'%s' लॉक फ़ाइल को बन्द करने में असफ़ल"
+
+#: ../src/unix/sound.cpp:77
+msgid "No sound"
+msgstr "कोई ध्वनि नहीं"
+
+#: ../src/unix/sound.cpp:364
+msgid "Unable to play sound asynchronously."
+msgstr "ध्वनि को अतुल्यकालिक रूप से चलाने में असमर्थ।"
+
+#: ../src/unix/sound.cpp:458
+#, c-format
+msgid "Couldn't load sound data from '%s'."
+msgstr "'%s' से ध्वनि डाटा को लोड नहीं किया जा सका।"
+
+#: ../src/unix/sound.cpp:465
+#, c-format
+msgid "Sound file '%s' is in unsupported format."
+msgstr "साउन्ड फ़ाइल '%s' एक असमर्थित प्रारूप में है।"
+
+#: ../src/unix/sound.cpp:480
+msgid "Sound data are in unsupported format."
+msgstr "साउन्ड डाटा एक असमर्थित प्रारूप में है।"
+
+#: ../src/unix/sound_sdl.cpp:226
+#, c-format
+msgid "Couldn't open audio: %s"
+msgstr "आडियो को नहीं खोला जा सका: %s"
+
+#: ../src/unix/threadpsx.cpp:1033
+msgid "Cannot retrieve thread scheduling policy."
+msgstr "थ्रेड समय-सारणी नीति को प्राप्त नहीं किया जा सकता है।"
+
+#: ../src/unix/threadpsx.cpp:1058
+#, c-format
+msgid "Cannot get priority range for scheduling policy %d."
+msgstr "%d नीति की समय-सारणी के लिए वरीयता सीमा को नहीं प्राप्त किया जा सका"
+
+#: ../src/unix/threadpsx.cpp:1066
+msgid "Thread priority setting is ignored."
+msgstr "थ्रेड वरीयता समायोजना पर ध्यान नहीं दिया गया।"
+
+#: ../src/unix/threadpsx.cpp:1221
+msgid ""
+"Failed to join a thread, potential memory leak detected - please restart the "
+"program"
+msgstr ""
+"एक थ्रेड में शामिल होने में असफ़ल, अत्याधिक स्मॄति रिसाव पाया गया -कॄपया इस कार्यक्रम को "
+"पुनः आरम्भ करें"
+
+#: ../src/unix/threadpsx.cpp:1352
+#, fuzzy, c-format
+msgid "Failed to set thread concurrency level to %lu"
+msgstr "%d थ्रेड वरीयता को स्थापित करने में असफ़ल।"
+
+#: ../src/unix/threadpsx.cpp:1481
+#, c-format
+msgid "Failed to set thread priority %d."
+msgstr "%d थ्रेड वरीयता को स्थापित करने में असफ़ल।"
+
+#: ../src/unix/threadpsx.cpp:1666
+msgid "Failed to terminate a thread."
+msgstr "एक थ्रेड को समाप्त करने में असफ़ल।"
+
+#: ../src/unix/threadpsx.cpp:1893
+msgid "Thread module initialization failed: failed to create thread key"
+msgstr "थ्रेड माड्यूल आरम्भीकरण असफ़ल रहा: थ्रेड कुँजी का निर्माण नहीं किया जा सका"
+
+#: ../src/unix/utilsunx.cpp:340
+msgid "Impossible to get child process input"
+msgstr "बाल प्रोसेस इनपुट का प्राप्त करना असम्भव"
+
+#: ../src/unix/utilsunx.cpp:390
+#, fuzzy
+msgid "Can't write to child process's stdin"
+msgstr "%d प्रोसेस को खत्म करने में असफ़ल"
+
+#: ../src/unix/utilsunx.cpp:644
+#, c-format
+msgid "Failed to execute '%s'\n"
+msgstr "'%s' का निष्पादन करने में असफ़ल\n"
+
+#: ../src/unix/utilsunx.cpp:678
+msgid "Fork failed"
+msgstr "फ़ार्क असफ़ल रहा"
+
+#: ../src/unix/utilsunx.cpp:701
+#, fuzzy
+msgid "Failed to set process priority"
+msgstr "%d थ्रेड वरीयता को स्थापित करने में असफ़ल।"
+
+#: ../src/unix/utilsunx.cpp:712
+msgid "Failed to redirect child process input/output"
+msgstr "बाल प्रोसेस इनपुट/आउटपुट को दिशानिर्देश देने में असफ़ल"
+
+#: ../src/unix/utilsunx.cpp:816
+msgid "Failed to set up non-blocking pipe, the program might hang."
+msgstr ""
+
+#: ../src/unix/utilsunx.cpp:1023
+msgid "Cannot get the hostname"
+msgstr "होस्टनाम को प्राप्त नहीं किया जा सका"
+
+#: ../src/unix/utilsunx.cpp:1059
+msgid "Cannot get the official hostname"
+msgstr "अधिकारिक होस्टनाम को प्राप्त नहीं किया जा सका"
+
+#: ../src/unix/wakeuppipe.cpp:49
+#, fuzzy
+msgid "Failed to create wake up pipe used by event loop."
+msgstr "एक स्थिति पट्टी का निर्माण करने में असफ़ल।"
+
+#: ../src/unix/wakeuppipe.cpp:56
+msgid "Failed to switch wake up pipe to non-blocking mode"
+msgstr ""
+
+#: ../src/unix/wakeuppipe.cpp:117
+#, fuzzy
+msgid "Failed to read from wake-up pipe"
+msgstr "लॉक फ़ाइल से पीआईडी को पढ़ने में असफ़ल।"
+
+#: ../src/x11/app.cpp:124
+#, c-format
+msgid "Invalid geometry specification '%s'"
+msgstr "अवैध जयामिति विशिष्टतायें '%s'"
+
+#: ../src/x11/app.cpp:167
+msgid "wxWidgets could not open display. Exiting."
+msgstr "wxWidgets के लिए अवलोकन को खोल नहीं पाया: बाहर निकल रहा है।"
+
+#: ../src/x11/utils.cpp:169
+#, c-format
+msgid "Failed to close the display \"%s\""
+msgstr "डिस्प्ले \"%s\" को बन्द करने में असफ़ल।"
+
+#: ../src/x11/utils.cpp:188
+#, c-format
+msgid "Failed to open display \"%s\"."
+msgstr "प्रदर्श युक्ति \"%s\" को खोलने में असफ़ल।"
+
+#: ../src/xml/xml.cpp:868
+#, c-format
+msgid "XML parsing error: '%s' at line %d"
+msgstr "एक्सएम एल पदभंजन त्रुटि: '%s' %d पंक्ति पर"
+
+#: ../src/xrc/xh_propgrid.cpp:239
+#, fuzzy, c-format
+msgid "Page %i"
+msgstr "पृष्ट %d"
+
+#: ../src/xrc/xmlres.cpp:448
+#, fuzzy, c-format
+msgid "Cannot load resources from '%s'."
+msgstr "'%s' फ़ाइल से स्रोत संसाधनों को नहीं लाया जा सकता है।"
+
+#: ../src/xrc/xmlres.cpp:799
+#, fuzzy, c-format
+msgid "Cannot open resources file '%s'."
+msgstr "'%s' फ़ाइल से स्रोत संसाधनों को नहीं लाया जा सकता है।"
+
+#: ../src/xrc/xmlres.cpp:806
+#, c-format
+msgid "Cannot load resources from file '%s'."
+msgstr "'%s' फ़ाइल से स्रोत संसाधनों को नहीं लाया जा सकता है।"
+
+#: ../src/xrc/xmlres.cpp:2767
+#, fuzzy, c-format
+msgid "Creating %s \"%s\" failed."
+msgstr "'%s' का निष्कर्षण '%s' में असफ़ल रहा।"
+
+#, fuzzy
+#~ msgctxt "keyboard key"
+#~ msgid "Alt+"
+#~ msgstr "Alt-"
+
+#, fuzzy
+#~ msgctxt "keyboard key"
+#~ msgid "Ctrl+"
+#~ msgstr "Ctrl-"
+
+#, fuzzy
+#~ msgctxt "keyboard key"
+#~ msgid "Shift+"
+#~ msgstr "Shift-"
+
+#, fuzzy
+#~ msgctxt "keyboard key"
+#~ msgid "RawCtrl+"
+#~ msgstr "Ctrl-"
+
+#~ msgid "Unsupported clipboard format."
+#~ msgstr "असमर्थित क्लिपबोर्ड प्रारूप।"
+
+#~ msgid "Background colour"
+#~ msgstr "पृष्टभूमि रंग"
+
+#~ msgid "Font:"
+#~ msgstr "फ़ॉन्ट:"
+
+#~ msgid "Size:"
+#~ msgstr "आकार:"
+
+#~ msgid "The font size in points."
+#~ msgstr "फ़ॉन्ट का आकार बिंदुओं में।"
+
+#~ msgid "Style:"
+#~ msgstr "शैली:"
+
+#~ msgid "Colour:"
+#~ msgstr "रंग:"
+
+#~ msgid "Shows a preview of the font."
+#~ msgstr "फ़ॉन्ट का पूर्वालोकन दिखाएँ।"
+
+#~ msgid "<Any>"
+#~ msgstr "<कोई भी>"
+
+#~ msgid "<Any Roman>"
+#~ msgstr "<कोई रोमन>"
+
+#~ msgid "<Any Decorative>"
+#~ msgstr "<कोई साज-सजावट>"
+
+#~ msgid "<Any Modern>"
+#~ msgstr "<कोई आधुनिक>"
+
+#~ msgid "<Any Script>"
+#~ msgstr "<कोई लिपि>"
+
+#~ msgid "<Any Swiss>"
+#~ msgstr "<कोई स्वीस>"
+
+#~ msgid "<Any Teletype>"
+#~ msgstr "<कोई टेलीटाइप>"
+
+#~ msgid "Printing "
+#~ msgstr "मुद्रण हो रहा है "
+
+#, fuzzy
+#~ msgid "Failed to insert text in the control."
+#~ msgstr "कार्यशील निर्देशिका को प्राप्त करने में असफ़ल"
+
+#~ msgid "Please choose a valid font."
+#~ msgstr "कॄपया एक वैध फ़ॉन्ट का चयन करें।"
+
+#, c-format
+#~ msgid "Failed to display HTML document in %s encoding"
+#~ msgstr "एचटीएमएल प्रलेख को %s एन्कोडिंग में दिखाने में असफ़ल"
+
+#, c-format
+#~ msgid "wxWidgets could not open display for '%s': exiting."
+#~ msgstr "wxWidgets '%s' के लिए अवलोकन को खोल नहीं पाया: बाहर निकल रहा है।"
+
+#~ msgid "Filter"
+#~ msgstr "फ़िल्टर"
+
+#~ msgid "Directories"
+#~ msgstr "निर्देशिकाओं"
+
+#~ msgid "Files"
+#~ msgstr "फ़ाइलें"
+
+#~ msgid "Selection"
+#~ msgstr "चयन"
+
+#, fuzzy
+#~ msgid "failed to retrieve execution result"
+#~ msgstr "आरऐएस त्रुटि संदेश के पाठ को पुनःप्राप्त करने में असफ़ल"
+
+#, fuzzy
+#~ msgid "&Save as"
+#~ msgstr "जैसा सुरक्षित करें"
+
+#, fuzzy
+#~ msgid "'%s' doesn't consist only of valid characters"
+#~ msgstr "'%s' में सिर्फ़ आल्फ़ाबेटिक अक्षरों को ही सम्मिलित होना चाहिए।"
+
+#~ msgid "'%s' should be numeric."
+#~ msgstr "'%s' को एक संख्या होना चाहिए।"
+
+#~ msgid "'%s' should only contain ASCII characters."
+#~ msgstr "'%s' में सिर्फ़ आस्की अक्षरों को ही सम्मिलित होना चाहिए।"
+
+#~ msgid "'%s' should only contain alphabetic characters."
+#~ msgstr "'%s' में सिर्फ़ आल्फ़ाबेटिक अक्षरों को ही सम्मिलित होना चाहिए।"
+
+#~ msgid "'%s' should only contain alphabetic or numeric characters."
+#~ msgstr "'%s' में सिर्फ़ आल्फ़ाबेटिक या न्यूमेरिक अक्षरों को ही सम्मिलित होना चाहिए।"
+
+#, fuzzy
+#~ msgid "'%s' should only contain digits."
+#~ msgstr "'%s' में सिर्फ़ आस्की अक्षरों को ही सम्मिलित होना चाहिए।"
+
+#~ msgid "Can't create window of class %s"
+#~ msgstr "%s वर्ग की खिड़की का निर्माण नहीं किया जा सकता है"
+
+#, fuzzy
+#~ msgid "Couldn't create the overlay window"
+#~ msgstr "एक समय-सचेतक का निर्माण नहीं किया जा सका"
+
+#, fuzzy
+#~ msgid "Couldn't init the context on the overlay window"
+#~ msgstr "वर्तमान थ्रेड सूचक को प्राप्त नहीं किया जा सका"
+
+#~ msgid "Failed to convert file \"%s\" to Unicode."
+#~ msgstr "फ़ाइल  \"%s\" को यूनिकोड में बदलने में असफ़ल।"
+
+#, fuzzy
+#~ msgid "Failed to set text in the text control."
+#~ msgstr "यूटीसी तंत्र समय प्राप्त करने में असफ़ल।"
+
+#~ msgid "No unused colour in image."
+#~ msgstr "आकृति में कोई बिना उपयोग किया हुआ रंग नहीं हें।"
+
+#, fuzzy
+#~ msgid "Not available"
+#~ msgstr "संकेत उपलब्ध नहीं हैं, क्षमा करें!"
+
+#~ msgid "Replace selection"
+#~ msgstr "चयन बदलें"
+
+#~ msgid "Save as"
+#~ msgstr "जैसा सुरक्षित करें"
+
+#~ msgid "locale '%s' cannot be set."
+#~ msgstr "'%s' लोकेल को स्थापित नहीं किया जा सका।"
+
+#, fuzzy
+#~ msgid "Column index not found."
+#~ msgstr "सहायता फ़ाइल \"%s\" नहीं मिली।"
+
+#~ msgid "Confirm registry update"
+#~ msgstr "रजिस्ट्री अपडेट के लिए संपुष्टी दें"
+
+#, fuzzy
+#~ msgid "Could not determine column index."
+#~ msgstr "प्रलेख पूर्वालोकन को आरम्भ नहीं किया जा सका।"
+
+#, fuzzy
+#~ msgid "Could not determine number of items"
+#~ msgstr "'%s' फ़ाइल का स्थान नहीं खोजा जा सका।"
+
+#, fuzzy
+#~ msgid "Could not get header description."
+#~ msgstr "मुद्रण को आरम्भ नहीं किया जा सका।"
+
+#, fuzzy
+#~ msgid "Could not get items."
+#~ msgstr "'%s' फ़ाइल का स्थान नहीं खोजा जा सका।"
+
+#, fuzzy
+#~ msgid "Could not get property flags."
+#~ msgstr "'%s' अस्थायी फ़ाइल का निर्माण नहीं हो सका"
+
+#, fuzzy
+#~ msgid "Could not get selected items."
+#~ msgstr "'%s' फ़ाइल का स्थान नहीं खोजा जा सका।"
+
+#, fuzzy
+#~ msgid "Could not remove column."
+#~ msgstr "कर्सर का निर्माण नहीं किया जा सका।"
+
+#, fuzzy
+#~ msgid "Could not retrieve number of items"
+#~ msgstr "'%s' अस्थायी फ़ाइल का निर्माण नहीं हो सका"
+
+#, fuzzy
+#~ msgid "Could not set column width."
+#~ msgstr "प्रलेख पूर्वालोकन को आरम्भ नहीं किया जा सका।"
+
+#, fuzzy
+#~ msgid "Could not set header description."
+#~ msgstr "मुद्रण को आरम्भ नहीं किया जा सका।"
+
+#, fuzzy
+#~ msgid "Could not set icon."
+#~ msgstr "मुद्रण को आरम्भ नहीं किया जा सका।"
+
+#, fuzzy
+#~ msgid "Could not set maximum width."
+#~ msgstr "मुद्रण को आरम्भ नहीं किया जा सका।"
+
+#, fuzzy
+#~ msgid "Could not set minimum width."
+#~ msgstr "मुद्रण को आरम्भ नहीं किया जा सका।"
+
+#, fuzzy
+#~ msgid "Could not set property flags."
+#~ msgstr "मुद्रण को आरम्भ नहीं किया जा सका।"
+
+#~ msgid ""
+#~ "Do you want to overwrite the command used to %s files with extension "
+#~ "\"%s\" ?\n"
+#~ "Current value is \n"
+#~ "%s, \n"
+#~ "New value is \n"
+#~ "%s %1"
+#~ msgstr ""
+#~ "%s फ़ाइलों, जो कि \"%s उपनामों वाली है, के लिए उपयोग में लाये जाने वाले इस निर्देश को "
+#~ "बदल कर लिखना चाहते है\" ?\n"
+#~ "वर्तमान वैल्यू निम्न है \n"
+#~ "%s, \n"
+#~ "नयी वैल्यू निम्न है \n"
+#~ "%s %1"
+
+#~ msgid "Failed to retrieve data from the clipboard."
+#~ msgstr "क्लिपबोर्ड से डाटा को पुनःप्राप्त करने में असफ़ल।"
+
+#~ msgid "GIF: Invalid gif index."
+#~ msgstr "जीआईएफ़: अवैध जीआईएफ़ इंडेक्स।"
+
+#~ msgid "GIF: unknown error!!!"
+#~ msgstr "जीआईएफ़: अज्ञात त्रुटि!!!"
+
+#~ msgid "New directory"
+#~ msgstr "नयी निर्देशिका"
+
+#~ msgid "Next"
+#~ msgstr "अगला"
+
+#~ msgid ""
+#~ "Please install a newer version of comctl32.dll\n"
+#~ "(at least version 4.70 is required but you have %d.%02d)\n"
+#~ "or this program won't operate correctly."
+#~ msgstr ""
+#~ "कॄपया comctl32.dll का एक नये संस्मरण का संसाधन करें\n"
+#~ "(कम-से-कम ४।७० संस्मरण की आवश्यकता है परन्तु आपके पास %d.%02d है)\n"
+#~ "अन्यथा यह कार्यक्रम भली-भांति नहीं चलेगा।"
+
+#, fuzzy
+#~ msgid "Rendering failed."
+#~ msgstr "समयसंचेतक का निर्माण असफ़ल रहा।"
+
+#~ msgid "Show hidden directories"
+#~ msgstr "छुपी हुई निर्देशिकाओं को दिखाएँ"
+
+#~ msgid "Too many colours in PNG, the image may be slightly blurred."
+#~ msgstr "पीएनजी में बहुत सारे रंग, यह आकॄति थोड़ी सी धूमल हो सकती है।"
+
+#, fuzzy
+#~ msgid "Unable to initialize Hildon program"
+#~ msgstr "ओपनजीएल का आरम्भीकरण करने में असफ़ल।"
+
+#, fuzzy
+#~ msgid "Unknown data format"
+#~ msgstr "डाटा प्रारूप में त्रुटि"
+
+#~ msgid "Win32s on Windows 3.1"
+#~ msgstr "विण्डो ३.१ पर विन३२एस"
+
+#, fuzzy
+#~ msgid "Windows 10"
+#~ msgstr "विण्डो 98"
+
+#, fuzzy
+#~ msgid "Windows 2000"
+#~ msgstr "विण्डो 95"
+
+#, fuzzy
+#~ msgid "Windows 7"
+#~ msgstr "विण्डो 95"
+
+#, fuzzy
+#~ msgid "Windows 8"
+#~ msgstr "विण्डो 98"
+
+#, fuzzy
+#~ msgid "Windows 8.1"
+#~ msgstr "विण्डो 98"
+
+#~ msgid "Windows 95"
+#~ msgstr "विण्डो 95"
+
+#~ msgid "Windows 95 OSR2"
+#~ msgstr "विण्डो 95 OSR2"
+
+#~ msgid "Windows 98"
+#~ msgstr "विण्डो 98"
+
+#~ msgid "Windows 98 SE"
+#~ msgstr "विण्डो 98 एस ई"
+
+#~ msgid "Windows 9x (%d.%d)"
+#~ msgstr "विण्डो 9x (%d.%d)"
+
+#~ msgid "Windows CE (%d.%d)"
+#~ msgstr "विण्डो CE (%d.%d)"
+
+#~ msgid "Windows ME"
+#~ msgstr "विण्डो एम ई"
+
+#, fuzzy
+#~ msgid "Windows NT %lu.%lu"
+#~ msgstr "विण्डो एन टी %lu.%lu (निर्माण %lu"
+
+#, fuzzy
+#~ msgid "Windows Server 10"
+#~ msgstr "विण्डो सर्वर २00३ (निर्माण %lu"
+
+#, fuzzy
+#~ msgid "Windows Server 2003"
+#~ msgstr "विण्डो सर्वर २00३ (निर्माण %lu"
+
+#, fuzzy
+#~ msgid "Windows Server 2008"
+#~ msgstr "विण्डो सर्वर २00३ (निर्माण %lu"
+
+#, fuzzy
+#~ msgid "Windows Server 2008 R2"
+#~ msgstr "विण्डो सर्वर २00३ (निर्माण %lu"
+
+#, fuzzy
+#~ msgid "Windows Server 2012"
+#~ msgstr "विण्डो सर्वर २00३ (निर्माण %lu"
+
+#, fuzzy
+#~ msgid "Windows Server 2012 R2"
+#~ msgstr "विण्डो सर्वर २00३ (निर्माण %lu"
+
+#, fuzzy
+#~ msgid "Windows Vista"
+#~ msgstr "विण्डो 95"
+
+#, fuzzy
+#~ msgid "Windows XP"
+#~ msgstr "विण्डो 95"
+
+#~ msgid "can't execute '%s'"
+#~ msgstr "'%s' का निष्पादन करने में असफ़ल"
+
+#~ msgid "error opening '%s'"
+#~ msgstr "'%s' खोलने में त्रुटि"
+
+#~ msgid "unknown seek origin"
+#~ msgstr "अज्ञात खोज मूल"
+
+#~ msgid "ADD"
+#~ msgstr "ADD"
+
+#~ msgid "BACK"
+#~ msgstr "BACK"
+
+#~ msgid "CANCEL"
+#~ msgstr "CANCEL"
+
+#~ msgid "CAPITAL"
+#~ msgstr "CAPITAL"
+
+#~ msgid "CLEAR"
+#~ msgstr "CLEAR"
+
+#~ msgid "COMMAND"
+#~ msgstr "COMMAND"
+
+#~ msgid "Cannot create mutex."
+#~ msgstr "म्यूटेक्स का निर्माण नहीं किया जा सकता है।"
+
+#~ msgid "Cannot resume thread %lu"
+#~ msgstr "%lu थ्रेड को समान-बिन्दु से पुनः आरम्भ नहीं किया जा सकता है"
+
+#~ msgid "Cannot suspend thread %lu"
+#~ msgstr "%lu थ्रेड को अधर में नहीं छोड़ा जा सकता है"
+
+#~ msgid "Couldn't acquire a mutex lock"
+#~ msgstr "एक म्यूटेक्स लॉक को नहीं पाया नहीं जा सका"
+
+#~ msgid "Couldn't release a mutex"
+#~ msgstr "एक म्यूटेक्स को छोड़ा नहीं जा सका"
+
+#~ msgid "DECIMAL"
+#~ msgstr "DECIMAL"
+
+#~ msgid "DEL"
+#~ msgstr "DEL"
+
+#~ msgid "DELETE"
+#~ msgstr "DELETE"
+
+#~ msgid "DIVIDE"
+#~ msgstr "DIVIDE"
+
+#~ msgid "DOWN"
+#~ msgstr "DOWN"
+
+#~ msgid "END"
+#~ msgstr "END"
+
+#~ msgid "ENTER"
+#~ msgstr "ENTER"
+
+#~ msgid "ESC"
+#~ msgstr "ESC"
+
+#~ msgid "ESCAPE"
+#~ msgstr "ESCAPE"
+
+#~ msgid "EXECUTE"
+#~ msgstr "EXECUTE"
+
+#~ msgid "Execution of command '%s' failed with error: %ul"
+#~ msgstr "'%s' निर्देश का निष्पादन त्रुटि के साथ असफ़ल रहा: %ul"
+
+#~ msgid ""
+#~ "File '%s' already exists.\n"
+#~ "Do you want to replace it?"
+#~ msgstr ""
+#~ "'%s' फ़ाइल पहिले से विद्यमान है।\n"
+#~ "क्या आप इसे बदलना चाहते है?"
+
+#~ msgid "HELP"
+#~ msgstr "HELP"
+
+#~ msgid "HOME"
+#~ msgstr "HOME"
+
+#~ msgid "INS"
+#~ msgstr "INS"
+
+#~ msgid "INSERT"
+#~ msgstr "INSERT"
+
+#~ msgid "KP_BEGIN"
+#~ msgstr "KP_BEGIN"
+
+#~ msgid "KP_DECIMAL"
+#~ msgstr "KP_DECIMAL"
+
+#~ msgid "KP_DELETE"
+#~ msgstr "KP_DELETE"
+
+#~ msgid "KP_DIVIDE"
+#~ msgstr "KP_DIVIDE"
+
+#~ msgid "KP_DOWN"
+#~ msgstr "KP_DOWN"
+
+#~ msgid "KP_ENTER"
+#~ msgstr "KP_ENTER"
+
+#~ msgid "KP_EQUAL"
+#~ msgstr "KP_EQUAL"
+
+#~ msgid "KP_HOME"
+#~ msgstr "KP_HOME"
+
+#~ msgid "KP_INSERT"
+#~ msgstr "KP_INSERT"
+
+#~ msgid "KP_LEFT"
+#~ msgstr "KP_LEFT"
+
+#~ msgid "KP_MULTIPLY"
+#~ msgstr "KP_MULTIPLY"
+
+#~ msgid "KP_NEXT"
+#~ msgstr "KP_NEXT"
+
+#~ msgid "KP_PAGEDOWN"
+#~ msgstr "KP_PAGEDOWN"
+
+#~ msgid "KP_PAGEUP"
+#~ msgstr "KP_PAGEUP"
+
+#~ msgid "KP_PRIOR"
+#~ msgstr "KP_PRIOR"
+
+#~ msgid "KP_RIGHT"
+#~ msgstr "KP_RIGHT"
+
+#~ msgid "KP_SEPARATOR"
+#~ msgstr "KP_SEPARATOR"
+
+#~ msgid "KP_SPACE"
+#~ msgstr "KP_SPACE"
+
+#~ msgid "KP_SUBTRACT"
+#~ msgstr "KP_SUBTRACT"
+
+#~ msgid "LEFT"
+#~ msgstr "LEFT"
+
+#~ msgid "MENU"
+#~ msgstr "MENU"
+
+#~ msgid "NUM_LOCK"
+#~ msgstr "NUM_LOCK"
+
+#~ msgid "PAGEDOWN"
+#~ msgstr "PAGEDOWN"
+
+#~ msgid "PAGEUP"
+#~ msgstr "PAGEUP"
+
+#~ msgid "PAUSE"
+#~ msgstr "PAUSE"
+
+#~ msgid "PGDN"
+#~ msgstr "PGDN"
+
+#~ msgid "PGUP"
+#~ msgstr "PGUP"
+
+#~ msgid "PRINT"
+#~ msgstr "PRINT"
+
+#~ msgid "RETURN"
+#~ msgstr "RETURN"
+
+#~ msgid "RIGHT"
+#~ msgstr "RIGHT"
+
+#~ msgid "SCROLL_LOCK"
+#~ msgstr "SCROLL_LOCK"
+
+#~ msgid "SELECT"
+#~ msgstr "SELECT"
+
+#~ msgid "SEPARATOR"
+#~ msgstr "SEPARATOR"
+
+#~ msgid "SNAPSHOT"
+#~ msgstr "SNAPSHOT"
+
+#~ msgid "SPACE"
+#~ msgstr "SPACE"
+
+#~ msgid "SUBTRACT"
+#~ msgstr "SUBTRACT"
+
+#~ msgid "TAB"
+#~ msgstr "TAB"
+
+#~ msgid "Timer creation failed."
+#~ msgstr "समयसंचेतक का निर्माण असफ़ल रहा।"
+
+#~ msgid "UP"
+#~ msgstr "UP"
+
+#~ msgid "WINDOWS_LEFT"
+#~ msgstr "WINDOWS_LEFT"
+
+#~ msgid "WINDOWS_MENU"
+#~ msgstr "WINDOWS_MENU"
+
+#~ msgid "WINDOWS_RIGHT"
+#~ msgstr "WINDOWS_RIGHT"
+
+#~ msgid "Print preview"
+#~ msgstr "मुद्रण पूर्वालोकन"
+
+#~ msgid "1"
+#~ msgstr "१"
+
+#, fuzzy
+#~ msgid "10"
+#~ msgstr "१"
+
+#~ msgid "3"
+#~ msgstr "३"
+
+#~ msgid "4"
+#~ msgstr "४"
+
+#~ msgid "5"
+#~ msgstr "५"
+
+#~ msgid "6"
+#~ msgstr "६"
+
+#~ msgid "7"
+#~ msgstr "७"
+
+#~ msgid "8"
+#~ msgstr "८"
+
+#~ msgid "9"
+#~ msgstr "९"
+
+#, fuzzy
+#~ msgid "&Preview..."
+#~ msgstr " पूर्वालोकन"
+
+#, fuzzy
+#~ msgid "Preview..."
+#~ msgstr " पूर्वालोकन"
+
+#~ msgid "&Save..."
+#~ msgstr "सुरक्षित करें (&S)"
+
+#~ msgid "About "
+#~ msgstr "के बारे में"
+
+#~ msgid "All files (*.*)|*"
+#~ msgstr "सभी फ़ाइलें (*.*)|*"
+
+#~ msgid "Cannot initialize SciTech MGL!"
+#~ msgstr "SciTech MGL का आरम्भीकरण नहीं किया जा सकता है!"
+
+#~ msgid "Cannot initialize display."
+#~ msgstr "प्रदर्शन का आरम्भीकरण नहीं किया जा सकता है।"
+
+#~ msgid "Cannot start thread: error writing TLS"
+#~ msgstr "थ्रेड को आरम्भ नहीं किया जा सका: टीएलएस लेखन में त्रुटि"
+
+#~ msgid "Close\tAlt-F4"
+#~ msgstr "समाप्त\tAlt-F4"
+
+#~ msgid "Couldn't create cursor."
+#~ msgstr "कर्सर का निर्माण नहीं किया जा सका।"
+
+#~ msgid "Directory '%s' doesn't exist!"
+#~ msgstr "'%s' निर्देशिका विद्यमान नहीं है!"
+
+#~ msgid "Mode %ix%i-%i not available."
+#~ msgstr "%ix%i-%i विधा उपलब्ध नहीं।"
+
+#~ msgid "Paper Size"
+#~ msgstr "पृष्ट आकार"
+
+#~ msgid " Couldn't create the UnicodeConverter"
+#~ msgstr "यूनिकोड रूपांन्तरक का निर्माण नहीं किया जा सका"
+
+#~ msgid "#define %s must be an integer."
+#~ msgstr "#परिभाषा %s पूर्ण संख्या होना चाहिए।"
+
+#~ msgid "%.*f GB"
+#~ msgstr "%.*f जीबी"
+
+#~ msgid "%.*f MB"
+#~ msgstr "%.*f मेगाबाइट"
+
+#~ msgid "%.*f TB"
+#~ msgstr "%.*f टीबी"
+
+#~ msgid "%.*f kB"
+#~ msgstr "%.*f किलोबाईट"
+
+#~ msgid "%s B"
+#~ msgstr "%s बाईट"
+
+#~ msgid "%s not a bitmap resource specification."
+#~ msgstr "%s बिट्मैप संसाधन विशिष्टता नहीं हें।"
+
+#~ msgid "%s not an icon resource specification."
+#~ msgstr "%s आइकॉन संसाधन विशिष्टता नहीं हें।"
+
+#~ msgid "%s: ill-formed resource file syntax."
+#~ msgstr "%s: संसाधन फ़ाइल वाक्यविन्यास गलत हें।"
+
+#~ msgid "&Goto..."
+#~ msgstr "जाएँ (&G)..."
+
+#~ msgid "&Open"
+#~ msgstr "खोलें (&O)..."
+
+#~ msgid "&Print"
+#~ msgstr "मुद्रण (&P)"
+
+#~ msgid "<<"
+#~ msgstr "<<"
+
+#~ msgid ">>"
+#~ msgstr ">>"
+
+#~ msgid ">>|"
+#~ msgstr ">>।"
+
+#~ msgid "Archive doesnt contain #SYSTEM file"
+#~ msgstr "लेखागार में #SYSTEM फ़ाइल समाविष्ट नहीं हें"
+
+#~ msgid "BIG5"
+#~ msgstr "BIG5"
+
+#~ msgid "Bitmap resource specification %s not found."
+#~ msgstr "बिट्मैप संसाधन विशिष्टता '%s' नहीं मिली।"
+
+#~ msgid "Can't check image format of file '%s': file does not exist."
+#~ msgstr "'%s' फ़ाइल के आकृति प्रारूप की जाँच नहीं की जा सकती है: फ़ाइल विद्यमान नहीं है।"
+
+#~ msgid "Can't load image from file '%s': file does not exist."
+#~ msgstr "'%s' फ़ाइल से आकॄति को नहीं लाया जा सकता है: फ़ाइल विद्यमान नहीं है।"
+
+#~ msgid "Cannot convert dialog units: dialog unknown."
+#~ msgstr "संवाद इकाइयों को बदला नहीं जा सकता है: अज्ञात संवाद।"
+
+#~ msgid "Cannot convert from the charset '%s'!"
+#~ msgstr "'%s' शब्दसमुच्चय से बदला नहीं जा सकता है!"
+
+#~ msgid "Cannot find container for unknown control '%s'."
+#~ msgstr "'%s' अज्ञात नियंत्रण के लिए संग्रहक को खोजा नहीं जा सका।"
+
+#~ msgid "Cannot find font node '%s'."
+#~ msgstr "'%s' फ़ॉन्ट नोड को खोजा नहीं जा सका।"
+
+#~ msgid "Cannot open file '%s'."
+#~ msgstr "'%s' फ़ाइल को खोला नहीं जा सकता है।"
+
+#~ msgid "Cannot parse coordinates from '%s'."
+#~ msgstr "'%s' से दिशा-निर्देशों का पदभंजन नहीं किया जा सकता है।"
+
+#~ msgid "Cannot parse dimension from '%s'."
+#~ msgstr "'%s' से आयामों का पदभंजन नहीं किया जा सकता है।"
+
+#~ msgid "Cant create the thread event queue"
+#~ msgstr "थ्रेड घटना कतार का निर्माण नहीं किया जा सकता है"
+
+#~ msgid "Click to cancel this window."
+#~ msgstr "इस खिड़की को निरस्त करने के लिए क्लिक करें।"
+
+#~ msgid "Could not unlock mutex"
+#~ msgstr "म्यूटेक्स को छोड़ा नहीं जा सका"
+
+#, fuzzy
+#~ msgid "Couldn't end the context on the overlay window"
+#~ msgstr "वर्तमान थ्रेड सूचक को प्राप्त नहीं किया जा सका"
+
+#~ msgid "Failed to %s dialup connection: %s"
+#~ msgstr "%s डायल-अप कनेक्शन के लिए असफ़ल: %s"
+
+#~ msgid "Failed to get clipboard data."
+#~ msgstr "क्लिपबोर्ड डाटा को प्राप्त करने में असफ़ल।"
+
+#~ msgid "Failed to load shared library '%s' Error '%s'"
+#~ msgstr "'%s' साझा लायबरी को लोड करने में असफ़ल त्रुटि '%s'"
+
+#, fuzzy
+#~ msgid "Failed to register OpenGL window class."
+#~ msgstr "ओपनजीएल का आरम्भीकरण करने में असफ़ल।"
+
+#~ msgid "Fatal error: "
+#~ msgstr "घातक त्रुटि: "
+
+#~ msgid "Found "
+#~ msgstr "मिली"
+
+#~ msgid "GB-2312"
+#~ msgstr "GB-2312"
+
+#~ msgid "Goto Page"
+#~ msgstr "पृष्ट पर जाएँ"
+
+#~ msgid "I64"
+#~ msgstr "I64"
+
+#~ msgid "Icon resource specification %s not found."
+#~ msgstr "आइकॉन संसाधन विशिष्टता '%s' नहीं मिली।"
+
+#~ msgid "Ill-formed resource file syntax."
+#~ msgstr "संसाधन फ़ाइल वाक्यविन्यास गलत हें।"
+
+#~ msgid "Inserts the chosen symbol."
+#~ msgstr "चुना हुआ चिह्न डाल दे।"
+
+#~ msgid "Internal error, illegal wxCustomTypeInfo"
+#~ msgstr "आंतरिक त्रुटि, अवैध wxCustomTypeInfo"
+
+#~ msgid "Invalid XRC resource '%s': doesn't have root node 'resource'."
+#~ msgstr "अवैध एक्सआरसी स्रोत-साधन '%s': रूट नोड 'resource' नहीं रखता है।"
+
+#~ msgid "Long Conversions not supported"
+#~ msgstr "लंबे रूपान्तरण समर्थित नहीं है"
+
+#~ msgid "No handler found for XML node '%s', class '%s'!"
+#~ msgstr "एक्सएमएल नोड'%s', वर्ग '%s' के लिए कोई हैन्डलर नहीं मिला!"
+
+#~ msgid "No image handler for type %ld defined."
+#~ msgstr "%ld प्रकार के लिए कोई आकृति हैन्डलर परिभाषित नहीं।"
+
+#~ msgid "Option '%s' requires a value, '=' expected."
+#~ msgstr "'%s' विकल्प को एक वैल्यू की आवश्यकता है, '=' की आशा की जाती है।"
+
+#~ msgid "Passing a already registered object to SetObjectName"
+#~ msgstr "SetObjectName को एक पहिले से पंजीकॄत ऑबजेक्ट को दिया जा रहा है"
+
+#~ msgid "Program aborted."
+#~ msgstr "कार्यक्रम निरस्त हो गया।"
+
+#~ msgid "Referenced object node with ref=\"%s\" not found!"
+#~ msgstr "संदर्भित ऑबजेक्ट नोड ref=\"%s\" के साथ नहीं मिला!"
+
+#~ msgid "Resource files must have same version number!"
+#~ msgstr "स्रोतसाधन फ़ाइल को समान संस्मरण संख्या वाला होना चाहिए!"
+
+#~ msgid "SHIFT-JIS"
+#~ msgstr "SHIFT-JIS"
+
+#~ msgid "Select a file"
+#~ msgstr "एक फ़ाइल का चयन करें"
+
+#~ msgid "Select all"
+#~ msgstr "सभी का चयन"
+
+#~ msgid "Sorry, could not open this file for saving."
+#~ msgstr "क्षमा करें, इस फ़ाइल को सुरक्षित करने के लिए खोला नहीं जा सका।"
+
+#~ msgid "Sorry, could not save this file."
+#~ msgstr "क्षमा करें, इस फ़ाइल को सुरक्षित नहीं किया जा सका।"
+
+#~ msgid ""
+#~ "Sorry, docking is not supported for ports other than wxMSW, wxMac and "
+#~ "wxGTK"
+#~ msgstr "क्षमा करें, डॉकीन सिर्फ wxMSW, wxMac और wxGTK के लिए समर्थित हें।"
+
+#~ msgid "Sorry, print preview needs a printer to be installed."
+#~ msgstr "क्षमा करें, मुद्रण पूर्वालोकन को एक प्रिंटर को संसाधित करने की आवश्यकता है।"
+
+#~ msgid "Status: "
+#~ msgstr "अवस्था:"
+
+#~ msgid ""
+#~ "Streaming delegates for not already streamed objects not yet supported"
+#~ msgstr ""
+#~ "स्ट्रीमिंग डेलीगेटों को पहिले से धाराप्रवाहित ऑबजेक्टों के लिए अभी समर्थन प्राप्त नहीं है"
+
+#~ msgid "Subclass '%s' not found for resource '%s', not subclassing!"
+#~ msgstr ""
+#~ "'%s' उपवर्ग '%s' स्रोत संसाधन के लिए नहीं मिला, उपवर्गीकरण नहीं किया जा रहा है!"
+
+#~ msgid "TIFF library error."
+#~ msgstr "टीआईएफ़एफ़ लेखागार त्रुटि।"
+
+#~ msgid "TIFF library warning."
+#~ msgstr "टीआईएफ़एफ़ लेखागार चेतावनी।"
+
+#~ msgid ""
+#~ "The file '%s' couldn't be opened.\n"
+#~ "It has been removed from the most recently used files list."
+#~ msgstr ""
+#~ "'%s' फ़ाइल को खोला नहीं जा सका।\n"
+#~ "इसे हाल ही में उपयोग में लायी गयी हुई फ़ाइलों की सूची में से हटा दिया गया है।"
+
+#~ msgid "The path '%s' contains too many \"..\"!"
+#~ msgstr "इस पथ '%s' में बहुत सारे \"..\" सम्मिलित है!"
+
+#~ msgid "Trying to solve a NULL hostname: giving up"
+#~ msgstr "एक रिक्त होस्टनाम को बूझने का प्रयास किया जा रहा है: छोड़ रहा हूँ"
+
+#~ msgid "Unexpected end of file while parsing resource."
+#~ msgstr "अनपेक्षित फ़ाइल अंत, संसाधन पदच्छेदन के समय"
+
+#~ msgid "Unknown style flag "
+#~ msgstr "अज्ञात शैली ध्वज "
+
+#~ msgid "Version %s"
+#~ msgstr "संस्मरण %s"
+
+#~ msgid "Video Output"
+#~ msgstr "विडियो आउटपुट"
+
+#~ msgid "Warning"
+#~ msgstr "चेतावनी"
+
+#~ msgid "Warning: attempt to remove HTML tag handler from empty stack."
+#~ msgstr "चेतावनी: खाली स्टैक से एचटीएमएल टैग हैन्डलर को हटाने का प्रयास ।"
+
+#~ msgid "Windows 2000 (build %lu"
+#~ msgstr "विण्डो २000 (निर्माण %lu"
+
+#~ msgid "XRC resource '%s' (class '%s') not found!"
+#~ msgstr "एक्सआरसी स्रोत संसाधन '%s' (वर्ग '%s') नहीं मिला!"
+
+#, fuzzy
+#~ msgid "XRC resource: Cannot create animation from '%s'."
+#~ msgstr "एक्सआरसी स्रोत संसाधन: '%s' से बिट्मैप का निर्माण किया जा सका।"
+
+#~ msgid "XRC resource: Cannot create bitmap from '%s'."
+#~ msgstr "एक्सआरसी स्रोत संसाधन: '%s' से बिट्मैप का निर्माण किया जा सका।"
+
+#~ msgid "XRC resource: Incorrect colour specification '%s' for property '%s'."
+#~ msgstr "एक्सआरसी स्रोतसाधन: गलत रंग विशिष्टता '%s' गुणधर्म '%s' के लिए।"
+
+#~ msgid "[EMPTY]"
+#~ msgstr "[रिक्त]"
+
+#~ msgid "catalog file for domain '%s' not found."
+#~ msgstr "'%s' डोमेन के लिए सूचीपत्र फ़ाइल नहीं मिली।"
+
+#~ msgid "delegate has no type info"
+#~ msgstr "डेलीगेट के पास कोई प्रकार सूचना नहीं है"
+
+#~ msgid "encoding %i"
+#~ msgstr "encoding %i"
+
+#~ msgid "establish"
+#~ msgstr "स्थापित"
+
+#~ msgid "initiate"
+#~ msgstr "शुरू करें"
+
+#~ msgid "invalid eof() return value."
+#~ msgstr "eof()  की रीटर्न वैल्यू अवैध।"
+
+#~ msgid "looking for catalog '%s' in path '%s'."
+#~ msgstr "'%s' सूचीपत्र के लिए '%s' पथ में देखा जा रहा है।"
+
+#~ msgid "unknown line terminator"
+#~ msgstr "अज्ञात पंक्ति टर्मिनेटर"
+
+#~ msgid "writing"
+#~ msgstr "लिखा जा रहा है"
+
+#~ msgid "wxRichTextBulletsPage"
+#~ msgstr "wxRichTextBulletsPage"
+
+#~ msgid "wxRichTextFontPage"
+#~ msgstr "wxRichTextFontPage"
+
+#~ msgid "wxRichTextListStylePage"
+#~ msgstr "wxRichTextListStylePage"
+
+#~ msgid "wxRichTextStylePage"
+#~ msgstr "wxRichTextStylePage"
+
+#~ msgid "wxSocket: invalid signature in ReadMsg."
+#~ msgstr "wxSocket: ReadMsg में अवैध हस्ताक्षर।"
+
+#~ msgid "wxSocket: unknown event!."
+#~ msgstr "wxSocket: अज्ञात घटना!"
+
+#~ msgid "|<<"
+#~ msgstr "।<<"
+
+#, fuzzy
+#~ msgid "Help : %s"
+#~ msgstr "सहायता: %s"
+
+#, fuzzy
+#~ msgid "Search!"
+#~ msgstr "खोजें"
+
+#~ msgid "."
+#~ msgstr "."
+
+#~ msgid "Cannot open URL '%s'"
+#~ msgstr "'%s' यूआरएल को नहीं खोला जा सका"
+
+#~ msgid "Error "
+#~ msgstr "त्रुटि "
+
+#~ msgid "Failed to create directory %s/.gnome."
+#~ msgstr "%s/.gnome निर्देशिका का निर्माण करने में असफ़ल।"
+
+#~ msgid "Failed to create directory %s/mime-info."
+#~ msgstr "%s/mime-info निर्देशिका का निर्माण करने में असफ़ल।"
+
+#~ msgid "Mailcap file %s, line %d: incomplete entry ignored."
+#~ msgstr "मेलकैप फ़ाइल %s, लाइन %d: अधूरी प्रविष्टी पर ध्यान नहीं दिया गया।"
+
+#~ msgid "Mime.types file %s, line %d: unterminated quoted string."
+#~ msgstr "माइम.टाइप्स फ़ाइल %s, लाइन %d: असमाप्त क्वोट श्रेणी।"
+
+#~ msgid "Unknown field in file %s, line %d: '%s'."
+#~ msgstr "%s फ़ाइल में %d पंक्ति पर अज्ञात प्रविष्टी: '%s'।"
+
+#~ msgid "bold "
+#~ msgstr "गहरा "
+
+#~ msgid "can't query for GUI plugins name in console applications"
+#~ msgstr "कन्सोल ऐप्लीकेशनो में जीयूआई प्लग-इनों के नाम के लिए पूछा नहीं जा सकता है"
+
+#~ msgid "light "
+#~ msgstr "हल्का "
+
+#~ msgid "underlined "
+#~ msgstr "रेखांकित "
+
+#, fuzzy
+#~ msgid "unsupported zip archive"
+#~ msgstr "जीज़िप शीर्ष में असमर्थित ध्वज"
+
+#, fuzzy
+#~ msgid ""
+#~ "Failed to get stack backtrace:\n"
+#~ "%s"
+#~ msgstr "आईएसपी नामों को प्राप्त करने में असफ़ल: %s"
+
+#~ msgid "Loading Grey Ascii PNM image is not yet implemented."
+#~ msgstr ""
+#~ "ग्रे आस्की पीएनएम आकृति का लोड किया जाना अभी तक क्रियान्वित नहीं किया गया है।"
+
+#~ msgid "Loading Grey Raw PNM image is not yet implemented."
+#~ msgstr "ग्रे रॉ पीएनएम आकृति का लोड किया जाना अभी तक क्रियान्वित नहीं किया गया है।"
+
+#, fuzzy
+#~ msgid "Cannot wait on thread to exit."
+#~ msgstr "थ्रेड समाप्ति की प्रतीक्षा नहीं की जा सकती है"
+
+#~ msgid "Could not load Rich Edit DLL '%s'"
+#~ msgstr "'%s' रिच ऐडिट डीएलएल को नहीं लोड किया जा सका"
+
+#~ msgid "ZIP handler currently supports only local files!"
+#~ msgstr "ज़िप हैन्डलर वर्तमान में सिर्फ़ स्थानीय फ़ाइलों को ही समर्थित करता है!"
+
+#, fuzzy
+#~ msgid ""
+#~ "can't seek on file descriptor %d, large files support is not enabled."
+#~ msgstr "फ़ाइल विवरणकर्ता %d पर खोज नहीं की जा सकती है"
+
+#~ msgid "More..."
+#~ msgstr "और अधिक..."
+
+#~ msgid "Setup"
+#~ msgstr "स्थापना"
+
+#~ msgid "/#SYSTEM"
+#~ msgstr "/#SYSTEM"
+
+#~ msgid "Backward"
+#~ msgstr "पीछे की ओर"
+
+#~ msgid "GetUnusedColour:: No Unused Color in image "
+#~ msgstr "GetUnusedColour:: आकॄति में कोई बिनाउपयोग का रंग नहीं "
+
+#~ msgid ""
+#~ "Can't create list control window, check that comctl32.dll is installed."
+#~ msgstr ""
+#~ "सूची नियंत्रण खिड़की का निर्माण नहीं किया जा सकता है, जाँच करें कि comctl32.dll "
+#~ "संसाधित है।"
+
+#~ msgid "Can't delete value of key '%s'"
+#~ msgstr "'%s' कुँजी के मूल्य को हटाया नहीं जा सकता है"
+
+#~ msgid "gmtime() failed"
+#~ msgstr "gmtime() असफ़ल रहा"
+
+#~ msgid "mktime() failed"
+#~ msgstr "mktime() असफ़ल रहा"
+
+#~ msgid "Invalid display mode । '%s'."
+#~ msgstr "अवैध अवलोकन विधा । '%s' ।"

--- a/po_wxstd/hr.po
+++ b/po_wxstd/hr.po
@@ -1,0 +1,9456 @@
+# Croatian translations for wxWidgets
+# Copyright (C) 2019 wxWidgets
+# This file is distributed under the same license as the wxWidgets package.
+# Milo Ivir <mail@milotype.de>, 2019.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: wxWidgets 3.3.x\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-05-14 20:23+0200\n"
+"PO-Revision-Date: 2023-05-14 14:24+0200\n"
+"Last-Translator: Milo Ivir <mail@milotype.de>\n"
+"Language-Team: \n"
+"Language: hr\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"n%10<=4 && (n%100<12 || n%100>14) ? 1 : 2);\n"
+"X-Generator: Poedit 3.0\n"
+
+#: ../include/wx/defs.h:2582
+msgid "All files (*.*)|*.*"
+msgstr "Sve datoteke (*.*)|*.*"
+
+#: ../include/wx/defs.h:2585
+msgid "All files (*)|*"
+msgstr "Sve datoteke (*)|*"
+
+#: ../include/wx/generic/progdlgg.h:85
+msgid "Elapsed time:"
+msgstr "Proteklo vrijeme:"
+
+#: ../include/wx/generic/progdlgg.h:86
+msgid "Estimated time:"
+msgstr "Procijenjeno vrijeme:"
+
+#: ../include/wx/generic/progdlgg.h:87
+msgid "Remaining time:"
+msgstr "Preostalo vrijeme:"
+
+#. TRANSLATORS: HTML printout default title.
+#: ../include/wx/html/htmprint.h:121 ../include/wx/prntbase.h:273
+#: ../include/wx/richtext/richtextprint.h:109 ../src/common/docview.cpp:2161
+msgid "Printout"
+msgstr "Ispis"
+
+#. TRANSLATORS: HTML easy print default title.
+#: ../include/wx/html/htmprint.h:234 ../include/wx/richtext/richtextprint.h:163
+#: ../src/common/prntbase.cpp:522 ../src/html/htmprint.cpp:291
+msgid "Printing"
+msgstr "Ispisivanje"
+
+#: ../include/wx/msgdlg.h:277 ../src/common/stockitem.cpp:211
+msgid "Yes"
+msgstr "Da"
+
+#: ../include/wx/msgdlg.h:278 ../src/common/stockitem.cpp:182
+msgid "No"
+msgstr "Ne"
+
+#: ../include/wx/msgdlg.h:279 ../src/common/stockitem.cpp:183
+#: ../src/msw/msgdlg.cpp:430 ../src/msw/msgdlg.cpp:734
+#: ../src/richtext/richtextstyledlg.cpp:292
+msgid "OK"
+msgstr "U redu"
+
+#: ../include/wx/msgdlg.h:280 ../src/common/stockitem.cpp:150
+#: ../src/msw/msgdlg.cpp:430 ../src/msw/progdlg.cpp:884
+#: ../src/richtext/richtextstyledlg.cpp:295
+msgid "Cancel"
+msgstr "Odustani"
+
+#: ../include/wx/msgdlg.h:281 ../src/common/stockitem.cpp:168
+#: ../src/html/helpdlg.cpp:63 ../src/html/helpfrm.cpp:108
+#: ../src/osx/button_osx.cpp:38
+msgid "Help"
+msgstr "Pomoć"
+
+#: ../include/wx/msw/ole/oleutils.h:52
+msgid "Cannot initialize OLE"
+msgstr "Nije moguće inicijalizirati OLE"
+
+#: ../include/wx/msw/private/fswatcher.h:48
+#, c-format
+msgid "Unable to close the handle for '%s'"
+msgstr "Nije moguće zatvoriti upravljač za „%s”"
+
+#: ../include/wx/msw/private/fswatcher.h:92
+#, c-format
+msgid "Failed to open directory \"%s\" for monitoring."
+msgstr "Neuspjelo otvaranje mape „%s” za praćenje."
+
+#: ../include/wx/msw/private/fswatcher.h:125
+msgid "Unable to close I/O completion port handle"
+msgstr "Nije moguće stvoriti ručku završnog priključka ulaza/izlaza"
+
+#: ../include/wx/msw/private/fswatcher.h:142
+msgid "Unable to associate handle with I/O completion port"
+msgstr "Nije moguće povezati ručku sa završnim priključkom ulaza/izlaza"
+
+#: ../include/wx/msw/private/fswatcher.h:148
+msgid "Unexpectedly new I/O completion port was created"
+msgstr "Stvoren je neočekivani završni priključak ulaza/izlaza"
+
+#: ../include/wx/msw/private/fswatcher.h:213
+msgid "Unable to post completion status"
+msgstr "Nije moguće objaviti status svršetka"
+
+#: ../include/wx/msw/private/fswatcher.h:262
+msgid "Unable to dequeue completion packet"
+msgstr "Nije moguće odraditi dequeue za završni paket"
+
+#: ../include/wx/msw/private/fswatcher.h:273
+msgid "Unable to create I/O completion port"
+msgstr "Nije moguće stvoriti završni priključak ulaza/izlaza"
+
+#: ../include/wx/richmsgdlg.h:29
+msgid "&See details"
+msgstr "&Prikaži detalje"
+
+#: ../include/wx/richmsgdlg.h:30
+msgid "&Hide details"
+msgstr "&Sakrij detalje"
+
+#: ../include/wx/richtext/richtextbuffer.h:3864
+msgid "&Box"
+msgstr "&Okvir"
+
+#: ../include/wx/richtext/richtextbuffer.h:5008
+msgid "&Picture"
+msgstr "&Slika"
+
+#: ../include/wx/richtext/richtextbuffer.h:5958
+msgid "&Cell"
+msgstr "Ć&elija"
+
+#: ../include/wx/richtext/richtextbuffer.h:6067
+msgid "&Table"
+msgstr "&Tablica"
+
+#: ../include/wx/richtext/richtextimagedlg.h:37
+msgid "Object Properties"
+msgstr "Svojstva objekta"
+
+#: ../include/wx/richtext/richtextsymboldlg.h:39
+msgid "Symbols"
+msgstr "Simboli"
+
+#: ../include/wx/unix/pipe.h:46
+msgid "Pipe creation failed"
+msgstr "Stvaranje cjevovoda nije uspjelo"
+
+#: ../include/wx/unix/private/displayx11.h:65
+msgid "Failed to enumerate video modes"
+msgstr "Neuspjelo pobrojavanje video modusa"
+
+#: ../include/wx/unix/private/displayx11.h:89
+msgid "Failed to change video mode"
+msgstr "Neuspjelo mijenjanje video modusa"
+
+#: ../include/wx/unix/private/fswatcher_kqueue.h:57
+#, c-format
+msgid "Unable to open path '%s'"
+msgstr "Nije moguće otvoriti stazu „%s”"
+
+#: ../include/wx/unix/private/fswatcher_kqueue.h:74
+#, c-format
+msgid "Unable to close path '%s'"
+msgstr "Nije moguće zatvoriti stazu „%s”"
+
+#: ../include/wx/xtiprop.h:175
+msgid "SetProperty called w/o valid setter"
+msgstr "SetProperty je pozvano bez valjanog postavljača"
+
+#: ../include/wx/xtiprop.h:184
+msgid "GetProperty called w/o valid getter"
+msgstr "GetProperty je pozvano bez valjanog dobavljača"
+
+#: ../include/wx/xtiprop.h:193
+msgid "AddToPropertyCollection called w/o valid adder"
+msgstr "AddToPropertyCollection je pozvano bez valjanog dodavača"
+
+#: ../include/wx/xtiprop.h:202
+msgid "GetPropertyCollection called w/o valid collection getter"
+msgstr "GetPropertyCollection je pozvano bez valjanog dobavljača kolekcija"
+
+#: ../include/wx/xtiprop.h:255
+msgid "AddToPropertyCollection called on a generic accessor"
+msgstr "AddToPropertyCollection je pozvano na generički pristupnik"
+
+#: ../include/wx/xtiprop.h:262
+msgid "GetPropertyCollection called on a generic accessor"
+msgstr "GetPropertyCollection je pozvano na generički pristupnik"
+
+#: ../src/aui/tabmdi.cpp:106 ../src/generic/mdig.cpp:94
+msgid "Cl&ose"
+msgstr "Zatv&ori"
+
+#: ../src/aui/tabmdi.cpp:107 ../src/generic/mdig.cpp:95
+msgid "Close All"
+msgstr "Zatvori sve"
+
+#: ../src/aui/tabmdi.cpp:109 ../src/generic/mdig.cpp:97 ../src/msw/mdi.cpp:175
+#: ../src/qt/mdi.cpp:258
+msgid "&Next"
+msgstr "&Sljedeće"
+
+#: ../src/aui/tabmdi.cpp:110 ../src/generic/mdig.cpp:98 ../src/msw/mdi.cpp:176
+#: ../src/qt/mdi.cpp:259
+msgid "&Previous"
+msgstr "&Prethodno"
+
+#: ../src/aui/tabmdi.cpp:332 ../src/aui/tabmdi.cpp:348
+#: ../src/aui/tabmdi.cpp:350 ../src/generic/mdig.cpp:291
+#: ../src/generic/mdig.cpp:307 ../src/generic/mdig.cpp:311
+#: ../src/msw/mdi.cpp:337 ../src/qt/mdi.cpp:462
+msgid "&Window"
+msgstr "&Prozor"
+
+#: ../src/common/accelcmn.cpp:47
+msgctxt "keyboard key"
+msgid "Delete"
+msgstr "Izbriši"
+
+#: ../src/common/accelcmn.cpp:48
+msgctxt "keyboard key"
+msgid "Del"
+msgstr "Del"
+
+#: ../src/common/accelcmn.cpp:49
+msgctxt "keyboard key"
+msgid "Back"
+msgstr "Natrag"
+
+#: ../src/common/accelcmn.cpp:49
+msgctxt "keyboard key"
+msgid "Backspace"
+msgstr "Izbriši natraške"
+
+#: ../src/common/accelcmn.cpp:50
+msgctxt "keyboard key"
+msgid "Insert"
+msgstr "Umetni"
+
+#: ../src/common/accelcmn.cpp:51
+msgctxt "keyboard key"
+msgid "Ins"
+msgstr "Umetni"
+
+#: ../src/common/accelcmn.cpp:52
+msgctxt "keyboard key"
+msgid "Enter"
+msgstr "Unesi"
+
+#: ../src/common/accelcmn.cpp:53
+msgctxt "keyboard key"
+msgid "Return"
+msgstr "Potvrdi"
+
+#: ../src/common/accelcmn.cpp:54
+msgctxt "keyboard key"
+msgid "PageUp"
+msgstr "Stranica gore"
+
+#: ../src/common/accelcmn.cpp:54
+msgctxt "keyboard key"
+msgid "Page Up"
+msgstr "Stranica gore"
+
+#: ../src/common/accelcmn.cpp:55
+msgctxt "keyboard key"
+msgid "PageDown"
+msgstr "Stranica dolje"
+
+#: ../src/common/accelcmn.cpp:55
+msgctxt "keyboard key"
+msgid "Page Down"
+msgstr "Stranica dolje"
+
+#: ../src/common/accelcmn.cpp:56
+msgctxt "keyboard key"
+msgid "PgUp"
+msgstr "Stranica gore"
+
+#: ../src/common/accelcmn.cpp:57
+msgctxt "keyboard key"
+msgid "PgDn"
+msgstr "Stranica dolje"
+
+#: ../src/common/accelcmn.cpp:58
+msgctxt "keyboard key"
+msgid "Left"
+msgstr "Lijevo"
+
+#: ../src/common/accelcmn.cpp:59
+msgctxt "keyboard key"
+msgid "Right"
+msgstr "Desno"
+
+#: ../src/common/accelcmn.cpp:60
+msgctxt "keyboard key"
+msgid "Up"
+msgstr "Gore"
+
+#: ../src/common/accelcmn.cpp:61
+msgctxt "keyboard key"
+msgid "Down"
+msgstr "Dolje"
+
+#: ../src/common/accelcmn.cpp:62
+msgctxt "keyboard key"
+msgid "Home"
+msgstr "Početna"
+
+#: ../src/common/accelcmn.cpp:63
+msgctxt "keyboard key"
+msgid "End"
+msgstr "Kraj"
+
+#: ../src/common/accelcmn.cpp:64
+msgctxt "keyboard key"
+msgid "Space"
+msgstr "Razmaknica"
+
+#: ../src/common/accelcmn.cpp:65
+msgctxt "keyboard key"
+msgid "Tab"
+msgstr "Tabulator"
+
+#: ../src/common/accelcmn.cpp:66
+msgctxt "keyboard key"
+msgid "Esc"
+msgstr "Esc"
+
+#: ../src/common/accelcmn.cpp:67
+msgctxt "keyboard key"
+msgid "Escape"
+msgstr "Escape"
+
+#: ../src/common/accelcmn.cpp:68
+msgctxt "keyboard key"
+msgid "Cancel"
+msgstr "Odustani"
+
+#: ../src/common/accelcmn.cpp:69
+msgctxt "keyboard key"
+msgid "Clear"
+msgstr "Izbriši"
+
+#: ../src/common/accelcmn.cpp:70
+msgctxt "keyboard key"
+msgid "Menu"
+msgstr "Izbornik"
+
+#: ../src/common/accelcmn.cpp:71
+msgctxt "keyboard key"
+msgid "Pause"
+msgstr "Pauza"
+
+#: ../src/common/accelcmn.cpp:72
+msgctxt "keyboard key"
+msgid "Capital"
+msgstr "Verzali"
+
+#: ../src/common/accelcmn.cpp:73
+msgctxt "keyboard key"
+msgid "Select"
+msgstr "Odaberi"
+
+#: ../src/common/accelcmn.cpp:74
+msgctxt "keyboard key"
+msgid "Print"
+msgstr "Ispiši"
+
+#: ../src/common/accelcmn.cpp:75
+msgctxt "keyboard key"
+msgid "Execute"
+msgstr "Izvrši"
+
+#: ../src/common/accelcmn.cpp:76
+msgctxt "keyboard key"
+msgid "Snapshot"
+msgstr "Snimka zaslona"
+
+#: ../src/common/accelcmn.cpp:77
+msgctxt "keyboard key"
+msgid "Help"
+msgstr "Pomoć"
+
+#: ../src/common/accelcmn.cpp:78
+msgctxt "keyboard key"
+msgid "Add"
+msgstr "Dodaj"
+
+#: ../src/common/accelcmn.cpp:79
+msgctxt "keyboard key"
+msgid "Separator"
+msgstr "Razdvojnik"
+
+#: ../src/common/accelcmn.cpp:80
+msgctxt "keyboard key"
+msgid "Subtract"
+msgstr "Oduzmi"
+
+#: ../src/common/accelcmn.cpp:81
+msgctxt "keyboard key"
+msgid "Decimal"
+msgstr "Decimala"
+
+#: ../src/common/accelcmn.cpp:82
+msgctxt "keyboard key"
+msgid "Multiply"
+msgstr "Pomnoži"
+
+#: ../src/common/accelcmn.cpp:83
+msgctxt "keyboard key"
+msgid "Divide"
+msgstr "Dijeli"
+
+#: ../src/common/accelcmn.cpp:84
+msgctxt "keyboard key"
+msgid "Num_lock"
+msgstr "Num_lokot"
+
+#: ../src/common/accelcmn.cpp:84
+msgctxt "keyboard key"
+msgid "Num Lock"
+msgstr "Num lokot"
+
+#: ../src/common/accelcmn.cpp:85
+msgctxt "keyboard key"
+msgid "Scroll_lock"
+msgstr "Lokot klizača"
+
+#: ../src/common/accelcmn.cpp:85
+msgctxt "keyboard key"
+msgid "Scroll Lock"
+msgstr "Lokot klizača"
+
+#: ../src/common/accelcmn.cpp:86
+msgctxt "keyboard key"
+msgid "KP_Space"
+msgstr "BT_Razmaknica"
+
+#: ../src/common/accelcmn.cpp:86
+msgctxt "keyboard key"
+msgid "Num Space"
+msgstr "Num Razmaknica"
+
+#: ../src/common/accelcmn.cpp:87
+msgctxt "keyboard key"
+msgid "KP_Tab"
+msgstr "BT_Tabulator"
+
+#: ../src/common/accelcmn.cpp:87
+msgctxt "keyboard key"
+msgid "Num Tab"
+msgstr "Num Tabulator"
+
+#: ../src/common/accelcmn.cpp:88
+msgctxt "keyboard key"
+msgid "KP_Enter"
+msgstr "BT_Unesi"
+
+#: ../src/common/accelcmn.cpp:88
+msgctxt "keyboard key"
+msgid "Num Enter"
+msgstr "Num Unesi"
+
+#: ../src/common/accelcmn.cpp:89
+msgctxt "keyboard key"
+msgid "KP_Home"
+msgstr "BT_Početna"
+
+#: ../src/common/accelcmn.cpp:89
+msgctxt "keyboard key"
+msgid "Num Home"
+msgstr "Num Početna"
+
+#: ../src/common/accelcmn.cpp:90
+msgctxt "keyboard key"
+msgid "KP_Left"
+msgstr "BT_Lijevo"
+
+#: ../src/common/accelcmn.cpp:90
+msgctxt "keyboard key"
+msgid "Num left"
+msgstr "Num Lijevo"
+
+#: ../src/common/accelcmn.cpp:91
+msgctxt "keyboard key"
+msgid "KP_Up"
+msgstr "BT_Gore"
+
+#: ../src/common/accelcmn.cpp:91
+msgctxt "keyboard key"
+msgid "Num Up"
+msgstr "Num Gore"
+
+#: ../src/common/accelcmn.cpp:92
+msgctxt "keyboard key"
+msgid "KP_Right"
+msgstr "BT_Desno"
+
+#: ../src/common/accelcmn.cpp:92
+msgctxt "keyboard key"
+msgid "Num Right"
+msgstr "Num Desno"
+
+#: ../src/common/accelcmn.cpp:93
+msgctxt "keyboard key"
+msgid "KP_Down"
+msgstr "BT_Dolje"
+
+#: ../src/common/accelcmn.cpp:93
+msgctxt "keyboard key"
+msgid "Num Down"
+msgstr "Num Dolje"
+
+#: ../src/common/accelcmn.cpp:94
+msgctxt "keyboard key"
+msgid "KP_PageUp"
+msgstr "BT_Stranica gore"
+
+#: ../src/common/accelcmn.cpp:94
+msgctxt "keyboard key"
+msgid "Num Page Up"
+msgstr "Num Stranica gore"
+
+#: ../src/common/accelcmn.cpp:95
+msgctxt "keyboard key"
+msgid "KP_PageDown"
+msgstr "BT_Stranica dolje"
+
+#: ../src/common/accelcmn.cpp:95
+msgctxt "keyboard key"
+msgid "Num Page Down"
+msgstr "Num Stranica dolje"
+
+#: ../src/common/accelcmn.cpp:96
+msgctxt "keyboard key"
+msgid "KP_Prior"
+msgstr "BT_Prethodno"
+
+#: ../src/common/accelcmn.cpp:97
+msgctxt "keyboard key"
+msgid "KP_Next"
+msgstr "BT_Sljedeće"
+
+#: ../src/common/accelcmn.cpp:98
+msgctxt "keyboard key"
+msgid "KP_End"
+msgstr "BT_Kraj"
+
+#: ../src/common/accelcmn.cpp:98
+msgctxt "keyboard key"
+msgid "Num End"
+msgstr "Num Kraj"
+
+#: ../src/common/accelcmn.cpp:99
+msgctxt "keyboard key"
+msgid "KP_Begin"
+msgstr "BT_Početak"
+
+#: ../src/common/accelcmn.cpp:99
+msgctxt "keyboard key"
+msgid "Num Begin"
+msgstr "Num Početak"
+
+#: ../src/common/accelcmn.cpp:100
+msgctxt "keyboard key"
+msgid "KP_Insert"
+msgstr "BT_Umetni"
+
+#: ../src/common/accelcmn.cpp:100
+msgctxt "keyboard key"
+msgid "Num Insert"
+msgstr "Num Umetni"
+
+#: ../src/common/accelcmn.cpp:101
+msgctxt "keyboard key"
+msgid "KP_Delete"
+msgstr "BT_Izbriši"
+
+#: ../src/common/accelcmn.cpp:101
+msgctxt "keyboard key"
+msgid "Num Delete"
+msgstr "Num Izbriši"
+
+#: ../src/common/accelcmn.cpp:102
+msgctxt "keyboard key"
+msgid "KP_Equal"
+msgstr "BT_Jednako"
+
+#: ../src/common/accelcmn.cpp:102
+msgctxt "keyboard key"
+msgid "Num ="
+msgstr "Num ="
+
+#: ../src/common/accelcmn.cpp:103
+msgctxt "keyboard key"
+msgid "KP_Multiply"
+msgstr "BT_Množenje"
+
+#: ../src/common/accelcmn.cpp:103
+msgctxt "keyboard key"
+msgid "Num *"
+msgstr "Num *"
+
+#: ../src/common/accelcmn.cpp:104
+msgctxt "keyboard key"
+msgid "KP_Add"
+msgstr "BT_Zbrajanje"
+
+#: ../src/common/accelcmn.cpp:104
+msgctxt "keyboard key"
+msgid "Num +"
+msgstr "Num +"
+
+#: ../src/common/accelcmn.cpp:105
+msgctxt "keyboard key"
+msgid "KP_Separator"
+msgstr "BT_Razdvojnik"
+
+#: ../src/common/accelcmn.cpp:105
+msgctxt "keyboard key"
+msgid "Num ,"
+msgstr "Num ,"
+
+#: ../src/common/accelcmn.cpp:106
+msgctxt "keyboard key"
+msgid "KP_Subtract"
+msgstr "BT_Oduzimanje"
+
+#: ../src/common/accelcmn.cpp:106
+msgctxt "keyboard key"
+msgid "Num -"
+msgstr "Num -"
+
+#: ../src/common/accelcmn.cpp:107
+msgctxt "keyboard key"
+msgid "KP_Decimal"
+msgstr "BT_Decimala"
+
+#: ../src/common/accelcmn.cpp:107
+msgctxt "keyboard key"
+msgid "Num ."
+msgstr "Num ."
+
+#: ../src/common/accelcmn.cpp:108
+msgctxt "keyboard key"
+msgid "KP_Divide"
+msgstr "BT_Dijeljenje"
+
+#: ../src/common/accelcmn.cpp:108
+msgctxt "keyboard key"
+msgid "Num /"
+msgstr "Num /"
+
+#: ../src/common/accelcmn.cpp:109
+msgctxt "keyboard key"
+msgid "Windows_Left"
+msgstr "Windows_Lijevo"
+
+#: ../src/common/accelcmn.cpp:110
+msgctxt "keyboard key"
+msgid "Windows_Right"
+msgstr "Windows_Desno"
+
+#: ../src/common/accelcmn.cpp:111
+msgctxt "keyboard key"
+msgid "Windows_Menu"
+msgstr "Windows_Izbornik"
+
+#: ../src/common/accelcmn.cpp:112
+msgctxt "keyboard key"
+msgid "Command"
+msgstr "Naredba"
+
+#: ../src/common/accelcmn.cpp:186 ../src/common/accelcmn.cpp:359
+msgctxt "keyboard key"
+msgid "Ctrl"
+msgstr "Ctrl"
+
+#: ../src/common/accelcmn.cpp:188 ../src/common/accelcmn.cpp:363
+msgctxt "keyboard key"
+msgid "Alt"
+msgstr "Alt"
+
+#: ../src/common/accelcmn.cpp:190 ../src/common/accelcmn.cpp:361
+msgctxt "keyboard key"
+msgid "Shift"
+msgstr "Shift"
+
+#: ../src/common/accelcmn.cpp:196
+msgctxt "keyboard key"
+msgid "num "
+msgstr "num "
+
+#: ../src/common/accelcmn.cpp:260 ../src/common/accelcmn.cpp:382
+msgctxt "keyboard key"
+msgid "F"
+msgstr "F"
+
+#: ../src/common/accelcmn.cpp:277 ../src/common/accelcmn.cpp:385
+msgctxt "keyboard key"
+msgid "KP_F"
+msgstr "BT_F"
+
+#: ../src/common/accelcmn.cpp:280 ../src/common/accelcmn.cpp:388
+msgctxt "keyboard key"
+msgid "KP_"
+msgstr "BT_"
+
+#: ../src/common/accelcmn.cpp:283 ../src/common/accelcmn.cpp:391
+msgctxt "keyboard key"
+msgid "SPECIAL"
+msgstr "SPECIJALNO"
+
+#: ../src/common/accelcmn.cpp:373
+#, fuzzy
+msgid "Ctrl"
+msgstr "Ctrl"
+
+#: ../src/common/appbase.cpp:786
+msgid "show this help message"
+msgstr "prikaži ovu obavijest pomoći"
+
+#: ../src/common/appbase.cpp:796
+msgid "generate verbose log messages"
+msgstr "stvori opširne log-poruke"
+
+#: ../src/common/appcmn.cpp:256
+msgid "specify the theme to use"
+msgstr "odredi temu koja će se koristiti"
+
+#: ../src/common/appcmn.cpp:270
+msgid "specify display mode to use (e.g. 640x480-16)"
+msgstr "odredi modus prikaza koji će se koristiti (npr. 640 × 480 - 16)"
+
+#: ../src/common/appcmn.cpp:292
+#, c-format
+msgid "Unsupported theme '%s'."
+msgstr "Nepodržana tema „%s”."
+
+#: ../src/common/appcmn.cpp:309
+#, c-format
+msgid "Invalid display mode specification '%s'."
+msgstr "Nevaljana specifikacija modusa prikaza „%s”."
+
+#: ../src/common/cmdline.cpp:875
+#, c-format
+msgid "Option '%s' can't be negated"
+msgstr "Nije moguće negirati opciju „%s”"
+
+#: ../src/common/cmdline.cpp:889
+#, c-format
+msgid "Unknown long option '%s'"
+msgstr "Nepoznata dugačka opcija „%s”"
+
+#: ../src/common/cmdline.cpp:904 ../src/common/cmdline.cpp:926
+#, c-format
+msgid "Unknown option '%s'"
+msgstr "Nepoznata opcija „%s”"
+
+#: ../src/common/cmdline.cpp:1004
+#, c-format
+msgid "Unexpected characters following option '%s'."
+msgstr "Neočekivani znakovi slijede opciju „%s”."
+
+#: ../src/common/cmdline.cpp:1039
+#, c-format
+msgid "Option '%s' requires a value."
+msgstr "Opcija „%s” zahtijeva vrijednost."
+
+#: ../src/common/cmdline.cpp:1058
+#, c-format
+msgid "Separator expected after the option '%s'."
+msgstr "Potreban je razdvojnik nakon opcije „%s”."
+
+#: ../src/common/cmdline.cpp:1088 ../src/common/cmdline.cpp:1106
+#, c-format
+msgid "'%s' is not a correct numeric value for option '%s'."
+msgstr "„%s” nije ispravna numerička vrijednost za opciju „%s”."
+
+#: ../src/common/cmdline.cpp:1122
+#, c-format
+msgid "Option '%s': '%s' cannot be converted to a date."
+msgstr "Opcija „%s”: Nije moguće konvertirati „%s” u datum."
+
+#: ../src/common/cmdline.cpp:1170
+#, c-format
+msgid "Unexpected parameter '%s'"
+msgstr "Neočekivani parametar „%s”"
+
+#. TRANSLATORS: Short name and long name for a command line option
+#: ../src/common/cmdline.cpp:1197
+#, c-format
+msgid "%s (or %s)"
+msgstr "%s (ili %s)"
+
+#: ../src/common/cmdline.cpp:1208
+#, c-format
+msgid "The value for the option '%s' must be specified."
+msgstr "Vrijednost opcije „%s” mora biti određena."
+
+#: ../src/common/cmdline.cpp:1230
+#, c-format
+msgid "The required parameter '%s' was not specified."
+msgstr "Obavezan parametar „%s” nije bio određen."
+
+#: ../src/common/cmdline.cpp:1289
+#, c-format
+msgid "Usage: %s"
+msgstr "Upotreba: %s"
+
+#: ../src/common/cmdline.cpp:1498
+msgid "str"
+msgstr "str"
+
+#: ../src/common/cmdline.cpp:1502
+msgid "num"
+msgstr "num"
+
+#: ../src/common/cmdline.cpp:1506
+msgid "double"
+msgstr "dvostruko"
+
+#: ../src/common/cmdline.cpp:1510
+msgid "date"
+msgstr "datum"
+
+#: ../src/common/cmdproc.cpp:250 ../src/common/cmdproc.cpp:276
+#: ../src/common/cmdproc.cpp:296
+msgid "Unnamed command"
+msgstr "Bezimena naredba"
+
+#: ../src/common/cmdproc.cpp:253
+msgid "&Undo "
+msgstr "&Poništi "
+
+#: ../src/common/cmdproc.cpp:255
+msgid "Can't &Undo "
+msgstr "&Poništavanje nije moguće "
+
+#: ../src/common/cmdproc.cpp:259 ../src/common/stockitem.cpp:208
+#: ../src/msw/textctrl.cpp:2880 ../src/osx/textctrl_osx.cpp:649
+#: ../src/richtext/richtextctrl.cpp:327
+msgid "&Undo"
+msgstr "&Poništi"
+
+#: ../src/common/cmdproc.cpp:277 ../src/common/cmdproc.cpp:297
+msgid "&Redo "
+msgstr "&Ponovi "
+
+#: ../src/common/cmdproc.cpp:281 ../src/common/cmdproc.cpp:288
+#: ../src/common/stockitem.cpp:190 ../src/msw/textctrl.cpp:2881
+#: ../src/osx/textctrl_osx.cpp:650 ../src/richtext/richtextctrl.cpp:328
+msgid "&Redo"
+msgstr "&Ponovi"
+
+#: ../src/common/colourcmn.cpp:41
+#, c-format
+msgid "String To Colour : Incorrect colour specification : %s"
+msgstr "Znakovni niz u boju : Netočna specifikacija boje : %s"
+
+#: ../src/common/config.cpp:259
+#, c-format
+msgid "Invalid value %ld for a boolean key \"%s\" in config file."
+msgstr ""
+"Nevaljana vrijedonst %ld za booleov ključ „%s” u konfiguracijskoj datoteci."
+
+#: ../src/common/config.cpp:526
+#, c-format
+msgid ""
+"Environment variables expansion failed: missing '%c' at position %u in '%s'."
+msgstr ""
+"Proširenje varijable okruženja nije uspjelo: nedostaje „%c” na položaju %u u "
+"„%s”."
+
+#: ../src/common/config.cpp:576 ../src/msw/regconf.cpp:272
+#, c-format
+msgid "'%s' has extra '..', ignored."
+msgstr "„%s” ima dodatne „..”, zanemareno."
+
+#. TRANSLATORS: Checkbox state name
+#: ../src/common/datavcmn.cpp:2166 ../src/generic/datavgen.cpp:1430
+msgid "checked"
+msgstr "aktivirano"
+
+#. TRANSLATORS: Checkbox state name
+#: ../src/common/datavcmn.cpp:2170 ../src/generic/datavgen.cpp:1432
+msgid "unchecked"
+msgstr "neaktivirano"
+
+#. TRANSLATORS: Checkbox state name
+#: ../src/common/datavcmn.cpp:2174
+msgid "undetermined"
+msgstr "neodređeno"
+
+#: ../src/common/datetimefmt.cpp:1875
+msgid "today"
+msgstr "danas"
+
+#: ../src/common/datetimefmt.cpp:1876
+msgid "yesterday"
+msgstr "jučer"
+
+#: ../src/common/datetimefmt.cpp:1877
+msgid "tomorrow"
+msgstr "sutra"
+
+#: ../src/common/datetimefmt.cpp:2071
+msgid "first"
+msgstr "prvi"
+
+#: ../src/common/datetimefmt.cpp:2072
+msgid "second"
+msgstr "drugi"
+
+#: ../src/common/datetimefmt.cpp:2073
+msgid "third"
+msgstr "treći"
+
+#: ../src/common/datetimefmt.cpp:2074
+msgid "fourth"
+msgstr "četvrti"
+
+#: ../src/common/datetimefmt.cpp:2075
+msgid "fifth"
+msgstr "peti"
+
+#: ../src/common/datetimefmt.cpp:2076
+msgid "sixth"
+msgstr "šesti"
+
+#: ../src/common/datetimefmt.cpp:2077
+msgid "seventh"
+msgstr "sedmi"
+
+#: ../src/common/datetimefmt.cpp:2078
+msgid "eighth"
+msgstr "osmi"
+
+#: ../src/common/datetimefmt.cpp:2079
+msgid "ninth"
+msgstr "deveti"
+
+#: ../src/common/datetimefmt.cpp:2080
+msgid "tenth"
+msgstr "deseti"
+
+#: ../src/common/datetimefmt.cpp:2081
+msgid "eleventh"
+msgstr "jedanaesti"
+
+#: ../src/common/datetimefmt.cpp:2082
+msgid "twelfth"
+msgstr "dvanaesti"
+
+#: ../src/common/datetimefmt.cpp:2083
+msgid "thirteenth"
+msgstr "trinaesti"
+
+#: ../src/common/datetimefmt.cpp:2084
+msgid "fourteenth"
+msgstr "četrnaesti"
+
+#: ../src/common/datetimefmt.cpp:2085
+msgid "fifteenth"
+msgstr "petnaesti"
+
+#: ../src/common/datetimefmt.cpp:2086
+msgid "sixteenth"
+msgstr "šesnaesti"
+
+#: ../src/common/datetimefmt.cpp:2087
+msgid "seventeenth"
+msgstr "sedamnaesti"
+
+#: ../src/common/datetimefmt.cpp:2088
+msgid "eighteenth"
+msgstr "osamnaesti"
+
+#: ../src/common/datetimefmt.cpp:2089
+msgid "nineteenth"
+msgstr "devetnaesti"
+
+#: ../src/common/datetimefmt.cpp:2090
+msgid "twentieth"
+msgstr "dvadeseti"
+
+#: ../src/common/datetimefmt.cpp:2248
+msgid "noon"
+msgstr "podne"
+
+#: ../src/common/datetimefmt.cpp:2249
+msgid "midnight"
+msgstr "ponoć"
+
+#: ../src/common/debugrpt.cpp:209
+#, c-format
+msgid "Failed to create directory \"%s\""
+msgstr "Neuspjelo stvaranje mape „%s”"
+
+#: ../src/common/debugrpt.cpp:210
+msgid "Debug report couldn't be created."
+msgstr "Izvještaj o otklanjanju grešaka nije bilo moguće stvoriti."
+
+#: ../src/common/debugrpt.cpp:227
+#, c-format
+msgid "Failed to remove debug report file \"%s\""
+msgstr "Neuspjelo uklanjanje datoteke za izvještaj o otklanjanju grešaka „%s”"
+
+#: ../src/common/debugrpt.cpp:239
+#, c-format
+msgid "Failed to clean up debug report directory \"%s\""
+msgstr "Neuspjelo pražnjenje mape izještaja o otklanjanju grešaka „%s”."
+
+#: ../src/common/debugrpt.cpp:514
+msgid "process context description"
+msgstr "obradi sadržaj opisa"
+
+#: ../src/common/debugrpt.cpp:538
+msgid "dump of the process state (binary)"
+msgstr "izvadak statusa procesa (binarno)"
+
+#: ../src/common/debugrpt.cpp:553
+msgid "Debug report generation has failed."
+msgstr "Stvaranje izvještaja o otklanjanju grešaka."
+
+#: ../src/common/debugrpt.cpp:560
+#, c-format
+msgid ""
+"Processing debug report has failed, leaving the files in \"%s\" directory."
+msgstr ""
+"Obrada izvještaja o otklanjanju grešaka nije uspjela. Datoteke ostaju u mapi "
+"„%s”."
+
+#: ../src/common/debugrpt.cpp:573
+msgid "A debug report has been generated. It can be found in"
+msgstr "Izvještaj o otklanjanju grešaka je stvoren. Nalazi se u"
+
+#: ../src/common/debugrpt.cpp:576
+msgid "And includes the following files:\n"
+msgstr "I sadržava sljedeće datoteke:\n"
+
+#: ../src/common/debugrpt.cpp:586
+msgid ""
+"\n"
+"Please send this report to the program maintainer, thank you!\n"
+msgstr ""
+"\n"
+"Molimo te da ovaj izvještaj pošalješ održavatelju programa. Hvala!\n"
+
+#: ../src/common/debugrpt.cpp:729
+msgid "Failed to execute curl, please install it in PATH."
+msgstr "Neuspjelo izvršavanje curl-a, instaliraj ga u PATH."
+
+#: ../src/common/debugrpt.cpp:742
+#, c-format
+msgid "Failed to upload the debug report (error code %d)."
+msgstr "Neuspjeli prijenos izvještaja o ispravljanju grešaka (kôd greške %d)."
+
+#: ../src/common/docview.cpp:366
+msgid "Save As"
+msgstr "Spremi kao"
+
+#: ../src/common/docview.cpp:457
+msgid "Discard changes and reload the last saved version?"
+msgstr "Zanemari promjene i ponovo učitaj posljednju spremljenu verziju?"
+
+#: ../src/common/docview.cpp:488
+msgid "unnamed"
+msgstr "neimenovano"
+
+#: ../src/common/docview.cpp:513
+#, c-format
+msgid "Do you want to save changes to %s?"
+msgstr "Želiš li spremiti promjene u %s?"
+
+#: ../src/common/docview.cpp:521 ../src/common/docview.cpp:560
+#: ../src/common/stockitem.cpp:195
+msgid "&Save"
+msgstr "&Spremi"
+
+#: ../src/common/docview.cpp:522 ../src/common/docview.cpp:560
+msgid "&Discard changes"
+msgstr "&Odbaci promjene"
+
+#: ../src/common/docview.cpp:523
+msgid "Do&n't close"
+msgstr "&Nemoj zatvoriti"
+
+#: ../src/common/docview.cpp:553
+#, c-format
+msgid "Do you want to save changes to %s before closing it?"
+msgstr "Želiš li spremiti promjene u %s prije zatvaranja?"
+
+#: ../src/common/docview.cpp:559
+msgid "The document must be closed."
+msgstr "Dokument se mora zatvoriti."
+
+#: ../src/common/docview.cpp:571
+#, c-format
+msgid "Saving %s failed, would you like to retry?"
+msgstr "Spremanje %s nije uspjelo. Želiš li pokušati ponovo?"
+
+#: ../src/common/docview.cpp:577
+msgid "Retry"
+msgstr "Pokušaj ponovo"
+
+#: ../src/common/docview.cpp:577
+msgid "Discard changes"
+msgstr "Odbaci promjene"
+
+#: ../src/common/docview.cpp:679
+#, c-format
+msgid "File \"%s\" could not be opened for writing."
+msgstr "Nije bilo moguće otvoriti datoteku „%s” za pisanje."
+
+#: ../src/common/docview.cpp:685
+#, c-format
+msgid "Failed to save document to the file \"%s\"."
+msgstr "Neuspjelo spremanje dokumenta u datoteku „%s”."
+
+#: ../src/common/docview.cpp:702
+#, c-format
+msgid "File \"%s\" could not be opened for reading."
+msgstr "Nije bilo moguće otvoriti datoteku „%s” za čitanje."
+
+#: ../src/common/docview.cpp:714
+#, c-format
+msgid "Failed to read document from the file \"%s\"."
+msgstr "Neuspjelo čitanje dokumenta iz datoteke „%s”."
+
+#: ../src/common/docview.cpp:1236
+#, c-format
+msgid ""
+"The file '%s' doesn't exist and couldn't be opened.\n"
+"It has been removed from the most recently used files list."
+msgstr ""
+"Datoteka „%s” ne postoji i ne može se otvoriti.\n"
+"Uklonjena je iz popisa nedavno otvorenih datoteka."
+
+#: ../src/common/docview.cpp:1296
+msgid "Print preview creation failed."
+msgstr "Izrada pregleda ispisa neuspjela."
+
+#: ../src/common/docview.cpp:1302
+msgid "Print Preview"
+msgstr "Pregled ispisa"
+
+#: ../src/common/docview.cpp:1517
+#, c-format
+msgid "The format of file '%s' couldn't be determined."
+msgstr "Nije bilo moguće ustanoviti format datoteke „%s”."
+
+#: ../src/common/docview.cpp:1643
+#, c-format
+msgid "unnamed%d"
+msgstr "neimenovano%d"
+
+#: ../src/common/docview.cpp:1660
+msgid " - "
+msgstr " – "
+
+#: ../src/common/docview.cpp:1791 ../src/common/docview.cpp:1844
+msgid "Open File"
+msgstr "Otvori datoteku"
+
+#: ../src/common/docview.cpp:1807
+msgid "File error"
+msgstr "Greška datoteke"
+
+#: ../src/common/docview.cpp:1809
+msgid "Sorry, could not open this file."
+msgstr "Nažalost nije moguće otvoriti ovu datoteku."
+
+#: ../src/common/docview.cpp:1843
+msgid "Sorry, the format for this file is unknown."
+msgstr "Nažalost je format datoteke nepoznat."
+
+#: ../src/common/docview.cpp:1924
+msgid "Select a document template"
+msgstr "Odaberi jedan predložak"
+
+#: ../src/common/docview.cpp:1925
+msgid "Templates"
+msgstr "Predlošci"
+
+#: ../src/common/docview.cpp:1998
+msgid "Select a document view"
+msgstr "Odaberi jedan pogled"
+
+#: ../src/common/docview.cpp:1999
+msgid "Views"
+msgstr "Prikazi"
+
+#: ../src/common/dynlib.cpp:81
+#, c-format
+msgid "Failed to load shared library '%s'"
+msgstr "Neuspjelo učitavanje dijeljenje biblioteke „%s”."
+
+#: ../src/common/dynlib.cpp:105
+#, c-format
+msgid "Couldn't find symbol '%s' in a dynamic library"
+msgstr "Nije bilo moguće naći simbol „%s” u dinamičkoj biblioteci"
+
+#: ../src/common/ffile.cpp:56 ../src/common/file.cpp:215
+#, c-format
+msgid "can't open file '%s'"
+msgstr "nije moguće otvoriti datoteku „%s”"
+
+#: ../src/common/ffile.cpp:72
+#, c-format
+msgid "can't close file '%s'"
+msgstr "nije moguće zatvoriti datoteku „%s”"
+
+#: ../src/common/ffile.cpp:106 ../src/common/ffile.cpp:131
+#, c-format
+msgid "Read error on file '%s'"
+msgstr "Greška u čitanju datoteke „%s”"
+
+#: ../src/common/ffile.cpp:148
+#, c-format
+msgid "Write error on file '%s'"
+msgstr "Zapiši grešku za datoteku „%s”"
+
+#: ../src/common/ffile.cpp:182
+#, c-format
+msgid "failed to flush the file '%s'"
+msgstr "neuspjelo pražnjenje datoteke „%s”"
+
+#: ../src/common/ffile.cpp:222
+#, c-format
+msgid "Seek error on file '%s' (large files not supported by stdio)"
+msgstr "Traži grešku u datoteci „%s” (stdio ne podržava velike datoteke)"
+
+#: ../src/common/ffile.cpp:232
+#, c-format
+msgid "Seek error on file '%s'"
+msgstr "Traži grešku u datoteci „%s”"
+
+#: ../src/common/ffile.cpp:248
+#, c-format
+msgid "Can't find current position in file '%s'"
+msgstr "Nije moguće naći trenutačni položaj u datoteci „%s”"
+
+#: ../src/common/ffile.cpp:349 ../src/common/file.cpp:569
+msgid "Failed to set temporary file permissions"
+msgstr "Neuspjelo postavljanje privremenih datotečnih prava"
+
+#: ../src/common/ffile.cpp:371
+#, c-format
+msgid "can't remove file '%s'"
+msgstr "nije moguće ukloniti datoteku „%s”"
+
+#: ../src/common/ffile.cpp:376 ../src/common/file.cpp:591
+#, c-format
+msgid "can't commit changes to file '%s'"
+msgstr "nije moguće potvrditi promjene za datoteku „%s”"
+
+#: ../src/common/ffile.cpp:388 ../src/common/file.cpp:603
+#, c-format
+msgid "can't remove temporary file '%s'"
+msgstr "nije moguće ukloniti privremenu datoteku „%s”"
+
+#: ../src/common/file.cpp:162
+#, c-format
+msgid "can't create file '%s'"
+msgstr "nije moguće stvoriti datoteku „%s”"
+
+#: ../src/common/file.cpp:229
+#, c-format
+msgid "can't close file descriptor %d"
+msgstr "nije moguće zatvoriti desriptora datoteka %d"
+
+#: ../src/common/file.cpp:332
+#, c-format
+msgid "can't read from file descriptor %d"
+msgstr "nije moguće čitanje iz deskriptora datoteka %d"
+
+#: ../src/common/file.cpp:351
+#, c-format
+msgid "can't write to file descriptor %d"
+msgstr "nije moguće zapisivanje u deskriptor datoteka %d"
+
+#: ../src/common/file.cpp:390
+#, c-format
+msgid "can't flush file descriptor %d"
+msgstr "nije moguće isprazniti deskriptor datoteka %d"
+
+#: ../src/common/file.cpp:432
+#, c-format
+msgid "can't seek on file descriptor %d"
+msgstr "nije moguće traženje na deskriptor datoteka %d"
+
+#: ../src/common/file.cpp:446
+#, c-format
+msgid "can't get seek position on file descriptor %d"
+msgstr "nije moguće dobiti poziciju traženja na deskriptoru datoteka %d"
+
+#: ../src/common/file.cpp:475
+#, c-format
+msgid "can't find length of file on file descriptor %d"
+msgstr "nije moguće naći duljinu datoteke na deskriptoru datoteka %d"
+
+#: ../src/common/file.cpp:505
+#, c-format
+msgid "can't determine if the end of file is reached on descriptor %d"
+msgstr "nije moguće odrediti dosezanje kraja datoteke na deskriptoru %d"
+
+#: ../src/common/fileconf.cpp:352
+#, c-format
+msgid ""
+" and additionally, the existing configuration file was renamed to \"%s\" and "
+"couldn't be renamed back, please rename it to its original path \"%s\""
+msgstr ""
+
+#: ../src/common/fileconf.cpp:389
+#, fuzzy
+msgid " due to the following error:\n"
+msgstr "I sadržava sljedeće datoteke:\n"
+
+#: ../src/common/fileconf.cpp:412
+#, fuzzy
+msgid "failed to rename the existing file"
+msgstr "Neuspjelo čitanje tekstualne datoteke „%s”."
+
+#: ../src/common/fileconf.cpp:421
+#, fuzzy
+msgid "failed to create the new file directory"
+msgstr "Neuspjelo dohvaćanje radne mape"
+
+#: ../src/common/fileconf.cpp:428
+#, fuzzy
+msgid "failed to move the file to the new location"
+msgstr "Neuspjelo postavljanje web-prikaza na modernu razinu emulacije"
+
+#: ../src/common/fileconf.cpp:462
+#, c-format
+msgid "can't open global configuration file '%s'."
+msgstr "nije moguće otvoriti datoteku globalne konfiguracije „%s”."
+
+#: ../src/common/fileconf.cpp:478
+#, c-format
+msgid "can't open user configuration file '%s'."
+msgstr "nije moguće otvoriti datoteku korisničke konfiguracije „%s”."
+
+#: ../src/common/fileconf.cpp:483
+#, c-format
+msgid "Changes won't be saved to avoid overwriting the existing file \"%s\""
+msgstr ""
+"Promjene se neće spremiti, kako bi se izbjeglo prepisivanje postojeće "
+"datoteke „%s”"
+
+#: ../src/common/fileconf.cpp:583
+msgid "Error reading config options."
+msgstr "Greška prilikom čitanja opcija konfiguracije."
+
+#: ../src/common/fileconf.cpp:593
+msgid "Failed to read config options."
+msgstr "Neuspjelo čitanje opcija koniguracije."
+
+#: ../src/common/fileconf.cpp:700
+#, c-format
+msgid "file '%s': unexpected character %c at line %zu."
+msgstr "datoteka „%s”: neočevani znak %c u %zu. retku."
+
+#: ../src/common/fileconf.cpp:736
+#, c-format
+msgid "file '%s', line %zu: '%s' ignored after group header."
+msgstr "datoteka „%s”, redak %zu: „%s” zanemareno nakon zaglavlja grupe."
+
+#: ../src/common/fileconf.cpp:765
+#, c-format
+msgid "file '%s', line %zu: '=' expected."
+msgstr "datoteka „%s”, redak %zu: „=” očekivano."
+
+#: ../src/common/fileconf.cpp:778
+#, c-format
+msgid "file '%s', line %zu: value for immutable key '%s' ignored."
+msgstr ""
+"datoteka „%s”, redak %zu: vrijednost nepromijenjivog ključa „%s” je "
+"zanemaren."
+
+#: ../src/common/fileconf.cpp:788
+#, c-format
+msgid "file '%s', line %zu: key '%s' was first found at line %d."
+msgstr "datoteka „%s”, redak %zu: ključ „%s” je najprije nađen u %d. retku."
+
+#: ../src/common/fileconf.cpp:1091
+#, c-format
+msgid "Config entry name cannot start with '%c'."
+msgstr "Konfiguracijsko ulazno ime ne može početi s „%c”."
+
+#: ../src/common/fileconf.cpp:1146
+#, fuzzy
+msgid "Failed to create configuration file directory."
+msgstr "Neuspjela izrada objekta konfiguracije fontova."
+
+#: ../src/common/fileconf.cpp:1158
+msgid "can't open user configuration file."
+msgstr "nije moguće otvoriti datoteku korisničke konfiguracije."
+
+#: ../src/common/fileconf.cpp:1172
+msgid "can't write user configuration file."
+msgstr "nije moguće zapisivanje datoteke korisničke konfiguracije."
+
+#: ../src/common/fileconf.cpp:1178
+msgid "Failed to update user configuration file."
+msgstr "Neuspjelo aktualiziranje datoteke korisničke konfiguracije."
+
+#: ../src/common/fileconf.cpp:1201
+msgid "Error saving user configuration data."
+msgstr "Greška prilikom spremanja podataka korisničke konfiguracije."
+
+#: ../src/common/fileconf.cpp:1313
+#, c-format
+msgid "can't delete user configuration file '%s'"
+msgstr "nije moguće izbrisati datoteku konfiguracije „%s”"
+
+#: ../src/common/fileconf.cpp:2007
+#, c-format
+msgid "entry '%s' appears more than once in group '%s'"
+msgstr "unos „%s” se pojavljuje višestruko u grupi „%s”"
+
+#: ../src/common/fileconf.cpp:2021
+#, c-format
+msgid "attempt to change immutable key '%s' ignored."
+msgstr "pokušaj mijenjanja nepromjenljivog ključa „%s” je zanemaren."
+
+#: ../src/common/fileconf.cpp:2118
+#, c-format
+msgid "trailing backslash ignored in '%s'"
+msgstr "obrnuta kosa crta na kraju je zanemarena u „%s”"
+
+#: ../src/common/fileconf.cpp:2153
+#, c-format
+msgid "unexpected \" at position %d in '%s'."
+msgstr "neočekivani \" na poziciji %d u „%s”."
+
+#: ../src/common/filefn.cpp:474
+#, c-format
+msgid "Failed to copy the file '%s' to '%s'"
+msgstr "Neuspjelo kopiranje datoteke „%s” u „%s”"
+
+#: ../src/common/filefn.cpp:487
+#, c-format
+msgid "Impossible to get permissions for file '%s'"
+msgstr "Nije moguće dobiti dozvolu za datoteku „%s”"
+
+#: ../src/common/filefn.cpp:501
+#, c-format
+msgid "Impossible to overwrite the file '%s'"
+msgstr "Nije moguće prepisati datoteku „%s”"
+
+#: ../src/common/filefn.cpp:508
+#, c-format
+msgid "Error copying the file '%s' to '%s'."
+msgstr "Greška prilikom kopiranja datoteke „%s” u „%s”."
+
+#: ../src/common/filefn.cpp:556
+#, c-format
+msgid "Impossible to set permissions for the file '%s'"
+msgstr "Nije moguće postaviti korisnička prava za datoteku „%s”"
+
+#: ../src/common/filefn.cpp:606
+#, c-format
+msgid ""
+"Failed to rename the file '%s' to '%s' because the destination file already "
+"exists."
+msgstr ""
+"Neuspjelo preimenovanje datoteke „%s” u „%s”, jer odredišna datoteka već "
+"postoji."
+
+#: ../src/common/filefn.cpp:623
+#, c-format
+msgid "File '%s' couldn't be renamed '%s'"
+msgstr "Datoteku „%s” nije bilo moguće preimenovati „%s”"
+
+#: ../src/common/filefn.cpp:639
+#, c-format
+msgid "File '%s' couldn't be removed"
+msgstr "Nije bilo moguće ukloniti datoteku „%s”"
+
+#: ../src/common/filefn.cpp:666
+#, c-format
+msgid "Directory '%s' couldn't be created"
+msgstr "Nije bilo moguće stvoriti mapu „%s”"
+
+#: ../src/common/filefn.cpp:680
+#, c-format
+msgid "Directory '%s' couldn't be deleted"
+msgstr "Nije bilo moguće izbrisati mapu „%s”"
+
+#: ../src/common/filefn.cpp:714
+#, c-format
+msgid "Cannot enumerate files '%s'"
+msgstr "Nije moguće numerirati datoteke „%s”"
+
+#: ../src/common/filefn.cpp:798
+msgid "Failed to get the working directory"
+msgstr "Neuspjelo dohvaćanje radne mape"
+
+#: ../src/common/filefn.cpp:843
+msgid "Could not set current working directory"
+msgstr "Nije bilo moguće postaviti trenutačnu radnu mapu"
+
+#: ../src/common/filefn.cpp:974
+#, c-format
+msgid "Files (%s)"
+msgstr "Datoteke (%s)"
+
+#: ../src/common/filename.cpp:182
+#, c-format
+msgid "Failed to open '%s' for reading"
+msgstr "Neuspjelo otvaranje „%s” za čitanje"
+
+#: ../src/common/filename.cpp:187
+#, c-format
+msgid "Failed to open '%s' for writing"
+msgstr "Neuspjelo otvaranje „%s” za pisanje"
+
+#: ../src/common/filename.cpp:199
+msgid "Failed to close file handle"
+msgstr "Neuspjelo zatvaranje upravljača datotekama"
+
+#: ../src/common/filename.cpp:1046
+msgid "Failed to create a temporary file name"
+msgstr "Neuspjelo stvaranje imena privremene datoteke"
+
+#: ../src/common/filename.cpp:1081
+msgid "Failed to open temporary file."
+msgstr "Neuspjelo otvaranje privremene datoteke."
+
+#: ../src/common/filename.cpp:2862
+#, c-format
+msgid "Failed to modify file times for '%s'"
+msgstr "Neuspjelo mijenjanje vremena datoteke za „%s”"
+
+#: ../src/common/filename.cpp:2877
+#, c-format
+msgid "Failed to touch the file '%s'"
+msgstr "Neuspjelo dodirivanje datoteke „%s”"
+
+#: ../src/common/filename.cpp:2958
+#, c-format
+msgid "Failed to retrieve file times for '%s'"
+msgstr "Neuspjelo dohvaćanje vremena datoteke za „%s”"
+
+#: ../src/common/filepickercmn.cpp:39 ../src/common/filepickercmn.cpp:40
+msgid "Browse"
+msgstr "Pregledaj"
+
+#: ../src/common/fldlgcmn.cpp:792 ../src/generic/filectrlg.cpp:1185
+#, c-format
+msgid "All files (%s)|%s"
+msgstr "Sve datoteke (%s)|%s"
+
+#. TRANSLATORS: %s are a file extension used to build a file wildcard string
+#: ../src/common/fldlgcmn.cpp:810
+#, c-format
+msgid "%s files (%s)|%s"
+msgstr "%s datoteka (%s)|%s"
+
+#: ../src/common/fldlgcmn.cpp:1072
+#, c-format
+msgid "Load %s file"
+msgstr "Učitaj %s datoteku"
+
+#: ../src/common/fldlgcmn.cpp:1074
+#, c-format
+msgid "Save %s file"
+msgstr "Spremi %s datoteku"
+
+#: ../src/common/fmapbase.cpp:144
+msgid "Western European (ISO-8859-1)"
+msgstr "Zapadnoeuropski (ISO-8859-1)"
+
+#: ../src/common/fmapbase.cpp:145
+msgid "Central European (ISO-8859-2)"
+msgstr "Srednjeeuropski (ISO-8859-2)"
+
+#: ../src/common/fmapbase.cpp:146
+msgid "Esperanto (ISO-8859-3)"
+msgstr "Esperanto (ISO-8859-3)"
+
+#: ../src/common/fmapbase.cpp:147
+msgid "Baltic (old) (ISO-8859-4)"
+msgstr "Baltički (ISO-8859-4)"
+
+#: ../src/common/fmapbase.cpp:148
+msgid "Cyrillic (ISO-8859-5)"
+msgstr "Ćirilica (ISO-8859-5)"
+
+#: ../src/common/fmapbase.cpp:149
+msgid "Arabic (ISO-8859-6)"
+msgstr "Arapski (ISO-8859-6)"
+
+#: ../src/common/fmapbase.cpp:150
+msgid "Greek (ISO-8859-7)"
+msgstr "Grčki (ISO-8859-7)"
+
+#: ../src/common/fmapbase.cpp:151
+msgid "Hebrew (ISO-8859-8)"
+msgstr "Hebrejski (ISO-8859-8-E)"
+
+#: ../src/common/fmapbase.cpp:152
+msgid "Turkish (ISO-8859-9)"
+msgstr "Turski (ISO-8859-9)"
+
+#: ../src/common/fmapbase.cpp:153
+msgid "Nordic (ISO-8859-10)"
+msgstr "Nordic (ISO-8859-10)"
+
+#: ../src/common/fmapbase.cpp:154
+msgid "Thai (ISO-8859-11)"
+msgstr "Tajlandski (ISO-8859-11)"
+
+#: ../src/common/fmapbase.cpp:155
+msgid "Indian (ISO-8859-12)"
+msgstr "Indijski (ISO-8859-12)"
+
+#: ../src/common/fmapbase.cpp:156
+msgid "Baltic (ISO-8859-13)"
+msgstr "Baltički (ISO-8859-13)"
+
+#: ../src/common/fmapbase.cpp:157
+msgid "Celtic (ISO-8859-14)"
+msgstr "Keltski (ISO-8859-14)"
+
+#: ../src/common/fmapbase.cpp:158
+msgid "Western European with Euro (ISO-8859-15)"
+msgstr "Zapadnoeuropski s eurom (ISO 8859-15)"
+
+#: ../src/common/fmapbase.cpp:159
+msgid "KOI8-R"
+msgstr "KOI8-R"
+
+#: ../src/common/fmapbase.cpp:160
+msgid "KOI8-U"
+msgstr "KOI8-U"
+
+#: ../src/common/fmapbase.cpp:161
+msgid "Windows/DOS OEM Cyrillic (CP 866)"
+msgstr "Windows/DOS OEM ćirilica (CP 866)"
+
+#: ../src/common/fmapbase.cpp:162
+msgid "Windows Thai (CP 874)"
+msgstr "Windows tajlandski (CP 874)"
+
+#: ../src/common/fmapbase.cpp:163
+msgid "Windows Japanese (CP 932) or Shift-JIS"
+msgstr "Windows japanski (CP 932) or Shift-JIS"
+
+#: ../src/common/fmapbase.cpp:164
+msgid "Windows Chinese Simplified (CP 936) or GB-2312"
+msgstr "Windows kineski pojednostavljeni (CP 936) or GB-2312"
+
+#: ../src/common/fmapbase.cpp:165
+msgid "Windows Korean (CP 949)"
+msgstr "Windows koreanski (CP 949)"
+
+#: ../src/common/fmapbase.cpp:166
+msgid "Windows Chinese Traditional (CP 950) or Big-5"
+msgstr "Windows kineski tradicionalni (CP 950) or Big-5"
+
+#: ../src/common/fmapbase.cpp:167
+msgid "Windows Central European (CP 1250)"
+msgstr "Windows srednjeeuropski (CP 1250)"
+
+#: ../src/common/fmapbase.cpp:168
+msgid "Windows Cyrillic (CP 1251)"
+msgstr "Windows ćirilica (CP 1251)"
+
+#: ../src/common/fmapbase.cpp:169
+msgid "Windows Western European (CP 1252)"
+msgstr "Windows zapadnoeuropski (CP 1252)"
+
+#: ../src/common/fmapbase.cpp:170
+msgid "Windows Greek (CP 1253)"
+msgstr "Windows grčki (CP 1253)"
+
+#: ../src/common/fmapbase.cpp:171
+msgid "Windows Turkish (CP 1254)"
+msgstr "Windows turski (CP 1254)"
+
+#: ../src/common/fmapbase.cpp:172
+msgid "Windows Hebrew (CP 1255)"
+msgstr "Windows hebrejski (CP 1255)"
+
+#: ../src/common/fmapbase.cpp:173
+msgid "Windows Arabic (CP 1256)"
+msgstr "Windows arapski (CP 1256)"
+
+#: ../src/common/fmapbase.cpp:174
+msgid "Windows Baltic (CP 1257)"
+msgstr "Windows baltički (CP 1257)"
+
+#: ../src/common/fmapbase.cpp:175
+msgid "Windows Vietnamese (CP 1258)"
+msgstr "Windows vijetnamski (CP 1258)"
+
+#: ../src/common/fmapbase.cpp:176
+msgid "Windows Johab (CP 1361)"
+msgstr "Windows johapski (CP 1361)"
+
+#: ../src/common/fmapbase.cpp:177
+msgid "Windows/DOS OEM (CP 437)"
+msgstr "Windows/DOS OEM (CP 437)"
+
+#: ../src/common/fmapbase.cpp:178
+msgid "Unicode 7 bit (UTF-7)"
+msgstr "Unicode 7 bit (UTF-7)"
+
+#: ../src/common/fmapbase.cpp:179
+msgid "Unicode 8 bit (UTF-8)"
+msgstr "Unicode 8 bit (UTF-8)"
+
+#: ../src/common/fmapbase.cpp:181 ../src/common/fmapbase.cpp:187
+msgid "Unicode 16 bit (UTF-16)"
+msgstr "Unicode 16 bit (UTF-16)"
+
+#: ../src/common/fmapbase.cpp:182
+msgid "Unicode 16 bit Little Endian (UTF-16LE)"
+msgstr "Unicode 16 bit Little Endian (UTF-16LE)"
+
+#: ../src/common/fmapbase.cpp:183 ../src/common/fmapbase.cpp:189
+msgid "Unicode 32 bit (UTF-32)"
+msgstr "Unicode 32 bit (UTF-32)"
+
+#: ../src/common/fmapbase.cpp:184
+msgid "Unicode 32 bit Little Endian (UTF-32LE)"
+msgstr "Unicode 32 bit Little Endian (UTF-32LE)"
+
+#: ../src/common/fmapbase.cpp:186
+msgid "Unicode 16 bit Big Endian (UTF-16BE)"
+msgstr "Unicode 16 bit Big Endian (UTF-16BE)"
+
+#: ../src/common/fmapbase.cpp:188
+msgid "Unicode 32 bit Big Endian (UTF-32BE)"
+msgstr "Unicode 32 bit Big Endian (UTF-32BE)"
+
+#: ../src/common/fmapbase.cpp:191
+msgid "Extended Unix Codepage for Japanese (EUC-JP)"
+msgstr "Proširena Unix kodna strana za japanski (EUC-JP)"
+
+#: ../src/common/fmapbase.cpp:192
+msgid "US-ASCII"
+msgstr "US-ASCII"
+
+#: ../src/common/fmapbase.cpp:193
+msgid "ISO-2022-JP"
+msgstr "Japanski (ISO-2022-JP)"
+
+#: ../src/common/fmapbase.cpp:195
+msgid "MacRoman"
+msgstr "MacLatinični"
+
+#: ../src/common/fmapbase.cpp:196
+msgid "MacJapanese"
+msgstr "MacJapanski"
+
+#: ../src/common/fmapbase.cpp:197
+msgid "MacChineseTrad"
+msgstr "MacKineskiTradicionalni"
+
+#: ../src/common/fmapbase.cpp:198
+msgid "MacKorean"
+msgstr "MacKorejanski"
+
+#: ../src/common/fmapbase.cpp:199
+msgid "MacArabic"
+msgstr "MacArapski"
+
+#: ../src/common/fmapbase.cpp:200
+msgid "MacHebrew"
+msgstr "MacHebrejski"
+
+#: ../src/common/fmapbase.cpp:201
+msgid "MacGreek"
+msgstr "MacGrčki"
+
+#: ../src/common/fmapbase.cpp:202
+msgid "MacCyrillic"
+msgstr "MacĆirilica"
+
+#: ../src/common/fmapbase.cpp:203
+msgid "MacDevanagari"
+msgstr "MacDevanagarski"
+
+#: ../src/common/fmapbase.cpp:204
+msgid "MacGurmukhi"
+msgstr "MacGurmuški"
+
+#: ../src/common/fmapbase.cpp:205
+msgid "MacGujarati"
+msgstr "MacGudžaratski"
+
+#: ../src/common/fmapbase.cpp:206
+msgid "MacOriya"
+msgstr "MacOrijski"
+
+#: ../src/common/fmapbase.cpp:207
+msgid "MacBengali"
+msgstr "MacBengalski"
+
+#: ../src/common/fmapbase.cpp:208
+msgid "MacTamil"
+msgstr "MacTamilski"
+
+#: ../src/common/fmapbase.cpp:209
+msgid "MacTelugu"
+msgstr "MacTeluški"
+
+#: ../src/common/fmapbase.cpp:210
+msgid "MacKannada"
+msgstr "MacKanarezijski"
+
+#: ../src/common/fmapbase.cpp:211
+msgid "MacMalayalam"
+msgstr "MacMalajalamski"
+
+#: ../src/common/fmapbase.cpp:212
+msgid "MacSinhalese"
+msgstr "MacSinhalski"
+
+#: ../src/common/fmapbase.cpp:213
+msgid "MacBurmese"
+msgstr "MacBurmanski"
+
+#: ../src/common/fmapbase.cpp:214
+msgid "MacKhmer"
+msgstr "MacKmerski"
+
+#: ../src/common/fmapbase.cpp:215
+msgid "MacThai"
+msgstr "MacTajski"
+
+#: ../src/common/fmapbase.cpp:216
+msgid "MacLaotian"
+msgstr "MacLaoški"
+
+#: ../src/common/fmapbase.cpp:217
+msgid "MacGeorgian"
+msgstr "MacGruzijski"
+
+#: ../src/common/fmapbase.cpp:218
+msgid "MacArmenian"
+msgstr "MacArmenski"
+
+#: ../src/common/fmapbase.cpp:219
+msgid "MacChineseSimp"
+msgstr "MacKineskiPojednostavljeni"
+
+#: ../src/common/fmapbase.cpp:220
+msgid "MacTibetan"
+msgstr "MacTibetanski"
+
+#: ../src/common/fmapbase.cpp:221
+msgid "MacMongolian"
+msgstr "MacMongolski"
+
+#: ../src/common/fmapbase.cpp:222
+msgid "MacEthiopic"
+msgstr "MacEtiopski"
+
+#: ../src/common/fmapbase.cpp:223
+msgid "MacCentralEurRoman"
+msgstr "MacSrednjeeuropskiLatinični"
+
+#: ../src/common/fmapbase.cpp:224
+msgid "MacVietnamese"
+msgstr "MacVijetnamski"
+
+#: ../src/common/fmapbase.cpp:225
+msgid "MacExtArabic"
+msgstr "MacProšireniArapski"
+
+#: ../src/common/fmapbase.cpp:226
+msgid "MacSymbol"
+msgstr "MacSimbolni"
+
+#: ../src/common/fmapbase.cpp:227
+msgid "MacDingbats"
+msgstr "MacDingbats"
+
+#: ../src/common/fmapbase.cpp:228
+msgid "MacTurkish"
+msgstr "MacTurski"
+
+#: ../src/common/fmapbase.cpp:229
+msgid "MacCroatian"
+msgstr "MacHrvatski"
+
+#: ../src/common/fmapbase.cpp:230
+msgid "MacIcelandic"
+msgstr "MacIslandski"
+
+#: ../src/common/fmapbase.cpp:231
+msgid "MacRomanian"
+msgstr "MacRumunjski"
+
+#: ../src/common/fmapbase.cpp:232
+msgid "MacCeltic"
+msgstr "MacKeltski"
+
+#: ../src/common/fmapbase.cpp:233
+msgid "MacGaelic"
+msgstr "MacGalski"
+
+#: ../src/common/fmapbase.cpp:234
+msgid "MacKeyboardGlyphs"
+msgstr "GrafemiMacTipkovnice"
+
+#: ../src/common/fmapbase.cpp:791
+msgid "Default encoding"
+msgstr "Zadano kodiranje"
+
+#: ../src/common/fmapbase.cpp:805
+#, c-format
+msgid "Unknown encoding (%d)"
+msgstr "Nepoznato kodiranje (%d)"
+
+#: ../src/common/fmapbase.cpp:815 ../src/richtext/richtextstyles.cpp:776
+msgid "default"
+msgstr "zadano"
+
+#: ../src/common/fmapbase.cpp:829
+#, c-format
+msgid "unknown-%d"
+msgstr "nepoznato-%d"
+
+#: ../src/common/fontcmn.cpp:924 ../src/common/fontcmn.cpp:1130
+msgid "underlined"
+msgstr "podcrtano"
+
+#: ../src/common/fontcmn.cpp:929
+msgid " strikethrough"
+msgstr " precrtano"
+
+#: ../src/common/fontcmn.cpp:942
+msgid " thin"
+msgstr " tanki"
+
+#: ../src/common/fontcmn.cpp:946
+msgid " extra light"
+msgstr " ekstra svjetli"
+
+#: ../src/common/fontcmn.cpp:950
+msgid " light"
+msgstr " svjetli"
+
+#: ../src/common/fontcmn.cpp:954
+msgid " medium"
+msgstr " srednji"
+
+#: ../src/common/fontcmn.cpp:958
+msgid " semi bold"
+msgstr " polu debeli"
+
+#: ../src/common/fontcmn.cpp:962
+msgid " bold"
+msgstr " debeli"
+
+#: ../src/common/fontcmn.cpp:966
+msgid " extra bold"
+msgstr " ekstra debeli"
+
+#: ../src/common/fontcmn.cpp:970
+msgid " heavy"
+msgstr " masni"
+
+#: ../src/common/fontcmn.cpp:974
+msgid " extra heavy"
+msgstr " ekstra masni"
+
+#: ../src/common/fontcmn.cpp:990
+msgid " italic"
+msgstr " kurziv"
+
+#: ../src/common/fontcmn.cpp:1134
+msgid "strikethrough"
+msgstr "precrtano"
+
+#: ../src/common/fontcmn.cpp:1143
+msgid "thin"
+msgstr "tanki"
+
+#: ../src/common/fontcmn.cpp:1156
+msgid "extralight"
+msgstr "ekstrasvjetli"
+
+#: ../src/common/fontcmn.cpp:1161
+msgid "light"
+msgstr "svijetli"
+
+#: ../src/common/fontcmn.cpp:1169 ../src/richtext/richtextstyles.cpp:775
+msgid "normal"
+msgstr "normalni"
+
+#: ../src/common/fontcmn.cpp:1174
+msgid "medium"
+msgstr "srednji"
+
+#: ../src/common/fontcmn.cpp:1179 ../src/common/fontcmn.cpp:1199
+msgid "semibold"
+msgstr "poludebeli"
+
+#: ../src/common/fontcmn.cpp:1184
+msgid "bold"
+msgstr "debeli"
+
+#: ../src/common/fontcmn.cpp:1194
+msgid "extrabold"
+msgstr "ekstradebeli"
+
+#: ../src/common/fontcmn.cpp:1204
+msgid "heavy"
+msgstr "masni"
+
+#: ../src/common/fontcmn.cpp:1212
+msgid "extraheavy"
+msgstr "ekstramasni"
+
+#: ../src/common/fontcmn.cpp:1217
+msgid "italic"
+msgstr "kurziv"
+
+#: ../src/common/fontmap.cpp:195
+msgid ": unknown charset"
+msgstr ": nepoznata kodna stranica"
+
+#: ../src/common/fontmap.cpp:199
+#, c-format
+msgid ""
+"The charset '%s' is unknown. You may select\n"
+"another charset to replace it with or choose\n"
+"[Cancel] if it cannot be replaced"
+msgstr ""
+"Kodna stranica „%s” nije poznata. Možeš odabrati\n"
+"neku drugu kodnu stranicu kao zamjenu ili\n"
+"[Odustani] ako izmjena nije moguća"
+
+#: ../src/common/fontmap.cpp:241
+#, c-format
+msgid "Failed to remember the encoding for the charset '%s'."
+msgstr "Neuspjelo pamćenje kodiranja za skupinu znakova „%s”."
+
+#: ../src/common/fontmap.cpp:321
+msgid "can't load any font, aborting"
+msgstr "nije moguće učitavanje fontova, prekida se"
+
+#: ../src/common/fontmap.cpp:409
+msgid ": unknown encoding"
+msgstr ": nepoznato kodiranje"
+
+#: ../src/common/fontmap.cpp:417
+#, c-format
+msgid ""
+"No font for displaying text in encoding '%s' found,\n"
+"but an alternative encoding '%s' is available.\n"
+"Do you want to use this encoding (otherwise you will have to choose another "
+"one)?"
+msgstr ""
+"Nijedan font nije nađen za prikaz teksta, kodiranog u „%s”,\n"
+"no dostupno je alternativno kodiranje „%s”.\n"
+"Želiš li koristiti ovo kodiranje (inače ćeš morati odabrati neko drugo)?"
+
+#: ../src/common/fontmap.cpp:422
+#, c-format
+msgid ""
+"No font for displaying text in encoding '%s' found.\n"
+"Would you like to select a font to be used for this encoding\n"
+"(otherwise the text in this encoding will not be shown correctly)?"
+msgstr ""
+"Nijedan font nije nađen za prikaz teksta, kodiranog u „%s”.\n"
+"Želiš li odabrati font za ovo kodiranje (inače se tekst s ovim\n"
+"kodiranjem neće pravilno prikazati)?"
+
+#: ../src/common/fs_mem.cpp:169
+#, c-format
+msgid "Memory VFS already contains file '%s'!"
+msgstr "Memorija VFS već sadržava datoteku „%s”!"
+
+#: ../src/common/fs_mem.cpp:232
+#, c-format
+msgid "Trying to remove file '%s' from memory VFS, but it is not loaded!"
+msgstr "Pokušaj uklanjanja datoteke „%s” iz memorije VFS, ali nije učitana!"
+
+#: ../src/common/fs_mem.cpp:262
+#, c-format
+msgid "Failed to store image '%s' to memory VFS!"
+msgstr "Neuspjelo spremanje slike „%s” u VFS memoriju!"
+
+#: ../src/common/ftp.cpp:197
+msgid "Timeout while waiting for FTP server to connect, try passive mode."
+msgstr ""
+"Prekoračenje vremena prilikom čekanja na spajanje s FTP serverom, pokušaj u "
+"pasivnom modusu."
+
+#: ../src/common/ftp.cpp:399
+#, c-format
+msgid "Failed to set FTP transfer mode to %s."
+msgstr "Neuspjelo postavljanje modusa za FTP prijenos na %s."
+
+#: ../src/common/ftp.cpp:400 ../src/richtext/richtextsymboldlg.cpp:432
+msgid "ASCII"
+msgstr "ASCII"
+
+#: ../src/common/ftp.cpp:400
+msgid "binary"
+msgstr "binarno"
+
+#: ../src/common/ftp.cpp:608
+msgid "The FTP server doesn't support the PORT command."
+msgstr "FTP server ne podržava PORT naredbe."
+
+#: ../src/common/ftp.cpp:622
+msgid "The FTP server doesn't support passive mode."
+msgstr "FTP server ne podržava pasivni modus."
+
+#: ../src/common/gifdecod.cpp:822
+#, c-format
+msgid "Incorrect GIF frame size (%u, %d) for the frame #%u"
+msgstr "Nepravilna veličina GIF okvira (%u, %d) za okvir #%u"
+
+#: ../src/common/glcmn.cpp:108
+msgid "Failed to allocate colour for OpenGL"
+msgstr "Neuspjelo alociranje boje za OpenGL"
+
+#: ../src/common/headerctrlcmn.cpp:57
+msgid "Please select the columns to show and define their order:"
+msgstr "Odaberi stupce koje želiš prikazati i odredi njihov raspored:"
+
+#: ../src/common/headerctrlcmn.cpp:58
+msgid "Customize Columns"
+msgstr "Prilagodi stupce"
+
+#: ../src/common/headerctrlcmn.cpp:304
+msgid "&Customize..."
+msgstr "&Prilagodi …"
+
+#: ../src/common/hyperlnkcmn.cpp:132
+#, c-format
+msgid "Failed to open URL \"%s\" in the default browser"
+msgstr "Neuspjelo otvaranje URL-a „%s” u zadanom pregledniku"
+
+#: ../src/common/iconbndl.cpp:195
+#, c-format
+msgid "Failed to load image %%d from file '%s'."
+msgstr "Neuspjelo učitavanje slike %%d iz datoteke „%s”."
+
+#: ../src/common/iconbndl.cpp:203
+#, c-format
+msgid "Failed to load image %d from stream."
+msgstr "Neuspjelo učitavanje slike %d iz tijeka."
+
+#: ../src/common/iconbndl.cpp:221
+#, c-format
+msgid "Failed to load icons from resource '%s'."
+msgstr "Neuspjelo učitavanje ikona iz resursa „%s”."
+
+#: ../src/common/imagbmp.cpp:97
+msgid "BMP: Couldn't save invalid image."
+msgstr "BMP: Nije bilo moguće spremiti nevaljanu sliku."
+
+#: ../src/common/imagbmp.cpp:137
+msgid "BMP: wxImage doesn't have own wxPalette."
+msgstr "BMP: wxImage nema vlastitu wxPalette."
+
+#: ../src/common/imagbmp.cpp:243
+msgid "BMP: Couldn't write the file (Bitmap) header."
+msgstr "BMP: Nije bilo moguće zapisati zaglavlje (bitmap) datoteke."
+
+#: ../src/common/imagbmp.cpp:266
+msgid "BMP: Couldn't write the file (BitmapInfo) header."
+msgstr "BMP: Nije bilo moguće zapisati zaglavlje (bitmapinfo) datoteke."
+
+#: ../src/common/imagbmp.cpp:353
+msgid "BMP: Couldn't write RGB color map."
+msgstr "BMP: Nije bilo moguće zapisati RGB mapu boja."
+
+#: ../src/common/imagbmp.cpp:487
+msgid "BMP: Couldn't write data."
+msgstr "BMP: Nije bilo moguće zapisati podatke."
+
+#: ../src/common/imagbmp.cpp:561 ../src/common/imagbmp.cpp:642
+msgid "BMP: Couldn't allocate memory."
+msgstr "BMP: Nije bilo moguće alocirati memoriju."
+
+#: ../src/common/imagbmp.cpp:1041
+msgid "DIB Header: Image width > 32767 pixels for file."
+msgstr "DIB Header: Širina slike > 32767 piksela za datoteku."
+
+#: ../src/common/imagbmp.cpp:1049
+msgid "DIB Header: Image height > 32767 pixels for file."
+msgstr "DIB Header: Visina slike > 32767 piksela za datoteku."
+
+#: ../src/common/imagbmp.cpp:1081
+msgid "DIB Header: Unknown bitdepth in file."
+msgstr "DIB zaglavlje: Nepoznata bit-dubina u datoteci."
+
+#: ../src/common/imagbmp.cpp:1156
+msgid "DIB Header: Unknown encoding in file."
+msgstr "DIB zaglavlje: Nepoznato kodiranje u datoteci."
+
+#: ../src/common/imagbmp.cpp:1165
+msgid "DIB Header: Encoding doesn't match bitdepth."
+msgstr "DIB zaglavlje: Kodiranje se ne poklapa s bit-dubinom."
+
+#: ../src/common/imagbmp.cpp:1180
+#, c-format
+msgid "BMP Header: Invalid number of colors (%d)."
+msgstr ""
+
+#: ../src/common/imagbmp.cpp:1273
+msgid "Error in reading image DIB."
+msgstr "Greška u čitanju DIB slike."
+
+#: ../src/common/imagbmp.cpp:1294
+msgid "ICO: Error in reading mask DIB."
+msgstr "ICO: Greška prilikom čitanja DIB maske."
+
+#: ../src/common/imagbmp.cpp:1353
+msgid "ICO: Image too tall for an icon."
+msgstr "ICO: Slika je pre visoka za ikonu."
+
+#: ../src/common/imagbmp.cpp:1361
+msgid "ICO: Image too wide for an icon."
+msgstr "ICO: Slika je pre široka za ikonu."
+
+#: ../src/common/imagbmp.cpp:1388 ../src/common/imagbmp.cpp:1488
+#: ../src/common/imagbmp.cpp:1503 ../src/common/imagbmp.cpp:1514
+#: ../src/common/imagbmp.cpp:1528 ../src/common/imagbmp.cpp:1576
+#: ../src/common/imagbmp.cpp:1591 ../src/common/imagbmp.cpp:1605
+#: ../src/common/imagbmp.cpp:1616
+msgid "ICO: Error writing the image file!"
+msgstr "ICO: Greška prilikom pisanja datoteke slike!"
+
+#: ../src/common/imagbmp.cpp:1701
+msgid "ICO: Invalid icon index."
+msgstr "ICO: Nevaljani indeks ikone."
+
+#: ../src/common/image.cpp:2410
+msgid "Image and mask have different sizes."
+msgstr "Slika i maska imaju različite veličine."
+
+#: ../src/common/image.cpp:2418 ../src/common/image.cpp:2459
+msgid "No unused colour in image being masked."
+msgstr "Nema nekorištenih boja u slici koja se maskira."
+
+#: ../src/common/image.cpp:2641
+#, c-format
+msgid "Failed to load bitmap \"%s\" from resources."
+msgstr "Neuspjelo učitavanje bitmapa „%s” iz resursa."
+
+#: ../src/common/image.cpp:2650
+#, c-format
+msgid "Failed to load icon \"%s\" from resources."
+msgstr "Neuspjelo učitavanje ikone „%s” iz resursa."
+
+#: ../src/common/image.cpp:2728 ../src/common/image.cpp:2747
+#, c-format
+msgid "Failed to load image from file \"%s\"."
+msgstr "Neuspjelo učitavanje slike iz datoteke „%s”."
+
+#: ../src/common/image.cpp:2761
+#, c-format
+msgid "Can't save image to file '%s': unknown extension."
+msgstr "Nije moguće spremanje slikovne datoteke „%s”: nepoznati sufiks."
+
+#: ../src/common/image.cpp:2869
+msgid "No handler found for image type."
+msgstr "Nije nađen upravljač za vrstu slike."
+
+#: ../src/common/image.cpp:2877 ../src/common/image.cpp:3000
+#: ../src/common/image.cpp:3066
+#, c-format
+msgid "No image handler for type %d defined."
+msgstr "Nijedan upravljač slikama za vrstu %d nije određen."
+
+#: ../src/common/image.cpp:2887
+#, c-format
+msgid "Image file is not of type %d."
+msgstr "Datoteka slike nije vrste %d."
+
+#: ../src/common/image.cpp:2970
+msgid "Can't automatically determine the image format for non-seekable input."
+msgstr ""
+"Nije moguće automatski odrediti format slike za unos koji se ne može tražiti."
+
+#: ../src/common/image.cpp:2988
+msgid "Unknown image data format."
+msgstr "Nepoznati format slikovnih podataka."
+
+#: ../src/common/image.cpp:3009
+#, c-format
+msgid "This is not a %s."
+msgstr "Ovo nije %s."
+
+#: ../src/common/image.cpp:3032 ../src/common/image.cpp:3080
+#, c-format
+msgid "No image handler for type %s defined."
+msgstr "Nijedan upravljač slikama za vrstu %s nije određen."
+
+#: ../src/common/image.cpp:3041
+#, c-format
+msgid "Image is not of type %s."
+msgstr "Slika nije vrste %s."
+
+#: ../src/common/image.cpp:3509
+#, c-format
+msgid "Failed to check format of image file \"%s\"."
+msgstr "Neuspjela provjera formata datoteke slike „%s”."
+
+#: ../src/common/imaggif.cpp:124
+msgid "GIF: error in GIF image format."
+msgstr "GIF: greška u GIF formatu slike."
+
+#: ../src/common/imaggif.cpp:129
+msgid "GIF: not enough memory."
+msgstr "GIF: nema dovoljno memorije."
+
+#: ../src/common/imaggif.cpp:134
+msgid "GIF: data stream seems to be truncated."
+msgstr "GIF: čini se, da je prijenos podataka odrezan."
+
+#: ../src/common/imaggif.cpp:240
+msgid "Couldn't initialize GIF hash table."
+msgstr "Nije bilo moguće initijalizirati GIF hash tablicu."
+
+#: ../src/common/imagiff.cpp:739
+msgid "IFF: error in IFF image format."
+msgstr "IFF: greška u IFF formatu slike."
+
+#: ../src/common/imagiff.cpp:742
+msgid "IFF: not enough memory."
+msgstr "IFF: nema dovoljno memorije."
+
+#: ../src/common/imagiff.cpp:745
+msgid "IFF: unknown error!!!"
+msgstr "IFF: nepoznata greška!!!"
+
+#: ../src/common/imagiff.cpp:755
+msgid "IFF: data stream seems to be truncated."
+msgstr "IFF: čini se, da je prijenos podataka odrezan."
+
+#: ../src/common/imagjpeg.cpp:258
+msgid "JPEG: Couldn't load - file is probably corrupted."
+msgstr "JPEG: Nije bilo moguće učitati – datoteka je vjerojatno oštećena."
+
+#: ../src/common/imagjpeg.cpp:437
+msgid "JPEG: Couldn't save image."
+msgstr "JPEG: Nije bilo moguće spremiti sliku."
+
+#: ../src/common/imagpcx.cpp:439
+msgid "PCX: this is not a PCX file."
+msgstr "PCX: ovo nije PCX datoteka."
+
+#: ../src/common/imagpcx.cpp:453
+msgid "PCX: image format unsupported"
+msgstr "PCX: format slike nije podržan"
+
+#: ../src/common/imagpcx.cpp:454 ../src/common/imagpcx.cpp:477
+msgid "PCX: couldn't allocate memory"
+msgstr "BMP: Nije bilo moguće alocirati memoriju"
+
+#: ../src/common/imagpcx.cpp:455
+msgid "PCX: version number too low"
+msgstr "PCX: broj verzije je pre nizak"
+
+#: ../src/common/imagpcx.cpp:456 ../src/common/imagpcx.cpp:478
+msgid "PCX: unknown error !!!"
+msgstr "PCX: nepoznata greška !!!"
+
+#: ../src/common/imagpcx.cpp:476
+msgid "PCX: invalid image"
+msgstr "PCX: nevaljana slika"
+
+#: ../src/common/imagpng.cpp:385
+#, c-format
+msgid "Unknown PNG resolution unit %d"
+msgstr "Nepoznata PNG jedinica rezolucije %d"
+
+#: ../src/common/imagpng.cpp:439
+msgid "Couldn't load a PNG image - file is corrupted or not enough memory."
+msgstr ""
+"Nije bilo moguće učitati PNG sliku – datoteka je pokvarena ili nema dovoljno "
+"memorije."
+
+#: ../src/common/imagpng.cpp:513 ../src/common/imagpng.cpp:524
+#: ../src/common/imagpng.cpp:534
+msgid "Couldn't save PNG image."
+msgstr "Nije bilo moguće spremiti PNG sliku."
+
+#: ../src/common/imagpnm.cpp:71
+msgid "PNM: File format is not recognized."
+msgstr "PNM: Format datoteke nije prepoznat."
+
+#: ../src/common/imagpnm.cpp:89
+msgid "PNM: Couldn't allocate memory."
+msgstr "PNM: Nije moguće alocirati memoriju."
+
+#: ../src/common/imagpnm.cpp:111 ../src/common/imagpnm.cpp:134
+#: ../src/common/imagpnm.cpp:156
+msgid "PNM: File seems truncated."
+msgstr "PNM: Datoteka se čini odrezanom."
+
+#: ../src/common/imagtiff.cpp:69
+#, c-format
+msgid " (in module \"%s\")"
+msgstr " (u modulu „%s”)"
+
+#: ../src/common/imagtiff.cpp:304
+msgid "TIFF: Error loading image."
+msgstr "TIFF: Greška prilikom učitavanja slike."
+
+#: ../src/common/imagtiff.cpp:314
+msgid "Invalid TIFF image index."
+msgstr "Nevaljani indeks TIFF slike."
+
+#: ../src/common/imagtiff.cpp:358
+msgid "TIFF: Image size is abnormally big."
+msgstr "TIFF: Slika je abnormalno velika."
+
+#: ../src/common/imagtiff.cpp:372 ../src/common/imagtiff.cpp:385
+#: ../src/common/imagtiff.cpp:769
+msgid "TIFF: Couldn't allocate memory."
+msgstr "TIFF: Nije moguće alocirati memoriju."
+
+#: ../src/common/imagtiff.cpp:471
+msgid "TIFF: Error reading image."
+msgstr "TIFF: Greška prilikom čitanja slike."
+
+#: ../src/common/imagtiff.cpp:532
+#, c-format
+msgid "Unknown TIFF resolution unit %d ignored"
+msgstr "Nepoznata TIFF jedinica rezolucije %d je zanemarena"
+
+#: ../src/common/imagtiff.cpp:611
+msgid "TIFF: Error saving image."
+msgstr "TIFF: Greška prilikom spremanja slike."
+
+#: ../src/common/imagtiff.cpp:868
+msgid "TIFF: Error writing image."
+msgstr "TIFF: Greška prilikom pisanja slike."
+
+#: ../src/common/imagtiff.cpp:881
+#, fuzzy
+msgid "TIFF: Error flushing data."
+msgstr "TIFF: Greška prilikom spremanja slike."
+
+#: ../src/common/imagwebp.cpp:56
+msgid "WebP: Invalid data (failed to get features)."
+msgstr ""
+
+#: ../src/common/imagwebp.cpp:65
+msgid "WebP: Allocating image memory failed."
+msgstr ""
+
+#: ../src/common/imagwebp.cpp:82
+msgid "WebP: Decoding RGBA image data failed."
+msgstr ""
+
+#: ../src/common/imagwebp.cpp:98
+msgid "WebP: Decoding RGB image data failed."
+msgstr ""
+
+#: ../src/common/imagwebp.cpp:113 ../src/common/imagwebp.cpp:201
+msgid "WebP: Allocating stream buffer failed."
+msgstr ""
+
+#: ../src/common/imagwebp.cpp:131
+#, fuzzy
+msgid "WebP: Failed to parse container data."
+msgstr "Neuspjelo postavljanje podataka međuspremnika."
+
+#: ../src/common/imagwebp.cpp:222
+#, fuzzy
+msgid "WebP: Error decoding animation."
+msgstr "Greška prilikom čitanja opcija konfiguracije."
+
+#: ../src/common/imagwebp.cpp:240
+msgid "WebP: Error getting next animation frame."
+msgstr ""
+
+#: ../src/common/init.cpp:172
+#, c-format
+msgid ""
+"Command line argument %d couldn't be converted to Unicode and will be "
+"ignored."
+msgstr ""
+"Argument naredbenog retka %d nije bilo moguće konvertirati u Unicode i bit "
+"će zanemaren."
+
+#: ../src/common/init.cpp:344
+msgid "Initialization failed in post init, aborting."
+msgstr "Inicijaliziranje u naknadnom inicijaliziranju nije uspjelo, prekid."
+
+#: ../src/common/intl.cpp:378
+#, c-format
+msgid "Cannot set locale to language \"%s\"."
+msgstr "Nije moguće postaviti lokalizaciju za „%s” jezik."
+
+#: ../src/common/log.cpp:232
+msgid "Error: "
+msgstr "Greška: "
+
+#: ../src/common/log.cpp:236
+msgid "Warning: "
+msgstr "Upozorenje: "
+
+#: ../src/common/log.cpp:284
+msgid "The previous message repeated once."
+msgstr "Prethodna obavijest se ponovila jednom."
+
+#: ../src/common/log.cpp:291
+#, c-format
+msgid "The previous message repeated %u time."
+msgid_plural "The previous message repeated %u times."
+msgstr[0] "Prethodna obavijest se ponovila %u puta."
+msgstr[1] "Prethodna obavijest se ponovila %u puta."
+msgstr[2] "Prethodna obavijest se ponovila %u puta."
+
+#: ../src/common/log.cpp:319
+#, c-format
+msgid "Last repeated message (\"%s\", %u time) wasn't output"
+msgid_plural "Last repeated message (\"%s\", %u times) wasn't output"
+msgstr[0] "Zadnja ponovljena poruka („%s”, %u puta) nije iznešena"
+msgstr[1] "Zadnja ponovljena poruka („%s”, %u puta) nije iznešena"
+msgstr[2] "Zadnja ponovljena poruka („%s”, %u puta) nije iznešena"
+
+#: ../src/common/log.cpp:435
+#, c-format
+msgid " (error %ld: %s)"
+msgstr " (greška %ld: %s)"
+
+#: ../src/common/lzmastream.cpp:121
+msgid "Failed to allocate memory for LZMA decompression."
+msgstr "Neuspjelo alociranje memorije za LZMA dekomprimiranje."
+
+#: ../src/common/lzmastream.cpp:125
+#, c-format
+msgid "Failed to initialize LZMA decompression: unexpected error %u."
+msgstr ""
+"Neuspjelo inicijaliziranje LZMA dekomprimiranja: neočekivana greška %u."
+
+#: ../src/common/lzmastream.cpp:179
+msgid "input is not in XZ format"
+msgstr "unos nije u XZ formatu"
+
+#: ../src/common/lzmastream.cpp:183
+msgid "input compressed using unknown XZ option"
+msgstr "unos je komprimiran koristeći nepoznatu opciju XZ formata"
+
+#: ../src/common/lzmastream.cpp:188
+msgid "input is corrupted"
+msgstr "unos je oštećen"
+
+#: ../src/common/lzmastream.cpp:192
+msgid "unknown decompression error"
+msgstr "nepoznata greška dekomprimiranja"
+
+#: ../src/common/lzmastream.cpp:196
+#, c-format
+msgid "LZMA decompression error: %s"
+msgstr "Greška LZMA dekomprimiranja: %s"
+
+#: ../src/common/lzmastream.cpp:231
+msgid "Failed to allocate memory for LZMA compression."
+msgstr "Neuspjelo alociranje memorije za LZMA komprimiranje."
+
+#: ../src/common/lzmastream.cpp:235
+#, c-format
+msgid "Failed to initialize LZMA compression: unexpected error %u."
+msgstr "Neuspjelo inicijaliziranje LZMA komprimiranja: neočekivana greška %u."
+
+#: ../src/common/lzmastream.cpp:267 ../src/common/lzmastream.cpp:342
+#: ../src/html/chm.cpp:336
+msgid "out of memory"
+msgstr "nema više memorije"
+
+#: ../src/common/lzmastream.cpp:276 ../src/common/lzmastream.cpp:346
+msgid "unknown compression error"
+msgstr "nepoznata greška komprimiranja"
+
+#: ../src/common/lzmastream.cpp:280
+#, c-format
+msgid "LZMA compression error: %s"
+msgstr "Greška LZMA komprimiranja: %s"
+
+#: ../src/common/lzmastream.cpp:350
+#, c-format
+msgid "LZMA compression error when flushing output: %s"
+msgstr "Greška LZMA komprimiranja prilikom nedovršavanja iznošaja: %s"
+
+#: ../src/common/mimecmn.cpp:167
+#, c-format
+msgid "Unmatched '{' in an entry for mime type %s."
+msgstr "Nezatvorena „{” u jednom unosu za mime vrstu %s."
+
+#: ../src/common/module.cpp:76
+#, c-format
+msgid "Circular dependency involving module \"%s\" detected."
+msgstr "Ustanovljena je beskonačna ovisnost u modulu „%s”."
+
+#: ../src/common/module.cpp:128
+#, c-format
+msgid "Dependency \"%s\" of module \"%s\" doesn't exist."
+msgstr "Ovisnost „%s” o modulu „%s” ne postoji."
+
+#: ../src/common/module.cpp:137
+#, c-format
+msgid "Module \"%s\" initialization failed"
+msgstr "Inicijaliziranje modula „%s” nije uspjelo"
+
+#: ../src/common/msgout.cpp:96
+msgid "Message"
+msgstr "Poruka"
+
+#: ../src/common/paper.cpp:70
+msgid "Letter, 8 1/2 x 11 in"
+msgstr "Letter, 8 1/2 x 11 in"
+
+#: ../src/common/paper.cpp:71
+msgid "Legal, 8 1/2 x 14 in"
+msgstr "Legal, 8 1/2 x 14 in"
+
+#: ../src/common/paper.cpp:72
+msgid "A4 sheet, 210 x 297 mm"
+msgstr "A4 arak, 210 × 297 mm"
+
+#: ../src/common/paper.cpp:73
+msgid "C sheet, 17 x 22 in"
+msgstr "C arak, 17 × 22 in"
+
+#: ../src/common/paper.cpp:74
+msgid "D sheet, 22 x 34 in"
+msgstr "D arak, 22 × 34 in"
+
+#: ../src/common/paper.cpp:75
+msgid "E sheet, 34 x 44 in"
+msgstr "E arak, 34 × 44 in"
+
+#: ../src/common/paper.cpp:76
+msgid "Letter Small, 8 1/2 x 11 in"
+msgstr "Letter Small, 8 1/2 x 11 in"
+
+#: ../src/common/paper.cpp:77
+msgid "Tabloid, 11 x 17 in"
+msgstr "Tabloid, 11 × 17 in"
+
+#: ../src/common/paper.cpp:78
+msgid "Ledger, 17 x 11 in"
+msgstr "Ledger, 17 × 11 in"
+
+#: ../src/common/paper.cpp:79
+msgid "Statement, 5 1/2 x 8 1/2 in"
+msgstr "Statement, 5 1/2 × 8 1/2 in"
+
+#: ../src/common/paper.cpp:80
+msgid "Executive, 7 1/4 x 10 1/2 in"
+msgstr "Executive, 7 1/4 × 10 1/2 in"
+
+#: ../src/common/paper.cpp:81
+msgid "A3 sheet, 297 x 420 mm"
+msgstr "A3 arak, 297 × 420 mm"
+
+#: ../src/common/paper.cpp:82
+msgid "A4 small sheet, 210 x 297 mm"
+msgstr "A4 mali arak, 210 × 297 mm"
+
+#: ../src/common/paper.cpp:83
+msgid "A5 sheet, 148 x 210 mm"
+msgstr "A5 arak, 148 × 210 mm"
+
+#: ../src/common/paper.cpp:84
+msgid "B4 sheet, 250 x 354 mm"
+msgstr "B4 arak, 250 × 354 mm"
+
+#: ../src/common/paper.cpp:85
+msgid "B5 sheet, 182 x 257 millimeter"
+msgstr "B5 arak, 182 × 257 millimeter"
+
+#: ../src/common/paper.cpp:86
+msgid "Folio, 8 1/2 x 13 in"
+msgstr "Folio, 8 1/2 × 13 in"
+
+#: ../src/common/paper.cpp:87
+msgid "Quarto, 215 x 275 mm"
+msgstr "Quarto, 215 × 275 mm"
+
+#: ../src/common/paper.cpp:88
+msgid "10 x 14 in"
+msgstr "10 × 14 in"
+
+#: ../src/common/paper.cpp:89
+msgid "11 x 17 in"
+msgstr "11 × 17 in"
+
+#: ../src/common/paper.cpp:90
+msgid "Note, 8 1/2 x 11 in"
+msgstr "Note, 8 1/2 × 11 in"
+
+#: ../src/common/paper.cpp:91
+msgid "#9 Envelope, 3 7/8 x 8 7/8 in"
+msgstr "#9 kuverta, 3 7/8 × 8 7/8 in"
+
+#: ../src/common/paper.cpp:92
+msgid "#10 Envelope, 4 1/8 x 9 1/2 in"
+msgstr "#10 kuverta, 4 1/8 × 9 1/2 in"
+
+#: ../src/common/paper.cpp:93
+msgid "#11 Envelope, 4 1/2 x 10 3/8 in"
+msgstr "#11 kuverta, 4 1/2 × 10 3/8 in"
+
+#: ../src/common/paper.cpp:94
+msgid "#12 Envelope, 4 3/4 x 11 in"
+msgstr "#12 kuverta, 4 3/4 × 11 in"
+
+#: ../src/common/paper.cpp:95
+msgid "#14 Envelope, 5 x 11 1/2 in"
+msgstr "#14 kuverta, 5 × 11 1/2 in"
+
+#: ../src/common/paper.cpp:96
+msgid "DL Envelope, 110 x 220 mm"
+msgstr "DL kuverta, 110 × 220 mm"
+
+#: ../src/common/paper.cpp:97
+msgid "C5 Envelope, 162 x 229 mm"
+msgstr "C5 kuverta, 162 × 229 mm"
+
+#: ../src/common/paper.cpp:98
+msgid "C3 Envelope, 324 x 458 mm"
+msgstr "C3 kuverta, 324 × 458 mm"
+
+#: ../src/common/paper.cpp:99
+msgid "C4 Envelope, 229 x 324 mm"
+msgstr "C4 kuverta, 229 × 324 mm"
+
+#: ../src/common/paper.cpp:100
+msgid "C6 Envelope, 114 x 162 mm"
+msgstr "C6 kuverta, 114 × 162 mm"
+
+#: ../src/common/paper.cpp:101
+msgid "C65 Envelope, 114 x 229 mm"
+msgstr "C65 kuverta, 114 × 229 mm"
+
+#: ../src/common/paper.cpp:102
+msgid "B4 Envelope, 250 x 353 mm"
+msgstr "B4 kuverta, 250 × 353 mm"
+
+#: ../src/common/paper.cpp:103
+msgid "B5 Envelope, 176 x 250 mm"
+msgstr "B5 kuverta, 176 × 250 mm"
+
+#: ../src/common/paper.cpp:104
+msgid "B6 Envelope, 176 x 125 mm"
+msgstr "B6 kuverta, 176 × 125 mm"
+
+#: ../src/common/paper.cpp:105
+msgid "Italy Envelope, 110 x 230 mm"
+msgstr "Talijanska kuverta, 110 × 230 mm"
+
+#: ../src/common/paper.cpp:106
+msgid "Monarch Envelope, 3 7/8 x 7 1/2 in"
+msgstr "Monarch kuverta, 3 7/8 × 7 1/2 in"
+
+#: ../src/common/paper.cpp:107
+msgid "6 3/4 Envelope, 3 5/8 x 6 1/2 in"
+msgstr "6 3/4 kuverta, 3 5/8 × 6 1/2 in"
+
+#: ../src/common/paper.cpp:108
+msgid "US Std Fanfold, 14 7/8 x 11 in"
+msgstr "US Std presavijen, 14 7/8 × 11 in"
+
+#: ../src/common/paper.cpp:109
+msgid "German Std Fanfold, 8 1/2 x 12 in"
+msgstr "Njemački Std presavijen, 8 1/2 × 12 in"
+
+#: ../src/common/paper.cpp:110
+msgid "German Legal Fanfold, 8 1/2 x 13 in"
+msgstr "Njemački Legal presavijen, 8 1/2 × 13 in"
+
+#: ../src/common/paper.cpp:112
+msgid "B4 (ISO) 250 x 353 mm"
+msgstr "B4 (ISO) 250 × 353 mm"
+
+#: ../src/common/paper.cpp:113
+msgid "Japanese Postcard 100 x 148 mm"
+msgstr "Japanska razglednica 100 × 148 mm"
+
+#: ../src/common/paper.cpp:114
+msgid "9 x 11 in"
+msgstr "9 × 11 in"
+
+#: ../src/common/paper.cpp:115
+msgid "10 x 11 in"
+msgstr "10 × 11 in"
+
+#: ../src/common/paper.cpp:116
+msgid "15 x 11 in"
+msgstr "15 × 11 in"
+
+#: ../src/common/paper.cpp:117
+msgid "Envelope Invite 220 x 220 mm"
+msgstr "Kuverta pozivnice 220 × 220 mm"
+
+#: ../src/common/paper.cpp:118
+msgid "Letter Extra 9 1/2 x 12 in"
+msgstr "Letter Extra 9 1/2 x 12 in"
+
+#: ../src/common/paper.cpp:119
+msgid "Legal Extra 9 1/2 x 15 in"
+msgstr "Legal Extra 9 1/2 x 15 in"
+
+#: ../src/common/paper.cpp:120
+msgid "Tabloid Extra 11.69 x 18 in"
+msgstr "Tabloid Extra 11.69 × 18 in"
+
+#: ../src/common/paper.cpp:121
+msgid "A4 Extra 9.27 x 12.69 in"
+msgstr "A4 ekstra 9.27 × 12.69 in"
+
+#: ../src/common/paper.cpp:122
+msgid "Letter Transverse 8 1/2 x 11 in"
+msgstr "Letter Transverse 8 1/2 x 11 in"
+
+#: ../src/common/paper.cpp:123
+msgid "A4 Transverse 210 x 297 mm"
+msgstr "A4 poprečno 210 × 297 mm"
+
+#: ../src/common/paper.cpp:124
+msgid "Letter Extra Transverse 9.275 x 12 in"
+msgstr "Letter Extra Transverse 9.275 x 12 in"
+
+#: ../src/common/paper.cpp:125
+msgid "SuperA/SuperA/A4 227 x 356 mm"
+msgstr "SuperA/SuperA/A4 227 × 356 mm"
+
+#: ../src/common/paper.cpp:126
+msgid "SuperB/SuperB/A3 305 x 487 mm"
+msgstr "SuperB/SuperB/A3 305 × 487 mm"
+
+#: ../src/common/paper.cpp:127
+msgid "Letter Plus 8 1/2 x 12.69 in"
+msgstr "Letter Plus 8 1/2 x 12.69 in"
+
+#: ../src/common/paper.cpp:128
+msgid "A4 Plus 210 x 330 mm"
+msgstr "A4 plus 210 × 330 mm"
+
+#: ../src/common/paper.cpp:129
+msgid "A5 Transverse 148 x 210 mm"
+msgstr "A5 poprečno 148 × 210 mm"
+
+#: ../src/common/paper.cpp:130
+msgid "B5 (JIS) Transverse 182 x 257 mm"
+msgstr "B5 (JIS) poprečno 182 × 257 mm"
+
+#: ../src/common/paper.cpp:131
+msgid "A3 Extra 322 x 445 mm"
+msgstr "A3 ekstra 322 × 445 mm"
+
+#: ../src/common/paper.cpp:132
+msgid "A5 Extra 174 x 235 mm"
+msgstr "A5 ekstra 174 × 235 mm"
+
+#: ../src/common/paper.cpp:133
+msgid "B5 (ISO) Extra 201 x 276 mm"
+msgstr "B5 (ISO) ekstra 201 × 276 mm"
+
+#: ../src/common/paper.cpp:134
+msgid "A2 420 x 594 mm"
+msgstr "A2 420 × 594 mm"
+
+#: ../src/common/paper.cpp:135
+msgid "A3 Transverse 297 x 420 mm"
+msgstr "A3 poprečno 297 × 420 mm"
+
+#: ../src/common/paper.cpp:136
+msgid "A3 Extra Transverse 322 x 445 mm"
+msgstr "A3 ekstra poprečno 322 × 445 mm"
+
+#: ../src/common/paper.cpp:138
+msgid "Japanese Double Postcard 200 x 148 mm"
+msgstr "Japanska dupla razglednica 200 × 148 mm"
+
+#: ../src/common/paper.cpp:139
+msgid "A6 105 x 148 mm"
+msgstr "A6 105 × 148 mm"
+
+#: ../src/common/paper.cpp:140
+msgid "Japanese Envelope Kaku #2"
+msgstr "Japanska kuverta Kaku #2"
+
+#: ../src/common/paper.cpp:141
+msgid "Japanese Envelope Kaku #3"
+msgstr "Japanska kuverta Kaku #3"
+
+#: ../src/common/paper.cpp:142
+msgid "Japanese Envelope Chou #3"
+msgstr "Japanska kuverta Chou #3"
+
+#: ../src/common/paper.cpp:143
+msgid "Japanese Envelope Chou #4"
+msgstr "Japanska kuverta Chou #4"
+
+#: ../src/common/paper.cpp:144
+msgid "Letter Rotated 11 x 8 1/2 in"
+msgstr "Letter Rotated 11 x 8 1/2 in"
+
+#: ../src/common/paper.cpp:145
+msgid "A3 Rotated 420 x 297 mm"
+msgstr "A3 rotirano 420 × 297 mm"
+
+#: ../src/common/paper.cpp:146
+msgid "A4 Rotated 297 x 210 mm"
+msgstr "A4 rotirano 297 × 210 mm"
+
+#: ../src/common/paper.cpp:147
+msgid "A5 Rotated 210 x 148 mm"
+msgstr "A5 rotirano 210 × 148 mm"
+
+#: ../src/common/paper.cpp:148
+msgid "B4 (JIS) Rotated 364 x 257 mm"
+msgstr "B4 (JIS) rotirano 364 × 257 mm"
+
+#: ../src/common/paper.cpp:149
+msgid "B5 (JIS) Rotated 257 x 182 mm"
+msgstr "B5 (JIS) rotirano 257 × 182 mm"
+
+#: ../src/common/paper.cpp:150
+msgid "Japanese Postcard Rotated 148 x 100 mm"
+msgstr "Japanska razglednica rotirano 148 × 100 mm"
+
+#: ../src/common/paper.cpp:151
+msgid "Double Japanese Postcard Rotated 148 x 200 mm"
+msgstr "Japanska dupla razglednica rotirano 148 × 200 mm"
+
+#: ../src/common/paper.cpp:152
+msgid "A6 Rotated 148 x 105 mm"
+msgstr "A6 rotirano 148 × 105 mm"
+
+#: ../src/common/paper.cpp:153
+msgid "Japanese Envelope Kaku #2 Rotated"
+msgstr "Japanska kuverta Kaku #2 rotirano"
+
+#: ../src/common/paper.cpp:154
+msgid "Japanese Envelope Kaku #3 Rotated"
+msgstr "Japanska kuverta Kaku #3 rotirano"
+
+#: ../src/common/paper.cpp:155
+msgid "Japanese Envelope Chou #3 Rotated"
+msgstr "Japanska kuverta Chou #3 rotirano"
+
+#: ../src/common/paper.cpp:156
+msgid "Japanese Envelope Chou #4 Rotated"
+msgstr "Japanska kuverta Chou #4 rotirano"
+
+#: ../src/common/paper.cpp:157
+msgid "B6 (JIS) 128 x 182 mm"
+msgstr "B6 (JIS) 128 × 182 mm"
+
+#: ../src/common/paper.cpp:158
+msgid "B6 (JIS) Rotated 182 x 128 mm"
+msgstr "B6 (JIS) rotirano 182 × 128 mm"
+
+#: ../src/common/paper.cpp:159
+msgid "12 x 11 in"
+msgstr "12 × 11 in"
+
+#: ../src/common/paper.cpp:160
+msgid "Japanese Envelope You #4"
+msgstr "Japanska kuverta You #4"
+
+#: ../src/common/paper.cpp:161
+msgid "Japanese Envelope You #4 Rotated"
+msgstr "Japanska kuverta You #4 rotirano"
+
+#: ../src/common/paper.cpp:162
+msgid "PRC 16K 146 x 215 mm"
+msgstr "PRC 16K 146 × 215 mm"
+
+#: ../src/common/paper.cpp:163
+msgid "PRC 32K 97 x 151 mm"
+msgstr "PRC 32K 97 × 151 mm"
+
+#: ../src/common/paper.cpp:164
+msgid "PRC 32K(Big) 97 x 151 mm"
+msgstr "PRC 32K(veliki) 97 × 151 mm"
+
+#: ../src/common/paper.cpp:165
+msgid "PRC Envelope #1 102 x 165 mm"
+msgstr "PRC kuverta #1 102 × 165 mm"
+
+#: ../src/common/paper.cpp:166
+msgid "PRC Envelope #2 102 x 176 mm"
+msgstr "PRC kuverta #2 102 × 176 mm"
+
+#: ../src/common/paper.cpp:167
+msgid "PRC Envelope #3 125 x 176 mm"
+msgstr "PRC kuverta #3 125 × 176 mm"
+
+#: ../src/common/paper.cpp:168
+msgid "PRC Envelope #4 110 x 208 mm"
+msgstr "PRC kuverta #4 110 × 208 mm"
+
+#: ../src/common/paper.cpp:169
+msgid "PRC Envelope #5 110 x 220 mm"
+msgstr "PRC kuverta #5 110 × 220 mm"
+
+#: ../src/common/paper.cpp:170
+msgid "PRC Envelope #6 120 x 230 mm"
+msgstr "PRC kuverta #6 120 × 230 mm"
+
+#: ../src/common/paper.cpp:171
+msgid "PRC Envelope #7 160 x 230 mm"
+msgstr "PRC kuverta #7 160 × 230 mm"
+
+#: ../src/common/paper.cpp:172
+msgid "PRC Envelope #8 120 x 309 mm"
+msgstr "PRC kuverta #8 120 × 309 mm"
+
+#: ../src/common/paper.cpp:173
+msgid "PRC Envelope #9 229 x 324 mm"
+msgstr "PRC kuverta #9 229 × 324 mm"
+
+#: ../src/common/paper.cpp:174
+msgid "PRC Envelope #10 324 x 458 mm"
+msgstr "PRC kuverta #10 324 × 458 mm"
+
+#: ../src/common/paper.cpp:175
+msgid "PRC 16K Rotated"
+msgstr "PRC 16K rotirano"
+
+#: ../src/common/paper.cpp:176
+msgid "PRC 32K Rotated"
+msgstr "PRC 32K rotirano"
+
+#: ../src/common/paper.cpp:177
+msgid "PRC 32K(Big) Rotated"
+msgstr "PRC 32K(veliki) rotirano"
+
+#: ../src/common/paper.cpp:178
+msgid "PRC Envelope #1 Rotated 165 x 102 mm"
+msgstr "PRC kuverta #1 rotirano 165 × 102 mm"
+
+#: ../src/common/paper.cpp:179
+msgid "PRC Envelope #2 Rotated 176 x 102 mm"
+msgstr "PRC kuverta #2 rotirano 176 × 102 mm"
+
+#: ../src/common/paper.cpp:180
+msgid "PRC Envelope #3 Rotated 176 x 125 mm"
+msgstr "PRC kuverta #3 rotirano 176 × 125 mm"
+
+#: ../src/common/paper.cpp:181
+msgid "PRC Envelope #4 Rotated 208 x 110 mm"
+msgstr "PRC kuverta #4 rotirano 208 × 110 mm"
+
+#: ../src/common/paper.cpp:182
+msgid "PRC Envelope #5 Rotated 220 x 110 mm"
+msgstr "PRC kuverta #5 rotirano 220 × 110 mm"
+
+#: ../src/common/paper.cpp:183
+msgid "PRC Envelope #6 Rotated 230 x 120 mm"
+msgstr "PRC kuverta #6 rotirano 230 × 120 mm"
+
+#: ../src/common/paper.cpp:184
+msgid "PRC Envelope #7 Rotated 230 x 160 mm"
+msgstr "PRC kuverta #7 rotirano 230 × 160 mm"
+
+#: ../src/common/paper.cpp:185
+msgid "PRC Envelope #8 Rotated 309 x 120 mm"
+msgstr "PRC kuverta #8 rotirano 309 × 120 mm"
+
+#: ../src/common/paper.cpp:186
+msgid "PRC Envelope #9 Rotated 324 x 229 mm"
+msgstr "PRC kuverta #9 rotirano 324 × 229 mm"
+
+#: ../src/common/paper.cpp:187
+msgid "PRC Envelope #10 Rotated 458 x 324 mm"
+msgstr "PRC kuverta #10 rotirano 458 × 324 mm"
+
+#: ../src/common/paper.cpp:192
+msgid "A0 sheet, 841 x 1189 mm"
+msgstr "A0 arak, 841 × 1189 mm"
+
+#: ../src/common/paper.cpp:193
+msgid "A1 sheet, 594 x 841 mm"
+msgstr "A1 arak, 594 × 841 mm"
+
+#: ../src/common/preferencescmn.cpp:37
+msgid "General"
+msgstr "Općenito"
+
+#: ../src/common/preferencescmn.cpp:40
+msgid "Advanced"
+msgstr "Napredno"
+
+#: ../src/common/prntbase.cpp:245
+msgid "Generic PostScript"
+msgstr "Generički PostScript"
+
+#: ../src/common/prntbase.cpp:259
+msgid "Ready"
+msgstr "Spremno"
+
+#: ../src/common/prntbase.cpp:331
+msgid "Printing Error"
+msgstr "Greška u ispisu"
+
+#: ../src/common/prntbase.cpp:413 ../src/common/prntbase.cpp:1597
+#: ../src/generic/prntdlgg.cpp:135 ../src/generic/prntdlgg.cpp:149
+#: ../src/gtk/print.cpp:628 ../src/gtk/print.cpp:646
+msgid "Print"
+msgstr "Ispiši"
+
+#: ../src/common/prntbase.cpp:471 ../src/generic/prntdlgg.cpp:809
+msgid "Page setup"
+msgstr "Postavke stranice"
+
+#: ../src/common/prntbase.cpp:525
+msgid "Please wait while printing..."
+msgstr "Pričekaj dok traje ispis …"
+
+#: ../src/common/prntbase.cpp:529
+msgid "Document:"
+msgstr "Dokument:"
+
+#: ../src/common/prntbase.cpp:532
+msgid "Progress:"
+msgstr "Tok:"
+
+#: ../src/common/prntbase.cpp:533
+msgid "Preparing"
+msgstr "Pripremanje"
+
+#: ../src/common/prntbase.cpp:552
+#, c-format
+msgid "Printing page %d"
+msgstr "Ispisivanje %d. stranice"
+
+#: ../src/common/prntbase.cpp:557
+#, c-format
+msgid "Printing page %d of %d"
+msgstr "Ispisivanje %d. stranice od %d"
+
+#: ../src/common/prntbase.cpp:560
+#, c-format
+msgid " (copy %d of %d)"
+msgstr " (kopija %d od %d)"
+
+#: ../src/common/prntbase.cpp:1604
+msgid "First page"
+msgstr "Prva stranica"
+
+#: ../src/common/prntbase.cpp:1609 ../src/html/helpwnd.cpp:659
+msgid "Previous page"
+msgstr "Prethodna stranica"
+
+#: ../src/common/prntbase.cpp:1623 ../src/html/helpwnd.cpp:660
+msgid "Next page"
+msgstr "Sljedeća stranica"
+
+#: ../src/common/prntbase.cpp:1628
+msgid "Last page"
+msgstr "Zadnja stranica"
+
+#: ../src/common/prntbase.cpp:1636 ../src/common/stockitem.cpp:215
+msgid "Zoom Out"
+msgstr "Umanji"
+
+#: ../src/common/prntbase.cpp:1650 ../src/common/stockitem.cpp:214
+msgid "Zoom In"
+msgstr "Uvećaj"
+
+#: ../src/common/prntbase.cpp:1656 ../src/common/stockitem.cpp:153
+#: ../src/generic/logg.cpp:553 ../src/univ/themes/win32.cpp:3752
+msgid "&Close"
+msgstr "&Zatvori"
+
+#: ../src/common/prntbase.cpp:2085
+msgid "Could not start document preview."
+msgstr "Nije bilo moguće započeti pregled dokumenta."
+
+#: ../src/common/prntbase.cpp:2085 ../src/common/prntbase.cpp:2129
+#: ../src/common/prntbase.cpp:2137
+msgid "Print Preview Failure"
+msgstr "Neuspjeli pregled ispisa"
+
+#: ../src/common/prntbase.cpp:2129 ../src/common/prntbase.cpp:2137
+msgid "Sorry, not enough memory to create a preview."
+msgstr "Nažalost nema dovoljno memorije za stvaranje pregleda."
+
+#: ../src/common/prntbase.cpp:2144
+#, c-format
+msgid "Page %d of %d"
+msgstr "%d. stranica od %d"
+
+#: ../src/common/prntbase.cpp:2146
+#, c-format
+msgid "Page %d"
+msgstr "Stranica %d"
+
+#: ../src/common/regex.cpp:382 ../src/html/chm.cpp:348
+msgid "unknown error"
+msgstr "nepoznata greška"
+
+#: ../src/common/regex.cpp:995
+#, c-format
+msgid "Invalid regular expression '%s': %s"
+msgstr "Nevaljan regularni izraz „%s”: %s"
+
+#: ../src/common/regex.cpp:1059
+#, c-format
+msgid "Failed to find match for regular expression: %s"
+msgstr "Neuspjeo nalaženje poklapanja ragularnog izraza: %s"
+
+#: ../src/common/rendcmn.cpp:188
+#, c-format
+msgid "Renderer \"%s\" has incompatible version %d.%d and couldn't be loaded."
+msgstr ""
+"Iscrtač „%s” ima nekompatibilnu verziju %d.%d i nije ga moguće učitati."
+
+#: ../src/common/secretstore.cpp:162
+msgid "Not available for this platform"
+msgstr "Nije dostupno za ovu platformu"
+
+#: ../src/common/secretstore.cpp:183
+#, c-format
+msgid "Saving password for \"%s\" failed: %s."
+msgstr "Spremanje lozinke za „%s” neuspjelo: %s."
+
+#: ../src/common/secretstore.cpp:205
+#, c-format
+msgid "Reading password for \"%s\" failed: %s."
+msgstr "Čitanje lozinke za „%s” neuspjelo: %s."
+
+#: ../src/common/secretstore.cpp:228
+#, c-format
+msgid "Deleting password for \"%s\" failed: %s."
+msgstr "Brisanje lozinke za „%s” neuspjelo: %s."
+
+#: ../src/common/selectdispatcher.cpp:254
+msgid "Failed to monitor I/O channels"
+msgstr "Neuspjelo praćenje ulaznih/izlaznih kanala"
+
+#: ../src/common/sizer.cpp:3054 ../src/common/stockitem.cpp:195
+msgid "Save"
+msgstr "Spremi"
+
+#: ../src/common/sizer.cpp:3056
+msgid "Don't Save"
+msgstr "Nemoj spremiti"
+
+#: ../src/common/socket.cpp:870
+msgid "Cannot initialize sockets"
+msgstr "Nije moguće inicijalizirati priključke"
+
+#: ../src/common/stockitem.cpp:127
+msgctxt "standard Windows menu"
+msgid "&Help"
+msgstr "&Pomoć"
+
+#: ../src/common/stockitem.cpp:144
+msgid "&About"
+msgstr "&O programu"
+
+#: ../src/common/stockitem.cpp:144
+msgid "About"
+msgstr "O programu"
+
+#: ../src/common/stockitem.cpp:145
+msgid "Add"
+msgstr "Dodaj"
+
+#: ../src/common/stockitem.cpp:146
+msgid "&Apply"
+msgstr "&Primijeni"
+
+#: ../src/common/stockitem.cpp:146
+msgid "Apply"
+msgstr "Primijeni"
+
+#: ../src/common/stockitem.cpp:147
+msgid "&Back"
+msgstr "&Natrag"
+
+#: ../src/common/stockitem.cpp:147
+msgid "Back"
+msgstr "Natrag"
+
+#: ../src/common/stockitem.cpp:148
+msgid "&Bold"
+msgstr "&Debeli"
+
+#: ../src/common/stockitem.cpp:148 ../src/generic/fontdlgg.cpp:326
+#: ../src/richtext/richtextfontpage.cpp:354
+msgid "Bold"
+msgstr "Debeli"
+
+#: ../src/common/stockitem.cpp:149
+msgid "&Bottom"
+msgstr "&Kraj"
+
+#: ../src/common/stockitem.cpp:149 ../src/richtext/richtextsizepage.cpp:287
+msgid "Bottom"
+msgstr "Kraj"
+
+#: ../src/common/stockitem.cpp:150 ../src/generic/fontdlgg.cpp:462
+#: ../src/generic/fontdlgg.cpp:481 ../src/generic/wizard.cpp:415
+msgid "&Cancel"
+msgstr "&Odustani"
+
+#: ../src/common/stockitem.cpp:151
+msgid "&CD-ROM"
+msgstr "&CD-ROM"
+
+#: ../src/common/stockitem.cpp:151
+msgid "CD-ROM"
+msgstr "CD-ROM"
+
+#: ../src/common/stockitem.cpp:152
+msgid "&Clear"
+msgstr "&Ukloni"
+
+#: ../src/common/stockitem.cpp:152
+msgid "Clear"
+msgstr "Izbriši"
+
+#: ../src/common/stockitem.cpp:153 ../src/generic/dbgrptg.cpp:93
+#: ../src/generic/progdlgg.cpp:778 ../src/html/helpdlg.cpp:86
+#: ../src/msw/progdlg.cpp:209 ../src/msw/progdlg.cpp:890
+#: ../src/richtext/richtextstyledlg.cpp:272
+#: ../src/richtext/richtextsymboldlg.cpp:448
+msgid "Close"
+msgstr "Zatvori"
+
+#: ../src/common/stockitem.cpp:154
+msgid "&Convert"
+msgstr "&Pretvori"
+
+#: ../src/common/stockitem.cpp:154
+msgid "Convert"
+msgstr "Pretvori"
+
+#: ../src/common/stockitem.cpp:155 ../src/msw/textctrl.cpp:2884
+#: ../src/osx/textctrl_osx.cpp:653 ../src/richtext/richtextctrl.cpp:331
+msgid "&Copy"
+msgstr "&Kopiraj"
+
+#: ../src/common/stockitem.cpp:155 ../src/stc/stc_i18n.cpp:18
+msgid "Copy"
+msgstr "Kopiraj"
+
+#: ../src/common/stockitem.cpp:156 ../src/msw/textctrl.cpp:2883
+#: ../src/osx/textctrl_osx.cpp:652 ../src/richtext/richtextctrl.cpp:330
+msgid "Cu&t"
+msgstr "Izr&eži"
+
+#: ../src/common/stockitem.cpp:156 ../src/stc/stc_i18n.cpp:17
+msgid "Cut"
+msgstr "Izreži"
+
+#: ../src/common/stockitem.cpp:157 ../src/msw/textctrl.cpp:2886
+#: ../src/osx/textctrl_osx.cpp:655 ../src/richtext/richtextctrl.cpp:333
+#: ../src/richtext/richtexttabspage.cpp:137
+msgid "&Delete"
+msgstr "&Izbriši"
+
+#: ../src/common/stockitem.cpp:157 ../src/richtext/richtextbuffer.cpp:8266
+#: ../src/stc/stc_i18n.cpp:20
+msgid "Delete"
+msgstr "Izbriši"
+
+#: ../src/common/stockitem.cpp:158
+msgid "&Down"
+msgstr "&Dolje"
+
+#: ../src/common/stockitem.cpp:158 ../src/generic/fdrepdlg.cpp:148
+msgid "Down"
+msgstr "Dolje"
+
+#: ../src/common/stockitem.cpp:159
+msgid "&Edit"
+msgstr "&Uredi"
+
+#: ../src/common/stockitem.cpp:159
+msgid "Edit"
+msgstr "Uredi"
+
+#: ../src/common/stockitem.cpp:160
+msgid "&Execute"
+msgstr "&Izvrši"
+
+#: ../src/common/stockitem.cpp:160
+msgid "Execute"
+msgstr "Izvrši"
+
+#: ../src/common/stockitem.cpp:161
+msgid "&Quit"
+msgstr "&Zatvori"
+
+#: ../src/common/stockitem.cpp:161
+msgid "Quit"
+msgstr "Zatvori"
+
+#: ../src/common/stockitem.cpp:162
+msgid "&File"
+msgstr "&Datoteka"
+
+#: ../src/common/stockitem.cpp:162
+msgid "File"
+msgstr "Datoteka"
+
+#: ../src/common/stockitem.cpp:163
+msgid "&Find..."
+msgstr "&Nađi …"
+
+#: ../src/common/stockitem.cpp:163
+msgid "Find..."
+msgstr "Nađi …"
+
+#: ../src/common/stockitem.cpp:164
+msgid "&First"
+msgstr "&Prvi"
+
+#: ../src/common/stockitem.cpp:164
+msgid "First"
+msgstr "Prvi"
+
+#: ../src/common/stockitem.cpp:165
+msgid "&Floppy"
+msgstr "&Flopi disk"
+
+#: ../src/common/stockitem.cpp:165
+msgid "Floppy"
+msgstr "Flopi disk"
+
+#: ../src/common/stockitem.cpp:166
+msgid "&Forward"
+msgstr "&Naprijed"
+
+#: ../src/common/stockitem.cpp:166
+msgid "Forward"
+msgstr "Naprijed"
+
+#: ../src/common/stockitem.cpp:167
+msgid "&Harddisk"
+msgstr "Čvrsti &disk"
+
+#: ../src/common/stockitem.cpp:167
+msgid "Harddisk"
+msgstr "Čvrsti disk"
+
+#: ../src/common/stockitem.cpp:168 ../src/generic/wizard.cpp:418
+#: ../src/osx/cocoa/menu.mm:225 ../src/richtext/richtextstyledlg.cpp:298
+#: ../src/richtext/richtextsymboldlg.cpp:451
+msgid "&Help"
+msgstr "&Pomoć"
+
+#: ../src/common/stockitem.cpp:169
+msgid "&Home"
+msgstr "&Početna"
+
+#: ../src/common/stockitem.cpp:169
+msgid "Home"
+msgstr "Početna"
+
+#: ../src/common/stockitem.cpp:170
+msgid "Indent"
+msgstr "Uvlaka"
+
+#: ../src/common/stockitem.cpp:171
+msgid "&Index"
+msgstr "&Indeks"
+
+#: ../src/common/stockitem.cpp:171 ../src/html/helpwnd.cpp:510
+msgid "Index"
+msgstr "Indeks"
+
+#: ../src/common/stockitem.cpp:172
+msgid "&Info"
+msgstr "&Informacije"
+
+#: ../src/common/stockitem.cpp:172
+msgid "Info"
+msgstr "Informacije"
+
+#: ../src/common/stockitem.cpp:173
+msgid "&Italic"
+msgstr "&Kurziv"
+
+#: ../src/common/stockitem.cpp:173 ../src/generic/fontdlgg.cpp:322
+#: ../src/richtext/richtextfontpage.cpp:350
+msgid "Italic"
+msgstr "Kurziv"
+
+#: ../src/common/stockitem.cpp:174
+msgid "&Jump to"
+msgstr "&Prijeđi na"
+
+#: ../src/common/stockitem.cpp:174
+msgid "Jump to"
+msgstr "Prijeđi na"
+
+#: ../src/common/stockitem.cpp:175
+msgid "Centered"
+msgstr "Centrirano"
+
+#: ../src/common/stockitem.cpp:176
+msgid "Justified"
+msgstr "Obostrano poravnato"
+
+#: ../src/common/stockitem.cpp:177
+msgid "Align Left"
+msgstr "Poravnaj u lijevo"
+
+#: ../src/common/stockitem.cpp:178
+msgid "Align Right"
+msgstr "Poravnaj u desno"
+
+#: ../src/common/stockitem.cpp:179
+msgid "&Last"
+msgstr "&Zadnji"
+
+#: ../src/common/stockitem.cpp:179
+msgid "Last"
+msgstr "Zadnji"
+
+#: ../src/common/stockitem.cpp:180
+msgid "&Network"
+msgstr "&Mreža"
+
+#: ../src/common/stockitem.cpp:180
+msgid "Network"
+msgstr "Mreža"
+
+#: ../src/common/stockitem.cpp:181 ../src/richtext/richtexttabspage.cpp:131
+msgid "&New"
+msgstr "&Nova"
+
+#: ../src/common/stockitem.cpp:181
+msgid "New"
+msgstr "Novo"
+
+#: ../src/common/stockitem.cpp:182 ../src/msw/msgdlg.cpp:417
+msgid "&No"
+msgstr "&Ne"
+
+#: ../src/common/stockitem.cpp:183 ../src/generic/fontdlgg.cpp:467
+#: ../src/generic/fontdlgg.cpp:474
+msgid "&OK"
+msgstr "&U redu"
+
+#: ../src/common/stockitem.cpp:184 ../src/generic/dbgrptg.cpp:341
+msgid "&Open..."
+msgstr "&Otvori …"
+
+#: ../src/common/stockitem.cpp:184
+msgid "Open..."
+msgstr "Otvori …"
+
+#: ../src/common/stockitem.cpp:185 ../src/msw/textctrl.cpp:2885
+#: ../src/osx/textctrl_osx.cpp:654 ../src/richtext/richtextctrl.cpp:332
+msgid "&Paste"
+msgstr "&Zalijepi"
+
+#: ../src/common/stockitem.cpp:185 ../src/richtext/richtextctrl.cpp:3484
+#: ../src/stc/stc_i18n.cpp:19
+msgid "Paste"
+msgstr "Zalijepi"
+
+#: ../src/common/stockitem.cpp:186
+msgid "&Preferences"
+msgstr "&Postavke"
+
+#: ../src/common/stockitem.cpp:186 ../src/osx/cocoa/preferences.mm:304
+msgid "Preferences"
+msgstr "Postavke"
+
+#: ../src/common/stockitem.cpp:187
+msgid "Print previe&w..."
+msgstr "Pregled ispis&a …"
+
+#: ../src/common/stockitem.cpp:187
+msgid "Print preview..."
+msgstr "Pregled ispisa …"
+
+#: ../src/common/stockitem.cpp:188
+msgid "&Print..."
+msgstr "&Ispiši …"
+
+#: ../src/common/stockitem.cpp:188
+msgid "Print..."
+msgstr "Ispiši …"
+
+#: ../src/common/stockitem.cpp:189 ../src/richtext/richtextctrl.cpp:337
+#: ../src/richtext/richtextctrl.cpp:5479
+msgid "&Properties"
+msgstr "&Svojstva"
+
+#: ../src/common/stockitem.cpp:189
+msgid "Properties"
+msgstr "Svojstva"
+
+#: ../src/common/stockitem.cpp:190 ../src/stc/stc_i18n.cpp:16
+msgid "Redo"
+msgstr "Ponovi"
+
+#: ../src/common/stockitem.cpp:191
+msgid "Refresh"
+msgstr "Osvježi"
+
+#: ../src/common/stockitem.cpp:192
+msgid "Remove"
+msgstr "Ukloni"
+
+#: ../src/common/stockitem.cpp:193
+msgid "Rep&lace..."
+msgstr "Zamije&ni …"
+
+#: ../src/common/stockitem.cpp:193
+msgid "Replace..."
+msgstr "Zamijeni …"
+
+#: ../src/common/stockitem.cpp:194
+msgid "Revert to Saved"
+msgstr "Vrati na spremljeno"
+
+#: ../src/common/stockitem.cpp:196 ../src/generic/logg.cpp:549
+msgid "Save &As..."
+msgstr "Spremi &kao …"
+
+#: ../src/common/stockitem.cpp:196
+msgid "Save As..."
+msgstr "Spremi kao …"
+
+#: ../src/common/stockitem.cpp:197 ../src/msw/textctrl.cpp:2888
+#: ../src/osx/textctrl_osx.cpp:657 ../src/richtext/richtextctrl.cpp:335
+msgid "Select &All"
+msgstr "Odaberi &sve"
+
+#: ../src/common/stockitem.cpp:197 ../src/stc/stc_i18n.cpp:21
+msgid "Select All"
+msgstr "Odaberi sve"
+
+#: ../src/common/stockitem.cpp:198
+msgid "&Color"
+msgstr "&Boja"
+
+#: ../src/common/stockitem.cpp:198
+msgid "Color"
+msgstr "Boja"
+
+#: ../src/common/stockitem.cpp:199
+msgid "&Font"
+msgstr "&Font"
+
+#: ../src/common/stockitem.cpp:199 ../src/richtext/richtextformatdlg.cpp:336
+msgid "Font"
+msgstr "Font"
+
+#: ../src/common/stockitem.cpp:200
+msgid "&Ascending"
+msgstr "&Uzlazno"
+
+#: ../src/common/stockitem.cpp:200
+msgid "Ascending"
+msgstr "Uzlazno"
+
+#: ../src/common/stockitem.cpp:201
+msgid "&Descending"
+msgstr "&Silazno"
+
+#: ../src/common/stockitem.cpp:201
+msgid "Descending"
+msgstr "Silazno"
+
+#: ../src/common/stockitem.cpp:202
+msgid "&Spell Check"
+msgstr "&Provjera pravopisa"
+
+#: ../src/common/stockitem.cpp:202
+msgid "Spell Check"
+msgstr "Provjera pravopisa"
+
+#: ../src/common/stockitem.cpp:203
+msgid "&Stop"
+msgstr "&Zaustavi"
+
+#: ../src/common/stockitem.cpp:203
+msgid "Stop"
+msgstr "Zaustavi"
+
+#: ../src/common/stockitem.cpp:204 ../src/richtext/richtextfontpage.cpp:274
+msgid "&Strikethrough"
+msgstr "&Precrtano"
+
+#: ../src/common/stockitem.cpp:204
+msgid "Strikethrough"
+msgstr "Precrtano"
+
+#: ../src/common/stockitem.cpp:205
+msgid "&Top"
+msgstr "&Gore"
+
+#: ../src/common/stockitem.cpp:205 ../src/richtext/richtextsizepage.cpp:285
+#: ../src/richtext/richtextsizepage.cpp:289
+msgid "Top"
+msgstr "Gore"
+
+#: ../src/common/stockitem.cpp:206
+msgid "Undelete"
+msgstr "Vrati izbrisano"
+
+#: ../src/common/stockitem.cpp:207 ../src/generic/fontdlgg.cpp:437
+msgid "&Underline"
+msgstr "&Podcrtaj"
+
+#: ../src/common/stockitem.cpp:207
+msgid "Underline"
+msgstr "Podcrtaj"
+
+#: ../src/common/stockitem.cpp:208 ../src/stc/stc_i18n.cpp:15
+msgid "Undo"
+msgstr "Poništi"
+
+#: ../src/common/stockitem.cpp:209
+msgid "&Unindent"
+msgstr "&Ukloni uvlaku"
+
+#: ../src/common/stockitem.cpp:209
+msgid "Unindent"
+msgstr "Ukloni uvlaku"
+
+#: ../src/common/stockitem.cpp:210
+msgid "&Up"
+msgstr "&Gore"
+
+#: ../src/common/stockitem.cpp:210 ../src/generic/fdrepdlg.cpp:148
+msgid "Up"
+msgstr "Gore"
+
+#: ../src/common/stockitem.cpp:211 ../src/msw/msgdlg.cpp:417
+msgid "&Yes"
+msgstr "&Da"
+
+#: ../src/common/stockitem.cpp:212
+msgid "&Actual Size"
+msgstr "&Stvarna veličina"
+
+#: ../src/common/stockitem.cpp:212
+msgid "Actual Size"
+msgstr "Stvarna veličina"
+
+#: ../src/common/stockitem.cpp:213
+msgid "Zoom to &Fit"
+msgstr "Prilagodi &zumiranje"
+
+#: ../src/common/stockitem.cpp:213
+msgid "Zoom to Fit"
+msgstr "Prilagodi zumiranje"
+
+#: ../src/common/stockitem.cpp:214
+msgid "Zoom &In"
+msgstr "U&većaj"
+
+#: ../src/common/stockitem.cpp:215
+msgid "Zoom &Out"
+msgstr "U&manji"
+
+#: ../src/common/stockitem.cpp:262
+msgid "Show about dialog"
+msgstr "Prikaži informativni dijalog"
+
+#: ../src/common/stockitem.cpp:263
+msgid "Copy selection"
+msgstr "Kopiraj odabir"
+
+#: ../src/common/stockitem.cpp:264
+msgid "Cut selection"
+msgstr "Izreži odabir"
+
+#: ../src/common/stockitem.cpp:265
+msgid "Delete selection"
+msgstr "Izbriši  odabir"
+
+#: ../src/common/stockitem.cpp:266
+msgid "Find in document"
+msgstr "Nađi u dokumentu"
+
+#: ../src/common/stockitem.cpp:267
+msgid "Find and replace in document"
+msgstr "Nađi i zamijeni u dokumentu"
+
+#: ../src/common/stockitem.cpp:268
+msgid "Paste selection"
+msgstr "Zalijepi odabir"
+
+#: ../src/common/stockitem.cpp:269
+msgid "Quit this program"
+msgstr "Zatvori ovaj program"
+
+#: ../src/common/stockitem.cpp:270
+msgid "Redo last action"
+msgstr "Ponovi zadnju radnju"
+
+#: ../src/common/stockitem.cpp:271
+msgid "Undo last action"
+msgstr "Poništi posljednju radnju"
+
+#: ../src/common/stockitem.cpp:272
+msgid "Create new document"
+msgstr "Stvori novi dokument"
+
+#: ../src/common/stockitem.cpp:273
+msgid "Open an existing document"
+msgstr "Otvori postojeću datoteku"
+
+#: ../src/common/stockitem.cpp:274
+msgid "Close current document"
+msgstr "Zatvori trenutačni dokument"
+
+#: ../src/common/stockitem.cpp:275
+msgid "Save current document"
+msgstr "Spremi trenutačni dokument"
+
+#: ../src/common/stockitem.cpp:276
+msgid "Save current document with a different filename"
+msgstr "Spremi trenutačni dokument pod drugim imenom"
+
+#: ../src/common/strconv.cpp:2324
+#, c-format
+msgid "Conversion to charset '%s' doesn't work."
+msgstr "Konverzija u kodnu stranicu „%s” ne radi."
+
+#: ../src/common/tarstrm.cpp:352 ../src/common/tarstrm.cpp:375
+#: ../src/common/tarstrm.cpp:406 ../src/generic/progdlgg.cpp:373
+msgid "unknown"
+msgstr "nepoznato"
+
+#: ../src/common/tarstrm.cpp:774
+msgid "incomplete header block in tar"
+msgstr "nepotpuni zaglavni blok u tar"
+
+#: ../src/common/tarstrm.cpp:798
+msgid "checksum failure reading tar header block"
+msgstr "greška u ispitnom zbroju prilikom čitanja zaglavnog bloka"
+
+#: ../src/common/tarstrm.cpp:971
+msgid "invalid data in extended tar header"
+msgstr "nevaljani podaci u proširenom tar zaglavlju"
+
+#: ../src/common/tarstrm.cpp:981 ../src/common/tarstrm.cpp:1003
+#: ../src/common/tarstrm.cpp:1477 ../src/common/tarstrm.cpp:1499
+msgid "tar entry not open"
+msgstr "tar unos nije otvoren"
+
+#: ../src/common/tarstrm.cpp:1023
+msgid "unexpected end of file"
+msgstr "neočekivani kraj datoteke"
+
+#: ../src/common/tarstrm.cpp:1297
+#, c-format
+msgid "%s did not fit the tar header for entry '%s'"
+msgstr "%s ne paše tar zaglavlju za unos „%s”"
+
+#: ../src/common/tarstrm.cpp:1359
+msgid "incorrect size given for tar entry"
+msgstr "nepravilna veličina, zadan za tar ulaz"
+
+#: ../src/common/textbuf.cpp:232
+#, c-format
+msgid "'%s' is probably a binary buffer."
+msgstr "„%s” je vjerojatno jedan binaran međuspremnik."
+
+#: ../src/common/textcmn.cpp:1006 ../src/richtext/richtextctrl.cpp:3053
+msgid "File couldn't be loaded."
+msgstr "Nije bilo moguće učitati datoteku."
+
+#: ../src/common/textfile.cpp:95
+#, c-format
+msgid "Failed to read text file \"%s\"."
+msgstr "Neuspjelo čitanje tekstualne datoteke „%s”."
+
+#: ../src/common/textfile.cpp:160
+#, c-format
+msgid "can't write buffer '%s' to disk."
+msgstr "nije moguće zapisivanje međuspremnika „%s” na disk."
+
+#: ../src/common/time.cpp:212
+msgid "Failed to get the local system time"
+msgstr "Neuspjelo dobivanje lokalnog vremena sustava"
+
+#: ../src/common/time.cpp:279
+msgid "wxGetTimeOfDay failed."
+msgstr "wxGetTimeOfDay nije uspjelo."
+
+#: ../src/common/translation.cpp:929
+#, c-format
+msgid "'%s' is not a valid message catalog."
+msgstr "„%s” nije valjan katalog obavijesti."
+
+#: ../src/common/translation.cpp:954
+msgid "Invalid message catalog."
+msgstr "Nevaljani katalog obavijesti."
+
+#: ../src/common/translation.cpp:1013
+#, c-format
+msgid "Failed to parse Plural-Forms: '%s'"
+msgstr "Neuspjela obrada oblika množine: „%s”"
+
+#: ../src/common/translation.cpp:1723
+#, c-format
+msgid "using catalog '%s' from '%s'."
+msgstr "koristi se katalog „%s” od „%s”."
+
+#: ../src/common/translation.cpp:1816
+#, c-format
+msgid "Resource '%s' is not a valid message catalog."
+msgstr "Resurs „%s” nije valjani katalog obavijesti."
+
+#: ../src/common/translation.cpp:1865
+msgid "Couldn't enumerate translations"
+msgstr "Nije bilo moguće numerirati prijevode"
+
+#: ../src/common/utilscmn.cpp:1145
+msgid "No default application configured for HTML files."
+msgstr "Nije konfigurirana standardna aplikacija za HTML datoteke."
+
+#: ../src/common/utilscmn.cpp:1190
+#, c-format
+msgid "Failed to open URL \"%s\" in default browser."
+msgstr "Neuspjelo otvaranje URL-a „%s” u zadanom pregledniku."
+
+#: ../src/common/valtext.cpp:144
+msgid "Validation conflict"
+msgstr "Konflikt u provjeri valjanosti"
+
+#: ../src/common/valtext.cpp:186
+msgid "Required information entry is empty."
+msgstr "Obavezan unos informacija je prazan."
+
+#: ../src/common/valtext.cpp:188
+#, c-format
+msgid "'%s' is one of the invalid strings"
+msgstr "„%s” je jedan od nevaljanih znakovnih nizova"
+
+#: ../src/common/valtext.cpp:190
+#, c-format
+msgid "'%s' is not one of the valid strings"
+msgstr "„%s” nije jedan od valjanih znakovnih nizova"
+
+#: ../src/common/valtext.cpp:199
+#, c-format
+msgid "'%s' contains invalid character(s)"
+msgstr "„%s” sadržava nevažeće slovne znakove"
+
+#: ../src/common/webrequest.cpp:139
+#, c-format
+msgid "Error: %s (%d)"
+msgstr "Greška: %s (%d)"
+
+#: ../src/common/webrequest.cpp:655
+#, fuzzy, c-format
+msgid ""
+"Not enough free disk space for download: %llu needed but only %llu available."
+msgstr "Nema dovoljno memorije na disku za preuzimanje."
+
+#: ../src/common/webrequest.cpp:669
+#, fuzzy, c-format
+msgid "Failed to create temporary file in %s"
+msgstr "Neuspjelo stvaranje imena privremene datoteke"
+
+#: ../src/common/webrequest_curl.cpp:1106
+msgid "libcurl could not be initialized"
+msgstr "libcurl nije bilo moguće inicijalizirati"
+
+#: ../src/common/webview.cpp:392
+msgid "RunScriptAsync not supported"
+msgstr "RunScriptAsync not supported nije podržano"
+
+#: ../src/common/webview.cpp:403 ../src/msw/webview_ie.cpp:1073
+#, c-format
+msgid "Error running JavaScript: %s"
+msgstr "Greška prilikom pokretanja JavaScripta: %s"
+
+#: ../src/common/webview_chromium.cpp:858
+#, fuzzy, c-format
+msgid "Failed to set proxy \"%s\": %s"
+msgstr "Neuspjelo stvaranje mape „%s”"
+
+#: ../src/common/webview_chromium.cpp:989
+msgid ""
+"Chromium can't be used because libcef.so wasn't loaded early enough; please "
+"relink the application or use LD_PRELOAD to load it earlier."
+msgstr ""
+
+#: ../src/common/webview_chromium.cpp:1108
+#, fuzzy
+msgid "Could not initialize Chromium"
+msgstr "Nije moguće inicijalizirati OLE"
+
+#: ../src/common/webview_chromium.cpp:1616
+msgid "Show DevTools"
+msgstr ""
+
+#: ../src/common/webview_chromium.cpp:1617
+#, fuzzy
+msgid "Close DevTools"
+msgstr "Zatvori sve"
+
+#: ../src/common/webview_chromium.cpp:1623
+msgid "Inspect"
+msgstr ""
+
+#: ../src/common/wincmn.cpp:1628
+msgid "This platform does not support background transparency."
+msgstr "Ova platforma ne podržava neprozirnost pozadine."
+
+#: ../src/common/wincmn.cpp:2097
+msgid "Could not transfer data to window"
+msgstr "Nije bilo moguće prenijeti podatke u prozor"
+
+#: ../src/common/windowid.cpp:240
+msgid "Out of window IDs.  Recommend shutting down application."
+msgstr "Van prozorskih ID-a. Preporučuje se zatvaranje aplikacije."
+
+#: ../src/common/xpmdecod.cpp:678
+msgid "XPM: incorrect header format!"
+msgstr "XPM: neispravan format zaglavlja!"
+
+#: ../src/common/xpmdecod.cpp:703
+#, c-format
+msgid "XPM: incorrect colour description in line %d"
+msgstr "XPM: neipravan opis boje u retku br. %d"
+
+#: ../src/common/xpmdecod.cpp:715 ../src/common/xpmdecod.cpp:724
+#, c-format
+msgid "XPM: malformed colour definition '%s' at line %d!"
+msgstr "XPM: nepravilna definicija boje „%s” u retku br. %d!"
+
+#: ../src/common/xpmdecod.cpp:754
+msgid "XPM: no colors left to use for mask!"
+msgstr "XPM: za masku nije preostala nijedna boja!"
+
+#: ../src/common/xpmdecod.cpp:781
+#, c-format
+msgid "XPM: truncated image data at line %d!"
+msgstr "XPM: odrezani podaci slike u retku br. %d!"
+
+#: ../src/common/xpmdecod.cpp:795
+msgid "XPM: Malformed pixel data!"
+msgstr "XPM: nepravilni piksel podaci!"
+
+#: ../src/common/xti.cpp:492
+msgid "Illegal Parameter Count for Create Method"
+msgstr "Nevažeće brojenje parametara za Create metodu"
+
+#: ../src/common/xti.cpp:504
+msgid "Illegal Parameter Count for ConstructObject Method"
+msgstr "Nevažeće brojenje parametara za ConstructObject metodu"
+
+#: ../src/common/xtistrm.cpp:161
+#, c-format
+msgid "Create Parameter %s not found in declared RTTI Parameters"
+msgstr "Parametar za stvaranje %s, nije nađen u prijavljenim RTTI parametrima"
+
+#: ../src/common/xtistrm.cpp:290
+msgid "Illegal Object Class (Non-wxEvtHandler) as Event Source"
+msgstr "Nevažeći razred objekta (Non-wxEvtHandler) kao izvor događaja"
+
+#: ../src/common/xtistrm.cpp:313 ../src/common/xtixml.cpp:345
+#: ../src/common/xtixml.cpp:498
+msgid "Type must have enum - long conversion"
+msgstr "Vrsta mora imati enum - long konverziju"
+
+#: ../src/common/xtistrm.cpp:400 ../src/common/xtistrm.cpp:415
+msgid "Invalid or Null Object ID passed to GetObjectClassInfo"
+msgstr "Nevaljani ili Null ID objekta je proslijeđen na GetObjectClassInfo"
+
+#: ../src/common/xtistrm.cpp:405
+msgid "Unknown Object passed to GetObjectClassInfo"
+msgstr "Nepoznati objekt je proslijeđen na GetObjectClassInfo"
+
+#: ../src/common/xtistrm.cpp:420
+msgid "Already Registered Object passed to SetObjectClassInfo"
+msgstr "Već registrirani objekt je proslijeđen na SetObjectClassInfo"
+
+#: ../src/common/xtistrm.cpp:430
+msgid "Invalid or Null Object ID passed to HasObjectClassInfo"
+msgstr "Nevaljani ili Null ID objekta je proslijeđen na HasObjectClassInfo"
+
+#: ../src/common/xtistrm.cpp:460
+msgid "Passing a already registered object to SetObject"
+msgstr "Slanje već registriranog objekta na SetObject"
+
+#: ../src/common/xtistrm.cpp:471
+msgid "Passing an unknown object to GetObject"
+msgstr "Dodavanje nepoznatog objekta GetObject-u"
+
+#: ../src/common/xtixml.cpp:229
+msgid "Forward hrefs are not supported"
+msgstr "Hrefs prema naprijed nisu podržani"
+
+#: ../src/common/xtixml.cpp:247
+#, c-format
+msgid "unknown class %s"
+msgstr "nepoznati razred %s"
+
+#: ../src/common/xtixml.cpp:253
+msgid "objects cannot have XML Text Nodes"
+msgstr "objekti ne mogu imati XML tekstualne čvorove"
+
+#: ../src/common/xtixml.cpp:258
+msgid "Objects must have an id attribute"
+msgstr "Objekt mora imati id svojstvo"
+
+#: ../src/common/xtixml.cpp:267
+#, c-format
+msgid "Doubly used id : %d"
+msgstr "Dvostruko korišten id : %d"
+
+#: ../src/common/xtixml.cpp:316
+#, c-format
+msgid "Unknown Property %s"
+msgstr "Nepoznato svojstvo %s"
+
+#: ../src/common/xtixml.cpp:407
+msgid "A non empty collection must consist of 'element' nodes"
+msgstr "Ne prazna kolekcija mora sadržavati „element” čvorove"
+
+#: ../src/common/xtixml.cpp:478
+msgid "incorrect event handler string, missing dot"
+msgstr "nepravilan znakovni niz upravljača događaja, nedostaje točka"
+
+#: ../src/common/zipstrm.cpp:559
+msgid "can't re-initialize zlib deflate stream"
+msgstr "nije moguće ponovo inicijalizirati zlib deflate tijek"
+
+#: ../src/common/zipstrm.cpp:584
+msgid "can't re-initialize zlib inflate stream"
+msgstr "nije moguće ponovo inicijalizirati zlib inflate tijek"
+
+#: ../src/common/zipstrm.cpp:1023
+msgid "Ignoring malformed extra data record, ZIP file may be corrupted"
+msgstr ""
+"Zanemaruje se pogrešno oblikovan dodatni zapis podataka, ZIP datoteka možda "
+"neće biti ispravna"
+
+#: ../src/common/zipstrm.cpp:1502
+msgid "assuming this is a multi-part zip concatenated"
+msgstr "pod pretpostavkom da se radi o višedjelnom lančanom zipu"
+
+#: ../src/common/zipstrm.cpp:1664
+msgid "invalid zip file"
+msgstr "nevaljana zip datoteka"
+
+#: ../src/common/zipstrm.cpp:1723
+msgid "can't find central directory in zip"
+msgstr "nije moguće pronaći osnovnu mapu u zipu"
+
+#: ../src/common/zipstrm.cpp:1812
+msgid "error reading zip central directory"
+msgstr "greška prilikom čitanja osnovne mape zip-a"
+
+#: ../src/common/zipstrm.cpp:1916
+msgid "error reading zip local header"
+msgstr "greška prilikom čitanja lokalnog zaglavlja zip-a"
+
+#: ../src/common/zipstrm.cpp:1964
+msgid "bad zipfile offset to entry"
+msgstr "neispravni odmak zip datoteke na unos"
+
+#: ../src/common/zipstrm.cpp:2031
+msgid "stored file length not in Zip header"
+msgstr "spremljena dužina datoteke nije u Zip zaglavlju"
+
+#: ../src/common/zipstrm.cpp:2045 ../src/common/zipstrm.cpp:2362
+msgid "unsupported Zip compression method"
+msgstr "nepodržana metoda Zip komprimiranja"
+
+#: ../src/common/zipstrm.cpp:2126
+#, c-format
+msgid "reading zip stream (entry %s): bad length"
+msgstr "čitanje zip tijeka (unos %s): loša duljina"
+
+#: ../src/common/zipstrm.cpp:2131
+#, c-format
+msgid "reading zip stream (entry %s): bad crc"
+msgstr "čitanje zip tijeka (unos %s): loš crc"
+
+#: ../src/common/zipstrm.cpp:2578
+#, c-format
+msgid "error writing zip entry '%s': file too large without ZIP64"
+msgstr ""
+"greška prilikom pisanja zip unosa „%s”: datoteka je prevelika bez ZIP64"
+
+#: ../src/common/zipstrm.cpp:2585
+#, c-format
+msgid "error writing zip entry '%s': bad crc or length"
+msgstr "greška prilikom pisanja zip unosa „%s”: krivi izvor ili duljina"
+
+#: ../src/common/zstream.cpp:155 ../src/common/zstream.cpp:315
+msgid "Gzip not supported by this version of zlib"
+msgstr "Gzip nije podržan od ove verzije zlib-a"
+
+#: ../src/common/zstream.cpp:182
+msgid "Can't initialize zlib inflate stream."
+msgstr "Nije moguće inicijalizirati zlib inflate tijek."
+
+#: ../src/common/zstream.cpp:241
+msgid "Can't read inflate stream: unexpected EOF in underlying stream."
+msgstr ""
+"Nije moguće čitati iz inflate tijeka: neočekivani kraj datoteke u osnovnom "
+"tijeku."
+
+#: ../src/common/zstream.cpp:248 ../src/common/zstream.cpp:423
+#, c-format
+msgid "zlib error %d"
+msgstr "zlib greška %d"
+
+#: ../src/common/zstream.cpp:249
+#, c-format
+msgid "Can't read from inflate stream: %s"
+msgstr "Nije moguće čitati iz inflate tijeka: %s"
+
+#: ../src/common/zstream.cpp:343
+msgid "Can't initialize zlib deflate stream."
+msgstr "Nije moguće inicijalizirati zlib deflate tijek."
+
+#: ../src/common/zstream.cpp:424
+#, c-format
+msgid "Can't write to deflate stream: %s"
+msgstr "Nije moguće pisati u deflate tijek: %s"
+
+#: ../src/dfb/bitmap.cpp:633 ../src/dfb/bitmap.cpp:667
+#, c-format
+msgid "No bitmap handler for type %d defined."
+msgstr "Nijedan upravljač bitmapa za vrstu %d nije određen."
+
+#: ../src/dfb/evtloop.cpp:99
+msgid "Failed to read event from DirectFB pipe"
+msgstr "Neuspjelo čitanje događaja iz DirectFB cjevovoda"
+
+#: ../src/dfb/evtloop.cpp:171
+msgid "Failed to switch DirectFB pipe to non-blocking mode"
+msgstr "Neuspjelo prebacivanje DirectFB cjevovod u ne-blokirajući modus"
+
+#: ../src/dfb/fontmgr.cpp:171
+#, c-format
+msgid "no fonts found in %s, using builtin font"
+msgstr "nisu nađeni fontovi u %s, koristi se ugrađeni font"
+
+#: ../src/dfb/fontmgr.cpp:177
+msgid "Default font"
+msgstr "Zadani font"
+
+#: ../src/dfb/fontmgr.cpp:195
+#, c-format
+msgid "Fonts index file %s disappeared while loading fonts."
+msgstr "Indeksna datoteka fontova %s je nestala prilikom učitavanja fontova."
+
+#: ../src/dfb/wrapdfb.cpp:60
+#, c-format
+msgid "DirectFB error %d occurred."
+msgstr "Došlo je do DirectFB greške %d."
+
+#: ../src/generic/aboutdlgg.cpp:69
+msgid "Developed by "
+msgstr "Razvoj: "
+
+#: ../src/generic/aboutdlgg.cpp:72
+msgid "Documentation by "
+msgstr "Dokumentacija: "
+
+#: ../src/generic/aboutdlgg.cpp:75
+msgid "Graphics art by "
+msgstr "Ilustracija: "
+
+#: ../src/generic/aboutdlgg.cpp:78
+msgid "Translations by "
+msgstr "Prijevodi: "
+
+#: ../src/generic/aboutdlgg.cpp:133 ../src/osx/cocoa/aboutdlg.mm:83
+msgid "Version "
+msgstr "Verzija "
+
+#. TRANSLATORS: %s is application name
+#: ../src/generic/aboutdlgg.cpp:146 ../src/msw/aboutdlg.cpp:60
+#, c-format
+msgid "About %s"
+msgstr "O programu %s"
+
+#: ../src/generic/aboutdlgg.cpp:181
+msgid "License"
+msgstr "Licenca"
+
+#: ../src/generic/aboutdlgg.cpp:184
+msgid "Developers"
+msgstr "Programeri"
+
+#: ../src/generic/aboutdlgg.cpp:188
+msgid "Documentation writers"
+msgstr "Autori dokumentacije"
+
+#: ../src/generic/aboutdlgg.cpp:192
+msgid "Artists"
+msgstr "Ilustratori"
+
+#: ../src/generic/aboutdlgg.cpp:196
+msgid "Translators"
+msgstr "Prevoditelji"
+
+#: ../src/generic/animateg.cpp:125
+msgid "No handler found for animation type."
+msgstr "Nijedan upravljač za vrstu animacije nije određen."
+
+#: ../src/generic/animateg.cpp:133
+#, c-format
+msgid "No animation handler for type %ld defined."
+msgstr "Nijedan upravljač animacijama za vrstu %ld nije određen."
+
+#: ../src/generic/animateg.cpp:145
+#, c-format
+msgid "Animation file is not of type %ld."
+msgstr "Datoteka animacije nije vrste %ld."
+
+#: ../src/generic/colrdlgg.cpp:154 ../src/gtk/colordlg.cpp:47
+msgid "Choose colour"
+msgstr "Odaberi boju"
+
+#: ../src/generic/colrdlgg.cpp:357
+msgid "Red:"
+msgstr "Crvena:"
+
+#: ../src/generic/colrdlgg.cpp:360
+msgid "Green:"
+msgstr "Zelena:"
+
+#: ../src/generic/colrdlgg.cpp:363
+msgid "Blue:"
+msgstr "Plava:"
+
+#: ../src/generic/colrdlgg.cpp:372
+msgid "Opacity:"
+msgstr "Neprozirnost:"
+
+#: ../src/generic/colrdlgg.cpp:384
+msgid "Add to custom colours"
+msgstr "Dodaj proizvoljnu boju"
+
+#: ../src/generic/creddlgg.cpp:56
+msgid "Username:"
+msgstr "Korisničko ime:"
+
+#: ../src/generic/creddlgg.cpp:63
+msgid "Password:"
+msgstr "Lozinka:"
+
+#. TRANSLATORS: Name of Boolean true value
+#: ../src/generic/datavgen.cpp:1178
+msgid "true"
+msgstr "točno"
+
+#. TRANSLATORS: Name of Boolean false value
+#: ../src/generic/datavgen.cpp:1180
+msgid "false"
+msgstr "netočno"
+
+#: ../src/generic/datavgen.cpp:6897
+#, c-format
+msgid "Row %i"
+msgstr "Redak %i"
+
+#. TRANSLATORS: Action for manipulating a tree control
+#: ../src/generic/datavgen.cpp:6987
+msgid "Collapse"
+msgstr "Sklopi"
+
+#. TRANSLATORS: Action for manipulating a tree control
+#: ../src/generic/datavgen.cpp:6990
+msgid "Expand"
+msgstr "Rasklopi"
+
+#. TRANSLATORS: Name of data view control and number of rows
+#: ../src/generic/datavgen.cpp:7011
+#, c-format
+msgid "%s (%d items)"
+msgstr "%s (%d stavki)"
+
+#: ../src/generic/datavgen.cpp:7062
+#, c-format
+msgid "Column %u"
+msgstr "Stupac %u"
+
+#. TRANSLATORS: Keystroke for manipulating a tree control
+#: ../src/generic/datavgen.cpp:7131 ../src/richtext/richtextbulletspage.cpp:189
+#: ../src/richtext/richtextbulletspage.cpp:192
+#: ../src/richtext/richtextbulletspage.cpp:193
+#: ../src/richtext/richtextliststylepage.cpp:252
+#: ../src/richtext/richtextliststylepage.cpp:255
+#: ../src/richtext/richtextliststylepage.cpp:256
+#: ../src/richtext/richtextsizepage.cpp:248
+msgid "Left"
+msgstr "Lijevo"
+
+#. TRANSLATORS: Keystroke for manipulating a tree control
+#: ../src/generic/datavgen.cpp:7134 ../src/richtext/richtextbulletspage.cpp:191
+#: ../src/richtext/richtextliststylepage.cpp:254
+#: ../src/richtext/richtextsizepage.cpp:249
+msgid "Right"
+msgstr "Desno"
+
+#: ../src/generic/datectlg.cpp:90
+#, c-format
+msgid ""
+"\"%s\" is not in the expected date format, please enter it as e.g. \"%s\"."
+msgstr ""
+
+#: ../src/generic/datectlg.cpp:94
+#, fuzzy
+msgid "Invalid date"
+msgstr "PCX: nevaljana slika"
+
+#: ../src/generic/dbgrptg.cpp:159
+#, c-format
+msgid "Open file \"%s\""
+msgstr "Otvori datoteku „%s”"
+
+#: ../src/generic/dbgrptg.cpp:170
+#, c-format
+msgid "Enter command to open file \"%s\":"
+msgstr "Upiši naredbu za otvaranje datoteke „%s”:"
+
+#: ../src/generic/dbgrptg.cpp:230
+msgid "Executable files (*.exe)|*.exe|"
+msgstr "Izvršavajuće datoteke (*.exe)|*.exe|"
+
+#: ../src/generic/dbgrptg.cpp:300
+#, c-format
+msgid "Debug report \"%s\""
+msgstr "Izvještaj o otklanjanju grešaka „%s”"
+
+#: ../src/generic/dbgrptg.cpp:316
+msgid "A debug report has been generated in the directory\n"
+msgstr "Izvještaj o otklanjanju grešaka je stvoren u mapi\n"
+
+#: ../src/generic/dbgrptg.cpp:317
+msgid "The following debug report will be generated\n"
+msgstr "Izradit će se sljedeći izvještaj o otklanjanju grešaka\n"
+
+#: ../src/generic/dbgrptg.cpp:321
+msgid ""
+"The report contains the files listed below. If any of these files contain "
+"private information,\n"
+"please uncheck them and they will be removed from the report.\n"
+msgstr ""
+"Izvještaj sadrži niže dolje nabrojane datoteke. Ako neke od njih sadrže "
+"privatne informacije,\n"
+"odznači ih i one će se ukloniti iz izvještaja.\n"
+
+#: ../src/generic/dbgrptg.cpp:323
+msgid ""
+"If you wish to suppress this debug report completely, please choose the "
+"\"Cancel\" button,\n"
+"but be warned that it may hinder improving the program, so if\n"
+"at all possible please do continue with the report generation.\n"
+msgstr ""
+"Ako želiš prekinuti ovaj izvještaj o otklanjanju grešaka, odaberi gumb "
+"„Odustani”.\n"
+"Time na žalost onemogućuješ ispravljanje programa.\n"
+"Ako možeš, molimo te da nastaviš s izradom izvještaja.\n"
+
+#: ../src/generic/dbgrptg.cpp:325
+msgid "              Thank you and we're sorry for the inconvenience!\n"
+msgstr "              Hvala, i žao nam je zbog nastalih neugodnosti!\n"
+
+#: ../src/generic/dbgrptg.cpp:333
+msgid "&Debug report preview:"
+msgstr "&Pregled izvještaja o otklanjanju grešaka:"
+
+#: ../src/generic/dbgrptg.cpp:339
+msgid "&View..."
+msgstr "&Prikaz …"
+
+#: ../src/generic/dbgrptg.cpp:359
+msgid "&Notes:"
+msgstr "&Napomene:"
+
+#: ../src/generic/dbgrptg.cpp:361
+msgid ""
+"If you have any additional information pertaining to this bug\n"
+"report, please enter it here and it will be joined to it:"
+msgstr ""
+"Ako imaš dodatne informacije za ovaj izvještaj o grešci,\n"
+"upiši ih ovdje i one će se dodati u izvještaj:"
+
+#: ../src/generic/dcpsg.cpp:1627
+msgid "Cannot open file for PostScript printing!"
+msgstr "Nije moguće otvoriti datoteku za ispis u PostScriptu!"
+
+#: ../src/generic/dirctrlg.cpp:402
+msgid "Computer"
+msgstr "Računalo"
+
+#: ../src/generic/dirctrlg.cpp:404
+msgid "Sections"
+msgstr "Odjeljci"
+
+#: ../src/generic/dirctrlg.cpp:482
+msgid "Home directory"
+msgstr "Početna mapa (home)"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/generic/dirctrlg.cpp:484 ../src/propgrid/advprops.cpp:811
+msgid "Desktop"
+msgstr "Desktop"
+
+#: ../src/generic/dirctrlg.cpp:528 ../src/generic/filectrlg.cpp:752
+msgid "Illegal directory name."
+msgstr "Nevažeće ime mape."
+
+#: ../src/generic/dirctrlg.cpp:528 ../src/generic/dirctrlg.cpp:546
+#: ../src/generic/dirctrlg.cpp:557 ../src/generic/dirdlgg.cpp:317
+#: ../src/generic/filectrlg.cpp:638 ../src/generic/filectrlg.cpp:752
+#: ../src/generic/filectrlg.cpp:766 ../src/generic/filectrlg.cpp:782
+#: ../src/generic/filectrlg.cpp:1356 ../src/generic/filectrlg.cpp:1387
+#: ../src/generic/filedlgg.cpp:362 ../src/gtk/filedlg.cpp:76
+msgid "Error"
+msgstr "Greška"
+
+#: ../src/generic/dirctrlg.cpp:546 ../src/generic/filectrlg.cpp:766
+msgid "File name exists already."
+msgstr "Ime datoteke već postoji."
+
+#: ../src/generic/dirctrlg.cpp:557 ../src/generic/dirdlgg.cpp:317
+#: ../src/generic/filectrlg.cpp:638 ../src/generic/filectrlg.cpp:782
+msgid "Operation not permitted."
+msgstr "Operacija nije dozvoljena."
+
+#: ../src/generic/dirdlgg.cpp:107 ../src/generic/filedlgg.cpp:207
+msgid "Create new directory"
+msgstr "Stvori novu mapu"
+
+#: ../src/generic/dirdlgg.cpp:112 ../src/generic/filedlgg.cpp:203
+msgid "Go to home directory"
+msgstr "Idi na osnovnu mapu"
+
+#: ../src/generic/dirdlgg.cpp:143
+msgid "Show &hidden directories"
+msgstr "Prikaži &skrivene mape"
+
+#: ../src/generic/dirdlgg.cpp:196
+#, c-format
+msgid ""
+"The directory '%s' does not exist\n"
+"Create it now?"
+msgstr ""
+"Mapa „%s” ne postoji.\n"
+"Želiš li je sada stvoriti?"
+
+#: ../src/generic/dirdlgg.cpp:198
+msgid "Directory does not exist"
+msgstr "Mapa ne postoji"
+
+#: ../src/generic/dirdlgg.cpp:214
+#, c-format
+msgid ""
+"Failed to create directory '%s'\n"
+"(Do you have the required permissions?)"
+msgstr ""
+"Neuspjela izrada mape „%s”\n"
+"(Imaš li potrebne dozvole?)"
+
+#: ../src/generic/dirdlgg.cpp:216
+msgid "Error creating directory"
+msgstr "Greška prilikom stvaranja mape"
+
+#: ../src/generic/dirdlgg.cpp:281
+msgid "You cannot add a new directory to this section."
+msgstr "Ne možeš dodati novu mapu ovom odjeljku."
+
+#: ../src/generic/dirdlgg.cpp:282
+msgid "Create directory"
+msgstr "Stvori mapu"
+
+#: ../src/generic/dirdlgg.cpp:291 ../src/generic/dirdlgg.cpp:301
+#: ../src/generic/filectrlg.cpp:614 ../src/generic/filectrlg.cpp:623
+msgid "NewName"
+msgstr "Novo ime"
+
+#: ../src/generic/editlbox.cpp:135
+msgid "Edit item"
+msgstr "Uredi stavku"
+
+#: ../src/generic/editlbox.cpp:143
+msgid "New item"
+msgstr "Nova stavka"
+
+#: ../src/generic/editlbox.cpp:151
+msgid "Delete item"
+msgstr "Izbriši stavku"
+
+#: ../src/generic/editlbox.cpp:159
+msgid "Move up"
+msgstr "Pomakni gore"
+
+#: ../src/generic/editlbox.cpp:164
+msgid "Move down"
+msgstr "Pomakni dolje"
+
+#: ../src/generic/fdrepdlg.cpp:108
+msgid "Search for:"
+msgstr "Traži:"
+
+#: ../src/generic/fdrepdlg.cpp:120
+msgid "Replace with:"
+msgstr "Zamijeni sa:"
+
+#: ../src/generic/fdrepdlg.cpp:140
+msgid "Whole word"
+msgstr "Cijela riječ"
+
+#: ../src/generic/fdrepdlg.cpp:143
+msgid "Match case"
+msgstr "Usporedi veličinu slova"
+
+#: ../src/generic/fdrepdlg.cpp:156
+msgid "Search direction"
+msgstr "Smjer traženja"
+
+#: ../src/generic/fdrepdlg.cpp:175
+msgid "&Replace"
+msgstr "&Zamijeni"
+
+#: ../src/generic/fdrepdlg.cpp:178
+msgid "Replace &all"
+msgstr "Zamijeni &sve"
+
+#: ../src/generic/filectrlg.cpp:246 ../src/generic/filectrlg.cpp:269
+msgid "<DIR>"
+msgstr "<DIR>"
+
+#: ../src/generic/filectrlg.cpp:248 ../src/generic/filectrlg.cpp:271
+msgid "<LINK>"
+msgstr "<POVEZNICA>"
+
+#: ../src/generic/filectrlg.cpp:250 ../src/generic/filectrlg.cpp:273
+msgid "<DRIVE>"
+msgstr "<DRIVE>"
+
+#: ../src/generic/filectrlg.cpp:275
+#, c-format
+msgid "%ld byte"
+msgid_plural "%ld bytes"
+msgstr[0] "%ld bajt"
+msgstr[1] "%ld bajta"
+msgstr[2] "%ld bajtova"
+
+#: ../src/generic/filectrlg.cpp:420
+msgid "Name"
+msgstr "Ime"
+
+#: ../src/generic/filectrlg.cpp:421 ../src/richtext/richtextformatdlg.cpp:361
+#: ../src/richtext/richtextsizepage.cpp:298
+msgid "Size"
+msgstr "Veličina"
+
+#: ../src/generic/filectrlg.cpp:422
+msgid "Type"
+msgstr "Vrsta"
+
+#: ../src/generic/filectrlg.cpp:423
+msgid "Modified"
+msgstr "Promijenjeno"
+
+#: ../src/generic/filectrlg.cpp:426
+msgid "Permissions"
+msgstr "Dozvole"
+
+#: ../src/generic/filectrlg.cpp:429
+msgid "Attributes"
+msgstr "Svojstva"
+
+#: ../src/generic/filectrlg.cpp:936
+msgid "Current directory:"
+msgstr "Trenutačna mapa:"
+
+#: ../src/generic/filectrlg.cpp:979
+msgid "Show &hidden files"
+msgstr "Prikaži &skrivene datoteke"
+
+#: ../src/generic/filectrlg.cpp:1355
+msgid "Illegal file specification."
+msgstr "Nevažeća specifikacija datoteke."
+
+#: ../src/generic/filectrlg.cpp:1387
+msgid "Directory doesn't exist."
+msgstr "Mapa ne postoji."
+
+#: ../src/generic/filedlgg.cpp:195
+msgid "View files as a list view"
+msgstr "Prikaži datoteke kao popis"
+
+#: ../src/generic/filedlgg.cpp:197
+msgid "View files as a detailed view"
+msgstr "Prikaži datoteke s detaljima"
+
+#: ../src/generic/filedlgg.cpp:200
+msgid "Go to parent directory"
+msgstr "Idi na matičnu mapu"
+
+#: ../src/generic/filedlgg.cpp:351 ../src/gtk/filedlg.cpp:59
+#, c-format
+msgid "File '%s' already exists, do you really want to overwrite it?"
+msgstr "Datoteka „%s”već postoji. Sigurno je želiš prepisati?"
+
+#: ../src/generic/filedlgg.cpp:354 ../src/gtk/filedlg.cpp:62
+msgid "Confirm"
+msgstr "Potvrdi"
+
+#: ../src/generic/filedlgg.cpp:362 ../src/gtk/filedlg.cpp:75
+msgid "Please choose an existing file."
+msgstr "Odaberi jednu postojeću datoteku."
+
+#: ../src/generic/filepickerg.cpp:64
+msgid "..."
+msgstr "…"
+
+#: ../src/generic/fontdlgg.cpp:76 ../src/richtext/richtextformatdlg.cpp:519
+msgid "ABCDEFGabcdefg12345"
+msgstr "ABĆĐEŠGabčdežg12345"
+
+#: ../src/generic/fontdlgg.cpp:315
+msgid "Roman"
+msgstr "Serifni"
+
+#: ../src/generic/fontdlgg.cpp:316
+msgid "Decorative"
+msgstr "Dekorativni"
+
+#: ../src/generic/fontdlgg.cpp:317
+msgid "Modern"
+msgstr "Moderni"
+
+#: ../src/generic/fontdlgg.cpp:318
+msgid "Script"
+msgstr "Pismo"
+
+#: ../src/generic/fontdlgg.cpp:319
+msgid "Swiss"
+msgstr "Švicarski"
+
+#: ../src/generic/fontdlgg.cpp:320
+msgid "Teletype"
+msgstr "Pisaći stroj"
+
+#: ../src/generic/fontdlgg.cpp:321 ../src/generic/fontdlgg.cpp:324
+msgid "Normal"
+msgstr "Normalni"
+
+#: ../src/generic/fontdlgg.cpp:323
+msgid "Slant"
+msgstr "Nagib"
+
+#: ../src/generic/fontdlgg.cpp:325
+msgid "Light"
+msgstr "Svijetli"
+
+#: ../src/generic/fontdlgg.cpp:363
+msgid "&Font family:"
+msgstr "&Obitelj fontova:"
+
+#: ../src/generic/fontdlgg.cpp:367 ../src/generic/fontdlgg.cpp:369
+msgid "The font family."
+msgstr "Obitelj fontova."
+
+#: ../src/generic/fontdlgg.cpp:374 ../src/richtext/richtextstylepage.cpp:105
+msgid "&Style:"
+msgstr "&Stil:"
+
+#: ../src/generic/fontdlgg.cpp:378 ../src/generic/fontdlgg.cpp:380
+msgid "The font style."
+msgstr "Stil fonta."
+
+#: ../src/generic/fontdlgg.cpp:385
+msgid "&Weight:"
+msgstr "&Debljina:"
+
+#: ../src/generic/fontdlgg.cpp:389 ../src/generic/fontdlgg.cpp:391
+msgid "The font weight."
+msgstr "Debljina fonta."
+
+#: ../src/generic/fontdlgg.cpp:399
+msgid "C&olour:"
+msgstr "B&oja:"
+
+#: ../src/generic/fontdlgg.cpp:407 ../src/generic/fontdlgg.cpp:409
+msgid "The font colour."
+msgstr "Boja fonta."
+
+#: ../src/generic/fontdlgg.cpp:415
+msgid "&Point size:"
+msgstr "&Veličina:"
+
+#: ../src/generic/fontdlgg.cpp:420 ../src/generic/fontdlgg.cpp:422
+#: ../src/generic/fontdlgg.cpp:426 ../src/generic/fontdlgg.cpp:428
+msgid "The font point size."
+msgstr "Veličina fonta."
+
+#: ../src/generic/fontdlgg.cpp:439 ../src/generic/fontdlgg.cpp:441
+msgid "Whether the font is underlined."
+msgstr "Je li font podcrtan."
+
+#: ../src/generic/fontdlgg.cpp:448 ../src/html/helpwnd.cpp:1215
+msgid "Preview:"
+msgstr "Pregled:"
+
+#: ../src/generic/fontdlgg.cpp:452 ../src/generic/fontdlgg.cpp:454
+msgid "Shows the font preview."
+msgstr "Prikazuje pregled fonta."
+
+#: ../src/generic/fontdlgg.cpp:464 ../src/generic/fontdlgg.cpp:483
+msgid "Click to cancel the font selection."
+msgstr "Klikni za odustajanje od odabira fonta."
+
+#: ../src/generic/fontdlgg.cpp:469 ../src/generic/fontdlgg.cpp:471
+#: ../src/generic/fontdlgg.cpp:476 ../src/generic/fontdlgg.cpp:478
+msgid "Click to confirm the font selection."
+msgstr "Klikni za potvrdu odabira fonta."
+
+#: ../src/generic/fontpickerg.cpp:50 ../src/gtk/fontdlg.cpp:77
+msgid "Choose font"
+msgstr "Odaberi font"
+
+#: ../src/generic/grid.cpp:6542
+msgid ""
+"Error copying grid to the clipboard. Either selected cells were not "
+"contiguous or no cell was selected."
+msgstr ""
+
+#: ../src/generic/grid.cpp:12739
+#, fuzzy
+msgid "Grid Corner"
+msgstr "Kut"
+
+#: ../src/generic/grid.cpp:12741
+#, fuzzy, c-format
+msgid "Column %s Header"
+msgstr "Stupac %u"
+
+#: ../src/generic/grid.cpp:12743
+#, c-format
+msgid "Row %s Header"
+msgstr ""
+
+#: ../src/generic/grid.cpp:12745
+#, fuzzy, c-format
+msgid "Column %s: %s"
+msgstr "Stupac %u"
+
+#: ../src/generic/grid.cpp:12749
+#, fuzzy, c-format
+msgid "Row %s: %s"
+msgstr "Redak %i"
+
+#: ../src/generic/grid.cpp:12753
+#, c-format
+msgid "Row %s, Column %s: %s"
+msgstr ""
+
+#: ../src/generic/helpext.cpp:257
+#, c-format
+msgid "Help directory \"%s\" not found."
+msgstr "Mapa pomoći „%s” nije pronađena."
+
+#: ../src/generic/helpext.cpp:265
+#, c-format
+msgid "Help file \"%s\" not found."
+msgstr "Datoteka pomoći „%s” nije pronađena."
+
+#: ../src/generic/helpext.cpp:284
+#, c-format
+msgid "Line %lu of map file \"%s\" has invalid syntax, skipped."
+msgstr "%lu. redak datoteke „%s” ima nevaljanu sintaksu, preskočeno."
+
+#: ../src/generic/helpext.cpp:292
+#, c-format
+msgid "No valid mappings found in the file \"%s\"."
+msgstr "U datoteci „%s” nisu pronađena valjana mapiranja."
+
+#: ../src/generic/helpext.cpp:435
+msgid "No entries found."
+msgstr "Unosi nisu pronađeni."
+
+#: ../src/generic/helpext.cpp:444 ../src/generic/helpext.cpp:445
+msgid "Help Index"
+msgstr "Indeks pomoći"
+
+#: ../src/generic/helpext.cpp:448
+msgid "Relevant entries:"
+msgstr "Relevantni unosi:"
+
+#: ../src/generic/helpext.cpp:449
+msgid "Entries found"
+msgstr "Pronađeni unosi"
+
+#: ../src/generic/hyperlinkg.cpp:170
+msgid "&Copy URL"
+msgstr "&Kopiraj URL"
+
+#: ../src/generic/infobar.cpp:119
+msgid "Hide this notification message."
+msgstr "Sakrij ovu obavijest."
+
+#. TRANSLATORS: %s will be either the application name or "Application"
+#: ../src/generic/logg.cpp:257
+#, c-format
+msgid "%s Error"
+msgstr "%s greška"
+
+#. TRANSLATORS: %s will be either the application name or "Application"
+#: ../src/generic/logg.cpp:263
+#, c-format
+msgid "%s Warning"
+msgstr "%s upozorenje"
+
+#. TRANSLATORS: %s will be either the application name or "Application"
+#: ../src/generic/logg.cpp:273
+#, c-format
+msgid "%s Information"
+msgstr "%s informacija"
+
+#: ../src/generic/logg.cpp:276
+msgid "Application"
+msgstr "Aplikacija"
+
+#: ../src/generic/logg.cpp:549
+msgid "Save log contents to file"
+msgstr "Spremi log-sadržaj u datoteku"
+
+#: ../src/generic/logg.cpp:551
+msgid "C&lear"
+msgstr "U&kloni"
+
+#: ../src/generic/logg.cpp:551
+msgid "Clear the log contents"
+msgstr "Očisti log sadržaj"
+
+#: ../src/generic/logg.cpp:553
+msgid "Close this window"
+msgstr "Zatvori ovaj prozor"
+
+#: ../src/generic/logg.cpp:554
+msgid "&Log"
+msgstr "&Log"
+
+#: ../src/generic/logg.cpp:610 ../src/generic/logg.cpp:992
+msgid "Can't save log contents to file."
+msgstr "Nije moguće spremiti log sadržaj u datoteku."
+
+#: ../src/generic/logg.cpp:613
+#, c-format
+msgid "Log saved to the file '%s'."
+msgstr "Log je spremljen u datoteku „%s”."
+
+#: ../src/generic/logg.cpp:719
+msgid "&Details"
+msgstr "&Detalji"
+
+#: ../src/generic/logg.cpp:972
+msgid "Failed to copy dialog contents to the clipboard."
+msgstr "Neuspjelo kopiranje sadržaja dijaloga u međuspremnik."
+
+#: ../src/generic/logg.cpp:1022
+#, c-format
+msgid "Append log to file '%s' (choosing [No] will overwrite it)?"
+msgstr ""
+"Pridodaj log-zapis datoteci „%s” (odabirom [Ne] će se datoteka prepisati)?"
+
+#: ../src/generic/logg.cpp:1024
+msgid "Question"
+msgstr "Pitanje"
+
+#: ../src/generic/logg.cpp:1038
+msgid "invalid message box return value"
+msgstr "nevaljana vraćena vrijednost okvira poruke"
+
+#: ../src/generic/notifmsgg.cpp:129
+msgid "Notice"
+msgstr "Napomena"
+
+#: ../src/generic/preferencesg.cpp:118
+#, c-format
+msgid "%s Preferences"
+msgstr "%s postavke"
+
+#: ../src/generic/printps.cpp:143
+msgid "Printing..."
+msgstr "Ispisivanje …"
+
+#: ../src/generic/printps.cpp:160 ../src/gtk/print.cpp:1076
+#: ../src/msw/printwin.cpp:235
+msgid "Could not start printing."
+msgstr "Nije bilo moguće pokrenuti ispis."
+
+#: ../src/generic/printps.cpp:183
+#, c-format
+msgid "Printing page %d..."
+msgstr "Ispisivanje %d. stranice …"
+
+#: ../src/generic/prntdlgg.cpp:171
+msgid "Printer options"
+msgstr "Opcije pisača"
+
+#: ../src/generic/prntdlgg.cpp:176
+msgid "Print to File"
+msgstr "Ispiši u datoteku"
+
+#: ../src/generic/prntdlgg.cpp:179
+msgid "Setup..."
+msgstr "Postavljanje …"
+
+#: ../src/generic/prntdlgg.cpp:187
+msgid "Printer:"
+msgstr "Pisač:"
+
+#: ../src/generic/prntdlgg.cpp:195
+msgid "Status:"
+msgstr "Stanje:"
+
+#: ../src/generic/prntdlgg.cpp:206
+msgid "All"
+msgstr "Sve"
+
+#: ../src/generic/prntdlgg.cpp:207
+msgid "Pages"
+msgstr "Stranice"
+
+#: ../src/generic/prntdlgg.cpp:215
+msgid "Print Range"
+msgstr "Opseg ispisa"
+
+#: ../src/generic/prntdlgg.cpp:229
+msgid "From:"
+msgstr "Od:"
+
+#: ../src/generic/prntdlgg.cpp:233
+msgid "To:"
+msgstr "Do:"
+
+#: ../src/generic/prntdlgg.cpp:238
+msgid "Copies:"
+msgstr "Kopije:"
+
+#: ../src/generic/prntdlgg.cpp:288
+msgid "PostScript file"
+msgstr "PostScript datoteka"
+
+#: ../src/generic/prntdlgg.cpp:439
+msgid "Print Setup"
+msgstr "Postavke ispisa"
+
+#: ../src/generic/prntdlgg.cpp:483
+msgid "Printer"
+msgstr "Pisač"
+
+#: ../src/generic/prntdlgg.cpp:501
+msgid "Default printer"
+msgstr "Zadani pisač"
+
+#: ../src/generic/prntdlgg.cpp:595 ../src/generic/prntdlgg.cpp:782
+#: ../src/generic/prntdlgg.cpp:822 ../src/generic/prntdlgg.cpp:835
+#: ../src/generic/prntdlgg.cpp:1031 ../src/generic/prntdlgg.cpp:1036
+msgid "Paper size"
+msgstr "Veličina papira"
+
+#: ../src/generic/prntdlgg.cpp:604 ../src/generic/prntdlgg.cpp:847
+msgid "Portrait"
+msgstr "Uspravno"
+
+#: ../src/generic/prntdlgg.cpp:605 ../src/generic/prntdlgg.cpp:848
+msgid "Landscape"
+msgstr "Položeno"
+
+#: ../src/generic/prntdlgg.cpp:607 ../src/generic/prntdlgg.cpp:849
+msgid "Orientation"
+msgstr "Položaj"
+
+#: ../src/generic/prntdlgg.cpp:610
+msgid "Options"
+msgstr "Opcije"
+
+#: ../src/generic/prntdlgg.cpp:612
+msgid "Print in colour"
+msgstr "Ispiši u boji"
+
+#: ../src/generic/prntdlgg.cpp:621
+msgid "Print spooling"
+msgstr "Pripremanje ispisa"
+
+#: ../src/generic/prntdlgg.cpp:623
+msgid "Printer command:"
+msgstr "Naredba pisača:"
+
+#: ../src/generic/prntdlgg.cpp:631
+msgid "Printer options:"
+msgstr "Opcije pisača:"
+
+#: ../src/generic/prntdlgg.cpp:860
+msgid "Left margin (mm):"
+msgstr "Lijeva margina (mm):"
+
+#: ../src/generic/prntdlgg.cpp:861
+msgid "Top margin (mm):"
+msgstr "Gornja margina (mm):"
+
+#: ../src/generic/prntdlgg.cpp:872
+msgid "Right margin (mm):"
+msgstr "Desna margina (mm):"
+
+#: ../src/generic/prntdlgg.cpp:873
+msgid "Bottom margin (mm):"
+msgstr "Donja margina (mm):"
+
+#: ../src/generic/prntdlgg.cpp:896
+msgid "Printer..."
+msgstr "Pisač …"
+
+#: ../src/generic/progdlgg.cpp:246
+msgid "&Skip"
+msgstr "&Preskoči"
+
+#: ../src/generic/progdlgg.cpp:347 ../src/generic/progdlgg.cpp:626
+msgid "Unknown"
+msgstr "Nepoznato"
+
+#: ../src/generic/progdlgg.cpp:451 ../src/msw/progdlg.cpp:526
+msgid "Done."
+msgstr "Gotovo."
+
+#: ../src/generic/srchctlg.cpp:55 ../src/gtk/srchctrl.cpp:206
+#: ../src/html/helpwnd.cpp:530 ../src/html/helpwnd.cpp:545
+msgid "Search"
+msgstr "Traži"
+
+#: ../src/generic/tabg.cpp:1026
+msgid "Could not find tab for id"
+msgstr "Nije bilo moguće naći karticu za id"
+
+#: ../src/generic/tipdlg.cpp:136
+msgid "Tips not available, sorry!"
+msgstr "Na žalost nema savjeta!"
+
+#: ../src/generic/tipdlg.cpp:197
+msgid "Tip of the Day"
+msgstr "Savjet dana"
+
+#: ../src/generic/tipdlg.cpp:207
+msgid "Did you know..."
+msgstr "Je li znaš …"
+
+#: ../src/generic/tipdlg.cpp:232
+msgid "&Show tips at startup"
+msgstr "&Prikaži savjete prilikom pokretanja"
+
+#: ../src/generic/tipdlg.cpp:236
+msgid "&Next Tip"
+msgstr "&Sljedeći savjet"
+
+#: ../src/generic/wizard.cpp:411
+msgid "&Next >"
+msgstr "&Sljedeće >"
+
+#: ../src/generic/wizard.cpp:412
+msgid "&Finish"
+msgstr "&Završi"
+
+#: ../src/generic/wizard.cpp:420
+msgid "< &Back"
+msgstr "< &Natrag"
+
+#: ../src/gtk/aboutdlg.cpp:204
+msgid "translator-credits"
+msgstr "Milo Ivir <mail@milotype.de>"
+
+#: ../src/gtk/app.cpp:517
+msgid ""
+"WARNING: using XIM input method is unsupported and may result in problems "
+"with input handling and flickering. Consider unsetting GTK_IM_MODULE or "
+"setting to \"ibus\"."
+msgstr ""
+"UPOZORENJE: korištenje metode XIM unosa nije podržano i može prouzročiti "
+"probleme u rukovanju s unosom i treperenjem. Deaktiviraj GTK_IM_MODULE ili "
+"postavi na „ibus”."
+
+#: ../src/gtk/app.cpp:569
+msgid "Unable to initialize GTK+, is DISPLAY set properly?"
+msgstr "Nije moguće inicijalizirati GTK+. Je li DISPLAY ispravno postavljen?"
+
+#: ../src/gtk/filedlg.cpp:89 ../src/gtk/filepicker.cpp:255
+#, c-format
+msgid "Changing current directory to \"%s\" failed"
+msgstr "Mijenjanje trenutačne mape u „%s” nije uspjelo"
+
+#: ../src/gtk/font.cpp:548
+msgid ""
+"Using private fonts is not supported on this system: Pango library is too "
+"old, 1.38 or later required."
+msgstr ""
+"Korištenje privatnih fontova nije podržano na ovom sustavu: Pango biblioteka "
+"je pre stara, potrebna je verzija 1.38 ili novija."
+
+#: ../src/gtk/font.cpp:558
+msgid "Failed to create font configuration object."
+msgstr "Neuspjela izrada objekta konfiguracije fontova."
+
+#: ../src/gtk/font.cpp:568
+#, c-format
+msgid "Failed to add custom font \"%s\"."
+msgstr "Neuspjelo dodavanje zadanog fonta „%s”."
+
+#: ../src/gtk/font.cpp:576
+msgid "Failed to register font configuration using private fonts."
+msgstr ""
+"Neuspjela registracija konfiguracije fontova koristeći privatne fontove."
+
+#: ../src/gtk/glcanvas.cpp:117 ../src/gtk/glcanvas.cpp:132
+msgid "Fatal Error"
+msgstr "Kobna greška"
+
+#: ../src/gtk/glcanvas.cpp:117
+msgid ""
+"This program wasn't compiled with EGL support required under Wayland, "
+"either\n"
+"install EGL libraries and rebuild or run it under X11 backend by setting\n"
+"environment variable GDK_BACKEND=x11 before starting your program."
+msgstr ""
+"Ovaj program nije kompiliran s EGL podrškom koja je potrebna u Waylandu.\n"
+"Instaliraj EGL biblioteke i ponovno ih izgradi ili pokreni ih u X11 pozadini "
+"postavljanjem\n"
+"varijable okruženja GDK_BACKEND=x11 prije pokretanja tvog programa."
+
+#: ../src/gtk/glcanvas.cpp:132
+msgid ""
+"wxGLCanvas is only supported on Wayland and X11 currently.  You may be able "
+"to\n"
+"work around this by setting environment variable GDK_BACKEND=x11 before\n"
+"starting your program."
+msgstr ""
+"wxGLCanvas se trenutačno se ne podržava na Waylandu i X11. Možda je moguće\n"
+"zaobići taj problem postavljanjem varijable okruženja GDK_BACKEND=x11 prije\n"
+"pokretanja programa."
+
+#: ../src/gtk/mdi.cpp:433
+msgid "MDI child"
+msgstr "MDI child"
+
+#: ../src/gtk/power.cpp:188
+#, fuzzy, c-format
+msgid "Failed to open D-Bus connection to the login manager: %s"
+msgstr "Neuspjelo povezivanje na server „%s” na temu „%s”"
+
+#: ../src/gtk/power.cpp:214
+#, fuzzy
+msgid "wxWidgets application"
+msgstr "Sakrij aplikaciju"
+
+#: ../src/gtk/power.cpp:226
+msgid "Application needs to keep running"
+msgstr ""
+
+#: ../src/gtk/power.cpp:233
+msgid "Clean up before suspend"
+msgstr ""
+
+#: ../src/gtk/power.cpp:259
+#, fuzzy, c-format
+msgid "Failed to inhibit sleep: %s"
+msgstr "Neuspjelo inicijaliziranje povezivanja: %s"
+
+#: ../src/gtk/power.cpp:265
+msgid "Unexpected response to D-Bus \"Inhibit\" request."
+msgstr ""
+
+#: ../src/gtk/print.cpp:218
+msgid "Custom size"
+msgstr "Prilagođena veličina"
+
+#: ../src/gtk/print.cpp:752
+#, fuzzy, c-format
+msgid "Error while printing: %s"
+msgstr "Greška prilikom spisa: "
+
+#: ../src/gtk/print.cpp:816
+msgid "Page Setup"
+msgstr "Postavke stranice"
+
+#: ../src/gtk/webview_webkit.cpp:932
+msgid "Retrieving JavaScript script output is not supported with WebKit v1"
+msgstr "Dohvaćanje iznošaja JavaScript skripta nije podržano s WebKit v1"
+
+#: ../src/gtk/webview_webkit2.cpp:1098
+msgid ""
+"Setting proxy is not supported by WebKit, at least version 2.16 is required."
+msgstr ""
+
+#: ../src/gtk/webview_webkit2.cpp:1104
+msgid "This program was compiled without support for setting WebKit proxy."
+msgstr ""
+
+#: ../src/gtk/window.cpp:6289
+msgid ""
+"GTK+ installed on this machine is too old to support screen compositing, "
+"please install GTK+ 2.12 or later."
+msgstr ""
+"Na ovom računalu instalirani GTK+ je pre star za podržavanje dijeljenja "
+"ekrana, instaliraj GTK+ 2.12 ili noviju verziju."
+
+#: ../src/gtk/window.cpp:6307
+msgid ""
+"Compositing not supported by this system, please enable it in your Window "
+"Manager."
+msgstr ""
+"Dijeljenje nije podržano u ovom sustavu. Aktiviraj ga u tvom upravljaču "
+"prozora."
+
+#: ../src/gtk/window.cpp:6318
+msgid ""
+"This program was compiled with a too old version of GTK+, please rebuild "
+"with GTK+ 2.12 or newer."
+msgstr ""
+"Ovaj je program kompiliran s pre starom verzijom GTK+, ponovo izgradi s GTK+ "
+"2.12 ili novijom verzijom."
+
+#: ../src/html/chm.cpp:138
+#, c-format
+msgid "Failed to open CHM archive '%s'."
+msgstr "Neuspjelo otvaranje CHM arhive „%s”."
+
+#: ../src/html/chm.cpp:270
+#, c-format
+msgid "Could not extract %s into %s: %s"
+msgstr "Nije bilo moguće izdvojiti %s u %s: %s"
+
+#: ../src/html/chm.cpp:324
+msgid "no error"
+msgstr "bez greške"
+
+#: ../src/html/chm.cpp:326
+msgid "bad arguments to library function"
+msgstr "neispravni argumenti za funkciju biblioteke"
+
+#: ../src/html/chm.cpp:328
+msgid "error opening file"
+msgstr "greška prilikom otvaranja datoteke"
+
+#: ../src/html/chm.cpp:330
+msgid "read error"
+msgstr "greška u čitanju"
+
+#: ../src/html/chm.cpp:332
+msgid "write error"
+msgstr "greška u pisanju"
+
+#: ../src/html/chm.cpp:334
+msgid "seek error"
+msgstr "traži grešku"
+
+#: ../src/html/chm.cpp:338
+msgid "bad signature"
+msgstr "neispravna signatura"
+
+#: ../src/html/chm.cpp:340
+msgid "error in data format"
+msgstr "greška u formatu podataka"
+
+#: ../src/html/chm.cpp:342
+msgid "checksum error"
+msgstr "greška u ispitnom zbroju"
+
+#: ../src/html/chm.cpp:344
+msgid "compression error"
+msgstr "greška u komprimiranju"
+
+#: ../src/html/chm.cpp:346
+msgid "decompression error"
+msgstr "greška u dekomprimiranju"
+
+#: ../src/html/chm.cpp:437
+#, c-format
+msgid "Could not locate file '%s'."
+msgstr "Nije bilo moguće pronaći datoteku „%s”."
+
+#: ../src/html/chm.cpp:711
+#, c-format
+msgid "Could not create temporary file '%s'"
+msgstr "Nije bilo moguće stvoriti privremenu datoteku „%s”"
+
+#: ../src/html/chm.cpp:718
+#, c-format
+msgid "Extraction of '%s' into '%s' failed."
+msgstr "Izvlačenje iz „%s” u „%s”."
+
+#: ../src/html/chm.cpp:806 ../src/html/chm.cpp:863
+msgid "CHM handler currently supports only local files!"
+msgstr "CHM upravljač trenutačno podržava samo lokalne datoteke!"
+
+#: ../src/html/chm.cpp:827
+msgid "Link contained '//', converted to absolute link."
+msgstr "Poveznica je sadržavala „//”; pretvorena je u apsolutnu poveznicu."
+
+#: ../src/html/helpctrl.cpp:59
+#, c-format
+msgid "Help: %s"
+msgstr "Pomoć: %s"
+
+#: ../src/html/helpctrl.cpp:155
+#, c-format
+msgid "Adding book %s"
+msgstr "Dodavanje knjige %s"
+
+#: ../src/html/helpdata.cpp:295
+#, c-format
+msgid "Cannot open contents file: %s"
+msgstr "Nije moguće otvoriti datoteku sadržaja: %s"
+
+#: ../src/html/helpdata.cpp:309
+#, c-format
+msgid "Cannot open index file: %s"
+msgstr "Nije moguće otvoriti datoteku indeksa: %s"
+
+#: ../src/html/helpdata.cpp:643
+msgid "noname"
+msgstr "bezimeno"
+
+#: ../src/html/helpdata.cpp:652
+#, c-format
+msgid "Cannot open HTML help book: %s"
+msgstr "Nije moguće otvoriti HTML knjigu pomoći: %s"
+
+#: ../src/html/helpwnd.cpp:315
+msgid "Displays help as you browse the books on the left."
+msgstr "Prikazuje pomoć prilikom pregledavanja knjiga na lijevo strani."
+
+#: ../src/html/helpwnd.cpp:411 ../src/html/helpwnd.cpp:1100
+#: ../src/html/helpwnd.cpp:1735
+msgid "(bookmarks)"
+msgstr "(knjižne oznake)"
+
+#: ../src/html/helpwnd.cpp:424
+msgid "Add current page to bookmarks"
+msgstr "Dodaj trenutačnu stranicu u knjižne oznake"
+
+#: ../src/html/helpwnd.cpp:425
+msgid "Remove current page from bookmarks"
+msgstr "Ukloni trenutačnu stranicu iz knjižnih oznaka"
+
+#: ../src/html/helpwnd.cpp:470
+msgid "Contents"
+msgstr "Sadržaj"
+
+#: ../src/html/helpwnd.cpp:485
+msgid "Find"
+msgstr "Nađi"
+
+#: ../src/html/helpwnd.cpp:487
+msgid "Show all"
+msgstr "Prikaži sve"
+
+#: ../src/html/helpwnd.cpp:497
+msgid ""
+"Display all index items that contain given substring. Search is case "
+"insensitive."
+msgstr ""
+"Prikaži sve indicirane stavke koje sadržavaju zadani znakovni niz. Pretraga "
+"ne razlikuje veličinu slova."
+
+#: ../src/html/helpwnd.cpp:498
+msgid "Show all items in index"
+msgstr "Prikaži sve stavke u indeksu"
+
+#: ../src/html/helpwnd.cpp:528
+msgid "Case sensitive"
+msgstr "Razlikovanje veličine slova"
+
+#: ../src/html/helpwnd.cpp:529
+msgid "Whole words only"
+msgstr "Samo cijele riječi"
+
+#: ../src/html/helpwnd.cpp:532
+msgid ""
+"Search contents of help book(s) for all occurrences of the text you typed "
+"above"
+msgstr ""
+"Pretraži sadržaj svih knjiga pomoći, i nađi sva pojavljivanja gore utipkanog "
+"teksta"
+
+#: ../src/html/helpwnd.cpp:653
+msgid "Show/hide navigation panel"
+msgstr "Prikaži/sakrij navigaciju"
+
+#: ../src/html/helpwnd.cpp:655
+msgid "Go back"
+msgstr "Idi natrag"
+
+#: ../src/html/helpwnd.cpp:656
+msgid "Go forward"
+msgstr "Idi naprijed"
+
+#: ../src/html/helpwnd.cpp:658
+msgid "Go one level up in document hierarchy"
+msgstr "Idi jednu razinu prema gore u hijerarhiji dokumenata"
+
+#: ../src/html/helpwnd.cpp:666 ../src/html/helpwnd.cpp:1547
+msgid "Open HTML document"
+msgstr "Otvori HTML datoteku"
+
+#: ../src/html/helpwnd.cpp:670
+msgid "Print this page"
+msgstr "Ispiši ovu stranicu"
+
+#: ../src/html/helpwnd.cpp:674
+msgid "Display options dialog"
+msgstr "Dijalog za opcije prikaza"
+
+#: ../src/html/helpwnd.cpp:795
+msgid "Please choose the page to display:"
+msgstr "Odaberi stranicu za prikazivanje:"
+
+#: ../src/html/helpwnd.cpp:796
+msgid "Help Topics"
+msgstr "Pomoć za teme"
+
+#: ../src/html/helpwnd.cpp:852
+msgid "Searching..."
+msgstr "Traženje …"
+
+#: ../src/html/helpwnd.cpp:853
+msgid "No matching page found yet"
+msgstr "Dosada nije nađena odgovarajuće stranica"
+
+#: ../src/html/helpwnd.cpp:870
+#, c-format
+msgid "Found %i matches"
+msgstr "Nađena su %i poklapanja"
+
+#: ../src/html/helpwnd.cpp:958
+msgid "(Help)"
+msgstr "(pomoć)"
+
+#: ../src/html/helpwnd.cpp:1026
+#, c-format
+msgid "%d of %lu"
+msgstr "%d od %lu"
+
+#: ../src/html/helpwnd.cpp:1028
+#, c-format
+msgid "%lu of %lu"
+msgstr "%lu od %lu"
+
+#: ../src/html/helpwnd.cpp:1047
+msgid "Search in all books"
+msgstr "Traži u svim knjigama"
+
+#: ../src/html/helpwnd.cpp:1193
+msgid "Help Browser Options"
+msgstr "Pomoć za opcije preglednika"
+
+#: ../src/html/helpwnd.cpp:1198
+msgid "Normal font:"
+msgstr "Normalni font:"
+
+#: ../src/html/helpwnd.cpp:1199
+msgid "Fixed font:"
+msgstr "Font fiksne širine:"
+
+#: ../src/html/helpwnd.cpp:1200
+msgid "Font size:"
+msgstr "Veličina fonta:"
+
+#: ../src/html/helpwnd.cpp:1245
+msgid "font size"
+msgstr "veličina fonta"
+
+#: ../src/html/helpwnd.cpp:1256
+msgid "Normal face<br>and <u>underlined</u>. "
+msgstr "Normalni font<br>i <u>podcrtano</u>. "
+
+#: ../src/html/helpwnd.cpp:1257
+msgid "<i>Italic face.</i> "
+msgstr "<i>Kurziv.</i> "
+
+#: ../src/html/helpwnd.cpp:1258
+msgid "<b>Bold face.</b> "
+msgstr "<b>Debeli.</b> "
+
+#: ../src/html/helpwnd.cpp:1259
+msgid "<b><i>Bold italic face.</i></b><br>"
+msgstr "<b><i>Debeli kurziv.</i></b><br>"
+
+#: ../src/html/helpwnd.cpp:1262
+msgid "Fixed size face.<br> <b>bold</b> <i>italic</i> "
+msgstr "Font fiksne širine.<br> <b>debeli</b> <i>kurziv</i> "
+
+#: ../src/html/helpwnd.cpp:1263
+msgid "<b><i>bold italic <u>underlined</u></i></b><br>"
+msgstr "<b><i>debeli kurziv <u>podcrtano</u></i></b><br>"
+
+#: ../src/html/helpwnd.cpp:1524
+msgid "Help Printing"
+msgstr "Pomoć za ispis"
+
+#: ../src/html/helpwnd.cpp:1527
+msgid "Cannot print empty page."
+msgstr "Nije moguće ispisati praznu stranicu."
+
+#: ../src/html/helpwnd.cpp:1540
+msgid "HTML files (*.html;*.htm)|*.html;*.htm|"
+msgstr "HTML datoteke (*.html;*.htm)|*.html;*.htm|"
+
+#: ../src/html/helpwnd.cpp:1541
+msgid "Help books (*.htb)|*.htb|Help books (*.zip)|*.zip|"
+msgstr "Pomoćne knjige (*.htb)|*.htb|Pomoćne knjige (*.zip)|*.zip|"
+
+#: ../src/html/helpwnd.cpp:1542
+msgid "HTML Help Project (*.hhp)|*.hhp|"
+msgstr "HTML pomoćni projekt (*.hhp)|*.hhp|"
+
+#: ../src/html/helpwnd.cpp:1544
+msgid "Compressed HTML Help file (*.chm)|*.chm|"
+msgstr "Komprimirana HTML datoteka pomoći (*.chm)|*.chm|"
+
+#: ../src/html/helpwnd.cpp:1671
+#, c-format
+msgid "%i of %u"
+msgstr "%i od %u"
+
+#: ../src/html/helpwnd.cpp:1709
+#, c-format
+msgid "%u of %u"
+msgstr "%u od %u"
+
+#: ../src/html/htmlfilt.cpp:134
+#, c-format
+msgid "Cannot open HTML document: %s"
+msgstr "Nije moguće otvoriti HTML dokument: %s"
+
+#: ../src/html/htmlwin.cpp:599
+msgid "Connecting..."
+msgstr "Spajanje …"
+
+#: ../src/html/htmlwin.cpp:616
+#, c-format
+msgid "Unable to open requested HTML document: %s"
+msgstr "Nije moguće otvoriti traženi HTML dokument: %s"
+
+#: ../src/html/htmlwin.cpp:630
+msgid "Loading : "
+msgstr "Učitavanje : "
+
+#: ../src/html/htmlwin.cpp:673
+msgid "Done"
+msgstr "Gotovo"
+
+#: ../src/html/htmlwin.cpp:723
+#, c-format
+msgid "HTML anchor %s does not exist."
+msgstr "HTML sidro %s ne postoji."
+
+#: ../src/html/htmlwin.cpp:1057
+#, c-format
+msgid "Copied to clipboard:\"%s\""
+msgstr "Kopirano u međuspremnik:„%s”"
+
+#: ../src/html/htmprint.cpp:269
+msgid ""
+"This document doesn't fit on the page horizontally and will be truncated "
+"when it is printed."
+msgstr ""
+"Ovaj dokument ne paše na stranicu vodoravno, te će biti odrezana u ispisu."
+
+#: ../src/html/htmprint.cpp:285
+#, c-format
+msgid ""
+"The document \"%s\" doesn't fit on the page horizontally and will be "
+"truncated if printed.\n"
+"\n"
+"Would you like to proceed with printing it nevertheless?"
+msgstr ""
+"Dokument „%s” ne paše na stranicu vodoravno, te će biti odrezana u ispisu.\n"
+"\n"
+"Želiš li ipak nastaviti s ispisom?"
+
+#: ../src/html/htmprint.cpp:296
+msgid ""
+"If possible, try changing the layout parameters to make the printout more "
+"narrow."
+msgstr ""
+"Ako moguće, pokušj promijeniti parametre za poredak stranice, kako bi ispis "
+"ispao uži."
+
+#: ../src/html/htmprint.cpp:445
+msgid ": file does not exist!"
+msgstr ": datoteka ne postoji!"
+
+#. TRANSLATORS: %s may be a document title.
+#: ../src/html/htmprint.cpp:717
+#, fuzzy, c-format
+msgid "%s Preview"
+msgstr " Pregled"
+
+#: ../src/html/htmprint.cpp:755 ../src/richtext/richtextprint.cpp:618
+msgid ""
+"There was a problem during page setup: you may need to set a default printer."
+msgstr ""
+"Došlo je do problema prilikom postavljanja stranice: možda moraš postaviti "
+"zadani pisač."
+
+#: ../src/msw/clipbrd.cpp:80
+msgid "Failed to open the clipboard."
+msgstr "Neuspjelo otvaranje međuspremnika."
+
+#: ../src/msw/clipbrd.cpp:101
+msgid "Failed to close the clipboard."
+msgstr "Neuspjelo zatvaranje međuspremnika."
+
+#: ../src/msw/clipbrd.cpp:113
+msgid "Failed to empty the clipboard."
+msgstr "Neuspjelo pražnjenje međuspremnika."
+
+#: ../src/msw/clipbrd.cpp:284
+msgid "Failed to put data on the clipboard"
+msgstr "Neuspjelo spremanje podataka u međuspremnik"
+
+#: ../src/msw/clipbrd.cpp:326
+msgid "Failed to get data from the clipboard"
+msgstr "Neuspjelo dobivanje podataka iz međuspremnika"
+
+#: ../src/msw/clipbrd.cpp:363
+msgid "Failed to retrieve the supported clipboard formats"
+msgstr "Neuspjelo dohvaćanje podržavajućih formata za međuspremnik"
+
+#: ../src/msw/colordlg.cpp:228
+#, c-format
+msgid "Colour selection dialog failed with error %0lx."
+msgstr "Dijalog za boju odabira nije uspjeo, zbog greške %0lx."
+
+#: ../src/msw/cursor.cpp:141
+msgid "Failed to create cursor."
+msgstr "Neuspjelo stvaranje pokazivača."
+
+#: ../src/msw/dde.cpp:279
+#, c-format
+msgid "Failed to register DDE server '%s'"
+msgstr "Neuspjelo registriranje DDE servera „%s”"
+
+#: ../src/msw/dde.cpp:300
+#, c-format
+msgid "Failed to unregister DDE server '%s'"
+msgstr "Neuspjelo odjavljivanje DDE servera „%s”"
+
+#: ../src/msw/dde.cpp:428
+#, c-format
+msgid "Failed to create connection to server '%s' on topic '%s'"
+msgstr "Neuspjelo povezivanje na server „%s” na temu „%s”"
+
+#: ../src/msw/dde.cpp:655
+msgid "DDE poke request failed"
+msgstr "DDE poke upit nije uspjeo"
+
+#: ../src/msw/dde.cpp:674
+msgid "Failed to establish an advise loop with DDE server"
+msgstr "Neuspjelo stvoriti advise petlju s DDE serverom"
+
+#: ../src/msw/dde.cpp:693
+msgid "Failed to terminate the advise loop with DDE server"
+msgstr "Neuspjelo prekidanje advise petlje s DDE serverom"
+
+#: ../src/msw/dde.cpp:768
+msgid "Failed to send DDE advise notification"
+msgstr "Neuspjelo slanje DDE advise napomena"
+
+#: ../src/msw/dde.cpp:1085
+msgid "Failed to create DDE string"
+msgstr "Neuspjelo stvaranje DDE znakovnog niza"
+
+#: ../src/msw/dde.cpp:1131
+msgid "no DDE error."
+msgstr "bez DDE greške."
+
+#: ../src/msw/dde.cpp:1135
+msgid "a request for a synchronous advise transaction has timed out."
+msgstr "vrijeme zahtjeva za sinkroniziranu preporučenu transakciju je isteklo."
+
+#: ../src/msw/dde.cpp:1138
+msgid "the response to the transaction caused the DDE_FBUSY bit to be set."
+msgstr "odgovor transakciji je prouzročilo, da se postavio DDE_FBUSY bit."
+
+#: ../src/msw/dde.cpp:1141
+msgid "a request for a synchronous data transaction has timed out."
+msgstr "vrijeme zahtjeva za sinkroniziranu transakciju podataka je isteklo."
+
+#: ../src/msw/dde.cpp:1144
+msgid ""
+"a DDEML function was called without first calling the DdeInitialize "
+"function,\n"
+"or an invalid instance identifier\n"
+"was passed to a DDEML function."
+msgstr ""
+"jedna DDEML funkcija je pozvana bez prethodnog pozivanja funkcije "
+"DdeInitialize,\n"
+"ili je jedan nevažeći identifikator instance\n"
+"proslijeđen DDEML funkciji."
+
+#: ../src/msw/dde.cpp:1147
+msgid ""
+"an application initialized as APPCLASS_MONITOR has\n"
+"attempted to perform a DDE transaction,\n"
+"or an application initialized as APPCMD_CLIENTONLY has \n"
+"attempted to perform server transactions."
+msgstr ""
+"aplikacija inicijalizirana kao APPCLASS_MONITOR\n"
+"pokušala je izvršiti DDE transakciju,\n"
+"ili aplikacija inicijalizirana kao APPCMD_CLIENTONLY\n"
+"pokušala je izvršiti transakcije servera."
+
+#: ../src/msw/dde.cpp:1150
+msgid "a request for a synchronous execute transaction has timed out."
+msgstr "vrijeme zahtjeva za sinkroniziranu izvršnu transakciju je isteklo."
+
+#: ../src/msw/dde.cpp:1153
+msgid "a parameter failed to be validated by the DDEML."
+msgstr "jedan parametar nije validiran od DDEML-a."
+
+#: ../src/msw/dde.cpp:1156
+msgid "a DDEML application has created a prolonged race condition."
+msgstr "jedna DDEML aplikacija je stvorila produljeno stanje."
+
+#: ../src/msw/dde.cpp:1159
+msgid "a memory allocation failed."
+msgstr "alociranje memorije nije uspjelo."
+
+#: ../src/msw/dde.cpp:1162
+msgid "a client's attempt to establish a conversation has failed."
+msgstr "pokušaj klijenta da uspostavi razgovor nije uspjeo."
+
+#: ../src/msw/dde.cpp:1165
+msgid "a transaction failed."
+msgstr "jedna transakcija nije uspjela."
+
+#: ../src/msw/dde.cpp:1168
+msgid "a request for a synchronous poke transaction has timed out."
+msgstr "vrijeme zahtjeva za sinkroniziranu guranu transakciju je isteklo."
+
+#: ../src/msw/dde.cpp:1171
+msgid "an internal call to the PostMessage function has failed. "
+msgstr "interni poziv na funkciju PostMessage nije uspjeo. "
+
+#: ../src/msw/dde.cpp:1174
+msgid "reentrancy problem."
+msgstr "problema prilikom ponovnog ulaženja."
+
+#: ../src/msw/dde.cpp:1177
+msgid ""
+"a server-side transaction was attempted on a conversation\n"
+"that was terminated by the client, or the server\n"
+"terminated before completing a transaction."
+msgstr ""
+"na razgovoru je pokušana transakcija sa strane servera\n"
+"koji je prekinut od strane klijenta ili ga je server prekinuo\n"
+"prije završetka transakcije."
+
+#: ../src/msw/dde.cpp:1180
+msgid "an internal error has occurred in the DDEML."
+msgstr "dogodila se interna greška u DDEML-u."
+
+#: ../src/msw/dde.cpp:1183
+msgid "a request to end an advise transaction has timed out."
+msgstr "vrijeme zahtjeva za prekidom preporučene transakcije je isteklo."
+
+#: ../src/msw/dde.cpp:1186
+msgid ""
+"an invalid transaction identifier was passed to a DDEML function.\n"
+"Once the application has returned from an XTYP_XACT_COMPLETE callback,\n"
+"the transaction identifier for that callback is no longer valid."
+msgstr ""
+"neispravni identifikator transakcije proslijeđen je DDEML funkciji.\n"
+"Nakon što se aplikacija vrati iz povratnog poziva XTYP_XACT_COMPLETE,\n"
+"identifikator transakcije za taj povratni poziv više nije valjan."
+
+#: ../src/msw/dde.cpp:1189
+#, c-format
+msgid "Unknown DDE error %08x"
+msgstr "Nepoznata DDE greška %08x"
+
+#: ../src/msw/dialup.cpp:343
+msgid ""
+"Dial up functions are unavailable because the remote access service (RAS) is "
+"not installed on this machine. Please install it."
+msgstr ""
+"Funkcije nazivanja nisu dostupne jer usluga daljinskog pristupa (RAS) nije "
+"instalirana na ovom računalu. Instaliraj ga."
+
+#: ../src/msw/dialup.cpp:402
+#, c-format
+msgid ""
+"The version of remote access service (RAS) installed on this machine is too "
+"old, please upgrade (the following required function is missing: %s)."
+msgstr ""
+"Na ovom računalu instalirana verzija usluge daljninskog pristupa (RAS) je "
+"pre stara, nadogradi je (nedostaje potrebna funkcija: %s)."
+
+#: ../src/msw/dialup.cpp:437
+msgid "Failed to retrieve text of RAS error message"
+msgstr "Neuspjelo dohvaćanje teksta iz RAS poruke o greškama"
+
+#: ../src/msw/dialup.cpp:440
+#, c-format
+msgid "unknown error (error code %08x)."
+msgstr "nepoznata greška (kod greške %08x)."
+
+#: ../src/msw/dialup.cpp:492
+#, c-format
+msgid "Cannot find active dialup connection: %s"
+msgstr "Nije moguće naći aktivnu vezu pozivanja: %s"
+
+#: ../src/msw/dialup.cpp:513
+msgid "Several active dialup connections found, choosing one randomly."
+msgstr "Pronađeno je nekoliko aktivnih veza, jedna je nasumce odabrana."
+
+#: ../src/msw/dialup.cpp:598 ../src/msw/dialup.cpp:832
+#, c-format
+msgid "Failed to establish dialup connection: %s"
+msgstr "Neuspjelo stvaranje aktivne veze pozivanja: %s"
+
+#: ../src/msw/dialup.cpp:664
+#, c-format
+msgid "Failed to get ISP names: %s"
+msgstr "Neuspjelo dobivanje ISP imena: %s"
+
+#: ../src/msw/dialup.cpp:712
+msgid "Failed to connect: no ISP to dial."
+msgstr "Neuspjelo povezivanje: nema ISP za biranje."
+
+#: ../src/msw/dialup.cpp:732
+msgid "Choose ISP to dial"
+msgstr "Odaberi ISP za biranje"
+
+#: ../src/msw/dialup.cpp:733
+msgid "Please choose which ISP do you want to connect to"
+msgstr "Odaberi davatelja internetskih usluga s kojim se želiš povezati"
+
+#: ../src/msw/dialup.cpp:766
+msgid "Failed to connect: missing username/password."
+msgstr "Neuspjelo povezivanje: nedostaje korisničko ime/lozinka."
+
+#: ../src/msw/dialup.cpp:796
+msgid "Cannot find the location of address book file"
+msgstr "Nije moguće naći mjesto datoteke adresara"
+
+#: ../src/msw/dialup.cpp:827
+#, c-format
+msgid "Failed to initiate dialup connection: %s"
+msgstr "Neuspjelo inicijaliziranje povezivanja: %s"
+
+#: ../src/msw/dialup.cpp:897
+msgid "Cannot hang up - no active dialup connection."
+msgstr "Nije moguće prekinuti poziv – nema aktivne veze pozivanja."
+
+#: ../src/msw/dialup.cpp:907
+#, c-format
+msgid "Failed to terminate the dialup connection: %s"
+msgstr "Neuspjelo prekidanje veze pozivanja: %s"
+
+#: ../src/msw/dib.cpp:313
+#, c-format
+msgid "Failed to save the bitmap image to file \"%s\"."
+msgstr "Neuspjelo spremanje bitmap slike u datoteku „%s”."
+
+#: ../src/msw/dib.cpp:543
+#, c-format
+msgid "Failed to allocate %luKb of memory for bitmap data."
+msgstr "Neuspjelo alociranje %lu Kb memorije za podatke bitmapa."
+
+#: ../src/msw/dir.cpp:241
+#, c-format
+msgid "Cannot enumerate files in directory '%s'"
+msgstr "Nije moguće numerirati datoteke u mapi „%s”"
+
+#: ../src/msw/dirdlg.cpp:368
+msgid "Couldn't obtain folder name"
+msgstr "Nije bilo moguće dobiti ime mape"
+
+#: ../src/msw/dlmsw.cpp:163
+#, c-format
+msgid "(error %d: %s)"
+msgstr "(greška %d: %s)"
+
+#: ../src/msw/dragimag.cpp:143 ../src/msw/dragimag.cpp:178
+#: ../src/msw/imaglist.cpp:309 ../src/msw/imaglist.cpp:331
+msgid "Couldn't add an image to the image list."
+msgstr "Nije bilo moguće dodati sliku u popis slika."
+
+#: ../src/msw/enhmeta.cpp:94
+#, c-format
+msgid "Failed to load metafile from file \"%s\"."
+msgstr "Neuspjelo učitavanje metafile iz datoteke „%s”."
+
+#: ../src/msw/fdrepdlg.cpp:412
+#, c-format
+msgid "Failed to create the standard find/replace dialog (error code %d)"
+msgstr ""
+"Neuspjelo stvaranje standardnog traži/zamijeni dijaloga (kodna greška %d)"
+
+#: ../src/msw/filedlg.cpp:1241
+msgid "Access to the file system is not allowed from secure desktop."
+msgstr ""
+
+#: ../src/msw/filedlg.cpp:1242
+msgid "Security warning"
+msgstr ""
+
+#: ../src/msw/filedlg.cpp:1533
+#, c-format
+msgid "File dialog failed with error code %0lx."
+msgstr "Greška u dijalogu, sa šifrom greške %0lx."
+
+#: ../src/msw/font.cpp:1120
+#, c-format
+msgid "Font file \"%s\" couldn't be loaded"
+msgstr "Nije bilo moguće učitati font-datoteku „%s”"
+
+#: ../src/msw/fontdlg.cpp:220
+#, c-format
+msgid "Common dialog failed with error code %0lx."
+msgstr "Uobičajeni dijalog nije uspjeo, sa šifrom greške %0lx."
+
+#: ../src/msw/fswatcher.cpp:67
+msgid "Ungraceful worker thread termination"
+msgstr "Neuredan prekid komponente procesa"
+
+#: ../src/msw/fswatcher.cpp:81
+msgid "Unable to create IOCP worker thread"
+msgstr ""
+"Nije moguće stvoriti komponentu procesa završnog priključka ulaza/izlaza"
+
+#: ../src/msw/fswatcher.cpp:88
+msgid "Unable to start IOCP worker thread"
+msgstr ""
+"Nije moguće pokrenuti komponentu procesa završnog priključka ulaza/izlaza"
+
+#: ../src/msw/fswatcher.cpp:140
+msgid "Monitoring individual files for changes is not supported currently."
+msgstr "Praćenje promjena pojedinih datoteka se trenutačno ne podržava."
+
+#: ../src/msw/fswatcher.cpp:165
+#, c-format
+msgid "Unable to set up watch for '%s'"
+msgstr "Nije moguće postaviti sat za „%s”"
+
+#: ../src/msw/fswatcher.cpp:466
+#, c-format
+msgid "Can't monitor non-existent directory \"%s\" for changes."
+msgstr "Nije moguće praćenje promjena za nepostojeću mapu „%s”."
+
+#: ../src/msw/glcanvas.cpp:577 ../src/unix/glx11.cpp:507
+msgid "OpenGL 3.0 or later is not supported by the OpenGL driver."
+msgstr "OpenGL driver ne podržava OpenGL 3.0 i novije."
+
+#: ../src/msw/glcanvas.cpp:601 ../src/osx/glcanvas_osx.cpp:395
+#: ../src/unix/glegl.cpp:304 ../src/unix/glx11.cpp:553
+msgid "Couldn't create OpenGL context"
+msgstr "Nije bilo moguće stvoriti OpenGL sadržaj"
+
+#: ../src/msw/glcanvas.cpp:1294
+msgid "Failed to initialize OpenGL"
+msgstr "Neuspjelo inicijaliziranje OpenGL-a"
+
+#: ../src/msw/graphicsd2d.cpp:607
+msgid "Could not register custom DirectWrite font loader."
+msgstr ""
+"Nije bilo moguće registrirati prilagođeni DirectWrite učitavač fontova."
+
+#: ../src/msw/helpchm.cpp:48
+msgid ""
+"MS HTML Help functions are unavailable because the MS HTML Help library is "
+"not installed on this machine. Please install it."
+msgstr ""
+"Funkcije za MS HTML pomoć nisu dostupne, jer biblioteka za MS HTML pomoć "
+"nije instalirana na ovom računalu. Instaliraj je."
+
+#: ../src/msw/helpchm.cpp:55
+msgid "Failed to initialize MS HTML Help."
+msgstr "Neuspjelo inicijaliziranje MS HTML pomoći."
+
+#: ../src/msw/iniconf.cpp:458
+#, c-format
+msgid "Can't delete the INI file '%s'"
+msgstr "Nije moguće izbrisati INI datoteku „%s”"
+
+#: ../src/msw/listctrl.cpp:995
+#, c-format
+msgid "Couldn't retrieve information about list control item %d."
+msgstr "Nije bilo moguće pronaći informacije o kontrolnoj stavci popisa %d."
+
+#: ../src/msw/mdi.cpp:170 ../src/qt/mdi.cpp:253
+msgid "&Cascade"
+msgstr "&Kaskada"
+
+#: ../src/msw/mdi.cpp:171
+msgid "Tile &Horizontally"
+msgstr "Poploči vodoravno"
+
+#: ../src/msw/mdi.cpp:172
+msgid "Tile &Vertically"
+msgstr "Poploči uspravno"
+
+#: ../src/msw/mdi.cpp:174
+msgid "&Arrange Icons"
+msgstr "&Rasporedi ikone"
+
+#: ../src/msw/mdi.cpp:621
+msgid "Failed to create MDI parent frame."
+msgstr "Neuspjela izrada MDI matičnog okvira."
+
+#: ../src/msw/mimetype.cpp:234
+#, c-format
+msgid "Failed to create registry entry for '%s' files."
+msgstr "Neuspjela izrada registarskog unosa za „%s” datoteka."
+
+#: ../src/msw/ole/automtn.cpp:495
+#, c-format
+msgid "Failed to find CLSID of \"%s\""
+msgstr "Neuspjelo pronalaženje CLSID-a od „%s”"
+
+#: ../src/msw/ole/automtn.cpp:512
+#, c-format
+msgid "Failed to create an instance of \"%s\""
+msgstr "Neuspjelo stvaranje instance od „%s”"
+
+#: ../src/msw/ole/automtn.cpp:552
+#, c-format
+msgid "Cannot get an active instance of \"%s\""
+msgstr "Nije moguće dobiti aktivnu instancu „%s”"
+
+#: ../src/msw/ole/automtn.cpp:564
+#, c-format
+msgid "Failed to get OLE automation interface for \"%s\""
+msgstr "Neuspjelo dobivanje OLE sučelje automatizacije za „%s”"
+
+#: ../src/msw/ole/automtn.cpp:621
+msgid "Unknown name or named argument."
+msgstr "Nepoznato ime ili imenovani argument."
+
+#: ../src/msw/ole/automtn.cpp:625
+msgid "Incorrect number of arguments."
+msgstr "Nepravilan broj argumenata."
+
+#: ../src/msw/ole/automtn.cpp:637
+msgid "Unknown exception"
+msgstr "Nepoznata iznimka"
+
+#: ../src/msw/ole/automtn.cpp:642
+msgid "Method or property not found."
+msgstr "Metoda ili svojstvo nisu nađeni."
+
+#: ../src/msw/ole/automtn.cpp:646
+msgid "Overflow while coercing argument values."
+msgstr "Prekoračenje prilikom prisiljivanja vrijedonsti argumenta."
+
+#: ../src/msw/ole/automtn.cpp:650
+msgid "Object implementation does not support named arguments."
+msgstr "Implementacija objekta ne podržava imenovane argumente."
+
+#: ../src/msw/ole/automtn.cpp:654
+msgid "The locale ID is unknown."
+msgstr "ID lokalizacije nije poznat."
+
+#: ../src/msw/ole/automtn.cpp:658
+msgid "Missing a required parameter."
+msgstr "Nedostaje obavezan parametar."
+
+#: ../src/msw/ole/automtn.cpp:662
+#, c-format
+msgid "Argument %u not found."
+msgstr "Argument %u nije nađen."
+
+#: ../src/msw/ole/automtn.cpp:666
+#, c-format
+msgid "Type mismatch in argument %u."
+msgstr "Nepodudaranje vrste u argumentu %u."
+
+#: ../src/msw/ole/automtn.cpp:670
+msgid "The system cannot find the file specified."
+msgstr "Sustav ne može naći određenu datoteku."
+
+#: ../src/msw/ole/automtn.cpp:674
+msgid "Class not registered."
+msgstr "Klasa nije registrirana."
+
+#: ../src/msw/ole/automtn.cpp:678
+#, c-format
+msgid "Unknown error %08x"
+msgstr "Nepoznata greška %08x"
+
+#: ../src/msw/ole/automtn.cpp:682
+#, c-format
+msgid "OLE Automation error in %s: %s"
+msgstr "Greška OLE automatizacije u %s: %s"
+
+#: ../src/msw/ole/dataobj.cpp:385
+#, c-format
+msgid "Couldn't register clipboard format '%s'."
+msgstr "Nije bilo moguće registrirati format međuspremnika „%s”."
+
+#: ../src/msw/ole/dataobj.cpp:402
+#, c-format
+msgid "The clipboard format '%d' doesn't exist."
+msgstr "Format međuspremnika „%d” ne postoji."
+
+#: ../src/msw/progdlg.cpp:1025
+msgid "Skip"
+msgstr "Preskoči"
+
+#: ../src/msw/registry.cpp:141
+#, c-format
+msgid "unknown (%lu)"
+msgstr "nepoznato (%lu)"
+
+#: ../src/msw/registry.cpp:409
+#, c-format
+msgid "Can't get info about registry key '%s'"
+msgstr "Nije moguće dobiti informacije o ključu „%s”"
+
+#: ../src/msw/registry.cpp:445
+#, c-format
+msgid "Can't open registry key '%s'"
+msgstr "Nije moguće otvoriti registarski ključ „%s”"
+
+#: ../src/msw/registry.cpp:478
+#, c-format
+msgid "Can't create registry key '%s'"
+msgstr "Nije moguće stvoriti registarski ključ „%s”"
+
+#: ../src/msw/registry.cpp:497
+#, c-format
+msgid "Can't close registry key '%s'"
+msgstr "Nije moguće zatvoriti registarski ključ „%s”"
+
+#: ../src/msw/registry.cpp:512
+#, c-format
+msgid "Registry value '%s' already exists."
+msgstr "Registarska vrijednost „%s” već postoji."
+
+#: ../src/msw/registry.cpp:520
+#, c-format
+msgid "Failed to rename registry value '%s' to '%s'."
+msgstr "Neuspjelo preimenovanje registarske vrijednost „%s” u „%s”."
+
+#: ../src/msw/registry.cpp:575
+#, c-format
+msgid "Can't copy values of unsupported type %d."
+msgstr "Nije moguće kopirati vrijednosti nepodržane vrste %d."
+
+#: ../src/msw/registry.cpp:586
+#, c-format
+msgid "Registry key '%s' does not exist, cannot rename it."
+msgstr "Registarski ključ „%s” ne postoji; nije ga moguće preimenovati."
+
+#: ../src/msw/registry.cpp:617
+#, c-format
+msgid "Registry key '%s' already exists."
+msgstr "Registarski ključ „%s” već postoji."
+
+#: ../src/msw/registry.cpp:625
+#, c-format
+msgid "Failed to rename the registry key '%s' to '%s'."
+msgstr "Neuspjelo preimenovanje registarskog ključa „%s” u „%s”."
+
+#: ../src/msw/registry.cpp:670
+#, c-format
+msgid "Failed to copy the registry subkey '%s' to '%s'."
+msgstr "Neuspjelo kopiranje registarskog pod-ključa „%s” u „%s”."
+
+#: ../src/msw/registry.cpp:683
+#, c-format
+msgid "Failed to copy registry value '%s'"
+msgstr "Neuspjelo kopiranje registarske vrijednost „%s”"
+
+#: ../src/msw/registry.cpp:692
+#, c-format
+msgid "Failed to copy the contents of registry key '%s' to '%s'."
+msgstr "Neuspjelo kopiranje sadržaja registarskog ključa „%s” u „%s”."
+
+#: ../src/msw/registry.cpp:718
+#, c-format
+msgid ""
+"Registry key '%s' is needed for normal system operation,\n"
+"deleting it will leave your system in unusable state:\n"
+"operation aborted."
+msgstr ""
+"Registarski ključ „%s” je potreban za normalan rad sustava.\n"
+"Brisanjem će tvoj sustav postati nestabilan:\n"
+"operacija je prekinuta."
+
+#: ../src/msw/registry.cpp:754
+#, c-format
+msgid "Can't delete key '%s'"
+msgstr "Nije moguće izbrisati ključ „%s”"
+
+#: ../src/msw/registry.cpp:782
+#, c-format
+msgid "Can't delete value '%s' from key '%s'"
+msgstr "Nije moguće izbrisati vrijednost „%s” ključa „%s”"
+
+#: ../src/msw/registry.cpp:855 ../src/msw/registry.cpp:887
+#: ../src/msw/registry.cpp:929 ../src/msw/registry.cpp:1000
+#, c-format
+msgid "Can't read value of key '%s'"
+msgstr "Nije moguće čitanje vrijednosti od ključa „%s”"
+
+#: ../src/msw/registry.cpp:873 ../src/msw/registry.cpp:915
+#: ../src/msw/registry.cpp:963 ../src/msw/registry.cpp:1106
+#, c-format
+msgid "Can't set value of '%s'"
+msgstr "Nije moguće postavljanje vrijednosti od „%s”"
+
+#: ../src/msw/registry.cpp:894 ../src/msw/registry.cpp:943
+#, c-format
+msgid "Registry value \"%s\" is not numeric (but of type %s)"
+msgstr "Registarska vrijednost „%s” nije numerička (ali je vrste %s)"
+
+#: ../src/msw/registry.cpp:979
+#, c-format
+msgid "Registry value \"%s\" is not binary (but of type %s)"
+msgstr "Registarska vrijednost „%s” nije binarna (ali je vrste %s)"
+
+#: ../src/msw/registry.cpp:1028
+#, c-format
+msgid "Registry value \"%s\" is not text (but of type %s)"
+msgstr "Registarska vrijednost „%s” nije tekst (ali je vrste %s)"
+
+#: ../src/msw/registry.cpp:1089
+#, c-format
+msgid "Can't read value of '%s'"
+msgstr "Nije moguće čitanje vrijednosti od „%s”"
+
+#: ../src/msw/registry.cpp:1157
+#, c-format
+msgid "Can't enumerate values of key '%s'"
+msgstr "Nije moguće numeriranje vrijednosti ključa „%s”"
+
+#: ../src/msw/registry.cpp:1196
+#, c-format
+msgid "Can't enumerate subkeys of key '%s'"
+msgstr "Nije moguće numeriranje podključeva ključa „%s”"
+
+#: ../src/msw/registry.cpp:1262
+#, c-format
+msgid ""
+"Exporting registry key: file \"%s\" already exists and won't be overwritten."
+msgstr ""
+"Izvoz ključa registra: datoteka „%s” već postoji i neće biti prepisana."
+
+#: ../src/msw/registry.cpp:1411
+#, c-format
+msgid "Can't export value of unsupported type %d."
+msgstr "Nije moguće izvesti vrijednost nepodržane vrste %d."
+
+#: ../src/msw/registry.cpp:1427
+#, c-format
+msgid "Ignoring value \"%s\" of the key \"%s\"."
+msgstr "Zanemarivanje vrijednosti „%s” tipke „%s”."
+
+#: ../src/msw/textctrl.cpp:596
+msgid ""
+"Impossible to create a rich edit control, using simple text control instead. "
+"Please reinstall riched32.dll"
+msgstr ""
+"Stvaranje uređivača bogatog teksta nije moguće, koristi se jednostavni "
+"uređivač. Instaliraj riched32.dll ponovo"
+
+#: ../src/msw/thread.cpp:522 ../src/unix/threadpsx.cpp:850
+msgid "Cannot start thread: error writing TLS."
+msgstr "Nije moguće započeti tijek: greška prilikom pisanja TLS-a."
+
+#: ../src/msw/thread.cpp:613
+msgid "Can't set thread priority"
+msgstr "Nije moguće postaviti prioritet komponente procesa"
+
+#: ../src/msw/thread.cpp:649
+msgid "Can't create thread"
+msgstr "Nije moguće stvoriti komponentu procesa"
+
+#: ../src/msw/thread.cpp:668
+msgid "Couldn't terminate thread"
+msgstr "Nije bilo moguće prekinuti komponentu procesa"
+
+#: ../src/msw/thread.cpp:799
+msgid "Cannot wait for thread termination"
+msgstr "Nije moguće čekati na prekid komponente procesa"
+
+#: ../src/msw/thread.cpp:873
+#, c-format
+msgid "Cannot suspend thread %lx"
+msgstr "Nije moguće odgoditi komponentu procesa %lx"
+
+#: ../src/msw/thread.cpp:903
+#, c-format
+msgid "Cannot resume thread %lx"
+msgstr "Nije moguće nastaviti komponentu procesa %lx"
+
+#: ../src/msw/thread.cpp:932
+msgid "Couldn't get the current thread pointer"
+msgstr "Nije bilo moguće dobiti trenutačni označivač komponente procesa"
+
+#: ../src/msw/thread.cpp:1333
+msgid ""
+"Thread module initialization failed: impossible to allocate index in thread "
+"local storage"
+msgstr ""
+"Neuspjela inicijalizacija modula komponente procesa: nije moguće alocirati "
+"indeks u komponenti procesa lokalnog spremišta"
+
+#: ../src/msw/thread.cpp:1345
+msgid ""
+"Thread module initialization failed: cannot store value in thread local "
+"storage"
+msgstr ""
+"Neuspjela inicijalizacija modula komponente procesa: nije moguće spremiti "
+"vrijednost u komponenti procesa lokalnog spremišta"
+
+#: ../src/msw/timer.cpp:133
+msgid "Couldn't create a timer"
+msgstr "Nije bilo moguće stvoriti brojač vremena"
+
+#: ../src/msw/utils.cpp:372
+msgid "can't find user's HOME, using current directory."
+msgstr ""
+"nije moguće pronaći korisničku početnu mapu, koristi se trenutačna mapa."
+
+#: ../src/msw/utils.cpp:662
+#, c-format
+msgid "Failed to kill process %d"
+msgstr "Neuspjelo nasilno prekidanje procesa %d"
+
+#: ../src/msw/utils.cpp:986
+#, c-format
+msgid "Failed to load resource \"%s\"."
+msgstr "Neuspjelo učitavanje resursa „%s”."
+
+#: ../src/msw/utils.cpp:993
+#, c-format
+msgid "Failed to lock resource \"%s\"."
+msgstr "Neuspjelo zaključavanje resursa „%s”."
+
+#. TRANSLATORS: MS Windows build number
+#: ../src/msw/utils.cpp:1209
+#, c-format
+msgid "build %lu"
+msgstr "gradnja %lu"
+
+#: ../src/msw/utils.cpp:1218
+msgid ", 64-bit edition"
+msgstr ", 64-bitno izdanje"
+
+#: ../src/msw/utilsexc.cpp:224
+msgid "Failed to create an anonymous pipe"
+msgstr "Neuspjelo stvaranje anonimnog cjevovoda"
+
+#: ../src/msw/utilsexc.cpp:697
+msgid "Failed to redirect the child process IO"
+msgstr "Neuspjelo preusmjeravanje podređenog procesa ulaza/izlaza"
+
+#: ../src/msw/utilsexc.cpp:870
+#, c-format
+msgid "Execution of command '%s' failed"
+msgstr "Izvršenje naredbe %s"
+
+#: ../src/msw/volume.cpp:337
+msgid "Failed to load mpr.dll."
+msgstr "Neuspjelo učitavanje mpr.dll-a."
+
+#: ../src/msw/volume.cpp:506
+#, c-format
+msgid "Cannot read typename from '%s'!"
+msgstr "Nije moguće čitati ime vrste od „%s”!"
+
+#: ../src/msw/volume.cpp:615
+#, c-format
+msgid "Cannot load icon from '%s'."
+msgstr "Nije moguće učitati ikone iz „%s”."
+
+#: ../src/msw/webview_edge.cpp:285
+msgid "This program was compiled without support for setting Edge proxy."
+msgstr ""
+
+#: ../src/msw/webview_ie.cpp:1010
+msgid "Failed to find web view emulation level in the registry"
+msgstr "Neuspjelo pronalaženje razine emulacije web prikaza u registru"
+
+#: ../src/msw/webview_ie.cpp:1019
+msgid "Failed to set web view to modern emulation level"
+msgstr "Neuspjelo postavljanje web-prikaza na modernu razinu emulacije"
+
+#: ../src/msw/webview_ie.cpp:1027
+msgid "Failed to reset web view to standard emulation level"
+msgstr "Neuspjelo obnavljanje web-prikaza na standardnu razinu emulacije"
+
+#: ../src/msw/webview_ie.cpp:1049
+msgid "Can't run JavaScript script without a valid HTML document"
+msgstr "JavaScript skripta se ne može pokrenuti bez valjanog HTML dokumenta"
+
+#: ../src/msw/webview_ie.cpp:1056
+msgid "Can't get the JavaScript object"
+msgstr "Nije moguće dobiti JavaScript objekt"
+
+#: ../src/msw/webview_ie.cpp:1070
+msgid "failed to evaluate"
+msgstr "neuspjela evaluacija"
+
+#: ../src/osx/cocoa/filedlg.mm:412
+msgid "File type:"
+msgstr "Vrsta datoteke:"
+
+#: ../src/osx/cocoa/menu.mm:242
+msgctxt "macOS menu name"
+msgid "Window"
+msgstr "Prozor"
+
+#: ../src/osx/cocoa/menu.mm:259
+msgctxt "macOS menu name"
+msgid "Help"
+msgstr "Pomoć"
+
+#: ../src/osx/cocoa/menu.mm:298
+msgctxt "macOS menu item"
+msgid "Minimize"
+msgstr "Smanji"
+
+#: ../src/osx/cocoa/menu.mm:303
+msgctxt "macOS menu item"
+msgid "Zoom"
+msgstr "Zumiraj"
+
+#: ../src/osx/cocoa/menu.mm:309
+msgctxt "macOS menu item"
+msgid "Bring All to Front"
+msgstr "Postavi sve naprijed"
+
+#: ../src/osx/core/sound.cpp:143
+#, c-format
+msgid "Failed to load sound from \"%s\" (error %d)."
+msgstr "Neuspjelo učitavanje zvuka iz „%s”. (greška %d)."
+
+#: ../src/osx/fontutil.cpp:80
+#, c-format
+msgid "Font file \"%s\" doesn't exist."
+msgstr "Font-datoteka „%s” ne postoji."
+
+#: ../src/osx/fontutil.cpp:88
+#, c-format
+msgid ""
+"Font file \"%s\" cannot be used as it is not inside the font directory "
+"\"%s\"."
+msgstr ""
+"Font-datoteka „%s” se ne može koristiti, jer se ne nalazi u mapi fontova "
+"„%s”."
+
+#: ../src/osx/menu_osx.cpp:496
+#, c-format
+msgctxt "macOS menu item"
+msgid "About %s"
+msgstr "O programu %s"
+
+#: ../src/osx/menu_osx.cpp:499
+msgctxt "macOS menu item"
+msgid "About..."
+msgstr "O programu …"
+
+#: ../src/osx/menu_osx.cpp:508
+msgctxt "macOS menu item"
+msgid "Preferences..."
+msgstr "Postavke …"
+
+#: ../src/osx/menu_osx.cpp:512
+msgctxt "macOS menu item"
+msgid "Services"
+msgstr "Usluge"
+
+#: ../src/osx/menu_osx.cpp:519
+#, c-format
+msgctxt "macOS menu item"
+msgid "Hide %s"
+msgstr "Sakrij %s"
+
+#: ../src/osx/menu_osx.cpp:522
+msgctxt "macOS menu item"
+msgid "Hide Application"
+msgstr "Sakrij aplikaciju"
+
+#: ../src/osx/menu_osx.cpp:526
+msgctxt "macOS menu item"
+msgid "Hide Others"
+msgstr "Sakrij ostalo"
+
+#: ../src/osx/menu_osx.cpp:528
+msgctxt "macOS menu item"
+msgid "Show All"
+msgstr "Prikaži sve"
+
+#: ../src/osx/menu_osx.cpp:534
+#, c-format
+msgctxt "macOS menu item"
+msgid "Quit %s"
+msgstr "Zatvori %s"
+
+#: ../src/osx/menu_osx.cpp:537
+msgctxt "macOS menu item"
+msgid "Quit Application"
+msgstr "Zatvori aplikaciju"
+
+#: ../src/osx/webview_webkit.mm:444
+msgid "Printing is not supported by the system web control"
+msgstr "Sustavsko upravljanje internetom ne podržava ispis"
+
+#: ../src/osx/webview_webkit.mm:453
+msgid "Print operation could not be initialized"
+msgstr "Nije bilo moguće inicijalizirati operaciju za ispis"
+
+#. TRANSLATORS: Label of font point size
+#: ../src/propgrid/advprops.cpp:605
+msgid "Point Size"
+msgstr "Veličina u tipografskim točkama"
+
+#. TRANSLATORS: Label of font face name
+#: ../src/propgrid/advprops.cpp:615
+msgid "Face Name"
+msgstr "Ime fonta"
+
+#. TRANSLATORS: Label of font style
+#: ../src/propgrid/advprops.cpp:623 ../src/richtext/richtextformatdlg.cpp:331
+msgid "Style"
+msgstr "Stil"
+
+#. TRANSLATORS: Label of font weight
+#: ../src/propgrid/advprops.cpp:628
+msgid "Weight"
+msgstr "Debljina"
+
+#. TRANSLATORS: Label of underlined font
+#: ../src/propgrid/advprops.cpp:633 ../src/richtext/richtextfontpage.cpp:358
+msgid "Underlined"
+msgstr "Podcrtano"
+
+#. TRANSLATORS: Label of font family
+#: ../src/propgrid/advprops.cpp:637
+msgid "Family"
+msgstr "Obitelj"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:801
+msgid "AppWorkspace"
+msgstr "Radna površina aplikacije"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:802
+msgid "ActiveBorder"
+msgstr "Aktivni rub"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:803
+msgid "ActiveCaption"
+msgstr "Aktivni podnaslov"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:804
+msgid "ButtonFace"
+msgstr "Ploha gumba"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:805
+msgid "ButtonHighlight"
+msgstr "Isticanje gumba"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:806
+msgid "ButtonShadow"
+msgstr "Sjena gumba"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:807
+msgid "ButtonText"
+msgstr "Tekst gumba"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:808
+msgid "CaptionText"
+msgstr "Tekst podnaslova"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:809
+msgid "ControlDark"
+msgstr "Upravljač tamno"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:810
+msgid "ControlLight"
+msgstr "Upravljač svjetlo"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:812
+msgid "GrayText"
+msgstr "Sivi tekst"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:813
+msgid "Highlight"
+msgstr "Istakni"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:814
+msgid "HighlightText"
+msgstr "Istakni tekst"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:815
+msgid "InactiveBorder"
+msgstr "Rub neaktivnih"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:816
+msgid "InactiveCaption"
+msgstr "Podnaslov neaktivnih"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:817
+msgid "InactiveCaptionText"
+msgstr "Tekst podnaslova neaktivnih"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:818
+msgid "Menu"
+msgstr "Izbornik"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:819
+msgid "Scrollbar"
+msgstr "Traka klizača"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:820
+msgid "Tooltip"
+msgstr "Opis alata"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:821
+msgid "TooltipText"
+msgstr "Tekst opisa alata"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:822
+msgid "Window"
+msgstr "Window"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:823
+msgid "WindowFrame"
+msgstr "Okvir prozora"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:824
+msgid "WindowText"
+msgstr "Tekst prozora"
+
+#. TRANSLATORS: Custom colour choice entry
+#: ../src/propgrid/advprops.cpp:825 ../src/propgrid/advprops.cpp:1532
+#: ../src/propgrid/advprops.cpp:1576
+msgid "Custom"
+msgstr "Prilagođeno"
+
+#: ../src/propgrid/advprops.cpp:1558
+msgid "Black"
+msgstr "Crna"
+
+#: ../src/propgrid/advprops.cpp:1559
+msgid "Maroon"
+msgstr "Kestenjasta"
+
+#: ../src/propgrid/advprops.cpp:1560
+msgid "Navy"
+msgstr "Mornarsko plava"
+
+#: ../src/propgrid/advprops.cpp:1561
+msgid "Purple"
+msgstr "Ljubičasta"
+
+#: ../src/propgrid/advprops.cpp:1562
+msgid "Teal"
+msgstr "Plavozelena"
+
+#: ../src/propgrid/advprops.cpp:1563
+msgid "Gray"
+msgstr "Siva"
+
+#: ../src/propgrid/advprops.cpp:1564
+msgid "Green"
+msgstr "Zelena"
+
+#: ../src/propgrid/advprops.cpp:1565
+msgid "Olive"
+msgstr "Maslinasta"
+
+#: ../src/propgrid/advprops.cpp:1566
+msgid "Brown"
+msgstr "Smeđa"
+
+#: ../src/propgrid/advprops.cpp:1567
+msgid "Blue"
+msgstr "Plava"
+
+#: ../src/propgrid/advprops.cpp:1568
+msgid "Fuchsia"
+msgstr "Fuksija"
+
+#: ../src/propgrid/advprops.cpp:1569
+msgid "Red"
+msgstr "Crvena"
+
+#: ../src/propgrid/advprops.cpp:1570
+msgid "Orange"
+msgstr "Narančasta"
+
+#: ../src/propgrid/advprops.cpp:1571
+msgid "Silver"
+msgstr "Srebrna"
+
+#: ../src/propgrid/advprops.cpp:1572
+msgid "Lime"
+msgstr "Limun"
+
+#: ../src/propgrid/advprops.cpp:1573
+msgid "Aqua"
+msgstr "Plavkasta"
+
+#: ../src/propgrid/advprops.cpp:1574
+msgid "Yellow"
+msgstr "Žuta"
+
+#: ../src/propgrid/advprops.cpp:1575
+msgid "White"
+msgstr "Bijela"
+
+#: ../src/propgrid/advprops.cpp:1718
+msgctxt "system cursor name"
+msgid "Default"
+msgstr "Zadano"
+
+#: ../src/propgrid/advprops.cpp:1719
+msgctxt "system cursor name"
+msgid "Arrow"
+msgstr "Strelica"
+
+#: ../src/propgrid/advprops.cpp:1720
+msgctxt "system cursor name"
+msgid "Right Arrow"
+msgstr "Strelica-Desno"
+
+#: ../src/propgrid/advprops.cpp:1721
+msgctxt "system cursor name"
+msgid "Blank"
+msgstr "Prazno"
+
+#: ../src/propgrid/advprops.cpp:1722
+msgctxt "system cursor name"
+msgid "Bullseye"
+msgstr "Meta"
+
+#: ../src/propgrid/advprops.cpp:1723
+msgctxt "system cursor name"
+msgid "Character"
+msgstr "Znak"
+
+#: ../src/propgrid/advprops.cpp:1724
+msgctxt "system cursor name"
+msgid "Cross"
+msgstr "Križić"
+
+#: ../src/propgrid/advprops.cpp:1725
+msgctxt "system cursor name"
+msgid "Hand"
+msgstr "Ruka"
+
+#: ../src/propgrid/advprops.cpp:1726
+msgctxt "system cursor name"
+msgid "I-Beam"
+msgstr "Okomita crta"
+
+#: ../src/propgrid/advprops.cpp:1727
+msgctxt "system cursor name"
+msgid "Left Button"
+msgstr "Lijevi gumb"
+
+#: ../src/propgrid/advprops.cpp:1728
+msgctxt "system cursor name"
+msgid "Magnifier"
+msgstr "Povećalo"
+
+#: ../src/propgrid/advprops.cpp:1729
+msgctxt "system cursor name"
+msgid "Middle Button"
+msgstr "Srednji gumb"
+
+#: ../src/propgrid/advprops.cpp:1730
+msgctxt "system cursor name"
+msgid "No Entry"
+msgstr "Bez unosa"
+
+#: ../src/propgrid/advprops.cpp:1731
+msgctxt "system cursor name"
+msgid "Paint Brush"
+msgstr "Kist za bojenje"
+
+#: ../src/propgrid/advprops.cpp:1732
+msgctxt "system cursor name"
+msgid "Pencil"
+msgstr "Olovka"
+
+#: ../src/propgrid/advprops.cpp:1733
+msgctxt "system cursor name"
+msgid "Point Left"
+msgstr "Ukaži na lijevo"
+
+#: ../src/propgrid/advprops.cpp:1734
+msgctxt "system cursor name"
+msgid "Point Right"
+msgstr "Ukaži na desno"
+
+#: ../src/propgrid/advprops.cpp:1735
+msgctxt "system cursor name"
+msgid "Question Arrow"
+msgstr "Strelica-Upitnik"
+
+#: ../src/propgrid/advprops.cpp:1736
+msgctxt "system cursor name"
+msgid "Right Button"
+msgstr "Desni gumb"
+
+#: ../src/propgrid/advprops.cpp:1737
+msgctxt "system cursor name"
+msgid "Sizing NE-SW"
+msgstr "Skaliranje SI-JZ"
+
+#: ../src/propgrid/advprops.cpp:1738
+msgctxt "system cursor name"
+msgid "Sizing N-S"
+msgstr "Skaliranje S-J"
+
+#: ../src/propgrid/advprops.cpp:1739
+msgctxt "system cursor name"
+msgid "Sizing NW-SE"
+msgstr "Skaliranje SZ-JI"
+
+#: ../src/propgrid/advprops.cpp:1740
+msgctxt "system cursor name"
+msgid "Sizing W-E"
+msgstr "Skaliranje Z-I"
+
+#: ../src/propgrid/advprops.cpp:1741
+msgctxt "system cursor name"
+msgid "Sizing"
+msgstr "Skaliranje"
+
+#: ../src/propgrid/advprops.cpp:1742
+msgctxt "system cursor name"
+msgid "Spraycan"
+msgstr "Sprej-limenka"
+
+#: ../src/propgrid/advprops.cpp:1743
+msgctxt "system cursor name"
+msgid "Wait"
+msgstr "Čekaj"
+
+#: ../src/propgrid/advprops.cpp:1744
+msgctxt "system cursor name"
+msgid "Watch"
+msgstr "Sat"
+
+#: ../src/propgrid/advprops.cpp:1745
+msgctxt "system cursor name"
+msgid "Wait Arrow"
+msgstr "Strelica-Čekaj"
+
+#: ../src/propgrid/advprops.cpp:2109
+msgid "Make a selection:"
+msgstr "Stvori odabir:"
+
+#: ../src/propgrid/manager.cpp:394
+msgid "Property"
+msgstr "Svojstvo"
+
+#: ../src/propgrid/manager.cpp:395
+msgid "Value"
+msgstr "Vrijednost"
+
+#: ../src/propgrid/manager.cpp:1683
+msgid "Categorized Mode"
+msgstr "Modus kategorizacije"
+
+#: ../src/propgrid/manager.cpp:1709
+msgid "Alphabetic Mode"
+msgstr "Slovni modus"
+
+#. TRANSLATORS: Name of Boolean false value
+#: ../src/propgrid/propgrid.cpp:230
+msgid "False"
+msgstr "Netočno"
+
+#. TRANSLATORS: Name of Boolean true value
+#: ../src/propgrid/propgrid.cpp:232
+msgid "True"
+msgstr "Točno"
+
+#. TRANSLATORS: Text  displayed for unspecified value
+#: ../src/propgrid/propgrid.cpp:428
+msgid "Unspecified"
+msgstr "Neodređeno"
+
+#. TRANSLATORS: Caption of message box displaying any property error
+#: ../src/propgrid/propgrid.cpp:3145 ../src/propgrid/propgrid.cpp:3282
+msgid "Property Error"
+msgstr "Greška svojstva"
+
+#: ../src/propgrid/propgrid.cpp:3259
+msgid "You have entered invalid value. Press ESC to cancel editing."
+msgstr ""
+"Uneseni su nevaljane vrijednosti. Pritisni ESC za odustajanje od uređivanja."
+
+#: ../src/propgrid/propgrid.cpp:6608
+#, c-format
+msgid "Error in resource: %s"
+msgstr "Greška u resursu: %s"
+
+#: ../src/propgrid/propgridiface.cpp:377
+#, c-format
+msgid ""
+"Type operation \"%s\" failed: Property labeled \"%s\" is of type \"%s\", NOT "
+"\"%s\"."
+msgstr ""
+"Operacija vrste „%s” nije uspjela: Svojstvo s oznakom „%s” je vrste „%s”, NE "
+"„%s”."
+
+#: ../src/propgrid/props.cpp:159
+#, c-format
+msgid "Unknown base %d. Base 10 will be used."
+msgstr "Nepoznata osnova %d. Koristit će se osnova 10."
+
+#: ../src/propgrid/props.cpp:324
+#, c-format
+msgid "Value must be %s or higher."
+msgstr "Vrijednost mora biti %s ili veće."
+
+#: ../src/propgrid/props.cpp:329 ../src/propgrid/props.cpp:356
+#, c-format
+msgid "Value must be between %s and %s."
+msgstr "Vrijednost mora biti između %s i %s."
+
+#: ../src/propgrid/props.cpp:351
+#, c-format
+msgid "Value must be %s or less."
+msgstr "Vrijednost mora biti %s ili manje."
+
+#: ../src/propgrid/props.cpp:1058
+#, c-format
+msgid "Not %s"
+msgstr "Nije %s"
+
+#: ../src/propgrid/props.cpp:1770
+msgid "Choose a directory:"
+msgstr "Odaberi mapu:"
+
+#: ../src/propgrid/props.cpp:2055
+msgid "Choose a file"
+msgstr "Odaberi datoteku"
+
+#: ../src/qt/mdi.cpp:254
+msgid "&Tile"
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:147
+#: ../src/richtext/richtextformatdlg.cpp:376
+msgid "Background"
+msgstr "Pozadina"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:159
+msgid "Background &colour:"
+msgstr "&Boja pozadine:"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:161
+#: ../src/richtext/richtextbackgroundpage.cpp:163
+msgid "Enables a background colour."
+msgstr "Aktivira pozadinsku boju."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:167
+#: ../src/richtext/richtextbackgroundpage.cpp:169
+msgid "The background colour."
+msgstr "Boja pozadine."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:178
+msgid "Shadow"
+msgstr "Sjena"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:193
+msgid "Use &shadow"
+msgstr "Koristi &sjenu"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:195
+#: ../src/richtext/richtextbackgroundpage.cpp:197
+msgid "Enables a shadow."
+msgstr "Aktivira sjenu."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:211
+msgid "&Horizontal offset:"
+msgstr "&Vodoravni odmak:"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:218
+#: ../src/richtext/richtextbackgroundpage.cpp:220
+msgid "The horizontal offset."
+msgstr "Vodoravni odmak."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:224
+#: ../src/richtext/richtextbackgroundpage.cpp:227
+#: ../src/richtext/richtextbackgroundpage.cpp:228
+#: ../src/richtext/richtextbackgroundpage.cpp:247
+#: ../src/richtext/richtextbackgroundpage.cpp:250
+#: ../src/richtext/richtextbackgroundpage.cpp:251
+#: ../src/richtext/richtextbackgroundpage.cpp:287
+#: ../src/richtext/richtextbackgroundpage.cpp:290
+#: ../src/richtext/richtextbackgroundpage.cpp:291
+#: ../src/richtext/richtextbackgroundpage.cpp:314
+#: ../src/richtext/richtextbackgroundpage.cpp:317
+#: ../src/richtext/richtextbackgroundpage.cpp:318
+#: ../src/richtext/richtextborderspage.cpp:252
+#: ../src/richtext/richtextborderspage.cpp:255
+#: ../src/richtext/richtextborderspage.cpp:256
+#: ../src/richtext/richtextborderspage.cpp:286
+#: ../src/richtext/richtextborderspage.cpp:289
+#: ../src/richtext/richtextborderspage.cpp:290
+#: ../src/richtext/richtextborderspage.cpp:320
+#: ../src/richtext/richtextborderspage.cpp:323
+#: ../src/richtext/richtextborderspage.cpp:324
+#: ../src/richtext/richtextborderspage.cpp:354
+#: ../src/richtext/richtextborderspage.cpp:357
+#: ../src/richtext/richtextborderspage.cpp:358
+#: ../src/richtext/richtextborderspage.cpp:420
+#: ../src/richtext/richtextborderspage.cpp:423
+#: ../src/richtext/richtextborderspage.cpp:424
+#: ../src/richtext/richtextborderspage.cpp:454
+#: ../src/richtext/richtextborderspage.cpp:457
+#: ../src/richtext/richtextborderspage.cpp:458
+#: ../src/richtext/richtextborderspage.cpp:488
+#: ../src/richtext/richtextborderspage.cpp:491
+#: ../src/richtext/richtextborderspage.cpp:492
+#: ../src/richtext/richtextborderspage.cpp:522
+#: ../src/richtext/richtextborderspage.cpp:525
+#: ../src/richtext/richtextborderspage.cpp:526
+#: ../src/richtext/richtextborderspage.cpp:590
+#: ../src/richtext/richtextborderspage.cpp:593
+#: ../src/richtext/richtextborderspage.cpp:594
+#: ../src/richtext/richtextfontpage.cpp:177
+#: ../src/richtext/richtextmarginspage.cpp:199
+#: ../src/richtext/richtextmarginspage.cpp:201
+#: ../src/richtext/richtextmarginspage.cpp:202
+#: ../src/richtext/richtextmarginspage.cpp:224
+#: ../src/richtext/richtextmarginspage.cpp:226
+#: ../src/richtext/richtextmarginspage.cpp:227
+#: ../src/richtext/richtextmarginspage.cpp:247
+#: ../src/richtext/richtextmarginspage.cpp:249
+#: ../src/richtext/richtextmarginspage.cpp:250
+#: ../src/richtext/richtextmarginspage.cpp:272
+#: ../src/richtext/richtextmarginspage.cpp:274
+#: ../src/richtext/richtextmarginspage.cpp:275
+#: ../src/richtext/richtextmarginspage.cpp:313
+#: ../src/richtext/richtextmarginspage.cpp:315
+#: ../src/richtext/richtextmarginspage.cpp:316
+#: ../src/richtext/richtextmarginspage.cpp:338
+#: ../src/richtext/richtextmarginspage.cpp:340
+#: ../src/richtext/richtextmarginspage.cpp:341
+#: ../src/richtext/richtextmarginspage.cpp:361
+#: ../src/richtext/richtextmarginspage.cpp:363
+#: ../src/richtext/richtextmarginspage.cpp:364
+#: ../src/richtext/richtextmarginspage.cpp:386
+#: ../src/richtext/richtextmarginspage.cpp:388
+#: ../src/richtext/richtextmarginspage.cpp:389
+#: ../src/richtext/richtextsizepage.cpp:337
+#: ../src/richtext/richtextsizepage.cpp:340
+#: ../src/richtext/richtextsizepage.cpp:341
+#: ../src/richtext/richtextsizepage.cpp:371
+#: ../src/richtext/richtextsizepage.cpp:374
+#: ../src/richtext/richtextsizepage.cpp:375
+#: ../src/richtext/richtextsizepage.cpp:398
+#: ../src/richtext/richtextsizepage.cpp:401
+#: ../src/richtext/richtextsizepage.cpp:402
+#: ../src/richtext/richtextsizepage.cpp:425
+#: ../src/richtext/richtextsizepage.cpp:428
+#: ../src/richtext/richtextsizepage.cpp:429
+#: ../src/richtext/richtextsizepage.cpp:452
+#: ../src/richtext/richtextsizepage.cpp:455
+#: ../src/richtext/richtextsizepage.cpp:456
+#: ../src/richtext/richtextsizepage.cpp:479
+#: ../src/richtext/richtextsizepage.cpp:482
+#: ../src/richtext/richtextsizepage.cpp:483
+#: ../src/richtext/richtextsizepage.cpp:553
+#: ../src/richtext/richtextsizepage.cpp:556
+#: ../src/richtext/richtextsizepage.cpp:557
+#: ../src/richtext/richtextsizepage.cpp:588
+#: ../src/richtext/richtextsizepage.cpp:591
+#: ../src/richtext/richtextsizepage.cpp:592
+#: ../src/richtext/richtextsizepage.cpp:623
+#: ../src/richtext/richtextsizepage.cpp:626
+#: ../src/richtext/richtextsizepage.cpp:627
+#: ../src/richtext/richtextsizepage.cpp:658
+#: ../src/richtext/richtextsizepage.cpp:661
+#: ../src/richtext/richtextsizepage.cpp:662
+msgid "px"
+msgstr "px"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:225
+#: ../src/richtext/richtextbackgroundpage.cpp:248
+#: ../src/richtext/richtextbackgroundpage.cpp:288
+#: ../src/richtext/richtextbackgroundpage.cpp:315
+#: ../src/richtext/richtextborderspage.cpp:253
+#: ../src/richtext/richtextborderspage.cpp:287
+#: ../src/richtext/richtextborderspage.cpp:321
+#: ../src/richtext/richtextborderspage.cpp:355
+#: ../src/richtext/richtextborderspage.cpp:421
+#: ../src/richtext/richtextborderspage.cpp:455
+#: ../src/richtext/richtextborderspage.cpp:489
+#: ../src/richtext/richtextborderspage.cpp:523
+#: ../src/richtext/richtextborderspage.cpp:591
+#: ../src/richtext/richtextmarginspage.cpp:200
+#: ../src/richtext/richtextmarginspage.cpp:225
+#: ../src/richtext/richtextmarginspage.cpp:248
+#: ../src/richtext/richtextmarginspage.cpp:273
+#: ../src/richtext/richtextmarginspage.cpp:314
+#: ../src/richtext/richtextmarginspage.cpp:339
+#: ../src/richtext/richtextmarginspage.cpp:362
+#: ../src/richtext/richtextmarginspage.cpp:387
+#: ../src/richtext/richtextsizepage.cpp:338
+#: ../src/richtext/richtextsizepage.cpp:372
+#: ../src/richtext/richtextsizepage.cpp:399
+#: ../src/richtext/richtextsizepage.cpp:426
+#: ../src/richtext/richtextsizepage.cpp:453
+#: ../src/richtext/richtextsizepage.cpp:480
+#: ../src/richtext/richtextsizepage.cpp:554
+#: ../src/richtext/richtextsizepage.cpp:589
+#: ../src/richtext/richtextsizepage.cpp:624
+#: ../src/richtext/richtextsizepage.cpp:659
+msgid "cm"
+msgstr "cm"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:226
+#: ../src/richtext/richtextbackgroundpage.cpp:249
+#: ../src/richtext/richtextbackgroundpage.cpp:289
+#: ../src/richtext/richtextbackgroundpage.cpp:316
+#: ../src/richtext/richtextborderspage.cpp:254
+#: ../src/richtext/richtextborderspage.cpp:288
+#: ../src/richtext/richtextborderspage.cpp:322
+#: ../src/richtext/richtextborderspage.cpp:356
+#: ../src/richtext/richtextborderspage.cpp:422
+#: ../src/richtext/richtextborderspage.cpp:456
+#: ../src/richtext/richtextborderspage.cpp:490
+#: ../src/richtext/richtextborderspage.cpp:524
+#: ../src/richtext/richtextborderspage.cpp:592
+#: ../src/richtext/richtextfontpage.cpp:176
+#: ../src/richtext/richtextfontpage.cpp:179
+msgid "pt"
+msgstr "pt"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:229
+#: ../src/richtext/richtextbackgroundpage.cpp:231
+#: ../src/richtext/richtextbackgroundpage.cpp:252
+#: ../src/richtext/richtextbackgroundpage.cpp:254
+#: ../src/richtext/richtextbackgroundpage.cpp:292
+#: ../src/richtext/richtextbackgroundpage.cpp:294
+#: ../src/richtext/richtextbackgroundpage.cpp:319
+#: ../src/richtext/richtextbackgroundpage.cpp:321
+msgid "Units for this value."
+msgstr "Jedinice za ovu vrijednost."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:234
+msgid "&Vertical offset:"
+msgstr "&Uspravni odmak:"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:241
+#: ../src/richtext/richtextbackgroundpage.cpp:243
+msgid "The vertical offset."
+msgstr "Uspravni odmak."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:257
+msgid "Shadow c&olour:"
+msgstr "&Boja sjene:"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:259
+#: ../src/richtext/richtextbackgroundpage.cpp:261
+msgid "Enables the shadow colour."
+msgstr "Aktivira boju sjene."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:265
+#: ../src/richtext/richtextbackgroundpage.cpp:267
+msgid "The shadow colour."
+msgstr "Boja sjene."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:270
+msgid "Sh&adow spread:"
+msgstr "Rasprostranjenost &sjene:"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:272
+#: ../src/richtext/richtextbackgroundpage.cpp:274
+msgid "Enables the shadow spread."
+msgstr "Aktivira rasprostiranje sjene."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:281
+#: ../src/richtext/richtextbackgroundpage.cpp:283
+msgid "The shadow spread."
+msgstr "Rasprostranjenost sjene."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:297
+msgid "&Blur distance:"
+msgstr "&Udaljenost mutnoće:"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:299
+#: ../src/richtext/richtextbackgroundpage.cpp:301
+msgid "Enables the blur distance."
+msgstr "Aktivira udaljenost mutnoće."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:308
+#: ../src/richtext/richtextbackgroundpage.cpp:310
+msgid "The shadow blur distance."
+msgstr "Udaljenost mutnoće sjene."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:324
+msgid "Opaci&ty:"
+msgstr "Neprozirnos&t:"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:326
+#: ../src/richtext/richtextbackgroundpage.cpp:328
+msgid "Enables the shadow opacity."
+msgstr "Aktivira neprozirnost sjene."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:335
+#: ../src/richtext/richtextbackgroundpage.cpp:337
+msgid "The shadow opacity."
+msgstr "Neprozirnost sjene."
+
+#. TRANSLATORS: Rich text page units (percentage)
+#: ../src/richtext/richtextbackgroundpage.cpp:340
+#: ../src/richtext/richtextsizepage.cpp:339
+#: ../src/richtext/richtextsizepage.cpp:373
+#: ../src/richtext/richtextsizepage.cpp:400
+#: ../src/richtext/richtextsizepage.cpp:427
+#: ../src/richtext/richtextsizepage.cpp:454
+#: ../src/richtext/richtextsizepage.cpp:481
+#: ../src/richtext/richtextsizepage.cpp:555
+#: ../src/richtext/richtextsizepage.cpp:590
+#: ../src/richtext/richtextsizepage.cpp:625
+#: ../src/richtext/richtextsizepage.cpp:660
+msgid "%"
+msgstr "%"
+
+#: ../src/richtext/richtextborderspage.cpp:229
+#: ../src/richtext/richtextborderspage.cpp:387
+msgid "Border"
+msgstr "Rub"
+
+#: ../src/richtext/richtextborderspage.cpp:242
+#: ../src/richtext/richtextborderspage.cpp:410
+#: ../src/richtext/richtextindentspage.cpp:194
+#: ../src/richtext/richtextliststylepage.cpp:384
+#: ../src/richtext/richtextmarginspage.cpp:185
+#: ../src/richtext/richtextmarginspage.cpp:299
+#: ../src/richtext/richtextsizepage.cpp:531
+#: ../src/richtext/richtextsizepage.cpp:538
+msgid "&Left:"
+msgstr "&Lijevo:"
+
+#: ../src/richtext/richtextborderspage.cpp:257
+#: ../src/richtext/richtextborderspage.cpp:259
+msgid "Units for the left border width."
+msgstr "Jedinice za debljinu lijevog ruba."
+
+#: ../src/richtext/richtextborderspage.cpp:266
+#: ../src/richtext/richtextborderspage.cpp:268
+#: ../src/richtext/richtextborderspage.cpp:300
+#: ../src/richtext/richtextborderspage.cpp:302
+#: ../src/richtext/richtextborderspage.cpp:334
+#: ../src/richtext/richtextborderspage.cpp:336
+#: ../src/richtext/richtextborderspage.cpp:368
+#: ../src/richtext/richtextborderspage.cpp:370
+#: ../src/richtext/richtextborderspage.cpp:434
+#: ../src/richtext/richtextborderspage.cpp:436
+#: ../src/richtext/richtextborderspage.cpp:468
+#: ../src/richtext/richtextborderspage.cpp:470
+#: ../src/richtext/richtextborderspage.cpp:502
+#: ../src/richtext/richtextborderspage.cpp:504
+#: ../src/richtext/richtextborderspage.cpp:536
+#: ../src/richtext/richtextborderspage.cpp:538
+msgid "The border line style."
+msgstr "Stil rubne linije."
+
+#: ../src/richtext/richtextborderspage.cpp:276
+#: ../src/richtext/richtextborderspage.cpp:444
+#: ../src/richtext/richtextindentspage.cpp:212
+#: ../src/richtext/richtextliststylepage.cpp:402
+#: ../src/richtext/richtextmarginspage.cpp:210
+#: ../src/richtext/richtextmarginspage.cpp:324
+#: ../src/richtext/richtextsizepage.cpp:601
+#: ../src/richtext/richtextsizepage.cpp:608
+msgid "&Right:"
+msgstr "&Desno:"
+
+#: ../src/richtext/richtextborderspage.cpp:291
+#: ../src/richtext/richtextborderspage.cpp:293
+msgid "Units for the right border width."
+msgstr "Jedinice za debljinu desnog ruba."
+
+#: ../src/richtext/richtextborderspage.cpp:310
+#: ../src/richtext/richtextborderspage.cpp:478
+#: ../src/richtext/richtextmarginspage.cpp:233
+#: ../src/richtext/richtextmarginspage.cpp:347
+#: ../src/richtext/richtextsizepage.cpp:566
+#: ../src/richtext/richtextsizepage.cpp:573
+msgid "&Top:"
+msgstr "&Gore:"
+
+#: ../src/richtext/richtextborderspage.cpp:325
+#: ../src/richtext/richtextborderspage.cpp:327
+msgid "Units for the top border width."
+msgstr "Jedinice za debljinu gornjeg ruba."
+
+#: ../src/richtext/richtextborderspage.cpp:344
+#: ../src/richtext/richtextborderspage.cpp:512
+#: ../src/richtext/richtextmarginspage.cpp:258
+#: ../src/richtext/richtextmarginspage.cpp:372
+#: ../src/richtext/richtextsizepage.cpp:636
+#: ../src/richtext/richtextsizepage.cpp:643
+msgid "&Bottom:"
+msgstr "&Dolje:"
+
+#: ../src/richtext/richtextborderspage.cpp:359
+#: ../src/richtext/richtextborderspage.cpp:361
+msgid "Units for the bottom border width."
+msgstr "Jedinice za debljinu donjeg ruba."
+
+#: ../src/richtext/richtextborderspage.cpp:380
+#: ../src/richtext/richtextborderspage.cpp:548
+msgid "&Synchronize values"
+msgstr "&Sinkroniziraj vrijednosti"
+
+#: ../src/richtext/richtextborderspage.cpp:382
+#: ../src/richtext/richtextborderspage.cpp:384
+#: ../src/richtext/richtextborderspage.cpp:550
+#: ../src/richtext/richtextborderspage.cpp:552
+msgid "Check to edit all borders simultaneously."
+msgstr "Aktiviraj za istovremeno mijenjanje svih rubova."
+
+#: ../src/richtext/richtextborderspage.cpp:397
+#: ../src/richtext/richtextborderspage.cpp:555
+msgid "Outline"
+msgstr "Kontura"
+
+#: ../src/richtext/richtextborderspage.cpp:425
+#: ../src/richtext/richtextborderspage.cpp:427
+msgid "Units for the left outline width."
+msgstr "Jedinice za debljinu lijeve konture."
+
+#: ../src/richtext/richtextborderspage.cpp:459
+#: ../src/richtext/richtextborderspage.cpp:461
+msgid "Units for the right outline width."
+msgstr "Jedinice za debljinu desne konture."
+
+#: ../src/richtext/richtextborderspage.cpp:493
+#: ../src/richtext/richtextborderspage.cpp:495
+msgid "Units for the top outline width."
+msgstr "Jedinice za debljinu gornje konture."
+
+#: ../src/richtext/richtextborderspage.cpp:527
+#: ../src/richtext/richtextborderspage.cpp:529
+msgid "Units for the bottom outline width."
+msgstr "Jedinice za debljinu donjeg obrisa."
+
+#: ../src/richtext/richtextborderspage.cpp:565
+#: ../src/richtext/richtextborderspage.cpp:600
+msgid "Corner"
+msgstr "Kut"
+
+#: ../src/richtext/richtextborderspage.cpp:574
+msgid "Corner &radius:"
+msgstr "Polumjer kuta:"
+
+#: ../src/richtext/richtextborderspage.cpp:576
+#: ../src/richtext/richtextborderspage.cpp:578
+msgid "An optional corner radius for adding rounded corners."
+msgstr "Opcionalni polumjer kuta za dodavanje zaobljenih kutova."
+
+#: ../src/richtext/richtextborderspage.cpp:584
+#: ../src/richtext/richtextborderspage.cpp:586
+msgid "The value of the corner radius."
+msgstr "Vrijednost radijusa kutova."
+
+#: ../src/richtext/richtextborderspage.cpp:595
+#: ../src/richtext/richtextborderspage.cpp:597
+msgid "Units for the corner radius."
+msgstr "Jedinice za radijus kutova."
+
+#: ../src/richtext/richtextborderspage.cpp:609
+#: ../src/richtext/richtextsizepage.cpp:247
+#: ../src/richtext/richtextsizepage.cpp:251
+msgid "None"
+msgstr "Bez"
+
+#: ../src/richtext/richtextborderspage.cpp:610
+msgid "Solid"
+msgstr "Ispunjeno"
+
+#: ../src/richtext/richtextborderspage.cpp:611
+msgid "Dotted"
+msgstr "Točkasto"
+
+#: ../src/richtext/richtextborderspage.cpp:612
+msgid "Dashed"
+msgstr "Isprekidano"
+
+#: ../src/richtext/richtextborderspage.cpp:613
+msgid "Double"
+msgstr "Dvostruko"
+
+#: ../src/richtext/richtextborderspage.cpp:614
+msgid "Groove"
+msgstr "Groove"
+
+#: ../src/richtext/richtextborderspage.cpp:615
+msgid "Ridge"
+msgstr "Hrbat"
+
+#: ../src/richtext/richtextborderspage.cpp:616
+msgid "Inset"
+msgstr "Sužavanje"
+
+#: ../src/richtext/richtextborderspage.cpp:617
+msgid "Outset"
+msgstr "Širenje"
+
+#: ../src/richtext/richtextbuffer.cpp:3518
+msgid "Change Style"
+msgstr "Promijeni stil"
+
+#: ../src/richtext/richtextbuffer.cpp:3701
+msgid "Change Object Style"
+msgstr "Promijeni stil objekta"
+
+#: ../src/richtext/richtextbuffer.cpp:3974
+#: ../src/richtext/richtextbuffer.cpp:8174
+msgid "Change Properties"
+msgstr "Promijeni svojstva"
+
+#: ../src/richtext/richtextbuffer.cpp:4346
+msgid "Change List Style"
+msgstr "Promijeni stil popisa"
+
+#: ../src/richtext/richtextbuffer.cpp:4519
+msgid "Renumber List"
+msgstr "Ponovi numeriranje"
+
+#: ../src/richtext/richtextbuffer.cpp:7867
+#: ../src/richtext/richtextbuffer.cpp:7897
+#: ../src/richtext/richtextbuffer.cpp:7939
+#: ../src/richtext/richtextctrl.cpp:1279 ../src/richtext/richtextctrl.cpp:1473
+msgid "Insert Text"
+msgstr "Umetni tekst"
+
+#: ../src/richtext/richtextbuffer.cpp:8023
+#: ../src/richtext/richtextbuffer.cpp:8979
+msgid "Insert Image"
+msgstr "Umetni sliku"
+
+#: ../src/richtext/richtextbuffer.cpp:8070
+msgid "Insert Object"
+msgstr "Umetni objekt"
+
+#: ../src/richtext/richtextbuffer.cpp:8112
+msgid "Insert Field"
+msgstr "Umetni polje"
+
+#: ../src/richtext/richtextbuffer.cpp:8410
+msgid "Too many EndStyle calls!"
+msgstr "Previše EndStyle poziva!"
+
+#: ../src/richtext/richtextbuffer.cpp:8785
+msgid "files"
+msgstr "datoteke"
+
+#: ../src/richtext/richtextbuffer.cpp:9380
+msgid "standard/circle"
+msgstr "standardno/krug"
+
+#: ../src/richtext/richtextbuffer.cpp:9381
+msgid "standard/circle-outline"
+msgstr "standardno/krug-kontura"
+
+#: ../src/richtext/richtextbuffer.cpp:9382
+msgid "standard/square"
+msgstr "standardno/kvadrat"
+
+#: ../src/richtext/richtextbuffer.cpp:9383
+msgid "standard/diamond"
+msgstr "standardno/romb"
+
+#: ../src/richtext/richtextbuffer.cpp:9384
+msgid "standard/triangle"
+msgstr "standardno/trokut"
+
+#: ../src/richtext/richtextbuffer.cpp:9423
+msgid "Box Properties"
+msgstr "Svojstva okvira"
+
+#: ../src/richtext/richtextbuffer.cpp:10006
+msgid "Multiple Cell Properties"
+msgstr "Višestruka svojstva ćelije"
+
+#: ../src/richtext/richtextbuffer.cpp:10008
+msgid "Cell Properties"
+msgstr "Svojstva ćelije"
+
+#: ../src/richtext/richtextbuffer.cpp:11256
+msgid "Set Cell Style"
+msgstr "Postavi stil ćelija"
+
+#: ../src/richtext/richtextbuffer.cpp:11330
+msgid "Delete Row"
+msgstr "Izbriši red"
+
+#: ../src/richtext/richtextbuffer.cpp:11380
+msgid "Delete Column"
+msgstr "Izbriši stupac"
+
+#: ../src/richtext/richtextbuffer.cpp:11431
+msgid "Add Row"
+msgstr "Dodaj red"
+
+#: ../src/richtext/richtextbuffer.cpp:11494
+msgid "Add Column"
+msgstr "Dodaj stupac"
+
+#: ../src/richtext/richtextbuffer.cpp:11537
+msgid "Table Properties"
+msgstr "Svojstva tablice"
+
+#: ../src/richtext/richtextbuffer.cpp:12899
+msgid "Picture Properties"
+msgstr "Svojstva slike"
+
+#: ../src/richtext/richtextbuffer.cpp:13169
+#: ../src/richtext/richtextbuffer.cpp:13279
+msgid "image"
+msgstr "slika"
+
+#: ../src/richtext/richtextbulletspage.cpp:145
+#: ../src/richtext/richtextliststylepage.cpp:209
+msgid "&Bullet style:"
+msgstr "&Stil znaka nabrajanja:"
+
+#: ../src/richtext/richtextbulletspage.cpp:150
+#: ../src/richtext/richtextbulletspage.cpp:152
+#: ../src/richtext/richtextliststylepage.cpp:214
+#: ../src/richtext/richtextliststylepage.cpp:216
+msgid "The available bullet styles."
+msgstr "Dostupni stilovi znakova nabrajanja."
+
+#: ../src/richtext/richtextbulletspage.cpp:158
+#: ../src/richtext/richtextliststylepage.cpp:221
+msgid "Peri&od"
+msgstr "T&očka"
+
+#: ../src/richtext/richtextbulletspage.cpp:160
+#: ../src/richtext/richtextbulletspage.cpp:162
+#: ../src/richtext/richtextliststylepage.cpp:223
+#: ../src/richtext/richtextliststylepage.cpp:225
+msgid "Check to add a period after the bullet."
+msgstr "Aktiviraj za dodavanje točke nakon znaka za nabrajanje."
+
+#. TRANSLATORS: Bullet point in parentheses option
+#: ../src/richtext/richtextbulletspage.cpp:167
+#: ../src/richtext/richtextliststylepage.cpp:230
+msgid "(*)"
+msgstr "(*)"
+
+#: ../src/richtext/richtextbulletspage.cpp:169
+#: ../src/richtext/richtextbulletspage.cpp:171
+#: ../src/richtext/richtextliststylepage.cpp:232
+#: ../src/richtext/richtextliststylepage.cpp:234
+msgid "Check to enclose the bullet in parentheses."
+msgstr "Aktiviraj za postavljanje znaka za nabrajanje između zagrada."
+
+#. TRANSLATORS: Right parenthesis bullet point option
+#: ../src/richtext/richtextbulletspage.cpp:176
+#: ../src/richtext/richtextliststylepage.cpp:239
+msgid "*)"
+msgstr "*)"
+
+#: ../src/richtext/richtextbulletspage.cpp:178
+#: ../src/richtext/richtextbulletspage.cpp:180
+#: ../src/richtext/richtextliststylepage.cpp:241
+#: ../src/richtext/richtextliststylepage.cpp:243
+msgid "Check to add a right parenthesis."
+msgstr "Aktiviraj za dodavanje desne zagrade."
+
+#: ../src/richtext/richtextbulletspage.cpp:185
+#: ../src/richtext/richtextliststylepage.cpp:248
+msgid "Bullet &Alignment:"
+msgstr "Poravnanje znaka nabrajanja:"
+
+#: ../src/richtext/richtextbulletspage.cpp:190
+#: ../src/richtext/richtextliststylepage.cpp:253
+msgid "Centre"
+msgstr "Centriraj"
+
+#: ../src/richtext/richtextbulletspage.cpp:194
+#: ../src/richtext/richtextbulletspage.cpp:196
+#: ../src/richtext/richtextbulletspage.cpp:217
+#: ../src/richtext/richtextbulletspage.cpp:219
+#: ../src/richtext/richtextliststylepage.cpp:257
+#: ../src/richtext/richtextliststylepage.cpp:259
+#: ../src/richtext/richtextliststylepage.cpp:278
+#: ../src/richtext/richtextliststylepage.cpp:280
+msgid "The bullet character."
+msgstr "Znak nabrajanja."
+
+#: ../src/richtext/richtextbulletspage.cpp:212
+#: ../src/richtext/richtextliststylepage.cpp:271
+msgid "&Symbol:"
+msgstr "&Simbol:"
+
+#: ../src/richtext/richtextbulletspage.cpp:222
+#: ../src/richtext/richtextliststylepage.cpp:283
+msgid "Ch&oose..."
+msgstr "O&daberi …"
+
+#: ../src/richtext/richtextbulletspage.cpp:223
+#: ../src/richtext/richtextbulletspage.cpp:225
+#: ../src/richtext/richtextliststylepage.cpp:284
+#: ../src/richtext/richtextliststylepage.cpp:286
+msgid "Click to browse for a symbol."
+msgstr "Klikni za potragu za simbolom."
+
+#: ../src/richtext/richtextbulletspage.cpp:230
+#: ../src/richtext/richtextliststylepage.cpp:291
+msgid "Symbol &font:"
+msgstr "Simbol-&font:"
+
+#: ../src/richtext/richtextbulletspage.cpp:235
+#: ../src/richtext/richtextbulletspage.cpp:237
+#: ../src/richtext/richtextliststylepage.cpp:297
+msgid "Available fonts."
+msgstr "Dostupni fontovi."
+
+#: ../src/richtext/richtextbulletspage.cpp:242
+#: ../src/richtext/richtextliststylepage.cpp:302
+msgid "S&tandard bullet name:"
+msgstr "S&tandardno ime znaka nabrajanja:"
+
+#: ../src/richtext/richtextbulletspage.cpp:247
+#: ../src/richtext/richtextbulletspage.cpp:249
+#: ../src/richtext/richtextliststylepage.cpp:307
+#: ../src/richtext/richtextliststylepage.cpp:309
+msgid "A standard bullet name."
+msgstr "Standardno ime znaka nabrajanja."
+
+#: ../src/richtext/richtextbulletspage.cpp:254
+msgid "&Number:"
+msgstr "&Broj:"
+
+#: ../src/richtext/richtextbulletspage.cpp:258
+#: ../src/richtext/richtextbulletspage.cpp:260
+msgid "The list item number."
+msgstr "Broj stavke u popisu."
+
+#: ../src/richtext/richtextbulletspage.cpp:266
+#: ../src/richtext/richtextbulletspage.cpp:268
+#: ../src/richtext/richtextliststylepage.cpp:475
+#: ../src/richtext/richtextliststylepage.cpp:477
+msgid "Shows a preview of the bullet settings."
+msgstr "Prikazuje pregled postavaka znakova nabrajanja."
+
+#: ../src/richtext/richtextbulletspage.cpp:276
+#: ../src/richtext/richtextliststylepage.cpp:484
+msgid "(None)"
+msgstr "(Bez)"
+
+#: ../src/richtext/richtextbulletspage.cpp:277
+#: ../src/richtext/richtextliststylepage.cpp:485
+msgid "Arabic"
+msgstr "Arapski"
+
+#: ../src/richtext/richtextbulletspage.cpp:278
+#: ../src/richtext/richtextliststylepage.cpp:486
+msgid "Upper case letters"
+msgstr "Velika slova"
+
+#: ../src/richtext/richtextbulletspage.cpp:279
+#: ../src/richtext/richtextliststylepage.cpp:487
+msgid "Lower case letters"
+msgstr "Mala slova"
+
+#: ../src/richtext/richtextbulletspage.cpp:280
+#: ../src/richtext/richtextliststylepage.cpp:488
+msgid "Upper case roman numerals"
+msgstr "Veliki rimski brojevi"
+
+#: ../src/richtext/richtextbulletspage.cpp:281
+#: ../src/richtext/richtextliststylepage.cpp:489
+msgid "Lower case roman numerals"
+msgstr "Mali rimski brojevi"
+
+#: ../src/richtext/richtextbulletspage.cpp:282
+#: ../src/richtext/richtextliststylepage.cpp:490
+msgid "Numbered outline"
+msgstr "Numerirani sadržaj"
+
+#: ../src/richtext/richtextbulletspage.cpp:283
+#: ../src/richtext/richtextliststylepage.cpp:491
+msgid "Symbol"
+msgstr "Simbol"
+
+#: ../src/richtext/richtextbulletspage.cpp:284
+#: ../src/richtext/richtextliststylepage.cpp:492
+msgid "Bitmap"
+msgstr "Bitmap"
+
+#: ../src/richtext/richtextbulletspage.cpp:285
+#: ../src/richtext/richtextliststylepage.cpp:493
+msgid "Standard"
+msgstr "Standardno"
+
+#: ../src/richtext/richtextbulletspage.cpp:287
+#: ../src/richtext/richtextliststylepage.cpp:495
+msgid "*"
+msgstr "*"
+
+#: ../src/richtext/richtextbulletspage.cpp:288
+#: ../src/richtext/richtextliststylepage.cpp:496
+msgid "-"
+msgstr "-"
+
+#: ../src/richtext/richtextbulletspage.cpp:289
+#: ../src/richtext/richtextliststylepage.cpp:497
+msgid ">"
+msgstr ">"
+
+#: ../src/richtext/richtextbulletspage.cpp:290
+#: ../src/richtext/richtextliststylepage.cpp:498
+msgid "+"
+msgstr "+"
+
+#: ../src/richtext/richtextbulletspage.cpp:291
+#: ../src/richtext/richtextliststylepage.cpp:499
+msgid "~"
+msgstr "~"
+
+#: ../src/richtext/richtextctrl.cpp:859
+msgid "Drag"
+msgstr "Povuci"
+
+#: ../src/richtext/richtextctrl.cpp:1338 ../src/richtext/richtextctrl.cpp:1559
+msgid "Delete Text"
+msgstr "Izbriši tekst"
+
+#: ../src/richtext/richtextctrl.cpp:1537
+msgid "Remove Bullet"
+msgstr "Ukloni znak nabrajanja"
+
+#: ../src/richtext/richtextctrl.cpp:3070
+msgid "The text couldn't be saved."
+msgstr "Nije bilo moguće spremiti tekst."
+
+#: ../src/richtext/richtextctrl.cpp:3644
+msgid "Replace"
+msgstr "Zamijeni"
+
+#: ../src/richtext/richtextfontpage.cpp:146
+#: ../src/richtext/richtextsymboldlg.cpp:384
+msgid "&Font:"
+msgstr "&Font:"
+
+#: ../src/richtext/richtextfontpage.cpp:150
+#: ../src/richtext/richtextfontpage.cpp:152
+msgid "Type a font name."
+msgstr "Upiši ime fonta."
+
+#: ../src/richtext/richtextfontpage.cpp:158
+msgid "&Size:"
+msgstr "&Veličina:"
+
+#: ../src/richtext/richtextfontpage.cpp:165
+#: ../src/richtext/richtextfontpage.cpp:167
+msgid "Type a size in points."
+msgstr "Upiši veličinu u točkama."
+
+#: ../src/richtext/richtextfontpage.cpp:180
+#: ../src/richtext/richtextfontpage.cpp:182
+msgid "The font size units, points or pixels."
+msgstr "Jedinice veličine fonta, u točkama ili pikselima."
+
+#: ../src/richtext/richtextfontpage.cpp:189
+#: ../src/richtext/richtextfontpage.cpp:191
+msgid "Lists the available fonts."
+msgstr "Popisuje dostupne fontove."
+
+#: ../src/richtext/richtextfontpage.cpp:196
+#: ../src/richtext/richtextfontpage.cpp:198
+msgid "Lists font sizes in points."
+msgstr "Popisuje veličine fonta u tiplografskim točkama."
+
+#: ../src/richtext/richtextfontpage.cpp:207
+msgid "Font st&yle:"
+msgstr "St&il fonta:"
+
+#: ../src/richtext/richtextfontpage.cpp:212
+#: ../src/richtext/richtextfontpage.cpp:214
+msgid "Select regular or italic style."
+msgstr "Odaberi regularni ili kurzivni stil."
+
+#: ../src/richtext/richtextfontpage.cpp:220
+msgid "Font &weight:"
+msgstr "&Debljina fonta:"
+
+#: ../src/richtext/richtextfontpage.cpp:225
+#: ../src/richtext/richtextfontpage.cpp:227
+msgid "Select regular or bold."
+msgstr "Odaberi regularni ili debeli."
+
+#: ../src/richtext/richtextfontpage.cpp:233
+msgid "&Underlining:"
+msgstr "&Podcrtavanje:"
+
+#: ../src/richtext/richtextfontpage.cpp:238
+#: ../src/richtext/richtextfontpage.cpp:240
+msgid "Select underlining or no underlining."
+msgstr "Odaberi podcrtavanje ili ne-podcrtavanje."
+
+#: ../src/richtext/richtextfontpage.cpp:248
+msgid "&Colour:"
+msgstr "&Boja:"
+
+#: ../src/richtext/richtextfontpage.cpp:253
+#: ../src/richtext/richtextfontpage.cpp:255
+msgid "Click to change the text colour."
+msgstr "Klikni za promjenu boje teksta."
+
+#: ../src/richtext/richtextfontpage.cpp:261
+msgid "&Bg colour:"
+msgstr "&Boja pozadine:"
+
+#: ../src/richtext/richtextfontpage.cpp:266
+#: ../src/richtext/richtextfontpage.cpp:268
+msgid "Click to change the text background colour."
+msgstr "Klikni za promjenu boje pozadine teksta."
+
+#: ../src/richtext/richtextfontpage.cpp:276
+#: ../src/richtext/richtextfontpage.cpp:278
+msgid "Check to show a line through the text."
+msgstr "Aktiviraj za prikaz crte preko teksta."
+
+#: ../src/richtext/richtextfontpage.cpp:281
+msgid "Ca&pitals"
+msgstr "Velika s&lova"
+
+#: ../src/richtext/richtextfontpage.cpp:283
+#: ../src/richtext/richtextfontpage.cpp:285
+msgid "Check to show the text in capitals."
+msgstr "Aktiviraj za prikaz teksta verzalnim slovima."
+
+#: ../src/richtext/richtextfontpage.cpp:288
+msgid "Small C&apitals"
+msgstr "Kapitalke"
+
+#: ../src/richtext/richtextfontpage.cpp:290
+#: ../src/richtext/richtextfontpage.cpp:292
+msgid "Check to show the text in small capitals."
+msgstr "Aktiviraj za prikaz teksta kapitalkama."
+
+#: ../src/richtext/richtextfontpage.cpp:295
+msgid "Supe&rscript"
+msgstr "Na&dignuto"
+
+#: ../src/richtext/richtextfontpage.cpp:297
+#: ../src/richtext/richtextfontpage.cpp:299
+msgid "Check to show the text in superscript."
+msgstr "Aktiviraj za prikaz teksta spušteno."
+
+#: ../src/richtext/richtextfontpage.cpp:302
+msgid "Subscrip&t"
+msgstr "Spuš&teno"
+
+#: ../src/richtext/richtextfontpage.cpp:304
+#: ../src/richtext/richtextfontpage.cpp:306
+msgid "Check to show the text in subscript."
+msgstr "Aktiviraj za prikaz teksta nadignuto."
+
+#: ../src/richtext/richtextfontpage.cpp:312
+msgid "Rig&ht-to-left"
+msgstr "Desn&o na lijevo"
+
+#: ../src/richtext/richtextfontpage.cpp:314
+#: ../src/richtext/richtextfontpage.cpp:316
+msgid "Check to indicate right-to-left text layout."
+msgstr "Aktiviraj za određivanje smjera teksta s desna nalijevo."
+
+#: ../src/richtext/richtextfontpage.cpp:319
+msgid "Suppress hyphe&nation"
+msgstr "Izostavi rastavljanje riječi"
+
+#: ../src/richtext/richtextfontpage.cpp:321
+#: ../src/richtext/richtextfontpage.cpp:323
+msgid "Check to suppress hyphenation."
+msgstr "Aktiviraj za izostavljanje rastavljanja riječi."
+
+#: ../src/richtext/richtextfontpage.cpp:329
+#: ../src/richtext/richtextfontpage.cpp:331
+msgid "Shows a preview of the font settings."
+msgstr "Prikazuje pregled font postavaka."
+
+#: ../src/richtext/richtextfontpage.cpp:348
+#: ../src/richtext/richtextfontpage.cpp:352
+#: ../src/richtext/richtextfontpage.cpp:356
+#: ../src/richtext/richtextformatdlg.cpp:873
+#: ../src/richtext/richtextindentspage.cpp:273
+#: ../src/richtext/richtextindentspage.cpp:285
+#: ../src/richtext/richtextindentspage.cpp:286
+#: ../src/richtext/richtextindentspage.cpp:310
+#: ../src/richtext/richtextindentspage.cpp:325
+#: ../src/richtext/richtextliststylepage.cpp:451
+#: ../src/richtext/richtextliststylepage.cpp:463
+#: ../src/richtext/richtextliststylepage.cpp:464
+msgid "(none)"
+msgstr "(bez)"
+
+#: ../src/richtext/richtextfontpage.cpp:349
+#: ../src/richtext/richtextfontpage.cpp:353
+msgid "Regular"
+msgstr "Regular"
+
+#: ../src/richtext/richtextfontpage.cpp:357
+msgid "Not underlined"
+msgstr "Nije podcrtano"
+
+#: ../src/richtext/richtextformatdlg.cpp:341
+msgid "Indents && Spacing"
+msgstr "Uvlake &i razmaci"
+
+#: ../src/richtext/richtextformatdlg.cpp:346
+msgid "Tabs"
+msgstr "Tabulatori"
+
+#: ../src/richtext/richtextformatdlg.cpp:351
+msgid "Bullets"
+msgstr "Znakovi nabrajanja"
+
+#: ../src/richtext/richtextformatdlg.cpp:356
+msgid "List Style"
+msgstr "Stil popisa"
+
+#: ../src/richtext/richtextformatdlg.cpp:366
+#: ../src/richtext/richtextmarginspage.cpp:170
+msgid "Margins"
+msgstr "Margine"
+
+#: ../src/richtext/richtextformatdlg.cpp:371
+msgid "Borders"
+msgstr "Obrubi"
+
+#: ../src/richtext/richtextformatdlg.cpp:765
+msgid "Colour"
+msgstr "Boja"
+
+#: ../src/richtext/richtextindentspage.cpp:127
+#: ../src/richtext/richtextliststylepage.cpp:322
+msgid "&Alignment"
+msgstr "&Poravnanje"
+
+#: ../src/richtext/richtextindentspage.cpp:138
+#: ../src/richtext/richtextliststylepage.cpp:331
+msgid "&Left"
+msgstr "&Lijevo"
+
+#: ../src/richtext/richtextindentspage.cpp:140
+#: ../src/richtext/richtextindentspage.cpp:142
+#: ../src/richtext/richtextliststylepage.cpp:333
+#: ../src/richtext/richtextliststylepage.cpp:335
+msgid "Left-align text."
+msgstr "Poravnaj tekst u lijevo."
+
+#: ../src/richtext/richtextindentspage.cpp:145
+#: ../src/richtext/richtextliststylepage.cpp:338
+msgid "&Right"
+msgstr "&Desno"
+
+#: ../src/richtext/richtextindentspage.cpp:147
+#: ../src/richtext/richtextindentspage.cpp:149
+#: ../src/richtext/richtextliststylepage.cpp:340
+#: ../src/richtext/richtextliststylepage.cpp:342
+msgid "Right-align text."
+msgstr "Poravnaj tekst u desno."
+
+#: ../src/richtext/richtextindentspage.cpp:152
+#: ../src/richtext/richtextliststylepage.cpp:345
+msgid "&Justified"
+msgstr "&Puni format"
+
+#: ../src/richtext/richtextindentspage.cpp:154
+#: ../src/richtext/richtextindentspage.cpp:156
+#: ../src/richtext/richtextliststylepage.cpp:347
+#: ../src/richtext/richtextliststylepage.cpp:349
+msgid "Justify text left and right."
+msgstr "Poravnaj tekst lijevo i desno."
+
+#: ../src/richtext/richtextindentspage.cpp:159
+#: ../src/richtext/richtextliststylepage.cpp:352
+msgid "Cen&tred"
+msgstr "Cen&trirano"
+
+#: ../src/richtext/richtextindentspage.cpp:161
+#: ../src/richtext/richtextindentspage.cpp:163
+#: ../src/richtext/richtextliststylepage.cpp:354
+#: ../src/richtext/richtextliststylepage.cpp:356
+msgid "Centre text."
+msgstr "Centriraj tekst."
+
+#: ../src/richtext/richtextindentspage.cpp:166
+#: ../src/richtext/richtextliststylepage.cpp:359
+msgid "&Indeterminate"
+msgstr "&Neodredi"
+
+#: ../src/richtext/richtextindentspage.cpp:168
+#: ../src/richtext/richtextindentspage.cpp:170
+#: ../src/richtext/richtextliststylepage.cpp:361
+#: ../src/richtext/richtextliststylepage.cpp:363
+msgid "Use the current alignment setting."
+msgstr "Koristi trenutačne postavke poravnanja."
+
+#: ../src/richtext/richtextindentspage.cpp:183
+#: ../src/richtext/richtextliststylepage.cpp:375
+msgid "&Indentation (tenths of a mm)"
+msgstr "&Uvlaka (u destinkama mm)"
+
+#: ../src/richtext/richtextindentspage.cpp:198
+#: ../src/richtext/richtextindentspage.cpp:200
+#: ../src/richtext/richtextliststylepage.cpp:388
+#: ../src/richtext/richtextliststylepage.cpp:390
+msgid "The left indent."
+msgstr "Lijeva uvlaka."
+
+#: ../src/richtext/richtextindentspage.cpp:203
+#: ../src/richtext/richtextliststylepage.cpp:393
+msgid "Left (&first line):"
+msgstr "Lijevo (prvi redak):"
+
+#: ../src/richtext/richtextindentspage.cpp:207
+#: ../src/richtext/richtextindentspage.cpp:209
+#: ../src/richtext/richtextliststylepage.cpp:397
+#: ../src/richtext/richtextliststylepage.cpp:399
+msgid "The first line indent."
+msgstr "Uvlaka za prvi redak."
+
+#: ../src/richtext/richtextindentspage.cpp:216
+#: ../src/richtext/richtextindentspage.cpp:218
+#: ../src/richtext/richtextliststylepage.cpp:406
+#: ../src/richtext/richtextliststylepage.cpp:408
+msgid "The right indent."
+msgstr "Desna uvlaka."
+
+#: ../src/richtext/richtextindentspage.cpp:221
+msgid "&Outline level:"
+msgstr "&Razina sadržaja:"
+
+#: ../src/richtext/richtextindentspage.cpp:226
+#: ../src/richtext/richtextindentspage.cpp:228
+msgid "The outline level."
+msgstr "Razina sadržaja."
+
+#: ../src/richtext/richtextindentspage.cpp:241
+#: ../src/richtext/richtextliststylepage.cpp:420
+msgid "&Spacing (tenths of a mm)"
+msgstr "&Spacioniranje (u desetinkama mm)"
+
+#: ../src/richtext/richtextindentspage.cpp:252
+msgid "&Before a paragraph:"
+msgstr "&Prije odlomka:"
+
+#: ../src/richtext/richtextindentspage.cpp:256
+#: ../src/richtext/richtextindentspage.cpp:258
+#: ../src/richtext/richtextliststylepage.cpp:433
+#: ../src/richtext/richtextliststylepage.cpp:435
+msgid "The spacing before the paragraph."
+msgstr "Razmak prije odlomka."
+
+#: ../src/richtext/richtextindentspage.cpp:261
+msgid "&After a paragraph:"
+msgstr "&Nakon odlomka:"
+
+#: ../src/richtext/richtextindentspage.cpp:266
+#: ../src/richtext/richtextliststylepage.cpp:442
+#: ../src/richtext/richtextliststylepage.cpp:444
+msgid "The spacing after the paragraph."
+msgstr "Razmak nakon odlomka."
+
+#: ../src/richtext/richtextindentspage.cpp:269
+msgid "L&ine spacing:"
+msgstr "Prore&d:"
+
+#: ../src/richtext/richtextindentspage.cpp:274
+#: ../src/richtext/richtextliststylepage.cpp:452
+msgid "Single"
+msgstr "Jedno"
+
+#: ../src/richtext/richtextindentspage.cpp:275
+#: ../src/richtext/richtextliststylepage.cpp:453
+msgid "1.1"
+msgstr "1,1"
+
+#: ../src/richtext/richtextindentspage.cpp:276
+#: ../src/richtext/richtextliststylepage.cpp:454
+msgid "1.2"
+msgstr "1,2"
+
+#: ../src/richtext/richtextindentspage.cpp:277
+#: ../src/richtext/richtextliststylepage.cpp:455
+msgid "1.3"
+msgstr "1,3"
+
+#: ../src/richtext/richtextindentspage.cpp:278
+#: ../src/richtext/richtextliststylepage.cpp:456
+msgid "1.4"
+msgstr "1,4"
+
+#: ../src/richtext/richtextindentspage.cpp:279
+#: ../src/richtext/richtextliststylepage.cpp:457
+msgid "1.5"
+msgstr "1,5"
+
+#: ../src/richtext/richtextindentspage.cpp:280
+#: ../src/richtext/richtextliststylepage.cpp:458
+msgid "1.6"
+msgstr "1,6"
+
+#: ../src/richtext/richtextindentspage.cpp:281
+#: ../src/richtext/richtextliststylepage.cpp:459
+msgid "1.7"
+msgstr "1,7"
+
+#: ../src/richtext/richtextindentspage.cpp:282
+#: ../src/richtext/richtextliststylepage.cpp:460
+msgid "1.8"
+msgstr "1,8"
+
+#: ../src/richtext/richtextindentspage.cpp:283
+#: ../src/richtext/richtextliststylepage.cpp:461
+msgid "1.9"
+msgstr "1,9"
+
+#: ../src/richtext/richtextindentspage.cpp:284
+#: ../src/richtext/richtextliststylepage.cpp:462
+msgid "2"
+msgstr "2"
+
+#: ../src/richtext/richtextindentspage.cpp:287
+#: ../src/richtext/richtextindentspage.cpp:289
+#: ../src/richtext/richtextliststylepage.cpp:465
+#: ../src/richtext/richtextliststylepage.cpp:467
+msgid "The line spacing."
+msgstr "Prored."
+
+#: ../src/richtext/richtextindentspage.cpp:292
+msgid "&Page Break"
+msgstr "&Prijelom stranice"
+
+#: ../src/richtext/richtextindentspage.cpp:294
+#: ../src/richtext/richtextindentspage.cpp:296
+msgid "Inserts a page break before the paragraph."
+msgstr "Umetni prijelom stranice prije odlomka."
+
+#: ../src/richtext/richtextindentspage.cpp:302
+#: ../src/richtext/richtextindentspage.cpp:304
+msgid "Shows a preview of the paragraph settings."
+msgstr "Prikazuje pregled postavaka odlomka."
+
+#: ../src/richtext/richtextliststylepage.cpp:182
+msgid "&List level:"
+msgstr "&Razina popisa:"
+
+#: ../src/richtext/richtextliststylepage.cpp:186
+#: ../src/richtext/richtextliststylepage.cpp:188
+msgid "Selects the list level to edit."
+msgstr "Odabire razinu popisa za uređivanje."
+
+#: ../src/richtext/richtextliststylepage.cpp:193
+msgid "&Font for Level..."
+msgstr "&Font za razinu …"
+
+#: ../src/richtext/richtextliststylepage.cpp:194
+#: ../src/richtext/richtextliststylepage.cpp:196
+msgid "Click to choose the font for this level."
+msgstr "Klikni za odabir fonta za ovu razinu."
+
+#: ../src/richtext/richtextliststylepage.cpp:312
+msgid "Bullet style"
+msgstr "Stil znaka nabrajanja"
+
+#: ../src/richtext/richtextliststylepage.cpp:429
+msgid "Before a paragraph:"
+msgstr "Prije odlomka:"
+
+#: ../src/richtext/richtextliststylepage.cpp:438
+msgid "After a paragraph:"
+msgstr "Nakon odlomka:"
+
+#: ../src/richtext/richtextliststylepage.cpp:447
+msgid "Line spacing:"
+msgstr "Prored:"
+
+#: ../src/richtext/richtextliststylepage.cpp:470
+msgid "Spacing"
+msgstr "Spacioniranje"
+
+#: ../src/richtext/richtextmarginspage.cpp:193
+#: ../src/richtext/richtextmarginspage.cpp:195
+msgid "The left margin size."
+msgstr "Veličina lijeve margine."
+
+#: ../src/richtext/richtextmarginspage.cpp:203
+#: ../src/richtext/richtextmarginspage.cpp:205
+msgid "Units for the left margin."
+msgstr "Jedinice za lijevu marginu."
+
+#: ../src/richtext/richtextmarginspage.cpp:218
+#: ../src/richtext/richtextmarginspage.cpp:220
+msgid "The right margin size."
+msgstr "Veličina desne margine."
+
+#: ../src/richtext/richtextmarginspage.cpp:228
+#: ../src/richtext/richtextmarginspage.cpp:230
+msgid "Units for the right margin."
+msgstr "Jedinice za desnu marginu."
+
+#: ../src/richtext/richtextmarginspage.cpp:241
+#: ../src/richtext/richtextmarginspage.cpp:243
+msgid "The top margin size."
+msgstr "Veličina gornje margine."
+
+#: ../src/richtext/richtextmarginspage.cpp:251
+#: ../src/richtext/richtextmarginspage.cpp:253
+msgid "Units for the top margin."
+msgstr "Jedinice za gornju marginu."
+
+#: ../src/richtext/richtextmarginspage.cpp:266
+#: ../src/richtext/richtextmarginspage.cpp:268
+msgid "The bottom margin size."
+msgstr "Veličina donje margine."
+
+#: ../src/richtext/richtextmarginspage.cpp:276
+#: ../src/richtext/richtextmarginspage.cpp:278
+msgid "Units for the bottom margin."
+msgstr "Jedinice za donju marginu."
+
+#: ../src/richtext/richtextmarginspage.cpp:284
+msgid "Padding"
+msgstr "Odmak"
+
+#: ../src/richtext/richtextmarginspage.cpp:307
+#: ../src/richtext/richtextmarginspage.cpp:309
+msgid "The left padding size."
+msgstr "Veličina lijevog odmaka."
+
+#: ../src/richtext/richtextmarginspage.cpp:317
+#: ../src/richtext/richtextmarginspage.cpp:319
+msgid "Units for the left padding."
+msgstr "Jedinice za debljinu lijevog odmaka."
+
+#: ../src/richtext/richtextmarginspage.cpp:332
+#: ../src/richtext/richtextmarginspage.cpp:334
+msgid "The right padding size."
+msgstr "Veličina desnog odmaka."
+
+#: ../src/richtext/richtextmarginspage.cpp:342
+#: ../src/richtext/richtextmarginspage.cpp:344
+msgid "Units for the right padding."
+msgstr "Jedinice za debljinu desnog odmaka."
+
+#: ../src/richtext/richtextmarginspage.cpp:355
+#: ../src/richtext/richtextmarginspage.cpp:357
+msgid "The top padding size."
+msgstr "Veličina gornjeg odmaka."
+
+#: ../src/richtext/richtextmarginspage.cpp:365
+#: ../src/richtext/richtextmarginspage.cpp:367
+msgid "Units for the top padding."
+msgstr "Jedinice za debljinu gornjeg odmaka."
+
+#: ../src/richtext/richtextmarginspage.cpp:380
+#: ../src/richtext/richtextmarginspage.cpp:382
+msgid "The bottom padding size."
+msgstr "Veličina donjeg odmaka."
+
+#: ../src/richtext/richtextmarginspage.cpp:390
+#: ../src/richtext/richtextmarginspage.cpp:392
+msgid "Units for the bottom padding."
+msgstr "Jedinice za debljinu donjeg odmaka."
+
+#: ../src/richtext/richtextprint.cpp:592
+msgid " Preview"
+msgstr " Pregled"
+
+#: ../src/richtext/richtextsizepage.cpp:228
+msgid "Floating"
+msgstr "Lebdeći"
+
+#: ../src/richtext/richtextsizepage.cpp:243
+msgid "&Floating mode:"
+msgstr "&Lebdeći modus:"
+
+#: ../src/richtext/richtextsizepage.cpp:252
+#: ../src/richtext/richtextsizepage.cpp:254
+msgid "How the object will float relative to the text."
+msgstr "Kako će se objekt postaviti u odnosu na tekst."
+
+#: ../src/richtext/richtextsizepage.cpp:265
+msgid "Alignment"
+msgstr "Poravnanje"
+
+#: ../src/richtext/richtextsizepage.cpp:277
+msgid "&Vertical alignment:"
+msgstr "&Uspravno poravnanje:"
+
+#: ../src/richtext/richtextsizepage.cpp:279
+#: ../src/richtext/richtextsizepage.cpp:281
+msgid "Enable vertical alignment."
+msgstr "Aktiviraj uspravno poravnanje."
+
+#: ../src/richtext/richtextsizepage.cpp:286
+msgid "Centred"
+msgstr "Centrirano"
+
+#: ../src/richtext/richtextsizepage.cpp:290
+#: ../src/richtext/richtextsizepage.cpp:292
+msgid "Vertical alignment."
+msgstr "Uspravno poravnanje."
+
+#: ../src/richtext/richtextsizepage.cpp:316
+#: ../src/richtext/richtextsizepage.cpp:323
+msgid "&Width:"
+msgstr "&Širina:"
+
+#: ../src/richtext/richtextsizepage.cpp:318
+#: ../src/richtext/richtextsizepage.cpp:320
+msgid "Enable the width value."
+msgstr "Aktiviraj vrijednost širine."
+
+#: ../src/richtext/richtextsizepage.cpp:331
+#: ../src/richtext/richtextsizepage.cpp:333
+msgid "The object width."
+msgstr "Širina objekta."
+
+#: ../src/richtext/richtextsizepage.cpp:342
+#: ../src/richtext/richtextsizepage.cpp:344
+msgid "Units for the object width."
+msgstr "Jedinice za širinu objekta."
+
+#: ../src/richtext/richtextsizepage.cpp:350
+#: ../src/richtext/richtextsizepage.cpp:357
+msgid "&Height:"
+msgstr "&Visina:"
+
+#: ../src/richtext/richtextsizepage.cpp:352
+#: ../src/richtext/richtextsizepage.cpp:354
+#: ../src/richtext/richtextsizepage.cpp:464
+#: ../src/richtext/richtextsizepage.cpp:466
+msgid "Enable the height value."
+msgstr "Aktiviraj vrijednost visine."
+
+#: ../src/richtext/richtextsizepage.cpp:365
+#: ../src/richtext/richtextsizepage.cpp:367
+msgid "The object height."
+msgstr "Visina objekta."
+
+#: ../src/richtext/richtextsizepage.cpp:376
+#: ../src/richtext/richtextsizepage.cpp:378
+msgid "Units for the object height."
+msgstr "Jedinice za visinu objekta."
+
+#: ../src/richtext/richtextsizepage.cpp:381
+msgid "Min width:"
+msgstr "Min. širina:"
+
+#: ../src/richtext/richtextsizepage.cpp:383
+#: ../src/richtext/richtextsizepage.cpp:385
+msgid "Enable the minimum width value."
+msgstr "Aktiviraj minimalnu vrijednost širine."
+
+#: ../src/richtext/richtextsizepage.cpp:392
+#: ../src/richtext/richtextsizepage.cpp:394
+msgid "The object minimum width."
+msgstr "Minimalna širina objekta."
+
+#: ../src/richtext/richtextsizepage.cpp:403
+#: ../src/richtext/richtextsizepage.cpp:405
+msgid "Units for the minimum object width."
+msgstr "Jedinice za minimalnu širinu objekta."
+
+#: ../src/richtext/richtextsizepage.cpp:408
+msgid "Min height:"
+msgstr "Min. visina:"
+
+#: ../src/richtext/richtextsizepage.cpp:410
+#: ../src/richtext/richtextsizepage.cpp:412
+msgid "Enable the minimum height value."
+msgstr "Aktiviraj minimalnu vrijednost visine."
+
+#: ../src/richtext/richtextsizepage.cpp:419
+#: ../src/richtext/richtextsizepage.cpp:421
+msgid "The object minimum height."
+msgstr "Minimalna visina objekta."
+
+#: ../src/richtext/richtextsizepage.cpp:430
+#: ../src/richtext/richtextsizepage.cpp:432
+msgid "Units for the minimum object height."
+msgstr "Jedinice za minimalnu visinu objekta."
+
+#: ../src/richtext/richtextsizepage.cpp:435
+msgid "Max width:"
+msgstr "Maks. širina:"
+
+#: ../src/richtext/richtextsizepage.cpp:437
+#: ../src/richtext/richtextsizepage.cpp:439
+msgid "Enable the maximum width value."
+msgstr "Aktiviraj maksimalnu vrijednost širine."
+
+#: ../src/richtext/richtextsizepage.cpp:446
+#: ../src/richtext/richtextsizepage.cpp:448
+msgid "The object maximum width."
+msgstr "Maksimalna širina objekta."
+
+#: ../src/richtext/richtextsizepage.cpp:457
+#: ../src/richtext/richtextsizepage.cpp:459
+msgid "Units for the maximum object width."
+msgstr "Jedinice za maksimalnu širinu objekta."
+
+#: ../src/richtext/richtextsizepage.cpp:462
+msgid "Max height:"
+msgstr "Maks. visina:"
+
+#: ../src/richtext/richtextsizepage.cpp:473
+#: ../src/richtext/richtextsizepage.cpp:475
+msgid "The object maximum height."
+msgstr "Maksimalna visina objekta."
+
+#: ../src/richtext/richtextsizepage.cpp:484
+#: ../src/richtext/richtextsizepage.cpp:486
+msgid "Units for the maximum object height."
+msgstr "Jedinice za maksimalnu visinu objekta."
+
+#: ../src/richtext/richtextsizepage.cpp:495
+msgid "Position"
+msgstr "Položaj"
+
+#: ../src/richtext/richtextsizepage.cpp:513
+msgid "&Position mode:"
+msgstr "&Modus položaja:"
+
+#: ../src/richtext/richtextsizepage.cpp:517
+#: ../src/richtext/richtextsizepage.cpp:522
+msgid "Static"
+msgstr "Statično"
+
+#: ../src/richtext/richtextsizepage.cpp:518
+msgid "Relative"
+msgstr "Relativno"
+
+#: ../src/richtext/richtextsizepage.cpp:519
+msgid "Absolute"
+msgstr "Apsolutno"
+
+#: ../src/richtext/richtextsizepage.cpp:520
+msgid "Fixed"
+msgstr "Fiksni"
+
+#: ../src/richtext/richtextsizepage.cpp:533
+#: ../src/richtext/richtextsizepage.cpp:535
+#: ../src/richtext/richtextsizepage.cpp:547
+#: ../src/richtext/richtextsizepage.cpp:549
+msgid "The left position."
+msgstr "Lijevi položaj."
+
+#: ../src/richtext/richtextsizepage.cpp:558
+#: ../src/richtext/richtextsizepage.cpp:560
+msgid "Units for the left position."
+msgstr "Jedinice za lijevi položaj."
+
+#: ../src/richtext/richtextsizepage.cpp:568
+#: ../src/richtext/richtextsizepage.cpp:570
+#: ../src/richtext/richtextsizepage.cpp:582
+#: ../src/richtext/richtextsizepage.cpp:584
+msgid "The top position."
+msgstr "Gornji položaj."
+
+#: ../src/richtext/richtextsizepage.cpp:593
+#: ../src/richtext/richtextsizepage.cpp:595
+msgid "Units for the top position."
+msgstr "Jedinice za gornji položaj."
+
+#: ../src/richtext/richtextsizepage.cpp:603
+#: ../src/richtext/richtextsizepage.cpp:605
+#: ../src/richtext/richtextsizepage.cpp:617
+#: ../src/richtext/richtextsizepage.cpp:619
+msgid "The right position."
+msgstr "Desni položaj."
+
+#: ../src/richtext/richtextsizepage.cpp:628
+#: ../src/richtext/richtextsizepage.cpp:630
+msgid "Units for the right position."
+msgstr "Jedinice za desni položaj."
+
+#: ../src/richtext/richtextsizepage.cpp:638
+#: ../src/richtext/richtextsizepage.cpp:640
+#: ../src/richtext/richtextsizepage.cpp:652
+#: ../src/richtext/richtextsizepage.cpp:654
+msgid "The bottom position."
+msgstr "Donji položaj."
+
+#: ../src/richtext/richtextsizepage.cpp:663
+#: ../src/richtext/richtextsizepage.cpp:665
+msgid "Units for the bottom position."
+msgstr "Jedinice za donji položaj."
+
+#: ../src/richtext/richtextsizepage.cpp:671
+msgid "&Move the object to:"
+msgstr "&Premjesti objekt u:"
+
+#: ../src/richtext/richtextsizepage.cpp:674
+msgid "&Previous Paragraph"
+msgstr "&Prethodni odlomak"
+
+#: ../src/richtext/richtextsizepage.cpp:675
+#: ../src/richtext/richtextsizepage.cpp:677
+msgid "Moves the object to the previous paragraph."
+msgstr "Premješta objekt u prethodni odlomak."
+
+#: ../src/richtext/richtextsizepage.cpp:680
+msgid "&Next Paragraph"
+msgstr "&Sljedeći odlomak"
+
+#: ../src/richtext/richtextsizepage.cpp:681
+#: ../src/richtext/richtextsizepage.cpp:683
+msgid "Moves the object to the next paragraph."
+msgstr "Premješta objekt u sljedeći odlomak."
+
+#: ../src/richtext/richtextstyledlg.cpp:193
+msgid "&Styles:"
+msgstr "&Stilovi:"
+
+#: ../src/richtext/richtextstyledlg.cpp:197
+#: ../src/richtext/richtextstyledlg.cpp:199
+msgid "The available styles."
+msgstr "Dostupni stilovi."
+
+#: ../src/richtext/richtextstyledlg.cpp:205
+#: ../src/richtext/richtextstyledlg.cpp:217
+msgid " "
+msgstr " "
+
+#: ../src/richtext/richtextstyledlg.cpp:209
+#: ../src/richtext/richtextstyledlg.cpp:211
+msgid "The style preview."
+msgstr "Pregled stilova."
+
+#: ../src/richtext/richtextstyledlg.cpp:220
+msgid "New &Character Style..."
+msgstr "Novi stil &slovnih znakova …"
+
+#: ../src/richtext/richtextstyledlg.cpp:221
+#: ../src/richtext/richtextstyledlg.cpp:223
+msgid "Click to create a new character style."
+msgstr "Klikni za stvaranje novog stila slovnih znakova."
+
+#: ../src/richtext/richtextstyledlg.cpp:226
+msgid "New &Paragraph Style..."
+msgstr "Novi stil &odlomka …"
+
+#: ../src/richtext/richtextstyledlg.cpp:227
+#: ../src/richtext/richtextstyledlg.cpp:229
+msgid "Click to create a new paragraph style."
+msgstr "Klikni za stvaranje novog stila odlomka."
+
+#: ../src/richtext/richtextstyledlg.cpp:232
+msgid "New &List Style..."
+msgstr "Novi stil &popisa …"
+
+#: ../src/richtext/richtextstyledlg.cpp:233
+#: ../src/richtext/richtextstyledlg.cpp:235
+msgid "Click to create a new list style."
+msgstr "Klikni za stvaranje novog stila popisa."
+
+#: ../src/richtext/richtextstyledlg.cpp:238
+msgid "New &Box Style..."
+msgstr "Novi stil &okvira …"
+
+#: ../src/richtext/richtextstyledlg.cpp:239
+#: ../src/richtext/richtextstyledlg.cpp:241
+msgid "Click to create a new box style."
+msgstr "Klikni za stvaranje novog stila okvira."
+
+#: ../src/richtext/richtextstyledlg.cpp:246
+msgid "&Apply Style"
+msgstr "&Primijeni stil"
+
+#: ../src/richtext/richtextstyledlg.cpp:247
+#: ../src/richtext/richtextstyledlg.cpp:249
+msgid "Click to apply the selected style."
+msgstr "Klikni za primjenu stila."
+
+#: ../src/richtext/richtextstyledlg.cpp:252
+msgid "&Rename Style..."
+msgstr "&Preimenuj stil …"
+
+#: ../src/richtext/richtextstyledlg.cpp:253
+#: ../src/richtext/richtextstyledlg.cpp:255
+msgid "Click to rename the selected style."
+msgstr "Klikni za preimenovanje odabranog stila."
+
+#: ../src/richtext/richtextstyledlg.cpp:258
+msgid "&Edit Style..."
+msgstr "&Uredi stil …"
+
+#: ../src/richtext/richtextstyledlg.cpp:259
+#: ../src/richtext/richtextstyledlg.cpp:261
+msgid "Click to edit the selected style."
+msgstr "Klikni za uređivanje odabranog stila."
+
+#: ../src/richtext/richtextstyledlg.cpp:264
+msgid "&Delete Style..."
+msgstr "&Izbriši stil …"
+
+#: ../src/richtext/richtextstyledlg.cpp:265
+#: ../src/richtext/richtextstyledlg.cpp:267
+msgid "Click to delete the selected style."
+msgstr "Klikni za uklanjanje odabranog stila."
+
+#: ../src/richtext/richtextstyledlg.cpp:274
+#: ../src/richtext/richtextstyledlg.cpp:276
+msgid "Click to close this window."
+msgstr "Klikni za zatvaranje ovog prozora."
+
+#: ../src/richtext/richtextstyledlg.cpp:282
+msgid "&Restart numbering"
+msgstr "&Ponovi numeriranje"
+
+#: ../src/richtext/richtextstyledlg.cpp:284
+#: ../src/richtext/richtextstyledlg.cpp:286
+msgid "Check to restart numbering."
+msgstr "Aktiviraj za ponovo numeriranje."
+
+#: ../src/richtext/richtextstyledlg.cpp:601
+msgid "Enter a character style name"
+msgstr "Unesi ime stila slovnih znakova"
+
+#: ../src/richtext/richtextstyledlg.cpp:601
+#: ../src/richtext/richtextstyledlg.cpp:606
+#: ../src/richtext/richtextstyledlg.cpp:649
+#: ../src/richtext/richtextstyledlg.cpp:654
+#: ../src/richtext/richtextstyledlg.cpp:815
+#: ../src/richtext/richtextstyledlg.cpp:820
+#: ../src/richtext/richtextstyledlg.cpp:888
+#: ../src/richtext/richtextstyledlg.cpp:896
+#: ../src/richtext/richtextstyledlg.cpp:929
+#: ../src/richtext/richtextstyledlg.cpp:934
+msgid "New Style"
+msgstr "Novi stil"
+
+#: ../src/richtext/richtextstyledlg.cpp:606
+#: ../src/richtext/richtextstyledlg.cpp:654
+#: ../src/richtext/richtextstyledlg.cpp:820
+#: ../src/richtext/richtextstyledlg.cpp:896
+#: ../src/richtext/richtextstyledlg.cpp:934
+msgid "Sorry, that name is taken. Please choose another."
+msgstr "Nažalost je to ime zauzeto. Odaberi drugo ime."
+
+#: ../src/richtext/richtextstyledlg.cpp:649
+msgid "Enter a paragraph style name"
+msgstr "Unesi ime stila odlomka"
+
+#: ../src/richtext/richtextstyledlg.cpp:777
+#, c-format
+msgid "Delete style %s?"
+msgstr "Izbrisati stil %s?"
+
+#: ../src/richtext/richtextstyledlg.cpp:777
+msgid "Delete Style"
+msgstr "Izbriši stil"
+
+#: ../src/richtext/richtextstyledlg.cpp:815
+msgid "Enter a list style name"
+msgstr "Unesi ime stila popisa"
+
+#: ../src/richtext/richtextstyledlg.cpp:888
+msgid "Enter a new style name"
+msgstr "Unesi novo ime stila"
+
+#: ../src/richtext/richtextstyledlg.cpp:929
+msgid "Enter a box style name"
+msgstr "Unesi ime stila okvira"
+
+#: ../src/richtext/richtextstylepage.cpp:109
+#: ../src/richtext/richtextstylepage.cpp:111
+msgid "The style name."
+msgstr "Ime stila."
+
+#: ../src/richtext/richtextstylepage.cpp:114
+msgid "&Based on:"
+msgstr "&Bazirano na:"
+
+#: ../src/richtext/richtextstylepage.cpp:119
+#: ../src/richtext/richtextstylepage.cpp:121
+msgid "The style on which this style is based."
+msgstr "Stil, na kojem se ovaj stil zasniva."
+
+#: ../src/richtext/richtextstylepage.cpp:124
+msgid "&Next style:"
+msgstr "&Sljedeći stil:"
+
+#: ../src/richtext/richtextstylepage.cpp:129
+#: ../src/richtext/richtextstylepage.cpp:131
+msgid "The default style for the next paragraph."
+msgstr "Zadani stil za sljedeći odlomak."
+
+#: ../src/richtext/richtextstyles.cpp:1057
+msgid "All styles"
+msgstr "Svi stilovi"
+
+#: ../src/richtext/richtextstyles.cpp:1058
+msgid "Paragraph styles"
+msgstr "Stilovi odlomaka"
+
+#: ../src/richtext/richtextstyles.cpp:1059
+msgid "Character styles"
+msgstr "Stilovi slovnih znakova"
+
+#: ../src/richtext/richtextstyles.cpp:1060
+msgid "List styles"
+msgstr "Stilovi popisa"
+
+#: ../src/richtext/richtextstyles.cpp:1061
+msgid "Box styles"
+msgstr "Stil okvira"
+
+#: ../src/richtext/richtextsymboldlg.cpp:389
+#: ../src/richtext/richtextsymboldlg.cpp:391
+msgid "The font from which to take the symbol."
+msgstr "Font, iz kojeg se preuzima simbol."
+
+#: ../src/richtext/richtextsymboldlg.cpp:396
+msgid "&Subset:"
+msgstr "&Podskupina:"
+
+#: ../src/richtext/richtextsymboldlg.cpp:401
+#: ../src/richtext/richtextsymboldlg.cpp:403
+msgid "Shows a Unicode subset."
+msgstr "Prikazuje Unicode podskupinu."
+
+#: ../src/richtext/richtextsymboldlg.cpp:412
+msgid "xxxx"
+msgstr "xxxx"
+
+#: ../src/richtext/richtextsymboldlg.cpp:417
+msgid "&Character code:"
+msgstr "&Slovni znak:"
+
+#: ../src/richtext/richtextsymboldlg.cpp:421
+#: ../src/richtext/richtextsymboldlg.cpp:423
+msgid "The character code."
+msgstr "Kȏd slovnog znaka."
+
+#: ../src/richtext/richtextsymboldlg.cpp:428
+msgid "&From:"
+msgstr "&Od:"
+
+#: ../src/richtext/richtextsymboldlg.cpp:433
+#: ../src/richtext/richtextsymboldlg.cpp:434
+#: ../src/richtext/richtextsymboldlg.cpp:435
+msgid "Unicode"
+msgstr "Unicode"
+
+#: ../src/richtext/richtextsymboldlg.cpp:436
+#: ../src/richtext/richtextsymboldlg.cpp:438
+msgid "The range to show."
+msgstr "Prikazani opseg."
+
+#: ../src/richtext/richtextsymboldlg.cpp:444
+msgid "Insert"
+msgstr "Umetni"
+
+#: ../src/richtext/richtextsymboldlg.cpp:478
+msgid "(Normal text)"
+msgstr "(Normalan tekst)"
+
+#: ../src/richtext/richtexttabspage.cpp:109
+msgid "&Position (tenths of a mm):"
+msgstr "&Položaj (u desetinkama mm):"
+
+#: ../src/richtext/richtexttabspage.cpp:113
+#: ../src/richtext/richtexttabspage.cpp:115
+msgid "The tab position."
+msgstr "Položaj tabulatora."
+
+#: ../src/richtext/richtexttabspage.cpp:119
+msgid "The tab positions."
+msgstr "Položaji tabulatora."
+
+#: ../src/richtext/richtexttabspage.cpp:132
+#: ../src/richtext/richtexttabspage.cpp:134
+msgid "Click to create a new tab position."
+msgstr "Klikni za stvaranje novog tabulatora."
+
+#: ../src/richtext/richtexttabspage.cpp:138
+#: ../src/richtext/richtexttabspage.cpp:140
+msgid "Click to delete the selected tab position."
+msgstr "Klikni za uklanjanje odabranog tabulatora."
+
+#: ../src/richtext/richtexttabspage.cpp:143
+msgid "Delete A&ll"
+msgstr "Izbriši s&ve"
+
+#: ../src/richtext/richtexttabspage.cpp:144
+#: ../src/richtext/richtexttabspage.cpp:146
+msgid "Click to delete all tab positions."
+msgstr "Klikni za uklanjanje svih tabulatora."
+
+#: ../src/univ/theme.cpp:110
+msgid "Failed to initialize GUI: no built-in themes found."
+msgstr "Neuspjelo inicijaliziranje grafičkog sučelja: nema ugrađenih tema."
+
+#: ../src/univ/themes/gtk.cpp:521
+msgid "GTK+ theme"
+msgstr "GTK+ tema"
+
+#: ../src/univ/themes/metal.cpp:164
+msgid "Metal theme"
+msgstr "Metalna tema"
+
+#: ../src/univ/themes/mono.cpp:512
+msgid "Simple monochrome theme"
+msgstr "Jednostavna jednobojna tema"
+
+#: ../src/univ/themes/win32.cpp:1098
+msgid "Win32 theme"
+msgstr "Win32 tema"
+
+#: ../src/univ/themes/win32.cpp:3743
+msgid "&Restore"
+msgstr "&Obnovi"
+
+#: ../src/univ/themes/win32.cpp:3744
+msgid "&Move"
+msgstr "&Premjesti"
+
+#: ../src/univ/themes/win32.cpp:3746
+msgid "&Size"
+msgstr "&Veličina"
+
+#: ../src/univ/themes/win32.cpp:3748
+msgid "Mi&nimize"
+msgstr "Sma&nji"
+
+#: ../src/univ/themes/win32.cpp:3750
+msgid "Ma&ximize"
+msgstr "Ma&ksimiraj"
+
+#: ../src/univ/themes/win32.cpp:3752
+msgid "Alt+"
+msgstr "Alt+"
+
+#: ../src/unix/appunix.cpp:178
+msgid "Failed to install signal handler"
+msgstr "Neuspjelo instaliranje signalnog upravljača"
+
+#: ../src/unix/dialup.cpp:351
+msgid "Already dialling ISP."
+msgstr "Već se bira ISP."
+
+#: ../src/unix/dlunix.cpp:93
+msgid "Failed to unload shared library"
+msgstr "Neuspjelo odstranjivanje učitane dijeljenje biblioteke"
+
+#: ../src/unix/dlunix.cpp:121
+msgid "Unknown dynamic library error"
+msgstr "Nepoznata greška dinamičke biblioteke"
+
+#: ../src/unix/epolldispatcher.cpp:84
+msgid "Failed to create epoll descriptor"
+msgstr "Neuspjelo stvaranje epoll deskriptora"
+
+#: ../src/unix/epolldispatcher.cpp:103
+msgid "Error closing epoll descriptor"
+msgstr "Greška prilikom zatvaranja epoll deskriptora"
+
+#: ../src/unix/epolldispatcher.cpp:116
+#, c-format
+msgid "Failed to add descriptor %d to epoll descriptor %d"
+msgstr "Neuspjelo dodavanje deskriptora %d epoll deskriptoru %d"
+
+#: ../src/unix/epolldispatcher.cpp:136
+#, c-format
+msgid "Failed to modify descriptor %d in epoll descriptor %d"
+msgstr "Neuspjelo mijenjanje deskriptora %d u epoll deskriptoru %d"
+
+#: ../src/unix/epolldispatcher.cpp:155
+#, c-format
+msgid "Failed to unregister descriptor %d from epoll descriptor %d"
+msgstr "Neuspjelo odjavljivanje deskriptora %d iz epoll deskriptora %d"
+
+#: ../src/unix/epolldispatcher.cpp:213
+#, c-format
+msgid "Waiting for IO on epoll descriptor %d failed"
+msgstr "Čekanje ulaza/izlaza na epoll deskriptor %d"
+
+#: ../src/unix/fswatcher_inotify.cpp:71
+msgid "Unable to create inotify instance"
+msgstr "Nije moguće stvoriti inotify instancu"
+
+#: ../src/unix/fswatcher_inotify.cpp:94
+msgid "Unable to close inotify instance"
+msgstr "Nije moguće zatvoriti inotify instancu"
+
+#: ../src/unix/fswatcher_inotify.cpp:106
+msgid "Unable to add inotify watch"
+msgstr "Nije moguće dodati inotify nadzor"
+
+#: ../src/unix/fswatcher_inotify.cpp:138
+#, c-format
+msgid "Unable to remove inotify watch %i"
+msgstr "Nije moguće ukloniti inotify nadzor %i"
+
+#: ../src/unix/fswatcher_inotify.cpp:271
+#, c-format
+msgid "Unexpected event for \"%s\": no matching watch descriptor."
+msgstr "Neočekivani događaj za „%s”: nema poklapajućih nadzornih opisnika."
+
+#: ../src/unix/fswatcher_inotify.cpp:320
+#, c-format
+msgid "Invalid inotify event for \"%s\""
+msgstr "Nevaljani inotify događaj za „%s”"
+
+#: ../src/unix/fswatcher_inotify.cpp:553
+msgid "Unable to read from inotify descriptor"
+msgstr "Nije moguće čitati iz inotify opisnika"
+
+#: ../src/unix/fswatcher_inotify.cpp:558
+msgid "EOF while reading from inotify descriptor"
+msgstr "EOF prilikom čitanja inotify deskriptora"
+
+#: ../src/unix/fswatcher_kqueue.cpp:114
+msgid "Unable to create kqueue instance"
+msgstr "Nije moguće stvoriti kqueue instancu"
+
+#: ../src/unix/fswatcher_kqueue.cpp:131
+msgid "Error closing kqueue instance"
+msgstr "Greška prilikom zatvaranja kqueue instance"
+
+#: ../src/unix/fswatcher_kqueue.cpp:153
+msgid "Unable to add kqueue watch"
+msgstr "Nije moguće dodati kqueue nadzor"
+
+#: ../src/unix/fswatcher_kqueue.cpp:170
+msgid "Unable to remove kqueue watch"
+msgstr "Nije moguće ukloniti kqueue nadzor"
+
+#: ../src/unix/fswatcher_kqueue.cpp:202
+msgid "Unable to get events from kqueue"
+msgstr "Nije moguće dobiti događaje iz kqueue"
+
+#: ../src/unix/mediactrl.cpp:966
+#, c-format
+msgid "Media playback error: %s"
+msgstr "Greška u pokretanju medija: %s"
+
+#: ../src/unix/mediactrl.cpp:1228
+#, c-format
+msgid "Failed to prepare playing \"%s\"."
+msgstr "Neuspjela priprema pokretanja „%s”."
+
+#: ../src/unix/snglinst.cpp:164
+#, c-format
+msgid "Failed to write to lock file '%s'"
+msgstr "Neuspjelo pisanje u datoteku za zaključavanje „%s”."
+
+#: ../src/unix/snglinst.cpp:177
+#, c-format
+msgid "Failed to set permissions on lock file '%s'"
+msgstr "Neuspjelo postavljanje korisničkih prava na zaključnu datoteku „%s”."
+
+#: ../src/unix/snglinst.cpp:194
+#, c-format
+msgid "Failed to lock the lock file '%s'"
+msgstr "Neuspjelo zaključavanje zaključne datoteke „%s”."
+
+#: ../src/unix/snglinst.cpp:237
+#, c-format
+msgid "Failed to inspect the lock file '%s'"
+msgstr "Neuspjelo provjeravanje zaključne datoteke „%s”"
+
+#: ../src/unix/snglinst.cpp:242
+#, c-format
+msgid "Lock file '%s' has incorrect owner."
+msgstr "Datoteka za zaključavanje „%s” ima neipravnog vlasnika."
+
+#: ../src/unix/snglinst.cpp:247
+#, c-format
+msgid "Lock file '%s' has incorrect permissions."
+msgstr "Datoteka za zaključavanje „%s” ima neipravna korisnička prava."
+
+#: ../src/unix/snglinst.cpp:265
+msgid "Failed to access lock file."
+msgstr "Neuspjeli pristup zaključnoj datoteci."
+
+#: ../src/unix/snglinst.cpp:274
+msgid "Failed to read PID from lock file."
+msgstr "Neuspjelo čitanje PID-a iz zaključne datoteke."
+
+#: ../src/unix/snglinst.cpp:284
+#, c-format
+msgid "Failed to remove stale lock file '%s'."
+msgstr "Neuspjelo uklanjanje stare zaključne datoteke „%s”."
+
+#: ../src/unix/snglinst.cpp:297
+#, c-format
+msgid "Deleted stale lock file '%s'."
+msgstr "Izbrisana je stara datoteka zaključavanja „%s”."
+
+#: ../src/unix/snglinst.cpp:308
+#, c-format
+msgid "Invalid lock file '%s'."
+msgstr "Nevaljana datoteka za zaključavanje „%s”."
+
+#: ../src/unix/snglinst.cpp:324
+#, c-format
+msgid "Failed to remove lock file '%s'"
+msgstr "Neuspjelo uklanjanje zaključne datoteke „%s”"
+
+#: ../src/unix/snglinst.cpp:330
+#, c-format
+msgid "Failed to unlock lock file '%s'"
+msgstr "Neuspjelo otključavanje zaključne datoteke „%s”"
+
+#: ../src/unix/snglinst.cpp:336
+#, c-format
+msgid "Failed to close lock file '%s'"
+msgstr "Neuspjelo zatvaranje zaključne datoteke „%s”"
+
+#: ../src/unix/sound.cpp:77
+msgid "No sound"
+msgstr "Bez zvuka"
+
+#: ../src/unix/sound.cpp:364
+msgid "Unable to play sound asynchronously."
+msgstr "Nije moguće pokrenuti zvuk asinkronično."
+
+#: ../src/unix/sound.cpp:458
+#, c-format
+msgid "Couldn't load sound data from '%s'."
+msgstr "Nije bilo moguće učitati zvukovne podatke od „%s”."
+
+#: ../src/unix/sound.cpp:465
+#, c-format
+msgid "Sound file '%s' is in unsupported format."
+msgstr "Zvukovna datoteka „%s” ima nepodržani format."
+
+#: ../src/unix/sound.cpp:480
+msgid "Sound data are in unsupported format."
+msgstr "Zvukovni podaci imaju nepodržani format."
+
+#: ../src/unix/sound_sdl.cpp:226
+#, c-format
+msgid "Couldn't open audio: %s"
+msgstr "Nije bilo moguće otvoriti audio: %s"
+
+#: ../src/unix/threadpsx.cpp:1033
+msgid "Cannot retrieve thread scheduling policy."
+msgstr "Nije moguće pronaći pravila rasporeda komponente procesa."
+
+#: ../src/unix/threadpsx.cpp:1058
+#, c-format
+msgid "Cannot get priority range for scheduling policy %d."
+msgstr "Nije moguće dobiti raspon prioriteta za pravilo rasporeda %d."
+
+#: ../src/unix/threadpsx.cpp:1066
+msgid "Thread priority setting is ignored."
+msgstr "Postavka prioriteta komponente procesa je zanemarena."
+
+#: ../src/unix/threadpsx.cpp:1221
+msgid ""
+"Failed to join a thread, potential memory leak detected - please restart the "
+"program"
+msgstr ""
+"Neuspjelo povezivanje komponente procesa, otkrivena ja moguća nedostatna "
+"memorija – ponovo pokreni program"
+
+#: ../src/unix/threadpsx.cpp:1352
+#, c-format
+msgid "Failed to set thread concurrency level to %lu"
+msgstr "Neuspjelo postavljanje razine podudarnosti komponente procesa na %lu"
+
+#: ../src/unix/threadpsx.cpp:1481
+#, c-format
+msgid "Failed to set thread priority %d."
+msgstr "Neuspjelo postavljanje prioriteta komponente procesa %d."
+
+#: ../src/unix/threadpsx.cpp:1666
+msgid "Failed to terminate a thread."
+msgstr "Neuspjelo prekidanje komponente procesa."
+
+#: ../src/unix/threadpsx.cpp:1893
+msgid "Thread module initialization failed: failed to create thread key"
+msgstr ""
+"Neuspjela inicijalizacija modula komponente procesa: neuspjela izrada ključa "
+"komponente procesa"
+
+#: ../src/unix/utilsunx.cpp:340
+msgid "Impossible to get child process input"
+msgstr "Nije moguće dobiti unos podređenog procesa"
+
+#: ../src/unix/utilsunx.cpp:390
+msgid "Can't write to child process's stdin"
+msgstr "Nije moguće pisanje u stdin podređenog procesa"
+
+#: ../src/unix/utilsunx.cpp:644
+#, c-format
+msgid "Failed to execute '%s'\n"
+msgstr "Neuspjelo izvršavanje „%s”\n"
+
+#: ../src/unix/utilsunx.cpp:678
+msgid "Fork failed"
+msgstr "Račvanje nije uspjelo"
+
+#: ../src/unix/utilsunx.cpp:701
+msgid "Failed to set process priority"
+msgstr "Neuspjelo postavljanje prioriteta procesa"
+
+#: ../src/unix/utilsunx.cpp:712
+msgid "Failed to redirect child process input/output"
+msgstr "Neuspjelo preusmjeravanje unosa/iznošaja podređenog procesa"
+
+#: ../src/unix/utilsunx.cpp:816
+msgid "Failed to set up non-blocking pipe, the program might hang."
+msgstr ""
+"Neuspjelo postavljanje ne-blokirajućeg cjevovoda. Program će možda zastati."
+
+#: ../src/unix/utilsunx.cpp:1023
+msgid "Cannot get the hostname"
+msgstr "Nije moguće dobiti ime hosta"
+
+#: ../src/unix/utilsunx.cpp:1059
+msgid "Cannot get the official hostname"
+msgstr "Nije moguće dobiti službeno ime hosta"
+
+#: ../src/unix/wakeuppipe.cpp:49
+msgid "Failed to create wake up pipe used by event loop."
+msgstr "Neuspjelo stvaranje wake up cjevovoda koju koristi petlja događaja."
+
+#: ../src/unix/wakeuppipe.cpp:56
+msgid "Failed to switch wake up pipe to non-blocking mode"
+msgstr "Neuspjelo prebacivanje wake up cjevovoda u ne-blokirajući modus"
+
+#: ../src/unix/wakeuppipe.cpp:117
+msgid "Failed to read from wake-up pipe"
+msgstr "Neuspjelo čitanje iz wake-up cjevovoda"
+
+#: ../src/x11/app.cpp:124
+#, c-format
+msgid "Invalid geometry specification '%s'"
+msgstr "Nevaljana specifikacija geometrije „%s”"
+
+#: ../src/x11/app.cpp:167
+msgid "wxWidgets could not open display. Exiting."
+msgstr "wxWidgets nije uspio otvoriti zaslon. Prekid."
+
+#: ../src/x11/utils.cpp:169
+#, c-format
+msgid "Failed to close the display \"%s\""
+msgstr "Neuspjelo zatvaranje prikaza „%s”"
+
+#: ../src/x11/utils.cpp:188
+#, c-format
+msgid "Failed to open display \"%s\"."
+msgstr "Neuspjelo otvaranje ekrana „%s”."
+
+#: ../src/xml/xml.cpp:868
+#, c-format
+msgid "XML parsing error: '%s' at line %d"
+msgstr "Greška u XML obradi: „%s” u %d. retku"
+
+#: ../src/xrc/xh_propgrid.cpp:239
+#, fuzzy, c-format
+msgid "Page %i"
+msgstr "Stranica %d"
+
+#: ../src/xrc/xmlres.cpp:448
+#, c-format
+msgid "Cannot load resources from '%s'."
+msgstr "Nije moguće učitati resurse iz „%s”."
+
+#: ../src/xrc/xmlres.cpp:799
+#, c-format
+msgid "Cannot open resources file '%s'."
+msgstr "Nije moguće otvoriti datoteku resursa „%s”."
+
+#: ../src/xrc/xmlres.cpp:806
+#, c-format
+msgid "Cannot load resources from file '%s'."
+msgstr "Nije moguće učitati resurse iz datoteke „%s”."
+
+#: ../src/xrc/xmlres.cpp:2767
+#, c-format
+msgid "Creating %s \"%s\" failed."
+msgstr "Stvaranje %s „%s” nije uspjelo."
+
+#, c-format
+#~ msgid "BMP: header has biClrUsed=%d when biBitCount=%d."
+#~ msgstr "BMP: zaglavlje ima biClrUsed=%d kad je biBitCount=%d."
+
+#~ msgctxt "keyboard key"
+#~ msgid "Alt+"
+#~ msgstr "Alt+"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Ctrl+"
+#~ msgstr "Ctrl+"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Shift+"
+#~ msgstr "Shift+"
+
+#~ msgctxt "keyboard key"
+#~ msgid "RawCtrl+"
+#~ msgstr "RawCtrl+"
+
+#~ msgid "Copying more than one selected block to clipboard is not supported."
+#~ msgstr ""
+#~ "Kopiranje više od jednog odabranog bloka u međuspremnik nije podržano."
+
+#~ msgid "Unsupported clipboard format."
+#~ msgstr "Nepodržani format međuspremnika."
+
+#~ msgid "Background colour"
+#~ msgstr "Boja pozadine"
+
+#~ msgid "Font:"
+#~ msgstr "Font:"
+
+#~ msgid "Size:"
+#~ msgstr "Veličina:"
+
+#~ msgid "The font size in points."
+#~ msgstr "Veličina fonta u točkama."
+
+#~ msgid "Style:"
+#~ msgstr "Stil:"
+
+#~ msgid "Check to make the font bold."
+#~ msgstr "Aktiviraj za korištenje debelog fonta."
+
+#~ msgid "Check to make the font italic."
+#~ msgstr "Aktiviraj za korištenje kurzivnog fonta."
+
+#~ msgid "Check to make the font underlined."
+#~ msgstr "Aktiviraj za korištenje podcrtanog fonta."
+
+#~ msgid "Colour:"
+#~ msgstr "Boja:"
+
+#~ msgid "Click to change the font colour."
+#~ msgstr "Klikni za mijenjanje boje fonta."
+
+#~ msgid "Shows a preview of the font."
+#~ msgstr "Prikazuje pregled fonta."
+
+#~ msgid "Click to cancel changes to the font."
+#~ msgstr "Klikni za prekidanje fontovskih promjena."
+
+#~ msgid "Click to confirm changes to the font."
+#~ msgstr "Klikni za potvrđivanje fontovskih promjena."
+
+#~ msgid "<Any>"
+#~ msgstr "<Bilo koji>"
+
+#~ msgid "<Any Roman>"
+#~ msgstr "<Bilo koji serifni>"
+
+#~ msgid "<Any Decorative>"
+#~ msgstr "<Bilo koji dekorativni>"
+
+#~ msgid "<Any Modern>"
+#~ msgstr "<Bilo koji moderni>"
+
+#~ msgid "<Any Script>"
+#~ msgstr "<Bilo koji krasopisni>"
+
+#~ msgid "<Any Swiss>"
+#~ msgstr "<Bilo koji bezserifni>"
+
+#~ msgid "<Any Teletype>"
+#~ msgstr "<Bilo koji strojopisni>"
+
+#~ msgid "Printing "
+#~ msgstr "Ispisivanje "
+
+#~ msgid "Failed to insert text in the control."
+#~ msgstr "Neuspjelo umetanje teksta u kontrolu."
+
+#~ msgid "Please choose a valid font."
+#~ msgstr "Odaberi valjani font."
+
+#, c-format
+#~ msgid "Failed to display HTML document in %s encoding"
+#~ msgstr "Neuspjeo prikaz HTML dokumenta %s kodiranjem"
+
+#, c-format
+#~ msgid "wxWidgets could not open display for '%s': exiting."
+#~ msgstr "wxWidgets nije uspio otvoriti zaslon za „%s”: prekid."
+
+#~ msgid "Filter"
+#~ msgstr "Filtar"
+
+#~ msgid "Directories"
+#~ msgstr "Mape"
+
+#~ msgid "Files"
+#~ msgstr "Datoteke"
+
+#~ msgid "Selection"
+#~ msgstr "Odabir"

--- a/po_wxstd/hu.po
+++ b/po_wxstd/hu.po
@@ -1,0 +1,10611 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: wxWidgets 3.3\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-05-14 20:23+0200\n"
+"PO-Revision-Date: 2009-07-26 20:12+0100\n"
+"Last-Translator: Oaron <oaron1@gmail.com>\n"
+"Language-Team: wxWidgets translators <wx-translators@wxwidgets.org>\n"
+"Language: hu\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: ../include/wx/defs.h:2582
+msgid "All files (*.*)|*.*"
+msgstr "Minden fájlt (*.*)|*.*"
+
+#: ../include/wx/defs.h:2585
+msgid "All files (*)|*"
+msgstr "Minden fájlt (*)|*"
+
+#: ../include/wx/generic/progdlgg.h:85
+#, fuzzy
+msgid "Elapsed time:"
+msgstr "Az eltelt idő : "
+
+#: ../include/wx/generic/progdlgg.h:86
+#, fuzzy
+msgid "Estimated time:"
+msgstr "A becsült idő : "
+
+#: ../include/wx/generic/progdlgg.h:87
+#, fuzzy
+msgid "Remaining time:"
+msgstr "A hátralevő idő : "
+
+#. TRANSLATORS: HTML printout default title.
+#: ../include/wx/html/htmprint.h:121 ../include/wx/prntbase.h:273
+#: ../include/wx/richtext/richtextprint.h:109 ../src/common/docview.cpp:2161
+#, fuzzy
+msgid "Printout"
+msgstr "Nyomtatás"
+
+#. TRANSLATORS: HTML easy print default title.
+#: ../include/wx/html/htmprint.h:234 ../include/wx/richtext/richtextprint.h:163
+#: ../src/common/prntbase.cpp:522 ../src/html/htmprint.cpp:291
+#, fuzzy
+msgid "Printing"
+msgstr "Nyomtatás"
+
+#: ../include/wx/msgdlg.h:277 ../src/common/stockitem.cpp:211
+msgid "Yes"
+msgstr "Igen"
+
+#: ../include/wx/msgdlg.h:278 ../src/common/stockitem.cpp:182
+msgid "No"
+msgstr "Nem"
+
+#: ../include/wx/msgdlg.h:279 ../src/common/stockitem.cpp:183
+#: ../src/msw/msgdlg.cpp:430 ../src/msw/msgdlg.cpp:734
+#: ../src/richtext/richtextstyledlg.cpp:292
+msgid "OK"
+msgstr "Ok"
+
+#: ../include/wx/msgdlg.h:280 ../src/common/stockitem.cpp:150
+#: ../src/msw/msgdlg.cpp:430 ../src/msw/progdlg.cpp:884
+#: ../src/richtext/richtextstyledlg.cpp:295
+msgid "Cancel"
+msgstr "Mégsem"
+
+#: ../include/wx/msgdlg.h:281 ../src/common/stockitem.cpp:168
+#: ../src/html/helpdlg.cpp:63 ../src/html/helpfrm.cpp:108
+#: ../src/osx/button_osx.cpp:38
+msgid "Help"
+msgstr "Súgó"
+
+#: ../include/wx/msw/ole/oleutils.h:52
+msgid "Cannot initialize OLE"
+msgstr "Nem tudom inicializálni az OLEt"
+
+#: ../include/wx/msw/private/fswatcher.h:48
+#, fuzzy, c-format
+msgid "Unable to close the handle for '%s'"
+msgstr "Nem sikerült lezárni a file kezelőt."
+
+#: ../include/wx/msw/private/fswatcher.h:92
+#, fuzzy, c-format
+msgid "Failed to open directory \"%s\" for monitoring."
+msgstr "Nem tudtam megnyitni '%s'-t %s-ként."
+
+#: ../include/wx/msw/private/fswatcher.h:125
+#, fuzzy
+msgid "Unable to close I/O completion port handle"
+msgstr "Nem sikerült lezárni a file kezelőt."
+
+#: ../include/wx/msw/private/fswatcher.h:142
+msgid "Unable to associate handle with I/O completion port"
+msgstr ""
+
+#: ../include/wx/msw/private/fswatcher.h:148
+msgid "Unexpectedly new I/O completion port was created"
+msgstr ""
+
+#: ../include/wx/msw/private/fswatcher.h:213
+msgid "Unable to post completion status"
+msgstr ""
+
+#: ../include/wx/msw/private/fswatcher.h:262
+msgid "Unable to dequeue completion packet"
+msgstr ""
+
+#: ../include/wx/msw/private/fswatcher.h:273
+#, fuzzy
+msgid "Unable to create I/O completion port"
+msgstr "Nem sikerült lérehozni egér mutatót."
+
+#: ../include/wx/richmsgdlg.h:29
+#, fuzzy
+msgid "&See details"
+msgstr "&Részletek"
+
+#: ../include/wx/richmsgdlg.h:30
+#, fuzzy
+msgid "&Hide details"
+msgstr "&Részletek"
+
+#: ../include/wx/richtext/richtextbuffer.h:3864
+#, fuzzy
+msgid "&Box"
+msgstr "Kövér"
+
+#: ../include/wx/richtext/richtextbuffer.h:5008
+msgid "&Picture"
+msgstr ""
+
+#: ../include/wx/richtext/richtextbuffer.h:5958
+#, fuzzy
+msgid "&Cell"
+msgstr "&Mégsem"
+
+#: ../include/wx/richtext/richtextbuffer.h:6067
+msgid "&Table"
+msgstr ""
+
+#: ../include/wx/richtext/richtextimagedlg.h:37
+#, fuzzy
+msgid "Object Properties"
+msgstr "&Tulajdonságok"
+
+#: ../include/wx/richtext/richtextsymboldlg.h:39
+#, fuzzy
+msgid "Symbols"
+msgstr "&Stílus:"
+
+#: ../include/wx/unix/pipe.h:46
+msgid "Pipe creation failed"
+msgstr "A cső létrehozása nem sikerült"
+
+#: ../include/wx/unix/private/displayx11.h:65
+msgid "Failed to enumerate video modes"
+msgstr "Nem sikerült megszámlálni a video módokat."
+
+#: ../include/wx/unix/private/displayx11.h:89
+msgid "Failed to change video mode"
+msgstr "Nem sikerült megváltoztatni a video módot."
+
+#: ../include/wx/unix/private/fswatcher_kqueue.h:57
+#, fuzzy, c-format
+msgid "Unable to open path '%s'"
+msgstr "Nem tudtam megnyitni a(z) '%s' CHM archive fájlt."
+
+#: ../include/wx/unix/private/fswatcher_kqueue.h:74
+#, fuzzy, c-format
+msgid "Unable to close path '%s'"
+msgstr "Nem sikerült lezárni a(z) '%s' lakat fájlt."
+
+#: ../include/wx/xtiprop.h:175
+msgid "SetProperty called w/o valid setter"
+msgstr "GetProperty híváskor nincs érvényes küldő"
+
+#: ../include/wx/xtiprop.h:184
+msgid "GetProperty called w/o valid getter"
+msgstr "GetProperty híváskor nincs érvényes fogadó"
+
+#: ../include/wx/xtiprop.h:193
+msgid "AddToPropertyCollection called w/o valid adder"
+msgstr "AddToPropertyCollection hívás érvényes hozzáadás nélkül"
+
+#: ../include/wx/xtiprop.h:202
+msgid "GetPropertyCollection called w/o valid collection getter"
+msgstr "GetProperty híváskor nincs érvényes gyűjtő fogadó"
+
+#: ../include/wx/xtiprop.h:255
+msgid "AddToPropertyCollection called on a generic accessor"
+msgstr "AddToPropertyCollection hívás generikus hozzáféréssel"
+
+#: ../include/wx/xtiprop.h:262
+msgid "GetPropertyCollection called on a generic accessor"
+msgstr "GetPropertyCollection generikus accessor hívás"
+
+#: ../src/aui/tabmdi.cpp:106 ../src/generic/mdig.cpp:94
+msgid "Cl&ose"
+msgstr "Be&zárás"
+
+#: ../src/aui/tabmdi.cpp:107 ../src/generic/mdig.cpp:95
+msgid "Close All"
+msgstr "Minden fájl bezárása"
+
+#: ../src/aui/tabmdi.cpp:109 ../src/generic/mdig.cpp:97 ../src/msw/mdi.cpp:175
+#: ../src/qt/mdi.cpp:258
+msgid "&Next"
+msgstr "&Következő "
+
+#: ../src/aui/tabmdi.cpp:110 ../src/generic/mdig.cpp:98 ../src/msw/mdi.cpp:176
+#: ../src/qt/mdi.cpp:259
+msgid "&Previous"
+msgstr "&Előző"
+
+#: ../src/aui/tabmdi.cpp:332 ../src/aui/tabmdi.cpp:348
+#: ../src/aui/tabmdi.cpp:350 ../src/generic/mdig.cpp:291
+#: ../src/generic/mdig.cpp:307 ../src/generic/mdig.cpp:311
+#: ../src/msw/mdi.cpp:337 ../src/qt/mdi.cpp:462
+msgid "&Window"
+msgstr "&Ablak"
+
+#: ../src/common/accelcmn.cpp:47
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Delete"
+msgstr "&Törlés"
+
+#: ../src/common/accelcmn.cpp:48
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Del"
+msgstr "&Törlés"
+
+#: ../src/common/accelcmn.cpp:49
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Back"
+msgstr "&Vissza"
+
+#: ../src/common/accelcmn.cpp:49
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Backspace"
+msgstr "&Vissza"
+
+#: ../src/common/accelcmn.cpp:50
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Insert"
+msgstr "Bekezdés"
+
+#: ../src/common/accelcmn.cpp:51
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Ins"
+msgstr "Bekezdés"
+
+#: ../src/common/accelcmn.cpp:52
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Enter"
+msgstr "Nyomtató"
+
+#: ../src/common/accelcmn.cpp:53
+msgctxt "keyboard key"
+msgid "Return"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:54
+#, fuzzy
+msgctxt "keyboard key"
+msgid "PageUp"
+msgstr "Oldalak"
+
+#: ../src/common/accelcmn.cpp:54
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Page Up"
+msgstr "%d. oldal"
+
+#: ../src/common/accelcmn.cpp:55
+#, fuzzy
+msgctxt "keyboard key"
+msgid "PageDown"
+msgstr "Le"
+
+#: ../src/common/accelcmn.cpp:55
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Page Down"
+msgstr "%d. oldal"
+
+#: ../src/common/accelcmn.cpp:56
+msgctxt "keyboard key"
+msgid "PgUp"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:57
+msgctxt "keyboard key"
+msgid "PgDn"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:58
+msgctxt "keyboard key"
+msgid "Left"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:59
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Right"
+msgstr "Vékony"
+
+#: ../src/common/accelcmn.cpp:60
+msgctxt "keyboard key"
+msgid "Up"
+msgstr "Fel"
+
+#: ../src/common/accelcmn.cpp:61
+msgctxt "keyboard key"
+msgid "Down"
+msgstr "Le"
+
+#: ../src/common/accelcmn.cpp:62
+msgctxt "keyboard key"
+msgid "Home"
+msgstr "Haza"
+
+#: ../src/common/accelcmn.cpp:63
+msgctxt "keyboard key"
+msgid "End"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:64
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Space"
+msgstr "Keresek..."
+
+#: ../src/common/accelcmn.cpp:65
+msgctxt "keyboard key"
+msgid "Tab"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:66
+msgctxt "keyboard key"
+msgid "Esc"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:67
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Escape"
+msgstr "Tájkép"
+
+#: ../src/common/accelcmn.cpp:68
+msgctxt "keyboard key"
+msgid "Cancel"
+msgstr "Mégsem"
+
+#: ../src/common/accelcmn.cpp:69
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Clear"
+msgstr "&Törlés"
+
+#: ../src/common/accelcmn.cpp:70
+msgctxt "keyboard key"
+msgid "Menu"
+msgstr "Menu"
+
+#: ../src/common/accelcmn.cpp:71
+msgctxt "keyboard key"
+msgid "Pause"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:72
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Capital"
+msgstr "dőlt"
+
+#: ../src/common/accelcmn.cpp:73
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Select"
+msgstr "Kiválasztott"
+
+#: ../src/common/accelcmn.cpp:74
+msgctxt "keyboard key"
+msgid "Print"
+msgstr "Nyomtatás"
+
+#: ../src/common/accelcmn.cpp:75
+msgctxt "keyboard key"
+msgid "Execute"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:76
+msgctxt "keyboard key"
+msgid "Snapshot"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:77
+msgctxt "keyboard key"
+msgid "Help"
+msgstr "Súgó"
+
+#: ../src/common/accelcmn.cpp:78
+msgctxt "keyboard key"
+msgid "Add"
+msgstr "Add hozzá"
+
+#: ../src/common/accelcmn.cpp:79
+msgctxt "keyboard key"
+msgid "Separator"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:80
+msgctxt "keyboard key"
+msgid "Subtract"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:81
+msgctxt "keyboard key"
+msgid "Decimal"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:82
+msgctxt "keyboard key"
+msgid "Multiply"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:83
+msgctxt "keyboard key"
+msgid "Divide"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:84
+msgctxt "keyboard key"
+msgid "Num_lock"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:84
+msgctxt "keyboard key"
+msgid "Num Lock"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:85
+msgctxt "keyboard key"
+msgid "Scroll_lock"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:85
+msgctxt "keyboard key"
+msgid "Scroll Lock"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:86
+msgctxt "keyboard key"
+msgid "KP_Space"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:86
+msgctxt "keyboard key"
+msgid "Num Space"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:87
+msgctxt "keyboard key"
+msgid "KP_Tab"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:87
+msgctxt "keyboard key"
+msgid "Num Tab"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:88
+#, fuzzy
+msgctxt "keyboard key"
+msgid "KP_Enter"
+msgstr "Nyomtató"
+
+#: ../src/common/accelcmn.cpp:88
+msgctxt "keyboard key"
+msgid "Num Enter"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:89
+#, fuzzy
+msgctxt "keyboard key"
+msgid "KP_Home"
+msgstr "Haza"
+
+#: ../src/common/accelcmn.cpp:89
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Num Home"
+msgstr "Haza"
+
+#: ../src/common/accelcmn.cpp:90
+msgctxt "keyboard key"
+msgid "KP_Left"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:90
+msgctxt "keyboard key"
+msgid "Num left"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:91
+msgctxt "keyboard key"
+msgid "KP_Up"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:91
+msgctxt "keyboard key"
+msgid "Num Up"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:92
+#, fuzzy
+msgctxt "keyboard key"
+msgid "KP_Right"
+msgstr "Vékony"
+
+#: ../src/common/accelcmn.cpp:92
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Num Right"
+msgstr "Vékony"
+
+#: ../src/common/accelcmn.cpp:93
+#, fuzzy
+msgctxt "keyboard key"
+msgid "KP_Down"
+msgstr "Le"
+
+#: ../src/common/accelcmn.cpp:93
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Num Down"
+msgstr "Le"
+
+#: ../src/common/accelcmn.cpp:94
+msgctxt "keyboard key"
+msgid "KP_PageUp"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:94
+msgctxt "keyboard key"
+msgid "Num Page Up"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:95
+msgctxt "keyboard key"
+msgid "KP_PageDown"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:95
+msgctxt "keyboard key"
+msgid "Num Page Down"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:96
+msgctxt "keyboard key"
+msgid "KP_Prior"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:97
+#, fuzzy
+msgctxt "keyboard key"
+msgid "KP_Next"
+msgstr "Következő "
+
+#: ../src/common/accelcmn.cpp:98
+msgctxt "keyboard key"
+msgid "KP_End"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:98
+msgctxt "keyboard key"
+msgid "Num End"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:99
+msgctxt "keyboard key"
+msgid "KP_Begin"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:99
+msgctxt "keyboard key"
+msgid "Num Begin"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:100
+#, fuzzy
+msgctxt "keyboard key"
+msgid "KP_Insert"
+msgstr "Bekezdés"
+
+#: ../src/common/accelcmn.cpp:100
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Num Insert"
+msgstr "Bekezdés"
+
+#: ../src/common/accelcmn.cpp:101
+#, fuzzy
+msgctxt "keyboard key"
+msgid "KP_Delete"
+msgstr "&Törlés"
+
+#: ../src/common/accelcmn.cpp:101
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Num Delete"
+msgstr "&Törlés"
+
+#: ../src/common/accelcmn.cpp:102
+msgctxt "keyboard key"
+msgid "KP_Equal"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:102
+msgctxt "keyboard key"
+msgid "Num ="
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:103
+msgctxt "keyboard key"
+msgid "KP_Multiply"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:103
+msgctxt "keyboard key"
+msgid "Num *"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:104
+msgctxt "keyboard key"
+msgid "KP_Add"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:104
+msgctxt "keyboard key"
+msgid "Num +"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:105
+msgctxt "keyboard key"
+msgid "KP_Separator"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:105
+msgctxt "keyboard key"
+msgid "Num ,"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:106
+msgctxt "keyboard key"
+msgid "KP_Subtract"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:106
+msgctxt "keyboard key"
+msgid "Num -"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:107
+msgctxt "keyboard key"
+msgid "KP_Decimal"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:107
+msgctxt "keyboard key"
+msgid "Num ."
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:108
+msgctxt "keyboard key"
+msgid "KP_Divide"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:108
+msgctxt "keyboard key"
+msgid "Num /"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:109
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Windows_Left"
+msgstr "Windows 95"
+
+#: ../src/common/accelcmn.cpp:110
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Windows_Right"
+msgstr "Windows 95"
+
+#: ../src/common/accelcmn.cpp:111
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Windows_Menu"
+msgstr "Windows ME"
+
+#: ../src/common/accelcmn.cpp:112
+msgctxt "keyboard key"
+msgid "Command"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:186 ../src/common/accelcmn.cpp:359
+msgctxt "keyboard key"
+msgid "Ctrl"
+msgstr "Ctrl"
+
+#: ../src/common/accelcmn.cpp:188 ../src/common/accelcmn.cpp:363
+msgctxt "keyboard key"
+msgid "Alt"
+msgstr "Alt"
+
+#: ../src/common/accelcmn.cpp:190 ../src/common/accelcmn.cpp:361
+msgctxt "keyboard key"
+msgid "Shift"
+msgstr "Shift"
+
+#: ../src/common/accelcmn.cpp:196
+msgctxt "keyboard key"
+msgid "num "
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:260 ../src/common/accelcmn.cpp:382
+msgctxt "keyboard key"
+msgid "F"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:277 ../src/common/accelcmn.cpp:385
+msgctxt "keyboard key"
+msgid "KP_F"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:280 ../src/common/accelcmn.cpp:388
+msgctxt "keyboard key"
+msgid "KP_"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:283 ../src/common/accelcmn.cpp:391
+msgctxt "keyboard key"
+msgid "SPECIAL"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:373
+#, fuzzy
+msgid "Ctrl"
+msgstr "Ctrl"
+
+#: ../src/common/appbase.cpp:786
+msgid "show this help message"
+msgstr "mutassa meg ezt az üzenetet a súgóban"
+
+#: ../src/common/appbase.cpp:796
+msgid "generate verbose log messages"
+msgstr "készíts bőbeszédű naplóbejegyzéseket "
+
+#: ../src/common/appcmn.cpp:256
+msgid "specify the theme to use"
+msgstr "jelölje ki a használandó bőrt"
+
+#: ../src/common/appcmn.cpp:270
+msgid "specify display mode to use (e.g. 640x480-16)"
+msgstr "jelölje ki a használandó megjelenítési módot (pl.. 640x480-16)"
+
+#: ../src/common/appcmn.cpp:292
+#, c-format
+msgid "Unsupported theme '%s'."
+msgstr "A(z) '%s' bőr nem támogatott."
+
+#: ../src/common/appcmn.cpp:309
+#, c-format
+msgid "Invalid display mode specification '%s'."
+msgstr "Hibás megjelenítési mód meghatározás: '%s'."
+
+#: ../src/common/cmdline.cpp:875
+#, fuzzy, c-format
+msgid "Option '%s' can't be negated"
+msgstr "Nem sikerült létrehozni a(z) '%s' könyvtárat"
+
+#: ../src/common/cmdline.cpp:889
+#, c-format
+msgid "Unknown long option '%s'"
+msgstr "Ismeretlen hosszú opció '%s'"
+
+#: ../src/common/cmdline.cpp:904 ../src/common/cmdline.cpp:926
+#, c-format
+msgid "Unknown option '%s'"
+msgstr "Ismeretlen opció '%s'"
+
+#: ../src/common/cmdline.cpp:1004
+#, fuzzy, c-format
+msgid "Unexpected characters following option '%s'."
+msgstr "Váratlan '%s' paraméter"
+
+#: ../src/common/cmdline.cpp:1039
+#, c-format
+msgid "Option '%s' requires a value."
+msgstr "A(z) '%s' beállítás egy értéket kér."
+
+#: ../src/common/cmdline.cpp:1058
+#, c-format
+msgid "Separator expected after the option '%s'."
+msgstr "A(z) '%s' választási lehetőség után elválasztó jelet vártam."
+
+#: ../src/common/cmdline.cpp:1088 ../src/common/cmdline.cpp:1106
+#, c-format
+msgid "'%s' is not a correct numeric value for option '%s'."
+msgstr "'%s' nem megfelelő számérték a(z) '%s' beállításához."
+
+#: ../src/common/cmdline.cpp:1122
+#, c-format
+msgid "Option '%s': '%s' cannot be converted to a date."
+msgstr "A(z) '%s' beállítása: '%s' nem alakítható át dátummá."
+
+#: ../src/common/cmdline.cpp:1170
+#, c-format
+msgid "Unexpected parameter '%s'"
+msgstr "Váratlan '%s' paraméter"
+
+#. TRANSLATORS: Short name and long name for a command line option
+#: ../src/common/cmdline.cpp:1197
+#, c-format
+msgid "%s (or %s)"
+msgstr "%s (vagy %s)"
+
+#: ../src/common/cmdline.cpp:1208
+#, c-format
+msgid "The value for the option '%s' must be specified."
+msgstr "A(z) '%s' beállítás értékét meg kell adni."
+
+#: ../src/common/cmdline.cpp:1230
+#, c-format
+msgid "The required parameter '%s' was not specified."
+msgstr "A szükséges '%s' paraméter nincs megadva."
+
+#: ../src/common/cmdline.cpp:1289
+#, c-format
+msgid "Usage: %s"
+msgstr "Használat: %s"
+
+#: ../src/common/cmdline.cpp:1498
+msgid "str"
+msgstr "str"
+
+#: ../src/common/cmdline.cpp:1502
+msgid "num"
+msgstr "num"
+
+#: ../src/common/cmdline.cpp:1506
+msgid "double"
+msgstr ""
+
+#: ../src/common/cmdline.cpp:1510
+msgid "date"
+msgstr "dátum"
+
+#: ../src/common/cmdproc.cpp:250 ../src/common/cmdproc.cpp:276
+#: ../src/common/cmdproc.cpp:296
+msgid "Unnamed command"
+msgstr "Név nélküli parancs"
+
+#: ../src/common/cmdproc.cpp:253
+msgid "&Undo "
+msgstr "&Visszavonás"
+
+#: ../src/common/cmdproc.cpp:255
+msgid "Can't &Undo "
+msgstr "Nem lehet &Visszavonni"
+
+#: ../src/common/cmdproc.cpp:259 ../src/common/stockitem.cpp:208
+#: ../src/msw/textctrl.cpp:2880 ../src/osx/textctrl_osx.cpp:649
+#: ../src/richtext/richtextctrl.cpp:327
+msgid "&Undo"
+msgstr "&Visszavonás"
+
+#: ../src/common/cmdproc.cpp:277 ../src/common/cmdproc.cpp:297
+msgid "&Redo "
+msgstr "&Újra"
+
+#: ../src/common/cmdproc.cpp:281 ../src/common/cmdproc.cpp:288
+#: ../src/common/stockitem.cpp:190 ../src/msw/textctrl.cpp:2881
+#: ../src/osx/textctrl_osx.cpp:650 ../src/richtext/richtextctrl.cpp:328
+msgid "&Redo"
+msgstr "&Újra"
+
+#: ../src/common/colourcmn.cpp:41
+#, c-format
+msgid "String To Colour : Incorrect colour specification : %s"
+msgstr "Szöveget színné: Helytelen szín meghatározás '%s'"
+
+#: ../src/common/config.cpp:259
+#, c-format
+msgid "Invalid value %ld for a boolean key \"%s\" in config file."
+msgstr ""
+
+#: ../src/common/config.cpp:526
+#, c-format
+msgid ""
+"Environment variables expansion failed: missing '%c' at position %u in '%s'."
+msgstr ""
+"A környezeti változók kifejtése nem sikerült: hiányzik '%c' a(z) %u helyen "
+"'%s'-ból."
+
+#: ../src/common/config.cpp:576 ../src/msw/regconf.cpp:272
+#, c-format
+msgid "'%s' has extra '..', ignored."
+msgstr "'%s' után felesleges '..'-t találtam, elhanyagoltam."
+
+#. TRANSLATORS: Checkbox state name
+#: ../src/common/datavcmn.cpp:2166 ../src/generic/datavgen.cpp:1430
+msgid "checked"
+msgstr ""
+
+#. TRANSLATORS: Checkbox state name
+#: ../src/common/datavcmn.cpp:2170 ../src/generic/datavgen.cpp:1432
+msgid "unchecked"
+msgstr ""
+
+#. TRANSLATORS: Checkbox state name
+#: ../src/common/datavcmn.cpp:2174
+#, fuzzy
+msgid "undetermined"
+msgstr "aláhúzott"
+
+#: ../src/common/datetimefmt.cpp:1875
+msgid "today"
+msgstr "ma"
+
+#: ../src/common/datetimefmt.cpp:1876
+msgid "yesterday"
+msgstr "tegnap"
+
+#: ../src/common/datetimefmt.cpp:1877
+msgid "tomorrow"
+msgstr "holnap"
+
+#: ../src/common/datetimefmt.cpp:2071
+msgid "first"
+msgstr "első"
+
+#: ../src/common/datetimefmt.cpp:2072
+msgid "second"
+msgstr "második"
+
+#: ../src/common/datetimefmt.cpp:2073
+msgid "third"
+msgstr "harmadik"
+
+#: ../src/common/datetimefmt.cpp:2074
+msgid "fourth"
+msgstr "negyedik"
+
+#: ../src/common/datetimefmt.cpp:2075
+msgid "fifth"
+msgstr "ötödik"
+
+#: ../src/common/datetimefmt.cpp:2076
+msgid "sixth"
+msgstr "hatodik"
+
+#: ../src/common/datetimefmt.cpp:2077
+msgid "seventh"
+msgstr "hetedik"
+
+#: ../src/common/datetimefmt.cpp:2078
+msgid "eighth"
+msgstr "nyolcadik"
+
+#: ../src/common/datetimefmt.cpp:2079
+msgid "ninth"
+msgstr "kilencedik"
+
+#: ../src/common/datetimefmt.cpp:2080
+msgid "tenth"
+msgstr "tizedik"
+
+#: ../src/common/datetimefmt.cpp:2081
+msgid "eleventh"
+msgstr "tizenegyedik"
+
+#: ../src/common/datetimefmt.cpp:2082
+msgid "twelfth"
+msgstr "tizenkettedik"
+
+#: ../src/common/datetimefmt.cpp:2083
+msgid "thirteenth"
+msgstr "tizenharmadik"
+
+#: ../src/common/datetimefmt.cpp:2084
+msgid "fourteenth"
+msgstr "tizennegyedik"
+
+#: ../src/common/datetimefmt.cpp:2085
+msgid "fifteenth"
+msgstr "tizenötödik"
+
+#: ../src/common/datetimefmt.cpp:2086
+msgid "sixteenth"
+msgstr "tizenhatodik"
+
+#: ../src/common/datetimefmt.cpp:2087
+msgid "seventeenth"
+msgstr "tizenhetedik"
+
+#: ../src/common/datetimefmt.cpp:2088
+msgid "eighteenth"
+msgstr "tizennyolcadik"
+
+#: ../src/common/datetimefmt.cpp:2089
+msgid "nineteenth"
+msgstr "tizenkilencedik"
+
+#: ../src/common/datetimefmt.cpp:2090
+msgid "twentieth"
+msgstr "huszadik"
+
+#: ../src/common/datetimefmt.cpp:2248
+msgid "noon"
+msgstr "dél"
+
+#: ../src/common/datetimefmt.cpp:2249
+msgid "midnight"
+msgstr "éjfél"
+
+#: ../src/common/debugrpt.cpp:209
+#, c-format
+msgid "Failed to create directory \"%s\""
+msgstr "Nem sikerült létrehozni a(z) \"%s\" könyvtárat"
+
+#: ../src/common/debugrpt.cpp:210
+msgid "Debug report couldn't be created."
+msgstr "Nem sikerült létrehozni a(z) '%s' könyvtárat."
+
+#: ../src/common/debugrpt.cpp:227
+#, c-format
+msgid "Failed to remove debug report file \"%s\""
+msgstr ""
+"Nem tudom eltávolítani a(z) '%s' hibekeresési jelentést tartalmazó fájlt."
+
+#: ../src/common/debugrpt.cpp:239
+#, c-format
+msgid "Failed to clean up debug report directory \"%s\""
+msgstr "Nem sikerült létrehozni a(z) hibakeresési jelentések \"%s\" könyvtárát"
+
+#: ../src/common/debugrpt.cpp:514
+msgid "process context description"
+msgstr "a folyamat jellemzőinek leírása"
+
+#: ../src/common/debugrpt.cpp:538
+msgid "dump of the process state (binary)"
+msgstr "a folyamat állapotának (bináris) nyomtatása"
+
+#: ../src/common/debugrpt.cpp:553
+msgid "Debug report generation has failed."
+msgstr "A hibakeresésről nem sikerült jelentést készíteni."
+
+#: ../src/common/debugrpt.cpp:560
+#, c-format
+msgid ""
+"Processing debug report has failed, leaving the files in \"%s\" directory."
+msgstr ""
+"A hibakeresési jelentés feldolgozása nem sikerült, a fájlokat a(z) \"%s\" "
+"könyvtárban hagytam."
+
+#: ../src/common/debugrpt.cpp:573
+#, fuzzy
+msgid "A debug report has been generated. It can be found in"
+msgstr "A hibakeresésről a jelentés ebben a könyvtárban van\n"
+
+#: ../src/common/debugrpt.cpp:576
+#, fuzzy
+msgid "And includes the following files:\n"
+msgstr "*** És a következő fájlokat tartalmazza:\n"
+
+#: ../src/common/debugrpt.cpp:586
+msgid ""
+"\n"
+"Please send this report to the program maintainer, thank you!\n"
+msgstr ""
+"\n"
+"Kérem küldje el ezt a jelentést a program karbantartójának! Köszönöm.\n"
+
+#: ../src/common/debugrpt.cpp:729
+msgid "Failed to execute curl, please install it in PATH."
+msgstr "Nem sikerült a curl-t végrehajtani, kérem tegye elérhetővé a PATH-on."
+
+#: ../src/common/debugrpt.cpp:742
+#, c-format
+msgid "Failed to upload the debug report (error code %d)."
+msgstr "Nem sikerült létrehozni a hibakereső jelentéstt (hibakód : %d) "
+
+#: ../src/common/docview.cpp:366
+msgid "Save As"
+msgstr "Mentés Másként"
+
+#: ../src/common/docview.cpp:457
+msgid "Discard changes and reload the last saved version?"
+msgstr ""
+
+#: ../src/common/docview.cpp:488
+msgid "unnamed"
+msgstr "névtelen"
+
+#: ../src/common/docview.cpp:513
+#, fuzzy, c-format
+msgid "Do you want to save changes to %s?"
+msgstr "Elmentsem a(z) %s dokument változásait?"
+
+#: ../src/common/docview.cpp:521 ../src/common/docview.cpp:560
+#: ../src/common/stockitem.cpp:195
+msgid "&Save"
+msgstr "&Mentés"
+
+#: ../src/common/docview.cpp:522 ../src/common/docview.cpp:560
+msgid "&Discard changes"
+msgstr ""
+
+#: ../src/common/docview.cpp:523
+#, fuzzy
+msgid "Do&n't close"
+msgstr "Ne mentsd el"
+
+#: ../src/common/docview.cpp:553
+#, fuzzy, c-format
+msgid "Do you want to save changes to %s before closing it?"
+msgstr "Elmentsem a(z) %s dokument változásait?"
+
+#: ../src/common/docview.cpp:559
+#, fuzzy
+msgid "The document must be closed."
+msgstr "A szöveget nem tudom elmenteni."
+
+#: ../src/common/docview.cpp:571
+#, c-format
+msgid "Saving %s failed, would you like to retry?"
+msgstr ""
+
+#: ../src/common/docview.cpp:577
+msgid "Retry"
+msgstr ""
+
+#: ../src/common/docview.cpp:577
+msgid "Discard changes"
+msgstr ""
+
+#: ../src/common/docview.cpp:679
+#, fuzzy, c-format
+msgid "File \"%s\" could not be opened for writing."
+msgstr "Nem tudtam megnyitni '%s'-t %s-ként."
+
+#: ../src/common/docview.cpp:685
+#, fuzzy, c-format
+msgid "Failed to save document to the file \"%s\"."
+msgstr "Nem tudtam elmenteni a bittérképet a(z)  '%s' fájlba."
+
+#: ../src/common/docview.cpp:702
+#, fuzzy, c-format
+msgid "File \"%s\" could not be opened for reading."
+msgstr "Nem tudtam megnyitni '%s'-t %s-ként."
+
+#: ../src/common/docview.cpp:714
+#, fuzzy, c-format
+msgid "Failed to read document from the file \"%s\"."
+msgstr "Nem tudtam betölteni a metafájlt a(z)  '%s' fájlból."
+
+#: ../src/common/docview.cpp:1236
+#, c-format
+msgid ""
+"The file '%s' doesn't exist and couldn't be opened.\n"
+"It has been removed from the most recently used files list."
+msgstr ""
+"A(z) '%s' fájl nem létezik és nem nyitható meg.\n"
+"A legutóbb használt fájlok listájáról is el van távolítva."
+
+#: ../src/common/docview.cpp:1296
+#, fuzzy
+msgid "Print preview creation failed."
+msgstr "A cső létrehozása nem sikerült"
+
+#: ../src/common/docview.cpp:1302
+msgid "Print Preview"
+msgstr "Nyomtatási kép"
+
+#: ../src/common/docview.cpp:1517
+#, fuzzy, c-format
+msgid "The format of file '%s' couldn't be determined."
+msgstr "Nem sikerült létrehozni a(z) '%s' könyvtárat"
+
+#: ../src/common/docview.cpp:1643
+#, c-format
+msgid "unnamed%d"
+msgstr "névtelen%d"
+
+#: ../src/common/docview.cpp:1660
+msgid " - "
+msgstr " - "
+
+#: ../src/common/docview.cpp:1791 ../src/common/docview.cpp:1844
+msgid "Open File"
+msgstr "Fájl Megnyitás"
+
+#: ../src/common/docview.cpp:1807
+msgid "File error"
+msgstr "Fájl hiba"
+
+#: ../src/common/docview.cpp:1809
+msgid "Sorry, could not open this file."
+msgstr "Sajnálom, nem tudtam megnyitni ezt a fájlt."
+
+#: ../src/common/docview.cpp:1843
+msgid "Sorry, the format for this file is unknown."
+msgstr "Sajnálom, ezt a fájl formátumot nem ismerem."
+
+#: ../src/common/docview.cpp:1924
+msgid "Select a document template"
+msgstr "Válasszon dokumentum mintát"
+
+#: ../src/common/docview.cpp:1925
+msgid "Templates"
+msgstr "Minták"
+
+#: ../src/common/docview.cpp:1998
+msgid "Select a document view"
+msgstr "Válasszon dokumentum nézetet"
+
+#: ../src/common/docview.cpp:1999
+msgid "Views"
+msgstr "Nézetek"
+
+#: ../src/common/dynlib.cpp:81
+#, c-format
+msgid "Failed to load shared library '%s'"
+msgstr "Nem tudtam betölteni a(z) '%s' osztott könyvtárat."
+
+#: ../src/common/dynlib.cpp:105
+#, c-format
+msgid "Couldn't find symbol '%s' in a dynamic library"
+msgstr "Nem találom a(z) '%s' szimbólumot a dinamikus könyvtárban"
+
+#: ../src/common/ffile.cpp:56 ../src/common/file.cpp:215
+#, c-format
+msgid "can't open file '%s'"
+msgstr "nem tudom megnyitni a(z) '%s' fájlt"
+
+#: ../src/common/ffile.cpp:72
+#, c-format
+msgid "can't close file '%s'"
+msgstr "nem tudom lezárni a(z) '%s' fájlt."
+
+#: ../src/common/ffile.cpp:106 ../src/common/ffile.cpp:131
+#, c-format
+msgid "Read error on file '%s'"
+msgstr "Olvasási hiba a(z) '%s' fájlban"
+
+#: ../src/common/ffile.cpp:148
+#, c-format
+msgid "Write error on file '%s'"
+msgstr "Irási hiba a(z) '%s' fájlban"
+
+#: ../src/common/ffile.cpp:182
+#, c-format
+msgid "failed to flush the file '%s'"
+msgstr "nem sikerült kiüríteni a(z) '%s' fájl pufferét"
+
+#: ../src/common/ffile.cpp:222
+#, c-format
+msgid "Seek error on file '%s' (large files not supported by stdio)"
+msgstr ""
+"Keresési hiba a(z) '%s' fájlban (a nagy fájlokat nem támogatja a stdio)"
+
+#: ../src/common/ffile.cpp:232
+#, c-format
+msgid "Seek error on file '%s'"
+msgstr "Keresési hiba a(z) '%s' fájlban"
+
+#: ../src/common/ffile.cpp:248
+#, c-format
+msgid "Can't find current position in file '%s'"
+msgstr "Nem találom a(z) '%s' fájlban a jelenlegi pozíciót"
+
+#: ../src/common/ffile.cpp:349 ../src/common/file.cpp:569
+msgid "Failed to set temporary file permissions"
+msgstr "Nem tudtam az átmeneti fájl engedélyeit beállítani."
+
+#: ../src/common/ffile.cpp:371
+#, c-format
+msgid "can't remove file '%s'"
+msgstr "nem tudom eltávolítani a(z) '%s' fájlt"
+
+#: ../src/common/ffile.cpp:376 ../src/common/file.cpp:591
+#, c-format
+msgid "can't commit changes to file '%s'"
+msgstr "nem tudom érvényre juttatni a(z) '%s' fájl változásait"
+
+#: ../src/common/ffile.cpp:388 ../src/common/file.cpp:603
+#, c-format
+msgid "can't remove temporary file '%s'"
+msgstr "nem tudom eltávolítani a(z) '%s' átmeneti fájlt"
+
+#: ../src/common/file.cpp:162
+#, c-format
+msgid "can't create file '%s'"
+msgstr "nem tudom létrehozni a(z) '%s' fájl-t"
+
+#: ../src/common/file.cpp:229
+#, c-format
+msgid "can't close file descriptor %d"
+msgstr "nem tudom lezárni a(z) %d fájl leírót"
+
+#: ../src/common/file.cpp:332
+#, c-format
+msgid "can't read from file descriptor %d"
+msgstr "nem tudok olvasni a(z) %d leíróval megadott fájból"
+
+#: ../src/common/file.cpp:351
+#, c-format
+msgid "can't write to file descriptor %d"
+msgstr "nem tudok írni a(z) %d leíróval megadott fájba"
+
+#: ../src/common/file.cpp:390
+#, c-format
+msgid "can't flush file descriptor %d"
+msgstr "nem tudom kiüríteni a(z) %d leíróval megadott fájl pufferét"
+
+#: ../src/common/file.cpp:432
+#, c-format
+msgid "can't seek on file descriptor %d"
+msgstr "nem tudok keresni a(z) %d leíróval megadott fájlban"
+
+#: ../src/common/file.cpp:446
+#, c-format
+msgid "can't get seek position on file descriptor %d"
+msgstr "nem találom a keresési pozíciót a(z) %d leíróval megadott fájlban"
+
+#: ../src/common/file.cpp:475
+#, c-format
+msgid "can't find length of file on file descriptor %d"
+msgstr ""
+"nem tudom meghatározni a fájl hosszát a(z) %d leíróval megadott fájlban"
+
+#: ../src/common/file.cpp:505
+#, c-format
+msgid "can't determine if the end of file is reached on descriptor %d"
+msgstr ""
+"nem tudom meghatározni, hogy a fájl végét értük-e el a(z) %d leíróval "
+"megadott fájlban"
+
+#: ../src/common/fileconf.cpp:352
+#, c-format
+msgid ""
+" and additionally, the existing configuration file was renamed to \"%s\" and "
+"couldn't be renamed back, please rename it to its original path \"%s\""
+msgstr ""
+
+#: ../src/common/fileconf.cpp:389
+#, fuzzy
+msgid " due to the following error:\n"
+msgstr "*** És a következő fájlokat tartalmazza:\n"
+
+#: ../src/common/fileconf.cpp:412
+#, fuzzy
+msgid "failed to rename the existing file"
+msgstr "Nem tudtam betölteni a metafájlt a(z)  '%s' fájlból."
+
+#: ../src/common/fileconf.cpp:421
+#, fuzzy
+msgid "failed to create the new file directory"
+msgstr "Nem sikerült létrehozni a munkakönyvtárat."
+
+#: ../src/common/fileconf.cpp:428
+#, fuzzy
+msgid "failed to move the file to the new location"
+msgstr "Nem tudtam befejezni a(z) %s telefon kapcsolatot."
+
+#: ../src/common/fileconf.cpp:462
+#, c-format
+msgid "can't open global configuration file '%s'."
+msgstr "nem tudom megnyitni a(z) '%s' globális konfigurációs fájlt."
+
+#: ../src/common/fileconf.cpp:478
+#, c-format
+msgid "can't open user configuration file '%s'."
+msgstr "nem tudom megnyitni a(z) '%s' felhasználói konfigurációs fájlt."
+
+#: ../src/common/fileconf.cpp:483
+#, c-format
+msgid "Changes won't be saved to avoid overwriting the existing file \"%s\""
+msgstr ""
+
+#: ../src/common/fileconf.cpp:583
+msgid "Error reading config options."
+msgstr "Hiba a konfigurációs beállítások olvasásakor."
+
+#: ../src/common/fileconf.cpp:593
+#, fuzzy
+msgid "Failed to read config options."
+msgstr "Hiba a konfigurációs beállítások olvasásakor."
+
+#: ../src/common/fileconf.cpp:700
+#, fuzzy, c-format
+msgid "file '%s': unexpected character %c at line %zu."
+msgstr "'%s' fájl: a(z) %c nem várt jel a(z) %d sorban."
+
+#: ../src/common/fileconf.cpp:736
+#, fuzzy, c-format
+msgid "file '%s', line %zu: '%s' ignored after group header."
+msgstr "'%s' fájl, %d. sor: '%s' -t elhanyagoltam a csoport fejléce után."
+
+#: ../src/common/fileconf.cpp:765
+#, fuzzy, c-format
+msgid "file '%s', line %zu: '=' expected."
+msgstr "'%s' fájl, %d. sor: '=' -t vártam."
+
+#: ../src/common/fileconf.cpp:778
+#, fuzzy, c-format
+msgid "file '%s', line %zu: value for immutable key '%s' ignored."
+msgstr ""
+"file '%s', line %d: a változtathatatlan '%s' kulcs új értékét elhanyagoltam."
+
+#: ../src/common/fileconf.cpp:788
+#, fuzzy, c-format
+msgid "file '%s', line %zu: key '%s' was first found at line %d."
+msgstr ""
+"'%s' fájl, %d. sor: a(z) '%s' kulcsot először a(z) %d sorban találtam meg."
+
+#: ../src/common/fileconf.cpp:1091
+#, c-format
+msgid "Config entry name cannot start with '%c'."
+msgstr "Konfigurációs bejegyzés nem kezdődhet '%c'-vel."
+
+#: ../src/common/fileconf.cpp:1146
+#, fuzzy
+msgid "Failed to create configuration file directory."
+msgstr "Nem tudom frissíteni a felhasználó konfigurációs fájlját."
+
+#: ../src/common/fileconf.cpp:1158
+msgid "can't open user configuration file."
+msgstr "nem tudom megnyitni a felhasználó konfigurációs fájlját."
+
+#: ../src/common/fileconf.cpp:1172
+msgid "can't write user configuration file."
+msgstr "nem tudom írni a felhasználó konfigurációs fájlját."
+
+#: ../src/common/fileconf.cpp:1178
+msgid "Failed to update user configuration file."
+msgstr "Nem tudom frissíteni a felhasználó konfigurációs fájlját."
+
+#: ../src/common/fileconf.cpp:1201
+msgid "Error saving user configuration data."
+msgstr "Hiba a felhasználói konfigurációs beállítások elmentésekor."
+
+#: ../src/common/fileconf.cpp:1313
+#, c-format
+msgid "can't delete user configuration file '%s'"
+msgstr "nem tudom törölni a(z) '%s' felhasználói konfigurációs fájlt"
+
+#: ../src/common/fileconf.cpp:2007
+#, c-format
+msgid "entry '%s' appears more than once in group '%s'"
+msgstr "a(z) '%s' elem egynél többször jelenik meg a(z) '%s' csoportban"
+
+#: ../src/common/fileconf.cpp:2021
+#, c-format
+msgid "attempt to change immutable key '%s' ignored."
+msgstr ""
+"elhanyagoltam a változtathatatlan '%s' kulcs megváltoztatására tett "
+"kísérletét."
+
+#: ../src/common/fileconf.cpp:2118
+#, c-format
+msgid "trailing backslash ignored in '%s'"
+msgstr ""
+
+#: ../src/common/fileconf.cpp:2153
+#, c-format
+msgid "unexpected \" at position %d in '%s'."
+msgstr "váratlan \" a(z) %d pozícióban, a(z) '%s' fájlban."
+
+#: ../src/common/filefn.cpp:474
+#, c-format
+msgid "Failed to copy the file '%s' to '%s'"
+msgstr "Nem sikerült lemásolni a(z) '%s' fájlt  '%s'-be."
+
+#: ../src/common/filefn.cpp:487
+#, c-format
+msgid "Impossible to get permissions for file '%s'"
+msgstr "Nem kapom meg a '%s' fájl engedélyeit."
+
+#: ../src/common/filefn.cpp:501
+#, c-format
+msgid "Impossible to overwrite the file '%s'"
+msgstr "Nem sikerült felülírni ni a(z) '%s' fájlt."
+
+#: ../src/common/filefn.cpp:508
+#, fuzzy, c-format
+msgid "Error copying the file '%s' to '%s'."
+msgstr "Nem sikerült lemásolni a(z) '%s' fájlt  '%s'-be."
+
+#: ../src/common/filefn.cpp:556
+#, c-format
+msgid "Impossible to set permissions for the file '%s'"
+msgstr "Nem lehet beállítani a  '%s' fájl engedélyeit."
+
+#: ../src/common/filefn.cpp:606
+#, c-format
+msgid ""
+"Failed to rename the file '%s' to '%s' because the destination file already "
+"exists."
+msgstr ""
+
+#: ../src/common/filefn.cpp:623
+#, fuzzy, c-format
+msgid "File '%s' couldn't be renamed '%s'"
+msgstr "Nem sikerült létrehozni a(z) '%s' könyvtárat"
+
+#: ../src/common/filefn.cpp:639
+#, fuzzy, c-format
+msgid "File '%s' couldn't be removed"
+msgstr "Nem sikerült létrehozni a(z) '%s' könyvtárat"
+
+#: ../src/common/filefn.cpp:666
+#, c-format
+msgid "Directory '%s' couldn't be created"
+msgstr "Nem sikerült létrehozni a(z) '%s' könyvtárat"
+
+#: ../src/common/filefn.cpp:680
+#, fuzzy, c-format
+msgid "Directory '%s' couldn't be deleted"
+msgstr "Nem sikerült létrehozni a(z) '%s' könyvtárat"
+
+#: ../src/common/filefn.cpp:714
+#, c-format
+msgid "Cannot enumerate files '%s'"
+msgstr "Nem tudom megszámolni a(z) '%s'  fájlokat"
+
+#: ../src/common/filefn.cpp:798
+msgid "Failed to get the working directory"
+msgstr "Nem sikerült létrehozni a munkakönyvtárat."
+
+#: ../src/common/filefn.cpp:843
+#, fuzzy
+msgid "Could not set current working directory"
+msgstr "Nem sikerült létrehozni a munkakönyvtárat."
+
+#: ../src/common/filefn.cpp:974
+#, c-format
+msgid "Files (%s)"
+msgstr "Fájlok (%s)"
+
+#: ../src/common/filename.cpp:182
+#, fuzzy, c-format
+msgid "Failed to open '%s' for reading"
+msgstr "Nem tudtam megnyitni '%s'-t %s-ként."
+
+#: ../src/common/filename.cpp:187
+#, fuzzy, c-format
+msgid "Failed to open '%s' for writing"
+msgstr "Nem tudtam megnyitni '%s'-t %s-ként."
+
+#: ../src/common/filename.cpp:199
+msgid "Failed to close file handle"
+msgstr "Nem sikerült lezárni a file kezelőt."
+
+#: ../src/common/filename.cpp:1046
+msgid "Failed to create a temporary file name"
+msgstr "Nem sikerült létrehozni átmeneti fájlnevet."
+
+#: ../src/common/filename.cpp:1081
+msgid "Failed to open temporary file."
+msgstr "Nem tudtam megnyitni az átmeneti fájlt."
+
+#: ../src/common/filename.cpp:2862
+#, c-format
+msgid "Failed to modify file times for '%s'"
+msgstr "Nem sikerült módosítani a(z) időket '%s'-re."
+
+#: ../src/common/filename.cpp:2877
+#, c-format
+msgid "Failed to touch the file '%s'"
+msgstr "Nem sikerült megérinteni a(z) '%s't."
+
+#: ../src/common/filename.cpp:2958
+#, c-format
+msgid "Failed to retrieve file times for '%s'"
+msgstr "Nem sikerült helyrehozni a fájl időket '%s'-re."
+
+#: ../src/common/filepickercmn.cpp:39 ../src/common/filepickercmn.cpp:40
+msgid "Browse"
+msgstr ""
+
+#: ../src/common/fldlgcmn.cpp:792 ../src/generic/filectrlg.cpp:1185
+#, c-format
+msgid "All files (%s)|%s"
+msgstr "Minden fájlt (%s)|%s"
+
+#. TRANSLATORS: %s are a file extension used to build a file wildcard string
+#: ../src/common/fldlgcmn.cpp:810
+#, c-format
+msgid "%s files (%s)|%s"
+msgstr "%s fájl (%s)|%s"
+
+#: ../src/common/fldlgcmn.cpp:1072
+#, c-format
+msgid "Load %s file"
+msgstr "A(z) %s fájl betöltése"
+
+#: ../src/common/fldlgcmn.cpp:1074
+#, c-format
+msgid "Save %s file"
+msgstr "A(z) %s fájl elmentése"
+
+#: ../src/common/fmapbase.cpp:144
+msgid "Western European (ISO-8859-1)"
+msgstr "Nyugat-európai (ISO-8859-1)"
+
+#: ../src/common/fmapbase.cpp:145
+msgid "Central European (ISO-8859-2)"
+msgstr "Közép-európai (ISO-8859-2)"
+
+#: ../src/common/fmapbase.cpp:146
+msgid "Esperanto (ISO-8859-3)"
+msgstr "Eszperantó (ISO-8859-3)"
+
+#: ../src/common/fmapbase.cpp:147
+msgid "Baltic (old) (ISO-8859-4)"
+msgstr "Balti (régi) (ISO-8859-4)"
+
+#: ../src/common/fmapbase.cpp:148
+msgid "Cyrillic (ISO-8859-5)"
+msgstr "Ciril (ISO-8859-5)"
+
+#: ../src/common/fmapbase.cpp:149
+msgid "Arabic (ISO-8859-6)"
+msgstr "Arab (ISO-8859-6)"
+
+#: ../src/common/fmapbase.cpp:150
+msgid "Greek (ISO-8859-7)"
+msgstr "Görög (ISO-8859-7)"
+
+#: ../src/common/fmapbase.cpp:151
+msgid "Hebrew (ISO-8859-8)"
+msgstr "Héber (ISO-8859-8)"
+
+#: ../src/common/fmapbase.cpp:152
+msgid "Turkish (ISO-8859-9)"
+msgstr "Török (ISO-8859-9)"
+
+#: ../src/common/fmapbase.cpp:153
+msgid "Nordic (ISO-8859-10)"
+msgstr "Északi (ISO-8859-10)"
+
+#: ../src/common/fmapbase.cpp:154
+msgid "Thai (ISO-8859-11)"
+msgstr "Thai (ISO-8859-11)"
+
+#: ../src/common/fmapbase.cpp:155
+msgid "Indian (ISO-8859-12)"
+msgstr "Indiai  (ISO-8859-12)"
+
+#: ../src/common/fmapbase.cpp:156
+msgid "Baltic (ISO-8859-13)"
+msgstr "Balti (ISO-8859-13)"
+
+#: ../src/common/fmapbase.cpp:157
+msgid "Celtic (ISO-8859-14)"
+msgstr "Kelta (ISO-8859-14)"
+
+#: ../src/common/fmapbase.cpp:158
+msgid "Western European with Euro (ISO-8859-15)"
+msgstr "Nyugat-európai Euro-val (ISO-8859-15)"
+
+#: ../src/common/fmapbase.cpp:159
+msgid "KOI8-R"
+msgstr "KOI8-R"
+
+#: ../src/common/fmapbase.cpp:160
+msgid "KOI8-U"
+msgstr "KOI8-U"
+
+#: ../src/common/fmapbase.cpp:161
+#, fuzzy
+msgid "Windows/DOS OEM Cyrillic (CP 866)"
+msgstr "Windows Orosz (CP 1251)"
+
+#: ../src/common/fmapbase.cpp:162
+msgid "Windows Thai (CP 874)"
+msgstr "Windows Thai (CP 874)"
+
+#: ../src/common/fmapbase.cpp:163
+#, fuzzy
+msgid "Windows Japanese (CP 932) or Shift-JIS"
+msgstr "Windows japán (CP 932)"
+
+#: ../src/common/fmapbase.cpp:164
+#, fuzzy
+msgid "Windows Chinese Simplified (CP 936) or GB-2312"
+msgstr "Windows egyszerűsített kínai (CP 936)"
+
+#: ../src/common/fmapbase.cpp:165
+msgid "Windows Korean (CP 949)"
+msgstr "Windows koreai (CP 949)"
+
+#: ../src/common/fmapbase.cpp:166
+#, fuzzy
+msgid "Windows Chinese Traditional (CP 950) or Big-5"
+msgstr "Windows hagyományos kínai (CP 950)"
+
+#: ../src/common/fmapbase.cpp:167
+msgid "Windows Central European (CP 1250)"
+msgstr "Windows Közép-európai (CP 1250)"
+
+#: ../src/common/fmapbase.cpp:168
+msgid "Windows Cyrillic (CP 1251)"
+msgstr "Windows Orosz (CP 1251)"
+
+#: ../src/common/fmapbase.cpp:169
+msgid "Windows Western European (CP 1252)"
+msgstr "Windows Nyugat-európai (CP 1252)"
+
+#: ../src/common/fmapbase.cpp:170
+msgid "Windows Greek (CP 1253)"
+msgstr "Windows Görög (CP 1253)"
+
+#: ../src/common/fmapbase.cpp:171
+msgid "Windows Turkish (CP 1254)"
+msgstr "Windows Török (CP 1254)"
+
+#: ../src/common/fmapbase.cpp:172
+msgid "Windows Hebrew (CP 1255)"
+msgstr "Windows Héber (CP 1255)"
+
+#: ../src/common/fmapbase.cpp:173
+msgid "Windows Arabic (CP 1256)"
+msgstr "Windows Arab (CP 1256)"
+
+#: ../src/common/fmapbase.cpp:174
+msgid "Windows Baltic (CP 1257)"
+msgstr "Windows Balti (CP 1257)"
+
+#: ../src/common/fmapbase.cpp:175
+#, fuzzy
+msgid "Windows Vietnamese (CP 1258)"
+msgstr "Windows Görög (CP 1253)"
+
+#: ../src/common/fmapbase.cpp:176
+#, fuzzy
+msgid "Windows Johab (CP 1361)"
+msgstr "Windows Arab (CP 1256)"
+
+#: ../src/common/fmapbase.cpp:177
+msgid "Windows/DOS OEM (CP 437)"
+msgstr "Windows/DOS OEM (CP 437)"
+
+#: ../src/common/fmapbase.cpp:178
+msgid "Unicode 7 bit (UTF-7)"
+msgstr "Unicode 7 bit (UTF-7)"
+
+#: ../src/common/fmapbase.cpp:179
+msgid "Unicode 8 bit (UTF-8)"
+msgstr "Unicode 8 bit (UTF-8)"
+
+#: ../src/common/fmapbase.cpp:181 ../src/common/fmapbase.cpp:187
+msgid "Unicode 16 bit (UTF-16)"
+msgstr "Unicode 16 bit (UTF-16)"
+
+#: ../src/common/fmapbase.cpp:182
+msgid "Unicode 16 bit Little Endian (UTF-16LE)"
+msgstr "Unicode 16 bit Little Endian (UTF-16LE)"
+
+#: ../src/common/fmapbase.cpp:183 ../src/common/fmapbase.cpp:189
+msgid "Unicode 32 bit (UTF-32)"
+msgstr "Unicode 32 bit (UTF-32)"
+
+#: ../src/common/fmapbase.cpp:184
+msgid "Unicode 32 bit Little Endian (UTF-32LE)"
+msgstr "Unicode 32 bit Little Endian (UTF-32LE)"
+
+#: ../src/common/fmapbase.cpp:186
+msgid "Unicode 16 bit Big Endian (UTF-16BE)"
+msgstr "Unicode 16 bit Big Endian (UTF-16BE)"
+
+#: ../src/common/fmapbase.cpp:188
+msgid "Unicode 32 bit Big Endian (UTF-32BE)"
+msgstr "Unicode 32 bit Big Endian (UTF-32BE)"
+
+#: ../src/common/fmapbase.cpp:191
+msgid "Extended Unix Codepage for Japanese (EUC-JP)"
+msgstr "Kiterjesztett japán Unix kódlap (EUC-JP)"
+
+#: ../src/common/fmapbase.cpp:192
+#, fuzzy
+msgid "US-ASCII"
+msgstr "ASCII"
+
+#: ../src/common/fmapbase.cpp:193
+msgid "ISO-2022-JP"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:195
+#, fuzzy
+msgid "MacRoman"
+msgstr "Roman"
+
+#: ../src/common/fmapbase.cpp:196
+msgid "MacJapanese"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:197
+msgid "MacChineseTrad"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:198
+msgid "MacKorean"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:199
+msgid "MacArabic"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:200
+msgid "MacHebrew"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:201
+msgid "MacGreek"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:202
+msgid "MacCyrillic"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:203
+msgid "MacDevanagari"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:204
+msgid "MacGurmukhi"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:205
+msgid "MacGujarati"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:206
+msgid "MacOriya"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:207
+msgid "MacBengali"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:208
+msgid "MacTamil"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:209
+msgid "MacTelugu"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:210
+msgid "MacKannada"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:211
+msgid "MacMalayalam"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:212
+#, fuzzy
+msgid "MacSinhalese"
+msgstr "Kis/nagybetű megkülönböztetés"
+
+#: ../src/common/fmapbase.cpp:213
+msgid "MacBurmese"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:214
+msgid "MacKhmer"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:215
+msgid "MacThai"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:216
+msgid "MacLaotian"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:217
+msgid "MacGeorgian"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:218
+msgid "MacArmenian"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:219
+msgid "MacChineseSimp"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:220
+msgid "MacTibetan"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:221
+msgid "MacMongolian"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:222
+msgid "MacEthiopic"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:223
+msgid "MacCentralEurRoman"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:224
+msgid "MacVietnamese"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:225
+msgid "MacExtArabic"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:226
+#, fuzzy
+msgid "MacSymbol"
+msgstr "&Stílus:"
+
+#: ../src/common/fmapbase.cpp:227
+msgid "MacDingbats"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:228
+msgid "MacTurkish"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:229
+msgid "MacCroatian"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:230
+msgid "MacIcelandic"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:231
+#, fuzzy
+msgid "MacRomanian"
+msgstr "Roman"
+
+#: ../src/common/fmapbase.cpp:232
+msgid "MacCeltic"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:233
+msgid "MacGaelic"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:234
+msgid "MacKeyboardGlyphs"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:791
+msgid "Default encoding"
+msgstr "Az alapértelmezett kódolás"
+
+#: ../src/common/fmapbase.cpp:805
+#, c-format
+msgid "Unknown encoding (%d)"
+msgstr "Ismeretlen (%d) kódolás"
+
+#: ../src/common/fmapbase.cpp:815 ../src/richtext/richtextstyles.cpp:776
+msgid "default"
+msgstr "alapértelmezés"
+
+#: ../src/common/fmapbase.cpp:829
+#, c-format
+msgid "unknown-%d"
+msgstr "ismeretlen-%d"
+
+#: ../src/common/fontcmn.cpp:924 ../src/common/fontcmn.cpp:1130
+msgid "underlined"
+msgstr "aláhúzott"
+
+#: ../src/common/fontcmn.cpp:929
+msgid " strikethrough"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:942
+msgid " thin"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:946
+#, fuzzy
+msgid " extra light"
+msgstr "vékony"
+
+#: ../src/common/fontcmn.cpp:950
+#, fuzzy
+msgid " light"
+msgstr "vékony"
+
+#: ../src/common/fontcmn.cpp:954
+msgid " medium"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:958
+#, fuzzy
+msgid " semi bold"
+msgstr "félkövér"
+
+#: ../src/common/fontcmn.cpp:962
+#, fuzzy
+msgid " bold"
+msgstr "félkövér"
+
+#: ../src/common/fontcmn.cpp:966
+#, fuzzy
+msgid " extra bold"
+msgstr "félkövér"
+
+#: ../src/common/fontcmn.cpp:970
+msgid " heavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:974
+msgid " extra heavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:990
+#, fuzzy
+msgid " italic"
+msgstr "dőlt"
+
+#: ../src/common/fontcmn.cpp:1134
+msgid "strikethrough"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1143
+msgid "thin"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1156
+#, fuzzy
+msgid "extralight"
+msgstr "vékony"
+
+#: ../src/common/fontcmn.cpp:1161
+msgid "light"
+msgstr "vékony"
+
+#: ../src/common/fontcmn.cpp:1169 ../src/richtext/richtextstyles.cpp:775
+#, fuzzy
+msgid "normal"
+msgstr "Normál"
+
+#: ../src/common/fontcmn.cpp:1174
+msgid "medium"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1179 ../src/common/fontcmn.cpp:1199
+#, fuzzy
+msgid "semibold"
+msgstr "félkövér"
+
+#: ../src/common/fontcmn.cpp:1184
+msgid "bold"
+msgstr "félkövér"
+
+#: ../src/common/fontcmn.cpp:1194
+#, fuzzy
+msgid "extrabold"
+msgstr "félkövér"
+
+#: ../src/common/fontcmn.cpp:1204
+msgid "heavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1212
+msgid "extraheavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1217
+msgid "italic"
+msgstr "dőlt"
+
+#: ../src/common/fontmap.cpp:195
+msgid ": unknown charset"
+msgstr ": ismeretlen jelkészlet"
+
+#: ../src/common/fontmap.cpp:199
+#, c-format
+msgid ""
+"The charset '%s' is unknown. You may select\n"
+"another charset to replace it with or choose\n"
+"[Cancel] if it cannot be replaced"
+msgstr ""
+"A(z) '%s' jelkészlet ismeretlen.Választhat másik\n"
+"készletet ennek helyettesítésére vagy\n"
+"[Mégsem]-t ha nem helyettesíthető"
+
+#: ../src/common/fontmap.cpp:241
+#, c-format
+msgid "Failed to remember the encoding for the charset '%s'."
+msgstr "Nem emlékszem a '%s' jelkészlet kódolására."
+
+#: ../src/common/fontmap.cpp:321
+msgid "can't load any font, aborting"
+msgstr "egyetlen jelkészletet sem tudok betölteni, kilépek"
+
+#: ../src/common/fontmap.cpp:409
+msgid ": unknown encoding"
+msgstr ": ismeretlen kódolás"
+
+#: ../src/common/fontmap.cpp:417
+#, c-format
+msgid ""
+"No font for displaying text in encoding '%s' found,\n"
+"but an alternative encoding '%s' is available.\n"
+"Do you want to use this encoding (otherwise you will have to choose another "
+"one)?"
+msgstr ""
+"Nem találtam jelkészletet a(z) '%s' kódoláshoz,\n"
+"de a vagylagos '%s' kódolás elérhető.\n"
+"Akarja használni ezt a kódolást  (egyébként másikat kell választania)?"
+
+#: ../src/common/fontmap.cpp:422
+#, c-format
+msgid ""
+"No font for displaying text in encoding '%s' found.\n"
+"Would you like to select a font to be used for this encoding\n"
+"(otherwise the text in this encoding will not be shown correctly)?"
+msgstr ""
+"Nem találtam jelkészletet a(z) '%s' kódoláshoz.\n"
+"Szeretne választani egy jelkészletet ehhez a kódoláshoz\n"
+"(különben az e kódolással készített szöveg nem jelezhető ki helyesen)?"
+
+#: ../src/common/fs_mem.cpp:169
+#, c-format
+msgid "Memory VFS already contains file '%s'!"
+msgstr "A VFS memóriában már van '%s' fájl!"
+
+#: ../src/common/fs_mem.cpp:232
+#, c-format
+msgid "Trying to remove file '%s' from memory VFS, but it is not loaded!"
+msgstr ""
+"Megpróbáltam eltávolítani a(z) '%s' fájlt a VFS tárolóból, de nincs betöltve!"
+
+#: ../src/common/fs_mem.cpp:262
+#, c-format
+msgid "Failed to store image '%s' to memory VFS!"
+msgstr "Nem tudtam a '%s' képet a VFS memóriába tárolni!"
+
+#: ../src/common/ftp.cpp:197
+msgid "Timeout while waiting for FTP server to connect, try passive mode."
+msgstr ""
+"Időkifutás az FTP kiszolgálóhoz való kapcsolódáskor, próbálja meg a passzív "
+"módot."
+
+#: ../src/common/ftp.cpp:399
+#, c-format
+msgid "Failed to set FTP transfer mode to %s."
+msgstr "Nem tudtam a(z) '%s' FTP átviteli módot beállítani."
+
+#: ../src/common/ftp.cpp:400 ../src/richtext/richtextsymboldlg.cpp:432
+msgid "ASCII"
+msgstr "ASCII"
+
+#: ../src/common/ftp.cpp:400
+msgid "binary"
+msgstr "bináris"
+
+#: ../src/common/ftp.cpp:608
+msgid "The FTP server doesn't support the PORT command."
+msgstr "Az FTP kiszolgáló nem támogatja a PORT parancsot."
+
+#: ../src/common/ftp.cpp:622
+msgid "The FTP server doesn't support passive mode."
+msgstr "Az FTP kiszolgáló nem támogatja a passzív módot."
+
+#: ../src/common/gifdecod.cpp:822
+#, c-format
+msgid "Incorrect GIF frame size (%u, %d) for the frame #%u"
+msgstr ""
+
+#: ../src/common/glcmn.cpp:108
+#, fuzzy
+msgid "Failed to allocate colour for OpenGL"
+msgstr "Nem sikerült lérehozni egér mutatót."
+
+#: ../src/common/headerctrlcmn.cpp:57
+msgid "Please select the columns to show and define their order:"
+msgstr ""
+
+#: ../src/common/headerctrlcmn.cpp:58
+#, fuzzy
+msgid "Customize Columns"
+msgstr "Jelkészlet méret"
+
+#: ../src/common/headerctrlcmn.cpp:304
+#, fuzzy
+msgid "&Customize..."
+msgstr "Jelkészlet méret"
+
+#: ../src/common/hyperlnkcmn.cpp:132
+#, fuzzy, c-format
+msgid "Failed to open URL \"%s\" in the default browser"
+msgstr "Nem tudtam megnyitni '%s'-t %s-ként."
+
+#: ../src/common/iconbndl.cpp:195
+#, fuzzy, c-format
+msgid "Failed to load image %%d from file '%s'."
+msgstr "Nem tudtam betölteni a(z) %d képet a  '%s' fájlból."
+
+#: ../src/common/iconbndl.cpp:203
+#, fuzzy, c-format
+msgid "Failed to load image %d from stream."
+msgstr "Nem tudtam betölteni a(z) %d képet a  '%s' fájlból."
+
+#: ../src/common/iconbndl.cpp:221
+#, fuzzy, c-format
+msgid "Failed to load icons from resource '%s'."
+msgstr "Nem tudtam betölteni a(z) %d képet a  '%s' fájlból."
+
+#: ../src/common/imagbmp.cpp:97
+msgid "BMP: Couldn't save invalid image."
+msgstr "BMP: Nem tudtam elmenteni a hibás képet."
+
+#: ../src/common/imagbmp.cpp:137
+msgid "BMP: wxImage doesn't have own wxPalette."
+msgstr "BMP: a wxImage-nek nincs saját wxPalette-je."
+
+#: ../src/common/imagbmp.cpp:243
+msgid "BMP: Couldn't write the file (Bitmap) header."
+msgstr "BMP: Nem tudtam kiírni a fájl (bittérkép) fejet."
+
+#: ../src/common/imagbmp.cpp:266
+msgid "BMP: Couldn't write the file (BitmapInfo) header."
+msgstr "BMP: Nem tudtam kiírni a fájl (bittérkép info) fejet."
+
+#: ../src/common/imagbmp.cpp:353
+msgid "BMP: Couldn't write RGB color map."
+msgstr "BMP: Nem tudtam kiírni az RGB színtérképet."
+
+#: ../src/common/imagbmp.cpp:487
+msgid "BMP: Couldn't write data."
+msgstr "BMP: Nem tudtam kiírni az adatokat."
+
+#: ../src/common/imagbmp.cpp:561 ../src/common/imagbmp.cpp:642
+msgid "BMP: Couldn't allocate memory."
+msgstr "BMP: Nem sikerült memóriát foglalni."
+
+#: ../src/common/imagbmp.cpp:1041
+msgid "DIB Header: Image width > 32767 pixels for file."
+msgstr "DIB fej: A képszélesség a fájl-ban  > 32767 pixel."
+
+#: ../src/common/imagbmp.cpp:1049
+msgid "DIB Header: Image height > 32767 pixels for file."
+msgstr "DIB fej: A képmagasság a fájl-ban  > 32767 pixel."
+
+#: ../src/common/imagbmp.cpp:1081
+msgid "DIB Header: Unknown bitdepth in file."
+msgstr "DIB fej: Ismeretlen bitmélység a fájl-ban."
+
+#: ../src/common/imagbmp.cpp:1156
+msgid "DIB Header: Unknown encoding in file."
+msgstr "DIB fej: Ismeretlen kódolás a fájl-ban."
+
+#: ../src/common/imagbmp.cpp:1165
+msgid "DIB Header: Encoding doesn't match bitdepth."
+msgstr "DIB fej: A kódolás nem felel meg a bitmélységnek."
+
+#: ../src/common/imagbmp.cpp:1180
+#, c-format
+msgid "BMP Header: Invalid number of colors (%d)."
+msgstr ""
+
+#: ../src/common/imagbmp.cpp:1273
+#, fuzzy
+msgid "Error in reading image DIB."
+msgstr "Hiba a DIB kép olvasásakor."
+
+#: ../src/common/imagbmp.cpp:1294
+msgid "ICO: Error in reading mask DIB."
+msgstr "ICO: Hiba a DIB maszk olvasásakor."
+
+#: ../src/common/imagbmp.cpp:1353
+msgid "ICO: Image too tall for an icon."
+msgstr "ICO: A kép túl magas az ikon számára."
+
+#: ../src/common/imagbmp.cpp:1361
+msgid "ICO: Image too wide for an icon."
+msgstr "ICO: A kép túl széles az ikon számára."
+
+#: ../src/common/imagbmp.cpp:1388 ../src/common/imagbmp.cpp:1488
+#: ../src/common/imagbmp.cpp:1503 ../src/common/imagbmp.cpp:1514
+#: ../src/common/imagbmp.cpp:1528 ../src/common/imagbmp.cpp:1576
+#: ../src/common/imagbmp.cpp:1591 ../src/common/imagbmp.cpp:1605
+#: ../src/common/imagbmp.cpp:1616
+msgid "ICO: Error writing the image file!"
+msgstr "ICO: Hiba a kép írásakor!"
+
+#: ../src/common/imagbmp.cpp:1701
+msgid "ICO: Invalid icon index."
+msgstr "ICO: Hibás icon index."
+
+#: ../src/common/image.cpp:2410
+msgid "Image and mask have different sizes."
+msgstr "A kép és a maszk mérete különböző."
+
+#: ../src/common/image.cpp:2418 ../src/common/image.cpp:2459
+msgid "No unused colour in image being masked."
+msgstr "A képben nincs maszkolva nem használt szín."
+
+#: ../src/common/image.cpp:2641
+#, fuzzy, c-format
+msgid "Failed to load bitmap \"%s\" from resources."
+msgstr "Nem tudtam betölteni a(z) %d képet a  '%s' fájlból."
+
+#: ../src/common/image.cpp:2650
+#, fuzzy, c-format
+msgid "Failed to load icon \"%s\" from resources."
+msgstr "Nem tudtam betölteni a(z) %d képet a  '%s' fájlból."
+
+#: ../src/common/image.cpp:2728 ../src/common/image.cpp:2747
+#, fuzzy, c-format
+msgid "Failed to load image from file \"%s\"."
+msgstr "Nem tudtam betölteni a(z) %d képet a  '%s' fájlból."
+
+#: ../src/common/image.cpp:2761
+#, c-format
+msgid "Can't save image to file '%s': unknown extension."
+msgstr ""
+"Nem tudom elmenteni a képet a(z) '%s' fájlba: nincs ilyen kiterjesztés."
+
+#: ../src/common/image.cpp:2869
+msgid "No handler found for image type."
+msgstr "Ilyen típusú képhez nem találtam kezelőt."
+
+#: ../src/common/image.cpp:2877 ../src/common/image.cpp:3000
+#: ../src/common/image.cpp:3066
+#, c-format
+msgid "No image handler for type %d defined."
+msgstr "%d  típusú képhez nincs kezelő meghatározva."
+
+#: ../src/common/image.cpp:2887
+#, fuzzy, c-format
+msgid "Image file is not of type %d."
+msgstr "A kép nem %d típusú."
+
+#: ../src/common/image.cpp:2970
+msgid "Can't automatically determine the image format for non-seekable input."
+msgstr ""
+
+#: ../src/common/image.cpp:2988
+#, fuzzy
+msgid "Unknown image data format."
+msgstr "adatformátum hiba"
+
+#: ../src/common/image.cpp:3009
+#, fuzzy, c-format
+msgid "This is not a %s."
+msgstr "PCX: ez nem PCX fájl."
+
+#: ../src/common/image.cpp:3032 ../src/common/image.cpp:3080
+#, c-format
+msgid "No image handler for type %s defined."
+msgstr "%s  típusú képhez nincs kezelő meghatározva."
+
+#: ../src/common/image.cpp:3041
+#, fuzzy, c-format
+msgid "Image is not of type %s."
+msgstr "A kép nem %d típusú."
+
+#: ../src/common/image.cpp:3509
+#, fuzzy, c-format
+msgid "Failed to check format of image file \"%s\"."
+msgstr "Nem tudtam elmenteni a bittérképet a(z)  '%s' fájlba."
+
+#: ../src/common/imaggif.cpp:124
+msgid "GIF: error in GIF image format."
+msgstr "GIF: hiba a GIF képformátumban."
+
+#: ../src/common/imaggif.cpp:129
+msgid "GIF: not enough memory."
+msgstr "GIF: nincs elég tároló."
+
+#: ../src/common/imaggif.cpp:134
+msgid "GIF: data stream seems to be truncated."
+msgstr "GIF: az adatfolyam csonkítottnak tűnik."
+
+#: ../src/common/imaggif.cpp:240
+#, fuzzy
+msgid "Couldn't initialize GIF hash table."
+msgstr "Nem tudom elindítani a zlib folyam tömörítését."
+
+#: ../src/common/imagiff.cpp:739
+msgid "IFF: error in IFF image format."
+msgstr "IFF: hiba a GIFF képformátumban."
+
+#: ../src/common/imagiff.cpp:742
+msgid "IFF: not enough memory."
+msgstr "IFF: nincs elég tároló."
+
+#: ../src/common/imagiff.cpp:745
+msgid "IFF: unknown error!!!"
+msgstr "IFF: ismeretlen hiba!!!"
+
+#: ../src/common/imagiff.cpp:755
+msgid "IFF: data stream seems to be truncated."
+msgstr "IFF: az adatfolyam csonkítottnak tűnik."
+
+#: ../src/common/imagjpeg.cpp:258
+msgid "JPEG: Couldn't load - file is probably corrupted."
+msgstr "JPEG: nem tudtam betölteni - a fájl valószínűleg hibás"
+
+#: ../src/common/imagjpeg.cpp:437
+msgid "JPEG: Couldn't save image."
+msgstr "JPEG: Nem tudtam elmenteni a képet."
+
+#: ../src/common/imagpcx.cpp:439
+msgid "PCX: this is not a PCX file."
+msgstr "PCX: ez nem PCX fájl."
+
+#: ../src/common/imagpcx.cpp:453
+msgid "PCX: image format unsupported"
+msgstr "PCX: nem támogatott kép formátum"
+
+#: ../src/common/imagpcx.cpp:454 ../src/common/imagpcx.cpp:477
+msgid "PCX: couldn't allocate memory"
+msgstr "PCX: nem tudtam memóriát foglalni"
+
+#: ../src/common/imagpcx.cpp:455
+msgid "PCX: version number too low"
+msgstr "PCX: túl alacsony verziószám"
+
+#: ../src/common/imagpcx.cpp:456 ../src/common/imagpcx.cpp:478
+msgid "PCX: unknown error !!!"
+msgstr "PCX: ismeretlen hiba !!!"
+
+#: ../src/common/imagpcx.cpp:476
+msgid "PCX: invalid image"
+msgstr "PCX: érvénytelen kép"
+
+#: ../src/common/imagpng.cpp:385
+#, fuzzy, c-format
+msgid "Unknown PNG resolution unit %d"
+msgstr "Ismeretlen opció '%s'"
+
+#: ../src/common/imagpng.cpp:439
+msgid "Couldn't load a PNG image - file is corrupted or not enough memory."
+msgstr ""
+"Nem tudtam betölteni a PNG képet - hibás a fájl vagy nincs elég memória."
+
+#: ../src/common/imagpng.cpp:513 ../src/common/imagpng.cpp:524
+#: ../src/common/imagpng.cpp:534
+msgid "Couldn't save PNG image."
+msgstr "Nem tudtam elmenteni a PNG képet."
+
+#: ../src/common/imagpnm.cpp:71
+msgid "PNM: File format is not recognized."
+msgstr "PNM: Azonosítalan fájl formátum."
+
+#: ../src/common/imagpnm.cpp:89
+msgid "PNM: Couldn't allocate memory."
+msgstr "PNM: nem tudtam memóriát foglalni."
+
+#: ../src/common/imagpnm.cpp:111 ../src/common/imagpnm.cpp:134
+#: ../src/common/imagpnm.cpp:156
+msgid "PNM: File seems truncated."
+msgstr "PNM: A fájl csonkítottnak tűnik."
+
+#: ../src/common/imagtiff.cpp:69
+#, fuzzy, c-format
+msgid " (in module \"%s\")"
+msgstr "tiff modul: %s"
+
+#: ../src/common/imagtiff.cpp:304
+msgid "TIFF: Error loading image."
+msgstr "TIFF: Hiba a kép betöltésekor."
+
+#: ../src/common/imagtiff.cpp:314
+msgid "Invalid TIFF image index."
+msgstr "Hibás TIFF kép index."
+
+#: ../src/common/imagtiff.cpp:358
+msgid "TIFF: Image size is abnormally big."
+msgstr ""
+
+#: ../src/common/imagtiff.cpp:372 ../src/common/imagtiff.cpp:385
+#: ../src/common/imagtiff.cpp:769
+msgid "TIFF: Couldn't allocate memory."
+msgstr "TIFF: Nem tudtam memóriát foglalni."
+
+#: ../src/common/imagtiff.cpp:471
+msgid "TIFF: Error reading image."
+msgstr "TIFF: Hiba a kép olvasásakor."
+
+#: ../src/common/imagtiff.cpp:532
+#, c-format
+msgid "Unknown TIFF resolution unit %d ignored"
+msgstr ""
+
+#: ../src/common/imagtiff.cpp:611
+msgid "TIFF: Error saving image."
+msgstr "TIFF: Hiba a kép elmentésekor."
+
+#: ../src/common/imagtiff.cpp:868
+msgid "TIFF: Error writing image."
+msgstr "TIFF: Hiba a kép írásakor."
+
+#: ../src/common/imagtiff.cpp:881
+#, fuzzy
+msgid "TIFF: Error flushing data."
+msgstr "TIFF: Hiba a kép elmentésekor."
+
+#: ../src/common/imagwebp.cpp:56
+msgid "WebP: Invalid data (failed to get features)."
+msgstr ""
+
+#: ../src/common/imagwebp.cpp:65
+msgid "WebP: Allocating image memory failed."
+msgstr ""
+
+#: ../src/common/imagwebp.cpp:82
+msgid "WebP: Decoding RGBA image data failed."
+msgstr ""
+
+#: ../src/common/imagwebp.cpp:98
+msgid "WebP: Decoding RGB image data failed."
+msgstr ""
+
+#: ../src/common/imagwebp.cpp:113 ../src/common/imagwebp.cpp:201
+msgid "WebP: Allocating stream buffer failed."
+msgstr ""
+
+#: ../src/common/imagwebp.cpp:131
+#, fuzzy
+msgid "WebP: Failed to parse container data."
+msgstr "Nem tudtam a vágólap adatot beállítani."
+
+#: ../src/common/imagwebp.cpp:222
+#, fuzzy
+msgid "WebP: Error decoding animation."
+msgstr "Hiba a konfigurációs beállítások olvasásakor."
+
+#: ../src/common/imagwebp.cpp:240
+msgid "WebP: Error getting next animation frame."
+msgstr ""
+
+#: ../src/common/init.cpp:172
+#, c-format
+msgid ""
+"Command line argument %d couldn't be converted to Unicode and will be "
+"ignored."
+msgstr ""
+
+#: ../src/common/init.cpp:344
+msgid "Initialization failed in post init, aborting."
+msgstr "Az inicializálás utolsó fázisa nem sikerült, kilépek."
+
+#: ../src/common/intl.cpp:378
+#, c-format
+msgid "Cannot set locale to language \"%s\"."
+msgstr ""
+
+#: ../src/common/log.cpp:232
+msgid "Error: "
+msgstr "Hiba: "
+
+#: ../src/common/log.cpp:236
+msgid "Warning: "
+msgstr "Figyelmeztetés: "
+
+#: ../src/common/log.cpp:284
+msgid "The previous message repeated once."
+msgstr ""
+
+#: ../src/common/log.cpp:291
+#, c-format
+msgid "The previous message repeated %u time."
+msgid_plural "The previous message repeated %u times."
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../src/common/log.cpp:319
+#, c-format
+msgid "Last repeated message (\"%s\", %u time) wasn't output"
+msgid_plural "Last repeated message (\"%s\", %u times) wasn't output"
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../src/common/log.cpp:435
+#, c-format
+msgid " (error %ld: %s)"
+msgstr "(hiba %ld: %s) "
+
+#: ../src/common/lzmastream.cpp:121
+#, fuzzy
+msgid "Failed to allocate memory for LZMA decompression."
+msgstr "Nem sikerült lérehozni egér mutatót."
+
+#: ../src/common/lzmastream.cpp:125
+#, c-format
+msgid "Failed to initialize LZMA decompression: unexpected error %u."
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:179
+msgid "input is not in XZ format"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:183
+msgid "input compressed using unknown XZ option"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:188
+msgid "input is corrupted"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:192
+#, fuzzy
+msgid "unknown decompression error"
+msgstr "kifejtési hiba"
+
+#: ../src/common/lzmastream.cpp:196
+#, fuzzy, c-format
+msgid "LZMA decompression error: %s"
+msgstr "kifejtési hiba"
+
+#: ../src/common/lzmastream.cpp:231
+#, fuzzy
+msgid "Failed to allocate memory for LZMA compression."
+msgstr "Nem sikerült lérehozni egér mutatót."
+
+#: ../src/common/lzmastream.cpp:235
+#, c-format
+msgid "Failed to initialize LZMA compression: unexpected error %u."
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:267 ../src/common/lzmastream.cpp:342
+#: ../src/html/chm.cpp:336
+msgid "out of memory"
+msgstr "nincs elég tároló."
+
+#: ../src/common/lzmastream.cpp:276 ../src/common/lzmastream.cpp:346
+#, fuzzy
+msgid "unknown compression error"
+msgstr "tömörítési hiba"
+
+#: ../src/common/lzmastream.cpp:280
+#, fuzzy, c-format
+msgid "LZMA compression error: %s"
+msgstr "tömörítési hiba"
+
+#: ../src/common/lzmastream.cpp:350
+#, c-format
+msgid "LZMA compression error when flushing output: %s"
+msgstr ""
+
+#: ../src/common/mimecmn.cpp:167
+#, c-format
+msgid "Unmatched '{' in an entry for mime type %s."
+msgstr "Páratlan '{' a(z) %s mime típus egyik elemében."
+
+#: ../src/common/module.cpp:76
+#, c-format
+msgid "Circular dependency involving module \"%s\" detected."
+msgstr ""
+
+#: ../src/common/module.cpp:128
+#, c-format
+msgid "Dependency \"%s\" of module \"%s\" doesn't exist."
+msgstr ""
+
+#: ../src/common/module.cpp:137
+#, c-format
+msgid "Module \"%s\" initialization failed"
+msgstr "Nem sikerült inicializálni a \"%s\" modult"
+
+#: ../src/common/msgout.cpp:96
+#, fuzzy
+msgid "Message"
+msgstr "%s üzenet"
+
+#: ../src/common/paper.cpp:70
+msgid "Letter, 8 1/2 x 11 in"
+msgstr "Levél, 8 1/2 x 11 hüvelyk"
+
+#: ../src/common/paper.cpp:71
+msgid "Legal, 8 1/2 x 14 in"
+msgstr "Jogi, 8 1/2 x 14 hüvelyk"
+
+#: ../src/common/paper.cpp:72
+msgid "A4 sheet, 210 x 297 mm"
+msgstr "A4 lap, 210 x 297 mm"
+
+#: ../src/common/paper.cpp:73
+msgid "C sheet, 17 x 22 in"
+msgstr "C lap,  17 x 22 hüvelyk"
+
+#: ../src/common/paper.cpp:74
+msgid "D sheet, 22 x 34 in"
+msgstr "D lap, 22 x 34 hüvelyk"
+
+#: ../src/common/paper.cpp:75
+msgid "E sheet, 34 x 44 in"
+msgstr "E lap, 34 x 44 hüvelyk"
+
+#: ../src/common/paper.cpp:76
+msgid "Letter Small, 8 1/2 x 11 in"
+msgstr "Kisméretű levél, 8 1/2 x 11 hüvelyk"
+
+#: ../src/common/paper.cpp:77
+msgid "Tabloid, 11 x 17 in"
+msgstr "Tabloid, 11 x 17 hüvelyk"
+
+#: ../src/common/paper.cpp:78
+msgid "Ledger, 17 x 11 in"
+msgstr "Ledger, 17 x 11 hüvelyk"
+
+#: ../src/common/paper.cpp:79
+msgid "Statement, 5 1/2 x 8 1/2 in"
+msgstr "Bejelentés, 5 1/2 x 8 1/2 hüvelyk"
+
+#: ../src/common/paper.cpp:80
+msgid "Executive, 7 1/4 x 10 1/2 in"
+msgstr "Executive, 7 1/4 x 10 1/2 hüvelyk"
+
+#: ../src/common/paper.cpp:81
+msgid "A3 sheet, 297 x 420 mm"
+msgstr "A3 lap, 297 x 420 mm"
+
+#: ../src/common/paper.cpp:82
+msgid "A4 small sheet, 210 x 297 mm"
+msgstr "A4 kis lap, 210 x 297 mm"
+
+#: ../src/common/paper.cpp:83
+msgid "A5 sheet, 148 x 210 mm"
+msgstr "A5 lap, 148 x 210 mm"
+
+#: ../src/common/paper.cpp:84
+msgid "B4 sheet, 250 x 354 mm"
+msgstr "B4 lap, 250 x 354 mm"
+
+#: ../src/common/paper.cpp:85
+msgid "B5 sheet, 182 x 257 millimeter"
+msgstr "B5 lap, 182 x 257 milliméter"
+
+#: ../src/common/paper.cpp:86
+msgid "Folio, 8 1/2 x 13 in"
+msgstr "Folio, 8 1/2 x 13 hüvelyk"
+
+#: ../src/common/paper.cpp:87
+msgid "Quarto, 215 x 275 mm"
+msgstr "Quarto, 215 x 275 mm"
+
+#: ../src/common/paper.cpp:88
+msgid "10 x 14 in"
+msgstr "10 x 14 hüvelyk"
+
+#: ../src/common/paper.cpp:89
+msgid "11 x 17 in"
+msgstr "11 x 17 hüvelyk"
+
+#: ../src/common/paper.cpp:90
+msgid "Note, 8 1/2 x 11 in"
+msgstr "Feljegyzés, 8 1/2 x 11 hüvelyk"
+
+#: ../src/common/paper.cpp:91
+#, fuzzy
+msgid "#9 Envelope, 3 7/8 x 8 7/8 in"
+msgstr "#10 Boriték, 3 7/8 x 8 7/8 hüvelyk"
+
+#: ../src/common/paper.cpp:92
+msgid "#10 Envelope, 4 1/8 x 9 1/2 in"
+msgstr "#10 Boriték, 4 1/8 x 9 1/2 hüvelyk"
+
+#: ../src/common/paper.cpp:93
+msgid "#11 Envelope, 4 1/2 x 10 3/8 in"
+msgstr "#11 Boriték, 4 1/2 x 10 3/8 hüvelyk"
+
+#: ../src/common/paper.cpp:94
+msgid "#12 Envelope, 4 3/4 x 11 in"
+msgstr "#12 Boriték, 4 3/4 x 11 hüvelyk"
+
+#: ../src/common/paper.cpp:95
+msgid "#14 Envelope, 5 x 11 1/2 in"
+msgstr "#14 Boriték, 5 x 11 1/2 hüvelyk"
+
+#: ../src/common/paper.cpp:96
+msgid "DL Envelope, 110 x 220 mm"
+msgstr "DL Boríték,  110 x 220 mm"
+
+#: ../src/common/paper.cpp:97
+msgid "C5 Envelope, 162 x 229 mm"
+msgstr "C5 Boríték, 162 x 229 mm"
+
+#: ../src/common/paper.cpp:98
+msgid "C3 Envelope, 324 x 458 mm"
+msgstr "C3 Boríték, 324 x 458 mm"
+
+#: ../src/common/paper.cpp:99
+msgid "C4 Envelope, 229 x 324 mm"
+msgstr "C4 Boríték, 229 x 324 mm"
+
+#: ../src/common/paper.cpp:100
+msgid "C6 Envelope, 114 x 162 mm"
+msgstr "C6 Boríték, 114 x 162 mm"
+
+#: ../src/common/paper.cpp:101
+msgid "C65 Envelope, 114 x 229 mm"
+msgstr "C65 Boríték, 114 x 229 mm"
+
+#: ../src/common/paper.cpp:102
+msgid "B4 Envelope, 250 x 353 mm"
+msgstr "B4 Boríték, 250 x 353 mm"
+
+#: ../src/common/paper.cpp:103
+msgid "B5 Envelope, 176 x 250 mm"
+msgstr "B5 Boriték, 176 x 250 mm"
+
+#: ../src/common/paper.cpp:104
+msgid "B6 Envelope, 176 x 125 mm"
+msgstr "B6 Boriték, 176 x 125 mm"
+
+#: ../src/common/paper.cpp:105
+msgid "Italy Envelope, 110 x 230 mm"
+msgstr "Olasz boríték, 110 x 230 mm"
+
+#: ../src/common/paper.cpp:106
+msgid "Monarch Envelope, 3 7/8 x 7 1/2 in"
+msgstr "Birodalmi boríték, 3 7/8 x 7 1/2 hüvelyk"
+
+#: ../src/common/paper.cpp:107
+msgid "6 3/4 Envelope, 3 5/8 x 6 1/2 in"
+msgstr "6 3/4 Boríték, 3 5/8 x 6 1/2 hüvelyk"
+
+#: ../src/common/paper.cpp:108
+msgid "US Std Fanfold, 14 7/8 x 11 in"
+msgstr "USA standard leporelló, 14 7/8 x 11 hüvelyk"
+
+#: ../src/common/paper.cpp:109
+msgid "German Std Fanfold, 8 1/2 x 12 in"
+msgstr "Német standard leporelló, 8 1/2 x 12 hüvelyk"
+
+#: ../src/common/paper.cpp:110
+msgid "German Legal Fanfold, 8 1/2 x 13 in"
+msgstr "Német bírósági leporelló, 8 1/2 x 13 hüvelyk"
+
+#: ../src/common/paper.cpp:112
+msgid "B4 (ISO) 250 x 353 mm"
+msgstr "B4 (ISO) 250 x 353 mm"
+
+#: ../src/common/paper.cpp:113
+msgid "Japanese Postcard 100 x 148 mm"
+msgstr "Japán levelezőlap 100 x 148 mm"
+
+#: ../src/common/paper.cpp:114
+msgid "9 x 11 in"
+msgstr "9 x 11 hüvelyk"
+
+#: ../src/common/paper.cpp:115
+msgid "10 x 11 in"
+msgstr "10 x 11 hüvelyk"
+
+#: ../src/common/paper.cpp:116
+msgid "15 x 11 in"
+msgstr "15 x 11 hüvelyk"
+
+#: ../src/common/paper.cpp:117
+msgid "Envelope Invite 220 x 220 mm"
+msgstr "Meghívó Boríték,  220 x 220 mm"
+
+#: ../src/common/paper.cpp:118
+msgid "Letter Extra 9 1/2 x 12 in"
+msgstr "Levél extra, 9 1/2 x 12 hüvelyk"
+
+#: ../src/common/paper.cpp:119
+msgid "Legal Extra 9 1/2 x 15 in"
+msgstr "Jogi extra, 9 1/2 x 15 hüvelyk"
+
+#: ../src/common/paper.cpp:120
+msgid "Tabloid Extra 11.69 x 18 in"
+msgstr "Tabloid Extra 11.69 x 18 in"
+
+#: ../src/common/paper.cpp:121
+msgid "A4 Extra 9.27 x 12.69 in"
+msgstr "A4 Extra 9.27 x 12.69 in"
+
+#: ../src/common/paper.cpp:122
+msgid "Letter Transverse 8 1/2 x 11 in"
+msgstr "Levél Transverse 8 1/2 x 11 in"
+
+#: ../src/common/paper.cpp:123
+msgid "A4 Transverse 210 x 297 mm"
+msgstr "A4 Transverse 210 x 297 mm"
+
+#: ../src/common/paper.cpp:124
+msgid "Letter Extra Transverse 9.275 x 12 in"
+msgstr "Levél Extra Transverse 9.275 x 12 in"
+
+#: ../src/common/paper.cpp:125
+msgid "SuperA/SuperA/A4 227 x 356 mm"
+msgstr "SuperA/SuperA/A4 227 x 356 mm"
+
+#: ../src/common/paper.cpp:126
+msgid "SuperB/SuperB/A3 305 x 487 mm"
+msgstr "SuperB/SuperB/A3 305 x 487 mm"
+
+#: ../src/common/paper.cpp:127
+msgid "Letter Plus 8 1/2 x 12.69 in"
+msgstr "Levél plusz, 8 1/2 x 12.69 hüvelyk"
+
+#: ../src/common/paper.cpp:128
+msgid "A4 Plus 210 x 330 mm"
+msgstr "A4 plus, 210 x 330 mm"
+
+#: ../src/common/paper.cpp:129
+msgid "A5 Transverse 148 x 210 mm"
+msgstr "A5 Transverse 148 x 210 mm"
+
+#: ../src/common/paper.cpp:130
+msgid "B5 (JIS) Transverse 182 x 257 mm"
+msgstr "B5 (JIS) Transverse 182 x 257 mm"
+
+#: ../src/common/paper.cpp:131
+msgid "A3 Extra 322 x 445 mm"
+msgstr "A3 Extra, 322 x 445 mm"
+
+#: ../src/common/paper.cpp:132
+msgid "A5 Extra 174 x 235 mm"
+msgstr "A5 Extra 174 x 235 mm"
+
+#: ../src/common/paper.cpp:133
+msgid "B5 (ISO) Extra 201 x 276 mm"
+msgstr "B5 (ISO) Extra 201 x 276 mm"
+
+#: ../src/common/paper.cpp:134
+msgid "A2 420 x 594 mm"
+msgstr "A2 420 x 594 mm"
+
+#: ../src/common/paper.cpp:135
+msgid "A3 Transverse 297 x 420 mm"
+msgstr "A3 Transverse 297 x 420 mm"
+
+#: ../src/common/paper.cpp:136
+msgid "A3 Extra Transverse 322 x 445 mm"
+msgstr "A3 Extra Transverse 322 x 445 mm"
+
+#: ../src/common/paper.cpp:138
+msgid "Japanese Double Postcard 200 x 148 mm"
+msgstr "Kétszeres méretű japán levelezőlap 200 x 148 mm"
+
+#: ../src/common/paper.cpp:139
+msgid "A6 105 x 148 mm"
+msgstr "A6 105 x 148 mm"
+
+#: ../src/common/paper.cpp:140
+msgid "Japanese Envelope Kaku #2"
+msgstr "Japán kaku boríték #2"
+
+#: ../src/common/paper.cpp:141
+msgid "Japanese Envelope Kaku #3"
+msgstr "Japán kaku boríték #3"
+
+#: ../src/common/paper.cpp:142
+msgid "Japanese Envelope Chou #3"
+msgstr "Japán chou boríték  #3"
+
+#: ../src/common/paper.cpp:143
+msgid "Japanese Envelope Chou #4"
+msgstr "Japán chou boríték #4"
+
+#: ../src/common/paper.cpp:144
+msgid "Letter Rotated 11 x 8 1/2 in"
+msgstr "Levél 11 x 8 1/2 hüvelyk, elfordított"
+
+#: ../src/common/paper.cpp:145
+msgid "A3 Rotated 420 x 297 mm"
+msgstr "A3 elfordított, 420 x 297 mm"
+
+#: ../src/common/paper.cpp:146
+msgid "A4 Rotated 297 x 210 mm"
+msgstr "A4 297 x 210 mm, elfordított"
+
+#: ../src/common/paper.cpp:147
+msgid "A5 Rotated 210 x 148 mm"
+msgstr "A5 Elfordított 210 x 148 mm"
+
+#: ../src/common/paper.cpp:148
+msgid "B4 (JIS) Rotated 364 x 257 mm"
+msgstr "B4 (JIS) Elfordított 364 x 257 mm"
+
+#: ../src/common/paper.cpp:149
+msgid "B5 (JIS) Rotated 257 x 182 mm"
+msgstr "B5 (JIS) Elfordított 257 x 182 mm"
+
+#: ../src/common/paper.cpp:150
+msgid "Japanese Postcard Rotated 148 x 100 mm"
+msgstr "Japán levelezőlap 148 x 100 mm c"
+
+#: ../src/common/paper.cpp:151
+msgid "Double Japanese Postcard Rotated 148 x 200 mm"
+msgstr "Kétszeres méretű japán levelezőlap, elfordított 148 x 200 mm"
+
+#: ../src/common/paper.cpp:152
+msgid "A6 Rotated 148 x 105 mm"
+msgstr "A6 elfordított 148 x 105 mm"
+
+#: ../src/common/paper.cpp:153
+msgid "Japanese Envelope Kaku #2 Rotated"
+msgstr "Japán kaku boríték #2 elfordított"
+
+#: ../src/common/paper.cpp:154
+msgid "Japanese Envelope Kaku #3 Rotated"
+msgstr "Japán kaku boríték #3 elfordított"
+
+#: ../src/common/paper.cpp:155
+msgid "Japanese Envelope Chou #3 Rotated"
+msgstr "Japán chou boríték #3 elfordított"
+
+#: ../src/common/paper.cpp:156
+msgid "Japanese Envelope Chou #4 Rotated"
+msgstr "Japán chou boríték #4 elfordított"
+
+#: ../src/common/paper.cpp:157
+msgid "B6 (JIS) 128 x 182 mm"
+msgstr "B6 (JIS) 128 x 182 mm"
+
+#: ../src/common/paper.cpp:158
+msgid "B6 (JIS) Rotated 182 x 128 mm"
+msgstr "B6 (JIS) Elfordított 182 x 128 mm"
+
+#: ../src/common/paper.cpp:159
+msgid "12 x 11 in"
+msgstr "12 x 11 hüvelyk"
+
+#: ../src/common/paper.cpp:160
+msgid "Japanese Envelope You #4"
+msgstr "Japán you boríték #4"
+
+#: ../src/common/paper.cpp:161
+msgid "Japanese Envelope You #4 Rotated"
+msgstr "Japán you boríték #4 elfordított"
+
+#: ../src/common/paper.cpp:162
+msgid "PRC 16K 146 x 215 mm"
+msgstr "PRC 16K 146 x 215 mm"
+
+#: ../src/common/paper.cpp:163
+msgid "PRC 32K 97 x 151 mm"
+msgstr "PRC 32K 97 x 151 mm"
+
+#: ../src/common/paper.cpp:164
+msgid "PRC 32K(Big) 97 x 151 mm"
+msgstr "PRC 32K(Nagy) 97 x 151 mm"
+
+#: ../src/common/paper.cpp:165
+msgid "PRC Envelope #1 102 x 165 mm"
+msgstr "PRC Boríték #1 102 x 165 mm"
+
+#: ../src/common/paper.cpp:166
+msgid "PRC Envelope #2 102 x 176 mm"
+msgstr "PRC Boríték #2 102 x 176 mm"
+
+#: ../src/common/paper.cpp:167
+msgid "PRC Envelope #3 125 x 176 mm"
+msgstr "PRC Boríték #3 125 x 176 mm"
+
+#: ../src/common/paper.cpp:168
+msgid "PRC Envelope #4 110 x 208 mm"
+msgstr "PRC Boríték #4 110 x 208 mm"
+
+#: ../src/common/paper.cpp:169
+msgid "PRC Envelope #5 110 x 220 mm"
+msgstr "PRC Boríték #5 110 x 220 mm"
+
+#: ../src/common/paper.cpp:170
+msgid "PRC Envelope #6 120 x 230 mm"
+msgstr "PRC Boríték #6 120 x 230 mm"
+
+#: ../src/common/paper.cpp:171
+msgid "PRC Envelope #7 160 x 230 mm"
+msgstr "PRC Boríték #7 160 x 230 mm"
+
+#: ../src/common/paper.cpp:172
+msgid "PRC Envelope #8 120 x 309 mm"
+msgstr "PRC Boríték #8 120 x 309 mm"
+
+#: ../src/common/paper.cpp:173
+msgid "PRC Envelope #9 229 x 324 mm"
+msgstr "PRC Boríték #9 229 x 324 mm"
+
+#: ../src/common/paper.cpp:174
+msgid "PRC Envelope #10 324 x 458 mm"
+msgstr "PRC Boríték #10 324 x 458 mm"
+
+#: ../src/common/paper.cpp:175
+msgid "PRC 16K Rotated"
+msgstr "PRC 16K elfordított"
+
+#: ../src/common/paper.cpp:176
+msgid "PRC 32K Rotated"
+msgstr "PRC 32K elfordított"
+
+#: ../src/common/paper.cpp:177
+msgid "PRC 32K(Big) Rotated"
+msgstr "PRC 32K(Nagy) elfordított"
+
+#: ../src/common/paper.cpp:178
+msgid "PRC Envelope #1 Rotated 165 x 102 mm"
+msgstr "PRC Boríték #1 165 x 102 mm, elfordított"
+
+#: ../src/common/paper.cpp:179
+msgid "PRC Envelope #2 Rotated 176 x 102 mm"
+msgstr "PRC Boríték #2 176 x 102 mm, elfordított"
+
+#: ../src/common/paper.cpp:180
+msgid "PRC Envelope #3 Rotated 176 x 125 mm"
+msgstr "PRC Boríték #3 176 x 125 mm, elfordított"
+
+#: ../src/common/paper.cpp:181
+msgid "PRC Envelope #4 Rotated 208 x 110 mm"
+msgstr "PRC Boríték #4 208 x 110 mm, elfordított"
+
+#: ../src/common/paper.cpp:182
+msgid "PRC Envelope #5 Rotated 220 x 110 mm"
+msgstr "PRC Boríték #5 220 x 110 mm, elfordított"
+
+#: ../src/common/paper.cpp:183
+msgid "PRC Envelope #6 Rotated 230 x 120 mm"
+msgstr "PRC Boríték #6 230 x 120 mm, elfordított"
+
+#: ../src/common/paper.cpp:184
+msgid "PRC Envelope #7 Rotated 230 x 160 mm"
+msgstr "PRC Boríték #7 230 x 160 mm, elfordított"
+
+#: ../src/common/paper.cpp:185
+msgid "PRC Envelope #8 Rotated 309 x 120 mm"
+msgstr "PRC Boríték #8 309 x 120 mm, elfordított"
+
+#: ../src/common/paper.cpp:186
+msgid "PRC Envelope #9 Rotated 324 x 229 mm"
+msgstr "PRC Boríték #9 324 x 229 mm, elfordított"
+
+#: ../src/common/paper.cpp:187
+msgid "PRC Envelope #10 Rotated 458 x 324 mm"
+msgstr "PRC Boríték #10 458 x 324 m, elfordított"
+
+#: ../src/common/paper.cpp:192
+#, fuzzy
+msgid "A0 sheet, 841 x 1189 mm"
+msgstr "A4 lap, 210 x 297 mm"
+
+#: ../src/common/paper.cpp:193
+#, fuzzy
+msgid "A1 sheet, 594 x 841 mm"
+msgstr "A3 lap, 297 x 420 mm"
+
+#: ../src/common/preferencescmn.cpp:37
+msgid "General"
+msgstr ""
+
+#: ../src/common/preferencescmn.cpp:40
+msgid "Advanced"
+msgstr ""
+
+#: ../src/common/prntbase.cpp:245
+msgid "Generic PostScript"
+msgstr "Generikus PostScript"
+
+#: ../src/common/prntbase.cpp:259
+msgid "Ready"
+msgstr "Kész"
+
+#: ../src/common/prntbase.cpp:331
+msgid "Printing Error"
+msgstr "Nyomtatási hiba"
+
+#: ../src/common/prntbase.cpp:413 ../src/common/prntbase.cpp:1597
+#: ../src/generic/prntdlgg.cpp:135 ../src/generic/prntdlgg.cpp:149
+#: ../src/gtk/print.cpp:628 ../src/gtk/print.cpp:646
+msgid "Print"
+msgstr "Nyomtatás"
+
+#: ../src/common/prntbase.cpp:471 ../src/generic/prntdlgg.cpp:809
+msgid "Page setup"
+msgstr "Oldal beállítás "
+
+#: ../src/common/prntbase.cpp:525
+#, fuzzy
+msgid "Please wait while printing..."
+msgstr "Kérem várjon amíg nyomtatok\n"
+
+#: ../src/common/prntbase.cpp:529
+msgid "Document:"
+msgstr ""
+
+#: ../src/common/prntbase.cpp:532
+msgid "Progress:"
+msgstr ""
+
+#: ../src/common/prntbase.cpp:533
+msgid "Preparing"
+msgstr ""
+
+#: ../src/common/prntbase.cpp:552
+#, fuzzy, c-format
+msgid "Printing page %d"
+msgstr "A(z) %d. oldalt nyomtatom..."
+
+#: ../src/common/prntbase.cpp:557
+#, fuzzy, c-format
+msgid "Printing page %d of %d"
+msgstr "A(z) %d. oldalt nyomtatom..."
+
+#: ../src/common/prntbase.cpp:560
+#, fuzzy, c-format
+msgid " (copy %d of %d)"
+msgstr "%d. oldal (%d-ből)"
+
+#: ../src/common/prntbase.cpp:1604
+#, fuzzy
+msgid "First page"
+msgstr "Következő oldal"
+
+#: ../src/common/prntbase.cpp:1609 ../src/html/helpwnd.cpp:659
+msgid "Previous page"
+msgstr "Előző oldal"
+
+#: ../src/common/prntbase.cpp:1623 ../src/html/helpwnd.cpp:660
+msgid "Next page"
+msgstr "Következő oldal"
+
+#: ../src/common/prntbase.cpp:1628
+#, fuzzy
+msgid "Last page"
+msgstr "Következő oldal"
+
+#: ../src/common/prntbase.cpp:1636 ../src/common/stockitem.cpp:215
+#, fuzzy
+msgid "Zoom Out"
+msgstr "&Kicsinyítés"
+
+#: ../src/common/prntbase.cpp:1650 ../src/common/stockitem.cpp:214
+#, fuzzy
+msgid "Zoom In"
+msgstr "&Nagyítás"
+
+#: ../src/common/prntbase.cpp:1656 ../src/common/stockitem.cpp:153
+#: ../src/generic/logg.cpp:553 ../src/univ/themes/win32.cpp:3752
+msgid "&Close"
+msgstr "&Bezár"
+
+#: ../src/common/prntbase.cpp:2085
+msgid "Could not start document preview."
+msgstr "Nem tudom a dokument megtekintését kezdeményezni."
+
+#: ../src/common/prntbase.cpp:2085 ../src/common/prntbase.cpp:2129
+#: ../src/common/prntbase.cpp:2137
+msgid "Print Preview Failure"
+msgstr "Nyomtatási kép hiba"
+
+#: ../src/common/prntbase.cpp:2129 ../src/common/prntbase.cpp:2137
+msgid "Sorry, not enough memory to create a preview."
+msgstr "Sajnálom, nincs elég memória az előkép létrehozásához."
+
+#: ../src/common/prntbase.cpp:2144
+#, c-format
+msgid "Page %d of %d"
+msgstr "%d. oldal (%d-ből)"
+
+#: ../src/common/prntbase.cpp:2146
+#, c-format
+msgid "Page %d"
+msgstr "%d. oldal"
+
+#: ../src/common/regex.cpp:382 ../src/html/chm.cpp:348
+msgid "unknown error"
+msgstr "ismeretlen hiba"
+
+#: ../src/common/regex.cpp:995
+#, c-format
+msgid "Invalid regular expression '%s': %s"
+msgstr "Hibás szabályos kifejezés '%s': %s"
+
+#: ../src/common/regex.cpp:1059
+#, fuzzy, c-format
+msgid "Failed to find match for regular expression: %s"
+msgstr "Nem sikerült megtalálni '%s'-t  a(z) '%s' szabályos kifejezésben."
+
+#: ../src/common/rendcmn.cpp:188
+#, c-format
+msgid "Renderer \"%s\" has incompatible version %d.%d and couldn't be loaded."
+msgstr ""
+"A \"%s\" renderer  verziója %d.%d nem megfelelő és ezért nem lehet betölteni."
+
+#: ../src/common/secretstore.cpp:162
+msgid "Not available for this platform"
+msgstr ""
+
+#: ../src/common/secretstore.cpp:183
+#, fuzzy, c-format
+msgid "Saving password for \"%s\" failed: %s."
+msgstr "Nem sikerült kifejteni  '%s'-t '%s'-be"
+
+#: ../src/common/secretstore.cpp:205
+#, fuzzy, c-format
+msgid "Reading password for \"%s\" failed: %s."
+msgstr "Nem sikerült kifejteni  '%s'-t '%s'-be"
+
+#: ../src/common/secretstore.cpp:228
+#, fuzzy, c-format
+msgid "Deleting password for \"%s\" failed: %s."
+msgstr "Nem sikerült kifejteni  '%s'-t '%s'-be"
+
+#: ../src/common/selectdispatcher.cpp:254
+msgid "Failed to monitor I/O channels"
+msgstr ""
+
+#: ../src/common/sizer.cpp:3054 ../src/common/stockitem.cpp:195
+msgid "Save"
+msgstr "Mentés"
+
+#: ../src/common/sizer.cpp:3056
+msgid "Don't Save"
+msgstr "Ne mentsd el"
+
+#: ../src/common/socket.cpp:870
+#, fuzzy
+msgid "Cannot initialize sockets"
+msgstr "Nem tudom inicializálni az OLEt"
+
+#: ../src/common/stockitem.cpp:127
+#, fuzzy
+msgctxt "standard Windows menu"
+msgid "&Help"
+msgstr "&Súgó"
+
+#: ../src/common/stockitem.cpp:144
+msgid "&About"
+msgstr "&Névjegy"
+
+#: ../src/common/stockitem.cpp:144
+#, fuzzy
+msgid "About"
+msgstr "&Névjegy"
+
+#: ../src/common/stockitem.cpp:145
+msgid "Add"
+msgstr "Add hozzá"
+
+#: ../src/common/stockitem.cpp:146
+msgid "&Apply"
+msgstr "&Alkalmazd"
+
+#: ../src/common/stockitem.cpp:146
+#, fuzzy
+msgid "Apply"
+msgstr "&Alkalmazd"
+
+#: ../src/common/stockitem.cpp:147
+msgid "&Back"
+msgstr "&Vissza"
+
+#: ../src/common/stockitem.cpp:147
+#, fuzzy
+msgid "Back"
+msgstr "&Vissza"
+
+#: ../src/common/stockitem.cpp:148
+msgid "&Bold"
+msgstr "Kövér"
+
+#: ../src/common/stockitem.cpp:148 ../src/generic/fontdlgg.cpp:326
+#: ../src/richtext/richtextfontpage.cpp:354
+msgid "Bold"
+msgstr "Félkövér"
+
+#: ../src/common/stockitem.cpp:149
+msgid "&Bottom"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:149 ../src/richtext/richtextsizepage.cpp:287
+msgid "Bottom"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:150 ../src/generic/fontdlgg.cpp:462
+#: ../src/generic/fontdlgg.cpp:481 ../src/generic/wizard.cpp:415
+msgid "&Cancel"
+msgstr "&Mégsem"
+
+#: ../src/common/stockitem.cpp:151
+msgid "&CD-ROM"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:151
+msgid "CD-ROM"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:152
+msgid "&Clear"
+msgstr "&Törlés"
+
+#: ../src/common/stockitem.cpp:152
+#, fuzzy
+msgid "Clear"
+msgstr "&Törlés"
+
+#: ../src/common/stockitem.cpp:153 ../src/generic/dbgrptg.cpp:93
+#: ../src/generic/progdlgg.cpp:778 ../src/html/helpdlg.cpp:86
+#: ../src/msw/progdlg.cpp:209 ../src/msw/progdlg.cpp:890
+#: ../src/richtext/richtextstyledlg.cpp:272
+#: ../src/richtext/richtextsymboldlg.cpp:448
+msgid "Close"
+msgstr "Bezárás"
+
+#: ../src/common/stockitem.cpp:154
+#, fuzzy
+msgid "&Convert"
+msgstr "Tartalom"
+
+#: ../src/common/stockitem.cpp:154
+#, fuzzy
+msgid "Convert"
+msgstr "Tartalom"
+
+#: ../src/common/stockitem.cpp:155 ../src/msw/textctrl.cpp:2884
+#: ../src/osx/textctrl_osx.cpp:653 ../src/richtext/richtextctrl.cpp:331
+msgid "&Copy"
+msgstr "&Másolás"
+
+#: ../src/common/stockitem.cpp:155 ../src/stc/stc_i18n.cpp:18
+#, fuzzy
+msgid "Copy"
+msgstr "&Másolás"
+
+#: ../src/common/stockitem.cpp:156 ../src/msw/textctrl.cpp:2883
+#: ../src/osx/textctrl_osx.cpp:652 ../src/richtext/richtextctrl.cpp:330
+msgid "Cu&t"
+msgstr "&Kivágás"
+
+#: ../src/common/stockitem.cpp:156 ../src/stc/stc_i18n.cpp:17
+#, fuzzy
+msgid "Cut"
+msgstr "&Kivágás"
+
+#: ../src/common/stockitem.cpp:157 ../src/msw/textctrl.cpp:2886
+#: ../src/osx/textctrl_osx.cpp:655 ../src/richtext/richtextctrl.cpp:333
+#: ../src/richtext/richtexttabspage.cpp:137
+msgid "&Delete"
+msgstr "&Törlés"
+
+#: ../src/common/stockitem.cpp:157 ../src/richtext/richtextbuffer.cpp:8266
+#: ../src/stc/stc_i18n.cpp:20
+#, fuzzy
+msgid "Delete"
+msgstr "&Törlés"
+
+#: ../src/common/stockitem.cpp:158
+msgid "&Down"
+msgstr "&Le"
+
+#: ../src/common/stockitem.cpp:158 ../src/generic/fdrepdlg.cpp:148
+msgid "Down"
+msgstr "Le"
+
+#: ../src/common/stockitem.cpp:159
+msgid "&Edit"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:159
+#, fuzzy
+msgid "Edit"
+msgstr "Bejegyzés szerkesztése"
+
+#: ../src/common/stockitem.cpp:160
+msgid "&Execute"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:160
+msgid "Execute"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:161
+msgid "&Quit"
+msgstr "&Kilépés"
+
+#: ../src/common/stockitem.cpp:161
+#, fuzzy
+msgid "Quit"
+msgstr "&Kilépés"
+
+#: ../src/common/stockitem.cpp:162
+msgid "&File"
+msgstr "&Fájl"
+
+#: ../src/common/stockitem.cpp:162
+msgid "File"
+msgstr "Fájl"
+
+#: ../src/common/stockitem.cpp:163
+#, fuzzy
+msgid "&Find..."
+msgstr "&Keres"
+
+#: ../src/common/stockitem.cpp:163
+#, fuzzy
+msgid "Find..."
+msgstr "Keres"
+
+#: ../src/common/stockitem.cpp:164
+#, fuzzy
+msgid "&First"
+msgstr "első"
+
+#: ../src/common/stockitem.cpp:164
+#, fuzzy
+msgid "First"
+msgstr "első"
+
+#: ../src/common/stockitem.cpp:165
+#, fuzzy
+msgid "&Floppy"
+msgstr "&Másolás"
+
+#: ../src/common/stockitem.cpp:165
+#, fuzzy
+msgid "Floppy"
+msgstr "&Másolás"
+
+#: ../src/common/stockitem.cpp:166
+msgid "&Forward"
+msgstr "&Előre"
+
+#: ../src/common/stockitem.cpp:166
+#, fuzzy
+msgid "Forward"
+msgstr "&Előre"
+
+#: ../src/common/stockitem.cpp:167
+msgid "&Harddisk"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:167
+msgid "Harddisk"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:168 ../src/generic/wizard.cpp:418
+#: ../src/osx/cocoa/menu.mm:225 ../src/richtext/richtextstyledlg.cpp:298
+#: ../src/richtext/richtextsymboldlg.cpp:451
+msgid "&Help"
+msgstr "&Súgó"
+
+#: ../src/common/stockitem.cpp:169
+msgid "&Home"
+msgstr "&Haza"
+
+#: ../src/common/stockitem.cpp:169
+msgid "Home"
+msgstr "Haza"
+
+#: ../src/common/stockitem.cpp:170
+msgid "Indent"
+msgstr "Bekezdés"
+
+#: ../src/common/stockitem.cpp:171
+msgid "&Index"
+msgstr "&Tartalom mutató"
+
+#: ../src/common/stockitem.cpp:171 ../src/html/helpwnd.cpp:510
+msgid "Index"
+msgstr "Tartalom mutató"
+
+#: ../src/common/stockitem.cpp:172
+#, fuzzy
+msgid "&Info"
+msgstr "&Visszavonás"
+
+#: ../src/common/stockitem.cpp:172
+msgid "Info"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:173
+msgid "&Italic"
+msgstr "&Dőlt"
+
+#: ../src/common/stockitem.cpp:173 ../src/generic/fontdlgg.cpp:322
+#: ../src/richtext/richtextfontpage.cpp:350
+msgid "Italic"
+msgstr "Dőlt"
+
+#: ../src/common/stockitem.cpp:174
+msgid "&Jump to"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:174
+msgid "Jump to"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:175
+msgid "Centered"
+msgstr "Középre igazítva"
+
+#: ../src/common/stockitem.cpp:176
+msgid "Justified"
+msgstr "Jóváhagyva"
+
+#: ../src/common/stockitem.cpp:177
+msgid "Align Left"
+msgstr "Balra igazítsd"
+
+#: ../src/common/stockitem.cpp:178
+msgid "Align Right"
+msgstr "Jobbra igazíts"
+
+#: ../src/common/stockitem.cpp:179
+#, fuzzy
+msgid "&Last"
+msgstr "&Beillesztés"
+
+#: ../src/common/stockitem.cpp:179
+#, fuzzy
+msgid "Last"
+msgstr "&Beillesztés"
+
+#: ../src/common/stockitem.cpp:180
+#, fuzzy
+msgid "&Network"
+msgstr "Ú&j "
+
+#: ../src/common/stockitem.cpp:180
+msgid "Network"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:181 ../src/richtext/richtexttabspage.cpp:131
+msgid "&New"
+msgstr "Ú&j "
+
+#: ../src/common/stockitem.cpp:181
+#, fuzzy
+msgid "New"
+msgstr "Ú&j "
+
+#: ../src/common/stockitem.cpp:182 ../src/msw/msgdlg.cpp:417
+msgid "&No"
+msgstr "&Nem"
+
+#: ../src/common/stockitem.cpp:183 ../src/generic/fontdlgg.cpp:467
+#: ../src/generic/fontdlgg.cpp:474
+msgid "&OK"
+msgstr "&Ok"
+
+#: ../src/common/stockitem.cpp:184 ../src/generic/dbgrptg.cpp:341
+msgid "&Open..."
+msgstr "&Megnyitás..."
+
+#: ../src/common/stockitem.cpp:184
+#, fuzzy
+msgid "Open..."
+msgstr "&Megnyitás..."
+
+#: ../src/common/stockitem.cpp:185 ../src/msw/textctrl.cpp:2885
+#: ../src/osx/textctrl_osx.cpp:654 ../src/richtext/richtextctrl.cpp:332
+msgid "&Paste"
+msgstr "&Beillesztés"
+
+#: ../src/common/stockitem.cpp:185 ../src/richtext/richtextctrl.cpp:3484
+#: ../src/stc/stc_i18n.cpp:19
+#, fuzzy
+msgid "Paste"
+msgstr "&Beillesztés"
+
+#: ../src/common/stockitem.cpp:186
+msgid "&Preferences"
+msgstr "&Előválasztás"
+
+#: ../src/common/stockitem.cpp:186 ../src/osx/cocoa/preferences.mm:304
+#, fuzzy
+msgid "Preferences"
+msgstr "&Előválasztás"
+
+#: ../src/common/stockitem.cpp:187
+#, fuzzy
+msgid "Print previe&w..."
+msgstr "Nyomtatási &kép"
+
+#: ../src/common/stockitem.cpp:187
+#, fuzzy
+msgid "Print preview..."
+msgstr "Nyomtatási elő&kép"
+
+#: ../src/common/stockitem.cpp:188
+msgid "&Print..."
+msgstr "&Nyomtatás..."
+
+#: ../src/common/stockitem.cpp:188
+#, fuzzy
+msgid "Print..."
+msgstr "&Nyomtatás..."
+
+#: ../src/common/stockitem.cpp:189 ../src/richtext/richtextctrl.cpp:337
+#: ../src/richtext/richtextctrl.cpp:5479
+msgid "&Properties"
+msgstr "&Tulajdonságok"
+
+#: ../src/common/stockitem.cpp:189
+#, fuzzy
+msgid "Properties"
+msgstr "&Tulajdonságok"
+
+#: ../src/common/stockitem.cpp:190 ../src/stc/stc_i18n.cpp:16
+#, fuzzy
+msgid "Redo"
+msgstr "&Újra"
+
+#: ../src/common/stockitem.cpp:191
+msgid "Refresh"
+msgstr "Frissíts"
+
+#: ../src/common/stockitem.cpp:192
+msgid "Remove"
+msgstr "Töröld"
+
+#: ../src/common/stockitem.cpp:193
+#, fuzzy
+msgid "Rep&lace..."
+msgstr "&Helyettesítsd"
+
+#: ../src/common/stockitem.cpp:193
+#, fuzzy
+msgid "Replace..."
+msgstr "&Helyettesítés"
+
+#: ../src/common/stockitem.cpp:194
+msgid "Revert to Saved"
+msgstr "Cseréld vissza az elmentettre"
+
+#: ../src/common/stockitem.cpp:196 ../src/generic/logg.cpp:549
+msgid "Save &As..."
+msgstr "&Mentés másként..."
+
+#: ../src/common/stockitem.cpp:196
+#, fuzzy
+msgid "Save As..."
+msgstr "&Mentés másként..."
+
+#: ../src/common/stockitem.cpp:197 ../src/msw/textctrl.cpp:2888
+#: ../src/osx/textctrl_osx.cpp:657 ../src/richtext/richtextctrl.cpp:335
+msgid "Select &All"
+msgstr "Válassz ki &minden fájlt"
+
+#: ../src/common/stockitem.cpp:197 ../src/stc/stc_i18n.cpp:21
+#, fuzzy
+msgid "Select All"
+msgstr "Válassz ki &minden fájlt"
+
+#: ../src/common/stockitem.cpp:198
+#, fuzzy
+msgid "&Color"
+msgstr "S&zín"
+
+#: ../src/common/stockitem.cpp:198
+#, fuzzy
+msgid "Color"
+msgstr "S&zín"
+
+#: ../src/common/stockitem.cpp:199
+#, fuzzy
+msgid "&Font"
+msgstr "Jelkészlet család:"
+
+#: ../src/common/stockitem.cpp:199 ../src/richtext/richtextformatdlg.cpp:336
+msgid "Font"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:200
+msgid "&Ascending"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:200
+#, fuzzy
+msgid "Ascending"
+msgstr "olvasok"
+
+#: ../src/common/stockitem.cpp:201
+msgid "&Descending"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:201
+#, fuzzy
+msgid "Descending"
+msgstr "Az alapértelmezett kódolás"
+
+#: ../src/common/stockitem.cpp:202
+msgid "&Spell Check"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:202
+msgid "Spell Check"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:203
+msgid "&Stop"
+msgstr "&Leállítás"
+
+#: ../src/common/stockitem.cpp:203
+#, fuzzy
+msgid "Stop"
+msgstr "&Leállítás"
+
+#: ../src/common/stockitem.cpp:204 ../src/richtext/richtextfontpage.cpp:274
+msgid "&Strikethrough"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:204
+msgid "Strikethrough"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:205
+#, fuzzy
+msgid "&Top"
+msgstr "&Másolás"
+
+#: ../src/common/stockitem.cpp:205 ../src/richtext/richtextsizepage.cpp:285
+#: ../src/richtext/richtextsizepage.cpp:289
+#, fuzzy
+msgid "Top"
+msgstr "Ig:"
+
+#: ../src/common/stockitem.cpp:206
+msgid "Undelete"
+msgstr "Törlés vissza"
+
+#: ../src/common/stockitem.cpp:207 ../src/generic/fontdlgg.cpp:437
+msgid "&Underline"
+msgstr "Alá&húzás"
+
+#: ../src/common/stockitem.cpp:207
+#, fuzzy
+msgid "Underline"
+msgstr "Alá&húzás"
+
+#: ../src/common/stockitem.cpp:208 ../src/stc/stc_i18n.cpp:15
+#, fuzzy
+msgid "Undo"
+msgstr "&Visszavonás"
+
+#: ../src/common/stockitem.cpp:209
+msgid "&Unindent"
+msgstr "&Kikezdés"
+
+#: ../src/common/stockitem.cpp:209
+#, fuzzy
+msgid "Unindent"
+msgstr "&Kikezdés"
+
+#: ../src/common/stockitem.cpp:210
+msgid "&Up"
+msgstr "&Fel"
+
+#: ../src/common/stockitem.cpp:210 ../src/generic/fdrepdlg.cpp:148
+msgid "Up"
+msgstr "Fel"
+
+#: ../src/common/stockitem.cpp:211 ../src/msw/msgdlg.cpp:417
+msgid "&Yes"
+msgstr "&Igen"
+
+#: ../src/common/stockitem.cpp:212
+msgid "&Actual Size"
+msgstr "&Aktuális méret"
+
+#: ../src/common/stockitem.cpp:212
+#, fuzzy
+msgid "Actual Size"
+msgstr "&Aktuális méret"
+
+#: ../src/common/stockitem.cpp:213
+msgid "Zoom to &Fit"
+msgstr "&Ablakméretű nagyítás"
+
+#: ../src/common/stockitem.cpp:213
+#, fuzzy
+msgid "Zoom to Fit"
+msgstr "&Ablakméretű nagyítás"
+
+#: ../src/common/stockitem.cpp:214
+msgid "Zoom &In"
+msgstr "&Nagyítás"
+
+#: ../src/common/stockitem.cpp:215
+msgid "Zoom &Out"
+msgstr "&Kicsinyítés"
+
+#: ../src/common/stockitem.cpp:262
+msgid "Show about dialog"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:263
+#, fuzzy
+msgid "Copy selection"
+msgstr "Kiválasztott"
+
+#: ../src/common/stockitem.cpp:264
+#, fuzzy
+msgid "Cut selection"
+msgstr "Kiválasztott"
+
+#: ../src/common/stockitem.cpp:265
+#, fuzzy
+msgid "Delete selection"
+msgstr "Kiválasztott"
+
+#: ../src/common/stockitem.cpp:266
+#, fuzzy
+msgid "Find in document"
+msgstr "Nyisd meg a HTML dokumentumot"
+
+#: ../src/common/stockitem.cpp:267
+msgid "Find and replace in document"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:268
+#, fuzzy
+msgid "Paste selection"
+msgstr "Kiválasztott"
+
+#: ../src/common/stockitem.cpp:269
+#, fuzzy
+msgid "Quit this program"
+msgstr "Nyomtasd ezt az oldalt"
+
+#: ../src/common/stockitem.cpp:270
+msgid "Redo last action"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:271
+msgid "Undo last action"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:272
+#, fuzzy
+msgid "Create new document"
+msgstr "Hozzon létre egy új könyvtárat"
+
+#: ../src/common/stockitem.cpp:273
+#, fuzzy
+msgid "Open an existing document"
+msgstr "Nyisd meg a HTML dokumentumot"
+
+#: ../src/common/stockitem.cpp:274
+msgid "Close current document"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:275
+#, fuzzy
+msgid "Save current document"
+msgstr "Válasszon dokumentum nézetet"
+
+#: ../src/common/stockitem.cpp:276
+msgid "Save current document with a different filename"
+msgstr ""
+
+#: ../src/common/strconv.cpp:2324
+#, c-format
+msgid "Conversion to charset '%s' doesn't work."
+msgstr "A  '%s' jelkészletté alakítás nem működik."
+
+#: ../src/common/tarstrm.cpp:352 ../src/common/tarstrm.cpp:375
+#: ../src/common/tarstrm.cpp:406 ../src/generic/progdlgg.cpp:373
+msgid "unknown"
+msgstr "ismeretlen"
+
+#: ../src/common/tarstrm.cpp:774
+msgid "incomplete header block in tar"
+msgstr ""
+
+#: ../src/common/tarstrm.cpp:798
+msgid "checksum failure reading tar header block"
+msgstr ""
+
+#: ../src/common/tarstrm.cpp:971
+msgid "invalid data in extended tar header"
+msgstr ""
+
+#: ../src/common/tarstrm.cpp:981 ../src/common/tarstrm.cpp:1003
+#: ../src/common/tarstrm.cpp:1477 ../src/common/tarstrm.cpp:1499
+msgid "tar entry not open"
+msgstr ""
+
+#: ../src/common/tarstrm.cpp:1023
+#, fuzzy
+msgid "unexpected end of file"
+msgstr "Váratlanul véget ért a fájl az erőforrás értelmezése során. "
+
+#: ../src/common/tarstrm.cpp:1297
+#, c-format
+msgid "%s did not fit the tar header for entry '%s'"
+msgstr ""
+
+#: ../src/common/tarstrm.cpp:1359
+msgid "incorrect size given for tar entry"
+msgstr ""
+
+#: ../src/common/textbuf.cpp:232
+#, c-format
+msgid "'%s' is probably a binary buffer."
+msgstr "'%s' valószínűleg bináris fájl."
+
+#: ../src/common/textcmn.cpp:1006 ../src/richtext/richtextctrl.cpp:3053
+msgid "File couldn't be loaded."
+msgstr "A fájlt nem tudtam betölteni."
+
+#: ../src/common/textfile.cpp:95
+#, fuzzy, c-format
+msgid "Failed to read text file \"%s\"."
+msgstr "Nem tudtam betölteni a metafájlt a(z)  '%s' fájlból."
+
+#: ../src/common/textfile.cpp:160
+#, c-format
+msgid "can't write buffer '%s' to disk."
+msgstr "nem tudom a mágneslemezre írni a(z) '%s' puffert."
+
+#: ../src/common/time.cpp:212
+msgid "Failed to get the local system time"
+msgstr "Nem kaptam meg a helyi rendszer időt."
+
+#: ../src/common/time.cpp:279
+msgid "wxGetTimeOfDay failed."
+msgstr "wxGetTimeOfDay hibát eredményezett."
+
+#: ../src/common/translation.cpp:929
+#, c-format
+msgid "'%s' is not a valid message catalog."
+msgstr "'%s' érvénytelen üzenet katalógus."
+
+#: ../src/common/translation.cpp:954
+#, fuzzy
+msgid "Invalid message catalog."
+msgstr "'%s' érvénytelen üzenet katalógus."
+
+#: ../src/common/translation.cpp:1013
+#, fuzzy, c-format
+msgid "Failed to parse Plural-Forms: '%s'"
+msgstr "Nem tudom értelmezni a(z)  '%s' többes számú alakotat"
+
+#: ../src/common/translation.cpp:1723
+#, c-format
+msgid "using catalog '%s' from '%s'."
+msgstr "a(z) '%s' katalógust használom (a(z) '%s' közül)."
+
+#: ../src/common/translation.cpp:1816
+#, fuzzy, c-format
+msgid "Resource '%s' is not a valid message catalog."
+msgstr "'%s' érvénytelen üzenet katalógus."
+
+#: ../src/common/translation.cpp:1865
+#, fuzzy
+msgid "Couldn't enumerate translations"
+msgstr "Nem tudtam befejezni a szálat"
+
+#: ../src/common/utilscmn.cpp:1145
+msgid "No default application configured for HTML files."
+msgstr ""
+
+#: ../src/common/utilscmn.cpp:1190
+#, fuzzy, c-format
+msgid "Failed to open URL \"%s\" in default browser."
+msgstr "Nem tudtam megnyitni '%s'-t %s-ként."
+
+#: ../src/common/valtext.cpp:144
+msgid "Validation conflict"
+msgstr "Érvényességi ütközés"
+
+#: ../src/common/valtext.cpp:186
+msgid "Required information entry is empty."
+msgstr ""
+
+#: ../src/common/valtext.cpp:188
+#, fuzzy, c-format
+msgid "'%s' is one of the invalid strings"
+msgstr "'%s' érvénytelen"
+
+#: ../src/common/valtext.cpp:190
+#, fuzzy, c-format
+msgid "'%s' is not one of the valid strings"
+msgstr "'%s' érvénytelen üzenet katalógus."
+
+#: ../src/common/valtext.cpp:199
+#, fuzzy, c-format
+msgid "'%s' contains invalid character(s)"
+msgstr "'%s' csak betűket tartalmazhat."
+
+#: ../src/common/webrequest.cpp:139
+#, fuzzy, c-format
+msgid "Error: %s (%d)"
+msgstr "Hiba: "
+
+#: ../src/common/webrequest.cpp:655
+#, c-format
+msgid ""
+"Not enough free disk space for download: %llu needed but only %llu available."
+msgstr ""
+
+#: ../src/common/webrequest.cpp:669
+#, fuzzy, c-format
+msgid "Failed to create temporary file in %s"
+msgstr "Nem sikerült létrehozni átmeneti fájlnevet."
+
+#: ../src/common/webrequest_curl.cpp:1106
+#, fuzzy
+msgid "libcurl could not be initialized"
+msgstr "A fájlt nem tudtam betölteni."
+
+#: ../src/common/webview.cpp:392
+#, fuzzy
+msgid "RunScriptAsync not supported"
+msgstr "Szöveg átalakítást nem támogatok"
+
+#: ../src/common/webview.cpp:403 ../src/msw/webview_ie.cpp:1073
+#, c-format
+msgid "Error running JavaScript: %s"
+msgstr ""
+
+#: ../src/common/webview_chromium.cpp:858
+#, fuzzy, c-format
+msgid "Failed to set proxy \"%s\": %s"
+msgstr "Nem sikerült létrehozni a(z) \"%s\" könyvtárat"
+
+#: ../src/common/webview_chromium.cpp:989
+msgid ""
+"Chromium can't be used because libcef.so wasn't loaded early enough; please "
+"relink the application or use LD_PRELOAD to load it earlier."
+msgstr ""
+
+#: ../src/common/webview_chromium.cpp:1108
+#, fuzzy
+msgid "Could not initialize Chromium"
+msgstr "Nem tudom elindítani a nyomtatást."
+
+#: ../src/common/webview_chromium.cpp:1616
+msgid "Show DevTools"
+msgstr ""
+
+#: ../src/common/webview_chromium.cpp:1617
+#, fuzzy
+msgid "Close DevTools"
+msgstr "Minden fájl bezárása"
+
+#: ../src/common/webview_chromium.cpp:1623
+msgid "Inspect"
+msgstr ""
+
+#: ../src/common/wincmn.cpp:1628
+msgid "This platform does not support background transparency."
+msgstr ""
+
+#: ../src/common/wincmn.cpp:2097
+msgid "Could not transfer data to window"
+msgstr "Nem tudtam adatot átvinni az ablakba"
+
+#: ../src/common/windowid.cpp:240
+msgid "Out of window IDs.  Recommend shutting down application."
+msgstr ""
+
+#: ../src/common/xpmdecod.cpp:678
+msgid "XPM: incorrect header format!"
+msgstr ""
+
+#: ../src/common/xpmdecod.cpp:703
+#, fuzzy, c-format
+msgid "XPM: incorrect colour description in line %d"
+msgstr "XPM: hiányos szín meghatározás '%s'!"
+
+#: ../src/common/xpmdecod.cpp:715 ../src/common/xpmdecod.cpp:724
+#, fuzzy, c-format
+msgid "XPM: malformed colour definition '%s' at line %d!"
+msgstr "XPM: hiányos szín meghatározás '%s'!"
+
+#: ../src/common/xpmdecod.cpp:754
+msgid "XPM: no colors left to use for mask!"
+msgstr ""
+
+#: ../src/common/xpmdecod.cpp:781
+#, c-format
+msgid "XPM: truncated image data at line %d!"
+msgstr ""
+
+#: ../src/common/xpmdecod.cpp:795
+msgid "XPM: Malformed pixel data!"
+msgstr "XPM: Hiányos pixel adat!"
+
+#: ../src/common/xti.cpp:492
+msgid "Illegal Parameter Count for Create Method"
+msgstr "A Create módszer hibás paraméter számot kapott"
+
+#: ../src/common/xti.cpp:504
+msgid "Illegal Parameter Count for ConstructObject Method"
+msgstr "A ConstructObject módszer hibás paraméterszámot kapott"
+
+#: ../src/common/xtistrm.cpp:161
+#, fuzzy, c-format
+msgid "Create Parameter %s not found in declared RTTI Parameters"
+msgstr "Nem találtam"
+
+#: ../src/common/xtistrm.cpp:290
+msgid "Illegal Object Class (Non-wxEvtHandler) as Event Source"
+msgstr "Hibás objektum osztály (Nem-wxEvtHandler) szerepel esemény forrásként"
+
+#: ../src/common/xtistrm.cpp:313 ../src/common/xtixml.cpp:345
+#: ../src/common/xtixml.cpp:498
+msgid "Type must have enum - long conversion"
+msgstr "A típust enum-ról long-ra kell alakítani"
+
+#: ../src/common/xtistrm.cpp:400 ../src/common/xtistrm.cpp:415
+msgid "Invalid or Null Object ID passed to GetObjectClassInfo"
+msgstr "Érvénytelen vagy Null Object ID-t kapott GetObjectClassInfo"
+
+#: ../src/common/xtistrm.cpp:405
+msgid "Unknown Object passed to GetObjectClassInfo"
+msgstr "GetObjectClassInfo ismeretlen objektumot kapott"
+
+#: ../src/common/xtistrm.cpp:420
+msgid "Already Registered Object passed to SetObjectClassInfo"
+msgstr "Egy már regisztrált objektumot adott át a SetObjectClassInfo-nak"
+
+#: ../src/common/xtistrm.cpp:430
+msgid "Invalid or Null Object ID passed to HasObjectClassInfo"
+msgstr "Érvénytelen vagy Null Object ID-t kapott HasObjectClassInfo"
+
+#: ../src/common/xtistrm.cpp:460
+msgid "Passing a already registered object to SetObject"
+msgstr "SetObject már regisztrált objektumot kapott"
+
+#: ../src/common/xtistrm.cpp:471
+#, fuzzy
+msgid "Passing an unknown object to GetObject"
+msgstr "GetObject ismeretlen objektumot kapott"
+
+#: ../src/common/xtixml.cpp:229
+msgid "Forward hrefs are not supported"
+msgstr "Előre mutató href-eket nem tudok használni"
+
+#: ../src/common/xtixml.cpp:247
+#, c-format
+msgid "unknown class %s"
+msgstr "ismeretlen osztály: %s"
+
+#: ../src/common/xtixml.cpp:253
+msgid "objects cannot have XML Text Nodes"
+msgstr "az objektumoknak nem lehet XML szöveg csomópontjuk"
+
+#: ../src/common/xtixml.cpp:258
+msgid "Objects must have an id attribute"
+msgstr "Az objektumoknak id jellemzúvel is rendelkezniük kell"
+
+#: ../src/common/xtixml.cpp:267
+#, c-format
+msgid "Doubly used id : %d"
+msgstr "Másodszor használt azonosító : %d"
+
+#: ../src/common/xtixml.cpp:316
+#, fuzzy, c-format
+msgid "Unknown Property %s"
+msgstr "Ismeretlen tulajdonság %s"
+
+#: ../src/common/xtixml.cpp:407
+msgid "A non empty collection must consist of 'element' nodes"
+msgstr "Egy nem-üres gyűjteménynek 'elem' csomópontokból kell állnia"
+
+#: ../src/common/xtixml.cpp:478
+msgid "incorrect event handler string, missing dot"
+msgstr "hibás eseménykezelő szöveg, a pont hiányzik"
+
+#: ../src/common/zipstrm.cpp:559
+msgid "can't re-initialize zlib deflate stream"
+msgstr "Nem tudom megkezdenii a zlib folyam kifejtését."
+
+#: ../src/common/zipstrm.cpp:584
+msgid "can't re-initialize zlib inflate stream"
+msgstr "Nem tudom elindítani a zlib folyam tömörítését."
+
+#: ../src/common/zipstrm.cpp:1023
+msgid "Ignoring malformed extra data record, ZIP file may be corrupted"
+msgstr ""
+
+#: ../src/common/zipstrm.cpp:1502
+msgid "assuming this is a multi-part zip concatenated"
+msgstr "azt hiszem ez egy több-részes zip egymás után pakolva"
+
+#: ../src/common/zipstrm.cpp:1664
+msgid "invalid zip file"
+msgstr "Hibás zip fájl."
+
+#: ../src/common/zipstrm.cpp:1723
+msgid "can't find central directory in zip"
+msgstr "nem találom a fő könyvtárat a zip-ben"
+
+#: ../src/common/zipstrm.cpp:1812
+msgid "error reading zip central directory"
+msgstr "hiba a zip fő könyvtár olvasásakor"
+
+#: ../src/common/zipstrm.cpp:1916
+msgid "error reading zip local header"
+msgstr "hiba a zip lokális fejrészének olvasásakor"
+
+#: ../src/common/zipstrm.cpp:1964
+msgid "bad zipfile offset to entry"
+msgstr "hibás zip-fájl offset"
+
+#: ../src/common/zipstrm.cpp:2031
+msgid "stored file length not in Zip header"
+msgstr "a Zip fejrészben nincs meg a tárolt fájl hossza"
+
+#: ../src/common/zipstrm.cpp:2045 ../src/common/zipstrm.cpp:2362
+msgid "unsupported Zip compression method"
+msgstr "nem támogatott Zip tömörítési módszer"
+
+#: ../src/common/zipstrm.cpp:2126
+#, c-format
+msgid "reading zip stream (entry %s): bad length"
+msgstr "a zip folyam olvasása ( a(z) %s adat): hibáshossz"
+
+#: ../src/common/zipstrm.cpp:2131
+#, c-format
+msgid "reading zip stream (entry %s): bad crc"
+msgstr "a zip folyam olvasása ( a(z) %s adat): hibás crc"
+
+#: ../src/common/zipstrm.cpp:2578
+#, fuzzy, c-format
+msgid "error writing zip entry '%s': file too large without ZIP64"
+msgstr "hiba a(z) '%s' zip adat írásakor: hibás crc vagy hossz"
+
+#: ../src/common/zipstrm.cpp:2585
+#, c-format
+msgid "error writing zip entry '%s': bad crc or length"
+msgstr "hiba a(z) '%s' zip adat írásakor: hibás crc vagy hossz"
+
+#: ../src/common/zstream.cpp:155 ../src/common/zstream.cpp:315
+msgid "Gzip not supported by this version of zlib"
+msgstr "A zlib ezen változata nem támogatja gzip-et"
+
+#: ../src/common/zstream.cpp:182
+msgid "Can't initialize zlib inflate stream."
+msgstr "Nem tudom elindítani a zlib folyam kifejtését."
+
+#: ../src/common/zstream.cpp:241
+msgid "Can't read inflate stream: unexpected EOF in underlying stream."
+msgstr "Nem tudom olvasni a folyamot, nem várt EOF-t találtam"
+
+#: ../src/common/zstream.cpp:248 ../src/common/zstream.cpp:423
+#, c-format
+msgid "zlib error %d"
+msgstr "zlib hiba %d"
+
+#: ../src/common/zstream.cpp:249
+#, c-format
+msgid "Can't read from inflate stream: %s"
+msgstr "Nem tudok olvasni a(z) %s tömörített folyamból"
+
+#: ../src/common/zstream.cpp:343
+msgid "Can't initialize zlib deflate stream."
+msgstr "Nem tudom elindítani a zlib folyam tömörítését."
+
+#: ../src/common/zstream.cpp:424
+#, c-format
+msgid "Can't write to deflate stream: %s"
+msgstr "Nem tudok írni a(z) %s tömörített folyamba"
+
+#: ../src/dfb/bitmap.cpp:633 ../src/dfb/bitmap.cpp:667
+#, fuzzy, c-format
+msgid "No bitmap handler for type %d defined."
+msgstr "%d  típusú képhez nincs kezelő meghatározva."
+
+#: ../src/dfb/evtloop.cpp:99
+#, fuzzy
+msgid "Failed to read event from DirectFB pipe"
+msgstr "Nem sikerült elolvasni a PID-t a lakat fájlból."
+
+#: ../src/dfb/evtloop.cpp:171
+msgid "Failed to switch DirectFB pipe to non-blocking mode"
+msgstr ""
+
+#: ../src/dfb/fontmgr.cpp:171
+#, c-format
+msgid "no fonts found in %s, using builtin font"
+msgstr ""
+
+#: ../src/dfb/fontmgr.cpp:177
+#, fuzzy
+msgid "Default font"
+msgstr "Az alapértelmezett nyomtató"
+
+#: ../src/dfb/fontmgr.cpp:195
+#, c-format
+msgid "Fonts index file %s disappeared while loading fonts."
+msgstr ""
+
+#: ../src/dfb/wrapdfb.cpp:60
+#, c-format
+msgid "DirectFB error %d occurred."
+msgstr ""
+
+#: ../src/generic/aboutdlgg.cpp:69
+msgid "Developed by "
+msgstr ""
+
+#: ../src/generic/aboutdlgg.cpp:72
+msgid "Documentation by "
+msgstr ""
+
+#: ../src/generic/aboutdlgg.cpp:75
+msgid "Graphics art by "
+msgstr ""
+
+#: ../src/generic/aboutdlgg.cpp:78
+msgid "Translations by "
+msgstr ""
+
+#: ../src/generic/aboutdlgg.cpp:133 ../src/osx/cocoa/aboutdlg.mm:83
+#, fuzzy
+msgid "Version "
+msgstr "Jogosultságok"
+
+#. TRANSLATORS: %s is application name
+#: ../src/generic/aboutdlgg.cpp:146 ../src/msw/aboutdlg.cpp:60
+#, fuzzy, c-format
+msgid "About %s"
+msgstr "&Névjegy..."
+
+#: ../src/generic/aboutdlgg.cpp:181
+msgid "License"
+msgstr ""
+
+#: ../src/generic/aboutdlgg.cpp:184
+msgid "Developers"
+msgstr ""
+
+#: ../src/generic/aboutdlgg.cpp:188
+msgid "Documentation writers"
+msgstr ""
+
+#: ../src/generic/aboutdlgg.cpp:192
+msgid "Artists"
+msgstr ""
+
+#: ../src/generic/aboutdlgg.cpp:196
+msgid "Translators"
+msgstr ""
+
+#: ../src/generic/animateg.cpp:125
+#, fuzzy
+msgid "No handler found for animation type."
+msgstr "Ilyen típusú képhez nem találtam kezelőt."
+
+#: ../src/generic/animateg.cpp:133
+#, fuzzy, c-format
+msgid "No animation handler for type %ld defined."
+msgstr "%d  típusú képhez nincs kezelő meghatározva."
+
+#: ../src/generic/animateg.cpp:145
+#, fuzzy, c-format
+msgid "Animation file is not of type %ld."
+msgstr "A kép nem %d típusú."
+
+#: ../src/generic/colrdlgg.cpp:154 ../src/gtk/colordlg.cpp:47
+msgid "Choose colour"
+msgstr "Válasszon színt"
+
+#: ../src/generic/colrdlgg.cpp:357
+msgid "Red:"
+msgstr ""
+
+#: ../src/generic/colrdlgg.cpp:360
+msgid "Green:"
+msgstr ""
+
+#: ../src/generic/colrdlgg.cpp:363
+msgid "Blue:"
+msgstr ""
+
+#: ../src/generic/colrdlgg.cpp:372
+msgid "Opacity:"
+msgstr ""
+
+#: ../src/generic/colrdlgg.cpp:384
+msgid "Add to custom colours"
+msgstr "Add hozzá a felhasználói színekhez"
+
+#: ../src/generic/creddlgg.cpp:56
+msgid "Username:"
+msgstr ""
+
+#: ../src/generic/creddlgg.cpp:63
+msgid "Password:"
+msgstr ""
+
+#. TRANSLATORS: Name of Boolean true value
+#: ../src/generic/datavgen.cpp:1178
+msgid "true"
+msgstr ""
+
+#. TRANSLATORS: Name of Boolean false value
+#: ../src/generic/datavgen.cpp:1180
+#, fuzzy
+msgid "false"
+msgstr "Fájl"
+
+#: ../src/generic/datavgen.cpp:6897
+#, c-format
+msgid "Row %i"
+msgstr ""
+
+#. TRANSLATORS: Action for manipulating a tree control
+#: ../src/generic/datavgen.cpp:6987
+msgid "Collapse"
+msgstr ""
+
+#. TRANSLATORS: Action for manipulating a tree control
+#: ../src/generic/datavgen.cpp:6990
+msgid "Expand"
+msgstr ""
+
+#. TRANSLATORS: Name of data view control and number of rows
+#: ../src/generic/datavgen.cpp:7011
+#, fuzzy, c-format
+msgid "%s (%d items)"
+msgstr "%s (vagy %s)"
+
+#: ../src/generic/datavgen.cpp:7062
+#, c-format
+msgid "Column %u"
+msgstr ""
+
+#. TRANSLATORS: Keystroke for manipulating a tree control
+#: ../src/generic/datavgen.cpp:7131 ../src/richtext/richtextbulletspage.cpp:189
+#: ../src/richtext/richtextbulletspage.cpp:192
+#: ../src/richtext/richtextbulletspage.cpp:193
+#: ../src/richtext/richtextliststylepage.cpp:252
+#: ../src/richtext/richtextliststylepage.cpp:255
+#: ../src/richtext/richtextliststylepage.cpp:256
+#: ../src/richtext/richtextsizepage.cpp:248
+msgid "Left"
+msgstr ""
+
+#. TRANSLATORS: Keystroke for manipulating a tree control
+#: ../src/generic/datavgen.cpp:7134 ../src/richtext/richtextbulletspage.cpp:191
+#: ../src/richtext/richtextliststylepage.cpp:254
+#: ../src/richtext/richtextsizepage.cpp:249
+#, fuzzy
+msgid "Right"
+msgstr "Vékony"
+
+#: ../src/generic/datectlg.cpp:90
+#, c-format
+msgid ""
+"\"%s\" is not in the expected date format, please enter it as e.g. \"%s\"."
+msgstr ""
+
+#: ../src/generic/datectlg.cpp:94
+#, fuzzy
+msgid "Invalid date"
+msgstr "PCX: érvénytelen kép"
+
+#: ../src/generic/dbgrptg.cpp:159
+#, c-format
+msgid "Open file \"%s\""
+msgstr "A(z) \"%s\" fájl megnyitása"
+
+#: ../src/generic/dbgrptg.cpp:170
+#, c-format
+msgid "Enter command to open file \"%s\":"
+msgstr "Írja be a(z) \"%s\" fájlt megnyitó parancsot:"
+
+#: ../src/generic/dbgrptg.cpp:230
+#, fuzzy
+msgid "Executable files (*.exe)|*.exe|"
+msgstr "Végrehajtható fájlok (*.exe)|*.exe|Minden fájl (*.*)|*.*||"
+
+#: ../src/generic/dbgrptg.cpp:300
+#, c-format
+msgid "Debug report \"%s\""
+msgstr "Hibakeresési jelentés \"%s\""
+
+#: ../src/generic/dbgrptg.cpp:316
+msgid "A debug report has been generated in the directory\n"
+msgstr "A hibakeresésről a jelentés ebben a könyvtárban van\n"
+
+#: ../src/generic/dbgrptg.cpp:317
+#, fuzzy
+msgid "The following debug report will be generated\n"
+msgstr "*** Elkészült a hibakeresésről a jelentés\n"
+
+#: ../src/generic/dbgrptg.cpp:321
+msgid ""
+"The report contains the files listed below. If any of these files contain "
+"private information,\n"
+"please uncheck them and they will be removed from the report.\n"
+msgstr ""
+"A jelentés az alább felsorolt fájlokat tartalmazza. Ha a fájlok valamelyike "
+"magánjellegű információt tartalmaz,\n"
+"szüntesse meg a kijelölését ls az nem fog szerepelni a jelentésben.\n"
+
+#: ../src/generic/dbgrptg.cpp:323
+msgid ""
+"If you wish to suppress this debug report completely, please choose the "
+"\"Cancel\" button,\n"
+"but be warned that it may hinder improving the program, so if\n"
+"at all possible please do continue with the report generation.\n"
+msgstr ""
+"Ha teljesen mellőzni akarja ennek a hibajavítási jelentésnek az elküldését, "
+"kérem válassza a \"Mégsem\" gombot,\n"
+"de kérem vegye figyelembe hogy ez hátráltathatja a program fejlesztését, "
+"tehát\n"
+"ha csak lehetséges, kérem folytassa a jelentés előállítását.\n"
+
+#: ../src/generic/dbgrptg.cpp:325
+msgid "              Thank you and we're sorry for the inconvenience!\n"
+msgstr "              Köszönjük és elnézést kérünk a kényelmetlenségért!\n"
+
+#: ../src/generic/dbgrptg.cpp:333
+msgid "&Debug report preview:"
+msgstr "&Előkép a hiba jelentésről:"
+
+#: ../src/generic/dbgrptg.cpp:339
+#, fuzzy
+msgid "&View..."
+msgstr "&Megnyitás..."
+
+#: ../src/generic/dbgrptg.cpp:359
+msgid "&Notes:"
+msgstr "&Megjegyzések:"
+
+#: ../src/generic/dbgrptg.cpp:361
+msgid ""
+"If you have any additional information pertaining to this bug\n"
+"report, please enter it here and it will be joined to it:"
+msgstr ""
+"Ha van erre a hibára vonatkozó egyéb információja,\n"
+"kérem írja be ide és azt a jelentéshez csatolom:"
+
+#: ../src/generic/dcpsg.cpp:1627
+msgid "Cannot open file for PostScript printing!"
+msgstr "Nem tudom a fájlt PostScript nyomtatásra megnyitni!"
+
+#: ../src/generic/dirctrlg.cpp:402
+msgid "Computer"
+msgstr "Számítógép"
+
+#: ../src/generic/dirctrlg.cpp:404
+msgid "Sections"
+msgstr "Szakaszok"
+
+#: ../src/generic/dirctrlg.cpp:482
+msgid "Home directory"
+msgstr "Saját könyvtár"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/generic/dirctrlg.cpp:484 ../src/propgrid/advprops.cpp:811
+msgid "Desktop"
+msgstr "Asztal"
+
+#: ../src/generic/dirctrlg.cpp:528 ../src/generic/filectrlg.cpp:752
+msgid "Illegal directory name."
+msgstr "Hibás könyvtár név."
+
+#: ../src/generic/dirctrlg.cpp:528 ../src/generic/dirctrlg.cpp:546
+#: ../src/generic/dirctrlg.cpp:557 ../src/generic/dirdlgg.cpp:317
+#: ../src/generic/filectrlg.cpp:638 ../src/generic/filectrlg.cpp:752
+#: ../src/generic/filectrlg.cpp:766 ../src/generic/filectrlg.cpp:782
+#: ../src/generic/filectrlg.cpp:1356 ../src/generic/filectrlg.cpp:1387
+#: ../src/generic/filedlgg.cpp:362 ../src/gtk/filedlg.cpp:76
+msgid "Error"
+msgstr "Hiba"
+
+#: ../src/generic/dirctrlg.cpp:546 ../src/generic/filectrlg.cpp:766
+msgid "File name exists already."
+msgstr "Már van ilyen nevű fájl."
+
+#: ../src/generic/dirctrlg.cpp:557 ../src/generic/dirdlgg.cpp:317
+#: ../src/generic/filectrlg.cpp:638 ../src/generic/filectrlg.cpp:782
+msgid "Operation not permitted."
+msgstr "Ez a művelet nincs megengedve."
+
+#: ../src/generic/dirdlgg.cpp:107 ../src/generic/filedlgg.cpp:207
+msgid "Create new directory"
+msgstr "Hozzon létre egy új könyvtárat"
+
+#: ../src/generic/dirdlgg.cpp:112 ../src/generic/filedlgg.cpp:203
+msgid "Go to home directory"
+msgstr "Menj a saját (hon) könyvtárba"
+
+#: ../src/generic/dirdlgg.cpp:143
+#, fuzzy
+msgid "Show &hidden directories"
+msgstr "Mutasd meg a rejtett könyvtárokat"
+
+#: ../src/generic/dirdlgg.cpp:196
+#, c-format
+msgid ""
+"The directory '%s' does not exist\n"
+"Create it now?"
+msgstr ""
+"A '%s' könyvtár nem létezik.\n"
+"Létrehozzam most?"
+
+#: ../src/generic/dirdlgg.cpp:198
+msgid "Directory does not exist"
+msgstr "A könyvtár nem létezik"
+
+#: ../src/generic/dirdlgg.cpp:214
+#, c-format
+msgid ""
+"Failed to create directory '%s'\n"
+"(Do you have the required permissions?)"
+msgstr ""
+"Nem sikerült létrehozni a '%s' könyvtárat.\n"
+"(Rendelkezik a szükséges jogosultsággal?)"
+
+#: ../src/generic/dirdlgg.cpp:216
+msgid "Error creating directory"
+msgstr "Hiba a könyvtár létrehozásakor"
+
+#: ../src/generic/dirdlgg.cpp:281
+msgid "You cannot add a new directory to this section."
+msgstr "Nem tud könyvtárat hozzáadni ehhez a szakaszhoz."
+
+#: ../src/generic/dirdlgg.cpp:282
+msgid "Create directory"
+msgstr "Hozzon létre könyvtárat"
+
+#: ../src/generic/dirdlgg.cpp:291 ../src/generic/dirdlgg.cpp:301
+#: ../src/generic/filectrlg.cpp:614 ../src/generic/filectrlg.cpp:623
+msgid "NewName"
+msgstr "ÚjNév"
+
+#: ../src/generic/editlbox.cpp:135
+msgid "Edit item"
+msgstr "Bejegyzés szerkesztése"
+
+#: ../src/generic/editlbox.cpp:143
+msgid "New item"
+msgstr "Új bejegyzés"
+
+#: ../src/generic/editlbox.cpp:151
+msgid "Delete item"
+msgstr "Bejegyzés törlése"
+
+#: ../src/generic/editlbox.cpp:159
+msgid "Move up"
+msgstr "Vidd &feljebb"
+
+#: ../src/generic/editlbox.cpp:164
+msgid "Move down"
+msgstr "Mozgasd lefelé"
+
+#: ../src/generic/fdrepdlg.cpp:108
+msgid "Search for:"
+msgstr "Keresés:"
+
+#: ../src/generic/fdrepdlg.cpp:120
+msgid "Replace with:"
+msgstr "Helyette:"
+
+#: ../src/generic/fdrepdlg.cpp:140
+msgid "Whole word"
+msgstr "Egész szó"
+
+#: ../src/generic/fdrepdlg.cpp:143
+msgid "Match case"
+msgstr "Kis/nagybetű megkülönböztetés"
+
+#: ../src/generic/fdrepdlg.cpp:156
+msgid "Search direction"
+msgstr "Keresési irány"
+
+#: ../src/generic/fdrepdlg.cpp:175
+msgid "&Replace"
+msgstr "&Helyettesítés"
+
+#: ../src/generic/fdrepdlg.cpp:178
+msgid "Replace &all"
+msgstr "Helyettesítsem &mindet"
+
+#: ../src/generic/filectrlg.cpp:246 ../src/generic/filectrlg.cpp:269
+msgid "<DIR>"
+msgstr "<DIR>"
+
+#: ../src/generic/filectrlg.cpp:248 ../src/generic/filectrlg.cpp:271
+msgid "<LINK>"
+msgstr "<LINK>"
+
+#: ../src/generic/filectrlg.cpp:250 ../src/generic/filectrlg.cpp:273
+msgid "<DRIVE>"
+msgstr "<MEGHAJTÓ>"
+
+#: ../src/generic/filectrlg.cpp:275
+#, fuzzy, c-format
+msgid "%ld byte"
+msgid_plural "%ld bytes"
+msgstr[0] "%ld bájt"
+msgstr[1] "%ld bájt"
+
+#: ../src/generic/filectrlg.cpp:420
+msgid "Name"
+msgstr "Név"
+
+#: ../src/generic/filectrlg.cpp:421 ../src/richtext/richtextformatdlg.cpp:361
+#: ../src/richtext/richtextsizepage.cpp:298
+msgid "Size"
+msgstr "Méret"
+
+#: ../src/generic/filectrlg.cpp:422
+msgid "Type"
+msgstr "Típus"
+
+#: ../src/generic/filectrlg.cpp:423
+msgid "Modified"
+msgstr "Módosítva"
+
+#: ../src/generic/filectrlg.cpp:426
+msgid "Permissions"
+msgstr "Jogosultságok"
+
+#: ../src/generic/filectrlg.cpp:429
+msgid "Attributes"
+msgstr "Tulajdonságok"
+
+#: ../src/generic/filectrlg.cpp:936
+msgid "Current directory:"
+msgstr "A jelenlegi könyvtár:"
+
+#: ../src/generic/filectrlg.cpp:979
+#, fuzzy
+msgid "Show &hidden files"
+msgstr "Mutasd meg a rejtett fájlokat"
+
+#: ../src/generic/filectrlg.cpp:1355
+msgid "Illegal file specification."
+msgstr "Hibás fájl meghatározás."
+
+#: ../src/generic/filectrlg.cpp:1387
+msgid "Directory doesn't exist."
+msgstr "A könyvtár nem létezik."
+
+#: ../src/generic/filedlgg.cpp:195
+msgid "View files as a list view"
+msgstr "A fájlok bemutatása lista szerűen"
+
+#: ../src/generic/filedlgg.cpp:197
+msgid "View files as a detailed view"
+msgstr "A fájlok bemutatása részletezve"
+
+#: ../src/generic/filedlgg.cpp:200
+msgid "Go to parent directory"
+msgstr "Menj a szülő könyvtárba"
+
+#: ../src/generic/filedlgg.cpp:351 ../src/gtk/filedlg.cpp:59
+#, c-format
+msgid "File '%s' already exists, do you really want to overwrite it?"
+msgstr "A(z) '%s file már létezik, valóban  felül akarja írni?"
+
+#: ../src/generic/filedlgg.cpp:354 ../src/gtk/filedlg.cpp:62
+msgid "Confirm"
+msgstr "Megerősítés"
+
+#: ../src/generic/filedlgg.cpp:362 ../src/gtk/filedlg.cpp:75
+msgid "Please choose an existing file."
+msgstr "Kérem válasszon egy létező fájlt."
+
+#: ../src/generic/filepickerg.cpp:64
+#, fuzzy
+msgid "..."
+msgstr ".."
+
+#: ../src/generic/fontdlgg.cpp:76 ../src/richtext/richtextformatdlg.cpp:519
+msgid "ABCDEFGabcdefg12345"
+msgstr "ABCDEFGabcdefg12345"
+
+#: ../src/generic/fontdlgg.cpp:315
+msgid "Roman"
+msgstr "Roman"
+
+#: ../src/generic/fontdlgg.cpp:316
+msgid "Decorative"
+msgstr "Dekoratív"
+
+#: ../src/generic/fontdlgg.cpp:317
+msgid "Modern"
+msgstr "Modern"
+
+#: ../src/generic/fontdlgg.cpp:318
+msgid "Script"
+msgstr "Script"
+
+#: ../src/generic/fontdlgg.cpp:319
+msgid "Swiss"
+msgstr "Svájci"
+
+#: ../src/generic/fontdlgg.cpp:320
+msgid "Teletype"
+msgstr "Teletype"
+
+#: ../src/generic/fontdlgg.cpp:321 ../src/generic/fontdlgg.cpp:324
+msgid "Normal"
+msgstr "Normál"
+
+#: ../src/generic/fontdlgg.cpp:323
+msgid "Slant"
+msgstr "Ferde"
+
+#: ../src/generic/fontdlgg.cpp:325
+msgid "Light"
+msgstr "Vékony"
+
+#: ../src/generic/fontdlgg.cpp:363
+msgid "&Font family:"
+msgstr "Jelkészlet család:"
+
+#: ../src/generic/fontdlgg.cpp:367 ../src/generic/fontdlgg.cpp:369
+msgid "The font family."
+msgstr "A betűkészlet családja."
+
+#: ../src/generic/fontdlgg.cpp:374 ../src/richtext/richtextstylepage.cpp:105
+msgid "&Style:"
+msgstr "&Stílus:"
+
+#: ../src/generic/fontdlgg.cpp:378 ../src/generic/fontdlgg.cpp:380
+msgid "The font style."
+msgstr "A betűkészlet stílusa."
+
+#: ../src/generic/fontdlgg.cpp:385
+msgid "&Weight:"
+msgstr "Hang&súly:"
+
+#: ../src/generic/fontdlgg.cpp:389 ../src/generic/fontdlgg.cpp:391
+msgid "The font weight."
+msgstr "A betűkészlet hangsúlya."
+
+#: ../src/generic/fontdlgg.cpp:399
+msgid "C&olour:"
+msgstr "S&zín"
+
+#: ../src/generic/fontdlgg.cpp:407 ../src/generic/fontdlgg.cpp:409
+msgid "The font colour."
+msgstr "A betűkészlet színe."
+
+#: ../src/generic/fontdlgg.cpp:415
+msgid "&Point size:"
+msgstr "Jelkészlet &pontmérete:"
+
+#: ../src/generic/fontdlgg.cpp:420 ../src/generic/fontdlgg.cpp:422
+#: ../src/generic/fontdlgg.cpp:426 ../src/generic/fontdlgg.cpp:428
+msgid "The font point size."
+msgstr "A jelkészlet mérete."
+
+#: ../src/generic/fontdlgg.cpp:439 ../src/generic/fontdlgg.cpp:441
+msgid "Whether the font is underlined."
+msgstr "Hogy aláhúzza-e a betűket."
+
+#: ../src/generic/fontdlgg.cpp:448 ../src/html/helpwnd.cpp:1215
+msgid "Preview:"
+msgstr "Előkép:"
+
+#: ../src/generic/fontdlgg.cpp:452 ../src/generic/fontdlgg.cpp:454
+msgid "Shows the font preview."
+msgstr "Betűkészlet előkép bemutatás"
+
+#: ../src/generic/fontdlgg.cpp:464 ../src/generic/fontdlgg.cpp:483
+msgid "Click to cancel the font selection."
+msgstr "Kattints ide a betűtípus választás törléséhez"
+
+#: ../src/generic/fontdlgg.cpp:469 ../src/generic/fontdlgg.cpp:471
+#: ../src/generic/fontdlgg.cpp:476 ../src/generic/fontdlgg.cpp:478
+msgid "Click to confirm the font selection."
+msgstr "Kattints ide a betűtípus választás megerősítéséhez"
+
+#: ../src/generic/fontpickerg.cpp:50 ../src/gtk/fontdlg.cpp:77
+msgid "Choose font"
+msgstr "Válasszon betűtípust"
+
+#: ../src/generic/grid.cpp:6542
+msgid ""
+"Error copying grid to the clipboard. Either selected cells were not "
+"contiguous or no cell was selected."
+msgstr ""
+
+#: ../src/generic/grid.cpp:12739
+msgid "Grid Corner"
+msgstr ""
+
+#: ../src/generic/grid.cpp:12741
+#, c-format
+msgid "Column %s Header"
+msgstr ""
+
+#: ../src/generic/grid.cpp:12743
+#, c-format
+msgid "Row %s Header"
+msgstr ""
+
+#: ../src/generic/grid.cpp:12745
+#, c-format
+msgid "Column %s: %s"
+msgstr ""
+
+#: ../src/generic/grid.cpp:12749
+#, fuzzy, c-format
+msgid "Row %s: %s"
+msgstr "\t%s: %s\n"
+
+#: ../src/generic/grid.cpp:12753
+#, c-format
+msgid "Row %s, Column %s: %s"
+msgstr ""
+
+#: ../src/generic/helpext.cpp:257
+#, c-format
+msgid "Help directory \"%s\" not found."
+msgstr ""
+
+#: ../src/generic/helpext.cpp:265
+#, fuzzy, c-format
+msgid "Help file \"%s\" not found."
+msgstr "a(z) '%s' domén konfigurációs fájlját nem találom."
+
+#: ../src/generic/helpext.cpp:284
+#, c-format
+msgid "Line %lu of map file \"%s\" has invalid syntax, skipped."
+msgstr ""
+
+#: ../src/generic/helpext.cpp:292
+#, c-format
+msgid "No valid mappings found in the file \"%s\"."
+msgstr ""
+
+#: ../src/generic/helpext.cpp:435
+msgid "No entries found."
+msgstr "Nem találtam elemet."
+
+#: ../src/generic/helpext.cpp:444 ../src/generic/helpext.cpp:445
+msgid "Help Index"
+msgstr "Súgó tartalomjegyzék"
+
+#: ../src/generic/helpext.cpp:448
+msgid "Relevant entries:"
+msgstr "A megfelelő tagok:"
+
+#: ../src/generic/helpext.cpp:449
+msgid "Entries found"
+msgstr "A talált bejegyzések"
+
+#: ../src/generic/hyperlinkg.cpp:170
+#, fuzzy
+msgid "&Copy URL"
+msgstr "&Másolás"
+
+#: ../src/generic/infobar.cpp:119
+msgid "Hide this notification message."
+msgstr ""
+
+#. TRANSLATORS: %s will be either the application name or "Application"
+#: ../src/generic/logg.cpp:257
+#, c-format
+msgid "%s Error"
+msgstr "%s Hiba"
+
+#. TRANSLATORS: %s will be either the application name or "Application"
+#: ../src/generic/logg.cpp:263
+#, c-format
+msgid "%s Warning"
+msgstr "%s Figyelmeztetés"
+
+#. TRANSLATORS: %s will be either the application name or "Application"
+#: ../src/generic/logg.cpp:273
+#, c-format
+msgid "%s Information"
+msgstr "%s Információ"
+
+#: ../src/generic/logg.cpp:276
+#, fuzzy
+msgid "Application"
+msgstr "Kiválasztott"
+
+#: ../src/generic/logg.cpp:549
+msgid "Save log contents to file"
+msgstr "Mentsd a napló tartalmát fájlba"
+
+#: ../src/generic/logg.cpp:551
+msgid "C&lear"
+msgstr "Tör&lés"
+
+#: ../src/generic/logg.cpp:551
+msgid "Clear the log contents"
+msgstr "A napló fájl törlése"
+
+#: ../src/generic/logg.cpp:553
+msgid "Close this window"
+msgstr "Zárja be ezt az ablakot"
+
+#: ../src/generic/logg.cpp:554
+msgid "&Log"
+msgstr "&Napló"
+
+#: ../src/generic/logg.cpp:610 ../src/generic/logg.cpp:992
+msgid "Can't save log contents to file."
+msgstr "Nem tudom a napló tartalmát fájlba menteni."
+
+#: ../src/generic/logg.cpp:613
+#, c-format
+msgid "Log saved to the file '%s'."
+msgstr "A naplót a(z) '%s' fájl-ba mentettem."
+
+#: ../src/generic/logg.cpp:719
+msgid "&Details"
+msgstr "&Részletek"
+
+#: ../src/generic/logg.cpp:972
+#, fuzzy
+msgid "Failed to copy dialog contents to the clipboard."
+msgstr "Nem tudtam megnyitni a vágólapot."
+
+#: ../src/generic/logg.cpp:1022
+#, c-format
+msgid "Append log to file '%s' (choosing [No] will overwrite it)?"
+msgstr ""
+"A naplót  a(z) '%s' file végéhez írjam? (Ha [Nem]-et választ, felülírom!)"
+
+#: ../src/generic/logg.cpp:1024
+msgid "Question"
+msgstr "Kérdés"
+
+#: ../src/generic/logg.cpp:1038
+msgid "invalid message box return value"
+msgstr "érvénytelen üzenet ablak visszatérési érték"
+
+#: ../src/generic/notifmsgg.cpp:129
+#, fuzzy
+msgid "Notice"
+msgstr "&Megjegyzések:"
+
+#: ../src/generic/preferencesg.cpp:118
+#, fuzzy, c-format
+msgid "%s Preferences"
+msgstr "&Előválasztás"
+
+#: ../src/generic/printps.cpp:143
+msgid "Printing..."
+msgstr "Nyomtatás..."
+
+#: ../src/generic/printps.cpp:160 ../src/gtk/print.cpp:1076
+#: ../src/msw/printwin.cpp:235
+msgid "Could not start printing."
+msgstr "Nem tudom elindítani a nyomtatást."
+
+#: ../src/generic/printps.cpp:183
+#, c-format
+msgid "Printing page %d..."
+msgstr "A(z) %d. oldalt nyomtatom..."
+
+#: ../src/generic/prntdlgg.cpp:171
+msgid "Printer options"
+msgstr "Nyomtató lehetőségek"
+
+#: ../src/generic/prntdlgg.cpp:176
+msgid "Print to File"
+msgstr "Nyomtatás fájlba"
+
+#: ../src/generic/prntdlgg.cpp:179
+msgid "Setup..."
+msgstr "Beállítás..."
+
+#: ../src/generic/prntdlgg.cpp:187
+msgid "Printer:"
+msgstr "Nyomtató:"
+
+#: ../src/generic/prntdlgg.cpp:195
+msgid "Status:"
+msgstr "Állapot:"
+
+#: ../src/generic/prntdlgg.cpp:206
+msgid "All"
+msgstr "Mindet"
+
+#: ../src/generic/prntdlgg.cpp:207
+msgid "Pages"
+msgstr "Oldalak"
+
+#: ../src/generic/prntdlgg.cpp:215
+msgid "Print Range"
+msgstr "Nyomtatási tartomány"
+
+#: ../src/generic/prntdlgg.cpp:229
+msgid "From:"
+msgstr "Tól:"
+
+#: ../src/generic/prntdlgg.cpp:233
+msgid "To:"
+msgstr "Ig:"
+
+#: ../src/generic/prntdlgg.cpp:238
+msgid "Copies:"
+msgstr "Másolat(ok):"
+
+#: ../src/generic/prntdlgg.cpp:288
+msgid "PostScript file"
+msgstr "PostScript fájl"
+
+#: ../src/generic/prntdlgg.cpp:439
+msgid "Print Setup"
+msgstr "Nyomtatási beállítások"
+
+#: ../src/generic/prntdlgg.cpp:483
+msgid "Printer"
+msgstr "Nyomtató"
+
+#: ../src/generic/prntdlgg.cpp:501
+msgid "Default printer"
+msgstr "Az alapértelmezett nyomtató"
+
+#: ../src/generic/prntdlgg.cpp:595 ../src/generic/prntdlgg.cpp:782
+#: ../src/generic/prntdlgg.cpp:822 ../src/generic/prntdlgg.cpp:835
+#: ../src/generic/prntdlgg.cpp:1031 ../src/generic/prntdlgg.cpp:1036
+msgid "Paper size"
+msgstr "Papír méret"
+
+#: ../src/generic/prntdlgg.cpp:604 ../src/generic/prntdlgg.cpp:847
+msgid "Portrait"
+msgstr "Álló"
+
+#: ../src/generic/prntdlgg.cpp:605 ../src/generic/prntdlgg.cpp:848
+msgid "Landscape"
+msgstr "Tájkép"
+
+#: ../src/generic/prntdlgg.cpp:607 ../src/generic/prntdlgg.cpp:849
+msgid "Orientation"
+msgstr "Irányultság"
+
+#: ../src/generic/prntdlgg.cpp:610
+msgid "Options"
+msgstr "Lehetőségek"
+
+#: ../src/generic/prntdlgg.cpp:612
+msgid "Print in colour"
+msgstr "Színes nyomtatás"
+
+#: ../src/generic/prntdlgg.cpp:621
+msgid "Print spooling"
+msgstr "Nyomtatás sorbaállítással"
+
+#: ../src/generic/prntdlgg.cpp:623
+msgid "Printer command:"
+msgstr "Nyomtató parancs:"
+
+#: ../src/generic/prntdlgg.cpp:631
+msgid "Printer options:"
+msgstr "Nyomtató lehetőségek:"
+
+#: ../src/generic/prntdlgg.cpp:860
+msgid "Left margin (mm):"
+msgstr "Bal margó (mm):"
+
+#: ../src/generic/prntdlgg.cpp:861
+msgid "Top margin (mm):"
+msgstr "Felső margó (mm):"
+
+#: ../src/generic/prntdlgg.cpp:872
+msgid "Right margin (mm):"
+msgstr "Jobb margó (mm):"
+
+#: ../src/generic/prntdlgg.cpp:873
+msgid "Bottom margin (mm):"
+msgstr "Alsó margó (mm):"
+
+#: ../src/generic/prntdlgg.cpp:896
+msgid "Printer..."
+msgstr "Nyomtató..."
+
+#: ../src/generic/progdlgg.cpp:246
+#, fuzzy
+msgid "&Skip"
+msgstr "Ugrás"
+
+#: ../src/generic/progdlgg.cpp:347 ../src/generic/progdlgg.cpp:626
+#, fuzzy
+msgid "Unknown"
+msgstr "ismeretlen"
+
+#: ../src/generic/progdlgg.cpp:451 ../src/msw/progdlg.cpp:526
+msgid "Done."
+msgstr "Kész."
+
+#: ../src/generic/srchctlg.cpp:55 ../src/gtk/srchctrl.cpp:206
+#: ../src/html/helpwnd.cpp:530 ../src/html/helpwnd.cpp:545
+msgid "Search"
+msgstr "Keresés"
+
+#: ../src/generic/tabg.cpp:1026
+msgid "Could not find tab for id"
+msgstr "Nem találok lapválasztót az azonosítóhoz"
+
+#: ../src/generic/tipdlg.cpp:136
+msgid "Tips not available, sorry!"
+msgstr "Nincsenek tippek, sajnálom!"
+
+#: ../src/generic/tipdlg.cpp:197
+msgid "Tip of the Day"
+msgstr "A Nap Tippje"
+
+#: ../src/generic/tipdlg.cpp:207
+msgid "Did you know..."
+msgstr "Tudta Ön, hogy..."
+
+#: ../src/generic/tipdlg.cpp:232
+msgid "&Show tips at startup"
+msgstr "&Mutass ötleteket inditáskor"
+
+#: ../src/generic/tipdlg.cpp:236
+msgid "&Next Tip"
+msgstr "&Következő ötlet"
+
+#: ../src/generic/wizard.cpp:411
+msgid "&Next >"
+msgstr "&Következő >"
+
+#: ../src/generic/wizard.cpp:412
+msgid "&Finish"
+msgstr "Be&fejez"
+
+#: ../src/generic/wizard.cpp:420
+msgid "< &Back"
+msgstr "< &Vissza"
+
+#: ../src/gtk/aboutdlg.cpp:204
+msgid "translator-credits"
+msgstr ""
+
+#: ../src/gtk/app.cpp:517
+msgid ""
+"WARNING: using XIM input method is unsupported and may result in problems "
+"with input handling and flickering. Consider unsetting GTK_IM_MODULE or "
+"setting to \"ibus\"."
+msgstr ""
+
+#: ../src/gtk/app.cpp:569
+msgid "Unable to initialize GTK+, is DISPLAY set properly?"
+msgstr ""
+
+#: ../src/gtk/filedlg.cpp:89 ../src/gtk/filepicker.cpp:255
+#, fuzzy, c-format
+msgid "Changing current directory to \"%s\" failed"
+msgstr "Nem sikerült létrehozni a(z) \"%s\" könyvtárat"
+
+#: ../src/gtk/font.cpp:548
+msgid ""
+"Using private fonts is not supported on this system: Pango library is too "
+"old, 1.38 or later required."
+msgstr ""
+
+#: ../src/gtk/font.cpp:558
+#, fuzzy
+msgid "Failed to create font configuration object."
+msgstr "Nem tudom frissíteni a felhasználó konfigurációs fájlját."
+
+#: ../src/gtk/font.cpp:568
+#, fuzzy, c-format
+msgid "Failed to add custom font \"%s\"."
+msgstr "Nem tudtam betölteni a metafájlt a(z)  '%s' fájlból."
+
+#: ../src/gtk/font.cpp:576
+#, fuzzy
+msgid "Failed to register font configuration using private fonts."
+msgstr "Nem tudom frissíteni a felhasználó konfigurációs fájlját."
+
+#: ../src/gtk/glcanvas.cpp:117 ../src/gtk/glcanvas.cpp:132
+#, fuzzy
+msgid "Fatal Error"
+msgstr "Végzetes hiba"
+
+#: ../src/gtk/glcanvas.cpp:117
+msgid ""
+"This program wasn't compiled with EGL support required under Wayland, "
+"either\n"
+"install EGL libraries and rebuild or run it under X11 backend by setting\n"
+"environment variable GDK_BACKEND=x11 before starting your program."
+msgstr ""
+
+#: ../src/gtk/glcanvas.cpp:132
+msgid ""
+"wxGLCanvas is only supported on Wayland and X11 currently.  You may be able "
+"to\n"
+"work around this by setting environment variable GDK_BACKEND=x11 before\n"
+"starting your program."
+msgstr ""
+
+#: ../src/gtk/mdi.cpp:433
+msgid "MDI child"
+msgstr "MDI gyermek"
+
+#: ../src/gtk/power.cpp:188
+#, fuzzy, c-format
+msgid "Failed to open D-Bus connection to the login manager: %s"
+msgstr "Nem sikerült %s a(z) %s telefonos kapcsolatban"
+
+#: ../src/gtk/power.cpp:214
+#, fuzzy
+msgid "wxWidgets application"
+msgstr "Kiválasztott"
+
+#: ../src/gtk/power.cpp:226
+msgid "Application needs to keep running"
+msgstr ""
+
+#: ../src/gtk/power.cpp:233
+msgid "Clean up before suspend"
+msgstr ""
+
+#: ../src/gtk/power.cpp:259
+#, fuzzy, c-format
+msgid "Failed to inhibit sleep: %s"
+msgstr "Nem tudtam befejezni a(z) %s telefon kapcsolatot."
+
+#: ../src/gtk/power.cpp:265
+msgid "Unexpected response to D-Bus \"Inhibit\" request."
+msgstr ""
+
+#: ../src/gtk/print.cpp:218
+#, fuzzy
+msgid "Custom size"
+msgstr "Jelkészlet méret"
+
+#: ../src/gtk/print.cpp:752
+#, fuzzy, c-format
+msgid "Error while printing: %s"
+msgstr "Hiba történt a semaforra várakozás során"
+
+#: ../src/gtk/print.cpp:816
+msgid "Page Setup"
+msgstr "Oldal beállítás"
+
+#: ../src/gtk/webview_webkit.cpp:932
+msgid "Retrieving JavaScript script output is not supported with WebKit v1"
+msgstr ""
+
+#: ../src/gtk/webview_webkit2.cpp:1098
+msgid ""
+"Setting proxy is not supported by WebKit, at least version 2.16 is required."
+msgstr ""
+
+#: ../src/gtk/webview_webkit2.cpp:1104
+msgid "This program was compiled without support for setting WebKit proxy."
+msgstr ""
+
+#: ../src/gtk/window.cpp:6289
+msgid ""
+"GTK+ installed on this machine is too old to support screen compositing, "
+"please install GTK+ 2.12 or later."
+msgstr ""
+
+#: ../src/gtk/window.cpp:6307
+msgid ""
+"Compositing not supported by this system, please enable it in your Window "
+"Manager."
+msgstr ""
+
+#: ../src/gtk/window.cpp:6318
+msgid ""
+"This program was compiled with a too old version of GTK+, please rebuild "
+"with GTK+ 2.12 or newer."
+msgstr ""
+
+#: ../src/html/chm.cpp:138
+#, c-format
+msgid "Failed to open CHM archive '%s'."
+msgstr "Nem tudtam megnyitni a(z) '%s' CHM archive fájlt."
+
+#: ../src/html/chm.cpp:270
+#, c-format
+msgid "Could not extract %s into %s: %s"
+msgstr "Nem tudtam kifejteni %s-t %s-be: %s"
+
+#: ../src/html/chm.cpp:324
+msgid "no error"
+msgstr "nincs hiba"
+
+#: ../src/html/chm.cpp:326
+msgid "bad arguments to library function"
+msgstr "hibás argumentumok a könyvtári függvényben"
+
+#: ../src/html/chm.cpp:328
+msgid "error opening file"
+msgstr "fájl megnyitási hiba"
+
+#: ../src/html/chm.cpp:330
+msgid "read error"
+msgstr "olvasás hiba"
+
+#: ../src/html/chm.cpp:332
+msgid "write error"
+msgstr "írási hiba"
+
+#: ../src/html/chm.cpp:334
+msgid "seek error"
+msgstr "keresési hiba"
+
+#: ../src/html/chm.cpp:338
+msgid "bad signature"
+msgstr "hibás aláírás"
+
+#: ../src/html/chm.cpp:340
+msgid "error in data format"
+msgstr "adatformátum hiba"
+
+#: ../src/html/chm.cpp:342
+msgid "checksum error"
+msgstr "hibás ellenőrző összeg"
+
+#: ../src/html/chm.cpp:344
+msgid "compression error"
+msgstr "tömörítési hiba"
+
+#: ../src/html/chm.cpp:346
+msgid "decompression error"
+msgstr "kifejtési hiba"
+
+#: ../src/html/chm.cpp:437
+#, c-format
+msgid "Could not locate file '%s'."
+msgstr "Nem tudtam megtalálni a(z) '%s' fájlt."
+
+#: ../src/html/chm.cpp:711
+#, c-format
+msgid "Could not create temporary file '%s'"
+msgstr "Nem tudom létrehozni a(z) '%s' átmeneti fájlt"
+
+#: ../src/html/chm.cpp:718
+#, c-format
+msgid "Extraction of '%s' into '%s' failed."
+msgstr "Nem sikerült kifejteni  '%s'-t '%s'-be"
+
+#: ../src/html/chm.cpp:806 ../src/html/chm.cpp:863
+msgid "CHM handler currently supports only local files!"
+msgstr "A CHM kezelő jelenleg csak helyi fájlokat támogat!"
+
+#: ../src/html/chm.cpp:827
+msgid "Link contained '//', converted to absolute link."
+msgstr "A mutató '//'-t tartalmazott, abszolút mutatóvá alakítottam."
+
+#: ../src/html/helpctrl.cpp:59
+#, c-format
+msgid "Help: %s"
+msgstr "Súgó: %s"
+
+#: ../src/html/helpctrl.cpp:155
+#, c-format
+msgid "Adding book %s"
+msgstr "Add hozzá a %s könyvet"
+
+#: ../src/html/helpdata.cpp:295
+#, c-format
+msgid "Cannot open contents file: %s"
+msgstr "Nem tudom megnyitni a(z) %s tartalom fájlt"
+
+#: ../src/html/helpdata.cpp:309
+#, c-format
+msgid "Cannot open index file: %s"
+msgstr "Nem tudom a(z) %s index fájlt megnyitni"
+
+#: ../src/html/helpdata.cpp:643
+msgid "noname"
+msgstr "névtelen"
+
+#: ../src/html/helpdata.cpp:652
+#, c-format
+msgid "Cannot open HTML help book: %s"
+msgstr "Nem tudom megnyitni a(z) %s súgó könyvet"
+
+#: ../src/html/helpwnd.cpp:315
+msgid "Displays help as you browse the books on the left."
+msgstr ""
+
+#: ../src/html/helpwnd.cpp:411 ../src/html/helpwnd.cpp:1100
+#: ../src/html/helpwnd.cpp:1735
+msgid "(bookmarks)"
+msgstr "(könyvjelzők)"
+
+#: ../src/html/helpwnd.cpp:424
+msgid "Add current page to bookmarks"
+msgstr "Add hozzá ezt a lapot a könyvjelzőkhöz"
+
+#: ../src/html/helpwnd.cpp:425
+msgid "Remove current page from bookmarks"
+msgstr "Töröld ezt az oldalt a könyvjelzők közül"
+
+#: ../src/html/helpwnd.cpp:470
+msgid "Contents"
+msgstr "Tartalom"
+
+#: ../src/html/helpwnd.cpp:485
+msgid "Find"
+msgstr "Keres"
+
+#: ../src/html/helpwnd.cpp:487
+msgid "Show all"
+msgstr "Mutatsd mindet"
+
+#: ../src/html/helpwnd.cpp:497
+msgid ""
+"Display all index items that contain given substring. Search is case "
+"insensitive."
+msgstr ""
+"Írja ki az összes index bejegyzést, ami tartalmazza az adott bejegyzést. A "
+"keresés kis/nagy betűre nem érzékeny."
+
+#: ../src/html/helpwnd.cpp:498
+msgid "Show all items in index"
+msgstr "Mutasd meg a tartalom mutató valamennyi elemét"
+
+#: ../src/html/helpwnd.cpp:528
+msgid "Case sensitive"
+msgstr "Kis/nagybetűk különbözőek"
+
+#: ../src/html/helpwnd.cpp:529
+msgid "Whole words only"
+msgstr "Csak egész szavak"
+
+#: ../src/html/helpwnd.cpp:532
+#, fuzzy
+msgid ""
+"Search contents of help book(s) for all occurrences of the text you typed "
+"above"
+msgstr ""
+"Keresd meg a fentebb beírt szöveg valamennyi előfordulását a súgó "
+"könyv(ek)ben"
+
+#: ../src/html/helpwnd.cpp:653
+msgid "Show/hide navigation panel"
+msgstr "Bemutatja/elrejti az irányító elemeket"
+
+#: ../src/html/helpwnd.cpp:655
+msgid "Go back"
+msgstr "Menj vissza"
+
+#: ../src/html/helpwnd.cpp:656
+msgid "Go forward"
+msgstr "Menj előre"
+
+#: ../src/html/helpwnd.cpp:658
+msgid "Go one level up in document hierarchy"
+msgstr "Menj a dokumentum hierarchia eggyel magasabb szintjére"
+
+#: ../src/html/helpwnd.cpp:666 ../src/html/helpwnd.cpp:1547
+msgid "Open HTML document"
+msgstr "Nyisd meg a HTML dokumentumot"
+
+#: ../src/html/helpwnd.cpp:670
+msgid "Print this page"
+msgstr "Nyomtasd ezt az oldalt"
+
+#: ../src/html/helpwnd.cpp:674
+msgid "Display options dialog"
+msgstr "Képernyő beállítási párbeszédablak"
+
+#: ../src/html/helpwnd.cpp:795
+msgid "Please choose the page to display:"
+msgstr "Kérem válassza ki a látni kívánt oldalt:"
+
+#: ../src/html/helpwnd.cpp:796
+msgid "Help Topics"
+msgstr "Súgó témakörök"
+
+#: ../src/html/helpwnd.cpp:852
+msgid "Searching..."
+msgstr "Keresek..."
+
+#: ../src/html/helpwnd.cpp:853
+msgid "No matching page found yet"
+msgstr "Még nem találtam egy megfelelő oldalt"
+
+#: ../src/html/helpwnd.cpp:870
+#, c-format
+msgid "Found %i matches"
+msgstr "%i megfelelőt találtam"
+
+#: ../src/html/helpwnd.cpp:958
+msgid "(Help)"
+msgstr "(Súgó)"
+
+#: ../src/html/helpwnd.cpp:1026
+#, fuzzy, c-format
+msgid "%d of %lu"
+msgstr "%i. (össz %i)"
+
+#: ../src/html/helpwnd.cpp:1028
+#, fuzzy, c-format
+msgid "%lu of %lu"
+msgstr "%i. (össz %i)"
+
+#: ../src/html/helpwnd.cpp:1047
+msgid "Search in all books"
+msgstr "Keresés az összes könyvben"
+
+#: ../src/html/helpwnd.cpp:1193
+msgid "Help Browser Options"
+msgstr "Súgó Böngésző beállítások"
+
+#: ../src/html/helpwnd.cpp:1198
+msgid "Normal font:"
+msgstr "Normál jelkészlet:"
+
+#: ../src/html/helpwnd.cpp:1199
+msgid "Fixed font:"
+msgstr "Nem skálázható jelkészlet:"
+
+#: ../src/html/helpwnd.cpp:1200
+msgid "Font size:"
+msgstr "Jelkészlet mérete:"
+
+#: ../src/html/helpwnd.cpp:1245
+msgid "font size"
+msgstr "Jelkészlet méret"
+
+#: ../src/html/helpwnd.cpp:1256
+msgid "Normal face<br>and <u>underlined</u>. "
+msgstr "Normál btű<br>and <u>aláhúzva</u>. "
+
+#: ../src/html/helpwnd.cpp:1257
+msgid "<i>Italic face.</i> "
+msgstr "<i>Dőlt betű.</i> "
+
+#: ../src/html/helpwnd.cpp:1258
+msgid "<b>Bold face.</b> "
+msgstr "<b>Félkövér betű.</b> "
+
+#: ../src/html/helpwnd.cpp:1259
+msgid "<b><i>Bold italic face.</i></b><br>"
+msgstr "<b><i>Félkövér dőlt betű.</i></b><br>"
+
+#: ../src/html/helpwnd.cpp:1262
+msgid "Fixed size face.<br> <b>bold</b> <i>italic</i> "
+msgstr "Rögzített méretű betű.<br> <b>bold</b> <i>dőlt</i> "
+
+#: ../src/html/helpwnd.cpp:1263
+msgid "<b><i>bold italic <u>underlined</u></i></b><br>"
+msgstr "<b><i>félkövér dőlt <u>aláhúzott</u></i></b><br>"
+
+#: ../src/html/helpwnd.cpp:1524
+msgid "Help Printing"
+msgstr "Súgó nyomtatás"
+
+#: ../src/html/helpwnd.cpp:1527
+msgid "Cannot print empty page."
+msgstr "Nem tudok üres oldalt nyomtatni."
+
+#: ../src/html/helpwnd.cpp:1540
+msgid "HTML files (*.html;*.htm)|*.html;*.htm|"
+msgstr "HTML fájlok (*.html;*.htm)|*.html;*.htm|"
+
+#: ../src/html/helpwnd.cpp:1541
+msgid "Help books (*.htb)|*.htb|Help books (*.zip)|*.zip|"
+msgstr "Súgó könyvek (*.htb)|*.htb|Súgó könyvek (*.zip)|*.zip|"
+
+#: ../src/html/helpwnd.cpp:1542
+msgid "HTML Help Project (*.hhp)|*.hhp|"
+msgstr "HTML Help Project (*.hhp)|*.hhp|"
+
+#: ../src/html/helpwnd.cpp:1544
+msgid "Compressed HTML Help file (*.chm)|*.chm|"
+msgstr "Tömörített HTML súgó file (*.chm)|*.chm|"
+
+#: ../src/html/helpwnd.cpp:1671
+#, fuzzy, c-format
+msgid "%i of %u"
+msgstr "%i. (össz %i)"
+
+#: ../src/html/helpwnd.cpp:1709
+#, fuzzy, c-format
+msgid "%u of %u"
+msgstr "%i. (össz %i)"
+
+#: ../src/html/htmlfilt.cpp:134
+#, c-format
+msgid "Cannot open HTML document: %s"
+msgstr "Nem tudom megnyitni a(z) %s HTML dokumentumot"
+
+#: ../src/html/htmlwin.cpp:599
+msgid "Connecting..."
+msgstr "Kapcsolódás..."
+
+#: ../src/html/htmlwin.cpp:616
+#, c-format
+msgid "Unable to open requested HTML document: %s"
+msgstr "Nem tudom megnyitni a kért %s HTML dokumentumot."
+
+#: ../src/html/htmlwin.cpp:630
+msgid "Loading : "
+msgstr "Betöltés : "
+
+#: ../src/html/htmlwin.cpp:673
+msgid "Done"
+msgstr "Kész"
+
+#: ../src/html/htmlwin.cpp:723
+#, c-format
+msgid "HTML anchor %s does not exist."
+msgstr "A(z) %s horgony nem létezik."
+
+#: ../src/html/htmlwin.cpp:1057
+#, c-format
+msgid "Copied to clipboard:\"%s\""
+msgstr "Átmásolva a \"%s\" vágólapra"
+
+#: ../src/html/htmprint.cpp:269
+msgid ""
+"This document doesn't fit on the page horizontally and will be truncated "
+"when it is printed."
+msgstr ""
+
+#: ../src/html/htmprint.cpp:285
+#, c-format
+msgid ""
+"The document \"%s\" doesn't fit on the page horizontally and will be "
+"truncated if printed.\n"
+"\n"
+"Would you like to proceed with printing it nevertheless?"
+msgstr ""
+
+#: ../src/html/htmprint.cpp:296
+msgid ""
+"If possible, try changing the layout parameters to make the printout more "
+"narrow."
+msgstr ""
+
+#: ../src/html/htmprint.cpp:445
+msgid ": file does not exist!"
+msgstr ": a file nem létezik!"
+
+#. TRANSLATORS: %s may be a document title.
+#: ../src/html/htmprint.cpp:717
+#, fuzzy, c-format
+msgid "%s Preview"
+msgstr " Nyomtatási előkép"
+
+#: ../src/html/htmprint.cpp:755 ../src/richtext/richtextprint.cpp:618
+msgid ""
+"There was a problem during page setup: you may need to set a default printer."
+msgstr ""
+"Az oldal beállításakor hiba történt: lehet hogy az alapértelmezett nyomtatót "
+"kellene beállítania."
+
+#: ../src/msw/clipbrd.cpp:80
+msgid "Failed to open the clipboard."
+msgstr "Nem tudtam megnyitni a vágólapot."
+
+#: ../src/msw/clipbrd.cpp:101
+msgid "Failed to close the clipboard."
+msgstr "Nem sikerült lezárni a vágólapot."
+
+#: ../src/msw/clipbrd.cpp:113
+msgid "Failed to empty the clipboard."
+msgstr "Nem sikerült kiüríteni a vágólapot."
+
+#: ../src/msw/clipbrd.cpp:284
+msgid "Failed to put data on the clipboard"
+msgstr "Nem tudtam adatokat tenni a vágólapra."
+
+#: ../src/msw/clipbrd.cpp:326
+msgid "Failed to get data from the clipboard"
+msgstr "Nem kaptam a vágólapról adatokat"
+
+#: ../src/msw/clipbrd.cpp:363
+msgid "Failed to retrieve the supported clipboard formats"
+msgstr "Nem tudtam meghatározni a támogatott vágólap formátumokat."
+
+#: ../src/msw/colordlg.cpp:228
+#, fuzzy, c-format
+msgid "Colour selection dialog failed with error %0lx."
+msgstr "Nem sikerült végrehajtani a(z) '%s' parancsot, hibakód: %ul"
+
+#: ../src/msw/cursor.cpp:141
+msgid "Failed to create cursor."
+msgstr "Nem sikerült lérehozni egér mutatót."
+
+#: ../src/msw/dde.cpp:279
+#, c-format
+msgid "Failed to register DDE server '%s'"
+msgstr "Nem tudtam regisztrálni a(z) '%s' DDE kiszolgálót"
+
+#: ../src/msw/dde.cpp:300
+#, c-format
+msgid "Failed to unregister DDE server '%s'"
+msgstr "Nem tudtam a(z) '%s' DDE kiszolgáló regisztrációját megszüntetni."
+
+#: ../src/msw/dde.cpp:428
+#, c-format
+msgid "Failed to create connection to server '%s' on topic '%s'"
+msgstr ""
+"Nem sikerült kapcsolatot létrehozni a '%s' kiszolgálóval a '%s' témában"
+
+#: ../src/msw/dde.cpp:655
+msgid "DDE poke request failed"
+msgstr "DDE adatbeírás nem sikerült"
+
+#: ../src/msw/dde.cpp:674
+msgid "Failed to establish an advise loop with DDE server"
+msgstr "Nem sikerült létrehozni tanácsadói kapcsolatot a DDE kiszolgálóval"
+
+#: ../src/msw/dde.cpp:693
+msgid "Failed to terminate the advise loop with DDE server"
+msgstr "Nem tudtam befejezni a tanácskozási ciklust a DDE kiszolgálóval."
+
+#: ../src/msw/dde.cpp:768
+msgid "Failed to send DDE advise notification"
+msgstr "Nem sikerült DDE tanácsot küldeni."
+
+#: ../src/msw/dde.cpp:1085
+msgid "Failed to create DDE string"
+msgstr "Nem sikerült létrehozni a DDE láncot"
+
+#: ../src/msw/dde.cpp:1131
+msgid "no DDE error."
+msgstr "nincs DDE hiba."
+
+#: ../src/msw/dde.cpp:1135
+msgid "a request for a synchronous advise transaction has timed out."
+msgstr "a szinkron tanácskérési tranzakció nem fejeződött be időre."
+
+#: ../src/msw/dde.cpp:1138
+msgid "the response to the transaction caused the DDE_FBUSY bit to be set."
+msgstr "a tranzakció eredményeként a DDE_FBUSY bit beállítódott."
+
+#: ../src/msw/dde.cpp:1141
+msgid "a request for a synchronous data transaction has timed out."
+msgstr "a szinkron adatkérési tranzakció nem fejeződött be időre."
+
+#: ../src/msw/dde.cpp:1144
+msgid ""
+"a DDEML function was called without first calling the DdeInitialize "
+"function,\n"
+"or an invalid instance identifier\n"
+"was passed to a DDEML function."
+msgstr ""
+"egy DDEML függvényt hívott anélkül, hogy először a  DdeInitialize függvényt "
+"hívta volna,\n"
+"vagy érvénytelen instance azonosítót \n"
+"adott át a DDEML függvénynek."
+
+#: ../src/msw/dde.cpp:1147
+msgid ""
+"an application initialized as APPCLASS_MONITOR has\n"
+"attempted to perform a DDE transaction,\n"
+"or an application initialized as APPCMD_CLIENTONLY has \n"
+"attempted to perform server transactions."
+msgstr ""
+"egy APPCLASS_MONITOR-ként inicializált alkalmazás\n"
+"DDE tranzakciót próbált végezni,\n"
+"vagy  APPCMD_CLIENTONLY-ként inicializált alkalmazás\n"
+"próbált meg kiszolgáló tranzakciót végezni."
+
+#: ../src/msw/dde.cpp:1150
+msgid "a request for a synchronous execute transaction has timed out."
+msgstr "a szinkron végrehajtás kérési tranzakció nem fejeződött be időre."
+
+#: ../src/msw/dde.cpp:1153
+msgid "a parameter failed to be validated by the DDEML."
+msgstr "a paramétert nem sikerült érvényesíttetni a DDEML-lel."
+
+#: ../src/msw/dde.cpp:1156
+msgid "a DDEML application has created a prolonged race condition."
+msgstr "a DDEML alkalmazás meghosszabított versenyhelyzetet teremtett."
+
+#: ../src/msw/dde.cpp:1159
+msgid "a memory allocation failed."
+msgstr "a memória lefoglalása nem sikerült."
+
+#: ../src/msw/dde.cpp:1162
+msgid "a client's attempt to establish a conversation has failed."
+msgstr "nem sikerült az ügyfél próbálkozása a párbeszéd létrehozására."
+
+#: ../src/msw/dde.cpp:1165
+msgid "a transaction failed."
+msgstr "sikertelen tranzakció."
+
+#: ../src/msw/dde.cpp:1168
+msgid "a request for a synchronous poke transaction has timed out."
+msgstr "a szinkron adatlerakás kérési tranzakció nem fejeződött be időre."
+
+#: ../src/msw/dde.cpp:1171
+msgid "an internal call to the PostMessage function has failed. "
+msgstr "egy belső PostMessage függvényhívás nem sikerült. "
+
+#: ../src/msw/dde.cpp:1174
+msgid "reentrancy problem."
+msgstr "újrabelépési probléma."
+
+#: ../src/msw/dde.cpp:1177
+msgid ""
+"a server-side transaction was attempted on a conversation\n"
+"that was terminated by the client, or the server\n"
+"terminated before completing a transaction."
+msgstr ""
+"a kiszolgáló olyan párbeszédben kísérelt meg tranzakciót végrehajtani\n"
+"amelyiket az ügyfél már befejezett, vagy a kiszolgáló\n"
+"a tranzakció befejezése előtt kilépett."
+
+#: ../src/msw/dde.cpp:1180
+msgid "an internal error has occurred in the DDEML."
+msgstr "belső hiba történt a DDEML-ben."
+
+#: ../src/msw/dde.cpp:1183
+msgid "a request to end an advise transaction has timed out."
+msgstr ""
+"a  tanácskozási tranzakció befejezésének kérése nem fejeződött be időre."
+
+#: ../src/msw/dde.cpp:1186
+msgid ""
+"an invalid transaction identifier was passed to a DDEML function.\n"
+"Once the application has returned from an XTYP_XACT_COMPLETE callback,\n"
+"the transaction identifier for that callback is no longer valid."
+msgstr ""
+"érvénytelen azonosítót adott át a DDEML függvénynek.\n"
+"Ha az alkalmazás visszatért egy XTYP_XACT_COMPLETE visszahívásból,\n"
+"a tranzakció azonosítója erre a hívásra már nem érvényes."
+
+#: ../src/msw/dde.cpp:1189
+#, c-format
+msgid "Unknown DDE error %08x"
+msgstr "Ismeretlen DDE hiba %08x"
+
+#: ../src/msw/dialup.cpp:343
+msgid ""
+"Dial up functions are unavailable because the remote access service (RAS) is "
+"not installed on this machine. Please install it."
+msgstr ""
+"A tárcsázó funkciók nem használhatók, mert a távoli elérés szolgáltatás "
+"(RAS) nincs installálva ezen a gépen. Kérem installálja."
+
+#: ../src/msw/dialup.cpp:402
+#, fuzzy, c-format
+msgid ""
+"The version of remote access service (RAS) installed on this machine is too "
+"old, please upgrade (the following required function is missing: %s)."
+msgstr ""
+"Az ezen a gépre installált távoli hozzáférési lehetőség  (RAS) túl régi, "
+"kérem frissítsen (A(z) %s szükséges funkció hiányzik)."
+
+#: ../src/msw/dialup.cpp:437
+msgid "Failed to retrieve text of RAS error message"
+msgstr "Nem sikerült értelmezni a RAS hibaüzenet szövegét."
+
+#: ../src/msw/dialup.cpp:440
+#, c-format
+msgid "unknown error (error code %08x)."
+msgstr "ismeretlen hiba (hiba kód %08x)."
+
+#: ../src/msw/dialup.cpp:492
+#, c-format
+msgid "Cannot find active dialup connection: %s"
+msgstr "Nem találom a(z) %s aktív telefonos kapcsolatot"
+
+#: ../src/msw/dialup.cpp:513
+msgid "Several active dialup connections found, choosing one randomly."
+msgstr ""
+"Több aktív telefonkapcsolatot találtam, az egyiket véletlenszerűen "
+"kiválasztom."
+
+#: ../src/msw/dialup.cpp:598 ../src/msw/dialup.cpp:832
+#, c-format
+msgid "Failed to establish dialup connection: %s"
+msgstr "Nem sikerült létrehozni a telefonos kapcsolatot: %s"
+
+#: ../src/msw/dialup.cpp:664
+#, c-format
+msgid "Failed to get ISP names: %s"
+msgstr "Nem kaptam meg a(z) %s ISP(szolgáltató) neveket"
+
+#: ../src/msw/dialup.cpp:712
+msgid "Failed to connect: no ISP to dial."
+msgstr ""
+"Nem sikerült létrehozni a kapcsolatot: nincs tárcsázható szolgáltató (ISP)."
+
+#: ../src/msw/dialup.cpp:732
+msgid "Choose ISP to dial"
+msgstr "Válassza ki a tárcsázandó szolgáltatót (ISPt)!"
+
+#: ../src/msw/dialup.cpp:733
+msgid "Please choose which ISP do you want to connect to"
+msgstr "Kérem válassza ki, melyik szolgáltatóhoz (ISP) akar kapcsolódni."
+
+#: ../src/msw/dialup.cpp:766
+msgid "Failed to connect: missing username/password."
+msgstr ""
+"Nem sikerült létrehozni a kapcsolatot: hiányzik a felhasználói név vagy a "
+"jelszó."
+
+#: ../src/msw/dialup.cpp:796
+msgid "Cannot find the location of address book file"
+msgstr "Nem találom a címjegyzék fájl helyét"
+
+#: ../src/msw/dialup.cpp:827
+#, fuzzy, c-format
+msgid "Failed to initiate dialup connection: %s"
+msgstr "Nem tudtam befejezni a(z) %s telefon kapcsolatot."
+
+#: ../src/msw/dialup.cpp:897
+msgid "Cannot hang up - no active dialup connection."
+msgstr "Nem tudom letenni - nincs aktív telefonkapcsolat."
+
+#: ../src/msw/dialup.cpp:907
+#, c-format
+msgid "Failed to terminate the dialup connection: %s"
+msgstr "Nem tudtam befejezni a(z) %s telefon kapcsolatot."
+
+#: ../src/msw/dib.cpp:313
+#, c-format
+msgid "Failed to save the bitmap image to file \"%s\"."
+msgstr "Nem tudtam elmenteni a bittérképet a(z)  '%s' fájlba."
+
+#: ../src/msw/dib.cpp:543
+#, fuzzy, c-format
+msgid "Failed to allocate %luKb of memory for bitmap data."
+msgstr "Nem sikerült %luKb tárterületet foglalni a memóriatérkép adatoknak."
+
+#: ../src/msw/dir.cpp:241
+#, c-format
+msgid "Cannot enumerate files in directory '%s'"
+msgstr "Nem tudom megszámolni a(z) '%s' könyvtárban a fájlokat"
+
+#: ../src/msw/dirdlg.cpp:368
+#, fuzzy
+msgid "Couldn't obtain folder name"
+msgstr "Nem tudtam időzítőt létrehozni"
+
+#: ../src/msw/dlmsw.cpp:163
+#, fuzzy, c-format
+msgid "(error %d: %s)"
+msgstr "(hiba %ld: %s) "
+
+#: ../src/msw/dragimag.cpp:143 ../src/msw/dragimag.cpp:178
+#: ../src/msw/imaglist.cpp:309 ../src/msw/imaglist.cpp:331
+msgid "Couldn't add an image to the image list."
+msgstr "Nem tudok egy képet a képek listájához hozzáadni."
+
+#: ../src/msw/enhmeta.cpp:94
+#, c-format
+msgid "Failed to load metafile from file \"%s\"."
+msgstr "Nem tudtam betölteni a metafájlt a(z)  '%s' fájlból."
+
+#: ../src/msw/fdrepdlg.cpp:412
+#, c-format
+msgid "Failed to create the standard find/replace dialog (error code %d)"
+msgstr ""
+"Nem sikerült létrehozni a keresés-helyettesítés párbeszéd ablakot (hibakód : "
+"%d) "
+
+#: ../src/msw/filedlg.cpp:1241
+msgid "Access to the file system is not allowed from secure desktop."
+msgstr ""
+
+#: ../src/msw/filedlg.cpp:1242
+msgid "Security warning"
+msgstr ""
+
+#: ../src/msw/filedlg.cpp:1533
+#, fuzzy, c-format
+msgid "File dialog failed with error code %0lx."
+msgstr "Nem sikerült végrehajtani a(z) '%s' parancsot, hibakód: %ul"
+
+#: ../src/msw/font.cpp:1120
+#, fuzzy, c-format
+msgid "Font file \"%s\" couldn't be loaded"
+msgstr "A fájlt nem tudtam betölteni."
+
+#: ../src/msw/fontdlg.cpp:220
+#, fuzzy, c-format
+msgid "Common dialog failed with error code %0lx."
+msgstr "Nem sikerült végrehajtani a(z) '%s' parancsot, hibakód: %ul"
+
+#: ../src/msw/fswatcher.cpp:67
+#, fuzzy
+msgid "Ungraceful worker thread termination"
+msgstr "Nem tudom megvárni a szál befejeződését"
+
+#: ../src/msw/fswatcher.cpp:81
+#, fuzzy
+msgid "Unable to create IOCP worker thread"
+msgstr "Nem sikerült létrehozni az MDI szülő keretet."
+
+#: ../src/msw/fswatcher.cpp:88
+msgid "Unable to start IOCP worker thread"
+msgstr ""
+
+#: ../src/msw/fswatcher.cpp:140
+msgid "Monitoring individual files for changes is not supported currently."
+msgstr ""
+
+#: ../src/msw/fswatcher.cpp:165
+#, fuzzy, c-format
+msgid "Unable to set up watch for '%s'"
+msgstr "Nem sikerült megérinteni a(z) '%s't."
+
+#: ../src/msw/fswatcher.cpp:466
+#, c-format
+msgid "Can't monitor non-existent directory \"%s\" for changes."
+msgstr ""
+
+#: ../src/msw/glcanvas.cpp:577 ../src/unix/glx11.cpp:507
+msgid "OpenGL 3.0 or later is not supported by the OpenGL driver."
+msgstr ""
+
+#: ../src/msw/glcanvas.cpp:601 ../src/osx/glcanvas_osx.cpp:395
+#: ../src/unix/glegl.cpp:304 ../src/unix/glx11.cpp:553
+#, fuzzy
+msgid "Couldn't create OpenGL context"
+msgstr "Nem tudtam időzítőt létrehozni"
+
+#: ../src/msw/glcanvas.cpp:1294
+msgid "Failed to initialize OpenGL"
+msgstr "Nem tudom elindítani az OpenGLt."
+
+#: ../src/msw/graphicsd2d.cpp:607
+msgid "Could not register custom DirectWrite font loader."
+msgstr ""
+
+#: ../src/msw/helpchm.cpp:48
+msgid ""
+"MS HTML Help functions are unavailable because the MS HTML Help library is "
+"not installed on this machine. Please install it."
+msgstr ""
+"A MS HTML funkciók nem használhatók, mert a MS HTML Help könyvtár nincs "
+"installálva ezen a gépen. Kérem installálja."
+
+#: ../src/msw/helpchm.cpp:55
+msgid "Failed to initialize MS HTML Help."
+msgstr "Nem sikerült elindítani az MS HTML súgót."
+
+#: ../src/msw/iniconf.cpp:458
+#, c-format
+msgid "Can't delete the INI file '%s'"
+msgstr "Nem tudom törölni a '%s' INI fájt"
+
+#: ../src/msw/listctrl.cpp:995
+#, c-format
+msgid "Couldn't retrieve information about list control item %d."
+msgstr "Nem kaptam információt a lista vezérlő %d eleméről."
+
+#: ../src/msw/mdi.cpp:170 ../src/qt/mdi.cpp:253
+msgid "&Cascade"
+msgstr "&Zuhatag"
+
+#: ../src/msw/mdi.cpp:171
+msgid "Tile &Horizontally"
+msgstr "Csempék &Vízszintesen"
+
+#: ../src/msw/mdi.cpp:172
+msgid "Tile &Vertically"
+msgstr "Csempék &Függőlegesen"
+
+#: ../src/msw/mdi.cpp:174
+msgid "&Arrange Icons"
+msgstr "Ikonok &elrendezése"
+
+#: ../src/msw/mdi.cpp:621
+msgid "Failed to create MDI parent frame."
+msgstr "Nem sikerült létrehozni az MDI szülő keretet."
+
+#: ../src/msw/mimetype.cpp:234
+#, c-format
+msgid "Failed to create registry entry for '%s' files."
+msgstr "Nem tudtam létrehozni registry bejegyzést a(z) '%s' fájlokra."
+
+#: ../src/msw/ole/automtn.cpp:495
+#, fuzzy, c-format
+msgid "Failed to find CLSID of \"%s\""
+msgstr "Nem tudtam megnyitni '%s'-t %s-ként."
+
+#: ../src/msw/ole/automtn.cpp:512
+#, fuzzy, c-format
+msgid "Failed to create an instance of \"%s\""
+msgstr "Nem sikerült létrehozni a(z) \"%s\" könyvtárat"
+
+#: ../src/msw/ole/automtn.cpp:552
+#, fuzzy, c-format
+msgid "Cannot get an active instance of \"%s\""
+msgstr "Nem találom a(z) %s aktív telefonos kapcsolatot"
+
+#: ../src/msw/ole/automtn.cpp:564
+#, fuzzy, c-format
+msgid "Failed to get OLE automation interface for \"%s\""
+msgstr "Nem sikerült létrehozni a(z) \"%s\" könyvtárat"
+
+#: ../src/msw/ole/automtn.cpp:621
+msgid "Unknown name or named argument."
+msgstr ""
+
+#: ../src/msw/ole/automtn.cpp:625
+msgid "Incorrect number of arguments."
+msgstr ""
+
+#: ../src/msw/ole/automtn.cpp:637
+#, fuzzy
+msgid "Unknown exception"
+msgstr "Ismeretlen opció '%s'"
+
+#: ../src/msw/ole/automtn.cpp:642
+msgid "Method or property not found."
+msgstr ""
+
+#: ../src/msw/ole/automtn.cpp:646
+msgid "Overflow while coercing argument values."
+msgstr ""
+
+#: ../src/msw/ole/automtn.cpp:650
+msgid "Object implementation does not support named arguments."
+msgstr ""
+
+#: ../src/msw/ole/automtn.cpp:654
+msgid "The locale ID is unknown."
+msgstr ""
+
+#: ../src/msw/ole/automtn.cpp:658
+msgid "Missing a required parameter."
+msgstr ""
+
+#: ../src/msw/ole/automtn.cpp:662
+#, fuzzy, c-format
+msgid "Argument %u not found."
+msgstr "a(z) '%s' domén konfigurációs fájlját nem találom."
+
+#: ../src/msw/ole/automtn.cpp:666
+#, c-format
+msgid "Type mismatch in argument %u."
+msgstr ""
+
+#: ../src/msw/ole/automtn.cpp:670
+msgid "The system cannot find the file specified."
+msgstr ""
+
+#: ../src/msw/ole/automtn.cpp:674
+#, fuzzy
+msgid "Class not registered."
+msgstr "Nem tudom létrehozni a szálat"
+
+#: ../src/msw/ole/automtn.cpp:678
+#, fuzzy, c-format
+msgid "Unknown error %08x"
+msgstr "Ismeretlen DDE hiba %08x"
+
+#: ../src/msw/ole/automtn.cpp:682
+#, c-format
+msgid "OLE Automation error in %s: %s"
+msgstr ""
+
+#: ../src/msw/ole/dataobj.cpp:385
+#, c-format
+msgid "Couldn't register clipboard format '%s'."
+msgstr "Nem tudtam regisztrálni a(z) '%s' vágólap formátumot."
+
+#: ../src/msw/ole/dataobj.cpp:402
+#, c-format
+msgid "The clipboard format '%d' doesn't exist."
+msgstr "A(z) '%d' vágólap formátum nem létezik."
+
+#: ../src/msw/progdlg.cpp:1025
+msgid "Skip"
+msgstr "Ugrás"
+
+#: ../src/msw/registry.cpp:141
+#, fuzzy, c-format
+msgid "unknown (%lu)"
+msgstr "ismeretlen"
+
+#: ../src/msw/registry.cpp:409
+#, c-format
+msgid "Can't get info about registry key '%s'"
+msgstr "Nincs információm a '%s' registry kulcsról"
+
+#: ../src/msw/registry.cpp:445
+#, c-format
+msgid "Can't open registry key '%s'"
+msgstr "Nem tudom megnyitni a(z) '%s' registry kulcsot"
+
+#: ../src/msw/registry.cpp:478
+#, c-format
+msgid "Can't create registry key '%s'"
+msgstr "Nem tudom létrehozni a '%s' registry kulcsot"
+
+#: ../src/msw/registry.cpp:497
+#, c-format
+msgid "Can't close registry key '%s'"
+msgstr "Nem tudom lezárni a(z) '%s' registry kulcsot"
+
+#: ../src/msw/registry.cpp:512
+#, c-format
+msgid "Registry value '%s' already exists."
+msgstr "Már létezik a(z) '%s' registry érték."
+
+#: ../src/msw/registry.cpp:520
+#, c-format
+msgid "Failed to rename registry value '%s' to '%s'."
+msgstr "Nem tudtam a(z) '%s' registry értéket '%s'-re átnevezni."
+
+#: ../src/msw/registry.cpp:575
+#, c-format
+msgid "Can't copy values of unsupported type %d."
+msgstr "Nem tudom a nem támogatott %d típusú értékeket lemásolni."
+
+#: ../src/msw/registry.cpp:586
+#, c-format
+msgid "Registry key '%s' does not exist, cannot rename it."
+msgstr "A(z) '%s' registry kulcs még nem létezik, nem tudom átnevezni."
+
+#: ../src/msw/registry.cpp:617
+#, c-format
+msgid "Registry key '%s' already exists."
+msgstr "Már létezik a(z) '%s' registry kulcs."
+
+#: ../src/msw/registry.cpp:625
+#, c-format
+msgid "Failed to rename the registry key '%s' to '%s'."
+msgstr "Nem tudtam a(z) '%s' registry kulcsot '%s'-re átnevezni."
+
+#: ../src/msw/registry.cpp:670
+#, c-format
+msgid "Failed to copy the registry subkey '%s' to '%s'."
+msgstr "Nem tudtam a(z) '%s' registry kulcsot '%s'-re átmásolni."
+
+#: ../src/msw/registry.cpp:683
+#, c-format
+msgid "Failed to copy registry value '%s'"
+msgstr "Nem sikerült lemásolni a(z) '%s' registry bejegyzést"
+
+#: ../src/msw/registry.cpp:692
+#, c-format
+msgid "Failed to copy the contents of registry key '%s' to '%s'."
+msgstr ""
+"Nem sikerült lemásolni a(z) '%s' registry kulcs tartalmát a(z) '%s'-be."
+
+#: ../src/msw/registry.cpp:718
+#, c-format
+msgid ""
+"Registry key '%s' is needed for normal system operation,\n"
+"deleting it will leave your system in unusable state:\n"
+"operation aborted."
+msgstr ""
+"A(z) '%s' registry kulcs a normális működéshez szükséges,\n"
+"annak törlése használhatatlanná teszi az Ön rendszerét:\n"
+"a műveletet nem hajtom végre."
+
+#: ../src/msw/registry.cpp:754
+#, c-format
+msgid "Can't delete key '%s'"
+msgstr "Nem tudom törölni a(z) '%s' kulcsot"
+
+#: ../src/msw/registry.cpp:782
+#, c-format
+msgid "Can't delete value '%s' from key '%s'"
+msgstr "Nem tudom törölni a '%s' értéket a '%s' kulcsból"
+
+#: ../src/msw/registry.cpp:855 ../src/msw/registry.cpp:887
+#: ../src/msw/registry.cpp:929 ../src/msw/registry.cpp:1000
+#, c-format
+msgid "Can't read value of key '%s'"
+msgstr "Nem tudom olvasni a(z) '%s' kulcs értékét"
+
+#: ../src/msw/registry.cpp:873 ../src/msw/registry.cpp:915
+#: ../src/msw/registry.cpp:963 ../src/msw/registry.cpp:1106
+#, c-format
+msgid "Can't set value of '%s'"
+msgstr "Nem tudom a(z) '%s' értéket beállítani"
+
+#: ../src/msw/registry.cpp:894 ../src/msw/registry.cpp:943
+#, c-format
+msgid "Registry value \"%s\" is not numeric (but of type %s)"
+msgstr ""
+
+#: ../src/msw/registry.cpp:979
+#, c-format
+msgid "Registry value \"%s\" is not binary (but of type %s)"
+msgstr ""
+
+#: ../src/msw/registry.cpp:1028
+#, c-format
+msgid "Registry value \"%s\" is not text (but of type %s)"
+msgstr ""
+
+#: ../src/msw/registry.cpp:1089
+#, c-format
+msgid "Can't read value of '%s'"
+msgstr "Nem tudom olvasni a(z) '%s' értékét"
+
+#: ../src/msw/registry.cpp:1157
+#, c-format
+msgid "Can't enumerate values of key '%s'"
+msgstr "Nem tudtam megszámlálni a(z) '%s' kulcs értékeit"
+
+#: ../src/msw/registry.cpp:1196
+#, c-format
+msgid "Can't enumerate subkeys of key '%s'"
+msgstr "Nem tudtam megszámlálni a(z) '%s' kulcs alkulcsait"
+
+#: ../src/msw/registry.cpp:1262
+#, c-format
+msgid ""
+"Exporting registry key: file \"%s\" already exists and won't be overwritten."
+msgstr ""
+"Registry kulcs exportálás: a fájl \"%s\" már létezik és nem írom felül."
+
+#: ../src/msw/registry.cpp:1411
+#, c-format
+msgid "Can't export value of unsupported type %d."
+msgstr "Nem tudom a nem támogatott %d típusú értékeket exportálni."
+
+#: ../src/msw/registry.cpp:1427
+#, c-format
+msgid "Ignoring value \"%s\" of the key \"%s\"."
+msgstr "Nem írom be a \"%s\" értéket a \"%s\" kulcsba."
+
+#: ../src/msw/textctrl.cpp:596
+msgid ""
+"Impossible to create a rich edit control, using simple text control instead. "
+"Please reinstall riched32.dll"
+msgstr ""
+"Nem tudok formázott szövegkontrollt készíteni, egyszerű szövegkontrollt "
+"használok helyette. Kérem installálja újra a riched32.dll fájlt"
+
+#: ../src/msw/thread.cpp:522 ../src/unix/threadpsx.cpp:850
+msgid "Cannot start thread: error writing TLS."
+msgstr "Nem tudom elindítani a szálat: hiba a TLS írásakor."
+
+#: ../src/msw/thread.cpp:613
+msgid "Can't set thread priority"
+msgstr "Nem tudom a szál prioritását beállítani"
+
+#: ../src/msw/thread.cpp:649
+msgid "Can't create thread"
+msgstr "Nem tudom létrehozni a szálat"
+
+#: ../src/msw/thread.cpp:668
+msgid "Couldn't terminate thread"
+msgstr "Nem tudtam befejezni a szálat"
+
+#: ../src/msw/thread.cpp:799
+msgid "Cannot wait for thread termination"
+msgstr "Nem tudom megvárni a szál befejeződését"
+
+#: ../src/msw/thread.cpp:873
+#, fuzzy, c-format
+msgid "Cannot suspend thread %lx"
+msgstr "Nem tudom felfüggeszteni a(z) %x szálat"
+
+#: ../src/msw/thread.cpp:903
+#, fuzzy, c-format
+msgid "Cannot resume thread %lx"
+msgstr "Nem tudom folytatni a(z) %x szálat"
+
+#: ../src/msw/thread.cpp:932
+msgid "Couldn't get the current thread pointer"
+msgstr "Nem kaptam meg a mutatót a jelenlegi szálhoz"
+
+#: ../src/msw/thread.cpp:1333
+msgid ""
+"Thread module initialization failed: impossible to allocate index in thread "
+"local storage"
+msgstr ""
+"A szál modul inicializálása nem sikerült: nem lehet indexet foglalni a szál "
+"helyi tárolájában"
+
+#: ../src/msw/thread.cpp:1345
+msgid ""
+"Thread module initialization failed: cannot store value in thread local "
+"storage"
+msgstr ""
+"A szál modul inicializálása nem sikerült: nem tudok értéket tárolni a szál "
+"helyi tárolójába"
+
+#: ../src/msw/timer.cpp:133
+msgid "Couldn't create a timer"
+msgstr "Nem tudtam időzítőt létrehozni"
+
+#: ../src/msw/utils.cpp:372
+msgid "can't find user's HOME, using current directory."
+msgstr ""
+"nem tudom meghatározni a felhasználó saját könyvtárát, a jelenlegit "
+"használom tovább."
+
+#: ../src/msw/utils.cpp:662
+#, c-format
+msgid "Failed to kill process %d"
+msgstr "Nem tudtam megölni a '%d' folyamatot."
+
+#: ../src/msw/utils.cpp:986
+#, fuzzy, c-format
+msgid "Failed to load resource \"%s\"."
+msgstr "Nem tudtam betölteni a metafájlt a(z)  '%s' fájlból."
+
+#: ../src/msw/utils.cpp:993
+#, fuzzy, c-format
+msgid "Failed to lock resource \"%s\"."
+msgstr "Nem sikerült lelakatolni a(z) '%s' lakat fájlt."
+
+#. TRANSLATORS: MS Windows build number
+#: ../src/msw/utils.cpp:1209
+#, fuzzy, c-format
+msgid "build %lu"
+msgstr "Windows XP (build %lu"
+
+#: ../src/msw/utils.cpp:1218
+msgid ", 64-bit edition"
+msgstr ""
+
+#: ../src/msw/utilsexc.cpp:224
+msgid "Failed to create an anonymous pipe"
+msgstr "Nem sikerült lérehozni a névtelen csövet."
+
+#: ../src/msw/utilsexc.cpp:697
+msgid "Failed to redirect the child process IO"
+msgstr "Nem tudtam átirányítani a gyermek processz be/kimenetét"
+
+#: ../src/msw/utilsexc.cpp:870
+#, c-format
+msgid "Execution of command '%s' failed"
+msgstr "Nem sikerült végrehajtani a(z) '%s' parancsot"
+
+#: ../src/msw/volume.cpp:337
+msgid "Failed to load mpr.dll."
+msgstr "Nem tudtam betölteni az mpr.dll-t."
+
+#: ../src/msw/volume.cpp:506
+#, c-format
+msgid "Cannot read typename from '%s'!"
+msgstr "Nem tudom elolvasni '%s' típusának nevét."
+
+#: ../src/msw/volume.cpp:615
+#, c-format
+msgid "Cannot load icon from '%s'."
+msgstr "Nem tudom betölteni az ikont '%s'-ből."
+
+#: ../src/msw/webview_edge.cpp:285
+msgid "This program was compiled without support for setting Edge proxy."
+msgstr ""
+
+#: ../src/msw/webview_ie.cpp:1010
+msgid "Failed to find web view emulation level in the registry"
+msgstr ""
+
+#: ../src/msw/webview_ie.cpp:1019
+msgid "Failed to set web view to modern emulation level"
+msgstr ""
+
+#: ../src/msw/webview_ie.cpp:1027
+msgid "Failed to reset web view to standard emulation level"
+msgstr ""
+
+#: ../src/msw/webview_ie.cpp:1049
+msgid "Can't run JavaScript script without a valid HTML document"
+msgstr ""
+
+#: ../src/msw/webview_ie.cpp:1056
+#, fuzzy
+msgid "Can't get the JavaScript object"
+msgstr "Nem tudom a szál prioritását beállítani"
+
+#: ../src/msw/webview_ie.cpp:1070
+#, fuzzy
+msgid "failed to evaluate"
+msgstr "Nem sikerült végrehajtani '%s'-t\n"
+
+#: ../src/osx/cocoa/filedlg.mm:412
+#, fuzzy
+msgid "File type:"
+msgstr "Teletype"
+
+#: ../src/osx/cocoa/menu.mm:242
+#, fuzzy
+msgctxt "macOS menu name"
+msgid "Window"
+msgstr "&Ablak"
+
+#: ../src/osx/cocoa/menu.mm:259
+#, fuzzy
+msgctxt "macOS menu name"
+msgid "Help"
+msgstr "Súgó"
+
+#: ../src/osx/cocoa/menu.mm:298
+#, fuzzy
+msgctxt "macOS menu item"
+msgid "Minimize"
+msgstr "Mi&nimalizál"
+
+#: ../src/osx/cocoa/menu.mm:303
+#, fuzzy
+msgctxt "macOS menu item"
+msgid "Zoom"
+msgstr "&Nagyítás"
+
+#: ../src/osx/cocoa/menu.mm:309
+msgctxt "macOS menu item"
+msgid "Bring All to Front"
+msgstr ""
+
+#: ../src/osx/core/sound.cpp:143
+#, fuzzy, c-format
+msgid "Failed to load sound from \"%s\" (error %d)."
+msgstr "Nem tudtam betölteni a metafájlt a(z)  '%s' fájlból."
+
+#: ../src/osx/fontutil.cpp:80
+#, fuzzy, c-format
+msgid "Font file \"%s\" doesn't exist."
+msgstr "A(z) '%s' file nem létezik."
+
+#: ../src/osx/fontutil.cpp:88
+#, c-format
+msgid ""
+"Font file \"%s\" cannot be used as it is not inside the font directory "
+"\"%s\"."
+msgstr ""
+
+#: ../src/osx/menu_osx.cpp:496
+#, fuzzy, c-format
+msgctxt "macOS menu item"
+msgid "About %s"
+msgstr "&Névjegy..."
+
+#: ../src/osx/menu_osx.cpp:499
+#, fuzzy
+msgctxt "macOS menu item"
+msgid "About..."
+msgstr "&Névjegy"
+
+#: ../src/osx/menu_osx.cpp:508
+#, fuzzy
+msgctxt "macOS menu item"
+msgid "Preferences..."
+msgstr "&Előválasztás"
+
+#: ../src/osx/menu_osx.cpp:512
+msgctxt "macOS menu item"
+msgid "Services"
+msgstr ""
+
+#: ../src/osx/menu_osx.cpp:519
+#, fuzzy, c-format
+msgctxt "macOS menu item"
+msgid "Hide %s"
+msgstr "Súgó: %s"
+
+#: ../src/osx/menu_osx.cpp:522
+#, fuzzy
+msgctxt "macOS menu item"
+msgid "Hide Application"
+msgstr "Kiválasztott"
+
+#: ../src/osx/menu_osx.cpp:526
+msgctxt "macOS menu item"
+msgid "Hide Others"
+msgstr ""
+
+#: ../src/osx/menu_osx.cpp:528
+#, fuzzy
+msgctxt "macOS menu item"
+msgid "Show All"
+msgstr "Mutatsd mindet"
+
+#: ../src/osx/menu_osx.cpp:534
+#, fuzzy, c-format
+msgctxt "macOS menu item"
+msgid "Quit %s"
+msgstr "&Kilépés"
+
+#: ../src/osx/menu_osx.cpp:537
+#, fuzzy
+msgctxt "macOS menu item"
+msgid "Quit Application"
+msgstr "Kiválasztott"
+
+#: ../src/osx/webview_webkit.mm:444
+#, fuzzy
+msgid "Printing is not supported by the system web control"
+msgstr "A zlib ezen változata nem támogatja gzip-et"
+
+#: ../src/osx/webview_webkit.mm:453
+#, fuzzy
+msgid "Print operation could not be initialized"
+msgstr "Nem tudom elindítani a megjelenítést."
+
+#. TRANSLATORS: Label of font point size
+#: ../src/propgrid/advprops.cpp:605
+#, fuzzy
+msgid "Point Size"
+msgstr "Jelkészlet &pontmérete:"
+
+#. TRANSLATORS: Label of font face name
+#: ../src/propgrid/advprops.cpp:615
+#, fuzzy
+msgid "Face Name"
+msgstr "ÚjNév"
+
+#. TRANSLATORS: Label of font style
+#: ../src/propgrid/advprops.cpp:623 ../src/richtext/richtextformatdlg.cpp:331
+#, fuzzy
+msgid "Style"
+msgstr "&Stílus:"
+
+#. TRANSLATORS: Label of font weight
+#: ../src/propgrid/advprops.cpp:628
+#, fuzzy
+msgid "Weight"
+msgstr "Hang&súly:"
+
+#. TRANSLATORS: Label of underlined font
+#: ../src/propgrid/advprops.cpp:633 ../src/richtext/richtextfontpage.cpp:358
+#, fuzzy
+msgid "Underlined"
+msgstr "Alá&húzás"
+
+#. TRANSLATORS: Label of font family
+#: ../src/propgrid/advprops.cpp:637
+#, fuzzy
+msgid "Family"
+msgstr "Jelkészlet család:"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:801
+msgid "AppWorkspace"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:802
+#, fuzzy
+msgid "ActiveBorder"
+msgstr "Modern"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:803
+msgid "ActiveCaption"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:804
+msgid "ButtonFace"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:805
+msgid "ButtonHighlight"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:806
+msgid "ButtonShadow"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:807
+msgid "ButtonText"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:808
+msgid "CaptionText"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:809
+msgid "ControlDark"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:810
+msgid "ControlLight"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:812
+msgid "GrayText"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:813
+#, fuzzy
+msgid "Highlight"
+msgstr "vékony"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:814
+msgid "HighlightText"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:815
+#, fuzzy
+msgid "InactiveBorder"
+msgstr "Modern"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:816
+msgid "InactiveCaption"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:817
+msgid "InactiveCaptionText"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:818
+msgid "Menu"
+msgstr "Menu"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:819
+msgid "Scrollbar"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:820
+msgid "Tooltip"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:821
+msgid "TooltipText"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:822
+#, fuzzy
+msgid "Window"
+msgstr "&Ablak"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:823
+#, fuzzy
+msgid "WindowFrame"
+msgstr "&Ablak"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:824
+#, fuzzy
+msgid "WindowText"
+msgstr "&Ablak"
+
+#. TRANSLATORS: Custom colour choice entry
+#: ../src/propgrid/advprops.cpp:825 ../src/propgrid/advprops.cpp:1532
+#: ../src/propgrid/advprops.cpp:1576
+#, fuzzy
+msgid "Custom"
+msgstr "Jelkészlet méret"
+
+#: ../src/propgrid/advprops.cpp:1558
+msgid "Black"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1559
+msgid "Maroon"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1560
+msgid "Navy"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1561
+msgid "Purple"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1562
+msgid "Teal"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1563
+msgid "Gray"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1564
+msgid "Green"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1565
+msgid "Olive"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1566
+msgid "Brown"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1567
+msgid "Blue"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1568
+msgid "Fuchsia"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1569
+#, fuzzy
+msgid "Red"
+msgstr "&Újra"
+
+#: ../src/propgrid/advprops.cpp:1570
+msgid "Orange"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1571
+msgid "Silver"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1572
+msgid "Lime"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1573
+msgid "Aqua"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1574
+msgid "Yellow"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1575
+msgid "White"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1718
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Default"
+msgstr "alapértelmezés"
+
+#: ../src/propgrid/advprops.cpp:1719
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Arrow"
+msgstr "holnap"
+
+#: ../src/propgrid/advprops.cpp:1720
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Right Arrow"
+msgstr "Vékony"
+
+#: ../src/propgrid/advprops.cpp:1721
+msgctxt "system cursor name"
+msgid "Blank"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1722
+msgctxt "system cursor name"
+msgid "Bullseye"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1723
+msgctxt "system cursor name"
+msgid "Character"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1724
+msgctxt "system cursor name"
+msgid "Cross"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1725
+msgctxt "system cursor name"
+msgid "Hand"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1726
+msgctxt "system cursor name"
+msgid "I-Beam"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1727
+msgctxt "system cursor name"
+msgid "Left Button"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1728
+msgctxt "system cursor name"
+msgid "Magnifier"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1729
+msgctxt "system cursor name"
+msgid "Middle Button"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1730
+msgctxt "system cursor name"
+msgid "No Entry"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1731
+msgctxt "system cursor name"
+msgid "Paint Brush"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1732
+msgctxt "system cursor name"
+msgid "Pencil"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1733
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Point Left"
+msgstr "Jelkészlet &pontmérete:"
+
+#: ../src/propgrid/advprops.cpp:1734
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Point Right"
+msgstr "Jobbra igazíts"
+
+#: ../src/propgrid/advprops.cpp:1735
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Question Arrow"
+msgstr "Kérdés"
+
+#: ../src/propgrid/advprops.cpp:1736
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Right Button"
+msgstr "Vékony"
+
+#: ../src/propgrid/advprops.cpp:1737
+msgctxt "system cursor name"
+msgid "Sizing NE-SW"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1738
+msgctxt "system cursor name"
+msgid "Sizing N-S"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1739
+msgctxt "system cursor name"
+msgid "Sizing NW-SE"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1740
+msgctxt "system cursor name"
+msgid "Sizing W-E"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1741
+msgctxt "system cursor name"
+msgid "Sizing"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1742
+msgctxt "system cursor name"
+msgid "Spraycan"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1743
+msgctxt "system cursor name"
+msgid "Wait"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1744
+msgctxt "system cursor name"
+msgid "Watch"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1745
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Wait Arrow"
+msgstr "Vékony"
+
+#: ../src/propgrid/advprops.cpp:2109
+#, fuzzy
+msgid "Make a selection:"
+msgstr "Kiválasztott"
+
+#: ../src/propgrid/manager.cpp:394
+#, fuzzy
+msgid "Property"
+msgstr "&Tulajdonságok"
+
+#: ../src/propgrid/manager.cpp:395
+msgid "Value"
+msgstr ""
+
+#: ../src/propgrid/manager.cpp:1683
+msgid "Categorized Mode"
+msgstr ""
+
+#: ../src/propgrid/manager.cpp:1709
+msgid "Alphabetic Mode"
+msgstr ""
+
+#. TRANSLATORS: Name of Boolean false value
+#: ../src/propgrid/propgrid.cpp:230
+#, fuzzy
+msgid "False"
+msgstr "Fájl"
+
+#. TRANSLATORS: Name of Boolean true value
+#: ../src/propgrid/propgrid.cpp:232
+msgid "True"
+msgstr ""
+
+#. TRANSLATORS: Text  displayed for unspecified value
+#: ../src/propgrid/propgrid.cpp:428
+#, fuzzy
+msgid "Unspecified"
+msgstr "Jóváhagyva"
+
+#. TRANSLATORS: Caption of message box displaying any property error
+#: ../src/propgrid/propgrid.cpp:3145 ../src/propgrid/propgrid.cpp:3282
+#, fuzzy
+msgid "Property Error"
+msgstr "Nyomtatási hiba"
+
+#: ../src/propgrid/propgrid.cpp:3259
+msgid "You have entered invalid value. Press ESC to cancel editing."
+msgstr ""
+
+#: ../src/propgrid/propgrid.cpp:6608
+#, c-format
+msgid "Error in resource: %s"
+msgstr ""
+
+#: ../src/propgrid/propgridiface.cpp:377
+#, c-format
+msgid ""
+"Type operation \"%s\" failed: Property labeled \"%s\" is of type \"%s\", NOT "
+"\"%s\"."
+msgstr ""
+
+#: ../src/propgrid/props.cpp:159
+#, c-format
+msgid "Unknown base %d. Base 10 will be used."
+msgstr ""
+
+#: ../src/propgrid/props.cpp:324
+#, c-format
+msgid "Value must be %s or higher."
+msgstr ""
+
+#: ../src/propgrid/props.cpp:329 ../src/propgrid/props.cpp:356
+#, fuzzy, c-format
+msgid "Value must be between %s and %s."
+msgstr "Adjon meg egy oldalszámot %d és %d között:"
+
+#: ../src/propgrid/props.cpp:351
+#, c-format
+msgid "Value must be %s or less."
+msgstr ""
+
+#: ../src/propgrid/props.cpp:1058
+#, fuzzy, c-format
+msgid "Not %s"
+msgstr "&Névjegy..."
+
+#: ../src/propgrid/props.cpp:1770
+#, fuzzy
+msgid "Choose a directory:"
+msgstr "Hozzon létre könyvtárat"
+
+#: ../src/propgrid/props.cpp:2055
+#, fuzzy
+msgid "Choose a file"
+msgstr "Válasszon betűtípust"
+
+#: ../src/qt/mdi.cpp:254
+msgid "&Tile"
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:147
+#: ../src/richtext/richtextformatdlg.cpp:376
+msgid "Background"
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:159
+msgid "Background &colour:"
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:161
+#: ../src/richtext/richtextbackgroundpage.cpp:163
+msgid "Enables a background colour."
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:167
+#: ../src/richtext/richtextbackgroundpage.cpp:169
+#, fuzzy
+msgid "The background colour."
+msgstr "A betűkészlet színe."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:178
+msgid "Shadow"
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:193
+msgid "Use &shadow"
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:195
+#: ../src/richtext/richtextbackgroundpage.cpp:197
+msgid "Enables a shadow."
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:211
+msgid "&Horizontal offset:"
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:218
+#: ../src/richtext/richtextbackgroundpage.cpp:220
+#, fuzzy
+msgid "The horizontal offset."
+msgstr "Csempék &Vízszintesen"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:224
+#: ../src/richtext/richtextbackgroundpage.cpp:227
+#: ../src/richtext/richtextbackgroundpage.cpp:228
+#: ../src/richtext/richtextbackgroundpage.cpp:247
+#: ../src/richtext/richtextbackgroundpage.cpp:250
+#: ../src/richtext/richtextbackgroundpage.cpp:251
+#: ../src/richtext/richtextbackgroundpage.cpp:287
+#: ../src/richtext/richtextbackgroundpage.cpp:290
+#: ../src/richtext/richtextbackgroundpage.cpp:291
+#: ../src/richtext/richtextbackgroundpage.cpp:314
+#: ../src/richtext/richtextbackgroundpage.cpp:317
+#: ../src/richtext/richtextbackgroundpage.cpp:318
+#: ../src/richtext/richtextborderspage.cpp:252
+#: ../src/richtext/richtextborderspage.cpp:255
+#: ../src/richtext/richtextborderspage.cpp:256
+#: ../src/richtext/richtextborderspage.cpp:286
+#: ../src/richtext/richtextborderspage.cpp:289
+#: ../src/richtext/richtextborderspage.cpp:290
+#: ../src/richtext/richtextborderspage.cpp:320
+#: ../src/richtext/richtextborderspage.cpp:323
+#: ../src/richtext/richtextborderspage.cpp:324
+#: ../src/richtext/richtextborderspage.cpp:354
+#: ../src/richtext/richtextborderspage.cpp:357
+#: ../src/richtext/richtextborderspage.cpp:358
+#: ../src/richtext/richtextborderspage.cpp:420
+#: ../src/richtext/richtextborderspage.cpp:423
+#: ../src/richtext/richtextborderspage.cpp:424
+#: ../src/richtext/richtextborderspage.cpp:454
+#: ../src/richtext/richtextborderspage.cpp:457
+#: ../src/richtext/richtextborderspage.cpp:458
+#: ../src/richtext/richtextborderspage.cpp:488
+#: ../src/richtext/richtextborderspage.cpp:491
+#: ../src/richtext/richtextborderspage.cpp:492
+#: ../src/richtext/richtextborderspage.cpp:522
+#: ../src/richtext/richtextborderspage.cpp:525
+#: ../src/richtext/richtextborderspage.cpp:526
+#: ../src/richtext/richtextborderspage.cpp:590
+#: ../src/richtext/richtextborderspage.cpp:593
+#: ../src/richtext/richtextborderspage.cpp:594
+#: ../src/richtext/richtextfontpage.cpp:177
+#: ../src/richtext/richtextmarginspage.cpp:199
+#: ../src/richtext/richtextmarginspage.cpp:201
+#: ../src/richtext/richtextmarginspage.cpp:202
+#: ../src/richtext/richtextmarginspage.cpp:224
+#: ../src/richtext/richtextmarginspage.cpp:226
+#: ../src/richtext/richtextmarginspage.cpp:227
+#: ../src/richtext/richtextmarginspage.cpp:247
+#: ../src/richtext/richtextmarginspage.cpp:249
+#: ../src/richtext/richtextmarginspage.cpp:250
+#: ../src/richtext/richtextmarginspage.cpp:272
+#: ../src/richtext/richtextmarginspage.cpp:274
+#: ../src/richtext/richtextmarginspage.cpp:275
+#: ../src/richtext/richtextmarginspage.cpp:313
+#: ../src/richtext/richtextmarginspage.cpp:315
+#: ../src/richtext/richtextmarginspage.cpp:316
+#: ../src/richtext/richtextmarginspage.cpp:338
+#: ../src/richtext/richtextmarginspage.cpp:340
+#: ../src/richtext/richtextmarginspage.cpp:341
+#: ../src/richtext/richtextmarginspage.cpp:361
+#: ../src/richtext/richtextmarginspage.cpp:363
+#: ../src/richtext/richtextmarginspage.cpp:364
+#: ../src/richtext/richtextmarginspage.cpp:386
+#: ../src/richtext/richtextmarginspage.cpp:388
+#: ../src/richtext/richtextmarginspage.cpp:389
+#: ../src/richtext/richtextsizepage.cpp:337
+#: ../src/richtext/richtextsizepage.cpp:340
+#: ../src/richtext/richtextsizepage.cpp:341
+#: ../src/richtext/richtextsizepage.cpp:371
+#: ../src/richtext/richtextsizepage.cpp:374
+#: ../src/richtext/richtextsizepage.cpp:375
+#: ../src/richtext/richtextsizepage.cpp:398
+#: ../src/richtext/richtextsizepage.cpp:401
+#: ../src/richtext/richtextsizepage.cpp:402
+#: ../src/richtext/richtextsizepage.cpp:425
+#: ../src/richtext/richtextsizepage.cpp:428
+#: ../src/richtext/richtextsizepage.cpp:429
+#: ../src/richtext/richtextsizepage.cpp:452
+#: ../src/richtext/richtextsizepage.cpp:455
+#: ../src/richtext/richtextsizepage.cpp:456
+#: ../src/richtext/richtextsizepage.cpp:479
+#: ../src/richtext/richtextsizepage.cpp:482
+#: ../src/richtext/richtextsizepage.cpp:483
+#: ../src/richtext/richtextsizepage.cpp:553
+#: ../src/richtext/richtextsizepage.cpp:556
+#: ../src/richtext/richtextsizepage.cpp:557
+#: ../src/richtext/richtextsizepage.cpp:588
+#: ../src/richtext/richtextsizepage.cpp:591
+#: ../src/richtext/richtextsizepage.cpp:592
+#: ../src/richtext/richtextsizepage.cpp:623
+#: ../src/richtext/richtextsizepage.cpp:626
+#: ../src/richtext/richtextsizepage.cpp:627
+#: ../src/richtext/richtextsizepage.cpp:658
+#: ../src/richtext/richtextsizepage.cpp:661
+#: ../src/richtext/richtextsizepage.cpp:662
+msgid "px"
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:225
+#: ../src/richtext/richtextbackgroundpage.cpp:248
+#: ../src/richtext/richtextbackgroundpage.cpp:288
+#: ../src/richtext/richtextbackgroundpage.cpp:315
+#: ../src/richtext/richtextborderspage.cpp:253
+#: ../src/richtext/richtextborderspage.cpp:287
+#: ../src/richtext/richtextborderspage.cpp:321
+#: ../src/richtext/richtextborderspage.cpp:355
+#: ../src/richtext/richtextborderspage.cpp:421
+#: ../src/richtext/richtextborderspage.cpp:455
+#: ../src/richtext/richtextborderspage.cpp:489
+#: ../src/richtext/richtextborderspage.cpp:523
+#: ../src/richtext/richtextborderspage.cpp:591
+#: ../src/richtext/richtextmarginspage.cpp:200
+#: ../src/richtext/richtextmarginspage.cpp:225
+#: ../src/richtext/richtextmarginspage.cpp:248
+#: ../src/richtext/richtextmarginspage.cpp:273
+#: ../src/richtext/richtextmarginspage.cpp:314
+#: ../src/richtext/richtextmarginspage.cpp:339
+#: ../src/richtext/richtextmarginspage.cpp:362
+#: ../src/richtext/richtextmarginspage.cpp:387
+#: ../src/richtext/richtextsizepage.cpp:338
+#: ../src/richtext/richtextsizepage.cpp:372
+#: ../src/richtext/richtextsizepage.cpp:399
+#: ../src/richtext/richtextsizepage.cpp:426
+#: ../src/richtext/richtextsizepage.cpp:453
+#: ../src/richtext/richtextsizepage.cpp:480
+#: ../src/richtext/richtextsizepage.cpp:554
+#: ../src/richtext/richtextsizepage.cpp:589
+#: ../src/richtext/richtextsizepage.cpp:624
+#: ../src/richtext/richtextsizepage.cpp:659
+msgid "cm"
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:226
+#: ../src/richtext/richtextbackgroundpage.cpp:249
+#: ../src/richtext/richtextbackgroundpage.cpp:289
+#: ../src/richtext/richtextbackgroundpage.cpp:316
+#: ../src/richtext/richtextborderspage.cpp:254
+#: ../src/richtext/richtextborderspage.cpp:288
+#: ../src/richtext/richtextborderspage.cpp:322
+#: ../src/richtext/richtextborderspage.cpp:356
+#: ../src/richtext/richtextborderspage.cpp:422
+#: ../src/richtext/richtextborderspage.cpp:456
+#: ../src/richtext/richtextborderspage.cpp:490
+#: ../src/richtext/richtextborderspage.cpp:524
+#: ../src/richtext/richtextborderspage.cpp:592
+#: ../src/richtext/richtextfontpage.cpp:176
+#: ../src/richtext/richtextfontpage.cpp:179
+msgid "pt"
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:229
+#: ../src/richtext/richtextbackgroundpage.cpp:231
+#: ../src/richtext/richtextbackgroundpage.cpp:252
+#: ../src/richtext/richtextbackgroundpage.cpp:254
+#: ../src/richtext/richtextbackgroundpage.cpp:292
+#: ../src/richtext/richtextbackgroundpage.cpp:294
+#: ../src/richtext/richtextbackgroundpage.cpp:319
+#: ../src/richtext/richtextbackgroundpage.cpp:321
+#, fuzzy
+msgid "Units for this value."
+msgstr "Nem tudom megvárni a szál befejeződését."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:234
+#, fuzzy
+msgid "&Vertical offset:"
+msgstr "Balra igazítsd"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:241
+#: ../src/richtext/richtextbackgroundpage.cpp:243
+#, fuzzy
+msgid "The vertical offset."
+msgstr "Nem tudom elindítani a nyomtatást."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:257
+#, fuzzy
+msgid "Shadow c&olour:"
+msgstr "Válasszon színt"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:259
+#: ../src/richtext/richtextbackgroundpage.cpp:261
+msgid "Enables the shadow colour."
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:265
+#: ../src/richtext/richtextbackgroundpage.cpp:267
+#, fuzzy
+msgid "The shadow colour."
+msgstr "A betűkészlet színe."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:270
+msgid "Sh&adow spread:"
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:272
+#: ../src/richtext/richtextbackgroundpage.cpp:274
+msgid "Enables the shadow spread."
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:281
+#: ../src/richtext/richtextbackgroundpage.cpp:283
+msgid "The shadow spread."
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:297
+msgid "&Blur distance:"
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:299
+#: ../src/richtext/richtextbackgroundpage.cpp:301
+#, fuzzy
+msgid "Enables the blur distance."
+msgstr "Nem tudom elindítani a nyomtatást."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:308
+#: ../src/richtext/richtextbackgroundpage.cpp:310
+msgid "The shadow blur distance."
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:324
+msgid "Opaci&ty:"
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:326
+#: ../src/richtext/richtextbackgroundpage.cpp:328
+msgid "Enables the shadow opacity."
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:335
+#: ../src/richtext/richtextbackgroundpage.cpp:337
+msgid "The shadow opacity."
+msgstr ""
+
+#. TRANSLATORS: Rich text page units (percentage)
+#: ../src/richtext/richtextbackgroundpage.cpp:340
+#: ../src/richtext/richtextsizepage.cpp:339
+#: ../src/richtext/richtextsizepage.cpp:373
+#: ../src/richtext/richtextsizepage.cpp:400
+#: ../src/richtext/richtextsizepage.cpp:427
+#: ../src/richtext/richtextsizepage.cpp:454
+#: ../src/richtext/richtextsizepage.cpp:481
+#: ../src/richtext/richtextsizepage.cpp:555
+#: ../src/richtext/richtextsizepage.cpp:590
+#: ../src/richtext/richtextsizepage.cpp:625
+#: ../src/richtext/richtextsizepage.cpp:660
+msgid "%"
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:229
+#: ../src/richtext/richtextborderspage.cpp:387
+#, fuzzy
+msgid "Border"
+msgstr "Modern"
+
+#: ../src/richtext/richtextborderspage.cpp:242
+#: ../src/richtext/richtextborderspage.cpp:410
+#: ../src/richtext/richtextindentspage.cpp:194
+#: ../src/richtext/richtextliststylepage.cpp:384
+#: ../src/richtext/richtextmarginspage.cpp:185
+#: ../src/richtext/richtextmarginspage.cpp:299
+#: ../src/richtext/richtextsizepage.cpp:531
+#: ../src/richtext/richtextsizepage.cpp:538
+msgid "&Left:"
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:257
+#: ../src/richtext/richtextborderspage.cpp:259
+msgid "Units for the left border width."
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:266
+#: ../src/richtext/richtextborderspage.cpp:268
+#: ../src/richtext/richtextborderspage.cpp:300
+#: ../src/richtext/richtextborderspage.cpp:302
+#: ../src/richtext/richtextborderspage.cpp:334
+#: ../src/richtext/richtextborderspage.cpp:336
+#: ../src/richtext/richtextborderspage.cpp:368
+#: ../src/richtext/richtextborderspage.cpp:370
+#: ../src/richtext/richtextborderspage.cpp:434
+#: ../src/richtext/richtextborderspage.cpp:436
+#: ../src/richtext/richtextborderspage.cpp:468
+#: ../src/richtext/richtextborderspage.cpp:470
+#: ../src/richtext/richtextborderspage.cpp:502
+#: ../src/richtext/richtextborderspage.cpp:504
+#: ../src/richtext/richtextborderspage.cpp:536
+#: ../src/richtext/richtextborderspage.cpp:538
+#, fuzzy
+msgid "The border line style."
+msgstr "A betűkészlet stílusa."
+
+#: ../src/richtext/richtextborderspage.cpp:276
+#: ../src/richtext/richtextborderspage.cpp:444
+#: ../src/richtext/richtextindentspage.cpp:212
+#: ../src/richtext/richtextliststylepage.cpp:402
+#: ../src/richtext/richtextmarginspage.cpp:210
+#: ../src/richtext/richtextmarginspage.cpp:324
+#: ../src/richtext/richtextsizepage.cpp:601
+#: ../src/richtext/richtextsizepage.cpp:608
+#, fuzzy
+msgid "&Right:"
+msgstr "Hang&súly:"
+
+#: ../src/richtext/richtextborderspage.cpp:291
+#: ../src/richtext/richtextborderspage.cpp:293
+msgid "Units for the right border width."
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:310
+#: ../src/richtext/richtextborderspage.cpp:478
+#: ../src/richtext/richtextmarginspage.cpp:233
+#: ../src/richtext/richtextmarginspage.cpp:347
+#: ../src/richtext/richtextsizepage.cpp:566
+#: ../src/richtext/richtextsizepage.cpp:573
+#, fuzzy
+msgid "&Top:"
+msgstr "Ig:"
+
+#: ../src/richtext/richtextborderspage.cpp:325
+#: ../src/richtext/richtextborderspage.cpp:327
+msgid "Units for the top border width."
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:344
+#: ../src/richtext/richtextborderspage.cpp:512
+#: ../src/richtext/richtextmarginspage.cpp:258
+#: ../src/richtext/richtextmarginspage.cpp:372
+#: ../src/richtext/richtextsizepage.cpp:636
+#: ../src/richtext/richtextsizepage.cpp:643
+msgid "&Bottom:"
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:359
+#: ../src/richtext/richtextborderspage.cpp:361
+msgid "Units for the bottom border width."
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:380
+#: ../src/richtext/richtextborderspage.cpp:548
+msgid "&Synchronize values"
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:382
+#: ../src/richtext/richtextborderspage.cpp:384
+#: ../src/richtext/richtextborderspage.cpp:550
+#: ../src/richtext/richtextborderspage.cpp:552
+msgid "Check to edit all borders simultaneously."
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:397
+#: ../src/richtext/richtextborderspage.cpp:555
+msgid "Outline"
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:425
+#: ../src/richtext/richtextborderspage.cpp:427
+msgid "Units for the left outline width."
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:459
+#: ../src/richtext/richtextborderspage.cpp:461
+msgid "Units for the right outline width."
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:493
+#: ../src/richtext/richtextborderspage.cpp:495
+msgid "Units for the top outline width."
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:527
+#: ../src/richtext/richtextborderspage.cpp:529
+msgid "Units for the bottom outline width."
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:565
+#: ../src/richtext/richtextborderspage.cpp:600
+msgid "Corner"
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:574
+msgid "Corner &radius:"
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:576
+#: ../src/richtext/richtextborderspage.cpp:578
+msgid "An optional corner radius for adding rounded corners."
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:584
+#: ../src/richtext/richtextborderspage.cpp:586
+msgid "The value of the corner radius."
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:595
+#: ../src/richtext/richtextborderspage.cpp:597
+#, fuzzy
+msgid "Units for the corner radius."
+msgstr "Nem tudom megvárni a szál befejeződését."
+
+#: ../src/richtext/richtextborderspage.cpp:609
+#: ../src/richtext/richtextsizepage.cpp:247
+#: ../src/richtext/richtextsizepage.cpp:251
+#, fuzzy
+msgid "None"
+msgstr "Kész"
+
+#: ../src/richtext/richtextborderspage.cpp:610
+#, fuzzy
+msgid "Solid"
+msgstr "Félkövér"
+
+#: ../src/richtext/richtextborderspage.cpp:611
+#, fuzzy
+msgid "Dotted"
+msgstr "Kész"
+
+#: ../src/richtext/richtextborderspage.cpp:612
+msgid "Dashed"
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:613
+#, fuzzy
+msgid "Double"
+msgstr "Kész"
+
+#: ../src/richtext/richtextborderspage.cpp:614
+msgid "Groove"
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:615
+#, fuzzy
+msgid "Ridge"
+msgstr "Vékony"
+
+#: ../src/richtext/richtextborderspage.cpp:616
+#, fuzzy
+msgid "Inset"
+msgstr "Bekezdés"
+
+#: ../src/richtext/richtextborderspage.cpp:617
+msgid "Outset"
+msgstr ""
+
+#: ../src/richtext/richtextbuffer.cpp:3518
+msgid "Change Style"
+msgstr ""
+
+#: ../src/richtext/richtextbuffer.cpp:3701
+msgid "Change Object Style"
+msgstr ""
+
+#: ../src/richtext/richtextbuffer.cpp:3974
+#: ../src/richtext/richtextbuffer.cpp:8174
+#, fuzzy
+msgid "Change Properties"
+msgstr "&Tulajdonságok"
+
+#: ../src/richtext/richtextbuffer.cpp:4346
+msgid "Change List Style"
+msgstr ""
+
+#: ../src/richtext/richtextbuffer.cpp:4519
+msgid "Renumber List"
+msgstr ""
+
+#: ../src/richtext/richtextbuffer.cpp:7867
+#: ../src/richtext/richtextbuffer.cpp:7897
+#: ../src/richtext/richtextbuffer.cpp:7939
+#: ../src/richtext/richtextctrl.cpp:1279 ../src/richtext/richtextctrl.cpp:1473
+msgid "Insert Text"
+msgstr ""
+
+#: ../src/richtext/richtextbuffer.cpp:8023
+#: ../src/richtext/richtextbuffer.cpp:8979
+msgid "Insert Image"
+msgstr ""
+
+#: ../src/richtext/richtextbuffer.cpp:8070
+#, fuzzy
+msgid "Insert Object"
+msgstr "Bekezdés"
+
+#: ../src/richtext/richtextbuffer.cpp:8112
+#, fuzzy
+msgid "Insert Field"
+msgstr "Bekezdés"
+
+#: ../src/richtext/richtextbuffer.cpp:8410
+msgid "Too many EndStyle calls!"
+msgstr ""
+
+#: ../src/richtext/richtextbuffer.cpp:8785
+#, fuzzy
+msgid "files"
+msgstr "Fájlok"
+
+#: ../src/richtext/richtextbuffer.cpp:9380
+msgid "standard/circle"
+msgstr ""
+
+#: ../src/richtext/richtextbuffer.cpp:9381
+msgid "standard/circle-outline"
+msgstr ""
+
+#: ../src/richtext/richtextbuffer.cpp:9382
+msgid "standard/square"
+msgstr ""
+
+#: ../src/richtext/richtextbuffer.cpp:9383
+msgid "standard/diamond"
+msgstr ""
+
+#: ../src/richtext/richtextbuffer.cpp:9384
+msgid "standard/triangle"
+msgstr ""
+
+#: ../src/richtext/richtextbuffer.cpp:9423
+#, fuzzy
+msgid "Box Properties"
+msgstr "&Tulajdonságok"
+
+#: ../src/richtext/richtextbuffer.cpp:10006
+msgid "Multiple Cell Properties"
+msgstr ""
+
+#: ../src/richtext/richtextbuffer.cpp:10008
+#, fuzzy
+msgid "Cell Properties"
+msgstr "&Tulajdonságok"
+
+#: ../src/richtext/richtextbuffer.cpp:11256
+#, fuzzy
+msgid "Set Cell Style"
+msgstr "Bejegyzés törlése"
+
+#: ../src/richtext/richtextbuffer.cpp:11330
+#, fuzzy
+msgid "Delete Row"
+msgstr "&Törlés"
+
+#: ../src/richtext/richtextbuffer.cpp:11380
+#, fuzzy
+msgid "Delete Column"
+msgstr "Kiválasztott"
+
+#: ../src/richtext/richtextbuffer.cpp:11431
+msgid "Add Row"
+msgstr ""
+
+#: ../src/richtext/richtextbuffer.cpp:11494
+msgid "Add Column"
+msgstr ""
+
+#: ../src/richtext/richtextbuffer.cpp:11537
+#, fuzzy
+msgid "Table Properties"
+msgstr "&Tulajdonságok"
+
+#: ../src/richtext/richtextbuffer.cpp:12899
+#, fuzzy
+msgid "Picture Properties"
+msgstr "&Tulajdonságok"
+
+#: ../src/richtext/richtextbuffer.cpp:13169
+#: ../src/richtext/richtextbuffer.cpp:13279
+msgid "image"
+msgstr ""
+
+#: ../src/richtext/richtextbulletspage.cpp:145
+#: ../src/richtext/richtextliststylepage.cpp:209
+msgid "&Bullet style:"
+msgstr ""
+
+#: ../src/richtext/richtextbulletspage.cpp:150
+#: ../src/richtext/richtextbulletspage.cpp:152
+#: ../src/richtext/richtextliststylepage.cpp:214
+#: ../src/richtext/richtextliststylepage.cpp:216
+msgid "The available bullet styles."
+msgstr ""
+
+#: ../src/richtext/richtextbulletspage.cpp:158
+#: ../src/richtext/richtextliststylepage.cpp:221
+msgid "Peri&od"
+msgstr ""
+
+#: ../src/richtext/richtextbulletspage.cpp:160
+#: ../src/richtext/richtextbulletspage.cpp:162
+#: ../src/richtext/richtextliststylepage.cpp:223
+#: ../src/richtext/richtextliststylepage.cpp:225
+msgid "Check to add a period after the bullet."
+msgstr ""
+
+#. TRANSLATORS: Bullet point in parentheses option
+#: ../src/richtext/richtextbulletspage.cpp:167
+#: ../src/richtext/richtextliststylepage.cpp:230
+msgid "(*)"
+msgstr ""
+
+#: ../src/richtext/richtextbulletspage.cpp:169
+#: ../src/richtext/richtextbulletspage.cpp:171
+#: ../src/richtext/richtextliststylepage.cpp:232
+#: ../src/richtext/richtextliststylepage.cpp:234
+msgid "Check to enclose the bullet in parentheses."
+msgstr ""
+
+#. TRANSLATORS: Right parenthesis bullet point option
+#: ../src/richtext/richtextbulletspage.cpp:176
+#: ../src/richtext/richtextliststylepage.cpp:239
+msgid "*)"
+msgstr ""
+
+#: ../src/richtext/richtextbulletspage.cpp:178
+#: ../src/richtext/richtextbulletspage.cpp:180
+#: ../src/richtext/richtextliststylepage.cpp:241
+#: ../src/richtext/richtextliststylepage.cpp:243
+msgid "Check to add a right parenthesis."
+msgstr ""
+
+#: ../src/richtext/richtextbulletspage.cpp:185
+#: ../src/richtext/richtextliststylepage.cpp:248
+msgid "Bullet &Alignment:"
+msgstr ""
+
+#: ../src/richtext/richtextbulletspage.cpp:190
+#: ../src/richtext/richtextliststylepage.cpp:253
+#, fuzzy
+msgid "Centre"
+msgstr "Középre igazítva"
+
+#: ../src/richtext/richtextbulletspage.cpp:194
+#: ../src/richtext/richtextbulletspage.cpp:196
+#: ../src/richtext/richtextbulletspage.cpp:217
+#: ../src/richtext/richtextbulletspage.cpp:219
+#: ../src/richtext/richtextliststylepage.cpp:257
+#: ../src/richtext/richtextliststylepage.cpp:259
+#: ../src/richtext/richtextliststylepage.cpp:278
+#: ../src/richtext/richtextliststylepage.cpp:280
+msgid "The bullet character."
+msgstr ""
+
+#: ../src/richtext/richtextbulletspage.cpp:212
+#: ../src/richtext/richtextliststylepage.cpp:271
+#, fuzzy
+msgid "&Symbol:"
+msgstr "&Stílus:"
+
+#: ../src/richtext/richtextbulletspage.cpp:222
+#: ../src/richtext/richtextliststylepage.cpp:283
+#, fuzzy
+msgid "Ch&oose..."
+msgstr "&Válasszon oldalszámot... "
+
+#: ../src/richtext/richtextbulletspage.cpp:223
+#: ../src/richtext/richtextbulletspage.cpp:225
+#: ../src/richtext/richtextliststylepage.cpp:284
+#: ../src/richtext/richtextliststylepage.cpp:286
+msgid "Click to browse for a symbol."
+msgstr ""
+
+#: ../src/richtext/richtextbulletspage.cpp:230
+#: ../src/richtext/richtextliststylepage.cpp:291
+#, fuzzy
+msgid "Symbol &font:"
+msgstr "Normál jelkészlet:"
+
+#: ../src/richtext/richtextbulletspage.cpp:235
+#: ../src/richtext/richtextbulletspage.cpp:237
+#: ../src/richtext/richtextliststylepage.cpp:297
+msgid "Available fonts."
+msgstr ""
+
+#: ../src/richtext/richtextbulletspage.cpp:242
+#: ../src/richtext/richtextliststylepage.cpp:302
+msgid "S&tandard bullet name:"
+msgstr ""
+
+#: ../src/richtext/richtextbulletspage.cpp:247
+#: ../src/richtext/richtextbulletspage.cpp:249
+#: ../src/richtext/richtextliststylepage.cpp:307
+#: ../src/richtext/richtextliststylepage.cpp:309
+msgid "A standard bullet name."
+msgstr ""
+
+#: ../src/richtext/richtextbulletspage.cpp:254
+msgid "&Number:"
+msgstr ""
+
+#: ../src/richtext/richtextbulletspage.cpp:258
+#: ../src/richtext/richtextbulletspage.cpp:260
+msgid "The list item number."
+msgstr ""
+
+#: ../src/richtext/richtextbulletspage.cpp:266
+#: ../src/richtext/richtextbulletspage.cpp:268
+#: ../src/richtext/richtextliststylepage.cpp:475
+#: ../src/richtext/richtextliststylepage.cpp:477
+msgid "Shows a preview of the bullet settings."
+msgstr ""
+
+#: ../src/richtext/richtextbulletspage.cpp:276
+#: ../src/richtext/richtextliststylepage.cpp:484
+msgid "(None)"
+msgstr ""
+
+#: ../src/richtext/richtextbulletspage.cpp:277
+#: ../src/richtext/richtextliststylepage.cpp:485
+msgid "Arabic"
+msgstr ""
+
+#: ../src/richtext/richtextbulletspage.cpp:278
+#: ../src/richtext/richtextliststylepage.cpp:486
+msgid "Upper case letters"
+msgstr ""
+
+#: ../src/richtext/richtextbulletspage.cpp:279
+#: ../src/richtext/richtextliststylepage.cpp:487
+msgid "Lower case letters"
+msgstr ""
+
+#: ../src/richtext/richtextbulletspage.cpp:280
+#: ../src/richtext/richtextliststylepage.cpp:488
+msgid "Upper case roman numerals"
+msgstr ""
+
+#: ../src/richtext/richtextbulletspage.cpp:281
+#: ../src/richtext/richtextliststylepage.cpp:489
+msgid "Lower case roman numerals"
+msgstr ""
+
+#: ../src/richtext/richtextbulletspage.cpp:282
+#: ../src/richtext/richtextliststylepage.cpp:490
+msgid "Numbered outline"
+msgstr ""
+
+#: ../src/richtext/richtextbulletspage.cpp:283
+#: ../src/richtext/richtextliststylepage.cpp:491
+msgid "Symbol"
+msgstr ""
+
+#: ../src/richtext/richtextbulletspage.cpp:284
+#: ../src/richtext/richtextliststylepage.cpp:492
+msgid "Bitmap"
+msgstr ""
+
+#: ../src/richtext/richtextbulletspage.cpp:285
+#: ../src/richtext/richtextliststylepage.cpp:493
+msgid "Standard"
+msgstr ""
+
+#: ../src/richtext/richtextbulletspage.cpp:287
+#: ../src/richtext/richtextliststylepage.cpp:495
+msgid "*"
+msgstr ""
+
+#: ../src/richtext/richtextbulletspage.cpp:288
+#: ../src/richtext/richtextliststylepage.cpp:496
+msgid "-"
+msgstr ""
+
+#: ../src/richtext/richtextbulletspage.cpp:289
+#: ../src/richtext/richtextliststylepage.cpp:497
+#, fuzzy
+msgid ">"
+msgstr ">>"
+
+#: ../src/richtext/richtextbulletspage.cpp:290
+#: ../src/richtext/richtextliststylepage.cpp:498
+msgid "+"
+msgstr ""
+
+#: ../src/richtext/richtextbulletspage.cpp:291
+#: ../src/richtext/richtextliststylepage.cpp:499
+msgid "~"
+msgstr ""
+
+#: ../src/richtext/richtextctrl.cpp:859
+msgid "Drag"
+msgstr ""
+
+#: ../src/richtext/richtextctrl.cpp:1338 ../src/richtext/richtextctrl.cpp:1559
+#, fuzzy
+msgid "Delete Text"
+msgstr "Bejegyzés törlése"
+
+#: ../src/richtext/richtextctrl.cpp:1537
+#, fuzzy
+msgid "Remove Bullet"
+msgstr "Töröld"
+
+#: ../src/richtext/richtextctrl.cpp:3070
+msgid "The text couldn't be saved."
+msgstr "A szöveget nem tudom elmenteni."
+
+#: ../src/richtext/richtextctrl.cpp:3644
+#, fuzzy
+msgid "Replace"
+msgstr "&Helyettesítés"
+
+#: ../src/richtext/richtextfontpage.cpp:146
+#: ../src/richtext/richtextsymboldlg.cpp:384
+#, fuzzy
+msgid "&Font:"
+msgstr "Jelkészlet család:"
+
+#: ../src/richtext/richtextfontpage.cpp:150
+#: ../src/richtext/richtextfontpage.cpp:152
+#, fuzzy
+msgid "Type a font name."
+msgstr "A betűkészlet családja."
+
+#: ../src/richtext/richtextfontpage.cpp:158
+#, fuzzy
+msgid "&Size:"
+msgstr "&Méret"
+
+#: ../src/richtext/richtextfontpage.cpp:165
+#: ../src/richtext/richtextfontpage.cpp:167
+msgid "Type a size in points."
+msgstr ""
+
+#: ../src/richtext/richtextfontpage.cpp:180
+#: ../src/richtext/richtextfontpage.cpp:182
+#, fuzzy
+msgid "The font size units, points or pixels."
+msgstr "A jelkészlet mérete."
+
+#: ../src/richtext/richtextfontpage.cpp:189
+#: ../src/richtext/richtextfontpage.cpp:191
+#, fuzzy
+msgid "Lists the available fonts."
+msgstr "Nincsenek tippek, sajnálom!"
+
+#: ../src/richtext/richtextfontpage.cpp:196
+#: ../src/richtext/richtextfontpage.cpp:198
+msgid "Lists font sizes in points."
+msgstr ""
+
+#: ../src/richtext/richtextfontpage.cpp:207
+#, fuzzy
+msgid "Font st&yle:"
+msgstr "Jelkészlet mérete:"
+
+#: ../src/richtext/richtextfontpage.cpp:212
+#: ../src/richtext/richtextfontpage.cpp:214
+msgid "Select regular or italic style."
+msgstr ""
+
+#: ../src/richtext/richtextfontpage.cpp:220
+#, fuzzy
+msgid "Font &weight:"
+msgstr "A betűkészlet hangsúlya."
+
+#: ../src/richtext/richtextfontpage.cpp:225
+#: ../src/richtext/richtextfontpage.cpp:227
+msgid "Select regular or bold."
+msgstr ""
+
+#: ../src/richtext/richtextfontpage.cpp:233
+#, fuzzy
+msgid "&Underlining:"
+msgstr "Alá&húzás"
+
+#: ../src/richtext/richtextfontpage.cpp:238
+#: ../src/richtext/richtextfontpage.cpp:240
+msgid "Select underlining or no underlining."
+msgstr ""
+
+#: ../src/richtext/richtextfontpage.cpp:248
+#, fuzzy
+msgid "&Colour:"
+msgstr "S&zín"
+
+#: ../src/richtext/richtextfontpage.cpp:253
+#: ../src/richtext/richtextfontpage.cpp:255
+#, fuzzy
+msgid "Click to change the text colour."
+msgstr "Kattints ide a betűtípus választás törléséhez"
+
+#: ../src/richtext/richtextfontpage.cpp:261
+#, fuzzy
+msgid "&Bg colour:"
+msgstr "S&zín"
+
+#: ../src/richtext/richtextfontpage.cpp:266
+#: ../src/richtext/richtextfontpage.cpp:268
+#, fuzzy
+msgid "Click to change the text background colour."
+msgstr "Kattints ide a betűtípus választás törléséhez"
+
+#: ../src/richtext/richtextfontpage.cpp:276
+#: ../src/richtext/richtextfontpage.cpp:278
+#, fuzzy
+msgid "Check to show a line through the text."
+msgstr "Kattints ide a betűtípus választás törléséhez"
+
+#: ../src/richtext/richtextfontpage.cpp:281
+msgid "Ca&pitals"
+msgstr ""
+
+#: ../src/richtext/richtextfontpage.cpp:283
+#: ../src/richtext/richtextfontpage.cpp:285
+#, fuzzy
+msgid "Check to show the text in capitals."
+msgstr "Kattints ide a betűtípus választás törléséhez"
+
+#: ../src/richtext/richtextfontpage.cpp:288
+msgid "Small C&apitals"
+msgstr ""
+
+#: ../src/richtext/richtextfontpage.cpp:290
+#: ../src/richtext/richtextfontpage.cpp:292
+#, fuzzy
+msgid "Check to show the text in small capitals."
+msgstr "Kattints ide a betűtípus választás törléséhez"
+
+#: ../src/richtext/richtextfontpage.cpp:295
+#, fuzzy
+msgid "Supe&rscript"
+msgstr "Script"
+
+#: ../src/richtext/richtextfontpage.cpp:297
+#: ../src/richtext/richtextfontpage.cpp:299
+#, fuzzy
+msgid "Check to show the text in superscript."
+msgstr "Kattints ide a betűtípus választás törléséhez"
+
+#: ../src/richtext/richtextfontpage.cpp:302
+#, fuzzy
+msgid "Subscrip&t"
+msgstr "Script"
+
+#: ../src/richtext/richtextfontpage.cpp:304
+#: ../src/richtext/richtextfontpage.cpp:306
+#, fuzzy
+msgid "Check to show the text in subscript."
+msgstr "Kattints ide a betűtípus választás törléséhez"
+
+#: ../src/richtext/richtextfontpage.cpp:312
+msgid "Rig&ht-to-left"
+msgstr ""
+
+#: ../src/richtext/richtextfontpage.cpp:314
+#: ../src/richtext/richtextfontpage.cpp:316
+#, fuzzy
+msgid "Check to indicate right-to-left text layout."
+msgstr "Kattints ide a betűtípus választás törléséhez"
+
+#: ../src/richtext/richtextfontpage.cpp:319
+msgid "Suppress hyphe&nation"
+msgstr ""
+
+#: ../src/richtext/richtextfontpage.cpp:321
+#: ../src/richtext/richtextfontpage.cpp:323
+msgid "Check to suppress hyphenation."
+msgstr ""
+
+#: ../src/richtext/richtextfontpage.cpp:329
+#: ../src/richtext/richtextfontpage.cpp:331
+msgid "Shows a preview of the font settings."
+msgstr ""
+
+#: ../src/richtext/richtextfontpage.cpp:348
+#: ../src/richtext/richtextfontpage.cpp:352
+#: ../src/richtext/richtextfontpage.cpp:356
+#: ../src/richtext/richtextformatdlg.cpp:873
+#: ../src/richtext/richtextindentspage.cpp:273
+#: ../src/richtext/richtextindentspage.cpp:285
+#: ../src/richtext/richtextindentspage.cpp:286
+#: ../src/richtext/richtextindentspage.cpp:310
+#: ../src/richtext/richtextindentspage.cpp:325
+#: ../src/richtext/richtextliststylepage.cpp:451
+#: ../src/richtext/richtextliststylepage.cpp:463
+#: ../src/richtext/richtextliststylepage.cpp:464
+#, fuzzy
+msgid "(none)"
+msgstr "névtelen"
+
+#: ../src/richtext/richtextfontpage.cpp:349
+#: ../src/richtext/richtextfontpage.cpp:353
+msgid "Regular"
+msgstr ""
+
+#: ../src/richtext/richtextfontpage.cpp:357
+#, fuzzy
+msgid "Not underlined"
+msgstr "aláhúzott"
+
+#: ../src/richtext/richtextformatdlg.cpp:341
+msgid "Indents && Spacing"
+msgstr ""
+
+#: ../src/richtext/richtextformatdlg.cpp:346
+msgid "Tabs"
+msgstr ""
+
+#: ../src/richtext/richtextformatdlg.cpp:351
+msgid "Bullets"
+msgstr ""
+
+#: ../src/richtext/richtextformatdlg.cpp:356
+msgid "List Style"
+msgstr ""
+
+#: ../src/richtext/richtextformatdlg.cpp:366
+#: ../src/richtext/richtextmarginspage.cpp:170
+msgid "Margins"
+msgstr ""
+
+#: ../src/richtext/richtextformatdlg.cpp:371
+#, fuzzy
+msgid "Borders"
+msgstr "Modern"
+
+#: ../src/richtext/richtextformatdlg.cpp:765
+#, fuzzy
+msgid "Colour"
+msgstr "S&zín"
+
+#: ../src/richtext/richtextindentspage.cpp:127
+#: ../src/richtext/richtextliststylepage.cpp:322
+#, fuzzy
+msgid "&Alignment"
+msgstr "Balra igazítsd"
+
+#: ../src/richtext/richtextindentspage.cpp:138
+#: ../src/richtext/richtextliststylepage.cpp:331
+msgid "&Left"
+msgstr ""
+
+#: ../src/richtext/richtextindentspage.cpp:140
+#: ../src/richtext/richtextindentspage.cpp:142
+#: ../src/richtext/richtextliststylepage.cpp:333
+#: ../src/richtext/richtextliststylepage.cpp:335
+msgid "Left-align text."
+msgstr ""
+
+#: ../src/richtext/richtextindentspage.cpp:145
+#: ../src/richtext/richtextliststylepage.cpp:338
+#, fuzzy
+msgid "&Right"
+msgstr "Vékony"
+
+#: ../src/richtext/richtextindentspage.cpp:147
+#: ../src/richtext/richtextindentspage.cpp:149
+#: ../src/richtext/richtextliststylepage.cpp:340
+#: ../src/richtext/richtextliststylepage.cpp:342
+msgid "Right-align text."
+msgstr ""
+
+#: ../src/richtext/richtextindentspage.cpp:152
+#: ../src/richtext/richtextliststylepage.cpp:345
+#, fuzzy
+msgid "&Justified"
+msgstr "Jóváhagyva"
+
+#: ../src/richtext/richtextindentspage.cpp:154
+#: ../src/richtext/richtextindentspage.cpp:156
+#: ../src/richtext/richtextliststylepage.cpp:347
+#: ../src/richtext/richtextliststylepage.cpp:349
+msgid "Justify text left and right."
+msgstr ""
+
+#: ../src/richtext/richtextindentspage.cpp:159
+#: ../src/richtext/richtextliststylepage.cpp:352
+#, fuzzy
+msgid "Cen&tred"
+msgstr "Középre igazítva"
+
+#: ../src/richtext/richtextindentspage.cpp:161
+#: ../src/richtext/richtextindentspage.cpp:163
+#: ../src/richtext/richtextliststylepage.cpp:354
+#: ../src/richtext/richtextliststylepage.cpp:356
+#, fuzzy
+msgid "Centre text."
+msgstr "Nem tudom létrehozni a mutex-et"
+
+#: ../src/richtext/richtextindentspage.cpp:166
+#: ../src/richtext/richtextliststylepage.cpp:359
+#, fuzzy
+msgid "&Indeterminate"
+msgstr "Alá&húzás"
+
+#: ../src/richtext/richtextindentspage.cpp:168
+#: ../src/richtext/richtextindentspage.cpp:170
+#: ../src/richtext/richtextliststylepage.cpp:361
+#: ../src/richtext/richtextliststylepage.cpp:363
+msgid "Use the current alignment setting."
+msgstr ""
+
+#: ../src/richtext/richtextindentspage.cpp:183
+#: ../src/richtext/richtextliststylepage.cpp:375
+msgid "&Indentation (tenths of a mm)"
+msgstr ""
+
+#: ../src/richtext/richtextindentspage.cpp:198
+#: ../src/richtext/richtextindentspage.cpp:200
+#: ../src/richtext/richtextliststylepage.cpp:388
+#: ../src/richtext/richtextliststylepage.cpp:390
+#, fuzzy
+msgid "The left indent."
+msgstr "A betűkészlet hangsúlya."
+
+#: ../src/richtext/richtextindentspage.cpp:203
+#: ../src/richtext/richtextliststylepage.cpp:393
+msgid "Left (&first line):"
+msgstr ""
+
+#: ../src/richtext/richtextindentspage.cpp:207
+#: ../src/richtext/richtextindentspage.cpp:209
+#: ../src/richtext/richtextliststylepage.cpp:397
+#: ../src/richtext/richtextliststylepage.cpp:399
+#, fuzzy
+msgid "The first line indent."
+msgstr "A jelkészlet mérete."
+
+#: ../src/richtext/richtextindentspage.cpp:216
+#: ../src/richtext/richtextindentspage.cpp:218
+#: ../src/richtext/richtextliststylepage.cpp:406
+#: ../src/richtext/richtextliststylepage.cpp:408
+msgid "The right indent."
+msgstr ""
+
+#: ../src/richtext/richtextindentspage.cpp:221
+msgid "&Outline level:"
+msgstr ""
+
+#: ../src/richtext/richtextindentspage.cpp:226
+#: ../src/richtext/richtextindentspage.cpp:228
+#, fuzzy
+msgid "The outline level."
+msgstr "Betűkészlet előkép bemutatás"
+
+#: ../src/richtext/richtextindentspage.cpp:241
+#: ../src/richtext/richtextliststylepage.cpp:420
+msgid "&Spacing (tenths of a mm)"
+msgstr ""
+
+#: ../src/richtext/richtextindentspage.cpp:252
+msgid "&Before a paragraph:"
+msgstr ""
+
+#: ../src/richtext/richtextindentspage.cpp:256
+#: ../src/richtext/richtextindentspage.cpp:258
+#: ../src/richtext/richtextliststylepage.cpp:433
+#: ../src/richtext/richtextliststylepage.cpp:435
+msgid "The spacing before the paragraph."
+msgstr ""
+
+#: ../src/richtext/richtextindentspage.cpp:261
+msgid "&After a paragraph:"
+msgstr ""
+
+#: ../src/richtext/richtextindentspage.cpp:266
+#: ../src/richtext/richtextliststylepage.cpp:442
+#: ../src/richtext/richtextliststylepage.cpp:444
+msgid "The spacing after the paragraph."
+msgstr ""
+
+#: ../src/richtext/richtextindentspage.cpp:269
+msgid "L&ine spacing:"
+msgstr ""
+
+#: ../src/richtext/richtextindentspage.cpp:274
+#: ../src/richtext/richtextliststylepage.cpp:452
+msgid "Single"
+msgstr ""
+
+#: ../src/richtext/richtextindentspage.cpp:275
+#: ../src/richtext/richtextliststylepage.cpp:453
+msgid "1.1"
+msgstr ""
+
+#: ../src/richtext/richtextindentspage.cpp:276
+#: ../src/richtext/richtextliststylepage.cpp:454
+msgid "1.2"
+msgstr ""
+
+#: ../src/richtext/richtextindentspage.cpp:277
+#: ../src/richtext/richtextliststylepage.cpp:455
+msgid "1.3"
+msgstr ""
+
+#: ../src/richtext/richtextindentspage.cpp:278
+#: ../src/richtext/richtextliststylepage.cpp:456
+msgid "1.4"
+msgstr ""
+
+#: ../src/richtext/richtextindentspage.cpp:279
+#: ../src/richtext/richtextliststylepage.cpp:457
+msgid "1.5"
+msgstr ""
+
+#: ../src/richtext/richtextindentspage.cpp:280
+#: ../src/richtext/richtextliststylepage.cpp:458
+msgid "1.6"
+msgstr ""
+
+#: ../src/richtext/richtextindentspage.cpp:281
+#: ../src/richtext/richtextliststylepage.cpp:459
+msgid "1.7"
+msgstr ""
+
+#: ../src/richtext/richtextindentspage.cpp:282
+#: ../src/richtext/richtextliststylepage.cpp:460
+msgid "1.8"
+msgstr ""
+
+#: ../src/richtext/richtextindentspage.cpp:283
+#: ../src/richtext/richtextliststylepage.cpp:461
+msgid "1.9"
+msgstr ""
+
+#: ../src/richtext/richtextindentspage.cpp:284
+#: ../src/richtext/richtextliststylepage.cpp:462
+msgid "2"
+msgstr ""
+
+#: ../src/richtext/richtextindentspage.cpp:287
+#: ../src/richtext/richtextindentspage.cpp:289
+#: ../src/richtext/richtextliststylepage.cpp:465
+#: ../src/richtext/richtextliststylepage.cpp:467
+msgid "The line spacing."
+msgstr ""
+
+#: ../src/richtext/richtextindentspage.cpp:292
+msgid "&Page Break"
+msgstr ""
+
+#: ../src/richtext/richtextindentspage.cpp:294
+#: ../src/richtext/richtextindentspage.cpp:296
+msgid "Inserts a page break before the paragraph."
+msgstr ""
+
+#: ../src/richtext/richtextindentspage.cpp:302
+#: ../src/richtext/richtextindentspage.cpp:304
+msgid "Shows a preview of the paragraph settings."
+msgstr ""
+
+#: ../src/richtext/richtextliststylepage.cpp:182
+msgid "&List level:"
+msgstr ""
+
+#: ../src/richtext/richtextliststylepage.cpp:186
+#: ../src/richtext/richtextliststylepage.cpp:188
+msgid "Selects the list level to edit."
+msgstr ""
+
+#: ../src/richtext/richtextliststylepage.cpp:193
+msgid "&Font for Level..."
+msgstr ""
+
+#: ../src/richtext/richtextliststylepage.cpp:194
+#: ../src/richtext/richtextliststylepage.cpp:196
+#, fuzzy
+msgid "Click to choose the font for this level."
+msgstr "Kattints ide a betűtípus választás törléséhez"
+
+#: ../src/richtext/richtextliststylepage.cpp:312
+msgid "Bullet style"
+msgstr ""
+
+#: ../src/richtext/richtextliststylepage.cpp:429
+msgid "Before a paragraph:"
+msgstr ""
+
+#: ../src/richtext/richtextliststylepage.cpp:438
+msgid "After a paragraph:"
+msgstr ""
+
+#: ../src/richtext/richtextliststylepage.cpp:447
+msgid "Line spacing:"
+msgstr ""
+
+#: ../src/richtext/richtextliststylepage.cpp:470
+#, fuzzy
+msgid "Spacing"
+msgstr "Keresek..."
+
+#: ../src/richtext/richtextmarginspage.cpp:193
+#: ../src/richtext/richtextmarginspage.cpp:195
+#, fuzzy
+msgid "The left margin size."
+msgstr "A jelkészlet mérete."
+
+#: ../src/richtext/richtextmarginspage.cpp:203
+#: ../src/richtext/richtextmarginspage.cpp:205
+msgid "Units for the left margin."
+msgstr ""
+
+#: ../src/richtext/richtextmarginspage.cpp:218
+#: ../src/richtext/richtextmarginspage.cpp:220
+#, fuzzy
+msgid "The right margin size."
+msgstr "A jelkészlet mérete."
+
+#: ../src/richtext/richtextmarginspage.cpp:228
+#: ../src/richtext/richtextmarginspage.cpp:230
+msgid "Units for the right margin."
+msgstr ""
+
+#: ../src/richtext/richtextmarginspage.cpp:241
+#: ../src/richtext/richtextmarginspage.cpp:243
+#, fuzzy
+msgid "The top margin size."
+msgstr "A jelkészlet mérete."
+
+#: ../src/richtext/richtextmarginspage.cpp:251
+#: ../src/richtext/richtextmarginspage.cpp:253
+#, fuzzy
+msgid "Units for the top margin."
+msgstr "Nem tudom megvárni a szál befejeződését."
+
+#: ../src/richtext/richtextmarginspage.cpp:266
+#: ../src/richtext/richtextmarginspage.cpp:268
+#, fuzzy
+msgid "The bottom margin size."
+msgstr "A jelkészlet mérete."
+
+#: ../src/richtext/richtextmarginspage.cpp:276
+#: ../src/richtext/richtextmarginspage.cpp:278
+msgid "Units for the bottom margin."
+msgstr ""
+
+#: ../src/richtext/richtextmarginspage.cpp:284
+#, fuzzy
+msgid "Padding"
+msgstr "olvasok"
+
+#: ../src/richtext/richtextmarginspage.cpp:307
+#: ../src/richtext/richtextmarginspage.cpp:309
+#, fuzzy
+msgid "The left padding size."
+msgstr "A jelkészlet mérete."
+
+#: ../src/richtext/richtextmarginspage.cpp:317
+#: ../src/richtext/richtextmarginspage.cpp:319
+msgid "Units for the left padding."
+msgstr ""
+
+#: ../src/richtext/richtextmarginspage.cpp:332
+#: ../src/richtext/richtextmarginspage.cpp:334
+#, fuzzy
+msgid "The right padding size."
+msgstr "A jelkészlet mérete."
+
+#: ../src/richtext/richtextmarginspage.cpp:342
+#: ../src/richtext/richtextmarginspage.cpp:344
+msgid "Units for the right padding."
+msgstr ""
+
+#: ../src/richtext/richtextmarginspage.cpp:355
+#: ../src/richtext/richtextmarginspage.cpp:357
+#, fuzzy
+msgid "The top padding size."
+msgstr "A jelkészlet mérete."
+
+#: ../src/richtext/richtextmarginspage.cpp:365
+#: ../src/richtext/richtextmarginspage.cpp:367
+msgid "Units for the top padding."
+msgstr ""
+
+#: ../src/richtext/richtextmarginspage.cpp:380
+#: ../src/richtext/richtextmarginspage.cpp:382
+#, fuzzy
+msgid "The bottom padding size."
+msgstr "A jelkészlet mérete."
+
+#: ../src/richtext/richtextmarginspage.cpp:390
+#: ../src/richtext/richtextmarginspage.cpp:392
+msgid "Units for the bottom padding."
+msgstr ""
+
+#: ../src/richtext/richtextprint.cpp:592
+msgid " Preview"
+msgstr " Nyomtatási előkép"
+
+#: ../src/richtext/richtextsizepage.cpp:228
+msgid "Floating"
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:243
+msgid "&Floating mode:"
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:252
+#: ../src/richtext/richtextsizepage.cpp:254
+msgid "How the object will float relative to the text."
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:265
+#, fuzzy
+msgid "Alignment"
+msgstr "Balra igazítsd"
+
+#: ../src/richtext/richtextsizepage.cpp:277
+#, fuzzy
+msgid "&Vertical alignment:"
+msgstr "Balra igazítsd"
+
+#: ../src/richtext/richtextsizepage.cpp:279
+#: ../src/richtext/richtextsizepage.cpp:281
+#, fuzzy
+msgid "Enable vertical alignment."
+msgstr "Nem tudom elindítani a nyomtatást."
+
+#: ../src/richtext/richtextsizepage.cpp:286
+#, fuzzy
+msgid "Centred"
+msgstr "Középre igazítva"
+
+#: ../src/richtext/richtextsizepage.cpp:290
+#: ../src/richtext/richtextsizepage.cpp:292
+#, fuzzy
+msgid "Vertical alignment."
+msgstr "Nem tudom elindítani a nyomtatást."
+
+#: ../src/richtext/richtextsizepage.cpp:316
+#: ../src/richtext/richtextsizepage.cpp:323
+#, fuzzy
+msgid "&Width:"
+msgstr "Hang&súly:"
+
+#: ../src/richtext/richtextsizepage.cpp:318
+#: ../src/richtext/richtextsizepage.cpp:320
+msgid "Enable the width value."
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:331
+#: ../src/richtext/richtextsizepage.cpp:333
+#, fuzzy
+msgid "The object width."
+msgstr "A betűkészlet hangsúlya."
+
+#: ../src/richtext/richtextsizepage.cpp:342
+#: ../src/richtext/richtextsizepage.cpp:344
+msgid "Units for the object width."
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:350
+#: ../src/richtext/richtextsizepage.cpp:357
+#, fuzzy
+msgid "&Height:"
+msgstr "Hang&súly:"
+
+#: ../src/richtext/richtextsizepage.cpp:352
+#: ../src/richtext/richtextsizepage.cpp:354
+#: ../src/richtext/richtextsizepage.cpp:464
+#: ../src/richtext/richtextsizepage.cpp:466
+msgid "Enable the height value."
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:365
+#: ../src/richtext/richtextsizepage.cpp:367
+#, fuzzy
+msgid "The object height."
+msgstr "A betűkészlet hangsúlya."
+
+#: ../src/richtext/richtextsizepage.cpp:376
+#: ../src/richtext/richtextsizepage.cpp:378
+msgid "Units for the object height."
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:381
+msgid "Min width:"
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:383
+#: ../src/richtext/richtextsizepage.cpp:385
+#, fuzzy
+msgid "Enable the minimum width value."
+msgstr "Nem tudom elindítani a nyomtatást."
+
+#: ../src/richtext/richtextsizepage.cpp:392
+#: ../src/richtext/richtextsizepage.cpp:394
+#, fuzzy
+msgid "The object minimum width."
+msgstr "A betűkészlet hangsúlya."
+
+#: ../src/richtext/richtextsizepage.cpp:403
+#: ../src/richtext/richtextsizepage.cpp:405
+#, fuzzy
+msgid "Units for the minimum object width."
+msgstr "A betűkészlet hangsúlya."
+
+#: ../src/richtext/richtextsizepage.cpp:408
+#, fuzzy
+msgid "Min height:"
+msgstr "A betűkészlet hangsúlya."
+
+#: ../src/richtext/richtextsizepage.cpp:410
+#: ../src/richtext/richtextsizepage.cpp:412
+msgid "Enable the minimum height value."
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:419
+#: ../src/richtext/richtextsizepage.cpp:421
+#, fuzzy
+msgid "The object minimum height."
+msgstr "A betűkészlet hangsúlya."
+
+#: ../src/richtext/richtextsizepage.cpp:430
+#: ../src/richtext/richtextsizepage.cpp:432
+#, fuzzy
+msgid "Units for the minimum object height."
+msgstr "A betűkészlet hangsúlya."
+
+#: ../src/richtext/richtextsizepage.cpp:435
+#, fuzzy
+msgid "Max width:"
+msgstr "Helyette:"
+
+#: ../src/richtext/richtextsizepage.cpp:437
+#: ../src/richtext/richtextsizepage.cpp:439
+#, fuzzy
+msgid "Enable the maximum width value."
+msgstr "Nem tudom elindítani a nyomtatást."
+
+#: ../src/richtext/richtextsizepage.cpp:446
+#: ../src/richtext/richtextsizepage.cpp:448
+#, fuzzy
+msgid "The object maximum width."
+msgstr "A betűkészlet hangsúlya."
+
+#: ../src/richtext/richtextsizepage.cpp:457
+#: ../src/richtext/richtextsizepage.cpp:459
+#, fuzzy
+msgid "Units for the maximum object width."
+msgstr "A betűkészlet hangsúlya."
+
+#: ../src/richtext/richtextsizepage.cpp:462
+#, fuzzy
+msgid "Max height:"
+msgstr "Hang&súly:"
+
+#: ../src/richtext/richtextsizepage.cpp:473
+#: ../src/richtext/richtextsizepage.cpp:475
+#, fuzzy
+msgid "The object maximum height."
+msgstr "A betűkészlet hangsúlya."
+
+#: ../src/richtext/richtextsizepage.cpp:484
+#: ../src/richtext/richtextsizepage.cpp:486
+#, fuzzy
+msgid "Units for the maximum object height."
+msgstr "A betűkészlet hangsúlya."
+
+#: ../src/richtext/richtextsizepage.cpp:495
+#, fuzzy
+msgid "Position"
+msgstr "Kérdés"
+
+#: ../src/richtext/richtextsizepage.cpp:513
+#, fuzzy
+msgid "&Position mode:"
+msgstr "Kérdés"
+
+#: ../src/richtext/richtextsizepage.cpp:517
+#: ../src/richtext/richtextsizepage.cpp:522
+#, fuzzy
+msgid "Static"
+msgstr "Állapot:"
+
+#: ../src/richtext/richtextsizepage.cpp:518
+#, fuzzy
+msgid "Relative"
+msgstr "Dekoratív"
+
+#: ../src/richtext/richtextsizepage.cpp:519
+msgid "Absolute"
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:520
+#, fuzzy
+msgid "Fixed"
+msgstr "Nem skálázható jelkészlet:"
+
+#: ../src/richtext/richtextsizepage.cpp:533
+#: ../src/richtext/richtextsizepage.cpp:535
+#: ../src/richtext/richtextsizepage.cpp:547
+#: ../src/richtext/richtextsizepage.cpp:549
+#, fuzzy
+msgid "The left position."
+msgstr "A jelkészlet mérete."
+
+#: ../src/richtext/richtextsizepage.cpp:558
+#: ../src/richtext/richtextsizepage.cpp:560
+#, fuzzy
+msgid "Units for the left position."
+msgstr "Nem tudom megvárni a szál befejeződését."
+
+#: ../src/richtext/richtextsizepage.cpp:568
+#: ../src/richtext/richtextsizepage.cpp:570
+#: ../src/richtext/richtextsizepage.cpp:582
+#: ../src/richtext/richtextsizepage.cpp:584
+#, fuzzy
+msgid "The top position."
+msgstr "A jelkészlet mérete."
+
+#: ../src/richtext/richtextsizepage.cpp:593
+#: ../src/richtext/richtextsizepage.cpp:595
+#, fuzzy
+msgid "Units for the top position."
+msgstr "Nem tudom megvárni a szál befejeződését."
+
+#: ../src/richtext/richtextsizepage.cpp:603
+#: ../src/richtext/richtextsizepage.cpp:605
+#: ../src/richtext/richtextsizepage.cpp:617
+#: ../src/richtext/richtextsizepage.cpp:619
+#, fuzzy
+msgid "The right position."
+msgstr "A jelkészlet mérete."
+
+#: ../src/richtext/richtextsizepage.cpp:628
+#: ../src/richtext/richtextsizepage.cpp:630
+#, fuzzy
+msgid "Units for the right position."
+msgstr "Nem tudom megvárni a szál befejeződését."
+
+#: ../src/richtext/richtextsizepage.cpp:638
+#: ../src/richtext/richtextsizepage.cpp:640
+#: ../src/richtext/richtextsizepage.cpp:652
+#: ../src/richtext/richtextsizepage.cpp:654
+#, fuzzy
+msgid "The bottom position."
+msgstr "A jelkészlet mérete."
+
+#: ../src/richtext/richtextsizepage.cpp:663
+#: ../src/richtext/richtextsizepage.cpp:665
+#, fuzzy
+msgid "Units for the bottom position."
+msgstr "Nem tudom megvárni a szál befejeződését."
+
+#: ../src/richtext/richtextsizepage.cpp:671
+msgid "&Move the object to:"
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:674
+#, fuzzy
+msgid "&Previous Paragraph"
+msgstr "Előző oldal"
+
+#: ../src/richtext/richtextsizepage.cpp:675
+#: ../src/richtext/richtextsizepage.cpp:677
+msgid "Moves the object to the previous paragraph."
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:680
+msgid "&Next Paragraph"
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:681
+#: ../src/richtext/richtextsizepage.cpp:683
+msgid "Moves the object to the next paragraph."
+msgstr ""
+
+#: ../src/richtext/richtextstyledlg.cpp:193
+#, fuzzy
+msgid "&Styles:"
+msgstr "&Stílus:"
+
+#: ../src/richtext/richtextstyledlg.cpp:197
+#: ../src/richtext/richtextstyledlg.cpp:199
+#, fuzzy
+msgid "The available styles."
+msgstr "A betűkészlet stílusa."
+
+#: ../src/richtext/richtextstyledlg.cpp:205
+#: ../src/richtext/richtextstyledlg.cpp:217
+msgid " "
+msgstr " "
+
+#: ../src/richtext/richtextstyledlg.cpp:209
+#: ../src/richtext/richtextstyledlg.cpp:211
+#, fuzzy
+msgid "The style preview."
+msgstr "Betűkészlet előkép bemutatás"
+
+#: ../src/richtext/richtextstyledlg.cpp:220
+msgid "New &Character Style..."
+msgstr ""
+
+#: ../src/richtext/richtextstyledlg.cpp:221
+#: ../src/richtext/richtextstyledlg.cpp:223
+msgid "Click to create a new character style."
+msgstr ""
+
+#: ../src/richtext/richtextstyledlg.cpp:226
+msgid "New &Paragraph Style..."
+msgstr ""
+
+#: ../src/richtext/richtextstyledlg.cpp:227
+#: ../src/richtext/richtextstyledlg.cpp:229
+msgid "Click to create a new paragraph style."
+msgstr ""
+
+#: ../src/richtext/richtextstyledlg.cpp:232
+msgid "New &List Style..."
+msgstr ""
+
+#: ../src/richtext/richtextstyledlg.cpp:233
+#: ../src/richtext/richtextstyledlg.cpp:235
+#, fuzzy
+msgid "Click to create a new list style."
+msgstr "Kattints ide a betűtípus választás törléséhez"
+
+#: ../src/richtext/richtextstyledlg.cpp:238
+#, fuzzy
+msgid "New &Box Style..."
+msgstr "Új bejegyzés"
+
+#: ../src/richtext/richtextstyledlg.cpp:239
+#: ../src/richtext/richtextstyledlg.cpp:241
+#, fuzzy
+msgid "Click to create a new box style."
+msgstr "Kattints ide a betűtípus választás törléséhez"
+
+#: ../src/richtext/richtextstyledlg.cpp:246
+#, fuzzy
+msgid "&Apply Style"
+msgstr "&Alkalmazd"
+
+#: ../src/richtext/richtextstyledlg.cpp:247
+#: ../src/richtext/richtextstyledlg.cpp:249
+#, fuzzy
+msgid "Click to apply the selected style."
+msgstr "Kattints ide a betűtípus választás törléséhez"
+
+#: ../src/richtext/richtextstyledlg.cpp:252
+msgid "&Rename Style..."
+msgstr ""
+
+#: ../src/richtext/richtextstyledlg.cpp:253
+#: ../src/richtext/richtextstyledlg.cpp:255
+#, fuzzy
+msgid "Click to rename the selected style."
+msgstr "Kattints ide a betűtípus választás törléséhez"
+
+#: ../src/richtext/richtextstyledlg.cpp:258
+#, fuzzy
+msgid "&Edit Style..."
+msgstr "Bejegyzés szerkesztése"
+
+#: ../src/richtext/richtextstyledlg.cpp:259
+#: ../src/richtext/richtextstyledlg.cpp:261
+#, fuzzy
+msgid "Click to edit the selected style."
+msgstr "Kattints ide a betűtípus választás törléséhez"
+
+#: ../src/richtext/richtextstyledlg.cpp:264
+#, fuzzy
+msgid "&Delete Style..."
+msgstr "Bejegyzés törlése"
+
+#: ../src/richtext/richtextstyledlg.cpp:265
+#: ../src/richtext/richtextstyledlg.cpp:267
+#, fuzzy
+msgid "Click to delete the selected style."
+msgstr "Kattints ide a betűtípus választás törléséhez"
+
+#: ../src/richtext/richtextstyledlg.cpp:274
+#: ../src/richtext/richtextstyledlg.cpp:276
+#, fuzzy
+msgid "Click to close this window."
+msgstr "Zárja be ezt az ablakot"
+
+#: ../src/richtext/richtextstyledlg.cpp:282
+msgid "&Restart numbering"
+msgstr ""
+
+#: ../src/richtext/richtextstyledlg.cpp:284
+#: ../src/richtext/richtextstyledlg.cpp:286
+msgid "Check to restart numbering."
+msgstr ""
+
+#: ../src/richtext/richtextstyledlg.cpp:601
+msgid "Enter a character style name"
+msgstr ""
+
+#: ../src/richtext/richtextstyledlg.cpp:601
+#: ../src/richtext/richtextstyledlg.cpp:606
+#: ../src/richtext/richtextstyledlg.cpp:649
+#: ../src/richtext/richtextstyledlg.cpp:654
+#: ../src/richtext/richtextstyledlg.cpp:815
+#: ../src/richtext/richtextstyledlg.cpp:820
+#: ../src/richtext/richtextstyledlg.cpp:888
+#: ../src/richtext/richtextstyledlg.cpp:896
+#: ../src/richtext/richtextstyledlg.cpp:929
+#: ../src/richtext/richtextstyledlg.cpp:934
+#, fuzzy
+msgid "New Style"
+msgstr "Új bejegyzés"
+
+#: ../src/richtext/richtextstyledlg.cpp:606
+#: ../src/richtext/richtextstyledlg.cpp:654
+#: ../src/richtext/richtextstyledlg.cpp:820
+#: ../src/richtext/richtextstyledlg.cpp:896
+#: ../src/richtext/richtextstyledlg.cpp:934
+msgid "Sorry, that name is taken. Please choose another."
+msgstr ""
+
+#: ../src/richtext/richtextstyledlg.cpp:649
+msgid "Enter a paragraph style name"
+msgstr ""
+
+#: ../src/richtext/richtextstyledlg.cpp:777
+#, fuzzy, c-format
+msgid "Delete style %s?"
+msgstr "Bejegyzés törlése"
+
+#: ../src/richtext/richtextstyledlg.cpp:777
+#, fuzzy
+msgid "Delete Style"
+msgstr "Bejegyzés törlése"
+
+#: ../src/richtext/richtextstyledlg.cpp:815
+msgid "Enter a list style name"
+msgstr ""
+
+#: ../src/richtext/richtextstyledlg.cpp:888
+#, fuzzy
+msgid "Enter a new style name"
+msgstr "A betűkészlet stílusa."
+
+#: ../src/richtext/richtextstyledlg.cpp:929
+#, fuzzy
+msgid "Enter a box style name"
+msgstr "A betűkészlet stílusa."
+
+#: ../src/richtext/richtextstylepage.cpp:109
+#: ../src/richtext/richtextstylepage.cpp:111
+#, fuzzy
+msgid "The style name."
+msgstr "A betűkészlet stílusa."
+
+#: ../src/richtext/richtextstylepage.cpp:114
+msgid "&Based on:"
+msgstr ""
+
+#: ../src/richtext/richtextstylepage.cpp:119
+#: ../src/richtext/richtextstylepage.cpp:121
+msgid "The style on which this style is based."
+msgstr ""
+
+#: ../src/richtext/richtextstylepage.cpp:124
+#, fuzzy
+msgid "&Next style:"
+msgstr "&Következő >"
+
+#: ../src/richtext/richtextstylepage.cpp:129
+#: ../src/richtext/richtextstylepage.cpp:131
+msgid "The default style for the next paragraph."
+msgstr ""
+
+#: ../src/richtext/richtextstyles.cpp:1057
+msgid "All styles"
+msgstr ""
+
+#: ../src/richtext/richtextstyles.cpp:1058
+msgid "Paragraph styles"
+msgstr ""
+
+#: ../src/richtext/richtextstyles.cpp:1059
+msgid "Character styles"
+msgstr ""
+
+#: ../src/richtext/richtextstyles.cpp:1060
+msgid "List styles"
+msgstr ""
+
+#: ../src/richtext/richtextstyles.cpp:1061
+#, fuzzy
+msgid "Box styles"
+msgstr "&Következő >"
+
+#: ../src/richtext/richtextsymboldlg.cpp:389
+#: ../src/richtext/richtextsymboldlg.cpp:391
+msgid "The font from which to take the symbol."
+msgstr ""
+
+#: ../src/richtext/richtextsymboldlg.cpp:396
+msgid "&Subset:"
+msgstr ""
+
+#: ../src/richtext/richtextsymboldlg.cpp:401
+#: ../src/richtext/richtextsymboldlg.cpp:403
+msgid "Shows a Unicode subset."
+msgstr ""
+
+#: ../src/richtext/richtextsymboldlg.cpp:412
+msgid "xxxx"
+msgstr ""
+
+#: ../src/richtext/richtextsymboldlg.cpp:417
+msgid "&Character code:"
+msgstr ""
+
+#: ../src/richtext/richtextsymboldlg.cpp:421
+#: ../src/richtext/richtextsymboldlg.cpp:423
+msgid "The character code."
+msgstr ""
+
+#: ../src/richtext/richtextsymboldlg.cpp:428
+#, fuzzy
+msgid "&From:"
+msgstr "Tól:"
+
+#: ../src/richtext/richtextsymboldlg.cpp:433
+#: ../src/richtext/richtextsymboldlg.cpp:434
+#: ../src/richtext/richtextsymboldlg.cpp:435
+#, fuzzy
+msgid "Unicode"
+msgstr "&Kikezdés"
+
+#: ../src/richtext/richtextsymboldlg.cpp:436
+#: ../src/richtext/richtextsymboldlg.cpp:438
+msgid "The range to show."
+msgstr ""
+
+#: ../src/richtext/richtextsymboldlg.cpp:444
+#, fuzzy
+msgid "Insert"
+msgstr "Bekezdés"
+
+#: ../src/richtext/richtextsymboldlg.cpp:478
+#, fuzzy
+msgid "(Normal text)"
+msgstr "Normál jelkészlet:"
+
+#: ../src/richtext/richtexttabspage.cpp:109
+msgid "&Position (tenths of a mm):"
+msgstr ""
+
+#: ../src/richtext/richtexttabspage.cpp:113
+#: ../src/richtext/richtexttabspage.cpp:115
+#, fuzzy
+msgid "The tab position."
+msgstr "A jelkészlet mérete."
+
+#: ../src/richtext/richtexttabspage.cpp:119
+#, fuzzy
+msgid "The tab positions."
+msgstr "A jelkészlet mérete."
+
+#: ../src/richtext/richtexttabspage.cpp:132
+#: ../src/richtext/richtexttabspage.cpp:134
+#, fuzzy
+msgid "Click to create a new tab position."
+msgstr "Kattints ide a betűtípus választás törléséhez"
+
+#: ../src/richtext/richtexttabspage.cpp:138
+#: ../src/richtext/richtexttabspage.cpp:140
+#, fuzzy
+msgid "Click to delete the selected tab position."
+msgstr "Kattints ide a betűtípus választás törléséhez"
+
+#: ../src/richtext/richtexttabspage.cpp:143
+#, fuzzy
+msgid "Delete A&ll"
+msgstr "Válassz ki &minden fájlt"
+
+#: ../src/richtext/richtexttabspage.cpp:144
+#: ../src/richtext/richtexttabspage.cpp:146
+#, fuzzy
+msgid "Click to delete all tab positions."
+msgstr "Kattints ide a betűtípus választás törléséhez"
+
+#: ../src/univ/theme.cpp:110
+msgid "Failed to initialize GUI: no built-in themes found."
+msgstr "Nem sikerült elindítani a GUIt: nem találtam beépített bőrt."
+
+#: ../src/univ/themes/gtk.cpp:521
+msgid "GTK+ theme"
+msgstr "GTK+ bőr"
+
+#: ../src/univ/themes/metal.cpp:164
+msgid "Metal theme"
+msgstr "Fém bőr"
+
+#: ../src/univ/themes/mono.cpp:512
+msgid "Simple monochrome theme"
+msgstr ""
+
+#: ../src/univ/themes/win32.cpp:1098
+msgid "Win32 theme"
+msgstr "Win32 bőr"
+
+#: ../src/univ/themes/win32.cpp:3743
+msgid "&Restore"
+msgstr "&Helyreállítás"
+
+#: ../src/univ/themes/win32.cpp:3744
+msgid "&Move"
+msgstr "&Áthelyezés"
+
+#: ../src/univ/themes/win32.cpp:3746
+msgid "&Size"
+msgstr "&Méret"
+
+#: ../src/univ/themes/win32.cpp:3748
+msgid "Mi&nimize"
+msgstr "Mi&nimalizál"
+
+#: ../src/univ/themes/win32.cpp:3750
+msgid "Ma&ximize"
+msgstr "Ma&ximalizál"
+
+#: ../src/univ/themes/win32.cpp:3752
+msgid "Alt+"
+msgstr ""
+
+#: ../src/unix/appunix.cpp:178
+#, fuzzy
+msgid "Failed to install signal handler"
+msgstr "Nem sikerült lezárni a file kezelőt."
+
+#: ../src/unix/dialup.cpp:351
+msgid "Already dialling ISP."
+msgstr "Már tárcsázom az ISPt."
+
+#: ../src/unix/dlunix.cpp:93
+#, fuzzy
+msgid "Failed to unload shared library"
+msgstr "Nem tudtam betölteni a(z) '%s' osztott könyvtárat."
+
+#: ../src/unix/dlunix.cpp:121
+msgid "Unknown dynamic library error"
+msgstr "Ismeretlen dinamikus könyvtár hiba"
+
+#: ../src/unix/epolldispatcher.cpp:84
+#, fuzzy
+msgid "Failed to create epoll descriptor"
+msgstr "Nem sikerült lérehozni egér mutatót."
+
+#: ../src/unix/epolldispatcher.cpp:103
+#, fuzzy
+msgid "Error closing epoll descriptor"
+msgstr "Hiba a könyvtár létrehozásakor"
+
+#: ../src/unix/epolldispatcher.cpp:116
+#, fuzzy, c-format
+msgid "Failed to add descriptor %d to epoll descriptor %d"
+msgstr "nem tudok írni a(z) %d leíróval megadott fájba"
+
+#: ../src/unix/epolldispatcher.cpp:136
+#, c-format
+msgid "Failed to modify descriptor %d in epoll descriptor %d"
+msgstr ""
+
+#: ../src/unix/epolldispatcher.cpp:155
+#, fuzzy, c-format
+msgid "Failed to unregister descriptor %d from epoll descriptor %d"
+msgstr "Nem tudtam adatot elővenni a vágólapról."
+
+#: ../src/unix/epolldispatcher.cpp:213
+#, fuzzy, c-format
+msgid "Waiting for IO on epoll descriptor %d failed"
+msgstr "Nem sikerült megvárni az alprocessz befejeződését"
+
+#: ../src/unix/fswatcher_inotify.cpp:71
+#, fuzzy
+msgid "Unable to create inotify instance"
+msgstr "Nem sikerült létrehozni a DDE láncot"
+
+#: ../src/unix/fswatcher_inotify.cpp:94
+#, fuzzy
+msgid "Unable to close inotify instance"
+msgstr "Nem sikerült lezárni a file kezelőt."
+
+#: ../src/unix/fswatcher_inotify.cpp:106
+msgid "Unable to add inotify watch"
+msgstr ""
+
+#: ../src/unix/fswatcher_inotify.cpp:138
+#, fuzzy, c-format
+msgid "Unable to remove inotify watch %i"
+msgstr "Nem sikerült létrehozni a DDE láncot"
+
+#: ../src/unix/fswatcher_inotify.cpp:271
+#, c-format
+msgid "Unexpected event for \"%s\": no matching watch descriptor."
+msgstr ""
+
+#: ../src/unix/fswatcher_inotify.cpp:320
+#, c-format
+msgid "Invalid inotify event for \"%s\""
+msgstr ""
+
+#: ../src/unix/fswatcher_inotify.cpp:553
+#, fuzzy
+msgid "Unable to read from inotify descriptor"
+msgstr "nem tudok olvasni a(z) %d leíróval megadott fájból"
+
+#: ../src/unix/fswatcher_inotify.cpp:558
+#, fuzzy
+msgid "EOF while reading from inotify descriptor"
+msgstr "nem tudok olvasni a(z) %d leíróval megadott fájból"
+
+#: ../src/unix/fswatcher_kqueue.cpp:114
+#, fuzzy
+msgid "Unable to create kqueue instance"
+msgstr "Nem sikerült létrehozni a DDE láncot"
+
+#: ../src/unix/fswatcher_kqueue.cpp:131
+#, fuzzy
+msgid "Error closing kqueue instance"
+msgstr "Hiba a könyvtár létrehozásakor"
+
+#: ../src/unix/fswatcher_kqueue.cpp:153
+msgid "Unable to add kqueue watch"
+msgstr ""
+
+#: ../src/unix/fswatcher_kqueue.cpp:170
+msgid "Unable to remove kqueue watch"
+msgstr ""
+
+#: ../src/unix/fswatcher_kqueue.cpp:202
+msgid "Unable to get events from kqueue"
+msgstr ""
+
+#: ../src/unix/mediactrl.cpp:966
+#, c-format
+msgid "Media playback error: %s"
+msgstr ""
+
+#: ../src/unix/mediactrl.cpp:1228
+#, fuzzy, c-format
+msgid "Failed to prepare playing \"%s\"."
+msgstr "Nem tudtam megnyitni '%s'-t %s-ként."
+
+#: ../src/unix/snglinst.cpp:164
+#, c-format
+msgid "Failed to write to lock file '%s'"
+msgstr "Nem sikerült írni a(z) '%s' lakat fájlba."
+
+#: ../src/unix/snglinst.cpp:177
+#, c-format
+msgid "Failed to set permissions on lock file '%s'"
+msgstr "Nem lehet beállítani a(z)  '%s' lezáró fájl engedélyeit"
+
+#: ../src/unix/snglinst.cpp:194
+#, c-format
+msgid "Failed to lock the lock file '%s'"
+msgstr "Nem sikerült lelakatolni a(z) '%s' lakat fájlt."
+
+#: ../src/unix/snglinst.cpp:237
+#, c-format
+msgid "Failed to inspect the lock file '%s'"
+msgstr "Nem sikerült megvizsgálni a(z) '%s' lezáró fájlt."
+
+#: ../src/unix/snglinst.cpp:242
+#, c-format
+msgid "Lock file '%s' has incorrect owner."
+msgstr "A(z) '%s' lezáró fájl tulajdonosa hibás."
+
+#: ../src/unix/snglinst.cpp:247
+#, c-format
+msgid "Lock file '%s' has incorrect permissions."
+msgstr "A(z) '%s' lezáró file hozzáférése hibás."
+
+#: ../src/unix/snglinst.cpp:265
+msgid "Failed to access lock file."
+msgstr "Nem sikerült elérni a lakat fájlt."
+
+#: ../src/unix/snglinst.cpp:274
+msgid "Failed to read PID from lock file."
+msgstr "Nem sikerült elolvasni a PID-t a lakat fájlból."
+
+#: ../src/unix/snglinst.cpp:284
+#, c-format
+msgid "Failed to remove stale lock file '%s'."
+msgstr "Nem tudtam eltávolítani az elavult  '%s' lakat fájlt."
+
+#: ../src/unix/snglinst.cpp:297
+#, c-format
+msgid "Deleted stale lock file '%s'."
+msgstr "A régi '%s' lakat fájt töröltem."
+
+#: ../src/unix/snglinst.cpp:308
+#, c-format
+msgid "Invalid lock file '%s'."
+msgstr "Hibás a(z) '%s' lakat fájl."
+
+#: ../src/unix/snglinst.cpp:324
+#, c-format
+msgid "Failed to remove lock file '%s'"
+msgstr "Nem tudom eltávolítani a(z) '%s' lakat fájlt."
+
+#: ../src/unix/snglinst.cpp:330
+#, c-format
+msgid "Failed to unlock lock file '%s'"
+msgstr "Nem sikerült felnyitni a(z) '%s'  lakat fájlt."
+
+#: ../src/unix/snglinst.cpp:336
+#, c-format
+msgid "Failed to close lock file '%s'"
+msgstr "Nem sikerült lezárni a(z) '%s' lakat fájlt."
+
+#: ../src/unix/sound.cpp:77
+msgid "No sound"
+msgstr "Nincs hang"
+
+#: ../src/unix/sound.cpp:364
+msgid "Unable to play sound asynchronously."
+msgstr "Nem tudok aszinkron módon hangot játszani."
+
+#: ../src/unix/sound.cpp:458
+#, c-format
+msgid "Couldn't load sound data from '%s'."
+msgstr "Nem tudtam betölteni hangot '%s'-ből."
+
+#: ../src/unix/sound.cpp:465
+#, c-format
+msgid "Sound file '%s' is in unsupported format."
+msgstr "A(z) '%s' hang fájl ismeretlen formátumban van."
+
+#: ../src/unix/sound.cpp:480
+msgid "Sound data are in unsupported format."
+msgstr "A hang adat ismeretlen formátumban van."
+
+#: ../src/unix/sound_sdl.cpp:226
+#, c-format
+msgid "Couldn't open audio: %s"
+msgstr "Nem tudtam megnyitni a(z) '%s' audiot"
+
+#: ../src/unix/threadpsx.cpp:1033
+msgid "Cannot retrieve thread scheduling policy."
+msgstr "Nem találom a szál ütemezés előírásait."
+
+#: ../src/unix/threadpsx.cpp:1058
+#, c-format
+msgid "Cannot get priority range for scheduling policy %d."
+msgstr "Nincs prioritási tartomány a(z) %d ütemezési előíráshoz."
+
+#: ../src/unix/threadpsx.cpp:1066
+msgid "Thread priority setting is ignored."
+msgstr "A szál prioritás beállítását elhanyagoltam."
+
+#: ../src/unix/threadpsx.cpp:1221
+msgid ""
+"Failed to join a thread, potential memory leak detected - please restart the "
+"program"
+msgstr ""
+"Nem tudtam a szálhoz csatlakozni, valószínűleg memória lyukat találtam - "
+"kérem indítsa újra a programot"
+
+#: ../src/unix/threadpsx.cpp:1352
+#, fuzzy, c-format
+msgid "Failed to set thread concurrency level to %lu"
+msgstr "Nem tudtam a(z) %d szál prioritást beállítani."
+
+#: ../src/unix/threadpsx.cpp:1481
+#, c-format
+msgid "Failed to set thread priority %d."
+msgstr "Nem tudtam a(z) %d szál prioritást beállítani."
+
+#: ../src/unix/threadpsx.cpp:1666
+msgid "Failed to terminate a thread."
+msgstr "Nem tudtam befejezni a szálat."
+
+#: ../src/unix/threadpsx.cpp:1893
+msgid "Thread module initialization failed: failed to create thread key"
+msgstr ""
+"A szál modul inicializálása nem sikerült: nem sikerült a szálhoz kulcsot "
+"készíteni"
+
+#: ../src/unix/utilsunx.cpp:340
+msgid "Impossible to get child process input"
+msgstr "Nem kapom meg a gyermek processz bemenetét."
+
+#: ../src/unix/utilsunx.cpp:390
+#, fuzzy
+msgid "Can't write to child process's stdin"
+msgstr "Nem tudtam megölni a '%d' folyamatot."
+
+#: ../src/unix/utilsunx.cpp:644
+#, c-format
+msgid "Failed to execute '%s'\n"
+msgstr "Nem sikerült végrehajtani '%s'-t\n"
+
+#: ../src/unix/utilsunx.cpp:678
+msgid "Fork failed"
+msgstr "A folyamat elágaztatása nem sikerült"
+
+#: ../src/unix/utilsunx.cpp:701
+#, fuzzy
+msgid "Failed to set process priority"
+msgstr "Nem tudtam a(z) %d szál prioritást beállítani."
+
+#: ../src/unix/utilsunx.cpp:712
+msgid "Failed to redirect child process input/output"
+msgstr "Nem tudtam átirányítani a gyermek processz be/kimenetét."
+
+#: ../src/unix/utilsunx.cpp:816
+msgid "Failed to set up non-blocking pipe, the program might hang."
+msgstr ""
+
+#: ../src/unix/utilsunx.cpp:1023
+msgid "Cannot get the hostname"
+msgstr "Nem ismerem a gazdagép nevét"
+
+#: ../src/unix/utilsunx.cpp:1059
+msgid "Cannot get the official hostname"
+msgstr "Nem ismerem a gazdagép hivatalos nevét"
+
+#: ../src/unix/wakeuppipe.cpp:49
+#, fuzzy
+msgid "Failed to create wake up pipe used by event loop."
+msgstr "Nem sikerült lérehozni az állapotsort."
+
+#: ../src/unix/wakeuppipe.cpp:56
+msgid "Failed to switch wake up pipe to non-blocking mode"
+msgstr ""
+
+#: ../src/unix/wakeuppipe.cpp:117
+#, fuzzy
+msgid "Failed to read from wake-up pipe"
+msgstr "Nem sikerült elolvasni a PID-t a lakat fájlból."
+
+#: ../src/x11/app.cpp:124
+#, c-format
+msgid "Invalid geometry specification '%s'"
+msgstr "Hibás geometriai meghatározás: '%s'."
+
+#: ../src/x11/app.cpp:167
+msgid "wxWidgets could not open display. Exiting."
+msgstr "A wxWidgets nem tudott képernyőt nyitni. Kilépés."
+
+#: ../src/x11/utils.cpp:169
+#, fuzzy, c-format
+msgid "Failed to close the display \"%s\""
+msgstr "Nem sikerült lezárni a vágólapot."
+
+#: ../src/x11/utils.cpp:188
+#, fuzzy, c-format
+msgid "Failed to open display \"%s\"."
+msgstr "Nem tudtam megnyitni '%s'-t %s-ként."
+
+#: ../src/xml/xml.cpp:868
+#, c-format
+msgid "XML parsing error: '%s' at line %d"
+msgstr "XML értelmezési hiba: '%s' a(z) %d sorban"
+
+#: ../src/xrc/xh_propgrid.cpp:239
+#, fuzzy, c-format
+msgid "Page %i"
+msgstr "%d. oldal"
+
+#: ../src/xrc/xmlres.cpp:448
+#, fuzzy, c-format
+msgid "Cannot load resources from '%s'."
+msgstr "Nem tudom betölteni az erőforrást a(z) '%s' fájlból."
+
+#: ../src/xrc/xmlres.cpp:799
+#, fuzzy, c-format
+msgid "Cannot open resources file '%s'."
+msgstr "Nem tudom betölteni az erőforrást a(z) '%s' fájlból."
+
+#: ../src/xrc/xmlres.cpp:806
+#, c-format
+msgid "Cannot load resources from file '%s'."
+msgstr "Nem tudom betölteni az erőforrást a(z) '%s' fájlból."
+
+#: ../src/xrc/xmlres.cpp:2767
+#, fuzzy, c-format
+msgid "Creating %s \"%s\" failed."
+msgstr "Nem sikerült kifejteni  '%s'-t '%s'-be"
+
+#, fuzzy
+#~ msgctxt "keyboard key"
+#~ msgid "Ctrl+"
+#~ msgstr "ctrl"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Shift+"
+#~ msgstr "Shift+"
+
+#, fuzzy
+#~ msgctxt "keyboard key"
+#~ msgid "RawCtrl+"
+#~ msgstr "ctrl"
+
+#~ msgid "Unsupported clipboard format."
+#~ msgstr "Nem támogatott vágólap formátum."
+
+#, fuzzy
+#~ msgid "Font:"
+#~ msgstr "Jelkészlet mérete:"
+
+#, fuzzy
+#~ msgid "Size:"
+#~ msgstr "Méret"
+
+#, fuzzy
+#~ msgid "The font size in points."
+#~ msgstr "A jelkészlet mérete."
+
+#, fuzzy
+#~ msgid "Style:"
+#~ msgstr "&Stílus:"
+
+#, fuzzy
+#~ msgid "Check to make the font bold."
+#~ msgstr "Kattints ide a betűtípus választás törléséhez"
+
+#, fuzzy
+#~ msgid "Check to make the font italic."
+#~ msgstr "Kattints ide a betűtípus választás törléséhez"
+
+#, fuzzy
+#~ msgid "Check to make the font underlined."
+#~ msgstr "Hogy aláhúzza-e a betűket."
+
+#, fuzzy
+#~ msgid "Colour:"
+#~ msgstr "S&zín"
+
+#, fuzzy
+#~ msgid "Click to change the font colour."
+#~ msgstr "Kattints ide a betűtípus választás törléséhez"
+
+#, fuzzy
+#~ msgid "Click to cancel changes to the font."
+#~ msgstr "Kattints ide a betűtípus választás törléséhez"
+
+#, fuzzy
+#~ msgid "Click to confirm changes to the font."
+#~ msgstr "Kattints ide a betűtípus választás megerősítéséhez"
+
+#, fuzzy
+#~ msgid "<Any Roman>"
+#~ msgstr "Roman"
+
+#, fuzzy
+#~ msgid "<Any Decorative>"
+#~ msgstr "Dekoratív"
+
+#, fuzzy
+#~ msgid "<Any Modern>"
+#~ msgstr "Modern"
+
+#, fuzzy
+#~ msgid "<Any Script>"
+#~ msgstr "Script"
+
+#, fuzzy
+#~ msgid "<Any Swiss>"
+#~ msgstr "Svájci"
+
+#, fuzzy
+#~ msgid "<Any Teletype>"
+#~ msgstr "Teletype"
+
+#~ msgid "Printing "
+#~ msgstr "Nyomtatás"
+
+#, fuzzy
+#~ msgid "Failed to insert text in the control."
+#~ msgstr "Nem sikerült létrehozni a munkakönyvtárat."
+
+#~ msgid "Please choose a valid font."
+#~ msgstr "Kérem válasszon egy érvényes jelkészletet."
+
+#, c-format
+#~ msgid "Failed to display HTML document in %s encoding"
+#~ msgstr "Nem sikerült a HTML dokumentumot %s kódolással megjeleníteni"
+
+#, c-format
+#~ msgid "wxWidgets could not open display for '%s': exiting."
+#~ msgstr "a wxWidgets nem tudott képernyőt nyitni '%s' számára: kilépés."
+
+#~ msgid "Filter"
+#~ msgstr "Szűrő"
+
+#~ msgid "Directories"
+#~ msgstr "Könyvtárak"
+
+#~ msgid "Files"
+#~ msgstr "Fájlok"
+
+#~ msgid "Selection"
+#~ msgstr "Kiválasztott"
+
+#~ msgid "conversion to 8-bit encoding failed"
+#~ msgstr "nem sikerült 8 bites kódolásúvá alakítani"
+
+#, fuzzy
+#~ msgid "failed to retrieve execution result"
+#~ msgstr "Nem sikerült értelmezni a RAS hibaüzenet szövegét."
+
+#, fuzzy
+#~ msgid "&Save as"
+#~ msgstr "Mentés Másként"
+
+#, fuzzy
+#~ msgid "'%s' doesn't consist only of valid characters"
+#~ msgstr "'%s' csak betűket tartalmazhat."
+
+#~ msgid "'%s' should be numeric."
+#~ msgstr "'%s' csak számérték lehet."
+
+#~ msgid "'%s' should only contain ASCII characters."
+#~ msgstr "'%s' csak ASCII jeleket tartalmazhat."
+
+#~ msgid "'%s' should only contain alphabetic characters."
+#~ msgstr "'%s' csak betűket tartalmazhat."
+
+#~ msgid "'%s' should only contain alphabetic or numeric characters."
+#~ msgstr "'%s' csak betűket vagy számokat tartalmazhat."
+
+#, fuzzy
+#~ msgid "'%s' should only contain digits."
+#~ msgstr "'%s' csak ASCII jeleket tartalmazhat."
+
+#~ msgid "Can't create window of class %s"
+#~ msgstr "Nem tudom létrehozni a(z) %s osztályhoz tartozó fájlt"
+
+#, fuzzy
+#~ msgid "Couldn't create the overlay window"
+#~ msgstr "Nem tudtam időzítőt létrehozni"
+
+#, fuzzy
+#~ msgid "Couldn't init the context on the overlay window"
+#~ msgstr "Nem kaptam meg a mutatót a jelenlegi szálhoz"
+
+#, fuzzy
+#~ msgid "Failed to convert file \"%s\" to Unicode."
+#~ msgstr "Nem sikerült lezárni a file kezelőt."
+
+#, fuzzy
+#~ msgid "Failed to set text in the text control."
+#~ msgstr "Nem sikerült létrehozni a munkakönyvtárat."
+
+#~ msgid "No unused colour in image."
+#~ msgstr "A képben nincs nem használt szín."
+
+#, fuzzy
+#~ msgid "Not available"
+#~ msgstr "Nincs XBM lehetőség!"
+
+#, fuzzy
+#~ msgid "Replace selection"
+#~ msgstr "Helyettesítsem &mindet"
+
+#, fuzzy
+#~ msgid "Save as"
+#~ msgstr "Mentés Másként"
+
+#, fuzzy
+#~ msgid "You cannot Clear an overlay that is not inited"
+#~ msgstr "Nem tud könyvtárat hozzáadni ehhez a szakaszhoz."
+
+#~ msgid "locale '%s' cannot be set."
+#~ msgstr "A(z) '%s' helyi változó nem állítható be."
+
+#, fuzzy
+#~ msgid "Column index not found."
+#~ msgstr "a(z) '%s' domén konfigurációs fájlját nem találom."
+
+#~ msgid "Confirm registry update"
+#~ msgstr "Registry frissítés megerősítése"
+
+#, fuzzy
+#~ msgid "Could not determine column index."
+#~ msgstr "Nem tudom a dokument megtekintését kezdeményezni."
+
+#, fuzzy
+#~ msgid "Could not determine number of columns."
+#~ msgstr "Nem tudtam megtalálni a(z) '%s' erőforrás betét fájlt."
+
+#, fuzzy
+#~ msgid "Could not determine number of items"
+#~ msgstr "Nem tudtam megtalálni a(z) '%s' erőforrás betét fájlt."
+
+#, fuzzy
+#~ msgid "Could not get header description."
+#~ msgstr "Nem tudom elindítani a nyomtatást."
+
+#, fuzzy
+#~ msgid "Could not get items."
+#~ msgstr "Nem tudtam megtalálni a(z) '%s' fájlt."
+
+#, fuzzy
+#~ msgid "Could not get property flags."
+#~ msgstr "Nem tudom létrehozni a(z) '%s' átmeneti fájlt"
+
+#, fuzzy
+#~ msgid "Could not get selected items."
+#~ msgstr "Nem tudtam megtalálni a(z) '%s' fájlt."
+
+#, fuzzy
+#~ msgid "Could not remove column."
+#~ msgstr "Nem tudtam létrehozni a képernyő pozició mutatót."
+
+#, fuzzy
+#~ msgid "Could not retrieve number of items"
+#~ msgstr "Nem tudom létrehozni a(z) '%s' átmeneti fájlt"
+
+#, fuzzy
+#~ msgid "Could not set column width."
+#~ msgstr "Nem tudom a dokument megtekintését kezdeményezni."
+
+#, fuzzy
+#~ msgid "Could not set header description."
+#~ msgstr "Nem tudom elindítani a nyomtatást."
+
+#, fuzzy
+#~ msgid "Could not set icon."
+#~ msgstr "Nem tudom elindítani a nyomtatást."
+
+#, fuzzy
+#~ msgid "Could not set maximum width."
+#~ msgstr "Nem tudom elindítani a nyomtatást."
+
+#, fuzzy
+#~ msgid "Could not set minimum width."
+#~ msgstr "Nem tudom elindítani a nyomtatást."
+
+#, fuzzy
+#~ msgid "Could not set property flags."
+#~ msgstr "Nem tudom elindítani a nyomtatást."
+
+#~ msgid ""
+#~ "Do you want to overwrite the command used to %s files with extension "
+#~ "\"%s\" ?\n"
+#~ "Current value is \n"
+#~ "%s, \n"
+#~ "New value is \n"
+#~ "%s %1"
+#~ msgstr ""
+#~ "Akarja, hogy átírjam a fájloknál használt % parancsot (csak \"%s\" "
+#~ "kiterjesztés esetén)?\n"
+#~ "A jelenlegi érték \n"
+#~ "%s, \n"
+#~ "Az új érték \n"
+#~ "%s %1"
+
+#~ msgid "Failed to retrieve data from the clipboard."
+#~ msgstr "Nem tudtam adatot elővenni a vágólapról."
+
+#~ msgid "GIF: Invalid gif index."
+#~ msgstr "GIF: Hibás gif index."
+
+#~ msgid "GIF: unknown error!!!"
+#~ msgstr "GIF: ismeretlen hiba!!!"
+
+#~ msgid "New directory"
+#~ msgstr "Új könyvtár"
+
+#~ msgid "Next"
+#~ msgstr "Következő "
+
+#, fuzzy
+#~ msgid "Number of columns could not be determined."
+#~ msgstr "A fájlt nem tudtam betölteni."
+
+#~ msgid ""
+#~ "Please install a newer version of comctl32.dll\n"
+#~ "(at least version 4.70 is required but you have %d.%02d)\n"
+#~ "or this program won't operate correctly."
+#~ msgstr ""
+#~ "Kérem installálja a comctl32.dll újabb verzióját\n"
+#~ "(legalább a 4.70 kellene, de Önnek a %d.%02d van)\n"
+#~ "vagy ez a program nem működik megfelelően."
+
+#, fuzzy
+#~ msgid "Rendering failed."
+#~ msgstr "Az időzítés létrehozása nem sikerült"
+
+#~ msgid "Show hidden directories"
+#~ msgstr "Mutasd meg a rejtett könyvtárokat"
+
+#, fuzzy
+#~ msgid ""
+#~ "This system doesn't support date controls, please upgrade your version of "
+#~ "comctl32.dll"
+#~ msgstr ""
+#~ "Ez a rendszer nem támogatja a dátumkiolvasó egységet, kérem frissítse a "
+#~ "comctl32.dll-t."
+
+#~ msgid "Too many colours in PNG, the image may be slightly blurred."
+#~ msgstr "Túl sok szín a PNG-ben, a kép kicsit homályos lehet."
+
+#, fuzzy
+#~ msgid "Unable to initialize Hildon program"
+#~ msgstr "Nem tudom elindítani az OpenGLt."
+
+#, fuzzy
+#~ msgid "Unknown data format"
+#~ msgstr "adatformátum hiba"
+
+#~ msgid "Win32s on Windows 3.1"
+#~ msgstr "Win32s a  Windows 3.1-en"
+
+#, fuzzy
+#~ msgid "Windows 10"
+#~ msgstr "Windows 98"
+
+#, fuzzy
+#~ msgid "Windows 2000"
+#~ msgstr "Windows 95"
+
+#, fuzzy
+#~ msgid "Windows 7"
+#~ msgstr "Windows 95"
+
+#, fuzzy
+#~ msgid "Windows 8"
+#~ msgstr "Windows 98"
+
+#, fuzzy
+#~ msgid "Windows 8.1"
+#~ msgstr "Windows 98"
+
+#~ msgid "Windows 95"
+#~ msgstr "Windows 95"
+
+#~ msgid "Windows 95 OSR2"
+#~ msgstr "Windows 95 OSR2"
+
+#~ msgid "Windows 98"
+#~ msgstr "Windows 98"
+
+#~ msgid "Windows 98 SE"
+#~ msgstr "Windows 98 SE"
+
+#~ msgid "Windows 9x (%d.%d)"
+#~ msgstr "Windows 9x (%d.%d)"
+
+#, fuzzy
+#~ msgid "Windows CE (%d.%d)"
+#~ msgstr "Windows 9x (%d.%d)"
+
+#~ msgid "Windows ME"
+#~ msgstr "Windows ME"
+
+#, fuzzy
+#~ msgid "Windows NT %lu.%lu"
+#~ msgstr "Windows NT %lu.%lu (build %lu"
+
+#, fuzzy
+#~ msgid "Windows Server 10"
+#~ msgstr "Windows Server 2003 (build %lu"
+
+#, fuzzy
+#~ msgid "Windows Server 2003"
+#~ msgstr "Windows Server 2003 (build %lu"
+
+#, fuzzy
+#~ msgid "Windows Server 2008"
+#~ msgstr "Windows Server 2003 (build %lu"
+
+#, fuzzy
+#~ msgid "Windows Server 2008 R2"
+#~ msgstr "Windows Server 2003 (build %lu"
+
+#, fuzzy
+#~ msgid "Windows Server 2012"
+#~ msgstr "Windows Server 2003 (build %lu"
+
+#, fuzzy
+#~ msgid "Windows Server 2012 R2"
+#~ msgstr "Windows Server 2003 (build %lu"
+
+#, fuzzy
+#~ msgid "Windows Vista"
+#~ msgstr "Windows 95"
+
+#, fuzzy
+#~ msgid "Windows XP"
+#~ msgstr "Windows 95"
+
+#~ msgid "can't execute '%s'"
+#~ msgstr "Nem sikerült végrehajtani '%s'-t"
+
+#~ msgid "error opening '%s'"
+#~ msgstr "hiba '%s' megnyitásakor"
+
+#~ msgid "unknown seek origin"
+#~ msgstr "ismeretlen keresési kezdőpont"
+
+#~ msgid "Cannot create mutex."
+#~ msgstr "Nem tudom létrehozni a mutex-et"
+
+#~ msgid "Cannot resume thread %lu"
+#~ msgstr "Nem tudom folytatni a(z) %lu szálat"
+
+#~ msgid "Cannot suspend thread %lu"
+#~ msgstr "Nem tudom felfüggeszteni a(z) %lu szálat"
+
+#~ msgid "Couldn't acquire a mutex lock"
+#~ msgstr "Nem tudtam mutex zárat létrehozni"
+
+#~ msgid "Couldn't release a mutex"
+#~ msgstr "Nem tudtam elengedni a mutex-et"
+
+#, fuzzy
+#~ msgid "DIVIDE"
+#~ msgstr "<MEGHAJTÓ>"
+
+#~ msgid "Execution of command '%s' failed with error: %ul"
+#~ msgstr "Nem sikerült végrehajtani a(z) '%s' parancsot, hibakód: %ul"
+
+#~ msgid ""
+#~ "File '%s' already exists.\n"
+#~ "Do you want to replace it?"
+#~ msgstr "A(z) '%s file már létezik. Akarja felülírni?"
+
+#~ msgid "Timer creation failed."
+#~ msgstr "Az időzítés létrehozása nem sikerült"
+
+#~ msgid "buffer is too small for Windows directory."
+#~ msgstr "a puffer túl kicsi a Windows könyvtár számára."
+
+#~ msgid "Print preview"
+#~ msgstr "Nyomtatási elő&kép"
+
+#, fuzzy
+#~ msgid "&Preview..."
+#~ msgstr " Nyomtatási előkép"
+
+#, fuzzy
+#~ msgid "Preview..."
+#~ msgstr " Nyomtatási előkép"
+
+#~ msgid "&Save..."
+#~ msgstr "&Mentés..."
+
+#, fuzzy
+#~ msgid "About "
+#~ msgstr "&Névjegy..."
+
+#~ msgid "All files (*.*)|*"
+#~ msgstr "Minden fájlt (*.*)|*"
+
+#~ msgid "Cannot initialize SciTech MGL!"
+#~ msgstr "Nem tudom elindítani az SciTech MGLt!"
+
+#~ msgid "Cannot initialize display."
+#~ msgstr "Nem tudom elindítani a megjelenítést."
+
+#~ msgid "Cannot start thread: error writing TLS"
+#~ msgstr "Nem tudom elindítani a szálat: hiba a TLS írásakor"
+
+#~ msgid "Close\tAlt-F4"
+#~ msgstr "Bezárás\tAlt-F4"
+
+#~ msgid "Couldn't create cursor."
+#~ msgstr "Nem tudtam létrehozni a képernyő pozició mutatót."
+
+#~ msgid "Directory '%s' doesn't exist!"
+#~ msgstr "A(z) '%s' könyvtár nem létezik!"
+
+#~ msgid "Mode %ix%i-%i not available."
+#~ msgstr "A %ix%i-%i mód nem létezik."
+
+#~ msgid "Paper Size"
+#~ msgstr "Papír méret"
+
+#~ msgid "&Goto..."
+#~ msgstr "&Válasszon oldalszámot... "
+
+#~ msgid "<<"
+#~ msgstr "<<"
+
+#~ msgid ">>"
+#~ msgstr ">>"
+
+#~ msgid ">>|"
+#~ msgstr ">>|"
+
+#~ msgid "Archive doesnt contain #SYSTEM file"
+#~ msgstr "Az archívum nem tartalmaz #SYSTEM fájlt"
+
+#~ msgid "Can't check image format of file '%s': file does not exist."
+#~ msgstr ""
+#~ "Nem tudom megvizsgálni a(z) '%s' kép fájl formátumát: nincs ilyen fájl."
+
+#~ msgid "Can't load image from file '%s': file does not exist."
+#~ msgstr "Nem tudom betölteni a képet a(z) '%s' fájlból: nincs ilyen fájl."
+
+#~ msgid "Cannot convert dialog units: dialog unknown."
+#~ msgstr "Nem tudom átalakítani a dialógus egységeit; ismeretlen dialógus."
+
+#~ msgid "Cannot convert from the charset '%s'!"
+#~ msgstr "Nem tudok átalakítani '%s' kódolásról!"
+
+#~ msgid "Cannot find container for unknown control '%s'."
+#~ msgstr "Nem találok tároló elemet a(z) '%s' ismeretlen irányitóelemhez."
+
+#~ msgid "Cannot find font node '%s'."
+#~ msgstr "Nem találom a(z) '%s' betűkészlet csomópontot"
+
+#~ msgid "Cannot open file '%s'."
+#~ msgstr "Nem tudom megnyitni a(z) '%s' fájlt."
+
+#~ msgid "Cannot parse coordinates from '%s'."
+#~ msgstr "Nem tudom értelmezni a koordinátákat '%s'-ből."
+
+#~ msgid "Cannot parse dimension from '%s'."
+#~ msgstr "Nem tudom értelmezni a dimenziót '%s'-ből."
+
+#~ msgid "Cant create the thread event queue"
+#~ msgstr "Nem tudom létrehozni a szál esemény sorát"
+
+#, fuzzy
+#~ msgid "Click to cancel this window."
+#~ msgstr "Zárja be ezt az ablakot"
+
+#, fuzzy
+#~ msgid "Click to confirm your selection."
+#~ msgstr "Kattints ide a betűtípus választás megerősítéséhez"
+
+#~ msgid "Could not unlock mutex"
+#~ msgstr "Nem tudtam kinyitni a mutex-et"
+
+#~ msgid "Error while waiting on semaphore"
+#~ msgstr "Hiba történt a semaforra várakozás során"
+
+#~ msgid "Failed to create a status bar."
+#~ msgstr "Nem sikerült lérehozni az állapotsort."
+
+#~ msgid "Failed to register OpenGL window class."
+#~ msgstr "Nem tudom regisztrálani az OpenGL ablak osztályt."
+
+#~ msgid "Fatal error: "
+#~ msgstr "Végzetes hiba:"
+
+#~ msgid "Goto Page"
+#~ msgstr "Meghatározott oldalra"
+
+#, fuzzy
+#~ msgid "Help : %s"
+#~ msgstr "Súgó: %s"
+
+#~ msgid "I64"
+#~ msgstr "I64"
+
+#~ msgid "Internal error, illegal wxCustomTypeInfo"
+#~ msgstr "Belső hiba, hibás wxCustomTypeInfo"
+
+#~ msgid "Invalid XRC resource '%s': doesn't have root node 'resource'."
+#~ msgstr "Érvénytelen '%s' erőforrás: nincs 'resource' csomópont."
+
+#~ msgid "No handler found for XML node '%s', class '%s'!"
+#~ msgstr "A '%s', class '%s' XML csomóponthoz nem találtam meghajtót!"
+
+#, fuzzy
+#~ msgid "No image handler for type %ld defined."
+#~ msgstr "%d  típusú képhez nincs kezelő meghatározva."
+
+#, fuzzy
+#~ msgid "Owner not initialized."
+#~ msgstr "Nem tudom elindítani a megjelenítést."
+
+#, fuzzy
+#~ msgid "Passed item is invalid."
+#~ msgstr "'%s' érvénytelen"
+
+#~ msgid "Passing a already registered object to SetObjectName"
+#~ msgstr "SetObjectName már regisztrált objektumot kapott"
+
+#~ msgid "Program aborted."
+#~ msgstr "A program rendellenesen fejeződött be."
+
+#~ msgid "Referenced object node with ref=\"%s\" not found!"
+#~ msgstr "A ref=\"%s\" számmal hivatkozott objektum csomópontot nem találom!"
+
+#~ msgid "Resource files must have same version number!"
+#~ msgstr "Az erőforrás fájloknak azonos verziószámúaknak kell lenniük!"
+
+#, fuzzy
+#~ msgid "Search!"
+#~ msgstr "Keresés"
+
+#~ msgid "Sorry, could not open this file for saving."
+#~ msgstr "Sajnálom, nem tudtam megnyitni a fájlt mentésre."
+
+#~ msgid "Sorry, could not save this file."
+#~ msgstr "Sajnálom, nem tudtam elmenteni ezt a fájlt."
+
+#~ msgid "Sorry, print preview needs a printer to be installed."
+#~ msgstr "Sajnálom, a nyomtatási előképhez állítson be egy nyomtatót."
+
+#~ msgid "Status: "
+#~ msgstr "Állapot: "
+
+#~ msgid ""
+#~ "Streaming delegates for not already streamed objects not yet supported"
+#~ msgstr ""
+#~ "Küldemények soros tárolása még nem sorosított objektumok számára még nem "
+#~ "támogatott"
+
+#~ msgid "Subclass '%s' not found for resource '%s', not subclassing!"
+#~ msgstr ""
+#~ "A(z) '%s' alosztályt nem találtama(z) '%s' erőforráshoz, nem tudom "
+#~ "használni!"
+
+#~ msgid "TIFF library error."
+#~ msgstr "TIFF könyvtár hiba."
+
+#~ msgid "TIFF library warning."
+#~ msgstr "TIFF könyvtár figyelmeztetés."
+
+#~ msgid ""
+#~ "The file '%s' couldn't be opened.\n"
+#~ "It has been removed from the most recently used files list."
+#~ msgstr ""
+#~ "A(z) '%s' fájlt nem sikerült megyitni.\n"
+#~ "A legutóbb használt fájlok listájáról is el van távolítva."
+
+#~ msgid "The path '%s' contains too many \"..\"!"
+#~ msgstr "A(z) '%s' útvonal túl sok \"..\"-t tartalmaz!"
+
+#~ msgid "Trying to solve a NULL hostname: giving up"
+#~ msgstr "Megpróbáltam feloldani a NULL gazdagép nevet: feladom"
+
+#~ msgid "Unknown style flag "
+#~ msgstr "Ismererlen stílus jel"
+
+#~ msgid "Warning"
+#~ msgstr "Figyelmeztetés"
+
+#~ msgid "Windows 2000 (build %lu"
+#~ msgstr "Windows 2000 (build %lu"
+
+#~ msgid "XRC resource '%s' (class '%s') not found!"
+#~ msgstr "Nem találom a(z) '%s'  XRC erőforrást ('%s' osztály)."
+
+#, fuzzy
+#~ msgid "XRC resource: Cannot create animation from '%s'."
+#~ msgstr "XRC erőforrás: Nem tudom létrehozni a(z) '%s'-ből a bittérképet."
+
+#~ msgid "XRC resource: Cannot create bitmap from '%s'."
+#~ msgstr "XRC erőforrás: Nem tudom létrehozni a(z) '%s'-ből a bittérképet."
+
+#, fuzzy
+#~ msgid ""
+#~ "XRC resource: Incorrect colour specification '%s' for attribute '%s'."
+#~ msgstr ""
+#~ "XRC erőforrás: Helytelen szín meghatározás '%s' a '%s' tulajdonságnál."
+
+#~ msgid "[EMPTY]"
+#~ msgstr "[ÜRES]"
+
+#~ msgid "catalog file for domain '%s' not found."
+#~ msgstr "a(z) '%s' domén konfigurációs fájlját nem találom."
+
+#~ msgid "delegate has no type info"
+#~ msgstr "a delegáltnak nincs típus jelzése"
+
+#, fuzzy
+#~ msgid "encoding %i"
+#~ msgstr "%s kódolás"
+
+#~ msgid "looking for catalog '%s' in path '%s'."
+#~ msgstr "keresem a(z) '%s' katalógust a(z) '%s' elérési úton."
+
+#~ msgid "wxSocket: invalid signature in ReadMsg."
+#~ msgstr "wxSocket: érvénytelen aláírás  ReadMsg-ben."
+
+#~ msgid "wxSocket: unknown event!."
+#~ msgstr "wxSocket: ismeretlen esemény."
+
+#~ msgid "|<<"
+#~ msgstr "|<<"
+
+#, fuzzy
+#~ msgid " Couldn't create the UnicodeConverter"
+#~ msgstr "Nem tudtam időzítőt létrehozni"
+
+#~ msgid "#define %s must be an integer."
+#~ msgstr "#define %s-nek egész típusúnak kell lennie."
+
+#~ msgid "%s not a bitmap resource specification."
+#~ msgstr "%s nem bittérkép erőforrás meghatározás."
+
+#~ msgid "%s not an icon resource specification."
+#~ msgstr "%s nem ikon erőforrás meghatározás."
+
+#~ msgid "%s: ill-formed resource file syntax."
+#~ msgstr "%s: nyelvtani hibás erőforrás file."
+
+#~ msgid "&Open"
+#~ msgstr "&Megnyitás"
+
+#~ msgid "&Print"
+#~ msgstr "&Nyomtatás"
+
+#~ msgid "*** It can be found in \"%s\"\n"
+#~ msgstr "*** Ez a \"%s\"-ben található\n"
+
+#~ msgid ""
+#~ ", expected static, #include or #define\n"
+#~ "while parsing resource."
+#~ msgstr ""
+#~ ",  static, #include or #define kulcsszót vártam\n"
+#~ "az erőforrás értelmezésekor."
+
+#~ msgid "Bitmap resource specification %s not found."
+#~ msgstr "Nem találom a(z) '%s'  bitmap erőforrást leírást."
+
+#~ msgid ""
+#~ "Could not resolve control class or id '%s'. Use (non-zero) integer "
+#~ "instead\n"
+#~ " or provide #define (see manual for caveats)"
+#~ msgstr ""
+#~ "Nem találtam a kontroll osztályt vagy a '%s' azonosítót. Használjon (nem-"
+#~ "nulla) egészt helyette\n"
+#~ " vagy adja meg #define használatával (lásd a kézikönyvet)"
+
+#~ msgid ""
+#~ "Could not resolve menu id '%s'. Use (non-zero) integer instead\n"
+#~ "or provide #define (see manual for caveats)"
+#~ msgstr ""
+#~ "Nem találtam meg a(z) '%s' menü azonosítót. Használjon (nem-nulla) "
+#~ "egészet helyette\n"
+#~ "vagy adja meg #define használatával (lásd a kézikönyvet a részletekért)"
+
+#, fuzzy
+#~ msgid "Couldn't end the context on the overlay window"
+#~ msgstr "Nem kaptam meg a mutatót a jelenlegi szálhoz"
+
+#~ msgid "Expected '*' while parsing resource."
+#~ msgstr "'*'-ot vártam az erőforrás értelmezése során. "
+
+#~ msgid "Expected '=' while parsing resource."
+#~ msgstr "'='-et vártam az erőforrás értelmezése során."
+
+#~ msgid "Expected 'char' while parsing resource."
+#~ msgstr "'char'-t vártam az erőforrás értelmezése során. "
+
+#~ msgid ""
+#~ "Failed to find XBM resource %s.\n"
+#~ "Forgot to use wxResourceLoadBitmapData?"
+#~ msgstr ""
+#~ "Nem találom a(z) %s XBM erőforrást.\n"
+#~ "Elfelejtette használni wxResourceLoadBitmapData-t?"
+
+#~ msgid ""
+#~ "Failed to find XBM resource %s.\n"
+#~ "Forgot to use wxResourceLoadIconData?"
+#~ msgstr ""
+#~ "Nem találom a(z) %s XBM erőforrást.\n"
+#~ "Elfelejtette használni wxResourceLoadIconData-t?"
+
+#~ msgid ""
+#~ "Failed to find XPM resource %s.\n"
+#~ "Forgot to use wxResourceLoadBitmapData?"
+#~ msgstr ""
+#~ "Nem találom a(z) %s erőforrást.\n"
+#~ "Elfelejtette használni wxResourceLoadBitmapData-t?"
+
+#~ msgid "Failed to get clipboard data."
+#~ msgstr "Nem tudtam a vágólap adatot elővenni."
+
+#~ msgid "Failed to load shared library '%s' Error '%s'"
+#~ msgstr "Nem tudtam betölteni a(z) '%s' osztott könyvtárat, '%s' hiba miatt."
+
+#~ msgid "Found "
+#~ msgstr "Megtaláltam"
+
+#~ msgid "Icon resource specification %s not found."
+#~ msgstr "Nem találom a(z) '%s'  ikon erőforrás leírást."
+
+#~ msgid "Ill-formed resource file syntax."
+#~ msgstr "Nyelvtani hibás erőforrás fájl"
+
+#~ msgid "Long Conversions not supported"
+#~ msgstr "A hosszú átalakításokat nem támogatom"
+
+#~ msgid "No XPM icon facility available!"
+#~ msgstr "Nincs XPM ikon lehetőség!"
+
+#~ msgid "Option '%s' requires a value, '=' expected."
+#~ msgstr "A(z) '%s' beállítás egy értéket kér, '='-et vártam."
+
+#, fuzzy
+#~ msgid "Select all"
+#~ msgstr "Válassz ki &minden fájlt"
+
+#~ msgid "Unexpected end of file while parsing resource."
+#~ msgstr "Váratlanul véget ért a fájl az erőforrás értelmezése során. "
+
+#~ msgid "Unrecognized style %s while parsing resource."
+#~ msgstr "%s: Ismeretlen stílus az erőforrás értelmezése során."
+
+#~ msgid "Video Output"
+#~ msgstr "Video kimenet"
+
+#~ msgid "Warning: attempt to remove HTML tag handler from empty stack."
+#~ msgstr ""
+#~ "Figyeleztetés: üres veremtárolóból próbál eltávolítani HTML kifejezés "
+#~ "kezelőt."
+
+#~ msgid "establish"
+#~ msgstr "megalapoz"
+
+#~ msgid "initiate"
+#~ msgstr "kezdeményez"
+
+#~ msgid "invalid eof() return value."
+#~ msgstr "érvénytelen eof() visszatérési érték."
+
+#~ msgid "unknown line terminator"
+#~ msgstr "ismeretlen sorhatároló"
+
+#~ msgid "writing"
+#~ msgstr "kiírás"
+
+#~ msgid "."
+#~ msgstr "."
+
+#~ msgid "Cannot open URL '%s'"
+#~ msgstr "Nem tudom megnyitni a(z) '%s' URL-t"
+
+#~ msgid "Error "
+#~ msgstr "Hiba"
+
+#~ msgid "Failed to create directory %s/.gnome."
+#~ msgstr "Nem sikerült létrehozni a(z) %s/.gnome."
+
+#~ msgid "Failed to create directory %s/mime-info."
+#~ msgstr "Nem tudtam létrehozni a(z) %s/mime-info könyvtárat."
+
+#~ msgid "MP Thread Support is not available on this System"
+#~ msgstr "Nincs MP szál támogatás ezen a rendszeren"
+
+#~ msgid "Mailcap file %s, line %d: incomplete entry ignored."
+#~ msgstr "Mailcap fájl %s, %d. sor: elhanyagoltam a hiányos bejegyzést."
+
+#~ msgid "Mime.types file %s, line %d: unterminated quoted string."
+#~ msgstr "%s mime-típusú fájl, %d. sor: befejezetlen idézőjeles szöveg."
+
+#~ msgid "Unknown field in file %s, line %d: '%s'."
+#~ msgstr "A(z) %s fájl %d-edik sorában: '%s' ismeretlen mező."
+
+#~ msgid "bold "
+#~ msgstr "félkövér"
+
+#~ msgid "can't query for GUI plugins name in console applications"
+#~ msgstr "konzol alkalmazásban nem informálúdhatok GUI betétról"
+
+#~ msgid "light "
+#~ msgstr "vékony"
+
+#~ msgid "underlined "
+#~ msgstr "aláhúzott"
+
+#~ msgid "unsupported zip archive"
+#~ msgstr "nem támogatott zip archívum"
+
+#~ msgid ""
+#~ "Failed to get stack backtrace:\n"
+#~ "%s"
+#~ msgstr ""
+#~ "Nem kaptam meg a veremtár nyomkövetést:\n"
+#~ "%s"
+
+#~ msgid "Loading Grey Ascii PNM image is not yet implemented."
+#~ msgstr "A szürke  Ascii PNM kép betöltése még nincs implementálva."
+
+#~ msgid "Loading Grey Raw PNM image is not yet implemented."
+#~ msgstr "A szürke nyers PNM kép betöltése még nincs implementálva."
+
+#~ msgid "Cannot wait on thread to exit."
+#~ msgstr "Nem tudom megvárni a szál befejeződését."
+
+#~ msgid "Could not load Rich Edit DLL '%s'"
+#~ msgstr "Nem tudom betölteni a(z) '%s' Rich Edit DLL-t"
+
+#~ msgid "ZIP handler currently supports only local files!"
+#~ msgstr "A ZIP kezelő jelenleg csak helyi fájlokat támogat!"
+
+#~ msgid ""
+#~ "can't seek on file descriptor %d, large files support is not enabled."
+#~ msgstr ""
+#~ "nem tudok keresni a(z) %d leíróval megadott fájlban, nagy fájlok "
+#~ "támogatása nem engedélyezett."
+
+#~ msgid "More..."
+#~ msgstr "Még..."
+
+#~ msgid "Setup"
+#~ msgstr "Beállítás"

--- a/po_wxstd/id.po
+++ b/po_wxstd/id.po
@@ -1,0 +1,10079 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: wxWidgets 3.3\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-05-14 20:23+0200\n"
+"PO-Revision-Date: 2020-06-26 21:31+0700\n"
+"Last-Translator: Hertatijanto Hartono <dvertx@gmail.com>\n"
+"Language-Team: ID <doplank@gmx.com>\n"
+"Language: id_ID\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"plural-forms: nplurals=1; plural=0\n"
+"X-Generator: Poedit 2.3.1\n"
+"X-Poedit-SourceCharset: UTF-8\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"X-Poedit-Bookmarks: 912,-1,-1,-1,-1,-1,-1,-1,-1,1004\n"
+
+#: ../include/wx/defs.h:2582
+msgid "All files (*.*)|*.*"
+msgstr "Semua berkas (*.*)|*.*"
+
+#: ../include/wx/defs.h:2585
+msgid "All files (*)|*"
+msgstr "Semua berkas (*)|*"
+
+#: ../include/wx/generic/progdlgg.h:85
+msgid "Elapsed time:"
+msgstr "Waktu terpakai:"
+
+#: ../include/wx/generic/progdlgg.h:86
+msgid "Estimated time:"
+msgstr "Waktu perkiraan:"
+
+#: ../include/wx/generic/progdlgg.h:87
+msgid "Remaining time:"
+msgstr "Waktu tersisa:"
+
+#. TRANSLATORS: HTML printout default title.
+#: ../include/wx/html/htmprint.h:121 ../include/wx/prntbase.h:273
+#: ../include/wx/richtext/richtextprint.h:109 ../src/common/docview.cpp:2161
+msgid "Printout"
+msgstr "Hasil cetakan"
+
+#. TRANSLATORS: HTML easy print default title.
+#: ../include/wx/html/htmprint.h:234 ../include/wx/richtext/richtextprint.h:163
+#: ../src/common/prntbase.cpp:522 ../src/html/htmprint.cpp:291
+msgid "Printing"
+msgstr "Mencetak"
+
+#: ../include/wx/msgdlg.h:277 ../src/common/stockitem.cpp:211
+msgid "Yes"
+msgstr "Ya"
+
+#: ../include/wx/msgdlg.h:278 ../src/common/stockitem.cpp:182
+msgid "No"
+msgstr "Tidak"
+
+#: ../include/wx/msgdlg.h:279 ../src/common/stockitem.cpp:183
+#: ../src/msw/msgdlg.cpp:430 ../src/msw/msgdlg.cpp:734
+#: ../src/richtext/richtextstyledlg.cpp:292
+msgid "OK"
+msgstr "OK"
+
+#: ../include/wx/msgdlg.h:280 ../src/common/stockitem.cpp:150
+#: ../src/msw/msgdlg.cpp:430 ../src/msw/progdlg.cpp:884
+#: ../src/richtext/richtextstyledlg.cpp:295
+msgid "Cancel"
+msgstr "Cancel"
+
+#: ../include/wx/msgdlg.h:281 ../src/common/stockitem.cpp:168
+#: ../src/html/helpdlg.cpp:63 ../src/html/helpfrm.cpp:108
+#: ../src/osx/button_osx.cpp:38
+msgid "Help"
+msgstr "Help"
+
+#: ../include/wx/msw/ole/oleutils.h:52
+msgid "Cannot initialize OLE"
+msgstr "Gagal menginisialisasi OLE"
+
+#: ../include/wx/msw/private/fswatcher.h:48
+#, c-format
+msgid "Unable to close the handle for '%s'"
+msgstr "Gagal menutup handle untuk '%s'"
+
+#: ../include/wx/msw/private/fswatcher.h:92
+#, c-format
+msgid "Failed to open directory \"%s\" for monitoring."
+msgstr "Gagal membuka direktori \"%s\" untuk dipantau."
+
+#: ../include/wx/msw/private/fswatcher.h:125
+msgid "Unable to close I/O completion port handle"
+msgstr "Gagal menutup handle penyelesaian port I/O"
+
+#: ../include/wx/msw/private/fswatcher.h:142
+msgid "Unable to associate handle with I/O completion port"
+msgstr "Gagal mengasosiasikan handle dengan port I/O"
+
+#: ../include/wx/msw/private/fswatcher.h:148
+msgid "Unexpectedly new I/O completion port was created"
+msgstr "Port penyeesaian I/O baru dibuat tanpa diharapkan"
+
+#: ../include/wx/msw/private/fswatcher.h:213
+msgid "Unable to post completion status"
+msgstr "Gagal memasang status penyelesaian"
+
+#: ../include/wx/msw/private/fswatcher.h:262
+msgid "Unable to dequeue completion packet"
+msgstr "Gagal men-dequeue paket penyelesaian"
+
+#: ../include/wx/msw/private/fswatcher.h:273
+msgid "Unable to create I/O completion port"
+msgstr "Gagal membuat penyelesaian port I/O"
+
+#: ../include/wx/richmsgdlg.h:29
+msgid "&See details"
+msgstr "&Lihat detail"
+
+#: ../include/wx/richmsgdlg.h:30
+msgid "&Hide details"
+msgstr "&Sembunyikan detail"
+
+#: ../include/wx/richtext/richtextbuffer.h:3864
+msgid "&Box"
+msgstr "&Kotak"
+
+#: ../include/wx/richtext/richtextbuffer.h:5008
+msgid "&Picture"
+msgstr "&Citra"
+
+#: ../include/wx/richtext/richtextbuffer.h:5958
+msgid "&Cell"
+msgstr "&Sel"
+
+#: ../include/wx/richtext/richtextbuffer.h:6067
+msgid "&Table"
+msgstr "&Tabel"
+
+#: ../include/wx/richtext/richtextimagedlg.h:37
+msgid "Object Properties"
+msgstr "Properti Obyek"
+
+#: ../include/wx/richtext/richtextsymboldlg.h:39
+msgid "Symbols"
+msgstr "Simbol"
+
+#: ../include/wx/unix/pipe.h:46
+msgid "Pipe creation failed"
+msgstr "Pembuatan pipa gagal"
+
+#: ../include/wx/unix/private/displayx11.h:65
+msgid "Failed to enumerate video modes"
+msgstr "Gagal menghitung jumlah mode video"
+
+#: ../include/wx/unix/private/displayx11.h:89
+msgid "Failed to change video mode"
+msgstr "Gagal merubah mode video"
+
+#: ../include/wx/unix/private/fswatcher_kqueue.h:57
+#, c-format
+msgid "Unable to open path '%s'"
+msgstr "Gagal membuka jalur '%s'"
+
+#: ../include/wx/unix/private/fswatcher_kqueue.h:74
+#, c-format
+msgid "Unable to close path '%s'"
+msgstr "Gagal menutup jalur '%s'"
+
+#: ../include/wx/xtiprop.h:175
+msgid "SetProperty called w/o valid setter"
+msgstr "SetProperty dipanggil tanpa pengatur yang valid"
+
+#: ../include/wx/xtiprop.h:184
+msgid "GetProperty called w/o valid getter"
+msgstr "GetProperty dipanggil tanpda pengambil valid getter"
+
+#: ../include/wx/xtiprop.h:193
+msgid "AddToPropertyCollection called w/o valid adder"
+msgstr "AddToPropertyCollection dipanggil tanpa penambah yang sah"
+
+#: ../include/wx/xtiprop.h:202
+msgid "GetPropertyCollection called w/o valid collection getter"
+msgstr "GetPropertyCollection dipanggil tanda valid collection getter"
+
+#: ../include/wx/xtiprop.h:255
+msgid "AddToPropertyCollection called on a generic accessor"
+msgstr "AddToPropertyCollection dipanggil pada suatu pengakses generik"
+
+#: ../include/wx/xtiprop.h:262
+msgid "GetPropertyCollection called on a generic accessor"
+msgstr "GetPropertyCollection disebut dengan generic accessor"
+
+#: ../src/aui/tabmdi.cpp:106 ../src/generic/mdig.cpp:94
+msgid "Cl&ose"
+msgstr "Tutu&p"
+
+#: ../src/aui/tabmdi.cpp:107 ../src/generic/mdig.cpp:95
+msgid "Close All"
+msgstr "Tutup Semua"
+
+#: ../src/aui/tabmdi.cpp:109 ../src/generic/mdig.cpp:97 ../src/msw/mdi.cpp:175
+#: ../src/qt/mdi.cpp:258
+msgid "&Next"
+msgstr "&Berikut"
+
+#: ../src/aui/tabmdi.cpp:110 ../src/generic/mdig.cpp:98 ../src/msw/mdi.cpp:176
+#: ../src/qt/mdi.cpp:259
+msgid "&Previous"
+msgstr "&Sebelumnya"
+
+#: ../src/aui/tabmdi.cpp:332 ../src/aui/tabmdi.cpp:348
+#: ../src/aui/tabmdi.cpp:350 ../src/generic/mdig.cpp:291
+#: ../src/generic/mdig.cpp:307 ../src/generic/mdig.cpp:311
+#: ../src/msw/mdi.cpp:337 ../src/qt/mdi.cpp:462
+msgid "&Window"
+msgstr "&Jendela"
+
+#: ../src/common/accelcmn.cpp:47
+msgctxt "keyboard key"
+msgid "Delete"
+msgstr "Delete"
+
+#: ../src/common/accelcmn.cpp:48
+msgctxt "keyboard key"
+msgid "Del"
+msgstr "Del"
+
+#: ../src/common/accelcmn.cpp:49
+msgctxt "keyboard key"
+msgid "Back"
+msgstr "Back"
+
+#: ../src/common/accelcmn.cpp:49
+msgctxt "keyboard key"
+msgid "Backspace"
+msgstr "Backspace"
+
+#: ../src/common/accelcmn.cpp:50
+msgctxt "keyboard key"
+msgid "Insert"
+msgstr "Insert"
+
+#: ../src/common/accelcmn.cpp:51
+msgctxt "keyboard key"
+msgid "Ins"
+msgstr "Ins"
+
+#: ../src/common/accelcmn.cpp:52
+msgctxt "keyboard key"
+msgid "Enter"
+msgstr "Enter"
+
+#: ../src/common/accelcmn.cpp:53
+msgctxt "keyboard key"
+msgid "Return"
+msgstr "Return"
+
+#: ../src/common/accelcmn.cpp:54
+msgctxt "keyboard key"
+msgid "PageUp"
+msgstr "PageUp"
+
+#: ../src/common/accelcmn.cpp:54
+msgctxt "keyboard key"
+msgid "Page Up"
+msgstr "Page Up"
+
+#: ../src/common/accelcmn.cpp:55
+msgctxt "keyboard key"
+msgid "PageDown"
+msgstr "PageDown"
+
+#: ../src/common/accelcmn.cpp:55
+msgctxt "keyboard key"
+msgid "Page Down"
+msgstr "Page Down"
+
+#: ../src/common/accelcmn.cpp:56
+msgctxt "keyboard key"
+msgid "PgUp"
+msgstr "PgUp"
+
+#: ../src/common/accelcmn.cpp:57
+msgctxt "keyboard key"
+msgid "PgDn"
+msgstr "PgDn"
+
+#: ../src/common/accelcmn.cpp:58
+msgctxt "keyboard key"
+msgid "Left"
+msgstr "Kiri"
+
+#: ../src/common/accelcmn.cpp:59
+msgctxt "keyboard key"
+msgid "Right"
+msgstr "Kanan"
+
+#: ../src/common/accelcmn.cpp:60
+msgctxt "keyboard key"
+msgid "Up"
+msgstr "Up"
+
+#: ../src/common/accelcmn.cpp:61
+msgctxt "keyboard key"
+msgid "Down"
+msgstr "Down"
+
+#: ../src/common/accelcmn.cpp:62
+msgctxt "keyboard key"
+msgid "Home"
+msgstr "Home"
+
+#: ../src/common/accelcmn.cpp:63
+msgctxt "keyboard key"
+msgid "End"
+msgstr "End"
+
+#: ../src/common/accelcmn.cpp:64
+msgctxt "keyboard key"
+msgid "Space"
+msgstr "Spacebar"
+
+#: ../src/common/accelcmn.cpp:65
+msgctxt "keyboard key"
+msgid "Tab"
+msgstr "Tab"
+
+#: ../src/common/accelcmn.cpp:66
+msgctxt "keyboard key"
+msgid "Esc"
+msgstr "Esc"
+
+#: ../src/common/accelcmn.cpp:67
+msgctxt "keyboard key"
+msgid "Escape"
+msgstr "Escape"
+
+#: ../src/common/accelcmn.cpp:68
+msgctxt "keyboard key"
+msgid "Cancel"
+msgstr "Cancel"
+
+#: ../src/common/accelcmn.cpp:69
+msgctxt "keyboard key"
+msgid "Clear"
+msgstr "Clear"
+
+#: ../src/common/accelcmn.cpp:70
+msgctxt "keyboard key"
+msgid "Menu"
+msgstr "Menu"
+
+#: ../src/common/accelcmn.cpp:71
+msgctxt "keyboard key"
+msgid "Pause"
+msgstr "Pause"
+
+#: ../src/common/accelcmn.cpp:72
+msgctxt "keyboard key"
+msgid "Capital"
+msgstr "Capital"
+
+#: ../src/common/accelcmn.cpp:73
+msgctxt "keyboard key"
+msgid "Select"
+msgstr "Select"
+
+#: ../src/common/accelcmn.cpp:74
+msgctxt "keyboard key"
+msgid "Print"
+msgstr "Print"
+
+#: ../src/common/accelcmn.cpp:75
+msgctxt "keyboard key"
+msgid "Execute"
+msgstr "Execute"
+
+#: ../src/common/accelcmn.cpp:76
+msgctxt "keyboard key"
+msgid "Snapshot"
+msgstr "Snapshot"
+
+#: ../src/common/accelcmn.cpp:77
+msgctxt "keyboard key"
+msgid "Help"
+msgstr "Help"
+
+#: ../src/common/accelcmn.cpp:78
+msgctxt "keyboard key"
+msgid "Add"
+msgstr "Add"
+
+#: ../src/common/accelcmn.cpp:79
+msgctxt "keyboard key"
+msgid "Separator"
+msgstr "Separator"
+
+#: ../src/common/accelcmn.cpp:80
+msgctxt "keyboard key"
+msgid "Subtract"
+msgstr "Subtract"
+
+#: ../src/common/accelcmn.cpp:81
+msgctxt "keyboard key"
+msgid "Decimal"
+msgstr "Decimal"
+
+#: ../src/common/accelcmn.cpp:82
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Multiply"
+msgstr "KP_Multiply"
+
+#: ../src/common/accelcmn.cpp:83
+msgctxt "keyboard key"
+msgid "Divide"
+msgstr "Divide"
+
+#: ../src/common/accelcmn.cpp:84
+msgctxt "keyboard key"
+msgid "Num_lock"
+msgstr "Num_lock"
+
+#: ../src/common/accelcmn.cpp:84
+msgctxt "keyboard key"
+msgid "Num Lock"
+msgstr "Num Lock"
+
+#: ../src/common/accelcmn.cpp:85
+msgctxt "keyboard key"
+msgid "Scroll_lock"
+msgstr "Scroll_lock"
+
+#: ../src/common/accelcmn.cpp:85
+msgctxt "keyboard key"
+msgid "Scroll Lock"
+msgstr "Scroll Lock"
+
+#: ../src/common/accelcmn.cpp:86
+msgctxt "keyboard key"
+msgid "KP_Space"
+msgstr "KP_Space"
+
+#: ../src/common/accelcmn.cpp:86
+msgctxt "keyboard key"
+msgid "Num Space"
+msgstr "Num Space"
+
+#: ../src/common/accelcmn.cpp:87
+msgctxt "keyboard key"
+msgid "KP_Tab"
+msgstr "KP_Tab"
+
+#: ../src/common/accelcmn.cpp:87
+msgctxt "keyboard key"
+msgid "Num Tab"
+msgstr "Num Tab"
+
+#: ../src/common/accelcmn.cpp:88
+msgctxt "keyboard key"
+msgid "KP_Enter"
+msgstr "KP_Enter"
+
+#: ../src/common/accelcmn.cpp:88
+msgctxt "keyboard key"
+msgid "Num Enter"
+msgstr "Num Enter"
+
+#: ../src/common/accelcmn.cpp:89
+msgctxt "keyboard key"
+msgid "KP_Home"
+msgstr "KP_Home"
+
+#: ../src/common/accelcmn.cpp:89
+msgctxt "keyboard key"
+msgid "Num Home"
+msgstr "Num Home"
+
+#: ../src/common/accelcmn.cpp:90
+msgctxt "keyboard key"
+msgid "KP_Left"
+msgstr "KP_Left"
+
+#: ../src/common/accelcmn.cpp:90
+msgctxt "keyboard key"
+msgid "Num left"
+msgstr "Num left"
+
+#: ../src/common/accelcmn.cpp:91
+msgctxt "keyboard key"
+msgid "KP_Up"
+msgstr "KP_Up"
+
+#: ../src/common/accelcmn.cpp:91
+msgctxt "keyboard key"
+msgid "Num Up"
+msgstr "Num Up"
+
+#: ../src/common/accelcmn.cpp:92
+msgctxt "keyboard key"
+msgid "KP_Right"
+msgstr "KP_Right"
+
+#: ../src/common/accelcmn.cpp:92
+msgctxt "keyboard key"
+msgid "Num Right"
+msgstr "Num Right"
+
+#: ../src/common/accelcmn.cpp:93
+msgctxt "keyboard key"
+msgid "KP_Down"
+msgstr "KP_Down"
+
+#: ../src/common/accelcmn.cpp:93
+msgctxt "keyboard key"
+msgid "Num Down"
+msgstr "Num Down"
+
+#: ../src/common/accelcmn.cpp:94
+msgctxt "keyboard key"
+msgid "KP_PageUp"
+msgstr "KP_PageUp"
+
+#: ../src/common/accelcmn.cpp:94
+msgctxt "keyboard key"
+msgid "Num Page Up"
+msgstr "Num Page Up"
+
+#: ../src/common/accelcmn.cpp:95
+msgctxt "keyboard key"
+msgid "KP_PageDown"
+msgstr "KP_PageDown"
+
+#: ../src/common/accelcmn.cpp:95
+msgctxt "keyboard key"
+msgid "Num Page Down"
+msgstr "Num Page Down"
+
+#: ../src/common/accelcmn.cpp:96
+msgctxt "keyboard key"
+msgid "KP_Prior"
+msgstr "KP_Prior"
+
+#: ../src/common/accelcmn.cpp:97
+msgctxt "keyboard key"
+msgid "KP_Next"
+msgstr "KP_Next"
+
+#: ../src/common/accelcmn.cpp:98
+msgctxt "keyboard key"
+msgid "KP_End"
+msgstr "KP_End"
+
+#: ../src/common/accelcmn.cpp:98
+msgctxt "keyboard key"
+msgid "Num End"
+msgstr "Num End"
+
+#: ../src/common/accelcmn.cpp:99
+msgctxt "keyboard key"
+msgid "KP_Begin"
+msgstr "KP_Begin"
+
+#: ../src/common/accelcmn.cpp:99
+msgctxt "keyboard key"
+msgid "Num Begin"
+msgstr "Num Begin"
+
+#: ../src/common/accelcmn.cpp:100
+msgctxt "keyboard key"
+msgid "KP_Insert"
+msgstr "KP_Insert"
+
+#: ../src/common/accelcmn.cpp:100
+msgctxt "keyboard key"
+msgid "Num Insert"
+msgstr "Num Insert"
+
+#: ../src/common/accelcmn.cpp:101
+msgctxt "keyboard key"
+msgid "KP_Delete"
+msgstr "KP_Delete"
+
+#: ../src/common/accelcmn.cpp:101
+msgctxt "keyboard key"
+msgid "Num Delete"
+msgstr "Num Delete"
+
+#: ../src/common/accelcmn.cpp:102
+msgctxt "keyboard key"
+msgid "KP_Equal"
+msgstr "KP_Equal"
+
+#: ../src/common/accelcmn.cpp:102
+msgctxt "keyboard key"
+msgid "Num ="
+msgstr "Num ="
+
+#: ../src/common/accelcmn.cpp:103
+msgctxt "keyboard key"
+msgid "KP_Multiply"
+msgstr "KP_Multiply"
+
+#: ../src/common/accelcmn.cpp:103
+msgctxt "keyboard key"
+msgid "Num *"
+msgstr "Num *"
+
+#: ../src/common/accelcmn.cpp:104
+msgctxt "keyboard key"
+msgid "KP_Add"
+msgstr "KP_Add"
+
+#: ../src/common/accelcmn.cpp:104
+msgctxt "keyboard key"
+msgid "Num +"
+msgstr "Num +"
+
+#: ../src/common/accelcmn.cpp:105
+msgctxt "keyboard key"
+msgid "KP_Separator"
+msgstr "KP_Separator"
+
+#: ../src/common/accelcmn.cpp:105
+msgctxt "keyboard key"
+msgid "Num ,"
+msgstr "Num ,"
+
+#: ../src/common/accelcmn.cpp:106
+msgctxt "keyboard key"
+msgid "KP_Subtract"
+msgstr "KP_Subtract"
+
+#: ../src/common/accelcmn.cpp:106
+msgctxt "keyboard key"
+msgid "Num -"
+msgstr "Num -"
+
+#: ../src/common/accelcmn.cpp:107
+msgctxt "keyboard key"
+msgid "KP_Decimal"
+msgstr "KP_Decimal"
+
+#: ../src/common/accelcmn.cpp:107
+msgctxt "keyboard key"
+msgid "Num ."
+msgstr "Num ."
+
+#: ../src/common/accelcmn.cpp:108
+msgctxt "keyboard key"
+msgid "KP_Divide"
+msgstr "KP_Divide"
+
+#: ../src/common/accelcmn.cpp:108
+msgctxt "keyboard key"
+msgid "Num /"
+msgstr "Num /"
+
+#: ../src/common/accelcmn.cpp:109
+msgctxt "keyboard key"
+msgid "Windows_Left"
+msgstr "Windows_Left"
+
+#: ../src/common/accelcmn.cpp:110
+msgctxt "keyboard key"
+msgid "Windows_Right"
+msgstr "Windows_Right"
+
+#: ../src/common/accelcmn.cpp:111
+msgctxt "keyboard key"
+msgid "Windows_Menu"
+msgstr "Windows_Menu"
+
+#: ../src/common/accelcmn.cpp:112
+msgctxt "keyboard key"
+msgid "Command"
+msgstr "Command"
+
+#: ../src/common/accelcmn.cpp:186 ../src/common/accelcmn.cpp:359
+msgctxt "keyboard key"
+msgid "Ctrl"
+msgstr "Ctrl"
+
+#: ../src/common/accelcmn.cpp:188 ../src/common/accelcmn.cpp:363
+msgctxt "keyboard key"
+msgid "Alt"
+msgstr "Alt"
+
+#: ../src/common/accelcmn.cpp:190 ../src/common/accelcmn.cpp:361
+msgctxt "keyboard key"
+msgid "Shift"
+msgstr "Geser"
+
+#: ../src/common/accelcmn.cpp:196
+msgctxt "keyboard key"
+msgid "num "
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:260 ../src/common/accelcmn.cpp:382
+msgctxt "keyboard key"
+msgid "F"
+msgstr "F"
+
+#: ../src/common/accelcmn.cpp:277 ../src/common/accelcmn.cpp:385
+msgctxt "keyboard key"
+msgid "KP_F"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:280 ../src/common/accelcmn.cpp:388
+msgctxt "keyboard key"
+msgid "KP_"
+msgstr "KP_"
+
+#: ../src/common/accelcmn.cpp:283 ../src/common/accelcmn.cpp:391
+msgctxt "keyboard key"
+msgid "SPECIAL"
+msgstr "SPESIAL"
+
+#: ../src/common/accelcmn.cpp:373
+#, fuzzy
+msgid "Ctrl"
+msgstr "Ctrl"
+
+#: ../src/common/appbase.cpp:786
+msgid "show this help message"
+msgstr "tampilkan pesan bantuan ini"
+
+#: ../src/common/appbase.cpp:796
+msgid "generate verbose log messages"
+msgstr "hasilkan pesan log lengkap"
+
+#: ../src/common/appcmn.cpp:256
+msgid "specify the theme to use"
+msgstr "spesifikasikan tema yang digunakan"
+
+#: ../src/common/appcmn.cpp:270
+msgid "specify display mode to use (e.g. 640x480-16)"
+msgstr "spesifikasikan mode tampilan yang digunakan (misalnya 640x480- 16)"
+
+#: ../src/common/appcmn.cpp:292
+#, c-format
+msgid "Unsupported theme '%s'."
+msgstr "Tema '%s' tidak didukung."
+
+#: ../src/common/appcmn.cpp:309
+#, c-format
+msgid "Invalid display mode specification '%s'."
+msgstr "Spesifikasi mode tampilan %s tidak sah."
+
+#: ../src/common/cmdline.cpp:875
+#, c-format
+msgid "Option '%s' can't be negated"
+msgstr "Opsi '%s' tidak boleh negatif"
+
+#: ../src/common/cmdline.cpp:889
+#, c-format
+msgid "Unknown long option '%s'"
+msgstr "Pilihan panjang '%s' tidak dikenal"
+
+#: ../src/common/cmdline.cpp:904 ../src/common/cmdline.cpp:926
+#, c-format
+msgid "Unknown option '%s'"
+msgstr "Pilihan '%s' tidak diketahui"
+
+#: ../src/common/cmdline.cpp:1004
+#, c-format
+msgid "Unexpected characters following option '%s'."
+msgstr "Karakter tidak diharapkan setelah opsi '%s'."
+
+#: ../src/common/cmdline.cpp:1039
+#, c-format
+msgid "Option '%s' requires a value."
+msgstr "Pilihan '%s' memerlukan suatu nilai."
+
+#: ../src/common/cmdline.cpp:1058
+#, c-format
+msgid "Separator expected after the option '%s'."
+msgstr "Pemisah diharapkan setelah pilihan '%s'."
+
+#: ../src/common/cmdline.cpp:1088 ../src/common/cmdline.cpp:1106
+#, c-format
+msgid "'%s' is not a correct numeric value for option '%s'."
+msgstr "'%s' bukan suatu nilai numerik yang benar untuk pilihan '%s'."
+
+#: ../src/common/cmdline.cpp:1122
+#, c-format
+msgid "Option '%s': '%s' cannot be converted to a date."
+msgstr "Pilihan '%s': '%s' tidak bisa dikonversi ke suatu tanggal."
+
+#: ../src/common/cmdline.cpp:1170
+#, c-format
+msgid "Unexpected parameter '%s'"
+msgstr "Parameter ‘%s’ tidak diharapkan"
+
+#. TRANSLATORS: Short name and long name for a command line option
+#: ../src/common/cmdline.cpp:1197
+#, c-format
+msgid "%s (or %s)"
+msgstr "%s (atau %s)"
+
+#: ../src/common/cmdline.cpp:1208
+#, c-format
+msgid "The value for the option '%s' must be specified."
+msgstr "Nilai untuk pilihan '%s' harus dispesifikasikan."
+
+#: ../src/common/cmdline.cpp:1230
+#, c-format
+msgid "The required parameter '%s' was not specified."
+msgstr "Parameter '%s' yang dibutuhkan tidak dispesifikasikan."
+
+#: ../src/common/cmdline.cpp:1289
+#, c-format
+msgid "Usage: %s"
+msgstr "Penggunaan: %s"
+
+#: ../src/common/cmdline.cpp:1498
+msgid "str"
+msgstr "str"
+
+#: ../src/common/cmdline.cpp:1502
+msgid "num"
+msgstr "angka"
+
+#: ../src/common/cmdline.cpp:1506
+msgid "double"
+msgstr "ganda"
+
+#: ../src/common/cmdline.cpp:1510
+msgid "date"
+msgstr "tanggal"
+
+#: ../src/common/cmdproc.cpp:250 ../src/common/cmdproc.cpp:276
+#: ../src/common/cmdproc.cpp:296
+msgid "Unnamed command"
+msgstr "Perintah tak bernama"
+
+#: ../src/common/cmdproc.cpp:253
+msgid "&Undo "
+msgstr "&Urungkan "
+
+#: ../src/common/cmdproc.cpp:255
+msgid "Can't &Undo "
+msgstr "Tidak Bisa &Urungkan "
+
+#: ../src/common/cmdproc.cpp:259 ../src/common/stockitem.cpp:208
+#: ../src/msw/textctrl.cpp:2880 ../src/osx/textctrl_osx.cpp:649
+#: ../src/richtext/richtextctrl.cpp:327
+msgid "&Undo"
+msgstr "&Urungkan"
+
+#: ../src/common/cmdproc.cpp:277 ../src/common/cmdproc.cpp:297
+msgid "&Redo "
+msgstr "&Kerjakan Lagi "
+
+#: ../src/common/cmdproc.cpp:281 ../src/common/cmdproc.cpp:288
+#: ../src/common/stockitem.cpp:190 ../src/msw/textctrl.cpp:2881
+#: ../src/osx/textctrl_osx.cpp:650 ../src/richtext/richtextctrl.cpp:328
+msgid "&Redo"
+msgstr "&Kerjakan Lagi"
+
+#: ../src/common/colourcmn.cpp:41
+#, c-format
+msgid "String To Colour : Incorrect colour specification : %s"
+msgstr "Warna String : Spesifikasi warna salah : %s"
+
+#: ../src/common/config.cpp:259
+#, c-format
+msgid "Invalid value %ld for a boolean key \"%s\" in config file."
+msgstr "Kesalahan nilai %ld untuk kunci boolean \"%s\" di berkas config."
+
+#: ../src/common/config.cpp:526
+#, c-format
+msgid ""
+"Environment variables expansion failed: missing '%c' at position %u in '%s'."
+msgstr ""
+"Pengembangan variabel lingkungan gagal: tidak ditemukan '%c' pada posisi %u "
+"di '%s'."
+
+#: ../src/common/config.cpp:576 ../src/msw/regconf.cpp:272
+#, c-format
+msgid "'%s' has extra '..', ignored."
+msgstr "'%s' mempunyai '..' ekstra, diabaikan."
+
+#. TRANSLATORS: Checkbox state name
+#: ../src/common/datavcmn.cpp:2166 ../src/generic/datavgen.cpp:1430
+msgid "checked"
+msgstr "tercentang"
+
+#. TRANSLATORS: Checkbox state name
+#: ../src/common/datavcmn.cpp:2170 ../src/generic/datavgen.cpp:1432
+msgid "unchecked"
+msgstr "tidak dicentang"
+
+#. TRANSLATORS: Checkbox state name
+#: ../src/common/datavcmn.cpp:2174
+msgid "undetermined"
+msgstr "tidak diketahui"
+
+#: ../src/common/datetimefmt.cpp:1875
+msgid "today"
+msgstr "hari ini"
+
+#: ../src/common/datetimefmt.cpp:1876
+msgid "yesterday"
+msgstr "kemarin"
+
+#: ../src/common/datetimefmt.cpp:1877
+msgid "tomorrow"
+msgstr "esok"
+
+#: ../src/common/datetimefmt.cpp:2071
+msgid "first"
+msgstr "pertama"
+
+#: ../src/common/datetimefmt.cpp:2072
+msgid "second"
+msgstr "kedua"
+
+#: ../src/common/datetimefmt.cpp:2073
+msgid "third"
+msgstr "ketiga"
+
+#: ../src/common/datetimefmt.cpp:2074
+msgid "fourth"
+msgstr "keempat"
+
+#: ../src/common/datetimefmt.cpp:2075
+msgid "fifth"
+msgstr "kelima"
+
+#: ../src/common/datetimefmt.cpp:2076
+msgid "sixth"
+msgstr "keenam"
+
+#: ../src/common/datetimefmt.cpp:2077
+msgid "seventh"
+msgstr "ketujuh"
+
+#: ../src/common/datetimefmt.cpp:2078
+msgid "eighth"
+msgstr "kedelapan"
+
+#: ../src/common/datetimefmt.cpp:2079
+msgid "ninth"
+msgstr "kesembilan"
+
+#: ../src/common/datetimefmt.cpp:2080
+msgid "tenth"
+msgstr "kesepuluh"
+
+#: ../src/common/datetimefmt.cpp:2081
+msgid "eleventh"
+msgstr "kesebelas"
+
+#: ../src/common/datetimefmt.cpp:2082
+msgid "twelfth"
+msgstr "keduabelas"
+
+#: ../src/common/datetimefmt.cpp:2083
+msgid "thirteenth"
+msgstr "ketigabelas"
+
+#: ../src/common/datetimefmt.cpp:2084
+msgid "fourteenth"
+msgstr "keempatbelas"
+
+#: ../src/common/datetimefmt.cpp:2085
+msgid "fifteenth"
+msgstr "kelimabelas"
+
+#: ../src/common/datetimefmt.cpp:2086
+msgid "sixteenth"
+msgstr "keenambelas"
+
+#: ../src/common/datetimefmt.cpp:2087
+msgid "seventeenth"
+msgstr "ketujuhbelas"
+
+#: ../src/common/datetimefmt.cpp:2088
+msgid "eighteenth"
+msgstr "kedelapanbelas"
+
+#: ../src/common/datetimefmt.cpp:2089
+msgid "nineteenth"
+msgstr "kesembilanbelas"
+
+#: ../src/common/datetimefmt.cpp:2090
+msgid "twentieth"
+msgstr "keduapuluh"
+
+#: ../src/common/datetimefmt.cpp:2248
+msgid "noon"
+msgstr "siang"
+
+#: ../src/common/datetimefmt.cpp:2249
+msgid "midnight"
+msgstr "tengah malam"
+
+#: ../src/common/debugrpt.cpp:209
+#, c-format
+msgid "Failed to create directory \"%s\""
+msgstr "Gagal membuat direktori \"%s\""
+
+#: ../src/common/debugrpt.cpp:210
+msgid "Debug report couldn't be created."
+msgstr "Laporan debut tidak dapat dibuat."
+
+#: ../src/common/debugrpt.cpp:227
+#, c-format
+msgid "Failed to remove debug report file \"%s\""
+msgstr "Gagal mengapus berkas laporan debug \"%s\""
+
+#: ../src/common/debugrpt.cpp:239
+#, c-format
+msgid "Failed to clean up debug report directory \"%s\""
+msgstr "Gagal membersihkan direktori laporan debug \"%s\""
+
+#: ../src/common/debugrpt.cpp:514
+msgid "process context description"
+msgstr "deskripsi konteks proses"
+
+#: ../src/common/debugrpt.cpp:538
+msgid "dump of the process state (binary)"
+msgstr "dump dari keadaan proses (biner)"
+
+#: ../src/common/debugrpt.cpp:553
+msgid "Debug report generation has failed."
+msgstr "Pembuatan laporan debut gagal."
+
+#: ../src/common/debugrpt.cpp:560
+#, c-format
+msgid ""
+"Processing debug report has failed, leaving the files in \"%s\" directory."
+msgstr "Gagal memproses laporan debug, membiarkan berkas di direktori \"%s\"."
+
+#: ../src/common/debugrpt.cpp:573
+msgid "A debug report has been generated. It can be found in"
+msgstr "Laporan debug berhasil dibuat. Laporan dapat ditemukan di"
+
+#: ../src/common/debugrpt.cpp:576
+msgid "And includes the following files:\n"
+msgstr "Dan sertakan berkas berikut:\n"
+
+#: ../src/common/debugrpt.cpp:586
+msgid ""
+"\n"
+"Please send this report to the program maintainer, thank you!\n"
+msgstr ""
+"\n"
+"Tolong kirimkan laporan ini kepada pemelihara program, terima kasih!\n"
+
+#: ../src/common/debugrpt.cpp:729
+msgid "Failed to execute curl, please install it in PATH."
+msgstr "Gagal mengeksekusi curl, tolong install di PATH."
+
+#: ../src/common/debugrpt.cpp:742
+#, c-format
+msgid "Failed to upload the debug report (error code %d)."
+msgstr "Gagal mengupload laporan debut (kode error %d)."
+
+#: ../src/common/docview.cpp:366
+msgid "Save As"
+msgstr "Simpan Sebagai"
+
+#: ../src/common/docview.cpp:457
+msgid "Discard changes and reload the last saved version?"
+msgstr "Batalkan semua perubahan dan buka ulang simpanan versi terakhir?"
+
+#: ../src/common/docview.cpp:488
+msgid "unnamed"
+msgstr "tanpa nama"
+
+#: ../src/common/docview.cpp:513
+#, c-format
+msgid "Do you want to save changes to %s?"
+msgstr "Apakah anda ingin menyimpan perubahan ke %s?"
+
+#: ../src/common/docview.cpp:521 ../src/common/docview.cpp:560
+#: ../src/common/stockitem.cpp:195
+msgid "&Save"
+msgstr "&Simpan"
+
+#: ../src/common/docview.cpp:522 ../src/common/docview.cpp:560
+msgid "&Discard changes"
+msgstr ""
+
+#: ../src/common/docview.cpp:523
+#, fuzzy
+msgid "Do&n't close"
+msgstr "Jangan Save"
+
+#: ../src/common/docview.cpp:553
+#, fuzzy, c-format
+msgid "Do you want to save changes to %s before closing it?"
+msgstr "Apakah anda ingin menyimpan perubahan ke %s?"
+
+#: ../src/common/docview.cpp:559
+#, fuzzy
+msgid "The document must be closed."
+msgstr "Teks tidak bisa disimpan."
+
+#: ../src/common/docview.cpp:571
+#, c-format
+msgid "Saving %s failed, would you like to retry?"
+msgstr ""
+
+#: ../src/common/docview.cpp:577
+msgid "Retry"
+msgstr ""
+
+#: ../src/common/docview.cpp:577
+msgid "Discard changes"
+msgstr ""
+
+#: ../src/common/docview.cpp:679
+#, c-format
+msgid "File \"%s\" could not be opened for writing."
+msgstr "Berkas \"%s\" tidak dapat dibuka untuk ditulisi."
+
+#: ../src/common/docview.cpp:685
+#, c-format
+msgid "Failed to save document to the file \"%s\"."
+msgstr "Gagal menyimpan dokumen ke berkas \"%s\"."
+
+#: ../src/common/docview.cpp:702
+#, c-format
+msgid "File \"%s\" could not be opened for reading."
+msgstr "Berkas \"%s\" tidak dapat dibuka untuk dibaca."
+
+#: ../src/common/docview.cpp:714
+#, c-format
+msgid "Failed to read document from the file \"%s\"."
+msgstr "Gagal untuk membaca dokumen dari berkas \"%s\"."
+
+#: ../src/common/docview.cpp:1236
+#, c-format
+msgid ""
+"The file '%s' doesn't exist and couldn't be opened.\n"
+"It has been removed from the most recently used files list."
+msgstr ""
+"Berkas '%s' tidak ada dan tidak bisa dibuka.\n"
+"Itu telah dihapus dari daftar berkas yang baru terpakai."
+
+#: ../src/common/docview.cpp:1296
+msgid "Print preview creation failed."
+msgstr "Membuat pratinjau cetakan gagal."
+
+#: ../src/common/docview.cpp:1302
+msgid "Print Preview"
+msgstr "Pratinjau Pencetakan"
+
+#: ../src/common/docview.cpp:1517
+#, c-format
+msgid "The format of file '%s' couldn't be determined."
+msgstr "Format berkas '%s' tidak dapat ditentukan."
+
+#: ../src/common/docview.cpp:1643
+#, c-format
+msgid "unnamed%d"
+msgstr "tanpa nama%d"
+
+#: ../src/common/docview.cpp:1660
+msgid " - "
+msgstr " - "
+
+#: ../src/common/docview.cpp:1791 ../src/common/docview.cpp:1844
+msgid "Open File"
+msgstr "Buka Berkas"
+
+#: ../src/common/docview.cpp:1807
+msgid "File error"
+msgstr "Galat berkas"
+
+#: ../src/common/docview.cpp:1809
+msgid "Sorry, could not open this file."
+msgstr "Maaf, gagal membuka file ini."
+
+#: ../src/common/docview.cpp:1843
+msgid "Sorry, the format for this file is unknown."
+msgstr "Maaf, format dari berkas ini tidak diketahui."
+
+#: ../src/common/docview.cpp:1924
+msgid "Select a document template"
+msgstr "Pilih template dokumen"
+
+#: ../src/common/docview.cpp:1925
+msgid "Templates"
+msgstr "Template"
+
+#: ../src/common/docview.cpp:1998
+msgid "Select a document view"
+msgstr "Pilih tampilan dokumen"
+
+#: ../src/common/docview.cpp:1999
+msgid "Views"
+msgstr "Tampilan"
+
+#: ../src/common/dynlib.cpp:81
+#, c-format
+msgid "Failed to load shared library '%s'"
+msgstr "Gagal memuat shared library '%s'"
+
+#: ../src/common/dynlib.cpp:105
+#, c-format
+msgid "Couldn't find symbol '%s' in a dynamic library"
+msgstr "Gagal menemukan simbol '%s' dalam pustaka dinamis"
+
+#: ../src/common/ffile.cpp:56 ../src/common/file.cpp:215
+#, c-format
+msgid "can't open file '%s'"
+msgstr "gagal membuka berkas '%s'"
+
+#: ../src/common/ffile.cpp:72
+#, c-format
+msgid "can't close file '%s'"
+msgstr "gagal menutup berkas '%s'"
+
+#: ../src/common/ffile.cpp:106 ../src/common/ffile.cpp:131
+#, c-format
+msgid "Read error on file '%s'"
+msgstr "Kesalahan membaca pada file '%s'"
+
+#: ../src/common/ffile.cpp:148
+#, c-format
+msgid "Write error on file '%s'"
+msgstr "Kesalahan menulis pada file '%s'"
+
+#: ../src/common/ffile.cpp:182
+#, c-format
+msgid "failed to flush the file '%s'"
+msgstr "gagal mem-flush berkas '%s'"
+
+#: ../src/common/ffile.cpp:222
+#, c-format
+msgid "Seek error on file '%s' (large files not supported by stdio)"
+msgstr ""
+"Galat pencarian pada berkas '%s' (berkas besar tidak didukung oleh stdio)"
+
+#: ../src/common/ffile.cpp:232
+#, c-format
+msgid "Seek error on file '%s'"
+msgstr "Galat pencarian pada file '%s'"
+
+#: ../src/common/ffile.cpp:248
+#, c-format
+msgid "Can't find current position in file '%s'"
+msgstr "Gagal menemukan posisi saat ini dalam berkas '%s'"
+
+#: ../src/common/ffile.cpp:349 ../src/common/file.cpp:569
+msgid "Failed to set temporary file permissions"
+msgstr "Gagal menetapkan permisi file sementara"
+
+#: ../src/common/ffile.cpp:371
+#, c-format
+msgid "can't remove file '%s'"
+msgstr "gagal menghapus file '%s'"
+
+#: ../src/common/ffile.cpp:376 ../src/common/file.cpp:591
+#, c-format
+msgid "can't commit changes to file '%s'"
+msgstr "gagal menerapkan perubahan ke berkas '%s'"
+
+#: ../src/common/ffile.cpp:388 ../src/common/file.cpp:603
+#, c-format
+msgid "can't remove temporary file '%s'"
+msgstr "gagal menghapus berkas sementara '%s'"
+
+#: ../src/common/file.cpp:162
+#, c-format
+msgid "can't create file '%s'"
+msgstr "gagal menciptakan berkas '%s'"
+
+#: ../src/common/file.cpp:229
+#, c-format
+msgid "can't close file descriptor %d"
+msgstr "gagal menutup file descriptor %d"
+
+#: ../src/common/file.cpp:332
+#, c-format
+msgid "can't read from file descriptor %d"
+msgstr "gagal membaca dari file descriptor %d"
+
+#: ../src/common/file.cpp:351
+#, c-format
+msgid "can't write to file descriptor %d"
+msgstr "gagal menulis ke file descriptor %d"
+
+#: ../src/common/file.cpp:390
+#, c-format
+msgid "can't flush file descriptor %d"
+msgstr "gagal mem-flush file descriptor %d"
+
+#: ../src/common/file.cpp:432
+#, c-format
+msgid "can't seek on file descriptor %d"
+msgstr "gagal melakukan seek pada file descriptor %d"
+
+#: ../src/common/file.cpp:446
+#, c-format
+msgid "can't get seek position on file descriptor %d"
+msgstr "gagal memperoleh posisi seek pada file descriptor %d"
+
+#: ../src/common/file.cpp:475
+#, c-format
+msgid "can't find length of file on file descriptor %d"
+msgstr "gagal menentukan panjang berkas pada file descriptor %d"
+
+#: ../src/common/file.cpp:505
+#, c-format
+msgid "can't determine if the end of file is reached on descriptor %d"
+msgstr "gagal menentukan apakah akhir berkas telah dicapai pada descriptor %d"
+
+#: ../src/common/fileconf.cpp:352
+#, c-format
+msgid ""
+" and additionally, the existing configuration file was renamed to \"%s\" and "
+"couldn't be renamed back, please rename it to its original path \"%s\""
+msgstr ""
+
+#: ../src/common/fileconf.cpp:389
+#, fuzzy
+msgid " due to the following error:\n"
+msgstr "Dan sertakan berkas berikut:\n"
+
+#: ../src/common/fileconf.cpp:412
+#, fuzzy
+msgid "failed to rename the existing file"
+msgstr "Gagal untuk membaca dokumen dari berkas \"%s\"."
+
+#: ../src/common/fileconf.cpp:421
+#, fuzzy
+msgid "failed to create the new file directory"
+msgstr "Gagal memperoleh direktori kerja"
+
+#: ../src/common/fileconf.cpp:428
+#, fuzzy
+msgid "failed to move the file to the new location"
+msgstr "Gagal menghentikan koneksi dialup: %s"
+
+#: ../src/common/fileconf.cpp:462
+#, c-format
+msgid "can't open global configuration file '%s'."
+msgstr "gagal membuka berkas konfigurasi global '%s'."
+
+#: ../src/common/fileconf.cpp:478
+#, c-format
+msgid "can't open user configuration file '%s'."
+msgstr "gagal membuka berkas konfigurasi pemakai '%s'."
+
+#: ../src/common/fileconf.cpp:483
+#, c-format
+msgid "Changes won't be saved to avoid overwriting the existing file \"%s\""
+msgstr ""
+"Perubahan tidak dapat disimpan untuk menghindari penimpaan berkas yang sudah "
+"ada \"%s\""
+
+#: ../src/common/fileconf.cpp:583
+msgid "Error reading config options."
+msgstr "Galat saat membaca opsi config."
+
+#: ../src/common/fileconf.cpp:593
+msgid "Failed to read config options."
+msgstr "Gagal membaca opsi konfigurasi."
+
+#: ../src/common/fileconf.cpp:700
+#, c-format
+msgid "file '%s': unexpected character %c at line %zu."
+msgstr "berkas '%s': karakter %c tidak diharapkan pada baris %zu."
+
+#: ../src/common/fileconf.cpp:736
+#, c-format
+msgid "file '%s', line %zu: '%s' ignored after group header."
+msgstr "berkas '%s', baris %zu: '%s' diabaikan setelah header grup."
+
+#: ../src/common/fileconf.cpp:765
+#, c-format
+msgid "file '%s', line %zu: '=' expected."
+msgstr "berkas '%s', baris %zu: '=' diharapkan."
+
+#: ../src/common/fileconf.cpp:778
+#, c-format
+msgid "file '%s', line %zu: value for immutable key '%s' ignored."
+msgstr "berkas '%s', baris %zu: nilai untuk kunci immutable '%s' diabaikan."
+
+#: ../src/common/fileconf.cpp:788
+#, c-format
+msgid "file '%s', line %zu: key '%s' was first found at line %d."
+msgstr "berkas '%s', baris %zu: kunci '%s' pertama ditemukan pada baris %d."
+
+#: ../src/common/fileconf.cpp:1091
+#, c-format
+msgid "Config entry name cannot start with '%c'."
+msgstr "Nama entri konfigurasi tidak bisa diawali dengan '%c'."
+
+#: ../src/common/fileconf.cpp:1146
+#, fuzzy
+msgid "Failed to create configuration file directory."
+msgstr "Gagal memperbaharui berkas konfigurasi."
+
+#: ../src/common/fileconf.cpp:1158
+msgid "can't open user configuration file."
+msgstr "gagal membuka berkas konfigurasi pemakai."
+
+#: ../src/common/fileconf.cpp:1172
+msgid "can't write user configuration file."
+msgstr "gagal menulis berkas konfigurasi pemakai."
+
+#: ../src/common/fileconf.cpp:1178
+msgid "Failed to update user configuration file."
+msgstr "Gagal memperbaharui berkas konfigurasi."
+
+#: ../src/common/fileconf.cpp:1201
+msgid "Error saving user configuration data."
+msgstr "Galat saat menyimpan data konfigurasi pengguna."
+
+#: ../src/common/fileconf.cpp:1313
+#, c-format
+msgid "can't delete user configuration file '%s'"
+msgstr "gagal menghapus berkas konfigurasi pemakai '%s'"
+
+#: ../src/common/fileconf.cpp:2007
+#, c-format
+msgid "entry '%s' appears more than once in group '%s'"
+msgstr "entri '%s' muncul lebih dari sekali dalam grup '%s'"
+
+#: ../src/common/fileconf.cpp:2021
+#, c-format
+msgid "attempt to change immutable key '%s' ignored."
+msgstr "mengabaikan usaha untuk mengubah kunci immutable '%s'."
+
+#: ../src/common/fileconf.cpp:2118
+#, c-format
+msgid "trailing backslash ignored in '%s'"
+msgstr "backslash yang mengekor diabaikan dalam '%s'"
+
+#: ../src/common/fileconf.cpp:2153
+#, c-format
+msgid "unexpected \" at position %d in '%s'."
+msgstr "\" tidak diharapkan pada posisi %d dalam '%s'."
+
+#: ../src/common/filefn.cpp:474
+#, c-format
+msgid "Failed to copy the file '%s' to '%s'"
+msgstr "Gagal menyalin berkas '%s' ke '%s'"
+
+#: ../src/common/filefn.cpp:487
+#, c-format
+msgid "Impossible to get permissions for file '%s'"
+msgstr "Tidak mungkin memperoleh permisi file '%s'"
+
+#: ../src/common/filefn.cpp:501
+#, c-format
+msgid "Impossible to overwrite the file '%s'"
+msgstr "Tidak mungkin menimpa file '%s'"
+
+#: ../src/common/filefn.cpp:508
+#, c-format
+msgid "Error copying the file '%s' to '%s'."
+msgstr "Gagal menyalin berkas dari '%s' ke ‘%s’."
+
+#: ../src/common/filefn.cpp:556
+#, c-format
+msgid "Impossible to set permissions for the file '%s'"
+msgstr "Tidak mungkin mengubah permisi file '%s'"
+
+#: ../src/common/filefn.cpp:606
+#, c-format
+msgid ""
+"Failed to rename the file '%s' to '%s' because the destination file already "
+"exists."
+msgstr ""
+"Gagal mengubah nama berkas '%s' ke '%s' karena berkas tujuan sudah ada."
+
+#: ../src/common/filefn.cpp:623
+#, c-format
+msgid "File '%s' couldn't be renamed '%s'"
+msgstr "Berkas '%s' tidak dapat diubah nama menjadi '%s'"
+
+#: ../src/common/filefn.cpp:639
+#, c-format
+msgid "File '%s' couldn't be removed"
+msgstr "Berkas '%s' tidak dapat dihapus"
+
+#: ../src/common/filefn.cpp:666
+#, c-format
+msgid "Directory '%s' couldn't be created"
+msgstr "Direktori '%s' tidak bisa dibuat"
+
+#: ../src/common/filefn.cpp:680
+#, c-format
+msgid "Directory '%s' couldn't be deleted"
+msgstr "Direktori '%s' tidak dapat dihapus"
+
+#: ../src/common/filefn.cpp:714
+#, c-format
+msgid "Cannot enumerate files '%s'"
+msgstr "Gagal mengenumerasi berkas '%s'"
+
+#: ../src/common/filefn.cpp:798
+msgid "Failed to get the working directory"
+msgstr "Gagal memperoleh direktori kerja"
+
+#: ../src/common/filefn.cpp:843
+msgid "Could not set current working directory"
+msgstr "Gagal mengatur lokasi direktori ini"
+
+#: ../src/common/filefn.cpp:974
+#, c-format
+msgid "Files (%s)"
+msgstr "Berkas (%s)"
+
+#: ../src/common/filename.cpp:182
+#, c-format
+msgid "Failed to open '%s' for reading"
+msgstr "Gagal membuka '%s' untuk dibaca"
+
+#: ../src/common/filename.cpp:187
+#, c-format
+msgid "Failed to open '%s' for writing"
+msgstr "Gagal membuka '%s' untuk menulis"
+
+#: ../src/common/filename.cpp:199
+msgid "Failed to close file handle"
+msgstr "Gagal menutup file handle"
+
+#: ../src/common/filename.cpp:1046
+msgid "Failed to create a temporary file name"
+msgstr "Gagal menciptakan suatu nama file sementara"
+
+#: ../src/common/filename.cpp:1081
+msgid "Failed to open temporary file."
+msgstr "Gagal membuka file sementara."
+
+#: ../src/common/filename.cpp:2862
+#, c-format
+msgid "Failed to modify file times for '%s'"
+msgstr "Gagal untuk memodifikasi waktu file untuk '%s'"
+
+#: ../src/common/filename.cpp:2877
+#, c-format
+msgid "Failed to touch the file '%s'"
+msgstr "Gagal membuat file kosong '%s'"
+
+#: ../src/common/filename.cpp:2958
+#, c-format
+msgid "Failed to retrieve file times for '%s'"
+msgstr "Gagal mengambil waktu file untuk '%s'"
+
+#: ../src/common/filepickercmn.cpp:39 ../src/common/filepickercmn.cpp:40
+msgid "Browse"
+msgstr "Ramban"
+
+#: ../src/common/fldlgcmn.cpp:792 ../src/generic/filectrlg.cpp:1185
+#, c-format
+msgid "All files (%s)|%s"
+msgstr "Semua berkas (%s)|%s"
+
+#. TRANSLATORS: %s are a file extension used to build a file wildcard string
+#: ../src/common/fldlgcmn.cpp:810
+#, c-format
+msgid "%s files (%s)|%s"
+msgstr "berkas %s (%s)|%s"
+
+#: ../src/common/fldlgcmn.cpp:1072
+#, c-format
+msgid "Load %s file"
+msgstr "Memuat berkas %s"
+
+#: ../src/common/fldlgcmn.cpp:1074
+#, c-format
+msgid "Save %s file"
+msgstr "Simpan berkas %s"
+
+#: ../src/common/fmapbase.cpp:144
+msgid "Western European (ISO-8859-1)"
+msgstr "Western European (ISO-8859-1)"
+
+#: ../src/common/fmapbase.cpp:145
+msgid "Central European (ISO-8859-2)"
+msgstr "Eropa Tengah (ISO-8859-2)"
+
+#: ../src/common/fmapbase.cpp:146
+msgid "Esperanto (ISO-8859-3)"
+msgstr "Esperanto (ISO-8859-3)"
+
+#: ../src/common/fmapbase.cpp:147
+msgid "Baltic (old) (ISO-8859-4)"
+msgstr "Baltik (tua) (ISO-8859-4)"
+
+#: ../src/common/fmapbase.cpp:148
+msgid "Cyrillic (ISO-8859-5)"
+msgstr "Cyrillic (ISO-8859-5)"
+
+#: ../src/common/fmapbase.cpp:149
+msgid "Arabic (ISO-8859-6)"
+msgstr "Arab (ISO-8859-6)"
+
+#: ../src/common/fmapbase.cpp:150
+msgid "Greek (ISO-8859-7)"
+msgstr "Greek (ISO-8859-7)"
+
+#: ../src/common/fmapbase.cpp:151
+msgid "Hebrew (ISO-8859-8)"
+msgstr "Hebrew (ISO-8859-8)"
+
+#: ../src/common/fmapbase.cpp:152
+msgid "Turkish (ISO-8859-9)"
+msgstr "Turkish (ISO-8859-9)"
+
+#: ../src/common/fmapbase.cpp:153
+msgid "Nordic (ISO-8859-10)"
+msgstr "Nordic (ISO-8859-10)"
+
+#: ../src/common/fmapbase.cpp:154
+msgid "Thai (ISO-8859-11)"
+msgstr "Thai (ISO-8859-11)"
+
+#: ../src/common/fmapbase.cpp:155
+msgid "Indian (ISO-8859-12)"
+msgstr "Indian (ISO-8859-12)"
+
+#: ../src/common/fmapbase.cpp:156
+msgid "Baltic (ISO-8859-13)"
+msgstr "Baltik (ISO-8859-13)"
+
+#: ../src/common/fmapbase.cpp:157
+msgid "Celtic (ISO-8859-14)"
+msgstr "Celtic (ISO-8859-14)"
+
+#: ../src/common/fmapbase.cpp:158
+msgid "Western European with Euro (ISO-8859-15)"
+msgstr "Western European with Euro (ISO-8859-15)"
+
+#: ../src/common/fmapbase.cpp:159
+msgid "KOI8-R"
+msgstr "KOI8-R"
+
+#: ../src/common/fmapbase.cpp:160
+msgid "KOI8-U"
+msgstr "KOI8-U"
+
+#: ../src/common/fmapbase.cpp:161
+msgid "Windows/DOS OEM Cyrillic (CP 866)"
+msgstr "Windows/DOS OEM Cyrillic (CP 866)"
+
+#: ../src/common/fmapbase.cpp:162
+msgid "Windows Thai (CP 874)"
+msgstr "Windows Thai (CP 874)"
+
+#: ../src/common/fmapbase.cpp:163
+msgid "Windows Japanese (CP 932) or Shift-JIS"
+msgstr "Windows Japanese (CP 932) or Shift-JIS"
+
+#: ../src/common/fmapbase.cpp:164
+msgid "Windows Chinese Simplified (CP 936) or GB-2312"
+msgstr "Windows Chinese Simplified (CP 936) or GB-2312"
+
+#: ../src/common/fmapbase.cpp:165
+msgid "Windows Korean (CP 949)"
+msgstr "Windows Korean (CP 949)"
+
+#: ../src/common/fmapbase.cpp:166
+msgid "Windows Chinese Traditional (CP 950) or Big-5"
+msgstr "Windows Chinese Traditional (CP 950) or Big-5"
+
+#: ../src/common/fmapbase.cpp:167
+msgid "Windows Central European (CP 1250)"
+msgstr "Windows Central European (CP 1250)"
+
+#: ../src/common/fmapbase.cpp:168
+msgid "Windows Cyrillic (CP 1251)"
+msgstr "Windows Cyrillic (CP 1251)"
+
+#: ../src/common/fmapbase.cpp:169
+msgid "Windows Western European (CP 1252)"
+msgstr "Windows Western European (CP 1252)"
+
+#: ../src/common/fmapbase.cpp:170
+msgid "Windows Greek (CP 1253)"
+msgstr "Windows Greek (CP 1253)"
+
+#: ../src/common/fmapbase.cpp:171
+msgid "Windows Turkish (CP 1254)"
+msgstr "Windows Turkish (CP 1254)"
+
+#: ../src/common/fmapbase.cpp:172
+msgid "Windows Hebrew (CP 1255)"
+msgstr "Windows Hebrew (CP 1255)"
+
+#: ../src/common/fmapbase.cpp:173
+msgid "Windows Arabic (CP 1256)"
+msgstr "Windows Arabic (CP 1256)"
+
+#: ../src/common/fmapbase.cpp:174
+msgid "Windows Baltic (CP 1257)"
+msgstr "Windows Baltic (CP 1257)"
+
+#: ../src/common/fmapbase.cpp:175
+msgid "Windows Vietnamese (CP 1258)"
+msgstr "Windows Vietnamese (CP 1258)"
+
+#: ../src/common/fmapbase.cpp:176
+msgid "Windows Johab (CP 1361)"
+msgstr "Windows Johab (CP 1361)"
+
+#: ../src/common/fmapbase.cpp:177
+msgid "Windows/DOS OEM (CP 437)"
+msgstr "Windows/DOS OEM (CP 437)"
+
+#: ../src/common/fmapbase.cpp:178
+msgid "Unicode 7 bit (UTF-7)"
+msgstr "Unicode 7 bit (UTF-7)"
+
+#: ../src/common/fmapbase.cpp:179
+msgid "Unicode 8 bit (UTF-8)"
+msgstr "Unicode 8 bit (UTF-8)"
+
+#: ../src/common/fmapbase.cpp:181 ../src/common/fmapbase.cpp:187
+msgid "Unicode 16 bit (UTF-16)"
+msgstr "Unicode 16 bit (UTF-16)"
+
+#: ../src/common/fmapbase.cpp:182
+msgid "Unicode 16 bit Little Endian (UTF-16LE)"
+msgstr "Unicode 16 bit Little Endian (UTF-16LE)"
+
+#: ../src/common/fmapbase.cpp:183 ../src/common/fmapbase.cpp:189
+msgid "Unicode 32 bit (UTF-32)"
+msgstr "Unicode 32 bit (UTF-32)"
+
+#: ../src/common/fmapbase.cpp:184
+msgid "Unicode 32 bit Little Endian (UTF-32LE)"
+msgstr "Unicode 32 bit Little Endian (UTF-32LE)"
+
+#: ../src/common/fmapbase.cpp:186
+msgid "Unicode 16 bit Big Endian (UTF-16BE)"
+msgstr "Unicode 16 bit Big Endian (UTF-16BE)"
+
+#: ../src/common/fmapbase.cpp:188
+msgid "Unicode 32 bit Big Endian (UTF-32BE)"
+msgstr "Unicode 32 bit Big Endian (UTF-32BE)"
+
+#: ../src/common/fmapbase.cpp:191
+msgid "Extended Unix Codepage for Japanese (EUC-JP)"
+msgstr "Extended Unix Codepage for Japanese (EUC-JP)"
+
+#: ../src/common/fmapbase.cpp:192
+msgid "US-ASCII"
+msgstr "US-ASCII"
+
+#: ../src/common/fmapbase.cpp:193
+msgid "ISO-2022-JP"
+msgstr "ISO-2022-JP"
+
+#: ../src/common/fmapbase.cpp:195
+msgid "MacRoman"
+msgstr "MacRoman"
+
+#: ../src/common/fmapbase.cpp:196
+msgid "MacJapanese"
+msgstr "MacJapanese"
+
+#: ../src/common/fmapbase.cpp:197
+msgid "MacChineseTrad"
+msgstr "MacChineseTrad"
+
+#: ../src/common/fmapbase.cpp:198
+msgid "MacKorean"
+msgstr "MacKorean"
+
+#: ../src/common/fmapbase.cpp:199
+msgid "MacArabic"
+msgstr "MacArabic"
+
+#: ../src/common/fmapbase.cpp:200
+msgid "MacHebrew"
+msgstr "MacHebrew"
+
+#: ../src/common/fmapbase.cpp:201
+msgid "MacGreek"
+msgstr "MacGreek"
+
+#: ../src/common/fmapbase.cpp:202
+msgid "MacCyrillic"
+msgstr "MacCyrillic"
+
+#: ../src/common/fmapbase.cpp:203
+msgid "MacDevanagari"
+msgstr "MacDevanagari"
+
+#: ../src/common/fmapbase.cpp:204
+msgid "MacGurmukhi"
+msgstr "MacGurmukhi"
+
+#: ../src/common/fmapbase.cpp:205
+msgid "MacGujarati"
+msgstr "MacGujarati"
+
+#: ../src/common/fmapbase.cpp:206
+msgid "MacOriya"
+msgstr "MacOriya"
+
+#: ../src/common/fmapbase.cpp:207
+msgid "MacBengali"
+msgstr "MacBengali"
+
+#: ../src/common/fmapbase.cpp:208
+msgid "MacTamil"
+msgstr "MacTamil"
+
+#: ../src/common/fmapbase.cpp:209
+msgid "MacTelugu"
+msgstr "MacTelugu"
+
+#: ../src/common/fmapbase.cpp:210
+msgid "MacKannada"
+msgstr "MacKannada"
+
+#: ../src/common/fmapbase.cpp:211
+msgid "MacMalayalam"
+msgstr "MacMalayalam"
+
+#: ../src/common/fmapbase.cpp:212
+msgid "MacSinhalese"
+msgstr "MacSinhalese"
+
+#: ../src/common/fmapbase.cpp:213
+msgid "MacBurmese"
+msgstr "MacBurmese"
+
+#: ../src/common/fmapbase.cpp:214
+msgid "MacKhmer"
+msgstr "MacKhmer"
+
+#: ../src/common/fmapbase.cpp:215
+msgid "MacThai"
+msgstr "MacThai"
+
+#: ../src/common/fmapbase.cpp:216
+msgid "MacLaotian"
+msgstr "MacLaotian"
+
+#: ../src/common/fmapbase.cpp:217
+msgid "MacGeorgian"
+msgstr "MacGeorgian"
+
+#: ../src/common/fmapbase.cpp:218
+msgid "MacArmenian"
+msgstr "MacArmenian"
+
+#: ../src/common/fmapbase.cpp:219
+msgid "MacChineseSimp"
+msgstr "MacChineseSimp"
+
+#: ../src/common/fmapbase.cpp:220
+msgid "MacTibetan"
+msgstr "MacTibetan"
+
+#: ../src/common/fmapbase.cpp:221
+msgid "MacMongolian"
+msgstr "MacMongolian"
+
+#: ../src/common/fmapbase.cpp:222
+msgid "MacEthiopic"
+msgstr "MacEthiopic"
+
+#: ../src/common/fmapbase.cpp:223
+msgid "MacCentralEurRoman"
+msgstr "MacCentralEurRoman"
+
+#: ../src/common/fmapbase.cpp:224
+msgid "MacVietnamese"
+msgstr "MacVietnamese"
+
+#: ../src/common/fmapbase.cpp:225
+msgid "MacExtArabic"
+msgstr "MacExtArabic"
+
+#: ../src/common/fmapbase.cpp:226
+msgid "MacSymbol"
+msgstr "MacSymbol"
+
+#: ../src/common/fmapbase.cpp:227
+msgid "MacDingbats"
+msgstr "MacDingbats"
+
+#: ../src/common/fmapbase.cpp:228
+msgid "MacTurkish"
+msgstr "MacTurkish"
+
+#: ../src/common/fmapbase.cpp:229
+msgid "MacCroatian"
+msgstr "MacCroatian"
+
+#: ../src/common/fmapbase.cpp:230
+msgid "MacIcelandic"
+msgstr "MacIcelandic"
+
+#: ../src/common/fmapbase.cpp:231
+msgid "MacRomanian"
+msgstr "MacRomanian"
+
+#: ../src/common/fmapbase.cpp:232
+msgid "MacCeltic"
+msgstr "MacCeltic"
+
+#: ../src/common/fmapbase.cpp:233
+msgid "MacGaelic"
+msgstr "MacGaelic"
+
+#: ../src/common/fmapbase.cpp:234
+msgid "MacKeyboardGlyphs"
+msgstr "MacKeyboardGlyphs"
+
+#: ../src/common/fmapbase.cpp:791
+msgid "Default encoding"
+msgstr "Pengkodean default"
+
+#: ../src/common/fmapbase.cpp:805
+#, c-format
+msgid "Unknown encoding (%d)"
+msgstr "Pengkodean (%d) tidak dikenal"
+
+#: ../src/common/fmapbase.cpp:815 ../src/richtext/richtextstyles.cpp:776
+msgid "default"
+msgstr "default"
+
+#: ../src/common/fmapbase.cpp:829
+#, c-format
+msgid "unknown-%d"
+msgstr "%d-tidak dikenal"
+
+#: ../src/common/fontcmn.cpp:924 ../src/common/fontcmn.cpp:1130
+msgid "underlined"
+msgstr "bergarisbawah"
+
+#: ../src/common/fontcmn.cpp:929
+msgid " strikethrough"
+msgstr " teks coret"
+
+#: ../src/common/fontcmn.cpp:942
+msgid " thin"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:946
+#, fuzzy
+msgid " extra light"
+msgstr " ringan"
+
+#: ../src/common/fontcmn.cpp:950
+msgid " light"
+msgstr " ringan"
+
+#: ../src/common/fontcmn.cpp:954
+msgid " medium"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:958
+#, fuzzy
+msgid " semi bold"
+msgstr " tebal"
+
+#: ../src/common/fontcmn.cpp:962
+msgid " bold"
+msgstr " tebal"
+
+#: ../src/common/fontcmn.cpp:966
+#, fuzzy
+msgid " extra bold"
+msgstr " tebal"
+
+#: ../src/common/fontcmn.cpp:970
+msgid " heavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:974
+msgid " extra heavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:990
+msgid " italic"
+msgstr " miring"
+
+#: ../src/common/fontcmn.cpp:1134
+msgid "strikethrough"
+msgstr "teks coret"
+
+#: ../src/common/fontcmn.cpp:1143
+msgid "thin"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1156
+#, fuzzy
+msgid "extralight"
+msgstr "ringan"
+
+#: ../src/common/fontcmn.cpp:1161
+msgid "light"
+msgstr "ringan"
+
+#: ../src/common/fontcmn.cpp:1169 ../src/richtext/richtextstyles.cpp:775
+msgid "normal"
+msgstr "normal"
+
+#: ../src/common/fontcmn.cpp:1174
+msgid "medium"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1179 ../src/common/fontcmn.cpp:1199
+#, fuzzy
+msgid "semibold"
+msgstr "tebal"
+
+#: ../src/common/fontcmn.cpp:1184
+msgid "bold"
+msgstr "tebal"
+
+#: ../src/common/fontcmn.cpp:1194
+#, fuzzy
+msgid "extrabold"
+msgstr "tebal"
+
+#: ../src/common/fontcmn.cpp:1204
+msgid "heavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1212
+msgid "extraheavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1217
+msgid "italic"
+msgstr "miring"
+
+#: ../src/common/fontmap.cpp:195
+msgid ": unknown charset"
+msgstr ": charset tidak dikenal"
+
+#: ../src/common/fontmap.cpp:199
+#, c-format
+msgid ""
+"The charset '%s' is unknown. You may select\n"
+"another charset to replace it with or choose\n"
+"[Cancel] if it cannot be replaced"
+msgstr ""
+"Charset '%s' tidak diketahui. Anda bisa memilih\n"
+"charset lain untuk menggantinya atau memilih\n"
+"[Batal] jika tidak bisa diganti"
+
+#: ../src/common/fontmap.cpp:241
+#, c-format
+msgid "Failed to remember the encoding for the charset '%s'."
+msgstr "Gagal mengingat pengkodean untuk charset '%s'."
+
+#: ../src/common/fontmap.cpp:321
+msgid "can't load any font, aborting"
+msgstr "gagal memuat font apapun, menggugurkan"
+
+#: ../src/common/fontmap.cpp:409
+msgid ": unknown encoding"
+msgstr ": pengkodean tidak diketahui"
+
+#: ../src/common/fontmap.cpp:417
+#, c-format
+msgid ""
+"No font for displaying text in encoding '%s' found,\n"
+"but an alternative encoding '%s' is available.\n"
+"Do you want to use this encoding (otherwise you will have to choose another "
+"one)?"
+msgstr ""
+"Tidak ditemukan font untuk menampilkan teks dalam pengkodean ‘%s’,\n"
+"tetapi alternatif pengkodean '%s' tersedia.\n"
+"Apakah anda ingin menggunakan pengkodean ini (jika tidak anda harus memilih "
+"lainnya)?"
+
+#: ../src/common/fontmap.cpp:422
+#, c-format
+msgid ""
+"No font for displaying text in encoding '%s' found.\n"
+"Would you like to select a font to be used for this encoding\n"
+"(otherwise the text in this encoding will not be shown correctly)?"
+msgstr ""
+"Tidak ditemukan font untuk menampilkan teks dalam pengkodean '%s'.\n"
+"Apakah anda mau memilih font untuk pengkodean ini\n"
+"(jika tidak teks dalam pengkodean tidak akan tampil secara benar)?"
+
+#: ../src/common/fs_mem.cpp:169
+#, c-format
+msgid "Memory VFS already contains file '%s'!"
+msgstr "Memory VFS telah terisi berkas '%s'!"
+
+#: ../src/common/fs_mem.cpp:232
+#, c-format
+msgid "Trying to remove file '%s' from memory VFS, but it is not loaded!"
+msgstr "Mencoba menghapus berkas '%s' dari memori VFS, walau tidak termuat!"
+
+#: ../src/common/fs_mem.cpp:262
+#, c-format
+msgid "Failed to store image '%s' to memory VFS!"
+msgstr "Gagal menyimpan citra '%s' ke memori VFS!"
+
+#: ../src/common/ftp.cpp:197
+msgid "Timeout while waiting for FTP server to connect, try passive mode."
+msgstr ""
+"Terjadi galat batas waktu ketika menghubungi FTP server, cobalah mode "
+"passive."
+
+#: ../src/common/ftp.cpp:399
+#, c-format
+msgid "Failed to set FTP transfer mode to %s."
+msgstr "Gagal menetapkan mode transfer FTP ke %s."
+
+#: ../src/common/ftp.cpp:400 ../src/richtext/richtextsymboldlg.cpp:432
+msgid "ASCII"
+msgstr "ASCII"
+
+#: ../src/common/ftp.cpp:400
+msgid "binary"
+msgstr "biner"
+
+#: ../src/common/ftp.cpp:608
+msgid "The FTP server doesn't support the PORT command."
+msgstr "Server FTP tersebut tidak mengdukung perintah PORT."
+
+#: ../src/common/ftp.cpp:622
+msgid "The FTP server doesn't support passive mode."
+msgstr "Server FTP tidak mendukung mode passive."
+
+#: ../src/common/gifdecod.cpp:822
+#, c-format
+msgid "Incorrect GIF frame size (%u, %d) for the frame #%u"
+msgstr "Ukuran frame GIF salah (%u, %d) untuk frame #%u"
+
+#: ../src/common/glcmn.cpp:108
+msgid "Failed to allocate colour for OpenGL"
+msgstr "Gagal mengalokasikan warna untuk OpenGL"
+
+#: ../src/common/headerctrlcmn.cpp:57
+msgid "Please select the columns to show and define their order:"
+msgstr "Silakan pilih kolom untuk ditampilkan dan definisikan urutannya:"
+
+#: ../src/common/headerctrlcmn.cpp:58
+msgid "Customize Columns"
+msgstr "Kustomisasi Kolom"
+
+#: ../src/common/headerctrlcmn.cpp:304
+msgid "&Customize..."
+msgstr "&Kustomisasi..."
+
+#: ../src/common/hyperlnkcmn.cpp:132
+#, fuzzy, c-format
+msgid "Failed to open URL \"%s\" in the default browser"
+msgstr "Gagal membuka URL \"%s\" pada browser."
+
+#: ../src/common/iconbndl.cpp:195
+#, c-format
+msgid "Failed to load image %%d from file '%s'."
+msgstr "Gagal memuat citra %%d dari berkas '%s'."
+
+#: ../src/common/iconbndl.cpp:203
+#, c-format
+msgid "Failed to load image %d from stream."
+msgstr "Gagal memuat citra %d dari stream."
+
+#: ../src/common/iconbndl.cpp:221
+#, c-format
+msgid "Failed to load icons from resource '%s'."
+msgstr "Gagal memuat ikon dari sumber “%s”."
+
+#: ../src/common/imagbmp.cpp:97
+msgid "BMP: Couldn't save invalid image."
+msgstr "BMP: Gagal menympan citra tidak sah."
+
+#: ../src/common/imagbmp.cpp:137
+msgid "BMP: wxImage doesn't have own wxPalette."
+msgstr "BMP: wxImage tidak mempunyai wxPallete."
+
+#: ../src/common/imagbmp.cpp:243
+msgid "BMP: Couldn't write the file (Bitmap) header."
+msgstr "BMP: Gagal menulis header berkas (Bitmap)."
+
+#: ../src/common/imagbmp.cpp:266
+msgid "BMP: Couldn't write the file (BitmapInfo) header."
+msgstr "BMP: Gagal menulis header berkas (BitmapInfo)"
+
+#: ../src/common/imagbmp.cpp:353
+msgid "BMP: Couldn't write RGB color map."
+msgstr "BMP: Gagal menulis peta warna RGB."
+
+#: ../src/common/imagbmp.cpp:487
+msgid "BMP: Couldn't write data."
+msgstr "BMP: Gagal menulis data."
+
+#: ../src/common/imagbmp.cpp:561 ../src/common/imagbmp.cpp:642
+msgid "BMP: Couldn't allocate memory."
+msgstr "BMP: Gagal mengalokasikan memori."
+
+#: ../src/common/imagbmp.cpp:1041
+msgid "DIB Header: Image width > 32767 pixels for file."
+msgstr "DIB Header: Lebar citra > 32767 pixel untuk berkas."
+
+#: ../src/common/imagbmp.cpp:1049
+msgid "DIB Header: Image height > 32767 pixels for file."
+msgstr "Header DIB: Tinggi citra > 32767 pixel untuk berkas."
+
+#: ../src/common/imagbmp.cpp:1081
+msgid "DIB Header: Unknown bitdepth in file."
+msgstr "DIB Header: bitdepth dalam berkas tidak diketahui."
+
+#: ../src/common/imagbmp.cpp:1156
+msgid "DIB Header: Unknown encoding in file."
+msgstr "Header DIB: Pengkodean dalam file tidak diketahui."
+
+#: ../src/common/imagbmp.cpp:1165
+msgid "DIB Header: Encoding doesn't match bitdepth."
+msgstr "Header DIB: Pengkodean tidak sesuai dengan bitdepth."
+
+#: ../src/common/imagbmp.cpp:1180
+#, c-format
+msgid "BMP Header: Invalid number of colors (%d)."
+msgstr ""
+
+#: ../src/common/imagbmp.cpp:1273
+msgid "Error in reading image DIB."
+msgstr "Galat ketika membaca citra DIB."
+
+#: ../src/common/imagbmp.cpp:1294
+msgid "ICO: Error in reading mask DIB."
+msgstr "ICO: Kesalahan dalam membaca mask DIB."
+
+#: ../src/common/imagbmp.cpp:1353
+msgid "ICO: Image too tall for an icon."
+msgstr "ICO: Citra terlalu tinggi untuk suatu ikon."
+
+#: ../src/common/imagbmp.cpp:1361
+msgid "ICO: Image too wide for an icon."
+msgstr "ICO: Citra terlalu lebar untuk suatu ikon."
+
+#: ../src/common/imagbmp.cpp:1388 ../src/common/imagbmp.cpp:1488
+#: ../src/common/imagbmp.cpp:1503 ../src/common/imagbmp.cpp:1514
+#: ../src/common/imagbmp.cpp:1528 ../src/common/imagbmp.cpp:1576
+#: ../src/common/imagbmp.cpp:1591 ../src/common/imagbmp.cpp:1605
+#: ../src/common/imagbmp.cpp:1616
+msgid "ICO: Error writing the image file!"
+msgstr "ICO: Kesalahan dalam menulis berkas citra!"
+
+#: ../src/common/imagbmp.cpp:1701
+msgid "ICO: Invalid icon index."
+msgstr "ICO: Indeks ikon tidak sah."
+
+#: ../src/common/image.cpp:2410
+msgid "Image and mask have different sizes."
+msgstr "Citra dan mask mempunyai ukuran yang berbeda."
+
+#: ../src/common/image.cpp:2418 ../src/common/image.cpp:2459
+msgid "No unused colour in image being masked."
+msgstr "Tidak tersedia warna pada citra yang di mask."
+
+#: ../src/common/image.cpp:2641
+#, c-format
+msgid "Failed to load bitmap \"%s\" from resources."
+msgstr "Gagal memuat bitmap \"%s\" dari sumber."
+
+#: ../src/common/image.cpp:2650
+#, c-format
+msgid "Failed to load icon \"%s\" from resources."
+msgstr "Gagal memuat ikon \"%s\" dari sumber."
+
+#: ../src/common/image.cpp:2728 ../src/common/image.cpp:2747
+#, c-format
+msgid "Failed to load image from file \"%s\"."
+msgstr "Gagal memuat citra dari berkas \"%s\"."
+
+#: ../src/common/image.cpp:2761
+#, c-format
+msgid "Can't save image to file '%s': unknown extension."
+msgstr "Gagal menyimpan citra ke berkas '%s': ekstensi tidak diketahui."
+
+#: ../src/common/image.cpp:2869
+msgid "No handler found for image type."
+msgstr "Tidak ditemukan handler untuk tipe citra tsb."
+
+#: ../src/common/image.cpp:2877 ../src/common/image.cpp:3000
+#: ../src/common/image.cpp:3066
+#, c-format
+msgid "No image handler for type %d defined."
+msgstr "Tidak ada handler citra untuk tipe %d yang didefinisikan."
+
+#: ../src/common/image.cpp:2887
+#, c-format
+msgid "Image file is not of type %d."
+msgstr "Berkas citra bukan bertipe %d."
+
+#: ../src/common/image.cpp:2970
+msgid "Can't automatically determine the image format for non-seekable input."
+msgstr "Gagal menentukan format citra bagi masukan yang tak bisa dirambah."
+
+#: ../src/common/image.cpp:2988
+msgid "Unknown image data format."
+msgstr "Format citra data tidak dikenal."
+
+#: ../src/common/image.cpp:3009
+#, c-format
+msgid "This is not a %s."
+msgstr "Ini bukan %s."
+
+#: ../src/common/image.cpp:3032 ../src/common/image.cpp:3080
+#, c-format
+msgid "No image handler for type %s defined."
+msgstr "Tidak ada handler citra untuk tipe %s yang didefinisikan."
+
+#: ../src/common/image.cpp:3041
+#, c-format
+msgid "Image is not of type %s."
+msgstr "Citra bukan dari tipe %s."
+
+#: ../src/common/image.cpp:3509
+#, c-format
+msgid "Failed to check format of image file \"%s\"."
+msgstr "Gagal mengecek format citra \"%s\"."
+
+#: ../src/common/imaggif.cpp:124
+msgid "GIF: error in GIF image format."
+msgstr "GIF: kesalahan pada format citra GIF."
+
+#: ../src/common/imaggif.cpp:129
+msgid "GIF: not enough memory."
+msgstr "GIF: tidak cukup memori."
+
+#: ../src/common/imaggif.cpp:134
+msgid "GIF: data stream seems to be truncated."
+msgstr "GIF: stream data kelihatannya terpotong."
+
+#: ../src/common/imaggif.cpp:240
+msgid "Couldn't initialize GIF hash table."
+msgstr "Gagal menjalankan GIF has table."
+
+#: ../src/common/imagiff.cpp:739
+msgid "IFF: error in IFF image format."
+msgstr "IFF: kesalahan dalam format citra IFF."
+
+#: ../src/common/imagiff.cpp:742
+msgid "IFF: not enough memory."
+msgstr "IFF: memori tidak cukup."
+
+#: ../src/common/imagiff.cpp:745
+msgid "IFF: unknown error!!!"
+msgstr "IFF: kesalahan yang tidak diketahui!!!"
+
+#: ../src/common/imagiff.cpp:755
+msgid "IFF: data stream seems to be truncated."
+msgstr "IFF: stream data kelihatannya terpotong."
+
+#: ../src/common/imagjpeg.cpp:258
+msgid "JPEG: Couldn't load - file is probably corrupted."
+msgstr "JPEG: Gagal memuat - berkas mungkin rusak."
+
+#: ../src/common/imagjpeg.cpp:437
+msgid "JPEG: Couldn't save image."
+msgstr "JPEG: Gagal menyimpan citra."
+
+#: ../src/common/imagpcx.cpp:439
+msgid "PCX: this is not a PCX file."
+msgstr "PCX: ini bukan file PCX."
+
+#: ../src/common/imagpcx.cpp:453
+msgid "PCX: image format unsupported"
+msgstr "PCX: format citra tidak didukung"
+
+#: ../src/common/imagpcx.cpp:454 ../src/common/imagpcx.cpp:477
+msgid "PCX: couldn't allocate memory"
+msgstr "PCX: tidak bisa mengalokasikan memori"
+
+#: ../src/common/imagpcx.cpp:455
+msgid "PCX: version number too low"
+msgstr "PCX: nomor versi terlalu rendah"
+
+#: ../src/common/imagpcx.cpp:456 ../src/common/imagpcx.cpp:478
+msgid "PCX: unknown error !!!"
+msgstr "PCX: kesalahan tidak diketahui !!!"
+
+#: ../src/common/imagpcx.cpp:476
+msgid "PCX: invalid image"
+msgstr "PCX: citra tidak sah"
+
+#: ../src/common/imagpng.cpp:385
+#, c-format
+msgid "Unknown PNG resolution unit %d"
+msgstr "Ukuran resolusi PNG %d tidak dikenal"
+
+#: ../src/common/imagpng.cpp:439
+msgid "Couldn't load a PNG image - file is corrupted or not enough memory."
+msgstr "Gagal memuat citra PNG - berkas rusak atau memori tidak cukup."
+
+#: ../src/common/imagpng.cpp:513 ../src/common/imagpng.cpp:524
+#: ../src/common/imagpng.cpp:534
+msgid "Couldn't save PNG image."
+msgstr "Gagal menyimpan citra PNG."
+
+#: ../src/common/imagpnm.cpp:71
+msgid "PNM: File format is not recognized."
+msgstr "PNM: format file tidak dikenal."
+
+#: ../src/common/imagpnm.cpp:89
+msgid "PNM: Couldn't allocate memory."
+msgstr "PNM: Gagal mengalokasikan memori."
+
+#: ../src/common/imagpnm.cpp:111 ../src/common/imagpnm.cpp:134
+#: ../src/common/imagpnm.cpp:156
+msgid "PNM: File seems truncated."
+msgstr "PNM: Kelihatannya file terpotong."
+
+#: ../src/common/imagtiff.cpp:69
+#, c-format
+msgid " (in module \"%s\")"
+msgstr " (dalam modul \"%s\")"
+
+#: ../src/common/imagtiff.cpp:304
+msgid "TIFF: Error loading image."
+msgstr "TIFF: Galat memuat citra."
+
+#: ../src/common/imagtiff.cpp:314
+msgid "Invalid TIFF image index."
+msgstr "Indeks citra TIFF tidak sah."
+
+#: ../src/common/imagtiff.cpp:358
+msgid "TIFF: Image size is abnormally big."
+msgstr "TIFF: Ukuran citra terlalu besar."
+
+#: ../src/common/imagtiff.cpp:372 ../src/common/imagtiff.cpp:385
+#: ../src/common/imagtiff.cpp:769
+msgid "TIFF: Couldn't allocate memory."
+msgstr "TIFF: Gagal mengalokasikan memori."
+
+#: ../src/common/imagtiff.cpp:471
+msgid "TIFF: Error reading image."
+msgstr "TIFF: Galat membaca citra."
+
+#: ../src/common/imagtiff.cpp:532
+#, c-format
+msgid "Unknown TIFF resolution unit %d ignored"
+msgstr "Ukuran resolusi TIFF %d yang tidak dikenal diabaikan"
+
+#: ../src/common/imagtiff.cpp:611
+msgid "TIFF: Error saving image."
+msgstr "TIFF: Galat menyimpan citra."
+
+#: ../src/common/imagtiff.cpp:868
+msgid "TIFF: Error writing image."
+msgstr "TIFF: Galat menulis citra."
+
+#: ../src/common/imagtiff.cpp:881
+#, fuzzy
+msgid "TIFF: Error flushing data."
+msgstr "TIFF: Galat menyimpan citra."
+
+#: ../src/common/imagwebp.cpp:56
+msgid "WebP: Invalid data (failed to get features)."
+msgstr ""
+
+#: ../src/common/imagwebp.cpp:65
+msgid "WebP: Allocating image memory failed."
+msgstr ""
+
+#: ../src/common/imagwebp.cpp:82
+msgid "WebP: Decoding RGBA image data failed."
+msgstr ""
+
+#: ../src/common/imagwebp.cpp:98
+msgid "WebP: Decoding RGB image data failed."
+msgstr ""
+
+#: ../src/common/imagwebp.cpp:113 ../src/common/imagwebp.cpp:201
+msgid "WebP: Allocating stream buffer failed."
+msgstr ""
+
+#: ../src/common/imagwebp.cpp:131
+#, fuzzy
+msgid "WebP: Failed to parse container data."
+msgstr "Gagal menetapkan data clipboard."
+
+#: ../src/common/imagwebp.cpp:222
+#, fuzzy
+msgid "WebP: Error decoding animation."
+msgstr "Galat saat membaca opsi config."
+
+#: ../src/common/imagwebp.cpp:240
+msgid "WebP: Error getting next animation frame."
+msgstr ""
+
+# verifikasi terjemahan s/d 2156
+# 20131008
+#: ../src/common/init.cpp:172
+#, c-format
+msgid ""
+"Command line argument %d couldn't be converted to Unicode and will be "
+"ignored."
+msgstr ""
+"Perintah Command Line %d tidak dapat diubah ke Unicode dan akan dibiarkan."
+
+#: ../src/common/init.cpp:344
+msgid "Initialization failed in post init, aborting."
+msgstr "Inisialisasi gagal saat init, membatalkan."
+
+#: ../src/common/intl.cpp:378
+#, c-format
+msgid "Cannot set locale to language \"%s\"."
+msgstr "Gagal mengatur bahasa ke \"%s\"."
+
+#: ../src/common/log.cpp:232
+msgid "Error: "
+msgstr "Kesalahan: "
+
+#: ../src/common/log.cpp:236
+msgid "Warning: "
+msgstr "Peringatan: "
+
+#: ../src/common/log.cpp:284
+msgid "The previous message repeated once."
+msgstr "Pesan sebelumnya diulang sekali."
+
+#: ../src/common/log.cpp:291
+#, c-format
+msgid "The previous message repeated %u time."
+msgid_plural "The previous message repeated %u times."
+msgstr[0] "Pesan sebelumnya diulang %u kali."
+
+#: ../src/common/log.cpp:319
+#, c-format
+msgid "Last repeated message (\"%s\", %u time) wasn't output"
+msgid_plural "Last repeated message (\"%s\", %u times) wasn't output"
+msgstr[0] "Pesan terakhir (\"%s\", %u waktu) bukan merupakan hasil"
+
+#: ../src/common/log.cpp:435
+#, c-format
+msgid " (error %ld: %s)"
+msgstr " (galat %ld: %s)"
+
+#: ../src/common/lzmastream.cpp:121
+#, fuzzy
+msgid "Failed to allocate memory for LZMA decompression."
+msgstr "Gagal mengalokasikan warna untuk OpenGL"
+
+#: ../src/common/lzmastream.cpp:125
+#, c-format
+msgid "Failed to initialize LZMA decompression: unexpected error %u."
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:179
+msgid "input is not in XZ format"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:183
+msgid "input compressed using unknown XZ option"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:188
+msgid "input is corrupted"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:192
+#, fuzzy
+msgid "unknown decompression error"
+msgstr "galat dekompresi"
+
+#: ../src/common/lzmastream.cpp:196
+#, fuzzy, c-format
+msgid "LZMA decompression error: %s"
+msgstr "galat dekompresi"
+
+#: ../src/common/lzmastream.cpp:231
+#, fuzzy
+msgid "Failed to allocate memory for LZMA compression."
+msgstr "Gagal mengalokasikan warna untuk OpenGL"
+
+#: ../src/common/lzmastream.cpp:235
+#, c-format
+msgid "Failed to initialize LZMA compression: unexpected error %u."
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:267 ../src/common/lzmastream.cpp:342
+#: ../src/html/chm.cpp:336
+msgid "out of memory"
+msgstr "memori tidak cukup"
+
+#: ../src/common/lzmastream.cpp:276 ../src/common/lzmastream.cpp:346
+#, fuzzy
+msgid "unknown compression error"
+msgstr "galat kompresi"
+
+#: ../src/common/lzmastream.cpp:280
+#, fuzzy, c-format
+msgid "LZMA compression error: %s"
+msgstr "galat kompresi"
+
+#: ../src/common/lzmastream.cpp:350
+#, c-format
+msgid "LZMA compression error when flushing output: %s"
+msgstr ""
+
+#: ../src/common/mimecmn.cpp:167
+#, c-format
+msgid "Unmatched '{' in an entry for mime type %s."
+msgstr "'{' tanpa pasangan dalam entri mime type %s."
+
+#: ../src/common/module.cpp:76
+#, c-format
+msgid "Circular dependency involving module \"%s\" detected."
+msgstr "Terdeteksi kebergantungan melingkar melibatkan modul \"%s\"."
+
+#: ../src/common/module.cpp:128
+#, c-format
+msgid "Dependency \"%s\" of module \"%s\" doesn't exist."
+msgstr "Ketergantungan \"%s\" dari modul \"%s\" tidak ada."
+
+#: ../src/common/module.cpp:137
+#, c-format
+msgid "Module \"%s\" initialization failed"
+msgstr "Modul \"%s\" gagal terpasang"
+
+#: ../src/common/msgout.cpp:96
+msgid "Message"
+msgstr "Pesan"
+
+#: ../src/common/paper.cpp:70
+msgid "Letter, 8 1/2 x 11 in"
+msgstr "Letter, 8 1/2 x 11 inci"
+
+#: ../src/common/paper.cpp:71
+msgid "Legal, 8 1/2 x 14 in"
+msgstr "Legal, 8 1/2 x 14 inci"
+
+#: ../src/common/paper.cpp:72
+msgid "A4 sheet, 210 x 297 mm"
+msgstr "Lembar A4, 210 x 297 mm"
+
+#: ../src/common/paper.cpp:73
+msgid "C sheet, 17 x 22 in"
+msgstr "Lembar C, 17 x 22 inci"
+
+#: ../src/common/paper.cpp:74
+msgid "D sheet, 22 x 34 in"
+msgstr "Kertas D, 22 x 34 in"
+
+#: ../src/common/paper.cpp:75
+msgid "E sheet, 34 x 44 in"
+msgstr "Kertas E, 34 x 44 inci"
+
+#: ../src/common/paper.cpp:76
+msgid "Letter Small, 8 1/2 x 11 in"
+msgstr "Letter Kecil, 8 1/2 x 11 inci"
+
+#: ../src/common/paper.cpp:77
+msgid "Tabloid, 11 x 17 in"
+msgstr "Tabloid, 11 x 17 inci"
+
+#: ../src/common/paper.cpp:78
+msgid "Ledger, 17 x 11 in"
+msgstr "Ledger, 17 x 11 in"
+
+#: ../src/common/paper.cpp:79
+msgid "Statement, 5 1/2 x 8 1/2 in"
+msgstr "Pernyataan, 5 1/2 x 8 1/2 inci"
+
+#: ../src/common/paper.cpp:80
+msgid "Executive, 7 1/4 x 10 1/2 in"
+msgstr "Eksekutif, 7 1/4 x 10 1/2 in"
+
+#: ../src/common/paper.cpp:81
+msgid "A3 sheet, 297 x 420 mm"
+msgstr "Lembar A3, 297 x 420 mm"
+
+#: ../src/common/paper.cpp:82
+msgid "A4 small sheet, 210 x 297 mm"
+msgstr "Lembar kecil A4, 210 x 297 mm"
+
+#: ../src/common/paper.cpp:83
+msgid "A5 sheet, 148 x 210 mm"
+msgstr "Lembar A5, 148 x 210 mm"
+
+#: ../src/common/paper.cpp:84
+msgid "B4 sheet, 250 x 354 mm"
+msgstr "Lembar B4, 250 x 354 mm"
+
+#: ../src/common/paper.cpp:85
+msgid "B5 sheet, 182 x 257 millimeter"
+msgstr "Lembar B5, 182 x 257 millimeter"
+
+#: ../src/common/paper.cpp:86
+msgid "Folio, 8 1/2 x 13 in"
+msgstr "Folio, 8 1/2 x 13 inci"
+
+#: ../src/common/paper.cpp:87
+msgid "Quarto, 215 x 275 mm"
+msgstr "Kuarto, 215 x 275 mm"
+
+#: ../src/common/paper.cpp:88
+msgid "10 x 14 in"
+msgstr "10 x 14 in"
+
+#: ../src/common/paper.cpp:89
+msgid "11 x 17 in"
+msgstr "11 x 17 in"
+
+#: ../src/common/paper.cpp:90
+msgid "Note, 8 1/2 x 11 in"
+msgstr "Catatan, 8 1/2 x 11 in"
+
+#: ../src/common/paper.cpp:91
+msgid "#9 Envelope, 3 7/8 x 8 7/8 in"
+msgstr "Amplop #9, 3 7/8 x 8 7/8 in"
+
+#: ../src/common/paper.cpp:92
+msgid "#10 Envelope, 4 1/8 x 9 1/2 in"
+msgstr "Amplop #10, 4 1/8 x 9 1/2 in"
+
+#: ../src/common/paper.cpp:93
+msgid "#11 Envelope, 4 1/2 x 10 3/8 in"
+msgstr "Amplop #11, 4 1/2 x 10 3/8 in"
+
+#: ../src/common/paper.cpp:94
+msgid "#12 Envelope, 4 3/4 x 11 in"
+msgstr "Amplop #12, 4 3/4 x 11 in"
+
+#: ../src/common/paper.cpp:95
+msgid "#14 Envelope, 5 x 11 1/2 in"
+msgstr "Amplop #14, 5 x 11 1/2 in"
+
+#: ../src/common/paper.cpp:96
+msgid "DL Envelope, 110 x 220 mm"
+msgstr "Amplop DL, 110 x 220 mm"
+
+#: ../src/common/paper.cpp:97
+msgid "C5 Envelope, 162 x 229 mm"
+msgstr "Amplop C5, 162 x 229 mm"
+
+#: ../src/common/paper.cpp:98
+msgid "C3 Envelope, 324 x 458 mm"
+msgstr "Amplop C3, 324 x 458 mm"
+
+#: ../src/common/paper.cpp:99
+msgid "C4 Envelope, 229 x 324 mm"
+msgstr "Amplop C4, 229 x 324 mm"
+
+#: ../src/common/paper.cpp:100
+msgid "C6 Envelope, 114 x 162 mm"
+msgstr "Amplop C6, 114 x 162 mm"
+
+#: ../src/common/paper.cpp:101
+msgid "C65 Envelope, 114 x 229 mm"
+msgstr "Amplop C65, 114 x 229 mm"
+
+#: ../src/common/paper.cpp:102
+msgid "B4 Envelope, 250 x 353 mm"
+msgstr "Amplop B4, 250 x 353 mm"
+
+#: ../src/common/paper.cpp:103
+msgid "B5 Envelope, 176 x 250 mm"
+msgstr "Amplop B5, 176 x 250 mm"
+
+#: ../src/common/paper.cpp:104
+msgid "B6 Envelope, 176 x 125 mm"
+msgstr "Amplop B6, 176 x 125 mm"
+
+#: ../src/common/paper.cpp:105
+msgid "Italy Envelope, 110 x 230 mm"
+msgstr "Amplop Italia,  110 x 230 mm"
+
+#: ../src/common/paper.cpp:106
+msgid "Monarch Envelope, 3 7/8 x 7 1/2 in"
+msgstr "Amplop Monarch, 3 7/8 x 7 1/2 inci"
+
+#: ../src/common/paper.cpp:107
+msgid "6 3/4 Envelope, 3 5/8 x 6 1/2 in"
+msgstr "Amplop 6 3/4, 3 5/8 x 6 1/2 in"
+
+#: ../src/common/paper.cpp:108
+msgid "US Std Fanfold, 14 7/8 x 11 in"
+msgstr "US Std Fanfold, 14 7/8 x 11 inci"
+
+#: ../src/common/paper.cpp:109
+msgid "German Std Fanfold, 8 1/2 x 12 in"
+msgstr "German Std Fanfold, 8 1/2 x 12 inci"
+
+#: ../src/common/paper.cpp:110
+msgid "German Legal Fanfold, 8 1/2 x 13 in"
+msgstr "German Legal Fanfold, 8 1/2 x 13 inci"
+
+#: ../src/common/paper.cpp:112
+msgid "B4 (ISO) 250 x 353 mm"
+msgstr "B4 (ISO) 250 x 353 mm"
+
+#: ../src/common/paper.cpp:113
+msgid "Japanese Postcard 100 x 148 mm"
+msgstr "Japanese Postcard 100 x 148 mm"
+
+#: ../src/common/paper.cpp:114
+msgid "9 x 11 in"
+msgstr "9 x 11 in"
+
+#: ../src/common/paper.cpp:115
+msgid "10 x 11 in"
+msgstr "10 x 11 in"
+
+#: ../src/common/paper.cpp:116
+msgid "15 x 11 in"
+msgstr "15 x 11 in"
+
+#: ../src/common/paper.cpp:117
+msgid "Envelope Invite 220 x 220 mm"
+msgstr "Amplop Undangan 220 x 220 mm"
+
+#: ../src/common/paper.cpp:118
+msgid "Letter Extra 9 1/2 x 12 in"
+msgstr "Letter Extra 9 1/2 x 12 in"
+
+#: ../src/common/paper.cpp:119
+msgid "Legal Extra 9 1/2 x 15 in"
+msgstr "Legal Extra 9 1/2 x 15 in"
+
+#: ../src/common/paper.cpp:120
+msgid "Tabloid Extra 11.69 x 18 in"
+msgstr "Tabloid Extra 11.69 x 18 in"
+
+#: ../src/common/paper.cpp:121
+msgid "A4 Extra 9.27 x 12.69 in"
+msgstr "A4 Ekstra 9.27 x 12.69 in"
+
+#: ../src/common/paper.cpp:122
+msgid "Letter Transverse 8 1/2 x 11 in"
+msgstr "Letter Transverse 8 1/2 x 11 in"
+
+#: ../src/common/paper.cpp:123
+msgid "A4 Transverse 210 x 297 mm"
+msgstr "A4 Transverse 210 x 297 mm"
+
+#: ../src/common/paper.cpp:124
+msgid "Letter Extra Transverse 9.275 x 12 in"
+msgstr "Letter Extra Transverse 9.275 x 12 in"
+
+#: ../src/common/paper.cpp:125
+msgid "SuperA/SuperA/A4 227 x 356 mm"
+msgstr "SuperA/SuperA/A4 227 x 356 mm"
+
+#: ../src/common/paper.cpp:126
+msgid "SuperB/SuperB/A3 305 x 487 mm"
+msgstr "SuperB/SuperB/A3 305 x 487 mm"
+
+#: ../src/common/paper.cpp:127
+msgid "Letter Plus 8 1/2 x 12.69 in"
+msgstr "Letter Plus 8 1/2 x 12.69 in"
+
+#: ../src/common/paper.cpp:128
+msgid "A4 Plus 210 x 330 mm"
+msgstr "A4 Plus 210 x 330 mm"
+
+#: ../src/common/paper.cpp:129
+msgid "A5 Transverse 148 x 210 mm"
+msgstr "A5 Transverse 148 x 210 mm"
+
+#: ../src/common/paper.cpp:130
+msgid "B5 (JIS) Transverse 182 x 257 mm"
+msgstr "B5 (JIS) Transverse 182 x 257 mm"
+
+#: ../src/common/paper.cpp:131
+msgid "A3 Extra 322 x 445 mm"
+msgstr "A3 Ekstra 322 x 445 mm"
+
+#: ../src/common/paper.cpp:132
+msgid "A5 Extra 174 x 235 mm"
+msgstr "A5 Ekstra 174 x 235 mm"
+
+#: ../src/common/paper.cpp:133
+msgid "B5 (ISO) Extra 201 x 276 mm"
+msgstr "B5 (ISO) Ekstra 201 x 276 mm"
+
+#: ../src/common/paper.cpp:134
+msgid "A2 420 x 594 mm"
+msgstr "A2 420 x 594 mm"
+
+#: ../src/common/paper.cpp:135
+msgid "A3 Transverse 297 x 420 mm"
+msgstr "A3 Transverse 297 x 420 mm"
+
+#: ../src/common/paper.cpp:136
+msgid "A3 Extra Transverse 322 x 445 mm"
+msgstr "A3 Ekstra Transverse 322 x 445 mm"
+
+#: ../src/common/paper.cpp:138
+msgid "Japanese Double Postcard 200 x 148 mm"
+msgstr "Japanese Double Postcard 200 x 148 mm"
+
+#: ../src/common/paper.cpp:139
+msgid "A6 105 x 148 mm"
+msgstr "A6 105 x 148 mm"
+
+#: ../src/common/paper.cpp:140
+msgid "Japanese Envelope Kaku #2"
+msgstr "Japanese Envelope Kaku #2"
+
+#: ../src/common/paper.cpp:141
+msgid "Japanese Envelope Kaku #3"
+msgstr "Japanese Envelope Kaku #3"
+
+#: ../src/common/paper.cpp:142
+msgid "Japanese Envelope Chou #3"
+msgstr "Japanese Envelope Chou #3"
+
+#: ../src/common/paper.cpp:143
+msgid "Japanese Envelope Chou #4"
+msgstr "Japanese Envelope Chou #4"
+
+#: ../src/common/paper.cpp:144
+msgid "Letter Rotated 11 x 8 1/2 in"
+msgstr "Letter Rotated 11 x 8 1/2 in"
+
+#: ../src/common/paper.cpp:145
+msgid "A3 Rotated 420 x 297 mm"
+msgstr "A3 Diputar 420 x 297 mm"
+
+#: ../src/common/paper.cpp:146
+msgid "A4 Rotated 297 x 210 mm"
+msgstr "A4 Diputar 297 x 210 mm"
+
+#: ../src/common/paper.cpp:147
+msgid "A5 Rotated 210 x 148 mm"
+msgstr "A5 Diputar 210 x 148 mm"
+
+#: ../src/common/paper.cpp:148
+msgid "B4 (JIS) Rotated 364 x 257 mm"
+msgstr "B4 (JIS) Diputar 364 x 257 mm"
+
+#: ../src/common/paper.cpp:149
+msgid "B5 (JIS) Rotated 257 x 182 mm"
+msgstr "B5 (JIS) Diputar 257 x 182 mm"
+
+#: ../src/common/paper.cpp:150
+msgid "Japanese Postcard Rotated 148 x 100 mm"
+msgstr "Japanese Postcard Rotated 148 x 100 mm"
+
+#: ../src/common/paper.cpp:151
+msgid "Double Japanese Postcard Rotated 148 x 200 mm"
+msgstr "Kartu Pos Jepang Ganda Diputar 148 x 200 mm"
+
+#: ../src/common/paper.cpp:152
+msgid "A6 Rotated 148 x 105 mm"
+msgstr "A6 Diputar 148 x 105 mm"
+
+#: ../src/common/paper.cpp:153
+msgid "Japanese Envelope Kaku #2 Rotated"
+msgstr "Japanese Envelope Kaku #2 Rotated"
+
+#: ../src/common/paper.cpp:154
+msgid "Japanese Envelope Kaku #3 Rotated"
+msgstr "Japanese Envelope Kaku #3 Rotated"
+
+#: ../src/common/paper.cpp:155
+msgid "Japanese Envelope Chou #3 Rotated"
+msgstr "Japanese Envelope Chou #3 Rotated"
+
+#: ../src/common/paper.cpp:156
+msgid "Japanese Envelope Chou #4 Rotated"
+msgstr "Japanese Envelope Chou #4 Rotated"
+
+#: ../src/common/paper.cpp:157
+msgid "B6 (JIS) 128 x 182 mm"
+msgstr "B6 (JIS) 128 x 182 mm"
+
+#: ../src/common/paper.cpp:158
+msgid "B6 (JIS) Rotated 182 x 128 mm"
+msgstr "B6 (JIS) Diputar 182 x 128 mm"
+
+#: ../src/common/paper.cpp:159
+msgid "12 x 11 in"
+msgstr "12 x 11 in"
+
+#: ../src/common/paper.cpp:160
+msgid "Japanese Envelope You #4"
+msgstr "Japanese Envelope You #4"
+
+#: ../src/common/paper.cpp:161
+msgid "Japanese Envelope You #4 Rotated"
+msgstr "Japanese Envelope You #4 Rotated"
+
+#: ../src/common/paper.cpp:162
+msgid "PRC 16K 146 x 215 mm"
+msgstr "PRC 16K 146 x 215 mm"
+
+#: ../src/common/paper.cpp:163
+msgid "PRC 32K 97 x 151 mm"
+msgstr "PRC 32K 97 x 151 mm"
+
+#: ../src/common/paper.cpp:164
+msgid "PRC 32K(Big) 97 x 151 mm"
+msgstr "PRC 32K(Big) 97 x 151 mm"
+
+#: ../src/common/paper.cpp:165
+msgid "PRC Envelope #1 102 x 165 mm"
+msgstr "PRC Envelope #1 102 x 165 mm"
+
+#: ../src/common/paper.cpp:166
+msgid "PRC Envelope #2 102 x 176 mm"
+msgstr "PRC Envelope #2 102 x 176 mm"
+
+#: ../src/common/paper.cpp:167
+msgid "PRC Envelope #3 125 x 176 mm"
+msgstr "PRC Envelope #3 125 x 176 mm"
+
+#: ../src/common/paper.cpp:168
+msgid "PRC Envelope #4 110 x 208 mm"
+msgstr "PRC Envelope #4 110 x 208 mm"
+
+#: ../src/common/paper.cpp:169
+msgid "PRC Envelope #5 110 x 220 mm"
+msgstr "PRC Envelope #5 110 x 220 mm"
+
+#: ../src/common/paper.cpp:170
+msgid "PRC Envelope #6 120 x 230 mm"
+msgstr "PRC Envelope #6 120 x 230 mm"
+
+#: ../src/common/paper.cpp:171
+msgid "PRC Envelope #7 160 x 230 mm"
+msgstr "PRC Envelope #7 160 x 230 mm"
+
+#: ../src/common/paper.cpp:172
+msgid "PRC Envelope #8 120 x 309 mm"
+msgstr "PRC Envelope #8 120 x 309 mm"
+
+#: ../src/common/paper.cpp:173
+msgid "PRC Envelope #9 229 x 324 mm"
+msgstr "PRC Envelope #9 229 x 324 mm"
+
+#: ../src/common/paper.cpp:174
+msgid "PRC Envelope #10 324 x 458 mm"
+msgstr "PRC Envelope #10 324 x 458 mm"
+
+#: ../src/common/paper.cpp:175
+msgid "PRC 16K Rotated"
+msgstr "PRC 16K Rotated"
+
+#: ../src/common/paper.cpp:176
+msgid "PRC 32K Rotated"
+msgstr "PRC 32K Rotated"
+
+#: ../src/common/paper.cpp:177
+msgid "PRC 32K(Big) Rotated"
+msgstr "PRC 32K(Big) Rotated"
+
+#: ../src/common/paper.cpp:178
+msgid "PRC Envelope #1 Rotated 165 x 102 mm"
+msgstr "PRC Envelope #1 Rotated 165 x 102 mm"
+
+#: ../src/common/paper.cpp:179
+msgid "PRC Envelope #2 Rotated 176 x 102 mm"
+msgstr "PRC Envelope #2 Rotated 176 x 102 mm"
+
+#: ../src/common/paper.cpp:180
+msgid "PRC Envelope #3 Rotated 176 x 125 mm"
+msgstr "PRC Envelope #3 Rotated 176 x 125 mm"
+
+#: ../src/common/paper.cpp:181
+msgid "PRC Envelope #4 Rotated 208 x 110 mm"
+msgstr "PRC Envelope #4 Rotated 208 x 110 mm"
+
+#: ../src/common/paper.cpp:182
+msgid "PRC Envelope #5 Rotated 220 x 110 mm"
+msgstr "PRC Envelope #5 Rotated 220 x 110 mm"
+
+#: ../src/common/paper.cpp:183
+msgid "PRC Envelope #6 Rotated 230 x 120 mm"
+msgstr "PRC Envelope #6 Rotated 230 x 120 mm"
+
+#: ../src/common/paper.cpp:184
+msgid "PRC Envelope #7 Rotated 230 x 160 mm"
+msgstr "PRC Envelope #7 Rotated 230 x 160 mm"
+
+#: ../src/common/paper.cpp:185
+msgid "PRC Envelope #8 Rotated 309 x 120 mm"
+msgstr "PRC Envelope #8 Rotated 309 x 120 mm"
+
+#: ../src/common/paper.cpp:186
+msgid "PRC Envelope #9 Rotated 324 x 229 mm"
+msgstr "PRC Envelope #9 Rotated 324 x 229 mm"
+
+#: ../src/common/paper.cpp:187
+msgid "PRC Envelope #10 Rotated 458 x 324 mm"
+msgstr "PRC Envelope #10 Rotated 458 x 324 mm"
+
+#: ../src/common/paper.cpp:192
+msgid "A0 sheet, 841 x 1189 mm"
+msgstr "Lembar A0, 841 x 1189 mm"
+
+#: ../src/common/paper.cpp:193
+msgid "A1 sheet, 594 x 841 mm"
+msgstr "Lembar A1, 594 x 841 mm"
+
+#: ../src/common/preferencescmn.cpp:37
+msgid "General"
+msgstr "Umum"
+
+#: ../src/common/preferencescmn.cpp:40
+msgid "Advanced"
+msgstr "Tingkat lanjut"
+
+#: ../src/common/prntbase.cpp:245
+msgid "Generic PostScript"
+msgstr "Postcript Generik"
+
+#: ../src/common/prntbase.cpp:259
+msgid "Ready"
+msgstr "Siap"
+
+#: ../src/common/prntbase.cpp:331
+msgid "Printing Error"
+msgstr "Galat Mencetak"
+
+#: ../src/common/prntbase.cpp:413 ../src/common/prntbase.cpp:1597
+#: ../src/generic/prntdlgg.cpp:135 ../src/generic/prntdlgg.cpp:149
+#: ../src/gtk/print.cpp:628 ../src/gtk/print.cpp:646
+msgid "Print"
+msgstr "Print"
+
+#: ../src/common/prntbase.cpp:471 ../src/generic/prntdlgg.cpp:809
+msgid "Page setup"
+msgstr "Pengaturan halaman"
+
+#: ../src/common/prntbase.cpp:525
+msgid "Please wait while printing..."
+msgstr "Mohon tunggu sedang dicetak..."
+
+#: ../src/common/prntbase.cpp:529
+msgid "Document:"
+msgstr "Dokumen:"
+
+#: ../src/common/prntbase.cpp:532
+msgid "Progress:"
+msgstr "Progres:"
+
+#: ../src/common/prntbase.cpp:533
+msgid "Preparing"
+msgstr "Mempersiapkan"
+
+#: ../src/common/prntbase.cpp:552
+#, c-format
+msgid "Printing page %d"
+msgstr "Mencetak halaman %d"
+
+#: ../src/common/prntbase.cpp:557
+#, c-format
+msgid "Printing page %d of %d"
+msgstr "Mencetak halaman %d dari %d"
+
+#: ../src/common/prntbase.cpp:560
+#, c-format
+msgid " (copy %d of %d)"
+msgstr " (salinan %d dari %d)"
+
+#: ../src/common/prntbase.cpp:1604
+msgid "First page"
+msgstr "Halaman pertama"
+
+#: ../src/common/prntbase.cpp:1609 ../src/html/helpwnd.cpp:659
+msgid "Previous page"
+msgstr "Halaman sebelumnya"
+
+#: ../src/common/prntbase.cpp:1623 ../src/html/helpwnd.cpp:660
+msgid "Next page"
+msgstr "Halaman berikut"
+
+#: ../src/common/prntbase.cpp:1628
+msgid "Last page"
+msgstr "Halaman terakhir"
+
+#: ../src/common/prntbase.cpp:1636 ../src/common/stockitem.cpp:215
+msgid "Zoom Out"
+msgstr "Perkecil"
+
+#: ../src/common/prntbase.cpp:1650 ../src/common/stockitem.cpp:214
+msgid "Zoom In"
+msgstr "Perbesar"
+
+#: ../src/common/prntbase.cpp:1656 ../src/common/stockitem.cpp:153
+#: ../src/generic/logg.cpp:553 ../src/univ/themes/win32.cpp:3752
+msgid "&Close"
+msgstr "&Tutup"
+
+#: ../src/common/prntbase.cpp:2085
+msgid "Could not start document preview."
+msgstr "Gagal memulai pratinjau dokumen."
+
+#: ../src/common/prntbase.cpp:2085 ../src/common/prntbase.cpp:2129
+#: ../src/common/prntbase.cpp:2137
+msgid "Print Preview Failure"
+msgstr "Gagal Pratinjau Pencetakan"
+
+#: ../src/common/prntbase.cpp:2129 ../src/common/prntbase.cpp:2137
+msgid "Sorry, not enough memory to create a preview."
+msgstr "Maaf, tidak cukup memori untuk membuat pratinjau."
+
+#: ../src/common/prntbase.cpp:2144
+#, c-format
+msgid "Page %d of %d"
+msgstr "Halaman %d dari %d"
+
+#: ../src/common/prntbase.cpp:2146
+#, c-format
+msgid "Page %d"
+msgstr "Halaman %d"
+
+#: ../src/common/regex.cpp:382 ../src/html/chm.cpp:348
+msgid "unknown error"
+msgstr "galat tidak dikenal"
+
+#: ../src/common/regex.cpp:995
+#, c-format
+msgid "Invalid regular expression '%s': %s"
+msgstr "Regular expression tidak sah '%s': %s"
+
+#: ../src/common/regex.cpp:1059
+#, c-format
+msgid "Failed to find match for regular expression: %s"
+msgstr "Gagal mencari ekspresi yang cocok: %s"
+
+#: ../src/common/rendcmn.cpp:188
+#, c-format
+msgid "Renderer \"%s\" has incompatible version %d.%d and couldn't be loaded."
+msgstr ""
+"Perender \"%s\" memiliki versi yang tidak kompatibel %d.%d dan tidak dapat "
+"dimuat."
+
+#: ../src/common/secretstore.cpp:162
+msgid "Not available for this platform"
+msgstr ""
+
+#: ../src/common/secretstore.cpp:183
+#, fuzzy, c-format
+msgid "Saving password for \"%s\" failed: %s."
+msgstr "Penyimpanan password untuk “%s/%s” gagal: %s."
+
+#: ../src/common/secretstore.cpp:205
+#, fuzzy, c-format
+msgid "Reading password for \"%s\" failed: %s."
+msgstr "Membaca password untuk \"%s/%s\" gagal: %s."
+
+#: ../src/common/secretstore.cpp:228
+#, fuzzy, c-format
+msgid "Deleting password for \"%s\" failed: %s."
+msgstr "Menghapus password untuk \"%s/%s\" gagal: %s."
+
+#: ../src/common/selectdispatcher.cpp:254
+msgid "Failed to monitor I/O channels"
+msgstr "Gagal memonitor saluran I/O"
+
+#: ../src/common/sizer.cpp:3054 ../src/common/stockitem.cpp:195
+msgid "Save"
+msgstr "Simpan"
+
+#: ../src/common/sizer.cpp:3056
+msgid "Don't Save"
+msgstr "Jangan Save"
+
+#: ../src/common/socket.cpp:870
+msgid "Cannot initialize sockets"
+msgstr "Gagal menginisialisasi soket"
+
+#: ../src/common/stockitem.cpp:127
+#, fuzzy
+msgctxt "standard Windows menu"
+msgid "&Help"
+msgstr "&Bantuan"
+
+#: ../src/common/stockitem.cpp:144
+msgid "&About"
+msgstr "Tent&ang"
+
+#: ../src/common/stockitem.cpp:144
+msgid "About"
+msgstr "Tentang"
+
+#: ../src/common/stockitem.cpp:145
+msgid "Add"
+msgstr "Add"
+
+#: ../src/common/stockitem.cpp:146
+msgid "&Apply"
+msgstr "Ter&apkan"
+
+#: ../src/common/stockitem.cpp:146
+msgid "Apply"
+msgstr "Terapkan"
+
+#: ../src/common/stockitem.cpp:147
+msgid "&Back"
+msgstr "&Mundur"
+
+#: ../src/common/stockitem.cpp:147
+msgid "Back"
+msgstr "Back"
+
+#: ../src/common/stockitem.cpp:148
+msgid "&Bold"
+msgstr "Te&bal"
+
+#: ../src/common/stockitem.cpp:148 ../src/generic/fontdlgg.cpp:326
+#: ../src/richtext/richtextfontpage.cpp:354
+msgid "Bold"
+msgstr "Tebal"
+
+#: ../src/common/stockitem.cpp:149
+msgid "&Bottom"
+msgstr "&Bawah"
+
+#: ../src/common/stockitem.cpp:149 ../src/richtext/richtextsizepage.cpp:287
+msgid "Bottom"
+msgstr "Bawah"
+
+#: ../src/common/stockitem.cpp:150 ../src/generic/fontdlgg.cpp:462
+#: ../src/generic/fontdlgg.cpp:481 ../src/generic/wizard.cpp:415
+msgid "&Cancel"
+msgstr "&Batal"
+
+#: ../src/common/stockitem.cpp:151
+#, fuzzy
+msgid "&CD-ROM"
+msgstr "&CD-Rom"
+
+#: ../src/common/stockitem.cpp:151
+#, fuzzy
+msgid "CD-ROM"
+msgstr "CD-Rom"
+
+#: ../src/common/stockitem.cpp:152
+msgid "&Clear"
+msgstr "&Bersihkan"
+
+#: ../src/common/stockitem.cpp:152
+msgid "Clear"
+msgstr "Clear"
+
+#: ../src/common/stockitem.cpp:153 ../src/generic/dbgrptg.cpp:93
+#: ../src/generic/progdlgg.cpp:778 ../src/html/helpdlg.cpp:86
+#: ../src/msw/progdlg.cpp:209 ../src/msw/progdlg.cpp:890
+#: ../src/richtext/richtextstyledlg.cpp:272
+#: ../src/richtext/richtextsymboldlg.cpp:448
+msgid "Close"
+msgstr "Tutup"
+
+#: ../src/common/stockitem.cpp:154
+msgid "&Convert"
+msgstr "&Ubah"
+
+#: ../src/common/stockitem.cpp:154
+msgid "Convert"
+msgstr "Ubah"
+
+#: ../src/common/stockitem.cpp:155 ../src/msw/textctrl.cpp:2884
+#: ../src/osx/textctrl_osx.cpp:653 ../src/richtext/richtextctrl.cpp:331
+msgid "&Copy"
+msgstr "&Salin"
+
+#: ../src/common/stockitem.cpp:155 ../src/stc/stc_i18n.cpp:18
+msgid "Copy"
+msgstr "Salin"
+
+#: ../src/common/stockitem.cpp:156 ../src/msw/textctrl.cpp:2883
+#: ../src/osx/textctrl_osx.cpp:652 ../src/richtext/richtextctrl.cpp:330
+msgid "Cu&t"
+msgstr "Po&tong"
+
+#: ../src/common/stockitem.cpp:156 ../src/stc/stc_i18n.cpp:17
+msgid "Cut"
+msgstr "Potong"
+
+#: ../src/common/stockitem.cpp:157 ../src/msw/textctrl.cpp:2886
+#: ../src/osx/textctrl_osx.cpp:655 ../src/richtext/richtextctrl.cpp:333
+#: ../src/richtext/richtexttabspage.cpp:137
+msgid "&Delete"
+msgstr "&Hapus"
+
+#: ../src/common/stockitem.cpp:157 ../src/richtext/richtextbuffer.cpp:8266
+#: ../src/stc/stc_i18n.cpp:20
+msgid "Delete"
+msgstr "Delete"
+
+#: ../src/common/stockitem.cpp:158
+msgid "&Down"
+msgstr "&Turun"
+
+#: ../src/common/stockitem.cpp:158 ../src/generic/fdrepdlg.cpp:148
+msgid "Down"
+msgstr "Down"
+
+#: ../src/common/stockitem.cpp:159
+msgid "&Edit"
+msgstr "&Sunting"
+
+#: ../src/common/stockitem.cpp:159
+msgid "Edit"
+msgstr "Sunting"
+
+#: ../src/common/stockitem.cpp:160
+msgid "&Execute"
+msgstr "&Jalankan"
+
+#: ../src/common/stockitem.cpp:160
+msgid "Execute"
+msgstr "Execute"
+
+#: ../src/common/stockitem.cpp:161
+msgid "&Quit"
+msgstr "&Keluar"
+
+#: ../src/common/stockitem.cpp:161
+msgid "Quit"
+msgstr "Keluar"
+
+#: ../src/common/stockitem.cpp:162
+msgid "&File"
+msgstr "&Berkas"
+
+#: ../src/common/stockitem.cpp:162
+msgid "File"
+msgstr "Berkas"
+
+#: ../src/common/stockitem.cpp:163
+#, fuzzy
+msgid "&Find..."
+msgstr "&Temukan"
+
+#: ../src/common/stockitem.cpp:163
+#, fuzzy
+msgid "Find..."
+msgstr "Temukan"
+
+#: ../src/common/stockitem.cpp:164
+msgid "&First"
+msgstr "&Pertama"
+
+#: ../src/common/stockitem.cpp:164
+msgid "First"
+msgstr "Pertama"
+
+#: ../src/common/stockitem.cpp:165
+msgid "&Floppy"
+msgstr "&Floppy"
+
+#: ../src/common/stockitem.cpp:165
+msgid "Floppy"
+msgstr "Floppy"
+
+#: ../src/common/stockitem.cpp:166
+msgid "&Forward"
+msgstr "&Maju"
+
+#: ../src/common/stockitem.cpp:166
+msgid "Forward"
+msgstr "Maju"
+
+#: ../src/common/stockitem.cpp:167
+msgid "&Harddisk"
+msgstr "&Harddisk"
+
+#: ../src/common/stockitem.cpp:167
+msgid "Harddisk"
+msgstr "Harddisk"
+
+#: ../src/common/stockitem.cpp:168 ../src/generic/wizard.cpp:418
+#: ../src/osx/cocoa/menu.mm:225 ../src/richtext/richtextstyledlg.cpp:298
+#: ../src/richtext/richtextsymboldlg.cpp:451
+msgid "&Help"
+msgstr "&Bantuan"
+
+#: ../src/common/stockitem.cpp:169
+msgid "&Home"
+msgstr "&Home"
+
+#: ../src/common/stockitem.cpp:169
+msgid "Home"
+msgstr "Home"
+
+#: ../src/common/stockitem.cpp:170
+msgid "Indent"
+msgstr "Inden"
+
+#: ../src/common/stockitem.cpp:171
+msgid "&Index"
+msgstr "&Indeks"
+
+#: ../src/common/stockitem.cpp:171 ../src/html/helpwnd.cpp:510
+msgid "Index"
+msgstr "Indeks"
+
+#: ../src/common/stockitem.cpp:172
+msgid "&Info"
+msgstr "&Info"
+
+#: ../src/common/stockitem.cpp:172
+msgid "Info"
+msgstr "Info"
+
+#: ../src/common/stockitem.cpp:173
+msgid "&Italic"
+msgstr "&Miring"
+
+#: ../src/common/stockitem.cpp:173 ../src/generic/fontdlgg.cpp:322
+#: ../src/richtext/richtextfontpage.cpp:350
+msgid "Italic"
+msgstr "Miring"
+
+#: ../src/common/stockitem.cpp:174
+msgid "&Jump to"
+msgstr "&Lompat ke"
+
+#: ../src/common/stockitem.cpp:174
+msgid "Jump to"
+msgstr "Lompat ke"
+
+#: ../src/common/stockitem.cpp:175
+msgid "Centered"
+msgstr "Tengah"
+
+#: ../src/common/stockitem.cpp:176
+msgid "Justified"
+msgstr "Rata kanan kiri"
+
+#: ../src/common/stockitem.cpp:177
+msgid "Align Left"
+msgstr "Rata Kiri"
+
+#: ../src/common/stockitem.cpp:178
+msgid "Align Right"
+msgstr "Rata Kanan"
+
+#: ../src/common/stockitem.cpp:179
+msgid "&Last"
+msgstr "Terak&hir"
+
+#: ../src/common/stockitem.cpp:179
+msgid "Last"
+msgstr "Terakhir"
+
+#: ../src/common/stockitem.cpp:180
+msgid "&Network"
+msgstr "&Jaringan"
+
+#: ../src/common/stockitem.cpp:180
+msgid "Network"
+msgstr "Jaringan"
+
+#: ../src/common/stockitem.cpp:181 ../src/richtext/richtexttabspage.cpp:131
+msgid "&New"
+msgstr "&Baru"
+
+#: ../src/common/stockitem.cpp:181
+msgid "New"
+msgstr "Baru"
+
+#: ../src/common/stockitem.cpp:182 ../src/msw/msgdlg.cpp:417
+msgid "&No"
+msgstr "&Tidak"
+
+#: ../src/common/stockitem.cpp:183 ../src/generic/fontdlgg.cpp:467
+#: ../src/generic/fontdlgg.cpp:474
+msgid "&OK"
+msgstr "&OK"
+
+#: ../src/common/stockitem.cpp:184 ../src/generic/dbgrptg.cpp:341
+msgid "&Open..."
+msgstr "&Buka..."
+
+#: ../src/common/stockitem.cpp:184
+msgid "Open..."
+msgstr "Buka..."
+
+#: ../src/common/stockitem.cpp:185 ../src/msw/textctrl.cpp:2885
+#: ../src/osx/textctrl_osx.cpp:654 ../src/richtext/richtextctrl.cpp:332
+msgid "&Paste"
+msgstr "&Tempel"
+
+#: ../src/common/stockitem.cpp:185 ../src/richtext/richtextctrl.cpp:3484
+#: ../src/stc/stc_i18n.cpp:19
+msgid "Paste"
+msgstr "Tempel"
+
+#: ../src/common/stockitem.cpp:186
+msgid "&Preferences"
+msgstr "&Preferensi"
+
+#: ../src/common/stockitem.cpp:186 ../src/osx/cocoa/preferences.mm:304
+msgid "Preferences"
+msgstr "Preferensi"
+
+#: ../src/common/stockitem.cpp:187
+msgid "Print previe&w..."
+msgstr "Prat&injau cetakan..."
+
+#: ../src/common/stockitem.cpp:187
+msgid "Print preview..."
+msgstr "Pratinjau cetakan..."
+
+#: ../src/common/stockitem.cpp:188
+msgid "&Print..."
+msgstr "&Cetak..."
+
+#: ../src/common/stockitem.cpp:188
+msgid "Print..."
+msgstr "Cetak..."
+
+#: ../src/common/stockitem.cpp:189 ../src/richtext/richtextctrl.cpp:337
+#: ../src/richtext/richtextctrl.cpp:5479
+msgid "&Properties"
+msgstr "&Properti"
+
+#: ../src/common/stockitem.cpp:189
+msgid "Properties"
+msgstr "Properti"
+
+#: ../src/common/stockitem.cpp:190 ../src/stc/stc_i18n.cpp:16
+msgid "Redo"
+msgstr "Ulangi"
+
+#: ../src/common/stockitem.cpp:191
+msgid "Refresh"
+msgstr "Refresh"
+
+#: ../src/common/stockitem.cpp:192
+msgid "Remove"
+msgstr "Hapus"
+
+#: ../src/common/stockitem.cpp:193
+#, fuzzy
+msgid "Rep&lace..."
+msgstr "Tim&pa"
+
+#: ../src/common/stockitem.cpp:193
+#, fuzzy
+msgid "Replace..."
+msgstr "Timpa"
+
+#: ../src/common/stockitem.cpp:194
+msgid "Revert to Saved"
+msgstr "Kembali ke yang tersimpan"
+
+#: ../src/common/stockitem.cpp:196 ../src/generic/logg.cpp:549
+msgid "Save &As..."
+msgstr "Simpan Seb&agai..."
+
+#: ../src/common/stockitem.cpp:196
+#, fuzzy
+msgid "Save As..."
+msgstr "Simpan Seb&agai..."
+
+#: ../src/common/stockitem.cpp:197 ../src/msw/textctrl.cpp:2888
+#: ../src/osx/textctrl_osx.cpp:657 ../src/richtext/richtextctrl.cpp:335
+msgid "Select &All"
+msgstr "Pilih Semu&a"
+
+#: ../src/common/stockitem.cpp:197 ../src/stc/stc_i18n.cpp:21
+msgid "Select All"
+msgstr "Pilih Semua"
+
+#: ../src/common/stockitem.cpp:198
+msgid "&Color"
+msgstr "&Warna"
+
+#: ../src/common/stockitem.cpp:198
+msgid "Color"
+msgstr "Warna"
+
+#: ../src/common/stockitem.cpp:199
+msgid "&Font"
+msgstr "&Font"
+
+#: ../src/common/stockitem.cpp:199 ../src/richtext/richtextformatdlg.cpp:336
+msgid "Font"
+msgstr "Font"
+
+#: ../src/common/stockitem.cpp:200
+msgid "&Ascending"
+msgstr "Urut N&aik"
+
+#: ../src/common/stockitem.cpp:200
+msgid "Ascending"
+msgstr "Urut naik"
+
+#: ../src/common/stockitem.cpp:201
+msgid "&Descending"
+msgstr "Urut &Turun"
+
+#: ../src/common/stockitem.cpp:201
+msgid "Descending"
+msgstr "Urut turun"
+
+#: ../src/common/stockitem.cpp:202
+msgid "&Spell Check"
+msgstr "Perik&sa Ejaan"
+
+#: ../src/common/stockitem.cpp:202
+msgid "Spell Check"
+msgstr "Periksa Ejaan"
+
+#: ../src/common/stockitem.cpp:203
+msgid "&Stop"
+msgstr "&Stop"
+
+#: ../src/common/stockitem.cpp:203
+msgid "Stop"
+msgstr "Stop"
+
+#: ../src/common/stockitem.cpp:204 ../src/richtext/richtextfontpage.cpp:274
+msgid "&Strikethrough"
+msgstr "&Coret"
+
+#: ../src/common/stockitem.cpp:204
+msgid "Strikethrough"
+msgstr "Teks coret"
+
+#: ../src/common/stockitem.cpp:205
+msgid "&Top"
+msgstr "A&tas"
+
+#: ../src/common/stockitem.cpp:205 ../src/richtext/richtextsizepage.cpp:285
+#: ../src/richtext/richtextsizepage.cpp:289
+msgid "Top"
+msgstr "Atas"
+
+#: ../src/common/stockitem.cpp:206
+msgid "Undelete"
+msgstr "Batal penghapusan"
+
+#: ../src/common/stockitem.cpp:207 ../src/generic/fontdlgg.cpp:437
+msgid "&Underline"
+msgstr "&Garisbawahi"
+
+#: ../src/common/stockitem.cpp:207
+msgid "Underline"
+msgstr "Garis bawah"
+
+#: ../src/common/stockitem.cpp:208 ../src/stc/stc_i18n.cpp:15
+msgid "Undo"
+msgstr "Urungkan"
+
+#: ../src/common/stockitem.cpp:209
+msgid "&Unindent"
+msgstr "&Unindent"
+
+#: ../src/common/stockitem.cpp:209
+msgid "Unindent"
+msgstr "Unindent"
+
+#: ../src/common/stockitem.cpp:210
+msgid "&Up"
+msgstr "&Naik"
+
+#: ../src/common/stockitem.cpp:210 ../src/generic/fdrepdlg.cpp:148
+msgid "Up"
+msgstr "Up"
+
+#: ../src/common/stockitem.cpp:211 ../src/msw/msgdlg.cpp:417
+msgid "&Yes"
+msgstr "&Ya"
+
+#: ../src/common/stockitem.cpp:212
+msgid "&Actual Size"
+msgstr "Ukuran Seben&arnya"
+
+#: ../src/common/stockitem.cpp:212
+msgid "Actual Size"
+msgstr "Ukuran Asli"
+
+#: ../src/common/stockitem.cpp:213
+msgid "Zoom to &Fit"
+msgstr "Perbesar agar &Pas"
+
+#: ../src/common/stockitem.cpp:213
+msgid "Zoom to Fit"
+msgstr "Perbesar agar Pas"
+
+#: ../src/common/stockitem.cpp:214
+msgid "Zoom &In"
+msgstr "Per&besar"
+
+#: ../src/common/stockitem.cpp:215
+msgid "Zoom &Out"
+msgstr "Per&kecil"
+
+#: ../src/common/stockitem.cpp:262
+msgid "Show about dialog"
+msgstr "Tampilkan dialog tentang"
+
+#: ../src/common/stockitem.cpp:263
+msgid "Copy selection"
+msgstr "Salin seleksi"
+
+#: ../src/common/stockitem.cpp:264
+msgid "Cut selection"
+msgstr "Potong seleksi"
+
+#: ../src/common/stockitem.cpp:265
+msgid "Delete selection"
+msgstr "Hapus seleksi"
+
+#: ../src/common/stockitem.cpp:266
+#, fuzzy
+msgid "Find in document"
+msgstr "Buka dokumen HTML"
+
+#: ../src/common/stockitem.cpp:267
+msgid "Find and replace in document"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:268
+msgid "Paste selection"
+msgstr "Tempel seleksi"
+
+#: ../src/common/stockitem.cpp:269
+msgid "Quit this program"
+msgstr "Keluar dari program ini"
+
+#: ../src/common/stockitem.cpp:270
+msgid "Redo last action"
+msgstr "Ulangi aksi terakhir"
+
+#: ../src/common/stockitem.cpp:271
+msgid "Undo last action"
+msgstr "Urungkan aksi terakhir"
+
+#: ../src/common/stockitem.cpp:272
+#, fuzzy
+msgid "Create new document"
+msgstr "Buat direktori baru"
+
+#: ../src/common/stockitem.cpp:273
+#, fuzzy
+msgid "Open an existing document"
+msgstr "Buka dokumen HTML"
+
+#: ../src/common/stockitem.cpp:274
+msgid "Close current document"
+msgstr "Tutup dokumen saat ini"
+
+#: ../src/common/stockitem.cpp:275
+msgid "Save current document"
+msgstr "Simpan dokumen ini"
+
+#: ../src/common/stockitem.cpp:276
+msgid "Save current document with a different filename"
+msgstr "Simpan dokumen ini dengan nama berkas berbeda"
+
+#: ../src/common/strconv.cpp:2324
+#, c-format
+msgid "Conversion to charset '%s' doesn't work."
+msgstr "Konversi ke charset '%s' tidak dimungkinkan."
+
+#: ../src/common/tarstrm.cpp:352 ../src/common/tarstrm.cpp:375
+#: ../src/common/tarstrm.cpp:406 ../src/generic/progdlgg.cpp:373
+msgid "unknown"
+msgstr "tidak dikenal"
+
+#: ../src/common/tarstrm.cpp:774
+msgid "incomplete header block in tar"
+msgstr "galat berkas tar"
+
+#: ../src/common/tarstrm.cpp:798
+msgid "checksum failure reading tar header block"
+msgstr "gagal checksum berkas tar"
+
+#: ../src/common/tarstrm.cpp:971
+msgid "invalid data in extended tar header"
+msgstr "data tidak valid pada header tar yang diperluas"
+
+#: ../src/common/tarstrm.cpp:981 ../src/common/tarstrm.cpp:1003
+#: ../src/common/tarstrm.cpp:1477 ../src/common/tarstrm.cpp:1499
+msgid "tar entry not open"
+msgstr "entri tar tidak terbuka"
+
+#: ../src/common/tarstrm.cpp:1023
+msgid "unexpected end of file"
+msgstr "akhir berkas yang tak diharapkan"
+
+#: ../src/common/tarstrm.cpp:1297
+#, c-format
+msgid "%s did not fit the tar header for entry '%s'"
+msgstr "%s tidak pas dengan header tar untuk entri '%s'"
+
+#: ../src/common/tarstrm.cpp:1359
+msgid "incorrect size given for tar entry"
+msgstr "salah ukuran pada isian tar"
+
+#: ../src/common/textbuf.cpp:232
+#, c-format
+msgid "'%s' is probably a binary buffer."
+msgstr "'%s' kemungkinan suatu penyangga biner."
+
+#: ../src/common/textcmn.cpp:1006 ../src/richtext/richtextctrl.cpp:3053
+msgid "File couldn't be loaded."
+msgstr "Berkas tidak bisa dimuat."
+
+#: ../src/common/textfile.cpp:95
+#, fuzzy, c-format
+msgid "Failed to read text file \"%s\"."
+msgstr "Gagal untuk membaca dokumen dari berkas \"%s\"."
+
+#: ../src/common/textfile.cpp:160
+#, c-format
+msgid "can't write buffer '%s' to disk."
+msgstr "gagal menulis buffer '%s' ke disk."
+
+#: ../src/common/time.cpp:212
+msgid "Failed to get the local system time"
+msgstr "Gagal memperoleh waktu lokal sistem"
+
+#: ../src/common/time.cpp:279
+msgid "wxGetTimeOfDay failed."
+msgstr "wxGetTimeOfDay gagal."
+
+#: ../src/common/translation.cpp:929
+#, c-format
+msgid "'%s' is not a valid message catalog."
+msgstr "'%s' bukan suatu katalog pesan yang sah."
+
+#: ../src/common/translation.cpp:954
+msgid "Invalid message catalog."
+msgstr "Kesalahan katalog pesan."
+
+#: ../src/common/translation.cpp:1013
+#, c-format
+msgid "Failed to parse Plural-Forms: '%s'"
+msgstr "Gagal mengurai Plural-Forms: '%s'"
+
+#: ../src/common/translation.cpp:1723
+#, c-format
+msgid "using catalog '%s' from '%s'."
+msgstr "menggunakan katalog '%s' dari '%s'."
+
+#: ../src/common/translation.cpp:1816
+#, c-format
+msgid "Resource '%s' is not a valid message catalog."
+msgstr "Sumber '%s' bukan pesan katalog yang valid."
+
+#: ../src/common/translation.cpp:1865
+msgid "Couldn't enumerate translations"
+msgstr "Gagal menghitung terjemahan"
+
+#: ../src/common/utilscmn.cpp:1145
+msgid "No default application configured for HTML files."
+msgstr "Aplikasi standar untuk membuka berkas HTML tidak tersedia."
+
+#: ../src/common/utilscmn.cpp:1190
+#, c-format
+msgid "Failed to open URL \"%s\" in default browser."
+msgstr "Gagal membuka URL \"%s\" pada browser."
+
+#: ../src/common/valtext.cpp:144
+msgid "Validation conflict"
+msgstr "Konflik validasi"
+
+#: ../src/common/valtext.cpp:186
+msgid "Required information entry is empty."
+msgstr "Entri informasi yang dibutuhkan kosong."
+
+#: ../src/common/valtext.cpp:188
+#, c-format
+msgid "'%s' is one of the invalid strings"
+msgstr "'%s' merupakan string tidak sah"
+
+#: ../src/common/valtext.cpp:190
+#, c-format
+msgid "'%s' is not one of the valid strings"
+msgstr "'%s' bukan merupakan string yang sah"
+
+#: ../src/common/valtext.cpp:199
+#, fuzzy, c-format
+msgid "'%s' contains invalid character(s)"
+msgstr "'%s' mengandung karakter ilegal"
+
+#: ../src/common/webrequest.cpp:139
+#, fuzzy, c-format
+msgid "Error: %s (%d)"
+msgstr "Kesalahan: "
+
+#: ../src/common/webrequest.cpp:655
+#, c-format
+msgid ""
+"Not enough free disk space for download: %llu needed but only %llu available."
+msgstr ""
+
+#: ../src/common/webrequest.cpp:669
+#, fuzzy, c-format
+msgid "Failed to create temporary file in %s"
+msgstr "Gagal menciptakan suatu nama file sementara"
+
+#: ../src/common/webrequest_curl.cpp:1106
+#, fuzzy
+msgid "libcurl could not be initialized"
+msgstr "Deskripsi kolom tidak dapat diinisialisasi."
+
+#: ../src/common/webview.cpp:392
+msgid "RunScriptAsync not supported"
+msgstr ""
+
+#: ../src/common/webview.cpp:403 ../src/msw/webview_ie.cpp:1073
+#, c-format
+msgid "Error running JavaScript: %s"
+msgstr ""
+
+#: ../src/common/webview_chromium.cpp:858
+#, fuzzy, c-format
+msgid "Failed to set proxy \"%s\": %s"
+msgstr "Gagal membuat direktori \"%s\""
+
+#: ../src/common/webview_chromium.cpp:989
+msgid ""
+"Chromium can't be used because libcef.so wasn't loaded early enough; please "
+"relink the application or use LD_PRELOAD to load it earlier."
+msgstr ""
+
+#: ../src/common/webview_chromium.cpp:1108
+#, fuzzy
+msgid "Could not initialize Chromium"
+msgstr "Gagal menginisialisasi libnotify."
+
+#: ../src/common/webview_chromium.cpp:1616
+msgid "Show DevTools"
+msgstr ""
+
+#: ../src/common/webview_chromium.cpp:1617
+#, fuzzy
+msgid "Close DevTools"
+msgstr "Tutup Semua"
+
+#: ../src/common/webview_chromium.cpp:1623
+msgid "Inspect"
+msgstr ""
+
+#: ../src/common/wincmn.cpp:1628
+msgid "This platform does not support background transparency."
+msgstr "Platform ini tidak mendukung transparansi background."
+
+#: ../src/common/wincmn.cpp:2097
+msgid "Could not transfer data to window"
+msgstr "Gagal mentransfer data ke jendela"
+
+#: ../src/common/windowid.cpp:240
+msgid "Out of window IDs.  Recommend shutting down application."
+msgstr "Kehabisan window ID. Mohon segera matikan aplikasi."
+
+#: ../src/common/xpmdecod.cpp:678
+msgid "XPM: incorrect header format!"
+msgstr "XPM: format header salah!"
+
+#: ../src/common/xpmdecod.cpp:703
+#, c-format
+msgid "XPM: incorrect colour description in line %d"
+msgstr "XPM: deskripsi warna salah pada baris %d"
+
+#: ../src/common/xpmdecod.cpp:715 ../src/common/xpmdecod.cpp:724
+#, c-format
+msgid "XPM: malformed colour definition '%s' at line %d!"
+msgstr "XPM: definisi warna cacat '%s' pada baris %d!"
+
+#: ../src/common/xpmdecod.cpp:754
+msgid "XPM: no colors left to use for mask!"
+msgstr "XPM: tidak ada sisa warna untuk mask!"
+
+#: ../src/common/xpmdecod.cpp:781
+#, c-format
+msgid "XPM: truncated image data at line %d!"
+msgstr "XPM: citra terpotong pada baris %d!"
+
+#: ../src/common/xpmdecod.cpp:795
+msgid "XPM: Malformed pixel data!"
+msgstr "XPM: Data pixel salah bentuk!"
+
+#: ../src/common/xti.cpp:492
+msgid "Illegal Parameter Count for Create Method"
+msgstr "Parameter Ilegal untuk moteode Create"
+
+#: ../src/common/xti.cpp:504
+msgid "Illegal Parameter Count for ConstructObject Method"
+msgstr "Parameter Ilegal untuk metode ConstructObject"
+
+#: ../src/common/xtistrm.cpp:161
+#, c-format
+msgid "Create Parameter %s not found in declared RTTI Parameters"
+msgstr "Membuat Parameter %s tidak dideklarasikan di RTTI Parameter"
+
+#: ../src/common/xtistrm.cpp:290
+msgid "Illegal Object Class (Non-wxEvtHandler) as Event Source"
+msgstr "Kelas Obyek Ilegal (Non-wxEvtHandler) sebagai Event Source"
+
+#: ../src/common/xtistrm.cpp:313 ../src/common/xtixml.cpp:345
+#: ../src/common/xtixml.cpp:498
+msgid "Type must have enum - long conversion"
+msgstr "Tipe harus memiliki konversi enum - long"
+
+#: ../src/common/xtistrm.cpp:400 ../src/common/xtistrm.cpp:415
+msgid "Invalid or Null Object ID passed to GetObjectClassInfo"
+msgstr "Tidak valid atau Null Object ID disampaikan ke HasObjectClassInfo"
+
+#: ../src/common/xtistrm.cpp:405
+msgid "Unknown Object passed to GetObjectClassInfo"
+msgstr "Obyek tidak dikenal disampaikan ke GetObjectClassInfo"
+
+#: ../src/common/xtistrm.cpp:420
+msgid "Already Registered Object passed to SetObjectClassInfo"
+msgstr "Obyek Yang Sudah Terdaftar disampaikan ke SetObjectClassInfo"
+
+#: ../src/common/xtistrm.cpp:430
+msgid "Invalid or Null Object ID passed to HasObjectClassInfo"
+msgstr "Tidak valid atau Null Object ID disampaikan ke HasObjectClassInfo"
+
+#: ../src/common/xtistrm.cpp:460
+msgid "Passing a already registered object to SetObject"
+msgstr "Menyampaikan obyek sudah teregister ke SetObject"
+
+#: ../src/common/xtistrm.cpp:471
+msgid "Passing an unknown object to GetObject"
+msgstr "Menyampaikan obyek tidak dikenal ke GetObject"
+
+#: ../src/common/xtixml.cpp:229
+msgid "Forward hrefs are not supported"
+msgstr "Forward hrefs tidak didukung"
+
+#: ../src/common/xtixml.cpp:247
+#, c-format
+msgid "unknown class %s"
+msgstr "kelas %s tidak dikenal"
+
+#: ../src/common/xtixml.cpp:253
+msgid "objects cannot have XML Text Nodes"
+msgstr "obyek tidak boleh mengandung node teks XML"
+
+#: ../src/common/xtixml.cpp:258
+msgid "Objects must have an id attribute"
+msgstr "Obyek harus memiliki atribut id"
+
+#: ../src/common/xtixml.cpp:267
+#, c-format
+msgid "Doubly used id : %d"
+msgstr "User id ganda : %d"
+
+#: ../src/common/xtixml.cpp:316
+#, c-format
+msgid "Unknown Property %s"
+msgstr "Properti %s tidak dikenal"
+
+#: ../src/common/xtixml.cpp:407
+msgid "A non empty collection must consist of 'element' nodes"
+msgstr "Suatu koleksi tak kosong mesti terdiri dari node 'elemen'"
+
+#: ../src/common/xtixml.cpp:478
+msgid "incorrect event handler string, missing dot"
+msgstr "string event handler salah, kurang titik"
+
+#: ../src/common/zipstrm.cpp:559
+msgid "can't re-initialize zlib deflate stream"
+msgstr "gagal menyiapkan zlib deflate stream"
+
+#: ../src/common/zipstrm.cpp:584
+msgid "can't re-initialize zlib inflate stream"
+msgstr "gagal menyiapkan zlib inflate stream"
+
+#: ../src/common/zipstrm.cpp:1023
+msgid "Ignoring malformed extra data record, ZIP file may be corrupted"
+msgstr ""
+
+#: ../src/common/zipstrm.cpp:1502
+msgid "assuming this is a multi-part zip concatenated"
+msgstr "mengasumsikan ini adalah berbagai berkas zip yang disambung"
+
+#: ../src/common/zipstrm.cpp:1664
+msgid "invalid zip file"
+msgstr "berkas zip tidak valid"
+
+#: ../src/common/zipstrm.cpp:1723
+msgid "can't find central directory in zip"
+msgstr "gagal menemukan sentral direktori pada zip"
+
+#: ../src/common/zipstrm.cpp:1812
+msgid "error reading zip central directory"
+msgstr "galat membaca sentral direktori zip"
+
+#: ../src/common/zipstrm.cpp:1916
+msgid "error reading zip local header"
+msgstr "galat membaca berkas zip"
+
+#: ../src/common/zipstrm.cpp:1964
+msgid "bad zipfile offset to entry"
+msgstr "salah offset di berkas zip terhadap entri"
+
+#: ../src/common/zipstrm.cpp:2031
+msgid "stored file length not in Zip header"
+msgstr "stored file length not in Zip header"
+
+#: ../src/common/zipstrm.cpp:2045 ../src/common/zipstrm.cpp:2362
+msgid "unsupported Zip compression method"
+msgstr "metode kompresi zip tidak didukung"
+
+#: ../src/common/zipstrm.cpp:2126
+#, c-format
+msgid "reading zip stream (entry %s): bad length"
+msgstr "membaca berkas zip (entri %s): ukuran buruk"
+
+#: ../src/common/zipstrm.cpp:2131
+#, c-format
+msgid "reading zip stream (entry %s): bad crc"
+msgstr "membaca berkas zip (entri %s): crc buruk"
+
+#: ../src/common/zipstrm.cpp:2578
+#, fuzzy, c-format
+msgid "error writing zip entry '%s': file too large without ZIP64"
+msgstr "galat membuat berkas zip '%s': crc rusak"
+
+#: ../src/common/zipstrm.cpp:2585
+#, c-format
+msgid "error writing zip entry '%s': bad crc or length"
+msgstr "galat membuat berkas zip '%s': crc rusak"
+
+#: ../src/common/zstream.cpp:155 ../src/common/zstream.cpp:315
+msgid "Gzip not supported by this version of zlib"
+msgstr "Gzip tidak didukung oleh versi zlib ini"
+
+#: ../src/common/zstream.cpp:182
+msgid "Can't initialize zlib inflate stream."
+msgstr "Gagal menginisialisasi stream inflate zlib."
+
+#: ../src/common/zstream.cpp:241
+msgid "Can't read inflate stream: unexpected EOF in underlying stream."
+msgstr ""
+"Gagal membaca stream inflate: EOF yang tak diharapkan pada stream yang "
+"mendasarinya."
+
+#: ../src/common/zstream.cpp:248 ../src/common/zstream.cpp:423
+#, c-format
+msgid "zlib error %d"
+msgstr "galat zlib %d"
+
+#: ../src/common/zstream.cpp:249
+#, c-format
+msgid "Can't read from inflate stream: %s"
+msgstr "Tak bisa membaca dari stream inflate: %s"
+
+#: ../src/common/zstream.cpp:343
+msgid "Can't initialize zlib deflate stream."
+msgstr "Gagal menginisialisasi stream deflate zlib."
+
+#: ../src/common/zstream.cpp:424
+#, c-format
+msgid "Can't write to deflate stream: %s"
+msgstr "Gagal menulis ke stream deflate: %s"
+
+#: ../src/dfb/bitmap.cpp:633 ../src/dfb/bitmap.cpp:667
+#, c-format
+msgid "No bitmap handler for type %d defined."
+msgstr "Tidak ada handler bitmap untuk tipe %d yang definisikan."
+
+#: ../src/dfb/evtloop.cpp:99
+msgid "Failed to read event from DirectFB pipe"
+msgstr "Gagal membaca event dari DirectFB pipe"
+
+#: ../src/dfb/evtloop.cpp:171
+msgid "Failed to switch DirectFB pipe to non-blocking mode"
+msgstr "Gagal mengubah DirectFB pipe ke mode non-blocking"
+
+#: ../src/dfb/fontmgr.cpp:171
+#, c-format
+msgid "no fonts found in %s, using builtin font"
+msgstr "font tidak ditemukan di %s, menggunakan font standar"
+
+#: ../src/dfb/fontmgr.cpp:177
+msgid "Default font"
+msgstr "Font standar"
+
+#: ../src/dfb/fontmgr.cpp:195
+#, c-format
+msgid "Fonts index file %s disappeared while loading fonts."
+msgstr "Berkas indeks font %s hilang ketika memuat font."
+
+#: ../src/dfb/wrapdfb.cpp:60
+#, c-format
+msgid "DirectFB error %d occurred."
+msgstr "Galat DirectFB %d terjadi."
+
+#: ../src/generic/aboutdlgg.cpp:69
+msgid "Developed by "
+msgstr "Dikembangkan oleh "
+
+#: ../src/generic/aboutdlgg.cpp:72
+msgid "Documentation by "
+msgstr "Dokumentasi oleh "
+
+#: ../src/generic/aboutdlgg.cpp:75
+msgid "Graphics art by "
+msgstr "Grafis oleh "
+
+#: ../src/generic/aboutdlgg.cpp:78
+msgid "Translations by "
+msgstr "Diterjemahkan oleh "
+
+#: ../src/generic/aboutdlgg.cpp:133 ../src/osx/cocoa/aboutdlg.mm:83
+msgid "Version "
+msgstr "Versi "
+
+#. TRANSLATORS: %s is application name
+#: ../src/generic/aboutdlgg.cpp:146 ../src/msw/aboutdlg.cpp:60
+#, c-format
+msgid "About %s"
+msgstr "Tentang %s"
+
+#: ../src/generic/aboutdlgg.cpp:181
+msgid "License"
+msgstr "Lisensi"
+
+#: ../src/generic/aboutdlgg.cpp:184
+msgid "Developers"
+msgstr "Pengembang"
+
+#: ../src/generic/aboutdlgg.cpp:188
+msgid "Documentation writers"
+msgstr "Penulis Dokumentasi"
+
+#: ../src/generic/aboutdlgg.cpp:192
+msgid "Artists"
+msgstr "Artis"
+
+#: ../src/generic/aboutdlgg.cpp:196
+msgid "Translators"
+msgstr "Penerjemah"
+
+#: ../src/generic/animateg.cpp:125
+msgid "No handler found for animation type."
+msgstr "Tidak ditemukan handler untuk tipe animasi tsb."
+
+#: ../src/generic/animateg.cpp:133
+#, c-format
+msgid "No animation handler for type %ld defined."
+msgstr "Tidak ada handler animasi ntuk tipe %ld yang definisikan."
+
+#: ../src/generic/animateg.cpp:145
+#, c-format
+msgid "Animation file is not of type %ld."
+msgstr "Berkas animasi bukan bertipe %ld."
+
+#: ../src/generic/colrdlgg.cpp:154 ../src/gtk/colordlg.cpp:47
+msgid "Choose colour"
+msgstr "Pilih warna"
+
+#: ../src/generic/colrdlgg.cpp:357
+msgid "Red:"
+msgstr "Merah:"
+
+#: ../src/generic/colrdlgg.cpp:360
+msgid "Green:"
+msgstr "Hijau:"
+
+#: ../src/generic/colrdlgg.cpp:363
+msgid "Blue:"
+msgstr "Biru:"
+
+#: ../src/generic/colrdlgg.cpp:372
+msgid "Opacity:"
+msgstr "Opacitas:"
+
+#: ../src/generic/colrdlgg.cpp:384
+msgid "Add to custom colours"
+msgstr "Tambahkan ke warna kustom"
+
+#: ../src/generic/creddlgg.cpp:56
+msgid "Username:"
+msgstr ""
+
+#: ../src/generic/creddlgg.cpp:63
+msgid "Password:"
+msgstr ""
+
+#. TRANSLATORS: Name of Boolean true value
+#: ../src/generic/datavgen.cpp:1178
+msgid "true"
+msgstr "true"
+
+#. TRANSLATORS: Name of Boolean false value
+#: ../src/generic/datavgen.cpp:1180
+msgid "false"
+msgstr "false"
+
+#: ../src/generic/datavgen.cpp:6897
+#, c-format
+msgid "Row %i"
+msgstr "Baris %i"
+
+#. TRANSLATORS: Action for manipulating a tree control
+#: ../src/generic/datavgen.cpp:6987
+msgid "Collapse"
+msgstr "Perkecil"
+
+#. TRANSLATORS: Action for manipulating a tree control
+#: ../src/generic/datavgen.cpp:6990
+msgid "Expand"
+msgstr "Perluas"
+
+#. TRANSLATORS: Name of data view control and number of rows
+#: ../src/generic/datavgen.cpp:7011
+#, c-format
+msgid "%s (%d items)"
+msgstr "%s (%d obyek)"
+
+#: ../src/generic/datavgen.cpp:7062
+#, c-format
+msgid "Column %u"
+msgstr "Kolom %u"
+
+#. TRANSLATORS: Keystroke for manipulating a tree control
+#: ../src/generic/datavgen.cpp:7131 ../src/richtext/richtextbulletspage.cpp:189
+#: ../src/richtext/richtextbulletspage.cpp:192
+#: ../src/richtext/richtextbulletspage.cpp:193
+#: ../src/richtext/richtextliststylepage.cpp:252
+#: ../src/richtext/richtextliststylepage.cpp:255
+#: ../src/richtext/richtextliststylepage.cpp:256
+#: ../src/richtext/richtextsizepage.cpp:248
+msgid "Left"
+msgstr "Kiri"
+
+#. TRANSLATORS: Keystroke for manipulating a tree control
+#: ../src/generic/datavgen.cpp:7134 ../src/richtext/richtextbulletspage.cpp:191
+#: ../src/richtext/richtextliststylepage.cpp:254
+#: ../src/richtext/richtextsizepage.cpp:249
+msgid "Right"
+msgstr "Kanan"
+
+#: ../src/generic/datectlg.cpp:90
+#, c-format
+msgid ""
+"\"%s\" is not in the expected date format, please enter it as e.g. \"%s\"."
+msgstr ""
+
+#: ../src/generic/datectlg.cpp:94
+#, fuzzy
+msgid "Invalid date"
+msgstr "Obyek data view salah"
+
+#: ../src/generic/dbgrptg.cpp:159
+#, c-format
+msgid "Open file \"%s\""
+msgstr "Buka berkas \"%s\""
+
+#: ../src/generic/dbgrptg.cpp:170
+#, c-format
+msgid "Enter command to open file \"%s\":"
+msgstr "Masukkan perintah untuk membuka file '%s':"
+
+#: ../src/generic/dbgrptg.cpp:230
+msgid "Executable files (*.exe)|*.exe|"
+msgstr "Berkas yang dapat dieksekusi (*.exe)|*.exe|"
+
+#: ../src/generic/dbgrptg.cpp:300
+#, c-format
+msgid "Debug report \"%s\""
+msgstr "Laporan debug \"%s\""
+
+#: ../src/generic/dbgrptg.cpp:316
+msgid "A debug report has been generated in the directory\n"
+msgstr "Laporan debug telah dihasilkan di dalam direktori\n"
+
+#: ../src/generic/dbgrptg.cpp:317
+msgid "The following debug report will be generated\n"
+msgstr ""
+
+#: ../src/generic/dbgrptg.cpp:321
+msgid ""
+"The report contains the files listed below. If any of these files contain "
+"private information,\n"
+"please uncheck them and they will be removed from the report.\n"
+msgstr ""
+"Laporan ini berisi berkas yang terdaftar dibawah. Jika ada berkas yang "
+"berisi informasi rahasia,\n"
+"tolong matikan centang dan berkas tersebut akan dihapus dari laporan.\n"
+
+#: ../src/generic/dbgrptg.cpp:323
+msgid ""
+"If you wish to suppress this debug report completely, please choose the "
+"\"Cancel\" button,\n"
+"but be warned that it may hinder improving the program, so if\n"
+"at all possible please do continue with the report generation.\n"
+msgstr ""
+"Jika anda ingin mendiamkan laporan debug seluruhnya, silakan pilih tombol "
+"\"Cancel\", \n"
+"tetapi hal tersebut dapat menghalangi pengembangan program, jadi jika\n"
+"memungkinkan tolong lanjutkan dengan pembuatan laporan.\n"
+
+#: ../src/generic/dbgrptg.cpp:325
+msgid "              Thank you and we're sorry for the inconvenience!\n"
+msgstr ""
+"              Terima kasih dan kami mohon maaf atas ketidaknyamanannya!\n"
+
+#: ../src/generic/dbgrptg.cpp:333
+msgid "&Debug report preview:"
+msgstr "&Pratinjau laporan debug:"
+
+#: ../src/generic/dbgrptg.cpp:339
+msgid "&View..."
+msgstr "&Tampilan."
+
+#: ../src/generic/dbgrptg.cpp:359
+msgid "&Notes:"
+msgstr "Catata&n:"
+
+#: ../src/generic/dbgrptg.cpp:361
+msgid ""
+"If you have any additional information pertaining to this bug\n"
+"report, please enter it here and it will be joined to it:"
+msgstr ""
+"Jika anda memiliki informasi tambahan mengenai laporan kekutu ini,\n"
+"tolong tuliskan disini dan info tersebut akan digabungkan:"
+
+#: ../src/generic/dcpsg.cpp:1627
+msgid "Cannot open file for PostScript printing!"
+msgstr "Gagal membuka berkas untuk pencetakan PostScript!"
+
+#: ../src/generic/dirctrlg.cpp:402
+msgid "Computer"
+msgstr "Komputer"
+
+#: ../src/generic/dirctrlg.cpp:404
+msgid "Sections"
+msgstr "Bagian"
+
+#: ../src/generic/dirctrlg.cpp:482
+msgid "Home directory"
+msgstr "Direktori rumah"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/generic/dirctrlg.cpp:484 ../src/propgrid/advprops.cpp:811
+msgid "Desktop"
+msgstr "Desktop"
+
+#: ../src/generic/dirctrlg.cpp:528 ../src/generic/filectrlg.cpp:752
+msgid "Illegal directory name."
+msgstr "Nama direktori tidak sah."
+
+#: ../src/generic/dirctrlg.cpp:528 ../src/generic/dirctrlg.cpp:546
+#: ../src/generic/dirctrlg.cpp:557 ../src/generic/dirdlgg.cpp:317
+#: ../src/generic/filectrlg.cpp:638 ../src/generic/filectrlg.cpp:752
+#: ../src/generic/filectrlg.cpp:766 ../src/generic/filectrlg.cpp:782
+#: ../src/generic/filectrlg.cpp:1356 ../src/generic/filectrlg.cpp:1387
+#: ../src/generic/filedlgg.cpp:362 ../src/gtk/filedlg.cpp:76
+msgid "Error"
+msgstr "Kesalahan"
+
+#: ../src/generic/dirctrlg.cpp:546 ../src/generic/filectrlg.cpp:766
+msgid "File name exists already."
+msgstr "Nama berkas sudah ada."
+
+#: ../src/generic/dirctrlg.cpp:557 ../src/generic/dirdlgg.cpp:317
+#: ../src/generic/filectrlg.cpp:638 ../src/generic/filectrlg.cpp:782
+msgid "Operation not permitted."
+msgstr "Operasi tidak diijinkan."
+
+#: ../src/generic/dirdlgg.cpp:107 ../src/generic/filedlgg.cpp:207
+msgid "Create new directory"
+msgstr "Buat direktori baru"
+
+#: ../src/generic/dirdlgg.cpp:112 ../src/generic/filedlgg.cpp:203
+msgid "Go to home directory"
+msgstr "Ke direktori home"
+
+#: ../src/generic/dirdlgg.cpp:143
+msgid "Show &hidden directories"
+msgstr "Tampilkan &direktor yang disembunyikan"
+
+#: ../src/generic/dirdlgg.cpp:196
+#, c-format
+msgid ""
+"The directory '%s' does not exist\n"
+"Create it now?"
+msgstr ""
+"Direktori '%s' tidak ada\n"
+"Buat sekarang?"
+
+#: ../src/generic/dirdlgg.cpp:198
+msgid "Directory does not exist"
+msgstr "Direktori tidak ada"
+
+#: ../src/generic/dirdlgg.cpp:214
+#, c-format
+msgid ""
+"Failed to create directory '%s'\n"
+"(Do you have the required permissions?)"
+msgstr ""
+"Gagal menciptakan direktori '%s'\n"
+"(Apakah anda mempunya permisi yang disyaratkan?)"
+
+#: ../src/generic/dirdlgg.cpp:216
+msgid "Error creating directory"
+msgstr "Kesalahan dalam menciptakan direktori"
+
+#: ../src/generic/dirdlgg.cpp:281
+msgid "You cannot add a new directory to this section."
+msgstr "Anda tidak dapat menambah direktori baru ke bagian ini."
+
+#: ../src/generic/dirdlgg.cpp:282
+msgid "Create directory"
+msgstr "Buat direktori"
+
+#: ../src/generic/dirdlgg.cpp:291 ../src/generic/dirdlgg.cpp:301
+#: ../src/generic/filectrlg.cpp:614 ../src/generic/filectrlg.cpp:623
+msgid "NewName"
+msgstr "NamaBaru"
+
+#: ../src/generic/editlbox.cpp:135
+msgid "Edit item"
+msgstr "Sunting butir"
+
+#: ../src/generic/editlbox.cpp:143
+msgid "New item"
+msgstr "Butir baru"
+
+#: ../src/generic/editlbox.cpp:151
+msgid "Delete item"
+msgstr "Hapus obyek"
+
+#: ../src/generic/editlbox.cpp:159
+msgid "Move up"
+msgstr "Gerakkan ke atas"
+
+#: ../src/generic/editlbox.cpp:164
+msgid "Move down"
+msgstr "Gerakkan ke bawah"
+
+#: ../src/generic/fdrepdlg.cpp:108
+msgid "Search for:"
+msgstr "Cari:"
+
+#: ../src/generic/fdrepdlg.cpp:120
+msgid "Replace with:"
+msgstr "Ganti dengan:"
+
+#: ../src/generic/fdrepdlg.cpp:140
+msgid "Whole word"
+msgstr "Seluruh kata"
+
+#: ../src/generic/fdrepdlg.cpp:143
+msgid "Match case"
+msgstr "Sesuaikan besar kecil huruf"
+
+#: ../src/generic/fdrepdlg.cpp:156
+msgid "Search direction"
+msgstr "Arah pencarian"
+
+#: ../src/generic/fdrepdlg.cpp:175
+msgid "&Replace"
+msgstr "&Ganti"
+
+#: ../src/generic/fdrepdlg.cpp:178
+msgid "Replace &all"
+msgstr "Ganti semu&a"
+
+#: ../src/generic/filectrlg.cpp:246 ../src/generic/filectrlg.cpp:269
+msgid "<DIR>"
+msgstr "<DIR>"
+
+#: ../src/generic/filectrlg.cpp:248 ../src/generic/filectrlg.cpp:271
+msgid "<LINK>"
+msgstr "<TAUT>"
+
+#: ../src/generic/filectrlg.cpp:250 ../src/generic/filectrlg.cpp:273
+msgid "<DRIVE>"
+msgstr "<DRIVE>"
+
+#: ../src/generic/filectrlg.cpp:275
+#, c-format
+msgid "%ld byte"
+msgid_plural "%ld bytes"
+msgstr[0] "%ld byte"
+
+#: ../src/generic/filectrlg.cpp:420
+msgid "Name"
+msgstr "Nama"
+
+#: ../src/generic/filectrlg.cpp:421 ../src/richtext/richtextformatdlg.cpp:361
+#: ../src/richtext/richtextsizepage.cpp:298
+msgid "Size"
+msgstr "Ukuran"
+
+#: ../src/generic/filectrlg.cpp:422
+msgid "Type"
+msgstr "Tipe"
+
+#: ../src/generic/filectrlg.cpp:423
+msgid "Modified"
+msgstr "Diubah"
+
+#: ../src/generic/filectrlg.cpp:426
+msgid "Permissions"
+msgstr "Permisi"
+
+#: ../src/generic/filectrlg.cpp:429
+msgid "Attributes"
+msgstr "Atribut"
+
+#: ../src/generic/filectrlg.cpp:936
+msgid "Current directory:"
+msgstr "Direktori saat ini:"
+
+#: ../src/generic/filectrlg.cpp:979
+msgid "Show &hidden files"
+msgstr "Tampilkan &berkas yang disembunyikan"
+
+#: ../src/generic/filectrlg.cpp:1355
+msgid "Illegal file specification."
+msgstr "Spesifikasi file tidak sah."
+
+#: ../src/generic/filectrlg.cpp:1387
+msgid "Directory doesn't exist."
+msgstr "Direktori tidak ada."
+
+#: ../src/generic/filedlgg.cpp:195
+msgid "View files as a list view"
+msgstr "Tampilkan berkas dalam tampilan daftar"
+
+#: ../src/generic/filedlgg.cpp:197
+msgid "View files as a detailed view"
+msgstr "Tampilkan berkas dalam tampilan rinci"
+
+#: ../src/generic/filedlgg.cpp:200
+msgid "Go to parent directory"
+msgstr "Ke direktori atasnya"
+
+#: ../src/generic/filedlgg.cpp:351 ../src/gtk/filedlg.cpp:59
+#, c-format
+msgid "File '%s' already exists, do you really want to overwrite it?"
+msgstr "Berkas '%s' sudah ada, apakah benar anda ingin menimpanya?"
+
+#: ../src/generic/filedlgg.cpp:354 ../src/gtk/filedlg.cpp:62
+msgid "Confirm"
+msgstr "Konfirmasi"
+
+#: ../src/generic/filedlgg.cpp:362 ../src/gtk/filedlg.cpp:75
+msgid "Please choose an existing file."
+msgstr "Silahkan pilih file yang ada."
+
+#: ../src/generic/filepickerg.cpp:64
+msgid "..."
+msgstr "..."
+
+#: ../src/generic/fontdlgg.cpp:76 ../src/richtext/richtextformatdlg.cpp:519
+msgid "ABCDEFGabcdefg12345"
+msgstr "ABCDEFGabcdefg12345"
+
+#: ../src/generic/fontdlgg.cpp:315
+msgid "Roman"
+msgstr "Roman"
+
+#: ../src/generic/fontdlgg.cpp:316
+msgid "Decorative"
+msgstr "Dekoratif"
+
+#: ../src/generic/fontdlgg.cpp:317
+msgid "Modern"
+msgstr "Modern"
+
+#: ../src/generic/fontdlgg.cpp:318
+msgid "Script"
+msgstr "Skrip"
+
+#: ../src/generic/fontdlgg.cpp:319
+msgid "Swiss"
+msgstr "Swiss"
+
+#: ../src/generic/fontdlgg.cpp:320
+msgid "Teletype"
+msgstr "Teletype"
+
+#: ../src/generic/fontdlgg.cpp:321 ../src/generic/fontdlgg.cpp:324
+msgid "Normal"
+msgstr "Normal"
+
+#: ../src/generic/fontdlgg.cpp:323
+msgid "Slant"
+msgstr "Sudut pandang"
+
+#: ../src/generic/fontdlgg.cpp:325
+msgid "Light"
+msgstr "Ringan"
+
+#: ../src/generic/fontdlgg.cpp:363
+msgid "&Font family:"
+msgstr "&Keluarga font:"
+
+#: ../src/generic/fontdlgg.cpp:367 ../src/generic/fontdlgg.cpp:369
+msgid "The font family."
+msgstr "Keluarga font."
+
+#: ../src/generic/fontdlgg.cpp:374 ../src/richtext/richtextstylepage.cpp:105
+msgid "&Style:"
+msgstr "&Gaya:"
+
+#: ../src/generic/fontdlgg.cpp:378 ../src/generic/fontdlgg.cpp:380
+msgid "The font style."
+msgstr "Gaya font."
+
+#: ../src/generic/fontdlgg.cpp:385
+msgid "&Weight:"
+msgstr "&Bobot:"
+
+#: ../src/generic/fontdlgg.cpp:389 ../src/generic/fontdlgg.cpp:391
+msgid "The font weight."
+msgstr "Berat font."
+
+#: ../src/generic/fontdlgg.cpp:399
+msgid "C&olour:"
+msgstr "W&arna:"
+
+#: ../src/generic/fontdlgg.cpp:407 ../src/generic/fontdlgg.cpp:409
+msgid "The font colour."
+msgstr "Warna font."
+
+#: ../src/generic/fontdlgg.cpp:415
+msgid "&Point size:"
+msgstr "&Ukuran titik:"
+
+#: ../src/generic/fontdlgg.cpp:420 ../src/generic/fontdlgg.cpp:422
+#: ../src/generic/fontdlgg.cpp:426 ../src/generic/fontdlgg.cpp:428
+msgid "The font point size."
+msgstr "Ukuran point font."
+
+#: ../src/generic/fontdlgg.cpp:439 ../src/generic/fontdlgg.cpp:441
+msgid "Whether the font is underlined."
+msgstr "Apakah font bergarisbawah."
+
+#: ../src/generic/fontdlgg.cpp:448 ../src/html/helpwnd.cpp:1215
+msgid "Preview:"
+msgstr "Pratinjau:"
+
+#: ../src/generic/fontdlgg.cpp:452 ../src/generic/fontdlgg.cpp:454
+msgid "Shows the font preview."
+msgstr "Tampilkan pratinjau font."
+
+#: ../src/generic/fontdlgg.cpp:464 ../src/generic/fontdlgg.cpp:483
+msgid "Click to cancel the font selection."
+msgstr "Klik untuk membatalkan font yang dipilih."
+
+#: ../src/generic/fontdlgg.cpp:469 ../src/generic/fontdlgg.cpp:471
+#: ../src/generic/fontdlgg.cpp:476 ../src/generic/fontdlgg.cpp:478
+msgid "Click to confirm the font selection."
+msgstr "Klik untuk mengkonfirmasi pemilihan font."
+
+#: ../src/generic/fontpickerg.cpp:50 ../src/gtk/fontdlg.cpp:77
+msgid "Choose font"
+msgstr "Pilih font"
+
+#: ../src/generic/grid.cpp:6542
+msgid ""
+"Error copying grid to the clipboard. Either selected cells were not "
+"contiguous or no cell was selected."
+msgstr ""
+
+#: ../src/generic/grid.cpp:12739
+#, fuzzy
+msgid "Grid Corner"
+msgstr "Pojok"
+
+#: ../src/generic/grid.cpp:12741
+#, fuzzy, c-format
+msgid "Column %s Header"
+msgstr "Kolom %u"
+
+#: ../src/generic/grid.cpp:12743
+#, c-format
+msgid "Row %s Header"
+msgstr ""
+
+#: ../src/generic/grid.cpp:12745
+#, fuzzy, c-format
+msgid "Column %s: %s"
+msgstr "Kolom %u"
+
+#: ../src/generic/grid.cpp:12749
+#, fuzzy, c-format
+msgid "Row %s: %s"
+msgstr "Baris %i"
+
+#: ../src/generic/grid.cpp:12753
+#, c-format
+msgid "Row %s, Column %s: %s"
+msgstr ""
+
+#: ../src/generic/helpext.cpp:257
+#, c-format
+msgid "Help directory \"%s\" not found."
+msgstr "Direktori bantuan \"%s\" tidak ditemukan."
+
+#: ../src/generic/helpext.cpp:265
+#, c-format
+msgid "Help file \"%s\" not found."
+msgstr "Berkas bantuan \"%s\" tidak ditemukan."
+
+#: ../src/generic/helpext.cpp:284
+#, c-format
+msgid "Line %lu of map file \"%s\" has invalid syntax, skipped."
+msgstr ""
+"Baris %lu dari berkas peta \"%s\" mempunyai sintaks yang salah, dilewati."
+
+#: ../src/generic/helpext.cpp:292
+#, c-format
+msgid "No valid mappings found in the file \"%s\"."
+msgstr "Tidak ada mapping yang sesuai di berkas ini \"%s\"."
+
+#: ../src/generic/helpext.cpp:435
+msgid "No entries found."
+msgstr "Tidak ada entri yang ditemukan."
+
+#: ../src/generic/helpext.cpp:444 ../src/generic/helpext.cpp:445
+msgid "Help Index"
+msgstr "Indeks Bantuan"
+
+#: ../src/generic/helpext.cpp:448
+msgid "Relevant entries:"
+msgstr "Entri yang relevan:"
+
+#: ../src/generic/helpext.cpp:449
+msgid "Entries found"
+msgstr "Entri ditemukan"
+
+#: ../src/generic/hyperlinkg.cpp:170
+msgid "&Copy URL"
+msgstr "&Salin URL"
+
+#: ../src/generic/infobar.cpp:119
+msgid "Hide this notification message."
+msgstr "Sembunyikan pesan pemberitahuan ini."
+
+#. TRANSLATORS: %s will be either the application name or "Application"
+#: ../src/generic/logg.cpp:257
+#, c-format
+msgid "%s Error"
+msgstr "Kesalahan %s"
+
+#. TRANSLATORS: %s will be either the application name or "Application"
+#: ../src/generic/logg.cpp:263
+#, c-format
+msgid "%s Warning"
+msgstr "Peringatan %s"
+
+#. TRANSLATORS: %s will be either the application name or "Application"
+#: ../src/generic/logg.cpp:273
+#, c-format
+msgid "%s Information"
+msgstr "Informasi %s"
+
+#: ../src/generic/logg.cpp:276
+msgid "Application"
+msgstr "Aplikasi"
+
+#: ../src/generic/logg.cpp:549
+msgid "Save log contents to file"
+msgstr "Simpan isi log ke berkas"
+
+#: ../src/generic/logg.cpp:551
+msgid "C&lear"
+msgstr "B&ersihkan"
+
+#: ../src/generic/logg.cpp:551
+msgid "Clear the log contents"
+msgstr "Bersihkan isi log"
+
+#: ../src/generic/logg.cpp:553
+msgid "Close this window"
+msgstr "Tutup jendela ini"
+
+#: ../src/generic/logg.cpp:554
+msgid "&Log"
+msgstr "&Log"
+
+#: ../src/generic/logg.cpp:610 ../src/generic/logg.cpp:992
+msgid "Can't save log contents to file."
+msgstr "Gagal menyimpan isi log ke berkas."
+
+#: ../src/generic/logg.cpp:613
+#, c-format
+msgid "Log saved to the file '%s'."
+msgstr "Log disimpan ke berkas '%s'."
+
+#: ../src/generic/logg.cpp:719
+msgid "&Details"
+msgstr "&Rinci"
+
+#: ../src/generic/logg.cpp:972
+msgid "Failed to copy dialog contents to the clipboard."
+msgstr "Gagal menyalin konten dialog ke clipboard."
+
+#: ../src/generic/logg.cpp:1022
+#, c-format
+msgid "Append log to file '%s' (choosing [No] will overwrite it)?"
+msgstr "Tambahkan log ke berkas '%s' (memilih [Tidak] akan menimpanya)?"
+
+#: ../src/generic/logg.cpp:1024
+msgid "Question"
+msgstr "Pertanyaan"
+
+#: ../src/generic/logg.cpp:1038
+msgid "invalid message box return value"
+msgstr "nilai kembali message box tidak sah"
+
+#: ../src/generic/notifmsgg.cpp:129
+msgid "Notice"
+msgstr "Pemberitahuan"
+
+#: ../src/generic/preferencesg.cpp:118
+#, c-format
+msgid "%s Preferences"
+msgstr "Preferensi %s"
+
+#: ../src/generic/printps.cpp:143
+msgid "Printing..."
+msgstr "Mencetak..."
+
+#: ../src/generic/printps.cpp:160 ../src/gtk/print.cpp:1076
+#: ../src/msw/printwin.cpp:235
+msgid "Could not start printing."
+msgstr "Gagal memulai pencetakan."
+
+#: ../src/generic/printps.cpp:183
+#, c-format
+msgid "Printing page %d..."
+msgstr "Mencetak halaman %d..."
+
+#: ../src/generic/prntdlgg.cpp:171
+msgid "Printer options"
+msgstr "Opsi pencetak"
+
+#: ../src/generic/prntdlgg.cpp:176
+msgid "Print to File"
+msgstr "Cetak ke Berkas"
+
+#: ../src/generic/prntdlgg.cpp:179
+msgid "Setup..."
+msgstr "Pengaturan..."
+
+#: ../src/generic/prntdlgg.cpp:187
+msgid "Printer:"
+msgstr "Mesin cetak:"
+
+#: ../src/generic/prntdlgg.cpp:195
+msgid "Status:"
+msgstr "Status:"
+
+#: ../src/generic/prntdlgg.cpp:206
+msgid "All"
+msgstr "Semua"
+
+#: ../src/generic/prntdlgg.cpp:207
+msgid "Pages"
+msgstr "Halaman"
+
+#: ../src/generic/prntdlgg.cpp:215
+msgid "Print Range"
+msgstr "Jangkauan Cetakan"
+
+#: ../src/generic/prntdlgg.cpp:229
+msgid "From:"
+msgstr "Dari:"
+
+#: ../src/generic/prntdlgg.cpp:233
+msgid "To:"
+msgstr "Kepada:"
+
+#: ../src/generic/prntdlgg.cpp:238
+msgid "Copies:"
+msgstr "Salinan:"
+
+#: ../src/generic/prntdlgg.cpp:288
+msgid "PostScript file"
+msgstr "Berkas PostScript"
+
+#: ../src/generic/prntdlgg.cpp:439
+msgid "Print Setup"
+msgstr "Pengaturan Cetakan"
+
+#: ../src/generic/prntdlgg.cpp:483
+msgid "Printer"
+msgstr "Printer"
+
+#: ../src/generic/prntdlgg.cpp:501
+msgid "Default printer"
+msgstr "Printer default"
+
+#: ../src/generic/prntdlgg.cpp:595 ../src/generic/prntdlgg.cpp:782
+#: ../src/generic/prntdlgg.cpp:822 ../src/generic/prntdlgg.cpp:835
+#: ../src/generic/prntdlgg.cpp:1031 ../src/generic/prntdlgg.cpp:1036
+msgid "Paper size"
+msgstr "Ukuran kertas"
+
+#: ../src/generic/prntdlgg.cpp:604 ../src/generic/prntdlgg.cpp:847
+msgid "Portrait"
+msgstr "Tegak"
+
+#: ../src/generic/prntdlgg.cpp:605 ../src/generic/prntdlgg.cpp:848
+msgid "Landscape"
+msgstr "Memanjang"
+
+#: ../src/generic/prntdlgg.cpp:607 ../src/generic/prntdlgg.cpp:849
+msgid "Orientation"
+msgstr "Orientasi"
+
+#: ../src/generic/prntdlgg.cpp:610
+msgid "Options"
+msgstr "Opsi"
+
+#: ../src/generic/prntdlgg.cpp:612
+msgid "Print in colour"
+msgstr "Cetak berwarna"
+
+#: ../src/generic/prntdlgg.cpp:621
+msgid "Print spooling"
+msgstr "Antrian pencetakan"
+
+#: ../src/generic/prntdlgg.cpp:623
+msgid "Printer command:"
+msgstr "Perintah pencetak:"
+
+#: ../src/generic/prntdlgg.cpp:631
+msgid "Printer options:"
+msgstr "Opsi pencetak:"
+
+#: ../src/generic/prntdlgg.cpp:860
+msgid "Left margin (mm):"
+msgstr "Batas kiri (mm):"
+
+#: ../src/generic/prntdlgg.cpp:861
+msgid "Top margin (mm):"
+msgstr "Batas atas (mm):"
+
+#: ../src/generic/prntdlgg.cpp:872
+msgid "Right margin (mm):"
+msgstr "Batas kanan (mm):"
+
+#: ../src/generic/prntdlgg.cpp:873
+msgid "Bottom margin (mm):"
+msgstr "Batas bawah (mm):"
+
+#: ../src/generic/prntdlgg.cpp:896
+msgid "Printer..."
+msgstr "Pencetak..."
+
+#: ../src/generic/progdlgg.cpp:246
+msgid "&Skip"
+msgstr "&Lewati"
+
+#: ../src/generic/progdlgg.cpp:347 ../src/generic/progdlgg.cpp:626
+msgid "Unknown"
+msgstr "Tidak dikenal"
+
+#: ../src/generic/progdlgg.cpp:451 ../src/msw/progdlg.cpp:526
+msgid "Done."
+msgstr "Selesai."
+
+#: ../src/generic/srchctlg.cpp:55 ../src/gtk/srchctrl.cpp:206
+#: ../src/html/helpwnd.cpp:530 ../src/html/helpwnd.cpp:545
+msgid "Search"
+msgstr "Cari"
+
+#: ../src/generic/tabg.cpp:1026
+msgid "Could not find tab for id"
+msgstr "Gagal menemukan tab untuk id"
+
+#: ../src/generic/tipdlg.cpp:136
+msgid "Tips not available, sorry!"
+msgstr "Tip tidak tersedia, maaf!"
+
+#: ../src/generic/tipdlg.cpp:197
+msgid "Tip of the Day"
+msgstr "Tip Hari Ini"
+
+#: ../src/generic/tipdlg.cpp:207
+msgid "Did you know..."
+msgstr "Tahukah anda..."
+
+#: ../src/generic/tipdlg.cpp:232
+msgid "&Show tips at startup"
+msgstr "&Tampilkan tip saat awal mula"
+
+#: ../src/generic/tipdlg.cpp:236
+msgid "&Next Tip"
+msgstr "&Tip Berikutnya"
+
+#: ../src/generic/wizard.cpp:411
+msgid "&Next >"
+msgstr "&Berikutnya >"
+
+#: ../src/generic/wizard.cpp:412
+msgid "&Finish"
+msgstr "&Selesai"
+
+#: ../src/generic/wizard.cpp:420
+msgid "< &Back"
+msgstr "< &Mundur"
+
+#: ../src/gtk/aboutdlg.cpp:204
+msgid "translator-credits"
+msgstr "penerjemah"
+
+#: ../src/gtk/app.cpp:517
+msgid ""
+"WARNING: using XIM input method is unsupported and may result in problems "
+"with input handling and flickering. Consider unsetting GTK_IM_MODULE or "
+"setting to \"ibus\"."
+msgstr ""
+
+#: ../src/gtk/app.cpp:569
+msgid "Unable to initialize GTK+, is DISPLAY set properly?"
+msgstr "Gagal menginisiasi GTK+, apakah DISPLAY sudah benar?"
+
+#: ../src/gtk/filedlg.cpp:89 ../src/gtk/filepicker.cpp:255
+#, c-format
+msgid "Changing current directory to \"%s\" failed"
+msgstr "Gagal pindah ke direktori \"%s\""
+
+#: ../src/gtk/font.cpp:548
+msgid ""
+"Using private fonts is not supported on this system: Pango library is too "
+"old, 1.38 or later required."
+msgstr ""
+
+#: ../src/gtk/font.cpp:558
+#, fuzzy
+msgid "Failed to create font configuration object."
+msgstr "Gagal memperbaharui berkas konfigurasi."
+
+#: ../src/gtk/font.cpp:568
+#, fuzzy, c-format
+msgid "Failed to add custom font \"%s\"."
+msgstr "Gagal untuk membaca dokumen dari berkas \"%s\"."
+
+#: ../src/gtk/font.cpp:576
+#, fuzzy
+msgid "Failed to register font configuration using private fonts."
+msgstr "Gagal memperbaharui berkas konfigurasi."
+
+#: ../src/gtk/glcanvas.cpp:117 ../src/gtk/glcanvas.cpp:132
+#, fuzzy
+msgid "Fatal Error"
+msgstr "Galat berkas"
+
+#: ../src/gtk/glcanvas.cpp:117
+msgid ""
+"This program wasn't compiled with EGL support required under Wayland, "
+"either\n"
+"install EGL libraries and rebuild or run it under X11 backend by setting\n"
+"environment variable GDK_BACKEND=x11 before starting your program."
+msgstr ""
+
+#: ../src/gtk/glcanvas.cpp:132
+msgid ""
+"wxGLCanvas is only supported on Wayland and X11 currently.  You may be able "
+"to\n"
+"work around this by setting environment variable GDK_BACKEND=x11 before\n"
+"starting your program."
+msgstr ""
+
+#: ../src/gtk/mdi.cpp:433
+msgid "MDI child"
+msgstr "MDI child"
+
+#: ../src/gtk/power.cpp:188
+#, fuzzy, c-format
+msgid "Failed to open D-Bus connection to the login manager: %s"
+msgstr "Gagal menciptakan koneksi ke server '%s' untuk topik '%s'"
+
+#: ../src/gtk/power.cpp:214
+#, fuzzy
+msgid "wxWidgets application"
+msgstr "Aplikasi"
+
+#: ../src/gtk/power.cpp:226
+msgid "Application needs to keep running"
+msgstr ""
+
+#: ../src/gtk/power.cpp:233
+msgid "Clean up before suspend"
+msgstr ""
+
+#: ../src/gtk/power.cpp:259
+#, fuzzy, c-format
+msgid "Failed to inhibit sleep: %s"
+msgstr "Gagal memulai koneksi dialup: %s"
+
+#: ../src/gtk/power.cpp:265
+msgid "Unexpected response to D-Bus \"Inhibit\" request."
+msgstr ""
+
+#: ../src/gtk/print.cpp:218
+msgid "Custom size"
+msgstr "Ukuran kustom"
+
+#: ../src/gtk/print.cpp:752
+#, fuzzy, c-format
+msgid "Error while printing: %s"
+msgstr "Galat ketika mencetak: "
+
+#: ../src/gtk/print.cpp:816
+msgid "Page Setup"
+msgstr "Pengaturan Halaman"
+
+#: ../src/gtk/webview_webkit.cpp:932
+msgid "Retrieving JavaScript script output is not supported with WebKit v1"
+msgstr ""
+
+#: ../src/gtk/webview_webkit2.cpp:1098
+msgid ""
+"Setting proxy is not supported by WebKit, at least version 2.16 is required."
+msgstr ""
+
+#: ../src/gtk/webview_webkit2.cpp:1104
+msgid "This program was compiled without support for setting WebKit proxy."
+msgstr ""
+
+#: ../src/gtk/window.cpp:6289
+msgid ""
+"GTK+ installed on this machine is too old to support screen compositing, "
+"please install GTK+ 2.12 or later."
+msgstr ""
+"GTK+ terpasang dimesin ini dan terlalu tua untuk mendukung fitur screen "
+"compositing, mohon memasang GTK+ 2.12 atau versi ke atasnya."
+
+#: ../src/gtk/window.cpp:6307
+msgid ""
+"Compositing not supported by this system, please enable it in your Window "
+"Manager."
+msgstr ""
+"Komposisi tidak didukung oleh sistem ini, tolong hidupkan pada WIndow "
+"Manager anda."
+
+#: ../src/gtk/window.cpp:6318
+msgid ""
+"This program was compiled with a too old version of GTK+, please rebuild "
+"with GTK+ 2.12 or newer."
+msgstr ""
+"Program ini telah dibuat dengan GTK+ lama, mohon dibuat kembali dengan GTK+ "
+"2.12 atau lebih baru."
+
+#: ../src/html/chm.cpp:138
+#, c-format
+msgid "Failed to open CHM archive '%s'."
+msgstr "Gagal membuka arsip CHM '%s'."
+
+#: ../src/html/chm.cpp:270
+#, c-format
+msgid "Could not extract %s into %s: %s"
+msgstr "Gagal mengekstrak %s ke dalam %s: %s"
+
+#: ../src/html/chm.cpp:324
+msgid "no error"
+msgstr "tidak ada galat"
+
+#: ../src/html/chm.cpp:326
+msgid "bad arguments to library function"
+msgstr "salah argumen ke fungsi pustaka"
+
+#: ../src/html/chm.cpp:328
+msgid "error opening file"
+msgstr "galat membuka berkas"
+
+#: ../src/html/chm.cpp:330
+msgid "read error"
+msgstr "galat ketika membaca"
+
+#: ../src/html/chm.cpp:332
+msgid "write error"
+msgstr "galat penulisan"
+
+#: ../src/html/chm.cpp:334
+msgid "seek error"
+msgstr "galat ketika mencari"
+
+#: ../src/html/chm.cpp:338
+msgid "bad signature"
+msgstr "tanda tangan salah"
+
+#: ../src/html/chm.cpp:340
+msgid "error in data format"
+msgstr "galat pada format data"
+
+#: ../src/html/chm.cpp:342
+msgid "checksum error"
+msgstr "galat checksum"
+
+#: ../src/html/chm.cpp:344
+msgid "compression error"
+msgstr "galat kompresi"
+
+#: ../src/html/chm.cpp:346
+msgid "decompression error"
+msgstr "galat dekompresi"
+
+#: ../src/html/chm.cpp:437
+#, c-format
+msgid "Could not locate file '%s'."
+msgstr "Gagal menemukan file '%s'."
+
+#: ../src/html/chm.cpp:711
+#, c-format
+msgid "Could not create temporary file '%s'"
+msgstr "Gagal membuat berkas sementara '%s'"
+
+#: ../src/html/chm.cpp:718
+#, c-format
+msgid "Extraction of '%s' into '%s' failed."
+msgstr "Hasil ekstrak dari '%s' ke dalam '%s' gagal."
+
+#: ../src/html/chm.cpp:806 ../src/html/chm.cpp:863
+msgid "CHM handler currently supports only local files!"
+msgstr "Penangan CHM saat ini hanya mendukung berkas lokal!"
+
+#: ../src/html/chm.cpp:827
+msgid "Link contained '//', converted to absolute link."
+msgstr "Tautan berisi '//', diubah ke tautan absolut."
+
+#: ../src/html/helpctrl.cpp:59
+#, c-format
+msgid "Help: %s"
+msgstr "Bantuan: %s"
+
+#: ../src/html/helpctrl.cpp:155
+#, c-format
+msgid "Adding book %s"
+msgstr "Menambahkan buku %s"
+
+#: ../src/html/helpdata.cpp:295
+#, c-format
+msgid "Cannot open contents file: %s"
+msgstr "Gagal membuka isi berkas: %s"
+
+#: ../src/html/helpdata.cpp:309
+#, c-format
+msgid "Cannot open index file: %s"
+msgstr "Gagal membuka berkas indeks: %s"
+
+#: ../src/html/helpdata.cpp:643
+msgid "noname"
+msgstr "tanpa nama"
+
+#: ../src/html/helpdata.cpp:652
+#, c-format
+msgid "Cannot open HTML help book: %s"
+msgstr "Gagal membuka buku bantuan HTML: %s"
+
+#: ../src/html/helpwnd.cpp:315
+msgid "Displays help as you browse the books on the left."
+msgstr "Tampilkan bantuan saat melihat buku di jendela sebelah kiri."
+
+#: ../src/html/helpwnd.cpp:411 ../src/html/helpwnd.cpp:1100
+#: ../src/html/helpwnd.cpp:1735
+msgid "(bookmarks)"
+msgstr "(tanda taut)"
+
+#: ../src/html/helpwnd.cpp:424
+msgid "Add current page to bookmarks"
+msgstr "Tambahkan halaman ini ke penanda taut"
+
+#: ../src/html/helpwnd.cpp:425
+msgid "Remove current page from bookmarks"
+msgstr "Hilangkan halaman saat ini dari bookmark"
+
+#: ../src/html/helpwnd.cpp:470
+msgid "Contents"
+msgstr "Isi"
+
+#: ../src/html/helpwnd.cpp:485
+msgid "Find"
+msgstr "Temukan"
+
+#: ../src/html/helpwnd.cpp:487
+msgid "Show all"
+msgstr "Tampilkan semua"
+
+#: ../src/html/helpwnd.cpp:497
+msgid ""
+"Display all index items that contain given substring. Search is case "
+"insensitive."
+msgstr ""
+"Tampilkan semua obyek indeks yang berisi substring tersebut. Pencarian tidak "
+"membedakan pemakaian huruf besar dan kecil."
+
+#: ../src/html/helpwnd.cpp:498
+msgid "Show all items in index"
+msgstr "Tampilkan semua butir dalam indeks"
+
+#: ../src/html/helpwnd.cpp:528
+msgid "Case sensitive"
+msgstr "Membedakan huruf besar dan kecil"
+
+#: ../src/html/helpwnd.cpp:529
+msgid "Whole words only"
+msgstr "Hanya seluruh kata"
+
+#: ../src/html/helpwnd.cpp:532
+msgid ""
+"Search contents of help book(s) for all occurrences of the text you typed "
+"above"
+msgstr ""
+"Cari isi dari konten bantuan untuk semua pemunculan dari teks yang "
+"diketikkan diatas"
+
+#: ../src/html/helpwnd.cpp:653
+msgid "Show/hide navigation panel"
+msgstr "Tampilkan/sembunyikan panel navigasi"
+
+#: ../src/html/helpwnd.cpp:655
+msgid "Go back"
+msgstr "Kembali"
+
+#: ../src/html/helpwnd.cpp:656
+msgid "Go forward"
+msgstr "Ke depan"
+
+#: ../src/html/helpwnd.cpp:658
+msgid "Go one level up in document hierarchy"
+msgstr "Ke satu tingkat diatas dalam hirarki dokumen"
+
+#: ../src/html/helpwnd.cpp:666 ../src/html/helpwnd.cpp:1547
+msgid "Open HTML document"
+msgstr "Buka dokumen HTML"
+
+#: ../src/html/helpwnd.cpp:670
+msgid "Print this page"
+msgstr "Cetak halaman ini"
+
+#: ../src/html/helpwnd.cpp:674
+msgid "Display options dialog"
+msgstr "Tampilkan dialog opsi"
+
+#: ../src/html/helpwnd.cpp:795
+msgid "Please choose the page to display:"
+msgstr "Silakan pilih lembar yang mau ditampilkan:"
+
+#: ../src/html/helpwnd.cpp:796
+msgid "Help Topics"
+msgstr "Topik Bantuan"
+
+#: ../src/html/helpwnd.cpp:852
+msgid "Searching..."
+msgstr "Mencari..."
+
+#: ../src/html/helpwnd.cpp:853
+msgid "No matching page found yet"
+msgstr "Tidak ditemukan halaman yang sesuai"
+
+#: ../src/html/helpwnd.cpp:870
+#, c-format
+msgid "Found %i matches"
+msgstr "Menemukan %i sesuai"
+
+#: ../src/html/helpwnd.cpp:958
+msgid "(Help)"
+msgstr "(Bantuan)"
+
+#: ../src/html/helpwnd.cpp:1026
+#, c-format
+msgid "%d of %lu"
+msgstr "%d dari %lu"
+
+#: ../src/html/helpwnd.cpp:1028
+#, c-format
+msgid "%lu of %lu"
+msgstr "%lu dari %lu"
+
+#: ../src/html/helpwnd.cpp:1047
+msgid "Search in all books"
+msgstr "Cari di semua buku"
+
+#: ../src/html/helpwnd.cpp:1193
+msgid "Help Browser Options"
+msgstr "Opsi Bantuan Browser"
+
+#: ../src/html/helpwnd.cpp:1198
+msgid "Normal font:"
+msgstr "Font normal:"
+
+#: ../src/html/helpwnd.cpp:1199
+msgid "Fixed font:"
+msgstr "Huruf tetap:"
+
+#: ../src/html/helpwnd.cpp:1200
+msgid "Font size:"
+msgstr "Ukuran huruf:"
+
+#: ../src/html/helpwnd.cpp:1245
+msgid "font size"
+msgstr "ukuran font"
+
+#: ../src/html/helpwnd.cpp:1256
+msgid "Normal face<br>and <u>underlined</u>. "
+msgstr "Huruf normal<br>dan <u>digarisbawahi</u>. "
+
+#: ../src/html/helpwnd.cpp:1257
+msgid "<i>Italic face.</i> "
+msgstr "<i>Contoh miring.</i> "
+
+#: ../src/html/helpwnd.cpp:1258
+msgid "<b>Bold face.</b> "
+msgstr "<b>Contoh tebal.</b> "
+
+#: ../src/html/helpwnd.cpp:1259
+msgid "<b><i>Bold italic face.</i></b><br>"
+msgstr "<b><i>Contoh miring tebal.</i></b><br>"
+
+#: ../src/html/helpwnd.cpp:1262
+msgid "Fixed size face.<br> <b>bold</b> <i>italic</i> "
+msgstr "Font ukuran tetap.<br> <b>tebal</b> <i>miring</i> "
+
+#: ../src/html/helpwnd.cpp:1263
+msgid "<b><i>bold italic <u>underlined</u></i></b><br>"
+msgstr "<b><i>miring tebal <u>digarisbawahi</u></i></b><br>"
+
+#: ../src/html/helpwnd.cpp:1524
+msgid "Help Printing"
+msgstr "Bantuan Pencetakan"
+
+#: ../src/html/helpwnd.cpp:1527
+msgid "Cannot print empty page."
+msgstr "Gagal mencetak halaman kosong."
+
+#: ../src/html/helpwnd.cpp:1540
+msgid "HTML files (*.html;*.htm)|*.html;*.htm|"
+msgstr "Berkas HTML (*.html;*.htm)|*.html;*.htm|"
+
+#: ../src/html/helpwnd.cpp:1541
+msgid "Help books (*.htb)|*.htb|Help books (*.zip)|*.zip|"
+msgstr "Buku bantuan (*.htb)|*.htb|Buku bantuan (*.zip)|*.zip|"
+
+#: ../src/html/helpwnd.cpp:1542
+msgid "HTML Help Project (*.hhp)|*.hhp|"
+msgstr "Proyek Bantuan HTML (*.hhp)|*.hhp|"
+
+#: ../src/html/helpwnd.cpp:1544
+msgid "Compressed HTML Help file (*.chm)|*.chm|"
+msgstr "Berkas Bantuan HML Terkompresi (*.chm)|*.chm|"
+
+#: ../src/html/helpwnd.cpp:1671
+#, c-format
+msgid "%i of %u"
+msgstr "%i dari %u"
+
+#: ../src/html/helpwnd.cpp:1709
+#, c-format
+msgid "%u of %u"
+msgstr "%u dari %u"
+
+#: ../src/html/htmlfilt.cpp:134
+#, c-format
+msgid "Cannot open HTML document: %s"
+msgstr "Gagal membuka dokumen HTML: %s"
+
+#: ../src/html/htmlwin.cpp:599
+msgid "Connecting..."
+msgstr "Membuat koneksi..."
+
+#: ../src/html/htmlwin.cpp:616
+#, c-format
+msgid "Unable to open requested HTML document: %s"
+msgstr "Gagal membuka dokumen HTML yang diminta: %s"
+
+#: ../src/html/htmlwin.cpp:630
+msgid "Loading : "
+msgstr "Memuat: "
+
+#: ../src/html/htmlwin.cpp:673
+msgid "Done"
+msgstr "Selesai"
+
+#: ../src/html/htmlwin.cpp:723
+#, c-format
+msgid "HTML anchor %s does not exist."
+msgstr "Anchor HTML %s tidak ada."
+
+#: ../src/html/htmlwin.cpp:1057
+#, c-format
+msgid "Copied to clipboard:\"%s\""
+msgstr "Tersalin ke clipboard: \"%s\""
+
+#: ../src/html/htmprint.cpp:269
+msgid ""
+"This document doesn't fit on the page horizontally and will be truncated "
+"when it is printed."
+msgstr ""
+"Dokumen tidak pas pada halaman secara horisontal dan akan terpotong ketika "
+"dicetak."
+
+#: ../src/html/htmprint.cpp:285
+#, c-format
+msgid ""
+"The document \"%s\" doesn't fit on the page horizontally and will be "
+"truncated if printed.\n"
+"\n"
+"Would you like to proceed with printing it nevertheless?"
+msgstr ""
+"Dokumen \"%s\" tidak pas pada halaman secara horisontal dan akan terpotong "
+"jika dicetak.\n"
+"\n"
+"Apakah akan dilanjutkan?"
+
+#: ../src/html/htmprint.cpp:296
+msgid ""
+"If possible, try changing the layout parameters to make the printout more "
+"narrow."
+msgstr ""
+"Jika memungkinkan, cobalah untuk mengubah parameter untuk membuat hasil "
+"cetakan mengecil."
+
+#: ../src/html/htmprint.cpp:445
+msgid ": file does not exist!"
+msgstr ": berkas tidak ada!"
+
+#. TRANSLATORS: %s may be a document title.
+#: ../src/html/htmprint.cpp:717
+#, fuzzy, c-format
+msgid "%s Preview"
+msgstr " Pratinjau"
+
+#: ../src/html/htmprint.cpp:755 ../src/richtext/richtextprint.cpp:618
+msgid ""
+"There was a problem during page setup: you may need to set a default printer."
+msgstr ""
+"Ada masalah pada saat mengatur halaman: mungkin perlu ditetapkan pencetak "
+"default."
+
+#: ../src/msw/clipbrd.cpp:80
+msgid "Failed to open the clipboard."
+msgstr "Gagal membuka clipboard."
+
+#: ../src/msw/clipbrd.cpp:101
+msgid "Failed to close the clipboard."
+msgstr "Gagal menutup clipboard."
+
+#: ../src/msw/clipbrd.cpp:113
+msgid "Failed to empty the clipboard."
+msgstr "Gagal mengosongkan clipboard."
+
+#: ../src/msw/clipbrd.cpp:284
+msgid "Failed to put data on the clipboard"
+msgstr "Gagal menempatkan data pada clipboard"
+
+#: ../src/msw/clipbrd.cpp:326
+msgid "Failed to get data from the clipboard"
+msgstr "Gagal memperoleh data dari clipboard"
+
+#: ../src/msw/clipbrd.cpp:363
+msgid "Failed to retrieve the supported clipboard formats"
+msgstr "Gagal mengambil format clipboard yang didukung"
+
+#: ../src/msw/colordlg.cpp:228
+#, c-format
+msgid "Colour selection dialog failed with error %0lx."
+msgstr "Dialog pemilihan warna gagal dengan galat %0lx."
+
+#: ../src/msw/cursor.cpp:141
+msgid "Failed to create cursor."
+msgstr "Gagal membuat kursor."
+
+#: ../src/msw/dde.cpp:279
+#, c-format
+msgid "Failed to register DDE server '%s'"
+msgstr "Gagal meregister server DDE '%s'"
+
+#: ../src/msw/dde.cpp:300
+#, c-format
+msgid "Failed to unregister DDE server '%s'"
+msgstr "Gagal melepas register server DDE '%s'"
+
+#: ../src/msw/dde.cpp:428
+#, c-format
+msgid "Failed to create connection to server '%s' on topic '%s'"
+msgstr "Gagal menciptakan koneksi ke server '%s' untuk topik '%s'"
+
+#: ../src/msw/dde.cpp:655
+msgid "DDE poke request failed"
+msgstr "Permintaan poke DDE gagal"
+
+#: ../src/msw/dde.cpp:674
+msgid "Failed to establish an advise loop with DDE server"
+msgstr "Gagal mengadakan advise loop dengan server DDE"
+
+#: ../src/msw/dde.cpp:693
+msgid "Failed to terminate the advise loop with DDE server"
+msgstr "Gagal menghentikan advise loop dengan server DDE"
+
+#: ../src/msw/dde.cpp:768
+msgid "Failed to send DDE advise notification"
+msgstr "Gagal mengirimkan pemberitahuan DDE advise"
+
+#: ../src/msw/dde.cpp:1085
+msgid "Failed to create DDE string"
+msgstr "Gagal menciptakan string DDE"
+
+#: ../src/msw/dde.cpp:1131
+msgid "no DDE error."
+msgstr "tidak ada kesalahan DDE."
+
+#: ../src/msw/dde.cpp:1135
+msgid "a request for a synchronous advise transaction has timed out."
+msgstr "permintaan untuk transaksi advise sinkron telah habis waktunya."
+
+#: ../src/msw/dde.cpp:1138
+msgid "the response to the transaction caused the DDE_FBUSY bit to be set."
+msgstr "tanggapan terhadap transaksi menyebabkan bit DDE_FBUSY ditetapkan."
+
+#: ../src/msw/dde.cpp:1141
+msgid "a request for a synchronous data transaction has timed out."
+msgstr "permintaan untuk transaksi data sinkron telah habis waktunya."
+
+#: ../src/msw/dde.cpp:1144
+msgid ""
+"a DDEML function was called without first calling the DdeInitialize "
+"function,\n"
+"or an invalid instance identifier\n"
+"was passed to a DDEML function."
+msgstr ""
+"fungsi DDEML dipanggil tanpa memanggil fungsi DdeInitialize,\n"
+"atau suatu identifikasi instan yang tidak sah\n"
+"disampaikan ke suatu fungsi DDEML."
+
+#: ../src/msw/dde.cpp:1147
+msgid ""
+"an application initialized as APPCLASS_MONITOR has\n"
+"attempted to perform a DDE transaction,\n"
+"or an application initialized as APPCMD_CLIENTONLY has \n"
+"attempted to perform server transactions."
+msgstr ""
+"aplikasi diinisialisasi sebagai APPCLASS_MONITOR telah\n"
+"berusaha melaksanakan transaksi DDE,\n"
+"atau aplikasi yang diinisialisasi sebagai APPCMD_CLIENTONLY telah \n"
+"berusaha melaksanakan transaksi server."
+
+#: ../src/msw/dde.cpp:1150
+msgid "a request for a synchronous execute transaction has timed out."
+msgstr "permintaan untuk transaksi eksekusi sinkron telah habis waktunya."
+
+#: ../src/msw/dde.cpp:1153
+msgid "a parameter failed to be validated by the DDEML."
+msgstr "parameter gagal divalidasi oleh DDEML."
+
+#: ../src/msw/dde.cpp:1156
+msgid "a DDEML application has created a prolonged race condition."
+msgstr "aplikasi DDEML telah menciptakan kondisi race berkesinambungan."
+
+#: ../src/msw/dde.cpp:1159
+msgid "a memory allocation failed."
+msgstr "alokasi memori gagal."
+
+#: ../src/msw/dde.cpp:1162
+msgid "a client's attempt to establish a conversation has failed."
+msgstr "usaha dari klien untuk memulai percakapan telah gagal."
+
+#: ../src/msw/dde.cpp:1165
+msgid "a transaction failed."
+msgstr "transaksi gagal."
+
+#: ../src/msw/dde.cpp:1168
+msgid "a request for a synchronous poke transaction has timed out."
+msgstr "permintaan untuk transaksi poke sinkron telah habis waktunya."
+
+#: ../src/msw/dde.cpp:1171
+msgid "an internal call to the PostMessage function has failed. "
+msgstr "panggilan internal ke fungsi PostMessage telah gagal. "
+
+#: ../src/msw/dde.cpp:1174
+msgid "reentrancy problem."
+msgstr "masalah reentransi kembali."
+
+#: ../src/msw/dde.cpp:1177
+msgid ""
+"a server-side transaction was attempted on a conversation\n"
+"that was terminated by the client, or the server\n"
+"terminated before completing a transaction."
+msgstr ""
+"transaksi disisi server telah diusahakan terhadap percakapan\n"
+"yang dihentikan oleh klien, atau server\n"
+"dihentikan sebelum menyelesaikan transaksi."
+
+#: ../src/msw/dde.cpp:1180
+msgid "an internal error has occurred in the DDEML."
+msgstr "kesalahan internal muncul dalam DDEML."
+
+#: ../src/msw/dde.cpp:1183
+msgid "a request to end an advise transaction has timed out."
+msgstr "permintaan untuk mengakhiri transaksi advise telah habis waktunya."
+
+#: ../src/msw/dde.cpp:1186
+msgid ""
+"an invalid transaction identifier was passed to a DDEML function.\n"
+"Once the application has returned from an XTYP_XACT_COMPLETE callback,\n"
+"the transaction identifier for that callback is no longer valid."
+msgstr ""
+"identifikasi transaksi yang tidak sah disampaikan ke suatu fungsi DDEML.\n"
+"Saat aplikasi kembali dari callback XTYP_XACT_COMPLETE,\n"
+"pengenal transaksi untuk callback tersebut tidak lagi sah."
+
+#: ../src/msw/dde.cpp:1189
+#, c-format
+msgid "Unknown DDE error %08x"
+msgstr "Galat DDE %08x tidak dikenal"
+
+#: ../src/msw/dialup.cpp:343
+msgid ""
+"Dial up functions are unavailable because the remote access service (RAS) is "
+"not installed on this machine. Please install it."
+msgstr ""
+"Fungsi dial up tidak tersedia karena remote access service (RAS) tidak "
+"terinstall pada mesin ini. Silahkan menginstall."
+
+#: ../src/msw/dialup.cpp:402
+#, c-format
+msgid ""
+"The version of remote access service (RAS) installed on this machine is too "
+"old, please upgrade (the following required function is missing: %s)."
+msgstr ""
+"Versi remote access service (RAS) terinstall di mesin ini terlalu tua, "
+"silahkan perbarui (fungsi yang dibutuhkan berikut ini hilang: %s)."
+
+#: ../src/msw/dialup.cpp:437
+msgid "Failed to retrieve text of RAS error message"
+msgstr "Gagal mengambil teks dari pesan kesalahan RAS"
+
+#: ../src/msw/dialup.cpp:440
+#, c-format
+msgid "unknown error (error code %08x)."
+msgstr "galat tidak dikenal (kode kesalahan %08x)."
+
+#: ../src/msw/dialup.cpp:492
+#, c-format
+msgid "Cannot find active dialup connection: %s"
+msgstr "Gagal menemukan koneksi dialup yang aktif: %s"
+
+#: ../src/msw/dialup.cpp:513
+msgid "Several active dialup connections found, choosing one randomly."
+msgstr "Dijumpai beberapa koneksi dialup aktif, pilih satu secara acak."
+
+#: ../src/msw/dialup.cpp:598 ../src/msw/dialup.cpp:832
+#, c-format
+msgid "Failed to establish dialup connection: %s"
+msgstr "Gagal membentuk koneksi dialup: %s"
+
+#: ../src/msw/dialup.cpp:664
+#, c-format
+msgid "Failed to get ISP names: %s"
+msgstr "Gagal memperoleh nama ISO: %s"
+
+#: ../src/msw/dialup.cpp:712
+msgid "Failed to connect: no ISP to dial."
+msgstr "Gagal koneksi: tidak ada ISP untuk didial."
+
+#: ../src/msw/dialup.cpp:732
+msgid "Choose ISP to dial"
+msgstr "Pilih ISP yang akan dihubungi"
+
+#: ../src/msw/dialup.cpp:733
+msgid "Please choose which ISP do you want to connect to"
+msgstr "Silahkan pilih ingin koneksi ke ISP mana"
+
+#: ../src/msw/dialup.cpp:766
+msgid "Failed to connect: missing username/password."
+msgstr "Gagal koneksi: kurang nama user/kata kunci."
+
+#: ../src/msw/dialup.cpp:796
+msgid "Cannot find the location of address book file"
+msgstr "Gagal menemukan lokasi dari berkas buku alamat"
+
+#: ../src/msw/dialup.cpp:827
+#, c-format
+msgid "Failed to initiate dialup connection: %s"
+msgstr "Gagal memulai koneksi dialup: %s"
+
+#: ../src/msw/dialup.cpp:897
+msgid "Cannot hang up - no active dialup connection."
+msgstr "Gagal memutus - tidak ada koneksi dialup yang aktif."
+
+#: ../src/msw/dialup.cpp:907
+#, c-format
+msgid "Failed to terminate the dialup connection: %s"
+msgstr "Gagal menghentikan koneksi dialup: %s"
+
+#: ../src/msw/dib.cpp:313
+#, c-format
+msgid "Failed to save the bitmap image to file \"%s\"."
+msgstr "Gagal menyimpan citra bitmap ke berkas \"%s\"."
+
+#: ../src/msw/dib.cpp:543
+#, c-format
+msgid "Failed to allocate %luKb of memory for bitmap data."
+msgstr "Gagal mengalokasikan %luKB dari memori untuk data bitmap."
+
+#: ../src/msw/dir.cpp:241
+#, c-format
+msgid "Cannot enumerate files in directory '%s'"
+msgstr "Gagal mengenumerasi berkas di direktori '%s'"
+
+#: ../src/msw/dirdlg.cpp:368
+msgid "Couldn't obtain folder name"
+msgstr "Gagal mendapatkan nama direktori"
+
+#: ../src/msw/dlmsw.cpp:163
+#, fuzzy, c-format
+msgid "(error %d: %s)"
+msgstr " (galat %ld: %s)"
+
+#: ../src/msw/dragimag.cpp:143 ../src/msw/dragimag.cpp:178
+#: ../src/msw/imaglist.cpp:309 ../src/msw/imaglist.cpp:331
+msgid "Couldn't add an image to the image list."
+msgstr "Gagal menambahkan citra ke daftar citra."
+
+#: ../src/msw/enhmeta.cpp:94
+#, c-format
+msgid "Failed to load metafile from file \"%s\"."
+msgstr "Gagal memuat metafile dari berkas \"%s\"."
+
+#: ../src/msw/fdrepdlg.cpp:412
+#, c-format
+msgid "Failed to create the standard find/replace dialog (error code %d)"
+msgstr "Gagal menciptakan dialog standar temukan/ganti (kode kesalahan %d)"
+
+#: ../src/msw/filedlg.cpp:1241
+msgid "Access to the file system is not allowed from secure desktop."
+msgstr ""
+
+#: ../src/msw/filedlg.cpp:1242
+msgid "Security warning"
+msgstr ""
+
+#: ../src/msw/filedlg.cpp:1533
+#, c-format
+msgid "File dialog failed with error code %0lx."
+msgstr "Dialog berkas gagal dengan kode galat %0lx."
+
+#: ../src/msw/font.cpp:1120
+#, fuzzy, c-format
+msgid "Font file \"%s\" couldn't be loaded"
+msgstr "Berkas tidak bisa dimuat."
+
+#: ../src/msw/fontdlg.cpp:220
+#, c-format
+msgid "Common dialog failed with error code %0lx."
+msgstr "Dialog umum gagal dengan kode galat %0lx."
+
+#: ../src/msw/fswatcher.cpp:67
+msgid "Ungraceful worker thread termination"
+msgstr "Thread pekerja dihentikan"
+
+#: ../src/msw/fswatcher.cpp:81
+msgid "Unable to create IOCP worker thread"
+msgstr "Gagal membuat thread IOCP"
+
+#: ../src/msw/fswatcher.cpp:88
+msgid "Unable to start IOCP worker thread"
+msgstr "Gagal memulai thread IOCP"
+
+#: ../src/msw/fswatcher.cpp:140
+msgid "Monitoring individual files for changes is not supported currently."
+msgstr "Saat ini pemantauan perubahan terhadap berkas tidak didukung."
+
+#: ../src/msw/fswatcher.cpp:165
+#, c-format
+msgid "Unable to set up watch for '%s'"
+msgstr "Gagal mengatur pengamatan untuk '%s'"
+
+#: ../src/msw/fswatcher.cpp:466
+#, c-format
+msgid "Can't monitor non-existent directory \"%s\" for changes."
+msgstr "Gagal memantau perubahan pada direktori yang tidak ada \"%s\"."
+
+#: ../src/msw/glcanvas.cpp:577 ../src/unix/glx11.cpp:507
+msgid "OpenGL 3.0 or later is not supported by the OpenGL driver."
+msgstr "OpenGL 3.0 atau lebih baru tidak didukung oleh driver OpenGL."
+
+#: ../src/msw/glcanvas.cpp:601 ../src/osx/glcanvas_osx.cpp:395
+#: ../src/unix/glegl.cpp:304 ../src/unix/glx11.cpp:553
+msgid "Couldn't create OpenGL context"
+msgstr "Gagal menciptakan konteks OpenGL"
+
+#: ../src/msw/glcanvas.cpp:1294
+msgid "Failed to initialize OpenGL"
+msgstr "Gagal menginisialisasi OpenGL"
+
+#: ../src/msw/graphicsd2d.cpp:607
+msgid "Could not register custom DirectWrite font loader."
+msgstr ""
+
+#: ../src/msw/helpchm.cpp:48
+msgid ""
+"MS HTML Help functions are unavailable because the MS HTML Help library is "
+"not installed on this machine. Please install it."
+msgstr ""
+"Fungsi MS HTML Help tidak tersedia karena pustaka MS HTML Help tidak "
+"terinstal di mesin ini. Silahkan instal."
+
+#: ../src/msw/helpchm.cpp:55
+msgid "Failed to initialize MS HTML Help."
+msgstr "Gagal menginisialisasi MS HTML Help."
+
+#: ../src/msw/iniconf.cpp:458
+#, c-format
+msgid "Can't delete the INI file '%s'"
+msgstr "Gagal menghapus berkas INI '%s'"
+
+#: ../src/msw/listctrl.cpp:995
+#, c-format
+msgid "Couldn't retrieve information about list control item %d."
+msgstr "Gagal mengambil informasi tentang obyek list control %d."
+
+#: ../src/msw/mdi.cpp:170 ../src/qt/mdi.cpp:253
+msgid "&Cascade"
+msgstr "&Bertingkat"
+
+#: ../src/msw/mdi.cpp:171
+msgid "Tile &Horizontally"
+msgstr "Tile &Horizontal"
+
+#: ../src/msw/mdi.cpp:172
+msgid "Tile &Vertically"
+msgstr "Tile &Vertikal"
+
+#: ../src/msw/mdi.cpp:174
+msgid "&Arrange Icons"
+msgstr "&Atur Ikon"
+
+#: ../src/msw/mdi.cpp:621
+msgid "Failed to create MDI parent frame."
+msgstr "Gagal menciptakan frame parent MDI."
+
+#: ../src/msw/mimetype.cpp:234
+#, c-format
+msgid "Failed to create registry entry for '%s' files."
+msgstr "Gagal menciptakan entri registri untuk file '%s'."
+
+#: ../src/msw/ole/automtn.cpp:495
+#, c-format
+msgid "Failed to find CLSID of \"%s\""
+msgstr "Gagal mencari CLSID  \"%s\""
+
+#: ../src/msw/ole/automtn.cpp:512
+#, c-format
+msgid "Failed to create an instance of \"%s\""
+msgstr "Gagal membuat  \"%s\""
+
+#: ../src/msw/ole/automtn.cpp:552
+#, c-format
+msgid "Cannot get an active instance of \"%s\""
+msgstr "Gagal memperoleh instan aktif dari \"%s\""
+
+#: ../src/msw/ole/automtn.cpp:564
+#, c-format
+msgid "Failed to get OLE automation interface for \"%s\""
+msgstr "Gagal mendapatkan tatap muka OLE automation untuk \"%s\""
+
+#: ../src/msw/ole/automtn.cpp:621
+msgid "Unknown name or named argument."
+msgstr "Nama atau argumen tidak dikenali."
+
+#: ../src/msw/ole/automtn.cpp:625
+msgid "Incorrect number of arguments."
+msgstr "Nomor argumen salah."
+
+#: ../src/msw/ole/automtn.cpp:637
+msgid "Unknown exception"
+msgstr "Pengecualian yang tidak dikenali"
+
+#: ../src/msw/ole/automtn.cpp:642
+msgid "Method or property not found."
+msgstr "Metode atau properti tidak ditemukan."
+
+#: ../src/msw/ole/automtn.cpp:646
+msgid "Overflow while coercing argument values."
+msgstr "Overflow saat memaksa nilai argumen."
+
+#: ../src/msw/ole/automtn.cpp:650
+msgid "Object implementation does not support named arguments."
+msgstr "Implementasi obyek tidak mendukung argumen bernama."
+
+#: ../src/msw/ole/automtn.cpp:654
+msgid "The locale ID is unknown."
+msgstr "ID bahasa tidak dikenali."
+
+#: ../src/msw/ole/automtn.cpp:658
+msgid "Missing a required parameter."
+msgstr "Berikan parameter yang dibutuhkan."
+
+#: ../src/msw/ole/automtn.cpp:662
+#, c-format
+msgid "Argument %u not found."
+msgstr "Argumen %u tidak ditemukan."
+
+#: ../src/msw/ole/automtn.cpp:666
+#, c-format
+msgid "Type mismatch in argument %u."
+msgstr "Tipe tidak sesuai pada argumen %u."
+
+#: ../src/msw/ole/automtn.cpp:670
+msgid "The system cannot find the file specified."
+msgstr "Sistem tidak menemukan berkas yang dicari."
+
+#: ../src/msw/ole/automtn.cpp:674
+msgid "Class not registered."
+msgstr "Kelas tidak terdaftar."
+
+#: ../src/msw/ole/automtn.cpp:678
+#, c-format
+msgid "Unknown error %08x"
+msgstr "Galat tidak dikenali %08x"
+
+#: ../src/msw/ole/automtn.cpp:682
+#, c-format
+msgid "OLE Automation error in %s: %s"
+msgstr "Galat OLE Otomatisasi di %s: %s"
+
+#: ../src/msw/ole/dataobj.cpp:385
+#, c-format
+msgid "Couldn't register clipboard format '%s'."
+msgstr "Gagal meregister format clipboard '%s'."
+
+#: ../src/msw/ole/dataobj.cpp:402
+#, c-format
+msgid "The clipboard format '%d' doesn't exist."
+msgstr "Format clipboard '%d' tidak ada."
+
+#: ../src/msw/progdlg.cpp:1025
+msgid "Skip"
+msgstr "Lewati"
+
+#: ../src/msw/registry.cpp:141
+#, c-format
+msgid "unknown (%lu)"
+msgstr "tidak dikenal (%lu)"
+
+#: ../src/msw/registry.cpp:409
+#, c-format
+msgid "Can't get info about registry key '%s'"
+msgstr "Gagal memperoleh info tentang kunci registri '%s'"
+
+#: ../src/msw/registry.cpp:445
+#, c-format
+msgid "Can't open registry key '%s'"
+msgstr "Gagal membuka kunci registri '%s'"
+
+#: ../src/msw/registry.cpp:478
+#, c-format
+msgid "Can't create registry key '%s'"
+msgstr "Gagal menciptakan kunci registri '%s'"
+
+#: ../src/msw/registry.cpp:497
+#, c-format
+msgid "Can't close registry key '%s'"
+msgstr "Gagal menutup kunci registri '%s'"
+
+#: ../src/msw/registry.cpp:512
+#, c-format
+msgid "Registry value '%s' already exists."
+msgstr "Nilai registri '%s' sudah ada."
+
+#: ../src/msw/registry.cpp:520
+#, c-format
+msgid "Failed to rename registry value '%s' to '%s'."
+msgstr "Gagal mengganti nama nilai registri '%s' ke '%s'."
+
+#: ../src/msw/registry.cpp:575
+#, c-format
+msgid "Can't copy values of unsupported type %d."
+msgstr "Gagal menyalin nilai dari tipe %d yang tidak didukung."
+
+#: ../src/msw/registry.cpp:586
+#, c-format
+msgid "Registry key '%s' does not exist, cannot rename it."
+msgstr "Kunci registri '%s' tidak ada, tidak bisa mengubah namanya."
+
+#: ../src/msw/registry.cpp:617
+#, c-format
+msgid "Registry key '%s' already exists."
+msgstr "Kunci registri '%s' sudah ada."
+
+#: ../src/msw/registry.cpp:625
+#, c-format
+msgid "Failed to rename the registry key '%s' to '%s'."
+msgstr "Gagal mengganti nama kunci registri '%s' ke '%s'."
+
+#: ../src/msw/registry.cpp:670
+#, c-format
+msgid "Failed to copy the registry subkey '%s' to '%s'."
+msgstr "Gagal mennyalin subkunci registri '%s' ke '%s'."
+
+#: ../src/msw/registry.cpp:683
+#, c-format
+msgid "Failed to copy registry value '%s'"
+msgstr "Gagal menyalin nilai registri '%s'"
+
+#: ../src/msw/registry.cpp:692
+#, c-format
+msgid "Failed to copy the contents of registry key '%s' to '%s'."
+msgstr "Gagal menyalin isi dari kunci registri '%s' ke '%s'."
+
+#: ../src/msw/registry.cpp:718
+#, c-format
+msgid ""
+"Registry key '%s' is needed for normal system operation,\n"
+"deleting it will leave your system in unusable state:\n"
+"operation aborted."
+msgstr ""
+"Kunci registri '%s' diperlukan untuk operasi sistem normal,\n"
+"menghapusnya akan menyebabkan sistem anda tidak stabil:\n"
+"operasi dibatalkan."
+
+#: ../src/msw/registry.cpp:754
+#, c-format
+msgid "Can't delete key '%s'"
+msgstr "Gagal menghapus kunci '%s'"
+
+#: ../src/msw/registry.cpp:782
+#, c-format
+msgid "Can't delete value '%s' from key '%s'"
+msgstr "Gagal menghapus nilai '%s' dari kunci '%s'"
+
+#: ../src/msw/registry.cpp:855 ../src/msw/registry.cpp:887
+#: ../src/msw/registry.cpp:929 ../src/msw/registry.cpp:1000
+#, c-format
+msgid "Can't read value of key '%s'"
+msgstr "Gagal membaca nilai dari kunci '%s'"
+
+#: ../src/msw/registry.cpp:873 ../src/msw/registry.cpp:915
+#: ../src/msw/registry.cpp:963 ../src/msw/registry.cpp:1106
+#, c-format
+msgid "Can't set value of '%s'"
+msgstr "Gagal menetapkan nilai dari '%s'"
+
+#: ../src/msw/registry.cpp:894 ../src/msw/registry.cpp:943
+#, c-format
+msgid "Registry value \"%s\" is not numeric (but of type %s)"
+msgstr "Nilai registri “%s” bukan numerik (melainkan tipe %s)"
+
+#: ../src/msw/registry.cpp:979
+#, c-format
+msgid "Registry value \"%s\" is not binary (but of type %s)"
+msgstr "Nilai registri \"%s\" bukan biner (melainkan tipe %s)"
+
+#: ../src/msw/registry.cpp:1028
+#, c-format
+msgid "Registry value \"%s\" is not text (but of type %s)"
+msgstr "Nilai registri “%s” bukan teks (melainkan tipe %s)"
+
+#: ../src/msw/registry.cpp:1089
+#, c-format
+msgid "Can't read value of '%s'"
+msgstr "Gagal membaca nilai dari '%s'"
+
+#: ../src/msw/registry.cpp:1157
+#, c-format
+msgid "Can't enumerate values of key '%s'"
+msgstr "Gagal mengenumerasi nilai dari kunci '%s'"
+
+#: ../src/msw/registry.cpp:1196
+#, c-format
+msgid "Can't enumerate subkeys of key '%s'"
+msgstr "Gagal mengenumerasi subkunci dari kunci '%s'"
+
+#: ../src/msw/registry.cpp:1262
+#, c-format
+msgid ""
+"Exporting registry key: file \"%s\" already exists and won't be overwritten."
+msgstr ""
+"Mengekspor kunci registri: berkas \"%s\" sudah ada dan tidak akan ditimpa."
+
+#: ../src/msw/registry.cpp:1411
+#, c-format
+msgid "Can't export value of unsupported type %d."
+msgstr "Gagal mengekspor nilai dari tipe %d yang tidak didukung."
+
+#: ../src/msw/registry.cpp:1427
+#, c-format
+msgid "Ignoring value \"%s\" of the key \"%s\"."
+msgstr "Mengabaikan nilai \"%s\" dari kunci \"%s\"."
+
+#: ../src/msw/textctrl.cpp:596
+msgid ""
+"Impossible to create a rich edit control, using simple text control instead. "
+"Please reinstall riched32.dll"
+msgstr ""
+"Tidak mungkin menciptakan suatu kontrol rich edit, menggunakan kontrol text "
+"sederhana sebagai gantinya. Silahkan install ulang riched32.dll"
+
+#: ../src/msw/thread.cpp:522 ../src/unix/threadpsx.cpp:850
+msgid "Cannot start thread: error writing TLS."
+msgstr "Gagal memulai thread: kesalahan menulis TLS."
+
+#: ../src/msw/thread.cpp:613
+msgid "Can't set thread priority"
+msgstr "Gagal menetapkan prioritas thread"
+
+#: ../src/msw/thread.cpp:649
+msgid "Can't create thread"
+msgstr "Gagal menciptakan thread"
+
+#: ../src/msw/thread.cpp:668
+msgid "Couldn't terminate thread"
+msgstr "Gagal menghentikan thread"
+
+#: ../src/msw/thread.cpp:799
+msgid "Cannot wait for thread termination"
+msgstr "Gagal menunggu penghentian thread"
+
+#: ../src/msw/thread.cpp:873
+#, c-format
+msgid "Cannot suspend thread %lx"
+msgstr "Gagal menunda thread %lx"
+
+#: ../src/msw/thread.cpp:903
+#, c-format
+msgid "Cannot resume thread %lx"
+msgstr "Gagal meneruskan thread %lx"
+
+#: ../src/msw/thread.cpp:932
+msgid "Couldn't get the current thread pointer"
+msgstr "Gagal memperoleh penunjuk thread saat ini"
+
+#: ../src/msw/thread.cpp:1333
+msgid ""
+"Thread module initialization failed: impossible to allocate index in thread "
+"local storage"
+msgstr ""
+"Inisialisasi modul thread gagal: tidak mungkin mengalokasikan indeks dalam "
+"penyimpanan thread lokal"
+
+#: ../src/msw/thread.cpp:1345
+msgid ""
+"Thread module initialization failed: cannot store value in thread local "
+"storage"
+msgstr ""
+"Inisialisasi modul thread gagal: tidak bisa menyimpan nilai dalam "
+"penyimpanan thread lokal"
+
+#: ../src/msw/timer.cpp:133
+msgid "Couldn't create a timer"
+msgstr "Gagal menciptakan pewaktu"
+
+#: ../src/msw/utils.cpp:372
+msgid "can't find user's HOME, using current directory."
+msgstr "gagal menemukan HOME pemakai, menggunakan direktori aktif saat ini."
+
+#: ../src/msw/utils.cpp:662
+#, c-format
+msgid "Failed to kill process %d"
+msgstr "Gagal untuk mematikan proses %d"
+
+#: ../src/msw/utils.cpp:986
+#, c-format
+msgid "Failed to load resource \"%s\"."
+msgstr "Gagal memuat sumber \"%s\"."
+
+#: ../src/msw/utils.cpp:993
+#, c-format
+msgid "Failed to lock resource \"%s\"."
+msgstr "Gagal menyunci sumber \"%s\"."
+
+#. TRANSLATORS: MS Windows build number
+#: ../src/msw/utils.cpp:1209
+#, c-format
+msgid "build %lu"
+msgstr "versi %lu"
+
+#: ../src/msw/utils.cpp:1218
+msgid ", 64-bit edition"
+msgstr ", edisi 64-bit"
+
+#: ../src/msw/utilsexc.cpp:224
+msgid "Failed to create an anonymous pipe"
+msgstr "Gagal menciptakan pipa anonymous"
+
+#: ../src/msw/utilsexc.cpp:697
+msgid "Failed to redirect the child process IO"
+msgstr "Gagal mengarahkan kembali proses IO child"
+
+#: ../src/msw/utilsexc.cpp:870
+#, c-format
+msgid "Execution of command '%s' failed"
+msgstr "Eksekusi perintah '%s' gagal"
+
+#: ../src/msw/volume.cpp:337
+msgid "Failed to load mpr.dll."
+msgstr "Gagal memuat mpr.dll."
+
+#: ../src/msw/volume.cpp:506
+#, c-format
+msgid "Cannot read typename from '%s'!"
+msgstr "Gagal membaca typename dari '%s'!"
+
+#: ../src/msw/volume.cpp:615
+#, c-format
+msgid "Cannot load icon from '%s'."
+msgstr "Gagal memuat ikon dari '%s'."
+
+#: ../src/msw/webview_edge.cpp:285
+msgid "This program was compiled without support for setting Edge proxy."
+msgstr ""
+
+#: ../src/msw/webview_ie.cpp:1010
+msgid "Failed to find web view emulation level in the registry"
+msgstr ""
+
+#: ../src/msw/webview_ie.cpp:1019
+msgid "Failed to set web view to modern emulation level"
+msgstr ""
+
+#: ../src/msw/webview_ie.cpp:1027
+msgid "Failed to reset web view to standard emulation level"
+msgstr ""
+
+#: ../src/msw/webview_ie.cpp:1049
+msgid "Can't run JavaScript script without a valid HTML document"
+msgstr ""
+
+#: ../src/msw/webview_ie.cpp:1056
+#, fuzzy
+msgid "Can't get the JavaScript object"
+msgstr "Gagal menetapkan prioritas thread"
+
+#: ../src/msw/webview_ie.cpp:1070
+#, fuzzy
+msgid "failed to evaluate"
+msgstr "Gagal mengeksekusi '%s'\n"
+
+#: ../src/osx/cocoa/filedlg.mm:412
+#, fuzzy
+msgid "File type:"
+msgstr "Teletype"
+
+#: ../src/osx/cocoa/menu.mm:242
+#, fuzzy
+msgctxt "macOS menu name"
+msgid "Window"
+msgstr "Window"
+
+#: ../src/osx/cocoa/menu.mm:259
+#, fuzzy
+msgctxt "macOS menu name"
+msgid "Help"
+msgstr "Help"
+
+#: ../src/osx/cocoa/menu.mm:298
+#, fuzzy
+msgctxt "macOS menu item"
+msgid "Minimize"
+msgstr "Mi%nimalkan"
+
+#: ../src/osx/cocoa/menu.mm:303
+#, fuzzy
+msgctxt "macOS menu item"
+msgid "Zoom"
+msgstr "Perbesar"
+
+#: ../src/osx/cocoa/menu.mm:309
+msgctxt "macOS menu item"
+msgid "Bring All to Front"
+msgstr ""
+
+#: ../src/osx/core/sound.cpp:143
+#, c-format
+msgid "Failed to load sound from \"%s\" (error %d)."
+msgstr "Gagal memuat suara dari \"%s\" (galat %d)."
+
+#: ../src/osx/fontutil.cpp:80
+#, fuzzy, c-format
+msgid "Font file \"%s\" doesn't exist."
+msgstr ": berkas tidak ada!"
+
+#: ../src/osx/fontutil.cpp:88
+#, c-format
+msgid ""
+"Font file \"%s\" cannot be used as it is not inside the font directory "
+"\"%s\"."
+msgstr ""
+
+#: ../src/osx/menu_osx.cpp:496
+#, c-format
+msgctxt "macOS menu item"
+msgid "About %s"
+msgstr "Tentang %s"
+
+#: ../src/osx/menu_osx.cpp:499
+msgctxt "macOS menu item"
+msgid "About..."
+msgstr "Tentang..."
+
+#: ../src/osx/menu_osx.cpp:508
+msgctxt "macOS menu item"
+msgid "Preferences..."
+msgstr "Preferensi..."
+
+#: ../src/osx/menu_osx.cpp:512
+msgctxt "macOS menu item"
+msgid "Services"
+msgstr "Layanan"
+
+#: ../src/osx/menu_osx.cpp:519
+#, c-format
+msgctxt "macOS menu item"
+msgid "Hide %s"
+msgstr "Sembunyi: %s"
+
+#: ../src/osx/menu_osx.cpp:522
+#, fuzzy
+msgctxt "macOS menu item"
+msgid "Hide Application"
+msgstr "Aplikasi"
+
+#: ../src/osx/menu_osx.cpp:526
+msgctxt "macOS menu item"
+msgid "Hide Others"
+msgstr "Sembunyikan Lainnya"
+
+#: ../src/osx/menu_osx.cpp:528
+msgctxt "macOS menu item"
+msgid "Show All"
+msgstr "Tampilkan Semua"
+
+#: ../src/osx/menu_osx.cpp:534
+#, c-format
+msgctxt "macOS menu item"
+msgid "Quit %s"
+msgstr "Keluar %s"
+
+#: ../src/osx/menu_osx.cpp:537
+#, fuzzy
+msgctxt "macOS menu item"
+msgid "Quit Application"
+msgstr "Aplikasi"
+
+#: ../src/osx/webview_webkit.mm:444
+#, fuzzy
+msgid "Printing is not supported by the system web control"
+msgstr "Gzip tidak didukung oleh versi zlib ini"
+
+#: ../src/osx/webview_webkit.mm:453
+#, fuzzy
+msgid "Print operation could not be initialized"
+msgstr "Deskripsi kolom tidak dapat diinisialisasi."
+
+#. TRANSLATORS: Label of font point size
+#: ../src/propgrid/advprops.cpp:605
+msgid "Point Size"
+msgstr "Ukuran Point"
+
+#. TRANSLATORS: Label of font face name
+#: ../src/propgrid/advprops.cpp:615
+msgid "Face Name"
+msgstr "Nama Face"
+
+#. TRANSLATORS: Label of font style
+#: ../src/propgrid/advprops.cpp:623 ../src/richtext/richtextformatdlg.cpp:331
+msgid "Style"
+msgstr "Gaya"
+
+#. TRANSLATORS: Label of font weight
+#: ../src/propgrid/advprops.cpp:628
+msgid "Weight"
+msgstr "Berat"
+
+#. TRANSLATORS: Label of underlined font
+#: ../src/propgrid/advprops.cpp:633 ../src/richtext/richtextfontpage.cpp:358
+msgid "Underlined"
+msgstr "Garis dibawahi"
+
+#. TRANSLATORS: Label of font family
+#: ../src/propgrid/advprops.cpp:637
+msgid "Family"
+msgstr "Keluarga"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:801
+msgid "AppWorkspace"
+msgstr "RuangKerjaApp"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:802
+msgid "ActiveBorder"
+msgstr "TepiAktif"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:803
+msgid "ActiveCaption"
+msgstr "JudulAktif"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:804
+msgid "ButtonFace"
+msgstr "TampakMukaTombol"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:805
+msgid "ButtonHighlight"
+msgstr "KilauTombol"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:806
+msgid "ButtonShadow"
+msgstr "BayanganTombol"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:807
+msgid "ButtonText"
+msgstr "TeksTombol"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:808
+msgid "CaptionText"
+msgstr "TeksJudul"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:809
+msgid "ControlDark"
+msgstr "KendaliGelap"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:810
+msgid "ControlLight"
+msgstr "KendaliTerang"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:812
+msgid "GrayText"
+msgstr "TeksAbu"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:813
+msgid "Highlight"
+msgstr "Kilau"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:814
+msgid "HighlightText"
+msgstr "KilauTeks"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:815
+msgid "InactiveBorder"
+msgstr "TepiTakAktif"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:816
+msgid "InactiveCaption"
+msgstr "JudulTakAktif"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:817
+msgid "InactiveCaptionText"
+msgstr "TeksJudulTakAktif"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:818
+msgid "Menu"
+msgstr "Menu"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:819
+msgid "Scrollbar"
+msgstr "BatangScroll"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:820
+msgid "Tooltip"
+msgstr "Tooltip"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:821
+msgid "TooltipText"
+msgstr "TeksTooltip"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:822
+msgid "Window"
+msgstr "Window"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:823
+msgid "WindowFrame"
+msgstr "WindowFrame"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:824
+msgid "WindowText"
+msgstr "WindowText"
+
+#. TRANSLATORS: Custom colour choice entry
+#: ../src/propgrid/advprops.cpp:825 ../src/propgrid/advprops.cpp:1532
+#: ../src/propgrid/advprops.cpp:1576
+msgid "Custom"
+msgstr "Kustom"
+
+#: ../src/propgrid/advprops.cpp:1558
+msgid "Black"
+msgstr "Hitam"
+
+#: ../src/propgrid/advprops.cpp:1559
+msgid "Maroon"
+msgstr "Ungu Kemerahan"
+
+#: ../src/propgrid/advprops.cpp:1560
+msgid "Navy"
+msgstr "Biru Tua"
+
+#: ../src/propgrid/advprops.cpp:1561
+msgid "Purple"
+msgstr "Ungu"
+
+#: ../src/propgrid/advprops.cpp:1562
+msgid "Teal"
+msgstr "Hijau Kebiruan"
+
+#: ../src/propgrid/advprops.cpp:1563
+msgid "Gray"
+msgstr "Abu-abu"
+
+#: ../src/propgrid/advprops.cpp:1564
+msgid "Green"
+msgstr "Hijau"
+
+#: ../src/propgrid/advprops.cpp:1565
+msgid "Olive"
+msgstr "Coklat Muda"
+
+#: ../src/propgrid/advprops.cpp:1566
+msgid "Brown"
+msgstr "Coklat"
+
+#: ../src/propgrid/advprops.cpp:1567
+msgid "Blue"
+msgstr "Biru"
+
+#: ../src/propgrid/advprops.cpp:1568
+msgid "Fuchsia"
+msgstr "Merah Muda"
+
+#: ../src/propgrid/advprops.cpp:1569
+msgid "Red"
+msgstr "Merah"
+
+#: ../src/propgrid/advprops.cpp:1570
+msgid "Orange"
+msgstr "Jingga"
+
+#: ../src/propgrid/advprops.cpp:1571
+msgid "Silver"
+msgstr "Perak"
+
+#: ../src/propgrid/advprops.cpp:1572
+msgid "Lime"
+msgstr "Kunig Kehijauan"
+
+#: ../src/propgrid/advprops.cpp:1573
+msgid "Aqua"
+msgstr "Biru Muda"
+
+#: ../src/propgrid/advprops.cpp:1574
+msgid "Yellow"
+msgstr "Kuning"
+
+#: ../src/propgrid/advprops.cpp:1575
+msgid "White"
+msgstr "Putih"
+
+#: ../src/propgrid/advprops.cpp:1718
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Default"
+msgstr "Standar"
+
+#: ../src/propgrid/advprops.cpp:1719
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Arrow"
+msgstr "Panah"
+
+#: ../src/propgrid/advprops.cpp:1720
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Right Arrow"
+msgstr "Panah Kanan"
+
+#: ../src/propgrid/advprops.cpp:1721
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Blank"
+msgstr "Kosong"
+
+#: ../src/propgrid/advprops.cpp:1722
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Bullseye"
+msgstr "Sasaran"
+
+#: ../src/propgrid/advprops.cpp:1723
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Character"
+msgstr "Karakter"
+
+#: ../src/propgrid/advprops.cpp:1724
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Cross"
+msgstr "Silang"
+
+#: ../src/propgrid/advprops.cpp:1725
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Hand"
+msgstr "Tangan"
+
+#: ../src/propgrid/advprops.cpp:1726
+#, fuzzy
+msgctxt "system cursor name"
+msgid "I-Beam"
+msgstr "Batang-I"
+
+#: ../src/propgrid/advprops.cpp:1727
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Left Button"
+msgstr "Tombol Kiri"
+
+#: ../src/propgrid/advprops.cpp:1728
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Magnifier"
+msgstr "Kaca Pembesar"
+
+#: ../src/propgrid/advprops.cpp:1729
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Middle Button"
+msgstr "Tombol Kanan"
+
+#: ../src/propgrid/advprops.cpp:1730
+#, fuzzy
+msgctxt "system cursor name"
+msgid "No Entry"
+msgstr "Dilarang Masuk"
+
+#: ../src/propgrid/advprops.cpp:1731
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Paint Brush"
+msgstr "Kuas"
+
+#: ../src/propgrid/advprops.cpp:1732
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Pencil"
+msgstr "Pensil"
+
+#: ../src/propgrid/advprops.cpp:1733
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Point Left"
+msgstr "Tunjuk Kiri"
+
+#: ../src/propgrid/advprops.cpp:1734
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Point Right"
+msgstr "Tunjuk Kanan"
+
+#: ../src/propgrid/advprops.cpp:1735
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Question Arrow"
+msgstr "Panah Tanda Tanya"
+
+#: ../src/propgrid/advprops.cpp:1736
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Right Button"
+msgstr "Tombol Kanan"
+
+#: ../src/propgrid/advprops.cpp:1737
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Sizing NE-SW"
+msgstr "Sizing NE-SW"
+
+#: ../src/propgrid/advprops.cpp:1738
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Sizing N-S"
+msgstr "Ubah Utara-Selatan"
+
+#: ../src/propgrid/advprops.cpp:1739
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Sizing NW-SE"
+msgstr "Sizing NW-SE"
+
+#: ../src/propgrid/advprops.cpp:1740
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Sizing W-E"
+msgstr "Sizing W-E"
+
+#: ../src/propgrid/advprops.cpp:1741
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Sizing"
+msgstr "Sizing"
+
+#: ../src/propgrid/advprops.cpp:1742
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Spraycan"
+msgstr "Kaleng Cat"
+
+#: ../src/propgrid/advprops.cpp:1743
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Wait"
+msgstr "Tunggu"
+
+#: ../src/propgrid/advprops.cpp:1744
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Watch"
+msgstr "Jam"
+
+#: ../src/propgrid/advprops.cpp:1745
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Wait Arrow"
+msgstr "Panah Tunggu"
+
+#: ../src/propgrid/advprops.cpp:2109
+msgid "Make a selection:"
+msgstr "Buat seleksi:"
+
+#: ../src/propgrid/manager.cpp:394
+msgid "Property"
+msgstr "Properti"
+
+#: ../src/propgrid/manager.cpp:395
+msgid "Value"
+msgstr "Nilai"
+
+#: ../src/propgrid/manager.cpp:1683
+msgid "Categorized Mode"
+msgstr "Mode Terkategorisasi"
+
+#: ../src/propgrid/manager.cpp:1709
+msgid "Alphabetic Mode"
+msgstr "Mode Alfabet"
+
+#. TRANSLATORS: Name of Boolean false value
+#: ../src/propgrid/propgrid.cpp:230
+msgid "False"
+msgstr "False"
+
+#. TRANSLATORS: Name of Boolean true value
+#: ../src/propgrid/propgrid.cpp:232
+msgid "True"
+msgstr "True"
+
+#. TRANSLATORS: Text  displayed for unspecified value
+#: ../src/propgrid/propgrid.cpp:428
+msgid "Unspecified"
+msgstr "Tidak dijabarkan"
+
+#. TRANSLATORS: Caption of message box displaying any property error
+#: ../src/propgrid/propgrid.cpp:3145 ../src/propgrid/propgrid.cpp:3282
+msgid "Property Error"
+msgstr "Galat Properti"
+
+#: ../src/propgrid/propgrid.cpp:3259
+msgid "You have entered invalid value. Press ESC to cancel editing."
+msgstr ""
+"Kamu telah mengisi nilai yang salah. Tekan ESC untuk membatalkan suntingan."
+
+#: ../src/propgrid/propgrid.cpp:6608
+#, c-format
+msgid "Error in resource: %s"
+msgstr "Galat pada sumber %s"
+
+#: ../src/propgrid/propgridiface.cpp:377
+#, c-format
+msgid ""
+"Type operation \"%s\" failed: Property labeled \"%s\" is of type \"%s\", NOT "
+"\"%s\"."
+msgstr ""
+"Tipe operasi \"%s\" gagal: Label properti \"%s\" seharusnya tipe \"%s\", "
+"BUKAN \"%s\"."
+
+#: ../src/propgrid/props.cpp:159
+#, c-format
+msgid "Unknown base %d. Base 10 will be used."
+msgstr ""
+
+#: ../src/propgrid/props.cpp:324
+#, c-format
+msgid "Value must be %s or higher."
+msgstr "Nilai harus %s atau lebih besar."
+
+#: ../src/propgrid/props.cpp:329 ../src/propgrid/props.cpp:356
+#, c-format
+msgid "Value must be between %s and %s."
+msgstr "Nilai harus di antara %s dan %s."
+
+#: ../src/propgrid/props.cpp:351
+#, c-format
+msgid "Value must be %s or less."
+msgstr "Nilai harus %s atau lebih kecil."
+
+#: ../src/propgrid/props.cpp:1058
+#, c-format
+msgid "Not %s"
+msgstr "Bukan %s"
+
+#: ../src/propgrid/props.cpp:1770
+msgid "Choose a directory:"
+msgstr "Pilih direktori:"
+
+#: ../src/propgrid/props.cpp:2055
+msgid "Choose a file"
+msgstr "Pilih berkas"
+
+#: ../src/qt/mdi.cpp:254
+msgid "&Tile"
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:147
+#: ../src/richtext/richtextformatdlg.cpp:376
+msgid "Background"
+msgstr "Latar belakang"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:159
+msgid "Background &colour:"
+msgstr "Warna &latar belakang:"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:161
+#: ../src/richtext/richtextbackgroundpage.cpp:163
+msgid "Enables a background colour."
+msgstr "Aktifkan warna background."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:167
+#: ../src/richtext/richtextbackgroundpage.cpp:169
+msgid "The background colour."
+msgstr "Warna background."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:178
+msgid "Shadow"
+msgstr "Bayangan"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:193
+msgid "Use &shadow"
+msgstr "Gunakan &bayangan"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:195
+#: ../src/richtext/richtextbackgroundpage.cpp:197
+msgid "Enables a shadow."
+msgstr "Aktifkan bayangan."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:211
+msgid "&Horizontal offset:"
+msgstr "Jarak &horizontal:"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:218
+#: ../src/richtext/richtextbackgroundpage.cpp:220
+msgid "The horizontal offset."
+msgstr "Jarak horizontal."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:224
+#: ../src/richtext/richtextbackgroundpage.cpp:227
+#: ../src/richtext/richtextbackgroundpage.cpp:228
+#: ../src/richtext/richtextbackgroundpage.cpp:247
+#: ../src/richtext/richtextbackgroundpage.cpp:250
+#: ../src/richtext/richtextbackgroundpage.cpp:251
+#: ../src/richtext/richtextbackgroundpage.cpp:287
+#: ../src/richtext/richtextbackgroundpage.cpp:290
+#: ../src/richtext/richtextbackgroundpage.cpp:291
+#: ../src/richtext/richtextbackgroundpage.cpp:314
+#: ../src/richtext/richtextbackgroundpage.cpp:317
+#: ../src/richtext/richtextbackgroundpage.cpp:318
+#: ../src/richtext/richtextborderspage.cpp:252
+#: ../src/richtext/richtextborderspage.cpp:255
+#: ../src/richtext/richtextborderspage.cpp:256
+#: ../src/richtext/richtextborderspage.cpp:286
+#: ../src/richtext/richtextborderspage.cpp:289
+#: ../src/richtext/richtextborderspage.cpp:290
+#: ../src/richtext/richtextborderspage.cpp:320
+#: ../src/richtext/richtextborderspage.cpp:323
+#: ../src/richtext/richtextborderspage.cpp:324
+#: ../src/richtext/richtextborderspage.cpp:354
+#: ../src/richtext/richtextborderspage.cpp:357
+#: ../src/richtext/richtextborderspage.cpp:358
+#: ../src/richtext/richtextborderspage.cpp:420
+#: ../src/richtext/richtextborderspage.cpp:423
+#: ../src/richtext/richtextborderspage.cpp:424
+#: ../src/richtext/richtextborderspage.cpp:454
+#: ../src/richtext/richtextborderspage.cpp:457
+#: ../src/richtext/richtextborderspage.cpp:458
+#: ../src/richtext/richtextborderspage.cpp:488
+#: ../src/richtext/richtextborderspage.cpp:491
+#: ../src/richtext/richtextborderspage.cpp:492
+#: ../src/richtext/richtextborderspage.cpp:522
+#: ../src/richtext/richtextborderspage.cpp:525
+#: ../src/richtext/richtextborderspage.cpp:526
+#: ../src/richtext/richtextborderspage.cpp:590
+#: ../src/richtext/richtextborderspage.cpp:593
+#: ../src/richtext/richtextborderspage.cpp:594
+#: ../src/richtext/richtextfontpage.cpp:177
+#: ../src/richtext/richtextmarginspage.cpp:199
+#: ../src/richtext/richtextmarginspage.cpp:201
+#: ../src/richtext/richtextmarginspage.cpp:202
+#: ../src/richtext/richtextmarginspage.cpp:224
+#: ../src/richtext/richtextmarginspage.cpp:226
+#: ../src/richtext/richtextmarginspage.cpp:227
+#: ../src/richtext/richtextmarginspage.cpp:247
+#: ../src/richtext/richtextmarginspage.cpp:249
+#: ../src/richtext/richtextmarginspage.cpp:250
+#: ../src/richtext/richtextmarginspage.cpp:272
+#: ../src/richtext/richtextmarginspage.cpp:274
+#: ../src/richtext/richtextmarginspage.cpp:275
+#: ../src/richtext/richtextmarginspage.cpp:313
+#: ../src/richtext/richtextmarginspage.cpp:315
+#: ../src/richtext/richtextmarginspage.cpp:316
+#: ../src/richtext/richtextmarginspage.cpp:338
+#: ../src/richtext/richtextmarginspage.cpp:340
+#: ../src/richtext/richtextmarginspage.cpp:341
+#: ../src/richtext/richtextmarginspage.cpp:361
+#: ../src/richtext/richtextmarginspage.cpp:363
+#: ../src/richtext/richtextmarginspage.cpp:364
+#: ../src/richtext/richtextmarginspage.cpp:386
+#: ../src/richtext/richtextmarginspage.cpp:388
+#: ../src/richtext/richtextmarginspage.cpp:389
+#: ../src/richtext/richtextsizepage.cpp:337
+#: ../src/richtext/richtextsizepage.cpp:340
+#: ../src/richtext/richtextsizepage.cpp:341
+#: ../src/richtext/richtextsizepage.cpp:371
+#: ../src/richtext/richtextsizepage.cpp:374
+#: ../src/richtext/richtextsizepage.cpp:375
+#: ../src/richtext/richtextsizepage.cpp:398
+#: ../src/richtext/richtextsizepage.cpp:401
+#: ../src/richtext/richtextsizepage.cpp:402
+#: ../src/richtext/richtextsizepage.cpp:425
+#: ../src/richtext/richtextsizepage.cpp:428
+#: ../src/richtext/richtextsizepage.cpp:429
+#: ../src/richtext/richtextsizepage.cpp:452
+#: ../src/richtext/richtextsizepage.cpp:455
+#: ../src/richtext/richtextsizepage.cpp:456
+#: ../src/richtext/richtextsizepage.cpp:479
+#: ../src/richtext/richtextsizepage.cpp:482
+#: ../src/richtext/richtextsizepage.cpp:483
+#: ../src/richtext/richtextsizepage.cpp:553
+#: ../src/richtext/richtextsizepage.cpp:556
+#: ../src/richtext/richtextsizepage.cpp:557
+#: ../src/richtext/richtextsizepage.cpp:588
+#: ../src/richtext/richtextsizepage.cpp:591
+#: ../src/richtext/richtextsizepage.cpp:592
+#: ../src/richtext/richtextsizepage.cpp:623
+#: ../src/richtext/richtextsizepage.cpp:626
+#: ../src/richtext/richtextsizepage.cpp:627
+#: ../src/richtext/richtextsizepage.cpp:658
+#: ../src/richtext/richtextsizepage.cpp:661
+#: ../src/richtext/richtextsizepage.cpp:662
+msgid "px"
+msgstr "px"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:225
+#: ../src/richtext/richtextbackgroundpage.cpp:248
+#: ../src/richtext/richtextbackgroundpage.cpp:288
+#: ../src/richtext/richtextbackgroundpage.cpp:315
+#: ../src/richtext/richtextborderspage.cpp:253
+#: ../src/richtext/richtextborderspage.cpp:287
+#: ../src/richtext/richtextborderspage.cpp:321
+#: ../src/richtext/richtextborderspage.cpp:355
+#: ../src/richtext/richtextborderspage.cpp:421
+#: ../src/richtext/richtextborderspage.cpp:455
+#: ../src/richtext/richtextborderspage.cpp:489
+#: ../src/richtext/richtextborderspage.cpp:523
+#: ../src/richtext/richtextborderspage.cpp:591
+#: ../src/richtext/richtextmarginspage.cpp:200
+#: ../src/richtext/richtextmarginspage.cpp:225
+#: ../src/richtext/richtextmarginspage.cpp:248
+#: ../src/richtext/richtextmarginspage.cpp:273
+#: ../src/richtext/richtextmarginspage.cpp:314
+#: ../src/richtext/richtextmarginspage.cpp:339
+#: ../src/richtext/richtextmarginspage.cpp:362
+#: ../src/richtext/richtextmarginspage.cpp:387
+#: ../src/richtext/richtextsizepage.cpp:338
+#: ../src/richtext/richtextsizepage.cpp:372
+#: ../src/richtext/richtextsizepage.cpp:399
+#: ../src/richtext/richtextsizepage.cpp:426
+#: ../src/richtext/richtextsizepage.cpp:453
+#: ../src/richtext/richtextsizepage.cpp:480
+#: ../src/richtext/richtextsizepage.cpp:554
+#: ../src/richtext/richtextsizepage.cpp:589
+#: ../src/richtext/richtextsizepage.cpp:624
+#: ../src/richtext/richtextsizepage.cpp:659
+msgid "cm"
+msgstr "cm"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:226
+#: ../src/richtext/richtextbackgroundpage.cpp:249
+#: ../src/richtext/richtextbackgroundpage.cpp:289
+#: ../src/richtext/richtextbackgroundpage.cpp:316
+#: ../src/richtext/richtextborderspage.cpp:254
+#: ../src/richtext/richtextborderspage.cpp:288
+#: ../src/richtext/richtextborderspage.cpp:322
+#: ../src/richtext/richtextborderspage.cpp:356
+#: ../src/richtext/richtextborderspage.cpp:422
+#: ../src/richtext/richtextborderspage.cpp:456
+#: ../src/richtext/richtextborderspage.cpp:490
+#: ../src/richtext/richtextborderspage.cpp:524
+#: ../src/richtext/richtextborderspage.cpp:592
+#: ../src/richtext/richtextfontpage.cpp:176
+#: ../src/richtext/richtextfontpage.cpp:179
+msgid "pt"
+msgstr "pt"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:229
+#: ../src/richtext/richtextbackgroundpage.cpp:231
+#: ../src/richtext/richtextbackgroundpage.cpp:252
+#: ../src/richtext/richtextbackgroundpage.cpp:254
+#: ../src/richtext/richtextbackgroundpage.cpp:292
+#: ../src/richtext/richtextbackgroundpage.cpp:294
+#: ../src/richtext/richtextbackgroundpage.cpp:319
+#: ../src/richtext/richtextbackgroundpage.cpp:321
+msgid "Units for this value."
+msgstr "Unit untuk nilai ini."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:234
+msgid "&Vertical offset:"
+msgstr "Jarak &vertikal:"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:241
+#: ../src/richtext/richtextbackgroundpage.cpp:243
+msgid "The vertical offset."
+msgstr "Jarak vertikal."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:257
+msgid "Shadow c&olour:"
+msgstr "&Warna bayangan:"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:259
+#: ../src/richtext/richtextbackgroundpage.cpp:261
+msgid "Enables the shadow colour."
+msgstr "Aktifkan warna bayangan."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:265
+#: ../src/richtext/richtextbackgroundpage.cpp:267
+msgid "The shadow colour."
+msgstr "Warna bayangan."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:270
+msgid "Sh&adow spread:"
+msgstr "Sebaran b&ayangan:"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:272
+#: ../src/richtext/richtextbackgroundpage.cpp:274
+msgid "Enables the shadow spread."
+msgstr "Aktifkan sebaran bayangan."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:281
+#: ../src/richtext/richtextbackgroundpage.cpp:283
+msgid "The shadow spread."
+msgstr "Sebaran bayangan."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:297
+msgid "&Blur distance:"
+msgstr "Jarak &blur:"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:299
+#: ../src/richtext/richtextbackgroundpage.cpp:301
+msgid "Enables the blur distance."
+msgstr "Aktifkan jarak blur."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:308
+#: ../src/richtext/richtextbackgroundpage.cpp:310
+msgid "The shadow blur distance."
+msgstr "Jarak blur bayangan."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:324
+msgid "Opaci&ty:"
+msgstr "Opaci&tas:"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:326
+#: ../src/richtext/richtextbackgroundpage.cpp:328
+msgid "Enables the shadow opacity."
+msgstr "Aktifkan opasitas bayangan."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:335
+#: ../src/richtext/richtextbackgroundpage.cpp:337
+msgid "The shadow opacity."
+msgstr "Opasitas bayangan."
+
+#. TRANSLATORS: Rich text page units (percentage)
+#: ../src/richtext/richtextbackgroundpage.cpp:340
+#: ../src/richtext/richtextsizepage.cpp:339
+#: ../src/richtext/richtextsizepage.cpp:373
+#: ../src/richtext/richtextsizepage.cpp:400
+#: ../src/richtext/richtextsizepage.cpp:427
+#: ../src/richtext/richtextsizepage.cpp:454
+#: ../src/richtext/richtextsizepage.cpp:481
+#: ../src/richtext/richtextsizepage.cpp:555
+#: ../src/richtext/richtextsizepage.cpp:590
+#: ../src/richtext/richtextsizepage.cpp:625
+#: ../src/richtext/richtextsizepage.cpp:660
+msgid "%"
+msgstr "%"
+
+#: ../src/richtext/richtextborderspage.cpp:229
+#: ../src/richtext/richtextborderspage.cpp:387
+msgid "Border"
+msgstr "Tepi"
+
+#: ../src/richtext/richtextborderspage.cpp:242
+#: ../src/richtext/richtextborderspage.cpp:410
+#: ../src/richtext/richtextindentspage.cpp:194
+#: ../src/richtext/richtextliststylepage.cpp:384
+#: ../src/richtext/richtextmarginspage.cpp:185
+#: ../src/richtext/richtextmarginspage.cpp:299
+#: ../src/richtext/richtextsizepage.cpp:531
+#: ../src/richtext/richtextsizepage.cpp:538
+msgid "&Left:"
+msgstr "&Kiri:"
+
+#: ../src/richtext/richtextborderspage.cpp:257
+#: ../src/richtext/richtextborderspage.cpp:259
+msgid "Units for the left border width."
+msgstr "Unit untuk lebar tepi kiri."
+
+#: ../src/richtext/richtextborderspage.cpp:266
+#: ../src/richtext/richtextborderspage.cpp:268
+#: ../src/richtext/richtextborderspage.cpp:300
+#: ../src/richtext/richtextborderspage.cpp:302
+#: ../src/richtext/richtextborderspage.cpp:334
+#: ../src/richtext/richtextborderspage.cpp:336
+#: ../src/richtext/richtextborderspage.cpp:368
+#: ../src/richtext/richtextborderspage.cpp:370
+#: ../src/richtext/richtextborderspage.cpp:434
+#: ../src/richtext/richtextborderspage.cpp:436
+#: ../src/richtext/richtextborderspage.cpp:468
+#: ../src/richtext/richtextborderspage.cpp:470
+#: ../src/richtext/richtextborderspage.cpp:502
+#: ../src/richtext/richtextborderspage.cpp:504
+#: ../src/richtext/richtextborderspage.cpp:536
+#: ../src/richtext/richtextborderspage.cpp:538
+msgid "The border line style."
+msgstr "Gaya garis tepi."
+
+#: ../src/richtext/richtextborderspage.cpp:276
+#: ../src/richtext/richtextborderspage.cpp:444
+#: ../src/richtext/richtextindentspage.cpp:212
+#: ../src/richtext/richtextliststylepage.cpp:402
+#: ../src/richtext/richtextmarginspage.cpp:210
+#: ../src/richtext/richtextmarginspage.cpp:324
+#: ../src/richtext/richtextsizepage.cpp:601
+#: ../src/richtext/richtextsizepage.cpp:608
+msgid "&Right:"
+msgstr "&Kanan:"
+
+#: ../src/richtext/richtextborderspage.cpp:291
+#: ../src/richtext/richtextborderspage.cpp:293
+msgid "Units for the right border width."
+msgstr "Unit untuk lebar tepi kanan."
+
+#: ../src/richtext/richtextborderspage.cpp:310
+#: ../src/richtext/richtextborderspage.cpp:478
+#: ../src/richtext/richtextmarginspage.cpp:233
+#: ../src/richtext/richtextmarginspage.cpp:347
+#: ../src/richtext/richtextsizepage.cpp:566
+#: ../src/richtext/richtextsizepage.cpp:573
+msgid "&Top:"
+msgstr "A&tas:"
+
+#: ../src/richtext/richtextborderspage.cpp:325
+#: ../src/richtext/richtextborderspage.cpp:327
+msgid "Units for the top border width."
+msgstr "Unit untuk lebar tepi atas."
+
+#: ../src/richtext/richtextborderspage.cpp:344
+#: ../src/richtext/richtextborderspage.cpp:512
+#: ../src/richtext/richtextmarginspage.cpp:258
+#: ../src/richtext/richtextmarginspage.cpp:372
+#: ../src/richtext/richtextsizepage.cpp:636
+#: ../src/richtext/richtextsizepage.cpp:643
+msgid "&Bottom:"
+msgstr "&Bawah:"
+
+#: ../src/richtext/richtextborderspage.cpp:359
+#: ../src/richtext/richtextborderspage.cpp:361
+msgid "Units for the bottom border width."
+msgstr "Unit untuk lebar tepi bawah."
+
+#: ../src/richtext/richtextborderspage.cpp:380
+#: ../src/richtext/richtextborderspage.cpp:548
+msgid "&Synchronize values"
+msgstr "&Sinkronisasikan nilai"
+
+#: ../src/richtext/richtextborderspage.cpp:382
+#: ../src/richtext/richtextborderspage.cpp:384
+#: ../src/richtext/richtextborderspage.cpp:550
+#: ../src/richtext/richtextborderspage.cpp:552
+msgid "Check to edit all borders simultaneously."
+msgstr "Centang untuk menyunting tepi secara bersamaan."
+
+#: ../src/richtext/richtextborderspage.cpp:397
+#: ../src/richtext/richtextborderspage.cpp:555
+msgid "Outline"
+msgstr "Outline"
+
+#: ../src/richtext/richtextborderspage.cpp:425
+#: ../src/richtext/richtextborderspage.cpp:427
+msgid "Units for the left outline width."
+msgstr "Unit untuk lebar ikhtisar kiri."
+
+#: ../src/richtext/richtextborderspage.cpp:459
+#: ../src/richtext/richtextborderspage.cpp:461
+msgid "Units for the right outline width."
+msgstr "Unit untuk lebar ikhtisar kanan."
+
+#: ../src/richtext/richtextborderspage.cpp:493
+#: ../src/richtext/richtextborderspage.cpp:495
+msgid "Units for the top outline width."
+msgstr "Unit untuk lebar ikhtisar atas."
+
+#: ../src/richtext/richtextborderspage.cpp:527
+#: ../src/richtext/richtextborderspage.cpp:529
+msgid "Units for the bottom outline width."
+msgstr "Unit untuk lebar ikhtisar bawah."
+
+#: ../src/richtext/richtextborderspage.cpp:565
+#: ../src/richtext/richtextborderspage.cpp:600
+msgid "Corner"
+msgstr "Pojok"
+
+#: ../src/richtext/richtextborderspage.cpp:574
+msgid "Corner &radius:"
+msgstr "&Radius pojokan:"
+
+#: ../src/richtext/richtextborderspage.cpp:576
+#: ../src/richtext/richtextborderspage.cpp:578
+msgid "An optional corner radius for adding rounded corners."
+msgstr "Opsi radius pojok untuk menambahkan pojokan melengkung."
+
+#: ../src/richtext/richtextborderspage.cpp:584
+#: ../src/richtext/richtextborderspage.cpp:586
+msgid "The value of the corner radius."
+msgstr "Nilai radius pojokan."
+
+#: ../src/richtext/richtextborderspage.cpp:595
+#: ../src/richtext/richtextborderspage.cpp:597
+msgid "Units for the corner radius."
+msgstr "Unit untuk radius pojokan."
+
+#: ../src/richtext/richtextborderspage.cpp:609
+#: ../src/richtext/richtextsizepage.cpp:247
+#: ../src/richtext/richtextsizepage.cpp:251
+msgid "None"
+msgstr "Tidak ada"
+
+#: ../src/richtext/richtextborderspage.cpp:610
+msgid "Solid"
+msgstr "Padat"
+
+#: ../src/richtext/richtextborderspage.cpp:611
+msgid "Dotted"
+msgstr "Titik"
+
+#: ../src/richtext/richtextborderspage.cpp:612
+msgid "Dashed"
+msgstr "Melesat"
+
+#: ../src/richtext/richtextborderspage.cpp:613
+msgid "Double"
+msgstr "Ganda"
+
+#: ../src/richtext/richtextborderspage.cpp:614
+msgid "Groove"
+msgstr "Groove"
+
+#: ../src/richtext/richtextborderspage.cpp:615
+msgid "Ridge"
+msgstr "Punggung"
+
+#: ../src/richtext/richtextborderspage.cpp:616
+msgid "Inset"
+msgstr "Inset"
+
+#: ../src/richtext/richtextborderspage.cpp:617
+msgid "Outset"
+msgstr "Outset"
+
+#: ../src/richtext/richtextbuffer.cpp:3518
+msgid "Change Style"
+msgstr "Ubah Gaya"
+
+#: ../src/richtext/richtextbuffer.cpp:3701
+msgid "Change Object Style"
+msgstr "Ubah Gaya Obyek"
+
+#: ../src/richtext/richtextbuffer.cpp:3974
+#: ../src/richtext/richtextbuffer.cpp:8174
+msgid "Change Properties"
+msgstr "Ubah Properti"
+
+#: ../src/richtext/richtextbuffer.cpp:4346
+msgid "Change List Style"
+msgstr "Ubah Gaya Daftar"
+
+#: ../src/richtext/richtextbuffer.cpp:4519
+msgid "Renumber List"
+msgstr "Nomori Ulang Daftar"
+
+#: ../src/richtext/richtextbuffer.cpp:7867
+#: ../src/richtext/richtextbuffer.cpp:7897
+#: ../src/richtext/richtextbuffer.cpp:7939
+#: ../src/richtext/richtextctrl.cpp:1279 ../src/richtext/richtextctrl.cpp:1473
+msgid "Insert Text"
+msgstr "Sisipkan Teks"
+
+#: ../src/richtext/richtextbuffer.cpp:8023
+#: ../src/richtext/richtextbuffer.cpp:8979
+msgid "Insert Image"
+msgstr "Sisipkan Citra"
+
+#: ../src/richtext/richtextbuffer.cpp:8070
+msgid "Insert Object"
+msgstr "Sisipkan Obyek"
+
+#: ../src/richtext/richtextbuffer.cpp:8112
+msgid "Insert Field"
+msgstr "Sisipkan Kolom"
+
+#: ../src/richtext/richtextbuffer.cpp:8410
+msgid "Too many EndStyle calls!"
+msgstr "Terlalu banyak pemanggilan EndStyle!"
+
+#: ../src/richtext/richtextbuffer.cpp:8785
+msgid "files"
+msgstr "berkas"
+
+#: ../src/richtext/richtextbuffer.cpp:9380
+msgid "standard/circle"
+msgstr "standar/lingkaran"
+
+#: ../src/richtext/richtextbuffer.cpp:9381
+msgid "standard/circle-outline"
+msgstr "standar/lingkaran-ikhtisar"
+
+#: ../src/richtext/richtextbuffer.cpp:9382
+msgid "standard/square"
+msgstr "standar/bujur sangkar"
+
+#: ../src/richtext/richtextbuffer.cpp:9383
+msgid "standard/diamond"
+msgstr "standar/intan"
+
+#: ../src/richtext/richtextbuffer.cpp:9384
+msgid "standard/triangle"
+msgstr "standar/segitiga"
+
+#: ../src/richtext/richtextbuffer.cpp:9423
+msgid "Box Properties"
+msgstr "Properti Kotak"
+
+#: ../src/richtext/richtextbuffer.cpp:10006
+msgid "Multiple Cell Properties"
+msgstr "Properti Multi Sel"
+
+#: ../src/richtext/richtextbuffer.cpp:10008
+msgid "Cell Properties"
+msgstr "Properti Sel"
+
+#: ../src/richtext/richtextbuffer.cpp:11256
+msgid "Set Cell Style"
+msgstr "Atur Gaya Sel"
+
+#: ../src/richtext/richtextbuffer.cpp:11330
+msgid "Delete Row"
+msgstr "Hapus Baris"
+
+#: ../src/richtext/richtextbuffer.cpp:11380
+msgid "Delete Column"
+msgstr "Hapus Kolom"
+
+#: ../src/richtext/richtextbuffer.cpp:11431
+msgid "Add Row"
+msgstr "Tambah Baris"
+
+#: ../src/richtext/richtextbuffer.cpp:11494
+msgid "Add Column"
+msgstr "Tambah Kolom"
+
+#: ../src/richtext/richtextbuffer.cpp:11537
+msgid "Table Properties"
+msgstr "Properti Tabel"
+
+#: ../src/richtext/richtextbuffer.cpp:12899
+msgid "Picture Properties"
+msgstr "Properti Citra"
+
+#: ../src/richtext/richtextbuffer.cpp:13169
+#: ../src/richtext/richtextbuffer.cpp:13279
+msgid "image"
+msgstr "citra"
+
+#: ../src/richtext/richtextbulletspage.cpp:145
+#: ../src/richtext/richtextliststylepage.cpp:209
+msgid "&Bullet style:"
+msgstr "&Gaya bullet:"
+
+#: ../src/richtext/richtextbulletspage.cpp:150
+#: ../src/richtext/richtextbulletspage.cpp:152
+#: ../src/richtext/richtextliststylepage.cpp:214
+#: ../src/richtext/richtextliststylepage.cpp:216
+msgid "The available bullet styles."
+msgstr "Gaya bullet yang tersedia."
+
+#: ../src/richtext/richtextbulletspage.cpp:158
+#: ../src/richtext/richtextliststylepage.cpp:221
+msgid "Peri&od"
+msgstr "Peri&ode"
+
+#: ../src/richtext/richtextbulletspage.cpp:160
+#: ../src/richtext/richtextbulletspage.cpp:162
+#: ../src/richtext/richtextliststylepage.cpp:223
+#: ../src/richtext/richtextliststylepage.cpp:225
+msgid "Check to add a period after the bullet."
+msgstr "Centang untuk menambah titik setelah bullet."
+
+#. TRANSLATORS: Bullet point in parentheses option
+#: ../src/richtext/richtextbulletspage.cpp:167
+#: ../src/richtext/richtextliststylepage.cpp:230
+msgid "(*)"
+msgstr "(*)"
+
+#: ../src/richtext/richtextbulletspage.cpp:169
+#: ../src/richtext/richtextbulletspage.cpp:171
+#: ../src/richtext/richtextliststylepage.cpp:232
+#: ../src/richtext/richtextliststylepage.cpp:234
+msgid "Check to enclose the bullet in parentheses."
+msgstr "Centang untuk mengapit bullet dalam tanda kurung."
+
+#. TRANSLATORS: Right parenthesis bullet point option
+#: ../src/richtext/richtextbulletspage.cpp:176
+#: ../src/richtext/richtextliststylepage.cpp:239
+msgid "*)"
+msgstr "*)"
+
+#: ../src/richtext/richtextbulletspage.cpp:178
+#: ../src/richtext/richtextbulletspage.cpp:180
+#: ../src/richtext/richtextliststylepage.cpp:241
+#: ../src/richtext/richtextliststylepage.cpp:243
+msgid "Check to add a right parenthesis."
+msgstr "Centang untuk menambah tanda kurung tutup."
+
+#: ../src/richtext/richtextbulletspage.cpp:185
+#: ../src/richtext/richtextliststylepage.cpp:248
+msgid "Bullet &Alignment:"
+msgstr "Per&ataan Bullet:"
+
+#: ../src/richtext/richtextbulletspage.cpp:190
+#: ../src/richtext/richtextliststylepage.cpp:253
+msgid "Centre"
+msgstr "Tengah"
+
+#: ../src/richtext/richtextbulletspage.cpp:194
+#: ../src/richtext/richtextbulletspage.cpp:196
+#: ../src/richtext/richtextbulletspage.cpp:217
+#: ../src/richtext/richtextbulletspage.cpp:219
+#: ../src/richtext/richtextliststylepage.cpp:257
+#: ../src/richtext/richtextliststylepage.cpp:259
+#: ../src/richtext/richtextliststylepage.cpp:278
+#: ../src/richtext/richtextliststylepage.cpp:280
+msgid "The bullet character."
+msgstr "Karakter bullet."
+
+#: ../src/richtext/richtextbulletspage.cpp:212
+#: ../src/richtext/richtextliststylepage.cpp:271
+msgid "&Symbol:"
+msgstr "&Simbol:"
+
+#: ../src/richtext/richtextbulletspage.cpp:222
+#: ../src/richtext/richtextliststylepage.cpp:283
+msgid "Ch&oose..."
+msgstr "Pi&lih..."
+
+#: ../src/richtext/richtextbulletspage.cpp:223
+#: ../src/richtext/richtextbulletspage.cpp:225
+#: ../src/richtext/richtextliststylepage.cpp:284
+#: ../src/richtext/richtextliststylepage.cpp:286
+msgid "Click to browse for a symbol."
+msgstr "Klik untuk meramban simbol."
+
+#: ../src/richtext/richtextbulletspage.cpp:230
+#: ../src/richtext/richtextliststylepage.cpp:291
+msgid "Symbol &font:"
+msgstr "Simbol &font:"
+
+#: ../src/richtext/richtextbulletspage.cpp:235
+#: ../src/richtext/richtextbulletspage.cpp:237
+#: ../src/richtext/richtextliststylepage.cpp:297
+msgid "Available fonts."
+msgstr "Font yang tesedia."
+
+#: ../src/richtext/richtextbulletspage.cpp:242
+#: ../src/richtext/richtextliststylepage.cpp:302
+msgid "S&tandard bullet name:"
+msgstr "Nama s&tandar bullet:"
+
+#: ../src/richtext/richtextbulletspage.cpp:247
+#: ../src/richtext/richtextbulletspage.cpp:249
+#: ../src/richtext/richtextliststylepage.cpp:307
+#: ../src/richtext/richtextliststylepage.cpp:309
+msgid "A standard bullet name."
+msgstr "Nama bullet standar."
+
+#: ../src/richtext/richtextbulletspage.cpp:254
+msgid "&Number:"
+msgstr "&Nomor:"
+
+#: ../src/richtext/richtextbulletspage.cpp:258
+#: ../src/richtext/richtextbulletspage.cpp:260
+msgid "The list item number."
+msgstr "Nomor butir daftar."
+
+#: ../src/richtext/richtextbulletspage.cpp:266
+#: ../src/richtext/richtextbulletspage.cpp:268
+#: ../src/richtext/richtextliststylepage.cpp:475
+#: ../src/richtext/richtextliststylepage.cpp:477
+msgid "Shows a preview of the bullet settings."
+msgstr "Tampilkan pratinjau pengaturan bullet."
+
+#: ../src/richtext/richtextbulletspage.cpp:276
+#: ../src/richtext/richtextliststylepage.cpp:484
+msgid "(None)"
+msgstr "(Nihil)"
+
+#: ../src/richtext/richtextbulletspage.cpp:277
+#: ../src/richtext/richtextliststylepage.cpp:485
+msgid "Arabic"
+msgstr "Arab"
+
+#: ../src/richtext/richtextbulletspage.cpp:278
+#: ../src/richtext/richtextliststylepage.cpp:486
+msgid "Upper case letters"
+msgstr "Huruf besar"
+
+#: ../src/richtext/richtextbulletspage.cpp:279
+#: ../src/richtext/richtextliststylepage.cpp:487
+msgid "Lower case letters"
+msgstr "Huruf kecil"
+
+#: ../src/richtext/richtextbulletspage.cpp:280
+#: ../src/richtext/richtextliststylepage.cpp:488
+msgid "Upper case roman numerals"
+msgstr "Huruf besar romawi"
+
+#: ../src/richtext/richtextbulletspage.cpp:281
+#: ../src/richtext/richtextliststylepage.cpp:489
+msgid "Lower case roman numerals"
+msgstr "Huruf kecil angka romawi"
+
+#: ../src/richtext/richtextbulletspage.cpp:282
+#: ../src/richtext/richtextliststylepage.cpp:490
+msgid "Numbered outline"
+msgstr "Ikhtisar bernomor"
+
+#: ../src/richtext/richtextbulletspage.cpp:283
+#: ../src/richtext/richtextliststylepage.cpp:491
+msgid "Symbol"
+msgstr "Simbol"
+
+#: ../src/richtext/richtextbulletspage.cpp:284
+#: ../src/richtext/richtextliststylepage.cpp:492
+msgid "Bitmap"
+msgstr "Bitmap"
+
+#: ../src/richtext/richtextbulletspage.cpp:285
+#: ../src/richtext/richtextliststylepage.cpp:493
+msgid "Standard"
+msgstr "Standar"
+
+#: ../src/richtext/richtextbulletspage.cpp:287
+#: ../src/richtext/richtextliststylepage.cpp:495
+msgid "*"
+msgstr "*"
+
+#: ../src/richtext/richtextbulletspage.cpp:288
+#: ../src/richtext/richtextliststylepage.cpp:496
+msgid "-"
+msgstr "-"
+
+#: ../src/richtext/richtextbulletspage.cpp:289
+#: ../src/richtext/richtextliststylepage.cpp:497
+msgid ">"
+msgstr ">"
+
+#: ../src/richtext/richtextbulletspage.cpp:290
+#: ../src/richtext/richtextliststylepage.cpp:498
+msgid "+"
+msgstr "+"
+
+#: ../src/richtext/richtextbulletspage.cpp:291
+#: ../src/richtext/richtextliststylepage.cpp:499
+msgid "~"
+msgstr "~"
+
+#: ../src/richtext/richtextctrl.cpp:859
+msgid "Drag"
+msgstr "Geser"
+
+#: ../src/richtext/richtextctrl.cpp:1338 ../src/richtext/richtextctrl.cpp:1559
+msgid "Delete Text"
+msgstr "Hapus Teks"
+
+#: ../src/richtext/richtextctrl.cpp:1537
+msgid "Remove Bullet"
+msgstr "Hapus Bullet"
+
+#: ../src/richtext/richtextctrl.cpp:3070
+msgid "The text couldn't be saved."
+msgstr "Teks tidak bisa disimpan."
+
+#: ../src/richtext/richtextctrl.cpp:3644
+msgid "Replace"
+msgstr "Timpa"
+
+#: ../src/richtext/richtextfontpage.cpp:146
+#: ../src/richtext/richtextsymboldlg.cpp:384
+msgid "&Font:"
+msgstr "&Font:"
+
+#: ../src/richtext/richtextfontpage.cpp:150
+#: ../src/richtext/richtextfontpage.cpp:152
+msgid "Type a font name."
+msgstr "Ketik nama font."
+
+#: ../src/richtext/richtextfontpage.cpp:158
+msgid "&Size:"
+msgstr "&Ukuran:"
+
+#: ../src/richtext/richtextfontpage.cpp:165
+#: ../src/richtext/richtextfontpage.cpp:167
+msgid "Type a size in points."
+msgstr "Ketik ukuran dalam point."
+
+#: ../src/richtext/richtextfontpage.cpp:180
+#: ../src/richtext/richtextfontpage.cpp:182
+msgid "The font size units, points or pixels."
+msgstr "Ukuran font, dalam point atau pixel."
+
+#: ../src/richtext/richtextfontpage.cpp:189
+#: ../src/richtext/richtextfontpage.cpp:191
+msgid "Lists the available fonts."
+msgstr "Daftar font yang tersedia."
+
+#: ../src/richtext/richtextfontpage.cpp:196
+#: ../src/richtext/richtextfontpage.cpp:198
+msgid "Lists font sizes in points."
+msgstr "Daftar ukuran font dalam point."
+
+#: ../src/richtext/richtextfontpage.cpp:207
+msgid "Font st&yle:"
+msgstr "Ga&ya font:"
+
+#: ../src/richtext/richtextfontpage.cpp:212
+#: ../src/richtext/richtextfontpage.cpp:214
+msgid "Select regular or italic style."
+msgstr "Pilih teks miring atau tidak."
+
+#: ../src/richtext/richtextfontpage.cpp:220
+msgid "Font &weight:"
+msgstr "Berat &font:"
+
+#: ../src/richtext/richtextfontpage.cpp:225
+#: ../src/richtext/richtextfontpage.cpp:227
+msgid "Select regular or bold."
+msgstr "Pilih teks tebal atau tidak."
+
+#: ../src/richtext/richtextfontpage.cpp:233
+msgid "&Underlining:"
+msgstr "&Garis bawah:"
+
+#: ../src/richtext/richtextfontpage.cpp:238
+#: ../src/richtext/richtextfontpage.cpp:240
+msgid "Select underlining or no underlining."
+msgstr "Pilih digarisbawahi atau tidak."
+
+#: ../src/richtext/richtextfontpage.cpp:248
+msgid "&Colour:"
+msgstr "&Warna:"
+
+#: ../src/richtext/richtextfontpage.cpp:253
+#: ../src/richtext/richtextfontpage.cpp:255
+msgid "Click to change the text colour."
+msgstr "Klik untuk mengubah warna teks."
+
+#: ../src/richtext/richtextfontpage.cpp:261
+msgid "&Bg colour:"
+msgstr "&Warna latar:"
+
+#: ../src/richtext/richtextfontpage.cpp:266
+#: ../src/richtext/richtextfontpage.cpp:268
+msgid "Click to change the text background colour."
+msgstr "Klik untuk mengubah warna latar belakang teks."
+
+#: ../src/richtext/richtextfontpage.cpp:276
+#: ../src/richtext/richtextfontpage.cpp:278
+msgid "Check to show a line through the text."
+msgstr "Centang untuk menampilkan garis menembus teks."
+
+#: ../src/richtext/richtextfontpage.cpp:281
+msgid "Ca&pitals"
+msgstr "Ka&pital"
+
+#: ../src/richtext/richtextfontpage.cpp:283
+#: ../src/richtext/richtextfontpage.cpp:285
+msgid "Check to show the text in capitals."
+msgstr "Centang untuk menampilkan teks dalam huruf besar."
+
+#: ../src/richtext/richtextfontpage.cpp:288
+msgid "Small C&apitals"
+msgstr "Ka&pital Ukuran Kecil"
+
+#: ../src/richtext/richtextfontpage.cpp:290
+#: ../src/richtext/richtextfontpage.cpp:292
+msgid "Check to show the text in small capitals."
+msgstr "Centang untuk menampilkan teks dalam huruf besar ukuran kecil."
+
+#: ../src/richtext/richtextfontpage.cpp:295
+msgid "Supe&rscript"
+msgstr "Supe&rscript"
+
+#: ../src/richtext/richtextfontpage.cpp:297
+#: ../src/richtext/richtextfontpage.cpp:299
+msgid "Check to show the text in superscript."
+msgstr "Centang untuk menampilkan teks dalam superscript."
+
+#: ../src/richtext/richtextfontpage.cpp:302
+msgid "Subscrip&t"
+msgstr "Subscrip&t"
+
+#: ../src/richtext/richtextfontpage.cpp:304
+#: ../src/richtext/richtextfontpage.cpp:306
+msgid "Check to show the text in subscript."
+msgstr "Centang untuk menampilkan teks dalam subscript."
+
+#: ../src/richtext/richtextfontpage.cpp:312
+msgid "Rig&ht-to-left"
+msgstr "&Kanan-ke-kiri"
+
+#: ../src/richtext/richtextfontpage.cpp:314
+#: ../src/richtext/richtextfontpage.cpp:316
+msgid "Check to indicate right-to-left text layout."
+msgstr "Centang untuk penulisan teks dari kanan-ke-kiri."
+
+#: ../src/richtext/richtextfontpage.cpp:319
+msgid "Suppress hyphe&nation"
+msgstr "Hindari ta&nda sambung"
+
+#: ../src/richtext/richtextfontpage.cpp:321
+#: ../src/richtext/richtextfontpage.cpp:323
+msgid "Check to suppress hyphenation."
+msgstr "Centang untuk menghindari tanda sambung."
+
+#: ../src/richtext/richtextfontpage.cpp:329
+#: ../src/richtext/richtextfontpage.cpp:331
+msgid "Shows a preview of the font settings."
+msgstr "Tampilkan pratinjau pengaturan font."
+
+#: ../src/richtext/richtextfontpage.cpp:348
+#: ../src/richtext/richtextfontpage.cpp:352
+#: ../src/richtext/richtextfontpage.cpp:356
+#: ../src/richtext/richtextformatdlg.cpp:873
+#: ../src/richtext/richtextindentspage.cpp:273
+#: ../src/richtext/richtextindentspage.cpp:285
+#: ../src/richtext/richtextindentspage.cpp:286
+#: ../src/richtext/richtextindentspage.cpp:310
+#: ../src/richtext/richtextindentspage.cpp:325
+#: ../src/richtext/richtextliststylepage.cpp:451
+#: ../src/richtext/richtextliststylepage.cpp:463
+#: ../src/richtext/richtextliststylepage.cpp:464
+msgid "(none)"
+msgstr "(nihil)"
+
+#: ../src/richtext/richtextfontpage.cpp:349
+#: ../src/richtext/richtextfontpage.cpp:353
+msgid "Regular"
+msgstr "Regular"
+
+#: ../src/richtext/richtextfontpage.cpp:357
+msgid "Not underlined"
+msgstr "Tidak digarisbawahi"
+
+#: ../src/richtext/richtextformatdlg.cpp:341
+msgid "Indents && Spacing"
+msgstr "Inden && Spasi"
+
+#: ../src/richtext/richtextformatdlg.cpp:346
+msgid "Tabs"
+msgstr "Tab"
+
+#: ../src/richtext/richtextformatdlg.cpp:351
+msgid "Bullets"
+msgstr "Bulet"
+
+#: ../src/richtext/richtextformatdlg.cpp:356
+msgid "List Style"
+msgstr "Daftar Gaya"
+
+#: ../src/richtext/richtextformatdlg.cpp:366
+#: ../src/richtext/richtextmarginspage.cpp:170
+msgid "Margins"
+msgstr "Batas"
+
+#: ../src/richtext/richtextformatdlg.cpp:371
+msgid "Borders"
+msgstr "Tepi"
+
+#: ../src/richtext/richtextformatdlg.cpp:765
+msgid "Colour"
+msgstr "Warna"
+
+#: ../src/richtext/richtextindentspage.cpp:127
+#: ../src/richtext/richtextliststylepage.cpp:322
+msgid "&Alignment"
+msgstr "Perat&aan"
+
+#: ../src/richtext/richtextindentspage.cpp:138
+#: ../src/richtext/richtextliststylepage.cpp:331
+msgid "&Left"
+msgstr "&Kiri"
+
+#: ../src/richtext/richtextindentspage.cpp:140
+#: ../src/richtext/richtextindentspage.cpp:142
+#: ../src/richtext/richtextliststylepage.cpp:333
+#: ../src/richtext/richtextliststylepage.cpp:335
+msgid "Left-align text."
+msgstr "Sejajarkan teks ke kiri."
+
+#: ../src/richtext/richtextindentspage.cpp:145
+#: ../src/richtext/richtextliststylepage.cpp:338
+msgid "&Right"
+msgstr "&Kanan"
+
+#: ../src/richtext/richtextindentspage.cpp:147
+#: ../src/richtext/richtextindentspage.cpp:149
+#: ../src/richtext/richtextliststylepage.cpp:340
+#: ../src/richtext/richtextliststylepage.cpp:342
+msgid "Right-align text."
+msgstr "Teks rata kanan."
+
+#: ../src/richtext/richtextindentspage.cpp:152
+#: ../src/richtext/richtextliststylepage.cpp:345
+msgid "&Justified"
+msgstr "&Rata kanan kiri"
+
+#: ../src/richtext/richtextindentspage.cpp:154
+#: ../src/richtext/richtextindentspage.cpp:156
+#: ../src/richtext/richtextliststylepage.cpp:347
+#: ../src/richtext/richtextliststylepage.cpp:349
+msgid "Justify text left and right."
+msgstr "Ratakan teks kanan dan kiri."
+
+#: ../src/richtext/richtextindentspage.cpp:159
+#: ../src/richtext/richtextliststylepage.cpp:352
+msgid "Cen&tred"
+msgstr "Te&ngah"
+
+#: ../src/richtext/richtextindentspage.cpp:161
+#: ../src/richtext/richtextindentspage.cpp:163
+#: ../src/richtext/richtextliststylepage.cpp:354
+#: ../src/richtext/richtextliststylepage.cpp:356
+msgid "Centre text."
+msgstr "Tengahi teks."
+
+#: ../src/richtext/richtextindentspage.cpp:166
+#: ../src/richtext/richtextliststylepage.cpp:359
+msgid "&Indeterminate"
+msgstr "&Tidak tentu"
+
+#: ../src/richtext/richtextindentspage.cpp:168
+#: ../src/richtext/richtextindentspage.cpp:170
+#: ../src/richtext/richtextliststylepage.cpp:361
+#: ../src/richtext/richtextliststylepage.cpp:363
+msgid "Use the current alignment setting."
+msgstr "Gunakan pengaturan penjajaran."
+
+#: ../src/richtext/richtextindentspage.cpp:183
+#: ../src/richtext/richtextliststylepage.cpp:375
+msgid "&Indentation (tenths of a mm)"
+msgstr "&Indentasi (persepuluh mm)"
+
+#: ../src/richtext/richtextindentspage.cpp:198
+#: ../src/richtext/richtextindentspage.cpp:200
+#: ../src/richtext/richtextliststylepage.cpp:388
+#: ../src/richtext/richtextliststylepage.cpp:390
+msgid "The left indent."
+msgstr "Indent kiri."
+
+#: ../src/richtext/richtextindentspage.cpp:203
+#: ../src/richtext/richtextliststylepage.cpp:393
+msgid "Left (&first line):"
+msgstr "Kiri (&baris pertama):"
+
+#: ../src/richtext/richtextindentspage.cpp:207
+#: ../src/richtext/richtextindentspage.cpp:209
+#: ../src/richtext/richtextliststylepage.cpp:397
+#: ../src/richtext/richtextliststylepage.cpp:399
+msgid "The first line indent."
+msgstr "Inden baris pertama."
+
+#: ../src/richtext/richtextindentspage.cpp:216
+#: ../src/richtext/richtextindentspage.cpp:218
+#: ../src/richtext/richtextliststylepage.cpp:406
+#: ../src/richtext/richtextliststylepage.cpp:408
+msgid "The right indent."
+msgstr "Indent kanan."
+
+#: ../src/richtext/richtextindentspage.cpp:221
+msgid "&Outline level:"
+msgstr "Level &ikhtisar:"
+
+#: ../src/richtext/richtextindentspage.cpp:226
+#: ../src/richtext/richtextindentspage.cpp:228
+msgid "The outline level."
+msgstr "Level ikhtisar."
+
+#: ../src/richtext/richtextindentspage.cpp:241
+#: ../src/richtext/richtextliststylepage.cpp:420
+msgid "&Spacing (tenths of a mm)"
+msgstr "&Spasi (persepuluh mm)"
+
+#: ../src/richtext/richtextindentspage.cpp:252
+msgid "&Before a paragraph:"
+msgstr "Se&belum paragraf:"
+
+#: ../src/richtext/richtextindentspage.cpp:256
+#: ../src/richtext/richtextindentspage.cpp:258
+#: ../src/richtext/richtextliststylepage.cpp:433
+#: ../src/richtext/richtextliststylepage.cpp:435
+msgid "The spacing before the paragraph."
+msgstr "Spasi sebelum paragraf."
+
+#: ../src/richtext/richtextindentspage.cpp:261
+msgid "&After a paragraph:"
+msgstr "Setel&ah paragraf:"
+
+#: ../src/richtext/richtextindentspage.cpp:266
+#: ../src/richtext/richtextliststylepage.cpp:442
+#: ../src/richtext/richtextliststylepage.cpp:444
+msgid "The spacing after the paragraph."
+msgstr "Spasi setelah paragraf."
+
+#: ../src/richtext/richtextindentspage.cpp:269
+msgid "L&ine spacing:"
+msgstr "Spasi b&aris:"
+
+#: ../src/richtext/richtextindentspage.cpp:274
+#: ../src/richtext/richtextliststylepage.cpp:452
+msgid "Single"
+msgstr "Tunggal"
+
+#: ../src/richtext/richtextindentspage.cpp:275
+#: ../src/richtext/richtextliststylepage.cpp:453
+msgid "1.1"
+msgstr "1.1"
+
+#: ../src/richtext/richtextindentspage.cpp:276
+#: ../src/richtext/richtextliststylepage.cpp:454
+msgid "1.2"
+msgstr "1.2"
+
+#: ../src/richtext/richtextindentspage.cpp:277
+#: ../src/richtext/richtextliststylepage.cpp:455
+msgid "1.3"
+msgstr "1.3"
+
+#: ../src/richtext/richtextindentspage.cpp:278
+#: ../src/richtext/richtextliststylepage.cpp:456
+msgid "1.4"
+msgstr "1.4"
+
+#: ../src/richtext/richtextindentspage.cpp:279
+#: ../src/richtext/richtextliststylepage.cpp:457
+msgid "1.5"
+msgstr "1.5"
+
+#: ../src/richtext/richtextindentspage.cpp:280
+#: ../src/richtext/richtextliststylepage.cpp:458
+msgid "1.6"
+msgstr "1.6"
+
+#: ../src/richtext/richtextindentspage.cpp:281
+#: ../src/richtext/richtextliststylepage.cpp:459
+msgid "1.7"
+msgstr "1.7"
+
+#: ../src/richtext/richtextindentspage.cpp:282
+#: ../src/richtext/richtextliststylepage.cpp:460
+msgid "1.8"
+msgstr "1.8"
+
+#: ../src/richtext/richtextindentspage.cpp:283
+#: ../src/richtext/richtextliststylepage.cpp:461
+msgid "1.9"
+msgstr "1.9"
+
+#: ../src/richtext/richtextindentspage.cpp:284
+#: ../src/richtext/richtextliststylepage.cpp:462
+msgid "2"
+msgstr "2"
+
+#: ../src/richtext/richtextindentspage.cpp:287
+#: ../src/richtext/richtextindentspage.cpp:289
+#: ../src/richtext/richtextliststylepage.cpp:465
+#: ../src/richtext/richtextliststylepage.cpp:467
+msgid "The line spacing."
+msgstr "Spasi baris."
+
+#: ../src/richtext/richtextindentspage.cpp:292
+msgid "&Page Break"
+msgstr "&Ganti Halaman"
+
+#: ../src/richtext/richtextindentspage.cpp:294
+#: ../src/richtext/richtextindentspage.cpp:296
+msgid "Inserts a page break before the paragraph."
+msgstr "Sisipkan pemisah halaman sebelum paragraf."
+
+#: ../src/richtext/richtextindentspage.cpp:302
+#: ../src/richtext/richtextindentspage.cpp:304
+msgid "Shows a preview of the paragraph settings."
+msgstr "Tampilkan pratinjau pengaturan paragraf."
+
+#: ../src/richtext/richtextliststylepage.cpp:182
+msgid "&List level:"
+msgstr "&Level daftar:"
+
+#: ../src/richtext/richtextliststylepage.cpp:186
+#: ../src/richtext/richtextliststylepage.cpp:188
+msgid "Selects the list level to edit."
+msgstr "Pilih tingkat daftar yang akan disunting."
+
+#: ../src/richtext/richtextliststylepage.cpp:193
+msgid "&Font for Level..."
+msgstr "&Font untuk Level..."
+
+#: ../src/richtext/richtextliststylepage.cpp:194
+#: ../src/richtext/richtextliststylepage.cpp:196
+msgid "Click to choose the font for this level."
+msgstr "Klik untuk memilih font bagi tingkatan ini."
+
+#: ../src/richtext/richtextliststylepage.cpp:312
+msgid "Bullet style"
+msgstr "Gaya bullet"
+
+#: ../src/richtext/richtextliststylepage.cpp:429
+msgid "Before a paragraph:"
+msgstr "Sebelum paragraf:"
+
+#: ../src/richtext/richtextliststylepage.cpp:438
+msgid "After a paragraph:"
+msgstr "Setelah paragraf:"
+
+#: ../src/richtext/richtextliststylepage.cpp:447
+msgid "Line spacing:"
+msgstr "Spasi baris:"
+
+#: ../src/richtext/richtextliststylepage.cpp:470
+msgid "Spacing"
+msgstr "Jarak"
+
+#: ../src/richtext/richtextmarginspage.cpp:193
+#: ../src/richtext/richtextmarginspage.cpp:195
+msgid "The left margin size."
+msgstr "Ukurang margin kiri."
+
+#: ../src/richtext/richtextmarginspage.cpp:203
+#: ../src/richtext/richtextmarginspage.cpp:205
+msgid "Units for the left margin."
+msgstr "Unit untuk batas kiri."
+
+#: ../src/richtext/richtextmarginspage.cpp:218
+#: ../src/richtext/richtextmarginspage.cpp:220
+msgid "The right margin size."
+msgstr "Ukuran margin kanan."
+
+#: ../src/richtext/richtextmarginspage.cpp:228
+#: ../src/richtext/richtextmarginspage.cpp:230
+msgid "Units for the right margin."
+msgstr "Unit untuk batas kanan."
+
+#: ../src/richtext/richtextmarginspage.cpp:241
+#: ../src/richtext/richtextmarginspage.cpp:243
+msgid "The top margin size."
+msgstr "Ukuran margin atas."
+
+#: ../src/richtext/richtextmarginspage.cpp:251
+#: ../src/richtext/richtextmarginspage.cpp:253
+msgid "Units for the top margin."
+msgstr "Unit untuk margin atas."
+
+#: ../src/richtext/richtextmarginspage.cpp:266
+#: ../src/richtext/richtextmarginspage.cpp:268
+msgid "The bottom margin size."
+msgstr "Ukuran margin bawah."
+
+#: ../src/richtext/richtextmarginspage.cpp:276
+#: ../src/richtext/richtextmarginspage.cpp:278
+msgid "Units for the bottom margin."
+msgstr "Unit untuk batas bawah."
+
+#: ../src/richtext/richtextmarginspage.cpp:284
+msgid "Padding"
+msgstr "Padding"
+
+#: ../src/richtext/richtextmarginspage.cpp:307
+#: ../src/richtext/richtextmarginspage.cpp:309
+msgid "The left padding size."
+msgstr "Ukurang padding kiri."
+
+#: ../src/richtext/richtextmarginspage.cpp:317
+#: ../src/richtext/richtextmarginspage.cpp:319
+msgid "Units for the left padding."
+msgstr "Unit untuk padding kiri."
+
+#: ../src/richtext/richtextmarginspage.cpp:332
+#: ../src/richtext/richtextmarginspage.cpp:334
+msgid "The right padding size."
+msgstr "Ukurang padding kanan."
+
+#: ../src/richtext/richtextmarginspage.cpp:342
+#: ../src/richtext/richtextmarginspage.cpp:344
+msgid "Units for the right padding."
+msgstr "Unit untuk padding kiri."
+
+#: ../src/richtext/richtextmarginspage.cpp:355
+#: ../src/richtext/richtextmarginspage.cpp:357
+msgid "The top padding size."
+msgstr "Ukurang padding atas."
+
+#: ../src/richtext/richtextmarginspage.cpp:365
+#: ../src/richtext/richtextmarginspage.cpp:367
+msgid "Units for the top padding."
+msgstr "Unit untuk padding atas."
+
+#: ../src/richtext/richtextmarginspage.cpp:380
+#: ../src/richtext/richtextmarginspage.cpp:382
+msgid "The bottom padding size."
+msgstr "Ukuran padding bawah."
+
+#: ../src/richtext/richtextmarginspage.cpp:390
+#: ../src/richtext/richtextmarginspage.cpp:392
+msgid "Units for the bottom padding."
+msgstr "Unit untuk padding bawah."
+
+#: ../src/richtext/richtextprint.cpp:592
+msgid " Preview"
+msgstr " Pratinjau"
+
+#: ../src/richtext/richtextsizepage.cpp:228
+msgid "Floating"
+msgstr "Mengambang"
+
+#: ../src/richtext/richtextsizepage.cpp:243
+msgid "&Floating mode:"
+msgstr "&Mode mengambang:"
+
+#: ../src/richtext/richtextsizepage.cpp:252
+#: ../src/richtext/richtextsizepage.cpp:254
+msgid "How the object will float relative to the text."
+msgstr "Bagaimana obyek akan mengapung relatif terhadap teks."
+
+#: ../src/richtext/richtextsizepage.cpp:265
+msgid "Alignment"
+msgstr "Perataan"
+
+#: ../src/richtext/richtextsizepage.cpp:277
+msgid "&Vertical alignment:"
+msgstr "Perataan &vertikal:"
+
+#: ../src/richtext/richtextsizepage.cpp:279
+#: ../src/richtext/richtextsizepage.cpp:281
+msgid "Enable vertical alignment."
+msgstr "Aktifkan penjajaran vertikal."
+
+#: ../src/richtext/richtextsizepage.cpp:286
+msgid "Centred"
+msgstr "Tengahkan"
+
+#: ../src/richtext/richtextsizepage.cpp:290
+#: ../src/richtext/richtextsizepage.cpp:292
+msgid "Vertical alignment."
+msgstr "Penjajaran vertikal."
+
+#: ../src/richtext/richtextsizepage.cpp:316
+#: ../src/richtext/richtextsizepage.cpp:323
+msgid "&Width:"
+msgstr "&Lebar:"
+
+#: ../src/richtext/richtextsizepage.cpp:318
+#: ../src/richtext/richtextsizepage.cpp:320
+msgid "Enable the width value."
+msgstr "Aktifkan nilai lebar."
+
+#: ../src/richtext/richtextsizepage.cpp:331
+#: ../src/richtext/richtextsizepage.cpp:333
+msgid "The object width."
+msgstr "Lebar obyek."
+
+#: ../src/richtext/richtextsizepage.cpp:342
+#: ../src/richtext/richtextsizepage.cpp:344
+msgid "Units for the object width."
+msgstr "Unit untuk lebar obyek."
+
+#: ../src/richtext/richtextsizepage.cpp:350
+#: ../src/richtext/richtextsizepage.cpp:357
+msgid "&Height:"
+msgstr "&Tinggi:"
+
+#: ../src/richtext/richtextsizepage.cpp:352
+#: ../src/richtext/richtextsizepage.cpp:354
+#: ../src/richtext/richtextsizepage.cpp:464
+#: ../src/richtext/richtextsizepage.cpp:466
+msgid "Enable the height value."
+msgstr "Aktifkan nilai tinggi."
+
+#: ../src/richtext/richtextsizepage.cpp:365
+#: ../src/richtext/richtextsizepage.cpp:367
+msgid "The object height."
+msgstr "Tinggi obyek."
+
+#: ../src/richtext/richtextsizepage.cpp:376
+#: ../src/richtext/richtextsizepage.cpp:378
+msgid "Units for the object height."
+msgstr "Unit untuk tinggi obyek."
+
+#: ../src/richtext/richtextsizepage.cpp:381
+msgid "Min width:"
+msgstr "Lebar minimal:"
+
+#: ../src/richtext/richtextsizepage.cpp:383
+#: ../src/richtext/richtextsizepage.cpp:385
+msgid "Enable the minimum width value."
+msgstr "Aktifkan nilai lebar minimum."
+
+#: ../src/richtext/richtextsizepage.cpp:392
+#: ../src/richtext/richtextsizepage.cpp:394
+msgid "The object minimum width."
+msgstr "Lebar minimum obyek."
+
+#: ../src/richtext/richtextsizepage.cpp:403
+#: ../src/richtext/richtextsizepage.cpp:405
+msgid "Units for the minimum object width."
+msgstr "Unit untuk lebar minimum obyek."
+
+#: ../src/richtext/richtextsizepage.cpp:408
+msgid "Min height:"
+msgstr "Tinggi minimal:"
+
+#: ../src/richtext/richtextsizepage.cpp:410
+#: ../src/richtext/richtextsizepage.cpp:412
+msgid "Enable the minimum height value."
+msgstr "Aktifkan nilai tinggi minimum."
+
+#: ../src/richtext/richtextsizepage.cpp:419
+#: ../src/richtext/richtextsizepage.cpp:421
+msgid "The object minimum height."
+msgstr "Tinggi minimum obyek."
+
+#: ../src/richtext/richtextsizepage.cpp:430
+#: ../src/richtext/richtextsizepage.cpp:432
+msgid "Units for the minimum object height."
+msgstr "Unit untuk tinggi minimum obyek."
+
+#: ../src/richtext/richtextsizepage.cpp:435
+msgid "Max width:"
+msgstr "Lebar maksimum:"
+
+#: ../src/richtext/richtextsizepage.cpp:437
+#: ../src/richtext/richtextsizepage.cpp:439
+msgid "Enable the maximum width value."
+msgstr "Aktifkan nilai lebar maksimum."
+
+#: ../src/richtext/richtextsizepage.cpp:446
+#: ../src/richtext/richtextsizepage.cpp:448
+msgid "The object maximum width."
+msgstr "Lebar maksimum obyek."
+
+#: ../src/richtext/richtextsizepage.cpp:457
+#: ../src/richtext/richtextsizepage.cpp:459
+msgid "Units for the maximum object width."
+msgstr "Unit untuk lebar maksimum obyek."
+
+#: ../src/richtext/richtextsizepage.cpp:462
+msgid "Max height:"
+msgstr "Tinggi maksimum:"
+
+#: ../src/richtext/richtextsizepage.cpp:473
+#: ../src/richtext/richtextsizepage.cpp:475
+msgid "The object maximum height."
+msgstr "Tinggi maksimum obyek."
+
+#: ../src/richtext/richtextsizepage.cpp:484
+#: ../src/richtext/richtextsizepage.cpp:486
+msgid "Units for the maximum object height."
+msgstr "Unit untuk tinggi maksimum obyek."
+
+#: ../src/richtext/richtextsizepage.cpp:495
+msgid "Position"
+msgstr "Posisi"
+
+#: ../src/richtext/richtextsizepage.cpp:513
+msgid "&Position mode:"
+msgstr "&Mode posisi:"
+
+#: ../src/richtext/richtextsizepage.cpp:517
+#: ../src/richtext/richtextsizepage.cpp:522
+msgid "Static"
+msgstr "Statik"
+
+#: ../src/richtext/richtextsizepage.cpp:518
+msgid "Relative"
+msgstr "Relatif"
+
+#: ../src/richtext/richtextsizepage.cpp:519
+msgid "Absolute"
+msgstr "Absolut"
+
+#: ../src/richtext/richtextsizepage.cpp:520
+msgid "Fixed"
+msgstr "Tetap"
+
+#: ../src/richtext/richtextsizepage.cpp:533
+#: ../src/richtext/richtextsizepage.cpp:535
+#: ../src/richtext/richtextsizepage.cpp:547
+#: ../src/richtext/richtextsizepage.cpp:549
+msgid "The left position."
+msgstr "Posisi kiri."
+
+#: ../src/richtext/richtextsizepage.cpp:558
+#: ../src/richtext/richtextsizepage.cpp:560
+msgid "Units for the left position."
+msgstr "Unit untuk posisi dikiri."
+
+#: ../src/richtext/richtextsizepage.cpp:568
+#: ../src/richtext/richtextsizepage.cpp:570
+#: ../src/richtext/richtextsizepage.cpp:582
+#: ../src/richtext/richtextsizepage.cpp:584
+msgid "The top position."
+msgstr "Posisi teratas."
+
+#: ../src/richtext/richtextsizepage.cpp:593
+#: ../src/richtext/richtextsizepage.cpp:595
+msgid "Units for the top position."
+msgstr "Unit untuk posisi atas."
+
+#: ../src/richtext/richtextsizepage.cpp:603
+#: ../src/richtext/richtextsizepage.cpp:605
+#: ../src/richtext/richtextsizepage.cpp:617
+#: ../src/richtext/richtextsizepage.cpp:619
+msgid "The right position."
+msgstr "Posisi kanan."
+
+#: ../src/richtext/richtextsizepage.cpp:628
+#: ../src/richtext/richtextsizepage.cpp:630
+msgid "Units for the right position."
+msgstr "Unit untuk untuk posisi kanan."
+
+#: ../src/richtext/richtextsizepage.cpp:638
+#: ../src/richtext/richtextsizepage.cpp:640
+#: ../src/richtext/richtextsizepage.cpp:652
+#: ../src/richtext/richtextsizepage.cpp:654
+msgid "The bottom position."
+msgstr "Posisi bawah."
+
+#: ../src/richtext/richtextsizepage.cpp:663
+#: ../src/richtext/richtextsizepage.cpp:665
+msgid "Units for the bottom position."
+msgstr "Unit untuk posisi dibawah."
+
+#: ../src/richtext/richtextsizepage.cpp:671
+msgid "&Move the object to:"
+msgstr "&Pindahkan obyek ke:"
+
+#: ../src/richtext/richtextsizepage.cpp:674
+msgid "&Previous Paragraph"
+msgstr "&Paragraf Sebelumnya"
+
+#: ../src/richtext/richtextsizepage.cpp:675
+#: ../src/richtext/richtextsizepage.cpp:677
+msgid "Moves the object to the previous paragraph."
+msgstr "Pindahkan obyek ke paragraf sebelumnya."
+
+#: ../src/richtext/richtextsizepage.cpp:680
+msgid "&Next Paragraph"
+msgstr "&Paragraf berikutnya"
+
+#: ../src/richtext/richtextsizepage.cpp:681
+#: ../src/richtext/richtextsizepage.cpp:683
+msgid "Moves the object to the next paragraph."
+msgstr "Pindahkan obyek ke paragraf selanjutnya."
+
+#: ../src/richtext/richtextstyledlg.cpp:193
+msgid "&Styles:"
+msgstr "&Gaya:"
+
+#: ../src/richtext/richtextstyledlg.cpp:197
+#: ../src/richtext/richtextstyledlg.cpp:199
+msgid "The available styles."
+msgstr "Gaya bullet yang tersedia."
+
+#: ../src/richtext/richtextstyledlg.cpp:205
+#: ../src/richtext/richtextstyledlg.cpp:217
+msgid " "
+msgstr " "
+
+#: ../src/richtext/richtextstyledlg.cpp:209
+#: ../src/richtext/richtextstyledlg.cpp:211
+msgid "The style preview."
+msgstr "Pratinjau gaya."
+
+#: ../src/richtext/richtextstyledlg.cpp:220
+msgid "New &Character Style..."
+msgstr "Gaya &Karakter Baru..."
+
+#: ../src/richtext/richtextstyledlg.cpp:221
+#: ../src/richtext/richtextstyledlg.cpp:223
+msgid "Click to create a new character style."
+msgstr "Klik untuk membuat gaya karakter yang baru."
+
+#: ../src/richtext/richtextstyledlg.cpp:226
+msgid "New &Paragraph Style..."
+msgstr "Gaya &Paragraf Baru..."
+
+#: ../src/richtext/richtextstyledlg.cpp:227
+#: ../src/richtext/richtextstyledlg.cpp:229
+msgid "Click to create a new paragraph style."
+msgstr "Klik untuk membuat gaya paragraf yang baru."
+
+#: ../src/richtext/richtextstyledlg.cpp:232
+msgid "New &List Style..."
+msgstr "Gaya &Daftar Baru..."
+
+#: ../src/richtext/richtextstyledlg.cpp:233
+#: ../src/richtext/richtextstyledlg.cpp:235
+msgid "Click to create a new list style."
+msgstr "Klik untuk membuat gaya daftar yang baru."
+
+#: ../src/richtext/richtextstyledlg.cpp:238
+msgid "New &Box Style..."
+msgstr "Gaya &Box Baru..."
+
+#: ../src/richtext/richtextstyledlg.cpp:239
+#: ../src/richtext/richtextstyledlg.cpp:241
+msgid "Click to create a new box style."
+msgstr "Klik untuk membuat gaya kotak yang baru."
+
+#: ../src/richtext/richtextstyledlg.cpp:246
+msgid "&Apply Style"
+msgstr "Ter&apkan Gaya"
+
+#: ../src/richtext/richtextstyledlg.cpp:247
+#: ../src/richtext/richtextstyledlg.cpp:249
+msgid "Click to apply the selected style."
+msgstr "Klik untuk menerapkan gaya yang dipilih."
+
+#: ../src/richtext/richtextstyledlg.cpp:252
+msgid "&Rename Style..."
+msgstr "&Ubah Nama Gaya..."
+
+#: ../src/richtext/richtextstyledlg.cpp:253
+#: ../src/richtext/richtextstyledlg.cpp:255
+msgid "Click to rename the selected style."
+msgstr "Klik untuk mengubah nama gaya yang dipilih."
+
+#: ../src/richtext/richtextstyledlg.cpp:258
+msgid "&Edit Style..."
+msgstr "&Sunting Gaya..."
+
+#: ../src/richtext/richtextstyledlg.cpp:259
+#: ../src/richtext/richtextstyledlg.cpp:261
+msgid "Click to edit the selected style."
+msgstr "Klik untuk menyunting gaya yang dipilih."
+
+#: ../src/richtext/richtextstyledlg.cpp:264
+msgid "&Delete Style..."
+msgstr "&Hapus Gaya..."
+
+#: ../src/richtext/richtextstyledlg.cpp:265
+#: ../src/richtext/richtextstyledlg.cpp:267
+msgid "Click to delete the selected style."
+msgstr "Klik untuk menghapus gaya yang dipilih."
+
+#: ../src/richtext/richtextstyledlg.cpp:274
+#: ../src/richtext/richtextstyledlg.cpp:276
+msgid "Click to close this window."
+msgstr "Klik untuk menutup jendela ini."
+
+#: ../src/richtext/richtextstyledlg.cpp:282
+msgid "&Restart numbering"
+msgstr "&Ulangi penomoran"
+
+#: ../src/richtext/richtextstyledlg.cpp:284
+#: ../src/richtext/richtextstyledlg.cpp:286
+msgid "Check to restart numbering."
+msgstr "Centang untuk memulai lagi penomoran."
+
+#: ../src/richtext/richtextstyledlg.cpp:601
+msgid "Enter a character style name"
+msgstr "Masukkan nama gaya karakter"
+
+#: ../src/richtext/richtextstyledlg.cpp:601
+#: ../src/richtext/richtextstyledlg.cpp:606
+#: ../src/richtext/richtextstyledlg.cpp:649
+#: ../src/richtext/richtextstyledlg.cpp:654
+#: ../src/richtext/richtextstyledlg.cpp:815
+#: ../src/richtext/richtextstyledlg.cpp:820
+#: ../src/richtext/richtextstyledlg.cpp:888
+#: ../src/richtext/richtextstyledlg.cpp:896
+#: ../src/richtext/richtextstyledlg.cpp:929
+#: ../src/richtext/richtextstyledlg.cpp:934
+msgid "New Style"
+msgstr "Gaya Baru"
+
+#: ../src/richtext/richtextstyledlg.cpp:606
+#: ../src/richtext/richtextstyledlg.cpp:654
+#: ../src/richtext/richtextstyledlg.cpp:820
+#: ../src/richtext/richtextstyledlg.cpp:896
+#: ../src/richtext/richtextstyledlg.cpp:934
+msgid "Sorry, that name is taken. Please choose another."
+msgstr "Maaf, nama sudah ada. Tolong pilih yang lain."
+
+#: ../src/richtext/richtextstyledlg.cpp:649
+msgid "Enter a paragraph style name"
+msgstr "Masukkan nama gaya paragraf"
+
+#: ../src/richtext/richtextstyledlg.cpp:777
+#, c-format
+msgid "Delete style %s?"
+msgstr "Hapus gaya %s?"
+
+#: ../src/richtext/richtextstyledlg.cpp:777
+msgid "Delete Style"
+msgstr "Hapus Gaya"
+
+#: ../src/richtext/richtextstyledlg.cpp:815
+msgid "Enter a list style name"
+msgstr "Masukkan daftar nama gaya"
+
+#: ../src/richtext/richtextstyledlg.cpp:888
+msgid "Enter a new style name"
+msgstr "Masukkan nama gaya baru"
+
+#: ../src/richtext/richtextstyledlg.cpp:929
+msgid "Enter a box style name"
+msgstr "Masukkan nama kotak gaya"
+
+#: ../src/richtext/richtextstylepage.cpp:109
+#: ../src/richtext/richtextstylepage.cpp:111
+msgid "The style name."
+msgstr "Nama gaya."
+
+#: ../src/richtext/richtextstylepage.cpp:114
+msgid "&Based on:"
+msgstr "&Berdasarkan:"
+
+#: ../src/richtext/richtextstylepage.cpp:119
+#: ../src/richtext/richtextstylepage.cpp:121
+msgid "The style on which this style is based."
+msgstr "Gaya dimana gaya ini didasarkan."
+
+#: ../src/richtext/richtextstylepage.cpp:124
+msgid "&Next style:"
+msgstr "&Gaya berikutnya:"
+
+#: ../src/richtext/richtextstylepage.cpp:129
+#: ../src/richtext/richtextstylepage.cpp:131
+msgid "The default style for the next paragraph."
+msgstr "Gaya standar untuk paragraf selanjutnya."
+
+#: ../src/richtext/richtextstyles.cpp:1057
+msgid "All styles"
+msgstr "Semua gaya"
+
+#: ../src/richtext/richtextstyles.cpp:1058
+msgid "Paragraph styles"
+msgstr "Gaya paragraf"
+
+#: ../src/richtext/richtextstyles.cpp:1059
+msgid "Character styles"
+msgstr "Gaya karakter"
+
+#: ../src/richtext/richtextstyles.cpp:1060
+msgid "List styles"
+msgstr "Daftar gaya"
+
+#: ../src/richtext/richtextstyles.cpp:1061
+msgid "Box styles"
+msgstr "Gaya kotak"
+
+#: ../src/richtext/richtextsymboldlg.cpp:389
+#: ../src/richtext/richtextsymboldlg.cpp:391
+msgid "The font from which to take the symbol."
+msgstr "Pilih font untuk mengambil simbol."
+
+#: ../src/richtext/richtextsymboldlg.cpp:396
+msgid "&Subset:"
+msgstr "&Subset:"
+
+#: ../src/richtext/richtextsymboldlg.cpp:401
+#: ../src/richtext/richtextsymboldlg.cpp:403
+msgid "Shows a Unicode subset."
+msgstr "Tampilkan subset Unicode."
+
+#: ../src/richtext/richtextsymboldlg.cpp:412
+msgid "xxxx"
+msgstr "xxxx"
+
+#: ../src/richtext/richtextsymboldlg.cpp:417
+msgid "&Character code:"
+msgstr "&Kode karakter:"
+
+#: ../src/richtext/richtextsymboldlg.cpp:421
+#: ../src/richtext/richtextsymboldlg.cpp:423
+msgid "The character code."
+msgstr "Kode karakter."
+
+#: ../src/richtext/richtextsymboldlg.cpp:428
+msgid "&From:"
+msgstr "&Dari:"
+
+#: ../src/richtext/richtextsymboldlg.cpp:433
+#: ../src/richtext/richtextsymboldlg.cpp:434
+#: ../src/richtext/richtextsymboldlg.cpp:435
+msgid "Unicode"
+msgstr "Unicode"
+
+#: ../src/richtext/richtextsymboldlg.cpp:436
+#: ../src/richtext/richtextsymboldlg.cpp:438
+msgid "The range to show."
+msgstr "Jangkauan yang akan diperlihatkan."
+
+#: ../src/richtext/richtextsymboldlg.cpp:444
+msgid "Insert"
+msgstr "Insert"
+
+#: ../src/richtext/richtextsymboldlg.cpp:478
+msgid "(Normal text)"
+msgstr "(Teks normal)"
+
+#: ../src/richtext/richtexttabspage.cpp:109
+msgid "&Position (tenths of a mm):"
+msgstr "&Posisi (persepuluh mm):"
+
+#: ../src/richtext/richtexttabspage.cpp:113
+#: ../src/richtext/richtexttabspage.cpp:115
+msgid "The tab position."
+msgstr "Posisi tab."
+
+#: ../src/richtext/richtexttabspage.cpp:119
+msgid "The tab positions."
+msgstr "Posisi tab."
+
+#: ../src/richtext/richtexttabspage.cpp:132
+#: ../src/richtext/richtexttabspage.cpp:134
+msgid "Click to create a new tab position."
+msgstr "Klik untuk membuat posisi tab baru."
+
+#: ../src/richtext/richtexttabspage.cpp:138
+#: ../src/richtext/richtexttabspage.cpp:140
+msgid "Click to delete the selected tab position."
+msgstr "Klik menghapus posisi tab yang dipilih."
+
+#: ../src/richtext/richtexttabspage.cpp:143
+msgid "Delete A&ll"
+msgstr "Hapus Semu&a"
+
+#: ../src/richtext/richtexttabspage.cpp:144
+#: ../src/richtext/richtexttabspage.cpp:146
+msgid "Click to delete all tab positions."
+msgstr "Klik untuk menghapus semua posisi tab."
+
+#: ../src/univ/theme.cpp:110
+msgid "Failed to initialize GUI: no built-in themes found."
+msgstr "Gagal menginisialisasi GUI: tidak ditemukan tema built-in."
+
+#: ../src/univ/themes/gtk.cpp:521
+msgid "GTK+ theme"
+msgstr "Tema GTK+"
+
+#: ../src/univ/themes/metal.cpp:164
+msgid "Metal theme"
+msgstr "Tema Metal"
+
+#: ../src/univ/themes/mono.cpp:512
+msgid "Simple monochrome theme"
+msgstr "Tema monochrome sederhana"
+
+#: ../src/univ/themes/win32.cpp:1098
+msgid "Win32 theme"
+msgstr "Tema Win32"
+
+#: ../src/univ/themes/win32.cpp:3743
+msgid "&Restore"
+msgstr "&Pulihkan"
+
+#: ../src/univ/themes/win32.cpp:3744
+msgid "&Move"
+msgstr "&Pindah"
+
+#: ../src/univ/themes/win32.cpp:3746
+msgid "&Size"
+msgstr "&Ukuran"
+
+#: ../src/univ/themes/win32.cpp:3748
+msgid "Mi&nimize"
+msgstr "Mi&nimalkan"
+
+#: ../src/univ/themes/win32.cpp:3750
+msgid "Ma&ximize"
+msgstr "Ma&ksimalkan"
+
+#: ../src/univ/themes/win32.cpp:3752
+msgid "Alt+"
+msgstr "Alt+"
+
+#: ../src/unix/appunix.cpp:178
+msgid "Failed to install signal handler"
+msgstr "Gagal memasang pengendali sinyal"
+
+#: ../src/unix/dialup.cpp:351
+msgid "Already dialling ISP."
+msgstr "Sedang menghubungi ISP."
+
+#: ../src/unix/dlunix.cpp:93
+#, fuzzy
+msgid "Failed to unload shared library"
+msgstr "Gagal memuat shared library '%s'"
+
+#: ../src/unix/dlunix.cpp:121
+msgid "Unknown dynamic library error"
+msgstr "Galat kepustakaan dinamis tidak dikenal"
+
+#: ../src/unix/epolldispatcher.cpp:84
+msgid "Failed to create epoll descriptor"
+msgstr "Gagal membuat epoll deskriptor"
+
+#: ../src/unix/epolldispatcher.cpp:103
+msgid "Error closing epoll descriptor"
+msgstr "Galat ketika menutup epoll deskriptor"
+
+#: ../src/unix/epolldispatcher.cpp:116
+#, c-format
+msgid "Failed to add descriptor %d to epoll descriptor %d"
+msgstr "Gagal menambahkan deskriptor %d ke epool deskriptor %d"
+
+#: ../src/unix/epolldispatcher.cpp:136
+#, c-format
+msgid "Failed to modify descriptor %d in epoll descriptor %d"
+msgstr "Gagal mengubah deskriptor %d dalam epoll deskriptor %d"
+
+#: ../src/unix/epolldispatcher.cpp:155
+#, c-format
+msgid "Failed to unregister descriptor %d from epoll descriptor %d"
+msgstr ""
+"Gagal untuk membatalkan pendaftara deskriptor %d dari epoll deskriptor %d"
+
+#: ../src/unix/epolldispatcher.cpp:213
+#, c-format
+msgid "Waiting for IO on epoll descriptor %d failed"
+msgstr "Menunggu IO di deskriptor epoll %d gagal"
+
+#: ../src/unix/fswatcher_inotify.cpp:71
+msgid "Unable to create inotify instance"
+msgstr "Gagal membuat instan inotify"
+
+#: ../src/unix/fswatcher_inotify.cpp:94
+msgid "Unable to close inotify instance"
+msgstr "Gagal menutup instan inotify"
+
+#: ../src/unix/fswatcher_inotify.cpp:106
+msgid "Unable to add inotify watch"
+msgstr "Gagal menambahkan pengamat inotify"
+
+#: ../src/unix/fswatcher_inotify.cpp:138
+#, c-format
+msgid "Unable to remove inotify watch %i"
+msgstr "Gagal menghapus pengamat inotify %i"
+
+#: ../src/unix/fswatcher_inotify.cpp:271
+#, c-format
+msgid "Unexpected event for \"%s\": no matching watch descriptor."
+msgstr ""
+"Kejadian yang tak diharapkan bagi \"%s\": tak ada deskriptor pengamat yang "
+"sesuai."
+
+#: ../src/unix/fswatcher_inotify.cpp:320
+#, c-format
+msgid "Invalid inotify event for \"%s\""
+msgstr "Event inotify “%s” tidak sah"
+
+#: ../src/unix/fswatcher_inotify.cpp:553
+msgid "Unable to read from inotify descriptor"
+msgstr "Gagal membaca deskriptor inotify"
+
+#: ../src/unix/fswatcher_inotify.cpp:558
+msgid "EOF while reading from inotify descriptor"
+msgstr "EOF ketika membaca dari deskriptor inotify"
+
+#: ../src/unix/fswatcher_kqueue.cpp:114
+msgid "Unable to create kqueue instance"
+msgstr "Gagal membuat instan kqueue"
+
+#: ../src/unix/fswatcher_kqueue.cpp:131
+msgid "Error closing kqueue instance"
+msgstr "Galat ketika menutup kqueue instance"
+
+#: ../src/unix/fswatcher_kqueue.cpp:153
+msgid "Unable to add kqueue watch"
+msgstr "Gagal menambahkan pengamat kqueue"
+
+#: ../src/unix/fswatcher_kqueue.cpp:170
+msgid "Unable to remove kqueue watch"
+msgstr "Gagal menghapus pengamat kqueue"
+
+#: ../src/unix/fswatcher_kqueue.cpp:202
+msgid "Unable to get events from kqueue"
+msgstr "Gagal mendapatkan even dari kqueue"
+
+#: ../src/unix/mediactrl.cpp:966
+#, c-format
+msgid "Media playback error: %s"
+msgstr "Galat media pemutar: %s"
+
+#: ../src/unix/mediactrl.cpp:1228
+#, c-format
+msgid "Failed to prepare playing \"%s\"."
+msgstr "Gagal memutar \"%s\"."
+
+#: ../src/unix/snglinst.cpp:164
+#, c-format
+msgid "Failed to write to lock file '%s'"
+msgstr "Gagal menulis file lock '%s'"
+
+#: ../src/unix/snglinst.cpp:177
+#, c-format
+msgid "Failed to set permissions on lock file '%s'"
+msgstr "Gagal mengatur izin mengunci berkas '%s'"
+
+#: ../src/unix/snglinst.cpp:194
+#, c-format
+msgid "Failed to lock the lock file '%s'"
+msgstr "Gagal mengunci lock file '%s'"
+
+#: ../src/unix/snglinst.cpp:237
+#, c-format
+msgid "Failed to inspect the lock file '%s'"
+msgstr "Gagal memeriksa berkas terkunci '%s'"
+
+#: ../src/unix/snglinst.cpp:242
+#, c-format
+msgid "Lock file '%s' has incorrect owner."
+msgstr "Kesalahan pemilik pada berkas kunci ‘%s’."
+
+#: ../src/unix/snglinst.cpp:247
+#, c-format
+msgid "Lock file '%s' has incorrect permissions."
+msgstr "Kesalahan hak akses pada berkas kunci '%s'."
+
+#: ../src/unix/snglinst.cpp:265
+msgid "Failed to access lock file."
+msgstr "Gagal mengakses file lock."
+
+#: ../src/unix/snglinst.cpp:274
+msgid "Failed to read PID from lock file."
+msgstr "Gagal membaca PID dari file lock."
+
+#: ../src/unix/snglinst.cpp:284
+#, c-format
+msgid "Failed to remove stale lock file '%s'."
+msgstr "Gagal menghapus berkas pengunci ‘%s’."
+
+#: ../src/unix/snglinst.cpp:297
+#, c-format
+msgid "Deleted stale lock file '%s'."
+msgstr "Menghapus file lock '%s' yang terhenti."
+
+#: ../src/unix/snglinst.cpp:308
+#, c-format
+msgid "Invalid lock file '%s'."
+msgstr "Berkas lock '%s' tidak sah."
+
+#: ../src/unix/snglinst.cpp:324
+#, c-format
+msgid "Failed to remove lock file '%s'"
+msgstr "Gagal menghilangkan file lock '%s'"
+
+#: ../src/unix/snglinst.cpp:330
+#, c-format
+msgid "Failed to unlock lock file '%s'"
+msgstr "Gagal membuka kunci dari file lock '%s'"
+
+#: ../src/unix/snglinst.cpp:336
+#, c-format
+msgid "Failed to close lock file '%s'"
+msgstr "Gagal menutup file lock '%s'"
+
+#: ../src/unix/sound.cpp:77
+msgid "No sound"
+msgstr "Tidak bersuara"
+
+#: ../src/unix/sound.cpp:364
+msgid "Unable to play sound asynchronously."
+msgstr "Gagal memainkan audio secara asinkron."
+
+#: ../src/unix/sound.cpp:458
+#, c-format
+msgid "Couldn't load sound data from '%s'."
+msgstr "Gagal memuat data suara dari '%s'."
+
+#: ../src/unix/sound.cpp:465
+#, c-format
+msgid "Sound file '%s' is in unsupported format."
+msgstr "Format berkas suara '%s' tidak didukung."
+
+#: ../src/unix/sound.cpp:480
+msgid "Sound data are in unsupported format."
+msgstr "Data suara tidak didukung."
+
+#: ../src/unix/sound_sdl.cpp:226
+#, c-format
+msgid "Couldn't open audio: %s"
+msgstr "Gagal membuka audio: %s"
+
+#: ../src/unix/threadpsx.cpp:1033
+msgid "Cannot retrieve thread scheduling policy."
+msgstr "Gagal mengambil kebijakan penjadwalan thread."
+
+#: ../src/unix/threadpsx.cpp:1058
+#, c-format
+msgid "Cannot get priority range for scheduling policy %d."
+msgstr "Gagal memperoleh jangkauan prioritas untuk kebijakan penjadwalan %d."
+
+#: ../src/unix/threadpsx.cpp:1066
+msgid "Thread priority setting is ignored."
+msgstr "Setelan prioritas thread diabaikan."
+
+#: ../src/unix/threadpsx.cpp:1221
+msgid ""
+"Failed to join a thread, potential memory leak detected - please restart the "
+"program"
+msgstr ""
+"Gagal bergabung ke thread, terdeteksi potensi kebocoran memori - silahkan "
+"jalankan ulang program"
+
+#: ../src/unix/threadpsx.cpp:1352
+#, c-format
+msgid "Failed to set thread concurrency level to %lu"
+msgstr "Gagal mengatur thread concurrency level pada %lu"
+
+#: ../src/unix/threadpsx.cpp:1481
+#, c-format
+msgid "Failed to set thread priority %d."
+msgstr "Gagal menetapkan prioritas thread %d."
+
+#: ../src/unix/threadpsx.cpp:1666
+msgid "Failed to terminate a thread."
+msgstr "Gagal menghentikan thread."
+
+#: ../src/unix/threadpsx.cpp:1893
+msgid "Thread module initialization failed: failed to create thread key"
+msgstr "Inisialisasi modul thread gagal: gagal menciptakan kunci thread"
+
+#: ../src/unix/utilsunx.cpp:340
+msgid "Impossible to get child process input"
+msgstr "Tidak mungkin memperoleh masukan dari proses anak"
+
+#: ../src/unix/utilsunx.cpp:390
+msgid "Can't write to child process's stdin"
+msgstr "Gagal menulis ke stdin proses anak"
+
+#: ../src/unix/utilsunx.cpp:644
+#, c-format
+msgid "Failed to execute '%s'\n"
+msgstr "Gagal mengeksekusi '%s'\n"
+
+# sort by translation
+# checked up to here 20131006-1302
+#: ../src/unix/utilsunx.cpp:678
+msgid "Fork failed"
+msgstr "Fork gagal"
+
+#: ../src/unix/utilsunx.cpp:701
+msgid "Failed to set process priority"
+msgstr "Gagal menetapkan prioritas proses"
+
+#: ../src/unix/utilsunx.cpp:712
+msgid "Failed to redirect child process input/output"
+msgstr "Gagal mengarahkan kembali proses masukan/keluaran child"
+
+#: ../src/unix/utilsunx.cpp:816
+msgid "Failed to set up non-blocking pipe, the program might hang."
+msgstr "Gagal mengatur no-blocking pipe, program mungkin akan mengalami galat."
+
+#: ../src/unix/utilsunx.cpp:1023
+msgid "Cannot get the hostname"
+msgstr "Gagal memperoleh nama host"
+
+#: ../src/unix/utilsunx.cpp:1059
+msgid "Cannot get the official hostname"
+msgstr "Gagal memperoleh nama host resmi"
+
+#: ../src/unix/wakeuppipe.cpp:49
+msgid "Failed to create wake up pipe used by event loop."
+msgstr "Gagal membuat wake up pipe yang digunakan oleh event loop."
+
+#: ../src/unix/wakeuppipe.cpp:56
+msgid "Failed to switch wake up pipe to non-blocking mode"
+msgstr "Gagal mengubah wake up pipe ke mode non-blocking"
+
+#: ../src/unix/wakeuppipe.cpp:117
+msgid "Failed to read from wake-up pipe"
+msgstr "Gagal membaca dari wake-up pipe"
+
+#: ../src/x11/app.cpp:124
+#, c-format
+msgid "Invalid geometry specification '%s'"
+msgstr "Spesifikasi geometri '%s' tidak sah"
+
+#: ../src/x11/app.cpp:167
+msgid "wxWidgets could not open display. Exiting."
+msgstr "wxWidgets tidak bisa membuka tampilan. Keluar."
+
+#: ../src/x11/utils.cpp:169
+#, c-format
+msgid "Failed to close the display \"%s\""
+msgstr "Gagal menutup \"%s\""
+
+#: ../src/x11/utils.cpp:188
+#, c-format
+msgid "Failed to open display \"%s\"."
+msgstr "Gagal membuka \"%s\"."
+
+#: ../src/xml/xml.cpp:868
+#, c-format
+msgid "XML parsing error: '%s' at line %d"
+msgstr "Kesalahan parsing XML: '%s' pada baris %d"
+
+#: ../src/xrc/xh_propgrid.cpp:239
+#, fuzzy, c-format
+msgid "Page %i"
+msgstr "Halaman %d"
+
+#: ../src/xrc/xmlres.cpp:448
+#, c-format
+msgid "Cannot load resources from '%s'."
+msgstr "Gagal memuat sumber daya dari '%s'."
+
+#: ../src/xrc/xmlres.cpp:799
+#, c-format
+msgid "Cannot open resources file '%s'."
+msgstr "Gagal membuka berkas sumber daya '%s'."
+
+#: ../src/xrc/xmlres.cpp:806
+#, c-format
+msgid "Cannot load resources from file '%s'."
+msgstr "Gagal memuat sumber daya dari berkas '%s'."
+
+#: ../src/xrc/xmlres.cpp:2767
+#, c-format
+msgid "Creating %s \"%s\" failed."
+msgstr "Gagal membuat %s \"%s\"."
+
+#~ msgctxt "keyboard key"
+#~ msgid "Alt+"
+#~ msgstr "Alt+"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Ctrl+"
+#~ msgstr "Ctrl+"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Shift+"
+#~ msgstr "Shift+"
+
+#~ msgctxt "keyboard key"
+#~ msgid "RawCtrl+"
+#~ msgstr "RawCtrl+"
+
+#~ msgid "Unsupported clipboard format."
+#~ msgstr "Format clipboard tidak didukung."
+
+#~ msgid "Background colour"
+#~ msgstr "Warna latar belakang"
+
+#~ msgid "Font:"
+#~ msgstr "Font:"
+
+#~ msgid "Size:"
+#~ msgstr "Ukuran:"
+
+#~ msgid "The font size in points."
+#~ msgstr "Ukuran font dalam point."
+
+#~ msgid "Style:"
+#~ msgstr "Gaya:"
+
+#~ msgid "Check to make the font bold."
+#~ msgstr "Centang untuk membuat font tebal."
+
+#~ msgid "Check to make the font italic."
+#~ msgstr "Centang untuk membuat font miring."
+
+#~ msgid "Check to make the font underlined."
+#~ msgstr "Centang untuk membuat font bergarisbawah."
+
+#~ msgid "Colour:"
+#~ msgstr "Warna:"
+
+#~ msgid "Click to change the font colour."
+#~ msgstr "Klik untuk mengubah warna font."
+
+#~ msgid "Shows a preview of the font."
+#~ msgstr "Tampilkan pratinjau font."
+
+#~ msgid "Click to cancel changes to the font."
+#~ msgstr "Klik untuk membatalkan perubahan font."
+
+#~ msgid "Click to confirm changes to the font."
+#~ msgstr "Klik untuk mengkonfirmasi perubahan atas font."
+
+#~ msgid "<Any>"
+#~ msgstr "<Apapun>"
+
+#~ msgid "<Any Roman>"
+#~ msgstr "<Sebarang Roman>"
+
+#~ msgid "<Any Decorative>"
+#~ msgstr "<Sebarang Dekoratif>"
+
+#~ msgid "<Any Modern>"
+#~ msgstr "<Sebarang Modern>"
+
+#~ msgid "<Any Script>"
+#~ msgstr "<Sebarang Skrip>"
+
+#~ msgid "<Any Swiss>"
+#~ msgstr "<Sebarang Swiss>"
+
+#~ msgid "<Any Teletype>"
+#~ msgstr "<Sebarang Teletype>"
+
+#~ msgid "Printing "
+#~ msgstr "Mencetak "
+
+#~ msgid "Failed to insert text in the control."
+#~ msgstr "Gagal menyisipkan teks ke dalam kontrol."
+
+#~ msgid "Please choose a valid font."
+#~ msgstr "Silahkan pilih font yang sah."
+
+#, c-format
+#~ msgid "Failed to display HTML document in %s encoding"
+#~ msgstr "Gagal menampilkan dokumen HTML dalam pengkodean %s"
+
+#, c-format
+#~ msgid "wxWidgets could not open display for '%s': exiting."
+#~ msgstr "wxWidgets tidak bisa membuka tampilan untuk '%s': keluar."
+
+#~ msgid "Filter"
+#~ msgstr "Penyaring"
+
+#~ msgid "Directories"
+#~ msgstr "Direktori"
+
+#~ msgid "Files"
+#~ msgstr "Berkas"
+
+#~ msgid "Selection"
+#~ msgstr "Seleksi"
+
+#~ msgid "conversion to 8-bit encoding failed"
+#~ msgstr "konversi ke enkoding 8-bit gagal"
+
+#, fuzzy
+#~ msgid "failed to retrieve execution result"
+#~ msgstr "Gagal mengambil teks dari pesan kesalahan RAS"
+
+#~ msgid " (while overwriting an existing item)"
+#~ msgstr " (saat menimpa obyek yang ada)"
+
+#~ msgid "&Save as"
+#~ msgstr "&Simpan sebagai"
+
+#~ msgid "'%s' doesn't consist only of valid characters"
+#~ msgstr "'%s' tidak terdiri dari karakter yang sah"
+
+#~ msgid "'%s' should be numeric."
+#~ msgstr "'%s' harus numerik."
+
+#~ msgid "'%s' should only contain ASCII characters."
+#~ msgstr "'%s' harus hanya berisi karakter ASCII."
+
+#~ msgid "'%s' should only contain alphabetic characters."
+#~ msgstr "'%s' harus hanya berisi karakter alfabet."
+
+#~ msgid "'%s' should only contain alphabetic or numeric characters."
+#~ msgstr "'%s' harus hanya berisi karakter alfabet atau numerik."
+
+#~ msgid "'%s' should only contain digits."
+#~ msgstr "'%s' hanya boleh berisi angka."
+
+#~ msgid "Can't create window of class %s"
+#~ msgstr "Gagal menciptakan jendela dari class %s"
+
+#~ msgid "Couldn't create the overlay window"
+#~ msgstr "Gagal membuat overlay window"
+
+#~ msgid "Couldn't init the context on the overlay window"
+#~ msgstr "Gagal menjalankan konteks di overlay window"
+
+#~ msgid "Failed to convert file \"%s\" to Unicode."
+#~ msgstr "Gagal mengubah berkas \"%s\" ke Unicode."
+
+#~ msgid "Failed to set text in the text control."
+#~ msgstr "Gagal mengatur teks pada teks kontrol."
+
+#~ msgid "Invalid GTK+ command line option, use \"%s --help\""
+#~ msgstr "Opsi perintah GTK+ salah, gunakan \"%s --help\""
+
+#~ msgid "No unused colour in image."
+#~ msgstr "Tidak tersedia warna di dalam citra."
+
+#~ msgid "Not available"
+#~ msgstr "Tidak tersedia"
+
+#~ msgid "Replace selection"
+#~ msgstr "Timpa seleksi"
+
+#~ msgid "Save as"
+#~ msgstr "Simpan sebagai"
+
+#~ msgid "Style Organiser"
+#~ msgstr "Pengelola Gaya"
+
+#~ msgid "The following standard GTK+ options are also supported:\n"
+#~ msgstr "Standar opsi GTK+ yang didukung:\n"
+
+#~ msgid "You cannot Clear an overlay that is not inited"
+#~ msgstr "Kamu tidak dapat membersihkan overlay yang belum di init"
+
+#~ msgid "You cannot Init an overlay twice"
+#~ msgstr "Jangan menginisiasi overlay dua kali"
+
+#~ msgid "locale '%s' cannot be set."
+#~ msgstr "bahasa '%s' tidak bisa ditetapkan."
+
+#~ msgid "Adding flavor TEXT failed"
+#~ msgstr "Penambahan rasa TEKS gagal"
+
+#~ msgid "Adding flavor utxt failed"
+#~ msgstr "Penambahan rasa utxt gagal"
+
+#~ msgid "Bitmap renderer cannot render value; value type: "
+#~ msgstr "Perender Bitmap tidak dapat merender nilai; tipe nilai:"
+
+#~ msgid ""
+#~ "Cannot create new column's ID. Probably max. number of columns reached."
+#~ msgstr ""
+#~ "Gagal membuat ID kolom baru. Mungkin banyak kolom sudah mencapai batas "
+#~ "maksimum."
+
+#~ msgid "Column could not be added."
+#~ msgstr "Kolom tidak bisa ditambahkan."
+
+#~ msgid "Column index not found."
+#~ msgstr "Indeks kolom tidak ditemukan."
+
+#~ msgid "Column width could not be determined"
+#~ msgstr "Lebar kolom tidak dapat ditentukan"
+
+#~ msgid "Column width could not be set."
+#~ msgstr "Lebar kolom tidak dapat ditata."
+
+#~ msgid "Confirm registry update"
+#~ msgstr "Konfirmasi peremajaan registri"
+
+#~ msgid "Could not determine column index."
+#~ msgstr "Gagal menentukan indeks kolom."
+
+#~ msgid "Could not determine column's position"
+#~ msgstr "Gagal menentukan posisi kolom."
+
+#~ msgid "Could not determine number of columns."
+#~ msgstr "Gagal menentukan jumlah kolom."
+
+#~ msgid "Could not determine number of items"
+#~ msgstr "Gagal menentukan jumlah obyek."
+
+#~ msgid "Could not get header description."
+#~ msgstr "Gagal mendapatkan deskripsi judul."
+
+#~ msgid "Could not get items."
+#~ msgstr "Gagal mendapatkan obyek."
+
+#~ msgid "Could not get property flags."
+#~ msgstr "Gagal mendapatkan bendera properti."
+
+#~ msgid "Could not get selected items."
+#~ msgstr "Gagal menentukan obyek yang dipilih."
+
+#~ msgid "Could not remove column."
+#~ msgstr "Gagal menghapus kolom."
+
+#~ msgid "Could not retrieve number of items"
+#~ msgstr "Gagal mengambil jumlah obyek."
+
+#~ msgid "Could not set column width."
+#~ msgstr "Gagal mengatur lebar kolom."
+
+#~ msgid "Could not set header description."
+#~ msgstr "Gagal mengatur keterangan judul."
+
+#~ msgid "Could not set icon."
+#~ msgstr "Gagal mengatur ikon"
+
+#~ msgid "Could not set maximum width."
+#~ msgstr "Gagal mengatur lebar maksimum."
+
+#~ msgid "Could not set minimum width."
+#~ msgstr "Gagal mengatur lebar minimum."
+
+#~ msgid "Could not set property flags."
+#~ msgstr "Gagal mengatur bendera properti."
+
+#~ msgid "Data object has invalid data format"
+#~ msgstr "Format data obyek salah"
+
+#~ msgid "Date renderer cannot render value; value type: "
+#~ msgstr "Gagal merender nilai penanggalan; tipe nilai: "
+
+#~ msgid ""
+#~ "Do you want to overwrite the command used to %s files with extension "
+#~ "\"%s\" ?\n"
+#~ "Current value is \n"
+#~ "%s, \n"
+#~ "New value is \n"
+#~ "%s %1"
+#~ msgstr ""
+#~ "Apakah anda ingin menimpa perintah yang digunakan untuk %s berkas dengan "
+#~ "ekstensi \"%s\" ?\n"
+#~ "Nilai saat ini adalah \n"
+#~ "%s, \n"
+#~ "Nilai baru adalah \n"
+#~ "%s %1"
+
+#~ msgid "Failed to retrieve data from the clipboard."
+#~ msgstr "Gagal mengambil data dari clipboard."
+
+#~ msgid "GIF: Invalid gif index."
+#~ msgstr "GIF: Indeks gif tidak sah."
+
+#~ msgid "GIF: unknown error!!!"
+#~ msgstr "GIF: error tidak dikenal!!!"
+
+#~ msgid "Icon & text renderer cannot render value; value type: "
+#~ msgstr "Pengolah ikon & teks tidak dapat mengolah nilai; tipe nilai: "
+
+#~ msgid "New directory"
+#~ msgstr "Direktori baru"
+
+#~ msgid "Next"
+#~ msgstr "Berikut"
+
+#~ msgid "No column existing."
+#~ msgstr "Tidak ada kolom."
+
+#~ msgid "No column for the specified column existing."
+#~ msgstr "Tidak ada kolom pada kolom pilihan."
+
+#~ msgid "No column for the specified column position existing."
+#~ msgstr "Tidak ada kolom pada posisi kolom yang dipilih."
+
+#~ msgid ""
+#~ "No renderer or invalid renderer type specified for custom data column."
+#~ msgstr ""
+#~ "Renderer belum ditentukan atau tidak sesuai untuk kolom data kustom ini."
+
+#~ msgid "No renderer specified for column."
+#~ msgstr "Renderer belum ditentukan untuk kolom ini."
+
+#~ msgid "Number of columns could not be determined."
+#~ msgstr "Jumlah kolom tidak dapat ditentukan."
+
+#~ msgid "OpenGL function \"%s\" failed: %s (error %d)"
+#~ msgstr "Fungsi OpenGL \"%s\" gagal: %s (galat %d)"
+
+#~ msgid ""
+#~ "Please install a newer version of comctl32.dll\n"
+#~ "(at least version 4.70 is required but you have %d.%02d)\n"
+#~ "or this program won't operate correctly."
+#~ msgstr ""
+#~ "Silahkan install versi comctl32.dll yang lebih baru\n"
+#~ "(setidaknya dibutuhkan versi 4.70 tetapi anda mempunyai %d.%02d)\n"
+#~ "atau program ini tidak akan beroperasi dengan benar."
+
+#~ msgid "Pointer to data view control not set correctly."
+#~ msgstr "Pointer ke kontrol data view tidak diset dengan benar."
+
+#~ msgid "Pointer to model not set correctly."
+#~ msgstr "Pointer ke model tidak diset dengan benar."
+
+#~ msgid "Progress renderer cannot render value type; value type: "
+#~ msgstr "Gagal merender nilai kemajuan; tipe nilai: "
+
+#~ msgid "Rendering failed."
+#~ msgstr "Rendering gagal."
+
+#~ msgid ""
+#~ "Setting directory access times is not supported under this OS version"
+#~ msgstr "Menata waktu akses direktori tidak didukung oleh versi OS ini"
+
+#~ msgid "Show hidden directories"
+#~ msgstr "Tampilkan direktori tersembunyi"
+
+#~ msgid "Text renderer cannot render value; value type: "
+#~ msgstr "Gagal merender nilai teks; tipe nilai: "
+
+#~ msgid "There is no column or renderer for the specified column index."
+#~ msgstr "Tidak ada kolom atau renderer untuk indeks kolom yang ditentukan."
+
+#~ msgid ""
+#~ "This system doesn't support date controls, please upgrade your version of "
+#~ "comctl32.dll"
+#~ msgstr ""
+#~ "Sistem ini tidak mendukung kontrol penanggalan, mohon perbaharui versi "
+#~ "comctl32.dll anda"
+
+#~ msgid "Toggle renderer cannot render value; value type: "
+#~ msgstr "Gagal merender nilai toggle; tipe nilai:"
+
+#~ msgid "Too many colours in PNG, the image may be slightly blurred."
+#~ msgstr "Terlalu banyak warna dalam PNG, citra mungkin akan sedikit blur."
+
+#~ msgid "Unable to handle native drag&drop data"
+#~ msgstr "Gagal menangani data drag&drop native"
+
+#~ msgid "Unable to initialize Hildon program"
+#~ msgstr "Gagal menginisialisasi progam Hildon"
+
+#~ msgid "Unknown data format"
+#~ msgstr "Format data tidak dikenal"
+
+#~ msgid "Valid pointer to native data view control does not exist"
+#~ msgstr "Tidak ada pointer valid ke kontrol data view"
+
+#~ msgid "Win32s on Windows 3.1"
+#~ msgstr "Win32 pada Windows 3.1"
+
+#, fuzzy
+#~ msgid "Windows 10"
+#~ msgstr "Windows 98"
+
+#~ msgid "Windows 2000"
+#~ msgstr "Windows 2000"
+
+#~ msgid "Windows 7"
+#~ msgstr "Windows 7"
+
+#, fuzzy
+#~ msgid "Windows 8"
+#~ msgstr "Windows 98"
+
+#, fuzzy
+#~ msgid "Windows 8.1"
+#~ msgstr "Windows 98"
+
+#~ msgid "Windows 95"
+#~ msgstr "Windows 95"
+
+#~ msgid "Windows 95 OSR2"
+#~ msgstr "Windows 95 OSR2"
+
+#~ msgid "Windows 98"
+#~ msgstr "Windows 98"
+
+#~ msgid "Windows 98 SE"
+#~ msgstr "Windows 98 SE"
+
+#~ msgid "Windows 9x (%d.%d)"
+#~ msgstr "Windows 9x (%d.%d)"
+
+#~ msgid "Windows CE (%d.%d)"
+#~ msgstr "Windows CE (%d.%d)"
+
+#~ msgid "Windows ME"
+#~ msgstr "Windows ME"
+
+#~ msgid "Windows NT %lu.%lu"
+#~ msgstr "Windows NT %lu.%lu"
+
+#, fuzzy
+#~ msgid "Windows Server 10"
+#~ msgstr "Windows Server 2003"
+
+#~ msgid "Windows Server 2003"
+#~ msgstr "Windows Server 2003"
+
+#~ msgid "Windows Server 2008"
+#~ msgstr "Windows Server 2008"
+
+#~ msgid "Windows Server 2008 R2"
+#~ msgstr "Windows Server 2008 R2"
+
+#, fuzzy
+#~ msgid "Windows Server 2012"
+#~ msgstr "Windows Server 2003"
+
+#, fuzzy
+#~ msgid "Windows Server 2012 R2"
+#~ msgstr "Windows Server 2008 R2"
+
+#~ msgid "Windows Vista"
+#~ msgstr "Windows Vista"
+
+#~ msgid "Windows XP"
+#~ msgstr "Windows XP"
+
+#~ msgid "can't execute '%s'"
+#~ msgstr "tidak dapat menjalankan '%s'"
+
+#~ msgid "error opening '%s'"
+#~ msgstr "galat membuka '%s'"
+
+#~ msgid "unknown seek origin"
+#~ msgstr "asal seek tidak diketahui"
+
+#~ msgid "wxWidget control pointer is not a data view pointer"
+#~ msgstr "Kontrol pointer wxWidget bukan merupakan pointer data view"
+
+#~ msgid "wxWidget's control not initialized."
+#~ msgstr "Kontrol wxWidget tidak diinisialisasi."
+
+#~ msgid "ADD"
+#~ msgstr "TAMBAH"
+
+#~ msgid "BACK"
+#~ msgstr "MUNDUR"
+
+#~ msgid "CANCEL"
+#~ msgstr "BATAL"
+
+#~ msgid "CAPITAL"
+#~ msgstr "KAPITAL"
+
+#~ msgid "CLEAR"
+#~ msgstr "BERSIHKAN"
+
+#~ msgid "COMMAND"
+#~ msgstr "PERINTAH"
+
+#~ msgid "Cannot create mutex."
+#~ msgstr "Gagal menciptakan mutex."
+
+#~ msgid "Cannot resume thread %lu"
+#~ msgstr "Gagal meneruskan thread %lu"
+
+#~ msgid "Cannot suspend thread %lu"
+#~ msgstr "Gagal menunda thread %lu"
+
+#~ msgid "Couldn't acquire a mutex lock"
+#~ msgstr "Gagal memperoleh kunci mutex"
+
+#~ msgid "Couldn't get hatch style from wxBrush."
+#~ msgstr "Gagal mengambil gaya hatch dari wxBrush."
+
+#~ msgid "Couldn't release a mutex"
+#~ msgstr "Gagal merilis mutex"
+
+#~ msgid "DECIMAL"
+#~ msgstr "DESIMAL"
+
+#~ msgid "DEL"
+#~ msgstr "DEL"
+
+#~ msgid "DELETE"
+#~ msgstr "HAPUS"
+
+#~ msgid "DIVIDE"
+#~ msgstr "BAGI"
+
+#~ msgid "DOWN"
+#~ msgstr "BAWAH"
+
+#~ msgid "END"
+#~ msgstr "SELESAI"
+
+#~ msgid "ENTER"
+#~ msgstr "MASUK"
+
+#~ msgid "ESC"
+#~ msgstr "LEPAS"
+
+#~ msgid "ESCAPE"
+#~ msgstr "LEPAS"
+
+#~ msgid "EXECUTE"
+#~ msgstr "JALANKAN"
+
+#~ msgid "Execution of command '%s' failed with error: %ul"
+#~ msgstr "Eksekusi perintah '%s' gagal dengan galat: %u|"
+
+#~ msgid ""
+#~ "File '%s' already exists.\n"
+#~ "Do you want to replace it?"
+#~ msgstr ""
+#~ "Berkas '%s' sudah ada.\n"
+#~ "Apakah anda ingin menggantinya?"
+
+#~ msgid "HELP"
+#~ msgstr "BANTUAN"
+
+#~ msgid "HOME"
+#~ msgstr "AWAL"
+
+#~ msgid "INS"
+#~ msgstr "SISIP"
+
+#~ msgid "INSERT"
+#~ msgstr "SISIPKAN"
+
+#~ msgid "KP_BEGIN"
+#~ msgstr "KP_BEGIN"
+
+#~ msgid "KP_DECIMAL"
+#~ msgstr "KP_DECIMAL"
+
+#~ msgid "KP_DELETE"
+#~ msgstr "KP_DELETE"
+
+#~ msgid "KP_DIVIDE"
+#~ msgstr "KP_DIVIDE"
+
+#~ msgid "KP_DOWN"
+#~ msgstr "KP_DOWN"
+
+#~ msgid "KP_ENTER"
+#~ msgstr "KP_ENTER"
+
+#~ msgid "KP_EQUAL"
+#~ msgstr "KP_EQUAL"
+
+#~ msgid "KP_HOME"
+#~ msgstr "KP_HOME"
+
+#~ msgid "KP_INSERT"
+#~ msgstr "KP_INSERT"
+
+#~ msgid "KP_LEFT"
+#~ msgstr "KP_LEFT"
+
+#~ msgid "KP_MULTIPLY"
+#~ msgstr "KP_MULTIPLY"
+
+#~ msgid "KP_NEXT"
+#~ msgstr "KP_NEXT"
+
+#~ msgid "KP_PAGEDOWN"
+#~ msgstr "KP_PAGEDOWN"
+
+#~ msgid "KP_PAGEUP"
+#~ msgstr "KP_PAGEUP"
+
+#~ msgid "KP_PRIOR"
+#~ msgstr "KP_PRIOR"
+
+#~ msgid "KP_RIGHT"
+#~ msgstr "KP_RIGHT"
+
+#~ msgid "KP_SEPARATOR"
+#~ msgstr "KP_SEPARATOR"
+
+#~ msgid "KP_SPACE"
+#~ msgstr "KP_SPACE"
+
+#~ msgid "KP_SUBTRACT"
+#~ msgstr "KP_SUBTRACT"
+
+#~ msgid "LEFT"
+#~ msgstr "LEFT"
+
+#~ msgid "MENU"
+#~ msgstr "MENU"
+
+#~ msgid "NUM_LOCK"
+#~ msgstr "NUM_LOCK"
+
+#~ msgid "PAGEDOWN"
+#~ msgstr "PAGEDOWN"
+
+#~ msgid "PAGEUP"
+#~ msgstr "PAGEUP"
+
+#~ msgid "PAUSE"
+#~ msgstr "PAUSE"
+
+#~ msgid "PGDN"
+#~ msgstr "PGDN"
+
+#~ msgid "PGUP"
+#~ msgstr "PGUP"
+
+#~ msgid "PRINT"
+#~ msgstr "PRINT"
+
+#~ msgid "RETURN"
+#~ msgstr "RETURN"
+
+#~ msgid "RIGHT"
+#~ msgstr "RIGHT"
+
+#~ msgid "SCROLL_LOCK"
+#~ msgstr "SCROLL_LOCK"
+
+#~ msgid "SELECT"
+#~ msgstr "SELECT"
+
+#~ msgid "SEPARATOR"
+#~ msgstr "SEPARATOR"
+
+#~ msgid "SNAPSHOT"
+#~ msgstr "SNAPSHOT"
+
+#~ msgid "SPACE"
+#~ msgstr "SPACE"
+
+#~ msgid "SUBTRACT"
+#~ msgstr "SUBTRACT"
+
+#~ msgid "TAB"
+#~ msgstr "TAB"
+
+#~ msgid "The print dialog returned an error."
+#~ msgstr "Dialog cetak mengembalikan galat."
+
+#~ msgid "The wxGtkPrinterDC cannot be used."
+#~ msgstr "wxGtkPrinterDC tidak dapat digunakan."
+
+#~ msgid "Timer creation failed."
+#~ msgstr "Pembuatan waktu gagal"
+
+#~ msgid "UP"
+#~ msgstr "UP"
+
+#~ msgid "WINDOWS_LEFT"
+#~ msgstr "WINDOWS_LEFT"
+
+#~ msgid "WINDOWS_MENU"
+#~ msgstr "WINDOWS_MENU"
+
+#~ msgid "WINDOWS_RIGHT"
+#~ msgstr "WINDOWS_RIGHT"
+
+#~ msgid "buffer is too small for Windows directory."
+#~ msgstr "peyangga terlalu kecil untuk direktory Windows."
+
+#~ msgid "not implemented"
+#~ msgstr "belum diimplementasikan"
+
+#~ msgid "wxPrintout::GetPageInfo gives a null maxPage."
+#~ msgstr "wxPrintout::GetPageInfo memberikan maxPage."
+
+#~ msgid "Event queue overflowed"
+#~ msgstr "Antrian peristiwa luber"
+
+#~ msgid "percent"
+#~ msgstr "persen"

--- a/po_wxstd/it.po
+++ b/po_wxstd/it.po
@@ -1,0 +1,9486 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: wxWidgets revised 31.10.2024 by bovirus\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-05-14 20:23+0200\n"
+"PO-Revision-Date: 2024-10-31 10:00+0100\n"
+"Last-Translator: bovirus <bovirus@gmail.com>\n"
+"Language-Team: wxWidgets translators <wx-translators@googlegroups.com>\n"
+"Language: it\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
+"X-Generator: Poedit 3.5\n"
+"X-Poedit-SourceCharset: UTF-8\n"
+
+#: ../include/wx/defs.h:2582
+msgid "All files (*.*)|*.*"
+msgstr "Tutti i file (*.*)|*.*"
+
+#: ../include/wx/defs.h:2585
+msgid "All files (*)|*"
+msgstr "Tutti i file (*)|*"
+
+#: ../include/wx/generic/progdlgg.h:85
+msgid "Elapsed time:"
+msgstr "Tempo trascorso:"
+
+#: ../include/wx/generic/progdlgg.h:86
+msgid "Estimated time:"
+msgstr "Tempo stimato:"
+
+#: ../include/wx/generic/progdlgg.h:87
+msgid "Remaining time:"
+msgstr "Tempo rimanente :"
+
+#. TRANSLATORS: HTML printout default title.
+#: ../include/wx/html/htmprint.h:121 ../include/wx/prntbase.h:273
+#: ../include/wx/richtext/richtextprint.h:109 ../src/common/docview.cpp:2161
+msgid "Printout"
+msgstr "Stampa"
+
+#. TRANSLATORS: HTML easy print default title.
+#: ../include/wx/html/htmprint.h:234 ../include/wx/richtext/richtextprint.h:163
+#: ../src/common/prntbase.cpp:522 ../src/html/htmprint.cpp:291
+msgid "Printing"
+msgstr "Stampa"
+
+#: ../include/wx/msgdlg.h:277 ../src/common/stockitem.cpp:211
+msgid "Yes"
+msgstr "Si"
+
+#: ../include/wx/msgdlg.h:278 ../src/common/stockitem.cpp:182
+msgid "No"
+msgstr "No"
+
+#: ../include/wx/msgdlg.h:279 ../src/common/stockitem.cpp:183
+#: ../src/msw/msgdlg.cpp:430 ../src/msw/msgdlg.cpp:734
+#: ../src/richtext/richtextstyledlg.cpp:292
+msgid "OK"
+msgstr "OK"
+
+#: ../include/wx/msgdlg.h:280 ../src/common/stockitem.cpp:150
+#: ../src/msw/msgdlg.cpp:430 ../src/msw/progdlg.cpp:884
+#: ../src/richtext/richtextstyledlg.cpp:295
+msgid "Cancel"
+msgstr "Annulla"
+
+#: ../include/wx/msgdlg.h:281 ../src/common/stockitem.cpp:168
+#: ../src/html/helpdlg.cpp:63 ../src/html/helpfrm.cpp:108
+#: ../src/osx/button_osx.cpp:38
+msgid "Help"
+msgstr "Aiuto"
+
+#: ../include/wx/msw/ole/oleutils.h:52
+msgid "Cannot initialize OLE"
+msgstr "Impossibile inizializzare OLE"
+
+#: ../include/wx/msw/private/fswatcher.h:48
+#, c-format
+msgid "Unable to close the handle for '%s'"
+msgstr "Impossibile chiudere gestore di '%s'"
+
+#: ../include/wx/msw/private/fswatcher.h:92
+#, c-format
+msgid "Failed to open directory \"%s\" for monitoring."
+msgstr "Impossibile aprire cartella \"%s\" per il monitoraggio."
+
+#: ../include/wx/msw/private/fswatcher.h:125
+msgid "Unable to close I/O completion port handle"
+msgstr "Impossibile chiudere gestore porta completamento I/O"
+
+#: ../include/wx/msw/private/fswatcher.h:142
+msgid "Unable to associate handle with I/O completion port"
+msgstr "Impossibile associare gestore completamento porta I/O"
+
+#: ../include/wx/msw/private/fswatcher.h:148
+msgid "Unexpectedly new I/O completion port was created"
+msgstr "È stata creata una nuova inaspettata porta completamento I/O"
+
+#: ../include/wx/msw/private/fswatcher.h:213
+msgid "Unable to post completion status"
+msgstr "Impossibile comunicare stato completamento"
+
+#: ../include/wx/msw/private/fswatcher.h:262
+msgid "Unable to dequeue completion packet"
+msgstr "Impossibile eliminare dalla coda pacchetto completamento"
+
+#: ../include/wx/msw/private/fswatcher.h:273
+msgid "Unable to create I/O completion port"
+msgstr "Impossibile creare porta completamento I/O"
+
+#: ../include/wx/richmsgdlg.h:29
+msgid "&See details"
+msgstr "&Visualizza dettagli"
+
+#: ../include/wx/richmsgdlg.h:30
+msgid "&Hide details"
+msgstr "&Nascondi dettagli"
+
+#: ../include/wx/richtext/richtextbuffer.h:3864
+msgid "&Box"
+msgstr "&Riquadro"
+
+#: ../include/wx/richtext/richtextbuffer.h:5008
+msgid "&Picture"
+msgstr "&Immagine"
+
+#: ../include/wx/richtext/richtextbuffer.h:5958
+msgid "&Cell"
+msgstr "&Cella"
+
+#: ../include/wx/richtext/richtextbuffer.h:6067
+msgid "&Table"
+msgstr "&Tabella"
+
+#: ../include/wx/richtext/richtextimagedlg.h:37
+msgid "Object Properties"
+msgstr "Proprietà oggetto"
+
+#: ../include/wx/richtext/richtextsymboldlg.h:39
+msgid "Symbols"
+msgstr "Simboli"
+
+#: ../include/wx/unix/pipe.h:46
+msgid "Pipe creation failed"
+msgstr "Creazione della pipe fallita"
+
+#: ../include/wx/unix/private/displayx11.h:65
+msgid "Failed to enumerate video modes"
+msgstr "Impossibile enumerare le modalità video"
+
+#: ../include/wx/unix/private/displayx11.h:89
+msgid "Failed to change video mode"
+msgstr "Impossibile cambiare la modalità video"
+
+#: ../include/wx/unix/private/fswatcher_kqueue.h:57
+#, c-format
+msgid "Unable to open path '%s'"
+msgstr "Impossibile aprire percorso '%s'"
+
+#: ../include/wx/unix/private/fswatcher_kqueue.h:74
+#, c-format
+msgid "Unable to close path '%s'"
+msgstr "Impossibile chiudere percorso '%s'"
+
+#: ../include/wx/xtiprop.h:175
+msgid "SetProperty called w/o valid setter"
+msgstr "SetProperty chiamata senza una valido setter"
+
+#: ../include/wx/xtiprop.h:184
+msgid "GetProperty called w/o valid getter"
+msgstr "GetProperty chiamato senza un valido getter"
+
+#: ../include/wx/xtiprop.h:193
+msgid "AddToPropertyCollection called w/o valid adder"
+msgstr "AddToPropertyCollection chiamata senza un valido adder"
+
+#: ../include/wx/xtiprop.h:202
+msgid "GetPropertyCollection called w/o valid collection getter"
+msgstr "GetPropertyCollection chiamato senza un valido collection getter"
+
+#: ../include/wx/xtiprop.h:255
+msgid "AddToPropertyCollection called on a generic accessor"
+msgstr "AddToPropertyCollection chiamata su generic accessor"
+
+#: ../include/wx/xtiprop.h:262
+msgid "GetPropertyCollection called on a generic accessor"
+msgstr "GetPropertyCollection chiamato su generic accessor"
+
+#: ../src/aui/tabmdi.cpp:106 ../src/generic/mdig.cpp:94
+msgid "Cl&ose"
+msgstr "C&hiudi"
+
+#: ../src/aui/tabmdi.cpp:107 ../src/generic/mdig.cpp:95
+msgid "Close All"
+msgstr "Chiudi &tutto"
+
+#: ../src/aui/tabmdi.cpp:109 ../src/generic/mdig.cpp:97 ../src/msw/mdi.cpp:175
+#: ../src/qt/mdi.cpp:258
+msgid "&Next"
+msgstr "&Avanti"
+
+#: ../src/aui/tabmdi.cpp:110 ../src/generic/mdig.cpp:98 ../src/msw/mdi.cpp:176
+#: ../src/qt/mdi.cpp:259
+msgid "&Previous"
+msgstr "&Precedente"
+
+#: ../src/aui/tabmdi.cpp:332 ../src/aui/tabmdi.cpp:348
+#: ../src/aui/tabmdi.cpp:350 ../src/generic/mdig.cpp:291
+#: ../src/generic/mdig.cpp:307 ../src/generic/mdig.cpp:311
+#: ../src/msw/mdi.cpp:337 ../src/qt/mdi.cpp:462
+msgid "&Window"
+msgstr "&Finestra"
+
+#: ../src/common/accelcmn.cpp:47
+msgctxt "keyboard key"
+msgid "Delete"
+msgstr "Elimina"
+
+#: ../src/common/accelcmn.cpp:48
+msgctxt "keyboard key"
+msgid "Del"
+msgstr "Canc"
+
+#: ../src/common/accelcmn.cpp:49
+msgctxt "keyboard key"
+msgid "Back"
+msgstr "Indietro"
+
+#: ../src/common/accelcmn.cpp:49
+msgctxt "keyboard key"
+msgid "Backspace"
+msgstr "Backspace"
+
+#: ../src/common/accelcmn.cpp:50
+msgctxt "keyboard key"
+msgid "Insert"
+msgstr "Inserisci"
+
+#: ../src/common/accelcmn.cpp:51
+msgctxt "keyboard key"
+msgid "Ins"
+msgstr "Aggiungi"
+
+#: ../src/common/accelcmn.cpp:52
+msgctxt "keyboard key"
+msgid "Enter"
+msgstr "Invio"
+
+#: ../src/common/accelcmn.cpp:53
+msgctxt "keyboard key"
+msgid "Return"
+msgstr "Invio"
+
+#: ../src/common/accelcmn.cpp:54
+msgctxt "keyboard key"
+msgid "PageUp"
+msgstr "PaginaSu"
+
+#: ../src/common/accelcmn.cpp:54
+msgctxt "keyboard key"
+msgid "Page Up"
+msgstr "Pagina su"
+
+#: ../src/common/accelcmn.cpp:55
+msgctxt "keyboard key"
+msgid "PageDown"
+msgstr "PaginaGiù"
+
+#: ../src/common/accelcmn.cpp:55
+msgctxt "keyboard key"
+msgid "Page Down"
+msgstr "Pagina giù"
+
+#: ../src/common/accelcmn.cpp:56
+msgctxt "keyboard key"
+msgid "PgUp"
+msgstr "PgSu"
+
+#: ../src/common/accelcmn.cpp:57
+msgctxt "keyboard key"
+msgid "PgDn"
+msgstr "PgGiù"
+
+#: ../src/common/accelcmn.cpp:58
+msgctxt "keyboard key"
+msgid "Left"
+msgstr "Sinistra"
+
+#: ../src/common/accelcmn.cpp:59
+msgctxt "keyboard key"
+msgid "Right"
+msgstr "Destra"
+
+#: ../src/common/accelcmn.cpp:60
+msgctxt "keyboard key"
+msgid "Up"
+msgstr "Su"
+
+#: ../src/common/accelcmn.cpp:61
+msgctxt "keyboard key"
+msgid "Down"
+msgstr "Giù"
+
+#: ../src/common/accelcmn.cpp:62
+msgctxt "keyboard key"
+msgid "Home"
+msgstr "Home"
+
+#: ../src/common/accelcmn.cpp:63
+msgctxt "keyboard key"
+msgid "End"
+msgstr "Fine"
+
+#: ../src/common/accelcmn.cpp:64
+msgctxt "keyboard key"
+msgid "Space"
+msgstr "Spazio"
+
+#: ../src/common/accelcmn.cpp:65
+msgctxt "keyboard key"
+msgid "Tab"
+msgstr "Tabulazione"
+
+#: ../src/common/accelcmn.cpp:66
+msgctxt "keyboard key"
+msgid "Esc"
+msgstr "Esc"
+
+#: ../src/common/accelcmn.cpp:67
+msgctxt "keyboard key"
+msgid "Escape"
+msgstr "Esci"
+
+#: ../src/common/accelcmn.cpp:68
+msgctxt "keyboard key"
+msgid "Cancel"
+msgstr "Annulla"
+
+#: ../src/common/accelcmn.cpp:69
+msgctxt "keyboard key"
+msgid "Clear"
+msgstr "Azzera"
+
+#: ../src/common/accelcmn.cpp:70
+msgctxt "keyboard key"
+msgid "Menu"
+msgstr "Menu"
+
+#: ../src/common/accelcmn.cpp:71
+msgctxt "keyboard key"
+msgid "Pause"
+msgstr "Pausa"
+
+#: ../src/common/accelcmn.cpp:72
+msgctxt "keyboard key"
+msgid "Capital"
+msgstr "Miauscole"
+
+#: ../src/common/accelcmn.cpp:73
+msgctxt "keyboard key"
+msgid "Select"
+msgstr "Seleziona"
+
+#: ../src/common/accelcmn.cpp:74
+msgctxt "keyboard key"
+msgid "Print"
+msgstr "Stampa"
+
+#: ../src/common/accelcmn.cpp:75
+msgctxt "keyboard key"
+msgid "Execute"
+msgstr "Esegui"
+
+#: ../src/common/accelcmn.cpp:76
+msgctxt "keyboard key"
+msgid "Snapshot"
+msgstr "Cattura"
+
+#: ../src/common/accelcmn.cpp:77
+msgctxt "keyboard key"
+msgid "Help"
+msgstr "Aiuto"
+
+#: ../src/common/accelcmn.cpp:78
+msgctxt "keyboard key"
+msgid "Add"
+msgstr "Aggiungi"
+
+#: ../src/common/accelcmn.cpp:79
+msgctxt "keyboard key"
+msgid "Separator"
+msgstr "Separatore"
+
+#: ../src/common/accelcmn.cpp:80
+msgctxt "keyboard key"
+msgid "Subtract"
+msgstr "Sottrai"
+
+#: ../src/common/accelcmn.cpp:81
+msgctxt "keyboard key"
+msgid "Decimal"
+msgstr "Decimale"
+
+#: ../src/common/accelcmn.cpp:82
+msgctxt "keyboard key"
+msgid "Multiply"
+msgstr "Moltiplica"
+
+#: ../src/common/accelcmn.cpp:83
+msgctxt "keyboard key"
+msgid "Divide"
+msgstr "Dividi"
+
+#: ../src/common/accelcmn.cpp:84
+msgctxt "keyboard key"
+msgid "Num_lock"
+msgstr "Blocco_Num"
+
+#: ../src/common/accelcmn.cpp:84
+msgctxt "keyboard key"
+msgid "Num Lock"
+msgstr "Num Blocco"
+
+#: ../src/common/accelcmn.cpp:85
+msgctxt "keyboard key"
+msgid "Scroll_lock"
+msgstr "Blocco_scorrimento"
+
+#: ../src/common/accelcmn.cpp:85
+msgctxt "keyboard key"
+msgid "Scroll Lock"
+msgstr "Blocco scorrimento"
+
+#: ../src/common/accelcmn.cpp:86
+msgctxt "keyboard key"
+msgid "KP_Space"
+msgstr "KP_Spazio"
+
+#: ../src/common/accelcmn.cpp:86
+msgctxt "keyboard key"
+msgid "Num Space"
+msgstr "Num Spazio"
+
+#: ../src/common/accelcmn.cpp:87
+msgctxt "keyboard key"
+msgid "KP_Tab"
+msgstr "KP_Tab"
+
+#: ../src/common/accelcmn.cpp:87
+msgctxt "keyboard key"
+msgid "Num Tab"
+msgstr "Num Tab"
+
+#: ../src/common/accelcmn.cpp:88
+msgctxt "keyboard key"
+msgid "KP_Enter"
+msgstr "KP_Invio"
+
+#: ../src/common/accelcmn.cpp:88
+msgctxt "keyboard key"
+msgid "Num Enter"
+msgstr "Num Invio"
+
+#: ../src/common/accelcmn.cpp:89
+msgctxt "keyboard key"
+msgid "KP_Home"
+msgstr "KP_Home"
+
+#: ../src/common/accelcmn.cpp:89
+msgctxt "keyboard key"
+msgid "Num Home"
+msgstr "Num Home"
+
+#: ../src/common/accelcmn.cpp:90
+msgctxt "keyboard key"
+msgid "KP_Left"
+msgstr "KP_Sinistra"
+
+#: ../src/common/accelcmn.cpp:90
+msgctxt "keyboard key"
+msgid "Num left"
+msgstr "Num Sinistra"
+
+#: ../src/common/accelcmn.cpp:91
+msgctxt "keyboard key"
+msgid "KP_Up"
+msgstr "KP_Su"
+
+#: ../src/common/accelcmn.cpp:91
+msgctxt "keyboard key"
+msgid "Num Up"
+msgstr "Num Su"
+
+#: ../src/common/accelcmn.cpp:92
+msgctxt "keyboard key"
+msgid "KP_Right"
+msgstr "K_Destra"
+
+#: ../src/common/accelcmn.cpp:92
+msgctxt "keyboard key"
+msgid "Num Right"
+msgstr "Num Destra"
+
+#: ../src/common/accelcmn.cpp:93
+msgctxt "keyboard key"
+msgid "KP_Down"
+msgstr "KP_Giù"
+
+#: ../src/common/accelcmn.cpp:93
+msgctxt "keyboard key"
+msgid "Num Down"
+msgstr "Giù"
+
+#: ../src/common/accelcmn.cpp:94
+msgctxt "keyboard key"
+msgid "KP_PageUp"
+msgstr "KP_PagSu"
+
+#: ../src/common/accelcmn.cpp:94
+msgctxt "keyboard key"
+msgid "Num Page Up"
+msgstr "Num PagSu"
+
+#: ../src/common/accelcmn.cpp:95
+msgctxt "keyboard key"
+msgid "KP_PageDown"
+msgstr "KP_PagGiù"
+
+#: ../src/common/accelcmn.cpp:95
+msgctxt "keyboard key"
+msgid "Num Page Down"
+msgstr "Num PagGiù"
+
+#: ../src/common/accelcmn.cpp:96
+msgctxt "keyboard key"
+msgid "KP_Prior"
+msgstr "KP_Precedente"
+
+#: ../src/common/accelcmn.cpp:97
+msgctxt "keyboard key"
+msgid "KP_Next"
+msgstr "KP_Successivo"
+
+#: ../src/common/accelcmn.cpp:98
+msgctxt "keyboard key"
+msgid "KP_End"
+msgstr "KP_Fine"
+
+#: ../src/common/accelcmn.cpp:98
+msgctxt "keyboard key"
+msgid "Num End"
+msgstr "Num Fine"
+
+#: ../src/common/accelcmn.cpp:99
+msgctxt "keyboard key"
+msgid "KP_Begin"
+msgstr "KP_Inizio"
+
+#: ../src/common/accelcmn.cpp:99
+msgctxt "keyboard key"
+msgid "Num Begin"
+msgstr "Num Inizio"
+
+#: ../src/common/accelcmn.cpp:100
+msgctxt "keyboard key"
+msgid "KP_Insert"
+msgstr "KP_Inserisci"
+
+#: ../src/common/accelcmn.cpp:100
+msgctxt "keyboard key"
+msgid "Num Insert"
+msgstr "Num Inserisci"
+
+#: ../src/common/accelcmn.cpp:101
+msgctxt "keyboard key"
+msgid "KP_Delete"
+msgstr "KP_Elimina"
+
+#: ../src/common/accelcmn.cpp:101
+msgctxt "keyboard key"
+msgid "Num Delete"
+msgstr "Cancella"
+
+#: ../src/common/accelcmn.cpp:102
+msgctxt "keyboard key"
+msgid "KP_Equal"
+msgstr "KP_Uguale"
+
+#: ../src/common/accelcmn.cpp:102
+msgctxt "keyboard key"
+msgid "Num ="
+msgstr "Num ="
+
+#: ../src/common/accelcmn.cpp:103
+msgctxt "keyboard key"
+msgid "KP_Multiply"
+msgstr "KP_Moltiplica"
+
+#: ../src/common/accelcmn.cpp:103
+msgctxt "keyboard key"
+msgid "Num *"
+msgstr "Num *"
+
+#: ../src/common/accelcmn.cpp:104
+msgctxt "keyboard key"
+msgid "KP_Add"
+msgstr "KP_Aggiungi"
+
+#: ../src/common/accelcmn.cpp:104
+msgctxt "keyboard key"
+msgid "Num +"
+msgstr "Num +"
+
+#: ../src/common/accelcmn.cpp:105
+msgctxt "keyboard key"
+msgid "KP_Separator"
+msgstr "KP_Separatore"
+
+#: ../src/common/accelcmn.cpp:105
+msgctxt "keyboard key"
+msgid "Num ,"
+msgstr "Num ,"
+
+#: ../src/common/accelcmn.cpp:106
+msgctxt "keyboard key"
+msgid "KP_Subtract"
+msgstr "KP_Sottrai"
+
+#: ../src/common/accelcmn.cpp:106
+msgctxt "keyboard key"
+msgid "Num -"
+msgstr "Num -"
+
+#: ../src/common/accelcmn.cpp:107
+msgctxt "keyboard key"
+msgid "KP_Decimal"
+msgstr "KP_decimale"
+
+#: ../src/common/accelcmn.cpp:107
+msgctxt "keyboard key"
+msgid "Num ."
+msgstr "Num ."
+
+#: ../src/common/accelcmn.cpp:108
+msgctxt "keyboard key"
+msgid "KP_Divide"
+msgstr "KP_Dividi"
+
+#: ../src/common/accelcmn.cpp:108
+msgctxt "keyboard key"
+msgid "Num /"
+msgstr "Num /"
+
+#: ../src/common/accelcmn.cpp:109
+msgctxt "keyboard key"
+msgid "Windows_Left"
+msgstr "Windows_Sinistra"
+
+#: ../src/common/accelcmn.cpp:110
+msgctxt "keyboard key"
+msgid "Windows_Right"
+msgstr "Windows_Destra"
+
+#: ../src/common/accelcmn.cpp:111
+msgctxt "keyboard key"
+msgid "Windows_Menu"
+msgstr "Windows_Menu"
+
+#: ../src/common/accelcmn.cpp:112
+msgctxt "keyboard key"
+msgid "Command"
+msgstr "Comando"
+
+#: ../src/common/accelcmn.cpp:186 ../src/common/accelcmn.cpp:359
+msgctxt "keyboard key"
+msgid "Ctrl"
+msgstr "Ctrl"
+
+#: ../src/common/accelcmn.cpp:188 ../src/common/accelcmn.cpp:363
+msgctxt "keyboard key"
+msgid "Alt"
+msgstr "Alt"
+
+#: ../src/common/accelcmn.cpp:190 ../src/common/accelcmn.cpp:361
+msgctxt "keyboard key"
+msgid "Shift"
+msgstr "Maiusc"
+
+#: ../src/common/accelcmn.cpp:196
+msgctxt "keyboard key"
+msgid "num "
+msgstr "num "
+
+#: ../src/common/accelcmn.cpp:260 ../src/common/accelcmn.cpp:382
+msgctxt "keyboard key"
+msgid "F"
+msgstr "F"
+
+#: ../src/common/accelcmn.cpp:277 ../src/common/accelcmn.cpp:385
+msgctxt "keyboard key"
+msgid "KP_F"
+msgstr "KP_F"
+
+#: ../src/common/accelcmn.cpp:280 ../src/common/accelcmn.cpp:388
+msgctxt "keyboard key"
+msgid "KP_"
+msgstr "KP_"
+
+#: ../src/common/accelcmn.cpp:283 ../src/common/accelcmn.cpp:391
+msgctxt "keyboard key"
+msgid "SPECIAL"
+msgstr "SPECIALE"
+
+#: ../src/common/accelcmn.cpp:373
+#, fuzzy
+msgid "Ctrl"
+msgstr "Ctrl"
+
+#: ../src/common/appbase.cpp:786
+msgid "show this help message"
+msgstr "visualizza questo messaggio di aiuto"
+
+#: ../src/common/appbase.cpp:796
+msgid "generate verbose log messages"
+msgstr "genera messaggi registro eventi dettagliati"
+
+#: ../src/common/appcmn.cpp:256
+msgid "specify the theme to use"
+msgstr "specifica il tema da utilizzare"
+
+#: ../src/common/appcmn.cpp:270
+msgid "specify display mode to use (e.g. 640x480-16)"
+msgstr "specifica la modalità video da utilizzare (es. 640x480-16)"
+
+#: ../src/common/appcmn.cpp:292
+#, c-format
+msgid "Unsupported theme '%s'."
+msgstr "Tema '%s' non supportato."
+
+#: ../src/common/appcmn.cpp:309
+#, c-format
+msgid "Invalid display mode specification '%s'."
+msgstr "Specifica della modalità video '%s' non valida."
+
+#: ../src/common/cmdline.cpp:875
+#, c-format
+msgid "Option '%s' can't be negated"
+msgstr "L'opzione '%s' non può essere negata"
+
+#: ../src/common/cmdline.cpp:889
+#, c-format
+msgid "Unknown long option '%s'"
+msgstr "Opzione lunga '%s' sconosciuta"
+
+#: ../src/common/cmdline.cpp:904 ../src/common/cmdline.cpp:926
+#, c-format
+msgid "Unknown option '%s'"
+msgstr "Opzione '%s' sconosciuta"
+
+#: ../src/common/cmdline.cpp:1004
+#, c-format
+msgid "Unexpected characters following option '%s'."
+msgstr "Caratteri non attesi dopo l'opzione '%s'."
+
+#: ../src/common/cmdline.cpp:1039
+#, c-format
+msgid "Option '%s' requires a value."
+msgstr "L'opzione '%s' richiede un valore."
+
+#: ../src/common/cmdline.cpp:1058
+#, c-format
+msgid "Separator expected after the option '%s'."
+msgstr "Atteso separatore dopo l'opzione '%s'."
+
+#: ../src/common/cmdline.cpp:1088 ../src/common/cmdline.cpp:1106
+#, c-format
+msgid "'%s' is not a correct numeric value for option '%s'."
+msgstr "'%s' non è un valore numerico corretto per l'opzione '%s'."
+
+#: ../src/common/cmdline.cpp:1122
+#, c-format
+msgid "Option '%s': '%s' cannot be converted to a date."
+msgstr "Opzione '%s': impossibile convertire '%s' in una data."
+
+#: ../src/common/cmdline.cpp:1170
+#, c-format
+msgid "Unexpected parameter '%s'"
+msgstr "Parametro '%s' non atteso"
+
+#. TRANSLATORS: Short name and long name for a command line option
+#: ../src/common/cmdline.cpp:1197
+#, c-format
+msgid "%s (or %s)"
+msgstr "%s (o %s)"
+
+#: ../src/common/cmdline.cpp:1208
+#, c-format
+msgid "The value for the option '%s' must be specified."
+msgstr "L'opzione '%s' richiede un parametro."
+
+#: ../src/common/cmdline.cpp:1230
+#, c-format
+msgid "The required parameter '%s' was not specified."
+msgstr "Il parametro '%s' è obbligatorio."
+
+#: ../src/common/cmdline.cpp:1289
+#, c-format
+msgid "Usage: %s"
+msgstr "Utilizzo: %s"
+
+#: ../src/common/cmdline.cpp:1498
+msgid "str"
+msgstr "str"
+
+#: ../src/common/cmdline.cpp:1502
+msgid "num"
+msgstr "num"
+
+#: ../src/common/cmdline.cpp:1506
+msgid "double"
+msgstr "doppio"
+
+#: ../src/common/cmdline.cpp:1510
+msgid "date"
+msgstr "data"
+
+#: ../src/common/cmdproc.cpp:250 ../src/common/cmdproc.cpp:276
+#: ../src/common/cmdproc.cpp:296
+msgid "Unnamed command"
+msgstr "Comando privo di nome"
+
+#: ../src/common/cmdproc.cpp:253
+msgid "&Undo "
+msgstr "&Annulla "
+
+#: ../src/common/cmdproc.cpp:255
+msgid "Can't &Undo "
+msgstr "Impossibile &annullare "
+
+#: ../src/common/cmdproc.cpp:259 ../src/common/stockitem.cpp:208
+#: ../src/msw/textctrl.cpp:2880 ../src/osx/textctrl_osx.cpp:649
+#: ../src/richtext/richtextctrl.cpp:327
+msgid "&Undo"
+msgstr "&Annulla"
+
+#: ../src/common/cmdproc.cpp:277 ../src/common/cmdproc.cpp:297
+msgid "&Redo "
+msgstr "&Ripeti "
+
+#: ../src/common/cmdproc.cpp:281 ../src/common/cmdproc.cpp:288
+#: ../src/common/stockitem.cpp:190 ../src/msw/textctrl.cpp:2881
+#: ../src/osx/textctrl_osx.cpp:650 ../src/richtext/richtextctrl.cpp:328
+msgid "&Redo"
+msgstr "&Ripeti"
+
+#: ../src/common/colourcmn.cpp:41
+#, c-format
+msgid "String To Colour : Incorrect colour specification : %s"
+msgstr "Specifica di colore '%s' non valida"
+
+#: ../src/common/config.cpp:259
+#, c-format
+msgid "Invalid value %ld for a boolean key \"%s\" in config file."
+msgstr ""
+"Valore non valido %ld per la chiave booleana \"%s\" nel file di "
+"configurazione."
+
+#: ../src/common/config.cpp:526
+#, c-format
+msgid ""
+"Environment variables expansion failed: missing '%c' at position %u in '%s'."
+msgstr ""
+"Espansione delle variabili di ambiente fallita: '%c' non trovato alla "
+"posizione %u in '%s'."
+
+#: ../src/common/config.cpp:576 ../src/msw/regconf.cpp:272
+#, c-format
+msgid "'%s' has extra '..', ignored."
+msgstr "'%s' ha troppi '..', ignorati."
+
+#. TRANSLATORS: Checkbox state name
+#: ../src/common/datavcmn.cpp:2166 ../src/generic/datavgen.cpp:1430
+msgid "checked"
+msgstr "verificato"
+
+#. TRANSLATORS: Checkbox state name
+#: ../src/common/datavcmn.cpp:2170 ../src/generic/datavgen.cpp:1432
+msgid "unchecked"
+msgstr "non verificato"
+
+#. TRANSLATORS: Checkbox state name
+#: ../src/common/datavcmn.cpp:2174
+msgid "undetermined"
+msgstr "non determinato"
+
+#: ../src/common/datetimefmt.cpp:1875
+msgid "today"
+msgstr "oggi"
+
+#: ../src/common/datetimefmt.cpp:1876
+msgid "yesterday"
+msgstr "ieri"
+
+#: ../src/common/datetimefmt.cpp:1877
+msgid "tomorrow"
+msgstr "domani"
+
+#: ../src/common/datetimefmt.cpp:2071
+msgid "first"
+msgstr "primo"
+
+#: ../src/common/datetimefmt.cpp:2072
+msgid "second"
+msgstr "due"
+
+#: ../src/common/datetimefmt.cpp:2073
+msgid "third"
+msgstr "tre"
+
+#: ../src/common/datetimefmt.cpp:2074
+msgid "fourth"
+msgstr "quattro"
+
+#: ../src/common/datetimefmt.cpp:2075
+msgid "fifth"
+msgstr "cinque"
+
+#: ../src/common/datetimefmt.cpp:2076
+msgid "sixth"
+msgstr "sei"
+
+#: ../src/common/datetimefmt.cpp:2077
+msgid "seventh"
+msgstr "sette"
+
+#: ../src/common/datetimefmt.cpp:2078
+msgid "eighth"
+msgstr "otto"
+
+#: ../src/common/datetimefmt.cpp:2079
+msgid "ninth"
+msgstr "nove"
+
+#: ../src/common/datetimefmt.cpp:2080
+msgid "tenth"
+msgstr "dieci"
+
+#: ../src/common/datetimefmt.cpp:2081
+msgid "eleventh"
+msgstr "undici"
+
+#: ../src/common/datetimefmt.cpp:2082
+msgid "twelfth"
+msgstr "dodici"
+
+#: ../src/common/datetimefmt.cpp:2083
+msgid "thirteenth"
+msgstr "tredici"
+
+#: ../src/common/datetimefmt.cpp:2084
+msgid "fourteenth"
+msgstr "quattordici"
+
+#: ../src/common/datetimefmt.cpp:2085
+msgid "fifteenth"
+msgstr "quindici"
+
+#: ../src/common/datetimefmt.cpp:2086
+msgid "sixteenth"
+msgstr "sedici"
+
+#: ../src/common/datetimefmt.cpp:2087
+msgid "seventeenth"
+msgstr "diciassette"
+
+#: ../src/common/datetimefmt.cpp:2088
+msgid "eighteenth"
+msgstr "diciotto"
+
+#: ../src/common/datetimefmt.cpp:2089
+msgid "nineteenth"
+msgstr "diciannove"
+
+#: ../src/common/datetimefmt.cpp:2090
+msgid "twentieth"
+msgstr "venti"
+
+#: ../src/common/datetimefmt.cpp:2248
+msgid "noon"
+msgstr "mezzogiorno"
+
+#: ../src/common/datetimefmt.cpp:2249
+msgid "midnight"
+msgstr "mezzanotte"
+
+#: ../src/common/debugrpt.cpp:209
+#, c-format
+msgid "Failed to create directory \"%s\""
+msgstr "Impossibile creare la cartella \"%s\""
+
+#: ../src/common/debugrpt.cpp:210
+msgid "Debug report couldn't be created."
+msgstr "Impossibile creare la segnalazione di errore."
+
+#: ../src/common/debugrpt.cpp:227
+#, c-format
+msgid "Failed to remove debug report file \"%s\""
+msgstr "Impossibile eliminare il file \"%s\" della segnalazione di errore"
+
+#: ../src/common/debugrpt.cpp:239
+#, c-format
+msgid "Failed to clean up debug report directory \"%s\""
+msgstr "Impossibile svuotare la cartella \"%s\" delle segnalazioni di errore"
+
+#: ../src/common/debugrpt.cpp:514
+msgid "process context description"
+msgstr "descrizione del contesto del programma"
+
+#: ../src/common/debugrpt.cpp:538
+msgid "dump of the process state (binary)"
+msgstr "dump dello stato del programma (binario)"
+
+#: ../src/common/debugrpt.cpp:553
+msgid "Debug report generation has failed."
+msgstr "Generazione della segnalazione di errore fallita."
+
+#: ../src/common/debugrpt.cpp:560
+#, c-format
+msgid ""
+"Processing debug report has failed, leaving the files in \"%s\" directory."
+msgstr ""
+"L'elaborazione della segnalazione di errore è fallita, i file sono "
+"memorizzati nella cartella \"%s\"."
+
+#: ../src/common/debugrpt.cpp:573
+msgid "A debug report has been generated. It can be found in"
+msgstr "È stata generato un rapporto di debug nella cartella"
+
+#: ../src/common/debugrpt.cpp:576
+msgid "And includes the following files:\n"
+msgstr "E includi i seguenti file:\n"
+
+#: ../src/common/debugrpt.cpp:586
+msgid ""
+"\n"
+"Please send this report to the program maintainer, thank you!\n"
+msgstr ""
+"\n"
+"Invia questo rapporto al manutentore del programma, grazie!\n"
+
+#: ../src/common/debugrpt.cpp:729
+msgid "Failed to execute curl, please install it in PATH."
+msgstr ""
+"Impossibile eseguire 'curl'.\n"
+"Inseriscilo nel PATH."
+
+#: ../src/common/debugrpt.cpp:742
+#, c-format
+msgid "Failed to upload the debug report (error code %d)."
+msgstr "Impossibile inviare la segnalazione di errore (codice di errore %d)."
+
+#: ../src/common/docview.cpp:366
+msgid "Save As"
+msgstr "Salva come"
+
+#: ../src/common/docview.cpp:457
+msgid "Discard changes and reload the last saved version?"
+msgstr "Vuoi annullare le modifiche e ricaricare l'ultima versione salvata?"
+
+#: ../src/common/docview.cpp:488
+msgid "unnamed"
+msgstr "senzanome"
+
+#: ../src/common/docview.cpp:513
+#, c-format
+msgid "Do you want to save changes to %s?"
+msgstr "Vuoi salvare le modifiche in %s?"
+
+#: ../src/common/docview.cpp:521 ../src/common/docview.cpp:560
+#: ../src/common/stockitem.cpp:195
+msgid "&Save"
+msgstr "&Salva"
+
+#: ../src/common/docview.cpp:522 ../src/common/docview.cpp:560
+msgid "&Discard changes"
+msgstr "&Non salvare le modifiche"
+
+#: ../src/common/docview.cpp:523
+msgid "Do&n't close"
+msgstr "Non chiudere"
+
+#: ../src/common/docview.cpp:553
+#, c-format
+msgid "Do you want to save changes to %s before closing it?"
+msgstr "Vuoi salvare le modifiche a \"%s\" prima di chiuderlo?"
+
+#: ../src/common/docview.cpp:559
+msgid "The document must be closed."
+msgstr "Il documento deve essere chiuso."
+
+#: ../src/common/docview.cpp:571
+#, c-format
+msgid "Saving %s failed, would you like to retry?"
+msgstr "Salvataggio di \"%s\" non riuscito, vuoi riprovare?"
+
+#: ../src/common/docview.cpp:577
+msgid "Retry"
+msgstr "Riprova"
+
+#: ../src/common/docview.cpp:577
+msgid "Discard changes"
+msgstr "Non salvare le modifiche"
+
+#: ../src/common/docview.cpp:679
+#, c-format
+msgid "File \"%s\" could not be opened for writing."
+msgstr "Impossibile aprire il file \"%s\" per la scrittura."
+
+#: ../src/common/docview.cpp:685
+#, c-format
+msgid "Failed to save document to the file \"%s\"."
+msgstr "Impossibile salvare il documento nel file \"%s\"."
+
+#: ../src/common/docview.cpp:702
+#, c-format
+msgid "File \"%s\" could not be opened for reading."
+msgstr "Impossibile aprire il file \"%s\" per la lettura."
+
+#: ../src/common/docview.cpp:714
+#, c-format
+msgid "Failed to read document from the file \"%s\"."
+msgstr "Impossibile leggere il documento dal file \"%s\"."
+
+#: ../src/common/docview.cpp:1236
+#, c-format
+msgid ""
+"The file '%s' doesn't exist and couldn't be opened.\n"
+"It has been removed from the most recently used files list."
+msgstr ""
+"Il file file '%s' non esiste e non può essere aperto.\n"
+"È stato rimosso dall'elenco dei file recentemente usati."
+
+#: ../src/common/docview.cpp:1296
+msgid "Print preview creation failed."
+msgstr "Creazione anteprima di stampa fallita."
+
+#: ../src/common/docview.cpp:1302
+msgid "Print Preview"
+msgstr "Anteprima di stampa"
+
+#: ../src/common/docview.cpp:1517
+#, c-format
+msgid "The format of file '%s' couldn't be determined."
+msgstr "Impossibile determinare il formato del file '%s'."
+
+#: ../src/common/docview.cpp:1643
+#, c-format
+msgid "unnamed%d"
+msgstr "senzanome%d"
+
+#: ../src/common/docview.cpp:1660
+msgid " - "
+msgstr " - "
+
+#: ../src/common/docview.cpp:1791 ../src/common/docview.cpp:1844
+msgid "Open File"
+msgstr "Apri file"
+
+#: ../src/common/docview.cpp:1807
+msgid "File error"
+msgstr "Errore file"
+
+#: ../src/common/docview.cpp:1809
+msgid "Sorry, could not open this file."
+msgstr "Impossibile aprire il file."
+
+#: ../src/common/docview.cpp:1843
+msgid "Sorry, the format for this file is unknown."
+msgstr "Formato del file sconosciuto."
+
+#: ../src/common/docview.cpp:1924
+msgid "Select a document template"
+msgstr "Scegli un modello di documento"
+
+#: ../src/common/docview.cpp:1925
+msgid "Templates"
+msgstr "Modelli"
+
+#: ../src/common/docview.cpp:1998
+msgid "Select a document view"
+msgstr "Scegli una visualizzazione del documento"
+
+#: ../src/common/docview.cpp:1999
+msgid "Views"
+msgstr "Visualizzazioni"
+
+#: ../src/common/dynlib.cpp:81
+#, c-format
+msgid "Failed to load shared library '%s'"
+msgstr "Impossibile caricare la libreria dinamica '%s'"
+
+#: ../src/common/dynlib.cpp:105
+#, c-format
+msgid "Couldn't find symbol '%s' in a dynamic library"
+msgstr "Impossibile trovare il simbolo '%s' nella libreria dinamica"
+
+#: ../src/common/ffile.cpp:56 ../src/common/file.cpp:215
+#, c-format
+msgid "can't open file '%s'"
+msgstr "impossibile aprire il file '%s'"
+
+#: ../src/common/ffile.cpp:72
+#, c-format
+msgid "can't close file '%s'"
+msgstr "impossibile chiudere il file '%s'"
+
+#: ../src/common/ffile.cpp:106 ../src/common/ffile.cpp:131
+#, c-format
+msgid "Read error on file '%s'"
+msgstr "Errore di lettura nel file '%s'"
+
+#: ../src/common/ffile.cpp:148
+#, c-format
+msgid "Write error on file '%s'"
+msgstr "Errore di scrittura nel file '%s'"
+
+#: ../src/common/ffile.cpp:182
+#, c-format
+msgid "failed to flush the file '%s'"
+msgstr "impossibile forzare la scrittura su disco del file '%s'"
+
+#: ../src/common/ffile.cpp:222
+#, c-format
+msgid "Seek error on file '%s' (large files not supported by stdio)"
+msgstr ""
+"Errore durante la ricerca nel file '%s' (stdio non supporta file di queste "
+"dimensioni))"
+
+#: ../src/common/ffile.cpp:232
+#, c-format
+msgid "Seek error on file '%s'"
+msgstr "Errore durante la ricerca nel file '%s'"
+
+#: ../src/common/ffile.cpp:248
+#, c-format
+msgid "Can't find current position in file '%s'"
+msgstr "Impossibile determinare la posizione attuale del file '%s'"
+
+#: ../src/common/ffile.cpp:349 ../src/common/file.cpp:569
+msgid "Failed to set temporary file permissions"
+msgstr "Impossibile impostare i permessi del file temporaneo"
+
+#: ../src/common/ffile.cpp:371
+#, c-format
+msgid "can't remove file '%s'"
+msgstr "impossibile eliminare il file '%s'"
+
+#: ../src/common/ffile.cpp:376 ../src/common/file.cpp:591
+#, c-format
+msgid "can't commit changes to file '%s'"
+msgstr "impossibile applicare i cambiamenti al file '%s'"
+
+#: ../src/common/ffile.cpp:388 ../src/common/file.cpp:603
+#, c-format
+msgid "can't remove temporary file '%s'"
+msgstr "impossibile eliminare il file temporaneo '%s'"
+
+#: ../src/common/file.cpp:162
+#, c-format
+msgid "can't create file '%s'"
+msgstr "impossibile creare il file '%s'"
+
+#: ../src/common/file.cpp:229
+#, c-format
+msgid "can't close file descriptor %d"
+msgstr "impossibile chiudere il descrittore di file %d"
+
+#: ../src/common/file.cpp:332
+#, c-format
+msgid "can't read from file descriptor %d"
+msgstr "impossibile leggere dal descrittore di file %d"
+
+#: ../src/common/file.cpp:351
+#, c-format
+msgid "can't write to file descriptor %d"
+msgstr "impossibile scrivere sul descrittore di file %d"
+
+#: ../src/common/file.cpp:390
+#, c-format
+msgid "can't flush file descriptor %d"
+msgstr "impossibile forzare la scrittura su disco del descrittore di file %d"
+
+#: ../src/common/file.cpp:432
+#, c-format
+msgid "can't seek on file descriptor %d"
+msgstr "impossibile eseguire una seek sul descrittore di file %d"
+
+#: ../src/common/file.cpp:446
+#, c-format
+msgid "can't get seek position on file descriptor %d"
+msgstr ""
+"impossibile determinare la posizione attuale del descrittore di file %d"
+
+#: ../src/common/file.cpp:475
+#, c-format
+msgid "can't find length of file on file descriptor %d"
+msgstr "impossibile determinare la dimensione del file del descritore %d"
+
+#: ../src/common/file.cpp:505
+#, c-format
+msgid "can't determine if the end of file is reached on descriptor %d"
+msgstr ""
+"impossibile determinare se il descrittore di file %d ha raggiunto la fine "
+"del file"
+
+#: ../src/common/fileconf.cpp:352
+#, c-format
+msgid ""
+" and additionally, the existing configuration file was renamed to \"%s\" and "
+"couldn't be renamed back, please rename it to its original path \"%s\""
+msgstr ""
+
+#: ../src/common/fileconf.cpp:389
+#, fuzzy
+msgid " due to the following error:\n"
+msgstr "E includi i seguenti file:\n"
+
+#: ../src/common/fileconf.cpp:412
+#, fuzzy
+msgid "failed to rename the existing file"
+msgstr "Impossibile leggere il file di testo \"%s\"."
+
+#: ../src/common/fileconf.cpp:421
+#, fuzzy
+msgid "failed to create the new file directory"
+msgstr "Impossibile determinare la cartella di lavoro"
+
+#: ../src/common/fileconf.cpp:428
+#, fuzzy
+msgid "failed to move the file to the new location"
+msgstr ""
+"Impossibile impostare la visualizzazione web al livello di emulazione moderno"
+
+#: ../src/common/fileconf.cpp:462
+#, c-format
+msgid "can't open global configuration file '%s'."
+msgstr "impossibile aprire il file globale di configurazione '%s'."
+
+#: ../src/common/fileconf.cpp:478
+#, c-format
+msgid "can't open user configuration file '%s'."
+msgstr "impossibile aprire il file di configurazione utente '%s'."
+
+#: ../src/common/fileconf.cpp:483
+#, c-format
+msgid "Changes won't be saved to avoid overwriting the existing file \"%s\""
+msgstr ""
+"I cambiamenti non verranno salvati per evitare la sovrascrittura del file "
+"\"%s\""
+
+#: ../src/common/fileconf.cpp:583
+msgid "Error reading config options."
+msgstr "Errore durante la lettura del file di configurazione."
+
+#: ../src/common/fileconf.cpp:593
+msgid "Failed to read config options."
+msgstr "Impossibile leggere opzioni configurazione."
+
+#: ../src/common/fileconf.cpp:700
+#, c-format
+msgid "file '%s': unexpected character %c at line %zu."
+msgstr "file '%s': carattere %c non atteso alla linea %zu."
+
+#: ../src/common/fileconf.cpp:736
+#, c-format
+msgid "file '%s', line %zu: '%s' ignored after group header."
+msgstr "file '%s', linea %zu: ignorato '%s' dopo intestazione gruppo."
+
+#: ../src/common/fileconf.cpp:765
+#, c-format
+msgid "file '%s', line %zu: '=' expected."
+msgstr "file '%s', linea %zu: atteso '='."
+
+#: ../src/common/fileconf.cpp:778
+#, c-format
+msgid "file '%s', line %zu: value for immutable key '%s' ignored."
+msgstr ""
+"file '%s', linea %zu: valore per la chiave non configurabile '%s' ignorato."
+
+#: ../src/common/fileconf.cpp:788
+#, c-format
+msgid "file '%s', line %zu: key '%s' was first found at line %d."
+msgstr "file '%s', linea %zu la chiave '%s' è già stata trovata alla linea %d."
+
+#: ../src/common/fileconf.cpp:1091
+#, c-format
+msgid "Config entry name cannot start with '%c'."
+msgstr "Il nome di una voce di configurazione non può iniziare con '%c'."
+
+#: ../src/common/fileconf.cpp:1146
+#, fuzzy
+msgid "Failed to create configuration file directory."
+msgstr "Impossibile creare l'oggetto di configurazione della font."
+
+#: ../src/common/fileconf.cpp:1158
+msgid "can't open user configuration file."
+msgstr "impossibile aprire il file di configurazione utente."
+
+#: ../src/common/fileconf.cpp:1172
+msgid "can't write user configuration file."
+msgstr "impossibile scrivere il file di configurazione utente."
+
+#: ../src/common/fileconf.cpp:1178
+msgid "Failed to update user configuration file."
+msgstr "Impossibile aggiornare il file di configurazione utente."
+
+#: ../src/common/fileconf.cpp:1201
+msgid "Error saving user configuration data."
+msgstr "Errore durante il salvataggio del file di configurazione."
+
+#: ../src/common/fileconf.cpp:1313
+#, c-format
+msgid "can't delete user configuration file '%s'"
+msgstr "impossibile eliminare il file di configurazione utente '%s'"
+
+#: ../src/common/fileconf.cpp:2007
+#, c-format
+msgid "entry '%s' appears more than once in group '%s'"
+msgstr "la voce '%s' è presente più volte nel gruppo '%s'"
+
+#: ../src/common/fileconf.cpp:2021
+#, c-format
+msgid "attempt to change immutable key '%s' ignored."
+msgstr "tentativo di modificare la chiave non modificabile '%s' ignorato."
+
+#: ../src/common/fileconf.cpp:2118
+#, c-format
+msgid "trailing backslash ignored in '%s'"
+msgstr "barra retroversa finale ignorata in '%s'"
+
+#: ../src/common/fileconf.cpp:2153
+#, c-format
+msgid "unexpected \" at position %d in '%s'."
+msgstr "\" non atteso alla posizione %d in '%s'."
+
+#: ../src/common/filefn.cpp:474
+#, c-format
+msgid "Failed to copy the file '%s' to '%s'"
+msgstr "Impossibile copiare copiare il file '%s' in '%s'"
+
+#: ../src/common/filefn.cpp:487
+#, c-format
+msgid "Impossible to get permissions for file '%s'"
+msgstr "Impossibile determinare i permessi per il file '%s'"
+
+#: ../src/common/filefn.cpp:501
+#, c-format
+msgid "Impossible to overwrite the file '%s'"
+msgstr "Impossibile sovrascrivere il file '%s'"
+
+#: ../src/common/filefn.cpp:508
+#, c-format
+msgid "Error copying the file '%s' to '%s'."
+msgstr "Impossibile copiare copiare il file '%s' in '%s'."
+
+#: ../src/common/filefn.cpp:556
+#, c-format
+msgid "Impossible to set permissions for the file '%s'"
+msgstr "Impossibile impostare i permessi per il file '%s'"
+
+#: ../src/common/filefn.cpp:606
+#, c-format
+msgid ""
+"Failed to rename the file '%s' to '%s' because the destination file already "
+"exists."
+msgstr ""
+"Impossibile rinominare il file '%s' in '%s' perché la destinazione esiste "
+"già."
+
+#: ../src/common/filefn.cpp:623
+#, c-format
+msgid "File '%s' couldn't be renamed '%s'"
+msgstr "Il file '%s' non può essere rinominato '%s'"
+
+#: ../src/common/filefn.cpp:639
+#, c-format
+msgid "File '%s' couldn't be removed"
+msgstr "Il file '%s' non può essere rimosso"
+
+#: ../src/common/filefn.cpp:666
+#, c-format
+msgid "Directory '%s' couldn't be created"
+msgstr "Impossibile creare la cartella '%s'"
+
+#: ../src/common/filefn.cpp:680
+#, c-format
+msgid "Directory '%s' couldn't be deleted"
+msgstr "La cartella '%s' non può essere eliminata"
+
+#: ../src/common/filefn.cpp:714
+#, c-format
+msgid "Cannot enumerate files '%s'"
+msgstr "Impossibile elencare i file '%s'"
+
+#: ../src/common/filefn.cpp:798
+msgid "Failed to get the working directory"
+msgstr "Impossibile determinare la cartella di lavoro"
+
+#: ../src/common/filefn.cpp:843
+msgid "Could not set current working directory"
+msgstr "Impossibile impostare la cartella di lavoro"
+
+#: ../src/common/filefn.cpp:974
+#, c-format
+msgid "Files (%s)"
+msgstr "File (%s)"
+
+#: ../src/common/filename.cpp:182
+#, c-format
+msgid "Failed to open '%s' for reading"
+msgstr "Impossibile aprire '%s' in lettura"
+
+#: ../src/common/filename.cpp:187
+#, c-format
+msgid "Failed to open '%s' for writing"
+msgstr "Impossibile aprire '%s' in scrittura"
+
+#: ../src/common/filename.cpp:199
+msgid "Failed to close file handle"
+msgstr "Impossibile chiudere il file"
+
+#: ../src/common/filename.cpp:1046
+msgid "Failed to create a temporary file name"
+msgstr "Impossibile creare il nome per il file temporaneo"
+
+#: ../src/common/filename.cpp:1081
+msgid "Failed to open temporary file."
+msgstr "Impossibile aprire un file temporaneo."
+
+#: ../src/common/filename.cpp:2862
+#, c-format
+msgid "Failed to modify file times for '%s'"
+msgstr "Impossibile modificare le date del file '%s'"
+
+#: ../src/common/filename.cpp:2877
+#, c-format
+msgid "Failed to touch the file '%s'"
+msgstr "Impossibile eseguire 'touch' sul file '%s'"
+
+#: ../src/common/filename.cpp:2958
+#, c-format
+msgid "Failed to retrieve file times for '%s'"
+msgstr "Impossibile ottenere le date del file '%s'"
+
+#: ../src/common/filepickercmn.cpp:39 ../src/common/filepickercmn.cpp:40
+msgid "Browse"
+msgstr "Sfoglia"
+
+#: ../src/common/fldlgcmn.cpp:792 ../src/generic/filectrlg.cpp:1185
+#, c-format
+msgid "All files (%s)|%s"
+msgstr "Tutti i file (%s)|%s"
+
+#. TRANSLATORS: %s are a file extension used to build a file wildcard string
+#: ../src/common/fldlgcmn.cpp:810
+#, c-format
+msgid "%s files (%s)|%s"
+msgstr "%s file (%s)|%s"
+
+#: ../src/common/fldlgcmn.cpp:1072
+#, c-format
+msgid "Load %s file"
+msgstr "Carica file %s"
+
+#: ../src/common/fldlgcmn.cpp:1074
+#, c-format
+msgid "Save %s file"
+msgstr "Salva il file %s"
+
+#: ../src/common/fmapbase.cpp:144
+msgid "Western European (ISO-8859-1)"
+msgstr "Europeo Occidentale (ISO-8859-1)"
+
+#: ../src/common/fmapbase.cpp:145
+msgid "Central European (ISO-8859-2)"
+msgstr "Europeo Centrale (ISO-8859-2)"
+
+#: ../src/common/fmapbase.cpp:146
+msgid "Esperanto (ISO-8859-3)"
+msgstr "Esperanto (ISO-8859-3)"
+
+#: ../src/common/fmapbase.cpp:147
+msgid "Baltic (old) (ISO-8859-4)"
+msgstr "Baltico (vecchio) (ISO-8859-4)"
+
+#: ../src/common/fmapbase.cpp:148
+msgid "Cyrillic (ISO-8859-5)"
+msgstr "Cirillico (ISO-8859-5)"
+
+#: ../src/common/fmapbase.cpp:149
+msgid "Arabic (ISO-8859-6)"
+msgstr "Arabo (ISO-8859-6)"
+
+#: ../src/common/fmapbase.cpp:150
+msgid "Greek (ISO-8859-7)"
+msgstr "Greco (ISO-8859-7)"
+
+#: ../src/common/fmapbase.cpp:151
+msgid "Hebrew (ISO-8859-8)"
+msgstr "Ebraico (ISO-8859-8)"
+
+#: ../src/common/fmapbase.cpp:152
+msgid "Turkish (ISO-8859-9)"
+msgstr "Turco (ISO-8859-9)"
+
+#: ../src/common/fmapbase.cpp:153
+msgid "Nordic (ISO-8859-10)"
+msgstr "Nordico (ISO-8859-10)"
+
+#: ../src/common/fmapbase.cpp:154
+msgid "Thai (ISO-8859-11)"
+msgstr "Thai (ISO-8859-11)"
+
+#: ../src/common/fmapbase.cpp:155
+msgid "Indian (ISO-8859-12)"
+msgstr "Indiano (ISO-8859-12)"
+
+#: ../src/common/fmapbase.cpp:156
+msgid "Baltic (ISO-8859-13)"
+msgstr "Baltico (ISO-8859-13)"
+
+#: ../src/common/fmapbase.cpp:157
+msgid "Celtic (ISO-8859-14)"
+msgstr "Celtico (ISO-8859-14)"
+
+#: ../src/common/fmapbase.cpp:158
+msgid "Western European with Euro (ISO-8859-15)"
+msgstr "Europeo Occidentale con Euro (ISO-8859-15)"
+
+#: ../src/common/fmapbase.cpp:159
+msgid "KOI8-R"
+msgstr "KOI8-R"
+
+#: ../src/common/fmapbase.cpp:160
+msgid "KOI8-U"
+msgstr "KOI8-U"
+
+#: ../src/common/fmapbase.cpp:161
+msgid "Windows/DOS OEM Cyrillic (CP 866)"
+msgstr "Windows/DOS OEM Cirillico (CP 866)"
+
+#: ../src/common/fmapbase.cpp:162
+msgid "Windows Thai (CP 874)"
+msgstr "Windows Tailandese (CP 874)"
+
+#: ../src/common/fmapbase.cpp:163
+msgid "Windows Japanese (CP 932) or Shift-JIS"
+msgstr "Windows Giapponese (CP 932) o Shift-JIS"
+
+#: ../src/common/fmapbase.cpp:164
+msgid "Windows Chinese Simplified (CP 936) or GB-2312"
+msgstr "Windows Cinese Semplificato (CP 936) o GB-2312"
+
+#: ../src/common/fmapbase.cpp:165
+msgid "Windows Korean (CP 949)"
+msgstr "Windows Coreano (CP 949)"
+
+#: ../src/common/fmapbase.cpp:166
+msgid "Windows Chinese Traditional (CP 950) or Big-5"
+msgstr "Windows Cinese tradizionale (CP 950) o Big-5"
+
+#: ../src/common/fmapbase.cpp:167
+msgid "Windows Central European (CP 1250)"
+msgstr "Windows Europeo Centrale (CP 1250)"
+
+#: ../src/common/fmapbase.cpp:168
+msgid "Windows Cyrillic (CP 1251)"
+msgstr "Windows Cirillico (CP 1251)"
+
+#: ../src/common/fmapbase.cpp:169
+msgid "Windows Western European (CP 1252)"
+msgstr "Windows Europeo Occidentale (CP 1252)"
+
+#: ../src/common/fmapbase.cpp:170
+msgid "Windows Greek (CP 1253)"
+msgstr "Windows Greco (CP 1253)"
+
+#: ../src/common/fmapbase.cpp:171
+msgid "Windows Turkish (CP 1254)"
+msgstr "Windows Turco (CP 1254)"
+
+#: ../src/common/fmapbase.cpp:172
+msgid "Windows Hebrew (CP 1255)"
+msgstr "Windows Ebraico (CP 1255)"
+
+#: ../src/common/fmapbase.cpp:173
+msgid "Windows Arabic (CP 1256)"
+msgstr "Windows Arabo (CP 1256)"
+
+#: ../src/common/fmapbase.cpp:174
+msgid "Windows Baltic (CP 1257)"
+msgstr "Windows Baltico (CP 1257)"
+
+#: ../src/common/fmapbase.cpp:175
+msgid "Windows Vietnamese (CP 1258)"
+msgstr "Windows Vietnamita (CP 1258)"
+
+#: ../src/common/fmapbase.cpp:176
+msgid "Windows Johab (CP 1361)"
+msgstr "Windows Johab (CP 1361)"
+
+#: ../src/common/fmapbase.cpp:177
+msgid "Windows/DOS OEM (CP 437)"
+msgstr "Windows/DOS OEM (CP 437)"
+
+#: ../src/common/fmapbase.cpp:178
+msgid "Unicode 7 bit (UTF-7)"
+msgstr "Unicode 7 bit (UTF-7)"
+
+#: ../src/common/fmapbase.cpp:179
+msgid "Unicode 8 bit (UTF-8)"
+msgstr "Unicode 8 bit (UTF-8)"
+
+#: ../src/common/fmapbase.cpp:181 ../src/common/fmapbase.cpp:187
+msgid "Unicode 16 bit (UTF-16)"
+msgstr "Unicode 16 bit (UTF-16)"
+
+#: ../src/common/fmapbase.cpp:182
+msgid "Unicode 16 bit Little Endian (UTF-16LE)"
+msgstr "Unicode 16 bit Little Endian (UTF-16LE)"
+
+#: ../src/common/fmapbase.cpp:183 ../src/common/fmapbase.cpp:189
+msgid "Unicode 32 bit (UTF-32)"
+msgstr "Unicode 32 bit (UTF-32)"
+
+#: ../src/common/fmapbase.cpp:184
+msgid "Unicode 32 bit Little Endian (UTF-32LE)"
+msgstr "Unicode 32 bit Little Endian (UTF-32LE)"
+
+#: ../src/common/fmapbase.cpp:186
+msgid "Unicode 16 bit Big Endian (UTF-16BE)"
+msgstr "Unicode 16 bit Big Endian (UTF-16BE)"
+
+#: ../src/common/fmapbase.cpp:188
+msgid "Unicode 32 bit Big Endian (UTF-32BE)"
+msgstr "Unicode 32 bit Big Endian (UTF-32BE)"
+
+#: ../src/common/fmapbase.cpp:191
+msgid "Extended Unix Codepage for Japanese (EUC-JP)"
+msgstr "Pagina codici Unix estesa per il Giapponese (EUC-JP)"
+
+#: ../src/common/fmapbase.cpp:192
+msgid "US-ASCII"
+msgstr "ASCII"
+
+#: ../src/common/fmapbase.cpp:193
+msgid "ISO-2022-JP"
+msgstr "ISO-2022-JP"
+
+#: ../src/common/fmapbase.cpp:195
+msgid "MacRoman"
+msgstr "Mac Roman"
+
+#: ../src/common/fmapbase.cpp:196
+msgid "MacJapanese"
+msgstr "Mac giapponese"
+
+#: ../src/common/fmapbase.cpp:197
+msgid "MacChineseTrad"
+msgstr "Mac cinese tradizionale"
+
+#: ../src/common/fmapbase.cpp:198
+msgid "MacKorean"
+msgstr "Mac coreano"
+
+#: ../src/common/fmapbase.cpp:199
+msgid "MacArabic"
+msgstr "Numeri arabi Mac"
+
+#: ../src/common/fmapbase.cpp:200
+msgid "MacHebrew"
+msgstr "Mac ebraico"
+
+#: ../src/common/fmapbase.cpp:201
+msgid "MacGreek"
+msgstr "Mac greco"
+
+#: ../src/common/fmapbase.cpp:202
+msgid "MacCyrillic"
+msgstr "Mac cirilico"
+
+#: ../src/common/fmapbase.cpp:203
+msgid "MacDevanagari"
+msgstr "Mac devangari"
+
+#: ../src/common/fmapbase.cpp:204
+msgid "MacGurmukhi"
+msgstr "Mac gurmukhi"
+
+#: ../src/common/fmapbase.cpp:205
+msgid "MacGujarati"
+msgstr "Mac gujarati"
+
+#: ../src/common/fmapbase.cpp:206
+msgid "MacOriya"
+msgstr "Mac oriya"
+
+#: ../src/common/fmapbase.cpp:207
+msgid "MacBengali"
+msgstr "Mac bengali"
+
+#: ../src/common/fmapbase.cpp:208
+msgid "MacTamil"
+msgstr "Mac tamil"
+
+#: ../src/common/fmapbase.cpp:209
+msgid "MacTelugu"
+msgstr "Mac telegu"
+
+#: ../src/common/fmapbase.cpp:210
+msgid "MacKannada"
+msgstr "Mac kannadia"
+
+#: ../src/common/fmapbase.cpp:211
+msgid "MacMalayalam"
+msgstr "Mac malayalam"
+
+#: ../src/common/fmapbase.cpp:212
+msgid "MacSinhalese"
+msgstr "Mac Sinhalese"
+
+#: ../src/common/fmapbase.cpp:213
+msgid "MacBurmese"
+msgstr "Mac burmese"
+
+#: ../src/common/fmapbase.cpp:214
+msgid "MacKhmer"
+msgstr "Mac khmer"
+
+#: ../src/common/fmapbase.cpp:215
+msgid "MacThai"
+msgstr "Mac tailandese"
+
+#: ../src/common/fmapbase.cpp:216
+msgid "MacLaotian"
+msgstr "Mac loatiano"
+
+#: ../src/common/fmapbase.cpp:217
+msgid "MacGeorgian"
+msgstr "Mac georgiano"
+
+#: ../src/common/fmapbase.cpp:218
+msgid "MacArmenian"
+msgstr "Mac armeno"
+
+#: ../src/common/fmapbase.cpp:219
+msgid "MacChineseSimp"
+msgstr "Mac cinese simplificato"
+
+#: ../src/common/fmapbase.cpp:220
+msgid "MacTibetan"
+msgstr "Mac tibetano"
+
+#: ../src/common/fmapbase.cpp:221
+msgid "MacMongolian"
+msgstr "Mac mongolo"
+
+#: ../src/common/fmapbase.cpp:222
+msgid "MacEthiopic"
+msgstr "Mac etiopico"
+
+#: ../src/common/fmapbase.cpp:223
+msgid "MacCentralEurRoman"
+msgstr "Mac Europa centrale roman"
+
+#: ../src/common/fmapbase.cpp:224
+msgid "MacVietnamese"
+msgstr "Mac vietnamita"
+
+#: ../src/common/fmapbase.cpp:225
+msgid "MacExtArabic"
+msgstr "Mac arabico esteso"
+
+#: ../src/common/fmapbase.cpp:226
+msgid "MacSymbol"
+msgstr "Mac Symbol"
+
+#: ../src/common/fmapbase.cpp:227
+msgid "MacDingbats"
+msgstr "Mac Dingbats"
+
+#: ../src/common/fmapbase.cpp:228
+msgid "MacTurkish"
+msgstr "Mac turco"
+
+#: ../src/common/fmapbase.cpp:229
+msgid "MacCroatian"
+msgstr "Mac croato"
+
+#: ../src/common/fmapbase.cpp:230
+msgid "MacIcelandic"
+msgstr "Ma islandese"
+
+#: ../src/common/fmapbase.cpp:231
+msgid "MacRomanian"
+msgstr "Mac rumeno"
+
+#: ../src/common/fmapbase.cpp:232
+msgid "MacCeltic"
+msgstr "Mac celtico"
+
+#: ../src/common/fmapbase.cpp:233
+msgid "MacGaelic"
+msgstr "Mac gaelico"
+
+#: ../src/common/fmapbase.cpp:234
+msgid "MacKeyboardGlyphs"
+msgstr "Mac tastiera glyphs"
+
+#: ../src/common/fmapbase.cpp:791
+msgid "Default encoding"
+msgstr "Codifca predefinita"
+
+#: ../src/common/fmapbase.cpp:805
+#, c-format
+msgid "Unknown encoding (%d)"
+msgstr "Codifica sconosciuta (%d)"
+
+#: ../src/common/fmapbase.cpp:815 ../src/richtext/richtextstyles.cpp:776
+msgid "default"
+msgstr "predefinito"
+
+#: ../src/common/fmapbase.cpp:829
+#, c-format
+msgid "unknown-%d"
+msgstr "sconosciuto-%d"
+
+#: ../src/common/fontcmn.cpp:924 ../src/common/fontcmn.cpp:1130
+msgid "underlined"
+msgstr "sottolineato"
+
+#: ../src/common/fontcmn.cpp:929
+msgid " strikethrough"
+msgstr " barrato"
+
+#: ../src/common/fontcmn.cpp:942
+msgid " thin"
+msgstr " sottile"
+
+#: ../src/common/fontcmn.cpp:946
+msgid " extra light"
+msgstr " extra leggero"
+
+#: ../src/common/fontcmn.cpp:950
+msgid " light"
+msgstr " leggero"
+
+#: ../src/common/fontcmn.cpp:954
+msgid " medium"
+msgstr " medio"
+
+#: ../src/common/fontcmn.cpp:958
+msgid " semi bold"
+msgstr " semi grassetto"
+
+#: ../src/common/fontcmn.cpp:962
+msgid " bold"
+msgstr " grassetto"
+
+#: ../src/common/fontcmn.cpp:966
+msgid " extra bold"
+msgstr " extra grassetto"
+
+#: ../src/common/fontcmn.cpp:970
+msgid " heavy"
+msgstr " pesante"
+
+#: ../src/common/fontcmn.cpp:974
+msgid " extra heavy"
+msgstr " extra pesante"
+
+#: ../src/common/fontcmn.cpp:990
+msgid " italic"
+msgstr " corsivo"
+
+#: ../src/common/fontcmn.cpp:1134
+msgid "strikethrough"
+msgstr "barrato"
+
+#: ../src/common/fontcmn.cpp:1143
+msgid "thin"
+msgstr "sottile"
+
+#: ../src/common/fontcmn.cpp:1156
+msgid "extralight"
+msgstr "extra leggero"
+
+#: ../src/common/fontcmn.cpp:1161
+msgid "light"
+msgstr "leggero"
+
+#: ../src/common/fontcmn.cpp:1169 ../src/richtext/richtextstyles.cpp:775
+msgid "normal"
+msgstr "normale"
+
+#: ../src/common/fontcmn.cpp:1174
+msgid "medium"
+msgstr "medio"
+
+#: ../src/common/fontcmn.cpp:1179 ../src/common/fontcmn.cpp:1199
+msgid "semibold"
+msgstr "semi grassetto"
+
+#: ../src/common/fontcmn.cpp:1184
+msgid "bold"
+msgstr "grassetto"
+
+#: ../src/common/fontcmn.cpp:1194
+msgid "extrabold"
+msgstr "extra grassetto"
+
+#: ../src/common/fontcmn.cpp:1204
+msgid "heavy"
+msgstr "pesante"
+
+#: ../src/common/fontcmn.cpp:1212
+msgid "extraheavy"
+msgstr "extra pesante"
+
+#: ../src/common/fontcmn.cpp:1217
+msgid "italic"
+msgstr "corsivo"
+
+#: ../src/common/fontmap.cpp:195
+msgid ": unknown charset"
+msgstr ": set di caratteri sconosciuto"
+
+#: ../src/common/fontmap.cpp:199
+#, c-format
+msgid ""
+"The charset '%s' is unknown. You may select\n"
+"another charset to replace it with or choose\n"
+"[Cancel] if it cannot be replaced"
+msgstr ""
+"Il set di caratteri '%s' è sconosciuto.\n"
+"È possibile sceglierne un altro in sostituzione oppure scegliere [Annulla] "
+"se non può essere sostituito."
+
+#: ../src/common/fontmap.cpp:241
+#, c-format
+msgid "Failed to remember the encoding for the charset '%s'."
+msgstr "Impossibile ricordare la codifica per il set di caratteri '%s'."
+
+#: ../src/common/fontmap.cpp:321
+msgid "can't load any font, aborting"
+msgstr "impossibile caricare un qualunque tipo di font. Uscita"
+
+#: ../src/common/fontmap.cpp:409
+msgid ": unknown encoding"
+msgstr ": codifica sconosciuta"
+
+#: ../src/common/fontmap.cpp:417
+#, c-format
+msgid ""
+"No font for displaying text in encoding '%s' found,\n"
+"but an alternative encoding '%s' is available.\n"
+"Do you want to use this encoding (otherwise you will have to choose another "
+"one)?"
+msgstr ""
+"Impossibile trovare un tipo di font per la codifica '%s',\n"
+"ma è disponibile la codifica alternativa '%s'.\n"
+"Vuoi utilizzare tale codifica (altrimenti sarà necessario sceglierne una "
+"differente)?"
+
+#: ../src/common/fontmap.cpp:422
+#, c-format
+msgid ""
+"No font for displaying text in encoding '%s' found.\n"
+"Would you like to select a font to be used for this encoding\n"
+"(otherwise the text in this encoding will not be shown correctly)?"
+msgstr ""
+"Impossibile trovare un tipo di font per la codifica del testo '%s'.\n"
+"Vuoi scegliere un carattere da utilizzare per questa codifica\n"
+"(altrimenti il testo con tale codifica non verrà visualizzato correttamente)?"
+
+#: ../src/common/fs_mem.cpp:169
+#, c-format
+msgid "Memory VFS already contains file '%s'!"
+msgstr "La memoria VFS contiene già il file '%s'!"
+
+#: ../src/common/fs_mem.cpp:232
+#, c-format
+msgid "Trying to remove file '%s' from memory VFS, but it is not loaded!"
+msgstr ""
+"Tentata la rimozione del file '%s' dalla memoria VFS, ma il file non è "
+"caricato!"
+
+#: ../src/common/fs_mem.cpp:262
+#, c-format
+msgid "Failed to store image '%s' to memory VFS!"
+msgstr "Impossibile memorizzare l'immagine '%s' nella memoria VFS!"
+
+#: ../src/common/ftp.cpp:197
+msgid "Timeout while waiting for FTP server to connect, try passive mode."
+msgstr ""
+"Tempo di attesa eccessivo durante l'attesa per la connessione del server "
+"FTP.\n"
+"Prova la modalità passiva."
+
+#: ../src/common/ftp.cpp:399
+#, c-format
+msgid "Failed to set FTP transfer mode to %s."
+msgstr "Impossibile impostare la modalità di trasferimneto FTP %s.."
+
+#: ../src/common/ftp.cpp:400 ../src/richtext/richtextsymboldlg.cpp:432
+msgid "ASCII"
+msgstr "ASCII"
+
+#: ../src/common/ftp.cpp:400
+msgid "binary"
+msgstr "binario"
+
+#: ../src/common/ftp.cpp:608
+msgid "The FTP server doesn't support the PORT command."
+msgstr "Il server FTP non supporta il comando PORT."
+
+#: ../src/common/ftp.cpp:622
+msgid "The FTP server doesn't support passive mode."
+msgstr "Il server FTP non supporta la modalità di trasferimento passiva."
+
+#: ../src/common/gifdecod.cpp:822
+#, c-format
+msgid "Incorrect GIF frame size (%u, %d) for the frame #%u"
+msgstr "Dimensione frame GTK non valida (%u, %d) per il frame #%u"
+
+#: ../src/common/glcmn.cpp:108
+msgid "Failed to allocate colour for OpenGL"
+msgstr "Impossibile allocare colore per OpenGL"
+
+#: ../src/common/headerctrlcmn.cpp:57
+msgid "Please select the columns to show and define their order:"
+msgstr "Seleziona le colonne da visualizzare e il loro ordine:"
+
+#: ../src/common/headerctrlcmn.cpp:58
+msgid "Customize Columns"
+msgstr "Personalizzazione colonne"
+
+#: ../src/common/headerctrlcmn.cpp:304
+msgid "&Customize..."
+msgstr "&Personalizza..."
+
+#: ../src/common/hyperlnkcmn.cpp:132
+#, c-format
+msgid "Failed to open URL \"%s\" in the default browser"
+msgstr "Impossibile aprire l'URL \"%s\" nel browser predefinito"
+
+#: ../src/common/iconbndl.cpp:195
+#, c-format
+msgid "Failed to load image %%d from file '%s'."
+msgstr "Impossibile caricare immagine %%d dal file '%s'."
+
+#: ../src/common/iconbndl.cpp:203
+#, c-format
+msgid "Failed to load image %d from stream."
+msgstr "Impossibile caricare immagine %d dallo stream."
+
+#: ../src/common/iconbndl.cpp:221
+#, c-format
+msgid "Failed to load icons from resource '%s'."
+msgstr "Impossibile caricare icona per la risorsa '%s'."
+
+#: ../src/common/imagbmp.cpp:97
+msgid "BMP: Couldn't save invalid image."
+msgstr "BMP: Impossibile salvare un'immagine non valida."
+
+#: ../src/common/imagbmp.cpp:137
+msgid "BMP: wxImage doesn't have own wxPalette."
+msgstr "BMP: l'oggetto wxImage non ha una propria wxPalette."
+
+#: ../src/common/imagbmp.cpp:243
+msgid "BMP: Couldn't write the file (Bitmap) header."
+msgstr "BMP: Impossibile scrivere l'header (Bitmap) del file."
+
+#: ../src/common/imagbmp.cpp:266
+msgid "BMP: Couldn't write the file (BitmapInfo) header."
+msgstr "BMP: Impossibile scrivere l'header (BitmapInfo) del file."
+
+#: ../src/common/imagbmp.cpp:353
+msgid "BMP: Couldn't write RGB color map."
+msgstr "BMP: Impossibile scrivere la mappa dei colori RGB."
+
+#: ../src/common/imagbmp.cpp:487
+msgid "BMP: Couldn't write data."
+msgstr "BMP: Impossibile scrivere i dati."
+
+#: ../src/common/imagbmp.cpp:561 ../src/common/imagbmp.cpp:642
+msgid "BMP: Couldn't allocate memory."
+msgstr "BMP: Impossibile allocare la memoria."
+
+#: ../src/common/imagbmp.cpp:1041
+msgid "DIB Header: Image width > 32767 pixels for file."
+msgstr ""
+"Intestazione DIB: la larghezza dell'immagine nel file è > di 32767 pixel."
+
+#: ../src/common/imagbmp.cpp:1049
+msgid "DIB Header: Image height > 32767 pixels for file."
+msgstr "Intestazione DIB: l'altezza dell'immagine nel file è > di 32767 pixel."
+
+#: ../src/common/imagbmp.cpp:1081
+msgid "DIB Header: Unknown bitdepth in file."
+msgstr "Intestazione DIB: numero di bit per pixel nel file sconosciuto."
+
+#: ../src/common/imagbmp.cpp:1156
+msgid "DIB Header: Unknown encoding in file."
+msgstr "Inetstazione DIB: Codifica del file sconosciuta."
+
+#: ../src/common/imagbmp.cpp:1165
+msgid "DIB Header: Encoding doesn't match bitdepth."
+msgstr ""
+"Intestazione DIB: la codifica non corrisponde al numero di bit per pixel."
+
+#: ../src/common/imagbmp.cpp:1180
+#, c-format
+msgid "BMP Header: Invalid number of colors (%d)."
+msgstr ""
+
+#: ../src/common/imagbmp.cpp:1273
+msgid "Error in reading image DIB."
+msgstr "Errore durante la lettura dell'immagine DIB."
+
+#: ../src/common/imagbmp.cpp:1294
+msgid "ICO: Error in reading mask DIB."
+msgstr "ICO: errore durante la lettura della maschera DIB."
+
+#: ../src/common/imagbmp.cpp:1353
+msgid "ICO: Image too tall for an icon."
+msgstr "ICO: immagine troppo alta per essere un'icona."
+
+#: ../src/common/imagbmp.cpp:1361
+msgid "ICO: Image too wide for an icon."
+msgstr "ICO: immagine troppo larga per essere un'icona."
+
+#: ../src/common/imagbmp.cpp:1388 ../src/common/imagbmp.cpp:1488
+#: ../src/common/imagbmp.cpp:1503 ../src/common/imagbmp.cpp:1514
+#: ../src/common/imagbmp.cpp:1528 ../src/common/imagbmp.cpp:1576
+#: ../src/common/imagbmp.cpp:1591 ../src/common/imagbmp.cpp:1605
+#: ../src/common/imagbmp.cpp:1616
+msgid "ICO: Error writing the image file!"
+msgstr "ICO: Errore durante la scrittura dell'immagine!"
+
+#: ../src/common/imagbmp.cpp:1701
+msgid "ICO: Invalid icon index."
+msgstr "ICO: indice dell'icona non valido."
+
+#: ../src/common/image.cpp:2410
+msgid "Image and mask have different sizes."
+msgstr "L'immagine e la maschera hanno dimensioni diverse."
+
+#: ../src/common/image.cpp:2418 ../src/common/image.cpp:2459
+msgid "No unused colour in image being masked."
+msgstr "Nessun colore inutilizzato nell'immagine da mascherare."
+
+#: ../src/common/image.cpp:2641
+#, c-format
+msgid "Failed to load bitmap \"%s\" from resources."
+msgstr "Impossibile caricare bitmap \"%s\" dalle risorse."
+
+#: ../src/common/image.cpp:2650
+#, c-format
+msgid "Failed to load icon \"%s\" from resources."
+msgstr "Impossibile caricare icona \"%s\" dalle risorse."
+
+#: ../src/common/image.cpp:2728 ../src/common/image.cpp:2747
+#, c-format
+msgid "Failed to load image from file \"%s\"."
+msgstr "Impossibile caricare il file immagine \"%s\"."
+
+#: ../src/common/image.cpp:2761
+#, c-format
+msgid "Can't save image to file '%s': unknown extension."
+msgstr "Impossibile salvare l'immagine nel file '%s': estensione sconosciuta."
+
+#: ../src/common/image.cpp:2869
+msgid "No handler found for image type."
+msgstr "Funzionalità non disponibili per questo formato di immagine."
+
+#: ../src/common/image.cpp:2877 ../src/common/image.cpp:3000
+#: ../src/common/image.cpp:3066
+#, c-format
+msgid "No image handler for type %d defined."
+msgstr "Funzionalità non disponibili per il formato di immagine %d."
+
+#: ../src/common/image.cpp:2887
+#, c-format
+msgid "Image file is not of type %d."
+msgstr "Il file immagine non è di tipo %d."
+
+#: ../src/common/image.cpp:2970
+msgid "Can't automatically determine the image format for non-seekable input."
+msgstr ""
+"Impossibile determinare il formato immagine per input non selezionabile."
+
+#: ../src/common/image.cpp:2988
+msgid "Unknown image data format."
+msgstr "Formato dati immagine sconosciuto."
+
+#: ../src/common/image.cpp:3009
+#, c-format
+msgid "This is not a %s."
+msgstr "Questo non è un %s."
+
+#: ../src/common/image.cpp:3032 ../src/common/image.cpp:3080
+#, c-format
+msgid "No image handler for type %s defined."
+msgstr "Funzionalità non disponibili per il formato di immagine %s."
+
+#: ../src/common/image.cpp:3041
+#, c-format
+msgid "Image is not of type %s."
+msgstr "L'immagine non è di tipo %s."
+
+#: ../src/common/image.cpp:3509
+#, c-format
+msgid "Failed to check format of image file \"%s\"."
+msgstr "Impossibile verificare formato immagine file \"%s\"."
+
+#: ../src/common/imaggif.cpp:124
+msgid "GIF: error in GIF image format."
+msgstr "GIF: errore nel formato GIF dell'immagine."
+
+#: ../src/common/imaggif.cpp:129
+msgid "GIF: not enough memory."
+msgstr "GIF: memoria insufficiente."
+
+#: ../src/common/imaggif.cpp:134
+msgid "GIF: data stream seems to be truncated."
+msgstr "GIF: il flusso dati sembra essere interrotto."
+
+#: ../src/common/imaggif.cpp:240
+msgid "Couldn't initialize GIF hash table."
+msgstr "Impossibile inizializzare la tabella GIF hash."
+
+#: ../src/common/imagiff.cpp:739
+msgid "IFF: error in IFF image format."
+msgstr "IFF: errore nel formato IFF dell'immagine."
+
+#: ../src/common/imagiff.cpp:742
+msgid "IFF: not enough memory."
+msgstr "IFF: memoria insufficiente."
+
+#: ../src/common/imagiff.cpp:745
+msgid "IFF: unknown error!!!"
+msgstr "IFF: errore sconosciuto!!!"
+
+#: ../src/common/imagiff.cpp:755
+msgid "IFF: data stream seems to be truncated."
+msgstr "IFF: il flusso dati sembra essere interrotto."
+
+#: ../src/common/imagjpeg.cpp:258
+msgid "JPEG: Couldn't load - file is probably corrupted."
+msgstr "JPEG: Caricamento impossibile - probabilmente il file è danneggiato."
+
+#: ../src/common/imagjpeg.cpp:437
+msgid "JPEG: Couldn't save image."
+msgstr "JPEG: Impossibile salvare l'immagine."
+
+#: ../src/common/imagpcx.cpp:439
+msgid "PCX: this is not a PCX file."
+msgstr "PCX: questo non è un file PCX."
+
+#: ../src/common/imagpcx.cpp:453
+msgid "PCX: image format unsupported"
+msgstr "PCX: formato non supportato"
+
+#: ../src/common/imagpcx.cpp:454 ../src/common/imagpcx.cpp:477
+msgid "PCX: couldn't allocate memory"
+msgstr "PCX: impossibile allocare la memoria"
+
+#: ../src/common/imagpcx.cpp:455
+msgid "PCX: version number too low"
+msgstr "PCX: numero di versione troppo piccolo"
+
+#: ../src/common/imagpcx.cpp:456 ../src/common/imagpcx.cpp:478
+msgid "PCX: unknown error !!!"
+msgstr "PCX: errore sconosciuto!!!"
+
+#: ../src/common/imagpcx.cpp:476
+msgid "PCX: invalid image"
+msgstr "PCX: immagine non valida"
+
+#: ../src/common/imagpng.cpp:385
+#, c-format
+msgid "Unknown PNG resolution unit %d"
+msgstr "Unità %d risoluzione PNG sconosciuta"
+
+#: ../src/common/imagpng.cpp:439
+msgid "Couldn't load a PNG image - file is corrupted or not enough memory."
+msgstr ""
+"Impossibile caricare un'immagine PNG - file danneggiato o memoria "
+"insufficiente."
+
+#: ../src/common/imagpng.cpp:513 ../src/common/imagpng.cpp:524
+#: ../src/common/imagpng.cpp:534
+msgid "Couldn't save PNG image."
+msgstr "Impossibile salvare l'immagine PNG."
+
+#: ../src/common/imagpnm.cpp:71
+msgid "PNM: File format is not recognized."
+msgstr "PNM: Formato del file sconosciuto."
+
+#: ../src/common/imagpnm.cpp:89
+msgid "PNM: Couldn't allocate memory."
+msgstr "PNM: Impossibile allocare la memoria."
+
+#: ../src/common/imagpnm.cpp:111 ../src/common/imagpnm.cpp:134
+#: ../src/common/imagpnm.cpp:156
+msgid "PNM: File seems truncated."
+msgstr "PNM: Il file sembra troncato."
+
+#: ../src/common/imagtiff.cpp:69
+#, c-format
+msgid " (in module \"%s\")"
+msgstr " (nel modulo \"%s\")"
+
+#: ../src/common/imagtiff.cpp:304
+msgid "TIFF: Error loading image."
+msgstr "TIFF: errore nel caricamento dell'immagine."
+
+#: ../src/common/imagtiff.cpp:314
+msgid "Invalid TIFF image index."
+msgstr "Indice dell'immagine TIFF non valido."
+
+#: ../src/common/imagtiff.cpp:358
+msgid "TIFF: Image size is abnormally big."
+msgstr "TIFF: dimensione immaggine esageratamenet grande."
+
+#: ../src/common/imagtiff.cpp:372 ../src/common/imagtiff.cpp:385
+#: ../src/common/imagtiff.cpp:769
+msgid "TIFF: Couldn't allocate memory."
+msgstr "TIFF: impossibile allocare la memoria."
+
+#: ../src/common/imagtiff.cpp:471
+msgid "TIFF: Error reading image."
+msgstr "TIFF: errore durante la lettura dell'immagine."
+
+#: ../src/common/imagtiff.cpp:532
+#, c-format
+msgid "Unknown TIFF resolution unit %d ignored"
+msgstr "Risoluzione TIFF sconosciuta - unità %d ignorata"
+
+#: ../src/common/imagtiff.cpp:611
+msgid "TIFF: Error saving image."
+msgstr "TIFF: errore nel salvataggio dell'immagine."
+
+#: ../src/common/imagtiff.cpp:868
+msgid "TIFF: Error writing image."
+msgstr "TIFF: errore durante la scrittura dell'immagine."
+
+#: ../src/common/imagtiff.cpp:881
+#, fuzzy
+msgid "TIFF: Error flushing data."
+msgstr "TIFF: errore nel salvataggio dell'immagine."
+
+#: ../src/common/imagwebp.cpp:56
+msgid "WebP: Invalid data (failed to get features)."
+msgstr ""
+
+#: ../src/common/imagwebp.cpp:65
+msgid "WebP: Allocating image memory failed."
+msgstr ""
+
+#: ../src/common/imagwebp.cpp:82
+msgid "WebP: Decoding RGBA image data failed."
+msgstr ""
+
+#: ../src/common/imagwebp.cpp:98
+msgid "WebP: Decoding RGB image data failed."
+msgstr ""
+
+#: ../src/common/imagwebp.cpp:113 ../src/common/imagwebp.cpp:201
+msgid "WebP: Allocating stream buffer failed."
+msgstr ""
+
+#: ../src/common/imagwebp.cpp:131
+#, fuzzy
+msgid "WebP: Failed to parse container data."
+msgstr "Impossibile scrivere i dati degli appunti."
+
+#: ../src/common/imagwebp.cpp:222
+#, fuzzy
+msgid "WebP: Error decoding animation."
+msgstr "Errore durante la lettura del file di configurazione."
+
+#: ../src/common/imagwebp.cpp:240
+msgid "WebP: Error getting next animation frame."
+msgstr ""
+
+#: ../src/common/init.cpp:172
+#, c-format
+msgid ""
+"Command line argument %d couldn't be converted to Unicode and will be "
+"ignored."
+msgstr ""
+"L'argomento %d della linea di comando non può essere convertito in Unicode e "
+"verrà ignorato."
+
+#: ../src/common/init.cpp:344
+msgid "Initialization failed in post init, aborting."
+msgstr "Inizializzazione fallita in \"post init\", esco."
+
+#: ../src/common/intl.cpp:378
+#, c-format
+msgid "Cannot set locale to language \"%s\"."
+msgstr "Impossibile impostare locale a lingua \"%s\"."
+
+#: ../src/common/log.cpp:232
+msgid "Error: "
+msgstr "Errore: "
+
+#: ../src/common/log.cpp:236
+msgid "Warning: "
+msgstr "Avviso: "
+
+#: ../src/common/log.cpp:284
+msgid "The previous message repeated once."
+msgstr "Il messaggio precedente è stato ripetuto una volta."
+
+#: ../src/common/log.cpp:291
+#, c-format
+msgid "The previous message repeated %u time."
+msgid_plural "The previous message repeated %u times."
+msgstr[0] "Il messaggio precedente è stato ripetuto %u volta."
+msgstr[1] "Il messaggio precedente è stato ripetuto %u volte."
+
+#: ../src/common/log.cpp:319
+#, c-format
+msgid "Last repeated message (\"%s\", %u time) wasn't output"
+msgid_plural "Last repeated message (\"%s\", %u times) wasn't output"
+msgstr[0] "L'ultimo messaggio ripetuto (\"%s\", %u volta) non è stato inviato"
+msgstr[1] "L'ultimo messaggio ripetuto (\"%s\", %u volte) non è stato inviato"
+
+#: ../src/common/log.cpp:435
+#, c-format
+msgid " (error %ld: %s)"
+msgstr " (errore %ld: %s)"
+
+#: ../src/common/lzmastream.cpp:121
+msgid "Failed to allocate memory for LZMA decompression."
+msgstr "Impossibile allocare memoria per la decompressione LZMA."
+
+#: ../src/common/lzmastream.cpp:125
+#, c-format
+msgid "Failed to initialize LZMA decompression: unexpected error %u."
+msgstr ""
+"Impossibile inizializzare la decompressione LZMA: errore imprevisto %u."
+
+#: ../src/common/lzmastream.cpp:179
+msgid "input is not in XZ format"
+msgstr "l'input non è in formato XZ"
+
+#: ../src/common/lzmastream.cpp:183
+msgid "input compressed using unknown XZ option"
+msgstr "sorgente compressa usando l'opzione XZ sconosciuta"
+
+#: ../src/common/lzmastream.cpp:188
+msgid "input is corrupted"
+msgstr "la sorgente è danneggiata"
+
+#: ../src/common/lzmastream.cpp:192
+msgid "unknown decompression error"
+msgstr "errore di decompressione sconosciuto"
+
+#: ../src/common/lzmastream.cpp:196
+#, c-format
+msgid "LZMA decompression error: %s"
+msgstr "Errore di decompressione LZMA: %s"
+
+#: ../src/common/lzmastream.cpp:231
+msgid "Failed to allocate memory for LZMA compression."
+msgstr "Impossibile allocare memoria per la compressione LZMA."
+
+#: ../src/common/lzmastream.cpp:235
+#, c-format
+msgid "Failed to initialize LZMA compression: unexpected error %u."
+msgstr "Impossibile inizializzare la compressione LZMA: errore imprevisto %u."
+
+#: ../src/common/lzmastream.cpp:267 ../src/common/lzmastream.cpp:342
+#: ../src/html/chm.cpp:336
+msgid "out of memory"
+msgstr "memoria insufficiente"
+
+#: ../src/common/lzmastream.cpp:276 ../src/common/lzmastream.cpp:346
+msgid "unknown compression error"
+msgstr "errore di compressione sconosciuto"
+
+#: ../src/common/lzmastream.cpp:280
+#, c-format
+msgid "LZMA compression error: %s"
+msgstr "Errore di compressione LZMA: %s"
+
+#: ../src/common/lzmastream.cpp:350
+#, c-format
+msgid "LZMA compression error when flushing output: %s"
+msgstr ""
+"Errore di compressione LZMA durante lo svuotamento della destinazione: %s"
+
+#: ../src/common/mimecmn.cpp:167
+#, c-format
+msgid "Unmatched '{' in an entry for mime type %s."
+msgstr "'{' spaiata in una voce per il tipo MIME %s."
+
+#: ../src/common/module.cpp:76
+#, c-format
+msgid "Circular dependency involving module \"%s\" detected."
+msgstr ""
+"È stata trovata una dipendenza circolare che coinvolge il modulo \"%s\"."
+
+#: ../src/common/module.cpp:128
+#, c-format
+msgid "Dependency \"%s\" of module \"%s\" doesn't exist."
+msgstr "La dipendenza \"%s\" del modulo \"%s\" non esiste."
+
+#: ../src/common/module.cpp:137
+#, c-format
+msgid "Module \"%s\" initialization failed"
+msgstr "Inizializzazione del modulo \"%s\" fallita"
+
+#: ../src/common/msgout.cpp:96
+msgid "Message"
+msgstr "Messaggio"
+
+#: ../src/common/paper.cpp:70
+msgid "Letter, 8 1/2 x 11 in"
+msgstr "Letter, 8 1/2 x 11 pollici"
+
+#: ../src/common/paper.cpp:71
+msgid "Legal, 8 1/2 x 14 in"
+msgstr "Legal, 8 1/2 x 14 pollici"
+
+#: ../src/common/paper.cpp:72
+msgid "A4 sheet, 210 x 297 mm"
+msgstr "Foglio A4, 210 x 297 mm"
+
+#: ../src/common/paper.cpp:73
+msgid "C sheet, 17 x 22 in"
+msgstr "Foglio C, 17 x 22 pollici"
+
+#: ../src/common/paper.cpp:74
+msgid "D sheet, 22 x 34 in"
+msgstr "Foglio D, 22 x 34 pollici"
+
+#: ../src/common/paper.cpp:75
+msgid "E sheet, 34 x 44 in"
+msgstr "Foglio E, 34 x 44 pollici"
+
+#: ../src/common/paper.cpp:76
+msgid "Letter Small, 8 1/2 x 11 in"
+msgstr "Letter Small, 8 1/2 x 11 pollici"
+
+#: ../src/common/paper.cpp:77
+msgid "Tabloid, 11 x 17 in"
+msgstr "Tabloid, 11 x 17 pollici"
+
+#: ../src/common/paper.cpp:78
+msgid "Ledger, 17 x 11 in"
+msgstr "Ledger, 17 x 11 pollici"
+
+#: ../src/common/paper.cpp:79
+msgid "Statement, 5 1/2 x 8 1/2 in"
+msgstr "Statement, 5 1/2 x 8 1/2 pollici"
+
+#: ../src/common/paper.cpp:80
+msgid "Executive, 7 1/4 x 10 1/2 in"
+msgstr "Executive, 7 1/4 x 10 1/2 pollici"
+
+#: ../src/common/paper.cpp:81
+msgid "A3 sheet, 297 x 420 mm"
+msgstr "Foglio A3, 297 x 420 mm"
+
+#: ../src/common/paper.cpp:82
+msgid "A4 small sheet, 210 x 297 mm"
+msgstr "Foglio A4, 210 x 297 mm"
+
+#: ../src/common/paper.cpp:83
+msgid "A5 sheet, 148 x 210 mm"
+msgstr "Foglio A5, 148 x 210 mm"
+
+#: ../src/common/paper.cpp:84
+msgid "B4 sheet, 250 x 354 mm"
+msgstr "Foglio B4, 250 x 354 mm"
+
+#: ../src/common/paper.cpp:85
+msgid "B5 sheet, 182 x 257 millimeter"
+msgstr "Foglio B5, 182 x 257 mm"
+
+#: ../src/common/paper.cpp:86
+msgid "Folio, 8 1/2 x 13 in"
+msgstr "Foglio, 8 1/2 x 13 pollici"
+
+#: ../src/common/paper.cpp:87
+msgid "Quarto, 215 x 275 mm"
+msgstr "Quarto, 215 x 275 mm"
+
+#: ../src/common/paper.cpp:88
+msgid "10 x 14 in"
+msgstr "10 x 14 pollici"
+
+#: ../src/common/paper.cpp:89
+msgid "11 x 17 in"
+msgstr "11 x 17 pollici"
+
+#: ../src/common/paper.cpp:90
+msgid "Note, 8 1/2 x 11 in"
+msgstr "Nota, 8 1/2 x 11 pollici"
+
+#: ../src/common/paper.cpp:91
+msgid "#9 Envelope, 3 7/8 x 8 7/8 in"
+msgstr "Busta #9, 3 7/8 x 8 7/8 pollici"
+
+#: ../src/common/paper.cpp:92
+msgid "#10 Envelope, 4 1/8 x 9 1/2 in"
+msgstr "Busta #10, 4 1/8 x 9 1/2 pollici"
+
+#: ../src/common/paper.cpp:93
+msgid "#11 Envelope, 4 1/2 x 10 3/8 in"
+msgstr "Busta #11, 4 1/2 x 10 3/8 pollici"
+
+#: ../src/common/paper.cpp:94
+msgid "#12 Envelope, 4 3/4 x 11 in"
+msgstr "Busta #12, 4 3/4 x 11 pollici"
+
+#: ../src/common/paper.cpp:95
+msgid "#14 Envelope, 5 x 11 1/2 in"
+msgstr "Busta #14, 5 x 11 1/2 pollici"
+
+#: ../src/common/paper.cpp:96
+msgid "DL Envelope, 110 x 220 mm"
+msgstr "Busta DL, 110 x 220 mm"
+
+#: ../src/common/paper.cpp:97
+msgid "C5 Envelope, 162 x 229 mm"
+msgstr "Busta C5, 162 x 229 mm"
+
+#: ../src/common/paper.cpp:98
+msgid "C3 Envelope, 324 x 458 mm"
+msgstr "Busta C3, 324 x 458 mm"
+
+#: ../src/common/paper.cpp:99
+msgid "C4 Envelope, 229 x 324 mm"
+msgstr "Busta C4, 229 x 324 mm"
+
+#: ../src/common/paper.cpp:100
+msgid "C6 Envelope, 114 x 162 mm"
+msgstr "Busta C6, 114 x 162 mm"
+
+#: ../src/common/paper.cpp:101
+msgid "C65 Envelope, 114 x 229 mm"
+msgstr "Busta C65, 114 x 229 mm"
+
+#: ../src/common/paper.cpp:102
+msgid "B4 Envelope, 250 x 353 mm"
+msgstr "Busta B4, 250 x 353 mm"
+
+#: ../src/common/paper.cpp:103
+msgid "B5 Envelope, 176 x 250 mm"
+msgstr "Busta B5, 176 x 250 mm"
+
+#: ../src/common/paper.cpp:104
+msgid "B6 Envelope, 176 x 125 mm"
+msgstr "Busta B6, 176 x 125 mm"
+
+#: ../src/common/paper.cpp:105
+msgid "Italy Envelope, 110 x 230 mm"
+msgstr "Busta Italiana, 110 x 230 mm"
+
+#: ../src/common/paper.cpp:106
+msgid "Monarch Envelope, 3 7/8 x 7 1/2 in"
+msgstr "Busta Monarch, 3 7/8 x 7 1/2 pollici"
+
+#: ../src/common/paper.cpp:107
+msgid "6 3/4 Envelope, 3 5/8 x 6 1/2 in"
+msgstr "Busta 6 3/4, 3 5/8 x 6 1/2 pollici"
+
+#: ../src/common/paper.cpp:108
+msgid "US Std Fanfold, 14 7/8 x 11 in"
+msgstr "Fanfold Std US, 14 7/8 x 11 pollici"
+
+#: ../src/common/paper.cpp:109
+msgid "German Std Fanfold, 8 1/2 x 12 in"
+msgstr "FanFol Std Tedesco, 8 1/2 x 12 pollici"
+
+#: ../src/common/paper.cpp:110
+msgid "German Legal Fanfold, 8 1/2 x 13 in"
+msgstr "Fanfold Legal Tedesco, 8 1/2 x 13 pollici"
+
+#: ../src/common/paper.cpp:112
+msgid "B4 (ISO) 250 x 353 mm"
+msgstr "Foglio B4 (ISO) 250 x 353 mm"
+
+#: ../src/common/paper.cpp:113
+msgid "Japanese Postcard 100 x 148 mm"
+msgstr "Cartolina giapponese 100 x 148 mm"
+
+#: ../src/common/paper.cpp:114
+msgid "9 x 11 in"
+msgstr "9 x 11 pollici"
+
+#: ../src/common/paper.cpp:115
+msgid "10 x 11 in"
+msgstr "10 x 11 pollici"
+
+#: ../src/common/paper.cpp:116
+msgid "15 x 11 in"
+msgstr "15 x 11 pollici"
+
+#: ../src/common/paper.cpp:117
+msgid "Envelope Invite 220 x 220 mm"
+msgstr "Busta Invite 220 x 220 mm"
+
+#: ../src/common/paper.cpp:118
+msgid "Letter Extra 9 1/2 x 12 in"
+msgstr "Letter Extra 9 1/2 x 12 pollici"
+
+#: ../src/common/paper.cpp:119
+msgid "Legal Extra 9 1/2 x 15 in"
+msgstr "Legal Extra 9 1/2 x 15 pollici"
+
+#: ../src/common/paper.cpp:120
+msgid "Tabloid Extra 11.69 x 18 in"
+msgstr "Tabloid Extra 11,69 x 18 pollici"
+
+#: ../src/common/paper.cpp:121
+msgid "A4 Extra 9.27 x 12.69 in"
+msgstr "Foglio A4 Extra 235 x 322 mm"
+
+#: ../src/common/paper.cpp:122
+msgid "Letter Transverse 8 1/2 x 11 in"
+msgstr "Letter Transverse 8 1/2 x 11 pollici"
+
+#: ../src/common/paper.cpp:123
+msgid "A4 Transverse 210 x 297 mm"
+msgstr "Foglio A4 Transverse 210 x 297 mm"
+
+#: ../src/common/paper.cpp:124
+msgid "Letter Extra Transverse 9.275 x 12 in"
+msgstr "Letter Extra Transverse 235 x 305 mm"
+
+#: ../src/common/paper.cpp:125
+msgid "SuperA/SuperA/A4 227 x 356 mm"
+msgstr "Foglio SuperA/SuperA/A4 227 x 356 mm"
+
+#: ../src/common/paper.cpp:126
+msgid "SuperB/SuperB/A3 305 x 487 mm"
+msgstr "Foglio SuperB/SuperB/A3 305 x 487 mm"
+
+#: ../src/common/paper.cpp:127
+msgid "Letter Plus 8 1/2 x 12.69 in"
+msgstr "Letter Plus 8 1/2 x 12.69 pollici"
+
+#: ../src/common/paper.cpp:128
+msgid "A4 Plus 210 x 330 mm"
+msgstr "Foglio A4 Plus 210 x 330 mm"
+
+#: ../src/common/paper.cpp:129
+msgid "A5 Transverse 148 x 210 mm"
+msgstr "Foglio A5 Transverse 148 x 210 mm"
+
+#: ../src/common/paper.cpp:130
+msgid "B5 (JIS) Transverse 182 x 257 mm"
+msgstr "Foglio B5 (JIS) 182 x 257 millimeter"
+
+#: ../src/common/paper.cpp:131
+msgid "A3 Extra 322 x 445 mm"
+msgstr "Foglio A3 Extra 322 x 445 mm"
+
+#: ../src/common/paper.cpp:132
+msgid "A5 Extra 174 x 235 mm"
+msgstr "Foglio A5 Extra 174 x 235 mm"
+
+#: ../src/common/paper.cpp:133
+msgid "B5 (ISO) Extra 201 x 276 mm"
+msgstr "Foglio B5 (ISO) Extra 201 x 276 mm"
+
+#: ../src/common/paper.cpp:134
+msgid "A2 420 x 594 mm"
+msgstr "Foglio A2 420 x 594 mm"
+
+#: ../src/common/paper.cpp:135
+msgid "A3 Transverse 297 x 420 mm"
+msgstr "Foglio A3 Transverse 297 x 420 mm"
+
+#: ../src/common/paper.cpp:136
+msgid "A3 Extra Transverse 322 x 445 mm"
+msgstr "Foglio A3 Extra Transverse 322 x 445 mm"
+
+#: ../src/common/paper.cpp:138
+msgid "Japanese Double Postcard 200 x 148 mm"
+msgstr "Doppia cartolina giapponese 200 x 148 mm"
+
+#: ../src/common/paper.cpp:139
+msgid "A6 105 x 148 mm"
+msgstr "Foglio A6 105 x 148 mm"
+
+#: ../src/common/paper.cpp:140
+msgid "Japanese Envelope Kaku #2"
+msgstr "Busta giapponese Kaku #2"
+
+#: ../src/common/paper.cpp:141
+msgid "Japanese Envelope Kaku #3"
+msgstr "Busta giapponese Kaku #3"
+
+#: ../src/common/paper.cpp:142
+msgid "Japanese Envelope Chou #3"
+msgstr "Busta giapponese Chou #3"
+
+#: ../src/common/paper.cpp:143
+msgid "Japanese Envelope Chou #4"
+msgstr "Busta giapponese Chou #4"
+
+#: ../src/common/paper.cpp:144
+msgid "Letter Rotated 11 x 8 1/2 in"
+msgstr "Letter ruotato 11 x 8 1/2 pollici"
+
+#: ../src/common/paper.cpp:145
+msgid "A3 Rotated 420 x 297 mm"
+msgstr "Foglio A3 Ruotato 420 x 297 mm"
+
+#: ../src/common/paper.cpp:146
+msgid "A4 Rotated 297 x 210 mm"
+msgstr "Foglio A4 ruotato 297 x 210 mm"
+
+#: ../src/common/paper.cpp:147
+msgid "A5 Rotated 210 x 148 mm"
+msgstr "Foglio A5 ruotato 210 x 148 mm"
+
+#: ../src/common/paper.cpp:148
+msgid "B4 (JIS) Rotated 364 x 257 mm"
+msgstr "Foglio B4 (JIS) Ruotato 364 x 257 mm"
+
+#: ../src/common/paper.cpp:149
+msgid "B5 (JIS) Rotated 257 x 182 mm"
+msgstr "Foglio B5 (JIS) Ruotato 257 x 182 mm"
+
+#: ../src/common/paper.cpp:150
+msgid "Japanese Postcard Rotated 148 x 100 mm"
+msgstr "Cartolina giapponese ruotata 148 x 100 mm"
+
+#: ../src/common/paper.cpp:151
+msgid "Double Japanese Postcard Rotated 148 x 200 mm"
+msgstr "Doppia cartolina giapponese ruotata 148 x 200 mm"
+
+#: ../src/common/paper.cpp:152
+msgid "A6 Rotated 148 x 105 mm"
+msgstr "Foglio A6 ruotato 148 x 105 mm"
+
+#: ../src/common/paper.cpp:153
+msgid "Japanese Envelope Kaku #2 Rotated"
+msgstr "Busta giapponese Kaku #2 ruotata"
+
+#: ../src/common/paper.cpp:154
+msgid "Japanese Envelope Kaku #3 Rotated"
+msgstr "Busta giapponese Kaku #3 ruotata"
+
+#: ../src/common/paper.cpp:155
+msgid "Japanese Envelope Chou #3 Rotated"
+msgstr "Busta giapponese Chou #3 ruotata"
+
+#: ../src/common/paper.cpp:156
+msgid "Japanese Envelope Chou #4 Rotated"
+msgstr "Busta giapponese Chou #4 ruotata"
+
+#: ../src/common/paper.cpp:157
+msgid "B6 (JIS) 128 x 182 mm"
+msgstr "Foglio B6 (JIS) 128 x 182 mm"
+
+#: ../src/common/paper.cpp:158
+msgid "B6 (JIS) Rotated 182 x 128 mm"
+msgstr "Foglio B6 (JIS) Ruotato 182 x 128 mm"
+
+#: ../src/common/paper.cpp:159
+msgid "12 x 11 in"
+msgstr "12 x 11 pollici"
+
+#: ../src/common/paper.cpp:160
+msgid "Japanese Envelope You #4"
+msgstr "Busta giapponese You #4"
+
+#: ../src/common/paper.cpp:161
+msgid "Japanese Envelope You #4 Rotated"
+msgstr "Busta giapponese You #4 ruotata"
+
+#: ../src/common/paper.cpp:162
+msgid "PRC 16K 146 x 215 mm"
+msgstr "Foglio Rep. Pop. Cinese 16K 146 x 215 mm"
+
+#: ../src/common/paper.cpp:163
+msgid "PRC 32K 97 x 151 mm"
+msgstr "Foglio Rep. Pop. Cinese 32K 97 x 151 mm"
+
+#: ../src/common/paper.cpp:164
+msgid "PRC 32K(Big) 97 x 151 mm"
+msgstr "Foglio Rep. Pop. Cinese 32K(grande) 97 x 151 mm"
+
+#: ../src/common/paper.cpp:165
+msgid "PRC Envelope #1 102 x 165 mm"
+msgstr "Busta Rep. Pop. Cinese #1 102 x 165 mm"
+
+#: ../src/common/paper.cpp:166
+msgid "PRC Envelope #2 102 x 176 mm"
+msgstr "Busta Rep. Pop. Cinese #2 102 x 176 mm"
+
+#: ../src/common/paper.cpp:167
+msgid "PRC Envelope #3 125 x 176 mm"
+msgstr "Busta Rep. Pop. Cinese #3 125 x 176 mm"
+
+#: ../src/common/paper.cpp:168
+msgid "PRC Envelope #4 110 x 208 mm"
+msgstr "Busta Rep. Pop. Cinese #4 110 x 208 mm"
+
+#: ../src/common/paper.cpp:169
+msgid "PRC Envelope #5 110 x 220 mm"
+msgstr "Busta Rep. Pop. Cinese #5 110 x 220 mm"
+
+#: ../src/common/paper.cpp:170
+msgid "PRC Envelope #6 120 x 230 mm"
+msgstr "Busta Rep. Pop. Cinese #6 120 x 230 mm"
+
+#: ../src/common/paper.cpp:171
+msgid "PRC Envelope #7 160 x 230 mm"
+msgstr "Busta Rep. Pop. Cinese #7 160 x 230 mm"
+
+#: ../src/common/paper.cpp:172
+msgid "PRC Envelope #8 120 x 309 mm"
+msgstr "Busta Rep. Pop. Cinese #8 120 x 309 mm"
+
+#: ../src/common/paper.cpp:173
+msgid "PRC Envelope #9 229 x 324 mm"
+msgstr "Busta Rep. Pop. Cinese #9 229 x 324 mm"
+
+#: ../src/common/paper.cpp:174
+msgid "PRC Envelope #10 324 x 458 mm"
+msgstr "Busta Rep. Pop. Cinese #10 324 x 458 mm"
+
+#: ../src/common/paper.cpp:175
+msgid "PRC 16K Rotated"
+msgstr "Foglio Rep. Pop. Cinese 16K Ruotato"
+
+#: ../src/common/paper.cpp:176
+msgid "PRC 32K Rotated"
+msgstr "Foglio Rep. Pop. Cinese 32K Ruotato"
+
+#: ../src/common/paper.cpp:177
+msgid "PRC 32K(Big) Rotated"
+msgstr "Foglio Rep. Pop. Cinese 32K(grande) ruotato"
+
+#: ../src/common/paper.cpp:178
+msgid "PRC Envelope #1 Rotated 165 x 102 mm"
+msgstr "Busta Rep. Pop. Cinese #1 ruotata 165 x 102 mm"
+
+#: ../src/common/paper.cpp:179
+msgid "PRC Envelope #2 Rotated 176 x 102 mm"
+msgstr "Busta Rep. Pop. Cinese #2 ruotata 176 x 102 mm"
+
+#: ../src/common/paper.cpp:180
+msgid "PRC Envelope #3 Rotated 176 x 125 mm"
+msgstr "Busta Rep. Pop. Cinese #3 ruotata 176 x 125 mm"
+
+#: ../src/common/paper.cpp:181
+msgid "PRC Envelope #4 Rotated 208 x 110 mm"
+msgstr "Busta Rep. Pop. Cinese #4 ruotata 208 x 110 mm"
+
+#: ../src/common/paper.cpp:182
+msgid "PRC Envelope #5 Rotated 220 x 110 mm"
+msgstr "Busta Rep. Pop. Cinese #5 ruotata 220 x 110 mm"
+
+#: ../src/common/paper.cpp:183
+msgid "PRC Envelope #6 Rotated 230 x 120 mm"
+msgstr "Busta Rep. Pop. Cinese #6 ruotata 230 x 120 mm"
+
+#: ../src/common/paper.cpp:184
+msgid "PRC Envelope #7 Rotated 230 x 160 mm"
+msgstr "Busta Rep. Pop. Cinese #7 ruotata 230 x 160 mm"
+
+#: ../src/common/paper.cpp:185
+msgid "PRC Envelope #8 Rotated 309 x 120 mm"
+msgstr "Busta Rep. Pop. Cinese #8 ruotata 309 x 120 mm"
+
+#: ../src/common/paper.cpp:186
+msgid "PRC Envelope #9 Rotated 324 x 229 mm"
+msgstr "Busta Rep. Pop. Cinese #9 ruotata 324 x 229 mm"
+
+#: ../src/common/paper.cpp:187
+msgid "PRC Envelope #10 Rotated 458 x 324 mm"
+msgstr "Busta Rep. Pop. Cinese #10 ruotata 458 x 324 mm"
+
+#: ../src/common/paper.cpp:192
+msgid "A0 sheet, 841 x 1189 mm"
+msgstr "Foglio A0, 841 x 1189 mm"
+
+#: ../src/common/paper.cpp:193
+msgid "A1 sheet, 594 x 841 mm"
+msgstr "Foglio A1, 594 x 841 mm"
+
+#: ../src/common/preferencescmn.cpp:37
+msgid "General"
+msgstr "Generale"
+
+#: ../src/common/preferencescmn.cpp:40
+msgid "Advanced"
+msgstr "Avanzate"
+
+#: ../src/common/prntbase.cpp:245
+msgid "Generic PostScript"
+msgstr "PostScript generico"
+
+#: ../src/common/prntbase.cpp:259
+msgid "Ready"
+msgstr "Pronto"
+
+#: ../src/common/prntbase.cpp:331
+msgid "Printing Error"
+msgstr "Errore durante la stampa"
+
+#: ../src/common/prntbase.cpp:413 ../src/common/prntbase.cpp:1597
+#: ../src/generic/prntdlgg.cpp:135 ../src/generic/prntdlgg.cpp:149
+#: ../src/gtk/print.cpp:628 ../src/gtk/print.cpp:646
+msgid "Print"
+msgstr "Stampa"
+
+#: ../src/common/prntbase.cpp:471 ../src/generic/prntdlgg.cpp:809
+msgid "Page setup"
+msgstr "Impostazioni pagina"
+
+#: ../src/common/prntbase.cpp:525
+msgid "Please wait while printing..."
+msgstr "Stampa..."
+
+#: ../src/common/prntbase.cpp:529
+msgid "Document:"
+msgstr "Documento:"
+
+#: ../src/common/prntbase.cpp:532
+msgid "Progress:"
+msgstr "Progresso:"
+
+#: ../src/common/prntbase.cpp:533
+msgid "Preparing"
+msgstr "Preparazione"
+
+#: ../src/common/prntbase.cpp:552
+#, c-format
+msgid "Printing page %d"
+msgstr "Stampa pagina %d"
+
+#: ../src/common/prntbase.cpp:557
+#, c-format
+msgid "Printing page %d of %d"
+msgstr "Stampa pagina %d di %d"
+
+#: ../src/common/prntbase.cpp:560
+#, c-format
+msgid " (copy %d of %d)"
+msgstr " (copia %d di %d)"
+
+#: ../src/common/prntbase.cpp:1604
+msgid "First page"
+msgstr "Prima pagina"
+
+#: ../src/common/prntbase.cpp:1609 ../src/html/helpwnd.cpp:659
+msgid "Previous page"
+msgstr "Pagina precedente"
+
+#: ../src/common/prntbase.cpp:1623 ../src/html/helpwnd.cpp:660
+msgid "Next page"
+msgstr "Pagina successiva"
+
+#: ../src/common/prntbase.cpp:1628
+msgid "Last page"
+msgstr "Ultima pagina"
+
+#: ../src/common/prntbase.cpp:1636 ../src/common/stockitem.cpp:215
+msgid "Zoom Out"
+msgstr "Riduci"
+
+#: ../src/common/prntbase.cpp:1650 ../src/common/stockitem.cpp:214
+msgid "Zoom In"
+msgstr "Ingrandisci"
+
+#: ../src/common/prntbase.cpp:1656 ../src/common/stockitem.cpp:153
+#: ../src/generic/logg.cpp:553 ../src/univ/themes/win32.cpp:3752
+msgid "&Close"
+msgstr "&Chiudi"
+
+#: ../src/common/prntbase.cpp:2085
+msgid "Could not start document preview."
+msgstr "Impossibile visualizzare l'anteprima del documento."
+
+#: ../src/common/prntbase.cpp:2085 ../src/common/prntbase.cpp:2129
+#: ../src/common/prntbase.cpp:2137
+msgid "Print Preview Failure"
+msgstr "Errore durante l'anteprima di stampa"
+
+#: ../src/common/prntbase.cpp:2129 ../src/common/prntbase.cpp:2137
+msgid "Sorry, not enough memory to create a preview."
+msgstr "Memoria insufficiente per la creazione di un'anteprima."
+
+#: ../src/common/prntbase.cpp:2144
+#, c-format
+msgid "Page %d of %d"
+msgstr "Pagina %d di %d"
+
+#: ../src/common/prntbase.cpp:2146
+#, c-format
+msgid "Page %d"
+msgstr "Pagina %d"
+
+#: ../src/common/regex.cpp:382 ../src/html/chm.cpp:348
+msgid "unknown error"
+msgstr "errore sconosciuto"
+
+#: ../src/common/regex.cpp:995
+#, c-format
+msgid "Invalid regular expression '%s': %s"
+msgstr "Espressione regolare '%s' non valida: %s"
+
+#: ../src/common/regex.cpp:1059
+#, c-format
+msgid "Failed to find match for regular expression: %s"
+msgstr "Impossibile trovare una corrispondenza per l'espressione regolare: %s"
+
+#: ../src/common/rendcmn.cpp:188
+#, c-format
+msgid "Renderer \"%s\" has incompatible version %d.%d and couldn't be loaded."
+msgstr ""
+"Il renderer \"%s\" ha una versione %d.%d che non è compatibile, quindi non è "
+"stato caricato."
+
+#: ../src/common/secretstore.cpp:162
+msgid "Not available for this platform"
+msgstr "Non disponibile per questa piattaforma"
+
+#: ../src/common/secretstore.cpp:183
+#, c-format
+msgid "Saving password for \"%s\" failed: %s."
+msgstr "Salvataggio password per \"%s\" non riuscito: %s."
+
+#: ../src/common/secretstore.cpp:205
+#, c-format
+msgid "Reading password for \"%s\" failed: %s."
+msgstr "Lettura della password per \"%s\" non riuscita: %s."
+
+#: ../src/common/secretstore.cpp:228
+#, c-format
+msgid "Deleting password for \"%s\" failed: %s."
+msgstr "Eliminazione fallita password per \"%s\": %s."
+
+#: ../src/common/selectdispatcher.cpp:254
+msgid "Failed to monitor I/O channels"
+msgstr "Impossibile monitorare canali I/O"
+
+#: ../src/common/sizer.cpp:3054 ../src/common/stockitem.cpp:195
+msgid "Save"
+msgstr "Salva"
+
+#: ../src/common/sizer.cpp:3056
+msgid "Don't Save"
+msgstr "Non salvare"
+
+#: ../src/common/socket.cpp:870
+msgid "Cannot initialize sockets"
+msgstr "Impossibile inizializzare socket"
+
+# The help menu is called just '?' on Italian versions of Windows
+#: ../src/common/stockitem.cpp:127
+msgctxt "standard Windows menu"
+msgid "&Help"
+msgstr "&Aiuto"
+
+#: ../src/common/stockitem.cpp:144
+msgid "&About"
+msgstr "Inform&azioni su"
+
+#: ../src/common/stockitem.cpp:144
+msgid "About"
+msgstr "Info su"
+
+#: ../src/common/stockitem.cpp:145
+msgid "Add"
+msgstr "Aggiungi"
+
+#: ../src/common/stockitem.cpp:146
+msgid "&Apply"
+msgstr "&Applica"
+
+#: ../src/common/stockitem.cpp:146
+msgid "Apply"
+msgstr "Applica"
+
+#: ../src/common/stockitem.cpp:147
+msgid "&Back"
+msgstr "&Indietro"
+
+#: ../src/common/stockitem.cpp:147
+msgid "Back"
+msgstr "Indietro"
+
+#: ../src/common/stockitem.cpp:148
+msgid "&Bold"
+msgstr "&Grassetto"
+
+#: ../src/common/stockitem.cpp:148 ../src/generic/fontdlgg.cpp:326
+#: ../src/richtext/richtextfontpage.cpp:354
+msgid "Bold"
+msgstr "Grassetto"
+
+#: ../src/common/stockitem.cpp:149
+msgid "&Bottom"
+msgstr "&Basso"
+
+#: ../src/common/stockitem.cpp:149 ../src/richtext/richtextsizepage.cpp:287
+msgid "Bottom"
+msgstr "Basso"
+
+#: ../src/common/stockitem.cpp:150 ../src/generic/fontdlgg.cpp:462
+#: ../src/generic/fontdlgg.cpp:481 ../src/generic/wizard.cpp:415
+msgid "&Cancel"
+msgstr "&Annulla"
+
+#: ../src/common/stockitem.cpp:151
+msgid "&CD-ROM"
+msgstr "&CD-ROM"
+
+#: ../src/common/stockitem.cpp:151
+msgid "CD-ROM"
+msgstr "CD-ROM"
+
+#: ../src/common/stockitem.cpp:152
+msgid "&Clear"
+msgstr "&Azzera"
+
+#: ../src/common/stockitem.cpp:152
+msgid "Clear"
+msgstr "Azzera"
+
+#: ../src/common/stockitem.cpp:153 ../src/generic/dbgrptg.cpp:93
+#: ../src/generic/progdlgg.cpp:778 ../src/html/helpdlg.cpp:86
+#: ../src/msw/progdlg.cpp:209 ../src/msw/progdlg.cpp:890
+#: ../src/richtext/richtextstyledlg.cpp:272
+#: ../src/richtext/richtextsymboldlg.cpp:448
+msgid "Close"
+msgstr "Chiudi"
+
+#: ../src/common/stockitem.cpp:154
+msgid "&Convert"
+msgstr "&Converti"
+
+#: ../src/common/stockitem.cpp:154
+msgid "Convert"
+msgstr "Converti"
+
+#: ../src/common/stockitem.cpp:155 ../src/msw/textctrl.cpp:2884
+#: ../src/osx/textctrl_osx.cpp:653 ../src/richtext/richtextctrl.cpp:331
+msgid "&Copy"
+msgstr "&Copia"
+
+#: ../src/common/stockitem.cpp:155 ../src/stc/stc_i18n.cpp:18
+msgid "Copy"
+msgstr "Copia"
+
+#: ../src/common/stockitem.cpp:156 ../src/msw/textctrl.cpp:2883
+#: ../src/osx/textctrl_osx.cpp:652 ../src/richtext/richtextctrl.cpp:330
+msgid "Cu&t"
+msgstr "Ta&glia"
+
+#: ../src/common/stockitem.cpp:156 ../src/stc/stc_i18n.cpp:17
+msgid "Cut"
+msgstr "Taglia"
+
+#: ../src/common/stockitem.cpp:157 ../src/msw/textctrl.cpp:2886
+#: ../src/osx/textctrl_osx.cpp:655 ../src/richtext/richtextctrl.cpp:333
+#: ../src/richtext/richtexttabspage.cpp:137
+msgid "&Delete"
+msgstr "&Elimina"
+
+#: ../src/common/stockitem.cpp:157 ../src/richtext/richtextbuffer.cpp:8266
+#: ../src/stc/stc_i18n.cpp:20
+msgid "Delete"
+msgstr "Elimina"
+
+#: ../src/common/stockitem.cpp:158
+msgid "&Down"
+msgstr "&Giù"
+
+#: ../src/common/stockitem.cpp:158 ../src/generic/fdrepdlg.cpp:148
+msgid "Down"
+msgstr "Giù"
+
+#: ../src/common/stockitem.cpp:159
+msgid "&Edit"
+msgstr "&Modifica"
+
+#: ../src/common/stockitem.cpp:159
+msgid "Edit"
+msgstr "Modifica"
+
+#: ../src/common/stockitem.cpp:160
+msgid "&Execute"
+msgstr "&Esegui"
+
+#: ../src/common/stockitem.cpp:160
+msgid "Execute"
+msgstr "Esegui"
+
+#: ../src/common/stockitem.cpp:161
+msgid "&Quit"
+msgstr "&Esci"
+
+#: ../src/common/stockitem.cpp:161
+msgid "Quit"
+msgstr "Esci"
+
+#: ../src/common/stockitem.cpp:162
+msgid "&File"
+msgstr "&File"
+
+#: ../src/common/stockitem.cpp:162
+msgid "File"
+msgstr "File"
+
+#: ../src/common/stockitem.cpp:163
+msgid "&Find..."
+msgstr "&Trova..."
+
+#: ../src/common/stockitem.cpp:163
+msgid "Find..."
+msgstr "Trova..."
+
+#: ../src/common/stockitem.cpp:164
+msgid "&First"
+msgstr "&Primo"
+
+#: ../src/common/stockitem.cpp:164
+msgid "First"
+msgstr "Primo"
+
+#: ../src/common/stockitem.cpp:165
+msgid "&Floppy"
+msgstr "&Floppy"
+
+#: ../src/common/stockitem.cpp:165
+msgid "Floppy"
+msgstr "Floppy"
+
+#: ../src/common/stockitem.cpp:166
+msgid "&Forward"
+msgstr "&Avanti"
+
+#: ../src/common/stockitem.cpp:166
+msgid "Forward"
+msgstr "Avanti"
+
+#: ../src/common/stockitem.cpp:167
+msgid "&Harddisk"
+msgstr "&Disco fisso"
+
+#: ../src/common/stockitem.cpp:167
+msgid "Harddisk"
+msgstr "Disco fisso"
+
+#: ../src/common/stockitem.cpp:168 ../src/generic/wizard.cpp:418
+#: ../src/osx/cocoa/menu.mm:225 ../src/richtext/richtextstyledlg.cpp:298
+#: ../src/richtext/richtextsymboldlg.cpp:451
+msgid "&Help"
+msgstr "&Aiuto"
+
+#: ../src/common/stockitem.cpp:169
+msgid "&Home"
+msgstr "&Home"
+
+#: ../src/common/stockitem.cpp:169
+msgid "Home"
+msgstr "Home"
+
+#: ../src/common/stockitem.cpp:170
+msgid "Indent"
+msgstr "Indenta"
+
+#: ../src/common/stockitem.cpp:171
+msgid "&Index"
+msgstr "&Indice"
+
+#: ../src/common/stockitem.cpp:171 ../src/html/helpwnd.cpp:510
+msgid "Index"
+msgstr "Indice"
+
+#: ../src/common/stockitem.cpp:172
+msgid "&Info"
+msgstr "&Info"
+
+#: ../src/common/stockitem.cpp:172
+msgid "Info"
+msgstr "Info"
+
+#: ../src/common/stockitem.cpp:173
+msgid "&Italic"
+msgstr "&Corsivo"
+
+#: ../src/common/stockitem.cpp:173 ../src/generic/fontdlgg.cpp:322
+#: ../src/richtext/richtextfontpage.cpp:350
+msgid "Italic"
+msgstr "Corsivo"
+
+#: ../src/common/stockitem.cpp:174
+msgid "&Jump to"
+msgstr "&Vai a"
+
+#: ../src/common/stockitem.cpp:174
+msgid "Jump to"
+msgstr "Vai a"
+
+#: ../src/common/stockitem.cpp:175
+msgid "Centered"
+msgstr "Centrato"
+
+#: ../src/common/stockitem.cpp:176
+msgid "Justified"
+msgstr "Giustificato"
+
+#: ../src/common/stockitem.cpp:177
+msgid "Align Left"
+msgstr "Allinea a destra"
+
+#: ../src/common/stockitem.cpp:178
+msgid "Align Right"
+msgstr "Allinea a destra"
+
+#: ../src/common/stockitem.cpp:179
+msgid "&Last"
+msgstr "&Ultimo"
+
+#: ../src/common/stockitem.cpp:179
+msgid "Last"
+msgstr "Ultimo"
+
+#: ../src/common/stockitem.cpp:180
+msgid "&Network"
+msgstr "&Rete"
+
+#: ../src/common/stockitem.cpp:180
+msgid "Network"
+msgstr "Rete"
+
+#: ../src/common/stockitem.cpp:181 ../src/richtext/richtexttabspage.cpp:131
+msgid "&New"
+msgstr "&Nuovo"
+
+#: ../src/common/stockitem.cpp:181
+msgid "New"
+msgstr "Nuovo"
+
+#: ../src/common/stockitem.cpp:182 ../src/msw/msgdlg.cpp:417
+msgid "&No"
+msgstr "&No"
+
+#: ../src/common/stockitem.cpp:183 ../src/generic/fontdlgg.cpp:467
+#: ../src/generic/fontdlgg.cpp:474
+msgid "&OK"
+msgstr "&OK"
+
+#: ../src/common/stockitem.cpp:184 ../src/generic/dbgrptg.cpp:341
+msgid "&Open..."
+msgstr "&Apri..."
+
+#: ../src/common/stockitem.cpp:184
+msgid "Open..."
+msgstr "Apri..."
+
+#: ../src/common/stockitem.cpp:185 ../src/msw/textctrl.cpp:2885
+#: ../src/osx/textctrl_osx.cpp:654 ../src/richtext/richtextctrl.cpp:332
+msgid "&Paste"
+msgstr "Incoll&a"
+
+#: ../src/common/stockitem.cpp:185 ../src/richtext/richtextctrl.cpp:3484
+#: ../src/stc/stc_i18n.cpp:19
+msgid "Paste"
+msgstr "Incolla"
+
+#: ../src/common/stockitem.cpp:186
+msgid "&Preferences"
+msgstr "&Preferenze"
+
+#: ../src/common/stockitem.cpp:186 ../src/osx/cocoa/preferences.mm:304
+msgid "Preferences"
+msgstr "Preferenze"
+
+#: ../src/common/stockitem.cpp:187
+msgid "Print previe&w..."
+msgstr "Ante&prima di stampa..."
+
+#: ../src/common/stockitem.cpp:187
+msgid "Print preview..."
+msgstr "Anteprima di stampa..."
+
+#: ../src/common/stockitem.cpp:188
+msgid "&Print..."
+msgstr "&Stampa..."
+
+#: ../src/common/stockitem.cpp:188
+msgid "Print..."
+msgstr "Stampa..."
+
+#: ../src/common/stockitem.cpp:189 ../src/richtext/richtextctrl.cpp:337
+#: ../src/richtext/richtextctrl.cpp:5479
+msgid "&Properties"
+msgstr "&Proprietà"
+
+#: ../src/common/stockitem.cpp:189
+msgid "Properties"
+msgstr "Proprietà"
+
+#: ../src/common/stockitem.cpp:190 ../src/stc/stc_i18n.cpp:16
+msgid "Redo"
+msgstr "Ripeti"
+
+#: ../src/common/stockitem.cpp:191
+msgid "Refresh"
+msgstr "Aggiorna"
+
+#: ../src/common/stockitem.cpp:192
+msgid "Remove"
+msgstr "Rimuovi"
+
+#: ../src/common/stockitem.cpp:193
+msgid "Rep&lace..."
+msgstr "&Sostituisci..."
+
+#: ../src/common/stockitem.cpp:193
+msgid "Replace..."
+msgstr "Sostituisci..."
+
+#: ../src/common/stockitem.cpp:194
+msgid "Revert to Saved"
+msgstr "Ritorna alla versione salvata"
+
+#: ../src/common/stockitem.cpp:196 ../src/generic/logg.cpp:549
+msgid "Save &As..."
+msgstr "Salva con n&ome..."
+
+#: ../src/common/stockitem.cpp:196
+msgid "Save As..."
+msgstr "Salva come..."
+
+#: ../src/common/stockitem.cpp:197 ../src/msw/textctrl.cpp:2888
+#: ../src/osx/textctrl_osx.cpp:657 ../src/richtext/richtextctrl.cpp:335
+msgid "Select &All"
+msgstr "&Seleziona tutto"
+
+#: ../src/common/stockitem.cpp:197 ../src/stc/stc_i18n.cpp:21
+msgid "Select All"
+msgstr "Seleziona tutto"
+
+#: ../src/common/stockitem.cpp:198
+msgid "&Color"
+msgstr "&Colore"
+
+#: ../src/common/stockitem.cpp:198
+msgid "Color"
+msgstr "Colore"
+
+#: ../src/common/stockitem.cpp:199
+msgid "&Font"
+msgstr "&Font"
+
+#: ../src/common/stockitem.cpp:199 ../src/richtext/richtextformatdlg.cpp:336
+msgid "Font"
+msgstr "Font"
+
+#: ../src/common/stockitem.cpp:200
+msgid "&Ascending"
+msgstr "&Ascendente"
+
+#: ../src/common/stockitem.cpp:200
+msgid "Ascending"
+msgstr "Ascendente"
+
+#: ../src/common/stockitem.cpp:201
+msgid "&Descending"
+msgstr "&Discendente"
+
+#: ../src/common/stockitem.cpp:201
+msgid "Descending"
+msgstr "Discendente"
+
+#: ../src/common/stockitem.cpp:202
+msgid "&Spell Check"
+msgstr "&Controllo ortografia"
+
+#: ../src/common/stockitem.cpp:202
+msgid "Spell Check"
+msgstr "Controllo ortografia"
+
+#: ../src/common/stockitem.cpp:203
+msgid "&Stop"
+msgstr "&Stop"
+
+#: ../src/common/stockitem.cpp:203
+msgid "Stop"
+msgstr "Stop"
+
+#: ../src/common/stockitem.cpp:204 ../src/richtext/richtextfontpage.cpp:274
+msgid "&Strikethrough"
+msgstr "&Barrato"
+
+#: ../src/common/stockitem.cpp:204
+msgid "Strikethrough"
+msgstr "Barrato"
+
+#: ../src/common/stockitem.cpp:205
+msgid "&Top"
+msgstr "Al&to"
+
+#: ../src/common/stockitem.cpp:205 ../src/richtext/richtextsizepage.cpp:285
+#: ../src/richtext/richtextsizepage.cpp:289
+msgid "Top"
+msgstr "Alto"
+
+#: ../src/common/stockitem.cpp:206
+msgid "Undelete"
+msgstr "Annulla elimina"
+
+#: ../src/common/stockitem.cpp:207 ../src/generic/fontdlgg.cpp:437
+msgid "&Underline"
+msgstr "&Sottolinea"
+
+#: ../src/common/stockitem.cpp:207
+msgid "Underline"
+msgstr "Sottolineato"
+
+#: ../src/common/stockitem.cpp:208 ../src/stc/stc_i18n.cpp:15
+msgid "Undo"
+msgstr "Annulla"
+
+#: ../src/common/stockitem.cpp:209
+msgid "&Unindent"
+msgstr "&Rimuovi indentazione"
+
+#: ../src/common/stockitem.cpp:209
+msgid "Unindent"
+msgstr "Rimuovi indentazione"
+
+#: ../src/common/stockitem.cpp:210
+msgid "&Up"
+msgstr "&Su"
+
+#: ../src/common/stockitem.cpp:210 ../src/generic/fdrepdlg.cpp:148
+msgid "Up"
+msgstr "Su"
+
+#: ../src/common/stockitem.cpp:211 ../src/msw/msgdlg.cpp:417
+msgid "&Yes"
+msgstr "&Si"
+
+#: ../src/common/stockitem.cpp:212
+msgid "&Actual Size"
+msgstr "Dimensione &attuale"
+
+#: ../src/common/stockitem.cpp:212
+msgid "Actual Size"
+msgstr "Dimensione attuale"
+
+#: ../src/common/stockitem.cpp:213
+msgid "Zoom to &Fit"
+msgstr "Adatta alla &finestra"
+
+#: ../src/common/stockitem.cpp:213
+msgid "Zoom to Fit"
+msgstr "Adatta alla finestra"
+
+#: ../src/common/stockitem.cpp:214
+msgid "Zoom &In"
+msgstr "&Ingrandisci"
+
+#: ../src/common/stockitem.cpp:215
+msgid "Zoom &Out"
+msgstr "&Rimpicciolisci"
+
+#: ../src/common/stockitem.cpp:262
+msgid "Show about dialog"
+msgstr "Visualizza la finestra di informazioni sul programma"
+
+#: ../src/common/stockitem.cpp:263
+msgid "Copy selection"
+msgstr "Copia selezione"
+
+#: ../src/common/stockitem.cpp:264
+msgid "Cut selection"
+msgstr "Taglia selezione"
+
+#: ../src/common/stockitem.cpp:265
+msgid "Delete selection"
+msgstr "Elimina selezione"
+
+#: ../src/common/stockitem.cpp:266
+msgid "Find in document"
+msgstr "Trova in un documento"
+
+#: ../src/common/stockitem.cpp:267
+msgid "Find and replace in document"
+msgstr "Trova e sostituisci nel documento"
+
+#: ../src/common/stockitem.cpp:268
+msgid "Paste selection"
+msgstr "Incolla la selezione"
+
+#: ../src/common/stockitem.cpp:269
+msgid "Quit this program"
+msgstr "Esci dal programma"
+
+#: ../src/common/stockitem.cpp:270
+msgid "Redo last action"
+msgstr "Ripristina l'ultima azione"
+
+#: ../src/common/stockitem.cpp:271
+msgid "Undo last action"
+msgstr "Annulla l'ultima azione"
+
+#: ../src/common/stockitem.cpp:272
+msgid "Create new document"
+msgstr "Crea nuovo documento"
+
+#: ../src/common/stockitem.cpp:273
+msgid "Open an existing document"
+msgstr "Apri un documento esistente"
+
+#: ../src/common/stockitem.cpp:274
+msgid "Close current document"
+msgstr "Chiudi il documento attuale"
+
+#: ../src/common/stockitem.cpp:275
+msgid "Save current document"
+msgstr "Salva il documento attuale"
+
+#: ../src/common/stockitem.cpp:276
+msgid "Save current document with a different filename"
+msgstr "Salva il documento con un nome differente"
+
+#: ../src/common/strconv.cpp:2324
+#, c-format
+msgid "Conversion to charset '%s' doesn't work."
+msgstr "La conversione nella codifica '%s' non funziona."
+
+#: ../src/common/tarstrm.cpp:352 ../src/common/tarstrm.cpp:375
+#: ../src/common/tarstrm.cpp:406 ../src/generic/progdlgg.cpp:373
+msgid "unknown"
+msgstr "sconosciuto"
+
+#: ../src/common/tarstrm.cpp:774
+msgid "incomplete header block in tar"
+msgstr "blocco di intestazione errato nel file tar"
+
+#: ../src/common/tarstrm.cpp:798
+msgid "checksum failure reading tar header block"
+msgstr "checksum errato durante la lettura dell'intestazione del file TAR"
+
+#: ../src/common/tarstrm.cpp:971
+msgid "invalid data in extended tar header"
+msgstr "dati errati nell'intestazione estesa del file TAR"
+
+#: ../src/common/tarstrm.cpp:981 ../src/common/tarstrm.cpp:1003
+#: ../src/common/tarstrm.cpp:1477 ../src/common/tarstrm.cpp:1499
+msgid "tar entry not open"
+msgstr "voce del file TAR non aperta"
+
+#: ../src/common/tarstrm.cpp:1023
+msgid "unexpected end of file"
+msgstr "fine del file non attesa"
+
+#: ../src/common/tarstrm.cpp:1297
+#, c-format
+msgid "%s did not fit the tar header for entry '%s'"
+msgstr "%s non ha trovato l'intestazione del file tar per l'elemento '%s'"
+
+#: ../src/common/tarstrm.cpp:1359
+msgid "incorrect size given for tar entry"
+msgstr "valore della dimensione errato per una voce del file TAR"
+
+#: ../src/common/textbuf.cpp:232
+#, c-format
+msgid "'%s' is probably a binary buffer."
+msgstr "'%s' probabilmente è un buffer binario."
+
+#: ../src/common/textcmn.cpp:1006 ../src/richtext/richtextctrl.cpp:3053
+msgid "File couldn't be loaded."
+msgstr "Impossibile caricare il file."
+
+#: ../src/common/textfile.cpp:95
+#, c-format
+msgid "Failed to read text file \"%s\"."
+msgstr "Impossibile leggere il file di testo \"%s\"."
+
+#: ../src/common/textfile.cpp:160
+#, c-format
+msgid "can't write buffer '%s' to disk."
+msgstr "impossibile scrivere su disco il buffer '%s'."
+
+#: ../src/common/time.cpp:212
+msgid "Failed to get the local system time"
+msgstr "Impossibile ottenere l'ora locale di sistema"
+
+#: ../src/common/time.cpp:279
+msgid "wxGetTimeOfDay failed."
+msgstr "wxGetTimeOfDay fallita."
+
+#: ../src/common/translation.cpp:929
+#, c-format
+msgid "'%s' is not a valid message catalog."
+msgstr "'%s' non è un catalogo di messaggi valido."
+
+#: ../src/common/translation.cpp:954
+msgid "Invalid message catalog."
+msgstr "Messaggio catalogo non valido."
+
+#: ../src/common/translation.cpp:1013
+#, c-format
+msgid "Failed to parse Plural-Forms: '%s'"
+msgstr "Impossibile analizzare forme plurali: '%s'"
+
+#: ../src/common/translation.cpp:1723
+#, c-format
+msgid "using catalog '%s' from '%s'."
+msgstr "utilizzato catalogo '%s' in '%s'."
+
+#: ../src/common/translation.cpp:1816
+#, c-format
+msgid "Resource '%s' is not a valid message catalog."
+msgstr "La risorsa '%s' non è un catalogo di messaggi valido."
+
+#: ../src/common/translation.cpp:1865
+msgid "Couldn't enumerate translations"
+msgstr "Impossibile enumerare la traduzione"
+
+#: ../src/common/utilscmn.cpp:1145
+msgid "No default application configured for HTML files."
+msgstr "Nessuna applicazione predefinita configurata per i file HTML."
+
+#: ../src/common/utilscmn.cpp:1190
+#, c-format
+msgid "Failed to open URL \"%s\" in default browser."
+msgstr "Impossibile aprire URL '%s' nel browser predefinito."
+
+#: ../src/common/valtext.cpp:144
+msgid "Validation conflict"
+msgstr "Conflitto durante la validazione"
+
+#: ../src/common/valtext.cpp:186
+msgid "Required information entry is empty."
+msgstr "Campo informazioni richieste vuoto."
+
+#: ../src/common/valtext.cpp:188
+#, c-format
+msgid "'%s' is one of the invalid strings"
+msgstr "'%s' è una delle stringhe non valide"
+
+#: ../src/common/valtext.cpp:190
+#, c-format
+msgid "'%s' is not one of the valid strings"
+msgstr "'%s' non è una delle stringhe non valide"
+
+#: ../src/common/valtext.cpp:199
+#, c-format
+msgid "'%s' contains invalid character(s)"
+msgstr "'%s' contiene caratteri non validi"
+
+#: ../src/common/webrequest.cpp:139
+#, c-format
+msgid "Error: %s (%d)"
+msgstr "Errore: %s (%d)"
+
+#: ../src/common/webrequest.cpp:655
+#, fuzzy, c-format
+msgid ""
+"Not enough free disk space for download: %llu needed but only %llu available."
+msgstr "Spazio su disco insufficiente per il download."
+
+#: ../src/common/webrequest.cpp:669
+#, fuzzy, c-format
+msgid "Failed to create temporary file in %s"
+msgstr "Impossibile creare il nome per il file temporaneo"
+
+#: ../src/common/webrequest_curl.cpp:1106
+msgid "libcurl could not be initialized"
+msgstr "libcurl non può essere inizializzato"
+
+#: ../src/common/webview.cpp:392
+msgid "RunScriptAsync not supported"
+msgstr "RunScriptAsync non supportata"
+
+#: ../src/common/webview.cpp:403 ../src/msw/webview_ie.cpp:1073
+#, c-format
+msgid "Error running JavaScript: %s"
+msgstr "Errore durante l'esecuzione del file JavaScript: %s"
+
+#: ../src/common/webview_chromium.cpp:858
+#, fuzzy, c-format
+msgid "Failed to set proxy \"%s\": %s"
+msgstr "Impossibile creare la cartella \"%s\""
+
+#: ../src/common/webview_chromium.cpp:989
+msgid ""
+"Chromium can't be used because libcef.so wasn't loaded early enough; please "
+"relink the application or use LD_PRELOAD to load it earlier."
+msgstr ""
+
+#: ../src/common/webview_chromium.cpp:1108
+#, fuzzy
+msgid "Could not initialize Chromium"
+msgstr "Impossibile inizializzare OLE"
+
+#: ../src/common/webview_chromium.cpp:1616
+msgid "Show DevTools"
+msgstr ""
+
+#: ../src/common/webview_chromium.cpp:1617
+#, fuzzy
+msgid "Close DevTools"
+msgstr "Chiudi &tutto"
+
+#: ../src/common/webview_chromium.cpp:1623
+msgid "Inspect"
+msgstr ""
+
+#: ../src/common/wincmn.cpp:1628
+msgid "This platform does not support background transparency."
+msgstr "La piattaforma non supporta la trasparenza sfondo."
+
+#: ../src/common/wincmn.cpp:2097
+msgid "Could not transfer data to window"
+msgstr "Impossibile trasferire i dati verso la finestra"
+
+#: ../src/common/windowid.cpp:240
+msgid "Out of window IDs.  Recommend shutting down application."
+msgstr ""
+"ID fuori della finestra. \n"
+"Ti suggeriamo di chiudere l'applicazione."
+
+#: ../src/common/xpmdecod.cpp:678
+msgid "XPM: incorrect header format!"
+msgstr "XPM: errore nel formato dell'intestazione!"
+
+#: ../src/common/xpmdecod.cpp:703
+#, c-format
+msgid "XPM: incorrect colour description in line %d"
+msgstr "XPM: definizione di colore scorretta alla riga %d"
+
+#: ../src/common/xpmdecod.cpp:715 ../src/common/xpmdecod.cpp:724
+#, c-format
+msgid "XPM: malformed colour definition '%s' at line %d!"
+msgstr "XPM: definizione di colore '%s' malformata alla riga %d!"
+
+#: ../src/common/xpmdecod.cpp:754
+msgid "XPM: no colors left to use for mask!"
+msgstr "XPM: nessun colore restante da usare per la amschera!"
+
+#: ../src/common/xpmdecod.cpp:781
+#, c-format
+msgid "XPM: truncated image data at line %d!"
+msgstr "XPM: i dati dell'immagine sono troncati alla riga %d!"
+
+#: ../src/common/xpmdecod.cpp:795
+msgid "XPM: Malformed pixel data!"
+msgstr "XPM: dati pixel malformati!"
+
+#: ../src/common/xti.cpp:492
+msgid "Illegal Parameter Count for Create Method"
+msgstr "Parameter Count per Create Method non consentito"
+
+#: ../src/common/xti.cpp:504
+msgid "Illegal Parameter Count for ConstructObject Method"
+msgstr "Parameter Count per ConstructObject non consentito"
+
+#: ../src/common/xtistrm.cpp:161
+#, c-format
+msgid "Create Parameter %s not found in declared RTTI Parameters"
+msgstr "Create Parameter %s non trovato nella dichiarazione dei parametri RTTI"
+
+#: ../src/common/xtistrm.cpp:290
+msgid "Illegal Object Class (Non-wxEvtHandler) as Event Source"
+msgstr "Object Class (Non-wxEvtHandler) come Event Source non consentito"
+
+#: ../src/common/xtistrm.cpp:313 ../src/common/xtixml.cpp:345
+#: ../src/common/xtixml.cpp:498
+msgid "Type must have enum - long conversion"
+msgstr "Tipo deve avere enumeratore - convertito a long"
+
+#: ../src/common/xtistrm.cpp:400 ../src/common/xtistrm.cpp:415
+msgid "Invalid or Null Object ID passed to GetObjectClassInfo"
+msgstr "ID oggetto non valida o nulla passata a GetObjectClassInfo"
+
+#: ../src/common/xtistrm.cpp:405
+msgid "Unknown Object passed to GetObjectClassInfo"
+msgstr "Oggetto non conosciuto passato a GetObjectClassInfo"
+
+#: ../src/common/xtistrm.cpp:420
+msgid "Already Registered Object passed to SetObjectClassInfo"
+msgstr "Oggetto già registrato passato a SetObjectClassInfo"
+
+#: ../src/common/xtistrm.cpp:430
+msgid "Invalid or Null Object ID passed to HasObjectClassInfo"
+msgstr "ID oggetto non valida o nulla passata a HasObjectClassInfo"
+
+#: ../src/common/xtistrm.cpp:460
+msgid "Passing a already registered object to SetObject"
+msgstr "Passato un oggetto già registrato a SetObject"
+
+#: ../src/common/xtistrm.cpp:471
+msgid "Passing an unknown object to GetObject"
+msgstr "Passato un oggetto sconosciuto a GetObject"
+
+#: ../src/common/xtixml.cpp:229
+msgid "Forward hrefs are not supported"
+msgstr "Forward hrefs non supportata"
+
+#: ../src/common/xtixml.cpp:247
+#, c-format
+msgid "unknown class %s"
+msgstr "classe %s sconosciuta"
+
+#: ../src/common/xtixml.cpp:253
+msgid "objects cannot have XML Text Nodes"
+msgstr "l'oggetto non può avere nodi XML Text"
+
+#: ../src/common/xtixml.cpp:258
+msgid "Objects must have an id attribute"
+msgstr "L'oggetto deve avere un ID ed un attributo"
+
+#: ../src/common/xtixml.cpp:267
+#, c-format
+msgid "Doubly used id : %d"
+msgstr "Doppio utilizzo di id : %d"
+
+#: ../src/common/xtixml.cpp:316
+#, c-format
+msgid "Unknown Property %s"
+msgstr "Proprietà %s sconosciuta"
+
+#: ../src/common/xtixml.cpp:407
+msgid "A non empty collection must consist of 'element' nodes"
+msgstr "Una collezione non vuota deve contenere nodi 'element'"
+
+#: ../src/common/xtixml.cpp:478
+msgid "incorrect event handler string, missing dot"
+msgstr "gestore evento stringa non corretto - manca punto"
+
+#: ../src/common/zipstrm.cpp:559
+msgid "can't re-initialize zlib deflate stream"
+msgstr "impossibile reinizializzare il flusso zlib di compressione"
+
+#: ../src/common/zipstrm.cpp:584
+msgid "can't re-initialize zlib inflate stream"
+msgstr "impossibile reinizializzare il flusso di decompressione zlib"
+
+#: ../src/common/zipstrm.cpp:1023
+msgid "Ignoring malformed extra data record, ZIP file may be corrupted"
+msgstr ""
+"Ignorando il record di dati extra non valido, il file ZIP potrebbe essere "
+"danneggiato"
+
+#: ../src/common/zipstrm.cpp:1502
+msgid "assuming this is a multi-part zip concatenated"
+msgstr "si assume che queste siano più parti di un archivio ZIP concatenato"
+
+#: ../src/common/zipstrm.cpp:1664
+msgid "invalid zip file"
+msgstr "file ZIP non valido"
+
+#: ../src/common/zipstrm.cpp:1723
+msgid "can't find central directory in zip"
+msgstr "impossibile trovare il catalogo all'interno del file ZIP"
+
+#: ../src/common/zipstrm.cpp:1812
+msgid "error reading zip central directory"
+msgstr "errore durante la lettura del catalogo del file ZIP"
+
+#: ../src/common/zipstrm.cpp:1916
+msgid "error reading zip local header"
+msgstr "errore durante la lettura dell'intestazione ZIP locale"
+
+#: ../src/common/zipstrm.cpp:1964
+msgid "bad zipfile offset to entry"
+msgstr "offset scorretto per il file nell'archivio ZIP"
+
+#: ../src/common/zipstrm.cpp:2031
+msgid "stored file length not in Zip header"
+msgstr "la lunghezza del file non è memorizzata nell'intestazione del file ZIP"
+
+#: ../src/common/zipstrm.cpp:2045 ../src/common/zipstrm.cpp:2362
+msgid "unsupported Zip compression method"
+msgstr "metodo di compressione non supportato per il file ZIP"
+
+#: ../src/common/zipstrm.cpp:2126
+#, c-format
+msgid "reading zip stream (entry %s): bad length"
+msgstr "lunghezza errata durante la lettura del file %s dal file ZIP"
+
+#: ../src/common/zipstrm.cpp:2131
+#, c-format
+msgid "reading zip stream (entry %s): bad crc"
+msgstr "lettura stream zip (elemento %s): CRC errato"
+
+#: ../src/common/zipstrm.cpp:2578
+#, c-format
+msgid "error writing zip entry '%s': file too large without ZIP64"
+msgstr ""
+"errore durante la scrittura del file '%s': file troppo grande senza ZIP64"
+
+#: ../src/common/zipstrm.cpp:2585
+#, c-format
+msgid "error writing zip entry '%s': bad crc or length"
+msgstr "errore durante la scrittura del file '%s': CRC o lunghezza errati"
+
+#: ../src/common/zstream.cpp:155 ../src/common/zstream.cpp:315
+msgid "Gzip not supported by this version of zlib"
+msgstr "Gzip non è supportato da questa versione della libreria zlib"
+
+#: ../src/common/zstream.cpp:182
+msgid "Can't initialize zlib inflate stream."
+msgstr "Impossibile inizializzare il flusso di compressione zlib."
+
+#: ../src/common/zstream.cpp:241
+msgid "Can't read inflate stream: unexpected EOF in underlying stream."
+msgstr ""
+"Impossibile leggere il flusso di decompressione: fine del file inattesa nel "
+"flusso di ingresso."
+
+#: ../src/common/zstream.cpp:248 ../src/common/zstream.cpp:423
+#, c-format
+msgid "zlib error %d"
+msgstr "errore zlib %d"
+
+#: ../src/common/zstream.cpp:249
+#, c-format
+msgid "Can't read from inflate stream: %s"
+msgstr "Impossibile leggere dal flusso di decompressione: %s"
+
+#: ../src/common/zstream.cpp:343
+msgid "Can't initialize zlib deflate stream."
+msgstr "Impossibile inizializzare il flusso zlib di decompressione."
+
+#: ../src/common/zstream.cpp:424
+#, c-format
+msgid "Can't write to deflate stream: %s"
+msgstr "Impossibile scrivere nel flusso di compressione: %s"
+
+#: ../src/dfb/bitmap.cpp:633 ../src/dfb/bitmap.cpp:667
+#, c-format
+msgid "No bitmap handler for type %d defined."
+msgstr "Nessun gestore bitmap definito per il tipo %d."
+
+#: ../src/dfb/evtloop.cpp:99
+msgid "Failed to read event from DirectFB pipe"
+msgstr "Impossibile leggere evento dalla coda DirectFB"
+
+#: ../src/dfb/evtloop.cpp:171
+msgid "Failed to switch DirectFB pipe to non-blocking mode"
+msgstr "Impossibile commutare coda DirectFB in modalità non bloccante"
+
+#: ../src/dfb/fontmgr.cpp:171
+#, c-format
+msgid "no fonts found in %s, using builtin font"
+msgstr "nessuna font trovata in %s - uso font integrata"
+
+#: ../src/dfb/fontmgr.cpp:177
+msgid "Default font"
+msgstr "Font predefinita"
+
+#: ../src/dfb/fontmgr.cpp:195
+#, c-format
+msgid "Fonts index file %s disappeared while loading fonts."
+msgstr "Il file indice font %s è sparito durante il caricamento delle font."
+
+#: ../src/dfb/wrapdfb.cpp:60
+#, c-format
+msgid "DirectFB error %d occurred."
+msgstr "Si è verificato un errore DirectFB %d."
+
+#: ../src/generic/aboutdlgg.cpp:69
+msgid "Developed by "
+msgstr "Sviluppato da "
+
+#: ../src/generic/aboutdlgg.cpp:72
+msgid "Documentation by "
+msgstr "Documentazione di "
+
+#: ../src/generic/aboutdlgg.cpp:75
+msgid "Graphics art by "
+msgstr "Grafica di "
+
+#: ../src/generic/aboutdlgg.cpp:78
+msgid "Translations by "
+msgstr "Tradotto da "
+
+#: ../src/generic/aboutdlgg.cpp:133 ../src/osx/cocoa/aboutdlg.mm:83
+msgid "Version "
+msgstr "Versione "
+
+#. TRANSLATORS: %s is application name
+#: ../src/generic/aboutdlgg.cpp:146 ../src/msw/aboutdlg.cpp:60
+#, c-format
+msgid "About %s"
+msgstr "Info su %s"
+
+#: ../src/generic/aboutdlgg.cpp:181
+msgid "License"
+msgstr "Licenza"
+
+#: ../src/generic/aboutdlgg.cpp:184
+msgid "Developers"
+msgstr "Sviluppatori"
+
+#: ../src/generic/aboutdlgg.cpp:188
+msgid "Documentation writers"
+msgstr "Autori documentazione"
+
+#: ../src/generic/aboutdlgg.cpp:192
+msgid "Artists"
+msgstr "Artisti"
+
+#: ../src/generic/aboutdlgg.cpp:196
+msgid "Translators"
+msgstr "Traduttori"
+
+#: ../src/generic/animateg.cpp:125
+msgid "No handler found for animation type."
+msgstr "Gestore non disponibile per questo formato animazione."
+
+#: ../src/generic/animateg.cpp:133
+#, c-format
+msgid "No animation handler for type %ld defined."
+msgstr "Gestore non disponibile per il formato immagine %ld."
+
+#: ../src/generic/animateg.cpp:145
+#, c-format
+msgid "Animation file is not of type %ld."
+msgstr "Il file animazione non è di tipo %ld."
+
+#: ../src/generic/colrdlgg.cpp:154 ../src/gtk/colordlg.cpp:47
+msgid "Choose colour"
+msgstr "Scegli un colore"
+
+#: ../src/generic/colrdlgg.cpp:357
+msgid "Red:"
+msgstr "Rosso:"
+
+#: ../src/generic/colrdlgg.cpp:360
+msgid "Green:"
+msgstr "Verde:"
+
+#: ../src/generic/colrdlgg.cpp:363
+msgid "Blue:"
+msgstr "Blu:"
+
+#: ../src/generic/colrdlgg.cpp:372
+msgid "Opacity:"
+msgstr "Opacità:"
+
+#: ../src/generic/colrdlgg.cpp:384
+msgid "Add to custom colours"
+msgstr "Aggiungi ai colori personalizzati"
+
+#: ../src/generic/creddlgg.cpp:56
+msgid "Username:"
+msgstr "Nome utente:"
+
+#: ../src/generic/creddlgg.cpp:63
+msgid "Password:"
+msgstr "Password:"
+
+#. TRANSLATORS: Name of Boolean true value
+#: ../src/generic/datavgen.cpp:1178
+msgid "true"
+msgstr "vero"
+
+#. TRANSLATORS: Name of Boolean false value
+#: ../src/generic/datavgen.cpp:1180
+msgid "false"
+msgstr "falso"
+
+#: ../src/generic/datavgen.cpp:6897
+#, c-format
+msgid "Row %i"
+msgstr "Colonna %i"
+
+#. TRANSLATORS: Action for manipulating a tree control
+#: ../src/generic/datavgen.cpp:6987
+msgid "Collapse"
+msgstr "Riduci"
+
+#. TRANSLATORS: Action for manipulating a tree control
+#: ../src/generic/datavgen.cpp:6990
+msgid "Expand"
+msgstr "Espandi"
+
+#. TRANSLATORS: Name of data view control and number of rows
+#: ../src/generic/datavgen.cpp:7011
+#, c-format
+msgid "%s (%d items)"
+msgstr "%s (%d elementi)"
+
+#: ../src/generic/datavgen.cpp:7062
+#, c-format
+msgid "Column %u"
+msgstr "Colonna %u"
+
+#. TRANSLATORS: Keystroke for manipulating a tree control
+#: ../src/generic/datavgen.cpp:7131 ../src/richtext/richtextbulletspage.cpp:189
+#: ../src/richtext/richtextbulletspage.cpp:192
+#: ../src/richtext/richtextbulletspage.cpp:193
+#: ../src/richtext/richtextliststylepage.cpp:252
+#: ../src/richtext/richtextliststylepage.cpp:255
+#: ../src/richtext/richtextliststylepage.cpp:256
+#: ../src/richtext/richtextsizepage.cpp:248
+msgid "Left"
+msgstr "Sinistra"
+
+#. TRANSLATORS: Keystroke for manipulating a tree control
+#: ../src/generic/datavgen.cpp:7134 ../src/richtext/richtextbulletspage.cpp:191
+#: ../src/richtext/richtextliststylepage.cpp:254
+#: ../src/richtext/richtextsizepage.cpp:249
+msgid "Right"
+msgstr "Destra"
+
+#: ../src/generic/datectlg.cpp:90
+#, c-format
+msgid ""
+"\"%s\" is not in the expected date format, please enter it as e.g. \"%s\"."
+msgstr ""
+
+#: ../src/generic/datectlg.cpp:94
+#, fuzzy
+msgid "Invalid date"
+msgstr "PCX: immagine non valida"
+
+#: ../src/generic/dbgrptg.cpp:159
+#, c-format
+msgid "Open file \"%s\""
+msgstr "Apri il file \"%s\""
+
+#: ../src/generic/dbgrptg.cpp:170
+#, c-format
+msgid "Enter command to open file \"%s\":"
+msgstr "Specifica il comando per aprire il file \"%s\":"
+
+#: ../src/generic/dbgrptg.cpp:230
+msgid "Executable files (*.exe)|*.exe|"
+msgstr "File eseguibili (*.exe)|*.exe|"
+
+#: ../src/generic/dbgrptg.cpp:300
+#, c-format
+msgid "Debug report \"%s\""
+msgstr "Segnalazione di errore \"%s\""
+
+#: ../src/generic/dbgrptg.cpp:316
+msgid "A debug report has been generated in the directory\n"
+msgstr "È stata generata nella cartella una segnalazione di errore\n"
+
+#: ../src/generic/dbgrptg.cpp:317
+msgid "The following debug report will be generated\n"
+msgstr "Verrà generato il seguente rapporto di debug\n"
+
+#: ../src/generic/dbgrptg.cpp:321
+msgid ""
+"The report contains the files listed below. If any of these files contain "
+"private information,\n"
+"please uncheck them and they will be removed from the report.\n"
+msgstr ""
+"La segnalazione contiene i file elencati.\n"
+"Se qualcuno di questi file contenesse informazioni private, rimuovi il segno "
+"di spunta per prevenirne l'inclusione nella segnalazione.\n"
+
+#: ../src/generic/dbgrptg.cpp:323
+msgid ""
+"If you wish to suppress this debug report completely, please choose the "
+"\"Cancel\" button,\n"
+"but be warned that it may hinder improving the program, so if\n"
+"at all possible please do continue with the report generation.\n"
+msgstr ""
+"Se non desideri inviare una segnalazione di errore, scegli il pulsante "
+"\"Annulla\", anche se questo potrebbe ostacolare il miglioramento del "
+"programma.\n"
+"Ti invitiamo pertanto a continuare con la generazione della segnalazione.\n"
+"\n"
+
+#: ../src/generic/dbgrptg.cpp:325
+msgid "              Thank you and we're sorry for the inconvenience!\n"
+msgstr "              Grazie, e ci scusiamo per il disturbo!\n"
+
+#: ../src/generic/dbgrptg.cpp:333
+msgid "&Debug report preview:"
+msgstr "Anteprima &della segnalazione di errore:"
+
+#: ../src/generic/dbgrptg.cpp:339
+msgid "&View..."
+msgstr "&Visalizza..."
+
+#: ../src/generic/dbgrptg.cpp:359
+msgid "&Notes:"
+msgstr "&Note:"
+
+#: ../src/generic/dbgrptg.cpp:361
+msgid ""
+"If you have any additional information pertaining to this bug\n"
+"report, please enter it here and it will be joined to it:"
+msgstr ""
+"Se disponi di ulteriori informazioni relativamente a questo errore,\n"
+"inseriscile e verranno allegate:"
+
+#: ../src/generic/dcpsg.cpp:1627
+msgid "Cannot open file for PostScript printing!"
+msgstr "Impossibile aprire il file per la stampa PostScript!"
+
+#: ../src/generic/dirctrlg.cpp:402
+msgid "Computer"
+msgstr "Computer"
+
+#: ../src/generic/dirctrlg.cpp:404
+msgid "Sections"
+msgstr "Sezioni"
+
+#: ../src/generic/dirctrlg.cpp:482
+msgid "Home directory"
+msgstr "Cartella home"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/generic/dirctrlg.cpp:484 ../src/propgrid/advprops.cpp:811
+msgid "Desktop"
+msgstr "Desktop"
+
+#: ../src/generic/dirctrlg.cpp:528 ../src/generic/filectrlg.cpp:752
+msgid "Illegal directory name."
+msgstr "Nome cartella non valido."
+
+#: ../src/generic/dirctrlg.cpp:528 ../src/generic/dirctrlg.cpp:546
+#: ../src/generic/dirctrlg.cpp:557 ../src/generic/dirdlgg.cpp:317
+#: ../src/generic/filectrlg.cpp:638 ../src/generic/filectrlg.cpp:752
+#: ../src/generic/filectrlg.cpp:766 ../src/generic/filectrlg.cpp:782
+#: ../src/generic/filectrlg.cpp:1356 ../src/generic/filectrlg.cpp:1387
+#: ../src/generic/filedlgg.cpp:362 ../src/gtk/filedlg.cpp:76
+msgid "Error"
+msgstr "Errore"
+
+#: ../src/generic/dirctrlg.cpp:546 ../src/generic/filectrlg.cpp:766
+msgid "File name exists already."
+msgstr "Nome file esistente."
+
+#: ../src/generic/dirctrlg.cpp:557 ../src/generic/dirdlgg.cpp:317
+#: ../src/generic/filectrlg.cpp:638 ../src/generic/filectrlg.cpp:782
+msgid "Operation not permitted."
+msgstr "Operazione non permessa."
+
+#: ../src/generic/dirdlgg.cpp:107 ../src/generic/filedlgg.cpp:207
+msgid "Create new directory"
+msgstr "Crea nuova cartella"
+
+#: ../src/generic/dirdlgg.cpp:112 ../src/generic/filedlgg.cpp:203
+msgid "Go to home directory"
+msgstr "Vai alla cartella Home"
+
+#: ../src/generic/dirdlgg.cpp:143
+msgid "Show &hidden directories"
+msgstr "Visualizza &cartelle nascoste"
+
+#: ../src/generic/dirdlgg.cpp:196
+#, c-format
+msgid ""
+"The directory '%s' does not exist\n"
+"Create it now?"
+msgstr ""
+"La cartella '%s' non esiste.\n"
+"Vuoi crearla adesso?"
+
+#: ../src/generic/dirdlgg.cpp:198
+msgid "Directory does not exist"
+msgstr "Cartella non esistente"
+
+#: ../src/generic/dirdlgg.cpp:214
+#, c-format
+msgid ""
+"Failed to create directory '%s'\n"
+"(Do you have the required permissions?)"
+msgstr ""
+"Impossibile creare la cartella '%s'\n"
+"(Si dispone dei permessi necessari?)"
+
+#: ../src/generic/dirdlgg.cpp:216
+msgid "Error creating directory"
+msgstr "Errore nella creazione della cartella"
+
+#: ../src/generic/dirdlgg.cpp:281
+msgid "You cannot add a new directory to this section."
+msgstr "Impossibile aggiungere una nuova cartella a questa sezione."
+
+#: ../src/generic/dirdlgg.cpp:282
+msgid "Create directory"
+msgstr "Crea cartella"
+
+#: ../src/generic/dirdlgg.cpp:291 ../src/generic/dirdlgg.cpp:301
+#: ../src/generic/filectrlg.cpp:614 ../src/generic/filectrlg.cpp:623
+msgid "NewName"
+msgstr "NuovoNome"
+
+#: ../src/generic/editlbox.cpp:135
+msgid "Edit item"
+msgstr "Modifica elemento"
+
+#: ../src/generic/editlbox.cpp:143
+msgid "New item"
+msgstr "Nuova elemento"
+
+#: ../src/generic/editlbox.cpp:151
+msgid "Delete item"
+msgstr "Elimina elemento"
+
+#: ../src/generic/editlbox.cpp:159
+msgid "Move up"
+msgstr "Sposta verso il basso"
+
+#: ../src/generic/editlbox.cpp:164
+msgid "Move down"
+msgstr "Sposta verso il basso"
+
+#: ../src/generic/fdrepdlg.cpp:108
+msgid "Search for:"
+msgstr "Trova:"
+
+#: ../src/generic/fdrepdlg.cpp:120
+msgid "Replace with:"
+msgstr "Sostituisci con:"
+
+#: ../src/generic/fdrepdlg.cpp:140
+msgid "Whole word"
+msgstr "Parola intera"
+
+#: ../src/generic/fdrepdlg.cpp:143
+msgid "Match case"
+msgstr "&Maiuscole/minuscole"
+
+#: ../src/generic/fdrepdlg.cpp:156
+msgid "Search direction"
+msgstr "Direzione"
+
+#: ../src/generic/fdrepdlg.cpp:175
+msgid "&Replace"
+msgstr "&Sostituisci"
+
+#: ../src/generic/fdrepdlg.cpp:178
+msgid "Replace &all"
+msgstr "Sostituisci t&utto"
+
+#: ../src/generic/filectrlg.cpp:246 ../src/generic/filectrlg.cpp:269
+msgid "<DIR>"
+msgstr "<CARTELLA>"
+
+#: ../src/generic/filectrlg.cpp:248 ../src/generic/filectrlg.cpp:271
+msgid "<LINK>"
+msgstr "<LINK>"
+
+#: ../src/generic/filectrlg.cpp:250 ../src/generic/filectrlg.cpp:273
+msgid "<DRIVE>"
+msgstr "<UNITA'>"
+
+#: ../src/generic/filectrlg.cpp:275
+#, c-format
+msgid "%ld byte"
+msgid_plural "%ld bytes"
+msgstr[0] "%ld byte"
+msgstr[1] "%ld byte"
+
+#: ../src/generic/filectrlg.cpp:420
+msgid "Name"
+msgstr "Nome"
+
+#: ../src/generic/filectrlg.cpp:421 ../src/richtext/richtextformatdlg.cpp:361
+#: ../src/richtext/richtextsizepage.cpp:298
+msgid "Size"
+msgstr "Dimensione"
+
+#: ../src/generic/filectrlg.cpp:422
+msgid "Type"
+msgstr "Tipo"
+
+#: ../src/generic/filectrlg.cpp:423
+msgid "Modified"
+msgstr "Modificato"
+
+#: ../src/generic/filectrlg.cpp:426
+msgid "Permissions"
+msgstr "Permessi"
+
+#: ../src/generic/filectrlg.cpp:429
+msgid "Attributes"
+msgstr "Attributi"
+
+#: ../src/generic/filectrlg.cpp:936
+msgid "Current directory:"
+msgstr "Cartella attuale:"
+
+#: ../src/generic/filectrlg.cpp:979
+msgid "Show &hidden files"
+msgstr "Visualizza i &file nascosti"
+
+#: ../src/generic/filectrlg.cpp:1355
+msgid "Illegal file specification."
+msgstr "Specifica di file non valida."
+
+#: ../src/generic/filectrlg.cpp:1387
+msgid "Directory doesn't exist."
+msgstr "Cartella non esistente."
+
+#: ../src/generic/filedlgg.cpp:195
+msgid "View files as a list view"
+msgstr "Visualizza i file - elenco"
+
+#: ../src/generic/filedlgg.cpp:197
+msgid "View files as a detailed view"
+msgstr "Visalizza file - dettagli"
+
+#: ../src/generic/filedlgg.cpp:200
+msgid "Go to parent directory"
+msgstr "Cartella superiore"
+
+#: ../src/generic/filedlgg.cpp:351 ../src/gtk/filedlg.cpp:59
+#, c-format
+msgid "File '%s' already exists, do you really want to overwrite it?"
+msgstr ""
+"File '%s' già esistente. \n"
+"Vuoi sovrascriverlo?"
+
+#: ../src/generic/filedlgg.cpp:354 ../src/gtk/filedlg.cpp:62
+msgid "Confirm"
+msgstr "Conferma"
+
+#: ../src/generic/filedlgg.cpp:362 ../src/gtk/filedlg.cpp:75
+msgid "Please choose an existing file."
+msgstr "Segli un file esistente."
+
+#: ../src/generic/filepickerg.cpp:64
+msgid "..."
+msgstr "..."
+
+#: ../src/generic/fontdlgg.cpp:76 ../src/richtext/richtextformatdlg.cpp:519
+msgid "ABCDEFGabcdefg12345"
+msgstr "ABCDEFGabcdefg12345"
+
+#: ../src/generic/fontdlgg.cpp:315
+msgid "Roman"
+msgstr "Roman"
+
+#: ../src/generic/fontdlgg.cpp:316
+msgid "Decorative"
+msgstr "Decorativo"
+
+#: ../src/generic/fontdlgg.cpp:317
+msgid "Modern"
+msgstr "Modern"
+
+#: ../src/generic/fontdlgg.cpp:318
+msgid "Script"
+msgstr "Script"
+
+#: ../src/generic/fontdlgg.cpp:319
+msgid "Swiss"
+msgstr "Swiss"
+
+#: ../src/generic/fontdlgg.cpp:320
+msgid "Teletype"
+msgstr "Teletype"
+
+#: ../src/generic/fontdlgg.cpp:321 ../src/generic/fontdlgg.cpp:324
+msgid "Normal"
+msgstr "Normale"
+
+#: ../src/generic/fontdlgg.cpp:323
+msgid "Slant"
+msgstr "Slant"
+
+#: ../src/generic/fontdlgg.cpp:325
+msgid "Light"
+msgstr "Leggero"
+
+#: ../src/generic/fontdlgg.cpp:363
+msgid "&Font family:"
+msgstr "&Famiglia font:"
+
+#: ../src/generic/fontdlgg.cpp:367 ../src/generic/fontdlgg.cpp:369
+msgid "The font family."
+msgstr "La famiglia di font."
+
+#: ../src/generic/fontdlgg.cpp:374 ../src/richtext/richtextstylepage.cpp:105
+msgid "&Style:"
+msgstr "&Stile:"
+
+#: ../src/generic/fontdlgg.cpp:378 ../src/generic/fontdlgg.cpp:380
+msgid "The font style."
+msgstr "Lo stile della font."
+
+#: ../src/generic/fontdlgg.cpp:385
+msgid "&Weight:"
+msgstr "&Peso:"
+
+#: ../src/generic/fontdlgg.cpp:389 ../src/generic/fontdlgg.cpp:391
+msgid "The font weight."
+msgstr "Il peso della font."
+
+#: ../src/generic/fontdlgg.cpp:399
+msgid "C&olour:"
+msgstr "C&olore:"
+
+#: ../src/generic/fontdlgg.cpp:407 ../src/generic/fontdlgg.cpp:409
+msgid "The font colour."
+msgstr "Il colore della font."
+
+#: ../src/generic/fontdlgg.cpp:415
+msgid "&Point size:"
+msgstr "Dimensione &punto:"
+
+#: ../src/generic/fontdlgg.cpp:420 ../src/generic/fontdlgg.cpp:422
+#: ../src/generic/fontdlgg.cpp:426 ../src/generic/fontdlgg.cpp:428
+msgid "The font point size."
+msgstr "Il corpo della font."
+
+#: ../src/generic/fontdlgg.cpp:439 ../src/generic/fontdlgg.cpp:441
+msgid "Whether the font is underlined."
+msgstr "Sottolineato."
+
+#: ../src/generic/fontdlgg.cpp:448 ../src/html/helpwnd.cpp:1215
+msgid "Preview:"
+msgstr "Anteprima:"
+
+#: ../src/generic/fontdlgg.cpp:452 ../src/generic/fontdlgg.cpp:454
+msgid "Shows the font preview."
+msgstr "Visualizza l'anteprima della font."
+
+#: ../src/generic/fontdlgg.cpp:464 ../src/generic/fontdlgg.cpp:483
+msgid "Click to cancel the font selection."
+msgstr "Clic per annullare la selezione del font."
+
+#: ../src/generic/fontdlgg.cpp:469 ../src/generic/fontdlgg.cpp:471
+#: ../src/generic/fontdlgg.cpp:476 ../src/generic/fontdlgg.cpp:478
+msgid "Click to confirm the font selection."
+msgstr "Clic per confermare la selezione del font."
+
+#: ../src/generic/fontpickerg.cpp:50 ../src/gtk/fontdlg.cpp:77
+msgid "Choose font"
+msgstr "Carattere"
+
+#: ../src/generic/grid.cpp:6542
+msgid ""
+"Error copying grid to the clipboard. Either selected cells were not "
+"contiguous or no cell was selected."
+msgstr ""
+
+#: ../src/generic/grid.cpp:12739
+#, fuzzy
+msgid "Grid Corner"
+msgstr "Angolo"
+
+#: ../src/generic/grid.cpp:12741
+#, fuzzy, c-format
+msgid "Column %s Header"
+msgstr "Colonna %u"
+
+#: ../src/generic/grid.cpp:12743
+#, c-format
+msgid "Row %s Header"
+msgstr ""
+
+#: ../src/generic/grid.cpp:12745
+#, fuzzy, c-format
+msgid "Column %s: %s"
+msgstr "Colonna %u"
+
+#: ../src/generic/grid.cpp:12749
+#, fuzzy, c-format
+msgid "Row %s: %s"
+msgstr "Colonna %i"
+
+#: ../src/generic/grid.cpp:12753
+#, c-format
+msgid "Row %s, Column %s: %s"
+msgstr ""
+
+#: ../src/generic/helpext.cpp:257
+#, c-format
+msgid "Help directory \"%s\" not found."
+msgstr "Cartella \"%s\" della Guida non trovata."
+
+#: ../src/generic/helpext.cpp:265
+#, c-format
+msgid "Help file \"%s\" not found."
+msgstr "File della Guida \"%s\" non trovato."
+
+#: ../src/generic/helpext.cpp:284
+#, c-format
+msgid "Line %lu of map file \"%s\" has invalid syntax, skipped."
+msgstr ""
+"La riga %lu del file mappa \"%s\" è stata scartata in quanto scorretta."
+
+#: ../src/generic/helpext.cpp:292
+#, c-format
+msgid "No valid mappings found in the file \"%s\"."
+msgstr "Il file \"%s\" non contiene mappature valide."
+
+#: ../src/generic/helpext.cpp:435
+msgid "No entries found."
+msgstr "Voci non trovate."
+
+#: ../src/generic/helpext.cpp:444 ../src/generic/helpext.cpp:445
+msgid "Help Index"
+msgstr "Indice"
+
+#: ../src/generic/helpext.cpp:448
+msgid "Relevant entries:"
+msgstr "Voci pertinenti:"
+
+#: ../src/generic/helpext.cpp:449
+msgid "Entries found"
+msgstr "Trovati"
+
+#: ../src/generic/hyperlinkg.cpp:170
+msgid "&Copy URL"
+msgstr "&Copia URL"
+
+#: ../src/generic/infobar.cpp:119
+msgid "Hide this notification message."
+msgstr "Nascondi questo messaggio di notifica."
+
+#. TRANSLATORS: %s will be either the application name or "Application"
+#: ../src/generic/logg.cpp:257
+#, c-format
+msgid "%s Error"
+msgstr "Errore %s"
+
+#. TRANSLATORS: %s will be either the application name or "Application"
+#: ../src/generic/logg.cpp:263
+#, c-format
+msgid "%s Warning"
+msgstr "Avviso %s"
+
+#. TRANSLATORS: %s will be either the application name or "Application"
+#: ../src/generic/logg.cpp:273
+#, c-format
+msgid "%s Information"
+msgstr "Info %s"
+
+#: ../src/generic/logg.cpp:276
+msgid "Application"
+msgstr "Applicazione"
+
+#: ../src/generic/logg.cpp:549
+msgid "Save log contents to file"
+msgstr "Salva il registro su file"
+
+#: ../src/generic/logg.cpp:551
+msgid "C&lear"
+msgstr "A&zzera"
+
+#: ../src/generic/logg.cpp:551
+msgid "Clear the log contents"
+msgstr "Elimina il contenuto del registro"
+
+#: ../src/generic/logg.cpp:553
+msgid "Close this window"
+msgstr "Chiudi questa finestra"
+
+#: ../src/generic/logg.cpp:554
+msgid "&Log"
+msgstr "&Registro"
+
+#: ../src/generic/logg.cpp:610 ../src/generic/logg.cpp:992
+msgid "Can't save log contents to file."
+msgstr "Impossibile salvare il contenuto del registro su file."
+
+#: ../src/generic/logg.cpp:613
+#, c-format
+msgid "Log saved to the file '%s'."
+msgstr "Registro salvato nel file '%s'."
+
+#: ../src/generic/logg.cpp:719
+msgid "&Details"
+msgstr "&Dettagli"
+
+#: ../src/generic/logg.cpp:972
+msgid "Failed to copy dialog contents to the clipboard."
+msgstr "Impossibile copiare contenuto finestra di dialogo negli Appunti."
+
+#: ../src/generic/logg.cpp:1022
+#, c-format
+msgid "Append log to file '%s' (choosing [No] will overwrite it)?"
+msgstr ""
+"Vuoi aggiungere il registro al file '%s' (scegli [No] per sovrascriverlo)?"
+
+#: ../src/generic/logg.cpp:1024
+msgid "Question"
+msgstr "Domanda"
+
+#: ../src/generic/logg.cpp:1038
+msgid "invalid message box return value"
+msgstr "il riquadro di dialogo ha ritornato un valore non valido"
+
+#: ../src/generic/notifmsgg.cpp:129
+msgid "Notice"
+msgstr "Nota"
+
+#: ../src/generic/preferencesg.cpp:118
+#, c-format
+msgid "%s Preferences"
+msgstr "Preferenze %s"
+
+#: ../src/generic/printps.cpp:143
+msgid "Printing..."
+msgstr "Stampa..."
+
+#: ../src/generic/printps.cpp:160 ../src/gtk/print.cpp:1076
+#: ../src/msw/printwin.cpp:235
+msgid "Could not start printing."
+msgstr "Impossibile avviare la stampa."
+
+#: ../src/generic/printps.cpp:183
+#, c-format
+msgid "Printing page %d..."
+msgstr "Stampa pagina %d..."
+
+#: ../src/generic/prntdlgg.cpp:171
+msgid "Printer options"
+msgstr "Opzioni stampante"
+
+#: ../src/generic/prntdlgg.cpp:176
+msgid "Print to File"
+msgstr "Stampa su file"
+
+#: ../src/generic/prntdlgg.cpp:179
+msgid "Setup..."
+msgstr "Configurazione..."
+
+#: ../src/generic/prntdlgg.cpp:187
+msgid "Printer:"
+msgstr "Stampante:"
+
+#: ../src/generic/prntdlgg.cpp:195
+msgid "Status:"
+msgstr "Stato:"
+
+#: ../src/generic/prntdlgg.cpp:206
+msgid "All"
+msgstr "Tutto"
+
+#: ../src/generic/prntdlgg.cpp:207
+msgid "Pages"
+msgstr "Pagine"
+
+#: ../src/generic/prntdlgg.cpp:215
+msgid "Print Range"
+msgstr "Intervallo stampa"
+
+#: ../src/generic/prntdlgg.cpp:229
+msgid "From:"
+msgstr "Da:"
+
+#: ../src/generic/prntdlgg.cpp:233
+msgid "To:"
+msgstr "Per:"
+
+#: ../src/generic/prntdlgg.cpp:238
+msgid "Copies:"
+msgstr "Copie:"
+
+#: ../src/generic/prntdlgg.cpp:288
+msgid "PostScript file"
+msgstr "File PostScript"
+
+#: ../src/generic/prntdlgg.cpp:439
+msgid "Print Setup"
+msgstr "Impostazioni di stampa"
+
+#: ../src/generic/prntdlgg.cpp:483
+msgid "Printer"
+msgstr "Stampante"
+
+#: ../src/generic/prntdlgg.cpp:501
+msgid "Default printer"
+msgstr "Stampante predefinita"
+
+#: ../src/generic/prntdlgg.cpp:595 ../src/generic/prntdlgg.cpp:782
+#: ../src/generic/prntdlgg.cpp:822 ../src/generic/prntdlgg.cpp:835
+#: ../src/generic/prntdlgg.cpp:1031 ../src/generic/prntdlgg.cpp:1036
+msgid "Paper size"
+msgstr "Dimensione foglio"
+
+#: ../src/generic/prntdlgg.cpp:604 ../src/generic/prntdlgg.cpp:847
+msgid "Portrait"
+msgstr "Verticale"
+
+#: ../src/generic/prntdlgg.cpp:605 ../src/generic/prntdlgg.cpp:848
+msgid "Landscape"
+msgstr "Orizzontale"
+
+#: ../src/generic/prntdlgg.cpp:607 ../src/generic/prntdlgg.cpp:849
+msgid "Orientation"
+msgstr "Orientamento"
+
+#: ../src/generic/prntdlgg.cpp:610
+msgid "Options"
+msgstr "Opzioni"
+
+#: ../src/generic/prntdlgg.cpp:612
+msgid "Print in colour"
+msgstr "Stampa a colori"
+
+#: ../src/generic/prntdlgg.cpp:621
+msgid "Print spooling"
+msgstr "Coda di stampa"
+
+#: ../src/generic/prntdlgg.cpp:623
+msgid "Printer command:"
+msgstr "Comando stampante:"
+
+#: ../src/generic/prntdlgg.cpp:631
+msgid "Printer options:"
+msgstr "Opzioni stampante:"
+
+#: ../src/generic/prntdlgg.cpp:860
+msgid "Left margin (mm):"
+msgstr "Margine sinistro (mm):"
+
+#: ../src/generic/prntdlgg.cpp:861
+msgid "Top margin (mm):"
+msgstr "Margine superiore (mm):"
+
+#: ../src/generic/prntdlgg.cpp:872
+msgid "Right margin (mm):"
+msgstr "Margine destro (mm):"
+
+#: ../src/generic/prntdlgg.cpp:873
+msgid "Bottom margin (mm):"
+msgstr "Margine inferiore (mm):"
+
+#: ../src/generic/prntdlgg.cpp:896
+msgid "Printer..."
+msgstr "Stampante..."
+
+#: ../src/generic/progdlgg.cpp:246
+msgid "&Skip"
+msgstr "&Salta"
+
+#: ../src/generic/progdlgg.cpp:347 ../src/generic/progdlgg.cpp:626
+msgid "Unknown"
+msgstr "Sconosciuta"
+
+#: ../src/generic/progdlgg.cpp:451 ../src/msw/progdlg.cpp:526
+msgid "Done."
+msgstr "Completato."
+
+#: ../src/generic/srchctlg.cpp:55 ../src/gtk/srchctrl.cpp:206
+#: ../src/html/helpwnd.cpp:530 ../src/html/helpwnd.cpp:545
+msgid "Search"
+msgstr "Cerca"
+
+#: ../src/generic/tabg.cpp:1026
+msgid "Could not find tab for id"
+msgstr "Impossibile trovare l'etichetta per l'id"
+
+#: ../src/generic/tipdlg.cpp:136
+msgid "Tips not available, sorry!"
+msgstr "Suggerimenti non disponibili!"
+
+#: ../src/generic/tipdlg.cpp:197
+msgid "Tip of the Day"
+msgstr "Suggerimento del giorno"
+
+#: ../src/generic/tipdlg.cpp:207
+msgid "Did you know..."
+msgstr "Lo sapevi che..."
+
+#: ../src/generic/tipdlg.cpp:232
+msgid "&Show tips at startup"
+msgstr "Vi&sualizza suggerimenti all'avvio"
+
+#: ../src/generic/tipdlg.cpp:236
+msgid "&Next Tip"
+msgstr "&Suggerimento successivo"
+
+#: ../src/generic/wizard.cpp:411
+msgid "&Next >"
+msgstr "&Avanti >"
+
+#: ../src/generic/wizard.cpp:412
+msgid "&Finish"
+msgstr "&Fine"
+
+#: ../src/generic/wizard.cpp:420
+msgid "< &Back"
+msgstr "< &Indietro"
+
+#: ../src/gtk/aboutdlg.cpp:204
+msgid "translator-credits"
+msgstr "ringraziamenti traduttore"
+
+#: ../src/gtk/app.cpp:517
+msgid ""
+"WARNING: using XIM input method is unsupported and may result in problems "
+"with input handling and flickering. Consider unsetting GTK_IM_MODULE or "
+"setting to \"ibus\"."
+msgstr ""
+"ATTENZIONE: l'uso del metodo sorgente XIM non è supportato e potrebbe "
+"causare problemi con la gestione della sorgente e lo sfarfallio.\n"
+"Prendi in considerazione la disimpostazione di GTK_IM_MODULE o "
+"l'impostazione su \"ibus\"."
+
+#: ../src/gtk/app.cpp:569
+msgid "Unable to initialize GTK+, is DISPLAY set properly?"
+msgstr "Impossibile inzializzare GTK+, DISPLAY impostato correttamente?"
+
+#: ../src/gtk/filedlg.cpp:89 ../src/gtk/filepicker.cpp:255
+#, c-format
+msgid "Changing current directory to \"%s\" failed"
+msgstr "Impossibile modificare la cartella attuale a \"%s\""
+
+#: ../src/gtk/font.cpp:548
+msgid ""
+"Using private fonts is not supported on this system: Pango library is too "
+"old, 1.38 or later required."
+msgstr ""
+"L'uso di font private non è supportato in questo sistema: la libreria Pango "
+"è troppo vecchia, è richiesta la versione 1.38 o successiva."
+
+#: ../src/gtk/font.cpp:558
+msgid "Failed to create font configuration object."
+msgstr "Impossibile creare l'oggetto di configurazione della font."
+
+#: ../src/gtk/font.cpp:568
+#, c-format
+msgid "Failed to add custom font \"%s\"."
+msgstr "Impossibile aggiungere la font personalizzata \"%s\"."
+
+#: ../src/gtk/font.cpp:576
+msgid "Failed to register font configuration using private fonts."
+msgstr ""
+"Impossibile registrare la configurazione della font usando le font private."
+
+#: ../src/gtk/glcanvas.cpp:117 ../src/gtk/glcanvas.cpp:132
+msgid "Fatal Error"
+msgstr "Errore fatale"
+
+#: ../src/gtk/glcanvas.cpp:117
+msgid ""
+"This program wasn't compiled with EGL support required under Wayland, "
+"either\n"
+"install EGL libraries and rebuild or run it under X11 backend by setting\n"
+"environment variable GDK_BACKEND=x11 before starting your program."
+msgstr ""
+"Anche questo programma non è stato compilato con il supporto EGL richiesto "
+"da Wayland\n"
+"Installa le librerie EGL e ricompilalo o eseguilo sotto il back-end X11 "
+"impostando\n"
+"prima di avviare il programma la variabile di ambiente GDK_BACKEND=x11."
+
+#: ../src/gtk/glcanvas.cpp:132
+msgid ""
+"wxGLCanvas is only supported on Wayland and X11 currently.  You may be able "
+"to\n"
+"work around this by setting environment variable GDK_BACKEND=x11 before\n"
+"starting your program."
+msgstr ""
+"wxGLCanvas è attualmente supportato solo in Wayland e X11.\n"
+"Potresti essere in grado di aggirare questo problema impostando prima di "
+"avviare il programma la variabile di ambiente GDK_BACKEND=x11."
+
+#: ../src/gtk/mdi.cpp:433
+msgid "MDI child"
+msgstr "Figlio MDI"
+
+#: ../src/gtk/power.cpp:188
+#, fuzzy, c-format
+msgid "Failed to open D-Bus connection to the login manager: %s"
+msgstr "Impossibile creare la connessione al server '%s' sull'argomento '%s'"
+
+#: ../src/gtk/power.cpp:214
+#, fuzzy
+msgid "wxWidgets application"
+msgstr "Nascondi applicazione"
+
+#: ../src/gtk/power.cpp:226
+msgid "Application needs to keep running"
+msgstr ""
+
+#: ../src/gtk/power.cpp:233
+msgid "Clean up before suspend"
+msgstr ""
+
+#: ../src/gtk/power.cpp:259
+#, fuzzy, c-format
+msgid "Failed to inhibit sleep: %s"
+msgstr "Impossibile inizializzare connessione dialup: %s"
+
+#: ../src/gtk/power.cpp:265
+msgid "Unexpected response to D-Bus \"Inhibit\" request."
+msgstr ""
+
+#: ../src/gtk/print.cpp:218
+msgid "Custom size"
+msgstr "Dimensione personalizzata"
+
+#: ../src/gtk/print.cpp:752
+#, fuzzy, c-format
+msgid "Error while printing: %s"
+msgstr "Errore durante la stampa: "
+
+#: ../src/gtk/print.cpp:816
+msgid "Page Setup"
+msgstr "Impostazioni pagina"
+
+#: ../src/gtk/webview_webkit.cpp:932
+msgid "Retrieving JavaScript script output is not supported with WebKit v1"
+msgstr ""
+"Il recupero della dell'output dello script JavaScript non è supportato con "
+"WebKit v1"
+
+#: ../src/gtk/webview_webkit2.cpp:1098
+msgid ""
+"Setting proxy is not supported by WebKit, at least version 2.16 is required."
+msgstr ""
+
+#: ../src/gtk/webview_webkit2.cpp:1104
+msgid "This program was compiled without support for setting WebKit proxy."
+msgstr ""
+
+#: ../src/gtk/window.cpp:6289
+msgid ""
+"GTK+ installed on this machine is too old to support screen compositing, "
+"please install GTK+ 2.12 or later."
+msgstr ""
+"GTK+ installato su questo computer è troppo vecchio per supportare "
+"composizione schermo. \n"
+"Installa GTK+ 2.12 o versione superiore."
+
+#: ../src/gtk/window.cpp:6307
+msgid ""
+"Compositing not supported by this system, please enable it in your Window "
+"Manager."
+msgstr ""
+"Composizione non supportata da questo sistema. \n"
+"Abilitala nel tuo gestore finestra."
+
+#: ../src/gtk/window.cpp:6318
+msgid ""
+"This program was compiled with a too old version of GTK+, please rebuild "
+"with GTK+ 2.12 or newer."
+msgstr ""
+"Questo programma è stato compilato con una versione troppo vecchia di GTK+.\n"
+"Ricompila con GTK+ 2.12 o versione superiore."
+
+#: ../src/html/chm.cpp:138
+#, c-format
+msgid "Failed to open CHM archive '%s'."
+msgstr "Impossibile aprire l'archivio CHM '%s'."
+
+#: ../src/html/chm.cpp:270
+#, c-format
+msgid "Could not extract %s into %s: %s"
+msgstr "Impossibile estrarre %s in %s: %s"
+
+#: ../src/html/chm.cpp:324
+msgid "no error"
+msgstr "nessun errore"
+
+#: ../src/html/chm.cpp:326
+msgid "bad arguments to library function"
+msgstr "funzione di libreria richiamata con argomento errato"
+
+#: ../src/html/chm.cpp:328
+msgid "error opening file"
+msgstr "errore nell'apertura file"
+
+#: ../src/html/chm.cpp:330
+msgid "read error"
+msgstr "errore di lettura"
+
+#: ../src/html/chm.cpp:332
+msgid "write error"
+msgstr "errore di scrittura"
+
+#: ../src/html/chm.cpp:334
+msgid "seek error"
+msgstr "errore nel riposizionamento"
+
+#: ../src/html/chm.cpp:338
+msgid "bad signature"
+msgstr "firma errata"
+
+#: ../src/html/chm.cpp:340
+msgid "error in data format"
+msgstr "errore nel formato dei dati"
+
+#: ../src/html/chm.cpp:342
+msgid "checksum error"
+msgstr "errore checksum"
+
+#: ../src/html/chm.cpp:344
+msgid "compression error"
+msgstr "errore di compressione"
+
+#: ../src/html/chm.cpp:346
+msgid "decompression error"
+msgstr "errore di decompressione"
+
+#: ../src/html/chm.cpp:437
+#, c-format
+msgid "Could not locate file '%s'."
+msgstr "Impossibile trovare il file '%s'."
+
+#: ../src/html/chm.cpp:711
+#, c-format
+msgid "Could not create temporary file '%s'"
+msgstr "Impossibile creare il file temporaneo '%s'"
+
+#: ../src/html/chm.cpp:718
+#, c-format
+msgid "Extraction of '%s' into '%s' failed."
+msgstr "Estrazione di '%s' in '%s' fallita."
+
+#: ../src/html/chm.cpp:806 ../src/html/chm.cpp:863
+msgid "CHM handler currently supports only local files!"
+msgstr "Il gestore di file CHM supporta unicamente file locali!"
+
+#: ../src/html/chm.cpp:827
+msgid "Link contained '//', converted to absolute link."
+msgstr ""
+"Il collegamento conteneva '//', ed è stato convertito a un collegamento "
+"assoluto."
+
+#: ../src/html/helpctrl.cpp:59
+#, c-format
+msgid "Help: %s"
+msgstr "Aiuto: %s"
+
+#: ../src/html/helpctrl.cpp:155
+#, c-format
+msgid "Adding book %s"
+msgstr "Aggiunta del libro %s"
+
+#: ../src/html/helpdata.cpp:295
+#, c-format
+msgid "Cannot open contents file: %s"
+msgstr "Impossibile aprire il file sommario: %s"
+
+#: ../src/html/helpdata.cpp:309
+#, c-format
+msgid "Cannot open index file: %s"
+msgstr "Impossibile aprire il file indice: %s"
+
+#: ../src/html/helpdata.cpp:643
+msgid "noname"
+msgstr "senzanome"
+
+#: ../src/html/helpdata.cpp:652
+#, c-format
+msgid "Cannot open HTML help book: %s"
+msgstr "Impossibile aprire il libro di help HTML: %s"
+
+#: ../src/html/helpwnd.cpp:315
+msgid "Displays help as you browse the books on the left."
+msgstr "Visualizza la guida mentre sfogli i manuali sulla sinistra."
+
+#: ../src/html/helpwnd.cpp:411 ../src/html/helpwnd.cpp:1100
+#: ../src/html/helpwnd.cpp:1735
+msgid "(bookmarks)"
+msgstr "(segnalibri)"
+
+#: ../src/html/helpwnd.cpp:424
+msgid "Add current page to bookmarks"
+msgstr "Aggiungi la pagina attuale ai segnalibri"
+
+#: ../src/html/helpwnd.cpp:425
+msgid "Remove current page from bookmarks"
+msgstr "Rimuovi la pagina attuale dai segnalibri"
+
+#: ../src/html/helpwnd.cpp:470
+msgid "Contents"
+msgstr "Sommario"
+
+#: ../src/html/helpwnd.cpp:485
+msgid "Find"
+msgstr "Trova"
+
+#: ../src/html/helpwnd.cpp:487
+msgid "Show all"
+msgstr "Visualizza tutto"
+
+#: ../src/html/helpwnd.cpp:497
+msgid ""
+"Display all index items that contain given substring. Search is case "
+"insensitive."
+msgstr ""
+"Visualizza tutte le voci dell'indice contenenti un dato testo.\n"
+"La ricerca non distingue maiuscole e minuscole."
+
+#: ../src/html/helpwnd.cpp:498
+msgid "Show all items in index"
+msgstr "Visualizza tutti le voci dell'indice"
+
+#: ../src/html/helpwnd.cpp:528
+msgid "Case sensitive"
+msgstr "Maiuscole/minuscole"
+
+#: ../src/html/helpwnd.cpp:529
+msgid "Whole words only"
+msgstr "Solo parole intere"
+
+#: ../src/html/helpwnd.cpp:532
+msgid ""
+"Search contents of help book(s) for all occurrences of the text you typed "
+"above"
+msgstr ""
+"Cerca i contenuti nelle Guida/e per tutte le occorrenze del testo digitato "
+"di seguito"
+
+#: ../src/html/helpwnd.cpp:653
+msgid "Show/hide navigation panel"
+msgstr "Visualizza/nascondi la barra di navigazione"
+
+#: ../src/html/helpwnd.cpp:655
+msgid "Go back"
+msgstr "Indietro"
+
+#: ../src/html/helpwnd.cpp:656
+msgid "Go forward"
+msgstr "Avanti"
+
+#: ../src/html/helpwnd.cpp:658
+msgid "Go one level up in document hierarchy"
+msgstr "Livello superiore nella gerarchia di documenti"
+
+#: ../src/html/helpwnd.cpp:666 ../src/html/helpwnd.cpp:1547
+msgid "Open HTML document"
+msgstr "Apri un documento HTML"
+
+#: ../src/html/helpwnd.cpp:670
+msgid "Print this page"
+msgstr "Stampa questa pagina"
+
+#: ../src/html/helpwnd.cpp:674
+msgid "Display options dialog"
+msgstr "Visualizza riquadro di dialogo per le opzioni"
+
+#: ../src/html/helpwnd.cpp:795
+msgid "Please choose the page to display:"
+msgstr "Scegli la pagina da visualizzare:"
+
+#: ../src/html/helpwnd.cpp:796
+msgid "Help Topics"
+msgstr "Contenuti"
+
+#: ../src/html/helpwnd.cpp:852
+msgid "Searching..."
+msgstr "Ricerca..."
+
+#: ../src/html/helpwnd.cpp:853
+msgid "No matching page found yet"
+msgstr "Pagina corrispondente non ancora trovata"
+
+#: ../src/html/helpwnd.cpp:870
+#, c-format
+msgid "Found %i matches"
+msgstr "Trovate %i corrispondenze"
+
+#: ../src/html/helpwnd.cpp:958
+msgid "(Help)"
+msgstr "(Aiuto)"
+
+#: ../src/html/helpwnd.cpp:1026
+#, c-format
+msgid "%d of %lu"
+msgstr "%d di %lu"
+
+#: ../src/html/helpwnd.cpp:1028
+#, c-format
+msgid "%lu of %lu"
+msgstr "%lu di %lu"
+
+#: ../src/html/helpwnd.cpp:1047
+msgid "Search in all books"
+msgstr "Cerca in tutti i libri"
+
+#: ../src/html/helpwnd.cpp:1193
+msgid "Help Browser Options"
+msgstr "Opzioni del browser della Guida"
+
+#: ../src/html/helpwnd.cpp:1198
+msgid "Normal font:"
+msgstr "Carattere normale:"
+
+#: ../src/html/helpwnd.cpp:1199
+msgid "Fixed font:"
+msgstr "Font a corpo fisso:"
+
+#: ../src/html/helpwnd.cpp:1200
+msgid "Font size:"
+msgstr "Corpo:"
+
+#: ../src/html/helpwnd.cpp:1245
+msgid "font size"
+msgstr "corpo"
+
+#: ../src/html/helpwnd.cpp:1256
+msgid "Normal face<br>and <u>underlined</u>. "
+msgstr "Normale <br>e <u>sottolineato</u>. "
+
+#: ../src/html/helpwnd.cpp:1257
+msgid "<i>Italic face.</i> "
+msgstr "<i>Corsivo.</i> "
+
+#: ../src/html/helpwnd.cpp:1258
+msgid "<b>Bold face.</b> "
+msgstr "<b>Grassetto.</b> "
+
+#: ../src/html/helpwnd.cpp:1259
+msgid "<b><i>Bold italic face.</i></b><br>"
+msgstr "<b><i>Grassetto corsivo.</i></b><br>"
+
+#: ../src/html/helpwnd.cpp:1262
+msgid "Fixed size face.<br> <b>bold</b> <i>italic</i> "
+msgstr "Larghezza fissa.<br> <b>grassetto</b> <i>corsivo</i> "
+
+#: ../src/html/helpwnd.cpp:1263
+msgid "<b><i>bold italic <u>underlined</u></i></b><br>"
+msgstr "<b><i>grassetto corsivo <u>sottolineato</u></i></b><br>"
+
+#: ../src/html/helpwnd.cpp:1524
+msgid "Help Printing"
+msgstr "Stampa"
+
+#: ../src/html/helpwnd.cpp:1527
+msgid "Cannot print empty page."
+msgstr "Impossibile stampare una pagina vuota."
+
+#: ../src/html/helpwnd.cpp:1540
+msgid "HTML files (*.html;*.htm)|*.html;*.htm|"
+msgstr "File HTML (*.html;*.htm)|*.html;*.htm|"
+
+#: ../src/html/helpwnd.cpp:1541
+msgid "Help books (*.htb)|*.htb|Help books (*.zip)|*.zip|"
+msgstr "Libro Guida (*.htb)|*.htb|Libro Guida (*.zip)|*.zip|"
+
+#: ../src/html/helpwnd.cpp:1542
+msgid "HTML Help Project (*.hhp)|*.hhp|"
+msgstr "Progetto HTML Help (*.hhp)|*.hhp|"
+
+#: ../src/html/helpwnd.cpp:1544
+msgid "Compressed HTML Help file (*.chm)|*.chm|"
+msgstr "Guida HTML (*.chm)|*.chm|"
+
+#: ../src/html/helpwnd.cpp:1671
+#, c-format
+msgid "%i of %u"
+msgstr "%i di %u"
+
+#: ../src/html/helpwnd.cpp:1709
+#, c-format
+msgid "%u of %u"
+msgstr "%u di %u"
+
+#: ../src/html/htmlfilt.cpp:134
+#, c-format
+msgid "Cannot open HTML document: %s"
+msgstr "Impossibile aprire il documento HTML: %s"
+
+#: ../src/html/htmlwin.cpp:599
+msgid "Connecting..."
+msgstr "Connessione..."
+
+#: ../src/html/htmlwin.cpp:616
+#, c-format
+msgid "Unable to open requested HTML document: %s"
+msgstr "Impossibile aprire il documento HTML richiesto: %s"
+
+#: ../src/html/htmlwin.cpp:630
+msgid "Loading : "
+msgstr "Caricamento : "
+
+#: ../src/html/htmlwin.cpp:673
+msgid "Done"
+msgstr "Completato"
+
+#: ../src/html/htmlwin.cpp:723
+#, c-format
+msgid "HTML anchor %s does not exist."
+msgstr "Ancora HTML %s non esistente."
+
+#: ../src/html/htmlwin.cpp:1057
+#, c-format
+msgid "Copied to clipboard:\"%s\""
+msgstr "Copiato negli Appunti:\"%s\""
+
+#: ../src/html/htmprint.cpp:269
+msgid ""
+"This document doesn't fit on the page horizontally and will be truncated "
+"when it is printed."
+msgstr ""
+"Il documento non è adattato alla pagina in orizzontale e verrà troncato in "
+"fase di stampa."
+
+#: ../src/html/htmprint.cpp:285
+#, c-format
+msgid ""
+"The document \"%s\" doesn't fit on the page horizontally and will be "
+"truncated if printed.\n"
+"\n"
+"Would you like to proceed with printing it nevertheless?"
+msgstr ""
+"Il documento \"%s\" non è adattato alla pagina orizzontalmente e verrà "
+"troncato in fase di stampa.\n"
+"\n"
+"Vuoi procedere comunque con la stampa?"
+
+#: ../src/html/htmprint.cpp:296
+msgid ""
+"If possible, try changing the layout parameters to make the printout more "
+"narrow."
+msgstr ""
+"Se possibile prova a modificare i parametri del layout per rendere la stampa "
+"più stretta."
+
+#: ../src/html/htmprint.cpp:445
+msgid ": file does not exist!"
+msgstr ": il file non esiste!"
+
+#. TRANSLATORS: %s may be a document title.
+#: ../src/html/htmprint.cpp:717
+#, fuzzy, c-format
+msgid "%s Preview"
+msgstr " Anteprima"
+
+#: ../src/html/htmprint.cpp:755 ../src/richtext/richtextprint.cpp:618
+msgid ""
+"There was a problem during page setup: you may need to set a default printer."
+msgstr ""
+"Si è verificato un problema: potrebbe essere necessario impostare una "
+"stampante predefinita."
+
+#: ../src/msw/clipbrd.cpp:80
+msgid "Failed to open the clipboard."
+msgstr "Impossibile aprire gli Appunti."
+
+#: ../src/msw/clipbrd.cpp:101
+msgid "Failed to close the clipboard."
+msgstr "Impossibile chiudere gli Appunti."
+
+#: ../src/msw/clipbrd.cpp:113
+msgid "Failed to empty the clipboard."
+msgstr "Impossibile eliminare il contenuto degli appunti."
+
+#: ../src/msw/clipbrd.cpp:284
+msgid "Failed to put data on the clipboard"
+msgstr "Impossibile mettere dati negli Appunti"
+
+#: ../src/msw/clipbrd.cpp:326
+msgid "Failed to get data from the clipboard"
+msgstr "Impossibile ottenere i dati dagli appunti"
+
+#: ../src/msw/clipbrd.cpp:363
+msgid "Failed to retrieve the supported clipboard formats"
+msgstr "Impossibile ottenere i formati supportati dagli appunti"
+
+#: ../src/msw/colordlg.cpp:228
+#, c-format
+msgid "Colour selection dialog failed with error %0lx."
+msgstr "Finestra selezione colore fallita con errore %0lx."
+
+#: ../src/msw/cursor.cpp:141
+msgid "Failed to create cursor."
+msgstr "Impossibile creare il cursore."
+
+#: ../src/msw/dde.cpp:279
+#, c-format
+msgid "Failed to register DDE server '%s'"
+msgstr "Impossibile registrare il server DDE '%s'"
+
+#: ../src/msw/dde.cpp:300
+#, c-format
+msgid "Failed to unregister DDE server '%s'"
+msgstr "Impossibile de-registrare il server DDE '%s'"
+
+#: ../src/msw/dde.cpp:428
+#, c-format
+msgid "Failed to create connection to server '%s' on topic '%s'"
+msgstr "Impossibile creare la connessione al server '%s' sull'argomento '%s'"
+
+#: ../src/msw/dde.cpp:655
+msgid "DDE poke request failed"
+msgstr "Richiesta DDE (poke) fallita"
+
+#: ../src/msw/dde.cpp:674
+msgid "Failed to establish an advise loop with DDE server"
+msgstr "Impossibile stabilire un ciclo advise con il server DDE"
+
+#: ../src/msw/dde.cpp:693
+msgid "Failed to terminate the advise loop with DDE server"
+msgstr "Impossibile terminare il ciclo advise con il server DDE"
+
+#: ../src/msw/dde.cpp:768
+msgid "Failed to send DDE advise notification"
+msgstr "Impossibile inviare una notifica advise DDE"
+
+#: ../src/msw/dde.cpp:1085
+msgid "Failed to create DDE string"
+msgstr "Impossibile creare la stringa DDE"
+
+#: ../src/msw/dde.cpp:1131
+msgid "no DDE error."
+msgstr "nessun errore DDE."
+
+#: ../src/msw/dde.cpp:1135
+msgid "a request for a synchronous advise transaction has timed out."
+msgstr ""
+"una richiesta di transazione sincrona (advise) ha superato il tempo massimo."
+
+#: ../src/msw/dde.cpp:1138
+msgid "the response to the transaction caused the DDE_FBUSY bit to be set."
+msgstr ""
+"la risposta alla transazione ha causato l'impostazione del bit DDE_FBUSY."
+
+#: ../src/msw/dde.cpp:1141
+msgid "a request for a synchronous data transaction has timed out."
+msgstr ""
+"una richiesta di transazione sincrona (data) ha superato il tempo massimo."
+
+#: ../src/msw/dde.cpp:1144
+msgid ""
+"a DDEML function was called without first calling the DdeInitialize "
+"function,\n"
+"or an invalid instance identifier\n"
+"was passed to a DDEML function."
+msgstr ""
+"una funzione DDEML è stata richiamata senza prima richiamare DdeInitialize, "
+"oppure è stato passato ad una funzione DDEML\n"
+"un identificatore di istanza non valido."
+
+#: ../src/msw/dde.cpp:1147
+msgid ""
+"an application initialized as APPCLASS_MONITOR has\n"
+"attempted to perform a DDE transaction,\n"
+"or an application initialized as APPCMD_CLIENTONLY has \n"
+"attempted to perform server transactions."
+msgstr ""
+"un'applicazione inizializzata come APPCLASS_MONITOR ha\n"
+"cercato di effettuare una transazione DDE,\n"
+"oppure un'applicazione inizializzata come APPCMD_CLIENTONLY\n"
+"ha cercato di effettuare una transazione server."
+
+#: ../src/msw/dde.cpp:1150
+msgid "a request for a synchronous execute transaction has timed out."
+msgstr ""
+"una richiesta di transazione sincrona (execute) ha superato il tempo massimo."
+
+#: ../src/msw/dde.cpp:1153
+msgid "a parameter failed to be validated by the DDEML."
+msgstr "un parametro ha fallito la validazione da parte del DDEML."
+
+#: ../src/msw/dde.cpp:1156
+msgid "a DDEML application has created a prolonged race condition."
+msgstr "un'applicazione DDEML ha creato una 'race condition' prolungata."
+
+#: ../src/msw/dde.cpp:1159
+msgid "a memory allocation failed."
+msgstr "allocazione di memoria è fallita."
+
+#: ../src/msw/dde.cpp:1162
+msgid "a client's attempt to establish a conversation has failed."
+msgstr "tentativo del client di stabilire una connessione fallito."
+
+#: ../src/msw/dde.cpp:1165
+msgid "a transaction failed."
+msgstr "una transazione è fallita."
+
+#: ../src/msw/dde.cpp:1168
+msgid "a request for a synchronous poke transaction has timed out."
+msgstr ""
+"una richiesta di transazione sincrona (poke) ha superato il tempo massimo."
+
+#: ../src/msw/dde.cpp:1171
+msgid "an internal call to the PostMessage function has failed. "
+msgstr "una chiamata interna alla funzione PostMessage è fallita. "
+
+#: ../src/msw/dde.cpp:1174
+msgid "reentrancy problem."
+msgstr "problema di rientranza."
+
+#: ../src/msw/dde.cpp:1177
+msgid ""
+"a server-side transaction was attempted on a conversation\n"
+"that was terminated by the client, or the server\n"
+"terminated before completing a transaction."
+msgstr ""
+"una transazione server è stata tentata su di una conversazione\n"
+"già terminata dal client, oppure il server\n"
+"è terminato prima di portare a termine la transazione."
+
+#: ../src/msw/dde.cpp:1180
+msgid "an internal error has occurred in the DDEML."
+msgstr "è avvenuto un errore interno nel DDEML."
+
+#: ../src/msw/dde.cpp:1183
+msgid "a request to end an advise transaction has timed out."
+msgstr ""
+"una richiesta di terminazione di transazione (advise) ha superato il tempo "
+"massimo."
+
+#: ../src/msw/dde.cpp:1186
+msgid ""
+"an invalid transaction identifier was passed to a DDEML function.\n"
+"Once the application has returned from an XTYP_XACT_COMPLETE callback,\n"
+"the transaction identifier for that callback is no longer valid."
+msgstr ""
+"è stato fornito un identificatore di transazione non valido ad una funzione "
+"DDEML.\n"
+"Una volta che l'applicazione è uscita da una callback XTYP_XACT_COMPLETE,\n"
+"l'identificatore di transazione per questa callback non è più valido."
+
+#: ../src/msw/dde.cpp:1189
+#, c-format
+msgid "Unknown DDE error %08x"
+msgstr "Errore DDE %08x sconosciuto"
+
+#: ../src/msw/dialup.cpp:343
+msgid ""
+"Dial up functions are unavailable because the remote access service (RAS) is "
+"not installed on this machine. Please install it."
+msgstr ""
+"Funzionalità di composizione telefonica non disponibili perchè il servizio "
+"di Accesso Remoto (RAS) non è installato su questo computer. Installa il "
+"servizio."
+
+#: ../src/msw/dialup.cpp:402
+#, c-format
+msgid ""
+"The version of remote access service (RAS) installed on this machine is too "
+"old, please upgrade (the following required function is missing: %s)."
+msgstr ""
+"La versione del servizio di Accesso Remoto (RAS) installata è troppo "
+"vecchia.\n"
+"Aggiornala (la funzione richiesta %s è assente)."
+
+#: ../src/msw/dialup.cpp:437
+msgid "Failed to retrieve text of RAS error message"
+msgstr ""
+"Impossibile ottenere il testo del messaggio di errore di Accesso Remoto (RAS)"
+
+#: ../src/msw/dialup.cpp:440
+#, c-format
+msgid "unknown error (error code %08x)."
+msgstr "errore sconosciuto (codice %08x)."
+
+#: ../src/msw/dialup.cpp:492
+#, c-format
+msgid "Cannot find active dialup connection: %s"
+msgstr "Impossibile trovare la connessione attiva: %s"
+
+#: ../src/msw/dialup.cpp:513
+msgid "Several active dialup connections found, choosing one randomly."
+msgstr "Trovate più connessioni attive, ne verrà scelta una a caso."
+
+#: ../src/msw/dialup.cpp:598 ../src/msw/dialup.cpp:832
+#, c-format
+msgid "Failed to establish dialup connection: %s"
+msgstr "Impossibile connettersi: %s"
+
+#: ../src/msw/dialup.cpp:664
+#, c-format
+msgid "Failed to get ISP names: %s"
+msgstr "Impossibile ottenere i nomi degli ISP: %s"
+
+#: ../src/msw/dialup.cpp:712
+msgid "Failed to connect: no ISP to dial."
+msgstr "Connessione impossibile: numero dell'ISP mancante."
+
+#: ../src/msw/dialup.cpp:732
+msgid "Choose ISP to dial"
+msgstr "Scegli l'ISP da chiamare"
+
+#: ../src/msw/dialup.cpp:733
+msgid "Please choose which ISP do you want to connect to"
+msgstr "Scegli l'ISP a cui connettersi"
+
+#: ../src/msw/dialup.cpp:766
+msgid "Failed to connect: missing username/password."
+msgstr "Connessione impossibile: mancano nome utente/password."
+
+#: ../src/msw/dialup.cpp:796
+msgid "Cannot find the location of address book file"
+msgstr "Impossibile trovare il file degli indirizzi"
+
+#: ../src/msw/dialup.cpp:827
+#, c-format
+msgid "Failed to initiate dialup connection: %s"
+msgstr "Impossibile inizializzare connessione dialup: %s"
+
+#: ../src/msw/dialup.cpp:897
+msgid "Cannot hang up - no active dialup connection."
+msgstr "Impossibile disconnettersi - nessuna connessione attiva."
+
+#: ../src/msw/dialup.cpp:907
+#, c-format
+msgid "Failed to terminate the dialup connection: %s"
+msgstr "Impossibile terminare la connessione: %s"
+
+#: ../src/msw/dib.cpp:313
+#, c-format
+msgid "Failed to save the bitmap image to file \"%s\"."
+msgstr "Impossibile salvare l'immagine bitmap nel file '%s'."
+
+#: ../src/msw/dib.cpp:543
+#, c-format
+msgid "Failed to allocate %luKb of memory for bitmap data."
+msgstr "Impossibile allocare %luKb di memoria per i dati bitmap."
+
+#: ../src/msw/dir.cpp:241
+#, c-format
+msgid "Cannot enumerate files in directory '%s'"
+msgstr "Impossibile elencare i file nella cartella '%s'"
+
+#: ../src/msw/dirdlg.cpp:368
+msgid "Couldn't obtain folder name"
+msgstr "Impossibile ottenere nome cartella"
+
+#: ../src/msw/dlmsw.cpp:163
+#, c-format
+msgid "(error %d: %s)"
+msgstr "(errore %d: %s)"
+
+#: ../src/msw/dragimag.cpp:143 ../src/msw/dragimag.cpp:178
+#: ../src/msw/imaglist.cpp:309 ../src/msw/imaglist.cpp:331
+msgid "Couldn't add an image to the image list."
+msgstr "Impossibile aggiungere un'immagine all'elenco."
+
+#: ../src/msw/enhmeta.cpp:94
+#, c-format
+msgid "Failed to load metafile from file \"%s\"."
+msgstr "Impossibile leggere il metafile dal file '%s'."
+
+#: ../src/msw/fdrepdlg.cpp:412
+#, c-format
+msgid "Failed to create the standard find/replace dialog (error code %d)"
+msgstr ""
+"Impossibile creare riquadro di ricerca/sostituzione standard (codice di "
+"errore %d)"
+
+#: ../src/msw/filedlg.cpp:1241
+msgid "Access to the file system is not allowed from secure desktop."
+msgstr ""
+
+#: ../src/msw/filedlg.cpp:1242
+msgid "Security warning"
+msgstr ""
+
+#: ../src/msw/filedlg.cpp:1533
+#, c-format
+msgid "File dialog failed with error code %0lx."
+msgstr "Finestra dialogo file fallita con codice errore %0lx."
+
+#: ../src/msw/font.cpp:1120
+#, c-format
+msgid "Font file \"%s\" couldn't be loaded"
+msgstr "Impossibile caricare il file della font \"%s\""
+
+#: ../src/msw/fontdlg.cpp:220
+#, c-format
+msgid "Common dialog failed with error code %0lx."
+msgstr "Finestra di dialogo comune fallita con codice errore %0lx."
+
+#: ../src/msw/fswatcher.cpp:67
+msgid "Ungraceful worker thread termination"
+msgstr "Chiusra del thread inaspettata"
+
+#: ../src/msw/fswatcher.cpp:81
+msgid "Unable to create IOCP worker thread"
+msgstr "Impossibile creare thread attività IOCP"
+
+#: ../src/msw/fswatcher.cpp:88
+msgid "Unable to start IOCP worker thread"
+msgstr "Impossibile avviare thread attività IOCP"
+
+#: ../src/msw/fswatcher.cpp:140
+msgid "Monitoring individual files for changes is not supported currently."
+msgstr ""
+"Il controllo dei cambiamenti dei file individuali non è attualmente "
+"supportato."
+
+#: ../src/msw/fswatcher.cpp:165
+#, c-format
+msgid "Unable to set up watch for '%s'"
+msgstr "Impossibile impostare controllo per '%s'"
+
+#: ../src/msw/fswatcher.cpp:466
+#, c-format
+msgid "Can't monitor non-existent directory \"%s\" for changes."
+msgstr "Impossibile monitorare la cartella \"%s\" per le modifiche."
+
+#: ../src/msw/glcanvas.cpp:577 ../src/unix/glx11.cpp:507
+msgid "OpenGL 3.0 or later is not supported by the OpenGL driver."
+msgstr "Il driver OpenGL non supporta OpenGL 3.0 o superiore."
+
+#: ../src/msw/glcanvas.cpp:601 ../src/osx/glcanvas_osx.cpp:395
+#: ../src/unix/glegl.cpp:304 ../src/unix/glx11.cpp:553
+msgid "Couldn't create OpenGL context"
+msgstr "Impossibile creare contesto OpenGL"
+
+#: ../src/msw/glcanvas.cpp:1294
+msgid "Failed to initialize OpenGL"
+msgstr "Impossibile inizializzare OpenGL"
+
+#: ../src/msw/graphicsd2d.cpp:607
+msgid "Could not register custom DirectWrite font loader."
+msgstr ""
+"Impossibile registrare il caricatore di font DirectWrite personalizzato."
+
+#: ../src/msw/helpchm.cpp:48
+msgid ""
+"MS HTML Help functions are unavailable because the MS HTML Help library is "
+"not installed on this machine. Please install it."
+msgstr ""
+"Funzionalità Guida HTML MS non disponibili perchè la relativa libreria non è "
+"installata in questo computer. Installa la libreria."
+
+#: ../src/msw/helpchm.cpp:55
+msgid "Failed to initialize MS HTML Help."
+msgstr "Impossibile inizializzare MS HTML Help."
+
+#: ../src/msw/iniconf.cpp:458
+#, c-format
+msgid "Can't delete the INI file '%s'"
+msgstr "Impossibile eliminare il file INI '%s'"
+
+#: ../src/msw/listctrl.cpp:995
+#, c-format
+msgid "Couldn't retrieve information about list control item %d."
+msgstr "Impossibile ottenere informazioni sull'elemento %d del list control."
+
+#: ../src/msw/mdi.cpp:170 ../src/qt/mdi.cpp:253
+msgid "&Cascade"
+msgstr "&Sovrapponi finestre"
+
+#: ../src/msw/mdi.cpp:171
+msgid "Tile &Horizontally"
+msgstr "Affianca orizzontalmente"
+
+#: ../src/msw/mdi.cpp:172
+msgid "Tile &Vertically"
+msgstr "Affianca verticalmente"
+
+#: ../src/msw/mdi.cpp:174
+msgid "&Arrange Icons"
+msgstr "&Disponi icone"
+
+#: ../src/msw/mdi.cpp:621
+msgid "Failed to create MDI parent frame."
+msgstr "Impossibile creare la finestra MDI madre."
+
+#: ../src/msw/mimetype.cpp:234
+#, c-format
+msgid "Failed to create registry entry for '%s' files."
+msgstr "Impossibile creare la voce del registro di sistema per i file '%s'."
+
+#: ../src/msw/ole/automtn.cpp:495
+#, c-format
+msgid "Failed to find CLSID of \"%s\""
+msgstr "Impossibile trovare CLSID di \"%s\""
+
+#: ../src/msw/ole/automtn.cpp:512
+#, c-format
+msgid "Failed to create an instance of \"%s\""
+msgstr "Impossibile creare una istanza di \"%s\""
+
+#: ../src/msw/ole/automtn.cpp:552
+#, c-format
+msgid "Cannot get an active instance of \"%s\""
+msgstr "Impossibile ottenere una istanza attiva di \"%s\""
+
+#: ../src/msw/ole/automtn.cpp:564
+#, c-format
+msgid "Failed to get OLE automation interface for \"%s\""
+msgstr "Impossibile ottenere intrefaccia automazione OLE per \"%s\""
+
+#: ../src/msw/ole/automtn.cpp:621
+msgid "Unknown name or named argument."
+msgstr "Nome sconosciuto o argomento nominale."
+
+#: ../src/msw/ole/automtn.cpp:625
+msgid "Incorrect number of arguments."
+msgstr "Numeri non validi degli argomenti."
+
+#: ../src/msw/ole/automtn.cpp:637
+msgid "Unknown exception"
+msgstr "Eccezione sconosciuta"
+
+#: ../src/msw/ole/automtn.cpp:642
+msgid "Method or property not found."
+msgstr "Metodo o proprietà non trovata."
+
+#: ../src/msw/ole/automtn.cpp:646
+msgid "Overflow while coercing argument values."
+msgstr "Overflow durante forzatura valori argomento."
+
+#: ../src/msw/ole/automtn.cpp:650
+msgid "Object implementation does not support named arguments."
+msgstr "L'implementazione dell'oggetto non supporta argomenti nominali."
+
+#: ../src/msw/ole/automtn.cpp:654
+msgid "The locale ID is unknown."
+msgstr "L'ID locale è sconosciuto."
+
+#: ../src/msw/ole/automtn.cpp:658
+msgid "Missing a required parameter."
+msgstr "Parametro richiesto mancante."
+
+#: ../src/msw/ole/automtn.cpp:662
+#, c-format
+msgid "Argument %u not found."
+msgstr "Argomento %u non trovato."
+
+#: ../src/msw/ole/automtn.cpp:666
+#, c-format
+msgid "Type mismatch in argument %u."
+msgstr "Tipo non corrispondente nell'argomento %u."
+
+#: ../src/msw/ole/automtn.cpp:670
+msgid "The system cannot find the file specified."
+msgstr "Il sistema non trova il file specificato."
+
+#: ../src/msw/ole/automtn.cpp:674
+msgid "Class not registered."
+msgstr "Classe non registrata."
+
+#: ../src/msw/ole/automtn.cpp:678
+#, c-format
+msgid "Unknown error %08x"
+msgstr "Errore %08x sconosciuto"
+
+#: ../src/msw/ole/automtn.cpp:682
+#, c-format
+msgid "OLE Automation error in %s: %s"
+msgstr "Errore automazione OLE in %s: %s"
+
+#: ../src/msw/ole/dataobj.cpp:385
+#, c-format
+msgid "Couldn't register clipboard format '%s'."
+msgstr "Impossibile registrare il formato '%s' degli appunti."
+
+#: ../src/msw/ole/dataobj.cpp:402
+#, c-format
+msgid "The clipboard format '%d' doesn't exist."
+msgstr "Il formato '%d' degli appunti non esiste."
+
+#: ../src/msw/progdlg.cpp:1025
+msgid "Skip"
+msgstr "Salta"
+
+#: ../src/msw/registry.cpp:141
+#, c-format
+msgid "unknown (%lu)"
+msgstr "sconosciuto (%lu)"
+
+#: ../src/msw/registry.cpp:409
+#, c-format
+msgid "Can't get info about registry key '%s'"
+msgstr ""
+"Impossibile ottenere informazioni sulla chiave '%s' del registro di sistema"
+
+#: ../src/msw/registry.cpp:445
+#, c-format
+msgid "Can't open registry key '%s'"
+msgstr "Impossibile aprire la chiave '%s' del registro di sistema"
+
+#: ../src/msw/registry.cpp:478
+#, c-format
+msgid "Can't create registry key '%s'"
+msgstr "Impossibile creare la chiave '%s' del registro di sistema"
+
+#: ../src/msw/registry.cpp:497
+#, c-format
+msgid "Can't close registry key '%s'"
+msgstr "Impossibile chiudere la chiave '%s' del registro di sistema"
+
+#: ../src/msw/registry.cpp:512
+#, c-format
+msgid "Registry value '%s' already exists."
+msgstr "Valore '%s' del registro di sistema già presente."
+
+#: ../src/msw/registry.cpp:520
+#, c-format
+msgid "Failed to rename registry value '%s' to '%s'."
+msgstr "Impossibile rinominare il valore '%s' del registro di sistema in '%s'."
+
+#: ../src/msw/registry.cpp:575
+#, c-format
+msgid "Can't copy values of unsupported type %d."
+msgstr "Impossibile copiare valori del tipo non supportato %d."
+
+#: ../src/msw/registry.cpp:586
+#, c-format
+msgid "Registry key '%s' does not exist, cannot rename it."
+msgstr ""
+"Chiave '%s' del registro di sistema non esistente. \n"
+"Impossibile rinominarla."
+
+#: ../src/msw/registry.cpp:617
+#, c-format
+msgid "Registry key '%s' already exists."
+msgstr "Chiave '%s' del registro di sistema già presente."
+
+#: ../src/msw/registry.cpp:625
+#, c-format
+msgid "Failed to rename the registry key '%s' to '%s'."
+msgstr "Impossibile rinominare la chiave '%s' del registro di sistema in '%s'."
+
+#: ../src/msw/registry.cpp:670
+#, c-format
+msgid "Failed to copy the registry subkey '%s' to '%s'."
+msgstr "Impossibile copiare la chiave '%s' del registro di sistema in '%s'."
+
+#: ../src/msw/registry.cpp:683
+#, c-format
+msgid "Failed to copy registry value '%s'"
+msgstr "Impossibile copiare il valore '%s' del registro di sistema"
+
+#: ../src/msw/registry.cpp:692
+#, c-format
+msgid "Failed to copy the contents of registry key '%s' to '%s'."
+msgstr ""
+"Impossibile copiare il contenuto della chiave '%s' del registro di sistema "
+"in '%s'."
+
+#: ../src/msw/registry.cpp:718
+#, c-format
+msgid ""
+"Registry key '%s' is needed for normal system operation,\n"
+"deleting it will leave your system in unusable state:\n"
+"operation aborted."
+msgstr ""
+"Chiave '%s' del registro di sistema necessaria per un corretto funzionamento "
+"del sistema.\n"
+"La cancellazione renderebbe il sistema inutilizzabile:\n"
+"Operazione abbandonata."
+
+#: ../src/msw/registry.cpp:754
+#, c-format
+msgid "Can't delete key '%s'"
+msgstr "Impossibile eliminare la chiave '%s'"
+
+#: ../src/msw/registry.cpp:782
+#, c-format
+msgid "Can't delete value '%s' from key '%s'"
+msgstr "Impossibile eliminare il valore '%s' dalla chiave '%s'"
+
+#: ../src/msw/registry.cpp:855 ../src/msw/registry.cpp:887
+#: ../src/msw/registry.cpp:929 ../src/msw/registry.cpp:1000
+#, c-format
+msgid "Can't read value of key '%s'"
+msgstr "Impossibile leggere il valore della chiave '%s'"
+
+#: ../src/msw/registry.cpp:873 ../src/msw/registry.cpp:915
+#: ../src/msw/registry.cpp:963 ../src/msw/registry.cpp:1106
+#, c-format
+msgid "Can't set value of '%s'"
+msgstr "Impossibile impostare il valore di '%s'"
+
+#: ../src/msw/registry.cpp:894 ../src/msw/registry.cpp:943
+#, c-format
+msgid "Registry value \"%s\" is not numeric (but of type %s)"
+msgstr "Il valore registro \"%s\" non è di tipo numerico (ma di tipo %s)"
+
+#: ../src/msw/registry.cpp:979
+#, c-format
+msgid "Registry value \"%s\" is not binary (but of type %s)"
+msgstr "Il valore registro \"%s\" non è di tipo binario (ma di tipo %s)"
+
+#: ../src/msw/registry.cpp:1028
+#, c-format
+msgid "Registry value \"%s\" is not text (but of type %s)"
+msgstr "Il valore registro \"%s\" non è di tipo testo (ma di tipo %s)"
+
+#: ../src/msw/registry.cpp:1089
+#, c-format
+msgid "Can't read value of '%s'"
+msgstr "Impossibile leggere il valore di '%s'"
+
+#: ../src/msw/registry.cpp:1157
+#, c-format
+msgid "Can't enumerate values of key '%s'"
+msgstr "Impossibile elencare i valori della chiave '%s'"
+
+#: ../src/msw/registry.cpp:1196
+#, c-format
+msgid "Can't enumerate subkeys of key '%s'"
+msgstr "Impossibile elencare le sotto chiavi della chiave '%s'"
+
+#: ../src/msw/registry.cpp:1262
+#, c-format
+msgid ""
+"Exporting registry key: file \"%s\" already exists and won't be overwritten."
+msgstr ""
+"Durante l'esportazione della chiave di registro: il file \"%s\" esiste e non "
+"verrà sovrascritto."
+
+#: ../src/msw/registry.cpp:1411
+#, c-format
+msgid "Can't export value of unsupported type %d."
+msgstr "Impossibile esportare valori del tipo non supportato %d."
+
+#: ../src/msw/registry.cpp:1427
+#, c-format
+msgid "Ignoring value \"%s\" of the key \"%s\"."
+msgstr "Il valore \"%s\" della chiave \"%s\" è stato ignorato."
+
+#: ../src/msw/textctrl.cpp:596
+msgid ""
+"Impossible to create a rich edit control, using simple text control instead. "
+"Please reinstall riched32.dll"
+msgstr ""
+"Impossibile creare un controllo Rich Edit, impiegato un controllo di tipo "
+"testo semplice.\n"
+"Reinstalla riched32.dll."
+
+#: ../src/msw/thread.cpp:522 ../src/unix/threadpsx.cpp:850
+msgid "Cannot start thread: error writing TLS."
+msgstr "Impossibile avviare il thread: errore nella scrittura del TLS."
+
+#: ../src/msw/thread.cpp:613
+msgid "Can't set thread priority"
+msgstr "Impossibile impostare la priorità del thread"
+
+#: ../src/msw/thread.cpp:649
+msgid "Can't create thread"
+msgstr "Impossibile creare il thread"
+
+#: ../src/msw/thread.cpp:668
+msgid "Couldn't terminate thread"
+msgstr "Impossibile terminare il thread"
+
+#: ../src/msw/thread.cpp:799
+msgid "Cannot wait for thread termination"
+msgstr "Impossibile attendere la fine del thread"
+
+#: ../src/msw/thread.cpp:873
+#, c-format
+msgid "Cannot suspend thread %lx"
+msgstr "Impossibile sospendere il thread %lx"
+
+#: ../src/msw/thread.cpp:903
+#, c-format
+msgid "Cannot resume thread %lx"
+msgstr "Impossibile riprendere il thread %lx"
+
+#: ../src/msw/thread.cpp:932
+msgid "Couldn't get the current thread pointer"
+msgstr "Impossibile ottenere un puntatore al thread attuale"
+
+#: ../src/msw/thread.cpp:1333
+msgid ""
+"Thread module initialization failed: impossible to allocate index in thread "
+"local storage"
+msgstr ""
+"Inizializzazione del modulo dei thread fallita: impossibile allocare "
+"l'indice nella memoria locale del thread"
+
+#: ../src/msw/thread.cpp:1345
+msgid ""
+"Thread module initialization failed: cannot store value in thread local "
+"storage"
+msgstr ""
+"Inizializzazione modulo dei thread fallita: impossibile memorizzare un "
+"valore nella memoria locale del thread"
+
+#: ../src/msw/timer.cpp:133
+msgid "Couldn't create a timer"
+msgstr "Impossibile creare un timer"
+
+#: ../src/msw/utils.cpp:372
+msgid "can't find user's HOME, using current directory."
+msgstr ""
+"impossibile trovare la HOME dell'utente, viene impiegata la cartella attuale."
+
+#: ../src/msw/utils.cpp:662
+#, c-format
+msgid "Failed to kill process %d"
+msgstr "Impossibile terminare il processo %d"
+
+#: ../src/msw/utils.cpp:986
+#, c-format
+msgid "Failed to load resource \"%s\"."
+msgstr "Impossibile caricare risorsa \"%s\"."
+
+#: ../src/msw/utils.cpp:993
+#, c-format
+msgid "Failed to lock resource \"%s\"."
+msgstr "Impossibile bloccare risorsa \"%s\"."
+
+#. TRANSLATORS: MS Windows build number
+#: ../src/msw/utils.cpp:1209
+#, c-format
+msgid "build %lu"
+msgstr "build %lu"
+
+#: ../src/msw/utils.cpp:1218
+msgid ", 64-bit edition"
+msgstr ", versione 64-bit"
+
+#: ../src/msw/utilsexc.cpp:224
+msgid "Failed to create an anonymous pipe"
+msgstr "Impossibile creare una pipe anonima"
+
+#: ../src/msw/utilsexc.cpp:697
+msgid "Failed to redirect the child process IO"
+msgstr "Impossibile redirigere l'input/output del processo figlio"
+
+#: ../src/msw/utilsexc.cpp:870
+#, c-format
+msgid "Execution of command '%s' failed"
+msgstr "Esecuzione del comando '%s' fallita"
+
+#: ../src/msw/volume.cpp:337
+msgid "Failed to load mpr.dll."
+msgstr "Impossibile caricare mpr.dll."
+
+#: ../src/msw/volume.cpp:506
+#, c-format
+msgid "Cannot read typename from '%s'!"
+msgstr "Impossibile leggere l'identificatore di tipo da '%s'!"
+
+#: ../src/msw/volume.cpp:615
+#, c-format
+msgid "Cannot load icon from '%s'."
+msgstr "Impossibile caricare l'icona da '%s'."
+
+#: ../src/msw/webview_edge.cpp:285
+msgid "This program was compiled without support for setting Edge proxy."
+msgstr ""
+
+#: ../src/msw/webview_ie.cpp:1010
+msgid "Failed to find web view emulation level in the registry"
+msgstr ""
+"Impossibile trovare il livello di emulazione della visualizzazione web nel "
+"registro"
+
+#: ../src/msw/webview_ie.cpp:1019
+msgid "Failed to set web view to modern emulation level"
+msgstr ""
+"Impossibile impostare la visualizzazione web al livello di emulazione moderno"
+
+#: ../src/msw/webview_ie.cpp:1027
+msgid "Failed to reset web view to standard emulation level"
+msgstr ""
+"Impossibile ripristinare la visualizzazione web al livello di emulazione "
+"standard"
+
+#: ../src/msw/webview_ie.cpp:1049
+msgid "Can't run JavaScript script without a valid HTML document"
+msgstr ""
+"Impossibile eseguire lo script JavaScript senza un documento HTML valido"
+
+#: ../src/msw/webview_ie.cpp:1056
+msgid "Can't get the JavaScript object"
+msgstr "Impossibile ottenere l'oggetto JavaScript"
+
+#: ../src/msw/webview_ie.cpp:1070
+msgid "failed to evaluate"
+msgstr "impossibile valutare"
+
+#: ../src/osx/cocoa/filedlg.mm:412
+msgid "File type:"
+msgstr "Tipo file:"
+
+#: ../src/osx/cocoa/menu.mm:242
+msgctxt "macOS menu name"
+msgid "Window"
+msgstr "Finestra"
+
+#: ../src/osx/cocoa/menu.mm:259
+msgctxt "macOS menu name"
+msgid "Help"
+msgstr "Aiuto"
+
+#: ../src/osx/cocoa/menu.mm:298
+msgctxt "macOS menu item"
+msgid "Minimize"
+msgstr "Minimizza"
+
+#: ../src/osx/cocoa/menu.mm:303
+msgctxt "macOS menu item"
+msgid "Zoom"
+msgstr "Zoom"
+
+#: ../src/osx/cocoa/menu.mm:309
+msgctxt "macOS menu item"
+msgid "Bring All to Front"
+msgstr "Porta tutto in primo piano"
+
+#: ../src/osx/core/sound.cpp:143
+#, c-format
+msgid "Failed to load sound from \"%s\" (error %d)."
+msgstr "Impossibile caricare suono da \"%s\" (errore %d)."
+
+#: ../src/osx/fontutil.cpp:80
+#, c-format
+msgid "Font file \"%s\" doesn't exist."
+msgstr "Il file font '%s' non esiste."
+
+#: ../src/osx/fontutil.cpp:88
+#, c-format
+msgid ""
+"Font file \"%s\" cannot be used as it is not inside the font directory "
+"\"%s\"."
+msgstr ""
+"Impossibile usare il file della font \"%s\" poiché non si trova all'interno "
+"della cartella delle font \"%s\"."
+
+#: ../src/osx/menu_osx.cpp:496
+#, c-format
+msgctxt "macOS menu item"
+msgid "About %s"
+msgstr "Info su %s"
+
+#: ../src/osx/menu_osx.cpp:499
+msgctxt "macOS menu item"
+msgid "About..."
+msgstr "Info..."
+
+#: ../src/osx/menu_osx.cpp:508
+msgctxt "macOS menu item"
+msgid "Preferences..."
+msgstr "Preferenze..."
+
+#: ../src/osx/menu_osx.cpp:512
+msgctxt "macOS menu item"
+msgid "Services"
+msgstr "Servizi"
+
+#: ../src/osx/menu_osx.cpp:519
+#, c-format
+msgctxt "macOS menu item"
+msgid "Hide %s"
+msgstr "Nascondi %s"
+
+#: ../src/osx/menu_osx.cpp:522
+msgctxt "macOS menu item"
+msgid "Hide Application"
+msgstr "Nascondi applicazione"
+
+#: ../src/osx/menu_osx.cpp:526
+msgctxt "macOS menu item"
+msgid "Hide Others"
+msgstr "Nascondi altri"
+
+#: ../src/osx/menu_osx.cpp:528
+msgctxt "macOS menu item"
+msgid "Show All"
+msgstr "Visualizza tutto"
+
+#: ../src/osx/menu_osx.cpp:534
+#, c-format
+msgctxt "macOS menu item"
+msgid "Quit %s"
+msgstr "Esci da %s"
+
+#: ../src/osx/menu_osx.cpp:537
+msgctxt "macOS menu item"
+msgid "Quit Application"
+msgstr "Esci dall'applicazione"
+
+#: ../src/osx/webview_webkit.mm:444
+msgid "Printing is not supported by the system web control"
+msgstr "La stampa non è supportata dal controllo web del sistema"
+
+#: ../src/osx/webview_webkit.mm:453
+msgid "Print operation could not be initialized"
+msgstr "Impossibile inizializzare l'operazione di stampa"
+
+#. TRANSLATORS: Label of font point size
+#: ../src/propgrid/advprops.cpp:605
+msgid "Point Size"
+msgstr "Dimensione punti"
+
+#. TRANSLATORS: Label of font face name
+#: ../src/propgrid/advprops.cpp:615
+msgid "Face Name"
+msgstr "Nome faccia"
+
+#. TRANSLATORS: Label of font style
+#: ../src/propgrid/advprops.cpp:623 ../src/richtext/richtextformatdlg.cpp:331
+msgid "Style"
+msgstr "Stile"
+
+#. TRANSLATORS: Label of font weight
+#: ../src/propgrid/advprops.cpp:628
+msgid "Weight"
+msgstr "Peso"
+
+#. TRANSLATORS: Label of underlined font
+#: ../src/propgrid/advprops.cpp:633 ../src/richtext/richtextfontpage.cpp:358
+msgid "Underlined"
+msgstr "Sottolineato"
+
+#. TRANSLATORS: Label of font family
+#: ../src/propgrid/advprops.cpp:637
+msgid "Family"
+msgstr "Famiglia"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:801
+msgid "AppWorkspace"
+msgstr "SpazioLavoroApp"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:802
+msgid "ActiveBorder"
+msgstr "Bordo attivo"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:803
+msgid "ActiveCaption"
+msgstr "Titolo attivo"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:804
+msgid "ButtonFace"
+msgstr "ApparenzaPulsante"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:805
+msgid "ButtonHighlight"
+msgstr "EvidenziazionePulsante"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:806
+msgid "ButtonShadow"
+msgstr "OmbreggiaturaPulasnte"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:807
+msgid "ButtonText"
+msgstr "TestoPulsante"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:808
+msgid "CaptionText"
+msgstr "TitoloTesto"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:809
+msgid "ControlDark"
+msgstr "ControlloScuro"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:810
+msgid "ControlLight"
+msgstr "ControlloChiaro"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:812
+msgid "GrayText"
+msgstr "Testo grigio"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:813
+msgid "Highlight"
+msgstr "Evidenzia"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:814
+msgid "HighlightText"
+msgstr "Testo evidenziato"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:815
+msgid "InactiveBorder"
+msgstr "Bordo non attivo"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:816
+msgid "InactiveCaption"
+msgstr "TitoloNonAttivo"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:817
+msgid "InactiveCaptionText"
+msgstr "TestoTitoloNonAttivo"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:818
+msgid "Menu"
+msgstr "Menu"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:819
+msgid "Scrollbar"
+msgstr "Barra scorrimento"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:820
+msgid "Tooltip"
+msgstr "Suggerimento"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:821
+msgid "TooltipText"
+msgstr "Testo suggerimento"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:822
+msgid "Window"
+msgstr "Finestra"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:823
+msgid "WindowFrame"
+msgstr "FrameFinestra"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:824
+msgid "WindowText"
+msgstr "TestoFinestra"
+
+#. TRANSLATORS: Custom colour choice entry
+#: ../src/propgrid/advprops.cpp:825 ../src/propgrid/advprops.cpp:1532
+#: ../src/propgrid/advprops.cpp:1576
+msgid "Custom"
+msgstr "Personalizzata"
+
+#: ../src/propgrid/advprops.cpp:1558
+msgid "Black"
+msgstr "Nero"
+
+#: ../src/propgrid/advprops.cpp:1559
+msgid "Maroon"
+msgstr "Marrone"
+
+#: ../src/propgrid/advprops.cpp:1560
+msgid "Navy"
+msgstr "Navy"
+
+#: ../src/propgrid/advprops.cpp:1561
+msgid "Purple"
+msgstr "Viola"
+
+#: ../src/propgrid/advprops.cpp:1562
+msgid "Teal"
+msgstr "Teal"
+
+#: ../src/propgrid/advprops.cpp:1563
+msgid "Gray"
+msgstr "Grigio"
+
+#: ../src/propgrid/advprops.cpp:1564
+msgid "Green"
+msgstr "Verde"
+
+#: ../src/propgrid/advprops.cpp:1565
+msgid "Olive"
+msgstr "Oliva"
+
+#: ../src/propgrid/advprops.cpp:1566
+msgid "Brown"
+msgstr "Marrone"
+
+#: ../src/propgrid/advprops.cpp:1567
+msgid "Blue"
+msgstr "Blu"
+
+#: ../src/propgrid/advprops.cpp:1568
+msgid "Fuchsia"
+msgstr "Fucsia"
+
+#: ../src/propgrid/advprops.cpp:1569
+msgid "Red"
+msgstr "Rosso"
+
+#: ../src/propgrid/advprops.cpp:1570
+msgid "Orange"
+msgstr "Arancio"
+
+#: ../src/propgrid/advprops.cpp:1571
+msgid "Silver"
+msgstr "Argento"
+
+#: ../src/propgrid/advprops.cpp:1572
+msgid "Lime"
+msgstr "Lime"
+
+#: ../src/propgrid/advprops.cpp:1573
+msgid "Aqua"
+msgstr "Acqua"
+
+#: ../src/propgrid/advprops.cpp:1574
+msgid "Yellow"
+msgstr "Giallo"
+
+#: ../src/propgrid/advprops.cpp:1575
+msgid "White"
+msgstr "Bianco"
+
+#: ../src/propgrid/advprops.cpp:1718
+msgctxt "system cursor name"
+msgid "Default"
+msgstr "Predefinito"
+
+#: ../src/propgrid/advprops.cpp:1719
+msgctxt "system cursor name"
+msgid "Arrow"
+msgstr "Freccia"
+
+#: ../src/propgrid/advprops.cpp:1720
+msgctxt "system cursor name"
+msgid "Right Arrow"
+msgstr "Freccia destra"
+
+#: ../src/propgrid/advprops.cpp:1721
+msgctxt "system cursor name"
+msgid "Blank"
+msgstr "Vuoto"
+
+#: ../src/propgrid/advprops.cpp:1722
+msgctxt "system cursor name"
+msgid "Bullseye"
+msgstr "Occhio di bue"
+
+#: ../src/propgrid/advprops.cpp:1723
+msgctxt "system cursor name"
+msgid "Character"
+msgstr "Carattere"
+
+#: ../src/propgrid/advprops.cpp:1724
+msgctxt "system cursor name"
+msgid "Cross"
+msgstr "Incrocio"
+
+#: ../src/propgrid/advprops.cpp:1725
+msgctxt "system cursor name"
+msgid "Hand"
+msgstr "Mano"
+
+#: ../src/propgrid/advprops.cpp:1726
+msgctxt "system cursor name"
+msgid "I-Beam"
+msgstr "I-Beam"
+
+#: ../src/propgrid/advprops.cpp:1727
+msgctxt "system cursor name"
+msgid "Left Button"
+msgstr "Pulsante sinistro"
+
+#: ../src/propgrid/advprops.cpp:1728
+msgctxt "system cursor name"
+msgid "Magnifier"
+msgstr "Ingrandimento"
+
+#: ../src/propgrid/advprops.cpp:1729
+msgctxt "system cursor name"
+msgid "Middle Button"
+msgstr "Pulsante centrale"
+
+#: ../src/propgrid/advprops.cpp:1730
+msgctxt "system cursor name"
+msgid "No Entry"
+msgstr "Nessun elemento"
+
+#: ../src/propgrid/advprops.cpp:1731
+msgctxt "system cursor name"
+msgid "Paint Brush"
+msgstr "Pennello"
+
+#: ../src/propgrid/advprops.cpp:1732
+msgctxt "system cursor name"
+msgid "Pencil"
+msgstr "Matita"
+
+#: ../src/propgrid/advprops.cpp:1733
+msgctxt "system cursor name"
+msgid "Point Left"
+msgstr "Punto a sinistra"
+
+#: ../src/propgrid/advprops.cpp:1734
+msgctxt "system cursor name"
+msgid "Point Right"
+msgstr "Punta a destra"
+
+#: ../src/propgrid/advprops.cpp:1735
+msgctxt "system cursor name"
+msgid "Question Arrow"
+msgstr "Freccia domanda"
+
+#: ../src/propgrid/advprops.cpp:1736
+msgctxt "system cursor name"
+msgid "Right Button"
+msgstr "Pulsante destro"
+
+#: ../src/propgrid/advprops.cpp:1737
+msgctxt "system cursor name"
+msgid "Sizing NE-SW"
+msgstr "Posizionamento NE-SO"
+
+#: ../src/propgrid/advprops.cpp:1738
+msgctxt "system cursor name"
+msgid "Sizing N-S"
+msgstr "Posizionamento N-S"
+
+#: ../src/propgrid/advprops.cpp:1739
+msgctxt "system cursor name"
+msgid "Sizing NW-SE"
+msgstr "Posizionamento NO-SE"
+
+#: ../src/propgrid/advprops.cpp:1740
+msgctxt "system cursor name"
+msgid "Sizing W-E"
+msgstr "Posizionamento O-E"
+
+#: ../src/propgrid/advprops.cpp:1741
+msgctxt "system cursor name"
+msgid "Sizing"
+msgstr "Posizionamento"
+
+#: ../src/propgrid/advprops.cpp:1742
+msgctxt "system cursor name"
+msgid "Spraycan"
+msgstr "Bombola spray"
+
+#: ../src/propgrid/advprops.cpp:1743
+msgctxt "system cursor name"
+msgid "Wait"
+msgstr "Attendi"
+
+#: ../src/propgrid/advprops.cpp:1744
+msgctxt "system cursor name"
+msgid "Watch"
+msgstr "Monitora"
+
+#: ../src/propgrid/advprops.cpp:1745
+msgctxt "system cursor name"
+msgid "Wait Arrow"
+msgstr "Freccia attesa"
+
+#: ../src/propgrid/advprops.cpp:2109
+msgid "Make a selection:"
+msgstr "Effettua una selezione:"
+
+#: ../src/propgrid/manager.cpp:394
+msgid "Property"
+msgstr "Proprietà"
+
+#: ../src/propgrid/manager.cpp:395
+msgid "Value"
+msgstr "Valore"
+
+#: ../src/propgrid/manager.cpp:1683
+msgid "Categorized Mode"
+msgstr "Modo categorizzato"
+
+#: ../src/propgrid/manager.cpp:1709
+msgid "Alphabetic Mode"
+msgstr "Modo alfabetico"
+
+#. TRANSLATORS: Name of Boolean false value
+#: ../src/propgrid/propgrid.cpp:230
+msgid "False"
+msgstr "Falso"
+
+#. TRANSLATORS: Name of Boolean true value
+#: ../src/propgrid/propgrid.cpp:232
+msgid "True"
+msgstr "Vero"
+
+#. TRANSLATORS: Text  displayed for unspecified value
+#: ../src/propgrid/propgrid.cpp:428
+msgid "Unspecified"
+msgstr "Non specificato"
+
+#. TRANSLATORS: Caption of message box displaying any property error
+#: ../src/propgrid/propgrid.cpp:3145 ../src/propgrid/propgrid.cpp:3282
+msgid "Property Error"
+msgstr "Errore proprietà"
+
+#: ../src/propgrid/propgrid.cpp:3259
+msgid "You have entered invalid value. Press ESC to cancel editing."
+msgstr ""
+"È stato inserito un valore non valido. \n"
+"Premi 'ESC' per annullare la modifica."
+
+#: ../src/propgrid/propgrid.cpp:6608
+#, c-format
+msgid "Error in resource: %s"
+msgstr "Errore nella risorsa: %s"
+
+#: ../src/propgrid/propgridiface.cpp:377
+#, c-format
+msgid ""
+"Type operation \"%s\" failed: Property labeled \"%s\" is of type \"%s\", NOT "
+"\"%s\"."
+msgstr ""
+"Tipo operazione \"%s\" fallita: etichetta proprietà: \"%s\" è del tipo "
+"\"%s\", NON \"%s\"."
+
+#: ../src/propgrid/props.cpp:159
+#, c-format
+msgid "Unknown base %d. Base 10 will be used."
+msgstr "Base sconosciuta %d. Verrà usata la base 10."
+
+#: ../src/propgrid/props.cpp:324
+#, c-format
+msgid "Value must be %s or higher."
+msgstr "Il valore deve essere %s o superiore."
+
+#: ../src/propgrid/props.cpp:329 ../src/propgrid/props.cpp:356
+#, c-format
+msgid "Value must be between %s and %s."
+msgstr "Il valore deve essere tra %s e %s."
+
+#: ../src/propgrid/props.cpp:351
+#, c-format
+msgid "Value must be %s or less."
+msgstr "Il valore deve essere %s o inferiore."
+
+#: ../src/propgrid/props.cpp:1058
+#, c-format
+msgid "Not %s"
+msgstr "Non %s"
+
+#: ../src/propgrid/props.cpp:1770
+msgid "Choose a directory:"
+msgstr "Scegli una cartella:"
+
+#: ../src/propgrid/props.cpp:2055
+msgid "Choose a file"
+msgstr "Scegli un file"
+
+#: ../src/qt/mdi.cpp:254
+msgid "&Tile"
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:147
+#: ../src/richtext/richtextformatdlg.cpp:376
+msgid "Background"
+msgstr "Sfondo"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:159
+msgid "Background &colour:"
+msgstr "Colore &sfondo:"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:161
+#: ../src/richtext/richtextbackgroundpage.cpp:163
+msgid "Enables a background colour."
+msgstr "Abilita colore sfondo."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:167
+#: ../src/richtext/richtextbackgroundpage.cpp:169
+msgid "The background colour."
+msgstr "Colore sfondo."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:178
+msgid "Shadow"
+msgstr "Ombra"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:193
+msgid "Use &shadow"
+msgstr "U&sa ombreggiatura"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:195
+#: ../src/richtext/richtextbackgroundpage.cpp:197
+msgid "Enables a shadow."
+msgstr "Abilita ombra."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:211
+msgid "&Horizontal offset:"
+msgstr "Offset &verticale:"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:218
+#: ../src/richtext/richtextbackgroundpage.cpp:220
+msgid "The horizontal offset."
+msgstr "L'offset orizzontale."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:224
+#: ../src/richtext/richtextbackgroundpage.cpp:227
+#: ../src/richtext/richtextbackgroundpage.cpp:228
+#: ../src/richtext/richtextbackgroundpage.cpp:247
+#: ../src/richtext/richtextbackgroundpage.cpp:250
+#: ../src/richtext/richtextbackgroundpage.cpp:251
+#: ../src/richtext/richtextbackgroundpage.cpp:287
+#: ../src/richtext/richtextbackgroundpage.cpp:290
+#: ../src/richtext/richtextbackgroundpage.cpp:291
+#: ../src/richtext/richtextbackgroundpage.cpp:314
+#: ../src/richtext/richtextbackgroundpage.cpp:317
+#: ../src/richtext/richtextbackgroundpage.cpp:318
+#: ../src/richtext/richtextborderspage.cpp:252
+#: ../src/richtext/richtextborderspage.cpp:255
+#: ../src/richtext/richtextborderspage.cpp:256
+#: ../src/richtext/richtextborderspage.cpp:286
+#: ../src/richtext/richtextborderspage.cpp:289
+#: ../src/richtext/richtextborderspage.cpp:290
+#: ../src/richtext/richtextborderspage.cpp:320
+#: ../src/richtext/richtextborderspage.cpp:323
+#: ../src/richtext/richtextborderspage.cpp:324
+#: ../src/richtext/richtextborderspage.cpp:354
+#: ../src/richtext/richtextborderspage.cpp:357
+#: ../src/richtext/richtextborderspage.cpp:358
+#: ../src/richtext/richtextborderspage.cpp:420
+#: ../src/richtext/richtextborderspage.cpp:423
+#: ../src/richtext/richtextborderspage.cpp:424
+#: ../src/richtext/richtextborderspage.cpp:454
+#: ../src/richtext/richtextborderspage.cpp:457
+#: ../src/richtext/richtextborderspage.cpp:458
+#: ../src/richtext/richtextborderspage.cpp:488
+#: ../src/richtext/richtextborderspage.cpp:491
+#: ../src/richtext/richtextborderspage.cpp:492
+#: ../src/richtext/richtextborderspage.cpp:522
+#: ../src/richtext/richtextborderspage.cpp:525
+#: ../src/richtext/richtextborderspage.cpp:526
+#: ../src/richtext/richtextborderspage.cpp:590
+#: ../src/richtext/richtextborderspage.cpp:593
+#: ../src/richtext/richtextborderspage.cpp:594
+#: ../src/richtext/richtextfontpage.cpp:177
+#: ../src/richtext/richtextmarginspage.cpp:199
+#: ../src/richtext/richtextmarginspage.cpp:201
+#: ../src/richtext/richtextmarginspage.cpp:202
+#: ../src/richtext/richtextmarginspage.cpp:224
+#: ../src/richtext/richtextmarginspage.cpp:226
+#: ../src/richtext/richtextmarginspage.cpp:227
+#: ../src/richtext/richtextmarginspage.cpp:247
+#: ../src/richtext/richtextmarginspage.cpp:249
+#: ../src/richtext/richtextmarginspage.cpp:250
+#: ../src/richtext/richtextmarginspage.cpp:272
+#: ../src/richtext/richtextmarginspage.cpp:274
+#: ../src/richtext/richtextmarginspage.cpp:275
+#: ../src/richtext/richtextmarginspage.cpp:313
+#: ../src/richtext/richtextmarginspage.cpp:315
+#: ../src/richtext/richtextmarginspage.cpp:316
+#: ../src/richtext/richtextmarginspage.cpp:338
+#: ../src/richtext/richtextmarginspage.cpp:340
+#: ../src/richtext/richtextmarginspage.cpp:341
+#: ../src/richtext/richtextmarginspage.cpp:361
+#: ../src/richtext/richtextmarginspage.cpp:363
+#: ../src/richtext/richtextmarginspage.cpp:364
+#: ../src/richtext/richtextmarginspage.cpp:386
+#: ../src/richtext/richtextmarginspage.cpp:388
+#: ../src/richtext/richtextmarginspage.cpp:389
+#: ../src/richtext/richtextsizepage.cpp:337
+#: ../src/richtext/richtextsizepage.cpp:340
+#: ../src/richtext/richtextsizepage.cpp:341
+#: ../src/richtext/richtextsizepage.cpp:371
+#: ../src/richtext/richtextsizepage.cpp:374
+#: ../src/richtext/richtextsizepage.cpp:375
+#: ../src/richtext/richtextsizepage.cpp:398
+#: ../src/richtext/richtextsizepage.cpp:401
+#: ../src/richtext/richtextsizepage.cpp:402
+#: ../src/richtext/richtextsizepage.cpp:425
+#: ../src/richtext/richtextsizepage.cpp:428
+#: ../src/richtext/richtextsizepage.cpp:429
+#: ../src/richtext/richtextsizepage.cpp:452
+#: ../src/richtext/richtextsizepage.cpp:455
+#: ../src/richtext/richtextsizepage.cpp:456
+#: ../src/richtext/richtextsizepage.cpp:479
+#: ../src/richtext/richtextsizepage.cpp:482
+#: ../src/richtext/richtextsizepage.cpp:483
+#: ../src/richtext/richtextsizepage.cpp:553
+#: ../src/richtext/richtextsizepage.cpp:556
+#: ../src/richtext/richtextsizepage.cpp:557
+#: ../src/richtext/richtextsizepage.cpp:588
+#: ../src/richtext/richtextsizepage.cpp:591
+#: ../src/richtext/richtextsizepage.cpp:592
+#: ../src/richtext/richtextsizepage.cpp:623
+#: ../src/richtext/richtextsizepage.cpp:626
+#: ../src/richtext/richtextsizepage.cpp:627
+#: ../src/richtext/richtextsizepage.cpp:658
+#: ../src/richtext/richtextsizepage.cpp:661
+#: ../src/richtext/richtextsizepage.cpp:662
+msgid "px"
+msgstr "px"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:225
+#: ../src/richtext/richtextbackgroundpage.cpp:248
+#: ../src/richtext/richtextbackgroundpage.cpp:288
+#: ../src/richtext/richtextbackgroundpage.cpp:315
+#: ../src/richtext/richtextborderspage.cpp:253
+#: ../src/richtext/richtextborderspage.cpp:287
+#: ../src/richtext/richtextborderspage.cpp:321
+#: ../src/richtext/richtextborderspage.cpp:355
+#: ../src/richtext/richtextborderspage.cpp:421
+#: ../src/richtext/richtextborderspage.cpp:455
+#: ../src/richtext/richtextborderspage.cpp:489
+#: ../src/richtext/richtextborderspage.cpp:523
+#: ../src/richtext/richtextborderspage.cpp:591
+#: ../src/richtext/richtextmarginspage.cpp:200
+#: ../src/richtext/richtextmarginspage.cpp:225
+#: ../src/richtext/richtextmarginspage.cpp:248
+#: ../src/richtext/richtextmarginspage.cpp:273
+#: ../src/richtext/richtextmarginspage.cpp:314
+#: ../src/richtext/richtextmarginspage.cpp:339
+#: ../src/richtext/richtextmarginspage.cpp:362
+#: ../src/richtext/richtextmarginspage.cpp:387
+#: ../src/richtext/richtextsizepage.cpp:338
+#: ../src/richtext/richtextsizepage.cpp:372
+#: ../src/richtext/richtextsizepage.cpp:399
+#: ../src/richtext/richtextsizepage.cpp:426
+#: ../src/richtext/richtextsizepage.cpp:453
+#: ../src/richtext/richtextsizepage.cpp:480
+#: ../src/richtext/richtextsizepage.cpp:554
+#: ../src/richtext/richtextsizepage.cpp:589
+#: ../src/richtext/richtextsizepage.cpp:624
+#: ../src/richtext/richtextsizepage.cpp:659
+msgid "cm"
+msgstr "cm"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:226
+#: ../src/richtext/richtextbackgroundpage.cpp:249
+#: ../src/richtext/richtextbackgroundpage.cpp:289
+#: ../src/richtext/richtextbackgroundpage.cpp:316
+#: ../src/richtext/richtextborderspage.cpp:254
+#: ../src/richtext/richtextborderspage.cpp:288
+#: ../src/richtext/richtextborderspage.cpp:322
+#: ../src/richtext/richtextborderspage.cpp:356
+#: ../src/richtext/richtextborderspage.cpp:422
+#: ../src/richtext/richtextborderspage.cpp:456
+#: ../src/richtext/richtextborderspage.cpp:490
+#: ../src/richtext/richtextborderspage.cpp:524
+#: ../src/richtext/richtextborderspage.cpp:592
+#: ../src/richtext/richtextfontpage.cpp:176
+#: ../src/richtext/richtextfontpage.cpp:179
+msgid "pt"
+msgstr "pt"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:229
+#: ../src/richtext/richtextbackgroundpage.cpp:231
+#: ../src/richtext/richtextbackgroundpage.cpp:252
+#: ../src/richtext/richtextbackgroundpage.cpp:254
+#: ../src/richtext/richtextbackgroundpage.cpp:292
+#: ../src/richtext/richtextbackgroundpage.cpp:294
+#: ../src/richtext/richtextbackgroundpage.cpp:319
+#: ../src/richtext/richtextbackgroundpage.cpp:321
+msgid "Units for this value."
+msgstr "Unità per questo valore."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:234
+msgid "&Vertical offset:"
+msgstr "Offset &verticale:"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:241
+#: ../src/richtext/richtextbackgroundpage.cpp:243
+msgid "The vertical offset."
+msgstr "L'offset verticale."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:257
+msgid "Shadow c&olour:"
+msgstr "C&olore ombreggiatura:"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:259
+#: ../src/richtext/richtextbackgroundpage.cpp:261
+msgid "Enables the shadow colour."
+msgstr "Abilita colore ombreggiatura."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:265
+#: ../src/richtext/richtextbackgroundpage.cpp:267
+msgid "The shadow colour."
+msgstr "Il colore ombreggiatura."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:270
+msgid "Sh&adow spread:"
+msgstr "Di&ffusione ombra:"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:272
+#: ../src/richtext/richtextbackgroundpage.cpp:274
+msgid "Enables the shadow spread."
+msgstr "Abilita diffusione ombra."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:281
+#: ../src/richtext/richtextbackgroundpage.cpp:283
+msgid "The shadow spread."
+msgstr "La diffusione ombraggiatura."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:297
+msgid "&Blur distance:"
+msgstr "Distanza &sfocatura:"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:299
+#: ../src/richtext/richtextbackgroundpage.cpp:301
+msgid "Enables the blur distance."
+msgstr "Abilita distanza sfocatura."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:308
+#: ../src/richtext/richtextbackgroundpage.cpp:310
+msgid "The shadow blur distance."
+msgstr "La distanza sfocatura ombreggiatura."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:324
+msgid "Opaci&ty:"
+msgstr "Opaci&tà:"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:326
+#: ../src/richtext/richtextbackgroundpage.cpp:328
+msgid "Enables the shadow opacity."
+msgstr "Abilita opacità ombra."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:335
+#: ../src/richtext/richtextbackgroundpage.cpp:337
+msgid "The shadow opacity."
+msgstr "L'opacità ombreggiatura."
+
+#. TRANSLATORS: Rich text page units (percentage)
+#: ../src/richtext/richtextbackgroundpage.cpp:340
+#: ../src/richtext/richtextsizepage.cpp:339
+#: ../src/richtext/richtextsizepage.cpp:373
+#: ../src/richtext/richtextsizepage.cpp:400
+#: ../src/richtext/richtextsizepage.cpp:427
+#: ../src/richtext/richtextsizepage.cpp:454
+#: ../src/richtext/richtextsizepage.cpp:481
+#: ../src/richtext/richtextsizepage.cpp:555
+#: ../src/richtext/richtextsizepage.cpp:590
+#: ../src/richtext/richtextsizepage.cpp:625
+#: ../src/richtext/richtextsizepage.cpp:660
+msgid "%"
+msgstr "%"
+
+#: ../src/richtext/richtextborderspage.cpp:229
+#: ../src/richtext/richtextborderspage.cpp:387
+msgid "Border"
+msgstr "Bordo"
+
+#: ../src/richtext/richtextborderspage.cpp:242
+#: ../src/richtext/richtextborderspage.cpp:410
+#: ../src/richtext/richtextindentspage.cpp:194
+#: ../src/richtext/richtextliststylepage.cpp:384
+#: ../src/richtext/richtextmarginspage.cpp:185
+#: ../src/richtext/richtextmarginspage.cpp:299
+#: ../src/richtext/richtextsizepage.cpp:531
+#: ../src/richtext/richtextsizepage.cpp:538
+msgid "&Left:"
+msgstr "&Sinistra:"
+
+#: ../src/richtext/richtextborderspage.cpp:257
+#: ../src/richtext/richtextborderspage.cpp:259
+msgid "Units for the left border width."
+msgstr "Unità larghezza bordo sinistro."
+
+#: ../src/richtext/richtextborderspage.cpp:266
+#: ../src/richtext/richtextborderspage.cpp:268
+#: ../src/richtext/richtextborderspage.cpp:300
+#: ../src/richtext/richtextborderspage.cpp:302
+#: ../src/richtext/richtextborderspage.cpp:334
+#: ../src/richtext/richtextborderspage.cpp:336
+#: ../src/richtext/richtextborderspage.cpp:368
+#: ../src/richtext/richtextborderspage.cpp:370
+#: ../src/richtext/richtextborderspage.cpp:434
+#: ../src/richtext/richtextborderspage.cpp:436
+#: ../src/richtext/richtextborderspage.cpp:468
+#: ../src/richtext/richtextborderspage.cpp:470
+#: ../src/richtext/richtextborderspage.cpp:502
+#: ../src/richtext/richtextborderspage.cpp:504
+#: ../src/richtext/richtextborderspage.cpp:536
+#: ../src/richtext/richtextborderspage.cpp:538
+msgid "The border line style."
+msgstr "Lo stile del bordo."
+
+#: ../src/richtext/richtextborderspage.cpp:276
+#: ../src/richtext/richtextborderspage.cpp:444
+#: ../src/richtext/richtextindentspage.cpp:212
+#: ../src/richtext/richtextliststylepage.cpp:402
+#: ../src/richtext/richtextmarginspage.cpp:210
+#: ../src/richtext/richtextmarginspage.cpp:324
+#: ../src/richtext/richtextsizepage.cpp:601
+#: ../src/richtext/richtextsizepage.cpp:608
+msgid "&Right:"
+msgstr "&Destra:"
+
+#: ../src/richtext/richtextborderspage.cpp:291
+#: ../src/richtext/richtextborderspage.cpp:293
+msgid "Units for the right border width."
+msgstr "Unità larghezza bordo destro."
+
+#: ../src/richtext/richtextborderspage.cpp:310
+#: ../src/richtext/richtextborderspage.cpp:478
+#: ../src/richtext/richtextmarginspage.cpp:233
+#: ../src/richtext/richtextmarginspage.cpp:347
+#: ../src/richtext/richtextsizepage.cpp:566
+#: ../src/richtext/richtextsizepage.cpp:573
+msgid "&Top:"
+msgstr "Al&to:"
+
+#: ../src/richtext/richtextborderspage.cpp:325
+#: ../src/richtext/richtextborderspage.cpp:327
+msgid "Units for the top border width."
+msgstr "Unita larghezza bordo superiore."
+
+#: ../src/richtext/richtextborderspage.cpp:344
+#: ../src/richtext/richtextborderspage.cpp:512
+#: ../src/richtext/richtextmarginspage.cpp:258
+#: ../src/richtext/richtextmarginspage.cpp:372
+#: ../src/richtext/richtextsizepage.cpp:636
+#: ../src/richtext/richtextsizepage.cpp:643
+msgid "&Bottom:"
+msgstr "&Basso:"
+
+#: ../src/richtext/richtextborderspage.cpp:359
+#: ../src/richtext/richtextborderspage.cpp:361
+msgid "Units for the bottom border width."
+msgstr "Unità larghezza bordo inferiore."
+
+#: ../src/richtext/richtextborderspage.cpp:380
+#: ../src/richtext/richtextborderspage.cpp:548
+msgid "&Synchronize values"
+msgstr "&Sincronizza valori"
+
+#: ../src/richtext/richtextborderspage.cpp:382
+#: ../src/richtext/richtextborderspage.cpp:384
+#: ../src/richtext/richtextborderspage.cpp:550
+#: ../src/richtext/richtextborderspage.cpp:552
+msgid "Check to edit all borders simultaneously."
+msgstr "Seleziona per modificare simultaneamente tutti i bordi."
+
+#: ../src/richtext/richtextborderspage.cpp:397
+#: ../src/richtext/richtextborderspage.cpp:555
+msgid "Outline"
+msgstr "Contorno"
+
+#: ../src/richtext/richtextborderspage.cpp:425
+#: ../src/richtext/richtextborderspage.cpp:427
+msgid "Units for the left outline width."
+msgstr "Unita larghezza contorno sinistro."
+
+#: ../src/richtext/richtextborderspage.cpp:459
+#: ../src/richtext/richtextborderspage.cpp:461
+msgid "Units for the right outline width."
+msgstr "Unità larghezza contorno destro."
+
+#: ../src/richtext/richtextborderspage.cpp:493
+#: ../src/richtext/richtextborderspage.cpp:495
+msgid "Units for the top outline width."
+msgstr "Unita larghezza contorno superiore."
+
+#: ../src/richtext/richtextborderspage.cpp:527
+#: ../src/richtext/richtextborderspage.cpp:529
+msgid "Units for the bottom outline width."
+msgstr "Unità larghezza contorno inferiore."
+
+#: ../src/richtext/richtextborderspage.cpp:565
+#: ../src/richtext/richtextborderspage.cpp:600
+msgid "Corner"
+msgstr "Angolo"
+
+#: ../src/richtext/richtextborderspage.cpp:574
+msgid "Corner &radius:"
+msgstr "&Raggio angolo:"
+
+#: ../src/richtext/richtextborderspage.cpp:576
+#: ../src/richtext/richtextborderspage.cpp:578
+msgid "An optional corner radius for adding rounded corners."
+msgstr "Un raggio angolo opzionale per aggiungere angoli arrotondati."
+
+#: ../src/richtext/richtextborderspage.cpp:584
+#: ../src/richtext/richtextborderspage.cpp:586
+msgid "The value of the corner radius."
+msgstr "Il valore del raggio angolo."
+
+#: ../src/richtext/richtextborderspage.cpp:595
+#: ../src/richtext/richtextborderspage.cpp:597
+msgid "Units for the corner radius."
+msgstr "Unità raggio angolo."
+
+#: ../src/richtext/richtextborderspage.cpp:609
+#: ../src/richtext/richtextsizepage.cpp:247
+#: ../src/richtext/richtextsizepage.cpp:251
+msgid "None"
+msgstr "Nessuno"
+
+#: ../src/richtext/richtextborderspage.cpp:610
+msgid "Solid"
+msgstr "Grassetto"
+
+#: ../src/richtext/richtextborderspage.cpp:611
+msgid "Dotted"
+msgstr "Punteggiato"
+
+#: ../src/richtext/richtextborderspage.cpp:612
+msgid "Dashed"
+msgstr "Tratteggiato"
+
+#: ../src/richtext/richtextborderspage.cpp:613
+msgid "Double"
+msgstr "Doppio"
+
+#: ../src/richtext/richtextborderspage.cpp:614
+msgid "Groove"
+msgstr "Scanalatura"
+
+#: ../src/richtext/richtextborderspage.cpp:615
+msgid "Ridge"
+msgstr "Crinale"
+
+#: ../src/richtext/richtextborderspage.cpp:616
+msgid "Inset"
+msgstr "Aggiunta"
+
+#: ../src/richtext/richtextborderspage.cpp:617
+msgid "Outset"
+msgstr "Rimozione"
+
+#: ../src/richtext/richtextbuffer.cpp:3518
+msgid "Change Style"
+msgstr "Modifica stile"
+
+#: ../src/richtext/richtextbuffer.cpp:3701
+msgid "Change Object Style"
+msgstr "Modifica stile oggetto"
+
+#: ../src/richtext/richtextbuffer.cpp:3974
+#: ../src/richtext/richtextbuffer.cpp:8174
+msgid "Change Properties"
+msgstr "Modifica proprietà"
+
+#: ../src/richtext/richtextbuffer.cpp:4346
+msgid "Change List Style"
+msgstr "Modifica stile elenco"
+
+#: ../src/richtext/richtextbuffer.cpp:4519
+msgid "Renumber List"
+msgstr "Rinumera l'elenco"
+
+#: ../src/richtext/richtextbuffer.cpp:7867
+#: ../src/richtext/richtextbuffer.cpp:7897
+#: ../src/richtext/richtextbuffer.cpp:7939
+#: ../src/richtext/richtextctrl.cpp:1279 ../src/richtext/richtextctrl.cpp:1473
+msgid "Insert Text"
+msgstr "Inserisci testo"
+
+#: ../src/richtext/richtextbuffer.cpp:8023
+#: ../src/richtext/richtextbuffer.cpp:8979
+msgid "Insert Image"
+msgstr "Inserisci immagine"
+
+#: ../src/richtext/richtextbuffer.cpp:8070
+msgid "Insert Object"
+msgstr "Inserisci oggetto"
+
+#: ../src/richtext/richtextbuffer.cpp:8112
+msgid "Insert Field"
+msgstr "Inserisci campo"
+
+#: ../src/richtext/richtextbuffer.cpp:8410
+msgid "Too many EndStyle calls!"
+msgstr "Troppe chiamate a EndStyle!"
+
+#: ../src/richtext/richtextbuffer.cpp:8785
+msgid "files"
+msgstr "file"
+
+#: ../src/richtext/richtextbuffer.cpp:9380
+msgid "standard/circle"
+msgstr "standard/cerchio"
+
+#: ../src/richtext/richtextbuffer.cpp:9381
+msgid "standard/circle-outline"
+msgstr "standard/cerchio con contorno"
+
+#: ../src/richtext/richtextbuffer.cpp:9382
+msgid "standard/square"
+msgstr "standard/quadrato"
+
+#: ../src/richtext/richtextbuffer.cpp:9383
+msgid "standard/diamond"
+msgstr "standard/diamante"
+
+#: ../src/richtext/richtextbuffer.cpp:9384
+msgid "standard/triangle"
+msgstr "standard/triangolo"
+
+#: ../src/richtext/richtextbuffer.cpp:9423
+msgid "Box Properties"
+msgstr "Proprietà riquadro"
+
+#: ../src/richtext/richtextbuffer.cpp:10006
+msgid "Multiple Cell Properties"
+msgstr "Proprietà celle multiple"
+
+#: ../src/richtext/richtextbuffer.cpp:10008
+msgid "Cell Properties"
+msgstr "Proprietà cella"
+
+#: ../src/richtext/richtextbuffer.cpp:11256
+msgid "Set Cell Style"
+msgstr "Imposta stile cella"
+
+#: ../src/richtext/richtextbuffer.cpp:11330
+msgid "Delete Row"
+msgstr "Elimina riga"
+
+#: ../src/richtext/richtextbuffer.cpp:11380
+msgid "Delete Column"
+msgstr "Elimina colonna"
+
+#: ../src/richtext/richtextbuffer.cpp:11431
+msgid "Add Row"
+msgstr "Aggiungi riga"
+
+#: ../src/richtext/richtextbuffer.cpp:11494
+msgid "Add Column"
+msgstr "Aggiungi colonna"
+
+#: ../src/richtext/richtextbuffer.cpp:11537
+msgid "Table Properties"
+msgstr "Proprietà tabella"
+
+#: ../src/richtext/richtextbuffer.cpp:12899
+msgid "Picture Properties"
+msgstr "Proprietà immagine"
+
+#: ../src/richtext/richtextbuffer.cpp:13169
+#: ../src/richtext/richtextbuffer.cpp:13279
+msgid "image"
+msgstr "immagine"
+
+#: ../src/richtext/richtextbulletspage.cpp:145
+#: ../src/richtext/richtextliststylepage.cpp:209
+msgid "&Bullet style:"
+msgstr "Stile &punto:"
+
+#: ../src/richtext/richtextbulletspage.cpp:150
+#: ../src/richtext/richtextbulletspage.cpp:152
+#: ../src/richtext/richtextliststylepage.cpp:214
+#: ../src/richtext/richtextliststylepage.cpp:216
+msgid "The available bullet styles."
+msgstr "Tipi di puntatura disponibili."
+
+#: ../src/richtext/richtextbulletspage.cpp:158
+#: ../src/richtext/richtextliststylepage.cpp:221
+msgid "Peri&od"
+msgstr "Punt&o"
+
+#: ../src/richtext/richtextbulletspage.cpp:160
+#: ../src/richtext/richtextbulletspage.cpp:162
+#: ../src/richtext/richtextliststylepage.cpp:223
+#: ../src/richtext/richtextliststylepage.cpp:225
+msgid "Check to add a period after the bullet."
+msgstr "Spunta per aggiungere un punto dopo il pallino."
+
+#. TRANSLATORS: Bullet point in parentheses option
+#: ../src/richtext/richtextbulletspage.cpp:167
+#: ../src/richtext/richtextliststylepage.cpp:230
+msgid "(*)"
+msgstr "(*)"
+
+#: ../src/richtext/richtextbulletspage.cpp:169
+#: ../src/richtext/richtextbulletspage.cpp:171
+#: ../src/richtext/richtextliststylepage.cpp:232
+#: ../src/richtext/richtextliststylepage.cpp:234
+msgid "Check to enclose the bullet in parentheses."
+msgstr "Spunta pe racchiudere la puntatura in una coppia di parentesi."
+
+#. TRANSLATORS: Right parenthesis bullet point option
+#: ../src/richtext/richtextbulletspage.cpp:176
+#: ../src/richtext/richtextliststylepage.cpp:239
+msgid "*)"
+msgstr "*)"
+
+#: ../src/richtext/richtextbulletspage.cpp:178
+#: ../src/richtext/richtextbulletspage.cpp:180
+#: ../src/richtext/richtextliststylepage.cpp:241
+#: ../src/richtext/richtextliststylepage.cpp:243
+msgid "Check to add a right parenthesis."
+msgstr "Spunta per aggiungere una parentesi chiusa a destra."
+
+#: ../src/richtext/richtextbulletspage.cpp:185
+#: ../src/richtext/richtextliststylepage.cpp:248
+msgid "Bullet &Alignment:"
+msgstr "&Allineamento punto elenco:"
+
+#: ../src/richtext/richtextbulletspage.cpp:190
+#: ../src/richtext/richtextliststylepage.cpp:253
+msgid "Centre"
+msgstr "Centrato"
+
+#: ../src/richtext/richtextbulletspage.cpp:194
+#: ../src/richtext/richtextbulletspage.cpp:196
+#: ../src/richtext/richtextbulletspage.cpp:217
+#: ../src/richtext/richtextbulletspage.cpp:219
+#: ../src/richtext/richtextliststylepage.cpp:257
+#: ../src/richtext/richtextliststylepage.cpp:259
+#: ../src/richtext/richtextliststylepage.cpp:278
+#: ../src/richtext/richtextliststylepage.cpp:280
+msgid "The bullet character."
+msgstr "Il carattere punto elenco."
+
+#: ../src/richtext/richtextbulletspage.cpp:212
+#: ../src/richtext/richtextliststylepage.cpp:271
+msgid "&Symbol:"
+msgstr "&Simbolo:"
+
+#: ../src/richtext/richtextbulletspage.cpp:222
+#: ../src/richtext/richtextliststylepage.cpp:283
+msgid "Ch&oose..."
+msgstr "&Scegli..."
+
+#: ../src/richtext/richtextbulletspage.cpp:223
+#: ../src/richtext/richtextbulletspage.cpp:225
+#: ../src/richtext/richtextliststylepage.cpp:284
+#: ../src/richtext/richtextliststylepage.cpp:286
+msgid "Click to browse for a symbol."
+msgstr "Clic per selezionare un simbolo."
+
+#: ../src/richtext/richtextbulletspage.cpp:230
+#: ../src/richtext/richtextliststylepage.cpp:291
+msgid "Symbol &font:"
+msgstr "&Font simboli:"
+
+#: ../src/richtext/richtextbulletspage.cpp:235
+#: ../src/richtext/richtextbulletspage.cpp:237
+#: ../src/richtext/richtextliststylepage.cpp:297
+msgid "Available fonts."
+msgstr "Font disponibili."
+
+#: ../src/richtext/richtextbulletspage.cpp:242
+#: ../src/richtext/richtextliststylepage.cpp:302
+msgid "S&tandard bullet name:"
+msgstr "Nome di una elenco puntato s&tandard:"
+
+#: ../src/richtext/richtextbulletspage.cpp:247
+#: ../src/richtext/richtextbulletspage.cpp:249
+#: ../src/richtext/richtextliststylepage.cpp:307
+#: ../src/richtext/richtextliststylepage.cpp:309
+msgid "A standard bullet name."
+msgstr "Il nome di un punto elenco standard."
+
+#: ../src/richtext/richtextbulletspage.cpp:254
+msgid "&Number:"
+msgstr "&Numero:"
+
+#: ../src/richtext/richtextbulletspage.cpp:258
+#: ../src/richtext/richtextbulletspage.cpp:260
+msgid "The list item number."
+msgstr "Il numero della voce dell'elenco."
+
+#: ../src/richtext/richtextbulletspage.cpp:266
+#: ../src/richtext/richtextbulletspage.cpp:268
+#: ../src/richtext/richtextliststylepage.cpp:475
+#: ../src/richtext/richtextliststylepage.cpp:477
+msgid "Shows a preview of the bullet settings."
+msgstr "Visualizza l'anteprima delle impostazioni di puntatura."
+
+#: ../src/richtext/richtextbulletspage.cpp:276
+#: ../src/richtext/richtextliststylepage.cpp:484
+msgid "(None)"
+msgstr "(Nessuno)"
+
+#: ../src/richtext/richtextbulletspage.cpp:277
+#: ../src/richtext/richtextliststylepage.cpp:485
+msgid "Arabic"
+msgstr "Numeri arabi"
+
+#: ../src/richtext/richtextbulletspage.cpp:278
+#: ../src/richtext/richtextliststylepage.cpp:486
+msgid "Upper case letters"
+msgstr "Lettere maiuscole"
+
+#: ../src/richtext/richtextbulletspage.cpp:279
+#: ../src/richtext/richtextliststylepage.cpp:487
+msgid "Lower case letters"
+msgstr "Lettere minuscole"
+
+#: ../src/richtext/richtextbulletspage.cpp:280
+#: ../src/richtext/richtextliststylepage.cpp:488
+msgid "Upper case roman numerals"
+msgstr "Numeri romani maiuscoli"
+
+#: ../src/richtext/richtextbulletspage.cpp:281
+#: ../src/richtext/richtextliststylepage.cpp:489
+msgid "Lower case roman numerals"
+msgstr "Numeri romani minuscoli"
+
+#: ../src/richtext/richtextbulletspage.cpp:282
+#: ../src/richtext/richtextliststylepage.cpp:490
+msgid "Numbered outline"
+msgstr "Numeri gerarchici"
+
+#: ../src/richtext/richtextbulletspage.cpp:283
+#: ../src/richtext/richtextliststylepage.cpp:491
+msgid "Symbol"
+msgstr "Simbolo"
+
+#: ../src/richtext/richtextbulletspage.cpp:284
+#: ../src/richtext/richtextliststylepage.cpp:492
+msgid "Bitmap"
+msgstr "Immagine"
+
+#: ../src/richtext/richtextbulletspage.cpp:285
+#: ../src/richtext/richtextliststylepage.cpp:493
+msgid "Standard"
+msgstr "Standard"
+
+#: ../src/richtext/richtextbulletspage.cpp:287
+#: ../src/richtext/richtextliststylepage.cpp:495
+msgid "*"
+msgstr "*"
+
+#: ../src/richtext/richtextbulletspage.cpp:288
+#: ../src/richtext/richtextliststylepage.cpp:496
+msgid "-"
+msgstr "-"
+
+#: ../src/richtext/richtextbulletspage.cpp:289
+#: ../src/richtext/richtextliststylepage.cpp:497
+msgid ">"
+msgstr ">"
+
+#: ../src/richtext/richtextbulletspage.cpp:290
+#: ../src/richtext/richtextliststylepage.cpp:498
+msgid "+"
+msgstr "+"
+
+#: ../src/richtext/richtextbulletspage.cpp:291
+#: ../src/richtext/richtextliststylepage.cpp:499
+msgid "~"
+msgstr "~"
+
+#: ../src/richtext/richtextctrl.cpp:859
+msgid "Drag"
+msgstr "Trascina"
+
+#: ../src/richtext/richtextctrl.cpp:1338 ../src/richtext/richtextctrl.cpp:1559
+msgid "Delete Text"
+msgstr "Elimina testo"
+
+#: ../src/richtext/richtextctrl.cpp:1537
+msgid "Remove Bullet"
+msgstr "Rimuovi punto elenco"
+
+#: ../src/richtext/richtextctrl.cpp:3070
+msgid "The text couldn't be saved."
+msgstr "Il testo non può essere salvato."
+
+#: ../src/richtext/richtextctrl.cpp:3644
+msgid "Replace"
+msgstr "Sostituisci"
+
+#: ../src/richtext/richtextfontpage.cpp:146
+#: ../src/richtext/richtextsymboldlg.cpp:384
+msgid "&Font:"
+msgstr "&Font:"
+
+#: ../src/richtext/richtextfontpage.cpp:150
+#: ../src/richtext/richtextfontpage.cpp:152
+msgid "Type a font name."
+msgstr "Digita un nome font."
+
+#: ../src/richtext/richtextfontpage.cpp:158
+msgid "&Size:"
+msgstr "Dimen&sione:"
+
+#: ../src/richtext/richtextfontpage.cpp:165
+#: ../src/richtext/richtextfontpage.cpp:167
+msgid "Type a size in points."
+msgstr "Inserisci la dimensione in punti."
+
+#: ../src/richtext/richtextfontpage.cpp:180
+#: ../src/richtext/richtextfontpage.cpp:182
+msgid "The font size units, points or pixels."
+msgstr "L'unità di misura della font, punti o pixel."
+
+#: ../src/richtext/richtextfontpage.cpp:189
+#: ../src/richtext/richtextfontpage.cpp:191
+msgid "Lists the available fonts."
+msgstr "Elenca i font disponibili."
+
+#: ../src/richtext/richtextfontpage.cpp:196
+#: ../src/richtext/richtextfontpage.cpp:198
+msgid "Lists font sizes in points."
+msgstr "Elenca le dimensioni in punti del font."
+
+#: ../src/richtext/richtextfontpage.cpp:207
+msgid "Font st&yle:"
+msgstr "St&ile font:"
+
+#: ../src/richtext/richtextfontpage.cpp:212
+#: ../src/richtext/richtextfontpage.cpp:214
+msgid "Select regular or italic style."
+msgstr "Seleziona normale e corsivo."
+
+#: ../src/richtext/richtextfontpage.cpp:220
+msgid "Font &weight:"
+msgstr "&Peso font:"
+
+#: ../src/richtext/richtextfontpage.cpp:225
+#: ../src/richtext/richtextfontpage.cpp:227
+msgid "Select regular or bold."
+msgstr "Seleziona normale e grassetto."
+
+#: ../src/richtext/richtextfontpage.cpp:233
+msgid "&Underlining:"
+msgstr "&Sottolineatura:"
+
+#: ../src/richtext/richtextfontpage.cpp:238
+#: ../src/richtext/richtextfontpage.cpp:240
+msgid "Select underlining or no underlining."
+msgstr "Seleziona sottolineato o non sottolineato."
+
+#: ../src/richtext/richtextfontpage.cpp:248
+msgid "&Colour:"
+msgstr "&Colore:"
+
+#: ../src/richtext/richtextfontpage.cpp:253
+#: ../src/richtext/richtextfontpage.cpp:255
+msgid "Click to change the text colour."
+msgstr "Seleziona per modificare il colore del testo."
+
+#: ../src/richtext/richtextfontpage.cpp:261
+msgid "&Bg colour:"
+msgstr "&Colore sfondo:"
+
+#: ../src/richtext/richtextfontpage.cpp:266
+#: ../src/richtext/richtextfontpage.cpp:268
+msgid "Click to change the text background colour."
+msgstr "Clic per modificare il colore sfondo del testo."
+
+#: ../src/richtext/richtextfontpage.cpp:276
+#: ../src/richtext/richtextfontpage.cpp:278
+msgid "Check to show a line through the text."
+msgstr "Spunta per visualizzare una linea attraverso il testo."
+
+#: ../src/richtext/richtextfontpage.cpp:281
+msgid "Ca&pitals"
+msgstr "&Maiuscole"
+
+#: ../src/richtext/richtextfontpage.cpp:283
+#: ../src/richtext/richtextfontpage.cpp:285
+msgid "Check to show the text in capitals."
+msgstr "Spunta per visualizzare il testo in maiuscolo."
+
+#: ../src/richtext/richtextfontpage.cpp:288
+msgid "Small C&apitals"
+msgstr "M&aiuscoletto"
+
+#: ../src/richtext/richtextfontpage.cpp:290
+#: ../src/richtext/richtextfontpage.cpp:292
+msgid "Check to show the text in small capitals."
+msgstr "Spunta per visualizzare il testo in maiuscoletto."
+
+#: ../src/richtext/richtextfontpage.cpp:295
+msgid "Supe&rscript"
+msgstr "&Apice"
+
+#: ../src/richtext/richtextfontpage.cpp:297
+#: ../src/richtext/richtextfontpage.cpp:299
+msgid "Check to show the text in superscript."
+msgstr "Spunta pe visualizzare il testo ome apice."
+
+#: ../src/richtext/richtextfontpage.cpp:302
+msgid "Subscrip&t"
+msgstr "&Pedice"
+
+#: ../src/richtext/richtextfontpage.cpp:304
+#: ../src/richtext/richtextfontpage.cpp:306
+msgid "Check to show the text in subscript."
+msgstr "Spunta per visualizzare il testo come pedice."
+
+#: ../src/richtext/richtextfontpage.cpp:312
+msgid "Rig&ht-to-left"
+msgstr "&Destra-a-sinistra"
+
+#: ../src/richtext/richtextfontpage.cpp:314
+#: ../src/richtext/richtextfontpage.cpp:316
+msgid "Check to indicate right-to-left text layout."
+msgstr "Seleziona per indicare layout testo destra-a-sinistra."
+
+#: ../src/richtext/richtextfontpage.cpp:319
+msgid "Suppress hyphe&nation"
+msgstr "Disabilita sillabazio&ne"
+
+#: ../src/richtext/richtextfontpage.cpp:321
+#: ../src/richtext/richtextfontpage.cpp:323
+msgid "Check to suppress hyphenation."
+msgstr "Seleziona per disabilitare la sillabazione."
+
+#: ../src/richtext/richtextfontpage.cpp:329
+#: ../src/richtext/richtextfontpage.cpp:331
+msgid "Shows a preview of the font settings."
+msgstr "Visualizza l'anteprima delle impostazioni font."
+
+#: ../src/richtext/richtextfontpage.cpp:348
+#: ../src/richtext/richtextfontpage.cpp:352
+#: ../src/richtext/richtextfontpage.cpp:356
+#: ../src/richtext/richtextformatdlg.cpp:873
+#: ../src/richtext/richtextindentspage.cpp:273
+#: ../src/richtext/richtextindentspage.cpp:285
+#: ../src/richtext/richtextindentspage.cpp:286
+#: ../src/richtext/richtextindentspage.cpp:310
+#: ../src/richtext/richtextindentspage.cpp:325
+#: ../src/richtext/richtextliststylepage.cpp:451
+#: ../src/richtext/richtextliststylepage.cpp:463
+#: ../src/richtext/richtextliststylepage.cpp:464
+msgid "(none)"
+msgstr "(nessuno)"
+
+#: ../src/richtext/richtextfontpage.cpp:349
+#: ../src/richtext/richtextfontpage.cpp:353
+msgid "Regular"
+msgstr "Normale"
+
+#: ../src/richtext/richtextfontpage.cpp:357
+msgid "Not underlined"
+msgstr "Non sottolineato"
+
+#: ../src/richtext/richtextformatdlg.cpp:341
+msgid "Indents && Spacing"
+msgstr "Rientri e spaziature"
+
+#: ../src/richtext/richtextformatdlg.cpp:346
+msgid "Tabs"
+msgstr "Tabulazioni"
+
+#: ../src/richtext/richtextformatdlg.cpp:351
+msgid "Bullets"
+msgstr "Puntatura"
+
+#: ../src/richtext/richtextformatdlg.cpp:356
+msgid "List Style"
+msgstr "Stile elenco"
+
+#: ../src/richtext/richtextformatdlg.cpp:366
+#: ../src/richtext/richtextmarginspage.cpp:170
+msgid "Margins"
+msgstr "Margini"
+
+#: ../src/richtext/richtextformatdlg.cpp:371
+msgid "Borders"
+msgstr "Bordi"
+
+#: ../src/richtext/richtextformatdlg.cpp:765
+msgid "Colour"
+msgstr "Colore"
+
+#: ../src/richtext/richtextindentspage.cpp:127
+#: ../src/richtext/richtextliststylepage.cpp:322
+msgid "&Alignment"
+msgstr "&Allineamento"
+
+#: ../src/richtext/richtextindentspage.cpp:138
+#: ../src/richtext/richtextliststylepage.cpp:331
+msgid "&Left"
+msgstr "&Sinistra"
+
+#: ../src/richtext/richtextindentspage.cpp:140
+#: ../src/richtext/richtextindentspage.cpp:142
+#: ../src/richtext/richtextliststylepage.cpp:333
+#: ../src/richtext/richtextliststylepage.cpp:335
+msgid "Left-align text."
+msgstr "Allinea a sinistra."
+
+#: ../src/richtext/richtextindentspage.cpp:145
+#: ../src/richtext/richtextliststylepage.cpp:338
+msgid "&Right"
+msgstr "&Destra"
+
+#: ../src/richtext/richtextindentspage.cpp:147
+#: ../src/richtext/richtextindentspage.cpp:149
+#: ../src/richtext/richtextliststylepage.cpp:340
+#: ../src/richtext/richtextliststylepage.cpp:342
+msgid "Right-align text."
+msgstr "Allinea a destra."
+
+#: ../src/richtext/richtextindentspage.cpp:152
+#: ../src/richtext/richtextliststylepage.cpp:345
+msgid "&Justified"
+msgstr "&Giustificato"
+
+#: ../src/richtext/richtextindentspage.cpp:154
+#: ../src/richtext/richtextindentspage.cpp:156
+#: ../src/richtext/richtextliststylepage.cpp:347
+#: ../src/richtext/richtextliststylepage.cpp:349
+msgid "Justify text left and right."
+msgstr "Justifica il testo a sinistra e a destra."
+
+#: ../src/richtext/richtextindentspage.cpp:159
+#: ../src/richtext/richtextliststylepage.cpp:352
+msgid "Cen&tred"
+msgstr "Cen&trato"
+
+#: ../src/richtext/richtextindentspage.cpp:161
+#: ../src/richtext/richtextindentspage.cpp:163
+#: ../src/richtext/richtextliststylepage.cpp:354
+#: ../src/richtext/richtextliststylepage.cpp:356
+msgid "Centre text."
+msgstr "Centra il testo."
+
+#: ../src/richtext/richtextindentspage.cpp:166
+#: ../src/richtext/richtextliststylepage.cpp:359
+msgid "&Indeterminate"
+msgstr "&Indeterminato"
+
+#: ../src/richtext/richtextindentspage.cpp:168
+#: ../src/richtext/richtextindentspage.cpp:170
+#: ../src/richtext/richtextliststylepage.cpp:361
+#: ../src/richtext/richtextliststylepage.cpp:363
+msgid "Use the current alignment setting."
+msgstr "Utilizza le impostazioni di allineamento correnti."
+
+#: ../src/richtext/richtextindentspage.cpp:183
+#: ../src/richtext/richtextliststylepage.cpp:375
+msgid "&Indentation (tenths of a mm)"
+msgstr "&Rientro (decimi di millimetro)"
+
+#: ../src/richtext/richtextindentspage.cpp:198
+#: ../src/richtext/richtextindentspage.cpp:200
+#: ../src/richtext/richtextliststylepage.cpp:388
+#: ../src/richtext/richtextliststylepage.cpp:390
+msgid "The left indent."
+msgstr "Il rientro dal margine sinistro."
+
+#: ../src/richtext/richtextindentspage.cpp:203
+#: ../src/richtext/richtextliststylepage.cpp:393
+msgid "Left (&first line):"
+msgstr "Sinistra (&prima riga):"
+
+#: ../src/richtext/richtextindentspage.cpp:207
+#: ../src/richtext/richtextindentspage.cpp:209
+#: ../src/richtext/richtextliststylepage.cpp:397
+#: ../src/richtext/richtextliststylepage.cpp:399
+msgid "The first line indent."
+msgstr "Il rientro della prima riga."
+
+#: ../src/richtext/richtextindentspage.cpp:216
+#: ../src/richtext/richtextindentspage.cpp:218
+#: ../src/richtext/richtextliststylepage.cpp:406
+#: ../src/richtext/richtextliststylepage.cpp:408
+msgid "The right indent."
+msgstr "Rientro da destra."
+
+#: ../src/richtext/richtextindentspage.cpp:221
+msgid "&Outline level:"
+msgstr "&Livello contorno:"
+
+#: ../src/richtext/richtextindentspage.cpp:226
+#: ../src/richtext/richtextindentspage.cpp:228
+msgid "The outline level."
+msgstr "Livello contorni."
+
+#: ../src/richtext/richtextindentspage.cpp:241
+#: ../src/richtext/richtextliststylepage.cpp:420
+msgid "&Spacing (tenths of a mm)"
+msgstr "&Spaziatura (decimi di millimetro)"
+
+#: ../src/richtext/richtextindentspage.cpp:252
+msgid "&Before a paragraph:"
+msgstr "&Prima di un paragrafo:"
+
+#: ../src/richtext/richtextindentspage.cpp:256
+#: ../src/richtext/richtextindentspage.cpp:258
+#: ../src/richtext/richtextliststylepage.cpp:433
+#: ../src/richtext/richtextliststylepage.cpp:435
+msgid "The spacing before the paragraph."
+msgstr "Spazio prima del paragrafo."
+
+#: ../src/richtext/richtextindentspage.cpp:261
+msgid "&After a paragraph:"
+msgstr "Dopo un p&aragrafo:"
+
+#: ../src/richtext/richtextindentspage.cpp:266
+#: ../src/richtext/richtextliststylepage.cpp:442
+#: ../src/richtext/richtextliststylepage.cpp:444
+msgid "The spacing after the paragraph."
+msgstr "Spazio dopo il paragrafo."
+
+#: ../src/richtext/richtextindentspage.cpp:269
+msgid "L&ine spacing:"
+msgstr "&Interlinea:"
+
+#: ../src/richtext/richtextindentspage.cpp:274
+#: ../src/richtext/richtextliststylepage.cpp:452
+msgid "Single"
+msgstr "Singola"
+
+#: ../src/richtext/richtextindentspage.cpp:275
+#: ../src/richtext/richtextliststylepage.cpp:453
+msgid "1.1"
+msgstr "1.1"
+
+#: ../src/richtext/richtextindentspage.cpp:276
+#: ../src/richtext/richtextliststylepage.cpp:454
+msgid "1.2"
+msgstr "1.2"
+
+#: ../src/richtext/richtextindentspage.cpp:277
+#: ../src/richtext/richtextliststylepage.cpp:455
+msgid "1.3"
+msgstr "1.3"
+
+#: ../src/richtext/richtextindentspage.cpp:278
+#: ../src/richtext/richtextliststylepage.cpp:456
+msgid "1.4"
+msgstr "1.4"
+
+#: ../src/richtext/richtextindentspage.cpp:279
+#: ../src/richtext/richtextliststylepage.cpp:457
+msgid "1.5"
+msgstr "1.5"
+
+#: ../src/richtext/richtextindentspage.cpp:280
+#: ../src/richtext/richtextliststylepage.cpp:458
+msgid "1.6"
+msgstr "1.6"
+
+#: ../src/richtext/richtextindentspage.cpp:281
+#: ../src/richtext/richtextliststylepage.cpp:459
+msgid "1.7"
+msgstr "1.7"
+
+#: ../src/richtext/richtextindentspage.cpp:282
+#: ../src/richtext/richtextliststylepage.cpp:460
+msgid "1.8"
+msgstr "1.8"
+
+#: ../src/richtext/richtextindentspage.cpp:283
+#: ../src/richtext/richtextliststylepage.cpp:461
+msgid "1.9"
+msgstr "1.9"
+
+#: ../src/richtext/richtextindentspage.cpp:284
+#: ../src/richtext/richtextliststylepage.cpp:462
+msgid "2"
+msgstr "2"
+
+#: ../src/richtext/richtextindentspage.cpp:287
+#: ../src/richtext/richtextindentspage.cpp:289
+#: ../src/richtext/richtextliststylepage.cpp:465
+#: ../src/richtext/richtextliststylepage.cpp:467
+msgid "The line spacing."
+msgstr "L'interlinea."
+
+#: ../src/richtext/richtextindentspage.cpp:292
+msgid "&Page Break"
+msgstr "Interruzione di &pagina"
+
+#: ../src/richtext/richtextindentspage.cpp:294
+#: ../src/richtext/richtextindentspage.cpp:296
+msgid "Inserts a page break before the paragraph."
+msgstr "Inserisci una interruzione pagina prima del paragrafo."
+
+#: ../src/richtext/richtextindentspage.cpp:302
+#: ../src/richtext/richtextindentspage.cpp:304
+msgid "Shows a preview of the paragraph settings."
+msgstr "Visualizza l'anteprima delle impostazioni di paragrafo."
+
+#: ../src/richtext/richtextliststylepage.cpp:182
+msgid "&List level:"
+msgstr "&Livello elenco:"
+
+#: ../src/richtext/richtextliststylepage.cpp:186
+#: ../src/richtext/richtextliststylepage.cpp:188
+msgid "Selects the list level to edit."
+msgstr "Seleziona il livello da modificare."
+
+#: ../src/richtext/richtextliststylepage.cpp:193
+msgid "&Font for Level..."
+msgstr "&Font per questo livello..."
+
+#: ../src/richtext/richtextliststylepage.cpp:194
+#: ../src/richtext/richtextliststylepage.cpp:196
+msgid "Click to choose the font for this level."
+msgstr "Seleziona per selezionare il font per il livello attuale."
+
+#: ../src/richtext/richtextliststylepage.cpp:312
+msgid "Bullet style"
+msgstr "Stile del punto"
+
+#: ../src/richtext/richtextliststylepage.cpp:429
+msgid "Before a paragraph:"
+msgstr "Prima di un paragrafo:"
+
+#: ../src/richtext/richtextliststylepage.cpp:438
+msgid "After a paragraph:"
+msgstr "Dopo un paragrafo:"
+
+#: ../src/richtext/richtextliststylepage.cpp:447
+msgid "Line spacing:"
+msgstr "Interlinea:"
+
+#: ../src/richtext/richtextliststylepage.cpp:470
+msgid "Spacing"
+msgstr "Spaziatura"
+
+#: ../src/richtext/richtextmarginspage.cpp:193
+#: ../src/richtext/richtextmarginspage.cpp:195
+msgid "The left margin size."
+msgstr "La dimensione del margine sinistro."
+
+#: ../src/richtext/richtextmarginspage.cpp:203
+#: ../src/richtext/richtextmarginspage.cpp:205
+msgid "Units for the left margin."
+msgstr "Unità margine sinistro."
+
+#: ../src/richtext/richtextmarginspage.cpp:218
+#: ../src/richtext/richtextmarginspage.cpp:220
+msgid "The right margin size."
+msgstr "La dimensione del margine destro."
+
+#: ../src/richtext/richtextmarginspage.cpp:228
+#: ../src/richtext/richtextmarginspage.cpp:230
+msgid "Units for the right margin."
+msgstr "Unità margine destro."
+
+#: ../src/richtext/richtextmarginspage.cpp:241
+#: ../src/richtext/richtextmarginspage.cpp:243
+msgid "The top margin size."
+msgstr "La dimensione del margine alto."
+
+#: ../src/richtext/richtextmarginspage.cpp:251
+#: ../src/richtext/richtextmarginspage.cpp:253
+msgid "Units for the top margin."
+msgstr "Unità margine superiore."
+
+#: ../src/richtext/richtextmarginspage.cpp:266
+#: ../src/richtext/richtextmarginspage.cpp:268
+msgid "The bottom margin size."
+msgstr "La dimensione del margine inferiore."
+
+#: ../src/richtext/richtextmarginspage.cpp:276
+#: ../src/richtext/richtextmarginspage.cpp:278
+msgid "Units for the bottom margin."
+msgstr "Unità margine basso."
+
+#: ../src/richtext/richtextmarginspage.cpp:284
+msgid "Padding"
+msgstr "Riempimento"
+
+#: ../src/richtext/richtextmarginspage.cpp:307
+#: ../src/richtext/richtextmarginspage.cpp:309
+msgid "The left padding size."
+msgstr "La dimensione del riempimento a sinistra."
+
+#: ../src/richtext/richtextmarginspage.cpp:317
+#: ../src/richtext/richtextmarginspage.cpp:319
+msgid "Units for the left padding."
+msgstr "Unità riempimento a sinistra."
+
+#: ../src/richtext/richtextmarginspage.cpp:332
+#: ../src/richtext/richtextmarginspage.cpp:334
+msgid "The right padding size."
+msgstr "La dimensione del riempimento a destra."
+
+#: ../src/richtext/richtextmarginspage.cpp:342
+#: ../src/richtext/richtextmarginspage.cpp:344
+msgid "Units for the right padding."
+msgstr "Unità riempimento a destra."
+
+#: ../src/richtext/richtextmarginspage.cpp:355
+#: ../src/richtext/richtextmarginspage.cpp:357
+msgid "The top padding size."
+msgstr "La dimensione del riempimento in alto."
+
+#: ../src/richtext/richtextmarginspage.cpp:365
+#: ../src/richtext/richtextmarginspage.cpp:367
+msgid "Units for the top padding."
+msgstr "Unità riempimento superiore."
+
+#: ../src/richtext/richtextmarginspage.cpp:380
+#: ../src/richtext/richtextmarginspage.cpp:382
+msgid "The bottom padding size."
+msgstr "La dimensione del riempimento inferiore."
+
+#: ../src/richtext/richtextmarginspage.cpp:390
+#: ../src/richtext/richtextmarginspage.cpp:392
+msgid "Units for the bottom padding."
+msgstr "Unità riempimento superiore."
+
+#: ../src/richtext/richtextprint.cpp:592
+msgid " Preview"
+msgstr " Anteprima"
+
+#: ../src/richtext/richtextsizepage.cpp:228
+msgid "Floating"
+msgstr "Flottuante"
+
+#: ../src/richtext/richtextsizepage.cpp:243
+msgid "&Floating mode:"
+msgstr "Modo &flottante:"
+
+#: ../src/richtext/richtextsizepage.cpp:252
+#: ../src/richtext/richtextsizepage.cpp:254
+msgid "How the object will float relative to the text."
+msgstr "Come l'oggetto sarà flottante rispetto al testo."
+
+#: ../src/richtext/richtextsizepage.cpp:265
+msgid "Alignment"
+msgstr "Allineamento"
+
+#: ../src/richtext/richtextsizepage.cpp:277
+msgid "&Vertical alignment:"
+msgstr "Allineamento &verticale:"
+
+#: ../src/richtext/richtextsizepage.cpp:279
+#: ../src/richtext/richtextsizepage.cpp:281
+msgid "Enable vertical alignment."
+msgstr "Abilita allineamento verticale."
+
+#: ../src/richtext/richtextsizepage.cpp:286
+msgid "Centred"
+msgstr "Centrato"
+
+#: ../src/richtext/richtextsizepage.cpp:290
+#: ../src/richtext/richtextsizepage.cpp:292
+msgid "Vertical alignment."
+msgstr "Allineamento verticale."
+
+#: ../src/richtext/richtextsizepage.cpp:316
+#: ../src/richtext/richtextsizepage.cpp:323
+msgid "&Width:"
+msgstr "&Larghezza:"
+
+#: ../src/richtext/richtextsizepage.cpp:318
+#: ../src/richtext/richtextsizepage.cpp:320
+msgid "Enable the width value."
+msgstr "Abilita il valore larghezza."
+
+#: ../src/richtext/richtextsizepage.cpp:331
+#: ../src/richtext/richtextsizepage.cpp:333
+msgid "The object width."
+msgstr "La larghezza dell'oggetto."
+
+#: ../src/richtext/richtextsizepage.cpp:342
+#: ../src/richtext/richtextsizepage.cpp:344
+msgid "Units for the object width."
+msgstr "Unità larghezza oggetto."
+
+#: ../src/richtext/richtextsizepage.cpp:350
+#: ../src/richtext/richtextsizepage.cpp:357
+msgid "&Height:"
+msgstr "&Altezza:"
+
+#: ../src/richtext/richtextsizepage.cpp:352
+#: ../src/richtext/richtextsizepage.cpp:354
+#: ../src/richtext/richtextsizepage.cpp:464
+#: ../src/richtext/richtextsizepage.cpp:466
+msgid "Enable the height value."
+msgstr "Abilita il valore altezza."
+
+#: ../src/richtext/richtextsizepage.cpp:365
+#: ../src/richtext/richtextsizepage.cpp:367
+msgid "The object height."
+msgstr "L'altezza dell'oggetto."
+
+#: ../src/richtext/richtextsizepage.cpp:376
+#: ../src/richtext/richtextsizepage.cpp:378
+msgid "Units for the object height."
+msgstr "Unità altezza oggetto."
+
+#: ../src/richtext/richtextsizepage.cpp:381
+msgid "Min width:"
+msgstr "Larghezza min.:"
+
+#: ../src/richtext/richtextsizepage.cpp:383
+#: ../src/richtext/richtextsizepage.cpp:385
+msgid "Enable the minimum width value."
+msgstr "Abilita il valore minimo larghezza."
+
+#: ../src/richtext/richtextsizepage.cpp:392
+#: ../src/richtext/richtextsizepage.cpp:394
+msgid "The object minimum width."
+msgstr "La larghezza minima dell'oggetto."
+
+#: ../src/richtext/richtextsizepage.cpp:403
+#: ../src/richtext/richtextsizepage.cpp:405
+msgid "Units for the minimum object width."
+msgstr "Unità larghezza oggetto."
+
+#: ../src/richtext/richtextsizepage.cpp:408
+msgid "Min height:"
+msgstr "Altezza min.:"
+
+#: ../src/richtext/richtextsizepage.cpp:410
+#: ../src/richtext/richtextsizepage.cpp:412
+msgid "Enable the minimum height value."
+msgstr "Abilita il valore massimo altezza."
+
+#: ../src/richtext/richtextsizepage.cpp:419
+#: ../src/richtext/richtextsizepage.cpp:421
+msgid "The object minimum height."
+msgstr "L'altezza minima dell'oggetto."
+
+#: ../src/richtext/richtextsizepage.cpp:430
+#: ../src/richtext/richtextsizepage.cpp:432
+msgid "Units for the minimum object height."
+msgstr "Unità altezza oggetto."
+
+#: ../src/richtext/richtextsizepage.cpp:435
+msgid "Max width:"
+msgstr "Larghezza max:"
+
+#: ../src/richtext/richtextsizepage.cpp:437
+#: ../src/richtext/richtextsizepage.cpp:439
+msgid "Enable the maximum width value."
+msgstr "Abilita il valore massimo larghezza."
+
+#: ../src/richtext/richtextsizepage.cpp:446
+#: ../src/richtext/richtextsizepage.cpp:448
+msgid "The object maximum width."
+msgstr "La larghezza massima dell'oggetto."
+
+#: ../src/richtext/richtextsizepage.cpp:457
+#: ../src/richtext/richtextsizepage.cpp:459
+msgid "Units for the maximum object width."
+msgstr "Unità larghezza oggetto."
+
+#: ../src/richtext/richtextsizepage.cpp:462
+msgid "Max height:"
+msgstr "Altezza max:"
+
+#: ../src/richtext/richtextsizepage.cpp:473
+#: ../src/richtext/richtextsizepage.cpp:475
+msgid "The object maximum height."
+msgstr "L'altezza massima dell'oggetto."
+
+#: ../src/richtext/richtextsizepage.cpp:484
+#: ../src/richtext/richtextsizepage.cpp:486
+msgid "Units for the maximum object height."
+msgstr "Unità altezza oggetto."
+
+#: ../src/richtext/richtextsizepage.cpp:495
+msgid "Position"
+msgstr "Posizione"
+
+#: ../src/richtext/richtextsizepage.cpp:513
+msgid "&Position mode:"
+msgstr "Modo &posizione:"
+
+#: ../src/richtext/richtextsizepage.cpp:517
+#: ../src/richtext/richtextsizepage.cpp:522
+msgid "Static"
+msgstr "Statico"
+
+#: ../src/richtext/richtextsizepage.cpp:518
+msgid "Relative"
+msgstr "Relativo"
+
+#: ../src/richtext/richtextsizepage.cpp:519
+msgid "Absolute"
+msgstr "Assoluto"
+
+#: ../src/richtext/richtextsizepage.cpp:520
+msgid "Fixed"
+msgstr "Fisso"
+
+#: ../src/richtext/richtextsizepage.cpp:533
+#: ../src/richtext/richtextsizepage.cpp:535
+#: ../src/richtext/richtextsizepage.cpp:547
+#: ../src/richtext/richtextsizepage.cpp:549
+msgid "The left position."
+msgstr "La posizione sinistra."
+
+#: ../src/richtext/richtextsizepage.cpp:558
+#: ../src/richtext/richtextsizepage.cpp:560
+msgid "Units for the left position."
+msgstr "Unità posizione sinistra."
+
+#: ../src/richtext/richtextsizepage.cpp:568
+#: ../src/richtext/richtextsizepage.cpp:570
+#: ../src/richtext/richtextsizepage.cpp:582
+#: ../src/richtext/richtextsizepage.cpp:584
+msgid "The top position."
+msgstr "La posizione alta."
+
+#: ../src/richtext/richtextsizepage.cpp:593
+#: ../src/richtext/richtextsizepage.cpp:595
+msgid "Units for the top position."
+msgstr "Unità posizione alta."
+
+#: ../src/richtext/richtextsizepage.cpp:603
+#: ../src/richtext/richtextsizepage.cpp:605
+#: ../src/richtext/richtextsizepage.cpp:617
+#: ../src/richtext/richtextsizepage.cpp:619
+msgid "The right position."
+msgstr "La posizione destra."
+
+#: ../src/richtext/richtextsizepage.cpp:628
+#: ../src/richtext/richtextsizepage.cpp:630
+msgid "Units for the right position."
+msgstr "Unità posizione destra."
+
+#: ../src/richtext/richtextsizepage.cpp:638
+#: ../src/richtext/richtextsizepage.cpp:640
+#: ../src/richtext/richtextsizepage.cpp:652
+#: ../src/richtext/richtextsizepage.cpp:654
+msgid "The bottom position."
+msgstr "La posizione inferiore."
+
+#: ../src/richtext/richtextsizepage.cpp:663
+#: ../src/richtext/richtextsizepage.cpp:665
+msgid "Units for the bottom position."
+msgstr "Unità posizione bassa."
+
+#: ../src/richtext/richtextsizepage.cpp:671
+msgid "&Move the object to:"
+msgstr "&Sposta l'oggetto in:"
+
+#: ../src/richtext/richtextsizepage.cpp:674
+msgid "&Previous Paragraph"
+msgstr "&Paragrafo precedente"
+
+#: ../src/richtext/richtextsizepage.cpp:675
+#: ../src/richtext/richtextsizepage.cpp:677
+msgid "Moves the object to the previous paragraph."
+msgstr "Sposta l'oggetto nel paragrafo precedente."
+
+#: ../src/richtext/richtextsizepage.cpp:680
+msgid "&Next Paragraph"
+msgstr "&Paragrafo successivo"
+
+#: ../src/richtext/richtextsizepage.cpp:681
+#: ../src/richtext/richtextsizepage.cpp:683
+msgid "Moves the object to the next paragraph."
+msgstr "Sposta l'oggetto nel prossimo paragrafo."
+
+#: ../src/richtext/richtextstyledlg.cpp:193
+msgid "&Styles:"
+msgstr "&Stili:"
+
+#: ../src/richtext/richtextstyledlg.cpp:197
+#: ../src/richtext/richtextstyledlg.cpp:199
+msgid "The available styles."
+msgstr "Gli stili disponibili."
+
+#: ../src/richtext/richtextstyledlg.cpp:205
+#: ../src/richtext/richtextstyledlg.cpp:217
+msgid " "
+msgstr " "
+
+#: ../src/richtext/richtextstyledlg.cpp:209
+#: ../src/richtext/richtextstyledlg.cpp:211
+msgid "The style preview."
+msgstr "L'anteprima dello stile."
+
+#: ../src/richtext/richtextstyledlg.cpp:220
+msgid "New &Character Style..."
+msgstr "Nuovo stile &carattere..."
+
+#: ../src/richtext/richtextstyledlg.cpp:221
+#: ../src/richtext/richtextstyledlg.cpp:223
+msgid "Click to create a new character style."
+msgstr "Seleziona per creare un nuovo stile carattere."
+
+#: ../src/richtext/richtextstyledlg.cpp:226
+msgid "New &Paragraph Style..."
+msgstr "Nuovo stile &paragrafo..."
+
+#: ../src/richtext/richtextstyledlg.cpp:227
+#: ../src/richtext/richtextstyledlg.cpp:229
+msgid "Click to create a new paragraph style."
+msgstr "Clic per creare un nuovo stile paragrafo."
+
+#: ../src/richtext/richtextstyledlg.cpp:232
+msgid "New &List Style..."
+msgstr "Nuovo stile e&lenco..."
+
+#: ../src/richtext/richtextstyledlg.cpp:233
+#: ../src/richtext/richtextstyledlg.cpp:235
+msgid "Click to create a new list style."
+msgstr "Clic per creare un nuovo stile elenco."
+
+#: ../src/richtext/richtextstyledlg.cpp:238
+msgid "New &Box Style..."
+msgstr "Nuovo stile &riquadro..."
+
+#: ../src/richtext/richtextstyledlg.cpp:239
+#: ../src/richtext/richtextstyledlg.cpp:241
+msgid "Click to create a new box style."
+msgstr "Seleziona per creare un nuovo stile riquadro."
+
+#: ../src/richtext/richtextstyledlg.cpp:246
+msgid "&Apply Style"
+msgstr "&Applica stile"
+
+#: ../src/richtext/richtextstyledlg.cpp:247
+#: ../src/richtext/richtextstyledlg.cpp:249
+msgid "Click to apply the selected style."
+msgstr "Clic per applicare lo stile attuale."
+
+#: ../src/richtext/richtextstyledlg.cpp:252
+msgid "&Rename Style..."
+msgstr "&Rinomina stile..."
+
+#: ../src/richtext/richtextstyledlg.cpp:253
+#: ../src/richtext/richtextstyledlg.cpp:255
+msgid "Click to rename the selected style."
+msgstr "Clic per rinominare lo stile selezionato."
+
+#: ../src/richtext/richtextstyledlg.cpp:258
+msgid "&Edit Style..."
+msgstr "&Modifica stile..."
+
+#: ../src/richtext/richtextstyledlg.cpp:259
+#: ../src/richtext/richtextstyledlg.cpp:261
+msgid "Click to edit the selected style."
+msgstr "Clic per modificare lo stile selezionato."
+
+#: ../src/richtext/richtextstyledlg.cpp:264
+msgid "&Delete Style..."
+msgstr "&Elimina stile..."
+
+#: ../src/richtext/richtextstyledlg.cpp:265
+#: ../src/richtext/richtextstyledlg.cpp:267
+msgid "Click to delete the selected style."
+msgstr "Clic per eliminare lo stile selezionato."
+
+#: ../src/richtext/richtextstyledlg.cpp:274
+#: ../src/richtext/richtextstyledlg.cpp:276
+msgid "Click to close this window."
+msgstr "Clic per chiudere questa finestra."
+
+#: ../src/richtext/richtextstyledlg.cpp:282
+msgid "&Restart numbering"
+msgstr "&Riavvia numerazione"
+
+#: ../src/richtext/richtextstyledlg.cpp:284
+#: ../src/richtext/richtextstyledlg.cpp:286
+msgid "Check to restart numbering."
+msgstr "Spunta per ricominciare la numerazione."
+
+#: ../src/richtext/richtextstyledlg.cpp:601
+msgid "Enter a character style name"
+msgstr "Inserisci il nome dello stile carattere"
+
+#: ../src/richtext/richtextstyledlg.cpp:601
+#: ../src/richtext/richtextstyledlg.cpp:606
+#: ../src/richtext/richtextstyledlg.cpp:649
+#: ../src/richtext/richtextstyledlg.cpp:654
+#: ../src/richtext/richtextstyledlg.cpp:815
+#: ../src/richtext/richtextstyledlg.cpp:820
+#: ../src/richtext/richtextstyledlg.cpp:888
+#: ../src/richtext/richtextstyledlg.cpp:896
+#: ../src/richtext/richtextstyledlg.cpp:929
+#: ../src/richtext/richtextstyledlg.cpp:934
+msgid "New Style"
+msgstr "Nuovo stile"
+
+#: ../src/richtext/richtextstyledlg.cpp:606
+#: ../src/richtext/richtextstyledlg.cpp:654
+#: ../src/richtext/richtextstyledlg.cpp:820
+#: ../src/richtext/richtextstyledlg.cpp:896
+#: ../src/richtext/richtextstyledlg.cpp:934
+msgid "Sorry, that name is taken. Please choose another."
+msgstr ""
+"Il nome è già in uso. \n"
+"Scegli un nome differente."
+
+#: ../src/richtext/richtextstyledlg.cpp:649
+msgid "Enter a paragraph style name"
+msgstr "Inserisci il nome dello stile paragrafo"
+
+#: ../src/richtext/richtextstyledlg.cpp:777
+#, c-format
+msgid "Delete style %s?"
+msgstr "Vuoi eliminare lo stile %s?"
+
+#: ../src/richtext/richtextstyledlg.cpp:777
+msgid "Delete Style"
+msgstr "Elimina stile"
+
+#: ../src/richtext/richtextstyledlg.cpp:815
+msgid "Enter a list style name"
+msgstr "Inserisci il nome dello stile elenco"
+
+#: ../src/richtext/richtextstyledlg.cpp:888
+msgid "Enter a new style name"
+msgstr "Inserisci il nome di un nuovo stile"
+
+#: ../src/richtext/richtextstyledlg.cpp:929
+msgid "Enter a box style name"
+msgstr "Inserisci il nome di un nuovo stile"
+
+#: ../src/richtext/richtextstylepage.cpp:109
+#: ../src/richtext/richtextstylepage.cpp:111
+msgid "The style name."
+msgstr "Il nome dello stile."
+
+#: ../src/richtext/richtextstylepage.cpp:114
+msgid "&Based on:"
+msgstr "&Basato su:"
+
+#: ../src/richtext/richtextstylepage.cpp:119
+#: ../src/richtext/richtextstylepage.cpp:121
+msgid "The style on which this style is based."
+msgstr "Lo stile su cui si basa questo stile."
+
+#: ../src/richtext/richtextstylepage.cpp:124
+msgid "&Next style:"
+msgstr "Stile &successivo:"
+
+#: ../src/richtext/richtextstylepage.cpp:129
+#: ../src/richtext/richtextstylepage.cpp:131
+msgid "The default style for the next paragraph."
+msgstr "Lo stile predefinito per il paragrafo successivo."
+
+#: ../src/richtext/richtextstyles.cpp:1057
+msgid "All styles"
+msgstr "Tutti gli stili"
+
+#: ../src/richtext/richtextstyles.cpp:1058
+msgid "Paragraph styles"
+msgstr "Stili paragrafo"
+
+#: ../src/richtext/richtextstyles.cpp:1059
+msgid "Character styles"
+msgstr "Stili carattere"
+
+#: ../src/richtext/richtextstyles.cpp:1060
+msgid "List styles"
+msgstr "Stili elenco"
+
+#: ../src/richtext/richtextstyles.cpp:1061
+msgid "Box styles"
+msgstr "Stili riquadro"
+
+#: ../src/richtext/richtextsymboldlg.cpp:389
+#: ../src/richtext/richtextsymboldlg.cpp:391
+msgid "The font from which to take the symbol."
+msgstr "Il font da cui prendere il simbolo."
+
+#: ../src/richtext/richtextsymboldlg.cpp:396
+msgid "&Subset:"
+msgstr "&Sottoinsieme:"
+
+#: ../src/richtext/richtextsymboldlg.cpp:401
+#: ../src/richtext/richtextsymboldlg.cpp:403
+msgid "Shows a Unicode subset."
+msgstr "Visualizza un sottoinsieme Unicode."
+
+#: ../src/richtext/richtextsymboldlg.cpp:412
+msgid "xxxx"
+msgstr "xxxx"
+
+#: ../src/richtext/richtextsymboldlg.cpp:417
+msgid "&Character code:"
+msgstr "&Codice carattere:"
+
+#: ../src/richtext/richtextsymboldlg.cpp:421
+#: ../src/richtext/richtextsymboldlg.cpp:423
+msgid "The character code."
+msgstr "Il codice del carattere."
+
+#: ../src/richtext/richtextsymboldlg.cpp:428
+msgid "&From:"
+msgstr "&Da:"
+
+#: ../src/richtext/richtextsymboldlg.cpp:433
+#: ../src/richtext/richtextsymboldlg.cpp:434
+#: ../src/richtext/richtextsymboldlg.cpp:435
+msgid "Unicode"
+msgstr "Unicode"
+
+#: ../src/richtext/richtextsymboldlg.cpp:436
+#: ../src/richtext/richtextsymboldlg.cpp:438
+msgid "The range to show."
+msgstr "Intervallo da visualizzare."
+
+#: ../src/richtext/richtextsymboldlg.cpp:444
+msgid "Insert"
+msgstr "Inserisci"
+
+#: ../src/richtext/richtextsymboldlg.cpp:478
+msgid "(Normal text)"
+msgstr "(Testo normale)"
+
+#: ../src/richtext/richtexttabspage.cpp:109
+msgid "&Position (tenths of a mm):"
+msgstr "&Posizione (decimi di millimetro):"
+
+#: ../src/richtext/richtexttabspage.cpp:113
+#: ../src/richtext/richtexttabspage.cpp:115
+msgid "The tab position."
+msgstr "Il punto di tabulazione."
+
+#: ../src/richtext/richtexttabspage.cpp:119
+msgid "The tab positions."
+msgstr "I punti di tabulazione."
+
+#: ../src/richtext/richtexttabspage.cpp:132
+#: ../src/richtext/richtexttabspage.cpp:134
+msgid "Click to create a new tab position."
+msgstr "Clic per creare una nuova posizione tabulazione."
+
+#: ../src/richtext/richtexttabspage.cpp:138
+#: ../src/richtext/richtexttabspage.cpp:140
+msgid "Click to delete the selected tab position."
+msgstr "Clic per eliminare la posizione tabulazione selezionata."
+
+#: ../src/richtext/richtexttabspage.cpp:143
+msgid "Delete A&ll"
+msgstr "&Elimina tutti"
+
+#: ../src/richtext/richtexttabspage.cpp:144
+#: ../src/richtext/richtexttabspage.cpp:146
+msgid "Click to delete all tab positions."
+msgstr "Clic per eliminare tutti le posizioni tabulazione."
+
+#: ../src/univ/theme.cpp:110
+msgid "Failed to initialize GUI: no built-in themes found."
+msgstr ""
+"Impossibile inizializzare l'interfaccia grafica (GUI): temi predefiniti non "
+"trovati."
+
+#: ../src/univ/themes/gtk.cpp:521
+msgid "GTK+ theme"
+msgstr "Tema GTK+"
+
+#: ../src/univ/themes/metal.cpp:164
+msgid "Metal theme"
+msgstr "Tema metallico"
+
+#: ../src/univ/themes/mono.cpp:512
+msgid "Simple monochrome theme"
+msgstr "Tema monocromatico"
+
+#: ../src/univ/themes/win32.cpp:1098
+msgid "Win32 theme"
+msgstr "Tema Win32"
+
+#: ../src/univ/themes/win32.cpp:3743
+msgid "&Restore"
+msgstr "&Ripristina"
+
+#: ../src/univ/themes/win32.cpp:3744
+msgid "&Move"
+msgstr "&Sposta"
+
+#: ../src/univ/themes/win32.cpp:3746
+msgid "&Size"
+msgstr "Dimen&sione"
+
+#: ../src/univ/themes/win32.cpp:3748
+msgid "Mi&nimize"
+msgstr "Riduci ad &icona"
+
+#: ../src/univ/themes/win32.cpp:3750
+msgid "Ma&ximize"
+msgstr "Massimi&zza"
+
+#: ../src/univ/themes/win32.cpp:3752
+msgid "Alt+"
+msgstr "Alt+"
+
+#: ../src/unix/appunix.cpp:178
+msgid "Failed to install signal handler"
+msgstr "Impossibile installare gestore segnale"
+
+#: ../src/unix/dialup.cpp:351
+msgid "Already dialling ISP."
+msgstr "Chiamata verso l'ISP già in corso."
+
+#: ../src/unix/dlunix.cpp:93
+msgid "Failed to unload shared library"
+msgstr "Impossibile scaricare la libreria condivisa"
+
+#: ../src/unix/dlunix.cpp:121
+msgid "Unknown dynamic library error"
+msgstr "Errore sconosciuto nella libreria dinamica"
+
+#: ../src/unix/epolldispatcher.cpp:84
+msgid "Failed to create epoll descriptor"
+msgstr "Impossibile creare descrittore epoll"
+
+#: ../src/unix/epolldispatcher.cpp:103
+msgid "Error closing epoll descriptor"
+msgstr "Errore nella chiusura descrittore epoll"
+
+#: ../src/unix/epolldispatcher.cpp:116
+#, c-format
+msgid "Failed to add descriptor %d to epoll descriptor %d"
+msgstr "Impossibile aggiungere descrittore %d al descrittore epoll %d"
+
+#: ../src/unix/epolldispatcher.cpp:136
+#, c-format
+msgid "Failed to modify descriptor %d in epoll descriptor %d"
+msgstr "Impossibile modificare il descrittore %d nel descrittore epoll %d"
+
+#: ../src/unix/epolldispatcher.cpp:155
+#, c-format
+msgid "Failed to unregister descriptor %d from epoll descriptor %d"
+msgstr "Impossibile deregistrare descrittore %d dal descrittore epoll %d"
+
+#: ../src/unix/epolldispatcher.cpp:213
+#, c-format
+msgid "Waiting for IO on epoll descriptor %d failed"
+msgstr "Attesa IO descrittore epoll %d fallita"
+
+#: ../src/unix/fswatcher_inotify.cpp:71
+msgid "Unable to create inotify instance"
+msgstr "Impossibile creare istanza inotify"
+
+#: ../src/unix/fswatcher_inotify.cpp:94
+msgid "Unable to close inotify instance"
+msgstr "Impossibile chiudere istanza inotify"
+
+#: ../src/unix/fswatcher_inotify.cpp:106
+msgid "Unable to add inotify watch"
+msgstr "Impossibile aggiungere monitor inotify"
+
+#: ../src/unix/fswatcher_inotify.cpp:138
+#, c-format
+msgid "Unable to remove inotify watch %i"
+msgstr "Impossibile rimuovere monitoraggio inotify %i"
+
+#: ../src/unix/fswatcher_inotify.cpp:271
+#, c-format
+msgid "Unexpected event for \"%s\": no matching watch descriptor."
+msgstr ""
+"Evento inaspettato per \"%s\": nessun descrittore monitoraggio "
+"corrispondente."
+
+#: ../src/unix/fswatcher_inotify.cpp:320
+#, c-format
+msgid "Invalid inotify event for \"%s\""
+msgstr "Evento 'inotify' non valido per \"%s\""
+
+#: ../src/unix/fswatcher_inotify.cpp:553
+msgid "Unable to read from inotify descriptor"
+msgstr "Impossibile leggere dal descrittore inotify"
+
+#: ../src/unix/fswatcher_inotify.cpp:558
+msgid "EOF while reading from inotify descriptor"
+msgstr "Fine file durante lettura da descrittore inotify"
+
+#: ../src/unix/fswatcher_kqueue.cpp:114
+msgid "Unable to create kqueue instance"
+msgstr "Impossibile creare istanza kqueue"
+
+#: ../src/unix/fswatcher_kqueue.cpp:131
+msgid "Error closing kqueue instance"
+msgstr "Errore chiusura istanza kqueue"
+
+#: ../src/unix/fswatcher_kqueue.cpp:153
+msgid "Unable to add kqueue watch"
+msgstr "Impossibile aggiungere montor kqueue"
+
+#: ../src/unix/fswatcher_kqueue.cpp:170
+msgid "Unable to remove kqueue watch"
+msgstr "Impossibile rimuovere controllo kqueue"
+
+#: ../src/unix/fswatcher_kqueue.cpp:202
+msgid "Unable to get events from kqueue"
+msgstr "Impossibile ottenere eventi da kqueue"
+
+#: ../src/unix/mediactrl.cpp:966
+#, c-format
+msgid "Media playback error: %s"
+msgstr "Errore riproduzione: %s"
+
+#: ../src/unix/mediactrl.cpp:1228
+#, c-format
+msgid "Failed to prepare playing \"%s\"."
+msgstr "Impossibile preparare riproduzione \"%s\"."
+
+#: ../src/unix/snglinst.cpp:164
+#, c-format
+msgid "Failed to write to lock file '%s'"
+msgstr "Impossibile scrivere nel file di blocco '%s'"
+
+#: ../src/unix/snglinst.cpp:177
+#, c-format
+msgid "Failed to set permissions on lock file '%s'"
+msgstr "Impossibile impostare i permessi per il file di lock '%s'"
+
+#: ../src/unix/snglinst.cpp:194
+#, c-format
+msgid "Failed to lock the lock file '%s'"
+msgstr "Impossibile bloccare il file di blocco '%s'"
+
+#: ../src/unix/snglinst.cpp:237
+#, c-format
+msgid "Failed to inspect the lock file '%s'"
+msgstr "Impossibile leggere il file di blocco '%s'"
+
+#: ../src/unix/snglinst.cpp:242
+#, c-format
+msgid "Lock file '%s' has incorrect owner."
+msgstr "Il file di blocco '%s' ha un proprietario errato."
+
+#: ../src/unix/snglinst.cpp:247
+#, c-format
+msgid "Lock file '%s' has incorrect permissions."
+msgstr "Il file di blocco '%s' ha permessi scorretti."
+
+#: ../src/unix/snglinst.cpp:265
+msgid "Failed to access lock file."
+msgstr "Impossibile accedere al file di lock."
+
+#: ../src/unix/snglinst.cpp:274
+msgid "Failed to read PID from lock file."
+msgstr "Impossibile leggere il PID dal file di blocco."
+
+#: ../src/unix/snglinst.cpp:284
+#, c-format
+msgid "Failed to remove stale lock file '%s'."
+msgstr "Impossibile eliminare il file di blocco obsoleto '%s'."
+
+#: ../src/unix/snglinst.cpp:297
+#, c-format
+msgid "Deleted stale lock file '%s'."
+msgstr "Eliminato file di blocco obsoleto '%s'."
+
+#: ../src/unix/snglinst.cpp:308
+#, c-format
+msgid "Invalid lock file '%s'."
+msgstr "File di blocco '%s' non valido."
+
+#: ../src/unix/snglinst.cpp:324
+#, c-format
+msgid "Failed to remove lock file '%s'"
+msgstr "Impossibile eliminare il file di blocco '%s'"
+
+#: ../src/unix/snglinst.cpp:330
+#, c-format
+msgid "Failed to unlock lock file '%s'"
+msgstr "Impossibile sbloccare il file di blocco '%s'"
+
+#: ../src/unix/snglinst.cpp:336
+#, c-format
+msgid "Failed to close lock file '%s'"
+msgstr "Impossibile chiudere il file di blocco '%s'"
+
+#: ../src/unix/sound.cpp:77
+msgid "No sound"
+msgstr "Nessun suono"
+
+#: ../src/unix/sound.cpp:364
+msgid "Unable to play sound asynchronously."
+msgstr "Impossibile riprodurre il suono in modalità asincrona."
+
+#: ../src/unix/sound.cpp:458
+#, c-format
+msgid "Couldn't load sound data from '%s'."
+msgstr "Impossibile leggere dati sonori da '%s'."
+
+#: ../src/unix/sound.cpp:465
+#, c-format
+msgid "Sound file '%s' is in unsupported format."
+msgstr "File sonoro '%s' ha un formato non supportato."
+
+#: ../src/unix/sound.cpp:480
+msgid "Sound data are in unsupported format."
+msgstr "Formato dei dati sonori non supportato."
+
+#: ../src/unix/sound_sdl.cpp:226
+#, c-format
+msgid "Couldn't open audio: %s"
+msgstr "Impossibile inizializzare l'audio: %s"
+
+#: ../src/unix/threadpsx.cpp:1033
+msgid "Cannot retrieve thread scheduling policy."
+msgstr "Impossibile determinare la strategia di pianificazione."
+
+#: ../src/unix/threadpsx.cpp:1058
+#, c-format
+msgid "Cannot get priority range for scheduling policy %d."
+msgstr ""
+"Impossibile ottenere un intervallo di priorità per la strategia di "
+"pianificazione %d."
+
+#: ../src/unix/threadpsx.cpp:1066
+msgid "Thread priority setting is ignored."
+msgstr "Priorità del thread ignorata."
+
+#: ../src/unix/threadpsx.cpp:1221
+msgid ""
+"Failed to join a thread, potential memory leak detected - please restart the "
+"program"
+msgstr ""
+"Impossibile esegure la join su di un thread, possibile memoria persa (leak) "
+"- esegui nuovamente il programma"
+
+#: ../src/unix/threadpsx.cpp:1352
+#, c-format
+msgid "Failed to set thread concurrency level to %lu"
+msgstr "Impossibile impostare livello concorrenza a %lu"
+
+#: ../src/unix/threadpsx.cpp:1481
+#, c-format
+msgid "Failed to set thread priority %d."
+msgstr "Impossibile assegnare la priorità %d al thread."
+
+#: ../src/unix/threadpsx.cpp:1666
+msgid "Failed to terminate a thread."
+msgstr "Impossibile terminare il thread."
+
+#: ../src/unix/threadpsx.cpp:1893
+msgid "Thread module initialization failed: failed to create thread key"
+msgstr ""
+"Inizializzazione del modulo dei thread fallita: errore nella creazione della "
+"chiave dei thread"
+
+#: ../src/unix/utilsunx.cpp:340
+msgid "Impossible to get child process input"
+msgstr "Impossibile ottenere l'input del processo figlio"
+
+#: ../src/unix/utilsunx.cpp:390
+msgid "Can't write to child process's stdin"
+msgstr "Impossibile scrivere nello stdin del processo figlio"
+
+#: ../src/unix/utilsunx.cpp:644
+#, c-format
+msgid "Failed to execute '%s'\n"
+msgstr "Impossibile eseguire '%s'\n"
+
+#: ../src/unix/utilsunx.cpp:678
+msgid "Fork failed"
+msgstr "Fork fallita"
+
+#: ../src/unix/utilsunx.cpp:701
+msgid "Failed to set process priority"
+msgstr "Impossibile impostare la priorità"
+
+#: ../src/unix/utilsunx.cpp:712
+msgid "Failed to redirect child process input/output"
+msgstr "Impossibile redirigere l'input/output del processo figlio"
+
+#: ../src/unix/utilsunx.cpp:816
+msgid "Failed to set up non-blocking pipe, the program might hang."
+msgstr ""
+"Impossibile impostare pipe non bloccante, il programma potrebbe bloccarsi."
+
+#: ../src/unix/utilsunx.cpp:1023
+msgid "Cannot get the hostname"
+msgstr "Impossibile ottenere il nome dell'host"
+
+#: ../src/unix/utilsunx.cpp:1059
+msgid "Cannot get the official hostname"
+msgstr "Impossibile ottenere il nome ufficiale dell'host"
+
+#: ../src/unix/wakeuppipe.cpp:49
+msgid "Failed to create wake up pipe used by event loop."
+msgstr "Impossibile creare coda risveglio usato da un loop evento."
+
+#: ../src/unix/wakeuppipe.cpp:56
+msgid "Failed to switch wake up pipe to non-blocking mode"
+msgstr "Impossibile commutare coda risveglio in modalità non bloccante"
+
+#: ../src/unix/wakeuppipe.cpp:117
+msgid "Failed to read from wake-up pipe"
+msgstr "Impossibile leggere dalla coda di risveglio"
+
+#: ../src/x11/app.cpp:124
+#, c-format
+msgid "Invalid geometry specification '%s'"
+msgstr "Specifica della posizione e/o dimensioni '%s' non valida"
+
+#: ../src/x11/app.cpp:167
+msgid "wxWidgets could not open display. Exiting."
+msgstr "wxWidgets non può aprire il display. Uscita."
+
+#: ../src/x11/utils.cpp:169
+#, c-format
+msgid "Failed to close the display \"%s\""
+msgstr "Impossibile chiudere il display \"%s\""
+
+#: ../src/x11/utils.cpp:188
+#, c-format
+msgid "Failed to open display \"%s\"."
+msgstr "Impossibile aprire il display \"%s\"."
+
+#: ../src/xml/xml.cpp:868
+#, c-format
+msgid "XML parsing error: '%s' at line %d"
+msgstr "Errore durante l'analisi XML: %s alla riga %d"
+
+#: ../src/xrc/xh_propgrid.cpp:239
+#, fuzzy, c-format
+msgid "Page %i"
+msgstr "Pagina %d"
+
+#: ../src/xrc/xmlres.cpp:448
+#, c-format
+msgid "Cannot load resources from '%s'."
+msgstr "Impossibile caricare le risorse da '%s'."
+
+#: ../src/xrc/xmlres.cpp:799
+#, c-format
+msgid "Cannot open resources file '%s'."
+msgstr "Impossibile aprire il file risorse '%s'."
+
+#: ../src/xrc/xmlres.cpp:806
+#, c-format
+msgid "Cannot load resources from file '%s'."
+msgstr "Impossibile caricare le risorse dal file '%s'."
+
+#: ../src/xrc/xmlres.cpp:2767
+#, c-format
+msgid "Creating %s \"%s\" failed."
+msgstr "Creazione di %s \"%s\" fallita."
+
+#, c-format
+#~ msgid "BMP: header has biClrUsed=%d when biBitCount=%d."
+#~ msgstr "BMP: l'intestazione ha biClrUsed=%d quando biBitCount=%d."
+
+#~ msgctxt "keyboard key"
+#~ msgid "Alt+"
+#~ msgstr "Alt+"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Ctrl+"
+#~ msgstr "Ctrl+"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Shift+"
+#~ msgstr "Maiusc+"
+
+#~ msgctxt "keyboard key"
+#~ msgid "RawCtrl+"
+#~ msgstr "RawCtrl+"
+
+#~ msgid "Copying more than one selected block to clipboard is not supported."
+#~ msgstr ""
+#~ "Non è supportata la copia di più di un blocco selezionato negli Appunti."
+
+#~ msgid "Unsupported clipboard format."
+#~ msgstr "Formato degli Appunti non supportato."
+
+#~ msgid "Background colour"
+#~ msgstr "Colore sfondo"
+
+#~ msgid "Font:"
+#~ msgstr "Font:"
+
+#~ msgid "Size:"
+#~ msgstr "Dimensione:"
+
+#~ msgid "The font size in points."
+#~ msgstr "La dimensione in punti del font."
+
+#~ msgid "Style:"
+#~ msgstr "Stile:"
+
+#~ msgid "Check to make the font bold."
+#~ msgstr "Clic per rendere il font grassetto."
+
+#~ msgid "Check to make the font italic."
+#~ msgstr "Seleziona per rendere il font corsivo."
+
+#~ msgid "Check to make the font underlined."
+#~ msgstr "Seleziona per rendere il font sottolineato."
+
+#~ msgid "Colour:"
+#~ msgstr "Colore:"
+
+#~ msgid "Click to change the font colour."
+#~ msgstr "Seleziona per modificare il colore del font."
+
+#~ msgid "Shows a preview of the font."
+#~ msgstr "Visualizza l'anteprima del font."
+
+#~ msgid "Click to cancel changes to the font."
+#~ msgstr "Seleziona per annullare le modifiche al font."
+
+#~ msgid "Click to confirm changes to the font."
+#~ msgstr "Seleziona per confermare le modifiche al font."
+
+#~ msgid "<Any>"
+#~ msgstr "<Qualunque>"
+
+#~ msgid "<Any Roman>"
+#~ msgstr "<Qualunque Roman>"
+
+#~ msgid "<Any Decorative>"
+#~ msgstr "<Qualunque decorativo>"
+
+#~ msgid "<Any Modern>"
+#~ msgstr "<Qualunque modern>"
+
+#~ msgid "<Any Script>"
+#~ msgstr "<Qualunque script>"
+
+#~ msgid "<Any Swiss>"
+#~ msgstr "<Qualunque Svizzero>"
+
+#~ msgid "<Any Teletype>"
+#~ msgstr "<Qualunque teletype>"

--- a/po_wxstd/ja.po
+++ b/po_wxstd/ja.po
@@ -1,0 +1,10720 @@
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: wxWidgets 3.3\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-05-14 20:23+0200\n"
+"PO-Revision-Date: 2024-05-15 23:51+0900\n"
+"Last-Translator: Ryo Nakano <ryonakaknock3@gmail.com>\n"
+"Language-Team: Japanese <wx-translators@wxwidgets.org>\n"
+"Language: ja\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+#: ../include/wx/defs.h:2582
+msgid "All files (*.*)|*.*"
+msgstr "すべてのファイル (*.*)|*.*"
+
+#: ../include/wx/defs.h:2585
+msgid "All files (*)|*"
+msgstr "すべてのファイル (*)|*"
+
+#: ../include/wx/generic/progdlgg.h:85
+msgid "Elapsed time:"
+msgstr "経過時間:"
+
+#: ../include/wx/generic/progdlgg.h:86
+msgid "Estimated time:"
+msgstr "予定時間:"
+
+#: ../include/wx/generic/progdlgg.h:87
+msgid "Remaining time:"
+msgstr "残り時間:"
+
+#. TRANSLATORS: HTML printout default title.
+#: ../include/wx/html/htmprint.h:121 ../include/wx/prntbase.h:273
+#: ../include/wx/richtext/richtextprint.h:109 ../src/common/docview.cpp:2161
+msgid "Printout"
+msgstr "印刷出力"
+
+#. TRANSLATORS: HTML easy print default title.
+#: ../include/wx/html/htmprint.h:234 ../include/wx/richtext/richtextprint.h:163
+#: ../src/common/prntbase.cpp:522 ../src/html/htmprint.cpp:291
+msgid "Printing"
+msgstr "印刷"
+
+#: ../include/wx/msgdlg.h:277 ../src/common/stockitem.cpp:211
+msgid "Yes"
+msgstr "はい"
+
+#: ../include/wx/msgdlg.h:278 ../src/common/stockitem.cpp:182
+msgid "No"
+msgstr "いいえ"
+
+#: ../include/wx/msgdlg.h:279 ../src/common/stockitem.cpp:183
+#: ../src/msw/msgdlg.cpp:430 ../src/msw/msgdlg.cpp:734
+#: ../src/richtext/richtextstyledlg.cpp:292
+msgid "OK"
+msgstr "OK"
+
+#: ../include/wx/msgdlg.h:280 ../src/common/stockitem.cpp:150
+#: ../src/msw/msgdlg.cpp:430 ../src/msw/progdlg.cpp:884
+#: ../src/richtext/richtextstyledlg.cpp:295
+msgid "Cancel"
+msgstr "キャンセル"
+
+#: ../include/wx/msgdlg.h:281 ../src/common/stockitem.cpp:168
+#: ../src/html/helpdlg.cpp:63 ../src/html/helpfrm.cpp:108
+#: ../src/osx/button_osx.cpp:38
+msgid "Help"
+msgstr "ヘルプ"
+
+#: ../include/wx/msw/ole/oleutils.h:52
+msgid "Cannot initialize OLE"
+msgstr "OLE を初期化できません"
+
+#: ../include/wx/msw/private/fswatcher.h:48
+#, c-format
+msgid "Unable to close the handle for '%s'"
+msgstr "'%s' へのハンドルを閉じることができませんでした。"
+
+#: ../include/wx/msw/private/fswatcher.h:92
+#, c-format
+msgid "Failed to open directory \"%s\" for monitoring."
+msgstr "監視対象のディレクトリ \"%s\" を開けませんでした。"
+
+#: ../include/wx/msw/private/fswatcher.h:125
+msgid "Unable to close I/O completion port handle"
+msgstr "I/O 完了ポートハンドルを閉じられません"
+
+#: ../include/wx/msw/private/fswatcher.h:142
+msgid "Unable to associate handle with I/O completion port"
+msgstr "ハンドルを I/O 完了ポートに関連づけできません"
+
+#: ../include/wx/msw/private/fswatcher.h:148
+msgid "Unexpectedly new I/O completion port was created"
+msgstr "予期しない新しい I/O 完了ポートが作成されました"
+
+#: ../include/wx/msw/private/fswatcher.h:213
+msgid "Unable to post completion status"
+msgstr "完了状態を post できませんでした"
+
+#: ../include/wx/msw/private/fswatcher.h:262
+msgid "Unable to dequeue completion packet"
+msgstr "完了パケットをキューから取り出せません"
+
+#: ../include/wx/msw/private/fswatcher.h:273
+msgid "Unable to create I/O completion port"
+msgstr "I/O 完了ポートを作成できません"
+
+#: ../include/wx/richmsgdlg.h:29
+msgid "&See details"
+msgstr "詳細を表示(&S)"
+
+#: ../include/wx/richmsgdlg.h:30
+msgid "&Hide details"
+msgstr "詳細を非表示(&H)"
+
+#: ../include/wx/richtext/richtextbuffer.h:3864
+msgid "&Box"
+msgstr "ボックス(&B)"
+
+#: ../include/wx/richtext/richtextbuffer.h:5008
+msgid "&Picture"
+msgstr "画像(&P)"
+
+#: ../include/wx/richtext/richtextbuffer.h:5958
+msgid "&Cell"
+msgstr "セル(&C)"
+
+#: ../include/wx/richtext/richtextbuffer.h:6067
+msgid "&Table"
+msgstr "表(&T)"
+
+#: ../include/wx/richtext/richtextimagedlg.h:37
+msgid "Object Properties"
+msgstr "オブジェクトのプロパティ"
+
+#: ../include/wx/richtext/richtextsymboldlg.h:39
+msgid "Symbols"
+msgstr "記号"
+
+#: ../include/wx/unix/pipe.h:46
+msgid "Pipe creation failed"
+msgstr "パイプを作成できませんでした"
+
+#: ../include/wx/unix/private/displayx11.h:65
+msgid "Failed to enumerate video modes"
+msgstr "画面モードを列挙できませんでした"
+
+#: ../include/wx/unix/private/displayx11.h:89
+msgid "Failed to change video mode"
+msgstr "画面モード変更に失敗しました"
+
+#: ../include/wx/unix/private/fswatcher_kqueue.h:57
+#, c-format
+msgid "Unable to open path '%s'"
+msgstr "パス '%s' を開くことができません"
+
+#: ../include/wx/unix/private/fswatcher_kqueue.h:74
+#, c-format
+msgid "Unable to close path '%s'"
+msgstr "パス '%s' を閉じることができませんでした。"
+
+#: ../include/wx/xtiprop.h:175
+msgid "SetProperty called w/o valid setter"
+msgstr "適切なsetterなしにSetPropertyが呼び出されました"
+
+#: ../include/wx/xtiprop.h:184
+msgid "GetProperty called w/o valid getter"
+msgstr "適切な getter なしに GetPropertyが呼び出されました"
+
+#: ../include/wx/xtiprop.h:193
+msgid "AddToPropertyCollection called w/o valid adder"
+msgstr "不適切な adder から AddToPropertyCollection が呼び出されました"
+
+#: ../include/wx/xtiprop.h:202
+msgid "GetPropertyCollection called w/o valid collection getter"
+msgstr ""
+"適切なコレクション getter なしに GetPropertyCollection が呼び出されました"
+
+#: ../include/wx/xtiprop.h:255
+msgid "AddToPropertyCollection called on a generic accessor"
+msgstr "非特殊化アクセサーの AddToPropertyCollection が呼び出されました"
+
+#: ../include/wx/xtiprop.h:262
+msgid "GetPropertyCollection called on a generic accessor"
+msgstr "汎用アクセサーに対して GetPropertyCollection が呼び出されました"
+
+#: ../src/aui/tabmdi.cpp:106 ../src/generic/mdig.cpp:94
+msgid "Cl&ose"
+msgstr "閉じる(&O)"
+
+#: ../src/aui/tabmdi.cpp:107 ../src/generic/mdig.cpp:95
+msgid "Close All"
+msgstr "すべて閉じる"
+
+#: ../src/aui/tabmdi.cpp:109 ../src/generic/mdig.cpp:97 ../src/msw/mdi.cpp:175
+#: ../src/qt/mdi.cpp:258
+msgid "&Next"
+msgstr "次へ(&N)"
+
+#: ../src/aui/tabmdi.cpp:110 ../src/generic/mdig.cpp:98 ../src/msw/mdi.cpp:176
+#: ../src/qt/mdi.cpp:259
+msgid "&Previous"
+msgstr "前へ(&P)"
+
+#: ../src/aui/tabmdi.cpp:332 ../src/aui/tabmdi.cpp:348
+#: ../src/aui/tabmdi.cpp:350 ../src/generic/mdig.cpp:291
+#: ../src/generic/mdig.cpp:307 ../src/generic/mdig.cpp:311
+#: ../src/msw/mdi.cpp:337 ../src/qt/mdi.cpp:462
+msgid "&Window"
+msgstr "ウィンドウ(&W)"
+
+#: ../src/common/accelcmn.cpp:47
+msgctxt "keyboard key"
+msgid "Delete"
+msgstr "Delete"
+
+#: ../src/common/accelcmn.cpp:48
+msgctxt "keyboard key"
+msgid "Del"
+msgstr "Del"
+
+#: ../src/common/accelcmn.cpp:49
+msgctxt "keyboard key"
+msgid "Back"
+msgstr "Back"
+
+#: ../src/common/accelcmn.cpp:49
+msgctxt "keyboard key"
+msgid "Backspace"
+msgstr "Backspace"
+
+#: ../src/common/accelcmn.cpp:50
+msgctxt "keyboard key"
+msgid "Insert"
+msgstr "Insert"
+
+#: ../src/common/accelcmn.cpp:51
+msgctxt "keyboard key"
+msgid "Ins"
+msgstr "Ins"
+
+#: ../src/common/accelcmn.cpp:52
+msgctxt "keyboard key"
+msgid "Enter"
+msgstr "Enter"
+
+#: ../src/common/accelcmn.cpp:53
+msgctxt "keyboard key"
+msgid "Return"
+msgstr "Return"
+
+#: ../src/common/accelcmn.cpp:54
+msgctxt "keyboard key"
+msgid "PageUp"
+msgstr "PageUp"
+
+#: ../src/common/accelcmn.cpp:54
+msgctxt "keyboard key"
+msgid "Page Up"
+msgstr "Page Up"
+
+#: ../src/common/accelcmn.cpp:55
+msgctxt "keyboard key"
+msgid "PageDown"
+msgstr "PageDown"
+
+#: ../src/common/accelcmn.cpp:55
+msgctxt "keyboard key"
+msgid "Page Down"
+msgstr "Page Down"
+
+#: ../src/common/accelcmn.cpp:56
+msgctxt "keyboard key"
+msgid "PgUp"
+msgstr "PgUp"
+
+#: ../src/common/accelcmn.cpp:57
+msgctxt "keyboard key"
+msgid "PgDn"
+msgstr "PgDn"
+
+#: ../src/common/accelcmn.cpp:58
+msgctxt "keyboard key"
+msgid "Left"
+msgstr "左"
+
+#: ../src/common/accelcmn.cpp:59
+msgctxt "keyboard key"
+msgid "Right"
+msgstr "右"
+
+#: ../src/common/accelcmn.cpp:60
+msgctxt "keyboard key"
+msgid "Up"
+msgstr "上"
+
+#: ../src/common/accelcmn.cpp:61
+msgctxt "keyboard key"
+msgid "Down"
+msgstr "下"
+
+#: ../src/common/accelcmn.cpp:62
+msgctxt "keyboard key"
+msgid "Home"
+msgstr "Home"
+
+#: ../src/common/accelcmn.cpp:63
+msgctxt "keyboard key"
+msgid "End"
+msgstr "End"
+
+#: ../src/common/accelcmn.cpp:64
+msgctxt "keyboard key"
+msgid "Space"
+msgstr "スペース"
+
+#: ../src/common/accelcmn.cpp:65
+msgctxt "keyboard key"
+msgid "Tab"
+msgstr "Tab"
+
+#: ../src/common/accelcmn.cpp:66
+msgctxt "keyboard key"
+msgid "Esc"
+msgstr "Esc"
+
+#: ../src/common/accelcmn.cpp:67
+msgctxt "keyboard key"
+msgid "Escape"
+msgstr "Escape"
+
+#: ../src/common/accelcmn.cpp:68
+msgctxt "keyboard key"
+msgid "Cancel"
+msgstr "キャンセル"
+
+#: ../src/common/accelcmn.cpp:69
+msgctxt "keyboard key"
+msgid "Clear"
+msgstr "Clear"
+
+#: ../src/common/accelcmn.cpp:70
+msgctxt "keyboard key"
+msgid "Menu"
+msgstr "メニュー"
+
+#: ../src/common/accelcmn.cpp:71
+msgctxt "keyboard key"
+msgid "Pause"
+msgstr "Pause"
+
+#: ../src/common/accelcmn.cpp:72
+msgctxt "keyboard key"
+msgid "Capital"
+msgstr "Capital"
+
+#: ../src/common/accelcmn.cpp:73
+msgctxt "keyboard key"
+msgid "Select"
+msgstr "選択"
+
+#: ../src/common/accelcmn.cpp:74
+msgctxt "keyboard key"
+msgid "Print"
+msgstr "印刷"
+
+#: ../src/common/accelcmn.cpp:75
+msgctxt "keyboard key"
+msgid "Execute"
+msgstr "実行"
+
+#: ../src/common/accelcmn.cpp:76
+msgctxt "keyboard key"
+msgid "Snapshot"
+msgstr "スナップショット"
+
+#: ../src/common/accelcmn.cpp:77
+msgctxt "keyboard key"
+msgid "Help"
+msgstr "ヘルプ"
+
+#: ../src/common/accelcmn.cpp:78
+msgctxt "keyboard key"
+msgid "Add"
+msgstr "加算"
+
+#: ../src/common/accelcmn.cpp:79
+msgctxt "keyboard key"
+msgid "Separator"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:80
+msgctxt "keyboard key"
+msgid "Subtract"
+msgstr "減算"
+
+#: ../src/common/accelcmn.cpp:81
+msgctxt "keyboard key"
+msgid "Decimal"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:82
+msgctxt "keyboard key"
+msgid "Multiply"
+msgstr "乗算"
+
+#: ../src/common/accelcmn.cpp:83
+msgctxt "keyboard key"
+msgid "Divide"
+msgstr "除算"
+
+#: ../src/common/accelcmn.cpp:84
+msgctxt "keyboard key"
+msgid "Num_lock"
+msgstr "Num_lock"
+
+#: ../src/common/accelcmn.cpp:84
+msgctxt "keyboard key"
+msgid "Num Lock"
+msgstr "Num Lock"
+
+#: ../src/common/accelcmn.cpp:85
+msgctxt "keyboard key"
+msgid "Scroll_lock"
+msgstr "Scroll_lock"
+
+#: ../src/common/accelcmn.cpp:85
+msgctxt "keyboard key"
+msgid "Scroll Lock"
+msgstr "Scroll Lock"
+
+#: ../src/common/accelcmn.cpp:86
+msgctxt "keyboard key"
+msgid "KP_Space"
+msgstr "KP_Space"
+
+#: ../src/common/accelcmn.cpp:86
+msgctxt "keyboard key"
+msgid "Num Space"
+msgstr "Num Space"
+
+#: ../src/common/accelcmn.cpp:87
+msgctxt "keyboard key"
+msgid "KP_Tab"
+msgstr "KP_Tab"
+
+#: ../src/common/accelcmn.cpp:87
+msgctxt "keyboard key"
+msgid "Num Tab"
+msgstr "Num Tab"
+
+#: ../src/common/accelcmn.cpp:88
+msgctxt "keyboard key"
+msgid "KP_Enter"
+msgstr "KP_Enter"
+
+#: ../src/common/accelcmn.cpp:88
+msgctxt "keyboard key"
+msgid "Num Enter"
+msgstr "Num Enter"
+
+#: ../src/common/accelcmn.cpp:89
+msgctxt "keyboard key"
+msgid "KP_Home"
+msgstr "KP_Home"
+
+#: ../src/common/accelcmn.cpp:89
+msgctxt "keyboard key"
+msgid "Num Home"
+msgstr "Num Home"
+
+#: ../src/common/accelcmn.cpp:90
+msgctxt "keyboard key"
+msgid "KP_Left"
+msgstr "KP_Left"
+
+#: ../src/common/accelcmn.cpp:90
+msgctxt "keyboard key"
+msgid "Num left"
+msgstr "Num left"
+
+#: ../src/common/accelcmn.cpp:91
+msgctxt "keyboard key"
+msgid "KP_Up"
+msgstr "KP_Up"
+
+#: ../src/common/accelcmn.cpp:91
+msgctxt "keyboard key"
+msgid "Num Up"
+msgstr "Num Up"
+
+#: ../src/common/accelcmn.cpp:92
+msgctxt "keyboard key"
+msgid "KP_Right"
+msgstr "KP_Right"
+
+#: ../src/common/accelcmn.cpp:92
+msgctxt "keyboard key"
+msgid "Num Right"
+msgstr "Num Right"
+
+#: ../src/common/accelcmn.cpp:93
+msgctxt "keyboard key"
+msgid "KP_Down"
+msgstr "KP_Down"
+
+#: ../src/common/accelcmn.cpp:93
+msgctxt "keyboard key"
+msgid "Num Down"
+msgstr "Num Down"
+
+#: ../src/common/accelcmn.cpp:94
+msgctxt "keyboard key"
+msgid "KP_PageUp"
+msgstr "KP_PageUp"
+
+#: ../src/common/accelcmn.cpp:94
+msgctxt "keyboard key"
+msgid "Num Page Up"
+msgstr "Num Page Up"
+
+#: ../src/common/accelcmn.cpp:95
+msgctxt "keyboard key"
+msgid "KP_PageDown"
+msgstr "KP_PageDown"
+
+#: ../src/common/accelcmn.cpp:95
+msgctxt "keyboard key"
+msgid "Num Page Down"
+msgstr "Num Page Down"
+
+#: ../src/common/accelcmn.cpp:96
+msgctxt "keyboard key"
+msgid "KP_Prior"
+msgstr "KP_Prior"
+
+#: ../src/common/accelcmn.cpp:97
+msgctxt "keyboard key"
+msgid "KP_Next"
+msgstr "KP_Next"
+
+#: ../src/common/accelcmn.cpp:98
+msgctxt "keyboard key"
+msgid "KP_End"
+msgstr "KP_End"
+
+#: ../src/common/accelcmn.cpp:98
+msgctxt "keyboard key"
+msgid "Num End"
+msgstr "Num End"
+
+#: ../src/common/accelcmn.cpp:99
+msgctxt "keyboard key"
+msgid "KP_Begin"
+msgstr "KP_Begin"
+
+#: ../src/common/accelcmn.cpp:99
+msgctxt "keyboard key"
+msgid "Num Begin"
+msgstr "Num Begin"
+
+#: ../src/common/accelcmn.cpp:100
+msgctxt "keyboard key"
+msgid "KP_Insert"
+msgstr "KP_Insert"
+
+#: ../src/common/accelcmn.cpp:100
+msgctxt "keyboard key"
+msgid "Num Insert"
+msgstr "Num Insert"
+
+#: ../src/common/accelcmn.cpp:101
+msgctxt "keyboard key"
+msgid "KP_Delete"
+msgstr "KP_Delete"
+
+#: ../src/common/accelcmn.cpp:101
+msgctxt "keyboard key"
+msgid "Num Delete"
+msgstr "Num Delete"
+
+#: ../src/common/accelcmn.cpp:102
+msgctxt "keyboard key"
+msgid "KP_Equal"
+msgstr "KP_Equal"
+
+#: ../src/common/accelcmn.cpp:102
+msgctxt "keyboard key"
+msgid "Num ="
+msgstr "Num ="
+
+#: ../src/common/accelcmn.cpp:103
+msgctxt "keyboard key"
+msgid "KP_Multiply"
+msgstr "KP_Multiply"
+
+#: ../src/common/accelcmn.cpp:103
+msgctxt "keyboard key"
+msgid "Num *"
+msgstr "Num *"
+
+#: ../src/common/accelcmn.cpp:104
+msgctxt "keyboard key"
+msgid "KP_Add"
+msgstr "KP_Add"
+
+#: ../src/common/accelcmn.cpp:104
+msgctxt "keyboard key"
+msgid "Num +"
+msgstr "Num +"
+
+#: ../src/common/accelcmn.cpp:105
+msgctxt "keyboard key"
+msgid "KP_Separator"
+msgstr "KP_Separator"
+
+#: ../src/common/accelcmn.cpp:105
+msgctxt "keyboard key"
+msgid "Num ,"
+msgstr "Num ,"
+
+#: ../src/common/accelcmn.cpp:106
+msgctxt "keyboard key"
+msgid "KP_Subtract"
+msgstr "KP_Subtract"
+
+#: ../src/common/accelcmn.cpp:106
+msgctxt "keyboard key"
+msgid "Num -"
+msgstr "Num -"
+
+#: ../src/common/accelcmn.cpp:107
+msgctxt "keyboard key"
+msgid "KP_Decimal"
+msgstr "KP_Decimal"
+
+#: ../src/common/accelcmn.cpp:107
+msgctxt "keyboard key"
+msgid "Num ."
+msgstr "Num ."
+
+#: ../src/common/accelcmn.cpp:108
+msgctxt "keyboard key"
+msgid "KP_Divide"
+msgstr "KP_Divide"
+
+#: ../src/common/accelcmn.cpp:108
+msgctxt "keyboard key"
+msgid "Num /"
+msgstr "Num /"
+
+#: ../src/common/accelcmn.cpp:109
+msgctxt "keyboard key"
+msgid "Windows_Left"
+msgstr "Windows_Left"
+
+#: ../src/common/accelcmn.cpp:110
+msgctxt "keyboard key"
+msgid "Windows_Right"
+msgstr "Windows_Right"
+
+#: ../src/common/accelcmn.cpp:111
+msgctxt "keyboard key"
+msgid "Windows_Menu"
+msgstr "Windows_Menu"
+
+#: ../src/common/accelcmn.cpp:112
+msgctxt "keyboard key"
+msgid "Command"
+msgstr "Command"
+
+#: ../src/common/accelcmn.cpp:186 ../src/common/accelcmn.cpp:359
+msgctxt "keyboard key"
+msgid "Ctrl"
+msgstr "Ctrl"
+
+#: ../src/common/accelcmn.cpp:188 ../src/common/accelcmn.cpp:363
+msgctxt "keyboard key"
+msgid "Alt"
+msgstr "Alt"
+
+#: ../src/common/accelcmn.cpp:190 ../src/common/accelcmn.cpp:361
+msgctxt "keyboard key"
+msgid "Shift"
+msgstr "Shift"
+
+#: ../src/common/accelcmn.cpp:196
+msgctxt "keyboard key"
+msgid "num "
+msgstr "num "
+
+#: ../src/common/accelcmn.cpp:260 ../src/common/accelcmn.cpp:382
+msgctxt "keyboard key"
+msgid "F"
+msgstr "F"
+
+#: ../src/common/accelcmn.cpp:277 ../src/common/accelcmn.cpp:385
+msgctxt "keyboard key"
+msgid "KP_F"
+msgstr "KP_F"
+
+#: ../src/common/accelcmn.cpp:280 ../src/common/accelcmn.cpp:388
+msgctxt "keyboard key"
+msgid "KP_"
+msgstr "KP_"
+
+#: ../src/common/accelcmn.cpp:283 ../src/common/accelcmn.cpp:391
+msgctxt "keyboard key"
+msgid "SPECIAL"
+msgstr "SPECIAL"
+
+#: ../src/common/accelcmn.cpp:373
+#, fuzzy
+msgid "Ctrl"
+msgstr "Ctrl"
+
+#: ../src/common/appbase.cpp:786
+msgid "show this help message"
+msgstr "このヘルプメッセージを表示する"
+
+#: ../src/common/appbase.cpp:796
+msgid "generate verbose log messages"
+msgstr "冗長なログメッセージを生成する"
+
+#: ../src/common/appcmn.cpp:256
+msgid "specify the theme to use"
+msgstr "使用するテーマを指定する"
+
+#: ../src/common/appcmn.cpp:270
+msgid "specify display mode to use (e.g. 640x480-16)"
+msgstr "使用する画面モードを指定する (例: 640x480-16)"
+
+#: ../src/common/appcmn.cpp:292
+#, c-format
+msgid "Unsupported theme '%s'."
+msgstr "テーマ '%s' は未対応です。"
+
+#: ../src/common/appcmn.cpp:309
+#, c-format
+msgid "Invalid display mode specification '%s'."
+msgstr "画面モード '%s' は正しい指定ではありません。"
+
+#: ../src/common/cmdline.cpp:875
+#, c-format
+msgid "Option '%s' can't be negated"
+msgstr "オプション '%s' は無効にできません"
+
+#: ../src/common/cmdline.cpp:889
+#, c-format
+msgid "Unknown long option '%s'"
+msgstr "未定義の詳細オプション名 '%s'"
+
+#: ../src/common/cmdline.cpp:904 ../src/common/cmdline.cpp:926
+#, c-format
+msgid "Unknown option '%s'"
+msgstr "未定義のオプション名 '%s'"
+
+#: ../src/common/cmdline.cpp:1004
+#, c-format
+msgid "Unexpected characters following option '%s'."
+msgstr "オプション '%s' に想定外の文字が続いています。"
+
+#: ../src/common/cmdline.cpp:1039
+#, c-format
+msgid "Option '%s' requires a value."
+msgstr "オプション '%s' には値の指定が必要です。"
+
+#: ../src/common/cmdline.cpp:1058
+#, c-format
+msgid "Separator expected after the option '%s'."
+msgstr "オプション '%s' の後には区切り文字が必要です。"
+
+#: ../src/common/cmdline.cpp:1088 ../src/common/cmdline.cpp:1106
+#, c-format
+msgid "'%s' is not a correct numeric value for option '%s'."
+msgstr "'%s' はオプション '%s' に使えない数値です。"
+
+#: ../src/common/cmdline.cpp:1122
+#, c-format
+msgid "Option '%s': '%s' cannot be converted to a date."
+msgstr "オプション '%s': '%s' という表現は日付に変換できません。"
+
+#: ../src/common/cmdline.cpp:1170
+#, c-format
+msgid "Unexpected parameter '%s'"
+msgstr "想定外の引数 '%s'"
+
+#. TRANSLATORS: Short name and long name for a command line option
+#: ../src/common/cmdline.cpp:1197
+#, c-format
+msgid "%s (or %s)"
+msgstr "%s (または %s)"
+
+#: ../src/common/cmdline.cpp:1208
+#, c-format
+msgid "The value for the option '%s' must be specified."
+msgstr "オプション '%s' の値は必ず指定してください。"
+
+#: ../src/common/cmdline.cpp:1230
+#, c-format
+msgid "The required parameter '%s' was not specified."
+msgstr "必須引数 '%s' が与えられていません。"
+
+#: ../src/common/cmdline.cpp:1289
+#, c-format
+msgid "Usage: %s"
+msgstr "使い方: %s"
+
+#: ../src/common/cmdline.cpp:1498
+msgid "str"
+msgstr "文字列"
+
+#: ../src/common/cmdline.cpp:1502
+msgid "num"
+msgstr "数値"
+
+#: ../src/common/cmdline.cpp:1506
+msgid "double"
+msgstr "double値"
+
+#: ../src/common/cmdline.cpp:1510
+msgid "date"
+msgstr "日付"
+
+#: ../src/common/cmdproc.cpp:250 ../src/common/cmdproc.cpp:276
+#: ../src/common/cmdproc.cpp:296
+msgid "Unnamed command"
+msgstr "無名コマンド"
+
+#: ../src/common/cmdproc.cpp:253
+msgid "&Undo "
+msgstr "元に戻す(&U)"
+
+#: ../src/common/cmdproc.cpp:255
+msgid "Can't &Undo "
+msgstr "戻せません(&U)"
+
+#: ../src/common/cmdproc.cpp:259 ../src/common/stockitem.cpp:208
+#: ../src/msw/textctrl.cpp:2880 ../src/osx/textctrl_osx.cpp:649
+#: ../src/richtext/richtextctrl.cpp:327
+msgid "&Undo"
+msgstr "元に戻す(&U)"
+
+#: ../src/common/cmdproc.cpp:277 ../src/common/cmdproc.cpp:297
+msgid "&Redo "
+msgstr "やり直す(&R)"
+
+#: ../src/common/cmdproc.cpp:281 ../src/common/cmdproc.cpp:288
+#: ../src/common/stockitem.cpp:190 ../src/msw/textctrl.cpp:2881
+#: ../src/osx/textctrl_osx.cpp:650 ../src/richtext/richtextctrl.cpp:328
+msgid "&Redo"
+msgstr "やり直す(&R)"
+
+#: ../src/common/colourcmn.cpp:41
+#, c-format
+msgid "String To Colour : Incorrect colour specification : %s"
+msgstr "文字列から色へ : 色指定が不正です : %s"
+
+#: ../src/common/config.cpp:259
+#, c-format
+msgid "Invalid value %ld for a boolean key \"%s\" in config file."
+msgstr "不正な値 %ld が設定ファイルのbooleanキー \"%s\" に指定されています。"
+
+#: ../src/common/config.cpp:526
+#, c-format
+msgid ""
+"Environment variables expansion failed: missing '%c' at position %u in '%s'."
+msgstr ""
+"環境変数の拡張に失敗しました: '%3$s' の %2$u 文字目に '%1$c' がありません。"
+
+#: ../src/common/config.cpp:576 ../src/msw/regconf.cpp:272
+#, c-format
+msgid "'%s' has extra '..', ignored."
+msgstr "'%s' に余分な '..' がありました。無視します。"
+
+#. TRANSLATORS: Checkbox state name
+#: ../src/common/datavcmn.cpp:2166 ../src/generic/datavgen.cpp:1430
+msgid "checked"
+msgstr "チェックあり"
+
+#. TRANSLATORS: Checkbox state name
+#: ../src/common/datavcmn.cpp:2170 ../src/generic/datavgen.cpp:1432
+msgid "unchecked"
+msgstr "チェックなし"
+
+#. TRANSLATORS: Checkbox state name
+#: ../src/common/datavcmn.cpp:2174
+msgid "undetermined"
+msgstr "未定義"
+
+#: ../src/common/datetimefmt.cpp:1875
+msgid "today"
+msgstr "今日"
+
+#: ../src/common/datetimefmt.cpp:1876
+msgid "yesterday"
+msgstr "昨日"
+
+#: ../src/common/datetimefmt.cpp:1877
+msgid "tomorrow"
+msgstr "明日"
+
+#: ../src/common/datetimefmt.cpp:2071
+msgid "first"
+msgstr "1日"
+
+#: ../src/common/datetimefmt.cpp:2072
+msgid "second"
+msgstr "2日"
+
+#: ../src/common/datetimefmt.cpp:2073
+msgid "third"
+msgstr "3日"
+
+#: ../src/common/datetimefmt.cpp:2074
+msgid "fourth"
+msgstr "4日"
+
+#: ../src/common/datetimefmt.cpp:2075
+msgid "fifth"
+msgstr "5日"
+
+#: ../src/common/datetimefmt.cpp:2076
+msgid "sixth"
+msgstr "6日"
+
+#: ../src/common/datetimefmt.cpp:2077
+msgid "seventh"
+msgstr "7日"
+
+#: ../src/common/datetimefmt.cpp:2078
+msgid "eighth"
+msgstr "8日"
+
+#: ../src/common/datetimefmt.cpp:2079
+msgid "ninth"
+msgstr "9日"
+
+#: ../src/common/datetimefmt.cpp:2080
+msgid "tenth"
+msgstr "10日"
+
+#: ../src/common/datetimefmt.cpp:2081
+msgid "eleventh"
+msgstr "11日"
+
+#: ../src/common/datetimefmt.cpp:2082
+msgid "twelfth"
+msgstr "12日"
+
+#: ../src/common/datetimefmt.cpp:2083
+msgid "thirteenth"
+msgstr "13日"
+
+#: ../src/common/datetimefmt.cpp:2084
+msgid "fourteenth"
+msgstr "14日"
+
+#: ../src/common/datetimefmt.cpp:2085
+msgid "fifteenth"
+msgstr "15日"
+
+#: ../src/common/datetimefmt.cpp:2086
+msgid "sixteenth"
+msgstr "16日"
+
+#: ../src/common/datetimefmt.cpp:2087
+msgid "seventeenth"
+msgstr "17日"
+
+#: ../src/common/datetimefmt.cpp:2088
+msgid "eighteenth"
+msgstr "18日"
+
+#: ../src/common/datetimefmt.cpp:2089
+msgid "nineteenth"
+msgstr "19日"
+
+#: ../src/common/datetimefmt.cpp:2090
+msgid "twentieth"
+msgstr "20日"
+
+#: ../src/common/datetimefmt.cpp:2248
+msgid "noon"
+msgstr "正午"
+
+#: ../src/common/datetimefmt.cpp:2249
+msgid "midnight"
+msgstr "0時"
+
+#: ../src/common/debugrpt.cpp:209
+#, c-format
+msgid "Failed to create directory \"%s\""
+msgstr "ディレクトリ \"%s\" を作成できませんでした"
+
+#: ../src/common/debugrpt.cpp:210
+msgid "Debug report couldn't be created."
+msgstr "デバッグレポートを作成できませんでした。"
+
+#: ../src/common/debugrpt.cpp:227
+#, c-format
+msgid "Failed to remove debug report file \"%s\""
+msgstr "デバッグレポートファイル \"%s\" を削除できませんでした"
+
+#: ../src/common/debugrpt.cpp:239
+#, c-format
+msgid "Failed to clean up debug report directory \"%s\""
+msgstr "デバッグレポートディレクトリ \"%s\" を全削除できませんでした"
+
+#: ../src/common/debugrpt.cpp:514
+msgid "process context description"
+msgstr "プロセスコンテキストの記述"
+
+#: ../src/common/debugrpt.cpp:538
+msgid "dump of the process state (binary)"
+msgstr "プロセス状態のダンプ (バイナリ)"
+
+#: ../src/common/debugrpt.cpp:553
+msgid "Debug report generation has failed."
+msgstr "デバッグレポートの作成に失敗しました。"
+
+#: ../src/common/debugrpt.cpp:560
+#, c-format
+msgid ""
+"Processing debug report has failed, leaving the files in \"%s\" directory."
+msgstr ""
+"デバッグレポートの処理に失敗しました。ディレクトリ \"%s\" にファイルを残しま"
+"す。"
+
+#: ../src/common/debugrpt.cpp:573
+msgid "A debug report has been generated. It can be found in"
+msgstr "デバッグレポートが作成されました。次の場所にあります:"
+
+#: ../src/common/debugrpt.cpp:576
+msgid "And includes the following files:\n"
+msgstr "次のファイルが含まれます:\n"
+
+#: ../src/common/debugrpt.cpp:586
+msgid ""
+"\n"
+"Please send this report to the program maintainer, thank you!\n"
+msgstr ""
+"\n"
+"このレポートをプログラムの保守担当者に送信してください。よろしくお願いいたし"
+"ます。\n"
+
+#: ../src/common/debugrpt.cpp:729
+msgid "Failed to execute curl, please install it in PATH."
+msgstr "curl を実行できません。PATHの参照先にインストールしてください。"
+
+#: ../src/common/debugrpt.cpp:742
+#, c-format
+msgid "Failed to upload the debug report (error code %d)."
+msgstr "デバッグレポートをアップロードできませんでした (エラーコード %d)。"
+
+#: ../src/common/docview.cpp:366
+msgid "Save As"
+msgstr "別名で保存"
+
+#: ../src/common/docview.cpp:457
+msgid "Discard changes and reload the last saved version?"
+msgstr "変更を破棄して最後に保存したものを読み直しますか?"
+
+#: ../src/common/docview.cpp:488
+msgid "unnamed"
+msgstr "名称未指定"
+
+#: ../src/common/docview.cpp:513
+#, c-format
+msgid "Do you want to save changes to %s?"
+msgstr "変更を %s へ保存しますか?"
+
+#: ../src/common/docview.cpp:521 ../src/common/docview.cpp:560
+#: ../src/common/stockitem.cpp:195
+msgid "&Save"
+msgstr "保存(&S)"
+
+#: ../src/common/docview.cpp:522 ../src/common/docview.cpp:560
+msgid "&Discard changes"
+msgstr "変更を破棄(&D)"
+
+#: ../src/common/docview.cpp:523
+msgid "Do&n't close"
+msgstr "閉じない(&N)"
+
+#: ../src/common/docview.cpp:553
+#, c-format
+msgid "Do you want to save changes to %s before closing it?"
+msgstr "閉じる前に変更を %s へ保存しますか?"
+
+#: ../src/common/docview.cpp:559
+msgid "The document must be closed."
+msgstr "文書を閉じる必要があります。"
+
+#: ../src/common/docview.cpp:571
+#, c-format
+msgid "Saving %s failed, would you like to retry?"
+msgstr "%s の保存に失敗しました。再試行しますか?"
+
+#: ../src/common/docview.cpp:577
+msgid "Retry"
+msgstr "再試行"
+
+#: ../src/common/docview.cpp:577
+msgid "Discard changes"
+msgstr "変更を破棄"
+
+#: ../src/common/docview.cpp:679
+#, c-format
+msgid "File \"%s\" could not be opened for writing."
+msgstr "ファイル '%s' を書き込み用に開けませんでした。"
+
+#: ../src/common/docview.cpp:685
+#, c-format
+msgid "Failed to save document to the file \"%s\"."
+msgstr "文書をファイル \"%s\" に保存できませんでした。"
+
+#: ../src/common/docview.cpp:702
+#, c-format
+msgid "File \"%s\" could not be opened for reading."
+msgstr "ファイル '%s' を読み取り用に開けませんでした。"
+
+#: ../src/common/docview.cpp:714
+#, c-format
+msgid "Failed to read document from the file \"%s\"."
+msgstr "ファイル \"%s\" から文書を読み取れませんでした。"
+
+#: ../src/common/docview.cpp:1236
+#, c-format
+msgid ""
+"The file '%s' doesn't exist and couldn't be opened.\n"
+"It has been removed from the most recently used files list."
+msgstr ""
+"ファイル '%s' が存在しないため開けませんでした。\n"
+"最近使ったファイルの一覧から削除されています。"
+
+#: ../src/common/docview.cpp:1296
+msgid "Print preview creation failed."
+msgstr "印刷プレビューを作成できませんでした。"
+
+#: ../src/common/docview.cpp:1302
+msgid "Print Preview"
+msgstr "印刷プレビュー"
+
+#: ../src/common/docview.cpp:1517
+#, c-format
+msgid "The format of file '%s' couldn't be determined."
+msgstr "ファイル '%s' の形式を判断できませんでした。"
+
+#: ../src/common/docview.cpp:1643
+#, c-format
+msgid "unnamed%d"
+msgstr "名称未指定%d"
+
+#: ../src/common/docview.cpp:1660
+msgid " - "
+msgstr " - "
+
+#: ../src/common/docview.cpp:1791 ../src/common/docview.cpp:1844
+msgid "Open File"
+msgstr "ファイルを開く"
+
+#: ../src/common/docview.cpp:1807
+msgid "File error"
+msgstr "ファイルエラー"
+
+#: ../src/common/docview.cpp:1809
+msgid "Sorry, could not open this file."
+msgstr "このファイルを開くことができませんでした。"
+
+#: ../src/common/docview.cpp:1843
+msgid "Sorry, the format for this file is unknown."
+msgstr "このファイルは形式が不明です。"
+
+#: ../src/common/docview.cpp:1924
+msgid "Select a document template"
+msgstr "文書のテンプレートを選んでください"
+
+#: ../src/common/docview.cpp:1925
+msgid "Templates"
+msgstr "テンプレート"
+
+#: ../src/common/docview.cpp:1998
+msgid "Select a document view"
+msgstr "文書ビューの選択"
+
+#: ../src/common/docview.cpp:1999
+msgid "Views"
+msgstr "ビュー"
+
+#: ../src/common/dynlib.cpp:81
+#, c-format
+msgid "Failed to load shared library '%s'"
+msgstr "共有ライブラリ '%s' を読み取れませんでした"
+
+#: ../src/common/dynlib.cpp:105
+#, c-format
+msgid "Couldn't find symbol '%s' in a dynamic library"
+msgstr "シンボル '%s' が動的ライブラリーの中に見つかりませんでした"
+
+#: ../src/common/ffile.cpp:56 ../src/common/file.cpp:215
+#, c-format
+msgid "can't open file '%s'"
+msgstr "ファイル '%s' を開くことができません"
+
+#: ../src/common/ffile.cpp:72
+#, c-format
+msgid "can't close file '%s'"
+msgstr "ファイル '%s' を閉じることができません"
+
+#: ../src/common/ffile.cpp:106 ../src/common/ffile.cpp:131
+#, c-format
+msgid "Read error on file '%s'"
+msgstr "ファイル '%s' の読み取りエラー"
+
+#: ../src/common/ffile.cpp:148
+#, c-format
+msgid "Write error on file '%s'"
+msgstr "ファイル '%s' への書き出しエラー"
+
+#: ../src/common/ffile.cpp:182
+#, c-format
+msgid "failed to flush the file '%s'"
+msgstr "ファイル '%s' のフラッシュができませんでした"
+
+#: ../src/common/ffile.cpp:222
+#, c-format
+msgid "Seek error on file '%s' (large files not supported by stdio)"
+msgstr "ファイル '%s' のシークエラー (stdioでは大きなファイルに対応できません)"
+
+#: ../src/common/ffile.cpp:232
+#, c-format
+msgid "Seek error on file '%s'"
+msgstr "ファイル '%s' のシークエラー"
+
+#: ../src/common/ffile.cpp:248
+#, c-format
+msgid "Can't find current position in file '%s'"
+msgstr "ファイル '%s' の現在位置を見つけられません"
+
+#: ../src/common/ffile.cpp:349 ../src/common/file.cpp:569
+msgid "Failed to set temporary file permissions"
+msgstr "一時ファイルのパーミッションを設定できませんでした"
+
+#: ../src/common/ffile.cpp:371
+#, c-format
+msgid "can't remove file '%s'"
+msgstr "ファイル '%s' を削除できません"
+
+#: ../src/common/ffile.cpp:376 ../src/common/file.cpp:591
+#, c-format
+msgid "can't commit changes to file '%s'"
+msgstr "変更をファイル '%s' に反映できません"
+
+#: ../src/common/ffile.cpp:388 ../src/common/file.cpp:603
+#, c-format
+msgid "can't remove temporary file '%s'"
+msgstr "一時ファイル '%s' を削除できません"
+
+#: ../src/common/file.cpp:162
+#, c-format
+msgid "can't create file '%s'"
+msgstr "ファイル '%s' を作成できません"
+
+#: ../src/common/file.cpp:229
+#, c-format
+msgid "can't close file descriptor %d"
+msgstr "記述子 %d のファイルを閉じることができません"
+
+#: ../src/common/file.cpp:332
+#, c-format
+msgid "can't read from file descriptor %d"
+msgstr "記述子 %d のファイルから読み取ることができません"
+
+#: ../src/common/file.cpp:351
+#, c-format
+msgid "can't write to file descriptor %d"
+msgstr "記述子 %d のファイルへ書き出すことができません"
+
+#: ../src/common/file.cpp:390
+#, c-format
+msgid "can't flush file descriptor %d"
+msgstr "記述子 %d のファイルをフラッシュできません"
+
+#: ../src/common/file.cpp:432
+#, c-format
+msgid "can't seek on file descriptor %d"
+msgstr "記述子 %d のファイルをシークできません"
+
+#: ../src/common/file.cpp:446
+#, c-format
+msgid "can't get seek position on file descriptor %d"
+msgstr "記述子 %d のファイルからシーク位置を取得できません"
+
+#: ../src/common/file.cpp:475
+#, c-format
+msgid "can't find length of file on file descriptor %d"
+msgstr "記述子 %d のファイルから長さを取得できません"
+
+#: ../src/common/file.cpp:505
+#, c-format
+msgid "can't determine if the end of file is reached on descriptor %d"
+msgstr "記述子 %d のファイルがEOFに達したかどうかを判断できません"
+
+#: ../src/common/fileconf.cpp:352
+#, c-format
+msgid ""
+" and additionally, the existing configuration file was renamed to \"%s\" and "
+"couldn't be renamed back, please rename it to its original path \"%s\""
+msgstr ""
+
+#: ../src/common/fileconf.cpp:389
+#, fuzzy
+msgid " due to the following error:\n"
+msgstr "次のファイルが含まれます:\n"
+
+#: ../src/common/fileconf.cpp:412
+#, fuzzy
+msgid "failed to rename the existing file"
+msgstr "ファイル \"%s\" から文書を読み取れませんでした。"
+
+#: ../src/common/fileconf.cpp:421
+#, fuzzy
+msgid "failed to create the new file directory"
+msgstr "作業ディレクトリを取得できませんでした"
+
+#: ../src/common/fileconf.cpp:428
+#, fuzzy
+msgid "failed to move the file to the new location"
+msgstr "ダイヤルアップ接続を終了できませんでした: %s"
+
+#: ../src/common/fileconf.cpp:462
+#, c-format
+msgid "can't open global configuration file '%s'."
+msgstr "共有設定ファイル '%s' を開くことができません。"
+
+#: ../src/common/fileconf.cpp:478
+#, c-format
+msgid "can't open user configuration file '%s'."
+msgstr "ユーザー設定ファイル '%s' を開くことができません。"
+
+#: ../src/common/fileconf.cpp:483
+#, c-format
+msgid "Changes won't be saved to avoid overwriting the existing file \"%s\""
+msgstr "既存ファイル \"%s\" への上書きを防ぐため、変更内容は保存されません"
+
+#: ../src/common/fileconf.cpp:583
+msgid "Error reading config options."
+msgstr "設定オプションの読み取り中にエラーが発生しました。"
+
+#: ../src/common/fileconf.cpp:593
+msgid "Failed to read config options."
+msgstr "設定オプションを読み取ることができませんでした。"
+
+#: ../src/common/fileconf.cpp:700
+#, c-format
+msgid "file '%s': unexpected character %c at line %zu."
+msgstr "ファイル '%s': 想定外の文字 %c が %zu 行目にありました。"
+
+#: ../src/common/fileconf.cpp:736
+#, c-format
+msgid "file '%s', line %zu: '%s' ignored after group header."
+msgstr "ファイル '%s' %zu 行目: グループヘッダの後にある '%s' は無視されます。"
+
+#: ../src/common/fileconf.cpp:765
+#, c-format
+msgid "file '%s', line %zu: '=' expected."
+msgstr "ファイル '%s' %zu 行目: '=' がありません。"
+
+#: ../src/common/fileconf.cpp:778
+#, c-format
+msgid "file '%s', line %zu: value for immutable key '%s' ignored."
+msgstr "ファイル '%s' %zu 行目: 不変キー '%s' への値は無視されます。"
+
+#: ../src/common/fileconf.cpp:788
+#, c-format
+msgid "file '%s', line %zu: key '%s' was first found at line %d."
+msgstr "ファイル '%s' %zu 行目: キー '%s' はすでに %d 行目に存在します。"
+
+#: ../src/common/fileconf.cpp:1091
+#, c-format
+msgid "Config entry name cannot start with '%c'."
+msgstr "設定項目名は '%c' で始めることができません。"
+
+#: ../src/common/fileconf.cpp:1146
+#, fuzzy
+msgid "Failed to create configuration file directory."
+msgstr "ユーザー設定ファイルを更新できませんでした。"
+
+#: ../src/common/fileconf.cpp:1158
+msgid "can't open user configuration file."
+msgstr "ユーザー設定ファイルを開くことができません。"
+
+#: ../src/common/fileconf.cpp:1172
+msgid "can't write user configuration file."
+msgstr "ユーザー設定ファイルを書き出すことができません。"
+
+#: ../src/common/fileconf.cpp:1178
+msgid "Failed to update user configuration file."
+msgstr "ユーザー設定ファイルを更新できませんでした。"
+
+#: ../src/common/fileconf.cpp:1201
+msgid "Error saving user configuration data."
+msgstr "ユーザー設定データの保存中にエラーが発生しました。"
+
+#: ../src/common/fileconf.cpp:1313
+#, c-format
+msgid "can't delete user configuration file '%s'"
+msgstr "ユーザー設定ファイル '%s' を削除できません"
+
+#: ../src/common/fileconf.cpp:2007
+#, c-format
+msgid "entry '%s' appears more than once in group '%s'"
+msgstr "項目 '%s' がグループ '%s' に2つ以上存在します"
+
+#: ../src/common/fileconf.cpp:2021
+#, c-format
+msgid "attempt to change immutable key '%s' ignored."
+msgstr "不変キー '%s' への変更要求を無視しました。"
+
+#: ../src/common/fileconf.cpp:2118
+#, c-format
+msgid "trailing backslash ignored in '%s'"
+msgstr "'%s' の末尾にあるバックスラッシュを無視しました"
+
+#: ../src/common/fileconf.cpp:2153
+#, c-format
+msgid "unexpected \" at position %d in '%s'."
+msgstr "'%2$s' の %1$d 文字目に想定外の\"があります。"
+
+#: ../src/common/filefn.cpp:474
+#, c-format
+msgid "Failed to copy the file '%s' to '%s'"
+msgstr "ファイル '%s' を '%s' へコピーできませんでした。"
+
+#: ../src/common/filefn.cpp:487
+#, c-format
+msgid "Impossible to get permissions for file '%s'"
+msgstr "ファイル '%s' のパーミッションは取得不可能です"
+
+#: ../src/common/filefn.cpp:501
+#, c-format
+msgid "Impossible to overwrite the file '%s'"
+msgstr "ファイル '%s' の上書きは不可能です"
+
+#: ../src/common/filefn.cpp:508
+#, c-format
+msgid "Error copying the file '%s' to '%s'."
+msgstr "ファイル '%s' を '%s' へコピー中にエラーが発生しました。"
+
+#: ../src/common/filefn.cpp:556
+#, c-format
+msgid "Impossible to set permissions for the file '%s'"
+msgstr "ファイル '%s' へのパーミッションは設定不可能です"
+
+#: ../src/common/filefn.cpp:606
+#, c-format
+msgid ""
+"Failed to rename the file '%s' to '%s' because the destination file already "
+"exists."
+msgstr ""
+"ファイル '%s' を '%s' に名称変更できませんでした。名称変更先のファイルがすで"
+"に存在しています。"
+
+#: ../src/common/filefn.cpp:623
+#, c-format
+msgid "File '%s' couldn't be renamed '%s'"
+msgstr "ファイル '%s' を '%s' へ名称変更できませんでした"
+
+#: ../src/common/filefn.cpp:639
+#, c-format
+msgid "File '%s' couldn't be removed"
+msgstr "ファイル '%s' を削除できませんでした"
+
+#: ../src/common/filefn.cpp:666
+#, c-format
+msgid "Directory '%s' couldn't be created"
+msgstr "ディレクトリ '%s' を作成できませんでした"
+
+#: ../src/common/filefn.cpp:680
+#, c-format
+msgid "Directory '%s' couldn't be deleted"
+msgstr "ディレクトリ '%s' を削除できませんでした"
+
+#: ../src/common/filefn.cpp:714
+#, c-format
+msgid "Cannot enumerate files '%s'"
+msgstr "ファイル '%s' を列挙できません"
+
+#: ../src/common/filefn.cpp:798
+msgid "Failed to get the working directory"
+msgstr "作業ディレクトリを取得できませんでした"
+
+#: ../src/common/filefn.cpp:843
+msgid "Could not set current working directory"
+msgstr "作業ディレクトリを設定できませんでした"
+
+#: ../src/common/filefn.cpp:974
+#, c-format
+msgid "Files (%s)"
+msgstr "ファイル (%s)"
+
+#: ../src/common/filename.cpp:182
+#, c-format
+msgid "Failed to open '%s' for reading"
+msgstr "ファイル '%s' を読み取り用に開くことができませんでした"
+
+#: ../src/common/filename.cpp:187
+#, c-format
+msgid "Failed to open '%s' for writing"
+msgstr "ファイル '%s' を書き込み用に開くことができませんでした"
+
+#: ../src/common/filename.cpp:199
+msgid "Failed to close file handle"
+msgstr "ファイルハンドルを閉じることができませんでした"
+
+#: ../src/common/filename.cpp:1046
+msgid "Failed to create a temporary file name"
+msgstr "一時ファイルの名前を作成できませんでした"
+
+#: ../src/common/filename.cpp:1081
+msgid "Failed to open temporary file."
+msgstr "一時ファイルを開くことができませんでした。"
+
+#: ../src/common/filename.cpp:2862
+#, c-format
+msgid "Failed to modify file times for '%s'"
+msgstr "'%s' のファイル時刻を変更できませんでした"
+
+#: ../src/common/filename.cpp:2877
+#, c-format
+msgid "Failed to touch the file '%s'"
+msgstr "ファイル '%s' の属性を変更できませんでした。"
+
+#: ../src/common/filename.cpp:2958
+#, c-format
+msgid "Failed to retrieve file times for '%s'"
+msgstr "'%s' のファイル時刻を取得できませんでした。"
+
+#: ../src/common/filepickercmn.cpp:39 ../src/common/filepickercmn.cpp:40
+msgid "Browse"
+msgstr "ファイルの選択"
+
+#: ../src/common/fldlgcmn.cpp:792 ../src/generic/filectrlg.cpp:1185
+#, c-format
+msgid "All files (%s)|%s"
+msgstr "すべてのファイル (%s)|%s"
+
+#. TRANSLATORS: %s are a file extension used to build a file wildcard string
+#: ../src/common/fldlgcmn.cpp:810
+#, c-format
+msgid "%s files (%s)|%s"
+msgstr "%s 形式 (%s)|%s"
+
+#: ../src/common/fldlgcmn.cpp:1072
+#, c-format
+msgid "Load %s file"
+msgstr "%s ファイルの読み取り"
+
+#: ../src/common/fldlgcmn.cpp:1074
+#, c-format
+msgid "Save %s file"
+msgstr "%s ファイルを保存"
+
+#: ../src/common/fmapbase.cpp:144
+msgid "Western European (ISO-8859-1)"
+msgstr "西ヨーロッパ言語 (ISO-8859-1)"
+
+#: ../src/common/fmapbase.cpp:145
+msgid "Central European (ISO-8859-2)"
+msgstr "中央ヨーロッパ言語 (ISO-8859-2)"
+
+#: ../src/common/fmapbase.cpp:146
+msgid "Esperanto (ISO-8859-3)"
+msgstr "エスペラント (ISO-8859-3)"
+
+#: ../src/common/fmapbase.cpp:147
+msgid "Baltic (old) (ISO-8859-4)"
+msgstr "バルト言語 (旧規格) (ISO-8859-4)"
+
+#: ../src/common/fmapbase.cpp:148
+msgid "Cyrillic (ISO-8859-5)"
+msgstr "キリル言語 (ISO-8859-5)"
+
+#: ../src/common/fmapbase.cpp:149
+msgid "Arabic (ISO-8859-6)"
+msgstr "アラビア語 (ISO-8859-6)"
+
+#: ../src/common/fmapbase.cpp:150
+msgid "Greek (ISO-8859-7)"
+msgstr "ギリシャ語 (ISO-8859-7)"
+
+#: ../src/common/fmapbase.cpp:151
+msgid "Hebrew (ISO-8859-8)"
+msgstr "ヘブライ語 (ISO-8859-8)"
+
+#: ../src/common/fmapbase.cpp:152
+msgid "Turkish (ISO-8859-9)"
+msgstr "トルコ語 (ISO-8859-9)"
+
+#: ../src/common/fmapbase.cpp:153
+msgid "Nordic (ISO-8859-10)"
+msgstr "北欧言語 (Latin-6, ISO-8859-10)"
+
+#: ../src/common/fmapbase.cpp:154
+msgid "Thai (ISO-8859-11)"
+msgstr "タイ語 (ISO-8859-11)"
+
+#: ../src/common/fmapbase.cpp:155
+msgid "Indian (ISO-8859-12)"
+msgstr "ISO-8859-12 (ケルト語→14/デーヴァナーガリー→破棄)"
+
+#: ../src/common/fmapbase.cpp:156
+msgid "Baltic (ISO-8859-13)"
+msgstr "バルト言語 (ISO-8859-13)"
+
+#: ../src/common/fmapbase.cpp:157
+msgid "Celtic (ISO-8859-14)"
+msgstr "ケルト語 (ISO-8859-14)"
+
+#: ../src/common/fmapbase.cpp:158
+msgid "Western European with Euro (ISO-8859-15)"
+msgstr "西ヨーロッパ言語ユーロ記号付き (ISO-8859-15)"
+
+#: ../src/common/fmapbase.cpp:159
+msgid "KOI8-R"
+msgstr "KOI8-R"
+
+#: ../src/common/fmapbase.cpp:160
+msgid "KOI8-U"
+msgstr "KOI8-U"
+
+#: ../src/common/fmapbase.cpp:161
+msgid "Windows/DOS OEM Cyrillic (CP 866)"
+msgstr "Windows/DOS OEM キリル言語 (CP 866)"
+
+#: ../src/common/fmapbase.cpp:162
+msgid "Windows Thai (CP 874)"
+msgstr "Windows タイ語 (CP 874)"
+
+#: ../src/common/fmapbase.cpp:163
+msgid "Windows Japanese (CP 932) or Shift-JIS"
+msgstr "Windows 日本語 (CP 932) / シフトJIS"
+
+#: ../src/common/fmapbase.cpp:164
+msgid "Windows Chinese Simplified (CP 936) or GB-2312"
+msgstr "Windows 簡体字中国語 (CP 936) / GB-2312"
+
+#: ../src/common/fmapbase.cpp:165
+msgid "Windows Korean (CP 949)"
+msgstr "Windows 韓国語 (CP 949)"
+
+#: ../src/common/fmapbase.cpp:166
+msgid "Windows Chinese Traditional (CP 950) or Big-5"
+msgstr "Windows 繁体字中国語 (CP 950) / Big-5"
+
+#: ../src/common/fmapbase.cpp:167
+msgid "Windows Central European (CP 1250)"
+msgstr "Windows 中央ヨーロッパ言語 (CP 1250)"
+
+#: ../src/common/fmapbase.cpp:168
+msgid "Windows Cyrillic (CP 1251)"
+msgstr "Windows キリル言語 (CP 1251)"
+
+#: ../src/common/fmapbase.cpp:169
+msgid "Windows Western European (CP 1252)"
+msgstr "Windows 西ヨーロッパ言語 (CP 1252)"
+
+#: ../src/common/fmapbase.cpp:170
+msgid "Windows Greek (CP 1253)"
+msgstr "Windows ギリシャ語 (CP 1253)"
+
+#: ../src/common/fmapbase.cpp:171
+msgid "Windows Turkish (CP 1254)"
+msgstr "Windows トルコ語 (CP 1254)"
+
+#: ../src/common/fmapbase.cpp:172
+msgid "Windows Hebrew (CP 1255)"
+msgstr "Windows ヘブライ語 (CP 1255)"
+
+#: ../src/common/fmapbase.cpp:173
+msgid "Windows Arabic (CP 1256)"
+msgstr "Windows アラビア語 (CP 1256)"
+
+#: ../src/common/fmapbase.cpp:174
+msgid "Windows Baltic (CP 1257)"
+msgstr "Windows バルト言語 (CP 1257)"
+
+#: ../src/common/fmapbase.cpp:175
+msgid "Windows Vietnamese (CP 1258)"
+msgstr "Windows ベトナム語 (CP 1258)"
+
+#: ../src/common/fmapbase.cpp:176
+msgid "Windows Johab (CP 1361)"
+msgstr "Windows Johab (CP 1361)"
+
+#: ../src/common/fmapbase.cpp:177
+msgid "Windows/DOS OEM (CP 437)"
+msgstr "Windows/DOS OEM (CP 437)"
+
+#: ../src/common/fmapbase.cpp:178
+msgid "Unicode 7 bit (UTF-7)"
+msgstr "Unicode 7 ビット (UTF-7)"
+
+#: ../src/common/fmapbase.cpp:179
+msgid "Unicode 8 bit (UTF-8)"
+msgstr "Unicode 8 ビット (UTF-8)"
+
+#: ../src/common/fmapbase.cpp:181 ../src/common/fmapbase.cpp:187
+msgid "Unicode 16 bit (UTF-16)"
+msgstr "Unicode 16 ビット (UTF-16)"
+
+#: ../src/common/fmapbase.cpp:182
+msgid "Unicode 16 bit Little Endian (UTF-16LE)"
+msgstr "Unicode 16ビット リトルエンディアン (UTF-16LE)"
+
+#: ../src/common/fmapbase.cpp:183 ../src/common/fmapbase.cpp:189
+msgid "Unicode 32 bit (UTF-32)"
+msgstr "Unicode 32 ビット (UTF-32)"
+
+#: ../src/common/fmapbase.cpp:184
+msgid "Unicode 32 bit Little Endian (UTF-32LE)"
+msgstr "Unicode 32 ビット リトルエンディアン (UTF-32LE)"
+
+#: ../src/common/fmapbase.cpp:186
+msgid "Unicode 16 bit Big Endian (UTF-16BE)"
+msgstr "Unicode 16 ビット ビッグエンディアン (UTF-16BE)"
+
+#: ../src/common/fmapbase.cpp:188
+msgid "Unicode 32 bit Big Endian (UTF-32BE)"
+msgstr "Unicode 32 ビット ビッグエンディアン (UTF-32BE)"
+
+#: ../src/common/fmapbase.cpp:191
+msgid "Extended Unix Codepage for Japanese (EUC-JP)"
+msgstr "日本語EUC (EUC-JP)"
+
+#: ../src/common/fmapbase.cpp:192
+msgid "US-ASCII"
+msgstr "US-ASCII"
+
+#: ../src/common/fmapbase.cpp:193
+msgid "ISO-2022-JP"
+msgstr "ISO-2022-JP"
+
+#: ../src/common/fmapbase.cpp:195
+msgid "MacRoman"
+msgstr "MacRoman"
+
+#: ../src/common/fmapbase.cpp:196
+msgid "MacJapanese"
+msgstr "MacJapanese"
+
+#: ../src/common/fmapbase.cpp:197
+msgid "MacChineseTrad"
+msgstr "MacChineseTrad"
+
+#: ../src/common/fmapbase.cpp:198
+msgid "MacKorean"
+msgstr "MacKorean"
+
+#: ../src/common/fmapbase.cpp:199
+msgid "MacArabic"
+msgstr "MacArabic"
+
+#: ../src/common/fmapbase.cpp:200
+msgid "MacHebrew"
+msgstr "MacHebrew"
+
+#: ../src/common/fmapbase.cpp:201
+msgid "MacGreek"
+msgstr "MacGreek"
+
+#: ../src/common/fmapbase.cpp:202
+msgid "MacCyrillic"
+msgstr "MacCyrillic"
+
+#: ../src/common/fmapbase.cpp:203
+msgid "MacDevanagari"
+msgstr "MacDevanagari"
+
+#: ../src/common/fmapbase.cpp:204
+msgid "MacGurmukhi"
+msgstr "MacGurmukhi"
+
+#: ../src/common/fmapbase.cpp:205
+msgid "MacGujarati"
+msgstr "MacGujarati"
+
+#: ../src/common/fmapbase.cpp:206
+msgid "MacOriya"
+msgstr "MacOriya"
+
+#: ../src/common/fmapbase.cpp:207
+msgid "MacBengali"
+msgstr "MacBengali"
+
+#: ../src/common/fmapbase.cpp:208
+msgid "MacTamil"
+msgstr "MacTamil"
+
+#: ../src/common/fmapbase.cpp:209
+msgid "MacTelugu"
+msgstr "MacTelugu"
+
+#: ../src/common/fmapbase.cpp:210
+msgid "MacKannada"
+msgstr "MacKannada"
+
+#: ../src/common/fmapbase.cpp:211
+msgid "MacMalayalam"
+msgstr "MacMalayalam"
+
+#: ../src/common/fmapbase.cpp:212
+msgid "MacSinhalese"
+msgstr "MacSinhalese"
+
+#: ../src/common/fmapbase.cpp:213
+msgid "MacBurmese"
+msgstr "MacBurmese"
+
+#: ../src/common/fmapbase.cpp:214
+msgid "MacKhmer"
+msgstr "MacKhmer"
+
+#: ../src/common/fmapbase.cpp:215
+msgid "MacThai"
+msgstr "MacThai"
+
+#: ../src/common/fmapbase.cpp:216
+msgid "MacLaotian"
+msgstr "MacLaotian"
+
+#: ../src/common/fmapbase.cpp:217
+msgid "MacGeorgian"
+msgstr "MacGeorgian"
+
+#: ../src/common/fmapbase.cpp:218
+msgid "MacArmenian"
+msgstr "MacArmenian"
+
+#: ../src/common/fmapbase.cpp:219
+msgid "MacChineseSimp"
+msgstr "MacChineseSimp"
+
+#: ../src/common/fmapbase.cpp:220
+msgid "MacTibetan"
+msgstr "MacTibetan"
+
+#: ../src/common/fmapbase.cpp:221
+msgid "MacMongolian"
+msgstr "MacMongolian"
+
+#: ../src/common/fmapbase.cpp:222
+msgid "MacEthiopic"
+msgstr "MacEthiopic"
+
+#: ../src/common/fmapbase.cpp:223
+msgid "MacCentralEurRoman"
+msgstr "MacCentralEurRoman"
+
+#: ../src/common/fmapbase.cpp:224
+msgid "MacVietnamese"
+msgstr "MacVietnamese"
+
+#: ../src/common/fmapbase.cpp:225
+msgid "MacExtArabic"
+msgstr "MacExtArabic"
+
+#: ../src/common/fmapbase.cpp:226
+msgid "MacSymbol"
+msgstr "MacSymbol"
+
+#: ../src/common/fmapbase.cpp:227
+msgid "MacDingbats"
+msgstr "MacDingbats"
+
+#: ../src/common/fmapbase.cpp:228
+msgid "MacTurkish"
+msgstr "MacTurkish"
+
+#: ../src/common/fmapbase.cpp:229
+msgid "MacCroatian"
+msgstr "MacCroatian"
+
+#: ../src/common/fmapbase.cpp:230
+msgid "MacIcelandic"
+msgstr "MacIcelandic"
+
+#: ../src/common/fmapbase.cpp:231
+msgid "MacRomanian"
+msgstr "MacRomanian"
+
+#: ../src/common/fmapbase.cpp:232
+msgid "MacCeltic"
+msgstr "MacCeltic"
+
+#: ../src/common/fmapbase.cpp:233
+msgid "MacGaelic"
+msgstr "MacGaelic"
+
+#: ../src/common/fmapbase.cpp:234
+msgid "MacKeyboardGlyphs"
+msgstr "MacKeyboardGlyphs"
+
+#: ../src/common/fmapbase.cpp:791
+msgid "Default encoding"
+msgstr "既定のエンコーディング"
+
+#: ../src/common/fmapbase.cpp:805
+#, c-format
+msgid "Unknown encoding (%d)"
+msgstr "不明なエンコーディング (%d)"
+
+#: ../src/common/fmapbase.cpp:815 ../src/richtext/richtextstyles.cpp:776
+msgid "default"
+msgstr "規定"
+
+#: ../src/common/fmapbase.cpp:829
+#, c-format
+msgid "unknown-%d"
+msgstr "不明-%d"
+
+#: ../src/common/fontcmn.cpp:924 ../src/common/fontcmn.cpp:1130
+msgid "underlined"
+msgstr "下線"
+
+#: ../src/common/fontcmn.cpp:929
+msgid " strikethrough"
+msgstr " 打ち消し線"
+
+#: ../src/common/fontcmn.cpp:942
+msgid " thin"
+msgstr " 超極細"
+
+#: ../src/common/fontcmn.cpp:946
+msgid " extra light"
+msgstr " 極細"
+
+#: ../src/common/fontcmn.cpp:950
+msgid " light"
+msgstr " 細"
+
+#: ../src/common/fontcmn.cpp:954
+msgid " medium"
+msgstr " 中"
+
+#: ../src/common/fontcmn.cpp:958
+msgid " semi bold"
+msgstr " 中太"
+
+#: ../src/common/fontcmn.cpp:962
+msgid " bold"
+msgstr " 太"
+
+#: ../src/common/fontcmn.cpp:966
+msgid " extra bold"
+msgstr " 特太"
+
+#: ../src/common/fontcmn.cpp:970
+msgid " heavy"
+msgstr " 極太"
+
+#: ../src/common/fontcmn.cpp:974
+msgid " extra heavy"
+msgstr " 超極太"
+
+#: ../src/common/fontcmn.cpp:990
+msgid " italic"
+msgstr " イタリック"
+
+#: ../src/common/fontcmn.cpp:1134
+msgid "strikethrough"
+msgstr "打ち消し線"
+
+#: ../src/common/fontcmn.cpp:1143
+msgid "thin"
+msgstr "超極細"
+
+#: ../src/common/fontcmn.cpp:1156
+msgid "extralight"
+msgstr "極細"
+
+#: ../src/common/fontcmn.cpp:1161
+msgid "light"
+msgstr "細"
+
+#: ../src/common/fontcmn.cpp:1169 ../src/richtext/richtextstyles.cpp:775
+msgid "normal"
+msgstr "通常"
+
+#: ../src/common/fontcmn.cpp:1174
+msgid "medium"
+msgstr "中"
+
+#: ../src/common/fontcmn.cpp:1179 ../src/common/fontcmn.cpp:1199
+msgid "semibold"
+msgstr "中太"
+
+#: ../src/common/fontcmn.cpp:1184
+msgid "bold"
+msgstr "太"
+
+#: ../src/common/fontcmn.cpp:1194
+msgid "extrabold"
+msgstr "特太"
+
+#: ../src/common/fontcmn.cpp:1204
+msgid "heavy"
+msgstr "極太"
+
+#: ../src/common/fontcmn.cpp:1212
+msgid "extraheavy"
+msgstr "超極太"
+
+#: ../src/common/fontcmn.cpp:1217
+msgid "italic"
+msgstr "イタリック"
+
+#: ../src/common/fontmap.cpp:195
+msgid ": unknown charset"
+msgstr ": 未知の文字集合"
+
+#: ../src/common/fontmap.cpp:199
+#, c-format
+msgid ""
+"The charset '%s' is unknown. You may select\n"
+"another charset to replace it with or choose\n"
+"[Cancel] if it cannot be replaced"
+msgstr ""
+"文字集合 '%s' は未知です。\n"
+"他の文字集合で置き換えるか、\n"
+"キャンセルしてください"
+
+#: ../src/common/fontmap.cpp:241
+#, c-format
+msgid "Failed to remember the encoding for the charset '%s'."
+msgstr "文字集合 '%s' に対するエンコーディングの記録に失敗しました。"
+
+#: ../src/common/fontmap.cpp:321
+msgid "can't load any font, aborting"
+msgstr "フォントが一切読み取れません、中止します"
+
+#: ../src/common/fontmap.cpp:409
+msgid ": unknown encoding"
+msgstr ": 未知のエンコーディング"
+
+#: ../src/common/fontmap.cpp:417
+#, c-format
+msgid ""
+"No font for displaying text in encoding '%s' found,\n"
+"but an alternative encoding '%s' is available.\n"
+"Do you want to use this encoding (otherwise you will have to choose another "
+"one)?"
+msgstr ""
+"エンコーディング '%s' のテキストを表示するフォントは見つかりませんが、\n"
+"代替のエンコーディング '%s' は利用可能です。\n"
+"このエンコーディングを使いますか? (使わない場合、他のエンコーディングを選ぶ必"
+"要があります)"
+
+#: ../src/common/fontmap.cpp:422
+#, c-format
+msgid ""
+"No font for displaying text in encoding '%s' found.\n"
+"Would you like to select a font to be used for this encoding\n"
+"(otherwise the text in this encoding will not be shown correctly)?"
+msgstr ""
+"エンコーディング '%s' のテキストを表示するフォントが見つかりません。\n"
+"このエンコーディングに使うフォントを選択しますか?\n"
+"(選択しない場合、このエンコーディングのテキストは正しく表示されません)"
+
+#: ../src/common/fs_mem.cpp:169
+#, c-format
+msgid "Memory VFS already contains file '%s'!"
+msgstr "メモリVFSにはファイル '%s' がすでにあります。"
+
+#: ../src/common/fs_mem.cpp:232
+#, c-format
+msgid "Trying to remove file '%s' from memory VFS, but it is not loaded!"
+msgstr "メモリVFSにまだ読み込まれていない '%s' の削除を要求されました。"
+
+#: ../src/common/fs_mem.cpp:262
+#, c-format
+msgid "Failed to store image '%s' to memory VFS!"
+msgstr "メモリVFS にイメージ '%s' を保存できませんでした。"
+
+#: ../src/common/ftp.cpp:197
+msgid "Timeout while waiting for FTP server to connect, try passive mode."
+msgstr ""
+"FTPサーバーとの接続待機中にタイムアウトしました。パッシブモードで試してみてく"
+"ださい。"
+
+#: ../src/common/ftp.cpp:399
+#, c-format
+msgid "Failed to set FTP transfer mode to %s."
+msgstr "FTP転送モードを %s に変更できませんでした。"
+
+#: ../src/common/ftp.cpp:400 ../src/richtext/richtextsymboldlg.cpp:432
+msgid "ASCII"
+msgstr "ASCII"
+
+#: ../src/common/ftp.cpp:400
+msgid "binary"
+msgstr "バイナリ"
+
+#: ../src/common/ftp.cpp:608
+msgid "The FTP server doesn't support the PORT command."
+msgstr "FTPサーバーはPORTコマンドに対応していません。"
+
+#: ../src/common/ftp.cpp:622
+msgid "The FTP server doesn't support passive mode."
+msgstr "FTPサーバーはパッシブモードに対応していません。"
+
+#: ../src/common/gifdecod.cpp:822
+#, c-format
+msgid "Incorrect GIF frame size (%u, %d) for the frame #%u"
+msgstr "GIF フレームの大きさ (%u, %d) が不適切です (フレーム #%u)"
+
+#: ../src/common/glcmn.cpp:108
+msgid "Failed to allocate colour for OpenGL"
+msgstr "OpenGL に色を割り当てることができませんでした"
+
+#: ../src/common/headerctrlcmn.cpp:57
+msgid "Please select the columns to show and define their order:"
+msgstr "表示する列とその順番を選んでください:"
+
+#: ../src/common/headerctrlcmn.cpp:58
+msgid "Customize Columns"
+msgstr "列のカスタマイズ"
+
+#: ../src/common/headerctrlcmn.cpp:304
+msgid "&Customize..."
+msgstr "カスタマイズ(&C)..."
+
+#: ../src/common/hyperlnkcmn.cpp:132
+#, c-format
+msgid "Failed to open URL \"%s\" in the default browser"
+msgstr "デフォルトブラウザでURL \"%s\" を開けませんでした"
+
+#: ../src/common/iconbndl.cpp:195
+#, c-format
+msgid "Failed to load image %%d from file '%s'."
+msgstr "画像 %%d をファイル '%s' から読み取れませんでした。"
+
+#: ../src/common/iconbndl.cpp:203
+#, c-format
+msgid "Failed to load image %d from stream."
+msgstr "画像 %d をストリームから読み取れませんでした。"
+
+#: ../src/common/iconbndl.cpp:221
+#, c-format
+msgid "Failed to load icons from resource '%s'."
+msgstr "アイコンをリソース '%s' から読み取れませんでした。"
+
+#: ../src/common/imagbmp.cpp:97
+msgid "BMP: Couldn't save invalid image."
+msgstr "BMP: 不正な画像を保存できませんでした。"
+
+#: ../src/common/imagbmp.cpp:137
+msgid "BMP: wxImage doesn't have own wxPalette."
+msgstr "BMP: wxImage は自身の wxPalette を保有していません。"
+
+#: ../src/common/imagbmp.cpp:243
+msgid "BMP: Couldn't write the file (Bitmap) header."
+msgstr "BMP: ファイル (Bitmap) ヘッダの書き出しに失敗しました。"
+
+#: ../src/common/imagbmp.cpp:266
+msgid "BMP: Couldn't write the file (BitmapInfo) header."
+msgstr "BMP: ファイル (BitmapInfo) ヘッダの書き出しに失敗しました。"
+
+#: ../src/common/imagbmp.cpp:353
+msgid "BMP: Couldn't write RGB color map."
+msgstr "BMP: RGB色索引を書き出せませんでした。"
+
+#: ../src/common/imagbmp.cpp:487
+msgid "BMP: Couldn't write data."
+msgstr "BMP: データを書き出せませんでした。"
+
+#: ../src/common/imagbmp.cpp:561 ../src/common/imagbmp.cpp:642
+msgid "BMP: Couldn't allocate memory."
+msgstr "BMP: メモリ割り当てに失敗しました。"
+
+#: ../src/common/imagbmp.cpp:1041
+msgid "DIB Header: Image width > 32767 pixels for file."
+msgstr "DIB ヘッダー: 画像の幅が32767ピクセルを超えています。"
+
+#: ../src/common/imagbmp.cpp:1049
+msgid "DIB Header: Image height > 32767 pixels for file."
+msgstr "DIB ヘッダー: 画像の高さが32767ピクセルを超えています。"
+
+#: ../src/common/imagbmp.cpp:1081
+msgid "DIB Header: Unknown bitdepth in file."
+msgstr "DIB ヘッダー: 未知のビット深度がファイルに含まれています。"
+
+#: ../src/common/imagbmp.cpp:1156
+msgid "DIB Header: Unknown encoding in file."
+msgstr "DIB ヘッダー: 未知のエンコーディングがファイルに含まれています。"
+
+#: ../src/common/imagbmp.cpp:1165
+msgid "DIB Header: Encoding doesn't match bitdepth."
+msgstr "DIB ヘッダー: エンコーディングがビット深度に一致しません。"
+
+#: ../src/common/imagbmp.cpp:1180
+#, c-format
+msgid "BMP Header: Invalid number of colors (%d)."
+msgstr ""
+
+#: ../src/common/imagbmp.cpp:1273
+msgid "Error in reading image DIB."
+msgstr "画像のDIB読み取り中にエラーが発生しました。"
+
+#: ../src/common/imagbmp.cpp:1294
+msgid "ICO: Error in reading mask DIB."
+msgstr "ICO: マスクDIBの読み取り中にエラーが発生しました。"
+
+#: ../src/common/imagbmp.cpp:1353
+msgid "ICO: Image too tall for an icon."
+msgstr "ICO: 縦に長すぎます。アイコンに変換できません。"
+
+#: ../src/common/imagbmp.cpp:1361
+msgid "ICO: Image too wide for an icon."
+msgstr "ICO: 幅が大きすぎます。アイコンに変換できません。"
+
+#: ../src/common/imagbmp.cpp:1388 ../src/common/imagbmp.cpp:1488
+#: ../src/common/imagbmp.cpp:1503 ../src/common/imagbmp.cpp:1514
+#: ../src/common/imagbmp.cpp:1528 ../src/common/imagbmp.cpp:1576
+#: ../src/common/imagbmp.cpp:1591 ../src/common/imagbmp.cpp:1605
+#: ../src/common/imagbmp.cpp:1616
+msgid "ICO: Error writing the image file!"
+msgstr "ICO: 画像ファイルの書き出し中にエラーが発生しました。"
+
+#: ../src/common/imagbmp.cpp:1701
+msgid "ICO: Invalid icon index."
+msgstr "ICO: アイコンの索引が不正です。"
+
+#: ../src/common/image.cpp:2410
+msgid "Image and mask have different sizes."
+msgstr "画像とマスクが異なる大きさになっています。"
+
+#: ../src/common/image.cpp:2418 ../src/common/image.cpp:2459
+msgid "No unused colour in image being masked."
+msgstr "マスクされるべき未使用色が画像にありません。"
+
+#: ../src/common/image.cpp:2641
+#, c-format
+msgid "Failed to load bitmap \"%s\" from resources."
+msgstr "リソースからビットマップ \"%s\" を読み取れませんでした。"
+
+#: ../src/common/image.cpp:2650
+#, c-format
+msgid "Failed to load icon \"%s\" from resources."
+msgstr "アイコン \"%s\" をリソースから読み取れませんでした。"
+
+#: ../src/common/image.cpp:2728 ../src/common/image.cpp:2747
+#, c-format
+msgid "Failed to load image from file \"%s\"."
+msgstr "ファイル \"%s\" から画像を読み取れませんでした。"
+
+#: ../src/common/image.cpp:2761
+#, c-format
+msgid "Can't save image to file '%s': unknown extension."
+msgstr "ファイル '%s' に画像を保存できません: 未対応の拡張子です。"
+
+#: ../src/common/image.cpp:2869
+msgid "No handler found for image type."
+msgstr "画像形式に対応するハンドラーが見つかりません。"
+
+#: ../src/common/image.cpp:2877 ../src/common/image.cpp:3000
+#: ../src/common/image.cpp:3066
+#, c-format
+msgid "No image handler for type %d defined."
+msgstr "形式 %d のイメージハンドラーが定義されていません。"
+
+#: ../src/common/image.cpp:2887
+#, c-format
+msgid "Image file is not of type %d."
+msgstr "画像ファイルは形式 %d ではありません。"
+
+#: ../src/common/image.cpp:2970
+msgid "Can't automatically determine the image format for non-seekable input."
+msgstr "シーク不可能な入力に対して画像形式を自動的に判断できません。"
+
+#: ../src/common/image.cpp:2988
+msgid "Unknown image data format."
+msgstr "不明な画像データ形式です。"
+
+#: ../src/common/image.cpp:3009
+#, c-format
+msgid "This is not a %s."
+msgstr "これは %s ではありません。"
+
+#: ../src/common/image.cpp:3032 ../src/common/image.cpp:3080
+#, c-format
+msgid "No image handler for type %s defined."
+msgstr "形式 %s の画像ハンドラーが定義されていません。"
+
+#: ../src/common/image.cpp:3041
+#, c-format
+msgid "Image is not of type %s."
+msgstr "画像は形式 %s ではありません。"
+
+#: ../src/common/image.cpp:3509
+#, c-format
+msgid "Failed to check format of image file \"%s\"."
+msgstr "画像ファイル \"%s\" の形式を確認できませんでした。"
+
+#: ../src/common/imaggif.cpp:124
+msgid "GIF: error in GIF image format."
+msgstr "GIF: GIF画像形式にエラーがありました。"
+
+#: ../src/common/imaggif.cpp:129
+msgid "GIF: not enough memory."
+msgstr "GIF: メモリ不足です。"
+
+#: ../src/common/imaggif.cpp:134
+msgid "GIF: data stream seems to be truncated."
+msgstr "GIF: データストリームに欠落があるようです。"
+
+#: ../src/common/imaggif.cpp:240
+msgid "Couldn't initialize GIF hash table."
+msgstr "GIFハッシュテーブルを初期化できません。"
+
+#: ../src/common/imagiff.cpp:739
+msgid "IFF: error in IFF image format."
+msgstr "IFF: IFF画像形式にエラーがありました。"
+
+#: ../src/common/imagiff.cpp:742
+msgid "IFF: not enough memory."
+msgstr "IFF: メモリ不足です。"
+
+#: ../src/common/imagiff.cpp:745
+msgid "IFF: unknown error!!!"
+msgstr "IFF: 未対応のエラーが発生しました。"
+
+#: ../src/common/imagiff.cpp:755
+msgid "IFF: data stream seems to be truncated."
+msgstr "IFF: データストリームに欠落があるようです。"
+
+#: ../src/common/imagjpeg.cpp:258
+msgid "JPEG: Couldn't load - file is probably corrupted."
+msgstr "JPEG: 読み取れません。ファイルが壊れている可能性があります。"
+
+#: ../src/common/imagjpeg.cpp:437
+msgid "JPEG: Couldn't save image."
+msgstr "JPEG: 画像を保存できません。"
+
+#: ../src/common/imagpcx.cpp:439
+msgid "PCX: this is not a PCX file."
+msgstr "PCX: PCXファイルではないようです。"
+
+#: ../src/common/imagpcx.cpp:453
+msgid "PCX: image format unsupported"
+msgstr "PCX: 画像形式は未対応です"
+
+#: ../src/common/imagpcx.cpp:454 ../src/common/imagpcx.cpp:477
+msgid "PCX: couldn't allocate memory"
+msgstr "PCX: メモリを割り当てることができません"
+
+#: ../src/common/imagpcx.cpp:455
+msgid "PCX: version number too low"
+msgstr "PCX: バージョン番号が低すぎるようです。"
+
+#: ../src/common/imagpcx.cpp:456 ../src/common/imagpcx.cpp:478
+msgid "PCX: unknown error !!!"
+msgstr "PCX: 未対応のエラーが発生しました。"
+
+#: ../src/common/imagpcx.cpp:476
+msgid "PCX: invalid image"
+msgstr "PCX: 不正な画像です"
+
+#: ../src/common/imagpng.cpp:385
+#, c-format
+msgid "Unknown PNG resolution unit %d"
+msgstr "未知のPNG解像度単位 %d"
+
+#: ../src/common/imagpng.cpp:439
+msgid "Couldn't load a PNG image - file is corrupted or not enough memory."
+msgstr "PNG画像を読み取れませんでした。ファイルが壊れているかメモリ不足です。"
+
+#: ../src/common/imagpng.cpp:513 ../src/common/imagpng.cpp:524
+#: ../src/common/imagpng.cpp:534
+msgid "Couldn't save PNG image."
+msgstr "PNG画像を保存できませんでした。"
+
+#: ../src/common/imagpnm.cpp:71
+msgid "PNM: File format is not recognized."
+msgstr "PNM: ファイル形式を認識できません。"
+
+#: ../src/common/imagpnm.cpp:89
+msgid "PNM: Couldn't allocate memory."
+msgstr "PNM: メモリを割り当てることができません。"
+
+#: ../src/common/imagpnm.cpp:111 ../src/common/imagpnm.cpp:134
+#: ../src/common/imagpnm.cpp:156
+msgid "PNM: File seems truncated."
+msgstr "PNM: ファイルに欠落があるようです。"
+
+#: ../src/common/imagtiff.cpp:69
+#, c-format
+msgid " (in module \"%s\")"
+msgstr " (モジュール \"%s\")"
+
+#: ../src/common/imagtiff.cpp:304
+msgid "TIFF: Error loading image."
+msgstr "TIFF: 画像の読み取りエラーが発生しました。"
+
+#: ../src/common/imagtiff.cpp:314
+msgid "Invalid TIFF image index."
+msgstr "TIFF 画像索引が不正です。"
+
+#: ../src/common/imagtiff.cpp:358
+msgid "TIFF: Image size is abnormally big."
+msgstr "TIFF: 画像の大きさが極端に大きいようです。"
+
+#: ../src/common/imagtiff.cpp:372 ../src/common/imagtiff.cpp:385
+#: ../src/common/imagtiff.cpp:769
+msgid "TIFF: Couldn't allocate memory."
+msgstr "TIFF: メモリ割り当てに失敗しました。"
+
+#: ../src/common/imagtiff.cpp:471
+msgid "TIFF: Error reading image."
+msgstr "TIFF: 画像の読み取りエラーが発生しました。"
+
+#: ../src/common/imagtiff.cpp:532
+#, c-format
+msgid "Unknown TIFF resolution unit %d ignored"
+msgstr "未知のTIFF解像度単位 %d を無視しました"
+
+#: ../src/common/imagtiff.cpp:611
+msgid "TIFF: Error saving image."
+msgstr "TIFF: 画像の保存エラーが発生しました。"
+
+#: ../src/common/imagtiff.cpp:868
+msgid "TIFF: Error writing image."
+msgstr "TIFF: 画像の書き出しエラーが発生しました。"
+
+#: ../src/common/imagtiff.cpp:881
+#, fuzzy
+msgid "TIFF: Error flushing data."
+msgstr "TIFF: 画像の保存エラーが発生しました。"
+
+#: ../src/common/imagwebp.cpp:56
+msgid "WebP: Invalid data (failed to get features)."
+msgstr ""
+
+#: ../src/common/imagwebp.cpp:65
+msgid "WebP: Allocating image memory failed."
+msgstr ""
+
+#: ../src/common/imagwebp.cpp:82
+msgid "WebP: Decoding RGBA image data failed."
+msgstr ""
+
+#: ../src/common/imagwebp.cpp:98
+msgid "WebP: Decoding RGB image data failed."
+msgstr ""
+
+#: ../src/common/imagwebp.cpp:113 ../src/common/imagwebp.cpp:201
+msgid "WebP: Allocating stream buffer failed."
+msgstr ""
+
+#: ../src/common/imagwebp.cpp:131
+#, fuzzy
+msgid "WebP: Failed to parse container data."
+msgstr "クリップボードデータを設定できませんでした。"
+
+#: ../src/common/imagwebp.cpp:222
+#, fuzzy
+msgid "WebP: Error decoding animation."
+msgstr "設定オプションの読み取り中にエラーが発生しました。"
+
+#: ../src/common/imagwebp.cpp:240
+msgid "WebP: Error getting next animation frame."
+msgstr ""
+
+#: ../src/common/init.cpp:172
+#, c-format
+msgid ""
+"Command line argument %d couldn't be converted to Unicode and will be "
+"ignored."
+msgstr "コマンドライン引数 %d はUnicodeに変換できません。無視されます。"
+
+#: ../src/common/init.cpp:344
+msgid "Initialization failed in post init, aborting."
+msgstr "PostInit での初期化に失敗しました。中断します。"
+
+#: ../src/common/intl.cpp:378
+#, c-format
+msgid "Cannot set locale to language \"%s\"."
+msgstr "ロケールを言語 \"%s\" に設定できません。"
+
+#: ../src/common/log.cpp:232
+msgid "Error: "
+msgstr "エラー: "
+
+#: ../src/common/log.cpp:236
+msgid "Warning: "
+msgstr "警告: "
+
+#: ../src/common/log.cpp:284
+msgid "The previous message repeated once."
+msgstr "直前のメッセージは 1 回繰り返されました。"
+
+#: ../src/common/log.cpp:291
+#, c-format
+msgid "The previous message repeated %u time."
+msgid_plural "The previous message repeated %u times."
+msgstr[0] "直前のメッセージは %u 回繰り返されました。"
+
+#: ../src/common/log.cpp:319
+#, c-format
+msgid "Last repeated message (\"%s\", %u time) wasn't output"
+msgid_plural "Last repeated message (\"%s\", %u times) wasn't output"
+msgstr[0] "最後に繰り返されたメッセージ (\"%s\", %u 回) は出力ではありません"
+
+#: ../src/common/log.cpp:435
+#, c-format
+msgid " (error %ld: %s)"
+msgstr " (エラー %ld: %s)"
+
+#: ../src/common/lzmastream.cpp:121
+msgid "Failed to allocate memory for LZMA decompression."
+msgstr "LZMA展開にメモリを割り当てることができませんでした。"
+
+#: ../src/common/lzmastream.cpp:125
+#, c-format
+msgid "Failed to initialize LZMA decompression: unexpected error %u."
+msgstr "LZMA展開を初期化できませんでした: 想定外のエラー %u が発生しました。"
+
+#: ../src/common/lzmastream.cpp:179
+msgid "input is not in XZ format"
+msgstr "入力はXZ形式ではありません"
+
+#: ../src/common/lzmastream.cpp:183
+msgid "input compressed using unknown XZ option"
+msgstr "未知のXZオプションを使用して圧縮されました"
+
+#: ../src/common/lzmastream.cpp:188
+msgid "input is corrupted"
+msgstr "入力は壊れています"
+
+#: ../src/common/lzmastream.cpp:192
+msgid "unknown decompression error"
+msgstr "未知の展開エラー"
+
+#: ../src/common/lzmastream.cpp:196
+#, c-format
+msgid "LZMA decompression error: %s"
+msgstr "LZMA展開エラー: %s"
+
+#: ../src/common/lzmastream.cpp:231
+msgid "Failed to allocate memory for LZMA compression."
+msgstr "LZMA圧縮にメモリを割り当てることができませんでした。"
+
+#: ../src/common/lzmastream.cpp:235
+#, c-format
+msgid "Failed to initialize LZMA compression: unexpected error %u."
+msgstr "LZMA圧縮を初期化できませんでした: 想定外のエラー %u が発生しました。"
+
+#: ../src/common/lzmastream.cpp:267 ../src/common/lzmastream.cpp:342
+#: ../src/html/chm.cpp:336
+msgid "out of memory"
+msgstr "メモリ不足"
+
+#: ../src/common/lzmastream.cpp:276 ../src/common/lzmastream.cpp:346
+msgid "unknown compression error"
+msgstr "未知の圧縮エラー"
+
+#: ../src/common/lzmastream.cpp:280
+#, c-format
+msgid "LZMA compression error: %s"
+msgstr "LZMA圧縮エラー: %s"
+
+#: ../src/common/lzmastream.cpp:350
+#, c-format
+msgid "LZMA compression error when flushing output: %s"
+msgstr "出力のフラッシュ中にLZMA圧縮エラーが発生しました: %s"
+
+#: ../src/common/mimecmn.cpp:167
+#, c-format
+msgid "Unmatched '{' in an entry for mime type %s."
+msgstr "MIME型 %s の項目に閉じていない '{' がありました。"
+
+#: ../src/common/module.cpp:76
+#, c-format
+msgid "Circular dependency involving module \"%s\" detected."
+msgstr "モジュール \"%s\" の解決を試みているときに循環参照を検出しました。"
+
+#: ../src/common/module.cpp:128
+#, c-format
+msgid "Dependency \"%s\" of module \"%s\" doesn't exist."
+msgstr "依存先の \"%s\" (モジュール \"%s\" 内) は存在しません。"
+
+#: ../src/common/module.cpp:137
+#, c-format
+msgid "Module \"%s\" initialization failed"
+msgstr "モジュール \"%s\" の初期化に失敗しました"
+
+#: ../src/common/msgout.cpp:96
+msgid "Message"
+msgstr "メッセージ"
+
+#: ../src/common/paper.cpp:70
+msgid "Letter, 8 1/2 x 11 in"
+msgstr "レター, 8 1/2 x 11インチ"
+
+#: ../src/common/paper.cpp:71
+msgid "Legal, 8 1/2 x 14 in"
+msgstr "リーガル, 8 1/2 x 14インチ"
+
+#: ../src/common/paper.cpp:72
+msgid "A4 sheet, 210 x 297 mm"
+msgstr "A4 シート, 210 x 297 mm"
+
+#: ../src/common/paper.cpp:73
+msgid "C sheet, 17 x 22 in"
+msgstr "Cサイズシート, 17 x 22インチ"
+
+#: ../src/common/paper.cpp:74
+msgid "D sheet, 22 x 34 in"
+msgstr "Dサイズシート, 22 x 34インチ"
+
+#: ../src/common/paper.cpp:75
+msgid "E sheet, 34 x 44 in"
+msgstr "Eサイズシート, 34 x 44インチ"
+
+#: ../src/common/paper.cpp:76
+msgid "Letter Small, 8 1/2 x 11 in"
+msgstr "レター Small, 8 1/2 x 11インチ"
+
+#: ../src/common/paper.cpp:77
+msgid "Tabloid, 11 x 17 in"
+msgstr "タブロイド, 11 x 17インチ"
+
+#: ../src/common/paper.cpp:78
+msgid "Ledger, 17 x 11 in"
+msgstr "Ledger(帳簿), 17 x 11インチ"
+
+#: ../src/common/paper.cpp:79
+msgid "Statement, 5 1/2 x 8 1/2 in"
+msgstr "ステートメント(計算書), 5 1/2 x 8 1/2インチ"
+
+#: ../src/common/paper.cpp:80
+msgid "Executive, 7 1/4 x 10 1/2 in"
+msgstr "エグゼクティブ, 7 1/4 x 10 1/2インチ"
+
+#: ../src/common/paper.cpp:81
+msgid "A3 sheet, 297 x 420 mm"
+msgstr "A3 シート, 297 x 420 mm"
+
+#: ../src/common/paper.cpp:82
+msgid "A4 small sheet, 210 x 297 mm"
+msgstr "A4 small sheet, 210 x 297 mm"
+
+#: ../src/common/paper.cpp:83
+msgid "A5 sheet, 148 x 210 mm"
+msgstr "A5 シート, 148 x 210 mm"
+
+#: ../src/common/paper.cpp:84
+msgid "B4 sheet, 250 x 354 mm"
+msgstr "B4 シート, 250 x 354 mm"
+
+#: ../src/common/paper.cpp:85
+msgid "B5 sheet, 182 x 257 millimeter"
+msgstr "B5 シート, 182 x 257 mm"
+
+#: ../src/common/paper.cpp:86
+msgid "Folio, 8 1/2 x 13 in"
+msgstr "フォリオ, 8 1/2 x 13インチ"
+
+#: ../src/common/paper.cpp:87
+msgid "Quarto, 215 x 275 mm"
+msgstr "クォート(四つ折り版), 215 x 275 mm"
+
+#: ../src/common/paper.cpp:88
+msgid "10 x 14 in"
+msgstr "10×14インチ"
+
+#: ../src/common/paper.cpp:89
+msgid "11 x 17 in"
+msgstr "11×17インチ"
+
+#: ../src/common/paper.cpp:90
+msgid "Note, 8 1/2 x 11 in"
+msgstr "ノート, 8 1/2×11インチ"
+
+#: ../src/common/paper.cpp:91
+msgid "#9 Envelope, 3 7/8 x 8 7/8 in"
+msgstr "#9 封筒, 3 7/8 x 8 7/8 インチ"
+
+#: ../src/common/paper.cpp:92
+msgid "#10 Envelope, 4 1/8 x 9 1/2 in"
+msgstr "#10 封筒, 4 1/8 x 9 1/2 インチ"
+
+#: ../src/common/paper.cpp:93
+msgid "#11 Envelope, 4 1/2 x 10 3/8 in"
+msgstr "#11 封筒, 4 1/2 x 10 3/8 インチ"
+
+#: ../src/common/paper.cpp:94
+msgid "#12 Envelope, 4 3/4 x 11 in"
+msgstr "#12 封筒, 4 3/4 x 11 インチ"
+
+#: ../src/common/paper.cpp:95
+msgid "#14 Envelope, 5 x 11 1/2 in"
+msgstr "#14 封筒, 5 x 11 1/2 インチ"
+
+#: ../src/common/paper.cpp:96
+msgid "DL Envelope, 110 x 220 mm"
+msgstr "DL 封筒, 110×220mm"
+
+#: ../src/common/paper.cpp:97
+msgid "C5 Envelope, 162 x 229 mm"
+msgstr "C5 封筒, 162×229mm"
+
+#: ../src/common/paper.cpp:98
+msgid "C3 Envelope, 324 x 458 mm"
+msgstr "C3 封筒, 324×458mm"
+
+#: ../src/common/paper.cpp:99
+msgid "C4 Envelope, 229 x 324 mm"
+msgstr "C4 封筒, 229×324mm"
+
+#: ../src/common/paper.cpp:100
+msgid "C6 Envelope, 114 x 162 mm"
+msgstr "C6 封筒, 114 x 162 mm"
+
+#: ../src/common/paper.cpp:101
+msgid "C65 Envelope, 114 x 229 mm"
+msgstr "C65 封筒, 114×229mm"
+
+#: ../src/common/paper.cpp:102
+msgid "B4 Envelope, 250 x 353 mm"
+msgstr "B4 封筒, 250 x 353 mm"
+
+#: ../src/common/paper.cpp:103
+msgid "B5 Envelope, 176 x 250 mm"
+msgstr "B5 封筒, 176 x 250 mm"
+
+#: ../src/common/paper.cpp:104
+msgid "B6 Envelope, 176 x 125 mm"
+msgstr "B6 封筒, 176 x 125 mm"
+
+#: ../src/common/paper.cpp:105
+msgid "Italy Envelope, 110 x 230 mm"
+msgstr "イタリア封筒, 110 x 230mm"
+
+#: ../src/common/paper.cpp:106
+msgid "Monarch Envelope, 3 7/8 x 7 1/2 in"
+msgstr "Monarch 封筒, 3 7/8 x 7 1/2インチ"
+
+#: ../src/common/paper.cpp:107
+msgid "6 3/4 Envelope, 3 5/8 x 6 1/2 in"
+msgstr "6 3/4 封筒, 3 5/8 × 6 1/2インチ"
+
+#: ../src/common/paper.cpp:108
+msgid "US Std Fanfold, 14 7/8 x 11 in"
+msgstr "米国標準折りたたみ連続紙, 14 7/8 x 11インチ"
+
+#: ../src/common/paper.cpp:109
+msgid "German Std Fanfold, 8 1/2 x 12 in"
+msgstr "ドイツ標準折りたたみ連続紙, 8 1/2 x 12インチ"
+
+#: ../src/common/paper.cpp:110
+msgid "German Legal Fanfold, 8 1/2 x 13 in"
+msgstr "ドイツリーガル折りたたみ連続紙, 8 1/2 x 13インチ"
+
+#: ../src/common/paper.cpp:112
+msgid "B4 (ISO) 250 x 353 mm"
+msgstr "B4 (ISO) 250 x 353 mm"
+
+#: ../src/common/paper.cpp:113
+msgid "Japanese Postcard 100 x 148 mm"
+msgstr "はがき 100×148mm"
+
+#: ../src/common/paper.cpp:114
+msgid "9 x 11 in"
+msgstr "9×11インチ"
+
+#: ../src/common/paper.cpp:115
+msgid "10 x 11 in"
+msgstr "10×11インチ"
+
+#: ../src/common/paper.cpp:116
+msgid "15 x 11 in"
+msgstr "15×11インチ"
+
+#: ../src/common/paper.cpp:117
+msgid "Envelope Invite 220 x 220 mm"
+msgstr "封筒 Invite 220 x 220 mm"
+
+#: ../src/common/paper.cpp:118
+msgid "Letter Extra 9 1/2 x 12 in"
+msgstr "レター Extra 9 1/2 x 12インチ"
+
+#: ../src/common/paper.cpp:119
+msgid "Legal Extra 9 1/2 x 15 in"
+msgstr "リーガル Extra 9 1/2 x 15インチ"
+
+#: ../src/common/paper.cpp:120
+msgid "Tabloid Extra 11.69 x 18 in"
+msgstr "タブロイド Extra 11.69 x 18インチ"
+
+#: ../src/common/paper.cpp:121
+msgid "A4 Extra 9.27 x 12.69 in"
+msgstr "A4 Extra 9.27 x 12.69インチ"
+
+#: ../src/common/paper.cpp:122
+msgid "Letter Transverse 8 1/2 x 11 in"
+msgstr "レター Transverse 8 1/2 x 11インチ"
+
+#: ../src/common/paper.cpp:123
+msgid "A4 Transverse 210 x 297 mm"
+msgstr "A4 Transverse 210 x 297 mm"
+
+#: ../src/common/paper.cpp:124
+msgid "Letter Extra Transverse 9.275 x 12 in"
+msgstr "レター Extra Transverse 9.275 x 12 インチ"
+
+#: ../src/common/paper.cpp:125
+msgid "SuperA/SuperA/A4 227 x 356 mm"
+msgstr "SuperA/SuperA/A4 227 x 356 mm"
+
+#: ../src/common/paper.cpp:126
+msgid "SuperB/SuperB/A3 305 x 487 mm"
+msgstr "SuperB/SuperB/A3 305 x 487 mm"
+
+#: ../src/common/paper.cpp:127
+msgid "Letter Plus 8 1/2 x 12.69 in"
+msgstr "レター Plus 8 1/2 x 12.69インチ"
+
+#: ../src/common/paper.cpp:128
+msgid "A4 Plus 210 x 330 mm"
+msgstr "A4 Plus 210 x 330 mm"
+
+#: ../src/common/paper.cpp:129
+msgid "A5 Transverse 148 x 210 mm"
+msgstr "A5 Transverse 148 x 210 mm"
+
+#: ../src/common/paper.cpp:130
+msgid "B5 (JIS) Transverse 182 x 257 mm"
+msgstr "B5 (JIS) Transverse 182 x 257 mm"
+
+#: ../src/common/paper.cpp:131
+msgid "A3 Extra 322 x 445 mm"
+msgstr "A3 Extra 322 x 445 mm"
+
+#: ../src/common/paper.cpp:132
+msgid "A5 Extra 174 x 235 mm"
+msgstr "A5 Extra 174 x 235 mm"
+
+#: ../src/common/paper.cpp:133
+msgid "B5 (ISO) Extra 201 x 276 mm"
+msgstr "B5 (ISO) Extra 201 x 276 mm"
+
+#: ../src/common/paper.cpp:134
+msgid "A2 420 x 594 mm"
+msgstr "A2 420×594 mm"
+
+#: ../src/common/paper.cpp:135
+msgid "A3 Transverse 297 x 420 mm"
+msgstr "A3 Transverse 297 x 420 mm"
+
+#: ../src/common/paper.cpp:136
+msgid "A3 Extra Transverse 322 x 445 mm"
+msgstr "A3 Extra Transverse 322 x 445 mm"
+
+#: ../src/common/paper.cpp:138
+msgid "Japanese Double Postcard 200 x 148 mm"
+msgstr "往復はがき 200×148mm"
+
+#: ../src/common/paper.cpp:139
+msgid "A6 105 x 148 mm"
+msgstr "A6 105×148mm"
+
+#: ../src/common/paper.cpp:140
+msgid "Japanese Envelope Kaku #2"
+msgstr "角形2号"
+
+#: ../src/common/paper.cpp:141
+msgid "Japanese Envelope Kaku #3"
+msgstr "角形3号"
+
+#: ../src/common/paper.cpp:142
+msgid "Japanese Envelope Chou #3"
+msgstr "長形3号"
+
+#: ../src/common/paper.cpp:143
+msgid "Japanese Envelope Chou #4"
+msgstr "長形4号"
+
+#: ../src/common/paper.cpp:144
+msgid "Letter Rotated 11 x 8 1/2 in"
+msgstr "レター 横置き 11 x 8 1/2インチ"
+
+#: ../src/common/paper.cpp:145
+msgid "A3 Rotated 420 x 297 mm"
+msgstr "A3横置き 420×297mm"
+
+#: ../src/common/paper.cpp:146
+msgid "A4 Rotated 297 x 210 mm"
+msgstr "A4横置き 297×210mm"
+
+#: ../src/common/paper.cpp:147
+msgid "A5 Rotated 210 x 148 mm"
+msgstr "A5横置き 210×148mm"
+
+#: ../src/common/paper.cpp:148
+msgid "B4 (JIS) Rotated 364 x 257 mm"
+msgstr "B4 (JIS) 横置き 364×257mm"
+
+#: ../src/common/paper.cpp:149
+msgid "B5 (JIS) Rotated 257 x 182 mm"
+msgstr "B5 (JIS) 横置き 257×182mm"
+
+#: ../src/common/paper.cpp:150
+msgid "Japanese Postcard Rotated 148 x 100 mm"
+msgstr "はがき横置き 148×100mm"
+
+#: ../src/common/paper.cpp:151
+msgid "Double Japanese Postcard Rotated 148 x 200 mm"
+msgstr "往復はがき横置き 148×200mm"
+
+#: ../src/common/paper.cpp:152
+msgid "A6 Rotated 148 x 105 mm"
+msgstr "A6横置き 148×105mm"
+
+#: ../src/common/paper.cpp:153
+msgid "Japanese Envelope Kaku #2 Rotated"
+msgstr "角形2号横置き"
+
+#: ../src/common/paper.cpp:154
+msgid "Japanese Envelope Kaku #3 Rotated"
+msgstr "角形3号横置き"
+
+#: ../src/common/paper.cpp:155
+msgid "Japanese Envelope Chou #3 Rotated"
+msgstr "長形3号横置き"
+
+#: ../src/common/paper.cpp:156
+msgid "Japanese Envelope Chou #4 Rotated"
+msgstr "長形4号横置き"
+
+#: ../src/common/paper.cpp:157
+msgid "B6 (JIS) 128 x 182 mm"
+msgstr "B6 (JIS) 128×182 mm"
+
+#: ../src/common/paper.cpp:158
+msgid "B6 (JIS) Rotated 182 x 128 mm"
+msgstr "B6 (JIS) 横置き 182×128mm"
+
+#: ../src/common/paper.cpp:159
+msgid "12 x 11 in"
+msgstr "12×11インチ"
+
+#: ../src/common/paper.cpp:160
+msgid "Japanese Envelope You #4"
+msgstr "洋形4号"
+
+#: ../src/common/paper.cpp:161
+msgid "Japanese Envelope You #4 Rotated"
+msgstr "洋形4号横置き"
+
+#: ../src/common/paper.cpp:162
+msgid "PRC 16K 146 x 215 mm"
+msgstr "中国 16K 146 x 215 mm"
+
+#: ../src/common/paper.cpp:163
+msgid "PRC 32K 97 x 151 mm"
+msgstr "中国 32K 97 x 151 mm"
+
+#: ../src/common/paper.cpp:164
+msgid "PRC 32K(Big) 97 x 151 mm"
+msgstr "中国 32K(Big) 97 x 151 mm"
+
+#: ../src/common/paper.cpp:165
+msgid "PRC Envelope #1 102 x 165 mm"
+msgstr "中国封筒 #1 102 x 165 mm"
+
+#: ../src/common/paper.cpp:166
+msgid "PRC Envelope #2 102 x 176 mm"
+msgstr "中国封筒 #2 102 x 176 mm"
+
+#: ../src/common/paper.cpp:167
+msgid "PRC Envelope #3 125 x 176 mm"
+msgstr "中国封筒 #3 125 x 176 mm"
+
+#: ../src/common/paper.cpp:168
+msgid "PRC Envelope #4 110 x 208 mm"
+msgstr "中国封筒 #4 110 x 208 mm"
+
+#: ../src/common/paper.cpp:169
+msgid "PRC Envelope #5 110 x 220 mm"
+msgstr "中国封筒 #5 110 x 220 mm"
+
+#: ../src/common/paper.cpp:170
+msgid "PRC Envelope #6 120 x 230 mm"
+msgstr "中国封筒 #6 120 x 230 mm"
+
+#: ../src/common/paper.cpp:171
+msgid "PRC Envelope #7 160 x 230 mm"
+msgstr "中国封筒 #7 160 x 230 mm"
+
+#: ../src/common/paper.cpp:172
+msgid "PRC Envelope #8 120 x 309 mm"
+msgstr "中国封筒 #8 120 x 309 mm"
+
+#: ../src/common/paper.cpp:173
+msgid "PRC Envelope #9 229 x 324 mm"
+msgstr "中国封筒 #9 229 x 324 mm"
+
+#: ../src/common/paper.cpp:174
+msgid "PRC Envelope #10 324 x 458 mm"
+msgstr "中国封筒 #10 324 x 458 mm"
+
+#: ../src/common/paper.cpp:175
+msgid "PRC 16K Rotated"
+msgstr "中国 16K 横置き"
+
+#: ../src/common/paper.cpp:176
+msgid "PRC 32K Rotated"
+msgstr "中国 32K 横置き"
+
+#: ../src/common/paper.cpp:177
+msgid "PRC 32K(Big) Rotated"
+msgstr "中国 32K(Big) 横置き"
+
+#: ../src/common/paper.cpp:178
+msgid "PRC Envelope #1 Rotated 165 x 102 mm"
+msgstr "中国封筒 #1 横置き 165 x 102 mm"
+
+#: ../src/common/paper.cpp:179
+msgid "PRC Envelope #2 Rotated 176 x 102 mm"
+msgstr "中国封筒 #2 横置き 176 x 102 mm"
+
+#: ../src/common/paper.cpp:180
+msgid "PRC Envelope #3 Rotated 176 x 125 mm"
+msgstr "中国封筒 #3 横置き 176 x 125 mm"
+
+#: ../src/common/paper.cpp:181
+msgid "PRC Envelope #4 Rotated 208 x 110 mm"
+msgstr "中国封筒 #4 横置き 208 x 110 mm"
+
+#: ../src/common/paper.cpp:182
+msgid "PRC Envelope #5 Rotated 220 x 110 mm"
+msgstr "中国封筒 #5 横置き 220 x 110 mm"
+
+#: ../src/common/paper.cpp:183
+msgid "PRC Envelope #6 Rotated 230 x 120 mm"
+msgstr "中国封筒 #6 横置き 230 x 120 mm"
+
+#: ../src/common/paper.cpp:184
+msgid "PRC Envelope #7 Rotated 230 x 160 mm"
+msgstr "中国封筒 #7 横置き 230 x 160 mm"
+
+#: ../src/common/paper.cpp:185
+msgid "PRC Envelope #8 Rotated 309 x 120 mm"
+msgstr "中国封筒 #8 横置き 309 x 120 mm"
+
+#: ../src/common/paper.cpp:186
+msgid "PRC Envelope #9 Rotated 324 x 229 mm"
+msgstr "中国封筒 #9 横置き 324 x 229 mm"
+
+#: ../src/common/paper.cpp:187
+msgid "PRC Envelope #10 Rotated 458 x 324 mm"
+msgstr "中国封筒 #10 横置き 458 x 324 mm"
+
+#: ../src/common/paper.cpp:192
+msgid "A0 sheet, 841 x 1189 mm"
+msgstr "A0 シート, 841 x 1189 mm"
+
+#: ../src/common/paper.cpp:193
+msgid "A1 sheet, 594 x 841 mm"
+msgstr "A1 シート, 594 x 841 mm"
+
+#: ../src/common/preferencescmn.cpp:37
+msgid "General"
+msgstr "一般"
+
+#: ../src/common/preferencescmn.cpp:40
+msgid "Advanced"
+msgstr "高度"
+
+#: ../src/common/prntbase.cpp:245
+msgid "Generic PostScript"
+msgstr "汎用 PostScipt"
+
+#: ../src/common/prntbase.cpp:259
+msgid "Ready"
+msgstr "準備完了"
+
+#: ../src/common/prntbase.cpp:331
+msgid "Printing Error"
+msgstr "印刷エラー"
+
+#: ../src/common/prntbase.cpp:413 ../src/common/prntbase.cpp:1597
+#: ../src/generic/prntdlgg.cpp:135 ../src/generic/prntdlgg.cpp:149
+#: ../src/gtk/print.cpp:628 ../src/gtk/print.cpp:646
+msgid "Print"
+msgstr "印刷"
+
+#: ../src/common/prntbase.cpp:471 ../src/generic/prntdlgg.cpp:809
+msgid "Page setup"
+msgstr "ページ設定"
+
+#: ../src/common/prntbase.cpp:525
+msgid "Please wait while printing..."
+msgstr "印刷が終わるまでお待ちください..."
+
+#: ../src/common/prntbase.cpp:529
+msgid "Document:"
+msgstr "文書:"
+
+#: ../src/common/prntbase.cpp:532
+msgid "Progress:"
+msgstr "進捗:"
+
+#: ../src/common/prntbase.cpp:533
+msgid "Preparing"
+msgstr "準備中"
+
+#: ../src/common/prntbase.cpp:552
+#, c-format
+msgid "Printing page %d"
+msgstr "ページ %d を印刷中"
+
+#: ../src/common/prntbase.cpp:557
+#, c-format
+msgid "Printing page %d of %d"
+msgstr "ページ %d / %dを印刷中"
+
+#: ../src/common/prntbase.cpp:560
+#, c-format
+msgid " (copy %d of %d)"
+msgstr " (部数 %d / %d)"
+
+#: ../src/common/prntbase.cpp:1604
+msgid "First page"
+msgstr "最初のページ"
+
+#: ../src/common/prntbase.cpp:1609 ../src/html/helpwnd.cpp:659
+msgid "Previous page"
+msgstr "前のページ"
+
+#: ../src/common/prntbase.cpp:1623 ../src/html/helpwnd.cpp:660
+msgid "Next page"
+msgstr "次のページ"
+
+#: ../src/common/prntbase.cpp:1628
+msgid "Last page"
+msgstr "最後のページ"
+
+#: ../src/common/prntbase.cpp:1636 ../src/common/stockitem.cpp:215
+msgid "Zoom Out"
+msgstr "縮小"
+
+#: ../src/common/prntbase.cpp:1650 ../src/common/stockitem.cpp:214
+msgid "Zoom In"
+msgstr "拡大"
+
+#: ../src/common/prntbase.cpp:1656 ../src/common/stockitem.cpp:153
+#: ../src/generic/logg.cpp:553 ../src/univ/themes/win32.cpp:3752
+msgid "&Close"
+msgstr "閉じる(&C)"
+
+#: ../src/common/prntbase.cpp:2085
+msgid "Could not start document preview."
+msgstr "文書プレビューを開始できませんでした。"
+
+#: ../src/common/prntbase.cpp:2085 ../src/common/prntbase.cpp:2129
+#: ../src/common/prntbase.cpp:2137
+msgid "Print Preview Failure"
+msgstr "印刷プレビュー失敗"
+
+#: ../src/common/prntbase.cpp:2129 ../src/common/prntbase.cpp:2137
+msgid "Sorry, not enough memory to create a preview."
+msgstr "プレビュー作成に必要なメモリが足りません。"
+
+#: ../src/common/prntbase.cpp:2144
+#, c-format
+msgid "Page %d of %d"
+msgstr "ページ %d / %d"
+
+#: ../src/common/prntbase.cpp:2146
+#, c-format
+msgid "Page %d"
+msgstr "ページ %d"
+
+#: ../src/common/regex.cpp:382 ../src/html/chm.cpp:348
+msgid "unknown error"
+msgstr "未知のエラー"
+
+#: ../src/common/regex.cpp:995
+#, c-format
+msgid "Invalid regular expression '%s': %s"
+msgstr "不正な正規表現 '%s': %s"
+
+#: ../src/common/regex.cpp:1059
+#, c-format
+msgid "Failed to find match for regular expression: %s"
+msgstr "正規表現に一致する部分が見つかりませんでした: %s"
+
+#: ../src/common/rendcmn.cpp:188
+#, c-format
+msgid "Renderer \"%s\" has incompatible version %d.%d and couldn't be loaded."
+msgstr ""
+"レンダラー \"%s\" は非互換バージョン %d.%d で実装されているため読み取ることが"
+"できません。"
+
+#: ../src/common/secretstore.cpp:162
+msgid "Not available for this platform"
+msgstr "このプラットフォームでは利用不可です"
+
+#: ../src/common/secretstore.cpp:183
+#, c-format
+msgid "Saving password for \"%s\" failed: %s."
+msgstr "\"%s\" のパスワードを保存できませんでした: %s。"
+
+#: ../src/common/secretstore.cpp:205
+#, c-format
+msgid "Reading password for \"%s\" failed: %s."
+msgstr "\"%s\" のパスワードを読み取れませんでした: %s。"
+
+#: ../src/common/secretstore.cpp:228
+#, c-format
+msgid "Deleting password for \"%s\" failed: %s."
+msgstr "\"%s\" のパスワードを削除できませんでした: %s。"
+
+#: ../src/common/selectdispatcher.cpp:254
+msgid "Failed to monitor I/O channels"
+msgstr "I/O チャネルの監視に失敗しました"
+
+#: ../src/common/sizer.cpp:3054 ../src/common/stockitem.cpp:195
+msgid "Save"
+msgstr "保存"
+
+#: ../src/common/sizer.cpp:3056
+msgid "Don't Save"
+msgstr "保存しない"
+
+#: ../src/common/socket.cpp:870
+msgid "Cannot initialize sockets"
+msgstr "ソケットを初期化できません"
+
+#: ../src/common/stockitem.cpp:127
+msgctxt "standard Windows menu"
+msgid "&Help"
+msgstr "ヘルプ(&H)"
+
+#: ../src/common/stockitem.cpp:144
+msgid "&About"
+msgstr "情報(&A)"
+
+#: ../src/common/stockitem.cpp:144
+msgid "About"
+msgstr "情報"
+
+#: ../src/common/stockitem.cpp:145
+msgid "Add"
+msgstr "追加"
+
+#: ../src/common/stockitem.cpp:146
+msgid "&Apply"
+msgstr "適用(&A)"
+
+#: ../src/common/stockitem.cpp:146
+msgid "Apply"
+msgstr "適用"
+
+#: ../src/common/stockitem.cpp:147
+msgid "&Back"
+msgstr "戻る(&B)"
+
+#: ../src/common/stockitem.cpp:147
+msgid "Back"
+msgstr "戻る"
+
+#: ../src/common/stockitem.cpp:148
+msgid "&Bold"
+msgstr "太字(&B)"
+
+#: ../src/common/stockitem.cpp:148 ../src/generic/fontdlgg.cpp:326
+#: ../src/richtext/richtextfontpage.cpp:354
+msgid "Bold"
+msgstr "太字"
+
+#: ../src/common/stockitem.cpp:149
+msgid "&Bottom"
+msgstr "下(&B)"
+
+#: ../src/common/stockitem.cpp:149 ../src/richtext/richtextsizepage.cpp:287
+msgid "Bottom"
+msgstr "下"
+
+#: ../src/common/stockitem.cpp:150 ../src/generic/fontdlgg.cpp:462
+#: ../src/generic/fontdlgg.cpp:481 ../src/generic/wizard.cpp:415
+msgid "&Cancel"
+msgstr "キャンセル(&C)"
+
+#: ../src/common/stockitem.cpp:151
+msgid "&CD-ROM"
+msgstr "CD-ROM(&C)"
+
+#: ../src/common/stockitem.cpp:151
+msgid "CD-ROM"
+msgstr "CD-ROM"
+
+#: ../src/common/stockitem.cpp:152
+msgid "&Clear"
+msgstr "消去(&C)"
+
+#: ../src/common/stockitem.cpp:152
+msgid "Clear"
+msgstr "消去"
+
+#: ../src/common/stockitem.cpp:153 ../src/generic/dbgrptg.cpp:93
+#: ../src/generic/progdlgg.cpp:778 ../src/html/helpdlg.cpp:86
+#: ../src/msw/progdlg.cpp:209 ../src/msw/progdlg.cpp:890
+#: ../src/richtext/richtextstyledlg.cpp:272
+#: ../src/richtext/richtextsymboldlg.cpp:448
+msgid "Close"
+msgstr "閉じる"
+
+#: ../src/common/stockitem.cpp:154
+msgid "&Convert"
+msgstr "変換(&C)"
+
+#: ../src/common/stockitem.cpp:154
+msgid "Convert"
+msgstr "変換"
+
+#: ../src/common/stockitem.cpp:155 ../src/msw/textctrl.cpp:2884
+#: ../src/osx/textctrl_osx.cpp:653 ../src/richtext/richtextctrl.cpp:331
+msgid "&Copy"
+msgstr "コピー(&C)"
+
+#: ../src/common/stockitem.cpp:155 ../src/stc/stc_i18n.cpp:18
+msgid "Copy"
+msgstr "コピー"
+
+#: ../src/common/stockitem.cpp:156 ../src/msw/textctrl.cpp:2883
+#: ../src/osx/textctrl_osx.cpp:652 ../src/richtext/richtextctrl.cpp:330
+msgid "Cu&t"
+msgstr "切り取り(&T)"
+
+#: ../src/common/stockitem.cpp:156 ../src/stc/stc_i18n.cpp:17
+msgid "Cut"
+msgstr "切り取り"
+
+#: ../src/common/stockitem.cpp:157 ../src/msw/textctrl.cpp:2886
+#: ../src/osx/textctrl_osx.cpp:655 ../src/richtext/richtextctrl.cpp:333
+#: ../src/richtext/richtexttabspage.cpp:137
+msgid "&Delete"
+msgstr "削除(&D)"
+
+#: ../src/common/stockitem.cpp:157 ../src/richtext/richtextbuffer.cpp:8266
+#: ../src/stc/stc_i18n.cpp:20
+msgid "Delete"
+msgstr "削除"
+
+#: ../src/common/stockitem.cpp:158
+msgid "&Down"
+msgstr "下(&D)"
+
+#: ../src/common/stockitem.cpp:158 ../src/generic/fdrepdlg.cpp:148
+msgid "Down"
+msgstr "下"
+
+#: ../src/common/stockitem.cpp:159
+msgid "&Edit"
+msgstr "編集(&E)"
+
+#: ../src/common/stockitem.cpp:159
+msgid "Edit"
+msgstr "編集"
+
+#: ../src/common/stockitem.cpp:160
+msgid "&Execute"
+msgstr "実行(&E)"
+
+#: ../src/common/stockitem.cpp:160
+msgid "Execute"
+msgstr "実行"
+
+#: ../src/common/stockitem.cpp:161
+msgid "&Quit"
+msgstr "終了(&Q)"
+
+#: ../src/common/stockitem.cpp:161
+msgid "Quit"
+msgstr "終了"
+
+#: ../src/common/stockitem.cpp:162
+msgid "&File"
+msgstr "ファイル(&F)"
+
+#: ../src/common/stockitem.cpp:162
+msgid "File"
+msgstr "ファイル"
+
+#: ../src/common/stockitem.cpp:163
+msgid "&Find..."
+msgstr "検索(&F)..."
+
+#: ../src/common/stockitem.cpp:163
+msgid "Find..."
+msgstr "検索..."
+
+#: ../src/common/stockitem.cpp:164
+msgid "&First"
+msgstr "最初へ(&F)"
+
+#: ../src/common/stockitem.cpp:164
+msgid "First"
+msgstr "最初へ"
+
+#: ../src/common/stockitem.cpp:165
+msgid "&Floppy"
+msgstr "フロッピー(&F)"
+
+#: ../src/common/stockitem.cpp:165
+msgid "Floppy"
+msgstr "フロッピー"
+
+#: ../src/common/stockitem.cpp:166
+msgid "&Forward"
+msgstr "前へ(&F)"
+
+#: ../src/common/stockitem.cpp:166
+msgid "Forward"
+msgstr "前へ"
+
+#: ../src/common/stockitem.cpp:167
+msgid "&Harddisk"
+msgstr "ハードディスク(&H)"
+
+#: ../src/common/stockitem.cpp:167
+msgid "Harddisk"
+msgstr "ハードディスク"
+
+#: ../src/common/stockitem.cpp:168 ../src/generic/wizard.cpp:418
+#: ../src/osx/cocoa/menu.mm:225 ../src/richtext/richtextstyledlg.cpp:298
+#: ../src/richtext/richtextsymboldlg.cpp:451
+msgid "&Help"
+msgstr "ヘルプ(&H)"
+
+#: ../src/common/stockitem.cpp:169
+msgid "&Home"
+msgstr "ホーム(&H)"
+
+#: ../src/common/stockitem.cpp:169
+msgid "Home"
+msgstr "ホーム"
+
+#: ../src/common/stockitem.cpp:170
+msgid "Indent"
+msgstr "字下げ"
+
+#: ../src/common/stockitem.cpp:171
+msgid "&Index"
+msgstr "索引(&I)"
+
+#: ../src/common/stockitem.cpp:171 ../src/html/helpwnd.cpp:510
+msgid "Index"
+msgstr "索引"
+
+#: ../src/common/stockitem.cpp:172
+msgid "&Info"
+msgstr "情報(&I)"
+
+#: ../src/common/stockitem.cpp:172
+msgid "Info"
+msgstr "情報"
+
+#: ../src/common/stockitem.cpp:173
+msgid "&Italic"
+msgstr "イタリック(&I)"
+
+#: ../src/common/stockitem.cpp:173 ../src/generic/fontdlgg.cpp:322
+#: ../src/richtext/richtextfontpage.cpp:350
+msgid "Italic"
+msgstr "イタリック"
+
+#: ../src/common/stockitem.cpp:174
+msgid "&Jump to"
+msgstr "移動(&J)"
+
+#: ../src/common/stockitem.cpp:174
+msgid "Jump to"
+msgstr "移動"
+
+#: ../src/common/stockitem.cpp:175
+msgid "Centered"
+msgstr "中央寄せ"
+
+#: ../src/common/stockitem.cpp:176
+msgid "Justified"
+msgstr "両端揃え"
+
+#: ../src/common/stockitem.cpp:177
+msgid "Align Left"
+msgstr "左寄せ"
+
+#: ../src/common/stockitem.cpp:178
+msgid "Align Right"
+msgstr "右寄せ"
+
+#: ../src/common/stockitem.cpp:179
+msgid "&Last"
+msgstr "最後へ(&L)"
+
+#: ../src/common/stockitem.cpp:179
+msgid "Last"
+msgstr "最後へ"
+
+#: ../src/common/stockitem.cpp:180
+msgid "&Network"
+msgstr "ネットワーク(&N)"
+
+#: ../src/common/stockitem.cpp:180
+msgid "Network"
+msgstr "ネットワーク"
+
+#: ../src/common/stockitem.cpp:181 ../src/richtext/richtexttabspage.cpp:131
+msgid "&New"
+msgstr "新規作成(&N)"
+
+#: ../src/common/stockitem.cpp:181
+msgid "New"
+msgstr "新規作成"
+
+#: ../src/common/stockitem.cpp:182 ../src/msw/msgdlg.cpp:417
+msgid "&No"
+msgstr "いいえ(&N)"
+
+#: ../src/common/stockitem.cpp:183 ../src/generic/fontdlgg.cpp:467
+#: ../src/generic/fontdlgg.cpp:474
+msgid "&OK"
+msgstr "OK(&O)"
+
+#: ../src/common/stockitem.cpp:184 ../src/generic/dbgrptg.cpp:341
+msgid "&Open..."
+msgstr "開く(&O)..."
+
+#: ../src/common/stockitem.cpp:184
+msgid "Open..."
+msgstr "開く..."
+
+#: ../src/common/stockitem.cpp:185 ../src/msw/textctrl.cpp:2885
+#: ../src/osx/textctrl_osx.cpp:654 ../src/richtext/richtextctrl.cpp:332
+msgid "&Paste"
+msgstr "貼り付け(&P)"
+
+#: ../src/common/stockitem.cpp:185 ../src/richtext/richtextctrl.cpp:3484
+#: ../src/stc/stc_i18n.cpp:19
+msgid "Paste"
+msgstr "貼り付け"
+
+#: ../src/common/stockitem.cpp:186
+msgid "&Preferences"
+msgstr "設定(&P)"
+
+#: ../src/common/stockitem.cpp:186 ../src/osx/cocoa/preferences.mm:304
+msgid "Preferences"
+msgstr "設定"
+
+#: ../src/common/stockitem.cpp:187
+msgid "Print previe&w..."
+msgstr "印刷プレビュー(&W)..."
+
+#: ../src/common/stockitem.cpp:187
+msgid "Print preview..."
+msgstr "印刷プレビュー..."
+
+#: ../src/common/stockitem.cpp:188
+msgid "&Print..."
+msgstr "印刷(&P)..."
+
+#: ../src/common/stockitem.cpp:188
+msgid "Print..."
+msgstr "印刷..."
+
+#: ../src/common/stockitem.cpp:189 ../src/richtext/richtextctrl.cpp:337
+#: ../src/richtext/richtextctrl.cpp:5479
+msgid "&Properties"
+msgstr "プロパティ(&P)"
+
+#: ../src/common/stockitem.cpp:189
+msgid "Properties"
+msgstr "プロパティ"
+
+#: ../src/common/stockitem.cpp:190 ../src/stc/stc_i18n.cpp:16
+msgid "Redo"
+msgstr "やり直す"
+
+#: ../src/common/stockitem.cpp:191
+msgid "Refresh"
+msgstr "更新"
+
+#: ../src/common/stockitem.cpp:192
+msgid "Remove"
+msgstr "削除"
+
+#: ../src/common/stockitem.cpp:193
+msgid "Rep&lace..."
+msgstr "置換(&L)..."
+
+#: ../src/common/stockitem.cpp:193
+msgid "Replace..."
+msgstr "置換..."
+
+#: ../src/common/stockitem.cpp:194
+msgid "Revert to Saved"
+msgstr "保存した状態に戻す"
+
+#: ../src/common/stockitem.cpp:196 ../src/generic/logg.cpp:549
+msgid "Save &As..."
+msgstr "別名で保存(&A)..."
+
+#: ../src/common/stockitem.cpp:196
+msgid "Save As..."
+msgstr "別名で保存..."
+
+#: ../src/common/stockitem.cpp:197 ../src/msw/textctrl.cpp:2888
+#: ../src/osx/textctrl_osx.cpp:657 ../src/richtext/richtextctrl.cpp:335
+msgid "Select &All"
+msgstr "すべて選択(&A)"
+
+#: ../src/common/stockitem.cpp:197 ../src/stc/stc_i18n.cpp:21
+msgid "Select All"
+msgstr "すべて選択"
+
+#: ../src/common/stockitem.cpp:198
+msgid "&Color"
+msgstr "色(&C)"
+
+#: ../src/common/stockitem.cpp:198
+msgid "Color"
+msgstr "色"
+
+#: ../src/common/stockitem.cpp:199
+msgid "&Font"
+msgstr "フォント(&F)"
+
+#: ../src/common/stockitem.cpp:199 ../src/richtext/richtextformatdlg.cpp:336
+msgid "Font"
+msgstr "フォント"
+
+#: ../src/common/stockitem.cpp:200
+msgid "&Ascending"
+msgstr "昇順(&A)"
+
+#: ../src/common/stockitem.cpp:200
+msgid "Ascending"
+msgstr "昇順"
+
+#: ../src/common/stockitem.cpp:201
+msgid "&Descending"
+msgstr "降順(&D)"
+
+#: ../src/common/stockitem.cpp:201
+msgid "Descending"
+msgstr "降順"
+
+#: ../src/common/stockitem.cpp:202
+msgid "&Spell Check"
+msgstr "スペルチェック(&S)"
+
+#: ../src/common/stockitem.cpp:202
+msgid "Spell Check"
+msgstr "スペルチェック"
+
+#: ../src/common/stockitem.cpp:203
+msgid "&Stop"
+msgstr "停止(&S)"
+
+#: ../src/common/stockitem.cpp:203
+msgid "Stop"
+msgstr "停止"
+
+#: ../src/common/stockitem.cpp:204 ../src/richtext/richtextfontpage.cpp:274
+msgid "&Strikethrough"
+msgstr "打ち消し線(&S)"
+
+#: ../src/common/stockitem.cpp:204
+msgid "Strikethrough"
+msgstr "打ち消し線"
+
+#: ../src/common/stockitem.cpp:205
+msgid "&Top"
+msgstr "上(&T)"
+
+#: ../src/common/stockitem.cpp:205 ../src/richtext/richtextsizepage.cpp:285
+#: ../src/richtext/richtextsizepage.cpp:289
+msgid "Top"
+msgstr "上"
+
+#: ../src/common/stockitem.cpp:206
+msgid "Undelete"
+msgstr "削除の取り消し"
+
+#: ../src/common/stockitem.cpp:207 ../src/generic/fontdlgg.cpp:437
+msgid "&Underline"
+msgstr "下線(&U)"
+
+#: ../src/common/stockitem.cpp:207
+msgid "Underline"
+msgstr "下線"
+
+#: ../src/common/stockitem.cpp:208 ../src/stc/stc_i18n.cpp:15
+msgid "Undo"
+msgstr "元に戻す"
+
+#: ../src/common/stockitem.cpp:209
+msgid "&Unindent"
+msgstr "字下げ解除(&U)"
+
+#: ../src/common/stockitem.cpp:209
+msgid "Unindent"
+msgstr "字下げ解除"
+
+#: ../src/common/stockitem.cpp:210
+msgid "&Up"
+msgstr "上(&U)"
+
+#: ../src/common/stockitem.cpp:210 ../src/generic/fdrepdlg.cpp:148
+msgid "Up"
+msgstr "上"
+
+#: ../src/common/stockitem.cpp:211 ../src/msw/msgdlg.cpp:417
+msgid "&Yes"
+msgstr "はい(&Y)"
+
+#: ../src/common/stockitem.cpp:212
+msgid "&Actual Size"
+msgstr "原寸(&A)"
+
+#: ../src/common/stockitem.cpp:212
+msgid "Actual Size"
+msgstr "原寸"
+
+#: ../src/common/stockitem.cpp:213
+msgid "Zoom to &Fit"
+msgstr "画面に合わせる(&F)"
+
+#: ../src/common/stockitem.cpp:213
+msgid "Zoom to Fit"
+msgstr "画面に合わせる"
+
+#: ../src/common/stockitem.cpp:214
+msgid "Zoom &In"
+msgstr "拡大(&I)"
+
+#: ../src/common/stockitem.cpp:215
+msgid "Zoom &Out"
+msgstr "縮小(&O)"
+
+#: ../src/common/stockitem.cpp:262
+msgid "Show about dialog"
+msgstr "情報ダイアログを表示します"
+
+#: ../src/common/stockitem.cpp:263
+msgid "Copy selection"
+msgstr "選択範囲をコピーします"
+
+#: ../src/common/stockitem.cpp:264
+msgid "Cut selection"
+msgstr "選択範囲を切り取ります"
+
+#: ../src/common/stockitem.cpp:265
+msgid "Delete selection"
+msgstr "選択範囲を削除します"
+
+#: ../src/common/stockitem.cpp:266
+msgid "Find in document"
+msgstr "文書内を検索します"
+
+#: ../src/common/stockitem.cpp:267
+msgid "Find and replace in document"
+msgstr "文書内で検索と置換を行います"
+
+#: ../src/common/stockitem.cpp:268
+msgid "Paste selection"
+msgstr "選択範囲を貼り付けます"
+
+#: ../src/common/stockitem.cpp:269
+msgid "Quit this program"
+msgstr "このプログラムを終了します"
+
+#: ../src/common/stockitem.cpp:270
+msgid "Redo last action"
+msgstr "最後のアクションをやり直します"
+
+#: ../src/common/stockitem.cpp:271
+msgid "Undo last action"
+msgstr "最後のアクションを元に戻します"
+
+#: ../src/common/stockitem.cpp:272
+msgid "Create new document"
+msgstr "新しい文書を作成します"
+
+#: ../src/common/stockitem.cpp:273
+msgid "Open an existing document"
+msgstr "既存の文書を開きます"
+
+#: ../src/common/stockitem.cpp:274
+msgid "Close current document"
+msgstr "現在の文書を閉じます"
+
+#: ../src/common/stockitem.cpp:275
+msgid "Save current document"
+msgstr "現在の文書を保存します"
+
+#: ../src/common/stockitem.cpp:276
+msgid "Save current document with a different filename"
+msgstr "現在の文書を別名で保存します"
+
+#: ../src/common/strconv.cpp:2324
+#, c-format
+msgid "Conversion to charset '%s' doesn't work."
+msgstr "文字集合 '%s' への変換が機能していません。"
+
+#: ../src/common/tarstrm.cpp:352 ../src/common/tarstrm.cpp:375
+#: ../src/common/tarstrm.cpp:406 ../src/generic/progdlgg.cpp:373
+msgid "unknown"
+msgstr "未知"
+
+#: ../src/common/tarstrm.cpp:774
+msgid "incomplete header block in tar"
+msgstr "不完全なtarヘッダブロックです"
+
+#: ../src/common/tarstrm.cpp:798
+msgid "checksum failure reading tar header block"
+msgstr "ヘッダーブロックを読み取り中にチェックサムの不整合が見つかりました"
+
+#: ../src/common/tarstrm.cpp:971
+msgid "invalid data in extended tar header"
+msgstr "拡張tarヘッダに不正なデータがあります"
+
+#: ../src/common/tarstrm.cpp:981 ../src/common/tarstrm.cpp:1003
+#: ../src/common/tarstrm.cpp:1477 ../src/common/tarstrm.cpp:1499
+msgid "tar entry not open"
+msgstr "TARの項目を開くことができません"
+
+#: ../src/common/tarstrm.cpp:1023
+msgid "unexpected end of file"
+msgstr "想定外の状況でファイル末尾に達しました"
+
+#: ../src/common/tarstrm.cpp:1297
+#, c-format
+msgid "%s did not fit the tar header for entry '%s'"
+msgstr "%s は tar のヘッダとして認識できませんでした '%s'"
+
+#: ../src/common/tarstrm.cpp:1359
+msgid "incorrect size given for tar entry"
+msgstr "tar項目に不正な大きさが与えられています"
+
+#: ../src/common/textbuf.cpp:232
+#, c-format
+msgid "'%s' is probably a binary buffer."
+msgstr "'%s' はおそらくバイナリバッファーです。"
+
+#: ../src/common/textcmn.cpp:1006 ../src/richtext/richtextctrl.cpp:3053
+msgid "File couldn't be loaded."
+msgstr "ファイルを読み取ることができません。"
+
+#: ../src/common/textfile.cpp:95
+#, fuzzy, c-format
+msgid "Failed to read text file \"%s\"."
+msgstr "ファイル \"%s\" から文書を読み取れませんでした。"
+
+#: ../src/common/textfile.cpp:160
+#, c-format
+msgid "can't write buffer '%s' to disk."
+msgstr "バッファー '%s' をディスクに書き出すことができません。"
+
+#: ../src/common/time.cpp:212
+msgid "Failed to get the local system time"
+msgstr "ローカルのシステム時刻を取得できませんでした"
+
+#: ../src/common/time.cpp:279
+msgid "wxGetTimeOfDay failed."
+msgstr "wxGetTimeOfDay が失敗しました。"
+
+#: ../src/common/translation.cpp:929
+#, c-format
+msgid "'%s' is not a valid message catalog."
+msgstr "'%s' は正しいメッセージカタログではありません。"
+
+#: ../src/common/translation.cpp:954
+msgid "Invalid message catalog."
+msgstr "正しいメッセージカタログではありません。"
+
+#: ../src/common/translation.cpp:1013
+#, c-format
+msgid "Failed to parse Plural-Forms: '%s'"
+msgstr "複数形を解析できません: '%s'"
+
+#: ../src/common/translation.cpp:1723
+#, c-format
+msgid "using catalog '%s' from '%s'."
+msgstr "カタログ '%s' を '%s' から利用します。"
+
+#: ../src/common/translation.cpp:1816
+#, c-format
+msgid "Resource '%s' is not a valid message catalog."
+msgstr "'%s' は正しいメッセージカタログではありません。"
+
+#: ../src/common/translation.cpp:1865
+#, fuzzy
+msgid "Couldn't enumerate translations"
+msgstr "スレッドを終了できませんでした"
+
+#: ../src/common/utilscmn.cpp:1145
+msgid "No default application configured for HTML files."
+msgstr "HTMLファイルに対する既定のアプリケーション設定がありません。"
+
+#: ../src/common/utilscmn.cpp:1190
+#, c-format
+msgid "Failed to open URL \"%s\" in default browser."
+msgstr "デフォルトブラウザでURL \"%s\" を開けませんでした。"
+
+#: ../src/common/valtext.cpp:144
+msgid "Validation conflict"
+msgstr "確認処理に矛盾があります"
+
+#: ../src/common/valtext.cpp:186
+msgid "Required information entry is empty."
+msgstr "必須情報項目が空です。"
+
+#: ../src/common/valtext.cpp:188
+#, fuzzy, c-format
+msgid "'%s' is one of the invalid strings"
+msgstr "'%s' は不正です"
+
+#: ../src/common/valtext.cpp:190
+#, fuzzy, c-format
+msgid "'%s' is not one of the valid strings"
+msgstr "'%s' は正しいメッセージカタログではありません。"
+
+#: ../src/common/valtext.cpp:199
+#, fuzzy, c-format
+msgid "'%s' contains invalid character(s)"
+msgstr "'%s' はアルファベット以外を受け付けません。"
+
+#: ../src/common/webrequest.cpp:139
+#, c-format
+msgid "Error: %s (%d)"
+msgstr "エラー: %s (%d)"
+
+#: ../src/common/webrequest.cpp:655
+#, c-format
+msgid ""
+"Not enough free disk space for download: %llu needed but only %llu available."
+msgstr ""
+
+#: ../src/common/webrequest.cpp:669
+#, fuzzy, c-format
+msgid "Failed to create temporary file in %s"
+msgstr "一時ファイルの名前を作成できませんでした"
+
+#: ../src/common/webrequest_curl.cpp:1106
+#, fuzzy
+msgid "libcurl could not be initialized"
+msgstr "列の記述を初期化できませんでした。"
+
+#: ../src/common/webview.cpp:392
+#, fuzzy
+msgid "RunScriptAsync not supported"
+msgstr "文字列変換は未対応です"
+
+#: ../src/common/webview.cpp:403 ../src/msw/webview_ie.cpp:1073
+#, c-format
+msgid "Error running JavaScript: %s"
+msgstr "JavaScript実行エラー: %s"
+
+#: ../src/common/webview_chromium.cpp:858
+#, fuzzy, c-format
+msgid "Failed to set proxy \"%s\": %s"
+msgstr "ディレクトリ \"%s\" を作成できませんでした"
+
+#: ../src/common/webview_chromium.cpp:989
+msgid ""
+"Chromium can't be used because libcef.so wasn't loaded early enough; please "
+"relink the application or use LD_PRELOAD to load it earlier."
+msgstr ""
+
+#: ../src/common/webview_chromium.cpp:1108
+#, fuzzy
+msgid "Could not initialize Chromium"
+msgstr "整列方法を設定できませんでした。"
+
+#: ../src/common/webview_chromium.cpp:1616
+msgid "Show DevTools"
+msgstr ""
+
+#: ../src/common/webview_chromium.cpp:1617
+#, fuzzy
+msgid "Close DevTools"
+msgstr "すべて閉じる"
+
+#: ../src/common/webview_chromium.cpp:1623
+msgid "Inspect"
+msgstr ""
+
+#: ../src/common/wincmn.cpp:1628
+msgid "This platform does not support background transparency."
+msgstr ""
+
+#: ../src/common/wincmn.cpp:2097
+msgid "Could not transfer data to window"
+msgstr "ウィンドウへデータを転送できませんでした"
+
+#: ../src/common/windowid.cpp:240
+msgid "Out of window IDs.  Recommend shutting down application."
+msgstr ""
+"ウィンドウIDが制限範囲を超えました。アプリケーションの再起動をおすすめしま"
+"す。"
+
+#: ../src/common/xpmdecod.cpp:678
+msgid "XPM: incorrect header format!"
+msgstr "XPM: ヘッダーの書式が不正です。"
+
+#: ../src/common/xpmdecod.cpp:703
+#, c-format
+msgid "XPM: incorrect colour description in line %d"
+msgstr "XPM: %d行目の色記述に問題があります"
+
+#: ../src/common/xpmdecod.cpp:715 ../src/common/xpmdecod.cpp:724
+#, c-format
+msgid "XPM: malformed colour definition '%s' at line %d!"
+msgstr "XPM: 定形外の色定義 '%s' が%d行目にありました。"
+
+#: ../src/common/xpmdecod.cpp:754
+msgid "XPM: no colors left to use for mask!"
+msgstr "XPM: マスクに使うための色が残っていません。"
+
+#: ../src/common/xpmdecod.cpp:781
+#, c-format
+msgid "XPM: truncated image data at line %d!"
+msgstr "XPM: %d行目に不完全な画像データがありました。"
+
+#: ../src/common/xpmdecod.cpp:795
+msgid "XPM: Malformed pixel data!"
+msgstr "XPM: 定形外のピクセルデータがありました"
+
+#: ../src/common/xti.cpp:492
+msgid "Illegal Parameter Count for Create Method"
+msgstr "Create メソッドに不正なカウント引数が与えられました。"
+
+#: ../src/common/xti.cpp:504
+msgid "Illegal Parameter Count for ConstructObject Method"
+msgstr "ConstructObject メソッドに不正なカウント引数が与えられました。"
+
+#: ../src/common/xtistrm.cpp:161
+#, fuzzy, c-format
+msgid "Create Parameter %s not found in declared RTTI Parameters"
+msgstr "宣言された RTTI 変数の中には Create で指定されたものがありません"
+
+#: ../src/common/xtistrm.cpp:290
+msgid "Illegal Object Class (Non-wxEvtHandler) as Event Source"
+msgstr "wxEvtHandler ではないオブジェクトクラスがイベントソースになっています"
+
+#: ../src/common/xtistrm.cpp:313 ../src/common/xtixml.cpp:345
+#: ../src/common/xtixml.cpp:498
+msgid "Type must have enum - long conversion"
+msgstr "型は列挙からlongへの変換が可能でなくてはなりません"
+
+#: ../src/common/xtistrm.cpp:400 ../src/common/xtistrm.cpp:415
+msgid "Invalid or Null Object ID passed to GetObjectClassInfo"
+msgstr ""
+"Null または不正なオブジェクト識別子が GetObjectClassInfo に渡されました"
+
+#: ../src/common/xtistrm.cpp:405
+msgid "Unknown Object passed to GetObjectClassInfo"
+msgstr "未知のオブジェクトが GetObjectClassInfo に渡されました"
+
+#: ../src/common/xtistrm.cpp:420
+msgid "Already Registered Object passed to SetObjectClassInfo"
+msgstr "登録済みのオブジェクトが SetObjectClassInfo に渡されました"
+
+#: ../src/common/xtistrm.cpp:430
+msgid "Invalid or Null Object ID passed to HasObjectClassInfo"
+msgstr ""
+"Null または不正なオブジェクト識別子が HasObjectClassInfo に渡されました"
+
+#: ../src/common/xtistrm.cpp:460
+msgid "Passing a already registered object to SetObject"
+msgstr "SetObject に登録済みのオブジェクトが渡されました"
+
+#: ../src/common/xtistrm.cpp:471
+msgid "Passing an unknown object to GetObject"
+msgstr "GetObject に未知のオブジェクトが渡されました"
+
+#: ../src/common/xtixml.cpp:229
+msgid "Forward hrefs are not supported"
+msgstr "前方参照のhrefには未対応です"
+
+#: ../src/common/xtixml.cpp:247
+#, c-format
+msgid "unknown class %s"
+msgstr "不明なクラス %s"
+
+#: ../src/common/xtixml.cpp:253
+msgid "objects cannot have XML Text Nodes"
+msgstr "オブジェクトは XML テキストノードを持つことができません"
+
+#: ../src/common/xtixml.cpp:258
+msgid "Objects must have an id attribute"
+msgstr "オブジェクトには id 属性が必須です"
+
+#: ../src/common/xtixml.cpp:267
+#, c-format
+msgid "Doubly used id : %d"
+msgstr "識別子が重複しています: %d"
+
+#: ../src/common/xtixml.cpp:316
+#, c-format
+msgid "Unknown Property %s"
+msgstr "未知のプロパティ %s"
+
+#: ../src/common/xtixml.cpp:407
+msgid "A non empty collection must consist of 'element' nodes"
+msgstr "空でないコレクションは 'element' ノードを必須とします"
+
+#: ../src/common/xtixml.cpp:478
+msgid "incorrect event handler string, missing dot"
+msgstr "点が付いていない不正なイベントハンドラー文字列です"
+
+#: ../src/common/zipstrm.cpp:559
+msgid "can't re-initialize zlib deflate stream"
+msgstr "zlibをdeflateストリームで再初期化できません"
+
+#: ../src/common/zipstrm.cpp:584
+msgid "can't re-initialize zlib inflate stream"
+msgstr "zlibをinflateストリームで再初期化できません"
+
+#: ../src/common/zipstrm.cpp:1023
+msgid "Ignoring malformed extra data record, ZIP file may be corrupted"
+msgstr ""
+
+#: ../src/common/zipstrm.cpp:1502
+msgid "assuming this is a multi-part zip concatenated"
+msgstr "複数のzipファイルが結合されるよう意図されたデータです"
+
+#: ../src/common/zipstrm.cpp:1664
+msgid "invalid zip file"
+msgstr "不完全なzipファイルです"
+
+#: ../src/common/zipstrm.cpp:1723
+msgid "can't find central directory in zip"
+msgstr "zip 内にセントラルディレクトリが見つかりません"
+
+#: ../src/common/zipstrm.cpp:1812
+msgid "error reading zip central directory"
+msgstr "zip のセントラルディレクトリを読み取り中にエラーが発生しました"
+
+#: ../src/common/zipstrm.cpp:1916
+msgid "error reading zip local header"
+msgstr "zipのローカルヘッダーを読み取り中にエラーが発生しました"
+
+#: ../src/common/zipstrm.cpp:1964
+msgid "bad zipfile offset to entry"
+msgstr "項目へのzipfileオフセットが不適当です"
+
+#: ../src/common/zipstrm.cpp:2031
+msgid "stored file length not in Zip header"
+msgstr "Zipヘッダーにファイルの長さが記されていません"
+
+#: ../src/common/zipstrm.cpp:2045 ../src/common/zipstrm.cpp:2362
+msgid "unsupported Zip compression method"
+msgstr "この Zip 圧縮法には未対応です"
+
+#: ../src/common/zipstrm.cpp:2126
+#, c-format
+msgid "reading zip stream (entry %s): bad length"
+msgstr "zipストリームの読み取り中 (項目 %s): 不正な長さ"
+
+#: ../src/common/zipstrm.cpp:2131
+#, c-format
+msgid "reading zip stream (entry %s): bad crc"
+msgstr "zipストリームの読み取り中 (項目 %s): CRC 不一致"
+
+#: ../src/common/zipstrm.cpp:2578
+#, fuzzy, c-format
+msgid "error writing zip entry '%s': file too large without ZIP64"
+msgstr "zip項目 '%s' の書き出しエラー: CRCまたは長さが不正です"
+
+#: ../src/common/zipstrm.cpp:2585
+#, c-format
+msgid "error writing zip entry '%s': bad crc or length"
+msgstr "zip項目 '%s' の書き出しエラー: CRCまたは長さが不正です"
+
+#: ../src/common/zstream.cpp:155 ../src/common/zstream.cpp:315
+msgid "Gzip not supported by this version of zlib"
+msgstr "このバージョンの zlib は Gzip を処理できません"
+
+#: ../src/common/zstream.cpp:182
+msgid "Can't initialize zlib inflate stream."
+msgstr "zlib の inflate ストリームを初期化できません。"
+
+#: ../src/common/zstream.cpp:241
+msgid "Can't read inflate stream: unexpected EOF in underlying stream."
+msgstr ""
+"inflate ストリームを読み取ることができません: 想定外の条件でEOFが元のストリー"
+"ムから検出されました。"
+
+#: ../src/common/zstream.cpp:248 ../src/common/zstream.cpp:423
+#, c-format
+msgid "zlib error %d"
+msgstr "zlib エラー %d"
+
+#: ../src/common/zstream.cpp:249
+#, c-format
+msgid "Can't read from inflate stream: %s"
+msgstr "inflateストリームから読み取ることができません: %s"
+
+#: ../src/common/zstream.cpp:343
+msgid "Can't initialize zlib deflate stream."
+msgstr "zlib の deflate ストリームを初期化できません。"
+
+#: ../src/common/zstream.cpp:424
+#, c-format
+msgid "Can't write to deflate stream: %s"
+msgstr "deflateストリームに書き出すことができません: %s"
+
+#: ../src/dfb/bitmap.cpp:633 ../src/dfb/bitmap.cpp:667
+#, c-format
+msgid "No bitmap handler for type %d defined."
+msgstr "'%d' 型のイメージハンドラは定義されていません。"
+
+#: ../src/dfb/evtloop.cpp:99
+msgid "Failed to read event from DirectFB pipe"
+msgstr "DirectFB パイプからのイベント読み取りに失敗しました"
+
+#: ../src/dfb/evtloop.cpp:171
+msgid "Failed to switch DirectFB pipe to non-blocking mode"
+msgstr ""
+"DirectFB パイプを non-blocking モードに切り替えることができませんでした"
+
+#: ../src/dfb/fontmgr.cpp:171
+#, c-format
+msgid "no fonts found in %s, using builtin font"
+msgstr "%s にフォントが含まれていません。ビルトインフォントを使用します"
+
+#: ../src/dfb/fontmgr.cpp:177
+msgid "Default font"
+msgstr "既定のフォント"
+
+#: ../src/dfb/fontmgr.cpp:195
+#, c-format
+msgid "Fonts index file %s disappeared while loading fonts."
+msgstr "フォントの読み取り中に索引ファイル %s が失われました。"
+
+#: ../src/dfb/wrapdfb.cpp:60
+#, fuzzy, c-format
+msgid "DirectFB error %d occurred."
+msgstr "DirectFB エラー %d が発生しました。"
+
+#: ../src/generic/aboutdlgg.cpp:69
+msgid "Developed by "
+msgstr "開発担当 "
+
+#: ../src/generic/aboutdlgg.cpp:72
+msgid "Documentation by "
+msgstr "ドキュメント担当 "
+
+#: ../src/generic/aboutdlgg.cpp:75
+msgid "Graphics art by "
+msgstr "デザイン担当 "
+
+#: ../src/generic/aboutdlgg.cpp:78
+msgid "Translations by "
+msgstr "翻訳担当 "
+
+#: ../src/generic/aboutdlgg.cpp:133 ../src/osx/cocoa/aboutdlg.mm:83
+msgid "Version "
+msgstr "バージョン "
+
+#. TRANSLATORS: %s is application name
+#: ../src/generic/aboutdlgg.cpp:146 ../src/msw/aboutdlg.cpp:60
+#, c-format
+msgid "About %s"
+msgstr "%s について"
+
+#: ../src/generic/aboutdlgg.cpp:181
+msgid "License"
+msgstr "ライセンス"
+
+#: ../src/generic/aboutdlgg.cpp:184
+msgid "Developers"
+msgstr "開発者"
+
+#: ../src/generic/aboutdlgg.cpp:188
+msgid "Documentation writers"
+msgstr "ドキュメントの著者"
+
+#: ../src/generic/aboutdlgg.cpp:192
+msgid "Artists"
+msgstr "デザイナー"
+
+#: ../src/generic/aboutdlgg.cpp:196
+msgid "Translators"
+msgstr "翻訳者"
+
+#: ../src/generic/animateg.cpp:125
+msgid "No handler found for animation type."
+msgstr "アニメーションタイプのハンドラーが見つかりません。"
+
+#: ../src/generic/animateg.cpp:133
+#, c-format
+msgid "No animation handler for type %ld defined."
+msgstr "%ld 型のアニメーションハンドラーは未定義です。"
+
+#: ../src/generic/animateg.cpp:145
+#, c-format
+msgid "Animation file is not of type %ld."
+msgstr "アニメーションファイルが %ld 型ではありません。"
+
+#: ../src/generic/colrdlgg.cpp:154 ../src/gtk/colordlg.cpp:47
+msgid "Choose colour"
+msgstr "色を選んでください"
+
+#: ../src/generic/colrdlgg.cpp:357
+msgid "Red:"
+msgstr "赤:"
+
+#: ../src/generic/colrdlgg.cpp:360
+msgid "Green:"
+msgstr "緑:"
+
+#: ../src/generic/colrdlgg.cpp:363
+msgid "Blue:"
+msgstr "青:"
+
+#: ../src/generic/colrdlgg.cpp:372
+msgid "Opacity:"
+msgstr "不透明度:"
+
+#: ../src/generic/colrdlgg.cpp:384
+msgid "Add to custom colours"
+msgstr "カスタムカラーへ追加します"
+
+#: ../src/generic/creddlgg.cpp:56
+msgid "Username:"
+msgstr ""
+
+#: ../src/generic/creddlgg.cpp:63
+msgid "Password:"
+msgstr ""
+
+#. TRANSLATORS: Name of Boolean true value
+#: ../src/generic/datavgen.cpp:1178
+msgid "true"
+msgstr ""
+
+#. TRANSLATORS: Name of Boolean false value
+#: ../src/generic/datavgen.cpp:1180
+#, fuzzy
+msgid "false"
+msgstr "偽"
+
+#: ../src/generic/datavgen.cpp:6897
+#, c-format
+msgid "Row %i"
+msgstr ""
+
+#. TRANSLATORS: Action for manipulating a tree control
+#: ../src/generic/datavgen.cpp:6987
+msgid "Collapse"
+msgstr ""
+
+#. TRANSLATORS: Action for manipulating a tree control
+#: ../src/generic/datavgen.cpp:6990
+msgid "Expand"
+msgstr ""
+
+#. TRANSLATORS: Name of data view control and number of rows
+#: ../src/generic/datavgen.cpp:7011
+#, c-format
+msgid "%s (%d items)"
+msgstr "%s (%d 項目)"
+
+#: ../src/generic/datavgen.cpp:7062
+#, c-format
+msgid "Column %u"
+msgstr ""
+
+#. TRANSLATORS: Keystroke for manipulating a tree control
+#: ../src/generic/datavgen.cpp:7131 ../src/richtext/richtextbulletspage.cpp:189
+#: ../src/richtext/richtextbulletspage.cpp:192
+#: ../src/richtext/richtextbulletspage.cpp:193
+#: ../src/richtext/richtextliststylepage.cpp:252
+#: ../src/richtext/richtextliststylepage.cpp:255
+#: ../src/richtext/richtextliststylepage.cpp:256
+#: ../src/richtext/richtextsizepage.cpp:248
+msgid "Left"
+msgstr "左"
+
+#. TRANSLATORS: Keystroke for manipulating a tree control
+#: ../src/generic/datavgen.cpp:7134 ../src/richtext/richtextbulletspage.cpp:191
+#: ../src/richtext/richtextliststylepage.cpp:254
+#: ../src/richtext/richtextsizepage.cpp:249
+msgid "Right"
+msgstr "右"
+
+#: ../src/generic/datectlg.cpp:90
+#, c-format
+msgid ""
+"\"%s\" is not in the expected date format, please enter it as e.g. \"%s\"."
+msgstr ""
+
+#: ../src/generic/datectlg.cpp:94
+#, fuzzy
+msgid "Invalid date"
+msgstr "不適切なデータビュー項目です"
+
+#: ../src/generic/dbgrptg.cpp:159
+#, c-format
+msgid "Open file \"%s\""
+msgstr "ファイル \"%s\" を開く"
+
+#: ../src/generic/dbgrptg.cpp:170
+#, c-format
+msgid "Enter command to open file \"%s\":"
+msgstr "\"%s\" ファイルを開くためのコマンドを入力してください:"
+
+#: ../src/generic/dbgrptg.cpp:230
+msgid "Executable files (*.exe)|*.exe|"
+msgstr "実行ファイル (*.exe)|*.exe|"
+
+#: ../src/generic/dbgrptg.cpp:300
+#, c-format
+msgid "Debug report \"%s\""
+msgstr "デバッグレポート \"%s\""
+
+#: ../src/generic/dbgrptg.cpp:316
+msgid "A debug report has been generated in the directory\n"
+msgstr "デバッグレポートが次のディレクトリに作成されました\n"
+
+#: ../src/generic/dbgrptg.cpp:317
+msgid "The following debug report will be generated\n"
+msgstr ""
+
+#: ../src/generic/dbgrptg.cpp:321
+msgid ""
+"The report contains the files listed below. If any of these files contain "
+"private information,\n"
+"please uncheck them and they will be removed from the report.\n"
+msgstr ""
+"レポートに含まれるファイルは下記の通りです。公開すべきでないファイルが含まれ"
+"ている場合は\n"
+"そのファイルのチェックを外せばレポートから取り除かれます。\n"
+
+#: ../src/generic/dbgrptg.cpp:323
+msgid ""
+"If you wish to suppress this debug report completely, please choose the "
+"\"Cancel\" button,\n"
+"but be warned that it may hinder improving the program, so if\n"
+"at all possible please do continue with the report generation.\n"
+msgstr ""
+"以後のデバッグレポート表示を完全に抑制したい場合は\"キャンセル\"ボタンを使っ"
+"てください。\n"
+"ただし、その抑制指示はプログラムの修正を遠ざけることになりますので\n"
+"できる限りレポート生成を続けるようにしてください。\n"
+
+#: ../src/generic/dbgrptg.cpp:325
+msgid "              Thank you and we're sorry for the inconvenience!\n"
+msgstr "              ご不便をおかけして申し訳ございません。\n"
+
+#: ../src/generic/dbgrptg.cpp:333
+msgid "&Debug report preview:"
+msgstr "デバッグレポートプレビュー(&D):"
+
+#: ../src/generic/dbgrptg.cpp:339
+msgid "&View..."
+msgstr "表示(&V) ..."
+
+#: ../src/generic/dbgrptg.cpp:359
+msgid "&Notes:"
+msgstr "注意書き(&N):"
+
+#: ../src/generic/dbgrptg.cpp:361
+msgid ""
+"If you have any additional information pertaining to this bug\n"
+"report, please enter it here and it will be joined to it:"
+msgstr ""
+"このバグレポートに関連する追加情報をお持ちの場合は\n"
+"ここに記入頂くことでバグレポートに追加されます:"
+
+#: ../src/generic/dcpsg.cpp:1627
+msgid "Cannot open file for PostScript printing!"
+msgstr "PostScript 印刷のためのファイルを開くことができません。"
+
+#: ../src/generic/dirctrlg.cpp:402
+msgid "Computer"
+msgstr "コンピューター"
+
+#: ../src/generic/dirctrlg.cpp:404
+msgid "Sections"
+msgstr "セクション"
+
+#: ../src/generic/dirctrlg.cpp:482
+msgid "Home directory"
+msgstr "ホームディレクトリ"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/generic/dirctrlg.cpp:484 ../src/propgrid/advprops.cpp:811
+msgid "Desktop"
+msgstr "デスクトップ"
+
+#: ../src/generic/dirctrlg.cpp:528 ../src/generic/filectrlg.cpp:752
+msgid "Illegal directory name."
+msgstr "不正なディレクトリ名です。"
+
+#: ../src/generic/dirctrlg.cpp:528 ../src/generic/dirctrlg.cpp:546
+#: ../src/generic/dirctrlg.cpp:557 ../src/generic/dirdlgg.cpp:317
+#: ../src/generic/filectrlg.cpp:638 ../src/generic/filectrlg.cpp:752
+#: ../src/generic/filectrlg.cpp:766 ../src/generic/filectrlg.cpp:782
+#: ../src/generic/filectrlg.cpp:1356 ../src/generic/filectrlg.cpp:1387
+#: ../src/generic/filedlgg.cpp:362 ../src/gtk/filedlg.cpp:76
+msgid "Error"
+msgstr "エラー"
+
+#: ../src/generic/dirctrlg.cpp:546 ../src/generic/filectrlg.cpp:766
+msgid "File name exists already."
+msgstr "その名前のファイルはすでに存在します。"
+
+#: ../src/generic/dirctrlg.cpp:557 ../src/generic/dirdlgg.cpp:317
+#: ../src/generic/filectrlg.cpp:638 ../src/generic/filectrlg.cpp:782
+msgid "Operation not permitted."
+msgstr "処理が許可されていません。"
+
+#: ../src/generic/dirdlgg.cpp:107 ../src/generic/filedlgg.cpp:207
+msgid "Create new directory"
+msgstr "新しいディレクトリを作成します"
+
+#: ../src/generic/dirdlgg.cpp:112 ../src/generic/filedlgg.cpp:203
+msgid "Go to home directory"
+msgstr "ホームディレクトリへ移動"
+
+#: ../src/generic/dirdlgg.cpp:143
+msgid "Show &hidden directories"
+msgstr "隠しディレクトリを表示する(&H)"
+
+#: ../src/generic/dirdlgg.cpp:196
+#, c-format
+msgid ""
+"The directory '%s' does not exist\n"
+"Create it now?"
+msgstr ""
+"ディレクトリ '%s' は存在しません\n"
+"作成しますか?"
+
+#: ../src/generic/dirdlgg.cpp:198
+msgid "Directory does not exist"
+msgstr "ディレクトリが存在しません"
+
+#: ../src/generic/dirdlgg.cpp:214
+#, c-format
+msgid ""
+"Failed to create directory '%s'\n"
+"(Do you have the required permissions?)"
+msgstr ""
+"'%s' を作成できませんでした。\n"
+"処理に必要なパーミッションをお持ちですか?"
+
+#: ../src/generic/dirdlgg.cpp:216
+msgid "Error creating directory"
+msgstr "ディレクトリ作成エラー"
+
+#: ../src/generic/dirdlgg.cpp:281
+msgid "You cannot add a new directory to this section."
+msgstr "このセクションに新しいディレクトリは追加できません。"
+
+#: ../src/generic/dirdlgg.cpp:282
+msgid "Create directory"
+msgstr "ディレクトリを作成します"
+
+#: ../src/generic/dirdlgg.cpp:291 ../src/generic/dirdlgg.cpp:301
+#: ../src/generic/filectrlg.cpp:614 ../src/generic/filectrlg.cpp:623
+msgid "NewName"
+msgstr "新しい名前"
+
+#: ../src/generic/editlbox.cpp:135
+msgid "Edit item"
+msgstr "項目の編集"
+
+#: ../src/generic/editlbox.cpp:143
+msgid "New item"
+msgstr "新規項目"
+
+#: ../src/generic/editlbox.cpp:151
+msgid "Delete item"
+msgstr "項目の削除"
+
+#: ../src/generic/editlbox.cpp:159
+msgid "Move up"
+msgstr "上に移動"
+
+#: ../src/generic/editlbox.cpp:164
+msgid "Move down"
+msgstr "下に移動"
+
+#: ../src/generic/fdrepdlg.cpp:108
+msgid "Search for:"
+msgstr "検索内容:"
+
+#: ../src/generic/fdrepdlg.cpp:120
+msgid "Replace with:"
+msgstr "置換先:"
+
+#: ../src/generic/fdrepdlg.cpp:140
+msgid "Whole word"
+msgstr "単語全体"
+
+#: ../src/generic/fdrepdlg.cpp:143
+msgid "Match case"
+msgstr "大文字小文字を区別"
+
+#: ../src/generic/fdrepdlg.cpp:156
+msgid "Search direction"
+msgstr "検索の方向"
+
+#: ../src/generic/fdrepdlg.cpp:175
+msgid "&Replace"
+msgstr "置換(&R)"
+
+#: ../src/generic/fdrepdlg.cpp:178
+msgid "Replace &all"
+msgstr "すべて置換(&A)"
+
+#: ../src/generic/filectrlg.cpp:246 ../src/generic/filectrlg.cpp:269
+msgid "<DIR>"
+msgstr "<ディレクトリ>"
+
+#: ../src/generic/filectrlg.cpp:248 ../src/generic/filectrlg.cpp:271
+msgid "<LINK>"
+msgstr "<リンク>"
+
+#: ../src/generic/filectrlg.cpp:250 ../src/generic/filectrlg.cpp:273
+msgid "<DRIVE>"
+msgstr "<ドライブ>"
+
+#: ../src/generic/filectrlg.cpp:275
+#, c-format
+msgid "%ld byte"
+msgid_plural "%ld bytes"
+msgstr[0] "%ld バイト"
+
+#: ../src/generic/filectrlg.cpp:420
+msgid "Name"
+msgstr "名前"
+
+#: ../src/generic/filectrlg.cpp:421 ../src/richtext/richtextformatdlg.cpp:361
+#: ../src/richtext/richtextsizepage.cpp:298
+msgid "Size"
+msgstr "大きさ"
+
+#: ../src/generic/filectrlg.cpp:422
+msgid "Type"
+msgstr "種類"
+
+#: ../src/generic/filectrlg.cpp:423
+msgid "Modified"
+msgstr "更新"
+
+#: ../src/generic/filectrlg.cpp:426
+msgid "Permissions"
+msgstr "パーミッション"
+
+#: ../src/generic/filectrlg.cpp:429
+msgid "Attributes"
+msgstr "属性"
+
+#: ../src/generic/filectrlg.cpp:936
+msgid "Current directory:"
+msgstr "カレントディレクトリ:"
+
+#: ../src/generic/filectrlg.cpp:979
+msgid "Show &hidden files"
+msgstr "隠しファイルを表示する(&H)"
+
+#: ../src/generic/filectrlg.cpp:1355
+msgid "Illegal file specification."
+msgstr "ファイル記述子が不正です。"
+
+#: ../src/generic/filectrlg.cpp:1387
+msgid "Directory doesn't exist."
+msgstr "ディレクトリが存在しません。"
+
+#: ../src/generic/filedlgg.cpp:195
+msgid "View files as a list view"
+msgstr "リスト形式でファイル一覧を見る"
+
+#: ../src/generic/filedlgg.cpp:197
+msgid "View files as a detailed view"
+msgstr "詳細情報付きでファイル一覧を見る"
+
+#: ../src/generic/filedlgg.cpp:200
+msgid "Go to parent directory"
+msgstr "親ディレクトリへ移動"
+
+#: ../src/generic/filedlgg.cpp:351 ../src/gtk/filedlg.cpp:59
+#, c-format
+msgid "File '%s' already exists, do you really want to overwrite it?"
+msgstr "ファイル %s はすでに存在します。上書きしてよろしいですか?"
+
+#: ../src/generic/filedlgg.cpp:354 ../src/gtk/filedlg.cpp:62
+msgid "Confirm"
+msgstr "確定"
+
+#: ../src/generic/filedlgg.cpp:362 ../src/gtk/filedlg.cpp:75
+msgid "Please choose an existing file."
+msgstr "存在するファイルを選んでください。"
+
+#: ../src/generic/filepickerg.cpp:64
+msgid "..."
+msgstr ""
+
+#: ../src/generic/fontdlgg.cpp:76 ../src/richtext/richtextformatdlg.cpp:519
+msgid "ABCDEFGabcdefg12345"
+msgstr "ABCDEFGabcdefg12345"
+
+#: ../src/generic/fontdlgg.cpp:315
+msgid "Roman"
+msgstr "Roman"
+
+#: ../src/generic/fontdlgg.cpp:316
+msgid "Decorative"
+msgstr "Decorative"
+
+#: ../src/generic/fontdlgg.cpp:317
+msgid "Modern"
+msgstr "Modern"
+
+#: ../src/generic/fontdlgg.cpp:318
+msgid "Script"
+msgstr "Script"
+
+#: ../src/generic/fontdlgg.cpp:319
+msgid "Swiss"
+msgstr "Swiss"
+
+#: ../src/generic/fontdlgg.cpp:320
+msgid "Teletype"
+msgstr "Teletype"
+
+#: ../src/generic/fontdlgg.cpp:321 ../src/generic/fontdlgg.cpp:324
+msgid "Normal"
+msgstr "通常"
+
+#: ../src/generic/fontdlgg.cpp:323
+msgid "Slant"
+msgstr "斜体"
+
+#: ../src/generic/fontdlgg.cpp:325
+msgid "Light"
+msgstr "軽量"
+
+#: ../src/generic/fontdlgg.cpp:363
+msgid "&Font family:"
+msgstr "フォントファミリー(&F):"
+
+#: ../src/generic/fontdlgg.cpp:367 ../src/generic/fontdlgg.cpp:369
+msgid "The font family."
+msgstr "フォントのファミリーを指定できます。"
+
+#: ../src/generic/fontdlgg.cpp:374 ../src/richtext/richtextstylepage.cpp:105
+msgid "&Style:"
+msgstr "スタイル(&S):"
+
+#: ../src/generic/fontdlgg.cpp:378 ../src/generic/fontdlgg.cpp:380
+msgid "The font style."
+msgstr "フォントのスタイルを指定できます。"
+
+#: ../src/generic/fontdlgg.cpp:385
+msgid "&Weight:"
+msgstr "ウエイト(&W):"
+
+#: ../src/generic/fontdlgg.cpp:389 ../src/generic/fontdlgg.cpp:391
+msgid "The font weight."
+msgstr "フォントのウエイトを指定できます。"
+
+#: ../src/generic/fontdlgg.cpp:399
+msgid "C&olour:"
+msgstr "色(&C):"
+
+#: ../src/generic/fontdlgg.cpp:407 ../src/generic/fontdlgg.cpp:409
+msgid "The font colour."
+msgstr "フォントの色を指定できます。"
+
+#: ../src/generic/fontdlgg.cpp:415
+msgid "&Point size:"
+msgstr "ポイントサイズ(&P):"
+
+#: ../src/generic/fontdlgg.cpp:420 ../src/generic/fontdlgg.cpp:422
+#: ../src/generic/fontdlgg.cpp:426 ../src/generic/fontdlgg.cpp:428
+msgid "The font point size."
+msgstr "フォントの大きさをポイントで記します。"
+
+#: ../src/generic/fontdlgg.cpp:439 ../src/generic/fontdlgg.cpp:441
+msgid "Whether the font is underlined."
+msgstr "フォントに下線が付くかどうか。"
+
+#: ../src/generic/fontdlgg.cpp:448 ../src/html/helpwnd.cpp:1215
+msgid "Preview:"
+msgstr "プレビュー:"
+
+#: ../src/generic/fontdlgg.cpp:452 ../src/generic/fontdlgg.cpp:454
+msgid "Shows the font preview."
+msgstr "フォントのプレビューを表示します。"
+
+#: ../src/generic/fontdlgg.cpp:464 ../src/generic/fontdlgg.cpp:483
+msgid "Click to cancel the font selection."
+msgstr "クリックでフォントの選択をキャンセルします。"
+
+#: ../src/generic/fontdlgg.cpp:469 ../src/generic/fontdlgg.cpp:471
+#: ../src/generic/fontdlgg.cpp:476 ../src/generic/fontdlgg.cpp:478
+msgid "Click to confirm the font selection."
+msgstr "クリックでフォントの選択を確定します。"
+
+#: ../src/generic/fontpickerg.cpp:50 ../src/gtk/fontdlg.cpp:77
+msgid "Choose font"
+msgstr "フォントを選んでください"
+
+#: ../src/generic/grid.cpp:6542
+msgid ""
+"Error copying grid to the clipboard. Either selected cells were not "
+"contiguous or no cell was selected."
+msgstr ""
+
+#: ../src/generic/grid.cpp:12739
+msgid "Grid Corner"
+msgstr ""
+
+#: ../src/generic/grid.cpp:12741
+#, c-format
+msgid "Column %s Header"
+msgstr ""
+
+#: ../src/generic/grid.cpp:12743
+#, c-format
+msgid "Row %s Header"
+msgstr ""
+
+#: ../src/generic/grid.cpp:12745
+#, c-format
+msgid "Column %s: %s"
+msgstr ""
+
+#: ../src/generic/grid.cpp:12749
+#, fuzzy, c-format
+msgid "Row %s: %s"
+msgstr "\t%s: %s\n"
+
+#: ../src/generic/grid.cpp:12753
+#, c-format
+msgid "Row %s, Column %s: %s"
+msgstr ""
+
+#: ../src/generic/helpext.cpp:257
+#, c-format
+msgid "Help directory \"%s\" not found."
+msgstr "ヘルプディレクトリ \"%s\" が見つかりません。"
+
+#: ../src/generic/helpext.cpp:265
+#, c-format
+msgid "Help file \"%s\" not found."
+msgstr "ヘルプファイル \"%s\" が見つかりません。"
+
+#: ../src/generic/helpext.cpp:284
+#, c-format
+msgid "Line %lu of map file \"%s\" has invalid syntax, skipped."
+msgstr ""
+"%lu 行目 (マップファイル \"%s\" ) に文法不適合がありました。無視します。"
+
+#: ../src/generic/helpext.cpp:292
+#, c-format
+msgid "No valid mappings found in the file \"%s\"."
+msgstr "ファイル \"%s\" には適切なマップが含まれていません。"
+
+#: ../src/generic/helpext.cpp:435
+msgid "No entries found."
+msgstr "項目が見つかりません。"
+
+#: ../src/generic/helpext.cpp:444 ../src/generic/helpext.cpp:445
+msgid "Help Index"
+msgstr "ヘルプの索引"
+
+#: ../src/generic/helpext.cpp:448
+msgid "Relevant entries:"
+msgstr "関連項目:"
+
+#: ../src/generic/helpext.cpp:449
+msgid "Entries found"
+msgstr "候補が見つかりました"
+
+#: ../src/generic/hyperlinkg.cpp:170
+msgid "&Copy URL"
+msgstr "URLをコピー(&C)"
+
+#: ../src/generic/infobar.cpp:119
+msgid "Hide this notification message."
+msgstr "この通知メッセージを隠します。"
+
+#. TRANSLATORS: %s will be either the application name or "Application"
+#: ../src/generic/logg.cpp:257
+#, c-format
+msgid "%s Error"
+msgstr "%s エラー"
+
+#. TRANSLATORS: %s will be either the application name or "Application"
+#: ../src/generic/logg.cpp:263
+#, c-format
+msgid "%s Warning"
+msgstr "%s 警告"
+
+#. TRANSLATORS: %s will be either the application name or "Application"
+#: ../src/generic/logg.cpp:273
+#, c-format
+msgid "%s Information"
+msgstr "%s 情報"
+
+#: ../src/generic/logg.cpp:276
+msgid "Application"
+msgstr "アプリケーション"
+
+#: ../src/generic/logg.cpp:549
+msgid "Save log contents to file"
+msgstr "ログの内容をファイルに保存します"
+
+#: ../src/generic/logg.cpp:551
+msgid "C&lear"
+msgstr "消去(&L)"
+
+#: ../src/generic/logg.cpp:551
+msgid "Clear the log contents"
+msgstr "ログの内容を消去します"
+
+#: ../src/generic/logg.cpp:553
+msgid "Close this window"
+msgstr "このウィンドウを閉じます"
+
+#: ../src/generic/logg.cpp:554
+msgid "&Log"
+msgstr "ログ(&L)"
+
+#: ../src/generic/logg.cpp:610 ../src/generic/logg.cpp:992
+msgid "Can't save log contents to file."
+msgstr "ログの内容をファイルに保存できませんでした。"
+
+#: ../src/generic/logg.cpp:613
+#, c-format
+msgid "Log saved to the file '%s'."
+msgstr "ファイル '%s' にログを保存しました。"
+
+#: ../src/generic/logg.cpp:719
+msgid "&Details"
+msgstr "詳細(&D)"
+
+#: ../src/generic/logg.cpp:972
+msgid "Failed to copy dialog contents to the clipboard."
+msgstr "ダイアログの内容をクリップボードにコピーできませんでした。"
+
+#: ../src/generic/logg.cpp:1022
+#, c-format
+msgid "Append log to file '%s' (choosing [No] will overwrite it)?"
+msgstr ""
+"ログをファイル '%s' に追加しますか? [いいえ]を選択すると再作成で上書きしま"
+"す。"
+
+#: ../src/generic/logg.cpp:1024
+msgid "Question"
+msgstr "確認"
+
+#: ../src/generic/logg.cpp:1038
+msgid "invalid message box return value"
+msgstr "メッセージボックスの戻り値が不正です"
+
+#: ../src/generic/notifmsgg.cpp:129
+msgid "Notice"
+msgstr "お知らせ"
+
+#: ../src/generic/preferencesg.cpp:118
+#, c-format
+msgid "%s Preferences"
+msgstr "%s の設定"
+
+#: ../src/generic/printps.cpp:143
+msgid "Printing..."
+msgstr "印刷中 ..."
+
+#: ../src/generic/printps.cpp:160 ../src/gtk/print.cpp:1076
+#: ../src/msw/printwin.cpp:235
+msgid "Could not start printing."
+msgstr "印刷を始められませんでした。"
+
+#: ../src/generic/printps.cpp:183
+#, c-format
+msgid "Printing page %d..."
+msgstr "%d ページを印刷中 ..."
+
+#: ../src/generic/prntdlgg.cpp:171
+msgid "Printer options"
+msgstr "プリンターのオプション"
+
+#: ../src/generic/prntdlgg.cpp:176
+msgid "Print to File"
+msgstr "ファイルへ印刷"
+
+#: ../src/generic/prntdlgg.cpp:179
+msgid "Setup..."
+msgstr "設定 ..."
+
+#: ../src/generic/prntdlgg.cpp:187
+msgid "Printer:"
+msgstr "プリンター:"
+
+#: ../src/generic/prntdlgg.cpp:195
+msgid "Status:"
+msgstr "状態:"
+
+#: ../src/generic/prntdlgg.cpp:206
+msgid "All"
+msgstr "すべて"
+
+#: ../src/generic/prntdlgg.cpp:207
+msgid "Pages"
+msgstr "指定"
+
+#: ../src/generic/prntdlgg.cpp:215
+msgid "Print Range"
+msgstr "印刷範囲"
+
+#: ../src/generic/prntdlgg.cpp:229
+msgid "From:"
+msgstr "開始ページ:"
+
+#: ../src/generic/prntdlgg.cpp:233
+msgid "To:"
+msgstr "末尾ページ:"
+
+#: ../src/generic/prntdlgg.cpp:238
+msgid "Copies:"
+msgstr "部数:"
+
+#: ../src/generic/prntdlgg.cpp:288
+msgid "PostScript file"
+msgstr "PostScript ファイル"
+
+#: ../src/generic/prntdlgg.cpp:439
+msgid "Print Setup"
+msgstr "印刷設定"
+
+#: ../src/generic/prntdlgg.cpp:483
+msgid "Printer"
+msgstr "プリンター"
+
+#: ../src/generic/prntdlgg.cpp:501
+msgid "Default printer"
+msgstr "既定のプリンター"
+
+#: ../src/generic/prntdlgg.cpp:595 ../src/generic/prntdlgg.cpp:782
+#: ../src/generic/prntdlgg.cpp:822 ../src/generic/prntdlgg.cpp:835
+#: ../src/generic/prntdlgg.cpp:1031 ../src/generic/prntdlgg.cpp:1036
+msgid "Paper size"
+msgstr "用紙サイズ"
+
+#: ../src/generic/prntdlgg.cpp:604 ../src/generic/prntdlgg.cpp:847
+msgid "Portrait"
+msgstr "縦置き"
+
+#: ../src/generic/prntdlgg.cpp:605 ../src/generic/prntdlgg.cpp:848
+msgid "Landscape"
+msgstr "横置き"
+
+#: ../src/generic/prntdlgg.cpp:607 ../src/generic/prntdlgg.cpp:849
+msgid "Orientation"
+msgstr "向き"
+
+#: ../src/generic/prntdlgg.cpp:610
+msgid "Options"
+msgstr "オプション"
+
+#: ../src/generic/prntdlgg.cpp:612
+msgid "Print in colour"
+msgstr "カラー印刷"
+
+#: ../src/generic/prntdlgg.cpp:621
+msgid "Print spooling"
+msgstr "印刷予約設定"
+
+#: ../src/generic/prntdlgg.cpp:623
+msgid "Printer command:"
+msgstr "プリンターへのコマンド:"
+
+#: ../src/generic/prntdlgg.cpp:631
+msgid "Printer options:"
+msgstr "プリンターのオプション:"
+
+#: ../src/generic/prntdlgg.cpp:860
+msgid "Left margin (mm):"
+msgstr "余白-左 (mm):"
+
+#: ../src/generic/prntdlgg.cpp:861
+msgid "Top margin (mm):"
+msgstr "余白-天 (mm):"
+
+#: ../src/generic/prntdlgg.cpp:872
+msgid "Right margin (mm):"
+msgstr "余白-右 (mm):"
+
+#: ../src/generic/prntdlgg.cpp:873
+msgid "Bottom margin (mm):"
+msgstr "余白-地 (mm):"
+
+#: ../src/generic/prntdlgg.cpp:896
+msgid "Printer..."
+msgstr "プリンター ..."
+
+#: ../src/generic/progdlgg.cpp:246
+msgid "&Skip"
+msgstr "スキップ(&S)"
+
+#: ../src/generic/progdlgg.cpp:347 ../src/generic/progdlgg.cpp:626
+msgid "Unknown"
+msgstr "不明"
+
+#: ../src/generic/progdlgg.cpp:451 ../src/msw/progdlg.cpp:526
+msgid "Done."
+msgstr "完了しました。"
+
+#: ../src/generic/srchctlg.cpp:55 ../src/gtk/srchctrl.cpp:206
+#: ../src/html/helpwnd.cpp:530 ../src/html/helpwnd.cpp:545
+msgid "Search"
+msgstr "検索"
+
+#: ../src/generic/tabg.cpp:1026
+msgid "Could not find tab for id"
+msgstr "識別子に対応したタブが見つかりませんでした"
+
+#: ../src/generic/tipdlg.cpp:136
+msgid "Tips not available, sorry!"
+msgstr "ヒントは利用できません、申し訳ありません。"
+
+#: ../src/generic/tipdlg.cpp:197
+msgid "Tip of the Day"
+msgstr "今日のヒント"
+
+#: ../src/generic/tipdlg.cpp:207
+msgid "Did you know..."
+msgstr "ご存じですか?"
+
+#: ../src/generic/tipdlg.cpp:232
+msgid "&Show tips at startup"
+msgstr "ヒントを起動時に表示(&S)"
+
+#: ../src/generic/tipdlg.cpp:236
+msgid "&Next Tip"
+msgstr "次のヒント(&N)"
+
+#: ../src/generic/wizard.cpp:411
+msgid "&Next >"
+msgstr "次へ(&N) >"
+
+#: ../src/generic/wizard.cpp:412
+msgid "&Finish"
+msgstr "完了(&F)"
+
+#: ../src/generic/wizard.cpp:420
+msgid "< &Back"
+msgstr "< 戻る(&B)"
+
+#: ../src/gtk/aboutdlg.cpp:204
+msgid "translator-credits"
+msgstr ""
+"James Bishop\n"
+"Hiroshi Saito\n"
+"Taishin Kin\n"
+"かばだんなさん\n"
+"kaba\n"
+"Suzumizaki-Kimitaka(鈴見咲君高)\n"
+"Ryo Nakano"
+
+#: ../src/gtk/app.cpp:517
+msgid ""
+"WARNING: using XIM input method is unsupported and may result in problems "
+"with input handling and flickering. Consider unsetting GTK_IM_MODULE or "
+"setting to \"ibus\"."
+msgstr ""
+
+#: ../src/gtk/app.cpp:569
+msgid "Unable to initialize GTK+, is DISPLAY set properly?"
+msgstr "GTK+を初期化できません。 DISPLAY が不適切の可能性があります。"
+
+#: ../src/gtk/filedlg.cpp:89 ../src/gtk/filepicker.cpp:255
+#, c-format
+msgid "Changing current directory to \"%s\" failed"
+msgstr "カレントディレクトリを \"%s\" に変更できませんでした"
+
+#: ../src/gtk/font.cpp:548
+msgid ""
+"Using private fonts is not supported on this system: Pango library is too "
+"old, 1.38 or later required."
+msgstr ""
+
+#: ../src/gtk/font.cpp:558
+#, fuzzy
+msgid "Failed to create font configuration object."
+msgstr "ユーザー設定ファイルを更新できませんでした。"
+
+#: ../src/gtk/font.cpp:568
+#, fuzzy, c-format
+msgid "Failed to add custom font \"%s\"."
+msgstr "ファイル \"%s\" から文書を読み取れませんでした。"
+
+#: ../src/gtk/font.cpp:576
+#, fuzzy
+msgid "Failed to register font configuration using private fonts."
+msgstr "ユーザー設定ファイルを更新できませんでした。"
+
+#: ../src/gtk/glcanvas.cpp:117 ../src/gtk/glcanvas.cpp:132
+#, fuzzy
+msgid "Fatal Error"
+msgstr "重大なエラー"
+
+#: ../src/gtk/glcanvas.cpp:117
+msgid ""
+"This program wasn't compiled with EGL support required under Wayland, "
+"either\n"
+"install EGL libraries and rebuild or run it under X11 backend by setting\n"
+"environment variable GDK_BACKEND=x11 before starting your program."
+msgstr ""
+
+#: ../src/gtk/glcanvas.cpp:132
+msgid ""
+"wxGLCanvas is only supported on Wayland and X11 currently.  You may be able "
+"to\n"
+"work around this by setting environment variable GDK_BACKEND=x11 before\n"
+"starting your program."
+msgstr ""
+
+#: ../src/gtk/mdi.cpp:433
+msgid "MDI child"
+msgstr "MDI子ウィンドウ"
+
+#: ../src/gtk/power.cpp:188
+#, fuzzy, c-format
+msgid "Failed to open D-Bus connection to the login manager: %s"
+msgstr "セッションマネージャへの接続に失敗しました: %s"
+
+#: ../src/gtk/power.cpp:214
+#, fuzzy
+msgid "wxWidgets application"
+msgstr "アプリケーションを非表示"
+
+#: ../src/gtk/power.cpp:226
+msgid "Application needs to keep running"
+msgstr ""
+
+#: ../src/gtk/power.cpp:233
+msgid "Clean up before suspend"
+msgstr ""
+
+#: ../src/gtk/power.cpp:259
+#, fuzzy, c-format
+msgid "Failed to inhibit sleep: %s"
+msgstr "ダイヤルアップ接続の初期化に失敗しました: %s"
+
+#: ../src/gtk/power.cpp:265
+msgid "Unexpected response to D-Bus \"Inhibit\" request."
+msgstr ""
+
+#: ../src/gtk/print.cpp:218
+msgid "Custom size"
+msgstr "任意の寸法指定"
+
+#: ../src/gtk/print.cpp:752
+#, fuzzy, c-format
+msgid "Error while printing: %s"
+msgstr "印刷中にエラーが発生しました: "
+
+#: ../src/gtk/print.cpp:816
+msgid "Page Setup"
+msgstr "ページの設定"
+
+#: ../src/gtk/webview_webkit.cpp:932
+msgid "Retrieving JavaScript script output is not supported with WebKit v1"
+msgstr ""
+
+#: ../src/gtk/webview_webkit2.cpp:1098
+msgid ""
+"Setting proxy is not supported by WebKit, at least version 2.16 is required."
+msgstr ""
+
+#: ../src/gtk/webview_webkit2.cpp:1104
+msgid "This program was compiled without support for setting WebKit proxy."
+msgstr ""
+
+#: ../src/gtk/window.cpp:6289
+msgid ""
+"GTK+ installed on this machine is too old to support screen compositing, "
+"please install GTK+ 2.12 or later."
+msgstr ""
+
+#: ../src/gtk/window.cpp:6307
+msgid ""
+"Compositing not supported by this system, please enable it in your Window "
+"Manager."
+msgstr ""
+
+#: ../src/gtk/window.cpp:6318
+msgid ""
+"This program was compiled with a too old version of GTK+, please rebuild "
+"with GTK+ 2.12 or newer."
+msgstr ""
+
+#: ../src/html/chm.cpp:138
+#, c-format
+msgid "Failed to open CHM archive '%s'."
+msgstr "CHM 書庫 '%s' を開くことができませんでした。"
+
+#: ../src/html/chm.cpp:270
+#, c-format
+msgid "Could not extract %s into %s: %s"
+msgstr "%s を %s に展開できませんでした: %s"
+
+#: ../src/html/chm.cpp:324
+msgid "no error"
+msgstr "エラーなし"
+
+#: ../src/html/chm.cpp:326
+msgid "bad arguments to library function"
+msgstr "ライブラリ関数への引数に問題があります"
+
+#: ../src/html/chm.cpp:328
+msgid "error opening file"
+msgstr "ファイルを開く際にエラーが発生しました"
+
+#: ../src/html/chm.cpp:330
+msgid "read error"
+msgstr "読み取りエラー"
+
+#: ../src/html/chm.cpp:332
+msgid "write error"
+msgstr "書き出しエラー"
+
+#: ../src/html/chm.cpp:334
+msgid "seek error"
+msgstr "シークエラー"
+
+#: ../src/html/chm.cpp:338
+msgid "bad signature"
+msgstr "未対応の識別文字です"
+
+#: ../src/html/chm.cpp:340
+msgid "error in data format"
+msgstr "データ書式のエラー"
+
+#: ../src/html/chm.cpp:342
+msgid "checksum error"
+msgstr "チェックサムエラー"
+
+#: ../src/html/chm.cpp:344
+msgid "compression error"
+msgstr "圧縮エラー"
+
+#: ../src/html/chm.cpp:346
+msgid "decompression error"
+msgstr "展開エラー"
+
+#: ../src/html/chm.cpp:437
+#, c-format
+msgid "Could not locate file '%s'."
+msgstr "ファイル '%s' の場所を特定できません。"
+
+#: ../src/html/chm.cpp:711
+#, c-format
+msgid "Could not create temporary file '%s'"
+msgstr "一時ファイル '%s' を作成できませんでした"
+
+#: ../src/html/chm.cpp:718
+#, c-format
+msgid "Extraction of '%s' into '%s' failed."
+msgstr "'%s' を '%s' に展開できませんでした。"
+
+#: ../src/html/chm.cpp:806 ../src/html/chm.cpp:863
+msgid "CHM handler currently supports only local files!"
+msgstr "CHM ハンドラーは現在ローカルファイルのみに対応しています。"
+
+#: ../src/html/chm.cpp:827
+msgid "Link contained '//', converted to absolute link."
+msgstr "リンクは '//' を含んでいます。絶対パスリンクに変換しました。"
+
+#: ../src/html/helpctrl.cpp:59
+#, c-format
+msgid "Help: %s"
+msgstr "ヘルプ: %s"
+
+#: ../src/html/helpctrl.cpp:155
+#, c-format
+msgid "Adding book %s"
+msgstr "ブック %s を追加しています"
+
+#: ../src/html/helpdata.cpp:295
+#, c-format
+msgid "Cannot open contents file: %s"
+msgstr "目次ファイルを開くことができません: %s"
+
+#: ../src/html/helpdata.cpp:309
+#, c-format
+msgid "Cannot open index file: %s"
+msgstr "索引ファイルを開くことができません: %s"
+
+#: ../src/html/helpdata.cpp:643
+msgid "noname"
+msgstr "名称未設定"
+
+#: ../src/html/helpdata.cpp:652
+#, c-format
+msgid "Cannot open HTML help book: %s"
+msgstr "HTMLヘルプブックを開くことができません: %s"
+
+#: ../src/html/helpwnd.cpp:315
+msgid "Displays help as you browse the books on the left."
+msgstr "横に置く本のようにヘルプを表示します。"
+
+#: ../src/html/helpwnd.cpp:411 ../src/html/helpwnd.cpp:1100
+#: ../src/html/helpwnd.cpp:1735
+msgid "(bookmarks)"
+msgstr "(ブックマーク)"
+
+#: ../src/html/helpwnd.cpp:424
+msgid "Add current page to bookmarks"
+msgstr "現在のページをブックマークに追加します"
+
+#: ../src/html/helpwnd.cpp:425
+msgid "Remove current page from bookmarks"
+msgstr "ブックマークから現在のページを削除します"
+
+#: ../src/html/helpwnd.cpp:470
+msgid "Contents"
+msgstr "目次"
+
+#: ../src/html/helpwnd.cpp:485
+msgid "Find"
+msgstr "検索"
+
+#: ../src/html/helpwnd.cpp:487
+msgid "Show all"
+msgstr "すべて表示"
+
+#: ../src/html/helpwnd.cpp:497
+msgid ""
+"Display all index items that contain given substring. Search is case "
+"insensitive."
+msgstr ""
+"与えられた文字列を含む索引項目を表示します。大文字小文字は区別しません。"
+
+#: ../src/html/helpwnd.cpp:498
+msgid "Show all items in index"
+msgstr "索引に全項目を表示します"
+
+#: ../src/html/helpwnd.cpp:528
+msgid "Case sensitive"
+msgstr "大文字小文字を区別"
+
+#: ../src/html/helpwnd.cpp:529
+msgid "Whole words only"
+msgstr "全体一致のみ"
+
+#: ../src/html/helpwnd.cpp:532
+msgid ""
+"Search contents of help book(s) for all occurrences of the text you typed "
+"above"
+msgstr "上で入力したテキストがある部分をヘルプブックの全体に渡って検索します"
+
+#: ../src/html/helpwnd.cpp:653
+msgid "Show/hide navigation panel"
+msgstr "ナビゲーションパネルの表示/非表示を切り替えます"
+
+#: ../src/html/helpwnd.cpp:655
+msgid "Go back"
+msgstr "戻る"
+
+#: ../src/html/helpwnd.cpp:656
+msgid "Go forward"
+msgstr "進む"
+
+#: ../src/html/helpwnd.cpp:658
+msgid "Go one level up in document hierarchy"
+msgstr "文書構造のひとつ上へ"
+
+#: ../src/html/helpwnd.cpp:666 ../src/html/helpwnd.cpp:1547
+msgid "Open HTML document"
+msgstr "HTML文書を開く"
+
+#: ../src/html/helpwnd.cpp:670
+msgid "Print this page"
+msgstr "このページを印刷"
+
+#: ../src/html/helpwnd.cpp:674
+msgid "Display options dialog"
+msgstr "オプションダイアログを表示します"
+
+#: ../src/html/helpwnd.cpp:795
+msgid "Please choose the page to display:"
+msgstr "表示するページを選んでください:"
+
+#: ../src/html/helpwnd.cpp:796
+msgid "Help Topics"
+msgstr "ヘルプトピック"
+
+#: ../src/html/helpwnd.cpp:852
+msgid "Searching..."
+msgstr "検索中..."
+
+#: ../src/html/helpwnd.cpp:853
+msgid "No matching page found yet"
+msgstr "一致するページがまだありません"
+
+#: ../src/html/helpwnd.cpp:870
+#, c-format
+msgid "Found %i matches"
+msgstr "%i 件の該当部を発見"
+
+#: ../src/html/helpwnd.cpp:958
+msgid "(Help)"
+msgstr "(ヘルプ)"
+
+#: ../src/html/helpwnd.cpp:1026
+#, fuzzy, c-format
+msgid "%d of %lu"
+msgstr "%i / %i"
+
+#: ../src/html/helpwnd.cpp:1028
+#, fuzzy, c-format
+msgid "%lu of %lu"
+msgstr "%i / %i"
+
+#: ../src/html/helpwnd.cpp:1047
+msgid "Search in all books"
+msgstr "すべてのブックを検索"
+
+#: ../src/html/helpwnd.cpp:1193
+msgid "Help Browser Options"
+msgstr "ヘルプブラウザのオプション"
+
+#: ../src/html/helpwnd.cpp:1198
+msgid "Normal font:"
+msgstr "通常のフォント:"
+
+#: ../src/html/helpwnd.cpp:1199
+msgid "Fixed font:"
+msgstr "固定幅フォント:"
+
+#: ../src/html/helpwnd.cpp:1200
+msgid "Font size:"
+msgstr "フォントの大きさ:"
+
+#: ../src/html/helpwnd.cpp:1245
+msgid "font size"
+msgstr "フォントの大きさ"
+
+#: ../src/html/helpwnd.cpp:1256
+msgid "Normal face<br>and <u>underlined</u>. "
+msgstr "通常<br> と <u>下線付き</u>。 "
+
+#: ../src/html/helpwnd.cpp:1257
+msgid "<i>Italic face.</i> "
+msgstr "<i>イタリック体。</i> "
+
+#: ../src/html/helpwnd.cpp:1258
+msgid "<b>Bold face.</b> "
+msgstr "<b>太字。</b> "
+
+#: ../src/html/helpwnd.cpp:1259
+msgid "<b><i>Bold italic face.</i></b><br>"
+msgstr "<b><i>太字でイタリック体。</i></b><br>"
+
+#: ../src/html/helpwnd.cpp:1262
+msgid "Fixed size face.<br> <b>bold</b> <i>italic</i> "
+msgstr "固定幅。<br> <b>太字</b><i>イタリック</i> "
+
+#: ../src/html/helpwnd.cpp:1263
+msgid "<b><i>bold italic <u>underlined</u></i></b><br>"
+msgstr "<b><i>太字でイタリック体 <u>下線</u></i></b><br>"
+
+#: ../src/html/helpwnd.cpp:1524
+msgid "Help Printing"
+msgstr "ヘルプの印刷"
+
+#: ../src/html/helpwnd.cpp:1527
+msgid "Cannot print empty page."
+msgstr "空のページは印刷できません。"
+
+#: ../src/html/helpwnd.cpp:1540
+msgid "HTML files (*.html;*.htm)|*.html;*.htm|"
+msgstr "HTML ファイル (*.html;*.htm)|*.html;*.htm|"
+
+#: ../src/html/helpwnd.cpp:1541
+msgid "Help books (*.htb)|*.htb|Help books (*.zip)|*.zip|"
+msgstr "ヘルプブック (*.htb)|*.htb|ヘルプブック (*.zip)|*.zip|"
+
+#: ../src/html/helpwnd.cpp:1542
+msgid "HTML Help Project (*.hhp)|*.hhp|"
+msgstr "HTMLヘルププロジェクト (*.hhp)|*.hhp|"
+
+#: ../src/html/helpwnd.cpp:1544
+msgid "Compressed HTML Help file (*.chm)|*.chm|"
+msgstr "圧縮HTMLヘルプ (*.chm)|*.chm|"
+
+#: ../src/html/helpwnd.cpp:1671
+#, fuzzy, c-format
+msgid "%i of %u"
+msgstr "%i / %i"
+
+#: ../src/html/helpwnd.cpp:1709
+#, fuzzy, c-format
+msgid "%u of %u"
+msgstr "%i / %i"
+
+#: ../src/html/htmlfilt.cpp:134
+#, c-format
+msgid "Cannot open HTML document: %s"
+msgstr "HTML文書を開くことができません: %s"
+
+#: ../src/html/htmlwin.cpp:599
+msgid "Connecting..."
+msgstr "接続中 ..."
+
+#: ../src/html/htmlwin.cpp:616
+#, c-format
+msgid "Unable to open requested HTML document: %s"
+msgstr "要求されたHTML文書を開くことができません: %s"
+
+#: ../src/html/htmlwin.cpp:630
+msgid "Loading : "
+msgstr "読み取り中 : "
+
+#: ../src/html/htmlwin.cpp:673
+msgid "Done"
+msgstr "完了"
+
+#: ../src/html/htmlwin.cpp:723
+#, c-format
+msgid "HTML anchor %s does not exist."
+msgstr "HTMLアンカー %s は存在しません。"
+
+#: ../src/html/htmlwin.cpp:1057
+#, c-format
+msgid "Copied to clipboard:\"%s\""
+msgstr "クリップボードへコピー:\"%s\""
+
+#: ../src/html/htmprint.cpp:269
+msgid ""
+"This document doesn't fit on the page horizontally and will be truncated "
+"when it is printed."
+msgstr ""
+"この文書はページの水平方向にあわせることができません。印刷すると切り詰められ"
+"ます。"
+
+#: ../src/html/htmprint.cpp:285
+#, c-format
+msgid ""
+"The document \"%s\" doesn't fit on the page horizontally and will be "
+"truncated if printed.\n"
+"\n"
+"Would you like to proceed with printing it nevertheless?"
+msgstr ""
+"文書 \"%s\" はページの水平方向にあわせることができません。印刷すると切り詰め"
+"られます。\n"
+"\n"
+"ご承知の上で印刷処理を進めますか?"
+
+#: ../src/html/htmprint.cpp:296
+msgid ""
+"If possible, try changing the layout parameters to make the printout more "
+"narrow."
+msgstr "出力結果がより狭い範囲に収まるように印刷設定値を変更してください。"
+
+#: ../src/html/htmprint.cpp:445
+msgid ": file does not exist!"
+msgstr ": ファイルがありません。"
+
+#. TRANSLATORS: %s may be a document title.
+#: ../src/html/htmprint.cpp:717
+#, fuzzy, c-format
+msgid "%s Preview"
+msgstr " プレビュー"
+
+#: ../src/html/htmprint.cpp:755 ../src/richtext/richtextprint.cpp:618
+msgid ""
+"There was a problem during page setup: you may need to set a default printer."
+msgstr ""
+"ページの準備中に問題が検出されました: 既定のプリンターが未指定なら指定してく"
+"ださい。"
+
+#: ../src/msw/clipbrd.cpp:80
+msgid "Failed to open the clipboard."
+msgstr "クリップボードを開くことができませんでした。"
+
+#: ../src/msw/clipbrd.cpp:101
+msgid "Failed to close the clipboard."
+msgstr "クリップボードを閉じることができませんでした。"
+
+#: ../src/msw/clipbrd.cpp:113
+msgid "Failed to empty the clipboard."
+msgstr "クリップボードを空にできませんでした。"
+
+#: ../src/msw/clipbrd.cpp:284
+msgid "Failed to put data on the clipboard"
+msgstr "データをクリップボードに置けませんでした"
+
+#: ../src/msw/clipbrd.cpp:326
+msgid "Failed to get data from the clipboard"
+msgstr "クリップボードからデータを取得できませんでした"
+
+#: ../src/msw/clipbrd.cpp:363
+msgid "Failed to retrieve the supported clipboard formats"
+msgstr "対応しているクリップボードの形式を取得できませんでした"
+
+#: ../src/msw/colordlg.cpp:228
+#, c-format
+msgid "Colour selection dialog failed with error %0lx."
+msgstr "色選択ダイアログがエラー %0lx で失敗しました。"
+
+#: ../src/msw/cursor.cpp:141
+msgid "Failed to create cursor."
+msgstr "カーソルを作成できませんでした。"
+
+#: ../src/msw/dde.cpp:279
+#, c-format
+msgid "Failed to register DDE server '%s'"
+msgstr "DDEサーバー '%s' を登録できませんでした。"
+
+#: ../src/msw/dde.cpp:300
+#, c-format
+msgid "Failed to unregister DDE server '%s'"
+msgstr "DDE サーバ '%s' の登録を削除できませんでした。"
+
+#: ../src/msw/dde.cpp:428
+#, c-format
+msgid "Failed to create connection to server '%s' on topic '%s'"
+msgstr "サーバー '%s' へのトピック '%s' 接続を確立できませんでした。"
+
+#: ../src/msw/dde.cpp:655
+msgid "DDE poke request failed"
+msgstr "DDE の poke 要求が失敗しました"
+
+#: ../src/msw/dde.cpp:674
+msgid "Failed to establish an advise loop with DDE server"
+msgstr "DDE サーバーとのアドバイスループを確立できませんでした"
+
+#: ../src/msw/dde.cpp:693
+msgid "Failed to terminate the advise loop with DDE server"
+msgstr "DDE サーバーとのアドバイスループを終了できませんでした"
+
+#: ../src/msw/dde.cpp:768
+msgid "Failed to send DDE advise notification"
+msgstr "DDE アドバイス通知を送信できませんでした"
+
+#: ../src/msw/dde.cpp:1085
+msgid "Failed to create DDE string"
+msgstr "DDE文字列を作成できませんでした"
+
+#: ../src/msw/dde.cpp:1131
+msgid "no DDE error."
+msgstr "DDE エラーはありませんでした。"
+
+#: ../src/msw/dde.cpp:1135
+msgid "a request for a synchronous advise transaction has timed out."
+msgstr "非同期 advise トランザクションの要求が時間切れになりました。"
+
+#: ../src/msw/dde.cpp:1138
+msgid "the response to the transaction caused the DDE_FBUSY bit to be set."
+msgstr "トランザクションへの応答が DDE_FBUSY ビットの設定を引き起こしました。"
+
+#: ../src/msw/dde.cpp:1141
+msgid "a request for a synchronous data transaction has timed out."
+msgstr "非同期 data トランザクションの要求が時間切れになりました。"
+
+#: ../src/msw/dde.cpp:1144
+msgid ""
+"a DDEML function was called without first calling the DdeInitialize "
+"function,\n"
+"or an invalid instance identifier\n"
+"was passed to a DDEML function."
+msgstr ""
+"DdeInitalize 関数より先に別の DDEML 関数が呼び出されたか、\n"
+"無効な実体識別子が DDEML 関数に渡されました。\n"
+"　"
+
+#: ../src/msw/dde.cpp:1147
+msgid ""
+"an application initialized as APPCLASS_MONITOR has\n"
+"attempted to perform a DDE transaction,\n"
+"or an application initialized as APPCMD_CLIENTONLY has \n"
+"attempted to perform server transactions."
+msgstr ""
+"APPCLASS_MONITOR として初期化されたアプリケーションが\n"
+"DDEトランザクションの実現を試みたか、\n"
+"APPCMD_CLIENTONLY で初期化されたものが\n"
+"サーバートランザクションの実現を試みようとしました。"
+
+#: ../src/msw/dde.cpp:1150
+msgid "a request for a synchronous execute transaction has timed out."
+msgstr "非同期 execute トランザクションの要求が時間切れになりました。"
+
+#: ../src/msw/dde.cpp:1153
+msgid "a parameter failed to be validated by the DDEML."
+msgstr "DDEML の評価により引数の失敗が検出されました。"
+
+#: ../src/msw/dde.cpp:1156
+msgid "a DDEML application has created a prolonged race condition."
+msgstr "DDEML アプリケーションが競合状態の延長として作成されています。"
+
+#: ../src/msw/dde.cpp:1159
+msgid "a memory allocation failed."
+msgstr "メモリ割り当てに失敗しました。"
+
+#: ../src/msw/dde.cpp:1162
+msgid "a client's attempt to establish a conversation has failed."
+msgstr "クライアントによる通信対話の確立が試みられましたが失敗しました。"
+
+#: ../src/msw/dde.cpp:1165
+msgid "a transaction failed."
+msgstr "トランザクションが失敗しました。"
+
+#: ../src/msw/dde.cpp:1168
+msgid "a request for a synchronous poke transaction has timed out."
+msgstr "非同期 poke トランザクションの要求が時間切れになりました。"
+
+#: ../src/msw/dde.cpp:1171
+msgid "an internal call to the PostMessage function has failed. "
+msgstr "PostMessage関数の内部呼び出しが失敗しました。 "
+
+#: ../src/msw/dde.cpp:1174
+msgid "reentrancy problem."
+msgstr "同期トランザクションが別の同期トランザクションを開始しようとしました。"
+
+#: ../src/msw/dde.cpp:1177
+msgid ""
+"a server-side transaction was attempted on a conversation\n"
+"that was terminated by the client, or the server\n"
+"terminated before completing a transaction."
+msgstr ""
+"サーバーサイドトランザクションが通信対話の確立を試みましたが\n"
+"クライアントによって終了されたかトランザクション成立前に\n"
+"終了してしまいました。"
+
+#: ../src/msw/dde.cpp:1180
+msgid "an internal error has occurred in the DDEML."
+msgstr "DDEMLの内部エラーが発生しました。"
+
+#: ../src/msw/dde.cpp:1183
+msgid "a request to end an advise transaction has timed out."
+msgstr "advise トランザクション終了の要求が時間切れになりました。"
+
+#: ../src/msw/dde.cpp:1186
+msgid ""
+"an invalid transaction identifier was passed to a DDEML function.\n"
+"Once the application has returned from an XTYP_XACT_COMPLETE callback,\n"
+"the transaction identifier for that callback is no longer valid."
+msgstr ""
+"不正なトランザクション識別子が DDEML 関数に渡されました。\n"
+"XTYP_XACT_COMPLETE コールバックで識別子を使った後復帰した\n"
+"アプリケーションはその識別子を以後の呼び出しで使うことができません。"
+
+#: ../src/msw/dde.cpp:1189
+#, c-format
+msgid "Unknown DDE error %08x"
+msgstr "想定外のDDE エラー 0x%08x"
+
+#: ../src/msw/dialup.cpp:343
+msgid ""
+"Dial up functions are unavailable because the remote access service (RAS) is "
+"not installed on this machine. Please install it."
+msgstr ""
+"リモートアクセスサービス(RAS)がインストールされていないため、ダイヤルアップは"
+"機能しません。RASをインストールしてください。"
+
+#: ../src/msw/dialup.cpp:402
+#, c-format
+msgid ""
+"The version of remote access service (RAS) installed on this machine is too "
+"old, please upgrade (the following required function is missing: %s)."
+msgstr ""
+"このコンピューターにインストールされているリモートアクセスサービス(RAS)は古す"
+"ぎるようです。新しいものを用意してください(機能 %s が必要です)。"
+
+#: ../src/msw/dialup.cpp:437
+msgid "Failed to retrieve text of RAS error message"
+msgstr "RAS エラーメッセージのテキストを取得できませんでした"
+
+#: ../src/msw/dialup.cpp:440
+#, c-format
+msgid "unknown error (error code %08x)."
+msgstr "想定外のエラーです (エラーコード 0x%08x)."
+
+#: ../src/msw/dialup.cpp:492
+#, c-format
+msgid "Cannot find active dialup connection: %s"
+msgstr "使用中のダイヤルアップ接続が見つかりません: %s"
+
+#: ../src/msw/dialup.cpp:513
+msgid "Several active dialup connections found, choosing one randomly."
+msgstr "複数のダイヤルアップ接続が有効です。乱数でひとつ選びます。"
+
+#: ../src/msw/dialup.cpp:598 ../src/msw/dialup.cpp:832
+#, c-format
+msgid "Failed to establish dialup connection: %s"
+msgstr "ダイヤルアップ接続を確立できませんでした: %s"
+
+#: ../src/msw/dialup.cpp:664
+#, c-format
+msgid "Failed to get ISP names: %s"
+msgstr "ISP名を取得できませんでした: %s"
+
+#: ../src/msw/dialup.cpp:712
+msgid "Failed to connect: no ISP to dial."
+msgstr "接続失敗: ダイヤル先のISPがありません。"
+
+#: ../src/msw/dialup.cpp:732
+msgid "Choose ISP to dial"
+msgstr "ダイヤル先のISPを選んでください"
+
+#: ../src/msw/dialup.cpp:733
+msgid "Please choose which ISP do you want to connect to"
+msgstr "接続したいISPを選んでください"
+
+#: ../src/msw/dialup.cpp:766
+msgid "Failed to connect: missing username/password."
+msgstr "接続に失敗: username/password が欠けています。"
+
+#: ../src/msw/dialup.cpp:796
+msgid "Cannot find the location of address book file"
+msgstr "住所録の位置を特定できません"
+
+#: ../src/msw/dialup.cpp:827
+#, c-format
+msgid "Failed to initiate dialup connection: %s"
+msgstr "ダイヤルアップ接続の初期化に失敗しました: %s"
+
+#: ../src/msw/dialup.cpp:897
+msgid "Cannot hang up - no active dialup connection."
+msgstr "接続を切るよう指示されましたが、有効なダイヤルアップ接続がありません。"
+
+#: ../src/msw/dialup.cpp:907
+#, c-format
+msgid "Failed to terminate the dialup connection: %s"
+msgstr "ダイヤルアップ接続を終了できませんでした: %s"
+
+#: ../src/msw/dib.cpp:313
+#, c-format
+msgid "Failed to save the bitmap image to file \"%s\"."
+msgstr "ファイル \"%s\" にビットマップイメージを保存できませんでした。"
+
+#: ../src/msw/dib.cpp:543
+#, c-format
+msgid "Failed to allocate %luKb of memory for bitmap data."
+msgstr "ビットマップデータ用のメモリ割り当て(%luKb)に失敗しました。"
+
+#: ../src/msw/dir.cpp:241
+#, c-format
+msgid "Cannot enumerate files in directory '%s'"
+msgstr "ディレクトリ '%s' のファイルは列挙できません"
+
+#: ../src/msw/dirdlg.cpp:368
+#, fuzzy
+msgid "Couldn't obtain folder name"
+msgstr "タイマーを作成できませんでした"
+
+#: ../src/msw/dlmsw.cpp:163
+#, c-format
+msgid "(error %d: %s)"
+msgstr "(エラー %d: %s)"
+
+#: ../src/msw/dragimag.cpp:143 ../src/msw/dragimag.cpp:178
+#: ../src/msw/imaglist.cpp:309 ../src/msw/imaglist.cpp:331
+msgid "Couldn't add an image to the image list."
+msgstr "イメージリストに画像を追加できませんでした。"
+
+#: ../src/msw/enhmeta.cpp:94
+#, c-format
+msgid "Failed to load metafile from file \"%s\"."
+msgstr "ファイル \"%s\" からメタファイルを読み取れませんでした。"
+
+#: ../src/msw/fdrepdlg.cpp:412
+#, c-format
+msgid "Failed to create the standard find/replace dialog (error code %d)"
+msgstr "標準の検索置換ダイアログを作成できませんでした (エラーコード %d)"
+
+#: ../src/msw/filedlg.cpp:1241
+msgid "Access to the file system is not allowed from secure desktop."
+msgstr ""
+
+#: ../src/msw/filedlg.cpp:1242
+msgid "Security warning"
+msgstr ""
+
+#: ../src/msw/filedlg.cpp:1533
+#, c-format
+msgid "File dialog failed with error code %0lx."
+msgstr "ファイルダイアログがエラー %0lx で失敗しました。"
+
+#: ../src/msw/font.cpp:1120
+#, fuzzy, c-format
+msgid "Font file \"%s\" couldn't be loaded"
+msgstr "ファイルを読み取ることができません。"
+
+#: ../src/msw/fontdlg.cpp:220
+#, c-format
+msgid "Common dialog failed with error code %0lx."
+msgstr "共通ダイアログがエラー %0lx で失敗しました。"
+
+#: ../src/msw/fswatcher.cpp:67
+msgid "Ungraceful worker thread termination"
+msgstr "ワーカースレッドを強引に停止させます"
+
+#: ../src/msw/fswatcher.cpp:81
+msgid "Unable to create IOCP worker thread"
+msgstr "IOCP ワーカースレッドを作成できません"
+
+#: ../src/msw/fswatcher.cpp:88
+msgid "Unable to start IOCP worker thread"
+msgstr "IOCP ワーカースレッドを開始できませんでした"
+
+#: ../src/msw/fswatcher.cpp:140
+msgid "Monitoring individual files for changes is not supported currently."
+msgstr ""
+
+#: ../src/msw/fswatcher.cpp:165
+#, c-format
+msgid "Unable to set up watch for '%s'"
+msgstr "'%s' の監視を準備できませんでした。"
+
+#: ../src/msw/fswatcher.cpp:466
+#, c-format
+msgid "Can't monitor non-existent directory \"%s\" for changes."
+msgstr "存在しないディレクトリ \"%s\" は変更の監視ができません。"
+
+#: ../src/msw/glcanvas.cpp:577 ../src/unix/glx11.cpp:507
+msgid "OpenGL 3.0 or later is not supported by the OpenGL driver."
+msgstr ""
+
+#: ../src/msw/glcanvas.cpp:601 ../src/osx/glcanvas_osx.cpp:395
+#: ../src/unix/glegl.cpp:304 ../src/unix/glx11.cpp:553
+#, fuzzy
+msgid "Couldn't create OpenGL context"
+msgstr "タイマーを作成できませんでした"
+
+#: ../src/msw/glcanvas.cpp:1294
+msgid "Failed to initialize OpenGL"
+msgstr "OpenGLを初期化できませんでした"
+
+#: ../src/msw/graphicsd2d.cpp:607
+msgid "Could not register custom DirectWrite font loader."
+msgstr ""
+
+#: ../src/msw/helpchm.cpp:48
+msgid ""
+"MS HTML Help functions are unavailable because the MS HTML Help library is "
+"not installed on this machine. Please install it."
+msgstr ""
+"Microsoft Help ライブラリーがインストールされていないので Microsoft HTML "
+"Help 機能が使えません。そのライブラリーをインストールしてください。"
+
+#: ../src/msw/helpchm.cpp:55
+msgid "Failed to initialize MS HTML Help."
+msgstr "Microsoft HTML Help を初期化できませんでした。"
+
+#: ../src/msw/iniconf.cpp:458
+#, c-format
+msgid "Can't delete the INI file '%s'"
+msgstr "INIファイル '%s' を削除できません"
+
+#: ../src/msw/listctrl.cpp:995
+#, c-format
+msgid "Couldn't retrieve information about list control item %d."
+msgstr "リストコントロールの項目 %d に関する情報を取得できませんでした。"
+
+#: ../src/msw/mdi.cpp:170 ../src/qt/mdi.cpp:253
+msgid "&Cascade"
+msgstr "重ねて表示(&C)"
+
+#: ../src/msw/mdi.cpp:171
+msgid "Tile &Horizontally"
+msgstr "横に並べる(&H)"
+
+#: ../src/msw/mdi.cpp:172
+msgid "Tile &Vertically"
+msgstr "縦に並べる(&V)"
+
+#: ../src/msw/mdi.cpp:174
+msgid "&Arrange Icons"
+msgstr "アイコンの整列(&A)"
+
+#: ../src/msw/mdi.cpp:621
+msgid "Failed to create MDI parent frame."
+msgstr "MDI親フレームを作成できませんでした。"
+
+#: ../src/msw/mimetype.cpp:234
+#, c-format
+msgid "Failed to create registry entry for '%s' files."
+msgstr "'%s' 用のレジストリエントリを作成できませんでした。"
+
+#: ../src/msw/ole/automtn.cpp:495
+#, fuzzy, c-format
+msgid "Failed to find CLSID of \"%s\""
+msgstr "リソース \"%s\" を読み取れませんでした。"
+
+#: ../src/msw/ole/automtn.cpp:512
+#, c-format
+msgid "Failed to create an instance of \"%s\""
+msgstr "\"%s\" のインスタンスを作成できませんでした"
+
+#: ../src/msw/ole/automtn.cpp:552
+#, fuzzy, c-format
+msgid "Cannot get an active instance of \"%s\""
+msgstr "使用中のダイヤルアップ接続が見つかりません: %s"
+
+#: ../src/msw/ole/automtn.cpp:564
+#, fuzzy, c-format
+msgid "Failed to get OLE automation interface for \"%s\""
+msgstr "ディレクトリー \"%s\" を作成できませんでした。"
+
+#: ../src/msw/ole/automtn.cpp:621
+#, fuzzy
+msgid "Unknown name or named argument."
+msgstr "未知のデータ様式です"
+
+#: ../src/msw/ole/automtn.cpp:625
+msgid "Incorrect number of arguments."
+msgstr ""
+
+#: ../src/msw/ole/automtn.cpp:637
+#, fuzzy
+msgid "Unknown exception"
+msgstr "未定義の簡易オプション名 '%s'"
+
+#: ../src/msw/ole/automtn.cpp:642
+msgid "Method or property not found."
+msgstr ""
+
+#: ../src/msw/ole/automtn.cpp:646
+msgid "Overflow while coercing argument values."
+msgstr ""
+
+#: ../src/msw/ole/automtn.cpp:650
+msgid "Object implementation does not support named arguments."
+msgstr ""
+
+#: ../src/msw/ole/automtn.cpp:654
+msgid "The locale ID is unknown."
+msgstr ""
+
+#: ../src/msw/ole/automtn.cpp:658
+msgid "Missing a required parameter."
+msgstr ""
+
+#: ../src/msw/ole/automtn.cpp:662
+#, fuzzy, c-format
+msgid "Argument %u not found."
+msgstr "列の索引が見つかりません。"
+
+#: ../src/msw/ole/automtn.cpp:666
+#, c-format
+msgid "Type mismatch in argument %u."
+msgstr ""
+
+#: ../src/msw/ole/automtn.cpp:670
+msgid "The system cannot find the file specified."
+msgstr ""
+
+#: ../src/msw/ole/automtn.cpp:674
+#, fuzzy
+msgid "Class not registered."
+msgstr "スレッドを作成できません"
+
+#: ../src/msw/ole/automtn.cpp:678
+#, fuzzy, c-format
+msgid "Unknown error %08x"
+msgstr "想定外のDDE エラー 0x%08x"
+
+#: ../src/msw/ole/automtn.cpp:682
+#, c-format
+msgid "OLE Automation error in %s: %s"
+msgstr ""
+
+#: ../src/msw/ole/dataobj.cpp:385
+#, c-format
+msgid "Couldn't register clipboard format '%s'."
+msgstr "クリップボードの形式 '%s' を登録できませんでした。"
+
+#: ../src/msw/ole/dataobj.cpp:402
+#, c-format
+msgid "The clipboard format '%d' doesn't exist."
+msgstr "クリップボードの形式 '%d' は存在しません。"
+
+#: ../src/msw/progdlg.cpp:1025
+msgid "Skip"
+msgstr "スキップ"
+
+#: ../src/msw/registry.cpp:141
+#, fuzzy, c-format
+msgid "unknown (%lu)"
+msgstr "不明"
+
+#: ../src/msw/registry.cpp:409
+#, c-format
+msgid "Can't get info about registry key '%s'"
+msgstr "レジストリキー '%s' の情報を取得できません"
+
+#: ../src/msw/registry.cpp:445
+#, c-format
+msgid "Can't open registry key '%s'"
+msgstr "レジストリキー '%s' を開くことができません"
+
+#: ../src/msw/registry.cpp:478
+#, c-format
+msgid "Can't create registry key '%s'"
+msgstr "レジストリキー '%s' を作成できません"
+
+#: ../src/msw/registry.cpp:497
+#, c-format
+msgid "Can't close registry key '%s'"
+msgstr "レジストリキー '%s' を閉じることができません"
+
+#: ../src/msw/registry.cpp:512
+#, c-format
+msgid "Registry value '%s' already exists."
+msgstr "レジストリの値 '%s' はすでに存在します。"
+
+#: ../src/msw/registry.cpp:520
+#, c-format
+msgid "Failed to rename registry value '%s' to '%s'."
+msgstr "レジストリの値を '%s' から '%s' に名称変更できませんでした。"
+
+#: ../src/msw/registry.cpp:575
+#, c-format
+msgid "Can't copy values of unsupported type %d."
+msgstr "未対応型 %d の値はコピーできません。"
+
+#: ../src/msw/registry.cpp:586
+#, c-format
+msgid "Registry key '%s' does not exist, cannot rename it."
+msgstr "名称変更元に指定されたレジストリキー '%s' は存在しません。"
+
+#: ../src/msw/registry.cpp:617
+#, c-format
+msgid "Registry key '%s' already exists."
+msgstr "レジストリキー '%s' はすでに存在します。"
+
+#: ../src/msw/registry.cpp:625
+#, c-format
+msgid "Failed to rename the registry key '%s' to '%s'."
+msgstr "レジストリキー '%s' を '%s' に名称変更できませんでした。"
+
+#: ../src/msw/registry.cpp:670
+#, c-format
+msgid "Failed to copy the registry subkey '%s' to '%s'."
+msgstr "レジストリのサブキー '%s' を '%s' へコピーできませんでした。"
+
+#: ../src/msw/registry.cpp:683
+#, c-format
+msgid "Failed to copy registry value '%s'"
+msgstr "レジストリの値 '%s' をコピーできませんでした。"
+
+#: ../src/msw/registry.cpp:692
+#, c-format
+msgid "Failed to copy the contents of registry key '%s' to '%s'."
+msgstr "レジストリキー '%s' の内容を '%s' へコピーできませんでした。"
+
+#: ../src/msw/registry.cpp:718
+#, c-format
+msgid ""
+"Registry key '%s' is needed for normal system operation,\n"
+"deleting it will leave your system in unusable state:\n"
+"operation aborted."
+msgstr ""
+"レジストリキー '%s' は通常のシステム動作に必要です。\n"
+"これを削除するとシステムを不安定にします:\n"
+"処理を中断しました。"
+
+#: ../src/msw/registry.cpp:754
+#, c-format
+msgid "Can't delete key '%s'"
+msgstr "キー '%s' を削除できません"
+
+#: ../src/msw/registry.cpp:782
+#, c-format
+msgid "Can't delete value '%s' from key '%s'"
+msgstr "値 '%s' をキー '%s' から削除できません"
+
+#: ../src/msw/registry.cpp:855 ../src/msw/registry.cpp:887
+#: ../src/msw/registry.cpp:929 ../src/msw/registry.cpp:1000
+#, c-format
+msgid "Can't read value of key '%s'"
+msgstr "キー '%s' の値を読み取ることができません"
+
+#: ../src/msw/registry.cpp:873 ../src/msw/registry.cpp:915
+#: ../src/msw/registry.cpp:963 ../src/msw/registry.cpp:1106
+#, c-format
+msgid "Can't set value of '%s'"
+msgstr "'%s' の値を設定できません"
+
+#: ../src/msw/registry.cpp:894 ../src/msw/registry.cpp:943
+#, c-format
+msgid "Registry value \"%s\" is not numeric (but of type %s)"
+msgstr ""
+
+#: ../src/msw/registry.cpp:979
+#, c-format
+msgid "Registry value \"%s\" is not binary (but of type %s)"
+msgstr ""
+
+#: ../src/msw/registry.cpp:1028
+#, c-format
+msgid "Registry value \"%s\" is not text (but of type %s)"
+msgstr ""
+
+#: ../src/msw/registry.cpp:1089
+#, c-format
+msgid "Can't read value of '%s'"
+msgstr "'%s' の値を読み取ることができません"
+
+#: ../src/msw/registry.cpp:1157
+#, c-format
+msgid "Can't enumerate values of key '%s'"
+msgstr "キー '%s' の値を列挙できません"
+
+#: ../src/msw/registry.cpp:1196
+#, c-format
+msgid "Can't enumerate subkeys of key '%s'"
+msgstr "キー '%s' のサブキーを列挙できません"
+
+#: ../src/msw/registry.cpp:1262
+#, c-format
+msgid ""
+"Exporting registry key: file \"%s\" already exists and won't be overwritten."
+msgstr ""
+"レジストリのエクスポート: ファイル \"%s\" はすでに存在します。上書きも行いま"
+"せん。"
+
+#: ../src/msw/registry.cpp:1411
+#, c-format
+msgid "Can't export value of unsupported type %d."
+msgstr "未対応型 %d の値はエクスポートできません。"
+
+#: ../src/msw/registry.cpp:1427
+#, c-format
+msgid "Ignoring value \"%s\" of the key \"%s\"."
+msgstr "値 \"%s\" を無視します (キー \"%s\")。"
+
+#: ../src/msw/textctrl.cpp:596
+msgid ""
+"Impossible to create a rich edit control, using simple text control instead. "
+"Please reinstall riched32.dll"
+msgstr ""
+"リッチエディットコントロールを作成できませんでした。代わりに簡素なテキストコ"
+"ントロールを使います。 riched32.dllを再インストールしてください。"
+
+#: ../src/msw/thread.cpp:522 ../src/unix/threadpsx.cpp:850
+msgid "Cannot start thread: error writing TLS."
+msgstr "スレッドを開始できませんでした: TLS への書き込みに失敗しています。"
+
+#: ../src/msw/thread.cpp:613
+msgid "Can't set thread priority"
+msgstr "スレッド優先度を設定できません"
+
+#: ../src/msw/thread.cpp:649
+msgid "Can't create thread"
+msgstr "スレッドを作成できません"
+
+#: ../src/msw/thread.cpp:668
+msgid "Couldn't terminate thread"
+msgstr "スレッドを終了できませんでした"
+
+#: ../src/msw/thread.cpp:799
+msgid "Cannot wait for thread termination"
+msgstr "スレッドの終了を待つことはできません"
+
+#: ../src/msw/thread.cpp:873
+#, fuzzy, c-format
+msgid "Cannot suspend thread %lx"
+msgstr "スレッド %x のサスペンドができません"
+
+#: ../src/msw/thread.cpp:903
+#, fuzzy, c-format
+msgid "Cannot resume thread %lx"
+msgstr "スレッド %x のリジュームができません"
+
+#: ../src/msw/thread.cpp:932
+msgid "Couldn't get the current thread pointer"
+msgstr "現在のスレッドを示すポインタを取得できませんでした"
+
+#: ../src/msw/thread.cpp:1333
+msgid ""
+"Thread module initialization failed: impossible to allocate index in thread "
+"local storage"
+msgstr ""
+"スレッドモジュールの初期化に失敗: スレッドローカルストレージに索引を割り当て"
+"られませんでした"
+
+#: ../src/msw/thread.cpp:1345
+msgid ""
+"Thread module initialization failed: cannot store value in thread local "
+"storage"
+msgstr ""
+"スレッドモジュールの初期化に失敗: スレッドローカルストレージに値を保存できま"
+"せんでした"
+
+#: ../src/msw/timer.cpp:133
+msgid "Couldn't create a timer"
+msgstr "タイマーを作成できませんでした"
+
+#: ../src/msw/utils.cpp:372
+msgid "can't find user's HOME, using current directory."
+msgstr "ユーザーの HOME が見つかりません。カレントディレクトリを使用します。"
+
+#: ../src/msw/utils.cpp:662
+#, c-format
+msgid "Failed to kill process %d"
+msgstr "プロセス %d の kill に失敗しました"
+
+#: ../src/msw/utils.cpp:986
+#, c-format
+msgid "Failed to load resource \"%s\"."
+msgstr "リソース \"%s\" を読み取れませんでした。"
+
+#: ../src/msw/utils.cpp:993
+#, c-format
+msgid "Failed to lock resource \"%s\"."
+msgstr "リソース \"%s\" をロックできませんでした。"
+
+#. TRANSLATORS: MS Windows build number
+#: ../src/msw/utils.cpp:1209
+#, c-format
+msgid "build %lu"
+msgstr "ビルド %lu"
+
+#: ../src/msw/utils.cpp:1218
+msgid ", 64-bit edition"
+msgstr ", 64ビットエディション"
+
+#: ../src/msw/utilsexc.cpp:224
+msgid "Failed to create an anonymous pipe"
+msgstr "匿名パイプを作成できませんでした"
+
+#: ../src/msw/utilsexc.cpp:697
+msgid "Failed to redirect the child process IO"
+msgstr "子プロセスの入出力をリダイレクトできませんでした"
+
+#: ../src/msw/utilsexc.cpp:870
+#, c-format
+msgid "Execution of command '%s' failed"
+msgstr "コマンド '%s' を実行できませんでした"
+
+#: ../src/msw/volume.cpp:337
+msgid "Failed to load mpr.dll."
+msgstr "mpr.dll を読み取れませんでした。"
+
+#: ../src/msw/volume.cpp:506
+#, c-format
+msgid "Cannot read typename from '%s'!"
+msgstr "'%s' の型名を読み出すことができません。"
+
+#: ../src/msw/volume.cpp:615
+#, c-format
+msgid "Cannot load icon from '%s'."
+msgstr "'%s' からアイコンを読み取れません。"
+
+#: ../src/msw/webview_edge.cpp:285
+msgid "This program was compiled without support for setting Edge proxy."
+msgstr ""
+
+#: ../src/msw/webview_ie.cpp:1010
+msgid "Failed to find web view emulation level in the registry"
+msgstr ""
+
+#: ../src/msw/webview_ie.cpp:1019
+msgid "Failed to set web view to modern emulation level"
+msgstr ""
+
+#: ../src/msw/webview_ie.cpp:1027
+msgid "Failed to reset web view to standard emulation level"
+msgstr ""
+
+#: ../src/msw/webview_ie.cpp:1049
+msgid "Can't run JavaScript script without a valid HTML document"
+msgstr ""
+
+#: ../src/msw/webview_ie.cpp:1056
+msgid "Can't get the JavaScript object"
+msgstr "JavaScript オブジェクトを取得できません"
+
+#: ../src/msw/webview_ie.cpp:1070
+msgid "failed to evaluate"
+msgstr "評価に失敗しました"
+
+#: ../src/osx/cocoa/filedlg.mm:412
+#, fuzzy
+msgid "File type:"
+msgstr "Teletype"
+
+#: ../src/osx/cocoa/menu.mm:242
+msgctxt "macOS menu name"
+msgid "Window"
+msgstr "ウインドウ"
+
+#: ../src/osx/cocoa/menu.mm:259
+msgctxt "macOS menu name"
+msgid "Help"
+msgstr "ヘルプ"
+
+#: ../src/osx/cocoa/menu.mm:298
+msgctxt "macOS menu item"
+msgid "Minimize"
+msgstr "しまう"
+
+#: ../src/osx/cocoa/menu.mm:303
+msgctxt "macOS menu item"
+msgid "Zoom"
+msgstr "拡大"
+
+#: ../src/osx/cocoa/menu.mm:309
+msgctxt "macOS menu item"
+msgid "Bring All to Front"
+msgstr "すべてを手前に移動"
+
+#: ../src/osx/core/sound.cpp:143
+#, c-format
+msgid "Failed to load sound from \"%s\" (error %d)."
+msgstr "\"%s\" からサウンドを読み取れませんでした (エラー %d)。"
+
+#: ../src/osx/fontutil.cpp:80
+#, c-format
+msgid "Font file \"%s\" doesn't exist."
+msgstr "フォントファイル \"%s\" は存在しません。"
+
+#: ../src/osx/fontutil.cpp:88
+#, c-format
+msgid ""
+"Font file \"%s\" cannot be used as it is not inside the font directory "
+"\"%s\"."
+msgstr ""
+"フォントファイル \"%s\" は、フォントディレクトリ \"%s\" に存在しないため、使"
+"用できません。"
+
+#: ../src/osx/menu_osx.cpp:496
+#, c-format
+msgctxt "macOS menu item"
+msgid "About %s"
+msgstr "%sについて"
+
+#: ../src/osx/menu_osx.cpp:499
+msgctxt "macOS menu item"
+msgid "About..."
+msgstr "このアプリケーションについて..."
+
+#: ../src/osx/menu_osx.cpp:508
+msgctxt "macOS menu item"
+msgid "Preferences..."
+msgstr "設定..."
+
+#: ../src/osx/menu_osx.cpp:512
+msgctxt "macOS menu item"
+msgid "Services"
+msgstr "サービス"
+
+#: ../src/osx/menu_osx.cpp:519
+#, c-format
+msgctxt "macOS menu item"
+msgid "Hide %s"
+msgstr "%sを非表示"
+
+#: ../src/osx/menu_osx.cpp:522
+msgctxt "macOS menu item"
+msgid "Hide Application"
+msgstr "アプリケーションを非表示"
+
+#: ../src/osx/menu_osx.cpp:526
+msgctxt "macOS menu item"
+msgid "Hide Others"
+msgstr "ほかを非表示"
+
+#: ../src/osx/menu_osx.cpp:528
+msgctxt "macOS menu item"
+msgid "Show All"
+msgstr "すべてを表示"
+
+#: ../src/osx/menu_osx.cpp:534
+#, c-format
+msgctxt "macOS menu item"
+msgid "Quit %s"
+msgstr "%sを終了"
+
+#: ../src/osx/menu_osx.cpp:537
+msgctxt "macOS menu item"
+msgid "Quit Application"
+msgstr "アプリケーションを終了"
+
+#: ../src/osx/webview_webkit.mm:444
+#, fuzzy
+msgid "Printing is not supported by the system web control"
+msgstr "このバージョンの zlib は Gzip を処理できません"
+
+#: ../src/osx/webview_webkit.mm:453
+#, fuzzy
+msgid "Print operation could not be initialized"
+msgstr "列の記述を初期化できませんでした。"
+
+#. TRANSLATORS: Label of font point size
+#: ../src/propgrid/advprops.cpp:605
+msgid "Point Size"
+msgstr "大きさ(ポイント)"
+
+#. TRANSLATORS: Label of font face name
+#: ../src/propgrid/advprops.cpp:615
+msgid "Face Name"
+msgstr "フォント名"
+
+#. TRANSLATORS: Label of font style
+#: ../src/propgrid/advprops.cpp:623 ../src/richtext/richtextformatdlg.cpp:331
+msgid "Style"
+msgstr "スタイル"
+
+#. TRANSLATORS: Label of font weight
+#: ../src/propgrid/advprops.cpp:628
+msgid "Weight"
+msgstr "ウエイト"
+
+#. TRANSLATORS: Label of underlined font
+#: ../src/propgrid/advprops.cpp:633 ../src/richtext/richtextfontpage.cpp:358
+msgid "Underlined"
+msgstr "下線付き"
+
+#. TRANSLATORS: Label of font family
+#: ../src/propgrid/advprops.cpp:637
+msgid "Family"
+msgstr "フォントファミリー"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:801
+msgid "AppWorkspace"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:802
+#, fuzzy
+msgid "ActiveBorder"
+msgstr "Modern"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:803
+msgid "ActiveCaption"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:804
+msgid "ButtonFace"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:805
+msgid "ButtonHighlight"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:806
+msgid "ButtonShadow"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:807
+msgid "ButtonText"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:808
+msgid "CaptionText"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:809
+msgid "ControlDark"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:810
+msgid "ControlLight"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:812
+msgid "GrayText"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:813
+#, fuzzy
+msgid "Highlight"
+msgstr "軽量"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:814
+#, fuzzy
+msgid "HighlightText"
+msgstr "右寄せにします。"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:815
+#, fuzzy
+msgid "InactiveBorder"
+msgstr "Modern"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:816
+msgid "InactiveCaption"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:817
+msgid "InactiveCaptionText"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:818
+msgid "Menu"
+msgstr "メニュー"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:819
+msgid "Scrollbar"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:820
+msgid "Tooltip"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:821
+msgid "TooltipText"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:822
+#, fuzzy
+msgid "Window"
+msgstr "ウィンドウ (&W)"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:823
+#, fuzzy
+msgid "WindowFrame"
+msgstr "ウィンドウ (&W)"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:824
+#, fuzzy
+msgid "WindowText"
+msgstr "ウィンドウ (&W)"
+
+#. TRANSLATORS: Custom colour choice entry
+#: ../src/propgrid/advprops.cpp:825 ../src/propgrid/advprops.cpp:1532
+#: ../src/propgrid/advprops.cpp:1576
+#, fuzzy
+msgid "Custom"
+msgstr "任意の寸法指定"
+
+#: ../src/propgrid/advprops.cpp:1558
+msgid "Black"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1559
+msgid "Maroon"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1560
+msgid "Navy"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1561
+msgid "Purple"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1562
+msgid "Teal"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1563
+msgid "Gray"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1564
+#, fuzzy
+msgid "Green"
+msgstr "MacGreek"
+
+#: ../src/propgrid/advprops.cpp:1565
+msgid "Olive"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1566
+#, fuzzy
+msgid "Brown"
+msgstr "ファイルの選択"
+
+#: ../src/propgrid/advprops.cpp:1567
+msgid "Blue"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1568
+msgid "Fuchsia"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1569
+#, fuzzy
+msgid "Red"
+msgstr "再実行"
+
+#: ../src/propgrid/advprops.cpp:1570
+msgid "Orange"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1571
+msgid "Silver"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1572
+msgid "Lime"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1573
+msgid "Aqua"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1574
+msgid "Yellow"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1575
+msgid "White"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1718
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Default"
+msgstr "規定"
+
+#: ../src/propgrid/advprops.cpp:1719
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Arrow"
+msgstr "明日"
+
+#: ../src/propgrid/advprops.cpp:1720
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Right Arrow"
+msgstr "右"
+
+#: ../src/propgrid/advprops.cpp:1721
+msgctxt "system cursor name"
+msgid "Blank"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1722
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Bullseye"
+msgstr "行頭文字のスタイル"
+
+#: ../src/propgrid/advprops.cpp:1723
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Character"
+msgstr "文字コード (&C):"
+
+#: ../src/propgrid/advprops.cpp:1724
+msgctxt "system cursor name"
+msgid "Cross"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1725
+msgctxt "system cursor name"
+msgid "Hand"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1726
+msgctxt "system cursor name"
+msgid "I-Beam"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1727
+msgctxt "system cursor name"
+msgid "Left Button"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1728
+msgctxt "system cursor name"
+msgid "Magnifier"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1729
+msgctxt "system cursor name"
+msgid "Middle Button"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1730
+msgctxt "system cursor name"
+msgid "No Entry"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1731
+msgctxt "system cursor name"
+msgid "Paint Brush"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1732
+msgctxt "system cursor name"
+msgid "Pencil"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1733
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Point Left"
+msgstr "大きさ(ポイント):"
+
+#: ../src/propgrid/advprops.cpp:1734
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Point Right"
+msgstr "右寄せ"
+
+#: ../src/propgrid/advprops.cpp:1735
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Question Arrow"
+msgstr "お尋ねします"
+
+#: ../src/propgrid/advprops.cpp:1736
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Right Button"
+msgstr "右"
+
+#: ../src/propgrid/advprops.cpp:1737
+msgctxt "system cursor name"
+msgid "Sizing NE-SW"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1738
+msgctxt "system cursor name"
+msgid "Sizing N-S"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1739
+msgctxt "system cursor name"
+msgid "Sizing NW-SE"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1740
+msgctxt "system cursor name"
+msgid "Sizing W-E"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1741
+msgctxt "system cursor name"
+msgid "Sizing"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1742
+msgctxt "system cursor name"
+msgid "Spraycan"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1743
+msgctxt "system cursor name"
+msgid "Wait"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1744
+msgctxt "system cursor name"
+msgid "Watch"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1745
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Wait Arrow"
+msgstr "右"
+
+#: ../src/propgrid/advprops.cpp:2109
+msgid "Make a selection:"
+msgstr "選択してください:"
+
+#: ../src/propgrid/manager.cpp:394
+msgid "Property"
+msgstr "プロパティ"
+
+#: ../src/propgrid/manager.cpp:395
+msgid "Value"
+msgstr "値"
+
+#: ../src/propgrid/manager.cpp:1683
+msgid "Categorized Mode"
+msgstr "種類順"
+
+#: ../src/propgrid/manager.cpp:1709
+msgid "Alphabetic Mode"
+msgstr "名前順"
+
+#. TRANSLATORS: Name of Boolean false value
+#: ../src/propgrid/propgrid.cpp:230
+msgid "False"
+msgstr "偽"
+
+#. TRANSLATORS: Name of Boolean true value
+#: ../src/propgrid/propgrid.cpp:232
+msgid "True"
+msgstr "真"
+
+#. TRANSLATORS: Text  displayed for unspecified value
+#: ../src/propgrid/propgrid.cpp:428
+msgid "Unspecified"
+msgstr "未指定"
+
+#. TRANSLATORS: Caption of message box displaying any property error
+#: ../src/propgrid/propgrid.cpp:3145 ../src/propgrid/propgrid.cpp:3282
+msgid "Property Error"
+msgstr "プロパティエラー"
+
+#: ../src/propgrid/propgrid.cpp:3259
+msgid "You have entered invalid value. Press ESC to cancel editing."
+msgstr ""
+
+#: ../src/propgrid/propgrid.cpp:6608
+#, c-format
+msgid "Error in resource: %s"
+msgstr "リソース中にエラー: %s"
+
+#: ../src/propgrid/propgridiface.cpp:377
+#, c-format
+msgid ""
+"Type operation \"%s\" failed: Property labeled \"%s\" is of type \"%s\", NOT "
+"\"%s\"."
+msgstr ""
+"型の処理 \"%s\" に失敗: \"%s\" とラベルされたプロパティは \"%s\" 型です。"
+"\"%s\" ではありません。"
+
+#: ../src/propgrid/props.cpp:159
+#, c-format
+msgid "Unknown base %d. Base 10 will be used."
+msgstr ""
+
+#: ../src/propgrid/props.cpp:324
+#, fuzzy, c-format
+msgid "Value must be %s or higher."
+msgstr "%f 以上の値にしてください"
+
+#: ../src/propgrid/props.cpp:329 ../src/propgrid/props.cpp:356
+#, fuzzy, c-format
+msgid "Value must be between %s and %s."
+msgstr "%f 以下の値にしてください"
+
+#: ../src/propgrid/props.cpp:351
+#, fuzzy, c-format
+msgid "Value must be %s or less."
+msgstr "%f 以下の値にしてください"
+
+#: ../src/propgrid/props.cpp:1058
+#, c-format
+msgid "Not %s"
+msgstr "%sではない"
+
+#: ../src/propgrid/props.cpp:1770
+msgid "Choose a directory:"
+msgstr "ディレクトリを選んでください:"
+
+#: ../src/propgrid/props.cpp:2055
+msgid "Choose a file"
+msgstr "フォントを選んでください"
+
+#: ../src/qt/mdi.cpp:254
+msgid "&Tile"
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:147
+#: ../src/richtext/richtextformatdlg.cpp:376
+#, fuzzy
+msgid "Background"
+msgstr "背景色"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:159
+#, fuzzy
+msgid "Background &colour:"
+msgstr "背景色"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:161
+#: ../src/richtext/richtextbackgroundpage.cpp:163
+#, fuzzy
+msgid "Enables a background colour."
+msgstr "背景色"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:167
+#: ../src/richtext/richtextbackgroundpage.cpp:169
+#, fuzzy
+msgid "The background colour."
+msgstr "背景色"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:178
+msgid "Shadow"
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:193
+msgid "Use &shadow"
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:195
+#: ../src/richtext/richtextbackgroundpage.cpp:197
+#, fuzzy
+msgid "Enables a shadow."
+msgstr "背景色"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:211
+msgid "&Horizontal offset:"
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:218
+#: ../src/richtext/richtextbackgroundpage.cpp:220
+#, fuzzy
+msgid "The horizontal offset."
+msgstr "横に並べる(&H)"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:224
+#: ../src/richtext/richtextbackgroundpage.cpp:227
+#: ../src/richtext/richtextbackgroundpage.cpp:228
+#: ../src/richtext/richtextbackgroundpage.cpp:247
+#: ../src/richtext/richtextbackgroundpage.cpp:250
+#: ../src/richtext/richtextbackgroundpage.cpp:251
+#: ../src/richtext/richtextbackgroundpage.cpp:287
+#: ../src/richtext/richtextbackgroundpage.cpp:290
+#: ../src/richtext/richtextbackgroundpage.cpp:291
+#: ../src/richtext/richtextbackgroundpage.cpp:314
+#: ../src/richtext/richtextbackgroundpage.cpp:317
+#: ../src/richtext/richtextbackgroundpage.cpp:318
+#: ../src/richtext/richtextborderspage.cpp:252
+#: ../src/richtext/richtextborderspage.cpp:255
+#: ../src/richtext/richtextborderspage.cpp:256
+#: ../src/richtext/richtextborderspage.cpp:286
+#: ../src/richtext/richtextborderspage.cpp:289
+#: ../src/richtext/richtextborderspage.cpp:290
+#: ../src/richtext/richtextborderspage.cpp:320
+#: ../src/richtext/richtextborderspage.cpp:323
+#: ../src/richtext/richtextborderspage.cpp:324
+#: ../src/richtext/richtextborderspage.cpp:354
+#: ../src/richtext/richtextborderspage.cpp:357
+#: ../src/richtext/richtextborderspage.cpp:358
+#: ../src/richtext/richtextborderspage.cpp:420
+#: ../src/richtext/richtextborderspage.cpp:423
+#: ../src/richtext/richtextborderspage.cpp:424
+#: ../src/richtext/richtextborderspage.cpp:454
+#: ../src/richtext/richtextborderspage.cpp:457
+#: ../src/richtext/richtextborderspage.cpp:458
+#: ../src/richtext/richtextborderspage.cpp:488
+#: ../src/richtext/richtextborderspage.cpp:491
+#: ../src/richtext/richtextborderspage.cpp:492
+#: ../src/richtext/richtextborderspage.cpp:522
+#: ../src/richtext/richtextborderspage.cpp:525
+#: ../src/richtext/richtextborderspage.cpp:526
+#: ../src/richtext/richtextborderspage.cpp:590
+#: ../src/richtext/richtextborderspage.cpp:593
+#: ../src/richtext/richtextborderspage.cpp:594
+#: ../src/richtext/richtextfontpage.cpp:177
+#: ../src/richtext/richtextmarginspage.cpp:199
+#: ../src/richtext/richtextmarginspage.cpp:201
+#: ../src/richtext/richtextmarginspage.cpp:202
+#: ../src/richtext/richtextmarginspage.cpp:224
+#: ../src/richtext/richtextmarginspage.cpp:226
+#: ../src/richtext/richtextmarginspage.cpp:227
+#: ../src/richtext/richtextmarginspage.cpp:247
+#: ../src/richtext/richtextmarginspage.cpp:249
+#: ../src/richtext/richtextmarginspage.cpp:250
+#: ../src/richtext/richtextmarginspage.cpp:272
+#: ../src/richtext/richtextmarginspage.cpp:274
+#: ../src/richtext/richtextmarginspage.cpp:275
+#: ../src/richtext/richtextmarginspage.cpp:313
+#: ../src/richtext/richtextmarginspage.cpp:315
+#: ../src/richtext/richtextmarginspage.cpp:316
+#: ../src/richtext/richtextmarginspage.cpp:338
+#: ../src/richtext/richtextmarginspage.cpp:340
+#: ../src/richtext/richtextmarginspage.cpp:341
+#: ../src/richtext/richtextmarginspage.cpp:361
+#: ../src/richtext/richtextmarginspage.cpp:363
+#: ../src/richtext/richtextmarginspage.cpp:364
+#: ../src/richtext/richtextmarginspage.cpp:386
+#: ../src/richtext/richtextmarginspage.cpp:388
+#: ../src/richtext/richtextmarginspage.cpp:389
+#: ../src/richtext/richtextsizepage.cpp:337
+#: ../src/richtext/richtextsizepage.cpp:340
+#: ../src/richtext/richtextsizepage.cpp:341
+#: ../src/richtext/richtextsizepage.cpp:371
+#: ../src/richtext/richtextsizepage.cpp:374
+#: ../src/richtext/richtextsizepage.cpp:375
+#: ../src/richtext/richtextsizepage.cpp:398
+#: ../src/richtext/richtextsizepage.cpp:401
+#: ../src/richtext/richtextsizepage.cpp:402
+#: ../src/richtext/richtextsizepage.cpp:425
+#: ../src/richtext/richtextsizepage.cpp:428
+#: ../src/richtext/richtextsizepage.cpp:429
+#: ../src/richtext/richtextsizepage.cpp:452
+#: ../src/richtext/richtextsizepage.cpp:455
+#: ../src/richtext/richtextsizepage.cpp:456
+#: ../src/richtext/richtextsizepage.cpp:479
+#: ../src/richtext/richtextsizepage.cpp:482
+#: ../src/richtext/richtextsizepage.cpp:483
+#: ../src/richtext/richtextsizepage.cpp:553
+#: ../src/richtext/richtextsizepage.cpp:556
+#: ../src/richtext/richtextsizepage.cpp:557
+#: ../src/richtext/richtextsizepage.cpp:588
+#: ../src/richtext/richtextsizepage.cpp:591
+#: ../src/richtext/richtextsizepage.cpp:592
+#: ../src/richtext/richtextsizepage.cpp:623
+#: ../src/richtext/richtextsizepage.cpp:626
+#: ../src/richtext/richtextsizepage.cpp:627
+#: ../src/richtext/richtextsizepage.cpp:658
+#: ../src/richtext/richtextsizepage.cpp:661
+#: ../src/richtext/richtextsizepage.cpp:662
+msgid "px"
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:225
+#: ../src/richtext/richtextbackgroundpage.cpp:248
+#: ../src/richtext/richtextbackgroundpage.cpp:288
+#: ../src/richtext/richtextbackgroundpage.cpp:315
+#: ../src/richtext/richtextborderspage.cpp:253
+#: ../src/richtext/richtextborderspage.cpp:287
+#: ../src/richtext/richtextborderspage.cpp:321
+#: ../src/richtext/richtextborderspage.cpp:355
+#: ../src/richtext/richtextborderspage.cpp:421
+#: ../src/richtext/richtextborderspage.cpp:455
+#: ../src/richtext/richtextborderspage.cpp:489
+#: ../src/richtext/richtextborderspage.cpp:523
+#: ../src/richtext/richtextborderspage.cpp:591
+#: ../src/richtext/richtextmarginspage.cpp:200
+#: ../src/richtext/richtextmarginspage.cpp:225
+#: ../src/richtext/richtextmarginspage.cpp:248
+#: ../src/richtext/richtextmarginspage.cpp:273
+#: ../src/richtext/richtextmarginspage.cpp:314
+#: ../src/richtext/richtextmarginspage.cpp:339
+#: ../src/richtext/richtextmarginspage.cpp:362
+#: ../src/richtext/richtextmarginspage.cpp:387
+#: ../src/richtext/richtextsizepage.cpp:338
+#: ../src/richtext/richtextsizepage.cpp:372
+#: ../src/richtext/richtextsizepage.cpp:399
+#: ../src/richtext/richtextsizepage.cpp:426
+#: ../src/richtext/richtextsizepage.cpp:453
+#: ../src/richtext/richtextsizepage.cpp:480
+#: ../src/richtext/richtextsizepage.cpp:554
+#: ../src/richtext/richtextsizepage.cpp:589
+#: ../src/richtext/richtextsizepage.cpp:624
+#: ../src/richtext/richtextsizepage.cpp:659
+msgid "cm"
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:226
+#: ../src/richtext/richtextbackgroundpage.cpp:249
+#: ../src/richtext/richtextbackgroundpage.cpp:289
+#: ../src/richtext/richtextbackgroundpage.cpp:316
+#: ../src/richtext/richtextborderspage.cpp:254
+#: ../src/richtext/richtextborderspage.cpp:288
+#: ../src/richtext/richtextborderspage.cpp:322
+#: ../src/richtext/richtextborderspage.cpp:356
+#: ../src/richtext/richtextborderspage.cpp:422
+#: ../src/richtext/richtextborderspage.cpp:456
+#: ../src/richtext/richtextborderspage.cpp:490
+#: ../src/richtext/richtextborderspage.cpp:524
+#: ../src/richtext/richtextborderspage.cpp:592
+#: ../src/richtext/richtextfontpage.cpp:176
+#: ../src/richtext/richtextfontpage.cpp:179
+msgid "pt"
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:229
+#: ../src/richtext/richtextbackgroundpage.cpp:231
+#: ../src/richtext/richtextbackgroundpage.cpp:252
+#: ../src/richtext/richtextbackgroundpage.cpp:254
+#: ../src/richtext/richtextbackgroundpage.cpp:292
+#: ../src/richtext/richtextbackgroundpage.cpp:294
+#: ../src/richtext/richtextbackgroundpage.cpp:319
+#: ../src/richtext/richtextbackgroundpage.cpp:321
+#, fuzzy
+msgid "Units for this value."
+msgstr "スレッドの終了待ちに失敗しました。"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:234
+#, fuzzy
+msgid "&Vertical offset:"
+msgstr "行頭文字の位置(&A):"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:241
+#: ../src/richtext/richtextbackgroundpage.cpp:243
+#, fuzzy
+msgid "The vertical offset."
+msgstr "整列方法を設定できませんでした。"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:257
+#, fuzzy
+msgid "Shadow c&olour:"
+msgstr "色を選んでください"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:259
+#: ../src/richtext/richtextbackgroundpage.cpp:261
+#, fuzzy
+msgid "Enables the shadow colour."
+msgstr "背景色"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:265
+#: ../src/richtext/richtextbackgroundpage.cpp:267
+#, fuzzy
+msgid "The shadow colour."
+msgstr "フォントの色を指定できます。"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:270
+msgid "Sh&adow spread:"
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:272
+#: ../src/richtext/richtextbackgroundpage.cpp:274
+msgid "Enables the shadow spread."
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:281
+#: ../src/richtext/richtextbackgroundpage.cpp:283
+msgid "The shadow spread."
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:297
+msgid "&Blur distance:"
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:299
+#: ../src/richtext/richtextbackgroundpage.cpp:301
+#, fuzzy
+msgid "Enables the blur distance."
+msgstr "最大幅を設定できませんでした。"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:308
+#: ../src/richtext/richtextbackgroundpage.cpp:310
+msgid "The shadow blur distance."
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:324
+msgid "Opaci&ty:"
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:326
+#: ../src/richtext/richtextbackgroundpage.cpp:328
+msgid "Enables the shadow opacity."
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:335
+#: ../src/richtext/richtextbackgroundpage.cpp:337
+msgid "The shadow opacity."
+msgstr ""
+
+#. TRANSLATORS: Rich text page units (percentage)
+#: ../src/richtext/richtextbackgroundpage.cpp:340
+#: ../src/richtext/richtextsizepage.cpp:339
+#: ../src/richtext/richtextsizepage.cpp:373
+#: ../src/richtext/richtextsizepage.cpp:400
+#: ../src/richtext/richtextsizepage.cpp:427
+#: ../src/richtext/richtextsizepage.cpp:454
+#: ../src/richtext/richtextsizepage.cpp:481
+#: ../src/richtext/richtextsizepage.cpp:555
+#: ../src/richtext/richtextsizepage.cpp:590
+#: ../src/richtext/richtextsizepage.cpp:625
+#: ../src/richtext/richtextsizepage.cpp:660
+#, fuzzy
+msgid "%"
+msgstr "%s"
+
+#: ../src/richtext/richtextborderspage.cpp:229
+#: ../src/richtext/richtextborderspage.cpp:387
+#, fuzzy
+msgid "Border"
+msgstr "Modern"
+
+#: ../src/richtext/richtextborderspage.cpp:242
+#: ../src/richtext/richtextborderspage.cpp:410
+#: ../src/richtext/richtextindentspage.cpp:194
+#: ../src/richtext/richtextliststylepage.cpp:384
+#: ../src/richtext/richtextmarginspage.cpp:185
+#: ../src/richtext/richtextmarginspage.cpp:299
+#: ../src/richtext/richtextsizepage.cpp:531
+#: ../src/richtext/richtextsizepage.cpp:538
+msgid "&Left:"
+msgstr "左(&L):"
+
+#: ../src/richtext/richtextborderspage.cpp:257
+#: ../src/richtext/richtextborderspage.cpp:259
+msgid "Units for the left border width."
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:266
+#: ../src/richtext/richtextborderspage.cpp:268
+#: ../src/richtext/richtextborderspage.cpp:300
+#: ../src/richtext/richtextborderspage.cpp:302
+#: ../src/richtext/richtextborderspage.cpp:334
+#: ../src/richtext/richtextborderspage.cpp:336
+#: ../src/richtext/richtextborderspage.cpp:368
+#: ../src/richtext/richtextborderspage.cpp:370
+#: ../src/richtext/richtextborderspage.cpp:434
+#: ../src/richtext/richtextborderspage.cpp:436
+#: ../src/richtext/richtextborderspage.cpp:468
+#: ../src/richtext/richtextborderspage.cpp:470
+#: ../src/richtext/richtextborderspage.cpp:502
+#: ../src/richtext/richtextborderspage.cpp:504
+#: ../src/richtext/richtextborderspage.cpp:536
+#: ../src/richtext/richtextborderspage.cpp:538
+#, fuzzy
+msgid "The border line style."
+msgstr "フォントのスタイルを指定できます。"
+
+#: ../src/richtext/richtextborderspage.cpp:276
+#: ../src/richtext/richtextborderspage.cpp:444
+#: ../src/richtext/richtextindentspage.cpp:212
+#: ../src/richtext/richtextliststylepage.cpp:402
+#: ../src/richtext/richtextmarginspage.cpp:210
+#: ../src/richtext/richtextmarginspage.cpp:324
+#: ../src/richtext/richtextsizepage.cpp:601
+#: ../src/richtext/richtextsizepage.cpp:608
+msgid "&Right:"
+msgstr "右(&R):"
+
+#: ../src/richtext/richtextborderspage.cpp:291
+#: ../src/richtext/richtextborderspage.cpp:293
+msgid "Units for the right border width."
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:310
+#: ../src/richtext/richtextborderspage.cpp:478
+#: ../src/richtext/richtextmarginspage.cpp:233
+#: ../src/richtext/richtextmarginspage.cpp:347
+#: ../src/richtext/richtextsizepage.cpp:566
+#: ../src/richtext/richtextsizepage.cpp:573
+msgid "&Top:"
+msgstr "上(&T):"
+
+#: ../src/richtext/richtextborderspage.cpp:325
+#: ../src/richtext/richtextborderspage.cpp:327
+msgid "Units for the top border width."
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:344
+#: ../src/richtext/richtextborderspage.cpp:512
+#: ../src/richtext/richtextmarginspage.cpp:258
+#: ../src/richtext/richtextmarginspage.cpp:372
+#: ../src/richtext/richtextsizepage.cpp:636
+#: ../src/richtext/richtextsizepage.cpp:643
+msgid "&Bottom:"
+msgstr "下(&B):"
+
+#: ../src/richtext/richtextborderspage.cpp:359
+#: ../src/richtext/richtextborderspage.cpp:361
+msgid "Units for the bottom border width."
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:380
+#: ../src/richtext/richtextborderspage.cpp:548
+msgid "&Synchronize values"
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:382
+#: ../src/richtext/richtextborderspage.cpp:384
+#: ../src/richtext/richtextborderspage.cpp:550
+#: ../src/richtext/richtextborderspage.cpp:552
+msgid "Check to edit all borders simultaneously."
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:397
+#: ../src/richtext/richtextborderspage.cpp:555
+#, fuzzy
+msgid "Outline"
+msgstr "アウトラインレベル (&O):"
+
+#: ../src/richtext/richtextborderspage.cpp:425
+#: ../src/richtext/richtextborderspage.cpp:427
+msgid "Units for the left outline width."
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:459
+#: ../src/richtext/richtextborderspage.cpp:461
+msgid "Units for the right outline width."
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:493
+#: ../src/richtext/richtextborderspage.cpp:495
+msgid "Units for the top outline width."
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:527
+#: ../src/richtext/richtextborderspage.cpp:529
+msgid "Units for the bottom outline width."
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:565
+#: ../src/richtext/richtextborderspage.cpp:600
+msgid "Corner"
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:574
+msgid "Corner &radius:"
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:576
+#: ../src/richtext/richtextborderspage.cpp:578
+msgid "An optional corner radius for adding rounded corners."
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:584
+#: ../src/richtext/richtextborderspage.cpp:586
+msgid "The value of the corner radius."
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:595
+#: ../src/richtext/richtextborderspage.cpp:597
+#, fuzzy
+msgid "Units for the corner radius."
+msgstr "スレッドの終了待ちに失敗しました。"
+
+#: ../src/richtext/richtextborderspage.cpp:609
+#: ../src/richtext/richtextsizepage.cpp:247
+#: ../src/richtext/richtextsizepage.cpp:251
+#, fuzzy
+msgid "None"
+msgstr "(なし)"
+
+#: ../src/richtext/richtextborderspage.cpp:610
+#, fuzzy
+msgid "Solid"
+msgstr "太字"
+
+#: ../src/richtext/richtextborderspage.cpp:611
+#, fuzzy
+msgid "Dotted"
+msgstr "完了"
+
+#: ../src/richtext/richtextborderspage.cpp:612
+msgid "Dashed"
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:613
+#, fuzzy
+msgid "Double"
+msgstr "double値"
+
+#: ../src/richtext/richtextborderspage.cpp:614
+msgid "Groove"
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:615
+#, fuzzy
+msgid "Ridge"
+msgstr "右"
+
+#: ../src/richtext/richtextborderspage.cpp:616
+#, fuzzy
+msgid "Inset"
+msgstr "挿入"
+
+#: ../src/richtext/richtextborderspage.cpp:617
+msgid "Outset"
+msgstr ""
+
+#: ../src/richtext/richtextbuffer.cpp:3518
+msgid "Change Style"
+msgstr "スタイルの変更"
+
+#: ../src/richtext/richtextbuffer.cpp:3701
+#, fuzzy
+msgid "Change Object Style"
+msgstr "リストスタイルを変更します"
+
+#: ../src/richtext/richtextbuffer.cpp:3974
+#: ../src/richtext/richtextbuffer.cpp:8174
+msgid "Change Properties"
+msgstr "プロパティを変更"
+
+#: ../src/richtext/richtextbuffer.cpp:4346
+msgid "Change List Style"
+msgstr "リストスタイルを変更します"
+
+#: ../src/richtext/richtextbuffer.cpp:4519
+msgid "Renumber List"
+msgstr "リスト連番の初期化"
+
+#: ../src/richtext/richtextbuffer.cpp:7867
+#: ../src/richtext/richtextbuffer.cpp:7897
+#: ../src/richtext/richtextbuffer.cpp:7939
+#: ../src/richtext/richtextctrl.cpp:1279 ../src/richtext/richtextctrl.cpp:1473
+msgid "Insert Text"
+msgstr "テキストの挿入"
+
+#: ../src/richtext/richtextbuffer.cpp:8023
+#: ../src/richtext/richtextbuffer.cpp:8979
+msgid "Insert Image"
+msgstr "画像の挿入"
+
+#: ../src/richtext/richtextbuffer.cpp:8070
+#, fuzzy
+msgid "Insert Object"
+msgstr "テキストの挿入"
+
+#: ../src/richtext/richtextbuffer.cpp:8112
+#, fuzzy
+msgid "Insert Field"
+msgstr "テキストの挿入"
+
+#: ../src/richtext/richtextbuffer.cpp:8410
+msgid "Too many EndStyle calls!"
+msgstr "EndStyle の呼び出しが多すぎます。"
+
+#: ../src/richtext/richtextbuffer.cpp:8785
+msgid "files"
+msgstr "ファイル"
+
+#: ../src/richtext/richtextbuffer.cpp:9380
+msgid "standard/circle"
+msgstr "標準/丸"
+
+#: ../src/richtext/richtextbuffer.cpp:9381
+#, fuzzy
+msgid "standard/circle-outline"
+msgstr "標準/丸"
+
+#: ../src/richtext/richtextbuffer.cpp:9382
+msgid "standard/square"
+msgstr "標準/四角"
+
+#: ../src/richtext/richtextbuffer.cpp:9383
+msgid "standard/diamond"
+msgstr "標準/ひし形"
+
+#: ../src/richtext/richtextbuffer.cpp:9384
+msgid "standard/triangle"
+msgstr "標準/三角"
+
+#: ../src/richtext/richtextbuffer.cpp:9423
+#, fuzzy
+msgid "Box Properties"
+msgstr "プロパティー (&P)"
+
+#: ../src/richtext/richtextbuffer.cpp:10006
+msgid "Multiple Cell Properties"
+msgstr ""
+
+#: ../src/richtext/richtextbuffer.cpp:10008
+#, fuzzy
+msgid "Cell Properties"
+msgstr "プロパティー (&P)"
+
+#: ../src/richtext/richtextbuffer.cpp:11256
+#, fuzzy
+msgid "Set Cell Style"
+msgstr "スタイルの削除"
+
+#: ../src/richtext/richtextbuffer.cpp:11330
+#, fuzzy
+msgid "Delete Row"
+msgstr "削除"
+
+#: ../src/richtext/richtextbuffer.cpp:11380
+#, fuzzy
+msgid "Delete Column"
+msgstr "選択範囲の削除"
+
+#: ../src/richtext/richtextbuffer.cpp:11431
+msgid "Add Row"
+msgstr ""
+
+#: ../src/richtext/richtextbuffer.cpp:11494
+msgid "Add Column"
+msgstr ""
+
+#: ../src/richtext/richtextbuffer.cpp:11537
+#, fuzzy
+msgid "Table Properties"
+msgstr "プロパティー (&P)"
+
+#: ../src/richtext/richtextbuffer.cpp:12899
+#, fuzzy
+msgid "Picture Properties"
+msgstr "プロパティー (&P)"
+
+#: ../src/richtext/richtextbuffer.cpp:13169
+#: ../src/richtext/richtextbuffer.cpp:13279
+msgid "image"
+msgstr "画像一時ファイル"
+
+#: ../src/richtext/richtextbulletspage.cpp:145
+#: ../src/richtext/richtextliststylepage.cpp:209
+msgid "&Bullet style:"
+msgstr "行頭文字のスタイル(&B):"
+
+#: ../src/richtext/richtextbulletspage.cpp:150
+#: ../src/richtext/richtextbulletspage.cpp:152
+#: ../src/richtext/richtextliststylepage.cpp:214
+#: ../src/richtext/richtextliststylepage.cpp:216
+msgid "The available bullet styles."
+msgstr "使用できる行頭文字スタイルです。"
+
+#: ../src/richtext/richtextbulletspage.cpp:158
+#: ../src/richtext/richtextliststylepage.cpp:221
+msgid "Peri&od"
+msgstr "ピリオド(&O)"
+
+#: ../src/richtext/richtextbulletspage.cpp:160
+#: ../src/richtext/richtextbulletspage.cpp:162
+#: ../src/richtext/richtextliststylepage.cpp:223
+#: ../src/richtext/richtextliststylepage.cpp:225
+msgid "Check to add a period after the bullet."
+msgstr "行頭文字の後にピリオドを付ける場合にチェックしてください。"
+
+#. TRANSLATORS: Bullet point in parentheses option
+#: ../src/richtext/richtextbulletspage.cpp:167
+#: ../src/richtext/richtextliststylepage.cpp:230
+msgid "(*)"
+msgstr "(*)"
+
+#: ../src/richtext/richtextbulletspage.cpp:169
+#: ../src/richtext/richtextbulletspage.cpp:171
+#: ../src/richtext/richtextliststylepage.cpp:232
+#: ../src/richtext/richtextliststylepage.cpp:234
+msgid "Check to enclose the bullet in parentheses."
+msgstr "行頭文字を丸括弧でくくる場合にチェックしてください。"
+
+#. TRANSLATORS: Right parenthesis bullet point option
+#: ../src/richtext/richtextbulletspage.cpp:176
+#: ../src/richtext/richtextliststylepage.cpp:239
+msgid "*)"
+msgstr "*)"
+
+#: ../src/richtext/richtextbulletspage.cpp:178
+#: ../src/richtext/richtextbulletspage.cpp:180
+#: ../src/richtext/richtextliststylepage.cpp:241
+#: ../src/richtext/richtextliststylepage.cpp:243
+msgid "Check to add a right parenthesis."
+msgstr "右丸括弧を加える場合はチェックしてください。"
+
+#: ../src/richtext/richtextbulletspage.cpp:185
+#: ../src/richtext/richtextliststylepage.cpp:248
+msgid "Bullet &Alignment:"
+msgstr "行頭文字の位置(&A):"
+
+#: ../src/richtext/richtextbulletspage.cpp:190
+#: ../src/richtext/richtextliststylepage.cpp:253
+msgid "Centre"
+msgstr "中央寄せ"
+
+#: ../src/richtext/richtextbulletspage.cpp:194
+#: ../src/richtext/richtextbulletspage.cpp:196
+#: ../src/richtext/richtextbulletspage.cpp:217
+#: ../src/richtext/richtextbulletspage.cpp:219
+#: ../src/richtext/richtextliststylepage.cpp:257
+#: ../src/richtext/richtextliststylepage.cpp:259
+#: ../src/richtext/richtextliststylepage.cpp:278
+#: ../src/richtext/richtextliststylepage.cpp:280
+msgid "The bullet character."
+msgstr "行頭文字を指定します。"
+
+#: ../src/richtext/richtextbulletspage.cpp:212
+#: ../src/richtext/richtextliststylepage.cpp:271
+msgid "&Symbol:"
+msgstr "記号(&S):"
+
+#: ../src/richtext/richtextbulletspage.cpp:222
+#: ../src/richtext/richtextliststylepage.cpp:283
+msgid "Ch&oose..."
+msgstr "選択(&O)..."
+
+#: ../src/richtext/richtextbulletspage.cpp:223
+#: ../src/richtext/richtextbulletspage.cpp:225
+#: ../src/richtext/richtextliststylepage.cpp:284
+#: ../src/richtext/richtextliststylepage.cpp:286
+msgid "Click to browse for a symbol."
+msgstr "クリックで記号を一覧できます。"
+
+#: ../src/richtext/richtextbulletspage.cpp:230
+#: ../src/richtext/richtextliststylepage.cpp:291
+msgid "Symbol &font:"
+msgstr "記号フォント(&F):"
+
+#: ../src/richtext/richtextbulletspage.cpp:235
+#: ../src/richtext/richtextbulletspage.cpp:237
+#: ../src/richtext/richtextliststylepage.cpp:297
+msgid "Available fonts."
+msgstr "有効なフォントです。"
+
+#: ../src/richtext/richtextbulletspage.cpp:242
+#: ../src/richtext/richtextliststylepage.cpp:302
+msgid "S&tandard bullet name:"
+msgstr "標準行頭文字名(&T):"
+
+#: ../src/richtext/richtextbulletspage.cpp:247
+#: ../src/richtext/richtextbulletspage.cpp:249
+#: ../src/richtext/richtextliststylepage.cpp:307
+#: ../src/richtext/richtextliststylepage.cpp:309
+msgid "A standard bullet name."
+msgstr "標準の行頭文字名を指定します。"
+
+#: ../src/richtext/richtextbulletspage.cpp:254
+msgid "&Number:"
+msgstr "番号(&N):"
+
+#: ../src/richtext/richtextbulletspage.cpp:258
+#: ../src/richtext/richtextbulletspage.cpp:260
+msgid "The list item number."
+msgstr "連番の番号を指定できます。"
+
+#: ../src/richtext/richtextbulletspage.cpp:266
+#: ../src/richtext/richtextbulletspage.cpp:268
+#: ../src/richtext/richtextliststylepage.cpp:475
+#: ../src/richtext/richtextliststylepage.cpp:477
+msgid "Shows a preview of the bullet settings."
+msgstr "行頭文字設定のプレビューを表示します。"
+
+#: ../src/richtext/richtextbulletspage.cpp:276
+#: ../src/richtext/richtextliststylepage.cpp:484
+msgid "(None)"
+msgstr "(なし)"
+
+#: ../src/richtext/richtextbulletspage.cpp:277
+#: ../src/richtext/richtextliststylepage.cpp:485
+msgid "Arabic"
+msgstr "算用数字"
+
+#: ../src/richtext/richtextbulletspage.cpp:278
+#: ../src/richtext/richtextliststylepage.cpp:486
+msgid "Upper case letters"
+msgstr "大文字単語"
+
+#: ../src/richtext/richtextbulletspage.cpp:279
+#: ../src/richtext/richtextliststylepage.cpp:487
+msgid "Lower case letters"
+msgstr "小文字単語"
+
+#: ../src/richtext/richtextbulletspage.cpp:280
+#: ../src/richtext/richtextliststylepage.cpp:488
+msgid "Upper case roman numerals"
+msgstr "大文字ローマ数字"
+
+#: ../src/richtext/richtextbulletspage.cpp:281
+#: ../src/richtext/richtextliststylepage.cpp:489
+msgid "Lower case roman numerals"
+msgstr "小文字ローマ数字"
+
+#: ../src/richtext/richtextbulletspage.cpp:282
+#: ../src/richtext/richtextliststylepage.cpp:490
+msgid "Numbered outline"
+msgstr "番号付きアウトライン"
+
+#: ../src/richtext/richtextbulletspage.cpp:283
+#: ../src/richtext/richtextliststylepage.cpp:491
+msgid "Symbol"
+msgstr "記号"
+
+#: ../src/richtext/richtextbulletspage.cpp:284
+#: ../src/richtext/richtextliststylepage.cpp:492
+msgid "Bitmap"
+msgstr "ビットマップ"
+
+#: ../src/richtext/richtextbulletspage.cpp:285
+#: ../src/richtext/richtextliststylepage.cpp:493
+msgid "Standard"
+msgstr "標準"
+
+#: ../src/richtext/richtextbulletspage.cpp:287
+#: ../src/richtext/richtextliststylepage.cpp:495
+msgid "*"
+msgstr "*"
+
+#: ../src/richtext/richtextbulletspage.cpp:288
+#: ../src/richtext/richtextliststylepage.cpp:496
+msgid "-"
+msgstr "-"
+
+#: ../src/richtext/richtextbulletspage.cpp:289
+#: ../src/richtext/richtextliststylepage.cpp:497
+msgid ">"
+msgstr ">"
+
+#: ../src/richtext/richtextbulletspage.cpp:290
+#: ../src/richtext/richtextliststylepage.cpp:498
+msgid "+"
+msgstr "+"
+
+#: ../src/richtext/richtextbulletspage.cpp:291
+#: ../src/richtext/richtextliststylepage.cpp:499
+msgid "~"
+msgstr "~"
+
+#: ../src/richtext/richtextctrl.cpp:859
+msgid "Drag"
+msgstr ""
+
+#: ../src/richtext/richtextctrl.cpp:1338 ../src/richtext/richtextctrl.cpp:1559
+msgid "Delete Text"
+msgstr "テキストの削除"
+
+#: ../src/richtext/richtextctrl.cpp:1537
+#, fuzzy
+msgid "Remove Bullet"
+msgstr "削除"
+
+#: ../src/richtext/richtextctrl.cpp:3070
+msgid "The text couldn't be saved."
+msgstr "テキストが保存できませんでした。"
+
+#: ../src/richtext/richtextctrl.cpp:3644
+msgid "Replace"
+msgstr "置換"
+
+#: ../src/richtext/richtextfontpage.cpp:146
+#: ../src/richtext/richtextsymboldlg.cpp:384
+msgid "&Font:"
+msgstr "フォント(&F):"
+
+#: ../src/richtext/richtextfontpage.cpp:150
+#: ../src/richtext/richtextfontpage.cpp:152
+msgid "Type a font name."
+msgstr "フォント名を指定します。"
+
+#: ../src/richtext/richtextfontpage.cpp:158
+msgid "&Size:"
+msgstr "大きさ(&S):"
+
+#: ../src/richtext/richtextfontpage.cpp:165
+#: ../src/richtext/richtextfontpage.cpp:167
+msgid "Type a size in points."
+msgstr "ポイントで大きさを指定します。"
+
+#: ../src/richtext/richtextfontpage.cpp:180
+#: ../src/richtext/richtextfontpage.cpp:182
+#, fuzzy
+msgid "The font size units, points or pixels."
+msgstr "フォントの大きさをポイントで記します。"
+
+#: ../src/richtext/richtextfontpage.cpp:189
+#: ../src/richtext/richtextfontpage.cpp:191
+msgid "Lists the available fonts."
+msgstr "利用できるフォントの一覧です。"
+
+#: ../src/richtext/richtextfontpage.cpp:196
+#: ../src/richtext/richtextfontpage.cpp:198
+msgid "Lists font sizes in points."
+msgstr "利用できるポイント指定の大きさ一覧です。"
+
+#: ../src/richtext/richtextfontpage.cpp:207
+msgid "Font st&yle:"
+msgstr "フォントのスタイル(&Y):"
+
+#: ../src/richtext/richtextfontpage.cpp:212
+#: ../src/richtext/richtextfontpage.cpp:214
+msgid "Select regular or italic style."
+msgstr "イタリックにするかしないかを選んでください。"
+
+#: ../src/richtext/richtextfontpage.cpp:220
+msgid "Font &weight:"
+msgstr "フォントのウエイト(&W):"
+
+#: ../src/richtext/richtextfontpage.cpp:225
+#: ../src/richtext/richtextfontpage.cpp:227
+msgid "Select regular or bold."
+msgstr "太字にするかしないかを選んでください。"
+
+#: ../src/richtext/richtextfontpage.cpp:233
+msgid "&Underlining:"
+msgstr "下線 (&U):"
+
+#: ../src/richtext/richtextfontpage.cpp:238
+#: ../src/richtext/richtextfontpage.cpp:240
+msgid "Select underlining or no underlining."
+msgstr "下線を付けるか付けないかを選んでください。"
+
+#: ../src/richtext/richtextfontpage.cpp:248
+msgid "&Colour:"
+msgstr "色 (&C):"
+
+#: ../src/richtext/richtextfontpage.cpp:253
+#: ../src/richtext/richtextfontpage.cpp:255
+msgid "Click to change the text colour."
+msgstr "クリックで文字色を変更します。"
+
+#: ../src/richtext/richtextfontpage.cpp:261
+msgid "&Bg colour:"
+msgstr "背景色 (&C):"
+
+#: ../src/richtext/richtextfontpage.cpp:266
+#: ../src/richtext/richtextfontpage.cpp:268
+msgid "Click to change the text background colour."
+msgstr "クリックで背景色を変更します。"
+
+#: ../src/richtext/richtextfontpage.cpp:276
+#: ../src/richtext/richtextfontpage.cpp:278
+msgid "Check to show a line through the text."
+msgstr "テキストを貫く打ち消し線を表示する場合にチェックしてください。"
+
+#: ../src/richtext/richtextfontpage.cpp:281
+msgid "Ca&pitals"
+msgstr "大文字化 (&P)"
+
+#: ../src/richtext/richtextfontpage.cpp:283
+#: ../src/richtext/richtextfontpage.cpp:285
+msgid "Check to show the text in capitals."
+msgstr "テキストを大文字にする場合にチェックしてください。"
+
+#: ../src/richtext/richtextfontpage.cpp:288
+#, fuzzy
+msgid "Small C&apitals"
+msgstr "大文字化 (&P)"
+
+#: ../src/richtext/richtextfontpage.cpp:290
+#: ../src/richtext/richtextfontpage.cpp:292
+#, fuzzy
+msgid "Check to show the text in small capitals."
+msgstr "テキストを大文字にする場合にチェックしてください。"
+
+#: ../src/richtext/richtextfontpage.cpp:295
+msgid "Supe&rscript"
+msgstr "上付き文字(&R)"
+
+#: ../src/richtext/richtextfontpage.cpp:297
+#: ../src/richtext/richtextfontpage.cpp:299
+msgid "Check to show the text in superscript."
+msgstr "テキストを上付き文字にする場合にチェックしてください。"
+
+#: ../src/richtext/richtextfontpage.cpp:302
+msgid "Subscrip&t"
+msgstr "下付き文字(&T)"
+
+#: ../src/richtext/richtextfontpage.cpp:304
+#: ../src/richtext/richtextfontpage.cpp:306
+msgid "Check to show the text in subscript."
+msgstr "テキストを下付き文字にする場合にチェックしてください。"
+
+#: ../src/richtext/richtextfontpage.cpp:312
+msgid "Rig&ht-to-left"
+msgstr ""
+
+#: ../src/richtext/richtextfontpage.cpp:314
+#: ../src/richtext/richtextfontpage.cpp:316
+#, fuzzy
+msgid "Check to indicate right-to-left text layout."
+msgstr "クリックで文字色を変更します。"
+
+#: ../src/richtext/richtextfontpage.cpp:319
+msgid "Suppress hyphe&nation"
+msgstr ""
+
+#: ../src/richtext/richtextfontpage.cpp:321
+#: ../src/richtext/richtextfontpage.cpp:323
+msgid "Check to suppress hyphenation."
+msgstr ""
+
+#: ../src/richtext/richtextfontpage.cpp:329
+#: ../src/richtext/richtextfontpage.cpp:331
+msgid "Shows a preview of the font settings."
+msgstr "フォント設定のプレビューを表示します。"
+
+#: ../src/richtext/richtextfontpage.cpp:348
+#: ../src/richtext/richtextfontpage.cpp:352
+#: ../src/richtext/richtextfontpage.cpp:356
+#: ../src/richtext/richtextformatdlg.cpp:873
+#: ../src/richtext/richtextindentspage.cpp:273
+#: ../src/richtext/richtextindentspage.cpp:285
+#: ../src/richtext/richtextindentspage.cpp:286
+#: ../src/richtext/richtextindentspage.cpp:310
+#: ../src/richtext/richtextindentspage.cpp:325
+#: ../src/richtext/richtextliststylepage.cpp:451
+#: ../src/richtext/richtextliststylepage.cpp:463
+#: ../src/richtext/richtextliststylepage.cpp:464
+msgid "(none)"
+msgstr "(なし)"
+
+#: ../src/richtext/richtextfontpage.cpp:349
+#: ../src/richtext/richtextfontpage.cpp:353
+msgid "Regular"
+msgstr "通常"
+
+#: ../src/richtext/richtextfontpage.cpp:357
+msgid "Not underlined"
+msgstr "下線なし"
+
+#: ../src/richtext/richtextformatdlg.cpp:341
+msgid "Indents && Spacing"
+msgstr "字下げと間隔"
+
+#: ../src/richtext/richtextformatdlg.cpp:346
+msgid "Tabs"
+msgstr "タブ"
+
+#: ../src/richtext/richtextformatdlg.cpp:351
+msgid "Bullets"
+msgstr "行頭文字"
+
+#: ../src/richtext/richtextformatdlg.cpp:356
+msgid "List Style"
+msgstr "リストスタイル"
+
+#: ../src/richtext/richtextformatdlg.cpp:366
+#: ../src/richtext/richtextmarginspage.cpp:170
+#, fuzzy
+msgid "Margins"
+msgstr "MacGeorgian"
+
+#: ../src/richtext/richtextformatdlg.cpp:371
+#, fuzzy
+msgid "Borders"
+msgstr "Modern"
+
+#: ../src/richtext/richtextformatdlg.cpp:765
+msgid "Colour"
+msgstr "色"
+
+#: ../src/richtext/richtextindentspage.cpp:127
+#: ../src/richtext/richtextliststylepage.cpp:322
+msgid "&Alignment"
+msgstr "整列 (&A)"
+
+#: ../src/richtext/richtextindentspage.cpp:138
+#: ../src/richtext/richtextliststylepage.cpp:331
+msgid "&Left"
+msgstr "左 (&L)"
+
+#: ../src/richtext/richtextindentspage.cpp:140
+#: ../src/richtext/richtextindentspage.cpp:142
+#: ../src/richtext/richtextliststylepage.cpp:333
+#: ../src/richtext/richtextliststylepage.cpp:335
+msgid "Left-align text."
+msgstr "テキストを左寄せにします。"
+
+#: ../src/richtext/richtextindentspage.cpp:145
+#: ../src/richtext/richtextliststylepage.cpp:338
+msgid "&Right"
+msgstr "右 (&R)"
+
+#: ../src/richtext/richtextindentspage.cpp:147
+#: ../src/richtext/richtextindentspage.cpp:149
+#: ../src/richtext/richtextliststylepage.cpp:340
+#: ../src/richtext/richtextliststylepage.cpp:342
+msgid "Right-align text."
+msgstr "右寄せにします。"
+
+#: ../src/richtext/richtextindentspage.cpp:152
+#: ../src/richtext/richtextliststylepage.cpp:345
+msgid "&Justified"
+msgstr "両端揃え (&J)"
+
+#: ../src/richtext/richtextindentspage.cpp:154
+#: ../src/richtext/richtextindentspage.cpp:156
+#: ../src/richtext/richtextliststylepage.cpp:347
+#: ../src/richtext/richtextliststylepage.cpp:349
+msgid "Justify text left and right."
+msgstr "左右端いっぱいにテキストを表示します。"
+
+#: ../src/richtext/richtextindentspage.cpp:159
+#: ../src/richtext/richtextliststylepage.cpp:352
+msgid "Cen&tred"
+msgstr "中央寄せ (&T)"
+
+#: ../src/richtext/richtextindentspage.cpp:161
+#: ../src/richtext/richtextindentspage.cpp:163
+#: ../src/richtext/richtextliststylepage.cpp:354
+#: ../src/richtext/richtextliststylepage.cpp:356
+msgid "Centre text."
+msgstr "テキストを中央寄せにします。"
+
+#: ../src/richtext/richtextindentspage.cpp:166
+#: ../src/richtext/richtextliststylepage.cpp:359
+msgid "&Indeterminate"
+msgstr "指定しない (&I)"
+
+#: ../src/richtext/richtextindentspage.cpp:168
+#: ../src/richtext/richtextindentspage.cpp:170
+#: ../src/richtext/richtextliststylepage.cpp:361
+#: ../src/richtext/richtextliststylepage.cpp:363
+msgid "Use the current alignment setting."
+msgstr "現在の整列設定を用います。"
+
+#: ../src/richtext/richtextindentspage.cpp:183
+#: ../src/richtext/richtextliststylepage.cpp:375
+msgid "&Indentation (tenths of a mm)"
+msgstr "字下げ(1/10ミリ単位) (&I)"
+
+#: ../src/richtext/richtextindentspage.cpp:198
+#: ../src/richtext/richtextindentspage.cpp:200
+#: ../src/richtext/richtextliststylepage.cpp:388
+#: ../src/richtext/richtextliststylepage.cpp:390
+msgid "The left indent."
+msgstr "左側の字下げを指定できます。"
+
+#: ../src/richtext/richtextindentspage.cpp:203
+#: ../src/richtext/richtextliststylepage.cpp:393
+msgid "Left (&first line):"
+msgstr "左-一行目 (&F):"
+
+#: ../src/richtext/richtextindentspage.cpp:207
+#: ../src/richtext/richtextindentspage.cpp:209
+#: ../src/richtext/richtextliststylepage.cpp:397
+#: ../src/richtext/richtextliststylepage.cpp:399
+msgid "The first line indent."
+msgstr "最初の行の字下げです。"
+
+#: ../src/richtext/richtextindentspage.cpp:216
+#: ../src/richtext/richtextindentspage.cpp:218
+#: ../src/richtext/richtextliststylepage.cpp:406
+#: ../src/richtext/richtextliststylepage.cpp:408
+msgid "The right indent."
+msgstr "右側の字下げです。"
+
+#: ../src/richtext/richtextindentspage.cpp:221
+msgid "&Outline level:"
+msgstr "アウトラインレベル (&O):"
+
+#: ../src/richtext/richtextindentspage.cpp:226
+#: ../src/richtext/richtextindentspage.cpp:228
+msgid "The outline level."
+msgstr "アウトラインレベルを指定できます。"
+
+#: ../src/richtext/richtextindentspage.cpp:241
+#: ../src/richtext/richtextliststylepage.cpp:420
+msgid "&Spacing (tenths of a mm)"
+msgstr "間隔 - 1/10mm単位 (&S)"
+
+#: ../src/richtext/richtextindentspage.cpp:252
+msgid "&Before a paragraph:"
+msgstr "段落の前 (&B):"
+
+#: ../src/richtext/richtextindentspage.cpp:256
+#: ../src/richtext/richtextindentspage.cpp:258
+#: ../src/richtext/richtextliststylepage.cpp:433
+#: ../src/richtext/richtextliststylepage.cpp:435
+msgid "The spacing before the paragraph."
+msgstr "段落の前の空間を指定します。"
+
+#: ../src/richtext/richtextindentspage.cpp:261
+msgid "&After a paragraph:"
+msgstr "段落の後 (&A):"
+
+#: ../src/richtext/richtextindentspage.cpp:266
+#: ../src/richtext/richtextliststylepage.cpp:442
+#: ../src/richtext/richtextliststylepage.cpp:444
+msgid "The spacing after the paragraph."
+msgstr "段落の後の空間を指定します。"
+
+#: ../src/richtext/richtextindentspage.cpp:269
+msgid "L&ine spacing:"
+msgstr "行間隔 (&I):"
+
+#: ../src/richtext/richtextindentspage.cpp:274
+#: ../src/richtext/richtextliststylepage.cpp:452
+msgid "Single"
+msgstr "1"
+
+#: ../src/richtext/richtextindentspage.cpp:275
+#: ../src/richtext/richtextliststylepage.cpp:453
+msgid "1.1"
+msgstr "1.1"
+
+#: ../src/richtext/richtextindentspage.cpp:276
+#: ../src/richtext/richtextliststylepage.cpp:454
+msgid "1.2"
+msgstr "1.2"
+
+#: ../src/richtext/richtextindentspage.cpp:277
+#: ../src/richtext/richtextliststylepage.cpp:455
+msgid "1.3"
+msgstr "1.3"
+
+#: ../src/richtext/richtextindentspage.cpp:278
+#: ../src/richtext/richtextliststylepage.cpp:456
+msgid "1.4"
+msgstr "1.4"
+
+#: ../src/richtext/richtextindentspage.cpp:279
+#: ../src/richtext/richtextliststylepage.cpp:457
+msgid "1.5"
+msgstr "1.5"
+
+#: ../src/richtext/richtextindentspage.cpp:280
+#: ../src/richtext/richtextliststylepage.cpp:458
+msgid "1.6"
+msgstr "1.6"
+
+#: ../src/richtext/richtextindentspage.cpp:281
+#: ../src/richtext/richtextliststylepage.cpp:459
+msgid "1.7"
+msgstr "1.7"
+
+#: ../src/richtext/richtextindentspage.cpp:282
+#: ../src/richtext/richtextliststylepage.cpp:460
+msgid "1.8"
+msgstr "1.8"
+
+#: ../src/richtext/richtextindentspage.cpp:283
+#: ../src/richtext/richtextliststylepage.cpp:461
+msgid "1.9"
+msgstr "1.9"
+
+#: ../src/richtext/richtextindentspage.cpp:284
+#: ../src/richtext/richtextliststylepage.cpp:462
+msgid "2"
+msgstr "2"
+
+#: ../src/richtext/richtextindentspage.cpp:287
+#: ../src/richtext/richtextindentspage.cpp:289
+#: ../src/richtext/richtextliststylepage.cpp:465
+#: ../src/richtext/richtextliststylepage.cpp:467
+msgid "The line spacing."
+msgstr "行間隔を指定できます。"
+
+#: ../src/richtext/richtextindentspage.cpp:292
+msgid "&Page Break"
+msgstr ""
+
+#: ../src/richtext/richtextindentspage.cpp:294
+#: ../src/richtext/richtextindentspage.cpp:296
+#, fuzzy
+msgid "Inserts a page break before the paragraph."
+msgstr "段落の前の空間を指定します。"
+
+#: ../src/richtext/richtextindentspage.cpp:302
+#: ../src/richtext/richtextindentspage.cpp:304
+msgid "Shows a preview of the paragraph settings."
+msgstr "段落設定のプレビューを表示します。"
+
+#: ../src/richtext/richtextliststylepage.cpp:182
+msgid "&List level:"
+msgstr "リストレベル (&L):"
+
+#: ../src/richtext/richtextliststylepage.cpp:186
+#: ../src/richtext/richtextliststylepage.cpp:188
+msgid "Selects the list level to edit."
+msgstr "編集したいリストレベルを選んでください。"
+
+#: ../src/richtext/richtextliststylepage.cpp:193
+msgid "&Font for Level..."
+msgstr "レベル毎のフォント (&F)..."
+
+#: ../src/richtext/richtextliststylepage.cpp:194
+#: ../src/richtext/richtextliststylepage.cpp:196
+msgid "Click to choose the font for this level."
+msgstr "クリックでこのレベルのフォントを選択します。"
+
+#: ../src/richtext/richtextliststylepage.cpp:312
+msgid "Bullet style"
+msgstr "行頭文字のスタイル"
+
+#: ../src/richtext/richtextliststylepage.cpp:429
+msgid "Before a paragraph:"
+msgstr "段落の前:"
+
+#: ../src/richtext/richtextliststylepage.cpp:438
+msgid "After a paragraph:"
+msgstr "段落の後:"
+
+#: ../src/richtext/richtextliststylepage.cpp:447
+msgid "Line spacing:"
+msgstr "行間隔:"
+
+#: ../src/richtext/richtextliststylepage.cpp:470
+msgid "Spacing"
+msgstr "間隔"
+
+#: ../src/richtext/richtextmarginspage.cpp:193
+#: ../src/richtext/richtextmarginspage.cpp:195
+#, fuzzy
+msgid "The left margin size."
+msgstr "フォントの大きさをポイントで記します。"
+
+#: ../src/richtext/richtextmarginspage.cpp:203
+#: ../src/richtext/richtextmarginspage.cpp:205
+msgid "Units for the left margin."
+msgstr ""
+
+#: ../src/richtext/richtextmarginspage.cpp:218
+#: ../src/richtext/richtextmarginspage.cpp:220
+#, fuzzy
+msgid "The right margin size."
+msgstr "右側の字下げです。"
+
+#: ../src/richtext/richtextmarginspage.cpp:228
+#: ../src/richtext/richtextmarginspage.cpp:230
+msgid "Units for the right margin."
+msgstr ""
+
+#: ../src/richtext/richtextmarginspage.cpp:241
+#: ../src/richtext/richtextmarginspage.cpp:243
+#, fuzzy
+msgid "The top margin size."
+msgstr "フォントの大きさをポイントで記します。"
+
+#: ../src/richtext/richtextmarginspage.cpp:251
+#: ../src/richtext/richtextmarginspage.cpp:253
+#, fuzzy
+msgid "Units for the top margin."
+msgstr "スレッドの終了待ちに失敗しました。"
+
+#: ../src/richtext/richtextmarginspage.cpp:266
+#: ../src/richtext/richtextmarginspage.cpp:268
+#, fuzzy
+msgid "The bottom margin size."
+msgstr "フォントの大きさをポイントで記します。"
+
+#: ../src/richtext/richtextmarginspage.cpp:276
+#: ../src/richtext/richtextmarginspage.cpp:278
+msgid "Units for the bottom margin."
+msgstr ""
+
+#: ../src/richtext/richtextmarginspage.cpp:284
+#, fuzzy
+msgid "Padding"
+msgstr "読み取り"
+
+#: ../src/richtext/richtextmarginspage.cpp:307
+#: ../src/richtext/richtextmarginspage.cpp:309
+#, fuzzy
+msgid "The left padding size."
+msgstr "フォントの大きさをポイントで記します。"
+
+#: ../src/richtext/richtextmarginspage.cpp:317
+#: ../src/richtext/richtextmarginspage.cpp:319
+msgid "Units for the left padding."
+msgstr ""
+
+#: ../src/richtext/richtextmarginspage.cpp:332
+#: ../src/richtext/richtextmarginspage.cpp:334
+#, fuzzy
+msgid "The right padding size."
+msgstr "右側の字下げです。"
+
+#: ../src/richtext/richtextmarginspage.cpp:342
+#: ../src/richtext/richtextmarginspage.cpp:344
+msgid "Units for the right padding."
+msgstr ""
+
+#: ../src/richtext/richtextmarginspage.cpp:355
+#: ../src/richtext/richtextmarginspage.cpp:357
+#, fuzzy
+msgid "The top padding size."
+msgstr "フォントの大きさをポイントで記します。"
+
+#: ../src/richtext/richtextmarginspage.cpp:365
+#: ../src/richtext/richtextmarginspage.cpp:367
+msgid "Units for the top padding."
+msgstr ""
+
+#: ../src/richtext/richtextmarginspage.cpp:380
+#: ../src/richtext/richtextmarginspage.cpp:382
+#, fuzzy
+msgid "The bottom padding size."
+msgstr "フォントの大きさをポイントで記します。"
+
+#: ../src/richtext/richtextmarginspage.cpp:390
+#: ../src/richtext/richtextmarginspage.cpp:392
+msgid "Units for the bottom padding."
+msgstr ""
+
+#: ../src/richtext/richtextprint.cpp:592
+msgid " Preview"
+msgstr " プレビュー"
+
+#: ../src/richtext/richtextsizepage.cpp:228
+msgid "Floating"
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:243
+msgid "&Floating mode:"
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:252
+#: ../src/richtext/richtextsizepage.cpp:254
+msgid "How the object will float relative to the text."
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:265
+#, fuzzy
+msgid "Alignment"
+msgstr "整列 (&A)"
+
+#: ../src/richtext/richtextsizepage.cpp:277
+#, fuzzy
+msgid "&Vertical alignment:"
+msgstr "行頭文字の位置(&A):"
+
+#: ../src/richtext/richtextsizepage.cpp:279
+#: ../src/richtext/richtextsizepage.cpp:281
+#, fuzzy
+msgid "Enable vertical alignment."
+msgstr "整列方法を設定できませんでした。"
+
+#: ../src/richtext/richtextsizepage.cpp:286
+#, fuzzy
+msgid "Centred"
+msgstr "中央寄せ (&T)"
+
+#: ../src/richtext/richtextsizepage.cpp:290
+#: ../src/richtext/richtextsizepage.cpp:292
+#, fuzzy
+msgid "Vertical alignment."
+msgstr "整列方法を設定できませんでした。"
+
+#: ../src/richtext/richtextsizepage.cpp:316
+#: ../src/richtext/richtextsizepage.cpp:323
+#, fuzzy
+msgid "&Width:"
+msgstr "ウエイト (&W):"
+
+#: ../src/richtext/richtextsizepage.cpp:318
+#: ../src/richtext/richtextsizepage.cpp:320
+msgid "Enable the width value."
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:331
+#: ../src/richtext/richtextsizepage.cpp:333
+#, fuzzy
+msgid "The object width."
+msgstr "フォントのウエイトを指定できます。"
+
+#: ../src/richtext/richtextsizepage.cpp:342
+#: ../src/richtext/richtextsizepage.cpp:344
+msgid "Units for the object width."
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:350
+#: ../src/richtext/richtextsizepage.cpp:357
+#, fuzzy
+msgid "&Height:"
+msgstr "ウエイト (&W):"
+
+#: ../src/richtext/richtextsizepage.cpp:352
+#: ../src/richtext/richtextsizepage.cpp:354
+#: ../src/richtext/richtextsizepage.cpp:464
+#: ../src/richtext/richtextsizepage.cpp:466
+msgid "Enable the height value."
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:365
+#: ../src/richtext/richtextsizepage.cpp:367
+#, fuzzy
+msgid "The object height."
+msgstr "フォントのウエイトを指定できます。"
+
+#: ../src/richtext/richtextsizepage.cpp:376
+#: ../src/richtext/richtextsizepage.cpp:378
+msgid "Units for the object height."
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:381
+msgid "Min width:"
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:383
+#: ../src/richtext/richtextsizepage.cpp:385
+#, fuzzy
+msgid "Enable the minimum width value."
+msgstr "最小幅を設定できませんでした。"
+
+#: ../src/richtext/richtextsizepage.cpp:392
+#: ../src/richtext/richtextsizepage.cpp:394
+#, fuzzy
+msgid "The object minimum width."
+msgstr "フォントのウエイトを指定できます。"
+
+#: ../src/richtext/richtextsizepage.cpp:403
+#: ../src/richtext/richtextsizepage.cpp:405
+#, fuzzy
+msgid "Units for the minimum object width."
+msgstr "フォントのウエイトを指定できます。"
+
+#: ../src/richtext/richtextsizepage.cpp:408
+#, fuzzy
+msgid "Min height:"
+msgstr "フォントのウエイト(&W):"
+
+#: ../src/richtext/richtextsizepage.cpp:410
+#: ../src/richtext/richtextsizepage.cpp:412
+msgid "Enable the minimum height value."
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:419
+#: ../src/richtext/richtextsizepage.cpp:421
+#, fuzzy
+msgid "The object minimum height."
+msgstr "フォントのウエイトを指定できます。"
+
+#: ../src/richtext/richtextsizepage.cpp:430
+#: ../src/richtext/richtextsizepage.cpp:432
+#, fuzzy
+msgid "Units for the minimum object height."
+msgstr "フォントのウエイトを指定できます。"
+
+#: ../src/richtext/richtextsizepage.cpp:435
+#, fuzzy
+msgid "Max width:"
+msgstr "置換先:"
+
+#: ../src/richtext/richtextsizepage.cpp:437
+#: ../src/richtext/richtextsizepage.cpp:439
+#, fuzzy
+msgid "Enable the maximum width value."
+msgstr "最大幅を設定できませんでした。"
+
+#: ../src/richtext/richtextsizepage.cpp:446
+#: ../src/richtext/richtextsizepage.cpp:448
+#, fuzzy
+msgid "The object maximum width."
+msgstr "フォントのウエイトを指定できます。"
+
+#: ../src/richtext/richtextsizepage.cpp:457
+#: ../src/richtext/richtextsizepage.cpp:459
+#, fuzzy
+msgid "Units for the maximum object width."
+msgstr "フォントのウエイトを指定できます。"
+
+#: ../src/richtext/richtextsizepage.cpp:462
+#, fuzzy
+msgid "Max height:"
+msgstr "ウエイト (&W):"
+
+#: ../src/richtext/richtextsizepage.cpp:473
+#: ../src/richtext/richtextsizepage.cpp:475
+#, fuzzy
+msgid "The object maximum height."
+msgstr "フォントのウエイトを指定できます。"
+
+#: ../src/richtext/richtextsizepage.cpp:484
+#: ../src/richtext/richtextsizepage.cpp:486
+#, fuzzy
+msgid "Units for the maximum object height."
+msgstr "フォントのウエイトを指定できます。"
+
+#: ../src/richtext/richtextsizepage.cpp:495
+#, fuzzy
+msgid "Position"
+msgstr "印刷"
+
+#: ../src/richtext/richtextsizepage.cpp:513
+#, fuzzy
+msgid "&Position mode:"
+msgstr "印刷"
+
+#: ../src/richtext/richtextsizepage.cpp:517
+#: ../src/richtext/richtextsizepage.cpp:522
+#, fuzzy
+msgid "Static"
+msgstr "状態:"
+
+#: ../src/richtext/richtextsizepage.cpp:518
+#, fuzzy
+msgid "Relative"
+msgstr "Decorative"
+
+#: ../src/richtext/richtextsizepage.cpp:519
+msgid "Absolute"
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:520
+#, fuzzy
+msgid "Fixed"
+msgstr "固定幅フォント:"
+
+#: ../src/richtext/richtextsizepage.cpp:533
+#: ../src/richtext/richtextsizepage.cpp:535
+#: ../src/richtext/richtextsizepage.cpp:547
+#: ../src/richtext/richtextsizepage.cpp:549
+#, fuzzy
+msgid "The left position."
+msgstr "タブ位置です。"
+
+#: ../src/richtext/richtextsizepage.cpp:558
+#: ../src/richtext/richtextsizepage.cpp:560
+#, fuzzy
+msgid "Units for the left position."
+msgstr "スレッドの終了待ちに失敗しました。"
+
+#: ../src/richtext/richtextsizepage.cpp:568
+#: ../src/richtext/richtextsizepage.cpp:570
+#: ../src/richtext/richtextsizepage.cpp:582
+#: ../src/richtext/richtextsizepage.cpp:584
+#, fuzzy
+msgid "The top position."
+msgstr "タブ位置です。"
+
+#: ../src/richtext/richtextsizepage.cpp:593
+#: ../src/richtext/richtextsizepage.cpp:595
+#, fuzzy
+msgid "Units for the top position."
+msgstr "スレッドの終了待ちに失敗しました。"
+
+#: ../src/richtext/richtextsizepage.cpp:603
+#: ../src/richtext/richtextsizepage.cpp:605
+#: ../src/richtext/richtextsizepage.cpp:617
+#: ../src/richtext/richtextsizepage.cpp:619
+#, fuzzy
+msgid "The right position."
+msgstr "タブ位置です。"
+
+#: ../src/richtext/richtextsizepage.cpp:628
+#: ../src/richtext/richtextsizepage.cpp:630
+#, fuzzy
+msgid "Units for the right position."
+msgstr "スレッドの終了待ちに失敗しました。"
+
+#: ../src/richtext/richtextsizepage.cpp:638
+#: ../src/richtext/richtextsizepage.cpp:640
+#: ../src/richtext/richtextsizepage.cpp:652
+#: ../src/richtext/richtextsizepage.cpp:654
+#, fuzzy
+msgid "The bottom position."
+msgstr "タブ位置です。"
+
+#: ../src/richtext/richtextsizepage.cpp:663
+#: ../src/richtext/richtextsizepage.cpp:665
+#, fuzzy
+msgid "Units for the bottom position."
+msgstr "スレッドの終了待ちに失敗しました。"
+
+#: ../src/richtext/richtextsizepage.cpp:671
+msgid "&Move the object to:"
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:674
+#, fuzzy
+msgid "&Previous Paragraph"
+msgstr "前のページ"
+
+#: ../src/richtext/richtextsizepage.cpp:675
+#: ../src/richtext/richtextsizepage.cpp:677
+#, fuzzy
+msgid "Moves the object to the previous paragraph."
+msgstr "前のHTMLページに戻る"
+
+#: ../src/richtext/richtextsizepage.cpp:680
+#, fuzzy
+msgid "&Next Paragraph"
+msgstr "段落の後 (&A):"
+
+#: ../src/richtext/richtextsizepage.cpp:681
+#: ../src/richtext/richtextsizepage.cpp:683
+#, fuzzy
+msgid "Moves the object to the next paragraph."
+msgstr "次の段落に適用されるスタイルを指定します。"
+
+#: ../src/richtext/richtextstyledlg.cpp:193
+msgid "&Styles:"
+msgstr "スタイル一覧 (&S):"
+
+#: ../src/richtext/richtextstyledlg.cpp:197
+#: ../src/richtext/richtextstyledlg.cpp:199
+msgid "The available styles."
+msgstr "使用できるスタイルです。"
+
+#: ../src/richtext/richtextstyledlg.cpp:205
+#: ../src/richtext/richtextstyledlg.cpp:217
+msgid " "
+msgstr " "
+
+#: ../src/richtext/richtextstyledlg.cpp:209
+#: ../src/richtext/richtextstyledlg.cpp:211
+msgid "The style preview."
+msgstr "スタイルのプレビューです。"
+
+#: ../src/richtext/richtextstyledlg.cpp:220
+msgid "New &Character Style..."
+msgstr "新規文字スタイル (&C) ..."
+
+#: ../src/richtext/richtextstyledlg.cpp:221
+#: ../src/richtext/richtextstyledlg.cpp:223
+msgid "Click to create a new character style."
+msgstr "クリックで新しい文字スタイルを作成できます。"
+
+#: ../src/richtext/richtextstyledlg.cpp:226
+msgid "New &Paragraph Style..."
+msgstr "新規段落スタイル (&P) ..."
+
+#: ../src/richtext/richtextstyledlg.cpp:227
+#: ../src/richtext/richtextstyledlg.cpp:229
+msgid "Click to create a new paragraph style."
+msgstr "クリックで新しい段落スタイルを作成できます。"
+
+#: ../src/richtext/richtextstyledlg.cpp:232
+msgid "New &List Style..."
+msgstr "新規リストスタイル (&L) ..."
+
+#: ../src/richtext/richtextstyledlg.cpp:233
+#: ../src/richtext/richtextstyledlg.cpp:235
+msgid "Click to create a new list style."
+msgstr "クリックで新しいリストスタイルを作成できます。"
+
+#: ../src/richtext/richtextstyledlg.cpp:238
+#, fuzzy
+msgid "New &Box Style..."
+msgstr "新規リストスタイル (&L) ..."
+
+#: ../src/richtext/richtextstyledlg.cpp:239
+#: ../src/richtext/richtextstyledlg.cpp:241
+#, fuzzy
+msgid "Click to create a new box style."
+msgstr "クリックで新しいリストスタイルを作成できます。"
+
+#: ../src/richtext/richtextstyledlg.cpp:246
+msgid "&Apply Style"
+msgstr "スタイルの適用 (&A)"
+
+#: ../src/richtext/richtextstyledlg.cpp:247
+#: ../src/richtext/richtextstyledlg.cpp:249
+msgid "Click to apply the selected style."
+msgstr "クリックで選択したスタイルを適用します。"
+
+#: ../src/richtext/richtextstyledlg.cpp:252
+msgid "&Rename Style..."
+msgstr "スタイル名を変更 (&R)..."
+
+#: ../src/richtext/richtextstyledlg.cpp:253
+#: ../src/richtext/richtextstyledlg.cpp:255
+msgid "Click to rename the selected style."
+msgstr "クリックで選択したスタイルの名前を変更できます。"
+
+#: ../src/richtext/richtextstyledlg.cpp:258
+msgid "&Edit Style..."
+msgstr "スタイルの編集 (&E) ..."
+
+#: ../src/richtext/richtextstyledlg.cpp:259
+#: ../src/richtext/richtextstyledlg.cpp:261
+msgid "Click to edit the selected style."
+msgstr "クリックで選択したスタイルを編集できます。"
+
+#: ../src/richtext/richtextstyledlg.cpp:264
+msgid "&Delete Style..."
+msgstr "スタイルの削除 (&D)..."
+
+#: ../src/richtext/richtextstyledlg.cpp:265
+#: ../src/richtext/richtextstyledlg.cpp:267
+msgid "Click to delete the selected style."
+msgstr "クリックで選択したスタイルを削除できます。"
+
+#: ../src/richtext/richtextstyledlg.cpp:274
+#: ../src/richtext/richtextstyledlg.cpp:276
+msgid "Click to close this window."
+msgstr "クリックでこのウィンドウを閉じます。"
+
+#: ../src/richtext/richtextstyledlg.cpp:282
+msgid "&Restart numbering"
+msgstr "番号付けのリセット (&R)"
+
+#: ../src/richtext/richtextstyledlg.cpp:284
+#: ../src/richtext/richtextstyledlg.cpp:286
+msgid "Check to restart numbering."
+msgstr "連番の初期化を指示する場合にチェックしてください。"
+
+#: ../src/richtext/richtextstyledlg.cpp:601
+msgid "Enter a character style name"
+msgstr "文字スタイル名を入力してください"
+
+#: ../src/richtext/richtextstyledlg.cpp:601
+#: ../src/richtext/richtextstyledlg.cpp:606
+#: ../src/richtext/richtextstyledlg.cpp:649
+#: ../src/richtext/richtextstyledlg.cpp:654
+#: ../src/richtext/richtextstyledlg.cpp:815
+#: ../src/richtext/richtextstyledlg.cpp:820
+#: ../src/richtext/richtextstyledlg.cpp:888
+#: ../src/richtext/richtextstyledlg.cpp:896
+#: ../src/richtext/richtextstyledlg.cpp:929
+#: ../src/richtext/richtextstyledlg.cpp:934
+msgid "New Style"
+msgstr "新規スタイル"
+
+#: ../src/richtext/richtextstyledlg.cpp:606
+#: ../src/richtext/richtextstyledlg.cpp:654
+#: ../src/richtext/richtextstyledlg.cpp:820
+#: ../src/richtext/richtextstyledlg.cpp:896
+#: ../src/richtext/richtextstyledlg.cpp:934
+msgid "Sorry, that name is taken. Please choose another."
+msgstr "その名前はすでに使われています。他の名前を選んでください。"
+
+#: ../src/richtext/richtextstyledlg.cpp:649
+msgid "Enter a paragraph style name"
+msgstr "段落スタイル名を指定してください"
+
+#: ../src/richtext/richtextstyledlg.cpp:777
+#, c-format
+msgid "Delete style %s?"
+msgstr "スタイル %s を削除しますか?"
+
+#: ../src/richtext/richtextstyledlg.cpp:777
+msgid "Delete Style"
+msgstr "スタイルの削除"
+
+#: ../src/richtext/richtextstyledlg.cpp:815
+msgid "Enter a list style name"
+msgstr "リストスタイル名を入力してください"
+
+#: ../src/richtext/richtextstyledlg.cpp:888
+msgid "Enter a new style name"
+msgstr "新しいスタイル名を入力してください"
+
+#: ../src/richtext/richtextstyledlg.cpp:929
+#, fuzzy
+msgid "Enter a box style name"
+msgstr "新しいスタイル名を入力してください。"
+
+#: ../src/richtext/richtextstylepage.cpp:109
+#: ../src/richtext/richtextstylepage.cpp:111
+msgid "The style name."
+msgstr "スタイル名です。"
+
+#: ../src/richtext/richtextstylepage.cpp:114
+msgid "&Based on:"
+msgstr "基底 (&B):"
+
+#: ../src/richtext/richtextstylepage.cpp:119
+#: ../src/richtext/richtextstylepage.cpp:121
+msgid "The style on which this style is based."
+msgstr "このスタイルの元となるスタイルです。"
+
+#: ../src/richtext/richtextstylepage.cpp:124
+msgid "&Next style:"
+msgstr "次のスタイル (&N):"
+
+#: ../src/richtext/richtextstylepage.cpp:129
+#: ../src/richtext/richtextstylepage.cpp:131
+msgid "The default style for the next paragraph."
+msgstr "次の段落に適用されるスタイルを指定します。"
+
+#: ../src/richtext/richtextstyles.cpp:1057
+msgid "All styles"
+msgstr "すべてのスタイル"
+
+#: ../src/richtext/richtextstyles.cpp:1058
+msgid "Paragraph styles"
+msgstr "段落スタイル"
+
+#: ../src/richtext/richtextstyles.cpp:1059
+msgid "Character styles"
+msgstr "文字のスタイル"
+
+#: ../src/richtext/richtextstyles.cpp:1060
+msgid "List styles"
+msgstr "リストスタイル"
+
+#: ../src/richtext/richtextstyles.cpp:1061
+#, fuzzy
+msgid "Box styles"
+msgstr "すべてのスタイル"
+
+#: ../src/richtext/richtextsymboldlg.cpp:389
+#: ../src/richtext/richtextsymboldlg.cpp:391
+msgid "The font from which to take the symbol."
+msgstr "記号の取得元フォントを指定できます。"
+
+#: ../src/richtext/richtextsymboldlg.cpp:396
+msgid "&Subset:"
+msgstr "部分表示 (&S):"
+
+#: ../src/richtext/richtextsymboldlg.cpp:401
+#: ../src/richtext/richtextsymboldlg.cpp:403
+msgid "Shows a Unicode subset."
+msgstr "Unicode の部分集合を表示します。"
+
+#: ../src/richtext/richtextsymboldlg.cpp:412
+msgid "xxxx"
+msgstr "xxxx"
+
+#: ../src/richtext/richtextsymboldlg.cpp:417
+msgid "&Character code:"
+msgstr "文字コード (&C):"
+
+#: ../src/richtext/richtextsymboldlg.cpp:421
+#: ../src/richtext/richtextsymboldlg.cpp:423
+msgid "The character code."
+msgstr "文字コードです。"
+
+#: ../src/richtext/richtextsymboldlg.cpp:428
+msgid "&From:"
+msgstr "取得元 (&F):"
+
+#: ../src/richtext/richtextsymboldlg.cpp:433
+#: ../src/richtext/richtextsymboldlg.cpp:434
+#: ../src/richtext/richtextsymboldlg.cpp:435
+msgid "Unicode"
+msgstr "Unicode"
+
+#: ../src/richtext/richtextsymboldlg.cpp:436
+#: ../src/richtext/richtextsymboldlg.cpp:438
+msgid "The range to show."
+msgstr "表示する範囲を指定できます。"
+
+#: ../src/richtext/richtextsymboldlg.cpp:444
+msgid "Insert"
+msgstr "挿入"
+
+#: ../src/richtext/richtextsymboldlg.cpp:478
+msgid "(Normal text)"
+msgstr "(通常のテキスト)"
+
+#: ../src/richtext/richtexttabspage.cpp:109
+msgid "&Position (tenths of a mm):"
+msgstr "位置(1/10ミリ単位) (&P)"
+
+#: ../src/richtext/richtexttabspage.cpp:113
+#: ../src/richtext/richtexttabspage.cpp:115
+msgid "The tab position."
+msgstr "タブ位置です。"
+
+#: ../src/richtext/richtexttabspage.cpp:119
+msgid "The tab positions."
+msgstr "タブ位置の一覧です。"
+
+#: ../src/richtext/richtexttabspage.cpp:132
+#: ../src/richtext/richtexttabspage.cpp:134
+msgid "Click to create a new tab position."
+msgstr "クリックで新しいタブ位置を作成できます。"
+
+#: ../src/richtext/richtexttabspage.cpp:138
+#: ../src/richtext/richtexttabspage.cpp:140
+msgid "Click to delete the selected tab position."
+msgstr "クリックで選択した他部位置を削除できます。"
+
+#: ../src/richtext/richtexttabspage.cpp:143
+msgid "Delete A&ll"
+msgstr "すべて削除(&L)"
+
+#: ../src/richtext/richtexttabspage.cpp:144
+#: ../src/richtext/richtexttabspage.cpp:146
+msgid "Click to delete all tab positions."
+msgstr "クリックですべてのタブ位置を削除できます。"
+
+#: ../src/univ/theme.cpp:110
+msgid "Failed to initialize GUI: no built-in themes found."
+msgstr "GUIの初期化に失敗: ビルトインテーマがありません。"
+
+#: ../src/univ/themes/gtk.cpp:521
+msgid "GTK+ theme"
+msgstr "GTK+ テーマ"
+
+#: ../src/univ/themes/metal.cpp:164
+msgid "Metal theme"
+msgstr "メタルテーマ"
+
+#: ../src/univ/themes/mono.cpp:512
+msgid "Simple monochrome theme"
+msgstr "簡素なモノクロのテーマ"
+
+#: ../src/univ/themes/win32.cpp:1098
+msgid "Win32 theme"
+msgstr "Win32 テーマ"
+
+#: ../src/univ/themes/win32.cpp:3743
+msgid "&Restore"
+msgstr "復元 (&R)"
+
+#: ../src/univ/themes/win32.cpp:3744
+msgid "&Move"
+msgstr "移動 (&M)"
+
+#: ../src/univ/themes/win32.cpp:3746
+msgid "&Size"
+msgstr "大きさ (&S)"
+
+#: ../src/univ/themes/win32.cpp:3748
+msgid "Mi&nimize"
+msgstr "最小化 (&N)"
+
+#: ../src/univ/themes/win32.cpp:3750
+msgid "Ma&ximize"
+msgstr "最大化 (&X)"
+
+#: ../src/univ/themes/win32.cpp:3752
+msgid "Alt+"
+msgstr "Alt+"
+
+#: ../src/unix/appunix.cpp:178
+msgid "Failed to install signal handler"
+msgstr "シグナルハンドラーのインストールに失敗しました"
+
+#: ../src/unix/dialup.cpp:351
+msgid "Already dialling ISP."
+msgstr "すでに ISP にダイヤル中です。"
+
+#: ../src/unix/dlunix.cpp:93
+#, fuzzy
+msgid "Failed to unload shared library"
+msgstr "共有ライブラリ '%s' を読み取れませんでした。"
+
+#: ../src/unix/dlunix.cpp:121
+msgid "Unknown dynamic library error"
+msgstr "想定外の動的ライブラリーエラー"
+
+#: ../src/unix/epolldispatcher.cpp:84
+msgid "Failed to create epoll descriptor"
+msgstr "epoll 記述子を作成できませんでした"
+
+#: ../src/unix/epolldispatcher.cpp:103
+msgid "Error closing epoll descriptor"
+msgstr "epoll記述子を閉じる際のエラー"
+
+#: ../src/unix/epolldispatcher.cpp:116
+#, c-format
+msgid "Failed to add descriptor %d to epoll descriptor %d"
+msgstr "記述子 %d を epoll 記述子 %d に追加できませんでした"
+
+#: ../src/unix/epolldispatcher.cpp:136
+#, c-format
+msgid "Failed to modify descriptor %d in epoll descriptor %d"
+msgstr "記述子 %d の変更が epoll 記述子 %d 内でできませんでした"
+
+#: ../src/unix/epolldispatcher.cpp:155
+#, c-format
+msgid "Failed to unregister descriptor %d from epoll descriptor %d"
+msgstr "記述子 %d を epoll記述子 %d から削除できませんでした"
+
+#: ../src/unix/epolldispatcher.cpp:213
+#, c-format
+msgid "Waiting for IO on epoll descriptor %d failed"
+msgstr "epoll 記述子 %d の IO 待ちに失敗しました"
+
+#: ../src/unix/fswatcher_inotify.cpp:71
+msgid "Unable to create inotify instance"
+msgstr "inotify 実体を作成できません"
+
+#: ../src/unix/fswatcher_inotify.cpp:94
+msgid "Unable to close inotify instance"
+msgstr "inotify 実体を閉じることができませんでした"
+
+#: ../src/unix/fswatcher_inotify.cpp:106
+msgid "Unable to add inotify watch"
+msgstr "inotify 監視を追加できませんでした"
+
+#: ../src/unix/fswatcher_inotify.cpp:138
+#, fuzzy, c-format
+msgid "Unable to remove inotify watch %i"
+msgstr "inotify 監視を削除できませんでした"
+
+#: ../src/unix/fswatcher_inotify.cpp:271
+#, c-format
+msgid "Unexpected event for \"%s\": no matching watch descriptor."
+msgstr ""
+
+#: ../src/unix/fswatcher_inotify.cpp:320
+#, c-format
+msgid "Invalid inotify event for \"%s\""
+msgstr ""
+
+#: ../src/unix/fswatcher_inotify.cpp:553
+msgid "Unable to read from inotify descriptor"
+msgstr "inotify 記述子から読み取ることができません"
+
+#: ../src/unix/fswatcher_inotify.cpp:558
+msgid "EOF while reading from inotify descriptor"
+msgstr "inotify 記述子 %d の読み取り中にEOFを検出しました"
+
+#: ../src/unix/fswatcher_kqueue.cpp:114
+msgid "Unable to create kqueue instance"
+msgstr "kqueue 実体を作成できません"
+
+#: ../src/unix/fswatcher_kqueue.cpp:131
+msgid "Error closing kqueue instance"
+msgstr "kqueue 実体を閉じる際のエラー"
+
+#: ../src/unix/fswatcher_kqueue.cpp:153
+msgid "Unable to add kqueue watch"
+msgstr "kqueue 監視を追加できませんでした"
+
+#: ../src/unix/fswatcher_kqueue.cpp:170
+msgid "Unable to remove kqueue watch"
+msgstr "kqueue 監視を削除できませんでした"
+
+#: ../src/unix/fswatcher_kqueue.cpp:202
+msgid "Unable to get events from kqueue"
+msgstr "kqueue からのイベントを取得できませんでした"
+
+#: ../src/unix/mediactrl.cpp:966
+#, c-format
+msgid "Media playback error: %s"
+msgstr "メディア再生エラー: %s"
+
+#: ../src/unix/mediactrl.cpp:1228
+#, fuzzy, c-format
+msgid "Failed to prepare playing \"%s\"."
+msgstr "ディスプレイ \"%s\" を開くことができませんでした。"
+
+#: ../src/unix/snglinst.cpp:164
+#, c-format
+msgid "Failed to write to lock file '%s'"
+msgstr "ロックファイル '%s' に書き込めませんでした。"
+
+#: ../src/unix/snglinst.cpp:177
+#, c-format
+msgid "Failed to set permissions on lock file '%s'"
+msgstr "ロックファイル '%s' のパーミッションを設定できませんでした。"
+
+#: ../src/unix/snglinst.cpp:194
+#, c-format
+msgid "Failed to lock the lock file '%s'"
+msgstr "ロックファイル '%s' をロックできませんでした"
+
+#: ../src/unix/snglinst.cpp:237
+#, c-format
+msgid "Failed to inspect the lock file '%s'"
+msgstr "ロックファイル '%s' を検査できませんでした"
+
+#: ../src/unix/snglinst.cpp:242
+#, c-format
+msgid "Lock file '%s' has incorrect owner."
+msgstr "ロックファイル '%s' は不正な所有者を示しています。"
+
+#: ../src/unix/snglinst.cpp:247
+#, c-format
+msgid "Lock file '%s' has incorrect permissions."
+msgstr "ロックファイル '%s' は不正なパーミッションを示しています。"
+
+#: ../src/unix/snglinst.cpp:265
+msgid "Failed to access lock file."
+msgstr "ロックファイルへアクセスできませんでした。"
+
+#: ../src/unix/snglinst.cpp:274
+msgid "Failed to read PID from lock file."
+msgstr "ロックファイルからPIDを読み取れませんでした。"
+
+#: ../src/unix/snglinst.cpp:284
+#, c-format
+msgid "Failed to remove stale lock file '%s'."
+msgstr "失効ロックファイル '%s' を削除できませんでした。"
+
+#: ../src/unix/snglinst.cpp:297
+#, c-format
+msgid "Deleted stale lock file '%s'."
+msgstr "無効なロックファイル '%s' を削除しました。"
+
+#: ../src/unix/snglinst.cpp:308
+#, c-format
+msgid "Invalid lock file '%s'."
+msgstr "不正なロックファイル'%s'です。"
+
+#: ../src/unix/snglinst.cpp:324
+#, c-format
+msgid "Failed to remove lock file '%s'"
+msgstr "ロックファイル '%s' を削除できませんでした。"
+
+#: ../src/unix/snglinst.cpp:330
+#, c-format
+msgid "Failed to unlock lock file '%s'"
+msgstr "ロックファイル '%s' のロック解除ができませんでした。"
+
+#: ../src/unix/snglinst.cpp:336
+#, c-format
+msgid "Failed to close lock file '%s'"
+msgstr "ロックファイル '%s' を閉じることができませんでした。"
+
+#: ../src/unix/sound.cpp:77
+msgid "No sound"
+msgstr "音声なし"
+
+#: ../src/unix/sound.cpp:364
+msgid "Unable to play sound asynchronously."
+msgstr "音の非同期演奏はできません。"
+
+#: ../src/unix/sound.cpp:458
+#, c-format
+msgid "Couldn't load sound data from '%s'."
+msgstr "音声データを '%s' から取得できませんでした。"
+
+#: ../src/unix/sound.cpp:465
+#, c-format
+msgid "Sound file '%s' is in unsupported format."
+msgstr "'%s' は未対応の形式が使われている音声ファイルです。"
+
+#: ../src/unix/sound.cpp:480
+msgid "Sound data are in unsupported format."
+msgstr "未対応の形式が使われている音声データです。"
+
+#: ../src/unix/sound_sdl.cpp:226
+#, c-format
+msgid "Couldn't open audio: %s"
+msgstr "音声を開くことができませんでした: %s"
+
+#: ../src/unix/threadpsx.cpp:1033
+msgid "Cannot retrieve thread scheduling policy."
+msgstr "スレッドスケジュールポリシーを取得できません。"
+
+#: ../src/unix/threadpsx.cpp:1058
+#, c-format
+msgid "Cannot get priority range for scheduling policy %d."
+msgstr "スケジューリングポリシー %d への優先度範囲を取得できません。"
+
+#: ../src/unix/threadpsx.cpp:1066
+msgid "Thread priority setting is ignored."
+msgstr "スレッド優先度の設定は無視されました。"
+
+#: ../src/unix/threadpsx.cpp:1221
+msgid ""
+"Failed to join a thread, potential memory leak detected - please restart the "
+"program"
+msgstr ""
+"スレッド接合に失敗しました。メモリリーク発生の可能性があります。プログラムを"
+"再起動してください。"
+
+#: ../src/unix/threadpsx.cpp:1352
+#, fuzzy, c-format
+msgid "Failed to set thread concurrency level to %lu"
+msgstr "スレッド優先度を %d に設定できませんでした。"
+
+#: ../src/unix/threadpsx.cpp:1481
+#, c-format
+msgid "Failed to set thread priority %d."
+msgstr "スレッド優先度を %d に設定できませんでした。"
+
+#: ../src/unix/threadpsx.cpp:1666
+msgid "Failed to terminate a thread."
+msgstr "スレッドを終了できませんでした。"
+
+#: ../src/unix/threadpsx.cpp:1893
+msgid "Thread module initialization failed: failed to create thread key"
+msgstr "スレッドモジュールの初期化に失敗: スレッドキーを作成できませんでした"
+
+#: ../src/unix/utilsunx.cpp:340
+msgid "Impossible to get child process input"
+msgstr "子プロセスの入力は取得不可能です"
+
+#: ../src/unix/utilsunx.cpp:390
+msgid "Can't write to child process's stdin"
+msgstr "子プロセスの標準入力には書き込めません"
+
+#: ../src/unix/utilsunx.cpp:644
+#, c-format
+msgid "Failed to execute '%s'\n"
+msgstr "'%s' の実行に失敗しました\n"
+
+#: ../src/unix/utilsunx.cpp:678
+msgid "Fork failed"
+msgstr "フォークに失敗しました"
+
+#: ../src/unix/utilsunx.cpp:701
+msgid "Failed to set process priority"
+msgstr "プロセスの優先度を設定できませんでした"
+
+#: ../src/unix/utilsunx.cpp:712
+msgid "Failed to redirect child process input/output"
+msgstr "子プロセスの入出力をリダイレクトできませんでした"
+
+#: ../src/unix/utilsunx.cpp:816
+msgid "Failed to set up non-blocking pipe, the program might hang."
+msgstr ""
+
+#: ../src/unix/utilsunx.cpp:1023
+msgid "Cannot get the hostname"
+msgstr "ホスト名を取得できません"
+
+#: ../src/unix/utilsunx.cpp:1059
+msgid "Cannot get the official hostname"
+msgstr "公的なホスト名を取得できません"
+
+#: ../src/unix/wakeuppipe.cpp:49
+msgid "Failed to create wake up pipe used by event loop."
+msgstr "イベントループが使う起動パイプの作成に失敗しました。"
+
+#: ../src/unix/wakeuppipe.cpp:56
+msgid "Failed to switch wake up pipe to non-blocking mode"
+msgstr "起動パイプをnon-blockingモードに切り替えることができませんでした"
+
+#: ../src/unix/wakeuppipe.cpp:117
+msgid "Failed to read from wake-up pipe"
+msgstr "起動パイプからの読み取りに失敗しました"
+
+#: ../src/x11/app.cpp:124
+#, c-format
+msgid "Invalid geometry specification '%s'"
+msgstr "画面設定 '%s' は正しい指定ではありません"
+
+#: ../src/x11/app.cpp:167
+msgid "wxWidgets could not open display. Exiting."
+msgstr "wxWidgets はディスプレイを開くことができませんでした。終了します。"
+
+#: ../src/x11/utils.cpp:169
+#, c-format
+msgid "Failed to close the display \"%s\""
+msgstr "ディスプレイ \"%s\" を閉じることができませんでした。"
+
+#: ../src/x11/utils.cpp:188
+#, c-format
+msgid "Failed to open display \"%s\"."
+msgstr "ディスプレイ \"%s\" を開くことができませんでした。"
+
+#: ../src/xml/xml.cpp:868
+#, c-format
+msgid "XML parsing error: '%s' at line %d"
+msgstr "XML 解析エラー: '%s' (%d行目)"
+
+#: ../src/xrc/xh_propgrid.cpp:239
+#, fuzzy, c-format
+msgid "Page %i"
+msgstr "ページ %d"
+
+#: ../src/xrc/xmlres.cpp:448
+#, c-format
+msgid "Cannot load resources from '%s'."
+msgstr "リソースファイル '%s' を読み取れません。"
+
+#: ../src/xrc/xmlres.cpp:799
+#, c-format
+msgid "Cannot open resources file '%s'."
+msgstr "リソースファイル '%s' を開くことができません。"
+
+#: ../src/xrc/xmlres.cpp:806
+#, c-format
+msgid "Cannot load resources from file '%s'."
+msgstr "ファイル '%s' からリソースを読み取れません。"
+
+#: ../src/xrc/xmlres.cpp:2767
+#, c-format
+msgid "Creating %s \"%s\" failed."
+msgstr "%s \"%s\" を作成できませんでした。"
+
+#, c-format
+#~ msgid "BMP: header has biClrUsed=%d when biBitCount=%d."
+#~ msgstr ""
+#~ "BMP: biBitCount=%2$dのとき、ヘッダーにbiClrUsed=%1$dが含まれています。"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Alt+"
+#~ msgstr "Alt+"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Ctrl+"
+#~ msgstr "Ctrl+"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Shift+"
+#~ msgstr "Shift+"
+
+#~ msgctxt "keyboard key"
+#~ msgid "RawCtrl+"
+#~ msgstr "RawCtrl+"
+
+#~ msgid "Unsupported clipboard format."
+#~ msgstr "未対応のクリップボードの形式です。"
+
+#~ msgid "Background colour"
+#~ msgstr "背景色"
+
+#~ msgid "Font:"
+#~ msgstr "フォント:"
+
+#~ msgid "Size:"
+#~ msgstr "大きさ:"
+
+#~ msgid "The font size in points."
+#~ msgstr "フォントの大きさをポイントで記します。"
+
+#~ msgid "Style:"
+#~ msgstr "スタイル:"
+
+#~ msgid "Check to make the font bold."
+#~ msgstr "フォントを太字にするときにチェックしてください。"
+
+#~ msgid "Check to make the font italic."
+#~ msgstr "フォントをイタリックにするときにチェックしてください。"
+
+#~ msgid "Check to make the font underlined."
+#~ msgstr "フォントに下線を付けるときにチェックしてください。"
+
+#~ msgid "Colour:"
+#~ msgstr "色:"
+
+#~ msgid "Click to change the font colour."
+#~ msgstr "クリックでフォントの色を変更します。"
+
+#~ msgid "Shows a preview of the font."
+#~ msgstr "フォントのプレビューを表示します。"
+
+#~ msgid "Click to cancel changes to the font."
+#~ msgstr "クリックでフォントの変更をキャンセルします。"
+
+#~ msgid "Click to confirm changes to the font."
+#~ msgstr "クリックでフォントの変更を確定します。"
+
+#~ msgid "<Any>"
+#~ msgstr "<いずれか>"
+
+#~ msgid "<Any Roman>"
+#~ msgstr "<Romanのいずれか>"
+
+#~ msgid "<Any Decorative>"
+#~ msgstr "<Decorativeのいずれか>"
+
+#~ msgid "<Any Modern>"
+#~ msgstr "<Modernのいずれか>"
+
+#~ msgid "<Any Script>"
+#~ msgstr "<Scriptのいずれか>"
+
+#~ msgid "<Any Swiss>"
+#~ msgstr "<Swissのいずれか>"
+
+#~ msgid "<Any Teletype>"
+#~ msgstr "<Teletypeのいずれか>"
+
+#~ msgid "Printing "
+#~ msgstr "印刷"
+
+#~ msgid "Failed to insert text in the control."
+#~ msgstr "そのコントロールにテキストを挿入できませんでした。"
+
+#~ msgid "Please choose a valid font."
+#~ msgstr "有効なフォントを選んでください。"
+
+#, c-format
+#~ msgid "Failed to display HTML document in %s encoding"
+#~ msgstr "%s エンコーディングで HTML 文書を表示できませんでした。"
+
+#, c-format
+#~ msgid "wxWidgets could not open display for '%s': exiting."
+#~ msgstr ""
+#~ "wxWidgets はディスプレイ '%s' を開くことができませんでした: 終了します。"
+
+#~ msgid "Filter"
+#~ msgstr "フィルター"
+
+#~ msgid "Directories"
+#~ msgstr "ディレクトリー"
+
+#~ msgid "Files"
+#~ msgstr "ファイル"
+
+#~ msgid "Selection"
+#~ msgstr "選択"
+
+#~ msgid "conversion to 8-bit encoding failed"
+#~ msgstr "8ビットエンコーディングへの変換に失敗しました"
+
+#, fuzzy
+#~ msgid "failed to retrieve execution result"
+#~ msgstr "RAS エラーメッセージのテキストを取得できませんでした。"
+
+#, fuzzy
+#~ msgid "&Save as"
+#~ msgstr "Save As"
+
+#, fuzzy
+#~ msgid "'%s' doesn't consist only of valid characters"
+#~ msgstr "'%s' はアルファベット以外を受け付けません。"
+
+#~ msgid "'%s' should be numeric."
+#~ msgstr "'%s' は数字でなくてはなりません。"
+
+#~ msgid "'%s' should only contain ASCII characters."
+#~ msgstr "'%s' は ASCII 文字以外を受け付けません。"
+
+#~ msgid "'%s' should only contain alphabetic characters."
+#~ msgstr "'%s' はアルファベット以外を受け付けません。"
+
+#~ msgid "'%s' should only contain alphabetic or numeric characters."
+#~ msgstr "'%s' はアルファベットと数字のみ受け付けます。"
+
+#~ msgid "'%s' should only contain digits."
+#~ msgstr "'%s' は数字以外を受け付けません。"
+
+#~ msgid "Can't create window of class %s"
+#~ msgstr "%s クラスのウィンドウを作成できません"
+
+#~ msgid "Couldn't create the overlay window"
+#~ msgstr "オーバーレイウィンドウを作成できませんでした"
+
+#~ msgid "Couldn't init the context on the overlay window"
+#~ msgstr "オーバーレイウィンドウの内容を初期化できませんでした。"
+
+#~ msgid "Failed to convert file \"%s\" to Unicode."
+#~ msgstr "ファイル \"%s\" を Unicode に変換できませんでした。"
+
+#~ msgid "Failed to set text in the text control."
+#~ msgstr "そのテキストコントロールにテキストを設定できませんでした。"
+
+#~ msgid "Invalid GTK+ command line option, use \"%s --help\""
+#~ msgstr ""
+#~ "不適切な GTK+ コマンドラインオプションです。\"%s --help\" で確認してくださ"
+#~ "い。"
+
+#~ msgid "No unused colour in image."
+#~ msgstr "画像に未使用色がありません。"
+
+#~ msgid "Not available"
+#~ msgstr "利用できません"
+
+#~ msgid "Replace selection"
+#~ msgstr "選択範囲を置換します"
+
+#, fuzzy
+#~ msgid "Save as"
+#~ msgstr "Save As"
+
+#~ msgid "Style Organiser"
+#~ msgstr "スタイルの構成"
+
+#~ msgid "The following standard GTK+ options are also supported:\n"
+#~ msgstr "次の標準GTK+オプションも利用できます:\n"
+
+#~ msgid "You cannot Clear an overlay that is not inited"
+#~ msgstr "オーバーレイは初期化する前に Clear できません"
+
+#~ msgid "You cannot Init an overlay twice"
+#~ msgstr "オーバーレイは二度 Init できません"
+
+#~ msgid "locale '%s' cannot be set."
+#~ msgstr "ロケールに '%s' を指定できませんでした｡"
+
+#~ msgid "Adding flavor TEXT failed"
+#~ msgstr "フレーバー TEXT を追加できませんでした"
+
+#~ msgid "Adding flavor utxt failed"
+#~ msgstr "フレーバー utxt を追加できませんでした"
+
+#~ msgid "Bitmap renderer cannot render value; value type: "
+#~ msgstr "ビットマップレンダラーが値をレンダリングできません; 値の型:"
+
+#~ msgid ""
+#~ "Cannot create new column's ID. Probably max. number of columns reached."
+#~ msgstr ""
+#~ "新しい列への識別子を作成できません。作成数が上限に達した可能性があります。"
+
+#~ msgid "Column could not be added."
+#~ msgstr "列を追加できませんでした。"
+
+#~ msgid "Column index not found."
+#~ msgstr "列の索引が見つかりません。"
+
+#~ msgid "Column width could not be determined"
+#~ msgstr "列の幅を決定できませんでした。"
+
+#~ msgid "Column width could not be set."
+#~ msgstr "列の幅を設定できませんでした。"
+
+#~ msgid "Confirm registry update"
+#~ msgstr "レジストリの更新を確定"
+
+#~ msgid "Could not determine column index."
+#~ msgstr "列の索引番号を特定できませんでした。"
+
+#~ msgid "Could not determine column's position"
+#~ msgstr "列の位置を特定できませんでした"
+
+#~ msgid "Could not determine number of columns."
+#~ msgstr "列の数を取得できませんでした。"
+
+#~ msgid "Could not determine number of items"
+#~ msgstr "項目数を取得できませんでした。"
+
+#~ msgid "Could not get header description."
+#~ msgstr "ヘッダ記述を取得できませんでした。"
+
+#~ msgid "Could not get items."
+#~ msgstr "項目を取得できませんでした。"
+
+#~ msgid "Could not get property flags."
+#~ msgstr "プロパティフラグを取得できませんでした。"
+
+#~ msgid "Could not get selected items."
+#~ msgstr "選択された項目を取得できませんでした。"
+
+#~ msgid "Could not remove column."
+#~ msgstr "列を削除できませんでした。"
+
+#~ msgid "Could not retrieve number of items"
+#~ msgstr "項目数を取得できませんでした。"
+
+#~ msgid "Could not set column width."
+#~ msgstr "列の幅を設定できませんでした。"
+
+#~ msgid "Could not set header description."
+#~ msgstr "ヘッダ記述を設定できませんでした。"
+
+#~ msgid "Could not set icon."
+#~ msgstr "アイコンを設定できませんでした。"
+
+#~ msgid "Could not set maximum width."
+#~ msgstr "最大幅を設定できませんでした。"
+
+#~ msgid "Could not set minimum width."
+#~ msgstr "最小幅を設定できませんでした。"
+
+#~ msgid "Could not set property flags."
+#~ msgstr "プロパティフラグを設定できませんでした。"
+
+#~ msgid "Data object has invalid data format"
+#~ msgstr "データオブジェクトが不適切な様式を保有しています"
+
+#~ msgid "Date renderer cannot render value; value type: "
+#~ msgstr "日付レンダラーが値をレンダリングできません; 値の型:"
+
+#~ msgid ""
+#~ "Do you want to overwrite the command used to %s files with extension "
+#~ "\"%s\" ?\n"
+#~ "Current value is \n"
+#~ "%s, \n"
+#~ "New value is \n"
+#~ "%s %1"
+#~ msgstr ""
+#~ "%s コマンドを拡張子 \"%s\" に適用するときの値を上書きしますか?\n"
+#~ "現在の値 :\n"
+#~ "%s, \n"
+#~ "新しい値 :\n"
+#~ "%s %1"
+
+#~ msgid "Failed to retrieve data from the clipboard."
+#~ msgstr "クリップボードからデータを受け取ることができませんでした。"
+
+#~ msgid "GIF: Invalid gif index."
+#~ msgstr "GIF: gifの索引が正しくないようです。"
+
+#~ msgid "GIF: unknown error!!!"
+#~ msgstr "GIF: 未知のエラーを検出しました。"
+
+#~ msgid "Icon & text renderer cannot render value; value type: "
+#~ msgstr "アイコンとテキストのレンダラーが値を処理できません; 値の型: "
+
+#~ msgid "New directory"
+#~ msgstr "新規ディレクトリー"
+
+#~ msgid "Next"
+#~ msgstr "次"
+
+#~ msgid "No column existing."
+#~ msgstr "列がありません。"
+
+#~ msgid "No column for the specified column existing."
+#~ msgstr "プロパティーに対応する列がありません。"
+
+#~ msgid "No column for the specified column position existing."
+#~ msgstr "指定された位置には列がありません。"
+
+#~ msgid ""
+#~ "No renderer or invalid renderer type specified for custom data column."
+#~ msgstr ""
+#~ "カスタムデータ列に不適切なレンダラーまたは不適切なその型が与えられました。"
+
+#~ msgid "No renderer specified for column."
+#~ msgstr "列に対してレンダラーが与えられていません。"
+
+#~ msgid "Number of columns could not be determined."
+#~ msgstr "列の数を決定できませんでした。"
+
+#~ msgid "OpenGL function \"%s\" failed: %s (error %d)"
+#~ msgstr "OpenGL 関数 \"%s\" が失敗: %s (エラー %d)"
+
+#~ msgid ""
+#~ "Please install a newer version of comctl32.dll\n"
+#~ "(at least version 4.70 is required but you have %d.%02d)\n"
+#~ "or this program won't operate correctly."
+#~ msgstr ""
+#~ "comctl32.dll の新しい版をインストールしてください。\n"
+#~ "4.70 以上の版が必要ですが現在インストールされているのは %d.%02d です｡\n"
+#~ "適切な版がないと正しく動作いたしません。"
+
+#~ msgid "Pointer to data view control not set correctly."
+#~ msgstr "データビューコントロールへのポインタが正しく設定されていません。"
+
+#~ msgid "Pointer to model not set correctly."
+#~ msgstr "モデルへのポインタが正しく設定されていません。"
+
+#~ msgid "Progress renderer cannot render value type; value type: "
+#~ msgstr "進行状況レンダラーが値を処理できません: 値の型: "
+
+#~ msgid "Rendering failed."
+#~ msgstr "レンダリングに失敗しました。"
+
+#~ msgid ""
+#~ "Setting directory access times is not supported under this OS version"
+#~ msgstr "このバージョンの OS ではディレクトリアクセス時刻を設定できません"
+
+#~ msgid "Show hidden directories"
+#~ msgstr "隠しディレクトリーを表示します"
+
+#~ msgid "Text renderer cannot render value; value type: "
+#~ msgstr "テキストレンダラーは次の値を処理できません; 値の型: "
+
+#~ msgid "There is no column or renderer for the specified column index."
+#~ msgstr "指定された列のレンダラーまたは列そのものが存在しません。"
+
+#~ msgid ""
+#~ "This system doesn't support date controls, please upgrade your version of "
+#~ "comctl32.dll"
+#~ msgstr ""
+#~ "このシステムは、date コントロールに未対応です。comctl32.dllを更新してくだ"
+#~ "さい"
+
+#~ msgid "Toggle renderer cannot render value; value type: "
+#~ msgstr "トグルレンダラーが値を処理できません: 値の型: "
+
+#~ msgid "Too many colours in PNG, the image may be slightly blurred."
+#~ msgstr "PNGにある色が多すぎます。少しぼやけた感じになるかもしれません。"
+
+#~ msgid "Unable to handle native drag&drop data"
+#~ msgstr "ネイティブのドラッグアンドドロップデータを制御できませんでした"
+
+#~ msgid "Unable to initialize Hildon program"
+#~ msgstr "Hildon プログラムを初期化できません"
+
+#~ msgid "Unknown data format"
+#~ msgstr "未知のデータ様式です"
+
+#~ msgid "Valid pointer to native data view control does not exist"
+#~ msgstr "ネイティブデータビューコントロールへの有効なポインタがありません。"
+
+#~ msgid "Win32s on Windows 3.1"
+#~ msgstr "Windows 3.1 上の Win32s"
+
+#, fuzzy
+#~ msgid "Windows 10"
+#~ msgstr "Windows 98"
+
+#, fuzzy
+#~ msgid "Windows 2000"
+#~ msgstr "Windows 95"
+
+#, fuzzy
+#~ msgid "Windows 7"
+#~ msgstr "Windows 95"
+
+#, fuzzy
+#~ msgid "Windows 8"
+#~ msgstr "Windows 98"
+
+#, fuzzy
+#~ msgid "Windows 8.1"
+#~ msgstr "Windows 98"
+
+#~ msgid "Windows 95"
+#~ msgstr "Windows 95"
+
+#~ msgid "Windows 95 OSR2"
+#~ msgstr "Windows 95 OSR2"
+
+#~ msgid "Windows 98"
+#~ msgstr "Windows 98"
+
+#~ msgid "Windows 98 SE"
+#~ msgstr "Windows 98 SE"
+
+#~ msgid "Windows 9x (%d.%d)"
+#~ msgstr "Windows 9x (%d.%d)"
+
+#~ msgid "Windows CE (%d.%d)"
+#~ msgstr "Windows CE (%d.%d)"
+
+#~ msgid "Windows ME"
+#~ msgstr "Windows ME"
+
+#, fuzzy
+#~ msgid "Windows NT %lu.%lu"
+#~ msgstr "Windows NT %lu.%lu (ビルド %lu"
+
+#, fuzzy
+#~ msgid "Windows Server 10"
+#~ msgstr "Windows Server 2003 (ビルド %lu"
+
+#, fuzzy
+#~ msgid "Windows Server 2003"
+#~ msgstr "Windows Server 2003 (ビルド %lu"
+
+#, fuzzy
+#~ msgid "Windows Server 2008"
+#~ msgstr "Windows Server 2003 (ビルド %lu"
+
+#, fuzzy
+#~ msgid "Windows Server 2008 R2"
+#~ msgstr "Windows Server 2003 (ビルド %lu"
+
+#, fuzzy
+#~ msgid "Windows Server 2012"
+#~ msgstr "Windows Server 2003 (ビルド %lu"
+
+#, fuzzy
+#~ msgid "Windows Server 2012 R2"
+#~ msgstr "Windows Server 2003 (ビルド %lu"
+
+#, fuzzy
+#~ msgid "Windows Vista"
+#~ msgstr "Windows Vista (ビルド %lu"
+
+#, fuzzy
+#~ msgid "Windows XP"
+#~ msgstr "Windows 95"
+
+#~ msgid "can't execute '%s'"
+#~ msgstr "'%s' を実行できません。"
+
+#~ msgid "error opening '%s'"
+#~ msgstr "'%s' を開く際にエラーが発生しました"
+
+#~ msgid "unknown seek origin"
+#~ msgstr "未対応のシーク方法です"
+
+#~ msgid "wxWidget control pointer is not a data view pointer"
+#~ msgstr ""
+#~ "wxWidgets コントロールポインターはデータビューポインターではありません"
+
+#~ msgid "wxWidget's control not initialized."
+#~ msgstr "wxWidgetsのコントロールが初期化されていません。"
+
+#~ msgid "ADD"
+#~ msgstr "ADD"
+
+#~ msgid "BACK"
+#~ msgstr "BS"
+
+#~ msgid "CANCEL"
+#~ msgstr "CANCEL"
+
+#~ msgid "CAPITAL"
+#~ msgstr "CapsLock"
+
+#~ msgid "CLEAR"
+#~ msgstr "CLEAR"
+
+#~ msgid "COMMAND"
+#~ msgstr "COMMAND"
+
+#~ msgid "Cannot create mutex."
+#~ msgstr "Mutex を作成できません。"
+
+#~ msgid "Cannot resume thread %lu"
+#~ msgstr "スレッド %lu のリジュームができません"
+
+#~ msgid "Cannot suspend thread %lu"
+#~ msgstr "スレッド %lu のサスペンドができません"
+
+#~ msgid "Couldn't acquire a mutex lock"
+#~ msgstr "Mutexロックを取得できませんでした｡"
+
+#~ msgid "Couldn't get hatch style from wxBrush."
+#~ msgstr "wxBrush からハッチスタイルを取得できませんでした。"
+
+#~ msgid "Couldn't release a mutex"
+#~ msgstr "Mutexを解放できませんでした"
+
+#~ msgid "DECIMAL"
+#~ msgstr "DECIMAL"
+
+#~ msgid "DEL"
+#~ msgstr "DEL"
+
+#~ msgid "DELETE"
+#~ msgstr "DELETE"
+
+#~ msgid "DIVIDE"
+#~ msgstr "DIVIDE"
+
+#~ msgid "DOWN"
+#~ msgstr "↓"
+
+#~ msgid "END"
+#~ msgstr "END"
+
+#~ msgid "ENTER"
+#~ msgstr "ENTER"
+
+#~ msgid "ESC"
+#~ msgstr "ESC"
+
+#~ msgid "ESCAPE"
+#~ msgstr "ESCAPE"
+
+#~ msgid "EXECUTE"
+#~ msgstr "EXECUTE"
+
+#~ msgid "Execution of command '%s' failed with error: %ul"
+#~ msgstr "コマンド '%s' を実行できませんでした。エラーコード: %ul"
+
+#~ msgid ""
+#~ "File '%s' already exists.\n"
+#~ "Do you want to replace it?"
+#~ msgstr ""
+#~ "ファイル '%s' はすでに存在します。\n"
+#~ "置き換えますか?"
+
+#~ msgid "HELP"
+#~ msgstr "HELP"
+
+#~ msgid "HOME"
+#~ msgstr "HOME"
+
+#~ msgid "INS"
+#~ msgstr "INS"
+
+#~ msgid "INSERT"
+#~ msgstr "INSERT"
+
+#~ msgid "KP_BEGIN"
+#~ msgstr "KP_BEGIN"
+
+#~ msgid "KP_DECIMAL"
+#~ msgstr "KP_DECIMAL"
+
+#~ msgid "KP_DELETE"
+#~ msgstr "KP_DELETE"
+
+#~ msgid "KP_DIVIDE"
+#~ msgstr "Num/"
+
+#~ msgid "KP_DOWN"
+#~ msgstr "Num↓"
+
+#~ msgid "KP_ENTER"
+#~ msgstr "NumEnter"
+
+#~ msgid "KP_EQUAL"
+#~ msgstr "Num="
+
+#~ msgid "KP_HOME"
+#~ msgstr "NumHome"
+
+#~ msgid "KP_INSERT"
+#~ msgstr "NumInsert"
+
+#~ msgid "KP_LEFT"
+#~ msgstr "Num←"
+
+#~ msgid "KP_MULTIPLY"
+#~ msgstr "Num*"
+
+#~ msgid "KP_NEXT"
+#~ msgstr "KP_NEXT"
+
+#~ msgid "KP_PAGEDOWN"
+#~ msgstr "NumPageDown"
+
+#~ msgid "KP_PAGEUP"
+#~ msgstr "NumPageUp"
+
+#~ msgid "KP_PRIOR"
+#~ msgstr "KP_PRIOR"
+
+#~ msgid "KP_RIGHT"
+#~ msgstr "Num→"
+
+#~ msgid "KP_SEPARATOR"
+#~ msgstr "KP_SEPARATOR"
+
+#~ msgid "KP_SPACE"
+#~ msgstr "KP_SPACE"
+
+#~ msgid "KP_SUBTRACT"
+#~ msgstr "Num-"
+
+#~ msgid "LEFT"
+#~ msgstr "←"
+
+#~ msgid "MENU"
+#~ msgstr "MENU"
+
+#~ msgid "NUM_LOCK"
+#~ msgstr "NumLock"
+
+#~ msgid "PAGEDOWN"
+#~ msgstr "PAGEDOWN"
+
+#~ msgid "PAGEUP"
+#~ msgstr "PAGEUP"
+
+#~ msgid "PAUSE"
+#~ msgstr "PAUSE"
+
+#~ msgid "PGDN"
+#~ msgstr "PGDN"
+
+#~ msgid "PGUP"
+#~ msgstr "PGUP"
+
+#~ msgid "PRINT"
+#~ msgstr "PrintScreen"
+
+#~ msgid "RETURN"
+#~ msgstr "RETURN"
+
+#~ msgid "RIGHT"
+#~ msgstr "→"
+
+#~ msgid "SCROLL_LOCK"
+#~ msgstr "ScrollLock"
+
+#~ msgid "SELECT"
+#~ msgstr "SELECT"
+
+#~ msgid "SEPARATOR"
+#~ msgstr "SEPARATOR"
+
+#~ msgid "SNAPSHOT"
+#~ msgstr "SNAPSHOT"
+
+#~ msgid "SPACE"
+#~ msgstr "SPACE"
+
+#~ msgid "SUBTRACT"
+#~ msgstr "SUBTRACT"
+
+#~ msgid "TAB"
+#~ msgstr "TAB"
+
+#~ msgid "The print dialog returned an error."
+#~ msgstr "印刷ダイアログがエラーを返しました。"
+
+#~ msgid "The wxGtkPrinterDC cannot be used."
+#~ msgstr "wxGtkPrinterDC が利用できません。"
+
+#~ msgid "Timer creation failed."
+#~ msgstr "タイマーの作成に失敗しました。"
+
+#~ msgid "UP"
+#~ msgstr "↑"
+
+#~ msgid "WINDOWS_LEFT"
+#~ msgstr "左Windows"
+
+#~ msgid "WINDOWS_MENU"
+#~ msgstr "Application"
+
+#~ msgid "WINDOWS_RIGHT"
+#~ msgstr "右Windows"
+
+#~ msgid "buffer is too small for Windows directory."
+#~ msgstr "バッファーが小さいので Windows ディレクトリーを格納できません。"
+
+#~ msgid "not implemented"
+#~ msgstr "実装されていません"
+
+#~ msgid "wxPrintout::GetPageInfo gives a null maxPage."
+#~ msgstr "wxPrintout::GetPageInfo が maxPage に 0 を返しました。"
+
+#~ msgid "Event queue overflowed"
+#~ msgstr "イベントキューが溢れました"
+
+#~ msgid "Print preview"
+#~ msgstr "印刷プレビュー"
+
+#~ msgid "'"
+#~ msgstr "'"
+
+#~ msgid "1"
+#~ msgstr "1"
+
+#, fuzzy
+#~ msgid "10"
+#~ msgstr "1"
+
+#~ msgid "3"
+#~ msgstr "3"
+
+#~ msgid "4"
+#~ msgstr "4"
+
+#~ msgid "5"
+#~ msgstr "5"
+
+#~ msgid "6"
+#~ msgstr "6"
+
+#~ msgid "7"
+#~ msgstr "7"
+
+#~ msgid "8"
+#~ msgstr "8"
+
+#~ msgid "9"
+#~ msgstr "9"
+
+#~ msgid "File system containing watched object was unmounted"
+#~ msgstr "監視中のオブジェクトを持つファイルシステムがアンマウントされました"
+
+#, fuzzy
+#~ msgid "&Preview..."
+#~ msgstr " プレビュー"
+
+#~ msgid "Passing an unkown object to GetObject"
+#~ msgstr "GetObject に未知のオブジェクトが渡されました"
+
+#, fuzzy
+#~ msgid "Preview..."
+#~ msgstr " プレビュー"
+
+#, fuzzy
+#~ msgid "The vertical offset relative to the paragraph."
+#~ msgstr "次の段落に適用されるスタイルを指定します。"
+
+#~ msgid "&Save..."
+#~ msgstr "保存 (&S) ..."
+
+#~ msgid "About "
+#~ msgstr "詳細"
+
+#~ msgid "All files (*.*)|*"
+#~ msgstr "すべてのファイル (*.*)|*"
+
+#~ msgid "Cannot initialize SciTech MGL!"
+#~ msgstr "SciTech MGL を初期化できません。"
+
+#~ msgid "Cannot initialize display."
+#~ msgstr "ディスプレイを初期化できません。"
+
+#~ msgid "Cannot start thread: error writing TLS"
+#~ msgstr "スレッドを開始できません: TLSへの書き込みに失敗しています。"
+
+#~ msgid "Close\tAlt-F4"
+#~ msgstr "閉じる\tAlt-F4"
+
+#~ msgid "Couldn't create cursor."
+#~ msgstr "カーソルを作成できませんでした"
+
+#~ msgid "Directory '%s' doesn't exist!"
+#~ msgstr "ディレクトリー '%s' は存在しません。"
+
+#~ msgid "Mode %ix%i-%i not available."
+#~ msgstr "モード %ix%i-%i は使えません。"
+
+#~ msgid "Paper Size"
+#~ msgstr "用紙サイズ"
+
+#~ msgid "&Goto..."
+#~ msgstr "移動 (&G)..."
+
+#~ msgid "<<"
+#~ msgstr "<<"
+
+#~ msgid ">>"
+#~ msgstr ">>"
+
+#~ msgid ">>|"
+#~ msgstr ">>|"
+
+#~ msgid "Added item is invalid."
+#~ msgstr "追加された項目は正しくないようです。"
+
+#~ msgid "BIG5"
+#~ msgstr "BIG5"
+
+#~ msgid "Can't check image format of file '%s': file does not exist."
+#~ msgstr "ファイル '%s' が存在しないため画像形式の調査はできません。"
+
+#~ msgid "Can't load image from file '%s': file does not exist."
+#~ msgstr "ファイル '%s' は存在しないため画像の読み取りができません。"
+
+#~ msgid "Cannot open file '%s'."
+#~ msgstr "ファイル '%s' を開くことができません。"
+
+#~ msgid "Changed item is invalid."
+#~ msgstr "変更された項目が不正のようです。"
+
+#~ msgid "Click to cancel this window."
+#~ msgstr "クリックでこのウィンドウをキャンセルします。"
+
+#~ msgid "Click to confirm your selection."
+#~ msgstr "クリックで選択を確定します。"
+
+#~ msgid "Column could not be added to native control."
+#~ msgstr "列をネイティブコントロールに追加できませんでした。"
+
+#~ msgid "Column does not have a renderer."
+#~ msgstr "列のレンダラーがありません。"
+
+#~ msgid "Column pointer must not be NULL."
+#~ msgstr "列のポインタは NULL にはできません。"
+
+#~ msgid "Column's model column has no equivalent in the associated model."
+#~ msgstr "関連づけられたモデルの中には列のモデルに適合するものがありません。"
+
+#~ msgid "Could not add column to internal structures."
+#~ msgstr "内部構造に列を追加できませんでした。"
+
+#~ msgid "Enter a page number between %d and %d:"
+#~ msgstr "%d から %d までの値でページを指定してください:"
+
+#~ msgid "Failed to create a status bar."
+#~ msgstr "ステータスバーを作成できませんでした。"
+
+#~ msgid "GB-2312"
+#~ msgstr "GB-2312"
+
+#~ msgid "Goto Page"
+#~ msgstr "ページ番号指定"
+
+#~ msgid ""
+#~ "HTML pagination algorithm generated more than the allowed maximum number "
+#~ "of pages and it can't continue any longer!"
+#~ msgstr ""
+#~ "HTMLのページ化アルゴリズムが出力可能数より多くのページを生成しました。生成"
+#~ "を中断します。"
+
+#~ msgid "I64"
+#~ msgstr "I64"
+
+#~ msgid "Internal error, illegal wxCustomTypeInfo"
+#~ msgstr "内部エラーです。不正な wxCustomTypeInfo を検出しました"
+
+#~ msgid "Model pointer not initialized."
+#~ msgstr "モデルポインターは初期化されていません。"
+
+#~ msgid "No image handler for type %ld defined."
+#~ msgstr "%ld 型のイメージハンドラーが定義されていません。"
+
+#~ msgid "No model associated with control."
+#~ msgstr "コントロールにモデルが関連づけられていません。"
+
+#~ msgid "Owner not initialized."
+#~ msgstr "Ownerは初期化されていません。"
+
+#~ msgid "Passed item is invalid."
+#~ msgstr "与えられた項目は無効です。"
+
+#~ msgid "Passing a already registered object to SetObjectName"
+#~ msgstr "SetObjectName に登録済みのオブジェクトが渡されました"
+
+#~ msgid "Pointer to dataview control must not be NULL"
+#~ msgstr "データビューコントロールへのポインタには NULL を指定できません"
+
+#~ msgid "Pointer to native control must not be NULL."
+#~ msgstr "ネイティブコントロールへのポインタには NULL を指定できません。"
+
+#~ msgid "SHIFT-JIS"
+#~ msgstr "SHIFT-JIS"
+
+#~ msgid ""
+#~ "Streaming delegates for not already streamed objects not yet supported"
+#~ msgstr ""
+#~ "ストリーム化されていないオブジェクトへのストリーム委譲は実装されていませ"
+#~ "ん。"
+
+#~ msgid ""
+#~ "The data format for the GET-direction of the to be added data object "
+#~ "already exists"
+#~ msgstr ""
+#~ "追加しようとしているデータオブジェクトのGET方向に関するデータ様式はすでに"
+#~ "存在します。"
+
+#~ msgid ""
+#~ "The data format for the SET-direction of the to be added data object "
+#~ "already exists"
+#~ msgstr ""
+#~ "追加しようとしているデータオブジェクトのSET方向に関するデータ様式はすでに"
+#~ "存在します。"
+
+#~ msgid "The file '%s' doesn't exist and couldn't be opened."
+#~ msgstr "ファイル '%s' を開こうとしましたが存在しませんでした。"
+
+#~ msgid "The path '%s' contains too many \"..\"!"
+#~ msgstr "パス '%s' に含まれる \"..\" が多すぎます。"
+
+#~ msgid "To be deleted item is invalid."
+#~ msgstr "削除しようとしている項目の指定が正しくないようです。"
+
+#~ msgid "Update"
+#~ msgstr "更新"
+
+#~ msgid "Value must be %lld or higher"
+#~ msgstr "%lld 以上の値にしてください"
+
+#~ msgid "Value must be %llu or higher"
+#~ msgstr "%llu 以上の値にしてください"
+
+#~ msgid "Value must be %llu or less"
+#~ msgstr "%llu 以下の値にしてください"
+
+#~ msgid "Warning"
+#~ msgstr "警告"
+
+#~ msgid "Windows 2000 (build %lu"
+#~ msgstr "Windows 2000 (ビルド %lu"
+
+#~ msgid "delegate has no type info"
+#~ msgstr "委譲の型情報がありません"
+
+#~ msgid "wxSearchEngine::LookFor must be called before scanning!"
+#~ msgstr "検索に先立って wxSearchEngine::LookFor を呼び出す必要があります。"
+
+#~ msgid "|<<"
+#~ msgstr "|<<"
+
+#~ msgid " Couldn't create the UnicodeConverter"
+#~ msgstr " UnicodeConverterを作成できません"
+
+#~ msgid "#define %s must be an integer."
+#~ msgstr "#define %s は整数でなくてはなりません。"
+
+#~ msgid "%.*f GB"
+#~ msgstr "%.*f GiB"
+
+#~ msgid "%.*f MB"
+#~ msgstr "%.*f MiB"
+
+#~ msgid "%.*f TB"
+#~ msgstr "%.*f TiB"
+
+#~ msgid "%.*f kB"
+#~ msgstr "%.*f KiB"
+
+#~ msgid "%s not a bitmap resource specification."
+#~ msgstr "%s をビットマップリソースとして認識できません。"
+
+#~ msgid "%s not an icon resource specification."
+#~ msgstr "%s をアイコンリソースとして認識できません。"
+
+#~ msgid "%s: ill-formed resource file syntax."
+#~ msgstr "%s: リソース文法が満たされていないようです。"
+
+#~ msgid "&Open"
+#~ msgstr "開く (&O)"
+
+#~ msgid "&Print"
+#~ msgstr "印刷 (&P)"
+
+#~ msgid ""
+#~ ", expected static, #include or #define\n"
+#~ "while parsing resource."
+#~ msgstr ""
+#~ "を見つけましたが static, #include, #defineの\n"
+#~ "どれでもありません｡"
+
+#~ msgid "Archive doesnt contain #SYSTEM file"
+#~ msgstr "書庫は #SYSTEM ファイルを含んでいません"
+
+#~ msgid "Bitmap resource specification %s not found."
+#~ msgstr "ビットマップリソース仕様 %s は未対応です。"
+
+#~ msgid "Cannot convert dialog units: dialog unknown."
+#~ msgstr "ダイアログ単位に変換できません: ダイアログが未知です。"
+
+#~ msgid "Cannot convert from the charset '%s'!"
+#~ msgstr "文字集合 '%s' から変換できません。"
+
+#~ msgid "Cannot find container for unknown control '%s'."
+#~ msgstr "未知のコントロール '%s' に対するコンテナを見つけられません。"
+
+#~ msgid "Cannot find font node '%s'."
+#~ msgstr "フォントノード '%s' が見つかりません。"
+
+#~ msgid "Cannot parse coordinates from '%s'."
+#~ msgstr "寸法を '%s' から取得できません。"
+
+#~ msgid "Cannot parse dimension from '%s'."
+#~ msgstr "'%s' から大きさの値を解析できません。"
+
+#~ msgid "Cant create the thread event queue"
+#~ msgstr "スレッドイベントキューを作成できませんでした"
+
+#~ msgid "Closes the dialog without inserting a symbol."
+#~ msgstr "記号を挿入せずにダイアログを閉じます。"
+
+#~ msgid "Control is wrongly initialized."
+#~ msgstr "コントロールが正しく初期化されていません。"
+
+#~ msgid "Could not find resource include file %s."
+#~ msgstr "リソースインクルードファイル %s が見つかりません。"
+
+#~ msgid ""
+#~ "Could not resolve control class or id '%s'. Use (non-zero) integer "
+#~ "instead\n"
+#~ " or provide #define (see manual for caveats)"
+#~ msgstr ""
+#~ "制御クラスまたは識別子 '%s' を解決できません。\n"
+#~ "0以外の整数を使うか #defineを用いてください (説明書の注意参照) 。"
+
+#~ msgid ""
+#~ "Could not resolve menu id '%s'. Use (non-zero) integer instead\n"
+#~ "or provide #define (see manual for caveats)"
+#~ msgstr ""
+#~ "識別子 '%s' を解決できません。\n"
+#~ "0以外の整数を使うか #define を用いてください (説明書の注意参照) 。"
+
+#~ msgid "Could not unlock mutex"
+#~ msgstr "Mutexのアンロックができませんでした"
+
+#~ msgid "Couldn't end the context on the overlay window"
+#~ msgstr "オーバーレイウィンドウの内容末尾にたどり着けませんでした。"
+
+#~ msgid "Data view control is not correctly initialized"
+#~ msgstr "データビューコントロールが正しく初期化されていません。"
+
+#~ msgid "Error while waiting on semaphore"
+#~ msgstr "セマフォー待ちの中途でエラーを検出しました"
+
+#~ msgid "Expected '*' while parsing resource."
+#~ msgstr "リソース解析中、必要な '*' がない場所を検出しました。"
+
+#~ msgid "Expected '=' while parsing resource."
+#~ msgstr "リソース解析中、必要な '=' がない場所を検出しました。"
+
+#~ msgid "Expected 'char' while parsing resource."
+#~ msgstr "リソース解析中、必要な 'char' がない場所を検出しました。"
+
+#~ msgid "Failed to %s dialup connection: %s"
+#~ msgstr "%s ダイヤルアップ接続に失敗しました: %s"
+
+#~ msgid ""
+#~ "Failed to find XBM resource %s.\n"
+#~ "Forgot to use wxResourceLoadBitmapData?"
+#~ msgstr ""
+#~ "XBM リソース %s が見つかりません。\n"
+#~ "wxResourceLoadBitmapData を使うのを忘れていませんか?"
+
+#~ msgid ""
+#~ "Failed to find XBM resource %s.\n"
+#~ "Forgot to use wxResourceLoadIconData?"
+#~ msgstr ""
+#~ "XBM リソース %s が見つかりません。\n"
+#~ "wxResourceLoadIconData を使うのを忘れていませんか?"
+
+#~ msgid ""
+#~ "Failed to find XPM resource %s.\n"
+#~ "Forgot to use wxResourceLoadBitmapData?"
+#~ msgstr ""
+#~ "XPM リソース %s が見つかりません。\n"
+#~ "wxResourceLoadBitmapData を使うのを忘れていませんか?"
+
+#~ msgid "Failed to get clipboard data."
+#~ msgstr "クリップボードのデータを取得できませんでした。"
+
+#~ msgid "Failed to load shared library '%s' Error '%s'"
+#~ msgstr "共有ライブラリ '%s' はエラー '%s' により読み取れませんでした。"
+
+#~ msgid "Failed to open '%s' for %s"
+#~ msgstr "'%s' を開くことができませんでした(%s)"
+
+#~ msgid "Failed to register OpenGL window class."
+#~ msgstr "OpenGL ウィンドウクラスを登録できませんでした。"
+
+#~ msgid "Fatal error: "
+#~ msgstr "重大なエラー:"
+
+#~ msgid "Found "
+#~ msgstr "リソース解析中に"
+
+#~ msgid "Go forward to the next HTML page"
+#~ msgstr "次のHTMLページに進む"
+
+#~ msgid "Help : %s"
+#~ msgstr "ヘルプ: %s"
+
+#~ msgid "Icon resource specification %s not found."
+#~ msgstr "アイコンリソース %s が見つかりません。"
+
+#~ msgid "Ill-formed resource file syntax."
+#~ msgstr "リソースファイルの書式に不整合があります。"
+
+#~ msgid "Inserts the chosen symbol."
+#~ msgstr "選択した記号を挿入します"
+
+#~ msgid "Invalid XRC resource '%s': doesn't have root node 'resource'."
+#~ msgstr "不正な XRC リソース '%s': ルートノードが 'resource' ではありません｡"
+
+#~ msgid "Long Conversions not supported"
+#~ msgstr "Long 型への変換には対応していません"
+
+#~ msgid "No XPM icon facility available!"
+#~ msgstr "XPM アイコン機能は利用できません。"
+
+#~ msgid "No fonts found in %s."
+#~ msgstr "%s にフォントがありません。"
+
+#~ msgid "No handler found for XML node '%s', class '%s'!"
+#~ msgstr "XMLノード '%s' 、class='%s'に対するハンドラーがありません。"
+
+#~ msgid "Option '%s' requires a value, '=' expected."
+#~ msgstr "オプション '%s' は '=' を挟んで値の指定が必要です。"
+
+#~ msgid "Preparing help window..."
+#~ msgstr "ヘルプウィンドウ準備中..."
+
+#~ msgid "Program aborted."
+#~ msgstr "プログラムを中断しました。"
+
+#~ msgid "Referenced object node with ref=\"%s\" not found!"
+#~ msgstr "ref=\"%s\" で参照されているノードが見つかりません。"
+
+#~ msgid "Resource files must have same version number!"
+#~ msgstr "リソースファイルは同じバージョン番号でなくてはなりません。"
+
+#~ msgid "Search!"
+#~ msgstr "検索"
+
+#~ msgid "Select a file"
+#~ msgstr "ファイルを選んでください"
+
+#~ msgid "Select all"
+#~ msgstr "すべて選択"
+
+#~ msgid "Sorry, could not open this file for saving."
+#~ msgstr "保存のためにこのファイルを開くことができませんでした｡"
+
+#~ msgid "Sorry, could not save this file."
+#~ msgstr "ファイルを保存することができませんでした。"
+
+#~ msgid ""
+#~ "Sorry, docking is not supported for ports other than wxMSW, wxMac and "
+#~ "wxGTK"
+#~ msgstr "ドッキングに対応しているのは wxMSW, wxMac, wxGTK だけです"
+
+#~ msgid "Sorry, print preview needs a printer to be installed."
+#~ msgstr "プレビューにはプリンターのインストールが必要です。"
+
+#~ msgid "Status: "
+#~ msgstr "状態:"
+
+#~ msgid "Subclass '%s' not found for resource '%s', not subclassing!"
+#~ msgstr ""
+#~ "サブクラスの元　'%s' がありませんでした。リソース '%s' はサブクラスにしま"
+#~ "せん。"
+
+#~ msgid "TIFF library error."
+#~ msgstr "TIFFライブラリーエラー。"
+
+#~ msgid "TIFF library warning."
+#~ msgstr "TIFFライブラリーの警告。"
+
+#~ msgid ""
+#~ "This system doesn't support date picker control, please upgrade your "
+#~ "version of comctl32.dll"
+#~ msgstr ""
+#~ "お使いのシステムは date picker コントロールに未対応です。comctl32.dll を新"
+#~ "しいものに更新してください"
+
+#~ msgid "Trying to solve a NULL hostname: giving up"
+#~ msgstr "NULLホスト名の解決を試行: 試行を中止しました"
+
+#~ msgid "Unexpected end of file while parsing resource."
+#~ msgstr "リソース解析中に想定外のEOFが検出されました。"
+
+#~ msgid "Unknown style flag "
+#~ msgstr "未知のスタイルフラグ"
+
+#~ msgid "Unkown Property %s"
+#~ msgstr "未定義の特性 %s"
+
+#~ msgid "Unrecognized style %s while parsing resource."
+#~ msgstr "リソース解析中に想定外のスタイル %s を検出しました。"
+
+#~ msgid "Version %s"
+#~ msgstr "version %s"
+
+#~ msgid "Video Output"
+#~ msgstr "映像出力"
+
+#~ msgid "Warning: attempt to remove HTML tag handler from empty stack."
+#~ msgstr "警告: 空のスタックからHTMLタグハンドラーを除去しようとしました。"
+
+#~ msgid "XRC resource '%s' (class '%s') not found!"
+#~ msgstr "XRC リソース '%s' (クラス '%s') が見つかりません。"
+
+#~ msgid "XRC resource: Cannot create animation from '%s'."
+#~ msgstr "XRC リソース: '%s' からアニメーションを作成できません。"
+
+#~ msgid "XRC resource: Cannot create bitmap from '%s'."
+#~ msgstr "XRC リソース: '%s' からビットマップを作成できません。"
+
+#~ msgid "XRC resource: Incorrect colour specification '%s' for property '%s'."
+#~ msgstr "XRC リソース: 色の設定値 '%s' は不正です(特性 '%s')"
+
+#~ msgid "[EMPTY]"
+#~ msgstr "[空]"
+
+#~ msgid "catalog file for domain '%s' not found."
+#~ msgstr "地域 '%s' に対するカタログファイルが見つかりません。"
+
+#~ msgid "encoding %i"
+#~ msgstr "エンコーディング %i"
+
+#~ msgid "establish"
+#~ msgstr "同期確立"
+
+#~ msgid "initiate"
+#~ msgstr "非同期確立"
+
+#~ msgid "invalid eof() return value."
+#~ msgstr "eof() の戻り値は不正なものになります。"
+
+#~ msgid "looking for catalog '%s' in path '%s'."
+#~ msgstr "カタログ '%s' をパス '%s' から探します。"
+
+#~ msgid "m_peer is not or incorrectly initialized"
+#~ msgstr "m_peer が正しく初期化されていません"
+
+#~ msgid "unknown line terminator"
+#~ msgstr "未対応の改行子です"
+
+#~ msgid "writing"
+#~ msgstr "書き出し"
+
+#~ msgid "wxRichTextBulletsPage"
+#~ msgstr "wxRichTextBulletsPage"
+
+#~ msgid "wxRichTextFontPage"
+#~ msgstr "wxRichTextFontPage"
+
+#~ msgid "wxRichTextListStylePage"
+#~ msgstr "wxRichTextListStylePage"
+
+#~ msgid "wxRichTextStylePage"
+#~ msgstr "wxRichTextStylePage"
+
+#~ msgid "wxSocket: invalid signature in ReadMsg."
+#~ msgstr "wxSocket: ReadMsgに不正なシグネチャーがありました。"
+
+#~ msgid "wxSocket: unknown event!."
+#~ msgstr "wxSocket: 未対応のイベントです。"

--- a/po_wxstd/ka.po
+++ b/po_wxstd/ka.po
@@ -1,0 +1,9255 @@
+# WxWidgets Georgian tanslation
+# Copyright (C) 2022 THE WxWidgets'S authors
+# This file is distributed under the same license as the WxWidgets package.
+# Temuri Doghonadze <temuri.doghonadze@gmail.com>, 2022 2025.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-05-14 20:23+0200\n"
+"PO-Revision-Date: 2025-09-26 10:07+0200\n"
+"Last-Translator: Temuri Doghonadze <temuri.doghonadze@gmail.com>\n"
+"Language-Team: \n"
+"Language: ka\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Poedit 3.7\n"
+
+#: ../include/wx/defs.h:2582
+msgid "All files (*.*)|*.*"
+msgstr "ყველა ფაილი (*.*)|*.*"
+
+#: ../include/wx/defs.h:2585
+msgid "All files (*)|*"
+msgstr "ყველა ფაილი(*)|*"
+
+#: ../include/wx/generic/progdlgg.h:85
+msgid "Elapsed time:"
+msgstr "გასული დრო:"
+
+#: ../include/wx/generic/progdlgg.h:86
+msgid "Estimated time:"
+msgstr "დაახლოებით დრო:"
+
+#: ../include/wx/generic/progdlgg.h:87
+msgid "Remaining time:"
+msgstr "დარჩენილი დრო:"
+
+#. TRANSLATORS: HTML printout default title.
+#: ../include/wx/html/htmprint.h:121 ../include/wx/prntbase.h:273
+#: ../include/wx/richtext/richtextprint.h:109 ../src/common/docview.cpp:2161
+msgid "Printout"
+msgstr "გამობეჭდვა"
+
+#. TRANSLATORS: HTML easy print default title.
+#: ../include/wx/html/htmprint.h:234 ../include/wx/richtext/richtextprint.h:163
+#: ../src/common/prntbase.cpp:522 ../src/html/htmprint.cpp:291
+msgid "Printing"
+msgstr "დაბეჭდვა"
+
+#: ../include/wx/msgdlg.h:277 ../src/common/stockitem.cpp:211
+msgid "Yes"
+msgstr "დიახ"
+
+#: ../include/wx/msgdlg.h:278 ../src/common/stockitem.cpp:182
+msgid "No"
+msgstr "არა"
+
+#: ../include/wx/msgdlg.h:279 ../src/common/stockitem.cpp:183
+#: ../src/msw/msgdlg.cpp:430 ../src/msw/msgdlg.cpp:734
+#: ../src/richtext/richtextstyledlg.cpp:292
+msgid "OK"
+msgstr "კარგი"
+
+#: ../include/wx/msgdlg.h:280 ../src/common/stockitem.cpp:150
+#: ../src/msw/msgdlg.cpp:430 ../src/msw/progdlg.cpp:884
+#: ../src/richtext/richtextstyledlg.cpp:295
+msgid "Cancel"
+msgstr "გაუქმება"
+
+#: ../include/wx/msgdlg.h:281 ../src/common/stockitem.cpp:168
+#: ../src/html/helpdlg.cpp:63 ../src/html/helpfrm.cpp:108
+#: ../src/osx/button_osx.cpp:38
+msgid "Help"
+msgstr "დახმარება"
+
+#: ../include/wx/msw/ole/oleutils.h:52
+msgid "Cannot initialize OLE"
+msgstr "OLE-ის ინიციალიზაციის შეცდომა"
+
+#: ../include/wx/msw/private/fswatcher.h:48
+#, c-format
+msgid "Unable to close the handle for '%s'"
+msgstr "%s-სთვის დამმუშავებლის დახურვა შეუძლებელია"
+
+#: ../include/wx/msw/private/fswatcher.h:92
+#, c-format
+msgid "Failed to open directory \"%s\" for monitoring."
+msgstr "საქაღალდის (%s) მონიტორინგისთვის გახსნის შეცდომა."
+
+#: ../include/wx/msw/private/fswatcher.h:125
+msgid "Unable to close I/O completion port handle"
+msgstr "I/O დასრულების პორტის დამმუშავებლის დახურვის შეცდომა"
+
+#: ../include/wx/msw/private/fswatcher.h:142
+msgid "Unable to associate handle with I/O completion port"
+msgstr "I/O დასრულების პორტთან დამმუშავებლის ასოცირების შეცდომა"
+
+#: ../include/wx/msw/private/fswatcher.h:148
+msgid "Unexpectedly new I/O completion port was created"
+msgstr "შექმნილია მოულოდნელი ახალი I/O დასრულების პორტი"
+
+#: ../include/wx/msw/private/fswatcher.h:213
+msgid "Unable to post completion status"
+msgstr "დასრულების სტატუსის გადაგზავნის შეცდომა"
+
+#: ../include/wx/msw/private/fswatcher.h:262
+msgid "Unable to dequeue completion packet"
+msgstr "დასრულების პაკეტის რიგიდან ამოღების შეცდომა"
+
+#: ../include/wx/msw/private/fswatcher.h:273
+msgid "Unable to create I/O completion port"
+msgstr "I/O დასრულების პორტის შექმნის შეცდომა"
+
+#: ../include/wx/richmsgdlg.h:29
+msgid "&See details"
+msgstr "&დეტალების ჩვენება"
+
+#: ../include/wx/richmsgdlg.h:30
+msgid "&Hide details"
+msgstr "&დეტალების დამალვა"
+
+#: ../include/wx/richtext/richtextbuffer.h:3864
+msgid "&Box"
+msgstr "&ყუთი"
+
+#: ../include/wx/richtext/richtextbuffer.h:5008
+msgid "&Picture"
+msgstr "&სურათი"
+
+#: ../include/wx/richtext/richtextbuffer.h:5958
+msgid "&Cell"
+msgstr "&უჯრედი"
+
+#: ../include/wx/richtext/richtextbuffer.h:6067
+msgid "&Table"
+msgstr "&ცხრილი"
+
+#: ../include/wx/richtext/richtextimagedlg.h:37
+msgid "Object Properties"
+msgstr "ობიექტის თვისებები"
+
+#: ../include/wx/richtext/richtextsymboldlg.h:39
+msgid "Symbols"
+msgstr "სიმბოლოები"
+
+#: ../include/wx/unix/pipe.h:46
+msgid "Pipe creation failed"
+msgstr "ფაიფის შექმნის შეცდოამ"
+
+#: ../include/wx/unix/private/displayx11.h:65
+msgid "Failed to enumerate video modes"
+msgstr "შესაძლო ვიდეორეჟიმების სიის შეცდომა"
+
+#: ../include/wx/unix/private/displayx11.h:89
+msgid "Failed to change video mode"
+msgstr "ვიდეორეჟიმის შექმნის შეცდომა"
+
+#: ../include/wx/unix/private/fswatcher_kqueue.h:57
+#, c-format
+msgid "Unable to open path '%s'"
+msgstr "ბილიკის გახსნის შეცდომა: %s"
+
+#: ../include/wx/unix/private/fswatcher_kqueue.h:74
+#, c-format
+msgid "Unable to close path '%s'"
+msgstr "ბილიკის დახურვის შეცდომა: %s"
+
+#: ../include/wx/xtiprop.h:175
+msgid "SetProperty called w/o valid setter"
+msgstr "SetProperty სწორი setter-ის გარეშეა გამოძახებული"
+
+#: ../include/wx/xtiprop.h:184
+msgid "GetProperty called w/o valid getter"
+msgstr "GetProperty სწორი getter-ის გარეშეა გამოძახებული"
+
+#: ../include/wx/xtiprop.h:193
+msgid "AddToPropertyCollection called w/o valid adder"
+msgstr "AddToPropertyCollection სწორი adder-ის გარეშეა გამოძახებული"
+
+#: ../include/wx/xtiprop.h:202
+msgid "GetPropertyCollection called w/o valid collection getter"
+msgstr "GetPropertyCollection სწორი getter-ის გარეშეა გამოძახებული"
+
+#: ../include/wx/xtiprop.h:255
+msgid "AddToPropertyCollection called on a generic accessor"
+msgstr "AddToPropertyCollection ზოგად accessor-ზეა გამოძახებული"
+
+#: ../include/wx/xtiprop.h:262
+msgid "GetPropertyCollection called on a generic accessor"
+msgstr "GetPropertyCollection ზოგად accessor-ზეა გამოძახებული"
+
+#: ../src/aui/tabmdi.cpp:106 ../src/generic/mdig.cpp:94
+msgid "Cl&ose"
+msgstr "&დახურვა"
+
+#: ../src/aui/tabmdi.cpp:107 ../src/generic/mdig.cpp:95
+msgid "Close All"
+msgstr "ყველას დახურვა"
+
+#: ../src/aui/tabmdi.cpp:109 ../src/generic/mdig.cpp:97 ../src/msw/mdi.cpp:175
+#: ../src/qt/mdi.cpp:258
+msgid "&Next"
+msgstr "&შემდეგი"
+
+#: ../src/aui/tabmdi.cpp:110 ../src/generic/mdig.cpp:98 ../src/msw/mdi.cpp:176
+#: ../src/qt/mdi.cpp:259
+msgid "&Previous"
+msgstr "&წინა"
+
+#: ../src/aui/tabmdi.cpp:332 ../src/aui/tabmdi.cpp:348
+#: ../src/aui/tabmdi.cpp:350 ../src/generic/mdig.cpp:291
+#: ../src/generic/mdig.cpp:307 ../src/generic/mdig.cpp:311
+#: ../src/msw/mdi.cpp:337 ../src/qt/mdi.cpp:462
+msgid "&Window"
+msgstr "&ფანჯარა"
+
+#: ../src/common/accelcmn.cpp:47
+msgctxt "keyboard key"
+msgid "Delete"
+msgstr "Delete"
+
+#: ../src/common/accelcmn.cpp:48
+msgctxt "keyboard key"
+msgid "Del"
+msgstr "Del"
+
+#: ../src/common/accelcmn.cpp:49
+msgctxt "keyboard key"
+msgid "Back"
+msgstr "უკან"
+
+#: ../src/common/accelcmn.cpp:49
+msgctxt "keyboard key"
+msgid "Backspace"
+msgstr "Backspace"
+
+#: ../src/common/accelcmn.cpp:50
+msgctxt "keyboard key"
+msgid "Insert"
+msgstr "ჩასმა"
+
+#: ../src/common/accelcmn.cpp:51
+msgctxt "keyboard key"
+msgid "Ins"
+msgstr "Ins"
+
+#: ../src/common/accelcmn.cpp:52
+msgctxt "keyboard key"
+msgid "Enter"
+msgstr "Enter"
+
+#: ../src/common/accelcmn.cpp:53
+msgctxt "keyboard key"
+msgid "Return"
+msgstr "Enter"
+
+#: ../src/common/accelcmn.cpp:54
+msgctxt "keyboard key"
+msgid "PageUp"
+msgstr "PageUp"
+
+#: ../src/common/accelcmn.cpp:54
+msgctxt "keyboard key"
+msgid "Page Up"
+msgstr "ღილაკი Page Up"
+
+#: ../src/common/accelcmn.cpp:55
+msgctxt "keyboard key"
+msgid "PageDown"
+msgstr "PageDown"
+
+#: ../src/common/accelcmn.cpp:55
+msgctxt "keyboard key"
+msgid "Page Down"
+msgstr "ღილაკი Page Down"
+
+#: ../src/common/accelcmn.cpp:56
+msgctxt "keyboard key"
+msgid "PgUp"
+msgstr "PgUp"
+
+#: ../src/common/accelcmn.cpp:57
+msgctxt "keyboard key"
+msgid "PgDn"
+msgstr "PgDn"
+
+#: ../src/common/accelcmn.cpp:58
+msgctxt "keyboard key"
+msgid "Left"
+msgstr "მარცხნივ"
+
+#: ../src/common/accelcmn.cpp:59
+msgctxt "keyboard key"
+msgid "Right"
+msgstr "მარჯვნივ"
+
+#: ../src/common/accelcmn.cpp:60
+msgctxt "keyboard key"
+msgid "Up"
+msgstr "მაღლა"
+
+#: ../src/common/accelcmn.cpp:61
+msgctxt "keyboard key"
+msgid "Down"
+msgstr "დაბლა"
+
+#: ../src/common/accelcmn.cpp:62
+msgctxt "keyboard key"
+msgid "Home"
+msgstr "საწყისი"
+
+#: ../src/common/accelcmn.cpp:63
+msgctxt "keyboard key"
+msgid "End"
+msgstr "End"
+
+#: ../src/common/accelcmn.cpp:64
+msgctxt "keyboard key"
+msgid "Space"
+msgstr "გამოტოვება"
+
+#: ../src/common/accelcmn.cpp:65
+msgctxt "keyboard key"
+msgid "Tab"
+msgstr "Tab"
+
+#: ../src/common/accelcmn.cpp:66
+msgctxt "keyboard key"
+msgid "Esc"
+msgstr "Esc"
+
+#: ../src/common/accelcmn.cpp:67
+msgctxt "keyboard key"
+msgid "Escape"
+msgstr "Escape"
+
+#: ../src/common/accelcmn.cpp:68
+msgctxt "keyboard key"
+msgid "Cancel"
+msgstr "გაუქმება"
+
+#: ../src/common/accelcmn.cpp:69
+msgctxt "keyboard key"
+msgid "Clear"
+msgstr "გაწმენდა"
+
+#: ../src/common/accelcmn.cpp:70
+msgctxt "keyboard key"
+msgid "Menu"
+msgstr "მენიუ"
+
+#: ../src/common/accelcmn.cpp:71
+msgctxt "keyboard key"
+msgid "Pause"
+msgstr "შეჩერება"
+
+#: ../src/common/accelcmn.cpp:72
+msgctxt "keyboard key"
+msgid "Capital"
+msgstr "Capital"
+
+#: ../src/common/accelcmn.cpp:73
+msgctxt "keyboard key"
+msgid "Select"
+msgstr "Select"
+
+#: ../src/common/accelcmn.cpp:74
+msgctxt "keyboard key"
+msgid "Print"
+msgstr "დაბეჭდვა"
+
+#: ../src/common/accelcmn.cpp:75
+msgctxt "keyboard key"
+msgid "Execute"
+msgstr "გაშვება"
+
+#: ../src/common/accelcmn.cpp:76
+msgctxt "keyboard key"
+msgid "Snapshot"
+msgstr "სწრაფი ასლი"
+
+#: ../src/common/accelcmn.cpp:77
+msgctxt "keyboard key"
+msgid "Help"
+msgstr "დახმარება"
+
+#: ../src/common/accelcmn.cpp:78
+msgctxt "keyboard key"
+msgid "Add"
+msgstr "Add"
+
+#: ../src/common/accelcmn.cpp:79
+msgctxt "keyboard key"
+msgid "Separator"
+msgstr "გამყოფი"
+
+#: ../src/common/accelcmn.cpp:80
+msgctxt "keyboard key"
+msgid "Subtract"
+msgstr "გამოკლება"
+
+#: ../src/common/accelcmn.cpp:81
+msgctxt "keyboard key"
+msgid "Decimal"
+msgstr "ათობითი"
+
+#: ../src/common/accelcmn.cpp:82
+msgctxt "keyboard key"
+msgid "Multiply"
+msgstr "გამრავლება"
+
+#: ../src/common/accelcmn.cpp:83
+msgctxt "keyboard key"
+msgid "Divide"
+msgstr "გაყოფა"
+
+#: ../src/common/accelcmn.cpp:84
+msgctxt "keyboard key"
+msgid "Num_lock"
+msgstr "Num_lock"
+
+#: ../src/common/accelcmn.cpp:84
+msgctxt "keyboard key"
+msgid "Num Lock"
+msgstr "Num Lock"
+
+#: ../src/common/accelcmn.cpp:85
+msgctxt "keyboard key"
+msgid "Scroll_lock"
+msgstr "Scroll_lock"
+
+#: ../src/common/accelcmn.cpp:85
+msgctxt "keyboard key"
+msgid "Scroll Lock"
+msgstr "Scroll Lock"
+
+#: ../src/common/accelcmn.cpp:86
+msgctxt "keyboard key"
+msgid "KP_Space"
+msgstr "KP_Space"
+
+#: ../src/common/accelcmn.cpp:86
+msgctxt "keyboard key"
+msgid "Num Space"
+msgstr "Num Space"
+
+#: ../src/common/accelcmn.cpp:87
+msgctxt "keyboard key"
+msgid "KP_Tab"
+msgstr "KP_Tab"
+
+#: ../src/common/accelcmn.cpp:87
+msgctxt "keyboard key"
+msgid "Num Tab"
+msgstr "Num Tab"
+
+#: ../src/common/accelcmn.cpp:88
+msgctxt "keyboard key"
+msgid "KP_Enter"
+msgstr "KP_Enter"
+
+#: ../src/common/accelcmn.cpp:88
+msgctxt "keyboard key"
+msgid "Num Enter"
+msgstr "Num Enter"
+
+#: ../src/common/accelcmn.cpp:89
+msgctxt "keyboard key"
+msgid "KP_Home"
+msgstr "სახლი"
+
+#: ../src/common/accelcmn.cpp:89
+msgctxt "keyboard key"
+msgid "Num Home"
+msgstr "Num Home"
+
+#: ../src/common/accelcmn.cpp:90
+msgctxt "keyboard key"
+msgid "KP_Left"
+msgstr "მარცხენა"
+
+#: ../src/common/accelcmn.cpp:90
+msgctxt "keyboard key"
+msgid "Num left"
+msgstr "Num left"
+
+#: ../src/common/accelcmn.cpp:91
+msgctxt "keyboard key"
+msgid "KP_Up"
+msgstr "KP_Up"
+
+#: ../src/common/accelcmn.cpp:91
+msgctxt "keyboard key"
+msgid "Num Up"
+msgstr "Num Up"
+
+#: ../src/common/accelcmn.cpp:92
+msgctxt "keyboard key"
+msgid "KP_Right"
+msgstr "KP_Right"
+
+#: ../src/common/accelcmn.cpp:92
+msgctxt "keyboard key"
+msgid "Num Right"
+msgstr "Num Right"
+
+#: ../src/common/accelcmn.cpp:93
+msgctxt "keyboard key"
+msgid "KP_Down"
+msgstr "KP_Down"
+
+#: ../src/common/accelcmn.cpp:93
+msgctxt "keyboard key"
+msgid "Num Down"
+msgstr "Num Down"
+
+#: ../src/common/accelcmn.cpp:94
+msgctxt "keyboard key"
+msgid "KP_PageUp"
+msgstr "KP_PageUp"
+
+#: ../src/common/accelcmn.cpp:94
+msgctxt "keyboard key"
+msgid "Num Page Up"
+msgstr "Num Page Up"
+
+#: ../src/common/accelcmn.cpp:95
+msgctxt "keyboard key"
+msgid "KP_PageDown"
+msgstr "KP_PageDown"
+
+#: ../src/common/accelcmn.cpp:95
+msgctxt "keyboard key"
+msgid "Num Page Down"
+msgstr "Num Page Down"
+
+#: ../src/common/accelcmn.cpp:96
+msgctxt "keyboard key"
+msgid "KP_Prior"
+msgstr "KP_Prior"
+
+#: ../src/common/accelcmn.cpp:97
+msgctxt "keyboard key"
+msgid "KP_Next"
+msgstr "KP_Next"
+
+#: ../src/common/accelcmn.cpp:98
+msgctxt "keyboard key"
+msgid "KP_End"
+msgstr "KP_End"
+
+#: ../src/common/accelcmn.cpp:98
+msgctxt "keyboard key"
+msgid "Num End"
+msgstr "Num End"
+
+#: ../src/common/accelcmn.cpp:99
+msgctxt "keyboard key"
+msgid "KP_Begin"
+msgstr "KP_Begin"
+
+#: ../src/common/accelcmn.cpp:99
+msgctxt "keyboard key"
+msgid "Num Begin"
+msgstr "Num Begin"
+
+#: ../src/common/accelcmn.cpp:100
+msgctxt "keyboard key"
+msgid "KP_Insert"
+msgstr "KP_Insert"
+
+#: ../src/common/accelcmn.cpp:100
+msgctxt "keyboard key"
+msgid "Num Insert"
+msgstr "Num Insert"
+
+#: ../src/common/accelcmn.cpp:101
+msgctxt "keyboard key"
+msgid "KP_Delete"
+msgstr "წაშლა"
+
+#: ../src/common/accelcmn.cpp:101
+msgctxt "keyboard key"
+msgid "Num Delete"
+msgstr "Num Delete"
+
+#: ../src/common/accelcmn.cpp:102
+msgctxt "keyboard key"
+msgid "KP_Equal"
+msgstr "KP_Equal"
+
+#: ../src/common/accelcmn.cpp:102
+msgctxt "keyboard key"
+msgid "Num ="
+msgstr "Num ="
+
+#: ../src/common/accelcmn.cpp:103
+msgctxt "keyboard key"
+msgid "KP_Multiply"
+msgstr "KP_Multiply"
+
+#: ../src/common/accelcmn.cpp:103
+msgctxt "keyboard key"
+msgid "Num *"
+msgstr "Num *"
+
+#: ../src/common/accelcmn.cpp:104
+msgctxt "keyboard key"
+msgid "KP_Add"
+msgstr "KP_Add"
+
+#: ../src/common/accelcmn.cpp:104
+msgctxt "keyboard key"
+msgid "Num +"
+msgstr "Num +"
+
+#: ../src/common/accelcmn.cpp:105
+msgctxt "keyboard key"
+msgid "KP_Separator"
+msgstr "KP_Separator"
+
+#: ../src/common/accelcmn.cpp:105
+msgctxt "keyboard key"
+msgid "Num ,"
+msgstr "Num ,"
+
+#: ../src/common/accelcmn.cpp:106
+msgctxt "keyboard key"
+msgid "KP_Subtract"
+msgstr "KP_Subtract"
+
+#: ../src/common/accelcmn.cpp:106
+msgctxt "keyboard key"
+msgid "Num -"
+msgstr "Num -"
+
+#: ../src/common/accelcmn.cpp:107
+msgctxt "keyboard key"
+msgid "KP_Decimal"
+msgstr "KP_Decimal"
+
+#: ../src/common/accelcmn.cpp:107
+msgctxt "keyboard key"
+msgid "Num ."
+msgstr "Num ."
+
+#: ../src/common/accelcmn.cpp:108
+msgctxt "keyboard key"
+msgid "KP_Divide"
+msgstr "KP_Divide"
+
+#: ../src/common/accelcmn.cpp:108
+msgctxt "keyboard key"
+msgid "Num /"
+msgstr "Num /"
+
+#: ../src/common/accelcmn.cpp:109
+msgctxt "keyboard key"
+msgid "Windows_Left"
+msgstr "Windows_Left"
+
+#: ../src/common/accelcmn.cpp:110
+msgctxt "keyboard key"
+msgid "Windows_Right"
+msgstr "Windows_Right"
+
+#: ../src/common/accelcmn.cpp:111
+msgctxt "keyboard key"
+msgid "Windows_Menu"
+msgstr "Windows_Menu"
+
+#: ../src/common/accelcmn.cpp:112
+msgctxt "keyboard key"
+msgid "Command"
+msgstr "ბრძანება"
+
+#: ../src/common/accelcmn.cpp:186 ../src/common/accelcmn.cpp:359
+msgctxt "keyboard key"
+msgid "Ctrl"
+msgstr "Ctrl"
+
+#: ../src/common/accelcmn.cpp:188 ../src/common/accelcmn.cpp:363
+msgctxt "keyboard key"
+msgid "Alt"
+msgstr "Alt"
+
+#: ../src/common/accelcmn.cpp:190 ../src/common/accelcmn.cpp:361
+msgctxt "keyboard key"
+msgid "Shift"
+msgstr "Shift"
+
+#: ../src/common/accelcmn.cpp:196
+msgctxt "keyboard key"
+msgid "num "
+msgstr "num "
+
+#: ../src/common/accelcmn.cpp:260 ../src/common/accelcmn.cpp:382
+msgctxt "keyboard key"
+msgid "F"
+msgstr "პ"
+
+#: ../src/common/accelcmn.cpp:277 ../src/common/accelcmn.cpp:385
+msgctxt "keyboard key"
+msgid "KP_F"
+msgstr "KP_F"
+
+#: ../src/common/accelcmn.cpp:280 ../src/common/accelcmn.cpp:388
+msgctxt "keyboard key"
+msgid "KP_"
+msgstr "KP_"
+
+#: ../src/common/accelcmn.cpp:283 ../src/common/accelcmn.cpp:391
+msgctxt "keyboard key"
+msgid "SPECIAL"
+msgstr "SPECIAL"
+
+#: ../src/common/accelcmn.cpp:373
+msgid "Ctrl"
+msgstr "Ctrl"
+
+#: ../src/common/appbase.cpp:786
+msgid "show this help message"
+msgstr "დახმარების ამ შეტყობინების ჩვენება"
+
+#: ../src/common/appbase.cpp:796
+msgid "generate verbose log messages"
+msgstr "დამატებითი შეტყობინებების გენერაცია"
+
+#: ../src/common/appcmn.cpp:256
+msgid "specify the theme to use"
+msgstr "მიუთითეთ გამოსაყენებელი თემა"
+
+#: ../src/common/appcmn.cpp:270
+msgid "specify display mode to use (e.g. 640x480-16)"
+msgstr "მიუთითეთ ეკრანის რეჟიმი (მაგ: 640x480-16)"
+
+#: ../src/common/appcmn.cpp:292
+#, c-format
+msgid "Unsupported theme '%s'."
+msgstr "მხარდაუჭერელი თემა '%s'."
+
+#: ../src/common/appcmn.cpp:309
+#, c-format
+msgid "Invalid display mode specification '%s'."
+msgstr "ეკრანის რეჟიმის არასწორი სპეციფიკაცია: %s."
+
+#: ../src/common/cmdline.cpp:875
+#, c-format
+msgid "Option '%s' can't be negated"
+msgstr "პარამეტრი %s-ის გაუარყოფითება არ შეგიძლიათ"
+
+#: ../src/common/cmdline.cpp:889
+#, c-format
+msgid "Unknown long option '%s'"
+msgstr "უცნობი გრძელი პარამეტრი %s"
+
+#: ../src/common/cmdline.cpp:904 ../src/common/cmdline.cpp:926
+#, c-format
+msgid "Unknown option '%s'"
+msgstr "უცნობი პარამეტრი %s"
+
+#: ../src/common/cmdline.cpp:1004
+#, c-format
+msgid "Unexpected characters following option '%s'."
+msgstr "პარამეტრის (%s) მომდევნო სიმბოლოები მოულოდნელია."
+
+#: ../src/common/cmdline.cpp:1039
+#, c-format
+msgid "Option '%s' requires a value."
+msgstr "პარამეტრს \"%s\" მნიშვნელობა სჭირდება."
+
+#: ../src/common/cmdline.cpp:1058
+#, c-format
+msgid "Separator expected after the option '%s'."
+msgstr "პარამეტრის (%s) შემდეგ აუცილებელი გამყოფის გარეშე."
+
+#: ../src/common/cmdline.cpp:1088 ../src/common/cmdline.cpp:1106
+#, c-format
+msgid "'%s' is not a correct numeric value for option '%s'."
+msgstr "%s პარამეტრი \"%s\"-ის სწორ რიცხვობრივ მნიშვნელობას არ წარმოადგენს."
+
+#: ../src/common/cmdline.cpp:1122
+#, c-format
+msgid "Option '%s': '%s' cannot be converted to a date."
+msgstr "პარამეტრი %s: %s-ის თარიღად გარდაქმნა შეუძლებელია."
+
+#: ../src/common/cmdline.cpp:1170
+#, c-format
+msgid "Unexpected parameter '%s'"
+msgstr "მოულოდნელი პარამეტრი: %s"
+
+#. TRANSLATORS: Short name and long name for a command line option
+#: ../src/common/cmdline.cpp:1197
+#, c-format
+msgid "%s (or %s)"
+msgstr "%s (ან %s)"
+
+#: ../src/common/cmdline.cpp:1208
+#, c-format
+msgid "The value for the option '%s' must be specified."
+msgstr "პარამეტრს \"%s\" მნიშვნელობა სჭირდება."
+
+#: ../src/common/cmdline.cpp:1230
+#, c-format
+msgid "The required parameter '%s' was not specified."
+msgstr "საჭირო პარამეტრის \"%s\" მნიშვნელობა მითითებული არაა."
+
+#: ../src/common/cmdline.cpp:1289
+#, c-format
+msgid "Usage: %s"
+msgstr "გამოყენება: %s\\"
+
+#: ../src/common/cmdline.cpp:1498
+msgid "str"
+msgstr "სტრ"
+
+#: ../src/common/cmdline.cpp:1502
+msgid "num"
+msgstr "რიცხვ"
+
+#: ../src/common/cmdline.cpp:1506
+msgid "double"
+msgstr "ორმაგი"
+
+#: ../src/common/cmdline.cpp:1510
+msgid "date"
+msgstr "თარიღი"
+
+#: ../src/common/cmdproc.cpp:250 ../src/common/cmdproc.cpp:276
+#: ../src/common/cmdproc.cpp:296
+msgid "Unnamed command"
+msgstr "სახელო ბრძანება"
+
+#: ../src/common/cmdproc.cpp:253
+msgid "&Undo "
+msgstr "&დაბრუნება "
+
+#: ../src/common/cmdproc.cpp:255
+msgid "Can't &Undo "
+msgstr "&დაბრუნება შეუძლებელია "
+
+#: ../src/common/cmdproc.cpp:259 ../src/common/stockitem.cpp:208
+#: ../src/msw/textctrl.cpp:2880 ../src/osx/textctrl_osx.cpp:649
+#: ../src/richtext/richtextctrl.cpp:327
+msgid "&Undo"
+msgstr "&დაბრუნება"
+
+#: ../src/common/cmdproc.cpp:277 ../src/common/cmdproc.cpp:297
+msgid "&Redo "
+msgstr "&გამეორება "
+
+#: ../src/common/cmdproc.cpp:281 ../src/common/cmdproc.cpp:288
+#: ../src/common/stockitem.cpp:190 ../src/msw/textctrl.cpp:2881
+#: ../src/osx/textctrl_osx.cpp:650 ../src/richtext/richtextctrl.cpp:328
+msgid "&Redo"
+msgstr "&გამეორება"
+
+#: ../src/common/colourcmn.cpp:41
+#, c-format
+msgid "String To Colour : Incorrect colour specification : %s"
+msgstr "სტრიქონიდან ფერამდე : ფერის არასწორი სპეციფიკაცია: %s"
+
+#: ../src/common/config.cpp:259
+#, c-format
+msgid "Invalid value %ld for a boolean key \"%s\" in config file."
+msgstr ""
+"კონფიგურაციის ფაილში არასწორი მნიშვნელობა %ld ლოგიკური პარამეტრისთვის %s."
+
+#: ../src/common/config.cpp:526
+#, c-format
+msgid ""
+"Environment variables expansion failed: missing '%c' at position %u in '%s'."
+msgstr ""
+"გარემოს ცვლადების განშლის შეცდომა: %3$s-ში პოზიციაზე %2$u-ში %1$c აკლია."
+
+#: ../src/common/config.cpp:576 ../src/msw/regconf.cpp:272
+#, c-format
+msgid "'%s' has extra '..', ignored."
+msgstr "'%s' -ს ზედმეტი '..' აქვს. იგნორირებულია."
+
+#. TRANSLATORS: Checkbox state name
+#: ../src/common/datavcmn.cpp:2166 ../src/generic/datavgen.cpp:1430
+msgid "checked"
+msgstr "ჩართულია"
+
+#. TRANSLATORS: Checkbox state name
+#: ../src/common/datavcmn.cpp:2170 ../src/generic/datavgen.cpp:1432
+msgid "unchecked"
+msgstr "გამორთულია"
+
+#. TRANSLATORS: Checkbox state name
+#: ../src/common/datavcmn.cpp:2174
+msgid "undetermined"
+msgstr "განუსაზღვრელია"
+
+#: ../src/common/datetimefmt.cpp:1875
+msgid "today"
+msgstr "დღეს"
+
+#: ../src/common/datetimefmt.cpp:1876
+msgid "yesterday"
+msgstr "გუშინ"
+
+#: ../src/common/datetimefmt.cpp:1877
+msgid "tomorrow"
+msgstr "ხვალ"
+
+#: ../src/common/datetimefmt.cpp:2071
+msgid "first"
+msgstr "პირველი"
+
+#: ../src/common/datetimefmt.cpp:2072
+msgid "second"
+msgstr "წამი"
+
+#: ../src/common/datetimefmt.cpp:2073
+msgid "third"
+msgstr "მესამე"
+
+#: ../src/common/datetimefmt.cpp:2074
+msgid "fourth"
+msgstr "მეოთხე"
+
+#: ../src/common/datetimefmt.cpp:2075
+msgid "fifth"
+msgstr "მეხუთე"
+
+#: ../src/common/datetimefmt.cpp:2076
+msgid "sixth"
+msgstr "მეექვსე"
+
+#: ../src/common/datetimefmt.cpp:2077
+msgid "seventh"
+msgstr "მეშვიდე"
+
+#: ../src/common/datetimefmt.cpp:2078
+msgid "eighth"
+msgstr "მერვე"
+
+#: ../src/common/datetimefmt.cpp:2079
+msgid "ninth"
+msgstr "მეცხრე"
+
+#: ../src/common/datetimefmt.cpp:2080
+msgid "tenth"
+msgstr "მეათე"
+
+#: ../src/common/datetimefmt.cpp:2081
+msgid "eleventh"
+msgstr "მეთერთმეტე"
+
+#: ../src/common/datetimefmt.cpp:2082
+msgid "twelfth"
+msgstr "მეთორმეტე"
+
+#: ../src/common/datetimefmt.cpp:2083
+msgid "thirteenth"
+msgstr "მეცამეტე"
+
+#: ../src/common/datetimefmt.cpp:2084
+msgid "fourteenth"
+msgstr "მეთოთხმეტე"
+
+#: ../src/common/datetimefmt.cpp:2085
+msgid "fifteenth"
+msgstr "მეთხუთმეტე"
+
+#: ../src/common/datetimefmt.cpp:2086
+msgid "sixteenth"
+msgstr "მეთექვსმეტე"
+
+#: ../src/common/datetimefmt.cpp:2087
+msgid "seventeenth"
+msgstr "მეჩვიდმეტე"
+
+#: ../src/common/datetimefmt.cpp:2088
+msgid "eighteenth"
+msgstr "მეთვრამეტე"
+
+#: ../src/common/datetimefmt.cpp:2089
+msgid "nineteenth"
+msgstr "მეცხრამეტე"
+
+#: ../src/common/datetimefmt.cpp:2090
+msgid "twentieth"
+msgstr "მეოცე"
+
+#: ../src/common/datetimefmt.cpp:2248
+msgid "noon"
+msgstr "საღამო"
+
+#: ../src/common/datetimefmt.cpp:2249
+msgid "midnight"
+msgstr "შუაღამე"
+
+#: ../src/common/debugrpt.cpp:209
+#, c-format
+msgid "Failed to create directory \"%s\""
+msgstr "საქაღალდის შექმნის შეცდომა: %s"
+
+#: ../src/common/debugrpt.cpp:210
+msgid "Debug report couldn't be created."
+msgstr "გამართვის ანგარიშის შექმნის შეცდომა."
+
+#: ../src/common/debugrpt.cpp:227
+#, c-format
+msgid "Failed to remove debug report file \"%s\""
+msgstr "გამართვის ანგარიშის ფაილის წაშლის შეცდომა: %s"
+
+#: ../src/common/debugrpt.cpp:239
+#, c-format
+msgid "Failed to clean up debug report directory \"%s\""
+msgstr "გამართვის ანგარიშის საქაღალდის (%s) გასუფთავების შეცდომა"
+
+#: ../src/common/debugrpt.cpp:514
+msgid "process context description"
+msgstr "პროცესის კონტექსტის აღწერა"
+
+#: ../src/common/debugrpt.cpp:538
+msgid "dump of the process state (binary)"
+msgstr "პროცესის მდგომარეობის დამპი (ბინარული)"
+
+#: ../src/common/debugrpt.cpp:553
+msgid "Debug report generation has failed."
+msgstr "გამართვის ანგარიშის გენერაციის შეცდომა."
+
+#: ../src/common/debugrpt.cpp:560
+#, c-format
+msgid ""
+"Processing debug report has failed, leaving the files in \"%s\" directory."
+msgstr ""
+"გამართვის ანგარიშის დამუშავების შეცდომა. ფაილები საქაღალდეში \"%s\" წაშლილი "
+"არ იქნება."
+
+#: ../src/common/debugrpt.cpp:573
+msgid "A debug report has been generated. It can be found in"
+msgstr "მიმდინარეობს გამართვის ანგარიშის ძებნა. მისი პოვნა შეგიძლიათ ბილიკზე"
+
+#: ../src/common/debugrpt.cpp:576
+msgid "And includes the following files:\n"
+msgstr "და შეიცავს შემდეგ ფაილებს:\n"
+
+#: ../src/common/debugrpt.cpp:586
+msgid ""
+"\n"
+"Please send this report to the program maintainer, thank you!\n"
+msgstr ""
+"\n"
+"გთხოვთ ეს ანგარიში პროგრამის ავტორს გაუგზავნოთ. მადლობა!\n"
+
+#: ../src/common/debugrpt.cpp:729
+msgid "Failed to execute curl, please install it in PATH."
+msgstr "Curl-ის გაშვების შეცდომა. გთხოვთ დააყენოთ."
+
+#: ../src/common/debugrpt.cpp:742
+#, c-format
+msgid "Failed to upload the debug report (error code %d)."
+msgstr "გამართვის ანგარიშის ატვირთვის შეცდომა (შეცდომის კოდი: %d)."
+
+#: ../src/common/docview.cpp:366
+msgid "Save As"
+msgstr "შენახვა, როგორც"
+
+#: ../src/common/docview.cpp:457
+msgid "Discard changes and reload the last saved version?"
+msgstr "გავაუქმო ცვლილებები და ჩავტვირთო ბოლოს შენახული ვერსია?"
+
+#: ../src/common/docview.cpp:488
+msgid "unnamed"
+msgstr "უსახელო"
+
+#: ../src/common/docview.cpp:513
+#, c-format
+msgid "Do you want to save changes to %s?"
+msgstr "გნებავთ'%s' -ის ცვლილებების შენახვა?"
+
+#: ../src/common/docview.cpp:521 ../src/common/docview.cpp:560
+#: ../src/common/stockitem.cpp:195
+msgid "&Save"
+msgstr "&შენახვა"
+
+#: ../src/common/docview.cpp:522 ../src/common/docview.cpp:560
+msgid "&Discard changes"
+msgstr "&ცვლილებების მოცილება"
+
+#: ../src/common/docview.cpp:523
+msgid "Do&n't close"
+msgstr "არ და&ხურო"
+
+#: ../src/common/docview.cpp:553
+#, c-format
+msgid "Do you want to save changes to %s before closing it?"
+msgstr "გნებავთ '%s' -ის ცვლილებების შენახვა მის დახურვამდე?"
+
+#: ../src/common/docview.cpp:559
+msgid "The document must be closed."
+msgstr "დოკუმენტი უნდა დაიხუროს."
+
+#: ../src/common/docview.cpp:571
+#, c-format
+msgid "Saving %s failed, would you like to retry?"
+msgstr "%s-ის შენახვა ჩავარდა. ვცადო თავიდან?"
+
+#: ../src/common/docview.cpp:577
+msgid "Retry"
+msgstr "თავიდან ცდა"
+
+#: ../src/common/docview.cpp:577
+msgid "Discard changes"
+msgstr "ცვლილებების გაუქმება"
+
+#: ../src/common/docview.cpp:679
+#, c-format
+msgid "File \"%s\" could not be opened for writing."
+msgstr "ფაილის (\"%s\") ჩასაწერად გახსნა შეუძლებელია."
+
+#: ../src/common/docview.cpp:685
+#, c-format
+msgid "Failed to save document to the file \"%s\"."
+msgstr "დოკუმენტის შენახვის შეცდომა: \"%s\"."
+
+#: ../src/common/docview.cpp:702
+#, c-format
+msgid "File \"%s\" could not be opened for reading."
+msgstr "ფაილის წასაკითხად გახსნის შეცდომა: %s."
+
+#: ../src/common/docview.cpp:714
+#, c-format
+msgid "Failed to read document from the file \"%s\"."
+msgstr "ფაილიდან \"%s\" დოკუმენტის წაკითხვის შეცდომა."
+
+#: ../src/common/docview.cpp:1236
+#, c-format
+msgid ""
+"The file '%s' doesn't exist and couldn't be opened.\n"
+"It has been removed from the most recently used files list."
+msgstr ""
+"ფაილი %s არ არსებობს და მისი გახსნა შეუძლებელია.\n"
+"წაიშალა ახლახანს გამოყენებული ფაილების სიიდან."
+
+#: ../src/common/docview.cpp:1296
+msgid "Print preview creation failed."
+msgstr "საბეჭდი ესკიზის გადახედვის შექმნის შეცდომა."
+
+#: ../src/common/docview.cpp:1302
+msgid "Print Preview"
+msgstr "დასაბეჭდის გადახედვა"
+
+#: ../src/common/docview.cpp:1517
+#, c-format
+msgid "The format of file '%s' couldn't be determined."
+msgstr "ფაილის (%s) ფორმატის განსაზღვრის შეცდომა."
+
+#: ../src/common/docview.cpp:1643
+#, c-format
+msgid "unnamed%d"
+msgstr "უსახელო%d"
+
+#: ../src/common/docview.cpp:1660
+msgid " - "
+msgstr " - "
+
+#: ../src/common/docview.cpp:1791 ../src/common/docview.cpp:1844
+msgid "Open File"
+msgstr "ფაილის გახსნა"
+
+#: ../src/common/docview.cpp:1807
+msgid "File error"
+msgstr "ფაილის შეცდომა"
+
+#: ../src/common/docview.cpp:1809
+msgid "Sorry, could not open this file."
+msgstr "ჩასაწერად გახსნა შეუძლებელია."
+
+#: ../src/common/docview.cpp:1843
+msgid "Sorry, the format for this file is unknown."
+msgstr "უცნობი ფორმატი."
+
+#: ../src/common/docview.cpp:1924
+msgid "Select a document template"
+msgstr "აირციეთ დოკუმენტის შაბლონი"
+
+#: ../src/common/docview.cpp:1925
+msgid "Templates"
+msgstr "ნიმუშები"
+
+#: ../src/common/docview.cpp:1998
+msgid "Select a document view"
+msgstr "აირჩიეთ დოკუმენტის ხედი"
+
+#: ../src/common/docview.cpp:1999
+msgid "Views"
+msgstr "ხედები"
+
+#: ../src/common/dynlib.cpp:81
+#, c-format
+msgid "Failed to load shared library '%s'"
+msgstr "გაზიარებული ბიბლიოთეკის ფაილის ჩატვირთვის შეცდომა: %s"
+
+#: ../src/common/dynlib.cpp:105
+#, c-format
+msgid "Couldn't find symbol '%s' in a dynamic library"
+msgstr "დინამიურ ბიბლიოთეკაში სიმბოლოს (%s) პოვნა შეუძლებელია"
+
+#: ../src/common/ffile.cpp:56 ../src/common/file.cpp:215
+#, c-format
+msgid "can't open file '%s'"
+msgstr "ფაილის გახსნის შეცდომა: %s"
+
+#: ../src/common/ffile.cpp:72
+#, c-format
+msgid "can't close file '%s'"
+msgstr "ფაილის დახურვის შეცდომა: %s"
+
+#: ../src/common/ffile.cpp:106 ../src/common/ffile.cpp:131
+#, c-format
+msgid "Read error on file '%s'"
+msgstr "ფაილის წაკითხვის პრობლემა: %s"
+
+#: ../src/common/ffile.cpp:148
+#, c-format
+msgid "Write error on file '%s'"
+msgstr "ფაილის ჩაწერის შეცდომა: %s"
+
+#: ../src/common/ffile.cpp:182
+#, c-format
+msgid "failed to flush the file '%s'"
+msgstr "ფაილის პირდაპირ დისკზე ჩაწერის შეცდომა: %s"
+
+#: ../src/common/ffile.cpp:222
+#, c-format
+msgid "Seek error on file '%s' (large files not supported by stdio)"
+msgstr ""
+"ფაილში გადახვევის შეცდომა: %s (stdio-ს დიდი ფაილების მხარდაჭერა არ გააჩნია)"
+
+#: ../src/common/ffile.cpp:232
+#, c-format
+msgid "Seek error on file '%s'"
+msgstr "ფაილში გადახვევის შეცდომა: %s"
+
+#: ../src/common/ffile.cpp:248
+#, c-format
+msgid "Can't find current position in file '%s'"
+msgstr "ფაილში (%s) მიმდინარე მდებარეობის პოვნის შეცდომა"
+
+#: ../src/common/ffile.cpp:349 ../src/common/file.cpp:569
+msgid "Failed to set temporary file permissions"
+msgstr "დროებითი ფაილის წვდომების დაყენების შეცდომა"
+
+#: ../src/common/ffile.cpp:371
+#, c-format
+msgid "can't remove file '%s'"
+msgstr "ფაილის წაშლის შეცდომა: %s"
+
+#: ../src/common/ffile.cpp:376 ../src/common/file.cpp:591
+#, c-format
+msgid "can't commit changes to file '%s'"
+msgstr "ფაილის ცვლილებების გადაცემის შეცდომა: %s"
+
+#: ../src/common/ffile.cpp:388 ../src/common/file.cpp:603
+#, c-format
+msgid "can't remove temporary file '%s'"
+msgstr "დროებითი ფაილის წაშლის შეცდომა: %s"
+
+#: ../src/common/file.cpp:162
+#, c-format
+msgid "can't create file '%s'"
+msgstr "ფაილის შექმნა შეუძლებელია: %s"
+
+#: ../src/common/file.cpp:229
+#, c-format
+msgid "can't close file descriptor %d"
+msgstr "ფაილის დესკრიპტორის დახურვის შეცდომა: %d"
+
+#: ../src/common/file.cpp:332
+#, c-format
+msgid "can't read from file descriptor %d"
+msgstr "ფაილის დესკრიპტორიდან წაკითხვის შეცდომა: %d"
+
+#: ../src/common/file.cpp:351
+#, c-format
+msgid "can't write to file descriptor %d"
+msgstr "ფაილის დესკრიპტორში ჩაწერის შეცდომა: %d"
+
+#: ../src/common/file.cpp:390
+#, c-format
+msgid "can't flush file descriptor %d"
+msgstr "ფაილის დესკრიპტორში პირდაპირი ჩაწერის შეცდომა: %d"
+
+#: ../src/common/file.cpp:432
+#, c-format
+msgid "can't seek on file descriptor %d"
+msgstr "ფაილის დესკრიპტორში გადახვევის შეცდომა: %d"
+
+#: ../src/common/file.cpp:446
+#, c-format
+msgid "can't get seek position on file descriptor %d"
+msgstr "ფაილის დესკრიპტორში მდებარეობაზე გადახვევის შეცდომა: %d"
+
+#: ../src/common/file.cpp:475
+#, c-format
+msgid "can't find length of file on file descriptor %d"
+msgstr "ფაილის დესკრიპტორზე ფაილის სიგრძის მიღების შეცდომა: %d"
+
+#: ../src/common/file.cpp:505
+#, c-format
+msgid "can't determine if the end of file is reached on descriptor %d"
+msgstr ""
+"ფაილის დესკრიპტორზე (%d)  გარკვევა, მიღწეულია თუ არა ფაილის ბოლო, შეუძლებელია"
+
+#: ../src/common/fileconf.cpp:352
+#, c-format
+msgid ""
+" and additionally, the existing configuration file was renamed to \"%s\" and "
+"couldn't be renamed back, please rename it to its original path \"%s\""
+msgstr ""
+" და დამატებით არსებული კონფიგურაციის ფაილის სახელი შეიცვალა \"%s\"-ზე და ამ "
+"გადარქმევის გაუქმება ვერ მოხერხდა. გადაარქვით მას სახელი ორიგინალზე და "
+"დააბრუნეთ ბილიკზე \"%s\""
+
+#: ../src/common/fileconf.cpp:389
+msgid " due to the following error:\n"
+msgstr " შემდეგი შეცდომის გამო:\n"
+
+#: ../src/common/fileconf.cpp:412
+msgid "failed to rename the existing file"
+msgstr "არსებული ფაილის სახელის გადარქმევა ჩავარდა"
+
+#: ../src/common/fileconf.cpp:421
+msgid "failed to create the new file directory"
+msgstr "ახალი ფაილების საქაღალდის შექმნა ჩავარდა"
+
+#: ../src/common/fileconf.cpp:428
+msgid "failed to move the file to the new location"
+msgstr "ფაილის ახალ მდებარეობაზე გადატანა ჩავარდა"
+
+#: ../src/common/fileconf.cpp:462
+#, c-format
+msgid "can't open global configuration file '%s'."
+msgstr "გლობალური კონფიგურაციის ფაილის გახსნის შეცდომა: %s."
+
+#: ../src/common/fileconf.cpp:478
+#, c-format
+msgid "can't open user configuration file '%s'."
+msgstr "მომხმარებლის კონფიგურაციის ფაილის გახსნის შეცდომა: %s."
+
+#: ../src/common/fileconf.cpp:483
+#, c-format
+msgid "Changes won't be saved to avoid overwriting the existing file \"%s\""
+msgstr ""
+"არსებული ფაილის (%s) თავზე გადაწერის თავიდან ასარიდებლად ცვლილებები შენახული "
+"არ იქნება"
+
+#: ../src/common/fileconf.cpp:583
+msgid "Error reading config options."
+msgstr "კონფიგურაციის პარამეტრების წაკითხვის შეცდომა."
+
+#: ../src/common/fileconf.cpp:593
+msgid "Failed to read config options."
+msgstr "კონფიგურაციის პარამეტრების წაკითხვის შეცდომა."
+
+#: ../src/common/fileconf.cpp:700
+#, c-format
+msgid "file '%s': unexpected character %c at line %zu."
+msgstr "ფაილი %s: მოულოდნელი სიმბოლო (%c) ხაზზე %zu."
+
+#: ../src/common/fileconf.cpp:736
+#, c-format
+msgid "file '%s', line %zu: '%s' ignored after group header."
+msgstr "ფაილი %s, ხაზი %zu: %s იგნორირებულია ჯგუფის თავსართის შემდეგ."
+
+#: ../src/common/fileconf.cpp:765
+#, c-format
+msgid "file '%s', line %zu: '=' expected."
+msgstr "ფაილი %s: ხაზი %zu: მოველოდი \"=\"."
+
+#: ../src/common/fileconf.cpp:778
+#, c-format
+msgid "file '%s', line %zu: value for immutable key '%s' ignored."
+msgstr ""
+"ფაილი '%s', ხაზი %zu: მნიშვნელობა უცვლელი გასაღებისთვის '%s' იგნორირებულია."
+
+#: ../src/common/fileconf.cpp:788
+#, c-format
+msgid "file '%s', line %zu: key '%s' was first found at line %d."
+msgstr "ფაილი '%s', ხაზი %zu: გასაღები '%s ' პირველად იქნა ნაპოვნი ხაზი %d."
+
+#: ../src/common/fileconf.cpp:1091
+#, c-format
+msgid "Config entry name cannot start with '%c'."
+msgstr "კონფიგურაციის ჩანაწერის სახელი '%c'-ით ვერ დაიწყება."
+
+#: ../src/common/fileconf.cpp:1146
+msgid "Failed to create configuration file directory."
+msgstr "კონფიგურაციის ფაილის საქაღალდის შექმნა ჩავარდა."
+
+#: ../src/common/fileconf.cpp:1158
+msgid "can't open user configuration file."
+msgstr "მომხმარებლის კონფიგურაციის ფაილის გახსნს შეცდომა."
+
+#: ../src/common/fileconf.cpp:1172
+msgid "can't write user configuration file."
+msgstr "მომხმარებლის კონფიგურაციის ფაილის ჩაწერის შეცდომა."
+
+#: ../src/common/fileconf.cpp:1178
+msgid "Failed to update user configuration file."
+msgstr "მომხმარებლის კონფიგურაციის ფაილის განახლების შეცდომა."
+
+#: ../src/common/fileconf.cpp:1201
+msgid "Error saving user configuration data."
+msgstr "მომხმარებლის კონფიგურაციის ფაილის შენახვის შეცდომა."
+
+#: ../src/common/fileconf.cpp:1313
+#, c-format
+msgid "can't delete user configuration file '%s'"
+msgstr "მომხმარებლის კონფიგურაციის ფაილის წაშლი შეცდომა: %s"
+
+#: ../src/common/fileconf.cpp:2007
+#, c-format
+msgid "entry '%s' appears more than once in group '%s'"
+msgstr "ჩანაწერი %s ერთზე მეტჯერაა ჯგუფში %s"
+
+#: ../src/common/fileconf.cpp:2021
+#, c-format
+msgid "attempt to change immutable key '%s' ignored."
+msgstr "მუდმივი გასაღების (%s) შეცვლის მცდელობა იგნორირებულია."
+
+#: ../src/common/fileconf.cpp:2118
+#, c-format
+msgid "trailing backslash ignored in '%s'"
+msgstr "\"%s\"-ში ხაზის ბოლოში მოყოლილი \\ იგნორირებულია"
+
+#: ../src/common/fileconf.cpp:2153
+#, c-format
+msgid "unexpected \" at position %d in '%s'."
+msgstr "პოზიციაზე %d %s-ში მოულოდნელი \"."
+
+#: ../src/common/filefn.cpp:474
+#, c-format
+msgid "Failed to copy the file '%s' to '%s'"
+msgstr "ფაილის %s-დან %s-მდე კოპირების შეცდომა"
+
+#: ../src/common/filefn.cpp:487
+#, c-format
+msgid "Impossible to get permissions for file '%s'"
+msgstr "წვდომების მიღების შეცდომა ფაილისთვის: %s"
+
+#: ../src/common/filefn.cpp:501
+#, c-format
+msgid "Impossible to overwrite the file '%s'"
+msgstr "თავზე გადაწერის შეცდომა ფაილისთვის:%s"
+
+#: ../src/common/filefn.cpp:508
+#, c-format
+msgid "Error copying the file '%s' to '%s'."
+msgstr "ფაილის %s-დან %s-მდე კოპირების შეცდომა."
+
+#: ../src/common/filefn.cpp:556
+#, c-format
+msgid "Impossible to set permissions for the file '%s'"
+msgstr "წვდომის უფლებების დაყენება შეუძლებელია ფაილისთვის %s"
+
+#: ../src/common/filefn.cpp:606
+#, c-format
+msgid ""
+"Failed to rename the file '%s' to '%s' because the destination file already "
+"exists."
+msgstr ""
+"ფაილის სახელის %s-დან %s-ზე გადარქმევის პრობლემა. სამიზნე ფაილი უკვე "
+"არსებობს."
+
+#: ../src/common/filefn.cpp:623
+#, c-format
+msgid "File '%s' couldn't be renamed '%s'"
+msgstr "ფაილის სახელის (%s) გადარქმევის (%s-მდე) შეცდომა"
+
+#: ../src/common/filefn.cpp:639
+#, c-format
+msgid "File '%s' couldn't be removed"
+msgstr "ფაილის წაშლა შეუძლებელია: %s"
+
+#: ../src/common/filefn.cpp:666
+#, c-format
+msgid "Directory '%s' couldn't be created"
+msgstr "საქაღალდის შექმნა შეუძლებელია (%s)"
+
+#: ../src/common/filefn.cpp:680
+#, c-format
+msgid "Directory '%s' couldn't be deleted"
+msgstr "საქაღალდის წაშლის შეცდომა: %s"
+
+#: ../src/common/filefn.cpp:714
+#, c-format
+msgid "Cannot enumerate files '%s'"
+msgstr "ფაილების ჩამოთვლა შეუძლებელია: %s"
+
+#: ../src/common/filefn.cpp:798
+msgid "Failed to get the working directory"
+msgstr "სამუშაო საქაღალდის მიღების შეცდომა"
+
+#: ../src/common/filefn.cpp:843
+msgid "Could not set current working directory"
+msgstr "მიმდინარე სამუშაო საქაღალდის დაყენების შეცდომა"
+
+#: ../src/common/filefn.cpp:974
+#, c-format
+msgid "Files (%s)"
+msgstr "ფაილები (%s)"
+
+#: ../src/common/filename.cpp:182
+#, c-format
+msgid "Failed to open '%s' for reading"
+msgstr "%s-ის წასაკითხად გახსნის შეცდომა"
+
+#: ../src/common/filename.cpp:187
+#, c-format
+msgid "Failed to open '%s' for writing"
+msgstr "%s-ის ჩაწერისთვის გახსნა შეუძლებელია"
+
+#: ../src/common/filename.cpp:199
+msgid "Failed to close file handle"
+msgstr "ფაილის დამმუშავებლის დახურვის შეცდომა"
+
+#: ../src/common/filename.cpp:1046
+msgid "Failed to create a temporary file name"
+msgstr "დროებითი ფაილის სახელის შექმნის შეცდომა"
+
+#: ../src/common/filename.cpp:1081
+msgid "Failed to open temporary file."
+msgstr "დროებითი ფაილის გახსნის შეცდომა."
+
+#: ../src/common/filename.cpp:2862
+#, c-format
+msgid "Failed to modify file times for '%s'"
+msgstr "ფაილის დროების ჩასწორების შეცდომა %s-სთვის"
+
+#: ../src/common/filename.cpp:2877
+#, c-format
+msgid "Failed to touch the file '%s'"
+msgstr "ფაილის შეხების შეცდომა: %s."
+
+#: ../src/common/filename.cpp:2958
+#, c-format
+msgid "Failed to retrieve file times for '%s'"
+msgstr "ფაილის დროების მიღების შეცდომა %s-სთვის"
+
+#: ../src/common/filepickercmn.cpp:39 ../src/common/filepickercmn.cpp:40
+msgid "Browse"
+msgstr "დათვალიერება"
+
+#: ../src/common/fldlgcmn.cpp:792 ../src/generic/filectrlg.cpp:1185
+#, c-format
+msgid "All files (%s)|%s"
+msgstr "ყველა ფაილი (%s)|%s"
+
+#. TRANSLATORS: %s are a file extension used to build a file wildcard string
+#: ../src/common/fldlgcmn.cpp:810
+#, c-format
+msgid "%s files (%s)|%s"
+msgstr "%s ფაილი (%s)|%s"
+
+#: ../src/common/fldlgcmn.cpp:1072
+#, c-format
+msgid "Load %s file"
+msgstr "%s ფაილის ჩატვირთვა"
+
+#: ../src/common/fldlgcmn.cpp:1074
+#, c-format
+msgid "Save %s file"
+msgstr "%s ფაილის შენახვა"
+
+#: ../src/common/fmapbase.cpp:144
+msgid "Western European (ISO-8859-1)"
+msgstr "დასავლეთ ევროპული (ISO-8859-1)"
+
+#: ../src/common/fmapbase.cpp:145
+msgid "Central European (ISO-8859-2)"
+msgstr "ცენტრალურ-ევროპული (ISO-8859-2)"
+
+#: ../src/common/fmapbase.cpp:146
+msgid "Esperanto (ISO-8859-3)"
+msgstr "ესპერანტო (ISO-8859-3)"
+
+#: ../src/common/fmapbase.cpp:147
+msgid "Baltic (old) (ISO-8859-4)"
+msgstr "ბალტიური (ძველი) (ISO-8859-4)"
+
+#: ../src/common/fmapbase.cpp:148
+msgid "Cyrillic (ISO-8859-5)"
+msgstr "კირილიცა (ISO-8859-5)"
+
+#: ../src/common/fmapbase.cpp:149
+msgid "Arabic (ISO-8859-6)"
+msgstr "არაბული (ISO-8859-6)"
+
+#: ../src/common/fmapbase.cpp:150
+msgid "Greek (ISO-8859-7)"
+msgstr "ბერძნული (ISO-8859-7)"
+
+#: ../src/common/fmapbase.cpp:151
+msgid "Hebrew (ISO-8859-8)"
+msgstr "ივრითი (ISO-8859-8)"
+
+#: ../src/common/fmapbase.cpp:152
+msgid "Turkish (ISO-8859-9)"
+msgstr "თურქული (ISO-8859-9)"
+
+#: ../src/common/fmapbase.cpp:153
+msgid "Nordic (ISO-8859-10)"
+msgstr "სკანდინავიური (ISO-8859-10)"
+
+#: ../src/common/fmapbase.cpp:154
+msgid "Thai (ISO-8859-11)"
+msgstr "ტაილანდური (ISO-8859-11)"
+
+#: ../src/common/fmapbase.cpp:155
+msgid "Indian (ISO-8859-12)"
+msgstr "ინდური (ISO-8859-12)"
+
+#: ../src/common/fmapbase.cpp:156
+msgid "Baltic (ISO-8859-13)"
+msgstr "ბალტიკური (ISO-8859-13)"
+
+#: ../src/common/fmapbase.cpp:157
+msgid "Celtic (ISO-8859-14)"
+msgstr "კელტური (ISO-8859-14)"
+
+#: ../src/common/fmapbase.cpp:158
+msgid "Western European with Euro (ISO-8859-15)"
+msgstr "დასავლეთ ევროპული, ევროთი (ISO-8859-15)"
+
+#: ../src/common/fmapbase.cpp:159
+msgid "KOI8-R"
+msgstr "KOI8-R"
+
+#: ../src/common/fmapbase.cpp:160
+msgid "KOI8-U"
+msgstr "KOI8-U"
+
+#: ../src/common/fmapbase.cpp:161
+msgid "Windows/DOS OEM Cyrillic (CP 866)"
+msgstr "Windows/DOS OEM კირილიცა (CP 866)"
+
+#: ../src/common/fmapbase.cpp:162
+msgid "Windows Thai (CP 874)"
+msgstr "Windows ტაილანდური (CP 874)"
+
+#: ../src/common/fmapbase.cpp:163
+msgid "Windows Japanese (CP 932) or Shift-JIS"
+msgstr "Windows იაპონური (CP 932) or Shift-JIS"
+
+#: ../src/common/fmapbase.cpp:164
+msgid "Windows Chinese Simplified (CP 936) or GB-2312"
+msgstr "Windows გამარტივებული ჩინური (CP 936) or GB-2312"
+
+#: ../src/common/fmapbase.cpp:165
+msgid "Windows Korean (CP 949)"
+msgstr "Windows კორეული (CP 949)"
+
+#: ../src/common/fmapbase.cpp:166
+msgid "Windows Chinese Traditional (CP 950) or Big-5"
+msgstr "Windows ჩინური ტრადიციული (CP 950) or Big-5"
+
+#: ../src/common/fmapbase.cpp:167
+msgid "Windows Central European (CP 1250)"
+msgstr "Windows ცენტრალური ევროპული (CP 1250)"
+
+#: ../src/common/fmapbase.cpp:168
+msgid "Windows Cyrillic (CP 1251)"
+msgstr "Windows კირილიცა (CP 1251)"
+
+#: ../src/common/fmapbase.cpp:169
+msgid "Windows Western European (CP 1252)"
+msgstr "Windows დასავლეთ ევროპული (CP 1252)"
+
+#: ../src/common/fmapbase.cpp:170
+msgid "Windows Greek (CP 1253)"
+msgstr "Windows ბერძნული (CP 1253)"
+
+#: ../src/common/fmapbase.cpp:171
+msgid "Windows Turkish (CP 1254)"
+msgstr "Windows თურქული (CP 1254)"
+
+#: ../src/common/fmapbase.cpp:172
+msgid "Windows Hebrew (CP 1255)"
+msgstr "Windows ივრითი (CP 1255)"
+
+#: ../src/common/fmapbase.cpp:173
+msgid "Windows Arabic (CP 1256)"
+msgstr "Windows არაბული (CP 1256)"
+
+#: ../src/common/fmapbase.cpp:174
+msgid "Windows Baltic (CP 1257)"
+msgstr "Windows ბალტიური (CP 1257)"
+
+#: ../src/common/fmapbase.cpp:175
+msgid "Windows Vietnamese (CP 1258)"
+msgstr "Windows ვიეტნამური (CP 1258)"
+
+#: ../src/common/fmapbase.cpp:176
+msgid "Windows Johab (CP 1361)"
+msgstr "Windows Johab (CP 1361)"
+
+#: ../src/common/fmapbase.cpp:177
+msgid "Windows/DOS OEM (CP 437)"
+msgstr "Windows/DOS OEM (CP 437)"
+
+#: ../src/common/fmapbase.cpp:178
+msgid "Unicode 7 bit (UTF-7)"
+msgstr "7-ბიტიანი უნიკოდი (UTF-7)"
+
+#: ../src/common/fmapbase.cpp:179
+msgid "Unicode 8 bit (UTF-8)"
+msgstr "8-ბიტიანი უნიკოდი (UTF-8)"
+
+#: ../src/common/fmapbase.cpp:181 ../src/common/fmapbase.cpp:187
+msgid "Unicode 16 bit (UTF-16)"
+msgstr "16-ბიტიანი უნიკოდი (UTF-16)"
+
+#: ../src/common/fmapbase.cpp:182
+msgid "Unicode 16 bit Little Endian (UTF-16LE)"
+msgstr "Unicode 16 bit Little Endian (UTF-16LE)"
+
+#: ../src/common/fmapbase.cpp:183 ../src/common/fmapbase.cpp:189
+msgid "Unicode 32 bit (UTF-32)"
+msgstr "32-ბიტიანი უნიკოდი (UTF-32)"
+
+#: ../src/common/fmapbase.cpp:184
+msgid "Unicode 32 bit Little Endian (UTF-32LE)"
+msgstr "Unicode 32 bit Little Endian (UTF-32LE)"
+
+#: ../src/common/fmapbase.cpp:186
+msgid "Unicode 16 bit Big Endian (UTF-16BE)"
+msgstr "Unicode 16 bit Big Endian (UTF-16BE)"
+
+#: ../src/common/fmapbase.cpp:188
+msgid "Unicode 32 bit Big Endian (UTF-32BE)"
+msgstr "Unicode 32 bit Big Endian (UTF-32BE)"
+
+#: ../src/common/fmapbase.cpp:191
+msgid "Extended Unix Codepage for Japanese (EUC-JP)"
+msgstr "Unix-ის გაფართოებული სიმბოლოების ნაკრები (EUC-JP)"
+
+#: ../src/common/fmapbase.cpp:192
+msgid "US-ASCII"
+msgstr "US-ASCII"
+
+#: ../src/common/fmapbase.cpp:193
+msgid "ISO-2022-JP"
+msgstr "ISO-2022-JP"
+
+#: ../src/common/fmapbase.cpp:195
+msgid "MacRoman"
+msgstr "MacRoman"
+
+#: ../src/common/fmapbase.cpp:196
+msgid "MacJapanese"
+msgstr "MacJapanese"
+
+#: ../src/common/fmapbase.cpp:197
+msgid "MacChineseTrad"
+msgstr "MacChineseTrad"
+
+#: ../src/common/fmapbase.cpp:198
+msgid "MacKorean"
+msgstr "MacKorean"
+
+#: ../src/common/fmapbase.cpp:199
+msgid "MacArabic"
+msgstr "MacArabic"
+
+#: ../src/common/fmapbase.cpp:200
+msgid "MacHebrew"
+msgstr "MacHebrew"
+
+#: ../src/common/fmapbase.cpp:201
+msgid "MacGreek"
+msgstr "MacGreek"
+
+#: ../src/common/fmapbase.cpp:202
+msgid "MacCyrillic"
+msgstr "MacCyrillic"
+
+#: ../src/common/fmapbase.cpp:203
+msgid "MacDevanagari"
+msgstr "MacDevanagari"
+
+#: ../src/common/fmapbase.cpp:204
+msgid "MacGurmukhi"
+msgstr "MacGurmukhi"
+
+#: ../src/common/fmapbase.cpp:205
+msgid "MacGujarati"
+msgstr "MacGujarati"
+
+#: ../src/common/fmapbase.cpp:206
+msgid "MacOriya"
+msgstr "MacOriya"
+
+#: ../src/common/fmapbase.cpp:207
+msgid "MacBengali"
+msgstr "MacBengali"
+
+#: ../src/common/fmapbase.cpp:208
+msgid "MacTamil"
+msgstr "MacTamil"
+
+#: ../src/common/fmapbase.cpp:209
+msgid "MacTelugu"
+msgstr "MacTelugu"
+
+#: ../src/common/fmapbase.cpp:210
+msgid "MacKannada"
+msgstr "MacKannada"
+
+#: ../src/common/fmapbase.cpp:211
+msgid "MacMalayalam"
+msgstr "MacMalayalam"
+
+#: ../src/common/fmapbase.cpp:212
+msgid "MacSinhalese"
+msgstr "MacSinhalese"
+
+#: ../src/common/fmapbase.cpp:213
+msgid "MacBurmese"
+msgstr "MacBurmese"
+
+#: ../src/common/fmapbase.cpp:214
+msgid "MacKhmer"
+msgstr "MacKhmer"
+
+#: ../src/common/fmapbase.cpp:215
+msgid "MacThai"
+msgstr "MacThai"
+
+#: ../src/common/fmapbase.cpp:216
+msgid "MacLaotian"
+msgstr "MacLaotian"
+
+#: ../src/common/fmapbase.cpp:217
+msgid "MacGeorgian"
+msgstr "MacGeorgian"
+
+#: ../src/common/fmapbase.cpp:218
+msgid "MacArmenian"
+msgstr "MacArmenian"
+
+#: ../src/common/fmapbase.cpp:219
+msgid "MacChineseSimp"
+msgstr "MacChineseSimp"
+
+#: ../src/common/fmapbase.cpp:220
+msgid "MacTibetan"
+msgstr "MacTibetan"
+
+#: ../src/common/fmapbase.cpp:221
+msgid "MacMongolian"
+msgstr "MacMongolian"
+
+#: ../src/common/fmapbase.cpp:222
+msgid "MacEthiopic"
+msgstr "MacEthiopic"
+
+#: ../src/common/fmapbase.cpp:223
+msgid "MacCentralEurRoman"
+msgstr "MacCentralEurRoman"
+
+#: ../src/common/fmapbase.cpp:224
+msgid "MacVietnamese"
+msgstr "MacVietnamese"
+
+#: ../src/common/fmapbase.cpp:225
+msgid "MacExtArabic"
+msgstr "MacExtArabic"
+
+#: ../src/common/fmapbase.cpp:226
+msgid "MacSymbol"
+msgstr "MacSymbol"
+
+#: ../src/common/fmapbase.cpp:227
+msgid "MacDingbats"
+msgstr "MacDingbats"
+
+#: ../src/common/fmapbase.cpp:228
+msgid "MacTurkish"
+msgstr "MacTurkish"
+
+#: ../src/common/fmapbase.cpp:229
+msgid "MacCroatian"
+msgstr "MacCroatian"
+
+#: ../src/common/fmapbase.cpp:230
+msgid "MacIcelandic"
+msgstr "MacIcelandic"
+
+#: ../src/common/fmapbase.cpp:231
+msgid "MacRomanian"
+msgstr "MacRomanian"
+
+#: ../src/common/fmapbase.cpp:232
+msgid "MacCeltic"
+msgstr "MacCeltic"
+
+#: ../src/common/fmapbase.cpp:233
+msgid "MacGaelic"
+msgstr "MacGaelic"
+
+#: ../src/common/fmapbase.cpp:234
+msgid "MacKeyboardGlyphs"
+msgstr "MacKeyboardGlyphs"
+
+#: ../src/common/fmapbase.cpp:791
+msgid "Default encoding"
+msgstr "ნაგულისხმები კოდირება"
+
+#: ../src/common/fmapbase.cpp:805
+#, c-format
+msgid "Unknown encoding (%d)"
+msgstr "უცნობი კოდირება (%d)"
+
+#: ../src/common/fmapbase.cpp:815 ../src/richtext/richtextstyles.cpp:776
+msgid "default"
+msgstr "ნაგულისხმები"
+
+#: ../src/common/fmapbase.cpp:829
+#, c-format
+msgid "unknown-%d"
+msgstr "უცნობი-%d"
+
+#: ../src/common/fontcmn.cpp:924 ../src/common/fontcmn.cpp:1130
+msgid "underlined"
+msgstr "ხაზგასმული"
+
+#: ../src/common/fontcmn.cpp:929
+msgid " strikethrough"
+msgstr " ხაზგადასმული"
+
+#: ../src/common/fontcmn.cpp:942
+msgid " thin"
+msgstr " თხელი"
+
+#: ../src/common/fontcmn.cpp:946
+msgid " extra light"
+msgstr " ძალიან თხელი"
+
+#: ../src/common/fontcmn.cpp:950
+msgid " light"
+msgstr " მსუბუქი"
+
+#: ../src/common/fontcmn.cpp:954
+msgid " medium"
+msgstr " საშუალო"
+
+#: ../src/common/fontcmn.cpp:958
+msgid " semi bold"
+msgstr " ნახევრად სქელი"
+
+#: ../src/common/fontcmn.cpp:962
+msgid " bold"
+msgstr " სქელი"
+
+#: ../src/common/fontcmn.cpp:966
+msgid " extra bold"
+msgstr " ძალიან სქელი"
+
+#: ../src/common/fontcmn.cpp:970
+msgid " heavy"
+msgstr " მძიმე"
+
+#: ../src/common/fontcmn.cpp:974
+msgid " extra heavy"
+msgstr " ძალიან მძიმე"
+
+#: ../src/common/fontcmn.cpp:990
+msgid " italic"
+msgstr " დახრილი"
+
+#: ../src/common/fontcmn.cpp:1134
+msgid "strikethrough"
+msgstr "ხაზგადასმული"
+
+#: ../src/common/fontcmn.cpp:1143
+msgid "thin"
+msgstr "თხელი"
+
+#: ../src/common/fontcmn.cpp:1156
+msgid "extralight"
+msgstr "ძალიან თხელი"
+
+#: ../src/common/fontcmn.cpp:1161
+msgid "light"
+msgstr "ღია"
+
+#: ../src/common/fontcmn.cpp:1169 ../src/richtext/richtextstyles.cpp:775
+msgid "normal"
+msgstr "ნორმალური"
+
+#: ../src/common/fontcmn.cpp:1174
+msgid "medium"
+msgstr "საშუალო"
+
+#: ../src/common/fontcmn.cpp:1179 ../src/common/fontcmn.cpp:1199
+msgid "semibold"
+msgstr "ნახევრად სქელი"
+
+#: ../src/common/fontcmn.cpp:1184
+msgid "bold"
+msgstr "სქელი"
+
+#: ../src/common/fontcmn.cpp:1194
+msgid "extrabold"
+msgstr "ძალიან სქელი"
+
+#: ../src/common/fontcmn.cpp:1204
+msgid "heavy"
+msgstr "მძიმე"
+
+#: ../src/common/fontcmn.cpp:1212
+msgid "extraheavy"
+msgstr "ძალიან მძიმე"
+
+#: ../src/common/fontcmn.cpp:1217
+msgid "italic"
+msgstr "დახრილი"
+
+#: ../src/common/fontmap.cpp:195
+msgid ": unknown charset"
+msgstr ": უცნობი კოდირება"
+
+#: ../src/common/fontmap.cpp:199
+#, c-format
+msgid ""
+"The charset '%s' is unknown. You may select\n"
+"another charset to replace it with or choose\n"
+"[Cancel] if it cannot be replaced"
+msgstr ""
+"კოდირება %s უცნობია. შეგიძლიათ აირჩიოთ\n"
+"სხვა კოდირება მის ჩასანაცვლებლად, ან აირჩიოთ\n"
+"[გაუქმება], თუ მისი ჩანაცვლება შეუძლებელია"
+
+#: ../src/common/fontmap.cpp:241
+#, c-format
+msgid "Failed to remember the encoding for the charset '%s'."
+msgstr "სიმბოლოების მიმდევრობისთვის (%s) კოდირების დამახსოვრების შეცდომა."
+
+#: ../src/common/fontmap.cpp:321
+msgid "can't load any font, aborting"
+msgstr "ჩასატვირთი ფონტის გარეშე. მუშაობის დასრულება"
+
+#: ../src/common/fontmap.cpp:409
+msgid ": unknown encoding"
+msgstr ": უცნობი კოდირება"
+
+#: ../src/common/fontmap.cpp:417
+#, c-format
+msgid ""
+"No font for displaying text in encoding '%s' found,\n"
+"but an alternative encoding '%s' is available.\n"
+"Do you want to use this encoding (otherwise you will have to choose another "
+"one)?"
+msgstr ""
+"კოდირების %s საჩვენებლად შესაბამისი ფონტი ვერ ვიპოვე.\n"
+"მაგრამ ხელმისაწვდომია სხვა კოდირება %s.\n"
+"გნებავთ ამ კოდირების გამოყენება (არადა სხვის არჩევა მოგიწევთ)?"
+
+#: ../src/common/fontmap.cpp:422
+#, c-format
+msgid ""
+"No font for displaying text in encoding '%s' found.\n"
+"Would you like to select a font to be used for this encoding\n"
+"(otherwise the text in this encoding will not be shown correctly)?"
+msgstr ""
+"კოდირებაში %s ტექსტის საჩვენებელი ფონტი ვერ ვიპოვე.\n"
+"გნებავთ ფონტი, რომელიც ამ კოდირების საჩვენებლად იქნება გამოყენებული, ხელით "
+"აირჩიოთ\n"
+"(წინააღმდეგ შემთხვევაში ამ კოდირების მქონე ტექსტი არასწორად იქნება "
+"ნაჩვენები)?"
+
+#: ../src/common/fs_mem.cpp:169
+#, c-format
+msgid "Memory VFS already contains file '%s'!"
+msgstr "მეხსიერების VFS ფაილს %s უკვე შეიცავს!"
+
+#: ../src/common/fs_mem.cpp:232
+#, c-format
+msgid "Trying to remove file '%s' from memory VFS, but it is not loaded!"
+msgstr ""
+"მცდელობა წაიშალოს ფაილი %s მეხსიერების VFS-დან. მაგრამ ის ჩატვირთული არაა!"
+
+#: ../src/common/fs_mem.cpp:262
+#, c-format
+msgid "Failed to store image '%s' to memory VFS!"
+msgstr "გამოსახულების (%s) მეხსიერების VFS-ში დამახსოვრების შეცდომა!"
+
+#: ../src/common/ftp.cpp:197
+msgid "Timeout while waiting for FTP server to connect, try passive mode."
+msgstr "FTP სერვერთან დაკავშირების დრო გავიდა. სცადეთ პასიური რეჟიმი."
+
+#: ../src/common/ftp.cpp:399
+#, c-format
+msgid "Failed to set FTP transfer mode to %s."
+msgstr "FTP -ის გადაწერის რეჟიმის %s-ზე დაყენების შეცდომა."
+
+#: ../src/common/ftp.cpp:400 ../src/richtext/richtextsymboldlg.cpp:432
+msgid "ASCII"
+msgstr "ASCII"
+
+#: ../src/common/ftp.cpp:400
+msgid "binary"
+msgstr "ბინარული"
+
+#: ../src/common/ftp.cpp:608
+msgid "The FTP server doesn't support the PORT command."
+msgstr "FTP სერვერს PORT ბრძანების მხარდაჭერა არ გააჩნია."
+
+#: ../src/common/ftp.cpp:622
+msgid "The FTP server doesn't support passive mode."
+msgstr "FTP სერვერს პასიური რეჟიმის მხარდაჭერა არ გააჩნია."
+
+#: ../src/common/gifdecod.cpp:822
+#, c-format
+msgid "Incorrect GIF frame size (%u, %d) for the frame #%u"
+msgstr "GIF კადრის არასწორი ზომა (%u, %d) კადრი #%u"
+
+#: ../src/common/glcmn.cpp:108
+msgid "Failed to allocate colour for OpenGL"
+msgstr "OpenGL-ის ფერის გამოყოფის შეცდომა"
+
+#: ../src/common/headerctrlcmn.cpp:57
+msgid "Please select the columns to show and define their order:"
+msgstr "აირჩიეთ საჩვენებელი სვეტები და აღწერეთ მათი ფერი:"
+
+#: ../src/common/headerctrlcmn.cpp:58
+msgid "Customize Columns"
+msgstr "სვეტების მორგება"
+
+#: ../src/common/headerctrlcmn.cpp:304
+msgid "&Customize..."
+msgstr "&მორგება..."
+
+#: ../src/common/hyperlnkcmn.cpp:132
+#, c-format
+msgid "Failed to open URL \"%s\" in the default browser"
+msgstr "URL-ის ნაგულისხმებ ბრაუზერში გახსნის შეცდომა: %s"
+
+#: ../src/common/iconbndl.cpp:195
+#, c-format
+msgid "Failed to load image %%d from file '%s'."
+msgstr "გამოსახულების (%%d) ჩატვირთვის შეცდომა ფაილიდან %s."
+
+#: ../src/common/iconbndl.cpp:203
+#, c-format
+msgid "Failed to load image %d from stream."
+msgstr "გამოსახულების (%d) ნაკადიდან ჩატვირთვის შეცდომა."
+
+#: ../src/common/iconbndl.cpp:221
+#, c-format
+msgid "Failed to load icons from resource '%s'."
+msgstr "რესურსიდან ხატულების ჩატვირთვის შეცდომა: %s."
+
+#: ../src/common/imagbmp.cpp:97
+msgid "BMP: Couldn't save invalid image."
+msgstr "BMP: არასწორი გამოსახულების შენახვის პრობლემა."
+
+#: ../src/common/imagbmp.cpp:137
+msgid "BMP: wxImage doesn't have own wxPalette."
+msgstr "BMP: wxImage -ს საკუთარი wxPalette არ გააჩნია."
+
+#: ../src/common/imagbmp.cpp:243
+msgid "BMP: Couldn't write the file (Bitmap) header."
+msgstr "BMP: ფაილის (ბიტური რუკის) თავსართის ჩაწერის შეცდომა."
+
+#: ../src/common/imagbmp.cpp:266
+msgid "BMP: Couldn't write the file (BitmapInfo) header."
+msgstr "BMP: ფაილის (BitmapInfo) თავსართის ჩაწერის შეცდომა."
+
+#: ../src/common/imagbmp.cpp:353
+msgid "BMP: Couldn't write RGB color map."
+msgstr "BMP: RGB ფერების რუკის ჩაწერის შეცდომა."
+
+#: ../src/common/imagbmp.cpp:487
+msgid "BMP: Couldn't write data."
+msgstr "BMP: მონაცემების ჩაწერის შეცდომა."
+
+#: ../src/common/imagbmp.cpp:561 ../src/common/imagbmp.cpp:642
+msgid "BMP: Couldn't allocate memory."
+msgstr "BMP: მეხსიერების გამოყოფის შეცდომა."
+
+#: ../src/common/imagbmp.cpp:1041
+msgid "DIB Header: Image width > 32767 pixels for file."
+msgstr "DIB თავსართი: გამოსახულების სიგანე > 32767 პიქსელი."
+
+#: ../src/common/imagbmp.cpp:1049
+msgid "DIB Header: Image height > 32767 pixels for file."
+msgstr "DIB თავსართი: გამოსახულების სიმაღლე > 32767 პიქსელი."
+
+#: ../src/common/imagbmp.cpp:1081
+msgid "DIB Header: Unknown bitdepth in file."
+msgstr "DIB თავსართი: უცნობი ბიტური სიღრმე."
+
+#: ../src/common/imagbmp.cpp:1156
+msgid "DIB Header: Unknown encoding in file."
+msgstr "DIB თავსართი: ფაილის უცნობი კოდირება."
+
+#: ../src/common/imagbmp.cpp:1165
+msgid "DIB Header: Encoding doesn't match bitdepth."
+msgstr "DIB თავსართი: კოდირება ბიტურ სიღრმეს არ ემთხვევა."
+
+#: ../src/common/imagbmp.cpp:1180
+#, c-format
+msgid "BMP Header: Invalid number of colors (%d)."
+msgstr "BMP თავსართი: ფერების არასწორი რაოდენობა (%d)."
+
+#: ../src/common/imagbmp.cpp:1273
+msgid "Error in reading image DIB."
+msgstr "გამოსახულებების DIB-ის წაკითხვის შეცდომა."
+
+#: ../src/common/imagbmp.cpp:1294
+msgid "ICO: Error in reading mask DIB."
+msgstr "ICO: ნიღბის DIB-ის წაკითხვის შეცდომა."
+
+#: ../src/common/imagbmp.cpp:1353
+msgid "ICO: Image too tall for an icon."
+msgstr "ICO: გამოსახულება ხატულისთვის მეტისმეტად გრძელია."
+
+#: ../src/common/imagbmp.cpp:1361
+msgid "ICO: Image too wide for an icon."
+msgstr "ICO: გამოსახულება ხატულისთვის მეტისმეტად განიერია."
+
+#: ../src/common/imagbmp.cpp:1388 ../src/common/imagbmp.cpp:1488
+#: ../src/common/imagbmp.cpp:1503 ../src/common/imagbmp.cpp:1514
+#: ../src/common/imagbmp.cpp:1528 ../src/common/imagbmp.cpp:1576
+#: ../src/common/imagbmp.cpp:1591 ../src/common/imagbmp.cpp:1605
+#: ../src/common/imagbmp.cpp:1616
+msgid "ICO: Error writing the image file!"
+msgstr "ICO: გამოსახულების ფაილის ჩაწერის შეცდომა!"
+
+#: ../src/common/imagbmp.cpp:1701
+msgid "ICO: Invalid icon index."
+msgstr "ICO: ხატულის არასწორი ინდექსი."
+
+#: ../src/common/image.cpp:2410
+msgid "Image and mask have different sizes."
+msgstr "გამოსახულებას და ნიღაბს სხვადასხვა ზომები აქვთ."
+
+#: ../src/common/image.cpp:2418 ../src/common/image.cpp:2459
+msgid "No unused colour in image being masked."
+msgstr "გამოსახულებაში გამოუყენებელი ფერის შენიღბვა არ ხდება."
+
+#: ../src/common/image.cpp:2641
+#, c-format
+msgid "Failed to load bitmap \"%s\" from resources."
+msgstr "რესურსებიდან ბიტური რუკის (%s) ჩატვირთვის შეცდომა."
+
+#: ../src/common/image.cpp:2650
+#, c-format
+msgid "Failed to load icon \"%s\" from resources."
+msgstr "რესურსებიდან ხატულის (%s) ჩატვირთვის შეცდომა."
+
+#: ../src/common/image.cpp:2728 ../src/common/image.cpp:2747
+#, c-format
+msgid "Failed to load image from file \"%s\"."
+msgstr "გამოსახულების ჩატვირთვის შეცდომა ფაილიდან %s."
+
+#: ../src/common/image.cpp:2761
+#, c-format
+msgid "Can't save image to file '%s': unknown extension."
+msgstr "გამოსახულების ფაილში %s ჩაწერის შეცდომა: უცნობი გაფართოება."
+
+#: ../src/common/image.cpp:2869
+msgid "No handler found for image type."
+msgstr "გამოსახულების ამ ტიპის დამმუშავებელი ვერ ვიპოვე."
+
+#: ../src/common/image.cpp:2877 ../src/common/image.cpp:3000
+#: ../src/common/image.cpp:3066
+#, c-format
+msgid "No image handler for type %d defined."
+msgstr "გამოსახულების დამმუშავებელი ტიპისთვის %d აღწერილი არაა."
+
+#: ../src/common/image.cpp:2887
+#, c-format
+msgid "Image file is not of type %d."
+msgstr "გამოსახულების ფაილი %d ტიპის არაა."
+
+#: ../src/common/image.cpp:2970
+msgid "Can't automatically determine the image format for non-seekable input."
+msgstr ""
+"გადაუხვევადი შეყვანისთვის გამოსახულების ფორმატის ავტომატური დადგენა "
+"შეუძლებელია."
+
+#: ../src/common/image.cpp:2988
+msgid "Unknown image data format."
+msgstr "გამოსახულების ფაილის უცნობი ფორმატი."
+
+#: ../src/common/image.cpp:3009
+#, c-format
+msgid "This is not a %s."
+msgstr "ეს %s არაა."
+
+#: ../src/common/image.cpp:3032 ../src/common/image.cpp:3080
+#, c-format
+msgid "No image handler for type %s defined."
+msgstr "გამოსახულების დამმუშავებელი ტიპისთვის %s აღწერილი არაა."
+
+#: ../src/common/image.cpp:3041
+#, c-format
+msgid "Image is not of type %s."
+msgstr "გამოსახულების ტიპი \"%s\" არაა."
+
+#: ../src/common/image.cpp:3509
+#, c-format
+msgid "Failed to check format of image file \"%s\"."
+msgstr "გამოსახულების ფაილის (%s) ფორმატის შემოწმების შეცდომა."
+
+#: ../src/common/imaggif.cpp:124
+msgid "GIF: error in GIF image format."
+msgstr "GIF: შეცდომა GIF გამოსახულების ფორმატში."
+
+#: ../src/common/imaggif.cpp:129
+msgid "GIF: not enough memory."
+msgstr "GIF: არასაკმარისი მეხსიერება.."
+
+#: ../src/common/imaggif.cpp:134
+msgid "GIF: data stream seems to be truncated."
+msgstr "GIF: როგორც ჩანს, მონაცემების ნაკადი წაკვეთილია."
+
+#: ../src/common/imaggif.cpp:240
+msgid "Couldn't initialize GIF hash table."
+msgstr "GIF-ის ჰეშ ცხრილის ინიციალიზაციის შეცდომა."
+
+#: ../src/common/imagiff.cpp:739
+msgid "IFF: error in IFF image format."
+msgstr "IFF: შეცდომა IFF გამოსახულების ფორმატში."
+
+#: ../src/common/imagiff.cpp:742
+msgid "IFF: not enough memory."
+msgstr "IFF: არასაკმარისი მეხსიერება."
+
+#: ../src/common/imagiff.cpp:745
+msgid "IFF: unknown error!!!"
+msgstr "IFF: უცნობი შეცდომა!!!"
+
+#: ../src/common/imagiff.cpp:755
+msgid "IFF: data stream seems to be truncated."
+msgstr "IFF: როგორც ჩანს, მონაცემების ნაკადი წაკვეთილია."
+
+#: ../src/common/imagjpeg.cpp:258
+msgid "JPEG: Couldn't load - file is probably corrupted."
+msgstr "JPEG: ჩატვირთვის შეცდომა - ფაილი ალბათ დაზიანებულია."
+
+#: ../src/common/imagjpeg.cpp:437
+msgid "JPEG: Couldn't save image."
+msgstr "JPEG: გამოსახულების შენახვის შეცდომა."
+
+#: ../src/common/imagpcx.cpp:439
+msgid "PCX: this is not a PCX file."
+msgstr "PCX: ეს PCX ფაილი არაა."
+
+#: ../src/common/imagpcx.cpp:453
+msgid "PCX: image format unsupported"
+msgstr "PCX: გამოსახულების მხარდაუჭერელი ფორმატი"
+
+#: ../src/common/imagpcx.cpp:454 ../src/common/imagpcx.cpp:477
+msgid "PCX: couldn't allocate memory"
+msgstr "PCX: მეხსიერების გამოყოფის შეცდომა"
+
+#: ../src/common/imagpcx.cpp:455
+msgid "PCX: version number too low"
+msgstr "PCX: ვერსია ძალიან დაბალია"
+
+#: ../src/common/imagpcx.cpp:456 ../src/common/imagpcx.cpp:478
+msgid "PCX: unknown error !!!"
+msgstr "PCX: უცნობი შეცდომა !!!"
+
+#: ../src/common/imagpcx.cpp:476
+msgid "PCX: invalid image"
+msgstr "PCX: არასწორი გამოსახულება"
+
+#: ../src/common/imagpng.cpp:385
+#, c-format
+msgid "Unknown PNG resolution unit %d"
+msgstr "PNG-ს გაფართოების უცნობი ერთეული: %d"
+
+#: ../src/common/imagpng.cpp:439
+msgid "Couldn't load a PNG image - file is corrupted or not enough memory."
+msgstr ""
+"PNG გამოსახულების ჩატვირთვის შეცდომა - ფაილი დაზიანებულია ან მეხსიერება არაა "
+"საკმარისი."
+
+#: ../src/common/imagpng.cpp:513 ../src/common/imagpng.cpp:524
+#: ../src/common/imagpng.cpp:534
+msgid "Couldn't save PNG image."
+msgstr "PNG გამოსახულების შენახვის შეცდომა."
+
+#: ../src/common/imagpnm.cpp:71
+msgid "PNM: File format is not recognized."
+msgstr "PNM: ფაილის უცნობი ფორმატი."
+
+#: ../src/common/imagpnm.cpp:89
+msgid "PNM: Couldn't allocate memory."
+msgstr "PNM: მეხსიერების გამოყოფის შეცდომა."
+
+#: ../src/common/imagpnm.cpp:111 ../src/common/imagpnm.cpp:134
+#: ../src/common/imagpnm.cpp:156
+msgid "PNM: File seems truncated."
+msgstr "PNM: ფაილი შეკვეცილია."
+
+#: ../src/common/imagtiff.cpp:69
+#, c-format
+msgid " (in module \"%s\")"
+msgstr " (მოდულში \"%s\")"
+
+#: ../src/common/imagtiff.cpp:304
+msgid "TIFF: Error loading image."
+msgstr "TIFF: გამოსახულების ჩატვირთვის შეცდომა."
+
+#: ../src/common/imagtiff.cpp:314
+msgid "Invalid TIFF image index."
+msgstr "TIFF გამოსახულების არასწორი ინდექსი."
+
+#: ../src/common/imagtiff.cpp:358
+msgid "TIFF: Image size is abnormally big."
+msgstr "TIFF: გამოსახულების ზომა არანორმალურად დიდია."
+
+#: ../src/common/imagtiff.cpp:372 ../src/common/imagtiff.cpp:385
+#: ../src/common/imagtiff.cpp:769
+msgid "TIFF: Couldn't allocate memory."
+msgstr "TIFF: მეხსიერების გამოყოფის შეცდომა."
+
+#: ../src/common/imagtiff.cpp:471
+msgid "TIFF: Error reading image."
+msgstr "TIFF: გამოსახულების კითხვის შეცდომა."
+
+#: ../src/common/imagtiff.cpp:532
+#, c-format
+msgid "Unknown TIFF resolution unit %d ignored"
+msgstr "TIFF-ის გაფართოების უცნობი ერთეული: %d. იგნორირებულია"
+
+#: ../src/common/imagtiff.cpp:611
+msgid "TIFF: Error saving image."
+msgstr "TIFF: გამოსახულების შენახვის შეცდომა."
+
+#: ../src/common/imagtiff.cpp:868
+msgid "TIFF: Error writing image."
+msgstr "TIFF: გამოსახულების ჩასწერის შეცდომა."
+
+#: ../src/common/imagtiff.cpp:881
+msgid "TIFF: Error flushing data."
+msgstr "TIFF: მონაცემების ჩაწერის შეცდომა."
+
+#: ../src/common/imagwebp.cpp:56
+msgid "WebP: Invalid data (failed to get features)."
+msgstr "WebP: არასწორი მონაცემები (თვისებების მიღება ჩავარდა)."
+
+#: ../src/common/imagwebp.cpp:65
+msgid "WebP: Allocating image memory failed."
+msgstr "WebP: გამოსახულების მეხსიერების გამოყოფა ჩავარდა."
+
+#: ../src/common/imagwebp.cpp:82
+msgid "WebP: Decoding RGBA image data failed."
+msgstr "WebP: RGBA გამოსახულების მონაცემების გაშიფვრა ჩავარდა."
+
+#: ../src/common/imagwebp.cpp:98
+msgid "WebP: Decoding RGB image data failed."
+msgstr "WebP: RGB გამოსახულების მონაცემების გაშიფვრა ჩავარდა."
+
+#: ../src/common/imagwebp.cpp:113 ../src/common/imagwebp.cpp:201
+msgid "WebP: Allocating stream buffer failed."
+msgstr "WebP: ნაკადის ბუფერის გამოყოფა ჩავარდა."
+
+#: ../src/common/imagwebp.cpp:131
+msgid "WebP: Failed to parse container data."
+msgstr "WebP: ვერ მოხერხდა კონტეინერის მონაცემების ანალიზი."
+
+#: ../src/common/imagwebp.cpp:222
+msgid "WebP: Error decoding animation."
+msgstr "WebP: ანიმაციის გაშიფვრის შეცდომა."
+
+#: ../src/common/imagwebp.cpp:240
+msgid "WebP: Error getting next animation frame."
+msgstr "WebP: შემდეგი ანიმაციის კადრის მიღების შეცდომა."
+
+#: ../src/common/init.cpp:172
+#, c-format
+msgid ""
+"Command line argument %d couldn't be converted to Unicode and will be "
+"ignored."
+msgstr ""
+"ბრძანების ტრიქონის არგუმენტი %d უნიკოდში ვერ გარდაიქმნა და იგნორირებული "
+"იქნება."
+
+#: ../src/common/init.cpp:344
+msgid "Initialization failed in post init, aborting."
+msgstr "ინიციალიზაციის შეცდომა init-ისშემდეგ. მუშაობის დასრულება."
+
+#: ../src/common/intl.cpp:378
+#, c-format
+msgid "Cannot set locale to language \"%s\"."
+msgstr "ვერ ხერხდება ლოკალის ენის \"%s\"-ზე დაყენება."
+
+#: ../src/common/log.cpp:232
+msgid "Error: "
+msgstr "შეცდომა: "
+
+#: ../src/common/log.cpp:236
+msgid "Warning: "
+msgstr "გაფრთხილება: "
+
+#: ../src/common/log.cpp:284
+msgid "The previous message repeated once."
+msgstr "წინა შეტყობინება ერთხელ გამეორდა."
+
+#: ../src/common/log.cpp:291
+#, c-format
+msgid "The previous message repeated %u time."
+msgid_plural "The previous message repeated %u times."
+msgstr[0] "წინა შეტყობინება %u-ჯერ გამეორდა."
+msgstr[1] "წინა შეტყობინება %u-ჯერ გამეორდა."
+
+#: ../src/common/log.cpp:319
+#, c-format
+msgid "Last repeated message (\"%s\", %u time) wasn't output"
+msgid_plural "Last repeated message (\"%s\", %u times) wasn't output"
+msgstr[0] "ბოლოს გამეორებული შეტყობინება (\"%s\", %u-ჯერ) გამოტანა არ იყო"
+msgstr[1] "ბოლოს გამეორებული შეტყობინება (\"%s\", %u-ჯერ) გამოტანა არ იყო"
+
+#: ../src/common/log.cpp:435
+#, c-format
+msgid " (error %ld: %s)"
+msgstr " (შეცდომა %ld: %s)"
+
+#: ../src/common/lzmastream.cpp:121
+msgid "Failed to allocate memory for LZMA decompression."
+msgstr "ვერ მოხერხდა მეხსიერების გამოყოფა LZMA გაშლისთვის."
+
+#: ../src/common/lzmastream.cpp:125
+#, c-format
+msgid "Failed to initialize LZMA decompression: unexpected error %u."
+msgstr "LZMA გაშლის ინიციალიზაციის მოულოდნელი შეცდომა: %u."
+
+#: ../src/common/lzmastream.cpp:179
+msgid "input is not in XZ format"
+msgstr "შეტანილი ინფორმაცია XZ ფორმატში არაა"
+
+#: ../src/common/lzmastream.cpp:183
+msgid "input compressed using unknown XZ option"
+msgstr "შემოყვანა XZ-ის უცნობი პარამეტრებითაა შეკუმშული"
+
+#: ../src/common/lzmastream.cpp:188
+msgid "input is corrupted"
+msgstr "შეტანა დაზიანებულია"
+
+#: ../src/common/lzmastream.cpp:192
+msgid "unknown decompression error"
+msgstr "გაშლის უცნობი შეცდომა"
+
+#: ../src/common/lzmastream.cpp:196
+#, c-format
+msgid "LZMA decompression error: %s"
+msgstr "LZMA დეკომპრესიის შეცდომა: %s"
+
+#: ../src/common/lzmastream.cpp:231
+msgid "Failed to allocate memory for LZMA compression."
+msgstr "ვერ მოხერხდა მეხსიერების გამოყოფა LZMA შეკუმშვისთვის."
+
+#: ../src/common/lzmastream.cpp:235
+#, c-format
+msgid "Failed to initialize LZMA compression: unexpected error %u."
+msgstr "LZMA შეკუმშვის ინიციალიზაციის მოულოდნელი შეცდომა: %u."
+
+#: ../src/common/lzmastream.cpp:267 ../src/common/lzmastream.cpp:342
+#: ../src/html/chm.cpp:336
+msgid "out of memory"
+msgstr "არასაკმარისი მეხსიერება"
+
+#: ../src/common/lzmastream.cpp:276 ../src/common/lzmastream.cpp:346
+msgid "unknown compression error"
+msgstr "შეკუმშვის უცნობი შეცდომა"
+
+#: ../src/common/lzmastream.cpp:280
+#, c-format
+msgid "LZMA compression error: %s"
+msgstr "LZMA შეკუმშვის შეცდომა: %s"
+
+#: ../src/common/lzmastream.cpp:350
+#, c-format
+msgid "LZMA compression error when flushing output: %s"
+msgstr "LZMA შეკუმშვის შეცდომა გამოტანის დისკზე ჩაწერისას: %s"
+
+#: ../src/common/mimecmn.cpp:167
+#, c-format
+msgid "Unmatched '{' in an entry for mime type %s."
+msgstr "დაუხურავი \"(\" ჩანაწერში mime ტიპისთვის %s."
+
+#: ../src/common/module.cpp:76
+#, c-format
+msgid "Circular dependency involving module \"%s\" detected."
+msgstr "ნაპოვნია წრიული დამოკიდებულება, რომელშიც გარეულია მოდული \"%s\"."
+
+#: ../src/common/module.cpp:128
+#, c-format
+msgid "Dependency \"%s\" of module \"%s\" doesn't exist."
+msgstr "მოდულის (%2$s) დამოკიდებულება \"%1$s\" არ არსებობს."
+
+#: ../src/common/module.cpp:137
+#, c-format
+msgid "Module \"%s\" initialization failed"
+msgstr "მოდულის ინიციალიზაციის შეცდომა: %s"
+
+#: ../src/common/msgout.cpp:96
+msgid "Message"
+msgstr "შეტყობინება"
+
+#: ../src/common/paper.cpp:70
+msgid "Letter, 8 1/2 x 11 in"
+msgstr "წერილი, 8 1/2 x 11 ინჩი"
+
+#: ../src/common/paper.cpp:71
+msgid "Legal, 8 1/2 x 14 in"
+msgstr "იურიდიული, 8 1/2 x 14 დუიმი"
+
+#: ../src/common/paper.cpp:72
+msgid "A4 sheet, 210 x 297 mm"
+msgstr "A4 ფურცელი, 210 x 297 მმ"
+
+#: ../src/common/paper.cpp:73
+msgid "C sheet, 17 x 22 in"
+msgstr "C ფურცელი, 17 x 22 დუიმი"
+
+#: ../src/common/paper.cpp:74
+msgid "D sheet, 22 x 34 in"
+msgstr "D ფურცელი, 22 x 34 დუიმი"
+
+#: ../src/common/paper.cpp:75
+msgid "E sheet, 34 x 44 in"
+msgstr "E ფურცელი, 34 x 44 დუიმი"
+
+#: ../src/common/paper.cpp:76
+msgid "Letter Small, 8 1/2 x 11 in"
+msgstr "წერილი პატარა, 8 1/2 x 11 დუიმი"
+
+#: ../src/common/paper.cpp:77
+msgid "Tabloid, 11 x 17 in"
+msgstr "ტაბლოიდი, 11 x 17 დუიმი"
+
+#: ../src/common/paper.cpp:78
+msgid "Ledger, 17 x 11 in"
+msgstr "ლეჯერი, 17 x 11 დუიმი"
+
+#: ../src/common/paper.cpp:79
+msgid "Statement, 5 1/2 x 8 1/2 in"
+msgstr "განცხადება, 5 1/2 x 8 1/2 დუიმი"
+
+#: ../src/common/paper.cpp:80
+msgid "Executive, 7 1/4 x 10 1/2 in"
+msgstr "აღმასრულებელი, 7 1/4 x 10 1/2 დუიმი"
+
+#: ../src/common/paper.cpp:81
+msgid "A3 sheet, 297 x 420 mm"
+msgstr "A3 ფურცელი, 297 x 420 მმ"
+
+#: ../src/common/paper.cpp:82
+msgid "A4 small sheet, 210 x 297 mm"
+msgstr "A4 პატარა ფურცელი, 210 x 297 მმ"
+
+#: ../src/common/paper.cpp:83
+msgid "A5 sheet, 148 x 210 mm"
+msgstr "A5 ფურცელი, 148 x 210 მმ"
+
+#: ../src/common/paper.cpp:84
+msgid "B4 sheet, 250 x 354 mm"
+msgstr "B4 ფურცელი, 250 x 354 მმ"
+
+#: ../src/common/paper.cpp:85
+msgid "B5 sheet, 182 x 257 millimeter"
+msgstr "B5 ფურცელი, 182 x 257 მილიმეტრიანი"
+
+#: ../src/common/paper.cpp:86
+msgid "Folio, 8 1/2 x 13 in"
+msgstr "ფოლიო, 8 1/2 x 13 დუიმი"
+
+#: ../src/common/paper.cpp:87
+msgid "Quarto, 215 x 275 mm"
+msgstr "კვარტო, 215 x 275 მმ"
+
+#: ../src/common/paper.cpp:88
+msgid "10 x 14 in"
+msgstr "10 x 14 დუიმი"
+
+#: ../src/common/paper.cpp:89
+msgid "11 x 17 in"
+msgstr "11 x 17 დუიმი"
+
+#: ../src/common/paper.cpp:90
+msgid "Note, 8 1/2 x 11 in"
+msgstr "შენიშვნა, 8 1/2 x 11 დუიმი"
+
+#: ../src/common/paper.cpp:91
+msgid "#9 Envelope, 3 7/8 x 8 7/8 in"
+msgstr "# 9 კონვერტი, 3 7/8 x 8 7/8 დუიმი"
+
+#: ../src/common/paper.cpp:92
+msgid "#10 Envelope, 4 1/8 x 9 1/2 in"
+msgstr "# 10 კონვერტი, 4 1/8 x 9 1/2 დუიმი"
+
+#: ../src/common/paper.cpp:93
+msgid "#11 Envelope, 4 1/2 x 10 3/8 in"
+msgstr "# 11 კონვერტი, 4 1/2 x 10 3/8 დუიმი"
+
+#: ../src/common/paper.cpp:94
+msgid "#12 Envelope, 4 3/4 x 11 in"
+msgstr "# 12 კონვერტი, 4 3/4 x 11 დუიმი"
+
+#: ../src/common/paper.cpp:95
+msgid "#14 Envelope, 5 x 11 1/2 in"
+msgstr "# 14 კონვერტი, 5 x 11 1/2 დუიმი"
+
+#: ../src/common/paper.cpp:96
+msgid "DL Envelope, 110 x 220 mm"
+msgstr "Dl კონვერტი, 110 x 220 მმ"
+
+#: ../src/common/paper.cpp:97
+msgid "C5 Envelope, 162 x 229 mm"
+msgstr "C5 კონვერტი, 162 x 229 მმ"
+
+#: ../src/common/paper.cpp:98
+msgid "C3 Envelope, 324 x 458 mm"
+msgstr "C3 კონვერტი, 324 x 458 მმ"
+
+#: ../src/common/paper.cpp:99
+msgid "C4 Envelope, 229 x 324 mm"
+msgstr "C4 კონვერტი, 229 x 324 მმ"
+
+#: ../src/common/paper.cpp:100
+msgid "C6 Envelope, 114 x 162 mm"
+msgstr "C6 კონვერტი, 114 x 162 მმ"
+
+#: ../src/common/paper.cpp:101
+msgid "C65 Envelope, 114 x 229 mm"
+msgstr "C65 კონვერტი, 114 x 229 მმ"
+
+#: ../src/common/paper.cpp:102
+msgid "B4 Envelope, 250 x 353 mm"
+msgstr "B4 კონვერტი, 250 x 353 მმ"
+
+#: ../src/common/paper.cpp:103
+msgid "B5 Envelope, 176 x 250 mm"
+msgstr "B5 კონვერტი, 176 x 250 მმ"
+
+#: ../src/common/paper.cpp:104
+msgid "B6 Envelope, 176 x 125 mm"
+msgstr "B6 კონვერტი, 176 x 125 მმ"
+
+#: ../src/common/paper.cpp:105
+msgid "Italy Envelope, 110 x 230 mm"
+msgstr "იტალიის კონვერტი, 110 x 230 მმ"
+
+#: ../src/common/paper.cpp:106
+msgid "Monarch Envelope, 3 7/8 x 7 1/2 in"
+msgstr "მონარქის კონვერტი, 3 7/8 x 7 1/2 დუიმი"
+
+#: ../src/common/paper.cpp:107
+msgid "6 3/4 Envelope, 3 5/8 x 6 1/2 in"
+msgstr "6 3/4 კონვერტი, 3 5/8 x 6 1/2 დუიმი"
+
+#: ../src/common/paper.cpp:108
+msgid "US Std Fanfold, 14 7/8 x 11 in"
+msgstr "აშშ Std Fanfold, 14 7/8 x 11 დუიმი"
+
+#: ../src/common/paper.cpp:109
+msgid "German Std Fanfold, 8 1/2 x 12 in"
+msgstr "გერმანული Std Fanfold, 8 1/2 x 12 დუიმი"
+
+#: ../src/common/paper.cpp:110
+msgid "German Legal Fanfold, 8 1/2 x 13 in"
+msgstr "გერმანიის იურიდიული Fanfold, 8 1/2 x 13 დუიმი"
+
+#: ../src/common/paper.cpp:112
+msgid "B4 (ISO) 250 x 353 mm"
+msgstr "B4 (ISO) 250 x 353 მმ"
+
+#: ../src/common/paper.cpp:113
+msgid "Japanese Postcard 100 x 148 mm"
+msgstr "იაპონური საფოსტო ბარათი 100 x 148 მმ"
+
+#: ../src/common/paper.cpp:114
+msgid "9 x 11 in"
+msgstr "9 x 11 დუიმი"
+
+#: ../src/common/paper.cpp:115
+msgid "10 x 11 in"
+msgstr "10 x 11 დუიმი"
+
+#: ../src/common/paper.cpp:116
+msgid "15 x 11 in"
+msgstr "15 x 11 დუიმი"
+
+#: ../src/common/paper.cpp:117
+msgid "Envelope Invite 220 x 220 mm"
+msgstr "მოსაწვევის კონვერტი 220 x 220 მმ"
+
+#: ../src/common/paper.cpp:118
+msgid "Letter Extra 9 1/2 x 12 in"
+msgstr "წერილი Extra 9 1/2 x 12 დუიმი"
+
+#: ../src/common/paper.cpp:119
+msgid "Legal Extra 9 1/2 x 15 in"
+msgstr "წერილი Extra 9 1/2 x 15 დუიმი"
+
+#: ../src/common/paper.cpp:120
+msgid "Tabloid Extra 11.69 x 18 in"
+msgstr "ტაბლოიდი Extra 11.69 x 18 დუიმი"
+
+#: ../src/common/paper.cpp:121
+msgid "A4 Extra 9.27 x 12.69 in"
+msgstr "A4 დამატებითი 9.27 x 12.69 დუიმი"
+
+#: ../src/common/paper.cpp:122
+msgid "Letter Transverse 8 1/2 x 11 in"
+msgstr "წერილი განივი 8 1/2 x 11 დუიმი"
+
+#: ../src/common/paper.cpp:123
+msgid "A4 Transverse 210 x 297 mm"
+msgstr "A4 განივი 210 x 297 მმ"
+
+#: ../src/common/paper.cpp:124
+msgid "Letter Extra Transverse 9.275 x 12 in"
+msgstr "წერილი დამატებითი განივი 9.275 x 12 დუიმი"
+
+#: ../src/common/paper.cpp:125
+msgid "SuperA/SuperA/A4 227 x 356 mm"
+msgstr "სუპერA/SuperA / A4 227 x 356 მმ"
+
+#: ../src/common/paper.cpp:126
+msgid "SuperB/SuperB/A3 305 x 487 mm"
+msgstr "SuperB/SuperB / A3 305 x 487 მმ"
+
+#: ../src/common/paper.cpp:127
+msgid "Letter Plus 8 1/2 x 12.69 in"
+msgstr "წერილი პლუს 8 1/2 x 12.69 დუიმი"
+
+#: ../src/common/paper.cpp:128
+msgid "A4 Plus 210 x 330 mm"
+msgstr "A4 Plus 210 x 330 მმ"
+
+#: ../src/common/paper.cpp:129
+msgid "A5 Transverse 148 x 210 mm"
+msgstr "A5 განივი 148 x 210 მმ"
+
+#: ../src/common/paper.cpp:130
+msgid "B5 (JIS) Transverse 182 x 257 mm"
+msgstr "B5 (JIS) განივი 182 x 257 მმ"
+
+#: ../src/common/paper.cpp:131
+msgid "A3 Extra 322 x 445 mm"
+msgstr "A3 Extra 322 x 445 მმ"
+
+#: ../src/common/paper.cpp:132
+msgid "A5 Extra 174 x 235 mm"
+msgstr "A5 Extra 174 x 235 მმ"
+
+#: ../src/common/paper.cpp:133
+msgid "B5 (ISO) Extra 201 x 276 mm"
+msgstr "B5 (ISO) Extra 201 x 276 მმ"
+
+#: ../src/common/paper.cpp:134
+msgid "A2 420 x 594 mm"
+msgstr "A2 420 x 594 მმ"
+
+#: ../src/common/paper.cpp:135
+msgid "A3 Transverse 297 x 420 mm"
+msgstr "A3 განივი 297 x 420 მმ"
+
+#: ../src/common/paper.cpp:136
+msgid "A3 Extra Transverse 322 x 445 mm"
+msgstr "A3 დამატებითი განივი 322 x 445 მმ"
+
+#: ../src/common/paper.cpp:138
+msgid "Japanese Double Postcard 200 x 148 mm"
+msgstr "იაპონური ორმაგი ღია ბარათი 200 x 148 მმ"
+
+#: ../src/common/paper.cpp:139
+msgid "A6 105 x 148 mm"
+msgstr "A6 105 x 148 მმ"
+
+#: ../src/common/paper.cpp:140
+msgid "Japanese Envelope Kaku #2"
+msgstr "იაპონური კონვერტი კაკუ #2"
+
+#: ../src/common/paper.cpp:141
+msgid "Japanese Envelope Kaku #3"
+msgstr "იაპონური კონვერტი კაკუ #3"
+
+#: ../src/common/paper.cpp:142
+msgid "Japanese Envelope Chou #3"
+msgstr "იაპონური კონვერტი Chou #3"
+
+#: ../src/common/paper.cpp:143
+msgid "Japanese Envelope Chou #4"
+msgstr "იაპონური კონვერტი Chou #4"
+
+#: ../src/common/paper.cpp:144
+msgid "Letter Rotated 11 x 8 1/2 in"
+msgstr "წერილი შემობრუნებული 11 x 8 1/2 დუიმი"
+
+#: ../src/common/paper.cpp:145
+msgid "A3 Rotated 420 x 297 mm"
+msgstr "A3 შემობრუნებული 420 x 297 მმ"
+
+#: ../src/common/paper.cpp:146
+msgid "A4 Rotated 297 x 210 mm"
+msgstr "A4 შემობრუნებული 297 x 210 მმ"
+
+#: ../src/common/paper.cpp:147
+msgid "A5 Rotated 210 x 148 mm"
+msgstr "A5 შემობრუნებული 210 x 148 მმ"
+
+#: ../src/common/paper.cpp:148
+msgid "B4 (JIS) Rotated 364 x 257 mm"
+msgstr "B4 (JIS) შემობრუნებული 364 x 257 მმ"
+
+#: ../src/common/paper.cpp:149
+msgid "B5 (JIS) Rotated 257 x 182 mm"
+msgstr "B5 (JIS) შემობრუნებული 257 x 182 მმ"
+
+#: ../src/common/paper.cpp:150
+msgid "Japanese Postcard Rotated 148 x 100 mm"
+msgstr "იაპონური საფოსტო ბარათი შემობრუნებული 148 x 100 მმ"
+
+#: ../src/common/paper.cpp:151
+msgid "Double Japanese Postcard Rotated 148 x 200 mm"
+msgstr "ორმაგი იაპონური საფოსტო ბარათი შემობრუნებული 148 x 200 მმ"
+
+#: ../src/common/paper.cpp:152
+msgid "A6 Rotated 148 x 105 mm"
+msgstr "A6 შემობრუნებული 148 x 105 მმ"
+
+#: ../src/common/paper.cpp:153
+msgid "Japanese Envelope Kaku #2 Rotated"
+msgstr "იაპონური კონვერტი კაკუ #2 შემობრუნებული"
+
+#: ../src/common/paper.cpp:154
+msgid "Japanese Envelope Kaku #3 Rotated"
+msgstr "იაპონური კონვერტი კაკუ #3 შემობრუნებული"
+
+#: ../src/common/paper.cpp:155
+msgid "Japanese Envelope Chou #3 Rotated"
+msgstr "იაპონური კონვერტი Chou #3 შემობრუნებული"
+
+#: ../src/common/paper.cpp:156
+msgid "Japanese Envelope Chou #4 Rotated"
+msgstr "იაპონური კონვერტი Chou #4 შემობრუნებული"
+
+#: ../src/common/paper.cpp:157
+msgid "B6 (JIS) 128 x 182 mm"
+msgstr "B6 (JIS) 128 x 182 მმ"
+
+#: ../src/common/paper.cpp:158
+msgid "B6 (JIS) Rotated 182 x 128 mm"
+msgstr "B6 (JIS) შემობრუნებული 182 x 128 მმ"
+
+#: ../src/common/paper.cpp:159
+msgid "12 x 11 in"
+msgstr "12 x 11 დუიმი"
+
+#: ../src/common/paper.cpp:160
+msgid "Japanese Envelope You #4"
+msgstr "იაპონური კონვერტი You #4"
+
+#: ../src/common/paper.cpp:161
+msgid "Japanese Envelope You #4 Rotated"
+msgstr "იაპონური კონვერტი You #4 შემობრუნებული"
+
+#: ../src/common/paper.cpp:162
+msgid "PRC 16K 146 x 215 mm"
+msgstr "PRC 16K 146 x 215 მმ"
+
+#: ../src/common/paper.cpp:163
+msgid "PRC 32K 97 x 151 mm"
+msgstr "PRC 32K 97 x 151 მმ"
+
+#: ../src/common/paper.cpp:164
+msgid "PRC 32K(Big) 97 x 151 mm"
+msgstr "PRC 32K(დიდი) 97 x 151 მმ"
+
+#: ../src/common/paper.cpp:165
+msgid "PRC Envelope #1 102 x 165 mm"
+msgstr "PRC კონვერტი #1 102 x 165 მმ"
+
+#: ../src/common/paper.cpp:166
+msgid "PRC Envelope #2 102 x 176 mm"
+msgstr "PRC კონვერტი #2 102 x 176 მმ"
+
+#: ../src/common/paper.cpp:167
+msgid "PRC Envelope #3 125 x 176 mm"
+msgstr "PRC კონვერტი #3 125 x 176 მმ"
+
+#: ../src/common/paper.cpp:168
+msgid "PRC Envelope #4 110 x 208 mm"
+msgstr "PRC კონვერტი #4 110 x 208 მმ"
+
+#: ../src/common/paper.cpp:169
+msgid "PRC Envelope #5 110 x 220 mm"
+msgstr "PRC კონვერტი #5 110 x 220 მმ"
+
+#: ../src/common/paper.cpp:170
+msgid "PRC Envelope #6 120 x 230 mm"
+msgstr "PRC კონვერტი #6 120 x 230 მმ"
+
+#: ../src/common/paper.cpp:171
+msgid "PRC Envelope #7 160 x 230 mm"
+msgstr "PRC კონვერტი #7 160 x 230 მმ"
+
+#: ../src/common/paper.cpp:172
+msgid "PRC Envelope #8 120 x 309 mm"
+msgstr "PRC კონვერტი #8 120 x 309 მმ"
+
+#: ../src/common/paper.cpp:173
+msgid "PRC Envelope #9 229 x 324 mm"
+msgstr "PRC კონვერტი #9 229 x 324 მმ"
+
+#: ../src/common/paper.cpp:174
+msgid "PRC Envelope #10 324 x 458 mm"
+msgstr "PRC კონვერტი #10 324 x 458 მმ"
+
+#: ../src/common/paper.cpp:175
+msgid "PRC 16K Rotated"
+msgstr "PRC 16K შემობრუნებული"
+
+#: ../src/common/paper.cpp:176
+msgid "PRC 32K Rotated"
+msgstr "PRC 32K შემობრუნებული"
+
+#: ../src/common/paper.cpp:177
+msgid "PRC 32K(Big) Rotated"
+msgstr "PRC 32K(დიდი) შემობრუნებული"
+
+#: ../src/common/paper.cpp:178
+msgid "PRC Envelope #1 Rotated 165 x 102 mm"
+msgstr "PRC კონვერტი #1 შემობრუნებული 165 x 102 მმ"
+
+#: ../src/common/paper.cpp:179
+msgid "PRC Envelope #2 Rotated 176 x 102 mm"
+msgstr "PRC კონვერტი #2 შემობრუნებული 176 x 102 მმ"
+
+#: ../src/common/paper.cpp:180
+msgid "PRC Envelope #3 Rotated 176 x 125 mm"
+msgstr "PRC კონვერტი #3 შემობრუნებული 176 x 125 მმ"
+
+#: ../src/common/paper.cpp:181
+msgid "PRC Envelope #4 Rotated 208 x 110 mm"
+msgstr "PRC კონვერტი #4 შემობრუნებული 208 x 110 მმ"
+
+#: ../src/common/paper.cpp:182
+msgid "PRC Envelope #5 Rotated 220 x 110 mm"
+msgstr "PRC კონვერტი #5 შემობრუნებული 220 x 110 მმ"
+
+#: ../src/common/paper.cpp:183
+msgid "PRC Envelope #6 Rotated 230 x 120 mm"
+msgstr "PRC კონვერტი #6 შემობრუნებული 230 x 120 მმ"
+
+#: ../src/common/paper.cpp:184
+msgid "PRC Envelope #7 Rotated 230 x 160 mm"
+msgstr "PRC კონვერტი #7 შემობრუნებული 230 x 160 მმ"
+
+#: ../src/common/paper.cpp:185
+msgid "PRC Envelope #8 Rotated 309 x 120 mm"
+msgstr "PRC კონვერტი #8 შემობრუნებული 309 x 120 მმ"
+
+#: ../src/common/paper.cpp:186
+msgid "PRC Envelope #9 Rotated 324 x 229 mm"
+msgstr "PRC კონვერტი # 9 შემობრუნებული 324 x 229 მმ"
+
+#: ../src/common/paper.cpp:187
+msgid "PRC Envelope #10 Rotated 458 x 324 mm"
+msgstr "PRC კონვერტი #10 შემობრუნებული 458 x 324 მმ"
+
+#: ../src/common/paper.cpp:192
+msgid "A0 sheet, 841 x 1189 mm"
+msgstr "A0 ფურცელი, 841 x 1189 მმ"
+
+#: ../src/common/paper.cpp:193
+msgid "A1 sheet, 594 x 841 mm"
+msgstr "A1 ფურცელი, 594 x 841 მმ"
+
+#: ../src/common/preferencescmn.cpp:37
+msgid "General"
+msgstr "ზოგადი"
+
+#: ../src/common/preferencescmn.cpp:40
+msgid "Advanced"
+msgstr "დაწინაურებული"
+
+#: ../src/common/prntbase.cpp:245
+msgid "Generic PostScript"
+msgstr "ზოგადი PostScript"
+
+#: ../src/common/prntbase.cpp:259
+msgid "Ready"
+msgstr "მზადაა"
+
+#: ../src/common/prntbase.cpp:331
+msgid "Printing Error"
+msgstr "ბეჭდვის შეცდომა"
+
+#: ../src/common/prntbase.cpp:413 ../src/common/prntbase.cpp:1597
+#: ../src/generic/prntdlgg.cpp:135 ../src/generic/prntdlgg.cpp:149
+#: ../src/gtk/print.cpp:628 ../src/gtk/print.cpp:646
+msgid "Print"
+msgstr "დაბეჭდვა"
+
+#: ../src/common/prntbase.cpp:471 ../src/generic/prntdlgg.cpp:809
+msgid "Page setup"
+msgstr "გვერდის პარამეტრები"
+
+#: ../src/common/prntbase.cpp:525
+msgid "Please wait while printing..."
+msgstr "მოითმინეთ, მიმდინარეობს დაბეჭდვა..."
+
+#: ../src/common/prntbase.cpp:529
+msgid "Document:"
+msgstr "დოკუმენტი:"
+
+#: ../src/common/prntbase.cpp:532
+msgid "Progress:"
+msgstr "მიმდინარეობა:"
+
+#: ../src/common/prntbase.cpp:533
+msgid "Preparing"
+msgstr "მომზადება"
+
+#: ../src/common/prntbase.cpp:552
+#, c-format
+msgid "Printing page %d"
+msgstr "იბეჭდება გვერდი %d"
+
+#: ../src/common/prntbase.cpp:557
+#, c-format
+msgid "Printing page %d of %d"
+msgstr "მინდინარეობს %d-ე გვერდის დაბეჭდვა %d-დან"
+
+#: ../src/common/prntbase.cpp:560
+#, c-format
+msgid " (copy %d of %d)"
+msgstr " (კოპირება %d %d-დან)"
+
+#: ../src/common/prntbase.cpp:1604
+msgid "First page"
+msgstr "პირველი გვერდი"
+
+#: ../src/common/prntbase.cpp:1609 ../src/html/helpwnd.cpp:659
+msgid "Previous page"
+msgstr "წინა გვერდი"
+
+#: ../src/common/prntbase.cpp:1623 ../src/html/helpwnd.cpp:660
+msgid "Next page"
+msgstr "შემდეგი გვერდი"
+
+#: ../src/common/prntbase.cpp:1628
+msgid "Last page"
+msgstr "ბოლო გვერდი"
+
+#: ../src/common/prntbase.cpp:1636 ../src/common/stockitem.cpp:215
+msgid "Zoom Out"
+msgstr "და_პატარავება"
+
+#: ../src/common/prntbase.cpp:1650 ../src/common/stockitem.cpp:214
+msgid "Zoom In"
+msgstr "გა_დიდება"
+
+#: ../src/common/prntbase.cpp:1656 ../src/common/stockitem.cpp:153
+#: ../src/generic/logg.cpp:553 ../src/univ/themes/win32.cpp:3752
+msgid "&Close"
+msgstr "დაკე&ტვა"
+
+#: ../src/common/prntbase.cpp:2085
+msgid "Could not start document preview."
+msgstr "დოკუმენტის გადახედვის დაწყების შეცდომა."
+
+#: ../src/common/prntbase.cpp:2085 ../src/common/prntbase.cpp:2129
+#: ../src/common/prntbase.cpp:2137
+msgid "Print Preview Failure"
+msgstr "დასაბეჭდის გადახედვის შეცდომა"
+
+#: ../src/common/prntbase.cpp:2129 ../src/common/prntbase.cpp:2137
+msgid "Sorry, not enough memory to create a preview."
+msgstr "არასაკმარისი მეხსიერება გადახედვის შესაქნელად."
+
+#: ../src/common/prntbase.cpp:2144
+#, c-format
+msgid "Page %d of %d"
+msgstr "%d-ე გვერდი %d-დან"
+
+#: ../src/common/prntbase.cpp:2146
+#, c-format
+msgid "Page %d"
+msgstr "%d გვერდი"
+
+#: ../src/common/regex.cpp:382 ../src/html/chm.cpp:348
+msgid "unknown error"
+msgstr "უცნობი შეცდომა"
+
+#: ../src/common/regex.cpp:995
+#, c-format
+msgid "Invalid regular expression '%s': %s"
+msgstr "არასწორი რეგულარული გამოსახულება (%s): %s"
+
+#: ../src/common/regex.cpp:1059
+#, c-format
+msgid "Failed to find match for regular expression: %s"
+msgstr "რეგულარული გამოსახულების დამთხვევის შეცდომა: %s"
+
+#: ../src/common/rendcmn.cpp:188
+#, c-format
+msgid "Renderer \"%s\" has incompatible version %d.%d and couldn't be loaded."
+msgstr "რენდერერის (%s) ვერსია (%d.%d) არათავსებადია და ვერ ჩაიტვირთება."
+
+#: ../src/common/secretstore.cpp:162
+msgid "Not available for this platform"
+msgstr "მიუწვდომელია ამ პლატფორმისთვის"
+
+#: ../src/common/secretstore.cpp:183
+#, c-format
+msgid "Saving password for \"%s\" failed: %s."
+msgstr "%s-ის პაროლის შენახვის შეცდომა: %s."
+
+#: ../src/common/secretstore.cpp:205
+#, c-format
+msgid "Reading password for \"%s\" failed: %s."
+msgstr "%s-ის პაროლის წაკითხვის შეცდომა: %s."
+
+#: ../src/common/secretstore.cpp:228
+#, c-format
+msgid "Deleting password for \"%s\" failed: %s."
+msgstr "%s-ის პაროლის წაშლის შეცდომა: %s."
+
+#: ../src/common/selectdispatcher.cpp:254
+msgid "Failed to monitor I/O channels"
+msgstr "I/O არხების მონიტორინგის შეცდომა"
+
+#: ../src/common/sizer.cpp:3054 ../src/common/stockitem.cpp:195
+msgid "Save"
+msgstr "შენახვა"
+
+#: ../src/common/sizer.cpp:3056
+msgid "Don't Save"
+msgstr "არ შეინახო"
+
+#: ../src/common/socket.cpp:870
+msgid "Cannot initialize sockets"
+msgstr "სოკეტების ინციალიზაციის შეცდომა"
+
+#: ../src/common/stockitem.cpp:127
+msgctxt "standard Windows menu"
+msgid "&Help"
+msgstr "&დახმარება"
+
+#: ../src/common/stockitem.cpp:144
+msgid "&About"
+msgstr "შ&ესახებ"
+
+#: ../src/common/stockitem.cpp:144
+msgid "About"
+msgstr "შესახებ"
+
+#: ../src/common/stockitem.cpp:145
+msgid "Add"
+msgstr "დამატება"
+
+#: ../src/common/stockitem.cpp:146
+msgid "&Apply"
+msgstr "გამოყენება"
+
+#: ../src/common/stockitem.cpp:146
+msgid "Apply"
+msgstr "გამოყენება"
+
+#: ../src/common/stockitem.cpp:147
+msgid "&Back"
+msgstr "&უკან"
+
+#: ../src/common/stockitem.cpp:147
+msgid "Back"
+msgstr "უკან"
+
+#: ../src/common/stockitem.cpp:148
+msgid "&Bold"
+msgstr "&სქელი"
+
+#: ../src/common/stockitem.cpp:148 ../src/generic/fontdlgg.cpp:326
+#: ../src/richtext/richtextfontpage.cpp:354
+msgid "Bold"
+msgstr "მუქი"
+
+#: ../src/common/stockitem.cpp:149
+msgid "&Bottom"
+msgstr "ქ&ვედა"
+
+#: ../src/common/stockitem.cpp:149 ../src/richtext/richtextsizepage.cpp:287
+msgid "Bottom"
+msgstr "ქვემოთ"
+
+#: ../src/common/stockitem.cpp:150 ../src/generic/fontdlgg.cpp:462
+#: ../src/generic/fontdlgg.cpp:481 ../src/generic/wizard.cpp:415
+msgid "&Cancel"
+msgstr "&შეწყვეტა"
+
+#: ../src/common/stockitem.cpp:151
+msgid "&CD-ROM"
+msgstr "&CD-ROM"
+
+#: ../src/common/stockitem.cpp:151
+msgid "CD-ROM"
+msgstr "CD-ROM"
+
+#: ../src/common/stockitem.cpp:152
+msgid "&Clear"
+msgstr "&გასუფთავება"
+
+#: ../src/common/stockitem.cpp:152
+msgid "Clear"
+msgstr "გაწმენდა"
+
+#: ../src/common/stockitem.cpp:153 ../src/generic/dbgrptg.cpp:93
+#: ../src/generic/progdlgg.cpp:778 ../src/html/helpdlg.cpp:86
+#: ../src/msw/progdlg.cpp:209 ../src/msw/progdlg.cpp:890
+#: ../src/richtext/richtextstyledlg.cpp:272
+#: ../src/richtext/richtextsymboldlg.cpp:448
+msgid "Close"
+msgstr "დახურვა"
+
+#: ../src/common/stockitem.cpp:154
+msgid "&Convert"
+msgstr "&გარდაქმნა"
+
+#: ../src/common/stockitem.cpp:154
+msgid "Convert"
+msgstr "გარდაქმნა"
+
+#: ../src/common/stockitem.cpp:155 ../src/msw/textctrl.cpp:2884
+#: ../src/osx/textctrl_osx.cpp:653 ../src/richtext/richtextctrl.cpp:331
+msgid "&Copy"
+msgstr "&კოპირება"
+
+#: ../src/common/stockitem.cpp:155 ../src/stc/stc_i18n.cpp:18
+msgid "Copy"
+msgstr "დააკოპირე"
+
+#: ../src/common/stockitem.cpp:156 ../src/msw/textctrl.cpp:2883
+#: ../src/osx/textctrl_osx.cpp:652 ../src/richtext/richtextctrl.cpp:330
+msgid "Cu&t"
+msgstr "ამ&ოჭრა"
+
+#: ../src/common/stockitem.cpp:156 ../src/stc/stc_i18n.cpp:17
+msgid "Cut"
+msgstr "ამოჭრა"
+
+#: ../src/common/stockitem.cpp:157 ../src/msw/textctrl.cpp:2886
+#: ../src/osx/textctrl_osx.cpp:655 ../src/richtext/richtextctrl.cpp:333
+#: ../src/richtext/richtexttabspage.cpp:137
+msgid "&Delete"
+msgstr "&წაშლა"
+
+#: ../src/common/stockitem.cpp:157 ../src/richtext/richtextbuffer.cpp:8266
+#: ../src/stc/stc_i18n.cpp:20
+msgid "Delete"
+msgstr "წაშლა"
+
+#: ../src/common/stockitem.cpp:158
+msgid "&Down"
+msgstr "&ქვემოთ"
+
+#: ../src/common/stockitem.cpp:158 ../src/generic/fdrepdlg.cpp:148
+msgid "Down"
+msgstr "დაბლა"
+
+#: ../src/common/stockitem.cpp:159
+msgid "&Edit"
+msgstr "&რედაქტირება"
+
+#: ../src/common/stockitem.cpp:159
+msgid "Edit"
+msgstr "ჩასწორება"
+
+#: ../src/common/stockitem.cpp:160
+msgid "&Execute"
+msgstr "&შესრულება"
+
+#: ../src/common/stockitem.cpp:160
+msgid "Execute"
+msgstr "გაშვება"
+
+#: ../src/common/stockitem.cpp:161
+msgid "&Quit"
+msgstr "&გასვლა"
+
+#: ../src/common/stockitem.cpp:161
+msgid "Quit"
+msgstr "გასვლა"
+
+#: ../src/common/stockitem.cpp:162
+msgid "&File"
+msgstr "ფაილი"
+
+#: ../src/common/stockitem.cpp:162
+msgid "File"
+msgstr "ფაილი"
+
+#: ../src/common/stockitem.cpp:163
+msgid "&Find..."
+msgstr "&პოვნა..."
+
+#: ../src/common/stockitem.cpp:163
+msgid "Find..."
+msgstr "მოძებნა…"
+
+#: ../src/common/stockitem.cpp:164
+msgid "&First"
+msgstr "&პირველი"
+
+#: ../src/common/stockitem.cpp:164
+msgid "First"
+msgstr "პირველი"
+
+#: ../src/common/stockitem.cpp:165
+msgid "&Floppy"
+msgstr "&დისკეტა"
+
+#: ../src/common/stockitem.cpp:165
+msgid "Floppy"
+msgstr "დისკეტა"
+
+#: ../src/common/stockitem.cpp:166
+msgid "&Forward"
+msgstr "&წინ"
+
+#: ../src/common/stockitem.cpp:166
+msgid "Forward"
+msgstr "წინ"
+
+#: ../src/common/stockitem.cpp:167
+msgid "&Harddisk"
+msgstr "&მყარიდისკი"
+
+#: ../src/common/stockitem.cpp:167
+msgid "Harddisk"
+msgstr "მყარიდისკი"
+
+#: ../src/common/stockitem.cpp:168 ../src/generic/wizard.cpp:418
+#: ../src/osx/cocoa/menu.mm:225 ../src/richtext/richtextstyledlg.cpp:298
+#: ../src/richtext/richtextsymboldlg.cpp:451
+msgid "&Help"
+msgstr "&დახმარება"
+
+#: ../src/common/stockitem.cpp:169
+msgid "&Home"
+msgstr "&სახლი"
+
+#: ../src/common/stockitem.cpp:169
+msgid "Home"
+msgstr "საწყისი"
+
+#: ../src/common/stockitem.cpp:170
+msgid "Indent"
+msgstr "შეწევა"
+
+#: ../src/common/stockitem.cpp:171
+msgid "&Index"
+msgstr "&ინდექსი"
+
+#: ../src/common/stockitem.cpp:171 ../src/html/helpwnd.cpp:510
+msgid "Index"
+msgstr "ინდექსი"
+
+#: ../src/common/stockitem.cpp:172
+msgid "&Info"
+msgstr "&ინფო"
+
+#: ../src/common/stockitem.cpp:172
+msgid "Info"
+msgstr "ინფორმაცია"
+
+#: ../src/common/stockitem.cpp:173
+msgid "&Italic"
+msgstr "&დახრილი"
+
+#: ../src/common/stockitem.cpp:173 ../src/generic/fontdlgg.cpp:322
+#: ../src/richtext/richtextfontpage.cpp:350
+msgid "Italic"
+msgstr "დახრილი"
+
+#: ../src/common/stockitem.cpp:174
+msgid "&Jump to"
+msgstr "&გადასვლა"
+
+#: ../src/common/stockitem.cpp:174
+msgid "Jump to"
+msgstr "გადასვლა"
+
+#: ../src/common/stockitem.cpp:175
+msgid "Centered"
+msgstr "შუაზე გასწორებული"
+
+#: ../src/common/stockitem.cpp:176
+msgid "Justified"
+msgstr "გასწორებული"
+
+#: ../src/common/stockitem.cpp:177
+msgid "Align Left"
+msgstr "მარცხნივ სწორება"
+
+#: ../src/common/stockitem.cpp:178
+msgid "Align Right"
+msgstr "მარჯვნივ სწორება"
+
+#: ../src/common/stockitem.cpp:179
+msgid "&Last"
+msgstr "&ბოლო"
+
+#: ../src/common/stockitem.cpp:179
+msgid "Last"
+msgstr "ბოლო"
+
+#: ../src/common/stockitem.cpp:180
+msgid "&Network"
+msgstr "&ქსელი"
+
+#: ../src/common/stockitem.cpp:180
+msgid "Network"
+msgstr "ქსელი"
+
+#: ../src/common/stockitem.cpp:181 ../src/richtext/richtexttabspage.cpp:131
+msgid "&New"
+msgstr "&ახალი"
+
+#: ../src/common/stockitem.cpp:181
+msgid "New"
+msgstr "&ახალი"
+
+#: ../src/common/stockitem.cpp:182 ../src/msw/msgdlg.cpp:417
+msgid "&No"
+msgstr "&არა"
+
+#: ../src/common/stockitem.cpp:183 ../src/generic/fontdlgg.cpp:467
+#: ../src/generic/fontdlgg.cpp:474
+msgid "&OK"
+msgstr "&OK"
+
+#: ../src/common/stockitem.cpp:184 ../src/generic/dbgrptg.cpp:341
+msgid "&Open..."
+msgstr "&გახსნა..."
+
+#: ../src/common/stockitem.cpp:184
+msgid "Open..."
+msgstr "გახსნა..."
+
+#: ../src/common/stockitem.cpp:185 ../src/msw/textctrl.cpp:2885
+#: ../src/osx/textctrl_osx.cpp:654 ../src/richtext/richtextctrl.cpp:332
+msgid "&Paste"
+msgstr "&ჩასმა"
+
+#: ../src/common/stockitem.cpp:185 ../src/richtext/richtextctrl.cpp:3484
+#: ../src/stc/stc_i18n.cpp:19
+msgid "Paste"
+msgstr "ჩასმა"
+
+#: ../src/common/stockitem.cpp:186
+msgid "&Preferences"
+msgstr "&გამართვა"
+
+#: ../src/common/stockitem.cpp:186 ../src/osx/cocoa/preferences.mm:304
+msgid "Preferences"
+msgstr "მორგება"
+
+#: ../src/common/stockitem.cpp:187
+msgid "Print previe&w..."
+msgstr "&დასაბეჭდის გადახედვა..."
+
+#: ../src/common/stockitem.cpp:187
+msgid "Print preview..."
+msgstr "დასაბეჭდის გადახედვა..."
+
+#: ../src/common/stockitem.cpp:188
+msgid "&Print..."
+msgstr "&ამობეჭდვა..."
+
+#: ../src/common/stockitem.cpp:188
+msgid "Print..."
+msgstr "დაბეჭდვა..."
+
+#: ../src/common/stockitem.cpp:189 ../src/richtext/richtextctrl.cpp:337
+#: ../src/richtext/richtextctrl.cpp:5479
+msgid "&Properties"
+msgstr "&თვისებები"
+
+#: ../src/common/stockitem.cpp:189
+msgid "Properties"
+msgstr "პარამეტრები"
+
+#: ../src/common/stockitem.cpp:190 ../src/stc/stc_i18n.cpp:16
+msgid "Redo"
+msgstr "ბრძანების აღდგენა"
+
+#: ../src/common/stockitem.cpp:191
+msgid "Refresh"
+msgstr "განახლება"
+
+#: ../src/common/stockitem.cpp:192
+msgid "Remove"
+msgstr "მოცილება"
+
+#: ../src/common/stockitem.cpp:193
+msgid "Rep&lace..."
+msgstr "&ჩანაცვლება..."
+
+#: ../src/common/stockitem.cpp:193
+msgid "Replace..."
+msgstr "ჩანაცვლება..."
+
+#: ../src/common/stockitem.cpp:194
+msgid "Revert to Saved"
+msgstr "შენახულზე დაბრუნება"
+
+#: ../src/common/stockitem.cpp:196 ../src/generic/logg.cpp:549
+msgid "Save &As..."
+msgstr "შეინახვა &როგორც..."
+
+#: ../src/common/stockitem.cpp:196
+msgid "Save As..."
+msgstr "შენახვა, როგორც..."
+
+#: ../src/common/stockitem.cpp:197 ../src/msw/textctrl.cpp:2888
+#: ../src/osx/textctrl_osx.cpp:657 ../src/richtext/richtextctrl.cpp:335
+msgid "Select &All"
+msgstr "ყველაფრის &მონიშვნა"
+
+#: ../src/common/stockitem.cpp:197 ../src/stc/stc_i18n.cpp:21
+msgid "Select All"
+msgstr "ყველაფრის მონიშვნა"
+
+#: ../src/common/stockitem.cpp:198
+msgid "&Color"
+msgstr "&ფერი"
+
+#: ../src/common/stockitem.cpp:198
+msgid "Color"
+msgstr "ფერი"
+
+#: ../src/common/stockitem.cpp:199
+msgid "&Font"
+msgstr "&ფონტი"
+
+#: ../src/common/stockitem.cpp:199 ../src/richtext/richtextformatdlg.cpp:336
+msgid "Font"
+msgstr "ფონტი"
+
+#: ../src/common/stockitem.cpp:200
+msgid "&Ascending"
+msgstr "&აღმავალი"
+
+#: ../src/common/stockitem.cpp:200
+msgid "Ascending"
+msgstr "ზრდის მიხედვით"
+
+#: ../src/common/stockitem.cpp:201
+msgid "&Descending"
+msgstr "&დაღმავალი"
+
+#: ../src/common/stockitem.cpp:201
+msgid "Descending"
+msgstr "Დაღმავალი"
+
+#: ../src/common/stockitem.cpp:202
+msgid "&Spell Check"
+msgstr "&მართლწერის შემოწმება"
+
+#: ../src/common/stockitem.cpp:202
+msgid "Spell Check"
+msgstr "მართლწერის შემოწმება"
+
+#: ../src/common/stockitem.cpp:203
+msgid "&Stop"
+msgstr "გაჩერება"
+
+#: ../src/common/stockitem.cpp:203
+msgid "Stop"
+msgstr "შეჩერება"
+
+#: ../src/common/stockitem.cpp:204 ../src/richtext/richtextfontpage.cpp:274
+msgid "&Strikethrough"
+msgstr "&ხაზგადასმული"
+
+#: ../src/common/stockitem.cpp:204
+msgid "Strikethrough"
+msgstr "ხაზგადასმული"
+
+#: ../src/common/stockitem.cpp:205
+msgid "&Top"
+msgstr "&ზედა"
+
+#: ../src/common/stockitem.cpp:205 ../src/richtext/richtextsizepage.cpp:285
+#: ../src/richtext/richtextsizepage.cpp:289
+msgid "Top"
+msgstr "თავში"
+
+#: ../src/common/stockitem.cpp:206
+msgid "Undelete"
+msgstr "წაშლის გაუქმება"
+
+#: ../src/common/stockitem.cpp:207 ../src/generic/fontdlgg.cpp:437
+msgid "&Underline"
+msgstr "&ხაზგასმა"
+
+#: ../src/common/stockitem.cpp:207
+msgid "Underline"
+msgstr "ხაზგასმული"
+
+#: ../src/common/stockitem.cpp:208 ../src/stc/stc_i18n.cpp:15
+msgid "Undo"
+msgstr "დაბრუნება"
+
+#: ../src/common/stockitem.cpp:209
+msgid "&Unindent"
+msgstr "&შეწევის გაუქმება"
+
+#: ../src/common/stockitem.cpp:209
+msgid "Unindent"
+msgstr "შეწევის გაუქმება"
+
+#: ../src/common/stockitem.cpp:210
+msgid "&Up"
+msgstr "&მაღლა"
+
+#: ../src/common/stockitem.cpp:210 ../src/generic/fdrepdlg.cpp:148
+msgid "Up"
+msgstr "მაღლა"
+
+#: ../src/common/stockitem.cpp:211 ../src/msw/msgdlg.cpp:417
+msgid "&Yes"
+msgstr "&დიახ"
+
+#: ../src/common/stockitem.cpp:212
+msgid "&Actual Size"
+msgstr "&რეალური ზომა"
+
+#: ../src/common/stockitem.cpp:212
+msgid "Actual Size"
+msgstr "რეალური ზომა"
+
+#: ../src/common/stockitem.cpp:213
+msgid "Zoom to &Fit"
+msgstr "&გადიდება მოსარგებად"
+
+#: ../src/common/stockitem.cpp:213
+msgid "Zoom to Fit"
+msgstr "გადიდება მოსარგებად"
+
+#: ../src/common/stockitem.cpp:214
+msgid "Zoom &In"
+msgstr "გადიდება"
+
+#: ../src/common/stockitem.cpp:215
+msgid "Zoom &Out"
+msgstr "გადიდება"
+
+#: ../src/common/stockitem.cpp:262
+msgid "Show about dialog"
+msgstr "\"შესახებ\" ფანჯრის ჩვენება"
+
+#: ../src/common/stockitem.cpp:263
+msgid "Copy selection"
+msgstr "მონიშნულის კოპირება"
+
+#: ../src/common/stockitem.cpp:264
+msgid "Cut selection"
+msgstr "მონიშნულის ამოჭრა"
+
+#: ../src/common/stockitem.cpp:265
+msgid "Delete selection"
+msgstr "მონიშნულის წაშლა"
+
+#: ../src/common/stockitem.cpp:266
+msgid "Find in document"
+msgstr "დოკუმენტში ძებნა"
+
+#: ../src/common/stockitem.cpp:267
+msgid "Find and replace in document"
+msgstr "დოკუმენტში ძებნა და ჩანაცვლება"
+
+#: ../src/common/stockitem.cpp:268
+msgid "Paste selection"
+msgstr "მონიშნულის ჩასმა"
+
+#: ../src/common/stockitem.cpp:269
+msgid "Quit this program"
+msgstr "პროგრამიდან გასვლა"
+
+#: ../src/common/stockitem.cpp:270
+msgid "Redo last action"
+msgstr "ბოლო ბრძანების გამეორება"
+
+#: ../src/common/stockitem.cpp:271
+msgid "Undo last action"
+msgstr "ბოლო ბრძანების გაუქმება"
+
+#: ../src/common/stockitem.cpp:272
+msgid "Create new document"
+msgstr "ახალი დოკუმენტის შექმნა"
+
+#: ../src/common/stockitem.cpp:273
+msgid "Open an existing document"
+msgstr "უკვე არსებული დოკუმენტის გახსნა"
+
+#: ../src/common/stockitem.cpp:274
+msgid "Close current document"
+msgstr "მიმდინარე დოკუმენტის დახურვა"
+
+#: ../src/common/stockitem.cpp:275
+msgid "Save current document"
+msgstr "მიმდინარე დოკუმენტის შენახვა"
+
+#: ../src/common/stockitem.cpp:276
+msgid "Save current document with a different filename"
+msgstr "მიმდინარე დოკუმენტის სხვა სახელით შენახვა"
+
+#: ../src/common/strconv.cpp:2324
+#, c-format
+msgid "Conversion to charset '%s' doesn't work."
+msgstr "კოდირებაზე (%s) გადაყვანა არ მუშაობს."
+
+#: ../src/common/tarstrm.cpp:352 ../src/common/tarstrm.cpp:375
+#: ../src/common/tarstrm.cpp:406 ../src/generic/progdlgg.cpp:373
+msgid "unknown"
+msgstr "უცნობი"
+
+#: ../src/common/tarstrm.cpp:774
+msgid "incomplete header block in tar"
+msgstr "tar ფაილის თავსართის ბლოკი არასრულია"
+
+#: ../src/common/tarstrm.cpp:798
+msgid "checksum failure reading tar header block"
+msgstr "არასწორი საკონტროლო ჯამი tar-ის თავსართის ბლოკის კითხვისას"
+
+#: ../src/common/tarstrm.cpp:971
+msgid "invalid data in extended tar header"
+msgstr "არასწორი მონაცემები tar-ის გაფართოებულ თავსართში"
+
+#: ../src/common/tarstrm.cpp:981 ../src/common/tarstrm.cpp:1003
+#: ../src/common/tarstrm.cpp:1477 ../src/common/tarstrm.cpp:1499
+msgid "tar entry not open"
+msgstr "tar ფაილის ერთეული ღია არაა"
+
+#: ../src/common/tarstrm.cpp:1023
+msgid "unexpected end of file"
+msgstr "ფაილის მოულოდნელი დასასრული"
+
+#: ../src/common/tarstrm.cpp:1297
+#, c-format
+msgid "%s did not fit the tar header for entry '%s'"
+msgstr "%s ვერ ჩაეტია tar-ის თავსართში ჩანაწერისთვის %s"
+
+#: ../src/common/tarstrm.cpp:1359
+msgid "incorrect size given for tar entry"
+msgstr "tar-ის ჩანაწერისთვის მითითებული ზომა არასწორია"
+
+#: ../src/common/textbuf.cpp:232
+#, c-format
+msgid "'%s' is probably a binary buffer."
+msgstr "%s ალბათ ბინარული ბაფერია."
+
+#: ../src/common/textcmn.cpp:1006 ../src/richtext/richtextctrl.cpp:3053
+msgid "File couldn't be loaded."
+msgstr "ფაილის ჩატვირთვა შეუძლებელია."
+
+#: ../src/common/textfile.cpp:95
+#, c-format
+msgid "Failed to read text file \"%s\"."
+msgstr "ტექსტური ფაილის კითხვის შეცდომა: %s."
+
+#: ../src/common/textfile.cpp:160
+#, c-format
+msgid "can't write buffer '%s' to disk."
+msgstr "ბაფერის (%s) დისკზე ჩაწერის პრობლემა."
+
+#: ../src/common/time.cpp:212
+msgid "Failed to get the local system time"
+msgstr "ლოკალური სისტემის დროის მიღების პრობლემა"
+
+#: ../src/common/time.cpp:279
+msgid "wxGetTimeOfDay failed."
+msgstr "wxGetTimeOfDay =ის შეცდომა."
+
+#: ../src/common/translation.cpp:929
+#, c-format
+msgid "'%s' is not a valid message catalog."
+msgstr "%s შეტყობინებების სწორ კატალოგს არ წარმოადგენს."
+
+#: ../src/common/translation.cpp:954
+msgid "Invalid message catalog."
+msgstr "შეტყობინებების არასწორი კატალოგი."
+
+#: ../src/common/translation.cpp:1013
+#, c-format
+msgid "Failed to parse Plural-Forms: '%s'"
+msgstr "მრავლობითი ფორმების დამუშავების შეცდომა: %s"
+
+#: ../src/common/translation.cpp:1723
+#, c-format
+msgid "using catalog '%s' from '%s'."
+msgstr "გამოიყენება კატალოგი (%s) %s-დან."
+
+#: ../src/common/translation.cpp:1816
+#, c-format
+msgid "Resource '%s' is not a valid message catalog."
+msgstr "რესურსი %s შეტყობინების სწორ კატალოგს არ წარმოადგენს."
+
+#: ../src/common/translation.cpp:1865
+msgid "Couldn't enumerate translations"
+msgstr "თარგმანების ჩამონათვლის შეცდომა"
+
+#: ../src/common/utilscmn.cpp:1145
+msgid "No default application configured for HTML files."
+msgstr "HTML ფაილებისთვის ნაგულისხმები აპლიკაცია გაწერილი არაა."
+
+#: ../src/common/utilscmn.cpp:1190
+#, c-format
+msgid "Failed to open URL \"%s\" in default browser."
+msgstr "URL-ის ნაგულისხმებ ბრაუზერში გახსნის შეცდომა: %s."
+
+#: ../src/common/valtext.cpp:144
+msgid "Validation conflict"
+msgstr "შემოწმების კონფლიქტი"
+
+#: ../src/common/valtext.cpp:186
+msgid "Required information entry is empty."
+msgstr "საჭირო ინფორმაციის ჩანაწერი ცარიელია."
+
+#: ../src/common/valtext.cpp:188
+#, c-format
+msgid "'%s' is one of the invalid strings"
+msgstr "%s ერთერთი არასწორი სტრიქონია"
+
+#: ../src/common/valtext.cpp:190
+#, c-format
+msgid "'%s' is not one of the valid strings"
+msgstr "%s ერთერთ სწორ სტრიქონს არ წარმოადგენს"
+
+#: ../src/common/valtext.cpp:199
+#, c-format
+msgid "'%s' contains invalid character(s)"
+msgstr "'%s' არასწორ სიმბოლოებს შეიცავს"
+
+#: ../src/common/webrequest.cpp:139
+#, c-format
+msgid "Error: %s (%d)"
+msgstr "შეცდომა: %s (%d)"
+
+#: ../src/common/webrequest.cpp:655
+#, c-format
+msgid ""
+"Not enough free disk space for download: %llu needed but only %llu available."
+msgstr ""
+"გადმოსაწერად დისკზე საკმარისი თავისუფალი ადგილი არაა: საჭიროა %llu, "
+"ხელმისაწვდომია, მხოლოდ, %llu."
+
+#: ../src/common/webrequest.cpp:669
+#, c-format
+msgid "Failed to create temporary file in %s"
+msgstr "დროებითი ფაილის სახელის შექმნის შეცდომა საქაღალდეში %s"
+
+#: ../src/common/webrequest_curl.cpp:1106
+msgid "libcurl could not be initialized"
+msgstr "libcurl-ის ინიციალიზაციის შეცდომა"
+
+#: ../src/common/webview.cpp:392
+msgid "RunScriptAsync not supported"
+msgstr "RunScriptAsync მხარდაუჭერელია"
+
+#: ../src/common/webview.cpp:403 ../src/msw/webview_ie.cpp:1073
+#, c-format
+msgid "Error running JavaScript: %s"
+msgstr "JavaScript-ის შესრულების შეცდომა: %s"
+
+#: ../src/common/webview_chromium.cpp:858
+#, c-format
+msgid "Failed to set proxy \"%s\": %s"
+msgstr "პროქსის \"%s\" დაყენება ჩავარდა: %s"
+
+#: ../src/common/webview_chromium.cpp:989
+msgid ""
+"Chromium can't be used because libcef.so wasn't loaded early enough; please "
+"relink the application or use LD_PRELOAD to load it earlier."
+msgstr ""
+"Chromium-ის გამოყენება შეუძლებელია, რადგან libcef საკმარისად ადრე არ იყო "
+"ჩატვირთული. გთხოვთ, თავიდან ააგეთ აპლიკაცია, ან მისი უფრო ადრე "
+"გამოსაყენებლად LD_PRELOAD გამოიყენეთ."
+
+#: ../src/common/webview_chromium.cpp:1108
+msgid "Could not initialize Chromium"
+msgstr "Chromium-ის ინიციალიზაციის შეცდომა"
+
+#: ../src/common/webview_chromium.cpp:1616
+msgid "Show DevTools"
+msgstr "DevTools-ის ჩვენება"
+
+#: ../src/common/webview_chromium.cpp:1617
+msgid "Close DevTools"
+msgstr "DevToolsი-ის დახურვა"
+
+#: ../src/common/webview_chromium.cpp:1623
+msgid "Inspect"
+msgstr "ინსპექცია"
+
+#: ../src/common/wincmn.cpp:1628
+msgid "This platform does not support background transparency."
+msgstr "ამ პლატფორმას ფონის გამჭვირვალობის მხარდაჭერა არ გააჩნია."
+
+#: ../src/common/wincmn.cpp:2097
+msgid "Could not transfer data to window"
+msgstr "მონაცემების ფანჯარაში გადაცემა შეუძლებელია"
+
+#: ../src/common/windowid.cpp:240
+msgid "Out of window IDs.  Recommend shutting down application."
+msgstr "ფანჯრის ID-ები აღარ დარჩა. რეკომენდებულია დახუროთ აპლიკაცია."
+
+#: ../src/common/xpmdecod.cpp:678
+msgid "XPM: incorrect header format!"
+msgstr "XPM: თავსართის არასწორი ფორმატი!"
+
+#: ../src/common/xpmdecod.cpp:703
+#, c-format
+msgid "XPM: incorrect colour description in line %d"
+msgstr "XPM: ფერის არასწორი აღწერა ხაზზე %d"
+
+#: ../src/common/xpmdecod.cpp:715 ../src/common/xpmdecod.cpp:724
+#, c-format
+msgid "XPM: malformed colour definition '%s' at line %d!"
+msgstr "XPM: ფერის (%s) არასწორი აღწერა ხაზზე %d!"
+
+#: ../src/common/xpmdecod.cpp:754
+msgid "XPM: no colors left to use for mask!"
+msgstr "XPM: ნიღბისთვის გამოსაყენებლად ფერები არ დარჩა!"
+
+#: ../src/common/xpmdecod.cpp:781
+#, c-format
+msgid "XPM: truncated image data at line %d!"
+msgstr "XPM: გამოსახულების მონაცემები მოკვეთილია ხაზზე %d!"
+
+#: ../src/common/xpmdecod.cpp:795
+msgid "XPM: Malformed pixel data!"
+msgstr "XPM: პიქსელის არასწორი მონაცემები!"
+
+#: ../src/common/xti.cpp:492
+msgid "Illegal Parameter Count for Create Method"
+msgstr "შექმნის მეთოდის არასწორი პარამეტრების რაოდენობა"
+
+#: ../src/common/xti.cpp:504
+msgid "Illegal Parameter Count for ConstructObject Method"
+msgstr "ConstructObject Method-ის არასწორი პარამეტრების რაოდენობა"
+
+#: ../src/common/xtistrm.cpp:161
+#, c-format
+msgid "Create Parameter %s not found in declared RTTI Parameters"
+msgstr "RTTI-ის აღწერილ პარამეტრებში პარამეტრი %s-ის შექმნა ნაპოვნი არაა"
+
+#: ../src/common/xtistrm.cpp:290
+msgid "Illegal Object Class (Non-wxEvtHandler) as Event Source"
+msgstr "მოვლენის წყაროდ მითითებული ობიექტის კლასი (Non-wxEvtHandler) არასწორია"
+
+#: ../src/common/xtistrm.cpp:313 ../src/common/xtixml.cpp:345
+#: ../src/common/xtixml.cpp:498
+msgid "Type must have enum - long conversion"
+msgstr "ტიპს enum-long გარდაქმნა უნდა ჰქონდეს"
+
+#: ../src/common/xtistrm.cpp:400 ../src/common/xtistrm.cpp:415
+msgid "Invalid or Null Object ID passed to GetObjectClassInfo"
+msgstr ""
+"GetObjectClassInfo-სთვის გადაცემული ობიექტის სახელი არასწორი ან ნულოვანია"
+
+#: ../src/common/xtistrm.cpp:405
+msgid "Unknown Object passed to GetObjectClassInfo"
+msgstr "GetObjectClassInfo-სთვის გადაცემული ობიექტი უცნობია"
+
+#: ../src/common/xtistrm.cpp:420
+msgid "Already Registered Object passed to SetObjectClassInfo"
+msgstr "SetObjectClassInfo-სთვის გადაცემული ობიექტი უკვე რეგისტრირებულია"
+
+#: ../src/common/xtistrm.cpp:430
+msgid "Invalid or Null Object ID passed to HasObjectClassInfo"
+msgstr ""
+"HasObjectClassInfo-სთვის გადაცემული ობიექტის სახელი არასწორი ან ნულოვანია"
+
+#: ../src/common/xtistrm.cpp:460
+msgid "Passing a already registered object to SetObject"
+msgstr "SetObject-სთვის უკვე რეგისტრირებული ობიექტის გადაცემა"
+
+#: ../src/common/xtistrm.cpp:471
+msgid "Passing an unknown object to GetObject"
+msgstr "GetObject-სთვის უცნობი ობიექტის გადაცემა"
+
+#: ../src/common/xtixml.cpp:229
+msgid "Forward hrefs are not supported"
+msgstr "ჯვარედინი ბმულები მხარდაუჭერელია"
+
+#: ../src/common/xtixml.cpp:247
+#, c-format
+msgid "unknown class %s"
+msgstr "უცნობი კლასი: %s"
+
+#: ../src/common/xtixml.cpp:253
+msgid "objects cannot have XML Text Nodes"
+msgstr "ობიექტებს XML-ის ტექსტური კვანძები ვერ ექნებათ"
+
+#: ../src/common/xtixml.cpp:258
+msgid "Objects must have an id attribute"
+msgstr "ობიექტებს ატრიბუტი \"id\" აუცილებელია, ჰქონდეთ"
+
+#: ../src/common/xtixml.cpp:267
+#, c-format
+msgid "Doubly used id : %d"
+msgstr "ორჯერ გამოყენებული id : %d"
+
+#: ../src/common/xtixml.cpp:316
+#, c-format
+msgid "Unknown Property %s"
+msgstr "უცნობ თვისება %s"
+
+#: ../src/common/xtixml.cpp:407
+msgid "A non empty collection must consist of 'element' nodes"
+msgstr "არაცარიელი კოლექციები 'ელემენტის' კვანძებისგან უნდა შედგებოდეს"
+
+#: ../src/common/xtixml.cpp:478
+msgid "incorrect event handler string, missing dot"
+msgstr "მოვლენის დამმუშავებლის არასწორ სტრიქონი. წერტილი აკლია"
+
+#: ../src/common/zipstrm.cpp:559
+msgid "can't re-initialize zlib deflate stream"
+msgstr "zlib-ის გაშლის ნაკადის თავიდან ინიციალიზაციის შეცდომა"
+
+#: ../src/common/zipstrm.cpp:584
+msgid "can't re-initialize zlib inflate stream"
+msgstr "zlib-ის შეკუმშვის ნაკადის თავიდან ინიციალიზაციის შეცდომა"
+
+#: ../src/common/zipstrm.cpp:1023
+msgid "Ignoring malformed extra data record, ZIP file may be corrupted"
+msgstr ""
+"დამატებითი მონაცემების არასწორი ჩანაწერის იგნორი. შეიძლება ZIP ფაილი "
+"დაზიანებულია"
+
+#: ../src/common/zipstrm.cpp:1502
+msgid "assuming this is a multi-part zip concatenated"
+msgstr "ჩავთვლი, რომ ეს შეერთებული მრავალნაწილიანია zip ფაილია"
+
+#: ../src/common/zipstrm.cpp:1664
+msgid "invalid zip file"
+msgstr "არასწორი zip ფაილი"
+
+#: ../src/common/zipstrm.cpp:1723
+msgid "can't find central directory in zip"
+msgstr "zp-ის ცენტრალური საქაღალდის პოვნა შეუძლებელია"
+
+#: ../src/common/zipstrm.cpp:1812
+msgid "error reading zip central directory"
+msgstr "zp-ის ცენტრალური საქაღალდის წაკითხვის შეცდომა"
+
+#: ../src/common/zipstrm.cpp:1916
+msgid "error reading zip local header"
+msgstr "zip-ის ლოკალური თავსართის წაკითხვის შეცდომა"
+
+#: ../src/common/zipstrm.cpp:1964
+msgid "bad zipfile offset to entry"
+msgstr "zip ფაილის არასწორი წანაცვლება"
+
+#: ../src/common/zipstrm.cpp:2031
+msgid "stored file length not in Zip header"
+msgstr "დამახსოვრებული ფაილის სიგრძე Zip თავსართში არაა"
+
+#: ../src/common/zipstrm.cpp:2045 ../src/common/zipstrm.cpp:2362
+msgid "unsupported Zip compression method"
+msgstr "zip შეკუმშვის მხარდაუჭერელი მეთოდი"
+
+#: ../src/common/zipstrm.cpp:2126
+#, c-format
+msgid "reading zip stream (entry %s): bad length"
+msgstr "zip ნაკადის წაკითხვა (ჩანაწერი %s): არასწორი სიგრძე"
+
+#: ../src/common/zipstrm.cpp:2131
+#, c-format
+msgid "reading zip stream (entry %s): bad crc"
+msgstr "zip ნაკადის წაკითხვა (ჩანაწერი %s): არასწორი CRC"
+
+#: ../src/common/zipstrm.cpp:2578
+#, c-format
+msgid "error writing zip entry '%s': file too large without ZIP64"
+msgstr "zip ჩანაწერის (%s) ჩაწერის შეცდომა: ZIP64-ის გარეშე ფაილი ძალიან დიდია"
+
+#: ../src/common/zipstrm.cpp:2585
+#, c-format
+msgid "error writing zip entry '%s': bad crc or length"
+msgstr "zip ჩანაწერის (%s) ჩაწერის შეცდომა: არასწორი CRC ან სიგრძე"
+
+#: ../src/common/zstream.cpp:155 ../src/common/zstream.cpp:315
+msgid "Gzip not supported by this version of zlib"
+msgstr "ამ ვერსიის zlib-ს gzip-ის მხარდაჭერა არ გააჩნია"
+
+#: ../src/common/zstream.cpp:182
+msgid "Can't initialize zlib inflate stream."
+msgstr "Zlib-ის შეკუმშვის ნაკადის ინიციალიზაციის შეცდომა."
+
+#: ../src/common/zstream.cpp:241
+msgid "Can't read inflate stream: unexpected EOF in underlying stream."
+msgstr "შეკუმშვის ნაკადის წაკითხვის შეცდომა: ქვედა ნაკადის მოულოდნელი EOF."
+
+#: ../src/common/zstream.cpp:248 ../src/common/zstream.cpp:423
+#, c-format
+msgid "zlib error %d"
+msgstr "zlib -ის შეცდომა %d"
+
+#: ../src/common/zstream.cpp:249
+#, c-format
+msgid "Can't read from inflate stream: %s"
+msgstr "შეკუმშვის ნაკადიდან წაკითხვის შეცდომა: %s"
+
+#: ../src/common/zstream.cpp:343
+msgid "Can't initialize zlib deflate stream."
+msgstr "Zlib-ის გაშლის ნაკადის ინიციალიზაციის შეცდომა."
+
+#: ../src/common/zstream.cpp:424
+#, c-format
+msgid "Can't write to deflate stream: %s"
+msgstr "გაშლის ნაკადში ჩაწერის შეცდომა: %s"
+
+#: ../src/dfb/bitmap.cpp:633 ../src/dfb/bitmap.cpp:667
+#, c-format
+msgid "No bitmap handler for type %d defined."
+msgstr "ბიტური რუკის დამმუშავებელი ტიპისთვის %d აღწერილი არაა."
+
+#: ../src/dfb/evtloop.cpp:99
+msgid "Failed to read event from DirectFB pipe"
+msgstr "DirectFB-ის ფაიფიდან მოვლენის წაკითხვა შეუძლებელია"
+
+#: ../src/dfb/evtloop.cpp:171
+msgid "Failed to switch DirectFB pipe to non-blocking mode"
+msgstr "DirectFB-ის ფაიფის არა-ბლოკირებად რეჟიმში გადართვის შეცდომა"
+
+#: ../src/dfb/fontmgr.cpp:171
+#, c-format
+msgid "no fonts found in %s, using builtin font"
+msgstr "%s-ში ფონტი ვერ ვიპოვე. გამოყენებული იქნება ჩაშენებული ფონტი"
+
+#: ../src/dfb/fontmgr.cpp:177
+msgid "Default font"
+msgstr "ნაგულისხმები ფონტი"
+
+#: ../src/dfb/fontmgr.cpp:195
+#, c-format
+msgid "Fonts index file %s disappeared while loading fonts."
+msgstr "ფონტის ინდექსის ფაილი %s ფონტების კითხვის მიმდინარეობისას გაქრა."
+
+#: ../src/dfb/wrapdfb.cpp:60
+#, c-format
+msgid "DirectFB error %d occurred."
+msgstr "DirectFB -ის შეცდომა: %d."
+
+#: ../src/generic/aboutdlgg.cpp:69
+msgid "Developed by "
+msgstr "დაწერილია "
+
+#: ../src/generic/aboutdlgg.cpp:72
+msgid "Documentation by "
+msgstr "დოკუმენტაციის ავტორი "
+
+#: ../src/generic/aboutdlgg.cpp:75
+msgid "Graphics art by "
+msgstr "გრაფიკის ავტორი "
+
+#: ../src/generic/aboutdlgg.cpp:78
+msgid "Translations by "
+msgstr "თარგმანები "
+
+#: ../src/generic/aboutdlgg.cpp:133 ../src/osx/cocoa/aboutdlg.mm:83
+msgid "Version "
+msgstr "ვერსია "
+
+#. TRANSLATORS: %s is application name
+#: ../src/generic/aboutdlgg.cpp:146 ../src/msw/aboutdlg.cpp:60
+#, c-format
+msgid "About %s"
+msgstr "%s-ის შესახებ"
+
+#: ../src/generic/aboutdlgg.cpp:181
+msgid "License"
+msgstr "ლიცენზია"
+
+#: ../src/generic/aboutdlgg.cpp:184
+msgid "Developers"
+msgstr "პროგრამისტები"
+
+#: ../src/generic/aboutdlgg.cpp:188
+msgid "Documentation writers"
+msgstr "დოკუმენტაციის ავტორები"
+
+#: ../src/generic/aboutdlgg.cpp:192
+msgid "Artists"
+msgstr "შემსრულებლები"
+
+#: ../src/generic/aboutdlgg.cpp:196
+msgid "Translators"
+msgstr "მთარგმნელები"
+
+#: ../src/generic/animateg.cpp:125
+msgid "No handler found for animation type."
+msgstr "ანიმაციის ტიპისთვის დამმუშავებელი ვერ ვიპოვე."
+
+#: ../src/generic/animateg.cpp:133
+#, c-format
+msgid "No animation handler for type %ld defined."
+msgstr "ანიმაციის ტიპისთვის(%ld) დამმუშავებელი ვერ ვიპოვე."
+
+#: ../src/generic/animateg.cpp:145
+#, c-format
+msgid "Animation file is not of type %ld."
+msgstr "ანიმაციის ფაილი %ld ტიპის არაა."
+
+#: ../src/generic/colrdlgg.cpp:154 ../src/gtk/colordlg.cpp:47
+msgid "Choose colour"
+msgstr "აირჩიეთ ფერი"
+
+#: ../src/generic/colrdlgg.cpp:357
+msgid "Red:"
+msgstr "წითელი:"
+
+#: ../src/generic/colrdlgg.cpp:360
+msgid "Green:"
+msgstr "მწვანე:"
+
+#: ../src/generic/colrdlgg.cpp:363
+msgid "Blue:"
+msgstr "ლურჯი:"
+
+#: ../src/generic/colrdlgg.cpp:372
+msgid "Opacity:"
+msgstr "გაუმჭვირვალობა:"
+
+#: ../src/generic/colrdlgg.cpp:384
+msgid "Add to custom colours"
+msgstr "ხელით მითითებულ ფერებში ჩამატება"
+
+#: ../src/generic/creddlgg.cpp:56
+msgid "Username:"
+msgstr "მომხმარებელი:"
+
+#: ../src/generic/creddlgg.cpp:63
+msgid "Password:"
+msgstr "პაროლი:"
+
+#. TRANSLATORS: Name of Boolean true value
+#: ../src/generic/datavgen.cpp:1178
+msgid "true"
+msgstr "სიმართლე"
+
+#. TRANSLATORS: Name of Boolean false value
+#: ../src/generic/datavgen.cpp:1180
+msgid "false"
+msgstr "მცდარი"
+
+#: ../src/generic/datavgen.cpp:6897
+#, c-format
+msgid "Row %i"
+msgstr "მწკრივი %i"
+
+#. TRANSLATORS: Action for manipulating a tree control
+#: ../src/generic/datavgen.cpp:6987
+msgid "Collapse"
+msgstr "აკეცვა"
+
+#. TRANSLATORS: Action for manipulating a tree control
+#: ../src/generic/datavgen.cpp:6990
+msgid "Expand"
+msgstr "გაფართოება"
+
+#. TRANSLATORS: Name of data view control and number of rows
+#: ../src/generic/datavgen.cpp:7011
+#, c-format
+msgid "%s (%d items)"
+msgstr "%s (%d ჩანაწერი)"
+
+#: ../src/generic/datavgen.cpp:7062
+#, c-format
+msgid "Column %u"
+msgstr "სვეტი %u"
+
+#. TRANSLATORS: Keystroke for manipulating a tree control
+#: ../src/generic/datavgen.cpp:7131 ../src/richtext/richtextbulletspage.cpp:189
+#: ../src/richtext/richtextbulletspage.cpp:192
+#: ../src/richtext/richtextbulletspage.cpp:193
+#: ../src/richtext/richtextliststylepage.cpp:252
+#: ../src/richtext/richtextliststylepage.cpp:255
+#: ../src/richtext/richtextliststylepage.cpp:256
+#: ../src/richtext/richtextsizepage.cpp:248
+msgid "Left"
+msgstr "მარცხნივ"
+
+#. TRANSLATORS: Keystroke for manipulating a tree control
+#: ../src/generic/datavgen.cpp:7134 ../src/richtext/richtextbulletspage.cpp:191
+#: ../src/richtext/richtextliststylepage.cpp:254
+#: ../src/richtext/richtextsizepage.cpp:249
+msgid "Right"
+msgstr "მარჯვნივ"
+
+#: ../src/generic/datectlg.cpp:90
+#, c-format
+msgid ""
+"\"%s\" is not in the expected date format, please enter it as e.g. \"%s\"."
+msgstr ""
+"\"%s\" მოსალოდნელი თარიღის ფორმატი არაა. შეიყვანეთ ის, მაგალითად, როგორც "
+"\"%s\"."
+
+#: ../src/generic/datectlg.cpp:94
+msgid "Invalid date"
+msgstr "არასწორი თარიღი"
+
+#: ../src/generic/dbgrptg.cpp:159
+#, c-format
+msgid "Open file \"%s\""
+msgstr "ფაილის გახსნა; \"%s\""
+
+#: ../src/generic/dbgrptg.cpp:170
+#, c-format
+msgid "Enter command to open file \"%s\":"
+msgstr "შეიყვანეთ ბრძანება ფაილის (%s) გასახსნელად:"
+
+#: ../src/generic/dbgrptg.cpp:230
+msgid "Executable files (*.exe)|*.exe|"
+msgstr "გამშვები ფაილები (*.exe)|*.exe|"
+
+#: ../src/generic/dbgrptg.cpp:300
+#, c-format
+msgid "Debug report \"%s\""
+msgstr "გამართვის ანგარიში %s"
+
+#: ../src/generic/dbgrptg.cpp:316
+msgid "A debug report has been generated in the directory\n"
+msgstr "გამართვის ანგარიში გენერირებულია საქაღალდეში\n"
+
+#: ../src/generic/dbgrptg.cpp:317
+msgid "The following debug report will be generated\n"
+msgstr "გენერირებული იქნება შემდეგი გამართვის ანგარიში\n"
+
+#: ../src/generic/dbgrptg.cpp:321
+msgid ""
+"The report contains the files listed below. If any of these files contain "
+"private information,\n"
+"please uncheck them and they will be removed from the report.\n"
+msgstr ""
+"ანგარიში შეიცავს ქვემოთ ჩამოთვლილ ფაილებს. თუ ნებისმიერი ამ ფაილთაგანი პირად "
+"ინფორმაციას შეიცავს,\n"
+"მოხსენით მონიშვნა და ისინი წაიშლება ანგარიშიდან.\n"
+
+#: ../src/generic/dbgrptg.cpp:323
+msgid ""
+"If you wish to suppress this debug report completely, please choose the "
+"\"Cancel\" button,\n"
+"but be warned that it may hinder improving the program, so if\n"
+"at all possible please do continue with the report generation.\n"
+msgstr ""
+
+#: ../src/generic/dbgrptg.cpp:325
+msgid "              Thank you and we're sorry for the inconvenience!\n"
+msgstr "               მადლობა და ბოდიში უხერხულობისთვის!\n"
+
+#: ../src/generic/dbgrptg.cpp:333
+msgid "&Debug report preview:"
+msgstr "&გამართვის ანგარიშის გადახედვა:"
+
+#: ../src/generic/dbgrptg.cpp:339
+msgid "&View..."
+msgstr "&ნახვა..."
+
+#: ../src/generic/dbgrptg.cpp:359
+msgid "&Notes:"
+msgstr "&შენიშვნები:"
+
+#: ../src/generic/dbgrptg.cpp:361
+msgid ""
+"If you have any additional information pertaining to this bug\n"
+"report, please enter it here and it will be joined to it:"
+msgstr ""
+
+#: ../src/generic/dcpsg.cpp:1627
+msgid "Cannot open file for PostScript printing!"
+msgstr "PostScript -ით დაბეჭდვისთვის ფაილის გახსნა შეუძლებელია!"
+
+#: ../src/generic/dirctrlg.cpp:402
+msgid "Computer"
+msgstr "კომპიუტერი"
+
+#: ../src/generic/dirctrlg.cpp:404
+msgid "Sections"
+msgstr "სექციები"
+
+#: ../src/generic/dirctrlg.cpp:482
+msgid "Home directory"
+msgstr "საწყისი საქაღალდე"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/generic/dirctrlg.cpp:484 ../src/propgrid/advprops.cpp:811
+msgid "Desktop"
+msgstr "სამუშაო მაგიდა"
+
+#: ../src/generic/dirctrlg.cpp:528 ../src/generic/filectrlg.cpp:752
+msgid "Illegal directory name."
+msgstr "საქაღალდის არასწორი სახელი."
+
+#: ../src/generic/dirctrlg.cpp:528 ../src/generic/dirctrlg.cpp:546
+#: ../src/generic/dirctrlg.cpp:557 ../src/generic/dirdlgg.cpp:317
+#: ../src/generic/filectrlg.cpp:638 ../src/generic/filectrlg.cpp:752
+#: ../src/generic/filectrlg.cpp:766 ../src/generic/filectrlg.cpp:782
+#: ../src/generic/filectrlg.cpp:1356 ../src/generic/filectrlg.cpp:1387
+#: ../src/generic/filedlgg.cpp:362 ../src/gtk/filedlg.cpp:76
+msgid "Error"
+msgstr "შეცდომა"
+
+#: ../src/generic/dirctrlg.cpp:546 ../src/generic/filectrlg.cpp:766
+msgid "File name exists already."
+msgstr "ფაილის სახელი უკვე არსებბს."
+
+#: ../src/generic/dirctrlg.cpp:557 ../src/generic/dirdlgg.cpp:317
+#: ../src/generic/filectrlg.cpp:638 ../src/generic/filectrlg.cpp:782
+msgid "Operation not permitted."
+msgstr "ოპერაცია ნებადაურთველია."
+
+#: ../src/generic/dirdlgg.cpp:107 ../src/generic/filedlgg.cpp:207
+msgid "Create new directory"
+msgstr "ახალი საქაღალდის შექმნა"
+
+#: ../src/generic/dirdlgg.cpp:112 ../src/generic/filedlgg.cpp:203
+msgid "Go to home directory"
+msgstr "საწყის საქაღალდეზე გადასვლა"
+
+#: ../src/generic/dirdlgg.cpp:143
+msgid "Show &hidden directories"
+msgstr "დამალული &საქაღალდეების ჩვენება"
+
+#: ../src/generic/dirdlgg.cpp:196
+#, c-format
+msgid ""
+"The directory '%s' does not exist\n"
+"Create it now?"
+msgstr ""
+"საქაღალდე %s არ არსებობს\n"
+"შევქმნა?"
+
+#: ../src/generic/dirdlgg.cpp:198
+msgid "Directory does not exist"
+msgstr "საქაღალდე არ არსებობს"
+
+#: ../src/generic/dirdlgg.cpp:214
+#, c-format
+msgid ""
+"Failed to create directory '%s'\n"
+"(Do you have the required permissions?)"
+msgstr ""
+"საქაღალდის შექმნის შეცდომა: %s\n"
+"(წვდომები გაქვთ?)"
+
+#: ../src/generic/dirdlgg.cpp:216
+msgid "Error creating directory"
+msgstr "საქაღალდის შექმნის შეცდომა"
+
+#: ../src/generic/dirdlgg.cpp:281
+msgid "You cannot add a new directory to this section."
+msgstr "ამ სექციას ახალ საქაღალდეს ვერ დაამატებთ."
+
+#: ../src/generic/dirdlgg.cpp:282
+msgid "Create directory"
+msgstr "საქაღალდის შექმნა"
+
+#: ../src/generic/dirdlgg.cpp:291 ../src/generic/dirdlgg.cpp:301
+#: ../src/generic/filectrlg.cpp:614 ../src/generic/filectrlg.cpp:623
+msgid "NewName"
+msgstr "ახალი სახელი"
+
+#: ../src/generic/editlbox.cpp:135
+msgid "Edit item"
+msgstr "ჩანაწერის ჩასწორება"
+
+#: ../src/generic/editlbox.cpp:143
+msgid "New item"
+msgstr "ახალი ჩანაწერი"
+
+#: ../src/generic/editlbox.cpp:151
+msgid "Delete item"
+msgstr "ჩანაწერის წაშლა"
+
+#: ../src/generic/editlbox.cpp:159
+msgid "Move up"
+msgstr "აწევა"
+
+#: ../src/generic/editlbox.cpp:164
+msgid "Move down"
+msgstr "ქვემოთ ჩამოწევა"
+
+#: ../src/generic/fdrepdlg.cpp:108
+msgid "Search for:"
+msgstr "ძებნა:"
+
+#: ../src/generic/fdrepdlg.cpp:120
+msgid "Replace with:"
+msgstr "ჩანაცვლება:"
+
+#: ../src/generic/fdrepdlg.cpp:140
+msgid "Whole word"
+msgstr "მთლიანი სიტყვა"
+
+#: ../src/generic/fdrepdlg.cpp:143
+msgid "Match case"
+msgstr "დიდი და პატარა ასოების სხვაობა"
+
+#: ../src/generic/fdrepdlg.cpp:156
+msgid "Search direction"
+msgstr "ძებნის მიმართულება"
+
+#: ../src/generic/fdrepdlg.cpp:175
+msgid "&Replace"
+msgstr "ჩანაცვლება"
+
+#: ../src/generic/fdrepdlg.cpp:178
+msgid "Replace &all"
+msgstr "ყველას &ჩანაცვლება"
+
+#: ../src/generic/filectrlg.cpp:246 ../src/generic/filectrlg.cpp:269
+msgid "<DIR>"
+msgstr "<სქღლდ>"
+
+#: ../src/generic/filectrlg.cpp:248 ../src/generic/filectrlg.cpp:271
+msgid "<LINK>"
+msgstr "<ბმული>"
+
+#: ../src/generic/filectrlg.cpp:250 ../src/generic/filectrlg.cpp:273
+msgid "<DRIVE>"
+msgstr "<დისკი>"
+
+#: ../src/generic/filectrlg.cpp:275
+#, c-format
+msgid "%ld byte"
+msgid_plural "%ld bytes"
+msgstr[0] "%ld ბაიტი"
+msgstr[1] "%ld ბაიტი"
+
+#: ../src/generic/filectrlg.cpp:420
+msgid "Name"
+msgstr "სახელი"
+
+#: ../src/generic/filectrlg.cpp:421 ../src/richtext/richtextformatdlg.cpp:361
+#: ../src/richtext/richtextsizepage.cpp:298
+msgid "Size"
+msgstr "ზომა"
+
+#: ../src/generic/filectrlg.cpp:422
+msgid "Type"
+msgstr "ტიპი"
+
+#: ../src/generic/filectrlg.cpp:423
+msgid "Modified"
+msgstr "შეცვლილია"
+
+#: ../src/generic/filectrlg.cpp:426
+msgid "Permissions"
+msgstr "წვდომები"
+
+#: ../src/generic/filectrlg.cpp:429
+msgid "Attributes"
+msgstr "ატრიბუტები"
+
+#: ../src/generic/filectrlg.cpp:936
+msgid "Current directory:"
+msgstr "მიმდინარე საქაღალდე:"
+
+#: ../src/generic/filectrlg.cpp:979
+msgid "Show &hidden files"
+msgstr "დამალული &ფაილების ჩვენება"
+
+#: ../src/generic/filectrlg.cpp:1355
+msgid "Illegal file specification."
+msgstr "ფაილის არასწორი სპეფიციკაცია."
+
+#: ../src/generic/filectrlg.cpp:1387
+msgid "Directory doesn't exist."
+msgstr "საქაღალდე არ არსებობს."
+
+#: ../src/generic/filedlgg.cpp:195
+msgid "View files as a list view"
+msgstr "ფაილების სიის ხედში ნახვა"
+
+#: ../src/generic/filedlgg.cpp:197
+msgid "View files as a detailed view"
+msgstr "ფაილების დეტალური ხედის ნახვა"
+
+#: ../src/generic/filedlgg.cpp:200
+msgid "Go to parent directory"
+msgstr "ზედა საქაღალდეზე გადასვლა"
+
+#: ../src/generic/filedlgg.cpp:351 ../src/gtk/filedlg.cpp:59
+#, c-format
+msgid "File '%s' already exists, do you really want to overwrite it?"
+msgstr "ფაილი %s უკვე არსებობს. გნებავთ გადავაწერო?"
+
+#: ../src/generic/filedlgg.cpp:354 ../src/gtk/filedlg.cpp:62
+msgid "Confirm"
+msgstr "დადასტურება"
+
+#: ../src/generic/filedlgg.cpp:362 ../src/gtk/filedlg.cpp:75
+msgid "Please choose an existing file."
+msgstr "გთხოვთ აირჩიოთ არსებული ფაილი."
+
+#: ../src/generic/filepickerg.cpp:64
+msgid "..."
+msgstr "..."
+
+#: ../src/generic/fontdlgg.cpp:76 ../src/richtext/richtextformatdlg.cpp:519
+msgid "ABCDEFGabcdefg12345"
+msgstr "ABCDEFGabcdefg12345"
+
+#: ../src/generic/fontdlgg.cpp:315
+msgid "Roman"
+msgstr "რომანული"
+
+#: ../src/generic/fontdlgg.cpp:316
+msgid "Decorative"
+msgstr "დეკორატიული"
+
+#: ../src/generic/fontdlgg.cpp:317
+msgid "Modern"
+msgstr "თანამედროვე"
+
+#: ../src/generic/fontdlgg.cpp:318
+msgid "Script"
+msgstr "სკრიპტი"
+
+#: ../src/generic/fontdlgg.cpp:319
+msgid "Swiss"
+msgstr "შვეიცარიული"
+
+#: ../src/generic/fontdlgg.cpp:320
+msgid "Teletype"
+msgstr "ტელეტაიპი"
+
+#: ../src/generic/fontdlgg.cpp:321 ../src/generic/fontdlgg.cpp:324
+msgid "Normal"
+msgstr "ნორმალური"
+
+#: ../src/generic/fontdlgg.cpp:323
+msgid "Slant"
+msgstr "დაცერება"
+
+#: ../src/generic/fontdlgg.cpp:325
+msgid "Light"
+msgstr "ღია"
+
+#: ../src/generic/fontdlgg.cpp:363
+msgid "&Font family:"
+msgstr "&ფონტის ოჯახი:"
+
+#: ../src/generic/fontdlgg.cpp:367 ../src/generic/fontdlgg.cpp:369
+msgid "The font family."
+msgstr "ფონტის ოჯახი."
+
+#: ../src/generic/fontdlgg.cpp:374 ../src/richtext/richtextstylepage.cpp:105
+msgid "&Style:"
+msgstr "&სტილი:"
+
+#: ../src/generic/fontdlgg.cpp:378 ../src/generic/fontdlgg.cpp:380
+msgid "The font style."
+msgstr "ფონტის სტილი."
+
+#: ../src/generic/fontdlgg.cpp:385
+msgid "&Weight:"
+msgstr "&წონა:"
+
+#: ../src/generic/fontdlgg.cpp:389 ../src/generic/fontdlgg.cpp:391
+msgid "The font weight."
+msgstr "ფონტის წონა."
+
+#: ../src/generic/fontdlgg.cpp:399
+msgid "C&olour:"
+msgstr "&ფერი:"
+
+#: ../src/generic/fontdlgg.cpp:407 ../src/generic/fontdlgg.cpp:409
+msgid "The font colour."
+msgstr "ფონტის ფერი."
+
+#: ../src/generic/fontdlgg.cpp:415
+msgid "&Point size:"
+msgstr "წერტილის &ზომა:"
+
+#: ../src/generic/fontdlgg.cpp:420 ../src/generic/fontdlgg.cpp:422
+#: ../src/generic/fontdlgg.cpp:426 ../src/generic/fontdlgg.cpp:428
+msgid "The font point size."
+msgstr "ფონტის წერტილის ზომა."
+
+#: ../src/generic/fontdlgg.cpp:439 ../src/generic/fontdlgg.cpp:441
+msgid "Whether the font is underlined."
+msgstr "არის თუ არა ფონტი ხასგაზმული."
+
+#: ../src/generic/fontdlgg.cpp:448 ../src/html/helpwnd.cpp:1215
+msgid "Preview:"
+msgstr "წინასწარი ნახვა:"
+
+#: ../src/generic/fontdlgg.cpp:452 ../src/generic/fontdlgg.cpp:454
+msgid "Shows the font preview."
+msgstr "ფონტის გადახედვის ჩვენება."
+
+#: ../src/generic/fontdlgg.cpp:464 ../src/generic/fontdlgg.cpp:483
+msgid "Click to cancel the font selection."
+msgstr "წკაპი ფონტის არჩევის გაუქებისთვის."
+
+#: ../src/generic/fontdlgg.cpp:469 ../src/generic/fontdlgg.cpp:471
+#: ../src/generic/fontdlgg.cpp:476 ../src/generic/fontdlgg.cpp:478
+msgid "Click to confirm the font selection."
+msgstr "წკაპი ფონტის არჩევანის დასადასტურებლად."
+
+#: ../src/generic/fontpickerg.cpp:50 ../src/gtk/fontdlg.cpp:77
+msgid "Choose font"
+msgstr "აირჩიეთ ფონტი"
+
+#: ../src/generic/grid.cpp:6542
+msgid ""
+"Error copying grid to the clipboard. Either selected cells were not "
+"contiguous or no cell was selected."
+msgstr ""
+
+#: ../src/generic/grid.cpp:12739
+msgid "Grid Corner"
+msgstr "ბადის კუთხე"
+
+#: ../src/generic/grid.cpp:12741
+#, c-format
+msgid "Column %s Header"
+msgstr "სვეტი %s თავსართი"
+
+#: ../src/generic/grid.cpp:12743
+#, c-format
+msgid "Row %s Header"
+msgstr "მწკრივი %s თავსართი"
+
+#: ../src/generic/grid.cpp:12745
+#, c-format
+msgid "Column %s: %s"
+msgstr "სვეტი %s: %s"
+
+#: ../src/generic/grid.cpp:12749
+#, c-format
+msgid "Row %s: %s"
+msgstr "მწკრივი %s: %s"
+
+#: ../src/generic/grid.cpp:12753
+#, c-format
+msgid "Row %s, Column %s: %s"
+msgstr "მწკრივი %s, სვეტი %s: %s"
+
+#: ../src/generic/helpext.cpp:257
+#, c-format
+msgid "Help directory \"%s\" not found."
+msgstr "დახმარების საქაღალდე %s არ არსებობს."
+
+#: ../src/generic/helpext.cpp:265
+#, c-format
+msgid "Help file \"%s\" not found."
+msgstr "დახმარების ფაილი %s არ არსებობს."
+
+#: ../src/generic/helpext.cpp:284
+#, c-format
+msgid "Line %lu of map file \"%s\" has invalid syntax, skipped."
+msgstr ""
+"ხაზზე %lu რუკის ფაილში \"%s\" აღმოჩენილია არასწორი სინტაქსი. გამოტოვებულია."
+
+#: ../src/generic/helpext.cpp:292
+#, c-format
+msgid "No valid mappings found in the file \"%s\"."
+msgstr "ფაილში %s სწორი მიბმები ვერ ვიპოვე."
+
+#: ../src/generic/helpext.cpp:435
+msgid "No entries found."
+msgstr "ჩანაწერების გარეშე."
+
+#: ../src/generic/helpext.cpp:444 ../src/generic/helpext.cpp:445
+msgid "Help Index"
+msgstr "დახმარების ინდექსი"
+
+#: ../src/generic/helpext.cpp:448
+msgid "Relevant entries:"
+msgstr "შესაბამისი ჩანაწერები:"
+
+#: ../src/generic/helpext.cpp:449
+msgid "Entries found"
+msgstr "ნაპოვნი ჩანაწერები"
+
+#: ../src/generic/hyperlinkg.cpp:170
+msgid "&Copy URL"
+msgstr "&URL-ის კოპირება"
+
+#: ../src/generic/infobar.cpp:119
+msgid "Hide this notification message."
+msgstr "გაფრთხილების ამ შეტყობინების დამალვა."
+
+#. TRANSLATORS: %s will be either the application name or "Application"
+#: ../src/generic/logg.cpp:257
+#, c-format
+msgid "%s Error"
+msgstr "%s: შეცდომა"
+
+#. TRANSLATORS: %s will be either the application name or "Application"
+#: ../src/generic/logg.cpp:263
+#, c-format
+msgid "%s Warning"
+msgstr "%s: გაფრთხილება"
+
+#. TRANSLATORS: %s will be either the application name or "Application"
+#: ../src/generic/logg.cpp:273
+#, c-format
+msgid "%s Information"
+msgstr "%s ინფორმაცია"
+
+#: ../src/generic/logg.cpp:276
+msgid "Application"
+msgstr "აპლიკაცია"
+
+#: ../src/generic/logg.cpp:549
+msgid "Save log contents to file"
+msgstr "ჟურნალის შემცველობის ფაილში ჩაწერა"
+
+#: ../src/generic/logg.cpp:551
+msgid "C&lear"
+msgstr "გასუ&ფთავება"
+
+#: ../src/generic/logg.cpp:551
+msgid "Clear the log contents"
+msgstr "ჟურნალის შემცველობის გასუფთავება"
+
+#: ../src/generic/logg.cpp:553
+msgid "Close this window"
+msgstr "ამ ფანჯრის დახურვა"
+
+#: ../src/generic/logg.cpp:554
+msgid "&Log"
+msgstr "&ჟურნალი"
+
+#: ../src/generic/logg.cpp:610 ../src/generic/logg.cpp:992
+msgid "Can't save log contents to file."
+msgstr "ჟურნალის შემცველობის ფაილში ჩაწერის შეცდომა."
+
+#: ../src/generic/logg.cpp:613
+#, c-format
+msgid "Log saved to the file '%s'."
+msgstr "ჟურნალი შენახულია ფაილში: %s."
+
+#: ../src/generic/logg.cpp:719
+msgid "&Details"
+msgstr "&დეტალები"
+
+#: ../src/generic/logg.cpp:972
+msgid "Failed to copy dialog contents to the clipboard."
+msgstr "ფანჯრის შემცველობის მიმოცვლის ბაფერში კოპირების შეცდომა."
+
+#: ../src/generic/logg.cpp:1022
+#, c-format
+msgid "Append log to file '%s' (choosing [No] will overwrite it)?"
+msgstr ""
+"მივაწერო ჟურნალის ფაილს (%s) ბოლოში (თუ აირჩევთ არას, თავზე გადაეწერება)?"
+
+#: ../src/generic/logg.cpp:1024
+msgid "Question"
+msgstr "კითხვა"
+
+#: ../src/generic/logg.cpp:1038
+msgid "invalid message box return value"
+msgstr "შეტყობინების ფანჯრიდან დაბრუნებული მნიშვნელობა დაუშვებელია"
+
+#: ../src/generic/notifmsgg.cpp:129
+msgid "Notice"
+msgstr "გაფრთხილება"
+
+#: ../src/generic/preferencesg.cpp:118
+#, c-format
+msgid "%s Preferences"
+msgstr "%s მორგება"
+
+#: ../src/generic/printps.cpp:143
+msgid "Printing..."
+msgstr "დაბეჭდვა..."
+
+#: ../src/generic/printps.cpp:160 ../src/gtk/print.cpp:1076
+#: ../src/msw/printwin.cpp:235
+msgid "Could not start printing."
+msgstr "ბეჭდვის დაწყება შეუძლებელია."
+
+#: ../src/generic/printps.cpp:183
+#, c-format
+msgid "Printing page %d..."
+msgstr "იბეჭდება გვერდი %d..."
+
+#: ../src/generic/prntdlgg.cpp:171
+msgid "Printer options"
+msgstr "პრინტერის მორგება"
+
+#: ../src/generic/prntdlgg.cpp:176
+msgid "Print to File"
+msgstr "ფაილში ბეჭდვა"
+
+#: ../src/generic/prntdlgg.cpp:179
+msgid "Setup..."
+msgstr "მორგება..."
+
+#: ../src/generic/prntdlgg.cpp:187
+msgid "Printer:"
+msgstr "პრინტერი:"
+
+#: ../src/generic/prntdlgg.cpp:195
+msgid "Status:"
+msgstr "მდგომარეობა:"
+
+#: ../src/generic/prntdlgg.cpp:206
+msgid "All"
+msgstr "ყველა"
+
+#: ../src/generic/prntdlgg.cpp:207
+msgid "Pages"
+msgstr "გვერდი"
+
+#: ../src/generic/prntdlgg.cpp:215
+msgid "Print Range"
+msgstr "ბეჭდვის დიაპაზონი"
+
+#: ../src/generic/prntdlgg.cpp:229
+msgid "From:"
+msgstr "ვისგან:"
+
+#: ../src/generic/prntdlgg.cpp:233
+msgid "To:"
+msgstr "სადამდე:"
+
+#: ../src/generic/prntdlgg.cpp:238
+msgid "Copies:"
+msgstr "ასლები:"
+
+#: ../src/generic/prntdlgg.cpp:288
+msgid "PostScript file"
+msgstr "PostScript ფაილი"
+
+#: ../src/generic/prntdlgg.cpp:439
+msgid "Print Setup"
+msgstr "ბეჭდვის მორგება"
+
+#: ../src/generic/prntdlgg.cpp:483
+msgid "Printer"
+msgstr "პრინტერი"
+
+#: ../src/generic/prntdlgg.cpp:501
+msgid "Default printer"
+msgstr "ნაგულისხმები პრინტერი"
+
+#: ../src/generic/prntdlgg.cpp:595 ../src/generic/prntdlgg.cpp:782
+#: ../src/generic/prntdlgg.cpp:822 ../src/generic/prntdlgg.cpp:835
+#: ../src/generic/prntdlgg.cpp:1031 ../src/generic/prntdlgg.cpp:1036
+msgid "Paper size"
+msgstr "გვერდის ზომა"
+
+#: ../src/generic/prntdlgg.cpp:604 ../src/generic/prntdlgg.cpp:847
+msgid "Portrait"
+msgstr "პორტრეტი"
+
+#: ../src/generic/prntdlgg.cpp:605 ../src/generic/prntdlgg.cpp:848
+msgid "Landscape"
+msgstr "ლანდშაფტი"
+
+#: ../src/generic/prntdlgg.cpp:607 ../src/generic/prntdlgg.cpp:849
+msgid "Orientation"
+msgstr "ორიენტაცია"
+
+#: ../src/generic/prntdlgg.cpp:610
+msgid "Options"
+msgstr "პარამეტრები"
+
+#: ../src/generic/prntdlgg.cpp:612
+msgid "Print in colour"
+msgstr "ფერადი ბეჭდვა"
+
+#: ../src/generic/prntdlgg.cpp:621
+msgid "Print spooling"
+msgstr "ბეჭდვის რიგი"
+
+#: ../src/generic/prntdlgg.cpp:623
+msgid "Printer command:"
+msgstr "პრინტერის ბრძანება:"
+
+#: ../src/generic/prntdlgg.cpp:631
+msgid "Printer options:"
+msgstr "პრინტერის პარამეტრები:"
+
+#: ../src/generic/prntdlgg.cpp:860
+msgid "Left margin (mm):"
+msgstr "მარცხენა ზღვარი (მმ):"
+
+#: ../src/generic/prntdlgg.cpp:861
+msgid "Top margin (mm):"
+msgstr "მარცხენა ზღვარი (მმ):"
+
+#: ../src/generic/prntdlgg.cpp:872
+msgid "Right margin (mm):"
+msgstr "მარცხენა ზღვარი (მმ):"
+
+#: ../src/generic/prntdlgg.cpp:873
+msgid "Bottom margin (mm):"
+msgstr "ქვედა ზღვარი (მმ):"
+
+#: ../src/generic/prntdlgg.cpp:896
+msgid "Printer..."
+msgstr "პრინტერი..."
+
+#: ../src/generic/progdlgg.cpp:246
+msgid "&Skip"
+msgstr "გამო&ტოვება"
+
+#: ../src/generic/progdlgg.cpp:347 ../src/generic/progdlgg.cpp:626
+msgid "Unknown"
+msgstr "უცნობი"
+
+#: ../src/generic/progdlgg.cpp:451 ../src/msw/progdlg.cpp:526
+msgid "Done."
+msgstr "მზადაა."
+
+#: ../src/generic/srchctlg.cpp:55 ../src/gtk/srchctrl.cpp:206
+#: ../src/html/helpwnd.cpp:530 ../src/html/helpwnd.cpp:545
+msgid "Search"
+msgstr "_ძებნა"
+
+#: ../src/generic/tabg.cpp:1026
+msgid "Could not find tab for id"
+msgstr "ჩანარდის პოვნა ID-სთვის შეუძლებელია"
+
+#: ../src/generic/tipdlg.cpp:136
+msgid "Tips not available, sorry!"
+msgstr "მინიშნებები მიუწვდომელია. ბოდიში!"
+
+#: ../src/generic/tipdlg.cpp:197
+msgid "Tip of the Day"
+msgstr "დღის მინიშნება"
+
+#: ../src/generic/tipdlg.cpp:207
+msgid "Did you know..."
+msgstr "იცოდით, რომ..."
+
+#: ../src/generic/tipdlg.cpp:232
+msgid "&Show tips at startup"
+msgstr "&გაშვებისას მინიშნებების ჩვენება"
+
+#: ../src/generic/tipdlg.cpp:236
+msgid "&Next Tip"
+msgstr "&შემდეგი მინიშნება"
+
+#: ../src/generic/wizard.cpp:411
+msgid "&Next >"
+msgstr "&შემდეგი >"
+
+#: ../src/generic/wizard.cpp:412
+msgid "&Finish"
+msgstr "&დასრულება"
+
+#: ../src/generic/wizard.cpp:420
+msgid "< &Back"
+msgstr "< &უკან"
+
+#: ../src/gtk/aboutdlg.cpp:204
+msgid "translator-credits"
+msgstr "თემური დოღონაძე"
+
+#: ../src/gtk/app.cpp:517
+msgid ""
+"WARNING: using XIM input method is unsupported and may result in problems "
+"with input handling and flickering. Consider unsetting GTK_IM_MODULE or "
+"setting to \"ibus\"."
+msgstr ""
+
+#: ../src/gtk/app.cpp:569
+msgid "Unable to initialize GTK+, is DISPLAY set properly?"
+msgstr "GTK+-ის ინიციალიზაციის შეცდომა. DISPLAY სწორადაა დაყენებული?"
+
+#: ../src/gtk/filedlg.cpp:89 ../src/gtk/filepicker.cpp:255
+#, c-format
+msgid "Changing current directory to \"%s\" failed"
+msgstr "მიმდინარე საქაღალდის %s-ზე შეცვლის შეცდომა"
+
+#: ../src/gtk/font.cpp:548
+msgid ""
+"Using private fonts is not supported on this system: Pango library is too "
+"old, 1.38 or later required."
+msgstr ""
+
+#: ../src/gtk/font.cpp:558
+msgid "Failed to create font configuration object."
+msgstr "ფონტის კონფიგურაციის ობიექტის შექმნის შეცდომა."
+
+#: ../src/gtk/font.cpp:568
+#, c-format
+msgid "Failed to add custom font \"%s\"."
+msgstr "თქვენი ფონტის დამატების შეცდომა: %s."
+
+#: ../src/gtk/font.cpp:576
+msgid "Failed to register font configuration using private fonts."
+msgstr "პირადი ფონტების გამოყენებით ფონტის რეგისტრაციის შეცდომა."
+
+#: ../src/gtk/glcanvas.cpp:117 ../src/gtk/glcanvas.cpp:132
+msgid "Fatal Error"
+msgstr "ფატალური შეცდომა"
+
+#: ../src/gtk/glcanvas.cpp:117
+msgid ""
+"This program wasn't compiled with EGL support required under Wayland, "
+"either\n"
+"install EGL libraries and rebuild or run it under X11 backend by setting\n"
+"environment variable GDK_BACKEND=x11 before starting your program."
+msgstr ""
+
+#: ../src/gtk/glcanvas.cpp:132
+msgid ""
+"wxGLCanvas is only supported on Wayland and X11 currently.  You may be able "
+"to\n"
+"work around this by setting environment variable GDK_BACKEND=x11 before\n"
+"starting your program."
+msgstr ""
+
+#: ../src/gtk/mdi.cpp:433
+msgid "MDI child"
+msgstr "MDI შვილი"
+
+#: ../src/gtk/power.cpp:188
+#, c-format
+msgid "Failed to open D-Bus connection to the login manager: %s"
+msgstr "D-Bus-ის კავშირის გახსნა შესვლის მენეჯერთან ჩავარდა: %s"
+
+#: ../src/gtk/power.cpp:214
+msgid "wxWidgets application"
+msgstr "wxWidgets-ის აპლიკაცია"
+
+#: ../src/gtk/power.cpp:226
+msgid "Application needs to keep running"
+msgstr "აპლიკაციის შესრულება უნდა გაგრძელდეს"
+
+#: ../src/gtk/power.cpp:233
+msgid "Clean up before suspend"
+msgstr "გასუფთავება შეჩერებამდე"
+
+#: ../src/gtk/power.cpp:259
+#, c-format
+msgid "Failed to inhibit sleep: %s"
+msgstr "ძილის დათრგუნვა ვერ მოხერხდა: %s"
+
+#: ../src/gtk/power.cpp:265
+msgid "Unexpected response to D-Bus \"Inhibit\" request."
+msgstr "მოულოდნელი პასუხი D-Bus-ის მოთხოვნაზე \"inhibit\"."
+
+#: ../src/gtk/print.cpp:218
+msgid "Custom size"
+msgstr "მორგებული ზომა"
+
+#: ../src/gtk/print.cpp:752
+#, c-format
+msgid "Error while printing: %s"
+msgstr "შეცდომა ბეჭდვისას: %s"
+
+#: ../src/gtk/print.cpp:816
+msgid "Page Setup"
+msgstr "გვერდის მორგება"
+
+#: ../src/gtk/webview_webkit.cpp:932
+msgid "Retrieving JavaScript script output is not supported with WebKit v1"
+msgstr ""
+"WebKit v1-ში JavaScript-ის გამოტანილი ინფორმაციის მიღება მხარდაჭერილი არაა"
+
+#: ../src/gtk/webview_webkit2.cpp:1098
+msgid ""
+"Setting proxy is not supported by WebKit, at least version 2.16 is required."
+msgstr ""
+"WebKit-ს პროქსის დაყენების მხარდაჭერა არ გააჩნია. აუცილებელი მინიმალური "
+"ვერსიაა 2.16."
+
+#: ../src/gtk/webview_webkit2.cpp:1104
+msgid "This program was compiled without support for setting WebKit proxy."
+msgstr "ეს პროგრამა აგებულია WebKit-ის პროქსის დაყენების მხარდაჭერის გარეშე."
+
+#: ../src/gtk/window.cpp:6289
+msgid ""
+"GTK+ installed on this machine is too old to support screen compositing, "
+"please install GTK+ 2.12 or later."
+msgstr ""
+
+#: ../src/gtk/window.cpp:6307
+msgid ""
+"Compositing not supported by this system, please enable it in your Window "
+"Manager."
+msgstr ""
+
+#: ../src/gtk/window.cpp:6318
+msgid ""
+"This program was compiled with a too old version of GTK+, please rebuild "
+"with GTK+ 2.12 or newer."
+msgstr ""
+
+#: ../src/html/chm.cpp:138
+#, c-format
+msgid "Failed to open CHM archive '%s'."
+msgstr "CHM არქივის გახსნის შეცდომა: %s."
+
+#: ../src/html/chm.cpp:270
+#, c-format
+msgid "Could not extract %s into %s: %s"
+msgstr "%s-ის %s-ში გაშლის შეცდომა: %s"
+
+#: ../src/html/chm.cpp:324
+msgid "no error"
+msgstr "შეცდომის გარეშე"
+
+#: ../src/html/chm.cpp:326
+msgid "bad arguments to library function"
+msgstr "ბიბლიოთეკის ფუნქციის არასწორი არგუმენტები"
+
+#: ../src/html/chm.cpp:328
+msgid "error opening file"
+msgstr "შეცდომა ფაილის გახსნისას"
+
+#: ../src/html/chm.cpp:330
+msgid "read error"
+msgstr "წაკითხვის შეცდომა"
+
+#: ../src/html/chm.cpp:332
+msgid "write error"
+msgstr "ჩაწერის შეცდომა"
+
+#: ../src/html/chm.cpp:334
+msgid "seek error"
+msgstr "ძიების შეცდომა"
+
+#: ../src/html/chm.cpp:338
+msgid "bad signature"
+msgstr "არასწორი ხელმოწერა"
+
+#: ../src/html/chm.cpp:340
+msgid "error in data format"
+msgstr "მონაცემების უცნობი ფორმატი"
+
+#: ../src/html/chm.cpp:342
+msgid "checksum error"
+msgstr "საკონტროლო ჯამის შეცდომა"
+
+#: ../src/html/chm.cpp:344
+msgid "compression error"
+msgstr "შეკუმშვის შეცდომა"
+
+#: ../src/html/chm.cpp:346
+msgid "decompression error"
+msgstr "გაშლის შეცდომა"
+
+#: ../src/html/chm.cpp:437
+#, c-format
+msgid "Could not locate file '%s'."
+msgstr "ფაილის (\"%s\") მოძებნა შეუძლებელია."
+
+#: ../src/html/chm.cpp:711
+#, c-format
+msgid "Could not create temporary file '%s'"
+msgstr "დროებითი ფაილის შექმნის შეცდომა (%s)"
+
+#: ../src/html/chm.cpp:718
+#, c-format
+msgid "Extraction of '%s' into '%s' failed."
+msgstr "%s-ის %s-ში გაშლის პრობლემა."
+
+#: ../src/html/chm.cpp:806 ../src/html/chm.cpp:863
+msgid "CHM handler currently supports only local files!"
+msgstr ""
+"CHM ფაილების დამმუშავებელს ამჟამად მხოლოდ ლოკალური ფაილების აღქმა შეუძლია!"
+
+#: ../src/html/chm.cpp:827
+msgid "Link contained '//', converted to absolute link."
+msgstr "ბმული შეიცავდა '//', აბსოლუტურ ბმულად გადავაკეთე."
+
+#: ../src/html/helpctrl.cpp:59
+#, c-format
+msgid "Help: %s"
+msgstr "დახმარება: %s"
+
+#: ../src/html/helpctrl.cpp:155
+#, c-format
+msgid "Adding book %s"
+msgstr "მისამართების წიგნი %s"
+
+#: ../src/html/helpdata.cpp:295
+#, c-format
+msgid "Cannot open contents file: %s"
+msgstr "შემცველობის ფაილის გახსნის შეცდომა: %s"
+
+#: ../src/html/helpdata.cpp:309
+#, c-format
+msgid "Cannot open index file: %s"
+msgstr "ინდექსის ფაილის გახსნის შეცდომა: %s"
+
+#: ../src/html/helpdata.cpp:643
+msgid "noname"
+msgstr "უსახელო"
+
+#: ../src/html/helpdata.cpp:652
+#, c-format
+msgid "Cannot open HTML help book: %s"
+msgstr "HTML დახმარების წიგნის გახსნის შეცდომა: %s"
+
+#: ../src/html/helpwnd.cpp:315
+msgid "Displays help as you browse the books on the left."
+msgstr "აჩვენებს დახმარებას მაშინ, როცა თქვენ მარცხნივ წიგნს ათვალიერებთ."
+
+#: ../src/html/helpwnd.cpp:411 ../src/html/helpwnd.cpp:1100
+#: ../src/html/helpwnd.cpp:1735
+msgid "(bookmarks)"
+msgstr "(სანიშნები)"
+
+#: ../src/html/helpwnd.cpp:424
+msgid "Add current page to bookmarks"
+msgstr "მიმდინარე გვერდის რჩეულებში დამატება"
+
+#: ../src/html/helpwnd.cpp:425
+msgid "Remove current page from bookmarks"
+msgstr "მიმდინარე გვერდის რჩეულებიდან წაშლა"
+
+#: ../src/html/helpwnd.cpp:470
+msgid "Contents"
+msgstr "შიგთავსი"
+
+#: ../src/html/helpwnd.cpp:485
+msgid "Find"
+msgstr "ძიება"
+
+#: ../src/html/helpwnd.cpp:487
+msgid "Show all"
+msgstr "ყველას ჩვენება"
+
+#: ../src/html/helpwnd.cpp:497
+msgid ""
+"Display all index items that contain given substring. Search is case "
+"insensitive."
+msgstr ""
+
+#: ../src/html/helpwnd.cpp:498
+msgid "Show all items in index"
+msgstr "ინდექსის ყველა ჩანაწერის ჩვენება"
+
+#: ../src/html/helpwnd.cpp:528
+msgid "Case sensitive"
+msgstr "დიდი და პატარა ასოების განსხვავება"
+
+#: ../src/html/helpwnd.cpp:529
+msgid "Whole words only"
+msgstr "მხოლოდ მთლიანი სიტყვები"
+
+#: ../src/html/helpwnd.cpp:532
+msgid ""
+"Search contents of help book(s) for all occurrences of the text you typed "
+"above"
+msgstr ""
+
+#: ../src/html/helpwnd.cpp:653
+msgid "Show/hide navigation panel"
+msgstr "ნავიგაციის პანელის ჩართ/გამორთ"
+
+#: ../src/html/helpwnd.cpp:655
+msgid "Go back"
+msgstr "უკან დაბრუნება"
+
+#: ../src/html/helpwnd.cpp:656
+msgid "Go forward"
+msgstr "წინ გადასვლა"
+
+#: ../src/html/helpwnd.cpp:658
+msgid "Go one level up in document hierarchy"
+msgstr "დოკუმენტების იერარქიაში ერთი დონით მაღლა აწევა"
+
+#: ../src/html/helpwnd.cpp:666 ../src/html/helpwnd.cpp:1547
+msgid "Open HTML document"
+msgstr "HTML დოკუმენტის გახსნა"
+
+#: ../src/html/helpwnd.cpp:670
+msgid "Print this page"
+msgstr "ამ გვერდის დაბეჭდვა"
+
+#: ../src/html/helpwnd.cpp:674
+msgid "Display options dialog"
+msgstr "მორგების ფანჯრის ჩვენება"
+
+#: ../src/html/helpwnd.cpp:795
+msgid "Please choose the page to display:"
+msgstr "საჩვენებელი გვერდის არჩევა:"
+
+#: ../src/html/helpwnd.cpp:796
+msgid "Help Topics"
+msgstr "დახმარების თემები"
+
+#: ../src/html/helpwnd.cpp:852
+msgid "Searching..."
+msgstr "ძებნა..."
+
+#: ../src/html/helpwnd.cpp:853
+msgid "No matching page found yet"
+msgstr "შესამაბისი გვერდი ჯერ ვერ ვიპოვე"
+
+#: ../src/html/helpwnd.cpp:870
+#, c-format
+msgid "Found %i matches"
+msgstr "ნაპოვნია %i დამთხვევა"
+
+#: ../src/html/helpwnd.cpp:958
+msgid "(Help)"
+msgstr "(დახმარება)"
+
+#: ../src/html/helpwnd.cpp:1026
+#, c-format
+msgid "%d of %lu"
+msgstr "%d %lu-დან"
+
+#: ../src/html/helpwnd.cpp:1028
+#, c-format
+msgid "%lu of %lu"
+msgstr "%lu %lu-დან"
+
+#: ../src/html/helpwnd.cpp:1047
+msgid "Search in all books"
+msgstr "ყველა წიგნში ძებნა"
+
+#: ../src/html/helpwnd.cpp:1193
+msgid "Help Browser Options"
+msgstr "დახმარების ბრაუზერის მორგება"
+
+#: ../src/html/helpwnd.cpp:1198
+msgid "Normal font:"
+msgstr "ნორმალური ფონტი:"
+
+#: ../src/html/helpwnd.cpp:1199
+msgid "Fixed font:"
+msgstr "ფიქსირებული ფონტი:"
+
+#: ../src/html/helpwnd.cpp:1200
+msgid "Font size:"
+msgstr "ფონტის ზომა:"
+
+#: ../src/html/helpwnd.cpp:1245
+msgid "font size"
+msgstr "ფონტის ზომა"
+
+#: ../src/html/helpwnd.cpp:1256
+msgid "Normal face<br>and <u>underlined</u>. "
+msgstr "ნორმალური <br>და<u>გაზგასმული</u>. "
+
+#: ../src/html/helpwnd.cpp:1257
+msgid "<i>Italic face.</i> "
+msgstr "<i>დახრილი ტექსტი.</i> "
+
+#: ../src/html/helpwnd.cpp:1258
+msgid "<b>Bold face.</b> "
+msgstr "<b>სქელი ტექსტი.</b> "
+
+#: ../src/html/helpwnd.cpp:1259
+msgid "<b><i>Bold italic face.</i></b><br>"
+msgstr "<b><i>სქელი კურსივი ტექსტი.</i></b><br>"
+
+#: ../src/html/helpwnd.cpp:1262
+msgid "Fixed size face.<br> <b>bold</b> <i>italic</i> "
+msgstr "ფიქსირებული სახის ფონტი.<br> <b>სქელი</b> <i>კურსივი</i> "
+
+#: ../src/html/helpwnd.cpp:1263
+msgid "<b><i>bold italic <u>underlined</u></i></b><br>"
+msgstr "<b><i>სქელი კურსივი <u>გაზგასმული</u></i></b><br>"
+
+#: ../src/html/helpwnd.cpp:1524
+msgid "Help Printing"
+msgstr "ბეჭდვის დახმარება"
+
+#: ../src/html/helpwnd.cpp:1527
+msgid "Cannot print empty page."
+msgstr "ცარიელი გვერდის დაბეჭდვა შეუძლებელია."
+
+#: ../src/html/helpwnd.cpp:1540
+msgid "HTML files (*.html;*.htm)|*.html;*.htm|"
+msgstr "HTML ფაილები (*.html;*.htm)|*.html;*.htm|"
+
+#: ../src/html/helpwnd.cpp:1541
+msgid "Help books (*.htb)|*.htb|Help books (*.zip)|*.zip|"
+msgstr "დახმარების წიგნები (*.htb)|*.htb|Help books (*.zip)|*.zip|"
+
+#: ../src/html/helpwnd.cpp:1542
+msgid "HTML Help Project (*.hhp)|*.hhp|"
+msgstr "HTML დახმარების პროექტი (*.hhp)|*.hhp|"
+
+#: ../src/html/helpwnd.cpp:1544
+msgid "Compressed HTML Help file (*.chm)|*.chm|"
+msgstr "დახმარების შეკუმშული HTML ფაილი (*.chm)|*.chm|"
+
+#: ../src/html/helpwnd.cpp:1671
+#, c-format
+msgid "%i of %u"
+msgstr "%i %u-დან"
+
+#: ../src/html/helpwnd.cpp:1709
+#, c-format
+msgid "%u of %u"
+msgstr "%u %u-დან"
+
+#: ../src/html/htmlfilt.cpp:134
+#, c-format
+msgid "Cannot open HTML document: %s"
+msgstr "HTML დოკუმენტის გახსნის შეცდომა: %s"
+
+#: ../src/html/htmlwin.cpp:599
+msgid "Connecting..."
+msgstr "დაკავშირება…"
+
+#: ../src/html/htmlwin.cpp:616
+#, c-format
+msgid "Unable to open requested HTML document: %s"
+msgstr "მოთხოვნილი HTML დოკუმენტის გახსნის შეცდომა: %s"
+
+#: ../src/html/htmlwin.cpp:630
+msgid "Loading : "
+msgstr "ჩატვირთვა : "
+
+#: ../src/html/htmlwin.cpp:673
+msgid "Done"
+msgstr "დასრულდა"
+
+#: ../src/html/htmlwin.cpp:723
+#, c-format
+msgid "HTML anchor %s does not exist."
+msgstr "HTML anchor %s არ არსებობს."
+
+#: ../src/html/htmlwin.cpp:1057
+#, c-format
+msgid "Copied to clipboard:\"%s\""
+msgstr "დაკოპირდა გაცვლის ბაფერში: %s"
+
+#: ../src/html/htmprint.cpp:269
+msgid ""
+"This document doesn't fit on the page horizontally and will be truncated "
+"when it is printed."
+msgstr ""
+
+#: ../src/html/htmprint.cpp:285
+#, c-format
+msgid ""
+"The document \"%s\" doesn't fit on the page horizontally and will be "
+"truncated if printed.\n"
+"\n"
+"Would you like to proceed with printing it nevertheless?"
+msgstr ""
+
+#: ../src/html/htmprint.cpp:296
+msgid ""
+"If possible, try changing the layout parameters to make the printout more "
+"narrow."
+msgstr ""
+
+#: ../src/html/htmprint.cpp:445
+msgid ": file does not exist!"
+msgstr ": ფაილი არ არსებობს!"
+
+#. TRANSLATORS: %s may be a document title.
+#: ../src/html/htmprint.cpp:717
+#, c-format
+msgid "%s Preview"
+msgstr "%s-ის მინიატურა"
+
+#: ../src/html/htmprint.cpp:755 ../src/richtext/richtextprint.cpp:618
+msgid ""
+"There was a problem during page setup: you may need to set a default printer."
+msgstr ""
+
+#: ../src/msw/clipbrd.cpp:80
+msgid "Failed to open the clipboard."
+msgstr "მიმოცვლის ბაფერის გახსნის შეცდომა."
+
+#: ../src/msw/clipbrd.cpp:101
+msgid "Failed to close the clipboard."
+msgstr "მიმოცვლის ბაფერის დახურვის შეცდომა."
+
+#: ../src/msw/clipbrd.cpp:113
+msgid "Failed to empty the clipboard."
+msgstr "მიმოცვლის ბაფერის გასუფთავების შეცდომა."
+
+#: ../src/msw/clipbrd.cpp:284
+msgid "Failed to put data on the clipboard"
+msgstr "მიმოცვლის ბაფერში მონაცემების ჩაწერის შეცდომა"
+
+#: ../src/msw/clipbrd.cpp:326
+msgid "Failed to get data from the clipboard"
+msgstr "მიმოცვლის ბაფერიდან მონაცემების წაკითხვის შეცდომა"
+
+#: ../src/msw/clipbrd.cpp:363
+msgid "Failed to retrieve the supported clipboard formats"
+msgstr "მიმოცვლის ბაფერის მხარდაჭერილი ფორმატების სიის მიღების შეცდომა"
+
+#: ../src/msw/colordlg.cpp:228
+#, c-format
+msgid "Colour selection dialog failed with error %0lx."
+msgstr "ფერის არჩევის ფანჯრის ავარია შეცდომის კოდით %0lx."
+
+#: ../src/msw/cursor.cpp:141
+msgid "Failed to create cursor."
+msgstr "კურსორის შექმნის შეცდომა."
+
+#: ../src/msw/dde.cpp:279
+#, c-format
+msgid "Failed to register DDE server '%s'"
+msgstr "DDE სერვერის რეგისტრაციის შეცდომა: %s"
+
+#: ../src/msw/dde.cpp:300
+#, c-format
+msgid "Failed to unregister DDE server '%s'"
+msgstr "DDE სერვერის რეგისტრაციის გაუქმების შეცდომა: %s"
+
+#: ../src/msw/dde.cpp:428
+#, c-format
+msgid "Failed to create connection to server '%s' on topic '%s'"
+msgstr ""
+
+#: ../src/msw/dde.cpp:655
+msgid "DDE poke request failed"
+msgstr "DDE poke მოთხოვნის შეცდომა"
+
+#: ../src/msw/dde.cpp:674
+msgid "Failed to establish an advise loop with DDE server"
+msgstr ""
+
+#: ../src/msw/dde.cpp:693
+msgid "Failed to terminate the advise loop with DDE server"
+msgstr "რჩვევების მარყუჟის შეჩერება DDE სერვერთან ჩავარდა"
+
+#: ../src/msw/dde.cpp:768
+msgid "Failed to send DDE advise notification"
+msgstr "DDE რჩევის გაფრთხილების გაგზავნა ჩავარდა"
+
+#: ../src/msw/dde.cpp:1085
+msgid "Failed to create DDE string"
+msgstr "DDE სტრიქონის შექმნის შეცდომა"
+
+#: ../src/msw/dde.cpp:1131
+msgid "no DDE error."
+msgstr "\"DDE\"-ის შეცდომის გარეშე."
+
+#: ../src/msw/dde.cpp:1135
+msgid "a request for a synchronous advise transaction has timed out."
+msgstr ""
+
+#: ../src/msw/dde.cpp:1138
+msgid "the response to the transaction caused the DDE_FBUSY bit to be set."
+msgstr ""
+
+#: ../src/msw/dde.cpp:1141
+msgid "a request for a synchronous data transaction has timed out."
+msgstr ""
+
+#: ../src/msw/dde.cpp:1144
+msgid ""
+"a DDEML function was called without first calling the DdeInitialize "
+"function,\n"
+"or an invalid instance identifier\n"
+"was passed to a DDEML function."
+msgstr ""
+
+#: ../src/msw/dde.cpp:1147
+msgid ""
+"an application initialized as APPCLASS_MONITOR has\n"
+"attempted to perform a DDE transaction,\n"
+"or an application initialized as APPCMD_CLIENTONLY has \n"
+"attempted to perform server transactions."
+msgstr ""
+
+#: ../src/msw/dde.cpp:1150
+msgid "a request for a synchronous execute transaction has timed out."
+msgstr ""
+
+#: ../src/msw/dde.cpp:1153
+msgid "a parameter failed to be validated by the DDEML."
+msgstr ""
+
+#: ../src/msw/dde.cpp:1156
+msgid "a DDEML application has created a prolonged race condition."
+msgstr ""
+
+#: ../src/msw/dde.cpp:1159
+msgid "a memory allocation failed."
+msgstr "მეხსიერების გამოყოფის შეცდომა."
+
+#: ../src/msw/dde.cpp:1162
+msgid "a client's attempt to establish a conversation has failed."
+msgstr ""
+
+#: ../src/msw/dde.cpp:1165
+msgid "a transaction failed."
+msgstr "ტრანზაქციის შეცდომა."
+
+#: ../src/msw/dde.cpp:1168
+msgid "a request for a synchronous poke transaction has timed out."
+msgstr ""
+
+#: ../src/msw/dde.cpp:1171
+msgid "an internal call to the PostMessage function has failed. "
+msgstr ""
+
+#: ../src/msw/dde.cpp:1174
+msgid "reentrancy problem."
+msgstr "თავიდან შესვლის პრობლემა."
+
+#: ../src/msw/dde.cpp:1177
+msgid ""
+"a server-side transaction was attempted on a conversation\n"
+"that was terminated by the client, or the server\n"
+"terminated before completing a transaction."
+msgstr ""
+
+#: ../src/msw/dde.cpp:1180
+msgid "an internal error has occurred in the DDEML."
+msgstr "\"DDEML\"-ის შიდა შეცდომა."
+
+#: ../src/msw/dde.cpp:1183
+msgid "a request to end an advise transaction has timed out."
+msgstr ""
+
+#: ../src/msw/dde.cpp:1186
+msgid ""
+"an invalid transaction identifier was passed to a DDEML function.\n"
+"Once the application has returned from an XTYP_XACT_COMPLETE callback,\n"
+"the transaction identifier for that callback is no longer valid."
+msgstr ""
+
+#: ../src/msw/dde.cpp:1189
+#, c-format
+msgid "Unknown DDE error %08x"
+msgstr "DDE-ის უცნობი შეცდომა %08x"
+
+#: ../src/msw/dialup.cpp:343
+msgid ""
+"Dial up functions are unavailable because the remote access service (RAS) is "
+"not installed on this machine. Please install it."
+msgstr ""
+
+#: ../src/msw/dialup.cpp:402
+#, c-format
+msgid ""
+"The version of remote access service (RAS) installed on this machine is too "
+"old, please upgrade (the following required function is missing: %s)."
+msgstr ""
+
+#: ../src/msw/dialup.cpp:437
+msgid "Failed to retrieve text of RAS error message"
+msgstr "RAS-ის შეცდომის შეტყობინების ტექსტის მიღების შეცდომა"
+
+#: ../src/msw/dialup.cpp:440
+#, c-format
+msgid "unknown error (error code %08x)."
+msgstr "უცნობი შეცდომა (შეცდომის კოდი %08x)."
+
+#: ../src/msw/dialup.cpp:492
+#, c-format
+msgid "Cannot find active dialup connection: %s"
+msgstr ""
+
+#: ../src/msw/dialup.cpp:513
+msgid "Several active dialup connections found, choosing one randomly."
+msgstr ""
+
+#: ../src/msw/dialup.cpp:598 ../src/msw/dialup.cpp:832
+#, c-format
+msgid "Failed to establish dialup connection: %s"
+msgstr "სატელეფონო კავშირის დამყარების შეცდომა: %s"
+
+#: ../src/msw/dialup.cpp:664
+#, c-format
+msgid "Failed to get ISP names: %s"
+msgstr "ISP-ების სახელების მიღების პრობლემა: %s"
+
+#: ../src/msw/dialup.cpp:712
+msgid "Failed to connect: no ISP to dial."
+msgstr "კავშირის შეცდომა: დასაკავშირებელი ISP-ის გარეშე."
+
+#: ../src/msw/dialup.cpp:732
+msgid "Choose ISP to dial"
+msgstr "აირჩიეთ ISP, რომ დავურეკოთ"
+
+#: ../src/msw/dialup.cpp:733
+msgid "Please choose which ISP do you want to connect to"
+msgstr ""
+
+#: ../src/msw/dialup.cpp:766
+msgid "Failed to connect: missing username/password."
+msgstr "შეერთების შეცდომა: აკლია მომხმარებელი/პაროლი."
+
+#: ../src/msw/dialup.cpp:796
+msgid "Cannot find the location of address book file"
+msgstr "მისამართების წიგნის ფაილის მდებარეობა ვერ ვიპოვე"
+
+#: ../src/msw/dialup.cpp:827
+#, c-format
+msgid "Failed to initiate dialup connection: %s"
+msgstr "სატელეფონო კავშირის ინიციალიზაციის შეცდომა: %s"
+
+#: ../src/msw/dialup.cpp:897
+msgid "Cannot hang up - no active dialup connection."
+msgstr "გათიშვა შეუძლებელია. ტელეფონით შეერთება არ არსებობს."
+
+#: ../src/msw/dialup.cpp:907
+#, c-format
+msgid "Failed to terminate the dialup connection: %s"
+msgstr "სატელეფონო კავშირის გაუქმების შეცდომა: %s"
+
+#: ../src/msw/dib.cpp:313
+#, c-format
+msgid "Failed to save the bitmap image to file \"%s\"."
+msgstr "ბიტური რუკის გამოსახულების ფაილში (%s) შენახვის შეცდომა."
+
+#: ../src/msw/dib.cpp:543
+#, c-format
+msgid "Failed to allocate %luKb of memory for bitmap data."
+msgstr ""
+
+#: ../src/msw/dir.cpp:241
+#, c-format
+msgid "Cannot enumerate files in directory '%s'"
+msgstr "შეუძლებელია ფაილების ჩამოთვლა საქაღალდეში \"%s\""
+
+#: ../src/msw/dirdlg.cpp:368
+msgid "Couldn't obtain folder name"
+msgstr "საქაღალდის სახელის მიღების შეცდომა"
+
+#: ../src/msw/dlmsw.cpp:163
+#, c-format
+msgid "(error %d: %s)"
+msgstr "(შეცდომა %d: %s)"
+
+#: ../src/msw/dragimag.cpp:143 ../src/msw/dragimag.cpp:178
+#: ../src/msw/imaglist.cpp:309 ../src/msw/imaglist.cpp:331
+msgid "Couldn't add an image to the image list."
+msgstr "გამოსახულების სიაში ჩამატება შეუძლებელია."
+
+#: ../src/msw/enhmeta.cpp:94
+#, c-format
+msgid "Failed to load metafile from file \"%s\"."
+msgstr "ფაილიდან (%s) მეტაფაილის ჩატვირთვის შეცდომა."
+
+#: ../src/msw/fdrepdlg.cpp:412
+#, c-format
+msgid "Failed to create the standard find/replace dialog (error code %d)"
+msgstr ""
+
+#: ../src/msw/filedlg.cpp:1241
+msgid "Access to the file system is not allowed from secure desktop."
+msgstr ""
+
+#: ../src/msw/filedlg.cpp:1242
+msgid "Security warning"
+msgstr "უსაფრთხოების გაფრთხილება"
+
+#: ../src/msw/filedlg.cpp:1533
+#, c-format
+msgid "File dialog failed with error code %0lx."
+msgstr "ფაილის არჩევის ფანჯრის ავარია კოდით %0lx."
+
+#: ../src/msw/font.cpp:1120
+#, c-format
+msgid "Font file \"%s\" couldn't be loaded"
+msgstr "ფონტის ფაილის ჩატვირთვა შეუძლებელია: %s"
+
+#: ../src/msw/fontdlg.cpp:220
+#, c-format
+msgid "Common dialog failed with error code %0lx."
+msgstr "საერთო ფანჯრის ავარია შეცდომის კოდით %0lx."
+
+#: ../src/msw/fswatcher.cpp:67
+msgid "Ungraceful worker thread termination"
+msgstr "დამხმარე პროცესის გაუფრთხილებელი დასრულება"
+
+#: ../src/msw/fswatcher.cpp:81
+msgid "Unable to create IOCP worker thread"
+msgstr "IOCP დამხმარე ნაკადის შექმნის შეცდომა"
+
+#: ../src/msw/fswatcher.cpp:88
+msgid "Unable to start IOCP worker thread"
+msgstr "IOCP დამხმარე ნაკადის გაშვების შეცდომა"
+
+#: ../src/msw/fswatcher.cpp:140
+msgid "Monitoring individual files for changes is not supported currently."
+msgstr ""
+
+#: ../src/msw/fswatcher.cpp:165
+#, c-format
+msgid "Unable to set up watch for '%s'"
+msgstr "%s-ის ყურების შეცდომა"
+
+#: ../src/msw/fswatcher.cpp:466
+#, c-format
+msgid "Can't monitor non-existent directory \"%s\" for changes."
+msgstr ""
+
+#: ../src/msw/glcanvas.cpp:577 ../src/unix/glx11.cpp:507
+msgid "OpenGL 3.0 or later is not supported by the OpenGL driver."
+msgstr ""
+
+#: ../src/msw/glcanvas.cpp:601 ../src/osx/glcanvas_osx.cpp:395
+#: ../src/unix/glegl.cpp:304 ../src/unix/glx11.cpp:553
+msgid "Couldn't create OpenGL context"
+msgstr "OpenGL-ის კონტექსტის შექმნის შეცდომა"
+
+#: ../src/msw/glcanvas.cpp:1294
+msgid "Failed to initialize OpenGL"
+msgstr "OpenGL-ის ინიციალიზაციის შექმნის შეცდომა"
+
+#: ../src/msw/graphicsd2d.cpp:607
+msgid "Could not register custom DirectWrite font loader."
+msgstr ""
+
+#: ../src/msw/helpchm.cpp:48
+msgid ""
+"MS HTML Help functions are unavailable because the MS HTML Help library is "
+"not installed on this machine. Please install it."
+msgstr ""
+
+#: ../src/msw/helpchm.cpp:55
+msgid "Failed to initialize MS HTML Help."
+msgstr "MS HTML Help-ის ინიციალიზაციის შეცდომა."
+
+#: ../src/msw/iniconf.cpp:458
+#, c-format
+msgid "Can't delete the INI file '%s'"
+msgstr "INI ფაილი (%s) ვერ წავშალე"
+
+#: ../src/msw/listctrl.cpp:995
+#, c-format
+msgid "Couldn't retrieve information about list control item %d."
+msgstr ""
+
+#: ../src/msw/mdi.cpp:170 ../src/qt/mdi.cpp:253
+msgid "&Cascade"
+msgstr "&კასკადი"
+
+#: ../src/msw/mdi.cpp:171
+msgid "Tile &Horizontally"
+msgstr "ფილები &ჰორიზონტალურად"
+
+#: ../src/msw/mdi.cpp:172
+msgid "Tile &Vertically"
+msgstr "ფილები &ვერტიკალურად"
+
+#: ../src/msw/mdi.cpp:174
+msgid "&Arrange Icons"
+msgstr "&ხატულების დალატება"
+
+#: ../src/msw/mdi.cpp:621
+msgid "Failed to create MDI parent frame."
+msgstr "MDI მშობლის ჩარჩოს შექმნის შეცდომა."
+
+#: ../src/msw/mimetype.cpp:234
+#, c-format
+msgid "Failed to create registry entry for '%s' files."
+msgstr "%s ფაილის რეგისტრაციის ჩანაწერის შექმნის შეცდომა."
+
+#: ../src/msw/ole/automtn.cpp:495
+#, c-format
+msgid "Failed to find CLSID of \"%s\""
+msgstr "%s-ის CLSID ვერ ვიპოვე"
+
+#: ../src/msw/ole/automtn.cpp:512
+#, c-format
+msgid "Failed to create an instance of \"%s\""
+msgstr "\"%s\"-ის გაშვებული ასლის შექმნის შეცდომა"
+
+#: ../src/msw/ole/automtn.cpp:552
+#, c-format
+msgid "Cannot get an active instance of \"%s\""
+msgstr "\"%s\"-ის აქტიური გაშვებული ასლის ა="
+
+#: ../src/msw/ole/automtn.cpp:564
+#, c-format
+msgid "Failed to get OLE automation interface for \"%s\""
+msgstr ""
+
+#: ../src/msw/ole/automtn.cpp:621
+msgid "Unknown name or named argument."
+msgstr "უცნობი სახელი ან სახელიანი არგუმენტი."
+
+#: ../src/msw/ole/automtn.cpp:625
+msgid "Incorrect number of arguments."
+msgstr "არგუმენტების არასწორი რაოდენობა."
+
+#: ../src/msw/ole/automtn.cpp:637
+msgid "Unknown exception"
+msgstr "უცნობი შეცდომა"
+
+#: ../src/msw/ole/automtn.cpp:642
+msgid "Method or property not found."
+msgstr "მეთოდი ან თვისება ვერ ვიპოვე."
+
+#: ../src/msw/ole/automtn.cpp:646
+msgid "Overflow while coercing argument values."
+msgstr ""
+
+#: ../src/msw/ole/automtn.cpp:650
+msgid "Object implementation does not support named arguments."
+msgstr ""
+
+#: ../src/msw/ole/automtn.cpp:654
+msgid "The locale ID is unknown."
+msgstr "ენის ID უცნობია."
+
+#: ../src/msw/ole/automtn.cpp:658
+msgid "Missing a required parameter."
+msgstr "აკლია აუცილებელი პარამეტრი."
+
+#: ../src/msw/ole/automtn.cpp:662
+#, c-format
+msgid "Argument %u not found."
+msgstr "არგუმენტი ვერ ვიპოვე: %u."
+
+#: ../src/msw/ole/automtn.cpp:666
+#, c-format
+msgid "Type mismatch in argument %u."
+msgstr "%u-ე არგუმენტის ტიპი არ ემთხვევა."
+
+#: ../src/msw/ole/automtn.cpp:670
+msgid "The system cannot find the file specified."
+msgstr "სისტემამ მითითებული ფაილი ვერ იპოვა."
+
+#: ../src/msw/ole/automtn.cpp:674
+msgid "Class not registered."
+msgstr "კლასი რეგისტრირებული არაა."
+
+#: ../src/msw/ole/automtn.cpp:678
+#, c-format
+msgid "Unknown error %08x"
+msgstr "უცნობი შეცდომა %08x"
+
+#: ../src/msw/ole/automtn.cpp:682
+#, c-format
+msgid "OLE Automation error in %s: %s"
+msgstr "%s-ში OLE-ის ავტომატიზაციის შეცდომა: %s"
+
+#: ../src/msw/ole/dataobj.cpp:385
+#, c-format
+msgid "Couldn't register clipboard format '%s'."
+msgstr "მიმოცვლის ბაფერის ფორმატის რეგისტრაციის შეცდომა: %s."
+
+#: ../src/msw/ole/dataobj.cpp:402
+#, c-format
+msgid "The clipboard format '%d' doesn't exist."
+msgstr "მიმოცვლის ბაფერის ფორმატი არ არსებობს: %d."
+
+#: ../src/msw/progdlg.cpp:1025
+msgid "Skip"
+msgstr "გამოტოვება"
+
+#: ../src/msw/registry.cpp:141
+#, c-format
+msgid "unknown (%lu)"
+msgstr "უცნობი (%lu)"
+
+#: ../src/msw/registry.cpp:409
+#, c-format
+msgid "Can't get info about registry key '%s'"
+msgstr "რეესტრის გასაღების (%s) შესახებ ინფორმაციის მიღების შეცდომა"
+
+#: ../src/msw/registry.cpp:445
+#, c-format
+msgid "Can't open registry key '%s'"
+msgstr "რეესტრის გასაღების გახსნის შეცდომა: %s"
+
+#: ../src/msw/registry.cpp:478
+#, c-format
+msgid "Can't create registry key '%s'"
+msgstr "რეესტრის გასაღების შექმნის შეცდომა: %s"
+
+#: ../src/msw/registry.cpp:497
+#, c-format
+msgid "Can't close registry key '%s'"
+msgstr "რეესტრის გასღების დახურვის შეცდომა: %s"
+
+#: ../src/msw/registry.cpp:512
+#, c-format
+msgid "Registry value '%s' already exists."
+msgstr "რეესტრის მნიშვნელობა უკვე არსებობს: %s."
+
+#: ../src/msw/registry.cpp:520
+#, c-format
+msgid "Failed to rename registry value '%s' to '%s'."
+msgstr ""
+
+#: ../src/msw/registry.cpp:575
+#, c-format
+msgid "Can't copy values of unsupported type %d."
+msgstr ""
+
+#: ../src/msw/registry.cpp:586
+#, c-format
+msgid "Registry key '%s' does not exist, cannot rename it."
+msgstr ""
+
+#: ../src/msw/registry.cpp:617
+#, c-format
+msgid "Registry key '%s' already exists."
+msgstr "რეესტრის გასაღები უკვე არსებობს: %s."
+
+#: ../src/msw/registry.cpp:625
+#, c-format
+msgid "Failed to rename the registry key '%s' to '%s'."
+msgstr "ვერ გადავარქვი სახელი რეესტრის გასაღებს '%s'-დან '%s'-ზე."
+
+#: ../src/msw/registry.cpp:670
+#, c-format
+msgid "Failed to copy the registry subkey '%s' to '%s'."
+msgstr "ვერ დავაკოპირე რეესტრის ქვეგასაღები '%s'-დან '%s'-მდე."
+
+#: ../src/msw/registry.cpp:683
+#, c-format
+msgid "Failed to copy registry value '%s'"
+msgstr "ვერ დავაკოპირე რეესტრის მნიშვნელობა '%s'"
+
+#: ../src/msw/registry.cpp:692
+#, c-format
+msgid "Failed to copy the contents of registry key '%s' to '%s'."
+msgstr ""
+
+#: ../src/msw/registry.cpp:718
+#, c-format
+msgid ""
+"Registry key '%s' is needed for normal system operation,\n"
+"deleting it will leave your system in unusable state:\n"
+"operation aborted."
+msgstr ""
+
+#: ../src/msw/registry.cpp:754
+#, c-format
+msgid "Can't delete key '%s'"
+msgstr "გასაღების წაშლის შეცდომა: %s"
+
+#: ../src/msw/registry.cpp:782
+#, c-format
+msgid "Can't delete value '%s' from key '%s'"
+msgstr "გასაღებიდან %2$s მნიშვნელობის (%1$s) წაშლია შეუძლებელია"
+
+#: ../src/msw/registry.cpp:855 ../src/msw/registry.cpp:887
+#: ../src/msw/registry.cpp:929 ../src/msw/registry.cpp:1000
+#, c-format
+msgid "Can't read value of key '%s'"
+msgstr "%s-ის მნიშვნელობის წაკითხვის შეცდომა"
+
+#: ../src/msw/registry.cpp:873 ../src/msw/registry.cpp:915
+#: ../src/msw/registry.cpp:963 ../src/msw/registry.cpp:1106
+#, c-format
+msgid "Can't set value of '%s'"
+msgstr "%s-ის მნიშვნელობის დაყენების შეცდომა"
+
+#: ../src/msw/registry.cpp:894 ../src/msw/registry.cpp:943
+#, c-format
+msgid "Registry value \"%s\" is not numeric (but of type %s)"
+msgstr ""
+
+#: ../src/msw/registry.cpp:979
+#, c-format
+msgid "Registry value \"%s\" is not binary (but of type %s)"
+msgstr ""
+
+#: ../src/msw/registry.cpp:1028
+#, c-format
+msgid "Registry value \"%s\" is not text (but of type %s)"
+msgstr ""
+
+#: ../src/msw/registry.cpp:1089
+#, c-format
+msgid "Can't read value of '%s'"
+msgstr "%s-ის მნიშვნელობის წაკითხვის შეცდომა"
+
+#: ../src/msw/registry.cpp:1157
+#, c-format
+msgid "Can't enumerate values of key '%s'"
+msgstr ""
+
+#: ../src/msw/registry.cpp:1196
+#, c-format
+msgid "Can't enumerate subkeys of key '%s'"
+msgstr ""
+
+#: ../src/msw/registry.cpp:1262
+#, c-format
+msgid ""
+"Exporting registry key: file \"%s\" already exists and won't be overwritten."
+msgstr ""
+
+#: ../src/msw/registry.cpp:1411
+#, c-format
+msgid "Can't export value of unsupported type %d."
+msgstr ""
+
+#: ../src/msw/registry.cpp:1427
+#, c-format
+msgid "Ignoring value \"%s\" of the key \"%s\"."
+msgstr "გამოტოვებული იქნება მნიშვნელობა \"%s\" გასაღებისთვის \"%s\"."
+
+#: ../src/msw/textctrl.cpp:596
+msgid ""
+"Impossible to create a rich edit control, using simple text control instead. "
+"Please reinstall riched32.dll"
+msgstr ""
+
+#: ../src/msw/thread.cpp:522 ../src/unix/threadpsx.cpp:850
+msgid "Cannot start thread: error writing TLS."
+msgstr "ნაკადის გაშვების შეცდომა: TLS-ის ჩაწერის შეცდომა."
+
+#: ../src/msw/thread.cpp:613
+msgid "Can't set thread priority"
+msgstr "ნაკადის პრიორიტეტის დაყენება შეუძლებელია"
+
+#: ../src/msw/thread.cpp:649
+msgid "Can't create thread"
+msgstr "ნაკადის შექმნის შეცდომა"
+
+#: ../src/msw/thread.cpp:668
+msgid "Couldn't terminate thread"
+msgstr "ნაკადის შეწყვეტა შეუძლებელია"
+
+#: ../src/msw/thread.cpp:799
+msgid "Cannot wait for thread termination"
+msgstr "ნაკადის შეწყვეტისთვის ლოდინი შეუძლებელია"
+
+#: ../src/msw/thread.cpp:873
+#, c-format
+msgid "Cannot suspend thread %lx"
+msgstr "ნაკადის (%lx) შეჩერების შეცდომა"
+
+#: ../src/msw/thread.cpp:903
+#, c-format
+msgid "Cannot resume thread %lx"
+msgstr "ნაკადის (%lx) გაგრძელების შეცდომა"
+
+#: ../src/msw/thread.cpp:932
+msgid "Couldn't get the current thread pointer"
+msgstr "მიმდინარე ნაკადის მაჩვენებლის მიღების შეცდომა"
+
+#: ../src/msw/thread.cpp:1333
+msgid ""
+"Thread module initialization failed: impossible to allocate index in thread "
+"local storage"
+msgstr ""
+
+#: ../src/msw/thread.cpp:1345
+msgid ""
+"Thread module initialization failed: cannot store value in thread local "
+"storage"
+msgstr ""
+
+#: ../src/msw/timer.cpp:133
+msgid "Couldn't create a timer"
+msgstr "ტაიმერის შექმნის შეცდომა"
+
+#: ../src/msw/utils.cpp:372
+msgid "can't find user's HOME, using current directory."
+msgstr ""
+"მომხმარებლის საწყისი საქაღალდე ვერ ვიპოვე. გამოვიყენებ მიმდინარე საქაღალდეს."
+
+#: ../src/msw/utils.cpp:662
+#, c-format
+msgid "Failed to kill process %d"
+msgstr "პროცესის მოკვლა შეუძლებელია: %d"
+
+#: ../src/msw/utils.cpp:986
+#, c-format
+msgid "Failed to load resource \"%s\"."
+msgstr "რესურსის ჩატვირთვის შეცდომა: %s."
+
+#: ../src/msw/utils.cpp:993
+#, c-format
+msgid "Failed to lock resource \"%s\"."
+msgstr "რესურსის დაბლოკვის შეცდომა: %s."
+
+#. TRANSLATORS: MS Windows build number
+#: ../src/msw/utils.cpp:1209
+#, c-format
+msgid "build %lu"
+msgstr "აგება %lu"
+
+#: ../src/msw/utils.cpp:1218
+msgid ", 64-bit edition"
+msgstr ", 64-ბიტიანი გამოცემა"
+
+#: ../src/msw/utilsexc.cpp:224
+msgid "Failed to create an anonymous pipe"
+msgstr "ანონიმური ფაიფის შექმნის შეცდომა"
+
+#: ../src/msw/utilsexc.cpp:697
+msgid "Failed to redirect the child process IO"
+msgstr "შვილი პროცესის IO-ის გადამისამართება ჩავარდა"
+
+#: ../src/msw/utilsexc.cpp:870
+#, c-format
+msgid "Execution of command '%s' failed"
+msgstr "ბრძანების შესრულების შეცდომა: %s"
+
+#: ../src/msw/volume.cpp:337
+msgid "Failed to load mpr.dll."
+msgstr "\"mpr.dll\"-ის ჩატვირთვის შეცდომა."
+
+#: ../src/msw/volume.cpp:506
+#, c-format
+msgid "Cannot read typename from '%s'!"
+msgstr "'%s'-დან typename ვერ წავიკითხე!"
+
+#: ../src/msw/volume.cpp:615
+#, c-format
+msgid "Cannot load icon from '%s'."
+msgstr "%s-დან ხატულის ჩატვირთვის შეცდომა."
+
+#: ../src/msw/webview_edge.cpp:285
+msgid "This program was compiled without support for setting Edge proxy."
+msgstr ""
+
+#: ../src/msw/webview_ie.cpp:1010
+msgid "Failed to find web view emulation level in the registry"
+msgstr ""
+
+#: ../src/msw/webview_ie.cpp:1019
+msgid "Failed to set web view to modern emulation level"
+msgstr ""
+
+#: ../src/msw/webview_ie.cpp:1027
+msgid "Failed to reset web view to standard emulation level"
+msgstr ""
+
+#: ../src/msw/webview_ie.cpp:1049
+msgid "Can't run JavaScript script without a valid HTML document"
+msgstr ""
+
+#: ../src/msw/webview_ie.cpp:1056
+msgid "Can't get the JavaScript object"
+msgstr "JavaScript-ის ობიექტის მიღების შეცდომა"
+
+#: ../src/msw/webview_ie.cpp:1070
+msgid "failed to evaluate"
+msgstr "შეფასების შეცდომა"
+
+#: ../src/osx/cocoa/filedlg.mm:412
+msgid "File type:"
+msgstr "ფაილის ტიპი:"
+
+#: ../src/osx/cocoa/menu.mm:242
+msgctxt "macOS menu name"
+msgid "Window"
+msgstr "ფანჯარა"
+
+#: ../src/osx/cocoa/menu.mm:259
+msgctxt "macOS menu name"
+msgid "Help"
+msgstr "დახმარება"
+
+#: ../src/osx/cocoa/menu.mm:298
+msgctxt "macOS menu item"
+msgid "Minimize"
+msgstr "ჩაკეცვა"
+
+#: ../src/osx/cocoa/menu.mm:303
+msgctxt "macOS menu item"
+msgid "Zoom"
+msgstr "მასშტაბი"
+
+#: ../src/osx/cocoa/menu.mm:309
+msgctxt "macOS menu item"
+msgid "Bring All to Front"
+msgstr "ყველას წინ გამოტანა"
+
+#: ../src/osx/core/sound.cpp:143
+#, c-format
+msgid "Failed to load sound from \"%s\" (error %d)."
+msgstr ""
+
+#: ../src/osx/fontutil.cpp:80
+#, c-format
+msgid "Font file \"%s\" doesn't exist."
+msgstr "ფონტის ფაილი არ არსებობს: %s."
+
+#: ../src/osx/fontutil.cpp:88
+#, c-format
+msgid ""
+"Font file \"%s\" cannot be used as it is not inside the font directory "
+"\"%s\"."
+msgstr ""
+
+#: ../src/osx/menu_osx.cpp:496
+#, c-format
+msgctxt "macOS menu item"
+msgid "About %s"
+msgstr "%s-ის შესახებ"
+
+#: ../src/osx/menu_osx.cpp:499
+msgctxt "macOS menu item"
+msgid "About..."
+msgstr "შესახებ..."
+
+#: ../src/osx/menu_osx.cpp:508
+msgctxt "macOS menu item"
+msgid "Preferences..."
+msgstr "მორგება..."
+
+#: ../src/osx/menu_osx.cpp:512
+msgctxt "macOS menu item"
+msgid "Services"
+msgstr "სერვისები"
+
+#: ../src/osx/menu_osx.cpp:519
+#, c-format
+msgctxt "macOS menu item"
+msgid "Hide %s"
+msgstr "%s-ის დამალვა"
+
+#: ../src/osx/menu_osx.cpp:522
+msgctxt "macOS menu item"
+msgid "Hide Application"
+msgstr "აპლიკაციის დამალვა"
+
+#: ../src/osx/menu_osx.cpp:526
+msgctxt "macOS menu item"
+msgid "Hide Others"
+msgstr "სხვების დამალვა"
+
+#: ../src/osx/menu_osx.cpp:528
+msgctxt "macOS menu item"
+msgid "Show All"
+msgstr "ყველას ჩვენება"
+
+#: ../src/osx/menu_osx.cpp:534
+#, c-format
+msgctxt "macOS menu item"
+msgid "Quit %s"
+msgstr "%s-დან გასვლა"
+
+#: ../src/osx/menu_osx.cpp:537
+msgctxt "macOS menu item"
+msgid "Quit Application"
+msgstr "აპლიკაციიდან გასვლა"
+
+#: ../src/osx/webview_webkit.mm:444
+msgid "Printing is not supported by the system web control"
+msgstr ""
+
+#: ../src/osx/webview_webkit.mm:453
+msgid "Print operation could not be initialized"
+msgstr "დაბეჭდვის ოპერაციის ინიციალიზაციის შეცდომა"
+
+#. TRANSLATORS: Label of font point size
+#: ../src/propgrid/advprops.cpp:605
+msgid "Point Size"
+msgstr "წერტილის ზომა"
+
+#. TRANSLATORS: Label of font face name
+#: ../src/propgrid/advprops.cpp:615
+msgid "Face Name"
+msgstr "ფონტის სახის სახელი"
+
+#. TRANSLATORS: Label of font style
+#: ../src/propgrid/advprops.cpp:623 ../src/richtext/richtextformatdlg.cpp:331
+msgid "Style"
+msgstr "სტილი"
+
+#. TRANSLATORS: Label of font weight
+#: ../src/propgrid/advprops.cpp:628
+msgid "Weight"
+msgstr "სიმძიმე"
+
+#. TRANSLATORS: Label of underlined font
+#: ../src/propgrid/advprops.cpp:633 ../src/richtext/richtextfontpage.cpp:358
+msgid "Underlined"
+msgstr "ხაზგასმული"
+
+#. TRANSLATORS: Label of font family
+#: ../src/propgrid/advprops.cpp:637
+msgid "Family"
+msgstr "ოჯახი"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:801
+msgid "AppWorkspace"
+msgstr "AppWorkspace"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:802
+msgid "ActiveBorder"
+msgstr "ActiveBorder"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:803
+msgid "ActiveCaption"
+msgstr "ActiveCaption"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:804
+msgid "ButtonFace"
+msgstr "ButtonFace"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:805
+msgid "ButtonHighlight"
+msgstr "ButtonHighlight"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:806
+msgid "ButtonShadow"
+msgstr "ButtonShadow"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:807
+msgid "ButtonText"
+msgstr "ButtonText"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:808
+msgid "CaptionText"
+msgstr "CaptionText"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:809
+msgid "ControlDark"
+msgstr "ControlDark"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:810
+msgid "ControlLight"
+msgstr "ControlLight"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:812
+msgid "GrayText"
+msgstr "GrayText"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:813
+msgid "Highlight"
+msgstr "მოუნიშნავის გაბუნდოვნება"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:814
+msgid "HighlightText"
+msgstr "HighlightText"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:815
+msgid "InactiveBorder"
+msgstr "InactiveBorder"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:816
+msgid "InactiveCaption"
+msgstr "InactiveCaption"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:817
+msgid "InactiveCaptionText"
+msgstr "InactiveCaptionText"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:818
+msgid "Menu"
+msgstr "მენიუ"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:819
+msgid "Scrollbar"
+msgstr "Scrollbar"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:820
+msgid "Tooltip"
+msgstr "მინიშნება"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:821
+msgid "TooltipText"
+msgstr "TooltipText"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:822
+msgid "Window"
+msgstr "ფანჯარა"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:823
+msgid "WindowFrame"
+msgstr "WindowFrame"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:824
+msgid "WindowText"
+msgstr "WindowText"
+
+#. TRANSLATORS: Custom colour choice entry
+#: ../src/propgrid/advprops.cpp:825 ../src/propgrid/advprops.cpp:1532
+#: ../src/propgrid/advprops.cpp:1576
+msgid "Custom"
+msgstr "განსხვავებული"
+
+#: ../src/propgrid/advprops.cpp:1558
+msgid "Black"
+msgstr "შავი"
+
+#: ../src/propgrid/advprops.cpp:1559
+msgid "Maroon"
+msgstr "ბორდოსფერი"
+
+#: ../src/propgrid/advprops.cpp:1560
+msgid "Navy"
+msgstr "მუქი ლურჯი"
+
+#: ../src/propgrid/advprops.cpp:1561
+msgid "Purple"
+msgstr "იისფერი"
+
+#: ../src/propgrid/advprops.cpp:1562
+msgid "Teal"
+msgstr "მომწვანო ლურჯი"
+
+#: ../src/propgrid/advprops.cpp:1563
+msgid "Gray"
+msgstr "ნაცრისფერი"
+
+#: ../src/propgrid/advprops.cpp:1564
+msgid "Green"
+msgstr "მწვანე"
+
+#: ../src/propgrid/advprops.cpp:1565
+msgid "Olive"
+msgstr "ზეთისხილისფერი"
+
+#: ../src/propgrid/advprops.cpp:1566
+msgid "Brown"
+msgstr "ყავისფერი"
+
+#: ../src/propgrid/advprops.cpp:1567
+msgid "Blue"
+msgstr "ლურჯი"
+
+#: ../src/propgrid/advprops.cpp:1568
+msgid "Fuchsia"
+msgstr "ფუქსიისფერი"
+
+#: ../src/propgrid/advprops.cpp:1569
+msgid "Red"
+msgstr "წითელი"
+
+#: ../src/propgrid/advprops.cpp:1570
+msgid "Orange"
+msgstr "ნარინჯისფერი"
+
+#: ../src/propgrid/advprops.cpp:1571
+msgid "Silver"
+msgstr "ვერცხლი"
+
+#: ../src/propgrid/advprops.cpp:1572
+msgid "Lime"
+msgstr "ლიმონის ფერი"
+
+#: ../src/propgrid/advprops.cpp:1573
+msgid "Aqua"
+msgstr "წყლის ფერი"
+
+#: ../src/propgrid/advprops.cpp:1574
+msgid "Yellow"
+msgstr "ყვითელი"
+
+#: ../src/propgrid/advprops.cpp:1575
+msgid "White"
+msgstr "თეთრი"
+
+#: ../src/propgrid/advprops.cpp:1718
+msgctxt "system cursor name"
+msgid "Default"
+msgstr "ნაგულისხმები"
+
+#: ../src/propgrid/advprops.cpp:1719
+msgctxt "system cursor name"
+msgid "Arrow"
+msgstr "ისარი"
+
+#: ../src/propgrid/advprops.cpp:1720
+msgctxt "system cursor name"
+msgid "Right Arrow"
+msgstr "ისარი მარჯვნივ"
+
+#: ../src/propgrid/advprops.cpp:1721
+msgctxt "system cursor name"
+msgid "Blank"
+msgstr "სუფთა"
+
+#: ../src/propgrid/advprops.cpp:1722
+msgctxt "system cursor name"
+msgid "Bullseye"
+msgstr "სამიზნე"
+
+#: ../src/propgrid/advprops.cpp:1723
+msgctxt "system cursor name"
+msgid "Character"
+msgstr "სიმბოლო"
+
+#: ../src/propgrid/advprops.cpp:1724
+msgctxt "system cursor name"
+msgid "Cross"
+msgstr "ჯვარი"
+
+#: ../src/propgrid/advprops.cpp:1725
+msgctxt "system cursor name"
+msgid "Hand"
+msgstr "ხელი"
+
+#: ../src/propgrid/advprops.cpp:1726
+msgctxt "system cursor name"
+msgid "I-Beam"
+msgstr "I-Beam"
+
+#: ../src/propgrid/advprops.cpp:1727
+msgctxt "system cursor name"
+msgid "Left Button"
+msgstr "მარცხენა ღილაკი"
+
+#: ../src/propgrid/advprops.cpp:1728
+msgctxt "system cursor name"
+msgid "Magnifier"
+msgstr "გამადიდებელი"
+
+#: ../src/propgrid/advprops.cpp:1729
+msgctxt "system cursor name"
+msgid "Middle Button"
+msgstr "შუა ღილაკი"
+
+#: ../src/propgrid/advprops.cpp:1730
+msgctxt "system cursor name"
+msgid "No Entry"
+msgstr "ჩანაწერის გარეშე"
+
+#: ../src/propgrid/advprops.cpp:1731
+msgctxt "system cursor name"
+msgid "Paint Brush"
+msgstr "სახატავი ფუნჯი"
+
+#: ../src/propgrid/advprops.cpp:1732
+msgctxt "system cursor name"
+msgid "Pencil"
+msgstr "ფანქარი"
+
+#: ../src/propgrid/advprops.cpp:1733
+msgctxt "system cursor name"
+msgid "Point Left"
+msgstr "წერტილი მარცხნივ"
+
+#: ../src/propgrid/advprops.cpp:1734
+msgctxt "system cursor name"
+msgid "Point Right"
+msgstr "წერტილი მარჯვნივ"
+
+#: ../src/propgrid/advprops.cpp:1735
+msgctxt "system cursor name"
+msgid "Question Arrow"
+msgstr "კითხვა"
+
+#: ../src/propgrid/advprops.cpp:1736
+msgctxt "system cursor name"
+msgid "Right Button"
+msgstr "მარჯვენა ღილაკი"
+
+#: ../src/propgrid/advprops.cpp:1737
+msgctxt "system cursor name"
+msgid "Sizing NE-SW"
+msgstr "ზომების შეცვლა NE-SW"
+
+#: ../src/propgrid/advprops.cpp:1738
+msgctxt "system cursor name"
+msgid "Sizing N-S"
+msgstr "ზომების შეცვლა N-S"
+
+#: ../src/propgrid/advprops.cpp:1739
+msgctxt "system cursor name"
+msgid "Sizing NW-SE"
+msgstr "ზომების შეცვლა NW-SE"
+
+#: ../src/propgrid/advprops.cpp:1740
+msgctxt "system cursor name"
+msgid "Sizing W-E"
+msgstr "ზომების შეცვლა W-E"
+
+#: ../src/propgrid/advprops.cpp:1741
+msgctxt "system cursor name"
+msgid "Sizing"
+msgstr "ზომების შეცვლა"
+
+#: ../src/propgrid/advprops.cpp:1742
+msgctxt "system cursor name"
+msgid "Spraycan"
+msgstr "აეროზოლი"
+
+#: ../src/propgrid/advprops.cpp:1743
+msgctxt "system cursor name"
+msgid "Wait"
+msgstr "მოცდა"
+
+#: ../src/propgrid/advprops.cpp:1744
+msgctxt "system cursor name"
+msgid "Watch"
+msgstr "ყურება"
+
+#: ../src/propgrid/advprops.cpp:1745
+msgctxt "system cursor name"
+msgid "Wait Arrow"
+msgstr "მოცდის ნიშანი"
+
+#: ../src/propgrid/advprops.cpp:2109
+msgid "Make a selection:"
+msgstr "აირჩიეთ:"
+
+#: ../src/propgrid/manager.cpp:394
+msgid "Property"
+msgstr "პარამეტრი"
+
+#: ../src/propgrid/manager.cpp:395
+msgid "Value"
+msgstr "მნიშვნელობა"
+
+#: ../src/propgrid/manager.cpp:1683
+msgid "Categorized Mode"
+msgstr "კატეგორიზირებული რეჟიმი"
+
+#: ../src/propgrid/manager.cpp:1709
+msgid "Alphabetic Mode"
+msgstr "ანბანური რეჟიმი"
+
+#. TRANSLATORS: Name of Boolean false value
+#: ../src/propgrid/propgrid.cpp:230
+msgid "False"
+msgstr "მცდარი"
+
+#. TRANSLATORS: Name of Boolean true value
+#: ../src/propgrid/propgrid.cpp:232
+msgid "True"
+msgstr "ჭეშმარიტი"
+
+#. TRANSLATORS: Text  displayed for unspecified value
+#: ../src/propgrid/propgrid.cpp:428
+msgid "Unspecified"
+msgstr "მიუთითებელი"
+
+#. TRANSLATORS: Caption of message box displaying any property error
+#: ../src/propgrid/propgrid.cpp:3145 ../src/propgrid/propgrid.cpp:3282
+msgid "Property Error"
+msgstr "თვისების შეცდომა"
+
+#: ../src/propgrid/propgrid.cpp:3259
+msgid "You have entered invalid value. Press ESC to cancel editing."
+msgstr ""
+
+#: ../src/propgrid/propgrid.cpp:6608
+#, c-format
+msgid "Error in resource: %s"
+msgstr "რესურსის შეცდომა: %s"
+
+#: ../src/propgrid/propgridiface.cpp:377
+#, c-format
+msgid ""
+"Type operation \"%s\" failed: Property labeled \"%s\" is of type \"%s\", NOT "
+"\"%s\"."
+msgstr ""
+
+#: ../src/propgrid/props.cpp:159
+#, c-format
+msgid "Unknown base %d. Base 10 will be used."
+msgstr ""
+
+#: ../src/propgrid/props.cpp:324
+#, c-format
+msgid "Value must be %s or higher."
+msgstr "მნიშვნელობა %s ან მეტი უნდა იყოს."
+
+#: ../src/propgrid/props.cpp:329 ../src/propgrid/props.cpp:356
+#, c-format
+msgid "Value must be between %s and %s."
+msgstr "მნიშვნელობის დიაპაზონია %s-%s."
+
+#: ../src/propgrid/props.cpp:351
+#, c-format
+msgid "Value must be %s or less."
+msgstr "მნიშვნველობა %s ან ნაკლები უნდა იყოს."
+
+#: ../src/propgrid/props.cpp:1058
+#, c-format
+msgid "Not %s"
+msgstr "არა %s"
+
+#: ../src/propgrid/props.cpp:1770
+msgid "Choose a directory:"
+msgstr "აირჩიეთ საქაღალდე:"
+
+#: ../src/propgrid/props.cpp:2055
+msgid "Choose a file"
+msgstr "ფაილის არჩევა"
+
+#: ../src/qt/mdi.cpp:254
+msgid "&Tile"
+msgstr "&ფილა"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:147
+#: ../src/richtext/richtextformatdlg.cpp:376
+msgid "Background"
+msgstr "ფონი"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:159
+msgid "Background &colour:"
+msgstr "&ფონის ფერი:"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:161
+#: ../src/richtext/richtextbackgroundpage.cpp:163
+msgid "Enables a background colour."
+msgstr "ჩართავს ფონის ფერს."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:167
+#: ../src/richtext/richtextbackgroundpage.cpp:169
+msgid "The background colour."
+msgstr "ფონის ფერი."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:178
+msgid "Shadow"
+msgstr "ჩრდილი"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:193
+msgid "Use &shadow"
+msgstr "&ჩრდილის გამოოყენება"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:195
+#: ../src/richtext/richtextbackgroundpage.cpp:197
+msgid "Enables a shadow."
+msgstr "ჩრდილის ჩართვა."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:211
+msgid "&Horizontal offset:"
+msgstr "&ჰორიზონტალური წანაცვლება:"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:218
+#: ../src/richtext/richtextbackgroundpage.cpp:220
+msgid "The horizontal offset."
+msgstr "ჰორიზონტალური წანაცვლება."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:224
+#: ../src/richtext/richtextbackgroundpage.cpp:227
+#: ../src/richtext/richtextbackgroundpage.cpp:228
+#: ../src/richtext/richtextbackgroundpage.cpp:247
+#: ../src/richtext/richtextbackgroundpage.cpp:250
+#: ../src/richtext/richtextbackgroundpage.cpp:251
+#: ../src/richtext/richtextbackgroundpage.cpp:287
+#: ../src/richtext/richtextbackgroundpage.cpp:290
+#: ../src/richtext/richtextbackgroundpage.cpp:291
+#: ../src/richtext/richtextbackgroundpage.cpp:314
+#: ../src/richtext/richtextbackgroundpage.cpp:317
+#: ../src/richtext/richtextbackgroundpage.cpp:318
+#: ../src/richtext/richtextborderspage.cpp:252
+#: ../src/richtext/richtextborderspage.cpp:255
+#: ../src/richtext/richtextborderspage.cpp:256
+#: ../src/richtext/richtextborderspage.cpp:286
+#: ../src/richtext/richtextborderspage.cpp:289
+#: ../src/richtext/richtextborderspage.cpp:290
+#: ../src/richtext/richtextborderspage.cpp:320
+#: ../src/richtext/richtextborderspage.cpp:323
+#: ../src/richtext/richtextborderspage.cpp:324
+#: ../src/richtext/richtextborderspage.cpp:354
+#: ../src/richtext/richtextborderspage.cpp:357
+#: ../src/richtext/richtextborderspage.cpp:358
+#: ../src/richtext/richtextborderspage.cpp:420
+#: ../src/richtext/richtextborderspage.cpp:423
+#: ../src/richtext/richtextborderspage.cpp:424
+#: ../src/richtext/richtextborderspage.cpp:454
+#: ../src/richtext/richtextborderspage.cpp:457
+#: ../src/richtext/richtextborderspage.cpp:458
+#: ../src/richtext/richtextborderspage.cpp:488
+#: ../src/richtext/richtextborderspage.cpp:491
+#: ../src/richtext/richtextborderspage.cpp:492
+#: ../src/richtext/richtextborderspage.cpp:522
+#: ../src/richtext/richtextborderspage.cpp:525
+#: ../src/richtext/richtextborderspage.cpp:526
+#: ../src/richtext/richtextborderspage.cpp:590
+#: ../src/richtext/richtextborderspage.cpp:593
+#: ../src/richtext/richtextborderspage.cpp:594
+#: ../src/richtext/richtextfontpage.cpp:177
+#: ../src/richtext/richtextmarginspage.cpp:199
+#: ../src/richtext/richtextmarginspage.cpp:201
+#: ../src/richtext/richtextmarginspage.cpp:202
+#: ../src/richtext/richtextmarginspage.cpp:224
+#: ../src/richtext/richtextmarginspage.cpp:226
+#: ../src/richtext/richtextmarginspage.cpp:227
+#: ../src/richtext/richtextmarginspage.cpp:247
+#: ../src/richtext/richtextmarginspage.cpp:249
+#: ../src/richtext/richtextmarginspage.cpp:250
+#: ../src/richtext/richtextmarginspage.cpp:272
+#: ../src/richtext/richtextmarginspage.cpp:274
+#: ../src/richtext/richtextmarginspage.cpp:275
+#: ../src/richtext/richtextmarginspage.cpp:313
+#: ../src/richtext/richtextmarginspage.cpp:315
+#: ../src/richtext/richtextmarginspage.cpp:316
+#: ../src/richtext/richtextmarginspage.cpp:338
+#: ../src/richtext/richtextmarginspage.cpp:340
+#: ../src/richtext/richtextmarginspage.cpp:341
+#: ../src/richtext/richtextmarginspage.cpp:361
+#: ../src/richtext/richtextmarginspage.cpp:363
+#: ../src/richtext/richtextmarginspage.cpp:364
+#: ../src/richtext/richtextmarginspage.cpp:386
+#: ../src/richtext/richtextmarginspage.cpp:388
+#: ../src/richtext/richtextmarginspage.cpp:389
+#: ../src/richtext/richtextsizepage.cpp:337
+#: ../src/richtext/richtextsizepage.cpp:340
+#: ../src/richtext/richtextsizepage.cpp:341
+#: ../src/richtext/richtextsizepage.cpp:371
+#: ../src/richtext/richtextsizepage.cpp:374
+#: ../src/richtext/richtextsizepage.cpp:375
+#: ../src/richtext/richtextsizepage.cpp:398
+#: ../src/richtext/richtextsizepage.cpp:401
+#: ../src/richtext/richtextsizepage.cpp:402
+#: ../src/richtext/richtextsizepage.cpp:425
+#: ../src/richtext/richtextsizepage.cpp:428
+#: ../src/richtext/richtextsizepage.cpp:429
+#: ../src/richtext/richtextsizepage.cpp:452
+#: ../src/richtext/richtextsizepage.cpp:455
+#: ../src/richtext/richtextsizepage.cpp:456
+#: ../src/richtext/richtextsizepage.cpp:479
+#: ../src/richtext/richtextsizepage.cpp:482
+#: ../src/richtext/richtextsizepage.cpp:483
+#: ../src/richtext/richtextsizepage.cpp:553
+#: ../src/richtext/richtextsizepage.cpp:556
+#: ../src/richtext/richtextsizepage.cpp:557
+#: ../src/richtext/richtextsizepage.cpp:588
+#: ../src/richtext/richtextsizepage.cpp:591
+#: ../src/richtext/richtextsizepage.cpp:592
+#: ../src/richtext/richtextsizepage.cpp:623
+#: ../src/richtext/richtextsizepage.cpp:626
+#: ../src/richtext/richtextsizepage.cpp:627
+#: ../src/richtext/richtextsizepage.cpp:658
+#: ../src/richtext/richtextsizepage.cpp:661
+#: ../src/richtext/richtextsizepage.cpp:662
+msgid "px"
+msgstr "px"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:225
+#: ../src/richtext/richtextbackgroundpage.cpp:248
+#: ../src/richtext/richtextbackgroundpage.cpp:288
+#: ../src/richtext/richtextbackgroundpage.cpp:315
+#: ../src/richtext/richtextborderspage.cpp:253
+#: ../src/richtext/richtextborderspage.cpp:287
+#: ../src/richtext/richtextborderspage.cpp:321
+#: ../src/richtext/richtextborderspage.cpp:355
+#: ../src/richtext/richtextborderspage.cpp:421
+#: ../src/richtext/richtextborderspage.cpp:455
+#: ../src/richtext/richtextborderspage.cpp:489
+#: ../src/richtext/richtextborderspage.cpp:523
+#: ../src/richtext/richtextborderspage.cpp:591
+#: ../src/richtext/richtextmarginspage.cpp:200
+#: ../src/richtext/richtextmarginspage.cpp:225
+#: ../src/richtext/richtextmarginspage.cpp:248
+#: ../src/richtext/richtextmarginspage.cpp:273
+#: ../src/richtext/richtextmarginspage.cpp:314
+#: ../src/richtext/richtextmarginspage.cpp:339
+#: ../src/richtext/richtextmarginspage.cpp:362
+#: ../src/richtext/richtextmarginspage.cpp:387
+#: ../src/richtext/richtextsizepage.cpp:338
+#: ../src/richtext/richtextsizepage.cpp:372
+#: ../src/richtext/richtextsizepage.cpp:399
+#: ../src/richtext/richtextsizepage.cpp:426
+#: ../src/richtext/richtextsizepage.cpp:453
+#: ../src/richtext/richtextsizepage.cpp:480
+#: ../src/richtext/richtextsizepage.cpp:554
+#: ../src/richtext/richtextsizepage.cpp:589
+#: ../src/richtext/richtextsizepage.cpp:624
+#: ../src/richtext/richtextsizepage.cpp:659
+msgid "cm"
+msgstr "სმ"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:226
+#: ../src/richtext/richtextbackgroundpage.cpp:249
+#: ../src/richtext/richtextbackgroundpage.cpp:289
+#: ../src/richtext/richtextbackgroundpage.cpp:316
+#: ../src/richtext/richtextborderspage.cpp:254
+#: ../src/richtext/richtextborderspage.cpp:288
+#: ../src/richtext/richtextborderspage.cpp:322
+#: ../src/richtext/richtextborderspage.cpp:356
+#: ../src/richtext/richtextborderspage.cpp:422
+#: ../src/richtext/richtextborderspage.cpp:456
+#: ../src/richtext/richtextborderspage.cpp:490
+#: ../src/richtext/richtextborderspage.cpp:524
+#: ../src/richtext/richtextborderspage.cpp:592
+#: ../src/richtext/richtextfontpage.cpp:176
+#: ../src/richtext/richtextfontpage.cpp:179
+msgid "pt"
+msgstr "pt"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:229
+#: ../src/richtext/richtextbackgroundpage.cpp:231
+#: ../src/richtext/richtextbackgroundpage.cpp:252
+#: ../src/richtext/richtextbackgroundpage.cpp:254
+#: ../src/richtext/richtextbackgroundpage.cpp:292
+#: ../src/richtext/richtextbackgroundpage.cpp:294
+#: ../src/richtext/richtextbackgroundpage.cpp:319
+#: ../src/richtext/richtextbackgroundpage.cpp:321
+msgid "Units for this value."
+msgstr "ამ მნიშვნელობის ერთეული."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:234
+msgid "&Vertical offset:"
+msgstr "&ვერტიკალური წანაცვლება:"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:241
+#: ../src/richtext/richtextbackgroundpage.cpp:243
+msgid "The vertical offset."
+msgstr "ვერტიკალური წანაცვლება."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:257
+msgid "Shadow c&olour:"
+msgstr "&ჩრდილის ფერი:"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:259
+#: ../src/richtext/richtextbackgroundpage.cpp:261
+msgid "Enables the shadow colour."
+msgstr "ჩრდილის ფერის ჩართვა."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:265
+#: ../src/richtext/richtextbackgroundpage.cpp:267
+msgid "The shadow colour."
+msgstr "ჩრდილის ფერი."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:270
+msgid "Sh&adow spread:"
+msgstr "&ჩრდილის გავრცელება:"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:272
+#: ../src/richtext/richtextbackgroundpage.cpp:274
+msgid "Enables the shadow spread."
+msgstr "ჩრდილის გავრცელების ჩართვა."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:281
+#: ../src/richtext/richtextbackgroundpage.cpp:283
+msgid "The shadow spread."
+msgstr "ჩრდილის გავრცელება."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:297
+msgid "&Blur distance:"
+msgstr "&ბუნდოვნების მანძილი:"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:299
+#: ../src/richtext/richtextbackgroundpage.cpp:301
+msgid "Enables the blur distance."
+msgstr "ბუნდოვნების მანძილის ჩართვა."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:308
+#: ../src/richtext/richtextbackgroundpage.cpp:310
+msgid "The shadow blur distance."
+msgstr "ჩრდილის ბუნდოვნების მანძილი."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:324
+msgid "Opaci&ty:"
+msgstr "&გაუმჭვირვალობა:"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:326
+#: ../src/richtext/richtextbackgroundpage.cpp:328
+msgid "Enables the shadow opacity."
+msgstr "ჩრდილის გაუმჭვირვალობის ჩართვა."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:335
+#: ../src/richtext/richtextbackgroundpage.cpp:337
+msgid "The shadow opacity."
+msgstr "ჩრდილის გაუმჭვირვალობა."
+
+#. TRANSLATORS: Rich text page units (percentage)
+#: ../src/richtext/richtextbackgroundpage.cpp:340
+#: ../src/richtext/richtextsizepage.cpp:339
+#: ../src/richtext/richtextsizepage.cpp:373
+#: ../src/richtext/richtextsizepage.cpp:400
+#: ../src/richtext/richtextsizepage.cpp:427
+#: ../src/richtext/richtextsizepage.cpp:454
+#: ../src/richtext/richtextsizepage.cpp:481
+#: ../src/richtext/richtextsizepage.cpp:555
+#: ../src/richtext/richtextsizepage.cpp:590
+#: ../src/richtext/richtextsizepage.cpp:625
+#: ../src/richtext/richtextsizepage.cpp:660
+msgid "%"
+msgstr "%"
+
+#: ../src/richtext/richtextborderspage.cpp:229
+#: ../src/richtext/richtextborderspage.cpp:387
+msgid "Border"
+msgstr "საზღვარი"
+
+#: ../src/richtext/richtextborderspage.cpp:242
+#: ../src/richtext/richtextborderspage.cpp:410
+#: ../src/richtext/richtextindentspage.cpp:194
+#: ../src/richtext/richtextliststylepage.cpp:384
+#: ../src/richtext/richtextmarginspage.cpp:185
+#: ../src/richtext/richtextmarginspage.cpp:299
+#: ../src/richtext/richtextsizepage.cpp:531
+#: ../src/richtext/richtextsizepage.cpp:538
+msgid "&Left:"
+msgstr "&მარცხენა:"
+
+#: ../src/richtext/richtextborderspage.cpp:257
+#: ../src/richtext/richtextborderspage.cpp:259
+msgid "Units for the left border width."
+msgstr "მარცხენა საზღვრის სიგანის ერთეული."
+
+#: ../src/richtext/richtextborderspage.cpp:266
+#: ../src/richtext/richtextborderspage.cpp:268
+#: ../src/richtext/richtextborderspage.cpp:300
+#: ../src/richtext/richtextborderspage.cpp:302
+#: ../src/richtext/richtextborderspage.cpp:334
+#: ../src/richtext/richtextborderspage.cpp:336
+#: ../src/richtext/richtextborderspage.cpp:368
+#: ../src/richtext/richtextborderspage.cpp:370
+#: ../src/richtext/richtextborderspage.cpp:434
+#: ../src/richtext/richtextborderspage.cpp:436
+#: ../src/richtext/richtextborderspage.cpp:468
+#: ../src/richtext/richtextborderspage.cpp:470
+#: ../src/richtext/richtextborderspage.cpp:502
+#: ../src/richtext/richtextborderspage.cpp:504
+#: ../src/richtext/richtextborderspage.cpp:536
+#: ../src/richtext/richtextborderspage.cpp:538
+msgid "The border line style."
+msgstr "საზღვრის ხაზის სტილი."
+
+#: ../src/richtext/richtextborderspage.cpp:276
+#: ../src/richtext/richtextborderspage.cpp:444
+#: ../src/richtext/richtextindentspage.cpp:212
+#: ../src/richtext/richtextliststylepage.cpp:402
+#: ../src/richtext/richtextmarginspage.cpp:210
+#: ../src/richtext/richtextmarginspage.cpp:324
+#: ../src/richtext/richtextsizepage.cpp:601
+#: ../src/richtext/richtextsizepage.cpp:608
+msgid "&Right:"
+msgstr "&მარჯვენა:"
+
+#: ../src/richtext/richtextborderspage.cpp:291
+#: ../src/richtext/richtextborderspage.cpp:293
+msgid "Units for the right border width."
+msgstr "მარჯვენა საზღვრის სიგანის ერთეული."
+
+#: ../src/richtext/richtextborderspage.cpp:310
+#: ../src/richtext/richtextborderspage.cpp:478
+#: ../src/richtext/richtextmarginspage.cpp:233
+#: ../src/richtext/richtextmarginspage.cpp:347
+#: ../src/richtext/richtextsizepage.cpp:566
+#: ../src/richtext/richtextsizepage.cpp:573
+msgid "&Top:"
+msgstr "&ზედა:"
+
+#: ../src/richtext/richtextborderspage.cpp:325
+#: ../src/richtext/richtextborderspage.cpp:327
+msgid "Units for the top border width."
+msgstr "ზედა საზღვრის სიგანის ერთეული."
+
+#: ../src/richtext/richtextborderspage.cpp:344
+#: ../src/richtext/richtextborderspage.cpp:512
+#: ../src/richtext/richtextmarginspage.cpp:258
+#: ../src/richtext/richtextmarginspage.cpp:372
+#: ../src/richtext/richtextsizepage.cpp:636
+#: ../src/richtext/richtextsizepage.cpp:643
+msgid "&Bottom:"
+msgstr "&ქვედა:"
+
+#: ../src/richtext/richtextborderspage.cpp:359
+#: ../src/richtext/richtextborderspage.cpp:361
+msgid "Units for the bottom border width."
+msgstr "ქვედა საზღვრის სიგანის ერთეული."
+
+#: ../src/richtext/richtextborderspage.cpp:380
+#: ../src/richtext/richtextborderspage.cpp:548
+msgid "&Synchronize values"
+msgstr "&მნიშვნელობების სინქრონიზაცია"
+
+#: ../src/richtext/richtextborderspage.cpp:382
+#: ../src/richtext/richtextborderspage.cpp:384
+#: ../src/richtext/richtextborderspage.cpp:550
+#: ../src/richtext/richtextborderspage.cpp:552
+msgid "Check to edit all borders simultaneously."
+msgstr "ჩართეთ ყველა საზღვრის ერთდროულად ჩასასწორებლად."
+
+#: ../src/richtext/richtextborderspage.cpp:397
+#: ../src/richtext/richtextborderspage.cpp:555
+msgid "Outline"
+msgstr "კონტური"
+
+#: ../src/richtext/richtextborderspage.cpp:425
+#: ../src/richtext/richtextborderspage.cpp:427
+msgid "Units for the left outline width."
+msgstr "მარცხენა კონტურის სიგანის ერთეული."
+
+#: ../src/richtext/richtextborderspage.cpp:459
+#: ../src/richtext/richtextborderspage.cpp:461
+msgid "Units for the right outline width."
+msgstr "მარჯვენა კონტურის სიგანის ერთეული."
+
+#: ../src/richtext/richtextborderspage.cpp:493
+#: ../src/richtext/richtextborderspage.cpp:495
+msgid "Units for the top outline width."
+msgstr "ზედა კონტურის სიგანის ერთეული."
+
+#: ../src/richtext/richtextborderspage.cpp:527
+#: ../src/richtext/richtextborderspage.cpp:529
+msgid "Units for the bottom outline width."
+msgstr "ქვედა კონტურის სიგანის ერთეული."
+
+#: ../src/richtext/richtextborderspage.cpp:565
+#: ../src/richtext/richtextborderspage.cpp:600
+msgid "Corner"
+msgstr "კუთხე"
+
+#: ../src/richtext/richtextborderspage.cpp:574
+msgid "Corner &radius:"
+msgstr "კუთხის &რადიუსი:"
+
+#: ../src/richtext/richtextborderspage.cpp:576
+#: ../src/richtext/richtextborderspage.cpp:578
+msgid "An optional corner radius for adding rounded corners."
+msgstr "არასავალდებულო კუთხის რადიუსი მომრგვალებული კუთხეების დასამატებლად."
+
+#: ../src/richtext/richtextborderspage.cpp:584
+#: ../src/richtext/richtextborderspage.cpp:586
+msgid "The value of the corner radius."
+msgstr "კუთხის რადიუსის მნიშვნელობა."
+
+#: ../src/richtext/richtextborderspage.cpp:595
+#: ../src/richtext/richtextborderspage.cpp:597
+msgid "Units for the corner radius."
+msgstr "კუთხის რადისუსის ერთეული."
+
+#: ../src/richtext/richtextborderspage.cpp:609
+#: ../src/richtext/richtextsizepage.cpp:247
+#: ../src/richtext/richtextsizepage.cpp:251
+msgid "None"
+msgstr "არაფერი"
+
+#: ../src/richtext/richtextborderspage.cpp:610
+msgid "Solid"
+msgstr "მყარი"
+
+#: ../src/richtext/richtextborderspage.cpp:611
+msgid "Dotted"
+msgstr "წერტილოვანი"
+
+#: ../src/richtext/richtextborderspage.cpp:612
+msgid "Dashed"
+msgstr "ტირეებით"
+
+#: ../src/richtext/richtextborderspage.cpp:613
+msgid "Double"
+msgstr "ორმაგი"
+
+#: ../src/richtext/richtextborderspage.cpp:614
+msgid "Groove"
+msgstr "სლოტი"
+
+#: ../src/richtext/richtextborderspage.cpp:615
+msgid "Ridge"
+msgstr "კიდე"
+
+#: ../src/richtext/richtextborderspage.cpp:616
+msgid "Inset"
+msgstr "ჩასმა"
+
+#: ../src/richtext/richtextborderspage.cpp:617
+msgid "Outset"
+msgstr "გარე ჩარჩო"
+
+#: ../src/richtext/richtextbuffer.cpp:3518
+msgid "Change Style"
+msgstr "სტილის შეცვლა"
+
+#: ../src/richtext/richtextbuffer.cpp:3701
+msgid "Change Object Style"
+msgstr "ობიექტის სტილის შეცვლა"
+
+#: ../src/richtext/richtextbuffer.cpp:3974
+#: ../src/richtext/richtextbuffer.cpp:8174
+msgid "Change Properties"
+msgstr "თვისებების შეცვლა"
+
+#: ../src/richtext/richtextbuffer.cpp:4346
+msgid "Change List Style"
+msgstr "სიის სტილის შეცვლა"
+
+#: ../src/richtext/richtextbuffer.cpp:4519
+msgid "Renumber List"
+msgstr "სიის გადანომრვა"
+
+#: ../src/richtext/richtextbuffer.cpp:7867
+#: ../src/richtext/richtextbuffer.cpp:7897
+#: ../src/richtext/richtextbuffer.cpp:7939
+#: ../src/richtext/richtextctrl.cpp:1279 ../src/richtext/richtextctrl.cpp:1473
+msgid "Insert Text"
+msgstr "ტექსტის ჩასმა"
+
+#: ../src/richtext/richtextbuffer.cpp:8023
+#: ../src/richtext/richtextbuffer.cpp:8979
+msgid "Insert Image"
+msgstr "გამოსახულების დამატება"
+
+#: ../src/richtext/richtextbuffer.cpp:8070
+msgid "Insert Object"
+msgstr "ობიექტის ჩასმა"
+
+#: ../src/richtext/richtextbuffer.cpp:8112
+msgid "Insert Field"
+msgstr "ველის ჩასმა"
+
+#: ../src/richtext/richtextbuffer.cpp:8410
+msgid "Too many EndStyle calls!"
+msgstr "EndStyle -ის მეტისმეტად ბევრი გამოძახება!"
+
+#: ../src/richtext/richtextbuffer.cpp:8785
+msgid "files"
+msgstr "ფაილები"
+
+#: ../src/richtext/richtextbuffer.cpp:9380
+msgid "standard/circle"
+msgstr "სტანდარტული/წრეწირი"
+
+#: ../src/richtext/richtextbuffer.cpp:9381
+msgid "standard/circle-outline"
+msgstr "სტანდარტული/წრეწირის-კონტური"
+
+#: ../src/richtext/richtextbuffer.cpp:9382
+msgid "standard/square"
+msgstr "სტანდარტული/ოთხკუთხედი"
+
+#: ../src/richtext/richtextbuffer.cpp:9383
+msgid "standard/diamond"
+msgstr "სტანდარტული/პრიზმა"
+
+#: ../src/richtext/richtextbuffer.cpp:9384
+msgid "standard/triangle"
+msgstr "სტანდარტული/სამკუთხედი"
+
+#: ../src/richtext/richtextbuffer.cpp:9423
+msgid "Box Properties"
+msgstr "ველის თვისებები"
+
+#: ../src/richtext/richtextbuffer.cpp:10006
+msgid "Multiple Cell Properties"
+msgstr "ბევრი უჯრედის თვისება"
+
+#: ../src/richtext/richtextbuffer.cpp:10008
+msgid "Cell Properties"
+msgstr "უჯრედის თვისებები"
+
+#: ../src/richtext/richtextbuffer.cpp:11256
+msgid "Set Cell Style"
+msgstr "უჯრედის სტილის დაყენება"
+
+#: ../src/richtext/richtextbuffer.cpp:11330
+msgid "Delete Row"
+msgstr "მწკრივის წაშლა"
+
+#: ../src/richtext/richtextbuffer.cpp:11380
+msgid "Delete Column"
+msgstr "სვეტის წაშლა"
+
+#: ../src/richtext/richtextbuffer.cpp:11431
+msgid "Add Row"
+msgstr "მწკრივის დამატება"
+
+#: ../src/richtext/richtextbuffer.cpp:11494
+msgid "Add Column"
+msgstr "წვეტის დამატება"
+
+#: ../src/richtext/richtextbuffer.cpp:11537
+msgid "Table Properties"
+msgstr "ცხრილის თვისებები"
+
+#: ../src/richtext/richtextbuffer.cpp:12899
+msgid "Picture Properties"
+msgstr "სურათის თვისებები"
+
+#: ../src/richtext/richtextbuffer.cpp:13169
+#: ../src/richtext/richtextbuffer.cpp:13279
+msgid "image"
+msgstr "გამოსახულება"
+
+#: ../src/richtext/richtextbulletspage.cpp:145
+#: ../src/richtext/richtextliststylepage.cpp:209
+msgid "&Bullet style:"
+msgstr "&ტყვიის სტილი:"
+
+#: ../src/richtext/richtextbulletspage.cpp:150
+#: ../src/richtext/richtextbulletspage.cpp:152
+#: ../src/richtext/richtextliststylepage.cpp:214
+#: ../src/richtext/richtextliststylepage.cpp:216
+msgid "The available bullet styles."
+msgstr "მარკერების ხელმისაწვდომი სტილები."
+
+#: ../src/richtext/richtextbulletspage.cpp:158
+#: ../src/richtext/richtextliststylepage.cpp:221
+msgid "Peri&od"
+msgstr "_წერტილი"
+
+#: ../src/richtext/richtextbulletspage.cpp:160
+#: ../src/richtext/richtextbulletspage.cpp:162
+#: ../src/richtext/richtextliststylepage.cpp:223
+#: ../src/richtext/richtextliststylepage.cpp:225
+msgid "Check to add a period after the bullet."
+msgstr "წკაპი მარკერის შემდეგ წერტილის დასამატებლად."
+
+#. TRANSLATORS: Bullet point in parentheses option
+#: ../src/richtext/richtextbulletspage.cpp:167
+#: ../src/richtext/richtextliststylepage.cpp:230
+msgid "(*)"
+msgstr "(*)"
+
+#: ../src/richtext/richtextbulletspage.cpp:169
+#: ../src/richtext/richtextbulletspage.cpp:171
+#: ../src/richtext/richtextliststylepage.cpp:232
+#: ../src/richtext/richtextliststylepage.cpp:234
+msgid "Check to enclose the bullet in parentheses."
+msgstr "წკაპი მარკერის ფრჩხილებში ჩასასმელად."
+
+#. TRANSLATORS: Right parenthesis bullet point option
+#: ../src/richtext/richtextbulletspage.cpp:176
+#: ../src/richtext/richtextliststylepage.cpp:239
+msgid "*)"
+msgstr "*)"
+
+#: ../src/richtext/richtextbulletspage.cpp:178
+#: ../src/richtext/richtextbulletspage.cpp:180
+#: ../src/richtext/richtextliststylepage.cpp:241
+#: ../src/richtext/richtextliststylepage.cpp:243
+msgid "Check to add a right parenthesis."
+msgstr "წკაპი მარჯვენა ფრჩხილის დასამატებლად."
+
+#: ../src/richtext/richtextbulletspage.cpp:185
+#: ../src/richtext/richtextliststylepage.cpp:248
+msgid "Bullet &Alignment:"
+msgstr "მარკერის &სწორება:"
+
+#: ../src/richtext/richtextbulletspage.cpp:190
+#: ../src/richtext/richtextliststylepage.cpp:253
+msgid "Centre"
+msgstr "ცენტრი"
+
+#: ../src/richtext/richtextbulletspage.cpp:194
+#: ../src/richtext/richtextbulletspage.cpp:196
+#: ../src/richtext/richtextbulletspage.cpp:217
+#: ../src/richtext/richtextbulletspage.cpp:219
+#: ../src/richtext/richtextliststylepage.cpp:257
+#: ../src/richtext/richtextliststylepage.cpp:259
+#: ../src/richtext/richtextliststylepage.cpp:278
+#: ../src/richtext/richtextliststylepage.cpp:280
+msgid "The bullet character."
+msgstr "მარკერის სიმბოლო."
+
+#: ../src/richtext/richtextbulletspage.cpp:212
+#: ../src/richtext/richtextliststylepage.cpp:271
+msgid "&Symbol:"
+msgstr "&სიმბოლო:"
+
+#: ../src/richtext/richtextbulletspage.cpp:222
+#: ../src/richtext/richtextliststylepage.cpp:283
+msgid "Ch&oose..."
+msgstr "&აირჩიეთ..."
+
+#: ../src/richtext/richtextbulletspage.cpp:223
+#: ../src/richtext/richtextbulletspage.cpp:225
+#: ../src/richtext/richtextliststylepage.cpp:284
+#: ../src/richtext/richtextliststylepage.cpp:286
+msgid "Click to browse for a symbol."
+msgstr "წკაპი სიმბოლოს მოსაძებნად."
+
+#: ../src/richtext/richtextbulletspage.cpp:230
+#: ../src/richtext/richtextliststylepage.cpp:291
+msgid "Symbol &font:"
+msgstr "სიმბოლოს &ფონტი:"
+
+#: ../src/richtext/richtextbulletspage.cpp:235
+#: ../src/richtext/richtextbulletspage.cpp:237
+#: ../src/richtext/richtextliststylepage.cpp:297
+msgid "Available fonts."
+msgstr "ხელმისაწვდომი ფონტები."
+
+#: ../src/richtext/richtextbulletspage.cpp:242
+#: ../src/richtext/richtextliststylepage.cpp:302
+msgid "S&tandard bullet name:"
+msgstr "&სტანდარტული მარკერის სახელი:"
+
+#: ../src/richtext/richtextbulletspage.cpp:247
+#: ../src/richtext/richtextbulletspage.cpp:249
+#: ../src/richtext/richtextliststylepage.cpp:307
+#: ../src/richtext/richtextliststylepage.cpp:309
+msgid "A standard bullet name."
+msgstr "სტანდარტული მარკერის სახელი."
+
+#: ../src/richtext/richtextbulletspage.cpp:254
+msgid "&Number:"
+msgstr "&რიცხვი:"
+
+#: ../src/richtext/richtextbulletspage.cpp:258
+#: ../src/richtext/richtextbulletspage.cpp:260
+msgid "The list item number."
+msgstr "სიის ჩანაწერის ნომერი."
+
+#: ../src/richtext/richtextbulletspage.cpp:266
+#: ../src/richtext/richtextbulletspage.cpp:268
+#: ../src/richtext/richtextliststylepage.cpp:475
+#: ../src/richtext/richtextliststylepage.cpp:477
+msgid "Shows a preview of the bullet settings."
+msgstr "მარკერის პარამეტრების გადახედვის ჩვენება."
+
+#: ../src/richtext/richtextbulletspage.cpp:276
+#: ../src/richtext/richtextliststylepage.cpp:484
+msgid "(None)"
+msgstr "(არცერთი)"
+
+#: ../src/richtext/richtextbulletspage.cpp:277
+#: ../src/richtext/richtextliststylepage.cpp:485
+msgid "Arabic"
+msgstr "არაბული"
+
+#: ../src/richtext/richtextbulletspage.cpp:278
+#: ../src/richtext/richtextliststylepage.cpp:486
+msgid "Upper case letters"
+msgstr "დიდი ასოები"
+
+#: ../src/richtext/richtextbulletspage.cpp:279
+#: ../src/richtext/richtextliststylepage.cpp:487
+msgid "Lower case letters"
+msgstr "პატარა ასოები"
+
+#: ../src/richtext/richtextbulletspage.cpp:280
+#: ../src/richtext/richtextliststylepage.cpp:488
+msgid "Upper case roman numerals"
+msgstr "დიდი რომაული რიცხვები"
+
+#: ../src/richtext/richtextbulletspage.cpp:281
+#: ../src/richtext/richtextliststylepage.cpp:489
+msgid "Lower case roman numerals"
+msgstr "პატარა რომაული რიცხვები"
+
+#: ../src/richtext/richtextbulletspage.cpp:282
+#: ../src/richtext/richtextliststylepage.cpp:490
+msgid "Numbered outline"
+msgstr "დანომრილი კონტური"
+
+#: ../src/richtext/richtextbulletspage.cpp:283
+#: ../src/richtext/richtextliststylepage.cpp:491
+msgid "Symbol"
+msgstr "სიმბოლო"
+
+#: ../src/richtext/richtextbulletspage.cpp:284
+#: ../src/richtext/richtextliststylepage.cpp:492
+msgid "Bitmap"
+msgstr "ბიტური რუკა"
+
+#: ../src/richtext/richtextbulletspage.cpp:285
+#: ../src/richtext/richtextliststylepage.cpp:493
+msgid "Standard"
+msgstr "სტანდარტული"
+
+#: ../src/richtext/richtextbulletspage.cpp:287
+#: ../src/richtext/richtextliststylepage.cpp:495
+msgid "*"
+msgstr "*"
+
+#: ../src/richtext/richtextbulletspage.cpp:288
+#: ../src/richtext/richtextliststylepage.cpp:496
+msgid "-"
+msgstr "-"
+
+#: ../src/richtext/richtextbulletspage.cpp:289
+#: ../src/richtext/richtextliststylepage.cpp:497
+msgid ">"
+msgstr ">"
+
+#: ../src/richtext/richtextbulletspage.cpp:290
+#: ../src/richtext/richtextliststylepage.cpp:498
+msgid "+"
+msgstr "+"
+
+#: ../src/richtext/richtextbulletspage.cpp:291
+#: ../src/richtext/richtextliststylepage.cpp:499
+msgid "~"
+msgstr "~"
+
+#: ../src/richtext/richtextctrl.cpp:859
+msgid "Drag"
+msgstr "გადათრევა"
+
+#: ../src/richtext/richtextctrl.cpp:1338 ../src/richtext/richtextctrl.cpp:1559
+msgid "Delete Text"
+msgstr "ტექსტის წაშლა"
+
+#: ../src/richtext/richtextctrl.cpp:1537
+msgid "Remove Bullet"
+msgstr "მარკერის მოცილება"
+
+#: ../src/richtext/richtextctrl.cpp:3070
+msgid "The text couldn't be saved."
+msgstr "ტექსტის შენახვა შეუძლებელია."
+
+#: ../src/richtext/richtextctrl.cpp:3644
+msgid "Replace"
+msgstr "ჩანაცვლება"
+
+#: ../src/richtext/richtextfontpage.cpp:146
+#: ../src/richtext/richtextsymboldlg.cpp:384
+msgid "&Font:"
+msgstr "&ფონტი:"
+
+#: ../src/richtext/richtextfontpage.cpp:150
+#: ../src/richtext/richtextfontpage.cpp:152
+msgid "Type a font name."
+msgstr "აკრიფეთ ფონტის სახელი."
+
+#: ../src/richtext/richtextfontpage.cpp:158
+msgid "&Size:"
+msgstr "&ზომა:"
+
+#: ../src/richtext/richtextfontpage.cpp:165
+#: ../src/richtext/richtextfontpage.cpp:167
+msgid "Type a size in points."
+msgstr "აკრიფეთ ზომა, წერტილებში."
+
+#: ../src/richtext/richtextfontpage.cpp:180
+#: ../src/richtext/richtextfontpage.cpp:182
+msgid "The font size units, points or pixels."
+msgstr "ფონტის ზომის ერთეული. წერტილები თუ პიქსელები."
+
+#: ../src/richtext/richtextfontpage.cpp:189
+#: ../src/richtext/richtextfontpage.cpp:191
+msgid "Lists the available fonts."
+msgstr "ხელმისაწვდომი ფონტების სია."
+
+#: ../src/richtext/richtextfontpage.cpp:196
+#: ../src/richtext/richtextfontpage.cpp:198
+msgid "Lists font sizes in points."
+msgstr "ფონტის ხელმისაწვდომი ზომების სია, წერტილებში."
+
+#: ../src/richtext/richtextfontpage.cpp:207
+msgid "Font st&yle:"
+msgstr "ფონტის &სტილი:"
+
+#: ../src/richtext/richtextfontpage.cpp:212
+#: ../src/richtext/richtextfontpage.cpp:214
+msgid "Select regular or italic style."
+msgstr "აირჩიეთ ჩვეულებრივი ან კურსივი სტილი."
+
+#: ../src/richtext/richtextfontpage.cpp:220
+msgid "Font &weight:"
+msgstr "ფონტის &წონა:"
+
+#: ../src/richtext/richtextfontpage.cpp:225
+#: ../src/richtext/richtextfontpage.cpp:227
+msgid "Select regular or bold."
+msgstr "აირჩიეთ ჩვეულებრივი ან სქელი."
+
+#: ../src/richtext/richtextfontpage.cpp:233
+msgid "&Underlining:"
+msgstr "&ხაზგასმა:"
+
+#: ../src/richtext/richtextfontpage.cpp:238
+#: ../src/richtext/richtextfontpage.cpp:240
+msgid "Select underlining or no underlining."
+msgstr "აირჩიეთ ქვეშგასმა ან ქვეშგასმის გარეშე."
+
+#: ../src/richtext/richtextfontpage.cpp:248
+msgid "&Colour:"
+msgstr "&ფერი:"
+
+#: ../src/richtext/richtextfontpage.cpp:253
+#: ../src/richtext/richtextfontpage.cpp:255
+msgid "Click to change the text colour."
+msgstr "წკაპი ტექსტის ფერის შესაცვლელად."
+
+#: ../src/richtext/richtextfontpage.cpp:261
+msgid "&Bg colour:"
+msgstr "&ფონის ფერი:"
+
+#: ../src/richtext/richtextfontpage.cpp:266
+#: ../src/richtext/richtextfontpage.cpp:268
+msgid "Click to change the text background colour."
+msgstr "წკაპი ტექსტის ფონის ფერის შესაცვლელად."
+
+#: ../src/richtext/richtextfontpage.cpp:276
+#: ../src/richtext/richtextfontpage.cpp:278
+msgid "Check to show a line through the text."
+msgstr "წკაპი ტექსტის მიღმა ხაზის საჩვენებლად."
+
+#: ../src/richtext/richtextfontpage.cpp:281
+msgid "Ca&pitals"
+msgstr "დიდი &ასოებით"
+
+#: ../src/richtext/richtextfontpage.cpp:283
+#: ../src/richtext/richtextfontpage.cpp:285
+msgid "Check to show the text in capitals."
+msgstr "წკაპი ტექსტის დიდი ასოებით საჩვენებლად."
+
+#: ../src/richtext/richtextfontpage.cpp:288
+msgid "Small C&apitals"
+msgstr "მცირე დიდი &ასოებით"
+
+#: ../src/richtext/richtextfontpage.cpp:290
+#: ../src/richtext/richtextfontpage.cpp:292
+msgid "Check to show the text in small capitals."
+msgstr "წკაპი ტექსტის პატარა ასოებით საჩვენებლად."
+
+#: ../src/richtext/richtextfontpage.cpp:295
+msgid "Supe&rscript"
+msgstr "&სუპერსკრიპტი"
+
+#: ../src/richtext/richtextfontpage.cpp:297
+#: ../src/richtext/richtextfontpage.cpp:299
+msgid "Check to show the text in superscript."
+msgstr "წკაპი ტექსტის სუპერსკრიპტით საჩვენებლად."
+
+#: ../src/richtext/richtextfontpage.cpp:302
+msgid "Subscrip&t"
+msgstr "&საბსკრიპტი"
+
+#: ../src/richtext/richtextfontpage.cpp:304
+#: ../src/richtext/richtextfontpage.cpp:306
+msgid "Check to show the text in subscript."
+msgstr "წკაპი ტექსის ქვესკრიპრიტით საჩვენებლად."
+
+#: ../src/richtext/richtextfontpage.cpp:312
+msgid "Rig&ht-to-left"
+msgstr "&მარჯვნიდან მარცხნივ"
+
+#: ../src/richtext/richtextfontpage.cpp:314
+#: ../src/richtext/richtextfontpage.cpp:316
+msgid "Check to indicate right-to-left text layout."
+msgstr "ჩართეთ მარჯვნიდან-მარცხნივ ტექსტის განლაგების მითითებისთვის."
+
+#: ../src/richtext/richtextfontpage.cpp:319
+msgid "Suppress hyphe&nation"
+msgstr "&გადატანების აკრძალვა"
+
+#: ../src/richtext/richtextfontpage.cpp:321
+#: ../src/richtext/richtextfontpage.cpp:323
+msgid "Check to suppress hyphenation."
+msgstr "ჩართეთ გადატანების ასაკრძალად."
+
+#: ../src/richtext/richtextfontpage.cpp:329
+#: ../src/richtext/richtextfontpage.cpp:331
+msgid "Shows a preview of the font settings."
+msgstr "ფონტის პარამეტრების გადახედვის ჩვენება."
+
+#: ../src/richtext/richtextfontpage.cpp:348
+#: ../src/richtext/richtextfontpage.cpp:352
+#: ../src/richtext/richtextfontpage.cpp:356
+#: ../src/richtext/richtextformatdlg.cpp:873
+#: ../src/richtext/richtextindentspage.cpp:273
+#: ../src/richtext/richtextindentspage.cpp:285
+#: ../src/richtext/richtextindentspage.cpp:286
+#: ../src/richtext/richtextindentspage.cpp:310
+#: ../src/richtext/richtextindentspage.cpp:325
+#: ../src/richtext/richtextliststylepage.cpp:451
+#: ../src/richtext/richtextliststylepage.cpp:463
+#: ../src/richtext/richtextliststylepage.cpp:464
+msgid "(none)"
+msgstr "(არაფერი)"
+
+#: ../src/richtext/richtextfontpage.cpp:349
+#: ../src/richtext/richtextfontpage.cpp:353
+msgid "Regular"
+msgstr "ჩვეულებრივი"
+
+#: ../src/richtext/richtextfontpage.cpp:357
+msgid "Not underlined"
+msgstr "ხაზგასმის გარეშე"
+
+#: ../src/richtext/richtextformatdlg.cpp:341
+msgid "Indents && Spacing"
+msgstr "შეწევა და დაშორება"
+
+#: ../src/richtext/richtextformatdlg.cpp:346
+msgid "Tabs"
+msgstr "დაფები"
+
+#: ../src/richtext/richtextformatdlg.cpp:351
+msgid "Bullets"
+msgstr "ტყვიები"
+
+#: ../src/richtext/richtextformatdlg.cpp:356
+msgid "List Style"
+msgstr "სიის სტილი"
+
+#: ../src/richtext/richtextformatdlg.cpp:366
+#: ../src/richtext/richtextmarginspage.cpp:170
+msgid "Margins"
+msgstr "გვერდის ველები"
+
+#: ../src/richtext/richtextformatdlg.cpp:371
+msgid "Borders"
+msgstr "საზღვრები"
+
+#: ../src/richtext/richtextformatdlg.cpp:765
+msgid "Colour"
+msgstr "ფერი"
+
+#: ../src/richtext/richtextindentspage.cpp:127
+#: ../src/richtext/richtextliststylepage.cpp:322
+msgid "&Alignment"
+msgstr "&სწორება"
+
+#: ../src/richtext/richtextindentspage.cpp:138
+#: ../src/richtext/richtextliststylepage.cpp:331
+msgid "&Left"
+msgstr "მარ&ცხნივ"
+
+#: ../src/richtext/richtextindentspage.cpp:140
+#: ../src/richtext/richtextindentspage.cpp:142
+#: ../src/richtext/richtextliststylepage.cpp:333
+#: ../src/richtext/richtextliststylepage.cpp:335
+msgid "Left-align text."
+msgstr "ტექსტის მარცხნივ-სწორება."
+
+#: ../src/richtext/richtextindentspage.cpp:145
+#: ../src/richtext/richtextliststylepage.cpp:338
+msgid "&Right"
+msgstr "მარ&ჯვნივ"
+
+#: ../src/richtext/richtextindentspage.cpp:147
+#: ../src/richtext/richtextindentspage.cpp:149
+#: ../src/richtext/richtextliststylepage.cpp:340
+#: ../src/richtext/richtextliststylepage.cpp:342
+msgid "Right-align text."
+msgstr "ტექსტის მარჯვნივ-სწორება."
+
+#: ../src/richtext/richtextindentspage.cpp:152
+#: ../src/richtext/richtextliststylepage.cpp:345
+msgid "&Justified"
+msgstr "&გასწორებული"
+
+#: ../src/richtext/richtextindentspage.cpp:154
+#: ../src/richtext/richtextindentspage.cpp:156
+#: ../src/richtext/richtextliststylepage.cpp:347
+#: ../src/richtext/richtextliststylepage.cpp:349
+msgid "Justify text left and right."
+msgstr "ტექსტის მარჯვნივ და მარცხნივ გასწორება."
+
+#: ../src/richtext/richtextindentspage.cpp:159
+#: ../src/richtext/richtextliststylepage.cpp:352
+msgid "Cen&tred"
+msgstr "&ცენტრირება"
+
+#: ../src/richtext/richtextindentspage.cpp:161
+#: ../src/richtext/richtextindentspage.cpp:163
+#: ../src/richtext/richtextliststylepage.cpp:354
+#: ../src/richtext/richtextliststylepage.cpp:356
+msgid "Centre text."
+msgstr "ტექსტის ცენტრირება."
+
+#: ../src/richtext/richtextindentspage.cpp:166
+#: ../src/richtext/richtextliststylepage.cpp:359
+msgid "&Indeterminate"
+msgstr "&გაურკვეველი"
+
+#: ../src/richtext/richtextindentspage.cpp:168
+#: ../src/richtext/richtextindentspage.cpp:170
+#: ../src/richtext/richtextliststylepage.cpp:361
+#: ../src/richtext/richtextliststylepage.cpp:363
+msgid "Use the current alignment setting."
+msgstr "სწორების მიმდინარე პარამეტრის ჩვენება."
+
+#: ../src/richtext/richtextindentspage.cpp:183
+#: ../src/richtext/richtextliststylepage.cpp:375
+msgid "&Indentation (tenths of a mm)"
+msgstr "&შეწევა (მმ-ის მეათედებში)"
+
+#: ../src/richtext/richtextindentspage.cpp:198
+#: ../src/richtext/richtextindentspage.cpp:200
+#: ../src/richtext/richtextliststylepage.cpp:388
+#: ../src/richtext/richtextliststylepage.cpp:390
+msgid "The left indent."
+msgstr "მარცხნივ შეწევა."
+
+#: ../src/richtext/richtextindentspage.cpp:203
+#: ../src/richtext/richtextliststylepage.cpp:393
+msgid "Left (&first line):"
+msgstr "მარცხნივ (&პირველი ხაზი):"
+
+#: ../src/richtext/richtextindentspage.cpp:207
+#: ../src/richtext/richtextindentspage.cpp:209
+#: ../src/richtext/richtextliststylepage.cpp:397
+#: ../src/richtext/richtextliststylepage.cpp:399
+msgid "The first line indent."
+msgstr "პირველი ხაზის შეწევა."
+
+#: ../src/richtext/richtextindentspage.cpp:216
+#: ../src/richtext/richtextindentspage.cpp:218
+#: ../src/richtext/richtextliststylepage.cpp:406
+#: ../src/richtext/richtextliststylepage.cpp:408
+msgid "The right indent."
+msgstr "მარჯვნივ შეწევა."
+
+#: ../src/richtext/richtextindentspage.cpp:221
+msgid "&Outline level:"
+msgstr "&კონტურის დონე:"
+
+#: ../src/richtext/richtextindentspage.cpp:226
+#: ../src/richtext/richtextindentspage.cpp:228
+msgid "The outline level."
+msgstr "კონტურის დონე."
+
+#: ../src/richtext/richtextindentspage.cpp:241
+#: ../src/richtext/richtextliststylepage.cpp:420
+msgid "&Spacing (tenths of a mm)"
+msgstr "&დაშორება (მმ-ის მეათედებში)"
+
+#: ../src/richtext/richtextindentspage.cpp:252
+msgid "&Before a paragraph:"
+msgstr "&პარაგრაფამდე:"
+
+#: ../src/richtext/richtextindentspage.cpp:256
+#: ../src/richtext/richtextindentspage.cpp:258
+#: ../src/richtext/richtextliststylepage.cpp:433
+#: ../src/richtext/richtextliststylepage.cpp:435
+msgid "The spacing before the paragraph."
+msgstr "პარაგრაფამდე დაშორება."
+
+#: ../src/richtext/richtextindentspage.cpp:261
+msgid "&After a paragraph:"
+msgstr "&პარაგრაფის შემდეგ:"
+
+#: ../src/richtext/richtextindentspage.cpp:266
+#: ../src/richtext/richtextliststylepage.cpp:442
+#: ../src/richtext/richtextliststylepage.cpp:444
+msgid "The spacing after the paragraph."
+msgstr "პარაგრაფის შემდეგ დაშორება."
+
+#: ../src/richtext/richtextindentspage.cpp:269
+msgid "L&ine spacing:"
+msgstr "&ხაზებს შორის ინტერვალი:"
+
+#: ../src/richtext/richtextindentspage.cpp:274
+#: ../src/richtext/richtextliststylepage.cpp:452
+msgid "Single"
+msgstr "ერთი"
+
+#: ../src/richtext/richtextindentspage.cpp:275
+#: ../src/richtext/richtextliststylepage.cpp:453
+msgid "1.1"
+msgstr "1.1"
+
+#: ../src/richtext/richtextindentspage.cpp:276
+#: ../src/richtext/richtextliststylepage.cpp:454
+msgid "1.2"
+msgstr "1.2"
+
+#: ../src/richtext/richtextindentspage.cpp:277
+#: ../src/richtext/richtextliststylepage.cpp:455
+msgid "1.3"
+msgstr "1.3"
+
+#: ../src/richtext/richtextindentspage.cpp:278
+#: ../src/richtext/richtextliststylepage.cpp:456
+msgid "1.4"
+msgstr "1.4"
+
+#: ../src/richtext/richtextindentspage.cpp:279
+#: ../src/richtext/richtextliststylepage.cpp:457
+msgid "1.5"
+msgstr "1.5"
+
+#: ../src/richtext/richtextindentspage.cpp:280
+#: ../src/richtext/richtextliststylepage.cpp:458
+msgid "1.6"
+msgstr "1.6"
+
+#: ../src/richtext/richtextindentspage.cpp:281
+#: ../src/richtext/richtextliststylepage.cpp:459
+msgid "1.7"
+msgstr "1.7"
+
+#: ../src/richtext/richtextindentspage.cpp:282
+#: ../src/richtext/richtextliststylepage.cpp:460
+msgid "1.8"
+msgstr "1.8"
+
+#: ../src/richtext/richtextindentspage.cpp:283
+#: ../src/richtext/richtextliststylepage.cpp:461
+msgid "1.9"
+msgstr "1.9"
+
+#: ../src/richtext/richtextindentspage.cpp:284
+#: ../src/richtext/richtextliststylepage.cpp:462
+msgid "2"
+msgstr "2"
+
+#: ../src/richtext/richtextindentspage.cpp:287
+#: ../src/richtext/richtextindentspage.cpp:289
+#: ../src/richtext/richtextliststylepage.cpp:465
+#: ../src/richtext/richtextliststylepage.cpp:467
+msgid "The line spacing."
+msgstr "ხაზებს შორის მანძილი."
+
+#: ../src/richtext/richtextindentspage.cpp:292
+msgid "&Page Break"
+msgstr "&გვერდის გახლეჩა"
+
+#: ../src/richtext/richtextindentspage.cpp:294
+#: ../src/richtext/richtextindentspage.cpp:296
+msgid "Inserts a page break before the paragraph."
+msgstr "ჩასვამს გვერდის გადატანას აბზაცამდე."
+
+#: ../src/richtext/richtextindentspage.cpp:302
+#: ../src/richtext/richtextindentspage.cpp:304
+msgid "Shows a preview of the paragraph settings."
+msgstr "აჩვენებს აბზაცის პარამეტრების მინიატურას."
+
+#: ../src/richtext/richtextliststylepage.cpp:182
+msgid "&List level:"
+msgstr "&სიის დონე:"
+
+#: ../src/richtext/richtextliststylepage.cpp:186
+#: ../src/richtext/richtextliststylepage.cpp:188
+msgid "Selects the list level to edit."
+msgstr "ირჩევს ჩასასწორებელი სიის დონეს."
+
+#: ../src/richtext/richtextliststylepage.cpp:193
+msgid "&Font for Level..."
+msgstr "&ფონტი დონისთვის...."
+
+#: ../src/richtext/richtextliststylepage.cpp:194
+#: ../src/richtext/richtextliststylepage.cpp:196
+msgid "Click to choose the font for this level."
+msgstr "დააწკაპუნეთ ამ დონისთვის ფონტის ასარჩევად."
+
+#: ../src/richtext/richtextliststylepage.cpp:312
+msgid "Bullet style"
+msgstr "მარკერის სტილი"
+
+#: ../src/richtext/richtextliststylepage.cpp:429
+msgid "Before a paragraph:"
+msgstr "პარაგრაფამდე:"
+
+#: ../src/richtext/richtextliststylepage.cpp:438
+msgid "After a paragraph:"
+msgstr "პარაგრაფის შემდეგ:"
+
+#: ../src/richtext/richtextliststylepage.cpp:447
+msgid "Line spacing:"
+msgstr "ხაზებს შუა მანძილი:"
+
+#: ../src/richtext/richtextliststylepage.cpp:470
+msgid "Spacing"
+msgstr "დაშორება"
+
+#: ../src/richtext/richtextmarginspage.cpp:193
+#: ../src/richtext/richtextmarginspage.cpp:195
+msgid "The left margin size."
+msgstr "მარცხენა ზღვრის ზომა."
+
+#: ../src/richtext/richtextmarginspage.cpp:203
+#: ../src/richtext/richtextmarginspage.cpp:205
+msgid "Units for the left margin."
+msgstr "მარცხენა ზღვრის ზომის ერთეული."
+
+#: ../src/richtext/richtextmarginspage.cpp:218
+#: ../src/richtext/richtextmarginspage.cpp:220
+msgid "The right margin size."
+msgstr "მარჯვენა ზღვრის ზომა."
+
+#: ../src/richtext/richtextmarginspage.cpp:228
+#: ../src/richtext/richtextmarginspage.cpp:230
+msgid "Units for the right margin."
+msgstr "მარჯვენა ზღვრის ზომის ერთეული."
+
+#: ../src/richtext/richtextmarginspage.cpp:241
+#: ../src/richtext/richtextmarginspage.cpp:243
+msgid "The top margin size."
+msgstr "ზედა ზღვრის ზომა."
+
+#: ../src/richtext/richtextmarginspage.cpp:251
+#: ../src/richtext/richtextmarginspage.cpp:253
+msgid "Units for the top margin."
+msgstr "ზედა ზღვრის ზომის ერთეული."
+
+#: ../src/richtext/richtextmarginspage.cpp:266
+#: ../src/richtext/richtextmarginspage.cpp:268
+msgid "The bottom margin size."
+msgstr "ქვედა ზღვრის ზომა."
+
+#: ../src/richtext/richtextmarginspage.cpp:276
+#: ../src/richtext/richtextmarginspage.cpp:278
+msgid "Units for the bottom margin."
+msgstr "ქვედა ზღვრის ზომის ერთეული."
+
+#: ../src/richtext/richtextmarginspage.cpp:284
+msgid "Padding"
+msgstr "შევსება"
+
+#: ../src/richtext/richtextmarginspage.cpp:307
+#: ../src/richtext/richtextmarginspage.cpp:309
+msgid "The left padding size."
+msgstr "მარცხნიდან შევსების ზომა."
+
+#: ../src/richtext/richtextmarginspage.cpp:317
+#: ../src/richtext/richtextmarginspage.cpp:319
+msgid "Units for the left padding."
+msgstr "მარცხნიდან შევსების ზომის ერთეული."
+
+#: ../src/richtext/richtextmarginspage.cpp:332
+#: ../src/richtext/richtextmarginspage.cpp:334
+msgid "The right padding size."
+msgstr "მარჯვნიდან შევსების ზომა."
+
+#: ../src/richtext/richtextmarginspage.cpp:342
+#: ../src/richtext/richtextmarginspage.cpp:344
+msgid "Units for the right padding."
+msgstr "მარჯვნიდან შევსების ზომის ერთეული."
+
+#: ../src/richtext/richtextmarginspage.cpp:355
+#: ../src/richtext/richtextmarginspage.cpp:357
+msgid "The top padding size."
+msgstr "ზემოდან შევსების ზომა."
+
+#: ../src/richtext/richtextmarginspage.cpp:365
+#: ../src/richtext/richtextmarginspage.cpp:367
+msgid "Units for the top padding."
+msgstr "ზემოდან შევსების ზომის ერთეული."
+
+#: ../src/richtext/richtextmarginspage.cpp:380
+#: ../src/richtext/richtextmarginspage.cpp:382
+msgid "The bottom padding size."
+msgstr "ქვემოთ შევსების ზომა."
+
+#: ../src/richtext/richtextmarginspage.cpp:390
+#: ../src/richtext/richtextmarginspage.cpp:392
+msgid "Units for the bottom padding."
+msgstr "ქვემოთ შევსების ზომის ერთეული."
+
+#: ../src/richtext/richtextprint.cpp:592
+msgid " Preview"
+msgstr " გადახედვა"
+
+#: ../src/richtext/richtextsizepage.cpp:228
+msgid "Floating"
+msgstr "მცურავი"
+
+#: ../src/richtext/richtextsizepage.cpp:243
+msgid "&Floating mode:"
+msgstr "&მცურავი რეჟიმი:"
+
+#: ../src/richtext/richtextsizepage.cpp:252
+#: ../src/richtext/richtextsizepage.cpp:254
+msgid "How the object will float relative to the text."
+msgstr "როგორ ილივლივებს ობიექტი ტექსტთან შედარებით."
+
+#: ../src/richtext/richtextsizepage.cpp:265
+msgid "Alignment"
+msgstr "სწორება"
+
+#: ../src/richtext/richtextsizepage.cpp:277
+msgid "&Vertical alignment:"
+msgstr "&ვერტიკალური სწორება:"
+
+#: ../src/richtext/richtextsizepage.cpp:279
+#: ../src/richtext/richtextsizepage.cpp:281
+msgid "Enable vertical alignment."
+msgstr "ვერტიკალური სწორების ჩართვა."
+
+#: ../src/richtext/richtextsizepage.cpp:286
+msgid "Centred"
+msgstr "ცენტრირებული"
+
+#: ../src/richtext/richtextsizepage.cpp:290
+#: ../src/richtext/richtextsizepage.cpp:292
+msgid "Vertical alignment."
+msgstr "ვერტიკალური სწორება."
+
+#: ../src/richtext/richtextsizepage.cpp:316
+#: ../src/richtext/richtextsizepage.cpp:323
+msgid "&Width:"
+msgstr "&სიგანე:"
+
+#: ../src/richtext/richtextsizepage.cpp:318
+#: ../src/richtext/richtextsizepage.cpp:320
+msgid "Enable the width value."
+msgstr "სიგანის მნიშვნელობის ჩართვა."
+
+#: ../src/richtext/richtextsizepage.cpp:331
+#: ../src/richtext/richtextsizepage.cpp:333
+msgid "The object width."
+msgstr "ობიექტის სიგანე."
+
+#: ../src/richtext/richtextsizepage.cpp:342
+#: ../src/richtext/richtextsizepage.cpp:344
+msgid "Units for the object width."
+msgstr "ობიექტის სიგანის ერთეული."
+
+#: ../src/richtext/richtextsizepage.cpp:350
+#: ../src/richtext/richtextsizepage.cpp:357
+msgid "&Height:"
+msgstr "&სიმაღლე:"
+
+#: ../src/richtext/richtextsizepage.cpp:352
+#: ../src/richtext/richtextsizepage.cpp:354
+#: ../src/richtext/richtextsizepage.cpp:464
+#: ../src/richtext/richtextsizepage.cpp:466
+msgid "Enable the height value."
+msgstr "სიმაღლის მნიშვნელობის ჩართვა."
+
+#: ../src/richtext/richtextsizepage.cpp:365
+#: ../src/richtext/richtextsizepage.cpp:367
+msgid "The object height."
+msgstr "ობიექტის სიმაღლე."
+
+#: ../src/richtext/richtextsizepage.cpp:376
+#: ../src/richtext/richtextsizepage.cpp:378
+msgid "Units for the object height."
+msgstr "ობიექტის სიმაღლის ერთეული."
+
+#: ../src/richtext/richtextsizepage.cpp:381
+msgid "Min width:"
+msgstr "მინ. სიგანე:"
+
+#: ../src/richtext/richtextsizepage.cpp:383
+#: ../src/richtext/richtextsizepage.cpp:385
+msgid "Enable the minimum width value."
+msgstr "მინიმალური სიგანის მნიშვნელობის ჩართვა."
+
+#: ../src/richtext/richtextsizepage.cpp:392
+#: ../src/richtext/richtextsizepage.cpp:394
+msgid "The object minimum width."
+msgstr "ობიექტის მინიმალური სიგანე."
+
+#: ../src/richtext/richtextsizepage.cpp:403
+#: ../src/richtext/richtextsizepage.cpp:405
+msgid "Units for the minimum object width."
+msgstr "ობიექტის მინიმალური სიგანის ერთეული."
+
+#: ../src/richtext/richtextsizepage.cpp:408
+msgid "Min height:"
+msgstr "მინ სიმაღლე:"
+
+#: ../src/richtext/richtextsizepage.cpp:410
+#: ../src/richtext/richtextsizepage.cpp:412
+msgid "Enable the minimum height value."
+msgstr "მინიმალური სიმაღლის მნიშვნელობის ჩართვა."
+
+#: ../src/richtext/richtextsizepage.cpp:419
+#: ../src/richtext/richtextsizepage.cpp:421
+msgid "The object minimum height."
+msgstr "ობიექტის მინიმალური სიმაღლე."
+
+#: ../src/richtext/richtextsizepage.cpp:430
+#: ../src/richtext/richtextsizepage.cpp:432
+msgid "Units for the minimum object height."
+msgstr "ობიექტის მინიმალური სიმაღლის ერთეული."
+
+#: ../src/richtext/richtextsizepage.cpp:435
+msgid "Max width:"
+msgstr "მაქს სიგანე:"
+
+#: ../src/richtext/richtextsizepage.cpp:437
+#: ../src/richtext/richtextsizepage.cpp:439
+msgid "Enable the maximum width value."
+msgstr "მაქსიმალური სიგანის მნიშვნელობის ჩართვა."
+
+#: ../src/richtext/richtextsizepage.cpp:446
+#: ../src/richtext/richtextsizepage.cpp:448
+msgid "The object maximum width."
+msgstr "ობიექტის მაქსიმალური სიგანე."
+
+#: ../src/richtext/richtextsizepage.cpp:457
+#: ../src/richtext/richtextsizepage.cpp:459
+msgid "Units for the maximum object width."
+msgstr "ობიექტის მაქსიმალური სიგანის ერთეული."
+
+#: ../src/richtext/richtextsizepage.cpp:462
+msgid "Max height:"
+msgstr "მაქს სიმაღლე:"
+
+#: ../src/richtext/richtextsizepage.cpp:473
+#: ../src/richtext/richtextsizepage.cpp:475
+msgid "The object maximum height."
+msgstr "ობიექტის მაქსიმალური სიმაღლე."
+
+#: ../src/richtext/richtextsizepage.cpp:484
+#: ../src/richtext/richtextsizepage.cpp:486
+msgid "Units for the maximum object height."
+msgstr "ობიექტის მაქსიმალური სიმაღლის ერთეული."
+
+#: ../src/richtext/richtextsizepage.cpp:495
+msgid "Position"
+msgstr "მდებარეობა"
+
+#: ../src/richtext/richtextsizepage.cpp:513
+msgid "&Position mode:"
+msgstr "&მდებარეობის რეჟიმი:"
+
+#: ../src/richtext/richtextsizepage.cpp:517
+#: ../src/richtext/richtextsizepage.cpp:522
+msgid "Static"
+msgstr "სტატიკური"
+
+#: ../src/richtext/richtextsizepage.cpp:518
+msgid "Relative"
+msgstr "ფარდობითი"
+
+#: ../src/richtext/richtextsizepage.cpp:519
+msgid "Absolute"
+msgstr "აბსოლუტური"
+
+#: ../src/richtext/richtextsizepage.cpp:520
+msgid "Fixed"
+msgstr "ფიქსირებული"
+
+#: ../src/richtext/richtextsizepage.cpp:533
+#: ../src/richtext/richtextsizepage.cpp:535
+#: ../src/richtext/richtextsizepage.cpp:547
+#: ../src/richtext/richtextsizepage.cpp:549
+msgid "The left position."
+msgstr "მარცხენა მდებარეობა."
+
+#: ../src/richtext/richtextsizepage.cpp:558
+#: ../src/richtext/richtextsizepage.cpp:560
+msgid "Units for the left position."
+msgstr "მარცხენა მდებარეობის ერთეულები."
+
+#: ../src/richtext/richtextsizepage.cpp:568
+#: ../src/richtext/richtextsizepage.cpp:570
+#: ../src/richtext/richtextsizepage.cpp:582
+#: ../src/richtext/richtextsizepage.cpp:584
+msgid "The top position."
+msgstr "ზედა მდებარეობა."
+
+#: ../src/richtext/richtextsizepage.cpp:593
+#: ../src/richtext/richtextsizepage.cpp:595
+msgid "Units for the top position."
+msgstr "ზედა მდებარეობის ერთეულები."
+
+#: ../src/richtext/richtextsizepage.cpp:603
+#: ../src/richtext/richtextsizepage.cpp:605
+#: ../src/richtext/richtextsizepage.cpp:617
+#: ../src/richtext/richtextsizepage.cpp:619
+msgid "The right position."
+msgstr "მარჯვენა მდებარეობა."
+
+#: ../src/richtext/richtextsizepage.cpp:628
+#: ../src/richtext/richtextsizepage.cpp:630
+msgid "Units for the right position."
+msgstr "მარჯვენა მდებარეობის ერთეულები."
+
+#: ../src/richtext/richtextsizepage.cpp:638
+#: ../src/richtext/richtextsizepage.cpp:640
+#: ../src/richtext/richtextsizepage.cpp:652
+#: ../src/richtext/richtextsizepage.cpp:654
+msgid "The bottom position."
+msgstr "ქვედა მდებარეობა."
+
+#: ../src/richtext/richtextsizepage.cpp:663
+#: ../src/richtext/richtextsizepage.cpp:665
+msgid "Units for the bottom position."
+msgstr "ქვედა მდებარეობის ერთეულები."
+
+#: ../src/richtext/richtextsizepage.cpp:671
+msgid "&Move the object to:"
+msgstr "&ობიექტის გადატანა:"
+
+#: ../src/richtext/richtextsizepage.cpp:674
+msgid "&Previous Paragraph"
+msgstr "&წინა პარაგრაფი"
+
+#: ../src/richtext/richtextsizepage.cpp:675
+#: ../src/richtext/richtextsizepage.cpp:677
+msgid "Moves the object to the previous paragraph."
+msgstr "ობიექტის წინა პარაგრაფში გადატანა."
+
+#: ../src/richtext/richtextsizepage.cpp:680
+msgid "&Next Paragraph"
+msgstr "&შემდეგი პარაგრაფი"
+
+#: ../src/richtext/richtextsizepage.cpp:681
+#: ../src/richtext/richtextsizepage.cpp:683
+msgid "Moves the object to the next paragraph."
+msgstr "ობიექტის შემდეგ პარაგრაფში გადატანა."
+
+#: ../src/richtext/richtextstyledlg.cpp:193
+msgid "&Styles:"
+msgstr "&სტილები:"
+
+#: ../src/richtext/richtextstyledlg.cpp:197
+#: ../src/richtext/richtextstyledlg.cpp:199
+msgid "The available styles."
+msgstr "ხელმისაწვდომი სტილები."
+
+#: ../src/richtext/richtextstyledlg.cpp:205
+#: ../src/richtext/richtextstyledlg.cpp:217
+msgid " "
+msgstr " "
+
+#: ../src/richtext/richtextstyledlg.cpp:209
+#: ../src/richtext/richtextstyledlg.cpp:211
+msgid "The style preview."
+msgstr "სტილის გადახედვა."
+
+#: ../src/richtext/richtextstyledlg.cpp:220
+msgid "New &Character Style..."
+msgstr "&სიმბოლოს ახალი სტილი..."
+
+#: ../src/richtext/richtextstyledlg.cpp:221
+#: ../src/richtext/richtextstyledlg.cpp:223
+msgid "Click to create a new character style."
+msgstr "წკაპი სიმბოლოს ახალი სტილის შესაქმნელად."
+
+#: ../src/richtext/richtextstyledlg.cpp:226
+msgid "New &Paragraph Style..."
+msgstr "&პარაგრაფის ახალი სტილი..."
+
+#: ../src/richtext/richtextstyledlg.cpp:227
+#: ../src/richtext/richtextstyledlg.cpp:229
+msgid "Click to create a new paragraph style."
+msgstr "წკაპი პარაგრაფის ახალი სტილის შესაქმნელად."
+
+#: ../src/richtext/richtextstyledlg.cpp:232
+msgid "New &List Style..."
+msgstr "&სიის ახალი სტილი..."
+
+#: ../src/richtext/richtextstyledlg.cpp:233
+#: ../src/richtext/richtextstyledlg.cpp:235
+msgid "Click to create a new list style."
+msgstr "წკაპი სიის ახალი სტილის შესაქმნელად."
+
+#: ../src/richtext/richtextstyledlg.cpp:238
+msgid "New &Box Style..."
+msgstr "&ველის ახალი სტილი..."
+
+#: ../src/richtext/richtextstyledlg.cpp:239
+#: ../src/richtext/richtextstyledlg.cpp:241
+msgid "Click to create a new box style."
+msgstr "წკაპი ველის ახალი სტილის შესაქმნელად."
+
+#: ../src/richtext/richtextstyledlg.cpp:246
+msgid "&Apply Style"
+msgstr "&სტილის გადატარება"
+
+#: ../src/richtext/richtextstyledlg.cpp:247
+#: ../src/richtext/richtextstyledlg.cpp:249
+msgid "Click to apply the selected style."
+msgstr "წკაპი არჩეული სტილის გადასატარებლად."
+
+#: ../src/richtext/richtextstyledlg.cpp:252
+msgid "&Rename Style..."
+msgstr "&სტილის სახელის გადარქმევა..."
+
+#: ../src/richtext/richtextstyledlg.cpp:253
+#: ../src/richtext/richtextstyledlg.cpp:255
+msgid "Click to rename the selected style."
+msgstr "წკაპი მონიშნული სტილის სახელის გადასარქმევად."
+
+#: ../src/richtext/richtextstyledlg.cpp:258
+msgid "&Edit Style..."
+msgstr "&სტილის ჩასწორება..."
+
+#: ../src/richtext/richtextstyledlg.cpp:259
+#: ../src/richtext/richtextstyledlg.cpp:261
+msgid "Click to edit the selected style."
+msgstr "წკაპი არჩეული სტილის ჩასასწორებლად."
+
+#: ../src/richtext/richtextstyledlg.cpp:264
+msgid "&Delete Style..."
+msgstr "&სტილის წაშლა..."
+
+#: ../src/richtext/richtextstyledlg.cpp:265
+#: ../src/richtext/richtextstyledlg.cpp:267
+msgid "Click to delete the selected style."
+msgstr "წკაპი მონიშნული სტილის წასაშლელად."
+
+#: ../src/richtext/richtextstyledlg.cpp:274
+#: ../src/richtext/richtextstyledlg.cpp:276
+msgid "Click to close this window."
+msgstr "წკაპი ფანჯრის დასახურად."
+
+#: ../src/richtext/richtextstyledlg.cpp:282
+msgid "&Restart numbering"
+msgstr "&მიმდევრობის რესტარტი"
+
+#: ../src/richtext/richtextstyledlg.cpp:284
+#: ../src/richtext/richtextstyledlg.cpp:286
+msgid "Check to restart numbering."
+msgstr "მონიშნეთ მიმდევრობის რესტარტისთვის."
+
+#: ../src/richtext/richtextstyledlg.cpp:601
+msgid "Enter a character style name"
+msgstr "შეიყვანეთ სიმბოლოს სტილის სახელი"
+
+#: ../src/richtext/richtextstyledlg.cpp:601
+#: ../src/richtext/richtextstyledlg.cpp:606
+#: ../src/richtext/richtextstyledlg.cpp:649
+#: ../src/richtext/richtextstyledlg.cpp:654
+#: ../src/richtext/richtextstyledlg.cpp:815
+#: ../src/richtext/richtextstyledlg.cpp:820
+#: ../src/richtext/richtextstyledlg.cpp:888
+#: ../src/richtext/richtextstyledlg.cpp:896
+#: ../src/richtext/richtextstyledlg.cpp:929
+#: ../src/richtext/richtextstyledlg.cpp:934
+msgid "New Style"
+msgstr "ახალი სტილი"
+
+#: ../src/richtext/richtextstyledlg.cpp:606
+#: ../src/richtext/richtextstyledlg.cpp:654
+#: ../src/richtext/richtextstyledlg.cpp:820
+#: ../src/richtext/richtextstyledlg.cpp:896
+#: ../src/richtext/richtextstyledlg.cpp:934
+msgid "Sorry, that name is taken. Please choose another."
+msgstr "სახელი დაკავებულია. შეიყვანეთ სხვა."
+
+#: ../src/richtext/richtextstyledlg.cpp:649
+msgid "Enter a paragraph style name"
+msgstr "პარაგრაფის სტილის სახელის შეყვანა"
+
+#: ../src/richtext/richtextstyledlg.cpp:777
+#, c-format
+msgid "Delete style %s?"
+msgstr "წავშალო სტილი %s?"
+
+#: ../src/richtext/richtextstyledlg.cpp:777
+msgid "Delete Style"
+msgstr "სტილის წაშლა"
+
+#: ../src/richtext/richtextstyledlg.cpp:815
+msgid "Enter a list style name"
+msgstr "შეყვანეთ სტილის სახელი"
+
+#: ../src/richtext/richtextstyledlg.cpp:888
+msgid "Enter a new style name"
+msgstr "შეიყვანეთ ახალი სტილის სახელი"
+
+#: ../src/richtext/richtextstyledlg.cpp:929
+msgid "Enter a box style name"
+msgstr "შეიყვანეთ ველის სტილის სახელი"
+
+#: ../src/richtext/richtextstylepage.cpp:109
+#: ../src/richtext/richtextstylepage.cpp:111
+msgid "The style name."
+msgstr "სტილის სახელი."
+
+#: ../src/richtext/richtextstylepage.cpp:114
+msgid "&Based on:"
+msgstr "&ბაზირებულია:"
+
+#: ../src/richtext/richtextstylepage.cpp:119
+#: ../src/richtext/richtextstylepage.cpp:121
+msgid "The style on which this style is based."
+msgstr "სტილი, რომლიდანაც გამომდინარეობს ეს სტილი."
+
+#: ../src/richtext/richtextstylepage.cpp:124
+msgid "&Next style:"
+msgstr "&შემდეგი სტილი:"
+
+#: ../src/richtext/richtextstylepage.cpp:129
+#: ../src/richtext/richtextstylepage.cpp:131
+msgid "The default style for the next paragraph."
+msgstr "შემდეგი პარაგრაფის ნაგულისხმები სტილი."
+
+#: ../src/richtext/richtextstyles.cpp:1057
+msgid "All styles"
+msgstr "ყველა სტილი"
+
+#: ../src/richtext/richtextstyles.cpp:1058
+msgid "Paragraph styles"
+msgstr "პარაგრაფის სტილები"
+
+#: ../src/richtext/richtextstyles.cpp:1059
+msgid "Character styles"
+msgstr "სიმბოლოს სტილები"
+
+#: ../src/richtext/richtextstyles.cpp:1060
+msgid "List styles"
+msgstr "სიის სტილები"
+
+#: ../src/richtext/richtextstyles.cpp:1061
+msgid "Box styles"
+msgstr "ველის სტილები"
+
+#: ../src/richtext/richtextsymboldlg.cpp:389
+#: ../src/richtext/richtextsymboldlg.cpp:391
+msgid "The font from which to take the symbol."
+msgstr "ფონტი, რომლიდანაც უნდა ავიღოთ სიმბოლო."
+
+#: ../src/richtext/richtextsymboldlg.cpp:396
+msgid "&Subset:"
+msgstr "&ქვესეტი:"
+
+#: ../src/richtext/richtextsymboldlg.cpp:401
+#: ../src/richtext/richtextsymboldlg.cpp:403
+msgid "Shows a Unicode subset."
+msgstr "უნიკოდის ქვესეტის ჩვენება."
+
+#: ../src/richtext/richtextsymboldlg.cpp:412
+msgid "xxxx"
+msgstr "xxxx"
+
+#: ../src/richtext/richtextsymboldlg.cpp:417
+msgid "&Character code:"
+msgstr "&სიმბოლოს კოდი:"
+
+#: ../src/richtext/richtextsymboldlg.cpp:421
+#: ../src/richtext/richtextsymboldlg.cpp:423
+msgid "The character code."
+msgstr "სიმბოლოს კოდი."
+
+#: ../src/richtext/richtextsymboldlg.cpp:428
+msgid "&From:"
+msgstr "&საიდან:"
+
+#: ../src/richtext/richtextsymboldlg.cpp:433
+#: ../src/richtext/richtextsymboldlg.cpp:434
+#: ../src/richtext/richtextsymboldlg.cpp:435
+msgid "Unicode"
+msgstr "უნიკოდი"
+
+#: ../src/richtext/richtextsymboldlg.cpp:436
+#: ../src/richtext/richtextsymboldlg.cpp:438
+msgid "The range to show."
+msgstr "საჩვენებელი დიაპაზონი."
+
+#: ../src/richtext/richtextsymboldlg.cpp:444
+msgid "Insert"
+msgstr "ჩასმა"
+
+#: ../src/richtext/richtextsymboldlg.cpp:478
+msgid "(Normal text)"
+msgstr "(ნორმალური ტექსტი)"
+
+#: ../src/richtext/richtexttabspage.cpp:109
+msgid "&Position (tenths of a mm):"
+msgstr "&მდებარეობა (მმ-ის მეათედებში):"
+
+#: ../src/richtext/richtexttabspage.cpp:113
+#: ../src/richtext/richtexttabspage.cpp:115
+msgid "The tab position."
+msgstr "ჩანართის მდებარეობა."
+
+#: ../src/richtext/richtexttabspage.cpp:119
+msgid "The tab positions."
+msgstr "ჩანართების მდებარეობა."
+
+#: ../src/richtext/richtexttabspage.cpp:132
+#: ../src/richtext/richtexttabspage.cpp:134
+msgid "Click to create a new tab position."
+msgstr "წკაპი ჩანართების ახალი მდებარეობის შესაქმნელად."
+
+#: ../src/richtext/richtexttabspage.cpp:138
+#: ../src/richtext/richtexttabspage.cpp:140
+msgid "Click to delete the selected tab position."
+msgstr "წკაპი ჩანართის მონიშნული მდებარეობის წასაშლელად."
+
+#: ../src/richtext/richtexttabspage.cpp:143
+msgid "Delete A&ll"
+msgstr "ყვე&ლაფრის წაშლა"
+
+#: ../src/richtext/richtexttabspage.cpp:144
+#: ../src/richtext/richtexttabspage.cpp:146
+msgid "Click to delete all tab positions."
+msgstr "წკაპი ჩანართის ყველა მდებარეობის წასაშლელად."
+
+#: ../src/univ/theme.cpp:110
+msgid "Failed to initialize GUI: no built-in themes found."
+msgstr "GUI-ის ინიციალიზაციის შეცდომა: ჩადგმული თემები ვერ ვიპოვე."
+
+#: ../src/univ/themes/gtk.cpp:521
+msgid "GTK+ theme"
+msgstr "GTK+-ის თემა"
+
+#: ../src/univ/themes/metal.cpp:164
+msgid "Metal theme"
+msgstr "თემა Metal"
+
+#: ../src/univ/themes/mono.cpp:512
+msgid "Simple monochrome theme"
+msgstr "მარტივი შავთეთრი თემა"
+
+#: ../src/univ/themes/win32.cpp:1098
+msgid "Win32 theme"
+msgstr "Win32 თემა"
+
+#: ../src/univ/themes/win32.cpp:3743
+msgid "&Restore"
+msgstr "ა&ღდგენა"
+
+#: ../src/univ/themes/win32.cpp:3744
+msgid "&Move"
+msgstr "&გადატანა"
+
+#: ../src/univ/themes/win32.cpp:3746
+msgid "&Size"
+msgstr "&ზომა"
+
+#: ../src/univ/themes/win32.cpp:3748
+msgid "Mi&nimize"
+msgstr "&ჩაკეცვა"
+
+#: ../src/univ/themes/win32.cpp:3750
+msgid "Ma&ximize"
+msgstr "&აკეცვა"
+
+#: ../src/univ/themes/win32.cpp:3752
+msgid "Alt+"
+msgstr "Alt+"
+
+#: ../src/unix/appunix.cpp:178
+msgid "Failed to install signal handler"
+msgstr "სიგნალის დამმუშავებლის დაყენების შეცდომა"
+
+#: ../src/unix/dialup.cpp:351
+msgid "Already dialling ISP."
+msgstr "უკვე ვურეკავ ISP-ს."
+
+#: ../src/unix/dlunix.cpp:93
+msgid "Failed to unload shared library"
+msgstr "გაზიარებული ბიბლიოთეკის ფაილის გამოტვირთვის შეცდომა"
+
+#: ../src/unix/dlunix.cpp:121
+msgid "Unknown dynamic library error"
+msgstr "გაზიარებული დინამიური ბიბლიოთეკის უცნობი შეცდომა"
+
+#: ../src/unix/epolldispatcher.cpp:84
+msgid "Failed to create epoll descriptor"
+msgstr "Epoll დესკრიპტორის შექმნის შეცდომა"
+
+#: ../src/unix/epolldispatcher.cpp:103
+msgid "Error closing epoll descriptor"
+msgstr "Epoll დესკრიპტორის დახურვის შეცდომა"
+
+#: ../src/unix/epolldispatcher.cpp:116
+#, c-format
+msgid "Failed to add descriptor %d to epoll descriptor %d"
+msgstr ""
+
+#: ../src/unix/epolldispatcher.cpp:136
+#, c-format
+msgid "Failed to modify descriptor %d in epoll descriptor %d"
+msgstr ""
+
+#: ../src/unix/epolldispatcher.cpp:155
+#, c-format
+msgid "Failed to unregister descriptor %d from epoll descriptor %d"
+msgstr ""
+
+#: ../src/unix/epolldispatcher.cpp:213
+#, c-format
+msgid "Waiting for IO on epoll descriptor %d failed"
+msgstr ""
+
+#: ../src/unix/fswatcher_inotify.cpp:71
+msgid "Unable to create inotify instance"
+msgstr "inotify-ის გაშვებული ასლის შექმნა შეუძლებელია"
+
+#: ../src/unix/fswatcher_inotify.cpp:94
+msgid "Unable to close inotify instance"
+msgstr "inotify-ის გაშვებული ასლის დახურვა შეუძლებელია"
+
+#: ../src/unix/fswatcher_inotify.cpp:106
+msgid "Unable to add inotify watch"
+msgstr "inotify-ის ყურების დამატება შეუძლებელია"
+
+#: ../src/unix/fswatcher_inotify.cpp:138
+#, c-format
+msgid "Unable to remove inotify watch %i"
+msgstr "inotify-ის ყურების %i წაშლა შეუძლებელია"
+
+#: ../src/unix/fswatcher_inotify.cpp:271
+#, c-format
+msgid "Unexpected event for \"%s\": no matching watch descriptor."
+msgstr ""
+
+#: ../src/unix/fswatcher_inotify.cpp:320
+#, c-format
+msgid "Invalid inotify event for \"%s\""
+msgstr "არასწორი inotify-ის მოვლენა \"%s\"-სთვის"
+
+#: ../src/unix/fswatcher_inotify.cpp:553
+msgid "Unable to read from inotify descriptor"
+msgstr "inotify-ის დესკრიპტორიდან წაკითხვა სეუძლებელია"
+
+#: ../src/unix/fswatcher_inotify.cpp:558
+msgid "EOF while reading from inotify descriptor"
+msgstr "EOF inotify-ის დესკრიპტორის კითხვისას"
+
+#: ../src/unix/fswatcher_kqueue.cpp:114
+msgid "Unable to create kqueue instance"
+msgstr "Kqueue-ის გაშვებული ასლის შექმნის შეცდომა"
+
+#: ../src/unix/fswatcher_kqueue.cpp:131
+msgid "Error closing kqueue instance"
+msgstr "Kqueue-ის გაშვებული ასლის დახურვის შეცდომა"
+
+#: ../src/unix/fswatcher_kqueue.cpp:153
+msgid "Unable to add kqueue watch"
+msgstr "Kqueue-ის მონიტორინგის დამატების შეცდომა"
+
+#: ../src/unix/fswatcher_kqueue.cpp:170
+msgid "Unable to remove kqueue watch"
+msgstr "Kqueue-ის მონიტორინგის წაშლის შეცდომა"
+
+#: ../src/unix/fswatcher_kqueue.cpp:202
+msgid "Unable to get events from kqueue"
+msgstr "Kqueue-დან მოვლენების მიღების შეცდომა"
+
+#: ../src/unix/mediactrl.cpp:966
+#, c-format
+msgid "Media playback error: %s"
+msgstr "მედიის დაკვრის შეცდომა: %s"
+
+#: ../src/unix/mediactrl.cpp:1228
+#, c-format
+msgid "Failed to prepare playing \"%s\"."
+msgstr "%s -ის დასაკრავად მომზადების შეცდომა."
+
+#: ../src/unix/snglinst.cpp:164
+#, c-format
+msgid "Failed to write to lock file '%s'"
+msgstr "ბლოკის ფაილში ჩაწერის შეცდომა: %s"
+
+#: ../src/unix/snglinst.cpp:177
+#, c-format
+msgid "Failed to set permissions on lock file '%s'"
+msgstr "ბლოკის ფაილზე წვდომების დაყენების შეცდომა: %s"
+
+#: ../src/unix/snglinst.cpp:194
+#, c-format
+msgid "Failed to lock the lock file '%s'"
+msgstr "ბლოკის ფაილის დაბლოკვის შეცდომა; %s"
+
+#: ../src/unix/snglinst.cpp:237
+#, c-format
+msgid "Failed to inspect the lock file '%s'"
+msgstr "ბლოკის ფაილის შემოწმების შეცდომა: %s"
+
+#: ../src/unix/snglinst.cpp:242
+#, c-format
+msgid "Lock file '%s' has incorrect owner."
+msgstr "ბლოკის ფაილის არასწორი მფლობელი: %s."
+
+#: ../src/unix/snglinst.cpp:247
+#, c-format
+msgid "Lock file '%s' has incorrect permissions."
+msgstr "ბლოკის ფაილის არასწორი წვდომები: %s."
+
+#: ../src/unix/snglinst.cpp:265
+msgid "Failed to access lock file."
+msgstr "ბლოკის ფაილთან წვდომის შეცდომა."
+
+#: ../src/unix/snglinst.cpp:274
+msgid "Failed to read PID from lock file."
+msgstr "ბლოკის ფაილიდან PID-ის წაკითხვის შეცდომა."
+
+#: ../src/unix/snglinst.cpp:284
+#, c-format
+msgid "Failed to remove stale lock file '%s'."
+msgstr "ბლოკის ძველი ფაილის წაშლის შეცდომა: %s."
+
+#: ../src/unix/snglinst.cpp:297
+#, c-format
+msgid "Deleted stale lock file '%s'."
+msgstr "წავშალე ბლოკის ძველი ფაილი: %s."
+
+#: ../src/unix/snglinst.cpp:308
+#, c-format
+msgid "Invalid lock file '%s'."
+msgstr "ბლოკის არასწორი ფაილი: %s."
+
+#: ../src/unix/snglinst.cpp:324
+#, c-format
+msgid "Failed to remove lock file '%s'"
+msgstr "ბლოკის ფაილის წაშლის შეცდომა: %s."
+
+#: ../src/unix/snglinst.cpp:330
+#, c-format
+msgid "Failed to unlock lock file '%s'"
+msgstr "ბლოკის ფაილის განბლოკვის შეცდომა: %s."
+
+#: ../src/unix/snglinst.cpp:336
+#, c-format
+msgid "Failed to close lock file '%s'"
+msgstr "ბლოკის ფაილის დახურვის შეცდომა: %s"
+
+#: ../src/unix/sound.cpp:77
+msgid "No sound"
+msgstr "ხმის გარეშე"
+
+#: ../src/unix/sound.cpp:364
+msgid "Unable to play sound asynchronously."
+msgstr "ხმის ასინქრონულად დაკვრა შეუძლებელია."
+
+#: ../src/unix/sound.cpp:458
+#, c-format
+msgid "Couldn't load sound data from '%s'."
+msgstr "ხმის მონაცემების %s-დან ჩატვირთვის შეცდომა."
+
+#: ../src/unix/sound.cpp:465
+#, c-format
+msgid "Sound file '%s' is in unsupported format."
+msgstr "ხმის ფაილის (%s) მხარდაუჭერელი ფორმატი."
+
+#: ../src/unix/sound.cpp:480
+msgid "Sound data are in unsupported format."
+msgstr "ხმის მონაცემების მხარდაუჭერელი ფორმატი."
+
+#: ../src/unix/sound_sdl.cpp:226
+#, c-format
+msgid "Couldn't open audio: %s"
+msgstr "აუდიოს გახსნის პრობლემა: %s"
+
+#: ../src/unix/threadpsx.cpp:1033
+msgid "Cannot retrieve thread scheduling policy."
+msgstr "ნაკადების მგეგმავის პოლიტიკის მიღების შეცდომა."
+
+#: ../src/unix/threadpsx.cpp:1058
+#, c-format
+msgid "Cannot get priority range for scheduling policy %d."
+msgstr ""
+
+#: ../src/unix/threadpsx.cpp:1066
+msgid "Thread priority setting is ignored."
+msgstr "ნაკადის პრიორიტეტის პარამეტრი იგნორირებულია."
+
+#: ../src/unix/threadpsx.cpp:1221
+msgid ""
+"Failed to join a thread, potential memory leak detected - please restart the "
+"program"
+msgstr ""
+
+#: ../src/unix/threadpsx.cpp:1352
+#, c-format
+msgid "Failed to set thread concurrency level to %lu"
+msgstr ""
+
+#: ../src/unix/threadpsx.cpp:1481
+#, c-format
+msgid "Failed to set thread priority %d."
+msgstr "ნაკადის (%d) პრიორიტეტის დაყენება შეუძლებელია."
+
+#: ../src/unix/threadpsx.cpp:1666
+msgid "Failed to terminate a thread."
+msgstr "ნაკადის შეჩერების შეცდომა."
+
+#: ../src/unix/threadpsx.cpp:1893
+msgid "Thread module initialization failed: failed to create thread key"
+msgstr ""
+
+#: ../src/unix/utilsunx.cpp:340
+msgid "Impossible to get child process input"
+msgstr "შვილი პროცესის შეყვანის მიღება შეუძლებელია"
+
+#: ../src/unix/utilsunx.cpp:390
+msgid "Can't write to child process's stdin"
+msgstr "შვილი პროცესის stdin-ში ჩაწერა შეუძლებელია"
+
+#: ../src/unix/utilsunx.cpp:644
+#, c-format
+msgid "Failed to execute '%s'\n"
+msgstr "%s-ის გაშვების შეცდომა\n"
+
+#: ../src/unix/utilsunx.cpp:678
+msgid "Fork failed"
+msgstr "ფორკის შეცდომა"
+
+#: ../src/unix/utilsunx.cpp:701
+msgid "Failed to set process priority"
+msgstr "პროცესის პრიორიტეტის დაყენების შეცდომა"
+
+#: ../src/unix/utilsunx.cpp:712
+msgid "Failed to redirect child process input/output"
+msgstr "ქვეპროცესში შეტანის ან მიღების გადამისამართება გამოყენება ვერ მოხერხდა"
+
+#: ../src/unix/utilsunx.cpp:816
+msgid "Failed to set up non-blocking pipe, the program might hang."
+msgstr ""
+
+#: ../src/unix/utilsunx.cpp:1023
+msgid "Cannot get the hostname"
+msgstr "ჰოსტის სახელის მიღების შეცდომა"
+
+#: ../src/unix/utilsunx.cpp:1059
+msgid "Cannot get the official hostname"
+msgstr "ჰოსტის ოფიციალური სახელის მიღების შეცდომა"
+
+#: ../src/unix/wakeuppipe.cpp:49
+msgid "Failed to create wake up pipe used by event loop."
+msgstr ""
+
+#: ../src/unix/wakeuppipe.cpp:56
+msgid "Failed to switch wake up pipe to non-blocking mode"
+msgstr ""
+
+#: ../src/unix/wakeuppipe.cpp:117
+msgid "Failed to read from wake-up pipe"
+msgstr "გაღვიძების არხიდან წაკითხვა შეუძლებელია"
+
+#: ../src/x11/app.cpp:124
+#, c-format
+msgid "Invalid geometry specification '%s'"
+msgstr "მითითებულ გეომეტრია არასწორია: %s"
+
+#: ../src/x11/app.cpp:167
+msgid "wxWidgets could not open display. Exiting."
+msgstr "wxWidgets -მა ეკრანი ვერ გახსნა. გამოსვლა."
+
+#: ../src/x11/utils.cpp:169
+#, c-format
+msgid "Failed to close the display \"%s\""
+msgstr "ეკრანის დახურვის შეცდომა: %s"
+
+#: ../src/x11/utils.cpp:188
+#, c-format
+msgid "Failed to open display \"%s\"."
+msgstr "ეკრანის გახსნის შეცდომა: %s."
+
+#: ../src/xml/xml.cpp:868
+#, c-format
+msgid "XML parsing error: '%s' at line %d"
+msgstr "XML-ის დამუშვების შეცდომა: '%s' ხაზთან %d"
+
+#: ../src/xrc/xh_propgrid.cpp:239
+#, c-format
+msgid "Page %i"
+msgstr "გვერდი %i"
+
+#: ../src/xrc/xmlres.cpp:448
+#, c-format
+msgid "Cannot load resources from '%s'."
+msgstr "'%s'-დან რესურსების ჩატვირთვის შეცდომა."
+
+#: ../src/xrc/xmlres.cpp:799
+#, c-format
+msgid "Cannot open resources file '%s'."
+msgstr "რესურსებს ფაილის გახსნის შეცდომა: %s."
+
+#: ../src/xrc/xmlres.cpp:806
+#, c-format
+msgid "Cannot load resources from file '%s'."
+msgstr "'%s'-დან რესურსების ჩატვირთვის შეცდომა."
+
+#: ../src/xrc/xmlres.cpp:2767
+#, c-format
+msgid "Creating %s \"%s\" failed."
+msgstr "შექმნა %s \"%s\" შეცდომა."

--- a/po_wxstd/ko_KR.po
+++ b/po_wxstd/ko_KR.po
@@ -1,0 +1,10386 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: wxWidgets 3.3\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-05-14 20:23+0200\n"
+"PO-Revision-Date: 2009-04-23 18:29+0900\n"
+"Last-Translator: 정성기 <dragoneyes.org@gmail.com>\n"
+"Language-Team: Korean <Korean>\n"
+"Language: ko\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Poedit-Language: Korean\n"
+"X-Poedit-Country: KOREA, REPUBLIC OF\n"
+"Plural-Forms: nplurals=2; plural=n == 1 ? 0 : 1;\n"
+
+#: ../include/wx/defs.h:2582
+msgid "All files (*.*)|*.*"
+msgstr "모든 파일 (*.*)|*.*"
+
+#: ../include/wx/defs.h:2585
+msgid "All files (*)|*"
+msgstr "모든 파일 (*)|*"
+
+#: ../include/wx/generic/progdlgg.h:85
+msgid "Elapsed time:"
+msgstr "경과 시간:"
+
+#: ../include/wx/generic/progdlgg.h:86
+msgid "Estimated time:"
+msgstr "예상 시간:"
+
+#: ../include/wx/generic/progdlgg.h:87
+msgid "Remaining time:"
+msgstr "남은 시간:"
+
+#. TRANSLATORS: HTML printout default title.
+#: ../include/wx/html/htmprint.h:121 ../include/wx/prntbase.h:273
+#: ../include/wx/richtext/richtextprint.h:109 ../src/common/docview.cpp:2161
+#, fuzzy
+msgid "Printout"
+msgstr "인쇄"
+
+#. TRANSLATORS: HTML easy print default title.
+#: ../include/wx/html/htmprint.h:234 ../include/wx/richtext/richtextprint.h:163
+#: ../src/common/prntbase.cpp:522 ../src/html/htmprint.cpp:291
+#, fuzzy
+msgid "Printing"
+msgstr "인쇄중"
+
+#: ../include/wx/msgdlg.h:277 ../src/common/stockitem.cpp:211
+msgid "Yes"
+msgstr "예"
+
+#: ../include/wx/msgdlg.h:278 ../src/common/stockitem.cpp:182
+msgid "No"
+msgstr "아니오"
+
+#: ../include/wx/msgdlg.h:279 ../src/common/stockitem.cpp:183
+#: ../src/msw/msgdlg.cpp:430 ../src/msw/msgdlg.cpp:734
+#: ../src/richtext/richtextstyledlg.cpp:292
+msgid "OK"
+msgstr "확인"
+
+#: ../include/wx/msgdlg.h:280 ../src/common/stockitem.cpp:150
+#: ../src/msw/msgdlg.cpp:430 ../src/msw/progdlg.cpp:884
+#: ../src/richtext/richtextstyledlg.cpp:295
+msgid "Cancel"
+msgstr "취소"
+
+#: ../include/wx/msgdlg.h:281 ../src/common/stockitem.cpp:168
+#: ../src/html/helpdlg.cpp:63 ../src/html/helpfrm.cpp:108
+#: ../src/osx/button_osx.cpp:38
+msgid "Help"
+msgstr "도움말"
+
+#: ../include/wx/msw/ole/oleutils.h:52
+msgid "Cannot initialize OLE"
+msgstr "OLE를 초기화할 수 없습니다"
+
+#: ../include/wx/msw/private/fswatcher.h:48
+#, fuzzy, c-format
+msgid "Unable to close the handle for '%s'"
+msgstr "파일 닫기를 실패했습니다."
+
+#: ../include/wx/msw/private/fswatcher.h:92
+#, fuzzy, c-format
+msgid "Failed to open directory \"%s\" for monitoring."
+msgstr "'%s' 파일을 쓰기 모드로 여는 데 실패했습니다."
+
+#: ../include/wx/msw/private/fswatcher.h:125
+#, fuzzy
+msgid "Unable to close I/O completion port handle"
+msgstr "파일 닫기를 실패했습니다."
+
+#: ../include/wx/msw/private/fswatcher.h:142
+msgid "Unable to associate handle with I/O completion port"
+msgstr ""
+
+#: ../include/wx/msw/private/fswatcher.h:148
+msgid "Unexpectedly new I/O completion port was created"
+msgstr ""
+
+#: ../include/wx/msw/private/fswatcher.h:213
+msgid "Unable to post completion status"
+msgstr ""
+
+#: ../include/wx/msw/private/fswatcher.h:262
+msgid "Unable to dequeue completion packet"
+msgstr ""
+
+#: ../include/wx/msw/private/fswatcher.h:273
+#, fuzzy
+msgid "Unable to create I/O completion port"
+msgstr "Epoll 디스크립터 생성을 실패했습니다."
+
+#: ../include/wx/richmsgdlg.h:29
+#, fuzzy
+msgid "&See details"
+msgstr "자세히(&D)"
+
+#: ../include/wx/richmsgdlg.h:30
+#, fuzzy
+msgid "&Hide details"
+msgstr "자세히(&D)"
+
+#: ../include/wx/richtext/richtextbuffer.h:3864
+#, fuzzy
+msgid "&Box"
+msgstr "굵게(&B)"
+
+#: ../include/wx/richtext/richtextbuffer.h:5008
+msgid "&Picture"
+msgstr ""
+
+#: ../include/wx/richtext/richtextbuffer.h:5958
+#, fuzzy
+msgid "&Cell"
+msgstr "취소(&C)"
+
+#: ../include/wx/richtext/richtextbuffer.h:6067
+#, fuzzy
+msgid "&Table"
+msgstr "탭"
+
+#: ../include/wx/richtext/richtextimagedlg.h:37
+#, fuzzy
+msgid "Object Properties"
+msgstr "특성(&P)"
+
+#: ../include/wx/richtext/richtextsymboldlg.h:39
+msgid "Symbols"
+msgstr "기호"
+
+#: ../include/wx/unix/pipe.h:46
+msgid "Pipe creation failed"
+msgstr "파이프 생성 실패"
+
+#: ../include/wx/unix/private/displayx11.h:65
+msgid "Failed to enumerate video modes"
+msgstr "디스플레이 모드 찾을 수 없습니다."
+
+#: ../include/wx/unix/private/displayx11.h:89
+msgid "Failed to change video mode"
+msgstr "비디오 모드 변경을 실패했습니다."
+
+#: ../include/wx/unix/private/fswatcher_kqueue.h:57
+#, fuzzy, c-format
+msgid "Unable to open path '%s'"
+msgstr "'%s' CHM 파일을 여는 데 실패했습니다."
+
+#: ../include/wx/unix/private/fswatcher_kqueue.h:74
+#, fuzzy, c-format
+msgid "Unable to close path '%s'"
+msgstr "'%s' 파일을 지우는 실패했습니다(잠금 파일)."
+
+#: ../include/wx/xtiprop.h:175
+msgid "SetProperty called w/o valid setter"
+msgstr ""
+
+#: ../include/wx/xtiprop.h:184
+msgid "GetProperty called w/o valid getter"
+msgstr ""
+
+#: ../include/wx/xtiprop.h:193
+msgid "AddToPropertyCollection called w/o valid adder"
+msgstr ""
+
+#: ../include/wx/xtiprop.h:202
+msgid "GetPropertyCollection called w/o valid collection getter"
+msgstr ""
+
+#: ../include/wx/xtiprop.h:255
+msgid "AddToPropertyCollection called on a generic accessor"
+msgstr ""
+
+#: ../include/wx/xtiprop.h:262
+msgid "GetPropertyCollection called on a generic accessor"
+msgstr ""
+
+#: ../src/aui/tabmdi.cpp:106 ../src/generic/mdig.cpp:94
+msgid "Cl&ose"
+msgstr "닫기(&O)"
+
+#: ../src/aui/tabmdi.cpp:107 ../src/generic/mdig.cpp:95
+msgid "Close All"
+msgstr "모두 닫기"
+
+#: ../src/aui/tabmdi.cpp:109 ../src/generic/mdig.cpp:97 ../src/msw/mdi.cpp:175
+#: ../src/qt/mdi.cpp:258
+msgid "&Next"
+msgstr "다음(&N)"
+
+#: ../src/aui/tabmdi.cpp:110 ../src/generic/mdig.cpp:98 ../src/msw/mdi.cpp:176
+#: ../src/qt/mdi.cpp:259
+msgid "&Previous"
+msgstr "이전(&P)"
+
+#: ../src/aui/tabmdi.cpp:332 ../src/aui/tabmdi.cpp:348
+#: ../src/aui/tabmdi.cpp:350 ../src/generic/mdig.cpp:291
+#: ../src/generic/mdig.cpp:307 ../src/generic/mdig.cpp:311
+#: ../src/msw/mdi.cpp:337 ../src/qt/mdi.cpp:462
+msgid "&Window"
+msgstr "창(&W)"
+
+#: ../src/common/accelcmn.cpp:47
+msgctxt "keyboard key"
+msgid "Delete"
+msgstr "지우기"
+
+#: ../src/common/accelcmn.cpp:48
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Del"
+msgstr "지우기"
+
+#: ../src/common/accelcmn.cpp:49
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Back"
+msgstr "뒤로(&B)"
+
+#: ../src/common/accelcmn.cpp:49
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Backspace"
+msgstr "뒤로(&B)"
+
+#: ../src/common/accelcmn.cpp:50
+msgctxt "keyboard key"
+msgid "Insert"
+msgstr "넣기"
+
+#: ../src/common/accelcmn.cpp:51
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Ins"
+msgstr "넣기"
+
+#: ../src/common/accelcmn.cpp:52
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Enter"
+msgstr "프린터"
+
+#: ../src/common/accelcmn.cpp:53
+msgctxt "keyboard key"
+msgid "Return"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:54
+#, fuzzy
+msgctxt "keyboard key"
+msgid "PageUp"
+msgstr "페이지"
+
+#: ../src/common/accelcmn.cpp:54
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Page Up"
+msgstr "페이지 %d"
+
+#: ../src/common/accelcmn.cpp:55
+#, fuzzy
+msgctxt "keyboard key"
+msgid "PageDown"
+msgstr "아래로"
+
+#: ../src/common/accelcmn.cpp:55
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Page Down"
+msgstr "페이지 %d"
+
+#: ../src/common/accelcmn.cpp:56
+msgctxt "keyboard key"
+msgid "PgUp"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:57
+msgctxt "keyboard key"
+msgid "PgDn"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:58
+msgctxt "keyboard key"
+msgid "Left"
+msgstr "왼쪽"
+
+#: ../src/common/accelcmn.cpp:59
+msgctxt "keyboard key"
+msgid "Right"
+msgstr "오른쪽"
+
+#: ../src/common/accelcmn.cpp:60
+msgctxt "keyboard key"
+msgid "Up"
+msgstr "위로"
+
+#: ../src/common/accelcmn.cpp:61
+msgctxt "keyboard key"
+msgid "Down"
+msgstr "아래로"
+
+#: ../src/common/accelcmn.cpp:62
+msgctxt "keyboard key"
+msgid "Home"
+msgstr "홈"
+
+#: ../src/common/accelcmn.cpp:63
+msgctxt "keyboard key"
+msgid "End"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:64
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Space"
+msgstr "간격"
+
+#: ../src/common/accelcmn.cpp:65
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Tab"
+msgstr "탭"
+
+#: ../src/common/accelcmn.cpp:66
+msgctxt "keyboard key"
+msgid "Esc"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:67
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Escape"
+msgstr "가로 방향"
+
+#: ../src/common/accelcmn.cpp:68
+msgctxt "keyboard key"
+msgid "Cancel"
+msgstr "취소"
+
+#: ../src/common/accelcmn.cpp:69
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Clear"
+msgstr "비우기(&C)"
+
+#: ../src/common/accelcmn.cpp:70
+msgctxt "keyboard key"
+msgid "Menu"
+msgstr "메뉴"
+
+#: ../src/common/accelcmn.cpp:71
+msgctxt "keyboard key"
+msgid "Pause"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:72
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Capital"
+msgstr "대문자(&P)"
+
+#: ../src/common/accelcmn.cpp:73
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Select"
+msgstr "선택"
+
+#: ../src/common/accelcmn.cpp:74
+msgctxt "keyboard key"
+msgid "Print"
+msgstr "인쇄"
+
+#: ../src/common/accelcmn.cpp:75
+msgctxt "keyboard key"
+msgid "Execute"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:76
+msgctxt "keyboard key"
+msgid "Snapshot"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:77
+msgctxt "keyboard key"
+msgid "Help"
+msgstr "도움말"
+
+#: ../src/common/accelcmn.cpp:78
+msgctxt "keyboard key"
+msgid "Add"
+msgstr "추가"
+
+#: ../src/common/accelcmn.cpp:79
+msgctxt "keyboard key"
+msgid "Separator"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:80
+msgctxt "keyboard key"
+msgid "Subtract"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:81
+msgctxt "keyboard key"
+msgid "Decimal"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:82
+msgctxt "keyboard key"
+msgid "Multiply"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:83
+msgctxt "keyboard key"
+msgid "Divide"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:84
+msgctxt "keyboard key"
+msgid "Num_lock"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:84
+msgctxt "keyboard key"
+msgid "Num Lock"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:85
+msgctxt "keyboard key"
+msgid "Scroll_lock"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:85
+msgctxt "keyboard key"
+msgid "Scroll Lock"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:86
+msgctxt "keyboard key"
+msgid "KP_Space"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:86
+msgctxt "keyboard key"
+msgid "Num Space"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:87
+msgctxt "keyboard key"
+msgid "KP_Tab"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:87
+msgctxt "keyboard key"
+msgid "Num Tab"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:88
+#, fuzzy
+msgctxt "keyboard key"
+msgid "KP_Enter"
+msgstr "프린터"
+
+#: ../src/common/accelcmn.cpp:88
+msgctxt "keyboard key"
+msgid "Num Enter"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:89
+#, fuzzy
+msgctxt "keyboard key"
+msgid "KP_Home"
+msgstr "홈"
+
+#: ../src/common/accelcmn.cpp:89
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Num Home"
+msgstr "홈"
+
+#: ../src/common/accelcmn.cpp:90
+#, fuzzy
+msgctxt "keyboard key"
+msgid "KP_Left"
+msgstr "왼쪽"
+
+#: ../src/common/accelcmn.cpp:90
+msgctxt "keyboard key"
+msgid "Num left"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:91
+msgctxt "keyboard key"
+msgid "KP_Up"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:91
+msgctxt "keyboard key"
+msgid "Num Up"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:92
+#, fuzzy
+msgctxt "keyboard key"
+msgid "KP_Right"
+msgstr "오른쪽"
+
+#: ../src/common/accelcmn.cpp:92
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Num Right"
+msgstr "오른쪽"
+
+#: ../src/common/accelcmn.cpp:93
+#, fuzzy
+msgctxt "keyboard key"
+msgid "KP_Down"
+msgstr "아래로"
+
+#: ../src/common/accelcmn.cpp:93
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Num Down"
+msgstr "아래로"
+
+#: ../src/common/accelcmn.cpp:94
+msgctxt "keyboard key"
+msgid "KP_PageUp"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:94
+msgctxt "keyboard key"
+msgid "Num Page Up"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:95
+msgctxt "keyboard key"
+msgid "KP_PageDown"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:95
+msgctxt "keyboard key"
+msgid "Num Page Down"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:96
+msgctxt "keyboard key"
+msgid "KP_Prior"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:97
+#, fuzzy
+msgctxt "keyboard key"
+msgid "KP_Next"
+msgstr "다음"
+
+#: ../src/common/accelcmn.cpp:98
+msgctxt "keyboard key"
+msgid "KP_End"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:98
+msgctxt "keyboard key"
+msgid "Num End"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:99
+msgctxt "keyboard key"
+msgid "KP_Begin"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:99
+msgctxt "keyboard key"
+msgid "Num Begin"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:100
+#, fuzzy
+msgctxt "keyboard key"
+msgid "KP_Insert"
+msgstr "넣기"
+
+#: ../src/common/accelcmn.cpp:100
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Num Insert"
+msgstr "넣기"
+
+#: ../src/common/accelcmn.cpp:101
+#, fuzzy
+msgctxt "keyboard key"
+msgid "KP_Delete"
+msgstr "지우기"
+
+#: ../src/common/accelcmn.cpp:101
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Num Delete"
+msgstr "지우기"
+
+#: ../src/common/accelcmn.cpp:102
+msgctxt "keyboard key"
+msgid "KP_Equal"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:102
+msgctxt "keyboard key"
+msgid "Num ="
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:103
+msgctxt "keyboard key"
+msgid "KP_Multiply"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:103
+msgctxt "keyboard key"
+msgid "Num *"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:104
+msgctxt "keyboard key"
+msgid "KP_Add"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:104
+msgctxt "keyboard key"
+msgid "Num +"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:105
+msgctxt "keyboard key"
+msgid "KP_Separator"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:105
+msgctxt "keyboard key"
+msgid "Num ,"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:106
+msgctxt "keyboard key"
+msgid "KP_Subtract"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:106
+msgctxt "keyboard key"
+msgid "Num -"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:107
+msgctxt "keyboard key"
+msgid "KP_Decimal"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:107
+msgctxt "keyboard key"
+msgid "Num ."
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:108
+msgctxt "keyboard key"
+msgid "KP_Divide"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:108
+msgctxt "keyboard key"
+msgid "Num /"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:109
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Windows_Left"
+msgstr "창(&W)"
+
+#: ../src/common/accelcmn.cpp:110
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Windows_Right"
+msgstr "창(&W)"
+
+#: ../src/common/accelcmn.cpp:111
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Windows_Menu"
+msgstr "창(&W)"
+
+#: ../src/common/accelcmn.cpp:112
+msgctxt "keyboard key"
+msgid "Command"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:186 ../src/common/accelcmn.cpp:359
+msgctxt "keyboard key"
+msgid "Ctrl"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:188 ../src/common/accelcmn.cpp:363
+msgctxt "keyboard key"
+msgid "Alt"
+msgstr "Alt"
+
+#: ../src/common/accelcmn.cpp:190 ../src/common/accelcmn.cpp:361
+msgctxt "keyboard key"
+msgid "Shift"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:196
+msgctxt "keyboard key"
+msgid "num "
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:260 ../src/common/accelcmn.cpp:382
+msgctxt "keyboard key"
+msgid "F"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:277 ../src/common/accelcmn.cpp:385
+msgctxt "keyboard key"
+msgid "KP_F"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:280 ../src/common/accelcmn.cpp:388
+msgctxt "keyboard key"
+msgid "KP_"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:283 ../src/common/accelcmn.cpp:391
+msgctxt "keyboard key"
+msgid "SPECIAL"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:373
+msgid "Ctrl"
+msgstr ""
+
+#: ../src/common/appbase.cpp:786
+msgid "show this help message"
+msgstr "이 도움말 계속 보기."
+
+#: ../src/common/appbase.cpp:796
+msgid "generate verbose log messages"
+msgstr "자세한 로그 메시지 생성"
+
+#: ../src/common/appcmn.cpp:256
+msgid "specify the theme to use"
+msgstr "사용할 테마"
+
+#: ../src/common/appcmn.cpp:270
+msgid "specify display mode to use (e.g. 640x480-16)"
+msgstr "디스플레이 모드 지정(예:640x480-16)"
+
+#: ../src/common/appcmn.cpp:292
+#, c-format
+msgid "Unsupported theme '%s'."
+msgstr "'%s' 테마는 지원하지 않습니다."
+
+#: ../src/common/appcmn.cpp:309
+#, c-format
+msgid "Invalid display mode specification '%s'."
+msgstr "설정된 디스플레이 모드('%s')가 없습니다."
+
+#: ../src/common/cmdline.cpp:875
+#, fuzzy, c-format
+msgid "Option '%s' can't be negated"
+msgstr "'%s' 디렉토리를 만들 수 없습니다."
+
+#: ../src/common/cmdline.cpp:889
+#, c-format
+msgid "Unknown long option '%s'"
+msgstr "%s 옵션을 찾을 수 없습니다."
+
+#: ../src/common/cmdline.cpp:904 ../src/common/cmdline.cpp:926
+#, c-format
+msgid "Unknown option '%s'"
+msgstr "%s 옵션을 찾을 수 없습니다."
+
+#: ../src/common/cmdline.cpp:1004
+#, c-format
+msgid "Unexpected characters following option '%s'."
+msgstr "'%s' 옵션에서 예기치 않은 문자가 있습니다."
+
+#: ../src/common/cmdline.cpp:1039
+#, c-format
+msgid "Option '%s' requires a value."
+msgstr "옵션에 '%s' 값이 필요합니다."
+
+#: ../src/common/cmdline.cpp:1058
+#, c-format
+msgid "Separator expected after the option '%s'."
+msgstr "옵션 '%s' 에 구분자가 없습니다."
+
+#: ../src/common/cmdline.cpp:1088 ../src/common/cmdline.cpp:1106
+#, c-format
+msgid "'%s' is not a correct numeric value for option '%s'."
+msgstr "잘못된 숫자 '%s' 가 '%s' 에 입력 되었습니다."
+
+#: ../src/common/cmdline.cpp:1122
+#, c-format
+msgid "Option '%s': '%s' cannot be converted to a date."
+msgstr "옵션 '%s': '%s' 를 날짜로 변환할 수 없습니다."
+
+#: ../src/common/cmdline.cpp:1170
+#, c-format
+msgid "Unexpected parameter '%s'"
+msgstr "'%s' 의 파라메타가 잘못되었습니다."
+
+#. TRANSLATORS: Short name and long name for a command line option
+#: ../src/common/cmdline.cpp:1197
+#, c-format
+msgid "%s (or %s)"
+msgstr "%s (또는 %s)"
+
+#: ../src/common/cmdline.cpp:1208
+#, c-format
+msgid "The value for the option '%s' must be specified."
+msgstr "'%s' 옵션에 대한 값을 지정해야합니다."
+
+#: ../src/common/cmdline.cpp:1230
+#, c-format
+msgid "The required parameter '%s' was not specified."
+msgstr "필수 매개 변수인 '%s' 가 지정되지 않았습니다."
+
+#: ../src/common/cmdline.cpp:1289
+#, c-format
+msgid "Usage: %s"
+msgstr "사용법: %s"
+
+#: ../src/common/cmdline.cpp:1498
+msgid "str"
+msgstr ""
+
+#: ../src/common/cmdline.cpp:1502
+msgid "num"
+msgstr ""
+
+#: ../src/common/cmdline.cpp:1506
+msgid "double"
+msgstr ""
+
+#: ../src/common/cmdline.cpp:1510
+msgid "date"
+msgstr ""
+
+#: ../src/common/cmdproc.cpp:250 ../src/common/cmdproc.cpp:276
+#: ../src/common/cmdproc.cpp:296
+msgid "Unnamed command"
+msgstr "익명의 명령"
+
+#: ../src/common/cmdproc.cpp:253
+msgid "&Undo "
+msgstr "실행취소(&U)"
+
+#: ../src/common/cmdproc.cpp:255
+msgid "Can't &Undo "
+msgstr "&실행취소 안됨"
+
+#: ../src/common/cmdproc.cpp:259 ../src/common/stockitem.cpp:208
+#: ../src/msw/textctrl.cpp:2880 ../src/osx/textctrl_osx.cpp:649
+#: ../src/richtext/richtextctrl.cpp:327
+msgid "&Undo"
+msgstr "실행취소(&U)"
+
+#: ../src/common/cmdproc.cpp:277 ../src/common/cmdproc.cpp:297
+msgid "&Redo "
+msgstr "다시실행(&R)"
+
+#: ../src/common/cmdproc.cpp:281 ../src/common/cmdproc.cpp:288
+#: ../src/common/stockitem.cpp:190 ../src/msw/textctrl.cpp:2881
+#: ../src/osx/textctrl_osx.cpp:650 ../src/richtext/richtextctrl.cpp:328
+msgid "&Redo"
+msgstr "다시실행(&R)"
+
+#: ../src/common/colourcmn.cpp:41
+#, c-format
+msgid "String To Colour : Incorrect colour specification : %s"
+msgstr "색상코드를 문자열로 변환 : 색상 지정이 잘못되었습니다 : %s"
+
+#: ../src/common/config.cpp:259
+#, c-format
+msgid "Invalid value %ld for a boolean key \"%s\" in config file."
+msgstr ""
+
+#: ../src/common/config.cpp:526
+#, c-format
+msgid ""
+"Environment variables expansion failed: missing '%c' at position %u in '%s'."
+msgstr "환경변수 추가 실패: '%c' 를 찾을 수 없습니다: %u 번째('%s' 에서)"
+
+#: ../src/common/config.cpp:576 ../src/msw/regconf.cpp:272
+#, c-format
+msgid "'%s' has extra '..', ignored."
+msgstr "'%s' 에서  '..' 는 무시합니다."
+
+#. TRANSLATORS: Checkbox state name
+#: ../src/common/datavcmn.cpp:2166 ../src/generic/datavgen.cpp:1430
+msgid "checked"
+msgstr ""
+
+#. TRANSLATORS: Checkbox state name
+#: ../src/common/datavcmn.cpp:2170 ../src/generic/datavgen.cpp:1432
+msgid "unchecked"
+msgstr ""
+
+#. TRANSLATORS: Checkbox state name
+#: ../src/common/datavcmn.cpp:2174
+#, fuzzy
+msgid "undetermined"
+msgstr "밑줄"
+
+#: ../src/common/datetimefmt.cpp:1875
+msgid "today"
+msgstr "오늘"
+
+#: ../src/common/datetimefmt.cpp:1876
+msgid "yesterday"
+msgstr "어제"
+
+#: ../src/common/datetimefmt.cpp:1877
+msgid "tomorrow"
+msgstr "내일"
+
+#: ../src/common/datetimefmt.cpp:2071
+msgid "first"
+msgstr "첫 번째"
+
+#: ../src/common/datetimefmt.cpp:2072
+msgid "second"
+msgstr "두 번째"
+
+#: ../src/common/datetimefmt.cpp:2073
+msgid "third"
+msgstr "세 번째"
+
+#: ../src/common/datetimefmt.cpp:2074
+msgid "fourth"
+msgstr "네 번째"
+
+#: ../src/common/datetimefmt.cpp:2075
+msgid "fifth"
+msgstr "다섯 번째"
+
+#: ../src/common/datetimefmt.cpp:2076
+msgid "sixth"
+msgstr "여섯 번째"
+
+#: ../src/common/datetimefmt.cpp:2077
+msgid "seventh"
+msgstr "일곱 번째"
+
+#: ../src/common/datetimefmt.cpp:2078
+msgid "eighth"
+msgstr "여덟 번째"
+
+#: ../src/common/datetimefmt.cpp:2079
+msgid "ninth"
+msgstr "아홉 번째"
+
+#: ../src/common/datetimefmt.cpp:2080
+msgid "tenth"
+msgstr "열 번째"
+
+#: ../src/common/datetimefmt.cpp:2081
+msgid "eleventh"
+msgstr "열한 번째"
+
+#: ../src/common/datetimefmt.cpp:2082
+msgid "twelfth"
+msgstr "열두 번째"
+
+#: ../src/common/datetimefmt.cpp:2083
+msgid "thirteenth"
+msgstr "열세 번째"
+
+#: ../src/common/datetimefmt.cpp:2084
+msgid "fourteenth"
+msgstr "열네 번째"
+
+#: ../src/common/datetimefmt.cpp:2085
+msgid "fifteenth"
+msgstr "열다섯 번째"
+
+#: ../src/common/datetimefmt.cpp:2086
+msgid "sixteenth"
+msgstr "열여섯 번째"
+
+#: ../src/common/datetimefmt.cpp:2087
+msgid "seventeenth"
+msgstr "열일곱 번째"
+
+#: ../src/common/datetimefmt.cpp:2088
+msgid "eighteenth"
+msgstr "열여덟 번째"
+
+#: ../src/common/datetimefmt.cpp:2089
+msgid "nineteenth"
+msgstr "열아홉 번째"
+
+#: ../src/common/datetimefmt.cpp:2090
+msgid "twentieth"
+msgstr "스무 번째"
+
+#: ../src/common/datetimefmt.cpp:2248
+msgid "noon"
+msgstr "정오"
+
+#: ../src/common/datetimefmt.cpp:2249
+msgid "midnight"
+msgstr "깊은 밤"
+
+#: ../src/common/debugrpt.cpp:209
+#, c-format
+msgid "Failed to create directory \"%s\""
+msgstr "디렉토리 \"%s\" 생성을 실패했습니다."
+
+#: ../src/common/debugrpt.cpp:210
+msgid "Debug report couldn't be created."
+msgstr "디보그 보고서가 생성되지 않았습니다."
+
+#: ../src/common/debugrpt.cpp:227
+#, c-format
+msgid "Failed to remove debug report file \"%s\""
+msgstr "디버그 보고서 파일 \"%s\" 의 삭제를 실패했습니다."
+
+#: ../src/common/debugrpt.cpp:239
+#, c-format
+msgid "Failed to clean up debug report directory \"%s\""
+msgstr "디버그 보고서 디렉토리 \"%s\" 를 비우는데 실패했습니다."
+
+#: ../src/common/debugrpt.cpp:514
+msgid "process context description"
+msgstr "프로세스 상태 설명"
+
+#: ../src/common/debugrpt.cpp:538
+msgid "dump of the process state (binary)"
+msgstr "현재프로세스의 덤프"
+
+#: ../src/common/debugrpt.cpp:553
+msgid "Debug report generation has failed."
+msgstr "디버그 보고서의 생성을 실패했습니다."
+
+#: ../src/common/debugrpt.cpp:560
+#, c-format
+msgid ""
+"Processing debug report has failed, leaving the files in \"%s\" directory."
+msgstr "디버그 보고서 생성 작업이 실패습니다(\"%s\" 디렉토리). "
+
+#: ../src/common/debugrpt.cpp:573
+msgid "A debug report has been generated. It can be found in"
+msgstr ""
+"디버그 보고서가 생성되었습니다. 다음의 디렉토리에서 확인 하실 수 있습니다."
+
+#: ../src/common/debugrpt.cpp:576
+msgid "And includes the following files:\n"
+msgstr "그리고 다음의 파일들을 포함하고 있습니다:\n"
+
+#: ../src/common/debugrpt.cpp:586
+msgid ""
+"\n"
+"Please send this report to the program maintainer, thank you!\n"
+msgstr ""
+"\n"
+"이보고서를 프로그램 개발자에게 보내주세요!\n"
+
+#: ../src/common/debugrpt.cpp:729
+msgid "Failed to execute curl, please install it in PATH."
+msgstr "Curl 을 실행할 수 없습니다. PATH 폴더에 설치해 주세요."
+
+#: ../src/common/debugrpt.cpp:742
+#, c-format
+msgid "Failed to upload the debug report (error code %d)."
+msgstr "디버그 보고서 전송 실패 (오류 코드 %d)"
+
+#: ../src/common/docview.cpp:366
+msgid "Save As"
+msgstr "다른 이름으로 저장"
+
+#: ../src/common/docview.cpp:457
+msgid "Discard changes and reload the last saved version?"
+msgstr ""
+
+#: ../src/common/docview.cpp:488
+msgid "unnamed"
+msgstr "이름없음"
+
+#: ../src/common/docview.cpp:513
+#, fuzzy, c-format
+msgid "Do you want to save changes to %s?"
+msgstr "%s 문서의 바뀐 내용을 저장하시겠습니까?"
+
+#: ../src/common/docview.cpp:521 ../src/common/docview.cpp:560
+#: ../src/common/stockitem.cpp:195
+msgid "&Save"
+msgstr "저장(&S)"
+
+#: ../src/common/docview.cpp:522 ../src/common/docview.cpp:560
+msgid "&Discard changes"
+msgstr ""
+
+#: ../src/common/docview.cpp:523
+#, fuzzy
+msgid "Do&n't close"
+msgstr "저장 하지 않음"
+
+#: ../src/common/docview.cpp:553
+#, fuzzy, c-format
+msgid "Do you want to save changes to %s before closing it?"
+msgstr "%s 문서의 바뀐 내용을 저장하시겠습니까?"
+
+#: ../src/common/docview.cpp:559
+#, fuzzy
+msgid "The document must be closed."
+msgstr "텍스트를 저장할 수 없습니다."
+
+#: ../src/common/docview.cpp:571
+#, c-format
+msgid "Saving %s failed, would you like to retry?"
+msgstr ""
+
+#: ../src/common/docview.cpp:577
+msgid "Retry"
+msgstr ""
+
+#: ../src/common/docview.cpp:577
+msgid "Discard changes"
+msgstr ""
+
+#: ../src/common/docview.cpp:679
+#, fuzzy, c-format
+msgid "File \"%s\" could not be opened for writing."
+msgstr "'%s' 파일을 쓰기 모드로 여는 데 실패했습니다."
+
+#: ../src/common/docview.cpp:685
+#, fuzzy, c-format
+msgid "Failed to save document to the file \"%s\"."
+msgstr "\"%s\" 비트맵 이미지 파을을 저장하는데 실패했습니다."
+
+#: ../src/common/docview.cpp:702
+#, fuzzy, c-format
+msgid "File \"%s\" could not be opened for reading."
+msgstr "'%s' 파일을 읽기 모드로 여는 데 실패했습니다."
+
+#: ../src/common/docview.cpp:714
+#, fuzzy, c-format
+msgid "Failed to read document from the file \"%s\"."
+msgstr "\"%s\" 파일에서 메타 파일을 읽어올 수 없습니다."
+
+#: ../src/common/docview.cpp:1236
+#, c-format
+msgid ""
+"The file '%s' doesn't exist and couldn't be opened.\n"
+"It has been removed from the most recently used files list."
+msgstr ""
+"파일 '%s' 가 없습니다.\n"
+"최근 사용 파일 목록 에서 제거된거 같습니다."
+
+#: ../src/common/docview.cpp:1296
+#, fuzzy
+msgid "Print preview creation failed."
+msgstr "파이프 생성 실패"
+
+#: ../src/common/docview.cpp:1302
+msgid "Print Preview"
+msgstr "인쇄 미리보기"
+
+#: ../src/common/docview.cpp:1517
+#, fuzzy, c-format
+msgid "The format of file '%s' couldn't be determined."
+msgstr "Column 너비를 정의할수 없습니다."
+
+#: ../src/common/docview.cpp:1643
+#, c-format
+msgid "unnamed%d"
+msgstr "이름없음%d"
+
+#: ../src/common/docview.cpp:1660
+msgid " - "
+msgstr " - "
+
+#: ../src/common/docview.cpp:1791 ../src/common/docview.cpp:1844
+msgid "Open File"
+msgstr "파일 열기"
+
+#: ../src/common/docview.cpp:1807
+msgid "File error"
+msgstr "파일 오류"
+
+#: ../src/common/docview.cpp:1809
+msgid "Sorry, could not open this file."
+msgstr "파일을 열 수 없습니다."
+
+#: ../src/common/docview.cpp:1843
+msgid "Sorry, the format for this file is unknown."
+msgstr "알수 없는 파일 형식 입니다."
+
+#: ../src/common/docview.cpp:1924
+msgid "Select a document template"
+msgstr "문서 템플릿을 선택합니다"
+
+#: ../src/common/docview.cpp:1925
+msgid "Templates"
+msgstr "템플릿"
+
+#: ../src/common/docview.cpp:1998
+msgid "Select a document view"
+msgstr "문서 뷰를 선택합니다"
+
+#: ../src/common/docview.cpp:1999
+msgid "Views"
+msgstr "보기"
+
+#: ../src/common/dynlib.cpp:81
+#, c-format
+msgid "Failed to load shared library '%s'"
+msgstr "'%s' 공유 Library를 읽어올 수 없습니다."
+
+#: ../src/common/dynlib.cpp:105
+#, c-format
+msgid "Couldn't find symbol '%s' in a dynamic library"
+msgstr "동적 Library에서 '%s' 기호를 찾을 수 없습니다."
+
+#: ../src/common/ffile.cpp:56 ../src/common/file.cpp:215
+#, c-format
+msgid "can't open file '%s'"
+msgstr " '%s' 파일을 열 수 없습니다"
+
+#: ../src/common/ffile.cpp:72
+#, c-format
+msgid "can't close file '%s'"
+msgstr "'%s' 파일을 닫을 수 없습니다."
+
+#: ../src/common/ffile.cpp:106 ../src/common/ffile.cpp:131
+#, c-format
+msgid "Read error on file '%s'"
+msgstr "'%s '파일을 읽는 데 오류가 발생했습니다."
+
+#: ../src/common/ffile.cpp:148
+#, c-format
+msgid "Write error on file '%s'"
+msgstr "'%s' 파일 쓰기 오류"
+
+#: ../src/common/ffile.cpp:182
+#, c-format
+msgid "failed to flush the file '%s'"
+msgstr "파일 '%s'를 비우는데 실패 했습니다."
+
+#: ../src/common/ffile.cpp:222
+#, c-format
+msgid "Seek error on file '%s' (large files not supported by stdio)"
+msgstr "파일 '%s' 에서 찾기 실패(큰 파일형식을 지원하지 않습니다.)"
+
+#: ../src/common/ffile.cpp:232
+#, c-format
+msgid "Seek error on file '%s'"
+msgstr "'%s' 파일에서 찾을 수 없습니다."
+
+#: ../src/common/ffile.cpp:248
+#, c-format
+msgid "Can't find current position in file '%s'"
+msgstr "파일 '%s' 에서 현재 위치를 찾을 수 없습니다."
+
+#: ../src/common/ffile.cpp:349 ../src/common/file.cpp:569
+msgid "Failed to set temporary file permissions"
+msgstr "임시 파일의 접근 권한 설정을 실패 했습니다."
+
+#: ../src/common/ffile.cpp:371
+#, c-format
+msgid "can't remove file '%s'"
+msgstr "'%s' 파일을 지울 수 없습니다"
+
+#: ../src/common/ffile.cpp:376 ../src/common/file.cpp:591
+#, c-format
+msgid "can't commit changes to file '%s'"
+msgstr "'%s' 파일의 바뀐점을 저장할 수 없습니다."
+
+#: ../src/common/ffile.cpp:388 ../src/common/file.cpp:603
+#, c-format
+msgid "can't remove temporary file '%s'"
+msgstr "'%s' 임시 파일을 지울 수 없습니다"
+
+#: ../src/common/file.cpp:162
+#, c-format
+msgid "can't create file '%s'"
+msgstr "'%s' 파일을 생성할 수 없습니다."
+
+#: ../src/common/file.cpp:229
+#, c-format
+msgid "can't close file descriptor %d"
+msgstr "파일 디스크립터 %d 를 닫을 수 없습니다."
+
+#: ../src/common/file.cpp:332
+#, c-format
+msgid "can't read from file descriptor %d"
+msgstr "파일 디스크립터 %d 에서 데이타를 읽어 올 수 없습니다."
+
+#: ../src/common/file.cpp:351
+#, c-format
+msgid "can't write to file descriptor %d"
+msgstr "파일 디스크립터 %d 에서 데이타를 쓸 수 없습니다."
+
+#: ../src/common/file.cpp:390
+#, c-format
+msgid "can't flush file descriptor %d"
+msgstr "파일 디스크립터 %d 를 비울수 없습니다."
+
+#: ../src/common/file.cpp:432
+#, c-format
+msgid "can't seek on file descriptor %d"
+msgstr "파일 디스크립터 %d 찾을 수 없습니다."
+
+#: ../src/common/file.cpp:446
+#, c-format
+msgid "can't get seek position on file descriptor %d"
+msgstr "파일 디스크립터 %d 의 현재 위치를 얻을 수 없습니다"
+
+#: ../src/common/file.cpp:475
+#, c-format
+msgid "can't find length of file on file descriptor %d"
+msgstr "파일 디스크립터 %d 에서 파일의 길이를 얻어올 수 없습니다."
+
+#: ../src/common/file.cpp:505
+#, c-format
+msgid "can't determine if the end of file is reached on descriptor %d"
+msgstr ""
+"파일 디스크립터 %d에서 현재 오프셋의 위치가 파일의 끝인지 알 수 없습니다."
+
+#: ../src/common/fileconf.cpp:352
+#, c-format
+msgid ""
+" and additionally, the existing configuration file was renamed to \"%s\" and "
+"couldn't be renamed back, please rename it to its original path \"%s\""
+msgstr ""
+
+#: ../src/common/fileconf.cpp:389
+#, fuzzy
+msgid " due to the following error:\n"
+msgstr "그리고 다음의 파일들을 포함하고 있습니다:\n"
+
+#: ../src/common/fileconf.cpp:412
+#, fuzzy
+msgid "failed to rename the existing file"
+msgstr "\"%s\" 파일에서 메타 파일을 읽어올 수 없습니다."
+
+#: ../src/common/fileconf.cpp:421
+#, fuzzy
+msgid "failed to create the new file directory"
+msgstr "작업 디렉토리를 가져오는데 실패했습니다."
+
+#: ../src/common/fileconf.cpp:428
+#, fuzzy
+msgid "failed to move the file to the new location"
+msgstr "전화연결 종료 실패: %s"
+
+#: ../src/common/fileconf.cpp:462
+#, c-format
+msgid "can't open global configuration file '%s'."
+msgstr "전역 설정파일 '%s' 을 열수 없습니다."
+
+#: ../src/common/fileconf.cpp:478
+#, c-format
+msgid "can't open user configuration file '%s'."
+msgstr "사용자 설정파일 '%s' 을 열수 없습니다."
+
+#: ../src/common/fileconf.cpp:483
+#, c-format
+msgid "Changes won't be saved to avoid overwriting the existing file \"%s\""
+msgstr ""
+"기존 파일  \"%s\" 을 덮어 쓰지 않기 위하여 변경사항을 저장하지 않습니다. "
+
+#: ../src/common/fileconf.cpp:583
+msgid "Error reading config options."
+msgstr "설정 읽기 오류."
+
+#: ../src/common/fileconf.cpp:593
+msgid "Failed to read config options."
+msgstr "설정을 읽어오지 못했습니다."
+
+#: ../src/common/fileconf.cpp:700
+#, fuzzy, c-format
+msgid "file '%s': unexpected character %c at line %zu."
+msgstr "'%s' 파일: 잘못입력된 문자 데이터 %c (%d번째 줄)"
+
+#: ../src/common/fileconf.cpp:736
+#, fuzzy, c-format
+msgid "file '%s', line %zu: '%s' ignored after group header."
+msgstr "파일[%s], 행[%d]: 헤더 이후의 '%s' 는 무시합니다."
+
+#: ../src/common/fileconf.cpp:765
+#, fuzzy, c-format
+msgid "file '%s', line %zu: '=' expected."
+msgstr "'%s' 파일, %d번째 줄 : '=' 을 찾을 수 없습니다."
+
+#: ../src/common/fileconf.cpp:778
+#, fuzzy, c-format
+msgid "file '%s', line %zu: value for immutable key '%s' ignored."
+msgstr "파일[%s], 행[%d]: 변경 불가능한 키값 '%s'는 무시합니다."
+
+#: ../src/common/fileconf.cpp:788
+#, fuzzy, c-format
+msgid "file '%s', line %zu: key '%s' was first found at line %d."
+msgstr "파일[%s], 행[%d], 키['%s'] : %d 행에서 처음으로 발견됨 "
+
+#: ../src/common/fileconf.cpp:1091
+#, c-format
+msgid "Config entry name cannot start with '%c'."
+msgstr "설정파일에 문자열은 '%c' 로 시작할 수 없습니다."
+
+#: ../src/common/fileconf.cpp:1146
+#, fuzzy
+msgid "Failed to create configuration file directory."
+msgstr "사용자 설정 파일을 갱신하는데 실패했습니다."
+
+#: ../src/common/fileconf.cpp:1158
+msgid "can't open user configuration file."
+msgstr "사용자 설정파일을 열수 없습니다."
+
+#: ../src/common/fileconf.cpp:1172
+msgid "can't write user configuration file."
+msgstr "사용자 설정을 파일에 쓸 수 없습니다"
+
+#: ../src/common/fileconf.cpp:1178
+msgid "Failed to update user configuration file."
+msgstr "사용자 설정 파일을 갱신하는데 실패했습니다."
+
+#: ../src/common/fileconf.cpp:1201
+msgid "Error saving user configuration data."
+msgstr "사용자 설정 정보 저장 실패."
+
+#: ../src/common/fileconf.cpp:1313
+#, c-format
+msgid "can't delete user configuration file '%s'"
+msgstr "사용자 설정파일 '%s' 을 삭제할 수 없습니다."
+
+#: ../src/common/fileconf.cpp:2007
+#, c-format
+msgid "entry '%s' appears more than once in group '%s'"
+msgstr "항목 '%s' 가 구룹 '%s' 에 하나이상 있습니다."
+
+#: ../src/common/fileconf.cpp:2021
+#, c-format
+msgid "attempt to change immutable key '%s' ignored."
+msgstr "변경 불가능한 설정의 변경을 시도했습니다. '%s' 무시합니다."
+
+#: ../src/common/fileconf.cpp:2118
+#, c-format
+msgid "trailing backslash ignored in '%s'"
+msgstr "'%s' 의 마지막 역슬러쉬는 무시됩니다."
+
+#: ../src/common/fileconf.cpp:2153
+#, c-format
+msgid "unexpected \" at position %d in '%s'."
+msgstr "%d 번째 줄('%s' 파일)에서 \" 문자가 잘못 입려되었습니다."
+
+#: ../src/common/filefn.cpp:474
+#, c-format
+msgid "Failed to copy the file '%s' to '%s'"
+msgstr "파일 '%s' 를 '%s' 로 복사하는데 실패했습니다."
+
+#: ../src/common/filefn.cpp:487
+#, c-format
+msgid "Impossible to get permissions for file '%s'"
+msgstr "'%s' 파일의 접근할 수 없습니다."
+
+#: ../src/common/filefn.cpp:501
+#, c-format
+msgid "Impossible to overwrite the file '%s'"
+msgstr "파일 '%s' 덮어쓰기 실패"
+
+#: ../src/common/filefn.cpp:508
+#, fuzzy, c-format
+msgid "Error copying the file '%s' to '%s'."
+msgstr "파일 '%s' 를 '%s' 로 복사하는데 실패했습니다."
+
+#: ../src/common/filefn.cpp:556
+#, c-format
+msgid "Impossible to set permissions for the file '%s'"
+msgstr "'%s' 파일의 접근권한을 변경할 수 없습니다."
+
+#: ../src/common/filefn.cpp:606
+#, c-format
+msgid ""
+"Failed to rename the file '%s' to '%s' because the destination file already "
+"exists."
+msgstr ""
+"파일이름을  '%s' 에서 '%s' 로 변경 실패, 동일한 파일이름이 이미 존재합니다."
+
+#: ../src/common/filefn.cpp:623
+#, fuzzy, c-format
+msgid "File '%s' couldn't be renamed '%s'"
+msgstr "'%s' 디렉토리를 만들 수 없습니다."
+
+#: ../src/common/filefn.cpp:639
+#, fuzzy, c-format
+msgid "File '%s' couldn't be removed"
+msgstr "'%s' 디렉토리를 만들 수 없습니다."
+
+#: ../src/common/filefn.cpp:666
+#, c-format
+msgid "Directory '%s' couldn't be created"
+msgstr "'%s' 디렉토리를 만들 수 없습니다."
+
+#: ../src/common/filefn.cpp:680
+#, fuzzy, c-format
+msgid "Directory '%s' couldn't be deleted"
+msgstr "'%s' 디렉토리를 만들 수 없습니다."
+
+#: ../src/common/filefn.cpp:714
+#, c-format
+msgid "Cannot enumerate files '%s'"
+msgstr "'%s' 에 해당하는 파일을 찾을 수 없습니다"
+
+#: ../src/common/filefn.cpp:798
+msgid "Failed to get the working directory"
+msgstr "작업 디렉토리를 가져오는데 실패했습니다."
+
+#: ../src/common/filefn.cpp:843
+#, fuzzy
+msgid "Could not set current working directory"
+msgstr "작업 디렉토리를 가져오는데 실패했습니다."
+
+#: ../src/common/filefn.cpp:974
+#, c-format
+msgid "Files (%s)"
+msgstr "파일 (%s)"
+
+#: ../src/common/filename.cpp:182
+#, c-format
+msgid "Failed to open '%s' for reading"
+msgstr "'%s' 파일을 읽기 모드로 여는 데 실패했습니다."
+
+#: ../src/common/filename.cpp:187
+#, c-format
+msgid "Failed to open '%s' for writing"
+msgstr "'%s' 파일을 쓰기 모드로 여는 데 실패했습니다."
+
+#: ../src/common/filename.cpp:199
+msgid "Failed to close file handle"
+msgstr "파일 닫기를 실패했습니다."
+
+#: ../src/common/filename.cpp:1046
+msgid "Failed to create a temporary file name"
+msgstr "임시 파일을 생성을 실패했습니다"
+
+#: ../src/common/filename.cpp:1081
+msgid "Failed to open temporary file."
+msgstr "임시 파일을 여는 데 실패했습니다."
+
+#: ../src/common/filename.cpp:2862
+#, c-format
+msgid "Failed to modify file times for '%s'"
+msgstr "%s 번 파일을 수정하는 데 실패"
+
+#: ../src/common/filename.cpp:2877
+#, c-format
+msgid "Failed to touch the file '%s'"
+msgstr "'%s' 파일 만들기 실패"
+
+#: ../src/common/filename.cpp:2958
+#, c-format
+msgid "Failed to retrieve file times for '%s'"
+msgstr "'%s' 번 파일검색 실패 "
+
+#: ../src/common/filepickercmn.cpp:39 ../src/common/filepickercmn.cpp:40
+msgid "Browse"
+msgstr "탐색창"
+
+#: ../src/common/fldlgcmn.cpp:792 ../src/generic/filectrlg.cpp:1185
+#, c-format
+msgid "All files (%s)|%s"
+msgstr "모든 파일 (%s)|%s"
+
+#. TRANSLATORS: %s are a file extension used to build a file wildcard string
+#: ../src/common/fldlgcmn.cpp:810
+#, c-format
+msgid "%s files (%s)|%s"
+msgstr "%s 파일 (%s)|%s"
+
+#: ../src/common/fldlgcmn.cpp:1072
+#, c-format
+msgid "Load %s file"
+msgstr "%s 파일 불러오기"
+
+#: ../src/common/fldlgcmn.cpp:1074
+#, c-format
+msgid "Save %s file"
+msgstr "%s 파일 저장"
+
+#: ../src/common/fmapbase.cpp:144
+msgid "Western European (ISO-8859-1)"
+msgstr "서유럽어 (ISO-8859-1)"
+
+#: ../src/common/fmapbase.cpp:145
+msgid "Central European (ISO-8859-2)"
+msgstr "중앙 유럽어 (ISO-8859-2)"
+
+#: ../src/common/fmapbase.cpp:146
+msgid "Esperanto (ISO-8859-3)"
+msgstr "남유럽어 (ISO-8859-3)"
+
+#: ../src/common/fmapbase.cpp:147
+msgid "Baltic (old) (ISO-8859-4)"
+msgstr "발트어 (old)(ISO-8859-4)"
+
+#: ../src/common/fmapbase.cpp:148
+msgid "Cyrillic (ISO-8859-5)"
+msgstr "아랍어 (ISO-8859-5)"
+
+#: ../src/common/fmapbase.cpp:149
+msgid "Arabic (ISO-8859-6)"
+msgstr "아랍어 (ISO-8859-6)"
+
+#: ../src/common/fmapbase.cpp:150
+msgid "Greek (ISO-8859-7)"
+msgstr "그리스어 (ISO-8859-7)"
+
+#: ../src/common/fmapbase.cpp:151
+msgid "Hebrew (ISO-8859-8)"
+msgstr "히브리어 (ISO-8859-8)"
+
+#: ../src/common/fmapbase.cpp:152
+msgid "Turkish (ISO-8859-9)"
+msgstr "터키어 (ISO-8859-9)"
+
+#: ../src/common/fmapbase.cpp:153
+msgid "Nordic (ISO-8859-10)"
+msgstr "노르웨이어 (ISO-8859-10)"
+
+#: ../src/common/fmapbase.cpp:154
+msgid "Thai (ISO-8859-11)"
+msgstr "타이어 (ISO-8859-11)"
+
+#: ../src/common/fmapbase.cpp:155
+msgid "Indian (ISO-8859-12)"
+msgstr "인도어 (ISO-8859-12)"
+
+#: ../src/common/fmapbase.cpp:156
+msgid "Baltic (ISO-8859-13)"
+msgstr "발트어 (ISO-8859-13)"
+
+#: ../src/common/fmapbase.cpp:157
+msgid "Celtic (ISO-8859-14)"
+msgstr "켈트어 (ISO-8859-14)"
+
+#: ../src/common/fmapbase.cpp:158
+msgid "Western European with Euro (ISO-8859-15)"
+msgstr "서유럽어 (ISO-8859-15)"
+
+#: ../src/common/fmapbase.cpp:159
+msgid "KOI8-R"
+msgstr "키릴어 (KOI8-R)"
+
+#: ../src/common/fmapbase.cpp:160
+msgid "KOI8-U"
+msgstr "키릴어 (KOI8-U)"
+
+#: ../src/common/fmapbase.cpp:161
+#, fuzzy
+msgid "Windows/DOS OEM Cyrillic (CP 866)"
+msgstr "Windows 키릴 자모 (CP 1251)"
+
+#: ../src/common/fmapbase.cpp:162
+msgid "Windows Thai (CP 874)"
+msgstr "Windows 태국어 (CP 874)"
+
+#: ../src/common/fmapbase.cpp:163
+#, fuzzy
+msgid "Windows Japanese (CP 932) or Shift-JIS"
+msgstr "Windows 일본어 (CP 932)"
+
+#: ../src/common/fmapbase.cpp:164
+#, fuzzy
+msgid "Windows Chinese Simplified (CP 936) or GB-2312"
+msgstr "Windows 중국어 간체 (CP 936)"
+
+#: ../src/common/fmapbase.cpp:165
+msgid "Windows Korean (CP 949)"
+msgstr "Windows 한국어 (CP 949)"
+
+#: ../src/common/fmapbase.cpp:166
+#, fuzzy
+msgid "Windows Chinese Traditional (CP 950) or Big-5"
+msgstr "Windows 중국어 번체 (CP 950)"
+
+#: ../src/common/fmapbase.cpp:167
+msgid "Windows Central European (CP 1250)"
+msgstr "Windows 중유럽어 (CP 1250)"
+
+#: ../src/common/fmapbase.cpp:168
+msgid "Windows Cyrillic (CP 1251)"
+msgstr "Windows 키릴 자모 (CP 1251)"
+
+#: ../src/common/fmapbase.cpp:169
+msgid "Windows Western European (CP 1252)"
+msgstr "Windows 서유럽어 (CP 1252)"
+
+#: ../src/common/fmapbase.cpp:170
+msgid "Windows Greek (CP 1253)"
+msgstr "Windows 그리스어 (CP 1253)"
+
+#: ../src/common/fmapbase.cpp:171
+msgid "Windows Turkish (CP 1254)"
+msgstr "Windows 터키어 (CP 1254)"
+
+#: ../src/common/fmapbase.cpp:172
+msgid "Windows Hebrew (CP 1255)"
+msgstr "Windows 히브리어 (CP 1255)"
+
+#: ../src/common/fmapbase.cpp:173
+msgid "Windows Arabic (CP 1256)"
+msgstr "Windows 아라비아어 (CP 1256)"
+
+#: ../src/common/fmapbase.cpp:174
+msgid "Windows Baltic (CP 1257)"
+msgstr "Windows 발트어 (CP 1257)"
+
+#: ../src/common/fmapbase.cpp:175
+#, fuzzy
+msgid "Windows Vietnamese (CP 1258)"
+msgstr "Windows 그리스어 (CP 1253)"
+
+#: ../src/common/fmapbase.cpp:176
+#, fuzzy
+msgid "Windows Johab (CP 1361)"
+msgstr "Windows 아라비아어 (CP 1256)"
+
+#: ../src/common/fmapbase.cpp:177
+msgid "Windows/DOS OEM (CP 437)"
+msgstr "Windows/DOS OEM - 미국 (CP 437)"
+
+#: ../src/common/fmapbase.cpp:178
+msgid "Unicode 7 bit (UTF-7)"
+msgstr "유니코드 (UTF-7)"
+
+#: ../src/common/fmapbase.cpp:179
+msgid "Unicode 8 bit (UTF-8)"
+msgstr "유니코드 (UTF-8)"
+
+#: ../src/common/fmapbase.cpp:181 ../src/common/fmapbase.cpp:187
+msgid "Unicode 16 bit (UTF-16)"
+msgstr "유니코드 (UTF-16)"
+
+#: ../src/common/fmapbase.cpp:182
+msgid "Unicode 16 bit Little Endian (UTF-16LE)"
+msgstr "유니코드 (UTF-16LE)"
+
+#: ../src/common/fmapbase.cpp:183 ../src/common/fmapbase.cpp:189
+msgid "Unicode 32 bit (UTF-32)"
+msgstr "유니코드 (UTF-32)"
+
+#: ../src/common/fmapbase.cpp:184
+msgid "Unicode 32 bit Little Endian (UTF-32LE)"
+msgstr "유니코드 (UTF-32LE)"
+
+#: ../src/common/fmapbase.cpp:186
+msgid "Unicode 16 bit Big Endian (UTF-16BE)"
+msgstr "유니코드 (UTF-16BE)"
+
+#: ../src/common/fmapbase.cpp:188
+msgid "Unicode 32 bit Big Endian (UTF-32BE)"
+msgstr "유니코드 (UTF-32BE)"
+
+#: ../src/common/fmapbase.cpp:191
+msgid "Extended Unix Codepage for Japanese (EUC-JP)"
+msgstr "일본어 (EUC-JP)"
+
+#: ../src/common/fmapbase.cpp:192
+msgid "US-ASCII"
+msgstr "영어 (US-ASCII)"
+
+#: ../src/common/fmapbase.cpp:193
+msgid "ISO-2022-JP"
+msgstr "일본어 (ISO-2022-JP)"
+
+#: ../src/common/fmapbase.cpp:195
+msgid "MacRoman"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:196
+msgid "MacJapanese"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:197
+msgid "MacChineseTrad"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:198
+msgid "MacKorean"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:199
+#, fuzzy
+msgid "MacArabic"
+msgstr "아랍어"
+
+#: ../src/common/fmapbase.cpp:200
+msgid "MacHebrew"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:201
+msgid "MacGreek"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:202
+msgid "MacCyrillic"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:203
+msgid "MacDevanagari"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:204
+msgid "MacGurmukhi"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:205
+msgid "MacGujarati"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:206
+msgid "MacOriya"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:207
+msgid "MacBengali"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:208
+msgid "MacTamil"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:209
+msgid "MacTelugu"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:210
+msgid "MacKannada"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:211
+msgid "MacMalayalam"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:212
+#, fuzzy
+msgid "MacSinhalese"
+msgstr "대소문자가 구분"
+
+#: ../src/common/fmapbase.cpp:213
+msgid "MacBurmese"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:214
+msgid "MacKhmer"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:215
+msgid "MacThai"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:216
+msgid "MacLaotian"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:217
+msgid "MacGeorgian"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:218
+msgid "MacArmenian"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:219
+msgid "MacChineseSimp"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:220
+msgid "MacTibetan"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:221
+msgid "MacMongolian"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:222
+msgid "MacEthiopic"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:223
+msgid "MacCentralEurRoman"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:224
+msgid "MacVietnamese"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:225
+#, fuzzy
+msgid "MacExtArabic"
+msgstr "아랍어"
+
+#: ../src/common/fmapbase.cpp:226
+#, fuzzy
+msgid "MacSymbol"
+msgstr "기호"
+
+#: ../src/common/fmapbase.cpp:227
+msgid "MacDingbats"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:228
+msgid "MacTurkish"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:229
+msgid "MacCroatian"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:230
+msgid "MacIcelandic"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:231
+msgid "MacRomanian"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:232
+msgid "MacCeltic"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:233
+msgid "MacGaelic"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:234
+msgid "MacKeyboardGlyphs"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:791
+msgid "Default encoding"
+msgstr "기본 인코딩"
+
+#: ../src/common/fmapbase.cpp:805
+#, c-format
+msgid "Unknown encoding (%d)"
+msgstr "인코딩 %d 를 찾을수 없습니다."
+
+#: ../src/common/fmapbase.cpp:815 ../src/richtext/richtextstyles.cpp:776
+msgid "default"
+msgstr "기본값"
+
+#: ../src/common/fmapbase.cpp:829
+#, c-format
+msgid "unknown-%d"
+msgstr "알 수 없음-%d"
+
+#: ../src/common/fontcmn.cpp:924 ../src/common/fontcmn.cpp:1130
+msgid "underlined"
+msgstr "밑줄"
+
+#: ../src/common/fontcmn.cpp:929
+msgid " strikethrough"
+msgstr " 취소선"
+
+#: ../src/common/fontcmn.cpp:942
+msgid " thin"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:946
+#, fuzzy
+msgid " extra light"
+msgstr " 가늘게"
+
+#: ../src/common/fontcmn.cpp:950
+msgid " light"
+msgstr " 가늘게"
+
+#: ../src/common/fontcmn.cpp:954
+msgid " medium"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:958
+#, fuzzy
+msgid " semi bold"
+msgstr " 굵게"
+
+#: ../src/common/fontcmn.cpp:962
+msgid " bold"
+msgstr " 굵게"
+
+#: ../src/common/fontcmn.cpp:966
+#, fuzzy
+msgid " extra bold"
+msgstr " 굵게"
+
+#: ../src/common/fontcmn.cpp:970
+msgid " heavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:974
+msgid " extra heavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:990
+msgid " italic"
+msgstr " 기울임"
+
+#: ../src/common/fontcmn.cpp:1134
+#, fuzzy
+msgid "strikethrough"
+msgstr "취소선(&S)"
+
+#: ../src/common/fontcmn.cpp:1143
+msgid "thin"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1156
+#, fuzzy
+msgid "extralight"
+msgstr "가늘게"
+
+#: ../src/common/fontcmn.cpp:1161
+msgid "light"
+msgstr "가늘게"
+
+#: ../src/common/fontcmn.cpp:1169 ../src/richtext/richtextstyles.cpp:775
+#, fuzzy
+msgid "normal"
+msgstr "보통"
+
+#: ../src/common/fontcmn.cpp:1174
+msgid "medium"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1179 ../src/common/fontcmn.cpp:1199
+#, fuzzy
+msgid "semibold"
+msgstr "굵게"
+
+#: ../src/common/fontcmn.cpp:1184
+msgid "bold"
+msgstr "굵게"
+
+#: ../src/common/fontcmn.cpp:1194
+#, fuzzy
+msgid "extrabold"
+msgstr "굵게"
+
+#: ../src/common/fontcmn.cpp:1204
+msgid "heavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1212
+msgid "extraheavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1217
+msgid "italic"
+msgstr "기울임"
+
+#: ../src/common/fontmap.cpp:195
+msgid ": unknown charset"
+msgstr ": 알 수 없는 문자셋"
+
+#: ../src/common/fontmap.cpp:199
+#, c-format
+msgid ""
+"The charset '%s' is unknown. You may select\n"
+"another charset to replace it with or choose\n"
+"[Cancel] if it cannot be replaced"
+msgstr ""
+"알 수 없는 문자 집합('%s')을 선택 했습니다.\n"
+"다름 문자집합을 선택하십시오.\n"
+"변경하지 원치 않으면 [취소] 클릭십시오."
+
+#: ../src/common/fontmap.cpp:241
+#, c-format
+msgid "Failed to remember the encoding for the charset '%s'."
+msgstr "'%s' 에 대한 서브 인코딩을 알수 없습니다."
+
+#: ../src/common/fontmap.cpp:321
+msgid "can't load any font, aborting"
+msgstr "글꼴 가져오기 실패, 작업을 취소합니다."
+
+#: ../src/common/fontmap.cpp:409
+msgid ": unknown encoding"
+msgstr ": 알 수 없는 문자 인코딩"
+
+#: ../src/common/fontmap.cpp:417
+#, c-format
+msgid ""
+"No font for displaying text in encoding '%s' found,\n"
+"but an alternative encoding '%s' is available.\n"
+"Do you want to use this encoding (otherwise you will have to choose another "
+"one)?"
+msgstr ""
+"인코딩 '%s' 를 보여줄 글꼴이 없습니다.\n"
+"다른 인코딩 '%s' 를 사용할 수 있습니다.\n"
+"이 인코딩을 사용하시겠습니까 (그렇지 않으면 또 다른 하나를 선택하셔야합니다)?"
+
+#: ../src/common/fontmap.cpp:422
+#, c-format
+msgid ""
+"No font for displaying text in encoding '%s' found.\n"
+"Would you like to select a font to be used for this encoding\n"
+"(otherwise the text in this encoding will not be shown correctly)?"
+msgstr ""
+"인코딩 '%s' 를 보여줄 글꼴이 없습니다.\n"
+"이 인코딩에 사용할 글꼴을 선택 하시겠습니까\n"
+"(그렇지 않으면이 인코딩에 텍스트가 제대로 표시되지 않습니다)?"
+
+#: ../src/common/fs_mem.cpp:169
+#, c-format
+msgid "Memory VFS already contains file '%s'!"
+msgstr "'%s' 파일이 VFS에 이미 포함되어 있습니다."
+
+#: ../src/common/fs_mem.cpp:232
+#, c-format
+msgid "Trying to remove file '%s' from memory VFS, but it is not loaded!"
+msgstr "VFS에서 파일 '%s' 를 삭제할 수 없습니다.(로딩되지 않았음)"
+
+#: ../src/common/fs_mem.cpp:262
+#, c-format
+msgid "Failed to store image '%s' to memory VFS!"
+msgstr "메모리 맵드 파일 '%s' 에 이미지 저장 실패"
+
+#: ../src/common/ftp.cpp:197
+msgid "Timeout while waiting for FTP server to connect, try passive mode."
+msgstr "FTP 접속 실패(Time-out), 패시브 모드로 시도해 보시오."
+
+#: ../src/common/ftp.cpp:399
+#, c-format
+msgid "Failed to set FTP transfer mode to %s."
+msgstr "FTP 전송모드를 %s 로 변경하지 못했습니다. "
+
+#: ../src/common/ftp.cpp:400 ../src/richtext/richtextsymboldlg.cpp:432
+msgid "ASCII"
+msgstr "아스키"
+
+#: ../src/common/ftp.cpp:400
+msgid "binary"
+msgstr "이진"
+
+#: ../src/common/ftp.cpp:608
+msgid "The FTP server doesn't support the PORT command."
+msgstr "FTP 서버가 포트 명령을 지원하지 않습니다."
+
+#: ../src/common/ftp.cpp:622
+msgid "The FTP server doesn't support passive mode."
+msgstr "FTP 서버가 패시브 모드를 지원하지 않습니다."
+
+#: ../src/common/gifdecod.cpp:822
+#, c-format
+msgid "Incorrect GIF frame size (%u, %d) for the frame #%u"
+msgstr ""
+
+#: ../src/common/glcmn.cpp:108
+msgid "Failed to allocate colour for OpenGL"
+msgstr "OpenGL 색상 할당을 실패 했습니다."
+
+#: ../src/common/headerctrlcmn.cpp:57
+msgid "Please select the columns to show and define their order:"
+msgstr ""
+
+#: ../src/common/headerctrlcmn.cpp:58
+#, fuzzy
+msgid "Customize Columns"
+msgstr "사용자 지정 크기"
+
+#: ../src/common/headerctrlcmn.cpp:304
+#, fuzzy
+msgid "&Customize..."
+msgstr "사용자 지정 크기"
+
+#: ../src/common/hyperlnkcmn.cpp:132
+#, fuzzy, c-format
+msgid "Failed to open URL \"%s\" in the default browser"
+msgstr "기본 탐색창에서 URL \"%s\" 여는데 실패했습니다."
+
+#: ../src/common/iconbndl.cpp:195
+#, fuzzy, c-format
+msgid "Failed to load image %%d from file '%s'."
+msgstr "%d 이미지('%s' 파일에서)를 읽어올 수 없습니다."
+
+#: ../src/common/iconbndl.cpp:203
+#, fuzzy, c-format
+msgid "Failed to load image %d from stream."
+msgstr "%d 이미지('%s' 파일에서)를 읽어올 수 없습니다."
+
+#: ../src/common/iconbndl.cpp:221
+#, fuzzy, c-format
+msgid "Failed to load icons from resource '%s'."
+msgstr "%d 이미지('%s' 파일에서)를 읽어올 수 없습니다."
+
+#: ../src/common/imagbmp.cpp:97
+msgid "BMP: Couldn't save invalid image."
+msgstr "BMP: 잘못된 이미지입니다. 저장할수 없음"
+
+#: ../src/common/imagbmp.cpp:137
+msgid "BMP: wxImage doesn't have own wxPalette."
+msgstr "BMP: wxImage가 wxPalette를 가지고 있지 않습니다."
+
+#: ../src/common/imagbmp.cpp:243
+msgid "BMP: Couldn't write the file (Bitmap) header."
+msgstr "BMP: 비트맵 해더를 작성할수 없습니다."
+
+#: ../src/common/imagbmp.cpp:266
+msgid "BMP: Couldn't write the file (BitmapInfo) header."
+msgstr "BMP: 비트맵 해더정보를 작성할수 없습니다."
+
+#: ../src/common/imagbmp.cpp:353
+msgid "BMP: Couldn't write RGB color map."
+msgstr "BMP: RGB 색상표(color map)를 사용한 쓰기 실패"
+
+#: ../src/common/imagbmp.cpp:487
+msgid "BMP: Couldn't write data."
+msgstr "BMP: 데이타 쓰기 실패"
+
+#: ../src/common/imagbmp.cpp:561 ../src/common/imagbmp.cpp:642
+msgid "BMP: Couldn't allocate memory."
+msgstr "BMP: 메모리 할당 실패"
+
+#: ../src/common/imagbmp.cpp:1041
+msgid "DIB Header: Image width > 32767 pixels for file."
+msgstr "DIB 헤더: 이미지 너비가 32767 픽셀 보다 큽니다."
+
+#: ../src/common/imagbmp.cpp:1049
+msgid "DIB Header: Image height > 32767 pixels for file."
+msgstr "DIB 헤더: 이미지 높이가  32767 픽셀 보다 큽니다."
+
+#: ../src/common/imagbmp.cpp:1081
+msgid "DIB Header: Unknown bitdepth in file."
+msgstr "DIB 헤더: 알수 없는 해상도."
+
+#: ../src/common/imagbmp.cpp:1156
+msgid "DIB Header: Unknown encoding in file."
+msgstr "DIB 헤더 : 알수없는 인코딩."
+
+#: ../src/common/imagbmp.cpp:1165
+msgid "DIB Header: Encoding doesn't match bitdepth."
+msgstr "DIB 헤더: 인코딩이 해상도와 일치 하지 않습니다."
+
+#: ../src/common/imagbmp.cpp:1180
+#, c-format
+msgid "BMP Header: Invalid number of colors (%d)."
+msgstr ""
+
+#: ../src/common/imagbmp.cpp:1273
+msgid "Error in reading image DIB."
+msgstr "DIB 이미지 읽기 오류."
+
+#: ../src/common/imagbmp.cpp:1294
+msgid "ICO: Error in reading mask DIB."
+msgstr "ICO: DIB 마스크에서 읽기 오류가 발생했습니다."
+
+#: ../src/common/imagbmp.cpp:1353
+msgid "ICO: Image too tall for an icon."
+msgstr "ICO: 아이콘 이미지가 너무큼(길이)"
+
+#: ../src/common/imagbmp.cpp:1361
+msgid "ICO: Image too wide for an icon."
+msgstr "ICO: 아이콘 이미지가 너무큼(너비)"
+
+#: ../src/common/imagbmp.cpp:1388 ../src/common/imagbmp.cpp:1488
+#: ../src/common/imagbmp.cpp:1503 ../src/common/imagbmp.cpp:1514
+#: ../src/common/imagbmp.cpp:1528 ../src/common/imagbmp.cpp:1576
+#: ../src/common/imagbmp.cpp:1591 ../src/common/imagbmp.cpp:1605
+#: ../src/common/imagbmp.cpp:1616
+msgid "ICO: Error writing the image file!"
+msgstr "ICO: 이미지 파일 쓰기 오류!"
+
+#: ../src/common/imagbmp.cpp:1701
+msgid "ICO: Invalid icon index."
+msgstr "ICO: ICON 인덱스가 잘못되었습니다."
+
+#: ../src/common/image.cpp:2410
+msgid "Image and mask have different sizes."
+msgstr "마스크의 사이즈 정보와 실제 이미지 사이즈가 동일하지 않습니다."
+
+#: ../src/common/image.cpp:2418 ../src/common/image.cpp:2459
+msgid "No unused colour in image being masked."
+msgstr "이미지에서 사용되지 않는 색상을 감춥니다."
+
+#: ../src/common/image.cpp:2641
+#, fuzzy, c-format
+msgid "Failed to load bitmap \"%s\" from resources."
+msgstr "%d 이미지('%s' 파일에서)를 읽어올 수 없습니다."
+
+#: ../src/common/image.cpp:2650
+#, fuzzy, c-format
+msgid "Failed to load icon \"%s\" from resources."
+msgstr "%d 이미지('%s' 파일에서)를 읽어올 수 없습니다."
+
+#: ../src/common/image.cpp:2728 ../src/common/image.cpp:2747
+#, fuzzy, c-format
+msgid "Failed to load image from file \"%s\"."
+msgstr "%d 이미지('%s' 파일에서)를 읽어올 수 없습니다."
+
+#: ../src/common/image.cpp:2761
+#, c-format
+msgid "Can't save image to file '%s': unknown extension."
+msgstr "이미지를 파일 '%s'에 저장할수 없음: 이미지 핸들러를 찾을 수 없습니다."
+
+#: ../src/common/image.cpp:2869
+msgid "No handler found for image type."
+msgstr "이미지 핸들러가 없습니다."
+
+#: ../src/common/image.cpp:2877 ../src/common/image.cpp:3000
+#: ../src/common/image.cpp:3066
+#, c-format
+msgid "No image handler for type %d defined."
+msgstr "타입 %d 에대한 이미지 핸들러가 정의되지 않았습니다."
+
+#: ../src/common/image.cpp:2887
+#, fuzzy, c-format
+msgid "Image file is not of type %d."
+msgstr "%ld 타입은 이미지 파일이 아닙니다."
+
+#: ../src/common/image.cpp:2970
+msgid "Can't automatically determine the image format for non-seekable input."
+msgstr ""
+
+#: ../src/common/image.cpp:2988
+#, fuzzy
+msgid "Unknown image data format."
+msgstr "데이터에 잘못된 형식이 있습니다."
+
+#: ../src/common/image.cpp:3009
+#, fuzzy, c-format
+msgid "This is not a %s."
+msgstr "PCX: PCX 파일이 아닙니다."
+
+#: ../src/common/image.cpp:3032 ../src/common/image.cpp:3080
+#, c-format
+msgid "No image handler for type %s defined."
+msgstr "타입 %s 에대한 이미지 핸들러가 정의되지 않았습니다."
+
+#: ../src/common/image.cpp:3041
+#, fuzzy, c-format
+msgid "Image is not of type %s."
+msgstr "%s 타입은 이미지 파일이 아닙니다."
+
+#: ../src/common/image.cpp:3509
+#, fuzzy, c-format
+msgid "Failed to check format of image file \"%s\"."
+msgstr "\"%s\" 비트맵 이미지 파을을 저장하는데 실패했습니다."
+
+#: ../src/common/imaggif.cpp:124
+msgid "GIF: error in GIF image format."
+msgstr "GIF: 이미지 포맷 오류"
+
+#: ../src/common/imaggif.cpp:129
+msgid "GIF: not enough memory."
+msgstr "GIF: 메모리가 부족합니다"
+
+#: ../src/common/imaggif.cpp:134
+msgid "GIF: data stream seems to be truncated."
+msgstr "GIF: 스트림 데이타가 잘렸습니다."
+
+#: ../src/common/imaggif.cpp:240
+#, fuzzy
+msgid "Couldn't initialize GIF hash table."
+msgstr "zlib에서 사용할 압축용 버퍼 할당하지 못했습니다."
+
+#: ../src/common/imagiff.cpp:739
+msgid "IFF: error in IFF image format."
+msgstr "IFF: IFF 이미지 포맷 오류"
+
+#: ../src/common/imagiff.cpp:742
+msgid "IFF: not enough memory."
+msgstr "IFF: 메모리가 부족합니다"
+
+#: ../src/common/imagiff.cpp:745
+msgid "IFF: unknown error!!!"
+msgstr "IFF: 알 수 없는 오류가 발생!!!"
+
+#: ../src/common/imagiff.cpp:755
+msgid "IFF: data stream seems to be truncated."
+msgstr "IFF: 스트림 데이타가 잘렸습니다."
+
+#: ../src/common/imagjpeg.cpp:258
+msgid "JPEG: Couldn't load - file is probably corrupted."
+msgstr "JPEG: 파일을 읽을 수 없습니다. 파일이 손상된 것 같습니다."
+
+#: ../src/common/imagjpeg.cpp:437
+msgid "JPEG: Couldn't save image."
+msgstr "JPEG: 이미지를 저장할수 없습니다."
+
+#: ../src/common/imagpcx.cpp:439
+msgid "PCX: this is not a PCX file."
+msgstr "PCX: PCX 파일이 아닙니다."
+
+#: ../src/common/imagpcx.cpp:453
+msgid "PCX: image format unsupported"
+msgstr "PCX: 이미지 포맷을 지원하지 않습니다."
+
+#: ../src/common/imagpcx.cpp:454 ../src/common/imagpcx.cpp:477
+msgid "PCX: couldn't allocate memory"
+msgstr "PCX: 메모리가 부족합니다"
+
+#: ../src/common/imagpcx.cpp:455
+msgid "PCX: version number too low"
+msgstr "PCX: 버전이 너무 낮습니다."
+
+#: ../src/common/imagpcx.cpp:456 ../src/common/imagpcx.cpp:478
+msgid "PCX: unknown error !!!"
+msgstr "PCX: 알 수 없는 오류가 발생!!!"
+
+#: ../src/common/imagpcx.cpp:476
+msgid "PCX: invalid image"
+msgstr "PCX: 이미지가 잘못되었습니다."
+
+#: ../src/common/imagpng.cpp:385
+#, fuzzy, c-format
+msgid "Unknown PNG resolution unit %d"
+msgstr "알 수 없는 TIFF 해상도 단위(%d)임, 무시합니다."
+
+#: ../src/common/imagpng.cpp:439
+msgid "Couldn't load a PNG image - file is corrupted or not enough memory."
+msgstr "PNG 이미지를 가져오지 못했습니다 - 파일손상 또는 메모리 부족"
+
+#: ../src/common/imagpng.cpp:513 ../src/common/imagpng.cpp:524
+#: ../src/common/imagpng.cpp:534
+msgid "Couldn't save PNG image."
+msgstr "PNG 이미지를 저장할 수 없습니다."
+
+#: ../src/common/imagpnm.cpp:71
+msgid "PNM: File format is not recognized."
+msgstr "PNM: 파일 포맷을 인식할 수 없습니다."
+
+#: ../src/common/imagpnm.cpp:89
+msgid "PNM: Couldn't allocate memory."
+msgstr "PNM: 메모리가 부족합니다."
+
+#: ../src/common/imagpnm.cpp:111 ../src/common/imagpnm.cpp:134
+#: ../src/common/imagpnm.cpp:156
+msgid "PNM: File seems truncated."
+msgstr "PNM: 파일이 잘렸습니다."
+
+#: ../src/common/imagtiff.cpp:69
+#, fuzzy, c-format
+msgid " (in module \"%s\")"
+msgstr "tiff 모듈: %s"
+
+#: ../src/common/imagtiff.cpp:304
+msgid "TIFF: Error loading image."
+msgstr "TIFF: 이미지 읽어오기 오류."
+
+#: ../src/common/imagtiff.cpp:314
+msgid "Invalid TIFF image index."
+msgstr "TIFF 이미지가 잘못되었습니다."
+
+#: ../src/common/imagtiff.cpp:358
+msgid "TIFF: Image size is abnormally big."
+msgstr ""
+
+#: ../src/common/imagtiff.cpp:372 ../src/common/imagtiff.cpp:385
+#: ../src/common/imagtiff.cpp:769
+msgid "TIFF: Couldn't allocate memory."
+msgstr "TIFF: 메모리를 할당할 수 없습니다."
+
+#: ../src/common/imagtiff.cpp:471
+msgid "TIFF: Error reading image."
+msgstr "TIFF: 이미지 읽기 오류."
+
+#: ../src/common/imagtiff.cpp:532
+#, c-format
+msgid "Unknown TIFF resolution unit %d ignored"
+msgstr "알 수 없는 TIFF 해상도 단위(%d)임, 무시합니다."
+
+#: ../src/common/imagtiff.cpp:611
+msgid "TIFF: Error saving image."
+msgstr "TIFF: 이미지 저장 오류."
+
+#: ../src/common/imagtiff.cpp:868
+msgid "TIFF: Error writing image."
+msgstr "TIFF: 이미지 쓰기 오류"
+
+#: ../src/common/imagtiff.cpp:881
+#, fuzzy
+msgid "TIFF: Error flushing data."
+msgstr "TIFF: 이미지 저장 오류."
+
+#: ../src/common/imagwebp.cpp:56
+msgid "WebP: Invalid data (failed to get features)."
+msgstr ""
+
+#: ../src/common/imagwebp.cpp:65
+msgid "WebP: Allocating image memory failed."
+msgstr ""
+
+#: ../src/common/imagwebp.cpp:82
+msgid "WebP: Decoding RGBA image data failed."
+msgstr ""
+
+#: ../src/common/imagwebp.cpp:98
+msgid "WebP: Decoding RGB image data failed."
+msgstr ""
+
+#: ../src/common/imagwebp.cpp:113 ../src/common/imagwebp.cpp:201
+msgid "WebP: Allocating stream buffer failed."
+msgstr ""
+
+#: ../src/common/imagwebp.cpp:131
+#, fuzzy
+msgid "WebP: Failed to parse container data."
+msgstr "클립보드 데이타 설정을 실패했습니다."
+
+#: ../src/common/imagwebp.cpp:222
+#, fuzzy
+msgid "WebP: Error decoding animation."
+msgstr "설정 읽기 오류."
+
+#: ../src/common/imagwebp.cpp:240
+msgid "WebP: Error getting next animation frame."
+msgstr ""
+
+#: ../src/common/init.cpp:172
+#, c-format
+msgid ""
+"Command line argument %d couldn't be converted to Unicode and will be "
+"ignored."
+msgstr "명령행 인자 %d는 유니코드로 변경할수 없어 인자를 무시합니다."
+
+#: ../src/common/init.cpp:344
+msgid "Initialization failed in post init, aborting."
+msgstr "등록된 모듈들의 초기화를 실패했습니다."
+
+#: ../src/common/intl.cpp:378
+#, c-format
+msgid "Cannot set locale to language \"%s\"."
+msgstr "\"%s\" 에 대한 언어 로케일을 설정할 수 없습니다."
+
+#: ../src/common/log.cpp:232
+msgid "Error: "
+msgstr "오류:"
+
+#: ../src/common/log.cpp:236
+msgid "Warning: "
+msgstr "경고: "
+
+#: ../src/common/log.cpp:284
+#, fuzzy
+msgid "The previous message repeated once."
+msgstr "이전의 중요한 메세지를 보여줍니다"
+
+#: ../src/common/log.cpp:291
+#, fuzzy, c-format
+msgid "The previous message repeated %u time."
+msgid_plural "The previous message repeated %u times."
+msgstr[0] "이전의 중요한 메세지를 보여줍니다"
+msgstr[1] "이전의 중요한 메세지를 %lu번 보여줍니다"
+
+#: ../src/common/log.cpp:319
+#, c-format
+msgid "Last repeated message (\"%s\", %u time) wasn't output"
+msgid_plural "Last repeated message (\"%s\", %u times) wasn't output"
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../src/common/log.cpp:435
+#, c-format
+msgid " (error %ld: %s)"
+msgstr " (오류 %ld: %s)"
+
+#: ../src/common/lzmastream.cpp:121
+#, fuzzy
+msgid "Failed to allocate memory for LZMA decompression."
+msgstr "OpenGL 색상 할당을 실패 했습니다."
+
+#: ../src/common/lzmastream.cpp:125
+#, c-format
+msgid "Failed to initialize LZMA decompression: unexpected error %u."
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:179
+msgid "input is not in XZ format"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:183
+msgid "input compressed using unknown XZ option"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:188
+msgid "input is corrupted"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:192
+#, fuzzy
+msgid "unknown decompression error"
+msgstr "압축 풀기 오류"
+
+#: ../src/common/lzmastream.cpp:196
+#, fuzzy, c-format
+msgid "LZMA decompression error: %s"
+msgstr "압축 풀기 오류"
+
+#: ../src/common/lzmastream.cpp:231
+#, fuzzy
+msgid "Failed to allocate memory for LZMA compression."
+msgstr "OpenGL 색상 할당을 실패 했습니다."
+
+#: ../src/common/lzmastream.cpp:235
+#, c-format
+msgid "Failed to initialize LZMA compression: unexpected error %u."
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:267 ../src/common/lzmastream.cpp:342
+#: ../src/html/chm.cpp:336
+msgid "out of memory"
+msgstr "메모리 부족"
+
+#: ../src/common/lzmastream.cpp:276 ../src/common/lzmastream.cpp:346
+#, fuzzy
+msgid "unknown compression error"
+msgstr "압축 오류"
+
+#: ../src/common/lzmastream.cpp:280
+#, fuzzy, c-format
+msgid "LZMA compression error: %s"
+msgstr "압축 오류"
+
+#: ../src/common/lzmastream.cpp:350
+#, c-format
+msgid "LZMA compression error when flushing output: %s"
+msgstr ""
+
+#: ../src/common/mimecmn.cpp:167
+#, c-format
+msgid "Unmatched '{' in an entry for mime type %s."
+msgstr "'%s' MIME 타입에서 '{' 의 짝이 맞지 않습니다."
+
+#: ../src/common/module.cpp:76
+#, c-format
+msgid "Circular dependency involving module \"%s\" detected."
+msgstr "순환 종속성 모듈 \"%s\" 을 발견하였습니다."
+
+#: ../src/common/module.cpp:128
+#, c-format
+msgid "Dependency \"%s\" of module \"%s\" doesn't exist."
+msgstr "\"%s\" 에 종속적인 모듈 \"%s\" 이 존재하지 않습니다."
+
+#: ../src/common/module.cpp:137
+#, c-format
+msgid "Module \"%s\" initialization failed"
+msgstr "\"%s\" 모듈의 초기화 실패"
+
+#: ../src/common/msgout.cpp:96
+#, fuzzy
+msgid "Message"
+msgstr "알림 : %s"
+
+#: ../src/common/paper.cpp:70
+msgid "Letter, 8 1/2 x 11 in"
+msgstr "Letter, 8 1/2 x 11 in"
+
+#: ../src/common/paper.cpp:71
+msgid "Legal, 8 1/2 x 14 in"
+msgstr "Legal, 8 1/2 x 14 in"
+
+#: ../src/common/paper.cpp:72
+msgid "A4 sheet, 210 x 297 mm"
+msgstr "A4 용지, 210 x 297 mm"
+
+#: ../src/common/paper.cpp:73
+msgid "C sheet, 17 x 22 in"
+msgstr "C 용지, 17 x 22 in"
+
+#: ../src/common/paper.cpp:74
+msgid "D sheet, 22 x 34 in"
+msgstr "D 용지, 22 x 34 in"
+
+#: ../src/common/paper.cpp:75
+msgid "E sheet, 34 x 44 in"
+msgstr "E 용지, 34 x 44 in"
+
+#: ../src/common/paper.cpp:76
+msgid "Letter Small, 8 1/2 x 11 in"
+msgstr "Letter Small, 8 1/2 x 11 in"
+
+#: ../src/common/paper.cpp:77
+msgid "Tabloid, 11 x 17 in"
+msgstr "Tabloid, 11 x 17 in"
+
+#: ../src/common/paper.cpp:78
+msgid "Ledger, 17 x 11 in"
+msgstr "Ledger, 17 x 11 in"
+
+#: ../src/common/paper.cpp:79
+msgid "Statement, 5 1/2 x 8 1/2 in"
+msgstr "Statement, 5 1/2 x 8 1/2 in"
+
+#: ../src/common/paper.cpp:80
+msgid "Executive, 7 1/4 x 10 1/2 in"
+msgstr "Executive, 7 1/4 x 10 1/2 in"
+
+#: ../src/common/paper.cpp:81
+msgid "A3 sheet, 297 x 420 mm"
+msgstr "A3 용지, 297 x 420 mm"
+
+#: ../src/common/paper.cpp:82
+msgid "A4 small sheet, 210 x 297 mm"
+msgstr "A4 small sheet, 210 x 297 mm"
+
+#: ../src/common/paper.cpp:83
+msgid "A5 sheet, 148 x 210 mm"
+msgstr "A5 용지, 148 x 210 mm"
+
+#: ../src/common/paper.cpp:84
+msgid "B4 sheet, 250 x 354 mm"
+msgstr "B4 용지, 250 x 354 mm"
+
+#: ../src/common/paper.cpp:85
+msgid "B5 sheet, 182 x 257 millimeter"
+msgstr "B5 용지, 182 x 257 millimeter"
+
+#: ../src/common/paper.cpp:86
+msgid "Folio, 8 1/2 x 13 in"
+msgstr "Folio, 8 1/2 x 13 in"
+
+#: ../src/common/paper.cpp:87
+msgid "Quarto, 215 x 275 mm"
+msgstr "Quarto, 215 x 275 mm"
+
+#: ../src/common/paper.cpp:88
+msgid "10 x 14 in"
+msgstr "10 x 14 in"
+
+#: ../src/common/paper.cpp:89
+msgid "11 x 17 in"
+msgstr "11 x 17 in"
+
+#: ../src/common/paper.cpp:90
+msgid "Note, 8 1/2 x 11 in"
+msgstr "Note, 8 1/2 x 11 in"
+
+#: ../src/common/paper.cpp:91
+msgid "#9 Envelope, 3 7/8 x 8 7/8 in"
+msgstr "#9 봉투, 3 7/8 x 8 7/8 in"
+
+#: ../src/common/paper.cpp:92
+msgid "#10 Envelope, 4 1/8 x 9 1/2 in"
+msgstr "#10 봉투, 4 1/8 x 9 1/2 in"
+
+#: ../src/common/paper.cpp:93
+msgid "#11 Envelope, 4 1/2 x 10 3/8 in"
+msgstr "#11 봉투, 4 1/2 x 10 3/8 in"
+
+#: ../src/common/paper.cpp:94
+msgid "#12 Envelope, 4 3/4 x 11 in"
+msgstr "#12 봉투, 4 3/4 x 11 in"
+
+#: ../src/common/paper.cpp:95
+msgid "#14 Envelope, 5 x 11 1/2 in"
+msgstr "#14 봉투, 5 x 11 1/2 in"
+
+#: ../src/common/paper.cpp:96
+msgid "DL Envelope, 110 x 220 mm"
+msgstr "DL 봉투, 110 x 220 mm"
+
+#: ../src/common/paper.cpp:97
+msgid "C5 Envelope, 162 x 229 mm"
+msgstr "C5 봉투, 162 x 229 mm"
+
+#: ../src/common/paper.cpp:98
+msgid "C3 Envelope, 324 x 458 mm"
+msgstr "C3 봉투, 324 x 458 mm"
+
+#: ../src/common/paper.cpp:99
+msgid "C4 Envelope, 229 x 324 mm"
+msgstr "C4 봉투, 229 x 324 mm"
+
+#: ../src/common/paper.cpp:100
+msgid "C6 Envelope, 114 x 162 mm"
+msgstr "C6 봉투, 114 x 162 mm"
+
+#: ../src/common/paper.cpp:101
+msgid "C65 Envelope, 114 x 229 mm"
+msgstr "C65 봉투, 114 x 229 mm"
+
+#: ../src/common/paper.cpp:102
+msgid "B4 Envelope, 250 x 353 mm"
+msgstr "B4 봉투, 250 x 353 mm"
+
+#: ../src/common/paper.cpp:103
+msgid "B5 Envelope, 176 x 250 mm"
+msgstr "B5 봉투, 176 x 250 mm"
+
+#: ../src/common/paper.cpp:104
+msgid "B6 Envelope, 176 x 125 mm"
+msgstr "B6 봉투, 176 x 125 mm"
+
+#: ../src/common/paper.cpp:105
+msgid "Italy Envelope, 110 x 230 mm"
+msgstr "이탈리아 봉투, 110 x 230 mm"
+
+#: ../src/common/paper.cpp:106
+msgid "Monarch Envelope, 3 7/8 x 7 1/2 in"
+msgstr "Monarch 봉투, 3 7/8 x 7 1/2 in"
+
+#: ../src/common/paper.cpp:107
+msgid "6 3/4 Envelope, 3 5/8 x 6 1/2 in"
+msgstr "6 3/4 봉투, 3 5/8 x 6 1/2 in"
+
+#: ../src/common/paper.cpp:108
+msgid "US Std Fanfold, 14 7/8 x 11 in"
+msgstr "US Std Fanfold, 14 7/8 x 11 in"
+
+#: ../src/common/paper.cpp:109
+msgid "German Std Fanfold, 8 1/2 x 12 in"
+msgstr "German Std Fanfold, 8 1/2 x 12 in"
+
+#: ../src/common/paper.cpp:110
+msgid "German Legal Fanfold, 8 1/2 x 13 in"
+msgstr "German Legal Fanfold, 8 1/2 x 13 in"
+
+#: ../src/common/paper.cpp:112
+msgid "B4 (ISO) 250 x 353 mm"
+msgstr "B4 (ISO) 250 x 353 mm"
+
+#: ../src/common/paper.cpp:113
+msgid "Japanese Postcard 100 x 148 mm"
+msgstr "일본 옆서 100 x 148 mm"
+
+#: ../src/common/paper.cpp:114
+msgid "9 x 11 in"
+msgstr "9 x 11 in"
+
+#: ../src/common/paper.cpp:115
+msgid "10 x 11 in"
+msgstr "10 x 11 in"
+
+#: ../src/common/paper.cpp:116
+msgid "15 x 11 in"
+msgstr "15 x 11 in"
+
+#: ../src/common/paper.cpp:117
+msgid "Envelope Invite 220 x 220 mm"
+msgstr "봉투 Invite 220 x 220 mm"
+
+#: ../src/common/paper.cpp:118
+msgid "Letter Extra 9 1/2 x 12 in"
+msgstr "Letter Extra 9 1/2 x 12 in"
+
+#: ../src/common/paper.cpp:119
+msgid "Legal Extra 9 1/2 x 15 in"
+msgstr "Legal Extra 9 1/2 x 15 in"
+
+#: ../src/common/paper.cpp:120
+msgid "Tabloid Extra 11.69 x 18 in"
+msgstr "Tabloid Extra 11.69 x 18 in"
+
+#: ../src/common/paper.cpp:121
+msgid "A4 Extra 9.27 x 12.69 in"
+msgstr "A4 Extra 9.27 x 12.69 in"
+
+#: ../src/common/paper.cpp:122
+msgid "Letter Transverse 8 1/2 x 11 in"
+msgstr "Letter Transverse 8 1/2 x 11 in"
+
+#: ../src/common/paper.cpp:123
+msgid "A4 Transverse 210 x 297 mm"
+msgstr "A4 Transverse 210 x 297 mm"
+
+#: ../src/common/paper.cpp:124
+msgid "Letter Extra Transverse 9.275 x 12 in"
+msgstr "Letter Extra Transverse 9.275 x 12 in"
+
+#: ../src/common/paper.cpp:125
+msgid "SuperA/SuperA/A4 227 x 356 mm"
+msgstr "SuperA/SuperA/A4 227 x 356 mm"
+
+#: ../src/common/paper.cpp:126
+msgid "SuperB/SuperB/A3 305 x 487 mm"
+msgstr "SuperB/SuperB/A3 305 x 487 mm"
+
+#: ../src/common/paper.cpp:127
+msgid "Letter Plus 8 1/2 x 12.69 in"
+msgstr "Letter Plus 8 1/2 x 12.69 in"
+
+#: ../src/common/paper.cpp:128
+msgid "A4 Plus 210 x 330 mm"
+msgstr "A4 Plus 210 x 330 mm"
+
+#: ../src/common/paper.cpp:129
+msgid "A5 Transverse 148 x 210 mm"
+msgstr "A5 Transverse 148 x 210 mm"
+
+#: ../src/common/paper.cpp:130
+msgid "B5 (JIS) Transverse 182 x 257 mm"
+msgstr "B5 (JIS) Transverse 182 x 257 mm"
+
+#: ../src/common/paper.cpp:131
+msgid "A3 Extra 322 x 445 mm"
+msgstr "A3 Extra 322 x 445 mm"
+
+#: ../src/common/paper.cpp:132
+msgid "A5 Extra 174 x 235 mm"
+msgstr "A5 Extra 174 x 235 mm"
+
+#: ../src/common/paper.cpp:133
+msgid "B5 (ISO) Extra 201 x 276 mm"
+msgstr "B5 (ISO) Extra 201 x 276 mm"
+
+#: ../src/common/paper.cpp:134
+msgid "A2 420 x 594 mm"
+msgstr "A2 420 x 594 mm"
+
+#: ../src/common/paper.cpp:135
+msgid "A3 Transverse 297 x 420 mm"
+msgstr "A3 Transverse 297 x 420 mm"
+
+#: ../src/common/paper.cpp:136
+msgid "A3 Extra Transverse 322 x 445 mm"
+msgstr "A3 Extra Transverse 322 x 445 mm"
+
+#: ../src/common/paper.cpp:138
+msgid "Japanese Double Postcard 200 x 148 mm"
+msgstr "일본 Double 봉투 200 x 148 mm"
+
+#: ../src/common/paper.cpp:139
+msgid "A6 105 x 148 mm"
+msgstr "A6 105 x 148 mm"
+
+#: ../src/common/paper.cpp:140
+msgid "Japanese Envelope Kaku #2"
+msgstr "일본 봉투 Kaku #2"
+
+#: ../src/common/paper.cpp:141
+msgid "Japanese Envelope Kaku #3"
+msgstr "일본 봉투 Kaku #3"
+
+#: ../src/common/paper.cpp:142
+msgid "Japanese Envelope Chou #3"
+msgstr "일본 봉투 Chou #3"
+
+#: ../src/common/paper.cpp:143
+msgid "Japanese Envelope Chou #4"
+msgstr "일본 봉투 Chou #4"
+
+#: ../src/common/paper.cpp:144
+msgid "Letter Rotated 11 x 8 1/2 in"
+msgstr "Letter Rotated 11 x 8 1/2 in"
+
+#: ../src/common/paper.cpp:145
+msgid "A3 Rotated 420 x 297 mm"
+msgstr "A3 Rotated 420 x 297 mm"
+
+#: ../src/common/paper.cpp:146
+msgid "A4 Rotated 297 x 210 mm"
+msgstr "A4 Rotated 297 x 210 mm"
+
+#: ../src/common/paper.cpp:147
+msgid "A5 Rotated 210 x 148 mm"
+msgstr "A5 Rotated 210 x 148 mm"
+
+#: ../src/common/paper.cpp:148
+msgid "B4 (JIS) Rotated 364 x 257 mm"
+msgstr "B4 (JIS) Rotated 364 x 257 mm"
+
+#: ../src/common/paper.cpp:149
+msgid "B5 (JIS) Rotated 257 x 182 mm"
+msgstr "B5 (JIS) Rotated 257 x 182 mm"
+
+#: ../src/common/paper.cpp:150
+msgid "Japanese Postcard Rotated 148 x 100 mm"
+msgstr "일본 옆서 Rotated 148 x 100 mm"
+
+#: ../src/common/paper.cpp:151
+msgid "Double Japanese Postcard Rotated 148 x 200 mm"
+msgstr "Double 일본 옆서 Rotated 148 x 200 mm"
+
+#: ../src/common/paper.cpp:152
+msgid "A6 Rotated 148 x 105 mm"
+msgstr "A6 Rotated 148 x 105 mm"
+
+#: ../src/common/paper.cpp:153
+msgid "Japanese Envelope Kaku #2 Rotated"
+msgstr "일본 봉투 Kaku #2 Rotated"
+
+#: ../src/common/paper.cpp:154
+msgid "Japanese Envelope Kaku #3 Rotated"
+msgstr "일본 봉투 Kaku #3 Rotated"
+
+#: ../src/common/paper.cpp:155
+msgid "Japanese Envelope Chou #3 Rotated"
+msgstr "일본 봉투 Chou #3 Rotated"
+
+#: ../src/common/paper.cpp:156
+msgid "Japanese Envelope Chou #4 Rotated"
+msgstr "일본 봉투 Chou #4 Rotated"
+
+#: ../src/common/paper.cpp:157
+msgid "B6 (JIS) 128 x 182 mm"
+msgstr "B6 (JIS) 128 x 182 mm"
+
+#: ../src/common/paper.cpp:158
+msgid "B6 (JIS) Rotated 182 x 128 mm"
+msgstr "B6 (JIS) Rotated 182 x 128 mm"
+
+#: ../src/common/paper.cpp:159
+msgid "12 x 11 in"
+msgstr "12 x 11 in"
+
+#: ../src/common/paper.cpp:160
+msgid "Japanese Envelope You #4"
+msgstr "일본 봉투 You #4"
+
+#: ../src/common/paper.cpp:161
+msgid "Japanese Envelope You #4 Rotated"
+msgstr "일본 봉투 You #4 Rotated"
+
+#: ../src/common/paper.cpp:162
+msgid "PRC 16K 146 x 215 mm"
+msgstr "PRC 16K 146 x 215 mm"
+
+#: ../src/common/paper.cpp:163
+msgid "PRC 32K 97 x 151 mm"
+msgstr "PRC 32K 97 x 151 mm"
+
+#: ../src/common/paper.cpp:164
+msgid "PRC 32K(Big) 97 x 151 mm"
+msgstr "PRC 32K(Big) 97 x 151 mm"
+
+#: ../src/common/paper.cpp:165
+msgid "PRC Envelope #1 102 x 165 mm"
+msgstr "PRC 봉투 #1 102 x 165 mm"
+
+#: ../src/common/paper.cpp:166
+msgid "PRC Envelope #2 102 x 176 mm"
+msgstr "PRC 봉투 #2 102 x 176 mm"
+
+#: ../src/common/paper.cpp:167
+msgid "PRC Envelope #3 125 x 176 mm"
+msgstr "PRC 봉투 #3 125 x 176 mm"
+
+#: ../src/common/paper.cpp:168
+msgid "PRC Envelope #4 110 x 208 mm"
+msgstr "PRC 봉투 #4 110 x 208 mm"
+
+#: ../src/common/paper.cpp:169
+msgid "PRC Envelope #5 110 x 220 mm"
+msgstr "PRC 봉투 #5 110 x 220 mm"
+
+#: ../src/common/paper.cpp:170
+msgid "PRC Envelope #6 120 x 230 mm"
+msgstr "PRC 봉투 #6 120 x 230 mm"
+
+#: ../src/common/paper.cpp:171
+msgid "PRC Envelope #7 160 x 230 mm"
+msgstr "PRC 봉투 #7 160 x 230 mm"
+
+#: ../src/common/paper.cpp:172
+msgid "PRC Envelope #8 120 x 309 mm"
+msgstr "PRC 봉투 #8 120 x 309 mm"
+
+#: ../src/common/paper.cpp:173
+msgid "PRC Envelope #9 229 x 324 mm"
+msgstr "PRC 봉투 #9 229 x 324 mm"
+
+#: ../src/common/paper.cpp:174
+msgid "PRC Envelope #10 324 x 458 mm"
+msgstr "PRC 봉투 #10 324 x 458 mm"
+
+#: ../src/common/paper.cpp:175
+msgid "PRC 16K Rotated"
+msgstr "PRC 16K Rotated"
+
+#: ../src/common/paper.cpp:176
+msgid "PRC 32K Rotated"
+msgstr "PRC 32K Rotated"
+
+#: ../src/common/paper.cpp:177
+msgid "PRC 32K(Big) Rotated"
+msgstr "PRC 32K(Big) Rotated"
+
+#: ../src/common/paper.cpp:178
+msgid "PRC Envelope #1 Rotated 165 x 102 mm"
+msgstr "PRC 봉투 #1 Rotated 165 x 102 mm"
+
+#: ../src/common/paper.cpp:179
+msgid "PRC Envelope #2 Rotated 176 x 102 mm"
+msgstr "PRC 봉투 #2 Rotated 176 x 102 mm"
+
+#: ../src/common/paper.cpp:180
+msgid "PRC Envelope #3 Rotated 176 x 125 mm"
+msgstr "PRC 봉투 #3 Rotated 176 x 125 mm"
+
+#: ../src/common/paper.cpp:181
+msgid "PRC Envelope #4 Rotated 208 x 110 mm"
+msgstr "PRC 봉투 #4 Rotated 208 x 110 mm"
+
+#: ../src/common/paper.cpp:182
+msgid "PRC Envelope #5 Rotated 220 x 110 mm"
+msgstr "PRC 봉투 #5 Rotated 220 x 110 mm"
+
+#: ../src/common/paper.cpp:183
+msgid "PRC Envelope #6 Rotated 230 x 120 mm"
+msgstr "PRC 봉투 #6 Rotated 230 x 120 mm"
+
+#: ../src/common/paper.cpp:184
+msgid "PRC Envelope #7 Rotated 230 x 160 mm"
+msgstr "PRC 봉투 #7 Rotated 230 x 160 mm"
+
+#: ../src/common/paper.cpp:185
+msgid "PRC Envelope #8 Rotated 309 x 120 mm"
+msgstr "PRC 봉투 #8 Rotated 309 x 120 mm"
+
+#: ../src/common/paper.cpp:186
+msgid "PRC Envelope #9 Rotated 324 x 229 mm"
+msgstr "PRC 봉투 #9 Rotated 324 x 229 mm"
+
+#: ../src/common/paper.cpp:187
+msgid "PRC Envelope #10 Rotated 458 x 324 mm"
+msgstr "PRC 봉투 #10 Rotated 458 x 324 mm"
+
+#: ../src/common/paper.cpp:192
+#, fuzzy
+msgid "A0 sheet, 841 x 1189 mm"
+msgstr "A4 용지, 210 x 297 mm"
+
+#: ../src/common/paper.cpp:193
+#, fuzzy
+msgid "A1 sheet, 594 x 841 mm"
+msgstr "A3 용지, 297 x 420 mm"
+
+#: ../src/common/preferencescmn.cpp:37
+msgid "General"
+msgstr ""
+
+#: ../src/common/preferencescmn.cpp:40
+msgid "Advanced"
+msgstr ""
+
+#: ../src/common/prntbase.cpp:245
+msgid "Generic PostScript"
+msgstr "일반 PostScript"
+
+#: ../src/common/prntbase.cpp:259
+msgid "Ready"
+msgstr "준비"
+
+#: ../src/common/prntbase.cpp:331
+msgid "Printing Error"
+msgstr "인쇄 오류"
+
+#: ../src/common/prntbase.cpp:413 ../src/common/prntbase.cpp:1597
+#: ../src/generic/prntdlgg.cpp:135 ../src/generic/prntdlgg.cpp:149
+#: ../src/gtk/print.cpp:628 ../src/gtk/print.cpp:646
+msgid "Print"
+msgstr "인쇄"
+
+#: ../src/common/prntbase.cpp:471 ../src/generic/prntdlgg.cpp:809
+msgid "Page setup"
+msgstr "페이지 설정"
+
+#: ../src/common/prntbase.cpp:525
+#, fuzzy
+msgid "Please wait while printing..."
+msgstr "인쇄중 입니다.\n"
+
+#: ../src/common/prntbase.cpp:529
+#, fuzzy
+msgid "Document:"
+msgstr "문서화"
+
+#: ../src/common/prntbase.cpp:532
+msgid "Progress:"
+msgstr ""
+
+#: ../src/common/prntbase.cpp:533
+msgid "Preparing"
+msgstr ""
+
+#: ../src/common/prntbase.cpp:552
+#, fuzzy, c-format
+msgid "Printing page %d"
+msgstr "%d쪽 인쇄 중..."
+
+#: ../src/common/prntbase.cpp:557
+#, fuzzy, c-format
+msgid "Printing page %d of %d"
+msgstr "%d쪽 인쇄 중..."
+
+#: ../src/common/prntbase.cpp:560
+#, fuzzy, c-format
+msgid " (copy %d of %d)"
+msgstr "페이지 %d/%d"
+
+#: ../src/common/prntbase.cpp:1604
+#, fuzzy
+msgid "First page"
+msgstr "다음 페이지"
+
+#: ../src/common/prntbase.cpp:1609 ../src/html/helpwnd.cpp:659
+msgid "Previous page"
+msgstr "이전 페이지"
+
+#: ../src/common/prntbase.cpp:1623 ../src/html/helpwnd.cpp:660
+msgid "Next page"
+msgstr "다음 페이지"
+
+#: ../src/common/prntbase.cpp:1628
+#, fuzzy
+msgid "Last page"
+msgstr "다음 페이지"
+
+#: ../src/common/prntbase.cpp:1636 ../src/common/stockitem.cpp:215
+#, fuzzy
+msgid "Zoom Out"
+msgstr "축소(&O)"
+
+#: ../src/common/prntbase.cpp:1650 ../src/common/stockitem.cpp:214
+#, fuzzy
+msgid "Zoom In"
+msgstr "확대(&I)"
+
+#: ../src/common/prntbase.cpp:1656 ../src/common/stockitem.cpp:153
+#: ../src/generic/logg.cpp:553 ../src/univ/themes/win32.cpp:3752
+msgid "&Close"
+msgstr "닫기(&C)"
+
+#: ../src/common/prntbase.cpp:2085
+msgid "Could not start document preview."
+msgstr "문서 미리보기를 시작할 수 없습니다."
+
+#: ../src/common/prntbase.cpp:2085 ../src/common/prntbase.cpp:2129
+#: ../src/common/prntbase.cpp:2137
+msgid "Print Preview Failure"
+msgstr "인쇄 미리보기 실패"
+
+#: ../src/common/prntbase.cpp:2129 ../src/common/prntbase.cpp:2137
+msgid "Sorry, not enough memory to create a preview."
+msgstr "메모리가 부족하여 미리보기를 할 수 없습니다."
+
+#: ../src/common/prntbase.cpp:2144
+#, c-format
+msgid "Page %d of %d"
+msgstr "페이지 %d/%d"
+
+#: ../src/common/prntbase.cpp:2146
+#, c-format
+msgid "Page %d"
+msgstr "페이지 %d"
+
+#: ../src/common/regex.cpp:382 ../src/html/chm.cpp:348
+msgid "unknown error"
+msgstr "알 수 없는 오류"
+
+#: ../src/common/regex.cpp:995
+#, c-format
+msgid "Invalid regular expression '%s': %s"
+msgstr "올바르지 않은 정규식 '%s': %s"
+
+#: ../src/common/regex.cpp:1059
+#, c-format
+msgid "Failed to find match for regular expression: %s"
+msgstr "정규 표현식 %s 에 대한 검색 실패"
+
+#: ../src/common/rendcmn.cpp:188
+#, c-format
+msgid "Renderer \"%s\" has incompatible version %d.%d and couldn't be loaded."
+msgstr "Renderer \"%s\" 버전 %d.%d  는 호환되지 않습니다."
+
+#: ../src/common/secretstore.cpp:162
+msgid "Not available for this platform"
+msgstr ""
+
+#: ../src/common/secretstore.cpp:183
+#, fuzzy, c-format
+msgid "Saving password for \"%s\" failed: %s."
+msgstr "'%s' 의 추출('%s' 에서) 실패 했습니다."
+
+#: ../src/common/secretstore.cpp:205
+#, fuzzy, c-format
+msgid "Reading password for \"%s\" failed: %s."
+msgstr "'%s' 의 추출('%s' 에서) 실패 했습니다."
+
+#: ../src/common/secretstore.cpp:228
+#, fuzzy, c-format
+msgid "Deleting password for \"%s\" failed: %s."
+msgstr "'%s' 의 추출('%s' 에서) 실패 했습니다."
+
+#: ../src/common/selectdispatcher.cpp:254
+msgid "Failed to monitor I/O channels"
+msgstr "모니터의 I/O 채널 선택 실패"
+
+#: ../src/common/sizer.cpp:3054 ../src/common/stockitem.cpp:195
+msgid "Save"
+msgstr "저장"
+
+#: ../src/common/sizer.cpp:3056
+msgid "Don't Save"
+msgstr "저장 하지 않음"
+
+#: ../src/common/socket.cpp:870
+#, fuzzy
+msgid "Cannot initialize sockets"
+msgstr "OLE를 초기화할 수 없습니다"
+
+#: ../src/common/stockitem.cpp:127
+#, fuzzy
+msgctxt "standard Windows menu"
+msgid "&Help"
+msgstr "도움말(&H)"
+
+#: ../src/common/stockitem.cpp:144
+msgid "&About"
+msgstr "이 프로그램은(&A)"
+
+#: ../src/common/stockitem.cpp:144
+#, fuzzy
+msgid "About"
+msgstr "이 프로그램은(&A)"
+
+#: ../src/common/stockitem.cpp:145
+msgid "Add"
+msgstr "추가"
+
+#: ../src/common/stockitem.cpp:146
+msgid "&Apply"
+msgstr "적용(&A)"
+
+#: ../src/common/stockitem.cpp:146
+#, fuzzy
+msgid "Apply"
+msgstr "적용(&A)"
+
+#: ../src/common/stockitem.cpp:147
+msgid "&Back"
+msgstr "뒤로(&B)"
+
+#: ../src/common/stockitem.cpp:147
+#, fuzzy
+msgid "Back"
+msgstr "뒤로(&B)"
+
+#: ../src/common/stockitem.cpp:148
+msgid "&Bold"
+msgstr "굵게(&B)"
+
+#: ../src/common/stockitem.cpp:148 ../src/generic/fontdlgg.cpp:326
+#: ../src/richtext/richtextfontpage.cpp:354
+msgid "Bold"
+msgstr "굵게"
+
+#: ../src/common/stockitem.cpp:149
+msgid "&Bottom"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:149 ../src/richtext/richtextsizepage.cpp:287
+msgid "Bottom"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:150 ../src/generic/fontdlgg.cpp:462
+#: ../src/generic/fontdlgg.cpp:481 ../src/generic/wizard.cpp:415
+msgid "&Cancel"
+msgstr "취소(&C)"
+
+#: ../src/common/stockitem.cpp:151
+msgid "&CD-ROM"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:151
+msgid "CD-ROM"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:152
+msgid "&Clear"
+msgstr "비우기(&C)"
+
+#: ../src/common/stockitem.cpp:152
+#, fuzzy
+msgid "Clear"
+msgstr "비우기(&C)"
+
+#: ../src/common/stockitem.cpp:153 ../src/generic/dbgrptg.cpp:93
+#: ../src/generic/progdlgg.cpp:778 ../src/html/helpdlg.cpp:86
+#: ../src/msw/progdlg.cpp:209 ../src/msw/progdlg.cpp:890
+#: ../src/richtext/richtextstyledlg.cpp:272
+#: ../src/richtext/richtextsymboldlg.cpp:448
+msgid "Close"
+msgstr "닫기"
+
+#: ../src/common/stockitem.cpp:154
+#, fuzzy
+msgid "&Convert"
+msgstr "목차"
+
+#: ../src/common/stockitem.cpp:154
+#, fuzzy
+msgid "Convert"
+msgstr "목차"
+
+#: ../src/common/stockitem.cpp:155 ../src/msw/textctrl.cpp:2884
+#: ../src/osx/textctrl_osx.cpp:653 ../src/richtext/richtextctrl.cpp:331
+msgid "&Copy"
+msgstr "복사(&D)"
+
+#: ../src/common/stockitem.cpp:155 ../src/stc/stc_i18n.cpp:18
+msgid "Copy"
+msgstr "복사"
+
+#: ../src/common/stockitem.cpp:156 ../src/msw/textctrl.cpp:2883
+#: ../src/osx/textctrl_osx.cpp:652 ../src/richtext/richtextctrl.cpp:330
+msgid "Cu&t"
+msgstr "잘라내기(&T)"
+
+#: ../src/common/stockitem.cpp:156 ../src/stc/stc_i18n.cpp:17
+msgid "Cut"
+msgstr "잘라내기"
+
+#: ../src/common/stockitem.cpp:157 ../src/msw/textctrl.cpp:2886
+#: ../src/osx/textctrl_osx.cpp:655 ../src/richtext/richtextctrl.cpp:333
+#: ../src/richtext/richtexttabspage.cpp:137
+msgid "&Delete"
+msgstr "지우기(&D)"
+
+#: ../src/common/stockitem.cpp:157 ../src/richtext/richtextbuffer.cpp:8266
+#: ../src/stc/stc_i18n.cpp:20
+msgid "Delete"
+msgstr "지우기"
+
+#: ../src/common/stockitem.cpp:158
+msgid "&Down"
+msgstr "아래로(&D)"
+
+#: ../src/common/stockitem.cpp:158 ../src/generic/fdrepdlg.cpp:148
+msgid "Down"
+msgstr "아래로"
+
+#: ../src/common/stockitem.cpp:159
+msgid "&Edit"
+msgstr "편집(&E)"
+
+#: ../src/common/stockitem.cpp:159
+#, fuzzy
+msgid "Edit"
+msgstr "편집(&E)"
+
+#: ../src/common/stockitem.cpp:160
+msgid "&Execute"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:160
+msgid "Execute"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:161
+msgid "&Quit"
+msgstr "종료(&Q)"
+
+#: ../src/common/stockitem.cpp:161
+#, fuzzy
+msgid "Quit"
+msgstr "종료(&Q)"
+
+#: ../src/common/stockitem.cpp:162
+msgid "&File"
+msgstr "파일(&F)"
+
+#: ../src/common/stockitem.cpp:162
+msgid "File"
+msgstr "파일"
+
+#: ../src/common/stockitem.cpp:163
+#, fuzzy
+msgid "&Find..."
+msgstr "찾기(&F)"
+
+#: ../src/common/stockitem.cpp:163
+#, fuzzy
+msgid "Find..."
+msgstr "찾기"
+
+#: ../src/common/stockitem.cpp:164
+#, fuzzy
+msgid "&First"
+msgstr "첫 번째"
+
+#: ../src/common/stockitem.cpp:164
+#, fuzzy
+msgid "First"
+msgstr "첫 번째"
+
+#: ../src/common/stockitem.cpp:165
+#, fuzzy
+msgid "&Floppy"
+msgstr "복사(&D)"
+
+#: ../src/common/stockitem.cpp:165
+#, fuzzy
+msgid "Floppy"
+msgstr "복사"
+
+#: ../src/common/stockitem.cpp:166
+msgid "&Forward"
+msgstr "앞으로(&F)"
+
+#: ../src/common/stockitem.cpp:166
+#, fuzzy
+msgid "Forward"
+msgstr "앞으로(&F)"
+
+#: ../src/common/stockitem.cpp:167
+msgid "&Harddisk"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:167
+msgid "Harddisk"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:168 ../src/generic/wizard.cpp:418
+#: ../src/osx/cocoa/menu.mm:225 ../src/richtext/richtextstyledlg.cpp:298
+#: ../src/richtext/richtextsymboldlg.cpp:451
+msgid "&Help"
+msgstr "도움말(&H)"
+
+#: ../src/common/stockitem.cpp:169
+msgid "&Home"
+msgstr "홈(&H)"
+
+#: ../src/common/stockitem.cpp:169
+msgid "Home"
+msgstr "홈"
+
+#: ../src/common/stockitem.cpp:170
+msgid "Indent"
+msgstr "들여쓰기"
+
+#: ../src/common/stockitem.cpp:171
+msgid "&Index"
+msgstr "색인(&I)"
+
+#: ../src/common/stockitem.cpp:171 ../src/html/helpwnd.cpp:510
+msgid "Index"
+msgstr "차례"
+
+#: ../src/common/stockitem.cpp:172
+#, fuzzy
+msgid "&Info"
+msgstr "실행취소(&U)"
+
+#: ../src/common/stockitem.cpp:172
+msgid "Info"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:173
+msgid "&Italic"
+msgstr "기울임(&I)"
+
+#: ../src/common/stockitem.cpp:173 ../src/generic/fontdlgg.cpp:322
+#: ../src/richtext/richtextfontpage.cpp:350
+msgid "Italic"
+msgstr "기울임"
+
+#: ../src/common/stockitem.cpp:174
+msgid "&Jump to"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:174
+msgid "Jump to"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:175
+msgid "Centered"
+msgstr "중앙"
+
+#: ../src/common/stockitem.cpp:176
+msgid "Justified"
+msgstr "정렬"
+
+#: ../src/common/stockitem.cpp:177
+msgid "Align Left"
+msgstr "왼쪽 정렬"
+
+#: ../src/common/stockitem.cpp:178
+msgid "Align Right"
+msgstr "오른쪽 정렬"
+
+#: ../src/common/stockitem.cpp:179
+#, fuzzy
+msgid "&Last"
+msgstr "붙여넣기(&P)"
+
+#: ../src/common/stockitem.cpp:179
+#, fuzzy
+msgid "Last"
+msgstr "붙여 넣기"
+
+#: ../src/common/stockitem.cpp:180
+#, fuzzy
+msgid "&Network"
+msgstr "새로 만들기(&N)"
+
+#: ../src/common/stockitem.cpp:180
+msgid "Network"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:181 ../src/richtext/richtexttabspage.cpp:131
+msgid "&New"
+msgstr "새로 만들기(&N)"
+
+#: ../src/common/stockitem.cpp:181
+#, fuzzy
+msgid "New"
+msgstr "새로 만들기(&N)"
+
+#: ../src/common/stockitem.cpp:182 ../src/msw/msgdlg.cpp:417
+msgid "&No"
+msgstr "아니오(&N)"
+
+#: ../src/common/stockitem.cpp:183 ../src/generic/fontdlgg.cpp:467
+#: ../src/generic/fontdlgg.cpp:474
+msgid "&OK"
+msgstr "확인(&O)"
+
+#: ../src/common/stockitem.cpp:184 ../src/generic/dbgrptg.cpp:341
+msgid "&Open..."
+msgstr "열기...(&O)"
+
+#: ../src/common/stockitem.cpp:184
+#, fuzzy
+msgid "Open..."
+msgstr "열기...(&O)"
+
+#: ../src/common/stockitem.cpp:185 ../src/msw/textctrl.cpp:2885
+#: ../src/osx/textctrl_osx.cpp:654 ../src/richtext/richtextctrl.cpp:332
+msgid "&Paste"
+msgstr "붙여넣기(&P)"
+
+#: ../src/common/stockitem.cpp:185 ../src/richtext/richtextctrl.cpp:3484
+#: ../src/stc/stc_i18n.cpp:19
+msgid "Paste"
+msgstr "붙여 넣기"
+
+#: ../src/common/stockitem.cpp:186
+msgid "&Preferences"
+msgstr "설정(&P)"
+
+#: ../src/common/stockitem.cpp:186 ../src/osx/cocoa/preferences.mm:304
+#, fuzzy
+msgid "Preferences"
+msgstr "설정(&P)"
+
+#: ../src/common/stockitem.cpp:187
+#, fuzzy
+msgid "Print previe&w..."
+msgstr "인쇄 미리 보기(&W)"
+
+#: ../src/common/stockitem.cpp:187
+#, fuzzy
+msgid "Print preview..."
+msgstr "인쇄 미리 보기"
+
+#: ../src/common/stockitem.cpp:188
+msgid "&Print..."
+msgstr "인쇄...(&P)"
+
+#: ../src/common/stockitem.cpp:188
+#, fuzzy
+msgid "Print..."
+msgstr "인쇄...(&P)"
+
+#: ../src/common/stockitem.cpp:189 ../src/richtext/richtextctrl.cpp:337
+#: ../src/richtext/richtextctrl.cpp:5479
+msgid "&Properties"
+msgstr "특성(&P)"
+
+#: ../src/common/stockitem.cpp:189
+#, fuzzy
+msgid "Properties"
+msgstr "특성(&P)"
+
+#: ../src/common/stockitem.cpp:190 ../src/stc/stc_i18n.cpp:16
+msgid "Redo"
+msgstr "다시 실행"
+
+#: ../src/common/stockitem.cpp:191
+msgid "Refresh"
+msgstr "새로고침"
+
+#: ../src/common/stockitem.cpp:192
+msgid "Remove"
+msgstr "지우기"
+
+#: ../src/common/stockitem.cpp:193
+#, fuzzy
+msgid "Rep&lace..."
+msgstr "바꾸기(&L)"
+
+#: ../src/common/stockitem.cpp:193
+#, fuzzy
+msgid "Replace..."
+msgstr "바꾸기"
+
+#: ../src/common/stockitem.cpp:194
+msgid "Revert to Saved"
+msgstr "저장된 상태로 되돌리기"
+
+#: ../src/common/stockitem.cpp:196 ../src/generic/logg.cpp:549
+msgid "Save &As..."
+msgstr "다른 이름으로 저장(&A)"
+
+#: ../src/common/stockitem.cpp:196
+#, fuzzy
+msgid "Save As..."
+msgstr "다른 이름으로 저장(&A)"
+
+#: ../src/common/stockitem.cpp:197 ../src/msw/textctrl.cpp:2888
+#: ../src/osx/textctrl_osx.cpp:657 ../src/richtext/richtextctrl.cpp:335
+msgid "Select &All"
+msgstr "모두 선택(&A)"
+
+#: ../src/common/stockitem.cpp:197 ../src/stc/stc_i18n.cpp:21
+msgid "Select All"
+msgstr "모두 선택"
+
+#: ../src/common/stockitem.cpp:198
+#, fuzzy
+msgid "&Color"
+msgstr "색상(&D):"
+
+#: ../src/common/stockitem.cpp:198
+#, fuzzy
+msgid "Color"
+msgstr "색상"
+
+#: ../src/common/stockitem.cpp:199
+#, fuzzy
+msgid "&Font"
+msgstr "글꼴(&F):"
+
+#: ../src/common/stockitem.cpp:199 ../src/richtext/richtextformatdlg.cpp:336
+msgid "Font"
+msgstr "Font"
+
+#: ../src/common/stockitem.cpp:200
+msgid "&Ascending"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:200
+#, fuzzy
+msgid "Ascending"
+msgstr "인코딩 %i"
+
+#: ../src/common/stockitem.cpp:201
+msgid "&Descending"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:201
+#, fuzzy
+msgid "Descending"
+msgstr "기본 인코딩"
+
+#: ../src/common/stockitem.cpp:202
+msgid "&Spell Check"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:202
+msgid "Spell Check"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:203
+msgid "&Stop"
+msgstr "중지(&S)"
+
+#: ../src/common/stockitem.cpp:203
+#, fuzzy
+msgid "Stop"
+msgstr "중지(&S)"
+
+#: ../src/common/stockitem.cpp:204 ../src/richtext/richtextfontpage.cpp:274
+msgid "&Strikethrough"
+msgstr "취소선(&S)"
+
+#: ../src/common/stockitem.cpp:204
+#, fuzzy
+msgid "Strikethrough"
+msgstr "취소선(&S)"
+
+#: ../src/common/stockitem.cpp:205
+#, fuzzy
+msgid "&Top"
+msgstr "복사(&D)"
+
+#: ../src/common/stockitem.cpp:205 ../src/richtext/richtextsizepage.cpp:285
+#: ../src/richtext/richtextsizepage.cpp:289
+#, fuzzy
+msgid "Top"
+msgstr "수신:"
+
+#: ../src/common/stockitem.cpp:206
+msgid "Undelete"
+msgstr "되살리기"
+
+#: ../src/common/stockitem.cpp:207 ../src/generic/fontdlgg.cpp:437
+msgid "&Underline"
+msgstr "밑줄(&U)"
+
+#: ../src/common/stockitem.cpp:207
+#, fuzzy
+msgid "Underline"
+msgstr "밑줄(&U)"
+
+#: ../src/common/stockitem.cpp:208 ../src/stc/stc_i18n.cpp:15
+msgid "Undo"
+msgstr "실행 취소"
+
+#: ../src/common/stockitem.cpp:209
+msgid "&Unindent"
+msgstr "내어쓰기"
+
+#: ../src/common/stockitem.cpp:209
+#, fuzzy
+msgid "Unindent"
+msgstr "내어쓰기"
+
+#: ../src/common/stockitem.cpp:210
+msgid "&Up"
+msgstr "위로(&U)"
+
+#: ../src/common/stockitem.cpp:210 ../src/generic/fdrepdlg.cpp:148
+msgid "Up"
+msgstr "위로"
+
+#: ../src/common/stockitem.cpp:211 ../src/msw/msgdlg.cpp:417
+msgid "&Yes"
+msgstr "예(&Y)"
+
+#: ../src/common/stockitem.cpp:212
+msgid "&Actual Size"
+msgstr "실제 크기(&A)"
+
+#: ../src/common/stockitem.cpp:212
+#, fuzzy
+msgid "Actual Size"
+msgstr "실제 크기(&A)"
+
+#: ../src/common/stockitem.cpp:213
+msgid "Zoom to &Fit"
+msgstr "화면에 맞추기"
+
+#: ../src/common/stockitem.cpp:213
+#, fuzzy
+msgid "Zoom to Fit"
+msgstr "화면에 맞추기"
+
+#: ../src/common/stockitem.cpp:214
+msgid "Zoom &In"
+msgstr "확대(&I)"
+
+#: ../src/common/stockitem.cpp:215
+msgid "Zoom &Out"
+msgstr "축소(&O)"
+
+#: ../src/common/stockitem.cpp:262
+msgid "Show about dialog"
+msgstr "정보 대화상자 표시"
+
+#: ../src/common/stockitem.cpp:263
+msgid "Copy selection"
+msgstr "선택한 부분 복사"
+
+#: ../src/common/stockitem.cpp:264
+msgid "Cut selection"
+msgstr "선택한 부분 잘라내기"
+
+#: ../src/common/stockitem.cpp:265
+msgid "Delete selection"
+msgstr "선택한 부분 지우기"
+
+#: ../src/common/stockitem.cpp:266
+#, fuzzy
+msgid "Find in document"
+msgstr "HTML 문서를 엽니다"
+
+#: ../src/common/stockitem.cpp:267
+msgid "Find and replace in document"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:268
+msgid "Paste selection"
+msgstr "선택한 부분을 붙여 넣기"
+
+#: ../src/common/stockitem.cpp:269
+msgid "Quit this program"
+msgstr "이 프로그램을 닫습니다"
+
+#: ../src/common/stockitem.cpp:270
+msgid "Redo last action"
+msgstr "마지막 동작을 다시 실행합니다"
+
+#: ../src/common/stockitem.cpp:271
+msgid "Undo last action"
+msgstr "마지막 동작을 취소합니다"
+
+#: ../src/common/stockitem.cpp:272
+#, fuzzy
+msgid "Create new document"
+msgstr "새 디렉토리를 생성"
+
+#: ../src/common/stockitem.cpp:273
+#, fuzzy
+msgid "Open an existing document"
+msgstr "HTML 문서를 엽니다"
+
+#: ../src/common/stockitem.cpp:274
+msgid "Close current document"
+msgstr "현재 문서를 닫습니다."
+
+#: ../src/common/stockitem.cpp:275
+msgid "Save current document"
+msgstr "현재 문서를 저장합니다."
+
+#: ../src/common/stockitem.cpp:276
+msgid "Save current document with a different filename"
+msgstr "현재 문서를 다른 파일 이름으로 저장합니다."
+
+#: ../src/common/strconv.cpp:2324
+#, c-format
+msgid "Conversion to charset '%s' doesn't work."
+msgstr "문자 인코딩 '%s' 으로의 변환이 실패했습니다."
+
+#: ../src/common/tarstrm.cpp:352 ../src/common/tarstrm.cpp:375
+#: ../src/common/tarstrm.cpp:406 ../src/generic/progdlgg.cpp:373
+msgid "unknown"
+msgstr "알 수 없음"
+
+#: ../src/common/tarstrm.cpp:774
+msgid "incomplete header block in tar"
+msgstr "tar 헤더가 잘못되었습니다."
+
+#: ../src/common/tarstrm.cpp:798
+msgid "checksum failure reading tar header block"
+msgstr "tar의 Checksum 실패"
+
+#: ../src/common/tarstrm.cpp:971
+msgid "invalid data in extended tar header"
+msgstr "tar 확장 헤더가 잘못되었습니다."
+
+#: ../src/common/tarstrm.cpp:981 ../src/common/tarstrm.cpp:1003
+#: ../src/common/tarstrm.cpp:1477 ../src/common/tarstrm.cpp:1499
+msgid "tar entry not open"
+msgstr "tar 파일 열기 실패"
+
+#: ../src/common/tarstrm.cpp:1023
+msgid "unexpected end of file"
+msgstr "파일이 갑작스럽게 끝났습니다"
+
+#: ../src/common/tarstrm.cpp:1297
+#, c-format
+msgid "%s did not fit the tar header for entry '%s'"
+msgstr "%s 발생 '%s' 파일의 tar 헤더 정보가 손상되었습니다"
+
+#: ../src/common/tarstrm.cpp:1359
+msgid "incorrect size given for tar entry"
+msgstr "tar 파일의 크기가 잘못되었습니다."
+
+#: ../src/common/textbuf.cpp:232
+#, c-format
+msgid "'%s' is probably a binary buffer."
+msgstr "'%s' 는 이진 버퍼 입니다."
+
+#: ../src/common/textcmn.cpp:1006 ../src/richtext/richtextctrl.cpp:3053
+msgid "File couldn't be loaded."
+msgstr "파일을 읽어올 수 없습니다."
+
+#: ../src/common/textfile.cpp:95
+#, fuzzy, c-format
+msgid "Failed to read text file \"%s\"."
+msgstr "\"%s\" 파일에서 메타 파일을 읽어올 수 없습니다."
+
+#: ../src/common/textfile.cpp:160
+#, c-format
+msgid "can't write buffer '%s' to disk."
+msgstr "문자열 '%s' 를 디스크에 쓸 수 없습니다."
+
+#: ../src/common/time.cpp:212
+msgid "Failed to get the local system time"
+msgstr "로컬 시스템이 시간을 얻어올 수 없습니다."
+
+#: ../src/common/time.cpp:279
+msgid "wxGetTimeOfDay failed."
+msgstr "wxGetTimeOfDay 함수 실패"
+
+#: ../src/common/translation.cpp:929
+#, c-format
+msgid "'%s' is not a valid message catalog."
+msgstr "'%s'은 메시지 카탈로그가 아닙니다."
+
+#: ../src/common/translation.cpp:954
+#, fuzzy
+msgid "Invalid message catalog."
+msgstr "'%s'은 메시지 카탈로그가 아닙니다."
+
+#: ../src/common/translation.cpp:1013
+#, fuzzy, c-format
+msgid "Failed to parse Plural-Forms: '%s'"
+msgstr "복수형(Plural-Forms) 표현식을 해석할 수 없음: '%s'"
+
+#: ../src/common/translation.cpp:1723
+#, c-format
+msgid "using catalog '%s' from '%s'."
+msgstr "'%s' 카탈로그 사용 ('%s' 파일)"
+
+#: ../src/common/translation.cpp:1816
+#, fuzzy, c-format
+msgid "Resource '%s' is not a valid message catalog."
+msgstr "'%s'은 메시지 카탈로그가 아닙니다."
+
+#: ../src/common/translation.cpp:1865
+#, fuzzy
+msgid "Couldn't enumerate translations"
+msgstr "스레드를 종료할 수없습니다."
+
+#: ../src/common/utilscmn.cpp:1145
+msgid "No default application configured for HTML files."
+msgstr "HTML 기본 브라우저가 없습니다."
+
+#: ../src/common/utilscmn.cpp:1190
+#, c-format
+msgid "Failed to open URL \"%s\" in default browser."
+msgstr "기본 탐색창에서 URL \"%s\" 여는데 실패했습니다."
+
+#: ../src/common/valtext.cpp:144
+msgid "Validation conflict"
+msgstr "충돌"
+
+#: ../src/common/valtext.cpp:186
+msgid "Required information entry is empty."
+msgstr ""
+
+#: ../src/common/valtext.cpp:188
+#, fuzzy, c-format
+msgid "'%s' is one of the invalid strings"
+msgstr "'%s'이(가) 잘못되었습니다"
+
+#: ../src/common/valtext.cpp:190
+#, fuzzy, c-format
+msgid "'%s' is not one of the valid strings"
+msgstr "'%s'은 메시지 카탈로그가 아닙니다."
+
+#: ../src/common/valtext.cpp:199
+#, fuzzy, c-format
+msgid "'%s' contains invalid character(s)"
+msgstr "문자열 '%s' 에는 알파벳 이외의 문자가 입력되었습니다."
+
+#: ../src/common/webrequest.cpp:139
+#, fuzzy, c-format
+msgid "Error: %s (%d)"
+msgstr "오류:"
+
+#: ../src/common/webrequest.cpp:655
+#, c-format
+msgid ""
+"Not enough free disk space for download: %llu needed but only %llu available."
+msgstr ""
+
+#: ../src/common/webrequest.cpp:669
+#, fuzzy, c-format
+msgid "Failed to create temporary file in %s"
+msgstr "임시 파일을 생성을 실패했습니다"
+
+#: ../src/common/webrequest_curl.cpp:1106
+#, fuzzy
+msgid "libcurl could not be initialized"
+msgstr "Column 정보를 초기화 할 수 없습니다."
+
+#: ../src/common/webview.cpp:392
+msgid "RunScriptAsync not supported"
+msgstr ""
+
+#: ../src/common/webview.cpp:403 ../src/msw/webview_ie.cpp:1073
+#, c-format
+msgid "Error running JavaScript: %s"
+msgstr ""
+
+#: ../src/common/webview_chromium.cpp:858
+#, fuzzy, c-format
+msgid "Failed to set proxy \"%s\": %s"
+msgstr "디렉토리 \"%s\" 생성을 실패했습니다."
+
+#: ../src/common/webview_chromium.cpp:989
+msgid ""
+"Chromium can't be used because libcef.so wasn't loaded early enough; please "
+"relink the application or use LD_PRELOAD to load it earlier."
+msgstr ""
+
+#: ../src/common/webview_chromium.cpp:1108
+#, fuzzy
+msgid "Could not initialize Chromium"
+msgstr "정렬 방식을 지정할 수 없습니다."
+
+#: ../src/common/webview_chromium.cpp:1616
+msgid "Show DevTools"
+msgstr ""
+
+#: ../src/common/webview_chromium.cpp:1617
+#, fuzzy
+msgid "Close DevTools"
+msgstr "모두 닫기"
+
+#: ../src/common/webview_chromium.cpp:1623
+msgid "Inspect"
+msgstr ""
+
+#: ../src/common/wincmn.cpp:1628
+msgid "This platform does not support background transparency."
+msgstr ""
+
+#: ../src/common/wincmn.cpp:2097
+msgid "Could not transfer data to window"
+msgstr "데이타를 창으로 내보낼 수 없습니다."
+
+#: ../src/common/windowid.cpp:240
+msgid "Out of window IDs.  Recommend shutting down application."
+msgstr "원도우 ID가 잘못되었습니다. 응용 프로그램을 종료합니다."
+
+#: ../src/common/xpmdecod.cpp:678
+msgid "XPM: incorrect header format!"
+msgstr "XPM: 헤더를 찾을 수 없습니다"
+
+#: ../src/common/xpmdecod.cpp:703
+#, c-format
+msgid "XPM: incorrect colour description in line %d"
+msgstr "XPM: %d 행의 색상지정이 잘못되었습니다."
+
+#: ../src/common/xpmdecod.cpp:715 ../src/common/xpmdecod.cpp:724
+#, c-format
+msgid "XPM: malformed colour definition '%s' at line %d!"
+msgstr "XPM: '%s' 파일의  %d 행의 색상 지정이 잘못되었습니다!"
+
+#: ../src/common/xpmdecod.cpp:754
+msgid "XPM: no colors left to use for mask!"
+msgstr "XPM: 마스크로 사용할 생상이 정의되어 있지 않습니다."
+
+#: ../src/common/xpmdecod.cpp:781
+#, c-format
+msgid "XPM: truncated image data at line %d!"
+msgstr "XPM: %d 행에서 이미지가 잘렸습니다!"
+
+#: ../src/common/xpmdecod.cpp:795
+msgid "XPM: Malformed pixel data!"
+msgstr "XPM: 잘못된 픽셀 데이타"
+
+#: ../src/common/xti.cpp:492
+msgid "Illegal Parameter Count for Create Method"
+msgstr ""
+
+#: ../src/common/xti.cpp:504
+msgid "Illegal Parameter Count for ConstructObject Method"
+msgstr ""
+
+#: ../src/common/xtistrm.cpp:161
+#, fuzzy, c-format
+msgid "Create Parameter %s not found in declared RTTI Parameters"
+msgstr "생성된 매개 변수 이름을 RTTI 에서 찾을 수 없습니다."
+
+#: ../src/common/xtistrm.cpp:290
+msgid "Illegal Object Class (Non-wxEvtHandler) as Event Source"
+msgstr "잘못된 클래스 객체입니다.(wxEvtHandler 상속한 클래스가 아님)"
+
+#: ../src/common/xtistrm.cpp:313 ../src/common/xtixml.cpp:345
+#: ../src/common/xtixml.cpp:498
+msgid "Type must have enum - long conversion"
+msgstr "받드시 ConvertToLong 함수를 가져야 함니다."
+
+#: ../src/common/xtistrm.cpp:400 ../src/common/xtistrm.cpp:415
+msgid "Invalid or Null Object ID passed to GetObjectClassInfo"
+msgstr ""
+"GetObjectClassInfo(int objectID) 함수의 매개 변수가 NULL 혹은 잘못된 값입니"
+"다."
+
+#: ../src/common/xtistrm.cpp:405
+msgid "Unknown Object passed to GetObjectClassInfo"
+msgstr "GetObjectClassInfo 에서 객체를 찾을 수 없습니다."
+
+#: ../src/common/xtistrm.cpp:420
+msgid "Already Registered Object passed to SetObjectClassInfo"
+msgstr "이미 등록된 객체입니다(SetObjectClassInfo) "
+
+#: ../src/common/xtistrm.cpp:430
+msgid "Invalid or Null Object ID passed to HasObjectClassInfo"
+msgstr ""
+"HasObjectClassInfo(int objectID) 함수의 매개 변수가 NULL 혹은 잘못된 값입니"
+"다."
+
+#: ../src/common/xtistrm.cpp:460
+msgid "Passing a already registered object to SetObject"
+msgstr "이미 등록된 객체입니다. 무시함"
+
+#: ../src/common/xtistrm.cpp:471
+#, fuzzy
+msgid "Passing an unknown object to GetObject"
+msgstr "알수없는 객체입니다. 무시함"
+
+#: ../src/common/xtixml.cpp:229
+msgid "Forward hrefs are not supported"
+msgstr "포워드 hrefs 지원되지 않습니다"
+
+#: ../src/common/xtixml.cpp:247
+#, c-format
+msgid "unknown class %s"
+msgstr "%s 는 알 수 없는 클래스입니다."
+
+#: ../src/common/xtixml.cpp:253
+msgid "objects cannot have XML Text Nodes"
+msgstr "텍스트 자식 노드가 없습니다. "
+
+#: ../src/common/xtixml.cpp:258
+msgid "Objects must have an id attribute"
+msgstr "객체는 반드시 속성 ID를 가져야 합니다."
+
+#: ../src/common/xtixml.cpp:267
+#, c-format
+msgid "Doubly used id : %d"
+msgstr "객체 ID가 이미 정의되어 있습니다: %d"
+
+#: ../src/common/xtixml.cpp:316
+#, c-format
+msgid "Unknown Property %s"
+msgstr "속성 %s 을 찾을 수 없습니다."
+
+#: ../src/common/xtixml.cpp:407
+msgid "A non empty collection must consist of 'element' nodes"
+msgstr "CollectionType 'element' 노드로 구성되어야 합니다."
+
+#: ../src/common/xtixml.cpp:478
+msgid "incorrect event handler string, missing dot"
+msgstr "잘못된 문자열 : '.' 문자가 없음"
+
+#: ../src/common/zipstrm.cpp:559
+msgid "can't re-initialize zlib deflate stream"
+msgstr "zlib 출력 스트림을 재 초기화 할 수 없습니다"
+
+#: ../src/common/zipstrm.cpp:584
+msgid "can't re-initialize zlib inflate stream"
+msgstr "zlib 입력 스트림을 재 초기화 할 수 없습니다"
+
+#: ../src/common/zipstrm.cpp:1023
+msgid "Ignoring malformed extra data record, ZIP file may be corrupted"
+msgstr ""
+
+#: ../src/common/zipstrm.cpp:1502
+msgid "assuming this is a multi-part zip concatenated"
+msgstr "분활 압축으로 되어있습니다."
+
+#: ../src/common/zipstrm.cpp:1664
+msgid "invalid zip file"
+msgstr "zip 파일이 잘못되었습니다"
+
+#: ../src/common/zipstrm.cpp:1723
+msgid "can't find central directory in zip"
+msgstr "Zip 압축 스트립에서 Central-Directory 를 찾을 수 없습니다."
+
+#: ../src/common/zipstrm.cpp:1812
+msgid "error reading zip central directory"
+msgstr "CENTRAL_MAGIC 을 읽을 수 없습니다."
+
+#: ../src/common/zipstrm.cpp:1916
+msgid "error reading zip local header"
+msgstr "Zip 파일 읽기 오류"
+
+#: ../src/common/zipstrm.cpp:1964
+msgid "bad zipfile offset to entry"
+msgstr "Zip 파일 헤더가 잘못되었습니다."
+
+#: ../src/common/zipstrm.cpp:2031
+msgid "stored file length not in Zip header"
+msgstr "Zip 헤더에 파일의 길이가 없습니다."
+
+#: ../src/common/zipstrm.cpp:2045 ../src/common/zipstrm.cpp:2362
+msgid "unsupported Zip compression method"
+msgstr "Zip 압축을 지원하지 않습니다."
+
+#: ../src/common/zipstrm.cpp:2126
+#, c-format
+msgid "reading zip stream (entry %s): bad length"
+msgstr "ZIP 스트림 일기 (%s): 길이가 잘못됨"
+
+#: ../src/common/zipstrm.cpp:2131
+#, c-format
+msgid "reading zip stream (entry %s): bad crc"
+msgstr "ZIP 스트림 일기 (%s): CRC 오류"
+
+#: ../src/common/zipstrm.cpp:2578
+#, fuzzy, c-format
+msgid "error writing zip entry '%s': file too large without ZIP64"
+msgstr "Zip 오류('%s'): CRC 오류"
+
+#: ../src/common/zipstrm.cpp:2585
+#, c-format
+msgid "error writing zip entry '%s': bad crc or length"
+msgstr "Zip 오류('%s'): CRC 오류"
+
+#: ../src/common/zstream.cpp:155 ../src/common/zstream.cpp:315
+msgid "Gzip not supported by this version of zlib"
+msgstr "사용중인 zlib 버전에서 Gzip을 지원하지 않습니다."
+
+#: ../src/common/zstream.cpp:182
+msgid "Can't initialize zlib inflate stream."
+msgstr "zlib에서 사용할 압축용 버퍼 할당하지 못했습니다."
+
+#: ../src/common/zstream.cpp:241
+msgid "Can't read inflate stream: unexpected EOF in underlying stream."
+msgstr "압축 해제 실패: 압축 데이타가 갑작스럽게 끝났습니다."
+
+#: ../src/common/zstream.cpp:248 ../src/common/zstream.cpp:423
+#, c-format
+msgid "zlib error %d"
+msgstr "압축모듈(zlib) 오류 %d"
+
+#: ../src/common/zstream.cpp:249
+#, c-format
+msgid "Can't read from inflate stream: %s"
+msgstr "압축 해제 실패: %s"
+
+#: ../src/common/zstream.cpp:343
+msgid "Can't initialize zlib deflate stream."
+msgstr "zlib에서 사용할 압축용 버퍼 할당하지 못했습니다."
+
+#: ../src/common/zstream.cpp:424
+#, c-format
+msgid "Can't write to deflate stream: %s"
+msgstr "압축 실패: %s"
+
+#: ../src/dfb/bitmap.cpp:633 ../src/dfb/bitmap.cpp:667
+#, c-format
+msgid "No bitmap handler for type %d defined."
+msgstr "타입 %d 에대한 비트맵 핸들러가 정의되지 않았습니다."
+
+#: ../src/dfb/evtloop.cpp:99
+#, fuzzy
+msgid "Failed to read event from DirectFB pipe"
+msgstr "Wake-up 파이프에서 읽는 데 실패했습니다."
+
+#: ../src/dfb/evtloop.cpp:171
+#, fuzzy
+msgid "Failed to switch DirectFB pipe to non-blocking mode"
+msgstr "비동기 모드에서 파이프를 Wake-up 상태롤 변경하는데 실패"
+
+#: ../src/dfb/fontmgr.cpp:171
+#, c-format
+msgid "no fonts found in %s, using builtin font"
+msgstr "%s 에서 글꼴을 찾을 수 없어, 기본 글꼴을 사용합니다."
+
+#: ../src/dfb/fontmgr.cpp:177
+msgid "Default font"
+msgstr "기본 글꼴"
+
+#: ../src/dfb/fontmgr.cpp:195
+#, c-format
+msgid "Fonts index file %s disappeared while loading fonts."
+msgstr "글꼴을 읽어오는 동안 글꼴 색인파일 %s 이(가) 사라졌습니다."
+
+#: ../src/dfb/wrapdfb.cpp:60
+#, fuzzy, c-format
+msgid "DirectFB error %d occurred."
+msgstr "Direct 가속시 오류 %d 발생."
+
+#: ../src/generic/aboutdlgg.cpp:69
+msgid "Developed by "
+msgstr "개발"
+
+#: ../src/generic/aboutdlgg.cpp:72
+msgid "Documentation by "
+msgstr "문서화"
+
+#: ../src/generic/aboutdlgg.cpp:75
+msgid "Graphics art by "
+msgstr "그래픽"
+
+#: ../src/generic/aboutdlgg.cpp:78
+msgid "Translations by "
+msgstr "번역"
+
+#: ../src/generic/aboutdlgg.cpp:133 ../src/osx/cocoa/aboutdlg.mm:83
+#, fuzzy
+msgid "Version "
+msgstr "버전 %s"
+
+#. TRANSLATORS: %s is application name
+#: ../src/generic/aboutdlgg.cpp:146 ../src/msw/aboutdlg.cpp:60
+#, c-format
+msgid "About %s"
+msgstr "%s 정보"
+
+#: ../src/generic/aboutdlgg.cpp:181
+msgid "License"
+msgstr "사용권"
+
+#: ../src/generic/aboutdlgg.cpp:184
+msgid "Developers"
+msgstr "개발자"
+
+#: ../src/generic/aboutdlgg.cpp:188
+msgid "Documentation writers"
+msgstr "문서 작성자"
+
+#: ../src/generic/aboutdlgg.cpp:192
+msgid "Artists"
+msgstr "Artists"
+
+#: ../src/generic/aboutdlgg.cpp:196
+msgid "Translators"
+msgstr "번역자"
+
+#: ../src/generic/animateg.cpp:125
+msgid "No handler found for animation type."
+msgstr "애니매이션 핸들러가 없습니다."
+
+#: ../src/generic/animateg.cpp:133
+#, c-format
+msgid "No animation handler for type %ld defined."
+msgstr "%ld 타입에 대한 애니매이션 핸들러가 없습니다."
+
+#: ../src/generic/animateg.cpp:145
+#, c-format
+msgid "Animation file is not of type %ld."
+msgstr "%ld 타입은 애니매이션 파일이 아닙니다."
+
+#: ../src/generic/colrdlgg.cpp:154 ../src/gtk/colordlg.cpp:47
+msgid "Choose colour"
+msgstr "색상 선택"
+
+#: ../src/generic/colrdlgg.cpp:357
+msgid "Red:"
+msgstr ""
+
+#: ../src/generic/colrdlgg.cpp:360
+msgid "Green:"
+msgstr ""
+
+#: ../src/generic/colrdlgg.cpp:363
+msgid "Blue:"
+msgstr ""
+
+#: ../src/generic/colrdlgg.cpp:372
+msgid "Opacity:"
+msgstr ""
+
+#: ../src/generic/colrdlgg.cpp:384
+msgid "Add to custom colours"
+msgstr "사용자 색상 추가"
+
+#: ../src/generic/creddlgg.cpp:56
+msgid "Username:"
+msgstr ""
+
+#: ../src/generic/creddlgg.cpp:63
+msgid "Password:"
+msgstr ""
+
+#. TRANSLATORS: Name of Boolean true value
+#: ../src/generic/datavgen.cpp:1178
+msgid "true"
+msgstr ""
+
+#. TRANSLATORS: Name of Boolean false value
+#: ../src/generic/datavgen.cpp:1180
+#, fuzzy
+msgid "false"
+msgstr "파일"
+
+#: ../src/generic/datavgen.cpp:6897
+#, c-format
+msgid "Row %i"
+msgstr ""
+
+#. TRANSLATORS: Action for manipulating a tree control
+#: ../src/generic/datavgen.cpp:6987
+msgid "Collapse"
+msgstr ""
+
+#. TRANSLATORS: Action for manipulating a tree control
+#: ../src/generic/datavgen.cpp:6990
+msgid "Expand"
+msgstr ""
+
+#. TRANSLATORS: Name of data view control and number of rows
+#: ../src/generic/datavgen.cpp:7011
+#, fuzzy, c-format
+msgid "%s (%d items)"
+msgstr "%s (또는 %s)"
+
+#: ../src/generic/datavgen.cpp:7062
+#, c-format
+msgid "Column %u"
+msgstr ""
+
+#. TRANSLATORS: Keystroke for manipulating a tree control
+#: ../src/generic/datavgen.cpp:7131 ../src/richtext/richtextbulletspage.cpp:189
+#: ../src/richtext/richtextbulletspage.cpp:192
+#: ../src/richtext/richtextbulletspage.cpp:193
+#: ../src/richtext/richtextliststylepage.cpp:252
+#: ../src/richtext/richtextliststylepage.cpp:255
+#: ../src/richtext/richtextliststylepage.cpp:256
+#: ../src/richtext/richtextsizepage.cpp:248
+msgid "Left"
+msgstr "왼쪽"
+
+#. TRANSLATORS: Keystroke for manipulating a tree control
+#: ../src/generic/datavgen.cpp:7134 ../src/richtext/richtextbulletspage.cpp:191
+#: ../src/richtext/richtextliststylepage.cpp:254
+#: ../src/richtext/richtextsizepage.cpp:249
+msgid "Right"
+msgstr "오른쪽"
+
+#: ../src/generic/datectlg.cpp:90
+#, c-format
+msgid ""
+"\"%s\" is not in the expected date format, please enter it as e.g. \"%s\"."
+msgstr ""
+
+#: ../src/generic/datectlg.cpp:94
+#, fuzzy
+msgid "Invalid date"
+msgstr "아이템 데이타뷰가 잘못되었습니다."
+
+#: ../src/generic/dbgrptg.cpp:159
+#, c-format
+msgid "Open file \"%s\""
+msgstr "\"%s\" 파일 엽니다."
+
+#: ../src/generic/dbgrptg.cpp:170
+#, c-format
+msgid "Enter command to open file \"%s\":"
+msgstr "\"%s\" 파일의 열기 명령을 입력하십시오:"
+
+#: ../src/generic/dbgrptg.cpp:230
+#, fuzzy
+msgid "Executable files (*.exe)|*.exe|"
+msgstr "실행 파일 (*.exe)|*.exe|All files (*.*)|*.*||"
+
+#: ../src/generic/dbgrptg.cpp:300
+#, c-format
+msgid "Debug report \"%s\""
+msgstr "디보그 보고서 \"%s\""
+
+#: ../src/generic/dbgrptg.cpp:316
+msgid "A debug report has been generated in the directory\n"
+msgstr "디버그 보고서가 다음 디렉토리에 생성되었습니다\n"
+
+#: ../src/generic/dbgrptg.cpp:317
+msgid "The following debug report will be generated\n"
+msgstr ""
+
+#: ../src/generic/dbgrptg.cpp:321
+msgid ""
+"The report contains the files listed below. If any of these files contain "
+"private information,\n"
+"please uncheck them and they will be removed from the report.\n"
+msgstr ""
+"이 보고서는 아래의 파일들을 포함하고 있습니다. 개인 정보가 포함된 파일이 있다"
+"면,\n"
+"체크를 해제하여 보고서에서 제외할수 있습니다.\n"
+
+#: ../src/generic/dbgrptg.cpp:323
+msgid ""
+"If you wish to suppress this debug report completely, please choose the "
+"\"Cancel\" button,\n"
+"but be warned that it may hinder improving the program, so if\n"
+"at all possible please do continue with the report generation.\n"
+msgstr ""
+"디버그 보고서를 원하지 않는다면 \"취소\" 버튼을 선택하십시오.\n"
+"하지만 프로그램 개선을 방해할 수 있습니다.\n"
+"가능하시면 보고서를 생성해 주십시오.\n"
+
+#: ../src/generic/dbgrptg.cpp:325
+msgid "              Thank you and we're sorry for the inconvenience!\n"
+msgstr "              불편을 드려 죄송합니다!\n"
+
+#: ../src/generic/dbgrptg.cpp:333
+msgid "&Debug report preview:"
+msgstr "디버그 보고서 미리보기(&D):"
+
+#: ../src/generic/dbgrptg.cpp:339
+#, fuzzy
+msgid "&View..."
+msgstr "열기...(&O)"
+
+#: ../src/generic/dbgrptg.cpp:359
+msgid "&Notes:"
+msgstr "&주의:"
+
+#: ../src/generic/dbgrptg.cpp:361
+msgid ""
+"If you have any additional information pertaining to this bug\n"
+"report, please enter it here and it will be joined to it:"
+msgstr ""
+"이 버그에 대한 추가적인 정보가 있다면\n"
+"여기에 입력하시면 보고서에 포함됩니다.:"
+
+#: ../src/generic/dcpsg.cpp:1627
+msgid "Cannot open file for PostScript printing!"
+msgstr "파일을 열수 없습니다. PostScript 파일 인쇄실패"
+
+#: ../src/generic/dirctrlg.cpp:402
+msgid "Computer"
+msgstr "컴퓨터"
+
+#: ../src/generic/dirctrlg.cpp:404
+msgid "Sections"
+msgstr "섹션"
+
+#: ../src/generic/dirctrlg.cpp:482
+msgid "Home directory"
+msgstr "홈 디렉토리"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/generic/dirctrlg.cpp:484 ../src/propgrid/advprops.cpp:811
+msgid "Desktop"
+msgstr "바탕 화면"
+
+#: ../src/generic/dirctrlg.cpp:528 ../src/generic/filectrlg.cpp:752
+msgid "Illegal directory name."
+msgstr "잘못된 디렉토리 이름입니다."
+
+#: ../src/generic/dirctrlg.cpp:528 ../src/generic/dirctrlg.cpp:546
+#: ../src/generic/dirctrlg.cpp:557 ../src/generic/dirdlgg.cpp:317
+#: ../src/generic/filectrlg.cpp:638 ../src/generic/filectrlg.cpp:752
+#: ../src/generic/filectrlg.cpp:766 ../src/generic/filectrlg.cpp:782
+#: ../src/generic/filectrlg.cpp:1356 ../src/generic/filectrlg.cpp:1387
+#: ../src/generic/filedlgg.cpp:362 ../src/gtk/filedlg.cpp:76
+msgid "Error"
+msgstr "오류"
+
+#: ../src/generic/dirctrlg.cpp:546 ../src/generic/filectrlg.cpp:766
+msgid "File name exists already."
+msgstr "파일이 이미 있습니다."
+
+#: ../src/generic/dirctrlg.cpp:557 ../src/generic/dirdlgg.cpp:317
+#: ../src/generic/filectrlg.cpp:638 ../src/generic/filectrlg.cpp:782
+msgid "Operation not permitted."
+msgstr "작동이 허가되지 않음"
+
+#: ../src/generic/dirdlgg.cpp:107 ../src/generic/filedlgg.cpp:207
+msgid "Create new directory"
+msgstr "새 디렉토리를 생성"
+
+#: ../src/generic/dirdlgg.cpp:112 ../src/generic/filedlgg.cpp:203
+msgid "Go to home directory"
+msgstr "홈 디렉토리로 가기"
+
+#: ../src/generic/dirdlgg.cpp:143
+msgid "Show &hidden directories"
+msgstr "숨김 폴더 표시(&H)"
+
+#: ../src/generic/dirdlgg.cpp:196
+#, c-format
+msgid ""
+"The directory '%s' does not exist\n"
+"Create it now?"
+msgstr ""
+"디렉토리 '%s' 가 없습니다\n"
+"디렉토리를 생성하시겠습니까?"
+
+#: ../src/generic/dirdlgg.cpp:198
+msgid "Directory does not exist"
+msgstr "디렉토리가 존재하지 않습니다."
+
+#: ../src/generic/dirdlgg.cpp:214
+#, c-format
+msgid ""
+"Failed to create directory '%s'\n"
+"(Do you have the required permissions?)"
+msgstr ""
+"'%s' 디렉토리 생성 실패\n"
+"(접근권한을 확인하세요.)"
+
+#: ../src/generic/dirdlgg.cpp:216
+msgid "Error creating directory"
+msgstr "디렉토리 생성 오류"
+
+#: ../src/generic/dirdlgg.cpp:281
+msgid "You cannot add a new directory to this section."
+msgstr "이 섹션에 새 디렉토리를 추가할 수 없습니다."
+
+#: ../src/generic/dirdlgg.cpp:282
+msgid "Create directory"
+msgstr "디렉토리 생성"
+
+#: ../src/generic/dirdlgg.cpp:291 ../src/generic/dirdlgg.cpp:301
+#: ../src/generic/filectrlg.cpp:614 ../src/generic/filectrlg.cpp:623
+msgid "NewName"
+msgstr "새 이름"
+
+#: ../src/generic/editlbox.cpp:135
+msgid "Edit item"
+msgstr "아이템 편집"
+
+#: ../src/generic/editlbox.cpp:143
+msgid "New item"
+msgstr "새 아이템"
+
+#: ../src/generic/editlbox.cpp:151
+msgid "Delete item"
+msgstr "아이템 지우기"
+
+#: ../src/generic/editlbox.cpp:159
+msgid "Move up"
+msgstr "위로 이동"
+
+#: ../src/generic/editlbox.cpp:164
+msgid "Move down"
+msgstr "아래로 이동"
+
+#: ../src/generic/fdrepdlg.cpp:108
+msgid "Search for:"
+msgstr "찾을 문자열: "
+
+#: ../src/generic/fdrepdlg.cpp:120
+msgid "Replace with:"
+msgstr "다음으로 바꾸기:"
+
+#: ../src/generic/fdrepdlg.cpp:140
+msgid "Whole word"
+msgstr "전체 단어 일치"
+
+#: ../src/generic/fdrepdlg.cpp:143
+msgid "Match case"
+msgstr "대소문자가 구분"
+
+#: ../src/generic/fdrepdlg.cpp:156
+msgid "Search direction"
+msgstr "찾는 방향"
+
+#: ../src/generic/fdrepdlg.cpp:175
+msgid "&Replace"
+msgstr "바꾸기(&R)"
+
+#: ../src/generic/fdrepdlg.cpp:178
+msgid "Replace &all"
+msgstr "모두 바꾸기(&A)"
+
+#: ../src/generic/filectrlg.cpp:246 ../src/generic/filectrlg.cpp:269
+msgid "<DIR>"
+msgstr ""
+
+#: ../src/generic/filectrlg.cpp:248 ../src/generic/filectrlg.cpp:271
+msgid "<LINK>"
+msgstr ""
+
+#: ../src/generic/filectrlg.cpp:250 ../src/generic/filectrlg.cpp:273
+msgid "<DRIVE>"
+msgstr ""
+
+#: ../src/generic/filectrlg.cpp:275
+#, c-format
+msgid "%ld byte"
+msgid_plural "%ld bytes"
+msgstr[0] "%ld 바이트"
+msgstr[1] "%ld 바이트"
+
+#: ../src/generic/filectrlg.cpp:420
+msgid "Name"
+msgstr "이름"
+
+#: ../src/generic/filectrlg.cpp:421 ../src/richtext/richtextformatdlg.cpp:361
+#: ../src/richtext/richtextsizepage.cpp:298
+msgid "Size"
+msgstr "크기"
+
+#: ../src/generic/filectrlg.cpp:422
+msgid "Type"
+msgstr "타입"
+
+#: ../src/generic/filectrlg.cpp:423
+msgid "Modified"
+msgstr "수정됨"
+
+#: ../src/generic/filectrlg.cpp:426
+msgid "Permissions"
+msgstr "권한"
+
+#: ../src/generic/filectrlg.cpp:429
+msgid "Attributes"
+msgstr "속성"
+
+#: ../src/generic/filectrlg.cpp:936
+msgid "Current directory:"
+msgstr "현재 디렉토리:"
+
+#: ../src/generic/filectrlg.cpp:979
+msgid "Show &hidden files"
+msgstr "숨겨진 파일 표시(&H)"
+
+#: ../src/generic/filectrlg.cpp:1355
+msgid "Illegal file specification."
+msgstr "파일 경로가 잘못되었습니다."
+
+#: ../src/generic/filectrlg.cpp:1387
+msgid "Directory doesn't exist."
+msgstr "디렉토리가 존재하지 않습니다."
+
+#: ../src/generic/filedlgg.cpp:195
+msgid "View files as a list view"
+msgstr "목록보기로 파일보기"
+
+#: ../src/generic/filedlgg.cpp:197
+msgid "View files as a detailed view"
+msgstr "자세히보기로 파일보기"
+
+#: ../src/generic/filedlgg.cpp:200
+msgid "Go to parent directory"
+msgstr "부모 디렉토리로 가기"
+
+#: ../src/generic/filedlgg.cpp:351 ../src/gtk/filedlg.cpp:59
+#, c-format
+msgid "File '%s' already exists, do you really want to overwrite it?"
+msgstr "'%s' 파일이 이미 있습니다.  이 파일을 덮어 쓰시겠습니까?"
+
+#: ../src/generic/filedlgg.cpp:354 ../src/gtk/filedlg.cpp:62
+msgid "Confirm"
+msgstr "확인"
+
+#: ../src/generic/filedlgg.cpp:362 ../src/gtk/filedlg.cpp:75
+msgid "Please choose an existing file."
+msgstr "파일을 선택하십시오"
+
+#: ../src/generic/filepickerg.cpp:64
+msgid "..."
+msgstr ""
+
+#: ../src/generic/fontdlgg.cpp:76 ../src/richtext/richtextformatdlg.cpp:519
+msgid "ABCDEFGabcdefg12345"
+msgstr "ABCDEFGabcdefg12345"
+
+#: ../src/generic/fontdlgg.cpp:315
+msgid "Roman"
+msgstr ""
+
+#: ../src/generic/fontdlgg.cpp:316
+msgid "Decorative"
+msgstr "Decorative"
+
+#: ../src/generic/fontdlgg.cpp:317
+msgid "Modern"
+msgstr "Modern"
+
+#: ../src/generic/fontdlgg.cpp:318
+msgid "Script"
+msgstr ""
+
+#: ../src/generic/fontdlgg.cpp:319
+msgid "Swiss"
+msgstr ""
+
+#: ../src/generic/fontdlgg.cpp:320
+msgid "Teletype"
+msgstr ""
+
+#: ../src/generic/fontdlgg.cpp:321 ../src/generic/fontdlgg.cpp:324
+msgid "Normal"
+msgstr "보통"
+
+#: ../src/generic/fontdlgg.cpp:323
+msgid "Slant"
+msgstr "대각선"
+
+#: ../src/generic/fontdlgg.cpp:325
+msgid "Light"
+msgstr "가늘게"
+
+#: ../src/generic/fontdlgg.cpp:363
+msgid "&Font family:"
+msgstr "글꼴 패밀리(&F):"
+
+#: ../src/generic/fontdlgg.cpp:367 ../src/generic/fontdlgg.cpp:369
+msgid "The font family."
+msgstr "글꼴 패밀리"
+
+#: ../src/generic/fontdlgg.cpp:374 ../src/richtext/richtextstylepage.cpp:105
+msgid "&Style:"
+msgstr "모양새(&S):"
+
+#: ../src/generic/fontdlgg.cpp:378 ../src/generic/fontdlgg.cpp:380
+msgid "The font style."
+msgstr "글꼴 모양새"
+
+#: ../src/generic/fontdlgg.cpp:385
+msgid "&Weight:"
+msgstr "두께(&W):"
+
+#: ../src/generic/fontdlgg.cpp:389 ../src/generic/fontdlgg.cpp:391
+msgid "The font weight."
+msgstr "글꼴 두께"
+
+#: ../src/generic/fontdlgg.cpp:399
+msgid "C&olour:"
+msgstr "색상(&O):"
+
+#: ../src/generic/fontdlgg.cpp:407 ../src/generic/fontdlgg.cpp:409
+msgid "The font colour."
+msgstr "글꼴 색상"
+
+#: ../src/generic/fontdlgg.cpp:415
+msgid "&Point size:"
+msgstr "크기(&P):"
+
+#: ../src/generic/fontdlgg.cpp:420 ../src/generic/fontdlgg.cpp:422
+#: ../src/generic/fontdlgg.cpp:426 ../src/generic/fontdlgg.cpp:428
+msgid "The font point size."
+msgstr "글꼴 크기"
+
+#: ../src/generic/fontdlgg.cpp:439 ../src/generic/fontdlgg.cpp:441
+msgid "Whether the font is underlined."
+msgstr "글꼴 밑줄이 있는지 여부입니다."
+
+#: ../src/generic/fontdlgg.cpp:448 ../src/html/helpwnd.cpp:1215
+msgid "Preview:"
+msgstr "미리보기:"
+
+#: ../src/generic/fontdlgg.cpp:452 ../src/generic/fontdlgg.cpp:454
+msgid "Shows the font preview."
+msgstr "글꼴 미리보기"
+
+#: ../src/generic/fontdlgg.cpp:464 ../src/generic/fontdlgg.cpp:483
+msgid "Click to cancel the font selection."
+msgstr "선택한 글꼴을 취소하려면 여기를 누르십시오."
+
+#: ../src/generic/fontdlgg.cpp:469 ../src/generic/fontdlgg.cpp:471
+#: ../src/generic/fontdlgg.cpp:476 ../src/generic/fontdlgg.cpp:478
+msgid "Click to confirm the font selection."
+msgstr "선택한 글꼴을 적용하려면 여기를 누르십시오."
+
+#: ../src/generic/fontpickerg.cpp:50 ../src/gtk/fontdlg.cpp:77
+msgid "Choose font"
+msgstr "글꼴 선택"
+
+#: ../src/generic/grid.cpp:6542
+msgid ""
+"Error copying grid to the clipboard. Either selected cells were not "
+"contiguous or no cell was selected."
+msgstr ""
+
+#: ../src/generic/grid.cpp:12739
+msgid "Grid Corner"
+msgstr ""
+
+#: ../src/generic/grid.cpp:12741
+#, c-format
+msgid "Column %s Header"
+msgstr ""
+
+#: ../src/generic/grid.cpp:12743
+#, c-format
+msgid "Row %s Header"
+msgstr ""
+
+#: ../src/generic/grid.cpp:12745
+#, c-format
+msgid "Column %s: %s"
+msgstr ""
+
+#: ../src/generic/grid.cpp:12749
+#, c-format
+msgid "Row %s: %s"
+msgstr ""
+
+#: ../src/generic/grid.cpp:12753
+#, c-format
+msgid "Row %s, Column %s: %s"
+msgstr ""
+
+#: ../src/generic/helpext.cpp:257
+#, c-format
+msgid "Help directory \"%s\" not found."
+msgstr "도움말 디렉토리 \"%s\" 가 없습니다."
+
+#: ../src/generic/helpext.cpp:265
+#, c-format
+msgid "Help file \"%s\" not found."
+msgstr "도움말 파일 \"%s\" 이 없습니다."
+
+#: ../src/generic/helpext.cpp:284
+#, c-format
+msgid "Line %lu of map file \"%s\" has invalid syntax, skipped."
+msgstr "%lu 행(맵 파일 \"%s\" 에서) 에 문법이 잘못되었습니다."
+
+#: ../src/generic/helpext.cpp:292
+#, c-format
+msgid "No valid mappings found in the file \"%s\"."
+msgstr "\"%s\" 로 검색된 파일이 없습니다."
+
+#: ../src/generic/helpext.cpp:435
+msgid "No entries found."
+msgstr "항목이 없습니다."
+
+#: ../src/generic/helpext.cpp:444 ../src/generic/helpext.cpp:445
+msgid "Help Index"
+msgstr "도움말 인덱스"
+
+#: ../src/generic/helpext.cpp:448
+msgid "Relevant entries:"
+msgstr "관련 항목:"
+
+#: ../src/generic/helpext.cpp:449
+msgid "Entries found"
+msgstr "발견 항목"
+
+#: ../src/generic/hyperlinkg.cpp:170
+msgid "&Copy URL"
+msgstr "URL 복사(&D)"
+
+#: ../src/generic/infobar.cpp:119
+msgid "Hide this notification message."
+msgstr ""
+
+#. TRANSLATORS: %s will be either the application name or "Application"
+#: ../src/generic/logg.cpp:257
+#, c-format
+msgid "%s Error"
+msgstr "오류 : %s"
+
+#. TRANSLATORS: %s will be either the application name or "Application"
+#: ../src/generic/logg.cpp:263
+#, c-format
+msgid "%s Warning"
+msgstr "경고 : %s"
+
+#. TRANSLATORS: %s will be either the application name or "Application"
+#: ../src/generic/logg.cpp:273
+#, c-format
+msgid "%s Information"
+msgstr "정보 : %s"
+
+#: ../src/generic/logg.cpp:276
+#, fuzzy
+msgid "Application"
+msgstr "선택"
+
+#: ../src/generic/logg.cpp:549
+msgid "Save log contents to file"
+msgstr "파일에 로그 저장"
+
+#: ../src/generic/logg.cpp:551
+msgid "C&lear"
+msgstr "지우기(&L)"
+
+#: ../src/generic/logg.cpp:551
+msgid "Clear the log contents"
+msgstr "로그 내용 지우기"
+
+#: ../src/generic/logg.cpp:553
+msgid "Close this window"
+msgstr "현재 창을 닫습니다."
+
+#: ../src/generic/logg.cpp:554
+msgid "&Log"
+msgstr "로그(&L)"
+
+#: ../src/generic/logg.cpp:610 ../src/generic/logg.cpp:992
+msgid "Can't save log contents to file."
+msgstr "로그를 파일로 저장할 수 없습니다."
+
+#: ../src/generic/logg.cpp:613
+#, c-format
+msgid "Log saved to the file '%s'."
+msgstr "'%s' 파일에 로그 저장."
+
+#: ../src/generic/logg.cpp:719
+msgid "&Details"
+msgstr "자세히(&D)"
+
+#: ../src/generic/logg.cpp:972
+#, fuzzy
+msgid "Failed to copy dialog contents to the clipboard."
+msgstr "클립보드를 여는 데 실패했습니다."
+
+#: ../src/generic/logg.cpp:1022
+#, c-format
+msgid "Append log to file '%s' (choosing [No] will overwrite it)?"
+msgstr "'%s' 파일에 로그를 추가 하시겠습니까 (아니요 시 덮어쓰기 수행)?"
+
+#: ../src/generic/logg.cpp:1024
+msgid "Question"
+msgstr "질문"
+
+#: ../src/generic/logg.cpp:1038
+msgid "invalid message box return value"
+msgstr "메세지창의 반환값이 잘못되었습니다."
+
+#: ../src/generic/notifmsgg.cpp:129
+msgid "Notice"
+msgstr "알림"
+
+#: ../src/generic/preferencesg.cpp:118
+#, fuzzy, c-format
+msgid "%s Preferences"
+msgstr "설정(&P)"
+
+#: ../src/generic/printps.cpp:143
+msgid "Printing..."
+msgstr "인쇄중..."
+
+#: ../src/generic/printps.cpp:160 ../src/gtk/print.cpp:1076
+#: ../src/msw/printwin.cpp:235
+msgid "Could not start printing."
+msgstr "인쇄를 시작할 수 없습니다."
+
+#: ../src/generic/printps.cpp:183
+#, c-format
+msgid "Printing page %d..."
+msgstr "%d쪽 인쇄 중..."
+
+#: ../src/generic/prntdlgg.cpp:171
+msgid "Printer options"
+msgstr "인쇄 설정"
+
+#: ../src/generic/prntdlgg.cpp:176
+msgid "Print to File"
+msgstr "파일로 인쇄"
+
+#: ../src/generic/prntdlgg.cpp:179
+msgid "Setup..."
+msgstr "설정..."
+
+#: ../src/generic/prntdlgg.cpp:187
+msgid "Printer:"
+msgstr "프린터:"
+
+#: ../src/generic/prntdlgg.cpp:195
+msgid "Status:"
+msgstr "상태:"
+
+#: ../src/generic/prntdlgg.cpp:206
+msgid "All"
+msgstr "모두"
+
+#: ../src/generic/prntdlgg.cpp:207
+msgid "Pages"
+msgstr "페이지"
+
+#: ../src/generic/prntdlgg.cpp:215
+msgid "Print Range"
+msgstr "인쇄 범위"
+
+#: ../src/generic/prntdlgg.cpp:229
+msgid "From:"
+msgstr "송신:"
+
+#: ../src/generic/prntdlgg.cpp:233
+msgid "To:"
+msgstr "수신:"
+
+#: ../src/generic/prntdlgg.cpp:238
+msgid "Copies:"
+msgstr "인쇄 매수:"
+
+#: ../src/generic/prntdlgg.cpp:288
+msgid "PostScript file"
+msgstr "PostScript 파일"
+
+#: ../src/generic/prntdlgg.cpp:439
+msgid "Print Setup"
+msgstr "인쇄 설정"
+
+#: ../src/generic/prntdlgg.cpp:483
+msgid "Printer"
+msgstr "프린터"
+
+#: ../src/generic/prntdlgg.cpp:501
+msgid "Default printer"
+msgstr "프린터 기본값"
+
+#: ../src/generic/prntdlgg.cpp:595 ../src/generic/prntdlgg.cpp:782
+#: ../src/generic/prntdlgg.cpp:822 ../src/generic/prntdlgg.cpp:835
+#: ../src/generic/prntdlgg.cpp:1031 ../src/generic/prntdlgg.cpp:1036
+msgid "Paper size"
+msgstr "용지 크기"
+
+#: ../src/generic/prntdlgg.cpp:604 ../src/generic/prntdlgg.cpp:847
+msgid "Portrait"
+msgstr "세로 방향"
+
+#: ../src/generic/prntdlgg.cpp:605 ../src/generic/prntdlgg.cpp:848
+msgid "Landscape"
+msgstr "가로 방향"
+
+#: ../src/generic/prntdlgg.cpp:607 ../src/generic/prntdlgg.cpp:849
+msgid "Orientation"
+msgstr "방향"
+
+#: ../src/generic/prntdlgg.cpp:610
+msgid "Options"
+msgstr "설정"
+
+#: ../src/generic/prntdlgg.cpp:612
+msgid "Print in colour"
+msgstr "인쇄 색상"
+
+#: ../src/generic/prntdlgg.cpp:621
+msgid "Print spooling"
+msgstr "인쇄 스풀러"
+
+#: ../src/generic/prntdlgg.cpp:623
+msgid "Printer command:"
+msgstr "인쇄 명령:"
+
+#: ../src/generic/prntdlgg.cpp:631
+msgid "Printer options:"
+msgstr "인쇄 설정:"
+
+#: ../src/generic/prntdlgg.cpp:860
+msgid "Left margin (mm):"
+msgstr "왼쪽 여백(mm):"
+
+#: ../src/generic/prntdlgg.cpp:861
+msgid "Top margin (mm):"
+msgstr "상단 여백(mm):"
+
+#: ../src/generic/prntdlgg.cpp:872
+msgid "Right margin (mm):"
+msgstr "오른쪽 여백(mm):"
+
+#: ../src/generic/prntdlgg.cpp:873
+msgid "Bottom margin (mm):"
+msgstr "버튼 여백(mm):"
+
+#: ../src/generic/prntdlgg.cpp:896
+msgid "Printer..."
+msgstr "프린터..."
+
+#: ../src/generic/progdlgg.cpp:246
+msgid "&Skip"
+msgstr "건너뛰기(&S)"
+
+#: ../src/generic/progdlgg.cpp:347 ../src/generic/progdlgg.cpp:626
+msgid "Unknown"
+msgstr "알수 없음"
+
+#: ../src/generic/progdlgg.cpp:451 ../src/msw/progdlg.cpp:526
+msgid "Done."
+msgstr "완료."
+
+#: ../src/generic/srchctlg.cpp:55 ../src/gtk/srchctrl.cpp:206
+#: ../src/html/helpwnd.cpp:530 ../src/html/helpwnd.cpp:545
+msgid "Search"
+msgstr "찾기"
+
+#: ../src/generic/tabg.cpp:1026
+msgid "Could not find tab for id"
+msgstr "tab ID를 찿을 수 없습니다."
+
+#: ../src/generic/tipdlg.cpp:136
+msgid "Tips not available, sorry!"
+msgstr "유용한 팁이 없습니다."
+
+#: ../src/generic/tipdlg.cpp:197
+msgid "Tip of the Day"
+msgstr "오늘의 팁"
+
+#: ../src/generic/tipdlg.cpp:207
+msgid "Did you know..."
+msgstr "팁 보기"
+
+#: ../src/generic/tipdlg.cpp:232
+msgid "&Show tips at startup"
+msgstr "시작시 팁 보여주기(&S)"
+
+#: ../src/generic/tipdlg.cpp:236
+msgid "&Next Tip"
+msgstr "다음 팁(&N)"
+
+#: ../src/generic/wizard.cpp:411
+msgid "&Next >"
+msgstr "다음(&N) >"
+
+#: ../src/generic/wizard.cpp:412
+msgid "&Finish"
+msgstr "종료(&F)"
+
+#: ../src/generic/wizard.cpp:420
+msgid "< &Back"
+msgstr "< &뒤로"
+
+#: ../src/gtk/aboutdlg.cpp:204
+msgid "translator-credits"
+msgstr "번역"
+
+#: ../src/gtk/app.cpp:517
+msgid ""
+"WARNING: using XIM input method is unsupported and may result in problems "
+"with input handling and flickering. Consider unsetting GTK_IM_MODULE or "
+"setting to \"ibus\"."
+msgstr ""
+
+#: ../src/gtk/app.cpp:569
+msgid "Unable to initialize GTK+, is DISPLAY set properly?"
+msgstr "GTK+ 초기화 할 수 없습니다. 디스플레이 설정이 바르게 되어 있습니까?"
+
+#: ../src/gtk/filedlg.cpp:89 ../src/gtk/filepicker.cpp:255
+#, fuzzy, c-format
+msgid "Changing current directory to \"%s\" failed"
+msgstr "디렉토리 \"%s\" 생성을 실패했습니다."
+
+#: ../src/gtk/font.cpp:548
+msgid ""
+"Using private fonts is not supported on this system: Pango library is too "
+"old, 1.38 or later required."
+msgstr ""
+
+#: ../src/gtk/font.cpp:558
+#, fuzzy
+msgid "Failed to create font configuration object."
+msgstr "사용자 설정 파일을 갱신하는데 실패했습니다."
+
+#: ../src/gtk/font.cpp:568
+#, fuzzy, c-format
+msgid "Failed to add custom font \"%s\"."
+msgstr "\"%s\" 파일에서 메타 파일을 읽어올 수 없습니다."
+
+#: ../src/gtk/font.cpp:576
+#, fuzzy
+msgid "Failed to register font configuration using private fonts."
+msgstr "사용자 설정 파일을 갱신하는데 실패했습니다."
+
+#: ../src/gtk/glcanvas.cpp:117 ../src/gtk/glcanvas.cpp:132
+#, fuzzy
+msgid "Fatal Error"
+msgstr "치명적인 오류"
+
+#: ../src/gtk/glcanvas.cpp:117
+msgid ""
+"This program wasn't compiled with EGL support required under Wayland, "
+"either\n"
+"install EGL libraries and rebuild or run it under X11 backend by setting\n"
+"environment variable GDK_BACKEND=x11 before starting your program."
+msgstr ""
+
+#: ../src/gtk/glcanvas.cpp:132
+msgid ""
+"wxGLCanvas is only supported on Wayland and X11 currently.  You may be able "
+"to\n"
+"work around this by setting environment variable GDK_BACKEND=x11 before\n"
+"starting your program."
+msgstr ""
+
+#: ../src/gtk/mdi.cpp:433
+msgid "MDI child"
+msgstr "MDI 자식"
+
+#: ../src/gtk/power.cpp:188
+#, fuzzy, c-format
+msgid "Failed to open D-Bus connection to the login manager: %s"
+msgstr "세션 관리자에 연결 실패: %s"
+
+#: ../src/gtk/power.cpp:214
+#, fuzzy
+msgid "wxWidgets application"
+msgstr "선택"
+
+#: ../src/gtk/power.cpp:226
+msgid "Application needs to keep running"
+msgstr ""
+
+#: ../src/gtk/power.cpp:233
+msgid "Clean up before suspend"
+msgstr ""
+
+#: ../src/gtk/power.cpp:259
+#, fuzzy, c-format
+msgid "Failed to inhibit sleep: %s"
+msgstr "dialup 연결을 초기화 하는데 실패: %s"
+
+#: ../src/gtk/power.cpp:265
+msgid "Unexpected response to D-Bus \"Inhibit\" request."
+msgstr ""
+
+#: ../src/gtk/print.cpp:218
+msgid "Custom size"
+msgstr "사용자 지정 크기"
+
+#: ../src/gtk/print.cpp:752
+#, fuzzy, c-format
+msgid "Error while printing: %s"
+msgstr "인쇄하는 도중 오류 발생:"
+
+#: ../src/gtk/print.cpp:816
+msgid "Page Setup"
+msgstr "페이지 설정"
+
+#: ../src/gtk/webview_webkit.cpp:932
+msgid "Retrieving JavaScript script output is not supported with WebKit v1"
+msgstr ""
+
+#: ../src/gtk/webview_webkit2.cpp:1098
+msgid ""
+"Setting proxy is not supported by WebKit, at least version 2.16 is required."
+msgstr ""
+
+#: ../src/gtk/webview_webkit2.cpp:1104
+msgid "This program was compiled without support for setting WebKit proxy."
+msgstr ""
+
+#: ../src/gtk/window.cpp:6289
+msgid ""
+"GTK+ installed on this machine is too old to support screen compositing, "
+"please install GTK+ 2.12 or later."
+msgstr ""
+
+#: ../src/gtk/window.cpp:6307
+msgid ""
+"Compositing not supported by this system, please enable it in your Window "
+"Manager."
+msgstr ""
+
+#: ../src/gtk/window.cpp:6318
+msgid ""
+"This program was compiled with a too old version of GTK+, please rebuild "
+"with GTK+ 2.12 or newer."
+msgstr ""
+
+#: ../src/html/chm.cpp:138
+#, c-format
+msgid "Failed to open CHM archive '%s'."
+msgstr "'%s' CHM 파일을 여는 데 실패했습니다."
+
+#: ../src/html/chm.cpp:270
+#, c-format
+msgid "Could not extract %s into %s: %s"
+msgstr "%s 를 %s 에서 추출할 수 없음: %s"
+
+#: ../src/html/chm.cpp:324
+msgid "no error"
+msgstr "오류 없음"
+
+#: ../src/html/chm.cpp:326
+msgid "bad arguments to library function"
+msgstr "Library 함수의 매개변수가 잘못되었습니다."
+
+#: ../src/html/chm.cpp:328
+msgid "error opening file"
+msgstr "파일 열기 오류"
+
+#: ../src/html/chm.cpp:330
+msgid "read error"
+msgstr "읽기 오류"
+
+#: ../src/html/chm.cpp:332
+msgid "write error"
+msgstr "쓰기 오류"
+
+#: ../src/html/chm.cpp:334
+msgid "seek error"
+msgstr "찿기 오류"
+
+#: ../src/html/chm.cpp:338
+msgid "bad signature"
+msgstr "잘못된 서명"
+
+#: ../src/html/chm.cpp:340
+msgid "error in data format"
+msgstr "데이터에 잘못된 형식이 있습니다."
+
+#: ../src/html/chm.cpp:342
+msgid "checksum error"
+msgstr "체크섬 오류"
+
+#: ../src/html/chm.cpp:344
+msgid "compression error"
+msgstr "압축 오류"
+
+#: ../src/html/chm.cpp:346
+msgid "decompression error"
+msgstr "압축 풀기 오류"
+
+#: ../src/html/chm.cpp:437
+#, c-format
+msgid "Could not locate file '%s'."
+msgstr "'%s' 파일을 찾을 수 없습니다."
+
+#: ../src/html/chm.cpp:711
+#, c-format
+msgid "Could not create temporary file '%s'"
+msgstr "임시 파일 '%s' 을 만들수 없습니다."
+
+#: ../src/html/chm.cpp:718
+#, c-format
+msgid "Extraction of '%s' into '%s' failed."
+msgstr "'%s' 의 추출('%s' 에서) 실패 했습니다."
+
+#: ../src/html/chm.cpp:806 ../src/html/chm.cpp:863
+msgid "CHM handler currently supports only local files!"
+msgstr "CHM 헤더는 현재 로컬 파일만을 지원합니다."
+
+#: ../src/html/chm.cpp:827
+msgid "Link contained '//', converted to absolute link."
+msgstr "링크에 '//' 가 포함되어 있어, 절대주소로 변환 합니다."
+
+#: ../src/html/helpctrl.cpp:59
+#, c-format
+msgid "Help: %s"
+msgstr "도움말: %s"
+
+#: ../src/html/helpctrl.cpp:155
+#, c-format
+msgid "Adding book %s"
+msgstr "'%s' 북파일 추가"
+
+#: ../src/html/helpdata.cpp:295
+#, c-format
+msgid "Cannot open contents file: %s"
+msgstr "파일을 열 수 없습니다: %s"
+
+#: ../src/html/helpdata.cpp:309
+#, c-format
+msgid "Cannot open index file: %s"
+msgstr "'%s' 차례 파일을 열 수 없습니다."
+
+#: ../src/html/helpdata.cpp:643
+msgid "noname"
+msgstr "이름없음"
+
+#: ../src/html/helpdata.cpp:652
+#, c-format
+msgid "Cannot open HTML help book: %s"
+msgstr "HTML 도움말을 열 수 없습니다: %s"
+
+#: ../src/html/helpwnd.cpp:315
+msgid "Displays help as you browse the books on the left."
+msgstr "왼쪽에 도움말 탐색창을 표시합니다."
+
+#: ../src/html/helpwnd.cpp:411 ../src/html/helpwnd.cpp:1100
+#: ../src/html/helpwnd.cpp:1735
+msgid "(bookmarks)"
+msgstr "(책갈피)"
+
+#: ../src/html/helpwnd.cpp:424
+msgid "Add current page to bookmarks"
+msgstr "현재 페이지를 책갈피에 추가 합니다."
+
+#: ../src/html/helpwnd.cpp:425
+msgid "Remove current page from bookmarks"
+msgstr "현재 페이지의 책갈피를 제거 합니다."
+
+#: ../src/html/helpwnd.cpp:470
+msgid "Contents"
+msgstr "목차"
+
+#: ../src/html/helpwnd.cpp:485
+msgid "Find"
+msgstr "찾기"
+
+#: ../src/html/helpwnd.cpp:487
+msgid "Show all"
+msgstr "모두 표시"
+
+#: ../src/html/helpwnd.cpp:497
+msgid ""
+"Display all index items that contain given substring. Search is case "
+"insensitive."
+msgstr ""
+"문자열을 포함하는 모든 색인 항목을 표시합니다. 검색시 대소문자를 구분하지 않"
+"습니다"
+
+#: ../src/html/helpwnd.cpp:498
+msgid "Show all items in index"
+msgstr "색인의 모든 아이템 표시"
+
+#: ../src/html/helpwnd.cpp:528
+msgid "Case sensitive"
+msgstr "대/소문자 구분"
+
+#: ../src/html/helpwnd.cpp:529
+msgid "Whole words only"
+msgstr "단어 단위로 검색"
+
+#: ../src/html/helpwnd.cpp:532
+#, fuzzy
+msgid ""
+"Search contents of help book(s) for all occurrences of the text you typed "
+"above"
+msgstr "위에서 입력한 내용을 검색합니다.  "
+
+#: ../src/html/helpwnd.cpp:653
+msgid "Show/hide navigation panel"
+msgstr "탐색 도구모음 보이기/감추기"
+
+#: ../src/html/helpwnd.cpp:655
+msgid "Go back"
+msgstr "뒤로 가기"
+
+#: ../src/html/helpwnd.cpp:656
+msgid "Go forward"
+msgstr "앞으로 가기"
+
+#: ../src/html/helpwnd.cpp:658
+msgid "Go one level up in document hierarchy"
+msgstr "위로 이동"
+
+#: ../src/html/helpwnd.cpp:666 ../src/html/helpwnd.cpp:1547
+msgid "Open HTML document"
+msgstr "HTML 문서를 엽니다"
+
+#: ../src/html/helpwnd.cpp:670
+msgid "Print this page"
+msgstr "이 페이지를 인쇄"
+
+#: ../src/html/helpwnd.cpp:674
+msgid "Display options dialog"
+msgstr "보기 설정 창"
+
+#: ../src/html/helpwnd.cpp:795
+msgid "Please choose the page to display:"
+msgstr "표시할 페이지를 선택하시기 바랍니다 :"
+
+#: ../src/html/helpwnd.cpp:796
+msgid "Help Topics"
+msgstr "도움말 주제"
+
+#: ../src/html/helpwnd.cpp:852
+msgid "Searching..."
+msgstr "찾는 중..."
+
+#: ../src/html/helpwnd.cpp:853
+msgid "No matching page found yet"
+msgstr "일치하는 페이지를 찾을 수 없습니다."
+
+#: ../src/html/helpwnd.cpp:870
+#, c-format
+msgid "Found %i matches"
+msgstr "%i 개의 항목 검색됨"
+
+#: ../src/html/helpwnd.cpp:958
+msgid "(Help)"
+msgstr "(도움말)"
+
+#: ../src/html/helpwnd.cpp:1026
+#, fuzzy, c-format
+msgid "%d of %lu"
+msgstr "%i / %i"
+
+#: ../src/html/helpwnd.cpp:1028
+#, fuzzy, c-format
+msgid "%lu of %lu"
+msgstr "%i / %i"
+
+#: ../src/html/helpwnd.cpp:1047
+msgid "Search in all books"
+msgstr "모든 도움말 에서 찾기"
+
+#: ../src/html/helpwnd.cpp:1193
+msgid "Help Browser Options"
+msgstr "도움말 설정"
+
+#: ../src/html/helpwnd.cpp:1198
+msgid "Normal font:"
+msgstr "보통 글꼴:"
+
+#: ../src/html/helpwnd.cpp:1199
+msgid "Fixed font:"
+msgstr "고정폭 글꼴:"
+
+#: ../src/html/helpwnd.cpp:1200
+msgid "Font size:"
+msgstr "글꼴 크기:"
+
+#: ../src/html/helpwnd.cpp:1245
+msgid "font size"
+msgstr "글꼴 크기"
+
+#: ../src/html/helpwnd.cpp:1256
+msgid "Normal face<br>and <u>underlined</u>. "
+msgstr "일반 모습<br>그리고 <u>밑줄</u>. "
+
+#: ../src/html/helpwnd.cpp:1257
+msgid "<i>Italic face.</i> "
+msgstr "<i>기울임 모습.</i> "
+
+#: ../src/html/helpwnd.cpp:1258
+msgid "<b>Bold face.</b> "
+msgstr "<b>굵게 모습.</b> "
+
+#: ../src/html/helpwnd.cpp:1259
+msgid "<b><i>Bold italic face.</i></b><br>"
+msgstr "<b><i>굵게 기울임 모습.</i></b><br>"
+
+#: ../src/html/helpwnd.cpp:1262
+msgid "Fixed size face.<br> <b>bold</b> <i>italic</i> "
+msgstr "고정 폭 모습.<br> <b>굵게</b> <i>기울임</i> "
+
+#: ../src/html/helpwnd.cpp:1263
+msgid "<b><i>bold italic <u>underlined</u></i></b><br>"
+msgstr "<b><i>굵게 기울임 <u>밑줄</u></i></b><br>"
+
+#: ../src/html/helpwnd.cpp:1524
+msgid "Help Printing"
+msgstr "인쇄 도움말"
+
+#: ../src/html/helpwnd.cpp:1527
+msgid "Cannot print empty page."
+msgstr "빈 페이지를 인쇄할 수 없습니다."
+
+#: ../src/html/helpwnd.cpp:1540
+msgid "HTML files (*.html;*.htm)|*.html;*.htm|"
+msgstr "HTML 파일 (*.html;*.htm)|*.html;*.htm|"
+
+#: ../src/html/helpwnd.cpp:1541
+msgid "Help books (*.htb)|*.htb|Help books (*.zip)|*.zip|"
+msgstr "도움말 문서 (*.htb)|*.htb|Help books (*.zip)|*.zip|"
+
+#: ../src/html/helpwnd.cpp:1542
+msgid "HTML Help Project (*.hhp)|*.hhp|"
+msgstr "HTML 도움말 프로젝트 (*.hhp)|*.hhp|"
+
+#: ../src/html/helpwnd.cpp:1544
+msgid "Compressed HTML Help file (*.chm)|*.chm|"
+msgstr "압축된 HTML 도움말 파일 (*.chm)|*.chm|"
+
+#: ../src/html/helpwnd.cpp:1671
+#, fuzzy, c-format
+msgid "%i of %u"
+msgstr "%i / %i"
+
+#: ../src/html/helpwnd.cpp:1709
+#, fuzzy, c-format
+msgid "%u of %u"
+msgstr "%i / %i"
+
+#: ../src/html/htmlfilt.cpp:134
+#, c-format
+msgid "Cannot open HTML document: %s"
+msgstr "HTML 문서를 열 수 없습니다: %s"
+
+#: ../src/html/htmlwin.cpp:599
+msgid "Connecting..."
+msgstr "연결중..."
+
+#: ../src/html/htmlwin.cpp:616
+#, c-format
+msgid "Unable to open requested HTML document: %s"
+msgstr "HTML 문서를 열 수 없습니다: %s"
+
+#: ../src/html/htmlwin.cpp:630
+msgid "Loading : "
+msgstr "불러오는 중:"
+
+#: ../src/html/htmlwin.cpp:673
+msgid "Done"
+msgstr "완료"
+
+#: ../src/html/htmlwin.cpp:723
+#, c-format
+msgid "HTML anchor %s does not exist."
+msgstr "HTML anchor %s 가 없습니다."
+
+#: ../src/html/htmlwin.cpp:1057
+#, c-format
+msgid "Copied to clipboard:\"%s\""
+msgstr "클립보드로 복사:\"%s\""
+
+#: ../src/html/htmprint.cpp:269
+msgid ""
+"This document doesn't fit on the page horizontally and will be truncated "
+"when it is printed."
+msgstr ""
+
+#: ../src/html/htmprint.cpp:285
+#, c-format
+msgid ""
+"The document \"%s\" doesn't fit on the page horizontally and will be "
+"truncated if printed.\n"
+"\n"
+"Would you like to proceed with printing it nevertheless?"
+msgstr ""
+
+#: ../src/html/htmprint.cpp:296
+msgid ""
+"If possible, try changing the layout parameters to make the printout more "
+"narrow."
+msgstr ""
+
+#: ../src/html/htmprint.cpp:445
+msgid ": file does not exist!"
+msgstr ": 파일이 존재하지 않습니다!"
+
+#. TRANSLATORS: %s may be a document title.
+#: ../src/html/htmprint.cpp:717
+#, fuzzy, c-format
+msgid "%s Preview"
+msgstr " 미리보기"
+
+#: ../src/html/htmprint.cpp:755 ../src/richtext/richtextprint.cpp:618
+msgid ""
+"There was a problem during page setup: you may need to set a default printer."
+msgstr ""
+"페이지를 설정하는 동안 문제가 발생했습니다. 기본프린터를 설정해 주세요."
+
+#: ../src/msw/clipbrd.cpp:80
+msgid "Failed to open the clipboard."
+msgstr "클립보드를 여는 데 실패했습니다."
+
+#: ../src/msw/clipbrd.cpp:101
+msgid "Failed to close the clipboard."
+msgstr "클립보드를 닫는 데 실패했습니다."
+
+#: ../src/msw/clipbrd.cpp:113
+msgid "Failed to empty the clipboard."
+msgstr "클립보드를 비우는데 실패했습니다."
+
+#: ../src/msw/clipbrd.cpp:284
+msgid "Failed to put data on the clipboard"
+msgstr "클립보드에 데이타 추가 실패"
+
+#: ../src/msw/clipbrd.cpp:326
+msgid "Failed to get data from the clipboard"
+msgstr "클립보드 데이타를 가져오는데 실패했습니다."
+
+#: ../src/msw/clipbrd.cpp:363
+msgid "Failed to retrieve the supported clipboard formats"
+msgstr "제공되는 클립보드 포맷을 찾을 수 없습니다."
+
+#: ../src/msw/colordlg.cpp:228
+#, c-format
+msgid "Colour selection dialog failed with error %0lx."
+msgstr "색상 선택창에서 오류 발생 : %0lx"
+
+#: ../src/msw/cursor.cpp:141
+msgid "Failed to create cursor."
+msgstr "마우스 커서 생성을 실패했습니다."
+
+#: ../src/msw/dde.cpp:279
+#, c-format
+msgid "Failed to register DDE server '%s'"
+msgstr "'%s' DDE 서버 등록 실패"
+
+#: ../src/msw/dde.cpp:300
+#, c-format
+msgid "Failed to unregister DDE server '%s'"
+msgstr "등록된 '%s' DDE 서버를 제거하는데 실패했습니다. "
+
+#: ../src/msw/dde.cpp:428
+#, c-format
+msgid "Failed to create connection to server '%s' on topic '%s'"
+msgstr "'%s' 서버의 '%s' 서비스로의 접속을 실패 했습니다."
+
+#: ../src/msw/dde.cpp:655
+msgid "DDE poke request failed"
+msgstr "DDE 로 데이타 전송 실패"
+
+#: ../src/msw/dde.cpp:674
+msgid "Failed to establish an advise loop with DDE server"
+msgstr "DDE 서버의 어드바이스 루프로의 연결을 실패 했습니다."
+
+#: ../src/msw/dde.cpp:693
+msgid "Failed to terminate the advise loop with DDE server"
+msgstr "DDE 서버의 어드바이스를 종료할 수 없습니다."
+
+#: ../src/msw/dde.cpp:768
+msgid "Failed to send DDE advise notification"
+msgstr "DDE 어드바이서에서 통지 전송을 실패했습니다"
+
+#: ../src/msw/dde.cpp:1085
+msgid "Failed to create DDE string"
+msgstr "DDE 문자열 생성을 실패 했습니다."
+
+#: ../src/msw/dde.cpp:1131
+msgid "no DDE error."
+msgstr "DDE 오류 없음."
+
+#: ../src/msw/dde.cpp:1135
+msgid "a request for a synchronous advise transaction has timed out."
+msgstr "어브바이스 트랜잭션에 대한 동기화 요청이 제한 시간을 초과했습니다."
+
+#: ../src/msw/dde.cpp:1138
+msgid "the response to the transaction caused the DDE_FBUSY bit to be set."
+msgstr "DDE 오류: DMLERR_BUSY 상태"
+
+#: ../src/msw/dde.cpp:1141
+msgid "a request for a synchronous data transaction has timed out."
+msgstr "데이터 트랜잭션에 대한  동기화 요청이 제한 시간을 초과했습니다."
+
+#: ../src/msw/dde.cpp:1144
+msgid ""
+"a DDEML function was called without first calling the DdeInitialize "
+"function,\n"
+"or an invalid instance identifier\n"
+"was passed to a DDEML function."
+msgstr ""
+"a DDEML 함수를 사용하지 전에 반드시 DdeInitialize 함수를 호출해야 합니다,\n"
+"혹은 DDEML 함수에 전달된 인스턴스 ID가\n"
+"잘못되엇습니다."
+
+#: ../src/msw/dde.cpp:1147
+msgid ""
+"an application initialized as APPCLASS_MONITOR has\n"
+"attempted to perform a DDE transaction,\n"
+"or an application initialized as APPCMD_CLIENTONLY has \n"
+"attempted to perform server transactions."
+msgstr ""
+"APPCLASS_MONITOR 에서 초기화된 프로그램이\n"
+"DDE 트랜잭션을 시도함,\n"
+"혹은 APPCMD_CLIENTONLY에서 초기화된 프로그램이\n"
+"서버 트랜잭션을 시도했습니다."
+
+#: ../src/msw/dde.cpp:1150
+msgid "a request for a synchronous execute transaction has timed out."
+msgstr "트랜잭션을 실행에 대한 동기화 요청이 시간이 초과되었습니다."
+
+#: ../src/msw/dde.cpp:1153
+msgid "a parameter failed to be validated by the DDEML."
+msgstr "DDEML 오류: 잘못된 파라미터 전달"
+
+#: ../src/msw/dde.cpp:1156
+msgid "a DDEML application has created a prolonged race condition."
+msgstr "프로그램이 경쟁 상태에 빠졋습니다."
+
+#: ../src/msw/dde.cpp:1159
+msgid "a memory allocation failed."
+msgstr "메모리가 부족합니다."
+
+#: ../src/msw/dde.cpp:1162
+msgid "a client's attempt to establish a conversation has failed."
+msgstr "클라이언트의 연결시도가 실패했습니다."
+
+#: ../src/msw/dde.cpp:1165
+msgid "a transaction failed."
+msgstr "트랜잭션에 실패했습니다."
+
+#: ../src/msw/dde.cpp:1168
+msgid "a request for a synchronous poke transaction has timed out."
+msgstr "포크 트랜잭션에 대한 동기화 요청이 제한 시간을 초과했습니다."
+
+#: ../src/msw/dde.cpp:1171
+msgid "an internal call to the PostMessage function has failed. "
+msgstr "내부 호출을 통한 PostMessage 함수 호출이 실패했습니다."
+
+#: ../src/msw/dde.cpp:1174
+msgid "reentrancy problem."
+msgstr "재진입 문제 발생."
+
+#: ../src/msw/dde.cpp:1177
+msgid ""
+"a server-side transaction was attempted on a conversation\n"
+"that was terminated by the client, or the server\n"
+"terminated before completing a transaction."
+msgstr ""
+"트랜잭션이 실패 했습니다.\n"
+"트랜잭션이 종료되지 전에\n"
+"서버또는 클라이언트가 종료 되었습니다."
+
+#: ../src/msw/dde.cpp:1180
+msgid "an internal error has occurred in the DDEML."
+msgstr "DDEML: 시스템 오류 발생"
+
+#: ../src/msw/dde.cpp:1183
+msgid "a request to end an advise transaction has timed out."
+msgstr "어브바이스 트랜잭션에 대한 종료 요청이 제한 시간을 초과했습니다."
+
+#: ../src/msw/dde.cpp:1186
+msgid ""
+"an invalid transaction identifier was passed to a DDEML function.\n"
+"Once the application has returned from an XTYP_XACT_COMPLETE callback,\n"
+"the transaction identifier for that callback is no longer valid."
+msgstr ""
+"an invalid transaction identifier was passed to a DDEML 에서 트랜잭션 ID(큐"
+"ID)를 찾을 수 없습니다..\n"
+"XTYP_XACT_COMPLETE 콜백함수에서 일단 프로그램으로 돌아옴,\n"
+"콜백을 위한 트랜잭션 ID(큐ID)가 더이상 유효하지 않습니다."
+
+#: ../src/msw/dde.cpp:1189
+#, c-format
+msgid "Unknown DDE error %08x"
+msgstr "%08x 의 DDE 오류 메세지를 찾을 수 없습니다."
+
+#: ../src/msw/dialup.cpp:343
+msgid ""
+"Dial up functions are unavailable because the remote access service (RAS) is "
+"not installed on this machine. Please install it."
+msgstr "RAS가 설치되지 않아 전화 연결을 할수 없습니다. RAS 설치해 주십시오. "
+
+#: ../src/msw/dialup.cpp:402
+#, c-format
+msgid ""
+"The version of remote access service (RAS) installed on this machine is too "
+"old, please upgrade (the following required function is missing: %s)."
+msgstr ""
+"RAS 버전이 오래되었습니다. 업데이트를 확인해 주세요(다음의 함수들을 지원하지 "
+"않습니다: %s)."
+
+#: ../src/msw/dialup.cpp:437
+msgid "Failed to retrieve text of RAS error message"
+msgstr "RAS 오류 메시지의 텍스트의 검색 실패"
+
+#: ../src/msw/dialup.cpp:440
+#, c-format
+msgid "unknown error (error code %08x)."
+msgstr "알 수 없는 오류 (오류 코드 %08x)."
+
+#: ../src/msw/dialup.cpp:492
+#, c-format
+msgid "Cannot find active dialup connection: %s"
+msgstr "동작중인 전화 연결을 찾을수 없습니다: %s"
+
+#: ../src/msw/dialup.cpp:513
+msgid "Several active dialup connections found, choosing one randomly."
+msgstr "여러개의 활성화된 전화연결을 찾았습니다. 임의로 하나를 선택합니다."
+
+#: ../src/msw/dialup.cpp:598 ../src/msw/dialup.cpp:832
+#, c-format
+msgid "Failed to establish dialup connection: %s"
+msgstr "%s 에 dialup 연결을 실패했습니다."
+
+#: ../src/msw/dialup.cpp:664
+#, c-format
+msgid "Failed to get ISP names: %s"
+msgstr "ISP 이름을 가져오기 실패: %s"
+
+#: ../src/msw/dialup.cpp:712
+msgid "Failed to connect: no ISP to dial."
+msgstr "접속 실패: 전화 접속을 위한 ISP가 없음"
+
+#: ../src/msw/dialup.cpp:732
+msgid "Choose ISP to dial"
+msgstr "ISP에 전화 연결 "
+
+#: ../src/msw/dialup.cpp:733
+msgid "Please choose which ISP do you want to connect to"
+msgstr "연결할 ISP를 선택하십시오."
+
+#: ../src/msw/dialup.cpp:766
+msgid "Failed to connect: missing username/password."
+msgstr "접속 실패: ID 또는 Password가 잘못되었습니다."
+
+#: ../src/msw/dialup.cpp:796
+msgid "Cannot find the location of address book file"
+msgstr "주소록 파일에서 위치를 찾을 수 없습니다."
+
+#: ../src/msw/dialup.cpp:827
+#, c-format
+msgid "Failed to initiate dialup connection: %s"
+msgstr "dialup 연결을 초기화 하는데 실패: %s"
+
+#: ../src/msw/dialup.cpp:897
+msgid "Cannot hang up - no active dialup connection."
+msgstr "접속을 끊을 수 없습니다 - 현재 활성화된 전화 연결이 없습니다."
+
+#: ../src/msw/dialup.cpp:907
+#, c-format
+msgid "Failed to terminate the dialup connection: %s"
+msgstr "전화연결 종료 실패: %s"
+
+#: ../src/msw/dib.cpp:313
+#, c-format
+msgid "Failed to save the bitmap image to file \"%s\"."
+msgstr "\"%s\" 비트맵 이미지 파을을 저장하는데 실패했습니다."
+
+#: ../src/msw/dib.cpp:543
+#, fuzzy, c-format
+msgid "Failed to allocate %luKb of memory for bitmap data."
+msgstr "비트맵 데이타를  위한 메모리(%luKb) 할당이 실패했습니다."
+
+#: ../src/msw/dir.cpp:241
+#, c-format
+msgid "Cannot enumerate files in directory '%s'"
+msgstr "'%s' 폴더에서 파일을 찾을 수 없습니다."
+
+#: ../src/msw/dirdlg.cpp:368
+#, fuzzy
+msgid "Couldn't obtain folder name"
+msgstr "타이머를 생성할 수 없습니다."
+
+#: ../src/msw/dlmsw.cpp:163
+#, fuzzy, c-format
+msgid "(error %d: %s)"
+msgstr " (오류 %ld: %s)"
+
+#: ../src/msw/dragimag.cpp:143 ../src/msw/dragimag.cpp:178
+#: ../src/msw/imaglist.cpp:309 ../src/msw/imaglist.cpp:331
+msgid "Couldn't add an image to the image list."
+msgstr "이미지 목록에 이미지를 추가할 수 없습니다."
+
+#: ../src/msw/enhmeta.cpp:94
+#, c-format
+msgid "Failed to load metafile from file \"%s\"."
+msgstr "\"%s\" 파일에서 메타 파일을 읽어올 수 없습니다."
+
+#: ../src/msw/fdrepdlg.cpp:412
+#, c-format
+msgid "Failed to create the standard find/replace dialog (error code %d)"
+msgstr "표준 찾기/바꾸기 창 생성 실패(오류 코드 %d)"
+
+#: ../src/msw/filedlg.cpp:1241
+msgid "Access to the file system is not allowed from secure desktop."
+msgstr ""
+
+#: ../src/msw/filedlg.cpp:1242
+msgid "Security warning"
+msgstr ""
+
+#: ../src/msw/filedlg.cpp:1533
+#, fuzzy, c-format
+msgid "File dialog failed with error code %0lx."
+msgstr "색상 선택창에서 오류 발생 : %0lx"
+
+#: ../src/msw/font.cpp:1120
+#, fuzzy, c-format
+msgid "Font file \"%s\" couldn't be loaded"
+msgstr "파일을 읽어올 수 없습니다."
+
+#: ../src/msw/fontdlg.cpp:220
+#, fuzzy, c-format
+msgid "Common dialog failed with error code %0lx."
+msgstr "색상 선택창에서 오류 발생 : %0lx"
+
+#: ../src/msw/fswatcher.cpp:67
+#, fuzzy
+msgid "Ungraceful worker thread termination"
+msgstr "쓰레드 종료 실패로 Thread를 강제로 종료합니다"
+
+#: ../src/msw/fswatcher.cpp:81
+#, fuzzy
+msgid "Unable to create IOCP worker thread"
+msgstr "MDI의 프레임 생성을 실패 했습니다."
+
+#: ../src/msw/fswatcher.cpp:88
+msgid "Unable to start IOCP worker thread"
+msgstr ""
+
+#: ../src/msw/fswatcher.cpp:140
+msgid "Monitoring individual files for changes is not supported currently."
+msgstr ""
+
+#: ../src/msw/fswatcher.cpp:165
+#, fuzzy, c-format
+msgid "Unable to set up watch for '%s'"
+msgstr "'%s' 파일 만들기 실패"
+
+#: ../src/msw/fswatcher.cpp:466
+#, c-format
+msgid "Can't monitor non-existent directory \"%s\" for changes."
+msgstr ""
+
+#: ../src/msw/glcanvas.cpp:577 ../src/unix/glx11.cpp:507
+msgid "OpenGL 3.0 or later is not supported by the OpenGL driver."
+msgstr ""
+
+#: ../src/msw/glcanvas.cpp:601 ../src/osx/glcanvas_osx.cpp:395
+#: ../src/unix/glegl.cpp:304 ../src/unix/glx11.cpp:553
+#, fuzzy
+msgid "Couldn't create OpenGL context"
+msgstr "타이머를 생성할 수 없습니다."
+
+#: ../src/msw/glcanvas.cpp:1294
+msgid "Failed to initialize OpenGL"
+msgstr "OpenGL 초기화를 실패했습니다."
+
+#: ../src/msw/graphicsd2d.cpp:607
+msgid "Could not register custom DirectWrite font loader."
+msgstr ""
+
+#: ../src/msw/helpchm.cpp:48
+msgid ""
+"MS HTML Help functions are unavailable because the MS HTML Help library is "
+"not installed on this machine. Please install it."
+msgstr ""
+"MS HTML Help SDK가 설치되어 있지 않아 MS HTML Help 함수를 사용할 수 없습니"
+"다. "
+
+#: ../src/msw/helpchm.cpp:55
+msgid "Failed to initialize MS HTML Help."
+msgstr "MS HTML 도움말 초기화 실패."
+
+#: ../src/msw/iniconf.cpp:458
+#, c-format
+msgid "Can't delete the INI file '%s'"
+msgstr "'%s' INI 파일을 삭제할 수 없습니다."
+
+#: ../src/msw/listctrl.cpp:995
+#, c-format
+msgid "Couldn't retrieve information about list control item %d."
+msgstr "목록보기 에서  아이템 %d 의 정보를 가져올 수 없습니다.  "
+
+#: ../src/msw/mdi.cpp:170 ../src/qt/mdi.cpp:253
+msgid "&Cascade"
+msgstr "계단식(&C)"
+
+#: ../src/msw/mdi.cpp:171
+msgid "Tile &Horizontally"
+msgstr "수평 타일"
+
+#: ../src/msw/mdi.cpp:172
+msgid "Tile &Vertically"
+msgstr "수직 타일"
+
+#: ../src/msw/mdi.cpp:174
+msgid "&Arrange Icons"
+msgstr "아이콘 표시(&A)"
+
+#: ../src/msw/mdi.cpp:621
+msgid "Failed to create MDI parent frame."
+msgstr "MDI의 프레임 생성을 실패 했습니다."
+
+#: ../src/msw/mimetype.cpp:234
+#, c-format
+msgid "Failed to create registry entry for '%s' files."
+msgstr "'%s' 타입의 파일실행을 위한 레지스터 키 등록을 실패했습니다."
+
+#: ../src/msw/ole/automtn.cpp:495
+#, fuzzy, c-format
+msgid "Failed to find CLSID of \"%s\""
+msgstr "'%s' 디스플레이를 여는 데 실패했습니다."
+
+#: ../src/msw/ole/automtn.cpp:512
+#, fuzzy, c-format
+msgid "Failed to create an instance of \"%s\""
+msgstr "디렉토리 \"%s\" 생성을 실패했습니다."
+
+#: ../src/msw/ole/automtn.cpp:552
+#, fuzzy, c-format
+msgid "Cannot get an active instance of \"%s\""
+msgstr "동작중인 전화 연결을 찾을수 없습니다: %s"
+
+#: ../src/msw/ole/automtn.cpp:564
+#, fuzzy, c-format
+msgid "Failed to get OLE automation interface for \"%s\""
+msgstr "디렉토리 \"%s\" 생성을 실패했습니다."
+
+#: ../src/msw/ole/automtn.cpp:621
+msgid "Unknown name or named argument."
+msgstr ""
+
+#: ../src/msw/ole/automtn.cpp:625
+msgid "Incorrect number of arguments."
+msgstr ""
+
+#: ../src/msw/ole/automtn.cpp:637
+#, fuzzy
+msgid "Unknown exception"
+msgstr "%s 옵션을 찾을 수 없습니다."
+
+#: ../src/msw/ole/automtn.cpp:642
+msgid "Method or property not found."
+msgstr ""
+
+#: ../src/msw/ole/automtn.cpp:646
+msgid "Overflow while coercing argument values."
+msgstr ""
+
+#: ../src/msw/ole/automtn.cpp:650
+msgid "Object implementation does not support named arguments."
+msgstr ""
+
+#: ../src/msw/ole/automtn.cpp:654
+msgid "The locale ID is unknown."
+msgstr ""
+
+#: ../src/msw/ole/automtn.cpp:658
+msgid "Missing a required parameter."
+msgstr ""
+
+#: ../src/msw/ole/automtn.cpp:662
+#, fuzzy, c-format
+msgid "Argument %u not found."
+msgstr "Column index를 찾을수 없습니다."
+
+#: ../src/msw/ole/automtn.cpp:666
+#, c-format
+msgid "Type mismatch in argument %u."
+msgstr ""
+
+#: ../src/msw/ole/automtn.cpp:670
+msgid "The system cannot find the file specified."
+msgstr ""
+
+#: ../src/msw/ole/automtn.cpp:674
+#, fuzzy
+msgid "Class not registered."
+msgstr "쓰레드 생성 할 수 없습니다"
+
+#: ../src/msw/ole/automtn.cpp:678
+#, fuzzy, c-format
+msgid "Unknown error %08x"
+msgstr "%08x 의 DDE 오류 메세지를 찾을 수 없습니다."
+
+#: ../src/msw/ole/automtn.cpp:682
+#, c-format
+msgid "OLE Automation error in %s: %s"
+msgstr ""
+
+#: ../src/msw/ole/dataobj.cpp:385
+#, c-format
+msgid "Couldn't register clipboard format '%s'."
+msgstr "%s 형식을 클립보드에 등록할 수 없습니다."
+
+#: ../src/msw/ole/dataobj.cpp:402
+#, c-format
+msgid "The clipboard format '%d' doesn't exist."
+msgstr "%d 포맷이 클립보드에 없습니다."
+
+#: ../src/msw/progdlg.cpp:1025
+msgid "Skip"
+msgstr "건너뛰기"
+
+#: ../src/msw/registry.cpp:141
+#, fuzzy, c-format
+msgid "unknown (%lu)"
+msgstr "알 수 없음"
+
+#: ../src/msw/registry.cpp:409
+#, c-format
+msgid "Can't get info about registry key '%s'"
+msgstr "레지스터 키 '%s' 의 정보를 가져올 수 없습니다."
+
+#: ../src/msw/registry.cpp:445
+#, c-format
+msgid "Can't open registry key '%s'"
+msgstr "레지스터 키 '%s' 를 열 수 없습니다."
+
+#: ../src/msw/registry.cpp:478
+#, c-format
+msgid "Can't create registry key '%s'"
+msgstr "레지스터 키 '%s'  생성 할 수 없습니다"
+
+#: ../src/msw/registry.cpp:497
+#, c-format
+msgid "Can't close registry key '%s'"
+msgstr "레지스터 키 '%s'  닫을 수 없습니다"
+
+#: ../src/msw/registry.cpp:512
+#, c-format
+msgid "Registry value '%s' already exists."
+msgstr "'%s' 레지스터 값이 이미 존재합니다."
+
+#: ../src/msw/registry.cpp:520
+#, c-format
+msgid "Failed to rename registry value '%s' to '%s'."
+msgstr "'%s' 레지스트 값을 '%s'로 변경 실패"
+
+#: ../src/msw/registry.cpp:575
+#, c-format
+msgid "Can't copy values of unsupported type %d."
+msgstr "%d는 지원되지 않는 데이타 타입으로 레지스트 값 복사 할 수 없습니다"
+
+#: ../src/msw/registry.cpp:586
+#, c-format
+msgid "Registry key '%s' does not exist, cannot rename it."
+msgstr "레지스트 키 '%s' 가 없어, 이름을 변경할 수 없습니다."
+
+#: ../src/msw/registry.cpp:617
+#, c-format
+msgid "Registry key '%s' already exists."
+msgstr "'%s' 레지스터 키가 이미 존재합니다."
+
+#: ../src/msw/registry.cpp:625
+#, c-format
+msgid "Failed to rename the registry key '%s' to '%s'."
+msgstr "'%s' 레지스트 키를 '%s'로 변경 실패"
+
+#: ../src/msw/registry.cpp:670
+#, c-format
+msgid "Failed to copy the registry subkey '%s' to '%s'."
+msgstr "레지스터 서브키 '%s' 에서 '%s' 로의 값 복사가 실패 했습니다."
+
+#: ../src/msw/registry.cpp:683
+#, c-format
+msgid "Failed to copy registry value '%s'"
+msgstr "레지스트 값 '%s' 을 복사하는데 실패했습니다."
+
+#: ../src/msw/registry.cpp:692
+#, c-format
+msgid "Failed to copy the contents of registry key '%s' to '%s'."
+msgstr "레지스터 키 '%s' 에서 '%s' 로 값 복사가 실패했습니다."
+
+#: ../src/msw/registry.cpp:718
+#, c-format
+msgid ""
+"Registry key '%s' is needed for normal system operation,\n"
+"deleting it will leave your system in unusable state:\n"
+"operation aborted."
+msgstr ""
+"레지스트 키 '%s' 는 기본 시스템에서 사용합니다.\n"
+"이 키를 지우시면 시스템이 불안전한 상태가 됩니다.:\n"
+"삭제를 취소 합니다."
+
+#: ../src/msw/registry.cpp:754
+#, c-format
+msgid "Can't delete key '%s'"
+msgstr "레지스터 키 '%s'  삭제 할 수 없습니다"
+
+#: ../src/msw/registry.cpp:782
+#, c-format
+msgid "Can't delete value '%s' from key '%s'"
+msgstr "레지스터 값 '%s' 을 지울수 없습니다(레지스터 키 '%s' 에서)"
+
+#: ../src/msw/registry.cpp:855 ../src/msw/registry.cpp:887
+#: ../src/msw/registry.cpp:929 ../src/msw/registry.cpp:1000
+#, c-format
+msgid "Can't read value of key '%s'"
+msgstr "레지스터 키값 '%s' 를 읽을 수 없습니다."
+
+#: ../src/msw/registry.cpp:873 ../src/msw/registry.cpp:915
+#: ../src/msw/registry.cpp:963 ../src/msw/registry.cpp:1106
+#, c-format
+msgid "Can't set value of '%s'"
+msgstr "레지스터 키 '%s' 의 값을 설정 할 수 없습니다."
+
+#: ../src/msw/registry.cpp:894 ../src/msw/registry.cpp:943
+#, c-format
+msgid "Registry value \"%s\" is not numeric (but of type %s)"
+msgstr ""
+
+#: ../src/msw/registry.cpp:979
+#, c-format
+msgid "Registry value \"%s\" is not binary (but of type %s)"
+msgstr ""
+
+#: ../src/msw/registry.cpp:1028
+#, c-format
+msgid "Registry value \"%s\" is not text (but of type %s)"
+msgstr ""
+
+#: ../src/msw/registry.cpp:1089
+#, c-format
+msgid "Can't read value of '%s'"
+msgstr "레지스터 키값 '%s' 를 읽을 수 없습니다."
+
+#: ../src/msw/registry.cpp:1157
+#, c-format
+msgid "Can't enumerate values of key '%s'"
+msgstr "레지스터 키값 '%s' 를 찾을 수 없습니다."
+
+#: ../src/msw/registry.cpp:1196
+#, c-format
+msgid "Can't enumerate subkeys of key '%s'"
+msgstr "레지스터 키 '%s' 의 하위 키들을 찾을 수 없습니다."
+
+#: ../src/msw/registry.cpp:1262
+#, c-format
+msgid ""
+"Exporting registry key: file \"%s\" already exists and won't be overwritten."
+msgstr "레지스터 키값 가져오기: 파일 \"%s\" 이미 존재합니다."
+
+#: ../src/msw/registry.cpp:1411
+#, c-format
+msgid "Can't export value of unsupported type %d."
+msgstr "지원되지 않는 %d 타입의 레지스트 값을 내보낼 수 없습니다."
+
+#: ../src/msw/registry.cpp:1427
+#, c-format
+msgid "Ignoring value \"%s\" of the key \"%s\"."
+msgstr "레지스터 값 \"%s\" 을 무시합니다.(레지스터 키 \"%s\" 에서)"
+
+#: ../src/msw/textctrl.cpp:596
+msgid ""
+"Impossible to create a rich edit control, using simple text control instead. "
+"Please reinstall riched32.dll"
+msgstr ""
+"Rich Edit 컨트롤을 생성할 수 없어 Simple Text 컨트롤로 대체 하였습니다. "
+"riched32.dll 을 재설치 하십시오."
+
+#: ../src/msw/thread.cpp:522 ../src/unix/threadpsx.cpp:850
+msgid "Cannot start thread: error writing TLS."
+msgstr "쓰레드 시작 실패: TLS 쓰기 오류."
+
+#: ../src/msw/thread.cpp:613
+msgid "Can't set thread priority"
+msgstr "쓰레드 우선 순위를 설정할 수 없습니다."
+
+#: ../src/msw/thread.cpp:649
+msgid "Can't create thread"
+msgstr "쓰레드 생성 할 수 없습니다"
+
+#: ../src/msw/thread.cpp:668
+msgid "Couldn't terminate thread"
+msgstr "스레드를 종료할 수없습니다."
+
+#: ../src/msw/thread.cpp:799
+msgid "Cannot wait for thread termination"
+msgstr "쓰레드 종료 실패로 Thread를 강제로 종료합니다"
+
+#: ../src/msw/thread.cpp:873
+#, fuzzy, c-format
+msgid "Cannot suspend thread %lx"
+msgstr "쓰레드 %x 일시정지 할 수 없습니다"
+
+#: ../src/msw/thread.cpp:903
+#, fuzzy, c-format
+msgid "Cannot resume thread %lx"
+msgstr "쓰레드 %x 를 다시시작 할 수 없습니다"
+
+#: ../src/msw/thread.cpp:932
+msgid "Couldn't get the current thread pointer"
+msgstr "현재 쓰레드 포인터를 얻지 못했습니다."
+
+#: ../src/msw/thread.cpp:1333
+msgid ""
+"Thread module initialization failed: impossible to allocate index in thread "
+"local storage"
+msgstr "쓰레드 모듈 초기화 실패:TLS 인덱스 할당 실패"
+
+#: ../src/msw/thread.cpp:1345
+msgid ""
+"Thread module initialization failed: cannot store value in thread local "
+"storage"
+msgstr "쓰레드 모듈 초기화 실패:TLS 초기화 실패 "
+
+#: ../src/msw/timer.cpp:133
+msgid "Couldn't create a timer"
+msgstr "타이머를 생성할 수 없습니다."
+
+#: ../src/msw/utils.cpp:372
+msgid "can't find user's HOME, using current directory."
+msgstr "홈 디렉토리를 찾을수 없어 현재 디렉토리를 사용합니다."
+
+#: ../src/msw/utils.cpp:662
+#, c-format
+msgid "Failed to kill process %d"
+msgstr "프로세스 %d 종료할 수 없습니다."
+
+#: ../src/msw/utils.cpp:986
+#, fuzzy, c-format
+msgid "Failed to load resource \"%s\"."
+msgstr "\"%s\" 파일에서 메타 파일을 읽어올 수 없습니다."
+
+#: ../src/msw/utils.cpp:993
+#, fuzzy, c-format
+msgid "Failed to lock resource \"%s\"."
+msgstr "'%s' 잠금 파일의 잠금 실패 "
+
+#. TRANSLATORS: MS Windows build number
+#: ../src/msw/utils.cpp:1209
+#, c-format
+msgid "build %lu"
+msgstr ""
+
+#: ../src/msw/utils.cpp:1218
+msgid ", 64-bit edition"
+msgstr ""
+
+#: ../src/msw/utilsexc.cpp:224
+msgid "Failed to create an anonymous pipe"
+msgstr "익명 파이프 생성을 실패했습니다."
+
+#: ../src/msw/utilsexc.cpp:697
+msgid "Failed to redirect the child process IO"
+msgstr "자식 프로세스의 입출력 리다이렉트 실패"
+
+#: ../src/msw/utilsexc.cpp:870
+#, c-format
+msgid "Execution of command '%s' failed"
+msgstr "'%s' 명령 실행 실패"
+
+#: ../src/msw/volume.cpp:337
+msgid "Failed to load mpr.dll."
+msgstr "mpr.dll 을 읽어올 수 없습니다."
+
+#: ../src/msw/volume.cpp:506
+#, c-format
+msgid "Cannot read typename from '%s'!"
+msgstr "'%s' 에서 장치이름을 읽어올 수 없습니다."
+
+#: ../src/msw/volume.cpp:615
+#, c-format
+msgid "Cannot load icon from '%s'."
+msgstr "'%s' 아이콘을 읽어올 수 없습니다."
+
+#: ../src/msw/webview_edge.cpp:285
+msgid "This program was compiled without support for setting Edge proxy."
+msgstr ""
+
+#: ../src/msw/webview_ie.cpp:1010
+msgid "Failed to find web view emulation level in the registry"
+msgstr ""
+
+#: ../src/msw/webview_ie.cpp:1019
+msgid "Failed to set web view to modern emulation level"
+msgstr ""
+
+#: ../src/msw/webview_ie.cpp:1027
+msgid "Failed to reset web view to standard emulation level"
+msgstr ""
+
+#: ../src/msw/webview_ie.cpp:1049
+msgid "Can't run JavaScript script without a valid HTML document"
+msgstr ""
+
+#: ../src/msw/webview_ie.cpp:1056
+#, fuzzy
+msgid "Can't get the JavaScript object"
+msgstr "쓰레드 우선 순위를 설정할 수 없습니다."
+
+#: ../src/msw/webview_ie.cpp:1070
+#, fuzzy
+msgid "failed to evaluate"
+msgstr "'%s' 실행을 실패했습니다.\n"
+
+#: ../src/osx/cocoa/filedlg.mm:412
+#, fuzzy
+msgid "File type:"
+msgstr "파일 오류"
+
+#: ../src/osx/cocoa/menu.mm:242
+#, fuzzy
+msgctxt "macOS menu name"
+msgid "Window"
+msgstr "창(&W)"
+
+#: ../src/osx/cocoa/menu.mm:259
+#, fuzzy
+msgctxt "macOS menu name"
+msgid "Help"
+msgstr "도움말"
+
+#: ../src/osx/cocoa/menu.mm:298
+#, fuzzy
+msgctxt "macOS menu item"
+msgid "Minimize"
+msgstr "최소화(&N)"
+
+#: ../src/osx/cocoa/menu.mm:303
+#, fuzzy
+msgctxt "macOS menu item"
+msgid "Zoom"
+msgstr "확대(&I)"
+
+#: ../src/osx/cocoa/menu.mm:309
+msgctxt "macOS menu item"
+msgid "Bring All to Front"
+msgstr ""
+
+#: ../src/osx/core/sound.cpp:143
+#, fuzzy, c-format
+msgid "Failed to load sound from \"%s\" (error %d)."
+msgstr "\"%s\" 파일에서 메타 파일을 읽어올 수 없습니다."
+
+#: ../src/osx/fontutil.cpp:80
+#, fuzzy, c-format
+msgid "Font file \"%s\" doesn't exist."
+msgstr "%s 파일이 없습니다."
+
+#: ../src/osx/fontutil.cpp:88
+#, c-format
+msgid ""
+"Font file \"%s\" cannot be used as it is not inside the font directory "
+"\"%s\"."
+msgstr ""
+
+#: ../src/osx/menu_osx.cpp:496
+#, c-format
+msgctxt "macOS menu item"
+msgid "About %s"
+msgstr "%s 정보"
+
+#: ../src/osx/menu_osx.cpp:499
+#, fuzzy
+msgctxt "macOS menu item"
+msgid "About..."
+msgstr "이 프로그램은(&A)"
+
+#: ../src/osx/menu_osx.cpp:508
+#, fuzzy
+msgctxt "macOS menu item"
+msgid "Preferences..."
+msgstr "설정(&P)"
+
+#: ../src/osx/menu_osx.cpp:512
+msgctxt "macOS menu item"
+msgid "Services"
+msgstr ""
+
+#: ../src/osx/menu_osx.cpp:519
+#, fuzzy, c-format
+msgctxt "macOS menu item"
+msgid "Hide %s"
+msgstr "도움말: %s"
+
+#: ../src/osx/menu_osx.cpp:522
+#, fuzzy
+msgctxt "macOS menu item"
+msgid "Hide Application"
+msgstr "선택"
+
+#: ../src/osx/menu_osx.cpp:526
+msgctxt "macOS menu item"
+msgid "Hide Others"
+msgstr ""
+
+#: ../src/osx/menu_osx.cpp:528
+#, fuzzy
+msgctxt "macOS menu item"
+msgid "Show All"
+msgstr "모두 표시"
+
+#: ../src/osx/menu_osx.cpp:534
+#, fuzzy, c-format
+msgctxt "macOS menu item"
+msgid "Quit %s"
+msgstr "종료(&Q)"
+
+#: ../src/osx/menu_osx.cpp:537
+#, fuzzy
+msgctxt "macOS menu item"
+msgid "Quit Application"
+msgstr "선택"
+
+#: ../src/osx/webview_webkit.mm:444
+#, fuzzy
+msgid "Printing is not supported by the system web control"
+msgstr "사용중인 zlib 버전에서 Gzip을 지원하지 않습니다."
+
+#: ../src/osx/webview_webkit.mm:453
+#, fuzzy
+msgid "Print operation could not be initialized"
+msgstr "Column 정보를 초기화 할 수 없습니다."
+
+#. TRANSLATORS: Label of font point size
+#: ../src/propgrid/advprops.cpp:605
+#, fuzzy
+msgid "Point Size"
+msgstr "크기(&P):"
+
+#. TRANSLATORS: Label of font face name
+#: ../src/propgrid/advprops.cpp:615
+#, fuzzy
+msgid "Face Name"
+msgstr "새 이름"
+
+#. TRANSLATORS: Label of font style
+#: ../src/propgrid/advprops.cpp:623 ../src/richtext/richtextformatdlg.cpp:331
+msgid "Style"
+msgstr "모양새"
+
+#. TRANSLATORS: Label of font weight
+#: ../src/propgrid/advprops.cpp:628
+#, fuzzy
+msgid "Weight"
+msgstr "두께(&W):"
+
+#. TRANSLATORS: Label of underlined font
+#: ../src/propgrid/advprops.cpp:633 ../src/richtext/richtextfontpage.cpp:358
+msgid "Underlined"
+msgstr "밑줄"
+
+#. TRANSLATORS: Label of font family
+#: ../src/propgrid/advprops.cpp:637
+#, fuzzy
+msgid "Family"
+msgstr "글꼴 패밀리(&F):"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:801
+msgid "AppWorkspace"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:802
+#, fuzzy
+msgid "ActiveBorder"
+msgstr "Modern"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:803
+msgid "ActiveCaption"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:804
+msgid "ButtonFace"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:805
+msgid "ButtonHighlight"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:806
+msgid "ButtonShadow"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:807
+msgid "ButtonText"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:808
+msgid "CaptionText"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:809
+msgid "ControlDark"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:810
+msgid "ControlLight"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:812
+msgid "GrayText"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:813
+#, fuzzy
+msgid "Highlight"
+msgstr "가늘게"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:814
+#, fuzzy
+msgid "HighlightText"
+msgstr "텍스트 오른쪽 정렬"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:815
+#, fuzzy
+msgid "InactiveBorder"
+msgstr "Modern"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:816
+msgid "InactiveCaption"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:817
+msgid "InactiveCaptionText"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:818
+msgid "Menu"
+msgstr "메뉴"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:819
+msgid "Scrollbar"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:820
+msgid "Tooltip"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:821
+msgid "TooltipText"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:822
+#, fuzzy
+msgid "Window"
+msgstr "창(&W)"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:823
+#, fuzzy
+msgid "WindowFrame"
+msgstr "창(&W)"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:824
+#, fuzzy
+msgid "WindowText"
+msgstr "창(&W)"
+
+#. TRANSLATORS: Custom colour choice entry
+#: ../src/propgrid/advprops.cpp:825 ../src/propgrid/advprops.cpp:1532
+#: ../src/propgrid/advprops.cpp:1576
+#, fuzzy
+msgid "Custom"
+msgstr "사용자 지정 크기"
+
+#: ../src/propgrid/advprops.cpp:1558
+msgid "Black"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1559
+msgid "Maroon"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1560
+msgid "Navy"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1561
+msgid "Purple"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1562
+msgid "Teal"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1563
+msgid "Gray"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1564
+msgid "Green"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1565
+msgid "Olive"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1566
+#, fuzzy
+msgid "Brown"
+msgstr "탐색창"
+
+#: ../src/propgrid/advprops.cpp:1567
+msgid "Blue"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1568
+msgid "Fuchsia"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1569
+#, fuzzy
+msgid "Red"
+msgstr "다시 실행"
+
+#: ../src/propgrid/advprops.cpp:1570
+msgid "Orange"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1571
+msgid "Silver"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1572
+msgid "Lime"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1573
+msgid "Aqua"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1574
+msgid "Yellow"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1575
+msgid "White"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1718
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Default"
+msgstr "기본값"
+
+#: ../src/propgrid/advprops.cpp:1719
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Arrow"
+msgstr "내일"
+
+#: ../src/propgrid/advprops.cpp:1720
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Right Arrow"
+msgstr "오른쪽"
+
+#: ../src/propgrid/advprops.cpp:1721
+msgctxt "system cursor name"
+msgid "Blank"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1722
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Bullseye"
+msgstr "글머리 모양새"
+
+#: ../src/propgrid/advprops.cpp:1723
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Character"
+msgstr "문자 코드(&C):"
+
+#: ../src/propgrid/advprops.cpp:1724
+msgctxt "system cursor name"
+msgid "Cross"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1725
+msgctxt "system cursor name"
+msgid "Hand"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1726
+msgctxt "system cursor name"
+msgid "I-Beam"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1727
+msgctxt "system cursor name"
+msgid "Left Button"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1728
+msgctxt "system cursor name"
+msgid "Magnifier"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1729
+msgctxt "system cursor name"
+msgid "Middle Button"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1730
+msgctxt "system cursor name"
+msgid "No Entry"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1731
+msgctxt "system cursor name"
+msgid "Paint Brush"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1732
+msgctxt "system cursor name"
+msgid "Pencil"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1733
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Point Left"
+msgstr "크기(&P):"
+
+#: ../src/propgrid/advprops.cpp:1734
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Point Right"
+msgstr "오른쪽 정렬"
+
+#: ../src/propgrid/advprops.cpp:1735
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Question Arrow"
+msgstr "질문"
+
+#: ../src/propgrid/advprops.cpp:1736
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Right Button"
+msgstr "오른쪽"
+
+#: ../src/propgrid/advprops.cpp:1737
+msgctxt "system cursor name"
+msgid "Sizing NE-SW"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1738
+msgctxt "system cursor name"
+msgid "Sizing N-S"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1739
+msgctxt "system cursor name"
+msgid "Sizing NW-SE"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1740
+msgctxt "system cursor name"
+msgid "Sizing W-E"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1741
+msgctxt "system cursor name"
+msgid "Sizing"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1742
+msgctxt "system cursor name"
+msgid "Spraycan"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1743
+msgctxt "system cursor name"
+msgid "Wait"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1744
+msgctxt "system cursor name"
+msgid "Watch"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1745
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Wait Arrow"
+msgstr "오른쪽"
+
+#: ../src/propgrid/advprops.cpp:2109
+#, fuzzy
+msgid "Make a selection:"
+msgstr "선택한 부분을 붙여 넣기"
+
+#: ../src/propgrid/manager.cpp:394
+#, fuzzy
+msgid "Property"
+msgstr "특성(&P)"
+
+#: ../src/propgrid/manager.cpp:395
+msgid "Value"
+msgstr ""
+
+#: ../src/propgrid/manager.cpp:1683
+msgid "Categorized Mode"
+msgstr ""
+
+#: ../src/propgrid/manager.cpp:1709
+msgid "Alphabetic Mode"
+msgstr ""
+
+#. TRANSLATORS: Name of Boolean false value
+#: ../src/propgrid/propgrid.cpp:230
+#, fuzzy
+msgid "False"
+msgstr "파일"
+
+#. TRANSLATORS: Name of Boolean true value
+#: ../src/propgrid/propgrid.cpp:232
+msgid "True"
+msgstr ""
+
+#. TRANSLATORS: Text  displayed for unspecified value
+#: ../src/propgrid/propgrid.cpp:428
+#, fuzzy
+msgid "Unspecified"
+msgstr "정렬"
+
+#. TRANSLATORS: Caption of message box displaying any property error
+#: ../src/propgrid/propgrid.cpp:3145 ../src/propgrid/propgrid.cpp:3282
+#, fuzzy
+msgid "Property Error"
+msgstr "인쇄 오류"
+
+#: ../src/propgrid/propgrid.cpp:3259
+msgid "You have entered invalid value. Press ESC to cancel editing."
+msgstr ""
+
+#: ../src/propgrid/propgrid.cpp:6608
+#, c-format
+msgid "Error in resource: %s"
+msgstr ""
+
+#: ../src/propgrid/propgridiface.cpp:377
+#, c-format
+msgid ""
+"Type operation \"%s\" failed: Property labeled \"%s\" is of type \"%s\", NOT "
+"\"%s\"."
+msgstr ""
+
+#: ../src/propgrid/props.cpp:159
+#, c-format
+msgid "Unknown base %d. Base 10 will be used."
+msgstr ""
+
+#: ../src/propgrid/props.cpp:324
+#, c-format
+msgid "Value must be %s or higher."
+msgstr ""
+
+#: ../src/propgrid/props.cpp:329 ../src/propgrid/props.cpp:356
+#, fuzzy, c-format
+msgid "Value must be between %s and %s."
+msgstr "%d 와 %d 사의의 페이지 번호를 입력 하십시오."
+
+#: ../src/propgrid/props.cpp:351
+#, c-format
+msgid "Value must be %s or less."
+msgstr ""
+
+#: ../src/propgrid/props.cpp:1058
+#, fuzzy, c-format
+msgid "Not %s"
+msgstr "%s 정보"
+
+#: ../src/propgrid/props.cpp:1770
+#, fuzzy
+msgid "Choose a directory:"
+msgstr "디렉토리 생성"
+
+#: ../src/propgrid/props.cpp:2055
+#, fuzzy
+msgid "Choose a file"
+msgstr "글꼴 선택"
+
+#: ../src/qt/mdi.cpp:254
+msgid "&Tile"
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:147
+#: ../src/richtext/richtextformatdlg.cpp:376
+#, fuzzy
+msgid "Background"
+msgstr "배경 색"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:159
+#, fuzzy
+msgid "Background &colour:"
+msgstr "배경 색"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:161
+#: ../src/richtext/richtextbackgroundpage.cpp:163
+#, fuzzy
+msgid "Enables a background colour."
+msgstr "배경 색"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:167
+#: ../src/richtext/richtextbackgroundpage.cpp:169
+#, fuzzy
+msgid "The background colour."
+msgstr "배경 색"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:178
+msgid "Shadow"
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:193
+msgid "Use &shadow"
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:195
+#: ../src/richtext/richtextbackgroundpage.cpp:197
+#, fuzzy
+msgid "Enables a shadow."
+msgstr "배경 색"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:211
+msgid "&Horizontal offset:"
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:218
+#: ../src/richtext/richtextbackgroundpage.cpp:220
+#, fuzzy
+msgid "The horizontal offset."
+msgstr "수평 타일"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:224
+#: ../src/richtext/richtextbackgroundpage.cpp:227
+#: ../src/richtext/richtextbackgroundpage.cpp:228
+#: ../src/richtext/richtextbackgroundpage.cpp:247
+#: ../src/richtext/richtextbackgroundpage.cpp:250
+#: ../src/richtext/richtextbackgroundpage.cpp:251
+#: ../src/richtext/richtextbackgroundpage.cpp:287
+#: ../src/richtext/richtextbackgroundpage.cpp:290
+#: ../src/richtext/richtextbackgroundpage.cpp:291
+#: ../src/richtext/richtextbackgroundpage.cpp:314
+#: ../src/richtext/richtextbackgroundpage.cpp:317
+#: ../src/richtext/richtextbackgroundpage.cpp:318
+#: ../src/richtext/richtextborderspage.cpp:252
+#: ../src/richtext/richtextborderspage.cpp:255
+#: ../src/richtext/richtextborderspage.cpp:256
+#: ../src/richtext/richtextborderspage.cpp:286
+#: ../src/richtext/richtextborderspage.cpp:289
+#: ../src/richtext/richtextborderspage.cpp:290
+#: ../src/richtext/richtextborderspage.cpp:320
+#: ../src/richtext/richtextborderspage.cpp:323
+#: ../src/richtext/richtextborderspage.cpp:324
+#: ../src/richtext/richtextborderspage.cpp:354
+#: ../src/richtext/richtextborderspage.cpp:357
+#: ../src/richtext/richtextborderspage.cpp:358
+#: ../src/richtext/richtextborderspage.cpp:420
+#: ../src/richtext/richtextborderspage.cpp:423
+#: ../src/richtext/richtextborderspage.cpp:424
+#: ../src/richtext/richtextborderspage.cpp:454
+#: ../src/richtext/richtextborderspage.cpp:457
+#: ../src/richtext/richtextborderspage.cpp:458
+#: ../src/richtext/richtextborderspage.cpp:488
+#: ../src/richtext/richtextborderspage.cpp:491
+#: ../src/richtext/richtextborderspage.cpp:492
+#: ../src/richtext/richtextborderspage.cpp:522
+#: ../src/richtext/richtextborderspage.cpp:525
+#: ../src/richtext/richtextborderspage.cpp:526
+#: ../src/richtext/richtextborderspage.cpp:590
+#: ../src/richtext/richtextborderspage.cpp:593
+#: ../src/richtext/richtextborderspage.cpp:594
+#: ../src/richtext/richtextfontpage.cpp:177
+#: ../src/richtext/richtextmarginspage.cpp:199
+#: ../src/richtext/richtextmarginspage.cpp:201
+#: ../src/richtext/richtextmarginspage.cpp:202
+#: ../src/richtext/richtextmarginspage.cpp:224
+#: ../src/richtext/richtextmarginspage.cpp:226
+#: ../src/richtext/richtextmarginspage.cpp:227
+#: ../src/richtext/richtextmarginspage.cpp:247
+#: ../src/richtext/richtextmarginspage.cpp:249
+#: ../src/richtext/richtextmarginspage.cpp:250
+#: ../src/richtext/richtextmarginspage.cpp:272
+#: ../src/richtext/richtextmarginspage.cpp:274
+#: ../src/richtext/richtextmarginspage.cpp:275
+#: ../src/richtext/richtextmarginspage.cpp:313
+#: ../src/richtext/richtextmarginspage.cpp:315
+#: ../src/richtext/richtextmarginspage.cpp:316
+#: ../src/richtext/richtextmarginspage.cpp:338
+#: ../src/richtext/richtextmarginspage.cpp:340
+#: ../src/richtext/richtextmarginspage.cpp:341
+#: ../src/richtext/richtextmarginspage.cpp:361
+#: ../src/richtext/richtextmarginspage.cpp:363
+#: ../src/richtext/richtextmarginspage.cpp:364
+#: ../src/richtext/richtextmarginspage.cpp:386
+#: ../src/richtext/richtextmarginspage.cpp:388
+#: ../src/richtext/richtextmarginspage.cpp:389
+#: ../src/richtext/richtextsizepage.cpp:337
+#: ../src/richtext/richtextsizepage.cpp:340
+#: ../src/richtext/richtextsizepage.cpp:341
+#: ../src/richtext/richtextsizepage.cpp:371
+#: ../src/richtext/richtextsizepage.cpp:374
+#: ../src/richtext/richtextsizepage.cpp:375
+#: ../src/richtext/richtextsizepage.cpp:398
+#: ../src/richtext/richtextsizepage.cpp:401
+#: ../src/richtext/richtextsizepage.cpp:402
+#: ../src/richtext/richtextsizepage.cpp:425
+#: ../src/richtext/richtextsizepage.cpp:428
+#: ../src/richtext/richtextsizepage.cpp:429
+#: ../src/richtext/richtextsizepage.cpp:452
+#: ../src/richtext/richtextsizepage.cpp:455
+#: ../src/richtext/richtextsizepage.cpp:456
+#: ../src/richtext/richtextsizepage.cpp:479
+#: ../src/richtext/richtextsizepage.cpp:482
+#: ../src/richtext/richtextsizepage.cpp:483
+#: ../src/richtext/richtextsizepage.cpp:553
+#: ../src/richtext/richtextsizepage.cpp:556
+#: ../src/richtext/richtextsizepage.cpp:557
+#: ../src/richtext/richtextsizepage.cpp:588
+#: ../src/richtext/richtextsizepage.cpp:591
+#: ../src/richtext/richtextsizepage.cpp:592
+#: ../src/richtext/richtextsizepage.cpp:623
+#: ../src/richtext/richtextsizepage.cpp:626
+#: ../src/richtext/richtextsizepage.cpp:627
+#: ../src/richtext/richtextsizepage.cpp:658
+#: ../src/richtext/richtextsizepage.cpp:661
+#: ../src/richtext/richtextsizepage.cpp:662
+msgid "px"
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:225
+#: ../src/richtext/richtextbackgroundpage.cpp:248
+#: ../src/richtext/richtextbackgroundpage.cpp:288
+#: ../src/richtext/richtextbackgroundpage.cpp:315
+#: ../src/richtext/richtextborderspage.cpp:253
+#: ../src/richtext/richtextborderspage.cpp:287
+#: ../src/richtext/richtextborderspage.cpp:321
+#: ../src/richtext/richtextborderspage.cpp:355
+#: ../src/richtext/richtextborderspage.cpp:421
+#: ../src/richtext/richtextborderspage.cpp:455
+#: ../src/richtext/richtextborderspage.cpp:489
+#: ../src/richtext/richtextborderspage.cpp:523
+#: ../src/richtext/richtextborderspage.cpp:591
+#: ../src/richtext/richtextmarginspage.cpp:200
+#: ../src/richtext/richtextmarginspage.cpp:225
+#: ../src/richtext/richtextmarginspage.cpp:248
+#: ../src/richtext/richtextmarginspage.cpp:273
+#: ../src/richtext/richtextmarginspage.cpp:314
+#: ../src/richtext/richtextmarginspage.cpp:339
+#: ../src/richtext/richtextmarginspage.cpp:362
+#: ../src/richtext/richtextmarginspage.cpp:387
+#: ../src/richtext/richtextsizepage.cpp:338
+#: ../src/richtext/richtextsizepage.cpp:372
+#: ../src/richtext/richtextsizepage.cpp:399
+#: ../src/richtext/richtextsizepage.cpp:426
+#: ../src/richtext/richtextsizepage.cpp:453
+#: ../src/richtext/richtextsizepage.cpp:480
+#: ../src/richtext/richtextsizepage.cpp:554
+#: ../src/richtext/richtextsizepage.cpp:589
+#: ../src/richtext/richtextsizepage.cpp:624
+#: ../src/richtext/richtextsizepage.cpp:659
+msgid "cm"
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:226
+#: ../src/richtext/richtextbackgroundpage.cpp:249
+#: ../src/richtext/richtextbackgroundpage.cpp:289
+#: ../src/richtext/richtextbackgroundpage.cpp:316
+#: ../src/richtext/richtextborderspage.cpp:254
+#: ../src/richtext/richtextborderspage.cpp:288
+#: ../src/richtext/richtextborderspage.cpp:322
+#: ../src/richtext/richtextborderspage.cpp:356
+#: ../src/richtext/richtextborderspage.cpp:422
+#: ../src/richtext/richtextborderspage.cpp:456
+#: ../src/richtext/richtextborderspage.cpp:490
+#: ../src/richtext/richtextborderspage.cpp:524
+#: ../src/richtext/richtextborderspage.cpp:592
+#: ../src/richtext/richtextfontpage.cpp:176
+#: ../src/richtext/richtextfontpage.cpp:179
+msgid "pt"
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:229
+#: ../src/richtext/richtextbackgroundpage.cpp:231
+#: ../src/richtext/richtextbackgroundpage.cpp:252
+#: ../src/richtext/richtextbackgroundpage.cpp:254
+#: ../src/richtext/richtextbackgroundpage.cpp:292
+#: ../src/richtext/richtextbackgroundpage.cpp:294
+#: ../src/richtext/richtextbackgroundpage.cpp:319
+#: ../src/richtext/richtextbackgroundpage.cpp:321
+#, fuzzy
+msgid "Units for this value."
+msgstr "쓰레드를 종료할 수 없습니다."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:234
+#, fuzzy
+msgid "&Vertical offset:"
+msgstr "글머리 정렬(&A)"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:241
+#: ../src/richtext/richtextbackgroundpage.cpp:243
+#, fuzzy
+msgid "The vertical offset."
+msgstr "정렬 방식을 지정할 수 없습니다."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:257
+#, fuzzy
+msgid "Shadow c&olour:"
+msgstr "색상 선택"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:259
+#: ../src/richtext/richtextbackgroundpage.cpp:261
+#, fuzzy
+msgid "Enables the shadow colour."
+msgstr "배경 색"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:265
+#: ../src/richtext/richtextbackgroundpage.cpp:267
+#, fuzzy
+msgid "The shadow colour."
+msgstr "글꼴 색상"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:270
+msgid "Sh&adow spread:"
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:272
+#: ../src/richtext/richtextbackgroundpage.cpp:274
+msgid "Enables the shadow spread."
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:281
+#: ../src/richtext/richtextbackgroundpage.cpp:283
+msgid "The shadow spread."
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:297
+msgid "&Blur distance:"
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:299
+#: ../src/richtext/richtextbackgroundpage.cpp:301
+#, fuzzy
+msgid "Enables the blur distance."
+msgstr "최대 너비를 지정할 수 없습니다."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:308
+#: ../src/richtext/richtextbackgroundpage.cpp:310
+msgid "The shadow blur distance."
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:324
+msgid "Opaci&ty:"
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:326
+#: ../src/richtext/richtextbackgroundpage.cpp:328
+msgid "Enables the shadow opacity."
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:335
+#: ../src/richtext/richtextbackgroundpage.cpp:337
+msgid "The shadow opacity."
+msgstr ""
+
+#. TRANSLATORS: Rich text page units (percentage)
+#: ../src/richtext/richtextbackgroundpage.cpp:340
+#: ../src/richtext/richtextsizepage.cpp:339
+#: ../src/richtext/richtextsizepage.cpp:373
+#: ../src/richtext/richtextsizepage.cpp:400
+#: ../src/richtext/richtextsizepage.cpp:427
+#: ../src/richtext/richtextsizepage.cpp:454
+#: ../src/richtext/richtextsizepage.cpp:481
+#: ../src/richtext/richtextsizepage.cpp:555
+#: ../src/richtext/richtextsizepage.cpp:590
+#: ../src/richtext/richtextsizepage.cpp:625
+#: ../src/richtext/richtextsizepage.cpp:660
+#, fuzzy
+msgid "%"
+msgstr "%s"
+
+#: ../src/richtext/richtextborderspage.cpp:229
+#: ../src/richtext/richtextborderspage.cpp:387
+#, fuzzy
+msgid "Border"
+msgstr "Modern"
+
+#: ../src/richtext/richtextborderspage.cpp:242
+#: ../src/richtext/richtextborderspage.cpp:410
+#: ../src/richtext/richtextindentspage.cpp:194
+#: ../src/richtext/richtextliststylepage.cpp:384
+#: ../src/richtext/richtextmarginspage.cpp:185
+#: ../src/richtext/richtextmarginspage.cpp:299
+#: ../src/richtext/richtextsizepage.cpp:531
+#: ../src/richtext/richtextsizepage.cpp:538
+msgid "&Left:"
+msgstr "왼쪽(&L):"
+
+#: ../src/richtext/richtextborderspage.cpp:257
+#: ../src/richtext/richtextborderspage.cpp:259
+msgid "Units for the left border width."
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:266
+#: ../src/richtext/richtextborderspage.cpp:268
+#: ../src/richtext/richtextborderspage.cpp:300
+#: ../src/richtext/richtextborderspage.cpp:302
+#: ../src/richtext/richtextborderspage.cpp:334
+#: ../src/richtext/richtextborderspage.cpp:336
+#: ../src/richtext/richtextborderspage.cpp:368
+#: ../src/richtext/richtextborderspage.cpp:370
+#: ../src/richtext/richtextborderspage.cpp:434
+#: ../src/richtext/richtextborderspage.cpp:436
+#: ../src/richtext/richtextborderspage.cpp:468
+#: ../src/richtext/richtextborderspage.cpp:470
+#: ../src/richtext/richtextborderspage.cpp:502
+#: ../src/richtext/richtextborderspage.cpp:504
+#: ../src/richtext/richtextborderspage.cpp:536
+#: ../src/richtext/richtextborderspage.cpp:538
+#, fuzzy
+msgid "The border line style."
+msgstr "글꼴 모양새"
+
+#: ../src/richtext/richtextborderspage.cpp:276
+#: ../src/richtext/richtextborderspage.cpp:444
+#: ../src/richtext/richtextindentspage.cpp:212
+#: ../src/richtext/richtextliststylepage.cpp:402
+#: ../src/richtext/richtextmarginspage.cpp:210
+#: ../src/richtext/richtextmarginspage.cpp:324
+#: ../src/richtext/richtextsizepage.cpp:601
+#: ../src/richtext/richtextsizepage.cpp:608
+msgid "&Right:"
+msgstr "오른쪽(&R):"
+
+#: ../src/richtext/richtextborderspage.cpp:291
+#: ../src/richtext/richtextborderspage.cpp:293
+msgid "Units for the right border width."
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:310
+#: ../src/richtext/richtextborderspage.cpp:478
+#: ../src/richtext/richtextmarginspage.cpp:233
+#: ../src/richtext/richtextmarginspage.cpp:347
+#: ../src/richtext/richtextsizepage.cpp:566
+#: ../src/richtext/richtextsizepage.cpp:573
+#, fuzzy
+msgid "&Top:"
+msgstr "수신:"
+
+#: ../src/richtext/richtextborderspage.cpp:325
+#: ../src/richtext/richtextborderspage.cpp:327
+msgid "Units for the top border width."
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:344
+#: ../src/richtext/richtextborderspage.cpp:512
+#: ../src/richtext/richtextmarginspage.cpp:258
+#: ../src/richtext/richtextmarginspage.cpp:372
+#: ../src/richtext/richtextsizepage.cpp:636
+#: ../src/richtext/richtextsizepage.cpp:643
+msgid "&Bottom:"
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:359
+#: ../src/richtext/richtextborderspage.cpp:361
+msgid "Units for the bottom border width."
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:380
+#: ../src/richtext/richtextborderspage.cpp:548
+msgid "&Synchronize values"
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:382
+#: ../src/richtext/richtextborderspage.cpp:384
+#: ../src/richtext/richtextborderspage.cpp:550
+#: ../src/richtext/richtextborderspage.cpp:552
+msgid "Check to edit all borders simultaneously."
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:397
+#: ../src/richtext/richtextborderspage.cpp:555
+#, fuzzy
+msgid "Outline"
+msgstr "들여쓰기 단계(&O)"
+
+#: ../src/richtext/richtextborderspage.cpp:425
+#: ../src/richtext/richtextborderspage.cpp:427
+msgid "Units for the left outline width."
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:459
+#: ../src/richtext/richtextborderspage.cpp:461
+msgid "Units for the right outline width."
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:493
+#: ../src/richtext/richtextborderspage.cpp:495
+msgid "Units for the top outline width."
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:527
+#: ../src/richtext/richtextborderspage.cpp:529
+msgid "Units for the bottom outline width."
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:565
+#: ../src/richtext/richtextborderspage.cpp:600
+msgid "Corner"
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:574
+msgid "Corner &radius:"
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:576
+#: ../src/richtext/richtextborderspage.cpp:578
+msgid "An optional corner radius for adding rounded corners."
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:584
+#: ../src/richtext/richtextborderspage.cpp:586
+msgid "The value of the corner radius."
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:595
+#: ../src/richtext/richtextborderspage.cpp:597
+#, fuzzy
+msgid "Units for the corner radius."
+msgstr "쓰레드를 종료할 수 없습니다."
+
+#: ../src/richtext/richtextborderspage.cpp:609
+#: ../src/richtext/richtextsizepage.cpp:247
+#: ../src/richtext/richtextsizepage.cpp:251
+#, fuzzy
+msgid "None"
+msgstr "(없음)"
+
+#: ../src/richtext/richtextborderspage.cpp:610
+#, fuzzy
+msgid "Solid"
+msgstr "굵게"
+
+#: ../src/richtext/richtextborderspage.cpp:611
+#, fuzzy
+msgid "Dotted"
+msgstr "완료"
+
+#: ../src/richtext/richtextborderspage.cpp:612
+msgid "Dashed"
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:613
+#, fuzzy
+msgid "Double"
+msgstr "완료"
+
+#: ../src/richtext/richtextborderspage.cpp:614
+msgid "Groove"
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:615
+#, fuzzy
+msgid "Ridge"
+msgstr "오른쪽"
+
+#: ../src/richtext/richtextborderspage.cpp:616
+#, fuzzy
+msgid "Inset"
+msgstr "넣기"
+
+#: ../src/richtext/richtextborderspage.cpp:617
+msgid "Outset"
+msgstr ""
+
+#: ../src/richtext/richtextbuffer.cpp:3518
+msgid "Change Style"
+msgstr "모양새 바꾸기"
+
+#: ../src/richtext/richtextbuffer.cpp:3701
+#, fuzzy
+msgid "Change Object Style"
+msgstr "목록 모양새 바꾸기"
+
+#: ../src/richtext/richtextbuffer.cpp:3974
+#: ../src/richtext/richtextbuffer.cpp:8174
+#, fuzzy
+msgid "Change Properties"
+msgstr "특성(&P)"
+
+#: ../src/richtext/richtextbuffer.cpp:4346
+msgid "Change List Style"
+msgstr "목록 모양새 바꾸기"
+
+#: ../src/richtext/richtextbuffer.cpp:4519
+msgid "Renumber List"
+msgstr "목록 번호 다시 매기기"
+
+#: ../src/richtext/richtextbuffer.cpp:7867
+#: ../src/richtext/richtextbuffer.cpp:7897
+#: ../src/richtext/richtextbuffer.cpp:7939
+#: ../src/richtext/richtextctrl.cpp:1279 ../src/richtext/richtextctrl.cpp:1473
+msgid "Insert Text"
+msgstr "텍스트 넣기"
+
+#: ../src/richtext/richtextbuffer.cpp:8023
+#: ../src/richtext/richtextbuffer.cpp:8979
+msgid "Insert Image"
+msgstr "그림 넣기"
+
+#: ../src/richtext/richtextbuffer.cpp:8070
+#, fuzzy
+msgid "Insert Object"
+msgstr "텍스트 넣기"
+
+#: ../src/richtext/richtextbuffer.cpp:8112
+#, fuzzy
+msgid "Insert Field"
+msgstr "텍스트 넣기"
+
+#: ../src/richtext/richtextbuffer.cpp:8410
+msgid "Too many EndStyle calls!"
+msgstr "EndStyle 함수를 너무 많이 호출함"
+
+#: ../src/richtext/richtextbuffer.cpp:8785
+msgid "files"
+msgstr "파일"
+
+#: ../src/richtext/richtextbuffer.cpp:9380
+#, fuzzy
+msgid "standard/circle"
+msgstr "표준"
+
+#: ../src/richtext/richtextbuffer.cpp:9381
+msgid "standard/circle-outline"
+msgstr ""
+
+#: ../src/richtext/richtextbuffer.cpp:9382
+#, fuzzy
+msgid "standard/square"
+msgstr "표준"
+
+#: ../src/richtext/richtextbuffer.cpp:9383
+msgid "standard/diamond"
+msgstr ""
+
+#: ../src/richtext/richtextbuffer.cpp:9384
+msgid "standard/triangle"
+msgstr ""
+
+#: ../src/richtext/richtextbuffer.cpp:9423
+#, fuzzy
+msgid "Box Properties"
+msgstr "특성(&P)"
+
+#: ../src/richtext/richtextbuffer.cpp:10006
+msgid "Multiple Cell Properties"
+msgstr ""
+
+#: ../src/richtext/richtextbuffer.cpp:10008
+#, fuzzy
+msgid "Cell Properties"
+msgstr "특성(&P)"
+
+#: ../src/richtext/richtextbuffer.cpp:11256
+#, fuzzy
+msgid "Set Cell Style"
+msgstr "모양새 지우기"
+
+#: ../src/richtext/richtextbuffer.cpp:11330
+#, fuzzy
+msgid "Delete Row"
+msgstr "지우기"
+
+#: ../src/richtext/richtextbuffer.cpp:11380
+#, fuzzy
+msgid "Delete Column"
+msgstr "선택한 부분 지우기"
+
+#: ../src/richtext/richtextbuffer.cpp:11431
+msgid "Add Row"
+msgstr ""
+
+#: ../src/richtext/richtextbuffer.cpp:11494
+msgid "Add Column"
+msgstr ""
+
+#: ../src/richtext/richtextbuffer.cpp:11537
+#, fuzzy
+msgid "Table Properties"
+msgstr "특성(&P)"
+
+#: ../src/richtext/richtextbuffer.cpp:12899
+#, fuzzy
+msgid "Picture Properties"
+msgstr "특성(&P)"
+
+#: ../src/richtext/richtextbuffer.cpp:13169
+#: ../src/richtext/richtextbuffer.cpp:13279
+msgid "image"
+msgstr "그림"
+
+#: ../src/richtext/richtextbulletspage.cpp:145
+#: ../src/richtext/richtextliststylepage.cpp:209
+msgid "&Bullet style:"
+msgstr "글머리 모양새(&B)"
+
+#: ../src/richtext/richtextbulletspage.cpp:150
+#: ../src/richtext/richtextbulletspage.cpp:152
+#: ../src/richtext/richtextliststylepage.cpp:214
+#: ../src/richtext/richtextliststylepage.cpp:216
+msgid "The available bullet styles."
+msgstr "사용가능한 글머리 모양새"
+
+#: ../src/richtext/richtextbulletspage.cpp:158
+#: ../src/richtext/richtextliststylepage.cpp:221
+msgid "Peri&od"
+msgstr "마침표(&O)"
+
+#: ../src/richtext/richtextbulletspage.cpp:160
+#: ../src/richtext/richtextbulletspage.cpp:162
+#: ../src/richtext/richtextliststylepage.cpp:223
+#: ../src/richtext/richtextliststylepage.cpp:225
+msgid "Check to add a period after the bullet."
+msgstr "글머리 뒤에 마침표 추가."
+
+#. TRANSLATORS: Bullet point in parentheses option
+#: ../src/richtext/richtextbulletspage.cpp:167
+#: ../src/richtext/richtextliststylepage.cpp:230
+msgid "(*)"
+msgstr "(*)"
+
+#: ../src/richtext/richtextbulletspage.cpp:169
+#: ../src/richtext/richtextbulletspage.cpp:171
+#: ../src/richtext/richtextliststylepage.cpp:232
+#: ../src/richtext/richtextliststylepage.cpp:234
+msgid "Check to enclose the bullet in parentheses."
+msgstr "글머리에 괄호추가"
+
+#. TRANSLATORS: Right parenthesis bullet point option
+#: ../src/richtext/richtextbulletspage.cpp:176
+#: ../src/richtext/richtextliststylepage.cpp:239
+msgid "*)"
+msgstr "*)"
+
+#: ../src/richtext/richtextbulletspage.cpp:178
+#: ../src/richtext/richtextbulletspage.cpp:180
+#: ../src/richtext/richtextliststylepage.cpp:241
+#: ../src/richtext/richtextliststylepage.cpp:243
+msgid "Check to add a right parenthesis."
+msgstr "오른쪽 괄호 추가"
+
+#: ../src/richtext/richtextbulletspage.cpp:185
+#: ../src/richtext/richtextliststylepage.cpp:248
+msgid "Bullet &Alignment:"
+msgstr "글머리 정렬(&A)"
+
+#: ../src/richtext/richtextbulletspage.cpp:190
+#: ../src/richtext/richtextliststylepage.cpp:253
+msgid "Centre"
+msgstr "중앙"
+
+#: ../src/richtext/richtextbulletspage.cpp:194
+#: ../src/richtext/richtextbulletspage.cpp:196
+#: ../src/richtext/richtextbulletspage.cpp:217
+#: ../src/richtext/richtextbulletspage.cpp:219
+#: ../src/richtext/richtextliststylepage.cpp:257
+#: ../src/richtext/richtextliststylepage.cpp:259
+#: ../src/richtext/richtextliststylepage.cpp:278
+#: ../src/richtext/richtextliststylepage.cpp:280
+msgid "The bullet character."
+msgstr "글머리 문자"
+
+#: ../src/richtext/richtextbulletspage.cpp:212
+#: ../src/richtext/richtextliststylepage.cpp:271
+msgid "&Symbol:"
+msgstr "심볼(&S):"
+
+#: ../src/richtext/richtextbulletspage.cpp:222
+#: ../src/richtext/richtextliststylepage.cpp:283
+msgid "Ch&oose..."
+msgstr "선택(&o)..."
+
+#: ../src/richtext/richtextbulletspage.cpp:223
+#: ../src/richtext/richtextbulletspage.cpp:225
+#: ../src/richtext/richtextliststylepage.cpp:284
+#: ../src/richtext/richtextliststylepage.cpp:286
+msgid "Click to browse for a symbol."
+msgstr "기호 탐색창을 보시려면 여기를 누르십시오."
+
+#: ../src/richtext/richtextbulletspage.cpp:230
+#: ../src/richtext/richtextliststylepage.cpp:291
+msgid "Symbol &font:"
+msgstr "기호 글꼴(&F):"
+
+#: ../src/richtext/richtextbulletspage.cpp:235
+#: ../src/richtext/richtextbulletspage.cpp:237
+#: ../src/richtext/richtextliststylepage.cpp:297
+msgid "Available fonts."
+msgstr "사용가능한 글꼴"
+
+#: ../src/richtext/richtextbulletspage.cpp:242
+#: ../src/richtext/richtextliststylepage.cpp:302
+msgid "S&tandard bullet name:"
+msgstr "표준 글머리 이름(&T):"
+
+#: ../src/richtext/richtextbulletspage.cpp:247
+#: ../src/richtext/richtextbulletspage.cpp:249
+#: ../src/richtext/richtextliststylepage.cpp:307
+#: ../src/richtext/richtextliststylepage.cpp:309
+msgid "A standard bullet name."
+msgstr "표준 글머리 이름."
+
+#: ../src/richtext/richtextbulletspage.cpp:254
+msgid "&Number:"
+msgstr "번호(&N):"
+
+#: ../src/richtext/richtextbulletspage.cpp:258
+#: ../src/richtext/richtextbulletspage.cpp:260
+msgid "The list item number."
+msgstr "목록 번호 매기기."
+
+#: ../src/richtext/richtextbulletspage.cpp:266
+#: ../src/richtext/richtextbulletspage.cpp:268
+#: ../src/richtext/richtextliststylepage.cpp:475
+#: ../src/richtext/richtextliststylepage.cpp:477
+msgid "Shows a preview of the bullet settings."
+msgstr "글머리 설정 미리보기."
+
+#: ../src/richtext/richtextbulletspage.cpp:276
+#: ../src/richtext/richtextliststylepage.cpp:484
+msgid "(None)"
+msgstr "(없음)"
+
+#: ../src/richtext/richtextbulletspage.cpp:277
+#: ../src/richtext/richtextliststylepage.cpp:485
+msgid "Arabic"
+msgstr "아랍어"
+
+#: ../src/richtext/richtextbulletspage.cpp:278
+#: ../src/richtext/richtextliststylepage.cpp:486
+msgid "Upper case letters"
+msgstr "모두 대문자"
+
+#: ../src/richtext/richtextbulletspage.cpp:279
+#: ../src/richtext/richtextliststylepage.cpp:487
+msgid "Lower case letters"
+msgstr "소문자로 변경"
+
+#: ../src/richtext/richtextbulletspage.cpp:280
+#: ../src/richtext/richtextliststylepage.cpp:488
+msgid "Upper case roman numerals"
+msgstr "로마 숫자를 대문자로"
+
+#: ../src/richtext/richtextbulletspage.cpp:281
+#: ../src/richtext/richtextliststylepage.cpp:489
+msgid "Lower case roman numerals"
+msgstr "로마 숫자를 소문자로 변경"
+
+#: ../src/richtext/richtextbulletspage.cpp:282
+#: ../src/richtext/richtextliststylepage.cpp:490
+msgid "Numbered outline"
+msgstr "Numbered  형태"
+
+#: ../src/richtext/richtextbulletspage.cpp:283
+#: ../src/richtext/richtextliststylepage.cpp:491
+msgid "Symbol"
+msgstr "기호"
+
+#: ../src/richtext/richtextbulletspage.cpp:284
+#: ../src/richtext/richtextliststylepage.cpp:492
+msgid "Bitmap"
+msgstr "비트맵"
+
+#: ../src/richtext/richtextbulletspage.cpp:285
+#: ../src/richtext/richtextliststylepage.cpp:493
+msgid "Standard"
+msgstr "표준"
+
+#: ../src/richtext/richtextbulletspage.cpp:287
+#: ../src/richtext/richtextliststylepage.cpp:495
+msgid "*"
+msgstr "*"
+
+#: ../src/richtext/richtextbulletspage.cpp:288
+#: ../src/richtext/richtextliststylepage.cpp:496
+msgid "-"
+msgstr "-"
+
+#: ../src/richtext/richtextbulletspage.cpp:289
+#: ../src/richtext/richtextliststylepage.cpp:497
+msgid ">"
+msgstr ">"
+
+#: ../src/richtext/richtextbulletspage.cpp:290
+#: ../src/richtext/richtextliststylepage.cpp:498
+msgid "+"
+msgstr "+"
+
+#: ../src/richtext/richtextbulletspage.cpp:291
+#: ../src/richtext/richtextliststylepage.cpp:499
+msgid "~"
+msgstr "~"
+
+#: ../src/richtext/richtextctrl.cpp:859
+msgid "Drag"
+msgstr ""
+
+#: ../src/richtext/richtextctrl.cpp:1338 ../src/richtext/richtextctrl.cpp:1559
+msgid "Delete Text"
+msgstr "텍스트 삭제"
+
+#: ../src/richtext/richtextctrl.cpp:1537
+#, fuzzy
+msgid "Remove Bullet"
+msgstr "지우기"
+
+#: ../src/richtext/richtextctrl.cpp:3070
+msgid "The text couldn't be saved."
+msgstr "텍스트를 저장할 수 없습니다."
+
+#: ../src/richtext/richtextctrl.cpp:3644
+msgid "Replace"
+msgstr "바꾸기"
+
+#: ../src/richtext/richtextfontpage.cpp:146
+#: ../src/richtext/richtextsymboldlg.cpp:384
+msgid "&Font:"
+msgstr "글꼴(&F):"
+
+#: ../src/richtext/richtextfontpage.cpp:150
+#: ../src/richtext/richtextfontpage.cpp:152
+msgid "Type a font name."
+msgstr "글꼴 이름"
+
+#: ../src/richtext/richtextfontpage.cpp:158
+msgid "&Size:"
+msgstr "크기(&S)"
+
+#: ../src/richtext/richtextfontpage.cpp:165
+#: ../src/richtext/richtextfontpage.cpp:167
+msgid "Type a size in points."
+msgstr "포인트로 나타낸 글꼴 크기"
+
+#: ../src/richtext/richtextfontpage.cpp:180
+#: ../src/richtext/richtextfontpage.cpp:182
+#, fuzzy
+msgid "The font size units, points or pixels."
+msgstr "포인트로 나타낸 글꼴 크기"
+
+#: ../src/richtext/richtextfontpage.cpp:189
+#: ../src/richtext/richtextfontpage.cpp:191
+msgid "Lists the available fonts."
+msgstr "목록에서 사용가능한 글꼴"
+
+#: ../src/richtext/richtextfontpage.cpp:196
+#: ../src/richtext/richtextfontpage.cpp:198
+msgid "Lists font sizes in points."
+msgstr "목록의 글꼴 크기."
+
+#: ../src/richtext/richtextfontpage.cpp:207
+msgid "Font st&yle:"
+msgstr "글꼴 모양새(&Y):"
+
+#: ../src/richtext/richtextfontpage.cpp:212
+#: ../src/richtext/richtextfontpage.cpp:214
+msgid "Select regular or italic style."
+msgstr "일반 또는 기울임 모양새 선택하시오."
+
+#: ../src/richtext/richtextfontpage.cpp:220
+msgid "Font &weight:"
+msgstr "글꼴 굵기(&W):"
+
+#: ../src/richtext/richtextfontpage.cpp:225
+#: ../src/richtext/richtextfontpage.cpp:227
+msgid "Select regular or bold."
+msgstr "일반/굵게를 선택합니다."
+
+#: ../src/richtext/richtextfontpage.cpp:233
+msgid "&Underlining:"
+msgstr "밑줄(&U):"
+
+#: ../src/richtext/richtextfontpage.cpp:238
+#: ../src/richtext/richtextfontpage.cpp:240
+msgid "Select underlining or no underlining."
+msgstr "밑줄/밑줄 없음 을 선택합니다."
+
+#: ../src/richtext/richtextfontpage.cpp:248
+msgid "&Colour:"
+msgstr "색상(&D):"
+
+#: ../src/richtext/richtextfontpage.cpp:253
+#: ../src/richtext/richtextfontpage.cpp:255
+msgid "Click to change the text colour."
+msgstr "텍스트 색상 변경 하려면 여기를 누르십시오."
+
+#: ../src/richtext/richtextfontpage.cpp:261
+#, fuzzy
+msgid "&Bg colour:"
+msgstr "색상(&D):"
+
+#: ../src/richtext/richtextfontpage.cpp:266
+#: ../src/richtext/richtextfontpage.cpp:268
+#, fuzzy
+msgid "Click to change the text background colour."
+msgstr "텍스트 색상 변경 하려면 여기를 누르십시오."
+
+#: ../src/richtext/richtextfontpage.cpp:276
+#: ../src/richtext/richtextfontpage.cpp:278
+msgid "Check to show a line through the text."
+msgstr "취소선 보기."
+
+#: ../src/richtext/richtextfontpage.cpp:281
+msgid "Ca&pitals"
+msgstr "대문자(&P)"
+
+#: ../src/richtext/richtextfontpage.cpp:283
+#: ../src/richtext/richtextfontpage.cpp:285
+msgid "Check to show the text in capitals."
+msgstr "대문자로 보기"
+
+#: ../src/richtext/richtextfontpage.cpp:288
+#, fuzzy
+msgid "Small C&apitals"
+msgstr "대문자(&P)"
+
+#: ../src/richtext/richtextfontpage.cpp:290
+#: ../src/richtext/richtextfontpage.cpp:292
+#, fuzzy
+msgid "Check to show the text in small capitals."
+msgstr "대문자로 보기"
+
+#: ../src/richtext/richtextfontpage.cpp:295
+msgid "Supe&rscript"
+msgstr "위 첨자(&R)"
+
+#: ../src/richtext/richtextfontpage.cpp:297
+#: ../src/richtext/richtextfontpage.cpp:299
+msgid "Check to show the text in superscript."
+msgstr "위 첨자로 보기"
+
+#: ../src/richtext/richtextfontpage.cpp:302
+msgid "Subscrip&t"
+msgstr "아래 첨자(&T)"
+
+#: ../src/richtext/richtextfontpage.cpp:304
+#: ../src/richtext/richtextfontpage.cpp:306
+msgid "Check to show the text in subscript."
+msgstr "아래 첨자로 보기"
+
+#: ../src/richtext/richtextfontpage.cpp:312
+msgid "Rig&ht-to-left"
+msgstr ""
+
+#: ../src/richtext/richtextfontpage.cpp:314
+#: ../src/richtext/richtextfontpage.cpp:316
+#, fuzzy
+msgid "Check to indicate right-to-left text layout."
+msgstr "텍스트 색상 변경 하려면 여기를 누르십시오."
+
+#: ../src/richtext/richtextfontpage.cpp:319
+msgid "Suppress hyphe&nation"
+msgstr ""
+
+#: ../src/richtext/richtextfontpage.cpp:321
+#: ../src/richtext/richtextfontpage.cpp:323
+msgid "Check to suppress hyphenation."
+msgstr ""
+
+#: ../src/richtext/richtextfontpage.cpp:329
+#: ../src/richtext/richtextfontpage.cpp:331
+msgid "Shows a preview of the font settings."
+msgstr "글꼴의 미리 보기를 표시"
+
+#: ../src/richtext/richtextfontpage.cpp:348
+#: ../src/richtext/richtextfontpage.cpp:352
+#: ../src/richtext/richtextfontpage.cpp:356
+#: ../src/richtext/richtextformatdlg.cpp:873
+#: ../src/richtext/richtextindentspage.cpp:273
+#: ../src/richtext/richtextindentspage.cpp:285
+#: ../src/richtext/richtextindentspage.cpp:286
+#: ../src/richtext/richtextindentspage.cpp:310
+#: ../src/richtext/richtextindentspage.cpp:325
+#: ../src/richtext/richtextliststylepage.cpp:451
+#: ../src/richtext/richtextliststylepage.cpp:463
+#: ../src/richtext/richtextliststylepage.cpp:464
+msgid "(none)"
+msgstr "(없음)"
+
+#: ../src/richtext/richtextfontpage.cpp:349
+#: ../src/richtext/richtextfontpage.cpp:353
+msgid "Regular"
+msgstr "일반"
+
+#: ../src/richtext/richtextfontpage.cpp:357
+msgid "Not underlined"
+msgstr "밑줄 없음"
+
+#: ../src/richtext/richtextformatdlg.cpp:341
+msgid "Indents && Spacing"
+msgstr "들여쓰기 && 줄 간격"
+
+#: ../src/richtext/richtextformatdlg.cpp:346
+msgid "Tabs"
+msgstr "탭"
+
+#: ../src/richtext/richtextformatdlg.cpp:351
+msgid "Bullets"
+msgstr "글머리"
+
+#: ../src/richtext/richtextformatdlg.cpp:356
+msgid "List Style"
+msgstr "목록 모양새"
+
+#: ../src/richtext/richtextformatdlg.cpp:366
+#: ../src/richtext/richtextmarginspage.cpp:170
+msgid "Margins"
+msgstr ""
+
+#: ../src/richtext/richtextformatdlg.cpp:371
+#, fuzzy
+msgid "Borders"
+msgstr "Modern"
+
+#: ../src/richtext/richtextformatdlg.cpp:765
+msgid "Colour"
+msgstr "색상"
+
+#: ../src/richtext/richtextindentspage.cpp:127
+#: ../src/richtext/richtextliststylepage.cpp:322
+msgid "&Alignment"
+msgstr "정렬(&A)"
+
+#: ../src/richtext/richtextindentspage.cpp:138
+#: ../src/richtext/richtextliststylepage.cpp:331
+msgid "&Left"
+msgstr "왼쪽(&L)"
+
+#: ../src/richtext/richtextindentspage.cpp:140
+#: ../src/richtext/richtextindentspage.cpp:142
+#: ../src/richtext/richtextliststylepage.cpp:333
+#: ../src/richtext/richtextliststylepage.cpp:335
+msgid "Left-align text."
+msgstr "텍스트 왼쪽 정렬."
+
+#: ../src/richtext/richtextindentspage.cpp:145
+#: ../src/richtext/richtextliststylepage.cpp:338
+msgid "&Right"
+msgstr "오른쪽(&R):"
+
+#: ../src/richtext/richtextindentspage.cpp:147
+#: ../src/richtext/richtextindentspage.cpp:149
+#: ../src/richtext/richtextliststylepage.cpp:340
+#: ../src/richtext/richtextliststylepage.cpp:342
+msgid "Right-align text."
+msgstr "텍스트 오른쪽 정렬"
+
+#: ../src/richtext/richtextindentspage.cpp:152
+#: ../src/richtext/richtextliststylepage.cpp:345
+msgid "&Justified"
+msgstr "정렬(&J)"
+
+#: ../src/richtext/richtextindentspage.cpp:154
+#: ../src/richtext/richtextindentspage.cpp:156
+#: ../src/richtext/richtextliststylepage.cpp:347
+#: ../src/richtext/richtextliststylepage.cpp:349
+msgid "Justify text left and right."
+msgstr "오른쪽 및 왼쪽 정렬."
+
+#: ../src/richtext/richtextindentspage.cpp:159
+#: ../src/richtext/richtextliststylepage.cpp:352
+msgid "Cen&tred"
+msgstr "중앙(&T)"
+
+#: ../src/richtext/richtextindentspage.cpp:161
+#: ../src/richtext/richtextindentspage.cpp:163
+#: ../src/richtext/richtextliststylepage.cpp:354
+#: ../src/richtext/richtextliststylepage.cpp:356
+msgid "Centre text."
+msgstr "텍스트 중앙 정렬."
+
+#: ../src/richtext/richtextindentspage.cpp:166
+#: ../src/richtext/richtextliststylepage.cpp:359
+msgid "&Indeterminate"
+msgstr "정의하지않음(&I)"
+
+#: ../src/richtext/richtextindentspage.cpp:168
+#: ../src/richtext/richtextindentspage.cpp:170
+#: ../src/richtext/richtextliststylepage.cpp:361
+#: ../src/richtext/richtextliststylepage.cpp:363
+msgid "Use the current alignment setting."
+msgstr "현재 정렬 방식 사용"
+
+#: ../src/richtext/richtextindentspage.cpp:183
+#: ../src/richtext/richtextliststylepage.cpp:375
+msgid "&Indentation (tenths of a mm)"
+msgstr "들여쓰기(&I)(mm/10)"
+
+#: ../src/richtext/richtextindentspage.cpp:198
+#: ../src/richtext/richtextindentspage.cpp:200
+#: ../src/richtext/richtextliststylepage.cpp:388
+#: ../src/richtext/richtextliststylepage.cpp:390
+msgid "The left indent."
+msgstr "왼쪽 들여쓰기"
+
+#: ../src/richtext/richtextindentspage.cpp:203
+#: ../src/richtext/richtextliststylepage.cpp:393
+msgid "Left (&first line):"
+msgstr "첫 줄 들여쓰기:"
+
+#: ../src/richtext/richtextindentspage.cpp:207
+#: ../src/richtext/richtextindentspage.cpp:209
+#: ../src/richtext/richtextliststylepage.cpp:397
+#: ../src/richtext/richtextliststylepage.cpp:399
+msgid "The first line indent."
+msgstr "첫 줄 들여쓰기"
+
+#: ../src/richtext/richtextindentspage.cpp:216
+#: ../src/richtext/richtextindentspage.cpp:218
+#: ../src/richtext/richtextliststylepage.cpp:406
+#: ../src/richtext/richtextliststylepage.cpp:408
+msgid "The right indent."
+msgstr "오른쪽 들여쓰기"
+
+#: ../src/richtext/richtextindentspage.cpp:221
+msgid "&Outline level:"
+msgstr "들여쓰기 단계(&O)"
+
+#: ../src/richtext/richtextindentspage.cpp:226
+#: ../src/richtext/richtextindentspage.cpp:228
+msgid "The outline level."
+msgstr "들여쓰기 단계."
+
+#: ../src/richtext/richtextindentspage.cpp:241
+#: ../src/richtext/richtextliststylepage.cpp:420
+msgid "&Spacing (tenths of a mm)"
+msgstr "간격(&S)(mm/10)"
+
+#: ../src/richtext/richtextindentspage.cpp:252
+msgid "&Before a paragraph:"
+msgstr "단락 전(&B):."
+
+#: ../src/richtext/richtextindentspage.cpp:256
+#: ../src/richtext/richtextindentspage.cpp:258
+#: ../src/richtext/richtextliststylepage.cpp:433
+#: ../src/richtext/richtextliststylepage.cpp:435
+msgid "The spacing before the paragraph."
+msgstr "단락 전 간격"
+
+#: ../src/richtext/richtextindentspage.cpp:261
+msgid "&After a paragraph:"
+msgstr "단락 후(&A):"
+
+#: ../src/richtext/richtextindentspage.cpp:266
+#: ../src/richtext/richtextliststylepage.cpp:442
+#: ../src/richtext/richtextliststylepage.cpp:444
+msgid "The spacing after the paragraph."
+msgstr "단락 후 간격"
+
+#: ../src/richtext/richtextindentspage.cpp:269
+msgid "L&ine spacing:"
+msgstr "줄 간격(&I):"
+
+#: ../src/richtext/richtextindentspage.cpp:274
+#: ../src/richtext/richtextliststylepage.cpp:452
+msgid "Single"
+msgstr "일반"
+
+#: ../src/richtext/richtextindentspage.cpp:275
+#: ../src/richtext/richtextliststylepage.cpp:453
+#, fuzzy
+msgid "1.1"
+msgstr "1.5"
+
+#: ../src/richtext/richtextindentspage.cpp:276
+#: ../src/richtext/richtextliststylepage.cpp:454
+#, fuzzy
+msgid "1.2"
+msgstr "1.5"
+
+#: ../src/richtext/richtextindentspage.cpp:277
+#: ../src/richtext/richtextliststylepage.cpp:455
+#, fuzzy
+msgid "1.3"
+msgstr "1.5"
+
+#: ../src/richtext/richtextindentspage.cpp:278
+#: ../src/richtext/richtextliststylepage.cpp:456
+#, fuzzy
+msgid "1.4"
+msgstr "1.5"
+
+#: ../src/richtext/richtextindentspage.cpp:279
+#: ../src/richtext/richtextliststylepage.cpp:457
+msgid "1.5"
+msgstr "1.5"
+
+#: ../src/richtext/richtextindentspage.cpp:280
+#: ../src/richtext/richtextliststylepage.cpp:458
+#, fuzzy
+msgid "1.6"
+msgstr "1.5"
+
+#: ../src/richtext/richtextindentspage.cpp:281
+#: ../src/richtext/richtextliststylepage.cpp:459
+#, fuzzy
+msgid "1.7"
+msgstr "1.5"
+
+#: ../src/richtext/richtextindentspage.cpp:282
+#: ../src/richtext/richtextliststylepage.cpp:460
+#, fuzzy
+msgid "1.8"
+msgstr "1.5"
+
+#: ../src/richtext/richtextindentspage.cpp:283
+#: ../src/richtext/richtextliststylepage.cpp:461
+#, fuzzy
+msgid "1.9"
+msgstr "1.5"
+
+#: ../src/richtext/richtextindentspage.cpp:284
+#: ../src/richtext/richtextliststylepage.cpp:462
+msgid "2"
+msgstr "2"
+
+#: ../src/richtext/richtextindentspage.cpp:287
+#: ../src/richtext/richtextindentspage.cpp:289
+#: ../src/richtext/richtextliststylepage.cpp:465
+#: ../src/richtext/richtextliststylepage.cpp:467
+msgid "The line spacing."
+msgstr "줄 간격"
+
+#: ../src/richtext/richtextindentspage.cpp:292
+msgid "&Page Break"
+msgstr ""
+
+#: ../src/richtext/richtextindentspage.cpp:294
+#: ../src/richtext/richtextindentspage.cpp:296
+#, fuzzy
+msgid "Inserts a page break before the paragraph."
+msgstr "단락 전 간격"
+
+#: ../src/richtext/richtextindentspage.cpp:302
+#: ../src/richtext/richtextindentspage.cpp:304
+msgid "Shows a preview of the paragraph settings."
+msgstr "단락 설정 미리 보기"
+
+#: ../src/richtext/richtextliststylepage.cpp:182
+msgid "&List level:"
+msgstr "목록 단계(&L):"
+
+#: ../src/richtext/richtextliststylepage.cpp:186
+#: ../src/richtext/richtextliststylepage.cpp:188
+msgid "Selects the list level to edit."
+msgstr "편집할 목록 단계를 선택하시오."
+
+#: ../src/richtext/richtextliststylepage.cpp:193
+msgid "&Font for Level..."
+msgstr "사용할 글꼴(&F)..."
+
+#: ../src/richtext/richtextliststylepage.cpp:194
+#: ../src/richtext/richtextliststylepage.cpp:196
+msgid "Click to choose the font for this level."
+msgstr "현재 단계의 글꼴을 선택 하시려면 클릭하십시오.."
+
+#: ../src/richtext/richtextliststylepage.cpp:312
+msgid "Bullet style"
+msgstr "글머리 모양새"
+
+#: ../src/richtext/richtextliststylepage.cpp:429
+msgid "Before a paragraph:"
+msgstr "단락 전:"
+
+#: ../src/richtext/richtextliststylepage.cpp:438
+msgid "After a paragraph:"
+msgstr "단락 후:"
+
+#: ../src/richtext/richtextliststylepage.cpp:447
+msgid "Line spacing:"
+msgstr "줄 간격:"
+
+#: ../src/richtext/richtextliststylepage.cpp:470
+msgid "Spacing"
+msgstr "간격"
+
+#: ../src/richtext/richtextmarginspage.cpp:193
+#: ../src/richtext/richtextmarginspage.cpp:195
+#, fuzzy
+msgid "The left margin size."
+msgstr "글꼴 크기"
+
+#: ../src/richtext/richtextmarginspage.cpp:203
+#: ../src/richtext/richtextmarginspage.cpp:205
+msgid "Units for the left margin."
+msgstr ""
+
+#: ../src/richtext/richtextmarginspage.cpp:218
+#: ../src/richtext/richtextmarginspage.cpp:220
+#, fuzzy
+msgid "The right margin size."
+msgstr "오른쪽 들여쓰기"
+
+#: ../src/richtext/richtextmarginspage.cpp:228
+#: ../src/richtext/richtextmarginspage.cpp:230
+msgid "Units for the right margin."
+msgstr ""
+
+#: ../src/richtext/richtextmarginspage.cpp:241
+#: ../src/richtext/richtextmarginspage.cpp:243
+#, fuzzy
+msgid "The top margin size."
+msgstr "글꼴 크기"
+
+#: ../src/richtext/richtextmarginspage.cpp:251
+#: ../src/richtext/richtextmarginspage.cpp:253
+#, fuzzy
+msgid "Units for the top margin."
+msgstr "쓰레드를 종료할 수 없습니다."
+
+#: ../src/richtext/richtextmarginspage.cpp:266
+#: ../src/richtext/richtextmarginspage.cpp:268
+#, fuzzy
+msgid "The bottom margin size."
+msgstr "글꼴 크기"
+
+#: ../src/richtext/richtextmarginspage.cpp:276
+#: ../src/richtext/richtextmarginspage.cpp:278
+msgid "Units for the bottom margin."
+msgstr ""
+
+#: ../src/richtext/richtextmarginspage.cpp:284
+msgid "Padding"
+msgstr ""
+
+#: ../src/richtext/richtextmarginspage.cpp:307
+#: ../src/richtext/richtextmarginspage.cpp:309
+#, fuzzy
+msgid "The left padding size."
+msgstr "글꼴 크기"
+
+#: ../src/richtext/richtextmarginspage.cpp:317
+#: ../src/richtext/richtextmarginspage.cpp:319
+msgid "Units for the left padding."
+msgstr ""
+
+#: ../src/richtext/richtextmarginspage.cpp:332
+#: ../src/richtext/richtextmarginspage.cpp:334
+#, fuzzy
+msgid "The right padding size."
+msgstr "오른쪽 들여쓰기"
+
+#: ../src/richtext/richtextmarginspage.cpp:342
+#: ../src/richtext/richtextmarginspage.cpp:344
+msgid "Units for the right padding."
+msgstr ""
+
+#: ../src/richtext/richtextmarginspage.cpp:355
+#: ../src/richtext/richtextmarginspage.cpp:357
+#, fuzzy
+msgid "The top padding size."
+msgstr "글꼴 크기"
+
+#: ../src/richtext/richtextmarginspage.cpp:365
+#: ../src/richtext/richtextmarginspage.cpp:367
+msgid "Units for the top padding."
+msgstr ""
+
+#: ../src/richtext/richtextmarginspage.cpp:380
+#: ../src/richtext/richtextmarginspage.cpp:382
+#, fuzzy
+msgid "The bottom padding size."
+msgstr "글꼴 크기"
+
+#: ../src/richtext/richtextmarginspage.cpp:390
+#: ../src/richtext/richtextmarginspage.cpp:392
+msgid "Units for the bottom padding."
+msgstr ""
+
+#: ../src/richtext/richtextprint.cpp:592
+msgid " Preview"
+msgstr " 미리보기"
+
+#: ../src/richtext/richtextsizepage.cpp:228
+msgid "Floating"
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:243
+msgid "&Floating mode:"
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:252
+#: ../src/richtext/richtextsizepage.cpp:254
+msgid "How the object will float relative to the text."
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:265
+#, fuzzy
+msgid "Alignment"
+msgstr "정렬(&A)"
+
+#: ../src/richtext/richtextsizepage.cpp:277
+#, fuzzy
+msgid "&Vertical alignment:"
+msgstr "글머리 정렬(&A)"
+
+#: ../src/richtext/richtextsizepage.cpp:279
+#: ../src/richtext/richtextsizepage.cpp:281
+#, fuzzy
+msgid "Enable vertical alignment."
+msgstr "정렬 방식을 지정할 수 없습니다."
+
+#: ../src/richtext/richtextsizepage.cpp:286
+#, fuzzy
+msgid "Centred"
+msgstr "중앙(&T)"
+
+#: ../src/richtext/richtextsizepage.cpp:290
+#: ../src/richtext/richtextsizepage.cpp:292
+#, fuzzy
+msgid "Vertical alignment."
+msgstr "정렬 방식을 지정할 수 없습니다."
+
+#: ../src/richtext/richtextsizepage.cpp:316
+#: ../src/richtext/richtextsizepage.cpp:323
+#, fuzzy
+msgid "&Width:"
+msgstr "두께(&W):"
+
+#: ../src/richtext/richtextsizepage.cpp:318
+#: ../src/richtext/richtextsizepage.cpp:320
+msgid "Enable the width value."
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:331
+#: ../src/richtext/richtextsizepage.cpp:333
+#, fuzzy
+msgid "The object width."
+msgstr "글꼴 두께"
+
+#: ../src/richtext/richtextsizepage.cpp:342
+#: ../src/richtext/richtextsizepage.cpp:344
+msgid "Units for the object width."
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:350
+#: ../src/richtext/richtextsizepage.cpp:357
+#, fuzzy
+msgid "&Height:"
+msgstr "두께(&W):"
+
+#: ../src/richtext/richtextsizepage.cpp:352
+#: ../src/richtext/richtextsizepage.cpp:354
+#: ../src/richtext/richtextsizepage.cpp:464
+#: ../src/richtext/richtextsizepage.cpp:466
+msgid "Enable the height value."
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:365
+#: ../src/richtext/richtextsizepage.cpp:367
+#, fuzzy
+msgid "The object height."
+msgstr "글꼴 두께"
+
+#: ../src/richtext/richtextsizepage.cpp:376
+#: ../src/richtext/richtextsizepage.cpp:378
+msgid "Units for the object height."
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:381
+msgid "Min width:"
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:383
+#: ../src/richtext/richtextsizepage.cpp:385
+#, fuzzy
+msgid "Enable the minimum width value."
+msgstr "최소 너비를 지정할 수 없습니다."
+
+#: ../src/richtext/richtextsizepage.cpp:392
+#: ../src/richtext/richtextsizepage.cpp:394
+#, fuzzy
+msgid "The object minimum width."
+msgstr "글꼴 두께"
+
+#: ../src/richtext/richtextsizepage.cpp:403
+#: ../src/richtext/richtextsizepage.cpp:405
+#, fuzzy
+msgid "Units for the minimum object width."
+msgstr "글꼴 두께"
+
+#: ../src/richtext/richtextsizepage.cpp:408
+#, fuzzy
+msgid "Min height:"
+msgstr "글꼴 굵기(&W):"
+
+#: ../src/richtext/richtextsizepage.cpp:410
+#: ../src/richtext/richtextsizepage.cpp:412
+msgid "Enable the minimum height value."
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:419
+#: ../src/richtext/richtextsizepage.cpp:421
+#, fuzzy
+msgid "The object minimum height."
+msgstr "글꼴 두께"
+
+#: ../src/richtext/richtextsizepage.cpp:430
+#: ../src/richtext/richtextsizepage.cpp:432
+#, fuzzy
+msgid "Units for the minimum object height."
+msgstr "글꼴 두께"
+
+#: ../src/richtext/richtextsizepage.cpp:435
+#, fuzzy
+msgid "Max width:"
+msgstr "다음으로 바꾸기:"
+
+#: ../src/richtext/richtextsizepage.cpp:437
+#: ../src/richtext/richtextsizepage.cpp:439
+#, fuzzy
+msgid "Enable the maximum width value."
+msgstr "최대 너비를 지정할 수 없습니다."
+
+#: ../src/richtext/richtextsizepage.cpp:446
+#: ../src/richtext/richtextsizepage.cpp:448
+#, fuzzy
+msgid "The object maximum width."
+msgstr "글꼴 두께"
+
+#: ../src/richtext/richtextsizepage.cpp:457
+#: ../src/richtext/richtextsizepage.cpp:459
+#, fuzzy
+msgid "Units for the maximum object width."
+msgstr "글꼴 두께"
+
+#: ../src/richtext/richtextsizepage.cpp:462
+#, fuzzy
+msgid "Max height:"
+msgstr "두께(&W):"
+
+#: ../src/richtext/richtextsizepage.cpp:473
+#: ../src/richtext/richtextsizepage.cpp:475
+#, fuzzy
+msgid "The object maximum height."
+msgstr "글꼴 두께"
+
+#: ../src/richtext/richtextsizepage.cpp:484
+#: ../src/richtext/richtextsizepage.cpp:486
+#, fuzzy
+msgid "Units for the maximum object height."
+msgstr "글꼴 두께"
+
+#: ../src/richtext/richtextsizepage.cpp:495
+#, fuzzy
+msgid "Position"
+msgstr "질문"
+
+#: ../src/richtext/richtextsizepage.cpp:513
+#, fuzzy
+msgid "&Position mode:"
+msgstr "질문"
+
+#: ../src/richtext/richtextsizepage.cpp:517
+#: ../src/richtext/richtextsizepage.cpp:522
+#, fuzzy
+msgid "Static"
+msgstr "상태:"
+
+#: ../src/richtext/richtextsizepage.cpp:518
+#, fuzzy
+msgid "Relative"
+msgstr "Decorative"
+
+#: ../src/richtext/richtextsizepage.cpp:519
+msgid "Absolute"
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:520
+#, fuzzy
+msgid "Fixed"
+msgstr "고정폭 글꼴:"
+
+#: ../src/richtext/richtextsizepage.cpp:533
+#: ../src/richtext/richtextsizepage.cpp:535
+#: ../src/richtext/richtextsizepage.cpp:547
+#: ../src/richtext/richtextsizepage.cpp:549
+#, fuzzy
+msgid "The left position."
+msgstr "탭 위치"
+
+#: ../src/richtext/richtextsizepage.cpp:558
+#: ../src/richtext/richtextsizepage.cpp:560
+#, fuzzy
+msgid "Units for the left position."
+msgstr "쓰레드를 종료할 수 없습니다."
+
+#: ../src/richtext/richtextsizepage.cpp:568
+#: ../src/richtext/richtextsizepage.cpp:570
+#: ../src/richtext/richtextsizepage.cpp:582
+#: ../src/richtext/richtextsizepage.cpp:584
+#, fuzzy
+msgid "The top position."
+msgstr "탭 위치"
+
+#: ../src/richtext/richtextsizepage.cpp:593
+#: ../src/richtext/richtextsizepage.cpp:595
+#, fuzzy
+msgid "Units for the top position."
+msgstr "쓰레드를 종료할 수 없습니다."
+
+#: ../src/richtext/richtextsizepage.cpp:603
+#: ../src/richtext/richtextsizepage.cpp:605
+#: ../src/richtext/richtextsizepage.cpp:617
+#: ../src/richtext/richtextsizepage.cpp:619
+#, fuzzy
+msgid "The right position."
+msgstr "탭 위치"
+
+#: ../src/richtext/richtextsizepage.cpp:628
+#: ../src/richtext/richtextsizepage.cpp:630
+#, fuzzy
+msgid "Units for the right position."
+msgstr "쓰레드를 종료할 수 없습니다."
+
+#: ../src/richtext/richtextsizepage.cpp:638
+#: ../src/richtext/richtextsizepage.cpp:640
+#: ../src/richtext/richtextsizepage.cpp:652
+#: ../src/richtext/richtextsizepage.cpp:654
+#, fuzzy
+msgid "The bottom position."
+msgstr "탭 위치"
+
+#: ../src/richtext/richtextsizepage.cpp:663
+#: ../src/richtext/richtextsizepage.cpp:665
+#, fuzzy
+msgid "Units for the bottom position."
+msgstr "쓰레드를 종료할 수 없습니다."
+
+#: ../src/richtext/richtextsizepage.cpp:671
+msgid "&Move the object to:"
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:674
+#, fuzzy
+msgid "&Previous Paragraph"
+msgstr "이전 페이지"
+
+#: ../src/richtext/richtextsizepage.cpp:675
+#: ../src/richtext/richtextsizepage.cpp:677
+#, fuzzy
+msgid "Moves the object to the previous paragraph."
+msgstr "이전 HTML 페이지로 이동"
+
+#: ../src/richtext/richtextsizepage.cpp:680
+#, fuzzy
+msgid "&Next Paragraph"
+msgstr "단락 후(&A):"
+
+#: ../src/richtext/richtextsizepage.cpp:681
+#: ../src/richtext/richtextsizepage.cpp:683
+#, fuzzy
+msgid "Moves the object to the next paragraph."
+msgstr "다음 단락의 기본 모양새"
+
+#: ../src/richtext/richtextstyledlg.cpp:193
+msgid "&Styles:"
+msgstr "모양새(&S):"
+
+#: ../src/richtext/richtextstyledlg.cpp:197
+#: ../src/richtext/richtextstyledlg.cpp:199
+msgid "The available styles."
+msgstr "사용가능한 모양새"
+
+#: ../src/richtext/richtextstyledlg.cpp:205
+#: ../src/richtext/richtextstyledlg.cpp:217
+msgid " "
+msgstr " "
+
+#: ../src/richtext/richtextstyledlg.cpp:209
+#: ../src/richtext/richtextstyledlg.cpp:211
+msgid "The style preview."
+msgstr "모양새 미리보기"
+
+#: ../src/richtext/richtextstyledlg.cpp:220
+msgid "New &Character Style..."
+msgstr "새 글꼴 모양새(&C)..."
+
+#: ../src/richtext/richtextstyledlg.cpp:221
+#: ../src/richtext/richtextstyledlg.cpp:223
+msgid "Click to create a new character style."
+msgstr "새로운 글꼴 모양새를 만들려면 여기를 누르십시오."
+
+#: ../src/richtext/richtextstyledlg.cpp:226
+msgid "New &Paragraph Style..."
+msgstr "새 단락 모양새(&P)"
+
+#: ../src/richtext/richtextstyledlg.cpp:227
+#: ../src/richtext/richtextstyledlg.cpp:229
+msgid "Click to create a new paragraph style."
+msgstr "새로운 단락 모양새를 만들려면 여기를 누르십시오."
+
+#: ../src/richtext/richtextstyledlg.cpp:232
+msgid "New &List Style..."
+msgstr "새 목록 모양새(&L)"
+
+#: ../src/richtext/richtextstyledlg.cpp:233
+#: ../src/richtext/richtextstyledlg.cpp:235
+msgid "Click to create a new list style."
+msgstr "새로운 목록 모양새를 만들려면 여기를 누르십시오."
+
+#: ../src/richtext/richtextstyledlg.cpp:238
+#, fuzzy
+msgid "New &Box Style..."
+msgstr "새 목록 모양새(&L)"
+
+#: ../src/richtext/richtextstyledlg.cpp:239
+#: ../src/richtext/richtextstyledlg.cpp:241
+#, fuzzy
+msgid "Click to create a new box style."
+msgstr "새로운 목록 모양새를 만들려면 여기를 누르십시오."
+
+#: ../src/richtext/richtextstyledlg.cpp:246
+msgid "&Apply Style"
+msgstr "모양새 적용(&A)"
+
+#: ../src/richtext/richtextstyledlg.cpp:247
+#: ../src/richtext/richtextstyledlg.cpp:249
+msgid "Click to apply the selected style."
+msgstr "선택한 모양새를 적용하려면 클릭하십시오"
+
+#: ../src/richtext/richtextstyledlg.cpp:252
+msgid "&Rename Style..."
+msgstr "모양새 이름 바꾸기(&R)..."
+
+#: ../src/richtext/richtextstyledlg.cpp:253
+#: ../src/richtext/richtextstyledlg.cpp:255
+msgid "Click to rename the selected style."
+msgstr "선택한 모양새의 이름을 변경하려면 여기를 누르십시오."
+
+#: ../src/richtext/richtextstyledlg.cpp:258
+msgid "&Edit Style..."
+msgstr "편집 모양새...(&E)"
+
+#: ../src/richtext/richtextstyledlg.cpp:259
+#: ../src/richtext/richtextstyledlg.cpp:261
+msgid "Click to edit the selected style."
+msgstr "선택한 팔레트를 편집하려면 여기를 누르십시오."
+
+#: ../src/richtext/richtextstyledlg.cpp:264
+msgid "&Delete Style..."
+msgstr "모양새 지우기...(&D)"
+
+#: ../src/richtext/richtextstyledlg.cpp:265
+#: ../src/richtext/richtextstyledlg.cpp:267
+msgid "Click to delete the selected style."
+msgstr "선택한 모양새를 지우려면 여기를 누르십시오."
+
+#: ../src/richtext/richtextstyledlg.cpp:274
+#: ../src/richtext/richtextstyledlg.cpp:276
+msgid "Click to close this window."
+msgstr "현재 창을 닫으려면 여기를 누르십시오."
+
+#: ../src/richtext/richtextstyledlg.cpp:282
+msgid "&Restart numbering"
+msgstr "번호 다시 매기기(&R)"
+
+#: ../src/richtext/richtextstyledlg.cpp:284
+#: ../src/richtext/richtextstyledlg.cpp:286
+msgid "Check to restart numbering."
+msgstr "번호 다시 매기기 선택"
+
+#: ../src/richtext/richtextstyledlg.cpp:601
+msgid "Enter a character style name"
+msgstr "글꼴 모양새 이름을 입력하십시오"
+
+#: ../src/richtext/richtextstyledlg.cpp:601
+#: ../src/richtext/richtextstyledlg.cpp:606
+#: ../src/richtext/richtextstyledlg.cpp:649
+#: ../src/richtext/richtextstyledlg.cpp:654
+#: ../src/richtext/richtextstyledlg.cpp:815
+#: ../src/richtext/richtextstyledlg.cpp:820
+#: ../src/richtext/richtextstyledlg.cpp:888
+#: ../src/richtext/richtextstyledlg.cpp:896
+#: ../src/richtext/richtextstyledlg.cpp:929
+#: ../src/richtext/richtextstyledlg.cpp:934
+msgid "New Style"
+msgstr "새 모양새"
+
+#: ../src/richtext/richtextstyledlg.cpp:606
+#: ../src/richtext/richtextstyledlg.cpp:654
+#: ../src/richtext/richtextstyledlg.cpp:820
+#: ../src/richtext/richtextstyledlg.cpp:896
+#: ../src/richtext/richtextstyledlg.cpp:934
+msgid "Sorry, that name is taken. Please choose another."
+msgstr "이미 존재하는 이름입니다. 다른 이름을 선택하십시오."
+
+#: ../src/richtext/richtextstyledlg.cpp:649
+msgid "Enter a paragraph style name"
+msgstr "단락 모양새 이름을 입력하십시오"
+
+#: ../src/richtext/richtextstyledlg.cpp:777
+#, c-format
+msgid "Delete style %s?"
+msgstr "'%s' 모양새를 지우시겠습니다까?"
+
+#: ../src/richtext/richtextstyledlg.cpp:777
+msgid "Delete Style"
+msgstr "모양새 지우기"
+
+#: ../src/richtext/richtextstyledlg.cpp:815
+msgid "Enter a list style name"
+msgstr "목록 모양새 이름을 입력하십시오"
+
+#: ../src/richtext/richtextstyledlg.cpp:888
+msgid "Enter a new style name"
+msgstr "새 모양새 이름을 입력하십시오"
+
+#: ../src/richtext/richtextstyledlg.cpp:929
+#, fuzzy
+msgid "Enter a box style name"
+msgstr "새 모양새 이름을 입력하십시오"
+
+#: ../src/richtext/richtextstylepage.cpp:109
+#: ../src/richtext/richtextstylepage.cpp:111
+msgid "The style name."
+msgstr "모양새 이름"
+
+#: ../src/richtext/richtextstylepage.cpp:114
+msgid "&Based on:"
+msgstr "기본(&B)"
+
+#: ../src/richtext/richtextstylepage.cpp:119
+#: ../src/richtext/richtextstylepage.cpp:121
+msgid "The style on which this style is based."
+msgstr "기본 모양새."
+
+#: ../src/richtext/richtextstylepage.cpp:124
+msgid "&Next style:"
+msgstr "다음 모양새(&N)"
+
+#: ../src/richtext/richtextstylepage.cpp:129
+#: ../src/richtext/richtextstylepage.cpp:131
+msgid "The default style for the next paragraph."
+msgstr "다음 단락의 기본 모양새"
+
+#: ../src/richtext/richtextstyles.cpp:1057
+msgid "All styles"
+msgstr "모든 모양새"
+
+#: ../src/richtext/richtextstyles.cpp:1058
+msgid "Paragraph styles"
+msgstr "단락 모양새"
+
+#: ../src/richtext/richtextstyles.cpp:1059
+msgid "Character styles"
+msgstr "글꼴 모양새"
+
+#: ../src/richtext/richtextstyles.cpp:1060
+msgid "List styles"
+msgstr "목록 모양새"
+
+#: ../src/richtext/richtextstyles.cpp:1061
+#, fuzzy
+msgid "Box styles"
+msgstr "모든 모양새"
+
+#: ../src/richtext/richtextsymboldlg.cpp:389
+#: ../src/richtext/richtextsymboldlg.cpp:391
+msgid "The font from which to take the symbol."
+msgstr "기호의 글꼴."
+
+#: ../src/richtext/richtextsymboldlg.cpp:396
+msgid "&Subset:"
+msgstr "분류(&S):"
+
+#: ../src/richtext/richtextsymboldlg.cpp:401
+#: ../src/richtext/richtextsymboldlg.cpp:403
+msgid "Shows a Unicode subset."
+msgstr "Unicode 부분집합 표시"
+
+#: ../src/richtext/richtextsymboldlg.cpp:412
+msgid "xxxx"
+msgstr ""
+
+#: ../src/richtext/richtextsymboldlg.cpp:417
+msgid "&Character code:"
+msgstr "문자 코드(&C):"
+
+#: ../src/richtext/richtextsymboldlg.cpp:421
+#: ../src/richtext/richtextsymboldlg.cpp:423
+msgid "The character code."
+msgstr "문자 코드."
+
+#: ../src/richtext/richtextsymboldlg.cpp:428
+msgid "&From:"
+msgstr "송신(&F):"
+
+#: ../src/richtext/richtextsymboldlg.cpp:433
+#: ../src/richtext/richtextsymboldlg.cpp:434
+#: ../src/richtext/richtextsymboldlg.cpp:435
+msgid "Unicode"
+msgstr "유니코드"
+
+#: ../src/richtext/richtextsymboldlg.cpp:436
+#: ../src/richtext/richtextsymboldlg.cpp:438
+msgid "The range to show."
+msgstr "범위 보기"
+
+#: ../src/richtext/richtextsymboldlg.cpp:444
+msgid "Insert"
+msgstr "넣기"
+
+#: ../src/richtext/richtextsymboldlg.cpp:478
+msgid "(Normal text)"
+msgstr "(일반 텍스트)"
+
+#: ../src/richtext/richtexttabspage.cpp:109
+msgid "&Position (tenths of a mm):"
+msgstr "위치(&P)(mm/10):"
+
+#: ../src/richtext/richtexttabspage.cpp:113
+#: ../src/richtext/richtexttabspage.cpp:115
+msgid "The tab position."
+msgstr "탭 위치"
+
+#: ../src/richtext/richtexttabspage.cpp:119
+msgid "The tab positions."
+msgstr "탭 위치"
+
+#: ../src/richtext/richtexttabspage.cpp:132
+#: ../src/richtext/richtexttabspage.cpp:134
+msgid "Click to create a new tab position."
+msgstr "새로운 탭 위치 만들려면 여기를 누르십시오."
+
+#: ../src/richtext/richtexttabspage.cpp:138
+#: ../src/richtext/richtexttabspage.cpp:140
+msgid "Click to delete the selected tab position."
+msgstr "선택한 탭 위치를 삭제 하시려면 클릭하십시오."
+
+#: ../src/richtext/richtexttabspage.cpp:143
+msgid "Delete A&ll"
+msgstr "모두 지우기(&L)"
+
+#: ../src/richtext/richtexttabspage.cpp:144
+#: ../src/richtext/richtexttabspage.cpp:146
+msgid "Click to delete all tab positions."
+msgstr "모든 탭 위치를 삭제 하시려면 클릭하십시오."
+
+#: ../src/univ/theme.cpp:110
+msgid "Failed to initialize GUI: no built-in themes found."
+msgstr "GUI 초기화 실패: 테마를 찾을 수 없습니다."
+
+#: ../src/univ/themes/gtk.cpp:521
+msgid "GTK+ theme"
+msgstr "Gtk+ 테마"
+
+#: ../src/univ/themes/metal.cpp:164
+msgid "Metal theme"
+msgstr "메탈 테마"
+
+#: ../src/univ/themes/mono.cpp:512
+msgid "Simple monochrome theme"
+msgstr "Simple monochrome 테마"
+
+#: ../src/univ/themes/win32.cpp:1098
+msgid "Win32 theme"
+msgstr "Win32 테마"
+
+#: ../src/univ/themes/win32.cpp:3743
+msgid "&Restore"
+msgstr "이전 크기로(&R)"
+
+#: ../src/univ/themes/win32.cpp:3744
+msgid "&Move"
+msgstr "이동(&M)"
+
+#: ../src/univ/themes/win32.cpp:3746
+msgid "&Size"
+msgstr "크기(&S)"
+
+#: ../src/univ/themes/win32.cpp:3748
+msgid "Mi&nimize"
+msgstr "최소화(&N)"
+
+#: ../src/univ/themes/win32.cpp:3750
+msgid "Ma&ximize"
+msgstr "최대화(&X)"
+
+#: ../src/univ/themes/win32.cpp:3752
+msgid "Alt+"
+msgstr ""
+
+#: ../src/unix/appunix.cpp:178
+msgid "Failed to install signal handler"
+msgstr "Signal 등록을 실패했습니다."
+
+#: ../src/unix/dialup.cpp:351
+msgid "Already dialling ISP."
+msgstr "이미 ISP에 전화 연결중입니다."
+
+#: ../src/unix/dlunix.cpp:93
+#, fuzzy
+msgid "Failed to unload shared library"
+msgstr "'%s' 공유 Library를 읽어올 수 없습니다."
+
+#: ../src/unix/dlunix.cpp:121
+msgid "Unknown dynamic library error"
+msgstr "알수 없는 동적 Library 오류"
+
+#: ../src/unix/epolldispatcher.cpp:84
+msgid "Failed to create epoll descriptor"
+msgstr "Epoll 디스크립터 생성을 실패했습니다."
+
+#: ../src/unix/epolldispatcher.cpp:103
+msgid "Error closing epoll descriptor"
+msgstr "Epoll 디스크립터 닫기 실패"
+
+#: ../src/unix/epolldispatcher.cpp:116
+#, c-format
+msgid "Failed to add descriptor %d to epoll descriptor %d"
+msgstr "Epoll 디스크립터 %d 에 파일 디스크립터 %d 을 추가하는데 실패했습니다. "
+
+#: ../src/unix/epolldispatcher.cpp:136
+#, c-format
+msgid "Failed to modify descriptor %d in epoll descriptor %d"
+msgstr "Epoll 디스크립터 %d에서  파일 디스크립터 %d의 수정을 실패 했습니다."
+
+#: ../src/unix/epolldispatcher.cpp:155
+#, c-format
+msgid "Failed to unregister descriptor %d from epoll descriptor %d"
+msgstr "Epoll 디스크립트 %d 에서 파일 디스크립터 %d를 제거하지 못했습니다."
+
+#: ../src/unix/epolldispatcher.cpp:213
+#, c-format
+msgid "Waiting for IO on epoll descriptor %d failed"
+msgstr "Epoll 디스크립터 %d 의 입출력 대기가 실패했습니다."
+
+#: ../src/unix/fswatcher_inotify.cpp:71
+#, fuzzy
+msgid "Unable to create inotify instance"
+msgstr "DDE 문자열 생성을 실패 했습니다."
+
+#: ../src/unix/fswatcher_inotify.cpp:94
+#, fuzzy
+msgid "Unable to close inotify instance"
+msgstr "파일 닫기를 실패했습니다."
+
+#: ../src/unix/fswatcher_inotify.cpp:106
+msgid "Unable to add inotify watch"
+msgstr ""
+
+#: ../src/unix/fswatcher_inotify.cpp:138
+#, fuzzy, c-format
+msgid "Unable to remove inotify watch %i"
+msgstr "DDE 문자열 생성을 실패 했습니다."
+
+#: ../src/unix/fswatcher_inotify.cpp:271
+#, c-format
+msgid "Unexpected event for \"%s\": no matching watch descriptor."
+msgstr ""
+
+#: ../src/unix/fswatcher_inotify.cpp:320
+#, c-format
+msgid "Invalid inotify event for \"%s\""
+msgstr ""
+
+#: ../src/unix/fswatcher_inotify.cpp:553
+#, fuzzy
+msgid "Unable to read from inotify descriptor"
+msgstr "파일 디스크립터 %d 에서 데이타를 읽어 올 수 없습니다."
+
+#: ../src/unix/fswatcher_inotify.cpp:558
+#, fuzzy
+msgid "EOF while reading from inotify descriptor"
+msgstr "파일 디스크립터 %d 에서 데이타를 읽어 올 수 없습니다."
+
+#: ../src/unix/fswatcher_kqueue.cpp:114
+#, fuzzy
+msgid "Unable to create kqueue instance"
+msgstr "DDE 문자열 생성을 실패 했습니다."
+
+#: ../src/unix/fswatcher_kqueue.cpp:131
+#, fuzzy
+msgid "Error closing kqueue instance"
+msgstr "Epoll 디스크립터 닫기 실패"
+
+#: ../src/unix/fswatcher_kqueue.cpp:153
+msgid "Unable to add kqueue watch"
+msgstr ""
+
+#: ../src/unix/fswatcher_kqueue.cpp:170
+msgid "Unable to remove kqueue watch"
+msgstr ""
+
+#: ../src/unix/fswatcher_kqueue.cpp:202
+msgid "Unable to get events from kqueue"
+msgstr ""
+
+#: ../src/unix/mediactrl.cpp:966
+#, c-format
+msgid "Media playback error: %s"
+msgstr ""
+
+#: ../src/unix/mediactrl.cpp:1228
+#, fuzzy, c-format
+msgid "Failed to prepare playing \"%s\"."
+msgstr "'%s' 디스플레이를 여는 데 실패했습니다."
+
+#: ../src/unix/snglinst.cpp:164
+#, c-format
+msgid "Failed to write to lock file '%s'"
+msgstr "'%s' 잠금 파일에 쓰기를 실패했습니다."
+
+#: ../src/unix/snglinst.cpp:177
+#, c-format
+msgid "Failed to set permissions on lock file '%s'"
+msgstr "잠금 파일 '%s' 의 접근권한 설정을 실패했습니다."
+
+#: ../src/unix/snglinst.cpp:194
+#, c-format
+msgid "Failed to lock the lock file '%s'"
+msgstr "'%s' 잠금 파일의 잠금 실패 "
+
+#: ../src/unix/snglinst.cpp:237
+#, c-format
+msgid "Failed to inspect the lock file '%s'"
+msgstr "'%s' 파일 조사를 실패했습니다(잠금 파일)."
+
+#: ../src/unix/snglinst.cpp:242
+#, c-format
+msgid "Lock file '%s' has incorrect owner."
+msgstr "'%s' 잠금파일의 소유자가 잘못되었습니다."
+
+#: ../src/unix/snglinst.cpp:247
+#, c-format
+msgid "Lock file '%s' has incorrect permissions."
+msgstr "'%s' 잠금파일의 접근권한이 잘못되었습니다."
+
+#: ../src/unix/snglinst.cpp:265
+msgid "Failed to access lock file."
+msgstr "파일 접근에 실패했습니다(잠금 파일)."
+
+#: ../src/unix/snglinst.cpp:274
+msgid "Failed to read PID from lock file."
+msgstr "잠금 파일에서  pid를  읽는 데 실패했습니다."
+
+#: ../src/unix/snglinst.cpp:284
+#, c-format
+msgid "Failed to remove stale lock file '%s'."
+msgstr "오래된 잠금 파일 '%s' 의 삭제 실패"
+
+#: ../src/unix/snglinst.cpp:297
+#, c-format
+msgid "Deleted stale lock file '%s'."
+msgstr "오래된 잠금 파일 '%s' 삭제."
+
+#: ../src/unix/snglinst.cpp:308
+#, c-format
+msgid "Invalid lock file '%s'."
+msgstr "'%s' 잠금 파일이 없습니다."
+
+#: ../src/unix/snglinst.cpp:324
+#, c-format
+msgid "Failed to remove lock file '%s'"
+msgstr "'%s' 잠금 파일을 지우는 데 실패했습니다"
+
+#: ../src/unix/snglinst.cpp:330
+#, c-format
+msgid "Failed to unlock lock file '%s'"
+msgstr "'%s' 파일의 잠금 해제 실패"
+
+#: ../src/unix/snglinst.cpp:336
+#, c-format
+msgid "Failed to close lock file '%s'"
+msgstr "'%s' 파일을 지우는 실패했습니다(잠금 파일)."
+
+#: ../src/unix/sound.cpp:77
+msgid "No sound"
+msgstr "소리 없음"
+
+#: ../src/unix/sound.cpp:364
+msgid "Unable to play sound asynchronously."
+msgstr "사운드를 비동기로 재생할 수 없습니다."
+
+#: ../src/unix/sound.cpp:458
+#, c-format
+msgid "Couldn't load sound data from '%s'."
+msgstr "'%s' 에서 소리 데이타를 읽어올 수 없습니다."
+
+#: ../src/unix/sound.cpp:465
+#, c-format
+msgid "Sound file '%s' is in unsupported format."
+msgstr "'\"%s' 사운드 파일은 지원되지 않는 형식입니다."
+
+#: ../src/unix/sound.cpp:480
+msgid "Sound data are in unsupported format."
+msgstr "소리 데이타가 알 수 없는 형식 입니다."
+
+#: ../src/unix/sound_sdl.cpp:226
+#, c-format
+msgid "Couldn't open audio: %s"
+msgstr "오디오 열기 실패: %s"
+
+#: ../src/unix/threadpsx.cpp:1033
+msgid "Cannot retrieve thread scheduling policy."
+msgstr "스레드 스케줄링 정책을 찾을 수 없습니다."
+
+#: ../src/unix/threadpsx.cpp:1058
+#, c-format
+msgid "Cannot get priority range for scheduling policy %d."
+msgstr "스케줄링 정책 %d 에서 우선순위 범위를 얻을 수 없습니다."
+
+#: ../src/unix/threadpsx.cpp:1066
+msgid "Thread priority setting is ignored."
+msgstr "쓰레드 우선순위 설정을 무시합니다."
+
+#: ../src/unix/threadpsx.cpp:1221
+msgid ""
+"Failed to join a thread, potential memory leak detected - please restart the "
+"program"
+msgstr ""
+"쓰레드 종료 실패, 잠재적인 메모리 누수 감지함. 프로그램을 다시 시작하십시오."
+
+#: ../src/unix/threadpsx.cpp:1352
+#, fuzzy, c-format
+msgid "Failed to set thread concurrency level to %lu"
+msgstr "스레드 우선순위(%d) 설정을 실패했습니다."
+
+#: ../src/unix/threadpsx.cpp:1481
+#, c-format
+msgid "Failed to set thread priority %d."
+msgstr "스레드 우선순위(%d) 설정을 실패했습니다."
+
+#: ../src/unix/threadpsx.cpp:1666
+msgid "Failed to terminate a thread."
+msgstr "스레드를 종료를 실패했습니다."
+
+#: ../src/unix/threadpsx.cpp:1893
+msgid "Thread module initialization failed: failed to create thread key"
+msgstr "쓰레드 모듈 초기화 실패: 쓰레드 키 생성 실패"
+
+#: ../src/unix/utilsunx.cpp:340
+msgid "Impossible to get child process input"
+msgstr "자식 프로세스의 입력 리다이렉트 실패"
+
+#: ../src/unix/utilsunx.cpp:390
+#, fuzzy
+msgid "Can't write to child process's stdin"
+msgstr "프로세스 %d 종료할 수 없습니다."
+
+#: ../src/unix/utilsunx.cpp:644
+#, c-format
+msgid "Failed to execute '%s'\n"
+msgstr "'%s' 실행을 실패했습니다.\n"
+
+#: ../src/unix/utilsunx.cpp:678
+msgid "Fork failed"
+msgstr "포크 실패"
+
+#: ../src/unix/utilsunx.cpp:701
+#, fuzzy
+msgid "Failed to set process priority"
+msgstr "스레드 우선순위(%d) 설정을 실패했습니다."
+
+#: ../src/unix/utilsunx.cpp:712
+msgid "Failed to redirect child process input/output"
+msgstr "자식 프로세스의 입력 또는 출력의 리다이렉트 실패"
+
+#: ../src/unix/utilsunx.cpp:816
+msgid "Failed to set up non-blocking pipe, the program might hang."
+msgstr ""
+
+#: ../src/unix/utilsunx.cpp:1023
+msgid "Cannot get the hostname"
+msgstr "hostname을 얻을 수 없습니다"
+
+#: ../src/unix/utilsunx.cpp:1059
+msgid "Cannot get the official hostname"
+msgstr "공식 hostname을 얻을 수 없습니다"
+
+#: ../src/unix/wakeuppipe.cpp:49
+msgid "Failed to create wake up pipe used by event loop."
+msgstr "이벤트 루프에 의한 파이프 Wake-up이 실패 했습니다."
+
+#: ../src/unix/wakeuppipe.cpp:56
+msgid "Failed to switch wake up pipe to non-blocking mode"
+msgstr "비동기 모드에서 파이프를 Wake-up 상태롤 변경하는데 실패"
+
+#: ../src/unix/wakeuppipe.cpp:117
+msgid "Failed to read from wake-up pipe"
+msgstr "Wake-up 파이프에서 읽는 데 실패했습니다."
+
+#: ../src/x11/app.cpp:124
+#, c-format
+msgid "Invalid geometry specification '%s'"
+msgstr "잘못된 Geometry 지정: '%s'"
+
+#: ../src/x11/app.cpp:167
+msgid "wxWidgets could not open display. Exiting."
+msgstr "wxWidgets: 디스플레이 열기 실패. 종료합니다."
+
+#: ../src/x11/utils.cpp:169
+#, c-format
+msgid "Failed to close the display \"%s\""
+msgstr "디스플레이 \"%s\" 를 닫는 데 실패했습니다."
+
+#: ../src/x11/utils.cpp:188
+#, c-format
+msgid "Failed to open display \"%s\"."
+msgstr "'%s' 디스플레이를 여는 데 실패했습니다."
+
+#: ../src/xml/xml.cpp:868
+#, c-format
+msgid "XML parsing error: '%s' at line %d"
+msgstr "XML 해석 오류: %s  (줄번호 %d)"
+
+#: ../src/xrc/xh_propgrid.cpp:239
+#, fuzzy, c-format
+msgid "Page %i"
+msgstr "페이지 %d"
+
+#: ../src/xrc/xmlres.cpp:448
+#, fuzzy, c-format
+msgid "Cannot load resources from '%s'."
+msgstr "'%s' 파일에서 리소스를 읽어올 수 없습니다."
+
+#: ../src/xrc/xmlres.cpp:799
+#, fuzzy, c-format
+msgid "Cannot open resources file '%s'."
+msgstr "'%s' 파일에서 리소스를 읽어올 수 없습니다."
+
+#: ../src/xrc/xmlres.cpp:806
+#, c-format
+msgid "Cannot load resources from file '%s'."
+msgstr "'%s' 파일에서 리소스를 읽어올 수 없습니다."
+
+#: ../src/xrc/xmlres.cpp:2767
+#, fuzzy, c-format
+msgid "Creating %s \"%s\" failed."
+msgstr "'%s' 의 추출('%s' 에서) 실패 했습니다."
+
+#~ msgid "Unsupported clipboard format."
+#~ msgstr "클립보드를 지원하지 않습니다."
+
+#~ msgid "Background colour"
+#~ msgstr "배경 색"
+
+#~ msgid "Font:"
+#~ msgstr "글꼴:"
+
+#~ msgid "Size:"
+#~ msgstr "크기:"
+
+#~ msgid "The font size in points."
+#~ msgstr "포인트로 나타낸 글꼴 크기"
+
+#~ msgid "Style:"
+#~ msgstr "모양새:"
+
+#~ msgid "Check to make the font bold."
+#~ msgstr "글꼴을 굵게"
+
+#~ msgid "Check to make the font italic."
+#~ msgstr "글꼴을 기울임"
+
+#~ msgid "Check to make the font underlined."
+#~ msgstr "글꼴에 밑줄을 추가."
+
+#~ msgid "Colour:"
+#~ msgstr "색상:"
+
+#~ msgid "Click to change the font colour."
+#~ msgstr "글꼴의 색상을 변경 하려면 여기를 누르십시오."
+
+#~ msgid "Shows a preview of the font."
+#~ msgstr "글꼴 미리보기"
+
+#~ msgid "Click to cancel changes to the font."
+#~ msgstr "글꼴 변경을 취소하려면 여기를 누르십시오."
+
+#~ msgid "Click to confirm changes to the font."
+#~ msgstr "글꼴을 변경 적용하려면 여기를 누르십시오."
+
+#~ msgid "Printing "
+#~ msgstr "인쇄중"
+
+#~ msgid "Failed to insert text in the control."
+#~ msgstr "컨트롤에 텍스트 삽입 실패."
+
+#~ msgid "Please choose a valid font."
+#~ msgstr "사용 가능한 글꼴을 선택하십시오."
+
+#, c-format
+#~ msgid "Failed to display HTML document in %s encoding"
+#~ msgstr "%s 인코딩으로 HTML 문서 보기 실패"
+
+#, c-format
+#~ msgid "wxWidgets could not open display for '%s': exiting."
+#~ msgstr "wxWidgets: 디스플레이 '%s' 의 열기 실패. 종료합니다."
+
+#~ msgid "Filter"
+#~ msgstr "필터"
+
+#~ msgid "Directories"
+#~ msgstr "디렉토리"
+
+#~ msgid "Files"
+#~ msgstr "파일"
+
+#~ msgid "Selection"
+#~ msgstr "선택"
+
+#~ msgid "conversion to 8-bit encoding failed"
+#~ msgstr "8비트 인코딩 변환 실패"
+
+#, fuzzy
+#~ msgid "failed to retrieve execution result"
+#~ msgstr "RAS 오류 메시지의 텍스트의 검색 실패"
+
+#, fuzzy
+#~ msgid "&Save as"
+#~ msgstr "다른 이름으로 저장"
+
+#, fuzzy
+#~ msgid "'%s' doesn't consist only of valid characters"
+#~ msgstr "문자열 '%s' 에는 알파벳 이외의 문자가 입력되었습니다."
+
+#~ msgid "'%s' should be numeric."
+#~ msgstr "'%s' 에 숫자 이외의 문자가 입력되었습니다."
+
+#~ msgid "'%s' should only contain ASCII characters."
+#~ msgstr "문자열 '%s' 에는 ASCII 이외의 문자가 입력되었습니다."
+
+#~ msgid "'%s' should only contain alphabetic characters."
+#~ msgstr "문자열 '%s' 에는 알파벳 이외의 문자가 입력되었습니다."
+
+#~ msgid "'%s' should only contain alphabetic or numeric characters."
+#~ msgstr "문자열 '%s' 에는 알파벳 및 숫자 이외의 문자가 입력되었습니다."
+
+#, fuzzy
+#~ msgid "'%s' should only contain digits."
+#~ msgstr "문자열 '%s' 에는 ASCII 이외의 문자가 입력되었습니다."
+
+#~ msgid "Can't create window of class %s"
+#~ msgstr "클래스 %s 에서 윈도우생성 할 수 없습니다"
+
+#~ msgid "Couldn't create the overlay window"
+#~ msgstr "오버레이 창을 생성할 수 없습니다."
+
+#~ msgid "Couldn't init the context on the overlay window"
+#~ msgstr "오버레이창의 내용을 초기화 하지 못했습니다."
+
+#~ msgid "Failed to convert file \"%s\" to Unicode."
+#~ msgstr "\"%s\" 파을을 유니코드로 변환하는데 실패했습니다."
+
+#~ msgid "Failed to set text in the text control."
+#~ msgstr "텍스트 Control의 텍스트 입력 실패(인코딩 변환문제)"
+
+#~ msgid "Invalid GTK+ command line option, use \"%s --help\""
+#~ msgstr ""
+#~ "GTK+의 명령행 옵션이 잘못됨, 자세한 사항은 다음을 입력해 보세요 : \"%s --"
+#~ "help\""
+
+#~ msgid "No unused colour in image."
+#~ msgstr "이미지에 사용되지 않은 색상"
+
+#, fuzzy
+#~ msgid "Not available"
+#~ msgstr "유용한 팁이 없습니다."
+
+#~ msgid "Replace selection"
+#~ msgstr "현재 선택 바꾸기"
+
+#, fuzzy
+#~ msgid "Save as"
+#~ msgstr "다른 이름으로 저장"
+
+#~ msgid "Style Organiser"
+#~ msgstr "모양새 관리"
+
+#~ msgid "The following standard GTK+ options are also supported:\n"
+#~ msgstr "다음은 표준 GTK+ 에서 지원하는 옵션입니다:\n"
+
+#~ msgid "You cannot Clear an overlay that is not inited"
+#~ msgstr "오버레이 지울수 없습니다. 초기화 되지 않았습니다."
+
+#~ msgid "You cannot Init an overlay twice"
+#~ msgstr "오버레이를 두번 초기화 할 수 없습니다."
+
+#~ msgid "locale '%s' cannot be set."
+#~ msgstr "문자 인코딩을 '%s' 로 설정할 수 없습니다."
+
+#, fuzzy
+#~ msgid "Bitmap renderer cannot render value; value type: "
+#~ msgstr "비트맵 Renderer가 데이타 타입 및 데이타를 처리할 수 없습니다."
+
+#, fuzzy
+#~ msgid ""
+#~ "Cannot create new column's ID. Probably max. number of columns reached."
+#~ msgstr ""
+#~ "새로운 Column ID를 만들수 없습니다. 아마도 Column의 개수가 최대치에 도달한"
+#~ "것 같습니다."
+
+#~ msgid "Column could not be added."
+#~ msgstr "Column을 추가할수 없습니다."
+
+#~ msgid "Column index not found."
+#~ msgstr "Column index를 찾을수 없습니다."
+
+#~ msgid "Column width could not be determined"
+#~ msgstr "Column 너비를 정의할수 없습니다."
+
+#~ msgid "Column width could not be set."
+#~ msgstr "Column 너비를 설정할 수 없습니다."
+
+#~ msgid "Confirm registry update"
+#~ msgstr "레지스트 업데이트 확인"
+
+#~ msgid "Could not determine column index."
+#~ msgstr "Column index를 정의할 수 없습니다."
+
+#~ msgid "Could not determine column's position"
+#~ msgstr "Column 위치를 정의할 수 없습니다."
+
+#, fuzzy
+#~ msgid "Could not determine number of columns."
+#~ msgstr "다수의 아이템을 정의할 수 없습니다."
+
+#~ msgid "Could not determine number of items"
+#~ msgstr "다수의 아이템을 정의할 수 없습니다."
+
+#~ msgid "Could not get header description."
+#~ msgstr "헤더 정보를 얻을 수 없습니다."
+
+#~ msgid "Could not get items."
+#~ msgstr "아이템을 얻을 수 없습니다."
+
+#~ msgid "Could not get property flags."
+#~ msgstr "속성 플래그를 얻을 수 없습니다"
+
+#~ msgid "Could not get selected items."
+#~ msgstr "선택한 아이템을 얻을 수 없습니다."
+
+#~ msgid "Could not remove column."
+#~ msgstr "Column을 지울 수 없습니다."
+
+#~ msgid "Could not retrieve number of items"
+#~ msgstr "다수의 아이템을 복구할 수 없습니다."
+
+#~ msgid "Could not set column width."
+#~ msgstr "Column의 너비를 지정할 수 없습니다"
+
+#~ msgid "Could not set header description."
+#~ msgstr "헤더 정보를 설정할 수 없습니다."
+
+#~ msgid "Could not set icon."
+#~ msgstr "아이콘을 지정할 수 없습니다."
+
+#~ msgid "Could not set maximum width."
+#~ msgstr "최대 너비를 지정할 수 없습니다."
+
+#~ msgid "Could not set minimum width."
+#~ msgstr "최소 너비를 지정할 수 없습니다."
+
+#~ msgid "Could not set property flags."
+#~ msgstr "속성 플래그를 지정할 수 없습니다."
+
+#, fuzzy
+#~ msgid "Date renderer cannot render value; value type: "
+#~ msgstr "데이타 Renderer가 데이타 타입 및 데이타를 처리할 수 없습니다."
+
+#~ msgid ""
+#~ "Do you want to overwrite the command used to %s files with extension "
+#~ "\"%s\" ?\n"
+#~ "Current value is \n"
+#~ "%s, \n"
+#~ "New value is \n"
+#~ "%s %1"
+#~ msgstr ""
+#~ "레지스터 값 %s 을 \"%s\" 로 변경하시겠습니까?\n"
+#~ "현재 값 \n"
+#~ "%s, \n"
+#~ "새 값 \n"
+#~ "%s %1"
+
+#~ msgid "Failed to retrieve data from the clipboard."
+#~ msgstr "클립 보드에서 데이터 가져오기를 실패했습니다."
+
+#~ msgid "GIF: Invalid gif index."
+#~ msgstr "GIF: gif 인덱스가 잘못되었습니다."
+
+#~ msgid "GIF: unknown error!!!"
+#~ msgstr "GIF: 알 수 없는 오류 발생!!!"
+
+#, fuzzy
+#~ msgid "Icon & text renderer cannot render value; value type: "
+#~ msgstr "아이콘 및 문서 Renderer가 타입및 값을 처리할 수 없습니다"
+
+#~ msgid "New directory"
+#~ msgstr "새 디렉토리"
+
+#~ msgid "Next"
+#~ msgstr "다음"
+
+#~ msgid "No column existing."
+#~ msgstr "Column 이 없습니다."
+
+#, fuzzy
+#~ msgid "No column for the specified column existing."
+#~ msgstr "지정된 Column 인덱스에 데이타가 없습니다."
+
+#~ msgid "No column for the specified column position existing."
+#~ msgstr "지정된 Column 위치에 데이타가 없습니다."
+
+#, fuzzy
+#~ msgid ""
+#~ "No renderer or invalid renderer type specified for custom data column."
+#~ msgstr "사용자 정의 Column 에 지정된 Randerer  잘못되었습니다."
+
+#, fuzzy
+#~ msgid "No renderer specified for column."
+#~ msgstr "Column 을 위한 Renderer가 지정되지 않았습니다."
+
+#, fuzzy
+#~ msgid "Number of columns could not be determined."
+#~ msgstr "Column 너비를 정의할수 없습니다."
+
+#~ msgid "OpenGL function \"%s\" failed: %s (error %d)"
+#~ msgstr "OpenGL 함수 \"%s\" 실패: %s (오류 %d)"
+
+#~ msgid ""
+#~ "Please install a newer version of comctl32.dll\n"
+#~ "(at least version 4.70 is required but you have %d.%02d)\n"
+#~ "or this program won't operate correctly."
+#~ msgstr ""
+#~ "최신 comctl32.dll 설치하십시오.\n"
+#~ "(버전 4.70 이상이 필요합니다. 현재 설치버전: %d.%02d)\n"
+#~ "프로그램이 정상적으로 동작하지 않습니다."
+
+#, fuzzy
+#~ msgid "Pointer to data view control not set correctly."
+#~ msgstr "데이타뷰 컨트롤 설정이 잘못되었습니다."
+
+#, fuzzy
+#~ msgid "Pointer to model not set correctly."
+#~ msgstr "모델 설정이 잘못되었습니다."
+
+#, fuzzy
+#~ msgid "Progress renderer cannot render value type; value type: "
+#~ msgstr "Renderer 가 타입 및 값을 처리할수 없습니다."
+
+#~ msgid "Rendering failed."
+#~ msgstr "Rendering 실패"
+
+#~ msgid "Show hidden directories"
+#~ msgstr "숨김 폴더 표시"
+
+#, fuzzy
+#~ msgid "Text renderer cannot render value; value type: "
+#~ msgstr "텍스트 Renderer 가 타입및 값을 처리할 수 없습니다."
+
+#~ msgid "There is no column or renderer for the specified column index."
+#~ msgstr "색인에서 지정한 Randerer 혹은 Column이 없습니다."
+
+#~ msgid ""
+#~ "This system doesn't support date controls, please upgrade your version of "
+#~ "comctl32.dll"
+#~ msgstr ""
+#~ "현재 시스템은 데이타 컨트롤을 지원 하지 않습니다, comctl32.dll 업데이트를 "
+#~ "확인하세요."
+
+#, fuzzy
+#~ msgid "Toggle renderer cannot render value; value type: "
+#~ msgstr "Toggle renderer 가 타입및 값을 처리할 수 없습니다."
+
+#~ msgid "Too many colours in PNG, the image may be slightly blurred."
+#~ msgstr "PNG 이미지에 색상이 너무 많습니다. 이미지가 약간 흐려 수 있습니다."
+
+#~ msgid "Unable to initialize Hildon program"
+#~ msgstr "Hildon 프로그램을 초기화할 수 없습니다."
+
+#, fuzzy
+#~ msgid "Unknown data format"
+#~ msgstr "데이터에 잘못된 형식이 있습니다."
+
+#, fuzzy
+#~ msgid "Valid pointer to native data view control does not exist"
+#~ msgstr "OS API 데이타뷰 컨트롤에 대한 유효한 포인터가 존재하지 않습니다."
+
+#, fuzzy
+#~ msgid "Windows 10"
+#~ msgstr "창(&W)"
+
+#, fuzzy
+#~ msgid "Windows 2000"
+#~ msgstr "창(&W)"
+
+#, fuzzy
+#~ msgid "Windows 7"
+#~ msgstr "창(&W)"
+
+#, fuzzy
+#~ msgid "Windows 8"
+#~ msgstr "창(&W)"
+
+#, fuzzy
+#~ msgid "Windows 8.1"
+#~ msgstr "창(&W)"
+
+#, fuzzy
+#~ msgid "Windows Server 10"
+#~ msgstr "Windows 그리스어 (CP 1253)"
+
+#, fuzzy
+#~ msgid "Windows Server 2003"
+#~ msgstr "Windows 그리스어 (CP 1253)"
+
+#, fuzzy
+#~ msgid "Windows Server 2008"
+#~ msgstr "Windows 히브리어 (CP 1255)"
+
+#, fuzzy
+#~ msgid "Windows Server 2008 R2"
+#~ msgstr "Windows 히브리어 (CP 1255)"
+
+#, fuzzy
+#~ msgid "Windows Server 2012"
+#~ msgstr "Windows 그리스어 (CP 1253)"
+
+#, fuzzy
+#~ msgid "Windows Server 2012 R2"
+#~ msgstr "Windows 히브리어 (CP 1255)"
+
+#, fuzzy
+#~ msgid "Windows Vista"
+#~ msgstr "창(&W)"
+
+#, fuzzy
+#~ msgid "Windows XP"
+#~ msgstr "창(&W)"
+
+#~ msgid "can't execute '%s'"
+#~ msgstr "'%s' 를 실행할 수 없습니다."
+
+#~ msgid "error opening '%s'"
+#~ msgstr "'%s' 파일 여는 중  오류가 발생했습니다."
+
+#~ msgid "unknown seek origin"
+#~ msgstr "seek 잘못 입력"
+
+#~ msgid "wxWidget control pointer is not a data view pointer"
+#~ msgstr "wxWidget 컨트롤 포인터가 데이타뷰 포인터가 아닙니다."
+
+#, fuzzy
+#~ msgid "wxWidget's control not initialized."
+#~ msgstr "모델 위치가 초기화 되지 않았습니다."
+
+#~ msgid "Cannot create mutex."
+#~ msgstr "뮤텍스 생성 할 수 없습니다"
+
+#~ msgid "Cannot resume thread %lu"
+#~ msgstr "쓰레드 %lu 를 다시시작 실패"
+
+#~ msgid "Cannot suspend thread %lu"
+#~ msgstr "쓰레드 %lu 일시정지 할 수 없습니다"
+
+#~ msgid "Couldn't acquire a mutex lock"
+#~ msgstr "뮤텍스 잠금을 실패했습니다."
+
+#~ msgid "Couldn't get hatch style from wxBrush."
+#~ msgstr "wxBrush 에서 무늬 모양새를 얻지 못했습니다."
+
+#~ msgid "Couldn't release a mutex"
+#~ msgstr "뮤텍스를 해제할 수 없습니다."
+
+#~ msgid "Execution of command '%s' failed with error: %ul"
+#~ msgstr "'%s' 명령 실행 실패 (오류: %ul)"
+
+#~ msgid ""
+#~ "File '%s' already exists.\n"
+#~ "Do you want to replace it?"
+#~ msgstr "'%s' 파일이 이미 있습니다.  이 파일을 바꾸시겠습니까?"
+
+#~ msgid "MENU"
+#~ msgstr "MENU"
+
+#~ msgid "The print dialog returned an error."
+#~ msgstr "인쇄창에서 오류 발생"
+
+#~ msgid "The wxGtkPrinterDC cannot be used."
+#~ msgstr "wxGtkPrinterDC 를 사용할 수 없습니다."
+
+#~ msgid "Timer creation failed."
+#~ msgstr "타이머를 생성할 수 없습니다."
+
+#~ msgid "UP"
+#~ msgstr "UP"
+
+#~ msgid "buffer is too small for Windows directory."
+#~ msgstr "윈도우 디렉토리를 위한 버퍼가 너무 작습니다."
+
+#~ msgid "not implemented"
+#~ msgstr "구현하지 않음"
+
+#~ msgid "wxPrintout::GetPageInfo gives a null maxPage."
+#~ msgstr "wxPrintout::GetPageInfo: maxPage가 0입니다."
+
+#~ msgid "Print preview"
+#~ msgstr "인쇄 미리 보기"
+
+#~ msgid "1"
+#~ msgstr "1"
+
+#, fuzzy
+#~ msgid "10"
+#~ msgstr "1"
+
+#~ msgid "3"
+#~ msgstr "3"
+
+#~ msgid "4"
+#~ msgstr "4"
+
+#~ msgid "5"
+#~ msgstr "5"
+
+#~ msgid "6"
+#~ msgstr "6"
+
+#~ msgid "7"
+#~ msgstr "7"
+
+#~ msgid "8"
+#~ msgstr "8"
+
+#~ msgid "9"
+#~ msgstr "9"
+
+#, fuzzy
+#~ msgid "&Preview..."
+#~ msgstr " 미리보기"
+
+#, fuzzy
+#~ msgid "Preview..."
+#~ msgstr " 미리보기"
+
+#, fuzzy
+#~ msgid "The vertical offset relative to the paragraph."
+#~ msgstr "다음 단락의 기본 모양새"
+
+#~ msgid "&Save..."
+#~ msgstr "저장...(&S)"
+
+#~ msgid "About "
+#~ msgstr "정보"
+
+#~ msgid "All files (*.*)|*"
+#~ msgstr "모든 파일 (*.*)|*"
+
+#~ msgid "Cannot initialize SciTech MGL!"
+#~ msgstr "SciTech MGL를 초기화 할 수 없습니다."
+
+#~ msgid "Cannot initialize display."
+#~ msgstr "디스플레이를 초기화할 수 없습니다."
+
+#~ msgid "Cannot start thread: error writing TLS"
+#~ msgstr "쓰레드를 시작할 수 없습니다 : TLS 쓰기 오류"
+
+#~ msgid "Close\tAlt-F4"
+#~ msgstr "닫기\tAlt-F4"
+
+#~ msgid "Couldn't create cursor."
+#~ msgstr "커서를 생성할 수 없습니다."
+
+#~ msgid "Directory '%s' doesn't exist!"
+#~ msgstr "'%s' 디렉토리가 존재하지 않습니다."
+
+#~ msgid "Mode %ix%i-%i not available."
+#~ msgstr "%ix%i-%i 디스플레이 모드는 사용할수 없습니다."
+
+#~ msgid "Paper Size"
+#~ msgstr "용지 크기"
+
+#~ msgid "%.*f GB"
+#~ msgstr "%.*f 기가바이트(GB)"
+
+#~ msgid "%.*f MB"
+#~ msgstr "%.*f 메가바이트(MB)"
+
+#~ msgid "%.*f TB"
+#~ msgstr "%.*f 테라바이트(TB)"
+
+#~ msgid "%.*f kB"
+#~ msgstr "%.*f 킬로바이트(kB)"
+
+#~ msgid "%s B"
+#~ msgstr "%s 바이트(byte)"
+
+#~ msgid "&Goto..."
+#~ msgstr "이동...(&G)"
+
+#~ msgid "<<"
+#~ msgstr "이전"
+
+#~ msgid ">>"
+#~ msgstr "다음"
+
+#~ msgid ">>|"
+#~ msgstr "끝"
+
+#~ msgid "Added item is invalid."
+#~ msgstr "추가된 아이템이 잘못되었습니다."
+
+#~ msgid "Archive doesnt contain #SYSTEM file"
+#~ msgstr "아카이브에 #SYSTEM 파일이 없습니다."
+
+#~ msgid "BIG5"
+#~ msgstr "중국어 (BIG5)"
+
+#~ msgid "Can't check image format of file '%s': file does not exist."
+#~ msgstr "'%s' 파일의 이미지 포맷을 확인 실패: 파일이 존재하지 않습니다."
+
+#~ msgid "Can't load image from file '%s': file does not exist."
+#~ msgstr "'%s' 파일에서 이미지를 가져올수 없습니다: 파일이 없습니다."
+
+#~ msgid "Cannot convert dialog units: dialog unknown."
+#~ msgstr "wxDLG_UNIT 로 변환 실패: 정의되지 않은 Dialog 타입."
+
+#~ msgid "Cannot convert from the charset '%s'!"
+#~ msgstr "'%s' 문자셋을 변환할 수 없습니다!"
+
+#~ msgid "Cannot find container for unknown control '%s'."
+#~ msgstr "Control '%s' 가 소속된 부모창을 찾을 수 없습니다."
+
+#~ msgid "Cannot find font node '%s'."
+#~ msgstr "'%s' 글꼴 노드를 찾을 수 없습니다."
+
+#~ msgid "Cannot open file '%s'."
+#~ msgstr "'%s' 파일 을 열 수 없습니다."
+
+#~ msgid "Cannot parse coordinates from '%s'."
+#~ msgstr "%s 에서 위치값을 해석할 수 없습니다."
+
+#~ msgid "Cannot parse dimension from '%s'."
+#~ msgstr "%s 에서 차원(Dimension)을 해석할 수 없습니다."
+
+#~ msgid "Cant create the thread event queue"
+#~ msgstr "쓰레드 이벤트 큐를 생성할 수 없습니다."
+
+#~ msgid "Changed item is invalid."
+#~ msgstr "바꾼 아이템이 잘못되었습니다."
+
+#~ msgid "Click to cancel this window."
+#~ msgstr "현재 창을 취소하려면 여기를 누르십시오."
+
+#~ msgid "Click to confirm your selection."
+#~ msgstr "선택사항을 적용하려면 여기를 누르십시오."
+
+#, fuzzy
+#~ msgid "Column does not have a renderer."
+#~ msgstr "Column은 renderer 를 가지고 있지 않습니다."
+
+#, fuzzy
+#~ msgid "Column pointer must not be NULL."
+#~ msgstr "Column 주소는 NULL 값을 가질 수 없습니다."
+
+#, fuzzy
+#~ msgid "Column's model column has no equivalent in the associated model."
+#~ msgstr "Column 모델이 관형형 모델과 일치 하지 않습니다."
+
+#, fuzzy
+#~ msgid "Control is wrongly initialized."
+#~ msgstr "Control 이 잘못 초기화 되었습니다."
+
+#~ msgid "Could not add column to internal structures."
+#~ msgstr "내부 자료구조에 Column을 추가할 수 없습니다."
+
+#~ msgid "Could not unlock mutex"
+#~ msgstr "뮤텍스 잠금을 해제할 수 없습니다."
+
+#, fuzzy
+#~ msgid "Data view control is not correctly initialized"
+#~ msgstr "데이타 뷰 컨트롤의 초기화가 잘못되었습니다."
+
+#~ msgid "Error while waiting on semaphore"
+#~ msgstr "세마포어 대기중에 오류 발생"
+
+#~ msgid "Failed to create a status bar."
+#~ msgstr "상태 표시줄 생성을 실패했습니다."
+
+#~ msgid "Failed to register OpenGL window class."
+#~ msgstr "OpenGL 등록 실패"
+
+#~ msgid "Fatal error: "
+#~ msgstr "치명적인 오류:"
+
+#~ msgid "GB-2312"
+#~ msgstr "GB-2312"
+
+#~ msgid "Go forward to the next HTML page"
+#~ msgstr "다음 HTML 페이지로 이동"
+
+#~ msgid "Goto Page"
+#~ msgstr "페이지 이동"
+
+#~ msgid ""
+#~ "HTML pagination algorithm generated more than the allowed maximum number "
+#~ "of pages and it can't continue any longer!"
+#~ msgstr ""
+#~ "HTML 페이지 매김 알고리즘에서 허용되는 최대 페이지를 초과하여 더 이상 계속"
+#~ "할 수 없습니다. "
+
+#~ msgid "Help : %s"
+#~ msgstr "도움말 : %s"
+
+#~ msgid "I64"
+#~ msgstr "I64"
+
+#~ msgid "Internal error, illegal wxCustomTypeInfo"
+#~ msgstr "내부 오류, 잘못된 wxCustomTypeInfo 사용"
+
+#~ msgid "Invalid XRC resource '%s': doesn't have root node 'resource'."
+#~ msgstr "'%s' XRC 리소스가 잘못됨: 'resource' 루트노드가 없습니다."
+
+#~ msgid "No handler found for XML node '%s', class '%s'!"
+#~ msgstr "XML 노드 '%s' 에 속성 '%s' 를 찾을 수 없습니다!"
+
+#~ msgid "No image handler for type %ld defined."
+#~ msgstr "%ld 타입에 대한 이미지 핸들러가 없습니다."
+
+#, fuzzy
+#~ msgid "No model associated with control."
+#~ msgstr "Control에 연결된 모델이 없습니다."
+
+#, fuzzy
+#~ msgid "Owner not initialized."
+#~ msgstr "소유자가 초기화되지 않았습니다."
+
+#, fuzzy
+#~ msgid "Passed item is invalid."
+#~ msgstr "잘못된 아이템은 무시합니다."
+
+#~ msgid "Passing a already registered object to SetObjectName"
+#~ msgstr "이미 등록된 객체이름 입니다. 무시함"
+
+#~ msgid "Preparing help window..."
+#~ msgstr "도움말 준비중"
+
+#~ msgid "Program aborted."
+#~ msgstr "프로그램 실패."
+
+#~ msgid "Referenced object node with ref=\"%s\" not found!"
+#~ msgstr "참조 \"%s\" 를 찾을 수 없습니다. "
+
+#~ msgid "Resource files must have same version number!"
+#~ msgstr "동일한 버전의 리소스 파일이 없습니다."
+
+#~ msgid "SHIFT-JIS"
+#~ msgstr "일본어 (SHIFT-JIS)"
+
+#~ msgid "Search!"
+#~ msgstr "찾기!"
+
+#~ msgid "Sorry, could not open this file for saving."
+#~ msgstr "이 파일을 쓰기모드로 열 수 없습니다."
+
+#~ msgid "Sorry, could not save this file."
+#~ msgstr "파일을 저장할 수 없습니다."
+
+#~ msgid "Sorry, print preview needs a printer to be installed."
+#~ msgstr "인쇄 미리보기를 하려면 프린트(드라이버) 가 설치 되어야 합니다."
+
+#~ msgid "Status: "
+#~ msgstr "상태:"
+
+#~ msgid ""
+#~ "Streaming delegates for not already streamed objects not yet supported"
+#~ msgstr "준비된 출력 스트림이 없습니다."
+
+#~ msgid "Subclass '%s' not found for resource '%s', not subclassing!"
+#~ msgstr "하위 클래스 '%s' 를 리소스 '%s' 에서 찾을 수 없습니다."
+
+#~ msgid "TIFF library error."
+#~ msgstr "TIFF library 오류."
+
+#~ msgid "TIFF library warning."
+#~ msgstr "TIFF library 경고"
+
+#~ msgid ""
+#~ "The file '%s' couldn't be opened.\n"
+#~ "It has been removed from the most recently used files list."
+#~ msgstr ""
+#~ "파일 '%s' 을 열 수 없습니다.\n"
+#~ "최근 사용 파일 목록 에서 제거된거 같습니다."
+
+#~ msgid "The path '%s' contains too many \"..\"!"
+#~ msgstr "경로 '%s' 에 너무 많은 \"..\" 을 포함하고 있습니다.!"
+
+#~ msgid "Trying to solve a NULL hostname: giving up"
+#~ msgstr "Hostname이 빈 문자열입니다."
+
+#~ msgid "Unknown style flag "
+#~ msgstr "모양새를 찾을 수 없습니다."
+
+#~ msgid "Warning"
+#~ msgstr "경고"
+
+#~ msgid "XRC resource '%s' (class '%s') not found!"
+#~ msgstr "XRC 리소스 '%s' 에서 class '%s' 를 찾을 수 없습니다."
+
+#~ msgid "XRC resource: Cannot create animation from '%s'."
+#~ msgstr "XRC 리소스: '%s' 에서 애니매이션을 생성할 수 없습니다."
+
+#~ msgid "XRC resource: Cannot create bitmap from '%s'."
+#~ msgstr "XRC 리소스: '%s' 에서 비트맵을 생성할 수 없습니다.."
+
+#~ msgid ""
+#~ "XRC resource: Incorrect colour specification '%s' for attribute '%s'."
+#~ msgstr "XRC 리소스: 색상 지정 '%s' 이 잘못되었습니다(속성:'%s')."
+
+#~ msgid "[EMPTY]"
+#~ msgstr "[빈]"
+
+#~ msgid "catalog file for domain '%s' not found."
+#~ msgstr "'%s' 도메인에서 카달로그 파일을 찾을 수 없습니다."
+
+#~ msgid "delegate has no type info"
+#~ msgstr "delegateTypeInfo 가 없습니다."
+
+#~ msgid "looking for catalog '%s' in path '%s'."
+#~ msgstr "카달로그 '%s' 를 찾는중(경로: '%s')."
+
+#, fuzzy
+#~ msgid "m_peer is not or incorrectly initialized"
+#~ msgstr "m_peer 초기화 실패 혹은 잘못 초기화됨"
+
+#~ msgid "wxRichTextFontPage"
+#~ msgstr "wxRichTextFontPage"
+
+#~ msgid "wxSearchEngine::LookFor must be called before scanning!"
+#~ msgstr ""
+#~ "wxSearchEngine::LookFor 함수는 wxSearchEngine::Scan 함수보다 먼저 수행되어"
+#~ "야 합니다."
+
+#~ msgid "wxSocket: invalid signature in ReadMsg."
+#~ msgstr "wxSocket: 일긍 메세지의 서명이 잘못됨"
+
+#~ msgid "wxSocket: unknown event!."
+#~ msgstr "wxSocket: 알 수 없는 이벤트 발생!"
+
+#~ msgid "|<<"
+#~ msgstr "처음"

--- a/po_wxstd/lt.po
+++ b/po_wxstd/lt.po
@@ -1,0 +1,9252 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: wxWidgets 3.3\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-05-14 20:23+0200\n"
+"PO-Revision-Date: 2015-07-09 11:22+0200\n"
+"Last-Translator: Andrius <andrius.balsevicius@gmail.com>\n"
+"Language-Team: wxWidgets translators <wx-translators@googlegroups.com>\n"
+"Language: lt\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=n != 1;\n"
+
+#: ../include/wx/defs.h:2582
+msgid "All files (*.*)|*.*"
+msgstr ""
+
+#: ../include/wx/defs.h:2585
+msgid "All files (*)|*"
+msgstr ""
+
+#: ../include/wx/generic/progdlgg.h:85
+msgid "Elapsed time:"
+msgstr ""
+
+#: ../include/wx/generic/progdlgg.h:86
+msgid "Estimated time:"
+msgstr ""
+
+#: ../include/wx/generic/progdlgg.h:87
+msgid "Remaining time:"
+msgstr ""
+
+#. TRANSLATORS: HTML printout default title.
+#: ../include/wx/html/htmprint.h:121 ../include/wx/prntbase.h:273
+#: ../include/wx/richtext/richtextprint.h:109 ../src/common/docview.cpp:2161
+msgid "Printout"
+msgstr ""
+
+#. TRANSLATORS: HTML easy print default title.
+#: ../include/wx/html/htmprint.h:234 ../include/wx/richtext/richtextprint.h:163
+#: ../src/common/prntbase.cpp:522 ../src/html/htmprint.cpp:291
+msgid "Printing"
+msgstr ""
+
+#: ../include/wx/msgdlg.h:277 ../src/common/stockitem.cpp:211
+msgid "Yes"
+msgstr "Taip"
+
+#: ../include/wx/msgdlg.h:278 ../src/common/stockitem.cpp:182
+msgid "No"
+msgstr "Ne"
+
+#: ../include/wx/msgdlg.h:279 ../src/common/stockitem.cpp:183
+#: ../src/msw/msgdlg.cpp:430 ../src/msw/msgdlg.cpp:734
+#: ../src/richtext/richtextstyledlg.cpp:292
+msgid "OK"
+msgstr "GERAI"
+
+#: ../include/wx/msgdlg.h:280 ../src/common/stockitem.cpp:150
+#: ../src/msw/msgdlg.cpp:430 ../src/msw/progdlg.cpp:884
+#: ../src/richtext/richtextstyledlg.cpp:295
+msgid "Cancel"
+msgstr "Atsisakyti"
+
+#: ../include/wx/msgdlg.h:281 ../src/common/stockitem.cpp:168
+#: ../src/html/helpdlg.cpp:63 ../src/html/helpfrm.cpp:108
+#: ../src/osx/button_osx.cpp:38
+msgid "Help"
+msgstr "Pagalba"
+
+#: ../include/wx/msw/ole/oleutils.h:52
+msgid "Cannot initialize OLE"
+msgstr ""
+
+#: ../include/wx/msw/private/fswatcher.h:48
+#, c-format
+msgid "Unable to close the handle for '%s'"
+msgstr ""
+
+#: ../include/wx/msw/private/fswatcher.h:92
+#, c-format
+msgid "Failed to open directory \"%s\" for monitoring."
+msgstr ""
+
+#: ../include/wx/msw/private/fswatcher.h:125
+msgid "Unable to close I/O completion port handle"
+msgstr ""
+
+#: ../include/wx/msw/private/fswatcher.h:142
+msgid "Unable to associate handle with I/O completion port"
+msgstr ""
+
+#: ../include/wx/msw/private/fswatcher.h:148
+msgid "Unexpectedly new I/O completion port was created"
+msgstr ""
+
+#: ../include/wx/msw/private/fswatcher.h:213
+msgid "Unable to post completion status"
+msgstr ""
+
+#: ../include/wx/msw/private/fswatcher.h:262
+msgid "Unable to dequeue completion packet"
+msgstr ""
+
+#: ../include/wx/msw/private/fswatcher.h:273
+msgid "Unable to create I/O completion port"
+msgstr ""
+
+#: ../include/wx/richmsgdlg.h:29
+msgid "&See details"
+msgstr ""
+
+#: ../include/wx/richmsgdlg.h:30
+msgid "&Hide details"
+msgstr ""
+
+#: ../include/wx/richtext/richtextbuffer.h:3864
+msgid "&Box"
+msgstr "&Dėžutė"
+
+#: ../include/wx/richtext/richtextbuffer.h:5008
+msgid "&Picture"
+msgstr ""
+
+#: ../include/wx/richtext/richtextbuffer.h:5958
+msgid "&Cell"
+msgstr ""
+
+#: ../include/wx/richtext/richtextbuffer.h:6067
+msgid "&Table"
+msgstr ""
+
+#: ../include/wx/richtext/richtextimagedlg.h:37
+msgid "Object Properties"
+msgstr "Objektų savybs"
+
+#: ../include/wx/richtext/richtextsymboldlg.h:39
+msgid "Symbols"
+msgstr "Simbolis"
+
+#: ../include/wx/unix/pipe.h:46
+msgid "Pipe creation failed"
+msgstr ""
+
+#: ../include/wx/unix/private/displayx11.h:65
+msgid "Failed to enumerate video modes"
+msgstr ""
+
+#: ../include/wx/unix/private/displayx11.h:89
+msgid "Failed to change video mode"
+msgstr ""
+
+#: ../include/wx/unix/private/fswatcher_kqueue.h:57
+#, c-format
+msgid "Unable to open path '%s'"
+msgstr ""
+
+#: ../include/wx/unix/private/fswatcher_kqueue.h:74
+#, c-format
+msgid "Unable to close path '%s'"
+msgstr ""
+
+#: ../include/wx/xtiprop.h:175
+msgid "SetProperty called w/o valid setter"
+msgstr ""
+
+#: ../include/wx/xtiprop.h:184
+msgid "GetProperty called w/o valid getter"
+msgstr ""
+
+#: ../include/wx/xtiprop.h:193
+msgid "AddToPropertyCollection called w/o valid adder"
+msgstr ""
+
+#: ../include/wx/xtiprop.h:202
+msgid "GetPropertyCollection called w/o valid collection getter"
+msgstr ""
+
+#: ../include/wx/xtiprop.h:255
+msgid "AddToPropertyCollection called on a generic accessor"
+msgstr ""
+
+#: ../include/wx/xtiprop.h:262
+msgid "GetPropertyCollection called on a generic accessor"
+msgstr ""
+
+#: ../src/aui/tabmdi.cpp:106 ../src/generic/mdig.cpp:94
+msgid "Cl&ose"
+msgstr ""
+
+#: ../src/aui/tabmdi.cpp:107 ../src/generic/mdig.cpp:95
+msgid "Close All"
+msgstr "Užverti visus"
+
+#: ../src/aui/tabmdi.cpp:109 ../src/generic/mdig.cpp:97 ../src/msw/mdi.cpp:175
+#: ../src/qt/mdi.cpp:258
+msgid "&Next"
+msgstr "&Kitas"
+
+#: ../src/aui/tabmdi.cpp:110 ../src/generic/mdig.cpp:98 ../src/msw/mdi.cpp:176
+#: ../src/qt/mdi.cpp:259
+msgid "&Previous"
+msgstr "&Ankstesnis"
+
+#: ../src/aui/tabmdi.cpp:332 ../src/aui/tabmdi.cpp:348
+#: ../src/aui/tabmdi.cpp:350 ../src/generic/mdig.cpp:291
+#: ../src/generic/mdig.cpp:307 ../src/generic/mdig.cpp:311
+#: ../src/msw/mdi.cpp:337 ../src/qt/mdi.cpp:462
+msgid "&Window"
+msgstr "&Langas"
+
+#: ../src/common/accelcmn.cpp:47
+msgctxt "keyboard key"
+msgid "Delete"
+msgstr "Ištrinti"
+
+#: ../src/common/accelcmn.cpp:48
+msgctxt "keyboard key"
+msgid "Del"
+msgstr "Ištrinti"
+
+#: ../src/common/accelcmn.cpp:49
+msgctxt "keyboard key"
+msgid "Back"
+msgstr "Galas"
+
+#: ../src/common/accelcmn.cpp:49
+msgctxt "keyboard key"
+msgid "Backspace"
+msgstr "Galas"
+
+#: ../src/common/accelcmn.cpp:50
+msgctxt "keyboard key"
+msgid "Insert"
+msgstr "Įterpti"
+
+#: ../src/common/accelcmn.cpp:51
+msgctxt "keyboard key"
+msgid "Ins"
+msgstr "Įterpti"
+
+#: ../src/common/accelcmn.cpp:52
+msgctxt "keyboard key"
+msgid "Enter"
+msgstr "Spausdintuvas"
+
+#: ../src/common/accelcmn.cpp:53
+msgctxt "keyboard key"
+msgid "Return"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:54
+msgctxt "keyboard key"
+msgid "PageUp"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:54
+msgctxt "keyboard key"
+msgid "Page Up"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:55
+msgctxt "keyboard key"
+msgid "PageDown"
+msgstr "Žemyn"
+
+#: ../src/common/accelcmn.cpp:55
+msgctxt "keyboard key"
+msgid "Page Down"
+msgstr "Žemyn"
+
+#: ../src/common/accelcmn.cpp:56
+msgctxt "keyboard key"
+msgid "PgUp"
+msgstr "PgUp"
+
+#: ../src/common/accelcmn.cpp:57
+msgctxt "keyboard key"
+msgid "PgDn"
+msgstr "PgDn"
+
+#: ../src/common/accelcmn.cpp:58
+msgctxt "keyboard key"
+msgid "Left"
+msgstr "Kairė"
+
+#: ../src/common/accelcmn.cpp:59
+msgctxt "keyboard key"
+msgid "Right"
+msgstr "Dešinė"
+
+#: ../src/common/accelcmn.cpp:60
+msgctxt "keyboard key"
+msgid "Up"
+msgstr "Aukštyn"
+
+#: ../src/common/accelcmn.cpp:61
+msgctxt "keyboard key"
+msgid "Down"
+msgstr "Žemyn"
+
+#: ../src/common/accelcmn.cpp:62
+msgctxt "keyboard key"
+msgid "Home"
+msgstr "Pagrindinis"
+
+#: ../src/common/accelcmn.cpp:63
+msgctxt "keyboard key"
+msgid "End"
+msgstr "Pabaiga"
+
+#: ../src/common/accelcmn.cpp:64
+msgctxt "keyboard key"
+msgid "Space"
+msgstr "Tarpas"
+
+#: ../src/common/accelcmn.cpp:65
+msgctxt "keyboard key"
+msgid "Tab"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:66
+msgctxt "keyboard key"
+msgid "Esc"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:67
+msgctxt "keyboard key"
+msgid "Escape"
+msgstr "Gulsčias"
+
+#: ../src/common/accelcmn.cpp:68
+msgctxt "keyboard key"
+msgid "Cancel"
+msgstr "Atsisakyti"
+
+#: ../src/common/accelcmn.cpp:69
+msgctxt "keyboard key"
+msgid "Clear"
+msgstr "Išvalyti"
+
+#: ../src/common/accelcmn.cpp:70
+msgctxt "keyboard key"
+msgid "Menu"
+msgstr "Meniu"
+
+#: ../src/common/accelcmn.cpp:71
+msgctxt "keyboard key"
+msgid "Pause"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:72
+msgctxt "keyboard key"
+msgid "Capital"
+msgstr "Kursyvas"
+
+#: ../src/common/accelcmn.cpp:73
+msgctxt "keyboard key"
+msgid "Select"
+msgstr "Parinkti"
+
+#: ../src/common/accelcmn.cpp:74
+msgctxt "keyboard key"
+msgid "Print"
+msgstr "Spausdinti"
+
+#: ../src/common/accelcmn.cpp:75
+msgctxt "keyboard key"
+msgid "Execute"
+msgstr "Vykdyti"
+
+#: ../src/common/accelcmn.cpp:76
+msgctxt "keyboard key"
+msgid "Snapshot"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:77
+msgctxt "keyboard key"
+msgid "Help"
+msgstr "Pagalba"
+
+#: ../src/common/accelcmn.cpp:78
+msgctxt "keyboard key"
+msgid "Add"
+msgstr "Pridėti"
+
+#: ../src/common/accelcmn.cpp:79
+msgctxt "keyboard key"
+msgid "Separator"
+msgstr "Skirtukas"
+
+#: ../src/common/accelcmn.cpp:80
+msgctxt "keyboard key"
+msgid "Subtract"
+msgstr "Atimti"
+
+#: ../src/common/accelcmn.cpp:81
+msgctxt "keyboard key"
+msgid "Decimal"
+msgstr "Dešimtainis"
+
+#: ../src/common/accelcmn.cpp:82
+msgctxt "keyboard key"
+msgid "Multiply"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:83
+msgctxt "keyboard key"
+msgid "Divide"
+msgstr "Padalinti"
+
+#: ../src/common/accelcmn.cpp:84
+msgctxt "keyboard key"
+msgid "Num_lock"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:84
+msgctxt "keyboard key"
+msgid "Num Lock"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:85
+msgctxt "keyboard key"
+msgid "Scroll_lock"
+msgstr "Perslinkimo_užrakinimas"
+
+#: ../src/common/accelcmn.cpp:85
+msgctxt "keyboard key"
+msgid "Scroll Lock"
+msgstr "Perslinkimo užrakinimas"
+
+#: ../src/common/accelcmn.cpp:86
+msgctxt "keyboard key"
+msgid "KP_Space"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:86
+msgctxt "keyboard key"
+msgid "Num Space"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:87
+msgctxt "keyboard key"
+msgid "KP_Tab"
+msgstr "KP_TAB"
+
+#: ../src/common/accelcmn.cpp:87
+msgctxt "keyboard key"
+msgid "Num Tab"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:88
+msgctxt "keyboard key"
+msgid "KP_Enter"
+msgstr "Spausdintuvas"
+
+#: ../src/common/accelcmn.cpp:88
+msgctxt "keyboard key"
+msgid "Num Enter"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:89
+msgctxt "keyboard key"
+msgid "KP_Home"
+msgstr "Pagrindinis"
+
+#: ../src/common/accelcmn.cpp:89
+msgctxt "keyboard key"
+msgid "Num Home"
+msgstr "Pagrindinis"
+
+#: ../src/common/accelcmn.cpp:90
+msgctxt "keyboard key"
+msgid "KP_Left"
+msgstr "Kairė"
+
+#: ../src/common/accelcmn.cpp:90
+msgctxt "keyboard key"
+msgid "Num left"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:91
+msgctxt "keyboard key"
+msgid "KP_Up"
+msgstr "KP_UP"
+
+#: ../src/common/accelcmn.cpp:91
+msgctxt "keyboard key"
+msgid "Num Up"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:92
+msgctxt "keyboard key"
+msgid "KP_Right"
+msgstr "Dešinė"
+
+#: ../src/common/accelcmn.cpp:92
+msgctxt "keyboard key"
+msgid "Num Right"
+msgstr "Dešinė"
+
+#: ../src/common/accelcmn.cpp:93
+msgctxt "keyboard key"
+msgid "KP_Down"
+msgstr "Žemyn"
+
+#: ../src/common/accelcmn.cpp:93
+msgctxt "keyboard key"
+msgid "Num Down"
+msgstr "Žemyn"
+
+#: ../src/common/accelcmn.cpp:94
+msgctxt "keyboard key"
+msgid "KP_PageUp"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:94
+msgctxt "keyboard key"
+msgid "Num Page Up"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:95
+msgctxt "keyboard key"
+msgid "KP_PageDown"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:95
+msgctxt "keyboard key"
+msgid "Num Page Down"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:96
+msgctxt "keyboard key"
+msgid "KP_Prior"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:97
+msgctxt "keyboard key"
+msgid "KP_Next"
+msgstr "Kitas"
+
+#: ../src/common/accelcmn.cpp:98
+msgctxt "keyboard key"
+msgid "KP_End"
+msgstr "KP_END"
+
+#: ../src/common/accelcmn.cpp:98
+msgctxt "keyboard key"
+msgid "Num End"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:99
+msgctxt "keyboard key"
+msgid "KP_Begin"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:99
+msgctxt "keyboard key"
+msgid "Num Begin"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:100
+msgctxt "keyboard key"
+msgid "KP_Insert"
+msgstr "Įterpti"
+
+#: ../src/common/accelcmn.cpp:100
+msgctxt "keyboard key"
+msgid "Num Insert"
+msgstr "Įterpti"
+
+#: ../src/common/accelcmn.cpp:101
+msgctxt "keyboard key"
+msgid "KP_Delete"
+msgstr "Ištrinti"
+
+#: ../src/common/accelcmn.cpp:101
+msgctxt "keyboard key"
+msgid "Num Delete"
+msgstr "Ištrinti"
+
+#: ../src/common/accelcmn.cpp:102
+msgctxt "keyboard key"
+msgid "KP_Equal"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:102
+msgctxt "keyboard key"
+msgid "Num ="
+msgstr "Num ="
+
+#: ../src/common/accelcmn.cpp:103
+msgctxt "keyboard key"
+msgid "KP_Multiply"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:103
+msgctxt "keyboard key"
+msgid "Num *"
+msgstr "Num *"
+
+#: ../src/common/accelcmn.cpp:104
+msgctxt "keyboard key"
+msgid "KP_Add"
+msgstr "KP_ADD"
+
+#: ../src/common/accelcmn.cpp:104
+msgctxt "keyboard key"
+msgid "Num +"
+msgstr "Num +"
+
+#: ../src/common/accelcmn.cpp:105
+msgctxt "keyboard key"
+msgid "KP_Separator"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:105
+msgctxt "keyboard key"
+msgid "Num ,"
+msgstr "Num ,"
+
+#: ../src/common/accelcmn.cpp:106
+msgctxt "keyboard key"
+msgid "KP_Subtract"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:106
+msgctxt "keyboard key"
+msgid "Num -"
+msgstr "Num -"
+
+#: ../src/common/accelcmn.cpp:107
+msgctxt "keyboard key"
+msgid "KP_Decimal"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:107
+msgctxt "keyboard key"
+msgid "Num ."
+msgstr "Num ."
+
+#: ../src/common/accelcmn.cpp:108
+msgctxt "keyboard key"
+msgid "KP_Divide"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:108
+msgctxt "keyboard key"
+msgid "Num /"
+msgstr "Num /"
+
+#: ../src/common/accelcmn.cpp:109
+msgctxt "keyboard key"
+msgid "Windows_Left"
+msgstr "&Langas"
+
+#: ../src/common/accelcmn.cpp:110
+msgctxt "keyboard key"
+msgid "Windows_Right"
+msgstr "&Langas"
+
+#: ../src/common/accelcmn.cpp:111
+msgctxt "keyboard key"
+msgid "Windows_Menu"
+msgstr "&Langas"
+
+#: ../src/common/accelcmn.cpp:112
+msgctxt "keyboard key"
+msgid "Command"
+msgstr "Komanda"
+
+#: ../src/common/accelcmn.cpp:186 ../src/common/accelcmn.cpp:359
+msgctxt "keyboard key"
+msgid "Ctrl"
+msgstr "Ctrl"
+
+#: ../src/common/accelcmn.cpp:188 ../src/common/accelcmn.cpp:363
+msgctxt "keyboard key"
+msgid "Alt"
+msgstr "Alt"
+
+#: ../src/common/accelcmn.cpp:190 ../src/common/accelcmn.cpp:361
+msgctxt "keyboard key"
+msgid "Shift"
+msgstr "Shift"
+
+#: ../src/common/accelcmn.cpp:196
+msgctxt "keyboard key"
+msgid "num "
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:260 ../src/common/accelcmn.cpp:382
+msgctxt "keyboard key"
+msgid "F"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:277 ../src/common/accelcmn.cpp:385
+msgctxt "keyboard key"
+msgid "KP_F"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:280 ../src/common/accelcmn.cpp:388
+msgctxt "keyboard key"
+msgid "KP_"
+msgstr "KP_"
+
+#: ../src/common/accelcmn.cpp:283 ../src/common/accelcmn.cpp:391
+msgctxt "keyboard key"
+msgid "SPECIAL"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:373
+#, fuzzy
+msgid "Ctrl"
+msgstr "Ctrl"
+
+#: ../src/common/appbase.cpp:786
+msgid "show this help message"
+msgstr ""
+
+#: ../src/common/appbase.cpp:796
+msgid "generate verbose log messages"
+msgstr ""
+
+#: ../src/common/appcmn.cpp:256
+msgid "specify the theme to use"
+msgstr ""
+
+#: ../src/common/appcmn.cpp:270
+msgid "specify display mode to use (e.g. 640x480-16)"
+msgstr ""
+
+#: ../src/common/appcmn.cpp:292
+#, c-format
+msgid "Unsupported theme '%s'."
+msgstr ""
+
+#: ../src/common/appcmn.cpp:309
+#, c-format
+msgid "Invalid display mode specification '%s'."
+msgstr ""
+
+#: ../src/common/cmdline.cpp:875
+#, c-format
+msgid "Option '%s' can't be negated"
+msgstr ""
+
+#: ../src/common/cmdline.cpp:889
+#, c-format
+msgid "Unknown long option '%s'"
+msgstr ""
+
+#: ../src/common/cmdline.cpp:904 ../src/common/cmdline.cpp:926
+#, c-format
+msgid "Unknown option '%s'"
+msgstr ""
+
+#: ../src/common/cmdline.cpp:1004
+#, c-format
+msgid "Unexpected characters following option '%s'."
+msgstr ""
+
+#: ../src/common/cmdline.cpp:1039
+#, c-format
+msgid "Option '%s' requires a value."
+msgstr ""
+
+#: ../src/common/cmdline.cpp:1058
+#, c-format
+msgid "Separator expected after the option '%s'."
+msgstr ""
+
+#: ../src/common/cmdline.cpp:1088 ../src/common/cmdline.cpp:1106
+#, c-format
+msgid "'%s' is not a correct numeric value for option '%s'."
+msgstr ""
+
+#: ../src/common/cmdline.cpp:1122
+#, c-format
+msgid "Option '%s': '%s' cannot be converted to a date."
+msgstr ""
+
+#: ../src/common/cmdline.cpp:1170
+#, c-format
+msgid "Unexpected parameter '%s'"
+msgstr ""
+
+#. TRANSLATORS: Short name and long name for a command line option
+#: ../src/common/cmdline.cpp:1197
+#, c-format
+msgid "%s (or %s)"
+msgstr "%s (iš %s)"
+
+#: ../src/common/cmdline.cpp:1208
+#, c-format
+msgid "The value for the option '%s' must be specified."
+msgstr ""
+
+#: ../src/common/cmdline.cpp:1230
+#, c-format
+msgid "The required parameter '%s' was not specified."
+msgstr ""
+
+#: ../src/common/cmdline.cpp:1289
+#, c-format
+msgid "Usage: %s"
+msgstr ""
+
+#: ../src/common/cmdline.cpp:1498
+msgid "str"
+msgstr ""
+
+#: ../src/common/cmdline.cpp:1502
+msgid "num"
+msgstr "num"
+
+#: ../src/common/cmdline.cpp:1506
+msgid "double"
+msgstr "dvigubas"
+
+#: ../src/common/cmdline.cpp:1510
+msgid "date"
+msgstr "data"
+
+#: ../src/common/cmdproc.cpp:250 ../src/common/cmdproc.cpp:276
+#: ../src/common/cmdproc.cpp:296
+msgid "Unnamed command"
+msgstr ""
+
+#: ../src/common/cmdproc.cpp:253
+msgid "&Undo "
+msgstr "Atša&ukti "
+
+#: ../src/common/cmdproc.cpp:255
+msgid "Can't &Undo "
+msgstr ""
+
+#: ../src/common/cmdproc.cpp:259 ../src/common/stockitem.cpp:208
+#: ../src/msw/textctrl.cpp:2880 ../src/osx/textctrl_osx.cpp:649
+#: ../src/richtext/richtextctrl.cpp:327
+msgid "&Undo"
+msgstr "Atša&ukti"
+
+#: ../src/common/cmdproc.cpp:277 ../src/common/cmdproc.cpp:297
+msgid "&Redo "
+msgstr "Paka&rtoti "
+
+#: ../src/common/cmdproc.cpp:281 ../src/common/cmdproc.cpp:288
+#: ../src/common/stockitem.cpp:190 ../src/msw/textctrl.cpp:2881
+#: ../src/osx/textctrl_osx.cpp:650 ../src/richtext/richtextctrl.cpp:328
+msgid "&Redo"
+msgstr "Paka&rtoti"
+
+#: ../src/common/colourcmn.cpp:41
+#, c-format
+msgid "String To Colour : Incorrect colour specification : %s"
+msgstr ""
+
+#: ../src/common/config.cpp:259
+#, c-format
+msgid "Invalid value %ld for a boolean key \"%s\" in config file."
+msgstr ""
+
+#: ../src/common/config.cpp:526
+#, c-format
+msgid ""
+"Environment variables expansion failed: missing '%c' at position %u in '%s'."
+msgstr ""
+
+#: ../src/common/config.cpp:576 ../src/msw/regconf.cpp:272
+#, c-format
+msgid "'%s' has extra '..', ignored."
+msgstr ""
+
+#. TRANSLATORS: Checkbox state name
+#: ../src/common/datavcmn.cpp:2166 ../src/generic/datavgen.cpp:1430
+msgid "checked"
+msgstr ""
+
+#. TRANSLATORS: Checkbox state name
+#: ../src/common/datavcmn.cpp:2170 ../src/generic/datavgen.cpp:1432
+msgid "unchecked"
+msgstr ""
+
+#. TRANSLATORS: Checkbox state name
+#: ../src/common/datavcmn.cpp:2174
+msgid "undetermined"
+msgstr ""
+
+#: ../src/common/datetimefmt.cpp:1875
+msgid "today"
+msgstr ""
+
+#: ../src/common/datetimefmt.cpp:1876
+msgid "yesterday"
+msgstr ""
+
+#: ../src/common/datetimefmt.cpp:1877
+msgid "tomorrow"
+msgstr ""
+
+#: ../src/common/datetimefmt.cpp:2071
+msgid "first"
+msgstr "pirmas"
+
+#: ../src/common/datetimefmt.cpp:2072
+msgid "second"
+msgstr "sekundė"
+
+#: ../src/common/datetimefmt.cpp:2073
+msgid "third"
+msgstr ""
+
+#: ../src/common/datetimefmt.cpp:2074
+msgid "fourth"
+msgstr ""
+
+#: ../src/common/datetimefmt.cpp:2075
+msgid "fifth"
+msgstr "penktas"
+
+#: ../src/common/datetimefmt.cpp:2076
+msgid "sixth"
+msgstr ""
+
+#: ../src/common/datetimefmt.cpp:2077
+msgid "seventh"
+msgstr ""
+
+#: ../src/common/datetimefmt.cpp:2078
+msgid "eighth"
+msgstr "aštuntas"
+
+#: ../src/common/datetimefmt.cpp:2079
+msgid "ninth"
+msgstr ""
+
+#: ../src/common/datetimefmt.cpp:2080
+msgid "tenth"
+msgstr ""
+
+#: ../src/common/datetimefmt.cpp:2081
+msgid "eleventh"
+msgstr "vienuoliktas"
+
+#: ../src/common/datetimefmt.cpp:2082
+msgid "twelfth"
+msgstr ""
+
+#: ../src/common/datetimefmt.cpp:2083
+msgid "thirteenth"
+msgstr ""
+
+#: ../src/common/datetimefmt.cpp:2084
+msgid "fourteenth"
+msgstr "keturioliktas"
+
+#: ../src/common/datetimefmt.cpp:2085
+msgid "fifteenth"
+msgstr "penkioliktas"
+
+#: ../src/common/datetimefmt.cpp:2086
+msgid "sixteenth"
+msgstr ""
+
+#: ../src/common/datetimefmt.cpp:2087
+msgid "seventeenth"
+msgstr ""
+
+#: ../src/common/datetimefmt.cpp:2088
+msgid "eighteenth"
+msgstr "aštuonioliktas"
+
+#: ../src/common/datetimefmt.cpp:2089
+msgid "nineteenth"
+msgstr ""
+
+#: ../src/common/datetimefmt.cpp:2090
+msgid "twentieth"
+msgstr ""
+
+#: ../src/common/datetimefmt.cpp:2248
+msgid "noon"
+msgstr ""
+
+#: ../src/common/datetimefmt.cpp:2249
+msgid "midnight"
+msgstr ""
+
+#: ../src/common/debugrpt.cpp:209
+#, c-format
+msgid "Failed to create directory \"%s\""
+msgstr ""
+
+#: ../src/common/debugrpt.cpp:210
+msgid "Debug report couldn't be created."
+msgstr ""
+
+#: ../src/common/debugrpt.cpp:227
+#, c-format
+msgid "Failed to remove debug report file \"%s\""
+msgstr ""
+
+#: ../src/common/debugrpt.cpp:239
+#, c-format
+msgid "Failed to clean up debug report directory \"%s\""
+msgstr ""
+
+#: ../src/common/debugrpt.cpp:514
+msgid "process context description"
+msgstr ""
+
+#: ../src/common/debugrpt.cpp:538
+msgid "dump of the process state (binary)"
+msgstr ""
+
+#: ../src/common/debugrpt.cpp:553
+msgid "Debug report generation has failed."
+msgstr ""
+
+#: ../src/common/debugrpt.cpp:560
+#, c-format
+msgid ""
+"Processing debug report has failed, leaving the files in \"%s\" directory."
+msgstr ""
+
+#: ../src/common/debugrpt.cpp:573
+msgid "A debug report has been generated. It can be found in"
+msgstr ""
+
+#: ../src/common/debugrpt.cpp:576
+msgid "And includes the following files:\n"
+msgstr ""
+
+#: ../src/common/debugrpt.cpp:586
+msgid ""
+"\n"
+"Please send this report to the program maintainer, thank you!\n"
+msgstr ""
+
+#: ../src/common/debugrpt.cpp:729
+msgid "Failed to execute curl, please install it in PATH."
+msgstr ""
+
+#: ../src/common/debugrpt.cpp:742
+#, c-format
+msgid "Failed to upload the debug report (error code %d)."
+msgstr ""
+
+#: ../src/common/docview.cpp:366
+msgid "Save As"
+msgstr "Išsaugoti kaip"
+
+#: ../src/common/docview.cpp:457
+msgid "Discard changes and reload the last saved version?"
+msgstr ""
+
+#: ../src/common/docview.cpp:488
+msgid "unnamed"
+msgstr ""
+
+#: ../src/common/docview.cpp:513
+#, c-format
+msgid "Do you want to save changes to %s?"
+msgstr "Ar norite išsaugoti %s pakeitimus?"
+
+#: ../src/common/docview.cpp:521 ../src/common/docview.cpp:560
+#: ../src/common/stockitem.cpp:195
+msgid "&Save"
+msgstr "&Išsaugoti"
+
+#: ../src/common/docview.cpp:522 ../src/common/docview.cpp:560
+msgid "&Discard changes"
+msgstr ""
+
+#: ../src/common/docview.cpp:523
+#, fuzzy
+msgid "Do&n't close"
+msgstr "Nesaugoti"
+
+#: ../src/common/docview.cpp:553
+#, fuzzy, c-format
+msgid "Do you want to save changes to %s before closing it?"
+msgstr "Ar norite išsaugoti %s pakeitimus?"
+
+#: ../src/common/docview.cpp:559
+msgid "The document must be closed."
+msgstr ""
+
+#: ../src/common/docview.cpp:571
+#, c-format
+msgid "Saving %s failed, would you like to retry?"
+msgstr ""
+
+#: ../src/common/docview.cpp:577
+msgid "Retry"
+msgstr ""
+
+#: ../src/common/docview.cpp:577
+msgid "Discard changes"
+msgstr ""
+
+#: ../src/common/docview.cpp:679
+#, c-format
+msgid "File \"%s\" could not be opened for writing."
+msgstr ""
+
+#: ../src/common/docview.cpp:685
+#, c-format
+msgid "Failed to save document to the file \"%s\"."
+msgstr ""
+
+#: ../src/common/docview.cpp:702
+#, c-format
+msgid "File \"%s\" could not be opened for reading."
+msgstr ""
+
+#: ../src/common/docview.cpp:714
+#, c-format
+msgid "Failed to read document from the file \"%s\"."
+msgstr ""
+
+#: ../src/common/docview.cpp:1236
+#, c-format
+msgid ""
+"The file '%s' doesn't exist and couldn't be opened.\n"
+"It has been removed from the most recently used files list."
+msgstr ""
+
+#: ../src/common/docview.cpp:1296
+msgid "Print preview creation failed."
+msgstr ""
+
+#: ../src/common/docview.cpp:1302
+msgid "Print Preview"
+msgstr "Spausdinimo peržiūra"
+
+#: ../src/common/docview.cpp:1517
+#, c-format
+msgid "The format of file '%s' couldn't be determined."
+msgstr ""
+
+#: ../src/common/docview.cpp:1643
+#, c-format
+msgid "unnamed%d"
+msgstr ""
+
+#: ../src/common/docview.cpp:1660
+msgid " - "
+msgstr " - "
+
+#: ../src/common/docview.cpp:1791 ../src/common/docview.cpp:1844
+msgid "Open File"
+msgstr "Atverti failą"
+
+#: ../src/common/docview.cpp:1807
+msgid "File error"
+msgstr ""
+
+#: ../src/common/docview.cpp:1809
+msgid "Sorry, could not open this file."
+msgstr ""
+
+#: ../src/common/docview.cpp:1843
+msgid "Sorry, the format for this file is unknown."
+msgstr ""
+
+#: ../src/common/docview.cpp:1924
+msgid "Select a document template"
+msgstr ""
+
+#: ../src/common/docview.cpp:1925
+msgid "Templates"
+msgstr "Šablonai"
+
+#: ../src/common/docview.cpp:1998
+msgid "Select a document view"
+msgstr ""
+
+#: ../src/common/docview.cpp:1999
+msgid "Views"
+msgstr "Vaizdai"
+
+#: ../src/common/dynlib.cpp:81
+#, c-format
+msgid "Failed to load shared library '%s'"
+msgstr ""
+
+#: ../src/common/dynlib.cpp:105
+#, c-format
+msgid "Couldn't find symbol '%s' in a dynamic library"
+msgstr ""
+
+#: ../src/common/ffile.cpp:56 ../src/common/file.cpp:215
+#, c-format
+msgid "can't open file '%s'"
+msgstr ""
+
+#: ../src/common/ffile.cpp:72
+#, c-format
+msgid "can't close file '%s'"
+msgstr ""
+
+#: ../src/common/ffile.cpp:106 ../src/common/ffile.cpp:131
+#, c-format
+msgid "Read error on file '%s'"
+msgstr ""
+
+#: ../src/common/ffile.cpp:148
+#, c-format
+msgid "Write error on file '%s'"
+msgstr ""
+
+#: ../src/common/ffile.cpp:182
+#, c-format
+msgid "failed to flush the file '%s'"
+msgstr ""
+
+#: ../src/common/ffile.cpp:222
+#, c-format
+msgid "Seek error on file '%s' (large files not supported by stdio)"
+msgstr ""
+
+#: ../src/common/ffile.cpp:232
+#, c-format
+msgid "Seek error on file '%s'"
+msgstr ""
+
+#: ../src/common/ffile.cpp:248
+#, c-format
+msgid "Can't find current position in file '%s'"
+msgstr ""
+
+#: ../src/common/ffile.cpp:349 ../src/common/file.cpp:569
+msgid "Failed to set temporary file permissions"
+msgstr ""
+
+#: ../src/common/ffile.cpp:371
+#, c-format
+msgid "can't remove file '%s'"
+msgstr ""
+
+#: ../src/common/ffile.cpp:376 ../src/common/file.cpp:591
+#, c-format
+msgid "can't commit changes to file '%s'"
+msgstr ""
+
+#: ../src/common/ffile.cpp:388 ../src/common/file.cpp:603
+#, c-format
+msgid "can't remove temporary file '%s'"
+msgstr ""
+
+#: ../src/common/file.cpp:162
+#, c-format
+msgid "can't create file '%s'"
+msgstr ""
+
+#: ../src/common/file.cpp:229
+#, c-format
+msgid "can't close file descriptor %d"
+msgstr ""
+
+#: ../src/common/file.cpp:332
+#, c-format
+msgid "can't read from file descriptor %d"
+msgstr ""
+
+#: ../src/common/file.cpp:351
+#, c-format
+msgid "can't write to file descriptor %d"
+msgstr ""
+
+#: ../src/common/file.cpp:390
+#, c-format
+msgid "can't flush file descriptor %d"
+msgstr ""
+
+#: ../src/common/file.cpp:432
+#, c-format
+msgid "can't seek on file descriptor %d"
+msgstr ""
+
+#: ../src/common/file.cpp:446
+#, c-format
+msgid "can't get seek position on file descriptor %d"
+msgstr ""
+
+#: ../src/common/file.cpp:475
+#, c-format
+msgid "can't find length of file on file descriptor %d"
+msgstr ""
+
+#: ../src/common/file.cpp:505
+#, c-format
+msgid "can't determine if the end of file is reached on descriptor %d"
+msgstr ""
+
+#: ../src/common/fileconf.cpp:352
+#, c-format
+msgid ""
+" and additionally, the existing configuration file was renamed to \"%s\" and "
+"couldn't be renamed back, please rename it to its original path \"%s\""
+msgstr ""
+
+#: ../src/common/fileconf.cpp:389
+msgid " due to the following error:\n"
+msgstr ""
+
+#: ../src/common/fileconf.cpp:412
+msgid "failed to rename the existing file"
+msgstr ""
+
+#: ../src/common/fileconf.cpp:421
+msgid "failed to create the new file directory"
+msgstr ""
+
+#: ../src/common/fileconf.cpp:428
+msgid "failed to move the file to the new location"
+msgstr ""
+
+#: ../src/common/fileconf.cpp:462
+#, c-format
+msgid "can't open global configuration file '%s'."
+msgstr ""
+
+#: ../src/common/fileconf.cpp:478
+#, c-format
+msgid "can't open user configuration file '%s'."
+msgstr ""
+
+#: ../src/common/fileconf.cpp:483
+#, c-format
+msgid "Changes won't be saved to avoid overwriting the existing file \"%s\""
+msgstr ""
+
+#: ../src/common/fileconf.cpp:583
+msgid "Error reading config options."
+msgstr ""
+
+#: ../src/common/fileconf.cpp:593
+msgid "Failed to read config options."
+msgstr ""
+
+#: ../src/common/fileconf.cpp:700
+#, c-format
+msgid "file '%s': unexpected character %c at line %zu."
+msgstr ""
+
+#: ../src/common/fileconf.cpp:736
+#, c-format
+msgid "file '%s', line %zu: '%s' ignored after group header."
+msgstr ""
+
+#: ../src/common/fileconf.cpp:765
+#, c-format
+msgid "file '%s', line %zu: '=' expected."
+msgstr ""
+
+#: ../src/common/fileconf.cpp:778
+#, c-format
+msgid "file '%s', line %zu: value for immutable key '%s' ignored."
+msgstr ""
+
+#: ../src/common/fileconf.cpp:788
+#, c-format
+msgid "file '%s', line %zu: key '%s' was first found at line %d."
+msgstr ""
+
+#: ../src/common/fileconf.cpp:1091
+#, c-format
+msgid "Config entry name cannot start with '%c'."
+msgstr ""
+
+#: ../src/common/fileconf.cpp:1146
+msgid "Failed to create configuration file directory."
+msgstr ""
+
+#: ../src/common/fileconf.cpp:1158
+msgid "can't open user configuration file."
+msgstr ""
+
+#: ../src/common/fileconf.cpp:1172
+msgid "can't write user configuration file."
+msgstr ""
+
+#: ../src/common/fileconf.cpp:1178
+msgid "Failed to update user configuration file."
+msgstr ""
+
+#: ../src/common/fileconf.cpp:1201
+msgid "Error saving user configuration data."
+msgstr ""
+
+#: ../src/common/fileconf.cpp:1313
+#, c-format
+msgid "can't delete user configuration file '%s'"
+msgstr ""
+
+#: ../src/common/fileconf.cpp:2007
+#, c-format
+msgid "entry '%s' appears more than once in group '%s'"
+msgstr ""
+
+#: ../src/common/fileconf.cpp:2021
+#, c-format
+msgid "attempt to change immutable key '%s' ignored."
+msgstr ""
+
+#: ../src/common/fileconf.cpp:2118
+#, c-format
+msgid "trailing backslash ignored in '%s'"
+msgstr ""
+
+#: ../src/common/fileconf.cpp:2153
+#, c-format
+msgid "unexpected \" at position %d in '%s'."
+msgstr ""
+
+#: ../src/common/filefn.cpp:474
+#, c-format
+msgid "Failed to copy the file '%s' to '%s'"
+msgstr ""
+
+#: ../src/common/filefn.cpp:487
+#, c-format
+msgid "Impossible to get permissions for file '%s'"
+msgstr ""
+
+#: ../src/common/filefn.cpp:501
+#, c-format
+msgid "Impossible to overwrite the file '%s'"
+msgstr ""
+
+#: ../src/common/filefn.cpp:508
+#, c-format
+msgid "Error copying the file '%s' to '%s'."
+msgstr ""
+
+#: ../src/common/filefn.cpp:556
+#, c-format
+msgid "Impossible to set permissions for the file '%s'"
+msgstr ""
+
+#: ../src/common/filefn.cpp:606
+#, c-format
+msgid ""
+"Failed to rename the file '%s' to '%s' because the destination file already "
+"exists."
+msgstr ""
+
+#: ../src/common/filefn.cpp:623
+#, c-format
+msgid "File '%s' couldn't be renamed '%s'"
+msgstr "Failas '%s' negali būti pervadintas į '%s'"
+
+#: ../src/common/filefn.cpp:639
+#, c-format
+msgid "File '%s' couldn't be removed"
+msgstr "Failas '%s' negali būti pašalintas"
+
+#: ../src/common/filefn.cpp:666
+#, c-format
+msgid "Directory '%s' couldn't be created"
+msgstr ""
+
+#: ../src/common/filefn.cpp:680
+#, c-format
+msgid "Directory '%s' couldn't be deleted"
+msgstr ""
+
+#: ../src/common/filefn.cpp:714
+#, c-format
+msgid "Cannot enumerate files '%s'"
+msgstr ""
+
+#: ../src/common/filefn.cpp:798
+msgid "Failed to get the working directory"
+msgstr ""
+
+#: ../src/common/filefn.cpp:843
+msgid "Could not set current working directory"
+msgstr "Nepavyko nustatyti aktyvaus darbo aplanko"
+
+#: ../src/common/filefn.cpp:974
+#, c-format
+msgid "Files (%s)"
+msgstr ""
+
+#: ../src/common/filename.cpp:182
+#, c-format
+msgid "Failed to open '%s' for reading"
+msgstr ""
+
+#: ../src/common/filename.cpp:187
+#, c-format
+msgid "Failed to open '%s' for writing"
+msgstr ""
+
+#: ../src/common/filename.cpp:199
+msgid "Failed to close file handle"
+msgstr ""
+
+#: ../src/common/filename.cpp:1046
+msgid "Failed to create a temporary file name"
+msgstr ""
+
+#: ../src/common/filename.cpp:1081
+msgid "Failed to open temporary file."
+msgstr ""
+
+#: ../src/common/filename.cpp:2862
+#, c-format
+msgid "Failed to modify file times for '%s'"
+msgstr ""
+
+#: ../src/common/filename.cpp:2877
+#, c-format
+msgid "Failed to touch the file '%s'"
+msgstr ""
+
+#: ../src/common/filename.cpp:2958
+#, c-format
+msgid "Failed to retrieve file times for '%s'"
+msgstr ""
+
+#: ../src/common/filepickercmn.cpp:39 ../src/common/filepickercmn.cpp:40
+msgid "Browse"
+msgstr "Naršyti"
+
+#: ../src/common/fldlgcmn.cpp:792 ../src/generic/filectrlg.cpp:1185
+#, c-format
+msgid "All files (%s)|%s"
+msgstr ""
+
+#. TRANSLATORS: %s are a file extension used to build a file wildcard string
+#: ../src/common/fldlgcmn.cpp:810
+#, c-format
+msgid "%s files (%s)|%s"
+msgstr ""
+
+#: ../src/common/fldlgcmn.cpp:1072
+#, c-format
+msgid "Load %s file"
+msgstr ""
+
+#: ../src/common/fldlgcmn.cpp:1074
+#, c-format
+msgid "Save %s file"
+msgstr "Išsaugoti %s failą"
+
+#: ../src/common/fmapbase.cpp:144
+msgid "Western European (ISO-8859-1)"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:145
+msgid "Central European (ISO-8859-2)"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:146
+msgid "Esperanto (ISO-8859-3)"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:147
+msgid "Baltic (old) (ISO-8859-4)"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:148
+msgid "Cyrillic (ISO-8859-5)"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:149
+msgid "Arabic (ISO-8859-6)"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:150
+msgid "Greek (ISO-8859-7)"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:151
+msgid "Hebrew (ISO-8859-8)"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:152
+msgid "Turkish (ISO-8859-9)"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:153
+msgid "Nordic (ISO-8859-10)"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:154
+msgid "Thai (ISO-8859-11)"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:155
+msgid "Indian (ISO-8859-12)"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:156
+msgid "Baltic (ISO-8859-13)"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:157
+msgid "Celtic (ISO-8859-14)"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:158
+msgid "Western European with Euro (ISO-8859-15)"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:159
+msgid "KOI8-R"
+msgstr "KOI8-R"
+
+#: ../src/common/fmapbase.cpp:160
+msgid "KOI8-U"
+msgstr "KOI8-U"
+
+#: ../src/common/fmapbase.cpp:161
+msgid "Windows/DOS OEM Cyrillic (CP 866)"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:162
+msgid "Windows Thai (CP 874)"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:163
+msgid "Windows Japanese (CP 932) or Shift-JIS"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:164
+msgid "Windows Chinese Simplified (CP 936) or GB-2312"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:165
+msgid "Windows Korean (CP 949)"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:166
+msgid "Windows Chinese Traditional (CP 950) or Big-5"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:167
+msgid "Windows Central European (CP 1250)"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:168
+msgid "Windows Cyrillic (CP 1251)"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:169
+msgid "Windows Western European (CP 1252)"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:170
+msgid "Windows Greek (CP 1253)"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:171
+msgid "Windows Turkish (CP 1254)"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:172
+msgid "Windows Hebrew (CP 1255)"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:173
+msgid "Windows Arabic (CP 1256)"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:174
+msgid "Windows Baltic (CP 1257)"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:175
+msgid "Windows Vietnamese (CP 1258)"
+msgstr "Windows Vietnamese (CP 1258)"
+
+#: ../src/common/fmapbase.cpp:176
+msgid "Windows Johab (CP 1361)"
+msgstr "Windows Johab (CP 1361)"
+
+#: ../src/common/fmapbase.cpp:177
+msgid "Windows/DOS OEM (CP 437)"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:178
+msgid "Unicode 7 bit (UTF-7)"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:179
+msgid "Unicode 8 bit (UTF-8)"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:181 ../src/common/fmapbase.cpp:187
+msgid "Unicode 16 bit (UTF-16)"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:182
+msgid "Unicode 16 bit Little Endian (UTF-16LE)"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:183 ../src/common/fmapbase.cpp:189
+msgid "Unicode 32 bit (UTF-32)"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:184
+msgid "Unicode 32 bit Little Endian (UTF-32LE)"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:186
+msgid "Unicode 16 bit Big Endian (UTF-16BE)"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:188
+msgid "Unicode 32 bit Big Endian (UTF-32BE)"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:191
+msgid "Extended Unix Codepage for Japanese (EUC-JP)"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:192
+msgid "US-ASCII"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:193
+msgid "ISO-2022-JP"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:195
+msgid "MacRoman"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:196
+msgid "MacJapanese"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:197
+msgid "MacChineseTrad"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:198
+msgid "MacKorean"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:199
+msgid "MacArabic"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:200
+msgid "MacHebrew"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:201
+msgid "MacGreek"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:202
+msgid "MacCyrillic"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:203
+msgid "MacDevanagari"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:204
+msgid "MacGurmukhi"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:205
+msgid "MacGujarati"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:206
+msgid "MacOriya"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:207
+msgid "MacBengali"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:208
+msgid "MacTamil"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:209
+msgid "MacTelugu"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:210
+msgid "MacKannada"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:211
+msgid "MacMalayalam"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:212
+msgid "MacSinhalese"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:213
+msgid "MacBurmese"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:214
+msgid "MacKhmer"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:215
+msgid "MacThai"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:216
+msgid "MacLaotian"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:217
+msgid "MacGeorgian"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:218
+msgid "MacArmenian"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:219
+msgid "MacChineseSimp"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:220
+msgid "MacTibetan"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:221
+msgid "MacMongolian"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:222
+msgid "MacEthiopic"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:223
+msgid "MacCentralEurRoman"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:224
+msgid "MacVietnamese"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:225
+msgid "MacExtArabic"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:226
+msgid "MacSymbol"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:227
+msgid "MacDingbats"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:228
+msgid "MacTurkish"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:229
+msgid "MacCroatian"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:230
+msgid "MacIcelandic"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:231
+msgid "MacRomanian"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:232
+msgid "MacCeltic"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:233
+msgid "MacGaelic"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:234
+msgid "MacKeyboardGlyphs"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:791
+msgid "Default encoding"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:805
+#, c-format
+msgid "Unknown encoding (%d)"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:815 ../src/richtext/richtextstyles.cpp:776
+msgid "default"
+msgstr "numatytasis"
+
+#: ../src/common/fmapbase.cpp:829
+#, c-format
+msgid "unknown-%d"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:924 ../src/common/fontcmn.cpp:1130
+msgid "underlined"
+msgstr "pabrauktas"
+
+#: ../src/common/fontcmn.cpp:929
+msgid " strikethrough"
+msgstr " perbrauktas"
+
+#: ../src/common/fontcmn.cpp:942
+msgid " thin"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:946
+msgid " extra light"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:950
+msgid " light"
+msgstr " lengvas"
+
+#: ../src/common/fontcmn.cpp:954
+msgid " medium"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:958
+msgid " semi bold"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:962
+msgid " bold"
+msgstr " pastorintas"
+
+#: ../src/common/fontcmn.cpp:966
+msgid " extra bold"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:970
+msgid " heavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:974
+msgid " extra heavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:990
+msgid " italic"
+msgstr " kursyvas"
+
+#: ../src/common/fontcmn.cpp:1134
+msgid "strikethrough"
+msgstr "perbrauktas"
+
+#: ../src/common/fontcmn.cpp:1143
+msgid "thin"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1156
+msgid "extralight"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1161
+msgid "light"
+msgstr "lengvas"
+
+#: ../src/common/fontcmn.cpp:1169 ../src/richtext/richtextstyles.cpp:775
+msgid "normal"
+msgstr "normalus"
+
+#: ../src/common/fontcmn.cpp:1174
+msgid "medium"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1179 ../src/common/fontcmn.cpp:1199
+msgid "semibold"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1184
+msgid "bold"
+msgstr "pastorintas"
+
+#: ../src/common/fontcmn.cpp:1194
+msgid "extrabold"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1204
+msgid "heavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1212
+msgid "extraheavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1217
+msgid "italic"
+msgstr "kursyvas"
+
+#: ../src/common/fontmap.cpp:195
+msgid ": unknown charset"
+msgstr ""
+
+#: ../src/common/fontmap.cpp:199
+#, c-format
+msgid ""
+"The charset '%s' is unknown. You may select\n"
+"another charset to replace it with or choose\n"
+"[Cancel] if it cannot be replaced"
+msgstr ""
+
+#: ../src/common/fontmap.cpp:241
+#, c-format
+msgid "Failed to remember the encoding for the charset '%s'."
+msgstr ""
+
+#: ../src/common/fontmap.cpp:321
+msgid "can't load any font, aborting"
+msgstr ""
+
+#: ../src/common/fontmap.cpp:409
+msgid ": unknown encoding"
+msgstr ""
+
+#: ../src/common/fontmap.cpp:417
+#, c-format
+msgid ""
+"No font for displaying text in encoding '%s' found,\n"
+"but an alternative encoding '%s' is available.\n"
+"Do you want to use this encoding (otherwise you will have to choose another "
+"one)?"
+msgstr ""
+
+#: ../src/common/fontmap.cpp:422
+#, c-format
+msgid ""
+"No font for displaying text in encoding '%s' found.\n"
+"Would you like to select a font to be used for this encoding\n"
+"(otherwise the text in this encoding will not be shown correctly)?"
+msgstr ""
+
+#: ../src/common/fs_mem.cpp:169
+#, c-format
+msgid "Memory VFS already contains file '%s'!"
+msgstr ""
+
+#: ../src/common/fs_mem.cpp:232
+#, c-format
+msgid "Trying to remove file '%s' from memory VFS, but it is not loaded!"
+msgstr ""
+
+#: ../src/common/fs_mem.cpp:262
+#, c-format
+msgid "Failed to store image '%s' to memory VFS!"
+msgstr ""
+
+#: ../src/common/ftp.cpp:197
+msgid "Timeout while waiting for FTP server to connect, try passive mode."
+msgstr ""
+
+#: ../src/common/ftp.cpp:399
+#, c-format
+msgid "Failed to set FTP transfer mode to %s."
+msgstr ""
+
+#: ../src/common/ftp.cpp:400 ../src/richtext/richtextsymboldlg.cpp:432
+msgid "ASCII"
+msgstr "ASCII"
+
+#: ../src/common/ftp.cpp:400
+msgid "binary"
+msgstr ""
+
+#: ../src/common/ftp.cpp:608
+msgid "The FTP server doesn't support the PORT command."
+msgstr ""
+
+#: ../src/common/ftp.cpp:622
+msgid "The FTP server doesn't support passive mode."
+msgstr ""
+
+#: ../src/common/gifdecod.cpp:822
+#, c-format
+msgid "Incorrect GIF frame size (%u, %d) for the frame #%u"
+msgstr ""
+
+#: ../src/common/glcmn.cpp:108
+msgid "Failed to allocate colour for OpenGL"
+msgstr ""
+
+#: ../src/common/headerctrlcmn.cpp:57
+msgid "Please select the columns to show and define their order:"
+msgstr ""
+
+#: ../src/common/headerctrlcmn.cpp:58
+msgid "Customize Columns"
+msgstr ""
+
+#: ../src/common/headerctrlcmn.cpp:304
+msgid "&Customize..."
+msgstr "&Pritaikyti..."
+
+#: ../src/common/hyperlnkcmn.cpp:132
+#, c-format
+msgid "Failed to open URL \"%s\" in the default browser"
+msgstr ""
+
+#: ../src/common/iconbndl.cpp:195
+#, c-format
+msgid "Failed to load image %%d from file '%s'."
+msgstr ""
+
+#: ../src/common/iconbndl.cpp:203
+#, c-format
+msgid "Failed to load image %d from stream."
+msgstr ""
+
+#: ../src/common/iconbndl.cpp:221
+#, c-format
+msgid "Failed to load icons from resource '%s'."
+msgstr ""
+
+#: ../src/common/imagbmp.cpp:97
+msgid "BMP: Couldn't save invalid image."
+msgstr ""
+
+#: ../src/common/imagbmp.cpp:137
+msgid "BMP: wxImage doesn't have own wxPalette."
+msgstr ""
+
+#: ../src/common/imagbmp.cpp:243
+msgid "BMP: Couldn't write the file (Bitmap) header."
+msgstr ""
+
+#: ../src/common/imagbmp.cpp:266
+msgid "BMP: Couldn't write the file (BitmapInfo) header."
+msgstr ""
+
+#: ../src/common/imagbmp.cpp:353
+msgid "BMP: Couldn't write RGB color map."
+msgstr ""
+
+#: ../src/common/imagbmp.cpp:487
+msgid "BMP: Couldn't write data."
+msgstr ""
+
+#: ../src/common/imagbmp.cpp:561 ../src/common/imagbmp.cpp:642
+msgid "BMP: Couldn't allocate memory."
+msgstr ""
+
+#: ../src/common/imagbmp.cpp:1041
+msgid "DIB Header: Image width > 32767 pixels for file."
+msgstr ""
+
+#: ../src/common/imagbmp.cpp:1049
+msgid "DIB Header: Image height > 32767 pixels for file."
+msgstr ""
+
+#: ../src/common/imagbmp.cpp:1081
+msgid "DIB Header: Unknown bitdepth in file."
+msgstr ""
+
+#: ../src/common/imagbmp.cpp:1156
+msgid "DIB Header: Unknown encoding in file."
+msgstr ""
+
+#: ../src/common/imagbmp.cpp:1165
+msgid "DIB Header: Encoding doesn't match bitdepth."
+msgstr ""
+
+#: ../src/common/imagbmp.cpp:1180
+#, c-format
+msgid "BMP Header: Invalid number of colors (%d)."
+msgstr ""
+
+#: ../src/common/imagbmp.cpp:1273
+msgid "Error in reading image DIB."
+msgstr ""
+
+#: ../src/common/imagbmp.cpp:1294
+msgid "ICO: Error in reading mask DIB."
+msgstr ""
+
+#: ../src/common/imagbmp.cpp:1353
+msgid "ICO: Image too tall for an icon."
+msgstr ""
+
+#: ../src/common/imagbmp.cpp:1361
+msgid "ICO: Image too wide for an icon."
+msgstr ""
+
+#: ../src/common/imagbmp.cpp:1388 ../src/common/imagbmp.cpp:1488
+#: ../src/common/imagbmp.cpp:1503 ../src/common/imagbmp.cpp:1514
+#: ../src/common/imagbmp.cpp:1528 ../src/common/imagbmp.cpp:1576
+#: ../src/common/imagbmp.cpp:1591 ../src/common/imagbmp.cpp:1605
+#: ../src/common/imagbmp.cpp:1616
+msgid "ICO: Error writing the image file!"
+msgstr ""
+
+#: ../src/common/imagbmp.cpp:1701
+msgid "ICO: Invalid icon index."
+msgstr ""
+
+#: ../src/common/image.cpp:2410
+msgid "Image and mask have different sizes."
+msgstr ""
+
+#: ../src/common/image.cpp:2418 ../src/common/image.cpp:2459
+msgid "No unused colour in image being masked."
+msgstr ""
+
+#: ../src/common/image.cpp:2641
+#, c-format
+msgid "Failed to load bitmap \"%s\" from resources."
+msgstr "Nepavyko įkelti taškinės grafikos \"%s\" iš resursų."
+
+#: ../src/common/image.cpp:2650
+#, c-format
+msgid "Failed to load icon \"%s\" from resources."
+msgstr "Nepavyko įkelti piktogramos \"%s\" iš resursų."
+
+#: ../src/common/image.cpp:2728 ../src/common/image.cpp:2747
+#, c-format
+msgid "Failed to load image from file \"%s\"."
+msgstr ""
+
+#: ../src/common/image.cpp:2761
+#, c-format
+msgid "Can't save image to file '%s': unknown extension."
+msgstr ""
+
+#: ../src/common/image.cpp:2869
+msgid "No handler found for image type."
+msgstr ""
+
+#: ../src/common/image.cpp:2877 ../src/common/image.cpp:3000
+#: ../src/common/image.cpp:3066
+#, c-format
+msgid "No image handler for type %d defined."
+msgstr ""
+
+#: ../src/common/image.cpp:2887
+#, c-format
+msgid "Image file is not of type %d."
+msgstr ""
+
+#: ../src/common/image.cpp:2970
+msgid "Can't automatically determine the image format for non-seekable input."
+msgstr ""
+
+#: ../src/common/image.cpp:2988
+msgid "Unknown image data format."
+msgstr ""
+
+#: ../src/common/image.cpp:3009
+#, c-format
+msgid "This is not a %s."
+msgstr ""
+
+#: ../src/common/image.cpp:3032 ../src/common/image.cpp:3080
+#, c-format
+msgid "No image handler for type %s defined."
+msgstr ""
+
+#: ../src/common/image.cpp:3041
+#, c-format
+msgid "Image is not of type %s."
+msgstr ""
+
+#: ../src/common/image.cpp:3509
+#, c-format
+msgid "Failed to check format of image file \"%s\"."
+msgstr ""
+
+#: ../src/common/imaggif.cpp:124
+msgid "GIF: error in GIF image format."
+msgstr ""
+
+#: ../src/common/imaggif.cpp:129
+msgid "GIF: not enough memory."
+msgstr ""
+
+#: ../src/common/imaggif.cpp:134
+msgid "GIF: data stream seems to be truncated."
+msgstr ""
+
+#: ../src/common/imaggif.cpp:240
+msgid "Couldn't initialize GIF hash table."
+msgstr ""
+
+#: ../src/common/imagiff.cpp:739
+msgid "IFF: error in IFF image format."
+msgstr ""
+
+#: ../src/common/imagiff.cpp:742
+msgid "IFF: not enough memory."
+msgstr ""
+
+#: ../src/common/imagiff.cpp:745
+msgid "IFF: unknown error!!!"
+msgstr ""
+
+#: ../src/common/imagiff.cpp:755
+msgid "IFF: data stream seems to be truncated."
+msgstr ""
+
+#: ../src/common/imagjpeg.cpp:258
+msgid "JPEG: Couldn't load - file is probably corrupted."
+msgstr ""
+
+#: ../src/common/imagjpeg.cpp:437
+msgid "JPEG: Couldn't save image."
+msgstr ""
+
+#: ../src/common/imagpcx.cpp:439
+msgid "PCX: this is not a PCX file."
+msgstr ""
+
+#: ../src/common/imagpcx.cpp:453
+msgid "PCX: image format unsupported"
+msgstr ""
+
+#: ../src/common/imagpcx.cpp:454 ../src/common/imagpcx.cpp:477
+msgid "PCX: couldn't allocate memory"
+msgstr ""
+
+#: ../src/common/imagpcx.cpp:455
+msgid "PCX: version number too low"
+msgstr ""
+
+#: ../src/common/imagpcx.cpp:456 ../src/common/imagpcx.cpp:478
+msgid "PCX: unknown error !!!"
+msgstr ""
+
+#: ../src/common/imagpcx.cpp:476
+msgid "PCX: invalid image"
+msgstr ""
+
+#: ../src/common/imagpng.cpp:385
+#, c-format
+msgid "Unknown PNG resolution unit %d"
+msgstr ""
+
+#: ../src/common/imagpng.cpp:439
+msgid "Couldn't load a PNG image - file is corrupted or not enough memory."
+msgstr ""
+
+#: ../src/common/imagpng.cpp:513 ../src/common/imagpng.cpp:524
+#: ../src/common/imagpng.cpp:534
+msgid "Couldn't save PNG image."
+msgstr ""
+
+#: ../src/common/imagpnm.cpp:71
+msgid "PNM: File format is not recognized."
+msgstr ""
+
+#: ../src/common/imagpnm.cpp:89
+msgid "PNM: Couldn't allocate memory."
+msgstr ""
+
+#: ../src/common/imagpnm.cpp:111 ../src/common/imagpnm.cpp:134
+#: ../src/common/imagpnm.cpp:156
+msgid "PNM: File seems truncated."
+msgstr ""
+
+#: ../src/common/imagtiff.cpp:69
+#, c-format
+msgid " (in module \"%s\")"
+msgstr ""
+
+#: ../src/common/imagtiff.cpp:304
+msgid "TIFF: Error loading image."
+msgstr ""
+
+#: ../src/common/imagtiff.cpp:314
+msgid "Invalid TIFF image index."
+msgstr ""
+
+#: ../src/common/imagtiff.cpp:358
+msgid "TIFF: Image size is abnormally big."
+msgstr ""
+
+#: ../src/common/imagtiff.cpp:372 ../src/common/imagtiff.cpp:385
+#: ../src/common/imagtiff.cpp:769
+msgid "TIFF: Couldn't allocate memory."
+msgstr ""
+
+#: ../src/common/imagtiff.cpp:471
+msgid "TIFF: Error reading image."
+msgstr ""
+
+#: ../src/common/imagtiff.cpp:532
+#, c-format
+msgid "Unknown TIFF resolution unit %d ignored"
+msgstr ""
+
+#: ../src/common/imagtiff.cpp:611
+msgid "TIFF: Error saving image."
+msgstr ""
+
+#: ../src/common/imagtiff.cpp:868
+msgid "TIFF: Error writing image."
+msgstr ""
+
+#: ../src/common/imagtiff.cpp:881
+msgid "TIFF: Error flushing data."
+msgstr ""
+
+#: ../src/common/imagwebp.cpp:56
+msgid "WebP: Invalid data (failed to get features)."
+msgstr ""
+
+#: ../src/common/imagwebp.cpp:65
+msgid "WebP: Allocating image memory failed."
+msgstr ""
+
+#: ../src/common/imagwebp.cpp:82
+msgid "WebP: Decoding RGBA image data failed."
+msgstr ""
+
+#: ../src/common/imagwebp.cpp:98
+msgid "WebP: Decoding RGB image data failed."
+msgstr ""
+
+#: ../src/common/imagwebp.cpp:113 ../src/common/imagwebp.cpp:201
+msgid "WebP: Allocating stream buffer failed."
+msgstr ""
+
+#: ../src/common/imagwebp.cpp:131
+msgid "WebP: Failed to parse container data."
+msgstr ""
+
+#: ../src/common/imagwebp.cpp:222
+msgid "WebP: Error decoding animation."
+msgstr ""
+
+#: ../src/common/imagwebp.cpp:240
+msgid "WebP: Error getting next animation frame."
+msgstr ""
+
+#: ../src/common/init.cpp:172
+#, c-format
+msgid ""
+"Command line argument %d couldn't be converted to Unicode and will be "
+"ignored."
+msgstr ""
+
+#: ../src/common/init.cpp:344
+msgid "Initialization failed in post init, aborting."
+msgstr ""
+
+#: ../src/common/intl.cpp:378
+#, c-format
+msgid "Cannot set locale to language \"%s\"."
+msgstr ""
+
+#: ../src/common/log.cpp:232
+msgid "Error: "
+msgstr "Klaida: "
+
+#: ../src/common/log.cpp:236
+msgid "Warning: "
+msgstr "Perspėjimas: "
+
+#: ../src/common/log.cpp:284
+msgid "The previous message repeated once."
+msgstr ""
+
+#: ../src/common/log.cpp:291
+#, c-format
+msgid "The previous message repeated %u time."
+msgid_plural "The previous message repeated %u times."
+msgstr[0] "Ankstesnis pranešimas pakartotas %u kartą."
+msgstr[1] "Ankstesnis pranešimas pakartotas %u kartų."
+msgstr[2] "Ankstesnis pranešimas pakartotas %u kartų."
+
+#: ../src/common/log.cpp:319
+#, c-format
+msgid "Last repeated message (\"%s\", %u time) wasn't output"
+msgid_plural "Last repeated message (\"%s\", %u times) wasn't output"
+msgstr[0] ""
+"Paskutinis pasikartojantis pranešimas (\"%s\", %u kartą) nebuvo išvestas"
+msgstr[1] ""
+"Paskutinis pasikartojantis pranešimas (\"%s\", %u kartų) nebuvo išvestas"
+msgstr[2] ""
+"Paskutinis pasikartojantis pranešimas (\"%s\", %u kartų) nebuvo išvestas"
+
+#: ../src/common/log.cpp:435
+#, c-format
+msgid " (error %ld: %s)"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:121
+msgid "Failed to allocate memory for LZMA decompression."
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:125
+#, c-format
+msgid "Failed to initialize LZMA decompression: unexpected error %u."
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:179
+msgid "input is not in XZ format"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:183
+msgid "input compressed using unknown XZ option"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:188
+msgid "input is corrupted"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:192
+msgid "unknown decompression error"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:196
+#, c-format
+msgid "LZMA decompression error: %s"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:231
+msgid "Failed to allocate memory for LZMA compression."
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:235
+#, c-format
+msgid "Failed to initialize LZMA compression: unexpected error %u."
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:267 ../src/common/lzmastream.cpp:342
+#: ../src/html/chm.cpp:336
+msgid "out of memory"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:276 ../src/common/lzmastream.cpp:346
+msgid "unknown compression error"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:280
+#, c-format
+msgid "LZMA compression error: %s"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:350
+#, c-format
+msgid "LZMA compression error when flushing output: %s"
+msgstr ""
+
+#: ../src/common/mimecmn.cpp:167
+#, c-format
+msgid "Unmatched '{' in an entry for mime type %s."
+msgstr ""
+
+#: ../src/common/module.cpp:76
+#, c-format
+msgid "Circular dependency involving module \"%s\" detected."
+msgstr ""
+
+#: ../src/common/module.cpp:128
+#, c-format
+msgid "Dependency \"%s\" of module \"%s\" doesn't exist."
+msgstr ""
+
+#: ../src/common/module.cpp:137
+#, c-format
+msgid "Module \"%s\" initialization failed"
+msgstr ""
+
+#: ../src/common/msgout.cpp:96
+msgid "Message"
+msgstr "Pranešimas"
+
+#: ../src/common/paper.cpp:70
+msgid "Letter, 8 1/2 x 11 in"
+msgstr "Laiškas, 8 1/2 x 11 colių"
+
+#: ../src/common/paper.cpp:71
+msgid "Legal, 8 1/2 x 14 in"
+msgstr "Legalus, 8 1/2 x 14 colių"
+
+#: ../src/common/paper.cpp:72
+msgid "A4 sheet, 210 x 297 mm"
+msgstr "A4 lapas, 210 x 297 mm"
+
+#: ../src/common/paper.cpp:73
+msgid "C sheet, 17 x 22 in"
+msgstr ""
+
+#: ../src/common/paper.cpp:74
+msgid "D sheet, 22 x 34 in"
+msgstr ""
+
+#: ../src/common/paper.cpp:75
+msgid "E sheet, 34 x 44 in"
+msgstr ""
+
+#: ../src/common/paper.cpp:76
+msgid "Letter Small, 8 1/2 x 11 in"
+msgstr "Laiškas Mažas, 8 1/2 x 11 colių"
+
+#: ../src/common/paper.cpp:77
+msgid "Tabloid, 11 x 17 in"
+msgstr ""
+
+#: ../src/common/paper.cpp:78
+msgid "Ledger, 17 x 11 in"
+msgstr ""
+
+#: ../src/common/paper.cpp:79
+msgid "Statement, 5 1/2 x 8 1/2 in"
+msgstr ""
+
+#: ../src/common/paper.cpp:80
+msgid "Executive, 7 1/4 x 10 1/2 in"
+msgstr ""
+
+#: ../src/common/paper.cpp:81
+msgid "A3 sheet, 297 x 420 mm"
+msgstr "A3 lapas, 297 x 420 mm"
+
+#: ../src/common/paper.cpp:82
+msgid "A4 small sheet, 210 x 297 mm"
+msgstr "A4 small lapas, 210 x 297 mm"
+
+#: ../src/common/paper.cpp:83
+msgid "A5 sheet, 148 x 210 mm"
+msgstr "A5 lapas, 148 x 210 mm"
+
+#: ../src/common/paper.cpp:84
+msgid "B4 sheet, 250 x 354 mm"
+msgstr "B4 lapas, 250 x 354 mm"
+
+#: ../src/common/paper.cpp:85
+msgid "B5 sheet, 182 x 257 millimeter"
+msgstr "B5 lapas, 182 x 257 millimeter"
+
+#: ../src/common/paper.cpp:86
+msgid "Folio, 8 1/2 x 13 in"
+msgstr ""
+
+#: ../src/common/paper.cpp:87
+msgid "Quarto, 215 x 275 mm"
+msgstr ""
+
+#: ../src/common/paper.cpp:88
+msgid "10 x 14 in"
+msgstr "10 x 14 colių"
+
+#: ../src/common/paper.cpp:89
+msgid "11 x 17 in"
+msgstr "11 x 17 colių"
+
+#: ../src/common/paper.cpp:90
+msgid "Note, 8 1/2 x 11 in"
+msgstr ""
+
+#: ../src/common/paper.cpp:91
+msgid "#9 Envelope, 3 7/8 x 8 7/8 in"
+msgstr "#9 Vokas, 3 7/8 x 8 7/8 colių"
+
+#: ../src/common/paper.cpp:92
+msgid "#10 Envelope, 4 1/8 x 9 1/2 in"
+msgstr "#10 Vokas, 4 1/8 x 9 1/2 colių"
+
+#: ../src/common/paper.cpp:93
+msgid "#11 Envelope, 4 1/2 x 10 3/8 in"
+msgstr "#11 Vokas, 4 1/2 x 10 3/8 colių"
+
+#: ../src/common/paper.cpp:94
+msgid "#12 Envelope, 4 3/4 x 11 in"
+msgstr "#12 Vokas, 4 3/4 x 11 colių"
+
+#: ../src/common/paper.cpp:95
+msgid "#14 Envelope, 5 x 11 1/2 in"
+msgstr "#14 Vokas, 5 x 11 1/2 colių"
+
+#: ../src/common/paper.cpp:96
+msgid "DL Envelope, 110 x 220 mm"
+msgstr ""
+
+#: ../src/common/paper.cpp:97
+msgid "C5 Envelope, 162 x 229 mm"
+msgstr "C5 Vokas, 162 x 229 mm"
+
+#: ../src/common/paper.cpp:98
+msgid "C3 Envelope, 324 x 458 mm"
+msgstr "C3 Vokas, 324 x 458 mm"
+
+#: ../src/common/paper.cpp:99
+msgid "C4 Envelope, 229 x 324 mm"
+msgstr "C4 Vokas, 229 x 324 mm"
+
+#: ../src/common/paper.cpp:100
+msgid "C6 Envelope, 114 x 162 mm"
+msgstr "C6 Vokas, 114 x 162 mm"
+
+#: ../src/common/paper.cpp:101
+msgid "C65 Envelope, 114 x 229 mm"
+msgstr "C65 Vokas, 114 x 229 mm"
+
+#: ../src/common/paper.cpp:102
+msgid "B4 Envelope, 250 x 353 mm"
+msgstr "B4 Vokas, 250 x 353 mm"
+
+#: ../src/common/paper.cpp:103
+msgid "B5 Envelope, 176 x 250 mm"
+msgstr "B5 Vokas, 176 x 250 mm"
+
+#: ../src/common/paper.cpp:104
+msgid "B6 Envelope, 176 x 125 mm"
+msgstr "B6 Vokas, 176 x 125 mm"
+
+#: ../src/common/paper.cpp:105
+msgid "Italy Envelope, 110 x 230 mm"
+msgstr ""
+
+#: ../src/common/paper.cpp:106
+msgid "Monarch Envelope, 3 7/8 x 7 1/2 in"
+msgstr ""
+
+#: ../src/common/paper.cpp:107
+msgid "6 3/4 Envelope, 3 5/8 x 6 1/2 in"
+msgstr "6 3/4 Vokas, 3 5/8 x 6 1/2 colių"
+
+#: ../src/common/paper.cpp:108
+msgid "US Std Fanfold, 14 7/8 x 11 in"
+msgstr ""
+
+#: ../src/common/paper.cpp:109
+msgid "German Std Fanfold, 8 1/2 x 12 in"
+msgstr ""
+
+#: ../src/common/paper.cpp:110
+msgid "German Legal Fanfold, 8 1/2 x 13 in"
+msgstr ""
+
+#: ../src/common/paper.cpp:112
+msgid "B4 (ISO) 250 x 353 mm"
+msgstr "B4 (ISO) 250 x 353 mm"
+
+#: ../src/common/paper.cpp:113
+msgid "Japanese Postcard 100 x 148 mm"
+msgstr ""
+
+#: ../src/common/paper.cpp:114
+msgid "9 x 11 in"
+msgstr "9 x 11 colių"
+
+#: ../src/common/paper.cpp:115
+msgid "10 x 11 in"
+msgstr "10 x 11 colių"
+
+#: ../src/common/paper.cpp:116
+msgid "15 x 11 in"
+msgstr "15 x 11 colių"
+
+#: ../src/common/paper.cpp:117
+msgid "Envelope Invite 220 x 220 mm"
+msgstr ""
+
+#: ../src/common/paper.cpp:118
+msgid "Letter Extra 9 1/2 x 12 in"
+msgstr "Laiškas Ekstra 9 1/2 x 12 colių"
+
+#: ../src/common/paper.cpp:119
+msgid "Legal Extra 9 1/2 x 15 in"
+msgstr "Legalus Ekstra 9 1/2 x 15 colių"
+
+#: ../src/common/paper.cpp:120
+msgid "Tabloid Extra 11.69 x 18 in"
+msgstr ""
+
+#: ../src/common/paper.cpp:121
+msgid "A4 Extra 9.27 x 12.69 in"
+msgstr "A4 Ekstra 9.27 x 12.69 colių"
+
+#: ../src/common/paper.cpp:122
+msgid "Letter Transverse 8 1/2 x 11 in"
+msgstr "Laiškas Skerscoliųis 8 1/2 x 11 colių"
+
+#: ../src/common/paper.cpp:123
+msgid "A4 Transverse 210 x 297 mm"
+msgstr "A4 Skersinis 210 x 297 mm"
+
+#: ../src/common/paper.cpp:124
+msgid "Letter Extra Transverse 9.275 x 12 in"
+msgstr "Laiškas Ekstra Skerscoliųis 9.275 x 12 colių"
+
+#: ../src/common/paper.cpp:125
+msgid "SuperA/SuperA/A4 227 x 356 mm"
+msgstr "SuperA/SuperA/A4 227 x 356 mm"
+
+#: ../src/common/paper.cpp:126
+msgid "SuperB/SuperB/A3 305 x 487 mm"
+msgstr "SuperB/SuperB/A3 305 x 487 mm"
+
+#: ../src/common/paper.cpp:127
+msgid "Letter Plus 8 1/2 x 12.69 in"
+msgstr "Laiškas Plius 8 1/2 x 12.69 colių"
+
+#: ../src/common/paper.cpp:128
+msgid "A4 Plus 210 x 330 mm"
+msgstr "A4 Plius 210 x 330 mm"
+
+#: ../src/common/paper.cpp:129
+msgid "A5 Transverse 148 x 210 mm"
+msgstr "A5 Skersinis 148 x 210 mm"
+
+#: ../src/common/paper.cpp:130
+msgid "B5 (JIS) Transverse 182 x 257 mm"
+msgstr "B5 (JIS) Skersinis 182 x 257 mm"
+
+#: ../src/common/paper.cpp:131
+msgid "A3 Extra 322 x 445 mm"
+msgstr "A3 Ekstra 322 x 445 mm"
+
+#: ../src/common/paper.cpp:132
+msgid "A5 Extra 174 x 235 mm"
+msgstr "A5 Ekstra 174 x 235 mm"
+
+#: ../src/common/paper.cpp:133
+msgid "B5 (ISO) Extra 201 x 276 mm"
+msgstr "B5 (ISO) Ekstra 201 x 276 mm"
+
+#: ../src/common/paper.cpp:134
+msgid "A2 420 x 594 mm"
+msgstr "A2 420 x 594 mm"
+
+#: ../src/common/paper.cpp:135
+msgid "A3 Transverse 297 x 420 mm"
+msgstr "A3 Skersinis 297 x 420 mm"
+
+#: ../src/common/paper.cpp:136
+msgid "A3 Extra Transverse 322 x 445 mm"
+msgstr "A3 Ekstra Skersinis 322 x 445 mm"
+
+#: ../src/common/paper.cpp:138
+msgid "Japanese Double Postcard 200 x 148 mm"
+msgstr ""
+
+#: ../src/common/paper.cpp:139
+msgid "A6 105 x 148 mm"
+msgstr "A6 105 x 148 mm"
+
+#: ../src/common/paper.cpp:140
+msgid "Japanese Envelope Kaku #2"
+msgstr ""
+
+#: ../src/common/paper.cpp:141
+msgid "Japanese Envelope Kaku #3"
+msgstr ""
+
+#: ../src/common/paper.cpp:142
+msgid "Japanese Envelope Chou #3"
+msgstr ""
+
+#: ../src/common/paper.cpp:143
+msgid "Japanese Envelope Chou #4"
+msgstr ""
+
+#: ../src/common/paper.cpp:144
+msgid "Letter Rotated 11 x 8 1/2 in"
+msgstr "Laiškas Pasuktas 11 x 8 1/2 colių"
+
+#: ../src/common/paper.cpp:145
+msgid "A3 Rotated 420 x 297 mm"
+msgstr "A3 Pasuktas 420 x 297 mm"
+
+#: ../src/common/paper.cpp:146
+msgid "A4 Rotated 297 x 210 mm"
+msgstr "A4 Pasuktas 297 x 210 mm"
+
+#: ../src/common/paper.cpp:147
+msgid "A5 Rotated 210 x 148 mm"
+msgstr "A5 Pasuktas 210 x 148 mm"
+
+#: ../src/common/paper.cpp:148
+msgid "B4 (JIS) Rotated 364 x 257 mm"
+msgstr "B4 (JIS) Pasuktas 364 x 257 mm"
+
+#: ../src/common/paper.cpp:149
+msgid "B5 (JIS) Rotated 257 x 182 mm"
+msgstr "B5 (JIS) Pasuktas 257 x 182 mm"
+
+#: ../src/common/paper.cpp:150
+msgid "Japanese Postcard Rotated 148 x 100 mm"
+msgstr ""
+
+#: ../src/common/paper.cpp:151
+msgid "Double Japanese Postcard Rotated 148 x 200 mm"
+msgstr ""
+
+#: ../src/common/paper.cpp:152
+msgid "A6 Rotated 148 x 105 mm"
+msgstr "A6 Pasuktas 148 x 105 mm"
+
+#: ../src/common/paper.cpp:153
+msgid "Japanese Envelope Kaku #2 Rotated"
+msgstr ""
+
+#: ../src/common/paper.cpp:154
+msgid "Japanese Envelope Kaku #3 Rotated"
+msgstr ""
+
+#: ../src/common/paper.cpp:155
+msgid "Japanese Envelope Chou #3 Rotated"
+msgstr ""
+
+#: ../src/common/paper.cpp:156
+msgid "Japanese Envelope Chou #4 Rotated"
+msgstr ""
+
+#: ../src/common/paper.cpp:157
+msgid "B6 (JIS) 128 x 182 mm"
+msgstr "B6 (JIS) 128 x 182 mm"
+
+#: ../src/common/paper.cpp:158
+msgid "B6 (JIS) Rotated 182 x 128 mm"
+msgstr "B6 (JIS) Pasuktas 182 x 128 mm"
+
+#: ../src/common/paper.cpp:159
+msgid "12 x 11 in"
+msgstr "12 x 11 colių"
+
+#: ../src/common/paper.cpp:160
+msgid "Japanese Envelope You #4"
+msgstr ""
+
+#: ../src/common/paper.cpp:161
+msgid "Japanese Envelope You #4 Rotated"
+msgstr ""
+
+#: ../src/common/paper.cpp:162
+msgid "PRC 16K 146 x 215 mm"
+msgstr "PRC 16K 146 x 215 mm"
+
+#: ../src/common/paper.cpp:163
+msgid "PRC 32K 97 x 151 mm"
+msgstr "PRC 32K 97 x 151 mm"
+
+#: ../src/common/paper.cpp:164
+msgid "PRC 32K(Big) 97 x 151 mm"
+msgstr "PRC 32K(Big) 97 x 151 mm"
+
+#: ../src/common/paper.cpp:165
+msgid "PRC Envelope #1 102 x 165 mm"
+msgstr "PRC Vokas #1 102 x 165 mm"
+
+#: ../src/common/paper.cpp:166
+msgid "PRC Envelope #2 102 x 176 mm"
+msgstr "PRC Vokas #2 102 x 176 mm"
+
+#: ../src/common/paper.cpp:167
+msgid "PRC Envelope #3 125 x 176 mm"
+msgstr "PRC Vokas #3 125 x 176 mm"
+
+#: ../src/common/paper.cpp:168
+msgid "PRC Envelope #4 110 x 208 mm"
+msgstr "PRC Vokas #4 110 x 208 mm"
+
+#: ../src/common/paper.cpp:169
+msgid "PRC Envelope #5 110 x 220 mm"
+msgstr "PRC Vokas #5 110 x 220 mm"
+
+#: ../src/common/paper.cpp:170
+msgid "PRC Envelope #6 120 x 230 mm"
+msgstr "PRC Vokas #6 120 x 230 mm"
+
+#: ../src/common/paper.cpp:171
+msgid "PRC Envelope #7 160 x 230 mm"
+msgstr "PRC Vokas #7 160 x 230 mm"
+
+#: ../src/common/paper.cpp:172
+msgid "PRC Envelope #8 120 x 309 mm"
+msgstr "PRC Vokas #8 120 x 309 mm"
+
+#: ../src/common/paper.cpp:173
+msgid "PRC Envelope #9 229 x 324 mm"
+msgstr "PRC Vokas #9 229 x 324 mm"
+
+#: ../src/common/paper.cpp:174
+msgid "PRC Envelope #10 324 x 458 mm"
+msgstr "PRC Vokas #10 324 x 458 mm"
+
+#: ../src/common/paper.cpp:175
+msgid "PRC 16K Rotated"
+msgstr "PRC 16K Pasuktas"
+
+#: ../src/common/paper.cpp:176
+msgid "PRC 32K Rotated"
+msgstr "PRC 32K Pasuktas"
+
+#: ../src/common/paper.cpp:177
+msgid "PRC 32K(Big) Rotated"
+msgstr "PRC 32K(Big) Pasuktas"
+
+#: ../src/common/paper.cpp:178
+msgid "PRC Envelope #1 Rotated 165 x 102 mm"
+msgstr "PRC Vokas #1 Pasuktas 165 x 102 mm"
+
+#: ../src/common/paper.cpp:179
+msgid "PRC Envelope #2 Rotated 176 x 102 mm"
+msgstr "PRC Vokas #2 Pasuktas 176 x 102 mm"
+
+#: ../src/common/paper.cpp:180
+msgid "PRC Envelope #3 Rotated 176 x 125 mm"
+msgstr "PRC Vokas #3 Pasuktas 176 x 125 mm"
+
+#: ../src/common/paper.cpp:181
+msgid "PRC Envelope #4 Rotated 208 x 110 mm"
+msgstr "PRC Vokas #4 Pasuktas 208 x 110 mm"
+
+#: ../src/common/paper.cpp:182
+msgid "PRC Envelope #5 Rotated 220 x 110 mm"
+msgstr "PRC Vokas #5 Pasuktas 220 x 110 mm"
+
+#: ../src/common/paper.cpp:183
+msgid "PRC Envelope #6 Rotated 230 x 120 mm"
+msgstr "PRC Vokas #6 Pasuktas 230 x 120 mm"
+
+#: ../src/common/paper.cpp:184
+msgid "PRC Envelope #7 Rotated 230 x 160 mm"
+msgstr "PRC Vokas #7 Pasuktas 230 x 160 mm"
+
+#: ../src/common/paper.cpp:185
+msgid "PRC Envelope #8 Rotated 309 x 120 mm"
+msgstr "PRC Vokas #8 Pasuktas 309 x 120 mm"
+
+#: ../src/common/paper.cpp:186
+msgid "PRC Envelope #9 Rotated 324 x 229 mm"
+msgstr "PRC Vokas #9 Pasuktas 324 x 229 mm"
+
+#: ../src/common/paper.cpp:187
+msgid "PRC Envelope #10 Rotated 458 x 324 mm"
+msgstr "PRC Vokas #10 Pasuktas 458 x 324 mm"
+
+#: ../src/common/paper.cpp:192
+msgid "A0 sheet, 841 x 1189 mm"
+msgstr "A0 lapas, 841 x 1189 mm"
+
+#: ../src/common/paper.cpp:193
+msgid "A1 sheet, 594 x 841 mm"
+msgstr "A1 lapas, 594 x 841 mm"
+
+#: ../src/common/preferencescmn.cpp:37
+msgid "General"
+msgstr "Bendra"
+
+#: ../src/common/preferencescmn.cpp:40
+msgid "Advanced"
+msgstr "Išsamiau"
+
+#: ../src/common/prntbase.cpp:245
+msgid "Generic PostScript"
+msgstr ""
+
+#: ../src/common/prntbase.cpp:259
+msgid "Ready"
+msgstr "Pasiruošęs"
+
+#: ../src/common/prntbase.cpp:331
+msgid "Printing Error"
+msgstr ""
+
+#: ../src/common/prntbase.cpp:413 ../src/common/prntbase.cpp:1597
+#: ../src/generic/prntdlgg.cpp:135 ../src/generic/prntdlgg.cpp:149
+#: ../src/gtk/print.cpp:628 ../src/gtk/print.cpp:646
+msgid "Print"
+msgstr "Spausdinti"
+
+#: ../src/common/prntbase.cpp:471 ../src/generic/prntdlgg.cpp:809
+msgid "Page setup"
+msgstr "Puslapio sąranka"
+
+#: ../src/common/prntbase.cpp:525
+msgid "Please wait while printing..."
+msgstr "Prašome palaukti kol spausdinama..."
+
+#: ../src/common/prntbase.cpp:529
+msgid "Document:"
+msgstr "Dokumentas:"
+
+#: ../src/common/prntbase.cpp:532
+msgid "Progress:"
+msgstr "Progresas:"
+
+#: ../src/common/prntbase.cpp:533
+msgid "Preparing"
+msgstr "Ruošiamasi"
+
+#: ../src/common/prntbase.cpp:552
+#, c-format
+msgid "Printing page %d"
+msgstr ""
+
+#: ../src/common/prntbase.cpp:557
+#, c-format
+msgid "Printing page %d of %d"
+msgstr "Spausdinamas puslapis %d iš %d"
+
+#: ../src/common/prntbase.cpp:560
+#, c-format
+msgid " (copy %d of %d)"
+msgstr " kopija %d iš %d"
+
+#: ../src/common/prntbase.cpp:1604
+msgid "First page"
+msgstr ""
+
+#: ../src/common/prntbase.cpp:1609 ../src/html/helpwnd.cpp:659
+msgid "Previous page"
+msgstr ""
+
+#: ../src/common/prntbase.cpp:1623 ../src/html/helpwnd.cpp:660
+msgid "Next page"
+msgstr "Kitas puslapis"
+
+#: ../src/common/prntbase.cpp:1628
+msgid "Last page"
+msgstr ""
+
+#: ../src/common/prntbase.cpp:1636 ../src/common/stockitem.cpp:215
+msgid "Zoom Out"
+msgstr "Mažinti"
+
+#: ../src/common/prntbase.cpp:1650 ../src/common/stockitem.cpp:214
+msgid "Zoom In"
+msgstr "Didinti"
+
+#: ../src/common/prntbase.cpp:1656 ../src/common/stockitem.cpp:153
+#: ../src/generic/logg.cpp:553 ../src/univ/themes/win32.cpp:3752
+msgid "&Close"
+msgstr "&Užverti"
+
+#: ../src/common/prntbase.cpp:2085
+msgid "Could not start document preview."
+msgstr ""
+
+#: ../src/common/prntbase.cpp:2085 ../src/common/prntbase.cpp:2129
+#: ../src/common/prntbase.cpp:2137
+msgid "Print Preview Failure"
+msgstr ""
+
+#: ../src/common/prntbase.cpp:2129 ../src/common/prntbase.cpp:2137
+msgid "Sorry, not enough memory to create a preview."
+msgstr ""
+
+#: ../src/common/prntbase.cpp:2144
+#, c-format
+msgid "Page %d of %d"
+msgstr ""
+
+#: ../src/common/prntbase.cpp:2146
+#, c-format
+msgid "Page %d"
+msgstr ""
+
+#: ../src/common/regex.cpp:382 ../src/html/chm.cpp:348
+msgid "unknown error"
+msgstr "nežinoma klaida"
+
+#: ../src/common/regex.cpp:995
+#, c-format
+msgid "Invalid regular expression '%s': %s"
+msgstr ""
+
+#: ../src/common/regex.cpp:1059
+#, c-format
+msgid "Failed to find match for regular expression: %s"
+msgstr ""
+
+#: ../src/common/rendcmn.cpp:188
+#, c-format
+msgid "Renderer \"%s\" has incompatible version %d.%d and couldn't be loaded."
+msgstr ""
+
+#: ../src/common/secretstore.cpp:162
+msgid "Not available for this platform"
+msgstr ""
+
+#: ../src/common/secretstore.cpp:183
+#, c-format
+msgid "Saving password for \"%s\" failed: %s."
+msgstr ""
+
+#: ../src/common/secretstore.cpp:205
+#, c-format
+msgid "Reading password for \"%s\" failed: %s."
+msgstr ""
+
+#: ../src/common/secretstore.cpp:228
+#, c-format
+msgid "Deleting password for \"%s\" failed: %s."
+msgstr ""
+
+#: ../src/common/selectdispatcher.cpp:254
+msgid "Failed to monitor I/O channels"
+msgstr ""
+
+#: ../src/common/sizer.cpp:3054 ../src/common/stockitem.cpp:195
+msgid "Save"
+msgstr "Išsaugoti"
+
+#: ../src/common/sizer.cpp:3056
+msgid "Don't Save"
+msgstr "Nesaugoti"
+
+#: ../src/common/socket.cpp:870
+msgid "Cannot initialize sockets"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:127
+msgctxt "standard Windows menu"
+msgid "&Help"
+msgstr "&Pagalba"
+
+#: ../src/common/stockitem.cpp:144
+msgid "&About"
+msgstr "&Apie"
+
+#: ../src/common/stockitem.cpp:144
+msgid "About"
+msgstr "Apie"
+
+#: ../src/common/stockitem.cpp:145
+msgid "Add"
+msgstr "Pridėti"
+
+#: ../src/common/stockitem.cpp:146
+msgid "&Apply"
+msgstr "&Pritaikyti"
+
+#: ../src/common/stockitem.cpp:146
+msgid "Apply"
+msgstr "Pritaikyti"
+
+#: ../src/common/stockitem.cpp:147
+msgid "&Back"
+msgstr "&Atgal"
+
+#: ../src/common/stockitem.cpp:147
+msgid "Back"
+msgstr "Galas"
+
+#: ../src/common/stockitem.cpp:148
+msgid "&Bold"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:148 ../src/generic/fontdlgg.cpp:326
+#: ../src/richtext/richtextfontpage.cpp:354
+msgid "Bold"
+msgstr "Pastorintas"
+
+#: ../src/common/stockitem.cpp:149
+msgid "&Bottom"
+msgstr "&Apačios"
+
+#: ../src/common/stockitem.cpp:149 ../src/richtext/richtextsizepage.cpp:287
+msgid "Bottom"
+msgstr "Apačia"
+
+#: ../src/common/stockitem.cpp:150 ../src/generic/fontdlgg.cpp:462
+#: ../src/generic/fontdlgg.cpp:481 ../src/generic/wizard.cpp:415
+msgid "&Cancel"
+msgstr "Atša&ukti"
+
+#: ../src/common/stockitem.cpp:151
+msgid "&CD-ROM"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:151
+msgid "CD-ROM"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:152
+msgid "&Clear"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:152
+msgid "Clear"
+msgstr "Išvalyti"
+
+#: ../src/common/stockitem.cpp:153 ../src/generic/dbgrptg.cpp:93
+#: ../src/generic/progdlgg.cpp:778 ../src/html/helpdlg.cpp:86
+#: ../src/msw/progdlg.cpp:209 ../src/msw/progdlg.cpp:890
+#: ../src/richtext/richtextstyledlg.cpp:272
+#: ../src/richtext/richtextsymboldlg.cpp:448
+msgid "Close"
+msgstr "Užverti"
+
+#: ../src/common/stockitem.cpp:154
+msgid "&Convert"
+msgstr "&Paversti"
+
+#: ../src/common/stockitem.cpp:154
+msgid "Convert"
+msgstr "Konvertuoti"
+
+#: ../src/common/stockitem.cpp:155 ../src/msw/textctrl.cpp:2884
+#: ../src/osx/textctrl_osx.cpp:653 ../src/richtext/richtextctrl.cpp:331
+msgid "&Copy"
+msgstr "&Kopijuoti"
+
+#: ../src/common/stockitem.cpp:155 ../src/stc/stc_i18n.cpp:18
+msgid "Copy"
+msgstr "Kopijuoti"
+
+#: ../src/common/stockitem.cpp:156 ../src/msw/textctrl.cpp:2883
+#: ../src/osx/textctrl_osx.cpp:652 ../src/richtext/richtextctrl.cpp:330
+msgid "Cu&t"
+msgstr "Iškirp&ti"
+
+#: ../src/common/stockitem.cpp:156 ../src/stc/stc_i18n.cpp:17
+msgid "Cut"
+msgstr "Iškirpti"
+
+#: ../src/common/stockitem.cpp:157 ../src/msw/textctrl.cpp:2886
+#: ../src/osx/textctrl_osx.cpp:655 ../src/richtext/richtextctrl.cpp:333
+#: ../src/richtext/richtexttabspage.cpp:137
+msgid "&Delete"
+msgstr "&Ištrinti"
+
+#: ../src/common/stockitem.cpp:157 ../src/richtext/richtextbuffer.cpp:8266
+#: ../src/stc/stc_i18n.cpp:20
+msgid "Delete"
+msgstr "Ištrinti"
+
+#: ../src/common/stockitem.cpp:158
+msgid "&Down"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:158 ../src/generic/fdrepdlg.cpp:148
+msgid "Down"
+msgstr "Žemyn"
+
+#: ../src/common/stockitem.cpp:159
+msgid "&Edit"
+msgstr "T&aisyti"
+
+#: ../src/common/stockitem.cpp:159
+msgid "Edit"
+msgstr "Taisyti"
+
+#: ../src/common/stockitem.cpp:160
+msgid "&Execute"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:160
+msgid "Execute"
+msgstr "Vykdyti"
+
+#: ../src/common/stockitem.cpp:161
+msgid "&Quit"
+msgstr "Iš&eiti"
+
+#: ../src/common/stockitem.cpp:161
+msgid "Quit"
+msgstr "Išeiti"
+
+#: ../src/common/stockitem.cpp:162
+msgid "&File"
+msgstr "&Failas"
+
+#: ../src/common/stockitem.cpp:162
+msgid "File"
+msgstr "Failas"
+
+#: ../src/common/stockitem.cpp:163
+msgid "&Find..."
+msgstr ""
+
+#: ../src/common/stockitem.cpp:163
+msgid "Find..."
+msgstr ""
+
+#: ../src/common/stockitem.cpp:164
+msgid "&First"
+msgstr "&Pirmas"
+
+#: ../src/common/stockitem.cpp:164
+msgid "First"
+msgstr "Pirmas"
+
+#: ../src/common/stockitem.cpp:165
+msgid "&Floppy"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:165
+msgid "Floppy"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:166
+msgid "&Forward"
+msgstr "&Pirmyn"
+
+#: ../src/common/stockitem.cpp:166
+msgid "Forward"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:167
+msgid "&Harddisk"
+msgstr "&Kietasis diskas"
+
+#: ../src/common/stockitem.cpp:167
+msgid "Harddisk"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:168 ../src/generic/wizard.cpp:418
+#: ../src/osx/cocoa/menu.mm:225 ../src/richtext/richtextstyledlg.cpp:298
+#: ../src/richtext/richtextsymboldlg.cpp:451
+msgid "&Help"
+msgstr "&Pagalba"
+
+#: ../src/common/stockitem.cpp:169
+msgid "&Home"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:169
+msgid "Home"
+msgstr "Pagrindinis"
+
+#: ../src/common/stockitem.cpp:170
+msgid "Indent"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:171
+msgid "&Index"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:171 ../src/html/helpwnd.cpp:510
+msgid "Index"
+msgstr "Indeksas"
+
+#: ../src/common/stockitem.cpp:172
+msgid "&Info"
+msgstr "&Informacija"
+
+#: ../src/common/stockitem.cpp:172
+msgid "Info"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:173
+msgid "&Italic"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:173 ../src/generic/fontdlgg.cpp:322
+#: ../src/richtext/richtextfontpage.cpp:350
+msgid "Italic"
+msgstr "Kursyvas"
+
+#: ../src/common/stockitem.cpp:174
+msgid "&Jump to"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:174
+msgid "Jump to"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:175
+msgid "Centered"
+msgstr "Centruotas"
+
+#: ../src/common/stockitem.cpp:176
+msgid "Justified"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:177
+msgid "Align Left"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:178
+msgid "Align Right"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:179
+msgid "&Last"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:179
+msgid "Last"
+msgstr "Paskutinis"
+
+#: ../src/common/stockitem.cpp:180
+msgid "&Network"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:180
+msgid "Network"
+msgstr "Tinklas"
+
+#: ../src/common/stockitem.cpp:181 ../src/richtext/richtexttabspage.cpp:131
+msgid "&New"
+msgstr "&Naujas"
+
+#: ../src/common/stockitem.cpp:181
+msgid "New"
+msgstr "Naujas"
+
+#: ../src/common/stockitem.cpp:182 ../src/msw/msgdlg.cpp:417
+msgid "&No"
+msgstr "&Ne"
+
+#: ../src/common/stockitem.cpp:183 ../src/generic/fontdlgg.cpp:467
+#: ../src/generic/fontdlgg.cpp:474
+msgid "&OK"
+msgstr "&Gerai"
+
+#: ../src/common/stockitem.cpp:184 ../src/generic/dbgrptg.cpp:341
+msgid "&Open..."
+msgstr "&Atverti..."
+
+#: ../src/common/stockitem.cpp:184
+msgid "Open..."
+msgstr "Atverti..."
+
+#: ../src/common/stockitem.cpp:185 ../src/msw/textctrl.cpp:2885
+#: ../src/osx/textctrl_osx.cpp:654 ../src/richtext/richtextctrl.cpp:332
+msgid "&Paste"
+msgstr "Įk&lijuoti"
+
+#: ../src/common/stockitem.cpp:185 ../src/richtext/richtextctrl.cpp:3484
+#: ../src/stc/stc_i18n.cpp:19
+msgid "Paste"
+msgstr "Įklijuoti"
+
+#: ../src/common/stockitem.cpp:186
+msgid "&Preferences"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:186 ../src/osx/cocoa/preferences.mm:304
+msgid "Preferences"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:187
+msgid "Print previe&w..."
+msgstr "&Spausdinimo peržiūra..."
+
+#: ../src/common/stockitem.cpp:187
+msgid "Print preview..."
+msgstr "Spausdinimo peržiūra..."
+
+#: ../src/common/stockitem.cpp:188
+msgid "&Print..."
+msgstr "S&pausdinti..."
+
+#: ../src/common/stockitem.cpp:188
+msgid "Print..."
+msgstr "Spausdinti..."
+
+#: ../src/common/stockitem.cpp:189 ../src/richtext/richtextctrl.cpp:337
+#: ../src/richtext/richtextctrl.cpp:5479
+msgid "&Properties"
+msgstr "&Savybės"
+
+#: ../src/common/stockitem.cpp:189
+msgid "Properties"
+msgstr "Savybės"
+
+#: ../src/common/stockitem.cpp:190 ../src/stc/stc_i18n.cpp:16
+msgid "Redo"
+msgstr "Grąžinti atšauktą"
+
+#: ../src/common/stockitem.cpp:191
+msgid "Refresh"
+msgstr "Atnaujinti"
+
+#: ../src/common/stockitem.cpp:192
+msgid "Remove"
+msgstr "Pašalinti"
+
+#: ../src/common/stockitem.cpp:193
+msgid "Rep&lace..."
+msgstr ""
+
+#: ../src/common/stockitem.cpp:193
+msgid "Replace..."
+msgstr ""
+
+#: ../src/common/stockitem.cpp:194
+msgid "Revert to Saved"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:196 ../src/generic/logg.cpp:549
+msgid "Save &As..."
+msgstr "Išs&augoti kaip..."
+
+#: ../src/common/stockitem.cpp:196
+msgid "Save As..."
+msgstr ""
+
+#: ../src/common/stockitem.cpp:197 ../src/msw/textctrl.cpp:2888
+#: ../src/osx/textctrl_osx.cpp:657 ../src/richtext/richtextctrl.cpp:335
+msgid "Select &All"
+msgstr "P&ažymėti viską"
+
+#: ../src/common/stockitem.cpp:197 ../src/stc/stc_i18n.cpp:21
+msgid "Select All"
+msgstr "Pažymėti viską"
+
+#: ../src/common/stockitem.cpp:198
+msgid "&Color"
+msgstr "&Spalva"
+
+#: ../src/common/stockitem.cpp:198
+msgid "Color"
+msgstr "Spalva"
+
+#: ../src/common/stockitem.cpp:199
+msgid "&Font"
+msgstr "Š&riftas"
+
+#: ../src/common/stockitem.cpp:199 ../src/richtext/richtextformatdlg.cpp:336
+msgid "Font"
+msgstr "Šriftas"
+
+#: ../src/common/stockitem.cpp:200
+msgid "&Ascending"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:200
+msgid "Ascending"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:201
+msgid "&Descending"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:201
+msgid "Descending"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:202
+msgid "&Spell Check"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:202
+msgid "Spell Check"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:203
+msgid "&Stop"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:203
+msgid "Stop"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:204 ../src/richtext/richtextfontpage.cpp:274
+msgid "&Strikethrough"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:204
+msgid "Strikethrough"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:205
+msgid "&Top"
+msgstr "&Viršaus"
+
+#: ../src/common/stockitem.cpp:205 ../src/richtext/richtextsizepage.cpp:285
+#: ../src/richtext/richtextsizepage.cpp:289
+msgid "Top"
+msgstr "Viršus"
+
+#: ../src/common/stockitem.cpp:206
+msgid "Undelete"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:207 ../src/generic/fontdlgg.cpp:437
+msgid "&Underline"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:207
+msgid "Underline"
+msgstr "Pabraukti"
+
+#: ../src/common/stockitem.cpp:208 ../src/stc/stc_i18n.cpp:15
+msgid "Undo"
+msgstr "Atšaukti"
+
+#: ../src/common/stockitem.cpp:209
+msgid "&Unindent"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:209
+msgid "Unindent"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:210
+msgid "&Up"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:210 ../src/generic/fdrepdlg.cpp:148
+msgid "Up"
+msgstr "Aukštyn"
+
+#: ../src/common/stockitem.cpp:211 ../src/msw/msgdlg.cpp:417
+msgid "&Yes"
+msgstr "&Taip"
+
+#: ../src/common/stockitem.cpp:212
+msgid "&Actual Size"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:212
+msgid "Actual Size"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:213
+msgid "Zoom to &Fit"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:213
+msgid "Zoom to Fit"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:214
+msgid "Zoom &In"
+msgstr "&Didinti"
+
+#: ../src/common/stockitem.cpp:215
+msgid "Zoom &Out"
+msgstr "&Mažinti"
+
+#: ../src/common/stockitem.cpp:262
+msgid "Show about dialog"
+msgstr "Rodyti apie dialogą"
+
+#: ../src/common/stockitem.cpp:263
+msgid "Copy selection"
+msgstr "Kopijuoti parinktį"
+
+#: ../src/common/stockitem.cpp:264
+msgid "Cut selection"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:265
+msgid "Delete selection"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:266
+msgid "Find in document"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:267
+msgid "Find and replace in document"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:268
+msgid "Paste selection"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:269
+msgid "Quit this program"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:270
+msgid "Redo last action"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:271
+msgid "Undo last action"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:272
+msgid "Create new document"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:273
+msgid "Open an existing document"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:274
+msgid "Close current document"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:275
+msgid "Save current document"
+msgstr "Išsaugoti aktyvų dokumentą"
+
+#: ../src/common/stockitem.cpp:276
+msgid "Save current document with a different filename"
+msgstr "Išsaugoti aktyvų dokumentą kitu pavadinimu"
+
+#: ../src/common/strconv.cpp:2324
+#, c-format
+msgid "Conversion to charset '%s' doesn't work."
+msgstr ""
+
+#: ../src/common/tarstrm.cpp:352 ../src/common/tarstrm.cpp:375
+#: ../src/common/tarstrm.cpp:406 ../src/generic/progdlgg.cpp:373
+msgid "unknown"
+msgstr "nežinomas"
+
+#: ../src/common/tarstrm.cpp:774
+msgid "incomplete header block in tar"
+msgstr ""
+
+#: ../src/common/tarstrm.cpp:798
+msgid "checksum failure reading tar header block"
+msgstr ""
+
+#: ../src/common/tarstrm.cpp:971
+msgid "invalid data in extended tar header"
+msgstr ""
+
+#: ../src/common/tarstrm.cpp:981 ../src/common/tarstrm.cpp:1003
+#: ../src/common/tarstrm.cpp:1477 ../src/common/tarstrm.cpp:1499
+msgid "tar entry not open"
+msgstr ""
+
+#: ../src/common/tarstrm.cpp:1023
+msgid "unexpected end of file"
+msgstr ""
+
+#: ../src/common/tarstrm.cpp:1297
+#, c-format
+msgid "%s did not fit the tar header for entry '%s'"
+msgstr ""
+
+#: ../src/common/tarstrm.cpp:1359
+msgid "incorrect size given for tar entry"
+msgstr ""
+
+#: ../src/common/textbuf.cpp:232
+#, c-format
+msgid "'%s' is probably a binary buffer."
+msgstr ""
+
+#: ../src/common/textcmn.cpp:1006 ../src/richtext/richtextctrl.cpp:3053
+msgid "File couldn't be loaded."
+msgstr ""
+
+#: ../src/common/textfile.cpp:95
+#, c-format
+msgid "Failed to read text file \"%s\"."
+msgstr ""
+
+#: ../src/common/textfile.cpp:160
+#, c-format
+msgid "can't write buffer '%s' to disk."
+msgstr ""
+
+#: ../src/common/time.cpp:212
+msgid "Failed to get the local system time"
+msgstr ""
+
+#: ../src/common/time.cpp:279
+msgid "wxGetTimeOfDay failed."
+msgstr ""
+
+#: ../src/common/translation.cpp:929
+#, c-format
+msgid "'%s' is not a valid message catalog."
+msgstr ""
+
+#: ../src/common/translation.cpp:954
+msgid "Invalid message catalog."
+msgstr ""
+
+#: ../src/common/translation.cpp:1013
+#, c-format
+msgid "Failed to parse Plural-Forms: '%s'"
+msgstr ""
+
+#: ../src/common/translation.cpp:1723
+#, c-format
+msgid "using catalog '%s' from '%s'."
+msgstr ""
+
+#: ../src/common/translation.cpp:1816
+#, c-format
+msgid "Resource '%s' is not a valid message catalog."
+msgstr ""
+
+#: ../src/common/translation.cpp:1865
+msgid "Couldn't enumerate translations"
+msgstr ""
+
+#: ../src/common/utilscmn.cpp:1145
+msgid "No default application configured for HTML files."
+msgstr ""
+
+#: ../src/common/utilscmn.cpp:1190
+#, c-format
+msgid "Failed to open URL \"%s\" in default browser."
+msgstr ""
+
+#: ../src/common/valtext.cpp:144
+msgid "Validation conflict"
+msgstr ""
+
+#: ../src/common/valtext.cpp:186
+msgid "Required information entry is empty."
+msgstr ""
+
+#: ../src/common/valtext.cpp:188
+#, c-format
+msgid "'%s' is one of the invalid strings"
+msgstr ""
+
+#: ../src/common/valtext.cpp:190
+#, c-format
+msgid "'%s' is not one of the valid strings"
+msgstr ""
+
+#: ../src/common/valtext.cpp:199
+#, c-format
+msgid "'%s' contains invalid character(s)"
+msgstr ""
+
+#: ../src/common/webrequest.cpp:139
+#, c-format
+msgid "Error: %s (%d)"
+msgstr ""
+
+#: ../src/common/webrequest.cpp:655
+#, c-format
+msgid ""
+"Not enough free disk space for download: %llu needed but only %llu available."
+msgstr ""
+
+#: ../src/common/webrequest.cpp:669
+#, fuzzy, c-format
+msgid "Failed to create temporary file in %s"
+msgstr "Nepavyko paruošti grojimui \"%s\"."
+
+#: ../src/common/webrequest_curl.cpp:1106
+msgid "libcurl could not be initialized"
+msgstr ""
+
+#: ../src/common/webview.cpp:392
+msgid "RunScriptAsync not supported"
+msgstr ""
+
+#: ../src/common/webview.cpp:403 ../src/msw/webview_ie.cpp:1073
+#, c-format
+msgid "Error running JavaScript: %s"
+msgstr ""
+
+#: ../src/common/webview_chromium.cpp:858
+#, fuzzy, c-format
+msgid "Failed to set proxy \"%s\": %s"
+msgstr "Nepavyko paruošti grojimui \"%s\"."
+
+#: ../src/common/webview_chromium.cpp:989
+msgid ""
+"Chromium can't be used because libcef.so wasn't loaded early enough; please "
+"relink the application or use LD_PRELOAD to load it earlier."
+msgstr ""
+
+#: ../src/common/webview_chromium.cpp:1108
+msgid "Could not initialize Chromium"
+msgstr ""
+
+#: ../src/common/webview_chromium.cpp:1616
+msgid "Show DevTools"
+msgstr ""
+
+#: ../src/common/webview_chromium.cpp:1617
+#, fuzzy
+msgid "Close DevTools"
+msgstr "Užverti visus"
+
+#: ../src/common/webview_chromium.cpp:1623
+msgid "Inspect"
+msgstr ""
+
+#: ../src/common/wincmn.cpp:1628
+msgid "This platform does not support background transparency."
+msgstr "Platforma nepalaiko permatomo fono."
+
+#: ../src/common/wincmn.cpp:2097
+msgid "Could not transfer data to window"
+msgstr ""
+
+#: ../src/common/windowid.cpp:240
+msgid "Out of window IDs.  Recommend shutting down application."
+msgstr ""
+
+#: ../src/common/xpmdecod.cpp:678
+msgid "XPM: incorrect header format!"
+msgstr ""
+
+#: ../src/common/xpmdecod.cpp:703
+#, c-format
+msgid "XPM: incorrect colour description in line %d"
+msgstr ""
+
+#: ../src/common/xpmdecod.cpp:715 ../src/common/xpmdecod.cpp:724
+#, c-format
+msgid "XPM: malformed colour definition '%s' at line %d!"
+msgstr ""
+
+#: ../src/common/xpmdecod.cpp:754
+msgid "XPM: no colors left to use for mask!"
+msgstr ""
+
+#: ../src/common/xpmdecod.cpp:781
+#, c-format
+msgid "XPM: truncated image data at line %d!"
+msgstr ""
+
+#: ../src/common/xpmdecod.cpp:795
+msgid "XPM: Malformed pixel data!"
+msgstr ""
+
+#: ../src/common/xti.cpp:492
+msgid "Illegal Parameter Count for Create Method"
+msgstr ""
+
+#: ../src/common/xti.cpp:504
+msgid "Illegal Parameter Count for ConstructObject Method"
+msgstr ""
+
+#: ../src/common/xtistrm.cpp:161
+#, c-format
+msgid "Create Parameter %s not found in declared RTTI Parameters"
+msgstr ""
+
+#: ../src/common/xtistrm.cpp:290
+msgid "Illegal Object Class (Non-wxEvtHandler) as Event Source"
+msgstr ""
+
+#: ../src/common/xtistrm.cpp:313 ../src/common/xtixml.cpp:345
+#: ../src/common/xtixml.cpp:498
+msgid "Type must have enum - long conversion"
+msgstr ""
+
+#: ../src/common/xtistrm.cpp:400 ../src/common/xtistrm.cpp:415
+msgid "Invalid or Null Object ID passed to GetObjectClassInfo"
+msgstr ""
+
+#: ../src/common/xtistrm.cpp:405
+msgid "Unknown Object passed to GetObjectClassInfo"
+msgstr ""
+
+#: ../src/common/xtistrm.cpp:420
+msgid "Already Registered Object passed to SetObjectClassInfo"
+msgstr ""
+
+#: ../src/common/xtistrm.cpp:430
+msgid "Invalid or Null Object ID passed to HasObjectClassInfo"
+msgstr ""
+
+#: ../src/common/xtistrm.cpp:460
+msgid "Passing a already registered object to SetObject"
+msgstr ""
+
+#: ../src/common/xtistrm.cpp:471
+msgid "Passing an unknown object to GetObject"
+msgstr "Netinkamas objektas perduodamas GetObject"
+
+#: ../src/common/xtixml.cpp:229
+msgid "Forward hrefs are not supported"
+msgstr ""
+
+#: ../src/common/xtixml.cpp:247
+#, c-format
+msgid "unknown class %s"
+msgstr ""
+
+#: ../src/common/xtixml.cpp:253
+msgid "objects cannot have XML Text Nodes"
+msgstr ""
+
+#: ../src/common/xtixml.cpp:258
+msgid "Objects must have an id attribute"
+msgstr ""
+
+#: ../src/common/xtixml.cpp:267
+#, c-format
+msgid "Doubly used id : %d"
+msgstr ""
+
+#: ../src/common/xtixml.cpp:316
+#, c-format
+msgid "Unknown Property %s"
+msgstr ""
+
+#: ../src/common/xtixml.cpp:407
+msgid "A non empty collection must consist of 'element' nodes"
+msgstr ""
+
+#: ../src/common/xtixml.cpp:478
+msgid "incorrect event handler string, missing dot"
+msgstr ""
+
+#: ../src/common/zipstrm.cpp:559
+msgid "can't re-initialize zlib deflate stream"
+msgstr ""
+
+#: ../src/common/zipstrm.cpp:584
+msgid "can't re-initialize zlib inflate stream"
+msgstr ""
+
+#: ../src/common/zipstrm.cpp:1023
+msgid "Ignoring malformed extra data record, ZIP file may be corrupted"
+msgstr ""
+
+#: ../src/common/zipstrm.cpp:1502
+msgid "assuming this is a multi-part zip concatenated"
+msgstr ""
+
+#: ../src/common/zipstrm.cpp:1664
+msgid "invalid zip file"
+msgstr ""
+
+#: ../src/common/zipstrm.cpp:1723
+msgid "can't find central directory in zip"
+msgstr ""
+
+#: ../src/common/zipstrm.cpp:1812
+msgid "error reading zip central directory"
+msgstr ""
+
+#: ../src/common/zipstrm.cpp:1916
+msgid "error reading zip local header"
+msgstr ""
+
+#: ../src/common/zipstrm.cpp:1964
+msgid "bad zipfile offset to entry"
+msgstr ""
+
+#: ../src/common/zipstrm.cpp:2031
+msgid "stored file length not in Zip header"
+msgstr ""
+
+#: ../src/common/zipstrm.cpp:2045 ../src/common/zipstrm.cpp:2362
+msgid "unsupported Zip compression method"
+msgstr ""
+
+#: ../src/common/zipstrm.cpp:2126
+#, c-format
+msgid "reading zip stream (entry %s): bad length"
+msgstr ""
+
+#: ../src/common/zipstrm.cpp:2131
+#, c-format
+msgid "reading zip stream (entry %s): bad crc"
+msgstr ""
+
+#: ../src/common/zipstrm.cpp:2578
+#, c-format
+msgid "error writing zip entry '%s': file too large without ZIP64"
+msgstr ""
+
+#: ../src/common/zipstrm.cpp:2585
+#, c-format
+msgid "error writing zip entry '%s': bad crc or length"
+msgstr ""
+
+#: ../src/common/zstream.cpp:155 ../src/common/zstream.cpp:315
+msgid "Gzip not supported by this version of zlib"
+msgstr ""
+
+#: ../src/common/zstream.cpp:182
+msgid "Can't initialize zlib inflate stream."
+msgstr ""
+
+#: ../src/common/zstream.cpp:241
+msgid "Can't read inflate stream: unexpected EOF in underlying stream."
+msgstr ""
+
+#: ../src/common/zstream.cpp:248 ../src/common/zstream.cpp:423
+#, c-format
+msgid "zlib error %d"
+msgstr ""
+
+#: ../src/common/zstream.cpp:249
+#, c-format
+msgid "Can't read from inflate stream: %s"
+msgstr ""
+
+#: ../src/common/zstream.cpp:343
+msgid "Can't initialize zlib deflate stream."
+msgstr ""
+
+#: ../src/common/zstream.cpp:424
+#, c-format
+msgid "Can't write to deflate stream: %s"
+msgstr ""
+
+#: ../src/dfb/bitmap.cpp:633 ../src/dfb/bitmap.cpp:667
+#, c-format
+msgid "No bitmap handler for type %d defined."
+msgstr ""
+
+#: ../src/dfb/evtloop.cpp:99
+msgid "Failed to read event from DirectFB pipe"
+msgstr ""
+
+#: ../src/dfb/evtloop.cpp:171
+msgid "Failed to switch DirectFB pipe to non-blocking mode"
+msgstr ""
+
+#: ../src/dfb/fontmgr.cpp:171
+#, c-format
+msgid "no fonts found in %s, using builtin font"
+msgstr ""
+
+#: ../src/dfb/fontmgr.cpp:177
+msgid "Default font"
+msgstr ""
+
+#: ../src/dfb/fontmgr.cpp:195
+#, c-format
+msgid "Fonts index file %s disappeared while loading fonts."
+msgstr ""
+
+#: ../src/dfb/wrapdfb.cpp:60
+#, c-format
+msgid "DirectFB error %d occurred."
+msgstr "Įvyko DirectFB klaida %d."
+
+#: ../src/generic/aboutdlgg.cpp:69
+msgid "Developed by "
+msgstr ""
+
+#: ../src/generic/aboutdlgg.cpp:72
+msgid "Documentation by "
+msgstr ""
+
+#: ../src/generic/aboutdlgg.cpp:75
+msgid "Graphics art by "
+msgstr ""
+
+#: ../src/generic/aboutdlgg.cpp:78
+msgid "Translations by "
+msgstr ""
+
+#: ../src/generic/aboutdlgg.cpp:133 ../src/osx/cocoa/aboutdlg.mm:83
+msgid "Version "
+msgstr "Versija "
+
+#. TRANSLATORS: %s is application name
+#: ../src/generic/aboutdlgg.cpp:146 ../src/msw/aboutdlg.cpp:60
+#, c-format
+msgid "About %s"
+msgstr "Apie %s"
+
+#: ../src/generic/aboutdlgg.cpp:181
+msgid "License"
+msgstr "Licencija"
+
+#: ../src/generic/aboutdlgg.cpp:184
+msgid "Developers"
+msgstr ""
+
+#: ../src/generic/aboutdlgg.cpp:188
+msgid "Documentation writers"
+msgstr ""
+
+#: ../src/generic/aboutdlgg.cpp:192
+msgid "Artists"
+msgstr ""
+
+#: ../src/generic/aboutdlgg.cpp:196
+msgid "Translators"
+msgstr ""
+
+#: ../src/generic/animateg.cpp:125
+msgid "No handler found for animation type."
+msgstr ""
+
+#: ../src/generic/animateg.cpp:133
+#, c-format
+msgid "No animation handler for type %ld defined."
+msgstr ""
+
+#: ../src/generic/animateg.cpp:145
+#, c-format
+msgid "Animation file is not of type %ld."
+msgstr ""
+
+#: ../src/generic/colrdlgg.cpp:154 ../src/gtk/colordlg.cpp:47
+msgid "Choose colour"
+msgstr ""
+
+#: ../src/generic/colrdlgg.cpp:357
+msgid "Red:"
+msgstr ""
+
+#: ../src/generic/colrdlgg.cpp:360
+msgid "Green:"
+msgstr ""
+
+#: ../src/generic/colrdlgg.cpp:363
+msgid "Blue:"
+msgstr ""
+
+#: ../src/generic/colrdlgg.cpp:372
+msgid "Opacity:"
+msgstr ""
+
+#: ../src/generic/colrdlgg.cpp:384
+msgid "Add to custom colours"
+msgstr ""
+
+#: ../src/generic/creddlgg.cpp:56
+msgid "Username:"
+msgstr ""
+
+#: ../src/generic/creddlgg.cpp:63
+msgid "Password:"
+msgstr ""
+
+#. TRANSLATORS: Name of Boolean true value
+#: ../src/generic/datavgen.cpp:1178
+msgid "true"
+msgstr ""
+
+#. TRANSLATORS: Name of Boolean false value
+#: ../src/generic/datavgen.cpp:1180
+msgid "false"
+msgstr ""
+
+#: ../src/generic/datavgen.cpp:6897
+#, c-format
+msgid "Row %i"
+msgstr ""
+
+#. TRANSLATORS: Action for manipulating a tree control
+#: ../src/generic/datavgen.cpp:6987
+msgid "Collapse"
+msgstr ""
+
+#. TRANSLATORS: Action for manipulating a tree control
+#: ../src/generic/datavgen.cpp:6990
+msgid "Expand"
+msgstr ""
+
+#. TRANSLATORS: Name of data view control and number of rows
+#: ../src/generic/datavgen.cpp:7011
+#, c-format
+msgid "%s (%d items)"
+msgstr ""
+
+#: ../src/generic/datavgen.cpp:7062
+#, c-format
+msgid "Column %u"
+msgstr ""
+
+#. TRANSLATORS: Keystroke for manipulating a tree control
+#: ../src/generic/datavgen.cpp:7131 ../src/richtext/richtextbulletspage.cpp:189
+#: ../src/richtext/richtextbulletspage.cpp:192
+#: ../src/richtext/richtextbulletspage.cpp:193
+#: ../src/richtext/richtextliststylepage.cpp:252
+#: ../src/richtext/richtextliststylepage.cpp:255
+#: ../src/richtext/richtextliststylepage.cpp:256
+#: ../src/richtext/richtextsizepage.cpp:248
+msgid "Left"
+msgstr "Kairė"
+
+#. TRANSLATORS: Keystroke for manipulating a tree control
+#: ../src/generic/datavgen.cpp:7134 ../src/richtext/richtextbulletspage.cpp:191
+#: ../src/richtext/richtextliststylepage.cpp:254
+#: ../src/richtext/richtextsizepage.cpp:249
+msgid "Right"
+msgstr "Dešinė"
+
+#: ../src/generic/datectlg.cpp:90
+#, c-format
+msgid ""
+"\"%s\" is not in the expected date format, please enter it as e.g. \"%s\"."
+msgstr ""
+
+#: ../src/generic/datectlg.cpp:94
+msgid "Invalid date"
+msgstr ""
+
+#: ../src/generic/dbgrptg.cpp:159
+#, c-format
+msgid "Open file \"%s\""
+msgstr ""
+
+#: ../src/generic/dbgrptg.cpp:170
+#, c-format
+msgid "Enter command to open file \"%s\":"
+msgstr ""
+
+#: ../src/generic/dbgrptg.cpp:230
+msgid "Executable files (*.exe)|*.exe|"
+msgstr "Vykdomieji failai (*.exe)|*.exe|"
+
+#: ../src/generic/dbgrptg.cpp:300
+#, c-format
+msgid "Debug report \"%s\""
+msgstr ""
+
+#: ../src/generic/dbgrptg.cpp:316
+msgid "A debug report has been generated in the directory\n"
+msgstr ""
+
+#: ../src/generic/dbgrptg.cpp:317
+msgid "The following debug report will be generated\n"
+msgstr ""
+
+#: ../src/generic/dbgrptg.cpp:321
+msgid ""
+"The report contains the files listed below. If any of these files contain "
+"private information,\n"
+"please uncheck them and they will be removed from the report.\n"
+msgstr ""
+
+#: ../src/generic/dbgrptg.cpp:323
+msgid ""
+"If you wish to suppress this debug report completely, please choose the "
+"\"Cancel\" button,\n"
+"but be warned that it may hinder improving the program, so if\n"
+"at all possible please do continue with the report generation.\n"
+msgstr ""
+
+#: ../src/generic/dbgrptg.cpp:325
+msgid "              Thank you and we're sorry for the inconvenience!\n"
+msgstr ""
+
+#: ../src/generic/dbgrptg.cpp:333
+msgid "&Debug report preview:"
+msgstr ""
+
+#: ../src/generic/dbgrptg.cpp:339
+msgid "&View..."
+msgstr "&Rodyti..."
+
+#: ../src/generic/dbgrptg.cpp:359
+msgid "&Notes:"
+msgstr ""
+
+#: ../src/generic/dbgrptg.cpp:361
+msgid ""
+"If you have any additional information pertaining to this bug\n"
+"report, please enter it here and it will be joined to it:"
+msgstr ""
+
+#: ../src/generic/dcpsg.cpp:1627
+msgid "Cannot open file for PostScript printing!"
+msgstr ""
+
+#: ../src/generic/dirctrlg.cpp:402
+msgid "Computer"
+msgstr ""
+
+#: ../src/generic/dirctrlg.cpp:404
+msgid "Sections"
+msgstr "Pjūviai"
+
+#: ../src/generic/dirctrlg.cpp:482
+msgid "Home directory"
+msgstr "Pagrindinis aplankas"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/generic/dirctrlg.cpp:484 ../src/propgrid/advprops.cpp:811
+msgid "Desktop"
+msgstr "Darbastalis"
+
+#: ../src/generic/dirctrlg.cpp:528 ../src/generic/filectrlg.cpp:752
+msgid "Illegal directory name."
+msgstr ""
+
+#: ../src/generic/dirctrlg.cpp:528 ../src/generic/dirctrlg.cpp:546
+#: ../src/generic/dirctrlg.cpp:557 ../src/generic/dirdlgg.cpp:317
+#: ../src/generic/filectrlg.cpp:638 ../src/generic/filectrlg.cpp:752
+#: ../src/generic/filectrlg.cpp:766 ../src/generic/filectrlg.cpp:782
+#: ../src/generic/filectrlg.cpp:1356 ../src/generic/filectrlg.cpp:1387
+#: ../src/generic/filedlgg.cpp:362 ../src/gtk/filedlg.cpp:76
+msgid "Error"
+msgstr "Klaida"
+
+#: ../src/generic/dirctrlg.cpp:546 ../src/generic/filectrlg.cpp:766
+msgid "File name exists already."
+msgstr "Toks failo pavadinimas jau yra."
+
+#: ../src/generic/dirctrlg.cpp:557 ../src/generic/dirdlgg.cpp:317
+#: ../src/generic/filectrlg.cpp:638 ../src/generic/filectrlg.cpp:782
+msgid "Operation not permitted."
+msgstr ""
+
+#: ../src/generic/dirdlgg.cpp:107 ../src/generic/filedlgg.cpp:207
+msgid "Create new directory"
+msgstr ""
+
+#: ../src/generic/dirdlgg.cpp:112 ../src/generic/filedlgg.cpp:203
+msgid "Go to home directory"
+msgstr ""
+
+#: ../src/generic/dirdlgg.cpp:143
+msgid "Show &hidden directories"
+msgstr ""
+
+#: ../src/generic/dirdlgg.cpp:196
+#, c-format
+msgid ""
+"The directory '%s' does not exist\n"
+"Create it now?"
+msgstr ""
+
+#: ../src/generic/dirdlgg.cpp:198
+msgid "Directory does not exist"
+msgstr ""
+
+#: ../src/generic/dirdlgg.cpp:214
+#, c-format
+msgid ""
+"Failed to create directory '%s'\n"
+"(Do you have the required permissions?)"
+msgstr ""
+
+#: ../src/generic/dirdlgg.cpp:216
+msgid "Error creating directory"
+msgstr ""
+
+#: ../src/generic/dirdlgg.cpp:281
+msgid "You cannot add a new directory to this section."
+msgstr ""
+
+#: ../src/generic/dirdlgg.cpp:282
+msgid "Create directory"
+msgstr ""
+
+#: ../src/generic/dirdlgg.cpp:291 ../src/generic/dirdlgg.cpp:301
+#: ../src/generic/filectrlg.cpp:614 ../src/generic/filectrlg.cpp:623
+msgid "NewName"
+msgstr ""
+
+#: ../src/generic/editlbox.cpp:135
+msgid "Edit item"
+msgstr ""
+
+#: ../src/generic/editlbox.cpp:143
+msgid "New item"
+msgstr ""
+
+#: ../src/generic/editlbox.cpp:151
+msgid "Delete item"
+msgstr "Ištrinti elementą"
+
+#: ../src/generic/editlbox.cpp:159
+msgid "Move up"
+msgstr "Perkelti aukštyn"
+
+#: ../src/generic/editlbox.cpp:164
+msgid "Move down"
+msgstr "Perkelti žemyn"
+
+#: ../src/generic/fdrepdlg.cpp:108
+msgid "Search for:"
+msgstr ""
+
+#: ../src/generic/fdrepdlg.cpp:120
+msgid "Replace with:"
+msgstr "Pakeisti šiuo:"
+
+#: ../src/generic/fdrepdlg.cpp:140
+msgid "Whole word"
+msgstr ""
+
+#: ../src/generic/fdrepdlg.cpp:143
+msgid "Match case"
+msgstr "Skirti didžiąsias"
+
+#: ../src/generic/fdrepdlg.cpp:156
+msgid "Search direction"
+msgstr ""
+
+#: ../src/generic/fdrepdlg.cpp:175
+msgid "&Replace"
+msgstr ""
+
+#: ../src/generic/fdrepdlg.cpp:178
+msgid "Replace &all"
+msgstr ""
+
+#: ../src/generic/filectrlg.cpp:246 ../src/generic/filectrlg.cpp:269
+msgid "<DIR>"
+msgstr ""
+
+#: ../src/generic/filectrlg.cpp:248 ../src/generic/filectrlg.cpp:271
+msgid "<LINK>"
+msgstr "NUORODA"
+
+#: ../src/generic/filectrlg.cpp:250 ../src/generic/filectrlg.cpp:273
+msgid "<DRIVE>"
+msgstr ""
+
+#: ../src/generic/filectrlg.cpp:275
+#, c-format
+msgid "%ld byte"
+msgid_plural "%ld bytes"
+msgstr[0] "%ld baitų"
+msgstr[1] "%ld baitų"
+msgstr[2] "%ld baitų"
+
+#: ../src/generic/filectrlg.cpp:420
+msgid "Name"
+msgstr "Pavadinimas"
+
+#: ../src/generic/filectrlg.cpp:421 ../src/richtext/richtextformatdlg.cpp:361
+#: ../src/richtext/richtextsizepage.cpp:298
+msgid "Size"
+msgstr "Dydis"
+
+#: ../src/generic/filectrlg.cpp:422
+msgid "Type"
+msgstr "Tipas"
+
+#: ../src/generic/filectrlg.cpp:423
+msgid "Modified"
+msgstr "Pakeista"
+
+#: ../src/generic/filectrlg.cpp:426
+msgid "Permissions"
+msgstr ""
+
+#: ../src/generic/filectrlg.cpp:429
+msgid "Attributes"
+msgstr "Atributai"
+
+#: ../src/generic/filectrlg.cpp:936
+msgid "Current directory:"
+msgstr ""
+
+#: ../src/generic/filectrlg.cpp:979
+msgid "Show &hidden files"
+msgstr ""
+
+#: ../src/generic/filectrlg.cpp:1355
+msgid "Illegal file specification."
+msgstr ""
+
+#: ../src/generic/filectrlg.cpp:1387
+msgid "Directory doesn't exist."
+msgstr ""
+
+#: ../src/generic/filedlgg.cpp:195
+msgid "View files as a list view"
+msgstr ""
+
+#: ../src/generic/filedlgg.cpp:197
+msgid "View files as a detailed view"
+msgstr ""
+
+#: ../src/generic/filedlgg.cpp:200
+msgid "Go to parent directory"
+msgstr ""
+
+#: ../src/generic/filedlgg.cpp:351 ../src/gtk/filedlg.cpp:59
+#, c-format
+msgid "File '%s' already exists, do you really want to overwrite it?"
+msgstr ""
+
+#: ../src/generic/filedlgg.cpp:354 ../src/gtk/filedlg.cpp:62
+msgid "Confirm"
+msgstr "Patvirtinti"
+
+#: ../src/generic/filedlgg.cpp:362 ../src/gtk/filedlg.cpp:75
+msgid "Please choose an existing file."
+msgstr ""
+
+#: ../src/generic/filepickerg.cpp:64
+msgid "..."
+msgstr "..."
+
+#: ../src/generic/fontdlgg.cpp:76 ../src/richtext/richtextformatdlg.cpp:519
+msgid "ABCDEFGabcdefg12345"
+msgstr "ABCDEFGabcdefg12345"
+
+#: ../src/generic/fontdlgg.cpp:315
+msgid "Roman"
+msgstr ""
+
+#: ../src/generic/fontdlgg.cpp:316
+msgid "Decorative"
+msgstr ""
+
+#: ../src/generic/fontdlgg.cpp:317
+msgid "Modern"
+msgstr ""
+
+#: ../src/generic/fontdlgg.cpp:318
+msgid "Script"
+msgstr "SCRIPT"
+
+#: ../src/generic/fontdlgg.cpp:319
+msgid "Swiss"
+msgstr ""
+
+#: ../src/generic/fontdlgg.cpp:320
+msgid "Teletype"
+msgstr ""
+
+#: ../src/generic/fontdlgg.cpp:321 ../src/generic/fontdlgg.cpp:324
+msgid "Normal"
+msgstr "Normalus"
+
+#: ../src/generic/fontdlgg.cpp:323
+msgid "Slant"
+msgstr ""
+
+#: ../src/generic/fontdlgg.cpp:325
+msgid "Light"
+msgstr "Šviesa"
+
+#: ../src/generic/fontdlgg.cpp:363
+msgid "&Font family:"
+msgstr "Š&riftų šeima:"
+
+#: ../src/generic/fontdlgg.cpp:367 ../src/generic/fontdlgg.cpp:369
+msgid "The font family."
+msgstr ""
+
+#: ../src/generic/fontdlgg.cpp:374 ../src/richtext/richtextstylepage.cpp:105
+msgid "&Style:"
+msgstr ""
+
+#: ../src/generic/fontdlgg.cpp:378 ../src/generic/fontdlgg.cpp:380
+msgid "The font style."
+msgstr ""
+
+#: ../src/generic/fontdlgg.cpp:385
+msgid "&Weight:"
+msgstr ""
+
+#: ../src/generic/fontdlgg.cpp:389 ../src/generic/fontdlgg.cpp:391
+msgid "The font weight."
+msgstr ""
+
+#: ../src/generic/fontdlgg.cpp:399
+msgid "C&olour:"
+msgstr ""
+
+#: ../src/generic/fontdlgg.cpp:407 ../src/generic/fontdlgg.cpp:409
+msgid "The font colour."
+msgstr ""
+
+#: ../src/generic/fontdlgg.cpp:415
+msgid "&Point size:"
+msgstr ""
+
+#: ../src/generic/fontdlgg.cpp:420 ../src/generic/fontdlgg.cpp:422
+#: ../src/generic/fontdlgg.cpp:426 ../src/generic/fontdlgg.cpp:428
+msgid "The font point size."
+msgstr ""
+
+#: ../src/generic/fontdlgg.cpp:439 ../src/generic/fontdlgg.cpp:441
+msgid "Whether the font is underlined."
+msgstr ""
+
+#: ../src/generic/fontdlgg.cpp:448 ../src/html/helpwnd.cpp:1215
+msgid "Preview:"
+msgstr "Peržiūra:"
+
+#: ../src/generic/fontdlgg.cpp:452 ../src/generic/fontdlgg.cpp:454
+msgid "Shows the font preview."
+msgstr ""
+
+#: ../src/generic/fontdlgg.cpp:464 ../src/generic/fontdlgg.cpp:483
+msgid "Click to cancel the font selection."
+msgstr ""
+
+#: ../src/generic/fontdlgg.cpp:469 ../src/generic/fontdlgg.cpp:471
+#: ../src/generic/fontdlgg.cpp:476 ../src/generic/fontdlgg.cpp:478
+msgid "Click to confirm the font selection."
+msgstr ""
+
+#: ../src/generic/fontpickerg.cpp:50 ../src/gtk/fontdlg.cpp:77
+msgid "Choose font"
+msgstr ""
+
+#: ../src/generic/grid.cpp:6542
+msgid ""
+"Error copying grid to the clipboard. Either selected cells were not "
+"contiguous or no cell was selected."
+msgstr ""
+
+#: ../src/generic/grid.cpp:12739
+msgid "Grid Corner"
+msgstr ""
+
+#: ../src/generic/grid.cpp:12741
+#, c-format
+msgid "Column %s Header"
+msgstr ""
+
+#: ../src/generic/grid.cpp:12743
+#, c-format
+msgid "Row %s Header"
+msgstr ""
+
+#: ../src/generic/grid.cpp:12745
+#, c-format
+msgid "Column %s: %s"
+msgstr ""
+
+#: ../src/generic/grid.cpp:12749
+#, c-format
+msgid "Row %s: %s"
+msgstr ""
+
+#: ../src/generic/grid.cpp:12753
+#, c-format
+msgid "Row %s, Column %s: %s"
+msgstr ""
+
+#: ../src/generic/helpext.cpp:257
+#, c-format
+msgid "Help directory \"%s\" not found."
+msgstr ""
+
+#: ../src/generic/helpext.cpp:265
+#, c-format
+msgid "Help file \"%s\" not found."
+msgstr ""
+
+#: ../src/generic/helpext.cpp:284
+#, c-format
+msgid "Line %lu of map file \"%s\" has invalid syntax, skipped."
+msgstr ""
+
+#: ../src/generic/helpext.cpp:292
+#, c-format
+msgid "No valid mappings found in the file \"%s\"."
+msgstr ""
+
+#: ../src/generic/helpext.cpp:435
+msgid "No entries found."
+msgstr ""
+
+#: ../src/generic/helpext.cpp:444 ../src/generic/helpext.cpp:445
+msgid "Help Index"
+msgstr ""
+
+#: ../src/generic/helpext.cpp:448
+msgid "Relevant entries:"
+msgstr ""
+
+#: ../src/generic/helpext.cpp:449
+msgid "Entries found"
+msgstr ""
+
+#: ../src/generic/hyperlinkg.cpp:170
+msgid "&Copy URL"
+msgstr ""
+
+#: ../src/generic/infobar.cpp:119
+msgid "Hide this notification message."
+msgstr ""
+
+#. TRANSLATORS: %s will be either the application name or "Application"
+#: ../src/generic/logg.cpp:257
+#, c-format
+msgid "%s Error"
+msgstr ""
+
+#. TRANSLATORS: %s will be either the application name or "Application"
+#: ../src/generic/logg.cpp:263
+#, c-format
+msgid "%s Warning"
+msgstr ""
+
+#. TRANSLATORS: %s will be either the application name or "Application"
+#: ../src/generic/logg.cpp:273
+#, c-format
+msgid "%s Information"
+msgstr ""
+
+#: ../src/generic/logg.cpp:276
+msgid "Application"
+msgstr "Objektų parinktis"
+
+#: ../src/generic/logg.cpp:549
+msgid "Save log contents to file"
+msgstr "Išsaugoti žurnalo turinį į failą"
+
+#: ../src/generic/logg.cpp:551
+msgid "C&lear"
+msgstr "Išva&lyti"
+
+#: ../src/generic/logg.cpp:551
+msgid "Clear the log contents"
+msgstr ""
+
+#: ../src/generic/logg.cpp:553
+msgid "Close this window"
+msgstr ""
+
+#: ../src/generic/logg.cpp:554
+msgid "&Log"
+msgstr ""
+
+#: ../src/generic/logg.cpp:610 ../src/generic/logg.cpp:992
+msgid "Can't save log contents to file."
+msgstr ""
+
+#: ../src/generic/logg.cpp:613
+#, c-format
+msgid "Log saved to the file '%s'."
+msgstr ""
+
+#: ../src/generic/logg.cpp:719
+msgid "&Details"
+msgstr ""
+
+#: ../src/generic/logg.cpp:972
+msgid "Failed to copy dialog contents to the clipboard."
+msgstr ""
+
+#: ../src/generic/logg.cpp:1022
+#, c-format
+msgid "Append log to file '%s' (choosing [No] will overwrite it)?"
+msgstr ""
+
+#: ../src/generic/logg.cpp:1024
+msgid "Question"
+msgstr ""
+
+#: ../src/generic/logg.cpp:1038
+msgid "invalid message box return value"
+msgstr ""
+
+#: ../src/generic/notifmsgg.cpp:129
+msgid "Notice"
+msgstr ""
+
+#: ../src/generic/preferencesg.cpp:118
+#, c-format
+msgid "%s Preferences"
+msgstr ""
+
+#: ../src/generic/printps.cpp:143
+msgid "Printing..."
+msgstr ""
+
+#: ../src/generic/printps.cpp:160 ../src/gtk/print.cpp:1076
+#: ../src/msw/printwin.cpp:235
+msgid "Could not start printing."
+msgstr ""
+
+#: ../src/generic/printps.cpp:183
+#, c-format
+msgid "Printing page %d..."
+msgstr ""
+
+#: ../src/generic/prntdlgg.cpp:171
+msgid "Printer options"
+msgstr ""
+
+#: ../src/generic/prntdlgg.cpp:176
+msgid "Print to File"
+msgstr ""
+
+#: ../src/generic/prntdlgg.cpp:179
+msgid "Setup..."
+msgstr "Sąranka..."
+
+#: ../src/generic/prntdlgg.cpp:187
+msgid "Printer:"
+msgstr "Spausdintuvas:"
+
+#: ../src/generic/prntdlgg.cpp:195
+msgid "Status:"
+msgstr "Būsena:"
+
+#: ../src/generic/prntdlgg.cpp:206
+msgid "All"
+msgstr "Viskas"
+
+#: ../src/generic/prntdlgg.cpp:207
+msgid "Pages"
+msgstr ""
+
+#: ../src/generic/prntdlgg.cpp:215
+msgid "Print Range"
+msgstr ""
+
+#: ../src/generic/prntdlgg.cpp:229
+msgid "From:"
+msgstr "Nuo:"
+
+#: ../src/generic/prntdlgg.cpp:233
+msgid "To:"
+msgstr ""
+
+#: ../src/generic/prntdlgg.cpp:238
+msgid "Copies:"
+msgstr ""
+
+#: ../src/generic/prntdlgg.cpp:288
+msgid "PostScript file"
+msgstr ""
+
+#: ../src/generic/prntdlgg.cpp:439
+msgid "Print Setup"
+msgstr ""
+
+#: ../src/generic/prntdlgg.cpp:483
+msgid "Printer"
+msgstr "Spausdintuvas"
+
+#: ../src/generic/prntdlgg.cpp:501
+msgid "Default printer"
+msgstr ""
+
+#: ../src/generic/prntdlgg.cpp:595 ../src/generic/prntdlgg.cpp:782
+#: ../src/generic/prntdlgg.cpp:822 ../src/generic/prntdlgg.cpp:835
+#: ../src/generic/prntdlgg.cpp:1031 ../src/generic/prntdlgg.cpp:1036
+msgid "Paper size"
+msgstr "Popieriaus dydis"
+
+#: ../src/generic/prntdlgg.cpp:604 ../src/generic/prntdlgg.cpp:847
+msgid "Portrait"
+msgstr "Stačias"
+
+#: ../src/generic/prntdlgg.cpp:605 ../src/generic/prntdlgg.cpp:848
+msgid "Landscape"
+msgstr "Gulsčias"
+
+#: ../src/generic/prntdlgg.cpp:607 ../src/generic/prntdlgg.cpp:849
+msgid "Orientation"
+msgstr "Orientavimas"
+
+#: ../src/generic/prntdlgg.cpp:610
+msgid "Options"
+msgstr "Nuostatos"
+
+#: ../src/generic/prntdlgg.cpp:612
+msgid "Print in colour"
+msgstr ""
+
+#: ../src/generic/prntdlgg.cpp:621
+msgid "Print spooling"
+msgstr ""
+
+#: ../src/generic/prntdlgg.cpp:623
+msgid "Printer command:"
+msgstr ""
+
+#: ../src/generic/prntdlgg.cpp:631
+msgid "Printer options:"
+msgstr ""
+
+#: ../src/generic/prntdlgg.cpp:860
+msgid "Left margin (mm):"
+msgstr ""
+
+#: ../src/generic/prntdlgg.cpp:861
+msgid "Top margin (mm):"
+msgstr ""
+
+#: ../src/generic/prntdlgg.cpp:872
+msgid "Right margin (mm):"
+msgstr ""
+
+#: ../src/generic/prntdlgg.cpp:873
+msgid "Bottom margin (mm):"
+msgstr ""
+
+#: ../src/generic/prntdlgg.cpp:896
+msgid "Printer..."
+msgstr "Spausdintuvas..."
+
+#: ../src/generic/progdlgg.cpp:246
+msgid "&Skip"
+msgstr "Pralei&sti"
+
+#: ../src/generic/progdlgg.cpp:347 ../src/generic/progdlgg.cpp:626
+msgid "Unknown"
+msgstr "Nežinomas"
+
+#: ../src/generic/progdlgg.cpp:451 ../src/msw/progdlg.cpp:526
+msgid "Done."
+msgstr "Baigta."
+
+#: ../src/generic/srchctlg.cpp:55 ../src/gtk/srchctrl.cpp:206
+#: ../src/html/helpwnd.cpp:530 ../src/html/helpwnd.cpp:545
+msgid "Search"
+msgstr "Ieškoti"
+
+#: ../src/generic/tabg.cpp:1026
+msgid "Could not find tab for id"
+msgstr ""
+
+#: ../src/generic/tipdlg.cpp:136
+msgid "Tips not available, sorry!"
+msgstr ""
+
+#: ../src/generic/tipdlg.cpp:197
+msgid "Tip of the Day"
+msgstr "Dienos patarimas"
+
+#: ../src/generic/tipdlg.cpp:207
+msgid "Did you know..."
+msgstr "Ar žinote, kad..."
+
+#: ../src/generic/tipdlg.cpp:232
+msgid "&Show tips at startup"
+msgstr ""
+
+#: ../src/generic/tipdlg.cpp:236
+msgid "&Next Tip"
+msgstr "&Kitas patarimas"
+
+#: ../src/generic/wizard.cpp:411
+msgid "&Next >"
+msgstr "&Toliau >"
+
+#: ../src/generic/wizard.cpp:412
+msgid "&Finish"
+msgstr "&Baigti"
+
+#: ../src/generic/wizard.cpp:420
+msgid "< &Back"
+msgstr "< &Atgal"
+
+#: ../src/gtk/aboutdlg.cpp:204
+msgid "translator-credits"
+msgstr ""
+
+#: ../src/gtk/app.cpp:517
+msgid ""
+"WARNING: using XIM input method is unsupported and may result in problems "
+"with input handling and flickering. Consider unsetting GTK_IM_MODULE or "
+"setting to \"ibus\"."
+msgstr ""
+
+#: ../src/gtk/app.cpp:569
+msgid "Unable to initialize GTK+, is DISPLAY set properly?"
+msgstr ""
+
+#: ../src/gtk/filedlg.cpp:89 ../src/gtk/filepicker.cpp:255
+#, c-format
+msgid "Changing current directory to \"%s\" failed"
+msgstr ""
+
+#: ../src/gtk/font.cpp:548
+msgid ""
+"Using private fonts is not supported on this system: Pango library is too "
+"old, 1.38 or later required."
+msgstr ""
+
+#: ../src/gtk/font.cpp:558
+msgid "Failed to create font configuration object."
+msgstr ""
+
+#: ../src/gtk/font.cpp:568
+#, c-format
+msgid "Failed to add custom font \"%s\"."
+msgstr ""
+
+#: ../src/gtk/font.cpp:576
+msgid "Failed to register font configuration using private fonts."
+msgstr ""
+
+#: ../src/gtk/glcanvas.cpp:117 ../src/gtk/glcanvas.cpp:132
+msgid "Fatal Error"
+msgstr ""
+
+#: ../src/gtk/glcanvas.cpp:117
+msgid ""
+"This program wasn't compiled with EGL support required under Wayland, "
+"either\n"
+"install EGL libraries and rebuild or run it under X11 backend by setting\n"
+"environment variable GDK_BACKEND=x11 before starting your program."
+msgstr ""
+
+#: ../src/gtk/glcanvas.cpp:132
+msgid ""
+"wxGLCanvas is only supported on Wayland and X11 currently.  You may be able "
+"to\n"
+"work around this by setting environment variable GDK_BACKEND=x11 before\n"
+"starting your program."
+msgstr ""
+
+#: ../src/gtk/mdi.cpp:433
+msgid "MDI child"
+msgstr ""
+
+#: ../src/gtk/power.cpp:188
+#, c-format
+msgid "Failed to open D-Bus connection to the login manager: %s"
+msgstr ""
+
+#: ../src/gtk/power.cpp:214
+#, fuzzy
+msgid "wxWidgets application"
+msgstr "Objektų parinktis"
+
+#: ../src/gtk/power.cpp:226
+msgid "Application needs to keep running"
+msgstr ""
+
+#: ../src/gtk/power.cpp:233
+msgid "Clean up before suspend"
+msgstr ""
+
+#: ../src/gtk/power.cpp:259
+#, fuzzy, c-format
+msgid "Failed to inhibit sleep: %s"
+msgstr "Nepavyko paruošti grojimui \"%s\"."
+
+#: ../src/gtk/power.cpp:265
+msgid "Unexpected response to D-Bus \"Inhibit\" request."
+msgstr ""
+
+#: ../src/gtk/print.cpp:218
+msgid "Custom size"
+msgstr ""
+
+#: ../src/gtk/print.cpp:752
+#, c-format
+msgid "Error while printing: %s"
+msgstr ""
+
+#: ../src/gtk/print.cpp:816
+msgid "Page Setup"
+msgstr "Puslapio sąranka"
+
+#: ../src/gtk/webview_webkit.cpp:932
+msgid "Retrieving JavaScript script output is not supported with WebKit v1"
+msgstr ""
+
+#: ../src/gtk/webview_webkit2.cpp:1098
+msgid ""
+"Setting proxy is not supported by WebKit, at least version 2.16 is required."
+msgstr ""
+
+#: ../src/gtk/webview_webkit2.cpp:1104
+msgid "This program was compiled without support for setting WebKit proxy."
+msgstr ""
+
+#: ../src/gtk/window.cpp:6289
+msgid ""
+"GTK+ installed on this machine is too old to support screen compositing, "
+"please install GTK+ 2.12 or later."
+msgstr ""
+"GTK+ įdiegtas šiame kompiuteryje yra per senas, kad palaikytų komponavimą "
+"ekrane, prašome instaliuoti GTK+ 2.12 arba naujesnį."
+
+#: ../src/gtk/window.cpp:6307
+msgid ""
+"Compositing not supported by this system, please enable it in your Window "
+"Manager."
+msgstr ""
+"Komponavimas nėra įgalintas šioje sistemoje, prašome įgalinti tai Windows "
+"tvarkyklėje."
+
+#: ../src/gtk/window.cpp:6318
+msgid ""
+"This program was compiled with a too old version of GTK+, please rebuild "
+"with GTK+ 2.12 or newer."
+msgstr ""
+"Ši programa buvo sukompiliuota su sena GKT+ versija, prašome sukompiliuoti "
+"ją su GTK+ 2.12 arba naujesne versija."
+
+#: ../src/html/chm.cpp:138
+#, c-format
+msgid "Failed to open CHM archive '%s'."
+msgstr ""
+
+#: ../src/html/chm.cpp:270
+#, c-format
+msgid "Could not extract %s into %s: %s"
+msgstr ""
+
+#: ../src/html/chm.cpp:324
+msgid "no error"
+msgstr ""
+
+#: ../src/html/chm.cpp:326
+msgid "bad arguments to library function"
+msgstr ""
+
+#: ../src/html/chm.cpp:328
+msgid "error opening file"
+msgstr ""
+
+#: ../src/html/chm.cpp:330
+msgid "read error"
+msgstr ""
+
+#: ../src/html/chm.cpp:332
+msgid "write error"
+msgstr ""
+
+#: ../src/html/chm.cpp:334
+msgid "seek error"
+msgstr ""
+
+#: ../src/html/chm.cpp:338
+msgid "bad signature"
+msgstr ""
+
+#: ../src/html/chm.cpp:340
+msgid "error in data format"
+msgstr ""
+
+#: ../src/html/chm.cpp:342
+msgid "checksum error"
+msgstr ""
+
+#: ../src/html/chm.cpp:344
+msgid "compression error"
+msgstr ""
+
+#: ../src/html/chm.cpp:346
+msgid "decompression error"
+msgstr "išspaudimo klaida"
+
+#: ../src/html/chm.cpp:437
+#, c-format
+msgid "Could not locate file '%s'."
+msgstr ""
+
+#: ../src/html/chm.cpp:711
+#, c-format
+msgid "Could not create temporary file '%s'"
+msgstr ""
+
+#: ../src/html/chm.cpp:718
+#, c-format
+msgid "Extraction of '%s' into '%s' failed."
+msgstr ""
+
+#: ../src/html/chm.cpp:806 ../src/html/chm.cpp:863
+msgid "CHM handler currently supports only local files!"
+msgstr ""
+
+#: ../src/html/chm.cpp:827
+msgid "Link contained '//', converted to absolute link."
+msgstr ""
+
+#: ../src/html/helpctrl.cpp:59
+#, c-format
+msgid "Help: %s"
+msgstr ""
+
+#: ../src/html/helpctrl.cpp:155
+#, c-format
+msgid "Adding book %s"
+msgstr ""
+
+#: ../src/html/helpdata.cpp:295
+#, c-format
+msgid "Cannot open contents file: %s"
+msgstr ""
+
+#: ../src/html/helpdata.cpp:309
+#, c-format
+msgid "Cannot open index file: %s"
+msgstr ""
+
+#: ../src/html/helpdata.cpp:643
+msgid "noname"
+msgstr ""
+
+#: ../src/html/helpdata.cpp:652
+#, c-format
+msgid "Cannot open HTML help book: %s"
+msgstr ""
+
+#: ../src/html/helpwnd.cpp:315
+msgid "Displays help as you browse the books on the left."
+msgstr ""
+
+#: ../src/html/helpwnd.cpp:411 ../src/html/helpwnd.cpp:1100
+#: ../src/html/helpwnd.cpp:1735
+msgid "(bookmarks)"
+msgstr ""
+
+#: ../src/html/helpwnd.cpp:424
+msgid "Add current page to bookmarks"
+msgstr ""
+
+#: ../src/html/helpwnd.cpp:425
+msgid "Remove current page from bookmarks"
+msgstr ""
+
+#: ../src/html/helpwnd.cpp:470
+msgid "Contents"
+msgstr "Turinys"
+
+#: ../src/html/helpwnd.cpp:485
+msgid "Find"
+msgstr "Rasti"
+
+#: ../src/html/helpwnd.cpp:487
+msgid "Show all"
+msgstr "Rodyti viską"
+
+#: ../src/html/helpwnd.cpp:497
+msgid ""
+"Display all index items that contain given substring. Search is case "
+"insensitive."
+msgstr ""
+
+#: ../src/html/helpwnd.cpp:498
+msgid "Show all items in index"
+msgstr ""
+
+#: ../src/html/helpwnd.cpp:528
+msgid "Case sensitive"
+msgstr ""
+
+#: ../src/html/helpwnd.cpp:529
+msgid "Whole words only"
+msgstr ""
+
+#: ../src/html/helpwnd.cpp:532
+msgid ""
+"Search contents of help book(s) for all occurrences of the text you typed "
+"above"
+msgstr ""
+
+#: ../src/html/helpwnd.cpp:653
+msgid "Show/hide navigation panel"
+msgstr ""
+
+#: ../src/html/helpwnd.cpp:655
+msgid "Go back"
+msgstr "Eiti atgal"
+
+#: ../src/html/helpwnd.cpp:656
+msgid "Go forward"
+msgstr ""
+
+#: ../src/html/helpwnd.cpp:658
+msgid "Go one level up in document hierarchy"
+msgstr ""
+
+#: ../src/html/helpwnd.cpp:666 ../src/html/helpwnd.cpp:1547
+msgid "Open HTML document"
+msgstr ""
+
+#: ../src/html/helpwnd.cpp:670
+msgid "Print this page"
+msgstr ""
+
+#: ../src/html/helpwnd.cpp:674
+msgid "Display options dialog"
+msgstr ""
+
+#: ../src/html/helpwnd.cpp:795
+msgid "Please choose the page to display:"
+msgstr ""
+
+#: ../src/html/helpwnd.cpp:796
+msgid "Help Topics"
+msgstr ""
+
+#: ../src/html/helpwnd.cpp:852
+msgid "Searching..."
+msgstr ""
+
+#: ../src/html/helpwnd.cpp:853
+msgid "No matching page found yet"
+msgstr ""
+
+#: ../src/html/helpwnd.cpp:870
+#, c-format
+msgid "Found %i matches"
+msgstr ""
+
+#: ../src/html/helpwnd.cpp:958
+msgid "(Help)"
+msgstr "Pagalba"
+
+#: ../src/html/helpwnd.cpp:1026
+#, c-format
+msgid "%d of %lu"
+msgstr "%d iš %lu"
+
+#: ../src/html/helpwnd.cpp:1028
+#, c-format
+msgid "%lu of %lu"
+msgstr "%lu iš %lu"
+
+#: ../src/html/helpwnd.cpp:1047
+msgid "Search in all books"
+msgstr ""
+
+#: ../src/html/helpwnd.cpp:1193
+msgid "Help Browser Options"
+msgstr ""
+
+#: ../src/html/helpwnd.cpp:1198
+msgid "Normal font:"
+msgstr ""
+
+#: ../src/html/helpwnd.cpp:1199
+msgid "Fixed font:"
+msgstr ""
+
+#: ../src/html/helpwnd.cpp:1200
+msgid "Font size:"
+msgstr "Šrifto dydis:"
+
+#: ../src/html/helpwnd.cpp:1245
+msgid "font size"
+msgstr "šrifto dydis"
+
+#: ../src/html/helpwnd.cpp:1256
+msgid "Normal face<br>and <u>underlined</u>. "
+msgstr ""
+
+#: ../src/html/helpwnd.cpp:1257
+msgid "<i>Italic face.</i> "
+msgstr ""
+
+#: ../src/html/helpwnd.cpp:1258
+msgid "<b>Bold face.</b> "
+msgstr ""
+
+#: ../src/html/helpwnd.cpp:1259
+msgid "<b><i>Bold italic face.</i></b><br>"
+msgstr ""
+
+#: ../src/html/helpwnd.cpp:1262
+msgid "Fixed size face.<br> <b>bold</b> <i>italic</i> "
+msgstr ""
+
+#: ../src/html/helpwnd.cpp:1263
+msgid "<b><i>bold italic <u>underlined</u></i></b><br>"
+msgstr ""
+
+#: ../src/html/helpwnd.cpp:1524
+msgid "Help Printing"
+msgstr ""
+
+#: ../src/html/helpwnd.cpp:1527
+msgid "Cannot print empty page."
+msgstr ""
+
+#: ../src/html/helpwnd.cpp:1540
+msgid "HTML files (*.html;*.htm)|*.html;*.htm|"
+msgstr ""
+
+#: ../src/html/helpwnd.cpp:1541
+msgid "Help books (*.htb)|*.htb|Help books (*.zip)|*.zip|"
+msgstr ""
+
+#: ../src/html/helpwnd.cpp:1542
+msgid "HTML Help Project (*.hhp)|*.hhp|"
+msgstr ""
+
+#: ../src/html/helpwnd.cpp:1544
+msgid "Compressed HTML Help file (*.chm)|*.chm|"
+msgstr ""
+
+#: ../src/html/helpwnd.cpp:1671
+#, c-format
+msgid "%i of %u"
+msgstr "%i iš %u"
+
+#: ../src/html/helpwnd.cpp:1709
+#, c-format
+msgid "%u of %u"
+msgstr "%u iš %u"
+
+#: ../src/html/htmlfilt.cpp:134
+#, c-format
+msgid "Cannot open HTML document: %s"
+msgstr ""
+
+#: ../src/html/htmlwin.cpp:599
+msgid "Connecting..."
+msgstr ""
+
+#: ../src/html/htmlwin.cpp:616
+#, c-format
+msgid "Unable to open requested HTML document: %s"
+msgstr ""
+
+#: ../src/html/htmlwin.cpp:630
+msgid "Loading : "
+msgstr ""
+
+#: ../src/html/htmlwin.cpp:673
+msgid "Done"
+msgstr "Baigta"
+
+#: ../src/html/htmlwin.cpp:723
+#, c-format
+msgid "HTML anchor %s does not exist."
+msgstr ""
+
+#: ../src/html/htmlwin.cpp:1057
+#, c-format
+msgid "Copied to clipboard:\"%s\""
+msgstr ""
+
+#: ../src/html/htmprint.cpp:269
+msgid ""
+"This document doesn't fit on the page horizontally and will be truncated "
+"when it is printed."
+msgstr ""
+
+#: ../src/html/htmprint.cpp:285
+#, c-format
+msgid ""
+"The document \"%s\" doesn't fit on the page horizontally and will be "
+"truncated if printed.\n"
+"\n"
+"Would you like to proceed with printing it nevertheless?"
+msgstr ""
+
+#: ../src/html/htmprint.cpp:296
+msgid ""
+"If possible, try changing the layout parameters to make the printout more "
+"narrow."
+msgstr ""
+
+#: ../src/html/htmprint.cpp:445
+msgid ": file does not exist!"
+msgstr ""
+
+#. TRANSLATORS: %s may be a document title.
+#: ../src/html/htmprint.cpp:717
+#, fuzzy, c-format
+msgid "%s Preview"
+msgstr " Peržiūra"
+
+#: ../src/html/htmprint.cpp:755 ../src/richtext/richtextprint.cpp:618
+msgid ""
+"There was a problem during page setup: you may need to set a default printer."
+msgstr ""
+
+#: ../src/msw/clipbrd.cpp:80
+msgid "Failed to open the clipboard."
+msgstr ""
+
+#: ../src/msw/clipbrd.cpp:101
+msgid "Failed to close the clipboard."
+msgstr ""
+
+#: ../src/msw/clipbrd.cpp:113
+msgid "Failed to empty the clipboard."
+msgstr ""
+
+#: ../src/msw/clipbrd.cpp:284
+msgid "Failed to put data on the clipboard"
+msgstr ""
+
+#: ../src/msw/clipbrd.cpp:326
+msgid "Failed to get data from the clipboard"
+msgstr ""
+
+#: ../src/msw/clipbrd.cpp:363
+msgid "Failed to retrieve the supported clipboard formats"
+msgstr ""
+
+#: ../src/msw/colordlg.cpp:228
+#, c-format
+msgid "Colour selection dialog failed with error %0lx."
+msgstr ""
+
+#: ../src/msw/cursor.cpp:141
+msgid "Failed to create cursor."
+msgstr ""
+
+#: ../src/msw/dde.cpp:279
+#, c-format
+msgid "Failed to register DDE server '%s'"
+msgstr ""
+
+#: ../src/msw/dde.cpp:300
+#, c-format
+msgid "Failed to unregister DDE server '%s'"
+msgstr ""
+
+#: ../src/msw/dde.cpp:428
+#, c-format
+msgid "Failed to create connection to server '%s' on topic '%s'"
+msgstr ""
+
+#: ../src/msw/dde.cpp:655
+msgid "DDE poke request failed"
+msgstr ""
+
+#: ../src/msw/dde.cpp:674
+msgid "Failed to establish an advise loop with DDE server"
+msgstr ""
+
+#: ../src/msw/dde.cpp:693
+msgid "Failed to terminate the advise loop with DDE server"
+msgstr ""
+
+#: ../src/msw/dde.cpp:768
+msgid "Failed to send DDE advise notification"
+msgstr ""
+
+#: ../src/msw/dde.cpp:1085
+msgid "Failed to create DDE string"
+msgstr ""
+
+#: ../src/msw/dde.cpp:1131
+msgid "no DDE error."
+msgstr ""
+
+#: ../src/msw/dde.cpp:1135
+msgid "a request for a synchronous advise transaction has timed out."
+msgstr ""
+
+#: ../src/msw/dde.cpp:1138
+msgid "the response to the transaction caused the DDE_FBUSY bit to be set."
+msgstr ""
+
+#: ../src/msw/dde.cpp:1141
+msgid "a request for a synchronous data transaction has timed out."
+msgstr ""
+
+#: ../src/msw/dde.cpp:1144
+msgid ""
+"a DDEML function was called without first calling the DdeInitialize "
+"function,\n"
+"or an invalid instance identifier\n"
+"was passed to a DDEML function."
+msgstr ""
+
+#: ../src/msw/dde.cpp:1147
+msgid ""
+"an application initialized as APPCLASS_MONITOR has\n"
+"attempted to perform a DDE transaction,\n"
+"or an application initialized as APPCMD_CLIENTONLY has \n"
+"attempted to perform server transactions."
+msgstr ""
+
+#: ../src/msw/dde.cpp:1150
+msgid "a request for a synchronous execute transaction has timed out."
+msgstr ""
+
+#: ../src/msw/dde.cpp:1153
+msgid "a parameter failed to be validated by the DDEML."
+msgstr ""
+
+#: ../src/msw/dde.cpp:1156
+msgid "a DDEML application has created a prolonged race condition."
+msgstr ""
+
+#: ../src/msw/dde.cpp:1159
+msgid "a memory allocation failed."
+msgstr ""
+
+#: ../src/msw/dde.cpp:1162
+msgid "a client's attempt to establish a conversation has failed."
+msgstr ""
+
+#: ../src/msw/dde.cpp:1165
+msgid "a transaction failed."
+msgstr ""
+
+#: ../src/msw/dde.cpp:1168
+msgid "a request for a synchronous poke transaction has timed out."
+msgstr ""
+
+#: ../src/msw/dde.cpp:1171
+msgid "an internal call to the PostMessage function has failed. "
+msgstr ""
+
+#: ../src/msw/dde.cpp:1174
+msgid "reentrancy problem."
+msgstr ""
+
+#: ../src/msw/dde.cpp:1177
+msgid ""
+"a server-side transaction was attempted on a conversation\n"
+"that was terminated by the client, or the server\n"
+"terminated before completing a transaction."
+msgstr ""
+
+#: ../src/msw/dde.cpp:1180
+msgid "an internal error has occurred in the DDEML."
+msgstr ""
+
+#: ../src/msw/dde.cpp:1183
+msgid "a request to end an advise transaction has timed out."
+msgstr ""
+
+#: ../src/msw/dde.cpp:1186
+msgid ""
+"an invalid transaction identifier was passed to a DDEML function.\n"
+"Once the application has returned from an XTYP_XACT_COMPLETE callback,\n"
+"the transaction identifier for that callback is no longer valid."
+msgstr ""
+
+#: ../src/msw/dde.cpp:1189
+#, c-format
+msgid "Unknown DDE error %08x"
+msgstr ""
+
+#: ../src/msw/dialup.cpp:343
+msgid ""
+"Dial up functions are unavailable because the remote access service (RAS) is "
+"not installed on this machine. Please install it."
+msgstr ""
+
+#: ../src/msw/dialup.cpp:402
+#, c-format
+msgid ""
+"The version of remote access service (RAS) installed on this machine is too "
+"old, please upgrade (the following required function is missing: %s)."
+msgstr ""
+
+#: ../src/msw/dialup.cpp:437
+msgid "Failed to retrieve text of RAS error message"
+msgstr ""
+
+#: ../src/msw/dialup.cpp:440
+#, c-format
+msgid "unknown error (error code %08x)."
+msgstr ""
+
+#: ../src/msw/dialup.cpp:492
+#, c-format
+msgid "Cannot find active dialup connection: %s"
+msgstr ""
+
+#: ../src/msw/dialup.cpp:513
+msgid "Several active dialup connections found, choosing one randomly."
+msgstr ""
+
+#: ../src/msw/dialup.cpp:598 ../src/msw/dialup.cpp:832
+#, c-format
+msgid "Failed to establish dialup connection: %s"
+msgstr ""
+
+#: ../src/msw/dialup.cpp:664
+#, c-format
+msgid "Failed to get ISP names: %s"
+msgstr ""
+
+#: ../src/msw/dialup.cpp:712
+msgid "Failed to connect: no ISP to dial."
+msgstr ""
+
+#: ../src/msw/dialup.cpp:732
+msgid "Choose ISP to dial"
+msgstr ""
+
+#: ../src/msw/dialup.cpp:733
+msgid "Please choose which ISP do you want to connect to"
+msgstr ""
+
+#: ../src/msw/dialup.cpp:766
+msgid "Failed to connect: missing username/password."
+msgstr ""
+
+#: ../src/msw/dialup.cpp:796
+msgid "Cannot find the location of address book file"
+msgstr ""
+
+#: ../src/msw/dialup.cpp:827
+#, c-format
+msgid "Failed to initiate dialup connection: %s"
+msgstr ""
+
+#: ../src/msw/dialup.cpp:897
+msgid "Cannot hang up - no active dialup connection."
+msgstr ""
+
+#: ../src/msw/dialup.cpp:907
+#, c-format
+msgid "Failed to terminate the dialup connection: %s"
+msgstr ""
+
+#: ../src/msw/dib.cpp:313
+#, c-format
+msgid "Failed to save the bitmap image to file \"%s\"."
+msgstr ""
+
+#: ../src/msw/dib.cpp:543
+#, c-format
+msgid "Failed to allocate %luKb of memory for bitmap data."
+msgstr ""
+
+#: ../src/msw/dir.cpp:241
+#, c-format
+msgid "Cannot enumerate files in directory '%s'"
+msgstr ""
+
+#: ../src/msw/dirdlg.cpp:368
+msgid "Couldn't obtain folder name"
+msgstr "Nepavyko gauti aplanko pavadinimo"
+
+#: ../src/msw/dlmsw.cpp:163
+#, c-format
+msgid "(error %d: %s)"
+msgstr ""
+
+#: ../src/msw/dragimag.cpp:143 ../src/msw/dragimag.cpp:178
+#: ../src/msw/imaglist.cpp:309 ../src/msw/imaglist.cpp:331
+msgid "Couldn't add an image to the image list."
+msgstr ""
+
+#: ../src/msw/enhmeta.cpp:94
+#, c-format
+msgid "Failed to load metafile from file \"%s\"."
+msgstr ""
+
+#: ../src/msw/fdrepdlg.cpp:412
+#, c-format
+msgid "Failed to create the standard find/replace dialog (error code %d)"
+msgstr ""
+
+#: ../src/msw/filedlg.cpp:1241
+msgid "Access to the file system is not allowed from secure desktop."
+msgstr ""
+
+#: ../src/msw/filedlg.cpp:1242
+msgid "Security warning"
+msgstr ""
+
+#: ../src/msw/filedlg.cpp:1533
+#, c-format
+msgid "File dialog failed with error code %0lx."
+msgstr ""
+
+#: ../src/msw/font.cpp:1120
+#, c-format
+msgid "Font file \"%s\" couldn't be loaded"
+msgstr ""
+
+#: ../src/msw/fontdlg.cpp:220
+#, c-format
+msgid "Common dialog failed with error code %0lx."
+msgstr ""
+
+#: ../src/msw/fswatcher.cpp:67
+msgid "Ungraceful worker thread termination"
+msgstr ""
+
+#: ../src/msw/fswatcher.cpp:81
+msgid "Unable to create IOCP worker thread"
+msgstr ""
+
+#: ../src/msw/fswatcher.cpp:88
+msgid "Unable to start IOCP worker thread"
+msgstr ""
+
+#: ../src/msw/fswatcher.cpp:140
+msgid "Monitoring individual files for changes is not supported currently."
+msgstr ""
+
+#: ../src/msw/fswatcher.cpp:165
+#, c-format
+msgid "Unable to set up watch for '%s'"
+msgstr ""
+
+#: ../src/msw/fswatcher.cpp:466
+#, c-format
+msgid "Can't monitor non-existent directory \"%s\" for changes."
+msgstr ""
+
+#: ../src/msw/glcanvas.cpp:577 ../src/unix/glx11.cpp:507
+msgid "OpenGL 3.0 or later is not supported by the OpenGL driver."
+msgstr ""
+
+#: ../src/msw/glcanvas.cpp:601 ../src/osx/glcanvas_osx.cpp:395
+#: ../src/unix/glegl.cpp:304 ../src/unix/glx11.cpp:553
+msgid "Couldn't create OpenGL context"
+msgstr ""
+
+#: ../src/msw/glcanvas.cpp:1294
+msgid "Failed to initialize OpenGL"
+msgstr ""
+
+#: ../src/msw/graphicsd2d.cpp:607
+msgid "Could not register custom DirectWrite font loader."
+msgstr ""
+
+#: ../src/msw/helpchm.cpp:48
+msgid ""
+"MS HTML Help functions are unavailable because the MS HTML Help library is "
+"not installed on this machine. Please install it."
+msgstr ""
+
+#: ../src/msw/helpchm.cpp:55
+msgid "Failed to initialize MS HTML Help."
+msgstr ""
+
+#: ../src/msw/iniconf.cpp:458
+#, c-format
+msgid "Can't delete the INI file '%s'"
+msgstr ""
+
+#: ../src/msw/listctrl.cpp:995
+#, c-format
+msgid "Couldn't retrieve information about list control item %d."
+msgstr ""
+
+#: ../src/msw/mdi.cpp:170 ../src/qt/mdi.cpp:253
+msgid "&Cascade"
+msgstr ""
+
+#: ../src/msw/mdi.cpp:171
+msgid "Tile &Horizontally"
+msgstr "Išdėstyti &horizontaliai"
+
+#: ../src/msw/mdi.cpp:172
+msgid "Tile &Vertically"
+msgstr "Išdėstyti &vertikaliai"
+
+#: ../src/msw/mdi.cpp:174
+msgid "&Arrange Icons"
+msgstr ""
+
+#: ../src/msw/mdi.cpp:621
+msgid "Failed to create MDI parent frame."
+msgstr ""
+
+#: ../src/msw/mimetype.cpp:234
+#, c-format
+msgid "Failed to create registry entry for '%s' files."
+msgstr ""
+
+#: ../src/msw/ole/automtn.cpp:495
+#, c-format
+msgid "Failed to find CLSID of \"%s\""
+msgstr ""
+
+#: ../src/msw/ole/automtn.cpp:512
+#, c-format
+msgid "Failed to create an instance of \"%s\""
+msgstr ""
+
+#: ../src/msw/ole/automtn.cpp:552
+#, c-format
+msgid "Cannot get an active instance of \"%s\""
+msgstr ""
+
+#: ../src/msw/ole/automtn.cpp:564
+#, c-format
+msgid "Failed to get OLE automation interface for \"%s\""
+msgstr ""
+
+#: ../src/msw/ole/automtn.cpp:621
+msgid "Unknown name or named argument."
+msgstr ""
+
+#: ../src/msw/ole/automtn.cpp:625
+msgid "Incorrect number of arguments."
+msgstr ""
+
+#: ../src/msw/ole/automtn.cpp:637
+msgid "Unknown exception"
+msgstr ""
+
+#: ../src/msw/ole/automtn.cpp:642
+msgid "Method or property not found."
+msgstr ""
+
+#: ../src/msw/ole/automtn.cpp:646
+msgid "Overflow while coercing argument values."
+msgstr ""
+
+#: ../src/msw/ole/automtn.cpp:650
+msgid "Object implementation does not support named arguments."
+msgstr ""
+
+#: ../src/msw/ole/automtn.cpp:654
+msgid "The locale ID is unknown."
+msgstr ""
+
+#: ../src/msw/ole/automtn.cpp:658
+msgid "Missing a required parameter."
+msgstr ""
+
+#: ../src/msw/ole/automtn.cpp:662
+#, c-format
+msgid "Argument %u not found."
+msgstr ""
+
+#: ../src/msw/ole/automtn.cpp:666
+#, c-format
+msgid "Type mismatch in argument %u."
+msgstr ""
+
+#: ../src/msw/ole/automtn.cpp:670
+msgid "The system cannot find the file specified."
+msgstr ""
+
+#: ../src/msw/ole/automtn.cpp:674
+msgid "Class not registered."
+msgstr ""
+
+#: ../src/msw/ole/automtn.cpp:678
+#, c-format
+msgid "Unknown error %08x"
+msgstr ""
+
+#: ../src/msw/ole/automtn.cpp:682
+#, c-format
+msgid "OLE Automation error in %s: %s"
+msgstr ""
+
+#: ../src/msw/ole/dataobj.cpp:385
+#, c-format
+msgid "Couldn't register clipboard format '%s'."
+msgstr ""
+
+#: ../src/msw/ole/dataobj.cpp:402
+#, c-format
+msgid "The clipboard format '%d' doesn't exist."
+msgstr ""
+
+#: ../src/msw/progdlg.cpp:1025
+msgid "Skip"
+msgstr "Praleisti"
+
+#: ../src/msw/registry.cpp:141
+#, c-format
+msgid "unknown (%lu)"
+msgstr ""
+
+#: ../src/msw/registry.cpp:409
+#, c-format
+msgid "Can't get info about registry key '%s'"
+msgstr ""
+
+#: ../src/msw/registry.cpp:445
+#, c-format
+msgid "Can't open registry key '%s'"
+msgstr ""
+
+#: ../src/msw/registry.cpp:478
+#, c-format
+msgid "Can't create registry key '%s'"
+msgstr ""
+
+#: ../src/msw/registry.cpp:497
+#, c-format
+msgid "Can't close registry key '%s'"
+msgstr ""
+
+#: ../src/msw/registry.cpp:512
+#, c-format
+msgid "Registry value '%s' already exists."
+msgstr ""
+
+#: ../src/msw/registry.cpp:520
+#, c-format
+msgid "Failed to rename registry value '%s' to '%s'."
+msgstr ""
+
+#: ../src/msw/registry.cpp:575
+#, c-format
+msgid "Can't copy values of unsupported type %d."
+msgstr ""
+
+#: ../src/msw/registry.cpp:586
+#, c-format
+msgid "Registry key '%s' does not exist, cannot rename it."
+msgstr ""
+
+#: ../src/msw/registry.cpp:617
+#, c-format
+msgid "Registry key '%s' already exists."
+msgstr ""
+
+#: ../src/msw/registry.cpp:625
+#, c-format
+msgid "Failed to rename the registry key '%s' to '%s'."
+msgstr ""
+
+#: ../src/msw/registry.cpp:670
+#, c-format
+msgid "Failed to copy the registry subkey '%s' to '%s'."
+msgstr ""
+
+#: ../src/msw/registry.cpp:683
+#, c-format
+msgid "Failed to copy registry value '%s'"
+msgstr ""
+
+#: ../src/msw/registry.cpp:692
+#, c-format
+msgid "Failed to copy the contents of registry key '%s' to '%s'."
+msgstr ""
+
+#: ../src/msw/registry.cpp:718
+#, c-format
+msgid ""
+"Registry key '%s' is needed for normal system operation,\n"
+"deleting it will leave your system in unusable state:\n"
+"operation aborted."
+msgstr ""
+
+#: ../src/msw/registry.cpp:754
+#, c-format
+msgid "Can't delete key '%s'"
+msgstr ""
+
+#: ../src/msw/registry.cpp:782
+#, c-format
+msgid "Can't delete value '%s' from key '%s'"
+msgstr ""
+
+#: ../src/msw/registry.cpp:855 ../src/msw/registry.cpp:887
+#: ../src/msw/registry.cpp:929 ../src/msw/registry.cpp:1000
+#, c-format
+msgid "Can't read value of key '%s'"
+msgstr ""
+
+#: ../src/msw/registry.cpp:873 ../src/msw/registry.cpp:915
+#: ../src/msw/registry.cpp:963 ../src/msw/registry.cpp:1106
+#, c-format
+msgid "Can't set value of '%s'"
+msgstr ""
+
+#: ../src/msw/registry.cpp:894 ../src/msw/registry.cpp:943
+#, c-format
+msgid "Registry value \"%s\" is not numeric (but of type %s)"
+msgstr ""
+
+#: ../src/msw/registry.cpp:979
+#, c-format
+msgid "Registry value \"%s\" is not binary (but of type %s)"
+msgstr ""
+
+#: ../src/msw/registry.cpp:1028
+#, c-format
+msgid "Registry value \"%s\" is not text (but of type %s)"
+msgstr ""
+
+#: ../src/msw/registry.cpp:1089
+#, c-format
+msgid "Can't read value of '%s'"
+msgstr ""
+
+#: ../src/msw/registry.cpp:1157
+#, c-format
+msgid "Can't enumerate values of key '%s'"
+msgstr ""
+
+#: ../src/msw/registry.cpp:1196
+#, c-format
+msgid "Can't enumerate subkeys of key '%s'"
+msgstr ""
+
+#: ../src/msw/registry.cpp:1262
+#, c-format
+msgid ""
+"Exporting registry key: file \"%s\" already exists and won't be overwritten."
+msgstr ""
+
+#: ../src/msw/registry.cpp:1411
+#, c-format
+msgid "Can't export value of unsupported type %d."
+msgstr ""
+
+#: ../src/msw/registry.cpp:1427
+#, c-format
+msgid "Ignoring value \"%s\" of the key \"%s\"."
+msgstr ""
+
+#: ../src/msw/textctrl.cpp:596
+msgid ""
+"Impossible to create a rich edit control, using simple text control instead. "
+"Please reinstall riched32.dll"
+msgstr ""
+
+#: ../src/msw/thread.cpp:522 ../src/unix/threadpsx.cpp:850
+msgid "Cannot start thread: error writing TLS."
+msgstr ""
+
+#: ../src/msw/thread.cpp:613
+msgid "Can't set thread priority"
+msgstr ""
+
+#: ../src/msw/thread.cpp:649
+msgid "Can't create thread"
+msgstr ""
+
+#: ../src/msw/thread.cpp:668
+msgid "Couldn't terminate thread"
+msgstr ""
+
+#: ../src/msw/thread.cpp:799
+msgid "Cannot wait for thread termination"
+msgstr ""
+
+#: ../src/msw/thread.cpp:873
+#, c-format
+msgid "Cannot suspend thread %lx"
+msgstr ""
+
+#: ../src/msw/thread.cpp:903
+#, c-format
+msgid "Cannot resume thread %lx"
+msgstr ""
+
+#: ../src/msw/thread.cpp:932
+msgid "Couldn't get the current thread pointer"
+msgstr ""
+
+#: ../src/msw/thread.cpp:1333
+msgid ""
+"Thread module initialization failed: impossible to allocate index in thread "
+"local storage"
+msgstr ""
+
+#: ../src/msw/thread.cpp:1345
+msgid ""
+"Thread module initialization failed: cannot store value in thread local "
+"storage"
+msgstr ""
+
+#: ../src/msw/timer.cpp:133
+msgid "Couldn't create a timer"
+msgstr ""
+
+#: ../src/msw/utils.cpp:372
+msgid "can't find user's HOME, using current directory."
+msgstr ""
+
+#: ../src/msw/utils.cpp:662
+#, c-format
+msgid "Failed to kill process %d"
+msgstr ""
+
+#: ../src/msw/utils.cpp:986
+#, c-format
+msgid "Failed to load resource \"%s\"."
+msgstr ""
+
+#: ../src/msw/utils.cpp:993
+#, c-format
+msgid "Failed to lock resource \"%s\"."
+msgstr ""
+
+#. TRANSLATORS: MS Windows build number
+#: ../src/msw/utils.cpp:1209
+#, c-format
+msgid "build %lu"
+msgstr ""
+
+#: ../src/msw/utils.cpp:1218
+msgid ", 64-bit edition"
+msgstr ", 64-bit laida"
+
+#: ../src/msw/utilsexc.cpp:224
+msgid "Failed to create an anonymous pipe"
+msgstr ""
+
+#: ../src/msw/utilsexc.cpp:697
+msgid "Failed to redirect the child process IO"
+msgstr ""
+
+#: ../src/msw/utilsexc.cpp:870
+#, c-format
+msgid "Execution of command '%s' failed"
+msgstr ""
+
+#: ../src/msw/volume.cpp:337
+msgid "Failed to load mpr.dll."
+msgstr ""
+
+#: ../src/msw/volume.cpp:506
+#, c-format
+msgid "Cannot read typename from '%s'!"
+msgstr ""
+
+#: ../src/msw/volume.cpp:615
+#, c-format
+msgid "Cannot load icon from '%s'."
+msgstr ""
+
+#: ../src/msw/webview_edge.cpp:285
+msgid "This program was compiled without support for setting Edge proxy."
+msgstr ""
+
+#: ../src/msw/webview_ie.cpp:1010
+msgid "Failed to find web view emulation level in the registry"
+msgstr ""
+
+#: ../src/msw/webview_ie.cpp:1019
+msgid "Failed to set web view to modern emulation level"
+msgstr ""
+
+#: ../src/msw/webview_ie.cpp:1027
+msgid "Failed to reset web view to standard emulation level"
+msgstr ""
+
+#: ../src/msw/webview_ie.cpp:1049
+msgid "Can't run JavaScript script without a valid HTML document"
+msgstr ""
+
+#: ../src/msw/webview_ie.cpp:1056
+msgid "Can't get the JavaScript object"
+msgstr ""
+
+#: ../src/msw/webview_ie.cpp:1070
+msgid "failed to evaluate"
+msgstr ""
+
+#: ../src/osx/cocoa/filedlg.mm:412
+msgid "File type:"
+msgstr ""
+
+#: ../src/osx/cocoa/menu.mm:242
+#, fuzzy
+msgctxt "macOS menu name"
+msgid "Window"
+msgstr "&Langas"
+
+#: ../src/osx/cocoa/menu.mm:259
+#, fuzzy
+msgctxt "macOS menu name"
+msgid "Help"
+msgstr "Pagalba"
+
+#: ../src/osx/cocoa/menu.mm:298
+msgctxt "macOS menu item"
+msgid "Minimize"
+msgstr ""
+
+#: ../src/osx/cocoa/menu.mm:303
+#, fuzzy
+msgctxt "macOS menu item"
+msgid "Zoom"
+msgstr "Didinti"
+
+#: ../src/osx/cocoa/menu.mm:309
+msgctxt "macOS menu item"
+msgid "Bring All to Front"
+msgstr ""
+
+#: ../src/osx/core/sound.cpp:143
+#, c-format
+msgid "Failed to load sound from \"%s\" (error %d)."
+msgstr ""
+
+#: ../src/osx/fontutil.cpp:80
+#, c-format
+msgid "Font file \"%s\" doesn't exist."
+msgstr ""
+
+#: ../src/osx/fontutil.cpp:88
+#, c-format
+msgid ""
+"Font file \"%s\" cannot be used as it is not inside the font directory "
+"\"%s\"."
+msgstr ""
+
+#: ../src/osx/menu_osx.cpp:496
+#, c-format
+msgctxt "macOS menu item"
+msgid "About %s"
+msgstr "Apie %s"
+
+#: ../src/osx/menu_osx.cpp:499
+msgctxt "macOS menu item"
+msgid "About..."
+msgstr "Apie..."
+
+#: ../src/osx/menu_osx.cpp:508
+msgctxt "macOS menu item"
+msgid "Preferences..."
+msgstr ""
+
+#: ../src/osx/menu_osx.cpp:512
+msgctxt "macOS menu item"
+msgid "Services"
+msgstr "Tarnybos"
+
+#: ../src/osx/menu_osx.cpp:519
+#, c-format
+msgctxt "macOS menu item"
+msgid "Hide %s"
+msgstr "Slėpti %s"
+
+#: ../src/osx/menu_osx.cpp:522
+#, fuzzy
+msgctxt "macOS menu item"
+msgid "Hide Application"
+msgstr "Objektų parinktis"
+
+#: ../src/osx/menu_osx.cpp:526
+msgctxt "macOS menu item"
+msgid "Hide Others"
+msgstr "Slėpti kitus"
+
+#: ../src/osx/menu_osx.cpp:528
+msgctxt "macOS menu item"
+msgid "Show All"
+msgstr "Rodyti viską"
+
+#: ../src/osx/menu_osx.cpp:534
+#, c-format
+msgctxt "macOS menu item"
+msgid "Quit %s"
+msgstr "Išeiti %s"
+
+#: ../src/osx/menu_osx.cpp:537
+#, fuzzy
+msgctxt "macOS menu item"
+msgid "Quit Application"
+msgstr "Objektų parinktis"
+
+#: ../src/osx/webview_webkit.mm:444
+msgid "Printing is not supported by the system web control"
+msgstr ""
+
+#: ../src/osx/webview_webkit.mm:453
+msgid "Print operation could not be initialized"
+msgstr ""
+
+#. TRANSLATORS: Label of font point size
+#: ../src/propgrid/advprops.cpp:605
+msgid "Point Size"
+msgstr ""
+
+#. TRANSLATORS: Label of font face name
+#: ../src/propgrid/advprops.cpp:615
+msgid "Face Name"
+msgstr ""
+
+#. TRANSLATORS: Label of font style
+#: ../src/propgrid/advprops.cpp:623 ../src/richtext/richtextformatdlg.cpp:331
+msgid "Style"
+msgstr "Stilius"
+
+#. TRANSLATORS: Label of font weight
+#: ../src/propgrid/advprops.cpp:628
+msgid "Weight"
+msgstr "Storis"
+
+#. TRANSLATORS: Label of underlined font
+#: ../src/propgrid/advprops.cpp:633 ../src/richtext/richtextfontpage.cpp:358
+msgid "Underlined"
+msgstr ""
+
+#. TRANSLATORS: Label of font family
+#: ../src/propgrid/advprops.cpp:637
+msgid "Family"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:801
+msgid "AppWorkspace"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:802
+msgid "ActiveBorder"
+msgstr "Rėmelis"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:803
+msgid "ActiveCaption"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:804
+msgid "ButtonFace"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:805
+msgid "ButtonHighlight"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:806
+msgid "ButtonShadow"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:807
+msgid "ButtonText"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:808
+msgid "CaptionText"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:809
+msgid "ControlDark"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:810
+msgid "ControlLight"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:812
+msgid "GrayText"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:813
+msgid "Highlight"
+msgstr "&Aukštis"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:814
+msgid "HighlightText"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:815
+msgid "InactiveBorder"
+msgstr "Rėmelis"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:816
+msgid "InactiveCaption"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:817
+msgid "InactiveCaptionText"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:818
+msgid "Menu"
+msgstr "Meniu"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:819
+msgid "Scrollbar"
+msgstr "Slinkties juosta"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:820
+msgid "Tooltip"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:821
+msgid "TooltipText"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:822
+msgid "Window"
+msgstr "&Langas"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:823
+msgid "WindowFrame"
+msgstr "&Langas"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:824
+msgid "WindowText"
+msgstr "&Langas"
+
+#. TRANSLATORS: Custom colour choice entry
+#: ../src/propgrid/advprops.cpp:825 ../src/propgrid/advprops.cpp:1532
+#: ../src/propgrid/advprops.cpp:1576
+msgid "Custom"
+msgstr "&Pritaikyti"
+
+#: ../src/propgrid/advprops.cpp:1558
+msgid "Black"
+msgstr "Juoda"
+
+#: ../src/propgrid/advprops.cpp:1559
+msgid "Maroon"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1560
+msgid "Navy"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1561
+msgid "Purple"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1562
+msgid "Teal"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1563
+msgid "Gray"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1564
+msgid "Green"
+msgstr "Žalia"
+
+#: ../src/propgrid/advprops.cpp:1565
+msgid "Olive"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1566
+msgid "Brown"
+msgstr "Naršyti"
+
+#: ../src/propgrid/advprops.cpp:1567
+msgid "Blue"
+msgstr "Mėlyna"
+
+#: ../src/propgrid/advprops.cpp:1568
+msgid "Fuchsia"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1569
+msgid "Red"
+msgstr "Raudonas"
+
+#: ../src/propgrid/advprops.cpp:1570
+msgid "Orange"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1571
+msgid "Silver"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1572
+msgid "Lime"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1573
+msgid "Aqua"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1574
+msgid "Yellow"
+msgstr "Geltona"
+
+#: ../src/propgrid/advprops.cpp:1575
+msgid "White"
+msgstr "Balta"
+
+#: ../src/propgrid/advprops.cpp:1718
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Default"
+msgstr "Numatytasis"
+
+#: ../src/propgrid/advprops.cpp:1719
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Arrow"
+msgstr "Rodyklė"
+
+#: ../src/propgrid/advprops.cpp:1720
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Right Arrow"
+msgstr "Dešinė"
+
+#: ../src/propgrid/advprops.cpp:1721
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Blank"
+msgstr "Tuščia"
+
+#: ../src/propgrid/advprops.cpp:1722
+msgctxt "system cursor name"
+msgid "Bullseye"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1723
+msgctxt "system cursor name"
+msgid "Character"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1724
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Cross"
+msgstr "Kirsti"
+
+#: ../src/propgrid/advprops.cpp:1725
+msgctxt "system cursor name"
+msgid "Hand"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1726
+msgctxt "system cursor name"
+msgid "I-Beam"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1727
+msgctxt "system cursor name"
+msgid "Left Button"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1728
+msgctxt "system cursor name"
+msgid "Magnifier"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1729
+msgctxt "system cursor name"
+msgid "Middle Button"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1730
+msgctxt "system cursor name"
+msgid "No Entry"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1731
+msgctxt "system cursor name"
+msgid "Paint Brush"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1732
+msgctxt "system cursor name"
+msgid "Pencil"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1733
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Point Left"
+msgstr "&Aukštis"
+
+#: ../src/propgrid/advprops.cpp:1734
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Point Right"
+msgstr "&Aukštis"
+
+#: ../src/propgrid/advprops.cpp:1735
+msgctxt "system cursor name"
+msgid "Question Arrow"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1736
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Right Button"
+msgstr "Dešinė"
+
+#: ../src/propgrid/advprops.cpp:1737
+msgctxt "system cursor name"
+msgid "Sizing NE-SW"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1738
+msgctxt "system cursor name"
+msgid "Sizing N-S"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1739
+msgctxt "system cursor name"
+msgid "Sizing NW-SE"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1740
+msgctxt "system cursor name"
+msgid "Sizing W-E"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1741
+msgctxt "system cursor name"
+msgid "Sizing"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1742
+msgctxt "system cursor name"
+msgid "Spraycan"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1743
+msgctxt "system cursor name"
+msgid "Wait"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1744
+msgctxt "system cursor name"
+msgid "Watch"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1745
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Wait Arrow"
+msgstr "Dešinė"
+
+#: ../src/propgrid/advprops.cpp:2109
+msgid "Make a selection:"
+msgstr ""
+
+#: ../src/propgrid/manager.cpp:394
+msgid "Property"
+msgstr "Savybė"
+
+#: ../src/propgrid/manager.cpp:395
+msgid "Value"
+msgstr "Reikšmė"
+
+#: ../src/propgrid/manager.cpp:1683
+msgid "Categorized Mode"
+msgstr ""
+
+#: ../src/propgrid/manager.cpp:1709
+msgid "Alphabetic Mode"
+msgstr ""
+
+#. TRANSLATORS: Name of Boolean false value
+#: ../src/propgrid/propgrid.cpp:230
+msgid "False"
+msgstr "Klaidingas"
+
+#. TRANSLATORS: Name of Boolean true value
+#: ../src/propgrid/propgrid.cpp:232
+msgid "True"
+msgstr "Teisingas"
+
+#. TRANSLATORS: Text  displayed for unspecified value
+#: ../src/propgrid/propgrid.cpp:428
+msgid "Unspecified"
+msgstr ""
+
+#. TRANSLATORS: Caption of message box displaying any property error
+#: ../src/propgrid/propgrid.cpp:3145 ../src/propgrid/propgrid.cpp:3282
+msgid "Property Error"
+msgstr ""
+
+#: ../src/propgrid/propgrid.cpp:3259
+msgid "You have entered invalid value. Press ESC to cancel editing."
+msgstr ""
+
+#: ../src/propgrid/propgrid.cpp:6608
+#, c-format
+msgid "Error in resource: %s"
+msgstr ""
+
+#: ../src/propgrid/propgridiface.cpp:377
+#, c-format
+msgid ""
+"Type operation \"%s\" failed: Property labeled \"%s\" is of type \"%s\", NOT "
+"\"%s\"."
+msgstr ""
+
+#: ../src/propgrid/props.cpp:159
+#, c-format
+msgid "Unknown base %d. Base 10 will be used."
+msgstr ""
+
+#: ../src/propgrid/props.cpp:324
+#, c-format
+msgid "Value must be %s or higher."
+msgstr ""
+
+#: ../src/propgrid/props.cpp:329 ../src/propgrid/props.cpp:356
+#, c-format
+msgid "Value must be between %s and %s."
+msgstr ""
+
+#: ../src/propgrid/props.cpp:351
+#, c-format
+msgid "Value must be %s or less."
+msgstr ""
+
+#: ../src/propgrid/props.cpp:1058
+#, c-format
+msgid "Not %s"
+msgstr ""
+
+#: ../src/propgrid/props.cpp:1770
+msgid "Choose a directory:"
+msgstr ""
+
+#: ../src/propgrid/props.cpp:2055
+msgid "Choose a file"
+msgstr "Parinkti failą"
+
+#: ../src/qt/mdi.cpp:254
+msgid "&Tile"
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:147
+#: ../src/richtext/richtextformatdlg.cpp:376
+msgid "Background"
+msgstr "Fonas"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:159
+msgid "Background &colour:"
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:161
+#: ../src/richtext/richtextbackgroundpage.cpp:163
+msgid "Enables a background colour."
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:167
+#: ../src/richtext/richtextbackgroundpage.cpp:169
+msgid "The background colour."
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:178
+msgid "Shadow"
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:193
+msgid "Use &shadow"
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:195
+#: ../src/richtext/richtextbackgroundpage.cpp:197
+msgid "Enables a shadow."
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:211
+msgid "&Horizontal offset:"
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:218
+#: ../src/richtext/richtextbackgroundpage.cpp:220
+msgid "The horizontal offset."
+msgstr "Išdėstyti &horizontaliai."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:224
+#: ../src/richtext/richtextbackgroundpage.cpp:227
+#: ../src/richtext/richtextbackgroundpage.cpp:228
+#: ../src/richtext/richtextbackgroundpage.cpp:247
+#: ../src/richtext/richtextbackgroundpage.cpp:250
+#: ../src/richtext/richtextbackgroundpage.cpp:251
+#: ../src/richtext/richtextbackgroundpage.cpp:287
+#: ../src/richtext/richtextbackgroundpage.cpp:290
+#: ../src/richtext/richtextbackgroundpage.cpp:291
+#: ../src/richtext/richtextbackgroundpage.cpp:314
+#: ../src/richtext/richtextbackgroundpage.cpp:317
+#: ../src/richtext/richtextbackgroundpage.cpp:318
+#: ../src/richtext/richtextborderspage.cpp:252
+#: ../src/richtext/richtextborderspage.cpp:255
+#: ../src/richtext/richtextborderspage.cpp:256
+#: ../src/richtext/richtextborderspage.cpp:286
+#: ../src/richtext/richtextborderspage.cpp:289
+#: ../src/richtext/richtextborderspage.cpp:290
+#: ../src/richtext/richtextborderspage.cpp:320
+#: ../src/richtext/richtextborderspage.cpp:323
+#: ../src/richtext/richtextborderspage.cpp:324
+#: ../src/richtext/richtextborderspage.cpp:354
+#: ../src/richtext/richtextborderspage.cpp:357
+#: ../src/richtext/richtextborderspage.cpp:358
+#: ../src/richtext/richtextborderspage.cpp:420
+#: ../src/richtext/richtextborderspage.cpp:423
+#: ../src/richtext/richtextborderspage.cpp:424
+#: ../src/richtext/richtextborderspage.cpp:454
+#: ../src/richtext/richtextborderspage.cpp:457
+#: ../src/richtext/richtextborderspage.cpp:458
+#: ../src/richtext/richtextborderspage.cpp:488
+#: ../src/richtext/richtextborderspage.cpp:491
+#: ../src/richtext/richtextborderspage.cpp:492
+#: ../src/richtext/richtextborderspage.cpp:522
+#: ../src/richtext/richtextborderspage.cpp:525
+#: ../src/richtext/richtextborderspage.cpp:526
+#: ../src/richtext/richtextborderspage.cpp:590
+#: ../src/richtext/richtextborderspage.cpp:593
+#: ../src/richtext/richtextborderspage.cpp:594
+#: ../src/richtext/richtextfontpage.cpp:177
+#: ../src/richtext/richtextmarginspage.cpp:199
+#: ../src/richtext/richtextmarginspage.cpp:201
+#: ../src/richtext/richtextmarginspage.cpp:202
+#: ../src/richtext/richtextmarginspage.cpp:224
+#: ../src/richtext/richtextmarginspage.cpp:226
+#: ../src/richtext/richtextmarginspage.cpp:227
+#: ../src/richtext/richtextmarginspage.cpp:247
+#: ../src/richtext/richtextmarginspage.cpp:249
+#: ../src/richtext/richtextmarginspage.cpp:250
+#: ../src/richtext/richtextmarginspage.cpp:272
+#: ../src/richtext/richtextmarginspage.cpp:274
+#: ../src/richtext/richtextmarginspage.cpp:275
+#: ../src/richtext/richtextmarginspage.cpp:313
+#: ../src/richtext/richtextmarginspage.cpp:315
+#: ../src/richtext/richtextmarginspage.cpp:316
+#: ../src/richtext/richtextmarginspage.cpp:338
+#: ../src/richtext/richtextmarginspage.cpp:340
+#: ../src/richtext/richtextmarginspage.cpp:341
+#: ../src/richtext/richtextmarginspage.cpp:361
+#: ../src/richtext/richtextmarginspage.cpp:363
+#: ../src/richtext/richtextmarginspage.cpp:364
+#: ../src/richtext/richtextmarginspage.cpp:386
+#: ../src/richtext/richtextmarginspage.cpp:388
+#: ../src/richtext/richtextmarginspage.cpp:389
+#: ../src/richtext/richtextsizepage.cpp:337
+#: ../src/richtext/richtextsizepage.cpp:340
+#: ../src/richtext/richtextsizepage.cpp:341
+#: ../src/richtext/richtextsizepage.cpp:371
+#: ../src/richtext/richtextsizepage.cpp:374
+#: ../src/richtext/richtextsizepage.cpp:375
+#: ../src/richtext/richtextsizepage.cpp:398
+#: ../src/richtext/richtextsizepage.cpp:401
+#: ../src/richtext/richtextsizepage.cpp:402
+#: ../src/richtext/richtextsizepage.cpp:425
+#: ../src/richtext/richtextsizepage.cpp:428
+#: ../src/richtext/richtextsizepage.cpp:429
+#: ../src/richtext/richtextsizepage.cpp:452
+#: ../src/richtext/richtextsizepage.cpp:455
+#: ../src/richtext/richtextsizepage.cpp:456
+#: ../src/richtext/richtextsizepage.cpp:479
+#: ../src/richtext/richtextsizepage.cpp:482
+#: ../src/richtext/richtextsizepage.cpp:483
+#: ../src/richtext/richtextsizepage.cpp:553
+#: ../src/richtext/richtextsizepage.cpp:556
+#: ../src/richtext/richtextsizepage.cpp:557
+#: ../src/richtext/richtextsizepage.cpp:588
+#: ../src/richtext/richtextsizepage.cpp:591
+#: ../src/richtext/richtextsizepage.cpp:592
+#: ../src/richtext/richtextsizepage.cpp:623
+#: ../src/richtext/richtextsizepage.cpp:626
+#: ../src/richtext/richtextsizepage.cpp:627
+#: ../src/richtext/richtextsizepage.cpp:658
+#: ../src/richtext/richtextsizepage.cpp:661
+#: ../src/richtext/richtextsizepage.cpp:662
+msgid "px"
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:225
+#: ../src/richtext/richtextbackgroundpage.cpp:248
+#: ../src/richtext/richtextbackgroundpage.cpp:288
+#: ../src/richtext/richtextbackgroundpage.cpp:315
+#: ../src/richtext/richtextborderspage.cpp:253
+#: ../src/richtext/richtextborderspage.cpp:287
+#: ../src/richtext/richtextborderspage.cpp:321
+#: ../src/richtext/richtextborderspage.cpp:355
+#: ../src/richtext/richtextborderspage.cpp:421
+#: ../src/richtext/richtextborderspage.cpp:455
+#: ../src/richtext/richtextborderspage.cpp:489
+#: ../src/richtext/richtextborderspage.cpp:523
+#: ../src/richtext/richtextborderspage.cpp:591
+#: ../src/richtext/richtextmarginspage.cpp:200
+#: ../src/richtext/richtextmarginspage.cpp:225
+#: ../src/richtext/richtextmarginspage.cpp:248
+#: ../src/richtext/richtextmarginspage.cpp:273
+#: ../src/richtext/richtextmarginspage.cpp:314
+#: ../src/richtext/richtextmarginspage.cpp:339
+#: ../src/richtext/richtextmarginspage.cpp:362
+#: ../src/richtext/richtextmarginspage.cpp:387
+#: ../src/richtext/richtextsizepage.cpp:338
+#: ../src/richtext/richtextsizepage.cpp:372
+#: ../src/richtext/richtextsizepage.cpp:399
+#: ../src/richtext/richtextsizepage.cpp:426
+#: ../src/richtext/richtextsizepage.cpp:453
+#: ../src/richtext/richtextsizepage.cpp:480
+#: ../src/richtext/richtextsizepage.cpp:554
+#: ../src/richtext/richtextsizepage.cpp:589
+#: ../src/richtext/richtextsizepage.cpp:624
+#: ../src/richtext/richtextsizepage.cpp:659
+msgid "cm"
+msgstr "cm"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:226
+#: ../src/richtext/richtextbackgroundpage.cpp:249
+#: ../src/richtext/richtextbackgroundpage.cpp:289
+#: ../src/richtext/richtextbackgroundpage.cpp:316
+#: ../src/richtext/richtextborderspage.cpp:254
+#: ../src/richtext/richtextborderspage.cpp:288
+#: ../src/richtext/richtextborderspage.cpp:322
+#: ../src/richtext/richtextborderspage.cpp:356
+#: ../src/richtext/richtextborderspage.cpp:422
+#: ../src/richtext/richtextborderspage.cpp:456
+#: ../src/richtext/richtextborderspage.cpp:490
+#: ../src/richtext/richtextborderspage.cpp:524
+#: ../src/richtext/richtextborderspage.cpp:592
+#: ../src/richtext/richtextfontpage.cpp:176
+#: ../src/richtext/richtextfontpage.cpp:179
+msgid "pt"
+msgstr "pt"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:229
+#: ../src/richtext/richtextbackgroundpage.cpp:231
+#: ../src/richtext/richtextbackgroundpage.cpp:252
+#: ../src/richtext/richtextbackgroundpage.cpp:254
+#: ../src/richtext/richtextbackgroundpage.cpp:292
+#: ../src/richtext/richtextbackgroundpage.cpp:294
+#: ../src/richtext/richtextbackgroundpage.cpp:319
+#: ../src/richtext/richtextbackgroundpage.cpp:321
+msgid "Units for this value."
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:234
+msgid "&Vertical offset:"
+msgstr "&Vertikali lygiuotė:"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:241
+#: ../src/richtext/richtextbackgroundpage.cpp:243
+msgid "The vertical offset."
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:257
+msgid "Shadow c&olour:"
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:259
+#: ../src/richtext/richtextbackgroundpage.cpp:261
+msgid "Enables the shadow colour."
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:265
+#: ../src/richtext/richtextbackgroundpage.cpp:267
+msgid "The shadow colour."
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:270
+msgid "Sh&adow spread:"
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:272
+#: ../src/richtext/richtextbackgroundpage.cpp:274
+msgid "Enables the shadow spread."
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:281
+#: ../src/richtext/richtextbackgroundpage.cpp:283
+msgid "The shadow spread."
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:297
+msgid "&Blur distance:"
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:299
+#: ../src/richtext/richtextbackgroundpage.cpp:301
+msgid "Enables the blur distance."
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:308
+#: ../src/richtext/richtextbackgroundpage.cpp:310
+msgid "The shadow blur distance."
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:324
+msgid "Opaci&ty:"
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:326
+#: ../src/richtext/richtextbackgroundpage.cpp:328
+msgid "Enables the shadow opacity."
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:335
+#: ../src/richtext/richtextbackgroundpage.cpp:337
+msgid "The shadow opacity."
+msgstr ""
+
+#. TRANSLATORS: Rich text page units (percentage)
+#: ../src/richtext/richtextbackgroundpage.cpp:340
+#: ../src/richtext/richtextsizepage.cpp:339
+#: ../src/richtext/richtextsizepage.cpp:373
+#: ../src/richtext/richtextsizepage.cpp:400
+#: ../src/richtext/richtextsizepage.cpp:427
+#: ../src/richtext/richtextsizepage.cpp:454
+#: ../src/richtext/richtextsizepage.cpp:481
+#: ../src/richtext/richtextsizepage.cpp:555
+#: ../src/richtext/richtextsizepage.cpp:590
+#: ../src/richtext/richtextsizepage.cpp:625
+#: ../src/richtext/richtextsizepage.cpp:660
+msgid "%"
+msgstr "%"
+
+#: ../src/richtext/richtextborderspage.cpp:229
+#: ../src/richtext/richtextborderspage.cpp:387
+msgid "Border"
+msgstr "Rėmelis"
+
+#: ../src/richtext/richtextborderspage.cpp:242
+#: ../src/richtext/richtextborderspage.cpp:410
+#: ../src/richtext/richtextindentspage.cpp:194
+#: ../src/richtext/richtextliststylepage.cpp:384
+#: ../src/richtext/richtextmarginspage.cpp:185
+#: ../src/richtext/richtextmarginspage.cpp:299
+#: ../src/richtext/richtextsizepage.cpp:531
+#: ../src/richtext/richtextsizepage.cpp:538
+msgid "&Left:"
+msgstr "&Kairės:"
+
+#: ../src/richtext/richtextborderspage.cpp:257
+#: ../src/richtext/richtextborderspage.cpp:259
+msgid "Units for the left border width."
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:266
+#: ../src/richtext/richtextborderspage.cpp:268
+#: ../src/richtext/richtextborderspage.cpp:300
+#: ../src/richtext/richtextborderspage.cpp:302
+#: ../src/richtext/richtextborderspage.cpp:334
+#: ../src/richtext/richtextborderspage.cpp:336
+#: ../src/richtext/richtextborderspage.cpp:368
+#: ../src/richtext/richtextborderspage.cpp:370
+#: ../src/richtext/richtextborderspage.cpp:434
+#: ../src/richtext/richtextborderspage.cpp:436
+#: ../src/richtext/richtextborderspage.cpp:468
+#: ../src/richtext/richtextborderspage.cpp:470
+#: ../src/richtext/richtextborderspage.cpp:502
+#: ../src/richtext/richtextborderspage.cpp:504
+#: ../src/richtext/richtextborderspage.cpp:536
+#: ../src/richtext/richtextborderspage.cpp:538
+msgid "The border line style."
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:276
+#: ../src/richtext/richtextborderspage.cpp:444
+#: ../src/richtext/richtextindentspage.cpp:212
+#: ../src/richtext/richtextliststylepage.cpp:402
+#: ../src/richtext/richtextmarginspage.cpp:210
+#: ../src/richtext/richtextmarginspage.cpp:324
+#: ../src/richtext/richtextsizepage.cpp:601
+#: ../src/richtext/richtextsizepage.cpp:608
+msgid "&Right:"
+msgstr "&Dešinės:"
+
+#: ../src/richtext/richtextborderspage.cpp:291
+#: ../src/richtext/richtextborderspage.cpp:293
+msgid "Units for the right border width."
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:310
+#: ../src/richtext/richtextborderspage.cpp:478
+#: ../src/richtext/richtextmarginspage.cpp:233
+#: ../src/richtext/richtextmarginspage.cpp:347
+#: ../src/richtext/richtextsizepage.cpp:566
+#: ../src/richtext/richtextsizepage.cpp:573
+msgid "&Top:"
+msgstr "&Viršaus:"
+
+#: ../src/richtext/richtextborderspage.cpp:325
+#: ../src/richtext/richtextborderspage.cpp:327
+msgid "Units for the top border width."
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:344
+#: ../src/richtext/richtextborderspage.cpp:512
+#: ../src/richtext/richtextmarginspage.cpp:258
+#: ../src/richtext/richtextmarginspage.cpp:372
+#: ../src/richtext/richtextsizepage.cpp:636
+#: ../src/richtext/richtextsizepage.cpp:643
+msgid "&Bottom:"
+msgstr "&Apačios:"
+
+#: ../src/richtext/richtextborderspage.cpp:359
+#: ../src/richtext/richtextborderspage.cpp:361
+msgid "Units for the bottom border width."
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:380
+#: ../src/richtext/richtextborderspage.cpp:548
+msgid "&Synchronize values"
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:382
+#: ../src/richtext/richtextborderspage.cpp:384
+#: ../src/richtext/richtextborderspage.cpp:550
+#: ../src/richtext/richtextborderspage.cpp:552
+msgid "Check to edit all borders simultaneously."
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:397
+#: ../src/richtext/richtextborderspage.cpp:555
+msgid "Outline"
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:425
+#: ../src/richtext/richtextborderspage.cpp:427
+msgid "Units for the left outline width."
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:459
+#: ../src/richtext/richtextborderspage.cpp:461
+msgid "Units for the right outline width."
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:493
+#: ../src/richtext/richtextborderspage.cpp:495
+msgid "Units for the top outline width."
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:527
+#: ../src/richtext/richtextborderspage.cpp:529
+msgid "Units for the bottom outline width."
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:565
+#: ../src/richtext/richtextborderspage.cpp:600
+msgid "Corner"
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:574
+msgid "Corner &radius:"
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:576
+#: ../src/richtext/richtextborderspage.cpp:578
+msgid "An optional corner radius for adding rounded corners."
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:584
+#: ../src/richtext/richtextborderspage.cpp:586
+msgid "The value of the corner radius."
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:595
+#: ../src/richtext/richtextborderspage.cpp:597
+msgid "Units for the corner radius."
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:609
+#: ../src/richtext/richtextsizepage.cpp:247
+#: ../src/richtext/richtextsizepage.cpp:251
+msgid "None"
+msgstr "Joks"
+
+#: ../src/richtext/richtextborderspage.cpp:610
+msgid "Solid"
+msgstr "Kūnas"
+
+#: ../src/richtext/richtextborderspage.cpp:611
+msgid "Dotted"
+msgstr "Taškinis"
+
+#: ../src/richtext/richtextborderspage.cpp:612
+msgid "Dashed"
+msgstr "Brūkšninis"
+
+#: ../src/richtext/richtextborderspage.cpp:613
+msgid "Double"
+msgstr "Dvigubas"
+
+#: ../src/richtext/richtextborderspage.cpp:614
+msgid "Groove"
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:615
+msgid "Ridge"
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:616
+msgid "Inset"
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:617
+msgid "Outset"
+msgstr ""
+
+#: ../src/richtext/richtextbuffer.cpp:3518
+msgid "Change Style"
+msgstr ""
+
+#: ../src/richtext/richtextbuffer.cpp:3701
+msgid "Change Object Style"
+msgstr ""
+
+#: ../src/richtext/richtextbuffer.cpp:3974
+#: ../src/richtext/richtextbuffer.cpp:8174
+msgid "Change Properties"
+msgstr "&Savybės"
+
+#: ../src/richtext/richtextbuffer.cpp:4346
+msgid "Change List Style"
+msgstr ""
+
+#: ../src/richtext/richtextbuffer.cpp:4519
+msgid "Renumber List"
+msgstr ""
+
+#: ../src/richtext/richtextbuffer.cpp:7867
+#: ../src/richtext/richtextbuffer.cpp:7897
+#: ../src/richtext/richtextbuffer.cpp:7939
+#: ../src/richtext/richtextctrl.cpp:1279 ../src/richtext/richtextctrl.cpp:1473
+msgid "Insert Text"
+msgstr ""
+
+#: ../src/richtext/richtextbuffer.cpp:8023
+#: ../src/richtext/richtextbuffer.cpp:8979
+msgid "Insert Image"
+msgstr ""
+
+#: ../src/richtext/richtextbuffer.cpp:8070
+msgid "Insert Object"
+msgstr "Įterpti objektą"
+
+#: ../src/richtext/richtextbuffer.cpp:8112
+msgid "Insert Field"
+msgstr "Įterpti"
+
+#: ../src/richtext/richtextbuffer.cpp:8410
+msgid "Too many EndStyle calls!"
+msgstr ""
+
+#: ../src/richtext/richtextbuffer.cpp:8785
+msgid "files"
+msgstr "failai"
+
+#: ../src/richtext/richtextbuffer.cpp:9380
+msgid "standard/circle"
+msgstr ""
+
+#: ../src/richtext/richtextbuffer.cpp:9381
+msgid "standard/circle-outline"
+msgstr ""
+
+#: ../src/richtext/richtextbuffer.cpp:9382
+msgid "standard/square"
+msgstr ""
+
+#: ../src/richtext/richtextbuffer.cpp:9383
+msgid "standard/diamond"
+msgstr ""
+
+#: ../src/richtext/richtextbuffer.cpp:9384
+msgid "standard/triangle"
+msgstr ""
+
+#: ../src/richtext/richtextbuffer.cpp:9423
+msgid "Box Properties"
+msgstr ""
+
+#: ../src/richtext/richtextbuffer.cpp:10006
+msgid "Multiple Cell Properties"
+msgstr ""
+
+#: ../src/richtext/richtextbuffer.cpp:10008
+msgid "Cell Properties"
+msgstr ""
+
+#: ../src/richtext/richtextbuffer.cpp:11256
+msgid "Set Cell Style"
+msgstr "Nustatyti langelio tipą"
+
+#: ../src/richtext/richtextbuffer.cpp:11330
+msgid "Delete Row"
+msgstr "Ištrinti"
+
+#: ../src/richtext/richtextbuffer.cpp:11380
+msgid "Delete Column"
+msgstr "Ištrinti stilių"
+
+#: ../src/richtext/richtextbuffer.cpp:11431
+msgid "Add Row"
+msgstr ""
+
+#: ../src/richtext/richtextbuffer.cpp:11494
+msgid "Add Column"
+msgstr ""
+
+#: ../src/richtext/richtextbuffer.cpp:11537
+msgid "Table Properties"
+msgstr ""
+
+#: ../src/richtext/richtextbuffer.cpp:12899
+msgid "Picture Properties"
+msgstr ""
+
+#: ../src/richtext/richtextbuffer.cpp:13169
+#: ../src/richtext/richtextbuffer.cpp:13279
+msgid "image"
+msgstr ""
+
+#: ../src/richtext/richtextbulletspage.cpp:145
+#: ../src/richtext/richtextliststylepage.cpp:209
+msgid "&Bullet style:"
+msgstr ""
+
+#: ../src/richtext/richtextbulletspage.cpp:150
+#: ../src/richtext/richtextbulletspage.cpp:152
+#: ../src/richtext/richtextliststylepage.cpp:214
+#: ../src/richtext/richtextliststylepage.cpp:216
+msgid "The available bullet styles."
+msgstr ""
+
+#: ../src/richtext/richtextbulletspage.cpp:158
+#: ../src/richtext/richtextliststylepage.cpp:221
+msgid "Peri&od"
+msgstr ""
+
+#: ../src/richtext/richtextbulletspage.cpp:160
+#: ../src/richtext/richtextbulletspage.cpp:162
+#: ../src/richtext/richtextliststylepage.cpp:223
+#: ../src/richtext/richtextliststylepage.cpp:225
+msgid "Check to add a period after the bullet."
+msgstr ""
+
+#. TRANSLATORS: Bullet point in parentheses option
+#: ../src/richtext/richtextbulletspage.cpp:167
+#: ../src/richtext/richtextliststylepage.cpp:230
+msgid "(*)"
+msgstr "*"
+
+#: ../src/richtext/richtextbulletspage.cpp:169
+#: ../src/richtext/richtextbulletspage.cpp:171
+#: ../src/richtext/richtextliststylepage.cpp:232
+#: ../src/richtext/richtextliststylepage.cpp:234
+msgid "Check to enclose the bullet in parentheses."
+msgstr ""
+
+#. TRANSLATORS: Right parenthesis bullet point option
+#: ../src/richtext/richtextbulletspage.cpp:176
+#: ../src/richtext/richtextliststylepage.cpp:239
+msgid "*)"
+msgstr "*)"
+
+#: ../src/richtext/richtextbulletspage.cpp:178
+#: ../src/richtext/richtextbulletspage.cpp:180
+#: ../src/richtext/richtextliststylepage.cpp:241
+#: ../src/richtext/richtextliststylepage.cpp:243
+msgid "Check to add a right parenthesis."
+msgstr ""
+
+#: ../src/richtext/richtextbulletspage.cpp:185
+#: ../src/richtext/richtextliststylepage.cpp:248
+msgid "Bullet &Alignment:"
+msgstr ""
+
+#: ../src/richtext/richtextbulletspage.cpp:190
+#: ../src/richtext/richtextliststylepage.cpp:253
+msgid "Centre"
+msgstr ""
+
+#: ../src/richtext/richtextbulletspage.cpp:194
+#: ../src/richtext/richtextbulletspage.cpp:196
+#: ../src/richtext/richtextbulletspage.cpp:217
+#: ../src/richtext/richtextbulletspage.cpp:219
+#: ../src/richtext/richtextliststylepage.cpp:257
+#: ../src/richtext/richtextliststylepage.cpp:259
+#: ../src/richtext/richtextliststylepage.cpp:278
+#: ../src/richtext/richtextliststylepage.cpp:280
+msgid "The bullet character."
+msgstr ""
+
+#: ../src/richtext/richtextbulletspage.cpp:212
+#: ../src/richtext/richtextliststylepage.cpp:271
+msgid "&Symbol:"
+msgstr "&Simbolis:"
+
+#: ../src/richtext/richtextbulletspage.cpp:222
+#: ../src/richtext/richtextliststylepage.cpp:283
+msgid "Ch&oose..."
+msgstr ""
+
+#: ../src/richtext/richtextbulletspage.cpp:223
+#: ../src/richtext/richtextbulletspage.cpp:225
+#: ../src/richtext/richtextliststylepage.cpp:284
+#: ../src/richtext/richtextliststylepage.cpp:286
+msgid "Click to browse for a symbol."
+msgstr ""
+
+#: ../src/richtext/richtextbulletspage.cpp:230
+#: ../src/richtext/richtextliststylepage.cpp:291
+msgid "Symbol &font:"
+msgstr ""
+
+#: ../src/richtext/richtextbulletspage.cpp:235
+#: ../src/richtext/richtextbulletspage.cpp:237
+#: ../src/richtext/richtextliststylepage.cpp:297
+msgid "Available fonts."
+msgstr ""
+
+#: ../src/richtext/richtextbulletspage.cpp:242
+#: ../src/richtext/richtextliststylepage.cpp:302
+msgid "S&tandard bullet name:"
+msgstr ""
+
+#: ../src/richtext/richtextbulletspage.cpp:247
+#: ../src/richtext/richtextbulletspage.cpp:249
+#: ../src/richtext/richtextliststylepage.cpp:307
+#: ../src/richtext/richtextliststylepage.cpp:309
+msgid "A standard bullet name."
+msgstr ""
+
+#: ../src/richtext/richtextbulletspage.cpp:254
+msgid "&Number:"
+msgstr ""
+
+#: ../src/richtext/richtextbulletspage.cpp:258
+#: ../src/richtext/richtextbulletspage.cpp:260
+msgid "The list item number."
+msgstr ""
+
+#: ../src/richtext/richtextbulletspage.cpp:266
+#: ../src/richtext/richtextbulletspage.cpp:268
+#: ../src/richtext/richtextliststylepage.cpp:475
+#: ../src/richtext/richtextliststylepage.cpp:477
+msgid "Shows a preview of the bullet settings."
+msgstr ""
+
+#: ../src/richtext/richtextbulletspage.cpp:276
+#: ../src/richtext/richtextliststylepage.cpp:484
+msgid "(None)"
+msgstr "Joks"
+
+#: ../src/richtext/richtextbulletspage.cpp:277
+#: ../src/richtext/richtextliststylepage.cpp:485
+msgid "Arabic"
+msgstr ""
+
+#: ../src/richtext/richtextbulletspage.cpp:278
+#: ../src/richtext/richtextliststylepage.cpp:486
+msgid "Upper case letters"
+msgstr ""
+
+#: ../src/richtext/richtextbulletspage.cpp:279
+#: ../src/richtext/richtextliststylepage.cpp:487
+msgid "Lower case letters"
+msgstr ""
+
+#: ../src/richtext/richtextbulletspage.cpp:280
+#: ../src/richtext/richtextliststylepage.cpp:488
+msgid "Upper case roman numerals"
+msgstr ""
+
+#: ../src/richtext/richtextbulletspage.cpp:281
+#: ../src/richtext/richtextliststylepage.cpp:489
+msgid "Lower case roman numerals"
+msgstr ""
+
+#: ../src/richtext/richtextbulletspage.cpp:282
+#: ../src/richtext/richtextliststylepage.cpp:490
+msgid "Numbered outline"
+msgstr ""
+
+#: ../src/richtext/richtextbulletspage.cpp:283
+#: ../src/richtext/richtextliststylepage.cpp:491
+msgid "Symbol"
+msgstr "Simbolis"
+
+#: ../src/richtext/richtextbulletspage.cpp:284
+#: ../src/richtext/richtextliststylepage.cpp:492
+msgid "Bitmap"
+msgstr "Taškinė grafika"
+
+#: ../src/richtext/richtextbulletspage.cpp:285
+#: ../src/richtext/richtextliststylepage.cpp:493
+msgid "Standard"
+msgstr "Standartinis"
+
+#: ../src/richtext/richtextbulletspage.cpp:287
+#: ../src/richtext/richtextliststylepage.cpp:495
+msgid "*"
+msgstr "*"
+
+#: ../src/richtext/richtextbulletspage.cpp:288
+#: ../src/richtext/richtextliststylepage.cpp:496
+msgid "-"
+msgstr "-"
+
+#: ../src/richtext/richtextbulletspage.cpp:289
+#: ../src/richtext/richtextliststylepage.cpp:497
+msgid ">"
+msgstr ">"
+
+#: ../src/richtext/richtextbulletspage.cpp:290
+#: ../src/richtext/richtextliststylepage.cpp:498
+msgid "+"
+msgstr "+"
+
+#: ../src/richtext/richtextbulletspage.cpp:291
+#: ../src/richtext/richtextliststylepage.cpp:499
+msgid "~"
+msgstr "~"
+
+#: ../src/richtext/richtextctrl.cpp:859
+msgid "Drag"
+msgstr "Vilkti"
+
+#: ../src/richtext/richtextctrl.cpp:1338 ../src/richtext/richtextctrl.cpp:1559
+msgid "Delete Text"
+msgstr ""
+
+#: ../src/richtext/richtextctrl.cpp:1537
+msgid "Remove Bullet"
+msgstr "Pašalinti ženklelį"
+
+#: ../src/richtext/richtextctrl.cpp:3070
+msgid "The text couldn't be saved."
+msgstr ""
+
+#: ../src/richtext/richtextctrl.cpp:3644
+msgid "Replace"
+msgstr "Pakeisti"
+
+#: ../src/richtext/richtextfontpage.cpp:146
+#: ../src/richtext/richtextsymboldlg.cpp:384
+msgid "&Font:"
+msgstr "Š&riftas:"
+
+#: ../src/richtext/richtextfontpage.cpp:150
+#: ../src/richtext/richtextfontpage.cpp:152
+msgid "Type a font name."
+msgstr ""
+
+#: ../src/richtext/richtextfontpage.cpp:158
+msgid "&Size:"
+msgstr "&Dydis:"
+
+#: ../src/richtext/richtextfontpage.cpp:165
+#: ../src/richtext/richtextfontpage.cpp:167
+msgid "Type a size in points."
+msgstr ""
+
+#: ../src/richtext/richtextfontpage.cpp:180
+#: ../src/richtext/richtextfontpage.cpp:182
+msgid "The font size units, points or pixels."
+msgstr "Šrifto dydžio vienetai, punktai arba taškai."
+
+#: ../src/richtext/richtextfontpage.cpp:189
+#: ../src/richtext/richtextfontpage.cpp:191
+msgid "Lists the available fonts."
+msgstr ""
+
+#: ../src/richtext/richtextfontpage.cpp:196
+#: ../src/richtext/richtextfontpage.cpp:198
+msgid "Lists font sizes in points."
+msgstr ""
+
+#: ../src/richtext/richtextfontpage.cpp:207
+msgid "Font st&yle:"
+msgstr ""
+
+#: ../src/richtext/richtextfontpage.cpp:212
+#: ../src/richtext/richtextfontpage.cpp:214
+msgid "Select regular or italic style."
+msgstr ""
+
+#: ../src/richtext/richtextfontpage.cpp:220
+msgid "Font &weight:"
+msgstr ""
+
+#: ../src/richtext/richtextfontpage.cpp:225
+#: ../src/richtext/richtextfontpage.cpp:227
+msgid "Select regular or bold."
+msgstr ""
+
+#: ../src/richtext/richtextfontpage.cpp:233
+msgid "&Underlining:"
+msgstr ""
+
+#: ../src/richtext/richtextfontpage.cpp:238
+#: ../src/richtext/richtextfontpage.cpp:240
+msgid "Select underlining or no underlining."
+msgstr ""
+
+#: ../src/richtext/richtextfontpage.cpp:248
+msgid "&Colour:"
+msgstr ""
+
+#: ../src/richtext/richtextfontpage.cpp:253
+#: ../src/richtext/richtextfontpage.cpp:255
+msgid "Click to change the text colour."
+msgstr ""
+
+#: ../src/richtext/richtextfontpage.cpp:261
+msgid "&Bg colour:"
+msgstr ""
+
+#: ../src/richtext/richtextfontpage.cpp:266
+#: ../src/richtext/richtextfontpage.cpp:268
+msgid "Click to change the text background colour."
+msgstr ""
+
+#: ../src/richtext/richtextfontpage.cpp:276
+#: ../src/richtext/richtextfontpage.cpp:278
+msgid "Check to show a line through the text."
+msgstr ""
+
+#: ../src/richtext/richtextfontpage.cpp:281
+msgid "Ca&pitals"
+msgstr ""
+
+#: ../src/richtext/richtextfontpage.cpp:283
+#: ../src/richtext/richtextfontpage.cpp:285
+msgid "Check to show the text in capitals."
+msgstr ""
+
+#: ../src/richtext/richtextfontpage.cpp:288
+msgid "Small C&apitals"
+msgstr ""
+
+#: ../src/richtext/richtextfontpage.cpp:290
+#: ../src/richtext/richtextfontpage.cpp:292
+msgid "Check to show the text in small capitals."
+msgstr ""
+
+#: ../src/richtext/richtextfontpage.cpp:295
+msgid "Supe&rscript"
+msgstr ""
+
+#: ../src/richtext/richtextfontpage.cpp:297
+#: ../src/richtext/richtextfontpage.cpp:299
+msgid "Check to show the text in superscript."
+msgstr ""
+
+#: ../src/richtext/richtextfontpage.cpp:302
+msgid "Subscrip&t"
+msgstr ""
+
+#: ../src/richtext/richtextfontpage.cpp:304
+#: ../src/richtext/richtextfontpage.cpp:306
+msgid "Check to show the text in subscript."
+msgstr ""
+
+#: ../src/richtext/richtextfontpage.cpp:312
+msgid "Rig&ht-to-left"
+msgstr ""
+
+#: ../src/richtext/richtextfontpage.cpp:314
+#: ../src/richtext/richtextfontpage.cpp:316
+msgid "Check to indicate right-to-left text layout."
+msgstr ""
+
+#: ../src/richtext/richtextfontpage.cpp:319
+msgid "Suppress hyphe&nation"
+msgstr ""
+
+#: ../src/richtext/richtextfontpage.cpp:321
+#: ../src/richtext/richtextfontpage.cpp:323
+msgid "Check to suppress hyphenation."
+msgstr ""
+
+#: ../src/richtext/richtextfontpage.cpp:329
+#: ../src/richtext/richtextfontpage.cpp:331
+msgid "Shows a preview of the font settings."
+msgstr ""
+
+#: ../src/richtext/richtextfontpage.cpp:348
+#: ../src/richtext/richtextfontpage.cpp:352
+#: ../src/richtext/richtextfontpage.cpp:356
+#: ../src/richtext/richtextformatdlg.cpp:873
+#: ../src/richtext/richtextindentspage.cpp:273
+#: ../src/richtext/richtextindentspage.cpp:285
+#: ../src/richtext/richtextindentspage.cpp:286
+#: ../src/richtext/richtextindentspage.cpp:310
+#: ../src/richtext/richtextindentspage.cpp:325
+#: ../src/richtext/richtextliststylepage.cpp:451
+#: ../src/richtext/richtextliststylepage.cpp:463
+#: ../src/richtext/richtextliststylepage.cpp:464
+msgid "(none)"
+msgstr "Joks"
+
+#: ../src/richtext/richtextfontpage.cpp:349
+#: ../src/richtext/richtextfontpage.cpp:353
+msgid "Regular"
+msgstr "Įprastas"
+
+#: ../src/richtext/richtextfontpage.cpp:357
+msgid "Not underlined"
+msgstr ""
+
+#: ../src/richtext/richtextformatdlg.cpp:341
+msgid "Indents && Spacing"
+msgstr ""
+
+#: ../src/richtext/richtextformatdlg.cpp:346
+msgid "Tabs"
+msgstr ""
+
+#: ../src/richtext/richtextformatdlg.cpp:351
+msgid "Bullets"
+msgstr ""
+
+#: ../src/richtext/richtextformatdlg.cpp:356
+msgid "List Style"
+msgstr "Sąrašo stilius"
+
+#: ../src/richtext/richtextformatdlg.cpp:366
+#: ../src/richtext/richtextmarginspage.cpp:170
+msgid "Margins"
+msgstr ""
+
+#: ../src/richtext/richtextformatdlg.cpp:371
+msgid "Borders"
+msgstr ""
+
+#: ../src/richtext/richtextformatdlg.cpp:765
+msgid "Colour"
+msgstr ""
+
+#: ../src/richtext/richtextindentspage.cpp:127
+#: ../src/richtext/richtextliststylepage.cpp:322
+msgid "&Alignment"
+msgstr ""
+
+#: ../src/richtext/richtextindentspage.cpp:138
+#: ../src/richtext/richtextliststylepage.cpp:331
+msgid "&Left"
+msgstr "&Kairės"
+
+#: ../src/richtext/richtextindentspage.cpp:140
+#: ../src/richtext/richtextindentspage.cpp:142
+#: ../src/richtext/richtextliststylepage.cpp:333
+#: ../src/richtext/richtextliststylepage.cpp:335
+msgid "Left-align text."
+msgstr ""
+
+#: ../src/richtext/richtextindentspage.cpp:145
+#: ../src/richtext/richtextliststylepage.cpp:338
+msgid "&Right"
+msgstr "&Dešinės"
+
+#: ../src/richtext/richtextindentspage.cpp:147
+#: ../src/richtext/richtextindentspage.cpp:149
+#: ../src/richtext/richtextliststylepage.cpp:340
+#: ../src/richtext/richtextliststylepage.cpp:342
+msgid "Right-align text."
+msgstr ""
+
+#: ../src/richtext/richtextindentspage.cpp:152
+#: ../src/richtext/richtextliststylepage.cpp:345
+msgid "&Justified"
+msgstr ""
+
+#: ../src/richtext/richtextindentspage.cpp:154
+#: ../src/richtext/richtextindentspage.cpp:156
+#: ../src/richtext/richtextliststylepage.cpp:347
+#: ../src/richtext/richtextliststylepage.cpp:349
+msgid "Justify text left and right."
+msgstr ""
+
+#: ../src/richtext/richtextindentspage.cpp:159
+#: ../src/richtext/richtextliststylepage.cpp:352
+msgid "Cen&tred"
+msgstr ""
+
+#: ../src/richtext/richtextindentspage.cpp:161
+#: ../src/richtext/richtextindentspage.cpp:163
+#: ../src/richtext/richtextliststylepage.cpp:354
+#: ../src/richtext/richtextliststylepage.cpp:356
+msgid "Centre text."
+msgstr ""
+
+#: ../src/richtext/richtextindentspage.cpp:166
+#: ../src/richtext/richtextliststylepage.cpp:359
+msgid "&Indeterminate"
+msgstr ""
+
+#: ../src/richtext/richtextindentspage.cpp:168
+#: ../src/richtext/richtextindentspage.cpp:170
+#: ../src/richtext/richtextliststylepage.cpp:361
+#: ../src/richtext/richtextliststylepage.cpp:363
+msgid "Use the current alignment setting."
+msgstr ""
+
+#: ../src/richtext/richtextindentspage.cpp:183
+#: ../src/richtext/richtextliststylepage.cpp:375
+msgid "&Indentation (tenths of a mm)"
+msgstr ""
+
+#: ../src/richtext/richtextindentspage.cpp:198
+#: ../src/richtext/richtextindentspage.cpp:200
+#: ../src/richtext/richtextliststylepage.cpp:388
+#: ../src/richtext/richtextliststylepage.cpp:390
+msgid "The left indent."
+msgstr ""
+
+#: ../src/richtext/richtextindentspage.cpp:203
+#: ../src/richtext/richtextliststylepage.cpp:393
+msgid "Left (&first line):"
+msgstr ""
+
+#: ../src/richtext/richtextindentspage.cpp:207
+#: ../src/richtext/richtextindentspage.cpp:209
+#: ../src/richtext/richtextliststylepage.cpp:397
+#: ../src/richtext/richtextliststylepage.cpp:399
+msgid "The first line indent."
+msgstr ""
+
+#: ../src/richtext/richtextindentspage.cpp:216
+#: ../src/richtext/richtextindentspage.cpp:218
+#: ../src/richtext/richtextliststylepage.cpp:406
+#: ../src/richtext/richtextliststylepage.cpp:408
+msgid "The right indent."
+msgstr ""
+
+#: ../src/richtext/richtextindentspage.cpp:221
+msgid "&Outline level:"
+msgstr ""
+
+#: ../src/richtext/richtextindentspage.cpp:226
+#: ../src/richtext/richtextindentspage.cpp:228
+msgid "The outline level."
+msgstr ""
+
+#: ../src/richtext/richtextindentspage.cpp:241
+#: ../src/richtext/richtextliststylepage.cpp:420
+msgid "&Spacing (tenths of a mm)"
+msgstr ""
+
+#: ../src/richtext/richtextindentspage.cpp:252
+msgid "&Before a paragraph:"
+msgstr ""
+
+#: ../src/richtext/richtextindentspage.cpp:256
+#: ../src/richtext/richtextindentspage.cpp:258
+#: ../src/richtext/richtextliststylepage.cpp:433
+#: ../src/richtext/richtextliststylepage.cpp:435
+msgid "The spacing before the paragraph."
+msgstr ""
+
+#: ../src/richtext/richtextindentspage.cpp:261
+msgid "&After a paragraph:"
+msgstr ""
+
+#: ../src/richtext/richtextindentspage.cpp:266
+#: ../src/richtext/richtextliststylepage.cpp:442
+#: ../src/richtext/richtextliststylepage.cpp:444
+msgid "The spacing after the paragraph."
+msgstr ""
+
+#: ../src/richtext/richtextindentspage.cpp:269
+msgid "L&ine spacing:"
+msgstr ""
+
+#: ../src/richtext/richtextindentspage.cpp:274
+#: ../src/richtext/richtextliststylepage.cpp:452
+msgid "Single"
+msgstr ""
+
+#: ../src/richtext/richtextindentspage.cpp:275
+#: ../src/richtext/richtextliststylepage.cpp:453
+msgid "1.1"
+msgstr "1.1"
+
+#: ../src/richtext/richtextindentspage.cpp:276
+#: ../src/richtext/richtextliststylepage.cpp:454
+msgid "1.2"
+msgstr "1.2"
+
+#: ../src/richtext/richtextindentspage.cpp:277
+#: ../src/richtext/richtextliststylepage.cpp:455
+msgid "1.3"
+msgstr "1.3"
+
+#: ../src/richtext/richtextindentspage.cpp:278
+#: ../src/richtext/richtextliststylepage.cpp:456
+msgid "1.4"
+msgstr "1.4"
+
+#: ../src/richtext/richtextindentspage.cpp:279
+#: ../src/richtext/richtextliststylepage.cpp:457
+msgid "1.5"
+msgstr "1.5"
+
+#: ../src/richtext/richtextindentspage.cpp:280
+#: ../src/richtext/richtextliststylepage.cpp:458
+msgid "1.6"
+msgstr "1.6"
+
+#: ../src/richtext/richtextindentspage.cpp:281
+#: ../src/richtext/richtextliststylepage.cpp:459
+msgid "1.7"
+msgstr "1.7"
+
+#: ../src/richtext/richtextindentspage.cpp:282
+#: ../src/richtext/richtextliststylepage.cpp:460
+msgid "1.8"
+msgstr "1.8"
+
+#: ../src/richtext/richtextindentspage.cpp:283
+#: ../src/richtext/richtextliststylepage.cpp:461
+msgid "1.9"
+msgstr "1.9"
+
+#: ../src/richtext/richtextindentspage.cpp:284
+#: ../src/richtext/richtextliststylepage.cpp:462
+msgid "2"
+msgstr "2"
+
+#: ../src/richtext/richtextindentspage.cpp:287
+#: ../src/richtext/richtextindentspage.cpp:289
+#: ../src/richtext/richtextliststylepage.cpp:465
+#: ../src/richtext/richtextliststylepage.cpp:467
+msgid "The line spacing."
+msgstr ""
+
+#: ../src/richtext/richtextindentspage.cpp:292
+msgid "&Page Break"
+msgstr ""
+
+#: ../src/richtext/richtextindentspage.cpp:294
+#: ../src/richtext/richtextindentspage.cpp:296
+msgid "Inserts a page break before the paragraph."
+msgstr ""
+
+#: ../src/richtext/richtextindentspage.cpp:302
+#: ../src/richtext/richtextindentspage.cpp:304
+msgid "Shows a preview of the paragraph settings."
+msgstr ""
+
+#: ../src/richtext/richtextliststylepage.cpp:182
+msgid "&List level:"
+msgstr ""
+
+#: ../src/richtext/richtextliststylepage.cpp:186
+#: ../src/richtext/richtextliststylepage.cpp:188
+msgid "Selects the list level to edit."
+msgstr ""
+
+#: ../src/richtext/richtextliststylepage.cpp:193
+msgid "&Font for Level..."
+msgstr "Š&riftas lygiui..."
+
+#: ../src/richtext/richtextliststylepage.cpp:194
+#: ../src/richtext/richtextliststylepage.cpp:196
+msgid "Click to choose the font for this level."
+msgstr ""
+
+#: ../src/richtext/richtextliststylepage.cpp:312
+msgid "Bullet style"
+msgstr ""
+
+#: ../src/richtext/richtextliststylepage.cpp:429
+msgid "Before a paragraph:"
+msgstr ""
+
+#: ../src/richtext/richtextliststylepage.cpp:438
+msgid "After a paragraph:"
+msgstr ""
+
+#: ../src/richtext/richtextliststylepage.cpp:447
+msgid "Line spacing:"
+msgstr ""
+
+#: ../src/richtext/richtextliststylepage.cpp:470
+msgid "Spacing"
+msgstr "Tarpai"
+
+#: ../src/richtext/richtextmarginspage.cpp:193
+#: ../src/richtext/richtextmarginspage.cpp:195
+msgid "The left margin size."
+msgstr ""
+
+#: ../src/richtext/richtextmarginspage.cpp:203
+#: ../src/richtext/richtextmarginspage.cpp:205
+msgid "Units for the left margin."
+msgstr ""
+
+#: ../src/richtext/richtextmarginspage.cpp:218
+#: ../src/richtext/richtextmarginspage.cpp:220
+msgid "The right margin size."
+msgstr ""
+
+#: ../src/richtext/richtextmarginspage.cpp:228
+#: ../src/richtext/richtextmarginspage.cpp:230
+msgid "Units for the right margin."
+msgstr ""
+
+#: ../src/richtext/richtextmarginspage.cpp:241
+#: ../src/richtext/richtextmarginspage.cpp:243
+msgid "The top margin size."
+msgstr ""
+
+#: ../src/richtext/richtextmarginspage.cpp:251
+#: ../src/richtext/richtextmarginspage.cpp:253
+msgid "Units for the top margin."
+msgstr ""
+
+#: ../src/richtext/richtextmarginspage.cpp:266
+#: ../src/richtext/richtextmarginspage.cpp:268
+msgid "The bottom margin size."
+msgstr ""
+
+#: ../src/richtext/richtextmarginspage.cpp:276
+#: ../src/richtext/richtextmarginspage.cpp:278
+msgid "Units for the bottom margin."
+msgstr ""
+
+#: ../src/richtext/richtextmarginspage.cpp:284
+msgid "Padding"
+msgstr ""
+
+#: ../src/richtext/richtextmarginspage.cpp:307
+#: ../src/richtext/richtextmarginspage.cpp:309
+msgid "The left padding size."
+msgstr ""
+
+#: ../src/richtext/richtextmarginspage.cpp:317
+#: ../src/richtext/richtextmarginspage.cpp:319
+msgid "Units for the left padding."
+msgstr ""
+
+#: ../src/richtext/richtextmarginspage.cpp:332
+#: ../src/richtext/richtextmarginspage.cpp:334
+msgid "The right padding size."
+msgstr ""
+
+#: ../src/richtext/richtextmarginspage.cpp:342
+#: ../src/richtext/richtextmarginspage.cpp:344
+msgid "Units for the right padding."
+msgstr ""
+
+#: ../src/richtext/richtextmarginspage.cpp:355
+#: ../src/richtext/richtextmarginspage.cpp:357
+msgid "The top padding size."
+msgstr ""
+
+#: ../src/richtext/richtextmarginspage.cpp:365
+#: ../src/richtext/richtextmarginspage.cpp:367
+msgid "Units for the top padding."
+msgstr ""
+
+#: ../src/richtext/richtextmarginspage.cpp:380
+#: ../src/richtext/richtextmarginspage.cpp:382
+msgid "The bottom padding size."
+msgstr ""
+
+#: ../src/richtext/richtextmarginspage.cpp:390
+#: ../src/richtext/richtextmarginspage.cpp:392
+msgid "Units for the bottom padding."
+msgstr ""
+
+#: ../src/richtext/richtextprint.cpp:592
+msgid " Preview"
+msgstr " Peržiūra"
+
+#: ../src/richtext/richtextsizepage.cpp:228
+msgid "Floating"
+msgstr "Plaukiojantis"
+
+#: ../src/richtext/richtextsizepage.cpp:243
+msgid "&Floating mode:"
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:252
+#: ../src/richtext/richtextsizepage.cpp:254
+msgid "How the object will float relative to the text."
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:265
+msgid "Alignment"
+msgstr "Lygiuotė"
+
+#: ../src/richtext/richtextsizepage.cpp:277
+msgid "&Vertical alignment:"
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:279
+#: ../src/richtext/richtextsizepage.cpp:281
+msgid "Enable vertical alignment."
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:286
+msgid "Centred"
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:290
+#: ../src/richtext/richtextsizepage.cpp:292
+msgid "Vertical alignment."
+msgstr "Vertikali lygiuotė."
+
+#: ../src/richtext/richtextsizepage.cpp:316
+#: ../src/richtext/richtextsizepage.cpp:323
+msgid "&Width:"
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:318
+#: ../src/richtext/richtextsizepage.cpp:320
+msgid "Enable the width value."
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:331
+#: ../src/richtext/richtextsizepage.cpp:333
+msgid "The object width."
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:342
+#: ../src/richtext/richtextsizepage.cpp:344
+msgid "Units for the object width."
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:350
+#: ../src/richtext/richtextsizepage.cpp:357
+msgid "&Height:"
+msgstr "&Aukštis:"
+
+#: ../src/richtext/richtextsizepage.cpp:352
+#: ../src/richtext/richtextsizepage.cpp:354
+#: ../src/richtext/richtextsizepage.cpp:464
+#: ../src/richtext/richtextsizepage.cpp:466
+msgid "Enable the height value."
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:365
+#: ../src/richtext/richtextsizepage.cpp:367
+msgid "The object height."
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:376
+#: ../src/richtext/richtextsizepage.cpp:378
+msgid "Units for the object height."
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:381
+msgid "Min width:"
+msgstr "Min. plotis:"
+
+#: ../src/richtext/richtextsizepage.cpp:383
+#: ../src/richtext/richtextsizepage.cpp:385
+msgid "Enable the minimum width value."
+msgstr "Įgalinti minimalaus pločio reikšmę."
+
+#: ../src/richtext/richtextsizepage.cpp:392
+#: ../src/richtext/richtextsizepage.cpp:394
+msgid "The object minimum width."
+msgstr "Minimalus objekto plotis."
+
+#: ../src/richtext/richtextsizepage.cpp:403
+#: ../src/richtext/richtextsizepage.cpp:405
+msgid "Units for the minimum object width."
+msgstr "Minimalaus objekto pločio vienetai."
+
+#: ../src/richtext/richtextsizepage.cpp:408
+msgid "Min height:"
+msgstr "&Aukštis:"
+
+#: ../src/richtext/richtextsizepage.cpp:410
+#: ../src/richtext/richtextsizepage.cpp:412
+msgid "Enable the minimum height value."
+msgstr "Įgalinti minimalaus aukščio reikšmę."
+
+#: ../src/richtext/richtextsizepage.cpp:419
+#: ../src/richtext/richtextsizepage.cpp:421
+msgid "The object minimum height."
+msgstr "Minimalus objekto aukštis."
+
+#: ../src/richtext/richtextsizepage.cpp:430
+#: ../src/richtext/richtextsizepage.cpp:432
+msgid "Units for the minimum object height."
+msgstr "Minimalaus objekto aukščio vienetai."
+
+#: ../src/richtext/richtextsizepage.cpp:435
+msgid "Max width:"
+msgstr "Pakeisti kuo:"
+
+#: ../src/richtext/richtextsizepage.cpp:437
+#: ../src/richtext/richtextsizepage.cpp:439
+msgid "Enable the maximum width value."
+msgstr "Įgalinti maksimalaus pločio reikšmę."
+
+#: ../src/richtext/richtextsizepage.cpp:446
+#: ../src/richtext/richtextsizepage.cpp:448
+msgid "The object maximum width."
+msgstr "Maksimalus objekto plotis."
+
+#: ../src/richtext/richtextsizepage.cpp:457
+#: ../src/richtext/richtextsizepage.cpp:459
+msgid "Units for the maximum object width."
+msgstr "Maksimalaus objekto pločio vienetai."
+
+#: ../src/richtext/richtextsizepage.cpp:462
+msgid "Max height:"
+msgstr "&Aukštis:"
+
+#: ../src/richtext/richtextsizepage.cpp:473
+#: ../src/richtext/richtextsizepage.cpp:475
+msgid "The object maximum height."
+msgstr "Maksimalus objekto aukštis."
+
+#: ../src/richtext/richtextsizepage.cpp:484
+#: ../src/richtext/richtextsizepage.cpp:486
+msgid "Units for the maximum object height."
+msgstr "Maksimalaus objekto aukščio vienetai."
+
+#: ../src/richtext/richtextsizepage.cpp:495
+msgid "Position"
+msgstr "Padėtis"
+
+#: ../src/richtext/richtextsizepage.cpp:513
+msgid "&Position mode:"
+msgstr "&Padėtis:"
+
+#: ../src/richtext/richtextsizepage.cpp:517
+#: ../src/richtext/richtextsizepage.cpp:522
+msgid "Static"
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:518
+msgid "Relative"
+msgstr "Santykinis"
+
+#: ../src/richtext/richtextsizepage.cpp:519
+msgid "Absolute"
+msgstr "Absoliutus"
+
+#: ../src/richtext/richtextsizepage.cpp:520
+msgid "Fixed"
+msgstr "Ištaisyta"
+
+#: ../src/richtext/richtextsizepage.cpp:533
+#: ../src/richtext/richtextsizepage.cpp:535
+#: ../src/richtext/richtextsizepage.cpp:547
+#: ../src/richtext/richtextsizepage.cpp:549
+msgid "The left position."
+msgstr "Kairė pozicija."
+
+#: ../src/richtext/richtextsizepage.cpp:558
+#: ../src/richtext/richtextsizepage.cpp:560
+msgid "Units for the left position."
+msgstr "Kairės pozicijos vienetai."
+
+#: ../src/richtext/richtextsizepage.cpp:568
+#: ../src/richtext/richtextsizepage.cpp:570
+#: ../src/richtext/richtextsizepage.cpp:582
+#: ../src/richtext/richtextsizepage.cpp:584
+msgid "The top position."
+msgstr "Viršutinė pozicija."
+
+#: ../src/richtext/richtextsizepage.cpp:593
+#: ../src/richtext/richtextsizepage.cpp:595
+msgid "Units for the top position."
+msgstr "Viršutinės pozicijos vienetai."
+
+#: ../src/richtext/richtextsizepage.cpp:603
+#: ../src/richtext/richtextsizepage.cpp:605
+#: ../src/richtext/richtextsizepage.cpp:617
+#: ../src/richtext/richtextsizepage.cpp:619
+msgid "The right position."
+msgstr "Dešinė pozicija."
+
+#: ../src/richtext/richtextsizepage.cpp:628
+#: ../src/richtext/richtextsizepage.cpp:630
+msgid "Units for the right position."
+msgstr "Dešinės pozicijos vienetai."
+
+#: ../src/richtext/richtextsizepage.cpp:638
+#: ../src/richtext/richtextsizepage.cpp:640
+#: ../src/richtext/richtextsizepage.cpp:652
+#: ../src/richtext/richtextsizepage.cpp:654
+msgid "The bottom position."
+msgstr "Apatinė pozicija."
+
+#: ../src/richtext/richtextsizepage.cpp:663
+#: ../src/richtext/richtextsizepage.cpp:665
+msgid "Units for the bottom position."
+msgstr "Apatinės pozicijos vienetai."
+
+#: ../src/richtext/richtextsizepage.cpp:671
+msgid "&Move the object to:"
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:674
+msgid "&Previous Paragraph"
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:675
+#: ../src/richtext/richtextsizepage.cpp:677
+msgid "Moves the object to the previous paragraph."
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:680
+msgid "&Next Paragraph"
+msgstr "&Kita pastraipa"
+
+#: ../src/richtext/richtextsizepage.cpp:681
+#: ../src/richtext/richtextsizepage.cpp:683
+msgid "Moves the object to the next paragraph."
+msgstr ""
+
+#: ../src/richtext/richtextstyledlg.cpp:193
+msgid "&Styles:"
+msgstr ""
+
+#: ../src/richtext/richtextstyledlg.cpp:197
+#: ../src/richtext/richtextstyledlg.cpp:199
+msgid "The available styles."
+msgstr ""
+
+#: ../src/richtext/richtextstyledlg.cpp:205
+#: ../src/richtext/richtextstyledlg.cpp:217
+msgid " "
+msgstr " "
+
+#: ../src/richtext/richtextstyledlg.cpp:209
+#: ../src/richtext/richtextstyledlg.cpp:211
+msgid "The style preview."
+msgstr ""
+
+#: ../src/richtext/richtextstyledlg.cpp:220
+msgid "New &Character Style..."
+msgstr ""
+
+#: ../src/richtext/richtextstyledlg.cpp:221
+#: ../src/richtext/richtextstyledlg.cpp:223
+msgid "Click to create a new character style."
+msgstr ""
+
+#: ../src/richtext/richtextstyledlg.cpp:226
+msgid "New &Paragraph Style..."
+msgstr ""
+
+#: ../src/richtext/richtextstyledlg.cpp:227
+#: ../src/richtext/richtextstyledlg.cpp:229
+msgid "Click to create a new paragraph style."
+msgstr ""
+
+#: ../src/richtext/richtextstyledlg.cpp:232
+msgid "New &List Style..."
+msgstr ""
+
+#: ../src/richtext/richtextstyledlg.cpp:233
+#: ../src/richtext/richtextstyledlg.cpp:235
+msgid "Click to create a new list style."
+msgstr ""
+
+#: ../src/richtext/richtextstyledlg.cpp:238
+msgid "New &Box Style..."
+msgstr "Naujas &Dėžutės stilius..."
+
+#: ../src/richtext/richtextstyledlg.cpp:239
+#: ../src/richtext/richtextstyledlg.cpp:241
+msgid "Click to create a new box style."
+msgstr "Spustelėkite sukurti naujam dėžutės stiliui."
+
+#: ../src/richtext/richtextstyledlg.cpp:246
+msgid "&Apply Style"
+msgstr ""
+
+#: ../src/richtext/richtextstyledlg.cpp:247
+#: ../src/richtext/richtextstyledlg.cpp:249
+msgid "Click to apply the selected style."
+msgstr ""
+
+#: ../src/richtext/richtextstyledlg.cpp:252
+msgid "&Rename Style..."
+msgstr ""
+
+#: ../src/richtext/richtextstyledlg.cpp:253
+#: ../src/richtext/richtextstyledlg.cpp:255
+msgid "Click to rename the selected style."
+msgstr ""
+
+#: ../src/richtext/richtextstyledlg.cpp:258
+msgid "&Edit Style..."
+msgstr ""
+
+#: ../src/richtext/richtextstyledlg.cpp:259
+#: ../src/richtext/richtextstyledlg.cpp:261
+msgid "Click to edit the selected style."
+msgstr ""
+
+#: ../src/richtext/richtextstyledlg.cpp:264
+msgid "&Delete Style..."
+msgstr ""
+
+#: ../src/richtext/richtextstyledlg.cpp:265
+#: ../src/richtext/richtextstyledlg.cpp:267
+msgid "Click to delete the selected style."
+msgstr ""
+
+#: ../src/richtext/richtextstyledlg.cpp:274
+#: ../src/richtext/richtextstyledlg.cpp:276
+msgid "Click to close this window."
+msgstr ""
+
+#: ../src/richtext/richtextstyledlg.cpp:282
+msgid "&Restart numbering"
+msgstr ""
+
+#: ../src/richtext/richtextstyledlg.cpp:284
+#: ../src/richtext/richtextstyledlg.cpp:286
+msgid "Check to restart numbering."
+msgstr ""
+
+#: ../src/richtext/richtextstyledlg.cpp:601
+msgid "Enter a character style name"
+msgstr ""
+
+#: ../src/richtext/richtextstyledlg.cpp:601
+#: ../src/richtext/richtextstyledlg.cpp:606
+#: ../src/richtext/richtextstyledlg.cpp:649
+#: ../src/richtext/richtextstyledlg.cpp:654
+#: ../src/richtext/richtextstyledlg.cpp:815
+#: ../src/richtext/richtextstyledlg.cpp:820
+#: ../src/richtext/richtextstyledlg.cpp:888
+#: ../src/richtext/richtextstyledlg.cpp:896
+#: ../src/richtext/richtextstyledlg.cpp:929
+#: ../src/richtext/richtextstyledlg.cpp:934
+msgid "New Style"
+msgstr ""
+
+#: ../src/richtext/richtextstyledlg.cpp:606
+#: ../src/richtext/richtextstyledlg.cpp:654
+#: ../src/richtext/richtextstyledlg.cpp:820
+#: ../src/richtext/richtextstyledlg.cpp:896
+#: ../src/richtext/richtextstyledlg.cpp:934
+msgid "Sorry, that name is taken. Please choose another."
+msgstr ""
+
+#: ../src/richtext/richtextstyledlg.cpp:649
+msgid "Enter a paragraph style name"
+msgstr ""
+
+#: ../src/richtext/richtextstyledlg.cpp:777
+#, c-format
+msgid "Delete style %s?"
+msgstr ""
+
+#: ../src/richtext/richtextstyledlg.cpp:777
+msgid "Delete Style"
+msgstr "Ištrinti stilių"
+
+#: ../src/richtext/richtextstyledlg.cpp:815
+msgid "Enter a list style name"
+msgstr ""
+
+#: ../src/richtext/richtextstyledlg.cpp:888
+msgid "Enter a new style name"
+msgstr ""
+
+#: ../src/richtext/richtextstyledlg.cpp:929
+msgid "Enter a box style name"
+msgstr "Įveskite dėžutės stiliaus pavadinimą"
+
+#: ../src/richtext/richtextstylepage.cpp:109
+#: ../src/richtext/richtextstylepage.cpp:111
+msgid "The style name."
+msgstr ""
+
+#: ../src/richtext/richtextstylepage.cpp:114
+msgid "&Based on:"
+msgstr ""
+
+#: ../src/richtext/richtextstylepage.cpp:119
+#: ../src/richtext/richtextstylepage.cpp:121
+msgid "The style on which this style is based."
+msgstr ""
+
+#: ../src/richtext/richtextstylepage.cpp:124
+msgid "&Next style:"
+msgstr "&Kitas stilius:"
+
+#: ../src/richtext/richtextstylepage.cpp:129
+#: ../src/richtext/richtextstylepage.cpp:131
+msgid "The default style for the next paragraph."
+msgstr ""
+
+#: ../src/richtext/richtextstyles.cpp:1057
+msgid "All styles"
+msgstr ""
+
+#: ../src/richtext/richtextstyles.cpp:1058
+msgid "Paragraph styles"
+msgstr ""
+
+#: ../src/richtext/richtextstyles.cpp:1059
+msgid "Character styles"
+msgstr ""
+
+#: ../src/richtext/richtextstyles.cpp:1060
+msgid "List styles"
+msgstr ""
+
+#: ../src/richtext/richtextstyles.cpp:1061
+msgid "Box styles"
+msgstr ""
+
+#: ../src/richtext/richtextsymboldlg.cpp:389
+#: ../src/richtext/richtextsymboldlg.cpp:391
+msgid "The font from which to take the symbol."
+msgstr ""
+
+#: ../src/richtext/richtextsymboldlg.cpp:396
+msgid "&Subset:"
+msgstr ""
+
+#: ../src/richtext/richtextsymboldlg.cpp:401
+#: ../src/richtext/richtextsymboldlg.cpp:403
+msgid "Shows a Unicode subset."
+msgstr ""
+
+#: ../src/richtext/richtextsymboldlg.cpp:412
+msgid "xxxx"
+msgstr "xxxx"
+
+#: ../src/richtext/richtextsymboldlg.cpp:417
+msgid "&Character code:"
+msgstr ""
+
+#: ../src/richtext/richtextsymboldlg.cpp:421
+#: ../src/richtext/richtextsymboldlg.cpp:423
+msgid "The character code."
+msgstr ""
+
+#: ../src/richtext/richtextsymboldlg.cpp:428
+msgid "&From:"
+msgstr "&Nuo:"
+
+#: ../src/richtext/richtextsymboldlg.cpp:433
+#: ../src/richtext/richtextsymboldlg.cpp:434
+#: ../src/richtext/richtextsymboldlg.cpp:435
+msgid "Unicode"
+msgstr ""
+
+#: ../src/richtext/richtextsymboldlg.cpp:436
+#: ../src/richtext/richtextsymboldlg.cpp:438
+msgid "The range to show."
+msgstr ""
+
+#: ../src/richtext/richtextsymboldlg.cpp:444
+msgid "Insert"
+msgstr "Įterpti"
+
+#: ../src/richtext/richtextsymboldlg.cpp:478
+msgid "(Normal text)"
+msgstr ""
+
+#: ../src/richtext/richtexttabspage.cpp:109
+msgid "&Position (tenths of a mm):"
+msgstr ""
+
+#: ../src/richtext/richtexttabspage.cpp:113
+#: ../src/richtext/richtexttabspage.cpp:115
+msgid "The tab position."
+msgstr ""
+
+#: ../src/richtext/richtexttabspage.cpp:119
+msgid "The tab positions."
+msgstr ""
+
+#: ../src/richtext/richtexttabspage.cpp:132
+#: ../src/richtext/richtexttabspage.cpp:134
+msgid "Click to create a new tab position."
+msgstr ""
+
+#: ../src/richtext/richtexttabspage.cpp:138
+#: ../src/richtext/richtexttabspage.cpp:140
+msgid "Click to delete the selected tab position."
+msgstr ""
+
+#: ../src/richtext/richtexttabspage.cpp:143
+msgid "Delete A&ll"
+msgstr ""
+
+#: ../src/richtext/richtexttabspage.cpp:144
+#: ../src/richtext/richtexttabspage.cpp:146
+msgid "Click to delete all tab positions."
+msgstr ""
+
+#: ../src/univ/theme.cpp:110
+msgid "Failed to initialize GUI: no built-in themes found."
+msgstr ""
+
+#: ../src/univ/themes/gtk.cpp:521
+msgid "GTK+ theme"
+msgstr ""
+
+#: ../src/univ/themes/metal.cpp:164
+msgid "Metal theme"
+msgstr ""
+
+#: ../src/univ/themes/mono.cpp:512
+msgid "Simple monochrome theme"
+msgstr ""
+
+#: ../src/univ/themes/win32.cpp:1098
+msgid "Win32 theme"
+msgstr ""
+
+#: ../src/univ/themes/win32.cpp:3743
+msgid "&Restore"
+msgstr "&Atstatyti"
+
+#: ../src/univ/themes/win32.cpp:3744
+msgid "&Move"
+msgstr "&Perkelti"
+
+#: ../src/univ/themes/win32.cpp:3746
+msgid "&Size"
+msgstr "&Dydis"
+
+#: ../src/univ/themes/win32.cpp:3748
+msgid "Mi&nimize"
+msgstr ""
+
+#: ../src/univ/themes/win32.cpp:3750
+msgid "Ma&ximize"
+msgstr ""
+
+#: ../src/univ/themes/win32.cpp:3752
+msgid "Alt+"
+msgstr "Alt+"
+
+#: ../src/unix/appunix.cpp:178
+msgid "Failed to install signal handler"
+msgstr ""
+
+#: ../src/unix/dialup.cpp:351
+msgid "Already dialling ISP."
+msgstr ""
+
+#: ../src/unix/dlunix.cpp:93
+msgid "Failed to unload shared library"
+msgstr ""
+
+#: ../src/unix/dlunix.cpp:121
+msgid "Unknown dynamic library error"
+msgstr ""
+
+#: ../src/unix/epolldispatcher.cpp:84
+msgid "Failed to create epoll descriptor"
+msgstr ""
+
+#: ../src/unix/epolldispatcher.cpp:103
+msgid "Error closing epoll descriptor"
+msgstr ""
+
+#: ../src/unix/epolldispatcher.cpp:116
+#, c-format
+msgid "Failed to add descriptor %d to epoll descriptor %d"
+msgstr ""
+
+#: ../src/unix/epolldispatcher.cpp:136
+#, c-format
+msgid "Failed to modify descriptor %d in epoll descriptor %d"
+msgstr ""
+
+#: ../src/unix/epolldispatcher.cpp:155
+#, c-format
+msgid "Failed to unregister descriptor %d from epoll descriptor %d"
+msgstr ""
+
+#: ../src/unix/epolldispatcher.cpp:213
+#, c-format
+msgid "Waiting for IO on epoll descriptor %d failed"
+msgstr ""
+
+#: ../src/unix/fswatcher_inotify.cpp:71
+msgid "Unable to create inotify instance"
+msgstr ""
+
+#: ../src/unix/fswatcher_inotify.cpp:94
+msgid "Unable to close inotify instance"
+msgstr ""
+
+#: ../src/unix/fswatcher_inotify.cpp:106
+msgid "Unable to add inotify watch"
+msgstr ""
+
+#: ../src/unix/fswatcher_inotify.cpp:138
+#, c-format
+msgid "Unable to remove inotify watch %i"
+msgstr ""
+
+#: ../src/unix/fswatcher_inotify.cpp:271
+#, c-format
+msgid "Unexpected event for \"%s\": no matching watch descriptor."
+msgstr ""
+
+#: ../src/unix/fswatcher_inotify.cpp:320
+#, c-format
+msgid "Invalid inotify event for \"%s\""
+msgstr ""
+
+#: ../src/unix/fswatcher_inotify.cpp:553
+msgid "Unable to read from inotify descriptor"
+msgstr ""
+
+#: ../src/unix/fswatcher_inotify.cpp:558
+msgid "EOF while reading from inotify descriptor"
+msgstr ""
+
+#: ../src/unix/fswatcher_kqueue.cpp:114
+msgid "Unable to create kqueue instance"
+msgstr ""
+
+#: ../src/unix/fswatcher_kqueue.cpp:131
+msgid "Error closing kqueue instance"
+msgstr ""
+
+#: ../src/unix/fswatcher_kqueue.cpp:153
+msgid "Unable to add kqueue watch"
+msgstr ""
+
+#: ../src/unix/fswatcher_kqueue.cpp:170
+msgid "Unable to remove kqueue watch"
+msgstr ""
+
+#: ../src/unix/fswatcher_kqueue.cpp:202
+msgid "Unable to get events from kqueue"
+msgstr ""
+
+#: ../src/unix/mediactrl.cpp:966
+#, c-format
+msgid "Media playback error: %s"
+msgstr "Medijos grojimo klaida: %s"
+
+#: ../src/unix/mediactrl.cpp:1228
+#, c-format
+msgid "Failed to prepare playing \"%s\"."
+msgstr "Nepavyko paruošti grojimui \"%s\"."
+
+#: ../src/unix/snglinst.cpp:164
+#, c-format
+msgid "Failed to write to lock file '%s'"
+msgstr ""
+
+#: ../src/unix/snglinst.cpp:177
+#, c-format
+msgid "Failed to set permissions on lock file '%s'"
+msgstr ""
+
+#: ../src/unix/snglinst.cpp:194
+#, c-format
+msgid "Failed to lock the lock file '%s'"
+msgstr ""
+
+#: ../src/unix/snglinst.cpp:237
+#, c-format
+msgid "Failed to inspect the lock file '%s'"
+msgstr ""
+
+#: ../src/unix/snglinst.cpp:242
+#, c-format
+msgid "Lock file '%s' has incorrect owner."
+msgstr ""
+
+#: ../src/unix/snglinst.cpp:247
+#, c-format
+msgid "Lock file '%s' has incorrect permissions."
+msgstr ""
+
+#: ../src/unix/snglinst.cpp:265
+msgid "Failed to access lock file."
+msgstr ""
+
+#: ../src/unix/snglinst.cpp:274
+msgid "Failed to read PID from lock file."
+msgstr ""
+
+#: ../src/unix/snglinst.cpp:284
+#, c-format
+msgid "Failed to remove stale lock file '%s'."
+msgstr ""
+
+#: ../src/unix/snglinst.cpp:297
+#, c-format
+msgid "Deleted stale lock file '%s'."
+msgstr ""
+
+#: ../src/unix/snglinst.cpp:308
+#, c-format
+msgid "Invalid lock file '%s'."
+msgstr ""
+
+#: ../src/unix/snglinst.cpp:324
+#, c-format
+msgid "Failed to remove lock file '%s'"
+msgstr ""
+
+#: ../src/unix/snglinst.cpp:330
+#, c-format
+msgid "Failed to unlock lock file '%s'"
+msgstr ""
+
+#: ../src/unix/snglinst.cpp:336
+#, c-format
+msgid "Failed to close lock file '%s'"
+msgstr ""
+
+#: ../src/unix/sound.cpp:77
+msgid "No sound"
+msgstr ""
+
+#: ../src/unix/sound.cpp:364
+msgid "Unable to play sound asynchronously."
+msgstr ""
+
+#: ../src/unix/sound.cpp:458
+#, c-format
+msgid "Couldn't load sound data from '%s'."
+msgstr ""
+
+#: ../src/unix/sound.cpp:465
+#, c-format
+msgid "Sound file '%s' is in unsupported format."
+msgstr ""
+
+#: ../src/unix/sound.cpp:480
+msgid "Sound data are in unsupported format."
+msgstr ""
+
+#: ../src/unix/sound_sdl.cpp:226
+#, c-format
+msgid "Couldn't open audio: %s"
+msgstr ""
+
+#: ../src/unix/threadpsx.cpp:1033
+msgid "Cannot retrieve thread scheduling policy."
+msgstr ""
+
+#: ../src/unix/threadpsx.cpp:1058
+#, c-format
+msgid "Cannot get priority range for scheduling policy %d."
+msgstr ""
+
+#: ../src/unix/threadpsx.cpp:1066
+msgid "Thread priority setting is ignored."
+msgstr ""
+
+#: ../src/unix/threadpsx.cpp:1221
+msgid ""
+"Failed to join a thread, potential memory leak detected - please restart the "
+"program"
+msgstr ""
+
+#: ../src/unix/threadpsx.cpp:1352
+#, c-format
+msgid "Failed to set thread concurrency level to %lu"
+msgstr "Nepavyko nustatyti gijų sutapimo lygmens į %lu"
+
+#: ../src/unix/threadpsx.cpp:1481
+#, c-format
+msgid "Failed to set thread priority %d."
+msgstr ""
+
+#: ../src/unix/threadpsx.cpp:1666
+msgid "Failed to terminate a thread."
+msgstr ""
+
+#: ../src/unix/threadpsx.cpp:1893
+msgid "Thread module initialization failed: failed to create thread key"
+msgstr ""
+
+#: ../src/unix/utilsunx.cpp:340
+msgid "Impossible to get child process input"
+msgstr ""
+
+#: ../src/unix/utilsunx.cpp:390
+msgid "Can't write to child process's stdin"
+msgstr ""
+
+#: ../src/unix/utilsunx.cpp:644
+#, c-format
+msgid "Failed to execute '%s'\n"
+msgstr ""
+
+#: ../src/unix/utilsunx.cpp:678
+msgid "Fork failed"
+msgstr ""
+
+#: ../src/unix/utilsunx.cpp:701
+msgid "Failed to set process priority"
+msgstr ""
+
+#: ../src/unix/utilsunx.cpp:712
+msgid "Failed to redirect child process input/output"
+msgstr ""
+
+#: ../src/unix/utilsunx.cpp:816
+msgid "Failed to set up non-blocking pipe, the program might hang."
+msgstr ""
+
+#: ../src/unix/utilsunx.cpp:1023
+msgid "Cannot get the hostname"
+msgstr ""
+
+#: ../src/unix/utilsunx.cpp:1059
+msgid "Cannot get the official hostname"
+msgstr ""
+
+#: ../src/unix/wakeuppipe.cpp:49
+msgid "Failed to create wake up pipe used by event loop."
+msgstr ""
+
+#: ../src/unix/wakeuppipe.cpp:56
+msgid "Failed to switch wake up pipe to non-blocking mode"
+msgstr ""
+
+#: ../src/unix/wakeuppipe.cpp:117
+msgid "Failed to read from wake-up pipe"
+msgstr ""
+
+#: ../src/x11/app.cpp:124
+#, c-format
+msgid "Invalid geometry specification '%s'"
+msgstr ""
+
+#: ../src/x11/app.cpp:167
+msgid "wxWidgets could not open display. Exiting."
+msgstr ""
+
+#: ../src/x11/utils.cpp:169
+#, c-format
+msgid "Failed to close the display \"%s\""
+msgstr ""
+
+#: ../src/x11/utils.cpp:188
+#, c-format
+msgid "Failed to open display \"%s\"."
+msgstr ""
+
+#: ../src/xml/xml.cpp:868
+#, c-format
+msgid "XML parsing error: '%s' at line %d"
+msgstr ""
+
+#: ../src/xrc/xh_propgrid.cpp:239
+#, fuzzy, c-format
+msgid "Page %i"
+msgstr "Žemyn"
+
+#: ../src/xrc/xmlres.cpp:448
+#, c-format
+msgid "Cannot load resources from '%s'."
+msgstr ""
+
+#: ../src/xrc/xmlres.cpp:799
+#, c-format
+msgid "Cannot open resources file '%s'."
+msgstr ""
+
+#: ../src/xrc/xmlres.cpp:806
+#, c-format
+msgid "Cannot load resources from file '%s'."
+msgstr ""
+
+#: ../src/xrc/xmlres.cpp:2767
+#, c-format
+msgid "Creating %s \"%s\" failed."
+msgstr ""
+
+#~ msgctxt "keyboard key"
+#~ msgid "Alt+"
+#~ msgstr "Alt+"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Ctrl+"
+#~ msgstr "Ctrl+"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Shift+"
+#~ msgstr "Shift+"
+
+#~ msgctxt "keyboard key"
+#~ msgid "RawCtrl+"
+#~ msgstr "RawCtrl+"
+
+#~ msgid "Font:"
+#~ msgstr "Šriftas:"
+
+#~ msgid "Size:"
+#~ msgstr "Dydis:"
+
+#~ msgid "Style:"
+#~ msgstr "Stilius:"
+
+#~ msgid "Filter"
+#~ msgstr "FILTER"
+
+#~ msgid "Files"
+#~ msgstr "Failai"
+
+#~ msgid "Selection"
+#~ msgstr "Parinktis"

--- a/po_wxstd/lv.po
+++ b/po_wxstd/lv.po
@@ -1,0 +1,10443 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: wxWidgets 3.3\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-05-14 20:23+0200\n"
+"PO-Revision-Date: 2013-01-23 13:14+0300\n"
+"Last-Translator: Jānis Eisaks <jancs@dv.lv>\n"
+"Language-Team: wxWidgets translators <wx-translators@wxwidgets.org>\n"
+"Language: Latvian\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n != 0 ? 1 : "
+"2);\n"
+"X-Generator: Rosetta (http://launchpad.ubuntu.com/rosetta/)\n"
+"X-Poedit-Language: Latvian\n"
+"X-Poedit-Country: LATVIA\n"
+"X-Poedit-SourceCharset: utf-8\n"
+
+#: ../include/wx/defs.h:2582
+msgid "All files (*.*)|*.*"
+msgstr "Visus failus (*.*)|*.*"
+
+#: ../include/wx/defs.h:2585
+msgid "All files (*)|*"
+msgstr "Visus failus (*)|*"
+
+#: ../include/wx/generic/progdlgg.h:85
+#, fuzzy
+msgid "Elapsed time:"
+msgstr "Pagājušais laiks:"
+
+#: ../include/wx/generic/progdlgg.h:86
+#, fuzzy
+msgid "Estimated time:"
+msgstr "Aptuvenais laiks:"
+
+#: ../include/wx/generic/progdlgg.h:87
+#, fuzzy
+msgid "Remaining time:"
+msgstr "Atlikušais laiks:"
+
+#. TRANSLATORS: HTML printout default title.
+#: ../include/wx/html/htmprint.h:121 ../include/wx/prntbase.h:273
+#: ../include/wx/richtext/richtextprint.h:109 ../src/common/docview.cpp:2161
+msgid "Printout"
+msgstr "Izdruka"
+
+#. TRANSLATORS: HTML easy print default title.
+#: ../include/wx/html/htmprint.h:234 ../include/wx/richtext/richtextprint.h:163
+#: ../src/common/prntbase.cpp:522 ../src/html/htmprint.cpp:291
+msgid "Printing"
+msgstr "Drukāšana"
+
+#: ../include/wx/msgdlg.h:277 ../src/common/stockitem.cpp:211
+msgid "Yes"
+msgstr "Jā"
+
+#: ../include/wx/msgdlg.h:278 ../src/common/stockitem.cpp:182
+msgid "No"
+msgstr "Nē"
+
+#: ../include/wx/msgdlg.h:279 ../src/common/stockitem.cpp:183
+#: ../src/msw/msgdlg.cpp:430 ../src/msw/msgdlg.cpp:734
+#: ../src/richtext/richtextstyledlg.cpp:292
+msgid "OK"
+msgstr "Labi"
+
+#: ../include/wx/msgdlg.h:280 ../src/common/stockitem.cpp:150
+#: ../src/msw/msgdlg.cpp:430 ../src/msw/progdlg.cpp:884
+#: ../src/richtext/richtextstyledlg.cpp:295
+msgid "Cancel"
+msgstr "Atcelt"
+
+#: ../include/wx/msgdlg.h:281 ../src/common/stockitem.cpp:168
+#: ../src/html/helpdlg.cpp:63 ../src/html/helpfrm.cpp:108
+#: ../src/osx/button_osx.cpp:38
+msgid "Help"
+msgstr "Palīdzība"
+
+#: ../include/wx/msw/ole/oleutils.h:52
+msgid "Cannot initialize OLE"
+msgstr "Nav iespējams inicializēt OLE"
+
+#: ../include/wx/msw/private/fswatcher.h:48
+#, c-format
+msgid "Unable to close the handle for '%s'"
+msgstr ""
+
+#: ../include/wx/msw/private/fswatcher.h:92
+#, c-format
+msgid "Failed to open directory \"%s\" for monitoring."
+msgstr "Mapi \"%s\" atvērt novērošanai neizdevās."
+
+#: ../include/wx/msw/private/fswatcher.h:125
+msgid "Unable to close I/O completion port handle"
+msgstr ""
+
+#: ../include/wx/msw/private/fswatcher.h:142
+msgid "Unable to associate handle with I/O completion port"
+msgstr ""
+
+#: ../include/wx/msw/private/fswatcher.h:148
+msgid "Unexpectedly new I/O completion port was created"
+msgstr ""
+
+#: ../include/wx/msw/private/fswatcher.h:213
+msgid "Unable to post completion status"
+msgstr ""
+
+#: ../include/wx/msw/private/fswatcher.h:262
+msgid "Unable to dequeue completion packet"
+msgstr ""
+
+#: ../include/wx/msw/private/fswatcher.h:273
+msgid "Unable to create I/O completion port"
+msgstr ""
+
+#: ../include/wx/richmsgdlg.h:29
+msgid "&See details"
+msgstr "&Skatīt detaļas"
+
+#: ../include/wx/richmsgdlg.h:30
+msgid "&Hide details"
+msgstr "Slēpt &detaļas"
+
+#: ../include/wx/richtext/richtextbuffer.h:3864
+msgid "&Box"
+msgstr "&Rāmis"
+
+#: ../include/wx/richtext/richtextbuffer.h:5008
+msgid "&Picture"
+msgstr "&Attēls"
+
+#: ../include/wx/richtext/richtextbuffer.h:5958
+msgid "&Cell"
+msgstr "Šū&na"
+
+#: ../include/wx/richtext/richtextbuffer.h:6067
+msgid "&Table"
+msgstr "&Tabula"
+
+#: ../include/wx/richtext/richtextimagedlg.h:37
+msgid "Object Properties"
+msgstr "Objekta īpašības"
+
+#: ../include/wx/richtext/richtextsymboldlg.h:39
+msgid "Symbols"
+msgstr "Simboli"
+
+#: ../include/wx/unix/pipe.h:46
+msgid "Pipe creation failed"
+msgstr ""
+
+#: ../include/wx/unix/private/displayx11.h:65
+msgid "Failed to enumerate video modes"
+msgstr "Neizdevās uzskaitīt video režīmus"
+
+#: ../include/wx/unix/private/displayx11.h:89
+msgid "Failed to change video mode"
+msgstr "Nevar nomainīt video režīmu"
+
+#: ../include/wx/unix/private/fswatcher_kqueue.h:57
+#, c-format
+msgid "Unable to open path '%s'"
+msgstr "Neizdevās atvērt ceļu  '%s'"
+
+#: ../include/wx/unix/private/fswatcher_kqueue.h:74
+#, c-format
+msgid "Unable to close path '%s'"
+msgstr "Neizdevās aizvērt ceļu  '%s'"
+
+#: ../include/wx/xtiprop.h:175
+msgid "SetProperty called w/o valid setter"
+msgstr ""
+
+#: ../include/wx/xtiprop.h:184
+msgid "GetProperty called w/o valid getter"
+msgstr ""
+
+#: ../include/wx/xtiprop.h:193
+msgid "AddToPropertyCollection called w/o valid adder"
+msgstr ""
+
+#: ../include/wx/xtiprop.h:202
+msgid "GetPropertyCollection called w/o valid collection getter"
+msgstr ""
+
+#: ../include/wx/xtiprop.h:255
+msgid "AddToPropertyCollection called on a generic accessor"
+msgstr ""
+
+#: ../include/wx/xtiprop.h:262
+msgid "GetPropertyCollection called on a generic accessor"
+msgstr ""
+
+#: ../src/aui/tabmdi.cpp:106 ../src/generic/mdig.cpp:94
+msgid "Cl&ose"
+msgstr "Aiz&vērt"
+
+#: ../src/aui/tabmdi.cpp:107 ../src/generic/mdig.cpp:95
+msgid "Close All"
+msgstr "Aizvērt Visus"
+
+#: ../src/aui/tabmdi.cpp:109 ../src/generic/mdig.cpp:97 ../src/msw/mdi.cpp:175
+#: ../src/qt/mdi.cpp:258
+msgid "&Next"
+msgstr "&Nākošais"
+
+#: ../src/aui/tabmdi.cpp:110 ../src/generic/mdig.cpp:98 ../src/msw/mdi.cpp:176
+#: ../src/qt/mdi.cpp:259
+msgid "&Previous"
+msgstr "Ie&priekšējais"
+
+#: ../src/aui/tabmdi.cpp:332 ../src/aui/tabmdi.cpp:348
+#: ../src/aui/tabmdi.cpp:350 ../src/generic/mdig.cpp:291
+#: ../src/generic/mdig.cpp:307 ../src/generic/mdig.cpp:311
+#: ../src/msw/mdi.cpp:337 ../src/qt/mdi.cpp:462
+msgid "&Window"
+msgstr "&Logs"
+
+#: ../src/common/accelcmn.cpp:47
+msgctxt "keyboard key"
+msgid "Delete"
+msgstr "Dzēst"
+
+#: ../src/common/accelcmn.cpp:48
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Del"
+msgstr "Dzēst"
+
+#: ../src/common/accelcmn.cpp:49
+msgctxt "keyboard key"
+msgid "Back"
+msgstr "Atpakaļ"
+
+#: ../src/common/accelcmn.cpp:49
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Backspace"
+msgstr "Atpakaļ"
+
+#: ../src/common/accelcmn.cpp:50
+msgctxt "keyboard key"
+msgid "Insert"
+msgstr "Insert"
+
+#: ../src/common/accelcmn.cpp:51
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Ins"
+msgstr "Iespiests"
+
+#: ../src/common/accelcmn.cpp:52
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Enter"
+msgstr "Printeris"
+
+#: ../src/common/accelcmn.cpp:53
+msgctxt "keyboard key"
+msgid "Return"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:54
+#, fuzzy
+msgctxt "keyboard key"
+msgid "PageUp"
+msgstr "Lapas"
+
+#: ../src/common/accelcmn.cpp:54
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Page Up"
+msgstr "Lapa %d"
+
+#: ../src/common/accelcmn.cpp:55
+#, fuzzy
+msgctxt "keyboard key"
+msgid "PageDown"
+msgstr "Lejup"
+
+#: ../src/common/accelcmn.cpp:55
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Page Down"
+msgstr "Lapa %d"
+
+#: ../src/common/accelcmn.cpp:56
+msgctxt "keyboard key"
+msgid "PgUp"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:57
+msgctxt "keyboard key"
+msgid "PgDn"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:58
+msgctxt "keyboard key"
+msgid "Left"
+msgstr "Pa kreisi"
+
+#: ../src/common/accelcmn.cpp:59
+msgctxt "keyboard key"
+msgid "Right"
+msgstr "Pa labi"
+
+#: ../src/common/accelcmn.cpp:60
+msgctxt "keyboard key"
+msgid "Up"
+msgstr "Uz augšu"
+
+#: ../src/common/accelcmn.cpp:61
+msgctxt "keyboard key"
+msgid "Down"
+msgstr "Lejup"
+
+#: ../src/common/accelcmn.cpp:62
+msgctxt "keyboard key"
+msgid "Home"
+msgstr "Home"
+
+#: ../src/common/accelcmn.cpp:63
+msgctxt "keyboard key"
+msgid "End"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:64
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Space"
+msgstr "Atstarpes"
+
+#: ../src/common/accelcmn.cpp:65
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Tab"
+msgstr "Tabuācijas"
+
+#: ../src/common/accelcmn.cpp:66
+msgctxt "keyboard key"
+msgid "Esc"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:67
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Escape"
+msgstr "Ainava"
+
+#: ../src/common/accelcmn.cpp:68
+msgctxt "keyboard key"
+msgid "Cancel"
+msgstr "Atcelt"
+
+#: ../src/common/accelcmn.cpp:69
+msgctxt "keyboard key"
+msgid "Clear"
+msgstr "Notīrīt"
+
+#: ../src/common/accelcmn.cpp:70
+msgctxt "keyboard key"
+msgid "Menu"
+msgstr "Izvēlne"
+
+#: ../src/common/accelcmn.cpp:71
+msgctxt "keyboard key"
+msgid "Pause"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:72
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Capital"
+msgstr "Lieli burti"
+
+#: ../src/common/accelcmn.cpp:73
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Select"
+msgstr "Iezīmējums"
+
+#: ../src/common/accelcmn.cpp:74
+msgctxt "keyboard key"
+msgid "Print"
+msgstr "Drukāt"
+
+#: ../src/common/accelcmn.cpp:75
+msgctxt "keyboard key"
+msgid "Execute"
+msgstr "Izpildīt"
+
+#: ../src/common/accelcmn.cpp:76
+msgctxt "keyboard key"
+msgid "Snapshot"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:77
+msgctxt "keyboard key"
+msgid "Help"
+msgstr "Palīdzība"
+
+#: ../src/common/accelcmn.cpp:78
+msgctxt "keyboard key"
+msgid "Add"
+msgstr "Pievienot"
+
+#: ../src/common/accelcmn.cpp:79
+msgctxt "keyboard key"
+msgid "Separator"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:80
+msgctxt "keyboard key"
+msgid "Subtract"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:81
+msgctxt "keyboard key"
+msgid "Decimal"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:82
+msgctxt "keyboard key"
+msgid "Multiply"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:83
+msgctxt "keyboard key"
+msgid "Divide"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:84
+msgctxt "keyboard key"
+msgid "Num_lock"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:84
+msgctxt "keyboard key"
+msgid "Num Lock"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:85
+msgctxt "keyboard key"
+msgid "Scroll_lock"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:85
+msgctxt "keyboard key"
+msgid "Scroll Lock"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:86
+msgctxt "keyboard key"
+msgid "KP_Space"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:86
+msgctxt "keyboard key"
+msgid "Num Space"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:87
+#, fuzzy
+msgctxt "keyboard key"
+msgid "KP_Tab"
+msgstr "KP_TAB"
+
+#: ../src/common/accelcmn.cpp:87
+msgctxt "keyboard key"
+msgid "Num Tab"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:88
+#, fuzzy
+msgctxt "keyboard key"
+msgid "KP_Enter"
+msgstr "Printeris"
+
+#: ../src/common/accelcmn.cpp:88
+msgctxt "keyboard key"
+msgid "Num Enter"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:89
+#, fuzzy
+msgctxt "keyboard key"
+msgid "KP_Home"
+msgstr "Home"
+
+#: ../src/common/accelcmn.cpp:89
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Num Home"
+msgstr "Home"
+
+#: ../src/common/accelcmn.cpp:90
+#, fuzzy
+msgctxt "keyboard key"
+msgid "KP_Left"
+msgstr "Pa kreisi"
+
+#: ../src/common/accelcmn.cpp:90
+msgctxt "keyboard key"
+msgid "Num left"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:91
+#, fuzzy
+msgctxt "keyboard key"
+msgid "KP_Up"
+msgstr "KP_UP"
+
+#: ../src/common/accelcmn.cpp:91
+msgctxt "keyboard key"
+msgid "Num Up"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:92
+#, fuzzy
+msgctxt "keyboard key"
+msgid "KP_Right"
+msgstr "Pa labi"
+
+#: ../src/common/accelcmn.cpp:92
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Num Right"
+msgstr "Pa labi"
+
+#: ../src/common/accelcmn.cpp:93
+#, fuzzy
+msgctxt "keyboard key"
+msgid "KP_Down"
+msgstr "Lejup"
+
+#: ../src/common/accelcmn.cpp:93
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Num Down"
+msgstr "Lejup"
+
+#: ../src/common/accelcmn.cpp:94
+msgctxt "keyboard key"
+msgid "KP_PageUp"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:94
+msgctxt "keyboard key"
+msgid "Num Page Up"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:95
+msgctxt "keyboard key"
+msgid "KP_PageDown"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:95
+msgctxt "keyboard key"
+msgid "Num Page Down"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:96
+msgctxt "keyboard key"
+msgid "KP_Prior"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:97
+#, fuzzy
+msgctxt "keyboard key"
+msgid "KP_Next"
+msgstr "Nākošais"
+
+#: ../src/common/accelcmn.cpp:98
+#, fuzzy
+msgctxt "keyboard key"
+msgid "KP_End"
+msgstr "KP_END"
+
+#: ../src/common/accelcmn.cpp:98
+msgctxt "keyboard key"
+msgid "Num End"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:99
+msgctxt "keyboard key"
+msgid "KP_Begin"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:99
+msgctxt "keyboard key"
+msgid "Num Begin"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:100
+#, fuzzy
+msgctxt "keyboard key"
+msgid "KP_Insert"
+msgstr "Insert"
+
+#: ../src/common/accelcmn.cpp:100
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Num Insert"
+msgstr "Insert"
+
+#: ../src/common/accelcmn.cpp:101
+#, fuzzy
+msgctxt "keyboard key"
+msgid "KP_Delete"
+msgstr "Dzēst"
+
+#: ../src/common/accelcmn.cpp:101
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Num Delete"
+msgstr "Dzēst"
+
+#: ../src/common/accelcmn.cpp:102
+msgctxt "keyboard key"
+msgid "KP_Equal"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:102
+msgctxt "keyboard key"
+msgid "Num ="
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:103
+msgctxt "keyboard key"
+msgid "KP_Multiply"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:103
+msgctxt "keyboard key"
+msgid "Num *"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:104
+#, fuzzy
+msgctxt "keyboard key"
+msgid "KP_Add"
+msgstr "KP_ADD"
+
+#: ../src/common/accelcmn.cpp:104
+msgctxt "keyboard key"
+msgid "Num +"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:105
+msgctxt "keyboard key"
+msgid "KP_Separator"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:105
+msgctxt "keyboard key"
+msgid "Num ,"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:106
+msgctxt "keyboard key"
+msgid "KP_Subtract"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:106
+msgctxt "keyboard key"
+msgid "Num -"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:107
+msgctxt "keyboard key"
+msgid "KP_Decimal"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:107
+msgctxt "keyboard key"
+msgid "Num ."
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:108
+msgctxt "keyboard key"
+msgid "KP_Divide"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:108
+msgctxt "keyboard key"
+msgid "Num /"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:109
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Windows_Left"
+msgstr "Windows 7"
+
+#: ../src/common/accelcmn.cpp:110
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Windows_Right"
+msgstr "Windows Vista"
+
+#: ../src/common/accelcmn.cpp:111
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Windows_Menu"
+msgstr "Windows ME"
+
+#: ../src/common/accelcmn.cpp:112
+msgctxt "keyboard key"
+msgid "Command"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:186 ../src/common/accelcmn.cpp:359
+msgctxt "keyboard key"
+msgid "Ctrl"
+msgstr "Ctrl"
+
+#: ../src/common/accelcmn.cpp:188 ../src/common/accelcmn.cpp:363
+msgctxt "keyboard key"
+msgid "Alt"
+msgstr "Alt"
+
+#: ../src/common/accelcmn.cpp:190 ../src/common/accelcmn.cpp:361
+msgctxt "keyboard key"
+msgid "Shift"
+msgstr "Shift"
+
+#: ../src/common/accelcmn.cpp:196
+msgctxt "keyboard key"
+msgid "num "
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:260 ../src/common/accelcmn.cpp:382
+msgctxt "keyboard key"
+msgid "F"
+msgstr "F"
+
+#: ../src/common/accelcmn.cpp:277 ../src/common/accelcmn.cpp:385
+msgctxt "keyboard key"
+msgid "KP_F"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:280 ../src/common/accelcmn.cpp:388
+msgctxt "keyboard key"
+msgid "KP_"
+msgstr "KP_"
+
+#: ../src/common/accelcmn.cpp:283 ../src/common/accelcmn.cpp:391
+msgctxt "keyboard key"
+msgid "SPECIAL"
+msgstr "Speciāls"
+
+#: ../src/common/accelcmn.cpp:373
+#, fuzzy
+msgid "Ctrl"
+msgstr "Ctrl"
+
+#: ../src/common/appbase.cpp:786
+msgid "show this help message"
+msgstr "parādīt šo palīdzības paziņojumu"
+
+#: ../src/common/appbase.cpp:796
+msgid "generate verbose log messages"
+msgstr "veidot izsmeļošus žurnāla ierakstus"
+
+#: ../src/common/appcmn.cpp:256
+msgid "specify the theme to use"
+msgstr "norādiet izmantojamo tēmu"
+
+#: ../src/common/appcmn.cpp:270
+msgid "specify display mode to use (e.g. 640x480-16)"
+msgstr "norādiet izmantojamo ekrāna režīmu (piem. 640x480-16)"
+
+#: ../src/common/appcmn.cpp:292
+#, c-format
+msgid "Unsupported theme '%s'."
+msgstr "Neatbalstīta tēma '%s'."
+
+#: ../src/common/appcmn.cpp:309
+#, c-format
+msgid "Invalid display mode specification '%s'."
+msgstr "Nederīga ekrāna režīma specifikācija '%s'."
+
+#: ../src/common/cmdline.cpp:875
+#, c-format
+msgid "Option '%s' can't be negated"
+msgstr ""
+
+#: ../src/common/cmdline.cpp:889
+#, c-format
+msgid "Unknown long option '%s'"
+msgstr "Nezināma garā opcija '%s'"
+
+#: ../src/common/cmdline.cpp:904 ../src/common/cmdline.cpp:926
+#, c-format
+msgid "Unknown option '%s'"
+msgstr "Nezināma opcija '%s'"
+
+#: ../src/common/cmdline.cpp:1004
+#, c-format
+msgid "Unexpected characters following option '%s'."
+msgstr "Negaidīti simboli aiz iestatījuma '%s'."
+
+#: ../src/common/cmdline.cpp:1039
+#, c-format
+msgid "Option '%s' requires a value."
+msgstr "Iestatījumam '%s' ir nepieciešama vērtība."
+
+#: ../src/common/cmdline.cpp:1058
+#, c-format
+msgid "Separator expected after the option '%s'."
+msgstr "Aiz iestatījuma '%s' ir jābūt atdalītājam."
+
+#: ../src/common/cmdline.cpp:1088 ../src/common/cmdline.cpp:1106
+#, c-format
+msgid "'%s' is not a correct numeric value for option '%s'."
+msgstr "'%s' ir nekorekta skaitliska vērtība opcijai '%s'."
+
+#: ../src/common/cmdline.cpp:1122
+#, c-format
+msgid "Option '%s': '%s' cannot be converted to a date."
+msgstr "Iestatījums '%s': '%s' nav pārvēršams par datumu."
+
+#: ../src/common/cmdline.cpp:1170
+#, c-format
+msgid "Unexpected parameter '%s'"
+msgstr "Negaidīts parametrs '%s'"
+
+#. TRANSLATORS: Short name and long name for a command line option
+#: ../src/common/cmdline.cpp:1197
+#, c-format
+msgid "%s (or %s)"
+msgstr "%s (vai %s)"
+
+#: ../src/common/cmdline.cpp:1208
+#, c-format
+msgid "The value for the option '%s' must be specified."
+msgstr "Ir jānorāda iestatījuma '%s' vērtība."
+
+#: ../src/common/cmdline.cpp:1230
+#, c-format
+msgid "The required parameter '%s' was not specified."
+msgstr "Nav norādīts nepieciešamais parametrs '%s'."
+
+#: ../src/common/cmdline.cpp:1289
+#, c-format
+msgid "Usage: %s"
+msgstr "Lietošana: %s"
+
+#: ../src/common/cmdline.cpp:1498
+msgid "str"
+msgstr "str"
+
+#: ../src/common/cmdline.cpp:1502
+msgid "num"
+msgstr "Num"
+
+#: ../src/common/cmdline.cpp:1506
+msgid "double"
+msgstr "dubults"
+
+#: ../src/common/cmdline.cpp:1510
+msgid "date"
+msgstr "datums"
+
+#: ../src/common/cmdproc.cpp:250 ../src/common/cmdproc.cpp:276
+#: ../src/common/cmdproc.cpp:296
+msgid "Unnamed command"
+msgstr "Nenosaukta komanda"
+
+#: ../src/common/cmdproc.cpp:253
+msgid "&Undo "
+msgstr "Atsa&ukt "
+
+#: ../src/common/cmdproc.cpp:255
+msgid "Can't &Undo "
+msgstr "Nevar &atcelt"
+
+#: ../src/common/cmdproc.cpp:259 ../src/common/stockitem.cpp:208
+#: ../src/msw/textctrl.cpp:2880 ../src/osx/textctrl_osx.cpp:649
+#: ../src/richtext/richtextctrl.cpp:327
+msgid "&Undo"
+msgstr "Atsa&ukt"
+
+#: ../src/common/cmdproc.cpp:277 ../src/common/cmdproc.cpp:297
+msgid "&Redo "
+msgstr "Atat&saukt "
+
+#: ../src/common/cmdproc.cpp:281 ../src/common/cmdproc.cpp:288
+#: ../src/common/stockitem.cpp:190 ../src/msw/textctrl.cpp:2881
+#: ../src/osx/textctrl_osx.cpp:650 ../src/richtext/richtextctrl.cpp:328
+msgid "&Redo"
+msgstr "Atat&saukt"
+
+#: ../src/common/colourcmn.cpp:41
+#, c-format
+msgid "String To Colour : Incorrect colour specification : %s"
+msgstr "Virkne par krāsu: nepareiza krāsas specifikācija: %s"
+
+#: ../src/common/config.cpp:259
+#, c-format
+msgid "Invalid value %ld for a boolean key \"%s\" in config file."
+msgstr "Konfigurācijas failā nederīga vērtība %ld Bula atslēgai \"%s\"."
+
+#: ../src/common/config.cpp:526
+#, c-format
+msgid ""
+"Environment variables expansion failed: missing '%c' at position %u in '%s'."
+msgstr ""
+
+#: ../src/common/config.cpp:576 ../src/msw/regconf.cpp:272
+#, c-format
+msgid "'%s' has extra '..', ignored."
+msgstr "'%s' ir lieks '..', nav ņemts vērā."
+
+#. TRANSLATORS: Checkbox state name
+#: ../src/common/datavcmn.cpp:2166 ../src/generic/datavgen.cpp:1430
+msgid "checked"
+msgstr ""
+
+#. TRANSLATORS: Checkbox state name
+#: ../src/common/datavcmn.cpp:2170 ../src/generic/datavgen.cpp:1432
+msgid "unchecked"
+msgstr ""
+
+#. TRANSLATORS: Checkbox state name
+#: ../src/common/datavcmn.cpp:2174
+#, fuzzy
+msgid "undetermined"
+msgstr "pasvītrots"
+
+#: ../src/common/datetimefmt.cpp:1875
+msgid "today"
+msgstr "šodiena"
+
+#: ../src/common/datetimefmt.cpp:1876
+msgid "yesterday"
+msgstr "varardiena"
+
+#: ../src/common/datetimefmt.cpp:1877
+msgid "tomorrow"
+msgstr "rītdiena"
+
+#: ../src/common/datetimefmt.cpp:2071
+msgid "first"
+msgstr "pirmais"
+
+#: ../src/common/datetimefmt.cpp:2072
+msgid "second"
+msgstr "otrais"
+
+#: ../src/common/datetimefmt.cpp:2073
+msgid "third"
+msgstr "trešā"
+
+#: ../src/common/datetimefmt.cpp:2074
+msgid "fourth"
+msgstr "ceturtais"
+
+#: ../src/common/datetimefmt.cpp:2075
+msgid "fifth"
+msgstr "piektais"
+
+#: ../src/common/datetimefmt.cpp:2076
+msgid "sixth"
+msgstr "sestais"
+
+#: ../src/common/datetimefmt.cpp:2077
+msgid "seventh"
+msgstr "septītais"
+
+#: ../src/common/datetimefmt.cpp:2078
+msgid "eighth"
+msgstr "astotais"
+
+#: ../src/common/datetimefmt.cpp:2079
+msgid "ninth"
+msgstr "devītais"
+
+#: ../src/common/datetimefmt.cpp:2080
+msgid "tenth"
+msgstr "desmitais"
+
+#: ../src/common/datetimefmt.cpp:2081
+msgid "eleventh"
+msgstr "vienpadsmitais"
+
+#: ../src/common/datetimefmt.cpp:2082
+msgid "twelfth"
+msgstr "divpadsmitais"
+
+#: ../src/common/datetimefmt.cpp:2083
+msgid "thirteenth"
+msgstr "trīspadsmitais"
+
+#: ../src/common/datetimefmt.cpp:2084
+msgid "fourteenth"
+msgstr "četrpadsmitais"
+
+#: ../src/common/datetimefmt.cpp:2085
+msgid "fifteenth"
+msgstr "piecpadsmitais"
+
+#: ../src/common/datetimefmt.cpp:2086
+msgid "sixteenth"
+msgstr "sešpadsmitais"
+
+#: ../src/common/datetimefmt.cpp:2087
+msgid "seventeenth"
+msgstr "septiņpadsmitais"
+
+#: ../src/common/datetimefmt.cpp:2088
+msgid "eighteenth"
+msgstr "astoņpadsmitais"
+
+#: ../src/common/datetimefmt.cpp:2089
+msgid "nineteenth"
+msgstr "deviņpadsmitais"
+
+#: ../src/common/datetimefmt.cpp:2090
+msgid "twentieth"
+msgstr "divdesmitais"
+
+#: ../src/common/datetimefmt.cpp:2248
+msgid "noon"
+msgstr "dienas vidus"
+
+#: ../src/common/datetimefmt.cpp:2249
+msgid "midnight"
+msgstr "pusnakts"
+
+#: ../src/common/debugrpt.cpp:209
+#, c-format
+msgid "Failed to create directory \"%s\""
+msgstr "Neizdevās izveidot mapi \"%s\""
+
+#: ../src/common/debugrpt.cpp:210
+msgid "Debug report couldn't be created."
+msgstr "Nav iespējams izveidot atkļūdošanas atskaiti."
+
+#: ../src/common/debugrpt.cpp:227
+#, c-format
+msgid "Failed to remove debug report file \"%s\""
+msgstr "Neizdevās izdzēst atkļūdošanas atskaites failu  \"%s\""
+
+#: ../src/common/debugrpt.cpp:239
+#, c-format
+msgid "Failed to clean up debug report directory \"%s\""
+msgstr "Nav iespējams iztīrīt atkļūdošanas atskaites mapi \"%s\""
+
+#: ../src/common/debugrpt.cpp:514
+msgid "process context description"
+msgstr "procesa konteksta apraksts"
+
+#: ../src/common/debugrpt.cpp:538
+msgid "dump of the process state (binary)"
+msgstr ""
+
+#: ../src/common/debugrpt.cpp:553
+msgid "Debug report generation has failed."
+msgstr "Neizdevās izveidot atkļūdošanas atskaiti."
+
+#: ../src/common/debugrpt.cpp:560
+#, c-format
+msgid ""
+"Processing debug report has failed, leaving the files in \"%s\" directory."
+msgstr ""
+"Atkļūdošanas atskaišu apstrāde neizdevās, faili tiek atstāti mapē \"%s\"."
+
+#: ../src/common/debugrpt.cpp:573
+msgid "A debug report has been generated. It can be found in"
+msgstr "Atkļūdošanas ziņojums ir izveidots. Tas ir atrodams"
+
+#: ../src/common/debugrpt.cpp:576
+msgid "And includes the following files:\n"
+msgstr "Un ietver sekojošus failus:\n"
+
+#: ../src/common/debugrpt.cpp:586
+msgid ""
+"\n"
+"Please send this report to the program maintainer, thank you!\n"
+msgstr ""
+"\n"
+"Lūdzu nosūtiet šo ziņojumu programmas uzturētajam, paldies!\n"
+
+#: ../src/common/debugrpt.cpp:729
+msgid "Failed to execute curl, please install it in PATH."
+msgstr "Neizdevās izpildīt curl, lūdzu uzstādiet to sistēmas ceļā (PATH)."
+
+#: ../src/common/debugrpt.cpp:742
+#, c-format
+msgid "Failed to upload the debug report (error code %d)."
+msgstr "Neizdevās augšupielādēt atkļūdošanas atskaiti (kļūda kods %d)."
+
+#: ../src/common/docview.cpp:366
+msgid "Save As"
+msgstr "Saglabāt kā"
+
+#: ../src/common/docview.cpp:457
+msgid "Discard changes and reload the last saved version?"
+msgstr "Atmest izmaiņas un atvērt pēdējo saglabāto versiju?"
+
+#: ../src/common/docview.cpp:488
+msgid "unnamed"
+msgstr "nenosaukts"
+
+#: ../src/common/docview.cpp:513
+#, c-format
+msgid "Do you want to save changes to %s?"
+msgstr "Vai vēlaties saglabāt izmaiņas %s?"
+
+#: ../src/common/docview.cpp:521 ../src/common/docview.cpp:560
+#: ../src/common/stockitem.cpp:195
+msgid "&Save"
+msgstr "&Saglabāt"
+
+#: ../src/common/docview.cpp:522 ../src/common/docview.cpp:560
+msgid "&Discard changes"
+msgstr ""
+
+#: ../src/common/docview.cpp:523
+#, fuzzy
+msgid "Do&n't close"
+msgstr "Nesaglabāt"
+
+#: ../src/common/docview.cpp:553
+#, fuzzy, c-format
+msgid "Do you want to save changes to %s before closing it?"
+msgstr "Vai vēlaties saglabāt izmaiņas %s?"
+
+#: ../src/common/docview.cpp:559
+#, fuzzy
+msgid "The document must be closed."
+msgstr "Tekstu nav iespējams saglabāt."
+
+#: ../src/common/docview.cpp:571
+#, c-format
+msgid "Saving %s failed, would you like to retry?"
+msgstr ""
+
+#: ../src/common/docview.cpp:577
+msgid "Retry"
+msgstr ""
+
+#: ../src/common/docview.cpp:577
+msgid "Discard changes"
+msgstr ""
+
+#: ../src/common/docview.cpp:679
+#, c-format
+msgid "File \"%s\" could not be opened for writing."
+msgstr "Fails \"%s\" nav atverams rakstīšanai."
+
+#: ../src/common/docview.cpp:685
+#, c-format
+msgid "Failed to save document to the file \"%s\"."
+msgstr "Neizdevās saglabāt dokumentu failā \"%s\"."
+
+#: ../src/common/docview.cpp:702
+#, c-format
+msgid "File \"%s\" could not be opened for reading."
+msgstr "Fails \"%s\" nav atverams lasīšanai."
+
+#: ../src/common/docview.cpp:714
+#, c-format
+msgid "Failed to read document from the file \"%s\"."
+msgstr "Neizdevās ielasīt dokumentu no faila \"%s\"."
+
+#: ../src/common/docview.cpp:1236
+#, c-format
+msgid ""
+"The file '%s' doesn't exist and couldn't be opened.\n"
+"It has been removed from the most recently used files list."
+msgstr ""
+"Fails '%s' nepastāv un nav atverams.\n"
+"Tas ir aizvākts no pēdējo izmantoto failu saraksta."
+
+#: ../src/common/docview.cpp:1296
+msgid "Print preview creation failed."
+msgstr "Neizdevās izveidot izdrukas priekšskatījumu."
+
+#: ../src/common/docview.cpp:1302
+msgid "Print Preview"
+msgstr "Drukas priekšskatījums"
+
+#: ../src/common/docview.cpp:1517
+#, c-format
+msgid "The format of file '%s' couldn't be determined."
+msgstr "Nav iespējams noteikt faila '%s' formātu."
+
+#: ../src/common/docview.cpp:1643
+#, c-format
+msgid "unnamed%d"
+msgstr "nenosaukts%d"
+
+#: ../src/common/docview.cpp:1660
+msgid " - "
+msgstr " - "
+
+#: ../src/common/docview.cpp:1791 ../src/common/docview.cpp:1844
+msgid "Open File"
+msgstr "Atvērt failu"
+
+#: ../src/common/docview.cpp:1807
+msgid "File error"
+msgstr "Faila kļūda"
+
+#: ../src/common/docview.cpp:1809
+msgid "Sorry, could not open this file."
+msgstr "Diemžēl, šis fails nav atverams."
+
+#: ../src/common/docview.cpp:1843
+msgid "Sorry, the format for this file is unknown."
+msgstr "Atvainojiet, šis faila formāts nav zinams."
+
+#: ../src/common/docview.cpp:1924
+msgid "Select a document template"
+msgstr "Izvēlieties dokumenta sagatavi"
+
+#: ../src/common/docview.cpp:1925
+msgid "Templates"
+msgstr "Sagataves"
+
+#: ../src/common/docview.cpp:1998
+msgid "Select a document view"
+msgstr "Izvēlieties dokumenta skatu"
+
+#: ../src/common/docview.cpp:1999
+msgid "Views"
+msgstr "Skati"
+
+#: ../src/common/dynlib.cpp:81
+#, c-format
+msgid "Failed to load shared library '%s'"
+msgstr "Nevar ielādēt koplietojamo bibliotēku '%s'"
+
+#: ../src/common/dynlib.cpp:105
+#, c-format
+msgid "Couldn't find symbol '%s' in a dynamic library"
+msgstr "Simbols '%s' nav atrodams dinamiskajā bibliotēkā"
+
+#: ../src/common/ffile.cpp:56 ../src/common/file.cpp:215
+#, c-format
+msgid "can't open file '%s'"
+msgstr "nevar atvērt failu '%s'"
+
+#: ../src/common/ffile.cpp:72
+#, c-format
+msgid "can't close file '%s'"
+msgstr "nevar aizvērt failu '%s'"
+
+#: ../src/common/ffile.cpp:106 ../src/common/ffile.cpp:131
+#, c-format
+msgid "Read error on file '%s'"
+msgstr "Lasīšanas kļūda failā '%s'"
+
+#: ../src/common/ffile.cpp:148
+#, c-format
+msgid "Write error on file '%s'"
+msgstr "Rakstīšanas kļūda failā '%s'"
+
+#: ../src/common/ffile.cpp:182
+#, c-format
+msgid "failed to flush the file '%s'"
+msgstr ""
+
+#: ../src/common/ffile.cpp:222
+#, c-format
+msgid "Seek error on file '%s' (large files not supported by stdio)"
+msgstr ""
+
+#: ../src/common/ffile.cpp:232
+#, c-format
+msgid "Seek error on file '%s'"
+msgstr ""
+
+#: ../src/common/ffile.cpp:248
+#, c-format
+msgid "Can't find current position in file '%s'"
+msgstr "Nav iespējams atrast pašreizējo pozīciju failā '%s'"
+
+#: ../src/common/ffile.cpp:349 ../src/common/file.cpp:569
+msgid "Failed to set temporary file permissions"
+msgstr "Neizdevās uzstādīt pieejas tiesības pagaidu failam"
+
+#: ../src/common/ffile.cpp:371
+#, c-format
+msgid "can't remove file '%s'"
+msgstr "nevar nodzēst failu '%s'"
+
+#: ../src/common/ffile.cpp:376 ../src/common/file.cpp:591
+#, c-format
+msgid "can't commit changes to file '%s'"
+msgstr "failā '%s' nav iespējams saglabāt izmaiņas"
+
+#: ../src/common/ffile.cpp:388 ../src/common/file.cpp:603
+#, c-format
+msgid "can't remove temporary file '%s'"
+msgstr "nevar nodzēst pagaidu failu '%s'"
+
+#: ../src/common/file.cpp:162
+#, c-format
+msgid "can't create file '%s'"
+msgstr "nevar izdzēst failu '%s'"
+
+#: ../src/common/file.cpp:229
+#, c-format
+msgid "can't close file descriptor %d"
+msgstr ""
+
+#: ../src/common/file.cpp:332
+#, c-format
+msgid "can't read from file descriptor %d"
+msgstr ""
+
+#: ../src/common/file.cpp:351
+#, c-format
+msgid "can't write to file descriptor %d"
+msgstr ""
+
+#: ../src/common/file.cpp:390
+#, c-format
+msgid "can't flush file descriptor %d"
+msgstr ""
+
+#: ../src/common/file.cpp:432
+#, c-format
+msgid "can't seek on file descriptor %d"
+msgstr ""
+
+#: ../src/common/file.cpp:446
+#, c-format
+msgid "can't get seek position on file descriptor %d"
+msgstr ""
+
+#: ../src/common/file.cpp:475
+#, c-format
+msgid "can't find length of file on file descriptor %d"
+msgstr ""
+
+#: ../src/common/file.cpp:505
+#, c-format
+msgid "can't determine if the end of file is reached on descriptor %d"
+msgstr ""
+
+#: ../src/common/fileconf.cpp:352
+#, c-format
+msgid ""
+" and additionally, the existing configuration file was renamed to \"%s\" and "
+"couldn't be renamed back, please rename it to its original path \"%s\""
+msgstr ""
+
+#: ../src/common/fileconf.cpp:389
+#, fuzzy
+msgid " due to the following error:\n"
+msgstr "Un ietver sekojošus failus:\n"
+
+#: ../src/common/fileconf.cpp:412
+#, fuzzy
+msgid "failed to rename the existing file"
+msgstr "Neizdevās ielasīt dokumentu no faila \"%s\"."
+
+#: ../src/common/fileconf.cpp:421
+#, fuzzy
+msgid "failed to create the new file directory"
+msgstr "Neizdevās noteikt darba mapi"
+
+#: ../src/common/fileconf.cpp:428
+#, fuzzy
+msgid "failed to move the file to the new location"
+msgstr "Neizdevās pārtraukt iezvanpieejas savienojumu: %s"
+
+#: ../src/common/fileconf.cpp:462
+#, c-format
+msgid "can't open global configuration file '%s'."
+msgstr "nevar atvērt globālo konfigurācijas failu '%s'."
+
+#: ../src/common/fileconf.cpp:478
+#, c-format
+msgid "can't open user configuration file '%s'."
+msgstr "nevar atvērt lietotāja konfigurācijas failu '%s'."
+
+#: ../src/common/fileconf.cpp:483
+#, c-format
+msgid "Changes won't be saved to avoid overwriting the existing file \"%s\""
+msgstr ""
+"Izmaiņas netiks saglabātas, lai izvairītos no pastāvošā faila \"%s\" "
+"pārrakstīšanas"
+
+#: ../src/common/fileconf.cpp:583
+msgid "Error reading config options."
+msgstr "Kļūda lasot konfigurācijas iestatījumus."
+
+#: ../src/common/fileconf.cpp:593
+msgid "Failed to read config options."
+msgstr "Neizdevās nolasīt konfigurācijas datus."
+
+#: ../src/common/fileconf.cpp:700
+#, fuzzy, c-format
+msgid "file '%s': unexpected character %c at line %zu."
+msgstr "fails '%s': negaidīts simbols %c %d rindā."
+
+#: ../src/common/fileconf.cpp:736
+#, fuzzy, c-format
+msgid "file '%s', line %zu: '%s' ignored after group header."
+msgstr "fails '%s', rinda %d: pēc grupas galvenes '%s' nav ņemts vērā."
+
+#: ../src/common/fileconf.cpp:765
+#, fuzzy, c-format
+msgid "file '%s', line %zu: '=' expected."
+msgstr "fails '%s', rinda %d: nepieciešama '=' ."
+
+#: ../src/common/fileconf.cpp:778
+#, fuzzy, c-format
+msgid "file '%s', line %zu: value for immutable key '%s' ignored."
+msgstr "fails '%s', rinda %d: nemainīgās atslēgas vērtība '%s' nav ņemta vērā."
+
+#: ../src/common/fileconf.cpp:788
+#, fuzzy, c-format
+msgid "file '%s', line %zu: key '%s' was first found at line %d."
+msgstr "fails '%s', rinda %d: atslēga '%s' pirmo reizi atrasta rindā %d."
+
+#: ../src/common/fileconf.cpp:1091
+#, c-format
+msgid "Config entry name cannot start with '%c'."
+msgstr "Konfigurācijas ieraksta nosaukums nevar sākties ar  '%c'."
+
+#: ../src/common/fileconf.cpp:1146
+#, fuzzy
+msgid "Failed to create configuration file directory."
+msgstr "Neizdevās atsvaidzināt lietotāja konfigurācijas failu."
+
+#: ../src/common/fileconf.cpp:1158
+msgid "can't open user configuration file."
+msgstr "nevar atvērt lietotāja konfigurācijas failu."
+
+#: ../src/common/fileconf.cpp:1172
+msgid "can't write user configuration file."
+msgstr "nevar pierakstīt lietotāja konfigurācijas failu."
+
+#: ../src/common/fileconf.cpp:1178
+msgid "Failed to update user configuration file."
+msgstr "Neizdevās atsvaidzināt lietotāja konfigurācijas failu."
+
+#: ../src/common/fileconf.cpp:1201
+msgid "Error saving user configuration data."
+msgstr "Kļūda saglabājot lietotāja konfigurācijas datus."
+
+#: ../src/common/fileconf.cpp:1313
+#, c-format
+msgid "can't delete user configuration file '%s'"
+msgstr "nevar izdzēst lietotāja konfigurācijas failu '%s'"
+
+#: ../src/common/fileconf.cpp:2007
+#, c-format
+msgid "entry '%s' appears more than once in group '%s'"
+msgstr "ieraksts '%s' grupā '%s' parādās vairākkārt"
+
+#: ../src/common/fileconf.cpp:2021
+#, c-format
+msgid "attempt to change immutable key '%s' ignored."
+msgstr "mēģinājums mainīt nemainīgu atslēgu '%s' nav ņemts vērā."
+
+#: ../src/common/fileconf.cpp:2118
+#, c-format
+msgid "trailing backslash ignored in '%s'"
+msgstr "nav ņemta vērā '%s' noslēdzošā reversā slīpsvītra"
+
+#: ../src/common/fileconf.cpp:2153
+#, c-format
+msgid "unexpected \" at position %d in '%s'."
+msgstr "negaidīta \"  pozīcijā %d virknē  '%s'."
+
+#: ../src/common/filefn.cpp:474
+#, c-format
+msgid "Failed to copy the file '%s' to '%s'"
+msgstr "Neizdevās nokopēt failu '%s' uz '%s'"
+
+#: ../src/common/filefn.cpp:487
+#, c-format
+msgid "Impossible to get permissions for file '%s'"
+msgstr "Nav iespējams iegūt pieejas tiesības failam  '%s'"
+
+#: ../src/common/filefn.cpp:501
+#, c-format
+msgid "Impossible to overwrite the file '%s'"
+msgstr "Nav iespējams pārrakstīt failu '%s'"
+
+#: ../src/common/filefn.cpp:508
+#, fuzzy, c-format
+msgid "Error copying the file '%s' to '%s'."
+msgstr "Neizdevās nokopēt failu '%s' uz '%s'"
+
+#: ../src/common/filefn.cpp:556
+#, c-format
+msgid "Impossible to set permissions for the file '%s'"
+msgstr "Nav iespējams noteikt pieejas tiesības failam '%s'"
+
+#: ../src/common/filefn.cpp:606
+#, c-format
+msgid ""
+"Failed to rename the file '%s' to '%s' because the destination file already "
+"exists."
+msgstr "Neizdevās pārdēvēt failu '%s' par '%s' jo mērķa fails jau pastāv."
+
+#: ../src/common/filefn.cpp:623
+#, c-format
+msgid "File '%s' couldn't be renamed '%s'"
+msgstr "Fails '%s' nav pārdēvējams par '%s'"
+
+#: ../src/common/filefn.cpp:639
+#, c-format
+msgid "File '%s' couldn't be removed"
+msgstr "Fails '%s' nav izdzēšams"
+
+#: ../src/common/filefn.cpp:666
+#, c-format
+msgid "Directory '%s' couldn't be created"
+msgstr "Mapi '%s' nevarēja izveidot"
+
+#: ../src/common/filefn.cpp:680
+#, c-format
+msgid "Directory '%s' couldn't be deleted"
+msgstr "Mapi '%s' nav iespējams izdzēst"
+
+#: ../src/common/filefn.cpp:714
+#, c-format
+msgid "Cannot enumerate files '%s'"
+msgstr "Nav iespējams uzskaitīt failus '%s'"
+
+#: ../src/common/filefn.cpp:798
+msgid "Failed to get the working directory"
+msgstr "Neizdevās noteikt darba mapi"
+
+#: ../src/common/filefn.cpp:843
+msgid "Could not set current working directory"
+msgstr "Neizdevās iestatīt pašreizējo darba mapi"
+
+#: ../src/common/filefn.cpp:974
+#, c-format
+msgid "Files (%s)"
+msgstr "Faili (%s)"
+
+#: ../src/common/filename.cpp:182
+#, c-format
+msgid "Failed to open '%s' for reading"
+msgstr "Neizdevās atvērt '%s' lasīšanai"
+
+#: ../src/common/filename.cpp:187
+#, c-format
+msgid "Failed to open '%s' for writing"
+msgstr "Neizdevās atvērt '%s' rakstīšanai"
+
+#: ../src/common/filename.cpp:199
+msgid "Failed to close file handle"
+msgstr "Neizdevās aizvērt faila turi."
+
+#: ../src/common/filename.cpp:1046
+msgid "Failed to create a temporary file name"
+msgstr "Neizdevās izveidot pagaidu faila nosaukumu"
+
+#: ../src/common/filename.cpp:1081
+msgid "Failed to open temporary file."
+msgstr "Neizdevās uz atvērt pagaidu failu"
+
+#: ../src/common/filename.cpp:2862
+#, c-format
+msgid "Failed to modify file times for '%s'"
+msgstr "Neizdevās izmainīt faila  '%s' laikus"
+
+#: ../src/common/filename.cpp:2877
+#, c-format
+msgid "Failed to touch the file '%s'"
+msgstr "Neizdevās pieskarties (touch) failam '%s'"
+
+#: ../src/common/filename.cpp:2958
+#, c-format
+msgid "Failed to retrieve file times for '%s'"
+msgstr "Neizdevās iegūt faila '%s' laikus"
+
+#: ../src/common/filepickercmn.cpp:39 ../src/common/filepickercmn.cpp:40
+msgid "Browse"
+msgstr "Pārlūkot"
+
+#: ../src/common/fldlgcmn.cpp:792 ../src/generic/filectrlg.cpp:1185
+#, c-format
+msgid "All files (%s)|%s"
+msgstr "Visus failus (%s)|%s"
+
+#. TRANSLATORS: %s are a file extension used to build a file wildcard string
+#: ../src/common/fldlgcmn.cpp:810
+#, c-format
+msgid "%s files (%s)|%s"
+msgstr "%s failus (%s)|%s"
+
+#: ../src/common/fldlgcmn.cpp:1072
+#, c-format
+msgid "Load %s file"
+msgstr "Ielādēt %s failu"
+
+#: ../src/common/fldlgcmn.cpp:1074
+#, c-format
+msgid "Save %s file"
+msgstr "Saglabāt %s failu "
+
+#: ../src/common/fmapbase.cpp:144
+msgid "Western European (ISO-8859-1)"
+msgstr "Rietumeiropas (ISO-8859-1)"
+
+#: ../src/common/fmapbase.cpp:145
+msgid "Central European (ISO-8859-2)"
+msgstr "Centrāl Eiropiešu (ISO-8859-2)"
+
+#: ../src/common/fmapbase.cpp:146
+msgid "Esperanto (ISO-8859-3)"
+msgstr "Esperanto (ISO-8859-3)"
+
+#: ../src/common/fmapbase.cpp:147
+msgid "Baltic (old) (ISO-8859-4)"
+msgstr "Baltijas (vecais) (ISO-8859-4)"
+
+#: ../src/common/fmapbase.cpp:148
+msgid "Cyrillic (ISO-8859-5)"
+msgstr "Kirilisks (ISO-8859-5)"
+
+#: ../src/common/fmapbase.cpp:149
+msgid "Arabic (ISO-8859-6)"
+msgstr "Arābu (ISO-8859-6)"
+
+#: ../src/common/fmapbase.cpp:150
+msgid "Greek (ISO-8859-7)"
+msgstr "Grieķu (ISO-8859-7)"
+
+#: ../src/common/fmapbase.cpp:151
+msgid "Hebrew (ISO-8859-8)"
+msgstr "Ebreju (ISO-8859-8)"
+
+#: ../src/common/fmapbase.cpp:152
+msgid "Turkish (ISO-8859-9)"
+msgstr "Turku (ISO-8859-9)"
+
+#: ../src/common/fmapbase.cpp:153
+msgid "Nordic (ISO-8859-10)"
+msgstr "Ziemeļvalstu (ISO-8859-10)"
+
+#: ../src/common/fmapbase.cpp:154
+msgid "Thai (ISO-8859-11)"
+msgstr "Taju (ISO-8859-11/TIS-620)"
+
+#: ../src/common/fmapbase.cpp:155
+msgid "Indian (ISO-8859-12)"
+msgstr "Indiešu (ISO-8859-12)"
+
+#: ../src/common/fmapbase.cpp:156
+msgid "Baltic (ISO-8859-13)"
+msgstr "Baltijas (ISO-8859-13)"
+
+#: ../src/common/fmapbase.cpp:157
+msgid "Celtic (ISO-8859-14)"
+msgstr "Ķeltu (ISO-8859-14)"
+
+#: ../src/common/fmapbase.cpp:158
+msgid "Western European with Euro (ISO-8859-15)"
+msgstr "Rietumeiropas ar Eiro (ISO-8859-15)"
+
+#: ../src/common/fmapbase.cpp:159
+msgid "KOI8-R"
+msgstr "KOI8-R"
+
+#: ../src/common/fmapbase.cpp:160
+msgid "KOI8-U"
+msgstr "KOI8-U"
+
+#: ../src/common/fmapbase.cpp:161
+msgid "Windows/DOS OEM Cyrillic (CP 866)"
+msgstr "Windows/DOS OEM Kirilica (CP 866)"
+
+#: ../src/common/fmapbase.cpp:162
+msgid "Windows Thai (CP 874)"
+msgstr "Windows Taju (CP 874)"
+
+#: ../src/common/fmapbase.cpp:163
+msgid "Windows Japanese (CP 932) or Shift-JIS"
+msgstr "Windows Japāņu (CP 932) va8i Shift-JIS"
+
+#: ../src/common/fmapbase.cpp:164
+msgid "Windows Chinese Simplified (CP 936) or GB-2312"
+msgstr "Windows Ķīnas vienkāršotais (CP 936) or GB-2312"
+
+#: ../src/common/fmapbase.cpp:165
+msgid "Windows Korean (CP 949)"
+msgstr "Windows Korean (CP 949)"
+
+#: ../src/common/fmapbase.cpp:166
+msgid "Windows Chinese Traditional (CP 950) or Big-5"
+msgstr "Windows Ķīnas tradicionālais (CP 950) or Big-5"
+
+#: ../src/common/fmapbase.cpp:167
+msgid "Windows Central European (CP 1250)"
+msgstr "Windows Centrāleiropas (CP 1250)"
+
+#: ../src/common/fmapbase.cpp:168
+msgid "Windows Cyrillic (CP 1251)"
+msgstr "Windows Kirilica (CP 1251)"
+
+#: ../src/common/fmapbase.cpp:169
+msgid "Windows Western European (CP 1252)"
+msgstr "Windows Rietumeiropas (CP 1252)"
+
+#: ../src/common/fmapbase.cpp:170
+msgid "Windows Greek (CP 1253)"
+msgstr "Windows Grieķu (CP 1253)"
+
+#: ../src/common/fmapbase.cpp:171
+msgid "Windows Turkish (CP 1254)"
+msgstr "Windows Turku (CP 1254)"
+
+#: ../src/common/fmapbase.cpp:172
+msgid "Windows Hebrew (CP 1255)"
+msgstr "Windows Ebreju (CP 1255)"
+
+#: ../src/common/fmapbase.cpp:173
+msgid "Windows Arabic (CP 1256)"
+msgstr "Windows Arābu (CP 1256)"
+
+#: ../src/common/fmapbase.cpp:174
+msgid "Windows Baltic (CP 1257)"
+msgstr "Windows Baltijas (CP 1257)"
+
+#: ../src/common/fmapbase.cpp:175
+#, fuzzy
+msgid "Windows Vietnamese (CP 1258)"
+msgstr "Windows Grieķu (CP 1253)"
+
+#: ../src/common/fmapbase.cpp:176
+#, fuzzy
+msgid "Windows Johab (CP 1361)"
+msgstr "Windows Arābu (CP 1256)"
+
+#: ../src/common/fmapbase.cpp:177
+msgid "Windows/DOS OEM (CP 437)"
+msgstr "Windows/DOS OEM (CP 437)"
+
+#: ../src/common/fmapbase.cpp:178
+msgid "Unicode 7 bit (UTF-7)"
+msgstr "Unikods 7 bit (UTF-7)"
+
+#: ../src/common/fmapbase.cpp:179
+msgid "Unicode 8 bit (UTF-8)"
+msgstr "Unikods 8 bit (UTF-8)"
+
+#: ../src/common/fmapbase.cpp:181 ../src/common/fmapbase.cpp:187
+msgid "Unicode 16 bit (UTF-16)"
+msgstr "Unikods 16 bit (UTF-16)"
+
+#: ../src/common/fmapbase.cpp:182
+msgid "Unicode 16 bit Little Endian (UTF-16LE)"
+msgstr "Unikods 16 bit Little Endian (UTF-16LE)"
+
+#: ../src/common/fmapbase.cpp:183 ../src/common/fmapbase.cpp:189
+msgid "Unicode 32 bit (UTF-32)"
+msgstr "Unikods 32 bit (UTF-32)"
+
+#: ../src/common/fmapbase.cpp:184
+msgid "Unicode 32 bit Little Endian (UTF-32LE)"
+msgstr "Unikods 32 bit Little Endian (UTF-32LE)"
+
+#: ../src/common/fmapbase.cpp:186
+msgid "Unicode 16 bit Big Endian (UTF-16BE)"
+msgstr "Unikods 16 bit Big Endian (UTF-16BE)"
+
+#: ../src/common/fmapbase.cpp:188
+msgid "Unicode 32 bit Big Endian (UTF-32BE)"
+msgstr "Unikods 32 bit Big Endian (UTF-32BE)"
+
+#: ../src/common/fmapbase.cpp:191
+msgid "Extended Unix Codepage for Japanese (EUC-JP)"
+msgstr "Paplašinātā Unix kodu lapa japāņu valodai (EUC-JP)"
+
+#: ../src/common/fmapbase.cpp:192
+msgid "US-ASCII"
+msgstr "US-ASCII"
+
+#: ../src/common/fmapbase.cpp:193
+msgid "ISO-2022-JP"
+msgstr "ISO-2022-JP"
+
+#: ../src/common/fmapbase.cpp:195
+msgid "MacRoman"
+msgstr "Romāņu (MacRoman)"
+
+#: ../src/common/fmapbase.cpp:196
+msgid "MacJapanese"
+msgstr "Japāņu (MacJapanese)"
+
+#: ../src/common/fmapbase.cpp:197
+msgid "MacChineseTrad"
+msgstr "Ķīnas tradicionālais (MacChineseTrad)"
+
+#: ../src/common/fmapbase.cpp:198
+msgid "MacKorean"
+msgstr "Korejiešu (MacKorean)"
+
+#: ../src/common/fmapbase.cpp:199
+msgid "MacArabic"
+msgstr "Arābu (MacArabic)"
+
+#: ../src/common/fmapbase.cpp:200
+msgid "MacHebrew"
+msgstr "Ebreju (MacHebrew)"
+
+#: ../src/common/fmapbase.cpp:201
+msgid "MacGreek"
+msgstr "Grieķu (MacGreek)"
+
+#: ../src/common/fmapbase.cpp:202
+msgid "MacCyrillic"
+msgstr "Kirilica (MacCyrillic)"
+
+#: ../src/common/fmapbase.cpp:203
+msgid "MacDevanagari"
+msgstr "Devanagari (MacDevanagari)"
+
+#: ../src/common/fmapbase.cpp:204
+msgid "MacGurmukhi"
+msgstr "Gurmuhi (MacGurmukhi)"
+
+#: ../src/common/fmapbase.cpp:205
+msgid "MacGujarati"
+msgstr "Gudžaratu (MacGujarati)"
+
+#: ../src/common/fmapbase.cpp:206
+msgid "MacOriya"
+msgstr "MacOriya"
+
+#: ../src/common/fmapbase.cpp:207
+msgid "MacBengali"
+msgstr "Bengāļu (MacBengali)"
+
+#: ../src/common/fmapbase.cpp:208
+msgid "MacTamil"
+msgstr "Tamilu (MacTamil)"
+
+#: ../src/common/fmapbase.cpp:209
+msgid "MacTelugu"
+msgstr "Telugu (MacTelugu)"
+
+#: ../src/common/fmapbase.cpp:210
+msgid "MacKannada"
+msgstr "MacKannada"
+
+#: ../src/common/fmapbase.cpp:211
+msgid "MacMalayalam"
+msgstr "MacMalayalam"
+
+#: ../src/common/fmapbase.cpp:212
+msgid "MacSinhalese"
+msgstr "MacSinhalese"
+
+#: ../src/common/fmapbase.cpp:213
+msgid "MacBurmese"
+msgstr "Birmas (MacBurmese)"
+
+#: ../src/common/fmapbase.cpp:214
+msgid "MacKhmer"
+msgstr "Khmeru (MacKhmer)"
+
+#: ../src/common/fmapbase.cpp:215
+msgid "MacThai"
+msgstr "Taju (MacThai)"
+
+#: ../src/common/fmapbase.cpp:216
+msgid "MacLaotian"
+msgstr "Laosiešu (MacLaotian)"
+
+#: ../src/common/fmapbase.cpp:217
+msgid "MacGeorgian"
+msgstr "Gruzīņu (MacGeorgian)"
+
+#: ../src/common/fmapbase.cpp:218
+msgid "MacArmenian"
+msgstr "Armēņu (MacArmenian)"
+
+#: ../src/common/fmapbase.cpp:219
+msgid "MacChineseSimp"
+msgstr "Ķīnas vienkāršotais (MacChineseSimp)"
+
+#: ../src/common/fmapbase.cpp:220
+msgid "MacTibetan"
+msgstr "Tibetiešu (MacTibetan)"
+
+#: ../src/common/fmapbase.cpp:221
+msgid "MacMongolian"
+msgstr "Mongoļu (MacMongolian)"
+
+#: ../src/common/fmapbase.cpp:222
+msgid "MacEthiopic"
+msgstr "Etiopiešu (MacEthiopic)"
+
+#: ../src/common/fmapbase.cpp:223
+msgid "MacCentralEurRoman"
+msgstr "Centrāleiropas romāņu (MacCentralEurRoman)"
+
+#: ../src/common/fmapbase.cpp:224
+msgid "MacVietnamese"
+msgstr "Vjetnamiešu (MacVietnamese)"
+
+#: ../src/common/fmapbase.cpp:225
+msgid "MacExtArabic"
+msgstr "Arābu papl. (MacExtArabic)"
+
+#: ../src/common/fmapbase.cpp:226
+msgid "MacSymbol"
+msgstr "Simbolu (MacSymbol)"
+
+#: ../src/common/fmapbase.cpp:227
+msgid "MacDingbats"
+msgstr "MacDingbats"
+
+#: ../src/common/fmapbase.cpp:228
+msgid "MacTurkish"
+msgstr "Turku (MacTurkish)"
+
+#: ../src/common/fmapbase.cpp:229
+msgid "MacCroatian"
+msgstr "Horvātu (MacCroatian)"
+
+#: ../src/common/fmapbase.cpp:230
+msgid "MacIcelandic"
+msgstr "Islandiešu (MacIcelandic)"
+
+#: ../src/common/fmapbase.cpp:231
+msgid "MacRomanian"
+msgstr "Rumāņu (MacRomanian)"
+
+#: ../src/common/fmapbase.cpp:232
+msgid "MacCeltic"
+msgstr "Ķeltu (MacCeltic)"
+
+#: ../src/common/fmapbase.cpp:233
+msgid "MacGaelic"
+msgstr "Īru (MacGaelic)"
+
+#: ../src/common/fmapbase.cpp:234
+msgid "MacKeyboardGlyphs"
+msgstr "MacKeyboardGlyphs"
+
+#: ../src/common/fmapbase.cpp:791
+msgid "Default encoding"
+msgstr "Noklusētais kodējums"
+
+#: ../src/common/fmapbase.cpp:805
+#, c-format
+msgid "Unknown encoding (%d)"
+msgstr "Nezināms kodējums (%d)"
+
+#: ../src/common/fmapbase.cpp:815 ../src/richtext/richtextstyles.cpp:776
+msgid "default"
+msgstr "noklusētais"
+
+#: ../src/common/fmapbase.cpp:829
+#, c-format
+msgid "unknown-%d"
+msgstr "nezināms-%d"
+
+#: ../src/common/fontcmn.cpp:924 ../src/common/fontcmn.cpp:1130
+msgid "underlined"
+msgstr "pasvītrots"
+
+#: ../src/common/fontcmn.cpp:929
+msgid " strikethrough"
+msgstr " caursvītrots"
+
+#: ../src/common/fontcmn.cpp:942
+msgid " thin"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:946
+#, fuzzy
+msgid " extra light"
+msgstr "gaišs"
+
+#: ../src/common/fontcmn.cpp:950
+msgid " light"
+msgstr "gaišs"
+
+#: ../src/common/fontcmn.cpp:954
+msgid " medium"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:958
+#, fuzzy
+msgid " semi bold"
+msgstr "treknraksts"
+
+#: ../src/common/fontcmn.cpp:962
+msgid " bold"
+msgstr "treknraksts"
+
+#: ../src/common/fontcmn.cpp:966
+#, fuzzy
+msgid " extra bold"
+msgstr "treknraksts"
+
+#: ../src/common/fontcmn.cpp:970
+msgid " heavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:974
+msgid " extra heavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:990
+msgid " italic"
+msgstr "kursīvs"
+
+#: ../src/common/fontcmn.cpp:1134
+msgid "strikethrough"
+msgstr "caursvītrots"
+
+#: ../src/common/fontcmn.cpp:1143
+msgid "thin"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1156
+#, fuzzy
+msgid "extralight"
+msgstr "viegls"
+
+#: ../src/common/fontcmn.cpp:1161
+msgid "light"
+msgstr "viegls"
+
+#: ../src/common/fontcmn.cpp:1169 ../src/richtext/richtextstyles.cpp:775
+msgid "normal"
+msgstr "normāls"
+
+#: ../src/common/fontcmn.cpp:1174
+msgid "medium"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1179 ../src/common/fontcmn.cpp:1199
+#, fuzzy
+msgid "semibold"
+msgstr "treknraksts"
+
+#: ../src/common/fontcmn.cpp:1184
+msgid "bold"
+msgstr "treknraksts"
+
+#: ../src/common/fontcmn.cpp:1194
+#, fuzzy
+msgid "extrabold"
+msgstr "treknraksts"
+
+#: ../src/common/fontcmn.cpp:1204
+msgid "heavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1212
+msgid "extraheavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1217
+msgid "italic"
+msgstr "slīpraksts"
+
+#: ../src/common/fontmap.cpp:195
+msgid ": unknown charset"
+msgstr ": nezināma rakstzīmju kopa"
+
+#: ../src/common/fontmap.cpp:199
+#, c-format
+msgid ""
+"The charset '%s' is unknown. You may select\n"
+"another charset to replace it with or choose\n"
+"[Cancel] if it cannot be replaced"
+msgstr ""
+"Kodējums '%s' ir nepazīstams. Varat izvēlēties\n"
+"citu kodējumu, ar ko to aizvietot, vai izvēlēties\n"
+"[Atcelt], ja tas nav aizvietojams."
+
+#: ../src/common/fontmap.cpp:241
+#, c-format
+msgid "Failed to remember the encoding for the charset '%s'."
+msgstr ""
+
+#: ../src/common/fontmap.cpp:321
+msgid "can't load any font, aborting"
+msgstr "nav iespējams ielādēt nevienu fontu, pārtrauc darbu"
+
+#: ../src/common/fontmap.cpp:409
+msgid ": unknown encoding"
+msgstr ": nezināms kodējums"
+
+#: ../src/common/fontmap.cpp:417
+#, c-format
+msgid ""
+"No font for displaying text in encoding '%s' found,\n"
+"but an alternative encoding '%s' is available.\n"
+"Do you want to use this encoding (otherwise you will have to choose another "
+"one)?"
+msgstr ""
+"Nav atrasts fonts teksta attēlošanai kodējumā '%s',\n"
+"taču ir pieejams alternatīvam kodējumam '%s'.\n"
+"Vai vēlaties izmantot šo kodējumu (citādi būs jāizvēlas cits)?"
+
+#: ../src/common/fontmap.cpp:422
+#, c-format
+msgid ""
+"No font for displaying text in encoding '%s' found.\n"
+"Would you like to select a font to be used for this encoding\n"
+"(otherwise the text in this encoding will not be shown correctly)?"
+msgstr ""
+"Nav atrasts fonts teksta attēlošanai kodējumā '%s'\n"
+"Vai vēlaties izvēlēties citu fontu šim kodējumam\n"
+"(citādi teksts šajā kodējumā tiks attēlots nekorekti)?"
+
+#: ../src/common/fs_mem.cpp:169
+#, c-format
+msgid "Memory VFS already contains file '%s'!"
+msgstr "Atmiņas VFS jau ir fails '%s'!"
+
+#: ../src/common/fs_mem.cpp:232
+#, c-format
+msgid "Trying to remove file '%s' from memory VFS, but it is not loaded!"
+msgstr "Mēģinājums aizvākt failu '%s' no atmiņas VFS, taču tas nav ielādēts!"
+
+#: ../src/common/fs_mem.cpp:262
+#, c-format
+msgid "Failed to store image '%s' to memory VFS!"
+msgstr "Neizdevās saglabāt attēlu '%s' atmiņas VFS!"
+
+#: ../src/common/ftp.cpp:197
+msgid "Timeout while waiting for FTP server to connect, try passive mode."
+msgstr ""
+
+#: ../src/common/ftp.cpp:399
+#, c-format
+msgid "Failed to set FTP transfer mode to %s."
+msgstr "Neizdevās uzstādīt FTP datu pārraides režīmu %s."
+
+#: ../src/common/ftp.cpp:400 ../src/richtext/richtextsymboldlg.cpp:432
+msgid "ASCII"
+msgstr "ASCII"
+
+#: ../src/common/ftp.cpp:400
+msgid "binary"
+msgstr "binārs"
+
+#: ../src/common/ftp.cpp:608
+msgid "The FTP server doesn't support the PORT command."
+msgstr "FTP serveris neatbalsta PORT komandu."
+
+#: ../src/common/ftp.cpp:622
+msgid "The FTP server doesn't support passive mode."
+msgstr "FTP serveris neatbalsta pasīvo režīmu."
+
+#: ../src/common/gifdecod.cpp:822
+#, c-format
+msgid "Incorrect GIF frame size (%u, %d) for the frame #%u"
+msgstr ""
+
+#: ../src/common/glcmn.cpp:108
+msgid "Failed to allocate colour for OpenGL"
+msgstr "Neizdevās piešķirt krāsu OpenGL"
+
+#: ../src/common/headerctrlcmn.cpp:57
+msgid "Please select the columns to show and define their order:"
+msgstr "Lūdzu, izvēlieties attēlojamās slejas un nosakiet to kārtību:"
+
+#: ../src/common/headerctrlcmn.cpp:58
+msgid "Customize Columns"
+msgstr "Pielāgot slejas"
+
+#: ../src/common/headerctrlcmn.cpp:304
+msgid "&Customize..."
+msgstr "&Pielāgot..."
+
+#: ../src/common/hyperlnkcmn.cpp:132
+#, fuzzy, c-format
+msgid "Failed to open URL \"%s\" in the default browser"
+msgstr "Noklusētajā pārlūkā neizdevās atvērt URL \"%s\"."
+
+#: ../src/common/iconbndl.cpp:195
+#, c-format
+msgid "Failed to load image %%d from file '%s'."
+msgstr "Neizdevās ielādēt attēlu %%d no faila '%s'."
+
+#: ../src/common/iconbndl.cpp:203
+#, c-format
+msgid "Failed to load image %d from stream."
+msgstr "Neizdevās ielādēt attēlu %d no straumējuma."
+
+#: ../src/common/iconbndl.cpp:221
+#, fuzzy, c-format
+msgid "Failed to load icons from resource '%s'."
+msgstr "Neizdevās ielādēt attēlu %d no straumējuma."
+
+#: ../src/common/imagbmp.cpp:97
+msgid "BMP: Couldn't save invalid image."
+msgstr "BMP: nevar saglabāt kļūdainu attēlu."
+
+#: ../src/common/imagbmp.cpp:137
+msgid "BMP: wxImage doesn't have own wxPalette."
+msgstr "BMP: wxImage nepastās individuāla wxPalette."
+
+#: ../src/common/imagbmp.cpp:243
+msgid "BMP: Couldn't write the file (Bitmap) header."
+msgstr "BMP: nav iespējams pierakstīt faila (Bitmap) galveni."
+
+#: ../src/common/imagbmp.cpp:266
+msgid "BMP: Couldn't write the file (BitmapInfo) header."
+msgstr "BMP: nav iespējams pierakstīt faila  (BitmapInfo) galveni."
+
+#: ../src/common/imagbmp.cpp:353
+msgid "BMP: Couldn't write RGB color map."
+msgstr "BMP: nav iespējams pierakstīt RGB krāsu karti."
+
+#: ../src/common/imagbmp.cpp:487
+msgid "BMP: Couldn't write data."
+msgstr "BMP: nevar ierakstīt datus."
+
+#: ../src/common/imagbmp.cpp:561 ../src/common/imagbmp.cpp:642
+msgid "BMP: Couldn't allocate memory."
+msgstr "BMP: nevar piešķirt atmiņu."
+
+#: ../src/common/imagbmp.cpp:1041
+msgid "DIB Header: Image width > 32767 pixels for file."
+msgstr "DIB galvene: attēla platums > 32767 pikseļiem."
+
+#: ../src/common/imagbmp.cpp:1049
+msgid "DIB Header: Image height > 32767 pixels for file."
+msgstr "DIB galvene: attēla augstums > 32767 pikseļiem."
+
+#: ../src/common/imagbmp.cpp:1081
+msgid "DIB Header: Unknown bitdepth in file."
+msgstr "DIB galvene: nezināms bitu dziļums."
+
+#: ../src/common/imagbmp.cpp:1156
+msgid "DIB Header: Unknown encoding in file."
+msgstr "DIB galvene: nezināms faila kodējums."
+
+#: ../src/common/imagbmp.cpp:1165
+msgid "DIB Header: Encoding doesn't match bitdepth."
+msgstr "DIB galvene: kodējums neatbilst bitu dziļumam."
+
+#: ../src/common/imagbmp.cpp:1180
+#, c-format
+msgid "BMP Header: Invalid number of colors (%d)."
+msgstr ""
+
+#: ../src/common/imagbmp.cpp:1273
+msgid "Error in reading image DIB."
+msgstr "Kļūda nolasot attēla DIB"
+
+#: ../src/common/imagbmp.cpp:1294
+msgid "ICO: Error in reading mask DIB."
+msgstr "ICO: kļūda lasot DIB masku."
+
+#: ../src/common/imagbmp.cpp:1353
+msgid "ICO: Image too tall for an icon."
+msgstr "ICO: attēls ikonai ir pārāk augsts."
+
+#: ../src/common/imagbmp.cpp:1361
+msgid "ICO: Image too wide for an icon."
+msgstr "ICO: attēls ikonai ir pārāk plats."
+
+#: ../src/common/imagbmp.cpp:1388 ../src/common/imagbmp.cpp:1488
+#: ../src/common/imagbmp.cpp:1503 ../src/common/imagbmp.cpp:1514
+#: ../src/common/imagbmp.cpp:1528 ../src/common/imagbmp.cpp:1576
+#: ../src/common/imagbmp.cpp:1591 ../src/common/imagbmp.cpp:1605
+#: ../src/common/imagbmp.cpp:1616
+msgid "ICO: Error writing the image file!"
+msgstr "ICO: kļūda rakstot attēla failu!"
+
+#: ../src/common/imagbmp.cpp:1701
+msgid "ICO: Invalid icon index."
+msgstr "ICO: nederīgs ikonas indekss."
+
+#: ../src/common/image.cpp:2410
+msgid "Image and mask have different sizes."
+msgstr "Attēla un maskas izmēri nesakrīt."
+
+#: ../src/common/image.cpp:2418 ../src/common/image.cpp:2459
+msgid "No unused colour in image being masked."
+msgstr ""
+
+#: ../src/common/image.cpp:2641
+#, fuzzy, c-format
+msgid "Failed to load bitmap \"%s\" from resources."
+msgstr "Neizdevās ielādēt attēlu %d no straumējuma."
+
+#: ../src/common/image.cpp:2650
+#, fuzzy, c-format
+msgid "Failed to load icon \"%s\" from resources."
+msgstr "Neizdevās ielādēt attēlu %d no straumējuma."
+
+#: ../src/common/image.cpp:2728 ../src/common/image.cpp:2747
+#, c-format
+msgid "Failed to load image from file \"%s\"."
+msgstr "Neizdevās ielādēt attēlu no faila \"%s\"."
+
+#: ../src/common/image.cpp:2761
+#, c-format
+msgid "Can't save image to file '%s': unknown extension."
+msgstr "Nav iespējams saglabāt attēlu failā '%s: nezināms paplašinājums."
+
+#: ../src/common/image.cpp:2869
+msgid "No handler found for image type."
+msgstr ""
+
+#: ../src/common/image.cpp:2877 ../src/common/image.cpp:3000
+#: ../src/common/image.cpp:3066
+#, c-format
+msgid "No image handler for type %d defined."
+msgstr ""
+
+#: ../src/common/image.cpp:2887
+#, c-format
+msgid "Image file is not of type %d."
+msgstr "Attēla faila tips nav %d."
+
+#: ../src/common/image.cpp:2970
+msgid "Can't automatically determine the image format for non-seekable input."
+msgstr ""
+
+#: ../src/common/image.cpp:2988
+msgid "Unknown image data format."
+msgstr "Nezinām attēla datu formāts."
+
+#: ../src/common/image.cpp:3009
+#, c-format
+msgid "This is not a %s."
+msgstr "Šis nav %s."
+
+#: ../src/common/image.cpp:3032 ../src/common/image.cpp:3080
+#, c-format
+msgid "No image handler for type %s defined."
+msgstr ""
+
+#: ../src/common/image.cpp:3041
+#, c-format
+msgid "Image is not of type %s."
+msgstr "Attēla tips nav %s."
+
+#: ../src/common/image.cpp:3509
+#, c-format
+msgid "Failed to check format of image file \"%s\"."
+msgstr "Neizdevās pārbaudīt attēla \"%s\" faila formātu."
+
+#: ../src/common/imaggif.cpp:124
+msgid "GIF: error in GIF image format."
+msgstr "GIF: kļūda GIF attēla formātā."
+
+#: ../src/common/imaggif.cpp:129
+msgid "GIF: not enough memory."
+msgstr "GIF: nepietiek atmiņas."
+
+#: ../src/common/imaggif.cpp:134
+msgid "GIF: data stream seems to be truncated."
+msgstr "GIF: datu plūsma šķiet aprauta."
+
+#: ../src/common/imaggif.cpp:240
+msgid "Couldn't initialize GIF hash table."
+msgstr "Neizdevās inicializēt GIF hash tabulu"
+
+#: ../src/common/imagiff.cpp:739
+msgid "IFF: error in IFF image format."
+msgstr "IFF: kļūda IFF attēla formātā."
+
+#: ../src/common/imagiff.cpp:742
+msgid "IFF: not enough memory."
+msgstr "IFF: nepietiek atmiņas."
+
+#: ../src/common/imagiff.cpp:745
+msgid "IFF: unknown error!!!"
+msgstr "IFF: nezināma kļūda!!!"
+
+#: ../src/common/imagiff.cpp:755
+msgid "IFF: data stream seems to be truncated."
+msgstr "IFF: datu plūsma šķiet aprauta."
+
+#: ../src/common/imagjpeg.cpp:258
+msgid "JPEG: Couldn't load - file is probably corrupted."
+msgstr "JPEG: nav atverams - iespējams, fails ir bojāts."
+
+#: ../src/common/imagjpeg.cpp:437
+msgid "JPEG: Couldn't save image."
+msgstr "JPEG: nav iespējams saglabāt attēlu."
+
+#: ../src/common/imagpcx.cpp:439
+msgid "PCX: this is not a PCX file."
+msgstr "PCX: tas nav  PCX fails."
+
+#: ../src/common/imagpcx.cpp:453
+msgid "PCX: image format unsupported"
+msgstr "PCX: neatbalstīts attēla formāts"
+
+#: ../src/common/imagpcx.cpp:454 ../src/common/imagpcx.cpp:477
+msgid "PCX: couldn't allocate memory"
+msgstr "PCX: nevar piešķirt atmiņu."
+
+#: ../src/common/imagpcx.cpp:455
+msgid "PCX: version number too low"
+msgstr "PCX: pārāk zems versijas numurs"
+
+#: ../src/common/imagpcx.cpp:456 ../src/common/imagpcx.cpp:478
+msgid "PCX: unknown error !!!"
+msgstr "PCX: nezināma kļūda!!!"
+
+#: ../src/common/imagpcx.cpp:476
+msgid "PCX: invalid image"
+msgstr "PCX: nederīgs attēls"
+
+#: ../src/common/imagpng.cpp:385
+#, c-format
+msgid "Unknown PNG resolution unit %d"
+msgstr "Nezināma PNG izšķirtspējas vienība %d"
+
+#: ../src/common/imagpng.cpp:439
+msgid "Couldn't load a PNG image - file is corrupted or not enough memory."
+msgstr "Neizdevās atvērt PNG attēlu - bojāts fails vai nepietiek atmiņas."
+
+#: ../src/common/imagpng.cpp:513 ../src/common/imagpng.cpp:524
+#: ../src/common/imagpng.cpp:534
+msgid "Couldn't save PNG image."
+msgstr "Neizdevās saglabāt PNG attēlu."
+
+#: ../src/common/imagpnm.cpp:71
+msgid "PNM: File format is not recognized."
+msgstr "PNM: faila formāts nav atpazīts."
+
+#: ../src/common/imagpnm.cpp:89
+msgid "PNM: Couldn't allocate memory."
+msgstr "PNM: nevar piešķirt atmiņu."
+
+#: ../src/common/imagpnm.cpp:111 ../src/common/imagpnm.cpp:134
+#: ../src/common/imagpnm.cpp:156
+msgid "PNM: File seems truncated."
+msgstr "PNM: fails šķiet aprauts."
+
+#: ../src/common/imagtiff.cpp:69
+#, c-format
+msgid " (in module \"%s\")"
+msgstr " (modulī \"%s\")"
+
+#: ../src/common/imagtiff.cpp:304
+msgid "TIFF: Error loading image."
+msgstr "TIFF: kļūda ielādējot attēlu."
+
+#: ../src/common/imagtiff.cpp:314
+msgid "Invalid TIFF image index."
+msgstr "Nederīgs TIFF attēla indekss."
+
+#: ../src/common/imagtiff.cpp:358
+msgid "TIFF: Image size is abnormally big."
+msgstr "TIFF: attēla izmērs ir nedabīgi liels."
+
+#: ../src/common/imagtiff.cpp:372 ../src/common/imagtiff.cpp:385
+#: ../src/common/imagtiff.cpp:769
+msgid "TIFF: Couldn't allocate memory."
+msgstr "TIFF: nevar piešķirt atmiņu."
+
+#: ../src/common/imagtiff.cpp:471
+msgid "TIFF: Error reading image."
+msgstr "TIFF: kļūda lasot attēlu."
+
+#: ../src/common/imagtiff.cpp:532
+#, c-format
+msgid "Unknown TIFF resolution unit %d ignored"
+msgstr "Nav ņemta vērā nezināma TIFF izšķirtspējas vienība %d"
+
+#: ../src/common/imagtiff.cpp:611
+msgid "TIFF: Error saving image."
+msgstr "TIFF: kļūda saglabājot attēlu."
+
+#: ../src/common/imagtiff.cpp:868
+msgid "TIFF: Error writing image."
+msgstr "TIFF: kļūda pierakstot attēlu."
+
+#: ../src/common/imagtiff.cpp:881
+#, fuzzy
+msgid "TIFF: Error flushing data."
+msgstr "TIFF: kļūda saglabājot attēlu."
+
+#: ../src/common/imagwebp.cpp:56
+msgid "WebP: Invalid data (failed to get features)."
+msgstr ""
+
+#: ../src/common/imagwebp.cpp:65
+msgid "WebP: Allocating image memory failed."
+msgstr ""
+
+#: ../src/common/imagwebp.cpp:82
+msgid "WebP: Decoding RGBA image data failed."
+msgstr ""
+
+#: ../src/common/imagwebp.cpp:98
+msgid "WebP: Decoding RGB image data failed."
+msgstr ""
+
+#: ../src/common/imagwebp.cpp:113 ../src/common/imagwebp.cpp:201
+msgid "WebP: Allocating stream buffer failed."
+msgstr ""
+
+#: ../src/common/imagwebp.cpp:131
+#, fuzzy
+msgid "WebP: Failed to parse container data."
+msgstr "Neizdevās iestatīt starpliktuves datus."
+
+#: ../src/common/imagwebp.cpp:222
+#, fuzzy
+msgid "WebP: Error decoding animation."
+msgstr "Kļūda lasot konfigurācijas iestatījumus."
+
+#: ../src/common/imagwebp.cpp:240
+msgid "WebP: Error getting next animation frame."
+msgstr ""
+
+#: ../src/common/init.cpp:172
+#, c-format
+msgid ""
+"Command line argument %d couldn't be converted to Unicode and will be "
+"ignored."
+msgstr ""
+"Komandrindas parametru %d nav iespējams pārvērst uz Unikodu, tāpēc tas "
+"netiks ņemts vērā."
+
+#: ../src/common/init.cpp:344
+msgid "Initialization failed in post init, aborting."
+msgstr ""
+
+#: ../src/common/intl.cpp:378
+#, c-format
+msgid "Cannot set locale to language \"%s\"."
+msgstr "Neizdevās uzstādīt valodas \"%s\" lokāli."
+
+#: ../src/common/log.cpp:232
+msgid "Error: "
+msgstr "Kļūda: "
+
+#: ../src/common/log.cpp:236
+msgid "Warning: "
+msgstr "Brīdinājums: "
+
+#: ../src/common/log.cpp:284
+msgid "The previous message repeated once."
+msgstr "Iepriekšējais paziņojums atkārtojās vienreiz."
+
+#: ../src/common/log.cpp:291
+#, fuzzy, c-format
+msgid "The previous message repeated %u time."
+msgid_plural "The previous message repeated %u times."
+msgstr[0] "Iepriekšējais paziņojums atkārtojās %lu reizi."
+msgstr[1] "Iepriekšējais paziņojums atkārtojās %lu reizes."
+msgstr[2] "Iepriekšējais paziņojums atkārtojās %lu reizes."
+
+#: ../src/common/log.cpp:319
+#, fuzzy, c-format
+msgid "Last repeated message (\"%s\", %u time) wasn't output"
+msgid_plural "Last repeated message (\"%s\", %u times) wasn't output"
+msgstr[0] "Pēdējais atkārtotais paziņojums (\"%s\", %lu reize) netika izvadīts"
+msgstr[1] "Pēdējie atkārtotie paziņojumi (\"%s\", %lu reizes) netika izvadīti"
+msgstr[2] "Pēdējais atkārtotais paziņojums (\"%s\", %lu reize) netika izvadīts"
+
+#: ../src/common/log.cpp:435
+#, c-format
+msgid " (error %ld: %s)"
+msgstr " (kļūda %ld: %s)"
+
+#: ../src/common/lzmastream.cpp:121
+#, fuzzy
+msgid "Failed to allocate memory for LZMA decompression."
+msgstr "Neizdevās piešķirt krāsu OpenGL"
+
+#: ../src/common/lzmastream.cpp:125
+#, c-format
+msgid "Failed to initialize LZMA decompression: unexpected error %u."
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:179
+msgid "input is not in XZ format"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:183
+msgid "input compressed using unknown XZ option"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:188
+msgid "input is corrupted"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:192
+#, fuzzy
+msgid "unknown decompression error"
+msgstr "atspiešanas kļūda"
+
+#: ../src/common/lzmastream.cpp:196
+#, fuzzy, c-format
+msgid "LZMA decompression error: %s"
+msgstr "atspiešanas kļūda"
+
+#: ../src/common/lzmastream.cpp:231
+#, fuzzy
+msgid "Failed to allocate memory for LZMA compression."
+msgstr "Neizdevās piešķirt krāsu OpenGL"
+
+#: ../src/common/lzmastream.cpp:235
+#, c-format
+msgid "Failed to initialize LZMA compression: unexpected error %u."
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:267 ../src/common/lzmastream.cpp:342
+#: ../src/html/chm.cpp:336
+msgid "out of memory"
+msgstr "pietrūkst atmiņas"
+
+#: ../src/common/lzmastream.cpp:276 ../src/common/lzmastream.cpp:346
+#, fuzzy
+msgid "unknown compression error"
+msgstr "saspiešanas kļūda"
+
+#: ../src/common/lzmastream.cpp:280
+#, fuzzy, c-format
+msgid "LZMA compression error: %s"
+msgstr "saspiešanas kļūda"
+
+#: ../src/common/lzmastream.cpp:350
+#, c-format
+msgid "LZMA compression error when flushing output: %s"
+msgstr ""
+
+#: ../src/common/mimecmn.cpp:167
+#, c-format
+msgid "Unmatched '{' in an entry for mime type %s."
+msgstr "Nenoslēgta '{' MIME tipa %s ierakstā."
+
+#: ../src/common/module.cpp:76
+#, c-format
+msgid "Circular dependency involving module \"%s\" detected."
+msgstr ""
+
+#: ../src/common/module.cpp:128
+#, c-format
+msgid "Dependency \"%s\" of module \"%s\" doesn't exist."
+msgstr "Bibliotēka \"%s\", kas nepieciešama moduļa \"%s\" darbībai, nepastāv."
+
+#: ../src/common/module.cpp:137
+#, c-format
+msgid "Module \"%s\" initialization failed"
+msgstr "Neizdevās inicializēt moduli \"%s\""
+
+#: ../src/common/msgout.cpp:96
+msgid "Message"
+msgstr "Vēstule"
+
+#: ../src/common/paper.cpp:70
+msgid "Letter, 8 1/2 x 11 in"
+msgstr "Letter, 8 1/2 x 11 in"
+
+#: ../src/common/paper.cpp:71
+msgid "Legal, 8 1/2 x 14 in"
+msgstr "Legal, 8 1/2 x 14 in"
+
+#: ../src/common/paper.cpp:72
+msgid "A4 sheet, 210 x 297 mm"
+msgstr "A4 loksne, 210 x 297 mm"
+
+#: ../src/common/paper.cpp:73
+msgid "C sheet, 17 x 22 in"
+msgstr "C loksne, 432 x 559 mm"
+
+#: ../src/common/paper.cpp:74
+msgid "D sheet, 22 x 34 in"
+msgstr "D loksne, 559 x 864 mm"
+
+#: ../src/common/paper.cpp:75
+msgid "E sheet, 34 x 44 in"
+msgstr "E loksne, 34 x 44 in"
+
+#: ../src/common/paper.cpp:76
+msgid "Letter Small, 8 1/2 x 11 in"
+msgstr "Letter Small, 8 1/2 x 11 in"
+
+#: ../src/common/paper.cpp:77
+msgid "Tabloid, 11 x 17 in"
+msgstr "Tabloid, 11 x 17 in"
+
+#: ../src/common/paper.cpp:78
+msgid "Ledger, 17 x 11 in"
+msgstr "Ledger, 17 x 11 in"
+
+#: ../src/common/paper.cpp:79
+msgid "Statement, 5 1/2 x 8 1/2 in"
+msgstr "Statement, 5 1/2 x 8 1/2 in"
+
+#: ../src/common/paper.cpp:80
+msgid "Executive, 7 1/4 x 10 1/2 in"
+msgstr "Executive, 7 1/4 x 10 1/2 in"
+
+#: ../src/common/paper.cpp:81
+msgid "A3 sheet, 297 x 420 mm"
+msgstr "A3 loksne, 297 x 420 mm"
+
+#: ../src/common/paper.cpp:82
+msgid "A4 small sheet, 210 x 297 mm"
+msgstr "A4 mazā loksne, 210 x 297 mm"
+
+#: ../src/common/paper.cpp:83
+msgid "A5 sheet, 148 x 210 mm"
+msgstr "A5 loksne, 148 x 210 mm"
+
+#: ../src/common/paper.cpp:84
+msgid "B4 sheet, 250 x 354 mm"
+msgstr "B4 loksne, 250 x 354 mm"
+
+#: ../src/common/paper.cpp:85
+msgid "B5 sheet, 182 x 257 millimeter"
+msgstr "B5 loksne, 182 x 257 mm"
+
+#: ../src/common/paper.cpp:86
+msgid "Folio, 8 1/2 x 13 in"
+msgstr "Folio, 8 1/2 x 13 in"
+
+#: ../src/common/paper.cpp:87
+msgid "Quarto, 215 x 275 mm"
+msgstr "Quarto, 215 x 275 mm"
+
+#: ../src/common/paper.cpp:88
+msgid "10 x 14 in"
+msgstr "25.4 x 35.6 cm"
+
+#: ../src/common/paper.cpp:89
+msgid "11 x 17 in"
+msgstr "27.9 x 43.2 cm"
+
+#: ../src/common/paper.cpp:90
+msgid "Note, 8 1/2 x 11 in"
+msgstr "Note, 8 1/2 x 11 in"
+
+#: ../src/common/paper.cpp:91
+msgid "#9 Envelope, 3 7/8 x 8 7/8 in"
+msgstr "Aploksne Nr. 9, 9.8 x 22.5 cm"
+
+#: ../src/common/paper.cpp:92
+msgid "#10 Envelope, 4 1/8 x 9 1/2 in"
+msgstr "Aploksne Nr. 10, 10.5 x 24.1 cm"
+
+#: ../src/common/paper.cpp:93
+msgid "#11 Envelope, 4 1/2 x 10 3/8 in"
+msgstr "Aploksne Nr. 11, 11.4 x 26.4 cm"
+
+#: ../src/common/paper.cpp:94
+msgid "#12 Envelope, 4 3/4 x 11 in"
+msgstr "Aploksne Nr. 12, 12.1 x 27.9 cm"
+
+#: ../src/common/paper.cpp:95
+msgid "#14 Envelope, 5 x 11 1/2 in"
+msgstr "Aploksne Nr. 14, 12.7 x 29.2 cm"
+
+#: ../src/common/paper.cpp:96
+msgid "DL Envelope, 110 x 220 mm"
+msgstr "Aploksne DL, 110 x 220 mm"
+
+#: ../src/common/paper.cpp:97
+msgid "C5 Envelope, 162 x 229 mm"
+msgstr "C5 aploksne, 162 x 229 mm"
+
+#: ../src/common/paper.cpp:98
+msgid "C3 Envelope, 324 x 458 mm"
+msgstr "C3 aploksne, 324 x 458 mm"
+
+#: ../src/common/paper.cpp:99
+msgid "C4 Envelope, 229 x 324 mm"
+msgstr "C4 aploksne, 229 x 324 mm"
+
+#: ../src/common/paper.cpp:100
+msgid "C6 Envelope, 114 x 162 mm"
+msgstr "C6 aploksne, 114 x 162 mm"
+
+#: ../src/common/paper.cpp:101
+msgid "C65 Envelope, 114 x 229 mm"
+msgstr "C65 aploksne, 114 x 229 mm"
+
+#: ../src/common/paper.cpp:102
+msgid "B4 Envelope, 250 x 353 mm"
+msgstr "B4 aploksne, 250 x 353 mm"
+
+#: ../src/common/paper.cpp:103
+msgid "B5 Envelope, 176 x 250 mm"
+msgstr "B5 aploksne, 176 x 250 mm"
+
+#: ../src/common/paper.cpp:104
+msgid "B6 Envelope, 176 x 125 mm"
+msgstr "B6 aploksne, 176 x 125 mm"
+
+#: ../src/common/paper.cpp:105
+msgid "Italy Envelope, 110 x 230 mm"
+msgstr "Itāļu aploksne, 110 x 230 mm"
+
+#: ../src/common/paper.cpp:106
+msgid "Monarch Envelope, 3 7/8 x 7 1/2 in"
+msgstr "Monarch aploksne, 3 7/8 x 7 1/2 in"
+
+#: ../src/common/paper.cpp:107
+msgid "6 3/4 Envelope, 3 5/8 x 6 1/2 in"
+msgstr "Aplpksne 6 3/4, 9.2 x 16.5 cm"
+
+#: ../src/common/paper.cpp:108
+msgid "US Std Fanfold, 14 7/8 x 11 in"
+msgstr "US Std Fanfold, 14 7/8 x 11 in"
+
+#: ../src/common/paper.cpp:109
+msgid "German Std Fanfold, 8 1/2 x 12 in"
+msgstr "German Std Fanfold, 8 1/2 x 12 in"
+
+#: ../src/common/paper.cpp:110
+msgid "German Legal Fanfold, 8 1/2 x 13 in"
+msgstr "German Legal Fanfold, 8 1/2 x 13 in"
+
+#: ../src/common/paper.cpp:112
+msgid "B4 (ISO) 250 x 353 mm"
+msgstr "B4 (ISO) 250 x 353 mm"
+
+#: ../src/common/paper.cpp:113
+msgid "Japanese Postcard 100 x 148 mm"
+msgstr "Japāņu pastkarte 100 x 148 mm"
+
+#: ../src/common/paper.cpp:114
+msgid "9 x 11 in"
+msgstr "9 x 11 in"
+
+#: ../src/common/paper.cpp:115
+msgid "10 x 11 in"
+msgstr "10 x 11 in"
+
+#: ../src/common/paper.cpp:116
+msgid "15 x 11 in"
+msgstr "15 x 11 in"
+
+#: ../src/common/paper.cpp:117
+msgid "Envelope Invite 220 x 220 mm"
+msgstr "Aploksne Invite 220 x 220 mm"
+
+#: ../src/common/paper.cpp:118
+msgid "Letter Extra 9 1/2 x 12 in"
+msgstr "Letter Extra 9 1/2 x 12 in"
+
+#: ../src/common/paper.cpp:119
+msgid "Legal Extra 9 1/2 x 15 in"
+msgstr "Legal Extra 9 1/2 x 15 in"
+
+#: ../src/common/paper.cpp:120
+msgid "Tabloid Extra 11.69 x 18 in"
+msgstr "Tabloid Extra 11.69 x 18 in"
+
+#: ../src/common/paper.cpp:121
+msgid "A4 Extra 9.27 x 12.69 in"
+msgstr "A4 Extra 9.27 x 12.69 in"
+
+#: ../src/common/paper.cpp:122
+msgid "Letter Transverse 8 1/2 x 11 in"
+msgstr "Letter Transverse 8 1/2 x 11 in"
+
+#: ../src/common/paper.cpp:123
+msgid "A4 Transverse 210 x 297 mm"
+msgstr "A4 Transverse 210 x 297 mm"
+
+#: ../src/common/paper.cpp:124
+msgid "Letter Extra Transverse 9.275 x 12 in"
+msgstr "Letter Extra Transverse 9.275 x 12 in"
+
+#: ../src/common/paper.cpp:125
+msgid "SuperA/SuperA/A4 227 x 356 mm"
+msgstr "SuperA/SuperA/A4 227 x 356 mm"
+
+#: ../src/common/paper.cpp:126
+msgid "SuperB/SuperB/A3 305 x 487 mm"
+msgstr "SuperB/SuperB/A3 305 x 487 mm"
+
+#: ../src/common/paper.cpp:127
+msgid "Letter Plus 8 1/2 x 12.69 in"
+msgstr "Letter Plus 8 1/2 x 12.69 in"
+
+#: ../src/common/paper.cpp:128
+msgid "A4 Plus 210 x 330 mm"
+msgstr "A4 Plus 210 x 330 mm"
+
+#: ../src/common/paper.cpp:129
+msgid "A5 Transverse 148 x 210 mm"
+msgstr "A5 Transverse 148 x 210 mm"
+
+#: ../src/common/paper.cpp:130
+msgid "B5 (JIS) Transverse 182 x 257 mm"
+msgstr "B5 (JIS) Transverse 182 x 257 mm"
+
+#: ../src/common/paper.cpp:131
+msgid "A3 Extra 322 x 445 mm"
+msgstr "A3 Extra 322 x 445 mm"
+
+#: ../src/common/paper.cpp:132
+msgid "A5 Extra 174 x 235 mm"
+msgstr "A5 Extra 174 x 235 mm"
+
+#: ../src/common/paper.cpp:133
+msgid "B5 (ISO) Extra 201 x 276 mm"
+msgstr "B5 (ISO) Extra 201 x 276 mm"
+
+#: ../src/common/paper.cpp:134
+msgid "A2 420 x 594 mm"
+msgstr "A2 420 x 594 mm"
+
+#: ../src/common/paper.cpp:135
+msgid "A3 Transverse 297 x 420 mm"
+msgstr "A3 Transverse 297 x 420 mm"
+
+#: ../src/common/paper.cpp:136
+msgid "A3 Extra Transverse 322 x 445 mm"
+msgstr "A3 Extra Transverse 322 x 445 mm"
+
+#: ../src/common/paper.cpp:138
+msgid "Japanese Double Postcard 200 x 148 mm"
+msgstr "Japāņu dubultā pastkate, 200 x 148 mm"
+
+#: ../src/common/paper.cpp:139
+msgid "A6 105 x 148 mm"
+msgstr "A6 105 x 148 mm"
+
+#: ../src/common/paper.cpp:140
+msgid "Japanese Envelope Kaku #2"
+msgstr "Japāņu aploksne Kaku #2"
+
+#: ../src/common/paper.cpp:141
+msgid "Japanese Envelope Kaku #3"
+msgstr "Japāņu aploksne Kaku #3"
+
+#: ../src/common/paper.cpp:142
+msgid "Japanese Envelope Chou #3"
+msgstr "Japāņu aploksne Chou #3"
+
+#: ../src/common/paper.cpp:143
+msgid "Japanese Envelope Chou #4"
+msgstr "Japāņu aploksne Chou #4"
+
+#: ../src/common/paper.cpp:144
+msgid "Letter Rotated 11 x 8 1/2 in"
+msgstr "Letter Rotated 11 x 8 1/2 in"
+
+#: ../src/common/paper.cpp:145
+msgid "A3 Rotated 420 x 297 mm"
+msgstr "A3 Rotated 420 x 297 mm"
+
+#: ../src/common/paper.cpp:146
+msgid "A4 Rotated 297 x 210 mm"
+msgstr "A4 Rotated 297 x 210 mm"
+
+#: ../src/common/paper.cpp:147
+msgid "A5 Rotated 210 x 148 mm"
+msgstr "A5 Rotated 210 x 148 mm"
+
+#: ../src/common/paper.cpp:148
+msgid "B4 (JIS) Rotated 364 x 257 mm"
+msgstr "B4 (JIS) Rotated 364 x 257 mm"
+
+#: ../src/common/paper.cpp:149
+msgid "B5 (JIS) Rotated 257 x 182 mm"
+msgstr "B5 (JIS) Rotated 257 x 182 mm"
+
+#: ../src/common/paper.cpp:150
+msgid "Japanese Postcard Rotated 148 x 100 mm"
+msgstr "Japāņu pastkate, pagriezta 148 x 100 mm"
+
+#: ../src/common/paper.cpp:151
+msgid "Double Japanese Postcard Rotated 148 x 200 mm"
+msgstr "Dubultā Japāņu pastkarte, pagriezta, 148 x 200 mm"
+
+#: ../src/common/paper.cpp:152
+msgid "A6 Rotated 148 x 105 mm"
+msgstr "A6 Rotated 148 x 105 mm"
+
+#: ../src/common/paper.cpp:153
+msgid "Japanese Envelope Kaku #2 Rotated"
+msgstr "Japāņu aploksne Kaku #2 Rotated"
+
+#: ../src/common/paper.cpp:154
+msgid "Japanese Envelope Kaku #3 Rotated"
+msgstr "Japāņu aploksne Kaku #3 Rotated"
+
+#: ../src/common/paper.cpp:155
+msgid "Japanese Envelope Chou #3 Rotated"
+msgstr "Japāņu aploksne Chou #3 Rotated"
+
+#: ../src/common/paper.cpp:156
+msgid "Japanese Envelope Chou #4 Rotated"
+msgstr "Japāņu aploksne Chou #4 Rotated"
+
+#: ../src/common/paper.cpp:157
+msgid "B6 (JIS) 128 x 182 mm"
+msgstr "B6 (JIS) 128 x 182 mm"
+
+#: ../src/common/paper.cpp:158
+msgid "B6 (JIS) Rotated 182 x 128 mm"
+msgstr "B6 (JIS) Rotated 182 x 128 mm"
+
+#: ../src/common/paper.cpp:159
+msgid "12 x 11 in"
+msgstr "12 x 11 in"
+
+#: ../src/common/paper.cpp:160
+msgid "Japanese Envelope You #4"
+msgstr "Japāņu aploksne You #4"
+
+#: ../src/common/paper.cpp:161
+msgid "Japanese Envelope You #4 Rotated"
+msgstr "Japāņu aploksne You #4 Rotated"
+
+#: ../src/common/paper.cpp:162
+msgid "PRC 16K 146 x 215 mm"
+msgstr "ĶTR 16K 146 x 215 mm"
+
+#: ../src/common/paper.cpp:163
+msgid "PRC 32K 97 x 151 mm"
+msgstr "ĶTR 32K 97 x 151 mm"
+
+#: ../src/common/paper.cpp:164
+msgid "PRC 32K(Big) 97 x 151 mm"
+msgstr "ĶTR 32K(Big) 97 x 151 mm"
+
+#: ../src/common/paper.cpp:165
+msgid "PRC Envelope #1 102 x 165 mm"
+msgstr "ĶTR aploksne #1 102 x 165 mm"
+
+#: ../src/common/paper.cpp:166
+msgid "PRC Envelope #2 102 x 176 mm"
+msgstr "ĶTR aploksne #2 102 x 176 mm"
+
+#: ../src/common/paper.cpp:167
+msgid "PRC Envelope #3 125 x 176 mm"
+msgstr "ĶTR aploksne #3 125 x 176 mm"
+
+#: ../src/common/paper.cpp:168
+msgid "PRC Envelope #4 110 x 208 mm"
+msgstr "ĶTR aploksne #4 110 x 208 mm"
+
+#: ../src/common/paper.cpp:169
+msgid "PRC Envelope #5 110 x 220 mm"
+msgstr "ĶTR aploksne #5 110 x 220 mm"
+
+#: ../src/common/paper.cpp:170
+msgid "PRC Envelope #6 120 x 230 mm"
+msgstr "ĶTR aploksne #6 120 x 230 mm"
+
+#: ../src/common/paper.cpp:171
+msgid "PRC Envelope #7 160 x 230 mm"
+msgstr "ĶTR aploksne #7 160 x 230 mm"
+
+#: ../src/common/paper.cpp:172
+msgid "PRC Envelope #8 120 x 309 mm"
+msgstr "ĶTR aploksne #8 120 x 309 mm"
+
+#: ../src/common/paper.cpp:173
+msgid "PRC Envelope #9 229 x 324 mm"
+msgstr "ĶTR aploksne #9 229 x 324 mm"
+
+#: ../src/common/paper.cpp:174
+msgid "PRC Envelope #10 324 x 458 mm"
+msgstr "ĶTR aploksne #10 324 x 458 mm"
+
+#: ../src/common/paper.cpp:175
+msgid "PRC 16K Rotated"
+msgstr "ĶTR 16K pagriezta"
+
+#: ../src/common/paper.cpp:176
+msgid "PRC 32K Rotated"
+msgstr "ĶTR 32K pagriezta"
+
+#: ../src/common/paper.cpp:177
+msgid "PRC 32K(Big) Rotated"
+msgstr "ĶTR 32K(Big) pagriezta"
+
+#: ../src/common/paper.cpp:178
+msgid "PRC Envelope #1 Rotated 165 x 102 mm"
+msgstr "ĶTR aploksne #1 Rotated 165 x 102 mm"
+
+#: ../src/common/paper.cpp:179
+msgid "PRC Envelope #2 Rotated 176 x 102 mm"
+msgstr "ĶTR aploksne #2 Rotated 176 x 102 mm"
+
+#: ../src/common/paper.cpp:180
+msgid "PRC Envelope #3 Rotated 176 x 125 mm"
+msgstr "ĶTR aploksne #3 Rotated 176 x 125 mm"
+
+#: ../src/common/paper.cpp:181
+msgid "PRC Envelope #4 Rotated 208 x 110 mm"
+msgstr "ĶTR aploksne #4 Rotated 208 x 110 mm"
+
+#: ../src/common/paper.cpp:182
+msgid "PRC Envelope #5 Rotated 220 x 110 mm"
+msgstr "ĶTR aploksne #5 Rotated 220 x 110 mm"
+
+#: ../src/common/paper.cpp:183
+msgid "PRC Envelope #6 Rotated 230 x 120 mm"
+msgstr "ĶTR aploksne #6 Rotated 230 x 120 mm"
+
+#: ../src/common/paper.cpp:184
+msgid "PRC Envelope #7 Rotated 230 x 160 mm"
+msgstr "ĶTR aploksne #7 Rotated 230 x 160 mm"
+
+#: ../src/common/paper.cpp:185
+msgid "PRC Envelope #8 Rotated 309 x 120 mm"
+msgstr "ĶTR aploksne #8 Rotated 309 x 120 mm"
+
+#: ../src/common/paper.cpp:186
+msgid "PRC Envelope #9 Rotated 324 x 229 mm"
+msgstr "ĶTR aploksne #9 Rotated 324 x 229 mm"
+
+#: ../src/common/paper.cpp:187
+msgid "PRC Envelope #10 Rotated 458 x 324 mm"
+msgstr "ĶTR aploksne #10 Rotated 458 x 324 mm"
+
+#: ../src/common/paper.cpp:192
+msgid "A0 sheet, 841 x 1189 mm"
+msgstr "A0 loksne, 841 x 1189 mm"
+
+#: ../src/common/paper.cpp:193
+msgid "A1 sheet, 594 x 841 mm"
+msgstr "A1 loksne,  594 x 841 mm"
+
+#: ../src/common/preferencescmn.cpp:37
+msgid "General"
+msgstr ""
+
+#: ../src/common/preferencescmn.cpp:40
+msgid "Advanced"
+msgstr ""
+
+#: ../src/common/prntbase.cpp:245
+msgid "Generic PostScript"
+msgstr "Klasiskais PostScript"
+
+#: ../src/common/prntbase.cpp:259
+msgid "Ready"
+msgstr "Gatavs"
+
+#: ../src/common/prntbase.cpp:331
+msgid "Printing Error"
+msgstr "Drukāšanas Kļūda"
+
+#: ../src/common/prntbase.cpp:413 ../src/common/prntbase.cpp:1597
+#: ../src/generic/prntdlgg.cpp:135 ../src/generic/prntdlgg.cpp:149
+#: ../src/gtk/print.cpp:628 ../src/gtk/print.cpp:646
+msgid "Print"
+msgstr "Drukāt"
+
+#: ../src/common/prntbase.cpp:471 ../src/generic/prntdlgg.cpp:809
+msgid "Page setup"
+msgstr "Lapas iestatījumi"
+
+#: ../src/common/prntbase.cpp:525
+#, fuzzy
+msgid "Please wait while printing..."
+msgstr "Lūdzu, gaidiet, notiek drukāšana\n"
+
+#: ../src/common/prntbase.cpp:529
+#, fuzzy
+msgid "Document:"
+msgstr "Dokumentācijas autori"
+
+#: ../src/common/prntbase.cpp:532
+msgid "Progress:"
+msgstr ""
+
+#: ../src/common/prntbase.cpp:533
+msgid "Preparing"
+msgstr ""
+
+#: ../src/common/prntbase.cpp:552
+#, fuzzy, c-format
+msgid "Printing page %d"
+msgstr "Drukājas lapa %d..."
+
+#: ../src/common/prntbase.cpp:557
+#, fuzzy, c-format
+msgid "Printing page %d of %d"
+msgstr "Drukājas lapa %d..."
+
+#: ../src/common/prntbase.cpp:560
+#, fuzzy, c-format
+msgid " (copy %d of %d)"
+msgstr "Lapa %d no %d"
+
+#: ../src/common/prntbase.cpp:1604
+msgid "First page"
+msgstr "Pirmā lapa"
+
+#: ../src/common/prntbase.cpp:1609 ../src/html/helpwnd.cpp:659
+msgid "Previous page"
+msgstr "Iepriekšējā lapa"
+
+#: ../src/common/prntbase.cpp:1623 ../src/html/helpwnd.cpp:660
+msgid "Next page"
+msgstr "Nākamā lapa"
+
+#: ../src/common/prntbase.cpp:1628
+msgid "Last page"
+msgstr "Pēdējā lapa"
+
+#: ../src/common/prntbase.cpp:1636 ../src/common/stockitem.cpp:215
+msgid "Zoom Out"
+msgstr "Attālināt"
+
+#: ../src/common/prntbase.cpp:1650 ../src/common/stockitem.cpp:214
+msgid "Zoom In"
+msgstr "Tuvināt"
+
+#: ../src/common/prntbase.cpp:1656 ../src/common/stockitem.cpp:153
+#: ../src/generic/logg.cpp:553 ../src/univ/themes/win32.cpp:3752
+msgid "&Close"
+msgstr "Ai&zvērt"
+
+#: ../src/common/prntbase.cpp:2085
+msgid "Could not start document preview."
+msgstr "Neizdevās parādīt dokumenta priekšskatījumu."
+
+#: ../src/common/prntbase.cpp:2085 ../src/common/prntbase.cpp:2129
+#: ../src/common/prntbase.cpp:2137
+msgid "Print Preview Failure"
+msgstr "Drukas priekšskatījuma kļūda"
+
+#: ../src/common/prntbase.cpp:2129 ../src/common/prntbase.cpp:2137
+msgid "Sorry, not enough memory to create a preview."
+msgstr ""
+"Diemžēl, nav pietiekami daudz brīvas atmiņas priekšskatījuma izveidošanai."
+
+#: ../src/common/prntbase.cpp:2144
+#, c-format
+msgid "Page %d of %d"
+msgstr "Lapa %d no %d"
+
+#: ../src/common/prntbase.cpp:2146
+#, c-format
+msgid "Page %d"
+msgstr "Lapa %d"
+
+#: ../src/common/regex.cpp:382 ../src/html/chm.cpp:348
+msgid "unknown error"
+msgstr "nezināma kļūda"
+
+#: ../src/common/regex.cpp:995
+#, c-format
+msgid "Invalid regular expression '%s': %s"
+msgstr "Nederīga regulārā izteiksme '%s': %s"
+
+#: ../src/common/regex.cpp:1059
+#, c-format
+msgid "Failed to find match for regular expression: %s"
+msgstr "Neizdevās atrast atbilstību regulārai izteiksmei: %s"
+
+#: ../src/common/rendcmn.cpp:188
+#, c-format
+msgid "Renderer \"%s\" has incompatible version %d.%d and couldn't be loaded."
+msgstr ""
+
+#: ../src/common/secretstore.cpp:162
+msgid "Not available for this platform"
+msgstr ""
+
+#: ../src/common/secretstore.cpp:183
+#, fuzzy, c-format
+msgid "Saving password for \"%s\" failed: %s."
+msgstr "Neizdevās izveidot hronometru"
+
+#: ../src/common/secretstore.cpp:205
+#, fuzzy, c-format
+msgid "Reading password for \"%s\" failed: %s."
+msgstr "Neizdevās izveidot hronometru"
+
+#: ../src/common/secretstore.cpp:228
+#, fuzzy, c-format
+msgid "Deleting password for \"%s\" failed: %s."
+msgstr "Neizdevās izveidot hronometru"
+
+#: ../src/common/selectdispatcher.cpp:254
+msgid "Failed to monitor I/O channels"
+msgstr ""
+
+#: ../src/common/sizer.cpp:3054 ../src/common/stockitem.cpp:195
+msgid "Save"
+msgstr "Saglabāt"
+
+#: ../src/common/sizer.cpp:3056
+msgid "Don't Save"
+msgstr "Nesaglabāt"
+
+#: ../src/common/socket.cpp:870
+msgid "Cannot initialize sockets"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:127
+#, fuzzy
+msgctxt "standard Windows menu"
+msgid "&Help"
+msgstr "&Palīdzība"
+
+#: ../src/common/stockitem.cpp:144
+msgid "&About"
+msgstr "&Par"
+
+#: ../src/common/stockitem.cpp:144
+msgid "About"
+msgstr "Par"
+
+#: ../src/common/stockitem.cpp:145
+msgid "Add"
+msgstr "Pievienot"
+
+#: ../src/common/stockitem.cpp:146
+msgid "&Apply"
+msgstr "&Pielietot"
+
+#: ../src/common/stockitem.cpp:146
+msgid "Apply"
+msgstr "Pielietot"
+
+#: ../src/common/stockitem.cpp:147
+msgid "&Back"
+msgstr "A&tpakaļ"
+
+#: ../src/common/stockitem.cpp:147
+msgid "Back"
+msgstr "Atpakaļ"
+
+#: ../src/common/stockitem.cpp:148
+msgid "&Bold"
+msgstr "&Treknraksts"
+
+#: ../src/common/stockitem.cpp:148 ../src/generic/fontdlgg.cpp:326
+#: ../src/richtext/richtextfontpage.cpp:354
+msgid "Bold"
+msgstr "Treknraksts"
+
+#: ../src/common/stockitem.cpp:149
+msgid "&Bottom"
+msgstr "A&pakšā"
+
+#: ../src/common/stockitem.cpp:149 ../src/richtext/richtextsizepage.cpp:287
+msgid "Bottom"
+msgstr "Apakša"
+
+#: ../src/common/stockitem.cpp:150 ../src/generic/fontdlgg.cpp:462
+#: ../src/generic/fontdlgg.cpp:481 ../src/generic/wizard.cpp:415
+msgid "&Cancel"
+msgstr "At&celt"
+
+#: ../src/common/stockitem.cpp:151
+#, fuzzy
+msgid "&CD-ROM"
+msgstr "&CD-Rom"
+
+#: ../src/common/stockitem.cpp:151
+#, fuzzy
+msgid "CD-ROM"
+msgstr "CD-Rom"
+
+#: ../src/common/stockitem.cpp:152
+msgid "&Clear"
+msgstr "&Notīrīt"
+
+#: ../src/common/stockitem.cpp:152
+msgid "Clear"
+msgstr "Notīrīt"
+
+#: ../src/common/stockitem.cpp:153 ../src/generic/dbgrptg.cpp:93
+#: ../src/generic/progdlgg.cpp:778 ../src/html/helpdlg.cpp:86
+#: ../src/msw/progdlg.cpp:209 ../src/msw/progdlg.cpp:890
+#: ../src/richtext/richtextstyledlg.cpp:272
+#: ../src/richtext/richtextsymboldlg.cpp:448
+msgid "Close"
+msgstr "Aizvērt"
+
+#: ../src/common/stockitem.cpp:154
+msgid "&Convert"
+msgstr "&Pārveidot"
+
+#: ../src/common/stockitem.cpp:154
+msgid "Convert"
+msgstr "Pārveidot"
+
+#: ../src/common/stockitem.cpp:155 ../src/msw/textctrl.cpp:2884
+#: ../src/osx/textctrl_osx.cpp:653 ../src/richtext/richtextctrl.cpp:331
+msgid "&Copy"
+msgstr "&Kopēt"
+
+#: ../src/common/stockitem.cpp:155 ../src/stc/stc_i18n.cpp:18
+msgid "Copy"
+msgstr "Kopēt"
+
+#: ../src/common/stockitem.cpp:156 ../src/msw/textctrl.cpp:2883
+#: ../src/osx/textctrl_osx.cpp:652 ../src/richtext/richtextctrl.cpp:330
+msgid "Cu&t"
+msgstr "Izgriez&t"
+
+#: ../src/common/stockitem.cpp:156 ../src/stc/stc_i18n.cpp:17
+msgid "Cut"
+msgstr "Izgriezt"
+
+#: ../src/common/stockitem.cpp:157 ../src/msw/textctrl.cpp:2886
+#: ../src/osx/textctrl_osx.cpp:655 ../src/richtext/richtextctrl.cpp:333
+#: ../src/richtext/richtexttabspage.cpp:137
+msgid "&Delete"
+msgstr "&Dzēst"
+
+#: ../src/common/stockitem.cpp:157 ../src/richtext/richtextbuffer.cpp:8266
+#: ../src/stc/stc_i18n.cpp:20
+msgid "Delete"
+msgstr "Dzēst"
+
+#: ../src/common/stockitem.cpp:158
+msgid "&Down"
+msgstr "&Lejup"
+
+#: ../src/common/stockitem.cpp:158 ../src/generic/fdrepdlg.cpp:148
+msgid "Down"
+msgstr "Lejup"
+
+#: ../src/common/stockitem.cpp:159
+msgid "&Edit"
+msgstr "&Labot"
+
+#: ../src/common/stockitem.cpp:159
+msgid "Edit"
+msgstr "Labot"
+
+#: ../src/common/stockitem.cpp:160
+msgid "&Execute"
+msgstr "&Izpildīt"
+
+#: ../src/common/stockitem.cpp:160
+msgid "Execute"
+msgstr "Izpildīt"
+
+#: ../src/common/stockitem.cpp:161
+msgid "&Quit"
+msgstr "I&ziet"
+
+#: ../src/common/stockitem.cpp:161
+msgid "Quit"
+msgstr "Iziet"
+
+#: ../src/common/stockitem.cpp:162
+msgid "&File"
+msgstr "&Fails"
+
+#: ../src/common/stockitem.cpp:162
+msgid "File"
+msgstr "Fails"
+
+#: ../src/common/stockitem.cpp:163
+#, fuzzy
+msgid "&Find..."
+msgstr "&Meklēt"
+
+#: ../src/common/stockitem.cpp:163
+#, fuzzy
+msgid "Find..."
+msgstr "Meklēt"
+
+#: ../src/common/stockitem.cpp:164
+msgid "&First"
+msgstr "&Pirmais"
+
+#: ../src/common/stockitem.cpp:164
+msgid "First"
+msgstr "Pirmais"
+
+#: ../src/common/stockitem.cpp:165
+msgid "&Floppy"
+msgstr "&Diskete"
+
+#: ../src/common/stockitem.cpp:165
+msgid "Floppy"
+msgstr "Diskete"
+
+#: ../src/common/stockitem.cpp:166
+msgid "&Forward"
+msgstr "Uz &priekšu"
+
+#: ../src/common/stockitem.cpp:166
+msgid "Forward"
+msgstr "Pārsūtīt"
+
+#: ../src/common/stockitem.cpp:167
+msgid "&Harddisk"
+msgstr "&Cietais disks"
+
+#: ../src/common/stockitem.cpp:167
+msgid "Harddisk"
+msgstr "Cietais disks"
+
+#: ../src/common/stockitem.cpp:168 ../src/generic/wizard.cpp:418
+#: ../src/osx/cocoa/menu.mm:225 ../src/richtext/richtextstyledlg.cpp:298
+#: ../src/richtext/richtextsymboldlg.cpp:451
+msgid "&Help"
+msgstr "&Palīdzība"
+
+#: ../src/common/stockitem.cpp:169
+msgid "&Home"
+msgstr "&Mājas"
+
+#: ../src/common/stockitem.cpp:169
+msgid "Home"
+msgstr "Home"
+
+#: ../src/common/stockitem.cpp:170
+msgid "Indent"
+msgstr "Atkāpe"
+
+#: ../src/common/stockitem.cpp:171
+msgid "&Index"
+msgstr "&Indekss"
+
+#: ../src/common/stockitem.cpp:171 ../src/html/helpwnd.cpp:510
+msgid "Index"
+msgstr "Indekss"
+
+#: ../src/common/stockitem.cpp:172
+msgid "&Info"
+msgstr "Info"
+
+#: ../src/common/stockitem.cpp:172
+msgid "Info"
+msgstr "Info"
+
+#: ../src/common/stockitem.cpp:173
+msgid "&Italic"
+msgstr "&Slīpraksts"
+
+#: ../src/common/stockitem.cpp:173 ../src/generic/fontdlgg.cpp:322
+#: ../src/richtext/richtextfontpage.cpp:350
+msgid "Italic"
+msgstr "Kursīvs"
+
+#: ../src/common/stockitem.cpp:174
+msgid "&Jump to"
+msgstr "Pārle&kt uz"
+
+#: ../src/common/stockitem.cpp:174
+msgid "Jump to"
+msgstr "Pārlekt uz"
+
+#: ../src/common/stockitem.cpp:175
+msgid "Centered"
+msgstr "Centrēts"
+
+#: ../src/common/stockitem.cpp:176
+msgid "Justified"
+msgstr "Izlīdzināts"
+
+#: ../src/common/stockitem.cpp:177
+msgid "Align Left"
+msgstr "Izlīdzināt gar kreiso"
+
+#: ../src/common/stockitem.cpp:178
+msgid "Align Right"
+msgstr "Izlīdzināt gar labo"
+
+#: ../src/common/stockitem.cpp:179
+msgid "&Last"
+msgstr "&Pēdējais"
+
+#: ../src/common/stockitem.cpp:179
+msgid "Last"
+msgstr "Pēdējā"
+
+#: ../src/common/stockitem.cpp:180
+msgid "&Network"
+msgstr "&Tīkls"
+
+#: ../src/common/stockitem.cpp:180
+msgid "Network"
+msgstr "Tīkls"
+
+#: ../src/common/stockitem.cpp:181 ../src/richtext/richtexttabspage.cpp:131
+msgid "&New"
+msgstr "&Jauns"
+
+#: ../src/common/stockitem.cpp:181
+msgid "New"
+msgstr "Jauns"
+
+#: ../src/common/stockitem.cpp:182 ../src/msw/msgdlg.cpp:417
+msgid "&No"
+msgstr "&Nē"
+
+#: ../src/common/stockitem.cpp:183 ../src/generic/fontdlgg.cpp:467
+#: ../src/generic/fontdlgg.cpp:474
+msgid "&OK"
+msgstr "&Labi"
+
+#: ../src/common/stockitem.cpp:184 ../src/generic/dbgrptg.cpp:341
+msgid "&Open..."
+msgstr "&Atvērt..."
+
+#: ../src/common/stockitem.cpp:184
+msgid "Open..."
+msgstr "Atvērt..."
+
+#: ../src/common/stockitem.cpp:185 ../src/msw/textctrl.cpp:2885
+#: ../src/osx/textctrl_osx.cpp:654 ../src/richtext/richtextctrl.cpp:332
+msgid "&Paste"
+msgstr "Ie&līmēt"
+
+#: ../src/common/stockitem.cpp:185 ../src/richtext/richtextctrl.cpp:3484
+#: ../src/stc/stc_i18n.cpp:19
+msgid "Paste"
+msgstr "Ielīmēt"
+
+#: ../src/common/stockitem.cpp:186
+msgid "&Preferences"
+msgstr "&Preferences"
+
+#: ../src/common/stockitem.cpp:186 ../src/osx/cocoa/preferences.mm:304
+msgid "Preferences"
+msgstr "Iestatījumi"
+
+#: ../src/common/stockitem.cpp:187
+#, fuzzy
+msgid "Print previe&w..."
+msgstr "Drukas priekš&skatījums"
+
+#: ../src/common/stockitem.cpp:187
+#, fuzzy
+msgid "Print preview..."
+msgstr "Drukas priekšskatījums"
+
+#: ../src/common/stockitem.cpp:188
+msgid "&Print..."
+msgstr "&Drukāt..."
+
+#: ../src/common/stockitem.cpp:188
+msgid "Print..."
+msgstr "Drukāt..."
+
+#: ../src/common/stockitem.cpp:189 ../src/richtext/richtextctrl.cpp:337
+#: ../src/richtext/richtextctrl.cpp:5479
+msgid "&Properties"
+msgstr "&Rekvizīti"
+
+#: ../src/common/stockitem.cpp:189
+msgid "Properties"
+msgstr "Īpašības"
+
+#: ../src/common/stockitem.cpp:190 ../src/stc/stc_i18n.cpp:16
+msgid "Redo"
+msgstr "Atkārtot"
+
+#: ../src/common/stockitem.cpp:191
+msgid "Refresh"
+msgstr "Atsvaidzināt skatu"
+
+#: ../src/common/stockitem.cpp:192
+msgid "Remove"
+msgstr "Aizvākt"
+
+#: ../src/common/stockitem.cpp:193
+#, fuzzy
+msgid "Rep&lace..."
+msgstr "Aiz&vietot"
+
+#: ../src/common/stockitem.cpp:193
+#, fuzzy
+msgid "Replace..."
+msgstr "Aizvietot"
+
+#: ../src/common/stockitem.cpp:194
+msgid "Revert to Saved"
+msgstr "Atgriezties pie saglabātā"
+
+#: ../src/common/stockitem.cpp:196 ../src/generic/logg.cpp:549
+msgid "Save &As..."
+msgstr "Saglabāt &kā..."
+
+#: ../src/common/stockitem.cpp:196
+#, fuzzy
+msgid "Save As..."
+msgstr "Saglabāt &kā..."
+
+#: ../src/common/stockitem.cpp:197 ../src/msw/textctrl.cpp:2888
+#: ../src/osx/textctrl_osx.cpp:657 ../src/richtext/richtextctrl.cpp:335
+msgid "Select &All"
+msgstr "Izvēlēties &visu"
+
+#: ../src/common/stockitem.cpp:197 ../src/stc/stc_i18n.cpp:21
+msgid "Select All"
+msgstr "Iezīmēt visu"
+
+#: ../src/common/stockitem.cpp:198
+msgid "&Color"
+msgstr "&Krāsa"
+
+#: ../src/common/stockitem.cpp:198
+msgid "Color"
+msgstr "Krāsa"
+
+#: ../src/common/stockitem.cpp:199
+msgid "&Font"
+msgstr "&Fonts"
+
+#: ../src/common/stockitem.cpp:199 ../src/richtext/richtextformatdlg.cpp:336
+msgid "Font"
+msgstr "Fonts"
+
+#: ../src/common/stockitem.cpp:200
+msgid "&Ascending"
+msgstr "&Augoši"
+
+#: ../src/common/stockitem.cpp:200
+msgid "Ascending"
+msgstr "Augoši"
+
+#: ../src/common/stockitem.cpp:201
+msgid "&Descending"
+msgstr "&Dilstoši"
+
+#: ../src/common/stockitem.cpp:201
+msgid "Descending"
+msgstr "Dilstoši"
+
+#: ../src/common/stockitem.cpp:202
+msgid "&Spell Check"
+msgstr "Pareizrak&stība"
+
+#: ../src/common/stockitem.cpp:202
+msgid "Spell Check"
+msgstr "Pareizrakstība"
+
+#: ../src/common/stockitem.cpp:203
+msgid "&Stop"
+msgstr "Ap&stādināt"
+
+#: ../src/common/stockitem.cpp:203
+msgid "Stop"
+msgstr "Apturēt"
+
+#: ../src/common/stockitem.cpp:204 ../src/richtext/richtextfontpage.cpp:274
+msgid "&Strikethrough"
+msgstr "Caur&svītrot"
+
+#: ../src/common/stockitem.cpp:204
+msgid "Strikethrough"
+msgstr "Caursvītrots"
+
+#: ../src/common/stockitem.cpp:205
+msgid "&Top"
+msgstr "&Augšā"
+
+#: ../src/common/stockitem.cpp:205 ../src/richtext/richtextsizepage.cpp:285
+#: ../src/richtext/richtextsizepage.cpp:289
+msgid "Top"
+msgstr "Augša"
+
+#: ../src/common/stockitem.cpp:206
+msgid "Undelete"
+msgstr "Atjaunot"
+
+#: ../src/common/stockitem.cpp:207 ../src/generic/fontdlgg.cpp:437
+msgid "&Underline"
+msgstr "Pasvītroj&ums"
+
+#: ../src/common/stockitem.cpp:207
+msgid "Underline"
+msgstr "Pasvītrot"
+
+#: ../src/common/stockitem.cpp:208 ../src/stc/stc_i18n.cpp:15
+msgid "Undo"
+msgstr "Atsaukt"
+
+#: ../src/common/stockitem.cpp:209
+msgid "&Unindent"
+msgstr "&Samazināt atkāpi"
+
+#: ../src/common/stockitem.cpp:209
+msgid "Unindent"
+msgstr "Samazināt atkāpi"
+
+#: ../src/common/stockitem.cpp:210
+msgid "&Up"
+msgstr "A&ugšup"
+
+#: ../src/common/stockitem.cpp:210 ../src/generic/fdrepdlg.cpp:148
+msgid "Up"
+msgstr "Uz augšu"
+
+#: ../src/common/stockitem.cpp:211 ../src/msw/msgdlg.cpp:417
+msgid "&Yes"
+msgstr "&Jā"
+
+#: ../src/common/stockitem.cpp:212
+msgid "&Actual Size"
+msgstr "&Patiesais izmērs"
+
+#: ../src/common/stockitem.cpp:212
+msgid "Actual Size"
+msgstr "Patiesais Izmērs"
+
+#: ../src/common/stockitem.cpp:213
+msgid "Zoom to &Fit"
+msgstr "Ietilpināt attēlu"
+
+#: ../src/common/stockitem.cpp:213
+msgid "Zoom to Fit"
+msgstr "Ietilpināt"
+
+#: ../src/common/stockitem.cpp:214
+msgid "Zoom &In"
+msgstr "Pa&lielināt"
+
+#: ../src/common/stockitem.cpp:215
+msgid "Zoom &Out"
+msgstr "Sa&mazināt"
+
+#: ../src/common/stockitem.cpp:262
+msgid "Show about dialog"
+msgstr "Rādīt apraksta dialogu"
+
+#: ../src/common/stockitem.cpp:263
+msgid "Copy selection"
+msgstr "Kopēt iezīmēto"
+
+#: ../src/common/stockitem.cpp:264
+msgid "Cut selection"
+msgstr "Izgriezt iezīmēto"
+
+#: ../src/common/stockitem.cpp:265
+msgid "Delete selection"
+msgstr "Dzēst iezīmēto"
+
+#: ../src/common/stockitem.cpp:266
+#, fuzzy
+msgid "Find in document"
+msgstr "Atvērt HTML dokumentu"
+
+#: ../src/common/stockitem.cpp:267
+msgid "Find and replace in document"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:268
+msgid "Paste selection"
+msgstr "Ielīmēt iezīmēto"
+
+#: ../src/common/stockitem.cpp:269
+msgid "Quit this program"
+msgstr "Iziet no šīs programmas"
+
+#: ../src/common/stockitem.cpp:270
+msgid "Redo last action"
+msgstr "Atkārtot pēdējo darbību"
+
+#: ../src/common/stockitem.cpp:271
+msgid "Undo last action"
+msgstr "Atsaukt pēdējo darbību"
+
+#: ../src/common/stockitem.cpp:272
+#, fuzzy
+msgid "Create new document"
+msgstr "Izveidot Jaunu mapi"
+
+#: ../src/common/stockitem.cpp:273
+#, fuzzy
+msgid "Open an existing document"
+msgstr "Atvērt HTML dokumentu"
+
+#: ../src/common/stockitem.cpp:274
+msgid "Close current document"
+msgstr "Aizvērt aktīvo dokumentu"
+
+#: ../src/common/stockitem.cpp:275
+msgid "Save current document"
+msgstr "Saglabāt aktīvo dokumentu"
+
+#: ../src/common/stockitem.cpp:276
+msgid "Save current document with a different filename"
+msgstr "Saglabāt pašreizējo dokumentu ar citu nosaukumu"
+
+#: ../src/common/strconv.cpp:2324
+#, c-format
+msgid "Conversion to charset '%s' doesn't work."
+msgstr "Pārvēršana uz kodējumu '%s' nedarbojas."
+
+#: ../src/common/tarstrm.cpp:352 ../src/common/tarstrm.cpp:375
+#: ../src/common/tarstrm.cpp:406 ../src/generic/progdlgg.cpp:373
+msgid "unknown"
+msgstr "nezināms"
+
+#: ../src/common/tarstrm.cpp:774
+msgid "incomplete header block in tar"
+msgstr ""
+
+#: ../src/common/tarstrm.cpp:798
+msgid "checksum failure reading tar header block"
+msgstr ""
+
+#: ../src/common/tarstrm.cpp:971
+msgid "invalid data in extended tar header"
+msgstr "Nederīgi dati..."
+
+#: ../src/common/tarstrm.cpp:981 ../src/common/tarstrm.cpp:1003
+#: ../src/common/tarstrm.cpp:1477 ../src/common/tarstrm.cpp:1499
+msgid "tar entry not open"
+msgstr ""
+
+#: ../src/common/tarstrm.cpp:1023
+msgid "unexpected end of file"
+msgstr "negaidītas faila beigas"
+
+#: ../src/common/tarstrm.cpp:1297
+#, c-format
+msgid "%s did not fit the tar header for entry '%s'"
+msgstr ""
+
+#: ../src/common/tarstrm.cpp:1359
+msgid "incorrect size given for tar entry"
+msgstr ""
+
+#: ../src/common/textbuf.cpp:232
+#, c-format
+msgid "'%s' is probably a binary buffer."
+msgstr "'%s', iespējams, ir binārais buferis."
+
+#: ../src/common/textcmn.cpp:1006 ../src/richtext/richtextctrl.cpp:3053
+msgid "File couldn't be loaded."
+msgstr "Failu nevar ielādēt."
+
+#: ../src/common/textfile.cpp:95
+#, fuzzy, c-format
+msgid "Failed to read text file \"%s\"."
+msgstr "Neizdevās ielasīt dokumentu no faila \"%s\"."
+
+#: ../src/common/textfile.cpp:160
+#, c-format
+msgid "can't write buffer '%s' to disk."
+msgstr "nevar ierakstīt bufera '%s' saturu diskā."
+
+#: ../src/common/time.cpp:212
+msgid "Failed to get the local system time"
+msgstr "Neizdevās nolasīt lokālās sistēmas laiku"
+
+#: ../src/common/time.cpp:279
+msgid "wxGetTimeOfDay failed."
+msgstr "wxGetTimeOfDay beidzās ar kļūdu."
+
+#: ../src/common/translation.cpp:929
+#, c-format
+msgid "'%s' is not a valid message catalog."
+msgstr "'%s' ir nederīgs ziņojumu katalogs."
+
+#: ../src/common/translation.cpp:954
+msgid "Invalid message catalog."
+msgstr ""
+
+#: ../src/common/translation.cpp:1013
+#, c-format
+msgid "Failed to parse Plural-Forms: '%s'"
+msgstr ""
+
+#: ../src/common/translation.cpp:1723
+#, c-format
+msgid "using catalog '%s' from '%s'."
+msgstr "izmanto katalogu '%s' no '%s'."
+
+#: ../src/common/translation.cpp:1816
+#, c-format
+msgid "Resource '%s' is not a valid message catalog."
+msgstr ""
+
+#: ../src/common/translation.cpp:1865
+msgid "Couldn't enumerate translations"
+msgstr "Neizdevās uzskaitīt tulkojumus"
+
+#: ../src/common/utilscmn.cpp:1145
+msgid "No default application configured for HTML files."
+msgstr "Noklusētā aplikācija HTML failu attēlošanai nav iestatīta."
+
+#: ../src/common/utilscmn.cpp:1190
+#, c-format
+msgid "Failed to open URL \"%s\" in default browser."
+msgstr "Noklusētajā pārlūkā neizdevās atvērt URL \"%s\"."
+
+#: ../src/common/valtext.cpp:144
+msgid "Validation conflict"
+msgstr "Pārbaudes konflikts"
+
+#: ../src/common/valtext.cpp:186
+msgid "Required information entry is empty."
+msgstr "Nepieciešamais informācijas ieraksts ir tukšs."
+
+#: ../src/common/valtext.cpp:188
+#, fuzzy, c-format
+msgid "'%s' is one of the invalid strings"
+msgstr "'%s' ir nederīgs"
+
+#: ../src/common/valtext.cpp:190
+#, fuzzy, c-format
+msgid "'%s' is not one of the valid strings"
+msgstr "'%s' ir nederīgs ziņojumu katalogs."
+
+#: ../src/common/valtext.cpp:199
+#, fuzzy, c-format
+msgid "'%s' contains invalid character(s)"
+msgstr "'%s' drīkst saturēt tikai alfabēta rakstzīmes."
+
+#: ../src/common/webrequest.cpp:139
+#, fuzzy, c-format
+msgid "Error: %s (%d)"
+msgstr "Kļūda: "
+
+#: ../src/common/webrequest.cpp:655
+#, c-format
+msgid ""
+"Not enough free disk space for download: %llu needed but only %llu available."
+msgstr ""
+
+#: ../src/common/webrequest.cpp:669
+#, fuzzy, c-format
+msgid "Failed to create temporary file in %s"
+msgstr "Neizdevās izveidot pagaidu faila nosaukumu"
+
+#: ../src/common/webrequest_curl.cpp:1106
+#, fuzzy
+msgid "libcurl could not be initialized"
+msgstr "Nav iespējams inicializēt slejas aprakstu."
+
+#: ../src/common/webview.cpp:392
+#, fuzzy
+msgid "RunScriptAsync not supported"
+msgstr "Virkņu pārvēršana nav atbalstīta"
+
+#: ../src/common/webview.cpp:403 ../src/msw/webview_ie.cpp:1073
+#, c-format
+msgid "Error running JavaScript: %s"
+msgstr ""
+
+#: ../src/common/webview_chromium.cpp:858
+#, fuzzy, c-format
+msgid "Failed to set proxy \"%s\": %s"
+msgstr "Neizdevās izveidot mapi \"%s\""
+
+#: ../src/common/webview_chromium.cpp:989
+msgid ""
+"Chromium can't be used because libcef.so wasn't loaded early enough; please "
+"relink the application or use LD_PRELOAD to load it earlier."
+msgstr ""
+
+#: ../src/common/webview_chromium.cpp:1108
+#, fuzzy
+msgid "Could not initialize Chromium"
+msgstr "Neizdevās iestatīt izlīdiznājumu."
+
+#: ../src/common/webview_chromium.cpp:1616
+msgid "Show DevTools"
+msgstr ""
+
+#: ../src/common/webview_chromium.cpp:1617
+#, fuzzy
+msgid "Close DevTools"
+msgstr "Aizvērt Visus"
+
+#: ../src/common/webview_chromium.cpp:1623
+msgid "Inspect"
+msgstr ""
+
+#: ../src/common/wincmn.cpp:1628
+msgid "This platform does not support background transparency."
+msgstr "Šī platforma neuztur fona caurspīdīgumu."
+
+#: ../src/common/wincmn.cpp:2097
+msgid "Could not transfer data to window"
+msgstr "Neizdevās pārvietot datus uz logu"
+
+#: ../src/common/windowid.cpp:240
+msgid "Out of window IDs.  Recommend shutting down application."
+msgstr "Logu ID ir beigušies. Ieteicams aizvērt aplikāciju."
+
+#: ../src/common/xpmdecod.cpp:678
+msgid "XPM: incorrect header format!"
+msgstr "XPM: nepareizs galvenes formāts!"
+
+#: ../src/common/xpmdecod.cpp:703
+#, c-format
+msgid "XPM: incorrect colour description in line %d"
+msgstr "XPM: nepareizs krāsas apraksts rindā %d"
+
+#: ../src/common/xpmdecod.cpp:715 ../src/common/xpmdecod.cpp:724
+#, c-format
+msgid "XPM: malformed colour definition '%s' at line %d!"
+msgstr "XPM: kļūdaina krāsa definīcija '%s' rindā %d!"
+
+#: ../src/common/xpmdecod.cpp:754
+msgid "XPM: no colors left to use for mask!"
+msgstr "XPM: nav atlikusi neviena maskai izmantojam krāsa!"
+
+#: ../src/common/xpmdecod.cpp:781
+#, c-format
+msgid "XPM: truncated image data at line %d!"
+msgstr "XPM: aprauti attēla dati rindā %d!"
+
+#: ../src/common/xpmdecod.cpp:795
+msgid "XPM: Malformed pixel data!"
+msgstr "XPM: nepareizi pikseļu dati!"
+
+#: ../src/common/xti.cpp:492
+msgid "Illegal Parameter Count for Create Method"
+msgstr "Nederīgs parametru skaits metodei Create"
+
+#: ../src/common/xti.cpp:504
+msgid "Illegal Parameter Count for ConstructObject Method"
+msgstr "Nederīgs parametru skaits metodei ConstructObject"
+
+#: ../src/common/xtistrm.cpp:161
+#, c-format
+msgid "Create Parameter %s not found in declared RTTI Parameters"
+msgstr ""
+
+#: ../src/common/xtistrm.cpp:290
+msgid "Illegal Object Class (Non-wxEvtHandler) as Event Source"
+msgstr ""
+
+#: ../src/common/xtistrm.cpp:313 ../src/common/xtixml.cpp:345
+#: ../src/common/xtixml.cpp:498
+msgid "Type must have enum - long conversion"
+msgstr ""
+
+#: ../src/common/xtistrm.cpp:400 ../src/common/xtistrm.cpp:415
+msgid "Invalid or Null Object ID passed to GetObjectClassInfo"
+msgstr "GetObjectClassInfo nodots nederīgs vai tukšs objekta ID"
+
+#: ../src/common/xtistrm.cpp:405
+msgid "Unknown Object passed to GetObjectClassInfo"
+msgstr "GetObjectClassInfo nodots nezināms objekts"
+
+#: ../src/common/xtistrm.cpp:420
+msgid "Already Registered Object passed to SetObjectClassInfo"
+msgstr ""
+
+#: ../src/common/xtistrm.cpp:430
+msgid "Invalid or Null Object ID passed to HasObjectClassInfo"
+msgstr "HasObjectClassInfo nodots nederīgs vai tukšs objekta ID"
+
+#: ../src/common/xtistrm.cpp:460
+msgid "Passing a already registered object to SetObject"
+msgstr ""
+
+#: ../src/common/xtistrm.cpp:471
+#, fuzzy
+msgid "Passing an unknown object to GetObject"
+msgstr "GetObjectClassInfo nodots nezināms objekts"
+
+#: ../src/common/xtixml.cpp:229
+msgid "Forward hrefs are not supported"
+msgstr ""
+
+#: ../src/common/xtixml.cpp:247
+#, c-format
+msgid "unknown class %s"
+msgstr "nezināma klase %s"
+
+#: ../src/common/xtixml.cpp:253
+msgid "objects cannot have XML Text Nodes"
+msgstr ""
+
+#: ../src/common/xtixml.cpp:258
+msgid "Objects must have an id attribute"
+msgstr "Objektiem ir jābūt id atribūtiem"
+
+#: ../src/common/xtixml.cpp:267
+#, c-format
+msgid "Doubly used id : %d"
+msgstr "Divreiz izmantots id: %d"
+
+#: ../src/common/xtixml.cpp:316
+#, c-format
+msgid "Unknown Property %s"
+msgstr "Nezināma īpašība %s"
+
+#: ../src/common/xtixml.cpp:407
+msgid "A non empty collection must consist of 'element' nodes"
+msgstr ""
+
+#: ../src/common/xtixml.cpp:478
+msgid "incorrect event handler string, missing dot"
+msgstr ""
+
+#: ../src/common/zipstrm.cpp:559
+msgid "can't re-initialize zlib deflate stream"
+msgstr ""
+
+#: ../src/common/zipstrm.cpp:584
+msgid "can't re-initialize zlib inflate stream"
+msgstr ""
+
+#: ../src/common/zipstrm.cpp:1023
+msgid "Ignoring malformed extra data record, ZIP file may be corrupted"
+msgstr ""
+
+#: ../src/common/zipstrm.cpp:1502
+msgid "assuming this is a multi-part zip concatenated"
+msgstr "pieņemot, ka tas ir apvienots vairāku daļu zip"
+
+#: ../src/common/zipstrm.cpp:1664
+msgid "invalid zip file"
+msgstr "nederīgs zip fails"
+
+#: ../src/common/zipstrm.cpp:1723
+msgid "can't find central directory in zip"
+msgstr "nav iespējams atrast galveno zip mapi"
+
+#: ../src/common/zipstrm.cpp:1812
+msgid "error reading zip central directory"
+msgstr "kļūda lasot zip galveno mapi"
+
+#: ../src/common/zipstrm.cpp:1916
+msgid "error reading zip local header"
+msgstr ""
+
+#: ../src/common/zipstrm.cpp:1964
+msgid "bad zipfile offset to entry"
+msgstr ""
+
+#: ../src/common/zipstrm.cpp:2031
+msgid "stored file length not in Zip header"
+msgstr ""
+
+#: ../src/common/zipstrm.cpp:2045 ../src/common/zipstrm.cpp:2362
+msgid "unsupported Zip compression method"
+msgstr "neatbalstīta Zip kompresijas metode"
+
+#: ../src/common/zipstrm.cpp:2126
+#, c-format
+msgid "reading zip stream (entry %s): bad length"
+msgstr ""
+
+#: ../src/common/zipstrm.cpp:2131
+#, c-format
+msgid "reading zip stream (entry %s): bad crc"
+msgstr ""
+
+#: ../src/common/zipstrm.cpp:2578
+#, c-format
+msgid "error writing zip entry '%s': file too large without ZIP64"
+msgstr ""
+
+#: ../src/common/zipstrm.cpp:2585
+#, c-format
+msgid "error writing zip entry '%s': bad crc or length"
+msgstr ""
+
+#: ../src/common/zstream.cpp:155 ../src/common/zstream.cpp:315
+msgid "Gzip not supported by this version of zlib"
+msgstr "Šī zlib versija neuztur gzip"
+
+#: ../src/common/zstream.cpp:182
+msgid "Can't initialize zlib inflate stream."
+msgstr "Nevar inicializēt zlib atspiešanas straumējumu."
+
+#: ../src/common/zstream.cpp:241
+msgid "Can't read inflate stream: unexpected EOF in underlying stream."
+msgstr ""
+
+#: ../src/common/zstream.cpp:248 ../src/common/zstream.cpp:423
+#, c-format
+msgid "zlib error %d"
+msgstr "zlib kļūda  %d"
+
+#: ../src/common/zstream.cpp:249
+#, c-format
+msgid "Can't read from inflate stream: %s"
+msgstr ""
+
+#: ../src/common/zstream.cpp:343
+msgid "Can't initialize zlib deflate stream."
+msgstr "Nevar inicializēt zlib saspiešanas straumējumu."
+
+#: ../src/common/zstream.cpp:424
+#, c-format
+msgid "Can't write to deflate stream: %s"
+msgstr ""
+
+#: ../src/dfb/bitmap.cpp:633 ../src/dfb/bitmap.cpp:667
+#, c-format
+msgid "No bitmap handler for type %d defined."
+msgstr ""
+
+#: ../src/dfb/evtloop.cpp:99
+msgid "Failed to read event from DirectFB pipe"
+msgstr "Neizdevās nolasīt notikumu no DirectFB programmkanāla."
+
+#: ../src/dfb/evtloop.cpp:171
+msgid "Failed to switch DirectFB pipe to non-blocking mode"
+msgstr ""
+
+#: ../src/dfb/fontmgr.cpp:171
+#, c-format
+msgid "no fonts found in %s, using builtin font"
+msgstr "mapē %s nav atrasts neviens fonts, izmanto iebūvēto fontu"
+
+#: ../src/dfb/fontmgr.cpp:177
+msgid "Default font"
+msgstr "Noklusētais fonts"
+
+#: ../src/dfb/fontmgr.cpp:195
+#, c-format
+msgid "Fonts index file %s disappeared while loading fonts."
+msgstr "Fontu saraksta fails %s ir pazudis fontu ielādes laikā."
+
+#: ../src/dfb/wrapdfb.cpp:60
+#, fuzzy, c-format
+msgid "DirectFB error %d occurred."
+msgstr "Radās DirectFB kļūda %d."
+
+#: ../src/generic/aboutdlgg.cpp:69
+msgid "Developed by "
+msgstr "Izstrādājis "
+
+#: ../src/generic/aboutdlgg.cpp:72
+msgid "Documentation by "
+msgstr "Dokumentācijas autori"
+
+#: ../src/generic/aboutdlgg.cpp:75
+msgid "Graphics art by "
+msgstr "Grafiskais noformējums -"
+
+#: ../src/generic/aboutdlgg.cpp:78
+msgid "Translations by "
+msgstr "Tulkojumu autori -"
+
+#: ../src/generic/aboutdlgg.cpp:133 ../src/osx/cocoa/aboutdlg.mm:83
+msgid "Version "
+msgstr "Versija"
+
+#. TRANSLATORS: %s is application name
+#: ../src/generic/aboutdlgg.cpp:146 ../src/msw/aboutdlg.cpp:60
+#, c-format
+msgid "About %s"
+msgstr "Par %s"
+
+#: ../src/generic/aboutdlgg.cpp:181
+msgid "License"
+msgstr "Licence"
+
+#: ../src/generic/aboutdlgg.cpp:184
+msgid "Developers"
+msgstr "Izstrādātāji"
+
+#: ../src/generic/aboutdlgg.cpp:188
+msgid "Documentation writers"
+msgstr "Dokumentācijas sastādītāji"
+
+#: ../src/generic/aboutdlgg.cpp:192
+msgid "Artists"
+msgstr "Izpildītāji"
+
+#: ../src/generic/aboutdlgg.cpp:196
+msgid "Translators"
+msgstr "Tulkotāji"
+
+#: ../src/generic/animateg.cpp:125
+msgid "No handler found for animation type."
+msgstr ""
+
+#: ../src/generic/animateg.cpp:133
+#, c-format
+msgid "No animation handler for type %ld defined."
+msgstr ""
+
+#: ../src/generic/animateg.cpp:145
+#, c-format
+msgid "Animation file is not of type %ld."
+msgstr "Animācijas faila tips nav  %ld."
+
+#: ../src/generic/colrdlgg.cpp:154 ../src/gtk/colordlg.cpp:47
+msgid "Choose colour"
+msgstr "Izvēlieties krāsu"
+
+#: ../src/generic/colrdlgg.cpp:357
+msgid "Red:"
+msgstr ""
+
+#: ../src/generic/colrdlgg.cpp:360
+#, fuzzy
+msgid "Green:"
+msgstr "Grieķu (MacGreek)"
+
+#: ../src/generic/colrdlgg.cpp:363
+msgid "Blue:"
+msgstr ""
+
+#: ../src/generic/colrdlgg.cpp:372
+msgid "Opacity:"
+msgstr ""
+
+#: ../src/generic/colrdlgg.cpp:384
+msgid "Add to custom colours"
+msgstr "Pievienot pielāgotajām krāsām"
+
+#: ../src/generic/creddlgg.cpp:56
+msgid "Username:"
+msgstr ""
+
+#: ../src/generic/creddlgg.cpp:63
+msgid "Password:"
+msgstr ""
+
+#. TRANSLATORS: Name of Boolean true value
+#: ../src/generic/datavgen.cpp:1178
+msgid "true"
+msgstr ""
+
+#. TRANSLATORS: Name of Boolean false value
+#: ../src/generic/datavgen.cpp:1180
+#, fuzzy
+msgid "false"
+msgstr "Aplams"
+
+#: ../src/generic/datavgen.cpp:6897
+#, c-format
+msgid "Row %i"
+msgstr ""
+
+#. TRANSLATORS: Action for manipulating a tree control
+#: ../src/generic/datavgen.cpp:6987
+msgid "Collapse"
+msgstr ""
+
+#. TRANSLATORS: Action for manipulating a tree control
+#: ../src/generic/datavgen.cpp:6990
+msgid "Expand"
+msgstr ""
+
+#. TRANSLATORS: Name of data view control and number of rows
+#: ../src/generic/datavgen.cpp:7011
+#, fuzzy, c-format
+msgid "%s (%d items)"
+msgstr "%s (vai %s)"
+
+#: ../src/generic/datavgen.cpp:7062
+#, c-format
+msgid "Column %u"
+msgstr ""
+
+#. TRANSLATORS: Keystroke for manipulating a tree control
+#: ../src/generic/datavgen.cpp:7131 ../src/richtext/richtextbulletspage.cpp:189
+#: ../src/richtext/richtextbulletspage.cpp:192
+#: ../src/richtext/richtextbulletspage.cpp:193
+#: ../src/richtext/richtextliststylepage.cpp:252
+#: ../src/richtext/richtextliststylepage.cpp:255
+#: ../src/richtext/richtextliststylepage.cpp:256
+#: ../src/richtext/richtextsizepage.cpp:248
+msgid "Left"
+msgstr "Pa kreisi"
+
+#. TRANSLATORS: Keystroke for manipulating a tree control
+#: ../src/generic/datavgen.cpp:7134 ../src/richtext/richtextbulletspage.cpp:191
+#: ../src/richtext/richtextliststylepage.cpp:254
+#: ../src/richtext/richtextsizepage.cpp:249
+msgid "Right"
+msgstr "Pa labi"
+
+#: ../src/generic/datectlg.cpp:90
+#, c-format
+msgid ""
+"\"%s\" is not in the expected date format, please enter it as e.g. \"%s\"."
+msgstr ""
+
+#: ../src/generic/datectlg.cpp:94
+#, fuzzy
+msgid "Invalid date"
+msgstr "PCX: nederīgs attēls"
+
+#: ../src/generic/dbgrptg.cpp:159
+#, c-format
+msgid "Open file \"%s\""
+msgstr "Atvērt failu \"%s\""
+
+#: ../src/generic/dbgrptg.cpp:170
+#, c-format
+msgid "Enter command to open file \"%s\":"
+msgstr "Ievadiet komandu faila \"%s\" atvēršanai:"
+
+#: ../src/generic/dbgrptg.cpp:230
+msgid "Executable files (*.exe)|*.exe|"
+msgstr "Izpildāmie faili (*.exe)|*.exe|"
+
+#: ../src/generic/dbgrptg.cpp:300
+#, c-format
+msgid "Debug report \"%s\""
+msgstr "Atkļūdošanas atskaite \"%s\""
+
+#: ../src/generic/dbgrptg.cpp:316
+msgid "A debug report has been generated in the directory\n"
+msgstr "Atkļūdošanas atskaite izveidota mapē\n"
+
+#: ../src/generic/dbgrptg.cpp:317
+msgid "The following debug report will be generated\n"
+msgstr ""
+
+#: ../src/generic/dbgrptg.cpp:321
+msgid ""
+"The report contains the files listed below. If any of these files contain "
+"private information,\n"
+"please uncheck them and they will be removed from the report.\n"
+msgstr ""
+"Atskaite satur zemāk uzskaitītos failus. Ja kāds no tiem satur privātu "
+"informāciju,\n"
+"lūdzu, atķeksējiet tos un tie tiks aizvākti no atskaites.\n"
+
+#: ../src/generic/dbgrptg.cpp:323
+msgid ""
+"If you wish to suppress this debug report completely, please choose the "
+"\"Cancel\" button,\n"
+"but be warned that it may hinder improving the program, so if\n"
+"at all possible please do continue with the report generation.\n"
+msgstr ""
+"Lai ignorētu šo kļūdas paziņojumu pilnībā, uzklikšķiniet \"Atcelt\",\n"
+"taču ņemiet vērā, ka tas kavēs uzlabošanu,tādēļ, ja iespējams,\n"
+"lūdzu, turpiniet kļūdas atskaites veidošanu.\n"
+
+#: ../src/generic/dbgrptg.cpp:325
+msgid "              Thank you and we're sorry for the inconvenience!\n"
+msgstr "              Paldies! Atvainojiet par sagādātajām neērtībām!\n"
+
+#: ../src/generic/dbgrptg.cpp:333
+msgid "&Debug report preview:"
+msgstr "A&tkļūdošanas ziņojuma priekšskatījums:"
+
+#: ../src/generic/dbgrptg.cpp:339
+msgid "&View..."
+msgstr "&Skatīt..."
+
+#: ../src/generic/dbgrptg.cpp:359
+msgid "&Notes:"
+msgstr "Piezī&mes:"
+
+#: ../src/generic/dbgrptg.cpp:361
+msgid ""
+"If you have any additional information pertaining to this bug\n"
+"report, please enter it here and it will be joined to it:"
+msgstr ""
+"Ja jums ir vēl kāda informācija, kas attiecas uz šo atkļūdošanas\n"
+"atskaiti, lūdzu, ievadiet to šeit un tā tiks pievienota atskaitei:"
+
+#: ../src/generic/dcpsg.cpp:1627
+msgid "Cannot open file for PostScript printing!"
+msgstr "Nav iespējams atvērt failu drukāšanai PostScript!"
+
+#: ../src/generic/dirctrlg.cpp:402
+msgid "Computer"
+msgstr "Dators"
+
+#: ../src/generic/dirctrlg.cpp:404
+msgid "Sections"
+msgstr "Sadaļas"
+
+#: ../src/generic/dirctrlg.cpp:482
+msgid "Home directory"
+msgstr "Mājas mape"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/generic/dirctrlg.cpp:484 ../src/propgrid/advprops.cpp:811
+msgid "Desktop"
+msgstr "Darba virsma"
+
+#: ../src/generic/dirctrlg.cpp:528 ../src/generic/filectrlg.cpp:752
+msgid "Illegal directory name."
+msgstr "Nederīgs mapes nosaukums."
+
+#: ../src/generic/dirctrlg.cpp:528 ../src/generic/dirctrlg.cpp:546
+#: ../src/generic/dirctrlg.cpp:557 ../src/generic/dirdlgg.cpp:317
+#: ../src/generic/filectrlg.cpp:638 ../src/generic/filectrlg.cpp:752
+#: ../src/generic/filectrlg.cpp:766 ../src/generic/filectrlg.cpp:782
+#: ../src/generic/filectrlg.cpp:1356 ../src/generic/filectrlg.cpp:1387
+#: ../src/generic/filedlgg.cpp:362 ../src/gtk/filedlg.cpp:76
+msgid "Error"
+msgstr "Kļūda"
+
+#: ../src/generic/dirctrlg.cpp:546 ../src/generic/filectrlg.cpp:766
+msgid "File name exists already."
+msgstr "Faila nosaukumu jau pastāv."
+
+#: ../src/generic/dirctrlg.cpp:557 ../src/generic/dirdlgg.cpp:317
+#: ../src/generic/filectrlg.cpp:638 ../src/generic/filectrlg.cpp:782
+msgid "Operation not permitted."
+msgstr "Darbība nav atļauta."
+
+#: ../src/generic/dirdlgg.cpp:107 ../src/generic/filedlgg.cpp:207
+msgid "Create new directory"
+msgstr "Izveidot Jaunu mapi"
+
+#: ../src/generic/dirdlgg.cpp:112 ../src/generic/filedlgg.cpp:203
+msgid "Go to home directory"
+msgstr "Iet uz mājas direktoriju"
+
+#: ../src/generic/dirdlgg.cpp:143
+msgid "Show &hidden directories"
+msgstr "Rādīt &slēptās mapes"
+
+#: ../src/generic/dirdlgg.cpp:196
+#, c-format
+msgid ""
+"The directory '%s' does not exist\n"
+"Create it now?"
+msgstr ""
+"Mape '%s' nepastāv\n"
+"Izveidot tagad?"
+
+#: ../src/generic/dirdlgg.cpp:198
+msgid "Directory does not exist"
+msgstr "Mape nepastāv"
+
+#: ../src/generic/dirdlgg.cpp:214
+#, c-format
+msgid ""
+"Failed to create directory '%s'\n"
+"(Do you have the required permissions?)"
+msgstr ""
+"Nezidevās izveidot mapi '%s'\n"
+"(Vai jums ir atbilstošas pieejas tiesības?)"
+
+#: ../src/generic/dirdlgg.cpp:216
+msgid "Error creating directory"
+msgstr "Kļūda izveidojot mapi"
+
+#: ../src/generic/dirdlgg.cpp:281
+msgid "You cannot add a new directory to this section."
+msgstr "Jūs nevarat pievienot jaunu mapi šai sekcijai."
+
+#: ../src/generic/dirdlgg.cpp:282
+msgid "Create directory"
+msgstr "Izveidot mapi"
+
+#: ../src/generic/dirdlgg.cpp:291 ../src/generic/dirdlgg.cpp:301
+#: ../src/generic/filectrlg.cpp:614 ../src/generic/filectrlg.cpp:623
+msgid "NewName"
+msgstr ""
+
+#: ../src/generic/editlbox.cpp:135
+msgid "Edit item"
+msgstr "Rediģēt objektu"
+
+#: ../src/generic/editlbox.cpp:143
+msgid "New item"
+msgstr "Jauna vienība"
+
+#: ../src/generic/editlbox.cpp:151
+msgid "Delete item"
+msgstr "Dzēst objektu"
+
+#: ../src/generic/editlbox.cpp:159
+msgid "Move up"
+msgstr "Uz augšu"
+
+#: ../src/generic/editlbox.cpp:164
+msgid "Move down"
+msgstr "Uz leju"
+
+#: ../src/generic/fdrepdlg.cpp:108
+msgid "Search for:"
+msgstr "Meklēt:"
+
+#: ../src/generic/fdrepdlg.cpp:120
+msgid "Replace with:"
+msgstr "Aizstāt ar:"
+
+#: ../src/generic/fdrepdlg.cpp:140
+msgid "Whole word"
+msgstr "Viss vārds"
+
+#: ../src/generic/fdrepdlg.cpp:143
+msgid "Match case"
+msgstr "Reģistrjutīgs"
+
+#: ../src/generic/fdrepdlg.cpp:156
+msgid "Search direction"
+msgstr "Meklēšanas virziens"
+
+#: ../src/generic/fdrepdlg.cpp:175
+msgid "&Replace"
+msgstr "Aiz&vietot"
+
+#: ../src/generic/fdrepdlg.cpp:178
+msgid "Replace &all"
+msgstr "&Aizstāt visus"
+
+#: ../src/generic/filectrlg.cpp:246 ../src/generic/filectrlg.cpp:269
+msgid "<DIR>"
+msgstr "<DIR>"
+
+#: ../src/generic/filectrlg.cpp:248 ../src/generic/filectrlg.cpp:271
+msgid "<LINK>"
+msgstr "<SAITE>"
+
+#: ../src/generic/filectrlg.cpp:250 ../src/generic/filectrlg.cpp:273
+msgid "<DRIVE>"
+msgstr "<DISKS>"
+
+#: ../src/generic/filectrlg.cpp:275
+#, c-format
+msgid "%ld byte"
+msgid_plural "%ld bytes"
+msgstr[0] "%ld baits"
+msgstr[1] "%ld baiti"
+msgstr[2] "%ld baiti"
+
+#: ../src/generic/filectrlg.cpp:420
+msgid "Name"
+msgstr "Nosaukums"
+
+#: ../src/generic/filectrlg.cpp:421 ../src/richtext/richtextformatdlg.cpp:361
+#: ../src/richtext/richtextsizepage.cpp:298
+msgid "Size"
+msgstr "Izmērs"
+
+#: ../src/generic/filectrlg.cpp:422
+msgid "Type"
+msgstr "Tips"
+
+#: ../src/generic/filectrlg.cpp:423
+msgid "Modified"
+msgstr "Izmainīts"
+
+#: ../src/generic/filectrlg.cpp:426
+msgid "Permissions"
+msgstr "Atļaujas"
+
+#: ../src/generic/filectrlg.cpp:429
+msgid "Attributes"
+msgstr "Atribūti"
+
+#: ../src/generic/filectrlg.cpp:936
+msgid "Current directory:"
+msgstr "Aktuālā mape:"
+
+#: ../src/generic/filectrlg.cpp:979
+msgid "Show &hidden files"
+msgstr "Rādīt &slēptos failus"
+
+#: ../src/generic/filectrlg.cpp:1355
+msgid "Illegal file specification."
+msgstr "Nederīga faila specifikācija."
+
+#: ../src/generic/filectrlg.cpp:1387
+msgid "Directory doesn't exist."
+msgstr "Mape nepastāv."
+
+#: ../src/generic/filedlgg.cpp:195
+msgid "View files as a list view"
+msgstr "Aplūkot failus saraksta skatā"
+
+#: ../src/generic/filedlgg.cpp:197
+msgid "View files as a detailed view"
+msgstr "Aplūkot failus detalizētajā skatā"
+
+#: ../src/generic/filedlgg.cpp:200
+msgid "Go to parent directory"
+msgstr "Iet uz vecāka direktoriju"
+
+#: ../src/generic/filedlgg.cpp:351 ../src/gtk/filedlg.cpp:59
+#, c-format
+msgid "File '%s' already exists, do you really want to overwrite it?"
+msgstr "Fails '%s' jau eksistē, vai patiešām vēlaties to pārrakstīt?"
+
+#: ../src/generic/filedlgg.cpp:354 ../src/gtk/filedlg.cpp:62
+msgid "Confirm"
+msgstr "Apstiprināt"
+
+#: ../src/generic/filedlgg.cpp:362 ../src/gtk/filedlg.cpp:75
+msgid "Please choose an existing file."
+msgstr "Lūdzu, izvēlieties esošu failu."
+
+#: ../src/generic/filepickerg.cpp:64
+msgid "..."
+msgstr "..."
+
+#: ../src/generic/fontdlgg.cpp:76 ../src/richtext/richtextformatdlg.cpp:519
+msgid "ABCDEFGabcdefg12345"
+msgstr "AĀBCČDŠaābcčdš12345"
+
+#: ../src/generic/fontdlgg.cpp:315
+msgid "Roman"
+msgstr "Romāņu"
+
+#: ../src/generic/fontdlgg.cpp:316
+msgid "Decorative"
+msgstr "Dekoratīvs"
+
+#: ../src/generic/fontdlgg.cpp:317
+msgid "Modern"
+msgstr "Moderns"
+
+#: ../src/generic/fontdlgg.cpp:318
+msgid "Script"
+msgstr "Rokraksta"
+
+#: ../src/generic/fontdlgg.cpp:319
+msgid "Swiss"
+msgstr "Šveices"
+
+#: ../src/generic/fontdlgg.cpp:320
+msgid "Teletype"
+msgstr "Teletaips"
+
+#: ../src/generic/fontdlgg.cpp:321 ../src/generic/fontdlgg.cpp:324
+msgid "Normal"
+msgstr "Normāls"
+
+#: ../src/generic/fontdlgg.cpp:323
+msgid "Slant"
+msgstr "Slīpums"
+
+#: ../src/generic/fontdlgg.cpp:325
+msgid "Light"
+msgstr "Gaišs"
+
+#: ../src/generic/fontdlgg.cpp:363
+msgid "&Font family:"
+msgstr "&Fontu saime:"
+
+#: ../src/generic/fontdlgg.cpp:367 ../src/generic/fontdlgg.cpp:369
+msgid "The font family."
+msgstr "Fontu saime."
+
+#: ../src/generic/fontdlgg.cpp:374 ../src/richtext/richtextstylepage.cpp:105
+msgid "&Style:"
+msgstr "&Stils:"
+
+#: ../src/generic/fontdlgg.cpp:378 ../src/generic/fontdlgg.cpp:380
+msgid "The font style."
+msgstr "Fonta stils."
+
+#: ../src/generic/fontdlgg.cpp:385
+msgid "&Weight:"
+msgstr "&Svars:"
+
+#: ../src/generic/fontdlgg.cpp:389 ../src/generic/fontdlgg.cpp:391
+msgid "The font weight."
+msgstr "Fonta svars."
+
+#: ../src/generic/fontdlgg.cpp:399
+msgid "C&olour:"
+msgstr "&Krāsa:"
+
+#: ../src/generic/fontdlgg.cpp:407 ../src/generic/fontdlgg.cpp:409
+msgid "The font colour."
+msgstr "Fonta krāsa."
+
+#: ../src/generic/fontdlgg.cpp:415
+msgid "&Point size:"
+msgstr "&Punkta izmērs:"
+
+#: ../src/generic/fontdlgg.cpp:420 ../src/generic/fontdlgg.cpp:422
+#: ../src/generic/fontdlgg.cpp:426 ../src/generic/fontdlgg.cpp:428
+msgid "The font point size."
+msgstr "Fonta izmērs punktos."
+
+#: ../src/generic/fontdlgg.cpp:439 ../src/generic/fontdlgg.cpp:441
+msgid "Whether the font is underlined."
+msgstr "Vai fonts ir pasvītrots."
+
+#: ../src/generic/fontdlgg.cpp:448 ../src/html/helpwnd.cpp:1215
+msgid "Preview:"
+msgstr "Priekšskatījums:"
+
+#: ../src/generic/fontdlgg.cpp:452 ../src/generic/fontdlgg.cpp:454
+msgid "Shows the font preview."
+msgstr "Rāda fonta priekšskatījumu."
+
+#: ../src/generic/fontdlgg.cpp:464 ../src/generic/fontdlgg.cpp:483
+msgid "Click to cancel the font selection."
+msgstr "Nospiediet, lai atceltu fonta izvēli."
+
+#: ../src/generic/fontdlgg.cpp:469 ../src/generic/fontdlgg.cpp:471
+#: ../src/generic/fontdlgg.cpp:476 ../src/generic/fontdlgg.cpp:478
+msgid "Click to confirm the font selection."
+msgstr "Nospiediet, lai apstiprinātu fonta izvēli."
+
+#: ../src/generic/fontpickerg.cpp:50 ../src/gtk/fontdlg.cpp:77
+msgid "Choose font"
+msgstr "Izvēlieties fontu"
+
+#: ../src/generic/grid.cpp:6542
+msgid ""
+"Error copying grid to the clipboard. Either selected cells were not "
+"contiguous or no cell was selected."
+msgstr ""
+
+#: ../src/generic/grid.cpp:12739
+msgid "Grid Corner"
+msgstr ""
+
+#: ../src/generic/grid.cpp:12741
+#, c-format
+msgid "Column %s Header"
+msgstr ""
+
+#: ../src/generic/grid.cpp:12743
+#, c-format
+msgid "Row %s Header"
+msgstr ""
+
+#: ../src/generic/grid.cpp:12745
+#, c-format
+msgid "Column %s: %s"
+msgstr ""
+
+#: ../src/generic/grid.cpp:12749
+#, fuzzy, c-format
+msgid "Row %s: %s"
+msgstr "\t%s: %s\n"
+
+#: ../src/generic/grid.cpp:12753
+#, c-format
+msgid "Row %s, Column %s: %s"
+msgstr ""
+
+#: ../src/generic/helpext.cpp:257
+#, c-format
+msgid "Help directory \"%s\" not found."
+msgstr "Palīdzības mape \"%s\" nav atrasta."
+
+#: ../src/generic/helpext.cpp:265
+#, c-format
+msgid "Help file \"%s\" not found."
+msgstr "Palīdzības fails \"%s\" nav atrasts."
+
+#: ../src/generic/helpext.cpp:284
+#, c-format
+msgid "Line %lu of map file \"%s\" has invalid syntax, skipped."
+msgstr ""
+
+#: ../src/generic/helpext.cpp:292
+#, c-format
+msgid "No valid mappings found in the file \"%s\"."
+msgstr ""
+
+#: ../src/generic/helpext.cpp:435
+msgid "No entries found."
+msgstr "Nav atrasts neviens ieraksts."
+
+#: ../src/generic/helpext.cpp:444 ../src/generic/helpext.cpp:445
+msgid "Help Index"
+msgstr "Palīdzības saturs"
+
+#: ../src/generic/helpext.cpp:448
+msgid "Relevant entries:"
+msgstr "Saistītie ieraksti:"
+
+#: ../src/generic/helpext.cpp:449
+msgid "Entries found"
+msgstr "Ieraksti atrasti"
+
+#: ../src/generic/hyperlinkg.cpp:170
+msgid "&Copy URL"
+msgstr "&Kopēt URL"
+
+#: ../src/generic/infobar.cpp:119
+msgid "Hide this notification message."
+msgstr "Slēpt šo paziņojumu."
+
+#. TRANSLATORS: %s will be either the application name or "Application"
+#: ../src/generic/logg.cpp:257
+#, c-format
+msgid "%s Error"
+msgstr "%s Kļuda"
+
+#. TRANSLATORS: %s will be either the application name or "Application"
+#: ../src/generic/logg.cpp:263
+#, c-format
+msgid "%s Warning"
+msgstr "%s Brīdinājums"
+
+#. TRANSLATORS: %s will be either the application name or "Application"
+#: ../src/generic/logg.cpp:273
+#, c-format
+msgid "%s Information"
+msgstr "%s Informācija"
+
+#: ../src/generic/logg.cpp:276
+msgid "Application"
+msgstr "Programma"
+
+#: ../src/generic/logg.cpp:549
+msgid "Save log contents to file"
+msgstr "Saglabāt žurnāla saturu failā"
+
+#: ../src/generic/logg.cpp:551
+msgid "C&lear"
+msgstr "&Tīrīt"
+
+#: ../src/generic/logg.cpp:551
+msgid "Clear the log contents"
+msgstr "Notīrīt žurnāla saturu"
+
+#: ../src/generic/logg.cpp:553
+msgid "Close this window"
+msgstr "Aizvērt šo logu"
+
+#: ../src/generic/logg.cpp:554
+msgid "&Log"
+msgstr "Žurnā&ls"
+
+#: ../src/generic/logg.cpp:610 ../src/generic/logg.cpp:992
+msgid "Can't save log contents to file."
+msgstr "Nav iespējams saglabāt žurnāla saturu failā."
+
+#: ../src/generic/logg.cpp:613
+#, c-format
+msgid "Log saved to the file '%s'."
+msgstr "Žurnāls saglabāts failā '%s'."
+
+#: ../src/generic/logg.cpp:719
+msgid "&Details"
+msgstr "&Detaļas"
+
+#: ../src/generic/logg.cpp:972
+msgid "Failed to copy dialog contents to the clipboard."
+msgstr "Neizdevās nokopēt dialoga saturu uz starpliktuvi."
+
+#: ../src/generic/logg.cpp:1022
+#, c-format
+msgid "Append log to file '%s' (choosing [No] will overwrite it)?"
+msgstr ""
+"Papildināt failu '%s' ar žurnāla ierakstiem (izvēloties  [Nē] tas tiks "
+"pārrakstīts)?"
+
+#: ../src/generic/logg.cpp:1024
+msgid "Question"
+msgstr "Jautājums"
+
+#: ../src/generic/logg.cpp:1038
+msgid "invalid message box return value"
+msgstr ""
+
+#: ../src/generic/notifmsgg.cpp:129
+msgid "Notice"
+msgstr "Paziņojums"
+
+#: ../src/generic/preferencesg.cpp:118
+#, fuzzy, c-format
+msgid "%s Preferences"
+msgstr "Iestatījumi"
+
+#: ../src/generic/printps.cpp:143
+msgid "Printing..."
+msgstr "Drukājas..."
+
+#: ../src/generic/printps.cpp:160 ../src/gtk/print.cpp:1076
+#: ../src/msw/printwin.cpp:235
+msgid "Could not start printing."
+msgstr "Neizdevās sākt drukāšanu."
+
+#: ../src/generic/printps.cpp:183
+#, c-format
+msgid "Printing page %d..."
+msgstr "Drukājas lapa %d..."
+
+#: ../src/generic/prntdlgg.cpp:171
+msgid "Printer options"
+msgstr "Printera iestatījumi"
+
+#: ../src/generic/prntdlgg.cpp:176
+msgid "Print to File"
+msgstr "Drukāt failā"
+
+#: ../src/generic/prntdlgg.cpp:179
+msgid "Setup..."
+msgstr "Iestatīt..."
+
+#: ../src/generic/prntdlgg.cpp:187
+msgid "Printer:"
+msgstr "Drukas iekārta:"
+
+#: ../src/generic/prntdlgg.cpp:195
+msgid "Status:"
+msgstr "Statuss:"
+
+#: ../src/generic/prntdlgg.cpp:206
+msgid "All"
+msgstr "Visu"
+
+#: ../src/generic/prntdlgg.cpp:207
+msgid "Pages"
+msgstr "Lapas"
+
+#: ../src/generic/prntdlgg.cpp:215
+msgid "Print Range"
+msgstr "Drukāt diapazonu"
+
+#: ../src/generic/prntdlgg.cpp:229
+msgid "From:"
+msgstr "Sūtītājs:"
+
+#: ../src/generic/prntdlgg.cpp:233
+msgid "To:"
+msgstr "Saņēmējs:"
+
+#: ../src/generic/prntdlgg.cpp:238
+msgid "Copies:"
+msgstr "Kopijas:"
+
+#: ../src/generic/prntdlgg.cpp:288
+msgid "PostScript file"
+msgstr "PostScript fails"
+
+#: ../src/generic/prntdlgg.cpp:439
+msgid "Print Setup"
+msgstr "Drukas iestatījumi"
+
+#: ../src/generic/prntdlgg.cpp:483
+msgid "Printer"
+msgstr "Printeris"
+
+#: ../src/generic/prntdlgg.cpp:501
+msgid "Default printer"
+msgstr "Noklusētais printeris"
+
+#: ../src/generic/prntdlgg.cpp:595 ../src/generic/prntdlgg.cpp:782
+#: ../src/generic/prntdlgg.cpp:822 ../src/generic/prntdlgg.cpp:835
+#: ../src/generic/prntdlgg.cpp:1031 ../src/generic/prntdlgg.cpp:1036
+msgid "Paper size"
+msgstr "Papīra izmērs"
+
+#: ../src/generic/prntdlgg.cpp:604 ../src/generic/prntdlgg.cpp:847
+msgid "Portrait"
+msgstr "Portrets"
+
+#: ../src/generic/prntdlgg.cpp:605 ../src/generic/prntdlgg.cpp:848
+msgid "Landscape"
+msgstr "Ainava"
+
+#: ../src/generic/prntdlgg.cpp:607 ../src/generic/prntdlgg.cpp:849
+msgid "Orientation"
+msgstr "Orientācija"
+
+#: ../src/generic/prntdlgg.cpp:610
+msgid "Options"
+msgstr "Iestatījumi"
+
+#: ../src/generic/prntdlgg.cpp:612
+msgid "Print in colour"
+msgstr "Drukāt krāsainu"
+
+#: ../src/generic/prntdlgg.cpp:621
+msgid "Print spooling"
+msgstr "Drukas spolēšana"
+
+#: ../src/generic/prntdlgg.cpp:623
+msgid "Printer command:"
+msgstr "Printera komanda:"
+
+#: ../src/generic/prntdlgg.cpp:631
+msgid "Printer options:"
+msgstr "Printera iestatījumi:"
+
+#: ../src/generic/prntdlgg.cpp:860
+msgid "Left margin (mm):"
+msgstr "Kreisā apmale (mm):"
+
+#: ../src/generic/prntdlgg.cpp:861
+msgid "Top margin (mm):"
+msgstr "Augšējā mala (mm):"
+
+#: ../src/generic/prntdlgg.cpp:872
+msgid "Right margin (mm):"
+msgstr "Labā apmale (mm):"
+
+#: ../src/generic/prntdlgg.cpp:873
+msgid "Bottom margin (mm):"
+msgstr "Apakšējā mala (mm):"
+
+#: ../src/generic/prntdlgg.cpp:896
+msgid "Printer..."
+msgstr "Printeris.."
+
+#: ../src/generic/progdlgg.cpp:246
+msgid "&Skip"
+msgstr "&Izlaist"
+
+#: ../src/generic/progdlgg.cpp:347 ../src/generic/progdlgg.cpp:626
+msgid "Unknown"
+msgstr "Nezināms"
+
+#: ../src/generic/progdlgg.cpp:451 ../src/msw/progdlg.cpp:526
+msgid "Done."
+msgstr "Izdarīts."
+
+#: ../src/generic/srchctlg.cpp:55 ../src/gtk/srchctrl.cpp:206
+#: ../src/html/helpwnd.cpp:530 ../src/html/helpwnd.cpp:545
+msgid "Search"
+msgstr "Meklēt"
+
+#: ../src/generic/tabg.cpp:1026
+msgid "Could not find tab for id"
+msgstr ""
+
+#: ../src/generic/tipdlg.cpp:136
+msgid "Tips not available, sorry!"
+msgstr "Dienas padomi nav pieejami!"
+
+#: ../src/generic/tipdlg.cpp:197
+msgid "Tip of the Day"
+msgstr "Dienas padoms"
+
+#: ../src/generic/tipdlg.cpp:207
+msgid "Did you know..."
+msgstr "Vai jūs zināt..."
+
+#: ../src/generic/tipdlg.cpp:232
+msgid "&Show tips at startup"
+msgstr "Rādīt dienas padomu&s"
+
+#: ../src/generic/tipdlg.cpp:236
+msgid "&Next Tip"
+msgstr "&Nākošais Padoms"
+
+#: ../src/generic/wizard.cpp:411
+msgid "&Next >"
+msgstr "&Nākošais >"
+
+#: ../src/generic/wizard.cpp:412
+msgid "&Finish"
+msgstr "&Pabeigt"
+
+#: ../src/generic/wizard.cpp:420
+msgid "< &Back"
+msgstr "< At&pakaļ"
+
+#: ../src/gtk/aboutdlg.cpp:204
+msgid "translator-credits"
+msgstr "atzinība tulkotājiem"
+
+#: ../src/gtk/app.cpp:517
+msgid ""
+"WARNING: using XIM input method is unsupported and may result in problems "
+"with input handling and flickering. Consider unsetting GTK_IM_MODULE or "
+"setting to \"ibus\"."
+msgstr ""
+
+#: ../src/gtk/app.cpp:569
+msgid "Unable to initialize GTK+, is DISPLAY set properly?"
+msgstr ""
+"Nav iespējams inicializēt GTK+, vai DISPLAY parametrs ir iestatīts pareizi?"
+
+#: ../src/gtk/filedlg.cpp:89 ../src/gtk/filepicker.cpp:255
+#, fuzzy, c-format
+msgid "Changing current directory to \"%s\" failed"
+msgstr "Neizdevās izveidot mapi \"%s\""
+
+#: ../src/gtk/font.cpp:548
+msgid ""
+"Using private fonts is not supported on this system: Pango library is too "
+"old, 1.38 or later required."
+msgstr ""
+
+#: ../src/gtk/font.cpp:558
+#, fuzzy
+msgid "Failed to create font configuration object."
+msgstr "Neizdevās atsvaidzināt lietotāja konfigurācijas failu."
+
+#: ../src/gtk/font.cpp:568
+#, fuzzy, c-format
+msgid "Failed to add custom font \"%s\"."
+msgstr "Neizdevās ielasīt dokumentu no faila \"%s\"."
+
+#: ../src/gtk/font.cpp:576
+#, fuzzy
+msgid "Failed to register font configuration using private fonts."
+msgstr "Neizdevās atsvaidzināt lietotāja konfigurācijas failu."
+
+#: ../src/gtk/glcanvas.cpp:117 ../src/gtk/glcanvas.cpp:132
+#, fuzzy
+msgid "Fatal Error"
+msgstr "Fatāla kļūda"
+
+#: ../src/gtk/glcanvas.cpp:117
+msgid ""
+"This program wasn't compiled with EGL support required under Wayland, "
+"either\n"
+"install EGL libraries and rebuild or run it under X11 backend by setting\n"
+"environment variable GDK_BACKEND=x11 before starting your program."
+msgstr ""
+
+#: ../src/gtk/glcanvas.cpp:132
+msgid ""
+"wxGLCanvas is only supported on Wayland and X11 currently.  You may be able "
+"to\n"
+"work around this by setting environment variable GDK_BACKEND=x11 before\n"
+"starting your program."
+msgstr ""
+
+#: ../src/gtk/mdi.cpp:433
+msgid "MDI child"
+msgstr ""
+
+#: ../src/gtk/power.cpp:188
+#, fuzzy, c-format
+msgid "Failed to open D-Bus connection to the login manager: %s"
+msgstr "Neizdevās izveidot savienojumu ar serveri '%s'par tematu '%s'"
+
+#: ../src/gtk/power.cpp:214
+#, fuzzy
+msgid "wxWidgets application"
+msgstr "Programma"
+
+#: ../src/gtk/power.cpp:226
+msgid "Application needs to keep running"
+msgstr ""
+
+#: ../src/gtk/power.cpp:233
+msgid "Clean up before suspend"
+msgstr ""
+
+#: ../src/gtk/power.cpp:259
+#, fuzzy, c-format
+msgid "Failed to inhibit sleep: %s"
+msgstr "Neizdevās izveidot iezvanpieejas savienojumu: %s"
+
+#: ../src/gtk/power.cpp:265
+msgid "Unexpected response to D-Bus \"Inhibit\" request."
+msgstr ""
+
+#: ../src/gtk/print.cpp:218
+msgid "Custom size"
+msgstr "Pielāgots izmērs"
+
+#: ../src/gtk/print.cpp:752
+#, fuzzy, c-format
+msgid "Error while printing: %s"
+msgstr "Kļūda drukājot:"
+
+#: ../src/gtk/print.cpp:816
+msgid "Page Setup"
+msgstr "Lapas iestatījumi"
+
+#: ../src/gtk/webview_webkit.cpp:932
+msgid "Retrieving JavaScript script output is not supported with WebKit v1"
+msgstr ""
+
+#: ../src/gtk/webview_webkit2.cpp:1098
+msgid ""
+"Setting proxy is not supported by WebKit, at least version 2.16 is required."
+msgstr ""
+
+#: ../src/gtk/webview_webkit2.cpp:1104
+msgid "This program was compiled without support for setting WebKit proxy."
+msgstr ""
+
+#: ../src/gtk/window.cpp:6289
+msgid ""
+"GTK+ installed on this machine is too old to support screen compositing, "
+"please install GTK+ 2.12 or later."
+msgstr ""
+
+#: ../src/gtk/window.cpp:6307
+msgid ""
+"Compositing not supported by this system, please enable it in your Window "
+"Manager."
+msgstr ""
+
+#: ../src/gtk/window.cpp:6318
+msgid ""
+"This program was compiled with a too old version of GTK+, please rebuild "
+"with GTK+ 2.12 or newer."
+msgstr ""
+"Šī programma ir kompilēta ar pārāk vecu GTK+ versiju, lūdzu, pārkompilējiet "
+"ar GTK+ 2.12 vai jaunāku."
+
+#: ../src/html/chm.cpp:138
+#, c-format
+msgid "Failed to open CHM archive '%s'."
+msgstr "Neizdevās atvērt CHM arhīvu '%s'."
+
+#: ../src/html/chm.cpp:270
+#, c-format
+msgid "Could not extract %s into %s: %s"
+msgstr ""
+
+#: ../src/html/chm.cpp:324
+msgid "no error"
+msgstr "nav kļūdu"
+
+#: ../src/html/chm.cpp:326
+msgid "bad arguments to library function"
+msgstr "bibliotēkas funkcijai nederīgi argumenti"
+
+#: ../src/html/chm.cpp:328
+msgid "error opening file"
+msgstr "kļūda atverot failu"
+
+#: ../src/html/chm.cpp:330
+msgid "read error"
+msgstr "lasīšanas kļūda"
+
+#: ../src/html/chm.cpp:332
+msgid "write error"
+msgstr "rakstīšanas kļūda"
+
+#: ../src/html/chm.cpp:334
+msgid "seek error"
+msgstr "pozicionēšanas kļūda"
+
+#: ../src/html/chm.cpp:338
+msgid "bad signature"
+msgstr "nederīgs paraksts"
+
+#: ../src/html/chm.cpp:340
+msgid "error in data format"
+msgstr "kļūda datu formātā"
+
+#: ../src/html/chm.cpp:342
+msgid "checksum error"
+msgstr "kļūda kontrolsummā"
+
+#: ../src/html/chm.cpp:344
+msgid "compression error"
+msgstr "saspiešanas kļūda"
+
+#: ../src/html/chm.cpp:346
+msgid "decompression error"
+msgstr "atspiešanas kļūda"
+
+#: ../src/html/chm.cpp:437
+#, c-format
+msgid "Could not locate file '%s'."
+msgstr "Neizdevās atrast failu '%s'."
+
+#: ../src/html/chm.cpp:711
+#, c-format
+msgid "Could not create temporary file '%s'"
+msgstr "Neizdevās izveidot pagaidu failu '%s'"
+
+#: ../src/html/chm.cpp:718
+#, c-format
+msgid "Extraction of '%s' into '%s' failed."
+msgstr ""
+
+#: ../src/html/chm.cpp:806 ../src/html/chm.cpp:863
+msgid "CHM handler currently supports only local files!"
+msgstr ""
+
+#: ../src/html/chm.cpp:827
+msgid "Link contained '//', converted to absolute link."
+msgstr "Saite saturēja '//', pārvērsta par absolūto saiti.."
+
+#: ../src/html/helpctrl.cpp:59
+#, c-format
+msgid "Help: %s"
+msgstr "Palīdzība: %s"
+
+#: ../src/html/helpctrl.cpp:155
+#, c-format
+msgid "Adding book %s"
+msgstr "Pievieno grāmatu %s"
+
+#: ../src/html/helpdata.cpp:295
+#, c-format
+msgid "Cannot open contents file: %s"
+msgstr "Nav iespējams atvērt satura failu: %s"
+
+#: ../src/html/helpdata.cpp:309
+#, c-format
+msgid "Cannot open index file: %s"
+msgstr "Nav iespējams atvērt indeksu failu: %s"
+
+#: ../src/html/helpdata.cpp:643
+msgid "noname"
+msgstr "bezvārda"
+
+#: ../src/html/helpdata.cpp:652
+#, c-format
+msgid "Cannot open HTML help book: %s"
+msgstr "Nav iespējams atvērt HTML palīdzības grāmatu: %s"
+
+#: ../src/html/helpwnd.cpp:315
+msgid "Displays help as you browse the books on the left."
+msgstr "Parāda palīdzību pārlūkojot grāmatu sarakstu kreisajā pusē."
+
+#: ../src/html/helpwnd.cpp:411 ../src/html/helpwnd.cpp:1100
+#: ../src/html/helpwnd.cpp:1735
+msgid "(bookmarks)"
+msgstr "(grāmatzīme)"
+
+#: ../src/html/helpwnd.cpp:424
+msgid "Add current page to bookmarks"
+msgstr "Pievienot grāmatzīmēm pašreizējo lapu"
+
+#: ../src/html/helpwnd.cpp:425
+msgid "Remove current page from bookmarks"
+msgstr "Izņemt pašreizējo lapu no grāmatazīmēm"
+
+#: ../src/html/helpwnd.cpp:470
+msgid "Contents"
+msgstr "Saturs"
+
+#: ../src/html/helpwnd.cpp:485
+msgid "Find"
+msgstr "Meklēt"
+
+#: ../src/html/helpwnd.cpp:487
+msgid "Show all"
+msgstr "Rādīt visas"
+
+#: ../src/html/helpwnd.cpp:497
+msgid ""
+"Display all index items that contain given substring. Search is case "
+"insensitive."
+msgstr ""
+"Parādīt visus indeksa ierakstus, kas satur norādīto apakšvirkni. Meklēšana "
+"nav reģistrjūtīga."
+
+#: ../src/html/helpwnd.cpp:498
+msgid "Show all items in index"
+msgstr "Rādīt visus saraksta locekļus"
+
+#: ../src/html/helpwnd.cpp:528
+msgid "Case sensitive"
+msgstr "Reģistrjūtīgs"
+
+#: ../src/html/helpwnd.cpp:529
+msgid "Whole words only"
+msgstr "Tikai veselus vārdus"
+
+#: ../src/html/helpwnd.cpp:532
+msgid ""
+"Search contents of help book(s) for all occurrences of the text you typed "
+"above"
+msgstr "Meklēt palīdzības grāmatas(-u) saturā tekstu, ko ievadījāt augstāk"
+
+#: ../src/html/helpwnd.cpp:653
+msgid "Show/hide navigation panel"
+msgstr "Rādīt/slēpt navigācijas paneli"
+
+#: ../src/html/helpwnd.cpp:655
+msgid "Go back"
+msgstr "Iet atpakaļ"
+
+#: ../src/html/helpwnd.cpp:656
+msgid "Go forward"
+msgstr "Iet uz priekšu"
+
+#: ../src/html/helpwnd.cpp:658
+msgid "Go one level up in document hierarchy"
+msgstr "Iet vienu līmeni augstāk dokumenta hierarhijā"
+
+#: ../src/html/helpwnd.cpp:666 ../src/html/helpwnd.cpp:1547
+msgid "Open HTML document"
+msgstr "Atvērt HTML dokumentu"
+
+#: ../src/html/helpwnd.cpp:670
+msgid "Print this page"
+msgstr "Drukāt šo lapu"
+
+#: ../src/html/helpwnd.cpp:674
+msgid "Display options dialog"
+msgstr "Ekrāna iestatījumu dialogs"
+
+#: ../src/html/helpwnd.cpp:795
+msgid "Please choose the page to display:"
+msgstr "Lūdzu, izvēlieties attēlojamo lapu:"
+
+#: ../src/html/helpwnd.cpp:796
+msgid "Help Topics"
+msgstr "Palīdzības temati"
+
+#: ../src/html/helpwnd.cpp:852
+msgid "Searching..."
+msgstr "Meklē..."
+
+#: ../src/html/helpwnd.cpp:853
+msgid "No matching page found yet"
+msgstr "Pagaidām netika atrasta atbilstoša lapa"
+
+#: ../src/html/helpwnd.cpp:870
+#, c-format
+msgid "Found %i matches"
+msgstr "Atrastas %i atbilstības"
+
+#: ../src/html/helpwnd.cpp:958
+msgid "(Help)"
+msgstr "(Palīdzība)"
+
+#: ../src/html/helpwnd.cpp:1026
+#, c-format
+msgid "%d of %lu"
+msgstr "%d no %lu"
+
+#: ../src/html/helpwnd.cpp:1028
+#, c-format
+msgid "%lu of %lu"
+msgstr "%lu no %lu"
+
+#: ../src/html/helpwnd.cpp:1047
+msgid "Search in all books"
+msgstr "Meklēt visās grāmatās"
+
+#: ../src/html/helpwnd.cpp:1193
+msgid "Help Browser Options"
+msgstr "Palīdzības pārlūka iestatījumi"
+
+#: ../src/html/helpwnd.cpp:1198
+msgid "Normal font:"
+msgstr "Normāls fonts:"
+
+#: ../src/html/helpwnd.cpp:1199
+msgid "Fixed font:"
+msgstr "Fiksēts fonts:"
+
+#: ../src/html/helpwnd.cpp:1200
+msgid "Font size:"
+msgstr "Fonta izmērs:"
+
+#: ../src/html/helpwnd.cpp:1245
+msgid "font size"
+msgstr "fonta izmērs"
+
+#: ../src/html/helpwnd.cpp:1256
+msgid "Normal face<br>and <u>underlined</u>. "
+msgstr "Normāls fonts<br>un  <u>pasvītrots</u>. "
+
+#: ../src/html/helpwnd.cpp:1257
+msgid "<i>Italic face.</i> "
+msgstr "<i>Kursīvs.</i>"
+
+#: ../src/html/helpwnd.cpp:1258
+msgid "<b>Bold face.</b> "
+msgstr "<b>Treknraksts.</b> "
+
+#: ../src/html/helpwnd.cpp:1259
+msgid "<b><i>Bold italic face.</i></b><br>"
+msgstr "<b><i>Treknraksts kursīvā.</i></b><br>"
+
+#: ../src/html/helpwnd.cpp:1262
+msgid "Fixed size face.<br> <b>bold</b> <i>italic</i> "
+msgstr "Fiksēta izmēra.<br> <b>treknraksts</b> <i>kursīvs</i> "
+
+#: ../src/html/helpwnd.cpp:1263
+msgid "<b><i>bold italic <u>underlined</u></i></b><br>"
+msgstr "<b><i>treknraksts kursīvā <u>pasvītrots</u></i></b><br>"
+
+#: ../src/html/helpwnd.cpp:1524
+msgid "Help Printing"
+msgstr "Palīdzība par drukāšanu"
+
+#: ../src/html/helpwnd.cpp:1527
+msgid "Cannot print empty page."
+msgstr "Nav iespējams nodrukāt tukšu lapu."
+
+#: ../src/html/helpwnd.cpp:1540
+msgid "HTML files (*.html;*.htm)|*.html;*.htm|"
+msgstr "HTML faili (*.html;*.htm)|*.html;*.htm|"
+
+#: ../src/html/helpwnd.cpp:1541
+msgid "Help books (*.htb)|*.htb|Help books (*.zip)|*.zip|"
+msgstr "Palīdzības grāmatas (*.htb)|*.htb|Palīdzības grāmatas (*.zip)|*.zip|"
+
+#: ../src/html/helpwnd.cpp:1542
+msgid "HTML Help Project (*.hhp)|*.hhp|"
+msgstr "HTML Help Project (*.hhp)|*.hhp|"
+
+#: ../src/html/helpwnd.cpp:1544
+msgid "Compressed HTML Help file (*.chm)|*.chm|"
+msgstr "Saspiests HTML Help fails (*.chm)|*.chm|"
+
+#: ../src/html/helpwnd.cpp:1671
+#, fuzzy, c-format
+msgid "%i of %u"
+msgstr "%i no %i"
+
+#: ../src/html/helpwnd.cpp:1709
+#, fuzzy, c-format
+msgid "%u of %u"
+msgstr "%lu no %lu"
+
+#: ../src/html/htmlfilt.cpp:134
+#, c-format
+msgid "Cannot open HTML document: %s"
+msgstr "Nav iespējams atvērt HTML dokumentu: %s"
+
+#: ../src/html/htmlwin.cpp:599
+msgid "Connecting..."
+msgstr "Savienošanās..."
+
+#: ../src/html/htmlwin.cpp:616
+#, c-format
+msgid "Unable to open requested HTML document: %s"
+msgstr "Nav iespējams atvērt pieprasīto HTML dokumentu: %s"
+
+#: ../src/html/htmlwin.cpp:630
+msgid "Loading : "
+msgstr "Lasa..."
+
+#: ../src/html/htmlwin.cpp:673
+msgid "Done"
+msgstr "Izdarīts"
+
+#: ../src/html/htmlwin.cpp:723
+#, c-format
+msgid "HTML anchor %s does not exist."
+msgstr "HTML enkurs %s nepastāv."
+
+#: ../src/html/htmlwin.cpp:1057
+#, c-format
+msgid "Copied to clipboard:\"%s\""
+msgstr "Nokopēts starpliktuvē:\"%s\""
+
+#: ../src/html/htmprint.cpp:269
+msgid ""
+"This document doesn't fit on the page horizontally and will be truncated "
+"when it is printed."
+msgstr ""
+"Šis dokuments neietilpst lapā horizontālā virzienā un tādēļ drukājot tiks "
+"aprauts."
+
+#: ../src/html/htmprint.cpp:285
+#, c-format
+msgid ""
+"The document \"%s\" doesn't fit on the page horizontally and will be "
+"truncated if printed.\n"
+"\n"
+"Would you like to proceed with printing it nevertheless?"
+msgstr ""
+"Dokuments \"%s\" neietilpst lapā horizontālā virzienā un tādēļ drukājot tiks "
+"aprauts.\n"
+"\n"
+"Turpināt drukāt neskatoties uz to?"
+
+#: ../src/html/htmprint.cpp:296
+msgid ""
+"If possible, try changing the layout parameters to make the printout more "
+"narrow."
+msgstr ""
+"Ja iespējams, mēģiniet mainīt izkārtojumu, lai padarītu izdruku šaurāku."
+
+#: ../src/html/htmprint.cpp:445
+msgid ": file does not exist!"
+msgstr ": fails neeksistē!"
+
+#. TRANSLATORS: %s may be a document title.
+#: ../src/html/htmprint.cpp:717
+#, fuzzy, c-format
+msgid "%s Preview"
+msgstr " Priekšskatījums"
+
+#: ../src/html/htmprint.cpp:755 ../src/richtext/richtextprint.cpp:618
+msgid ""
+"There was a problem during page setup: you may need to set a default printer."
+msgstr "Kļūme lapas iestatījumos: iespējams, jānorāda noklusētais printeris."
+
+#: ../src/msw/clipbrd.cpp:80
+msgid "Failed to open the clipboard."
+msgstr "Neizdevās atvērt starpliktuvi."
+
+#: ../src/msw/clipbrd.cpp:101
+msgid "Failed to close the clipboard."
+msgstr "Nevar aizvērt starpliktuvi."
+
+#: ../src/msw/clipbrd.cpp:113
+msgid "Failed to empty the clipboard."
+msgstr "Neizdevās iztīrīt starpliktuvi."
+
+#: ../src/msw/clipbrd.cpp:284
+msgid "Failed to put data on the clipboard"
+msgstr "Neizdevās ievieto datus starpliktuvē"
+
+#: ../src/msw/clipbrd.cpp:326
+msgid "Failed to get data from the clipboard"
+msgstr "Neizdevās iegūt datus no starpliktuves."
+
+#: ../src/msw/clipbrd.cpp:363
+msgid "Failed to retrieve the supported clipboard formats"
+msgstr "Neizdevās saņemt atbalstītos starpliktuves formātus."
+
+#: ../src/msw/colordlg.cpp:228
+#, c-format
+msgid "Colour selection dialog failed with error %0lx."
+msgstr "Krāsu izvēles dialogs pārtrauca darbību ar kļūdu  %0lx."
+
+#: ../src/msw/cursor.cpp:141
+msgid "Failed to create cursor."
+msgstr "Neizdevās izveidot kursoru."
+
+#: ../src/msw/dde.cpp:279
+#, c-format
+msgid "Failed to register DDE server '%s'"
+msgstr "Neizdevās reģistrēt DDE serveri '%s'"
+
+#: ../src/msw/dde.cpp:300
+#, c-format
+msgid "Failed to unregister DDE server '%s'"
+msgstr "Neizdevās dereģistrēt DDE serveri '%s'"
+
+#: ../src/msw/dde.cpp:428
+#, c-format
+msgid "Failed to create connection to server '%s' on topic '%s'"
+msgstr "Neizdevās izveidot savienojumu ar serveri '%s'par tematu '%s'"
+
+#: ../src/msw/dde.cpp:655
+msgid "DDE poke request failed"
+msgstr ""
+
+#: ../src/msw/dde.cpp:674
+msgid "Failed to establish an advise loop with DDE server"
+msgstr ""
+
+#: ../src/msw/dde.cpp:693
+msgid "Failed to terminate the advise loop with DDE server"
+msgstr ""
+
+#: ../src/msw/dde.cpp:768
+msgid "Failed to send DDE advise notification"
+msgstr ""
+
+#: ../src/msw/dde.cpp:1085
+msgid "Failed to create DDE string"
+msgstr "Neizdevās izveidot DDE virkni"
+
+#: ../src/msw/dde.cpp:1131
+msgid "no DDE error."
+msgstr "nav DDE kļūdas."
+
+#: ../src/msw/dde.cpp:1135
+msgid "a request for a synchronous advise transaction has timed out."
+msgstr ""
+
+#: ../src/msw/dde.cpp:1138
+msgid "the response to the transaction caused the DDE_FBUSY bit to be set."
+msgstr ""
+
+#: ../src/msw/dde.cpp:1141
+msgid "a request for a synchronous data transaction has timed out."
+msgstr ""
+
+#: ../src/msw/dde.cpp:1144
+msgid ""
+"a DDEML function was called without first calling the DdeInitialize "
+"function,\n"
+"or an invalid instance identifier\n"
+"was passed to a DDEML function."
+msgstr ""
+
+#: ../src/msw/dde.cpp:1147
+msgid ""
+"an application initialized as APPCLASS_MONITOR has\n"
+"attempted to perform a DDE transaction,\n"
+"or an application initialized as APPCMD_CLIENTONLY has \n"
+"attempted to perform server transactions."
+msgstr ""
+
+#: ../src/msw/dde.cpp:1150
+msgid "a request for a synchronous execute transaction has timed out."
+msgstr ""
+
+#: ../src/msw/dde.cpp:1153
+msgid "a parameter failed to be validated by the DDEML."
+msgstr "DDEML neapstiprināja parametru."
+
+#: ../src/msw/dde.cpp:1156
+msgid "a DDEML application has created a prolonged race condition."
+msgstr ""
+
+#: ../src/msw/dde.cpp:1159
+msgid "a memory allocation failed."
+msgstr "atmiņas izdalīšanas kļūda."
+
+#: ../src/msw/dde.cpp:1162
+msgid "a client's attempt to establish a conversation has failed."
+msgstr ""
+
+#: ../src/msw/dde.cpp:1165
+msgid "a transaction failed."
+msgstr "transakcija neizdevās."
+
+#: ../src/msw/dde.cpp:1168
+msgid "a request for a synchronous poke transaction has timed out."
+msgstr ""
+
+#: ../src/msw/dde.cpp:1171
+msgid "an internal call to the PostMessage function has failed. "
+msgstr "iekšējais funkcijas PostMessage izsaukums neizdevās."
+
+#: ../src/msw/dde.cpp:1174
+msgid "reentrancy problem."
+msgstr ""
+
+#: ../src/msw/dde.cpp:1177
+msgid ""
+"a server-side transaction was attempted on a conversation\n"
+"that was terminated by the client, or the server\n"
+"terminated before completing a transaction."
+msgstr ""
+
+#: ../src/msw/dde.cpp:1180
+msgid "an internal error has occurred in the DDEML."
+msgstr "DDEML radās iekšēja kļuda."
+
+#: ../src/msw/dde.cpp:1183
+msgid "a request to end an advise transaction has timed out."
+msgstr ""
+
+#: ../src/msw/dde.cpp:1186
+msgid ""
+"an invalid transaction identifier was passed to a DDEML function.\n"
+"Once the application has returned from an XTYP_XACT_COMPLETE callback,\n"
+"the transaction identifier for that callback is no longer valid."
+msgstr ""
+
+#: ../src/msw/dde.cpp:1189
+#, c-format
+msgid "Unknown DDE error %08x"
+msgstr "Nezināma DDE kļūda %08x"
+
+#: ../src/msw/dialup.cpp:343
+msgid ""
+"Dial up functions are unavailable because the remote access service (RAS) is "
+"not installed on this machine. Please install it."
+msgstr ""
+"Iezvanpieejas funkcijas nav pieejamas, jo uz šī datora nav uzstādīts "
+"attālinātās pieejas serviss (RAS). Lūdzu, uzstādiet to."
+
+#: ../src/msw/dialup.cpp:402
+#, c-format
+msgid ""
+"The version of remote access service (RAS) installed on this machine is too "
+"old, please upgrade (the following required function is missing: %s)."
+msgstr ""
+"Uz šī datora uzstādītās attālinātās pieejas servisa (RAS) versija ir pārāk "
+"veca. Lūdzu, atsvaidziniet to (trūkst sekojoša nepieciešamā funkcija: %s)."
+
+#: ../src/msw/dialup.cpp:437
+msgid "Failed to retrieve text of RAS error message"
+msgstr "Neizdevās saņemt RAS ķļūdas paziņojuma tekstu."
+
+#: ../src/msw/dialup.cpp:440
+#, c-format
+msgid "unknown error (error code %08x)."
+msgstr "nezināma kļūda (kļūdas kods %08x)."
+
+#: ../src/msw/dialup.cpp:492
+#, c-format
+msgid "Cannot find active dialup connection: %s"
+msgstr "Aktīva iezvanpieeja nav atrodama: %s"
+
+#: ../src/msw/dialup.cpp:513
+msgid "Several active dialup connections found, choosing one randomly."
+msgstr "Atrastas vairākas aktīvas iezvanpieejas, tiek izvēlēja viena no tām."
+
+#: ../src/msw/dialup.cpp:598 ../src/msw/dialup.cpp:832
+#, c-format
+msgid "Failed to establish dialup connection: %s"
+msgstr "Neizdevās izveidot iezvanpieejas savienojumu: %s"
+
+#: ../src/msw/dialup.cpp:664
+#, c-format
+msgid "Failed to get ISP names: %s"
+msgstr "Neizdevās iegūt ISP nosaukumus: %s"
+
+#: ../src/msw/dialup.cpp:712
+msgid "Failed to connect: no ISP to dial."
+msgstr "Nav iespējams pieslēgties: nav ISP, kam zvanīt."
+
+#: ../src/msw/dialup.cpp:732
+msgid "Choose ISP to dial"
+msgstr "Izvēlieties ISP, kuram zvanīt"
+
+#: ../src/msw/dialup.cpp:733
+msgid "Please choose which ISP do you want to connect to"
+msgstr "Lūdzu izvēlieties ISP, kuram vēlaties pieslēgties"
+
+#: ../src/msw/dialup.cpp:766
+msgid "Failed to connect: missing username/password."
+msgstr "Nav iespējams pieslēgties: nav norādīts lietotāja vārds.parole."
+
+#: ../src/msw/dialup.cpp:796
+msgid "Cannot find the location of address book file"
+msgstr "Nav iespējams noteikt adrešu grāmatas faila atrašanās vietu"
+
+#: ../src/msw/dialup.cpp:827
+#, c-format
+msgid "Failed to initiate dialup connection: %s"
+msgstr "Neizdevās izveidot iezvanpieejas savienojumu: %s"
+
+#: ../src/msw/dialup.cpp:897
+msgid "Cannot hang up - no active dialup connection."
+msgstr "Nav iespējams nolikt klausuli - nav aktīva iezvanpieejas savienojuma"
+
+#: ../src/msw/dialup.cpp:907
+#, c-format
+msgid "Failed to terminate the dialup connection: %s"
+msgstr "Neizdevās pārtraukt iezvanpieejas savienojumu: %s"
+
+#: ../src/msw/dib.cpp:313
+#, c-format
+msgid "Failed to save the bitmap image to file \"%s\"."
+msgstr "Neizdevās saglabāt bitkartes attēlu failā \"%s\"."
+
+#: ../src/msw/dib.cpp:543
+#, c-format
+msgid "Failed to allocate %luKb of memory for bitmap data."
+msgstr "Neizdevās piešķirt %luKb atmiņas bitkartes datiem."
+
+#: ../src/msw/dir.cpp:241
+#, c-format
+msgid "Cannot enumerate files in directory '%s'"
+msgstr "Nav iespējams uzskaitīt failus mapē '%s'"
+
+#: ../src/msw/dirdlg.cpp:368
+#, fuzzy
+msgid "Couldn't obtain folder name"
+msgstr "Neizdevās izveidot hronometru"
+
+#: ../src/msw/dlmsw.cpp:163
+#, fuzzy, c-format
+msgid "(error %d: %s)"
+msgstr " (kļūda %ld: %s)"
+
+#: ../src/msw/dragimag.cpp:143 ../src/msw/dragimag.cpp:178
+#: ../src/msw/imaglist.cpp:309 ../src/msw/imaglist.cpp:331
+msgid "Couldn't add an image to the image list."
+msgstr "Neizdevās pievienot attēlu sarakstam."
+
+#: ../src/msw/enhmeta.cpp:94
+#, c-format
+msgid "Failed to load metafile from file \"%s\"."
+msgstr "Neizdevās ielādēt matafailu no faila \"%s\"."
+
+#: ../src/msw/fdrepdlg.cpp:412
+#, c-format
+msgid "Failed to create the standard find/replace dialog (error code %d)"
+msgstr "Neizdevās atvērt standarta Meklēt/aizvietot dialogu (kļūdas kods %d)"
+
+#: ../src/msw/filedlg.cpp:1241
+msgid "Access to the file system is not allowed from secure desktop."
+msgstr ""
+
+#: ../src/msw/filedlg.cpp:1242
+msgid "Security warning"
+msgstr ""
+
+#: ../src/msw/filedlg.cpp:1533
+#, c-format
+msgid "File dialog failed with error code %0lx."
+msgstr "Faila dialogs pārtrauca dabību ar kļūdu %0lx."
+
+#: ../src/msw/font.cpp:1120
+#, fuzzy, c-format
+msgid "Font file \"%s\" couldn't be loaded"
+msgstr "Failu nevar ielādēt."
+
+#: ../src/msw/fontdlg.cpp:220
+#, c-format
+msgid "Common dialog failed with error code %0lx."
+msgstr ""
+
+#: ../src/msw/fswatcher.cpp:67
+msgid "Ungraceful worker thread termination"
+msgstr ""
+
+#: ../src/msw/fswatcher.cpp:81
+msgid "Unable to create IOCP worker thread"
+msgstr ""
+
+#: ../src/msw/fswatcher.cpp:88
+msgid "Unable to start IOCP worker thread"
+msgstr ""
+
+#: ../src/msw/fswatcher.cpp:140
+msgid "Monitoring individual files for changes is not supported currently."
+msgstr "Sekošana izmaiņām atsevišķos failos pagaidām netiek uzturēta."
+
+#: ../src/msw/fswatcher.cpp:165
+#, c-format
+msgid "Unable to set up watch for '%s'"
+msgstr ""
+
+#: ../src/msw/fswatcher.cpp:466
+#, c-format
+msgid "Can't monitor non-existent directory \"%s\" for changes."
+msgstr "Nav iespējams sekot izmaiņām neesoša mapē \"%s\"."
+
+#: ../src/msw/glcanvas.cpp:577 ../src/unix/glx11.cpp:507
+msgid "OpenGL 3.0 or later is not supported by the OpenGL driver."
+msgstr ""
+
+#: ../src/msw/glcanvas.cpp:601 ../src/osx/glcanvas_osx.cpp:395
+#: ../src/unix/glegl.cpp:304 ../src/unix/glx11.cpp:553
+#, fuzzy
+msgid "Couldn't create OpenGL context"
+msgstr "Neizdevās izveidot hronometru"
+
+#: ../src/msw/glcanvas.cpp:1294
+msgid "Failed to initialize OpenGL"
+msgstr "Neizdevās inicializēt OpenGL"
+
+#: ../src/msw/graphicsd2d.cpp:607
+msgid "Could not register custom DirectWrite font loader."
+msgstr ""
+
+#: ../src/msw/helpchm.cpp:48
+msgid ""
+"MS HTML Help functions are unavailable because the MS HTML Help library is "
+"not installed on this machine. Please install it."
+msgstr ""
+"MS HTML Help funkcijas nav pieejamas, jo MS HTML Help bibliotēka nav "
+"uzstādīta uz šīs mašīnas . Lūdzu, uzstādiet to."
+
+#: ../src/msw/helpchm.cpp:55
+msgid "Failed to initialize MS HTML Help."
+msgstr "Neizdevās inicializēt MS HTML Help."
+
+#: ../src/msw/iniconf.cpp:458
+#, c-format
+msgid "Can't delete the INI file '%s'"
+msgstr "Nav iespējams izdzēst INI failu '%s'"
+
+#: ../src/msw/listctrl.cpp:995
+#, c-format
+msgid "Couldn't retrieve information about list control item %d."
+msgstr "Nav iespējams iegūt informāciju par saraksta vadīklas vienumu %d."
+
+#: ../src/msw/mdi.cpp:170 ../src/qt/mdi.cpp:253
+msgid "&Cascade"
+msgstr "&Kaskādēt"
+
+#: ../src/msw/mdi.cpp:171
+msgid "Tile &Horizontally"
+msgstr "Atspulgs pa &horizontāli"
+
+#: ../src/msw/mdi.cpp:172
+msgid "Tile &Vertically"
+msgstr "Atspulgs pa &vertikāli"
+
+#: ../src/msw/mdi.cpp:174
+msgid "&Arrange Icons"
+msgstr "S&akārtot Ikonas"
+
+#: ../src/msw/mdi.cpp:621
+msgid "Failed to create MDI parent frame."
+msgstr ""
+
+#: ../src/msw/mimetype.cpp:234
+#, c-format
+msgid "Failed to create registry entry for '%s' files."
+msgstr "Neizdevās izveidot reģistra ierakstu '%s' failiem."
+
+#: ../src/msw/ole/automtn.cpp:495
+#, c-format
+msgid "Failed to find CLSID of \"%s\""
+msgstr "Neizdevās atrast \"%s\" CLSID"
+
+#: ../src/msw/ole/automtn.cpp:512
+#, c-format
+msgid "Failed to create an instance of \"%s\""
+msgstr ""
+
+#: ../src/msw/ole/automtn.cpp:552
+#, c-format
+msgid "Cannot get an active instance of \"%s\""
+msgstr ""
+
+#: ../src/msw/ole/automtn.cpp:564
+#, c-format
+msgid "Failed to get OLE automation interface for \"%s\""
+msgstr "Neizdevās saņemt \"%s\" OLE automatizācijas saskarni"
+
+#: ../src/msw/ole/automtn.cpp:621
+msgid "Unknown name or named argument."
+msgstr ""
+
+#: ../src/msw/ole/automtn.cpp:625
+msgid "Incorrect number of arguments."
+msgstr "Nepareizs argumentu skaits."
+
+#: ../src/msw/ole/automtn.cpp:637
+msgid "Unknown exception"
+msgstr "Nezināma izņēmuma situācija"
+
+#: ../src/msw/ole/automtn.cpp:642
+msgid "Method or property not found."
+msgstr "Metode vai īpašība nav atrasta."
+
+#: ../src/msw/ole/automtn.cpp:646
+msgid "Overflow while coercing argument values."
+msgstr ""
+
+#: ../src/msw/ole/automtn.cpp:650
+msgid "Object implementation does not support named arguments."
+msgstr ""
+
+#: ../src/msw/ole/automtn.cpp:654
+msgid "The locale ID is unknown."
+msgstr "Lokāles ID nav zināms."
+
+#: ../src/msw/ole/automtn.cpp:658
+msgid "Missing a required parameter."
+msgstr "Iztrūkst nepieciešamais paramatrs."
+
+#: ../src/msw/ole/automtn.cpp:662
+#, c-format
+msgid "Argument %u not found."
+msgstr "Arguments %u nav atrasts."
+
+#: ../src/msw/ole/automtn.cpp:666
+#, c-format
+msgid "Type mismatch in argument %u."
+msgstr "Tipu neatbilstība argumentā %u."
+
+#: ../src/msw/ole/automtn.cpp:670
+msgid "The system cannot find the file specified."
+msgstr "Sistēma nespēja atrast norādīto failu."
+
+#: ../src/msw/ole/automtn.cpp:674
+msgid "Class not registered."
+msgstr "Klase nav reģistrēta."
+
+#: ../src/msw/ole/automtn.cpp:678
+#, c-format
+msgid "Unknown error %08x"
+msgstr "Nezināma kļūda %08x"
+
+#: ../src/msw/ole/automtn.cpp:682
+#, c-format
+msgid "OLE Automation error in %s: %s"
+msgstr "OLE automatizācijas kļūda %s: %s"
+
+#: ../src/msw/ole/dataobj.cpp:385
+#, c-format
+msgid "Couldn't register clipboard format '%s'."
+msgstr "Neizdevās reģistrēt starpliktuves formātu '%s'."
+
+#: ../src/msw/ole/dataobj.cpp:402
+#, c-format
+msgid "The clipboard format '%d' doesn't exist."
+msgstr "Starpliktuves formāts '%d' nepastāv."
+
+#: ../src/msw/progdlg.cpp:1025
+msgid "Skip"
+msgstr "Izlaist"
+
+#: ../src/msw/registry.cpp:141
+#, fuzzy, c-format
+msgid "unknown (%lu)"
+msgstr "nezināms"
+
+#: ../src/msw/registry.cpp:409
+#, c-format
+msgid "Can't get info about registry key '%s'"
+msgstr "Nav iespējams iegūt informāciju par reģistra atslēgu '%s'"
+
+#: ../src/msw/registry.cpp:445
+#, c-format
+msgid "Can't open registry key '%s'"
+msgstr "Nav iespējams atvērt reģistra atslēgu '%s'"
+
+#: ../src/msw/registry.cpp:478
+#, c-format
+msgid "Can't create registry key '%s'"
+msgstr "Nav iespējams izveidot reģistra atslēgu '%s'"
+
+#: ../src/msw/registry.cpp:497
+#, c-format
+msgid "Can't close registry key '%s'"
+msgstr "Nav iespējams aizvērt reģistra atslēgu '%s'"
+
+#: ../src/msw/registry.cpp:512
+#, c-format
+msgid "Registry value '%s' already exists."
+msgstr "Reģistra vērtība '%s' jau pastāv."
+
+#: ../src/msw/registry.cpp:520
+#, c-format
+msgid "Failed to rename registry value '%s' to '%s'."
+msgstr "Neizdevās pārdēvēt reģistra vērtību '%s' par '%s'."
+
+#: ../src/msw/registry.cpp:575
+#, c-format
+msgid "Can't copy values of unsupported type %d."
+msgstr "Nav iespējams nokopēt neatbalstīta tipa %d vērtības."
+
+#: ../src/msw/registry.cpp:586
+#, c-format
+msgid "Registry key '%s' does not exist, cannot rename it."
+msgstr "Reģistra atslēga '%s' nepastāv, nav iespējams pārdēvēt."
+
+#: ../src/msw/registry.cpp:617
+#, c-format
+msgid "Registry key '%s' already exists."
+msgstr "Reģistra atslēga '%s' jau pastāv."
+
+#: ../src/msw/registry.cpp:625
+#, c-format
+msgid "Failed to rename the registry key '%s' to '%s'."
+msgstr "Neizdevās pārdēvēt reģistra atslēgu '%s' par '%s'."
+
+#: ../src/msw/registry.cpp:670
+#, c-format
+msgid "Failed to copy the registry subkey '%s' to '%s'."
+msgstr "Neizdevās nokopēt reģistra apakšatslēgu '%s' uz '%s'."
+
+#: ../src/msw/registry.cpp:683
+#, c-format
+msgid "Failed to copy registry value '%s'"
+msgstr "Neizdevās nokopēt reģistra vertību '%s'"
+
+#: ../src/msw/registry.cpp:692
+#, c-format
+msgid "Failed to copy the contents of registry key '%s' to '%s'."
+msgstr "Nav iespējams nokopēt reģistra atslēgas '%s' saturu uz '%s'."
+
+#: ../src/msw/registry.cpp:718
+#, c-format
+msgid ""
+"Registry key '%s' is needed for normal system operation,\n"
+"deleting it will leave your system in unusable state:\n"
+"operation aborted."
+msgstr ""
+"Reģistra atslēga '%s' ir nepieciešama normālai sistēmas darbībai,\n"
+"tās dzēšana var novest sistēmu nelietojamā stāvoklī:\n"
+"darbība atcelta."
+
+#: ../src/msw/registry.cpp:754
+#, c-format
+msgid "Can't delete key '%s'"
+msgstr "Nav iespējams izdzēst atslēgu '%s'"
+
+#: ../src/msw/registry.cpp:782
+#, c-format
+msgid "Can't delete value '%s' from key '%s'"
+msgstr "Nav iespējams izdzēst vērtību '%s' no atslēgas '%s'"
+
+#: ../src/msw/registry.cpp:855 ../src/msw/registry.cpp:887
+#: ../src/msw/registry.cpp:929 ../src/msw/registry.cpp:1000
+#, c-format
+msgid "Can't read value of key '%s'"
+msgstr "Nav iespējams nolasīt atslēgas '%s' vērtību"
+
+#: ../src/msw/registry.cpp:873 ../src/msw/registry.cpp:915
+#: ../src/msw/registry.cpp:963 ../src/msw/registry.cpp:1106
+#, c-format
+msgid "Can't set value of '%s'"
+msgstr "Nav iespējams iestatīt '%s' vērtību"
+
+#: ../src/msw/registry.cpp:894 ../src/msw/registry.cpp:943
+#, c-format
+msgid "Registry value \"%s\" is not numeric (but of type %s)"
+msgstr ""
+
+#: ../src/msw/registry.cpp:979
+#, c-format
+msgid "Registry value \"%s\" is not binary (but of type %s)"
+msgstr ""
+
+#: ../src/msw/registry.cpp:1028
+#, c-format
+msgid "Registry value \"%s\" is not text (but of type %s)"
+msgstr ""
+
+#: ../src/msw/registry.cpp:1089
+#, c-format
+msgid "Can't read value of '%s'"
+msgstr " '%s' vērtība nav nolasāma"
+
+#: ../src/msw/registry.cpp:1157
+#, c-format
+msgid "Can't enumerate values of key '%s'"
+msgstr "Nav iespējams uzskaitīt atslēgas '%s' vērtības"
+
+#: ../src/msw/registry.cpp:1196
+#, c-format
+msgid "Can't enumerate subkeys of key '%s'"
+msgstr "Nav iespējams uzskaitīt atslēgas '%s' apakšatslēgas"
+
+#: ../src/msw/registry.cpp:1262
+#, c-format
+msgid ""
+"Exporting registry key: file \"%s\" already exists and won't be overwritten."
+msgstr ""
+"Reģistra atslēgas eksports: fails \"%s\" jau pastāv un netiks pārrakstīts."
+
+#: ../src/msw/registry.cpp:1411
+#, c-format
+msgid "Can't export value of unsupported type %d."
+msgstr "Nav iespējams eksportēt neatbalstīta tipa %d vērtību."
+
+#: ../src/msw/registry.cpp:1427
+#, c-format
+msgid "Ignoring value \"%s\" of the key \"%s\"."
+msgstr "Ignorēta vērtība \"%s\" atslēgai \"%s\"."
+
+#: ../src/msw/textctrl.cpp:596
+msgid ""
+"Impossible to create a rich edit control, using simple text control instead. "
+"Please reinstall riched32.dll"
+msgstr ""
+
+#: ../src/msw/thread.cpp:522 ../src/unix/threadpsx.cpp:850
+msgid "Cannot start thread: error writing TLS."
+msgstr "Nav iespējams palaist pavedienu: kļūda rakstot TLS."
+
+#: ../src/msw/thread.cpp:613
+msgid "Can't set thread priority"
+msgstr "Nav iespējams uzstādīt pavediena prioritāti"
+
+#: ../src/msw/thread.cpp:649
+msgid "Can't create thread"
+msgstr "Nav iespējams izveidot pavedienu"
+
+#: ../src/msw/thread.cpp:668
+msgid "Couldn't terminate thread"
+msgstr "Nav iespējams pārtraukt pavedienu"
+
+#: ../src/msw/thread.cpp:799
+msgid "Cannot wait for thread termination"
+msgstr "Nevar gaidīt uz pavediena apstāšanos"
+
+#: ../src/msw/thread.cpp:873
+#, fuzzy, c-format
+msgid "Cannot suspend thread %lx"
+msgstr "Nav iespējams apturēt pavedienu %x"
+
+#: ../src/msw/thread.cpp:903
+#, fuzzy, c-format
+msgid "Cannot resume thread %lx"
+msgstr "Nav iespējams atsākt pavedienu %x"
+
+#: ../src/msw/thread.cpp:932
+msgid "Couldn't get the current thread pointer"
+msgstr "Nevar iegūt pašreizējā pavediena rādītāju"
+
+#: ../src/msw/thread.cpp:1333
+msgid ""
+"Thread module initialization failed: impossible to allocate index in thread "
+"local storage"
+msgstr ""
+"Kļūda inicializējot pavediena moduli: nav iespējams piešķirt indeksu "
+"pavediena lokālajā glabātuvē"
+
+#: ../src/msw/thread.cpp:1345
+msgid ""
+"Thread module initialization failed: cannot store value in thread local "
+"storage"
+msgstr ""
+"Kļūda inicializējot pavediena moduli: nav iespējams saglabāt vērtību "
+"pavediena lokālajā glabātuvē"
+
+#: ../src/msw/timer.cpp:133
+msgid "Couldn't create a timer"
+msgstr "Neizdevās izveidot hronometru"
+
+#: ../src/msw/utils.cpp:372
+msgid "can't find user's HOME, using current directory."
+msgstr "lietotāja mājas mape nav atrodama, izmanto pašreizējo mapi."
+
+#: ../src/msw/utils.cpp:662
+#, c-format
+msgid "Failed to kill process %d"
+msgstr "Neizdevās pārtraukt procesu %d"
+
+#: ../src/msw/utils.cpp:986
+#, c-format
+msgid "Failed to load resource \"%s\"."
+msgstr "Neizdevās ielādēt resursu \"%s\"."
+
+#: ../src/msw/utils.cpp:993
+#, c-format
+msgid "Failed to lock resource \"%s\"."
+msgstr "Neizdevās aizslēgt resursu: \"%s\"."
+
+#. TRANSLATORS: MS Windows build number
+#: ../src/msw/utils.cpp:1209
+#, c-format
+msgid "build %lu"
+msgstr "versija %lu"
+
+#: ../src/msw/utils.cpp:1218
+msgid ", 64-bit edition"
+msgstr ", 64 bitu versija"
+
+#: ../src/msw/utilsexc.cpp:224
+msgid "Failed to create an anonymous pipe"
+msgstr "Neizdevās izveidot anonīmu programmkanālu"
+
+#: ../src/msw/utilsexc.cpp:697
+msgid "Failed to redirect the child process IO"
+msgstr ""
+
+#: ../src/msw/utilsexc.cpp:870
+#, c-format
+msgid "Execution of command '%s' failed"
+msgstr "Komandas '%s' izpilde neizdevās"
+
+#: ../src/msw/volume.cpp:337
+msgid "Failed to load mpr.dll."
+msgstr "Nevar ielādēt mpr.dll."
+
+#: ../src/msw/volume.cpp:506
+#, c-format
+msgid "Cannot read typename from '%s'!"
+msgstr "Nav iespējams nolasīt tipa nosaukumu no  '%s'!"
+
+#: ../src/msw/volume.cpp:615
+#, c-format
+msgid "Cannot load icon from '%s'."
+msgstr " Nav iespējams ielādēt ikonu no '%s'."
+
+#: ../src/msw/webview_edge.cpp:285
+msgid "This program was compiled without support for setting Edge proxy."
+msgstr ""
+
+#: ../src/msw/webview_ie.cpp:1010
+msgid "Failed to find web view emulation level in the registry"
+msgstr ""
+
+#: ../src/msw/webview_ie.cpp:1019
+msgid "Failed to set web view to modern emulation level"
+msgstr ""
+
+#: ../src/msw/webview_ie.cpp:1027
+msgid "Failed to reset web view to standard emulation level"
+msgstr ""
+
+#: ../src/msw/webview_ie.cpp:1049
+msgid "Can't run JavaScript script without a valid HTML document"
+msgstr ""
+
+#: ../src/msw/webview_ie.cpp:1056
+#, fuzzy
+msgid "Can't get the JavaScript object"
+msgstr "Nav iespējams uzstādīt pavediena prioritāti"
+
+#: ../src/msw/webview_ie.cpp:1070
+#, fuzzy
+msgid "failed to evaluate"
+msgstr "Neizdevās izpildīt '%s'\n"
+
+#: ../src/osx/cocoa/filedlg.mm:412
+#, fuzzy
+msgid "File type:"
+msgstr "Teletaips"
+
+#: ../src/osx/cocoa/menu.mm:242
+#, fuzzy
+msgctxt "macOS menu name"
+msgid "Window"
+msgstr "&Logs"
+
+#: ../src/osx/cocoa/menu.mm:259
+#, fuzzy
+msgctxt "macOS menu name"
+msgid "Help"
+msgstr "Palīdzība"
+
+#: ../src/osx/cocoa/menu.mm:298
+#, fuzzy
+msgctxt "macOS menu item"
+msgid "Minimize"
+msgstr "Mi&nimizēt"
+
+#: ../src/osx/cocoa/menu.mm:303
+#, fuzzy
+msgctxt "macOS menu item"
+msgid "Zoom"
+msgstr "Tuvināt"
+
+#: ../src/osx/cocoa/menu.mm:309
+msgctxt "macOS menu item"
+msgid "Bring All to Front"
+msgstr ""
+
+#: ../src/osx/core/sound.cpp:143
+#, fuzzy, c-format
+msgid "Failed to load sound from \"%s\" (error %d)."
+msgstr "Neizdevās ielādēt resursu \"%s\"."
+
+#: ../src/osx/fontutil.cpp:80
+#, fuzzy, c-format
+msgid "Font file \"%s\" doesn't exist."
+msgstr "Fails '%s' neeksistē."
+
+#: ../src/osx/fontutil.cpp:88
+#, c-format
+msgid ""
+"Font file \"%s\" cannot be used as it is not inside the font directory "
+"\"%s\"."
+msgstr ""
+
+#: ../src/osx/menu_osx.cpp:496
+#, c-format
+msgctxt "macOS menu item"
+msgid "About %s"
+msgstr "Par %s"
+
+#: ../src/osx/menu_osx.cpp:499
+#, fuzzy
+msgctxt "macOS menu item"
+msgid "About..."
+msgstr "P&ar..."
+
+#: ../src/osx/menu_osx.cpp:508
+msgctxt "macOS menu item"
+msgid "Preferences..."
+msgstr "Iestatījumi.."
+
+#: ../src/osx/menu_osx.cpp:512
+msgctxt "macOS menu item"
+msgid "Services"
+msgstr ""
+
+#: ../src/osx/menu_osx.cpp:519
+#, c-format
+msgctxt "macOS menu item"
+msgid "Hide %s"
+msgstr "Slēpt %s"
+
+#: ../src/osx/menu_osx.cpp:522
+#, fuzzy
+msgctxt "macOS menu item"
+msgid "Hide Application"
+msgstr "Programma"
+
+#: ../src/osx/menu_osx.cpp:526
+msgctxt "macOS menu item"
+msgid "Hide Others"
+msgstr "Slēpt citus"
+
+#: ../src/osx/menu_osx.cpp:528
+msgctxt "macOS menu item"
+msgid "Show All"
+msgstr "Rādīt visas"
+
+#: ../src/osx/menu_osx.cpp:534
+#, c-format
+msgctxt "macOS menu item"
+msgid "Quit %s"
+msgstr "Iziet no %s"
+
+#: ../src/osx/menu_osx.cpp:537
+#, fuzzy
+msgctxt "macOS menu item"
+msgid "Quit Application"
+msgstr "Programma"
+
+#: ../src/osx/webview_webkit.mm:444
+#, fuzzy
+msgid "Printing is not supported by the system web control"
+msgstr "Šī zlib versija neuztur gzip"
+
+#: ../src/osx/webview_webkit.mm:453
+#, fuzzy
+msgid "Print operation could not be initialized"
+msgstr "Nav iespējams inicializēt slejas aprakstu."
+
+#. TRANSLATORS: Label of font point size
+#: ../src/propgrid/advprops.cpp:605
+msgid "Point Size"
+msgstr "Izmērs punktos"
+
+#. TRANSLATORS: Label of font face name
+#: ../src/propgrid/advprops.cpp:615
+msgid "Face Name"
+msgstr "Fonta nosaukums"
+
+#. TRANSLATORS: Label of font style
+#: ../src/propgrid/advprops.cpp:623 ../src/richtext/richtextformatdlg.cpp:331
+msgid "Style"
+msgstr "Stils"
+
+#. TRANSLATORS: Label of font weight
+#: ../src/propgrid/advprops.cpp:628
+msgid "Weight"
+msgstr "Svars"
+
+#. TRANSLATORS: Label of underlined font
+#: ../src/propgrid/advprops.cpp:633 ../src/richtext/richtextfontpage.cpp:358
+msgid "Underlined"
+msgstr "Pasvītrots"
+
+#. TRANSLATORS: Label of font family
+#: ../src/propgrid/advprops.cpp:637
+msgid "Family"
+msgstr "Saime"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:801
+msgid "AppWorkspace"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:802
+#, fuzzy
+msgid "ActiveBorder"
+msgstr "Mala"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:803
+msgid "ActiveCaption"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:804
+msgid "ButtonFace"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:805
+msgid "ButtonHighlight"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:806
+msgid "ButtonShadow"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:807
+msgid "ButtonText"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:808
+msgid "CaptionText"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:809
+msgid "ControlDark"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:810
+msgid "ControlLight"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:812
+msgid "GrayText"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:813
+#, fuzzy
+msgid "Highlight"
+msgstr "viegls"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:814
+#, fuzzy
+msgid "HighlightText"
+msgstr "Izlīdzināt tekstu pa labi."
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:815
+#, fuzzy
+msgid "InactiveBorder"
+msgstr "Mala"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:816
+msgid "InactiveCaption"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:817
+msgid "InactiveCaptionText"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:818
+msgid "Menu"
+msgstr "Izvēlne"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:819
+msgid "Scrollbar"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:820
+msgid "Tooltip"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:821
+msgid "TooltipText"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:822
+#, fuzzy
+msgid "Window"
+msgstr "&Logs"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:823
+#, fuzzy
+msgid "WindowFrame"
+msgstr "&Logs"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:824
+#, fuzzy
+msgid "WindowText"
+msgstr "&Logs"
+
+#. TRANSLATORS: Custom colour choice entry
+#: ../src/propgrid/advprops.cpp:825 ../src/propgrid/advprops.cpp:1532
+#: ../src/propgrid/advprops.cpp:1576
+#, fuzzy
+msgid "Custom"
+msgstr "Pielāgots izmērs"
+
+#: ../src/propgrid/advprops.cpp:1558
+msgid "Black"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1559
+msgid "Maroon"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1560
+msgid "Navy"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1561
+msgid "Purple"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1562
+msgid "Teal"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1563
+msgid "Gray"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1564
+#, fuzzy
+msgid "Green"
+msgstr "Grieķu (MacGreek)"
+
+#: ../src/propgrid/advprops.cpp:1565
+msgid "Olive"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1566
+#, fuzzy
+msgid "Brown"
+msgstr "Pārlūkot"
+
+#: ../src/propgrid/advprops.cpp:1567
+msgid "Blue"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1568
+msgid "Fuchsia"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1569
+#, fuzzy
+msgid "Red"
+msgstr "Atkārtot"
+
+#: ../src/propgrid/advprops.cpp:1570
+msgid "Orange"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1571
+msgid "Silver"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1572
+msgid "Lime"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1573
+msgid "Aqua"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1574
+msgid "Yellow"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1575
+msgid "White"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1718
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Default"
+msgstr "noklusētais"
+
+#: ../src/propgrid/advprops.cpp:1719
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Arrow"
+msgstr "rītdiena"
+
+#: ../src/propgrid/advprops.cpp:1720
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Right Arrow"
+msgstr "Pa labi"
+
+#: ../src/propgrid/advprops.cpp:1721
+msgctxt "system cursor name"
+msgid "Blank"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1722
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Bullseye"
+msgstr "Aizzīmju stils"
+
+#: ../src/propgrid/advprops.cpp:1723
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Character"
+msgstr "Rakstzī&mju kods:"
+
+#: ../src/propgrid/advprops.cpp:1724
+msgctxt "system cursor name"
+msgid "Cross"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1725
+msgctxt "system cursor name"
+msgid "Hand"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1726
+msgctxt "system cursor name"
+msgid "I-Beam"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1727
+msgctxt "system cursor name"
+msgid "Left Button"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1728
+msgctxt "system cursor name"
+msgid "Magnifier"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1729
+msgctxt "system cursor name"
+msgid "Middle Button"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1730
+msgctxt "system cursor name"
+msgid "No Entry"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1731
+msgctxt "system cursor name"
+msgid "Paint Brush"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1732
+msgctxt "system cursor name"
+msgid "Pencil"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1733
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Point Left"
+msgstr "Izmērs punktos"
+
+#: ../src/propgrid/advprops.cpp:1734
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Point Right"
+msgstr "Izlīdzināt gar labo"
+
+#: ../src/propgrid/advprops.cpp:1735
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Question Arrow"
+msgstr "Jautājums"
+
+#: ../src/propgrid/advprops.cpp:1736
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Right Button"
+msgstr "Pa labi"
+
+#: ../src/propgrid/advprops.cpp:1737
+msgctxt "system cursor name"
+msgid "Sizing NE-SW"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1738
+msgctxt "system cursor name"
+msgid "Sizing N-S"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1739
+msgctxt "system cursor name"
+msgid "Sizing NW-SE"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1740
+msgctxt "system cursor name"
+msgid "Sizing W-E"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1741
+msgctxt "system cursor name"
+msgid "Sizing"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1742
+msgctxt "system cursor name"
+msgid "Spraycan"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1743
+msgctxt "system cursor name"
+msgid "Wait"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1744
+msgctxt "system cursor name"
+msgid "Watch"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1745
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Wait Arrow"
+msgstr "Pa labi"
+
+#: ../src/propgrid/advprops.cpp:2109
+msgid "Make a selection:"
+msgstr "Veidot izvēli:"
+
+#: ../src/propgrid/manager.cpp:394
+msgid "Property"
+msgstr "Īpašība"
+
+#: ../src/propgrid/manager.cpp:395
+msgid "Value"
+msgstr "Vērtība"
+
+#: ../src/propgrid/manager.cpp:1683
+msgid "Categorized Mode"
+msgstr "Šķirotais režīms"
+
+#: ../src/propgrid/manager.cpp:1709
+msgid "Alphabetic Mode"
+msgstr "Alfabētiskais režīms"
+
+#. TRANSLATORS: Name of Boolean false value
+#: ../src/propgrid/propgrid.cpp:230
+msgid "False"
+msgstr "Aplams"
+
+#. TRANSLATORS: Name of Boolean true value
+#: ../src/propgrid/propgrid.cpp:232
+msgid "True"
+msgstr "Patiess"
+
+#. TRANSLATORS: Text  displayed for unspecified value
+#: ../src/propgrid/propgrid.cpp:428
+msgid "Unspecified"
+msgstr "Nenorādīts"
+
+#. TRANSLATORS: Caption of message box displaying any property error
+#: ../src/propgrid/propgrid.cpp:3145 ../src/propgrid/propgrid.cpp:3282
+msgid "Property Error"
+msgstr "Īpašības kļūda "
+
+#: ../src/propgrid/propgrid.cpp:3259
+msgid "You have entered invalid value. Press ESC to cancel editing."
+msgstr ""
+"Jūs ievadījāt nederīgu vērtību. Nospiediet ESC, lai pārtauktu labošanu."
+
+#: ../src/propgrid/propgrid.cpp:6608
+#, c-format
+msgid "Error in resource: %s"
+msgstr "Kļūda resursā: %s"
+
+#: ../src/propgrid/propgridiface.cpp:377
+#, c-format
+msgid ""
+"Type operation \"%s\" failed: Property labeled \"%s\" is of type \"%s\", NOT "
+"\"%s\"."
+msgstr ""
+"Tipu operācijas \"%s\" kļūda: īpašības ar apzīmējumu \"%s\" tips ir \"%s\", "
+"NEVIS \"%s\"."
+
+#: ../src/propgrid/props.cpp:159
+#, c-format
+msgid "Unknown base %d. Base 10 will be used."
+msgstr ""
+
+#: ../src/propgrid/props.cpp:324
+#, c-format
+msgid "Value must be %s or higher."
+msgstr "Vērtībai jābūt vienādai ar %s vai lielākai."
+
+#: ../src/propgrid/props.cpp:329 ../src/propgrid/props.cpp:356
+#, c-format
+msgid "Value must be between %s and %s."
+msgstr "Leņķim jābūt starp %s un %s."
+
+#: ../src/propgrid/props.cpp:351
+#, c-format
+msgid "Value must be %s or less."
+msgstr "Vērtībai jābūt vienādai ar %s vai mazākai."
+
+#: ../src/propgrid/props.cpp:1058
+#, c-format
+msgid "Not %s"
+msgstr "Nav %s"
+
+#: ../src/propgrid/props.cpp:1770
+msgid "Choose a directory:"
+msgstr "Izvēlieties mapi:"
+
+#: ../src/propgrid/props.cpp:2055
+msgid "Choose a file"
+msgstr "Izvēlieties failu"
+
+#: ../src/qt/mdi.cpp:254
+msgid "&Tile"
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:147
+#: ../src/richtext/richtextformatdlg.cpp:376
+msgid "Background"
+msgstr "Fons"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:159
+msgid "Background &colour:"
+msgstr "&Fona krāsa:"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:161
+#: ../src/richtext/richtextbackgroundpage.cpp:163
+msgid "Enables a background colour."
+msgstr "Iespējo fona krāsu."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:167
+#: ../src/richtext/richtextbackgroundpage.cpp:169
+msgid "The background colour."
+msgstr "Fona krāsa."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:178
+msgid "Shadow"
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:193
+msgid "Use &shadow"
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:195
+#: ../src/richtext/richtextbackgroundpage.cpp:197
+#, fuzzy
+msgid "Enables a shadow."
+msgstr "Iespējo fona krāsu."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:211
+#, fuzzy
+msgid "&Horizontal offset:"
+msgstr "Vertikālā n&obīde"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:218
+#: ../src/richtext/richtextbackgroundpage.cpp:220
+#, fuzzy
+msgid "The horizontal offset."
+msgstr "Iespējot vertikālo nobīdi."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:224
+#: ../src/richtext/richtextbackgroundpage.cpp:227
+#: ../src/richtext/richtextbackgroundpage.cpp:228
+#: ../src/richtext/richtextbackgroundpage.cpp:247
+#: ../src/richtext/richtextbackgroundpage.cpp:250
+#: ../src/richtext/richtextbackgroundpage.cpp:251
+#: ../src/richtext/richtextbackgroundpage.cpp:287
+#: ../src/richtext/richtextbackgroundpage.cpp:290
+#: ../src/richtext/richtextbackgroundpage.cpp:291
+#: ../src/richtext/richtextbackgroundpage.cpp:314
+#: ../src/richtext/richtextbackgroundpage.cpp:317
+#: ../src/richtext/richtextbackgroundpage.cpp:318
+#: ../src/richtext/richtextborderspage.cpp:252
+#: ../src/richtext/richtextborderspage.cpp:255
+#: ../src/richtext/richtextborderspage.cpp:256
+#: ../src/richtext/richtextborderspage.cpp:286
+#: ../src/richtext/richtextborderspage.cpp:289
+#: ../src/richtext/richtextborderspage.cpp:290
+#: ../src/richtext/richtextborderspage.cpp:320
+#: ../src/richtext/richtextborderspage.cpp:323
+#: ../src/richtext/richtextborderspage.cpp:324
+#: ../src/richtext/richtextborderspage.cpp:354
+#: ../src/richtext/richtextborderspage.cpp:357
+#: ../src/richtext/richtextborderspage.cpp:358
+#: ../src/richtext/richtextborderspage.cpp:420
+#: ../src/richtext/richtextborderspage.cpp:423
+#: ../src/richtext/richtextborderspage.cpp:424
+#: ../src/richtext/richtextborderspage.cpp:454
+#: ../src/richtext/richtextborderspage.cpp:457
+#: ../src/richtext/richtextborderspage.cpp:458
+#: ../src/richtext/richtextborderspage.cpp:488
+#: ../src/richtext/richtextborderspage.cpp:491
+#: ../src/richtext/richtextborderspage.cpp:492
+#: ../src/richtext/richtextborderspage.cpp:522
+#: ../src/richtext/richtextborderspage.cpp:525
+#: ../src/richtext/richtextborderspage.cpp:526
+#: ../src/richtext/richtextborderspage.cpp:590
+#: ../src/richtext/richtextborderspage.cpp:593
+#: ../src/richtext/richtextborderspage.cpp:594
+#: ../src/richtext/richtextfontpage.cpp:177
+#: ../src/richtext/richtextmarginspage.cpp:199
+#: ../src/richtext/richtextmarginspage.cpp:201
+#: ../src/richtext/richtextmarginspage.cpp:202
+#: ../src/richtext/richtextmarginspage.cpp:224
+#: ../src/richtext/richtextmarginspage.cpp:226
+#: ../src/richtext/richtextmarginspage.cpp:227
+#: ../src/richtext/richtextmarginspage.cpp:247
+#: ../src/richtext/richtextmarginspage.cpp:249
+#: ../src/richtext/richtextmarginspage.cpp:250
+#: ../src/richtext/richtextmarginspage.cpp:272
+#: ../src/richtext/richtextmarginspage.cpp:274
+#: ../src/richtext/richtextmarginspage.cpp:275
+#: ../src/richtext/richtextmarginspage.cpp:313
+#: ../src/richtext/richtextmarginspage.cpp:315
+#: ../src/richtext/richtextmarginspage.cpp:316
+#: ../src/richtext/richtextmarginspage.cpp:338
+#: ../src/richtext/richtextmarginspage.cpp:340
+#: ../src/richtext/richtextmarginspage.cpp:341
+#: ../src/richtext/richtextmarginspage.cpp:361
+#: ../src/richtext/richtextmarginspage.cpp:363
+#: ../src/richtext/richtextmarginspage.cpp:364
+#: ../src/richtext/richtextmarginspage.cpp:386
+#: ../src/richtext/richtextmarginspage.cpp:388
+#: ../src/richtext/richtextmarginspage.cpp:389
+#: ../src/richtext/richtextsizepage.cpp:337
+#: ../src/richtext/richtextsizepage.cpp:340
+#: ../src/richtext/richtextsizepage.cpp:341
+#: ../src/richtext/richtextsizepage.cpp:371
+#: ../src/richtext/richtextsizepage.cpp:374
+#: ../src/richtext/richtextsizepage.cpp:375
+#: ../src/richtext/richtextsizepage.cpp:398
+#: ../src/richtext/richtextsizepage.cpp:401
+#: ../src/richtext/richtextsizepage.cpp:402
+#: ../src/richtext/richtextsizepage.cpp:425
+#: ../src/richtext/richtextsizepage.cpp:428
+#: ../src/richtext/richtextsizepage.cpp:429
+#: ../src/richtext/richtextsizepage.cpp:452
+#: ../src/richtext/richtextsizepage.cpp:455
+#: ../src/richtext/richtextsizepage.cpp:456
+#: ../src/richtext/richtextsizepage.cpp:479
+#: ../src/richtext/richtextsizepage.cpp:482
+#: ../src/richtext/richtextsizepage.cpp:483
+#: ../src/richtext/richtextsizepage.cpp:553
+#: ../src/richtext/richtextsizepage.cpp:556
+#: ../src/richtext/richtextsizepage.cpp:557
+#: ../src/richtext/richtextsizepage.cpp:588
+#: ../src/richtext/richtextsizepage.cpp:591
+#: ../src/richtext/richtextsizepage.cpp:592
+#: ../src/richtext/richtextsizepage.cpp:623
+#: ../src/richtext/richtextsizepage.cpp:626
+#: ../src/richtext/richtextsizepage.cpp:627
+#: ../src/richtext/richtextsizepage.cpp:658
+#: ../src/richtext/richtextsizepage.cpp:661
+#: ../src/richtext/richtextsizepage.cpp:662
+msgid "px"
+msgstr " px"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:225
+#: ../src/richtext/richtextbackgroundpage.cpp:248
+#: ../src/richtext/richtextbackgroundpage.cpp:288
+#: ../src/richtext/richtextbackgroundpage.cpp:315
+#: ../src/richtext/richtextborderspage.cpp:253
+#: ../src/richtext/richtextborderspage.cpp:287
+#: ../src/richtext/richtextborderspage.cpp:321
+#: ../src/richtext/richtextborderspage.cpp:355
+#: ../src/richtext/richtextborderspage.cpp:421
+#: ../src/richtext/richtextborderspage.cpp:455
+#: ../src/richtext/richtextborderspage.cpp:489
+#: ../src/richtext/richtextborderspage.cpp:523
+#: ../src/richtext/richtextborderspage.cpp:591
+#: ../src/richtext/richtextmarginspage.cpp:200
+#: ../src/richtext/richtextmarginspage.cpp:225
+#: ../src/richtext/richtextmarginspage.cpp:248
+#: ../src/richtext/richtextmarginspage.cpp:273
+#: ../src/richtext/richtextmarginspage.cpp:314
+#: ../src/richtext/richtextmarginspage.cpp:339
+#: ../src/richtext/richtextmarginspage.cpp:362
+#: ../src/richtext/richtextmarginspage.cpp:387
+#: ../src/richtext/richtextsizepage.cpp:338
+#: ../src/richtext/richtextsizepage.cpp:372
+#: ../src/richtext/richtextsizepage.cpp:399
+#: ../src/richtext/richtextsizepage.cpp:426
+#: ../src/richtext/richtextsizepage.cpp:453
+#: ../src/richtext/richtextsizepage.cpp:480
+#: ../src/richtext/richtextsizepage.cpp:554
+#: ../src/richtext/richtextsizepage.cpp:589
+#: ../src/richtext/richtextsizepage.cpp:624
+#: ../src/richtext/richtextsizepage.cpp:659
+msgid "cm"
+msgstr "cm"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:226
+#: ../src/richtext/richtextbackgroundpage.cpp:249
+#: ../src/richtext/richtextbackgroundpage.cpp:289
+#: ../src/richtext/richtextbackgroundpage.cpp:316
+#: ../src/richtext/richtextborderspage.cpp:254
+#: ../src/richtext/richtextborderspage.cpp:288
+#: ../src/richtext/richtextborderspage.cpp:322
+#: ../src/richtext/richtextborderspage.cpp:356
+#: ../src/richtext/richtextborderspage.cpp:422
+#: ../src/richtext/richtextborderspage.cpp:456
+#: ../src/richtext/richtextborderspage.cpp:490
+#: ../src/richtext/richtextborderspage.cpp:524
+#: ../src/richtext/richtextborderspage.cpp:592
+#: ../src/richtext/richtextfontpage.cpp:176
+#: ../src/richtext/richtextfontpage.cpp:179
+msgid "pt"
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:229
+#: ../src/richtext/richtextbackgroundpage.cpp:231
+#: ../src/richtext/richtextbackgroundpage.cpp:252
+#: ../src/richtext/richtextbackgroundpage.cpp:254
+#: ../src/richtext/richtextbackgroundpage.cpp:292
+#: ../src/richtext/richtextbackgroundpage.cpp:294
+#: ../src/richtext/richtextbackgroundpage.cpp:319
+#: ../src/richtext/richtextbackgroundpage.cpp:321
+#, fuzzy
+msgid "Units for this value."
+msgstr "Vienības kreisajai malai."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:234
+#, fuzzy
+msgid "&Vertical offset:"
+msgstr "Vertikālā n&obīde"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:241
+#: ../src/richtext/richtextbackgroundpage.cpp:243
+#, fuzzy
+msgid "The vertical offset."
+msgstr "Iespējot vertikālo nobīdi."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:257
+#, fuzzy
+msgid "Shadow c&olour:"
+msgstr "Izvēlieties krāsu"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:259
+#: ../src/richtext/richtextbackgroundpage.cpp:261
+#, fuzzy
+msgid "Enables the shadow colour."
+msgstr "Iespējo fona krāsu."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:265
+#: ../src/richtext/richtextbackgroundpage.cpp:267
+#, fuzzy
+msgid "The shadow colour."
+msgstr "Fonta krāsa."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:270
+msgid "Sh&adow spread:"
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:272
+#: ../src/richtext/richtextbackgroundpage.cpp:274
+#, fuzzy
+msgid "Enables the shadow spread."
+msgstr "Iespējot platuma vērtību"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:281
+#: ../src/richtext/richtextbackgroundpage.cpp:283
+msgid "The shadow spread."
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:297
+msgid "&Blur distance:"
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:299
+#: ../src/richtext/richtextbackgroundpage.cpp:301
+#, fuzzy
+msgid "Enables the blur distance."
+msgstr "Iespējot platuma vērtību"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:308
+#: ../src/richtext/richtextbackgroundpage.cpp:310
+msgid "The shadow blur distance."
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:324
+msgid "Opaci&ty:"
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:326
+#: ../src/richtext/richtextbackgroundpage.cpp:328
+#, fuzzy
+msgid "Enables the shadow opacity."
+msgstr "Iespējot platuma vērtību"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:335
+#: ../src/richtext/richtextbackgroundpage.cpp:337
+msgid "The shadow opacity."
+msgstr ""
+
+#. TRANSLATORS: Rich text page units (percentage)
+#: ../src/richtext/richtextbackgroundpage.cpp:340
+#: ../src/richtext/richtextsizepage.cpp:339
+#: ../src/richtext/richtextsizepage.cpp:373
+#: ../src/richtext/richtextsizepage.cpp:400
+#: ../src/richtext/richtextsizepage.cpp:427
+#: ../src/richtext/richtextsizepage.cpp:454
+#: ../src/richtext/richtextsizepage.cpp:481
+#: ../src/richtext/richtextsizepage.cpp:555
+#: ../src/richtext/richtextsizepage.cpp:590
+#: ../src/richtext/richtextsizepage.cpp:625
+#: ../src/richtext/richtextsizepage.cpp:660
+msgid "%"
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:229
+#: ../src/richtext/richtextborderspage.cpp:387
+msgid "Border"
+msgstr "Mala"
+
+#: ../src/richtext/richtextborderspage.cpp:242
+#: ../src/richtext/richtextborderspage.cpp:410
+#: ../src/richtext/richtextindentspage.cpp:194
+#: ../src/richtext/richtextliststylepage.cpp:384
+#: ../src/richtext/richtextmarginspage.cpp:185
+#: ../src/richtext/richtextmarginspage.cpp:299
+#: ../src/richtext/richtextsizepage.cpp:531
+#: ../src/richtext/richtextsizepage.cpp:538
+msgid "&Left:"
+msgstr "&Pa kreisi:"
+
+#: ../src/richtext/richtextborderspage.cpp:257
+#: ../src/richtext/richtextborderspage.cpp:259
+msgid "Units for the left border width."
+msgstr "Vienības kreisās apmales platumam."
+
+#: ../src/richtext/richtextborderspage.cpp:266
+#: ../src/richtext/richtextborderspage.cpp:268
+#: ../src/richtext/richtextborderspage.cpp:300
+#: ../src/richtext/richtextborderspage.cpp:302
+#: ../src/richtext/richtextborderspage.cpp:334
+#: ../src/richtext/richtextborderspage.cpp:336
+#: ../src/richtext/richtextborderspage.cpp:368
+#: ../src/richtext/richtextborderspage.cpp:370
+#: ../src/richtext/richtextborderspage.cpp:434
+#: ../src/richtext/richtextborderspage.cpp:436
+#: ../src/richtext/richtextborderspage.cpp:468
+#: ../src/richtext/richtextborderspage.cpp:470
+#: ../src/richtext/richtextborderspage.cpp:502
+#: ../src/richtext/richtextborderspage.cpp:504
+#: ../src/richtext/richtextborderspage.cpp:536
+#: ../src/richtext/richtextborderspage.cpp:538
+#, fuzzy
+msgid "The border line style."
+msgstr "Fonta stils."
+
+#: ../src/richtext/richtextborderspage.cpp:276
+#: ../src/richtext/richtextborderspage.cpp:444
+#: ../src/richtext/richtextindentspage.cpp:212
+#: ../src/richtext/richtextliststylepage.cpp:402
+#: ../src/richtext/richtextmarginspage.cpp:210
+#: ../src/richtext/richtextmarginspage.cpp:324
+#: ../src/richtext/richtextsizepage.cpp:601
+#: ../src/richtext/richtextsizepage.cpp:608
+msgid "&Right:"
+msgstr "&Pa labi:"
+
+#: ../src/richtext/richtextborderspage.cpp:291
+#: ../src/richtext/richtextborderspage.cpp:293
+msgid "Units for the right border width."
+msgstr "Vienības labās apmales platumam."
+
+#: ../src/richtext/richtextborderspage.cpp:310
+#: ../src/richtext/richtextborderspage.cpp:478
+#: ../src/richtext/richtextmarginspage.cpp:233
+#: ../src/richtext/richtextmarginspage.cpp:347
+#: ../src/richtext/richtextsizepage.cpp:566
+#: ../src/richtext/richtextsizepage.cpp:573
+msgid "&Top:"
+msgstr "&Augša:"
+
+#: ../src/richtext/richtextborderspage.cpp:325
+#: ../src/richtext/richtextborderspage.cpp:327
+msgid "Units for the top border width."
+msgstr "Vienības augšējās malas platumam."
+
+#: ../src/richtext/richtextborderspage.cpp:344
+#: ../src/richtext/richtextborderspage.cpp:512
+#: ../src/richtext/richtextmarginspage.cpp:258
+#: ../src/richtext/richtextmarginspage.cpp:372
+#: ../src/richtext/richtextsizepage.cpp:636
+#: ../src/richtext/richtextsizepage.cpp:643
+msgid "&Bottom:"
+msgstr "&Apakša:"
+
+#: ../src/richtext/richtextborderspage.cpp:359
+#: ../src/richtext/richtextborderspage.cpp:361
+msgid "Units for the bottom border width."
+msgstr "Vienības apakšējās malas platumam."
+
+#: ../src/richtext/richtextborderspage.cpp:380
+#: ../src/richtext/richtextborderspage.cpp:548
+msgid "&Synchronize values"
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:382
+#: ../src/richtext/richtextborderspage.cpp:384
+#: ../src/richtext/richtextborderspage.cpp:550
+#: ../src/richtext/richtextborderspage.cpp:552
+msgid "Check to edit all borders simultaneously."
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:397
+#: ../src/richtext/richtextborderspage.cpp:555
+msgid "Outline"
+msgstr "Aprises"
+
+#: ../src/richtext/richtextborderspage.cpp:425
+#: ../src/richtext/richtextborderspage.cpp:427
+msgid "Units for the left outline width."
+msgstr "Vienības kreisās malas aprišu platumam."
+
+#: ../src/richtext/richtextborderspage.cpp:459
+#: ../src/richtext/richtextborderspage.cpp:461
+msgid "Units for the right outline width."
+msgstr "Vienības labās malas aprisēm."
+
+#: ../src/richtext/richtextborderspage.cpp:493
+#: ../src/richtext/richtextborderspage.cpp:495
+msgid "Units for the top outline width."
+msgstr "Vienības augšējās aprises platumam."
+
+#: ../src/richtext/richtextborderspage.cpp:527
+#: ../src/richtext/richtextborderspage.cpp:529
+msgid "Units for the bottom outline width."
+msgstr "Vienības apakšējās aprises platumam."
+
+#: ../src/richtext/richtextborderspage.cpp:565
+#: ../src/richtext/richtextborderspage.cpp:600
+msgid "Corner"
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:574
+msgid "Corner &radius:"
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:576
+#: ../src/richtext/richtextborderspage.cpp:578
+msgid "An optional corner radius for adding rounded corners."
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:584
+#: ../src/richtext/richtextborderspage.cpp:586
+msgid "The value of the corner radius."
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:595
+#: ../src/richtext/richtextborderspage.cpp:597
+#, fuzzy
+msgid "Units for the corner radius."
+msgstr "Vienības augšējam papildinājumam."
+
+#: ../src/richtext/richtextborderspage.cpp:609
+#: ../src/richtext/richtextsizepage.cpp:247
+#: ../src/richtext/richtextsizepage.cpp:251
+msgid "None"
+msgstr "Nekas"
+
+#: ../src/richtext/richtextborderspage.cpp:610
+msgid "Solid"
+msgstr "Vienlaidus"
+
+#: ../src/richtext/richtextborderspage.cpp:611
+msgid "Dotted"
+msgstr "Punktēta"
+
+#: ../src/richtext/richtextborderspage.cpp:612
+msgid "Dashed"
+msgstr "Svītrots"
+
+#: ../src/richtext/richtextborderspage.cpp:613
+msgid "Double"
+msgstr "Divkāršs"
+
+#: ../src/richtext/richtextborderspage.cpp:614
+msgid "Groove"
+msgstr "Kaifīgie"
+
+#: ../src/richtext/richtextborderspage.cpp:615
+msgid "Ridge"
+msgstr "Kore"
+
+#: ../src/richtext/richtextborderspage.cpp:616
+msgid "Inset"
+msgstr "Iespiests"
+
+#: ../src/richtext/richtextborderspage.cpp:617
+msgid "Outset"
+msgstr "Izspiests"
+
+#: ../src/richtext/richtextbuffer.cpp:3518
+msgid "Change Style"
+msgstr "Mainīt stilu"
+
+#: ../src/richtext/richtextbuffer.cpp:3701
+msgid "Change Object Style"
+msgstr "Mainīt objekta stilu"
+
+#: ../src/richtext/richtextbuffer.cpp:3974
+#: ../src/richtext/richtextbuffer.cpp:8174
+msgid "Change Properties"
+msgstr "Mainīt īpašības"
+
+#: ../src/richtext/richtextbuffer.cpp:4346
+msgid "Change List Style"
+msgstr "Mainīt saraksta stilu"
+
+#: ../src/richtext/richtextbuffer.cpp:4519
+msgid "Renumber List"
+msgstr "Pārnumurēt sarakstu"
+
+#: ../src/richtext/richtextbuffer.cpp:7867
+#: ../src/richtext/richtextbuffer.cpp:7897
+#: ../src/richtext/richtextbuffer.cpp:7939
+#: ../src/richtext/richtextctrl.cpp:1279 ../src/richtext/richtextctrl.cpp:1473
+msgid "Insert Text"
+msgstr "Ievietot tekstu"
+
+#: ../src/richtext/richtextbuffer.cpp:8023
+#: ../src/richtext/richtextbuffer.cpp:8979
+msgid "Insert Image"
+msgstr "Ievietot attēlu"
+
+#: ../src/richtext/richtextbuffer.cpp:8070
+msgid "Insert Object"
+msgstr "Ievietot objektu"
+
+#: ../src/richtext/richtextbuffer.cpp:8112
+#, fuzzy
+msgid "Insert Field"
+msgstr "Ievietot tekstu"
+
+#: ../src/richtext/richtextbuffer.cpp:8410
+msgid "Too many EndStyle calls!"
+msgstr "Par daudz EndStyle izsaukumu!"
+
+#: ../src/richtext/richtextbuffer.cpp:8785
+msgid "files"
+msgstr "failus"
+
+#: ../src/richtext/richtextbuffer.cpp:9380
+msgid "standard/circle"
+msgstr "standarta/rinķis"
+
+#: ../src/richtext/richtextbuffer.cpp:9381
+msgid "standard/circle-outline"
+msgstr "standarta/riņķa aprises"
+
+#: ../src/richtext/richtextbuffer.cpp:9382
+msgid "standard/square"
+msgstr "standarta/kvadrāts"
+
+#: ../src/richtext/richtextbuffer.cpp:9383
+msgid "standard/diamond"
+msgstr "standarta/rombs"
+
+#: ../src/richtext/richtextbuffer.cpp:9384
+msgid "standard/triangle"
+msgstr "standarta/trīsstūris"
+
+#: ../src/richtext/richtextbuffer.cpp:9423
+msgid "Box Properties"
+msgstr "Rāmja īpašības"
+
+#: ../src/richtext/richtextbuffer.cpp:10006
+msgid "Multiple Cell Properties"
+msgstr "Vairāku šūnu īpašības"
+
+#: ../src/richtext/richtextbuffer.cpp:10008
+msgid "Cell Properties"
+msgstr "Tabulas šūnas parametri"
+
+#: ../src/richtext/richtextbuffer.cpp:11256
+msgid "Set Cell Style"
+msgstr "Iestatīt šūnas stilu"
+
+#: ../src/richtext/richtextbuffer.cpp:11330
+#, fuzzy
+msgid "Delete Row"
+msgstr "Dzēst"
+
+#: ../src/richtext/richtextbuffer.cpp:11380
+#, fuzzy
+msgid "Delete Column"
+msgstr "Dzēst iezīmēto"
+
+#: ../src/richtext/richtextbuffer.cpp:11431
+msgid "Add Row"
+msgstr ""
+
+#: ../src/richtext/richtextbuffer.cpp:11494
+msgid "Add Column"
+msgstr ""
+
+#: ../src/richtext/richtextbuffer.cpp:11537
+msgid "Table Properties"
+msgstr "Tabulas īpašības"
+
+#: ../src/richtext/richtextbuffer.cpp:12899
+msgid "Picture Properties"
+msgstr "Attēla īpašības"
+
+#: ../src/richtext/richtextbuffer.cpp:13169
+#: ../src/richtext/richtextbuffer.cpp:13279
+msgid "image"
+msgstr "attēls"
+
+#: ../src/richtext/richtextbulletspage.cpp:145
+#: ../src/richtext/richtextliststylepage.cpp:209
+msgid "&Bullet style:"
+msgstr "Aizzīmj&u stils:"
+
+#: ../src/richtext/richtextbulletspage.cpp:150
+#: ../src/richtext/richtextbulletspage.cpp:152
+#: ../src/richtext/richtextliststylepage.cpp:214
+#: ../src/richtext/richtextliststylepage.cpp:216
+msgid "The available bullet styles."
+msgstr "Pieejamie aizzīmju stili."
+
+#: ../src/richtext/richtextbulletspage.cpp:158
+#: ../src/richtext/richtextliststylepage.cpp:221
+msgid "Peri&od"
+msgstr "Peri&ods"
+
+#: ../src/richtext/richtextbulletspage.cpp:160
+#: ../src/richtext/richtextbulletspage.cpp:162
+#: ../src/richtext/richtextliststylepage.cpp:223
+#: ../src/richtext/richtextliststylepage.cpp:225
+msgid "Check to add a period after the bullet."
+msgstr "Atzīmējiet, lai aiz aizzīmes pievienotu punktu."
+
+#. TRANSLATORS: Bullet point in parentheses option
+#: ../src/richtext/richtextbulletspage.cpp:167
+#: ../src/richtext/richtextliststylepage.cpp:230
+msgid "(*)"
+msgstr "(*)"
+
+#: ../src/richtext/richtextbulletspage.cpp:169
+#: ../src/richtext/richtextbulletspage.cpp:171
+#: ../src/richtext/richtextliststylepage.cpp:232
+#: ../src/richtext/richtextliststylepage.cpp:234
+msgid "Check to enclose the bullet in parentheses."
+msgstr "Atzīmējiet, lai iekļautu aizzīmi iekavās."
+
+#. TRANSLATORS: Right parenthesis bullet point option
+#: ../src/richtext/richtextbulletspage.cpp:176
+#: ../src/richtext/richtextliststylepage.cpp:239
+msgid "*)"
+msgstr "*)"
+
+#: ../src/richtext/richtextbulletspage.cpp:178
+#: ../src/richtext/richtextbulletspage.cpp:180
+#: ../src/richtext/richtextliststylepage.cpp:241
+#: ../src/richtext/richtextliststylepage.cpp:243
+msgid "Check to add a right parenthesis."
+msgstr "Atzīmējiet, lai pievienotu labo iekavu."
+
+#: ../src/richtext/richtextbulletspage.cpp:185
+#: ../src/richtext/richtextliststylepage.cpp:248
+msgid "Bullet &Alignment:"
+msgstr "&Aizzīmējumu izlīdzināšana:"
+
+#: ../src/richtext/richtextbulletspage.cpp:190
+#: ../src/richtext/richtextliststylepage.cpp:253
+msgid "Centre"
+msgstr "Centrēt"
+
+#: ../src/richtext/richtextbulletspage.cpp:194
+#: ../src/richtext/richtextbulletspage.cpp:196
+#: ../src/richtext/richtextbulletspage.cpp:217
+#: ../src/richtext/richtextbulletspage.cpp:219
+#: ../src/richtext/richtextliststylepage.cpp:257
+#: ../src/richtext/richtextliststylepage.cpp:259
+#: ../src/richtext/richtextliststylepage.cpp:278
+#: ../src/richtext/richtextliststylepage.cpp:280
+msgid "The bullet character."
+msgstr "Aizzīmes rakstzīme."
+
+#: ../src/richtext/richtextbulletspage.cpp:212
+#: ../src/richtext/richtextliststylepage.cpp:271
+msgid "&Symbol:"
+msgstr "&Simbols:"
+
+#: ../src/richtext/richtextbulletspage.cpp:222
+#: ../src/richtext/richtextliststylepage.cpp:283
+msgid "Ch&oose..."
+msgstr "Iz&vēlieties..."
+
+#: ../src/richtext/richtextbulletspage.cpp:223
+#: ../src/richtext/richtextbulletspage.cpp:225
+#: ../src/richtext/richtextliststylepage.cpp:284
+#: ../src/richtext/richtextliststylepage.cpp:286
+msgid "Click to browse for a symbol."
+msgstr "Nospiediet, lai sameklētu vajadzīgo simbolu."
+
+#: ../src/richtext/richtextbulletspage.cpp:230
+#: ../src/richtext/richtextliststylepage.cpp:291
+msgid "Symbol &font:"
+msgstr "Simbola &fonts:"
+
+#: ../src/richtext/richtextbulletspage.cpp:235
+#: ../src/richtext/richtextbulletspage.cpp:237
+#: ../src/richtext/richtextliststylepage.cpp:297
+msgid "Available fonts."
+msgstr "Pieejamie fonti."
+
+#: ../src/richtext/richtextbulletspage.cpp:242
+#: ../src/richtext/richtextliststylepage.cpp:302
+msgid "S&tandard bullet name:"
+msgstr "S&tandarta aizzīmes nosaukums:"
+
+#: ../src/richtext/richtextbulletspage.cpp:247
+#: ../src/richtext/richtextbulletspage.cpp:249
+#: ../src/richtext/richtextliststylepage.cpp:307
+#: ../src/richtext/richtextliststylepage.cpp:309
+msgid "A standard bullet name."
+msgstr "Standarta aizzīmes nosaukums."
+
+#: ../src/richtext/richtextbulletspage.cpp:254
+msgid "&Number:"
+msgstr "&Skaitlis:"
+
+#: ../src/richtext/richtextbulletspage.cpp:258
+#: ../src/richtext/richtextbulletspage.cpp:260
+msgid "The list item number."
+msgstr "Saraksta locekļa numurs."
+
+#: ../src/richtext/richtextbulletspage.cpp:266
+#: ../src/richtext/richtextbulletspage.cpp:268
+#: ../src/richtext/richtextliststylepage.cpp:475
+#: ../src/richtext/richtextliststylepage.cpp:477
+msgid "Shows a preview of the bullet settings."
+msgstr "Rāda aizzīmju iestatījumu priekšskatījumu."
+
+#: ../src/richtext/richtextbulletspage.cpp:276
+#: ../src/richtext/richtextliststylepage.cpp:484
+msgid "(None)"
+msgstr "(Nekas)"
+
+#: ../src/richtext/richtextbulletspage.cpp:277
+#: ../src/richtext/richtextliststylepage.cpp:485
+msgid "Arabic"
+msgstr "Arābu"
+
+#: ../src/richtext/richtextbulletspage.cpp:278
+#: ../src/richtext/richtextliststylepage.cpp:486
+msgid "Upper case letters"
+msgstr "Lieli burti"
+
+#: ../src/richtext/richtextbulletspage.cpp:279
+#: ../src/richtext/richtextliststylepage.cpp:487
+msgid "Lower case letters"
+msgstr "Mazie burti"
+
+#: ../src/richtext/richtextbulletspage.cpp:280
+#: ../src/richtext/richtextliststylepage.cpp:488
+msgid "Upper case roman numerals"
+msgstr "Romiešu cipari ar lielajiem burtiem."
+
+#: ../src/richtext/richtextbulletspage.cpp:281
+#: ../src/richtext/richtextliststylepage.cpp:489
+msgid "Lower case roman numerals"
+msgstr "Romiešu cipari ar mazajiem burtiem"
+
+#: ../src/richtext/richtextbulletspage.cpp:282
+#: ../src/richtext/richtextliststylepage.cpp:490
+msgid "Numbered outline"
+msgstr "Numurētas aprises"
+
+#: ../src/richtext/richtextbulletspage.cpp:283
+#: ../src/richtext/richtextliststylepage.cpp:491
+msgid "Symbol"
+msgstr "Simbols"
+
+#: ../src/richtext/richtextbulletspage.cpp:284
+#: ../src/richtext/richtextliststylepage.cpp:492
+msgid "Bitmap"
+msgstr "Bitkarte"
+
+#: ../src/richtext/richtextbulletspage.cpp:285
+#: ../src/richtext/richtextliststylepage.cpp:493
+msgid "Standard"
+msgstr "Standarta"
+
+#: ../src/richtext/richtextbulletspage.cpp:287
+#: ../src/richtext/richtextliststylepage.cpp:495
+msgid "*"
+msgstr "*"
+
+#: ../src/richtext/richtextbulletspage.cpp:288
+#: ../src/richtext/richtextliststylepage.cpp:496
+msgid "-"
+msgstr "-"
+
+#: ../src/richtext/richtextbulletspage.cpp:289
+#: ../src/richtext/richtextliststylepage.cpp:497
+msgid ">"
+msgstr ">"
+
+#: ../src/richtext/richtextbulletspage.cpp:290
+#: ../src/richtext/richtextliststylepage.cpp:498
+msgid "+"
+msgstr "+"
+
+#: ../src/richtext/richtextbulletspage.cpp:291
+#: ../src/richtext/richtextliststylepage.cpp:499
+msgid "~"
+msgstr "~"
+
+#: ../src/richtext/richtextctrl.cpp:859
+msgid "Drag"
+msgstr "Vilkt"
+
+#: ../src/richtext/richtextctrl.cpp:1338 ../src/richtext/richtextctrl.cpp:1559
+msgid "Delete Text"
+msgstr "Dzēst tekstu"
+
+#: ../src/richtext/richtextctrl.cpp:1537
+#, fuzzy
+msgid "Remove Bullet"
+msgstr "Aizvākt"
+
+#: ../src/richtext/richtextctrl.cpp:3070
+msgid "The text couldn't be saved."
+msgstr "Tekstu nav iespējams saglabāt."
+
+#: ../src/richtext/richtextctrl.cpp:3644
+msgid "Replace"
+msgstr "Aizvietot"
+
+#: ../src/richtext/richtextfontpage.cpp:146
+#: ../src/richtext/richtextsymboldlg.cpp:384
+msgid "&Font:"
+msgstr "&Fonts:"
+
+#: ../src/richtext/richtextfontpage.cpp:150
+#: ../src/richtext/richtextfontpage.cpp:152
+msgid "Type a font name."
+msgstr "Ierakstiet fonta nosaukumu."
+
+#: ../src/richtext/richtextfontpage.cpp:158
+msgid "&Size:"
+msgstr "&Izmērs:"
+
+#: ../src/richtext/richtextfontpage.cpp:165
+#: ../src/richtext/richtextfontpage.cpp:167
+msgid "Type a size in points."
+msgstr "Ierakstiet izmēru punktos."
+
+#: ../src/richtext/richtextfontpage.cpp:180
+#: ../src/richtext/richtextfontpage.cpp:182
+#, fuzzy
+msgid "The font size units, points or pixels."
+msgstr "Fonta izmērs punktos"
+
+#: ../src/richtext/richtextfontpage.cpp:189
+#: ../src/richtext/richtextfontpage.cpp:191
+msgid "Lists the available fonts."
+msgstr "Parāda pieejamo fontu sarakstu."
+
+#: ../src/richtext/richtextfontpage.cpp:196
+#: ../src/richtext/richtextfontpage.cpp:198
+msgid "Lists font sizes in points."
+msgstr "Parāda fontu izmērus punktos."
+
+#: ../src/richtext/richtextfontpage.cpp:207
+msgid "Font st&yle:"
+msgstr "Fonta st&ils:"
+
+#: ../src/richtext/richtextfontpage.cpp:212
+#: ../src/richtext/richtextfontpage.cpp:214
+msgid "Select regular or italic style."
+msgstr "Izvēlieties parasto vai kursīva stilu."
+
+#: ../src/richtext/richtextfontpage.cpp:220
+msgid "Font &weight:"
+msgstr "Fonta &svars:"
+
+#: ../src/richtext/richtextfontpage.cpp:225
+#: ../src/richtext/richtextfontpage.cpp:227
+msgid "Select regular or bold."
+msgstr "Izvēlieties parasto vai trekno."
+
+#: ../src/richtext/richtextfontpage.cpp:233
+msgid "&Underlining:"
+msgstr "Pasvītroj&ums:"
+
+#: ../src/richtext/richtextfontpage.cpp:238
+#: ../src/richtext/richtextfontpage.cpp:240
+msgid "Select underlining or no underlining."
+msgstr "Izvēlieties pasvītroto vai nepasvītroto."
+
+#: ../src/richtext/richtextfontpage.cpp:248
+msgid "&Colour:"
+msgstr "&Krāsa:"
+
+#: ../src/richtext/richtextfontpage.cpp:253
+#: ../src/richtext/richtextfontpage.cpp:255
+msgid "Click to change the text colour."
+msgstr "Nospiediet, lai mainītu teksta krāsu."
+
+#: ../src/richtext/richtextfontpage.cpp:261
+msgid "&Bg colour:"
+msgstr "&Fona krāsa: "
+
+#: ../src/richtext/richtextfontpage.cpp:266
+#: ../src/richtext/richtextfontpage.cpp:268
+msgid "Click to change the text background colour."
+msgstr "Nospiediet, lai manītu teksta fona krāsu."
+
+#: ../src/richtext/richtextfontpage.cpp:276
+#: ../src/richtext/richtextfontpage.cpp:278
+msgid "Check to show a line through the text."
+msgstr "Atzīmējiet, lai rādītu pārsvītrotu tekstu."
+
+#: ../src/richtext/richtextfontpage.cpp:281
+msgid "Ca&pitals"
+msgstr "Lieli burti"
+
+#: ../src/richtext/richtextfontpage.cpp:283
+#: ../src/richtext/richtextfontpage.cpp:285
+msgid "Check to show the text in capitals."
+msgstr "Atzīmējiet, lai rādītu kapitalizētu tekstu"
+
+#: ../src/richtext/richtextfontpage.cpp:288
+#, fuzzy
+msgid "Small C&apitals"
+msgstr "Lieli burti"
+
+#: ../src/richtext/richtextfontpage.cpp:290
+#: ../src/richtext/richtextfontpage.cpp:292
+#, fuzzy
+msgid "Check to show the text in small capitals."
+msgstr "Atzīmējiet, lai rādītu kapitalizētu tekstu"
+
+#: ../src/richtext/richtextfontpage.cpp:295
+msgid "Supe&rscript"
+msgstr "Augš&raksts"
+
+#: ../src/richtext/richtextfontpage.cpp:297
+#: ../src/richtext/richtextfontpage.cpp:299
+msgid "Check to show the text in superscript."
+msgstr "Atzīmējiet, lai rādītu tekstu augšrakstā."
+
+#: ../src/richtext/richtextfontpage.cpp:302
+msgid "Subscrip&t"
+msgstr "Apakšraks&ts"
+
+#: ../src/richtext/richtextfontpage.cpp:304
+#: ../src/richtext/richtextfontpage.cpp:306
+msgid "Check to show the text in subscript."
+msgstr "Atzīmējiet, lai rādītu tekstu apakšrakstā."
+
+#: ../src/richtext/richtextfontpage.cpp:312
+msgid "Rig&ht-to-left"
+msgstr ""
+
+#: ../src/richtext/richtextfontpage.cpp:314
+#: ../src/richtext/richtextfontpage.cpp:316
+#, fuzzy
+msgid "Check to indicate right-to-left text layout."
+msgstr "Nospiediet, lai mainītu teksta krāsu."
+
+#: ../src/richtext/richtextfontpage.cpp:319
+msgid "Suppress hyphe&nation"
+msgstr ""
+
+#: ../src/richtext/richtextfontpage.cpp:321
+#: ../src/richtext/richtextfontpage.cpp:323
+msgid "Check to suppress hyphenation."
+msgstr ""
+
+#: ../src/richtext/richtextfontpage.cpp:329
+#: ../src/richtext/richtextfontpage.cpp:331
+msgid "Shows a preview of the font settings."
+msgstr "Rāda fonta iestatījumu priekšskatījumu."
+
+#: ../src/richtext/richtextfontpage.cpp:348
+#: ../src/richtext/richtextfontpage.cpp:352
+#: ../src/richtext/richtextfontpage.cpp:356
+#: ../src/richtext/richtextformatdlg.cpp:873
+#: ../src/richtext/richtextindentspage.cpp:273
+#: ../src/richtext/richtextindentspage.cpp:285
+#: ../src/richtext/richtextindentspage.cpp:286
+#: ../src/richtext/richtextindentspage.cpp:310
+#: ../src/richtext/richtextindentspage.cpp:325
+#: ../src/richtext/richtextliststylepage.cpp:451
+#: ../src/richtext/richtextliststylepage.cpp:463
+#: ../src/richtext/richtextliststylepage.cpp:464
+msgid "(none)"
+msgstr "(nekas)"
+
+#: ../src/richtext/richtextfontpage.cpp:349
+#: ../src/richtext/richtextfontpage.cpp:353
+msgid "Regular"
+msgstr "Regulārs"
+
+#: ../src/richtext/richtextfontpage.cpp:357
+msgid "Not underlined"
+msgstr "Nav pasvītrots"
+
+#: ../src/richtext/richtextformatdlg.cpp:341
+msgid "Indents && Spacing"
+msgstr "Atkāpes un atstarpes"
+
+#: ../src/richtext/richtextformatdlg.cpp:346
+msgid "Tabs"
+msgstr "Tabuācijas"
+
+#: ../src/richtext/richtextformatdlg.cpp:351
+msgid "Bullets"
+msgstr "Aizzīmes"
+
+#: ../src/richtext/richtextformatdlg.cpp:356
+msgid "List Style"
+msgstr "Saraksta stils"
+
+#: ../src/richtext/richtextformatdlg.cpp:366
+#: ../src/richtext/richtextmarginspage.cpp:170
+msgid "Margins"
+msgstr "Apmales"
+
+#: ../src/richtext/richtextformatdlg.cpp:371
+msgid "Borders"
+msgstr "Malas"
+
+#: ../src/richtext/richtextformatdlg.cpp:765
+msgid "Colour"
+msgstr "Krāsa"
+
+#: ../src/richtext/richtextindentspage.cpp:127
+#: ../src/richtext/richtextliststylepage.cpp:322
+msgid "&Alignment"
+msgstr "&Novietojums"
+
+#: ../src/richtext/richtextindentspage.cpp:138
+#: ../src/richtext/richtextliststylepage.cpp:331
+msgid "&Left"
+msgstr "&Kreisajā pusē"
+
+#: ../src/richtext/richtextindentspage.cpp:140
+#: ../src/richtext/richtextindentspage.cpp:142
+#: ../src/richtext/richtextliststylepage.cpp:333
+#: ../src/richtext/richtextliststylepage.cpp:335
+msgid "Left-align text."
+msgstr "Izlīdzināt pa kreisi."
+
+#: ../src/richtext/richtextindentspage.cpp:145
+#: ../src/richtext/richtextliststylepage.cpp:338
+msgid "&Right"
+msgstr "&Labajā pusē"
+
+#: ../src/richtext/richtextindentspage.cpp:147
+#: ../src/richtext/richtextindentspage.cpp:149
+#: ../src/richtext/richtextliststylepage.cpp:340
+#: ../src/richtext/richtextliststylepage.cpp:342
+msgid "Right-align text."
+msgstr "Izlīdzināt tekstu pa labi."
+
+#: ../src/richtext/richtextindentspage.cpp:152
+#: ../src/richtext/richtextliststylepage.cpp:345
+msgid "&Justified"
+msgstr "&Izlīdzināts"
+
+#: ../src/richtext/richtextindentspage.cpp:154
+#: ../src/richtext/richtextindentspage.cpp:156
+#: ../src/richtext/richtextliststylepage.cpp:347
+#: ../src/richtext/richtextliststylepage.cpp:349
+msgid "Justify text left and right."
+msgstr "Izlidzināt tekstu pa kreisi un pa labi."
+
+#: ../src/richtext/richtextindentspage.cpp:159
+#: ../src/richtext/richtextliststylepage.cpp:352
+msgid "Cen&tred"
+msgstr "Cen&trēts"
+
+#: ../src/richtext/richtextindentspage.cpp:161
+#: ../src/richtext/richtextindentspage.cpp:163
+#: ../src/richtext/richtextliststylepage.cpp:354
+#: ../src/richtext/richtextliststylepage.cpp:356
+msgid "Centre text."
+msgstr "Centrēt tekstu."
+
+#: ../src/richtext/richtextindentspage.cpp:166
+#: ../src/richtext/richtextliststylepage.cpp:359
+msgid "&Indeterminate"
+msgstr "&Nenoteikts"
+
+#: ../src/richtext/richtextindentspage.cpp:168
+#: ../src/richtext/richtextindentspage.cpp:170
+#: ../src/richtext/richtextliststylepage.cpp:361
+#: ../src/richtext/richtextliststylepage.cpp:363
+msgid "Use the current alignment setting."
+msgstr "Izmantot pašreizējo izlīdzināšanas iestatījumu."
+
+#: ../src/richtext/richtextindentspage.cpp:183
+#: ../src/richtext/richtextliststylepage.cpp:375
+msgid "&Indentation (tenths of a mm)"
+msgstr "Atkāpe (mm desm&itdaļās)"
+
+#: ../src/richtext/richtextindentspage.cpp:198
+#: ../src/richtext/richtextindentspage.cpp:200
+#: ../src/richtext/richtextliststylepage.cpp:388
+#: ../src/richtext/richtextliststylepage.cpp:390
+msgid "The left indent."
+msgstr "Atkāpe no kreisās malas."
+
+#: ../src/richtext/richtextindentspage.cpp:203
+#: ../src/richtext/richtextliststylepage.cpp:393
+msgid "Left (&first line):"
+msgstr "Kreisā (&pirmā rinda):"
+
+#: ../src/richtext/richtextindentspage.cpp:207
+#: ../src/richtext/richtextindentspage.cpp:209
+#: ../src/richtext/richtextliststylepage.cpp:397
+#: ../src/richtext/richtextliststylepage.cpp:399
+msgid "The first line indent."
+msgstr "Pirmā rinda ar atkāpi."
+
+#: ../src/richtext/richtextindentspage.cpp:216
+#: ../src/richtext/richtextindentspage.cpp:218
+#: ../src/richtext/richtextliststylepage.cpp:406
+#: ../src/richtext/richtextliststylepage.cpp:408
+msgid "The right indent."
+msgstr "Atkāpe no labās malas."
+
+#: ../src/richtext/richtextindentspage.cpp:221
+msgid "&Outline level:"
+msgstr "&Aprišu līmenis:"
+
+#: ../src/richtext/richtextindentspage.cpp:226
+#: ../src/richtext/richtextindentspage.cpp:228
+msgid "The outline level."
+msgstr "Aprises līmenis."
+
+#: ../src/richtext/richtextindentspage.cpp:241
+#: ../src/richtext/richtextliststylepage.cpp:420
+msgid "&Spacing (tenths of a mm)"
+msgstr "At&starpe (mm desmitdaļās)"
+
+#: ../src/richtext/richtextindentspage.cpp:252
+msgid "&Before a paragraph:"
+msgstr "Pi&rms rindkopas:"
+
+#: ../src/richtext/richtextindentspage.cpp:256
+#: ../src/richtext/richtextindentspage.cpp:258
+#: ../src/richtext/richtextliststylepage.cpp:433
+#: ../src/richtext/richtextliststylepage.cpp:435
+msgid "The spacing before the paragraph."
+msgstr "Atstarpe pirms rindkopas."
+
+#: ../src/richtext/richtextindentspage.cpp:261
+msgid "&After a paragraph:"
+msgstr "Aiz rindkopas:"
+
+#: ../src/richtext/richtextindentspage.cpp:266
+#: ../src/richtext/richtextliststylepage.cpp:442
+#: ../src/richtext/richtextliststylepage.cpp:444
+msgid "The spacing after the paragraph."
+msgstr "Atstarpe aiz rindkopas."
+
+#: ../src/richtext/richtextindentspage.cpp:269
+msgid "L&ine spacing:"
+msgstr "Rindu atstarpe:"
+
+#: ../src/richtext/richtextindentspage.cpp:274
+#: ../src/richtext/richtextliststylepage.cpp:452
+msgid "Single"
+msgstr "Viena"
+
+#: ../src/richtext/richtextindentspage.cpp:275
+#: ../src/richtext/richtextliststylepage.cpp:453
+msgid "1.1"
+msgstr "1.1"
+
+#: ../src/richtext/richtextindentspage.cpp:276
+#: ../src/richtext/richtextliststylepage.cpp:454
+msgid "1.2"
+msgstr "1.2"
+
+#: ../src/richtext/richtextindentspage.cpp:277
+#: ../src/richtext/richtextliststylepage.cpp:455
+msgid "1.3"
+msgstr "1.3"
+
+#: ../src/richtext/richtextindentspage.cpp:278
+#: ../src/richtext/richtextliststylepage.cpp:456
+msgid "1.4"
+msgstr "1.4"
+
+#: ../src/richtext/richtextindentspage.cpp:279
+#: ../src/richtext/richtextliststylepage.cpp:457
+msgid "1.5"
+msgstr "1.5"
+
+#: ../src/richtext/richtextindentspage.cpp:280
+#: ../src/richtext/richtextliststylepage.cpp:458
+msgid "1.6"
+msgstr "1.6"
+
+#: ../src/richtext/richtextindentspage.cpp:281
+#: ../src/richtext/richtextliststylepage.cpp:459
+msgid "1.7"
+msgstr "1.7"
+
+#: ../src/richtext/richtextindentspage.cpp:282
+#: ../src/richtext/richtextliststylepage.cpp:460
+msgid "1.8"
+msgstr "1.8"
+
+#: ../src/richtext/richtextindentspage.cpp:283
+#: ../src/richtext/richtextliststylepage.cpp:461
+msgid "1.9"
+msgstr "1.9"
+
+#: ../src/richtext/richtextindentspage.cpp:284
+#: ../src/richtext/richtextliststylepage.cpp:462
+msgid "2"
+msgstr "2"
+
+#: ../src/richtext/richtextindentspage.cpp:287
+#: ../src/richtext/richtextindentspage.cpp:289
+#: ../src/richtext/richtextliststylepage.cpp:465
+#: ../src/richtext/richtextliststylepage.cpp:467
+msgid "The line spacing."
+msgstr "Rindu atstarpe."
+
+#: ../src/richtext/richtextindentspage.cpp:292
+msgid "&Page Break"
+msgstr "La&pas atdalītājs"
+
+#: ../src/richtext/richtextindentspage.cpp:294
+#: ../src/richtext/richtextindentspage.cpp:296
+msgid "Inserts a page break before the paragraph."
+msgstr "Ievietot lapas pārtraukumu pirms rindkopas."
+
+#: ../src/richtext/richtextindentspage.cpp:302
+#: ../src/richtext/richtextindentspage.cpp:304
+msgid "Shows a preview of the paragraph settings."
+msgstr "Rāda rindkopas iestatījumu priekšskatījumu."
+
+#: ../src/richtext/richtextliststylepage.cpp:182
+msgid "&List level:"
+msgstr "Saraksta &līmenis:"
+
+#: ../src/richtext/richtextliststylepage.cpp:186
+#: ../src/richtext/richtextliststylepage.cpp:188
+msgid "Selects the list level to edit."
+msgstr "Izvēlas labojamo saraksta līmeni."
+
+#: ../src/richtext/richtextliststylepage.cpp:193
+msgid "&Font for Level..."
+msgstr "Līmeņa &fonts..."
+
+#: ../src/richtext/richtextliststylepage.cpp:194
+#: ../src/richtext/richtextliststylepage.cpp:196
+msgid "Click to choose the font for this level."
+msgstr "Nospiediet, lai izvēlētos fontu šim līmenim."
+
+#: ../src/richtext/richtextliststylepage.cpp:312
+msgid "Bullet style"
+msgstr "Aizzīmju stils"
+
+#: ../src/richtext/richtextliststylepage.cpp:429
+msgid "Before a paragraph:"
+msgstr "Pirms rindkopas:"
+
+#: ../src/richtext/richtextliststylepage.cpp:438
+msgid "After a paragraph:"
+msgstr "Aiz rindkopas:"
+
+#: ../src/richtext/richtextliststylepage.cpp:447
+msgid "Line spacing:"
+msgstr "Rindu atstarpe:"
+
+#: ../src/richtext/richtextliststylepage.cpp:470
+msgid "Spacing"
+msgstr "Atstarpes"
+
+#: ../src/richtext/richtextmarginspage.cpp:193
+#: ../src/richtext/richtextmarginspage.cpp:195
+msgid "The left margin size."
+msgstr "Kreisās malas lielums."
+
+#: ../src/richtext/richtextmarginspage.cpp:203
+#: ../src/richtext/richtextmarginspage.cpp:205
+msgid "Units for the left margin."
+msgstr "Vienības kreisajai malai."
+
+#: ../src/richtext/richtextmarginspage.cpp:218
+#: ../src/richtext/richtextmarginspage.cpp:220
+msgid "The right margin size."
+msgstr "Labās malas lielums."
+
+#: ../src/richtext/richtextmarginspage.cpp:228
+#: ../src/richtext/richtextmarginspage.cpp:230
+msgid "Units for the right margin."
+msgstr "Vienības kreisajai malai."
+
+#: ../src/richtext/richtextmarginspage.cpp:241
+#: ../src/richtext/richtextmarginspage.cpp:243
+msgid "The top margin size."
+msgstr "Augšējās malas lielums."
+
+#: ../src/richtext/richtextmarginspage.cpp:251
+#: ../src/richtext/richtextmarginspage.cpp:253
+msgid "Units for the top margin."
+msgstr "Vienības augšējai malai."
+
+#: ../src/richtext/richtextmarginspage.cpp:266
+#: ../src/richtext/richtextmarginspage.cpp:268
+msgid "The bottom margin size."
+msgstr "Apakšējās malas izmērs."
+
+#: ../src/richtext/richtextmarginspage.cpp:276
+#: ../src/richtext/richtextmarginspage.cpp:278
+msgid "Units for the bottom margin."
+msgstr "Vienības apakšējai malai."
+
+#: ../src/richtext/richtextmarginspage.cpp:284
+msgid "Padding"
+msgstr "Papildināšana"
+
+#: ../src/richtext/richtextmarginspage.cpp:307
+#: ../src/richtext/richtextmarginspage.cpp:309
+msgid "The left padding size."
+msgstr "Kreisās malas papildinājuma lielums."
+
+#: ../src/richtext/richtextmarginspage.cpp:317
+#: ../src/richtext/richtextmarginspage.cpp:319
+msgid "Units for the left padding."
+msgstr "Vienības kreisās malas papildinājumam."
+
+#: ../src/richtext/richtextmarginspage.cpp:332
+#: ../src/richtext/richtextmarginspage.cpp:334
+msgid "The right padding size."
+msgstr "Labās malas papildinājuma lielums."
+
+#: ../src/richtext/richtextmarginspage.cpp:342
+#: ../src/richtext/richtextmarginspage.cpp:344
+msgid "Units for the right padding."
+msgstr "Vienības labās malas papildinājumam."
+
+#: ../src/richtext/richtextmarginspage.cpp:355
+#: ../src/richtext/richtextmarginspage.cpp:357
+msgid "The top padding size."
+msgstr "Augšējā papildinājuma lielums."
+
+#: ../src/richtext/richtextmarginspage.cpp:365
+#: ../src/richtext/richtextmarginspage.cpp:367
+msgid "Units for the top padding."
+msgstr "Vienības augšējam papildinājumam."
+
+#: ../src/richtext/richtextmarginspage.cpp:380
+#: ../src/richtext/richtextmarginspage.cpp:382
+msgid "The bottom padding size."
+msgstr "Apakšējā papildinājuma lielums."
+
+#: ../src/richtext/richtextmarginspage.cpp:390
+#: ../src/richtext/richtextmarginspage.cpp:392
+msgid "Units for the bottom padding."
+msgstr "Vienības apakšējās malas papildinājumam."
+
+#: ../src/richtext/richtextprint.cpp:592
+msgid " Preview"
+msgstr " Priekšskatījums"
+
+#: ../src/richtext/richtextsizepage.cpp:228
+msgid "Floating"
+msgstr "Peldošs"
+
+#: ../src/richtext/richtextsizepage.cpp:243
+msgid "&Floating mode:"
+msgstr "&Peldošais režīms:"
+
+#: ../src/richtext/richtextsizepage.cpp:252
+#: ../src/richtext/richtextsizepage.cpp:254
+msgid "How the object will float relative to the text."
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:265
+msgid "Alignment"
+msgstr "Izlīdzinašana"
+
+#: ../src/richtext/richtextsizepage.cpp:277
+msgid "&Vertical alignment:"
+msgstr "&Vertikālā izlīdzināšana:"
+
+#: ../src/richtext/richtextsizepage.cpp:279
+#: ../src/richtext/richtextsizepage.cpp:281
+msgid "Enable vertical alignment."
+msgstr "Iespējot vertikālo izlīdzināšanu"
+
+#: ../src/richtext/richtextsizepage.cpp:286
+msgid "Centred"
+msgstr "Centrēts"
+
+#: ../src/richtext/richtextsizepage.cpp:290
+#: ../src/richtext/richtextsizepage.cpp:292
+msgid "Vertical alignment."
+msgstr "Vertikālais izlīdzinājums"
+
+#: ../src/richtext/richtextsizepage.cpp:316
+#: ../src/richtext/richtextsizepage.cpp:323
+msgid "&Width:"
+msgstr "&Platums:"
+
+#: ../src/richtext/richtextsizepage.cpp:318
+#: ../src/richtext/richtextsizepage.cpp:320
+msgid "Enable the width value."
+msgstr "Iespējot platuma vērtību"
+
+#: ../src/richtext/richtextsizepage.cpp:331
+#: ../src/richtext/richtextsizepage.cpp:333
+msgid "The object width."
+msgstr "Objekta platums."
+
+#: ../src/richtext/richtextsizepage.cpp:342
+#: ../src/richtext/richtextsizepage.cpp:344
+msgid "Units for the object width."
+msgstr "Vienības objekta platumam."
+
+#: ../src/richtext/richtextsizepage.cpp:350
+#: ../src/richtext/richtextsizepage.cpp:357
+msgid "&Height:"
+msgstr "&Augstums:"
+
+#: ../src/richtext/richtextsizepage.cpp:352
+#: ../src/richtext/richtextsizepage.cpp:354
+#: ../src/richtext/richtextsizepage.cpp:464
+#: ../src/richtext/richtextsizepage.cpp:466
+msgid "Enable the height value."
+msgstr "Iespējot augstuma vērtību."
+
+#: ../src/richtext/richtextsizepage.cpp:365
+#: ../src/richtext/richtextsizepage.cpp:367
+msgid "The object height."
+msgstr "Objekta augstums."
+
+#: ../src/richtext/richtextsizepage.cpp:376
+#: ../src/richtext/richtextsizepage.cpp:378
+msgid "Units for the object height."
+msgstr "Vienības objekta augstumam."
+
+#: ../src/richtext/richtextsizepage.cpp:381
+msgid "Min width:"
+msgstr "Min. platums"
+
+#: ../src/richtext/richtextsizepage.cpp:383
+#: ../src/richtext/richtextsizepage.cpp:385
+msgid "Enable the minimum width value."
+msgstr "Iespējot minimālā platuma vērtību."
+
+#: ../src/richtext/richtextsizepage.cpp:392
+#: ../src/richtext/richtextsizepage.cpp:394
+msgid "The object minimum width."
+msgstr "Objekta minimālais platums."
+
+#: ../src/richtext/richtextsizepage.cpp:403
+#: ../src/richtext/richtextsizepage.cpp:405
+msgid "Units for the minimum object width."
+msgstr "Vienības objekta minimālajam platumam."
+
+#: ../src/richtext/richtextsizepage.cpp:408
+msgid "Min height:"
+msgstr "Min. augstums:"
+
+#: ../src/richtext/richtextsizepage.cpp:410
+#: ../src/richtext/richtextsizepage.cpp:412
+msgid "Enable the minimum height value."
+msgstr "Iespējot minimālā augstuma vērtību."
+
+#: ../src/richtext/richtextsizepage.cpp:419
+#: ../src/richtext/richtextsizepage.cpp:421
+#, fuzzy
+msgid "The object minimum height."
+msgstr "Objekta minimālais augstums."
+
+#: ../src/richtext/richtextsizepage.cpp:430
+#: ../src/richtext/richtextsizepage.cpp:432
+msgid "Units for the minimum object height."
+msgstr "Vienības objekta minimālajam augstumam."
+
+#: ../src/richtext/richtextsizepage.cpp:435
+msgid "Max width:"
+msgstr "Maksimālais platums:"
+
+#: ../src/richtext/richtextsizepage.cpp:437
+#: ../src/richtext/richtextsizepage.cpp:439
+msgid "Enable the maximum width value."
+msgstr "Iespējot maksimālā platuma vērtību."
+
+#: ../src/richtext/richtextsizepage.cpp:446
+#: ../src/richtext/richtextsizepage.cpp:448
+msgid "The object maximum width."
+msgstr "Objekta maksimālais platums."
+
+#: ../src/richtext/richtextsizepage.cpp:457
+#: ../src/richtext/richtextsizepage.cpp:459
+msgid "Units for the maximum object width."
+msgstr "Vienības objekta maksimālajam platumam."
+
+#: ../src/richtext/richtextsizepage.cpp:462
+msgid "Max height:"
+msgstr "Maksimālais augstums:"
+
+#: ../src/richtext/richtextsizepage.cpp:473
+#: ../src/richtext/richtextsizepage.cpp:475
+msgid "The object maximum height."
+msgstr "Objekta maksimālais augstums."
+
+#: ../src/richtext/richtextsizepage.cpp:484
+#: ../src/richtext/richtextsizepage.cpp:486
+msgid "Units for the maximum object height."
+msgstr "Vienības objekta maksimālajam augstumam."
+
+#: ../src/richtext/richtextsizepage.cpp:495
+msgid "Position"
+msgstr "Pozīcija"
+
+#: ../src/richtext/richtextsizepage.cpp:513
+#, fuzzy
+msgid "&Position mode:"
+msgstr "&Peldošais režīms:"
+
+#: ../src/richtext/richtextsizepage.cpp:517
+#: ../src/richtext/richtextsizepage.cpp:522
+#, fuzzy
+msgid "Static"
+msgstr "Statuss:"
+
+#: ../src/richtext/richtextsizepage.cpp:518
+#, fuzzy
+msgid "Relative"
+msgstr "Dekoratīvs"
+
+#: ../src/richtext/richtextsizepage.cpp:519
+msgid "Absolute"
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:520
+#, fuzzy
+msgid "Fixed"
+msgstr "Fiksēts fonts:"
+
+#: ../src/richtext/richtextsizepage.cpp:533
+#: ../src/richtext/richtextsizepage.cpp:535
+#: ../src/richtext/richtextsizepage.cpp:547
+#: ../src/richtext/richtextsizepage.cpp:549
+#, fuzzy
+msgid "The left position."
+msgstr "Tabulatora pozīcija."
+
+#: ../src/richtext/richtextsizepage.cpp:558
+#: ../src/richtext/richtextsizepage.cpp:560
+#, fuzzy
+msgid "Units for the left position."
+msgstr "Vienības kreisās malas papildinājumam."
+
+#: ../src/richtext/richtextsizepage.cpp:568
+#: ../src/richtext/richtextsizepage.cpp:570
+#: ../src/richtext/richtextsizepage.cpp:582
+#: ../src/richtext/richtextsizepage.cpp:584
+#, fuzzy
+msgid "The top position."
+msgstr "Tabulatora pozīcija."
+
+#: ../src/richtext/richtextsizepage.cpp:593
+#: ../src/richtext/richtextsizepage.cpp:595
+#, fuzzy
+msgid "Units for the top position."
+msgstr "Vienības augšējam papildinājumam."
+
+#: ../src/richtext/richtextsizepage.cpp:603
+#: ../src/richtext/richtextsizepage.cpp:605
+#: ../src/richtext/richtextsizepage.cpp:617
+#: ../src/richtext/richtextsizepage.cpp:619
+#, fuzzy
+msgid "The right position."
+msgstr "Tabulatora pozīcija."
+
+#: ../src/richtext/richtextsizepage.cpp:628
+#: ../src/richtext/richtextsizepage.cpp:630
+#, fuzzy
+msgid "Units for the right position."
+msgstr "Vienības labās malas papildinājumam."
+
+#: ../src/richtext/richtextsizepage.cpp:638
+#: ../src/richtext/richtextsizepage.cpp:640
+#: ../src/richtext/richtextsizepage.cpp:652
+#: ../src/richtext/richtextsizepage.cpp:654
+#, fuzzy
+msgid "The bottom position."
+msgstr "Tabulatora pozīcija."
+
+#: ../src/richtext/richtextsizepage.cpp:663
+#: ../src/richtext/richtextsizepage.cpp:665
+#, fuzzy
+msgid "Units for the bottom position."
+msgstr "Vienības apakšējās malas papildinājumam."
+
+#: ../src/richtext/richtextsizepage.cpp:671
+msgid "&Move the object to:"
+msgstr "&Pārvietot objektu uz:"
+
+#: ../src/richtext/richtextsizepage.cpp:674
+msgid "&Previous Paragraph"
+msgstr "Ie&priekšējā rindkopa"
+
+#: ../src/richtext/richtextsizepage.cpp:675
+#: ../src/richtext/richtextsizepage.cpp:677
+msgid "Moves the object to the previous paragraph."
+msgstr "Pārvieto objektu uz iepriekšējo rindkopu."
+
+#: ../src/richtext/richtextsizepage.cpp:680
+msgid "&Next Paragraph"
+msgstr "&Nākamā rindkopa"
+
+#: ../src/richtext/richtextsizepage.cpp:681
+#: ../src/richtext/richtextsizepage.cpp:683
+msgid "Moves the object to the next paragraph."
+msgstr "Pārvieto objektu uz nākošo rindkopu."
+
+#: ../src/richtext/richtextstyledlg.cpp:193
+msgid "&Styles:"
+msgstr "&Stili:"
+
+#: ../src/richtext/richtextstyledlg.cpp:197
+#: ../src/richtext/richtextstyledlg.cpp:199
+msgid "The available styles."
+msgstr "Pieejamie stili."
+
+#: ../src/richtext/richtextstyledlg.cpp:205
+#: ../src/richtext/richtextstyledlg.cpp:217
+msgid " "
+msgstr " "
+
+#: ../src/richtext/richtextstyledlg.cpp:209
+#: ../src/richtext/richtextstyledlg.cpp:211
+msgid "The style preview."
+msgstr "Stila priekšskatījums."
+
+#: ../src/richtext/richtextstyledlg.cpp:220
+msgid "New &Character Style..."
+msgstr "Jauns rakstzīmju stils..."
+
+#: ../src/richtext/richtextstyledlg.cpp:221
+#: ../src/richtext/richtextstyledlg.cpp:223
+msgid "Click to create a new character style."
+msgstr "Nospiediet, lai izveidotu jaunu burtu stilu."
+
+#: ../src/richtext/richtextstyledlg.cpp:226
+msgid "New &Paragraph Style..."
+msgstr "Jauns rindko&pas stils..."
+
+#: ../src/richtext/richtextstyledlg.cpp:227
+#: ../src/richtext/richtextstyledlg.cpp:229
+msgid "Click to create a new paragraph style."
+msgstr "Nospiediet, lai izveidotu jaunu rindkopas stilu."
+
+#: ../src/richtext/richtextstyledlg.cpp:232
+msgid "New &List Style..."
+msgstr "Jaunas saraksta stils..."
+
+#: ../src/richtext/richtextstyledlg.cpp:233
+#: ../src/richtext/richtextstyledlg.cpp:235
+msgid "Click to create a new list style."
+msgstr "Nospiediet, lai izveidotu jaunu saraksta stilu."
+
+#: ../src/richtext/richtextstyledlg.cpp:238
+msgid "New &Box Style..."
+msgstr "Jauns &rāmja stils..."
+
+#: ../src/richtext/richtextstyledlg.cpp:239
+#: ../src/richtext/richtextstyledlg.cpp:241
+msgid "Click to create a new box style."
+msgstr "Nospiediet, lai izveidotu jaunu rāmja stilu."
+
+#: ../src/richtext/richtextstyledlg.cpp:246
+msgid "&Apply Style"
+msgstr "&Pielietot stilu"
+
+#: ../src/richtext/richtextstyledlg.cpp:247
+#: ../src/richtext/richtextstyledlg.cpp:249
+msgid "Click to apply the selected style."
+msgstr "Nospiediet, lai pielietotu izvēlēto stilu."
+
+#: ../src/richtext/richtextstyledlg.cpp:252
+msgid "&Rename Style..."
+msgstr "Pā&rdēvēt stilu..."
+
+#: ../src/richtext/richtextstyledlg.cpp:253
+#: ../src/richtext/richtextstyledlg.cpp:255
+msgid "Click to rename the selected style."
+msgstr "Nospiediet, lai pārdēvētu izvēlēto stilu."
+
+#: ../src/richtext/richtextstyledlg.cpp:258
+msgid "&Edit Style..."
+msgstr "&Labot stilu..."
+
+#: ../src/richtext/richtextstyledlg.cpp:259
+#: ../src/richtext/richtextstyledlg.cpp:261
+msgid "Click to edit the selected style."
+msgstr "Nospiediet, lai labotu izvēlēto stilu."
+
+#: ../src/richtext/richtextstyledlg.cpp:264
+msgid "&Delete Style..."
+msgstr "&Dzēst stilu..."
+
+#: ../src/richtext/richtextstyledlg.cpp:265
+#: ../src/richtext/richtextstyledlg.cpp:267
+msgid "Click to delete the selected style."
+msgstr "Nospiediet, lai dzēstu izvēlēto stilu."
+
+#: ../src/richtext/richtextstyledlg.cpp:274
+#: ../src/richtext/richtextstyledlg.cpp:276
+msgid "Click to close this window."
+msgstr "Nospiediet, lai aizvērtu šo logu"
+
+#: ../src/richtext/richtextstyledlg.cpp:282
+msgid "&Restart numbering"
+msgstr "Atsākt numu&rēšanu"
+
+#: ../src/richtext/richtextstyledlg.cpp:284
+#: ../src/richtext/richtextstyledlg.cpp:286
+msgid "Check to restart numbering."
+msgstr "Atzīmējiet, lai atsāktu numurēšanu."
+
+#: ../src/richtext/richtextstyledlg.cpp:601
+msgid "Enter a character style name"
+msgstr "Ievadiet rakstzīmju stila nosaukumu"
+
+#: ../src/richtext/richtextstyledlg.cpp:601
+#: ../src/richtext/richtextstyledlg.cpp:606
+#: ../src/richtext/richtextstyledlg.cpp:649
+#: ../src/richtext/richtextstyledlg.cpp:654
+#: ../src/richtext/richtextstyledlg.cpp:815
+#: ../src/richtext/richtextstyledlg.cpp:820
+#: ../src/richtext/richtextstyledlg.cpp:888
+#: ../src/richtext/richtextstyledlg.cpp:896
+#: ../src/richtext/richtextstyledlg.cpp:929
+#: ../src/richtext/richtextstyledlg.cpp:934
+msgid "New Style"
+msgstr "Jauns stils"
+
+#: ../src/richtext/richtextstyledlg.cpp:606
+#: ../src/richtext/richtextstyledlg.cpp:654
+#: ../src/richtext/richtextstyledlg.cpp:820
+#: ../src/richtext/richtextstyledlg.cpp:896
+#: ../src/richtext/richtextstyledlg.cpp:934
+msgid "Sorry, that name is taken. Please choose another."
+msgstr "Diemžēl, šis vārds jau ir aizņemts. Izvēlieties citu."
+
+#: ../src/richtext/richtextstyledlg.cpp:649
+msgid "Enter a paragraph style name"
+msgstr "Ievadiet rindkopas stila nosaukumu"
+
+#: ../src/richtext/richtextstyledlg.cpp:777
+#, c-format
+msgid "Delete style %s?"
+msgstr "Dzēst stilu %s?"
+
+#: ../src/richtext/richtextstyledlg.cpp:777
+msgid "Delete Style"
+msgstr "Dzēst stilu"
+
+#: ../src/richtext/richtextstyledlg.cpp:815
+msgid "Enter a list style name"
+msgstr "Ievadiet saraksta stila nosaukumu"
+
+#: ../src/richtext/richtextstyledlg.cpp:888
+msgid "Enter a new style name"
+msgstr "Ievadiet jaunā stila nosaukumu"
+
+#: ../src/richtext/richtextstyledlg.cpp:929
+msgid "Enter a box style name"
+msgstr "Ievadiet rāmja stila nosaukumu"
+
+#: ../src/richtext/richtextstylepage.cpp:109
+#: ../src/richtext/richtextstylepage.cpp:111
+msgid "The style name."
+msgstr "Stila nosaukums."
+
+#: ../src/richtext/richtextstylepage.cpp:114
+msgid "&Based on:"
+msgstr "&Balstīts uz:"
+
+#: ../src/richtext/richtextstylepage.cpp:119
+#: ../src/richtext/richtextstylepage.cpp:121
+msgid "The style on which this style is based."
+msgstr "Stils, kas ir šī stila pamatā."
+
+#: ../src/richtext/richtextstylepage.cpp:124
+msgid "&Next style:"
+msgstr "&Nākošais stils:"
+
+#: ../src/richtext/richtextstylepage.cpp:129
+#: ../src/richtext/richtextstylepage.cpp:131
+msgid "The default style for the next paragraph."
+msgstr "Nākošās rindkopas noklusētais stils."
+
+#: ../src/richtext/richtextstyles.cpp:1057
+msgid "All styles"
+msgstr "Visi stili"
+
+#: ../src/richtext/richtextstyles.cpp:1058
+msgid "Paragraph styles"
+msgstr "Rindkopu stili"
+
+#: ../src/richtext/richtextstyles.cpp:1059
+msgid "Character styles"
+msgstr "Rakstzīmju stili"
+
+#: ../src/richtext/richtextstyles.cpp:1060
+msgid "List styles"
+msgstr "Stilu saraksts"
+
+#: ../src/richtext/richtextstyles.cpp:1061
+msgid "Box styles"
+msgstr "&Rāmju stili"
+
+#: ../src/richtext/richtextsymboldlg.cpp:389
+#: ../src/richtext/richtextsymboldlg.cpp:391
+msgid "The font from which to take the symbol."
+msgstr "Fonts, no kura ņemt simbolu."
+
+#: ../src/richtext/richtextsymboldlg.cpp:396
+msgid "&Subset:"
+msgstr "&Apakškopa:"
+
+#: ../src/richtext/richtextsymboldlg.cpp:401
+#: ../src/richtext/richtextsymboldlg.cpp:403
+msgid "Shows a Unicode subset."
+msgstr "Rāda Unicode apakškopu."
+
+#: ../src/richtext/richtextsymboldlg.cpp:412
+msgid "xxxx"
+msgstr "xxxx"
+
+#: ../src/richtext/richtextsymboldlg.cpp:417
+msgid "&Character code:"
+msgstr "Rakstzī&mju kods:"
+
+#: ../src/richtext/richtextsymboldlg.cpp:421
+#: ../src/richtext/richtextsymboldlg.cpp:423
+msgid "The character code."
+msgstr "Rakstzīmes kods."
+
+#: ../src/richtext/richtextsymboldlg.cpp:428
+msgid "&From:"
+msgstr "&No:"
+
+#: ../src/richtext/richtextsymboldlg.cpp:433
+#: ../src/richtext/richtextsymboldlg.cpp:434
+#: ../src/richtext/richtextsymboldlg.cpp:435
+msgid "Unicode"
+msgstr "Unikods"
+
+#: ../src/richtext/richtextsymboldlg.cpp:436
+#: ../src/richtext/richtextsymboldlg.cpp:438
+msgid "The range to show."
+msgstr "Rādāmais diapazons."
+
+#: ../src/richtext/richtextsymboldlg.cpp:444
+msgid "Insert"
+msgstr "Insert"
+
+#: ../src/richtext/richtextsymboldlg.cpp:478
+msgid "(Normal text)"
+msgstr "(Parasts teksts)"
+
+#: ../src/richtext/richtexttabspage.cpp:109
+msgid "&Position (tenths of a mm):"
+msgstr "No&vietojums (mm desmitdaļās)"
+
+#: ../src/richtext/richtexttabspage.cpp:113
+#: ../src/richtext/richtexttabspage.cpp:115
+msgid "The tab position."
+msgstr "Tabulatora pozīcija."
+
+#: ../src/richtext/richtexttabspage.cpp:119
+msgid "The tab positions."
+msgstr "Tabulatora pozīcijas."
+
+#: ../src/richtext/richtexttabspage.cpp:132
+#: ../src/richtext/richtexttabspage.cpp:134
+msgid "Click to create a new tab position."
+msgstr "Nospiediet, lai izveidotu jaunu tabulatora pozīciju."
+
+#: ../src/richtext/richtexttabspage.cpp:138
+#: ../src/richtext/richtexttabspage.cpp:140
+msgid "Click to delete the selected tab position."
+msgstr "Nospiediet, lai dzēstu izvēlēto tabulatora pozīciju."
+
+#: ../src/richtext/richtexttabspage.cpp:143
+msgid "Delete A&ll"
+msgstr "Dzēst v&isu"
+
+#: ../src/richtext/richtexttabspage.cpp:144
+#: ../src/richtext/richtexttabspage.cpp:146
+msgid "Click to delete all tab positions."
+msgstr "Nospiediet, lai dzēstu visas tabulatora pozīcijas."
+
+#: ../src/univ/theme.cpp:110
+msgid "Failed to initialize GUI: no built-in themes found."
+msgstr ""
+"Neizdevās inicializēt grafisko lietotāja saskarni: nav atrasta neviena "
+"iebūvēta tēma."
+
+#: ../src/univ/themes/gtk.cpp:521
+msgid "GTK+ theme"
+msgstr "GTK+ tēma"
+
+#: ../src/univ/themes/metal.cpp:164
+msgid "Metal theme"
+msgstr "Metāla tēma"
+
+#: ../src/univ/themes/mono.cpp:512
+msgid "Simple monochrome theme"
+msgstr "Vienkrāsaina tēma"
+
+#: ../src/univ/themes/win32.cpp:1098
+msgid "Win32 theme"
+msgstr "Win32 tēma"
+
+#: ../src/univ/themes/win32.cpp:3743
+msgid "&Restore"
+msgstr "At&jaunot"
+
+#: ../src/univ/themes/win32.cpp:3744
+msgid "&Move"
+msgstr "&Pārvietot"
+
+#: ../src/univ/themes/win32.cpp:3746
+msgid "&Size"
+msgstr "Izmēr&s"
+
+#: ../src/univ/themes/win32.cpp:3748
+msgid "Mi&nimize"
+msgstr "Mi&nimizēt"
+
+#: ../src/univ/themes/win32.cpp:3750
+msgid "Ma&ximize"
+msgstr "Ma&ksimizēt"
+
+#: ../src/univ/themes/win32.cpp:3752
+msgid "Alt+"
+msgstr "Alt+"
+
+#: ../src/unix/appunix.cpp:178
+msgid "Failed to install signal handler"
+msgstr ""
+
+#: ../src/unix/dialup.cpp:351
+msgid "Already dialling ISP."
+msgstr "ISP jau tiek zvanīts."
+
+#: ../src/unix/dlunix.cpp:93
+#, fuzzy
+msgid "Failed to unload shared library"
+msgstr "Nevar ielādēt koplietojamo bibliotēku '%s'"
+
+#: ../src/unix/dlunix.cpp:121
+msgid "Unknown dynamic library error"
+msgstr "Nezināma dinamiskās bibliotēkas kļūda"
+
+#: ../src/unix/epolldispatcher.cpp:84
+msgid "Failed to create epoll descriptor"
+msgstr ""
+
+#: ../src/unix/epolldispatcher.cpp:103
+msgid "Error closing epoll descriptor"
+msgstr ""
+
+#: ../src/unix/epolldispatcher.cpp:116
+#, c-format
+msgid "Failed to add descriptor %d to epoll descriptor %d"
+msgstr ""
+
+#: ../src/unix/epolldispatcher.cpp:136
+#, c-format
+msgid "Failed to modify descriptor %d in epoll descriptor %d"
+msgstr ""
+
+#: ../src/unix/epolldispatcher.cpp:155
+#, c-format
+msgid "Failed to unregister descriptor %d from epoll descriptor %d"
+msgstr ""
+
+#: ../src/unix/epolldispatcher.cpp:213
+#, c-format
+msgid "Waiting for IO on epoll descriptor %d failed"
+msgstr ""
+
+#: ../src/unix/fswatcher_inotify.cpp:71
+msgid "Unable to create inotify instance"
+msgstr ""
+
+#: ../src/unix/fswatcher_inotify.cpp:94
+msgid "Unable to close inotify instance"
+msgstr ""
+
+#: ../src/unix/fswatcher_inotify.cpp:106
+msgid "Unable to add inotify watch"
+msgstr ""
+
+#: ../src/unix/fswatcher_inotify.cpp:138
+#, fuzzy, c-format
+msgid "Unable to remove inotify watch %i"
+msgstr "Neizdevās atvērt ceļu  '%s'"
+
+#: ../src/unix/fswatcher_inotify.cpp:271
+#, c-format
+msgid "Unexpected event for \"%s\": no matching watch descriptor."
+msgstr ""
+
+#: ../src/unix/fswatcher_inotify.cpp:320
+#, c-format
+msgid "Invalid inotify event for \"%s\""
+msgstr ""
+
+#: ../src/unix/fswatcher_inotify.cpp:553
+msgid "Unable to read from inotify descriptor"
+msgstr ""
+
+#: ../src/unix/fswatcher_inotify.cpp:558
+msgid "EOF while reading from inotify descriptor"
+msgstr ""
+
+#: ../src/unix/fswatcher_kqueue.cpp:114
+msgid "Unable to create kqueue instance"
+msgstr ""
+
+#: ../src/unix/fswatcher_kqueue.cpp:131
+msgid "Error closing kqueue instance"
+msgstr ""
+
+#: ../src/unix/fswatcher_kqueue.cpp:153
+msgid "Unable to add kqueue watch"
+msgstr ""
+
+#: ../src/unix/fswatcher_kqueue.cpp:170
+msgid "Unable to remove kqueue watch"
+msgstr ""
+
+#: ../src/unix/fswatcher_kqueue.cpp:202
+msgid "Unable to get events from kqueue"
+msgstr ""
+
+#: ../src/unix/mediactrl.cpp:966
+#, c-format
+msgid "Media playback error: %s"
+msgstr ""
+
+#: ../src/unix/mediactrl.cpp:1228
+#, fuzzy, c-format
+msgid "Failed to prepare playing \"%s\"."
+msgstr "Neizdevās atvērt displeju \"%s\"."
+
+#: ../src/unix/snglinst.cpp:164
+#, c-format
+msgid "Failed to write to lock file '%s'"
+msgstr "Neizdevās ierakstīt slēdzenes failā '%s'"
+
+#: ../src/unix/snglinst.cpp:177
+#, c-format
+msgid "Failed to set permissions on lock file '%s'"
+msgstr "Neizdevās uzstādīt pieejas tiesības slēdzenes failam '%s'"
+
+#: ../src/unix/snglinst.cpp:194
+#, c-format
+msgid "Failed to lock the lock file '%s'"
+msgstr "Neizdevās aizslēgt slēdzenes failu '%s'"
+
+#: ../src/unix/snglinst.cpp:237
+#, c-format
+msgid "Failed to inspect the lock file '%s'"
+msgstr "Neizdevās pārbaudīt slēdzenes failu '%s'"
+
+#: ../src/unix/snglinst.cpp:242
+#, c-format
+msgid "Lock file '%s' has incorrect owner."
+msgstr "Slēdzenes failam '%s' ir nepareizs īpašnieks."
+
+#: ../src/unix/snglinst.cpp:247
+#, c-format
+msgid "Lock file '%s' has incorrect permissions."
+msgstr "slēdzenes failam '%s' ir nepareizas pieejas tiesības."
+
+#: ../src/unix/snglinst.cpp:265
+msgid "Failed to access lock file."
+msgstr "Neizdevās piekļūt slēdzenes failam."
+
+#: ../src/unix/snglinst.cpp:274
+msgid "Failed to read PID from lock file."
+msgstr "Neizdevās nolasīt PID no slēdzenes faila."
+
+#: ../src/unix/snglinst.cpp:284
+#, c-format
+msgid "Failed to remove stale lock file '%s'."
+msgstr "Neizdevās izdzēst izmantoto slēdzenes failu '%s'."
+
+#: ../src/unix/snglinst.cpp:297
+#, c-format
+msgid "Deleted stale lock file '%s'."
+msgstr "Izdzēsts izmantotais slēdzenes fails '%s'."
+
+#: ../src/unix/snglinst.cpp:308
+#, c-format
+msgid "Invalid lock file '%s'."
+msgstr "Nederīgs slēdzenes fails '%s'."
+
+#: ../src/unix/snglinst.cpp:324
+#, c-format
+msgid "Failed to remove lock file '%s'"
+msgstr "Neizdevās izdzēst slēdzenes failu '%s'"
+
+#: ../src/unix/snglinst.cpp:330
+#, c-format
+msgid "Failed to unlock lock file '%s'"
+msgstr "Neizdevās atslēgt slēdzenes failu '%s'"
+
+#: ../src/unix/snglinst.cpp:336
+#, c-format
+msgid "Failed to close lock file '%s'"
+msgstr "Neizdevās aizvērt slēdzenes failu '%s'"
+
+#: ../src/unix/sound.cpp:77
+msgid "No sound"
+msgstr "Nav skaņas"
+
+#: ../src/unix/sound.cpp:364
+msgid "Unable to play sound asynchronously."
+msgstr "Nav iespējams atskaņot skaņu asinhroni."
+
+#: ../src/unix/sound.cpp:458
+#, c-format
+msgid "Couldn't load sound data from '%s'."
+msgstr "Neizdevās ielādēt skaņas datus no '%s'."
+
+#: ../src/unix/sound.cpp:465
+#, c-format
+msgid "Sound file '%s' is in unsupported format."
+msgstr "Skaņās faila '%s' formāts nav atbalstīts."
+
+#: ../src/unix/sound.cpp:480
+msgid "Sound data are in unsupported format."
+msgstr "Skaņas dati ir neatbalstītā formātā."
+
+#: ../src/unix/sound_sdl.cpp:226
+#, c-format
+msgid "Couldn't open audio: %s"
+msgstr "Neizdevās atvērt audio: %s"
+
+#: ../src/unix/threadpsx.cpp:1033
+msgid "Cannot retrieve thread scheduling policy."
+msgstr ""
+
+#: ../src/unix/threadpsx.cpp:1058
+#, c-format
+msgid "Cannot get priority range for scheduling policy %d."
+msgstr ""
+
+#: ../src/unix/threadpsx.cpp:1066
+msgid "Thread priority setting is ignored."
+msgstr "Pavediena prioritātes iestatījums nav ņemts vērā."
+
+#: ../src/unix/threadpsx.cpp:1221
+msgid ""
+"Failed to join a thread, potential memory leak detected - please restart the "
+"program"
+msgstr ""
+"Kļūda pievienojoties pavedienam, atrasta iespējama atmiņas noplūde - lūdzu "
+"pārstartējiet programmu"
+
+#: ../src/unix/threadpsx.cpp:1352
+#, fuzzy, c-format
+msgid "Failed to set thread concurrency level to %lu"
+msgstr "Neizdevās uzstādīt pavediena prioritāti %d."
+
+#: ../src/unix/threadpsx.cpp:1481
+#, c-format
+msgid "Failed to set thread priority %d."
+msgstr "Neizdevās uzstādīt pavediena prioritāti %d."
+
+#: ../src/unix/threadpsx.cpp:1666
+msgid "Failed to terminate a thread."
+msgstr "Neizdevās pārtraukt pavedienu."
+
+#: ../src/unix/threadpsx.cpp:1893
+msgid "Thread module initialization failed: failed to create thread key"
+msgstr ""
+"Kļūda inicializējot pavediena moduli: nav iespējams izveidot pavediena "
+"atslēgu"
+
+#: ../src/unix/utilsunx.cpp:340
+msgid "Impossible to get child process input"
+msgstr ""
+
+#: ../src/unix/utilsunx.cpp:390
+msgid "Can't write to child process's stdin"
+msgstr ""
+
+#: ../src/unix/utilsunx.cpp:644
+#, c-format
+msgid "Failed to execute '%s'\n"
+msgstr "Neizdevās izpildīt '%s'\n"
+
+#: ../src/unix/utilsunx.cpp:678
+msgid "Fork failed"
+msgstr ""
+
+#: ../src/unix/utilsunx.cpp:701
+#, fuzzy
+msgid "Failed to set process priority"
+msgstr "Neizdevās uzstādīt pavediena prioritāti %d."
+
+#: ../src/unix/utilsunx.cpp:712
+msgid "Failed to redirect child process input/output"
+msgstr ""
+
+#: ../src/unix/utilsunx.cpp:816
+msgid "Failed to set up non-blocking pipe, the program might hang."
+msgstr ""
+
+#: ../src/unix/utilsunx.cpp:1023
+msgid "Cannot get the hostname"
+msgstr "Nevar atrast resursdatora vārdu"
+
+#: ../src/unix/utilsunx.cpp:1059
+msgid "Cannot get the official hostname"
+msgstr "Nevar atrast oficiālo resursdatora vārdu"
+
+#: ../src/unix/wakeuppipe.cpp:49
+msgid "Failed to create wake up pipe used by event loop."
+msgstr ""
+
+#: ../src/unix/wakeuppipe.cpp:56
+msgid "Failed to switch wake up pipe to non-blocking mode"
+msgstr ""
+
+#: ../src/unix/wakeuppipe.cpp:117
+msgid "Failed to read from wake-up pipe"
+msgstr ""
+
+#: ../src/x11/app.cpp:124
+#, c-format
+msgid "Invalid geometry specification '%s'"
+msgstr "Nederīga ģeometrijas specifikācija '%s'."
+
+#: ../src/x11/app.cpp:167
+msgid "wxWidgets could not open display. Exiting."
+msgstr "wxWidgets neizdevās atvērt ekrānu. Beidz darbu."
+
+#: ../src/x11/utils.cpp:169
+#, c-format
+msgid "Failed to close the display \"%s\""
+msgstr "Neizdevās aizvērt ekrānu \"%s\""
+
+#: ../src/x11/utils.cpp:188
+#, c-format
+msgid "Failed to open display \"%s\"."
+msgstr "Neizdevās atvērt displeju \"%s\"."
+
+#: ../src/xml/xml.cpp:868
+#, c-format
+msgid "XML parsing error: '%s' at line %d"
+msgstr ""
+
+#: ../src/xrc/xh_propgrid.cpp:239
+#, fuzzy, c-format
+msgid "Page %i"
+msgstr "Lapa %d"
+
+#: ../src/xrc/xmlres.cpp:448
+#, c-format
+msgid "Cannot load resources from '%s'."
+msgstr "Nav iespējams ielādēt resursus no '%s'."
+
+#: ../src/xrc/xmlres.cpp:799
+#, c-format
+msgid "Cannot open resources file '%s'."
+msgstr "Nav iespējams atvērt resursu failu  '%s'."
+
+#: ../src/xrc/xmlres.cpp:806
+#, c-format
+msgid "Cannot load resources from file '%s'."
+msgstr "Nav iespējams ielādēt resursus no faila '%s'."
+
+#: ../src/xrc/xmlres.cpp:2767
+#, fuzzy, c-format
+msgid "Creating %s \"%s\" failed."
+msgstr "Neizdevās izveidot hronometru"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Alt+"
+#~ msgstr "Alt+"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Ctrl+"
+#~ msgstr "Ctrl+"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Shift+"
+#~ msgstr "Shift+"
+
+#~ msgctxt "keyboard key"
+#~ msgid "RawCtrl+"
+#~ msgstr "RawCtrl+"
+
+#~ msgid "Unsupported clipboard format."
+#~ msgstr "Neatbalstīts starpliktuves formāts."
+
+#~ msgid "Background colour"
+#~ msgstr "Fona krāsa"
+
+#~ msgid "Font:"
+#~ msgstr "Fonts:"
+
+#~ msgid "Size:"
+#~ msgstr "Izmērs:"
+
+#~ msgid "The font size in points."
+#~ msgstr "Fonta izmērs punktos"
+
+#~ msgid "Style:"
+#~ msgstr "Stils:"
+
+#~ msgid "Check to make the font bold."
+#~ msgstr "Atzīmējiet, lai iegūtu fontu treknrakstā."
+
+#~ msgid "Check to make the font italic."
+#~ msgstr "Atzīmējiet, lai iegūtu fontu kursīvā."
+
+#~ msgid "Check to make the font underlined."
+#~ msgstr "Atzīmējiet, lai iegūtu fontu ar pasvītrojumu."
+
+#~ msgid "Colour:"
+#~ msgstr "Krāsa:"
+
+#~ msgid "Click to change the font colour."
+#~ msgstr "Nospiediet, lai mainītu fonta krāsu."
+
+#~ msgid "Shows a preview of the font."
+#~ msgstr "Rāda fonta priekšskatījumu."
+
+#~ msgid "Click to cancel changes to the font."
+#~ msgstr "Nospiediet, lai atceltu fonta izmaiņas."
+
+#~ msgid "Click to confirm changes to the font."
+#~ msgstr "Nospiediet, lai apstiprinātu fonta izmaiņas."
+
+#~ msgid "<Any>"
+#~ msgstr "<Jebkurš>"
+
+#~ msgid "<Any Roman>"
+#~ msgstr "<Jebkurš romāņu>"
+
+#~ msgid "<Any Decorative>"
+#~ msgstr "<Jebkurš dekoratīvais>"
+
+#~ msgid "<Any Modern>"
+#~ msgstr "<Jebkurš modernais>"
+
+#~ msgid "<Any Script>"
+#~ msgstr "<Jebkurš rokraksta>"
+
+#~ msgid "<Any Swiss>"
+#~ msgstr "<Jebkurš Šveices>"
+
+#~ msgid "<Any Teletype>"
+#~ msgstr "<Jebkurš teletaipa>"
+
+#~ msgid "Printing "
+#~ msgstr "Drukāšana"
+
+#~ msgid "Failed to insert text in the control."
+#~ msgstr "Neizdevās ievietot tekstu vadīklā."
+
+#~ msgid "Please choose a valid font."
+#~ msgstr "Lūdzu, izvēlieties derīgu fontu."
+
+#, c-format
+#~ msgid "Failed to display HTML document in %s encoding"
+#~ msgstr "Neizdevās parādīt  HTML dokumentu %s kodējumā"
+
+#, c-format
+#~ msgid "wxWidgets could not open display for '%s': exiting."
+#~ msgstr "wxWidgets neizdevās atvērt ekrānu priekš '%s': beidz darbu."
+
+#~ msgid "Filter"
+#~ msgstr "Filtrs"
+
+#~ msgid "Directories"
+#~ msgstr "Mapes"
+
+#~ msgid "Files"
+#~ msgstr "Faili"
+
+#~ msgid "Selection"
+#~ msgstr "Iezīmējums"
+
+#~ msgid "conversion to 8-bit encoding failed"
+#~ msgstr "neizdevās pārvērst 8 bitu kodējumā"
+
+#, fuzzy
+#~ msgid "failed to retrieve execution result"
+#~ msgstr "Neizdevās saņemt RAS ķļūdas paziņojuma tekstu."
+
+#~ msgid "&Save as"
+#~ msgstr "&Saglabāt Kā "
+
+#, fuzzy
+#~ msgid "'%s' doesn't consist only of valid characters"
+#~ msgstr "'%s' drīkst saturēt tikai alfabēta rakstzīmes."
+
+#~ msgid "'%s' should be numeric."
+#~ msgstr "'%s' ir jābūt skaitliskam."
+
+#~ msgid "'%s' should only contain ASCII characters."
+#~ msgstr "'%s' drīkst saturēt tikai ASCII simbolus."
+
+#~ msgid "'%s' should only contain alphabetic characters."
+#~ msgstr "'%s' drīkst saturēt tikai alfabēta rakstzīmes."
+
+#~ msgid "'%s' should only contain alphabetic or numeric characters."
+#~ msgstr "'%s' drīkst saturēt tikai alfabēta un skaitliskas rakstzīmes."
+
+#~ msgid "'%s' should only contain digits."
+#~ msgstr "'%s' drīkst saturēt tikai ciparus."
+
+#~ msgid "Can't create window of class %s"
+#~ msgstr "Nav iespējams izveidot %s klases logu"
+
+#~ msgid "Failed to convert file \"%s\" to Unicode."
+#~ msgstr "Neizdevās pārvērst failu \"%s\"  uz Unikodu."
+
+#~ msgid "Failed to set text in the text control."
+#~ msgstr "Neizdevās iestatīt tekstu teksta vadīklā."
+
+#~ msgid "Invalid GTK+ command line option, use \"%s --help\""
+#~ msgstr "Nederīgs GTK+ komandrindas parametrs, izmantojiet \"%s --help\""
+
+#~ msgid "No unused colour in image."
+#~ msgstr "Attēls nesatur neizmantotas krāsas."
+
+#~ msgid "Not available"
+#~ msgstr "Nav pieejams"
+
+#~ msgid "Replace selection"
+#~ msgstr "Aizvietot iezīmējumu"
+
+#~ msgid "Save as"
+#~ msgstr "Saglabāt kā"
+
+#~ msgid "Style Organiser"
+#~ msgstr "Stilu vadība"
+
+#~ msgid "The following standard GTK+ options are also supported:\n"
+#~ msgstr "Tiek atbalstīti arī sekojoši GTK+ standarta iestatījumi:\n"
+
+#~ msgid "locale '%s' cannot be set."
+#~ msgstr "lokāli '%s' nav iespējams uzstādīt."
+
+#~ msgid ""
+#~ "Cannot create new column's ID. Probably max. number of columns reached."
+#~ msgstr ""
+#~ "Nevar izveidot jaunas lejas ID. Iespējams, sasniegts maksimālais sleju "
+#~ "skaits."
+
+#~ msgid "Column could not be added."
+#~ msgstr "Pievienot sleju nav iespējams."
+
+#~ msgid "Column index not found."
+#~ msgstr "Slejas indekss nav atrasts."
+
+#~ msgid "Column width could not be determined"
+#~ msgstr "Nav iespējams noteikt slejas platumu."
+
+#~ msgid "Column width could not be set."
+#~ msgstr "Nav iespējams iestatīt slejas platumu."
+
+#~ msgid "Confirm registry update"
+#~ msgstr "Apstiprināt reģistra atsvaidzināšanu"
+
+#~ msgid "Could not determine column index."
+#~ msgstr "Neizdevās noteikt slejas indeksu."
+
+#~ msgid "Could not determine column's position"
+#~ msgstr "Neizdevās noteikt slejas novietojumu."
+
+#~ msgid "Could not determine number of columns."
+#~ msgstr "Neizdevās noteikt sleju skaitu."
+
+#~ msgid "Could not determine number of items"
+#~ msgstr "Neizdevās noteikt objektu skaitu."
+
+#~ msgid "Could not get header description."
+#~ msgstr "Neizdevās nolasīt galvenes aprakstu."
+
+#~ msgid "Could not get items."
+#~ msgstr "Neizdevās saņemt objektus."
+
+#~ msgid "Could not get property flags."
+#~ msgstr "Neizdevās nolasīt īpašību karogus."
+
+#~ msgid "Could not get selected items."
+#~ msgstr "Neizdevās saņemt izvēlētos objektus."
+
+#~ msgid "Could not remove column."
+#~ msgstr "Neizdevās izdzēst sleju."
+
+#~ msgid "Could not retrieve number of items"
+#~ msgstr "Neizdevās iegūt objektu skaitu."
+
+#~ msgid "Could not set column width."
+#~ msgstr "Neizdevās iestatīt slejas platumu."
+
+#~ msgid "Could not set header description."
+#~ msgstr "Neizdevās iestatīt galvenes aprakstu."
+
+#~ msgid "Could not set icon."
+#~ msgstr "Neizdevās iestatīt ikonu."
+
+#~ msgid "Could not set maximum width."
+#~ msgstr "Neizdevās iestatīt maksimālo platumu."
+
+#~ msgid "Could not set minimum width."
+#~ msgstr "Neizdevās iestatīt minimālo platumu."
+
+#~ msgid "Could not set property flags."
+#~ msgstr "Neizdevās uzstādīt īpašību karogus."
+
+#~ msgid "Data object has invalid data format"
+#~ msgstr "Datu objektam ir nederīgs datu formāts"
+
+#~ msgid ""
+#~ "Do you want to overwrite the command used to %s files with extension "
+#~ "\"%s\" ?\n"
+#~ "Current value is \n"
+#~ "%s, \n"
+#~ "New value is \n"
+#~ "%s %1"
+#~ msgstr ""
+#~ "Vai vēlaties nomainīt %s failiem ar paplašinājumu \"%s\" izmantoto "
+#~ "komandu?\n"
+#~ "Pašreizējā \n"
+#~ "%s, \n"
+#~ "Jaunā \n"
+#~ "%s %1"
+
+#~ msgid "Failed to retrieve data from the clipboard."
+#~ msgstr "Neizdevās iegūt datus no starpliktuves."
+
+#~ msgid "GIF: Invalid gif index."
+#~ msgstr "GIF: nederīgs gif indekss."
+
+#~ msgid "GIF: unknown error!!!"
+#~ msgstr "GIF: nezināma kļūda!!!"
+
+#~ msgid "New directory"
+#~ msgstr "Jauna mape"
+
+#~ msgid "Next"
+#~ msgstr "Nākošais"
+
+#~ msgid "No column existing."
+#~ msgstr "Nav nevienas slejas"
+
+#~ msgid "No column for the specified column existing."
+#~ msgstr "Norādītajai slejai atbilstoša sleja nepastāv."
+
+#~ msgid "No column for the specified column position existing."
+#~ msgstr "Norādītajai slejas pozīcijai atbilstoša sleja nepastāv."
+
+#~ msgid "Number of columns could not be determined."
+#~ msgstr "Sleju skaits nav nosakāms."
+
+#~ msgid "OpenGL function \"%s\" failed: %s (error %d)"
+#~ msgstr "OpenGL funkcija \"%s\" nav izpildīta: %s (kļūda %d)"
+
+#~ msgid ""
+#~ "Please install a newer version of comctl32.dll\n"
+#~ "(at least version 4.70 is required but you have %d.%02d)\n"
+#~ "or this program won't operate correctly."
+#~ msgstr ""
+#~ "Lūdzu uzstādiet jaunāku comctl32.dll versiju\n"
+#~ "(ir nepieciešama vismaz 4.70, taču jums ir uzstādīta  %d.%02d)\n"
+#~ "vai arī šī programma nedarbosies korekti."
+
+#~ msgid ""
+#~ "Setting directory access times is not supported under this OS version"
+#~ msgstr "Mapju pieejas laika iestatīšana nav atbalstīta šajā OS versijā"
+
+#~ msgid "Show hidden directories"
+#~ msgstr "Rādīt slēptās mapes"
+
+#~ msgid ""
+#~ "This system doesn't support date controls, please upgrade your version of "
+#~ "comctl32.dll"
+#~ msgstr ""
+#~ "Sistēma neuztur datumu vadīklas, lūdzu atsvaidziniet comctl32.dll versiju"
+
+#~ msgid "Too many colours in PNG, the image may be slightly blurred."
+#~ msgstr "PNG attēlā ir pārāk daudz krāsu, attēls var būt nedaudz izplūdis."
+
+#~ msgid "Unable to initialize Hildon program"
+#~ msgstr "Neizdevās palaist Hildon programmu."
+
+#~ msgid "Unknown data format"
+#~ msgstr "Nezināms datu formāts"
+
+#~ msgid "Win32s on Windows 3.1"
+#~ msgstr "Win32s uz Windows 3.1"
+
+#, fuzzy
+#~ msgid "Windows 10"
+#~ msgstr "Windows 98"
+
+#~ msgid "Windows 2000"
+#~ msgstr "Windows 2000"
+
+#~ msgid "Windows 7"
+#~ msgstr "Windows 7"
+
+#, fuzzy
+#~ msgid "Windows 8"
+#~ msgstr "Windows 98"
+
+#, fuzzy
+#~ msgid "Windows 8.1"
+#~ msgstr "Windows 98"
+
+#~ msgid "Windows 95"
+#~ msgstr "Windows 95"
+
+#~ msgid "Windows 95 OSR2"
+#~ msgstr "Windows 95 OSR2"
+
+#~ msgid "Windows 98"
+#~ msgstr "Windows 98"
+
+#~ msgid "Windows 98 SE"
+#~ msgstr "Windows 98 SE"
+
+#~ msgid "Windows 9x (%d.%d)"
+#~ msgstr "Windows 9x (%d.%d)"
+
+#~ msgid "Windows CE (%d.%d)"
+#~ msgstr "Windows CE (%d.%d)"
+
+#~ msgid "Windows ME"
+#~ msgstr "Windows ME"
+
+#~ msgid "Windows NT %lu.%lu"
+#~ msgstr "Windows NT %lu.%lu"
+
+#, fuzzy
+#~ msgid "Windows Server 10"
+#~ msgstr "Windows Server 2003"
+
+#~ msgid "Windows Server 2003"
+#~ msgstr "Windows Server 2003"
+
+#~ msgid "Windows Server 2008"
+#~ msgstr "Windows Server 2008"
+
+#~ msgid "Windows Server 2008 R2"
+#~ msgstr "Windows Server 2008 R2"
+
+#, fuzzy
+#~ msgid "Windows Server 2012"
+#~ msgstr "Windows Server 2003"
+
+#, fuzzy
+#~ msgid "Windows Server 2012 R2"
+#~ msgstr "Windows Server 2008 R2"
+
+#~ msgid "Windows Vista"
+#~ msgstr "Windows Vista"
+
+#~ msgid "Windows XP"
+#~ msgstr "Windows XP"
+
+#~ msgid "can't execute '%s'"
+#~ msgstr "nevar izpildīt '%s'"
+
+#~ msgid "error opening '%s'"
+#~ msgstr "kļūda atverot '%s'"
+
+#~ msgid "unknown seek origin"
+#~ msgstr "nezināms pozicionēšanas avots"
+
+#~ msgid "wxWidget's control not initialized."
+#~ msgstr "wxWidget's vadīkla nav inicializēta."
+
+#~ msgid "ADD"
+#~ msgstr "PIEV"
+
+#~ msgid "BACK"
+#~ msgstr "ATPAKAĻ"
+
+#~ msgid "CANCEL"
+#~ msgstr "ATCELT"
+
+#~ msgid "CAPITAL"
+#~ msgstr "CAPITAL"
+
+#~ msgid "CLEAR"
+#~ msgstr "Notīrīt"
+
+#~ msgid "COMMAND"
+#~ msgstr "KOMANDA"
+
+#~ msgid "Cannot resume thread %lu"
+#~ msgstr "Nav iespējams atsākt pavedienu %lu"
+
+#~ msgid "Cannot suspend thread %lu"
+#~ msgstr "Nav iespējams apturēt pavedienu %lu"
+
+#~ msgid "DECIMAL"
+#~ msgstr "DECIMĀLS"
+
+#~ msgid "DEL"
+#~ msgstr "DEL"
+
+#~ msgid "DELETE"
+#~ msgstr "DZĒST"
+
+#~ msgid "DIVIDE"
+#~ msgstr "DALĪT"
+
+#~ msgid "DOWN"
+#~ msgstr "Lejup"
+
+#~ msgid "END"
+#~ msgstr "BEIGAS"
+
+#~ msgid "ENTER"
+#~ msgstr "ENTER"
+
+#~ msgid "ESC"
+#~ msgstr "ESC"
+
+#~ msgid "ESCAPE"
+#~ msgstr "ESCAPE"
+
+#~ msgid "EXECUTE"
+#~ msgstr "IZPILDĪT"
+
+#~ msgid "Execution of command '%s' failed with error: %ul"
+#~ msgstr "Komandas '%s' izpilde beidzās ar kļūdu: %ul"
+
+#~ msgid ""
+#~ "File '%s' already exists.\n"
+#~ "Do you want to replace it?"
+#~ msgstr ""
+#~ "Fails '%s' jau eksistē.\n"
+#~ "Vai vēlaties to aizstāt?"
+
+#~ msgid "HELP"
+#~ msgstr "Palīdzība"
+
+#~ msgid "HOME"
+#~ msgstr "Mājas"
+
+#~ msgid "INS"
+#~ msgstr "IEV"
+
+#~ msgid "INSERT"
+#~ msgstr "IEVIETOT"
+
+#~ msgid "KP_BEGIN"
+#~ msgstr "KP_BEGIN"
+
+#~ msgid "KP_DECIMAL"
+#~ msgstr "KP_DECIMAL"
+
+#~ msgid "KP_DELETE"
+#~ msgstr "KP_DELETE"
+
+#~ msgid "KP_DIVIDE"
+#~ msgstr "KP_DIVIDE"
+
+#~ msgid "KP_DOWN"
+#~ msgstr "KP_DOWN"
+
+#~ msgid "KP_ENTER"
+#~ msgstr "KP_ENTER"
+
+#~ msgid "KP_EQUAL"
+#~ msgstr "KP_EQUAL"
+
+#~ msgid "KP_HOME"
+#~ msgstr "KP_HOME"
+
+#~ msgid "KP_INSERT"
+#~ msgstr "KP_INSERT"
+
+#~ msgid "KP_LEFT"
+#~ msgstr "KP_LEFT"
+
+#~ msgid "KP_MULTIPLY"
+#~ msgstr "KP_MULTIPLY"
+
+#~ msgid "KP_NEXT"
+#~ msgstr "KP_NEXT"
+
+#~ msgid "KP_PAGEDOWN"
+#~ msgstr "KP_PAGEDOWN"
+
+#~ msgid "KP_PAGEUP"
+#~ msgstr "KP_PAGEUP"
+
+#~ msgid "KP_PRIOR"
+#~ msgstr "KP_PRIOR"
+
+#~ msgid "KP_RIGHT"
+#~ msgstr "KP_RIGHT"
+
+#~ msgid "KP_SEPARATOR"
+#~ msgstr "KP_SEPARATOR"
+
+#~ msgid "KP_SPACE"
+#~ msgstr "KP_SPACE"
+
+#~ msgid "KP_SUBTRACT"
+#~ msgstr "KP_SUBTRACT"
+
+#~ msgid "LEFT"
+#~ msgstr "Pa kreisi"
+
+#~ msgid "MENU"
+#~ msgstr "Izvēlne"
+
+#~ msgid "NUM_LOCK"
+#~ msgstr "Num_Lock"
+
+#~ msgid "PAGEDOWN"
+#~ msgstr "PAGEDOWN"
+
+#~ msgid "PAGEUP"
+#~ msgstr "PAGEUP"
+
+#~ msgid "PAUSE"
+#~ msgstr "Pause"
+
+#~ msgid "PGDN"
+#~ msgstr "PGDN"
+
+#~ msgid "PGUP"
+#~ msgstr "PGUP"
+
+#~ msgid "PRINT"
+#~ msgstr "Drukāt"
+
+#~ msgid "RETURN"
+#~ msgstr "RETURN"
+
+#~ msgid "RIGHT"
+#~ msgstr "Pa labi"
+
+#~ msgid "SCROLL_LOCK"
+#~ msgstr "SCROLL_LOCK"
+
+#~ msgid "SELECT"
+#~ msgstr "Atlasīt "
+
+#~ msgid "SEPARATOR"
+#~ msgstr "ATDALĪTĀJS"
+
+#~ msgid "SNAPSHOT"
+#~ msgstr "Momentuzņēmums"
+
+#~ msgid "SPACE"
+#~ msgstr "Atstarpe"
+
+#~ msgid "SUBTRACT"
+#~ msgstr "Atņemt"
+
+#~ msgid "TAB"
+#~ msgstr "TAB"
+
+#~ msgid "The print dialog returned an error."
+#~ msgstr "Drukāšanas dialogs atbildēja ar kļūdu."
+
+#~ msgid "The wxGtkPrinterDC cannot be used."
+#~ msgstr "xwGtkPrinterDC nav izmantojams."
+
+#~ msgid "UP"
+#~ msgstr "Augšup"
+
+#~ msgid "WINDOWS_LEFT"
+#~ msgstr "WINDOWS_LEFT"
+
+#~ msgid "WINDOWS_MENU"
+#~ msgstr "WINDOWS_MENU"
+
+#~ msgid "WINDOWS_RIGHT"
+#~ msgstr "WINDOWS_RIGHT"
+
+#~ msgid "buffer is too small for Windows directory."
+#~ msgstr "buferis ir pārāk mazs Windows mapei."
+
+#~ msgid "not implemented"
+#~ msgstr "nav realizēts"
+
+#~ msgid "Event queue overflowed"
+#~ msgstr "Notikumu rinda pārpildīta"
+
+#~ msgid "percent"
+#~ msgstr "procenti"
+
+#~ msgid "Print preview"
+#~ msgstr "Drukas priekšskatījums"
+
+#~ msgid "'"
+#~ msgstr "'"
+
+#~ msgid "&Preview..."
+#~ msgstr "&Priekšskatījums..."
+
+#~ msgid "1"
+#~ msgstr "1"
+
+#~ msgid "10"
+#~ msgstr "10"
+
+#~ msgid "3"
+#~ msgstr "3"
+
+#~ msgid "4"
+#~ msgstr "4"
+
+#~ msgid "5"
+#~ msgstr "5"
+
+#~ msgid "6"
+#~ msgstr "6"
+
+#~ msgid "7"
+#~ msgstr "7"
+
+#~ msgid "8"
+#~ msgstr "8"
+
+#~ msgid "9"
+#~ msgstr "9"
+
+#~ msgid "Can't monitor non-existent path \"%s\" for changes."
+#~ msgstr "Nav iespējams sekot izmaiņām neesoša ceļā \"%s\"."
+
+#~ msgid "Preview..."
+#~ msgstr "Priekšskatījums..."
+
+#~ msgid "The vertical offset relative to the paragraph."
+#~ msgstr "Vertikālā nobīde attiecībā pret rindkopu."
+
+#~ msgid "Units for the object offset."
+#~ msgstr "Vienības objekta nobīdei."
+
+#~ msgid " Couldn't create the UnicodeConverter"
+#~ msgstr " Nevarēja izveidot UnicodeConverter"
+
+#~ msgid "#define %s must be an integer."
+#~ msgstr "#define %s ir jābūt skaitlim."
+
+#~ msgid "%.*f GB"
+#~ msgstr "%.*f GB"
+
+#~ msgid "%.*f MB"
+#~ msgstr "%.*f MB"
+
+#~ msgid "%.*f TB"
+#~ msgstr "%.*f TB"
+
+#~ msgid "%.*f kB"
+#~ msgstr "%.*f kB"
+
+#~ msgid "%s B"
+#~ msgstr "%s B"
+
+#~ msgid "%s not a bitmap resource specification."
+#~ msgstr "%s nav bitkartes resursa specifikācijas."
+
+#~ msgid "%s not an icon resource specification."
+#~ msgstr "%s nav ikonas resursa specifikācijas."
+
+#~ msgid "%s: ill-formed resource file syntax."
+#~ msgstr "%s: kļūdaina resursu faila sintakse."
+
+#~ msgid "&Goto..."
+#~ msgstr "&Iet uz..."
+
+#~ msgid "&Open"
+#~ msgstr "&Atvērt"
+
+#~ msgid "&Print"
+#~ msgstr "&Drukāt"
+
+#~ msgid "&Save..."
+#~ msgstr "&Saglabāt..."
+
+#~ msgid ""
+#~ ", expected static, #include or #define\n"
+#~ "while parsing resource."
+#~ msgstr ""
+#~ ", gaidīts static, #include vai #define\n"
+#~ "analizējot resursu."
+
+#~ msgid "<<"
+#~ msgstr "<<"
+
+#~ msgid ">>"
+#~ msgstr ">>"
+
+#~ msgid ">>|"
+#~ msgstr ">>|"
+
+#~ msgid "All files (*.*)|*"
+#~ msgstr "Visus failus (*.*)|*"
+
+#~ msgid "Alt-"
+#~ msgstr "Alt-"
+
+#~ msgid "Archive doesnt contain #SYSTEM file"
+#~ msgstr "Arhīvs nesatur #SYSTEM failu"
+
+#~ msgid "BIG5"
+#~ msgstr "BIG5"
+
+#~ msgid "Bitmap resource specification %s not found."
+#~ msgstr "Bitkartes resursa specifikācija %s nav atrasta."
+
+#~ msgid "Can't check image format of file '%s': file does not exist."
+#~ msgstr "Nav iespējams pārbaudīt faila '%s' attēla formātu: fails nepastāv."
+
+#~ msgid "Can't load image from file '%s': file does not exist."
+#~ msgstr "Nevar ielādēt attēlu no faila '%s': fails neeksistē."
+
+#~ msgid "Cannot convert dialog units: dialog unknown."
+#~ msgstr "Nav iespējams pārvērst dialoga vienības: nezināms dialogs."
+
+#~ msgid "Cannot convert from the charset '%s'!"
+#~ msgstr "Nav iespējams pārvērst no kodējuma '%s'!"
+
+#, fuzzy
+#~ msgid "Cannot find font node '%s'."
+#~ msgstr "Nevar atrast fontu %1, fails %2."
+
+#~ msgid "Cannot initialize SciTech MGL!"
+#~ msgstr "Nav iespējams inicializēt SciTech MGL!"
+
+#~ msgid "Cannot initialize display."
+#~ msgstr "Nevar atvērt ekrānu."
+
+#~ msgid "Cannot open file '%s'."
+#~ msgstr "Nevar atvērt failu '%s'."
+
+#, fuzzy
+#~ msgid "Cannot parse coordinates from '%s'."
+#~ msgstr "Nevar tulkot %s uz %s"
+
+#, fuzzy
+#~ msgid "Cannot parse dimension from '%s'."
+#~ msgstr "Nevar tulkot %s uz %s"
+
+#~ msgid "Click to cancel this window."
+#~ msgstr "Nospiediet, lai atceltu šo logu."
+
+#~ msgid "Click to confirm your selection."
+#~ msgstr "Nospiediet, lai apstiprinātu Jūsu izvēli."
+
+#~ msgid "Close\tAlt-F4"
+#~ msgstr "Aizvērt\tAlt-F4"
+
+#~ msgid "Closes the dialog without inserting a symbol."
+#~ msgstr "Aizver dialogu, neievietojot simbolu."
+
+#, fuzzy
+#~ msgid "Could not unlock mutex"
+#~ msgstr "Nevarēja atvērt konsoli.\n"
+
+#~ msgid "Directory '%s' doesn't exist!"
+#~ msgstr "Mape '%s' nepastāv!"
+
+#, fuzzy
+#~ msgid "Expected '*' while parsing resource."
+#~ msgstr "Kļūda, analizējot argumentus: %s\n"
+
+#, fuzzy
+#~ msgid "Expected '=' while parsing resource."
+#~ msgstr "Kļūda, analizējot argumentus: %s\n"
+
+#, fuzzy
+#~ msgid "Failed to %s dialup connection: %s"
+#~ msgstr "ftpfs: savienojums ar serveri neizdevās: %s"
+
+#~ msgid ""
+#~ "Failed to find XBM resource %s.\n"
+#~ "Forgot to use wxResourceLoadBitmapData?"
+#~ msgstr ""
+#~ "Neizdevās atrast XBM resursu %s.\n"
+#~ "Aizmirsāt izmantot wxResourceLoadBitmapData?"
+
+#~ msgid ""
+#~ "Failed to find XBM resource %s.\n"
+#~ "Forgot to use wxResourceLoadIconData?"
+#~ msgstr ""
+#~ "Neizdevās atrast XBM resursu %s.\n"
+#~ "Aizmirsāt izmantot wxResourceLoadIconData?"
+
+#~ msgid ""
+#~ "Failed to find XPM resource %s.\n"
+#~ "Forgot to use wxResourceLoadBitmapData?"
+#~ msgstr ""
+#~ "Neizdevās atrast XBM resursu %s.\n"
+#~ "Aizmirsāt izmantot wxResourceLoadBitmapData?"
+
+#~ msgid "Failed to get clipboard data."
+#~ msgstr "Neizdevās iegūt starpliktuves datus."
+
+#~ msgid "Failed to load shared library '%s' Error '%s'"
+#~ msgstr "Neizdevās ielādēt koplietojamo bibliotēku '%s' Kļūda '%s'"
+
+#~ msgid "Failed to register OpenGL window class."
+#~ msgstr "Neizdevās reģistrēt OpenGL loga klasi."
+
+#~ msgid "Fatal error: "
+#~ msgstr "Fatāla kļūda: "
+
+#~ msgid "Found "
+#~ msgstr "Atrasts"
+
+#~ msgid "GB-2312"
+#~ msgstr "GB-2312"
+
+#~ msgid "Goto Page"
+#~ msgstr "Iet uz Lapu"
+
+#~ msgid ""
+#~ "HTML pagination algorithm generated more than the allowed maximum number "
+#~ "of pages and it can't continue any longer!"
+#~ msgstr ""
+#~ "HTML lapdales algoritms ir izveidojis vairāk lappušu, nekā pieļaujams un "
+#~ "tādēļ tas nevar turpināt darbu!"
+
+#~ msgid "I64"
+#~ msgstr "I64"
+
+#~ msgid "Icon resource specification %s not found."
+#~ msgstr "Ikonas resursu specifikācija %s nav atrasta."
+
+#~ msgid "Ill-formed resource file syntax."
+#~ msgstr "Kļūdaina resursu faila sintakse."
+
+#~ msgid "Inserts the chosen symbol."
+#~ msgstr "Ievieto izvēlēto simbolu."
+
+#~ msgid "Internal error, illegal wxCustomTypeInfo"
+#~ msgstr "Iekšēja kļūda: nederīga wxCustomTypeInfo"
+
+#, fuzzy
+#~ msgid "Long Conversions not supported"
+#~ msgstr "Failu augšuieplāde nav atbalstīta."
+
+#~ msgid "Mode %ix%i-%i not available."
+#~ msgstr "Režīms %ix%i-%i nav pieejams."
+
+#~ msgid "Option '%s' requires a value, '=' expected."
+#~ msgstr "Iestatījumam '%s' ir nepieciešama vērtība, tik sagaidīta zīme '='."
+
+#~ msgid "Paper Size"
+#~ msgstr "Papīra izmērs"
+
+#~ msgid "Program aborted."
+#~ msgstr "Programmas izpilde pārtraukta."
+
+#~ msgid "SHIFT-JIS"
+#~ msgstr "SHIFT-JIS"
+
+#~ msgid "Select a file"
+#~ msgstr "Izvēlieties failu"
+
+#~ msgid "Select all"
+#~ msgstr "Iezīmēt visu"
+
+#~ msgid "Sorry, could not open this file for saving."
+#~ msgstr "Diemžēl, šis fails nav atverams saglabāšanai."
+
+#~ msgid "Sorry, could not save this file."
+#~ msgstr "Diemžēl, šo failu saglabāt nav iespējams."
+
+#~ msgid "Sorry, print preview needs a printer to be installed."
+#~ msgstr ""
+#~ "Diemžēl, lai izveidotu drukas priekšskatījumu, ir jābūt uzstādītai drukas "
+#~ "iekārtai."
+
+#~ msgid "Status: "
+#~ msgstr "Statuss: "
+
+#~ msgid "TIFF library error."
+#~ msgstr "TIFF bibliotēkas kļūda."
+
+#~ msgid "TIFF library warning."
+#~ msgstr "TIFF bibliotēkas brīdinājums."
+
+#~ msgid ""
+#~ "The file '%s' couldn't be opened.\n"
+#~ "It has been removed from the most recently used files list."
+#~ msgstr ""
+#~ "Failu '%s' nav iespējams atvērt.\n"
+#~ "Tas ir izņemts no nesen lietoto failu saraksta."
+
+#~ msgid "The path '%s' contains too many \"..\"!"
+#~ msgstr "Ceļš '%s' satur pārāk daudz \"..\"!"
+
+#~ msgid "Unknown style flag "
+#~ msgstr "Nezināms stila karogs"
+
+#~ msgid "Version %s"
+#~ msgstr "Versija %s"
+
+#~ msgid "Video Output"
+#~ msgstr "Video izvade"
+
+#~ msgid "Warning"
+#~ msgstr "Brīdinājums"
+
+#~ msgid "Windows 2000 (build %lu"
+#~ msgstr "Windows 2000 (build %lu"
+
+#~ msgid "XRC resource '%s' (class '%s') not found!"
+#~ msgstr "XRC resurss '%s' (klase '%s') nav atrasts!"
+
+#~ msgid "XRC resource: Cannot create animation from '%s'."
+#~ msgstr "XRC resurss: nav iespējams izveidot animāciju no '%s'."
+
+#~ msgid "XRC resource: Cannot create bitmap from '%s'."
+#~ msgstr "XRC resurss: nav iespējams izveidot bitkarti no '%s'."
+
+#~ msgid "XRC resource: Incorrect colour specification '%s' for property '%s'."
+#~ msgstr "XRC resurss: kļūdaina krāsas specifikācija '%s' īpašībai '%s'."
+
+#~ msgid "[EMPTY]"
+#~ msgstr "[TUKŠS]"
+
+#~ msgid "catalog file for domain '%s' not found."
+#~ msgstr "kataloga fails domēnam '%s' nav atrasts."
+
+#, fuzzy
+#~ msgid "delegate has no type info"
+#~ msgstr "Darbvirsmas elementa failam %1 nav tipa (Type=...) ieraksta."
+
+#~ msgid "encoding %i"
+#~ msgstr "kodējums %i"
+
+#, fuzzy
+#~ msgid "establish"
+#~ msgstr "Izveido tīkla savienojumu"
+
+#, fuzzy
+#~ msgid "initiate"
+#~ msgstr "Nevar inicializēt %1 protokolu"
+
+#, fuzzy
+#~ msgid "invalid eof() return value."
+#~ msgstr "Nederīga atgrieztā vērtība no %s"
+
+#~ msgid "unknown line terminator"
+#~ msgstr "nezināms rindas noslēgums"
+
+#~ msgid "writing"
+#~ msgstr "raksta"
+
+#~ msgid "wxRichTextBulletsPage"
+#~ msgstr "wxRichTextBulletsPage"
+
+#~ msgid "wxRichTextFontPage"
+#~ msgstr "wxRichTextFontPage"
+
+#~ msgid "wxRichTextListStylePage"
+#~ msgstr "wxRichTextListStylePage"
+
+#~ msgid "wxRichTextStylePage"
+#~ msgstr "wxRichTextStylePage"
+
+#~ msgid "wxSocket: invalid signature in ReadMsg."
+#~ msgstr "wxSocket: nederīgs paraksts ReadMsg."
+
+#~ msgid "wxSocket: unknown event!."
+#~ msgstr "wxSocket: nezināms notikums!"
+
+#~ msgid "|<<"
+#~ msgstr "|<<"
+
+#, fuzzy
+#~ msgid "*** It can be found in \"%s\"\n"
+#~ msgstr "*** To var atrast \"%s\"\n"
+
+#, fuzzy
+#~ msgid "Help : %s"
+#~ msgstr "Palīdzība"
+
+#, fuzzy
+#~ msgid "Search!"
+#~ msgstr "Meklēt"
+
+#~ msgid "."
+#~ msgstr "."
+
+#~ msgid "Error "
+#~ msgstr "Kļūda "

--- a/po_wxstd/ms.po
+++ b/po_wxstd/ms.po
@@ -1,0 +1,10753 @@
+# Malay translation of wxstd.po
+# Copyright (C) 2006 wxWidgets dev-team
+# This file is distributed under the same license as the wxWidgets package.
+# Mahrazi Mohd Kamal <mahrazi@gmail.com>, 2006.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: wxWidgets 3.3\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-05-14 20:23+0200\n"
+"PO-Revision-Date: 2006-11-06 10:48+0800\n"
+"Last-Translator: Mahrazi Mohd Kamal <mahrazi@gmail.com>\n"
+"Language-Team: ms_MY <ms@li.org>\n"
+"Language: ms\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Poedit-Language: Malay\n"
+"X-Poedit-Country: MALAYSIA\n"
+
+#: ../include/wx/defs.h:2582
+msgid "All files (*.*)|*.*"
+msgstr "Semua fail (*.*)|*.*"
+
+#: ../include/wx/defs.h:2585
+msgid "All files (*)|*"
+msgstr "Semua fail (*)|*"
+
+#: ../include/wx/generic/progdlgg.h:85
+#, fuzzy
+msgid "Elapsed time:"
+msgstr "Masa berlalu : "
+
+#: ../include/wx/generic/progdlgg.h:86
+#, fuzzy
+msgid "Estimated time:"
+msgstr "Masa anggaran : "
+
+#: ../include/wx/generic/progdlgg.h:87
+#, fuzzy
+msgid "Remaining time:"
+msgstr "Masa yang tinggal :"
+
+#. TRANSLATORS: HTML printout default title.
+#: ../include/wx/html/htmprint.h:121 ../include/wx/prntbase.h:273
+#: ../include/wx/richtext/richtextprint.h:109 ../src/common/docview.cpp:2161
+#, fuzzy
+msgid "Printout"
+msgstr "Cetak"
+
+#. TRANSLATORS: HTML easy print default title.
+#: ../include/wx/html/htmprint.h:234 ../include/wx/richtext/richtextprint.h:163
+#: ../src/common/prntbase.cpp:522 ../src/html/htmprint.cpp:291
+#, fuzzy
+msgid "Printing"
+msgstr "Mencetak "
+
+#: ../include/wx/msgdlg.h:277 ../src/common/stockitem.cpp:211
+msgid "Yes"
+msgstr "Ya"
+
+#: ../include/wx/msgdlg.h:278 ../src/common/stockitem.cpp:182
+msgid "No"
+msgstr "Tidak"
+
+#: ../include/wx/msgdlg.h:279 ../src/common/stockitem.cpp:183
+#: ../src/msw/msgdlg.cpp:430 ../src/msw/msgdlg.cpp:734
+#: ../src/richtext/richtextstyledlg.cpp:292
+msgid "OK"
+msgstr "OK"
+
+#: ../include/wx/msgdlg.h:280 ../src/common/stockitem.cpp:150
+#: ../src/msw/msgdlg.cpp:430 ../src/msw/progdlg.cpp:884
+#: ../src/richtext/richtextstyledlg.cpp:295
+msgid "Cancel"
+msgstr "Batal"
+
+#: ../include/wx/msgdlg.h:281 ../src/common/stockitem.cpp:168
+#: ../src/html/helpdlg.cpp:63 ../src/html/helpfrm.cpp:108
+#: ../src/osx/button_osx.cpp:38
+msgid "Help"
+msgstr "Bantuan"
+
+#: ../include/wx/msw/ole/oleutils.h:52
+msgid "Cannot initialize OLE"
+msgstr "Gagal mulakan OLE"
+
+#: ../include/wx/msw/private/fswatcher.h:48
+#, fuzzy, c-format
+msgid "Unable to close the handle for '%s'"
+msgstr "Gagal tutup pengemudi fail"
+
+#: ../include/wx/msw/private/fswatcher.h:92
+#, fuzzy, c-format
+msgid "Failed to open directory \"%s\" for monitoring."
+msgstr "Gagal buka '%s' untuk %s"
+
+#: ../include/wx/msw/private/fswatcher.h:125
+#, fuzzy
+msgid "Unable to close I/O completion port handle"
+msgstr "Gagal tutup pengemudi fail"
+
+#: ../include/wx/msw/private/fswatcher.h:142
+msgid "Unable to associate handle with I/O completion port"
+msgstr ""
+
+#: ../include/wx/msw/private/fswatcher.h:148
+msgid "Unexpectedly new I/O completion port was created"
+msgstr ""
+
+#: ../include/wx/msw/private/fswatcher.h:213
+msgid "Unable to post completion status"
+msgstr ""
+
+#: ../include/wx/msw/private/fswatcher.h:262
+msgid "Unable to dequeue completion packet"
+msgstr ""
+
+#: ../include/wx/msw/private/fswatcher.h:273
+#, fuzzy
+msgid "Unable to create I/O completion port"
+msgstr "Gagal cipta TextEncodingConverter"
+
+#: ../include/wx/richmsgdlg.h:29
+#, fuzzy
+msgid "&See details"
+msgstr "&Terperinci"
+
+#: ../include/wx/richmsgdlg.h:30
+#, fuzzy
+msgid "&Hide details"
+msgstr "&Terperinci"
+
+#: ../include/wx/richtext/richtextbuffer.h:3864
+#, fuzzy
+msgid "&Box"
+msgstr "Te&bal"
+
+#: ../include/wx/richtext/richtextbuffer.h:5008
+msgid "&Picture"
+msgstr ""
+
+#: ../include/wx/richtext/richtextbuffer.h:5958
+#, fuzzy
+msgid "&Cell"
+msgstr "&Batal"
+
+#: ../include/wx/richtext/richtextbuffer.h:6067
+#, fuzzy
+msgid "&Table"
+msgstr "Tab"
+
+#: ../include/wx/richtext/richtextimagedlg.h:37
+#, fuzzy
+msgid "Object Properties"
+msgstr "&Ciri-ciri"
+
+#: ../include/wx/richtext/richtextsymboldlg.h:39
+msgid "Symbols"
+msgstr "Simbol"
+
+#: ../include/wx/unix/pipe.h:46
+msgid "Pipe creation failed"
+msgstr "Gagal mencipta paip"
+
+#: ../include/wx/unix/private/displayx11.h:65
+msgid "Failed to enumerate video modes"
+msgstr "Gagal menghitung mod video"
+
+#: ../include/wx/unix/private/displayx11.h:89
+msgid "Failed to change video mode"
+msgstr "Klik menukar mod video"
+
+#: ../include/wx/unix/private/fswatcher_kqueue.h:57
+#, fuzzy, c-format
+msgid "Unable to open path '%s'"
+msgstr "Gagal membuka arkib sementara '%s'."
+
+#: ../include/wx/unix/private/fswatcher_kqueue.h:74
+#, fuzzy, c-format
+msgid "Unable to close path '%s'"
+msgstr "Gagal menutup fail kunci '%s'"
+
+#: ../include/wx/xtiprop.h:175
+msgid "SetProperty called w/o valid setter"
+msgstr "SetProperty dipanggil tanpa setter sah"
+
+#: ../include/wx/xtiprop.h:184
+msgid "GetProperty called w/o valid getter"
+msgstr "GetProperty dipanggill tanpa getter sah"
+
+#: ../include/wx/xtiprop.h:193
+msgid "AddToPropertyCollection called w/o valid adder"
+msgstr "AddToPropertyCollection dipanggill tanpa penambah sah"
+
+#: ../include/wx/xtiprop.h:202
+msgid "GetPropertyCollection called w/o valid collection getter"
+msgstr "GetPropertyCollection dipangil tanpa getter koleksi"
+
+#: ../include/wx/xtiprop.h:255
+msgid "AddToPropertyCollection called on a generic accessor"
+msgstr "AddToPropertyCollection dipanggil pada generic accessor"
+
+#: ../include/wx/xtiprop.h:262
+msgid "GetPropertyCollection called on a generic accessor"
+msgstr "GetPropertyCollection dipanggil pada accessor umum"
+
+#: ../src/aui/tabmdi.cpp:106 ../src/generic/mdig.cpp:94
+msgid "Cl&ose"
+msgstr "Tutup"
+
+#: ../src/aui/tabmdi.cpp:107 ../src/generic/mdig.cpp:95
+msgid "Close All"
+msgstr "Tutup &Semua"
+
+#: ../src/aui/tabmdi.cpp:109 ../src/generic/mdig.cpp:97 ../src/msw/mdi.cpp:175
+#: ../src/qt/mdi.cpp:258
+msgid "&Next"
+msgstr "Seterus&nya"
+
+#: ../src/aui/tabmdi.cpp:110 ../src/generic/mdig.cpp:98 ../src/msw/mdi.cpp:176
+#: ../src/qt/mdi.cpp:259
+msgid "&Previous"
+msgstr "&Sebelum"
+
+#: ../src/aui/tabmdi.cpp:332 ../src/aui/tabmdi.cpp:348
+#: ../src/aui/tabmdi.cpp:350 ../src/generic/mdig.cpp:291
+#: ../src/generic/mdig.cpp:307 ../src/generic/mdig.cpp:311
+#: ../src/msw/mdi.cpp:337 ../src/qt/mdi.cpp:462
+msgid "&Window"
+msgstr "&Tetingkap"
+
+#: ../src/common/accelcmn.cpp:47
+msgctxt "keyboard key"
+msgid "Delete"
+msgstr "Padam"
+
+#: ../src/common/accelcmn.cpp:48
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Del"
+msgstr "Padam"
+
+#: ../src/common/accelcmn.cpp:49
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Back"
+msgstr "Kem&bali"
+
+#: ../src/common/accelcmn.cpp:49
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Backspace"
+msgstr "Kem&bali"
+
+#: ../src/common/accelcmn.cpp:50
+msgctxt "keyboard key"
+msgid "Insert"
+msgstr "Selit"
+
+#: ../src/common/accelcmn.cpp:51
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Ins"
+msgstr "Selit"
+
+#: ../src/common/accelcmn.cpp:52
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Enter"
+msgstr "Pencetak"
+
+#: ../src/common/accelcmn.cpp:53
+msgctxt "keyboard key"
+msgid "Return"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:54
+#, fuzzy
+msgctxt "keyboard key"
+msgid "PageUp"
+msgstr "Laman"
+
+#: ../src/common/accelcmn.cpp:54
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Page Up"
+msgstr "Laman %d"
+
+#: ../src/common/accelcmn.cpp:55
+#, fuzzy
+msgctxt "keyboard key"
+msgid "PageDown"
+msgstr "Turun"
+
+#: ../src/common/accelcmn.cpp:55
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Page Down"
+msgstr "Laman %d"
+
+#: ../src/common/accelcmn.cpp:56
+msgctxt "keyboard key"
+msgid "PgUp"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:57
+msgctxt "keyboard key"
+msgid "PgDn"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:58
+msgctxt "keyboard key"
+msgid "Left"
+msgstr "Kiri"
+
+#: ../src/common/accelcmn.cpp:59
+msgctxt "keyboard key"
+msgid "Right"
+msgstr "Kanan"
+
+#: ../src/common/accelcmn.cpp:60
+msgctxt "keyboard key"
+msgid "Up"
+msgstr "Naik"
+
+#: ../src/common/accelcmn.cpp:61
+msgctxt "keyboard key"
+msgid "Down"
+msgstr "Turun"
+
+#: ../src/common/accelcmn.cpp:62
+msgctxt "keyboard key"
+msgid "Home"
+msgstr "Rumah"
+
+#: ../src/common/accelcmn.cpp:63
+msgctxt "keyboard key"
+msgid "End"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:64
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Space"
+msgstr "Ruang"
+
+#: ../src/common/accelcmn.cpp:65
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Tab"
+msgstr "Tab"
+
+#: ../src/common/accelcmn.cpp:66
+msgctxt "keyboard key"
+msgid "Esc"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:67
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Escape"
+msgstr "Lanskap"
+
+#: ../src/common/accelcmn.cpp:68
+msgctxt "keyboard key"
+msgid "Cancel"
+msgstr "Batal"
+
+#: ../src/common/accelcmn.cpp:69
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Clear"
+msgstr "Kosongkan"
+
+#: ../src/common/accelcmn.cpp:70
+msgctxt "keyboard key"
+msgid "Menu"
+msgstr "Menu"
+
+#: ../src/common/accelcmn.cpp:71
+msgctxt "keyboard key"
+msgid "Pause"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:72
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Capital"
+msgstr "italik"
+
+#: ../src/common/accelcmn.cpp:73
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Select"
+msgstr "Pemilihan"
+
+#: ../src/common/accelcmn.cpp:74
+msgctxt "keyboard key"
+msgid "Print"
+msgstr "Cetak"
+
+#: ../src/common/accelcmn.cpp:75
+msgctxt "keyboard key"
+msgid "Execute"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:76
+msgctxt "keyboard key"
+msgid "Snapshot"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:77
+msgctxt "keyboard key"
+msgid "Help"
+msgstr "Bantuan"
+
+#: ../src/common/accelcmn.cpp:78
+msgctxt "keyboard key"
+msgid "Add"
+msgstr "Tambah"
+
+#: ../src/common/accelcmn.cpp:79
+msgctxt "keyboard key"
+msgid "Separator"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:80
+msgctxt "keyboard key"
+msgid "Subtract"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:81
+msgctxt "keyboard key"
+msgid "Decimal"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:82
+msgctxt "keyboard key"
+msgid "Multiply"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:83
+msgctxt "keyboard key"
+msgid "Divide"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:84
+msgctxt "keyboard key"
+msgid "Num_lock"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:84
+msgctxt "keyboard key"
+msgid "Num Lock"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:85
+msgctxt "keyboard key"
+msgid "Scroll_lock"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:85
+msgctxt "keyboard key"
+msgid "Scroll Lock"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:86
+msgctxt "keyboard key"
+msgid "KP_Space"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:86
+msgctxt "keyboard key"
+msgid "Num Space"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:87
+#, fuzzy
+msgctxt "keyboard key"
+msgid "KP_Tab"
+msgstr "KP_TAB"
+
+#: ../src/common/accelcmn.cpp:87
+msgctxt "keyboard key"
+msgid "Num Tab"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:88
+#, fuzzy
+msgctxt "keyboard key"
+msgid "KP_Enter"
+msgstr "Pencetak"
+
+#: ../src/common/accelcmn.cpp:88
+msgctxt "keyboard key"
+msgid "Num Enter"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:89
+#, fuzzy
+msgctxt "keyboard key"
+msgid "KP_Home"
+msgstr "Rumah"
+
+#: ../src/common/accelcmn.cpp:89
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Num Home"
+msgstr "Rumah"
+
+#: ../src/common/accelcmn.cpp:90
+#, fuzzy
+msgctxt "keyboard key"
+msgid "KP_Left"
+msgstr "Kiri"
+
+#: ../src/common/accelcmn.cpp:90
+msgctxt "keyboard key"
+msgid "Num left"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:91
+#, fuzzy
+msgctxt "keyboard key"
+msgid "KP_Up"
+msgstr "KP_UP"
+
+#: ../src/common/accelcmn.cpp:91
+msgctxt "keyboard key"
+msgid "Num Up"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:92
+#, fuzzy
+msgctxt "keyboard key"
+msgid "KP_Right"
+msgstr "Kanan"
+
+#: ../src/common/accelcmn.cpp:92
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Num Right"
+msgstr "Kanan"
+
+#: ../src/common/accelcmn.cpp:93
+#, fuzzy
+msgctxt "keyboard key"
+msgid "KP_Down"
+msgstr "Turun"
+
+#: ../src/common/accelcmn.cpp:93
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Num Down"
+msgstr "Turun"
+
+#: ../src/common/accelcmn.cpp:94
+msgctxt "keyboard key"
+msgid "KP_PageUp"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:94
+msgctxt "keyboard key"
+msgid "Num Page Up"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:95
+msgctxt "keyboard key"
+msgid "KP_PageDown"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:95
+msgctxt "keyboard key"
+msgid "Num Page Down"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:96
+msgctxt "keyboard key"
+msgid "KP_Prior"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:97
+#, fuzzy
+msgctxt "keyboard key"
+msgid "KP_Next"
+msgstr "Maju"
+
+#: ../src/common/accelcmn.cpp:98
+#, fuzzy
+msgctxt "keyboard key"
+msgid "KP_End"
+msgstr "KP_END"
+
+#: ../src/common/accelcmn.cpp:98
+msgctxt "keyboard key"
+msgid "Num End"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:99
+msgctxt "keyboard key"
+msgid "KP_Begin"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:99
+msgctxt "keyboard key"
+msgid "Num Begin"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:100
+#, fuzzy
+msgctxt "keyboard key"
+msgid "KP_Insert"
+msgstr "Selit"
+
+#: ../src/common/accelcmn.cpp:100
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Num Insert"
+msgstr "Selit"
+
+#: ../src/common/accelcmn.cpp:101
+#, fuzzy
+msgctxt "keyboard key"
+msgid "KP_Delete"
+msgstr "Padam"
+
+#: ../src/common/accelcmn.cpp:101
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Num Delete"
+msgstr "Padam"
+
+#: ../src/common/accelcmn.cpp:102
+msgctxt "keyboard key"
+msgid "KP_Equal"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:102
+msgctxt "keyboard key"
+msgid "Num ="
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:103
+msgctxt "keyboard key"
+msgid "KP_Multiply"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:103
+msgctxt "keyboard key"
+msgid "Num *"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:104
+#, fuzzy
+msgctxt "keyboard key"
+msgid "KP_Add"
+msgstr "KP_ADD"
+
+#: ../src/common/accelcmn.cpp:104
+msgctxt "keyboard key"
+msgid "Num +"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:105
+msgctxt "keyboard key"
+msgid "KP_Separator"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:105
+msgctxt "keyboard key"
+msgid "Num ,"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:106
+msgctxt "keyboard key"
+msgid "KP_Subtract"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:106
+msgctxt "keyboard key"
+msgid "Num -"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:107
+msgctxt "keyboard key"
+msgid "KP_Decimal"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:107
+msgctxt "keyboard key"
+msgid "Num ."
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:108
+msgctxt "keyboard key"
+msgid "KP_Divide"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:108
+msgctxt "keyboard key"
+msgid "Num /"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:109
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Windows_Left"
+msgstr "Windows 95"
+
+#: ../src/common/accelcmn.cpp:110
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Windows_Right"
+msgstr "Windows 95"
+
+#: ../src/common/accelcmn.cpp:111
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Windows_Menu"
+msgstr "Windows ME"
+
+#: ../src/common/accelcmn.cpp:112
+msgctxt "keyboard key"
+msgid "Command"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:186 ../src/common/accelcmn.cpp:359
+msgctxt "keyboard key"
+msgid "Ctrl"
+msgstr "Ctrl"
+
+#: ../src/common/accelcmn.cpp:188 ../src/common/accelcmn.cpp:363
+msgctxt "keyboard key"
+msgid "Alt"
+msgstr "Alt"
+
+#: ../src/common/accelcmn.cpp:190 ../src/common/accelcmn.cpp:361
+msgctxt "keyboard key"
+msgid "Shift"
+msgstr "Shif"
+
+#: ../src/common/accelcmn.cpp:196
+msgctxt "keyboard key"
+msgid "num "
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:260 ../src/common/accelcmn.cpp:382
+msgctxt "keyboard key"
+msgid "F"
+msgstr "F"
+
+#: ../src/common/accelcmn.cpp:277 ../src/common/accelcmn.cpp:385
+msgctxt "keyboard key"
+msgid "KP_F"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:280 ../src/common/accelcmn.cpp:388
+msgctxt "keyboard key"
+msgid "KP_"
+msgstr "KP_"
+
+#: ../src/common/accelcmn.cpp:283 ../src/common/accelcmn.cpp:391
+msgctxt "keyboard key"
+msgid "SPECIAL"
+msgstr "SPECIAL"
+
+#: ../src/common/accelcmn.cpp:373
+#, fuzzy
+msgid "Ctrl"
+msgstr "Ctrl"
+
+#: ../src/common/appbase.cpp:786
+msgid "show this help message"
+msgstr "tunjukkan mesej bantuan ini"
+
+#: ../src/common/appbase.cpp:796
+msgid "generate verbose log messages"
+msgstr "menjana mesej log meleret"
+
+#: ../src/common/appcmn.cpp:256
+msgid "specify the theme to use"
+msgstr "pastikan tema untuk diguna"
+
+#: ../src/common/appcmn.cpp:270
+msgid "specify display mode to use (e.g. 640x480-16)"
+msgstr "tentukan mod paparan untuk diguna (cth. 640x480-16)"
+
+#: ../src/common/appcmn.cpp:292
+#, c-format
+msgid "Unsupported theme '%s'."
+msgstr "Tema tidak disokong '%s'."
+
+#: ../src/common/appcmn.cpp:309
+#, c-format
+msgid "Invalid display mode specification '%s'."
+msgstr "Spesifikasi mod paparan '%s' tidak sah."
+
+#: ../src/common/cmdline.cpp:875
+#, fuzzy, c-format
+msgid "Option '%s' can't be negated"
+msgstr "Direktori '%s' gagal dicipta"
+
+#: ../src/common/cmdline.cpp:889
+#, c-format
+msgid "Unknown long option '%s'"
+msgstr "Pilihan panjang '%s' tidak diketahui"
+
+#: ../src/common/cmdline.cpp:904 ../src/common/cmdline.cpp:926
+#, c-format
+msgid "Unknown option '%s'"
+msgstr "Pilihan '%s' tidak diketahui"
+
+#: ../src/common/cmdline.cpp:1004
+#, c-format
+msgid "Unexpected characters following option '%s'."
+msgstr "Aksara mengikut pilihan '%s' tidak dijangka."
+
+#: ../src/common/cmdline.cpp:1039
+#, c-format
+msgid "Option '%s' requires a value."
+msgstr "Pilihan '%s' perlukan nilai."
+
+#: ../src/common/cmdline.cpp:1058
+#, c-format
+msgid "Separator expected after the option '%s'."
+msgstr "Pembahagi dijangka selepas pilihan '%s'."
+
+#: ../src/common/cmdline.cpp:1088 ../src/common/cmdline.cpp:1106
+#, c-format
+msgid "'%s' is not a correct numeric value for option '%s'."
+msgstr "'%s' bukanlah nilai nombor yang betul untul pilihan '%s'."
+
+#: ../src/common/cmdline.cpp:1122
+#, c-format
+msgid "Option '%s': '%s' cannot be converted to a date."
+msgstr "Pilihan '%s': '%s' gagal ditukar kepada tarikh."
+
+#: ../src/common/cmdline.cpp:1170
+#, c-format
+msgid "Unexpected parameter '%s'"
+msgstr "Parameter tidak dijangka '%s'"
+
+#. TRANSLATORS: Short name and long name for a command line option
+#: ../src/common/cmdline.cpp:1197
+#, c-format
+msgid "%s (or %s)"
+msgstr "%s (or %s)"
+
+#: ../src/common/cmdline.cpp:1208
+#, c-format
+msgid "The value for the option '%s' must be specified."
+msgstr "Nilai pilihan '%s' mesti ditentukan."
+
+#: ../src/common/cmdline.cpp:1230
+#, c-format
+msgid "The required parameter '%s' was not specified."
+msgstr "Parameter yang diperlukan '%s' tidak ditentukan."
+
+#: ../src/common/cmdline.cpp:1289
+#, c-format
+msgid "Usage: %s"
+msgstr "Penggunaan: %s"
+
+#: ../src/common/cmdline.cpp:1498
+msgid "str"
+msgstr "str"
+
+#: ../src/common/cmdline.cpp:1502
+msgid "num"
+msgstr "nom"
+
+#: ../src/common/cmdline.cpp:1506
+msgid "double"
+msgstr ""
+
+#: ../src/common/cmdline.cpp:1510
+msgid "date"
+msgstr "tarikh"
+
+#: ../src/common/cmdproc.cpp:250 ../src/common/cmdproc.cpp:276
+#: ../src/common/cmdproc.cpp:296
+msgid "Unnamed command"
+msgstr "Arahan tidak bernama"
+
+#: ../src/common/cmdproc.cpp:253
+msgid "&Undo "
+msgstr "&Nyahcara "
+
+#: ../src/common/cmdproc.cpp:255
+msgid "Can't &Undo "
+msgstr "Tidak Nyahcara "
+
+#: ../src/common/cmdproc.cpp:259 ../src/common/stockitem.cpp:208
+#: ../src/msw/textctrl.cpp:2880 ../src/osx/textctrl_osx.cpp:649
+#: ../src/richtext/richtextctrl.cpp:327
+msgid "&Undo"
+msgstr "&Nyahcara"
+
+#: ../src/common/cmdproc.cpp:277 ../src/common/cmdproc.cpp:297
+msgid "&Redo "
+msgstr "&Ulangcara "
+
+#: ../src/common/cmdproc.cpp:281 ../src/common/cmdproc.cpp:288
+#: ../src/common/stockitem.cpp:190 ../src/msw/textctrl.cpp:2881
+#: ../src/osx/textctrl_osx.cpp:650 ../src/richtext/richtextctrl.cpp:328
+msgid "&Redo"
+msgstr "&Ulangcara"
+
+#: ../src/common/colourcmn.cpp:41
+#, c-format
+msgid "String To Colour : Incorrect colour specification : %s"
+msgstr "Rentetan Kepada Warna : Spesifikasi warna salah : %s"
+
+#: ../src/common/config.cpp:259
+#, c-format
+msgid "Invalid value %ld for a boolean key \"%s\" in config file."
+msgstr ""
+
+#: ../src/common/config.cpp:526
+#, c-format
+msgid ""
+"Environment variables expansion failed: missing '%c' at position %u in '%s'."
+msgstr ""
+"Perluasan pembolehubah persekitaran gagal: hilang '%c' pada posisi %u dalam "
+"'%s'."
+
+#: ../src/common/config.cpp:576 ../src/msw/regconf.cpp:272
+#, c-format
+msgid "'%s' has extra '..', ignored."
+msgstr "'%s' ada lebihan '..', diabaikan."
+
+#. TRANSLATORS: Checkbox state name
+#: ../src/common/datavcmn.cpp:2166 ../src/generic/datavgen.cpp:1430
+msgid "checked"
+msgstr ""
+
+#. TRANSLATORS: Checkbox state name
+#: ../src/common/datavcmn.cpp:2170 ../src/generic/datavgen.cpp:1432
+msgid "unchecked"
+msgstr ""
+
+#. TRANSLATORS: Checkbox state name
+#: ../src/common/datavcmn.cpp:2174
+#, fuzzy
+msgid "undetermined"
+msgstr "digaris bawahkan"
+
+#: ../src/common/datetimefmt.cpp:1875
+msgid "today"
+msgstr "hari ini"
+
+#: ../src/common/datetimefmt.cpp:1876
+msgid "yesterday"
+msgstr "semalam"
+
+#: ../src/common/datetimefmt.cpp:1877
+msgid "tomorrow"
+msgstr "esok"
+
+#: ../src/common/datetimefmt.cpp:2071
+msgid "first"
+msgstr "pertama"
+
+#: ../src/common/datetimefmt.cpp:2072
+msgid "second"
+msgstr "kedua"
+
+#: ../src/common/datetimefmt.cpp:2073
+msgid "third"
+msgstr "ketiga"
+
+#: ../src/common/datetimefmt.cpp:2074
+msgid "fourth"
+msgstr "keempat"
+
+#: ../src/common/datetimefmt.cpp:2075
+msgid "fifth"
+msgstr "kelima"
+
+#: ../src/common/datetimefmt.cpp:2076
+msgid "sixth"
+msgstr "keenam"
+
+#: ../src/common/datetimefmt.cpp:2077
+msgid "seventh"
+msgstr "ketujuh"
+
+#: ../src/common/datetimefmt.cpp:2078
+msgid "eighth"
+msgstr "kelapan"
+
+#: ../src/common/datetimefmt.cpp:2079
+msgid "ninth"
+msgstr "kesembilan"
+
+#: ../src/common/datetimefmt.cpp:2080
+msgid "tenth"
+msgstr "kesepuluh"
+
+#: ../src/common/datetimefmt.cpp:2081
+msgid "eleventh"
+msgstr "kesebelas"
+
+#: ../src/common/datetimefmt.cpp:2082
+msgid "twelfth"
+msgstr "kedua belas"
+
+#: ../src/common/datetimefmt.cpp:2083
+msgid "thirteenth"
+msgstr "ketiga belas"
+
+#: ../src/common/datetimefmt.cpp:2084
+msgid "fourteenth"
+msgstr "keempat belas"
+
+#: ../src/common/datetimefmt.cpp:2085
+msgid "fifteenth"
+msgstr "kelima belas"
+
+#: ../src/common/datetimefmt.cpp:2086
+msgid "sixteenth"
+msgstr "keenam belas"
+
+#: ../src/common/datetimefmt.cpp:2087
+msgid "seventeenth"
+msgstr "ketujuh belas"
+
+#: ../src/common/datetimefmt.cpp:2088
+msgid "eighteenth"
+msgstr "kelapan belas"
+
+#: ../src/common/datetimefmt.cpp:2089
+msgid "nineteenth"
+msgstr "kesembilan belas"
+
+#: ../src/common/datetimefmt.cpp:2090
+msgid "twentieth"
+msgstr "keduua puluh"
+
+#: ../src/common/datetimefmt.cpp:2248
+msgid "noon"
+msgstr "tengahari"
+
+#: ../src/common/datetimefmt.cpp:2249
+msgid "midnight"
+msgstr "tengah malam"
+
+#: ../src/common/debugrpt.cpp:209
+#, c-format
+msgid "Failed to create directory \"%s\""
+msgstr "Gagal mencipta direktori \"%s\""
+
+#: ../src/common/debugrpt.cpp:210
+msgid "Debug report couldn't be created."
+msgstr "Gagal mencipta laporan nyahpijat."
+
+#: ../src/common/debugrpt.cpp:227
+#, c-format
+msgid "Failed to remove debug report file \"%s\""
+msgstr "Gagal buang fail laporan nyahpijat \"%s\""
+
+#: ../src/common/debugrpt.cpp:239
+#, c-format
+msgid "Failed to clean up debug report directory \"%s\""
+msgstr "Gagal membersihkan direktori laporan nyahpijat \"%s\""
+
+#: ../src/common/debugrpt.cpp:514
+msgid "process context description"
+msgstr "huraian proses konteks"
+
+#: ../src/common/debugrpt.cpp:538
+msgid "dump of the process state (binary)"
+msgstr "buang keadaan prosess (binari)"
+
+#: ../src/common/debugrpt.cpp:553
+msgid "Debug report generation has failed."
+msgstr "Gagal menjana laporan nyahpijat"
+
+#: ../src/common/debugrpt.cpp:560
+#, c-format
+msgid ""
+"Processing debug report has failed, leaving the files in \"%s\" directory."
+msgstr ""
+"Gagal memproses laporan nyahpijat, meninggalkan fail dalam direktori \"%s\"."
+
+#: ../src/common/debugrpt.cpp:573
+#, fuzzy
+msgid "A debug report has been generated. It can be found in"
+msgstr "Laporan nyahpijat telah dijana dalam direktori\n"
+
+#: ../src/common/debugrpt.cpp:576
+#, fuzzy
+msgid "And includes the following files:\n"
+msgstr "*** Dan termasuk fail berikut:\n"
+
+#: ../src/common/debugrpt.cpp:586
+msgid ""
+"\n"
+"Please send this report to the program maintainer, thank you!\n"
+msgstr ""
+"\n"
+"Sila hantar laporan ini kepada penyelenggara program, terima kasih!\n"
+
+#: ../src/common/debugrpt.cpp:729
+msgid "Failed to execute curl, please install it in PATH."
+msgstr "Gagal melaksanakan curl. sila pasangkannya dalam PATH."
+
+#: ../src/common/debugrpt.cpp:742
+#, c-format
+msgid "Failed to upload the debug report (error code %d)."
+msgstr "Gagal muatnaik laporan nyahpijat (kod ralat %d)."
+
+#: ../src/common/docview.cpp:366
+msgid "Save As"
+msgstr "Simpan Sebagai"
+
+#: ../src/common/docview.cpp:457
+msgid "Discard changes and reload the last saved version?"
+msgstr ""
+
+#: ../src/common/docview.cpp:488
+msgid "unnamed"
+msgstr "tanpanama"
+
+#: ../src/common/docview.cpp:513
+#, fuzzy, c-format
+msgid "Do you want to save changes to %s?"
+msgstr "Adakah anda ingin menyimpan perubahan kepada dokumen \"%s\"?"
+
+#: ../src/common/docview.cpp:521 ../src/common/docview.cpp:560
+#: ../src/common/stockitem.cpp:195
+msgid "&Save"
+msgstr "&Simpan"
+
+#: ../src/common/docview.cpp:522 ../src/common/docview.cpp:560
+msgid "&Discard changes"
+msgstr ""
+
+#: ../src/common/docview.cpp:523
+#, fuzzy
+msgid "Do&n't close"
+msgstr "Jangan Simpan"
+
+#: ../src/common/docview.cpp:553
+#, fuzzy, c-format
+msgid "Do you want to save changes to %s before closing it?"
+msgstr "Adakah anda ingin menyimpan perubahan kepada dokumen \"%s\"?"
+
+#: ../src/common/docview.cpp:559
+#, fuzzy
+msgid "The document must be closed."
+msgstr "Teks gagal disimpan."
+
+#: ../src/common/docview.cpp:571
+#, c-format
+msgid "Saving %s failed, would you like to retry?"
+msgstr ""
+
+#: ../src/common/docview.cpp:577
+msgid "Retry"
+msgstr ""
+
+#: ../src/common/docview.cpp:577
+msgid "Discard changes"
+msgstr ""
+
+#: ../src/common/docview.cpp:679
+#, fuzzy, c-format
+msgid "File \"%s\" could not be opened for writing."
+msgstr "Gagal buka '%s' untuk %s"
+
+#: ../src/common/docview.cpp:685
+#, fuzzy, c-format
+msgid "Failed to save document to the file \"%s\"."
+msgstr "Gagal menyimpan peta bit kepada fail \"%s\"."
+
+#: ../src/common/docview.cpp:702
+#, fuzzy, c-format
+msgid "File \"%s\" could not be opened for reading."
+msgstr "Gagal buka '%s' untuk %s"
+
+#: ../src/common/docview.cpp:714
+#, fuzzy, c-format
+msgid "Failed to read document from the file \"%s\"."
+msgstr "Gagal memuat metafail dari fail \"%s\"."
+
+#: ../src/common/docview.cpp:1236
+#, c-format
+msgid ""
+"The file '%s' doesn't exist and couldn't be opened.\n"
+"It has been removed from the most recently used files list."
+msgstr ""
+"Fail '%s' tidak wujud dan Gagal dibuka.\n"
+"Ia telah dibuang dari senarai fail paling baru diguna."
+
+#: ../src/common/docview.cpp:1296
+#, fuzzy
+msgid "Print preview creation failed."
+msgstr "Gagal mencipta paip"
+
+#: ../src/common/docview.cpp:1302
+msgid "Print Preview"
+msgstr "Pralihat Cetak"
+
+#: ../src/common/docview.cpp:1517
+#, fuzzy, c-format
+msgid "The format of file '%s' couldn't be determined."
+msgstr "Direktori '%s' gagal dicipta"
+
+#: ../src/common/docview.cpp:1643
+#, c-format
+msgid "unnamed%d"
+msgstr "tanpanama%d"
+
+#: ../src/common/docview.cpp:1660
+msgid " - "
+msgstr " - "
+
+#: ../src/common/docview.cpp:1791 ../src/common/docview.cpp:1844
+msgid "Open File"
+msgstr "Buka Fail"
+
+#: ../src/common/docview.cpp:1807
+msgid "File error"
+msgstr "Ralat fail"
+
+#: ../src/common/docview.cpp:1809
+msgid "Sorry, could not open this file."
+msgstr "Maaf, Gagal membuka fail."
+
+#: ../src/common/docview.cpp:1843
+msgid "Sorry, the format for this file is unknown."
+msgstr "Maaf, format fail ini tidak diketahui."
+
+#: ../src/common/docview.cpp:1924
+msgid "Select a document template"
+msgstr "Pilih templat dokumen"
+
+#: ../src/common/docview.cpp:1925
+msgid "Templates"
+msgstr "Templat"
+
+#: ../src/common/docview.cpp:1998
+msgid "Select a document view"
+msgstr "Pilih lihat dokumen"
+
+#: ../src/common/docview.cpp:1999
+msgid "Views"
+msgstr "Pandangan"
+
+#: ../src/common/dynlib.cpp:81
+#, c-format
+msgid "Failed to load shared library '%s'"
+msgstr "Gagal memuat pustaka kongsi '%s'"
+
+#: ../src/common/dynlib.cpp:105
+#, c-format
+msgid "Couldn't find symbol '%s' in a dynamic library"
+msgstr "Gagal menemui simbol '%s' dalam pustaka dinamik"
+
+#: ../src/common/ffile.cpp:56 ../src/common/file.cpp:215
+#, c-format
+msgid "can't open file '%s'"
+msgstr "gagal membuka fail '%s'"
+
+#: ../src/common/ffile.cpp:72
+#, c-format
+msgid "can't close file '%s'"
+msgstr "gagal menutup dail '%s'"
+
+#: ../src/common/ffile.cpp:106 ../src/common/ffile.cpp:131
+#, c-format
+msgid "Read error on file '%s'"
+msgstr "Ralat baca pada fail '%s'"
+
+#: ../src/common/ffile.cpp:148
+#, c-format
+msgid "Write error on file '%s'"
+msgstr "Ralat tulis fail '%s'"
+
+#: ../src/common/ffile.cpp:182
+#, c-format
+msgid "failed to flush the file '%s'"
+msgstr "gagal menyegarkan fail '%s'"
+
+#: ../src/common/ffile.cpp:222
+#, c-format
+msgid "Seek error on file '%s' (large files not supported by stdio)"
+msgstr "Mencari ralat pada fail '%s' (fail besar tidak disokong oleh stdio)"
+
+#: ../src/common/ffile.cpp:232
+#, c-format
+msgid "Seek error on file '%s'"
+msgstr "Cari ralat pada fail '%s'"
+
+#: ../src/common/ffile.cpp:248
+#, c-format
+msgid "Can't find current position in file '%s'"
+msgstr "Gagal mencari posisi semasa dalam fail '%s'"
+
+#: ../src/common/ffile.cpp:349 ../src/common/file.cpp:569
+msgid "Failed to set temporary file permissions"
+msgstr "PGagal tetapkan keizinan fail sementara."
+
+#: ../src/common/ffile.cpp:371
+#, c-format
+msgid "can't remove file '%s'"
+msgstr "gagal membuang fail '%s'"
+
+#: ../src/common/ffile.cpp:376 ../src/common/file.cpp:591
+#, c-format
+msgid "can't commit changes to file '%s'"
+msgstr "Gagal lakukan perubahan kepada fail '%s'"
+
+#: ../src/common/ffile.cpp:388 ../src/common/file.cpp:603
+#, c-format
+msgid "can't remove temporary file '%s'"
+msgstr "gagal membuang fail sementara '%s'"
+
+#: ../src/common/file.cpp:162
+#, c-format
+msgid "can't create file '%s'"
+msgstr "gagal mencipta fail '%s'"
+
+#: ../src/common/file.cpp:229
+#, c-format
+msgid "can't close file descriptor %d"
+msgstr "gagal tutup penghurai fail %d"
+
+#: ../src/common/file.cpp:332
+#, c-format
+msgid "can't read from file descriptor %d"
+msgstr "gagal membaca dari penghurai fail %d"
+
+#: ../src/common/file.cpp:351
+#, c-format
+msgid "can't write to file descriptor %d"
+msgstr "gagal menulis kepada penghurai %d"
+
+#: ../src/common/file.cpp:390
+#, c-format
+msgid "can't flush file descriptor %d"
+msgstr "gagal mengeluarkan penghurai fail %d"
+
+#: ../src/common/file.cpp:432
+#, c-format
+msgid "can't seek on file descriptor %d"
+msgstr "gagal menemui penghurai fail %d"
+
+#: ../src/common/file.cpp:446
+#, c-format
+msgid "can't get seek position on file descriptor %d"
+msgstr "Gagal menemui posisi pada fail penghurai %d"
+
+#: ../src/common/file.cpp:475
+#, c-format
+msgid "can't find length of file on file descriptor %d"
+msgstr "gagal menemui panjang fail pada penghurai fail %d"
+
+#: ../src/common/file.cpp:505
+#, c-format
+msgid "can't determine if the end of file is reached on descriptor %d"
+msgstr "Gagal ditentukan jika EOF dicapai pada penghurai %d"
+
+#: ../src/common/fileconf.cpp:352
+#, c-format
+msgid ""
+" and additionally, the existing configuration file was renamed to \"%s\" and "
+"couldn't be renamed back, please rename it to its original path \"%s\""
+msgstr ""
+
+#: ../src/common/fileconf.cpp:389
+#, fuzzy
+msgid " due to the following error:\n"
+msgstr "*** Dan termasuk fail berikut:\n"
+
+#: ../src/common/fileconf.cpp:412
+#, fuzzy
+msgid "failed to rename the existing file"
+msgstr "Gagal memuat metafail dari fail \"%s\"."
+
+#: ../src/common/fileconf.cpp:421
+#, fuzzy
+msgid "failed to create the new file directory"
+msgstr "Gagal mendapatkan direktori kerja"
+
+#: ../src/common/fileconf.cpp:428
+#, fuzzy
+msgid "failed to move the file to the new location"
+msgstr "Gagal menamatkan sambungan mendial: %s"
+
+#: ../src/common/fileconf.cpp:462
+#, c-format
+msgid "can't open global configuration file '%s'."
+msgstr "gagal membuka fail konfigurasi global '%s'."
+
+#: ../src/common/fileconf.cpp:478
+#, c-format
+msgid "can't open user configuration file '%s'."
+msgstr "gagal membuka fail konfigurasi pengguna '%s'."
+
+#: ../src/common/fileconf.cpp:483
+#, c-format
+msgid "Changes won't be saved to avoid overwriting the existing file \"%s\""
+msgstr ""
+
+#: ../src/common/fileconf.cpp:583
+msgid "Error reading config options."
+msgstr "Ralat membaca pilihan konfig."
+
+#: ../src/common/fileconf.cpp:593
+#, fuzzy
+msgid "Failed to read config options."
+msgstr "Ralat membaca pilihan konfig."
+
+#: ../src/common/fileconf.cpp:700
+#, fuzzy, c-format
+msgid "file '%s': unexpected character %c at line %zu."
+msgstr "fail '%s': aksara %c tidak dijangka pada baris %d."
+
+#: ../src/common/fileconf.cpp:736
+#, fuzzy, c-format
+msgid "file '%s', line %zu: '%s' ignored after group header."
+msgstr "fail '%s', baris %d: '%s' diabaikan selepas kepala kumpulan."
+
+#: ../src/common/fileconf.cpp:765
+#, fuzzy, c-format
+msgid "file '%s', line %zu: '=' expected."
+msgstr "fail '%s', baris %d: '=' dijangka."
+
+#: ../src/common/fileconf.cpp:778
+#, fuzzy, c-format
+msgid "file '%s', line %zu: value for immutable key '%s' ignored."
+msgstr "fail '%s', baris %d: nilai untuk nilai tetap '%s' diabaikan."
+
+#: ../src/common/fileconf.cpp:788
+#, fuzzy, c-format
+msgid "file '%s', line %zu: key '%s' was first found at line %d."
+msgstr "fail '%s', baris %d: kunci '%s' pertama kali sitemui pada baris %d."
+
+#: ../src/common/fileconf.cpp:1091
+#, c-format
+msgid "Config entry name cannot start with '%c'."
+msgstr "Nama masukan konfig tidak boleh dimulakan dengan '%c'."
+
+#: ../src/common/fileconf.cpp:1146
+#, fuzzy
+msgid "Failed to create configuration file directory."
+msgstr "Gagal naiktaraf fail konfigurasi pengguna."
+
+#: ../src/common/fileconf.cpp:1158
+msgid "can't open user configuration file."
+msgstr "gagal membuka fail konfigurasi pengguna."
+
+#: ../src/common/fileconf.cpp:1172
+msgid "can't write user configuration file."
+msgstr "gagal menulis fail konfigurasi pengguna."
+
+#: ../src/common/fileconf.cpp:1178
+msgid "Failed to update user configuration file."
+msgstr "Gagal naiktaraf fail konfigurasi pengguna."
+
+#: ../src/common/fileconf.cpp:1201
+msgid "Error saving user configuration data."
+msgstr "Ralat menulis fail konfigurasi pengguna."
+
+#: ../src/common/fileconf.cpp:1313
+#, c-format
+msgid "can't delete user configuration file '%s'"
+msgstr "gagal memadam fail konfigurasi pengguna '%s'"
+
+#: ../src/common/fileconf.cpp:2007
+#, c-format
+msgid "entry '%s' appears more than once in group '%s'"
+msgstr "masukan '%s' dipaparkan lebih dari sekali dalam kumpulan '%s'"
+
+#: ../src/common/fileconf.cpp:2021
+#, c-format
+msgid "attempt to change immutable key '%s' ignored."
+msgstr "Cubaan mengubah kunci tidak boleh disenyapkan '%s' diabaikan."
+
+#: ../src/common/fileconf.cpp:2118
+#, c-format
+msgid "trailing backslash ignored in '%s'"
+msgstr ""
+
+#: ../src/common/fileconf.cpp:2153
+#, c-format
+msgid "unexpected \" at position %d in '%s'."
+msgstr "\" tidak dijangka pada posisi %d dalam '%s'."
+
+#: ../src/common/filefn.cpp:474
+#, c-format
+msgid "Failed to copy the file '%s' to '%s'"
+msgstr "Gagal salin fail '%s' ke '%s'."
+
+#: ../src/common/filefn.cpp:487
+#, c-format
+msgid "Impossible to get permissions for file '%s'"
+msgstr "Mustahil mendapatkan keizinan untuk fail '%s'"
+
+#: ../src/common/filefn.cpp:501
+#, c-format
+msgid "Impossible to overwrite the file '%s'"
+msgstr "Mustahil untuk menindih fail '%s'"
+
+#: ../src/common/filefn.cpp:508
+#, fuzzy, c-format
+msgid "Error copying the file '%s' to '%s'."
+msgstr "Gagal salin fail '%s' ke '%s'."
+
+#: ../src/common/filefn.cpp:556
+#, c-format
+msgid "Impossible to set permissions for the file '%s'"
+msgstr "Mustahil untuk menetapkan keizinan fail '%s'"
+
+#: ../src/common/filefn.cpp:606
+#, c-format
+msgid ""
+"Failed to rename the file '%s' to '%s' because the destination file already "
+"exists."
+msgstr ""
+"Gagal menamakan semula fail '%s' kepada '%s' disebabkan fail destinasi telah "
+"wujud."
+
+#: ../src/common/filefn.cpp:623
+#, fuzzy, c-format
+msgid "File '%s' couldn't be renamed '%s'"
+msgstr "Direktori '%s' gagal dicipta"
+
+#: ../src/common/filefn.cpp:639
+#, fuzzy, c-format
+msgid "File '%s' couldn't be removed"
+msgstr "Direktori '%s' gagal dicipta"
+
+#: ../src/common/filefn.cpp:666
+#, c-format
+msgid "Directory '%s' couldn't be created"
+msgstr "Direktori '%s' gagal dicipta"
+
+#: ../src/common/filefn.cpp:680
+#, fuzzy, c-format
+msgid "Directory '%s' couldn't be deleted"
+msgstr "Direktori '%s' gagal dicipta"
+
+#: ../src/common/filefn.cpp:714
+#, c-format
+msgid "Cannot enumerate files '%s'"
+msgstr "Gagal menghitung fail '%s'"
+
+#: ../src/common/filefn.cpp:798
+msgid "Failed to get the working directory"
+msgstr "Gagal mendapatkan direktori kerja"
+
+#: ../src/common/filefn.cpp:843
+#, fuzzy
+msgid "Could not set current working directory"
+msgstr "Gagal mendapatkan direktori kerja"
+
+#: ../src/common/filefn.cpp:974
+#, c-format
+msgid "Files (%s)"
+msgstr "Fail (%s)"
+
+#: ../src/common/filename.cpp:182
+#, fuzzy, c-format
+msgid "Failed to open '%s' for reading"
+msgstr "Gagal buka '%s' untuk %s"
+
+#: ../src/common/filename.cpp:187
+#, fuzzy, c-format
+msgid "Failed to open '%s' for writing"
+msgstr "Gagal buka '%s' untuk %s"
+
+#: ../src/common/filename.cpp:199
+msgid "Failed to close file handle"
+msgstr "Gagal tutup pengemudi fail"
+
+#: ../src/common/filename.cpp:1046
+msgid "Failed to create a temporary file name"
+msgstr "Gagal mencipta nama fail sementara"
+
+#: ../src/common/filename.cpp:1081
+msgid "Failed to open temporary file."
+msgstr "Gagal membuka fail sementara."
+
+#: ../src/common/filename.cpp:2862
+#, c-format
+msgid "Failed to modify file times for '%s'"
+msgstr "Gagal mengubahsuai masa fail untuk '%s'"
+
+#: ../src/common/filename.cpp:2877
+#, c-format
+msgid "Failed to touch the file '%s'"
+msgstr "Gagal sentuh fail '%s'"
+
+#: ../src/common/filename.cpp:2958
+#, c-format
+msgid "Failed to retrieve file times for '%s'"
+msgstr "Gagal mendapatkan masa fail untuk '%s'"
+
+#: ../src/common/filepickercmn.cpp:39 ../src/common/filepickercmn.cpp:40
+msgid "Browse"
+msgstr ""
+
+#: ../src/common/fldlgcmn.cpp:792 ../src/generic/filectrlg.cpp:1185
+#, c-format
+msgid "All files (%s)|%s"
+msgstr "Semua fail (%s)|%s"
+
+#. TRANSLATORS: %s are a file extension used to build a file wildcard string
+#: ../src/common/fldlgcmn.cpp:810
+#, c-format
+msgid "%s files (%s)|%s"
+msgstr "fail %s (%s)|%s"
+
+#: ../src/common/fldlgcmn.cpp:1072
+#, c-format
+msgid "Load %s file"
+msgstr "Memuatkan fail %s"
+
+#: ../src/common/fldlgcmn.cpp:1074
+#, c-format
+msgid "Save %s file"
+msgstr "Simpan fail %s"
+
+#: ../src/common/fmapbase.cpp:144
+msgid "Western European (ISO-8859-1)"
+msgstr "Eropah Barat (ISO-8859-1)"
+
+#: ../src/common/fmapbase.cpp:145
+msgid "Central European (ISO-8859-2)"
+msgstr "Eropah Tengah (ISO-8859-2)"
+
+#: ../src/common/fmapbase.cpp:146
+msgid "Esperanto (ISO-8859-3)"
+msgstr "Esperanto (ISO-8859-3)"
+
+#: ../src/common/fmapbase.cpp:147
+msgid "Baltic (old) (ISO-8859-4)"
+msgstr "Baltik (lama) (ISO-8859-4)"
+
+#: ../src/common/fmapbase.cpp:148
+msgid "Cyrillic (ISO-8859-5)"
+msgstr "Cyrillic (ISO-8859-5)"
+
+#: ../src/common/fmapbase.cpp:149
+msgid "Arabic (ISO-8859-6)"
+msgstr "Arabik (ISO-8859-6)"
+
+#: ../src/common/fmapbase.cpp:150
+msgid "Greek (ISO-8859-7)"
+msgstr "Greek (ISO-8859-7)"
+
+#: ../src/common/fmapbase.cpp:151
+msgid "Hebrew (ISO-8859-8)"
+msgstr "Hebrew (ISO-8859-8)"
+
+#: ../src/common/fmapbase.cpp:152
+msgid "Turkish (ISO-8859-9)"
+msgstr "Turkish (ISO-8859-9)"
+
+#: ../src/common/fmapbase.cpp:153
+msgid "Nordic (ISO-8859-10)"
+msgstr "Nordic (ISO-8859-10)"
+
+#: ../src/common/fmapbase.cpp:154
+msgid "Thai (ISO-8859-11)"
+msgstr "Thai (ISO-8859-11)"
+
+#: ../src/common/fmapbase.cpp:155
+msgid "Indian (ISO-8859-12)"
+msgstr "Indian (ISO-8859-12)"
+
+#: ../src/common/fmapbase.cpp:156
+msgid "Baltic (ISO-8859-13)"
+msgstr "Baltik (ISO-8859-13)"
+
+#: ../src/common/fmapbase.cpp:157
+msgid "Celtic (ISO-8859-14)"
+msgstr "Celtic (ISO-8859-14)"
+
+#: ../src/common/fmapbase.cpp:158
+msgid "Western European with Euro (ISO-8859-15)"
+msgstr "Eropah Barat dengan Euro (ISO-8859-15)"
+
+#: ../src/common/fmapbase.cpp:159
+msgid "KOI8-R"
+msgstr "KOI8-R"
+
+#: ../src/common/fmapbase.cpp:160
+msgid "KOI8-U"
+msgstr "KOI8-U"
+
+#: ../src/common/fmapbase.cpp:161
+#, fuzzy
+msgid "Windows/DOS OEM Cyrillic (CP 866)"
+msgstr "Windows Cyrillic (CP 1251)"
+
+#: ../src/common/fmapbase.cpp:162
+msgid "Windows Thai (CP 874)"
+msgstr "Windows Thai (CP 874)"
+
+#: ../src/common/fmapbase.cpp:163
+#, fuzzy
+msgid "Windows Japanese (CP 932) or Shift-JIS"
+msgstr "Windows Japun (CP 932)"
+
+#: ../src/common/fmapbase.cpp:164
+#, fuzzy
+msgid "Windows Chinese Simplified (CP 936) or GB-2312"
+msgstr "Windows China Dipermudah (CP 936)"
+
+#: ../src/common/fmapbase.cpp:165
+msgid "Windows Korean (CP 949)"
+msgstr "Windows Korea (CP 949)"
+
+#: ../src/common/fmapbase.cpp:166
+#, fuzzy
+msgid "Windows Chinese Traditional (CP 950) or Big-5"
+msgstr "Windows China Tradisional (CP 950)"
+
+#: ../src/common/fmapbase.cpp:167
+msgid "Windows Central European (CP 1250)"
+msgstr "Windows Eropah Tengah (CP 1250)"
+
+#: ../src/common/fmapbase.cpp:168
+msgid "Windows Cyrillic (CP 1251)"
+msgstr "Windows Cyrillic (CP 1251)"
+
+#: ../src/common/fmapbase.cpp:169
+msgid "Windows Western European (CP 1252)"
+msgstr "Windows Eropah Barat (CP 1252)"
+
+#: ../src/common/fmapbase.cpp:170
+msgid "Windows Greek (CP 1253)"
+msgstr "Windows Greek (CP 1253)"
+
+#: ../src/common/fmapbase.cpp:171
+msgid "Windows Turkish (CP 1254)"
+msgstr "Windows Turki (CP 1254)"
+
+#: ../src/common/fmapbase.cpp:172
+msgid "Windows Hebrew (CP 1255)"
+msgstr "Windows Hebrew (CP 1255)"
+
+#: ../src/common/fmapbase.cpp:173
+msgid "Windows Arabic (CP 1256)"
+msgstr "Windows Arab (CP 1256)"
+
+#: ../src/common/fmapbase.cpp:174
+msgid "Windows Baltic (CP 1257)"
+msgstr "Windows Baltik (CP 1257)"
+
+#: ../src/common/fmapbase.cpp:175
+#, fuzzy
+msgid "Windows Vietnamese (CP 1258)"
+msgstr "Windows Greek (CP 1253)"
+
+#: ../src/common/fmapbase.cpp:176
+#, fuzzy
+msgid "Windows Johab (CP 1361)"
+msgstr "Windows Arab (CP 1256)"
+
+#: ../src/common/fmapbase.cpp:177
+msgid "Windows/DOS OEM (CP 437)"
+msgstr "Windows/DOS OEM (CP 437)"
+
+#: ../src/common/fmapbase.cpp:178
+msgid "Unicode 7 bit (UTF-7)"
+msgstr "Unikod 7 bit (UTF-7)"
+
+#: ../src/common/fmapbase.cpp:179
+msgid "Unicode 8 bit (UTF-8)"
+msgstr "Unikod 8 bit (UTF-8)"
+
+#: ../src/common/fmapbase.cpp:181 ../src/common/fmapbase.cpp:187
+msgid "Unicode 16 bit (UTF-16)"
+msgstr "Unikod 16 bit (UTF-16)"
+
+#: ../src/common/fmapbase.cpp:182
+msgid "Unicode 16 bit Little Endian (UTF-16LE)"
+msgstr "Unikod 16 bit Little Endian (UTF-16LE)"
+
+#: ../src/common/fmapbase.cpp:183 ../src/common/fmapbase.cpp:189
+msgid "Unicode 32 bit (UTF-32)"
+msgstr "Unikod 32 bit (UTF-32)"
+
+#: ../src/common/fmapbase.cpp:184
+msgid "Unicode 32 bit Little Endian (UTF-32LE)"
+msgstr "Unikod 32 bit Little Endian (UTF-32LE)"
+
+#: ../src/common/fmapbase.cpp:186
+msgid "Unicode 16 bit Big Endian (UTF-16BE)"
+msgstr "Unikod 16 bit Big Endian (UTF-16BE)"
+
+#: ../src/common/fmapbase.cpp:188
+msgid "Unicode 32 bit Big Endian (UTF-32BE)"
+msgstr "Unikod 32 bit Big Endian (UTF-32BE)"
+
+#: ../src/common/fmapbase.cpp:191
+msgid "Extended Unix Codepage for Japanese (EUC-JP)"
+msgstr "Extended Unix Codepage for Japanese (EUC-JP)"
+
+#: ../src/common/fmapbase.cpp:192
+msgid "US-ASCII"
+msgstr "US-ASCII"
+
+#: ../src/common/fmapbase.cpp:193
+msgid "ISO-2022-JP"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:195
+#, fuzzy
+msgid "MacRoman"
+msgstr "Roman"
+
+#: ../src/common/fmapbase.cpp:196
+msgid "MacJapanese"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:197
+msgid "MacChineseTrad"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:198
+msgid "MacKorean"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:199
+#, fuzzy
+msgid "MacArabic"
+msgstr "Arab"
+
+#: ../src/common/fmapbase.cpp:200
+msgid "MacHebrew"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:201
+msgid "MacGreek"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:202
+msgid "MacCyrillic"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:203
+msgid "MacDevanagari"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:204
+msgid "MacGurmukhi"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:205
+msgid "MacGujarati"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:206
+msgid "MacOriya"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:207
+msgid "MacBengali"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:208
+msgid "MacTamil"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:209
+msgid "MacTelugu"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:210
+msgid "MacKannada"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:211
+msgid "MacMalayalam"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:212
+#, fuzzy
+msgid "MacSinhalese"
+msgstr "Padan kes"
+
+#: ../src/common/fmapbase.cpp:213
+msgid "MacBurmese"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:214
+msgid "MacKhmer"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:215
+msgid "MacThai"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:216
+msgid "MacLaotian"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:217
+msgid "MacGeorgian"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:218
+msgid "MacArmenian"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:219
+msgid "MacChineseSimp"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:220
+msgid "MacTibetan"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:221
+msgid "MacMongolian"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:222
+msgid "MacEthiopic"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:223
+msgid "MacCentralEurRoman"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:224
+msgid "MacVietnamese"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:225
+#, fuzzy
+msgid "MacExtArabic"
+msgstr "Arab"
+
+#: ../src/common/fmapbase.cpp:226
+#, fuzzy
+msgid "MacSymbol"
+msgstr "Simbol"
+
+#: ../src/common/fmapbase.cpp:227
+msgid "MacDingbats"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:228
+msgid "MacTurkish"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:229
+msgid "MacCroatian"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:230
+msgid "MacIcelandic"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:231
+#, fuzzy
+msgid "MacRomanian"
+msgstr "Roman"
+
+#: ../src/common/fmapbase.cpp:232
+msgid "MacCeltic"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:233
+msgid "MacGaelic"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:234
+msgid "MacKeyboardGlyphs"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:791
+msgid "Default encoding"
+msgstr "Pengenkodan default"
+
+#: ../src/common/fmapbase.cpp:805
+#, c-format
+msgid "Unknown encoding (%d)"
+msgstr "Pengenkodan (%d) tidak diketahui"
+
+#: ../src/common/fmapbase.cpp:815 ../src/richtext/richtextstyles.cpp:776
+msgid "default"
+msgstr "lalai"
+
+#: ../src/common/fmapbase.cpp:829
+#, c-format
+msgid "unknown-%d"
+msgstr "tidak diketahui-%d"
+
+#: ../src/common/fontcmn.cpp:924 ../src/common/fontcmn.cpp:1130
+msgid "underlined"
+msgstr "digaris bawahkan"
+
+#: ../src/common/fontcmn.cpp:929
+msgid " strikethrough"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:942
+msgid " thin"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:946
+#, fuzzy
+msgid " extra light"
+msgstr "cerah"
+
+#: ../src/common/fontcmn.cpp:950
+msgid " light"
+msgstr "cerah"
+
+#: ../src/common/fontcmn.cpp:954
+msgid " medium"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:958
+#, fuzzy
+msgid " semi bold"
+msgstr "tebal"
+
+#: ../src/common/fontcmn.cpp:962
+msgid " bold"
+msgstr "tebal"
+
+#: ../src/common/fontcmn.cpp:966
+#, fuzzy
+msgid " extra bold"
+msgstr "tebal"
+
+#: ../src/common/fontcmn.cpp:970
+msgid " heavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:974
+msgid " extra heavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:990
+msgid " italic"
+msgstr "italik"
+
+#: ../src/common/fontcmn.cpp:1134
+msgid "strikethrough"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1143
+msgid "thin"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1156
+#, fuzzy
+msgid "extralight"
+msgstr "ringan"
+
+#: ../src/common/fontcmn.cpp:1161
+msgid "light"
+msgstr "ringan"
+
+#: ../src/common/fontcmn.cpp:1169 ../src/richtext/richtextstyles.cpp:775
+#, fuzzy
+msgid "normal"
+msgstr "Normal"
+
+#: ../src/common/fontcmn.cpp:1174
+msgid "medium"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1179 ../src/common/fontcmn.cpp:1199
+#, fuzzy
+msgid "semibold"
+msgstr "bold"
+
+#: ../src/common/fontcmn.cpp:1184
+msgid "bold"
+msgstr "bold"
+
+#: ../src/common/fontcmn.cpp:1194
+#, fuzzy
+msgid "extrabold"
+msgstr "bold"
+
+#: ../src/common/fontcmn.cpp:1204
+msgid "heavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1212
+msgid "extraheavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1217
+msgid "italic"
+msgstr "italik"
+
+#: ../src/common/fontmap.cpp:195
+msgid ": unknown charset"
+msgstr ": set aksara tidak diketahui"
+
+#: ../src/common/fontmap.cpp:199
+#, c-format
+msgid ""
+"The charset '%s' is unknown. You may select\n"
+"another charset to replace it with or choose\n"
+"[Cancel] if it cannot be replaced"
+msgstr ""
+"Set aksara '%s' tidak diketahui. Anda boleh memilih\n"
+"set aksara lain untuk digantikan atau pilih\n"
+"[Batal] jika tidak boleh diganti"
+
+#: ../src/common/fontmap.cpp:241
+#, c-format
+msgid "Failed to remember the encoding for the charset '%s'."
+msgstr "Gagal mengingat pengenkodan untuk set aksara '%s'."
+
+#: ../src/common/fontmap.cpp:321
+msgid "can't load any font, aborting"
+msgstr "gagal memuat sebarang fon, menggugurkan"
+
+#: ../src/common/fontmap.cpp:409
+msgid ": unknown encoding"
+msgstr ":pengenkodan tidak diketahui"
+
+#: ../src/common/fontmap.cpp:417
+#, c-format
+msgid ""
+"No font for displaying text in encoding '%s' found,\n"
+"but an alternative encoding '%s' is available.\n"
+"Do you want to use this encoding (otherwise you will have to choose another "
+"one)?"
+msgstr ""
+"Tiada fon ditemui untuk memaparkan teks dalam pengkodan '%s',\n"
+"tetapi wujudnya pengkodan alternatif '%s'.\n"
+"Adakah anda ingin menggunakan pengkodan ini (sebaliknya anda perlu memilih "
+"yang lain)?"
+
+#: ../src/common/fontmap.cpp:422
+#, c-format
+msgid ""
+"No font for displaying text in encoding '%s' found.\n"
+"Would you like to select a font to be used for this encoding\n"
+"(otherwise the text in this encoding will not be shown correctly)?"
+msgstr ""
+"Tiada fon ditemui untuk memaparkan teks dalam pengkodan '%s',\n"
+"Adakah anda ingin memilih fon utuk digunakan dengan pengkodan ini\n"
+"(sebaliknya teks dalam pengkodan ini tidak akan dapat dilihat dengan betul)?"
+
+#: ../src/common/fs_mem.cpp:169
+#, c-format
+msgid "Memory VFS already contains file '%s'!"
+msgstr "Memori VFS sedia mengandungi fail '%s'!"
+
+#: ../src/common/fs_mem.cpp:232
+#, c-format
+msgid "Trying to remove file '%s' from memory VFS, but it is not loaded!"
+msgstr ""
+"Mencuba untuk menyingkirkan fail '%s' daripada memori VFS, tetapi tidak "
+"dimuatkan!"
+
+#: ../src/common/fs_mem.cpp:262
+#, c-format
+msgid "Failed to store image '%s' to memory VFS!"
+msgstr "Gagal menyimpan imej '%s' kepada VFS memori!"
+
+#: ../src/common/ftp.cpp:197
+msgid "Timeout while waiting for FTP server to connect, try passive mode."
+msgstr "Masa tamat ketika menunggu sambuungan pelayan FTP, cuba mod pasif."
+
+#: ../src/common/ftp.cpp:399
+#, c-format
+msgid "Failed to set FTP transfer mode to %s."
+msgstr "Gagal menetapkan mod penhantaran FTP kepada %s."
+
+#: ../src/common/ftp.cpp:400 ../src/richtext/richtextsymboldlg.cpp:432
+msgid "ASCII"
+msgstr "ASCII"
+
+#: ../src/common/ftp.cpp:400
+msgid "binary"
+msgstr "binari"
+
+#: ../src/common/ftp.cpp:608
+msgid "The FTP server doesn't support the PORT command."
+msgstr "Pelayan FTP tidak menyokong arahan PORT."
+
+#: ../src/common/ftp.cpp:622
+msgid "The FTP server doesn't support passive mode."
+msgstr "Pelayan FTP tidak menyokong mod pasif."
+
+#: ../src/common/gifdecod.cpp:822
+#, c-format
+msgid "Incorrect GIF frame size (%u, %d) for the frame #%u"
+msgstr ""
+
+#: ../src/common/glcmn.cpp:108
+#, fuzzy
+msgid "Failed to allocate colour for OpenGL"
+msgstr "Gagal mencipta kursor."
+
+#: ../src/common/headerctrlcmn.cpp:57
+msgid "Please select the columns to show and define their order:"
+msgstr ""
+
+#: ../src/common/headerctrlcmn.cpp:58
+#, fuzzy
+msgid "Customize Columns"
+msgstr "Saiz Fon"
+
+#: ../src/common/headerctrlcmn.cpp:304
+#, fuzzy
+msgid "&Customize..."
+msgstr "Saiz Fon"
+
+#: ../src/common/hyperlnkcmn.cpp:132
+#, fuzzy, c-format
+msgid "Failed to open URL \"%s\" in the default browser"
+msgstr "Gagal buka '%s' untuk %s"
+
+#: ../src/common/iconbndl.cpp:195
+#, fuzzy, c-format
+msgid "Failed to load image %%d from file '%s'."
+msgstr "Gagal memuat imej %d dari fail '%s'."
+
+#: ../src/common/iconbndl.cpp:203
+#, fuzzy, c-format
+msgid "Failed to load image %d from stream."
+msgstr "Gagal memuat imej %d dari fail '%s'."
+
+#: ../src/common/iconbndl.cpp:221
+#, fuzzy, c-format
+msgid "Failed to load icons from resource '%s'."
+msgstr "Gagal memuat imej %d dari fail '%s'."
+
+#: ../src/common/imagbmp.cpp:97
+msgid "BMP: Couldn't save invalid image."
+msgstr "BMP: Tidak sapat menyimpan imej yang tidak sah."
+
+#: ../src/common/imagbmp.cpp:137
+msgid "BMP: wxImage doesn't have own wxPalette."
+msgstr "BMP: wxImage tidak mempunyai wxPalette."
+
+#: ../src/common/imagbmp.cpp:243
+msgid "BMP: Couldn't write the file (Bitmap) header."
+msgstr "BMP: Gagal menulis kepala fail (Bitmap)."
+
+#: ../src/common/imagbmp.cpp:266
+msgid "BMP: Couldn't write the file (BitmapInfo) header."
+msgstr "BMP: Gagal menulis fail kepala (BitmapInfo)."
+
+#: ../src/common/imagbmp.cpp:353
+msgid "BMP: Couldn't write RGB color map."
+msgstr "BMP: Gagal menulis peta warna RGB."
+
+#: ../src/common/imagbmp.cpp:487
+msgid "BMP: Couldn't write data."
+msgstr "BMP: Gagal menulis data."
+
+#: ../src/common/imagbmp.cpp:561 ../src/common/imagbmp.cpp:642
+msgid "BMP: Couldn't allocate memory."
+msgstr "BMP: Gagal sediakan memori."
+
+#: ../src/common/imagbmp.cpp:1041
+msgid "DIB Header: Image width > 32767 pixels for file."
+msgstr "Kepala DIB: Lebar imej > 32767 piksel untuk fail."
+
+#: ../src/common/imagbmp.cpp:1049
+msgid "DIB Header: Image height > 32767 pixels for file."
+msgstr "Kepala DIB: Tinggi imej > 32767 piksel untuk fail."
+
+#: ../src/common/imagbmp.cpp:1081
+msgid "DIB Header: Unknown bitdepth in file."
+msgstr "Kepala DIB: kedalaman bit fail tidak diketahui."
+
+#: ../src/common/imagbmp.cpp:1156
+msgid "DIB Header: Unknown encoding in file."
+msgstr "Kepala DIB: mengenkod fail tidak diketahui."
+
+#: ../src/common/imagbmp.cpp:1165
+msgid "DIB Header: Encoding doesn't match bitdepth."
+msgstr "Kepala DIB: pengenkod tidak sepadan kedalaman bit."
+
+#: ../src/common/imagbmp.cpp:1180
+#, c-format
+msgid "BMP Header: Invalid number of colors (%d)."
+msgstr ""
+
+#: ../src/common/imagbmp.cpp:1273
+msgid "Error in reading image DIB."
+msgstr "Ralat membaca DIB imej."
+
+#: ../src/common/imagbmp.cpp:1294
+msgid "ICO: Error in reading mask DIB."
+msgstr "ICO: Ralat baca DIB topeng."
+
+#: ../src/common/imagbmp.cpp:1353
+msgid "ICO: Image too tall for an icon."
+msgstr "ICO: Imej terlalu tinggi untuk ikon."
+
+#: ../src/common/imagbmp.cpp:1361
+msgid "ICO: Image too wide for an icon."
+msgstr "ICO: Imej terlalu lebar untuk ikon."
+
+#: ../src/common/imagbmp.cpp:1388 ../src/common/imagbmp.cpp:1488
+#: ../src/common/imagbmp.cpp:1503 ../src/common/imagbmp.cpp:1514
+#: ../src/common/imagbmp.cpp:1528 ../src/common/imagbmp.cpp:1576
+#: ../src/common/imagbmp.cpp:1591 ../src/common/imagbmp.cpp:1605
+#: ../src/common/imagbmp.cpp:1616
+msgid "ICO: Error writing the image file!"
+msgstr "Ralat menulis fail imej!"
+
+#: ../src/common/imagbmp.cpp:1701
+msgid "ICO: Invalid icon index."
+msgstr "ICO: Indeks ikon tidak sah."
+
+#: ../src/common/image.cpp:2410
+msgid "Image and mask have different sizes."
+msgstr "Imej san topeng memiliki saiz berbeza."
+
+#: ../src/common/image.cpp:2418 ../src/common/image.cpp:2459
+msgid "No unused colour in image being masked."
+msgstr "Tiada warna yang tidak digunakan dalam imej ditopengkan."
+
+#: ../src/common/image.cpp:2641
+#, fuzzy, c-format
+msgid "Failed to load bitmap \"%s\" from resources."
+msgstr "Gagal memuat imej %d dari fail '%s'."
+
+#: ../src/common/image.cpp:2650
+#, fuzzy, c-format
+msgid "Failed to load icon \"%s\" from resources."
+msgstr "Gagal memuat imej %d dari fail '%s'."
+
+#: ../src/common/image.cpp:2728 ../src/common/image.cpp:2747
+#, fuzzy, c-format
+msgid "Failed to load image from file \"%s\"."
+msgstr "Gagal memuat imej %d dari fail '%s'."
+
+#: ../src/common/image.cpp:2761
+#, c-format
+msgid "Can't save image to file '%s': unknown extension."
+msgstr "Gagal menyimpan fail imej '%s': sambungan tidak diketahui."
+
+#: ../src/common/image.cpp:2869
+msgid "No handler found for image type."
+msgstr "Tiada pengemudi ditemui untuk jenis imej."
+
+#: ../src/common/image.cpp:2877 ../src/common/image.cpp:3000
+#: ../src/common/image.cpp:3066
+#, c-format
+msgid "No image handler for type %d defined."
+msgstr "Tiada pengemudi imej untuk jenis %d ditetapkan."
+
+#: ../src/common/image.cpp:2887
+#, fuzzy, c-format
+msgid "Image file is not of type %d."
+msgstr "Fail imej bukan berjenis %ld."
+
+#: ../src/common/image.cpp:2970
+msgid "Can't automatically determine the image format for non-seekable input."
+msgstr ""
+
+#: ../src/common/image.cpp:2988
+#, fuzzy
+msgid "Unknown image data format."
+msgstr "ralat dalam format data"
+
+#: ../src/common/image.cpp:3009
+#, fuzzy, c-format
+msgid "This is not a %s."
+msgstr "PCX: ini bukahlah fail PCX."
+
+#: ../src/common/image.cpp:3032 ../src/common/image.cpp:3080
+#, c-format
+msgid "No image handler for type %s defined."
+msgstr "Tiada pengemudi imej untuk jenis %s ditetapkan."
+
+#: ../src/common/image.cpp:3041
+#, fuzzy, c-format
+msgid "Image is not of type %s."
+msgstr "Fail imej bukan berjenis %s."
+
+#: ../src/common/image.cpp:3509
+#, fuzzy, c-format
+msgid "Failed to check format of image file \"%s\"."
+msgstr "Gagal menyimpan peta bit kepada fail \"%s\"."
+
+#: ../src/common/imaggif.cpp:124
+msgid "GIF: error in GIF image format."
+msgstr "GIF: ralat dalam format imej GIF."
+
+#: ../src/common/imaggif.cpp:129
+msgid "GIF: not enough memory."
+msgstr "GIF: memori tidak mencukupi."
+
+#: ../src/common/imaggif.cpp:134
+msgid "GIF: data stream seems to be truncated."
+msgstr "GIF: strim data dilihat seperti dipotong."
+
+#: ../src/common/imaggif.cpp:240
+#, fuzzy
+msgid "Couldn't initialize GIF hash table."
+msgstr "Gagal memulakan strim zlib kempis."
+
+#: ../src/common/imagiff.cpp:739
+msgid "IFF: error in IFF image format."
+msgstr "IFF: ralat pada format imej IFF."
+
+#: ../src/common/imagiff.cpp:742
+msgid "IFF: not enough memory."
+msgstr "IFF: tidak cukup memori."
+
+#: ../src/common/imagiff.cpp:745
+msgid "IFF: unknown error!!!"
+msgstr "IFF: ralat tidak diketahui!!!"
+
+#: ../src/common/imagiff.cpp:755
+msgid "IFF: data stream seems to be truncated."
+msgstr "IFF: strim data dilihat seperti dipotong."
+
+#: ../src/common/imagjpeg.cpp:258
+msgid "JPEG: Couldn't load - file is probably corrupted."
+msgstr "JPEG: Gagal dimuat - kemungkinan fail rosak."
+
+#: ../src/common/imagjpeg.cpp:437
+msgid "JPEG: Couldn't save image."
+msgstr "JPEG: Gagal simpan imej."
+
+#: ../src/common/imagpcx.cpp:439
+msgid "PCX: this is not a PCX file."
+msgstr "PCX: ini bukahlah fail PCX."
+
+#: ../src/common/imagpcx.cpp:453
+msgid "PCX: image format unsupported"
+msgstr "PCX: format imej tidak disokong"
+
+#: ../src/common/imagpcx.cpp:454 ../src/common/imagpcx.cpp:477
+msgid "PCX: couldn't allocate memory"
+msgstr "PCX: gagal menempatkan memori"
+
+#: ../src/common/imagpcx.cpp:455
+msgid "PCX: version number too low"
+msgstr "PCX: nombor versi terlalu rendah"
+
+#: ../src/common/imagpcx.cpp:456 ../src/common/imagpcx.cpp:478
+msgid "PCX: unknown error !!!"
+msgstr "PCX: ralat tidak diketahui !!!"
+
+#: ../src/common/imagpcx.cpp:476
+msgid "PCX: invalid image"
+msgstr "PCX: imej tidak sah"
+
+#: ../src/common/imagpng.cpp:385
+#, fuzzy, c-format
+msgid "Unknown PNG resolution unit %d"
+msgstr "Pilihan '%s' tidak diketahui"
+
+#: ../src/common/imagpng.cpp:439
+msgid "Couldn't load a PNG image - file is corrupted or not enough memory."
+msgstr "Gagal memuat imej PNG - fail telah rosak atau tidak cukup memori."
+
+#: ../src/common/imagpng.cpp:513 ../src/common/imagpng.cpp:524
+#: ../src/common/imagpng.cpp:534
+msgid "Couldn't save PNG image."
+msgstr "Gagal simpan imej PNG."
+
+#: ../src/common/imagpnm.cpp:71
+msgid "PNM: File format is not recognized."
+msgstr "PNM: Format fail tidak dikenal."
+
+#: ../src/common/imagpnm.cpp:89
+msgid "PNM: Couldn't allocate memory."
+msgstr "PNM: Gagal menempatkan memori"
+
+#: ../src/common/imagpnm.cpp:111 ../src/common/imagpnm.cpp:134
+#: ../src/common/imagpnm.cpp:156
+msgid "PNM: File seems truncated."
+msgstr "PNM: Fail seperti dipotong."
+
+#: ../src/common/imagtiff.cpp:69
+#, fuzzy, c-format
+msgid " (in module \"%s\")"
+msgstr "modul tiff: %s"
+
+#: ../src/common/imagtiff.cpp:304
+msgid "TIFF: Error loading image."
+msgstr "TIFF: Ralat memuat imej."
+
+#: ../src/common/imagtiff.cpp:314
+msgid "Invalid TIFF image index."
+msgstr "Indeks imej TIFF tidak sah."
+
+#: ../src/common/imagtiff.cpp:358
+msgid "TIFF: Image size is abnormally big."
+msgstr ""
+
+#: ../src/common/imagtiff.cpp:372 ../src/common/imagtiff.cpp:385
+#: ../src/common/imagtiff.cpp:769
+msgid "TIFF: Couldn't allocate memory."
+msgstr "TIFF: Gagal menempatkan memori"
+
+#: ../src/common/imagtiff.cpp:471
+msgid "TIFF: Error reading image."
+msgstr "TIFF: Ralat membaca imej."
+
+#: ../src/common/imagtiff.cpp:532
+#, c-format
+msgid "Unknown TIFF resolution unit %d ignored"
+msgstr ""
+
+#: ../src/common/imagtiff.cpp:611
+msgid "TIFF: Error saving image."
+msgstr "TIFF: Ralat menyimpan imej."
+
+#: ../src/common/imagtiff.cpp:868
+msgid "TIFF: Error writing image."
+msgstr "TIFF: Ralat menulis imej."
+
+#: ../src/common/imagtiff.cpp:881
+#, fuzzy
+msgid "TIFF: Error flushing data."
+msgstr "TIFF: Ralat menyimpan imej."
+
+#: ../src/common/imagwebp.cpp:56
+msgid "WebP: Invalid data (failed to get features)."
+msgstr ""
+
+#: ../src/common/imagwebp.cpp:65
+msgid "WebP: Allocating image memory failed."
+msgstr ""
+
+#: ../src/common/imagwebp.cpp:82
+msgid "WebP: Decoding RGBA image data failed."
+msgstr ""
+
+#: ../src/common/imagwebp.cpp:98
+msgid "WebP: Decoding RGB image data failed."
+msgstr ""
+
+#: ../src/common/imagwebp.cpp:113 ../src/common/imagwebp.cpp:201
+msgid "WebP: Allocating stream buffer failed."
+msgstr ""
+
+#: ../src/common/imagwebp.cpp:131
+#, fuzzy
+msgid "WebP: Failed to parse container data."
+msgstr "Gagal tetapkan data klipbod."
+
+#: ../src/common/imagwebp.cpp:222
+#, fuzzy
+msgid "WebP: Error decoding animation."
+msgstr "Ralat membaca pilihan konfig."
+
+#: ../src/common/imagwebp.cpp:240
+msgid "WebP: Error getting next animation frame."
+msgstr ""
+
+#: ../src/common/init.cpp:172
+#, c-format
+msgid ""
+"Command line argument %d couldn't be converted to Unicode and will be "
+"ignored."
+msgstr ""
+
+#: ../src/common/init.cpp:344
+msgid "Initialization failed in post init, aborting."
+msgstr "Permulaan gagal pada mula pos, gugurkan."
+
+#: ../src/common/intl.cpp:378
+#, c-format
+msgid "Cannot set locale to language \"%s\"."
+msgstr ""
+
+#: ../src/common/log.cpp:232
+msgid "Error: "
+msgstr "Ralat: "
+
+#: ../src/common/log.cpp:236
+msgid "Warning: "
+msgstr "Amaran:"
+
+#: ../src/common/log.cpp:284
+msgid "The previous message repeated once."
+msgstr ""
+
+#: ../src/common/log.cpp:291
+#, c-format
+msgid "The previous message repeated %u time."
+msgid_plural "The previous message repeated %u times."
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../src/common/log.cpp:319
+#, c-format
+msgid "Last repeated message (\"%s\", %u time) wasn't output"
+msgid_plural "Last repeated message (\"%s\", %u times) wasn't output"
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../src/common/log.cpp:435
+#, c-format
+msgid " (error %ld: %s)"
+msgstr " (ralat %ld: %s)"
+
+#: ../src/common/lzmastream.cpp:121
+#, fuzzy
+msgid "Failed to allocate memory for LZMA decompression."
+msgstr "Gagal mencipta kursor."
+
+#: ../src/common/lzmastream.cpp:125
+#, c-format
+msgid "Failed to initialize LZMA decompression: unexpected error %u."
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:179
+msgid "input is not in XZ format"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:183
+msgid "input compressed using unknown XZ option"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:188
+msgid "input is corrupted"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:192
+#, fuzzy
+msgid "unknown decompression error"
+msgstr "ralat nyahmampat"
+
+#: ../src/common/lzmastream.cpp:196
+#, fuzzy, c-format
+msgid "LZMA decompression error: %s"
+msgstr "ralat nyahmampat"
+
+#: ../src/common/lzmastream.cpp:231
+#, fuzzy
+msgid "Failed to allocate memory for LZMA compression."
+msgstr "Gagal mencipta kursor."
+
+#: ../src/common/lzmastream.cpp:235
+#, c-format
+msgid "Failed to initialize LZMA compression: unexpected error %u."
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:267 ../src/common/lzmastream.cpp:342
+#: ../src/html/chm.cpp:336
+msgid "out of memory"
+msgstr "luar lingkungan memori"
+
+#: ../src/common/lzmastream.cpp:276 ../src/common/lzmastream.cpp:346
+#, fuzzy
+msgid "unknown compression error"
+msgstr "ralat mampatan"
+
+#: ../src/common/lzmastream.cpp:280
+#, fuzzy, c-format
+msgid "LZMA compression error: %s"
+msgstr "ralat mampatan"
+
+#: ../src/common/lzmastream.cpp:350
+#, c-format
+msgid "LZMA compression error when flushing output: %s"
+msgstr ""
+
+#: ../src/common/mimecmn.cpp:167
+#, c-format
+msgid "Unmatched '{' in an entry for mime type %s."
+msgstr "'{' tidak sepadan dalam masukan mime types %s."
+
+#: ../src/common/module.cpp:76
+#, c-format
+msgid "Circular dependency involving module \"%s\" detected."
+msgstr "Kebergantungan edaran dikesan melibatkan modul \"%s\"."
+
+#: ../src/common/module.cpp:128
+#, c-format
+msgid "Dependency \"%s\" of module \"%s\" doesn't exist."
+msgstr "Kebergantungan modul \"%s\" daripada \"%s\" tidak wujud."
+
+#: ../src/common/module.cpp:137
+#, c-format
+msgid "Module \"%s\" initialization failed"
+msgstr "Modul \"%s\" gagal dimulakan"
+
+#: ../src/common/msgout.cpp:96
+#, fuzzy
+msgid "Message"
+msgstr "%s mesej"
+
+#: ../src/common/paper.cpp:70
+msgid "Letter, 8 1/2 x 11 in"
+msgstr "Surat, 8 1/2 x 11 in"
+
+#: ../src/common/paper.cpp:71
+msgid "Legal, 8 1/2 x 14 in"
+msgstr "Legal, 8 1/2 x 14 in"
+
+#: ../src/common/paper.cpp:72
+msgid "A4 sheet, 210 x 297 mm"
+msgstr "Helai A4, 210 x 297 mm"
+
+#: ../src/common/paper.cpp:73
+msgid "C sheet, 17 x 22 in"
+msgstr "Helai C, 17 x 22 in"
+
+#: ../src/common/paper.cpp:74
+msgid "D sheet, 22 x 34 in"
+msgstr "Helai D, 22 x 34 in"
+
+#: ../src/common/paper.cpp:75
+msgid "E sheet, 34 x 44 in"
+msgstr "Helai E, 34 x 44 in"
+
+#: ../src/common/paper.cpp:76
+msgid "Letter Small, 8 1/2 x 11 in"
+msgstr "Surat Kecil, 8 1/2 x 11 in"
+
+#: ../src/common/paper.cpp:77
+msgid "Tabloid, 11 x 17 in"
+msgstr "Tabloid, 11 x 17 in"
+
+#: ../src/common/paper.cpp:78
+msgid "Ledger, 17 x 11 in"
+msgstr "Ledger, 17 x 11 in"
+
+#: ../src/common/paper.cpp:79
+msgid "Statement, 5 1/2 x 8 1/2 in"
+msgstr "Kenyataan, 5 1/2 x 8 1/2 in"
+
+#: ../src/common/paper.cpp:80
+msgid "Executive, 7 1/4 x 10 1/2 in"
+msgstr "Eksekutif, 7 1/4 x 10 1/2 in"
+
+#: ../src/common/paper.cpp:81
+msgid "A3 sheet, 297 x 420 mm"
+msgstr "Helai A3, 297 x 420 mm"
+
+#: ../src/common/paper.cpp:82
+msgid "A4 small sheet, 210 x 297 mm"
+msgstr "Helai kecil A4, 210 x 297 mm"
+
+#: ../src/common/paper.cpp:83
+msgid "A5 sheet, 148 x 210 mm"
+msgstr "Helai A5, 148 x 210 mm"
+
+#: ../src/common/paper.cpp:84
+msgid "B4 sheet, 250 x 354 mm"
+msgstr "Helai B4, 250 x 354 mm"
+
+#: ../src/common/paper.cpp:85
+msgid "B5 sheet, 182 x 257 millimeter"
+msgstr "Helai B5, 182 x 257 mm"
+
+#: ../src/common/paper.cpp:86
+msgid "Folio, 8 1/2 x 13 in"
+msgstr "Folio, 8 1/2 x 13 in"
+
+#: ../src/common/paper.cpp:87
+msgid "Quarto, 215 x 275 mm"
+msgstr "Quarto, 215 x 275 mm"
+
+#: ../src/common/paper.cpp:88
+msgid "10 x 14 in"
+msgstr "10 x 14 in"
+
+#: ../src/common/paper.cpp:89
+msgid "11 x 17 in"
+msgstr "11 x 17 in"
+
+#: ../src/common/paper.cpp:90
+msgid "Note, 8 1/2 x 11 in"
+msgstr "Nota, 8 1/2 x 11 in"
+
+#: ../src/common/paper.cpp:91
+msgid "#9 Envelope, 3 7/8 x 8 7/8 in"
+msgstr "Sampul #9, 3 7/8 x 8 7/8 in"
+
+#: ../src/common/paper.cpp:92
+msgid "#10 Envelope, 4 1/8 x 9 1/2 in"
+msgstr "Sampul #10, 4 1/8 x 9 1/2 in"
+
+#: ../src/common/paper.cpp:93
+msgid "#11 Envelope, 4 1/2 x 10 3/8 in"
+msgstr "Sampul #11, 4 1/2 x 10 3/8 in"
+
+#: ../src/common/paper.cpp:94
+msgid "#12 Envelope, 4 3/4 x 11 in"
+msgstr "Sampul #12, 4 3/4 x 11 in"
+
+#: ../src/common/paper.cpp:95
+msgid "#14 Envelope, 5 x 11 1/2 in"
+msgstr "Sampul #14, 5 x 11 1/2 in"
+
+#: ../src/common/paper.cpp:96
+msgid "DL Envelope, 110 x 220 mm"
+msgstr "Sampul DL, 110 x 220 mm"
+
+#: ../src/common/paper.cpp:97
+msgid "C5 Envelope, 162 x 229 mm"
+msgstr "Sampul C5, 162 x 229 mm"
+
+#: ../src/common/paper.cpp:98
+msgid "C3 Envelope, 324 x 458 mm"
+msgstr "Sampul C3, 324 x 458 mm"
+
+#: ../src/common/paper.cpp:99
+msgid "C4 Envelope, 229 x 324 mm"
+msgstr "Sampul C4, 229 x 324 mm"
+
+#: ../src/common/paper.cpp:100
+msgid "C6 Envelope, 114 x 162 mm"
+msgstr "Sampul C6, 114 x 162 mm"
+
+#: ../src/common/paper.cpp:101
+msgid "C65 Envelope, 114 x 229 mm"
+msgstr "Sampul C65, 114 x 229 mm"
+
+#: ../src/common/paper.cpp:102
+msgid "B4 Envelope, 250 x 353 mm"
+msgstr "B4 Envelope, 250 x 353 mm"
+
+#: ../src/common/paper.cpp:103
+msgid "B5 Envelope, 176 x 250 mm"
+msgstr "Sampul B5, 176 x 250 mm"
+
+#: ../src/common/paper.cpp:104
+msgid "B6 Envelope, 176 x 125 mm"
+msgstr "Sampul B6, 176 x 125 mm"
+
+#: ../src/common/paper.cpp:105
+msgid "Italy Envelope, 110 x 230 mm"
+msgstr "Sampul Itali, 110 x 230 mm"
+
+#: ../src/common/paper.cpp:106
+msgid "Monarch Envelope, 3 7/8 x 7 1/2 in"
+msgstr "Monarch Envelope, 3 7/8 x 7 1/2 in"
+
+#: ../src/common/paper.cpp:107
+msgid "6 3/4 Envelope, 3 5/8 x 6 1/2 in"
+msgstr "Sampul 6 3/4, 3 5/8 x 6 1/2 in"
+
+#: ../src/common/paper.cpp:108
+msgid "US Std Fanfold, 14 7/8 x 11 in"
+msgstr "Fanfold Piawai US, 14 7/8 x 11 in"
+
+#: ../src/common/paper.cpp:109
+msgid "German Std Fanfold, 8 1/2 x 12 in"
+msgstr "Fanfold Piawai Jerman, 8 1/2 x 12 in"
+
+#: ../src/common/paper.cpp:110
+msgid "German Legal Fanfold, 8 1/2 x 13 in"
+msgstr "Fanfold Legal Jerman, 8 1/2 x 13 in"
+
+#: ../src/common/paper.cpp:112
+msgid "B4 (ISO) 250 x 353 mm"
+msgstr "B4 (ISO) 250 x 353 mm"
+
+#: ../src/common/paper.cpp:113
+msgid "Japanese Postcard 100 x 148 mm"
+msgstr "Poskad Jepun 100 x 148 mm"
+
+#: ../src/common/paper.cpp:114
+msgid "9 x 11 in"
+msgstr "9 x 11 in"
+
+#: ../src/common/paper.cpp:115
+msgid "10 x 11 in"
+msgstr "10 x 11 in"
+
+#: ../src/common/paper.cpp:116
+msgid "15 x 11 in"
+msgstr "15 x 11 in"
+
+#: ../src/common/paper.cpp:117
+msgid "Envelope Invite 220 x 220 mm"
+msgstr "Sampul Jemputan 220 x 220 mm"
+
+#: ../src/common/paper.cpp:118
+msgid "Letter Extra 9 1/2 x 12 in"
+msgstr "Letter Ekstra 9 1/2 x 12 in"
+
+#: ../src/common/paper.cpp:119
+msgid "Legal Extra 9 1/2 x 15 in"
+msgstr "Legal Ekstra 9 1/2 x 15 in"
+
+#: ../src/common/paper.cpp:120
+msgid "Tabloid Extra 11.69 x 18 in"
+msgstr "Tabloid Ekstra 11.69 x 18 in"
+
+#: ../src/common/paper.cpp:121
+msgid "A4 Extra 9.27 x 12.69 in"
+msgstr "A4 Ekstra 9.27 x 12.69 in"
+
+#: ../src/common/paper.cpp:122
+msgid "Letter Transverse 8 1/2 x 11 in"
+msgstr "Surat Lintang 8 1/2 x 11 in"
+
+#: ../src/common/paper.cpp:123
+msgid "A4 Transverse 210 x 297 mm"
+msgstr "A4 Lintang 210 x 297 mm"
+
+#: ../src/common/paper.cpp:124
+msgid "Letter Extra Transverse 9.275 x 12 in"
+msgstr "Surat Ekstra Lintang 9.275 x 12 in"
+
+#: ../src/common/paper.cpp:125
+msgid "SuperA/SuperA/A4 227 x 356 mm"
+msgstr "SuperA/SuperA/A4 227 x 356 mm"
+
+#: ../src/common/paper.cpp:126
+msgid "SuperB/SuperB/A3 305 x 487 mm"
+msgstr "SuperB/SuperB/A3 305 x 487 mm"
+
+#: ../src/common/paper.cpp:127
+msgid "Letter Plus 8 1/2 x 12.69 in"
+msgstr "Surat Tambah 8 1/2 x 12.69 in"
+
+#: ../src/common/paper.cpp:128
+msgid "A4 Plus 210 x 330 mm"
+msgstr "A4 Tambah 210 x 330 mm"
+
+#: ../src/common/paper.cpp:129
+msgid "A5 Transverse 148 x 210 mm"
+msgstr "A5 Lintang 148 x 210 mm"
+
+#: ../src/common/paper.cpp:130
+msgid "B5 (JIS) Transverse 182 x 257 mm"
+msgstr "B5 (JIS) Lintang 182 x 257 mm"
+
+#: ../src/common/paper.cpp:131
+msgid "A3 Extra 322 x 445 mm"
+msgstr "A3 Extra 322 x 445 mm"
+
+#: ../src/common/paper.cpp:132
+msgid "A5 Extra 174 x 235 mm"
+msgstr "A5 Ekstra 174 x 235 mm"
+
+#: ../src/common/paper.cpp:133
+msgid "B5 (ISO) Extra 201 x 276 mm"
+msgstr "B5 (ISO) Ekstra 201 x 276 mm"
+
+#: ../src/common/paper.cpp:134
+msgid "A2 420 x 594 mm"
+msgstr "A2 420 x 594 mm"
+
+#: ../src/common/paper.cpp:135
+msgid "A3 Transverse 297 x 420 mm"
+msgstr "A3 Lintang 297 x 420 mm"
+
+#: ../src/common/paper.cpp:136
+msgid "A3 Extra Transverse 322 x 445 mm"
+msgstr "A3 Ekstra Lintang 322 x 445 mm"
+
+#: ../src/common/paper.cpp:138
+msgid "Japanese Double Postcard 200 x 148 mm"
+msgstr "Poskad Jepun Ganda Dua 200 x 148 mm"
+
+#: ../src/common/paper.cpp:139
+msgid "A6 105 x 148 mm"
+msgstr "A6 105 x 148 mm"
+
+#: ../src/common/paper.cpp:140
+msgid "Japanese Envelope Kaku #2"
+msgstr "Sampul Jepun Kaku #2"
+
+#: ../src/common/paper.cpp:141
+msgid "Japanese Envelope Kaku #3"
+msgstr "Sampul Jepun Kaku #3"
+
+#: ../src/common/paper.cpp:142
+msgid "Japanese Envelope Chou #3"
+msgstr "Sampul Jepun Chou #3"
+
+#: ../src/common/paper.cpp:143
+msgid "Japanese Envelope Chou #4"
+msgstr "Sampul Jepun Chou #4"
+
+#: ../src/common/paper.cpp:144
+msgid "Letter Rotated 11 x 8 1/2 in"
+msgstr "Surat Diputar 11 x 8 1/2 in"
+
+#: ../src/common/paper.cpp:145
+msgid "A3 Rotated 420 x 297 mm"
+msgstr "A3 Diputar 420 x 297 mm"
+
+#: ../src/common/paper.cpp:146
+msgid "A4 Rotated 297 x 210 mm"
+msgstr "A4 Diputar 297 x 210 mm"
+
+#: ../src/common/paper.cpp:147
+msgid "A5 Rotated 210 x 148 mm"
+msgstr "A5 Diputar 210 x 148 mm"
+
+#: ../src/common/paper.cpp:148
+msgid "B4 (JIS) Rotated 364 x 257 mm"
+msgstr "B4 (JIS) Diputar 364 x 257 mm"
+
+#: ../src/common/paper.cpp:149
+msgid "B5 (JIS) Rotated 257 x 182 mm"
+msgstr "B5 (JIS) Diputar 257 x 182 mm"
+
+#: ../src/common/paper.cpp:150
+msgid "Japanese Postcard Rotated 148 x 100 mm"
+msgstr "Poskad Jepun Diputar 148 x 100 mm"
+
+#: ../src/common/paper.cpp:151
+msgid "Double Japanese Postcard Rotated 148 x 200 mm"
+msgstr "Poskad Jepun Berganda Dua Diputar 148 x 200 mm"
+
+#: ../src/common/paper.cpp:152
+msgid "A6 Rotated 148 x 105 mm"
+msgstr "A6 Diputar 148 x 105 mm"
+
+#: ../src/common/paper.cpp:153
+msgid "Japanese Envelope Kaku #2 Rotated"
+msgstr "Sampul Jepun Kaku #2 Diputar"
+
+#: ../src/common/paper.cpp:154
+msgid "Japanese Envelope Kaku #3 Rotated"
+msgstr "Sampul Jepun Kaku #3 Diputar"
+
+#: ../src/common/paper.cpp:155
+msgid "Japanese Envelope Chou #3 Rotated"
+msgstr "Sampul Jepun Chou #3 Diputar"
+
+#: ../src/common/paper.cpp:156
+msgid "Japanese Envelope Chou #4 Rotated"
+msgstr "Sampul Jepun Chou #4 Diputar"
+
+#: ../src/common/paper.cpp:157
+msgid "B6 (JIS) 128 x 182 mm"
+msgstr "B6 (JIS) 128 x 182 mm"
+
+#: ../src/common/paper.cpp:158
+msgid "B6 (JIS) Rotated 182 x 128 mm"
+msgstr "B6 (JIS) Diputar 182 x 128 mm"
+
+#: ../src/common/paper.cpp:159
+msgid "12 x 11 in"
+msgstr "12 x 11 in"
+
+#: ../src/common/paper.cpp:160
+msgid "Japanese Envelope You #4"
+msgstr "Sampul Jepun You #4"
+
+#: ../src/common/paper.cpp:161
+msgid "Japanese Envelope You #4 Rotated"
+msgstr "Sampul Jepun You #4 Diputar"
+
+#: ../src/common/paper.cpp:162
+msgid "PRC 16K 146 x 215 mm"
+msgstr "PRC 16K 146 x 215 mm"
+
+#: ../src/common/paper.cpp:163
+msgid "PRC 32K 97 x 151 mm"
+msgstr "PRC 32K 97 x 151 mm"
+
+#: ../src/common/paper.cpp:164
+msgid "PRC 32K(Big) 97 x 151 mm"
+msgstr "PRC 32K(Besar) 97 x 151 mm"
+
+#: ../src/common/paper.cpp:165
+msgid "PRC Envelope #1 102 x 165 mm"
+msgstr "Sampul PRC #1 102 x 165 mm"
+
+#: ../src/common/paper.cpp:166
+msgid "PRC Envelope #2 102 x 176 mm"
+msgstr "Sampul PRC #2 102 x 176 mm"
+
+#: ../src/common/paper.cpp:167
+msgid "PRC Envelope #3 125 x 176 mm"
+msgstr "Sampul PRC #3 125 x 176 mm"
+
+#: ../src/common/paper.cpp:168
+msgid "PRC Envelope #4 110 x 208 mm"
+msgstr "Sampul PRC #4 110 x 208 mm"
+
+#: ../src/common/paper.cpp:169
+msgid "PRC Envelope #5 110 x 220 mm"
+msgstr "Sampul PRC #5 110 x 220 mm"
+
+#: ../src/common/paper.cpp:170
+msgid "PRC Envelope #6 120 x 230 mm"
+msgstr "Sampul PRC #6 120 x 230 mm"
+
+#: ../src/common/paper.cpp:171
+msgid "PRC Envelope #7 160 x 230 mm"
+msgstr "Sampul PRC #7 160 x 230 mm"
+
+#: ../src/common/paper.cpp:172
+msgid "PRC Envelope #8 120 x 309 mm"
+msgstr "Sampul PRC #8 120 x 309 mm"
+
+#: ../src/common/paper.cpp:173
+msgid "PRC Envelope #9 229 x 324 mm"
+msgstr "Sampul PRC #9 229 x 324 mm"
+
+#: ../src/common/paper.cpp:174
+msgid "PRC Envelope #10 324 x 458 mm"
+msgstr "Sampul PRC #10 324 x 458 mm"
+
+#: ../src/common/paper.cpp:175
+msgid "PRC 16K Rotated"
+msgstr "PRC 16K Diputar"
+
+#: ../src/common/paper.cpp:176
+msgid "PRC 32K Rotated"
+msgstr "PRC 32K Diputar"
+
+#: ../src/common/paper.cpp:177
+msgid "PRC 32K(Big) Rotated"
+msgstr "PRC 32K(Besar) Diputar"
+
+#: ../src/common/paper.cpp:178
+msgid "PRC Envelope #1 Rotated 165 x 102 mm"
+msgstr "Sampul PRC #1 Diputar 165 x 102 mm"
+
+#: ../src/common/paper.cpp:179
+msgid "PRC Envelope #2 Rotated 176 x 102 mm"
+msgstr "Sampul PRC #2 Diputar 176 x 102 mm"
+
+#: ../src/common/paper.cpp:180
+msgid "PRC Envelope #3 Rotated 176 x 125 mm"
+msgstr "Sampul PRC #3 Diputar 176 x 125 mm"
+
+#: ../src/common/paper.cpp:181
+msgid "PRC Envelope #4 Rotated 208 x 110 mm"
+msgstr "Sampul PRC #4 Diputar 208 x 110 mm"
+
+#: ../src/common/paper.cpp:182
+msgid "PRC Envelope #5 Rotated 220 x 110 mm"
+msgstr "Sampul PRC #5 Diputar 220 x 110 mm"
+
+#: ../src/common/paper.cpp:183
+msgid "PRC Envelope #6 Rotated 230 x 120 mm"
+msgstr "Sampul PRC #6  Diputar 230 x 120 mm"
+
+#: ../src/common/paper.cpp:184
+msgid "PRC Envelope #7 Rotated 230 x 160 mm"
+msgstr "Sampul PRC #7 Diputar 230 x 160 mm"
+
+#: ../src/common/paper.cpp:185
+msgid "PRC Envelope #8 Rotated 309 x 120 mm"
+msgstr "Sampul PRC #8 Diputar 309 x 120 mm"
+
+#: ../src/common/paper.cpp:186
+msgid "PRC Envelope #9 Rotated 324 x 229 mm"
+msgstr "Sampul PRC #9 Diputar 324 x 229 mm"
+
+#: ../src/common/paper.cpp:187
+msgid "PRC Envelope #10 Rotated 458 x 324 mm"
+msgstr "PRC Envelope #10 Rotated 458 x 324 mm"
+
+#: ../src/common/paper.cpp:192
+#, fuzzy
+msgid "A0 sheet, 841 x 1189 mm"
+msgstr "Helai A4, 210 x 297 mm"
+
+#: ../src/common/paper.cpp:193
+#, fuzzy
+msgid "A1 sheet, 594 x 841 mm"
+msgstr "Helai A3, 297 x 420 mm"
+
+#: ../src/common/preferencescmn.cpp:37
+msgid "General"
+msgstr ""
+
+#: ../src/common/preferencescmn.cpp:40
+msgid "Advanced"
+msgstr ""
+
+#: ../src/common/prntbase.cpp:245
+msgid "Generic PostScript"
+msgstr "PostScript Umum"
+
+#: ../src/common/prntbase.cpp:259
+msgid "Ready"
+msgstr "Sedia"
+
+#: ../src/common/prntbase.cpp:331
+msgid "Printing Error"
+msgstr "Ralat mencetak"
+
+#: ../src/common/prntbase.cpp:413 ../src/common/prntbase.cpp:1597
+#: ../src/generic/prntdlgg.cpp:135 ../src/generic/prntdlgg.cpp:149
+#: ../src/gtk/print.cpp:628 ../src/gtk/print.cpp:646
+msgid "Print"
+msgstr "Cetak"
+
+#: ../src/common/prntbase.cpp:471 ../src/generic/prntdlgg.cpp:809
+msgid "Page setup"
+msgstr "Tetapan halaman"
+
+#: ../src/common/prntbase.cpp:525
+#, fuzzy
+msgid "Please wait while printing..."
+msgstr "Sila tunggu semasa mencetak\n"
+
+#: ../src/common/prntbase.cpp:529
+#, fuzzy
+msgid "Document:"
+msgstr "Dokumentasi oleh"
+
+#: ../src/common/prntbase.cpp:532
+msgid "Progress:"
+msgstr ""
+
+#: ../src/common/prntbase.cpp:533
+msgid "Preparing"
+msgstr ""
+
+#: ../src/common/prntbase.cpp:552
+#, fuzzy, c-format
+msgid "Printing page %d"
+msgstr "Mencetak laman %d..."
+
+#: ../src/common/prntbase.cpp:557
+#, fuzzy, c-format
+msgid "Printing page %d of %d"
+msgstr "Mencetak laman %d..."
+
+#: ../src/common/prntbase.cpp:560
+#, fuzzy, c-format
+msgid " (copy %d of %d)"
+msgstr "Laman %d of %d"
+
+#: ../src/common/prntbase.cpp:1604
+#, fuzzy
+msgid "First page"
+msgstr "Laman berikut"
+
+#: ../src/common/prntbase.cpp:1609 ../src/html/helpwnd.cpp:659
+msgid "Previous page"
+msgstr "Laman sebelum:"
+
+#: ../src/common/prntbase.cpp:1623 ../src/html/helpwnd.cpp:660
+msgid "Next page"
+msgstr "Laman berikut"
+
+#: ../src/common/prntbase.cpp:1628
+#, fuzzy
+msgid "Last page"
+msgstr "Laman berikut"
+
+#: ../src/common/prntbase.cpp:1636 ../src/common/stockitem.cpp:215
+#, fuzzy
+msgid "Zoom Out"
+msgstr "Zum Keluar"
+
+#: ../src/common/prntbase.cpp:1650 ../src/common/stockitem.cpp:214
+#, fuzzy
+msgid "Zoom In"
+msgstr "Zum Masuk"
+
+#: ../src/common/prntbase.cpp:1656 ../src/common/stockitem.cpp:153
+#: ../src/generic/logg.cpp:553 ../src/univ/themes/win32.cpp:3752
+msgid "&Close"
+msgstr "&Tutup"
+
+#: ../src/common/prntbase.cpp:2085
+msgid "Could not start document preview."
+msgstr "Gagal mulakan pralihat dokumen."
+
+#: ../src/common/prntbase.cpp:2085 ../src/common/prntbase.cpp:2129
+#: ../src/common/prntbase.cpp:2137
+msgid "Print Preview Failure"
+msgstr "Gagal Pralihat Cetakan"
+
+#: ../src/common/prntbase.cpp:2129 ../src/common/prntbase.cpp:2137
+msgid "Sorry, not enough memory to create a preview."
+msgstr "Maaf, tidak cukup memori untuk mencipta pralihat."
+
+#: ../src/common/prntbase.cpp:2144
+#, c-format
+msgid "Page %d of %d"
+msgstr "Laman %d of %d"
+
+#: ../src/common/prntbase.cpp:2146
+#, c-format
+msgid "Page %d"
+msgstr "Laman %d"
+
+#: ../src/common/regex.cpp:382 ../src/html/chm.cpp:348
+msgid "unknown error"
+msgstr "ralat tidak diketahui"
+
+#: ../src/common/regex.cpp:995
+#, c-format
+msgid "Invalid regular expression '%s': %s"
+msgstr "Ungkapan nalar '%s' tidak sah: %s"
+
+#: ../src/common/regex.cpp:1059
+#, c-format
+msgid "Failed to find match for regular expression: %s"
+msgstr "Gagal menemui padanan ungkapan nalar: %s"
+
+#: ../src/common/rendcmn.cpp:188
+#, c-format
+msgid "Renderer \"%s\" has incompatible version %d.%d and couldn't be loaded."
+msgstr ""
+"Pelaku \"%s\" mempunyai versi %d.%d yang tidak serasi dan tidak akan "
+"dimuatkan."
+
+#: ../src/common/secretstore.cpp:162
+msgid "Not available for this platform"
+msgstr ""
+
+#: ../src/common/secretstore.cpp:183
+#, fuzzy, c-format
+msgid "Saving password for \"%s\" failed: %s."
+msgstr "Pengekstrakan '%s' kepada '%s' gagal."
+
+#: ../src/common/secretstore.cpp:205
+#, fuzzy, c-format
+msgid "Reading password for \"%s\" failed: %s."
+msgstr "Pengekstrakan '%s' kepada '%s' gagal."
+
+#: ../src/common/secretstore.cpp:228
+#, fuzzy, c-format
+msgid "Deleting password for \"%s\" failed: %s."
+msgstr "Pengekstrakan '%s' kepada '%s' gagal."
+
+#: ../src/common/selectdispatcher.cpp:254
+msgid "Failed to monitor I/O channels"
+msgstr ""
+
+#: ../src/common/sizer.cpp:3054 ../src/common/stockitem.cpp:195
+msgid "Save"
+msgstr "Simpan"
+
+#: ../src/common/sizer.cpp:3056
+msgid "Don't Save"
+msgstr "Jangan Simpan"
+
+#: ../src/common/socket.cpp:870
+#, fuzzy
+msgid "Cannot initialize sockets"
+msgstr "Gagal mulakan OLE"
+
+#: ../src/common/stockitem.cpp:127
+#, fuzzy
+msgctxt "standard Windows menu"
+msgid "&Help"
+msgstr "&Bantuan"
+
+#: ../src/common/stockitem.cpp:144
+msgid "&About"
+msgstr "Perih&al"
+
+#: ../src/common/stockitem.cpp:144
+#, fuzzy
+msgid "About"
+msgstr "Perih&al"
+
+#: ../src/common/stockitem.cpp:145
+msgid "Add"
+msgstr "Tambah"
+
+#: ../src/common/stockitem.cpp:146
+msgid "&Apply"
+msgstr "Ter&ap"
+
+#: ../src/common/stockitem.cpp:146
+#, fuzzy
+msgid "Apply"
+msgstr "Ter&ap"
+
+#: ../src/common/stockitem.cpp:147
+msgid "&Back"
+msgstr "Kem&bali"
+
+#: ../src/common/stockitem.cpp:147
+#, fuzzy
+msgid "Back"
+msgstr "Kem&bali"
+
+#: ../src/common/stockitem.cpp:148
+msgid "&Bold"
+msgstr "Te&bal"
+
+#: ../src/common/stockitem.cpp:148 ../src/generic/fontdlgg.cpp:326
+#: ../src/richtext/richtextfontpage.cpp:354
+msgid "Bold"
+msgstr "Tebal"
+
+#: ../src/common/stockitem.cpp:149
+msgid "&Bottom"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:149 ../src/richtext/richtextsizepage.cpp:287
+msgid "Bottom"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:150 ../src/generic/fontdlgg.cpp:462
+#: ../src/generic/fontdlgg.cpp:481 ../src/generic/wizard.cpp:415
+msgid "&Cancel"
+msgstr "&Batal"
+
+#: ../src/common/stockitem.cpp:151
+msgid "&CD-ROM"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:151
+msgid "CD-ROM"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:152
+msgid "&Clear"
+msgstr "Kosongkan"
+
+#: ../src/common/stockitem.cpp:152
+#, fuzzy
+msgid "Clear"
+msgstr "Kosongkan"
+
+#: ../src/common/stockitem.cpp:153 ../src/generic/dbgrptg.cpp:93
+#: ../src/generic/progdlgg.cpp:778 ../src/html/helpdlg.cpp:86
+#: ../src/msw/progdlg.cpp:209 ../src/msw/progdlg.cpp:890
+#: ../src/richtext/richtextstyledlg.cpp:272
+#: ../src/richtext/richtextsymboldlg.cpp:448
+msgid "Close"
+msgstr "Tutup"
+
+#: ../src/common/stockitem.cpp:154
+#, fuzzy
+msgid "&Convert"
+msgstr "Kandungan"
+
+#: ../src/common/stockitem.cpp:154
+#, fuzzy
+msgid "Convert"
+msgstr "Kandungan"
+
+#: ../src/common/stockitem.cpp:155 ../src/msw/textctrl.cpp:2884
+#: ../src/osx/textctrl_osx.cpp:653 ../src/richtext/richtextctrl.cpp:331
+msgid "&Copy"
+msgstr "&Salin"
+
+#: ../src/common/stockitem.cpp:155 ../src/stc/stc_i18n.cpp:18
+#, fuzzy
+msgid "Copy"
+msgstr "&Salin"
+
+#: ../src/common/stockitem.cpp:156 ../src/msw/textctrl.cpp:2883
+#: ../src/osx/textctrl_osx.cpp:652 ../src/richtext/richtextctrl.cpp:330
+msgid "Cu&t"
+msgstr "&Potong"
+
+#: ../src/common/stockitem.cpp:156 ../src/stc/stc_i18n.cpp:17
+#, fuzzy
+msgid "Cut"
+msgstr "&Potong"
+
+#: ../src/common/stockitem.cpp:157 ../src/msw/textctrl.cpp:2886
+#: ../src/osx/textctrl_osx.cpp:655 ../src/richtext/richtextctrl.cpp:333
+#: ../src/richtext/richtexttabspage.cpp:137
+msgid "&Delete"
+msgstr "Pa&dam"
+
+#: ../src/common/stockitem.cpp:157 ../src/richtext/richtextbuffer.cpp:8266
+#: ../src/stc/stc_i18n.cpp:20
+msgid "Delete"
+msgstr "Padam"
+
+#: ../src/common/stockitem.cpp:158
+msgid "&Down"
+msgstr "Turun"
+
+#: ../src/common/stockitem.cpp:158 ../src/generic/fdrepdlg.cpp:148
+msgid "Down"
+msgstr "Turun"
+
+#: ../src/common/stockitem.cpp:159
+msgid "&Edit"
+msgstr "&Edit"
+
+#: ../src/common/stockitem.cpp:159
+#, fuzzy
+msgid "Edit"
+msgstr "&Edit"
+
+#: ../src/common/stockitem.cpp:160
+msgid "&Execute"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:160
+msgid "Execute"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:161
+msgid "&Quit"
+msgstr "&Keluar"
+
+#: ../src/common/stockitem.cpp:161
+#, fuzzy
+msgid "Quit"
+msgstr "&Keluar"
+
+#: ../src/common/stockitem.cpp:162
+msgid "&File"
+msgstr "&Fail"
+
+#: ../src/common/stockitem.cpp:162
+msgid "File"
+msgstr "Fail"
+
+#: ../src/common/stockitem.cpp:163
+#, fuzzy
+msgid "&Find..."
+msgstr "Ca&ri"
+
+#: ../src/common/stockitem.cpp:163
+#, fuzzy
+msgid "Find..."
+msgstr "Cari"
+
+#: ../src/common/stockitem.cpp:164
+#, fuzzy
+msgid "&First"
+msgstr "pertama"
+
+#: ../src/common/stockitem.cpp:164
+#, fuzzy
+msgid "First"
+msgstr "pertama"
+
+#: ../src/common/stockitem.cpp:165
+#, fuzzy
+msgid "&Floppy"
+msgstr "&Salin"
+
+#: ../src/common/stockitem.cpp:165
+#, fuzzy
+msgid "Floppy"
+msgstr "&Salin"
+
+#: ../src/common/stockitem.cpp:166
+msgid "&Forward"
+msgstr "Maju"
+
+#: ../src/common/stockitem.cpp:166
+#, fuzzy
+msgid "Forward"
+msgstr "Maju"
+
+#: ../src/common/stockitem.cpp:167
+msgid "&Harddisk"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:167
+msgid "Harddisk"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:168 ../src/generic/wizard.cpp:418
+#: ../src/osx/cocoa/menu.mm:225 ../src/richtext/richtextstyledlg.cpp:298
+#: ../src/richtext/richtextsymboldlg.cpp:451
+msgid "&Help"
+msgstr "&Bantuan"
+
+#: ../src/common/stockitem.cpp:169
+msgid "&Home"
+msgstr "Ruma&h"
+
+#: ../src/common/stockitem.cpp:169
+msgid "Home"
+msgstr "Rumah"
+
+#: ../src/common/stockitem.cpp:170
+msgid "Indent"
+msgstr "Jarak"
+
+#: ../src/common/stockitem.cpp:171
+msgid "&Index"
+msgstr "&Indeks"
+
+#: ../src/common/stockitem.cpp:171 ../src/html/helpwnd.cpp:510
+msgid "Index"
+msgstr "Indeks"
+
+#: ../src/common/stockitem.cpp:172
+#, fuzzy
+msgid "&Info"
+msgstr "&Nyahcara"
+
+#: ../src/common/stockitem.cpp:172
+msgid "Info"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:173
+msgid "&Italic"
+msgstr "&Italik"
+
+#: ../src/common/stockitem.cpp:173 ../src/generic/fontdlgg.cpp:322
+#: ../src/richtext/richtextfontpage.cpp:350
+msgid "Italic"
+msgstr "Italik"
+
+#: ../src/common/stockitem.cpp:174
+msgid "&Jump to"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:174
+msgid "Jump to"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:175
+msgid "Centered"
+msgstr "Ketengah"
+
+#: ../src/common/stockitem.cpp:176
+msgid "Justified"
+msgstr "Ditentu"
+
+#: ../src/common/stockitem.cpp:177
+msgid "Align Left"
+msgstr "Jajar Kiri"
+
+#: ../src/common/stockitem.cpp:178
+msgid "Align Right"
+msgstr "Jajar Kanan"
+
+#: ../src/common/stockitem.cpp:179
+#, fuzzy
+msgid "&Last"
+msgstr "&Tepek"
+
+#: ../src/common/stockitem.cpp:179
+#, fuzzy
+msgid "Last"
+msgstr "Tampal"
+
+#: ../src/common/stockitem.cpp:180
+#, fuzzy
+msgid "&Network"
+msgstr "&Baru"
+
+#: ../src/common/stockitem.cpp:180
+msgid "Network"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:181 ../src/richtext/richtexttabspage.cpp:131
+msgid "&New"
+msgstr "&Baru"
+
+#: ../src/common/stockitem.cpp:181
+#, fuzzy
+msgid "New"
+msgstr "&Baru"
+
+#: ../src/common/stockitem.cpp:182 ../src/msw/msgdlg.cpp:417
+msgid "&No"
+msgstr "T&idak"
+
+#: ../src/common/stockitem.cpp:183 ../src/generic/fontdlgg.cpp:467
+#: ../src/generic/fontdlgg.cpp:474
+msgid "&OK"
+msgstr "&OK"
+
+#: ../src/common/stockitem.cpp:184 ../src/generic/dbgrptg.cpp:341
+msgid "&Open..."
+msgstr "&Buka..."
+
+#: ../src/common/stockitem.cpp:184
+#, fuzzy
+msgid "Open..."
+msgstr "&Buka..."
+
+#: ../src/common/stockitem.cpp:185 ../src/msw/textctrl.cpp:2885
+#: ../src/osx/textctrl_osx.cpp:654 ../src/richtext/richtextctrl.cpp:332
+msgid "&Paste"
+msgstr "&Tepek"
+
+#: ../src/common/stockitem.cpp:185 ../src/richtext/richtextctrl.cpp:3484
+#: ../src/stc/stc_i18n.cpp:19
+msgid "Paste"
+msgstr "Tampal"
+
+#: ../src/common/stockitem.cpp:186
+msgid "&Preferences"
+msgstr "Keutamaan"
+
+#: ../src/common/stockitem.cpp:186 ../src/osx/cocoa/preferences.mm:304
+#, fuzzy
+msgid "Preferences"
+msgstr "Keutamaan"
+
+#: ../src/common/stockitem.cpp:187
+#, fuzzy
+msgid "Print previe&w..."
+msgstr "Pralihat cetak"
+
+#: ../src/common/stockitem.cpp:187
+#, fuzzy
+msgid "Print preview..."
+msgstr "Pralihat cetak"
+
+#: ../src/common/stockitem.cpp:188
+msgid "&Print..."
+msgstr "Ce&tak..."
+
+#: ../src/common/stockitem.cpp:188
+#, fuzzy
+msgid "Print..."
+msgstr "Ce&tak..."
+
+#: ../src/common/stockitem.cpp:189 ../src/richtext/richtextctrl.cpp:337
+#: ../src/richtext/richtextctrl.cpp:5479
+msgid "&Properties"
+msgstr "&Ciri-ciri"
+
+#: ../src/common/stockitem.cpp:189
+#, fuzzy
+msgid "Properties"
+msgstr "&Ciri-ciri"
+
+#: ../src/common/stockitem.cpp:190 ../src/stc/stc_i18n.cpp:16
+#, fuzzy
+msgid "Redo"
+msgstr "&Ulangcara"
+
+#: ../src/common/stockitem.cpp:191
+msgid "Refresh"
+msgstr "Segarkan"
+
+#: ../src/common/stockitem.cpp:192
+msgid "Remove"
+msgstr "Buang"
+
+#: ../src/common/stockitem.cpp:193
+#, fuzzy
+msgid "Rep&lace..."
+msgstr "Ganti"
+
+#: ../src/common/stockitem.cpp:193
+#, fuzzy
+msgid "Replace..."
+msgstr "Ganti"
+
+#: ../src/common/stockitem.cpp:194
+msgid "Revert to Saved"
+msgstr "Kembali untuk Disimpan"
+
+#: ../src/common/stockitem.cpp:196 ../src/generic/logg.cpp:549
+msgid "Save &As..."
+msgstr "Simp&an Sebagai..."
+
+#: ../src/common/stockitem.cpp:196
+#, fuzzy
+msgid "Save As..."
+msgstr "Simp&an Sebagai..."
+
+#: ../src/common/stockitem.cpp:197 ../src/msw/textctrl.cpp:2888
+#: ../src/osx/textctrl_osx.cpp:657 ../src/richtext/richtextctrl.cpp:335
+msgid "Select &All"
+msgstr "Pilih &Semua"
+
+#: ../src/common/stockitem.cpp:197 ../src/stc/stc_i18n.cpp:21
+#, fuzzy
+msgid "Select All"
+msgstr "Pilih &Semua"
+
+#: ../src/common/stockitem.cpp:198
+#, fuzzy
+msgid "&Color"
+msgstr "Warna:"
+
+#: ../src/common/stockitem.cpp:198
+#, fuzzy
+msgid "Color"
+msgstr "Warna:"
+
+#: ../src/common/stockitem.cpp:199
+#, fuzzy
+msgid "&Font"
+msgstr "&Fon:"
+
+#: ../src/common/stockitem.cpp:199 ../src/richtext/richtextformatdlg.cpp:336
+msgid "Font"
+msgstr "Fon"
+
+#: ../src/common/stockitem.cpp:200
+msgid "&Ascending"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:200
+#, fuzzy
+msgid "Ascending"
+msgstr "membaca"
+
+#: ../src/common/stockitem.cpp:201
+msgid "&Descending"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:201
+#, fuzzy
+msgid "Descending"
+msgstr "Pengenkodan default"
+
+#: ../src/common/stockitem.cpp:202
+msgid "&Spell Check"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:202
+msgid "Spell Check"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:203
+msgid "&Stop"
+msgstr "&Henti"
+
+#: ../src/common/stockitem.cpp:203
+#, fuzzy
+msgid "Stop"
+msgstr "&Henti"
+
+#: ../src/common/stockitem.cpp:204 ../src/richtext/richtextfontpage.cpp:274
+msgid "&Strikethrough"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:204
+msgid "Strikethrough"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:205
+#, fuzzy
+msgid "&Top"
+msgstr "&Salin"
+
+#: ../src/common/stockitem.cpp:205 ../src/richtext/richtextsizepage.cpp:285
+#: ../src/richtext/richtextsizepage.cpp:289
+#, fuzzy
+msgid "Top"
+msgstr "Ke:"
+
+#: ../src/common/stockitem.cpp:206
+msgid "Undelete"
+msgstr "Nyahpadam"
+
+#: ../src/common/stockitem.cpp:207 ../src/generic/fontdlgg.cpp:437
+msgid "&Underline"
+msgstr "Garis bawah"
+
+#: ../src/common/stockitem.cpp:207
+#, fuzzy
+msgid "Underline"
+msgstr "Garis bawah"
+
+#: ../src/common/stockitem.cpp:208 ../src/stc/stc_i18n.cpp:15
+#, fuzzy
+msgid "Undo"
+msgstr "&Nyahcara"
+
+#: ../src/common/stockitem.cpp:209
+msgid "&Unindent"
+msgstr "Nyahjarak"
+
+#: ../src/common/stockitem.cpp:209
+#, fuzzy
+msgid "Unindent"
+msgstr "Nyahjarak"
+
+#: ../src/common/stockitem.cpp:210
+msgid "&Up"
+msgstr "A&tas"
+
+#: ../src/common/stockitem.cpp:210 ../src/generic/fdrepdlg.cpp:148
+msgid "Up"
+msgstr "Naik"
+
+#: ../src/common/stockitem.cpp:211 ../src/msw/msgdlg.cpp:417
+msgid "&Yes"
+msgstr "&Ya"
+
+#: ../src/common/stockitem.cpp:212
+msgid "&Actual Size"
+msgstr "Saiz Seben&ar"
+
+#: ../src/common/stockitem.cpp:212
+#, fuzzy
+msgid "Actual Size"
+msgstr "Saiz Seben&ar"
+
+#: ../src/common/stockitem.cpp:213
+msgid "Zoom to &Fit"
+msgstr "Zum Muat"
+
+#: ../src/common/stockitem.cpp:213
+#, fuzzy
+msgid "Zoom to Fit"
+msgstr "Zum Muat"
+
+#: ../src/common/stockitem.cpp:214
+msgid "Zoom &In"
+msgstr "Zum Masuk"
+
+#: ../src/common/stockitem.cpp:215
+msgid "Zoom &Out"
+msgstr "Zum Keluar"
+
+#: ../src/common/stockitem.cpp:262
+msgid "Show about dialog"
+msgstr "Tunjuk dialog perihal"
+
+#: ../src/common/stockitem.cpp:263
+msgid "Copy selection"
+msgstr "Salin pilihan"
+
+#: ../src/common/stockitem.cpp:264
+msgid "Cut selection"
+msgstr "Potong pilihan"
+
+#: ../src/common/stockitem.cpp:265
+msgid "Delete selection"
+msgstr "Padam pilihan"
+
+#: ../src/common/stockitem.cpp:266
+#, fuzzy
+msgid "Find in document"
+msgstr "Buka dokumen HTML"
+
+#: ../src/common/stockitem.cpp:267
+msgid "Find and replace in document"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:268
+msgid "Paste selection"
+msgstr "Tampal pilihan"
+
+#: ../src/common/stockitem.cpp:269
+msgid "Quit this program"
+msgstr "Keluar program ini"
+
+#: ../src/common/stockitem.cpp:270
+msgid "Redo last action"
+msgstr "Ulang tindakan akhir"
+
+#: ../src/common/stockitem.cpp:271
+msgid "Undo last action"
+msgstr "Batalkan tindakan akhir"
+
+#: ../src/common/stockitem.cpp:272
+#, fuzzy
+msgid "Create new document"
+msgstr "Cipta direktori baru"
+
+#: ../src/common/stockitem.cpp:273
+#, fuzzy
+msgid "Open an existing document"
+msgstr "Buka dokumen HTML"
+
+#: ../src/common/stockitem.cpp:274
+msgid "Close current document"
+msgstr "Tutup dokumen semasa"
+
+#: ../src/common/stockitem.cpp:275
+msgid "Save current document"
+msgstr "Simpan dokumen semasa"
+
+#: ../src/common/stockitem.cpp:276
+msgid "Save current document with a different filename"
+msgstr "Simpan dokumen semasa dengan nama fail berbeza"
+
+#: ../src/common/strconv.cpp:2324
+#, c-format
+msgid "Conversion to charset '%s' doesn't work."
+msgstr "Penukaran kepada set aksara '%s' tidak berfungsi."
+
+#: ../src/common/tarstrm.cpp:352 ../src/common/tarstrm.cpp:375
+#: ../src/common/tarstrm.cpp:406 ../src/generic/progdlgg.cpp:373
+msgid "unknown"
+msgstr "tidak diketahui"
+
+#: ../src/common/tarstrm.cpp:774
+msgid "incomplete header block in tar"
+msgstr "blok kepala tidak lengkap dalam tar"
+
+#: ../src/common/tarstrm.cpp:798
+msgid "checksum failure reading tar header block"
+msgstr "uji-jumlah gagal membaca blok kepala tar"
+
+#: ../src/common/tarstrm.cpp:971
+msgid "invalid data in extended tar header"
+msgstr "data tidak sah dalam kepala tar diperpanjang"
+
+#: ../src/common/tarstrm.cpp:981 ../src/common/tarstrm.cpp:1003
+#: ../src/common/tarstrm.cpp:1477 ../src/common/tarstrm.cpp:1499
+msgid "tar entry not open"
+msgstr "masukan tar tidak dibuka"
+
+#: ../src/common/tarstrm.cpp:1023
+msgid "unexpected end of file"
+msgstr "akhir fail tidak dijangka"
+
+#: ../src/common/tarstrm.cpp:1297
+#, c-format
+msgid "%s did not fit the tar header for entry '%s'"
+msgstr "%s tidak dapat muat kepala tar untuk masukan '%s'"
+
+#: ../src/common/tarstrm.cpp:1359
+msgid "incorrect size given for tar entry"
+msgstr "saiz diberi tidak betul untuk masukan tar"
+
+#: ../src/common/textbuf.cpp:232
+#, c-format
+msgid "'%s' is probably a binary buffer."
+msgstr "'%s' kemungkinan adalah penimbal binari."
+
+#: ../src/common/textcmn.cpp:1006 ../src/richtext/richtextctrl.cpp:3053
+msgid "File couldn't be loaded."
+msgstr "Fail gagal dimuatkan."
+
+#: ../src/common/textfile.cpp:95
+#, fuzzy, c-format
+msgid "Failed to read text file \"%s\"."
+msgstr "Gagal memuat metafail dari fail \"%s\"."
+
+#: ../src/common/textfile.cpp:160
+#, c-format
+msgid "can't write buffer '%s' to disk."
+msgstr "gagal menulis penimbal '%s' kepada cakera."
+
+#: ../src/common/time.cpp:212
+msgid "Failed to get the local system time"
+msgstr "Gagal mendapatkan masa sistem lokal"
+
+#: ../src/common/time.cpp:279
+msgid "wxGetTimeOfDay failed."
+msgstr "wxGetTimeOfDay gagal."
+
+#: ../src/common/translation.cpp:929
+#, c-format
+msgid "'%s' is not a valid message catalog."
+msgstr "'%s' bukanlah mesej katalog yang sah."
+
+#: ../src/common/translation.cpp:954
+#, fuzzy
+msgid "Invalid message catalog."
+msgstr "'%s' bukanlah mesej katalog yang sah."
+
+#: ../src/common/translation.cpp:1013
+#, fuzzy, c-format
+msgid "Failed to parse Plural-Forms: '%s'"
+msgstr "Gagal hurai Bentuk-Majmuk:'%s'"
+
+#: ../src/common/translation.cpp:1723
+#, c-format
+msgid "using catalog '%s' from '%s'."
+msgstr "guna katalog '%s' dari '%s'."
+
+#: ../src/common/translation.cpp:1816
+#, fuzzy, c-format
+msgid "Resource '%s' is not a valid message catalog."
+msgstr "'%s' bukanlah mesej katalog yang sah."
+
+#: ../src/common/translation.cpp:1865
+#, fuzzy
+msgid "Couldn't enumerate translations"
+msgstr "Gagal menamatkan benang"
+
+#: ../src/common/utilscmn.cpp:1145
+msgid "No default application configured for HTML files."
+msgstr ""
+
+#: ../src/common/utilscmn.cpp:1190
+#, fuzzy, c-format
+msgid "Failed to open URL \"%s\" in default browser."
+msgstr "Gagal buka '%s' untuk %s"
+
+#: ../src/common/valtext.cpp:144
+msgid "Validation conflict"
+msgstr "Konflik pengesahan"
+
+#: ../src/common/valtext.cpp:186
+msgid "Required information entry is empty."
+msgstr ""
+
+#: ../src/common/valtext.cpp:188
+#, fuzzy, c-format
+msgid "'%s' is one of the invalid strings"
+msgstr "'%s' tidak sah"
+
+#: ../src/common/valtext.cpp:190
+#, fuzzy, c-format
+msgid "'%s' is not one of the valid strings"
+msgstr "'%s' bukanlah mesej katalog yang sah."
+
+#: ../src/common/valtext.cpp:199
+#, fuzzy, c-format
+msgid "'%s' contains invalid character(s)"
+msgstr "'%s' sepatutnya mengandungi aksara abjab sahaja."
+
+#: ../src/common/webrequest.cpp:139
+#, fuzzy, c-format
+msgid "Error: %s (%d)"
+msgstr "Ralat: "
+
+#: ../src/common/webrequest.cpp:655
+#, c-format
+msgid ""
+"Not enough free disk space for download: %llu needed but only %llu available."
+msgstr ""
+
+#: ../src/common/webrequest.cpp:669
+#, fuzzy, c-format
+msgid "Failed to create temporary file in %s"
+msgstr "Gagal mencipta nama fail sementara"
+
+#: ../src/common/webrequest_curl.cpp:1106
+#, fuzzy
+msgid "libcurl could not be initialized"
+msgstr "Fail gagal dimuatkan."
+
+#: ../src/common/webview.cpp:392
+#, fuzzy
+msgid "RunScriptAsync not supported"
+msgstr "Penukaran rentetan tidak disokong"
+
+#: ../src/common/webview.cpp:403 ../src/msw/webview_ie.cpp:1073
+#, c-format
+msgid "Error running JavaScript: %s"
+msgstr ""
+
+#: ../src/common/webview_chromium.cpp:858
+#, fuzzy, c-format
+msgid "Failed to set proxy \"%s\": %s"
+msgstr "Gagal mencipta direktori \"%s\""
+
+#: ../src/common/webview_chromium.cpp:989
+msgid ""
+"Chromium can't be used because libcef.so wasn't loaded early enough; please "
+"relink the application or use LD_PRELOAD to load it earlier."
+msgstr ""
+
+#: ../src/common/webview_chromium.cpp:1108
+#, fuzzy
+msgid "Could not initialize Chromium"
+msgstr "Gagal mulakan mencetak."
+
+#: ../src/common/webview_chromium.cpp:1616
+msgid "Show DevTools"
+msgstr ""
+
+#: ../src/common/webview_chromium.cpp:1617
+#, fuzzy
+msgid "Close DevTools"
+msgstr "Tutup &Semua"
+
+#: ../src/common/webview_chromium.cpp:1623
+msgid "Inspect"
+msgstr ""
+
+#: ../src/common/wincmn.cpp:1628
+msgid "This platform does not support background transparency."
+msgstr ""
+
+#: ../src/common/wincmn.cpp:2097
+msgid "Could not transfer data to window"
+msgstr "Gagal hantar data ke tetingkap"
+
+#: ../src/common/windowid.cpp:240
+msgid "Out of window IDs.  Recommend shutting down application."
+msgstr ""
+
+#: ../src/common/xpmdecod.cpp:678
+msgid "XPM: incorrect header format!"
+msgstr "XPM: format kepala tidak betul!"
+
+#: ../src/common/xpmdecod.cpp:703
+#, c-format
+msgid "XPM: incorrect colour description in line %d"
+msgstr "XPM: definisi warna tidak betul pada baris %d"
+
+#: ../src/common/xpmdecod.cpp:715 ../src/common/xpmdecod.cpp:724
+#, c-format
+msgid "XPM: malformed colour definition '%s' at line %d!"
+msgstr "XPM: definisi warna tidak berfungsi '%s' pada baris %d!"
+
+#: ../src/common/xpmdecod.cpp:754
+#, fuzzy
+msgid "XPM: no colors left to use for mask!"
+msgstr "XPM: format kepala tidak betul!"
+
+#: ../src/common/xpmdecod.cpp:781
+#, c-format
+msgid "XPM: truncated image data at line %d!"
+msgstr "XPM: data imej dicantas pada baris %d!"
+
+#: ../src/common/xpmdecod.cpp:795
+msgid "XPM: Malformed pixel data!"
+msgstr "XPM: data piksel tidak berfungsi!"
+
+#: ../src/common/xti.cpp:492
+msgid "Illegal Parameter Count for Create Method"
+msgstr "Kiraan Parameter tidak sah untuk Method Create"
+
+#: ../src/common/xti.cpp:504
+msgid "Illegal Parameter Count for ConstructObject Method"
+msgstr "Kiraan Parameter tidak sah untuk Metod ConstructObject"
+
+#: ../src/common/xtistrm.cpp:161
+#, fuzzy, c-format
+msgid "Create Parameter %s not found in declared RTTI Parameters"
+msgstr "Parameter Cipta tidak dijumpai dalam parameter RRTI yang dinyatakan"
+
+#: ../src/common/xtistrm.cpp:290
+msgid "Illegal Object Class (Non-wxEvtHandler) as Event Source"
+msgstr "Kelas Objek tidak sah (Non-wxEvtHandler) sebagai Sumber Kejadian"
+
+#: ../src/common/xtistrm.cpp:313 ../src/common/xtixml.cpp:345
+#: ../src/common/xtixml.cpp:498
+msgid "Type must have enum - long conversion"
+msgstr "Jenis mestilah pertukaran hitung - panjang"
+
+#: ../src/common/xtistrm.cpp:400 ../src/common/xtistrm.cpp:415
+msgid "Invalid or Null Object ID passed to GetObjectClassInfo"
+msgstr "Tidak sah atau Null Object ID dilepaskan kepada GetObjectClassInfo"
+
+#: ../src/common/xtistrm.cpp:405
+msgid "Unknown Object passed to GetObjectClassInfo"
+msgstr "Objek Tidak Diketahui dilepaskan ke SetObjectClassInfo"
+
+#: ../src/common/xtistrm.cpp:420
+msgid "Already Registered Object passed to SetObjectClassInfo"
+msgstr "Objek Sedia Daftar dilepaskan ke SetObjectClassInfo"
+
+#: ../src/common/xtistrm.cpp:430
+msgid "Invalid or Null Object ID passed to HasObjectClassInfo"
+msgstr "Tidak sah atau Null Object ID dilepaskan kepada HasObjectClassInfo"
+
+#: ../src/common/xtistrm.cpp:460
+msgid "Passing a already registered object to SetObject"
+msgstr "Passing a already registered object to SetObject"
+
+#: ../src/common/xtistrm.cpp:471
+#, fuzzy
+msgid "Passing an unknown object to GetObject"
+msgstr "Melepaskan objek tidak diketahui kepada GetObject"
+
+#: ../src/common/xtixml.cpp:229
+msgid "Forward hrefs are not supported"
+msgstr "href yang dimaju tidak disokong"
+
+#: ../src/common/xtixml.cpp:247
+#, c-format
+msgid "unknown class %s"
+msgstr "kelas %s tidak diketahui"
+
+#: ../src/common/xtixml.cpp:253
+msgid "objects cannot have XML Text Nodes"
+msgstr "objek tidak boleh mempunyai Nod Teks XML"
+
+#: ../src/common/xtixml.cpp:258
+msgid "Objects must have an id attribute"
+msgstr "Objek perlu ada atribut id"
+
+#: ../src/common/xtixml.cpp:267
+#, c-format
+msgid "Doubly used id : %d"
+msgstr "Dua ID diguna : %d"
+
+#: ../src/common/xtixml.cpp:316
+#, fuzzy, c-format
+msgid "Unknown Property %s"
+msgstr "Milik Tidak Diketahui %s"
+
+#: ../src/common/xtixml.cpp:407
+msgid "A non empty collection must consist of 'element' nodes"
+msgstr "Pengumpulan bukan kosong mesti terdiri daripada nod 'elemen'"
+
+#: ../src/common/xtixml.cpp:478
+msgid "incorrect event handler string, missing dot"
+msgstr "rentetan pengemudi peristiwa salah, hilang titik"
+
+#: ../src/common/zipstrm.cpp:559
+msgid "can't re-initialize zlib deflate stream"
+msgstr "Gagal memulakan semula strim zlib kempis"
+
+#: ../src/common/zipstrm.cpp:584
+msgid "can't re-initialize zlib inflate stream"
+msgstr "Gagal memulakan semula strim zlib kembong"
+
+#: ../src/common/zipstrm.cpp:1023
+msgid "Ignoring malformed extra data record, ZIP file may be corrupted"
+msgstr ""
+
+#: ../src/common/zipstrm.cpp:1502
+msgid "assuming this is a multi-part zip concatenated"
+msgstr "mengandaikan yang ini adalah cantuman banyak-bahagian zip"
+
+#: ../src/common/zipstrm.cpp:1664
+msgid "invalid zip file"
+msgstr "fail zip tidak sah"
+
+#: ../src/common/zipstrm.cpp:1723
+msgid "can't find central directory in zip"
+msgstr "gagal menemui direktori pusat salam zip"
+
+#: ../src/common/zipstrm.cpp:1812
+msgid "error reading zip central directory"
+msgstr "ralat membaca direktori pusat zip"
+
+#: ../src/common/zipstrm.cpp:1916
+msgid "error reading zip local header"
+msgstr "ralat membaca kepala lokal zip"
+
+#: ../src/common/zipstrm.cpp:1964
+msgid "bad zipfile offset to entry"
+msgstr "offset fail zip kepada masukan rosak"
+
+#: ../src/common/zipstrm.cpp:2031
+msgid "stored file length not in Zip header"
+msgstr "panjang fail disimpan tidak dalam kepala Zip"
+
+#: ../src/common/zipstrm.cpp:2045 ../src/common/zipstrm.cpp:2362
+msgid "unsupported Zip compression method"
+msgstr "Mesej mampatan Zip tidak disokong"
+
+#: ../src/common/zipstrm.cpp:2126
+#, c-format
+msgid "reading zip stream (entry %s): bad length"
+msgstr "membaca strim zip (masukan %s): panjang buruk"
+
+#: ../src/common/zipstrm.cpp:2131
+#, c-format
+msgid "reading zip stream (entry %s): bad crc"
+msgstr "membaca strim zip (masukan %s): crc buruk"
+
+#: ../src/common/zipstrm.cpp:2578
+#, fuzzy, c-format
+msgid "error writing zip entry '%s': file too large without ZIP64"
+msgstr "gagal menulis masukan zip '%s': crc atau panjang rosak"
+
+#: ../src/common/zipstrm.cpp:2585
+#, c-format
+msgid "error writing zip entry '%s': bad crc or length"
+msgstr "gagal menulis masukan zip '%s': crc atau panjang rosak"
+
+#: ../src/common/zstream.cpp:155 ../src/common/zstream.cpp:315
+msgid "Gzip not supported by this version of zlib"
+msgstr "Gzip tidak disokong oleh versi zlib ini"
+
+#: ../src/common/zstream.cpp:182
+msgid "Can't initialize zlib inflate stream."
+msgstr "Gagal memulakan strim zlib kembong."
+
+#: ../src/common/zstream.cpp:241
+msgid "Can't read inflate stream: unexpected EOF in underlying stream."
+msgstr "Gagal membaca strim kembung: EOF tidak dijangka dalam dasar strim."
+
+#: ../src/common/zstream.cpp:248 ../src/common/zstream.cpp:423
+#, c-format
+msgid "zlib error %d"
+msgstr "Ralat zlib %d"
+
+#: ../src/common/zstream.cpp:249
+#, c-format
+msgid "Can't read from inflate stream: %s"
+msgstr "Gagal membaca daripada strim kembong: %s"
+
+#: ../src/common/zstream.cpp:343
+msgid "Can't initialize zlib deflate stream."
+msgstr "Gagal memulakan strim zlib kempis."
+
+#: ../src/common/zstream.cpp:424
+#, c-format
+msgid "Can't write to deflate stream: %s"
+msgstr "Gagal menulis kepada strim kempis: %s"
+
+#: ../src/dfb/bitmap.cpp:633 ../src/dfb/bitmap.cpp:667
+#, fuzzy, c-format
+msgid "No bitmap handler for type %d defined."
+msgstr "Tiada pengemudi imej untuk jenis %d ditetapkan."
+
+#: ../src/dfb/evtloop.cpp:99
+#, fuzzy
+msgid "Failed to read event from DirectFB pipe"
+msgstr "Gagal membaca PID daripada fail kunci."
+
+#: ../src/dfb/evtloop.cpp:171
+msgid "Failed to switch DirectFB pipe to non-blocking mode"
+msgstr ""
+
+#: ../src/dfb/fontmgr.cpp:171
+#, c-format
+msgid "no fonts found in %s, using builtin font"
+msgstr ""
+
+#: ../src/dfb/fontmgr.cpp:177
+#, fuzzy
+msgid "Default font"
+msgstr "Pencetak default"
+
+#: ../src/dfb/fontmgr.cpp:195
+#, c-format
+msgid "Fonts index file %s disappeared while loading fonts."
+msgstr ""
+
+#: ../src/dfb/wrapdfb.cpp:60
+#, fuzzy, c-format
+msgid "DirectFB error %d occurred."
+msgstr "Ralat DiretFB %d berlaku."
+
+#: ../src/generic/aboutdlgg.cpp:69
+msgid "Developed by "
+msgstr "Dibangunkan oleh"
+
+#: ../src/generic/aboutdlgg.cpp:72
+msgid "Documentation by "
+msgstr "Dokumentasi oleh"
+
+#: ../src/generic/aboutdlgg.cpp:75
+msgid "Graphics art by "
+msgstr "Seni grafik oleh"
+
+#: ../src/generic/aboutdlgg.cpp:78
+msgid "Translations by "
+msgstr "Diterjemah oleh"
+
+#: ../src/generic/aboutdlgg.cpp:133 ../src/osx/cocoa/aboutdlg.mm:83
+#, fuzzy
+msgid "Version "
+msgstr "Versi"
+
+#. TRANSLATORS: %s is application name
+#: ../src/generic/aboutdlgg.cpp:146 ../src/msw/aboutdlg.cpp:60
+#, fuzzy, c-format
+msgid "About %s"
+msgstr "Perihal"
+
+#: ../src/generic/aboutdlgg.cpp:181
+msgid "License"
+msgstr ""
+
+#: ../src/generic/aboutdlgg.cpp:184
+#, fuzzy
+msgid "Developers"
+msgstr "Dibangunkan oleh"
+
+#: ../src/generic/aboutdlgg.cpp:188
+#, fuzzy
+msgid "Documentation writers"
+msgstr "Dokumentasi oleh"
+
+#: ../src/generic/aboutdlgg.cpp:192
+msgid "Artists"
+msgstr ""
+
+#: ../src/generic/aboutdlgg.cpp:196
+#, fuzzy
+msgid "Translators"
+msgstr "Diterjemah oleh"
+
+#: ../src/generic/animateg.cpp:125
+msgid "No handler found for animation type."
+msgstr "Tiada pengemudi ditemui untuk jenis animasi."
+
+#: ../src/generic/animateg.cpp:133
+#, c-format
+msgid "No animation handler for type %ld defined."
+msgstr "Tiada pengemudi animasi untuk jenis %ld ditetapkan."
+
+#: ../src/generic/animateg.cpp:145
+#, c-format
+msgid "Animation file is not of type %ld."
+msgstr "Fail animasi bukan berjenis %ld."
+
+#: ../src/generic/colrdlgg.cpp:154 ../src/gtk/colordlg.cpp:47
+msgid "Choose colour"
+msgstr "Pilih warna"
+
+#: ../src/generic/colrdlgg.cpp:357
+msgid "Red:"
+msgstr ""
+
+#: ../src/generic/colrdlgg.cpp:360
+msgid "Green:"
+msgstr ""
+
+#: ../src/generic/colrdlgg.cpp:363
+msgid "Blue:"
+msgstr ""
+
+#: ../src/generic/colrdlgg.cpp:372
+msgid "Opacity:"
+msgstr ""
+
+#: ../src/generic/colrdlgg.cpp:384
+msgid "Add to custom colours"
+msgstr "Tambah kepada warna adat"
+
+#: ../src/generic/creddlgg.cpp:56
+msgid "Username:"
+msgstr ""
+
+#: ../src/generic/creddlgg.cpp:63
+msgid "Password:"
+msgstr ""
+
+#. TRANSLATORS: Name of Boolean true value
+#: ../src/generic/datavgen.cpp:1178
+msgid "true"
+msgstr ""
+
+#. TRANSLATORS: Name of Boolean false value
+#: ../src/generic/datavgen.cpp:1180
+#, fuzzy
+msgid "false"
+msgstr "Fail"
+
+#: ../src/generic/datavgen.cpp:6897
+#, c-format
+msgid "Row %i"
+msgstr ""
+
+#. TRANSLATORS: Action for manipulating a tree control
+#: ../src/generic/datavgen.cpp:6987
+msgid "Collapse"
+msgstr ""
+
+#. TRANSLATORS: Action for manipulating a tree control
+#: ../src/generic/datavgen.cpp:6990
+msgid "Expand"
+msgstr ""
+
+#. TRANSLATORS: Name of data view control and number of rows
+#: ../src/generic/datavgen.cpp:7011
+#, fuzzy, c-format
+msgid "%s (%d items)"
+msgstr "%s (or %s)"
+
+#: ../src/generic/datavgen.cpp:7062
+#, c-format
+msgid "Column %u"
+msgstr ""
+
+#. TRANSLATORS: Keystroke for manipulating a tree control
+#: ../src/generic/datavgen.cpp:7131 ../src/richtext/richtextbulletspage.cpp:189
+#: ../src/richtext/richtextbulletspage.cpp:192
+#: ../src/richtext/richtextbulletspage.cpp:193
+#: ../src/richtext/richtextliststylepage.cpp:252
+#: ../src/richtext/richtextliststylepage.cpp:255
+#: ../src/richtext/richtextliststylepage.cpp:256
+#: ../src/richtext/richtextsizepage.cpp:248
+msgid "Left"
+msgstr "Kiri"
+
+#. TRANSLATORS: Keystroke for manipulating a tree control
+#: ../src/generic/datavgen.cpp:7134 ../src/richtext/richtextbulletspage.cpp:191
+#: ../src/richtext/richtextliststylepage.cpp:254
+#: ../src/richtext/richtextsizepage.cpp:249
+msgid "Right"
+msgstr "Kanan"
+
+#: ../src/generic/datectlg.cpp:90
+#, c-format
+msgid ""
+"\"%s\" is not in the expected date format, please enter it as e.g. \"%s\"."
+msgstr ""
+
+#: ../src/generic/datectlg.cpp:94
+#, fuzzy
+msgid "Invalid date"
+msgstr "PCX: imej tidak sah"
+
+#: ../src/generic/dbgrptg.cpp:159
+#, c-format
+msgid "Open file \"%s\""
+msgstr "Buka fail  \"%s\""
+
+#: ../src/generic/dbgrptg.cpp:170
+#, c-format
+msgid "Enter command to open file \"%s\":"
+msgstr "Masukkan arahan untuk membuka fail \"%s\":"
+
+#: ../src/generic/dbgrptg.cpp:230
+#, fuzzy
+msgid "Executable files (*.exe)|*.exe|"
+msgstr "Fail boleh laksana (*.exe)|*.exe|Semua fail (*.*)|*.*||"
+
+#: ../src/generic/dbgrptg.cpp:300
+#, c-format
+msgid "Debug report \"%s\""
+msgstr "Laporan ralat \"%s\""
+
+#: ../src/generic/dbgrptg.cpp:316
+msgid "A debug report has been generated in the directory\n"
+msgstr "Laporan nyahpijat telah dijana dalam direktori\n"
+
+#: ../src/generic/dbgrptg.cpp:317
+#, fuzzy
+msgid "The following debug report will be generated\n"
+msgstr "*** Laporan nyahpijat telah dijana\n"
+
+#: ../src/generic/dbgrptg.cpp:321
+msgid ""
+"The report contains the files listed below. If any of these files contain "
+"private information,\n"
+"please uncheck them and they will be removed from the report.\n"
+msgstr ""
+"Laporan mengandungi senarai fail dibawah. Jika mana-mana fail mengandungi "
+"maklumat peribadi,\n"
+"sila buang tandanya dan akan dibuang daripada laporan.\n"
+
+#: ../src/generic/dbgrptg.cpp:323
+msgid ""
+"If you wish to suppress this debug report completely, please choose the "
+"\"Cancel\" button,\n"
+"but be warned that it may hinder improving the program, so if\n"
+"at all possible please do continue with the report generation.\n"
+msgstr ""
+"Jika anda berharap untuk mendiamkan laporan nyahpijat, sila pilih butang "
+"\"Batal\",\n"
+"tetapi diingatkan bahawa ini akan membelakangi kemajuan program, jika boleh\n"
+"sila teruskan dengan menjana laporan.\n"
+
+#: ../src/generic/dbgrptg.cpp:325
+msgid "              Thank you and we're sorry for the inconvenience!\n"
+msgstr "              Terima kasih dan segala kesulitan amat dikesali!\n"
+
+#: ../src/generic/dbgrptg.cpp:333
+msgid "&Debug report preview:"
+msgstr "Pralihat laporan nyahpijat:"
+
+#: ../src/generic/dbgrptg.cpp:339
+#, fuzzy
+msgid "&View..."
+msgstr "&Buka..."
+
+#: ../src/generic/dbgrptg.cpp:359
+msgid "&Notes:"
+msgstr "&Nota:"
+
+#: ../src/generic/dbgrptg.cpp:361
+msgid ""
+"If you have any additional information pertaining to this bug\n"
+"report, please enter it here and it will be joined to it:"
+msgstr ""
+"Jika anda mempunyai sebarang maklumat tambahan berkaitan dengan laporan\n"
+"nyahpijat, sila masukkan di sini dan ia akan digabungkan kepadanya:"
+
+#: ../src/generic/dcpsg.cpp:1627
+msgid "Cannot open file for PostScript printing!"
+msgstr "Gagal buka fail untuk cetak PostScript!"
+
+#: ../src/generic/dirctrlg.cpp:402
+msgid "Computer"
+msgstr "Komputer"
+
+#: ../src/generic/dirctrlg.cpp:404
+msgid "Sections"
+msgstr "Seksyen"
+
+#: ../src/generic/dirctrlg.cpp:482
+msgid "Home directory"
+msgstr "Direktori rumah"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/generic/dirctrlg.cpp:484 ../src/propgrid/advprops.cpp:811
+msgid "Desktop"
+msgstr "Desktop"
+
+#: ../src/generic/dirctrlg.cpp:528 ../src/generic/filectrlg.cpp:752
+msgid "Illegal directory name."
+msgstr "Nama direktori tidak sah."
+
+#: ../src/generic/dirctrlg.cpp:528 ../src/generic/dirctrlg.cpp:546
+#: ../src/generic/dirctrlg.cpp:557 ../src/generic/dirdlgg.cpp:317
+#: ../src/generic/filectrlg.cpp:638 ../src/generic/filectrlg.cpp:752
+#: ../src/generic/filectrlg.cpp:766 ../src/generic/filectrlg.cpp:782
+#: ../src/generic/filectrlg.cpp:1356 ../src/generic/filectrlg.cpp:1387
+#: ../src/generic/filedlgg.cpp:362 ../src/gtk/filedlg.cpp:76
+msgid "Error"
+msgstr "Ralat"
+
+#: ../src/generic/dirctrlg.cpp:546 ../src/generic/filectrlg.cpp:766
+msgid "File name exists already."
+msgstr "Nama fail sedia wujud."
+
+#: ../src/generic/dirctrlg.cpp:557 ../src/generic/dirdlgg.cpp:317
+#: ../src/generic/filectrlg.cpp:638 ../src/generic/filectrlg.cpp:782
+msgid "Operation not permitted."
+msgstr "Operasi tidak diizinkan."
+
+#: ../src/generic/dirdlgg.cpp:107 ../src/generic/filedlgg.cpp:207
+msgid "Create new directory"
+msgstr "Cipta direktori baru"
+
+#: ../src/generic/dirdlgg.cpp:112 ../src/generic/filedlgg.cpp:203
+msgid "Go to home directory"
+msgstr "Pergi ke direktori rumah"
+
+#: ../src/generic/dirdlgg.cpp:143
+msgid "Show &hidden directories"
+msgstr "Tunjuk direktori tersembunyi"
+
+#: ../src/generic/dirdlgg.cpp:196
+#, c-format
+msgid ""
+"The directory '%s' does not exist\n"
+"Create it now?"
+msgstr ""
+"Direktori '%s' tidak wujud\n"
+"Cipta sekarang?"
+
+#: ../src/generic/dirdlgg.cpp:198
+msgid "Directory does not exist"
+msgstr "Direktori tidak wujud"
+
+#: ../src/generic/dirdlgg.cpp:214
+#, c-format
+msgid ""
+"Failed to create directory '%s'\n"
+"(Do you have the required permissions?)"
+msgstr ""
+"Gagal mencipta direktori '%s'\n"
+"(Adakah anda memerlukan keizinan?)"
+
+#: ../src/generic/dirdlgg.cpp:216
+msgid "Error creating directory"
+msgstr "Ralat mencipta direktori"
+
+#: ../src/generic/dirdlgg.cpp:281
+msgid "You cannot add a new directory to this section."
+msgstr "Anda tidak boleh menambah direktori baru pada seksyen ini."
+
+#: ../src/generic/dirdlgg.cpp:282
+msgid "Create directory"
+msgstr "Cipta direktori"
+
+#: ../src/generic/dirdlgg.cpp:291 ../src/generic/dirdlgg.cpp:301
+#: ../src/generic/filectrlg.cpp:614 ../src/generic/filectrlg.cpp:623
+msgid "NewName"
+msgstr "NamaBaru"
+
+#: ../src/generic/editlbox.cpp:135
+msgid "Edit item"
+msgstr "Edit item"
+
+#: ../src/generic/editlbox.cpp:143
+msgid "New item"
+msgstr "Item Baru"
+
+#: ../src/generic/editlbox.cpp:151
+msgid "Delete item"
+msgstr "Padam item"
+
+#: ../src/generic/editlbox.cpp:159
+msgid "Move up"
+msgstr "Pindah atas"
+
+#: ../src/generic/editlbox.cpp:164
+msgid "Move down"
+msgstr "Pindah bawah"
+
+#: ../src/generic/fdrepdlg.cpp:108
+msgid "Search for:"
+msgstr "Cari:"
+
+#: ../src/generic/fdrepdlg.cpp:120
+msgid "Replace with:"
+msgstr "Ganti dengan:"
+
+#: ../src/generic/fdrepdlg.cpp:140
+msgid "Whole word"
+msgstr "Seluruh perkataan"
+
+#: ../src/generic/fdrepdlg.cpp:143
+msgid "Match case"
+msgstr "Padan kes"
+
+#: ../src/generic/fdrepdlg.cpp:156
+msgid "Search direction"
+msgstr "Carian hala"
+
+#: ../src/generic/fdrepdlg.cpp:175
+msgid "&Replace"
+msgstr "&Ganti"
+
+#: ../src/generic/fdrepdlg.cpp:178
+msgid "Replace &all"
+msgstr "G&anti Semua"
+
+#: ../src/generic/filectrlg.cpp:246 ../src/generic/filectrlg.cpp:269
+msgid "<DIR>"
+msgstr "<DIR>"
+
+#: ../src/generic/filectrlg.cpp:248 ../src/generic/filectrlg.cpp:271
+msgid "<LINK>"
+msgstr "<LINK>"
+
+#: ../src/generic/filectrlg.cpp:250 ../src/generic/filectrlg.cpp:273
+msgid "<DRIVE>"
+msgstr "<DRIVE>"
+
+#: ../src/generic/filectrlg.cpp:275
+#, c-format
+msgid "%ld byte"
+msgid_plural "%ld bytes"
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../src/generic/filectrlg.cpp:420
+msgid "Name"
+msgstr "Nama"
+
+#: ../src/generic/filectrlg.cpp:421 ../src/richtext/richtextformatdlg.cpp:361
+#: ../src/richtext/richtextsizepage.cpp:298
+msgid "Size"
+msgstr "Saiz"
+
+#: ../src/generic/filectrlg.cpp:422
+msgid "Type"
+msgstr "Jenis"
+
+#: ../src/generic/filectrlg.cpp:423
+msgid "Modified"
+msgstr "Diubahsuai"
+
+#: ../src/generic/filectrlg.cpp:426
+msgid "Permissions"
+msgstr "Keizinan"
+
+#: ../src/generic/filectrlg.cpp:429
+msgid "Attributes"
+msgstr "Atribut"
+
+#: ../src/generic/filectrlg.cpp:936
+msgid "Current directory:"
+msgstr "Direktori semasa:"
+
+#: ../src/generic/filectrlg.cpp:979
+msgid "Show &hidden files"
+msgstr "Tunjuk fail tersembunyi"
+
+#: ../src/generic/filectrlg.cpp:1355
+msgid "Illegal file specification."
+msgstr "spesifikasi fail tidak sah."
+
+#: ../src/generic/filectrlg.cpp:1387
+msgid "Directory doesn't exist."
+msgstr "Direktori tidak wujud."
+
+#: ../src/generic/filedlgg.cpp:195
+msgid "View files as a list view"
+msgstr "Lihat fail sebagai senarai lihat"
+
+#: ../src/generic/filedlgg.cpp:197
+msgid "View files as a detailed view"
+msgstr "Lihat fail sebagai lihat perincian"
+
+#: ../src/generic/filedlgg.cpp:200
+msgid "Go to parent directory"
+msgstr "Pergi ke direntori induk"
+
+#: ../src/generic/filedlgg.cpp:351 ../src/gtk/filedlg.cpp:59
+#, c-format
+msgid "File '%s' already exists, do you really want to overwrite it?"
+msgstr "Fail '%s' sedia wujud, anda pasti untuk menindihnya?"
+
+#: ../src/generic/filedlgg.cpp:354 ../src/gtk/filedlg.cpp:62
+msgid "Confirm"
+msgstr "Sah"
+
+#: ../src/generic/filedlgg.cpp:362 ../src/gtk/filedlg.cpp:75
+msgid "Please choose an existing file."
+msgstr "Sila pilih fail yang sedia ada."
+
+#: ../src/generic/filepickerg.cpp:64
+#, fuzzy
+msgid "..."
+msgstr ".."
+
+#: ../src/generic/fontdlgg.cpp:76 ../src/richtext/richtextformatdlg.cpp:519
+msgid "ABCDEFGabcdefg12345"
+msgstr "ABCDEFGabcdefg12345"
+
+#: ../src/generic/fontdlgg.cpp:315
+msgid "Roman"
+msgstr "Roman"
+
+#: ../src/generic/fontdlgg.cpp:316
+msgid "Decorative"
+msgstr "Dekoratif"
+
+#: ../src/generic/fontdlgg.cpp:317
+msgid "Modern"
+msgstr "Moden"
+
+#: ../src/generic/fontdlgg.cpp:318
+msgid "Script"
+msgstr "Skrip"
+
+#: ../src/generic/fontdlgg.cpp:319
+msgid "Swiss"
+msgstr "Swiss"
+
+#: ../src/generic/fontdlgg.cpp:320
+msgid "Teletype"
+msgstr "Teletaip"
+
+#: ../src/generic/fontdlgg.cpp:321 ../src/generic/fontdlgg.cpp:324
+msgid "Normal"
+msgstr "Normal"
+
+#: ../src/generic/fontdlgg.cpp:323
+msgid "Slant"
+msgstr "Condong"
+
+#: ../src/generic/fontdlgg.cpp:325
+msgid "Light"
+msgstr "Cerah"
+
+#: ../src/generic/fontdlgg.cpp:363
+msgid "&Font family:"
+msgstr "Keluarga &fon:"
+
+#: ../src/generic/fontdlgg.cpp:367 ../src/generic/fontdlgg.cpp:369
+msgid "The font family."
+msgstr "Keluarga Fon"
+
+#: ../src/generic/fontdlgg.cpp:374 ../src/richtext/richtextstylepage.cpp:105
+msgid "&Style:"
+msgstr "Ga&ya:"
+
+#: ../src/generic/fontdlgg.cpp:378 ../src/generic/fontdlgg.cpp:380
+msgid "The font style."
+msgstr "Gaya fon"
+
+#: ../src/generic/fontdlgg.cpp:385
+msgid "&Weight:"
+msgstr "Berat:"
+
+#: ../src/generic/fontdlgg.cpp:389 ../src/generic/fontdlgg.cpp:391
+msgid "The font weight."
+msgstr "Berat fon."
+
+#: ../src/generic/fontdlgg.cpp:399
+msgid "C&olour:"
+msgstr "Warna:"
+
+#: ../src/generic/fontdlgg.cpp:407 ../src/generic/fontdlgg.cpp:409
+msgid "The font colour."
+msgstr "Warna fon."
+
+#: ../src/generic/fontdlgg.cpp:415
+msgid "&Point size:"
+msgstr "Saiz titik:"
+
+#: ../src/generic/fontdlgg.cpp:420 ../src/generic/fontdlgg.cpp:422
+#: ../src/generic/fontdlgg.cpp:426 ../src/generic/fontdlgg.cpp:428
+msgid "The font point size."
+msgstr "Saiz titik fon."
+
+#: ../src/generic/fontdlgg.cpp:439 ../src/generic/fontdlgg.cpp:441
+msgid "Whether the font is underlined."
+msgstr "Sama ada fon bergaris-bawah."
+
+#: ../src/generic/fontdlgg.cpp:448 ../src/html/helpwnd.cpp:1215
+msgid "Preview:"
+msgstr "Pralihat:"
+
+#: ../src/generic/fontdlgg.cpp:452 ../src/generic/fontdlgg.cpp:454
+msgid "Shows the font preview."
+msgstr "Tunjuk pralihat fon."
+
+#: ../src/generic/fontdlgg.cpp:464 ../src/generic/fontdlgg.cpp:483
+msgid "Click to cancel the font selection."
+msgstr "Klik untuk batal pemilihan fon."
+
+#: ../src/generic/fontdlgg.cpp:469 ../src/generic/fontdlgg.cpp:471
+#: ../src/generic/fontdlgg.cpp:476 ../src/generic/fontdlgg.cpp:478
+msgid "Click to confirm the font selection."
+msgstr "Klik untuk pasti pemilihan fon."
+
+#: ../src/generic/fontpickerg.cpp:50 ../src/gtk/fontdlg.cpp:77
+msgid "Choose font"
+msgstr "Pilih fon"
+
+#: ../src/generic/grid.cpp:6542
+msgid ""
+"Error copying grid to the clipboard. Either selected cells were not "
+"contiguous or no cell was selected."
+msgstr ""
+
+#: ../src/generic/grid.cpp:12739
+msgid "Grid Corner"
+msgstr ""
+
+#: ../src/generic/grid.cpp:12741
+#, c-format
+msgid "Column %s Header"
+msgstr ""
+
+#: ../src/generic/grid.cpp:12743
+#, c-format
+msgid "Row %s Header"
+msgstr ""
+
+#: ../src/generic/grid.cpp:12745
+#, c-format
+msgid "Column %s: %s"
+msgstr ""
+
+#: ../src/generic/grid.cpp:12749
+#, fuzzy, c-format
+msgid "Row %s: %s"
+msgstr "\t%s: %s\n"
+
+#: ../src/generic/grid.cpp:12753
+#, c-format
+msgid "Row %s, Column %s: %s"
+msgstr ""
+
+#: ../src/generic/helpext.cpp:257
+#, c-format
+msgid "Help directory \"%s\" not found."
+msgstr "Direktori bantuan \"%s\" tidak ditemui."
+
+#: ../src/generic/helpext.cpp:265
+#, c-format
+msgid "Help file \"%s\" not found."
+msgstr "Fail bantuan \"%s\" tidak ditemui."
+
+#: ../src/generic/helpext.cpp:284
+#, c-format
+msgid "Line %lu of map file \"%s\" has invalid syntax, skipped."
+msgstr "Baris %lu fail peta \"%s\" terdapat sintaks tidak sah, dilangkau."
+
+#: ../src/generic/helpext.cpp:292
+#, c-format
+msgid "No valid mappings found in the file \"%s\"."
+msgstr "Tiada pemetaan sah ditemui dalam fail \"%s\"."
+
+#: ../src/generic/helpext.cpp:435
+msgid "No entries found."
+msgstr "Tiada masukan ditemui."
+
+#: ../src/generic/helpext.cpp:444 ../src/generic/helpext.cpp:445
+msgid "Help Index"
+msgstr "Indeks Bantuan"
+
+#: ../src/generic/helpext.cpp:448
+msgid "Relevant entries:"
+msgstr "Masukan berkaitan:"
+
+#: ../src/generic/helpext.cpp:449
+msgid "Entries found"
+msgstr "Masukan ditemui"
+
+#: ../src/generic/hyperlinkg.cpp:170
+#, fuzzy
+msgid "&Copy URL"
+msgstr "&Salin"
+
+#: ../src/generic/infobar.cpp:119
+msgid "Hide this notification message."
+msgstr ""
+
+#. TRANSLATORS: %s will be either the application name or "Application"
+#: ../src/generic/logg.cpp:257
+#, c-format
+msgid "%s Error"
+msgstr "%s Ralat"
+
+#. TRANSLATORS: %s will be either the application name or "Application"
+#: ../src/generic/logg.cpp:263
+#, c-format
+msgid "%s Warning"
+msgstr "%s Amaran"
+
+#. TRANSLATORS: %s will be either the application name or "Application"
+#: ../src/generic/logg.cpp:273
+#, c-format
+msgid "%s Information"
+msgstr "%s Maklumat"
+
+#: ../src/generic/logg.cpp:276
+#, fuzzy
+msgid "Application"
+msgstr "Pemilihan"
+
+#: ../src/generic/logg.cpp:549
+msgid "Save log contents to file"
+msgstr "Simpan kandungan log kepada fail."
+
+#: ../src/generic/logg.cpp:551
+msgid "C&lear"
+msgstr "Bersi&hkan"
+
+#: ../src/generic/logg.cpp:551
+msgid "Clear the log contents"
+msgstr "Lapangkan kandungan log"
+
+#: ../src/generic/logg.cpp:553
+msgid "Close this window"
+msgstr "Tutup tetingkap ini"
+
+#: ../src/generic/logg.cpp:554
+msgid "&Log"
+msgstr "&Log"
+
+#: ../src/generic/logg.cpp:610 ../src/generic/logg.cpp:992
+msgid "Can't save log contents to file."
+msgstr "Gagal menyimpan kandungan log kepada fail."
+
+#: ../src/generic/logg.cpp:613
+#, c-format
+msgid "Log saved to the file '%s'."
+msgstr "Log disimpan ke fail '%s'."
+
+#: ../src/generic/logg.cpp:719
+msgid "&Details"
+msgstr "&Terperinci"
+
+#: ../src/generic/logg.cpp:972
+#, fuzzy
+msgid "Failed to copy dialog contents to the clipboard."
+msgstr "Gagal membuka klipbod."
+
+#: ../src/generic/logg.cpp:1022
+#, c-format
+msgid "Append log to file '%s' (choosing [No] will overwrite it)?"
+msgstr "Tokok fail log '%s' (memilih [Tidak] akan menindihnya)?"
+
+#: ../src/generic/logg.cpp:1024
+msgid "Question"
+msgstr "Soalan"
+
+#: ../src/generic/logg.cpp:1038
+msgid "invalid message box return value"
+msgstr "nilai kembali kotak mesej tidak sah"
+
+#: ../src/generic/notifmsgg.cpp:129
+#, fuzzy
+msgid "Notice"
+msgstr "&Nota:"
+
+#: ../src/generic/preferencesg.cpp:118
+#, fuzzy, c-format
+msgid "%s Preferences"
+msgstr "Keutamaan"
+
+#: ../src/generic/printps.cpp:143
+msgid "Printing..."
+msgstr "Mencetak..."
+
+#: ../src/generic/printps.cpp:160 ../src/gtk/print.cpp:1076
+#: ../src/msw/printwin.cpp:235
+msgid "Could not start printing."
+msgstr "Gagal mulakan mencetak."
+
+#: ../src/generic/printps.cpp:183
+#, c-format
+msgid "Printing page %d..."
+msgstr "Mencetak laman %d..."
+
+#: ../src/generic/prntdlgg.cpp:171
+msgid "Printer options"
+msgstr "Pilihan pencetak"
+
+#: ../src/generic/prntdlgg.cpp:176
+msgid "Print to File"
+msgstr "Cetak ke Fail"
+
+#: ../src/generic/prntdlgg.cpp:179
+msgid "Setup..."
+msgstr "Tetapan..."
+
+#: ../src/generic/prntdlgg.cpp:187
+msgid "Printer:"
+msgstr "Pencetak:"
+
+#: ../src/generic/prntdlgg.cpp:195
+msgid "Status:"
+msgstr "Status:"
+
+#: ../src/generic/prntdlgg.cpp:206
+msgid "All"
+msgstr "Semua"
+
+#: ../src/generic/prntdlgg.cpp:207
+msgid "Pages"
+msgstr "Laman"
+
+#: ../src/generic/prntdlgg.cpp:215
+msgid "Print Range"
+msgstr "Julat Cetak"
+
+#: ../src/generic/prntdlgg.cpp:229
+msgid "From:"
+msgstr "Dari:"
+
+#: ../src/generic/prntdlgg.cpp:233
+msgid "To:"
+msgstr "Ke:"
+
+#: ../src/generic/prntdlgg.cpp:238
+msgid "Copies:"
+msgstr "Salinan:"
+
+#: ../src/generic/prntdlgg.cpp:288
+msgid "PostScript file"
+msgstr "Fail PostScript"
+
+#: ../src/generic/prntdlgg.cpp:439
+msgid "Print Setup"
+msgstr "Tetapan Cetak"
+
+#: ../src/generic/prntdlgg.cpp:483
+msgid "Printer"
+msgstr "Pencetak"
+
+#: ../src/generic/prntdlgg.cpp:501
+msgid "Default printer"
+msgstr "Pencetak default"
+
+#: ../src/generic/prntdlgg.cpp:595 ../src/generic/prntdlgg.cpp:782
+#: ../src/generic/prntdlgg.cpp:822 ../src/generic/prntdlgg.cpp:835
+#: ../src/generic/prntdlgg.cpp:1031 ../src/generic/prntdlgg.cpp:1036
+msgid "Paper size"
+msgstr "Saiz &kertas:"
+
+#: ../src/generic/prntdlgg.cpp:604 ../src/generic/prntdlgg.cpp:847
+msgid "Portrait"
+msgstr "Potret"
+
+#: ../src/generic/prntdlgg.cpp:605 ../src/generic/prntdlgg.cpp:848
+msgid "Landscape"
+msgstr "Lanskap"
+
+#: ../src/generic/prntdlgg.cpp:607 ../src/generic/prntdlgg.cpp:849
+msgid "Orientation"
+msgstr "Orientasi"
+
+#: ../src/generic/prntdlgg.cpp:610
+msgid "Options"
+msgstr "Pilihan"
+
+#: ../src/generic/prntdlgg.cpp:612
+msgid "Print in colour"
+msgstr "Cetak warna"
+
+#: ../src/generic/prntdlgg.cpp:621
+msgid "Print spooling"
+msgstr "Gelendong cetak"
+
+#: ../src/generic/prntdlgg.cpp:623
+msgid "Printer command:"
+msgstr "Arahan pencetak:"
+
+#: ../src/generic/prntdlgg.cpp:631
+msgid "Printer options:"
+msgstr "Pilihan pencetak:"
+
+#: ../src/generic/prntdlgg.cpp:860
+msgid "Left margin (mm):"
+msgstr "Left margin (mm):"
+
+#: ../src/generic/prntdlgg.cpp:861
+msgid "Top margin (mm):"
+msgstr "Jidar bawah (mm):"
+
+#: ../src/generic/prntdlgg.cpp:872
+msgid "Right margin (mm):"
+msgstr "Jidar kanan (mm):"
+
+#: ../src/generic/prntdlgg.cpp:873
+msgid "Bottom margin (mm):"
+msgstr "Jidar bawah (mm):"
+
+#: ../src/generic/prntdlgg.cpp:896
+msgid "Printer..."
+msgstr "Pencetak..."
+
+#: ../src/generic/progdlgg.cpp:246
+#, fuzzy
+msgid "&Skip"
+msgstr "Langkau"
+
+#: ../src/generic/progdlgg.cpp:347 ../src/generic/progdlgg.cpp:626
+msgid "Unknown"
+msgstr "Tidak Diketahui"
+
+#: ../src/generic/progdlgg.cpp:451 ../src/msw/progdlg.cpp:526
+msgid "Done."
+msgstr "Selesai."
+
+#: ../src/generic/srchctlg.cpp:55 ../src/gtk/srchctrl.cpp:206
+#: ../src/html/helpwnd.cpp:530 ../src/html/helpwnd.cpp:545
+msgid "Search"
+msgstr "Cari"
+
+#: ../src/generic/tabg.cpp:1026
+msgid "Could not find tab for id"
+msgstr "Gagal menemui tab untuk id"
+
+#: ../src/generic/tipdlg.cpp:136
+msgid "Tips not available, sorry!"
+msgstr "Kias tidak wujud, maaf!"
+
+#: ../src/generic/tipdlg.cpp:197
+msgid "Tip of the Day"
+msgstr "Petua Hari Ini"
+
+#: ../src/generic/tipdlg.cpp:207
+msgid "Did you know..."
+msgstr "Tahukah anda..."
+
+#: ../src/generic/tipdlg.cpp:232
+msgid "&Show tips at startup"
+msgstr "Papar pe&tua pada permulaan"
+
+#: ../src/generic/tipdlg.cpp:236
+msgid "&Next Tip"
+msgstr "Kias Seterusnya"
+
+#: ../src/generic/wizard.cpp:411
+msgid "&Next >"
+msgstr "Seterus&nya >"
+
+#: ../src/generic/wizard.cpp:412
+msgid "&Finish"
+msgstr "&Tamat"
+
+#: ../src/generic/wizard.cpp:420
+msgid "< &Back"
+msgstr "< &Undur"
+
+#: ../src/gtk/aboutdlg.cpp:204
+msgid "translator-credits"
+msgstr "Mahrazi Mohd Kamal <mahrazi@gmail.com>, 2006."
+
+#: ../src/gtk/app.cpp:517
+msgid ""
+"WARNING: using XIM input method is unsupported and may result in problems "
+"with input handling and flickering. Consider unsetting GTK_IM_MODULE or "
+"setting to \"ibus\"."
+msgstr ""
+
+#: ../src/gtk/app.cpp:569
+msgid "Unable to initialize GTK+, is DISPLAY set properly?"
+msgstr ""
+
+#: ../src/gtk/filedlg.cpp:89 ../src/gtk/filepicker.cpp:255
+#, fuzzy, c-format
+msgid "Changing current directory to \"%s\" failed"
+msgstr "Gagal mencipta direktori \"%s\""
+
+#: ../src/gtk/font.cpp:548
+msgid ""
+"Using private fonts is not supported on this system: Pango library is too "
+"old, 1.38 or later required."
+msgstr ""
+
+#: ../src/gtk/font.cpp:558
+#, fuzzy
+msgid "Failed to create font configuration object."
+msgstr "Gagal naiktaraf fail konfigurasi pengguna."
+
+#: ../src/gtk/font.cpp:568
+#, fuzzy, c-format
+msgid "Failed to add custom font \"%s\"."
+msgstr "Gagal memuat metafail dari fail \"%s\"."
+
+#: ../src/gtk/font.cpp:576
+#, fuzzy
+msgid "Failed to register font configuration using private fonts."
+msgstr "Gagal naiktaraf fail konfigurasi pengguna."
+
+#: ../src/gtk/glcanvas.cpp:117 ../src/gtk/glcanvas.cpp:132
+#, fuzzy
+msgid "Fatal Error"
+msgstr "Ralat maut"
+
+#: ../src/gtk/glcanvas.cpp:117
+msgid ""
+"This program wasn't compiled with EGL support required under Wayland, "
+"either\n"
+"install EGL libraries and rebuild or run it under X11 backend by setting\n"
+"environment variable GDK_BACKEND=x11 before starting your program."
+msgstr ""
+
+#: ../src/gtk/glcanvas.cpp:132
+msgid ""
+"wxGLCanvas is only supported on Wayland and X11 currently.  You may be able "
+"to\n"
+"work around this by setting environment variable GDK_BACKEND=x11 before\n"
+"starting your program."
+msgstr ""
+
+#: ../src/gtk/mdi.cpp:433
+msgid "MDI child"
+msgstr "Anak MDI"
+
+#: ../src/gtk/power.cpp:188
+#, fuzzy, c-format
+msgid "Failed to open D-Bus connection to the login manager: %s"
+msgstr "Gagal untuk %s mendial sambungan: %s"
+
+#: ../src/gtk/power.cpp:214
+#, fuzzy
+msgid "wxWidgets application"
+msgstr "Pemilihan"
+
+#: ../src/gtk/power.cpp:226
+msgid "Application needs to keep running"
+msgstr ""
+
+#: ../src/gtk/power.cpp:233
+msgid "Clean up before suspend"
+msgstr ""
+
+#: ../src/gtk/power.cpp:259
+#, fuzzy, c-format
+msgid "Failed to inhibit sleep: %s"
+msgstr "Gagal menamatkan sambungan mendial: %s"
+
+#: ../src/gtk/power.cpp:265
+msgid "Unexpected response to D-Bus \"Inhibit\" request."
+msgstr ""
+
+#: ../src/gtk/print.cpp:218
+#, fuzzy
+msgid "Custom size"
+msgstr "Saiz Fon"
+
+#: ../src/gtk/print.cpp:752
+#, fuzzy, c-format
+msgid "Error while printing: %s"
+msgstr "Ralat ketika menunggu semafor"
+
+#: ../src/gtk/print.cpp:816
+msgid "Page Setup"
+msgstr "Tetapan Halaman"
+
+#: ../src/gtk/webview_webkit.cpp:932
+msgid "Retrieving JavaScript script output is not supported with WebKit v1"
+msgstr ""
+
+#: ../src/gtk/webview_webkit2.cpp:1098
+msgid ""
+"Setting proxy is not supported by WebKit, at least version 2.16 is required."
+msgstr ""
+
+#: ../src/gtk/webview_webkit2.cpp:1104
+msgid "This program was compiled without support for setting WebKit proxy."
+msgstr ""
+
+#: ../src/gtk/window.cpp:6289
+msgid ""
+"GTK+ installed on this machine is too old to support screen compositing, "
+"please install GTK+ 2.12 or later."
+msgstr ""
+
+#: ../src/gtk/window.cpp:6307
+msgid ""
+"Compositing not supported by this system, please enable it in your Window "
+"Manager."
+msgstr ""
+
+#: ../src/gtk/window.cpp:6318
+msgid ""
+"This program was compiled with a too old version of GTK+, please rebuild "
+"with GTK+ 2.12 or newer."
+msgstr ""
+
+#: ../src/html/chm.cpp:138
+#, c-format
+msgid "Failed to open CHM archive '%s'."
+msgstr "Gagal membuka arkib sementara '%s'."
+
+#: ../src/html/chm.cpp:270
+#, c-format
+msgid "Could not extract %s into %s: %s"
+msgstr "Gagal ekstrak %s kepada %s: %s"
+
+#: ../src/html/chm.cpp:324
+msgid "no error"
+msgstr "tiada ralat"
+
+#: ../src/html/chm.cpp:326
+msgid "bad arguments to library function"
+msgstr "argumen buruk kepada fungsi pustaka"
+
+#: ../src/html/chm.cpp:328
+msgid "error opening file"
+msgstr "ralat membuka fail"
+
+#: ../src/html/chm.cpp:330
+msgid "read error"
+msgstr "ralat baca"
+
+#: ../src/html/chm.cpp:332
+msgid "write error"
+msgstr "ralat tulis"
+
+#: ../src/html/chm.cpp:334
+msgid "seek error"
+msgstr "ralat mencari"
+
+#: ../src/html/chm.cpp:338
+msgid "bad signature"
+msgstr "tandatangan rosak"
+
+#: ../src/html/chm.cpp:340
+msgid "error in data format"
+msgstr "ralat dalam format data"
+
+#: ../src/html/chm.cpp:342
+msgid "checksum error"
+msgstr "ralat checksum"
+
+#: ../src/html/chm.cpp:344
+msgid "compression error"
+msgstr "ralat mampatan"
+
+#: ../src/html/chm.cpp:346
+msgid "decompression error"
+msgstr "ralat nyahmampat"
+
+#: ../src/html/chm.cpp:437
+#, c-format
+msgid "Could not locate file '%s'."
+msgstr "Gagal menempatkan fail '%s'."
+
+#: ../src/html/chm.cpp:711
+#, c-format
+msgid "Could not create temporary file '%s'"
+msgstr "Gagal mencipta fail sementara '%s'"
+
+#: ../src/html/chm.cpp:718
+#, c-format
+msgid "Extraction of '%s' into '%s' failed."
+msgstr "Pengekstrakan '%s' kepada '%s' gagal."
+
+#: ../src/html/chm.cpp:806 ../src/html/chm.cpp:863
+msgid "CHM handler currently supports only local files!"
+msgstr "Pengemudi CHM kini hanya menyokong fail lokal!"
+
+#: ../src/html/chm.cpp:827
+msgid "Link contained '//', converted to absolute link."
+msgstr "Pautan mengandungi '//', tukar kepada pautan sebenar."
+
+#: ../src/html/helpctrl.cpp:59
+#, c-format
+msgid "Help: %s"
+msgstr "Bantuan: %s"
+
+#: ../src/html/helpctrl.cpp:155
+#, c-format
+msgid "Adding book %s"
+msgstr "Tambah buku %s"
+
+#: ../src/html/helpdata.cpp:295
+#, c-format
+msgid "Cannot open contents file: %s"
+msgstr "Gagal buka kandungan fial: %s"
+
+#: ../src/html/helpdata.cpp:309
+#, c-format
+msgid "Cannot open index file: %s"
+msgstr "Gagal buka fail indeks: %s"
+
+#: ../src/html/helpdata.cpp:643
+msgid "noname"
+msgstr "tiada nama"
+
+#: ../src/html/helpdata.cpp:652
+#, c-format
+msgid "Cannot open HTML help book: %s"
+msgstr "Gagal buka buku bantuan HTML: %s"
+
+#: ../src/html/helpwnd.cpp:315
+msgid "Displays help as you browse the books on the left."
+msgstr "Papar bantuan sebaik sahaja anda melayari kiri buku."
+
+#: ../src/html/helpwnd.cpp:411 ../src/html/helpwnd.cpp:1100
+#: ../src/html/helpwnd.cpp:1735
+msgid "(bookmarks)"
+msgstr "(tanda laman)"
+
+#: ../src/html/helpwnd.cpp:424
+msgid "Add current page to bookmarks"
+msgstr "Tambah laman semasa ke tanda laman"
+
+#: ../src/html/helpwnd.cpp:425
+msgid "Remove current page from bookmarks"
+msgstr "Buang laman semasa dari tanda laman"
+
+#: ../src/html/helpwnd.cpp:470
+msgid "Contents"
+msgstr "Kandungan"
+
+#: ../src/html/helpwnd.cpp:485
+msgid "Find"
+msgstr "Cari"
+
+#: ../src/html/helpwnd.cpp:487
+msgid "Show all"
+msgstr "Papar Semua"
+
+#: ../src/html/helpwnd.cpp:497
+msgid ""
+"Display all index items that contain given substring. Search is case "
+"insensitive."
+msgstr ""
+"Papar semua indeks item yang subrentetannya diberi. Carian adalah sensitif "
+"kes."
+
+#: ../src/html/helpwnd.cpp:498
+msgid "Show all items in index"
+msgstr "Tunjuk semua item indeks"
+
+#: ../src/html/helpwnd.cpp:528
+msgid "Case sensitive"
+msgstr "Sensitif kes"
+
+#: ../src/html/helpwnd.cpp:529
+msgid "Whole words only"
+msgstr "Seluruh perkataan sahaja"
+
+#: ../src/html/helpwnd.cpp:532
+#, fuzzy
+msgid ""
+"Search contents of help book(s) for all occurrences of the text you typed "
+"above"
+msgstr ""
+"Mencari kandungan buku bantuan untuk semua kejadian yang anda taip teks "
+"diatasnya"
+
+#: ../src/html/helpwnd.cpp:653
+msgid "Show/hide navigation panel"
+msgstr "Tunjuk/sorok panel navigasi"
+
+#: ../src/html/helpwnd.cpp:655
+msgid "Go back"
+msgstr "Kem&bali"
+
+#: ../src/html/helpwnd.cpp:656
+msgid "Go forward"
+msgstr "&Maju"
+
+#: ../src/html/helpwnd.cpp:658
+msgid "Go one level up in document hierarchy"
+msgstr "Pergi satu aras ke atas dalam hirarki dokumen"
+
+#: ../src/html/helpwnd.cpp:666 ../src/html/helpwnd.cpp:1547
+msgid "Open HTML document"
+msgstr "Buka dokumen HTML"
+
+#: ../src/html/helpwnd.cpp:670
+msgid "Print this page"
+msgstr "Cetak laman ini"
+
+#: ../src/html/helpwnd.cpp:674
+msgid "Display options dialog"
+msgstr "Papar dialog pilihan"
+
+#: ../src/html/helpwnd.cpp:795
+msgid "Please choose the page to display:"
+msgstr "Sila pilih laman yang ingin dipaparkan:"
+
+#: ../src/html/helpwnd.cpp:796
+msgid "Help Topics"
+msgstr "Topik Bantuan"
+
+#: ../src/html/helpwnd.cpp:852
+msgid "Searching..."
+msgstr "Mencari..."
+
+#: ../src/html/helpwnd.cpp:853
+msgid "No matching page found yet"
+msgstr "Tiada padanan laman ditemui"
+
+#: ../src/html/helpwnd.cpp:870
+#, c-format
+msgid "Found %i matches"
+msgstr "%i padanan ditemui"
+
+#: ../src/html/helpwnd.cpp:958
+msgid "(Help)"
+msgstr "(Bantuan)"
+
+#: ../src/html/helpwnd.cpp:1026
+#, fuzzy, c-format
+msgid "%d of %lu"
+msgstr "%i of %i"
+
+#: ../src/html/helpwnd.cpp:1028
+#, fuzzy, c-format
+msgid "%lu of %lu"
+msgstr "%i of %i"
+
+#: ../src/html/helpwnd.cpp:1047
+msgid "Search in all books"
+msgstr "Carian dalam semua buku"
+
+#: ../src/html/helpwnd.cpp:1193
+msgid "Help Browser Options"
+msgstr "Pilihan Pelungsur Bantuan"
+
+#: ../src/html/helpwnd.cpp:1198
+msgid "Normal font:"
+msgstr "Fon normal:"
+
+#: ../src/html/helpwnd.cpp:1199
+msgid "Fixed font:"
+msgstr "Fon tetap:"
+
+#: ../src/html/helpwnd.cpp:1200
+msgid "Font size:"
+msgstr "Saiz fon:"
+
+#: ../src/html/helpwnd.cpp:1245
+msgid "font size"
+msgstr "Saiz Fon"
+
+#: ../src/html/helpwnd.cpp:1256
+msgid "Normal face<br>and <u>underlined</u>. "
+msgstr "Rupa normal<br>dan <u>garis-bawah</u>. "
+
+#: ../src/html/helpwnd.cpp:1257
+msgid "<i>Italic face.</i> "
+msgstr "<i>Rupa italik.</i> "
+
+#: ../src/html/helpwnd.cpp:1258
+msgid "<b>Bold face.</b> "
+msgstr "<b>Rupa tebal.</b> "
+
+#: ../src/html/helpwnd.cpp:1259
+msgid "<b><i>Bold italic face.</i></b><br>"
+msgstr "<b><i>Rupa tebal italik.</i></b><br>"
+
+#: ../src/html/helpwnd.cpp:1262
+msgid "Fixed size face.<br> <b>bold</b> <i>italic</i> "
+msgstr "Rupa saiz tetap.<br><b>gelap</b><i>italik</i> "
+
+#: ../src/html/helpwnd.cpp:1263
+msgid "<b><i>bold italic <u>underlined</u></i></b><br>"
+msgstr "<b><i>tebal italik <u>garis bawah</u></i></b><br>"
+
+#: ../src/html/helpwnd.cpp:1524
+msgid "Help Printing"
+msgstr "Mencetak Bantuan"
+
+#: ../src/html/helpwnd.cpp:1527
+msgid "Cannot print empty page."
+msgstr "Gagal cipta laman kosong."
+
+#: ../src/html/helpwnd.cpp:1540
+msgid "HTML files (*.html;*.htm)|*.html;*.htm|"
+msgstr "Fail HTML (*.html;*.htm)|*.html;*.htm|"
+
+#: ../src/html/helpwnd.cpp:1541
+msgid "Help books (*.htb)|*.htb|Help books (*.zip)|*.zip|"
+msgstr "Buku Bantuan (*.htb)|*.htb|Buku Bantuan (*.zip)|*.zip|"
+
+#: ../src/html/helpwnd.cpp:1542
+msgid "HTML Help Project (*.hhp)|*.hhp|"
+msgstr "Projek Bantuan HTML (*.hhp)|*.hhp|"
+
+#: ../src/html/helpwnd.cpp:1544
+msgid "Compressed HTML Help file (*.chm)|*.chm|"
+msgstr "Fail Bantuan HTML Termampat (*.chm)|*.chm|"
+
+#: ../src/html/helpwnd.cpp:1671
+#, fuzzy, c-format
+msgid "%i of %u"
+msgstr "%i of %i"
+
+#: ../src/html/helpwnd.cpp:1709
+#, fuzzy, c-format
+msgid "%u of %u"
+msgstr "%i of %i"
+
+#: ../src/html/htmlfilt.cpp:134
+#, c-format
+msgid "Cannot open HTML document: %s"
+msgstr "Gagal buka dokumen HTML: %s"
+
+#: ../src/html/htmlwin.cpp:599
+msgid "Connecting..."
+msgstr "Menghubungkan..."
+
+#: ../src/html/htmlwin.cpp:616
+#, c-format
+msgid "Unable to open requested HTML document: %s"
+msgstr "Gagal membuka dokumen HTML yang diminta: %s"
+
+#: ../src/html/htmlwin.cpp:630
+msgid "Loading : "
+msgstr "Memuatkan: "
+
+#: ../src/html/htmlwin.cpp:673
+msgid "Done"
+msgstr "&Selesai"
+
+#: ../src/html/htmlwin.cpp:723
+#, c-format
+msgid "HTML anchor %s does not exist."
+msgstr "Sauh HTML %s tidak wujud."
+
+#: ../src/html/htmlwin.cpp:1057
+#, c-format
+msgid "Copied to clipboard:\"%s\""
+msgstr "Salin ke papan klip:\"%s\""
+
+#: ../src/html/htmprint.cpp:269
+msgid ""
+"This document doesn't fit on the page horizontally and will be truncated "
+"when it is printed."
+msgstr ""
+
+#: ../src/html/htmprint.cpp:285
+#, c-format
+msgid ""
+"The document \"%s\" doesn't fit on the page horizontally and will be "
+"truncated if printed.\n"
+"\n"
+"Would you like to proceed with printing it nevertheless?"
+msgstr ""
+
+#: ../src/html/htmprint.cpp:296
+msgid ""
+"If possible, try changing the layout parameters to make the printout more "
+"narrow."
+msgstr ""
+
+#: ../src/html/htmprint.cpp:445
+msgid ": file does not exist!"
+msgstr ": fail tidak wujud!"
+
+#. TRANSLATORS: %s may be a document title.
+#: ../src/html/htmprint.cpp:717
+#, fuzzy, c-format
+msgid "%s Preview"
+msgstr " Pralihat"
+
+#: ../src/html/htmprint.cpp:755 ../src/richtext/richtextprint.cpp:618
+msgid ""
+"There was a problem during page setup: you may need to set a default printer."
+msgstr ""
+"Terdapat masalah semasa pemasangan laman: anda mungkin perlukan memasang "
+"pencetak lalai."
+
+#: ../src/msw/clipbrd.cpp:80
+msgid "Failed to open the clipboard."
+msgstr "Gagal membuka klipbod."
+
+#: ../src/msw/clipbrd.cpp:101
+msgid "Failed to close the clipboard."
+msgstr "Gagal menutup klipbod."
+
+#: ../src/msw/clipbrd.cpp:113
+msgid "Failed to empty the clipboard."
+msgstr "Gagal melapangkan klipbod."
+
+#: ../src/msw/clipbrd.cpp:284
+msgid "Failed to put data on the clipboard"
+msgstr "Gagal letak data pada klipbod"
+
+#: ../src/msw/clipbrd.cpp:326
+msgid "Failed to get data from the clipboard"
+msgstr "Gagal memdapatkan data dari klipbod."
+
+#: ../src/msw/clipbrd.cpp:363
+msgid "Failed to retrieve the supported clipboard formats"
+msgstr "Gagal mendapatkan format klipbod disokong"
+
+#: ../src/msw/colordlg.cpp:228
+#, fuzzy, c-format
+msgid "Colour selection dialog failed with error %0lx."
+msgstr "Perlaksanaan arahan '%s' gagal dengan ralat: %ul"
+
+#: ../src/msw/cursor.cpp:141
+msgid "Failed to create cursor."
+msgstr "Gagal mencipta kursor."
+
+#: ../src/msw/dde.cpp:279
+#, c-format
+msgid "Failed to register DDE server '%s'"
+msgstr "Gagal daftar pelayan DDE '%s'"
+
+#: ../src/msw/dde.cpp:300
+#, c-format
+msgid "Failed to unregister DDE server '%s'"
+msgstr "Gagal nyahdaftar pelayan DDE '%s'"
+
+#: ../src/msw/dde.cpp:428
+#, c-format
+msgid "Failed to create connection to server '%s' on topic '%s'"
+msgstr "Gagal cipta smabugan ke pelayan '%s' pada topik '%s'"
+
+#: ../src/msw/dde.cpp:655
+msgid "DDE poke request failed"
+msgstr "Permintaan poke DDE gagal"
+
+#: ../src/msw/dde.cpp:674
+msgid "Failed to establish an advise loop with DDE server"
+msgstr "Gagal dirikan gelung yang dipertimbangkan dengan pelayan DDE"
+
+#: ../src/msw/dde.cpp:693
+msgid "Failed to terminate the advise loop with DDE server"
+msgstr "Gagal menamatkan gelung yang dipertimbangkan dengan pelayan DDE"
+
+#: ../src/msw/dde.cpp:768
+msgid "Failed to send DDE advise notification"
+msgstr "Gagal hantar pemberitahuan nasihat DDE"
+
+#: ../src/msw/dde.cpp:1085
+msgid "Failed to create DDE string"
+msgstr "Gagal cipta rentetan DDE"
+
+#: ../src/msw/dde.cpp:1131
+msgid "no DDE error."
+msgstr "tiada ralat DDE."
+
+#: ../src/msw/dde.cpp:1135
+msgid "a request for a synchronous advise transaction has timed out."
+msgstr "permintaan untuk transaksi menyegerakkan nasihat telah tamat tempoh."
+
+#: ../src/msw/dde.cpp:1138
+msgid "the response to the transaction caused the DDE_FBUSY bit to be set."
+msgstr "tindak balas kepada transaksi menyebabkan bit DDE_FBUSY ditetapkan."
+
+#: ../src/msw/dde.cpp:1141
+msgid "a request for a synchronous data transaction has timed out."
+msgstr "permintaan untuk transaksi menyegerakkan data telah tamat tempoh."
+
+#: ../src/msw/dde.cpp:1144
+msgid ""
+"a DDEML function was called without first calling the DdeInitialize "
+"function,\n"
+"or an invalid instance identifier\n"
+"was passed to a DDEML function."
+msgstr ""
+"Fungsi DDEML telah dipanggil tanpa memanggil fungdi DdeInitialize terlebih "
+"dahulu,\n"
+"atau pengenal contoh tidak sah\n"
+"telah dilepaskan kepada fungsi DDEML."
+
+#: ../src/msw/dde.cpp:1147
+msgid ""
+"an application initialized as APPCLASS_MONITOR has\n"
+"attempted to perform a DDE transaction,\n"
+"or an application initialized as APPCMD_CLIENTONLY has \n"
+"attempted to perform server transactions."
+msgstr ""
+"aplikasi dumulakan sebagai APPCLASS_MONITOR telah\n"
+"berusaha melakukan transaksi DDE, atau\n"
+"aplikasi dimulakan sebagai APPCMD_CLIENTONLY telah\n"
+"berusaha melakukan transaksi pelayan."
+
+#: ../src/msw/dde.cpp:1150
+msgid "a request for a synchronous execute transaction has timed out."
+msgstr "permintaan untuk transaksi menyegerakkan laksana telah tamat tempoh."
+
+#: ../src/msw/dde.cpp:1153
+msgid "a parameter failed to be validated by the DDEML."
+msgstr "parameter gagal disahkan oleh DDEML."
+
+#: ../src/msw/dde.cpp:1156
+msgid "a DDEML application has created a prolonged race condition."
+msgstr "Aplikasi DDEML telah mencipta keadaan memanjangkan bangsa."
+
+#: ../src/msw/dde.cpp:1159
+msgid "a memory allocation failed."
+msgstr "memori gagal ditempatkan."
+
+#: ../src/msw/dde.cpp:1162
+msgid "a client's attempt to establish a conversation has failed."
+msgstr "klien mencuba untuk mendirikan perbualan tetapi gagal."
+
+#: ../src/msw/dde.cpp:1165
+msgid "a transaction failed."
+msgstr "transaksi gagal."
+
+#: ../src/msw/dde.cpp:1168
+msgid "a request for a synchronous poke transaction has timed out."
+msgstr "permintaan untuk transaksi menyegerakkan penebuk telah tamat tempoh."
+
+#: ../src/msw/dde.cpp:1171
+msgid "an internal call to the PostMessage function has failed. "
+msgstr "panggilan dalaman kepada fungsi PostMessage gagal."
+
+#: ../src/msw/dde.cpp:1174
+msgid "reentrancy problem."
+msgstr "masalah kemassukan"
+
+#: ../src/msw/dde.cpp:1177
+msgid ""
+"a server-side transaction was attempted on a conversation\n"
+"that was terminated by the client, or the server\n"
+"terminated before completing a transaction."
+msgstr ""
+"transaksi pihak-pelayan telah diusahakan pada perbicaraan\n"
+"yang telah ditamatkan oleh klien, atau pelayan\n"
+"ditamatkan sebelum menyudahkan transaksi."
+
+#: ../src/msw/dde.cpp:1180
+msgid "an internal error has occurred in the DDEML."
+msgstr "ralat dalaman telah berlaku dalam DDEML."
+
+#: ../src/msw/dde.cpp:1183
+msgid "a request to end an advise transaction has timed out."
+msgstr "permintaan untuk menamatkan transaksi nasihat telah tamat tempoh."
+
+#: ../src/msw/dde.cpp:1186
+msgid ""
+"an invalid transaction identifier was passed to a DDEML function.\n"
+"Once the application has returned from an XTYP_XACT_COMPLETE callback,\n"
+"the transaction identifier for that callback is no longer valid."
+msgstr ""
+"pengenal transaksi tidak sah telah dilepaskan kepada fungsi DDEML.\n"
+"Sekali aplikasi telah dipulangkan kepada panggil-balik XTYP_XACT_COMPLETE,\n"
+"pengenal transaksi untuk panggil-balik tidak lagi sah."
+
+#: ../src/msw/dde.cpp:1189
+#, c-format
+msgid "Unknown DDE error %08x"
+msgstr "Ralat DDE %08x tidak diketahui"
+
+#: ../src/msw/dialup.cpp:343
+msgid ""
+"Dial up functions are unavailable because the remote access service (RAS) is "
+"not installed on this machine. Please install it."
+msgstr ""
+"Fungsi mendial tiada disebabkan servis capaian jauh (RAS) tidak dipasang "
+"pada mesin ini. Sila pasangkan."
+
+#: ../src/msw/dialup.cpp:402
+#, fuzzy, c-format
+msgid ""
+"The version of remote access service (RAS) installed on this machine is too "
+"old, please upgrade (the following required function is missing: %s)."
+msgstr ""
+"Versi servis capaian jauh (RAS) dipasang pada mesin ini terlalu lama, sila "
+"naiktaraf (fungsi diperlukan berikut telah hilang: %s)."
+
+#: ../src/msw/dialup.cpp:437
+msgid "Failed to retrieve text of RAS error message"
+msgstr "Gagal mendapatkan teks mesej ralat RAS"
+
+#: ../src/msw/dialup.cpp:440
+#, c-format
+msgid "unknown error (error code %08x)."
+msgstr "ralat tidak diketahui (kod ralat %08x)."
+
+#: ../src/msw/dialup.cpp:492
+#, c-format
+msgid "Cannot find active dialup connection: %s"
+msgstr "Gagal menemui sambungan mendial aktif: %s"
+
+#: ../src/msw/dialup.cpp:513
+msgid "Several active dialup connections found, choosing one randomly."
+msgstr "Beberapa sambungan mendial aktif ditemui, pilih satu secara rawak."
+
+#: ../src/msw/dialup.cpp:598 ../src/msw/dialup.cpp:832
+#, c-format
+msgid "Failed to establish dialup connection: %s"
+msgstr "Gagal mengukuhkan sambuungan mendial: %s"
+
+#: ../src/msw/dialup.cpp:664
+#, c-format
+msgid "Failed to get ISP names: %s"
+msgstr "Gagal mendapatkan nama ISP: %s"
+
+#: ../src/msw/dialup.cpp:712
+msgid "Failed to connect: no ISP to dial."
+msgstr "Gagal menyambung: tiada ISP untuk dail."
+
+#: ../src/msw/dialup.cpp:732
+msgid "Choose ISP to dial"
+msgstr "Pilih ISP untuk dail"
+
+#: ../src/msw/dialup.cpp:733
+msgid "Please choose which ISP do you want to connect to"
+msgstr "Sila pilih ISP yang mana anda ingin sambung kepadanya"
+
+#: ../src/msw/dialup.cpp:766
+msgid "Failed to connect: missing username/password."
+msgstr "Sila menyambung: hilang nama pengguna/kata laluan."
+
+#: ../src/msw/dialup.cpp:796
+msgid "Cannot find the location of address book file"
+msgstr "Gagal menemui lokasi fail buku alamat"
+
+#: ../src/msw/dialup.cpp:827
+#, fuzzy, c-format
+msgid "Failed to initiate dialup connection: %s"
+msgstr "Gagal menamatkan sambungan mendial: %s"
+
+#: ../src/msw/dialup.cpp:897
+msgid "Cannot hang up - no active dialup connection."
+msgstr "Gagal menggantung - tiada sambungan mendial aktif."
+
+#: ../src/msw/dialup.cpp:907
+#, c-format
+msgid "Failed to terminate the dialup connection: %s"
+msgstr "Gagal menamatkan sambungan mendial: %s"
+
+#: ../src/msw/dib.cpp:313
+#, c-format
+msgid "Failed to save the bitmap image to file \"%s\"."
+msgstr "Gagal menyimpan peta bit kepada fail \"%s\"."
+
+#: ../src/msw/dib.cpp:543
+#, fuzzy, c-format
+msgid "Failed to allocate %luKb of memory for bitmap data."
+msgstr "Gagal menyediakan %luKb memori untuk data peta bit."
+
+#: ../src/msw/dir.cpp:241
+#, c-format
+msgid "Cannot enumerate files in directory '%s'"
+msgstr "Gagal menghitung fail dalam direktori '%s'"
+
+#: ../src/msw/dirdlg.cpp:368
+#, fuzzy
+msgid "Couldn't obtain folder name"
+msgstr "Gagal cipta pemasa"
+
+#: ../src/msw/dlmsw.cpp:163
+#, fuzzy, c-format
+msgid "(error %d: %s)"
+msgstr " (ralat %ld: %s)"
+
+#: ../src/msw/dragimag.cpp:143 ../src/msw/dragimag.cpp:178
+#: ../src/msw/imaglist.cpp:309 ../src/msw/imaglist.cpp:331
+msgid "Couldn't add an image to the image list."
+msgstr "Gagal tambah imej kepada senarai imej."
+
+#: ../src/msw/enhmeta.cpp:94
+#, c-format
+msgid "Failed to load metafile from file \"%s\"."
+msgstr "Gagal memuat metafail dari fail \"%s\"."
+
+#: ../src/msw/fdrepdlg.cpp:412
+#, c-format
+msgid "Failed to create the standard find/replace dialog (error code %d)"
+msgstr "Gagal mencipta dialog cari/ganti piawai (kod ralat %d)"
+
+#: ../src/msw/filedlg.cpp:1241
+msgid "Access to the file system is not allowed from secure desktop."
+msgstr ""
+
+#: ../src/msw/filedlg.cpp:1242
+msgid "Security warning"
+msgstr ""
+
+#: ../src/msw/filedlg.cpp:1533
+#, fuzzy, c-format
+msgid "File dialog failed with error code %0lx."
+msgstr "Perlaksanaan arahan '%s' gagal dengan ralat: %ul"
+
+#: ../src/msw/font.cpp:1120
+#, fuzzy, c-format
+msgid "Font file \"%s\" couldn't be loaded"
+msgstr "Fail gagal dimuatkan."
+
+#: ../src/msw/fontdlg.cpp:220
+#, fuzzy, c-format
+msgid "Common dialog failed with error code %0lx."
+msgstr "Perlaksanaan arahan '%s' gagal dengan ralat: %ul"
+
+#: ../src/msw/fswatcher.cpp:67
+#, fuzzy
+msgid "Ungraceful worker thread termination"
+msgstr "Tidak dapat menunggu benang ditamatkan"
+
+#: ../src/msw/fswatcher.cpp:81
+#, fuzzy
+msgid "Unable to create IOCP worker thread"
+msgstr "Gagal cipta TextEncodingConverter"
+
+#: ../src/msw/fswatcher.cpp:88
+msgid "Unable to start IOCP worker thread"
+msgstr ""
+
+#: ../src/msw/fswatcher.cpp:140
+msgid "Monitoring individual files for changes is not supported currently."
+msgstr ""
+
+#: ../src/msw/fswatcher.cpp:165
+#, fuzzy, c-format
+msgid "Unable to set up watch for '%s'"
+msgstr "Gagal sentuh fail '%s'"
+
+#: ../src/msw/fswatcher.cpp:466
+#, c-format
+msgid "Can't monitor non-existent directory \"%s\" for changes."
+msgstr ""
+
+#: ../src/msw/glcanvas.cpp:577 ../src/unix/glx11.cpp:507
+msgid "OpenGL 3.0 or later is not supported by the OpenGL driver."
+msgstr ""
+
+#: ../src/msw/glcanvas.cpp:601 ../src/osx/glcanvas_osx.cpp:395
+#: ../src/unix/glegl.cpp:304 ../src/unix/glx11.cpp:553
+#, fuzzy
+msgid "Couldn't create OpenGL context"
+msgstr "Gagal cipta pemasa"
+
+#: ../src/msw/glcanvas.cpp:1294
+msgid "Failed to initialize OpenGL"
+msgstr "Gagal memulakan OpenGL"
+
+#: ../src/msw/graphicsd2d.cpp:607
+msgid "Could not register custom DirectWrite font loader."
+msgstr ""
+
+#: ../src/msw/helpchm.cpp:48
+msgid ""
+"MS HTML Help functions are unavailable because the MS HTML Help library is "
+"not installed on this machine. Please install it."
+msgstr ""
+"Fungsi Bantuan MS HTML tidak wujud kerana pustaka bantuan MS HTML tidak "
+"dipasang pasa mesin ini. SIla pasangkannya."
+
+#: ../src/msw/helpchm.cpp:55
+msgid "Failed to initialize MS HTML Help."
+msgstr "Gagal memulakan Bantuan MS HTML."
+
+#: ../src/msw/iniconf.cpp:458
+#, c-format
+msgid "Can't delete the INI file '%s'"
+msgstr "Gagal memadam fail INI '%s'"
+
+#: ../src/msw/listctrl.cpp:995
+#, c-format
+msgid "Couldn't retrieve information about list control item %d."
+msgstr "Gagal menyelamatkan maklumat perihal senarai item kawalan %d."
+
+#: ../src/msw/mdi.cpp:170 ../src/qt/mdi.cpp:253
+msgid "&Cascade"
+msgstr "Bertindih"
+
+#: ../src/msw/mdi.cpp:171
+msgid "Tile &Horizontally"
+msgstr "Jubin Me&lintang"
+
+#: ../src/msw/mdi.cpp:172
+msgid "Tile &Vertically"
+msgstr "Jubin Me&negak"
+
+#: ../src/msw/mdi.cpp:174
+msgid "&Arrange Icons"
+msgstr "Susun Ikon"
+
+#: ../src/msw/mdi.cpp:621
+msgid "Failed to create MDI parent frame."
+msgstr "Gagal cipta bingkai MDI induk."
+
+#: ../src/msw/mimetype.cpp:234
+#, c-format
+msgid "Failed to create registry entry for '%s' files."
+msgstr "Gagal mencipta kunci registri  untuk fail '%s'."
+
+#: ../src/msw/ole/automtn.cpp:495
+#, fuzzy, c-format
+msgid "Failed to find CLSID of \"%s\""
+msgstr "Gagal membuka papara \"%s\"."
+
+#: ../src/msw/ole/automtn.cpp:512
+#, fuzzy, c-format
+msgid "Failed to create an instance of \"%s\""
+msgstr "Gagal mencipta direktori \"%s\""
+
+#: ../src/msw/ole/automtn.cpp:552
+#, fuzzy, c-format
+msgid "Cannot get an active instance of \"%s\""
+msgstr "Gagal menemui sambungan mendial aktif: %s"
+
+#: ../src/msw/ole/automtn.cpp:564
+#, fuzzy, c-format
+msgid "Failed to get OLE automation interface for \"%s\""
+msgstr "Gagal mencipta direktori \"%s\""
+
+#: ../src/msw/ole/automtn.cpp:621
+msgid "Unknown name or named argument."
+msgstr ""
+
+#: ../src/msw/ole/automtn.cpp:625
+msgid "Incorrect number of arguments."
+msgstr ""
+
+#: ../src/msw/ole/automtn.cpp:637
+#, fuzzy
+msgid "Unknown exception"
+msgstr "Pilihan '%s' tidak diketahui"
+
+#: ../src/msw/ole/automtn.cpp:642
+msgid "Method or property not found."
+msgstr ""
+
+#: ../src/msw/ole/automtn.cpp:646
+msgid "Overflow while coercing argument values."
+msgstr ""
+
+#: ../src/msw/ole/automtn.cpp:650
+msgid "Object implementation does not support named arguments."
+msgstr ""
+
+#: ../src/msw/ole/automtn.cpp:654
+msgid "The locale ID is unknown."
+msgstr ""
+
+#: ../src/msw/ole/automtn.cpp:658
+msgid "Missing a required parameter."
+msgstr ""
+
+#: ../src/msw/ole/automtn.cpp:662
+#, fuzzy, c-format
+msgid "Argument %u not found."
+msgstr "Fail bantuan \"%s\" tidak ditemui."
+
+#: ../src/msw/ole/automtn.cpp:666
+#, c-format
+msgid "Type mismatch in argument %u."
+msgstr ""
+
+#: ../src/msw/ole/automtn.cpp:670
+msgid "The system cannot find the file specified."
+msgstr ""
+
+#: ../src/msw/ole/automtn.cpp:674
+#, fuzzy
+msgid "Class not registered."
+msgstr "Gagal mencipta benang"
+
+#: ../src/msw/ole/automtn.cpp:678
+#, fuzzy, c-format
+msgid "Unknown error %08x"
+msgstr "Ralat DDE %08x tidak diketahui"
+
+#: ../src/msw/ole/automtn.cpp:682
+#, c-format
+msgid "OLE Automation error in %s: %s"
+msgstr ""
+
+#: ../src/msw/ole/dataobj.cpp:385
+#, c-format
+msgid "Couldn't register clipboard format '%s'."
+msgstr "Gagal daftar format klipbod '%s'."
+
+#: ../src/msw/ole/dataobj.cpp:402
+#, c-format
+msgid "The clipboard format '%d' doesn't exist."
+msgstr "Format klipbod '%d' tidak wujud."
+
+#: ../src/msw/progdlg.cpp:1025
+msgid "Skip"
+msgstr "Langkau"
+
+#: ../src/msw/registry.cpp:141
+#, fuzzy, c-format
+msgid "unknown (%lu)"
+msgstr "tidak diketahui"
+
+#: ../src/msw/registry.cpp:409
+#, c-format
+msgid "Can't get info about registry key '%s'"
+msgstr "Gagal mendapatkan maklumat perihal kunci registri '%s'"
+
+#: ../src/msw/registry.cpp:445
+#, c-format
+msgid "Can't open registry key '%s'"
+msgstr "Gagal membuka kunci regisri '%s'"
+
+#: ../src/msw/registry.cpp:478
+#, c-format
+msgid "Can't create registry key '%s'"
+msgstr "Gagal mencipta kunci registri '%s'"
+
+#: ../src/msw/registry.cpp:497
+#, c-format
+msgid "Can't close registry key '%s'"
+msgstr "Gagal tutup kunci registri '%s'"
+
+#: ../src/msw/registry.cpp:512
+#, c-format
+msgid "Registry value '%s' already exists."
+msgstr "Nilai registri '%s' sedia wujud."
+
+#: ../src/msw/registry.cpp:520
+#, c-format
+msgid "Failed to rename registry value '%s' to '%s'."
+msgstr "Gagal menamakan nilai registri '%s' kepada '%s'."
+
+#: ../src/msw/registry.cpp:575
+#, c-format
+msgid "Can't copy values of unsupported type %d."
+msgstr "Gagal salin nilainya tidak menyokong jenis %d."
+
+#: ../src/msw/registry.cpp:586
+#, c-format
+msgid "Registry key '%s' does not exist, cannot rename it."
+msgstr "Kunci registri '%s' tidak wujud, Gagal menamakannya."
+
+#: ../src/msw/registry.cpp:617
+#, c-format
+msgid "Registry key '%s' already exists."
+msgstr "Kunci registri '%s' sedia wujud."
+
+#: ../src/msw/registry.cpp:625
+#, c-format
+msgid "Failed to rename the registry key '%s' to '%s'."
+msgstr "Gagal menamakan kunci registri '%s' kepada '%s'."
+
+#: ../src/msw/registry.cpp:670
+#, c-format
+msgid "Failed to copy the registry subkey '%s' to '%s'."
+msgstr "Gagal salin subkunci registri '%s' ke '%s'."
+
+#: ../src/msw/registry.cpp:683
+#, c-format
+msgid "Failed to copy registry value '%s'"
+msgstr "Gagal salin nilai registri '%s'"
+
+#: ../src/msw/registry.cpp:692
+#, c-format
+msgid "Failed to copy the contents of registry key '%s' to '%s'."
+msgstr "Gagal salin kandunugan kunci registri '%s' ke '%s'."
+
+#: ../src/msw/registry.cpp:718
+#, c-format
+msgid ""
+"Registry key '%s' is needed for normal system operation,\n"
+"deleting it will leave your system in unusable state:\n"
+"operation aborted."
+msgstr ""
+"Kunci registri '%s' diperlukan untuk operasi sistem normal,\n"
+"memadamnya akan menjadikan sistem anda dalam keadaan tidak berguna:\n"
+"operasi digugurkan."
+
+#: ../src/msw/registry.cpp:754
+#, c-format
+msgid "Can't delete key '%s'"
+msgstr "Gagal padam kunci '%s'"
+
+#: ../src/msw/registry.cpp:782
+#, c-format
+msgid "Can't delete value '%s' from key '%s'"
+msgstr "Gagal memadam nilai '%s' daripada kunci '%s'"
+
+#: ../src/msw/registry.cpp:855 ../src/msw/registry.cpp:887
+#: ../src/msw/registry.cpp:929 ../src/msw/registry.cpp:1000
+#, c-format
+msgid "Can't read value of key '%s'"
+msgstr "Gagal baca nilai kunci '%s'"
+
+#: ../src/msw/registry.cpp:873 ../src/msw/registry.cpp:915
+#: ../src/msw/registry.cpp:963 ../src/msw/registry.cpp:1106
+#, c-format
+msgid "Can't set value of '%s'"
+msgstr "Gagal tetapkan nilai '%s'"
+
+#: ../src/msw/registry.cpp:894 ../src/msw/registry.cpp:943
+#, c-format
+msgid "Registry value \"%s\" is not numeric (but of type %s)"
+msgstr ""
+
+#: ../src/msw/registry.cpp:979
+#, c-format
+msgid "Registry value \"%s\" is not binary (but of type %s)"
+msgstr ""
+
+#: ../src/msw/registry.cpp:1028
+#, c-format
+msgid "Registry value \"%s\" is not text (but of type %s)"
+msgstr ""
+
+#: ../src/msw/registry.cpp:1089
+#, c-format
+msgid "Can't read value of '%s'"
+msgstr "Gagal baca nilai '%s'"
+
+#: ../src/msw/registry.cpp:1157
+#, c-format
+msgid "Can't enumerate values of key '%s'"
+msgstr "Gagal menghitung nilai untuk kunci '%s'"
+
+#: ../src/msw/registry.cpp:1196
+#, c-format
+msgid "Can't enumerate subkeys of key '%s'"
+msgstr "Gagal menghitung subkunci untuk kunci '%s'"
+
+#: ../src/msw/registry.cpp:1262
+#, c-format
+msgid ""
+"Exporting registry key: file \"%s\" already exists and won't be overwritten."
+msgstr ""
+"Mengeksport kunci registri: fail \"%s\" sedia wujud dan tidak akan ditindih."
+
+#: ../src/msw/registry.cpp:1411
+#, c-format
+msgid "Can't export value of unsupported type %d."
+msgstr "Gagal eksport nilai yang tidak menyokong jenis %d"
+
+#: ../src/msw/registry.cpp:1427
+#, c-format
+msgid "Ignoring value \"%s\" of the key \"%s\"."
+msgstr "Abaikan nilai \"%s\" kunci \"%s\"."
+
+#: ../src/msw/textctrl.cpp:596
+msgid ""
+"Impossible to create a rich edit control, using simple text control instead. "
+"Please reinstall riched32.dll"
+msgstr ""
+"Mustahil untuk mencipta kawalan edit rich, sebaliknya gunakan kawalan mudah "
+"teks. Sila pasang semula riched32.dll"
+
+#: ../src/msw/thread.cpp:522 ../src/unix/threadpsx.cpp:850
+msgid "Cannot start thread: error writing TLS."
+msgstr "Gagal memulakan benang: ralat menulis TLS."
+
+#: ../src/msw/thread.cpp:613
+msgid "Can't set thread priority"
+msgstr "Gagal tetapkan keutamaan benang."
+
+#: ../src/msw/thread.cpp:649
+msgid "Can't create thread"
+msgstr "Gagal mencipta benang"
+
+#: ../src/msw/thread.cpp:668
+msgid "Couldn't terminate thread"
+msgstr "Gagal menamatkan benang"
+
+#: ../src/msw/thread.cpp:799
+msgid "Cannot wait for thread termination"
+msgstr "Tidak dapat menunggu benang ditamatkan"
+
+#: ../src/msw/thread.cpp:873
+#, fuzzy, c-format
+msgid "Cannot suspend thread %lx"
+msgstr "Gagal menggantung benang %x"
+
+#: ../src/msw/thread.cpp:903
+#, fuzzy, c-format
+msgid "Cannot resume thread %lx"
+msgstr "Gagal menyambung benang %x"
+
+#: ../src/msw/thread.cpp:932
+msgid "Couldn't get the current thread pointer"
+msgstr "Gagal dapatkan penunjuk benang semasa"
+
+#: ../src/msw/thread.cpp:1333
+msgid ""
+"Thread module initialization failed: impossible to allocate index in thread "
+"local storage"
+msgstr ""
+"Gagal memulakan modul benang: mustahil untuk menyediakan indeks dalam "
+"penyimpan benang lokal"
+
+#: ../src/msw/thread.cpp:1345
+msgid ""
+"Thread module initialization failed: cannot store value in thread local "
+"storage"
+msgstr ""
+"Gagal memulakan modul benang: Gagal simpan data dalam penyimpan benang lokal"
+
+#: ../src/msw/timer.cpp:133
+msgid "Couldn't create a timer"
+msgstr "Gagal cipta pemasa"
+
+#: ../src/msw/utils.cpp:372
+msgid "can't find user's HOME, using current directory."
+msgstr "Gagal mencari RUMAH pengguna, gunakan direktori semasa."
+
+#: ../src/msw/utils.cpp:662
+#, c-format
+msgid "Failed to kill process %d"
+msgstr "Gagal membunuh proses %d"
+
+#: ../src/msw/utils.cpp:986
+#, fuzzy, c-format
+msgid "Failed to load resource \"%s\"."
+msgstr "Gagal memuat metafail dari fail \"%s\"."
+
+#: ../src/msw/utils.cpp:993
+#, fuzzy, c-format
+msgid "Failed to lock resource \"%s\"."
+msgstr "Gagal mengunci fail kunci '%s'"
+
+#. TRANSLATORS: MS Windows build number
+#: ../src/msw/utils.cpp:1209
+#, fuzzy, c-format
+msgid "build %lu"
+msgstr "Windows XP (build %lu"
+
+#: ../src/msw/utils.cpp:1218
+msgid ", 64-bit edition"
+msgstr ""
+
+#: ../src/msw/utilsexc.cpp:224
+msgid "Failed to create an anonymous pipe"
+msgstr "Gagal mencipta saliran tanpanama"
+
+#: ../src/msw/utilsexc.cpp:697
+msgid "Failed to redirect the child process IO"
+msgstr "Gagal mengalihkan IO proses anak"
+
+#: ../src/msw/utilsexc.cpp:870
+#, c-format
+msgid "Execution of command '%s' failed"
+msgstr "Perlaksanaan arahan '%s' gagal"
+
+#: ../src/msw/volume.cpp:337
+msgid "Failed to load mpr.dll."
+msgstr "Gagal memuat mpr.dll."
+
+#: ../src/msw/volume.cpp:506
+#, c-format
+msgid "Cannot read typename from '%s'!"
+msgstr "Gagal baca nama jenis dari '%s'!"
+
+#: ../src/msw/volume.cpp:615
+#, c-format
+msgid "Cannot load icon from '%s'."
+msgstr "Gagal memuat ikon dari '%s'."
+
+#: ../src/msw/webview_edge.cpp:285
+msgid "This program was compiled without support for setting Edge proxy."
+msgstr ""
+
+#: ../src/msw/webview_ie.cpp:1010
+msgid "Failed to find web view emulation level in the registry"
+msgstr ""
+
+#: ../src/msw/webview_ie.cpp:1019
+msgid "Failed to set web view to modern emulation level"
+msgstr ""
+
+#: ../src/msw/webview_ie.cpp:1027
+msgid "Failed to reset web view to standard emulation level"
+msgstr ""
+
+#: ../src/msw/webview_ie.cpp:1049
+msgid "Can't run JavaScript script without a valid HTML document"
+msgstr ""
+
+#: ../src/msw/webview_ie.cpp:1056
+#, fuzzy
+msgid "Can't get the JavaScript object"
+msgstr "Gagal tetapkan keutamaan benang."
+
+#: ../src/msw/webview_ie.cpp:1070
+#, fuzzy
+msgid "failed to evaluate"
+msgstr "Gagal melaksanakan '%s'\n"
+
+#: ../src/osx/cocoa/filedlg.mm:412
+#, fuzzy
+msgid "File type:"
+msgstr "Teletaip"
+
+#: ../src/osx/cocoa/menu.mm:242
+#, fuzzy
+msgctxt "macOS menu name"
+msgid "Window"
+msgstr "&Tetingkap"
+
+#: ../src/osx/cocoa/menu.mm:259
+#, fuzzy
+msgctxt "macOS menu name"
+msgid "Help"
+msgstr "Bantuan"
+
+#: ../src/osx/cocoa/menu.mm:298
+#, fuzzy
+msgctxt "macOS menu item"
+msgid "Minimize"
+msgstr "Mi&nimum"
+
+#: ../src/osx/cocoa/menu.mm:303
+#, fuzzy
+msgctxt "macOS menu item"
+msgid "Zoom"
+msgstr "Zum Masuk"
+
+#: ../src/osx/cocoa/menu.mm:309
+msgctxt "macOS menu item"
+msgid "Bring All to Front"
+msgstr ""
+
+#: ../src/osx/core/sound.cpp:143
+#, fuzzy, c-format
+msgid "Failed to load sound from \"%s\" (error %d)."
+msgstr "Gagal memuat metafail dari fail \"%s\"."
+
+#: ../src/osx/fontutil.cpp:80
+#, fuzzy, c-format
+msgid "Font file \"%s\" doesn't exist."
+msgstr "Fail %s tidak wujud."
+
+#: ../src/osx/fontutil.cpp:88
+#, c-format
+msgid ""
+"Font file \"%s\" cannot be used as it is not inside the font directory "
+"\"%s\"."
+msgstr ""
+
+#: ../src/osx/menu_osx.cpp:496
+#, fuzzy, c-format
+msgctxt "macOS menu item"
+msgid "About %s"
+msgstr "Perihal"
+
+#: ../src/osx/menu_osx.cpp:499
+#, fuzzy
+msgctxt "macOS menu item"
+msgid "About..."
+msgstr "Perih&al"
+
+#: ../src/osx/menu_osx.cpp:508
+#, fuzzy
+msgctxt "macOS menu item"
+msgid "Preferences..."
+msgstr "Keutamaan"
+
+#: ../src/osx/menu_osx.cpp:512
+msgctxt "macOS menu item"
+msgid "Services"
+msgstr ""
+
+#: ../src/osx/menu_osx.cpp:519
+#, fuzzy, c-format
+msgctxt "macOS menu item"
+msgid "Hide %s"
+msgstr "Bantuan: %s"
+
+#: ../src/osx/menu_osx.cpp:522
+#, fuzzy
+msgctxt "macOS menu item"
+msgid "Hide Application"
+msgstr "Pemilihan"
+
+#: ../src/osx/menu_osx.cpp:526
+msgctxt "macOS menu item"
+msgid "Hide Others"
+msgstr ""
+
+#: ../src/osx/menu_osx.cpp:528
+#, fuzzy
+msgctxt "macOS menu item"
+msgid "Show All"
+msgstr "Papar Semua"
+
+#: ../src/osx/menu_osx.cpp:534
+#, fuzzy, c-format
+msgctxt "macOS menu item"
+msgid "Quit %s"
+msgstr "&Keluar"
+
+#: ../src/osx/menu_osx.cpp:537
+#, fuzzy
+msgctxt "macOS menu item"
+msgid "Quit Application"
+msgstr "Pemilihan"
+
+#: ../src/osx/webview_webkit.mm:444
+#, fuzzy
+msgid "Printing is not supported by the system web control"
+msgstr "Gzip tidak disokong oleh versi zlib ini"
+
+#: ../src/osx/webview_webkit.mm:453
+#, fuzzy
+msgid "Print operation could not be initialized"
+msgstr "Gagal mulakan paparan."
+
+#. TRANSLATORS: Label of font point size
+#: ../src/propgrid/advprops.cpp:605
+#, fuzzy
+msgid "Point Size"
+msgstr "Saiz titik:"
+
+#. TRANSLATORS: Label of font face name
+#: ../src/propgrid/advprops.cpp:615
+#, fuzzy
+msgid "Face Name"
+msgstr "NamaBaru"
+
+#. TRANSLATORS: Label of font style
+#: ../src/propgrid/advprops.cpp:623 ../src/richtext/richtextformatdlg.cpp:331
+msgid "Style"
+msgstr "Gaya"
+
+#. TRANSLATORS: Label of font weight
+#: ../src/propgrid/advprops.cpp:628
+#, fuzzy
+msgid "Weight"
+msgstr "Berat:"
+
+#. TRANSLATORS: Label of underlined font
+#: ../src/propgrid/advprops.cpp:633 ../src/richtext/richtextfontpage.cpp:358
+msgid "Underlined"
+msgstr "Digaris bawahkan"
+
+#. TRANSLATORS: Label of font family
+#: ../src/propgrid/advprops.cpp:637
+#, fuzzy
+msgid "Family"
+msgstr "Keluarga &fon:"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:801
+msgid "AppWorkspace"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:802
+#, fuzzy
+msgid "ActiveBorder"
+msgstr "Moden"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:803
+msgid "ActiveCaption"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:804
+msgid "ButtonFace"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:805
+msgid "ButtonHighlight"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:806
+msgid "ButtonShadow"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:807
+msgid "ButtonText"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:808
+msgid "CaptionText"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:809
+msgid "ControlDark"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:810
+msgid "ControlLight"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:812
+msgid "GrayText"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:813
+#, fuzzy
+msgid "Highlight"
+msgstr "ringan"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:814
+#, fuzzy
+msgid "HighlightText"
+msgstr "Jajar-kanan teks."
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:815
+#, fuzzy
+msgid "InactiveBorder"
+msgstr "Moden"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:816
+msgid "InactiveCaption"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:817
+msgid "InactiveCaptionText"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:818
+msgid "Menu"
+msgstr "Menu"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:819
+msgid "Scrollbar"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:820
+msgid "Tooltip"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:821
+msgid "TooltipText"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:822
+#, fuzzy
+msgid "Window"
+msgstr "&Tetingkap"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:823
+#, fuzzy
+msgid "WindowFrame"
+msgstr "&Tetingkap"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:824
+#, fuzzy
+msgid "WindowText"
+msgstr "&Tetingkap"
+
+#. TRANSLATORS: Custom colour choice entry
+#: ../src/propgrid/advprops.cpp:825 ../src/propgrid/advprops.cpp:1532
+#: ../src/propgrid/advprops.cpp:1576
+#, fuzzy
+msgid "Custom"
+msgstr "Saiz Fon"
+
+#: ../src/propgrid/advprops.cpp:1558
+msgid "Black"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1559
+msgid "Maroon"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1560
+msgid "Navy"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1561
+msgid "Purple"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1562
+msgid "Teal"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1563
+msgid "Gray"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1564
+msgid "Green"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1565
+msgid "Olive"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1566
+msgid "Brown"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1567
+msgid "Blue"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1568
+msgid "Fuchsia"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1569
+#, fuzzy
+msgid "Red"
+msgstr "&Ulangcara"
+
+#: ../src/propgrid/advprops.cpp:1570
+msgid "Orange"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1571
+msgid "Silver"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1572
+msgid "Lime"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1573
+msgid "Aqua"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1574
+msgid "Yellow"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1575
+msgid "White"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1718
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Default"
+msgstr "lalai"
+
+#: ../src/propgrid/advprops.cpp:1719
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Arrow"
+msgstr "esok"
+
+#: ../src/propgrid/advprops.cpp:1720
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Right Arrow"
+msgstr "Kanan"
+
+#: ../src/propgrid/advprops.cpp:1721
+msgctxt "system cursor name"
+msgid "Blank"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1722
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Bullseye"
+msgstr "Gaya peluru"
+
+#: ../src/propgrid/advprops.cpp:1723
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Character"
+msgstr "Kod aksara:"
+
+#: ../src/propgrid/advprops.cpp:1724
+msgctxt "system cursor name"
+msgid "Cross"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1725
+msgctxt "system cursor name"
+msgid "Hand"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1726
+msgctxt "system cursor name"
+msgid "I-Beam"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1727
+msgctxt "system cursor name"
+msgid "Left Button"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1728
+msgctxt "system cursor name"
+msgid "Magnifier"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1729
+msgctxt "system cursor name"
+msgid "Middle Button"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1730
+msgctxt "system cursor name"
+msgid "No Entry"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1731
+msgctxt "system cursor name"
+msgid "Paint Brush"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1732
+msgctxt "system cursor name"
+msgid "Pencil"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1733
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Point Left"
+msgstr "Saiz titik:"
+
+#: ../src/propgrid/advprops.cpp:1734
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Point Right"
+msgstr "Jajar Kanan"
+
+#: ../src/propgrid/advprops.cpp:1735
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Question Arrow"
+msgstr "Soalan"
+
+#: ../src/propgrid/advprops.cpp:1736
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Right Button"
+msgstr "Kanan"
+
+#: ../src/propgrid/advprops.cpp:1737
+msgctxt "system cursor name"
+msgid "Sizing NE-SW"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1738
+msgctxt "system cursor name"
+msgid "Sizing N-S"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1739
+msgctxt "system cursor name"
+msgid "Sizing NW-SE"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1740
+msgctxt "system cursor name"
+msgid "Sizing W-E"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1741
+msgctxt "system cursor name"
+msgid "Sizing"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1742
+msgctxt "system cursor name"
+msgid "Spraycan"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1743
+msgctxt "system cursor name"
+msgid "Wait"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1744
+msgctxt "system cursor name"
+msgid "Watch"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1745
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Wait Arrow"
+msgstr "Kanan"
+
+#: ../src/propgrid/advprops.cpp:2109
+#, fuzzy
+msgid "Make a selection:"
+msgstr "Tampal pilihan"
+
+#: ../src/propgrid/manager.cpp:394
+#, fuzzy
+msgid "Property"
+msgstr "&Ciri-ciri"
+
+#: ../src/propgrid/manager.cpp:395
+msgid "Value"
+msgstr ""
+
+#: ../src/propgrid/manager.cpp:1683
+msgid "Categorized Mode"
+msgstr ""
+
+#: ../src/propgrid/manager.cpp:1709
+msgid "Alphabetic Mode"
+msgstr ""
+
+#. TRANSLATORS: Name of Boolean false value
+#: ../src/propgrid/propgrid.cpp:230
+#, fuzzy
+msgid "False"
+msgstr "Fail"
+
+#. TRANSLATORS: Name of Boolean true value
+#: ../src/propgrid/propgrid.cpp:232
+msgid "True"
+msgstr ""
+
+#. TRANSLATORS: Text  displayed for unspecified value
+#: ../src/propgrid/propgrid.cpp:428
+#, fuzzy
+msgid "Unspecified"
+msgstr "Ditentu"
+
+#. TRANSLATORS: Caption of message box displaying any property error
+#: ../src/propgrid/propgrid.cpp:3145 ../src/propgrid/propgrid.cpp:3282
+#, fuzzy
+msgid "Property Error"
+msgstr "Ralat mencetak"
+
+#: ../src/propgrid/propgrid.cpp:3259
+msgid "You have entered invalid value. Press ESC to cancel editing."
+msgstr ""
+
+#: ../src/propgrid/propgrid.cpp:6608
+#, c-format
+msgid "Error in resource: %s"
+msgstr ""
+
+#: ../src/propgrid/propgridiface.cpp:377
+#, c-format
+msgid ""
+"Type operation \"%s\" failed: Property labeled \"%s\" is of type \"%s\", NOT "
+"\"%s\"."
+msgstr ""
+
+#: ../src/propgrid/props.cpp:159
+#, c-format
+msgid "Unknown base %d. Base 10 will be used."
+msgstr ""
+
+#: ../src/propgrid/props.cpp:324
+#, c-format
+msgid "Value must be %s or higher."
+msgstr ""
+
+#: ../src/propgrid/props.cpp:329 ../src/propgrid/props.cpp:356
+#, fuzzy, c-format
+msgid "Value must be between %s and %s."
+msgstr "Masukkan nombor laman antara %d dan %d:"
+
+#: ../src/propgrid/props.cpp:351
+#, c-format
+msgid "Value must be %s or less."
+msgstr ""
+
+#: ../src/propgrid/props.cpp:1058
+#, fuzzy, c-format
+msgid "Not %s"
+msgstr "Perihal"
+
+#: ../src/propgrid/props.cpp:1770
+#, fuzzy
+msgid "Choose a directory:"
+msgstr "Cipta direktori"
+
+#: ../src/propgrid/props.cpp:2055
+#, fuzzy
+msgid "Choose a file"
+msgstr "Pilih fon"
+
+#: ../src/qt/mdi.cpp:254
+msgid "&Tile"
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:147
+#: ../src/richtext/richtextformatdlg.cpp:376
+#, fuzzy
+msgid "Background"
+msgstr "Warna latar"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:159
+#, fuzzy
+msgid "Background &colour:"
+msgstr "Warna latar"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:161
+#: ../src/richtext/richtextbackgroundpage.cpp:163
+#, fuzzy
+msgid "Enables a background colour."
+msgstr "Warna latar"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:167
+#: ../src/richtext/richtextbackgroundpage.cpp:169
+#, fuzzy
+msgid "The background colour."
+msgstr "Warna latar"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:178
+msgid "Shadow"
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:193
+msgid "Use &shadow"
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:195
+#: ../src/richtext/richtextbackgroundpage.cpp:197
+#, fuzzy
+msgid "Enables a shadow."
+msgstr "Warna latar"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:211
+msgid "&Horizontal offset:"
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:218
+#: ../src/richtext/richtextbackgroundpage.cpp:220
+#, fuzzy
+msgid "The horizontal offset."
+msgstr "Jubin Me&lintang"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:224
+#: ../src/richtext/richtextbackgroundpage.cpp:227
+#: ../src/richtext/richtextbackgroundpage.cpp:228
+#: ../src/richtext/richtextbackgroundpage.cpp:247
+#: ../src/richtext/richtextbackgroundpage.cpp:250
+#: ../src/richtext/richtextbackgroundpage.cpp:251
+#: ../src/richtext/richtextbackgroundpage.cpp:287
+#: ../src/richtext/richtextbackgroundpage.cpp:290
+#: ../src/richtext/richtextbackgroundpage.cpp:291
+#: ../src/richtext/richtextbackgroundpage.cpp:314
+#: ../src/richtext/richtextbackgroundpage.cpp:317
+#: ../src/richtext/richtextbackgroundpage.cpp:318
+#: ../src/richtext/richtextborderspage.cpp:252
+#: ../src/richtext/richtextborderspage.cpp:255
+#: ../src/richtext/richtextborderspage.cpp:256
+#: ../src/richtext/richtextborderspage.cpp:286
+#: ../src/richtext/richtextborderspage.cpp:289
+#: ../src/richtext/richtextborderspage.cpp:290
+#: ../src/richtext/richtextborderspage.cpp:320
+#: ../src/richtext/richtextborderspage.cpp:323
+#: ../src/richtext/richtextborderspage.cpp:324
+#: ../src/richtext/richtextborderspage.cpp:354
+#: ../src/richtext/richtextborderspage.cpp:357
+#: ../src/richtext/richtextborderspage.cpp:358
+#: ../src/richtext/richtextborderspage.cpp:420
+#: ../src/richtext/richtextborderspage.cpp:423
+#: ../src/richtext/richtextborderspage.cpp:424
+#: ../src/richtext/richtextborderspage.cpp:454
+#: ../src/richtext/richtextborderspage.cpp:457
+#: ../src/richtext/richtextborderspage.cpp:458
+#: ../src/richtext/richtextborderspage.cpp:488
+#: ../src/richtext/richtextborderspage.cpp:491
+#: ../src/richtext/richtextborderspage.cpp:492
+#: ../src/richtext/richtextborderspage.cpp:522
+#: ../src/richtext/richtextborderspage.cpp:525
+#: ../src/richtext/richtextborderspage.cpp:526
+#: ../src/richtext/richtextborderspage.cpp:590
+#: ../src/richtext/richtextborderspage.cpp:593
+#: ../src/richtext/richtextborderspage.cpp:594
+#: ../src/richtext/richtextfontpage.cpp:177
+#: ../src/richtext/richtextmarginspage.cpp:199
+#: ../src/richtext/richtextmarginspage.cpp:201
+#: ../src/richtext/richtextmarginspage.cpp:202
+#: ../src/richtext/richtextmarginspage.cpp:224
+#: ../src/richtext/richtextmarginspage.cpp:226
+#: ../src/richtext/richtextmarginspage.cpp:227
+#: ../src/richtext/richtextmarginspage.cpp:247
+#: ../src/richtext/richtextmarginspage.cpp:249
+#: ../src/richtext/richtextmarginspage.cpp:250
+#: ../src/richtext/richtextmarginspage.cpp:272
+#: ../src/richtext/richtextmarginspage.cpp:274
+#: ../src/richtext/richtextmarginspage.cpp:275
+#: ../src/richtext/richtextmarginspage.cpp:313
+#: ../src/richtext/richtextmarginspage.cpp:315
+#: ../src/richtext/richtextmarginspage.cpp:316
+#: ../src/richtext/richtextmarginspage.cpp:338
+#: ../src/richtext/richtextmarginspage.cpp:340
+#: ../src/richtext/richtextmarginspage.cpp:341
+#: ../src/richtext/richtextmarginspage.cpp:361
+#: ../src/richtext/richtextmarginspage.cpp:363
+#: ../src/richtext/richtextmarginspage.cpp:364
+#: ../src/richtext/richtextmarginspage.cpp:386
+#: ../src/richtext/richtextmarginspage.cpp:388
+#: ../src/richtext/richtextmarginspage.cpp:389
+#: ../src/richtext/richtextsizepage.cpp:337
+#: ../src/richtext/richtextsizepage.cpp:340
+#: ../src/richtext/richtextsizepage.cpp:341
+#: ../src/richtext/richtextsizepage.cpp:371
+#: ../src/richtext/richtextsizepage.cpp:374
+#: ../src/richtext/richtextsizepage.cpp:375
+#: ../src/richtext/richtextsizepage.cpp:398
+#: ../src/richtext/richtextsizepage.cpp:401
+#: ../src/richtext/richtextsizepage.cpp:402
+#: ../src/richtext/richtextsizepage.cpp:425
+#: ../src/richtext/richtextsizepage.cpp:428
+#: ../src/richtext/richtextsizepage.cpp:429
+#: ../src/richtext/richtextsizepage.cpp:452
+#: ../src/richtext/richtextsizepage.cpp:455
+#: ../src/richtext/richtextsizepage.cpp:456
+#: ../src/richtext/richtextsizepage.cpp:479
+#: ../src/richtext/richtextsizepage.cpp:482
+#: ../src/richtext/richtextsizepage.cpp:483
+#: ../src/richtext/richtextsizepage.cpp:553
+#: ../src/richtext/richtextsizepage.cpp:556
+#: ../src/richtext/richtextsizepage.cpp:557
+#: ../src/richtext/richtextsizepage.cpp:588
+#: ../src/richtext/richtextsizepage.cpp:591
+#: ../src/richtext/richtextsizepage.cpp:592
+#: ../src/richtext/richtextsizepage.cpp:623
+#: ../src/richtext/richtextsizepage.cpp:626
+#: ../src/richtext/richtextsizepage.cpp:627
+#: ../src/richtext/richtextsizepage.cpp:658
+#: ../src/richtext/richtextsizepage.cpp:661
+#: ../src/richtext/richtextsizepage.cpp:662
+msgid "px"
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:225
+#: ../src/richtext/richtextbackgroundpage.cpp:248
+#: ../src/richtext/richtextbackgroundpage.cpp:288
+#: ../src/richtext/richtextbackgroundpage.cpp:315
+#: ../src/richtext/richtextborderspage.cpp:253
+#: ../src/richtext/richtextborderspage.cpp:287
+#: ../src/richtext/richtextborderspage.cpp:321
+#: ../src/richtext/richtextborderspage.cpp:355
+#: ../src/richtext/richtextborderspage.cpp:421
+#: ../src/richtext/richtextborderspage.cpp:455
+#: ../src/richtext/richtextborderspage.cpp:489
+#: ../src/richtext/richtextborderspage.cpp:523
+#: ../src/richtext/richtextborderspage.cpp:591
+#: ../src/richtext/richtextmarginspage.cpp:200
+#: ../src/richtext/richtextmarginspage.cpp:225
+#: ../src/richtext/richtextmarginspage.cpp:248
+#: ../src/richtext/richtextmarginspage.cpp:273
+#: ../src/richtext/richtextmarginspage.cpp:314
+#: ../src/richtext/richtextmarginspage.cpp:339
+#: ../src/richtext/richtextmarginspage.cpp:362
+#: ../src/richtext/richtextmarginspage.cpp:387
+#: ../src/richtext/richtextsizepage.cpp:338
+#: ../src/richtext/richtextsizepage.cpp:372
+#: ../src/richtext/richtextsizepage.cpp:399
+#: ../src/richtext/richtextsizepage.cpp:426
+#: ../src/richtext/richtextsizepage.cpp:453
+#: ../src/richtext/richtextsizepage.cpp:480
+#: ../src/richtext/richtextsizepage.cpp:554
+#: ../src/richtext/richtextsizepage.cpp:589
+#: ../src/richtext/richtextsizepage.cpp:624
+#: ../src/richtext/richtextsizepage.cpp:659
+msgid "cm"
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:226
+#: ../src/richtext/richtextbackgroundpage.cpp:249
+#: ../src/richtext/richtextbackgroundpage.cpp:289
+#: ../src/richtext/richtextbackgroundpage.cpp:316
+#: ../src/richtext/richtextborderspage.cpp:254
+#: ../src/richtext/richtextborderspage.cpp:288
+#: ../src/richtext/richtextborderspage.cpp:322
+#: ../src/richtext/richtextborderspage.cpp:356
+#: ../src/richtext/richtextborderspage.cpp:422
+#: ../src/richtext/richtextborderspage.cpp:456
+#: ../src/richtext/richtextborderspage.cpp:490
+#: ../src/richtext/richtextborderspage.cpp:524
+#: ../src/richtext/richtextborderspage.cpp:592
+#: ../src/richtext/richtextfontpage.cpp:176
+#: ../src/richtext/richtextfontpage.cpp:179
+msgid "pt"
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:229
+#: ../src/richtext/richtextbackgroundpage.cpp:231
+#: ../src/richtext/richtextbackgroundpage.cpp:252
+#: ../src/richtext/richtextbackgroundpage.cpp:254
+#: ../src/richtext/richtextbackgroundpage.cpp:292
+#: ../src/richtext/richtextbackgroundpage.cpp:294
+#: ../src/richtext/richtextbackgroundpage.cpp:319
+#: ../src/richtext/richtextbackgroundpage.cpp:321
+#, fuzzy
+msgid "Units for this value."
+msgstr "Gagal menunggu penamatan benang."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:234
+#, fuzzy
+msgid "&Vertical offset:"
+msgstr "J&ajaran Peluru:"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:241
+#: ../src/richtext/richtextbackgroundpage.cpp:243
+#, fuzzy
+msgid "The vertical offset."
+msgstr "Gagal mulakan mencetak."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:257
+#, fuzzy
+msgid "Shadow c&olour:"
+msgstr "Pilih warna"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:259
+#: ../src/richtext/richtextbackgroundpage.cpp:261
+#, fuzzy
+msgid "Enables the shadow colour."
+msgstr "Warna latar"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:265
+#: ../src/richtext/richtextbackgroundpage.cpp:267
+#, fuzzy
+msgid "The shadow colour."
+msgstr "Warna fon."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:270
+msgid "Sh&adow spread:"
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:272
+#: ../src/richtext/richtextbackgroundpage.cpp:274
+msgid "Enables the shadow spread."
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:281
+#: ../src/richtext/richtextbackgroundpage.cpp:283
+msgid "The shadow spread."
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:297
+msgid "&Blur distance:"
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:299
+#: ../src/richtext/richtextbackgroundpage.cpp:301
+#, fuzzy
+msgid "Enables the blur distance."
+msgstr "Gagal mulakan mencetak."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:308
+#: ../src/richtext/richtextbackgroundpage.cpp:310
+msgid "The shadow blur distance."
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:324
+msgid "Opaci&ty:"
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:326
+#: ../src/richtext/richtextbackgroundpage.cpp:328
+msgid "Enables the shadow opacity."
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:335
+#: ../src/richtext/richtextbackgroundpage.cpp:337
+msgid "The shadow opacity."
+msgstr ""
+
+#. TRANSLATORS: Rich text page units (percentage)
+#: ../src/richtext/richtextbackgroundpage.cpp:340
+#: ../src/richtext/richtextsizepage.cpp:339
+#: ../src/richtext/richtextsizepage.cpp:373
+#: ../src/richtext/richtextsizepage.cpp:400
+#: ../src/richtext/richtextsizepage.cpp:427
+#: ../src/richtext/richtextsizepage.cpp:454
+#: ../src/richtext/richtextsizepage.cpp:481
+#: ../src/richtext/richtextsizepage.cpp:555
+#: ../src/richtext/richtextsizepage.cpp:590
+#: ../src/richtext/richtextsizepage.cpp:625
+#: ../src/richtext/richtextsizepage.cpp:660
+#, fuzzy
+msgid "%"
+msgstr "%s B"
+
+#: ../src/richtext/richtextborderspage.cpp:229
+#: ../src/richtext/richtextborderspage.cpp:387
+#, fuzzy
+msgid "Border"
+msgstr "Moden"
+
+#: ../src/richtext/richtextborderspage.cpp:242
+#: ../src/richtext/richtextborderspage.cpp:410
+#: ../src/richtext/richtextindentspage.cpp:194
+#: ../src/richtext/richtextliststylepage.cpp:384
+#: ../src/richtext/richtextmarginspage.cpp:185
+#: ../src/richtext/richtextmarginspage.cpp:299
+#: ../src/richtext/richtextsizepage.cpp:531
+#: ../src/richtext/richtextsizepage.cpp:538
+msgid "&Left:"
+msgstr "&Kiri:"
+
+#: ../src/richtext/richtextborderspage.cpp:257
+#: ../src/richtext/richtextborderspage.cpp:259
+msgid "Units for the left border width."
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:266
+#: ../src/richtext/richtextborderspage.cpp:268
+#: ../src/richtext/richtextborderspage.cpp:300
+#: ../src/richtext/richtextborderspage.cpp:302
+#: ../src/richtext/richtextborderspage.cpp:334
+#: ../src/richtext/richtextborderspage.cpp:336
+#: ../src/richtext/richtextborderspage.cpp:368
+#: ../src/richtext/richtextborderspage.cpp:370
+#: ../src/richtext/richtextborderspage.cpp:434
+#: ../src/richtext/richtextborderspage.cpp:436
+#: ../src/richtext/richtextborderspage.cpp:468
+#: ../src/richtext/richtextborderspage.cpp:470
+#: ../src/richtext/richtextborderspage.cpp:502
+#: ../src/richtext/richtextborderspage.cpp:504
+#: ../src/richtext/richtextborderspage.cpp:536
+#: ../src/richtext/richtextborderspage.cpp:538
+#, fuzzy
+msgid "The border line style."
+msgstr "Gaya fon"
+
+#: ../src/richtext/richtextborderspage.cpp:276
+#: ../src/richtext/richtextborderspage.cpp:444
+#: ../src/richtext/richtextindentspage.cpp:212
+#: ../src/richtext/richtextliststylepage.cpp:402
+#: ../src/richtext/richtextmarginspage.cpp:210
+#: ../src/richtext/richtextmarginspage.cpp:324
+#: ../src/richtext/richtextsizepage.cpp:601
+#: ../src/richtext/richtextsizepage.cpp:608
+msgid "&Right:"
+msgstr "K&anan:"
+
+#: ../src/richtext/richtextborderspage.cpp:291
+#: ../src/richtext/richtextborderspage.cpp:293
+msgid "Units for the right border width."
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:310
+#: ../src/richtext/richtextborderspage.cpp:478
+#: ../src/richtext/richtextmarginspage.cpp:233
+#: ../src/richtext/richtextmarginspage.cpp:347
+#: ../src/richtext/richtextsizepage.cpp:566
+#: ../src/richtext/richtextsizepage.cpp:573
+#, fuzzy
+msgid "&Top:"
+msgstr "Ke:"
+
+#: ../src/richtext/richtextborderspage.cpp:325
+#: ../src/richtext/richtextborderspage.cpp:327
+msgid "Units for the top border width."
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:344
+#: ../src/richtext/richtextborderspage.cpp:512
+#: ../src/richtext/richtextmarginspage.cpp:258
+#: ../src/richtext/richtextmarginspage.cpp:372
+#: ../src/richtext/richtextsizepage.cpp:636
+#: ../src/richtext/richtextsizepage.cpp:643
+msgid "&Bottom:"
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:359
+#: ../src/richtext/richtextborderspage.cpp:361
+msgid "Units for the bottom border width."
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:380
+#: ../src/richtext/richtextborderspage.cpp:548
+msgid "&Synchronize values"
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:382
+#: ../src/richtext/richtextborderspage.cpp:384
+#: ../src/richtext/richtextborderspage.cpp:550
+#: ../src/richtext/richtextborderspage.cpp:552
+msgid "Check to edit all borders simultaneously."
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:397
+#: ../src/richtext/richtextborderspage.cpp:555
+#, fuzzy
+msgid "Outline"
+msgstr "Paras senarai:"
+
+#: ../src/richtext/richtextborderspage.cpp:425
+#: ../src/richtext/richtextborderspage.cpp:427
+msgid "Units for the left outline width."
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:459
+#: ../src/richtext/richtextborderspage.cpp:461
+msgid "Units for the right outline width."
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:493
+#: ../src/richtext/richtextborderspage.cpp:495
+msgid "Units for the top outline width."
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:527
+#: ../src/richtext/richtextborderspage.cpp:529
+msgid "Units for the bottom outline width."
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:565
+#: ../src/richtext/richtextborderspage.cpp:600
+msgid "Corner"
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:574
+msgid "Corner &radius:"
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:576
+#: ../src/richtext/richtextborderspage.cpp:578
+msgid "An optional corner radius for adding rounded corners."
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:584
+#: ../src/richtext/richtextborderspage.cpp:586
+msgid "The value of the corner radius."
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:595
+#: ../src/richtext/richtextborderspage.cpp:597
+#, fuzzy
+msgid "Units for the corner radius."
+msgstr "Gagal menunggu penamatan benang."
+
+#: ../src/richtext/richtextborderspage.cpp:609
+#: ../src/richtext/richtextsizepage.cpp:247
+#: ../src/richtext/richtextsizepage.cpp:251
+#, fuzzy
+msgid "None"
+msgstr "(Tiada)"
+
+#: ../src/richtext/richtextborderspage.cpp:610
+#, fuzzy
+msgid "Solid"
+msgstr "Tebal"
+
+#: ../src/richtext/richtextborderspage.cpp:611
+#, fuzzy
+msgid "Dotted"
+msgstr "&Selesai"
+
+#: ../src/richtext/richtextborderspage.cpp:612
+msgid "Dashed"
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:613
+#, fuzzy
+msgid "Double"
+msgstr "&Selesai"
+
+#: ../src/richtext/richtextborderspage.cpp:614
+msgid "Groove"
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:615
+#, fuzzy
+msgid "Ridge"
+msgstr "Kanan"
+
+#: ../src/richtext/richtextborderspage.cpp:616
+#, fuzzy
+msgid "Inset"
+msgstr "Selit"
+
+#: ../src/richtext/richtextborderspage.cpp:617
+msgid "Outset"
+msgstr ""
+
+#: ../src/richtext/richtextbuffer.cpp:3518
+msgid "Change Style"
+msgstr "Ubah Gaya"
+
+#: ../src/richtext/richtextbuffer.cpp:3701
+#, fuzzy
+msgid "Change Object Style"
+msgstr "Ubah Gaya Senarai"
+
+#: ../src/richtext/richtextbuffer.cpp:3974
+#: ../src/richtext/richtextbuffer.cpp:8174
+#, fuzzy
+msgid "Change Properties"
+msgstr "&Ciri-ciri"
+
+#: ../src/richtext/richtextbuffer.cpp:4346
+msgid "Change List Style"
+msgstr "Ubah Gaya Senarai"
+
+#: ../src/richtext/richtextbuffer.cpp:4519
+msgid "Renumber List"
+msgstr "Menomborkan Semula Senarai"
+
+#: ../src/richtext/richtextbuffer.cpp:7867
+#: ../src/richtext/richtextbuffer.cpp:7897
+#: ../src/richtext/richtextbuffer.cpp:7939
+#: ../src/richtext/richtextctrl.cpp:1279 ../src/richtext/richtextctrl.cpp:1473
+msgid "Insert Text"
+msgstr "Selit Teks"
+
+#: ../src/richtext/richtextbuffer.cpp:8023
+#: ../src/richtext/richtextbuffer.cpp:8979
+msgid "Insert Image"
+msgstr "Selit Imej"
+
+#: ../src/richtext/richtextbuffer.cpp:8070
+#, fuzzy
+msgid "Insert Object"
+msgstr "Selit Teks"
+
+#: ../src/richtext/richtextbuffer.cpp:8112
+#, fuzzy
+msgid "Insert Field"
+msgstr "Selit Teks"
+
+#: ../src/richtext/richtextbuffer.cpp:8410
+msgid "Too many EndStyle calls!"
+msgstr "Terlalu banyak panggilan EndStyle!"
+
+#: ../src/richtext/richtextbuffer.cpp:8785
+msgid "files"
+msgstr "fail"
+
+#: ../src/richtext/richtextbuffer.cpp:9380
+#, fuzzy
+msgid "standard/circle"
+msgstr "Piawai"
+
+#: ../src/richtext/richtextbuffer.cpp:9381
+msgid "standard/circle-outline"
+msgstr ""
+
+#: ../src/richtext/richtextbuffer.cpp:9382
+#, fuzzy
+msgid "standard/square"
+msgstr "Piawai"
+
+#: ../src/richtext/richtextbuffer.cpp:9383
+msgid "standard/diamond"
+msgstr ""
+
+#: ../src/richtext/richtextbuffer.cpp:9384
+msgid "standard/triangle"
+msgstr ""
+
+#: ../src/richtext/richtextbuffer.cpp:9423
+#, fuzzy
+msgid "Box Properties"
+msgstr "&Ciri-ciri"
+
+#: ../src/richtext/richtextbuffer.cpp:10006
+msgid "Multiple Cell Properties"
+msgstr ""
+
+#: ../src/richtext/richtextbuffer.cpp:10008
+#, fuzzy
+msgid "Cell Properties"
+msgstr "&Ciri-ciri"
+
+#: ../src/richtext/richtextbuffer.cpp:11256
+#, fuzzy
+msgid "Set Cell Style"
+msgstr "Padam Gaya"
+
+#: ../src/richtext/richtextbuffer.cpp:11330
+#, fuzzy
+msgid "Delete Row"
+msgstr "Padam"
+
+#: ../src/richtext/richtextbuffer.cpp:11380
+#, fuzzy
+msgid "Delete Column"
+msgstr "Padam pilihan"
+
+#: ../src/richtext/richtextbuffer.cpp:11431
+msgid "Add Row"
+msgstr ""
+
+#: ../src/richtext/richtextbuffer.cpp:11494
+msgid "Add Column"
+msgstr ""
+
+#: ../src/richtext/richtextbuffer.cpp:11537
+#, fuzzy
+msgid "Table Properties"
+msgstr "&Ciri-ciri"
+
+#: ../src/richtext/richtextbuffer.cpp:12899
+#, fuzzy
+msgid "Picture Properties"
+msgstr "&Ciri-ciri"
+
+#: ../src/richtext/richtextbuffer.cpp:13169
+#: ../src/richtext/richtextbuffer.cpp:13279
+msgid "image"
+msgstr "imej"
+
+#: ../src/richtext/richtextbulletspage.cpp:145
+#: ../src/richtext/richtextliststylepage.cpp:209
+msgid "&Bullet style:"
+msgstr "Gaya peluru:"
+
+#: ../src/richtext/richtextbulletspage.cpp:150
+#: ../src/richtext/richtextbulletspage.cpp:152
+#: ../src/richtext/richtextliststylepage.cpp:214
+#: ../src/richtext/richtextliststylepage.cpp:216
+msgid "The available bullet styles."
+msgstr "Gaya peluru yang ada."
+
+#: ../src/richtext/richtextbulletspage.cpp:158
+#: ../src/richtext/richtextliststylepage.cpp:221
+msgid "Peri&od"
+msgstr "N&oktah"
+
+#: ../src/richtext/richtextbulletspage.cpp:160
+#: ../src/richtext/richtextbulletspage.cpp:162
+#: ../src/richtext/richtextliststylepage.cpp:223
+#: ../src/richtext/richtextliststylepage.cpp:225
+msgid "Check to add a period after the bullet."
+msgstr "Tanda untuk menambah noktah selepas peluru."
+
+#. TRANSLATORS: Bullet point in parentheses option
+#: ../src/richtext/richtextbulletspage.cpp:167
+#: ../src/richtext/richtextliststylepage.cpp:230
+msgid "(*)"
+msgstr "(*)"
+
+#: ../src/richtext/richtextbulletspage.cpp:169
+#: ../src/richtext/richtextbulletspage.cpp:171
+#: ../src/richtext/richtextliststylepage.cpp:232
+#: ../src/richtext/richtextliststylepage.cpp:234
+msgid "Check to enclose the bullet in parentheses."
+msgstr "Tanda untuk menyertakan peluru dalam kurungan."
+
+#. TRANSLATORS: Right parenthesis bullet point option
+#: ../src/richtext/richtextbulletspage.cpp:176
+#: ../src/richtext/richtextliststylepage.cpp:239
+msgid "*)"
+msgstr "*)"
+
+#: ../src/richtext/richtextbulletspage.cpp:178
+#: ../src/richtext/richtextbulletspage.cpp:180
+#: ../src/richtext/richtextliststylepage.cpp:241
+#: ../src/richtext/richtextliststylepage.cpp:243
+msgid "Check to add a right parenthesis."
+msgstr "Tanda untuk menambah tanda kurungan yang betul."
+
+#: ../src/richtext/richtextbulletspage.cpp:185
+#: ../src/richtext/richtextliststylepage.cpp:248
+msgid "Bullet &Alignment:"
+msgstr "J&ajaran Peluru:"
+
+#: ../src/richtext/richtextbulletspage.cpp:190
+#: ../src/richtext/richtextliststylepage.cpp:253
+msgid "Centre"
+msgstr "Tengah"
+
+#: ../src/richtext/richtextbulletspage.cpp:194
+#: ../src/richtext/richtextbulletspage.cpp:196
+#: ../src/richtext/richtextbulletspage.cpp:217
+#: ../src/richtext/richtextbulletspage.cpp:219
+#: ../src/richtext/richtextliststylepage.cpp:257
+#: ../src/richtext/richtextliststylepage.cpp:259
+#: ../src/richtext/richtextliststylepage.cpp:278
+#: ../src/richtext/richtextliststylepage.cpp:280
+msgid "The bullet character."
+msgstr "Aksara peluru."
+
+#: ../src/richtext/richtextbulletspage.cpp:212
+#: ../src/richtext/richtextliststylepage.cpp:271
+msgid "&Symbol:"
+msgstr "Simbol:"
+
+#: ../src/richtext/richtextbulletspage.cpp:222
+#: ../src/richtext/richtextliststylepage.cpp:283
+msgid "Ch&oose..."
+msgstr "Pilih..."
+
+#: ../src/richtext/richtextbulletspage.cpp:223
+#: ../src/richtext/richtextbulletspage.cpp:225
+#: ../src/richtext/richtextliststylepage.cpp:284
+#: ../src/richtext/richtextliststylepage.cpp:286
+msgid "Click to browse for a symbol."
+msgstr "Klik untuk melungsur simbol."
+
+#: ../src/richtext/richtextbulletspage.cpp:230
+#: ../src/richtext/richtextliststylepage.cpp:291
+msgid "Symbol &font:"
+msgstr "Fon simbol:"
+
+#: ../src/richtext/richtextbulletspage.cpp:235
+#: ../src/richtext/richtextbulletspage.cpp:237
+#: ../src/richtext/richtextliststylepage.cpp:297
+msgid "Available fonts."
+msgstr "Fon yang ada."
+
+#: ../src/richtext/richtextbulletspage.cpp:242
+#: ../src/richtext/richtextliststylepage.cpp:302
+msgid "S&tandard bullet name:"
+msgstr "Nama peluru piawai:"
+
+#: ../src/richtext/richtextbulletspage.cpp:247
+#: ../src/richtext/richtextbulletspage.cpp:249
+#: ../src/richtext/richtextliststylepage.cpp:307
+#: ../src/richtext/richtextliststylepage.cpp:309
+msgid "A standard bullet name."
+msgstr "Nama peluru piawai"
+
+#: ../src/richtext/richtextbulletspage.cpp:254
+msgid "&Number:"
+msgstr "&Nombor:"
+
+#: ../src/richtext/richtextbulletspage.cpp:258
+#: ../src/richtext/richtextbulletspage.cpp:260
+msgid "The list item number."
+msgstr "Nombor senarai item."
+
+#: ../src/richtext/richtextbulletspage.cpp:266
+#: ../src/richtext/richtextbulletspage.cpp:268
+#: ../src/richtext/richtextliststylepage.cpp:475
+#: ../src/richtext/richtextliststylepage.cpp:477
+msgid "Shows a preview of the bullet settings."
+msgstr "Tunjuk pralihat tetapan peluru."
+
+#: ../src/richtext/richtextbulletspage.cpp:276
+#: ../src/richtext/richtextliststylepage.cpp:484
+msgid "(None)"
+msgstr "(Tiada)"
+
+#: ../src/richtext/richtextbulletspage.cpp:277
+#: ../src/richtext/richtextliststylepage.cpp:485
+msgid "Arabic"
+msgstr "Arab"
+
+#: ../src/richtext/richtextbulletspage.cpp:278
+#: ../src/richtext/richtextliststylepage.cpp:486
+msgid "Upper case letters"
+msgstr "Huruf besar"
+
+#: ../src/richtext/richtextbulletspage.cpp:279
+#: ../src/richtext/richtextliststylepage.cpp:487
+msgid "Lower case letters"
+msgstr "Aksara Huruf Kecil"
+
+#: ../src/richtext/richtextbulletspage.cpp:280
+#: ../src/richtext/richtextliststylepage.cpp:488
+msgid "Upper case roman numerals"
+msgstr "Nombor roman huruf besar"
+
+#: ../src/richtext/richtextbulletspage.cpp:281
+#: ../src/richtext/richtextliststylepage.cpp:489
+msgid "Lower case roman numerals"
+msgstr "Angka roman huruf kecil"
+
+#: ../src/richtext/richtextbulletspage.cpp:282
+#: ../src/richtext/richtextliststylepage.cpp:490
+msgid "Numbered outline"
+msgstr "Menomborkan panduan"
+
+#: ../src/richtext/richtextbulletspage.cpp:283
+#: ../src/richtext/richtextliststylepage.cpp:491
+msgid "Symbol"
+msgstr "Simbol"
+
+#: ../src/richtext/richtextbulletspage.cpp:284
+#: ../src/richtext/richtextliststylepage.cpp:492
+msgid "Bitmap"
+msgstr "Peta bit"
+
+#: ../src/richtext/richtextbulletspage.cpp:285
+#: ../src/richtext/richtextliststylepage.cpp:493
+msgid "Standard"
+msgstr "Piawai"
+
+#: ../src/richtext/richtextbulletspage.cpp:287
+#: ../src/richtext/richtextliststylepage.cpp:495
+msgid "*"
+msgstr "*"
+
+#: ../src/richtext/richtextbulletspage.cpp:288
+#: ../src/richtext/richtextliststylepage.cpp:496
+msgid "-"
+msgstr "-"
+
+#: ../src/richtext/richtextbulletspage.cpp:289
+#: ../src/richtext/richtextliststylepage.cpp:497
+msgid ">"
+msgstr ">"
+
+#: ../src/richtext/richtextbulletspage.cpp:290
+#: ../src/richtext/richtextliststylepage.cpp:498
+msgid "+"
+msgstr "+"
+
+#: ../src/richtext/richtextbulletspage.cpp:291
+#: ../src/richtext/richtextliststylepage.cpp:499
+msgid "~"
+msgstr "~"
+
+#: ../src/richtext/richtextctrl.cpp:859
+msgid "Drag"
+msgstr ""
+
+#: ../src/richtext/richtextctrl.cpp:1338 ../src/richtext/richtextctrl.cpp:1559
+msgid "Delete Text"
+msgstr "Padam Teks"
+
+#: ../src/richtext/richtextctrl.cpp:1537
+#, fuzzy
+msgid "Remove Bullet"
+msgstr "Buang"
+
+#: ../src/richtext/richtextctrl.cpp:3070
+msgid "The text couldn't be saved."
+msgstr "Teks gagal disimpan."
+
+#: ../src/richtext/richtextctrl.cpp:3644
+msgid "Replace"
+msgstr "Ganti"
+
+#: ../src/richtext/richtextfontpage.cpp:146
+#: ../src/richtext/richtextsymboldlg.cpp:384
+msgid "&Font:"
+msgstr "&Fon:"
+
+#: ../src/richtext/richtextfontpage.cpp:150
+#: ../src/richtext/richtextfontpage.cpp:152
+msgid "Type a font name."
+msgstr "Jenis nama fon."
+
+#: ../src/richtext/richtextfontpage.cpp:158
+msgid "&Size:"
+msgstr "Saiz:"
+
+#: ../src/richtext/richtextfontpage.cpp:165
+#: ../src/richtext/richtextfontpage.cpp:167
+msgid "Type a size in points."
+msgstr "Jenis saiz dalam titik."
+
+#: ../src/richtext/richtextfontpage.cpp:180
+#: ../src/richtext/richtextfontpage.cpp:182
+#, fuzzy
+msgid "The font size units, points or pixels."
+msgstr "Saiz fon dalam titik."
+
+#: ../src/richtext/richtextfontpage.cpp:189
+#: ../src/richtext/richtextfontpage.cpp:191
+msgid "Lists the available fonts."
+msgstr "Senarai fon yang ada."
+
+#: ../src/richtext/richtextfontpage.cpp:196
+#: ../src/richtext/richtextfontpage.cpp:198
+msgid "Lists font sizes in points."
+msgstr "Senaraikan saiz fon dalam titik."
+
+#: ../src/richtext/richtextfontpage.cpp:207
+msgid "Font st&yle:"
+msgstr "Gaya fon:"
+
+#: ../src/richtext/richtextfontpage.cpp:212
+#: ../src/richtext/richtextfontpage.cpp:214
+msgid "Select regular or italic style."
+msgstr "Pilih biasa atau gaya italik."
+
+#: ../src/richtext/richtextfontpage.cpp:220
+msgid "Font &weight:"
+msgstr "Berat fon:"
+
+#: ../src/richtext/richtextfontpage.cpp:225
+#: ../src/richtext/richtextfontpage.cpp:227
+msgid "Select regular or bold."
+msgstr "Pilih biasa atau tebal."
+
+#: ../src/richtext/richtextfontpage.cpp:233
+msgid "&Underlining:"
+msgstr "Garis bawah:"
+
+#: ../src/richtext/richtextfontpage.cpp:238
+#: ../src/richtext/richtextfontpage.cpp:240
+msgid "Select underlining or no underlining."
+msgstr "Pilih garis-bawah atau tiada garis-bawah."
+
+#: ../src/richtext/richtextfontpage.cpp:248
+msgid "&Colour:"
+msgstr "Warna:"
+
+#: ../src/richtext/richtextfontpage.cpp:253
+#: ../src/richtext/richtextfontpage.cpp:255
+msgid "Click to change the text colour."
+msgstr "Klik untuk ubah warna teks."
+
+#: ../src/richtext/richtextfontpage.cpp:261
+#, fuzzy
+msgid "&Bg colour:"
+msgstr "Warna:"
+
+#: ../src/richtext/richtextfontpage.cpp:266
+#: ../src/richtext/richtextfontpage.cpp:268
+#, fuzzy
+msgid "Click to change the text background colour."
+msgstr "Klik untuk ubah warna teks."
+
+#: ../src/richtext/richtextfontpage.cpp:276
+#: ../src/richtext/richtextfontpage.cpp:278
+#, fuzzy
+msgid "Check to show a line through the text."
+msgstr "Tanda untuk menambah noktah selepas peluru."
+
+#: ../src/richtext/richtextfontpage.cpp:281
+msgid "Ca&pitals"
+msgstr ""
+
+#: ../src/richtext/richtextfontpage.cpp:283
+#: ../src/richtext/richtextfontpage.cpp:285
+#, fuzzy
+msgid "Check to show the text in capitals."
+msgstr "Tanda untuk buat fon italik."
+
+#: ../src/richtext/richtextfontpage.cpp:288
+msgid "Small C&apitals"
+msgstr ""
+
+#: ../src/richtext/richtextfontpage.cpp:290
+#: ../src/richtext/richtextfontpage.cpp:292
+#, fuzzy
+msgid "Check to show the text in small capitals."
+msgstr "Tanda untuk buat fon italik."
+
+#: ../src/richtext/richtextfontpage.cpp:295
+#, fuzzy
+msgid "Supe&rscript"
+msgstr "Skrip"
+
+#: ../src/richtext/richtextfontpage.cpp:297
+#: ../src/richtext/richtextfontpage.cpp:299
+#, fuzzy
+msgid "Check to show the text in superscript."
+msgstr "Tanda untuk menyertakan peluru dalam kurungan."
+
+#: ../src/richtext/richtextfontpage.cpp:302
+#, fuzzy
+msgid "Subscrip&t"
+msgstr "Skrip"
+
+#: ../src/richtext/richtextfontpage.cpp:304
+#: ../src/richtext/richtextfontpage.cpp:306
+#, fuzzy
+msgid "Check to show the text in subscript."
+msgstr "Klik untuk ubah warna teks."
+
+#: ../src/richtext/richtextfontpage.cpp:312
+msgid "Rig&ht-to-left"
+msgstr ""
+
+#: ../src/richtext/richtextfontpage.cpp:314
+#: ../src/richtext/richtextfontpage.cpp:316
+#, fuzzy
+msgid "Check to indicate right-to-left text layout."
+msgstr "Klik untuk ubah warna teks."
+
+#: ../src/richtext/richtextfontpage.cpp:319
+msgid "Suppress hyphe&nation"
+msgstr ""
+
+#: ../src/richtext/richtextfontpage.cpp:321
+#: ../src/richtext/richtextfontpage.cpp:323
+msgid "Check to suppress hyphenation."
+msgstr ""
+
+#: ../src/richtext/richtextfontpage.cpp:329
+#: ../src/richtext/richtextfontpage.cpp:331
+msgid "Shows a preview of the font settings."
+msgstr "Tunjuk pralihat tetapan fon."
+
+#: ../src/richtext/richtextfontpage.cpp:348
+#: ../src/richtext/richtextfontpage.cpp:352
+#: ../src/richtext/richtextfontpage.cpp:356
+#: ../src/richtext/richtextformatdlg.cpp:873
+#: ../src/richtext/richtextindentspage.cpp:273
+#: ../src/richtext/richtextindentspage.cpp:285
+#: ../src/richtext/richtextindentspage.cpp:286
+#: ../src/richtext/richtextindentspage.cpp:310
+#: ../src/richtext/richtextindentspage.cpp:325
+#: ../src/richtext/richtextliststylepage.cpp:451
+#: ../src/richtext/richtextliststylepage.cpp:463
+#: ../src/richtext/richtextliststylepage.cpp:464
+msgid "(none)"
+msgstr "(tiada)"
+
+#: ../src/richtext/richtextfontpage.cpp:349
+#: ../src/richtext/richtextfontpage.cpp:353
+msgid "Regular"
+msgstr "Biasa"
+
+#: ../src/richtext/richtextfontpage.cpp:357
+msgid "Not underlined"
+msgstr "Tidak bergaris bawah"
+
+#: ../src/richtext/richtextformatdlg.cpp:341
+msgid "Indents && Spacing"
+msgstr "Takuk  && Ruang"
+
+#: ../src/richtext/richtextformatdlg.cpp:346
+msgid "Tabs"
+msgstr "Tab"
+
+#: ../src/richtext/richtextformatdlg.cpp:351
+msgid "Bullets"
+msgstr "Peluru"
+
+#: ../src/richtext/richtextformatdlg.cpp:356
+msgid "List Style"
+msgstr "Gaya Senarai"
+
+#: ../src/richtext/richtextformatdlg.cpp:366
+#: ../src/richtext/richtextmarginspage.cpp:170
+msgid "Margins"
+msgstr ""
+
+#: ../src/richtext/richtextformatdlg.cpp:371
+#, fuzzy
+msgid "Borders"
+msgstr "Moden"
+
+#: ../src/richtext/richtextformatdlg.cpp:765
+#, fuzzy
+msgid "Colour"
+msgstr "Warna:"
+
+#: ../src/richtext/richtextindentspage.cpp:127
+#: ../src/richtext/richtextliststylepage.cpp:322
+msgid "&Alignment"
+msgstr "J&ajaran"
+
+#: ../src/richtext/richtextindentspage.cpp:138
+#: ../src/richtext/richtextliststylepage.cpp:331
+msgid "&Left"
+msgstr "&Kiri"
+
+#: ../src/richtext/richtextindentspage.cpp:140
+#: ../src/richtext/richtextindentspage.cpp:142
+#: ../src/richtext/richtextliststylepage.cpp:333
+#: ../src/richtext/richtextliststylepage.cpp:335
+msgid "Left-align text."
+msgstr "Teks jajar-kiri."
+
+#: ../src/richtext/richtextindentspage.cpp:145
+#: ../src/richtext/richtextliststylepage.cpp:338
+msgid "&Right"
+msgstr "K&anan"
+
+#: ../src/richtext/richtextindentspage.cpp:147
+#: ../src/richtext/richtextindentspage.cpp:149
+#: ../src/richtext/richtextliststylepage.cpp:340
+#: ../src/richtext/richtextliststylepage.cpp:342
+msgid "Right-align text."
+msgstr "Jajar-kanan teks."
+
+#: ../src/richtext/richtextindentspage.cpp:152
+#: ../src/richtext/richtextliststylepage.cpp:345
+msgid "&Justified"
+msgstr "Justifi"
+
+#: ../src/richtext/richtextindentspage.cpp:154
+#: ../src/richtext/richtextindentspage.cpp:156
+#: ../src/richtext/richtextliststylepage.cpp:347
+#: ../src/richtext/richtextliststylepage.cpp:349
+msgid "Justify text left and right."
+msgstr "Benarkan teks kiri dan kanan."
+
+#: ../src/richtext/richtextindentspage.cpp:159
+#: ../src/richtext/richtextliststylepage.cpp:352
+msgid "Cen&tred"
+msgstr "Ke&tengah"
+
+#: ../src/richtext/richtextindentspage.cpp:161
+#: ../src/richtext/richtextindentspage.cpp:163
+#: ../src/richtext/richtextliststylepage.cpp:354
+#: ../src/richtext/richtextliststylepage.cpp:356
+msgid "Centre text."
+msgstr "Teks Tengah."
+
+#: ../src/richtext/richtextindentspage.cpp:166
+#: ../src/richtext/richtextliststylepage.cpp:359
+msgid "&Indeterminate"
+msgstr "Gagal ditentukan"
+
+#: ../src/richtext/richtextindentspage.cpp:168
+#: ../src/richtext/richtextindentspage.cpp:170
+#: ../src/richtext/richtextliststylepage.cpp:361
+#: ../src/richtext/richtextliststylepage.cpp:363
+msgid "Use the current alignment setting."
+msgstr "Guna tetapan penjajaran semasa."
+
+#: ../src/richtext/richtextindentspage.cpp:183
+#: ../src/richtext/richtextliststylepage.cpp:375
+msgid "&Indentation (tenths of a mm)"
+msgstr "Penakukan (satu persepuluh mm)"
+
+#: ../src/richtext/richtextindentspage.cpp:198
+#: ../src/richtext/richtextindentspage.cpp:200
+#: ../src/richtext/richtextliststylepage.cpp:388
+#: ../src/richtext/richtextliststylepage.cpp:390
+msgid "The left indent."
+msgstr "Takuk kiri."
+
+#: ../src/richtext/richtextindentspage.cpp:203
+#: ../src/richtext/richtextliststylepage.cpp:393
+msgid "Left (&first line):"
+msgstr "Kiri (baris pertama):"
+
+#: ../src/richtext/richtextindentspage.cpp:207
+#: ../src/richtext/richtextindentspage.cpp:209
+#: ../src/richtext/richtextliststylepage.cpp:397
+#: ../src/richtext/richtextliststylepage.cpp:399
+msgid "The first line indent."
+msgstr "Takuk baris pertama."
+
+#: ../src/richtext/richtextindentspage.cpp:216
+#: ../src/richtext/richtextindentspage.cpp:218
+#: ../src/richtext/richtextliststylepage.cpp:406
+#: ../src/richtext/richtextliststylepage.cpp:408
+msgid "The right indent."
+msgstr "Takuk kanan."
+
+#: ../src/richtext/richtextindentspage.cpp:221
+#, fuzzy
+msgid "&Outline level:"
+msgstr "Paras senarai:"
+
+#: ../src/richtext/richtextindentspage.cpp:226
+#: ../src/richtext/richtextindentspage.cpp:228
+#, fuzzy
+msgid "The outline level."
+msgstr "Pralihat gaya."
+
+#: ../src/richtext/richtextindentspage.cpp:241
+#: ../src/richtext/richtextliststylepage.cpp:420
+msgid "&Spacing (tenths of a mm)"
+msgstr "&Ruang (satu persepuluh mm)"
+
+#: ../src/richtext/richtextindentspage.cpp:252
+#, fuzzy
+msgid "&Before a paragraph:"
+msgstr "Sebelum perenggan:"
+
+#: ../src/richtext/richtextindentspage.cpp:256
+#: ../src/richtext/richtextindentspage.cpp:258
+#: ../src/richtext/richtextliststylepage.cpp:433
+#: ../src/richtext/richtextliststylepage.cpp:435
+msgid "The spacing before the paragraph."
+msgstr "Ruangan sebelum perenggan."
+
+#: ../src/richtext/richtextindentspage.cpp:261
+#, fuzzy
+msgid "&After a paragraph:"
+msgstr "Selepas satu perenggan:"
+
+#: ../src/richtext/richtextindentspage.cpp:266
+#: ../src/richtext/richtextliststylepage.cpp:442
+#: ../src/richtext/richtextliststylepage.cpp:444
+msgid "The spacing after the paragraph."
+msgstr "Ruangan selepas perenggan."
+
+#: ../src/richtext/richtextindentspage.cpp:269
+#, fuzzy
+msgid "L&ine spacing:"
+msgstr "Ruang baris:"
+
+#: ../src/richtext/richtextindentspage.cpp:274
+#: ../src/richtext/richtextliststylepage.cpp:452
+msgid "Single"
+msgstr "Tunggal"
+
+#: ../src/richtext/richtextindentspage.cpp:275
+#: ../src/richtext/richtextliststylepage.cpp:453
+#, fuzzy
+msgid "1.1"
+msgstr "1.5"
+
+#: ../src/richtext/richtextindentspage.cpp:276
+#: ../src/richtext/richtextliststylepage.cpp:454
+#, fuzzy
+msgid "1.2"
+msgstr "1.5"
+
+#: ../src/richtext/richtextindentspage.cpp:277
+#: ../src/richtext/richtextliststylepage.cpp:455
+#, fuzzy
+msgid "1.3"
+msgstr "1.5"
+
+#: ../src/richtext/richtextindentspage.cpp:278
+#: ../src/richtext/richtextliststylepage.cpp:456
+#, fuzzy
+msgid "1.4"
+msgstr "1.5"
+
+#: ../src/richtext/richtextindentspage.cpp:279
+#: ../src/richtext/richtextliststylepage.cpp:457
+msgid "1.5"
+msgstr "1.5"
+
+#: ../src/richtext/richtextindentspage.cpp:280
+#: ../src/richtext/richtextliststylepage.cpp:458
+#, fuzzy
+msgid "1.6"
+msgstr "1.5"
+
+#: ../src/richtext/richtextindentspage.cpp:281
+#: ../src/richtext/richtextliststylepage.cpp:459
+#, fuzzy
+msgid "1.7"
+msgstr "1.5"
+
+#: ../src/richtext/richtextindentspage.cpp:282
+#: ../src/richtext/richtextliststylepage.cpp:460
+#, fuzzy
+msgid "1.8"
+msgstr "1.5"
+
+#: ../src/richtext/richtextindentspage.cpp:283
+#: ../src/richtext/richtextliststylepage.cpp:461
+#, fuzzy
+msgid "1.9"
+msgstr "1.5"
+
+#: ../src/richtext/richtextindentspage.cpp:284
+#: ../src/richtext/richtextliststylepage.cpp:462
+msgid "2"
+msgstr "2"
+
+#: ../src/richtext/richtextindentspage.cpp:287
+#: ../src/richtext/richtextindentspage.cpp:289
+#: ../src/richtext/richtextliststylepage.cpp:465
+#: ../src/richtext/richtextliststylepage.cpp:467
+msgid "The line spacing."
+msgstr "Ruang baris."
+
+#: ../src/richtext/richtextindentspage.cpp:292
+msgid "&Page Break"
+msgstr ""
+
+#: ../src/richtext/richtextindentspage.cpp:294
+#: ../src/richtext/richtextindentspage.cpp:296
+#, fuzzy
+msgid "Inserts a page break before the paragraph."
+msgstr "Ruangan sebelum perenggan."
+
+#: ../src/richtext/richtextindentspage.cpp:302
+#: ../src/richtext/richtextindentspage.cpp:304
+msgid "Shows a preview of the paragraph settings."
+msgstr "Tunjuk pralihat tetapan perenggan."
+
+#: ../src/richtext/richtextliststylepage.cpp:182
+msgid "&List level:"
+msgstr "Paras senarai:"
+
+#: ../src/richtext/richtextliststylepage.cpp:186
+#: ../src/richtext/richtextliststylepage.cpp:188
+msgid "Selects the list level to edit."
+msgstr "Pilih paras senarai untuk edit."
+
+#: ../src/richtext/richtextliststylepage.cpp:193
+msgid "&Font for Level..."
+msgstr "Fon untuk Paras..."
+
+#: ../src/richtext/richtextliststylepage.cpp:194
+#: ../src/richtext/richtextliststylepage.cpp:196
+msgid "Click to choose the font for this level."
+msgstr "Klik untuk pilih fon untuk paras ini."
+
+#: ../src/richtext/richtextliststylepage.cpp:312
+msgid "Bullet style"
+msgstr "Gaya peluru"
+
+#: ../src/richtext/richtextliststylepage.cpp:429
+msgid "Before a paragraph:"
+msgstr "Sebelum perenggan:"
+
+#: ../src/richtext/richtextliststylepage.cpp:438
+msgid "After a paragraph:"
+msgstr "Selepas satu perenggan:"
+
+#: ../src/richtext/richtextliststylepage.cpp:447
+msgid "Line spacing:"
+msgstr "Ruang baris:"
+
+#: ../src/richtext/richtextliststylepage.cpp:470
+msgid "Spacing"
+msgstr "Ruang"
+
+#: ../src/richtext/richtextmarginspage.cpp:193
+#: ../src/richtext/richtextmarginspage.cpp:195
+#, fuzzy
+msgid "The left margin size."
+msgstr "Saiz titik fon."
+
+#: ../src/richtext/richtextmarginspage.cpp:203
+#: ../src/richtext/richtextmarginspage.cpp:205
+msgid "Units for the left margin."
+msgstr ""
+
+#: ../src/richtext/richtextmarginspage.cpp:218
+#: ../src/richtext/richtextmarginspage.cpp:220
+#, fuzzy
+msgid "The right margin size."
+msgstr "Takuk kanan."
+
+#: ../src/richtext/richtextmarginspage.cpp:228
+#: ../src/richtext/richtextmarginspage.cpp:230
+msgid "Units for the right margin."
+msgstr ""
+
+#: ../src/richtext/richtextmarginspage.cpp:241
+#: ../src/richtext/richtextmarginspage.cpp:243
+#, fuzzy
+msgid "The top margin size."
+msgstr "Saiz titik fon."
+
+#: ../src/richtext/richtextmarginspage.cpp:251
+#: ../src/richtext/richtextmarginspage.cpp:253
+#, fuzzy
+msgid "Units for the top margin."
+msgstr "Gagal menunggu penamatan benang."
+
+#: ../src/richtext/richtextmarginspage.cpp:266
+#: ../src/richtext/richtextmarginspage.cpp:268
+#, fuzzy
+msgid "The bottom margin size."
+msgstr "Saiz titik fon."
+
+#: ../src/richtext/richtextmarginspage.cpp:276
+#: ../src/richtext/richtextmarginspage.cpp:278
+msgid "Units for the bottom margin."
+msgstr ""
+
+#: ../src/richtext/richtextmarginspage.cpp:284
+#, fuzzy
+msgid "Padding"
+msgstr "membaca"
+
+#: ../src/richtext/richtextmarginspage.cpp:307
+#: ../src/richtext/richtextmarginspage.cpp:309
+#, fuzzy
+msgid "The left padding size."
+msgstr "Saiz titik fon."
+
+#: ../src/richtext/richtextmarginspage.cpp:317
+#: ../src/richtext/richtextmarginspage.cpp:319
+msgid "Units for the left padding."
+msgstr ""
+
+#: ../src/richtext/richtextmarginspage.cpp:332
+#: ../src/richtext/richtextmarginspage.cpp:334
+#, fuzzy
+msgid "The right padding size."
+msgstr "Takuk kanan."
+
+#: ../src/richtext/richtextmarginspage.cpp:342
+#: ../src/richtext/richtextmarginspage.cpp:344
+msgid "Units for the right padding."
+msgstr ""
+
+#: ../src/richtext/richtextmarginspage.cpp:355
+#: ../src/richtext/richtextmarginspage.cpp:357
+#, fuzzy
+msgid "The top padding size."
+msgstr "Saiz titik fon."
+
+#: ../src/richtext/richtextmarginspage.cpp:365
+#: ../src/richtext/richtextmarginspage.cpp:367
+msgid "Units for the top padding."
+msgstr ""
+
+#: ../src/richtext/richtextmarginspage.cpp:380
+#: ../src/richtext/richtextmarginspage.cpp:382
+#, fuzzy
+msgid "The bottom padding size."
+msgstr "Saiz titik fon."
+
+#: ../src/richtext/richtextmarginspage.cpp:390
+#: ../src/richtext/richtextmarginspage.cpp:392
+msgid "Units for the bottom padding."
+msgstr ""
+
+#: ../src/richtext/richtextprint.cpp:592
+msgid " Preview"
+msgstr " Pralihat"
+
+#: ../src/richtext/richtextsizepage.cpp:228
+#, fuzzy
+msgid "Floating"
+msgstr "Memformat"
+
+#: ../src/richtext/richtextsizepage.cpp:243
+msgid "&Floating mode:"
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:252
+#: ../src/richtext/richtextsizepage.cpp:254
+msgid "How the object will float relative to the text."
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:265
+#, fuzzy
+msgid "Alignment"
+msgstr "J&ajaran"
+
+#: ../src/richtext/richtextsizepage.cpp:277
+#, fuzzy
+msgid "&Vertical alignment:"
+msgstr "J&ajaran Peluru:"
+
+#: ../src/richtext/richtextsizepage.cpp:279
+#: ../src/richtext/richtextsizepage.cpp:281
+#, fuzzy
+msgid "Enable vertical alignment."
+msgstr "Gagal mulakan mencetak."
+
+#: ../src/richtext/richtextsizepage.cpp:286
+#, fuzzy
+msgid "Centred"
+msgstr "Ke&tengah"
+
+#: ../src/richtext/richtextsizepage.cpp:290
+#: ../src/richtext/richtextsizepage.cpp:292
+#, fuzzy
+msgid "Vertical alignment."
+msgstr "Gagal mulakan mencetak."
+
+#: ../src/richtext/richtextsizepage.cpp:316
+#: ../src/richtext/richtextsizepage.cpp:323
+#, fuzzy
+msgid "&Width:"
+msgstr "Berat:"
+
+#: ../src/richtext/richtextsizepage.cpp:318
+#: ../src/richtext/richtextsizepage.cpp:320
+msgid "Enable the width value."
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:331
+#: ../src/richtext/richtextsizepage.cpp:333
+#, fuzzy
+msgid "The object width."
+msgstr "Berat fon."
+
+#: ../src/richtext/richtextsizepage.cpp:342
+#: ../src/richtext/richtextsizepage.cpp:344
+msgid "Units for the object width."
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:350
+#: ../src/richtext/richtextsizepage.cpp:357
+#, fuzzy
+msgid "&Height:"
+msgstr "Berat:"
+
+#: ../src/richtext/richtextsizepage.cpp:352
+#: ../src/richtext/richtextsizepage.cpp:354
+#: ../src/richtext/richtextsizepage.cpp:464
+#: ../src/richtext/richtextsizepage.cpp:466
+msgid "Enable the height value."
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:365
+#: ../src/richtext/richtextsizepage.cpp:367
+#, fuzzy
+msgid "The object height."
+msgstr "Berat fon."
+
+#: ../src/richtext/richtextsizepage.cpp:376
+#: ../src/richtext/richtextsizepage.cpp:378
+msgid "Units for the object height."
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:381
+msgid "Min width:"
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:383
+#: ../src/richtext/richtextsizepage.cpp:385
+#, fuzzy
+msgid "Enable the minimum width value."
+msgstr "Gagal mulakan mencetak."
+
+#: ../src/richtext/richtextsizepage.cpp:392
+#: ../src/richtext/richtextsizepage.cpp:394
+#, fuzzy
+msgid "The object minimum width."
+msgstr "Berat fon."
+
+#: ../src/richtext/richtextsizepage.cpp:403
+#: ../src/richtext/richtextsizepage.cpp:405
+#, fuzzy
+msgid "Units for the minimum object width."
+msgstr "Berat fon."
+
+#: ../src/richtext/richtextsizepage.cpp:408
+#, fuzzy
+msgid "Min height:"
+msgstr "Berat fon:"
+
+#: ../src/richtext/richtextsizepage.cpp:410
+#: ../src/richtext/richtextsizepage.cpp:412
+msgid "Enable the minimum height value."
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:419
+#: ../src/richtext/richtextsizepage.cpp:421
+#, fuzzy
+msgid "The object minimum height."
+msgstr "Berat fon."
+
+#: ../src/richtext/richtextsizepage.cpp:430
+#: ../src/richtext/richtextsizepage.cpp:432
+#, fuzzy
+msgid "Units for the minimum object height."
+msgstr "Berat fon."
+
+#: ../src/richtext/richtextsizepage.cpp:435
+#, fuzzy
+msgid "Max width:"
+msgstr "Ganti dengan:"
+
+#: ../src/richtext/richtextsizepage.cpp:437
+#: ../src/richtext/richtextsizepage.cpp:439
+#, fuzzy
+msgid "Enable the maximum width value."
+msgstr "Gagal mulakan mencetak."
+
+#: ../src/richtext/richtextsizepage.cpp:446
+#: ../src/richtext/richtextsizepage.cpp:448
+#, fuzzy
+msgid "The object maximum width."
+msgstr "Berat fon."
+
+#: ../src/richtext/richtextsizepage.cpp:457
+#: ../src/richtext/richtextsizepage.cpp:459
+#, fuzzy
+msgid "Units for the maximum object width."
+msgstr "Berat fon."
+
+#: ../src/richtext/richtextsizepage.cpp:462
+#, fuzzy
+msgid "Max height:"
+msgstr "Berat:"
+
+#: ../src/richtext/richtextsizepage.cpp:473
+#: ../src/richtext/richtextsizepage.cpp:475
+#, fuzzy
+msgid "The object maximum height."
+msgstr "Berat fon."
+
+#: ../src/richtext/richtextsizepage.cpp:484
+#: ../src/richtext/richtextsizepage.cpp:486
+#, fuzzy
+msgid "Units for the maximum object height."
+msgstr "Berat fon."
+
+#: ../src/richtext/richtextsizepage.cpp:495
+#, fuzzy
+msgid "Position"
+msgstr "Soalan"
+
+#: ../src/richtext/richtextsizepage.cpp:513
+#, fuzzy
+msgid "&Position mode:"
+msgstr "Soalan"
+
+#: ../src/richtext/richtextsizepage.cpp:517
+#: ../src/richtext/richtextsizepage.cpp:522
+#, fuzzy
+msgid "Static"
+msgstr "Status:"
+
+#: ../src/richtext/richtextsizepage.cpp:518
+#, fuzzy
+msgid "Relative"
+msgstr "Dekoratif"
+
+#: ../src/richtext/richtextsizepage.cpp:519
+msgid "Absolute"
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:520
+#, fuzzy
+msgid "Fixed"
+msgstr "Fon tetap:"
+
+#: ../src/richtext/richtextsizepage.cpp:533
+#: ../src/richtext/richtextsizepage.cpp:535
+#: ../src/richtext/richtextsizepage.cpp:547
+#: ../src/richtext/richtextsizepage.cpp:549
+#, fuzzy
+msgid "The left position."
+msgstr "Posisi tab."
+
+#: ../src/richtext/richtextsizepage.cpp:558
+#: ../src/richtext/richtextsizepage.cpp:560
+#, fuzzy
+msgid "Units for the left position."
+msgstr "Gagal menunggu penamatan benang."
+
+#: ../src/richtext/richtextsizepage.cpp:568
+#: ../src/richtext/richtextsizepage.cpp:570
+#: ../src/richtext/richtextsizepage.cpp:582
+#: ../src/richtext/richtextsizepage.cpp:584
+#, fuzzy
+msgid "The top position."
+msgstr "Posisi tab."
+
+#: ../src/richtext/richtextsizepage.cpp:593
+#: ../src/richtext/richtextsizepage.cpp:595
+#, fuzzy
+msgid "Units for the top position."
+msgstr "Gagal menunggu penamatan benang."
+
+#: ../src/richtext/richtextsizepage.cpp:603
+#: ../src/richtext/richtextsizepage.cpp:605
+#: ../src/richtext/richtextsizepage.cpp:617
+#: ../src/richtext/richtextsizepage.cpp:619
+#, fuzzy
+msgid "The right position."
+msgstr "Posisi tab."
+
+#: ../src/richtext/richtextsizepage.cpp:628
+#: ../src/richtext/richtextsizepage.cpp:630
+#, fuzzy
+msgid "Units for the right position."
+msgstr "Gagal menunggu penamatan benang."
+
+#: ../src/richtext/richtextsizepage.cpp:638
+#: ../src/richtext/richtextsizepage.cpp:640
+#: ../src/richtext/richtextsizepage.cpp:652
+#: ../src/richtext/richtextsizepage.cpp:654
+#, fuzzy
+msgid "The bottom position."
+msgstr "Posisi tab."
+
+#: ../src/richtext/richtextsizepage.cpp:663
+#: ../src/richtext/richtextsizepage.cpp:665
+#, fuzzy
+msgid "Units for the bottom position."
+msgstr "Gagal menunggu penamatan benang."
+
+#: ../src/richtext/richtextsizepage.cpp:671
+msgid "&Move the object to:"
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:674
+#, fuzzy
+msgid "&Previous Paragraph"
+msgstr "Laman sebelum:"
+
+#: ../src/richtext/richtextsizepage.cpp:675
+#: ../src/richtext/richtextsizepage.cpp:677
+#, fuzzy
+msgid "Moves the object to the previous paragraph."
+msgstr "Undur ke laman HTML terdahulu"
+
+#: ../src/richtext/richtextsizepage.cpp:680
+#, fuzzy
+msgid "&Next Paragraph"
+msgstr "Selepas satu perenggan:"
+
+#: ../src/richtext/richtextsizepage.cpp:681
+#: ../src/richtext/richtextsizepage.cpp:683
+#, fuzzy
+msgid "Moves the object to the next paragraph."
+msgstr "Gaya lalai untuk perenggan berikut."
+
+#: ../src/richtext/richtextstyledlg.cpp:193
+msgid "&Styles:"
+msgstr "Gaya:"
+
+#: ../src/richtext/richtextstyledlg.cpp:197
+#: ../src/richtext/richtextstyledlg.cpp:199
+msgid "The available styles."
+msgstr "Gaya yang ada."
+
+#: ../src/richtext/richtextstyledlg.cpp:205
+#: ../src/richtext/richtextstyledlg.cpp:217
+msgid " "
+msgstr " "
+
+#: ../src/richtext/richtextstyledlg.cpp:209
+#: ../src/richtext/richtextstyledlg.cpp:211
+msgid "The style preview."
+msgstr "Pralihat gaya."
+
+#: ../src/richtext/richtextstyledlg.cpp:220
+msgid "New &Character Style..."
+msgstr "Gaya Aksara Baru..."
+
+#: ../src/richtext/richtextstyledlg.cpp:221
+#: ../src/richtext/richtextstyledlg.cpp:223
+msgid "Click to create a new character style."
+msgstr "Klik untuk cipta gaya aksara baru."
+
+#: ../src/richtext/richtextstyledlg.cpp:226
+msgid "New &Paragraph Style..."
+msgstr "Gaya &Perenggan Baru..."
+
+#: ../src/richtext/richtextstyledlg.cpp:227
+#: ../src/richtext/richtextstyledlg.cpp:229
+msgid "Click to create a new paragraph style."
+msgstr "Klik untuk cipta gaya perenggan baru."
+
+#: ../src/richtext/richtextstyledlg.cpp:232
+msgid "New &List Style..."
+msgstr "Senarai Gaya Baru..."
+
+#: ../src/richtext/richtextstyledlg.cpp:233
+#: ../src/richtext/richtextstyledlg.cpp:235
+msgid "Click to create a new list style."
+msgstr "Klik untuk cipta senarai baru gaya."
+
+#: ../src/richtext/richtextstyledlg.cpp:238
+#, fuzzy
+msgid "New &Box Style..."
+msgstr "Senarai Gaya Baru..."
+
+#: ../src/richtext/richtextstyledlg.cpp:239
+#: ../src/richtext/richtextstyledlg.cpp:241
+#, fuzzy
+msgid "Click to create a new box style."
+msgstr "Klik untuk cipta senarai baru gaya."
+
+#: ../src/richtext/richtextstyledlg.cpp:246
+msgid "&Apply Style"
+msgstr "Ter&ap Gaya"
+
+#: ../src/richtext/richtextstyledlg.cpp:247
+#: ../src/richtext/richtextstyledlg.cpp:249
+msgid "Click to apply the selected style."
+msgstr "Tanda untuk terapkan gaya pilihan."
+
+#: ../src/richtext/richtextstyledlg.cpp:252
+msgid "&Rename Style..."
+msgstr "Menamakan Gaya..."
+
+#: ../src/richtext/richtextstyledlg.cpp:253
+#: ../src/richtext/richtextstyledlg.cpp:255
+msgid "Click to rename the selected style."
+msgstr "Klik untuk menamakan fon terpilih."
+
+#: ../src/richtext/richtextstyledlg.cpp:258
+msgid "&Edit Style..."
+msgstr "&Edit Gaya..."
+
+#: ../src/richtext/richtextstyledlg.cpp:259
+#: ../src/richtext/richtextstyledlg.cpp:261
+msgid "Click to edit the selected style."
+msgstr "Klik untuk edit fon terpilih."
+
+#: ../src/richtext/richtextstyledlg.cpp:264
+msgid "&Delete Style..."
+msgstr "Pa&dam Gaya..."
+
+#: ../src/richtext/richtextstyledlg.cpp:265
+#: ../src/richtext/richtextstyledlg.cpp:267
+msgid "Click to delete the selected style."
+msgstr "Klik untuk padam gaya pilihan."
+
+#: ../src/richtext/richtextstyledlg.cpp:274
+#: ../src/richtext/richtextstyledlg.cpp:276
+msgid "Click to close this window."
+msgstr "Klik untuk tutup tetingkap ini"
+
+#: ../src/richtext/richtextstyledlg.cpp:282
+msgid "&Restart numbering"
+msgstr "Ulangmula pernomboran"
+
+#: ../src/richtext/richtextstyledlg.cpp:284
+#: ../src/richtext/richtextstyledlg.cpp:286
+msgid "Check to restart numbering."
+msgstr "Periksa untuk mulakan semula pernomboran."
+
+#: ../src/richtext/richtextstyledlg.cpp:601
+msgid "Enter a character style name"
+msgstr "Masukkan nama aksara gaya"
+
+#: ../src/richtext/richtextstyledlg.cpp:601
+#: ../src/richtext/richtextstyledlg.cpp:606
+#: ../src/richtext/richtextstyledlg.cpp:649
+#: ../src/richtext/richtextstyledlg.cpp:654
+#: ../src/richtext/richtextstyledlg.cpp:815
+#: ../src/richtext/richtextstyledlg.cpp:820
+#: ../src/richtext/richtextstyledlg.cpp:888
+#: ../src/richtext/richtextstyledlg.cpp:896
+#: ../src/richtext/richtextstyledlg.cpp:929
+#: ../src/richtext/richtextstyledlg.cpp:934
+msgid "New Style"
+msgstr "Gaya Baru"
+
+#: ../src/richtext/richtextstyledlg.cpp:606
+#: ../src/richtext/richtextstyledlg.cpp:654
+#: ../src/richtext/richtextstyledlg.cpp:820
+#: ../src/richtext/richtextstyledlg.cpp:896
+#: ../src/richtext/richtextstyledlg.cpp:934
+msgid "Sorry, that name is taken. Please choose another."
+msgstr "Maaf, nama sudah diambil. Sila pillih lain."
+
+#: ../src/richtext/richtextstyledlg.cpp:649
+msgid "Enter a paragraph style name"
+msgstr "Masukkan nama perenggan gaya"
+
+#: ../src/richtext/richtextstyledlg.cpp:777
+#, c-format
+msgid "Delete style %s?"
+msgstr "Padam gaya %s?"
+
+#: ../src/richtext/richtextstyledlg.cpp:777
+msgid "Delete Style"
+msgstr "Padam Gaya"
+
+#: ../src/richtext/richtextstyledlg.cpp:815
+msgid "Enter a list style name"
+msgstr "Masukkan nama senarai gaya "
+
+#: ../src/richtext/richtextstyledlg.cpp:888
+#, fuzzy
+msgid "Enter a new style name"
+msgstr "Masukkan nama senarai gaya "
+
+#: ../src/richtext/richtextstyledlg.cpp:929
+#, fuzzy
+msgid "Enter a box style name"
+msgstr "Masukkan nama senarai gaya "
+
+#: ../src/richtext/richtextstylepage.cpp:109
+#: ../src/richtext/richtextstylepage.cpp:111
+msgid "The style name."
+msgstr "Nama gaya."
+
+#: ../src/richtext/richtextstylepage.cpp:114
+msgid "&Based on:"
+msgstr "&Berasaskan:"
+
+#: ../src/richtext/richtextstylepage.cpp:119
+#: ../src/richtext/richtextstylepage.cpp:121
+msgid "The style on which this style is based."
+msgstr "Gaya yang pada gaya ini diasaskan."
+
+#: ../src/richtext/richtextstylepage.cpp:124
+msgid "&Next style:"
+msgstr "Gaya berikutnya:"
+
+#: ../src/richtext/richtextstylepage.cpp:129
+#: ../src/richtext/richtextstylepage.cpp:131
+msgid "The default style for the next paragraph."
+msgstr "Gaya lalai untuk perenggan berikut."
+
+#: ../src/richtext/richtextstyles.cpp:1057
+msgid "All styles"
+msgstr "Semua gaya"
+
+#: ../src/richtext/richtextstyles.cpp:1058
+msgid "Paragraph styles"
+msgstr "Gaya perenggan"
+
+#: ../src/richtext/richtextstyles.cpp:1059
+msgid "Character styles"
+msgstr "Gaya Aksara"
+
+#: ../src/richtext/richtextstyles.cpp:1060
+msgid "List styles"
+msgstr "Gaya senarai"
+
+#: ../src/richtext/richtextstyles.cpp:1061
+#, fuzzy
+msgid "Box styles"
+msgstr "Semua gaya"
+
+#: ../src/richtext/richtextsymboldlg.cpp:389
+#: ../src/richtext/richtextsymboldlg.cpp:391
+msgid "The font from which to take the symbol."
+msgstr "Fon yang akan mengambil simbol."
+
+#: ../src/richtext/richtextsymboldlg.cpp:396
+msgid "&Subset:"
+msgstr "&Subset:"
+
+#: ../src/richtext/richtextsymboldlg.cpp:401
+#: ../src/richtext/richtextsymboldlg.cpp:403
+msgid "Shows a Unicode subset."
+msgstr "Tunjuk subset Unikod."
+
+#: ../src/richtext/richtextsymboldlg.cpp:412
+msgid "xxxx"
+msgstr "xxxx"
+
+#: ../src/richtext/richtextsymboldlg.cpp:417
+msgid "&Character code:"
+msgstr "Kod aksara:"
+
+#: ../src/richtext/richtextsymboldlg.cpp:421
+#: ../src/richtext/richtextsymboldlg.cpp:423
+msgid "The character code."
+msgstr "Kod aksara."
+
+#: ../src/richtext/richtextsymboldlg.cpp:428
+msgid "&From:"
+msgstr "Dari: "
+
+#: ../src/richtext/richtextsymboldlg.cpp:433
+#: ../src/richtext/richtextsymboldlg.cpp:434
+#: ../src/richtext/richtextsymboldlg.cpp:435
+msgid "Unicode"
+msgstr "Unikod"
+
+#: ../src/richtext/richtextsymboldlg.cpp:436
+#: ../src/richtext/richtextsymboldlg.cpp:438
+msgid "The range to show."
+msgstr "Julat untuk ditunjuk."
+
+#: ../src/richtext/richtextsymboldlg.cpp:444
+msgid "Insert"
+msgstr "Selit"
+
+#: ../src/richtext/richtextsymboldlg.cpp:478
+msgid "(Normal text)"
+msgstr "(Teks Normal)"
+
+#: ../src/richtext/richtexttabspage.cpp:109
+msgid "&Position (tenths of a mm):"
+msgstr "&Posisi (satu persepuluh mm):"
+
+#: ../src/richtext/richtexttabspage.cpp:113
+#: ../src/richtext/richtexttabspage.cpp:115
+msgid "The tab position."
+msgstr "Posisi tab."
+
+#: ../src/richtext/richtexttabspage.cpp:119
+msgid "The tab positions."
+msgstr "Posisi tab."
+
+#: ../src/richtext/richtexttabspage.cpp:132
+#: ../src/richtext/richtexttabspage.cpp:134
+msgid "Click to create a new tab position."
+msgstr "Klik untuk cipta posisi baru tab."
+
+#: ../src/richtext/richtexttabspage.cpp:138
+#: ../src/richtext/richtexttabspage.cpp:140
+msgid "Click to delete the selected tab position."
+msgstr "Klik untuk padam posisi tab pilihan."
+
+#: ../src/richtext/richtexttabspage.cpp:143
+msgid "Delete A&ll"
+msgstr "P&adam Semua"
+
+#: ../src/richtext/richtexttabspage.cpp:144
+#: ../src/richtext/richtexttabspage.cpp:146
+msgid "Click to delete all tab positions."
+msgstr "Klik untuk padam semua posisi teks."
+
+#: ../src/univ/theme.cpp:110
+msgid "Failed to initialize GUI: no built-in themes found."
+msgstr "Gagal memulakan GUI: tiada tema bina-dalam ditemui."
+
+#: ../src/univ/themes/gtk.cpp:521
+msgid "GTK+ theme"
+msgstr "Tema GTK+"
+
+#: ../src/univ/themes/metal.cpp:164
+msgid "Metal theme"
+msgstr "Tema Metal"
+
+#: ../src/univ/themes/mono.cpp:512
+msgid "Simple monochrome theme"
+msgstr "Tema monokrom mudah"
+
+#: ../src/univ/themes/win32.cpp:1098
+msgid "Win32 theme"
+msgstr "Tema Win32"
+
+#: ../src/univ/themes/win32.cpp:3743
+msgid "&Restore"
+msgstr "&Pulih"
+
+#: ../src/univ/themes/win32.cpp:3744
+msgid "&Move"
+msgstr "&Pindah"
+
+#: ../src/univ/themes/win32.cpp:3746
+msgid "&Size"
+msgstr "&Saiz"
+
+#: ../src/univ/themes/win32.cpp:3748
+msgid "Mi&nimize"
+msgstr "Mi&nimum"
+
+#: ../src/univ/themes/win32.cpp:3750
+msgid "Ma&ximize"
+msgstr "Mak&simum"
+
+#: ../src/univ/themes/win32.cpp:3752
+#, fuzzy
+msgid "Alt+"
+msgstr "Alt-"
+
+#: ../src/unix/appunix.cpp:178
+#, fuzzy
+msgid "Failed to install signal handler"
+msgstr "Gagal tutup pengemudi fail"
+
+#: ../src/unix/dialup.cpp:351
+msgid "Already dialling ISP."
+msgstr "Sudah mendail ISP"
+
+#: ../src/unix/dlunix.cpp:93
+#, fuzzy
+msgid "Failed to unload shared library"
+msgstr "Gagal memuat pustaka kongsi '%s'"
+
+#: ../src/unix/dlunix.cpp:121
+msgid "Unknown dynamic library error"
+msgstr "Ralat pustaka dinamik tidak diketahui"
+
+#: ../src/unix/epolldispatcher.cpp:84
+#, fuzzy
+msgid "Failed to create epoll descriptor"
+msgstr "Gagal mencipta kursor."
+
+#: ../src/unix/epolldispatcher.cpp:103
+#, fuzzy
+msgid "Error closing epoll descriptor"
+msgstr "Ralat mencipta direktori"
+
+#: ../src/unix/epolldispatcher.cpp:116
+#, fuzzy, c-format
+msgid "Failed to add descriptor %d to epoll descriptor %d"
+msgstr "gagal menulis kepada penghurai %d"
+
+#: ../src/unix/epolldispatcher.cpp:136
+#, c-format
+msgid "Failed to modify descriptor %d in epoll descriptor %d"
+msgstr ""
+
+#: ../src/unix/epolldispatcher.cpp:155
+#, fuzzy, c-format
+msgid "Failed to unregister descriptor %d from epoll descriptor %d"
+msgstr "Gagal mendapatkan data dari klipbod."
+
+#: ../src/unix/epolldispatcher.cpp:213
+#, fuzzy, c-format
+msgid "Waiting for IO on epoll descriptor %d failed"
+msgstr "Gagal menunggu penamatan subproses"
+
+#: ../src/unix/fswatcher_inotify.cpp:71
+#, fuzzy
+msgid "Unable to create inotify instance"
+msgstr "Gagal cipta TextEncodingConverter"
+
+#: ../src/unix/fswatcher_inotify.cpp:94
+#, fuzzy
+msgid "Unable to close inotify instance"
+msgstr "Gagal tutup pengemudi fail"
+
+#: ../src/unix/fswatcher_inotify.cpp:106
+msgid "Unable to add inotify watch"
+msgstr ""
+
+#: ../src/unix/fswatcher_inotify.cpp:138
+#, fuzzy, c-format
+msgid "Unable to remove inotify watch %i"
+msgstr "Gagal cipta TextEncodingConverter"
+
+#: ../src/unix/fswatcher_inotify.cpp:271
+#, c-format
+msgid "Unexpected event for \"%s\": no matching watch descriptor."
+msgstr ""
+
+#: ../src/unix/fswatcher_inotify.cpp:320
+#, c-format
+msgid "Invalid inotify event for \"%s\""
+msgstr ""
+
+#: ../src/unix/fswatcher_inotify.cpp:553
+#, fuzzy
+msgid "Unable to read from inotify descriptor"
+msgstr "gagal membaca dari penghurai fail %d"
+
+#: ../src/unix/fswatcher_inotify.cpp:558
+#, fuzzy
+msgid "EOF while reading from inotify descriptor"
+msgstr "gagal membaca dari penghurai fail %d"
+
+#: ../src/unix/fswatcher_kqueue.cpp:114
+#, fuzzy
+msgid "Unable to create kqueue instance"
+msgstr "Gagal cipta TextEncodingConverter"
+
+#: ../src/unix/fswatcher_kqueue.cpp:131
+#, fuzzy
+msgid "Error closing kqueue instance"
+msgstr "Ralat mencipta direktori"
+
+#: ../src/unix/fswatcher_kqueue.cpp:153
+msgid "Unable to add kqueue watch"
+msgstr ""
+
+#: ../src/unix/fswatcher_kqueue.cpp:170
+msgid "Unable to remove kqueue watch"
+msgstr ""
+
+#: ../src/unix/fswatcher_kqueue.cpp:202
+msgid "Unable to get events from kqueue"
+msgstr ""
+
+#: ../src/unix/mediactrl.cpp:966
+#, c-format
+msgid "Media playback error: %s"
+msgstr ""
+
+#: ../src/unix/mediactrl.cpp:1228
+#, fuzzy, c-format
+msgid "Failed to prepare playing \"%s\"."
+msgstr "Gagal membuka papara \"%s\"."
+
+#: ../src/unix/snglinst.cpp:164
+#, c-format
+msgid "Failed to write to lock file '%s'"
+msgstr "Gagal menulis fail kunci '%s'"
+
+#: ../src/unix/snglinst.cpp:177
+#, c-format
+msgid "Failed to set permissions on lock file '%s'"
+msgstr "Gagal menetapkan keizinan pada fail kunci '%s'"
+
+#: ../src/unix/snglinst.cpp:194
+#, c-format
+msgid "Failed to lock the lock file '%s'"
+msgstr "Gagal mengunci fail kunci '%s'"
+
+#: ../src/unix/snglinst.cpp:237
+#, c-format
+msgid "Failed to inspect the lock file '%s'"
+msgstr "Gagal menyelia fail kunci '%s'"
+
+#: ../src/unix/snglinst.cpp:242
+#, c-format
+msgid "Lock file '%s' has incorrect owner."
+msgstr "Pemilik fail kunci '%s' yang salah."
+
+#: ../src/unix/snglinst.cpp:247
+#, c-format
+msgid "Lock file '%s' has incorrect permissions."
+msgstr "Keizinan fail kunci '%s' yang salah."
+
+#: ../src/unix/snglinst.cpp:265
+msgid "Failed to access lock file."
+msgstr "Gagal mencapai fail kunci."
+
+#: ../src/unix/snglinst.cpp:274
+msgid "Failed to read PID from lock file."
+msgstr "Gagal membaca PID daripada fail kunci."
+
+#: ../src/unix/snglinst.cpp:284
+#, c-format
+msgid "Failed to remove stale lock file '%s'."
+msgstr "Gagal buang fail laporan basi '%s'."
+
+#: ../src/unix/snglinst.cpp:297
+#, c-format
+msgid "Deleted stale lock file '%s'."
+msgstr "Padam fail kunci basi '%s'."
+
+#: ../src/unix/snglinst.cpp:308
+#, c-format
+msgid "Invalid lock file '%s'."
+msgstr "Fail kunci '%s' tidak sah."
+
+#: ../src/unix/snglinst.cpp:324
+#, c-format
+msgid "Failed to remove lock file '%s'"
+msgstr "Gagal buang fail kunci '%s'"
+
+#: ../src/unix/snglinst.cpp:330
+#, c-format
+msgid "Failed to unlock lock file '%s'"
+msgstr "Gagal nyahkunci fail kunci '%s'"
+
+#: ../src/unix/snglinst.cpp:336
+#, c-format
+msgid "Failed to close lock file '%s'"
+msgstr "Gagal menutup fail kunci '%s'"
+
+#: ../src/unix/sound.cpp:77
+msgid "No sound"
+msgstr "Tiada bunyi"
+
+#: ../src/unix/sound.cpp:364
+msgid "Unable to play sound asynchronously."
+msgstr "Gagal mainkan bunyi secara tak segerak."
+
+#: ../src/unix/sound.cpp:458
+#, c-format
+msgid "Couldn't load sound data from '%s'."
+msgstr "Gagal memuat data bunyi dari '%s'."
+
+#: ../src/unix/sound.cpp:465
+#, c-format
+msgid "Sound file '%s' is in unsupported format."
+msgstr "Fail bunyi '%s' dalam format yang tidak disokong."
+
+#: ../src/unix/sound.cpp:480
+msgid "Sound data are in unsupported format."
+msgstr "Data bunyi dalam format yang tidak disokong."
+
+#: ../src/unix/sound_sdl.cpp:226
+#, c-format
+msgid "Couldn't open audio: %s"
+msgstr "Gagal membuka audio: %s"
+
+#: ../src/unix/threadpsx.cpp:1033
+msgid "Cannot retrieve thread scheduling policy."
+msgstr "Gagal mendapatkan benang penjadualan polisi."
+
+#: ../src/unix/threadpsx.cpp:1058
+#, c-format
+msgid "Cannot get priority range for scheduling policy %d."
+msgstr "Gagal mendapatkan keutamaan banjaran untuk penjadualan polisi %d."
+
+#: ../src/unix/threadpsx.cpp:1066
+msgid "Thread priority setting is ignored."
+msgstr "Tetapan keutamaan benang diabaikan."
+
+#: ../src/unix/threadpsx.cpp:1221
+msgid ""
+"Failed to join a thread, potential memory leak detected - please restart the "
+"program"
+msgstr ""
+"Gagal mengikat benang, kemungkinan memori bocor dikesan - sila mulakan "
+"program"
+
+#: ../src/unix/threadpsx.cpp:1352
+#, fuzzy, c-format
+msgid "Failed to set thread concurrency level to %lu"
+msgstr "Gagal tetapkan keutamaan benang %d."
+
+#: ../src/unix/threadpsx.cpp:1481
+#, c-format
+msgid "Failed to set thread priority %d."
+msgstr "Gagal tetapkan keutamaan benang %d."
+
+#: ../src/unix/threadpsx.cpp:1666
+msgid "Failed to terminate a thread."
+msgstr "Gagal menghentikan benang."
+
+#: ../src/unix/threadpsx.cpp:1893
+msgid "Thread module initialization failed: failed to create thread key"
+msgstr "Modul benang gagal dimulakan: gagal cipta kunci benang"
+
+#: ../src/unix/utilsunx.cpp:340
+msgid "Impossible to get child process input"
+msgstr "Mustahil untuk mendapatkan input proses anak"
+
+#: ../src/unix/utilsunx.cpp:390
+#, fuzzy
+msgid "Can't write to child process's stdin"
+msgstr "Gagal membunuh proses %d"
+
+#: ../src/unix/utilsunx.cpp:644
+#, c-format
+msgid "Failed to execute '%s'\n"
+msgstr "Gagal melaksanakan '%s'\n"
+
+#: ../src/unix/utilsunx.cpp:678
+msgid "Fork failed"
+msgstr "Cabang gagal"
+
+#: ../src/unix/utilsunx.cpp:701
+#, fuzzy
+msgid "Failed to set process priority"
+msgstr "Gagal tetapkan keutamaan benang %d."
+
+#: ../src/unix/utilsunx.cpp:712
+msgid "Failed to redirect child process input/output"
+msgstr "Gagal mengalihkan  input/output proses anak"
+
+#: ../src/unix/utilsunx.cpp:816
+msgid "Failed to set up non-blocking pipe, the program might hang."
+msgstr ""
+
+#: ../src/unix/utilsunx.cpp:1023
+msgid "Cannot get the hostname"
+msgstr "Gagal mendapatkan namahos"
+
+#: ../src/unix/utilsunx.cpp:1059
+msgid "Cannot get the official hostname"
+msgstr "Gagal mendapatkan namahos rasmi"
+
+#: ../src/unix/wakeuppipe.cpp:49
+#, fuzzy
+msgid "Failed to create wake up pipe used by event loop."
+msgstr "Gagal cipta bar status."
+
+#: ../src/unix/wakeuppipe.cpp:56
+msgid "Failed to switch wake up pipe to non-blocking mode"
+msgstr ""
+
+#: ../src/unix/wakeuppipe.cpp:117
+#, fuzzy
+msgid "Failed to read from wake-up pipe"
+msgstr "Gagal membaca PID daripada fail kunci."
+
+#: ../src/x11/app.cpp:124
+#, c-format
+msgid "Invalid geometry specification '%s'"
+msgstr "Spesifikasi geometri tidak sah '%s'"
+
+#: ../src/x11/app.cpp:167
+msgid "wxWidgets could not open display. Exiting."
+msgstr "wxWidgets Gagal membuka paparan. Keluar."
+
+#: ../src/x11/utils.cpp:169
+#, c-format
+msgid "Failed to close the display \"%s\""
+msgstr "Gagal menutup paparan \"%s\""
+
+#: ../src/x11/utils.cpp:188
+#, c-format
+msgid "Failed to open display \"%s\"."
+msgstr "Gagal membuka papara \"%s\"."
+
+#: ../src/xml/xml.cpp:868
+#, c-format
+msgid "XML parsing error: '%s' at line %d"
+msgstr "Ralat menghurai XML: '%s' pada baris %d"
+
+#: ../src/xrc/xh_propgrid.cpp:239
+#, fuzzy, c-format
+msgid "Page %i"
+msgstr "Laman %d"
+
+#: ../src/xrc/xmlres.cpp:448
+#, fuzzy, c-format
+msgid "Cannot load resources from '%s'."
+msgstr "Gagal memuat sumber dari fail '%s'."
+
+#: ../src/xrc/xmlres.cpp:799
+#, fuzzy, c-format
+msgid "Cannot open resources file '%s'."
+msgstr "Gagal memuat sumber dari fail '%s'."
+
+#: ../src/xrc/xmlres.cpp:806
+#, c-format
+msgid "Cannot load resources from file '%s'."
+msgstr "Gagal memuat sumber dari fail '%s'."
+
+#: ../src/xrc/xmlres.cpp:2767
+#, fuzzy, c-format
+msgid "Creating %s \"%s\" failed."
+msgstr "Pengekstrakan '%s' kepada '%s' gagal."
+
+#, fuzzy
+#~ msgctxt "keyboard key"
+#~ msgid "Alt+"
+#~ msgstr "Alt-"
+
+#, fuzzy
+#~ msgctxt "keyboard key"
+#~ msgid "Ctrl+"
+#~ msgstr "Ctrl-"
+
+#, fuzzy
+#~ msgctxt "keyboard key"
+#~ msgid "Shift+"
+#~ msgstr "Shift-"
+
+#, fuzzy
+#~ msgctxt "keyboard key"
+#~ msgid "RawCtrl+"
+#~ msgstr "Ctrl-"
+
+#~ msgid "Unsupported clipboard format."
+#~ msgstr "Format klipbod tidak disokong."
+
+#~ msgid "Background colour"
+#~ msgstr "Warna latar"
+
+#~ msgid "Font:"
+#~ msgstr "Fon:"
+
+#~ msgid "Size:"
+#~ msgstr "Saiz:"
+
+#~ msgid "The font size in points."
+#~ msgstr "Saiz fon dalam titik."
+
+#~ msgid "Style:"
+#~ msgstr "Gaya:"
+
+#~ msgid "Check to make the font bold."
+#~ msgstr "Tanda untuk buat fon tebal."
+
+#~ msgid "Check to make the font italic."
+#~ msgstr "Tanda untuk buat fon italik."
+
+#~ msgid "Check to make the font underlined."
+#~ msgstr "Sama ada fon bergaris-bawah."
+
+#~ msgid "Colour:"
+#~ msgstr "Warna:"
+
+#~ msgid "Click to change the font colour."
+#~ msgstr "Klik untuk ubah warna fon."
+
+#~ msgid "Shows a preview of the font."
+#~ msgstr "Tunjuk pralihat fon."
+
+#~ msgid "Click to cancel changes to the font."
+#~ msgstr "Klik untuk batal perubahan fon."
+
+#~ msgid "Click to confirm changes to the font."
+#~ msgstr "Klik untuk kepastian perubahan pada fon."
+
+#~ msgid "<Any>"
+#~ msgstr "<Sebarang>"
+
+#~ msgid "<Any Roman>"
+#~ msgstr "<Sebarang Roman>"
+
+#~ msgid "<Any Decorative>"
+#~ msgstr "<Sebarang Dekoratif>"
+
+#~ msgid "<Any Modern>"
+#~ msgstr "<Sebarang Moden>"
+
+#~ msgid "<Any Script>"
+#~ msgstr "<Sebarang Skrip>"
+
+#~ msgid "<Any Swiss>"
+#~ msgstr "<Sebarang Swiss>"
+
+#~ msgid "<Any Teletype>"
+#~ msgstr "<Sebarang Teletaip>"
+
+#~ msgid "Printing "
+#~ msgstr "Mencetak "
+
+#~ msgid "Failed to insert text in the control."
+#~ msgstr "Gagal menyelitkan teks dalam kawalan."
+
+#~ msgid "Please choose a valid font."
+#~ msgstr "Sila pilih fon yang sah."
+
+#, c-format
+#~ msgid "Failed to display HTML document in %s encoding"
+#~ msgstr "Gagal papar dokumen HTML dalam pengkodan %s"
+
+#, c-format
+#~ msgid "wxWidgets could not open display for '%s': exiting."
+#~ msgstr "wxWidgets Gagal membuka paparan '%s': keluar."
+
+#~ msgid "Filter"
+#~ msgstr "Tapis"
+
+#~ msgid "Directories"
+#~ msgstr "Direktori"
+
+#~ msgid "Files"
+#~ msgstr "Fail"
+
+#~ msgid "Selection"
+#~ msgstr "Pemilihan"
+
+#~ msgid "conversion to 8-bit encoding failed"
+#~ msgstr "penukaran kepada pengenkod 8-bit gagal"
+
+#, fuzzy
+#~ msgid "failed to retrieve execution result"
+#~ msgstr "Gagal mendapatkan teks mesej ralat RAS"
+
+#, fuzzy
+#~ msgid "&Save as"
+#~ msgstr "Simpan Sebagai"
+
+#, fuzzy
+#~ msgid "'%s' doesn't consist only of valid characters"
+#~ msgstr "'%s' sepatutnya mengandungi aksara abjab sahaja."
+
+#~ msgid "'%s' should be numeric."
+#~ msgstr "'%s' sepatutnya nombor."
+
+#~ msgid "'%s' should only contain ASCII characters."
+#~ msgstr "'%s' sepatutnya mengandungi aksara ASCII sahaja."
+
+#~ msgid "'%s' should only contain alphabetic characters."
+#~ msgstr "'%s' sepatutnya mengandungi aksara abjab sahaja."
+
+#~ msgid "'%s' should only contain alphabetic or numeric characters."
+#~ msgstr "'%s' hanya patut mengandungi aksara abjab atau nombor."
+
+#, fuzzy
+#~ msgid "'%s' should only contain digits."
+#~ msgstr "'%s' sepatutnya mengandungi aksara ASCII sahaja."
+
+#~ msgid "Can't create window of class %s"
+#~ msgstr "Gagal mencipta tetingkap kelas %s"
+
+#~ msgid "Couldn't create the overlay window"
+#~ msgstr "Gagal mencipta tetingkap lapisan"
+
+#~ msgid "Couldn't init the context on the overlay window"
+#~ msgstr "Gagal memulakan konteks pada tetingkap lapisan"
+
+#, fuzzy
+#~ msgid "Failed to convert file \"%s\" to Unicode."
+#~ msgstr "Gagal menukar kadungan failkepada Unikod."
+
+#~ msgid "Failed to set text in the text control."
+#~ msgstr "Gagal menetapkan teks dalam kawalan teks."
+
+#~ msgid "No unused colour in image."
+#~ msgstr "Tiada warna yang tidak digunakan dalam imej."
+
+#, fuzzy
+#~ msgid "Not available"
+#~ msgstr "Tiada kemudahan XBM wujud!"
+
+#~ msgid "Replace selection"
+#~ msgstr "Ganti pilihan"
+
+#, fuzzy
+#~ msgid "Save as"
+#~ msgstr "Simpan Sebagai"
+
+#~ msgid "Style Organiser"
+#~ msgstr "Gaya Pengatur"
+
+#~ msgid "You cannot Clear an overlay that is not inited"
+#~ msgstr "Anda tidak boleh Kosongkan lapisan yang tidak dimulakan"
+
+#~ msgid "You cannot Init an overlay twice"
+#~ msgstr "Anda tidak boleh Init lapisan dua kali"
+
+#~ msgid "locale '%s' cannot be set."
+#~ msgstr "locale '%s' Gagal ditetapkan."
+
+#, fuzzy
+#~ msgid "Column index not found."
+#~ msgstr "Fail bantuan \"%s\" tidak ditemui."
+
+#~ msgid "Confirm registry update"
+#~ msgstr "Pasti kemaskini registri"
+
+#, fuzzy
+#~ msgid "Could not determine column index."
+#~ msgstr "Gagal mulakan pralihat dokumen."
+
+#, fuzzy
+#~ msgid "Could not determine number of columns."
+#~ msgstr "Gagal menemui fail sumber include %s."
+
+#, fuzzy
+#~ msgid "Could not determine number of items"
+#~ msgstr "Gagal menemui fail sumber include %s."
+
+#, fuzzy
+#~ msgid "Could not get header description."
+#~ msgstr "Gagal mulakan mencetak."
+
+#, fuzzy
+#~ msgid "Could not get items."
+#~ msgstr "Gagal menempatkan fail '%s'."
+
+#, fuzzy
+#~ msgid "Could not get property flags."
+#~ msgstr "Gagal mencipta fail sementara '%s'"
+
+#, fuzzy
+#~ msgid "Could not get selected items."
+#~ msgstr "Gagal menempatkan fail '%s'."
+
+#, fuzzy
+#~ msgid "Could not remove column."
+#~ msgstr "Gagal cipta kursor."
+
+#, fuzzy
+#~ msgid "Could not retrieve number of items"
+#~ msgstr "Gagal mencipta fail sementara '%s'"
+
+#, fuzzy
+#~ msgid "Could not set column width."
+#~ msgstr "Gagal mulakan pralihat dokumen."
+
+#, fuzzy
+#~ msgid "Could not set header description."
+#~ msgstr "Gagal mulakan mencetak."
+
+#, fuzzy
+#~ msgid "Could not set icon."
+#~ msgstr "Gagal mulakan mencetak."
+
+#, fuzzy
+#~ msgid "Could not set maximum width."
+#~ msgstr "Gagal mulakan mencetak."
+
+#, fuzzy
+#~ msgid "Could not set minimum width."
+#~ msgstr "Gagal mulakan mencetak."
+
+#, fuzzy
+#~ msgid "Could not set property flags."
+#~ msgstr "Gagal mulakan mencetak."
+
+#~ msgid ""
+#~ "Do you want to overwrite the command used to %s files with extension "
+#~ "\"%s\" ?\n"
+#~ "Current value is \n"
+#~ "%s, \n"
+#~ "New value is \n"
+#~ "%s %1"
+#~ msgstr ""
+#~ "Anda ingin menindih arahan yang diguna untuk fail %s dengan sambungan "
+#~ "\"%s\"?\n"
+#~ "Nilai semasa adalah \n"
+#~ "%s, \n"
+#~ "Nilai baru adalah \n"
+#~ "%s %1"
+
+#~ msgid "Failed to retrieve data from the clipboard."
+#~ msgstr "Gagal mendapatkan data dari klipbod."
+
+#~ msgid "GIF: Invalid gif index."
+#~ msgstr "GIF: Indeks gif tidak sah."
+
+#~ msgid "GIF: unknown error!!!"
+#~ msgstr "GIF: ralat tidak diketahui!!!"
+
+#~ msgid "New directory"
+#~ msgstr "Direktori baru"
+
+#~ msgid "Next"
+#~ msgstr "Maju"
+
+#, fuzzy
+#~ msgid "Number of columns could not be determined."
+#~ msgstr "Fail gagal dimuatkan."
+
+#~ msgid ""
+#~ "Please install a newer version of comctl32.dll\n"
+#~ "(at least version 4.70 is required but you have %d.%02d)\n"
+#~ "or this program won't operate correctly."
+#~ msgstr ""
+#~ "Sila pasangkan versi terbaru comctl32.dll\n"
+#~ "(sekurangnya versi 4.70 diperlukan tetapi anda mempunyai %d.%02d)\n"
+#~ "atau program ini Gagal beroperasi dengan betul."
+
+#, fuzzy
+#~ msgid "Rendering failed."
+#~ msgstr "Penciptaan pemasa gagal."
+
+#~ msgid "Show hidden directories"
+#~ msgstr "Papar direktori tersembunyi"
+
+#, fuzzy
+#~ msgid ""
+#~ "This system doesn't support date controls, please upgrade your version of "
+#~ "comctl32.dll"
+#~ msgstr ""
+#~ "Sistem ini tidak menyokong kawalan pegambil tarikh, sila naiktaraf versi "
+#~ "comctl32.dll sistem anda."
+
+#~ msgid "Too many colours in PNG, the image may be slightly blurred."
+#~ msgstr "Terlalu banyak warna dalam PNG, berkemungkinan imej sedikit kabur."
+
+#, fuzzy
+#~ msgid "Unable to initialize Hildon program"
+#~ msgstr "Gagal memulakan OpenGL"
+
+#, fuzzy
+#~ msgid "Unknown data format"
+#~ msgstr "ralat dalam format data"
+
+#~ msgid "Win32s on Windows 3.1"
+#~ msgstr "Win32s pada Windows 3.1"
+
+#, fuzzy
+#~ msgid "Windows 10"
+#~ msgstr "Windows 98"
+
+#, fuzzy
+#~ msgid "Windows 2000"
+#~ msgstr "Windows 95"
+
+#, fuzzy
+#~ msgid "Windows 7"
+#~ msgstr "Windows 95"
+
+#, fuzzy
+#~ msgid "Windows 8"
+#~ msgstr "Windows 98"
+
+#, fuzzy
+#~ msgid "Windows 8.1"
+#~ msgstr "Windows 98"
+
+#~ msgid "Windows 95"
+#~ msgstr "Windows 95"
+
+#~ msgid "Windows 95 OSR2"
+#~ msgstr "Windows 95 OSR2"
+
+#~ msgid "Windows 98"
+#~ msgstr "Windows 98"
+
+#~ msgid "Windows 98 SE"
+#~ msgstr "Windows 98 SE"
+
+#~ msgid "Windows 9x (%d.%d)"
+#~ msgstr "Windows 9x (%d.%d)"
+
+#~ msgid "Windows CE (%d.%d)"
+#~ msgstr "Windows CE (%d.%d)"
+
+#~ msgid "Windows ME"
+#~ msgstr "Windows ME"
+
+#, fuzzy
+#~ msgid "Windows NT %lu.%lu"
+#~ msgstr "Windows NT %lu.%lu (build %lu"
+
+#, fuzzy
+#~ msgid "Windows Server 10"
+#~ msgstr "Windows Server 2003 (build %lu"
+
+#, fuzzy
+#~ msgid "Windows Server 2003"
+#~ msgstr "Windows Server 2003 (build %lu"
+
+#, fuzzy
+#~ msgid "Windows Server 2008"
+#~ msgstr "Windows Server 2003 (build %lu"
+
+#, fuzzy
+#~ msgid "Windows Server 2008 R2"
+#~ msgstr "Windows Server 2003 (build %lu"
+
+#, fuzzy
+#~ msgid "Windows Server 2012"
+#~ msgstr "Windows Server 2003 (build %lu"
+
+#, fuzzy
+#~ msgid "Windows Server 2012 R2"
+#~ msgstr "Windows Server 2003 (build %lu"
+
+#, fuzzy
+#~ msgid "Windows Vista"
+#~ msgstr "Windows 95"
+
+#, fuzzy
+#~ msgid "Windows XP"
+#~ msgstr "Windows 95"
+
+#~ msgid "can't execute '%s'"
+#~ msgstr "gagal laksanakan '%s'"
+
+#~ msgid "error opening '%s'"
+#~ msgstr "ralat membuka '%s'"
+
+#~ msgid "unknown seek origin"
+#~ msgstr "carian asal tidak diketahui"
+
+#~ msgid "ADD"
+#~ msgstr "ADD"
+
+#~ msgid "BACK"
+#~ msgstr "BACK"
+
+#~ msgid "CANCEL"
+#~ msgstr "CANCEL"
+
+#~ msgid "CAPITAL"
+#~ msgstr "CAPITAL"
+
+#~ msgid "CLEAR"
+#~ msgstr "CLEAR"
+
+#~ msgid "COMMAND"
+#~ msgstr "COMMAND"
+
+#~ msgid "Cannot create mutex."
+#~ msgstr "Gagal mencipta mutex."
+
+#~ msgid "Cannot resume thread %lu"
+#~ msgstr "Gagal menyambung benang %lu"
+
+#~ msgid "Cannot suspend thread %lu"
+#~ msgstr "Gagal menggantung benang %lu"
+
+#~ msgid "Couldn't acquire a mutex lock"
+#~ msgstr "Gagal mendapatkan kunci mutex"
+
+#~ msgid "Couldn't release a mutex"
+#~ msgstr "Gagal lepaskan mutex"
+
+#~ msgid "DECIMAL"
+#~ msgstr "DECIMAL"
+
+#~ msgid "DEL"
+#~ msgstr "DEL"
+
+#~ msgid "DELETE"
+#~ msgstr "DELETE"
+
+#~ msgid "DIVIDE"
+#~ msgstr "DIVIDE"
+
+#~ msgid "DOWN"
+#~ msgstr "DOWN"
+
+#~ msgid "END"
+#~ msgstr "END"
+
+#~ msgid "ENTER"
+#~ msgstr "ENTER"
+
+#~ msgid "ESC"
+#~ msgstr "ESC"
+
+#~ msgid "ESCAPE"
+#~ msgstr "ESCAPE"
+
+#~ msgid "EXECUTE"
+#~ msgstr "EXECUTE"
+
+#~ msgid "Execution of command '%s' failed with error: %ul"
+#~ msgstr "Perlaksanaan arahan '%s' gagal dengan ralat: %ul"
+
+#~ msgid ""
+#~ "File '%s' already exists.\n"
+#~ "Do you want to replace it?"
+#~ msgstr ""
+#~ "Fail '%s' sedia wujud.\n"
+#~ "Anda pasti untuk gantinya?"
+
+#~ msgid "HELP"
+#~ msgstr "HELP"
+
+#~ msgid "HOME"
+#~ msgstr "HOME"
+
+#~ msgid "INS"
+#~ msgstr "INS"
+
+#~ msgid "INSERT"
+#~ msgstr "INSERT"
+
+#~ msgid "KP_BEGIN"
+#~ msgstr "KP_BEGIN"
+
+#~ msgid "KP_DECIMAL"
+#~ msgstr "KP_DECIMAL"
+
+#~ msgid "KP_DELETE"
+#~ msgstr "KP_DELETE"
+
+#~ msgid "KP_DIVIDE"
+#~ msgstr "KP_DIVIDE"
+
+#~ msgid "KP_DOWN"
+#~ msgstr "KP_DOWN"
+
+#~ msgid "KP_ENTER"
+#~ msgstr "KP_ENTER"
+
+#~ msgid "KP_EQUAL"
+#~ msgstr "KP_EQUAL"
+
+#~ msgid "KP_HOME"
+#~ msgstr "KP_HOME"
+
+#~ msgid "KP_INSERT"
+#~ msgstr "KP_INSERT"
+
+#~ msgid "KP_LEFT"
+#~ msgstr "KP_LEFT"
+
+#~ msgid "KP_MULTIPLY"
+#~ msgstr "KP_MULTIPLY"
+
+#~ msgid "KP_NEXT"
+#~ msgstr "KP_NEXT"
+
+#~ msgid "KP_PAGEDOWN"
+#~ msgstr "KP_PAGEDOWN"
+
+#~ msgid "KP_PAGEUP"
+#~ msgstr "KP_PAGEUP"
+
+#~ msgid "KP_PRIOR"
+#~ msgstr "KP_PRIOR"
+
+#~ msgid "KP_RIGHT"
+#~ msgstr "KP_RIGHT"
+
+#~ msgid "KP_SEPARATOR"
+#~ msgstr "KP_SEPARATOR"
+
+#~ msgid "KP_SPACE"
+#~ msgstr "KP_SPACE"
+
+#~ msgid "KP_SUBTRACT"
+#~ msgstr "KP_SUBTRACT"
+
+#~ msgid "LEFT"
+#~ msgstr "LEFT"
+
+#~ msgid "MENU"
+#~ msgstr "MENU"
+
+#~ msgid "NUM_LOCK"
+#~ msgstr "NUM_LOCK"
+
+#~ msgid "PAGEDOWN"
+#~ msgstr "PAGEDOWN"
+
+#~ msgid "PAGEUP"
+#~ msgstr "PAGEUP"
+
+#~ msgid "PAUSE"
+#~ msgstr "PAUSE"
+
+#~ msgid "PGDN"
+#~ msgstr "PGDN"
+
+#~ msgid "PGUP"
+#~ msgstr "PGUP"
+
+#~ msgid "PRINT"
+#~ msgstr "PRINT"
+
+#~ msgid "RETURN"
+#~ msgstr "RETURN"
+
+#~ msgid "RIGHT"
+#~ msgstr "RIGHT"
+
+#~ msgid "SCROLL_LOCK"
+#~ msgstr "SCROLL_LOCK"
+
+#~ msgid "SELECT"
+#~ msgstr "SELECT"
+
+#~ msgid "SEPARATOR"
+#~ msgstr "SEPARATOR"
+
+#~ msgid "SNAPSHOT"
+#~ msgstr "SNAPSHOT"
+
+#~ msgid "SPACE"
+#~ msgstr "SPACE"
+
+#~ msgid "SUBTRACT"
+#~ msgstr "SUBTRACT"
+
+#~ msgid "TAB"
+#~ msgstr "TAB"
+
+#~ msgid "Timer creation failed."
+#~ msgstr "Penciptaan pemasa gagal."
+
+#~ msgid "UP"
+#~ msgstr "UP"
+
+#~ msgid "WINDOWS_LEFT"
+#~ msgstr "WINDOWS_LEFT"
+
+#~ msgid "WINDOWS_MENU"
+#~ msgstr "WINDOWS_MENU"
+
+#~ msgid "WINDOWS_RIGHT"
+#~ msgstr "WINDOWS_RIGHT"
+
+#~ msgid "buffer is too small for Windows directory."
+#~ msgstr "penimbal terlalu kecil untuk direktori Windows."
+
+#~ msgid "Print preview"
+#~ msgstr "Pralihat cetak"
+
+#, fuzzy
+#~ msgid "&Preview..."
+#~ msgstr " Pralihat"
+
+#, fuzzy
+#~ msgid "Preview..."
+#~ msgstr " Pralihat"
+
+#, fuzzy
+#~ msgid "The vertical offset relative to the paragraph."
+#~ msgstr "Gaya lalai untuk perenggan berikut."
+
+#~ msgid "&Save..."
+#~ msgstr "&Simpan..."
+
+#~ msgid "About "
+#~ msgstr "Perihal"
+
+#~ msgid "All files (*.*)|*"
+#~ msgstr "Semua fail (*.*)|*"
+
+#~ msgid "Cannot initialize SciTech MGL!"
+#~ msgstr "Gagal mulakan SciTech MGL!"
+
+#~ msgid "Cannot initialize display."
+#~ msgstr "Gagal mulakan paparan."
+
+#~ msgid "Cannot start thread: error writing TLS"
+#~ msgstr "Tidak dapat memulakan benang: ralat menulis TLS."
+
+#~ msgid "Close\tAlt-F4"
+#~ msgstr "Tutup\tAlt-F4"
+
+#~ msgid "Couldn't create cursor."
+#~ msgstr "Gagal cipta kursor."
+
+#~ msgid "Directory '%s' doesn't exist!"
+#~ msgstr "Direktori '%s tidak wujud!"
+
+#~ msgid "Mode %ix%i-%i not available."
+#~ msgstr "Mode %ix%i-%i tidak wujud."
+
+#~ msgid "Paper Size"
+#~ msgstr "Saiz &kertas:"
+
+#~ msgid "%.*f GB"
+#~ msgstr "%.*f GB"
+
+#~ msgid "%.*f MB"
+#~ msgstr "%.*f MB"
+
+#~ msgid "%.*f TB"
+#~ msgstr "%.*f TB"
+
+#~ msgid "%.*f kB"
+#~ msgstr "%.*f kB"
+
+#~ msgid "%s B"
+#~ msgstr "%s B"
+
+#~ msgid "&Goto..."
+#~ msgstr "Per&gi..."
+
+#~ msgid "<<"
+#~ msgstr "<<"
+
+#~ msgid ">>"
+#~ msgstr ">>"
+
+#~ msgid ">>|"
+#~ msgstr ">>|"
+
+#~ msgid "Archive doesnt contain #SYSTEM file"
+#~ msgstr "Arkib tidak mengandungi fail #SYSTEM"
+
+#~ msgid "BIG5"
+#~ msgstr "BIG5"
+
+#~ msgid "Can't check image format of file '%s': file does not exist."
+#~ msgstr "Gagal periksa format imej pada fail '%s': fail tidak wujud."
+
+#~ msgid "Can't load image from file '%s': file does not exist."
+#~ msgstr "Gagal memuat imej dari fail '%s': fail tidak wujud."
+
+#~ msgid "Cannot convert dialog units: dialog unknown."
+#~ msgstr "Gagal menukar unit dialog: dialog tidak diketahui."
+
+#~ msgid "Cannot convert from the charset '%s'!"
+#~ msgstr "Gagal menukar daipada set aksara '%s'!"
+
+#~ msgid "Cannot find container for unknown control '%s'."
+#~ msgstr "Gagal menemui bekas kawalan tidak diketahui '%s'."
+
+#~ msgid "Cannot find font node '%s'."
+#~ msgstr "Gagal menemui nod fon '%s'."
+
+#~ msgid "Cannot open file '%s'."
+#~ msgstr "Gagal buka fail '%s'."
+
+#~ msgid "Cannot parse coordinates from '%s'."
+#~ msgstr "Gagal hurai koordinat dari '%s'."
+
+#~ msgid "Cannot parse dimension from '%s'."
+#~ msgstr "Gagal hurai dimensi dari '%s'."
+
+#~ msgid "Cant create the thread event queue"
+#~ msgstr "Gagal cipta barisan peristiwa benang"
+
+#~ msgid "Click to cancel this window."
+#~ msgstr "Klik untuk batal tetingkap ini."
+
+#~ msgid "Click to confirm your selection."
+#~ msgstr "Klik untuk kepastian pilihan anda."
+
+#~ msgid "Could not unlock mutex"
+#~ msgstr "Gagal nyahkunci mutex"
+
+#~ msgid "Error while waiting on semaphore"
+#~ msgstr "Ralat ketika menunggu semafor"
+
+#~ msgid "Failed to create a status bar."
+#~ msgstr "Gagal cipta bar status."
+
+#~ msgid "Failed to register OpenGL window class."
+#~ msgstr "Gagal daftarkan kelas tingkap OpenGL."
+
+#~ msgid "Fatal error: "
+#~ msgstr "Ralat maut: "
+
+#~ msgid "GB-2312"
+#~ msgstr "GB-2312"
+
+#~ msgid "Go forward to the next HTML page"
+#~ msgstr "Undur ke laman HTML berikut"
+
+#~ msgid "Goto Page"
+#~ msgstr "Tuju Laman"
+
+#, fuzzy
+#~ msgid ""
+#~ "HTML pagination algorithm generated more than the allowed maximum number "
+#~ "of pages and it can't continue any longer!"
+#~ msgstr ""
+#~ "Algorithma penghalaman HTML menjana lebih daripada bilangan maksima laman "
+#~ "dibenar dan ia boleh diteruskan lagi!"
+
+#~ msgid "Help : %s"
+#~ msgstr "Bantuan : %s"
+
+#~ msgid "I64"
+#~ msgstr "I64"
+
+#~ msgid "Internal error, illegal wxCustomTypeInfo"
+#~ msgstr "Ralat dalaman, wxCustomTypeInfo tidak sah"
+
+#~ msgid "Invalid XRC resource '%s': doesn't have root node 'resource'."
+#~ msgstr "Sumber XRC tidak sah '%s': tidak mempunyai 'sumber' nod root."
+
+#~ msgid "No handler found for XML node '%s', class '%s'!"
+#~ msgstr "Tiada pengemudi ditemui untuk nod XML '%s', kelas '%s'!"
+
+#~ msgid "No image handler for type %ld defined."
+#~ msgstr "Tiada pengemudi imej untuk jenis %ld ditetapkan."
+
+#, fuzzy
+#~ msgid "Owner not initialized."
+#~ msgstr "Gagal mulakan paparan."
+
+#, fuzzy
+#~ msgid "Passed item is invalid."
+#~ msgstr "'%s' tidak sah"
+
+#~ msgid "Passing a already registered object to SetObjectName"
+#~ msgstr "Passing a already registered object to SetObjectName"
+
+#~ msgid "Preparing help window..."
+#~ msgstr "menyediakan tetingkap bantuan..."
+
+#~ msgid "Program aborted."
+#~ msgstr "Program digugurkan"
+
+#~ msgid "Referenced object node with ref=\"%s\" not found!"
+#~ msgstr "Nod objek yang dirujuk dengan ref= \"%s\" tidak ditemui!"
+
+#~ msgid "Resource files must have same version number!"
+#~ msgstr "Fail sumber mesti mempunyai nombor versi sama!"
+
+#~ msgid "SHIFT-JIS"
+#~ msgstr "SHIFT-JIS"
+
+#~ msgid "Search!"
+#~ msgstr "Cari!"
+
+#~ msgid "Sorry, could not open this file for saving."
+#~ msgstr "Maaf, Gagal membuka fail untuk disimpan."
+
+#~ msgid "Sorry, could not save this file."
+#~ msgstr "Maaf, Gagal menyimpan fail."
+
+#~ msgid "Sorry, print preview needs a printer to be installed."
+#~ msgstr "Maaf, prapapar cetak memerlukan pencetak dipasang."
+
+#~ msgid "Status: "
+#~ msgstr "Status: "
+
+#~ msgid ""
+#~ "Streaming delegates for not already streamed objects not yet supported"
+#~ msgstr "Penstrim diwakilkan kerana tidak menstrim objek yang belum disokong"
+
+#~ msgid "Subclass '%s' not found for resource '%s', not subclassing!"
+#~ msgstr "Subkelas '%s'  tidak ditemui untuk sumber '%s', bukan subkelas!"
+
+#~ msgid "TIFF library error."
+#~ msgstr "Ralat pustaka TIFF."
+
+#~ msgid "TIFF library warning."
+#~ msgstr "Amaran pustaka TIFF."
+
+#~ msgid ""
+#~ "The file '%s' couldn't be opened.\n"
+#~ "It has been removed from the most recently used files list."
+#~ msgstr ""
+#~ "Fail '%s' Gagal dibuka.\n"
+#~ "Ia telah dibuang dari senarai fail paling baru diguna."
+
+#~ msgid "The path '%s' contains too many \"..\"!"
+#~ msgstr "Laluan '%s' mengandungi terlalu banyak \"..\"!"
+
+#~ msgid "Trying to solve a NULL hostname: giving up"
+#~ msgstr "Cuba untuk menyelesaikan namahos NULL: menyerah"
+
+#~ msgid "Unknown style flag "
+#~ msgstr "Bendera gaya tidak diketahui"
+
+#~ msgid "Warning"
+#~ msgstr "Amaran"
+
+#~ msgid "Windows 2000 (build %lu"
+#~ msgstr "Windows 2000 (build %lu"
+
+#~ msgid "XRC resource '%s' (class '%s') not found!"
+#~ msgstr "Sumber XRC '%s' (class '%s') tidak ditemui!"
+
+#~ msgid "XRC resource: Cannot create animation from '%s'."
+#~ msgstr "Sumber XRC: Gagal cipta animasi daripada '%s'."
+
+#~ msgid "XRC resource: Cannot create bitmap from '%s'."
+#~ msgstr "Sumber XRC: Gagal cipta peta bit dari '%s'."
+
+#, fuzzy
+#~ msgid ""
+#~ "XRC resource: Incorrect colour specification '%s' for attribute '%s'."
+#~ msgstr "Sumber XRC: Spesifikasi warna salah '%s' untuk milik '%s'."
+
+#~ msgid "[EMPTY]"
+#~ msgstr "[EMPTY]"
+
+#~ msgid "catalog file for domain '%s' not found."
+#~ msgstr "katalog fail untuk domain '%s' tidak ditemui."
+
+#~ msgid "delegate has no type info"
+#~ msgstr "utusan tiada jenis info"
+
+#~ msgid "encoding %i"
+#~ msgstr "mengkod %i"
+
+#~ msgid "looking for catalog '%s' in path '%s'."
+#~ msgstr "mencari katalog '%s' dalam laluan '%s'."
+
+#~ msgid "wxRichTextFontPage"
+#~ msgstr "wxRichTextFontPage"
+
+#~ msgid "wxSearchEngine::LookFor must be called before scanning!"
+#~ msgstr "wxSearchEngine::LookFor mestilah dipanggil sebelum mengimbas!"
+
+#~ msgid "wxSocket: invalid signature in ReadMsg."
+#~ msgstr "wxSocket: tandatangan tidak sah dalam ReadMsg."
+
+#~ msgid "wxSocket: unknown event!."
+#~ msgstr "wxSocket: peristiwa tidak diketahui!."
+
+#~ msgid "|<<"
+#~ msgstr "|<<"
+
+#~ msgid " Couldn't create the UnicodeConverter"
+#~ msgstr "Gagal cipta UnicodeConverter"
+
+#~ msgid "#define %s must be an integer."
+#~ msgstr "#define %s mestilah integer."
+
+#~ msgid "%s not a bitmap resource specification."
+#~ msgstr "%s bukan spesifikasi sumber peta bit."
+
+#~ msgid "%s not an icon resource specification."
+#~ msgstr "%s bukan spesifikasi ikon peta bit."
+
+#~ msgid "%s: ill-formed resource file syntax."
+#~ msgstr "%s: Sintaks fail sumber salah-bentuk"
+
+#~ msgid "&Open"
+#~ msgstr "B&uka"
+
+#~ msgid "&Print"
+#~ msgstr "Cetak"
+
+#~ msgid "*** It can be found in \"%s\"\n"
+#~ msgstr "*** Ia boleh ditemui dalam \"%s\"\n"
+
+#~ msgid ""
+#~ ", expected static, #include or #define\n"
+#~ "while parsing resource."
+#~ msgstr ""
+#~ ", dijangka statik, #include atau #define\n"
+#~ "ketika menghurai sumber."
+
+#~ msgid "Bitmap resource specification %s not found."
+#~ msgstr "Spesifikasi sumber peta bit %s tidak ditemui."
+
+#~ msgid "Closes the dialog without inserting a symbol."
+#~ msgstr "Tutup dialog tanpa menyelitkan simbol."
+
+#~ msgid ""
+#~ "Could not resolve control class or id '%s'. Use (non-zero) integer "
+#~ "instead\n"
+#~ " or provide #define (see manual for caveats)"
+#~ msgstr ""
+#~ "Gagal menyelesaikan kelas kawalan atau id '%s'. Sebaliknya guna integer "
+#~ "(bukan-sifar)\n"
+#~ " atau sediakan #define (llihat manual atau surat bantahan)"
+
+#~ msgid ""
+#~ "Could not resolve menu id '%s'. Use (non-zero) integer instead\n"
+#~ "or provide #define (see manual for caveats)"
+#~ msgstr ""
+#~ "Gagal selesaikan menu id '%s'. Sebaliknya guna integer(bukan-sifar0\n"
+#~ "atau sediakan #define (lihat manual atau surat bantahan)"
+
+#~ msgid "Couldn't end the context on the overlay window"
+#~ msgstr "Gagal mengakhiri konteks pada tetingkap lapisan"
+
+#~ msgid "Expected '*' while parsing resource."
+#~ msgstr "Dijangka '*' ketika menghurai sumber."
+
+#~ msgid "Expected '=' while parsing resource."
+#~ msgstr "Dijangka '=' ketika menghurai sumber."
+
+#~ msgid "Expected 'char' while parsing resource."
+#~ msgstr "Dijangka aksara ketika menghurai sumber."
+
+#~ msgid ""
+#~ "Failed to find XBM resource %s.\n"
+#~ "Forgot to use wxResourceLoadBitmapData?"
+#~ msgstr ""
+#~ "Gagal mencari sumber XBM %s.\n"
+#~ "Lupa menggunakan wxResourceLoadBitmapData?"
+
+#~ msgid ""
+#~ "Failed to find XBM resource %s.\n"
+#~ "Forgot to use wxResourceLoadIconData?"
+#~ msgstr ""
+#~ "Gagal mencari sumber XBM %s.\n"
+#~ "Lupa menggunakan wxResourceLoadIconData?"
+
+#~ msgid ""
+#~ "Failed to find XPM resource %s.\n"
+#~ "Forgot to use wxResourceLoadBitmapData?"
+#~ msgstr ""
+#~ "Gagal mencari sumber XBM %s.\n"
+#~ "Lupa menggunakan wxResourceLoadBitmapData?"
+
+#~ msgid "Failed to get clipboard data."
+#~ msgstr "Gagal mendapatkan data klipbod."
+
+#~ msgid "Failed to load shared library '%s' Error '%s'"
+#~ msgstr "Gagal memuat pustaka kongsi '%s' Ralat '%s'"
+
+#~ msgid "Found "
+#~ msgstr "Ditemui "
+
+#~ msgid "Icon resource specification %s not found."
+#~ msgstr "Spesifikasi sumber ikon %s tidak ditemui."
+
+#~ msgid "Ill-formed resource file syntax."
+#~ msgstr "Sintaks failsumber salah-bentuk."
+
+#~ msgid "Inserts the chosen symbol."
+#~ msgstr "Selit simbol dipilih."
+
+#~ msgid "Long Conversions not supported"
+#~ msgstr "Perbualan Panjang tidak disokong"
+
+#~ msgid "No XPM icon facility available!"
+#~ msgstr "Tiada kemudahan ikon XPM wujud!"
+
+#~ msgid "Option '%s' requires a value, '=' expected."
+#~ msgstr "Pilihan '%s' perlukan nilai, '='dijangka."
+
+#~ msgid "Select all"
+#~ msgstr "Cari semua"
+
+#~ msgid ""
+#~ "Sorry, docking is not supported for ports other than wxMSW, wxMac and "
+#~ "wxGTK"
+#~ msgstr ""
+#~ "Maaf, melabuh tidak disokong untuk port selain wxMSW, wxMax dan wxGTK"
+
+#~ msgid "Unexpected end of file while parsing resource."
+#~ msgstr "Pengakhiran fail tidak dijangka ketika menghurai sumber."
+
+#~ msgid "Unrecognized style %s while parsing resource."
+#~ msgstr "Gaya %s tidak dikenal ketika menghurai sumber."
+
+#~ msgid "Video Output"
+#~ msgstr "Output Video"
+
+#~ msgid "Warning: attempt to remove HTML tag handler from empty stack."
+#~ msgstr ""
+#~ "Amaran: cubaan untuk menyingkir pengemudi tag HTML daripada timbunan "
+#~ "kosong."
+
+#~ msgid "establish"
+#~ msgstr "dirikan"
+
+#~ msgid "initiate"
+#~ msgstr "mulakan"
+
+#~ msgid "invalid eof() return value."
+#~ msgstr "nilai kembali eof() tidak sah."
+
+#~ msgid "unknown line terminator"
+#~ msgstr "baris penamat tidak diketahui"
+
+#~ msgid "writing"
+#~ msgstr "menulis"
+
+#~ msgid "wxRichTextBulletsPage"
+#~ msgstr "wxRichTextBulletsPage"
+
+#~ msgid "wxRichTextListStylePage"
+#~ msgstr "wxRichTextListStylePage"
+
+#~ msgid "wxRichTextStylePage"
+#~ msgstr "wxRichTextStylePage"
+
+#~ msgid "."
+#~ msgstr "."
+
+#~ msgid "Cannot open URL '%s'"
+#~ msgstr "Gagal buka URL '%s'"
+
+#~ msgid "Error "
+#~ msgstr "Ralat "
+
+#~ msgid "Failed to create directory %s/.gnome."
+#~ msgstr "Gagal mencipta direktori %s/.gnome"
+
+#~ msgid "Failed to create directory %s/mime-info."
+#~ msgstr "Gagal mencipta direktori %s/mime-info."
+
+#~ msgid "MP Thread Support is not available on this System"
+#~ msgstr "Sokongan Tred MP tidak wujud pada Sistem ini"
+
+#~ msgid "Mailcap file %s, line %d: incomplete entry ignored."
+#~ msgstr "Fail Mailcap %s, baris %d: masukan tidak lengkap diabaikan."
+
+#~ msgid "Mime.types file %s, line %d: unterminated quoted string."
+#~ msgstr "Fail Mime.type %s, baris %d: rentetan dikutip Gagal ditamatkan."
+
+#~ msgid "PRC Envelope #10 Rotated 458 x 324 m"
+#~ msgstr "Sampul PRC #10 Diputar 324 x 458 mm"
+
+#~ msgid "Unknown field in file %s, line %d: '%s'."
+#~ msgstr "Medan tidak diketahui dalam fail %s, baris %d: '%s'."
+
+#~ msgid "bold "
+#~ msgstr "bold "
+
+#~ msgid "can't query for GUI plugins name in console applications"
+#~ msgstr "Gagal pertanyaan nama GUI plugin pada aplikasi konsol"
+
+#~ msgid "light "
+#~ msgstr "ringan "
+
+#~ msgid "underlined "
+#~ msgstr "digaris bawahkan "
+
+#~ msgid "unsupported zip archive"
+#~ msgstr "arkib zip tidak disokong"

--- a/po_wxstd/nb.po
+++ b/po_wxstd/nb.po
@@ -1,0 +1,10485 @@
+#
+# Translation of wxWidgets to Norwegian Bokmål.
+# Hans Fredrik Nordhaug <hans@nordhaug.priv.no>, 2004-2005
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: wxWidgets 3.3\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-05-14 20:23+0200\n"
+"PO-Revision-Date: 2015-10-27 22:33+0100\n"
+"Last-Translator: Hans Fredrik Nordhaug <hans@nordhaug.priv.no>\n"
+"Language-Team: Norwegian Bokmål <i18n-nb@lister.ping.uio.no>\n"
+"Language: nb\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Poedit 1.7.5\n"
+
+#: ../include/wx/defs.h:2582
+msgid "All files (*.*)|*.*"
+msgstr "Alle filer (*.*)|*.*"
+
+#: ../include/wx/defs.h:2585
+msgid "All files (*)|*"
+msgstr "Alle filer (*)|*"
+
+#: ../include/wx/generic/progdlgg.h:85
+#, fuzzy
+msgid "Elapsed time:"
+msgstr "Forløpt tid :"
+
+#: ../include/wx/generic/progdlgg.h:86
+#, fuzzy
+msgid "Estimated time:"
+msgstr "Anslått tid :"
+
+#: ../include/wx/generic/progdlgg.h:87
+#, fuzzy
+msgid "Remaining time:"
+msgstr "Gjenstående tid :"
+
+#. TRANSLATORS: HTML printout default title.
+#: ../include/wx/html/htmprint.h:121 ../include/wx/prntbase.h:273
+#: ../include/wx/richtext/richtextprint.h:109 ../src/common/docview.cpp:2161
+#, fuzzy
+msgid "Printout"
+msgstr "Utskrift"
+
+#. TRANSLATORS: HTML easy print default title.
+#: ../include/wx/html/htmprint.h:234 ../include/wx/richtext/richtextprint.h:163
+#: ../src/common/prntbase.cpp:522 ../src/html/htmprint.cpp:291
+#, fuzzy
+msgid "Printing"
+msgstr "Skriver ut"
+
+#: ../include/wx/msgdlg.h:277 ../src/common/stockitem.cpp:211
+msgid "Yes"
+msgstr "Ja"
+
+#: ../include/wx/msgdlg.h:278 ../src/common/stockitem.cpp:182
+msgid "No"
+msgstr "Nei"
+
+#: ../include/wx/msgdlg.h:279 ../src/common/stockitem.cpp:183
+#: ../src/msw/msgdlg.cpp:430 ../src/msw/msgdlg.cpp:734
+#: ../src/richtext/richtextstyledlg.cpp:292
+msgid "OK"
+msgstr "OK"
+
+#: ../include/wx/msgdlg.h:280 ../src/common/stockitem.cpp:150
+#: ../src/msw/msgdlg.cpp:430 ../src/msw/progdlg.cpp:884
+#: ../src/richtext/richtextstyledlg.cpp:295
+msgid "Cancel"
+msgstr "Avbryt"
+
+#: ../include/wx/msgdlg.h:281 ../src/common/stockitem.cpp:168
+#: ../src/html/helpdlg.cpp:63 ../src/html/helpfrm.cpp:108
+#: ../src/osx/button_osx.cpp:38
+msgid "Help"
+msgstr "Hjelp"
+
+#: ../include/wx/msw/ole/oleutils.h:52
+msgid "Cannot initialize OLE"
+msgstr "Klarte ikke initialisere OLE"
+
+#: ../include/wx/msw/private/fswatcher.h:48
+#, fuzzy, c-format
+msgid "Unable to close the handle for '%s'"
+msgstr "Klarte ikke lukke filreferanse"
+
+#: ../include/wx/msw/private/fswatcher.h:92
+#, fuzzy, c-format
+msgid "Failed to open directory \"%s\" for monitoring."
+msgstr "Klarte ikke åpne «%s» for «%s»"
+
+#: ../include/wx/msw/private/fswatcher.h:125
+#, fuzzy
+msgid "Unable to close I/O completion port handle"
+msgstr "Klarte ikke lukke filreferanse"
+
+#: ../include/wx/msw/private/fswatcher.h:142
+msgid "Unable to associate handle with I/O completion port"
+msgstr ""
+
+#: ../include/wx/msw/private/fswatcher.h:148
+msgid "Unexpectedly new I/O completion port was created"
+msgstr ""
+
+#: ../include/wx/msw/private/fswatcher.h:213
+msgid "Unable to post completion status"
+msgstr ""
+
+#: ../include/wx/msw/private/fswatcher.h:262
+msgid "Unable to dequeue completion packet"
+msgstr ""
+
+#: ../include/wx/msw/private/fswatcher.h:273
+#, fuzzy
+msgid "Unable to create I/O completion port"
+msgstr "Klarte ikke opprette peker."
+
+#: ../include/wx/richmsgdlg.h:29
+#, fuzzy
+msgid "&See details"
+msgstr "&detaljer"
+
+#: ../include/wx/richmsgdlg.h:30
+#, fuzzy
+msgid "&Hide details"
+msgstr "&detaljer"
+
+#: ../include/wx/richtext/richtextbuffer.h:3864
+#, fuzzy
+msgid "&Box"
+msgstr "&Fet"
+
+#: ../include/wx/richtext/richtextbuffer.h:5008
+msgid "&Picture"
+msgstr "&Bilde"
+
+#: ../include/wx/richtext/richtextbuffer.h:5958
+#, fuzzy
+msgid "&Cell"
+msgstr "&Avbryt"
+
+#: ../include/wx/richtext/richtextbuffer.h:6067
+msgid "&Table"
+msgstr "&Tabell"
+
+#: ../include/wx/richtext/richtextimagedlg.h:37
+#, fuzzy
+msgid "Object Properties"
+msgstr "&Egenskaper"
+
+#: ../include/wx/richtext/richtextsymboldlg.h:39
+msgid "Symbols"
+msgstr "Symboler"
+
+#: ../include/wx/unix/pipe.h:46
+msgid "Pipe creation failed"
+msgstr "Røropprettelse feilet"
+
+#: ../include/wx/unix/private/displayx11.h:65
+msgid "Failed to enumerate video modes"
+msgstr "Klarte ikke telle opp videomoder"
+
+#: ../include/wx/unix/private/displayx11.h:89
+msgid "Failed to change video mode"
+msgstr "Klarte ikke skifte videomodus"
+
+#: ../include/wx/unix/private/fswatcher_kqueue.h:57
+#, fuzzy, c-format
+msgid "Unable to open path '%s'"
+msgstr "Klarte ikke åpne CHM arkiv «%s»."
+
+#: ../include/wx/unix/private/fswatcher_kqueue.h:74
+#, fuzzy, c-format
+msgid "Unable to close path '%s'"
+msgstr "Klarte ikke lukke låsefil «%s»"
+
+#: ../include/wx/xtiprop.h:175
+msgid "SetProperty called w/o valid setter"
+msgstr "SetProperty kalt uten gyldig setter"
+
+#: ../include/wx/xtiprop.h:184
+msgid "GetProperty called w/o valid getter"
+msgstr "GetProperty kalt uten gyldig henter"
+
+#: ../include/wx/xtiprop.h:193
+msgid "AddToPropertyCollection called w/o valid adder"
+msgstr "AddToPropertyCollection kalt uten gyldig tillegger"
+
+#: ../include/wx/xtiprop.h:202
+msgid "GetPropertyCollection called w/o valid collection getter"
+msgstr "GetPropertyCollection kalt uten gyldig mengdehenter"
+
+#: ../include/wx/xtiprop.h:255
+msgid "AddToPropertyCollection called on a generic accessor"
+msgstr "AddToPropertyCollection kalt på generisk aksessor"
+
+#: ../include/wx/xtiprop.h:262
+msgid "GetPropertyCollection called on a generic accessor"
+msgstr "GetPropertyCollection kalt med generisk aksessor"
+
+#: ../src/aui/tabmdi.cpp:106 ../src/generic/mdig.cpp:94
+msgid "Cl&ose"
+msgstr "&Lukk"
+
+#: ../src/aui/tabmdi.cpp:107 ../src/generic/mdig.cpp:95
+msgid "Close All"
+msgstr "Lukk alle"
+
+#: ../src/aui/tabmdi.cpp:109 ../src/generic/mdig.cpp:97 ../src/msw/mdi.cpp:175
+#: ../src/qt/mdi.cpp:258
+msgid "&Next"
+msgstr "&Neste"
+
+#: ../src/aui/tabmdi.cpp:110 ../src/generic/mdig.cpp:98 ../src/msw/mdi.cpp:176
+#: ../src/qt/mdi.cpp:259
+msgid "&Previous"
+msgstr "&Forrige"
+
+#: ../src/aui/tabmdi.cpp:332 ../src/aui/tabmdi.cpp:348
+#: ../src/aui/tabmdi.cpp:350 ../src/generic/mdig.cpp:291
+#: ../src/generic/mdig.cpp:307 ../src/generic/mdig.cpp:311
+#: ../src/msw/mdi.cpp:337 ../src/qt/mdi.cpp:462
+msgid "&Window"
+msgstr "&Vindu"
+
+#: ../src/common/accelcmn.cpp:47
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Delete"
+msgstr "&Slett"
+
+#: ../src/common/accelcmn.cpp:48
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Del"
+msgstr "&Slett"
+
+#: ../src/common/accelcmn.cpp:49
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Back"
+msgstr "&Tilbake"
+
+#: ../src/common/accelcmn.cpp:49
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Backspace"
+msgstr "&Tilbake"
+
+#: ../src/common/accelcmn.cpp:50
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Insert"
+msgstr "Innrykk"
+
+#: ../src/common/accelcmn.cpp:51
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Ins"
+msgstr "Innrykk"
+
+#: ../src/common/accelcmn.cpp:52
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Enter"
+msgstr "Skriver"
+
+#: ../src/common/accelcmn.cpp:53
+msgctxt "keyboard key"
+msgid "Return"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:54
+#, fuzzy
+msgctxt "keyboard key"
+msgid "PageUp"
+msgstr "Sider"
+
+#: ../src/common/accelcmn.cpp:54
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Page Up"
+msgstr "Side %d"
+
+#: ../src/common/accelcmn.cpp:55
+#, fuzzy
+msgctxt "keyboard key"
+msgid "PageDown"
+msgstr "Ned"
+
+#: ../src/common/accelcmn.cpp:55
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Page Down"
+msgstr "Side %d"
+
+#: ../src/common/accelcmn.cpp:56
+msgctxt "keyboard key"
+msgid "PgUp"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:57
+msgctxt "keyboard key"
+msgid "PgDn"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:58
+msgctxt "keyboard key"
+msgid "Left"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:59
+msgctxt "keyboard key"
+msgid "Right"
+msgstr "Høyre"
+
+#: ../src/common/accelcmn.cpp:60
+msgctxt "keyboard key"
+msgid "Up"
+msgstr "Opp"
+
+#: ../src/common/accelcmn.cpp:61
+msgctxt "keyboard key"
+msgid "Down"
+msgstr "Ned"
+
+#: ../src/common/accelcmn.cpp:62
+msgctxt "keyboard key"
+msgid "Home"
+msgstr "Hjem"
+
+#: ../src/common/accelcmn.cpp:63
+msgctxt "keyboard key"
+msgid "End"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:64
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Space"
+msgstr "Søker..."
+
+#: ../src/common/accelcmn.cpp:65
+msgctxt "keyboard key"
+msgid "Tab"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:66
+msgctxt "keyboard key"
+msgid "Esc"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:67
+msgctxt "keyboard key"
+msgid "Escape"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:68
+msgctxt "keyboard key"
+msgid "Cancel"
+msgstr "Avbryt"
+
+#: ../src/common/accelcmn.cpp:69
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Clear"
+msgstr "&Fjern"
+
+#: ../src/common/accelcmn.cpp:70
+msgctxt "keyboard key"
+msgid "Menu"
+msgstr "Meny"
+
+#: ../src/common/accelcmn.cpp:71
+msgctxt "keyboard key"
+msgid "Pause"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:72
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Capital"
+msgstr "kursiv"
+
+#: ../src/common/accelcmn.cpp:73
+msgctxt "keyboard key"
+msgid "Select"
+msgstr "Velg"
+
+#: ../src/common/accelcmn.cpp:74
+msgctxt "keyboard key"
+msgid "Print"
+msgstr "Utskrift"
+
+#: ../src/common/accelcmn.cpp:75
+msgctxt "keyboard key"
+msgid "Execute"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:76
+msgctxt "keyboard key"
+msgid "Snapshot"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:77
+msgctxt "keyboard key"
+msgid "Help"
+msgstr "Hjelp"
+
+#: ../src/common/accelcmn.cpp:78
+msgctxt "keyboard key"
+msgid "Add"
+msgstr "Legg till"
+
+#: ../src/common/accelcmn.cpp:79
+msgctxt "keyboard key"
+msgid "Separator"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:80
+msgctxt "keyboard key"
+msgid "Subtract"
+msgstr "Trekk fra"
+
+#: ../src/common/accelcmn.cpp:81
+msgctxt "keyboard key"
+msgid "Decimal"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:82
+msgctxt "keyboard key"
+msgid "Multiply"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:83
+msgctxt "keyboard key"
+msgid "Divide"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:84
+msgctxt "keyboard key"
+msgid "Num_lock"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:84
+msgctxt "keyboard key"
+msgid "Num Lock"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:85
+msgctxt "keyboard key"
+msgid "Scroll_lock"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:85
+msgctxt "keyboard key"
+msgid "Scroll Lock"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:86
+msgctxt "keyboard key"
+msgid "KP_Space"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:86
+msgctxt "keyboard key"
+msgid "Num Space"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:87
+msgctxt "keyboard key"
+msgid "KP_Tab"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:87
+msgctxt "keyboard key"
+msgid "Num Tab"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:88
+#, fuzzy
+msgctxt "keyboard key"
+msgid "KP_Enter"
+msgstr "Skriver"
+
+#: ../src/common/accelcmn.cpp:88
+msgctxt "keyboard key"
+msgid "Num Enter"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:89
+#, fuzzy
+msgctxt "keyboard key"
+msgid "KP_Home"
+msgstr "Hjem"
+
+#: ../src/common/accelcmn.cpp:89
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Num Home"
+msgstr "Hjem"
+
+#: ../src/common/accelcmn.cpp:90
+msgctxt "keyboard key"
+msgid "KP_Left"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:90
+msgctxt "keyboard key"
+msgid "Num left"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:91
+msgctxt "keyboard key"
+msgid "KP_Up"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:91
+msgctxt "keyboard key"
+msgid "Num Up"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:92
+#, fuzzy
+msgctxt "keyboard key"
+msgid "KP_Right"
+msgstr "Lett"
+
+#: ../src/common/accelcmn.cpp:92
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Num Right"
+msgstr "Lett"
+
+#: ../src/common/accelcmn.cpp:93
+#, fuzzy
+msgctxt "keyboard key"
+msgid "KP_Down"
+msgstr "Ned"
+
+#: ../src/common/accelcmn.cpp:93
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Num Down"
+msgstr "Ned"
+
+#: ../src/common/accelcmn.cpp:94
+msgctxt "keyboard key"
+msgid "KP_PageUp"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:94
+msgctxt "keyboard key"
+msgid "Num Page Up"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:95
+msgctxt "keyboard key"
+msgid "KP_PageDown"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:95
+msgctxt "keyboard key"
+msgid "Num Page Down"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:96
+msgctxt "keyboard key"
+msgid "KP_Prior"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:97
+#, fuzzy
+msgctxt "keyboard key"
+msgid "KP_Next"
+msgstr "Neste"
+
+#: ../src/common/accelcmn.cpp:98
+msgctxt "keyboard key"
+msgid "KP_End"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:98
+msgctxt "keyboard key"
+msgid "Num End"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:99
+msgctxt "keyboard key"
+msgid "KP_Begin"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:99
+msgctxt "keyboard key"
+msgid "Num Begin"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:100
+#, fuzzy
+msgctxt "keyboard key"
+msgid "KP_Insert"
+msgstr "Innrykk"
+
+#: ../src/common/accelcmn.cpp:100
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Num Insert"
+msgstr "Innrykk"
+
+#: ../src/common/accelcmn.cpp:101
+#, fuzzy
+msgctxt "keyboard key"
+msgid "KP_Delete"
+msgstr "&Slett"
+
+#: ../src/common/accelcmn.cpp:101
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Num Delete"
+msgstr "&Slett"
+
+#: ../src/common/accelcmn.cpp:102
+msgctxt "keyboard key"
+msgid "KP_Equal"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:102
+msgctxt "keyboard key"
+msgid "Num ="
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:103
+msgctxt "keyboard key"
+msgid "KP_Multiply"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:103
+msgctxt "keyboard key"
+msgid "Num *"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:104
+msgctxt "keyboard key"
+msgid "KP_Add"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:104
+msgctxt "keyboard key"
+msgid "Num +"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:105
+msgctxt "keyboard key"
+msgid "KP_Separator"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:105
+msgctxt "keyboard key"
+msgid "Num ,"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:106
+msgctxt "keyboard key"
+msgid "KP_Subtract"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:106
+msgctxt "keyboard key"
+msgid "Num -"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:107
+msgctxt "keyboard key"
+msgid "KP_Decimal"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:107
+msgctxt "keyboard key"
+msgid "Num ."
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:108
+msgctxt "keyboard key"
+msgid "KP_Divide"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:108
+msgctxt "keyboard key"
+msgid "Num /"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:109
+msgctxt "keyboard key"
+msgid "Windows_Left"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:110
+msgctxt "keyboard key"
+msgid "Windows_Right"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:111
+msgctxt "keyboard key"
+msgid "Windows_Menu"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:112
+msgctxt "keyboard key"
+msgid "Command"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:186 ../src/common/accelcmn.cpp:359
+msgctxt "keyboard key"
+msgid "Ctrl"
+msgstr "Ctrl"
+
+#: ../src/common/accelcmn.cpp:188 ../src/common/accelcmn.cpp:363
+msgctxt "keyboard key"
+msgid "Alt"
+msgstr "Alt"
+
+#: ../src/common/accelcmn.cpp:190 ../src/common/accelcmn.cpp:361
+msgctxt "keyboard key"
+msgid "Shift"
+msgstr "Shift"
+
+#: ../src/common/accelcmn.cpp:196
+msgctxt "keyboard key"
+msgid "num "
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:260 ../src/common/accelcmn.cpp:382
+msgctxt "keyboard key"
+msgid "F"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:277 ../src/common/accelcmn.cpp:385
+msgctxt "keyboard key"
+msgid "KP_F"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:280 ../src/common/accelcmn.cpp:388
+msgctxt "keyboard key"
+msgid "KP_"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:283 ../src/common/accelcmn.cpp:391
+msgctxt "keyboard key"
+msgid "SPECIAL"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:373
+#, fuzzy
+msgid "Ctrl"
+msgstr "Ctrl"
+
+#: ../src/common/appbase.cpp:786
+msgid "show this help message"
+msgstr "vis denne hjelpmeldingen"
+
+#: ../src/common/appbase.cpp:796
+msgid "generate verbose log messages"
+msgstr "generer ordrike loggmeldinger"
+
+#: ../src/common/appcmn.cpp:256
+msgid "specify the theme to use"
+msgstr "oppgi temaet som skal bruker"
+
+#: ../src/common/appcmn.cpp:270
+msgid "specify display mode to use (e.g. 640x480-16)"
+msgstr "oppgi skjermmodus som skal brukes (f.eks. 640x480-16)"
+
+#: ../src/common/appcmn.cpp:292
+#, c-format
+msgid "Unsupported theme '%s'."
+msgstr "Ikke-støttet tema «%s»."
+
+#: ../src/common/appcmn.cpp:309
+#, c-format
+msgid "Invalid display mode specification '%s'."
+msgstr "Ugyldig spesifikasjon «%s» for skjermmodus."
+
+#: ../src/common/cmdline.cpp:875
+#, fuzzy, c-format
+msgid "Option '%s' can't be negated"
+msgstr "Mappe «%s» kunne ikke opprettes"
+
+#: ../src/common/cmdline.cpp:889
+#, c-format
+msgid "Unknown long option '%s'"
+msgstr "Ukjent lang opsjon «%s»"
+
+#: ../src/common/cmdline.cpp:904 ../src/common/cmdline.cpp:926
+#, c-format
+msgid "Unknown option '%s'"
+msgstr "Ukjent opsjon «%s»"
+
+#: ../src/common/cmdline.cpp:1004
+#, fuzzy, c-format
+msgid "Unexpected characters following option '%s'."
+msgstr "Uventet parameter «%s»"
+
+#: ../src/common/cmdline.cpp:1039
+#, c-format
+msgid "Option '%s' requires a value."
+msgstr "Opsjon «%s» må ha en verdi."
+
+#: ../src/common/cmdline.cpp:1058
+#, c-format
+msgid "Separator expected after the option '%s'."
+msgstr "Seperator forventet etter opsjonen «%s»."
+
+#: ../src/common/cmdline.cpp:1088 ../src/common/cmdline.cpp:1106
+#, c-format
+msgid "'%s' is not a correct numeric value for option '%s'."
+msgstr "«%s» er ikke en gyldig numerisk verdi for valg «%s»."
+
+#: ../src/common/cmdline.cpp:1122
+#, c-format
+msgid "Option '%s': '%s' cannot be converted to a date."
+msgstr "Opsjon «%s»: «%s» kan ikke konverteres til en dato."
+
+#: ../src/common/cmdline.cpp:1170
+#, c-format
+msgid "Unexpected parameter '%s'"
+msgstr "Uventet parameter «%s»"
+
+#. TRANSLATORS: Short name and long name for a command line option
+#: ../src/common/cmdline.cpp:1197
+#, c-format
+msgid "%s (or %s)"
+msgstr "%s (eller %s)"
+
+#: ../src/common/cmdline.cpp:1208
+#, c-format
+msgid "The value for the option '%s' must be specified."
+msgstr "Verdien for opsjonen «%s» må oppgies."
+
+#: ../src/common/cmdline.cpp:1230
+#, c-format
+msgid "The required parameter '%s' was not specified."
+msgstr "Den nødvendige parameteren «%s» var ikke oppgitt."
+
+#: ../src/common/cmdline.cpp:1289
+#, c-format
+msgid "Usage: %s"
+msgstr "Bruk: %s"
+
+#: ../src/common/cmdline.cpp:1498
+msgid "str"
+msgstr "str"
+
+#: ../src/common/cmdline.cpp:1502
+msgid "num"
+msgstr "nummer"
+
+#: ../src/common/cmdline.cpp:1506
+msgid "double"
+msgstr "dobbel"
+
+#: ../src/common/cmdline.cpp:1510
+msgid "date"
+msgstr "dato"
+
+#: ../src/common/cmdproc.cpp:250 ../src/common/cmdproc.cpp:276
+#: ../src/common/cmdproc.cpp:296
+msgid "Unnamed command"
+msgstr "Ikke-navngitt kommando"
+
+#: ../src/common/cmdproc.cpp:253
+msgid "&Undo "
+msgstr "&Angre"
+
+#: ../src/common/cmdproc.cpp:255
+msgid "Can't &Undo "
+msgstr "Klarte ikke &angre"
+
+#: ../src/common/cmdproc.cpp:259 ../src/common/stockitem.cpp:208
+#: ../src/msw/textctrl.cpp:2880 ../src/osx/textctrl_osx.cpp:649
+#: ../src/richtext/richtextctrl.cpp:327
+msgid "&Undo"
+msgstr "&Angre"
+
+#: ../src/common/cmdproc.cpp:277 ../src/common/cmdproc.cpp:297
+msgid "&Redo "
+msgstr "&Gjenta"
+
+#: ../src/common/cmdproc.cpp:281 ../src/common/cmdproc.cpp:288
+#: ../src/common/stockitem.cpp:190 ../src/msw/textctrl.cpp:2881
+#: ../src/osx/textctrl_osx.cpp:650 ../src/richtext/richtextctrl.cpp:328
+msgid "&Redo"
+msgstr "&Gjenta"
+
+#: ../src/common/colourcmn.cpp:41
+#, c-format
+msgid "String To Colour : Incorrect colour specification : %s"
+msgstr "Tekst til farge : Ugyldig fargespesifikasjon : %s"
+
+#: ../src/common/config.cpp:259
+#, c-format
+msgid "Invalid value %ld for a boolean key \"%s\" in config file."
+msgstr ""
+
+#: ../src/common/config.cpp:526
+#, c-format
+msgid ""
+"Environment variables expansion failed: missing '%c' at position %u in '%s'."
+msgstr ""
+"Utvidelse av miljøvariabel feilet: manglende «%c» i posisjon %u i «%s»."
+
+#: ../src/common/config.cpp:576 ../src/msw/regconf.cpp:272
+#, c-format
+msgid "'%s' has extra '..', ignored."
+msgstr "«%s» har ekstra «..», ignorert."
+
+#. TRANSLATORS: Checkbox state name
+#: ../src/common/datavcmn.cpp:2166 ../src/generic/datavgen.cpp:1430
+msgid "checked"
+msgstr ""
+
+#. TRANSLATORS: Checkbox state name
+#: ../src/common/datavcmn.cpp:2170 ../src/generic/datavgen.cpp:1432
+msgid "unchecked"
+msgstr ""
+
+#. TRANSLATORS: Checkbox state name
+#: ../src/common/datavcmn.cpp:2174
+#, fuzzy
+msgid "undetermined"
+msgstr "understreket"
+
+#: ../src/common/datetimefmt.cpp:1875
+msgid "today"
+msgstr "i dag"
+
+#: ../src/common/datetimefmt.cpp:1876
+msgid "yesterday"
+msgstr "i går"
+
+#: ../src/common/datetimefmt.cpp:1877
+msgid "tomorrow"
+msgstr "i morgen"
+
+#: ../src/common/datetimefmt.cpp:2071
+msgid "first"
+msgstr "først"
+
+#: ../src/common/datetimefmt.cpp:2072
+msgid "second"
+msgstr "andre"
+
+#: ../src/common/datetimefmt.cpp:2073
+msgid "third"
+msgstr "tredje"
+
+#: ../src/common/datetimefmt.cpp:2074
+msgid "fourth"
+msgstr "fjedre"
+
+#: ../src/common/datetimefmt.cpp:2075
+msgid "fifth"
+msgstr "femte"
+
+#: ../src/common/datetimefmt.cpp:2076
+msgid "sixth"
+msgstr "sjette"
+
+#: ../src/common/datetimefmt.cpp:2077
+msgid "seventh"
+msgstr "sjuende"
+
+#: ../src/common/datetimefmt.cpp:2078
+msgid "eighth"
+msgstr "åttende"
+
+#: ../src/common/datetimefmt.cpp:2079
+msgid "ninth"
+msgstr "niende"
+
+#: ../src/common/datetimefmt.cpp:2080
+msgid "tenth"
+msgstr "tiende"
+
+#: ../src/common/datetimefmt.cpp:2081
+msgid "eleventh"
+msgstr "ellevte"
+
+#: ../src/common/datetimefmt.cpp:2082
+msgid "twelfth"
+msgstr "tolvte"
+
+#: ../src/common/datetimefmt.cpp:2083
+msgid "thirteenth"
+msgstr "trettende"
+
+#: ../src/common/datetimefmt.cpp:2084
+msgid "fourteenth"
+msgstr "fjortende"
+
+#: ../src/common/datetimefmt.cpp:2085
+msgid "fifteenth"
+msgstr "femtende"
+
+#: ../src/common/datetimefmt.cpp:2086
+msgid "sixteenth"
+msgstr "sekstende"
+
+#: ../src/common/datetimefmt.cpp:2087
+msgid "seventeenth"
+msgstr "syttende"
+
+#: ../src/common/datetimefmt.cpp:2088
+msgid "eighteenth"
+msgstr "attende"
+
+#: ../src/common/datetimefmt.cpp:2089
+msgid "nineteenth"
+msgstr "nittende"
+
+#: ../src/common/datetimefmt.cpp:2090
+msgid "twentieth"
+msgstr "tjuende"
+
+#: ../src/common/datetimefmt.cpp:2248
+msgid "noon"
+msgstr "middag"
+
+#: ../src/common/datetimefmt.cpp:2249
+msgid "midnight"
+msgstr "midnatt"
+
+#: ../src/common/debugrpt.cpp:209
+#, c-format
+msgid "Failed to create directory \"%s\""
+msgstr "Klarte ikke opprette mappe «%s»"
+
+#: ../src/common/debugrpt.cpp:210
+msgid "Debug report couldn't be created."
+msgstr "Feilsøkingsrapport kunne ikke opprettes."
+
+#: ../src/common/debugrpt.cpp:227
+#, c-format
+msgid "Failed to remove debug report file \"%s\""
+msgstr "Klarte ikke slette feilsøkingsrapportfil «%s»"
+
+#: ../src/common/debugrpt.cpp:239
+#, c-format
+msgid "Failed to clean up debug report directory \"%s\""
+msgstr "Klarte ikke rydde opp i feilsøkingsrapportmappe «%s»"
+
+#: ../src/common/debugrpt.cpp:514
+msgid "process context description"
+msgstr "beskrivelse av prosesskonteksten"
+
+#: ../src/common/debugrpt.cpp:538
+msgid "dump of the process state (binary)"
+msgstr "dump av prosesstilstanden (binært)"
+
+#: ../src/common/debugrpt.cpp:553
+msgid "Debug report generation has failed."
+msgstr "Generering av feilsøkingsrapport feilet."
+
+#: ../src/common/debugrpt.cpp:560
+#, c-format
+msgid ""
+"Processing debug report has failed, leaving the files in \"%s\" directory."
+msgstr ""
+"Behandling av feilsøkingsrapporten feilet, etterlater filene i mappen «%s»."
+
+#: ../src/common/debugrpt.cpp:573
+#, fuzzy
+msgid "A debug report has been generated. It can be found in"
+msgstr "En feilsøkingsrapport har generert i mappen\n"
+
+#: ../src/common/debugrpt.cpp:576
+#, fuzzy
+msgid "And includes the following files:\n"
+msgstr "*** Og den inkluderer følgende filer:\n"
+
+#: ../src/common/debugrpt.cpp:586
+msgid ""
+"\n"
+"Please send this report to the program maintainer, thank you!\n"
+msgstr ""
+"\n"
+"Send denne rapporten til vedlikeholderen av programmet. På forhånd takk.\n"
+
+#: ../src/common/debugrpt.cpp:729
+msgid "Failed to execute curl, please install it in PATH."
+msgstr "Klarte ikke kjøre curl, installere den i stien (PATH)."
+
+#: ../src/common/debugrpt.cpp:742
+#, c-format
+msgid "Failed to upload the debug report (error code %d)."
+msgstr "Klarte ikke laste opp feilsøkingsrapporten (feilkode %d)"
+
+#: ../src/common/docview.cpp:366
+msgid "Save As"
+msgstr "Lagre Som"
+
+#: ../src/common/docview.cpp:457
+msgid "Discard changes and reload the last saved version?"
+msgstr "Forkast endringene og last opp den forrige versjonen?"
+
+#: ../src/common/docview.cpp:488
+msgid "unnamed"
+msgstr "uten navn"
+
+#: ../src/common/docview.cpp:513
+#, fuzzy, c-format
+msgid "Do you want to save changes to %s?"
+msgstr "Vil du lagre endringer til document «%s»?"
+
+#: ../src/common/docview.cpp:521 ../src/common/docview.cpp:560
+#: ../src/common/stockitem.cpp:195
+msgid "&Save"
+msgstr "&Lagre"
+
+#: ../src/common/docview.cpp:522 ../src/common/docview.cpp:560
+msgid "&Discard changes"
+msgstr ""
+
+#: ../src/common/docview.cpp:523
+#, fuzzy
+msgid "Do&n't close"
+msgstr "Ikke lagre"
+
+#: ../src/common/docview.cpp:553
+#, fuzzy, c-format
+msgid "Do you want to save changes to %s before closing it?"
+msgstr "Vil du lagre endringer til document «%s»?"
+
+#: ../src/common/docview.cpp:559
+#, fuzzy
+msgid "The document must be closed."
+msgstr "Klarte ikke lagre teksten."
+
+#: ../src/common/docview.cpp:571
+#, c-format
+msgid "Saving %s failed, would you like to retry?"
+msgstr ""
+
+#: ../src/common/docview.cpp:577
+msgid "Retry"
+msgstr ""
+
+#: ../src/common/docview.cpp:577
+msgid "Discard changes"
+msgstr ""
+
+#: ../src/common/docview.cpp:679
+#, fuzzy, c-format
+msgid "File \"%s\" could not be opened for writing."
+msgstr "Klarte ikke åpne «%s» for «%s»"
+
+#: ../src/common/docview.cpp:685
+#, fuzzy, c-format
+msgid "Failed to save document to the file \"%s\"."
+msgstr "Klarte ikke lagre bitmap-bilde til filen «%s». "
+
+#: ../src/common/docview.cpp:702
+#, fuzzy, c-format
+msgid "File \"%s\" could not be opened for reading."
+msgstr "Klarte ikke åpne «%s» for «%s»"
+
+#: ../src/common/docview.cpp:714
+#, fuzzy, c-format
+msgid "Failed to read document from the file \"%s\"."
+msgstr "Klarte ikke laste metafil fra filen «%s»."
+
+#: ../src/common/docview.cpp:1236
+#, c-format
+msgid ""
+"The file '%s' doesn't exist and couldn't be opened.\n"
+"It has been removed from the most recently used files list."
+msgstr ""
+"Filen «%s» eksisterer ikke og kunne ikke åpnes.\n"
+"Den er fjernet fra listen over nylig brukte filer."
+
+#: ../src/common/docview.cpp:1296
+#, fuzzy
+msgid "Print preview creation failed."
+msgstr "Røropprettelse feilet"
+
+#: ../src/common/docview.cpp:1302
+msgid "Print Preview"
+msgstr "Forhåndsvisning av utskrift"
+
+#: ../src/common/docview.cpp:1517
+#, fuzzy, c-format
+msgid "The format of file '%s' couldn't be determined."
+msgstr "Mappe «%s» kunne ikke opprettes"
+
+#: ../src/common/docview.cpp:1643
+#, c-format
+msgid "unnamed%d"
+msgstr "uten navn %d"
+
+#: ../src/common/docview.cpp:1660
+msgid " - "
+msgstr " - "
+
+#: ../src/common/docview.cpp:1791 ../src/common/docview.cpp:1844
+msgid "Open File"
+msgstr "Åpne Fil"
+
+#: ../src/common/docview.cpp:1807
+msgid "File error"
+msgstr "Filfeil"
+
+#: ../src/common/docview.cpp:1809
+msgid "Sorry, could not open this file."
+msgstr "Klarte ikke åpne denne filen."
+
+#: ../src/common/docview.cpp:1843
+msgid "Sorry, the format for this file is unknown."
+msgstr "Formatet for denne filen er ukjent."
+
+#: ../src/common/docview.cpp:1924
+msgid "Select a document template"
+msgstr "Velg en dokumentmal"
+
+#: ../src/common/docview.cpp:1925
+msgid "Templates"
+msgstr "Maler"
+
+#: ../src/common/docview.cpp:1998
+msgid "Select a document view"
+msgstr "Velg en dokumentvisning"
+
+#: ../src/common/docview.cpp:1999
+msgid "Views"
+msgstr "Visninger"
+
+#: ../src/common/dynlib.cpp:81
+#, c-format
+msgid "Failed to load shared library '%s'"
+msgstr "Klarte ikke laste delt bibliotek «%s»"
+
+#: ../src/common/dynlib.cpp:105
+#, c-format
+msgid "Couldn't find symbol '%s' in a dynamic library"
+msgstr "Klarte ikke finne symbol «%s» i et dynamisk bibliotek"
+
+#: ../src/common/ffile.cpp:56 ../src/common/file.cpp:215
+#, c-format
+msgid "can't open file '%s'"
+msgstr "klarte ikke åpne fil «%s»"
+
+#: ../src/common/ffile.cpp:72
+#, c-format
+msgid "can't close file '%s'"
+msgstr "klarte ikke lukke fil «%s»"
+
+#: ../src/common/ffile.cpp:106 ../src/common/ffile.cpp:131
+#, c-format
+msgid "Read error on file '%s'"
+msgstr "Lesefeil i fil «%s»"
+
+#: ../src/common/ffile.cpp:148
+#, c-format
+msgid "Write error on file '%s'"
+msgstr "Skrivefeil på fil «%s»"
+
+#: ../src/common/ffile.cpp:182
+#, c-format
+msgid "failed to flush the file '%s'"
+msgstr "klarte ikke tømme filen «%s»"
+
+#: ../src/common/ffile.cpp:222
+#, c-format
+msgid "Seek error on file '%s' (large files not supported by stdio)"
+msgstr "Søker etter feil i fil «%s» (store filer ikke støttet av stdio)"
+
+#: ../src/common/ffile.cpp:232
+#, c-format
+msgid "Seek error on file '%s'"
+msgstr "Søkefeil i filen «%s»"
+
+#: ../src/common/ffile.cpp:248
+#, c-format
+msgid "Can't find current position in file '%s'"
+msgstr "Klarte ikke finne gjeldende posisjon i filen «%s»"
+
+#: ../src/common/ffile.cpp:349 ../src/common/file.cpp:569
+msgid "Failed to set temporary file permissions"
+msgstr "Klarte ikke sette rettigheter for midlertidige filer"
+
+#: ../src/common/ffile.cpp:371
+#, c-format
+msgid "can't remove file '%s'"
+msgstr "klarte ikke slette fil «%s»"
+
+#: ../src/common/ffile.cpp:376 ../src/common/file.cpp:591
+#, c-format
+msgid "can't commit changes to file '%s'"
+msgstr "klarte ikke utføre endringene på filen «%s»"
+
+#: ../src/common/ffile.cpp:388 ../src/common/file.cpp:603
+#, c-format
+msgid "can't remove temporary file '%s'"
+msgstr "klarte ikke slette midlertidig fil «%s»"
+
+#: ../src/common/file.cpp:162
+#, c-format
+msgid "can't create file '%s'"
+msgstr "klarte ikke opprette fil «%s»"
+
+#: ../src/common/file.cpp:229
+#, c-format
+msgid "can't close file descriptor %d"
+msgstr "klarte ikke lukke fildeskriptor %d"
+
+#: ../src/common/file.cpp:332
+#, c-format
+msgid "can't read from file descriptor %d"
+msgstr "klarte ikke lese fra fildeskriptor %d"
+
+#: ../src/common/file.cpp:351
+#, c-format
+msgid "can't write to file descriptor %d"
+msgstr "klarte ikke skrive til deskriptor %d"
+
+#: ../src/common/file.cpp:390
+#, c-format
+msgid "can't flush file descriptor %d"
+msgstr "klarte ikke tømme fildeskriptor %d"
+
+#: ../src/common/file.cpp:432
+#, c-format
+msgid "can't seek on file descriptor %d"
+msgstr "klarte ikke søke på fildeskriptor %d"
+
+#: ../src/common/file.cpp:446
+#, c-format
+msgid "can't get seek position on file descriptor %d"
+msgstr "klarte ikke finne søkeposisjon på fildeskriptor %d"
+
+#: ../src/common/file.cpp:475
+#, c-format
+msgid "can't find length of file on file descriptor %d"
+msgstr "klarte ikke finne lengde av filen med deskriptor %d"
+
+#: ../src/common/file.cpp:505
+#, c-format
+msgid "can't determine if the end of file is reached on descriptor %d"
+msgstr "klarte ikke avgjøre om slutten på filen er nådd for deskriptor %d "
+
+#: ../src/common/fileconf.cpp:352
+#, c-format
+msgid ""
+" and additionally, the existing configuration file was renamed to \"%s\" and "
+"couldn't be renamed back, please rename it to its original path \"%s\""
+msgstr ""
+
+#: ../src/common/fileconf.cpp:389
+#, fuzzy
+msgid " due to the following error:\n"
+msgstr "*** Og den inkluderer følgende filer:\n"
+
+#: ../src/common/fileconf.cpp:412
+#, fuzzy
+msgid "failed to rename the existing file"
+msgstr "Klarte ikke laste metafil fra filen «%s»."
+
+#: ../src/common/fileconf.cpp:421
+#, fuzzy
+msgid "failed to create the new file directory"
+msgstr "Klarte ikke finne gjeldende mappe"
+
+#: ../src/common/fileconf.cpp:428
+#, fuzzy
+msgid "failed to move the file to the new location"
+msgstr "Klarte ikke avslutte oppringingskoblingen: %s"
+
+#: ../src/common/fileconf.cpp:462
+#, c-format
+msgid "can't open global configuration file '%s'."
+msgstr "klarte ikke åpne global konfigurasjonsfil «%s»."
+
+#: ../src/common/fileconf.cpp:478
+#, c-format
+msgid "can't open user configuration file '%s'."
+msgstr "klarte ikke åpne bruker konfigurasjonsfil «%s»."
+
+#: ../src/common/fileconf.cpp:483
+#, c-format
+msgid "Changes won't be saved to avoid overwriting the existing file \"%s\""
+msgstr ""
+"Endringer vil ikke bli lagret for å unngå å overskrive eksisterende fil "
+"\"%s\""
+
+#: ../src/common/fileconf.cpp:583
+msgid "Error reading config options."
+msgstr "Feil ved lesing av konfigurasjonsvalg."
+
+#: ../src/common/fileconf.cpp:593
+#, fuzzy
+msgid "Failed to read config options."
+msgstr "Feil ved lesing av konfigurasjonsvalg."
+
+#: ../src/common/fileconf.cpp:700
+#, fuzzy, c-format
+msgid "file '%s': unexpected character %c at line %zu."
+msgstr "fil «%s»: uventet tegn %c på linje %d."
+
+#: ../src/common/fileconf.cpp:736
+#, fuzzy, c-format
+msgid "file '%s', line %zu: '%s' ignored after group header."
+msgstr "fil «%s», linje %d: «%s» ignorert etter gruppehode."
+
+#: ../src/common/fileconf.cpp:765
+#, fuzzy, c-format
+msgid "file '%s', line %zu: '=' expected."
+msgstr "fil «%s», linje %d: «=» forventet."
+
+#: ../src/common/fileconf.cpp:778
+#, fuzzy, c-format
+msgid "file '%s', line %zu: value for immutable key '%s' ignored."
+msgstr "file «%s», linje %d: verdi for uforanderlig nøkkel «%s» ignorert."
+
+#: ../src/common/fileconf.cpp:788
+#, fuzzy, c-format
+msgid "file '%s', line %zu: key '%s' was first found at line %d."
+msgstr "file «%s», linje %d: nøkkel «%s» ble først funnet på linje %d."
+
+#: ../src/common/fileconf.cpp:1091
+#, c-format
+msgid "Config entry name cannot start with '%c'."
+msgstr "Konfigurasjonsoppføring kan ikke starte med «%c»."
+
+#: ../src/common/fileconf.cpp:1146
+#, fuzzy
+msgid "Failed to create configuration file directory."
+msgstr "Klarte ikke oppdatere bruker konfigurasjonsfil."
+
+#: ../src/common/fileconf.cpp:1158
+msgid "can't open user configuration file."
+msgstr "klarte ikke åpne bruker konfigurasjonsfil."
+
+#: ../src/common/fileconf.cpp:1172
+msgid "can't write user configuration file."
+msgstr "klarte ikke skrive til bruker konfigurasjonsfil."
+
+#: ../src/common/fileconf.cpp:1178
+msgid "Failed to update user configuration file."
+msgstr "Klarte ikke oppdatere bruker konfigurasjonsfil."
+
+#: ../src/common/fileconf.cpp:1201
+msgid "Error saving user configuration data."
+msgstr "Feil ved lagring av brukerkonfigurasjonsdata."
+
+#: ../src/common/fileconf.cpp:1313
+#, c-format
+msgid "can't delete user configuration file '%s'"
+msgstr "klarte ikke slette file «%s» for brukerkonfigurasjon"
+
+#: ../src/common/fileconf.cpp:2007
+#, c-format
+msgid "entry '%s' appears more than once in group '%s'"
+msgstr "oppføring «%s» forekommer mer enn en gang i gruppen «%s»"
+
+#: ../src/common/fileconf.cpp:2021
+#, c-format
+msgid "attempt to change immutable key '%s' ignored."
+msgstr "forsøk på å endre uforanderlig nøkkel «%s» ignorert."
+
+#: ../src/common/fileconf.cpp:2118
+#, c-format
+msgid "trailing backslash ignored in '%s'"
+msgstr ""
+
+#: ../src/common/fileconf.cpp:2153
+#, c-format
+msgid "unexpected \" at position %d in '%s'."
+msgstr "uventet \" i posisjon %d i «%s»."
+
+#: ../src/common/filefn.cpp:474
+#, c-format
+msgid "Failed to copy the file '%s' to '%s'"
+msgstr "Klarte ikke kopiere file «%s» til «%s»."
+
+#: ../src/common/filefn.cpp:487
+#, c-format
+msgid "Impossible to get permissions for file '%s'"
+msgstr "Klarte ikke få tak i rettigheter for filen «%s»"
+
+#: ../src/common/filefn.cpp:501
+#, c-format
+msgid "Impossible to overwrite the file '%s'"
+msgstr "Klarte ikke overskrive filen «%s»"
+
+#: ../src/common/filefn.cpp:508
+#, fuzzy, c-format
+msgid "Error copying the file '%s' to '%s'."
+msgstr "Klarte ikke kopiere file «%s» til «%s»."
+
+#: ../src/common/filefn.cpp:556
+#, c-format
+msgid "Impossible to set permissions for the file '%s'"
+msgstr "Klarte ikke sette rettigheter for filen «%s»"
+
+#: ../src/common/filefn.cpp:606
+#, c-format
+msgid ""
+"Failed to rename the file '%s' to '%s' because the destination file already "
+"exists."
+msgstr ""
+"Klarte ikke å døpe om fil '%s' til '%s' fordi navnet allerede er i bruk."
+
+#: ../src/common/filefn.cpp:623
+#, fuzzy, c-format
+msgid "File '%s' couldn't be renamed '%s'"
+msgstr "Mappe «%s» kunne ikke opprettes"
+
+#: ../src/common/filefn.cpp:639
+#, fuzzy, c-format
+msgid "File '%s' couldn't be removed"
+msgstr "Mappe «%s» kunne ikke opprettes"
+
+#: ../src/common/filefn.cpp:666
+#, c-format
+msgid "Directory '%s' couldn't be created"
+msgstr "Mappe «%s» kunne ikke opprettes"
+
+#: ../src/common/filefn.cpp:680
+#, fuzzy, c-format
+msgid "Directory '%s' couldn't be deleted"
+msgstr "Mappe «%s» kunne ikke opprettes"
+
+#: ../src/common/filefn.cpp:714
+#, c-format
+msgid "Cannot enumerate files '%s'"
+msgstr "Klarte ikke telle opp filer «%s»"
+
+#: ../src/common/filefn.cpp:798
+msgid "Failed to get the working directory"
+msgstr "Klarte ikke finne gjeldende mappe"
+
+#: ../src/common/filefn.cpp:843
+#, fuzzy
+msgid "Could not set current working directory"
+msgstr "Klarte ikke finne gjeldende mappe"
+
+#: ../src/common/filefn.cpp:974
+#, c-format
+msgid "Files (%s)"
+msgstr "Filer (%s)"
+
+#: ../src/common/filename.cpp:182
+#, fuzzy, c-format
+msgid "Failed to open '%s' for reading"
+msgstr "Klarte ikke åpne «%s» for «%s»"
+
+#: ../src/common/filename.cpp:187
+#, fuzzy, c-format
+msgid "Failed to open '%s' for writing"
+msgstr "Klarte ikke åpne «%s» for «%s»"
+
+#: ../src/common/filename.cpp:199
+msgid "Failed to close file handle"
+msgstr "Klarte ikke lukke filreferanse"
+
+#: ../src/common/filename.cpp:1046
+msgid "Failed to create a temporary file name"
+msgstr "Klarte ikke opprette et midlertidig filnavn"
+
+#: ../src/common/filename.cpp:1081
+msgid "Failed to open temporary file."
+msgstr "Klarte ikke åpne midlertidig fil."
+
+#: ../src/common/filename.cpp:2862
+#, c-format
+msgid "Failed to modify file times for '%s'"
+msgstr "Klarte ikke endre filtid for «%s»"
+
+#: ../src/common/filename.cpp:2877
+#, c-format
+msgid "Failed to touch the file '%s'"
+msgstr "Klarte ikke rør filen «%s»"
+
+#: ../src/common/filename.cpp:2958
+#, c-format
+msgid "Failed to retrieve file times for '%s'"
+msgstr "Klart ikke hente filtid for «%s»"
+
+#: ../src/common/filepickercmn.cpp:39 ../src/common/filepickercmn.cpp:40
+msgid "Browse"
+msgstr "Bla gjennom"
+
+#: ../src/common/fldlgcmn.cpp:792 ../src/generic/filectrlg.cpp:1185
+#, c-format
+msgid "All files (%s)|%s"
+msgstr "Alle filer (%s)|%s"
+
+#. TRANSLATORS: %s are a file extension used to build a file wildcard string
+#: ../src/common/fldlgcmn.cpp:810
+#, c-format
+msgid "%s files (%s)|%s"
+msgstr "%s filer (%s)|%s"
+
+#: ../src/common/fldlgcmn.cpp:1072
+#, c-format
+msgid "Load %s file"
+msgstr "Laster %s fil"
+
+#: ../src/common/fldlgcmn.cpp:1074
+#, c-format
+msgid "Save %s file"
+msgstr "Lagre %s fil"
+
+#: ../src/common/fmapbase.cpp:144
+msgid "Western European (ISO-8859-1)"
+msgstr "Vesteuropeisk (ISO-8859-1)"
+
+#: ../src/common/fmapbase.cpp:145
+msgid "Central European (ISO-8859-2)"
+msgstr "Sentraleuropeisk (ISO-8859-2)"
+
+#: ../src/common/fmapbase.cpp:146
+msgid "Esperanto (ISO-8859-3)"
+msgstr "Esperanto (ISO-8859-3)"
+
+#: ../src/common/fmapbase.cpp:147
+msgid "Baltic (old) (ISO-8859-4)"
+msgstr "Baltisk (gammel) (ISO-8859-4)"
+
+#: ../src/common/fmapbase.cpp:148
+msgid "Cyrillic (ISO-8859-5)"
+msgstr "Kyrillisk (ISO-8859-5)"
+
+#: ../src/common/fmapbase.cpp:149
+msgid "Arabic (ISO-8859-6)"
+msgstr "Arabisk (ISO-8859-6)"
+
+#: ../src/common/fmapbase.cpp:150
+msgid "Greek (ISO-8859-7)"
+msgstr "Gresk (ISO-8859-7)"
+
+#: ../src/common/fmapbase.cpp:151
+msgid "Hebrew (ISO-8859-8)"
+msgstr "Hebraisk (ISO-8859-8)"
+
+#: ../src/common/fmapbase.cpp:152
+msgid "Turkish (ISO-8859-9)"
+msgstr "Tyrkisk (ISO-8859-9)"
+
+#: ../src/common/fmapbase.cpp:153
+msgid "Nordic (ISO-8859-10)"
+msgstr "Nordisk (ISO-8859-10)"
+
+#: ../src/common/fmapbase.cpp:154
+msgid "Thai (ISO-8859-11)"
+msgstr "Thai (ISO-8859-11)"
+
+#: ../src/common/fmapbase.cpp:155
+msgid "Indian (ISO-8859-12)"
+msgstr "Indisk (ISO-8859-12)"
+
+#: ../src/common/fmapbase.cpp:156
+msgid "Baltic (ISO-8859-13)"
+msgstr "Baltisk (ISO-8859-13)"
+
+#: ../src/common/fmapbase.cpp:157
+msgid "Celtic (ISO-8859-14)"
+msgstr "Keltisk (ISO-8859-14)"
+
+#: ../src/common/fmapbase.cpp:158
+msgid "Western European with Euro (ISO-8859-15)"
+msgstr "Vesteuropeisk med euro (ISO-8859-15)"
+
+#: ../src/common/fmapbase.cpp:159
+msgid "KOI8-R"
+msgstr "KOI8-R"
+
+#: ../src/common/fmapbase.cpp:160
+msgid "KOI8-U"
+msgstr "KOI8-U"
+
+#: ../src/common/fmapbase.cpp:161
+msgid "Windows/DOS OEM Cyrillic (CP 866)"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:162
+msgid "Windows Thai (CP 874)"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:163
+#, fuzzy
+msgid "Windows Japanese (CP 932) or Shift-JIS"
+msgstr "Windows japansk (CP 932)"
+
+#: ../src/common/fmapbase.cpp:164
+#, fuzzy
+msgid "Windows Chinese Simplified (CP 936) or GB-2312"
+msgstr "Windows kinesisk med enkle tegn (CP 936)"
+
+#: ../src/common/fmapbase.cpp:165
+msgid "Windows Korean (CP 949)"
+msgstr "Windows koreansk (CP 949)"
+
+#: ../src/common/fmapbase.cpp:166
+#, fuzzy
+msgid "Windows Chinese Traditional (CP 950) or Big-5"
+msgstr "Windows kinesisk (CP 950)"
+
+#: ../src/common/fmapbase.cpp:167
+msgid "Windows Central European (CP 1250)"
+msgstr "Windows sentraleuropeisk (CP 1250)"
+
+#: ../src/common/fmapbase.cpp:168
+msgid "Windows Cyrillic (CP 1251)"
+msgstr "Windows kyrillisk (CP 1251)"
+
+#: ../src/common/fmapbase.cpp:169
+msgid "Windows Western European (CP 1252)"
+msgstr "Windows vesteuropeisk (CP 1252)"
+
+#: ../src/common/fmapbase.cpp:170
+msgid "Windows Greek (CP 1253)"
+msgstr "Windows gresk (CP 1253)"
+
+#: ../src/common/fmapbase.cpp:171
+msgid "Windows Turkish (CP 1254)"
+msgstr "Windows tyrkisk (CP 1254)"
+
+#: ../src/common/fmapbase.cpp:172
+msgid "Windows Hebrew (CP 1255)"
+msgstr "Windows hebraisk (CP 1255)"
+
+#: ../src/common/fmapbase.cpp:173
+msgid "Windows Arabic (CP 1256)"
+msgstr "Windows arabisk (CP 1256)"
+
+#: ../src/common/fmapbase.cpp:174
+msgid "Windows Baltic (CP 1257)"
+msgstr "Windows baltisk (CP 1257)"
+
+#: ../src/common/fmapbase.cpp:175
+msgid "Windows Vietnamese (CP 1258)"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:176
+msgid "Windows Johab (CP 1361)"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:177
+msgid "Windows/DOS OEM (CP 437)"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:178
+msgid "Unicode 7 bit (UTF-7)"
+msgstr "Unicode 7 bit (UTF-7)"
+
+#: ../src/common/fmapbase.cpp:179
+msgid "Unicode 8 bit (UTF-8)"
+msgstr "Unicode 8 bit (UTF-8)"
+
+#: ../src/common/fmapbase.cpp:181 ../src/common/fmapbase.cpp:187
+msgid "Unicode 16 bit (UTF-16)"
+msgstr "Unicode 16 bit (UTF-16)"
+
+#: ../src/common/fmapbase.cpp:182
+msgid "Unicode 16 bit Little Endian (UTF-16LE)"
+msgstr "Unicode 16 bit Little Endian (UTF-16LE)"
+
+#: ../src/common/fmapbase.cpp:183 ../src/common/fmapbase.cpp:189
+msgid "Unicode 32 bit (UTF-32)"
+msgstr "Unicode 32 bit (UTF-32)"
+
+#: ../src/common/fmapbase.cpp:184
+msgid "Unicode 32 bit Little Endian (UTF-32LE)"
+msgstr "Unicode 32 bit Little Endian (UTF-32LE)"
+
+#: ../src/common/fmapbase.cpp:186
+msgid "Unicode 16 bit Big Endian (UTF-16BE)"
+msgstr "Unicode 16 bit Big Endian (UTF-16BE)"
+
+#: ../src/common/fmapbase.cpp:188
+msgid "Unicode 32 bit Big Endian (UTF-32BE)"
+msgstr "Unicode 32 bit Big Endian (UTF-32BE)"
+
+#: ../src/common/fmapbase.cpp:191
+msgid "Extended Unix Codepage for Japanese (EUC-JP)"
+msgstr "Utvidet Unix tegntabell for japansk (EUC-JP)"
+
+#: ../src/common/fmapbase.cpp:192
+#, fuzzy
+msgid "US-ASCII"
+msgstr "ASCII"
+
+#: ../src/common/fmapbase.cpp:193
+msgid "ISO-2022-JP"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:195
+#, fuzzy
+msgid "MacRoman"
+msgstr "Roman"
+
+#: ../src/common/fmapbase.cpp:196
+msgid "MacJapanese"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:197
+msgid "MacChineseTrad"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:198
+msgid "MacKorean"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:199
+msgid "MacArabic"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:200
+msgid "MacHebrew"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:201
+msgid "MacGreek"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:202
+msgid "MacCyrillic"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:203
+msgid "MacDevanagari"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:204
+msgid "MacGurmukhi"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:205
+msgid "MacGujarati"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:206
+msgid "MacOriya"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:207
+msgid "MacBengali"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:208
+msgid "MacTamil"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:209
+msgid "MacTelugu"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:210
+msgid "MacKannada"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:211
+msgid "MacMalayalam"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:212
+#, fuzzy
+msgid "MacSinhalese"
+msgstr "Skill mellom store og små bokstaver"
+
+#: ../src/common/fmapbase.cpp:213
+msgid "MacBurmese"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:214
+msgid "MacKhmer"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:215
+msgid "MacThai"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:216
+msgid "MacLaotian"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:217
+msgid "MacGeorgian"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:218
+msgid "MacArmenian"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:219
+msgid "MacChineseSimp"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:220
+msgid "MacTibetan"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:221
+msgid "MacMongolian"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:222
+msgid "MacEthiopic"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:223
+msgid "MacCentralEurRoman"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:224
+msgid "MacVietnamese"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:225
+msgid "MacExtArabic"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:226
+#, fuzzy
+msgid "MacSymbol"
+msgstr "&Stil:"
+
+#: ../src/common/fmapbase.cpp:227
+msgid "MacDingbats"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:228
+msgid "MacTurkish"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:229
+msgid "MacCroatian"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:230
+msgid "MacIcelandic"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:231
+#, fuzzy
+msgid "MacRomanian"
+msgstr "Roman"
+
+#: ../src/common/fmapbase.cpp:232
+msgid "MacCeltic"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:233
+msgid "MacGaelic"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:234
+msgid "MacKeyboardGlyphs"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:791
+msgid "Default encoding"
+msgstr "Standardkoding"
+
+#: ../src/common/fmapbase.cpp:805
+#, c-format
+msgid "Unknown encoding (%d)"
+msgstr "Ukjent koding (%d)"
+
+#: ../src/common/fmapbase.cpp:815 ../src/richtext/richtextstyles.cpp:776
+msgid "default"
+msgstr "standard"
+
+#: ../src/common/fmapbase.cpp:829
+#, c-format
+msgid "unknown-%d"
+msgstr "ukjent-%d"
+
+#: ../src/common/fontcmn.cpp:924 ../src/common/fontcmn.cpp:1130
+msgid "underlined"
+msgstr "understreket"
+
+#: ../src/common/fontcmn.cpp:929
+msgid " strikethrough"
+msgstr "streke over"
+
+#: ../src/common/fontcmn.cpp:942
+msgid " thin"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:946
+#, fuzzy
+msgid " extra light"
+msgstr "lett"
+
+#: ../src/common/fontcmn.cpp:950
+#, fuzzy
+msgid " light"
+msgstr "lett"
+
+#: ../src/common/fontcmn.cpp:954
+msgid " medium"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:958
+#, fuzzy
+msgid " semi bold"
+msgstr "fet"
+
+#: ../src/common/fontcmn.cpp:962
+#, fuzzy
+msgid " bold"
+msgstr "fet"
+
+#: ../src/common/fontcmn.cpp:966
+#, fuzzy
+msgid " extra bold"
+msgstr "fet"
+
+#: ../src/common/fontcmn.cpp:970
+msgid " heavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:974
+msgid " extra heavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:990
+#, fuzzy
+msgid " italic"
+msgstr "kursiv"
+
+#: ../src/common/fontcmn.cpp:1134
+msgid "strikethrough"
+msgstr "overstrek"
+
+#: ../src/common/fontcmn.cpp:1143
+msgid "thin"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1156
+#, fuzzy
+msgid "extralight"
+msgstr "lett"
+
+#: ../src/common/fontcmn.cpp:1161
+msgid "light"
+msgstr "lett"
+
+#: ../src/common/fontcmn.cpp:1169 ../src/richtext/richtextstyles.cpp:775
+#, fuzzy
+msgid "normal"
+msgstr "Normal"
+
+#: ../src/common/fontcmn.cpp:1174
+msgid "medium"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1179 ../src/common/fontcmn.cpp:1199
+#, fuzzy
+msgid "semibold"
+msgstr "fet"
+
+#: ../src/common/fontcmn.cpp:1184
+msgid "bold"
+msgstr "fet"
+
+#: ../src/common/fontcmn.cpp:1194
+#, fuzzy
+msgid "extrabold"
+msgstr "fet"
+
+#: ../src/common/fontcmn.cpp:1204
+msgid "heavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1212
+msgid "extraheavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1217
+msgid "italic"
+msgstr "kursiv"
+
+#: ../src/common/fontmap.cpp:195
+msgid ": unknown charset"
+msgstr ": ukjent tegnsett"
+
+#: ../src/common/fontmap.cpp:199
+#, c-format
+msgid ""
+"The charset '%s' is unknown. You may select\n"
+"another charset to replace it with or choose\n"
+"[Cancel] if it cannot be replaced"
+msgstr ""
+"Tegnsettet «%s» er ukjent. Velg et annet tegnsett\n"
+"eller velg [Avbryt] hvis det ikke kan byttes ut."
+
+#: ../src/common/fontmap.cpp:241
+#, c-format
+msgid "Failed to remember the encoding for the charset '%s'."
+msgstr "Klarte ikke huske kodingen for tegnsettet «%s»."
+
+#: ../src/common/fontmap.cpp:321
+msgid "can't load any font, aborting"
+msgstr "klarte ikke laste noe skrifter, avbryter"
+
+#: ../src/common/fontmap.cpp:409
+msgid ": unknown encoding"
+msgstr ": ukjent koding"
+
+#: ../src/common/fontmap.cpp:417
+#, c-format
+msgid ""
+"No font for displaying text in encoding '%s' found,\n"
+"but an alternative encoding '%s' is available.\n"
+"Do you want to use this encoding (otherwise you will have to choose another "
+"one)?"
+msgstr ""
+"Ingen skrift for visning i koding «%s» funnet,\n"
+"men en alternativ koding «%s» er tilgjengelig.\n"
+"Vil du bruke denne koding (hvis ikke må du velge en annen)?"
+
+#: ../src/common/fontmap.cpp:422
+#, c-format
+msgid ""
+"No font for displaying text in encoding '%s' found.\n"
+"Would you like to select a font to be used for this encoding\n"
+"(otherwise the text in this encoding will not be shown correctly)?"
+msgstr ""
+"Ingen skrift for visning i koding «%s» funnet.\n"
+"Vil du velge en annen skrift for denne kodingen\n"
+"(hvis ikke vil teksten i denne kodingen bli vist feil)?"
+
+#: ../src/common/fs_mem.cpp:169
+#, c-format
+msgid "Memory VFS already contains file '%s'!"
+msgstr "Minne VFS inneholder allerede filen «%s»!"
+
+#: ../src/common/fs_mem.cpp:232
+#, c-format
+msgid "Trying to remove file '%s' from memory VFS, but it is not loaded!"
+msgstr "Prøvde å fjerne filen «%s» fra VFS minne, men den er ikke lastet!"
+
+#: ../src/common/fs_mem.cpp:262
+#, c-format
+msgid "Failed to store image '%s' to memory VFS!"
+msgstr "Klarte ikke lagre bilde «%s» til minne VFS!"
+
+#: ../src/common/ftp.cpp:197
+msgid "Timeout while waiting for FTP server to connect, try passive mode."
+msgstr "Tidsavbrudd under venting på FTP-tilkobling, prøv passiv modus."
+
+#: ../src/common/ftp.cpp:399
+#, c-format
+msgid "Failed to set FTP transfer mode to %s."
+msgstr "Klarte ikke sette FTP-overføringsmodus til %s."
+
+#: ../src/common/ftp.cpp:400 ../src/richtext/richtextsymboldlg.cpp:432
+msgid "ASCII"
+msgstr "ASCII"
+
+#: ../src/common/ftp.cpp:400
+msgid "binary"
+msgstr "binært"
+
+#: ../src/common/ftp.cpp:608
+msgid "The FTP server doesn't support the PORT command."
+msgstr "FTP-tjeneren støtter ikke PORT-kommandoen."
+
+#: ../src/common/ftp.cpp:622
+msgid "The FTP server doesn't support passive mode."
+msgstr "FTP-tjeneren støtter ikke passiv modus."
+
+#: ../src/common/gifdecod.cpp:822
+#, c-format
+msgid "Incorrect GIF frame size (%u, %d) for the frame #%u"
+msgstr ""
+
+#: ../src/common/glcmn.cpp:108
+#, fuzzy
+msgid "Failed to allocate colour for OpenGL"
+msgstr "Klarte ikke opprette peker."
+
+#: ../src/common/headerctrlcmn.cpp:57
+msgid "Please select the columns to show and define their order:"
+msgstr ""
+
+#: ../src/common/headerctrlcmn.cpp:58
+msgid "Customize Columns"
+msgstr "Selvvalgte kolonner"
+
+#: ../src/common/headerctrlcmn.cpp:304
+#, fuzzy
+msgid "&Customize..."
+msgstr "skriftstørrelse"
+
+#: ../src/common/hyperlnkcmn.cpp:132
+#, fuzzy, c-format
+msgid "Failed to open URL \"%s\" in the default browser"
+msgstr "Klarte ikke åpne «%s» for «%s»"
+
+#: ../src/common/iconbndl.cpp:195
+#, fuzzy, c-format
+msgid "Failed to load image %%d from file '%s'."
+msgstr "Klarte ikke laste bilde %d fra filen «%s»."
+
+#: ../src/common/iconbndl.cpp:203
+#, fuzzy, c-format
+msgid "Failed to load image %d from stream."
+msgstr "Klarte ikke laste bilde %d fra filen «%s»."
+
+#: ../src/common/iconbndl.cpp:221
+#, fuzzy, c-format
+msgid "Failed to load icons from resource '%s'."
+msgstr "Klarte ikke laste bilde %d fra filen «%s»."
+
+#: ../src/common/imagbmp.cpp:97
+msgid "BMP: Couldn't save invalid image."
+msgstr "BMP: Klarte ikke lagre ugyldig bilde."
+
+#: ../src/common/imagbmp.cpp:137
+msgid "BMP: wxImage doesn't have own wxPalette."
+msgstr "BMP: wxImage har ikke egen wxPalette."
+
+#: ../src/common/imagbmp.cpp:243
+msgid "BMP: Couldn't write the file (Bitmap) header."
+msgstr "BMP: Klarte ikke skrive filhodet (Bitmap)."
+
+#: ../src/common/imagbmp.cpp:266
+msgid "BMP: Couldn't write the file (BitmapInfo) header."
+msgstr "BMP: Klarte ikke skrive filehodet (BitmapInfo)."
+
+#: ../src/common/imagbmp.cpp:353
+msgid "BMP: Couldn't write RGB color map."
+msgstr "BMP: Klarte ikke skrive RGB-fargekart."
+
+#: ../src/common/imagbmp.cpp:487
+msgid "BMP: Couldn't write data."
+msgstr "BMP: Klarte ikke skrive data."
+
+#: ../src/common/imagbmp.cpp:561 ../src/common/imagbmp.cpp:642
+msgid "BMP: Couldn't allocate memory."
+msgstr "BMP: Klarte ikke reservere minne."
+
+#: ../src/common/imagbmp.cpp:1041
+msgid "DIB Header: Image width > 32767 pixels for file."
+msgstr "DIB-hode: Bildebredde > 32767 piksler for filen."
+
+#: ../src/common/imagbmp.cpp:1049
+msgid "DIB Header: Image height > 32767 pixels for file."
+msgstr "DIB-hode: Bildehøyde > 32767 piksler for filen."
+
+#: ../src/common/imagbmp.cpp:1081
+msgid "DIB Header: Unknown bitdepth in file."
+msgstr "DIB-hode: Ukjent bitdybde i filen."
+
+#: ../src/common/imagbmp.cpp:1156
+msgid "DIB Header: Unknown encoding in file."
+msgstr "DIB-hode: Ukjent koding i filen."
+
+#: ../src/common/imagbmp.cpp:1165
+msgid "DIB Header: Encoding doesn't match bitdepth."
+msgstr "DIB-hode: Koding stemmer ikke med bitdybde."
+
+#: ../src/common/imagbmp.cpp:1180
+#, c-format
+msgid "BMP Header: Invalid number of colors (%d)."
+msgstr ""
+
+#: ../src/common/imagbmp.cpp:1273
+#, fuzzy
+msgid "Error in reading image DIB."
+msgstr "Feil ved lesing av bilde DIB."
+
+#: ../src/common/imagbmp.cpp:1294
+msgid "ICO: Error in reading mask DIB."
+msgstr "ICO: Feil ved maskelesing DIB."
+
+#: ../src/common/imagbmp.cpp:1353
+msgid "ICO: Image too tall for an icon."
+msgstr "ICO: Bilde er for høyt for et ikon."
+
+#: ../src/common/imagbmp.cpp:1361
+msgid "ICO: Image too wide for an icon."
+msgstr "ICO: Bilde er for bredt for et ikon."
+
+#: ../src/common/imagbmp.cpp:1388 ../src/common/imagbmp.cpp:1488
+#: ../src/common/imagbmp.cpp:1503 ../src/common/imagbmp.cpp:1514
+#: ../src/common/imagbmp.cpp:1528 ../src/common/imagbmp.cpp:1576
+#: ../src/common/imagbmp.cpp:1591 ../src/common/imagbmp.cpp:1605
+#: ../src/common/imagbmp.cpp:1616
+msgid "ICO: Error writing the image file!"
+msgstr "ICO: Feil ved skriving av bildefil!"
+
+#: ../src/common/imagbmp.cpp:1701
+msgid "ICO: Invalid icon index."
+msgstr "ICO: Ugyldig ikonindeks"
+
+#: ../src/common/image.cpp:2410
+msgid "Image and mask have different sizes."
+msgstr "Bilde og maske har forskjellig størrelse."
+
+#: ../src/common/image.cpp:2418 ../src/common/image.cpp:2459
+msgid "No unused colour in image being masked."
+msgstr "Ingen ubrukte farger i bilde blir masket."
+
+#: ../src/common/image.cpp:2641
+#, fuzzy, c-format
+msgid "Failed to load bitmap \"%s\" from resources."
+msgstr "Klarte ikke laste bilde %d fra filen «%s»."
+
+#: ../src/common/image.cpp:2650
+#, fuzzy, c-format
+msgid "Failed to load icon \"%s\" from resources."
+msgstr "Klarte ikke laste bilde %d fra filen «%s»."
+
+#: ../src/common/image.cpp:2728 ../src/common/image.cpp:2747
+#, fuzzy, c-format
+msgid "Failed to load image from file \"%s\"."
+msgstr "Klarte ikke laste bilde %d fra filen «%s»."
+
+#: ../src/common/image.cpp:2761
+#, c-format
+msgid "Can't save image to file '%s': unknown extension."
+msgstr "Klarte ikke lagre bilde til filen «%s»: Ukjent filtype"
+
+#: ../src/common/image.cpp:2869
+msgid "No handler found for image type."
+msgstr "Ingen behandler funnet for bildetype."
+
+#: ../src/common/image.cpp:2877 ../src/common/image.cpp:3000
+#: ../src/common/image.cpp:3066
+#, c-format
+msgid "No image handler for type %d defined."
+msgstr "Ingen bildebehandler for type %d definert."
+
+#: ../src/common/image.cpp:2887
+#, fuzzy, c-format
+msgid "Image file is not of type %d."
+msgstr "Bildefil er ikke av type %d."
+
+#: ../src/common/image.cpp:2970
+msgid "Can't automatically determine the image format for non-seekable input."
+msgstr "Kan ikke automatisk bestemme bildeformatet."
+
+#: ../src/common/image.cpp:2988
+msgid "Unknown image data format."
+msgstr "Ukjent bildeformat"
+
+#: ../src/common/image.cpp:3009
+#, fuzzy, c-format
+msgid "This is not a %s."
+msgstr "PCX: Dette er ikke en PCX-fil"
+
+#: ../src/common/image.cpp:3032 ../src/common/image.cpp:3080
+#, c-format
+msgid "No image handler for type %s defined."
+msgstr "Ingen bildebehandler for type %s definert."
+
+#: ../src/common/image.cpp:3041
+#, fuzzy, c-format
+msgid "Image is not of type %s."
+msgstr "Bildefil er ikke av type %s."
+
+#: ../src/common/image.cpp:3509
+#, fuzzy, c-format
+msgid "Failed to check format of image file \"%s\"."
+msgstr "Klarte ikke lagre bitmap-bilde til filen «%s». "
+
+#: ../src/common/imaggif.cpp:124
+msgid "GIF: error in GIF image format."
+msgstr "GIF: Feil i GIF-bildeformat."
+
+#: ../src/common/imaggif.cpp:129
+msgid "GIF: not enough memory."
+msgstr "GIF: Ikke nok minne."
+
+#: ../src/common/imaggif.cpp:134
+msgid "GIF: data stream seems to be truncated."
+msgstr "GIF:Datastrømmen ser ut til å være trunkert."
+
+#: ../src/common/imaggif.cpp:240
+#, fuzzy
+msgid "Couldn't initialize GIF hash table."
+msgstr "Klarte ikke klargjøre zlib-strøm for nedpakking."
+
+#: ../src/common/imagiff.cpp:739
+msgid "IFF: error in IFF image format."
+msgstr "IFF: Feil i IFF-bildeformat."
+
+#: ../src/common/imagiff.cpp:742
+msgid "IFF: not enough memory."
+msgstr "IFF: Ikke nok minne."
+
+#: ../src/common/imagiff.cpp:745
+msgid "IFF: unknown error!!!"
+msgstr "IFF: Ukjent feil!"
+
+#: ../src/common/imagiff.cpp:755
+msgid "IFF: data stream seems to be truncated."
+msgstr "IFF: Datastrøm ser ut til å være trunkert."
+
+#: ../src/common/imagjpeg.cpp:258
+msgid "JPEG: Couldn't load - file is probably corrupted."
+msgstr "JPEG: Klarte ikke laste filen - sannsynligvis ødelagt."
+
+#: ../src/common/imagjpeg.cpp:437
+msgid "JPEG: Couldn't save image."
+msgstr "JPEG: Klarte ikke lagre bilde."
+
+#: ../src/common/imagpcx.cpp:439
+msgid "PCX: this is not a PCX file."
+msgstr "PCX: Dette er ikke en PCX-fil"
+
+#: ../src/common/imagpcx.cpp:453
+msgid "PCX: image format unsupported"
+msgstr "PCX: Bildeformat ikke støttet"
+
+#: ../src/common/imagpcx.cpp:454 ../src/common/imagpcx.cpp:477
+msgid "PCX: couldn't allocate memory"
+msgstr "PCX: Klarte ikke reservere minne"
+
+#: ../src/common/imagpcx.cpp:455
+msgid "PCX: version number too low"
+msgstr "PCX: Versjonsnummer er for lavt"
+
+#: ../src/common/imagpcx.cpp:456 ../src/common/imagpcx.cpp:478
+msgid "PCX: unknown error !!!"
+msgstr "PCX: Ukjent feil!"
+
+#: ../src/common/imagpcx.cpp:476
+msgid "PCX: invalid image"
+msgstr "PCX: Ugyldig bilde"
+
+#: ../src/common/imagpng.cpp:385
+#, fuzzy, c-format
+msgid "Unknown PNG resolution unit %d"
+msgstr "Ukjent opsjon «%s»"
+
+#: ../src/common/imagpng.cpp:439
+msgid "Couldn't load a PNG image - file is corrupted or not enough memory."
+msgstr ""
+"Klarte ikke laste PNG-bilde - filen er ødelagt er det er for lite minne."
+
+#: ../src/common/imagpng.cpp:513 ../src/common/imagpng.cpp:524
+#: ../src/common/imagpng.cpp:534
+msgid "Couldn't save PNG image."
+msgstr "Klarte ikke lagre PNG-bilde."
+
+#: ../src/common/imagpnm.cpp:71
+msgid "PNM: File format is not recognized."
+msgstr "PNM: Filformat ikke gjenkjent"
+
+#: ../src/common/imagpnm.cpp:89
+msgid "PNM: Couldn't allocate memory."
+msgstr "PNM: Klarte ikke reservere minne."
+
+#: ../src/common/imagpnm.cpp:111 ../src/common/imagpnm.cpp:134
+#: ../src/common/imagpnm.cpp:156
+msgid "PNM: File seems truncated."
+msgstr "PNM: Filen ser ut til å være trunkert."
+
+#: ../src/common/imagtiff.cpp:69
+#, fuzzy, c-format
+msgid " (in module \"%s\")"
+msgstr "TIFF-modul: %s"
+
+#: ../src/common/imagtiff.cpp:304
+msgid "TIFF: Error loading image."
+msgstr "TIFF: Feil ved bildelasting."
+
+#: ../src/common/imagtiff.cpp:314
+msgid "Invalid TIFF image index."
+msgstr "Ugyldig TIFF bildeindeks."
+
+#: ../src/common/imagtiff.cpp:358
+msgid "TIFF: Image size is abnormally big."
+msgstr "TIFF: Bildet er unormalt stort."
+
+#: ../src/common/imagtiff.cpp:372 ../src/common/imagtiff.cpp:385
+#: ../src/common/imagtiff.cpp:769
+msgid "TIFF: Couldn't allocate memory."
+msgstr "TIFF: Klarte ikke reservere minne."
+
+#: ../src/common/imagtiff.cpp:471
+msgid "TIFF: Error reading image."
+msgstr "TIFF: Feil ved bildelesing."
+
+#: ../src/common/imagtiff.cpp:532
+#, c-format
+msgid "Unknown TIFF resolution unit %d ignored"
+msgstr "Ukjent enhet %d for oppløsning i TIFF ble ignorert"
+
+#: ../src/common/imagtiff.cpp:611
+msgid "TIFF: Error saving image."
+msgstr "TIFF: Feil ved lagring av bilde."
+
+#: ../src/common/imagtiff.cpp:868
+msgid "TIFF: Error writing image."
+msgstr "TIFF: Feil ved skriving av bilde."
+
+#: ../src/common/imagtiff.cpp:881
+#, fuzzy
+msgid "TIFF: Error flushing data."
+msgstr "TIFF: Feil ved lagring av bilde."
+
+#: ../src/common/imagwebp.cpp:56
+msgid "WebP: Invalid data (failed to get features)."
+msgstr ""
+
+#: ../src/common/imagwebp.cpp:65
+msgid "WebP: Allocating image memory failed."
+msgstr ""
+
+#: ../src/common/imagwebp.cpp:82
+msgid "WebP: Decoding RGBA image data failed."
+msgstr ""
+
+#: ../src/common/imagwebp.cpp:98
+msgid "WebP: Decoding RGB image data failed."
+msgstr ""
+
+#: ../src/common/imagwebp.cpp:113 ../src/common/imagwebp.cpp:201
+msgid "WebP: Allocating stream buffer failed."
+msgstr ""
+
+#: ../src/common/imagwebp.cpp:131
+#, fuzzy
+msgid "WebP: Failed to parse container data."
+msgstr "Klarte ikke sette utklippstavledata."
+
+#: ../src/common/imagwebp.cpp:222
+#, fuzzy
+msgid "WebP: Error decoding animation."
+msgstr "Feil ved lesing av konfigurasjonsvalg."
+
+#: ../src/common/imagwebp.cpp:240
+msgid "WebP: Error getting next animation frame."
+msgstr ""
+
+#: ../src/common/init.cpp:172
+#, c-format
+msgid ""
+"Command line argument %d couldn't be converted to Unicode and will be "
+"ignored."
+msgstr ""
+
+#: ../src/common/init.cpp:344
+msgid "Initialization failed in post init, aborting."
+msgstr ""
+
+#: ../src/common/intl.cpp:378
+#, c-format
+msgid "Cannot set locale to language \"%s\"."
+msgstr "Kan ikke sette språket til \"%s\"."
+
+#: ../src/common/log.cpp:232
+msgid "Error: "
+msgstr "Feil:"
+
+#: ../src/common/log.cpp:236
+msgid "Warning: "
+msgstr "Advarsel:"
+
+#: ../src/common/log.cpp:284
+msgid "The previous message repeated once."
+msgstr "Den forrige meldingen repetert en gang."
+
+#: ../src/common/log.cpp:291
+#, c-format
+msgid "The previous message repeated %u time."
+msgid_plural "The previous message repeated %u times."
+msgstr[0] "Den forrige meldingen repetert %u gang."
+msgstr[1] "Den forrige meldingen repetert %u ganger."
+
+#: ../src/common/log.cpp:319
+#, c-format
+msgid "Last repeated message (\"%s\", %u time) wasn't output"
+msgid_plural "Last repeated message (\"%s\", %u times) wasn't output"
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../src/common/log.cpp:435
+#, c-format
+msgid " (error %ld: %s)"
+msgstr "(feil %ld: %s)"
+
+#: ../src/common/lzmastream.cpp:121
+#, fuzzy
+msgid "Failed to allocate memory for LZMA decompression."
+msgstr "Klarte ikke opprette peker."
+
+#: ../src/common/lzmastream.cpp:125
+#, c-format
+msgid "Failed to initialize LZMA decompression: unexpected error %u."
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:179
+msgid "input is not in XZ format"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:183
+msgid "input compressed using unknown XZ option"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:188
+msgid "input is corrupted"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:192
+#, fuzzy
+msgid "unknown decompression error"
+msgstr "feil ved utpakking"
+
+#: ../src/common/lzmastream.cpp:196
+#, fuzzy, c-format
+msgid "LZMA decompression error: %s"
+msgstr "feil ved utpakking"
+
+#: ../src/common/lzmastream.cpp:231
+#, fuzzy
+msgid "Failed to allocate memory for LZMA compression."
+msgstr "Klarte ikke opprette peker."
+
+#: ../src/common/lzmastream.cpp:235
+#, c-format
+msgid "Failed to initialize LZMA compression: unexpected error %u."
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:267 ../src/common/lzmastream.cpp:342
+#: ../src/html/chm.cpp:336
+msgid "out of memory"
+msgstr "tom for minne"
+
+#: ../src/common/lzmastream.cpp:276 ../src/common/lzmastream.cpp:346
+#, fuzzy
+msgid "unknown compression error"
+msgstr "kompresjonsfeil"
+
+#: ../src/common/lzmastream.cpp:280
+#, fuzzy, c-format
+msgid "LZMA compression error: %s"
+msgstr "kompresjonsfeil"
+
+#: ../src/common/lzmastream.cpp:350
+#, c-format
+msgid "LZMA compression error when flushing output: %s"
+msgstr ""
+
+#: ../src/common/mimecmn.cpp:167
+#, c-format
+msgid "Unmatched '{' in an entry for mime type %s."
+msgstr "Ubalansert «{» i en oppføring for mime-type %s."
+
+#: ../src/common/module.cpp:76
+#, c-format
+msgid "Circular dependency involving module \"%s\" detected."
+msgstr "Sirkulær avhengighet i modulen \"%s\" er oppdaget."
+
+#: ../src/common/module.cpp:128
+#, c-format
+msgid "Dependency \"%s\" of module \"%s\" doesn't exist."
+msgstr ""
+
+#: ../src/common/module.cpp:137
+#, c-format
+msgid "Module \"%s\" initialization failed"
+msgstr ""
+
+#: ../src/common/msgout.cpp:96
+msgid "Message"
+msgstr "Melding"
+
+#: ../src/common/paper.cpp:70
+msgid "Letter, 8 1/2 x 11 in"
+msgstr "Letter, 8 1/2 x 11 tommer"
+
+#: ../src/common/paper.cpp:71
+msgid "Legal, 8 1/2 x 14 in"
+msgstr "Legal, 8 1/2 x 14 in"
+
+#: ../src/common/paper.cpp:72
+msgid "A4 sheet, 210 x 297 mm"
+msgstr "A4-ark, 210 x 297 mm"
+
+#: ../src/common/paper.cpp:73
+msgid "C sheet, 17 x 22 in"
+msgstr "C-ark, 17 x 22 tommer"
+
+#: ../src/common/paper.cpp:74
+msgid "D sheet, 22 x 34 in"
+msgstr "D-ark, 22 x 34 tommer"
+
+#: ../src/common/paper.cpp:75
+msgid "E sheet, 34 x 44 in"
+msgstr "E-ark, 34 x 44 tommer"
+
+#: ../src/common/paper.cpp:76
+msgid "Letter Small, 8 1/2 x 11 in"
+msgstr "Letter (lite), 8 1/2 x 11 tommer"
+
+#: ../src/common/paper.cpp:77
+msgid "Tabloid, 11 x 17 in"
+msgstr "Tabloid, 11 x 17 tommer"
+
+#: ../src/common/paper.cpp:78
+msgid "Ledger, 17 x 11 in"
+msgstr "Ledger, 17 x 11 in"
+
+#: ../src/common/paper.cpp:79
+msgid "Statement, 5 1/2 x 8 1/2 in"
+msgstr "Statement, 5 1/2 x 8 1/2 tommer"
+
+#: ../src/common/paper.cpp:80
+msgid "Executive, 7 1/4 x 10 1/2 in"
+msgstr "Executive, 7 1/4 x 10 1/2 tommer"
+
+#: ../src/common/paper.cpp:81
+msgid "A3 sheet, 297 x 420 mm"
+msgstr "A3-ark, 297 x 420 mm"
+
+#: ../src/common/paper.cpp:82
+msgid "A4 small sheet, 210 x 297 mm"
+msgstr "A4-ark (små), 210 x 297 mm "
+
+#: ../src/common/paper.cpp:83
+msgid "A5 sheet, 148 x 210 mm"
+msgstr "A5-ark, 148 x 210 mm"
+
+#: ../src/common/paper.cpp:84
+msgid "B4 sheet, 250 x 354 mm"
+msgstr "B4-ark, 250 x 354 mm"
+
+#: ../src/common/paper.cpp:85
+msgid "B5 sheet, 182 x 257 millimeter"
+msgstr "B5-ark, 182 x 257 mm"
+
+#: ../src/common/paper.cpp:86
+msgid "Folio, 8 1/2 x 13 in"
+msgstr "Folio, 8 1/2 x 13 tommer"
+
+#: ../src/common/paper.cpp:87
+msgid "Quarto, 215 x 275 mm"
+msgstr "Quarto, 215 x 275 mm"
+
+#: ../src/common/paper.cpp:88
+msgid "10 x 14 in"
+msgstr "10 x 14 tommer"
+
+#: ../src/common/paper.cpp:89
+msgid "11 x 17 in"
+msgstr "11 x 17 tommer"
+
+#: ../src/common/paper.cpp:90
+msgid "Note, 8 1/2 x 11 in"
+msgstr "Notat, 8 1/2 x 11 tommer"
+
+#: ../src/common/paper.cpp:91
+msgid "#9 Envelope, 3 7/8 x 8 7/8 in"
+msgstr "#9 konvolutt, 3 7/8 x 8 7/8 tommer"
+
+#: ../src/common/paper.cpp:92
+msgid "#10 Envelope, 4 1/8 x 9 1/2 in"
+msgstr "#10 konvolutt, 4 1/8 x 9 1/2 tommer"
+
+#: ../src/common/paper.cpp:93
+msgid "#11 Envelope, 4 1/2 x 10 3/8 in"
+msgstr "#11 konvolutt, 4 1/2 x 10 3/8 tommer"
+
+#: ../src/common/paper.cpp:94
+msgid "#12 Envelope, 4 3/4 x 11 in"
+msgstr "#12 konvolutt, 4 3/4 x 11 tommer"
+
+#: ../src/common/paper.cpp:95
+msgid "#14 Envelope, 5 x 11 1/2 in"
+msgstr "#14 konvolutt, 5 x 11 1/2 tommer"
+
+#: ../src/common/paper.cpp:96
+msgid "DL Envelope, 110 x 220 mm"
+msgstr "DL-konvolutt, 110 x 220 mm"
+
+#: ../src/common/paper.cpp:97
+msgid "C5 Envelope, 162 x 229 mm"
+msgstr "C5-konvolutt, 162 x 229 mm"
+
+#: ../src/common/paper.cpp:98
+msgid "C3 Envelope, 324 x 458 mm"
+msgstr "C3-konvolutt, 324 x 458 mm"
+
+#: ../src/common/paper.cpp:99
+msgid "C4 Envelope, 229 x 324 mm"
+msgstr "C4-konvolutt, 229 x 324 mm"
+
+#: ../src/common/paper.cpp:100
+msgid "C6 Envelope, 114 x 162 mm"
+msgstr "C6-konvoluttm 114 x 162 mm"
+
+#: ../src/common/paper.cpp:101
+msgid "C65 Envelope, 114 x 229 mm"
+msgstr "C65-konvolutt, 114 x 229 mm"
+
+#: ../src/common/paper.cpp:102
+msgid "B4 Envelope, 250 x 353 mm"
+msgstr "B4-konvolutt, 250 x 353 mm"
+
+#: ../src/common/paper.cpp:103
+msgid "B5 Envelope, 176 x 250 mm"
+msgstr "B5-konvolutt, 176 x 250 mm"
+
+#: ../src/common/paper.cpp:104
+msgid "B6 Envelope, 176 x 125 mm"
+msgstr "B6-konvolutt, 176 x 125 mm"
+
+#: ../src/common/paper.cpp:105
+msgid "Italy Envelope, 110 x 230 mm"
+msgstr "Italia-konvolutt, 110 x 230 mm"
+
+#: ../src/common/paper.cpp:106
+msgid "Monarch Envelope, 3 7/8 x 7 1/2 in"
+msgstr "Monark-konvolutt, 3 7/8 x 7 1/2 tommer"
+
+#: ../src/common/paper.cpp:107
+msgid "6 3/4 Envelope, 3 5/8 x 6 1/2 in"
+msgstr "6 3/4 konvolutt, 3 5/8 x 6 1/2 tommer"
+
+#: ../src/common/paper.cpp:108
+msgid "US Std Fanfold, 14 7/8 x 11 in"
+msgstr "Amerikansk standard papir, 14 7/8 x 11 tommer"
+
+#: ../src/common/paper.cpp:109
+msgid "German Std Fanfold, 8 1/2 x 12 in"
+msgstr "Tysk vanlig papir, 8 1/2 x 12 tommer"
+
+#: ../src/common/paper.cpp:110
+msgid "German Legal Fanfold, 8 1/2 x 13 in"
+msgstr "Tysk juridisk papir, 8 1/2 x 13 tommer"
+
+#: ../src/common/paper.cpp:112
+#, fuzzy
+msgid "B4 (ISO) 250 x 353 mm"
+msgstr "B4-ark, 250 x 354 mm"
+
+#: ../src/common/paper.cpp:113
+msgid "Japanese Postcard 100 x 148 mm"
+msgstr ""
+
+#: ../src/common/paper.cpp:114
+#, fuzzy
+msgid "9 x 11 in"
+msgstr "11 x 17 tommer"
+
+#: ../src/common/paper.cpp:115
+#, fuzzy
+msgid "10 x 11 in"
+msgstr "10 x 14 tommer"
+
+#: ../src/common/paper.cpp:116
+#, fuzzy
+msgid "15 x 11 in"
+msgstr "10 x 14 tommer"
+
+#: ../src/common/paper.cpp:117
+#, fuzzy
+msgid "Envelope Invite 220 x 220 mm"
+msgstr "DL-konvolutt, 11 x 220 mm"
+
+#: ../src/common/paper.cpp:118
+#, fuzzy
+msgid "Letter Extra 9 1/2 x 12 in"
+msgstr "Letter, 8 1/2 x 11 tommer"
+
+#: ../src/common/paper.cpp:119
+#, fuzzy
+msgid "Legal Extra 9 1/2 x 15 in"
+msgstr "Legal, 8 1/2 x 14 in"
+
+#: ../src/common/paper.cpp:120
+#, fuzzy
+msgid "Tabloid Extra 11.69 x 18 in"
+msgstr "Tabloid, 11 x 17 tommer"
+
+#: ../src/common/paper.cpp:121
+msgid "A4 Extra 9.27 x 12.69 in"
+msgstr ""
+
+#: ../src/common/paper.cpp:122
+#, fuzzy
+msgid "Letter Transverse 8 1/2 x 11 in"
+msgstr "Letter, 8 1/2 x 11 tommer"
+
+#: ../src/common/paper.cpp:123
+#, fuzzy
+msgid "A4 Transverse 210 x 297 mm"
+msgstr "A4-ark, 210 x 297 mm"
+
+#: ../src/common/paper.cpp:124
+msgid "Letter Extra Transverse 9.275 x 12 in"
+msgstr ""
+
+#: ../src/common/paper.cpp:125
+msgid "SuperA/SuperA/A4 227 x 356 mm"
+msgstr ""
+
+#: ../src/common/paper.cpp:126
+msgid "SuperB/SuperB/A3 305 x 487 mm"
+msgstr ""
+
+#: ../src/common/paper.cpp:127
+#, fuzzy
+msgid "Letter Plus 8 1/2 x 12.69 in"
+msgstr "Letter, 8 1/2 x 11 tommer"
+
+#: ../src/common/paper.cpp:128
+#, fuzzy
+msgid "A4 Plus 210 x 330 mm"
+msgstr "A4-ark, 210 x 297 mm"
+
+#: ../src/common/paper.cpp:129
+#, fuzzy
+msgid "A5 Transverse 148 x 210 mm"
+msgstr "A5-ark, 148 x 210 mm"
+
+#: ../src/common/paper.cpp:130
+#, fuzzy
+msgid "B5 (JIS) Transverse 182 x 257 mm"
+msgstr "B5-ark, 182 x 257 mm"
+
+#: ../src/common/paper.cpp:131
+#, fuzzy
+msgid "A3 Extra 322 x 445 mm"
+msgstr "C3-konvolutt, 324 x 458 mm"
+
+#: ../src/common/paper.cpp:132
+#, fuzzy
+msgid "A5 Extra 174 x 235 mm"
+msgstr "A5-ark, 148 x 210 mm"
+
+#: ../src/common/paper.cpp:133
+msgid "B5 (ISO) Extra 201 x 276 mm"
+msgstr ""
+
+#: ../src/common/paper.cpp:134
+msgid "A2 420 x 594 mm"
+msgstr ""
+
+#: ../src/common/paper.cpp:135
+#, fuzzy
+msgid "A3 Transverse 297 x 420 mm"
+msgstr "A3-ark, 297 x 420 mm"
+
+#: ../src/common/paper.cpp:136
+#, fuzzy
+msgid "A3 Extra Transverse 322 x 445 mm"
+msgstr "C3-konvolutt, 324 x 458 mm"
+
+#: ../src/common/paper.cpp:138
+msgid "Japanese Double Postcard 200 x 148 mm"
+msgstr ""
+
+#: ../src/common/paper.cpp:139
+#, fuzzy
+msgid "A6 105 x 148 mm"
+msgstr "10 x 14 tommer"
+
+#: ../src/common/paper.cpp:140
+msgid "Japanese Envelope Kaku #2"
+msgstr ""
+
+#: ../src/common/paper.cpp:141
+msgid "Japanese Envelope Kaku #3"
+msgstr ""
+
+#: ../src/common/paper.cpp:142
+msgid "Japanese Envelope Chou #3"
+msgstr ""
+
+#: ../src/common/paper.cpp:143
+msgid "Japanese Envelope Chou #4"
+msgstr ""
+
+#: ../src/common/paper.cpp:144
+#, fuzzy
+msgid "Letter Rotated 11 x 8 1/2 in"
+msgstr "Letter, 8 1/2 x 11 tommer"
+
+#: ../src/common/paper.cpp:145
+#, fuzzy
+msgid "A3 Rotated 420 x 297 mm"
+msgstr "A4-ark, 210 x 297 mm"
+
+#: ../src/common/paper.cpp:146
+#, fuzzy
+msgid "A4 Rotated 297 x 210 mm"
+msgstr "A3-ark, 297 x 420 mm"
+
+#: ../src/common/paper.cpp:147
+msgid "A5 Rotated 210 x 148 mm"
+msgstr "A5 Rotert 210 x 148 mm"
+
+#: ../src/common/paper.cpp:148
+msgid "B4 (JIS) Rotated 364 x 257 mm"
+msgstr "B4 (JIS) Rotert 364 x 257 mm"
+
+#: ../src/common/paper.cpp:149
+msgid "B5 (JIS) Rotated 257 x 182 mm"
+msgstr "B5 (JIS) Rotert 257 x 182 mm"
+
+#: ../src/common/paper.cpp:150
+msgid "Japanese Postcard Rotated 148 x 100 mm"
+msgstr ""
+
+#: ../src/common/paper.cpp:151
+msgid "Double Japanese Postcard Rotated 148 x 200 mm"
+msgstr ""
+
+#: ../src/common/paper.cpp:152
+#, fuzzy
+msgid "A6 Rotated 148 x 105 mm"
+msgstr "A5-ark, 148 x 210 mm"
+
+#: ../src/common/paper.cpp:153
+msgid "Japanese Envelope Kaku #2 Rotated"
+msgstr ""
+
+#: ../src/common/paper.cpp:154
+msgid "Japanese Envelope Kaku #3 Rotated"
+msgstr ""
+
+#: ../src/common/paper.cpp:155
+msgid "Japanese Envelope Chou #3 Rotated"
+msgstr ""
+
+#: ../src/common/paper.cpp:156
+msgid "Japanese Envelope Chou #4 Rotated"
+msgstr ""
+
+#: ../src/common/paper.cpp:157
+msgid "B6 (JIS) 128 x 182 mm"
+msgstr ""
+
+#: ../src/common/paper.cpp:158
+msgid "B6 (JIS) Rotated 182 x 128 mm"
+msgstr "B6 (JIS) Rotert 182 x 128 mm"
+
+#: ../src/common/paper.cpp:159
+#, fuzzy
+msgid "12 x 11 in"
+msgstr "10 x 14 tommer"
+
+#: ../src/common/paper.cpp:160
+msgid "Japanese Envelope You #4"
+msgstr ""
+
+#: ../src/common/paper.cpp:161
+msgid "Japanese Envelope You #4 Rotated"
+msgstr ""
+
+#: ../src/common/paper.cpp:162
+msgid "PRC 16K 146 x 215 mm"
+msgstr ""
+
+#: ../src/common/paper.cpp:163
+msgid "PRC 32K 97 x 151 mm"
+msgstr ""
+
+#: ../src/common/paper.cpp:164
+msgid "PRC 32K(Big) 97 x 151 mm"
+msgstr ""
+
+#: ../src/common/paper.cpp:165
+#, fuzzy
+msgid "PRC Envelope #1 102 x 165 mm"
+msgstr "C6-konvoluttm 114 x 162 mm"
+
+#: ../src/common/paper.cpp:166
+#, fuzzy
+msgid "PRC Envelope #2 102 x 176 mm"
+msgstr "C6-konvoluttm 114 x 162 mm"
+
+#: ../src/common/paper.cpp:167
+#, fuzzy
+msgid "PRC Envelope #3 125 x 176 mm"
+msgstr "C6-konvoluttm 114 x 162 mm"
+
+#: ../src/common/paper.cpp:168
+#, fuzzy
+msgid "PRC Envelope #4 110 x 208 mm"
+msgstr "DL-konvolutt, 11 x 220 mm"
+
+#: ../src/common/paper.cpp:169
+#, fuzzy
+msgid "PRC Envelope #5 110 x 220 mm"
+msgstr "DL-konvolutt, 11 x 220 mm"
+
+#: ../src/common/paper.cpp:170
+#, fuzzy
+msgid "PRC Envelope #6 120 x 230 mm"
+msgstr "C5-konvolutt, 162 x 229 mm"
+
+#: ../src/common/paper.cpp:171
+#, fuzzy
+msgid "PRC Envelope #7 160 x 230 mm"
+msgstr "B5-konvolutt, 176 x 250 mm"
+
+#: ../src/common/paper.cpp:172
+#, fuzzy
+msgid "PRC Envelope #8 120 x 309 mm"
+msgstr "C5-konvolutt, 162 x 229 mm"
+
+#: ../src/common/paper.cpp:173
+#, fuzzy
+msgid "PRC Envelope #9 229 x 324 mm"
+msgstr "C4-konvolutt, 229 x 324 mm"
+
+#: ../src/common/paper.cpp:174
+#, fuzzy
+msgid "PRC Envelope #10 324 x 458 mm"
+msgstr "C3-konvolutt, 324 x 458 mm"
+
+#: ../src/common/paper.cpp:175
+msgid "PRC 16K Rotated"
+msgstr ""
+
+#: ../src/common/paper.cpp:176
+msgid "PRC 32K Rotated"
+msgstr ""
+
+#: ../src/common/paper.cpp:177
+msgid "PRC 32K(Big) Rotated"
+msgstr ""
+
+#: ../src/common/paper.cpp:178
+#, fuzzy
+msgid "PRC Envelope #1 Rotated 165 x 102 mm"
+msgstr "C6-konvoluttm 114 x 162 mm"
+
+#: ../src/common/paper.cpp:179
+#, fuzzy
+msgid "PRC Envelope #2 Rotated 176 x 102 mm"
+msgstr "B6-konvolutt, 176 x 125 mm"
+
+#: ../src/common/paper.cpp:180
+#, fuzzy
+msgid "PRC Envelope #3 Rotated 176 x 125 mm"
+msgstr "B6-konvolutt, 176 x 125 mm"
+
+#: ../src/common/paper.cpp:181
+#, fuzzy
+msgid "PRC Envelope #4 Rotated 208 x 110 mm"
+msgstr "C6-konvoluttm 114 x 162 mm"
+
+#: ../src/common/paper.cpp:182
+#, fuzzy
+msgid "PRC Envelope #5 Rotated 220 x 110 mm"
+msgstr "C4-konvolutt, 229 x 324 mm"
+
+#: ../src/common/paper.cpp:183
+#, fuzzy
+msgid "PRC Envelope #6 Rotated 230 x 120 mm"
+msgstr "C5-konvolutt, 162 x 229 mm"
+
+#: ../src/common/paper.cpp:184
+#, fuzzy
+msgid "PRC Envelope #7 Rotated 230 x 160 mm"
+msgstr "C6-konvoluttm 114 x 162 mm"
+
+#: ../src/common/paper.cpp:185
+#, fuzzy
+msgid "PRC Envelope #8 Rotated 309 x 120 mm"
+msgstr "C4-konvolutt, 229 x 324 mm"
+
+#: ../src/common/paper.cpp:186
+#, fuzzy
+msgid "PRC Envelope #9 Rotated 324 x 229 mm"
+msgstr "C5-konvolutt, 162 x 229 mm"
+
+#: ../src/common/paper.cpp:187
+#, fuzzy
+msgid "PRC Envelope #10 Rotated 458 x 324 mm"
+msgstr "C4-konvolutt, 229 x 324 mm"
+
+#: ../src/common/paper.cpp:192
+#, fuzzy
+msgid "A0 sheet, 841 x 1189 mm"
+msgstr "A4-ark, 210 x 297 mm"
+
+#: ../src/common/paper.cpp:193
+#, fuzzy
+msgid "A1 sheet, 594 x 841 mm"
+msgstr "A3-ark, 297 x 420 mm"
+
+#: ../src/common/preferencescmn.cpp:37
+msgid "General"
+msgstr "Generell"
+
+#: ../src/common/preferencescmn.cpp:40
+msgid "Advanced"
+msgstr "Avansert"
+
+#: ../src/common/prntbase.cpp:245
+msgid "Generic PostScript"
+msgstr "Generisk PostScript"
+
+#: ../src/common/prntbase.cpp:259
+msgid "Ready"
+msgstr "Klar"
+
+#: ../src/common/prntbase.cpp:331
+msgid "Printing Error"
+msgstr "Feil ved utskrift"
+
+#: ../src/common/prntbase.cpp:413 ../src/common/prntbase.cpp:1597
+#: ../src/generic/prntdlgg.cpp:135 ../src/generic/prntdlgg.cpp:149
+#: ../src/gtk/print.cpp:628 ../src/gtk/print.cpp:646
+msgid "Print"
+msgstr "Utskrift"
+
+#: ../src/common/prntbase.cpp:471 ../src/generic/prntdlgg.cpp:809
+msgid "Page setup"
+msgstr "Sideoppsett"
+
+#: ../src/common/prntbase.cpp:525
+#, fuzzy
+msgid "Please wait while printing..."
+msgstr "Vent mens utskriften pågår\n"
+
+#: ../src/common/prntbase.cpp:529
+msgid "Document:"
+msgstr "Dokument:"
+
+#: ../src/common/prntbase.cpp:532
+msgid "Progress:"
+msgstr "Framdrift:"
+
+#: ../src/common/prntbase.cpp:533
+msgid "Preparing"
+msgstr "Forbereder"
+
+#: ../src/common/prntbase.cpp:552
+#, fuzzy, c-format
+msgid "Printing page %d"
+msgstr "Skriver ut side %d..."
+
+#: ../src/common/prntbase.cpp:557
+#, fuzzy, c-format
+msgid "Printing page %d of %d"
+msgstr "Skriver ut side %d..."
+
+#: ../src/common/prntbase.cpp:560
+#, fuzzy, c-format
+msgid " (copy %d of %d)"
+msgstr "Side %d av %d"
+
+#: ../src/common/prntbase.cpp:1604
+msgid "First page"
+msgstr "Første side"
+
+#: ../src/common/prntbase.cpp:1609 ../src/html/helpwnd.cpp:659
+msgid "Previous page"
+msgstr "Forrige side"
+
+#: ../src/common/prntbase.cpp:1623 ../src/html/helpwnd.cpp:660
+msgid "Next page"
+msgstr "Neste side"
+
+#: ../src/common/prntbase.cpp:1628
+msgid "Last page"
+msgstr "Siste side"
+
+#: ../src/common/prntbase.cpp:1636 ../src/common/stockitem.cpp:215
+#, fuzzy
+msgid "Zoom Out"
+msgstr "Vis &mindre"
+
+#: ../src/common/prntbase.cpp:1650 ../src/common/stockitem.cpp:214
+#, fuzzy
+msgid "Zoom In"
+msgstr "Vis &større"
+
+#: ../src/common/prntbase.cpp:1656 ../src/common/stockitem.cpp:153
+#: ../src/generic/logg.cpp:553 ../src/univ/themes/win32.cpp:3752
+msgid "&Close"
+msgstr "&Lukk"
+
+#: ../src/common/prntbase.cpp:2085
+msgid "Could not start document preview."
+msgstr "Klarte ikke starte dokumentforhåndsvisning."
+
+#: ../src/common/prntbase.cpp:2085 ../src/common/prntbase.cpp:2129
+#: ../src/common/prntbase.cpp:2137
+msgid "Print Preview Failure"
+msgstr "Feil ved forhåndsvisning av utskrift"
+
+#: ../src/common/prntbase.cpp:2129 ../src/common/prntbase.cpp:2137
+msgid "Sorry, not enough memory to create a preview."
+msgstr "Ikke nok minne til å lage en forhåndsvisning."
+
+#: ../src/common/prntbase.cpp:2144
+#, c-format
+msgid "Page %d of %d"
+msgstr "Side %d av %d"
+
+#: ../src/common/prntbase.cpp:2146
+#, c-format
+msgid "Page %d"
+msgstr "Side %d"
+
+#: ../src/common/regex.cpp:382 ../src/html/chm.cpp:348
+msgid "unknown error"
+msgstr "ukjent feil "
+
+#: ../src/common/regex.cpp:995
+#, c-format
+msgid "Invalid regular expression '%s': %s"
+msgstr "Ugyldig regulært uttrykk «%s»: %s"
+
+#: ../src/common/regex.cpp:1059
+#, fuzzy, c-format
+msgid "Failed to find match for regular expression: %s"
+msgstr "Fant ingen treff for «%s» i regulært uttrykk: %s"
+
+#: ../src/common/rendcmn.cpp:188
+#, c-format
+msgid "Renderer \"%s\" has incompatible version %d.%d and couldn't be loaded."
+msgstr "Utfører «%s» har ikke-kompatibel versjon %d.%d og ble ikke lastet."
+
+#: ../src/common/secretstore.cpp:162
+msgid "Not available for this platform"
+msgstr ""
+
+#: ../src/common/secretstore.cpp:183
+#, fuzzy, c-format
+msgid "Saving password for \"%s\" failed: %s."
+msgstr "Utpakking av «%s» inni «%s» feilet."
+
+#: ../src/common/secretstore.cpp:205
+#, fuzzy, c-format
+msgid "Reading password for \"%s\" failed: %s."
+msgstr "Utpakking av «%s» inni «%s» feilet."
+
+#: ../src/common/secretstore.cpp:228
+#, fuzzy, c-format
+msgid "Deleting password for \"%s\" failed: %s."
+msgstr "Utpakking av «%s» inni «%s» feilet."
+
+#: ../src/common/selectdispatcher.cpp:254
+msgid "Failed to monitor I/O channels"
+msgstr "Klarte ikke å overvåke I/O-kanalene"
+
+#: ../src/common/sizer.cpp:3054 ../src/common/stockitem.cpp:195
+msgid "Save"
+msgstr "&Lagre"
+
+#: ../src/common/sizer.cpp:3056
+msgid "Don't Save"
+msgstr "Ikke lagre"
+
+#: ../src/common/socket.cpp:870
+#, fuzzy
+msgid "Cannot initialize sockets"
+msgstr "Klarte ikke initialisere OLE"
+
+#: ../src/common/stockitem.cpp:127
+#, fuzzy
+msgctxt "standard Windows menu"
+msgid "&Help"
+msgstr "&Hjelp"
+
+#: ../src/common/stockitem.cpp:144
+msgid "&About"
+msgstr "&Om"
+
+#: ../src/common/stockitem.cpp:144
+#, fuzzy
+msgid "About"
+msgstr "%Om"
+
+#: ../src/common/stockitem.cpp:145
+msgid "Add"
+msgstr "Legg till"
+
+#: ../src/common/stockitem.cpp:146
+msgid "&Apply"
+msgstr "&Bruk"
+
+#: ../src/common/stockitem.cpp:146
+#, fuzzy
+msgid "Apply"
+msgstr "&Bruk"
+
+#: ../src/common/stockitem.cpp:147
+msgid "&Back"
+msgstr "&Tilbake"
+
+#: ../src/common/stockitem.cpp:147
+#, fuzzy
+msgid "Back"
+msgstr "&Tilbake"
+
+#: ../src/common/stockitem.cpp:148
+msgid "&Bold"
+msgstr "&Fet"
+
+#: ../src/common/stockitem.cpp:148 ../src/generic/fontdlgg.cpp:326
+#: ../src/richtext/richtextfontpage.cpp:354
+msgid "Bold"
+msgstr "Fet"
+
+#: ../src/common/stockitem.cpp:149
+msgid "&Bottom"
+msgstr "&Bunn"
+
+#: ../src/common/stockitem.cpp:149 ../src/richtext/richtextsizepage.cpp:287
+msgid "Bottom"
+msgstr "Bunn"
+
+#: ../src/common/stockitem.cpp:150 ../src/generic/fontdlgg.cpp:462
+#: ../src/generic/fontdlgg.cpp:481 ../src/generic/wizard.cpp:415
+msgid "&Cancel"
+msgstr "&Avbryt"
+
+#: ../src/common/stockitem.cpp:151
+msgid "&CD-ROM"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:151
+msgid "CD-ROM"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:152
+msgid "&Clear"
+msgstr "&Fjern"
+
+#: ../src/common/stockitem.cpp:152
+#, fuzzy
+msgid "Clear"
+msgstr "&Fjern"
+
+#: ../src/common/stockitem.cpp:153 ../src/generic/dbgrptg.cpp:93
+#: ../src/generic/progdlgg.cpp:778 ../src/html/helpdlg.cpp:86
+#: ../src/msw/progdlg.cpp:209 ../src/msw/progdlg.cpp:890
+#: ../src/richtext/richtextstyledlg.cpp:272
+#: ../src/richtext/richtextsymboldlg.cpp:448
+msgid "Close"
+msgstr "Lukk"
+
+#: ../src/common/stockitem.cpp:154
+#, fuzzy
+msgid "&Convert"
+msgstr "Innhold"
+
+#: ../src/common/stockitem.cpp:154
+#, fuzzy
+msgid "Convert"
+msgstr "Innhold"
+
+#: ../src/common/stockitem.cpp:155 ../src/msw/textctrl.cpp:2884
+#: ../src/osx/textctrl_osx.cpp:653 ../src/richtext/richtextctrl.cpp:331
+msgid "&Copy"
+msgstr "&Kopier"
+
+#: ../src/common/stockitem.cpp:155 ../src/stc/stc_i18n.cpp:18
+#, fuzzy
+msgid "Copy"
+msgstr "&Kopier"
+
+#: ../src/common/stockitem.cpp:156 ../src/msw/textctrl.cpp:2883
+#: ../src/osx/textctrl_osx.cpp:652 ../src/richtext/richtextctrl.cpp:330
+msgid "Cu&t"
+msgstr "Klipp u&t"
+
+#: ../src/common/stockitem.cpp:156 ../src/stc/stc_i18n.cpp:17
+msgid "Cut"
+msgstr "Klipp u&t"
+
+#: ../src/common/stockitem.cpp:157 ../src/msw/textctrl.cpp:2886
+#: ../src/osx/textctrl_osx.cpp:655 ../src/richtext/richtextctrl.cpp:333
+#: ../src/richtext/richtexttabspage.cpp:137
+msgid "&Delete"
+msgstr "&Slett"
+
+#: ../src/common/stockitem.cpp:157 ../src/richtext/richtextbuffer.cpp:8266
+#: ../src/stc/stc_i18n.cpp:20
+#, fuzzy
+msgid "Delete"
+msgstr "&Slett"
+
+#: ../src/common/stockitem.cpp:158
+msgid "&Down"
+msgstr "&ned"
+
+#: ../src/common/stockitem.cpp:158 ../src/generic/fdrepdlg.cpp:148
+msgid "Down"
+msgstr "Ned"
+
+#: ../src/common/stockitem.cpp:159
+msgid "&Edit"
+msgstr "&Rediger"
+
+#: ../src/common/stockitem.cpp:159
+#, fuzzy
+msgid "Edit"
+msgstr "Redigere element"
+
+#: ../src/common/stockitem.cpp:160
+msgid "&Execute"
+msgstr "&Utfør"
+
+#: ../src/common/stockitem.cpp:160
+msgid "Execute"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:161
+msgid "&Quit"
+msgstr "&Slutt"
+
+#: ../src/common/stockitem.cpp:161
+#, fuzzy
+msgid "Quit"
+msgstr "&Slutt"
+
+#: ../src/common/stockitem.cpp:162
+msgid "&File"
+msgstr "&Fil"
+
+#: ../src/common/stockitem.cpp:162
+msgid "File"
+msgstr "Fil"
+
+#: ../src/common/stockitem.cpp:163
+#, fuzzy
+msgid "&Find..."
+msgstr "&Finn"
+
+#: ../src/common/stockitem.cpp:163
+#, fuzzy
+msgid "Find..."
+msgstr "Finn"
+
+#: ../src/common/stockitem.cpp:164
+#, fuzzy
+msgid "&First"
+msgstr "først"
+
+#: ../src/common/stockitem.cpp:164
+#, fuzzy
+msgid "First"
+msgstr "først"
+
+#: ../src/common/stockitem.cpp:165
+#, fuzzy
+msgid "&Floppy"
+msgstr "&Kopier"
+
+#: ../src/common/stockitem.cpp:165
+msgid "Floppy"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:166
+msgid "&Forward"
+msgstr "&Fremover"
+
+#: ../src/common/stockitem.cpp:166
+#, fuzzy
+msgid "Forward"
+msgstr "&Fremover"
+
+#: ../src/common/stockitem.cpp:167
+msgid "&Harddisk"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:167
+msgid "Harddisk"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:168 ../src/generic/wizard.cpp:418
+#: ../src/osx/cocoa/menu.mm:225 ../src/richtext/richtextstyledlg.cpp:298
+#: ../src/richtext/richtextsymboldlg.cpp:451
+msgid "&Help"
+msgstr "&Hjelp"
+
+#: ../src/common/stockitem.cpp:169
+msgid "&Home"
+msgstr "&Hjem"
+
+#: ../src/common/stockitem.cpp:169
+msgid "Home"
+msgstr "Hjem"
+
+#: ../src/common/stockitem.cpp:170
+msgid "Indent"
+msgstr "Innrykk"
+
+#: ../src/common/stockitem.cpp:171
+msgid "&Index"
+msgstr "&Indeks"
+
+#: ../src/common/stockitem.cpp:171 ../src/html/helpwnd.cpp:510
+msgid "Index"
+msgstr "Indeks"
+
+#: ../src/common/stockitem.cpp:172
+#, fuzzy
+msgid "&Info"
+msgstr "&Angre"
+
+#: ../src/common/stockitem.cpp:172
+msgid "Info"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:173
+msgid "&Italic"
+msgstr "&Kursiv"
+
+#: ../src/common/stockitem.cpp:173 ../src/generic/fontdlgg.cpp:322
+#: ../src/richtext/richtextfontpage.cpp:350
+msgid "Italic"
+msgstr "Kursiv"
+
+#: ../src/common/stockitem.cpp:174
+msgid "&Jump to"
+msgstr "&Hopp til"
+
+#: ../src/common/stockitem.cpp:174
+msgid "Jump to"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:175
+msgid "Centered"
+msgstr "Sentrert"
+
+#: ../src/common/stockitem.cpp:176
+msgid "Justified"
+msgstr "Justert"
+
+#: ../src/common/stockitem.cpp:177
+msgid "Align Left"
+msgstr "Venstrejustering"
+
+#: ../src/common/stockitem.cpp:178
+msgid "Align Right"
+msgstr "Høyrejustering"
+
+#: ../src/common/stockitem.cpp:179
+#, fuzzy
+msgid "&Last"
+msgstr "&Lim inn"
+
+#: ../src/common/stockitem.cpp:179
+msgid "Last"
+msgstr "Siste"
+
+#: ../src/common/stockitem.cpp:180
+#, fuzzy
+msgid "&Network"
+msgstr "&Ny"
+
+#: ../src/common/stockitem.cpp:180
+msgid "Network"
+msgstr "Nettverk"
+
+#: ../src/common/stockitem.cpp:181 ../src/richtext/richtexttabspage.cpp:131
+msgid "&New"
+msgstr "&Ny"
+
+#: ../src/common/stockitem.cpp:181
+#, fuzzy
+msgid "New"
+msgstr "&Ny"
+
+#: ../src/common/stockitem.cpp:182 ../src/msw/msgdlg.cpp:417
+msgid "&No"
+msgstr "&Nei"
+
+#: ../src/common/stockitem.cpp:183 ../src/generic/fontdlgg.cpp:467
+#: ../src/generic/fontdlgg.cpp:474
+msgid "&OK"
+msgstr "&OK"
+
+#: ../src/common/stockitem.cpp:184 ../src/generic/dbgrptg.cpp:341
+msgid "&Open..."
+msgstr "&Åpne..."
+
+#: ../src/common/stockitem.cpp:184
+#, fuzzy
+msgid "Open..."
+msgstr "&Åpne..."
+
+#: ../src/common/stockitem.cpp:185 ../src/msw/textctrl.cpp:2885
+#: ../src/osx/textctrl_osx.cpp:654 ../src/richtext/richtextctrl.cpp:332
+msgid "&Paste"
+msgstr "&Lim inn"
+
+#: ../src/common/stockitem.cpp:185 ../src/richtext/richtextctrl.cpp:3484
+#: ../src/stc/stc_i18n.cpp:19
+#, fuzzy
+msgid "Paste"
+msgstr "&Lim inn"
+
+#: ../src/common/stockitem.cpp:186
+msgid "&Preferences"
+msgstr "&Innstillinger"
+
+#: ../src/common/stockitem.cpp:186 ../src/osx/cocoa/preferences.mm:304
+#, fuzzy
+msgid "Preferences"
+msgstr "&Innstillinger"
+
+#: ../src/common/stockitem.cpp:187
+#, fuzzy
+msgid "Print previe&w..."
+msgstr "&Forhåndsvisning av utskrift"
+
+#: ../src/common/stockitem.cpp:187
+#, fuzzy
+msgid "Print preview..."
+msgstr "&Forhåndsvisning av utskrift"
+
+#: ../src/common/stockitem.cpp:188
+msgid "&Print..."
+msgstr "&Skriv ut..."
+
+#: ../src/common/stockitem.cpp:188
+#, fuzzy
+msgid "Print..."
+msgstr "&Skriv ut..."
+
+#: ../src/common/stockitem.cpp:189 ../src/richtext/richtextctrl.cpp:337
+#: ../src/richtext/richtextctrl.cpp:5479
+msgid "&Properties"
+msgstr "&Egenskaper"
+
+#: ../src/common/stockitem.cpp:189
+#, fuzzy
+msgid "Properties"
+msgstr "&Egenskaper"
+
+#: ../src/common/stockitem.cpp:190 ../src/stc/stc_i18n.cpp:16
+#, fuzzy
+msgid "Redo"
+msgstr "&Gjenta"
+
+#: ../src/common/stockitem.cpp:191
+msgid "Refresh"
+msgstr "Oppdater"
+
+#: ../src/common/stockitem.cpp:192
+msgid "Remove"
+msgstr "Slett"
+
+#: ../src/common/stockitem.cpp:193
+#, fuzzy
+msgid "Rep&lace..."
+msgstr "Er&statt"
+
+#: ../src/common/stockitem.cpp:193
+#, fuzzy
+msgid "Replace..."
+msgstr "&Erstatt"
+
+#: ../src/common/stockitem.cpp:194
+msgid "Revert to Saved"
+msgstr "Gå tilbake til lagret versjon"
+
+#: ../src/common/stockitem.cpp:196 ../src/generic/logg.cpp:549
+msgid "Save &As..."
+msgstr "Lagre &som..."
+
+#: ../src/common/stockitem.cpp:196
+#, fuzzy
+msgid "Save As..."
+msgstr "Lagre &som..."
+
+#: ../src/common/stockitem.cpp:197 ../src/msw/textctrl.cpp:2888
+#: ../src/osx/textctrl_osx.cpp:657 ../src/richtext/richtextctrl.cpp:335
+msgid "Select &All"
+msgstr "Velg &alle"
+
+#: ../src/common/stockitem.cpp:197 ../src/stc/stc_i18n.cpp:21
+#, fuzzy
+msgid "Select All"
+msgstr "Velg &alle"
+
+#: ../src/common/stockitem.cpp:198
+#, fuzzy
+msgid "&Color"
+msgstr "&Farge"
+
+#: ../src/common/stockitem.cpp:198
+#, fuzzy
+msgid "Color"
+msgstr "&Farge"
+
+#: ../src/common/stockitem.cpp:199
+#, fuzzy
+msgid "&Font"
+msgstr "&Skriftfamilie:"
+
+#: ../src/common/stockitem.cpp:199 ../src/richtext/richtextformatdlg.cpp:336
+msgid "Font"
+msgstr "Skrift"
+
+#: ../src/common/stockitem.cpp:200
+msgid "&Ascending"
+msgstr "&Stigende"
+
+#: ../src/common/stockitem.cpp:200
+#, fuzzy
+msgid "Ascending"
+msgstr "leser"
+
+#: ../src/common/stockitem.cpp:201
+msgid "&Descending"
+msgstr "&Synkende"
+
+#: ../src/common/stockitem.cpp:201
+#, fuzzy
+msgid "Descending"
+msgstr "Standardkoding"
+
+#: ../src/common/stockitem.cpp:202
+msgid "&Spell Check"
+msgstr "&Stavekontroll"
+
+#: ../src/common/stockitem.cpp:202
+msgid "Spell Check"
+msgstr "Stavekontroll"
+
+#: ../src/common/stockitem.cpp:203
+msgid "&Stop"
+msgstr "&Stopp"
+
+#: ../src/common/stockitem.cpp:203
+#, fuzzy
+msgid "Stop"
+msgstr "&Stopp"
+
+#: ../src/common/stockitem.cpp:204 ../src/richtext/richtextfontpage.cpp:274
+msgid "&Strikethrough"
+msgstr "&Streke over"
+
+#: ../src/common/stockitem.cpp:204
+msgid "Strikethrough"
+msgstr "Overstreke"
+
+#: ../src/common/stockitem.cpp:205
+#, fuzzy
+msgid "&Top"
+msgstr "&Kopier"
+
+#: ../src/common/stockitem.cpp:205 ../src/richtext/richtextsizepage.cpp:285
+#: ../src/richtext/richtextsizepage.cpp:289
+msgid "Top"
+msgstr "Topp"
+
+#: ../src/common/stockitem.cpp:206
+msgid "Undelete"
+msgstr "Angre sletting"
+
+#: ../src/common/stockitem.cpp:207 ../src/generic/fontdlgg.cpp:437
+msgid "&Underline"
+msgstr "&Strek under"
+
+#: ../src/common/stockitem.cpp:207
+#, fuzzy
+msgid "Underline"
+msgstr "&Strek under"
+
+#: ../src/common/stockitem.cpp:208 ../src/stc/stc_i18n.cpp:15
+#, fuzzy
+msgid "Undo"
+msgstr "&Angre"
+
+#: ../src/common/stockitem.cpp:209
+msgid "&Unindent"
+msgstr "&Fjern innrykk"
+
+#: ../src/common/stockitem.cpp:209
+#, fuzzy
+msgid "Unindent"
+msgstr "&Fjern innrykk"
+
+#: ../src/common/stockitem.cpp:210
+msgid "&Up"
+msgstr "&Opp"
+
+#: ../src/common/stockitem.cpp:210 ../src/generic/fdrepdlg.cpp:148
+msgid "Up"
+msgstr "Opp"
+
+#: ../src/common/stockitem.cpp:211 ../src/msw/msgdlg.cpp:417
+msgid "&Yes"
+msgstr "&Ja"
+
+#: ../src/common/stockitem.cpp:212
+msgid "&Actual Size"
+msgstr "&Faktisk størrelse"
+
+#: ../src/common/stockitem.cpp:212
+#, fuzzy
+msgid "Actual Size"
+msgstr "&Faktisk størrelse"
+
+#: ../src/common/stockitem.cpp:213
+msgid "Zoom to &Fit"
+msgstr "Tilpass til skjerm"
+
+#: ../src/common/stockitem.cpp:213
+#, fuzzy
+msgid "Zoom to Fit"
+msgstr "Tilpass til skjerm"
+
+#: ../src/common/stockitem.cpp:214
+msgid "Zoom &In"
+msgstr "Vis &større"
+
+#: ../src/common/stockitem.cpp:215
+msgid "Zoom &Out"
+msgstr "Vis &mindre"
+
+#: ../src/common/stockitem.cpp:262
+msgid "Show about dialog"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:263
+#, fuzzy
+msgid "Copy selection"
+msgstr "Seksjoner"
+
+#: ../src/common/stockitem.cpp:264
+msgid "Cut selection"
+msgstr "Klipp ut Seksjoner"
+
+#: ../src/common/stockitem.cpp:265
+#, fuzzy
+msgid "Delete selection"
+msgstr "Seksjoner"
+
+#: ../src/common/stockitem.cpp:266
+#, fuzzy
+msgid "Find in document"
+msgstr "Åpne HTML-dokument"
+
+#: ../src/common/stockitem.cpp:267
+msgid "Find and replace in document"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:268
+#, fuzzy
+msgid "Paste selection"
+msgstr "Seksjoner"
+
+#: ../src/common/stockitem.cpp:269
+#, fuzzy
+msgid "Quit this program"
+msgstr "Skriv ut denne siden"
+
+#: ../src/common/stockitem.cpp:270
+msgid "Redo last action"
+msgstr "Gjenta forrige"
+
+#: ../src/common/stockitem.cpp:271
+msgid "Undo last action"
+msgstr "Angre siste handlin"
+
+#: ../src/common/stockitem.cpp:272
+#, fuzzy
+msgid "Create new document"
+msgstr "Opprett ny mappe"
+
+#: ../src/common/stockitem.cpp:273
+#, fuzzy
+msgid "Open an existing document"
+msgstr "Åpne HTML-dokument"
+
+#: ../src/common/stockitem.cpp:274
+msgid "Close current document"
+msgstr "Lukk dette dokumentet"
+
+#: ../src/common/stockitem.cpp:275
+#, fuzzy
+msgid "Save current document"
+msgstr "Velg en dokumentvisning"
+
+#: ../src/common/stockitem.cpp:276
+msgid "Save current document with a different filename"
+msgstr "Lagre dette dokumentet med et annet filnavn"
+
+#: ../src/common/strconv.cpp:2324
+#, c-format
+msgid "Conversion to charset '%s' doesn't work."
+msgstr "Klarte ikke konvertere til tegnsett «%s»."
+
+#: ../src/common/tarstrm.cpp:352 ../src/common/tarstrm.cpp:375
+#: ../src/common/tarstrm.cpp:406 ../src/generic/progdlgg.cpp:373
+msgid "unknown"
+msgstr "ukjent"
+
+#: ../src/common/tarstrm.cpp:774
+msgid "incomplete header block in tar"
+msgstr "ukomplett hodeblokk i tar"
+
+#: ../src/common/tarstrm.cpp:798
+msgid "checksum failure reading tar header block"
+msgstr "kontrollsumfeil ved lesing av hodeblokk fra tar"
+
+#: ../src/common/tarstrm.cpp:971
+msgid "invalid data in extended tar header"
+msgstr "ugyldig data i utvidet tar-hode"
+
+#: ../src/common/tarstrm.cpp:981 ../src/common/tarstrm.cpp:1003
+#: ../src/common/tarstrm.cpp:1477 ../src/common/tarstrm.cpp:1499
+msgid "tar entry not open"
+msgstr "tar-innslag er ikke åpent"
+
+#: ../src/common/tarstrm.cpp:1023
+#, fuzzy
+msgid "unexpected end of file"
+msgstr "Uventet slutt på filen under tolking av ressurs."
+
+#: ../src/common/tarstrm.cpp:1297
+#, c-format
+msgid "%s did not fit the tar header for entry '%s'"
+msgstr "%s passet ikke med tar- hodet for innslag '%s'"
+
+#: ../src/common/tarstrm.cpp:1359
+msgid "incorrect size given for tar entry"
+msgstr "ugyldig størrelse for tar-innslag"
+
+#: ../src/common/textbuf.cpp:232
+#, c-format
+msgid "'%s' is probably a binary buffer."
+msgstr "«%s» er sannsynligvis en binær buffer."
+
+#: ../src/common/textcmn.cpp:1006 ../src/richtext/richtextctrl.cpp:3053
+msgid "File couldn't be loaded."
+msgstr "Klarte ikke laste filen."
+
+#: ../src/common/textfile.cpp:95
+#, fuzzy, c-format
+msgid "Failed to read text file \"%s\"."
+msgstr "Klarte ikke laste metafil fra filen «%s»."
+
+#: ../src/common/textfile.cpp:160
+#, c-format
+msgid "can't write buffer '%s' to disk."
+msgstr "klarte ikke skriver buffer «%s» til disk."
+
+#: ../src/common/time.cpp:212
+msgid "Failed to get the local system time"
+msgstr "Klarte ikke finne lokal systemtid"
+
+#: ../src/common/time.cpp:279
+msgid "wxGetTimeOfDay failed."
+msgstr "wxGetTimeOfDay feilet."
+
+#: ../src/common/translation.cpp:929
+#, c-format
+msgid "'%s' is not a valid message catalog."
+msgstr "«%s» er ikke en gyldig meldingskatalog."
+
+#: ../src/common/translation.cpp:954
+#, fuzzy
+msgid "Invalid message catalog."
+msgstr "«%s» er ikke en gyldig meldingskatalog."
+
+#: ../src/common/translation.cpp:1013
+#, fuzzy, c-format
+msgid "Failed to parse Plural-Forms: '%s'"
+msgstr "Klarte ikke tolke flertallsformer: «%s»"
+
+#: ../src/common/translation.cpp:1723
+#, c-format
+msgid "using catalog '%s' from '%s'."
+msgstr "bruker katalog «%s» fra «%s»."
+
+#: ../src/common/translation.cpp:1816
+#, fuzzy, c-format
+msgid "Resource '%s' is not a valid message catalog."
+msgstr "«%s» er ikke en gyldig meldingskatalog."
+
+#: ../src/common/translation.cpp:1865
+#, fuzzy
+msgid "Couldn't enumerate translations"
+msgstr "Klarte ikke avslutte tråden."
+
+#: ../src/common/utilscmn.cpp:1145
+msgid "No default application configured for HTML files."
+msgstr "Ingen applikasjon satt opp for HTML-filer."
+
+#: ../src/common/utilscmn.cpp:1190
+#, fuzzy, c-format
+msgid "Failed to open URL \"%s\" in default browser."
+msgstr "Klarte ikke åpne «%s» for «%s»"
+
+#: ../src/common/valtext.cpp:144
+msgid "Validation conflict"
+msgstr "Valideringskonflikt"
+
+#: ../src/common/valtext.cpp:186
+msgid "Required information entry is empty."
+msgstr ""
+
+#: ../src/common/valtext.cpp:188
+#, fuzzy, c-format
+msgid "'%s' is one of the invalid strings"
+msgstr "«%s» er ugyldig"
+
+#: ../src/common/valtext.cpp:190
+#, fuzzy, c-format
+msgid "'%s' is not one of the valid strings"
+msgstr "«%s» er ikke en gyldig meldingskatalog."
+
+#: ../src/common/valtext.cpp:199
+#, fuzzy, c-format
+msgid "'%s' contains invalid character(s)"
+msgstr "«%s» må kun inneholde bokstaver."
+
+#: ../src/common/webrequest.cpp:139
+#, fuzzy, c-format
+msgid "Error: %s (%d)"
+msgstr "Feil:"
+
+#: ../src/common/webrequest.cpp:655
+#, c-format
+msgid ""
+"Not enough free disk space for download: %llu needed but only %llu available."
+msgstr ""
+
+#: ../src/common/webrequest.cpp:669
+#, fuzzy, c-format
+msgid "Failed to create temporary file in %s"
+msgstr "Klarte ikke opprette et midlertidig filnavn"
+
+#: ../src/common/webrequest_curl.cpp:1106
+#, fuzzy
+msgid "libcurl could not be initialized"
+msgstr "Kolonnebeskrivele kunne ikke initialiseres."
+
+#: ../src/common/webview.cpp:392
+#, fuzzy
+msgid "RunScriptAsync not supported"
+msgstr "String conversions ikke støttet"
+
+#: ../src/common/webview.cpp:403 ../src/msw/webview_ie.cpp:1073
+#, c-format
+msgid "Error running JavaScript: %s"
+msgstr ""
+
+#: ../src/common/webview_chromium.cpp:858
+#, fuzzy, c-format
+msgid "Failed to set proxy \"%s\": %s"
+msgstr "Klarte ikke opprette mappe «%s»"
+
+#: ../src/common/webview_chromium.cpp:989
+msgid ""
+"Chromium can't be used because libcef.so wasn't loaded early enough; please "
+"relink the application or use LD_PRELOAD to load it earlier."
+msgstr ""
+
+#: ../src/common/webview_chromium.cpp:1108
+#, fuzzy
+msgid "Could not initialize Chromium"
+msgstr "Klarte ikke å sette justering."
+
+#: ../src/common/webview_chromium.cpp:1616
+msgid "Show DevTools"
+msgstr ""
+
+#: ../src/common/webview_chromium.cpp:1617
+#, fuzzy
+msgid "Close DevTools"
+msgstr "Lukk alle"
+
+#: ../src/common/webview_chromium.cpp:1623
+msgid "Inspect"
+msgstr ""
+
+#: ../src/common/wincmn.cpp:1628
+msgid "This platform does not support background transparency."
+msgstr "Denne plattformen støtter ikke transparente bakgrunner."
+
+#: ../src/common/wincmn.cpp:2097
+msgid "Could not transfer data to window"
+msgstr "Klarte ikke overføre data til vindu"
+
+#: ../src/common/windowid.cpp:240
+msgid "Out of window IDs.  Recommend shutting down application."
+msgstr ""
+
+#: ../src/common/xpmdecod.cpp:678
+msgid "XPM: incorrect header format!"
+msgstr "XPM: ugylig hodeformat!"
+
+#: ../src/common/xpmdecod.cpp:703
+#, fuzzy, c-format
+msgid "XPM: incorrect colour description in line %d"
+msgstr "XPM: Ugyldig fargedefinisjon «%s»!"
+
+#: ../src/common/xpmdecod.cpp:715 ../src/common/xpmdecod.cpp:724
+#, fuzzy, c-format
+msgid "XPM: malformed colour definition '%s' at line %d!"
+msgstr "XPM: Ugyldig fargedefinisjon «%s»!"
+
+#: ../src/common/xpmdecod.cpp:754
+msgid "XPM: no colors left to use for mask!"
+msgstr "XPM: ingen farger igjen å bruke for masken!"
+
+#: ../src/common/xpmdecod.cpp:781
+#, c-format
+msgid "XPM: truncated image data at line %d!"
+msgstr "XPM: trunkerte bildedata på linje %d!"
+
+#: ../src/common/xpmdecod.cpp:795
+msgid "XPM: Malformed pixel data!"
+msgstr "XPM: Ugyldig pikseldata"
+
+#: ../src/common/xti.cpp:492
+msgid "Illegal Parameter Count for Create Method"
+msgstr "Ugyldig antall parametre for Create-metode"
+
+#: ../src/common/xti.cpp:504
+msgid "Illegal Parameter Count for ConstructObject Method"
+msgstr "Ugyldig antall parametre for ConstructObject-metode"
+
+#: ../src/common/xtistrm.cpp:161
+#, fuzzy, c-format
+msgid "Create Parameter %s not found in declared RTTI Parameters"
+msgstr "Create Parameter ble ikke funnet blant deklarerte RTTI parametere"
+
+#: ../src/common/xtistrm.cpp:290
+msgid "Illegal Object Class (Non-wxEvtHandler) as Event Source"
+msgstr "Ulovlig objektklasse (Ikke-wxEvtHandler) som hendelseskilde"
+
+#: ../src/common/xtistrm.cpp:313 ../src/common/xtixml.cpp:345
+#: ../src/common/xtixml.cpp:498
+msgid "Type must have enum - long conversion"
+msgstr "Type må ha enum - long conversion"
+
+#: ../src/common/xtistrm.cpp:400 ../src/common/xtistrm.cpp:415
+msgid "Invalid or Null Object ID passed to GetObjectClassInfo"
+msgstr "Ugyldig eller nullobjekt-ID sendt til GetObjectClassInfo"
+
+#: ../src/common/xtistrm.cpp:405
+msgid "Unknown Object passed to GetObjectClassInfo"
+msgstr "Ukjent objekt sendt til GetObjectClassInfo"
+
+#: ../src/common/xtistrm.cpp:420
+msgid "Already Registered Object passed to SetObjectClassInfo"
+msgstr "Allerede registrert objekt sendt til SetObjectClassInfo"
+
+#: ../src/common/xtistrm.cpp:430
+msgid "Invalid or Null Object ID passed to HasObjectClassInfo"
+msgstr "Ugyldig eller nullobjekt-ID sendt til HasObjectClassInfo"
+
+#: ../src/common/xtistrm.cpp:460
+msgid "Passing a already registered object to SetObject"
+msgstr "Allerede registrert objekt sendt til SetObject"
+
+#: ../src/common/xtistrm.cpp:471
+#, fuzzy
+msgid "Passing an unknown object to GetObject"
+msgstr "Ukjent objekt sendt til GetObject"
+
+#: ../src/common/xtixml.cpp:229
+msgid "Forward hrefs are not supported"
+msgstr "Fremover HREF-er er ikke støttet"
+
+#: ../src/common/xtixml.cpp:247
+#, c-format
+msgid "unknown class %s"
+msgstr "ukjent klasse %s"
+
+#: ../src/common/xtixml.cpp:253
+msgid "objects cannot have XML Text Nodes"
+msgstr "objekter kan ikke ha XML-tekstnoder"
+
+#: ../src/common/xtixml.cpp:258
+msgid "Objects must have an id attribute"
+msgstr "Objekter må ha en ID attributt"
+
+#: ../src/common/xtixml.cpp:267
+#, c-format
+msgid "Doubly used id : %d"
+msgstr "Dobbel bruker-ID: %d"
+
+#: ../src/common/xtixml.cpp:316
+#, fuzzy, c-format
+msgid "Unknown Property %s"
+msgstr "Ukjent egenskap %s"
+
+#: ../src/common/xtixml.cpp:407
+msgid "A non empty collection must consist of 'element' nodes"
+msgstr "En ikke-tom mengde må bestå av «element»-noder"
+
+#: ../src/common/xtixml.cpp:478
+msgid "incorrect event handler string, missing dot"
+msgstr "ugyldig hendelsebehandlerstreng, mangler punktum"
+
+#: ../src/common/zipstrm.cpp:559
+msgid "can't re-initialize zlib deflate stream"
+msgstr "Klarte ikke klargjøre zlib-strøm for nedpakking."
+
+#: ../src/common/zipstrm.cpp:584
+msgid "can't re-initialize zlib inflate stream"
+msgstr "Klarte ikke klargjøre zlib-strøm for utpakking."
+
+#: ../src/common/zipstrm.cpp:1023
+msgid "Ignoring malformed extra data record, ZIP file may be corrupted"
+msgstr ""
+
+#: ../src/common/zipstrm.cpp:1502
+msgid "assuming this is a multi-part zip concatenated"
+msgstr "antar dette er en mangedelt zip-fil slått sammen"
+
+#: ../src/common/zipstrm.cpp:1664
+msgid "invalid zip file"
+msgstr "ugyldig zipfil"
+
+#: ../src/common/zipstrm.cpp:1723
+msgid "can't find central directory in zip"
+msgstr "Klarte ikke finne zip-sentralmappe"
+
+#: ../src/common/zipstrm.cpp:1812
+msgid "error reading zip central directory"
+msgstr "Feil ved lesing av zip-sentralmappe"
+
+#: ../src/common/zipstrm.cpp:1916
+msgid "error reading zip local header"
+msgstr "feil ved lesing av lokalt zip-hode "
+
+#: ../src/common/zipstrm.cpp:1964
+msgid "bad zipfile offset to entry"
+msgstr "ugylidg zipfil forskyvning til oppføring"
+
+#: ../src/common/zipstrm.cpp:2031
+msgid "stored file length not in Zip header"
+msgstr "lagret fillengde ikke funnet i Zip-hode"
+
+#: ../src/common/zipstrm.cpp:2045 ../src/common/zipstrm.cpp:2362
+msgid "unsupported Zip compression method"
+msgstr "ikke-støttet Zip-komprimeringsmetode"
+
+#: ../src/common/zipstrm.cpp:2126
+#, c-format
+msgid "reading zip stream (entry %s): bad length"
+msgstr "leser zip-strøm (oppføring %s): feil lengde"
+
+#: ../src/common/zipstrm.cpp:2131
+#, c-format
+msgid "reading zip stream (entry %s): bad crc"
+msgstr "leser zip-strøm (oppføring %s): feil crc"
+
+#: ../src/common/zipstrm.cpp:2578
+#, fuzzy, c-format
+msgid "error writing zip entry '%s': file too large without ZIP64"
+msgstr "feil ved skriving av zip-oppføring «%s»: feil crc eller lengde"
+
+#: ../src/common/zipstrm.cpp:2585
+#, c-format
+msgid "error writing zip entry '%s': bad crc or length"
+msgstr "feil ved skriving av zip-oppføring «%s»: feil crc eller lengde"
+
+#: ../src/common/zstream.cpp:155 ../src/common/zstream.cpp:315
+msgid "Gzip not supported by this version of zlib"
+msgstr "Gzip er ikke støttet av denne versjonen av zlib"
+
+#: ../src/common/zstream.cpp:182
+msgid "Can't initialize zlib inflate stream."
+msgstr "Klarte ikke klargjøre zlib-strøm for utpakking."
+
+#: ../src/common/zstream.cpp:241
+msgid "Can't read inflate stream: unexpected EOF in underlying stream."
+msgstr "Klarte ikke lese utpakkingsstrøm: uventet EOF i underliggende strøm."
+
+#: ../src/common/zstream.cpp:248 ../src/common/zstream.cpp:423
+#, c-format
+msgid "zlib error %d"
+msgstr "zlib-feil %d"
+
+#: ../src/common/zstream.cpp:249
+#, c-format
+msgid "Can't read from inflate stream: %s"
+msgstr "Klarte ikke lese fra utpakkingsstrøm: %s"
+
+#: ../src/common/zstream.cpp:343
+msgid "Can't initialize zlib deflate stream."
+msgstr "Klarte ikke klargjøre zlib-strøm for nedpakking."
+
+#: ../src/common/zstream.cpp:424
+#, c-format
+msgid "Can't write to deflate stream: %s"
+msgstr "Klarte ikke skrive til nedpakkingsstrøm: %s"
+
+#: ../src/dfb/bitmap.cpp:633 ../src/dfb/bitmap.cpp:667
+#, fuzzy, c-format
+msgid "No bitmap handler for type %d defined."
+msgstr "Ingen bildebehandler for type %d definert."
+
+#: ../src/dfb/evtloop.cpp:99
+#, fuzzy
+msgid "Failed to read event from DirectFB pipe"
+msgstr "Klarte ikke lses PID fra låsefil."
+
+#: ../src/dfb/evtloop.cpp:171
+msgid "Failed to switch DirectFB pipe to non-blocking mode"
+msgstr ""
+
+#: ../src/dfb/fontmgr.cpp:171
+#, c-format
+msgid "no fonts found in %s, using builtin font"
+msgstr "ingen fonter funnet i %s, bruker innebygd font"
+
+#: ../src/dfb/fontmgr.cpp:177
+#, fuzzy
+msgid "Default font"
+msgstr "Standard skriver"
+
+#: ../src/dfb/fontmgr.cpp:195
+#, c-format
+msgid "Fonts index file %s disappeared while loading fonts."
+msgstr "Skriftindeksfilen %s forsvant mens skrifttypene ble lastet opp."
+
+#: ../src/dfb/wrapdfb.cpp:60
+#, c-format
+msgid "DirectFB error %d occurred."
+msgstr ""
+
+#: ../src/generic/aboutdlgg.cpp:69
+msgid "Developed by "
+msgstr "Utviklet av"
+
+#: ../src/generic/aboutdlgg.cpp:72
+msgid "Documentation by "
+msgstr "Dokumentert av"
+
+#: ../src/generic/aboutdlgg.cpp:75
+msgid "Graphics art by "
+msgstr ""
+
+#: ../src/generic/aboutdlgg.cpp:78
+msgid "Translations by "
+msgstr "Oversatt av"
+
+#: ../src/generic/aboutdlgg.cpp:133 ../src/osx/cocoa/aboutdlg.mm:83
+#, fuzzy
+msgid "Version "
+msgstr "Rettigheter"
+
+#. TRANSLATORS: %s is application name
+#: ../src/generic/aboutdlgg.cpp:146 ../src/msw/aboutdlg.cpp:60
+#, fuzzy, c-format
+msgid "About %s"
+msgstr "%Om"
+
+#: ../src/generic/aboutdlgg.cpp:181
+msgid "License"
+msgstr "Lisens"
+
+#: ../src/generic/aboutdlgg.cpp:184
+msgid "Developers"
+msgstr "Utviklere"
+
+#: ../src/generic/aboutdlgg.cpp:188
+msgid "Documentation writers"
+msgstr "Dokumentforfattere"
+
+#: ../src/generic/aboutdlgg.cpp:192
+msgid "Artists"
+msgstr "Artister"
+
+#: ../src/generic/aboutdlgg.cpp:196
+msgid "Translators"
+msgstr "Oversettere"
+
+#: ../src/generic/animateg.cpp:125
+#, fuzzy
+msgid "No handler found for animation type."
+msgstr "Ingen behandler funnet for bildetype."
+
+#: ../src/generic/animateg.cpp:133
+#, fuzzy, c-format
+msgid "No animation handler for type %ld defined."
+msgstr "Ingen bildebehandler for type %d definert."
+
+#: ../src/generic/animateg.cpp:145
+#, fuzzy, c-format
+msgid "Animation file is not of type %ld."
+msgstr "Bildefil er ikke av type %d."
+
+#: ../src/generic/colrdlgg.cpp:154 ../src/gtk/colordlg.cpp:47
+msgid "Choose colour"
+msgstr "Velg farge"
+
+#: ../src/generic/colrdlgg.cpp:357
+msgid "Red:"
+msgstr ""
+
+#: ../src/generic/colrdlgg.cpp:360
+#, fuzzy
+msgid "Green:"
+msgstr "Grønn"
+
+#: ../src/generic/colrdlgg.cpp:363
+#, fuzzy
+msgid "Blue:"
+msgstr "Blå"
+
+#: ../src/generic/colrdlgg.cpp:372
+#, fuzzy
+msgid "Opacity:"
+msgstr "Dekkevne:"
+
+#: ../src/generic/colrdlgg.cpp:384
+msgid "Add to custom colours"
+msgstr "Legg til selvvalgte farge"
+
+#: ../src/generic/creddlgg.cpp:56
+msgid "Username:"
+msgstr ""
+
+#: ../src/generic/creddlgg.cpp:63
+msgid "Password:"
+msgstr ""
+
+#. TRANSLATORS: Name of Boolean true value
+#: ../src/generic/datavgen.cpp:1178
+msgid "true"
+msgstr ""
+
+#. TRANSLATORS: Name of Boolean false value
+#: ../src/generic/datavgen.cpp:1180
+msgid "false"
+msgstr ""
+
+#: ../src/generic/datavgen.cpp:6897
+#, c-format
+msgid "Row %i"
+msgstr ""
+
+#. TRANSLATORS: Action for manipulating a tree control
+#: ../src/generic/datavgen.cpp:6987
+msgid "Collapse"
+msgstr ""
+
+#. TRANSLATORS: Action for manipulating a tree control
+#: ../src/generic/datavgen.cpp:6990
+msgid "Expand"
+msgstr ""
+
+#. TRANSLATORS: Name of data view control and number of rows
+#: ../src/generic/datavgen.cpp:7011
+#, fuzzy, c-format
+msgid "%s (%d items)"
+msgstr "%s (eller %s)"
+
+#: ../src/generic/datavgen.cpp:7062
+#, fuzzy, c-format
+msgid "Column %u"
+msgstr "Legg til Kolonne"
+
+#. TRANSLATORS: Keystroke for manipulating a tree control
+#: ../src/generic/datavgen.cpp:7131 ../src/richtext/richtextbulletspage.cpp:189
+#: ../src/richtext/richtextbulletspage.cpp:192
+#: ../src/richtext/richtextbulletspage.cpp:193
+#: ../src/richtext/richtextliststylepage.cpp:252
+#: ../src/richtext/richtextliststylepage.cpp:255
+#: ../src/richtext/richtextliststylepage.cpp:256
+#: ../src/richtext/richtextsizepage.cpp:248
+msgid "Left"
+msgstr ""
+
+#. TRANSLATORS: Keystroke for manipulating a tree control
+#: ../src/generic/datavgen.cpp:7134 ../src/richtext/richtextbulletspage.cpp:191
+#: ../src/richtext/richtextliststylepage.cpp:254
+#: ../src/richtext/richtextsizepage.cpp:249
+msgid "Right"
+msgstr "Høyre"
+
+#: ../src/generic/datectlg.cpp:90
+#, c-format
+msgid ""
+"\"%s\" is not in the expected date format, please enter it as e.g. \"%s\"."
+msgstr ""
+
+#: ../src/generic/datectlg.cpp:94
+#, fuzzy
+msgid "Invalid date"
+msgstr "PCX: Ugyldig bilde"
+
+#: ../src/generic/dbgrptg.cpp:159
+#, c-format
+msgid "Open file \"%s\""
+msgstr "Åpne fil «%s»"
+
+#: ../src/generic/dbgrptg.cpp:170
+#, c-format
+msgid "Enter command to open file \"%s\":"
+msgstr "Skriv inn kommando for å åpne fil «%s»:"
+
+#: ../src/generic/dbgrptg.cpp:230
+#, fuzzy
+msgid "Executable files (*.exe)|*.exe|"
+msgstr "Kjørbare filer (*.exe)|*.exe|Alle filer (*.*)|*.*||"
+
+#: ../src/generic/dbgrptg.cpp:300
+#, c-format
+msgid "Debug report \"%s\""
+msgstr "Feilsøkingsrapport «%s»"
+
+#: ../src/generic/dbgrptg.cpp:316
+msgid "A debug report has been generated in the directory\n"
+msgstr "En feilsøkingsrapport har generert i mappen\n"
+
+#: ../src/generic/dbgrptg.cpp:317
+#, fuzzy
+msgid "The following debug report will be generated\n"
+msgstr "*** En feilsøkingsrapport har blitt generert\n"
+
+#: ../src/generic/dbgrptg.cpp:321
+msgid ""
+"The report contains the files listed below. If any of these files contain "
+"private information,\n"
+"please uncheck them and they will be removed from the report.\n"
+msgstr ""
+"Rapporten inneholder filene listet nedenfor. Hvis noen av disse filene "
+"inneholder privat informasjon,\n"
+"så fjerner du bare markeringen foran dem og de vil bli fjernet fra "
+"rapporten.\n"
+
+#: ../src/generic/dbgrptg.cpp:323
+msgid ""
+"If you wish to suppress this debug report completely, please choose the "
+"\"Cancel\" button,\n"
+"but be warned that it may hinder improving the program, so if\n"
+"at all possible please do continue with the report generation.\n"
+msgstr ""
+"Hvis du vil stanse denne feilsøkingsrapporten, velg «Avbryt»-knappen.\n"
+"Vær klar over at det kan hindre forbedring av programmet så\n"
+"det er best hvis du fortsetter genereringen av rapporten.\n"
+
+#: ../src/generic/dbgrptg.cpp:325
+msgid "              Thank you and we're sorry for the inconvenience!\n"
+msgstr "              Takk skal du ha og vi beklager bryet!\n"
+
+#: ../src/generic/dbgrptg.cpp:333
+msgid "&Debug report preview:"
+msgstr "&Forhåndsvisning av feilsøkingsrapport"
+
+#: ../src/generic/dbgrptg.cpp:339
+#, fuzzy
+msgid "&View..."
+msgstr "&Åpne..."
+
+#: ../src/generic/dbgrptg.cpp:359
+msgid "&Notes:"
+msgstr "&Notater:"
+
+#: ../src/generic/dbgrptg.cpp:361
+msgid ""
+"If you have any additional information pertaining to this bug\n"
+"report, please enter it here and it will be joined to it:"
+msgstr ""
+"Hvis du har mer informasjon som hører til denne feilrapporten,\n"
+"skriv det inn her og det vil bli lagt til:"
+
+#: ../src/generic/dcpsg.cpp:1627
+msgid "Cannot open file for PostScript printing!"
+msgstr "Klarte ikke åpne fil for PostScript-utskrift!"
+
+#: ../src/generic/dirctrlg.cpp:402
+msgid "Computer"
+msgstr "Datamaskin"
+
+#: ../src/generic/dirctrlg.cpp:404
+msgid "Sections"
+msgstr "Seksjoner"
+
+#: ../src/generic/dirctrlg.cpp:482
+msgid "Home directory"
+msgstr "Hjemmemappe"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/generic/dirctrlg.cpp:484 ../src/propgrid/advprops.cpp:811
+msgid "Desktop"
+msgstr "Skrivebord"
+
+#: ../src/generic/dirctrlg.cpp:528 ../src/generic/filectrlg.cpp:752
+msgid "Illegal directory name."
+msgstr "Ugyldig mappenavn."
+
+#: ../src/generic/dirctrlg.cpp:528 ../src/generic/dirctrlg.cpp:546
+#: ../src/generic/dirctrlg.cpp:557 ../src/generic/dirdlgg.cpp:317
+#: ../src/generic/filectrlg.cpp:638 ../src/generic/filectrlg.cpp:752
+#: ../src/generic/filectrlg.cpp:766 ../src/generic/filectrlg.cpp:782
+#: ../src/generic/filectrlg.cpp:1356 ../src/generic/filectrlg.cpp:1387
+#: ../src/generic/filedlgg.cpp:362 ../src/gtk/filedlg.cpp:76
+msgid "Error"
+msgstr "Feil"
+
+#: ../src/generic/dirctrlg.cpp:546 ../src/generic/filectrlg.cpp:766
+msgid "File name exists already."
+msgstr "Filnavn eksisterer allerede."
+
+#: ../src/generic/dirctrlg.cpp:557 ../src/generic/dirdlgg.cpp:317
+#: ../src/generic/filectrlg.cpp:638 ../src/generic/filectrlg.cpp:782
+msgid "Operation not permitted."
+msgstr "Operasjon ikke tillatt."
+
+#: ../src/generic/dirdlgg.cpp:107 ../src/generic/filedlgg.cpp:207
+msgid "Create new directory"
+msgstr "Opprett ny mappe"
+
+#: ../src/generic/dirdlgg.cpp:112 ../src/generic/filedlgg.cpp:203
+msgid "Go to home directory"
+msgstr "Gå til hjemmemappe"
+
+#: ../src/generic/dirdlgg.cpp:143
+#, fuzzy
+msgid "Show &hidden directories"
+msgstr "Vis skjulte mapper"
+
+#: ../src/generic/dirdlgg.cpp:196
+#, c-format
+msgid ""
+"The directory '%s' does not exist\n"
+"Create it now?"
+msgstr ""
+"Mappen «%s» finnes ikke.\n"
+"Opprett den nå?"
+
+#: ../src/generic/dirdlgg.cpp:198
+msgid "Directory does not exist"
+msgstr "Mappen eksisterer ikke"
+
+#: ../src/generic/dirdlgg.cpp:214
+#, c-format
+msgid ""
+"Failed to create directory '%s'\n"
+"(Do you have the required permissions?)"
+msgstr ""
+"Klarte ikke opprette mappen «%s»\n"
+"(Har du tilgangsrettighet?)"
+
+#: ../src/generic/dirdlgg.cpp:216
+msgid "Error creating directory"
+msgstr "Feil ved opprettelse av mappe"
+
+#: ../src/generic/dirdlgg.cpp:281
+msgid "You cannot add a new directory to this section."
+msgstr "Du kan ikke legge til en ny mappe i denne seksjonen."
+
+#: ../src/generic/dirdlgg.cpp:282
+msgid "Create directory"
+msgstr "Opprett mappe"
+
+#: ../src/generic/dirdlgg.cpp:291 ../src/generic/dirdlgg.cpp:301
+#: ../src/generic/filectrlg.cpp:614 ../src/generic/filectrlg.cpp:623
+msgid "NewName"
+msgstr "NyttNavn"
+
+#: ../src/generic/editlbox.cpp:135
+msgid "Edit item"
+msgstr "Redigere element"
+
+#: ../src/generic/editlbox.cpp:143
+msgid "New item"
+msgstr "Nytt element"
+
+#: ../src/generic/editlbox.cpp:151
+msgid "Delete item"
+msgstr "Slett element"
+
+#: ../src/generic/editlbox.cpp:159
+msgid "Move up"
+msgstr "Flytt opp"
+
+#: ../src/generic/editlbox.cpp:164
+msgid "Move down"
+msgstr "Flytt ned"
+
+#: ../src/generic/fdrepdlg.cpp:108
+msgid "Search for:"
+msgstr "Søk etter:"
+
+#: ../src/generic/fdrepdlg.cpp:120
+msgid "Replace with:"
+msgstr "Erstatt med:"
+
+#: ../src/generic/fdrepdlg.cpp:140
+msgid "Whole word"
+msgstr "Hele ord"
+
+#: ../src/generic/fdrepdlg.cpp:143
+msgid "Match case"
+msgstr "Skill mellom store og små bokstaver"
+
+#: ../src/generic/fdrepdlg.cpp:156
+msgid "Search direction"
+msgstr "Søkeretning"
+
+#: ../src/generic/fdrepdlg.cpp:175
+msgid "&Replace"
+msgstr "&Erstatt"
+
+#: ../src/generic/fdrepdlg.cpp:178
+msgid "Replace &all"
+msgstr "Erstatt &alle"
+
+#: ../src/generic/filectrlg.cpp:246 ../src/generic/filectrlg.cpp:269
+msgid "<DIR>"
+msgstr "<MAPPE>"
+
+#: ../src/generic/filectrlg.cpp:248 ../src/generic/filectrlg.cpp:271
+msgid "<LINK>"
+msgstr "<LENKE>"
+
+#: ../src/generic/filectrlg.cpp:250 ../src/generic/filectrlg.cpp:273
+msgid "<DRIVE>"
+msgstr "<LAGERENHET>"
+
+#: ../src/generic/filectrlg.cpp:275
+#, fuzzy, c-format
+msgid "%ld byte"
+msgid_plural "%ld bytes"
+msgstr[0] "%ld byte"
+msgstr[1] "%ld byte"
+
+#: ../src/generic/filectrlg.cpp:420
+msgid "Name"
+msgstr "Navn"
+
+#: ../src/generic/filectrlg.cpp:421 ../src/richtext/richtextformatdlg.cpp:361
+#: ../src/richtext/richtextsizepage.cpp:298
+msgid "Size"
+msgstr "Størrelse"
+
+#: ../src/generic/filectrlg.cpp:422
+msgid "Type"
+msgstr "Type"
+
+#: ../src/generic/filectrlg.cpp:423
+msgid "Modified"
+msgstr "Modifisert"
+
+#: ../src/generic/filectrlg.cpp:426
+msgid "Permissions"
+msgstr "Rettigheter"
+
+#: ../src/generic/filectrlg.cpp:429
+msgid "Attributes"
+msgstr "Atributter"
+
+#: ../src/generic/filectrlg.cpp:936
+msgid "Current directory:"
+msgstr "Gjeldende mappe:"
+
+#: ../src/generic/filectrlg.cpp:979
+#, fuzzy
+msgid "Show &hidden files"
+msgstr "Vis skjulte filer"
+
+#: ../src/generic/filectrlg.cpp:1355
+msgid "Illegal file specification."
+msgstr "Ugyldig filspesifikasjon."
+
+#: ../src/generic/filectrlg.cpp:1387
+msgid "Directory doesn't exist."
+msgstr "Mappen eksisterer ikke."
+
+#: ../src/generic/filedlgg.cpp:195
+msgid "View files as a list view"
+msgstr "Vis filer i liste-visning"
+
+#: ../src/generic/filedlgg.cpp:197
+msgid "View files as a detailed view"
+msgstr "Vis filer i detaljert visning"
+
+#: ../src/generic/filedlgg.cpp:200
+msgid "Go to parent directory"
+msgstr "Gå til foreldremappe"
+
+#: ../src/generic/filedlgg.cpp:351 ../src/gtk/filedlg.cpp:59
+#, c-format
+msgid "File '%s' already exists, do you really want to overwrite it?"
+msgstr "Filen «%s» eksisterer allerede. Vil du virkelig overskrive filen?"
+
+#: ../src/generic/filedlgg.cpp:354 ../src/gtk/filedlg.cpp:62
+msgid "Confirm"
+msgstr "Bekreft"
+
+#: ../src/generic/filedlgg.cpp:362 ../src/gtk/filedlg.cpp:75
+msgid "Please choose an existing file."
+msgstr "Velg en eksisterende fil."
+
+#: ../src/generic/filepickerg.cpp:64
+#, fuzzy
+msgid "..."
+msgstr ".."
+
+#: ../src/generic/fontdlgg.cpp:76 ../src/richtext/richtextformatdlg.cpp:519
+msgid "ABCDEFGabcdefg12345"
+msgstr "ABCDEFGabcdefg12345"
+
+#: ../src/generic/fontdlgg.cpp:315
+msgid "Roman"
+msgstr "Roman"
+
+#: ../src/generic/fontdlgg.cpp:316
+msgid "Decorative"
+msgstr "Dekorativ"
+
+#: ../src/generic/fontdlgg.cpp:317
+msgid "Modern"
+msgstr "Moderne"
+
+#: ../src/generic/fontdlgg.cpp:318
+msgid "Script"
+msgstr "Skript"
+
+#: ../src/generic/fontdlgg.cpp:319
+msgid "Swiss"
+msgstr "Swiss"
+
+#: ../src/generic/fontdlgg.cpp:320
+msgid "Teletype"
+msgstr "Teletype"
+
+#: ../src/generic/fontdlgg.cpp:321 ../src/generic/fontdlgg.cpp:324
+msgid "Normal"
+msgstr "Normal"
+
+#: ../src/generic/fontdlgg.cpp:323
+msgid "Slant"
+msgstr "Skrå"
+
+#: ../src/generic/fontdlgg.cpp:325
+msgid "Light"
+msgstr "Lett"
+
+#: ../src/generic/fontdlgg.cpp:363
+msgid "&Font family:"
+msgstr "&Skriftfamilie:"
+
+#: ../src/generic/fontdlgg.cpp:367 ../src/generic/fontdlgg.cpp:369
+msgid "The font family."
+msgstr "Skriftfamilie"
+
+#: ../src/generic/fontdlgg.cpp:374 ../src/richtext/richtextstylepage.cpp:105
+msgid "&Style:"
+msgstr "&Stil:"
+
+#: ../src/generic/fontdlgg.cpp:378 ../src/generic/fontdlgg.cpp:380
+msgid "The font style."
+msgstr "Skriftstil"
+
+#: ../src/generic/fontdlgg.cpp:385
+msgid "&Weight:"
+msgstr "&Vekt:"
+
+#: ../src/generic/fontdlgg.cpp:389 ../src/generic/fontdlgg.cpp:391
+msgid "The font weight."
+msgstr "Skriftvekt"
+
+#: ../src/generic/fontdlgg.cpp:399
+msgid "C&olour:"
+msgstr "&Farge"
+
+#: ../src/generic/fontdlgg.cpp:407 ../src/generic/fontdlgg.cpp:409
+msgid "The font colour."
+msgstr "Skriftfarge"
+
+#: ../src/generic/fontdlgg.cpp:415
+msgid "&Point size:"
+msgstr "&Punktstørrelse"
+
+#: ../src/generic/fontdlgg.cpp:420 ../src/generic/fontdlgg.cpp:422
+#: ../src/generic/fontdlgg.cpp:426 ../src/generic/fontdlgg.cpp:428
+msgid "The font point size."
+msgstr "Skriftpunktstørrelse"
+
+#: ../src/generic/fontdlgg.cpp:439 ../src/generic/fontdlgg.cpp:441
+msgid "Whether the font is underlined."
+msgstr "Om skriften er understreket."
+
+#: ../src/generic/fontdlgg.cpp:448 ../src/html/helpwnd.cpp:1215
+msgid "Preview:"
+msgstr "Forhåndsvisning:"
+
+#: ../src/generic/fontdlgg.cpp:452 ../src/generic/fontdlgg.cpp:454
+msgid "Shows the font preview."
+msgstr "Viser skriftforhåndsvisning."
+
+#: ../src/generic/fontdlgg.cpp:464 ../src/generic/fontdlgg.cpp:483
+msgid "Click to cancel the font selection."
+msgstr "Klikk for å avbrytevalg av font."
+
+#: ../src/generic/fontdlgg.cpp:469 ../src/generic/fontdlgg.cpp:471
+#: ../src/generic/fontdlgg.cpp:476 ../src/generic/fontdlgg.cpp:478
+msgid "Click to confirm the font selection."
+msgstr "Klikk for å bekrefte skriftvalg"
+
+#: ../src/generic/fontpickerg.cpp:50 ../src/gtk/fontdlg.cpp:77
+msgid "Choose font"
+msgstr "Velg skrift"
+
+#: ../src/generic/grid.cpp:6542
+msgid ""
+"Error copying grid to the clipboard. Either selected cells were not "
+"contiguous or no cell was selected."
+msgstr ""
+
+#: ../src/generic/grid.cpp:12739
+#, fuzzy
+msgid "Grid Corner"
+msgstr "Hjørne"
+
+#: ../src/generic/grid.cpp:12741
+#, fuzzy, c-format
+msgid "Column %s Header"
+msgstr "Legg til Kolonne"
+
+#: ../src/generic/grid.cpp:12743
+#, c-format
+msgid "Row %s Header"
+msgstr ""
+
+#: ../src/generic/grid.cpp:12745
+#, fuzzy, c-format
+msgid "Column %s: %s"
+msgstr "Legg til Kolonne"
+
+#: ../src/generic/grid.cpp:12749
+#, fuzzy, c-format
+msgid "Row %s: %s"
+msgstr "\t%s: %s\n"
+
+#: ../src/generic/grid.cpp:12753
+#, c-format
+msgid "Row %s, Column %s: %s"
+msgstr ""
+
+#: ../src/generic/helpext.cpp:257
+#, c-format
+msgid "Help directory \"%s\" not found."
+msgstr "Hjelpemappe \"%s\" ble ikke funet."
+
+#: ../src/generic/helpext.cpp:265
+#, fuzzy, c-format
+msgid "Help file \"%s\" not found."
+msgstr "katalogfil for domene «%s» ikke funnet."
+
+#: ../src/generic/helpext.cpp:284
+#, c-format
+msgid "Line %lu of map file \"%s\" has invalid syntax, skipped."
+msgstr ""
+
+#: ../src/generic/helpext.cpp:292
+#, c-format
+msgid "No valid mappings found in the file \"%s\"."
+msgstr ""
+
+#: ../src/generic/helpext.cpp:435
+msgid "No entries found."
+msgstr "Ingen oppføringer funnet."
+
+#: ../src/generic/helpext.cpp:444 ../src/generic/helpext.cpp:445
+msgid "Help Index"
+msgstr "Indeks for hjelp"
+
+#: ../src/generic/helpext.cpp:448
+msgid "Relevant entries:"
+msgstr "Relevante oppføringer:"
+
+#: ../src/generic/helpext.cpp:449
+msgid "Entries found"
+msgstr "Oppføringer funnet"
+
+#: ../src/generic/hyperlinkg.cpp:170
+#, fuzzy
+msgid "&Copy URL"
+msgstr "&Kopier"
+
+#: ../src/generic/infobar.cpp:119
+msgid "Hide this notification message."
+msgstr "Skjul denne meldingen."
+
+#. TRANSLATORS: %s will be either the application name or "Application"
+#: ../src/generic/logg.cpp:257
+#, c-format
+msgid "%s Error"
+msgstr "%s Feil"
+
+#. TRANSLATORS: %s will be either the application name or "Application"
+#: ../src/generic/logg.cpp:263
+#, c-format
+msgid "%s Warning"
+msgstr "%s Advarsel"
+
+#. TRANSLATORS: %s will be either the application name or "Application"
+#: ../src/generic/logg.cpp:273
+#, c-format
+msgid "%s Information"
+msgstr "%s Informasjon"
+
+#: ../src/generic/logg.cpp:276
+#, fuzzy
+msgid "Application"
+msgstr "Seksjoner"
+
+#: ../src/generic/logg.cpp:549
+msgid "Save log contents to file"
+msgstr "Lagre logginnhold til fil"
+
+#: ../src/generic/logg.cpp:551
+msgid "C&lear"
+msgstr "&Nullstill"
+
+#: ../src/generic/logg.cpp:551
+msgid "Clear the log contents"
+msgstr "Tøm loggen for innhold"
+
+#: ../src/generic/logg.cpp:553
+msgid "Close this window"
+msgstr "Lukk dette vinduet"
+
+#: ../src/generic/logg.cpp:554
+msgid "&Log"
+msgstr "&Logg"
+
+#: ../src/generic/logg.cpp:610 ../src/generic/logg.cpp:992
+msgid "Can't save log contents to file."
+msgstr "Klarte ikke lagre logginnholdet til fil."
+
+#: ../src/generic/logg.cpp:613
+#, c-format
+msgid "Log saved to the file '%s'."
+msgstr "Logg lagret til filen «%s»."
+
+#: ../src/generic/logg.cpp:719
+msgid "&Details"
+msgstr "&detaljer"
+
+#: ../src/generic/logg.cpp:972
+#, fuzzy
+msgid "Failed to copy dialog contents to the clipboard."
+msgstr "Klarte ikke åpne utklippstavle."
+
+#: ../src/generic/logg.cpp:1022
+#, c-format
+msgid "Append log to file '%s' (choosing [No] will overwrite it)?"
+msgstr "Tilføy logg til fil «%s» (velger du [Nei] overskrives filen)?"
+
+#: ../src/generic/logg.cpp:1024
+msgid "Question"
+msgstr "Spørsmål"
+
+#: ../src/generic/logg.cpp:1038
+msgid "invalid message box return value"
+msgstr "ugyldig meldingsboks returverdi"
+
+#: ../src/generic/notifmsgg.cpp:129
+#, fuzzy
+msgid "Notice"
+msgstr "&Notater:"
+
+#: ../src/generic/preferencesg.cpp:118
+#, fuzzy, c-format
+msgid "%s Preferences"
+msgstr "&Innstillinger"
+
+#: ../src/generic/printps.cpp:143
+msgid "Printing..."
+msgstr "Skriver ut..."
+
+#: ../src/generic/printps.cpp:160 ../src/gtk/print.cpp:1076
+#: ../src/msw/printwin.cpp:235
+msgid "Could not start printing."
+msgstr "Klarte ikke starte utskrift."
+
+#: ../src/generic/printps.cpp:183
+#, c-format
+msgid "Printing page %d..."
+msgstr "Skriver ut side %d..."
+
+#: ../src/generic/prntdlgg.cpp:171
+msgid "Printer options"
+msgstr "Skriveropsjoner"
+
+#: ../src/generic/prntdlgg.cpp:176
+msgid "Print to File"
+msgstr "Skriv til fil"
+
+#: ../src/generic/prntdlgg.cpp:179
+msgid "Setup..."
+msgstr "Sett opp..."
+
+#: ../src/generic/prntdlgg.cpp:187
+msgid "Printer:"
+msgstr "Skriver:"
+
+#: ../src/generic/prntdlgg.cpp:195
+msgid "Status:"
+msgstr "Status: "
+
+#: ../src/generic/prntdlgg.cpp:206
+msgid "All"
+msgstr "Alle"
+
+#: ../src/generic/prntdlgg.cpp:207
+msgid "Pages"
+msgstr "Sider"
+
+#: ../src/generic/prntdlgg.cpp:215
+msgid "Print Range"
+msgstr "Utskriftsområde"
+
+#: ../src/generic/prntdlgg.cpp:229
+msgid "From:"
+msgstr "Fra:"
+
+#: ../src/generic/prntdlgg.cpp:233
+msgid "To:"
+msgstr "Til:"
+
+#: ../src/generic/prntdlgg.cpp:238
+msgid "Copies:"
+msgstr "Kopier;"
+
+#: ../src/generic/prntdlgg.cpp:288
+msgid "PostScript file"
+msgstr "PostScript-fil"
+
+#: ../src/generic/prntdlgg.cpp:439
+msgid "Print Setup"
+msgstr "Oppsett av utskrift"
+
+#: ../src/generic/prntdlgg.cpp:483
+msgid "Printer"
+msgstr "Skriver"
+
+#: ../src/generic/prntdlgg.cpp:501
+msgid "Default printer"
+msgstr "Standard skriver"
+
+#: ../src/generic/prntdlgg.cpp:595 ../src/generic/prntdlgg.cpp:782
+#: ../src/generic/prntdlgg.cpp:822 ../src/generic/prntdlgg.cpp:835
+#: ../src/generic/prntdlgg.cpp:1031 ../src/generic/prntdlgg.cpp:1036
+msgid "Paper size"
+msgstr "Papirstørrelse"
+
+#: ../src/generic/prntdlgg.cpp:604 ../src/generic/prntdlgg.cpp:847
+msgid "Portrait"
+msgstr "Portrett"
+
+#: ../src/generic/prntdlgg.cpp:605 ../src/generic/prntdlgg.cpp:848
+msgid "Landscape"
+msgstr "Liggende"
+
+#: ../src/generic/prntdlgg.cpp:607 ../src/generic/prntdlgg.cpp:849
+msgid "Orientation"
+msgstr "Orientering"
+
+#: ../src/generic/prntdlgg.cpp:610
+msgid "Options"
+msgstr "Opsjoner"
+
+#: ../src/generic/prntdlgg.cpp:612
+msgid "Print in colour"
+msgstr "Utskrift med farger"
+
+#: ../src/generic/prntdlgg.cpp:621
+msgid "Print spooling"
+msgstr "Utskriftskø"
+
+#: ../src/generic/prntdlgg.cpp:623
+msgid "Printer command:"
+msgstr "Skriverkommando:"
+
+#: ../src/generic/prntdlgg.cpp:631
+msgid "Printer options:"
+msgstr "Skriveropsjoner:"
+
+#: ../src/generic/prntdlgg.cpp:860
+msgid "Left margin (mm):"
+msgstr "Venstremarg (mm):"
+
+#: ../src/generic/prntdlgg.cpp:861
+msgid "Top margin (mm):"
+msgstr "Toppmarg (mm):"
+
+#: ../src/generic/prntdlgg.cpp:872
+msgid "Right margin (mm):"
+msgstr "Høyremarg (mm):"
+
+#: ../src/generic/prntdlgg.cpp:873
+msgid "Bottom margin (mm):"
+msgstr "Marg nede (mm):"
+
+#: ../src/generic/prntdlgg.cpp:896
+msgid "Printer..."
+msgstr "Skriver..."
+
+#: ../src/generic/progdlgg.cpp:246
+#, fuzzy
+msgid "&Skip"
+msgstr "Hopp over"
+
+#: ../src/generic/progdlgg.cpp:347 ../src/generic/progdlgg.cpp:626
+#, fuzzy
+msgid "Unknown"
+msgstr "ukjent"
+
+#: ../src/generic/progdlgg.cpp:451 ../src/msw/progdlg.cpp:526
+msgid "Done."
+msgstr "ferdig."
+
+#: ../src/generic/srchctlg.cpp:55 ../src/gtk/srchctrl.cpp:206
+#: ../src/html/helpwnd.cpp:530 ../src/html/helpwnd.cpp:545
+msgid "Search"
+msgstr "Søk"
+
+#: ../src/generic/tabg.cpp:1026
+msgid "Could not find tab for id"
+msgstr "Klarte ikke finne tab for id"
+
+#: ../src/generic/tipdlg.cpp:136
+msgid "Tips not available, sorry!"
+msgstr "Tips er ikke tilgjengelig, beklager!"
+
+#: ../src/generic/tipdlg.cpp:197
+msgid "Tip of the Day"
+msgstr "Dagens tips"
+
+#: ../src/generic/tipdlg.cpp:207
+msgid "Did you know..."
+msgstr "Visste du at..."
+
+#: ../src/generic/tipdlg.cpp:232
+msgid "&Show tips at startup"
+msgstr "&Vis tips ved oppstart"
+
+#: ../src/generic/tipdlg.cpp:236
+msgid "&Next Tip"
+msgstr "&Neste tips"
+
+#: ../src/generic/wizard.cpp:411
+msgid "&Next >"
+msgstr "&Neste >"
+
+#: ../src/generic/wizard.cpp:412
+msgid "&Finish"
+msgstr "&Fullfør"
+
+#: ../src/generic/wizard.cpp:420
+msgid "< &Back"
+msgstr "< &Tilbake"
+
+#: ../src/gtk/aboutdlg.cpp:204
+msgid "translator-credits"
+msgstr ""
+
+#: ../src/gtk/app.cpp:517
+msgid ""
+"WARNING: using XIM input method is unsupported and may result in problems "
+"with input handling and flickering. Consider unsetting GTK_IM_MODULE or "
+"setting to \"ibus\"."
+msgstr ""
+
+#: ../src/gtk/app.cpp:569
+msgid "Unable to initialize GTK+, is DISPLAY set properly?"
+msgstr ""
+
+#: ../src/gtk/filedlg.cpp:89 ../src/gtk/filepicker.cpp:255
+#, fuzzy, c-format
+msgid "Changing current directory to \"%s\" failed"
+msgstr "Klarte ikke opprette mappe «%s»"
+
+#: ../src/gtk/font.cpp:548
+msgid ""
+"Using private fonts is not supported on this system: Pango library is too "
+"old, 1.38 or later required."
+msgstr ""
+
+#: ../src/gtk/font.cpp:558
+#, fuzzy
+msgid "Failed to create font configuration object."
+msgstr "Klarte ikke oppdatere bruker konfigurasjonsfil."
+
+#: ../src/gtk/font.cpp:568
+#, fuzzy, c-format
+msgid "Failed to add custom font \"%s\"."
+msgstr "Klarte ikke laste metafil fra filen «%s»."
+
+#: ../src/gtk/font.cpp:576
+#, fuzzy
+msgid "Failed to register font configuration using private fonts."
+msgstr "Klarte ikke oppdatere bruker konfigurasjonsfil."
+
+#: ../src/gtk/glcanvas.cpp:117 ../src/gtk/glcanvas.cpp:132
+#, fuzzy
+msgid "Fatal Error"
+msgstr "Kritisk feil"
+
+#: ../src/gtk/glcanvas.cpp:117
+msgid ""
+"This program wasn't compiled with EGL support required under Wayland, "
+"either\n"
+"install EGL libraries and rebuild or run it under X11 backend by setting\n"
+"environment variable GDK_BACKEND=x11 before starting your program."
+msgstr ""
+
+#: ../src/gtk/glcanvas.cpp:132
+msgid ""
+"wxGLCanvas is only supported on Wayland and X11 currently.  You may be able "
+"to\n"
+"work around this by setting environment variable GDK_BACKEND=x11 before\n"
+"starting your program."
+msgstr ""
+
+#: ../src/gtk/mdi.cpp:433
+msgid "MDI child"
+msgstr "MDI-barn"
+
+#: ../src/gtk/power.cpp:188
+#, fuzzy, c-format
+msgid "Failed to open D-Bus connection to the login manager: %s"
+msgstr "Klarte ikke %s oppringingsforbindelse: %s"
+
+#: ../src/gtk/power.cpp:214
+#, fuzzy
+msgid "wxWidgets application"
+msgstr "Seksjoner"
+
+#: ../src/gtk/power.cpp:226
+msgid "Application needs to keep running"
+msgstr ""
+
+#: ../src/gtk/power.cpp:233
+msgid "Clean up before suspend"
+msgstr ""
+
+#: ../src/gtk/power.cpp:259
+#, fuzzy, c-format
+msgid "Failed to inhibit sleep: %s"
+msgstr "Klarte ikke avslutte oppringingskoblingen: %s"
+
+#: ../src/gtk/power.cpp:265
+msgid "Unexpected response to D-Bus \"Inhibit\" request."
+msgstr ""
+
+#: ../src/gtk/print.cpp:218
+msgid "Custom size"
+msgstr "Selvvalgt størrelse"
+
+#: ../src/gtk/print.cpp:752
+#, fuzzy, c-format
+msgid "Error while printing: %s"
+msgstr "Feil under venting på semafor"
+
+#: ../src/gtk/print.cpp:816
+msgid "Page Setup"
+msgstr "Sideoppsett"
+
+#: ../src/gtk/webview_webkit.cpp:932
+msgid "Retrieving JavaScript script output is not supported with WebKit v1"
+msgstr ""
+
+#: ../src/gtk/webview_webkit2.cpp:1098
+msgid ""
+"Setting proxy is not supported by WebKit, at least version 2.16 is required."
+msgstr ""
+
+#: ../src/gtk/webview_webkit2.cpp:1104
+msgid "This program was compiled without support for setting WebKit proxy."
+msgstr ""
+
+#: ../src/gtk/window.cpp:6289
+msgid ""
+"GTK+ installed on this machine is too old to support screen compositing, "
+"please install GTK+ 2.12 or later."
+msgstr ""
+
+#: ../src/gtk/window.cpp:6307
+msgid ""
+"Compositing not supported by this system, please enable it in your Window "
+"Manager."
+msgstr ""
+
+#: ../src/gtk/window.cpp:6318
+msgid ""
+"This program was compiled with a too old version of GTK+, please rebuild "
+"with GTK+ 2.12 or newer."
+msgstr ""
+
+#: ../src/html/chm.cpp:138
+#, c-format
+msgid "Failed to open CHM archive '%s'."
+msgstr "Klarte ikke åpne CHM arkiv «%s»."
+
+#: ../src/html/chm.cpp:270
+#, c-format
+msgid "Could not extract %s into %s: %s"
+msgstr "Klarte ikke å trekke ut %s inni %s: %s"
+
+#: ../src/html/chm.cpp:324
+msgid "no error"
+msgstr "ingen feil"
+
+#: ../src/html/chm.cpp:326
+msgid "bad arguments to library function"
+msgstr "ugyldig argument til biblioteksfunksjon"
+
+#: ../src/html/chm.cpp:328
+msgid "error opening file"
+msgstr "feil ved åpning av fil"
+
+#: ../src/html/chm.cpp:330
+msgid "read error"
+msgstr "lesefeil"
+
+#: ../src/html/chm.cpp:332
+msgid "write error"
+msgstr "skrivefeil"
+
+#: ../src/html/chm.cpp:334
+msgid "seek error"
+msgstr "søkefeil"
+
+#: ../src/html/chm.cpp:338
+msgid "bad signature"
+msgstr "ugyldig signatur"
+
+#: ../src/html/chm.cpp:340
+msgid "error in data format"
+msgstr "feil i dataformat"
+
+#: ../src/html/chm.cpp:342
+msgid "checksum error"
+msgstr "kontrollsumfeil"
+
+#: ../src/html/chm.cpp:344
+msgid "compression error"
+msgstr "kompresjonsfeil"
+
+#: ../src/html/chm.cpp:346
+msgid "decompression error"
+msgstr "feil ved utpakking"
+
+#: ../src/html/chm.cpp:437
+#, c-format
+msgid "Could not locate file '%s'."
+msgstr "Klarte ikke å finne fil «%s»."
+
+#: ../src/html/chm.cpp:711
+#, c-format
+msgid "Could not create temporary file '%s'"
+msgstr "Klarte ikke opprette midlertidig fil «%s»"
+
+#: ../src/html/chm.cpp:718
+#, c-format
+msgid "Extraction of '%s' into '%s' failed."
+msgstr "Utpakking av «%s» inni «%s» feilet."
+
+#: ../src/html/chm.cpp:806 ../src/html/chm.cpp:863
+msgid "CHM handler currently supports only local files!"
+msgstr "CHM-behandleren støtter for øyeblikket bare lokale filer!"
+
+#: ../src/html/chm.cpp:827
+msgid "Link contained '//', converted to absolute link."
+msgstr "Lenke inneholdt «//», konvertert til absolutt lenke."
+
+#: ../src/html/helpctrl.cpp:59
+#, c-format
+msgid "Help: %s"
+msgstr "Hjelp: %s"
+
+#: ../src/html/helpctrl.cpp:155
+#, c-format
+msgid "Adding book %s"
+msgstr "Legger til bok %s"
+
+#: ../src/html/helpdata.cpp:295
+#, c-format
+msgid "Cannot open contents file: %s"
+msgstr "Klarte ikke åpne innholdsfil: %s"
+
+#: ../src/html/helpdata.cpp:309
+#, c-format
+msgid "Cannot open index file: %s"
+msgstr "Klarte ikke åpne indeksfile: %s"
+
+#: ../src/html/helpdata.cpp:643
+msgid "noname"
+msgstr "ikke navn"
+
+#: ../src/html/helpdata.cpp:652
+#, c-format
+msgid "Cannot open HTML help book: %s"
+msgstr "Klarte ikke åpne HTML-hjelpebok: %s"
+
+#: ../src/html/helpwnd.cpp:315
+msgid "Displays help as you browse the books on the left."
+msgstr "Viser hjelp mens du blar gjennom bøkene til venstre."
+
+#: ../src/html/helpwnd.cpp:411 ../src/html/helpwnd.cpp:1100
+#: ../src/html/helpwnd.cpp:1735
+msgid "(bookmarks)"
+msgstr "(bokmerker)"
+
+#: ../src/html/helpwnd.cpp:424
+msgid "Add current page to bookmarks"
+msgstr "Legg til gjeldende side til bokmerkene"
+
+#: ../src/html/helpwnd.cpp:425
+msgid "Remove current page from bookmarks"
+msgstr "Slett gjeldende side fra bokmerker"
+
+#: ../src/html/helpwnd.cpp:470
+msgid "Contents"
+msgstr "Innhold"
+
+#: ../src/html/helpwnd.cpp:485
+msgid "Find"
+msgstr "Finn"
+
+#: ../src/html/helpwnd.cpp:487
+msgid "Show all"
+msgstr "Vis alle"
+
+#: ../src/html/helpwnd.cpp:497
+msgid ""
+"Display all index items that contain given substring. Search is case "
+"insensitive."
+msgstr ""
+"Vis alle indekselementer som inneholder den oppgitte delstrengen. Søket er "
+"uavhengig av liten eller stor bokstav."
+
+#: ../src/html/helpwnd.cpp:498
+msgid "Show all items in index"
+msgstr "Vis alle elementer i indeksen"
+
+#: ../src/html/helpwnd.cpp:528
+msgid "Case sensitive"
+msgstr "Skill mellom små og store bokstaver"
+
+#: ../src/html/helpwnd.cpp:529
+msgid "Whole words only"
+msgstr "Bare hele ord"
+
+#: ../src/html/helpwnd.cpp:532
+#, fuzzy
+msgid ""
+"Search contents of help book(s) for all occurrences of the text you typed "
+"above"
+msgstr "Søk innholdet av alle hjelpebøker etter teksten du skrev ovenfor"
+
+#: ../src/html/helpwnd.cpp:653
+msgid "Show/hide navigation panel"
+msgstr "Vis/skjul navigasjonspanel"
+
+#: ../src/html/helpwnd.cpp:655
+msgid "Go back"
+msgstr "Gå tilbake"
+
+#: ../src/html/helpwnd.cpp:656
+msgid "Go forward"
+msgstr "Gå frem"
+
+#: ../src/html/helpwnd.cpp:658
+msgid "Go one level up in document hierarchy"
+msgstr "Gå et nivå opp i dokumenthierarkiet"
+
+#: ../src/html/helpwnd.cpp:666 ../src/html/helpwnd.cpp:1547
+msgid "Open HTML document"
+msgstr "Åpne HTML-dokument"
+
+#: ../src/html/helpwnd.cpp:670
+msgid "Print this page"
+msgstr "Skriv ut denne siden"
+
+#: ../src/html/helpwnd.cpp:674
+msgid "Display options dialog"
+msgstr "Vis innstillingsvindu"
+
+#: ../src/html/helpwnd.cpp:795
+msgid "Please choose the page to display:"
+msgstr "Velg siden som skal vises:"
+
+#: ../src/html/helpwnd.cpp:796
+msgid "Help Topics"
+msgstr "Emner for hjelp"
+
+#: ../src/html/helpwnd.cpp:852
+msgid "Searching..."
+msgstr "Søker..."
+
+#: ../src/html/helpwnd.cpp:853
+msgid "No matching page found yet"
+msgstr "Ingen sider med treff funnet enda"
+
+#: ../src/html/helpwnd.cpp:870
+#, c-format
+msgid "Found %i matches"
+msgstr "Fant %i treff"
+
+#: ../src/html/helpwnd.cpp:958
+msgid "(Help)"
+msgstr "(Hjelp)"
+
+#: ../src/html/helpwnd.cpp:1026
+#, fuzzy, c-format
+msgid "%d of %lu"
+msgstr "%i av %i"
+
+#: ../src/html/helpwnd.cpp:1028
+#, fuzzy, c-format
+msgid "%lu of %lu"
+msgstr "%i av %i"
+
+#: ../src/html/helpwnd.cpp:1047
+msgid "Search in all books"
+msgstr "Søk i alle bøker"
+
+#: ../src/html/helpwnd.cpp:1193
+msgid "Help Browser Options"
+msgstr "Innstillinger for hjelpleser"
+
+#: ../src/html/helpwnd.cpp:1198
+msgid "Normal font:"
+msgstr "Normal skrift:"
+
+#: ../src/html/helpwnd.cpp:1199
+msgid "Fixed font:"
+msgstr "Fast skrift:"
+
+#: ../src/html/helpwnd.cpp:1200
+msgid "Font size:"
+msgstr "Skriftstørrelse:"
+
+#: ../src/html/helpwnd.cpp:1245
+msgid "font size"
+msgstr "skriftstørrelse"
+
+#: ../src/html/helpwnd.cpp:1256
+msgid "Normal face<br>and <u>underlined</u>. "
+msgstr "Normal skrift<br>og <u>understreket</u>."
+
+#: ../src/html/helpwnd.cpp:1257
+msgid "<i>Italic face.</i> "
+msgstr "<i>Kursiv skrift.</i> "
+
+#: ../src/html/helpwnd.cpp:1258
+msgid "<b>Bold face.</b> "
+msgstr "<b>Fet skrift.</b> "
+
+#: ../src/html/helpwnd.cpp:1259
+msgid "<b><i>Bold italic face.</i></b><br>"
+msgstr "<b><i>Fet kursiv skrift.</i></b><br>"
+
+#: ../src/html/helpwnd.cpp:1262
+msgid "Fixed size face.<br> <b>bold</b> <i>italic</i> "
+msgstr "Fast størrelse skrift.<br> <b>fet</b> <i>kursiv</i>"
+
+#: ../src/html/helpwnd.cpp:1263
+msgid "<b><i>bold italic <u>underlined</u></i></b><br>"
+msgstr "<b><i>fet kursiv <u>understreket</u></i></b><br>"
+
+#: ../src/html/helpwnd.cpp:1524
+msgid "Help Printing"
+msgstr "Skriv ut hjelp"
+
+#: ../src/html/helpwnd.cpp:1527
+msgid "Cannot print empty page."
+msgstr "Klarte ikke skrive ut tom side."
+
+#: ../src/html/helpwnd.cpp:1540
+msgid "HTML files (*.html;*.htm)|*.html;*.htm|"
+msgstr "HTML-filer  (*.html;*.htm)|*.html;*.htm|"
+
+#: ../src/html/helpwnd.cpp:1541
+msgid "Help books (*.htb)|*.htb|Help books (*.zip)|*.zip|"
+msgstr "Hjelpebøker (*.htb)|*.htb|Hjelpebøker (*.zip)|*.zip|"
+
+#: ../src/html/helpwnd.cpp:1542
+msgid "HTML Help Project (*.hhp)|*.hhp|"
+msgstr "HTML hjelpprosjekt (*.hhp)|*.hhp|"
+
+#: ../src/html/helpwnd.cpp:1544
+msgid "Compressed HTML Help file (*.chm)|*.chm|"
+msgstr "Komprimert HTML-hjelpfil (*.chm)|*.chm|"
+
+#: ../src/html/helpwnd.cpp:1671
+#, fuzzy, c-format
+msgid "%i of %u"
+msgstr "%i av %i"
+
+#: ../src/html/helpwnd.cpp:1709
+#, fuzzy, c-format
+msgid "%u of %u"
+msgstr "%i av %i"
+
+#: ../src/html/htmlfilt.cpp:134
+#, c-format
+msgid "Cannot open HTML document: %s"
+msgstr "Klarte ikke åpne HTML-dokument: %s"
+
+#: ../src/html/htmlwin.cpp:599
+msgid "Connecting..."
+msgstr "Kobler til..."
+
+#: ../src/html/htmlwin.cpp:616
+#, c-format
+msgid "Unable to open requested HTML document: %s"
+msgstr "Klarte ikke åpne forespurt HTML-dokument: %s"
+
+#: ../src/html/htmlwin.cpp:630
+msgid "Loading : "
+msgstr "Laster:"
+
+#: ../src/html/htmlwin.cpp:673
+msgid "Done"
+msgstr "Ferdig"
+
+#: ../src/html/htmlwin.cpp:723
+#, c-format
+msgid "HTML anchor %s does not exist."
+msgstr "HTML-anker %s finnes ikke."
+
+#: ../src/html/htmlwin.cpp:1057
+#, c-format
+msgid "Copied to clipboard:\"%s\""
+msgstr "Kopiert til utklippstavle: «%s»"
+
+#: ../src/html/htmprint.cpp:269
+msgid ""
+"This document doesn't fit on the page horizontally and will be truncated "
+"when it is printed."
+msgstr ""
+"Dette dokumentet passer ikke horisontalt på siden og vil bli kuttet når det "
+"skrives ut."
+
+#: ../src/html/htmprint.cpp:285
+#, c-format
+msgid ""
+"The document \"%s\" doesn't fit on the page horizontally and will be "
+"truncated if printed.\n"
+"\n"
+"Would you like to proceed with printing it nevertheless?"
+msgstr ""
+"Dokumentet \"%s\" passer ikke horisontalt på siden ok vil kuttes når det "
+"skrives ut.\n"
+"\n"
+"Vil du fortsette likevel?"
+
+#: ../src/html/htmprint.cpp:296
+msgid ""
+"If possible, try changing the layout parameters to make the printout more "
+"narrow."
+msgstr "Om mulig forsøk å endre parametrene for å gjøre utskriften smalere."
+
+#: ../src/html/htmprint.cpp:445
+msgid ": file does not exist!"
+msgstr ": filen eksisterer ikke!"
+
+#. TRANSLATORS: %s may be a document title.
+#: ../src/html/htmprint.cpp:717
+#, fuzzy, c-format
+msgid "%s Preview"
+msgstr "Forhåndsvisning"
+
+#: ../src/html/htmprint.cpp:755 ../src/richtext/richtextprint.cpp:618
+msgid ""
+"There was a problem during page setup: you may need to set a default printer."
+msgstr ""
+"Det oppstod et problem med sideoppsettet - kanskje du må installere en "
+"skriver."
+
+#: ../src/msw/clipbrd.cpp:80
+msgid "Failed to open the clipboard."
+msgstr "Klarte ikke åpne utklippstavle."
+
+#: ../src/msw/clipbrd.cpp:101
+msgid "Failed to close the clipboard."
+msgstr "Klarte ikke lukke utklippstavlen."
+
+#: ../src/msw/clipbrd.cpp:113
+msgid "Failed to empty the clipboard."
+msgstr "Klarte ikke tømme utklippstavlen."
+
+#: ../src/msw/clipbrd.cpp:284
+msgid "Failed to put data on the clipboard"
+msgstr "Klarte ikke putte data på utklippstavlen."
+
+#: ../src/msw/clipbrd.cpp:326
+msgid "Failed to get data from the clipboard"
+msgstr "Klarte ikke hente data fra utklippstavlen."
+
+#: ../src/msw/clipbrd.cpp:363
+msgid "Failed to retrieve the supported clipboard formats"
+msgstr "Klarte ikke hente støttede utklippstavleformat"
+
+#: ../src/msw/colordlg.cpp:228
+#, fuzzy, c-format
+msgid "Colour selection dialog failed with error %0lx."
+msgstr "Utførelse av kommandoen «%s» feilet med feil: %ul"
+
+#: ../src/msw/cursor.cpp:141
+msgid "Failed to create cursor."
+msgstr "Klarte ikke opprette peker."
+
+#: ../src/msw/dde.cpp:279
+#, c-format
+msgid "Failed to register DDE server '%s'"
+msgstr "Klarte ikke registrere DDE-tjener «%s»"
+
+#: ../src/msw/dde.cpp:300
+#, c-format
+msgid "Failed to unregister DDE server '%s'"
+msgstr "Klarte ikke avregistrere DDE-tjener «%s»"
+
+#: ../src/msw/dde.cpp:428
+#, c-format
+msgid "Failed to create connection to server '%s' on topic '%s'"
+msgstr "Klarte ikke opprette forbindelse til tjener «%s» med budskap «%s»"
+
+#: ../src/msw/dde.cpp:655
+msgid "DDE poke request failed"
+msgstr "DDE-«snuse» forespørsel feilet"
+
+#: ../src/msw/dde.cpp:674
+msgid "Failed to establish an advise loop with DDE server"
+msgstr "Klarte ikke opprette en rådgivningsløkke med DDE-tjeneren"
+
+#: ../src/msw/dde.cpp:693
+msgid "Failed to terminate the advise loop with DDE server"
+msgstr "Klarte ikke avslutte rådgivningsløkka med DDE-tjeneren"
+
+#: ../src/msw/dde.cpp:768
+msgid "Failed to send DDE advise notification"
+msgstr "Klarte ikke send DDE-rådgivningsmelding"
+
+#: ../src/msw/dde.cpp:1085
+msgid "Failed to create DDE string"
+msgstr "Klarte ikke opprette DDE-streng"
+
+#: ../src/msw/dde.cpp:1131
+msgid "no DDE error."
+msgstr "ingen DDE-feil"
+
+#: ../src/msw/dde.cpp:1135
+msgid "a request for a synchronous advise transaction has timed out."
+msgstr "tidsavbrudd i en forespørsel etter synkron rådtransaksjon"
+
+#: ../src/msw/dde.cpp:1138
+msgid "the response to the transaction caused the DDE_FBUSY bit to be set."
+msgstr "svaret på transaksjonen gjorde at DDE_FBUSY-biten ble satt."
+
+#: ../src/msw/dde.cpp:1141
+msgid "a request for a synchronous data transaction has timed out."
+msgstr "tidsavbrudd i en forespørsel etter synkron datatransaksjon"
+
+#: ../src/msw/dde.cpp:1144
+msgid ""
+"a DDEML function was called without first calling the DdeInitialize "
+"function,\n"
+"or an invalid instance identifier\n"
+"was passed to a DDEML function."
+msgstr ""
+"en DDEML-funksjon ble kalt uten at DdeInitialize-funksjonen ble kalt først,\n"
+"eller en ugyldig instanseindentifikator\n"
+"ble sendt til en DDEML-funksjon."
+
+#: ../src/msw/dde.cpp:1147
+msgid ""
+"an application initialized as APPCLASS_MONITOR has\n"
+"attempted to perform a DDE transaction,\n"
+"or an application initialized as APPCMD_CLIENTONLY has \n"
+"attempted to perform server transactions."
+msgstr ""
+"et program initialisert som APPCLASS_MONITOR har\n"
+"prøvd å utføre en DDE-transaksjon,\n"
+"eller et program initialisert som APPCMD_CLIENTONLY har\n"
+"prøvd å utføre tjenertransaksjoner."
+
+#: ../src/msw/dde.cpp:1150
+msgid "a request for a synchronous execute transaction has timed out."
+msgstr "en forespørsel om en synkron utførselstransaksjon har gått ut på tid."
+
+#: ../src/msw/dde.cpp:1153
+msgid "a parameter failed to be validated by the DDEML."
+msgstr "en parameter ble ikke validert av DDEML-en."
+
+#: ../src/msw/dde.cpp:1156
+msgid "a DDEML application has created a prolonged race condition."
+msgstr "et DDEML-program har skapt en prolongert kappløpsbetingelse."
+
+#: ../src/msw/dde.cpp:1159
+msgid "a memory allocation failed."
+msgstr "en minnereservasjon feilet."
+
+#: ../src/msw/dde.cpp:1162
+msgid "a client's attempt to establish a conversation has failed."
+msgstr "en klients forsøk på å etablere en konversasjon feilet."
+
+#: ../src/msw/dde.cpp:1165
+msgid "a transaction failed."
+msgstr "en transaksjon feilet."
+
+#: ../src/msw/dde.cpp:1168
+msgid "a request for a synchronous poke transaction has timed out."
+msgstr "en forespørsel om en asynkron «snuse»-transaksjon har gått ut på tid."
+
+#: ../src/msw/dde.cpp:1171
+msgid "an internal call to the PostMessage function has failed. "
+msgstr "Et internt kall til PostMessage-funksjonen feilet."
+
+#: ../src/msw/dde.cpp:1174
+msgid "reentrancy problem."
+msgstr "gjeninngangsproblem."
+
+#: ../src/msw/dde.cpp:1177
+msgid ""
+"a server-side transaction was attempted on a conversation\n"
+"that was terminated by the client, or the server\n"
+"terminated before completing a transaction."
+msgstr ""
+"en tjenerside-transaksjon ble forsøkt på en samtale\n"
+"som ble avsluttet av klienten, eller tjeneren ble\n"
+"slått av før transaksjonen ble fullført."
+
+#: ../src/msw/dde.cpp:1180
+msgid "an internal error has occurred in the DDEML."
+msgstr "En intern feil har oppstått i DDEML-en."
+
+#: ../src/msw/dde.cpp:1183
+msgid "a request to end an advise transaction has timed out."
+msgstr ""
+"en forespørsel om å avslutte en rådgivningstransaksjon har gått ut på tid."
+
+#: ../src/msw/dde.cpp:1186
+msgid ""
+"an invalid transaction identifier was passed to a DDEML function.\n"
+"Once the application has returned from an XTYP_XACT_COMPLETE callback,\n"
+"the transaction identifier for that callback is no longer valid."
+msgstr ""
+"en ugyldig transaksjonsidentifikator ble sendt til en DDEML-funksjon.\n"
+"Når programmet har returnert fra et XTYP_XACT_COMPLETE-tilbakekall,\n"
+"så vil ikke transaksjonsidentifikatoren for det tilbakekallet lenger være "
+"gyldig."
+
+#: ../src/msw/dde.cpp:1189
+#, c-format
+msgid "Unknown DDE error %08x"
+msgstr "Ukjent DDE-feil %08x"
+
+#: ../src/msw/dialup.cpp:343
+msgid ""
+"Dial up functions are unavailable because the remote access service (RAS) is "
+"not installed on this machine. Please install it."
+msgstr ""
+"Oppringingsfunskjonene er utilgjengelig fordi Remote Access Service (RAS) "
+"ikke er installert på denne maskinene."
+
+#: ../src/msw/dialup.cpp:402
+#, fuzzy, c-format
+msgid ""
+"The version of remote access service (RAS) installed on this machine is too "
+"old, please upgrade (the following required function is missing: %s)."
+msgstr ""
+"Versjonen av Remote Access Service (RAS) installert på denne maskinen er for "
+"gammel. Du må oppgradere - følgende påkrevd funksjon mangler: %s"
+
+#: ../src/msw/dialup.cpp:437
+msgid "Failed to retrieve text of RAS error message"
+msgstr "Klarte ikke hente tekst fra RAS feilmelding"
+
+#: ../src/msw/dialup.cpp:440
+#, c-format
+msgid "unknown error (error code %08x)."
+msgstr "ukjent feil (feilkode %08x)."
+
+#: ../src/msw/dialup.cpp:492
+#, c-format
+msgid "Cannot find active dialup connection: %s"
+msgstr "Klarte ikke finne aktiv oppringingsforbindelse: %s"
+
+#: ../src/msw/dialup.cpp:513
+msgid "Several active dialup connections found, choosing one randomly."
+msgstr "Flere aktive oppringingsforbindelser funnet, velger en tilfeldig."
+
+#: ../src/msw/dialup.cpp:598 ../src/msw/dialup.cpp:832
+#, c-format
+msgid "Failed to establish dialup connection: %s"
+msgstr "Klarte ikke opprette oppringingsforbindelse: %s"
+
+#: ../src/msw/dialup.cpp:664
+#, c-format
+msgid "Failed to get ISP names: %s"
+msgstr "Klarte ikke få ISP navn: %s"
+
+#: ../src/msw/dialup.cpp:712
+msgid "Failed to connect: no ISP to dial."
+msgstr "Klarte ikke opprette forbindelse: ingen ISP å ringe til."
+
+#: ../src/msw/dialup.cpp:732
+msgid "Choose ISP to dial"
+msgstr "Velg ISP for oppringing"
+
+#: ../src/msw/dialup.cpp:733
+msgid "Please choose which ISP do you want to connect to"
+msgstr "Velg hvilken ISP du vil koble til"
+
+#: ../src/msw/dialup.cpp:766
+msgid "Failed to connect: missing username/password."
+msgstr "Klarte ikke opprette forbindelse: manglende brukernavn/passord."
+
+#: ../src/msw/dialup.cpp:796
+msgid "Cannot find the location of address book file"
+msgstr "Klarte ikke plasseringen til adressebokfilen"
+
+#: ../src/msw/dialup.cpp:827
+#, fuzzy, c-format
+msgid "Failed to initiate dialup connection: %s"
+msgstr "Klarte ikke avslutte oppringingskoblingen: %s"
+
+#: ../src/msw/dialup.cpp:897
+msgid "Cannot hang up - no active dialup connection."
+msgstr "Klarte ikke legge på - ingen aktiv oppringingsforbindelse."
+
+#: ../src/msw/dialup.cpp:907
+#, c-format
+msgid "Failed to terminate the dialup connection: %s"
+msgstr "Klarte ikke avslutte oppringingskoblingen: %s"
+
+#: ../src/msw/dib.cpp:313
+#, c-format
+msgid "Failed to save the bitmap image to file \"%s\"."
+msgstr "Klarte ikke lagre bitmap-bilde til filen «%s». "
+
+#: ../src/msw/dib.cpp:543
+#, fuzzy, c-format
+msgid "Failed to allocate %luKb of memory for bitmap data."
+msgstr "Klarte ikke reservere %lu Kb minne for bitmap data."
+
+#: ../src/msw/dir.cpp:241
+#, c-format
+msgid "Cannot enumerate files in directory '%s'"
+msgstr "Klarte ikke telle opp filer i mappen «%s»"
+
+#: ../src/msw/dirdlg.cpp:368
+#, fuzzy
+msgid "Couldn't obtain folder name"
+msgstr "Klarte ikke opprette en timer"
+
+#: ../src/msw/dlmsw.cpp:163
+#, fuzzy, c-format
+msgid "(error %d: %s)"
+msgstr "(feil %ld: %s)"
+
+#: ../src/msw/dragimag.cpp:143 ../src/msw/dragimag.cpp:178
+#: ../src/msw/imaglist.cpp:309 ../src/msw/imaglist.cpp:331
+msgid "Couldn't add an image to the image list."
+msgstr "Klarte ikke legge til et bilde i bildelisten."
+
+#: ../src/msw/enhmeta.cpp:94
+#, c-format
+msgid "Failed to load metafile from file \"%s\"."
+msgstr "Klarte ikke laste metafil fra filen «%s»."
+
+#: ../src/msw/fdrepdlg.cpp:412
+#, c-format
+msgid "Failed to create the standard find/replace dialog (error code %d)"
+msgstr "Klarte ikke opprette standard finn/erstattvindu (feilkode %d)"
+
+#: ../src/msw/filedlg.cpp:1241
+msgid "Access to the file system is not allowed from secure desktop."
+msgstr ""
+
+#: ../src/msw/filedlg.cpp:1242
+msgid "Security warning"
+msgstr ""
+
+#: ../src/msw/filedlg.cpp:1533
+#, fuzzy, c-format
+msgid "File dialog failed with error code %0lx."
+msgstr "Utførelse av kommandoen «%s» feilet med feil: %ul"
+
+#: ../src/msw/font.cpp:1120
+#, fuzzy, c-format
+msgid "Font file \"%s\" couldn't be loaded"
+msgstr "Klarte ikke laste filen."
+
+#: ../src/msw/fontdlg.cpp:220
+#, fuzzy, c-format
+msgid "Common dialog failed with error code %0lx."
+msgstr "Utførelse av kommandoen «%s» feilet med feil: %ul"
+
+#: ../src/msw/fswatcher.cpp:67
+#, fuzzy
+msgid "Ungraceful worker thread termination"
+msgstr "Klarte ikke vente på trådens avslutning"
+
+#: ../src/msw/fswatcher.cpp:81
+#, fuzzy
+msgid "Unable to create IOCP worker thread"
+msgstr "Klarte ikke opprette MDI foreldreramme."
+
+#: ../src/msw/fswatcher.cpp:88
+msgid "Unable to start IOCP worker thread"
+msgstr ""
+
+#: ../src/msw/fswatcher.cpp:140
+msgid "Monitoring individual files for changes is not supported currently."
+msgstr "Overvåking av endringer av individuelle filer er ikke støttet. "
+
+#: ../src/msw/fswatcher.cpp:165
+#, fuzzy, c-format
+msgid "Unable to set up watch for '%s'"
+msgstr "Klarte ikke rør filen «%s»"
+
+#: ../src/msw/fswatcher.cpp:466
+#, c-format
+msgid "Can't monitor non-existent directory \"%s\" for changes."
+msgstr "Kan ikke overvåke ikkeeksisterende katalog \"%s\" for endringer"
+
+#: ../src/msw/glcanvas.cpp:577 ../src/unix/glx11.cpp:507
+msgid "OpenGL 3.0 or later is not supported by the OpenGL driver."
+msgstr ""
+
+#: ../src/msw/glcanvas.cpp:601 ../src/osx/glcanvas_osx.cpp:395
+#: ../src/unix/glegl.cpp:304 ../src/unix/glx11.cpp:553
+#, fuzzy
+msgid "Couldn't create OpenGL context"
+msgstr "Klarte ikke opprette en timer"
+
+#: ../src/msw/glcanvas.cpp:1294
+msgid "Failed to initialize OpenGL"
+msgstr "Klarte ikke initialisere OpenGL"
+
+#: ../src/msw/graphicsd2d.cpp:607
+msgid "Could not register custom DirectWrite font loader."
+msgstr ""
+
+#: ../src/msw/helpchm.cpp:48
+msgid ""
+"MS HTML Help functions are unavailable because the MS HTML Help library is "
+"not installed on this machine. Please install it."
+msgstr ""
+"MS HTML hjelpefunksjoner er utilgjengelig fordi MS HTML hjelpebiblioteket "
+"ikke er installert på denne maskinen."
+
+#: ../src/msw/helpchm.cpp:55
+msgid "Failed to initialize MS HTML Help."
+msgstr "Klarte ikke initialisere MS HTML hjelp."
+
+#: ../src/msw/iniconf.cpp:458
+#, c-format
+msgid "Can't delete the INI file '%s'"
+msgstr "Klarte ikke slette INI-filen «%s»"
+
+#: ../src/msw/listctrl.cpp:995
+#, c-format
+msgid "Couldn't retrieve information about list control item %d."
+msgstr "Klarte ikke hente informasjon om listekontrolelement %d."
+
+#: ../src/msw/mdi.cpp:170 ../src/qt/mdi.cpp:253
+msgid "&Cascade"
+msgstr "&Kaskade"
+
+#: ../src/msw/mdi.cpp:171
+msgid "Tile &Horizontally"
+msgstr "Tile &horisontalt"
+
+#: ../src/msw/mdi.cpp:172
+msgid "Tile &Vertically"
+msgstr "Tile &vertikalt"
+
+#: ../src/msw/mdi.cpp:174
+msgid "&Arrange Icons"
+msgstr "&Still opp ikoner"
+
+#: ../src/msw/mdi.cpp:621
+msgid "Failed to create MDI parent frame."
+msgstr "Klarte ikke opprette MDI foreldreramme."
+
+#: ../src/msw/mimetype.cpp:234
+#, c-format
+msgid "Failed to create registry entry for '%s' files."
+msgstr "Klarte ikke opprette registeroppføring for «%s»-filer."
+
+#: ../src/msw/ole/automtn.cpp:495
+#, fuzzy, c-format
+msgid "Failed to find CLSID of \"%s\""
+msgstr "Klarte ikke åpne «%s» for «%s»"
+
+#: ../src/msw/ole/automtn.cpp:512
+#, fuzzy, c-format
+msgid "Failed to create an instance of \"%s\""
+msgstr "Klarte ikke opprette mappe «%s»"
+
+#: ../src/msw/ole/automtn.cpp:552
+#, fuzzy, c-format
+msgid "Cannot get an active instance of \"%s\""
+msgstr "Klarte ikke finne aktiv oppringingsforbindelse: %s"
+
+#: ../src/msw/ole/automtn.cpp:564
+#, fuzzy, c-format
+msgid "Failed to get OLE automation interface for \"%s\""
+msgstr "Klarte ikke opprette mappe «%s»"
+
+#: ../src/msw/ole/automtn.cpp:621
+msgid "Unknown name or named argument."
+msgstr "Ukjent navn eller argument."
+
+#: ../src/msw/ole/automtn.cpp:625
+msgid "Incorrect number of arguments."
+msgstr ""
+
+#: ../src/msw/ole/automtn.cpp:637
+#, fuzzy
+msgid "Unknown exception"
+msgstr "Ukjent opsjon «%s»"
+
+#: ../src/msw/ole/automtn.cpp:642
+msgid "Method or property not found."
+msgstr ""
+
+#: ../src/msw/ole/automtn.cpp:646
+msgid "Overflow while coercing argument values."
+msgstr ""
+
+#: ../src/msw/ole/automtn.cpp:650
+msgid "Object implementation does not support named arguments."
+msgstr ""
+
+#: ../src/msw/ole/automtn.cpp:654
+msgid "The locale ID is unknown."
+msgstr "ID på din locale er ukjent."
+
+#: ../src/msw/ole/automtn.cpp:658
+msgid "Missing a required parameter."
+msgstr "En påkrevd parameter mangler."
+
+#: ../src/msw/ole/automtn.cpp:662
+#, fuzzy, c-format
+msgid "Argument %u not found."
+msgstr "katalogfil for domene «%s» ikke funnet."
+
+#: ../src/msw/ole/automtn.cpp:666
+#, c-format
+msgid "Type mismatch in argument %u."
+msgstr ""
+
+#: ../src/msw/ole/automtn.cpp:670
+msgid "The system cannot find the file specified."
+msgstr "Systemet kan ikke finne den spesifiserte filen."
+
+#: ../src/msw/ole/automtn.cpp:674
+#, fuzzy
+msgid "Class not registered."
+msgstr "Klarte ikke opprette tråd"
+
+#: ../src/msw/ole/automtn.cpp:678
+#, fuzzy, c-format
+msgid "Unknown error %08x"
+msgstr "Ukjent DDE-feil %08x"
+
+#: ../src/msw/ole/automtn.cpp:682
+#, c-format
+msgid "OLE Automation error in %s: %s"
+msgstr ""
+
+#: ../src/msw/ole/dataobj.cpp:385
+#, c-format
+msgid "Couldn't register clipboard format '%s'."
+msgstr "Klarte ikke registrere utklippstavleformat «%s»."
+
+#: ../src/msw/ole/dataobj.cpp:402
+#, c-format
+msgid "The clipboard format '%d' doesn't exist."
+msgstr "Utklippstavleformatet «%d» finnes ikke."
+
+#: ../src/msw/progdlg.cpp:1025
+msgid "Skip"
+msgstr "Hopp over"
+
+#: ../src/msw/registry.cpp:141
+#, fuzzy, c-format
+msgid "unknown (%lu)"
+msgstr "ukjent"
+
+#: ../src/msw/registry.cpp:409
+#, c-format
+msgid "Can't get info about registry key '%s'"
+msgstr "Klarte ikke finne informasjon om registernøkkel «%s»"
+
+#: ../src/msw/registry.cpp:445
+#, c-format
+msgid "Can't open registry key '%s'"
+msgstr "Kan ikke åpne registernøkkel «%s»"
+
+#: ../src/msw/registry.cpp:478
+#, c-format
+msgid "Can't create registry key '%s'"
+msgstr "Klarte ikke opprette registernøkkel «%s»"
+
+#: ../src/msw/registry.cpp:497
+#, c-format
+msgid "Can't close registry key '%s'"
+msgstr "Klarte ikke lukke registernøkkel «%s»"
+
+#: ../src/msw/registry.cpp:512
+#, c-format
+msgid "Registry value '%s' already exists."
+msgstr "Registerverdi «%s» eksisterer allerede."
+
+#: ../src/msw/registry.cpp:520
+#, c-format
+msgid "Failed to rename registry value '%s' to '%s'."
+msgstr "Klarte ikke endre navn på registerverdi «%s» til «%s»."
+
+#: ../src/msw/registry.cpp:575
+#, c-format
+msgid "Can't copy values of unsupported type %d."
+msgstr "Klarte ikke kopiere verdier av ikke-støttet type %d."
+
+#: ../src/msw/registry.cpp:586
+#, c-format
+msgid "Registry key '%s' does not exist, cannot rename it."
+msgstr "Registernøkkel «%s» eksisterer ikke, kan ikke endre navn."
+
+#: ../src/msw/registry.cpp:617
+#, c-format
+msgid "Registry key '%s' already exists."
+msgstr "Registernøkkel «%s» eksisterer allerede."
+
+#: ../src/msw/registry.cpp:625
+#, c-format
+msgid "Failed to rename the registry key '%s' to '%s'."
+msgstr "Klarte ikke endre navn på registernøkkel «%s» til «%s»."
+
+#: ../src/msw/registry.cpp:670
+#, c-format
+msgid "Failed to copy the registry subkey '%s' to '%s'."
+msgstr "Klarte ikke kopiere registerundernøkkel «%s» til «%s»."
+
+#: ../src/msw/registry.cpp:683
+#, c-format
+msgid "Failed to copy registry value '%s'"
+msgstr "Klarte ikke kopiere registerverdir «%s»."
+
+#: ../src/msw/registry.cpp:692
+#, c-format
+msgid "Failed to copy the contents of registry key '%s' to '%s'."
+msgstr "Klarte ikke kopiere innholdet av registernøkkel «%s» til «%s»."
+
+#: ../src/msw/registry.cpp:718
+#, c-format
+msgid ""
+"Registry key '%s' is needed for normal system operation,\n"
+"deleting it will leave your system in unusable state:\n"
+"operation aborted."
+msgstr ""
+"Registernøkkel «%s» trengs for normal systemoperasjon,\n"
+"sletting vil etterlate system i en ubrukbar tilstand:\n"
+"operasjon avbrutt."
+
+#: ../src/msw/registry.cpp:754
+#, c-format
+msgid "Can't delete key '%s'"
+msgstr "Klarte ikke slette nøkkel «%s»"
+
+#: ../src/msw/registry.cpp:782
+#, c-format
+msgid "Can't delete value '%s' from key '%s'"
+msgstr "Klarte ikke slette verdien «%s» fra nøkkelen «%s»"
+
+#: ../src/msw/registry.cpp:855 ../src/msw/registry.cpp:887
+#: ../src/msw/registry.cpp:929 ../src/msw/registry.cpp:1000
+#, c-format
+msgid "Can't read value of key '%s'"
+msgstr "Klarte ikke lese verdien av nøkkel «%s»"
+
+#: ../src/msw/registry.cpp:873 ../src/msw/registry.cpp:915
+#: ../src/msw/registry.cpp:963 ../src/msw/registry.cpp:1106
+#, c-format
+msgid "Can't set value of '%s'"
+msgstr "Klarte ikke sette verdien for «%s»"
+
+#: ../src/msw/registry.cpp:894 ../src/msw/registry.cpp:943
+#, c-format
+msgid "Registry value \"%s\" is not numeric (but of type %s)"
+msgstr ""
+
+#: ../src/msw/registry.cpp:979
+#, c-format
+msgid "Registry value \"%s\" is not binary (but of type %s)"
+msgstr ""
+
+#: ../src/msw/registry.cpp:1028
+#, c-format
+msgid "Registry value \"%s\" is not text (but of type %s)"
+msgstr ""
+
+#: ../src/msw/registry.cpp:1089
+#, c-format
+msgid "Can't read value of '%s'"
+msgstr "Klarte ikke lese verdien til «%s»"
+
+#: ../src/msw/registry.cpp:1157
+#, c-format
+msgid "Can't enumerate values of key '%s'"
+msgstr "Klarte ikke telle opp verdier for nøkkel «%s»"
+
+#: ../src/msw/registry.cpp:1196
+#, c-format
+msgid "Can't enumerate subkeys of key '%s'"
+msgstr "Klarte ikke telle opp undernøkler av nøkkel «%s»"
+
+#: ../src/msw/registry.cpp:1262
+#, c-format
+msgid ""
+"Exporting registry key: file \"%s\" already exists and won't be overwritten."
+msgstr ""
+"Eksporterer registernøkkel: file «%s» eksisterer allerede og kan ikke "
+"overskrives"
+
+#: ../src/msw/registry.cpp:1411
+#, c-format
+msgid "Can't export value of unsupported type %d."
+msgstr "Klarte ikke eksportere verdi av ikke-støttet type %d."
+
+#: ../src/msw/registry.cpp:1427
+#, c-format
+msgid "Ignoring value \"%s\" of the key \"%s\"."
+msgstr "Ignorerer verdi «%s» for nøkkel «%s»"
+
+#: ../src/msw/textctrl.cpp:596
+msgid ""
+"Impossible to create a rich edit control, using simple text control instead. "
+"Please reinstall riched32.dll"
+msgstr ""
+"Klarte ikke opprette rik redigeringskontroll, bruker enkel tekstkontroll i "
+"steden. Gjeninstaller riched32.dll."
+
+#: ../src/msw/thread.cpp:522 ../src/unix/threadpsx.cpp:850
+msgid "Cannot start thread: error writing TLS."
+msgstr "Klarte ikke starte tråden: feil ved skriving til TLS."
+
+#: ../src/msw/thread.cpp:613
+msgid "Can't set thread priority"
+msgstr "Klarte ikke sette trådprioritet"
+
+#: ../src/msw/thread.cpp:649
+msgid "Can't create thread"
+msgstr "Klarte ikke opprette tråd"
+
+#: ../src/msw/thread.cpp:668
+msgid "Couldn't terminate thread"
+msgstr "Klarte ikke avslutte tråden."
+
+#: ../src/msw/thread.cpp:799
+msgid "Cannot wait for thread termination"
+msgstr "Klarte ikke vente på trådens avslutning"
+
+#: ../src/msw/thread.cpp:873
+#, fuzzy, c-format
+msgid "Cannot suspend thread %lx"
+msgstr "Klarte ikke innstille tråden %x"
+
+#: ../src/msw/thread.cpp:903
+#, fuzzy, c-format
+msgid "Cannot resume thread %lx"
+msgstr "Klarte ikke gjenoppta tråden %x"
+
+#: ../src/msw/thread.cpp:932
+msgid "Couldn't get the current thread pointer"
+msgstr "Klarte ikke finne gjeldende trådpeker"
+
+#: ../src/msw/thread.cpp:1333
+msgid ""
+"Thread module initialization failed: impossible to allocate index in thread "
+"local storage"
+msgstr ""
+"Initialisering av trådmodul feilet: umulig å reservere indeks i det lokale "
+"trådlager"
+
+#: ../src/msw/thread.cpp:1345
+msgid ""
+"Thread module initialization failed: cannot store value in thread local "
+"storage"
+msgstr ""
+"Initialisering av trådmodul feilet: klarte ikke lagre verdien i det lokale "
+"trådlageret"
+
+#: ../src/msw/timer.cpp:133
+msgid "Couldn't create a timer"
+msgstr "Klarte ikke opprette en timer"
+
+#: ../src/msw/utils.cpp:372
+msgid "can't find user's HOME, using current directory."
+msgstr "klarte ikke finne brukerens HOME, bruker gjeldende katalog."
+
+#: ../src/msw/utils.cpp:662
+#, c-format
+msgid "Failed to kill process %d"
+msgstr "Klarte ikke drepe prosess %d"
+
+#: ../src/msw/utils.cpp:986
+#, fuzzy, c-format
+msgid "Failed to load resource \"%s\"."
+msgstr "Klarte ikke laste metafil fra filen «%s»."
+
+#: ../src/msw/utils.cpp:993
+#, fuzzy, c-format
+msgid "Failed to lock resource \"%s\"."
+msgstr "Klarte ikke låse låsefilen «%s»"
+
+#. TRANSLATORS: MS Windows build number
+#: ../src/msw/utils.cpp:1209
+#, fuzzy, c-format
+msgid "build %lu"
+msgstr "Windows XP (build %lu"
+
+#: ../src/msw/utils.cpp:1218
+msgid ", 64-bit edition"
+msgstr ""
+
+#: ../src/msw/utilsexc.cpp:224
+msgid "Failed to create an anonymous pipe"
+msgstr "Klarte ikke opprette et anonym rør"
+
+#: ../src/msw/utilsexc.cpp:697
+msgid "Failed to redirect the child process IO"
+msgstr "Klarte ikke videresende underporsess IO"
+
+#: ../src/msw/utilsexc.cpp:870
+#, c-format
+msgid "Execution of command '%s' failed"
+msgstr "Utførelse av kommandoen «%s» feilet"
+
+#: ../src/msw/volume.cpp:337
+msgid "Failed to load mpr.dll."
+msgstr "Klarte ikke laste mpr.dll."
+
+#: ../src/msw/volume.cpp:506
+#, c-format
+msgid "Cannot read typename from '%s'!"
+msgstr "Klarte ikke lese typenavn fra «%s»!"
+
+#: ../src/msw/volume.cpp:615
+#, c-format
+msgid "Cannot load icon from '%s'."
+msgstr "Klarte ikke laste ikon fra «%s»."
+
+#: ../src/msw/webview_edge.cpp:285
+msgid "This program was compiled without support for setting Edge proxy."
+msgstr ""
+
+#: ../src/msw/webview_ie.cpp:1010
+msgid "Failed to find web view emulation level in the registry"
+msgstr ""
+
+#: ../src/msw/webview_ie.cpp:1019
+msgid "Failed to set web view to modern emulation level"
+msgstr ""
+
+#: ../src/msw/webview_ie.cpp:1027
+msgid "Failed to reset web view to standard emulation level"
+msgstr ""
+
+#: ../src/msw/webview_ie.cpp:1049
+msgid "Can't run JavaScript script without a valid HTML document"
+msgstr ""
+
+#: ../src/msw/webview_ie.cpp:1056
+#, fuzzy
+msgid "Can't get the JavaScript object"
+msgstr "Klarte ikke sette trådprioritet"
+
+#: ../src/msw/webview_ie.cpp:1070
+#, fuzzy
+msgid "failed to evaluate"
+msgstr "Klarte ikke utføre «%s»\n"
+
+#: ../src/osx/cocoa/filedlg.mm:412
+#, fuzzy
+msgid "File type:"
+msgstr "Teletype"
+
+#: ../src/osx/cocoa/menu.mm:242
+#, fuzzy
+msgctxt "macOS menu name"
+msgid "Window"
+msgstr "&Vindu"
+
+#: ../src/osx/cocoa/menu.mm:259
+#, fuzzy
+msgctxt "macOS menu name"
+msgid "Help"
+msgstr "Hjelp"
+
+#: ../src/osx/cocoa/menu.mm:298
+#, fuzzy
+msgctxt "macOS menu item"
+msgid "Minimize"
+msgstr "Mi&nimer"
+
+#: ../src/osx/cocoa/menu.mm:303
+#, fuzzy
+msgctxt "macOS menu item"
+msgid "Zoom"
+msgstr "Vis &større"
+
+#: ../src/osx/cocoa/menu.mm:309
+msgctxt "macOS menu item"
+msgid "Bring All to Front"
+msgstr ""
+
+#: ../src/osx/core/sound.cpp:143
+#, fuzzy, c-format
+msgid "Failed to load sound from \"%s\" (error %d)."
+msgstr "Klarte ikke laste metafil fra filen «%s»."
+
+#: ../src/osx/fontutil.cpp:80
+#, fuzzy, c-format
+msgid "Font file \"%s\" doesn't exist."
+msgstr "Filen «%s» eksisterer ikke."
+
+#: ../src/osx/fontutil.cpp:88
+#, c-format
+msgid ""
+"Font file \"%s\" cannot be used as it is not inside the font directory "
+"\"%s\"."
+msgstr ""
+
+#: ../src/osx/menu_osx.cpp:496
+#, fuzzy, c-format
+msgctxt "macOS menu item"
+msgid "About %s"
+msgstr "%Om"
+
+#: ../src/osx/menu_osx.cpp:499
+#, fuzzy
+msgctxt "macOS menu item"
+msgid "About..."
+msgstr "%Om"
+
+#: ../src/osx/menu_osx.cpp:508
+#, fuzzy
+msgctxt "macOS menu item"
+msgid "Preferences..."
+msgstr "&Innstillinger"
+
+#: ../src/osx/menu_osx.cpp:512
+msgctxt "macOS menu item"
+msgid "Services"
+msgstr "Tjenester"
+
+#: ../src/osx/menu_osx.cpp:519
+#, fuzzy, c-format
+msgctxt "macOS menu item"
+msgid "Hide %s"
+msgstr "Hjelp: %s"
+
+#: ../src/osx/menu_osx.cpp:522
+#, fuzzy
+msgctxt "macOS menu item"
+msgid "Hide Application"
+msgstr "Seksjoner"
+
+#: ../src/osx/menu_osx.cpp:526
+msgctxt "macOS menu item"
+msgid "Hide Others"
+msgstr "Skjul andre"
+
+#: ../src/osx/menu_osx.cpp:528
+#, fuzzy
+msgctxt "macOS menu item"
+msgid "Show All"
+msgstr "Vis alle"
+
+#: ../src/osx/menu_osx.cpp:534
+#, fuzzy, c-format
+msgctxt "macOS menu item"
+msgid "Quit %s"
+msgstr "&Slutt"
+
+#: ../src/osx/menu_osx.cpp:537
+#, fuzzy
+msgctxt "macOS menu item"
+msgid "Quit Application"
+msgstr "Seksjoner"
+
+#: ../src/osx/webview_webkit.mm:444
+#, fuzzy
+msgid "Printing is not supported by the system web control"
+msgstr "Gzip er ikke støttet av denne versjonen av zlib"
+
+#: ../src/osx/webview_webkit.mm:453
+#, fuzzy
+msgid "Print operation could not be initialized"
+msgstr "Kolonnebeskrivele kunne ikke initialiseres."
+
+#. TRANSLATORS: Label of font point size
+#: ../src/propgrid/advprops.cpp:605
+#, fuzzy
+msgid "Point Size"
+msgstr "&Punktstørrelse"
+
+#. TRANSLATORS: Label of font face name
+#: ../src/propgrid/advprops.cpp:615
+#, fuzzy
+msgid "Face Name"
+msgstr "NyttNavn"
+
+#. TRANSLATORS: Label of font style
+#: ../src/propgrid/advprops.cpp:623 ../src/richtext/richtextformatdlg.cpp:331
+#, fuzzy
+msgid "Style"
+msgstr "&Stil:"
+
+#. TRANSLATORS: Label of font weight
+#: ../src/propgrid/advprops.cpp:628
+#, fuzzy
+msgid "Weight"
+msgstr "&Vekt:"
+
+#. TRANSLATORS: Label of underlined font
+#: ../src/propgrid/advprops.cpp:633 ../src/richtext/richtextfontpage.cpp:358
+#, fuzzy
+msgid "Underlined"
+msgstr "&Strek under"
+
+#. TRANSLATORS: Label of font family
+#: ../src/propgrid/advprops.cpp:637
+#, fuzzy
+msgid "Family"
+msgstr "&Skriftfamilie:"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:801
+msgid "AppWorkspace"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:802
+#, fuzzy
+msgid "ActiveBorder"
+msgstr "Moderne"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:803
+msgid "ActiveCaption"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:804
+msgid "ButtonFace"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:805
+msgid "ButtonHighlight"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:806
+msgid "ButtonShadow"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:807
+msgid "ButtonText"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:808
+msgid "CaptionText"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:809
+msgid "ControlDark"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:810
+msgid "ControlLight"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:812
+msgid "GrayText"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:813
+msgid "Highlight"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:814
+msgid "HighlightText"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:815
+#, fuzzy
+msgid "InactiveBorder"
+msgstr "Moderne"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:816
+msgid "InactiveCaption"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:817
+msgid "InactiveCaptionText"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:818
+msgid "Menu"
+msgstr "Meny"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:819
+msgid "Scrollbar"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:820
+msgid "Tooltip"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:821
+msgid "TooltipText"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:822
+#, fuzzy
+msgid "Window"
+msgstr "&Vindu"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:823
+#, fuzzy
+msgid "WindowFrame"
+msgstr "&Vindu"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:824
+#, fuzzy
+msgid "WindowText"
+msgstr "&Vindu"
+
+#. TRANSLATORS: Custom colour choice entry
+#: ../src/propgrid/advprops.cpp:825 ../src/propgrid/advprops.cpp:1532
+#: ../src/propgrid/advprops.cpp:1576
+msgid "Custom"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1558
+msgid "Black"
+msgstr "Svart"
+
+#: ../src/propgrid/advprops.cpp:1559
+msgid "Maroon"
+msgstr "Rødbrun"
+
+#: ../src/propgrid/advprops.cpp:1560
+msgid "Navy"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1561
+msgid "Purple"
+msgstr "Purpur"
+
+#: ../src/propgrid/advprops.cpp:1562
+msgid "Teal"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1563
+msgid "Gray"
+msgstr "Grå"
+
+#: ../src/propgrid/advprops.cpp:1564
+msgid "Green"
+msgstr "Grønn"
+
+#: ../src/propgrid/advprops.cpp:1565
+msgid "Olive"
+msgstr "Oliven"
+
+#: ../src/propgrid/advprops.cpp:1566
+msgid "Brown"
+msgstr "Brun"
+
+#: ../src/propgrid/advprops.cpp:1567
+msgid "Blue"
+msgstr "Blå"
+
+#: ../src/propgrid/advprops.cpp:1568
+msgid "Fuchsia"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1569
+#, fuzzy
+msgid "Red"
+msgstr "&Gjenta"
+
+#: ../src/propgrid/advprops.cpp:1570
+msgid "Orange"
+msgstr "Oransje"
+
+#: ../src/propgrid/advprops.cpp:1571
+msgid "Silver"
+msgstr "Sølv"
+
+#: ../src/propgrid/advprops.cpp:1572
+msgid "Lime"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1573
+msgid "Aqua"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1574
+msgid "Yellow"
+msgstr "Gul"
+
+#: ../src/propgrid/advprops.cpp:1575
+msgid "White"
+msgstr "Hvit"
+
+#: ../src/propgrid/advprops.cpp:1718
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Default"
+msgstr "standard"
+
+#: ../src/propgrid/advprops.cpp:1719
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Arrow"
+msgstr "i morgen"
+
+#: ../src/propgrid/advprops.cpp:1720
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Right Arrow"
+msgstr "Høyrepil"
+
+#: ../src/propgrid/advprops.cpp:1721
+msgctxt "system cursor name"
+msgid "Blank"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1722
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Bullseye"
+msgstr "Punktlistestil"
+
+#: ../src/propgrid/advprops.cpp:1723
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Character"
+msgstr "Bokstavstiler"
+
+#: ../src/propgrid/advprops.cpp:1724
+msgctxt "system cursor name"
+msgid "Cross"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1725
+msgctxt "system cursor name"
+msgid "Hand"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1726
+msgctxt "system cursor name"
+msgid "I-Beam"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1727
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Left Button"
+msgstr "Høyreknapp"
+
+#: ../src/propgrid/advprops.cpp:1728
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Magnifier"
+msgstr "Forstørrelsesglass"
+
+#: ../src/propgrid/advprops.cpp:1729
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Middle Button"
+msgstr "Høyreknapp"
+
+#: ../src/propgrid/advprops.cpp:1730
+msgctxt "system cursor name"
+msgid "No Entry"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1731
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Paint Brush"
+msgstr "Malepensel"
+
+#: ../src/propgrid/advprops.cpp:1732
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Pencil"
+msgstr "Blyant"
+
+#: ../src/propgrid/advprops.cpp:1733
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Point Left"
+msgstr "&Punktstørrelse"
+
+#: ../src/propgrid/advprops.cpp:1734
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Point Right"
+msgstr "Høyrejustering"
+
+#: ../src/propgrid/advprops.cpp:1735
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Question Arrow"
+msgstr "Spørsmål"
+
+#: ../src/propgrid/advprops.cpp:1736
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Right Button"
+msgstr "Høyreknapp"
+
+#: ../src/propgrid/advprops.cpp:1737
+msgctxt "system cursor name"
+msgid "Sizing NE-SW"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1738
+msgctxt "system cursor name"
+msgid "Sizing N-S"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1739
+msgctxt "system cursor name"
+msgid "Sizing NW-SE"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1740
+msgctxt "system cursor name"
+msgid "Sizing W-E"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1741
+msgctxt "system cursor name"
+msgid "Sizing"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1742
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Spraycan"
+msgstr "Sprayboks"
+
+#: ../src/propgrid/advprops.cpp:1743
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Wait"
+msgstr "Vent"
+
+#: ../src/propgrid/advprops.cpp:1744
+msgctxt "system cursor name"
+msgid "Watch"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1745
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Wait Arrow"
+msgstr "Høyrepil"
+
+#: ../src/propgrid/advprops.cpp:2109
+msgid "Make a selection:"
+msgstr "SeksjonerGjør et valg:"
+
+#: ../src/propgrid/manager.cpp:394
+#, fuzzy
+msgid "Property"
+msgstr "&Egenskaper"
+
+#: ../src/propgrid/manager.cpp:395
+msgid "Value"
+msgstr "Verdi"
+
+#: ../src/propgrid/manager.cpp:1683
+msgid "Categorized Mode"
+msgstr "Kategorisert Modus"
+
+#: ../src/propgrid/manager.cpp:1709
+msgid "Alphabetic Mode"
+msgstr "Alfabetisk Modus"
+
+#. TRANSLATORS: Name of Boolean false value
+#: ../src/propgrid/propgrid.cpp:230
+msgid "False"
+msgstr ""
+
+#. TRANSLATORS: Name of Boolean true value
+#: ../src/propgrid/propgrid.cpp:232
+msgid "True"
+msgstr ""
+
+#. TRANSLATORS: Text  displayed for unspecified value
+#: ../src/propgrid/propgrid.cpp:428
+msgid "Unspecified"
+msgstr "Uspesifisert"
+
+#. TRANSLATORS: Caption of message box displaying any property error
+#: ../src/propgrid/propgrid.cpp:3145 ../src/propgrid/propgrid.cpp:3282
+#, fuzzy
+msgid "Property Error"
+msgstr "Feil ved utskrift"
+
+#: ../src/propgrid/propgrid.cpp:3259
+msgid "You have entered invalid value. Press ESC to cancel editing."
+msgstr "Du har lagt inn en ugyldig verdi. Trykk ESC for å avbryte redigering."
+
+#: ../src/propgrid/propgrid.cpp:6608
+#, c-format
+msgid "Error in resource: %s"
+msgstr ""
+
+#: ../src/propgrid/propgridiface.cpp:377
+#, c-format
+msgid ""
+"Type operation \"%s\" failed: Property labeled \"%s\" is of type \"%s\", NOT "
+"\"%s\"."
+msgstr ""
+
+#: ../src/propgrid/props.cpp:159
+#, c-format
+msgid "Unknown base %d. Base 10 will be used."
+msgstr ""
+
+#: ../src/propgrid/props.cpp:324
+#, c-format
+msgid "Value must be %s or higher."
+msgstr "Verdien må være %s eller høyere."
+
+#: ../src/propgrid/props.cpp:329 ../src/propgrid/props.cpp:356
+#, fuzzy, c-format
+msgid "Value must be between %s and %s."
+msgstr "Oppgi et sidetall mellom %d og %d:"
+
+#: ../src/propgrid/props.cpp:351
+#, c-format
+msgid "Value must be %s or less."
+msgstr "Verdien må være %s eller mindre."
+
+#: ../src/propgrid/props.cpp:1058
+#, fuzzy, c-format
+msgid "Not %s"
+msgstr "%Om"
+
+#: ../src/propgrid/props.cpp:1770
+#, fuzzy
+msgid "Choose a directory:"
+msgstr "Opprett mappe"
+
+#: ../src/propgrid/props.cpp:2055
+#, fuzzy
+msgid "Choose a file"
+msgstr "Velg skrift"
+
+#: ../src/qt/mdi.cpp:254
+msgid "&Tile"
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:147
+#: ../src/richtext/richtextformatdlg.cpp:376
+msgid "Background"
+msgstr "Bakgrunn"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:159
+msgid "Background &colour:"
+msgstr "&Bakgrunnsfarge"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:161
+#: ../src/richtext/richtextbackgroundpage.cpp:163
+msgid "Enables a background colour."
+msgstr "Bruk bakgrunnsfarge."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:167
+#: ../src/richtext/richtextbackgroundpage.cpp:169
+#, fuzzy
+msgid "The background colour."
+msgstr "Skriftfarge"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:178
+msgid "Shadow"
+msgstr "Skygge"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:193
+msgid "Use &shadow"
+msgstr "Bruk &skygge"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:195
+#: ../src/richtext/richtextbackgroundpage.cpp:197
+msgid "Enables a shadow."
+msgstr "Bruk skygge."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:211
+msgid "&Horizontal offset:"
+msgstr "&Horisontal offset:"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:218
+#: ../src/richtext/richtextbackgroundpage.cpp:220
+#, fuzzy
+msgid "The horizontal offset."
+msgstr "Tile &horisontalt"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:224
+#: ../src/richtext/richtextbackgroundpage.cpp:227
+#: ../src/richtext/richtextbackgroundpage.cpp:228
+#: ../src/richtext/richtextbackgroundpage.cpp:247
+#: ../src/richtext/richtextbackgroundpage.cpp:250
+#: ../src/richtext/richtextbackgroundpage.cpp:251
+#: ../src/richtext/richtextbackgroundpage.cpp:287
+#: ../src/richtext/richtextbackgroundpage.cpp:290
+#: ../src/richtext/richtextbackgroundpage.cpp:291
+#: ../src/richtext/richtextbackgroundpage.cpp:314
+#: ../src/richtext/richtextbackgroundpage.cpp:317
+#: ../src/richtext/richtextbackgroundpage.cpp:318
+#: ../src/richtext/richtextborderspage.cpp:252
+#: ../src/richtext/richtextborderspage.cpp:255
+#: ../src/richtext/richtextborderspage.cpp:256
+#: ../src/richtext/richtextborderspage.cpp:286
+#: ../src/richtext/richtextborderspage.cpp:289
+#: ../src/richtext/richtextborderspage.cpp:290
+#: ../src/richtext/richtextborderspage.cpp:320
+#: ../src/richtext/richtextborderspage.cpp:323
+#: ../src/richtext/richtextborderspage.cpp:324
+#: ../src/richtext/richtextborderspage.cpp:354
+#: ../src/richtext/richtextborderspage.cpp:357
+#: ../src/richtext/richtextborderspage.cpp:358
+#: ../src/richtext/richtextborderspage.cpp:420
+#: ../src/richtext/richtextborderspage.cpp:423
+#: ../src/richtext/richtextborderspage.cpp:424
+#: ../src/richtext/richtextborderspage.cpp:454
+#: ../src/richtext/richtextborderspage.cpp:457
+#: ../src/richtext/richtextborderspage.cpp:458
+#: ../src/richtext/richtextborderspage.cpp:488
+#: ../src/richtext/richtextborderspage.cpp:491
+#: ../src/richtext/richtextborderspage.cpp:492
+#: ../src/richtext/richtextborderspage.cpp:522
+#: ../src/richtext/richtextborderspage.cpp:525
+#: ../src/richtext/richtextborderspage.cpp:526
+#: ../src/richtext/richtextborderspage.cpp:590
+#: ../src/richtext/richtextborderspage.cpp:593
+#: ../src/richtext/richtextborderspage.cpp:594
+#: ../src/richtext/richtextfontpage.cpp:177
+#: ../src/richtext/richtextmarginspage.cpp:199
+#: ../src/richtext/richtextmarginspage.cpp:201
+#: ../src/richtext/richtextmarginspage.cpp:202
+#: ../src/richtext/richtextmarginspage.cpp:224
+#: ../src/richtext/richtextmarginspage.cpp:226
+#: ../src/richtext/richtextmarginspage.cpp:227
+#: ../src/richtext/richtextmarginspage.cpp:247
+#: ../src/richtext/richtextmarginspage.cpp:249
+#: ../src/richtext/richtextmarginspage.cpp:250
+#: ../src/richtext/richtextmarginspage.cpp:272
+#: ../src/richtext/richtextmarginspage.cpp:274
+#: ../src/richtext/richtextmarginspage.cpp:275
+#: ../src/richtext/richtextmarginspage.cpp:313
+#: ../src/richtext/richtextmarginspage.cpp:315
+#: ../src/richtext/richtextmarginspage.cpp:316
+#: ../src/richtext/richtextmarginspage.cpp:338
+#: ../src/richtext/richtextmarginspage.cpp:340
+#: ../src/richtext/richtextmarginspage.cpp:341
+#: ../src/richtext/richtextmarginspage.cpp:361
+#: ../src/richtext/richtextmarginspage.cpp:363
+#: ../src/richtext/richtextmarginspage.cpp:364
+#: ../src/richtext/richtextmarginspage.cpp:386
+#: ../src/richtext/richtextmarginspage.cpp:388
+#: ../src/richtext/richtextmarginspage.cpp:389
+#: ../src/richtext/richtextsizepage.cpp:337
+#: ../src/richtext/richtextsizepage.cpp:340
+#: ../src/richtext/richtextsizepage.cpp:341
+#: ../src/richtext/richtextsizepage.cpp:371
+#: ../src/richtext/richtextsizepage.cpp:374
+#: ../src/richtext/richtextsizepage.cpp:375
+#: ../src/richtext/richtextsizepage.cpp:398
+#: ../src/richtext/richtextsizepage.cpp:401
+#: ../src/richtext/richtextsizepage.cpp:402
+#: ../src/richtext/richtextsizepage.cpp:425
+#: ../src/richtext/richtextsizepage.cpp:428
+#: ../src/richtext/richtextsizepage.cpp:429
+#: ../src/richtext/richtextsizepage.cpp:452
+#: ../src/richtext/richtextsizepage.cpp:455
+#: ../src/richtext/richtextsizepage.cpp:456
+#: ../src/richtext/richtextsizepage.cpp:479
+#: ../src/richtext/richtextsizepage.cpp:482
+#: ../src/richtext/richtextsizepage.cpp:483
+#: ../src/richtext/richtextsizepage.cpp:553
+#: ../src/richtext/richtextsizepage.cpp:556
+#: ../src/richtext/richtextsizepage.cpp:557
+#: ../src/richtext/richtextsizepage.cpp:588
+#: ../src/richtext/richtextsizepage.cpp:591
+#: ../src/richtext/richtextsizepage.cpp:592
+#: ../src/richtext/richtextsizepage.cpp:623
+#: ../src/richtext/richtextsizepage.cpp:626
+#: ../src/richtext/richtextsizepage.cpp:627
+#: ../src/richtext/richtextsizepage.cpp:658
+#: ../src/richtext/richtextsizepage.cpp:661
+#: ../src/richtext/richtextsizepage.cpp:662
+msgid "px"
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:225
+#: ../src/richtext/richtextbackgroundpage.cpp:248
+#: ../src/richtext/richtextbackgroundpage.cpp:288
+#: ../src/richtext/richtextbackgroundpage.cpp:315
+#: ../src/richtext/richtextborderspage.cpp:253
+#: ../src/richtext/richtextborderspage.cpp:287
+#: ../src/richtext/richtextborderspage.cpp:321
+#: ../src/richtext/richtextborderspage.cpp:355
+#: ../src/richtext/richtextborderspage.cpp:421
+#: ../src/richtext/richtextborderspage.cpp:455
+#: ../src/richtext/richtextborderspage.cpp:489
+#: ../src/richtext/richtextborderspage.cpp:523
+#: ../src/richtext/richtextborderspage.cpp:591
+#: ../src/richtext/richtextmarginspage.cpp:200
+#: ../src/richtext/richtextmarginspage.cpp:225
+#: ../src/richtext/richtextmarginspage.cpp:248
+#: ../src/richtext/richtextmarginspage.cpp:273
+#: ../src/richtext/richtextmarginspage.cpp:314
+#: ../src/richtext/richtextmarginspage.cpp:339
+#: ../src/richtext/richtextmarginspage.cpp:362
+#: ../src/richtext/richtextmarginspage.cpp:387
+#: ../src/richtext/richtextsizepage.cpp:338
+#: ../src/richtext/richtextsizepage.cpp:372
+#: ../src/richtext/richtextsizepage.cpp:399
+#: ../src/richtext/richtextsizepage.cpp:426
+#: ../src/richtext/richtextsizepage.cpp:453
+#: ../src/richtext/richtextsizepage.cpp:480
+#: ../src/richtext/richtextsizepage.cpp:554
+#: ../src/richtext/richtextsizepage.cpp:589
+#: ../src/richtext/richtextsizepage.cpp:624
+#: ../src/richtext/richtextsizepage.cpp:659
+msgid "cm"
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:226
+#: ../src/richtext/richtextbackgroundpage.cpp:249
+#: ../src/richtext/richtextbackgroundpage.cpp:289
+#: ../src/richtext/richtextbackgroundpage.cpp:316
+#: ../src/richtext/richtextborderspage.cpp:254
+#: ../src/richtext/richtextborderspage.cpp:288
+#: ../src/richtext/richtextborderspage.cpp:322
+#: ../src/richtext/richtextborderspage.cpp:356
+#: ../src/richtext/richtextborderspage.cpp:422
+#: ../src/richtext/richtextborderspage.cpp:456
+#: ../src/richtext/richtextborderspage.cpp:490
+#: ../src/richtext/richtextborderspage.cpp:524
+#: ../src/richtext/richtextborderspage.cpp:592
+#: ../src/richtext/richtextfontpage.cpp:176
+#: ../src/richtext/richtextfontpage.cpp:179
+msgid "pt"
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:229
+#: ../src/richtext/richtextbackgroundpage.cpp:231
+#: ../src/richtext/richtextbackgroundpage.cpp:252
+#: ../src/richtext/richtextbackgroundpage.cpp:254
+#: ../src/richtext/richtextbackgroundpage.cpp:292
+#: ../src/richtext/richtextbackgroundpage.cpp:294
+#: ../src/richtext/richtextbackgroundpage.cpp:319
+#: ../src/richtext/richtextbackgroundpage.cpp:321
+#, fuzzy
+msgid "Units for this value."
+msgstr "Kan ikke vente på trådens avslutning."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:234
+#, fuzzy
+msgid "&Vertical offset:"
+msgstr "Venstrejustering"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:241
+#: ../src/richtext/richtextbackgroundpage.cpp:243
+#, fuzzy
+msgid "The vertical offset."
+msgstr "Klarte ikke starte utskrift."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:257
+msgid "Shadow c&olour:"
+msgstr "Velg skyggefarge"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:259
+#: ../src/richtext/richtextbackgroundpage.cpp:261
+msgid "Enables the shadow colour."
+msgstr "Bruk farge på skygge."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:265
+#: ../src/richtext/richtextbackgroundpage.cpp:267
+msgid "The shadow colour."
+msgstr "SkriftfargeFarge på skyggen."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:270
+msgid "Sh&adow spread:"
+msgstr "Skyggespredning:"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:272
+#: ../src/richtext/richtextbackgroundpage.cpp:274
+msgid "Enables the shadow spread."
+msgstr "Bruk skyggespredning."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:281
+#: ../src/richtext/richtextbackgroundpage.cpp:283
+msgid "The shadow spread."
+msgstr "Spredning på skyggen."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:297
+msgid "&Blur distance:"
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:299
+#: ../src/richtext/richtextbackgroundpage.cpp:301
+msgid "Enables the blur distance."
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:308
+#: ../src/richtext/richtextbackgroundpage.cpp:310
+msgid "The shadow blur distance."
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:324
+msgid "Opaci&ty:"
+msgstr "Dekkevne:"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:326
+#: ../src/richtext/richtextbackgroundpage.cpp:328
+msgid "Enables the shadow opacity."
+msgstr "Bruk dekkevne for skyggen."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:335
+#: ../src/richtext/richtextbackgroundpage.cpp:337
+msgid "The shadow opacity."
+msgstr "Dekkevnen til skyggen."
+
+#. TRANSLATORS: Rich text page units (percentage)
+#: ../src/richtext/richtextbackgroundpage.cpp:340
+#: ../src/richtext/richtextsizepage.cpp:339
+#: ../src/richtext/richtextsizepage.cpp:373
+#: ../src/richtext/richtextsizepage.cpp:400
+#: ../src/richtext/richtextsizepage.cpp:427
+#: ../src/richtext/richtextsizepage.cpp:454
+#: ../src/richtext/richtextsizepage.cpp:481
+#: ../src/richtext/richtextsizepage.cpp:555
+#: ../src/richtext/richtextsizepage.cpp:590
+#: ../src/richtext/richtextsizepage.cpp:625
+#: ../src/richtext/richtextsizepage.cpp:660
+msgid "%"
+msgstr "%"
+
+#: ../src/richtext/richtextborderspage.cpp:229
+#: ../src/richtext/richtextborderspage.cpp:387
+#, fuzzy
+msgid "Border"
+msgstr "Moderne"
+
+#: ../src/richtext/richtextborderspage.cpp:242
+#: ../src/richtext/richtextborderspage.cpp:410
+#: ../src/richtext/richtextindentspage.cpp:194
+#: ../src/richtext/richtextliststylepage.cpp:384
+#: ../src/richtext/richtextmarginspage.cpp:185
+#: ../src/richtext/richtextmarginspage.cpp:299
+#: ../src/richtext/richtextsizepage.cpp:531
+#: ../src/richtext/richtextsizepage.cpp:538
+msgid "&Left:"
+msgstr "&Venstre:"
+
+#: ../src/richtext/richtextborderspage.cpp:257
+#: ../src/richtext/richtextborderspage.cpp:259
+msgid "Units for the left border width."
+msgstr "Enheter for venstre margbredde."
+
+#: ../src/richtext/richtextborderspage.cpp:266
+#: ../src/richtext/richtextborderspage.cpp:268
+#: ../src/richtext/richtextborderspage.cpp:300
+#: ../src/richtext/richtextborderspage.cpp:302
+#: ../src/richtext/richtextborderspage.cpp:334
+#: ../src/richtext/richtextborderspage.cpp:336
+#: ../src/richtext/richtextborderspage.cpp:368
+#: ../src/richtext/richtextborderspage.cpp:370
+#: ../src/richtext/richtextborderspage.cpp:434
+#: ../src/richtext/richtextborderspage.cpp:436
+#: ../src/richtext/richtextborderspage.cpp:468
+#: ../src/richtext/richtextborderspage.cpp:470
+#: ../src/richtext/richtextborderspage.cpp:502
+#: ../src/richtext/richtextborderspage.cpp:504
+#: ../src/richtext/richtextborderspage.cpp:536
+#: ../src/richtext/richtextborderspage.cpp:538
+#, fuzzy
+msgid "The border line style."
+msgstr "Skriftstil"
+
+#: ../src/richtext/richtextborderspage.cpp:276
+#: ../src/richtext/richtextborderspage.cpp:444
+#: ../src/richtext/richtextindentspage.cpp:212
+#: ../src/richtext/richtextliststylepage.cpp:402
+#: ../src/richtext/richtextmarginspage.cpp:210
+#: ../src/richtext/richtextmarginspage.cpp:324
+#: ../src/richtext/richtextsizepage.cpp:601
+#: ../src/richtext/richtextsizepage.cpp:608
+#, fuzzy
+msgid "&Right:"
+msgstr "&Vekt:"
+
+#: ../src/richtext/richtextborderspage.cpp:291
+#: ../src/richtext/richtextborderspage.cpp:293
+msgid "Units for the right border width."
+msgstr "Enheter for bredden på høyremargen."
+
+#: ../src/richtext/richtextborderspage.cpp:310
+#: ../src/richtext/richtextborderspage.cpp:478
+#: ../src/richtext/richtextmarginspage.cpp:233
+#: ../src/richtext/richtextmarginspage.cpp:347
+#: ../src/richtext/richtextsizepage.cpp:566
+#: ../src/richtext/richtextsizepage.cpp:573
+#, fuzzy
+msgid "&Top:"
+msgstr "Til:"
+
+#: ../src/richtext/richtextborderspage.cpp:325
+#: ../src/richtext/richtextborderspage.cpp:327
+msgid "Units for the top border width."
+msgstr "Enheter for bredden på toppmargen."
+
+#: ../src/richtext/richtextborderspage.cpp:344
+#: ../src/richtext/richtextborderspage.cpp:512
+#: ../src/richtext/richtextmarginspage.cpp:258
+#: ../src/richtext/richtextmarginspage.cpp:372
+#: ../src/richtext/richtextsizepage.cpp:636
+#: ../src/richtext/richtextsizepage.cpp:643
+msgid "&Bottom:"
+msgstr "&Bunn:"
+
+#: ../src/richtext/richtextborderspage.cpp:359
+#: ../src/richtext/richtextborderspage.cpp:361
+msgid "Units for the bottom border width."
+msgstr "Enheter for bredde på bunnmarg."
+
+#: ../src/richtext/richtextborderspage.cpp:380
+#: ../src/richtext/richtextborderspage.cpp:548
+msgid "&Synchronize values"
+msgstr "&Synkroniser verdier"
+
+#: ../src/richtext/richtextborderspage.cpp:382
+#: ../src/richtext/richtextborderspage.cpp:384
+#: ../src/richtext/richtextborderspage.cpp:550
+#: ../src/richtext/richtextborderspage.cpp:552
+msgid "Check to edit all borders simultaneously."
+msgstr "Klikk for å legge til endre alle marger samtidig."
+
+#: ../src/richtext/richtextborderspage.cpp:397
+#: ../src/richtext/richtextborderspage.cpp:555
+msgid "Outline"
+msgstr "Disposisjon"
+
+#: ../src/richtext/richtextborderspage.cpp:425
+#: ../src/richtext/richtextborderspage.cpp:427
+msgid "Units for the left outline width."
+msgstr "Enheter for bredden på omriss til venstre. "
+
+#: ../src/richtext/richtextborderspage.cpp:459
+#: ../src/richtext/richtextborderspage.cpp:461
+msgid "Units for the right outline width."
+msgstr "Enheter for bredden på omrisset til høyre."
+
+#: ../src/richtext/richtextborderspage.cpp:493
+#: ../src/richtext/richtextborderspage.cpp:495
+msgid "Units for the top outline width."
+msgstr "Enheter for  bredden på omrisset på toppen."
+
+#: ../src/richtext/richtextborderspage.cpp:527
+#: ../src/richtext/richtextborderspage.cpp:529
+msgid "Units for the bottom outline width."
+msgstr "Enheter for bredde på omriss på bunnen."
+
+#: ../src/richtext/richtextborderspage.cpp:565
+#: ../src/richtext/richtextborderspage.cpp:600
+msgid "Corner"
+msgstr "Hjørne"
+
+#: ../src/richtext/richtextborderspage.cpp:574
+msgid "Corner &radius:"
+msgstr "Hjørne&radius:"
+
+#: ../src/richtext/richtextborderspage.cpp:576
+#: ../src/richtext/richtextborderspage.cpp:578
+msgid "An optional corner radius for adding rounded corners."
+msgstr "En valgfri radius for avrundede hjørner."
+
+#: ../src/richtext/richtextborderspage.cpp:584
+#: ../src/richtext/richtextborderspage.cpp:586
+msgid "The value of the corner radius."
+msgstr "Størrelsen på hjørneradius."
+
+#: ../src/richtext/richtextborderspage.cpp:595
+#: ../src/richtext/richtextborderspage.cpp:597
+msgid "Units for the corner radius."
+msgstr "Enheter for radius på hjørne."
+
+#: ../src/richtext/richtextborderspage.cpp:609
+#: ../src/richtext/richtextsizepage.cpp:247
+#: ../src/richtext/richtextsizepage.cpp:251
+#, fuzzy
+msgid "None"
+msgstr "Ferdig"
+
+#: ../src/richtext/richtextborderspage.cpp:610
+#, fuzzy
+msgid "Solid"
+msgstr "Fet"
+
+#: ../src/richtext/richtextborderspage.cpp:611
+msgid "Dotted"
+msgstr "Prikket"
+
+#: ../src/richtext/richtextborderspage.cpp:612
+msgid "Dashed"
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:613
+#, fuzzy
+msgid "Double"
+msgstr "Ferdig"
+
+#: ../src/richtext/richtextborderspage.cpp:614
+msgid "Groove"
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:615
+#, fuzzy
+msgid "Ridge"
+msgstr "Lett"
+
+#: ../src/richtext/richtextborderspage.cpp:616
+#, fuzzy
+msgid "Inset"
+msgstr "Innrykk"
+
+#: ../src/richtext/richtextborderspage.cpp:617
+msgid "Outset"
+msgstr ""
+
+#: ../src/richtext/richtextbuffer.cpp:3518
+msgid "Change Style"
+msgstr "Endre stil"
+
+#: ../src/richtext/richtextbuffer.cpp:3701
+msgid "Change Object Style"
+msgstr "Endre objektstilen"
+
+#: ../src/richtext/richtextbuffer.cpp:3974
+#: ../src/richtext/richtextbuffer.cpp:8174
+#, fuzzy
+msgid "Change Properties"
+msgstr "&Egenskaper"
+
+#: ../src/richtext/richtextbuffer.cpp:4346
+msgid "Change List Style"
+msgstr "Endre liststilen"
+
+#: ../src/richtext/richtextbuffer.cpp:4519
+msgid "Renumber List"
+msgstr "Renummerer liste"
+
+#: ../src/richtext/richtextbuffer.cpp:7867
+#: ../src/richtext/richtextbuffer.cpp:7897
+#: ../src/richtext/richtextbuffer.cpp:7939
+#: ../src/richtext/richtextctrl.cpp:1279 ../src/richtext/richtextctrl.cpp:1473
+msgid "Insert Text"
+msgstr "Sett inn Tekst"
+
+#: ../src/richtext/richtextbuffer.cpp:8023
+#: ../src/richtext/richtextbuffer.cpp:8979
+msgid "Insert Image"
+msgstr "Sett inn Bilde"
+
+#: ../src/richtext/richtextbuffer.cpp:8070
+msgid "Insert Object"
+msgstr "Sett inn Objekt"
+
+#: ../src/richtext/richtextbuffer.cpp:8112
+#, fuzzy
+msgid "Insert Field"
+msgstr "Innrykk"
+
+#: ../src/richtext/richtextbuffer.cpp:8410
+msgid "Too many EndStyle calls!"
+msgstr "For mange kall til EndStyle!"
+
+#: ../src/richtext/richtextbuffer.cpp:8785
+msgid "files"
+msgstr "Filer"
+
+#: ../src/richtext/richtextbuffer.cpp:9380
+msgid "standard/circle"
+msgstr "standard/sirkel"
+
+#: ../src/richtext/richtextbuffer.cpp:9381
+msgid "standard/circle-outline"
+msgstr "standard/sirkel-omriss"
+
+#: ../src/richtext/richtextbuffer.cpp:9382
+msgid "standard/square"
+msgstr "standard/firkant"
+
+#: ../src/richtext/richtextbuffer.cpp:9383
+msgid "standard/diamond"
+msgstr "standard/diamant"
+
+#: ../src/richtext/richtextbuffer.cpp:9384
+msgid "standard/triangle"
+msgstr "standard/triangel"
+
+#: ../src/richtext/richtextbuffer.cpp:9423
+#, fuzzy
+msgid "Box Properties"
+msgstr "&Egenskaper"
+
+#: ../src/richtext/richtextbuffer.cpp:10006
+msgid "Multiple Cell Properties"
+msgstr ""
+
+#: ../src/richtext/richtextbuffer.cpp:10008
+#, fuzzy
+msgid "Cell Properties"
+msgstr "&Egenskaper"
+
+#: ../src/richtext/richtextbuffer.cpp:11256
+msgid "Set Cell Style"
+msgstr "Sett cellestil"
+
+#: ../src/richtext/richtextbuffer.cpp:11330
+#, fuzzy
+msgid "Delete Row"
+msgstr "&Slett"
+
+#: ../src/richtext/richtextbuffer.cpp:11380
+#, fuzzy
+msgid "Delete Column"
+msgstr "Seksjoner"
+
+#: ../src/richtext/richtextbuffer.cpp:11431
+msgid "Add Row"
+msgstr "Legg til Rad"
+
+#: ../src/richtext/richtextbuffer.cpp:11494
+msgid "Add Column"
+msgstr "Legg til Kolonne"
+
+#: ../src/richtext/richtextbuffer.cpp:11537
+#, fuzzy
+msgid "Table Properties"
+msgstr "&Egenskaper"
+
+#: ../src/richtext/richtextbuffer.cpp:12899
+#, fuzzy
+msgid "Picture Properties"
+msgstr "&Egenskaper"
+
+#: ../src/richtext/richtextbuffer.cpp:13169
+#: ../src/richtext/richtextbuffer.cpp:13279
+msgid "image"
+msgstr "bilde"
+
+#: ../src/richtext/richtextbulletspage.cpp:145
+#: ../src/richtext/richtextliststylepage.cpp:209
+msgid "&Bullet style:"
+msgstr "&Punktstil:"
+
+#: ../src/richtext/richtextbulletspage.cpp:150
+#: ../src/richtext/richtextbulletspage.cpp:152
+#: ../src/richtext/richtextliststylepage.cpp:214
+#: ../src/richtext/richtextliststylepage.cpp:216
+msgid "The available bullet styles."
+msgstr "De tilgjengelige punktstilene."
+
+#: ../src/richtext/richtextbulletspage.cpp:158
+#: ../src/richtext/richtextliststylepage.cpp:221
+msgid "Peri&od"
+msgstr ""
+
+#: ../src/richtext/richtextbulletspage.cpp:160
+#: ../src/richtext/richtextbulletspage.cpp:162
+#: ../src/richtext/richtextliststylepage.cpp:223
+#: ../src/richtext/richtextliststylepage.cpp:225
+msgid "Check to add a period after the bullet."
+msgstr "Klikk for å legge til punktun etter punktet."
+
+#. TRANSLATORS: Bullet point in parentheses option
+#: ../src/richtext/richtextbulletspage.cpp:167
+#: ../src/richtext/richtextliststylepage.cpp:230
+msgid "(*)"
+msgstr ""
+
+#: ../src/richtext/richtextbulletspage.cpp:169
+#: ../src/richtext/richtextbulletspage.cpp:171
+#: ../src/richtext/richtextliststylepage.cpp:232
+#: ../src/richtext/richtextliststylepage.cpp:234
+msgid "Check to enclose the bullet in parentheses."
+msgstr "Klikk for å sette punktet i parentes."
+
+#. TRANSLATORS: Right parenthesis bullet point option
+#: ../src/richtext/richtextbulletspage.cpp:176
+#: ../src/richtext/richtextliststylepage.cpp:239
+msgid "*)"
+msgstr ""
+
+#: ../src/richtext/richtextbulletspage.cpp:178
+#: ../src/richtext/richtextbulletspage.cpp:180
+#: ../src/richtext/richtextliststylepage.cpp:241
+#: ../src/richtext/richtextliststylepage.cpp:243
+msgid "Check to add a right parenthesis."
+msgstr "Klikk for å legge til en høyreparentes."
+
+#: ../src/richtext/richtextbulletspage.cpp:185
+#: ../src/richtext/richtextliststylepage.cpp:248
+msgid "Bullet &Alignment:"
+msgstr "&Punktlisteplassering"
+
+#: ../src/richtext/richtextbulletspage.cpp:190
+#: ../src/richtext/richtextliststylepage.cpp:253
+#, fuzzy
+msgid "Centre"
+msgstr "Sentrert"
+
+#: ../src/richtext/richtextbulletspage.cpp:194
+#: ../src/richtext/richtextbulletspage.cpp:196
+#: ../src/richtext/richtextbulletspage.cpp:217
+#: ../src/richtext/richtextbulletspage.cpp:219
+#: ../src/richtext/richtextliststylepage.cpp:257
+#: ../src/richtext/richtextliststylepage.cpp:259
+#: ../src/richtext/richtextliststylepage.cpp:278
+#: ../src/richtext/richtextliststylepage.cpp:280
+msgid "The bullet character."
+msgstr "Punktbokstaven."
+
+#: ../src/richtext/richtextbulletspage.cpp:212
+#: ../src/richtext/richtextliststylepage.cpp:271
+#, fuzzy
+msgid "&Symbol:"
+msgstr "&Stil:"
+
+#: ../src/richtext/richtextbulletspage.cpp:222
+#: ../src/richtext/richtextliststylepage.cpp:283
+#, fuzzy
+msgid "Ch&oose..."
+msgstr "&Gå til"
+
+#: ../src/richtext/richtextbulletspage.cpp:223
+#: ../src/richtext/richtextbulletspage.cpp:225
+#: ../src/richtext/richtextliststylepage.cpp:284
+#: ../src/richtext/richtextliststylepage.cpp:286
+msgid "Click to browse for a symbol."
+msgstr "Klikk for å bla gjennom etter symbol."
+
+#: ../src/richtext/richtextbulletspage.cpp:230
+#: ../src/richtext/richtextliststylepage.cpp:291
+msgid "Symbol &font:"
+msgstr ""
+
+#: ../src/richtext/richtextbulletspage.cpp:235
+#: ../src/richtext/richtextbulletspage.cpp:237
+#: ../src/richtext/richtextliststylepage.cpp:297
+msgid "Available fonts."
+msgstr "Tilgjengelige fonter."
+
+#: ../src/richtext/richtextbulletspage.cpp:242
+#: ../src/richtext/richtextliststylepage.cpp:302
+msgid "S&tandard bullet name:"
+msgstr "S&tandard punktnavn:"
+
+#: ../src/richtext/richtextbulletspage.cpp:247
+#: ../src/richtext/richtextbulletspage.cpp:249
+#: ../src/richtext/richtextliststylepage.cpp:307
+#: ../src/richtext/richtextliststylepage.cpp:309
+msgid "A standard bullet name."
+msgstr "Et standard punktnavn."
+
+#: ../src/richtext/richtextbulletspage.cpp:254
+msgid "&Number:"
+msgstr "&Tall:"
+
+#: ../src/richtext/richtextbulletspage.cpp:258
+#: ../src/richtext/richtextbulletspage.cpp:260
+msgid "The list item number."
+msgstr "Nummer på listeinnslaget."
+
+#: ../src/richtext/richtextbulletspage.cpp:266
+#: ../src/richtext/richtextbulletspage.cpp:268
+#: ../src/richtext/richtextliststylepage.cpp:475
+#: ../src/richtext/richtextliststylepage.cpp:477
+msgid "Shows a preview of the bullet settings."
+msgstr "Forhåndsvisning av punktinnstillingene."
+
+#: ../src/richtext/richtextbulletspage.cpp:276
+#: ../src/richtext/richtextliststylepage.cpp:484
+msgid "(None)"
+msgstr "(Ingen)"
+
+#: ../src/richtext/richtextbulletspage.cpp:277
+#: ../src/richtext/richtextliststylepage.cpp:485
+msgid "Arabic"
+msgstr "Arabisk"
+
+#: ../src/richtext/richtextbulletspage.cpp:278
+#: ../src/richtext/richtextliststylepage.cpp:486
+msgid "Upper case letters"
+msgstr "Store bokstaver"
+
+#: ../src/richtext/richtextbulletspage.cpp:279
+#: ../src/richtext/richtextliststylepage.cpp:487
+msgid "Lower case letters"
+msgstr "Små bokstaver"
+
+#: ../src/richtext/richtextbulletspage.cpp:280
+#: ../src/richtext/richtextliststylepage.cpp:488
+msgid "Upper case roman numerals"
+msgstr "Romerske tall i store bokstaver"
+
+#: ../src/richtext/richtextbulletspage.cpp:281
+#: ../src/richtext/richtextliststylepage.cpp:489
+msgid "Lower case roman numerals"
+msgstr "Romerske tall med små bokstaver"
+
+#: ../src/richtext/richtextbulletspage.cpp:282
+#: ../src/richtext/richtextliststylepage.cpp:490
+msgid "Numbered outline"
+msgstr "Nummerert disposisjon"
+
+#: ../src/richtext/richtextbulletspage.cpp:283
+#: ../src/richtext/richtextliststylepage.cpp:491
+msgid "Symbol"
+msgstr ""
+
+#: ../src/richtext/richtextbulletspage.cpp:284
+#: ../src/richtext/richtextliststylepage.cpp:492
+msgid "Bitmap"
+msgstr ""
+
+#: ../src/richtext/richtextbulletspage.cpp:285
+#: ../src/richtext/richtextliststylepage.cpp:493
+msgid "Standard"
+msgstr ""
+
+#: ../src/richtext/richtextbulletspage.cpp:287
+#: ../src/richtext/richtextliststylepage.cpp:495
+msgid "*"
+msgstr ""
+
+#: ../src/richtext/richtextbulletspage.cpp:288
+#: ../src/richtext/richtextliststylepage.cpp:496
+msgid "-"
+msgstr ""
+
+#: ../src/richtext/richtextbulletspage.cpp:289
+#: ../src/richtext/richtextliststylepage.cpp:497
+#, fuzzy
+msgid ">"
+msgstr ">>"
+
+#: ../src/richtext/richtextbulletspage.cpp:290
+#: ../src/richtext/richtextliststylepage.cpp:498
+msgid "+"
+msgstr ""
+
+#: ../src/richtext/richtextbulletspage.cpp:291
+#: ../src/richtext/richtextliststylepage.cpp:499
+msgid "~"
+msgstr ""
+
+#: ../src/richtext/richtextctrl.cpp:859
+msgid "Drag"
+msgstr "Dra"
+
+#: ../src/richtext/richtextctrl.cpp:1338 ../src/richtext/richtextctrl.cpp:1559
+#, fuzzy
+msgid "Delete Text"
+msgstr "Slett element"
+
+#: ../src/richtext/richtextctrl.cpp:1537
+#, fuzzy
+msgid "Remove Bullet"
+msgstr "Slett"
+
+#: ../src/richtext/richtextctrl.cpp:3070
+msgid "The text couldn't be saved."
+msgstr "Klarte ikke lagre teksten."
+
+#: ../src/richtext/richtextctrl.cpp:3644
+#, fuzzy
+msgid "Replace"
+msgstr "&Erstatt"
+
+#: ../src/richtext/richtextfontpage.cpp:146
+#: ../src/richtext/richtextsymboldlg.cpp:384
+#, fuzzy
+msgid "&Font:"
+msgstr "&Skriftfamilie:"
+
+#: ../src/richtext/richtextfontpage.cpp:150
+#: ../src/richtext/richtextfontpage.cpp:152
+#, fuzzy
+msgid "Type a font name."
+msgstr "Skriftfamilie"
+
+#: ../src/richtext/richtextfontpage.cpp:158
+#, fuzzy
+msgid "&Size:"
+msgstr "&Størrelse"
+
+#: ../src/richtext/richtextfontpage.cpp:165
+#: ../src/richtext/richtextfontpage.cpp:167
+msgid "Type a size in points."
+msgstr "Oppgi en størrelse i 'points'"
+
+#: ../src/richtext/richtextfontpage.cpp:180
+#: ../src/richtext/richtextfontpage.cpp:182
+#, fuzzy
+msgid "The font size units, points or pixels."
+msgstr "Skriftpunktstørrelse"
+
+#: ../src/richtext/richtextfontpage.cpp:189
+#: ../src/richtext/richtextfontpage.cpp:191
+#, fuzzy
+msgid "Lists the available fonts."
+msgstr "Tips er ikke tilgjengelig, beklager!"
+
+#: ../src/richtext/richtextfontpage.cpp:196
+#: ../src/richtext/richtextfontpage.cpp:198
+msgid "Lists font sizes in points."
+msgstr "Lister opp fonter i punkter."
+
+#: ../src/richtext/richtextfontpage.cpp:207
+#, fuzzy
+msgid "Font st&yle:"
+msgstr "Skriftstørrelse:"
+
+#: ../src/richtext/richtextfontpage.cpp:212
+#: ../src/richtext/richtextfontpage.cpp:214
+msgid "Select regular or italic style."
+msgstr "Velg vanlig eller kursiv stil."
+
+#: ../src/richtext/richtextfontpage.cpp:220
+#, fuzzy
+msgid "Font &weight:"
+msgstr "Skriftvekt"
+
+#: ../src/richtext/richtextfontpage.cpp:225
+#: ../src/richtext/richtextfontpage.cpp:227
+msgid "Select regular or bold."
+msgstr "Velg vanlig eller fet."
+
+#: ../src/richtext/richtextfontpage.cpp:233
+#, fuzzy
+msgid "&Underlining:"
+msgstr "&Strek under"
+
+#: ../src/richtext/richtextfontpage.cpp:238
+#: ../src/richtext/richtextfontpage.cpp:240
+msgid "Select underlining or no underlining."
+msgstr "Velf understreking eller ikke."
+
+#: ../src/richtext/richtextfontpage.cpp:248
+#, fuzzy
+msgid "&Colour:"
+msgstr "&Farge"
+
+#: ../src/richtext/richtextfontpage.cpp:253
+#: ../src/richtext/richtextfontpage.cpp:255
+msgid "Click to change the text colour."
+msgstr "Klikk for å endre tekstfarge."
+
+#: ../src/richtext/richtextfontpage.cpp:261
+#, fuzzy
+msgid "&Bg colour:"
+msgstr "&Farge"
+
+#: ../src/richtext/richtextfontpage.cpp:266
+#: ../src/richtext/richtextfontpage.cpp:268
+msgid "Click to change the text background colour."
+msgstr "Klikk for å endre farge på tekstbakgrunn."
+
+#: ../src/richtext/richtextfontpage.cpp:276
+#: ../src/richtext/richtextfontpage.cpp:278
+msgid "Check to show a line through the text."
+msgstr "Klikk for å vise strek gjennom tekst."
+
+#: ../src/richtext/richtextfontpage.cpp:281
+msgid "Ca&pitals"
+msgstr "&Store bokstaver"
+
+#: ../src/richtext/richtextfontpage.cpp:283
+#: ../src/richtext/richtextfontpage.cpp:285
+msgid "Check to show the text in capitals."
+msgstr "Klikk for å vise tekst i store bokstaver."
+
+#: ../src/richtext/richtextfontpage.cpp:288
+msgid "Small C&apitals"
+msgstr "Små bokstaver"
+
+#: ../src/richtext/richtextfontpage.cpp:290
+#: ../src/richtext/richtextfontpage.cpp:292
+msgid "Check to show the text in small capitals."
+msgstr "Klikk for å vise tekst i små bokstaver."
+
+#: ../src/richtext/richtextfontpage.cpp:295
+#, fuzzy
+msgid "Supe&rscript"
+msgstr "Skript"
+
+#: ../src/richtext/richtextfontpage.cpp:297
+#: ../src/richtext/richtextfontpage.cpp:299
+msgid "Check to show the text in superscript."
+msgstr "Klikk for å vise tekst i superskript."
+
+#: ../src/richtext/richtextfontpage.cpp:302
+#, fuzzy
+msgid "Subscrip&t"
+msgstr "Skript"
+
+#: ../src/richtext/richtextfontpage.cpp:304
+#: ../src/richtext/richtextfontpage.cpp:306
+msgid "Check to show the text in subscript."
+msgstr "Klikk for å vise tekst i subskript."
+
+#: ../src/richtext/richtextfontpage.cpp:312
+msgid "Rig&ht-to-left"
+msgstr "Høyre-til-venstre"
+
+#: ../src/richtext/richtextfontpage.cpp:314
+#: ../src/richtext/richtextfontpage.cpp:316
+msgid "Check to indicate right-to-left text layout."
+msgstr "Klikk for å indikere høyre-mot-venstre skrift."
+
+#: ../src/richtext/richtextfontpage.cpp:319
+msgid "Suppress hyphe&nation"
+msgstr ""
+
+#: ../src/richtext/richtextfontpage.cpp:321
+#: ../src/richtext/richtextfontpage.cpp:323
+msgid "Check to suppress hyphenation."
+msgstr "Klikk for å unngå gåseøyne."
+
+#: ../src/richtext/richtextfontpage.cpp:329
+#: ../src/richtext/richtextfontpage.cpp:331
+msgid "Shows a preview of the font settings."
+msgstr "Forhåndsvisning av  skriftinnstillingene."
+
+#: ../src/richtext/richtextfontpage.cpp:348
+#: ../src/richtext/richtextfontpage.cpp:352
+#: ../src/richtext/richtextfontpage.cpp:356
+#: ../src/richtext/richtextformatdlg.cpp:873
+#: ../src/richtext/richtextindentspage.cpp:273
+#: ../src/richtext/richtextindentspage.cpp:285
+#: ../src/richtext/richtextindentspage.cpp:286
+#: ../src/richtext/richtextindentspage.cpp:310
+#: ../src/richtext/richtextindentspage.cpp:325
+#: ../src/richtext/richtextliststylepage.cpp:451
+#: ../src/richtext/richtextliststylepage.cpp:463
+#: ../src/richtext/richtextliststylepage.cpp:464
+#, fuzzy
+msgid "(none)"
+msgstr "ikke navn"
+
+#: ../src/richtext/richtextfontpage.cpp:349
+#: ../src/richtext/richtextfontpage.cpp:353
+msgid "Regular"
+msgstr "Vanlig"
+
+#: ../src/richtext/richtextfontpage.cpp:357
+#, fuzzy
+msgid "Not underlined"
+msgstr "understreket"
+
+#: ../src/richtext/richtextformatdlg.cpp:341
+msgid "Indents && Spacing"
+msgstr ""
+
+#: ../src/richtext/richtextformatdlg.cpp:346
+msgid "Tabs"
+msgstr ""
+
+#: ../src/richtext/richtextformatdlg.cpp:351
+msgid "Bullets"
+msgstr "Punkter"
+
+#: ../src/richtext/richtextformatdlg.cpp:356
+msgid "List Style"
+msgstr "Listestil"
+
+#: ../src/richtext/richtextformatdlg.cpp:366
+#: ../src/richtext/richtextmarginspage.cpp:170
+msgid "Margins"
+msgstr "Marger"
+
+#: ../src/richtext/richtextformatdlg.cpp:371
+#, fuzzy
+msgid "Borders"
+msgstr "Moderne"
+
+#: ../src/richtext/richtextformatdlg.cpp:765
+#, fuzzy
+msgid "Colour"
+msgstr "&Farge"
+
+#: ../src/richtext/richtextindentspage.cpp:127
+#: ../src/richtext/richtextliststylepage.cpp:322
+#, fuzzy
+msgid "&Alignment"
+msgstr "Venstrejustering"
+
+#: ../src/richtext/richtextindentspage.cpp:138
+#: ../src/richtext/richtextliststylepage.cpp:331
+msgid "&Left"
+msgstr "&Venstre"
+
+#: ../src/richtext/richtextindentspage.cpp:140
+#: ../src/richtext/richtextindentspage.cpp:142
+#: ../src/richtext/richtextliststylepage.cpp:333
+#: ../src/richtext/richtextliststylepage.cpp:335
+msgid "Left-align text."
+msgstr ""
+
+#: ../src/richtext/richtextindentspage.cpp:145
+#: ../src/richtext/richtextliststylepage.cpp:338
+#, fuzzy
+msgid "&Right"
+msgstr "Lett"
+
+#: ../src/richtext/richtextindentspage.cpp:147
+#: ../src/richtext/richtextindentspage.cpp:149
+#: ../src/richtext/richtextliststylepage.cpp:340
+#: ../src/richtext/richtextliststylepage.cpp:342
+msgid "Right-align text."
+msgstr "Høyrejuster tekst."
+
+#: ../src/richtext/richtextindentspage.cpp:152
+#: ../src/richtext/richtextliststylepage.cpp:345
+#, fuzzy
+msgid "&Justified"
+msgstr "Justert"
+
+#: ../src/richtext/richtextindentspage.cpp:154
+#: ../src/richtext/richtextindentspage.cpp:156
+#: ../src/richtext/richtextliststylepage.cpp:347
+#: ../src/richtext/richtextliststylepage.cpp:349
+msgid "Justify text left and right."
+msgstr "Juster teksten venstre og høyre."
+
+#: ../src/richtext/richtextindentspage.cpp:159
+#: ../src/richtext/richtextliststylepage.cpp:352
+#, fuzzy
+msgid "Cen&tred"
+msgstr "Sentrert"
+
+#: ../src/richtext/richtextindentspage.cpp:161
+#: ../src/richtext/richtextindentspage.cpp:163
+#: ../src/richtext/richtextliststylepage.cpp:354
+#: ../src/richtext/richtextliststylepage.cpp:356
+msgid "Centre text."
+msgstr "Sentrer tekst. "
+
+#: ../src/richtext/richtextindentspage.cpp:166
+#: ../src/richtext/richtextliststylepage.cpp:359
+#, fuzzy
+msgid "&Indeterminate"
+msgstr "&Strek under"
+
+#: ../src/richtext/richtextindentspage.cpp:168
+#: ../src/richtext/richtextindentspage.cpp:170
+#: ../src/richtext/richtextliststylepage.cpp:361
+#: ../src/richtext/richtextliststylepage.cpp:363
+msgid "Use the current alignment setting."
+msgstr "Bruk gjeldende justering."
+
+#: ../src/richtext/richtextindentspage.cpp:183
+#: ../src/richtext/richtextliststylepage.cpp:375
+msgid "&Indentation (tenths of a mm)"
+msgstr "&Innrykk (1/10 mm)"
+
+#: ../src/richtext/richtextindentspage.cpp:198
+#: ../src/richtext/richtextindentspage.cpp:200
+#: ../src/richtext/richtextliststylepage.cpp:388
+#: ../src/richtext/richtextliststylepage.cpp:390
+msgid "The left indent."
+msgstr "INnrykk fra venstre."
+
+#: ../src/richtext/richtextindentspage.cpp:203
+#: ../src/richtext/richtextliststylepage.cpp:393
+msgid "Left (&first line):"
+msgstr "Venstre (&første linje)"
+
+#: ../src/richtext/richtextindentspage.cpp:207
+#: ../src/richtext/richtextindentspage.cpp:209
+#: ../src/richtext/richtextliststylepage.cpp:397
+#: ../src/richtext/richtextliststylepage.cpp:399
+#, fuzzy
+msgid "The first line indent."
+msgstr "Skriftpunktstørrelse"
+
+#: ../src/richtext/richtextindentspage.cpp:216
+#: ../src/richtext/richtextindentspage.cpp:218
+#: ../src/richtext/richtextliststylepage.cpp:406
+#: ../src/richtext/richtextliststylepage.cpp:408
+msgid "The right indent."
+msgstr "Innrykk fra høyre."
+
+#: ../src/richtext/richtextindentspage.cpp:221
+msgid "&Outline level:"
+msgstr "&Disposisjonsnivå"
+
+#: ../src/richtext/richtextindentspage.cpp:226
+#: ../src/richtext/richtextindentspage.cpp:228
+#, fuzzy
+msgid "The outline level."
+msgstr "Viser skriftforhåndsvisning."
+
+#: ../src/richtext/richtextindentspage.cpp:241
+#: ../src/richtext/richtextliststylepage.cpp:420
+msgid "&Spacing (tenths of a mm)"
+msgstr "&Avstand (1/10 mm)"
+
+#: ../src/richtext/richtextindentspage.cpp:252
+msgid "&Before a paragraph:"
+msgstr "&Før avsnitt:"
+
+#: ../src/richtext/richtextindentspage.cpp:256
+#: ../src/richtext/richtextindentspage.cpp:258
+#: ../src/richtext/richtextliststylepage.cpp:433
+#: ../src/richtext/richtextliststylepage.cpp:435
+msgid "The spacing before the paragraph."
+msgstr "Avstand før avsnittet."
+
+#: ../src/richtext/richtextindentspage.cpp:261
+msgid "&After a paragraph:"
+msgstr "&Etter et avsnitt:"
+
+#: ../src/richtext/richtextindentspage.cpp:266
+#: ../src/richtext/richtextliststylepage.cpp:442
+#: ../src/richtext/richtextliststylepage.cpp:444
+msgid "The spacing after the paragraph."
+msgstr "Avstand etter avsnittet."
+
+#: ../src/richtext/richtextindentspage.cpp:269
+msgid "L&ine spacing:"
+msgstr "L&injeavstand:"
+
+#: ../src/richtext/richtextindentspage.cpp:274
+#: ../src/richtext/richtextliststylepage.cpp:452
+msgid "Single"
+msgstr "Enkel"
+
+#: ../src/richtext/richtextindentspage.cpp:275
+#: ../src/richtext/richtextliststylepage.cpp:453
+msgid "1.1"
+msgstr ""
+
+#: ../src/richtext/richtextindentspage.cpp:276
+#: ../src/richtext/richtextliststylepage.cpp:454
+msgid "1.2"
+msgstr ""
+
+#: ../src/richtext/richtextindentspage.cpp:277
+#: ../src/richtext/richtextliststylepage.cpp:455
+msgid "1.3"
+msgstr ""
+
+#: ../src/richtext/richtextindentspage.cpp:278
+#: ../src/richtext/richtextliststylepage.cpp:456
+msgid "1.4"
+msgstr ""
+
+#: ../src/richtext/richtextindentspage.cpp:279
+#: ../src/richtext/richtextliststylepage.cpp:457
+msgid "1.5"
+msgstr ""
+
+#: ../src/richtext/richtextindentspage.cpp:280
+#: ../src/richtext/richtextliststylepage.cpp:458
+msgid "1.6"
+msgstr ""
+
+#: ../src/richtext/richtextindentspage.cpp:281
+#: ../src/richtext/richtextliststylepage.cpp:459
+msgid "1.7"
+msgstr ""
+
+#: ../src/richtext/richtextindentspage.cpp:282
+#: ../src/richtext/richtextliststylepage.cpp:460
+msgid "1.8"
+msgstr ""
+
+#: ../src/richtext/richtextindentspage.cpp:283
+#: ../src/richtext/richtextliststylepage.cpp:461
+msgid "1.9"
+msgstr ""
+
+#: ../src/richtext/richtextindentspage.cpp:284
+#: ../src/richtext/richtextliststylepage.cpp:462
+msgid "2"
+msgstr ""
+
+#: ../src/richtext/richtextindentspage.cpp:287
+#: ../src/richtext/richtextindentspage.cpp:289
+#: ../src/richtext/richtextliststylepage.cpp:465
+#: ../src/richtext/richtextliststylepage.cpp:467
+msgid "The line spacing."
+msgstr "Linjeavstanden."
+
+#: ../src/richtext/richtextindentspage.cpp:292
+msgid "&Page Break"
+msgstr "&Ny side"
+
+#: ../src/richtext/richtextindentspage.cpp:294
+#: ../src/richtext/richtextindentspage.cpp:296
+msgid "Inserts a page break before the paragraph."
+msgstr "Sett inn sideskift før neste avsnitt."
+
+#: ../src/richtext/richtextindentspage.cpp:302
+#: ../src/richtext/richtextindentspage.cpp:304
+msgid "Shows a preview of the paragraph settings."
+msgstr "Forhåndsvisning av avsnittinnstillingene."
+
+#: ../src/richtext/richtextliststylepage.cpp:182
+msgid "&List level:"
+msgstr "&Listenivå:"
+
+#: ../src/richtext/richtextliststylepage.cpp:186
+#: ../src/richtext/richtextliststylepage.cpp:188
+msgid "Selects the list level to edit."
+msgstr "Velger listenivå som skal endres."
+
+#: ../src/richtext/richtextliststylepage.cpp:193
+msgid "&Font for Level..."
+msgstr "&Font for nivå..."
+
+#: ../src/richtext/richtextliststylepage.cpp:194
+#: ../src/richtext/richtextliststylepage.cpp:196
+msgid "Click to choose the font for this level."
+msgstr "Klikk for å velge for for dette nivået."
+
+#: ../src/richtext/richtextliststylepage.cpp:312
+msgid "Bullet style"
+msgstr "Punktlistestil"
+
+#: ../src/richtext/richtextliststylepage.cpp:429
+msgid "Before a paragraph:"
+msgstr "Før et avsnitt:"
+
+#: ../src/richtext/richtextliststylepage.cpp:438
+msgid "After a paragraph:"
+msgstr "Etter et avsnitt:"
+
+#: ../src/richtext/richtextliststylepage.cpp:447
+msgid "Line spacing:"
+msgstr "Linjeavstand:"
+
+#: ../src/richtext/richtextliststylepage.cpp:470
+#, fuzzy
+msgid "Spacing"
+msgstr "Søker..."
+
+#: ../src/richtext/richtextmarginspage.cpp:193
+#: ../src/richtext/richtextmarginspage.cpp:195
+msgid "The left margin size."
+msgstr "Størrelse på venstre marg."
+
+#: ../src/richtext/richtextmarginspage.cpp:203
+#: ../src/richtext/richtextmarginspage.cpp:205
+msgid "Units for the left margin."
+msgstr "Enheter for venstre marg."
+
+#: ../src/richtext/richtextmarginspage.cpp:218
+#: ../src/richtext/richtextmarginspage.cpp:220
+msgid "The right margin size."
+msgstr "Størelsen på høyre marg."
+
+#: ../src/richtext/richtextmarginspage.cpp:228
+#: ../src/richtext/richtextmarginspage.cpp:230
+msgid "Units for the right margin."
+msgstr "Enheter for høyremargen."
+
+#: ../src/richtext/richtextmarginspage.cpp:241
+#: ../src/richtext/richtextmarginspage.cpp:243
+msgid "The top margin size."
+msgstr "Margstørrelse på toppen"
+
+#: ../src/richtext/richtextmarginspage.cpp:251
+#: ../src/richtext/richtextmarginspage.cpp:253
+msgid "Units for the top margin."
+msgstr "Enheter for toppmargen."
+
+#: ../src/richtext/richtextmarginspage.cpp:266
+#: ../src/richtext/richtextmarginspage.cpp:268
+#, fuzzy
+msgid "The bottom margin size."
+msgstr "Skriftpunktstørrelse"
+
+#: ../src/richtext/richtextmarginspage.cpp:276
+#: ../src/richtext/richtextmarginspage.cpp:278
+msgid "Units for the bottom margin."
+msgstr "Enheter for bunnmarg."
+
+#: ../src/richtext/richtextmarginspage.cpp:284
+#, fuzzy
+msgid "Padding"
+msgstr "leser"
+
+#: ../src/richtext/richtextmarginspage.cpp:307
+#: ../src/richtext/richtextmarginspage.cpp:309
+msgid "The left padding size."
+msgstr "Polstring til venstre. "
+
+#: ../src/richtext/richtextmarginspage.cpp:317
+#: ../src/richtext/richtextmarginspage.cpp:319
+msgid "Units for the left padding."
+msgstr "Enheter for polstring til venstre."
+
+#: ../src/richtext/richtextmarginspage.cpp:332
+#: ../src/richtext/richtextmarginspage.cpp:334
+msgid "The right padding size."
+msgstr "Høyre polstring."
+
+#: ../src/richtext/richtextmarginspage.cpp:342
+#: ../src/richtext/richtextmarginspage.cpp:344
+msgid "Units for the right padding."
+msgstr "Enheter for polstring til høyre."
+
+#: ../src/richtext/richtextmarginspage.cpp:355
+#: ../src/richtext/richtextmarginspage.cpp:357
+msgid "The top padding size."
+msgstr "Polstring på toppen."
+
+#: ../src/richtext/richtextmarginspage.cpp:365
+#: ../src/richtext/richtextmarginspage.cpp:367
+msgid "Units for the top padding."
+msgstr "Enheter for polstring på toppen."
+
+#: ../src/richtext/richtextmarginspage.cpp:380
+#: ../src/richtext/richtextmarginspage.cpp:382
+#, fuzzy
+msgid "The bottom padding size."
+msgstr "Skriftpunktstørrelse"
+
+#: ../src/richtext/richtextmarginspage.cpp:390
+#: ../src/richtext/richtextmarginspage.cpp:392
+msgid "Units for the bottom padding."
+msgstr "Enheter for polstring på bunnen."
+
+#: ../src/richtext/richtextprint.cpp:592
+msgid " Preview"
+msgstr "Forhåndsvisning"
+
+#: ../src/richtext/richtextsizepage.cpp:228
+msgid "Floating"
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:243
+msgid "&Floating mode:"
+msgstr "&Flytende modus:"
+
+#: ../src/richtext/richtextsizepage.cpp:252
+#: ../src/richtext/richtextsizepage.cpp:254
+msgid "How the object will float relative to the text."
+msgstr "Hvordan objektet vil ligge relativt til teksten."
+
+#: ../src/richtext/richtextsizepage.cpp:265
+#, fuzzy
+msgid "Alignment"
+msgstr "Venstrejustering"
+
+#: ../src/richtext/richtextsizepage.cpp:277
+#, fuzzy
+msgid "&Vertical alignment:"
+msgstr "Venstrejustering"
+
+#: ../src/richtext/richtextsizepage.cpp:279
+#: ../src/richtext/richtextsizepage.cpp:281
+msgid "Enable vertical alignment."
+msgstr "Bruk vertikal justering."
+
+#: ../src/richtext/richtextsizepage.cpp:286
+#, fuzzy
+msgid "Centred"
+msgstr "Sentrert"
+
+#: ../src/richtext/richtextsizepage.cpp:290
+#: ../src/richtext/richtextsizepage.cpp:292
+#, fuzzy
+msgid "Vertical alignment."
+msgstr "Klarte ikke starte utskrift."
+
+#: ../src/richtext/richtextsizepage.cpp:316
+#: ../src/richtext/richtextsizepage.cpp:323
+#, fuzzy
+msgid "&Width:"
+msgstr "&Vekt:"
+
+#: ../src/richtext/richtextsizepage.cpp:318
+#: ../src/richtext/richtextsizepage.cpp:320
+msgid "Enable the width value."
+msgstr "Bruk bredde."
+
+#: ../src/richtext/richtextsizepage.cpp:331
+#: ../src/richtext/richtextsizepage.cpp:333
+msgid "The object width."
+msgstr "Bredde på objekt."
+
+#: ../src/richtext/richtextsizepage.cpp:342
+#: ../src/richtext/richtextsizepage.cpp:344
+msgid "Units for the object width."
+msgstr "Enheter for objektbredden."
+
+#: ../src/richtext/richtextsizepage.cpp:350
+#: ../src/richtext/richtextsizepage.cpp:357
+#, fuzzy
+msgid "&Height:"
+msgstr "&Vekt:"
+
+#: ../src/richtext/richtextsizepage.cpp:352
+#: ../src/richtext/richtextsizepage.cpp:354
+#: ../src/richtext/richtextsizepage.cpp:464
+#: ../src/richtext/richtextsizepage.cpp:466
+msgid "Enable the height value."
+msgstr "Bruk høydeinnstilling."
+
+#: ../src/richtext/richtextsizepage.cpp:365
+#: ../src/richtext/richtextsizepage.cpp:367
+msgid "The object height."
+msgstr "Objekthøyde."
+
+#: ../src/richtext/richtextsizepage.cpp:376
+#: ../src/richtext/richtextsizepage.cpp:378
+msgid "Units for the object height."
+msgstr "Enheter for objekthøyden."
+
+#: ../src/richtext/richtextsizepage.cpp:381
+msgid "Min width:"
+msgstr "Min bredde:"
+
+#: ../src/richtext/richtextsizepage.cpp:383
+#: ../src/richtext/richtextsizepage.cpp:385
+msgid "Enable the minimum width value."
+msgstr "Bruk  minimumsbredde."
+
+#: ../src/richtext/richtextsizepage.cpp:392
+#: ../src/richtext/richtextsizepage.cpp:394
+msgid "The object minimum width."
+msgstr "Minimum bredde på objekt."
+
+#: ../src/richtext/richtextsizepage.cpp:403
+#: ../src/richtext/richtextsizepage.cpp:405
+msgid "Units for the minimum object width."
+msgstr "Enheter for minimum objektbredde."
+
+#: ../src/richtext/richtextsizepage.cpp:408
+msgid "Min height:"
+msgstr "Min høyde:"
+
+#: ../src/richtext/richtextsizepage.cpp:410
+#: ../src/richtext/richtextsizepage.cpp:412
+msgid "Enable the minimum height value."
+msgstr "Bruk minimumshøyde. "
+
+#: ../src/richtext/richtextsizepage.cpp:419
+#: ../src/richtext/richtextsizepage.cpp:421
+msgid "The object minimum height."
+msgstr "Minimum høyde på objekt."
+
+#: ../src/richtext/richtextsizepage.cpp:430
+#: ../src/richtext/richtextsizepage.cpp:432
+msgid "Units for the minimum object height."
+msgstr "Enheter for minimum objekthøyde."
+
+#: ../src/richtext/richtextsizepage.cpp:435
+msgid "Max width:"
+msgstr "Maks bredde:"
+
+#: ../src/richtext/richtextsizepage.cpp:437
+#: ../src/richtext/richtextsizepage.cpp:439
+msgid "Enable the maximum width value."
+msgstr "Bruk maksimumsbredde."
+
+#: ../src/richtext/richtextsizepage.cpp:446
+#: ../src/richtext/richtextsizepage.cpp:448
+msgid "The object maximum width."
+msgstr "Maksimum bredde på objekt."
+
+#: ../src/richtext/richtextsizepage.cpp:457
+#: ../src/richtext/richtextsizepage.cpp:459
+msgid "Units for the maximum object width."
+msgstr "Enheter for maksimum objektbredde."
+
+#: ../src/richtext/richtextsizepage.cpp:462
+msgid "Max height:"
+msgstr "Maks høyde:"
+
+#: ../src/richtext/richtextsizepage.cpp:473
+#: ../src/richtext/richtextsizepage.cpp:475
+msgid "The object maximum height."
+msgstr "Maksimum høyde på onjekt."
+
+#: ../src/richtext/richtextsizepage.cpp:484
+#: ../src/richtext/richtextsizepage.cpp:486
+msgid "Units for the maximum object height."
+msgstr "Enheter for maksimum objekthøyde."
+
+#: ../src/richtext/richtextsizepage.cpp:495
+msgid "Position"
+msgstr "Posisjon"
+
+#: ../src/richtext/richtextsizepage.cpp:513
+#, fuzzy
+msgid "&Position mode:"
+msgstr "Spørsmål"
+
+#: ../src/richtext/richtextsizepage.cpp:517
+#: ../src/richtext/richtextsizepage.cpp:522
+#, fuzzy
+msgid "Static"
+msgstr "Status: "
+
+#: ../src/richtext/richtextsizepage.cpp:518
+#, fuzzy
+msgid "Relative"
+msgstr "Dekorativ"
+
+#: ../src/richtext/richtextsizepage.cpp:519
+msgid "Absolute"
+msgstr "Absolutt"
+
+#: ../src/richtext/richtextsizepage.cpp:520
+#, fuzzy
+msgid "Fixed"
+msgstr "Fast skrift:"
+
+#: ../src/richtext/richtextsizepage.cpp:533
+#: ../src/richtext/richtextsizepage.cpp:535
+#: ../src/richtext/richtextsizepage.cpp:547
+#: ../src/richtext/richtextsizepage.cpp:549
+msgid "The left position."
+msgstr "Venstre posisjon."
+
+#: ../src/richtext/richtextsizepage.cpp:558
+#: ../src/richtext/richtextsizepage.cpp:560
+msgid "Units for the left position."
+msgstr "Enheter for venstreplassering."
+
+#: ../src/richtext/richtextsizepage.cpp:568
+#: ../src/richtext/richtextsizepage.cpp:570
+#: ../src/richtext/richtextsizepage.cpp:582
+#: ../src/richtext/richtextsizepage.cpp:584
+msgid "The top position."
+msgstr "Plassering av topp"
+
+#: ../src/richtext/richtextsizepage.cpp:593
+#: ../src/richtext/richtextsizepage.cpp:595
+#, fuzzy
+msgid "Units for the top position."
+msgstr "Kan ikke vente på trådens avslutning."
+
+#: ../src/richtext/richtextsizepage.cpp:603
+#: ../src/richtext/richtextsizepage.cpp:605
+#: ../src/richtext/richtextsizepage.cpp:617
+#: ../src/richtext/richtextsizepage.cpp:619
+msgid "The right position."
+msgstr "Høyre posisjon"
+
+#: ../src/richtext/richtextsizepage.cpp:628
+#: ../src/richtext/richtextsizepage.cpp:630
+msgid "Units for the right position."
+msgstr "Enheter for høyreplassering."
+
+#: ../src/richtext/richtextsizepage.cpp:638
+#: ../src/richtext/richtextsizepage.cpp:640
+#: ../src/richtext/richtextsizepage.cpp:652
+#: ../src/richtext/richtextsizepage.cpp:654
+#, fuzzy
+msgid "The bottom position."
+msgstr "Skriftpunktstørrelse"
+
+#: ../src/richtext/richtextsizepage.cpp:663
+#: ../src/richtext/richtextsizepage.cpp:665
+msgid "Units for the bottom position."
+msgstr "Enheter for bunnplassering."
+
+#: ../src/richtext/richtextsizepage.cpp:671
+msgid "&Move the object to:"
+msgstr "&Flytt objekt til:"
+
+#: ../src/richtext/richtextsizepage.cpp:674
+#, fuzzy
+msgid "&Previous Paragraph"
+msgstr "Forrige side"
+
+#: ../src/richtext/richtextsizepage.cpp:675
+#: ../src/richtext/richtextsizepage.cpp:677
+msgid "Moves the object to the previous paragraph."
+msgstr "Flytter objektet til forige avsnitt."
+
+#: ../src/richtext/richtextsizepage.cpp:680
+msgid "&Next Paragraph"
+msgstr "&Neste avsnitt"
+
+#: ../src/richtext/richtextsizepage.cpp:681
+#: ../src/richtext/richtextsizepage.cpp:683
+msgid "Moves the object to the next paragraph."
+msgstr "Flytter objektet til neste avsnitt."
+
+#: ../src/richtext/richtextstyledlg.cpp:193
+#, fuzzy
+msgid "&Styles:"
+msgstr "&Stil:"
+
+#: ../src/richtext/richtextstyledlg.cpp:197
+#: ../src/richtext/richtextstyledlg.cpp:199
+#, fuzzy
+msgid "The available styles."
+msgstr "Skriftstil"
+
+#: ../src/richtext/richtextstyledlg.cpp:205
+#: ../src/richtext/richtextstyledlg.cpp:217
+msgid " "
+msgstr "  "
+
+#: ../src/richtext/richtextstyledlg.cpp:209
+#: ../src/richtext/richtextstyledlg.cpp:211
+#, fuzzy
+msgid "The style preview."
+msgstr "Viser skriftforhåndsvisning."
+
+#: ../src/richtext/richtextstyledlg.cpp:220
+msgid "New &Character Style..."
+msgstr "Ny &bokstavstil..."
+
+#: ../src/richtext/richtextstyledlg.cpp:221
+#: ../src/richtext/richtextstyledlg.cpp:223
+msgid "Click to create a new character style."
+msgstr "Klikk for å lage en ny bokstavstil."
+
+#: ../src/richtext/richtextstyledlg.cpp:226
+msgid "New &Paragraph Style..."
+msgstr "Ny &avsnittstil..."
+
+#: ../src/richtext/richtextstyledlg.cpp:227
+#: ../src/richtext/richtextstyledlg.cpp:229
+msgid "Click to create a new paragraph style."
+msgstr "Klikk for å lage en ny stil for avsnitt."
+
+#: ../src/richtext/richtextstyledlg.cpp:232
+msgid "New &List Style..."
+msgstr "Ny &liststil..."
+
+#: ../src/richtext/richtextstyledlg.cpp:233
+#: ../src/richtext/richtextstyledlg.cpp:235
+#, fuzzy
+msgid "Click to create a new list style."
+msgstr "Klikk for å avbryte skriftvalg."
+
+#: ../src/richtext/richtextstyledlg.cpp:238
+#, fuzzy
+msgid "New &Box Style..."
+msgstr "Nytt element"
+
+#: ../src/richtext/richtextstyledlg.cpp:239
+#: ../src/richtext/richtextstyledlg.cpp:241
+msgid "Click to create a new box style."
+msgstr "Klikk for å lage en ny boksstil."
+
+#: ../src/richtext/richtextstyledlg.cpp:246
+#, fuzzy
+msgid "&Apply Style"
+msgstr "&Bruk"
+
+#: ../src/richtext/richtextstyledlg.cpp:247
+#: ../src/richtext/richtextstyledlg.cpp:249
+msgid "Click to apply the selected style."
+msgstr "Klikk for å bruke valgt stil."
+
+#: ../src/richtext/richtextstyledlg.cpp:252
+msgid "&Rename Style..."
+msgstr "&Døp om Stil..."
+
+#: ../src/richtext/richtextstyledlg.cpp:253
+#: ../src/richtext/richtextstyledlg.cpp:255
+msgid "Click to rename the selected style."
+msgstr "Klikk for å døpe om valgt stil."
+
+#: ../src/richtext/richtextstyledlg.cpp:258
+#, fuzzy
+msgid "&Edit Style..."
+msgstr "Redigere element"
+
+#: ../src/richtext/richtextstyledlg.cpp:259
+#: ../src/richtext/richtextstyledlg.cpp:261
+msgid "Click to edit the selected style."
+msgstr "Klikk for å endre valgt stil."
+
+#: ../src/richtext/richtextstyledlg.cpp:264
+#, fuzzy
+msgid "&Delete Style..."
+msgstr "Slett element"
+
+#: ../src/richtext/richtextstyledlg.cpp:265
+#: ../src/richtext/richtextstyledlg.cpp:267
+msgid "Click to delete the selected style."
+msgstr "Klikk for å fjerne valgt stil.."
+
+#: ../src/richtext/richtextstyledlg.cpp:274
+#: ../src/richtext/richtextstyledlg.cpp:276
+#, fuzzy
+msgid "Click to close this window."
+msgstr "Lukk dette vinduet"
+
+#: ../src/richtext/richtextstyledlg.cpp:282
+msgid "&Restart numbering"
+msgstr "&Gjenstart nummerering"
+
+#: ../src/richtext/richtextstyledlg.cpp:284
+#: ../src/richtext/richtextstyledlg.cpp:286
+msgid "Check to restart numbering."
+msgstr "Klikk for å gjenstarte nummereringen."
+
+#: ../src/richtext/richtextstyledlg.cpp:601
+msgid "Enter a character style name"
+msgstr "Navn på bokstavstil"
+
+#: ../src/richtext/richtextstyledlg.cpp:601
+#: ../src/richtext/richtextstyledlg.cpp:606
+#: ../src/richtext/richtextstyledlg.cpp:649
+#: ../src/richtext/richtextstyledlg.cpp:654
+#: ../src/richtext/richtextstyledlg.cpp:815
+#: ../src/richtext/richtextstyledlg.cpp:820
+#: ../src/richtext/richtextstyledlg.cpp:888
+#: ../src/richtext/richtextstyledlg.cpp:896
+#: ../src/richtext/richtextstyledlg.cpp:929
+#: ../src/richtext/richtextstyledlg.cpp:934
+msgid "New Style"
+msgstr "Nytt elementNy stil"
+
+#: ../src/richtext/richtextstyledlg.cpp:606
+#: ../src/richtext/richtextstyledlg.cpp:654
+#: ../src/richtext/richtextstyledlg.cpp:820
+#: ../src/richtext/richtextstyledlg.cpp:896
+#: ../src/richtext/richtextstyledlg.cpp:934
+msgid "Sorry, that name is taken. Please choose another."
+msgstr "Beklager, det navnet er opptatt. Velg et annet."
+
+#: ../src/richtext/richtextstyledlg.cpp:649
+msgid "Enter a paragraph style name"
+msgstr "Navn på avsnittstil"
+
+#: ../src/richtext/richtextstyledlg.cpp:777
+#, fuzzy, c-format
+msgid "Delete style %s?"
+msgstr "Slett element"
+
+#: ../src/richtext/richtextstyledlg.cpp:777
+#, fuzzy
+msgid "Delete Style"
+msgstr "Slett element"
+
+#: ../src/richtext/richtextstyledlg.cpp:815
+msgid "Enter a list style name"
+msgstr "Navn på stilen"
+
+#: ../src/richtext/richtextstyledlg.cpp:888
+msgid "Enter a new style name"
+msgstr "Navn på skriftstil"
+
+#: ../src/richtext/richtextstyledlg.cpp:929
+msgid "Enter a box style name"
+msgstr "Navn på boksstil"
+
+#: ../src/richtext/richtextstylepage.cpp:109
+#: ../src/richtext/richtextstylepage.cpp:111
+msgid "The style name."
+msgstr "Stilnavn."
+
+#: ../src/richtext/richtextstylepage.cpp:114
+msgid "&Based on:"
+msgstr "&Basert på:"
+
+#: ../src/richtext/richtextstylepage.cpp:119
+#: ../src/richtext/richtextstylepage.cpp:121
+msgid "The style on which this style is based."
+msgstr "Stilen som denne stilen baseres på."
+
+#: ../src/richtext/richtextstylepage.cpp:124
+#, fuzzy
+msgid "&Next style:"
+msgstr "&Neste >"
+
+#: ../src/richtext/richtextstylepage.cpp:129
+#: ../src/richtext/richtextstylepage.cpp:131
+msgid "The default style for the next paragraph."
+msgstr "Standard stil for neste avsnitt."
+
+#: ../src/richtext/richtextstyles.cpp:1057
+msgid "All styles"
+msgstr "Alle stiler"
+
+#: ../src/richtext/richtextstyles.cpp:1058
+msgid "Paragraph styles"
+msgstr "Avsnittstil"
+
+#: ../src/richtext/richtextstyles.cpp:1059
+msgid "Character styles"
+msgstr "Bokstavstiler"
+
+#: ../src/richtext/richtextstyles.cpp:1060
+msgid "List styles"
+msgstr "List opp stiler"
+
+#: ../src/richtext/richtextstyles.cpp:1061
+#, fuzzy
+msgid "Box styles"
+msgstr "&Neste >"
+
+#: ../src/richtext/richtextsymboldlg.cpp:389
+#: ../src/richtext/richtextsymboldlg.cpp:391
+msgid "The font from which to take the symbol."
+msgstr "Fonten som symbolet hentes fra."
+
+#: ../src/richtext/richtextsymboldlg.cpp:396
+msgid "&Subset:"
+msgstr "&Undergruppe:"
+
+#: ../src/richtext/richtextsymboldlg.cpp:401
+#: ../src/richtext/richtextsymboldlg.cpp:403
+msgid "Shows a Unicode subset."
+msgstr "Viser en undergruppe av Unicode."
+
+#: ../src/richtext/richtextsymboldlg.cpp:412
+msgid "xxxx"
+msgstr ""
+
+#: ../src/richtext/richtextsymboldlg.cpp:417
+msgid "&Character code:"
+msgstr "&Tegnkode:"
+
+#: ../src/richtext/richtextsymboldlg.cpp:421
+#: ../src/richtext/richtextsymboldlg.cpp:423
+msgid "The character code."
+msgstr "Tegnkoden."
+
+#: ../src/richtext/richtextsymboldlg.cpp:428
+#, fuzzy
+msgid "&From:"
+msgstr "Fra:"
+
+#: ../src/richtext/richtextsymboldlg.cpp:433
+#: ../src/richtext/richtextsymboldlg.cpp:434
+#: ../src/richtext/richtextsymboldlg.cpp:435
+#, fuzzy
+msgid "Unicode"
+msgstr "&Fjern innrykk"
+
+#: ../src/richtext/richtextsymboldlg.cpp:436
+#: ../src/richtext/richtextsymboldlg.cpp:438
+msgid "The range to show."
+msgstr "Område som skal vises."
+
+#: ../src/richtext/richtextsymboldlg.cpp:444
+#, fuzzy
+msgid "Insert"
+msgstr "Innrykk"
+
+#: ../src/richtext/richtextsymboldlg.cpp:478
+#, fuzzy
+msgid "(Normal text)"
+msgstr "Normal skrift:"
+
+#: ../src/richtext/richtexttabspage.cpp:109
+msgid "&Position (tenths of a mm):"
+msgstr "&Posisjon(1/10 mm)"
+
+#: ../src/richtext/richtexttabspage.cpp:113
+#: ../src/richtext/richtexttabspage.cpp:115
+msgid "The tab position."
+msgstr "Tab-posisjonen."
+
+#: ../src/richtext/richtexttabspage.cpp:119
+msgid "The tab positions."
+msgstr "Tab-posisjonene."
+
+#: ../src/richtext/richtexttabspage.cpp:132
+#: ../src/richtext/richtexttabspage.cpp:134
+msgid "Click to create a new tab position."
+msgstr "Klikk for å lage ny tab-posisjon."
+
+#: ../src/richtext/richtexttabspage.cpp:138
+#: ../src/richtext/richtexttabspage.cpp:140
+msgid "Click to delete the selected tab position."
+msgstr "Klikk for å fjerne valgt tab-posisjon."
+
+#: ../src/richtext/richtexttabspage.cpp:143
+#, fuzzy
+msgid "Delete A&ll"
+msgstr "Velg &alle"
+
+#: ../src/richtext/richtexttabspage.cpp:144
+#: ../src/richtext/richtexttabspage.cpp:146
+msgid "Click to delete all tab positions."
+msgstr "Klikk for å fjerne alle tab-posisjoner."
+
+#: ../src/univ/theme.cpp:110
+msgid "Failed to initialize GUI: no built-in themes found."
+msgstr "Klarte ikke initialere GUI: ingen innebygde tema funnet."
+
+#: ../src/univ/themes/gtk.cpp:521
+msgid "GTK+ theme"
+msgstr "GTK+ tema"
+
+#: ../src/univ/themes/metal.cpp:164
+msgid "Metal theme"
+msgstr "Metaltema"
+
+#: ../src/univ/themes/mono.cpp:512
+msgid "Simple monochrome theme"
+msgstr "Enkelt monokromt tema"
+
+#: ../src/univ/themes/win32.cpp:1098
+msgid "Win32 theme"
+msgstr "Win32-tema"
+
+#: ../src/univ/themes/win32.cpp:3743
+msgid "&Restore"
+msgstr "&Gjenopprett"
+
+#: ../src/univ/themes/win32.cpp:3744
+msgid "&Move"
+msgstr "&Flytt"
+
+#: ../src/univ/themes/win32.cpp:3746
+msgid "&Size"
+msgstr "&Størrelse"
+
+#: ../src/univ/themes/win32.cpp:3748
+msgid "Mi&nimize"
+msgstr "Mi&nimer"
+
+#: ../src/univ/themes/win32.cpp:3750
+msgid "Ma&ximize"
+msgstr "Ma&ksimer"
+
+#: ../src/univ/themes/win32.cpp:3752
+msgid "Alt+"
+msgstr ""
+
+#: ../src/unix/appunix.cpp:178
+#, fuzzy
+msgid "Failed to install signal handler"
+msgstr "Klarte ikke lukke filreferanse"
+
+#: ../src/unix/dialup.cpp:351
+msgid "Already dialling ISP."
+msgstr "Ringer allerede ISP."
+
+#: ../src/unix/dlunix.cpp:93
+#, fuzzy
+msgid "Failed to unload shared library"
+msgstr "Klarte ikke laste delt bibliotek «%s»"
+
+#: ../src/unix/dlunix.cpp:121
+msgid "Unknown dynamic library error"
+msgstr "Ukjent feil i dynamisk bibliotek"
+
+#: ../src/unix/epolldispatcher.cpp:84
+#, fuzzy
+msgid "Failed to create epoll descriptor"
+msgstr "Klarte ikke opprette peker."
+
+#: ../src/unix/epolldispatcher.cpp:103
+#, fuzzy
+msgid "Error closing epoll descriptor"
+msgstr "Feil ved opprettelse av mappe"
+
+#: ../src/unix/epolldispatcher.cpp:116
+#, fuzzy, c-format
+msgid "Failed to add descriptor %d to epoll descriptor %d"
+msgstr "klarte ikke skrive til deskriptor %d"
+
+#: ../src/unix/epolldispatcher.cpp:136
+#, c-format
+msgid "Failed to modify descriptor %d in epoll descriptor %d"
+msgstr ""
+
+#: ../src/unix/epolldispatcher.cpp:155
+#, fuzzy, c-format
+msgid "Failed to unregister descriptor %d from epoll descriptor %d"
+msgstr "Klarte ikke hente data fra utklippstavlen."
+
+#: ../src/unix/epolldispatcher.cpp:213
+#, fuzzy, c-format
+msgid "Waiting for IO on epoll descriptor %d failed"
+msgstr "Venting på avslutning av underprosess feilet"
+
+#: ../src/unix/fswatcher_inotify.cpp:71
+#, fuzzy
+msgid "Unable to create inotify instance"
+msgstr "Klarte ikke opprette DDE-streng"
+
+#: ../src/unix/fswatcher_inotify.cpp:94
+#, fuzzy
+msgid "Unable to close inotify instance"
+msgstr "Klarte ikke lukke filreferanse"
+
+#: ../src/unix/fswatcher_inotify.cpp:106
+msgid "Unable to add inotify watch"
+msgstr ""
+
+#: ../src/unix/fswatcher_inotify.cpp:138
+#, fuzzy, c-format
+msgid "Unable to remove inotify watch %i"
+msgstr "Klarte ikke opprette DDE-streng"
+
+#: ../src/unix/fswatcher_inotify.cpp:271
+#, c-format
+msgid "Unexpected event for \"%s\": no matching watch descriptor."
+msgstr ""
+
+#: ../src/unix/fswatcher_inotify.cpp:320
+#, c-format
+msgid "Invalid inotify event for \"%s\""
+msgstr ""
+
+#: ../src/unix/fswatcher_inotify.cpp:553
+#, fuzzy
+msgid "Unable to read from inotify descriptor"
+msgstr "klarte ikke lese fra fildeskriptor %d"
+
+#: ../src/unix/fswatcher_inotify.cpp:558
+#, fuzzy
+msgid "EOF while reading from inotify descriptor"
+msgstr "klarte ikke lese fra fildeskriptor %d"
+
+#: ../src/unix/fswatcher_kqueue.cpp:114
+#, fuzzy
+msgid "Unable to create kqueue instance"
+msgstr "Klarte ikke opprette DDE-streng"
+
+#: ../src/unix/fswatcher_kqueue.cpp:131
+#, fuzzy
+msgid "Error closing kqueue instance"
+msgstr "Feil ved opprettelse av mappe"
+
+#: ../src/unix/fswatcher_kqueue.cpp:153
+msgid "Unable to add kqueue watch"
+msgstr ""
+
+#: ../src/unix/fswatcher_kqueue.cpp:170
+msgid "Unable to remove kqueue watch"
+msgstr ""
+
+#: ../src/unix/fswatcher_kqueue.cpp:202
+msgid "Unable to get events from kqueue"
+msgstr ""
+
+#: ../src/unix/mediactrl.cpp:966
+#, c-format
+msgid "Media playback error: %s"
+msgstr "Avspillingsfeil: %s"
+
+#: ../src/unix/mediactrl.cpp:1228
+#, fuzzy, c-format
+msgid "Failed to prepare playing \"%s\"."
+msgstr "Klarte ikke åpne «%s» for «%s»"
+
+#: ../src/unix/snglinst.cpp:164
+#, c-format
+msgid "Failed to write to lock file '%s'"
+msgstr "Klarte ikke skrive til låsefil «%s»"
+
+#: ../src/unix/snglinst.cpp:177
+#, c-format
+msgid "Failed to set permissions on lock file '%s'"
+msgstr "Klarte ikke sette rettigheter på låsefile «%s»"
+
+#: ../src/unix/snglinst.cpp:194
+#, c-format
+msgid "Failed to lock the lock file '%s'"
+msgstr "Klarte ikke låse låsefilen «%s»"
+
+#: ../src/unix/snglinst.cpp:237
+#, c-format
+msgid "Failed to inspect the lock file '%s'"
+msgstr "Klarte ikke inspisere låsefilen «%s»"
+
+#: ../src/unix/snglinst.cpp:242
+#, c-format
+msgid "Lock file '%s' has incorrect owner."
+msgstr "Låsefil «%s» har feil eier."
+
+#: ../src/unix/snglinst.cpp:247
+#, c-format
+msgid "Lock file '%s' has incorrect permissions."
+msgstr "Låsefeil «%s» har feil rettigheter."
+
+#: ../src/unix/snglinst.cpp:265
+msgid "Failed to access lock file."
+msgstr "Klarte ikke få fatt i låsefil."
+
+#: ../src/unix/snglinst.cpp:274
+msgid "Failed to read PID from lock file."
+msgstr "Klarte ikke lses PID fra låsefil."
+
+#: ../src/unix/snglinst.cpp:284
+#, c-format
+msgid "Failed to remove stale lock file '%s'."
+msgstr "Klarte ikke slette forslitt låsefil «%s»."
+
+#: ../src/unix/snglinst.cpp:297
+#, c-format
+msgid "Deleted stale lock file '%s'."
+msgstr "Slettet forslitt låsefil «%s»."
+
+#: ../src/unix/snglinst.cpp:308
+#, c-format
+msgid "Invalid lock file '%s'."
+msgstr "Ugyldig låsefil «%s»."
+
+#: ../src/unix/snglinst.cpp:324
+#, c-format
+msgid "Failed to remove lock file '%s'"
+msgstr "Klarte ikke slette låsefil «%s»"
+
+#: ../src/unix/snglinst.cpp:330
+#, c-format
+msgid "Failed to unlock lock file '%s'"
+msgstr "Klarte ikke låse opp låsefilen «%s»"
+
+#: ../src/unix/snglinst.cpp:336
+#, c-format
+msgid "Failed to close lock file '%s'"
+msgstr "Klarte ikke lukke låsefil «%s»"
+
+#: ../src/unix/sound.cpp:77
+msgid "No sound"
+msgstr "Ingen lyd"
+
+#: ../src/unix/sound.cpp:364
+msgid "Unable to play sound asynchronously."
+msgstr "Klarte ikke spille lyd asynkront."
+
+#: ../src/unix/sound.cpp:458
+#, c-format
+msgid "Couldn't load sound data from '%s'."
+msgstr "Klarte ikke laste lyddata fra «%s»."
+
+#: ../src/unix/sound.cpp:465
+#, c-format
+msgid "Sound file '%s' is in unsupported format."
+msgstr "Formatet på lydfilen «%s» er ikke støttet."
+
+#: ../src/unix/sound.cpp:480
+msgid "Sound data are in unsupported format."
+msgstr "Format for lyddata er ikke støttet."
+
+#: ../src/unix/sound_sdl.cpp:226
+#, c-format
+msgid "Couldn't open audio: %s"
+msgstr "Klarte ikke åpne lyd: %s"
+
+#: ../src/unix/threadpsx.cpp:1033
+msgid "Cannot retrieve thread scheduling policy."
+msgstr "Klarte ikke hente trådplanleggingspolitikk."
+
+#: ../src/unix/threadpsx.cpp:1058
+#, c-format
+msgid "Cannot get priority range for scheduling policy %d."
+msgstr "Klarte ikke finne prioritetsområde for planleggingspolitikk %d."
+
+#: ../src/unix/threadpsx.cpp:1066
+msgid "Thread priority setting is ignored."
+msgstr "Trådprioritetinnstilling ignorert."
+
+#: ../src/unix/threadpsx.cpp:1221
+msgid ""
+"Failed to join a thread, potential memory leak detected - please restart the "
+"program"
+msgstr ""
+"Klarte ikke bli med en tråd, potensiell minnelekkasje oppdaget - start "
+"programmet på nytt"
+
+#: ../src/unix/threadpsx.cpp:1352
+#, fuzzy, c-format
+msgid "Failed to set thread concurrency level to %lu"
+msgstr "Klarte ikke sette trådprioritet %d"
+
+#: ../src/unix/threadpsx.cpp:1481
+#, c-format
+msgid "Failed to set thread priority %d."
+msgstr "Klarte ikke sette trådprioritet %d"
+
+#: ../src/unix/threadpsx.cpp:1666
+msgid "Failed to terminate a thread."
+msgstr "Klarte ikke avslutte en tråd."
+
+#: ../src/unix/threadpsx.cpp:1893
+msgid "Thread module initialization failed: failed to create thread key"
+msgstr "Initialisering av trådmodul feilet: klarte ikke opprette trådnøkkel"
+
+#: ../src/unix/utilsunx.cpp:340
+msgid "Impossible to get child process input"
+msgstr "Klarte ikke få tak i inndata for underprosess"
+
+#: ../src/unix/utilsunx.cpp:390
+#, fuzzy
+msgid "Can't write to child process's stdin"
+msgstr "Klarte ikke drepe prosess %d"
+
+#: ../src/unix/utilsunx.cpp:644
+#, c-format
+msgid "Failed to execute '%s'\n"
+msgstr "Klarte ikke utføre «%s»\n"
+
+#: ../src/unix/utilsunx.cpp:678
+msgid "Fork failed"
+msgstr "Forgrening feilet"
+
+#: ../src/unix/utilsunx.cpp:701
+#, fuzzy
+msgid "Failed to set process priority"
+msgstr "Klarte ikke sette trådprioritet %d"
+
+#: ../src/unix/utilsunx.cpp:712
+msgid "Failed to redirect child process input/output"
+msgstr "Klarte ikke videresende underprosessen inndata/utdata"
+
+#: ../src/unix/utilsunx.cpp:816
+msgid "Failed to set up non-blocking pipe, the program might hang."
+msgstr ""
+"Klarte ikke å sette opp ikke-blokkerende 'pipe', programmet kan bli hengende."
+
+#: ../src/unix/utilsunx.cpp:1023
+msgid "Cannot get the hostname"
+msgstr "Klarte ikke finne tjenernavn"
+
+#: ../src/unix/utilsunx.cpp:1059
+msgid "Cannot get the official hostname"
+msgstr "Klarte ikke finne det offisielle tjenernavnet"
+
+#: ../src/unix/wakeuppipe.cpp:49
+#, fuzzy
+msgid "Failed to create wake up pipe used by event loop."
+msgstr "Klarte ikke opprette statusbar."
+
+#: ../src/unix/wakeuppipe.cpp:56
+msgid "Failed to switch wake up pipe to non-blocking mode"
+msgstr ""
+
+#: ../src/unix/wakeuppipe.cpp:117
+#, fuzzy
+msgid "Failed to read from wake-up pipe"
+msgstr "Klarte ikke lses PID fra låsefil."
+
+#: ../src/x11/app.cpp:124
+#, c-format
+msgid "Invalid geometry specification '%s'"
+msgstr "Ugyldig geometrispesifikasjon «%s»."
+
+#: ../src/x11/app.cpp:167
+msgid "wxWidgets could not open display. Exiting."
+msgstr "wxWidgets klarte ikke åpne skjerm. Avslutter."
+
+#: ../src/x11/utils.cpp:169
+#, fuzzy, c-format
+msgid "Failed to close the display \"%s\""
+msgstr "Klarte ikke lukke utklippstavlen."
+
+#: ../src/x11/utils.cpp:188
+#, fuzzy, c-format
+msgid "Failed to open display \"%s\"."
+msgstr "Klarte ikke åpne «%s» for «%s»"
+
+#: ../src/xml/xml.cpp:868
+#, c-format
+msgid "XML parsing error: '%s' at line %d"
+msgstr "XML tolkefeil: «%s» på linje %d"
+
+#: ../src/xrc/xh_propgrid.cpp:239
+#, fuzzy, c-format
+msgid "Page %i"
+msgstr "Side %d"
+
+#: ../src/xrc/xmlres.cpp:448
+#, fuzzy, c-format
+msgid "Cannot load resources from '%s'."
+msgstr "Klarte ikke laste ressurs fra filen «%s»."
+
+#: ../src/xrc/xmlres.cpp:799
+#, fuzzy, c-format
+msgid "Cannot open resources file '%s'."
+msgstr "Klarte ikke laste ressurs fra filen «%s»."
+
+#: ../src/xrc/xmlres.cpp:806
+#, c-format
+msgid "Cannot load resources from file '%s'."
+msgstr "Klarte ikke laste ressurs fra filen «%s»."
+
+#: ../src/xrc/xmlres.cpp:2767
+#, fuzzy, c-format
+msgid "Creating %s \"%s\" failed."
+msgstr "Utpakking av «%s» inni «%s» feilet."
+
+#, fuzzy
+#~ msgctxt "keyboard key"
+#~ msgid "RawCtrl+"
+#~ msgstr "ctrl"
+
+#~ msgid "Unsupported clipboard format."
+#~ msgstr "Ikke-støttet utklippstavleformat."
+
+#~ msgid "Background colour"
+#~ msgstr "Bakgrunnsfarge"
+
+#, fuzzy
+#~ msgid "Font:"
+#~ msgstr "Skriftstørrelse:"
+
+#, fuzzy
+#~ msgid "Size:"
+#~ msgstr "Størrelse"
+
+#, fuzzy
+#~ msgid "The font size in points."
+#~ msgstr "Skriftpunktstørrelse"
+
+#, fuzzy
+#~ msgid "Style:"
+#~ msgstr "&Stil:"
+
+#~ msgid "Check to make the font bold."
+#~ msgstr "Klikk for lage fet skrift."
+
+#~ msgid "Check to make the font italic."
+#~ msgstr "Klikk for å lage kursiv skrift."
+
+#, fuzzy
+#~ msgid "Check to make the font underlined."
+#~ msgstr "Om skriften er understreket."
+
+#, fuzzy
+#~ msgid "Colour:"
+#~ msgstr "&Farge"
+
+#~ msgid "Click to change the font colour."
+#~ msgstr "Klikk for å endre farge på skrift."
+
+#~ msgid "Shows a preview of the font."
+#~ msgstr "Forhåndsvisning av skrifttypen."
+
+#~ msgid "Click to cancel changes to the font."
+#~ msgstr "Klikk for å avbryte endringer på fonten."
+
+#, fuzzy
+#~ msgid "Click to confirm changes to the font."
+#~ msgstr "Klikk for å bekrefte skriftvalg"
+
+#, fuzzy
+#~ msgid "<Any Roman>"
+#~ msgstr "Roman"
+
+#, fuzzy
+#~ msgid "<Any Decorative>"
+#~ msgstr "Dekorativ"
+
+#, fuzzy
+#~ msgid "<Any Modern>"
+#~ msgstr "Moderne"
+
+#, fuzzy
+#~ msgid "<Any Script>"
+#~ msgstr "Skript"
+
+#, fuzzy
+#~ msgid "<Any Swiss>"
+#~ msgstr "Swiss"
+
+#, fuzzy
+#~ msgid "<Any Teletype>"
+#~ msgstr "Teletype"
+
+#~ msgid "Printing "
+#~ msgstr "Skriver ut"
+
+#, fuzzy
+#~ msgid "Failed to insert text in the control."
+#~ msgstr "Klarte ikke finne gjeldende mappe"
+
+#~ msgid "Please choose a valid font."
+#~ msgstr "Velg en gyldig skrift."
+
+#, c-format
+#~ msgid "Failed to display HTML document in %s encoding"
+#~ msgstr "Klarte ikke vise HTML-dokument med %s koding"
+
+#, c-format
+#~ msgid "wxWidgets could not open display for '%s': exiting."
+#~ msgstr "wxWidgets klarte ikke åpne skjerm for '%s': avslutter."
+
+#~ msgid "Filter"
+#~ msgstr "Filter"
+
+#~ msgid "Directories"
+#~ msgstr "Mapper"
+
+#~ msgid "Files"
+#~ msgstr "Filer"
+
+#~ msgid "Selection"
+#~ msgstr "Valg"
+
+#~ msgid "conversion to 8-bit encoding failed"
+#~ msgstr "konvertering til 8-bit koding feilet"
+
+#, fuzzy
+#~ msgid "failed to retrieve execution result"
+#~ msgstr "Klarte ikke hente tekst fra RAS feilmelding"
+
+#, fuzzy
+#~ msgid "&Save as"
+#~ msgstr "Lagre Som"
+
+#, fuzzy
+#~ msgid "'%s' doesn't consist only of valid characters"
+#~ msgstr "«%s» må kun inneholde bokstaver."
+
+#~ msgid "'%s' should be numeric."
+#~ msgstr "«%s» skal være numerisk."
+
+#~ msgid "'%s' should only contain ASCII characters."
+#~ msgstr "«%s» må kun inneholde ASCII-tegn."
+
+#~ msgid "'%s' should only contain alphabetic characters."
+#~ msgstr "«%s» må kun inneholde bokstaver."
+
+#~ msgid "'%s' should only contain alphabetic or numeric characters."
+#~ msgstr "«%s» må kun inneholde bokstaver eller tall."
+
+#, fuzzy
+#~ msgid "'%s' should only contain digits."
+#~ msgstr "«%s» må kun inneholde ASCII-tegn."
+
+#~ msgid "Can't create window of class %s"
+#~ msgstr "Klarte ikke opprette vindu av klasse %s"
+
+#, fuzzy
+#~ msgid "Couldn't create the overlay window"
+#~ msgstr "Klarte ikke opprette en timer"
+
+#, fuzzy
+#~ msgid "Couldn't init the context on the overlay window"
+#~ msgstr "Klarte ikke finne gjeldende trådpeker"
+
+#, fuzzy
+#~ msgid "Failed to convert file \"%s\" to Unicode."
+#~ msgstr "Klarte ikke lukke filreferanse"
+
+#, fuzzy
+#~ msgid "Failed to set text in the text control."
+#~ msgstr "Klarte ikke finne gjeldende mappe"
+
+#~ msgid "No unused colour in image."
+#~ msgstr "Ingen ubrukte farger i bildet."
+
+#, fuzzy
+#~ msgid "Not available"
+#~ msgstr "Ingen XBM-fasilitet tilgjengelig!"
+
+#, fuzzy
+#~ msgid "Replace selection"
+#~ msgstr "Erstatt &alle"
+
+#, fuzzy
+#~ msgid "Save as"
+#~ msgstr "Lagre Som"
+
+#~ msgid "Style Organiser"
+#~ msgstr "Stilorganiserer"
+
+#~ msgid "locale '%s' cannot be set."
+#~ msgstr "klarte ikke sette lokale «%s»."
+
+#~ msgid ""
+#~ "Cannot create new column's ID. Probably max. number of columns reached."
+#~ msgstr ""
+#~ "Kan ikke opprette nye kolonne-IDer. Sannsynligvis nådd maks. antall "
+#~ "kolonner."
+
+#, fuzzy
+#~ msgid "Column could not be added."
+#~ msgstr "Klarte ikke laste filen."
+
+#, fuzzy
+#~ msgid "Column index not found."
+#~ msgstr "katalogfil for domene «%s» ikke funnet."
+
+#~ msgid "Column width could not be determined"
+#~ msgstr "Kolonnebredden kunne ikke fastsettes."
+
+#~ msgid "Column width could not be set."
+#~ msgstr "Kolonnebredden kunne ikke settes."
+
+#~ msgid "Confirm registry update"
+#~ msgstr "Bekretft registeroppdatering"
+
+#~ msgid "Could not determine column index."
+#~ msgstr "Klarte ikke å fastsette kolonneindeks."
+
+#~ msgid "Could not determine column's position"
+#~ msgstr "Kunne ikke fastsette posisjonen til kolonnen"
+
+#~ msgid "Could not determine number of columns."
+#~ msgstr "Klarte ikke fastsette antall kolonner."
+
+#~ msgid "Could not determine number of items"
+#~ msgstr "Klarte ikke fastsette antall innslag."
+
+#~ msgid "Could not get header description."
+#~ msgstr "Klarte ikke å hente hodebeskrivelse."
+
+#~ msgid "Could not get items."
+#~ msgstr "Klarte ikke å hente innslag."
+
+#~ msgid "Could not get property flags."
+#~ msgstr "Klarte ikke å hente egenskapsflagg."
+
+#~ msgid "Could not get selected items."
+#~ msgstr "Klarte ikke å hente valgte innslag."
+
+#~ msgid "Could not remove column."
+#~ msgstr "Klarte ikke å fjerne kolonne."
+
+#~ msgid "Could not retrieve number of items"
+#~ msgstr "Klarte ikke å hente antall innslag"
+
+#~ msgid "Could not set column width."
+#~ msgstr "Klarte ikke å sette kolonnebredden."
+
+#~ msgid "Could not set header description."
+#~ msgstr "Klarte ikke å sette hodebeskrivelsen."
+
+#~ msgid "Could not set icon."
+#~ msgstr "Klarte ikke å sette ikon."
+
+#~ msgid "Could not set maximum width."
+#~ msgstr "Klarte ikke å sette maksbredden."
+
+#~ msgid "Could not set minimum width."
+#~ msgstr "Klarte ikke å sette minimumsbredden."
+
+#~ msgid "Could not set property flags."
+#~ msgstr "Klarte ikke å sette egenskapsflagg."
+
+#~ msgid ""
+#~ "Do you want to overwrite the command used to %s files with extension "
+#~ "\"%s\" ?\n"
+#~ "Current value is \n"
+#~ "%s, \n"
+#~ "New value is \n"
+#~ "%s %1"
+#~ msgstr ""
+#~ "Vil du overskrive kommandoen brukt for å %s filer av type «%s»?\n"
+#~ "Gjeldende verdi er \n"
+#~ "%s, \n"
+#~ "Ny verdi er \n"
+#~ "%s %1"
+
+#~ msgid "Failed to retrieve data from the clipboard."
+#~ msgstr "Klarte ikke hente data fra utklippstavlen."
+
+#~ msgid "GIF: Invalid gif index."
+#~ msgstr "GIF: Ugyldig GIF-indeks"
+
+#~ msgid "GIF: unknown error!!!"
+#~ msgstr "GIF: Ukjent feil!"
+
+#~ msgid "New directory"
+#~ msgstr "Ny mappe"
+
+#~ msgid "Next"
+#~ msgstr "Neste"
+
+#~ msgid "Number of columns could not be determined."
+#~ msgstr "Antall kolonner kunne ikke fastslås."
+
+#~ msgid ""
+#~ "Please install a newer version of comctl32.dll\n"
+#~ "(at least version 4.70 is required but you have %d.%02d)\n"
+#~ "or this program won't operate correctly."
+#~ msgstr ""
+#~ "Installer en nyere versjon av comctl32.dll\n"
+#~ "(minst versjon 4.70 er påkrevd, men du har %d.%02d)\n"
+#~ "eller så kommer ikke dette programmet til å virke."
+
+#, fuzzy
+#~ msgid "Rendering failed."
+#~ msgstr "Tidtager opprettelese feilet."
+
+#~ msgid "Show hidden directories"
+#~ msgstr "Vis skjulte mapper"
+
+#, fuzzy
+#~ msgid ""
+#~ "This system doesn't support date controls, please upgrade your version of "
+#~ "comctl32.dll"
+#~ msgstr ""
+#~ "Dette systemet støtter ikke datavalgkontrollen. Oppgrader din versjon av "
+#~ "comctl32.dll."
+
+#~ msgid "Too many colours in PNG, the image may be slightly blurred."
+#~ msgstr "For mange farger i PNG, bildet kan være litt uskarpt."
+
+#, fuzzy
+#~ msgid "Unable to initialize Hildon program"
+#~ msgstr "Klarte ikke initialisere OpenGL"
+
+#, fuzzy
+#~ msgid "Unknown data format"
+#~ msgstr "feil i dataformat"
+
+#~ msgid "Win32s on Windows 3.1"
+#~ msgstr "Win32 på Windows 3.1"
+
+#~ msgid "Windows 95"
+#~ msgstr "Windows 95"
+
+#~ msgid "Windows 95 OSR2"
+#~ msgstr "Windows 95 OSR2"
+
+#~ msgid "Windows 98"
+#~ msgstr "Windows 98"
+
+#~ msgid "Windows 98 SE"
+#~ msgstr "Windows 98 SE"
+
+#~ msgid "Windows 9x (%d.%d)"
+#~ msgstr "Windows 9x (%d.%d)"
+
+#, fuzzy
+#~ msgid "Windows NT %lu.%lu"
+#~ msgstr "Windows NT %lu.%lu (build %lu"
+
+#, fuzzy
+#~ msgid "Windows Server 2003"
+#~ msgstr "Windows Server 2003 (build %lu"
+
+#, fuzzy
+#~ msgid "can't execute '%s'"
+#~ msgstr "Klarte ikke utføre «%s»\n"
+
+#, fuzzy
+#~ msgid "error opening '%s'"
+#~ msgstr "feil ved åpning av fil"
+
+#~ msgid "unknown seek origin"
+#~ msgstr "ukjent søkestartpunkt"
+
+#, fuzzy
+#~ msgid "wxWidget's control not initialized."
+#~ msgstr "Klarte ikke initialisere skjerm."
+
+#~ msgid "Cannot create mutex."
+#~ msgstr "Klarte ikke opprette mutex."
+
+#~ msgid "Cannot resume thread %lu"
+#~ msgstr "Klarte ikke gjenoppta tråden %lu"
+
+#~ msgid "Cannot suspend thread %lu"
+#~ msgstr "Klarte ikke innstille tråden %lu"
+
+#~ msgid "Couldn't acquire a mutex lock"
+#~ msgstr "Klarte ikke sette mutex-lås"
+
+#~ msgid "Couldn't release a mutex"
+#~ msgstr "Klarte ikke slippe løs en mutex"
+
+#, fuzzy
+#~ msgid "DIVIDE"
+#~ msgstr "<LAGERENHET>"
+
+#~ msgid "Execution of command '%s' failed with error: %ul"
+#~ msgstr "Utførelse av kommandoen «%s» feilet med feil: %ul"
+
+#~ msgid ""
+#~ "File '%s' already exists.\n"
+#~ "Do you want to replace it?"
+#~ msgstr "Filen «%s» eksisterer allerede. Vil du virkelig bytte den ut?"
+
+#~ msgid "Timer creation failed."
+#~ msgstr "Tidtager opprettelese feilet."
+
+#~ msgid "Print preview"
+#~ msgstr "&Forhåndsvisning av utskrift"
+
+#, fuzzy
+#~ msgid "&Preview..."
+#~ msgstr "Forhåndsvisning"
+
+#, fuzzy
+#~ msgid "Preview..."
+#~ msgstr "Forhåndsvisning"
+
+#~ msgid "&Save..."
+#~ msgstr "&Lagre..."
+
+#, fuzzy
+#~ msgid "About "
+#~ msgstr "%Om"
+
+#~ msgid "All files (*.*)|*"
+#~ msgstr "Alle filer (*.*)|*"
+
+#~ msgid "Cannot initialize SciTech MGL!"
+#~ msgstr "Klarte ikke initialisere SciTech MGL!"
+
+#~ msgid "Cannot initialize display."
+#~ msgstr "Klarte ikke initialisere skjerm."
+
+#~ msgid "Cannot start thread: error writing TLS"
+#~ msgstr "Klarte ikke starte tråd: feil ved skriving til TLS"
+
+#~ msgid "Close\tAlt-F4"
+#~ msgstr "Lukk\tAlt-F4"
+
+#~ msgid "Couldn't create cursor."
+#~ msgstr "Klarte ikke opprette peker."
+
+#~ msgid "Directory '%s' doesn't exist!"
+#~ msgstr "Mappen «%s» eksisterer ikke!"
+
+#~ msgid "Mode %ix%i-%i not available."
+#~ msgstr "Modus %ix%i-%i ikke tilgjengelig."
+
+#~ msgid "Paper Size"
+#~ msgstr "Papirstørrelse"
+
+#~ msgid "&Goto..."
+#~ msgstr "&Gå til"
+
+#~ msgid "<<"
+#~ msgstr "<<"
+
+#~ msgid ">>"
+#~ msgstr ">>"
+
+#~ msgid ">>|"
+#~ msgstr ">>|"
+
+#~ msgid "Archive doesnt contain #SYSTEM file"
+#~ msgstr "Arkivet ineholder ikke #SYSTEM fil"
+
+#~ msgid "Can't check image format of file '%s': file does not exist."
+#~ msgstr ""
+#~ "Klarte ikke sjekke bildeformat for filen «%s»: filen eksisterer ikke."
+
+#~ msgid "Can't load image from file '%s': file does not exist."
+#~ msgstr "Klarte ikke lese bilde fra filen «%s»: filen eksisterer ikke."
+
+#~ msgid "Cannot convert dialog units: dialog unknown."
+#~ msgstr "Klarte ikke konvertere dialogenheter: ukjent dialog."
+
+#~ msgid "Cannot convert from the charset '%s'!"
+#~ msgstr "Klarte ikke convertere fra tegnsettet «%s»!"
+
+#~ msgid "Cannot find container for unknown control '%s'."
+#~ msgstr "Klarte ikke finne beholder for ukjent kontroll «%s»."
+
+#~ msgid "Cannot find font node '%s'."
+#~ msgstr "Klarte ikke finne fontnode «%s»."
+
+#~ msgid "Cannot open file '%s'."
+#~ msgstr "Klarte ikke åpne filen «%s»."
+
+#~ msgid "Cannot parse coordinates from '%s'."
+#~ msgstr "Klarte ikke tolke koordinater fra «%s»."
+
+#~ msgid "Cannot parse dimension from '%s'."
+#~ msgstr "Klarte ikke tolke dimensjoner fra «%s»."
+
+#~ msgid "Cant create the thread event queue"
+#~ msgstr "Klarte ikke opprette køen for trådhendelser"
+
+#, fuzzy
+#~ msgid "Click to cancel this window."
+#~ msgstr "Lukk dette vinduet"
+
+#, fuzzy
+#~ msgid "Click to confirm your selection."
+#~ msgstr "Klikk for å bekrefte skriftvalg"
+
+#~ msgid "Could not unlock mutex"
+#~ msgstr "Klarte ikke åpne mutex"
+
+#~ msgid "Error while waiting on semaphore"
+#~ msgstr "Feil under venting på semafor"
+
+#~ msgid "Failed to create a status bar."
+#~ msgstr "Klarte ikke opprette statusbar."
+
+#~ msgid "Failed to register OpenGL window class."
+#~ msgstr "Klarte ikke registrere OpenGL vindusklasse."
+
+#~ msgid "Fatal error: "
+#~ msgstr "Kritisk feil:"
+
+#~ msgid "Goto Page"
+#~ msgstr "Gå til side"
+
+#, fuzzy
+#~ msgid "Help : %s"
+#~ msgstr "Hjelp: %s"
+
+#~ msgid "I64"
+#~ msgstr "I64"
+
+#~ msgid "Internal error, illegal wxCustomTypeInfo"
+#~ msgstr "Intern feil, ugyldig wxCustomTypeInfo"
+
+#~ msgid "Invalid XRC resource '%s': doesn't have root node 'resource'."
+#~ msgstr "Ugyldig XRC-ressurs «%s»: har ikke rotnode «resource»."
+
+#~ msgid "No handler found for XML node '%s', class '%s'!"
+#~ msgstr "Ingen behandler funnet for XML-node «%s», klasse «%s»!"
+
+#, fuzzy
+#~ msgid "No image handler for type %ld defined."
+#~ msgstr "Ingen bildebehandler for type %d definert."
+
+#, fuzzy
+#~ msgid "Owner not initialized."
+#~ msgstr "Klarte ikke initialisere skjerm."
+
+#, fuzzy
+#~ msgid "Passed item is invalid."
+#~ msgstr "«%s» er ugyldig"
+
+#~ msgid "Passing a already registered object to SetObjectName"
+#~ msgstr "Allerede registrert objekt sendt til SetObjectName"
+
+#~ msgid "Program aborted."
+#~ msgstr "Program avbrutt."
+
+#~ msgid "Referenced object node with ref=\"%s\" not found!"
+#~ msgstr "Referert objektnode med ref=\"%s\" ikke funnet!"
+
+#~ msgid "Resource files must have same version number!"
+#~ msgstr "Ressursfiler må ha samme versjonsnummer!"
+
+#, fuzzy
+#~ msgid "Search!"
+#~ msgstr "Søk"
+
+#~ msgid "Sorry, could not open this file for saving."
+#~ msgstr "Klarte ikke åpne denne filen for lagring."
+
+#~ msgid "Sorry, could not save this file."
+#~ msgstr "Klarte ikke lagre denne filen."
+
+#~ msgid "Sorry, print preview needs a printer to be installed."
+#~ msgstr "Forhåndsvisning av utskrift krever at en skriver er installert."
+
+#~ msgid "Status: "
+#~ msgstr "Status: "
+
+#~ msgid ""
+#~ "Streaming delegates for not already streamed objects not yet supported"
+#~ msgstr ""
+#~ "Dataflyt-delegater for ikke allerede flytende objekter er ikke støttet"
+
+#~ msgid "Subclass '%s' not found for resource '%s', not subclassing!"
+#~ msgstr "Underklasse «%s» ikke funnet i ressurs «%s», ikke subclassing!"
+
+#~ msgid ""
+#~ "The file '%s' couldn't be opened.\n"
+#~ "It has been removed from the most recently used files list."
+#~ msgstr ""
+#~ "Klarte ikke åpne filen «%s».\n"
+#~ "Den er fjernet fra listen over nylig brukte filer."
+
+#~ msgid "The path '%s' contains too many \"..\"!"
+#~ msgstr "Stien «%s» inneholder for mange \"..\"!"
+
+#~ msgid "Trying to solve a NULL hostname: giving up"
+#~ msgstr "Prøver å løse NULL tjenernavn: gir opp"
+
+#~ msgid "Unknown style flag "
+#~ msgstr "Ukjent stilflagg"
+
+#~ msgid "Warning"
+#~ msgstr "Advarsel"
+
+#~ msgid "Windows 2000 (build %lu"
+#~ msgstr "Windows 2000 (build %lu"
+
+#~ msgid "XRC resource '%s' (class '%s') not found!"
+#~ msgstr "XRC-ressurs «%s» (klasse «%s») ikke funnet!"
+
+#, fuzzy
+#~ msgid "XRC resource: Cannot create animation from '%s'."
+#~ msgstr "XRC-ressurs: Klarte opprette bitmap fra «%s»."
+
+#~ msgid "XRC resource: Cannot create bitmap from '%s'."
+#~ msgstr "XRC-ressurs: Klarte opprette bitmap fra «%s»."
+
+#, fuzzy
+#~ msgid ""
+#~ "XRC resource: Incorrect colour specification '%s' for attribute '%s'."
+#~ msgstr "XRC-ressurs: Ugyldig fargespesifikasjon «%s» for egenskap «%s»."
+
+#~ msgid "[EMPTY]"
+#~ msgstr "[TOM]"
+
+#~ msgid "catalog file for domain '%s' not found."
+#~ msgstr "katalogfil for domene «%s» ikke funnet."
+
+#~ msgid "delegate has no type info"
+#~ msgstr "delegat har ingen typeinformasjon"
+
+#, fuzzy
+#~ msgid "encoding %i"
+#~ msgstr "koding %s"
+
+#~ msgid "looking for catalog '%s' in path '%s'."
+#~ msgstr "leter etter katalog «%s» i stien «%s»."
+
+#~ msgid "wxSocket: invalid signature in ReadMsg."
+#~ msgstr "wxSocket: ugyldig signatur i ReadMsg."
+
+#~ msgid "wxSocket: unknown event!."
+#~ msgstr "wxSocket: ukjent hendelset!."
+
+#~ msgid "|<<"
+#~ msgstr "|<<"
+
+#, fuzzy
+#~ msgid " Couldn't create the UnicodeConverter"
+#~ msgstr "Klarte ikke opprette en timer"
+
+#~ msgid "#define %s must be an integer."
+#~ msgstr "#define %s må være et heltall."
+
+#~ msgid "%s not a bitmap resource specification."
+#~ msgstr "%s er ikke en bitmap ressursspesifikasjon"
+
+#~ msgid "%s not an icon resource specification."
+#~ msgstr "%s er ikke en ikon ressursspesfikasjon"
+
+#~ msgid "%s: ill-formed resource file syntax."
+#~ msgstr "%s: feil syntaks i ressursfilen"
+
+#~ msgid "&Open"
+#~ msgstr "&Åpne"
+
+#~ msgid "&Print"
+#~ msgstr "&Skriv ut"
+
+#~ msgid "*** It can be found in \"%s\"\n"
+#~ msgstr "*** Den kan bli funnet i «%s»\n"
+
+#~ msgid ""
+#~ ", expected static, #include or #define\n"
+#~ "while parsing resource."
+#~ msgstr ""
+#~ ", forventet static, #include eller #define\n"
+#~ "under tolking av ressurs."
+
+#~ msgid "Bitmap resource specification %s not found."
+#~ msgstr "Bitmap ressursspesifikasjon %s ikke funnet."
+
+#~ msgid ""
+#~ "Could not resolve control class or id '%s'. Use (non-zero) integer "
+#~ "instead\n"
+#~ " or provide #define (see manual for caveats)"
+#~ msgstr ""
+#~ "Klarte ikke finne kontrollklasse eller ID «%s». Bruk (ikke-null) heltall "
+#~ "istedenfor\n"
+#~ "eller oppgi #define (se manual for advarsler)"
+
+#~ msgid ""
+#~ "Could not resolve menu id '%s'. Use (non-zero) integer instead\n"
+#~ "or provide #define (see manual for caveats)"
+#~ msgstr ""
+#~ "Klarte ikke finne meny-ID «%s». Bruk (ikke-null) heltall istedenfor\n"
+#~ "eller oppgi #define (se manual for advarsler)"
+
+#, fuzzy
+#~ msgid "Couldn't end the context on the overlay window"
+#~ msgstr "Klarte ikke finne gjeldende trådpeker"
+
+#~ msgid "Expected '*' while parsing resource."
+#~ msgstr "Forventet «*» under tolking av ressurs."
+
+#~ msgid "Expected '=' while parsing resource."
+#~ msgstr "Forventet «=» under tolking av ressurs."
+
+#~ msgid "Expected 'char' while parsing resource."
+#~ msgstr "Forventet «tegn» under tolking av ressurs."
+
+#~ msgid ""
+#~ "Failed to find XBM resource %s.\n"
+#~ "Forgot to use wxResourceLoadBitmapData?"
+#~ msgstr ""
+#~ "Klarte ikke finne XBM-ressurs %s.\n"
+#~ "Glemt å bruke wxResourceLoadBitmapData?"
+
+#~ msgid ""
+#~ "Failed to find XBM resource %s.\n"
+#~ "Forgot to use wxResourceLoadIconData?"
+#~ msgstr ""
+#~ "Klarte ikke finne XBM-ressurs %s.\n"
+#~ "Glemt å bruke wxResourceLoadIconData?"
+
+#~ msgid ""
+#~ "Failed to find XPM resource %s.\n"
+#~ "Forgot to use wxResourceLoadBitmapData?"
+#~ msgstr ""
+#~ "Klarte ikke finne XPM-ressurs %s.\n"
+#~ "Glemt å bruke wxResourceLoadBitmapData?"
+
+#~ msgid "Failed to get clipboard data."
+#~ msgstr "Klarte ikke hente data fra utklippstavlen."
+
+#~ msgid "Failed to load shared library '%s' Error '%s'"
+#~ msgstr "Klarte ikke laste delt bibliotek «%s» - feil «%s»"
+
+#~ msgid "Found "
+#~ msgstr "Fant"
+
+#~ msgid "Icon resource specification %s not found."
+#~ msgstr "Ikon ressursspesifikasjon %s ikke funnet."
+
+#~ msgid "Ill-formed resource file syntax."
+#~ msgstr "Ugyldig syntaks i ressursfil."
+
+#~ msgid "Long Conversions not supported"
+#~ msgstr "Long Conversions er ikke støttet"
+
+#~ msgid "No XPM icon facility available!"
+#~ msgstr "Ingen fasilitet for XPM-ikon tilgjengelig!"
+
+#~ msgid "Option '%s' requires a value, '=' expected."
+#~ msgstr "Opsjon «%s» må ha en verdi, «=» forventet."
+
+#, fuzzy
+#~ msgid "Select all"
+#~ msgstr "Velg &alle"
+
+#~ msgid "Unexpected end of file while parsing resource."
+#~ msgstr "Uventet slutt på filen under tolking av ressurs."
+
+#~ msgid "Unrecognized style %s while parsing resource."
+#~ msgstr "Ikke-gjenkjent stil %s under tolking av ressurs."
+
+#~ msgid "Video Output"
+#~ msgstr "Video utdata"
+
+#~ msgid "Warning: attempt to remove HTML tag handler from empty stack."
+#~ msgstr "Advarsel: Forsøk på å fjerne HTML-tagg fra en tom stabel."
+
+#~ msgid "establish"
+#~ msgstr "opprette"
+
+#~ msgid "initiate"
+#~ msgstr "klargjør"
+
+#~ msgid "invalid eof() return value."
+#~ msgstr "ugyldig eof() returverdi."
+
+#~ msgid "unknown line terminator"
+#~ msgstr "ukjent linjeavslutter"
+
+#~ msgid "writing"
+#~ msgstr "skriver"
+
+#~ msgid "."
+#~ msgstr "."
+
+#~ msgid "Cannot open URL '%s'"
+#~ msgstr "Klarte ikke åpne URL «%s»"
+
+#~ msgid "Error "
+#~ msgstr "Feil"
+
+#~ msgid "Failed to create directory %s/.gnome."
+#~ msgstr "Klarte ikke opprette mappe %s/.gnome."
+
+#~ msgid "Failed to create directory %s/mime-info."
+#~ msgstr "Klarte ikke oprette mappe %s/mime-info."
+
+#~ msgid "MP Thread Support is not available on this System"
+#~ msgstr "MP trådstøtte er ikke tilgjengelig på dette systemet"
+
+#~ msgid "Mailcap file %s, line %d: incomplete entry ignored."
+#~ msgstr "Mailcap-fil %s, linje %d: ufullstendig oppføring ignorert."
+
+#~ msgid "Mime.types file %s, line %d: unterminated quoted string."
+#~ msgstr "Mime.types-fil %s, linje %d: uavsluttet sitatstreng"
+
+#~ msgid "Unknown field in file %s, line %d: '%s'."
+#~ msgstr "Ukjent felt i filen %s, linje %d: «%s»."
+
+#~ msgid "bold "
+#~ msgstr "fet"
+
+#~ msgid "can't query for GUI plugins name in console applications"
+#~ msgstr "kan ikke spørre etter navn på GUI-programtillegg i konsollprogram"
+
+#~ msgid "light "
+#~ msgstr "lett"
+
+#~ msgid "underlined "
+#~ msgstr "understreket"
+
+#~ msgid "unsupported zip archive"
+#~ msgstr "ikke-støttet zip-arkiv"
+
+#~ msgid ""
+#~ "Failed to get stack backtrace:\n"
+#~ "%s"
+#~ msgstr "Klarte ikke få tak stabeltilbakesporing: %s"
+
+#~ msgid "Loading Grey Ascii PNM image is not yet implemented."
+#~ msgstr "Lesing av Grey Ascii PNM bilde er ikke implementert enda."
+
+#~ msgid "Loading Grey Raw PNM image is not yet implemented."
+#~ msgstr "Lesing av Grey Raw PNM bilde er ikke implementert enda."
+
+#~ msgid "Cannot wait on thread to exit."
+#~ msgstr "Klarte ikke vent på fullføring av tråden"
+
+#~ msgid "Could not load Rich Edit DLL '%s'"
+#~ msgstr "Klarte ikke laste Rich Edit DLL «%s»"
+
+#~ msgid "ZIP handler currently supports only local files!"
+#~ msgstr "ZIP-behandler støtter for øyeblikket kun lokale filer!"
+
+#~ msgid ""
+#~ "can't seek on file descriptor %d, large files support is not enabled."
+#~ msgstr ""
+#~ "klarte ikke søke på fildeskriptor %d, støtte for store filer er ikke "
+#~ "aktivert."
+
+#~ msgid "More..."
+#~ msgstr "Mer..."
+
+#~ msgid "Setup"
+#~ msgstr "Sett opp"

--- a/po_wxstd/ne.po
+++ b/po_wxstd/ne.po
@@ -1,0 +1,9821 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: wxWidgets 3.3\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-05-14 20:23+0200\n"
+"PO-Revision-Date: 2015-05-09 20:03+0545\n"
+"Last-Translator: drishtibachak@gmail.com\n"
+"Language-Team: Him Prasad Gautam <himjee@yahoo.com>\n"
+"Language: ne\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Country: Nepal\n"
+"plural-forms: nplurals=2; plural=n > 1\n"
+"X-Generator: Poedit 1.7.5\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: ../include/wx/defs.h:2582
+msgid "All files (*.*)|*.*"
+msgstr "सबै फाइलहरू(*.*)|*.*"
+
+#: ../include/wx/defs.h:2585
+msgid "All files (*)|*"
+msgstr "सबै फाइलहरू(*)|*"
+
+#: ../include/wx/generic/progdlgg.h:85
+msgid "Elapsed time:"
+msgstr "गुज्रिएको समय:"
+
+#: ../include/wx/generic/progdlgg.h:86
+msgid "Estimated time:"
+msgstr "अनुमानित समय:"
+
+#: ../include/wx/generic/progdlgg.h:87
+msgid "Remaining time:"
+msgstr "बांकि समय:"
+
+#. TRANSLATORS: HTML printout default title.
+#: ../include/wx/html/htmprint.h:121 ../include/wx/prntbase.h:273
+#: ../include/wx/richtext/richtextprint.h:109 ../src/common/docview.cpp:2161
+msgid "Printout"
+msgstr "छापिएका पानाहरू"
+
+#. TRANSLATORS: HTML easy print default title.
+#: ../include/wx/html/htmprint.h:234 ../include/wx/richtext/richtextprint.h:163
+#: ../src/common/prntbase.cpp:522 ../src/html/htmprint.cpp:291
+msgid "Printing"
+msgstr "छाप्ने काम हुँदैछ ।"
+
+#: ../include/wx/msgdlg.h:277 ../src/common/stockitem.cpp:211
+msgid "Yes"
+msgstr "हो"
+
+#: ../include/wx/msgdlg.h:278 ../src/common/stockitem.cpp:182
+msgid "No"
+msgstr "होइन"
+
+#: ../include/wx/msgdlg.h:279 ../src/common/stockitem.cpp:183
+#: ../src/msw/msgdlg.cpp:430 ../src/msw/msgdlg.cpp:734
+#: ../src/richtext/richtextstyledlg.cpp:292
+msgid "OK"
+msgstr "ठीक"
+
+#: ../include/wx/msgdlg.h:280 ../src/common/stockitem.cpp:150
+#: ../src/msw/msgdlg.cpp:430 ../src/msw/progdlg.cpp:884
+#: ../src/richtext/richtextstyledlg.cpp:295
+msgid "Cancel"
+msgstr "रद्द गर"
+
+#: ../include/wx/msgdlg.h:281 ../src/common/stockitem.cpp:168
+#: ../src/html/helpdlg.cpp:63 ../src/html/helpfrm.cpp:108
+#: ../src/osx/button_osx.cpp:38
+msgid "Help"
+msgstr "सहयोग"
+
+#: ../include/wx/msw/ole/oleutils.h:52
+msgid "Cannot initialize OLE"
+msgstr "OLE लाइ सुरु गर्न सकिँदैन ।"
+
+#: ../include/wx/msw/private/fswatcher.h:48
+#, c-format
+msgid "Unable to close the handle for '%s'"
+msgstr "हातो '%s' लाई बन्द गर्न सकिएन ।"
+
+#: ../include/wx/msw/private/fswatcher.h:92
+#, c-format
+msgid "Failed to open directory \"%s\" for monitoring."
+msgstr "अनुगमनका लागि घर्रा \"%s\" खोल्न सकिएन ।"
+
+#: ../include/wx/msw/private/fswatcher.h:125
+msgid "Unable to close I/O completion port handle"
+msgstr "I/O completion port हातोलाई बन्द गर्न सकिएन ।"
+
+#: ../include/wx/msw/private/fswatcher.h:142
+msgid "Unable to associate handle with I/O completion port"
+msgstr "हातोलाई I/O completion port सित समाविष्ट गर्न सकिएन ।"
+
+#: ../include/wx/msw/private/fswatcher.h:148
+msgid "Unexpectedly new I/O completion port was created"
+msgstr "अचानक नया I/O completion port को सिर्जना भयो"
+
+#: ../include/wx/msw/private/fswatcher.h:213
+msgid "Unable to post completion status"
+msgstr "समाप्तिको स्थिति पठाउन सकिएन ।"
+
+#: ../include/wx/msw/private/fswatcher.h:262
+msgid "Unable to dequeue completion packet"
+msgstr "completion packet लाई छरपस्ट गर्न सकिएन ।"
+
+#: ../include/wx/msw/private/fswatcher.h:273
+msgid "Unable to create I/O completion port"
+msgstr "I/O completion port लाई सिर्जना गर्न सकिएन ।"
+
+#: ../include/wx/richmsgdlg.h:29
+msgid "&See details"
+msgstr "&विस्तृत अवलोकन"
+
+#: ../include/wx/richmsgdlg.h:30
+msgid "&Hide details"
+msgstr "विस्तृत &लुकाउ "
+
+#: ../include/wx/richtext/richtextbuffer.h:3864
+msgid "&Box"
+msgstr "&बाकस"
+
+#: ../include/wx/richtext/richtextbuffer.h:5008
+msgid "&Picture"
+msgstr "&चीत्र"
+
+#: ../include/wx/richtext/richtextbuffer.h:5958
+msgid "&Cell"
+msgstr "&कोशिका"
+
+#: ../include/wx/richtext/richtextbuffer.h:6067
+msgid "&Table"
+msgstr "&तालिका"
+
+#: ../include/wx/richtext/richtextimagedlg.h:37
+msgid "Object Properties"
+msgstr "वस्तु गुणहरू"
+
+#: ../include/wx/richtext/richtextsymboldlg.h:39
+msgid "Symbols"
+msgstr "चिन्ह"
+
+#: ../include/wx/unix/pipe.h:46
+msgid "Pipe creation failed"
+msgstr "Pipe सिर्जना असफल भयो ।"
+
+#: ../include/wx/unix/private/displayx11.h:65
+msgid "Failed to enumerate video modes"
+msgstr "श्रव्य दृश्य मुद्रा गणना गर्न सकिएन ।"
+
+#: ../include/wx/unix/private/displayx11.h:89
+msgid "Failed to change video mode"
+msgstr "श्रव्य दृश्य मुद्रामा बदल्न सकिएन"
+
+#: ../include/wx/unix/private/fswatcher_kqueue.h:57
+#, c-format
+msgid "Unable to open path '%s'"
+msgstr "path '%s' खोल्न सकिएन ।"
+
+#: ../include/wx/unix/private/fswatcher_kqueue.h:74
+#, c-format
+msgid "Unable to close path '%s'"
+msgstr "path '%s' लाई बन्द गर्न सकिएन ।Unable to बन्द गर "
+
+#: ../include/wx/xtiprop.h:175
+msgid "SetProperty called w/o valid setter"
+msgstr "SetProperty called w/o valid setter"
+
+#: ../include/wx/xtiprop.h:184
+msgid "GetProperty called w/o valid getter"
+msgstr "GetProperty called w/o valid getter"
+
+#: ../include/wx/xtiprop.h:193
+msgid "AddToPropertyCollection called w/o valid adder"
+msgstr "w/o valid adder भनिने गुणहरूको सङ्ग्रहमा थप गर ।"
+
+#: ../include/wx/xtiprop.h:202
+msgid "GetPropertyCollection called w/o valid collection getter"
+msgstr "GetPropertyCollection called w/o valid collection getter"
+
+#: ../include/wx/xtiprop.h:255
+msgid "AddToPropertyCollection called on a generic accessor"
+msgstr "generic accessor भनिने गुणहरूको सङ्ग्रहमा थप गर ।"
+
+#: ../include/wx/xtiprop.h:262
+msgid "GetPropertyCollection called on a generic accessor"
+msgstr "GetPropertyCollection called on a generic accessor"
+
+#: ../src/aui/tabmdi.cpp:106 ../src/generic/mdig.cpp:94
+msgid "Cl&ose"
+msgstr "&बन्द गर"
+
+#: ../src/aui/tabmdi.cpp:107 ../src/generic/mdig.cpp:95
+msgid "Close All"
+msgstr "सबै बन्द गर "
+
+#: ../src/aui/tabmdi.cpp:109 ../src/generic/mdig.cpp:97 ../src/msw/mdi.cpp:175
+#: ../src/qt/mdi.cpp:258
+msgid "&Next"
+msgstr "&अघिल्लो"
+
+#: ../src/aui/tabmdi.cpp:110 ../src/generic/mdig.cpp:98 ../src/msw/mdi.cpp:176
+#: ../src/qt/mdi.cpp:259
+msgid "&Previous"
+msgstr "&पछिल्लो"
+
+#: ../src/aui/tabmdi.cpp:332 ../src/aui/tabmdi.cpp:348
+#: ../src/aui/tabmdi.cpp:350 ../src/generic/mdig.cpp:291
+#: ../src/generic/mdig.cpp:307 ../src/generic/mdig.cpp:311
+#: ../src/msw/mdi.cpp:337 ../src/qt/mdi.cpp:462
+msgid "&Window"
+msgstr "&विन्डो"
+
+#: ../src/common/accelcmn.cpp:47
+msgctxt "keyboard key"
+msgid "Delete"
+msgstr "मेटाइ देउ"
+
+#: ../src/common/accelcmn.cpp:48
+msgctxt "keyboard key"
+msgid "Del"
+msgstr "DEL"
+
+#: ../src/common/accelcmn.cpp:49
+msgctxt "keyboard key"
+msgid "Back"
+msgstr "पछाडी"
+
+#: ../src/common/accelcmn.cpp:49
+msgctxt "keyboard key"
+msgid "Backspace"
+msgstr "backspace"
+
+#: ../src/common/accelcmn.cpp:50
+msgctxt "keyboard key"
+msgid "Insert"
+msgstr "घुसाउ"
+
+#: ../src/common/accelcmn.cpp:51
+msgctxt "keyboard key"
+msgid "Ins"
+msgstr "INS"
+
+#: ../src/common/accelcmn.cpp:52
+msgctxt "keyboard key"
+msgid "Enter"
+msgstr "enter"
+
+#: ../src/common/accelcmn.cpp:53
+msgctxt "keyboard key"
+msgid "Return"
+msgstr "return"
+
+#: ../src/common/accelcmn.cpp:54
+msgctxt "keyboard key"
+msgid "PageUp"
+msgstr "PAGEUp"
+
+#: ../src/common/accelcmn.cpp:54
+msgctxt "keyboard key"
+msgid "Page Up"
+msgstr "माथिल्लो पृष्ट"
+
+#: ../src/common/accelcmn.cpp:55
+msgctxt "keyboard key"
+msgid "PageDown"
+msgstr "PAGEDOWN"
+
+#: ../src/common/accelcmn.cpp:55
+msgctxt "keyboard key"
+msgid "Page Down"
+msgstr "तल्लो पृष्ट"
+
+#: ../src/common/accelcmn.cpp:56
+msgctxt "keyboard key"
+msgid "PgUp"
+msgstr "PGUP"
+
+#: ../src/common/accelcmn.cpp:57
+msgctxt "keyboard key"
+msgid "PgDn"
+msgstr "PGDN"
+
+#: ../src/common/accelcmn.cpp:58
+msgctxt "keyboard key"
+msgid "Left"
+msgstr "देब्रे"
+
+#: ../src/common/accelcmn.cpp:59
+msgctxt "keyboard key"
+msgid "Right"
+msgstr "दाहिने"
+
+#: ../src/common/accelcmn.cpp:60
+msgctxt "keyboard key"
+msgid "Up"
+msgstr "माथि"
+
+#: ../src/common/accelcmn.cpp:61
+msgctxt "keyboard key"
+msgid "Down"
+msgstr "तल"
+
+#: ../src/common/accelcmn.cpp:62
+msgctxt "keyboard key"
+msgid "Home"
+msgstr "गृह"
+
+#: ../src/common/accelcmn.cpp:63
+msgctxt "keyboard key"
+msgid "End"
+msgstr "अन्त"
+
+#: ../src/common/accelcmn.cpp:64
+msgctxt "keyboard key"
+msgid "Space"
+msgstr "space"
+
+#: ../src/common/accelcmn.cpp:65
+msgctxt "keyboard key"
+msgid "Tab"
+msgstr "ट्याब"
+
+#: ../src/common/accelcmn.cpp:66
+msgctxt "keyboard key"
+msgid "Esc"
+msgstr "ESC"
+
+#: ../src/common/accelcmn.cpp:67
+msgctxt "keyboard key"
+msgid "Escape"
+msgstr "escape"
+
+#: ../src/common/accelcmn.cpp:68
+msgctxt "keyboard key"
+msgid "Cancel"
+msgstr "रद्द गर"
+
+#: ../src/common/accelcmn.cpp:69
+msgctxt "keyboard key"
+msgid "Clear"
+msgstr "मेटाउ"
+
+#: ../src/common/accelcmn.cpp:70
+msgctxt "keyboard key"
+msgid "Menu"
+msgstr "मेनु"
+
+#: ../src/common/accelcmn.cpp:71
+msgctxt "keyboard key"
+msgid "Pause"
+msgstr "विश्राम"
+
+#: ../src/common/accelcmn.cpp:72
+msgctxt "keyboard key"
+msgid "Capital"
+msgstr "ठूलोवर्ण"
+
+#: ../src/common/accelcmn.cpp:73
+msgctxt "keyboard key"
+msgid "Select"
+msgstr "चयन गर्नु"
+
+#: ../src/common/accelcmn.cpp:74
+msgctxt "keyboard key"
+msgid "Print"
+msgstr "छाप्ने काम गर"
+
+#: ../src/common/accelcmn.cpp:75
+msgctxt "keyboard key"
+msgid "Execute"
+msgstr "कार्यान्वयन गर"
+
+#: ../src/common/accelcmn.cpp:76
+msgctxt "keyboard key"
+msgid "Snapshot"
+msgstr "परिक्षण प्रति"
+
+#: ../src/common/accelcmn.cpp:77
+msgctxt "keyboard key"
+msgid "Help"
+msgstr "सहयोग"
+
+#: ../src/common/accelcmn.cpp:78
+msgctxt "keyboard key"
+msgid "Add"
+msgstr "थप"
+
+#: ../src/common/accelcmn.cpp:79
+msgctxt "keyboard key"
+msgid "Separator"
+msgstr "विभाजक"
+
+#: ../src/common/accelcmn.cpp:80
+msgctxt "keyboard key"
+msgid "Subtract"
+msgstr "घटाउ"
+
+#: ../src/common/accelcmn.cpp:81
+msgctxt "keyboard key"
+msgid "Decimal"
+msgstr "दशमलव"
+
+#: ../src/common/accelcmn.cpp:82
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Multiply"
+msgstr "KP_गुणन"
+
+#: ../src/common/accelcmn.cpp:83
+msgctxt "keyboard key"
+msgid "Divide"
+msgstr "विभाजन"
+
+#: ../src/common/accelcmn.cpp:84
+msgctxt "keyboard key"
+msgid "Num_lock"
+msgstr "num lock"
+
+#: ../src/common/accelcmn.cpp:84
+msgctxt "keyboard key"
+msgid "Num Lock"
+msgstr "num lock"
+
+#: ../src/common/accelcmn.cpp:85
+msgctxt "keyboard key"
+msgid "Scroll_lock"
+msgstr "सार्ने चाबी"
+
+#: ../src/common/accelcmn.cpp:85
+msgctxt "keyboard key"
+msgid "Scroll Lock"
+msgstr "सार्ने चाबी"
+
+#: ../src/common/accelcmn.cpp:86
+msgctxt "keyboard key"
+msgid "KP_Space"
+msgstr "KP_SPACE"
+
+#: ../src/common/accelcmn.cpp:86
+msgctxt "keyboard key"
+msgid "Num Space"
+msgstr "Num Space"
+
+#: ../src/common/accelcmn.cpp:87
+msgctxt "keyboard key"
+msgid "KP_Tab"
+msgstr "KP_TAB"
+
+#: ../src/common/accelcmn.cpp:87
+msgctxt "keyboard key"
+msgid "Num Tab"
+msgstr "Num Tab"
+
+#: ../src/common/accelcmn.cpp:88
+msgctxt "keyboard key"
+msgid "KP_Enter"
+msgstr "KP_ENTER"
+
+#: ../src/common/accelcmn.cpp:88
+msgctxt "keyboard key"
+msgid "Num Enter"
+msgstr "Num Enter"
+
+#: ../src/common/accelcmn.cpp:89
+msgctxt "keyboard key"
+msgid "KP_Home"
+msgstr "KP_गृह"
+
+#: ../src/common/accelcmn.cpp:89
+msgctxt "keyboard key"
+msgid "Num Home"
+msgstr "Num Home"
+
+#: ../src/common/accelcmn.cpp:90
+msgctxt "keyboard key"
+msgid "KP_Left"
+msgstr "KP_देब्रे"
+
+#: ../src/common/accelcmn.cpp:90
+msgctxt "keyboard key"
+msgid "Num left"
+msgstr "Num left"
+
+#: ../src/common/accelcmn.cpp:91
+msgctxt "keyboard key"
+msgid "KP_Up"
+msgstr "KP_माथि"
+
+#: ../src/common/accelcmn.cpp:91
+msgctxt "keyboard key"
+msgid "Num Up"
+msgstr "Num Up"
+
+#: ../src/common/accelcmn.cpp:92
+msgctxt "keyboard key"
+msgid "KP_Right"
+msgstr "KP_दाहिने"
+
+#: ../src/common/accelcmn.cpp:92
+msgctxt "keyboard key"
+msgid "Num Right"
+msgstr "Num Right"
+
+#: ../src/common/accelcmn.cpp:93
+msgctxt "keyboard key"
+msgid "KP_Down"
+msgstr "KP_तल"
+
+#: ../src/common/accelcmn.cpp:93
+msgctxt "keyboard key"
+msgid "Num Down"
+msgstr "Num Down"
+
+#: ../src/common/accelcmn.cpp:94
+msgctxt "keyboard key"
+msgid "KP_PageUp"
+msgstr "KP_माथिल्लो पृष्ट"
+
+#: ../src/common/accelcmn.cpp:94
+msgctxt "keyboard key"
+msgid "Num Page Up"
+msgstr "Num Page Up"
+
+#: ../src/common/accelcmn.cpp:95
+msgctxt "keyboard key"
+msgid "KP_PageDown"
+msgstr "KP_तल्लो पृष्ट"
+
+#: ../src/common/accelcmn.cpp:95
+msgctxt "keyboard key"
+msgid "Num Page Down"
+msgstr "Num Page Down"
+
+#: ../src/common/accelcmn.cpp:96
+msgctxt "keyboard key"
+msgid "KP_Prior"
+msgstr "KP_अघिल्लो"
+
+#: ../src/common/accelcmn.cpp:97
+msgctxt "keyboard key"
+msgid "KP_Next"
+msgstr "KP_अघिल्लो"
+
+#: ../src/common/accelcmn.cpp:98
+msgctxt "keyboard key"
+msgid "KP_End"
+msgstr "KP_अन्त्य"
+
+#: ../src/common/accelcmn.cpp:98
+msgctxt "keyboard key"
+msgid "Num End"
+msgstr "Num End"
+
+#: ../src/common/accelcmn.cpp:99
+msgctxt "keyboard key"
+msgid "KP_Begin"
+msgstr "KP_सुरु"
+
+#: ../src/common/accelcmn.cpp:99
+msgctxt "keyboard key"
+msgid "Num Begin"
+msgstr "Num Begin"
+
+#: ../src/common/accelcmn.cpp:100
+msgctxt "keyboard key"
+msgid "KP_Insert"
+msgstr "KP_INSERT"
+
+#: ../src/common/accelcmn.cpp:100
+msgctxt "keyboard key"
+msgid "Num Insert"
+msgstr "Num Insert"
+
+#: ../src/common/accelcmn.cpp:101
+msgctxt "keyboard key"
+msgid "KP_Delete"
+msgstr "KP_मेटाइ देउ"
+
+#: ../src/common/accelcmn.cpp:101
+msgctxt "keyboard key"
+msgid "Num Delete"
+msgstr "Num Delete"
+
+#: ../src/common/accelcmn.cpp:102
+msgctxt "keyboard key"
+msgid "KP_Equal"
+msgstr "KP_बराबर"
+
+#: ../src/common/accelcmn.cpp:102
+msgctxt "keyboard key"
+msgid "Num ="
+msgstr "Num ="
+
+#: ../src/common/accelcmn.cpp:103
+msgctxt "keyboard key"
+msgid "KP_Multiply"
+msgstr "KP_गुणन"
+
+#: ../src/common/accelcmn.cpp:103
+msgctxt "keyboard key"
+msgid "Num *"
+msgstr "Num *"
+
+#: ../src/common/accelcmn.cpp:104
+msgctxt "keyboard key"
+msgid "KP_Add"
+msgstr "KP_थप"
+
+#: ../src/common/accelcmn.cpp:104
+msgctxt "keyboard key"
+msgid "Num +"
+msgstr "Num +"
+
+#: ../src/common/accelcmn.cpp:105
+msgctxt "keyboard key"
+msgid "KP_Separator"
+msgstr "KP_विभाजक"
+
+#: ../src/common/accelcmn.cpp:105
+msgctxt "keyboard key"
+msgid "Num ,"
+msgstr "Num ,"
+
+#: ../src/common/accelcmn.cpp:106
+msgctxt "keyboard key"
+msgid "KP_Subtract"
+msgstr "KP_घटाउ"
+
+#: ../src/common/accelcmn.cpp:106
+msgctxt "keyboard key"
+msgid "Num -"
+msgstr "Num -"
+
+#: ../src/common/accelcmn.cpp:107
+msgctxt "keyboard key"
+msgid "KP_Decimal"
+msgstr "KP_दशमलव"
+
+#: ../src/common/accelcmn.cpp:107
+msgctxt "keyboard key"
+msgid "Num ."
+msgstr "Num ."
+
+#: ../src/common/accelcmn.cpp:108
+msgctxt "keyboard key"
+msgid "KP_Divide"
+msgstr "KP_भाग गर"
+
+#: ../src/common/accelcmn.cpp:108
+msgctxt "keyboard key"
+msgid "Num /"
+msgstr "Num /"
+
+#: ../src/common/accelcmn.cpp:109
+msgctxt "keyboard key"
+msgid "Windows_Left"
+msgstr "विन्डोज_देब्रे"
+
+#: ../src/common/accelcmn.cpp:110
+msgctxt "keyboard key"
+msgid "Windows_Right"
+msgstr "विन्डोज_दाहिने"
+
+#: ../src/common/accelcmn.cpp:111
+msgctxt "keyboard key"
+msgid "Windows_Menu"
+msgstr "विन्डोज_मेनु"
+
+#: ../src/common/accelcmn.cpp:112
+msgctxt "keyboard key"
+msgid "Command"
+msgstr "आदेश"
+
+#: ../src/common/accelcmn.cpp:186 ../src/common/accelcmn.cpp:359
+msgctxt "keyboard key"
+msgid "Ctrl"
+msgstr "नियन्त्रण"
+
+#: ../src/common/accelcmn.cpp:188 ../src/common/accelcmn.cpp:363
+msgctxt "keyboard key"
+msgid "Alt"
+msgstr "Alt"
+
+#: ../src/common/accelcmn.cpp:190 ../src/common/accelcmn.cpp:361
+msgctxt "keyboard key"
+msgid "Shift"
+msgstr "Shift"
+
+#: ../src/common/accelcmn.cpp:196
+msgctxt "keyboard key"
+msgid "num "
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:260 ../src/common/accelcmn.cpp:382
+msgctxt "keyboard key"
+msgid "F"
+msgstr "F"
+
+#: ../src/common/accelcmn.cpp:277 ../src/common/accelcmn.cpp:385
+msgctxt "keyboard key"
+msgid "KP_F"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:280 ../src/common/accelcmn.cpp:388
+msgctxt "keyboard key"
+msgid "KP_"
+msgstr "KP_"
+
+#: ../src/common/accelcmn.cpp:283 ../src/common/accelcmn.cpp:391
+msgctxt "keyboard key"
+msgid "SPECIAL"
+msgstr "विशेष"
+
+#: ../src/common/accelcmn.cpp:373
+#, fuzzy
+msgid "Ctrl"
+msgstr "नियन्त्रण"
+
+#: ../src/common/appbase.cpp:786
+msgid "show this help message"
+msgstr "यो सहयोग सन्देश देखाउ "
+
+#: ../src/common/appbase.cpp:796
+msgid "generate verbose log messages"
+msgstr "लामो सन्देशहरू उत्पादन गर्छ ।"
+
+#: ../src/common/appcmn.cpp:256
+msgid "specify the theme to use"
+msgstr "प्रयोगका लागि theme तोक्नु होला ।"
+
+#: ../src/common/appcmn.cpp:270
+msgid "specify display mode to use (e.g. 640x480-16)"
+msgstr "प्रयोगका लागि दृश्यक मुद्रा तोक्नु होला (e.g. 640x480-16)"
+
+#: ../src/common/appcmn.cpp:292
+#, c-format
+msgid "Unsupported theme '%s'."
+msgstr "असमर्थित theme '%s'"
+
+#: ../src/common/appcmn.cpp:309
+#, c-format
+msgid "Invalid display mode specification '%s'."
+msgstr "नमिल्दो दृश्य मुद्रा मानक '%s'"
+
+#: ../src/common/cmdline.cpp:875
+#, c-format
+msgid "Option '%s' can't be negated"
+msgstr "विकल्प '%s' नकारात्मक हुन सक्दैन ।"
+
+#: ../src/common/cmdline.cpp:889
+#, c-format
+msgid "Unknown long option '%s'"
+msgstr "अज्ञात लामो विकल्प '%s'"
+
+#: ../src/common/cmdline.cpp:904 ../src/common/cmdline.cpp:926
+#, c-format
+msgid "Unknown option '%s'"
+msgstr "अज्ञात विकल्प '%s'"
+
+#: ../src/common/cmdline.cpp:1004
+#, c-format
+msgid "Unexpected characters following option '%s'."
+msgstr "विकल्पहरू '%s' मा नसोचेका वर्णहरू "
+
+#: ../src/common/cmdline.cpp:1039
+#, c-format
+msgid "Option '%s' requires a value."
+msgstr "विकल्प '%s' को एउटा मान हुनै पर्दछ"
+
+#: ../src/common/cmdline.cpp:1058
+#, c-format
+msgid "Separator expected after the option '%s'."
+msgstr "विकल्प '%s' पछि विभाजक अपेक्षा गरिन्छ ।"
+
+#: ../src/common/cmdline.cpp:1088 ../src/common/cmdline.cpp:1106
+#, c-format
+msgid "'%s' is not a correct numeric value for option '%s'."
+msgstr "'%s' सहि सङ्ख्यात्मक मान विकल्प '%s' को लागि हदैन"
+
+#: ../src/common/cmdline.cpp:1122
+#, c-format
+msgid "Option '%s': '%s' cannot be converted to a date."
+msgstr "विकल्प '%s': '%s' मितिमा बदल्न सकिँदैन ।"
+
+#: ../src/common/cmdline.cpp:1170
+#, c-format
+msgid "Unexpected parameter '%s'"
+msgstr "नसोचेका parameter '%s'"
+
+#. TRANSLATORS: Short name and long name for a command line option
+#: ../src/common/cmdline.cpp:1197
+#, c-format
+msgid "%s (or %s)"
+msgstr "%s (अथवा %s)"
+
+#: ../src/common/cmdline.cpp:1208
+#, c-format
+msgid "The value for the option '%s' must be specified."
+msgstr "विकल्प '%s' को मान तोक्न पर्छ ।"
+
+#: ../src/common/cmdline.cpp:1230
+#, c-format
+msgid "The required parameter '%s' was not specified."
+msgstr "आवश्यक parameter '%s' तोकिएको थिएन ।"
+
+#: ../src/common/cmdline.cpp:1289
+#, c-format
+msgid "Usage: %s"
+msgstr "प्रयोग: %s"
+
+#: ../src/common/cmdline.cpp:1498
+msgid "str"
+msgstr "str"
+
+#: ../src/common/cmdline.cpp:1502
+msgid "num"
+msgstr "num"
+
+#: ../src/common/cmdline.cpp:1506
+msgid "double"
+msgstr "दोबर"
+
+#: ../src/common/cmdline.cpp:1510
+msgid "date"
+msgstr "मिति"
+
+#: ../src/common/cmdproc.cpp:250 ../src/common/cmdproc.cpp:276
+#: ../src/common/cmdproc.cpp:296
+msgid "Unnamed command"
+msgstr "बैनामै आदेश"
+
+#: ../src/common/cmdproc.cpp:253
+msgid "&Undo "
+msgstr "&उल्टाउ "
+
+#: ../src/common/cmdproc.cpp:255
+msgid "Can't &Undo "
+msgstr "&उल्टाउन सकिँदैन । "
+
+#: ../src/common/cmdproc.cpp:259 ../src/common/stockitem.cpp:208
+#: ../src/msw/textctrl.cpp:2880 ../src/osx/textctrl_osx.cpp:649
+#: ../src/richtext/richtextctrl.cpp:327
+msgid "&Undo"
+msgstr "&उल्टाउ"
+
+#: ../src/common/cmdproc.cpp:277 ../src/common/cmdproc.cpp:297
+msgid "&Redo "
+msgstr "&फेरि गर "
+
+#: ../src/common/cmdproc.cpp:281 ../src/common/cmdproc.cpp:288
+#: ../src/common/stockitem.cpp:190 ../src/msw/textctrl.cpp:2881
+#: ../src/osx/textctrl_osx.cpp:650 ../src/richtext/richtextctrl.cpp:328
+msgid "&Redo"
+msgstr "&फेरि गर"
+
+#: ../src/common/colourcmn.cpp:41
+#, c-format
+msgid "String To Colour : Incorrect colour specification : %s"
+msgstr "String को रङ्ग : गलत रङ्ग specification : %s"
+
+#: ../src/common/config.cpp:259
+#, c-format
+msgid "Invalid value %ld for a boolean key \"%s\" in config file."
+msgstr "मान %ld नमिल्दो छ (अभियोजन फाइलमा boolean कुञ्जी \"%s\" का लागि ) "
+
+#: ../src/common/config.cpp:526
+#, c-format
+msgid ""
+"Environment variables expansion failed: missing '%c' at position %u in '%s'."
+msgstr "वातावरणीय चल विस्तार असफल भयो: '%c' स्थान %u मा ('%s' को) हराएको छ ।"
+
+#: ../src/common/config.cpp:576 ../src/msw/regconf.cpp:272
+#, c-format
+msgid "'%s' has extra '..', ignored."
+msgstr "'%s' मा अतिरिक्त '..' रहेछ, बेवास्ता गर्नु होस् ।"
+
+#. TRANSLATORS: Checkbox state name
+#: ../src/common/datavcmn.cpp:2166 ../src/generic/datavgen.cpp:1430
+msgid "checked"
+msgstr ""
+
+#. TRANSLATORS: Checkbox state name
+#: ../src/common/datavcmn.cpp:2170 ../src/generic/datavgen.cpp:1432
+msgid "unchecked"
+msgstr ""
+
+#. TRANSLATORS: Checkbox state name
+#: ../src/common/datavcmn.cpp:2174
+#, fuzzy
+msgid "undetermined"
+msgstr "अधोरेखाङ्कित"
+
+#: ../src/common/datetimefmt.cpp:1875
+msgid "today"
+msgstr "आज"
+
+#: ../src/common/datetimefmt.cpp:1876
+msgid "yesterday"
+msgstr "हिजो"
+
+#: ../src/common/datetimefmt.cpp:1877
+msgid "tomorrow"
+msgstr "भोलि"
+
+#: ../src/common/datetimefmt.cpp:2071
+msgid "first"
+msgstr "प्रथम"
+
+#: ../src/common/datetimefmt.cpp:2072
+msgid "second"
+msgstr "दोस्रो"
+
+#: ../src/common/datetimefmt.cpp:2073
+msgid "third"
+msgstr "तेस्रो"
+
+#: ../src/common/datetimefmt.cpp:2074
+msgid "fourth"
+msgstr "चौथो"
+
+#: ../src/common/datetimefmt.cpp:2075
+msgid "fifth"
+msgstr "पाछौं"
+
+#: ../src/common/datetimefmt.cpp:2076
+msgid "sixth"
+msgstr "छैठौँ"
+
+#: ../src/common/datetimefmt.cpp:2077
+msgid "seventh"
+msgstr "सातौं"
+
+#: ../src/common/datetimefmt.cpp:2078
+msgid "eighth"
+msgstr "आठौं"
+
+#: ../src/common/datetimefmt.cpp:2079
+msgid "ninth"
+msgstr "नवौं"
+
+#: ../src/common/datetimefmt.cpp:2080
+msgid "tenth"
+msgstr "दसौं"
+
+#: ../src/common/datetimefmt.cpp:2081
+msgid "eleventh"
+msgstr "एघारौं"
+
+#: ../src/common/datetimefmt.cpp:2082
+msgid "twelfth"
+msgstr "बाह्रौं"
+
+#: ../src/common/datetimefmt.cpp:2083
+msgid "thirteenth"
+msgstr "तेह्रौं"
+
+#: ../src/common/datetimefmt.cpp:2084
+msgid "fourteenth"
+msgstr "चौधौं "
+
+#: ../src/common/datetimefmt.cpp:2085
+msgid "fifteenth"
+msgstr "पन्ध्रौं"
+
+#: ../src/common/datetimefmt.cpp:2086
+msgid "sixteenth"
+msgstr "सोह्रौं"
+
+#: ../src/common/datetimefmt.cpp:2087
+msgid "seventeenth"
+msgstr "सत्रौं"
+
+#: ../src/common/datetimefmt.cpp:2088
+msgid "eighteenth"
+msgstr "अठारौं"
+
+#: ../src/common/datetimefmt.cpp:2089
+msgid "nineteenth"
+msgstr "उन्नाइसौं"
+
+#: ../src/common/datetimefmt.cpp:2090
+msgid "twentieth"
+msgstr "बीसौं"
+
+#: ../src/common/datetimefmt.cpp:2248
+msgid "noon"
+msgstr "मध्यान्न"
+
+#: ../src/common/datetimefmt.cpp:2249
+msgid "midnight"
+msgstr "मध्य रात"
+
+#: ../src/common/debugrpt.cpp:209
+#, c-format
+msgid "Failed to create directory \"%s\""
+msgstr "घर्रा \"%s\" सिर्जना गर्न सकिएन ।"
+
+#: ../src/common/debugrpt.cpp:210
+msgid "Debug report couldn't be created."
+msgstr "खानतलासी प्रतिवेदन सिर्जना गर्न सकिएन"
+
+#: ../src/common/debugrpt.cpp:227
+#, c-format
+msgid "Failed to remove debug report file \"%s\""
+msgstr "खानतलासी प्रतिवेदन फाइल \"%s\" हटाउन सकिएन ।"
+
+#: ../src/common/debugrpt.cpp:239
+#, c-format
+msgid "Failed to clean up debug report directory \"%s\""
+msgstr "खानतलासी प्रतिवेदन घर्रा \"%s\" सफा गर्न सकिएन ।"
+
+#: ../src/common/debugrpt.cpp:514
+msgid "process context description"
+msgstr "प्रक्रिया सन्दर्भको बयान"
+
+#: ../src/common/debugrpt.cpp:538
+msgid "dump of the process state (binary)"
+msgstr "प्रक्रिया अवस्था थुप्रियो (binary)"
+
+#: ../src/common/debugrpt.cpp:553
+msgid "Debug report generation has failed."
+msgstr "खानतलासी प्रतिवेदन तयारी असफल भयो ।"
+
+#: ../src/common/debugrpt.cpp:560
+#, c-format
+msgid ""
+"Processing debug report has failed, leaving the files in \"%s\" directory."
+msgstr "\"%s\" घर्रामा फाइल राख्दै खान तलासी प्रतिवेदनको प्रशोधन असफल भयो ।"
+
+#: ../src/common/debugrpt.cpp:573
+msgid "A debug report has been generated. It can be found in"
+msgstr "खानतलासी प्रतिवेदन सिर्जना गरियो । यो राखेको स्थान"
+
+#: ../src/common/debugrpt.cpp:576
+msgid "And includes the following files:\n"
+msgstr "एवम् निमन लिखित फाइलहरू समावेश गर्छ:\n"
+
+#: ../src/common/debugrpt.cpp:586
+msgid ""
+"\n"
+"Please send this report to the program maintainer, thank you!\n"
+msgstr ""
+"\n"
+" कृपया यो प्रतिवेदन कार्यक्रम सम्भार कर्ता लाई पेश गर्नु होला । धन्यवाद!\n"
+
+#: ../src/common/debugrpt.cpp:729
+msgid "Failed to execute curl, please install it in PATH."
+msgstr "curl कार्यान्वयन गर्न सकिएन, कृपया यसलाई PATH मा स्थापन गर्नु होस् ।"
+
+#: ../src/common/debugrpt.cpp:742
+#, c-format
+msgid "Failed to upload the debug report (error code %d)."
+msgstr "खानतलासी प्रतिवेदन (गल्ती कोड %d) अपलोड गर्न सकिएन ।"
+
+#: ../src/common/docview.cpp:366
+msgid "Save As"
+msgstr "यसरी बचत गर "
+
+#: ../src/common/docview.cpp:457
+msgid "Discard changes and reload the last saved version?"
+msgstr "के परिवर्तन लाई त्यागेर अन्तिम बचत संस्करणलाई वहन गर्ने हो?"
+
+#: ../src/common/docview.cpp:488
+msgid "unnamed"
+msgstr "नाम नपाएको"
+
+#: ../src/common/docview.cpp:513
+#, c-format
+msgid "Do you want to save changes to %s?"
+msgstr "के तपाइ %s मा परिवर्तन लाई बचत गर्न चाहनु हुन्छ?"
+
+#: ../src/common/docview.cpp:521 ../src/common/docview.cpp:560
+#: ../src/common/stockitem.cpp:195
+msgid "&Save"
+msgstr "&बचत गर"
+
+#: ../src/common/docview.cpp:522 ../src/common/docview.cpp:560
+msgid "&Discard changes"
+msgstr ""
+
+#: ../src/common/docview.cpp:523
+#, fuzzy
+msgid "Do&n't close"
+msgstr "बचत नगर"
+
+#: ../src/common/docview.cpp:553
+#, fuzzy, c-format
+msgid "Do you want to save changes to %s before closing it?"
+msgstr "के तपाइ %s मा परिवर्तन लाई बचत गर्न चाहनु हुन्छ?"
+
+#: ../src/common/docview.cpp:559
+#, fuzzy
+msgid "The document must be closed."
+msgstr "पाठलाई बचत गर्न सकेन"
+
+#: ../src/common/docview.cpp:571
+#, c-format
+msgid "Saving %s failed, would you like to retry?"
+msgstr ""
+
+#: ../src/common/docview.cpp:577
+msgid "Retry"
+msgstr ""
+
+#: ../src/common/docview.cpp:577
+msgid "Discard changes"
+msgstr ""
+
+#: ../src/common/docview.cpp:679
+#, c-format
+msgid "File \"%s\" could not be opened for writing."
+msgstr "फाइल \"%s\" लेख्नका लागि खोल्न सकिएन ।"
+
+#: ../src/common/docview.cpp:685
+#, c-format
+msgid "Failed to save document to the file \"%s\"."
+msgstr "फाइल \"%s\" मा कागजातहरू बचत गर्न सकिएन ।"
+
+#: ../src/common/docview.cpp:702
+#, c-format
+msgid "File \"%s\" could not be opened for reading."
+msgstr "फाइल \"%s\" पढ्नको लागि खोल्न सकिएन ।"
+
+#: ../src/common/docview.cpp:714
+#, c-format
+msgid "Failed to read document from the file \"%s\"."
+msgstr "फाइल \"%s\". बाट कागजात पढ्न सकिएन ।"
+
+#: ../src/common/docview.cpp:1236
+#, c-format
+msgid ""
+"The file '%s' doesn't exist and couldn't be opened.\n"
+"It has been removed from the most recently used files list."
+msgstr ""
+"फाइल '%s' नभेटिएकोले खोल्न सकिएन ।\n"
+"यसलाई हालै प्रयोग गरेका फाइलहरूको सूचीबाट हटाइयो ।"
+
+#: ../src/common/docview.cpp:1296
+msgid "Print preview creation failed."
+msgstr "छापिने चेहराको सिर्जना असफल भयो ।"
+
+#: ../src/common/docview.cpp:1302
+msgid "Print Preview"
+msgstr "छापिने चेहरा"
+
+#: ../src/common/docview.cpp:1517
+#, c-format
+msgid "The format of file '%s' couldn't be determined."
+msgstr "फाइल '%s' को बनोट पता लगाउन सकिएन ।"
+
+#: ../src/common/docview.cpp:1643
+#, c-format
+msgid "unnamed%d"
+msgstr "नाम नभएको %d"
+
+#: ../src/common/docview.cpp:1660
+msgid " - "
+msgstr " - "
+
+#: ../src/common/docview.cpp:1791 ../src/common/docview.cpp:1844
+msgid "Open File"
+msgstr "फाइल पल्टाउ "
+
+#: ../src/common/docview.cpp:1807
+msgid "File error"
+msgstr "फाइलको गल्ती"
+
+#: ../src/common/docview.cpp:1809
+msgid "Sorry, could not open this file."
+msgstr "माफ गर्नु होस्, यो फाइल खोल्न सकिएन ।"
+
+#: ../src/common/docview.cpp:1843
+msgid "Sorry, the format for this file is unknown."
+msgstr "माफ गर्नु होस्, यो फाइलको बनोट थाहा भएन ।"
+
+#: ../src/common/docview.cpp:1924
+msgid "Select a document template"
+msgstr "एउटा कागजात  लेखोट चयन गर ।"
+
+#: ../src/common/docview.cpp:1925
+msgid "Templates"
+msgstr "लेखोट"
+
+#: ../src/common/docview.cpp:1998
+msgid "Select a document view"
+msgstr "एउटा कागजातको दृश्य चयन गर"
+
+#: ../src/common/docview.cpp:1999
+msgid "Views"
+msgstr "दृश्यहरू"
+
+#: ../src/common/dynlib.cpp:81
+#, c-format
+msgid "Failed to load shared library '%s'"
+msgstr "साझा पुस्तकालय '%s' वहन गर्न सकिएन "
+
+#: ../src/common/dynlib.cpp:105
+#, c-format
+msgid "Couldn't find symbol '%s' in a dynamic library"
+msgstr "चिन्ह '%s' गतिसित पुस्तकालयमा पाउन सकिएन"
+
+#: ../src/common/ffile.cpp:56 ../src/common/file.cpp:215
+#, c-format
+msgid "can't open file '%s'"
+msgstr "फाइल '%s' लाई पल्टाउन सकिँदैन ।"
+
+#: ../src/common/ffile.cpp:72
+#, c-format
+msgid "can't close file '%s'"
+msgstr "फाइल '%s' बन्द गर्न सकिँदैन ।"
+
+#: ../src/common/ffile.cpp:106 ../src/common/ffile.cpp:131
+#, c-format
+msgid "Read error on file '%s'"
+msgstr "फाइल '%s' मा पढ्न गल्ती भयो ।"
+
+#: ../src/common/ffile.cpp:148
+#, c-format
+msgid "Write error on file '%s'"
+msgstr "फाइल '%s' को लेखाइमा गल्ती"
+
+#: ../src/common/ffile.cpp:182
+#, c-format
+msgid "failed to flush the file '%s'"
+msgstr "फाइल '%s' लाइ चिल्लो पार्न असफल भयो ।"
+
+#: ../src/common/ffile.cpp:222
+#, c-format
+msgid "Seek error on file '%s' (large files not supported by stdio)"
+msgstr "फाइल '%s' (stdio ले ठूलो फाइललाई समर्थन गर्दै न ) मा खोजिको गल्ती । "
+
+#: ../src/common/ffile.cpp:232
+#, c-format
+msgid "Seek error on file '%s'"
+msgstr "फाइल '%s' मा खोजीको गल्ती ।"
+
+#: ../src/common/ffile.cpp:248
+#, c-format
+msgid "Can't find current position in file '%s'"
+msgstr "फाइल '%s' मा चालू स्थान पता लगाउन सकिँदैन ।"
+
+#: ../src/common/ffile.cpp:349 ../src/common/file.cpp:569
+msgid "Failed to set temporary file permissions"
+msgstr "अस्ताई फाइल अनुमित राख्न सकिएन ।"
+
+#: ../src/common/ffile.cpp:371
+#, c-format
+msgid "can't remove file '%s'"
+msgstr "फाइल '%s' लाइ हटाउन सकिँदैन ।"
+
+#: ../src/common/ffile.cpp:376 ../src/common/file.cpp:591
+#, c-format
+msgid "can't commit changes to file '%s'"
+msgstr "फाइल '%s' लाई वाचा गर्न सकिँदैन ।"
+
+#: ../src/common/ffile.cpp:388 ../src/common/file.cpp:603
+#, c-format
+msgid "can't remove temporary file '%s'"
+msgstr "अस्ताइ फाइल '%s' लाई हटाउन सकिँदैन ।"
+
+#: ../src/common/file.cpp:162
+#, c-format
+msgid "can't create file '%s'"
+msgstr "फाइल '%s' सिर्जना गर्न सकिँदैन ।"
+
+#: ../src/common/file.cpp:229
+#, c-format
+msgid "can't close file descriptor %d"
+msgstr "फाइल ब्याख्याकार %d बन्द गर्न सकिँदैन ।"
+
+#: ../src/common/file.cpp:332
+#, c-format
+msgid "can't read from file descriptor %d"
+msgstr "फाइल ब्याख्याकार %d बाट पढ्न सकिँदैन ।"
+
+#: ../src/common/file.cpp:351
+#, c-format
+msgid "can't write to file descriptor %d"
+msgstr "फाइल ब्याख्याकार %d लाई लेख्न सकिँदैन ।"
+
+#: ../src/common/file.cpp:390
+#, c-format
+msgid "can't flush file descriptor %d"
+msgstr "फाइल ब्याख्याकार %d लाई माझ्न सकिँदैन ।"
+
+#: ../src/common/file.cpp:432
+#, c-format
+msgid "can't seek on file descriptor %d"
+msgstr "फाइल ब्याख्याकार %d मा खोज्न सकिँदैन ।"
+
+#: ../src/common/file.cpp:446
+#, c-format
+msgid "can't get seek position on file descriptor %d"
+msgstr "फाइल ब्याख्याकार %d मा खोजी को स्थान पाउन सकिँदैन ।"
+
+#: ../src/common/file.cpp:475
+#, c-format
+msgid "can't find length of file on file descriptor %d"
+msgstr "फाइल ब्याख्याकार %d मा फाइल को लम्बाइ फेला पार्न सकिँदैन ।"
+
+#: ../src/common/file.cpp:505
+#, c-format
+msgid "can't determine if the end of file is reached on descriptor %d"
+msgstr "यदि फाइलको अन्त ब्याख्याकार %d मा पुगेको छ भने यसलाई पता लगाउन सकिँदैन ।"
+
+#: ../src/common/fileconf.cpp:352
+#, c-format
+msgid ""
+" and additionally, the existing configuration file was renamed to \"%s\" and "
+"couldn't be renamed back, please rename it to its original path \"%s\""
+msgstr ""
+
+#: ../src/common/fileconf.cpp:389
+#, fuzzy
+msgid " due to the following error:\n"
+msgstr "एवम् निमन लिखित फाइलहरू समावेश गर्छ:\n"
+
+#: ../src/common/fileconf.cpp:412
+#, fuzzy
+msgid "failed to rename the existing file"
+msgstr "फाइल \"%s\". बाट कागजात पढ्न सकिएन ।"
+
+#: ../src/common/fileconf.cpp:421
+#, fuzzy
+msgid "failed to create the new file directory"
+msgstr "कार्य गर्दै गरेको घर्रा पाउन सकिएन ।"
+
+#: ../src/common/fileconf.cpp:428
+#, fuzzy
+msgid "failed to move the file to the new location"
+msgstr "डायलअप जडान %s बन्द गर्न सकिएन ।"
+
+#: ../src/common/fileconf.cpp:462
+#, c-format
+msgid "can't open global configuration file '%s'."
+msgstr "साझा अभियोजन फाइल '%s' लाई खोल्न सकिएन ।"
+
+#: ../src/common/fileconf.cpp:478
+#, c-format
+msgid "can't open user configuration file '%s'."
+msgstr "उपभोक्ताको अभियोजन फाइल '%s' लाई खोल्न सकिएन ।"
+
+#: ../src/common/fileconf.cpp:483
+#, c-format
+msgid "Changes won't be saved to avoid overwriting the existing file \"%s\""
+msgstr ""
+"भइरहेको फाइल \"%s\" मा नया कुरा लेख्न नमिल्ने भएकोले परिवर्तनलाई बचत गर्न सकिँदैन ।"
+
+#: ../src/common/fileconf.cpp:583
+msgid "Error reading config options."
+msgstr "config विकल्प पढ्न गल्ती भयो ।"
+
+#: ../src/common/fileconf.cpp:593
+msgid "Failed to read config options."
+msgstr "अभियोजन विकल्प पढ्न सकिएन ।"
+
+#: ../src/common/fileconf.cpp:700
+#, fuzzy, c-format
+msgid "file '%s': unexpected character %c at line %zu."
+msgstr "फाइल '%s': वर्ण %c (%d लाइनमा ) अनपेक्षित छ ।"
+
+#: ../src/common/fileconf.cpp:736
+#, fuzzy, c-format
+msgid "file '%s', line %zu: '%s' ignored after group header."
+msgstr "फाइल '%s', लाइन %d: '%s' लाइ समूह header पछि बेवास्ता गरियो ।"
+
+#: ../src/common/fileconf.cpp:765
+#, fuzzy, c-format
+msgid "file '%s', line %zu: '=' expected."
+msgstr "फाइल '%s', लाइन %d: '=' को अपेक्षा गरियो ।"
+
+#: ../src/common/fileconf.cpp:778
+#, fuzzy, c-format
+msgid "file '%s', line %zu: value for immutable key '%s' ignored."
+msgstr "फाइल '%s', लाइन %d: अपरिवर्तित कुञ्जी '%s' को मान बेवास्ता गरियो ।"
+
+#: ../src/common/fileconf.cpp:788
+#, fuzzy, c-format
+msgid "file '%s', line %zu: key '%s' was first found at line %d."
+msgstr "फाइल '%s', लाइन %d: कुञ्जी '%s' पहिलो पटक लाइन %d मा पाइएको थियो ।"
+
+#: ../src/common/fileconf.cpp:1091
+#, c-format
+msgid "Config entry name cannot start with '%c'."
+msgstr "Config प्रविष्टि नाम '%c' सित सुरु हुँदैन"
+
+#: ../src/common/fileconf.cpp:1146
+#, fuzzy
+msgid "Failed to create configuration file directory."
+msgstr "उपभोक्ता अभियोजन फाइल अद्यावधि करण गर्न सकिएन ।"
+
+#: ../src/common/fileconf.cpp:1158
+msgid "can't open user configuration file."
+msgstr "उपभोक्ताको अभियोजन फाइललाई खोल्न सकिएन ।"
+
+#: ../src/common/fileconf.cpp:1172
+msgid "can't write user configuration file."
+msgstr "उपभोक्ताको अभियोजन फाइल लेख्न सकिँदैन "
+
+#: ../src/common/fileconf.cpp:1178
+msgid "Failed to update user configuration file."
+msgstr "उपभोक्ता अभियोजन फाइल अद्यावधि करण गर्न सकिएन ।"
+
+#: ../src/common/fileconf.cpp:1201
+msgid "Error saving user configuration data."
+msgstr "उपभोक्ताको अभियोजन तथ्याङ्क बचतमा गल्ती भयो ।"
+
+#: ../src/common/fileconf.cpp:1313
+#, c-format
+msgid "can't delete user configuration file '%s'"
+msgstr "उपभोक्ताको अभियोजन फाइल '%s' मेटाउन सकिँदैन ।"
+
+#: ../src/common/fileconf.cpp:2007
+#, c-format
+msgid "entry '%s' appears more than once in group '%s'"
+msgstr "प्रविष्टि '%s' समूह '%s' मा एक पल्ट भन्दा बढि देखिन्छ "
+
+#: ../src/common/fileconf.cpp:2021
+#, c-format
+msgid "attempt to change immutable key '%s' ignored."
+msgstr "परिवर्तित नहुने कुञ्जी '%s' को परिवर्तन प्रयासलाई बेवास्ता गरियो ।"
+
+#: ../src/common/fileconf.cpp:2118
+#, c-format
+msgid "trailing backslash ignored in '%s'"
+msgstr "'%s' मा पछाडिको backslash बेवास्ता गरियो ।"
+
+#: ../src/common/fileconf.cpp:2153
+#, c-format
+msgid "unexpected \" at position %d in '%s'."
+msgstr "\" अनपेक्षित छ, (स्थान %d '; %s' को ) ।"
+
+#: ../src/common/filefn.cpp:474
+#, c-format
+msgid "Failed to copy the file '%s' to '%s'"
+msgstr "फाइल '%s' को नक्कल '%s' मा उतार्न सकिएन ।"
+
+#: ../src/common/filefn.cpp:487
+#, c-format
+msgid "Impossible to get permissions for file '%s'"
+msgstr "फाइल '%s' को स्वीकृति पाउन सम्भव छैन ।"
+
+#: ../src/common/filefn.cpp:501
+#, c-format
+msgid "Impossible to overwrite the file '%s'"
+msgstr "फाइल '%s' मेटाएर अर्को फाइल बनाउन सम्भव छैन ।"
+
+#: ../src/common/filefn.cpp:508
+#, fuzzy, c-format
+msgid "Error copying the file '%s' to '%s'."
+msgstr "फाइल '%s' को नक्कल '%s' मा उतार्न सकिएन ।"
+
+#: ../src/common/filefn.cpp:556
+#, c-format
+msgid "Impossible to set permissions for the file '%s'"
+msgstr "फाइल '%s' को स्वीकृति तय गर्न सम्भव छैन ।"
+
+#: ../src/common/filefn.cpp:606
+#, c-format
+msgid ""
+"Failed to rename the file '%s' to '%s' because the destination file already "
+"exists."
+msgstr "यही नामको अर्को फाइल भएकोले '%s' फाइलको नाम '%s' मा फेर्न सकिएन ।"
+
+#: ../src/common/filefn.cpp:623
+#, c-format
+msgid "File '%s' couldn't be renamed '%s'"
+msgstr "फाइल '%s' को नामा करण '%s' राख्न सकिएन ।"
+
+#: ../src/common/filefn.cpp:639
+#, c-format
+msgid "File '%s' couldn't be removed"
+msgstr "फाइल '%s' लाई हटाउन सकिएन ।"
+
+#: ../src/common/filefn.cpp:666
+#, c-format
+msgid "Directory '%s' couldn't be created"
+msgstr "'%s' घर्रा सिर्जना गर्न सकिएन ।"
+
+#: ../src/common/filefn.cpp:680
+#, c-format
+msgid "Directory '%s' couldn't be deleted"
+msgstr "'%s' घर्रा मेटाउन सकिएन ।"
+
+#: ../src/common/filefn.cpp:714
+#, c-format
+msgid "Cannot enumerate files '%s'"
+msgstr "गल्ती '%s' गणना गर्न सकिँदैन ।"
+
+#: ../src/common/filefn.cpp:798
+msgid "Failed to get the working directory"
+msgstr "कार्य गर्दै गरेको घर्रा पाउन सकिएन ।"
+
+#: ../src/common/filefn.cpp:843
+msgid "Could not set current working directory"
+msgstr "चालू अवस्थामा रहेको घर्रा तय गर्न सकिएन"
+
+#: ../src/common/filefn.cpp:974
+#, c-format
+msgid "Files (%s)"
+msgstr "फाइलहरू (%s)"
+
+#: ../src/common/filename.cpp:182
+#, c-format
+msgid "Failed to open '%s' for reading"
+msgstr "पढ्नका लागि '%s' लाई खोल्न सकिएन ।"
+
+#: ../src/common/filename.cpp:187
+#, c-format
+msgid "Failed to open '%s' for writing"
+msgstr "लेख्नका लागि '%s' खोल्न सकिएन ।"
+
+#: ../src/common/filename.cpp:199
+msgid "Failed to close file handle"
+msgstr "फाइल को हातो बन्द गर्न सकिएन ।"
+
+#: ../src/common/filename.cpp:1046
+msgid "Failed to create a temporary file name"
+msgstr "अस्ताई फाइलको नाम सिर्जना गर्न सकिएन ।"
+
+#: ../src/common/filename.cpp:1081
+msgid "Failed to open temporary file."
+msgstr "अस्ताई फाइल खोल्न सकिएन ।"
+
+#: ../src/common/filename.cpp:2862
+#, c-format
+msgid "Failed to modify file times for '%s'"
+msgstr "'%s' फाइलको समय फेर बदल गर्न सकिएन ।"
+
+#: ../src/common/filename.cpp:2877
+#, c-format
+msgid "Failed to touch the file '%s'"
+msgstr "फाइल '%s' लाइ छु सकिएन ।"
+
+#: ../src/common/filename.cpp:2958
+#, c-format
+msgid "Failed to retrieve file times for '%s'"
+msgstr "फाइल '%s' को समय लिन सकिएन ।"
+
+#: ../src/common/filepickercmn.cpp:39 ../src/common/filepickercmn.cpp:40
+msgid "Browse"
+msgstr "खोतल्ने"
+
+#: ../src/common/fldlgcmn.cpp:792 ../src/generic/filectrlg.cpp:1185
+#, c-format
+msgid "All files (%s)|%s"
+msgstr "सबै फाइलहरू (%s)|%s"
+
+#. TRANSLATORS: %s are a file extension used to build a file wildcard string
+#: ../src/common/fldlgcmn.cpp:810
+#, c-format
+msgid "%s files (%s)|%s"
+msgstr "%s फाइल (%s)|%s"
+
+#: ../src/common/fldlgcmn.cpp:1072
+#, c-format
+msgid "Load %s file"
+msgstr "%s फाइल वहन गर "
+
+#: ../src/common/fldlgcmn.cpp:1074
+#, c-format
+msgid "Save %s file"
+msgstr "%s फाइललाई बचत गर "
+
+#: ../src/common/fmapbase.cpp:144
+msgid "Western European (ISO-8859-1)"
+msgstr "पश्चिमा युरोपेली (ISO-8859-1)"
+
+#: ../src/common/fmapbase.cpp:145
+msgid "Central European (ISO-8859-2)"
+msgstr "केन्द्रीय युरोपेली (ISO-8859-2)"
+
+#: ../src/common/fmapbase.cpp:146
+msgid "Esperanto (ISO-8859-3)"
+msgstr "Esperanto (ISO-8859-3)"
+
+#: ../src/common/fmapbase.cpp:147
+msgid "Baltic (old) (ISO-8859-4)"
+msgstr "Baltic (old) (ISO-8859-4)"
+
+#: ../src/common/fmapbase.cpp:148
+msgid "Cyrillic (ISO-8859-5)"
+msgstr "Cyrillic (ISO-8859-5)"
+
+#: ../src/common/fmapbase.cpp:149
+msgid "Arabic (ISO-8859-6)"
+msgstr "अरबी (ISO-8859-6)"
+
+#: ../src/common/fmapbase.cpp:150
+msgid "Greek (ISO-8859-7)"
+msgstr "Greek (ISO-8859-7)"
+
+#: ../src/common/fmapbase.cpp:151
+msgid "Hebrew (ISO-8859-8)"
+msgstr "हिब्रु (ISO-8859-8)"
+
+#: ../src/common/fmapbase.cpp:152
+msgid "Turkish (ISO-8859-9)"
+msgstr "Turkish (ISO-8859-9)"
+
+#: ../src/common/fmapbase.cpp:153
+msgid "Nordic (ISO-8859-10)"
+msgstr "Nordic (ISO-8859-10)"
+
+#: ../src/common/fmapbase.cpp:154
+msgid "Thai (ISO-8859-11)"
+msgstr "Thai (ISO-8859-11)"
+
+#: ../src/common/fmapbase.cpp:155
+msgid "Indian (ISO-8859-12)"
+msgstr "भारतीय (ISO-8859-12)"
+
+#: ../src/common/fmapbase.cpp:156
+msgid "Baltic (ISO-8859-13)"
+msgstr "Baltic (ISO-8859-13)"
+
+#: ../src/common/fmapbase.cpp:157
+msgid "Celtic (ISO-8859-14)"
+msgstr "Celtic (ISO-8859-14)"
+
+#: ../src/common/fmapbase.cpp:158
+msgid "Western European with Euro (ISO-8859-15)"
+msgstr "पश्चिमा युरोपेली with Euro (ISO-8859-15)"
+
+#: ../src/common/fmapbase.cpp:159
+msgid "KOI8-R"
+msgstr "KOI8-R"
+
+#: ../src/common/fmapbase.cpp:160
+msgid "KOI8-U"
+msgstr "KOI8-U"
+
+#: ../src/common/fmapbase.cpp:161
+msgid "Windows/DOS OEM Cyrillic (CP 866)"
+msgstr "विन्डोज /DOS OEM सेरिलिक (CP 866)"
+
+#: ../src/common/fmapbase.cpp:162
+msgid "Windows Thai (CP 874)"
+msgstr "थाइ विन्डोज (CP 874)"
+
+#: ../src/common/fmapbase.cpp:163
+msgid "Windows Japanese (CP 932) or Shift-JIS"
+msgstr "जापानी विन्डोज (CP 932) अथवा Shift-JIS"
+
+#: ../src/common/fmapbase.cpp:164
+msgid "Windows Chinese Simplified (CP 936) or GB-2312"
+msgstr "सरलीकृत चिनियाँ विन्डोज (CP 936) अथवा GB-2312"
+
+#: ../src/common/fmapbase.cpp:165
+msgid "Windows Korean (CP 949)"
+msgstr "कोरिया ली विन्डोज (CP 949)"
+
+#: ../src/common/fmapbase.cpp:166
+msgid "Windows Chinese Traditional (CP 950) or Big-5"
+msgstr "परम्परागत चिनियाँ विन्डोज (CP 950) अथवा Big-5"
+
+#: ../src/common/fmapbase.cpp:167
+msgid "Windows Central European (CP 1250)"
+msgstr "केन्द्रीय युरोपेली विन्डोज (CP 1250)"
+
+#: ../src/common/fmapbase.cpp:168
+msgid "Windows Cyrillic (CP 1251)"
+msgstr "सेरिलिक विन्डोज (CP 1251)"
+
+#: ../src/common/fmapbase.cpp:169
+msgid "Windows Western European (CP 1252)"
+msgstr "पश्चिमा युरोपेली विन्डोज (CP 1252)"
+
+#: ../src/common/fmapbase.cpp:170
+msgid "Windows Greek (CP 1253)"
+msgstr "ग्रीक विन्डोज (CP 1253)"
+
+#: ../src/common/fmapbase.cpp:171
+msgid "Windows Turkish (CP 1254)"
+msgstr "तुर्कि विन्डोज (CP 1254)"
+
+#: ../src/common/fmapbase.cpp:172
+msgid "Windows Hebrew (CP 1255)"
+msgstr "हिब्रु विन्डोज (CP 1255)"
+
+#: ../src/common/fmapbase.cpp:173
+msgid "Windows Arabic (CP 1256)"
+msgstr "अरबी विन्डोज (CP 1256)"
+
+#: ../src/common/fmapbase.cpp:174
+msgid "Windows Baltic (CP 1257)"
+msgstr "बाल्टीकन विन्डोज (CP 1257)"
+
+#: ../src/common/fmapbase.cpp:175
+msgid "Windows Vietnamese (CP 1258)"
+msgstr "भियतनामी विन्डोज (CP 1258)"
+
+#: ../src/common/fmapbase.cpp:176
+msgid "Windows Johab (CP 1361)"
+msgstr "जोहब विन्डोज (CP 1361)"
+
+#: ../src/common/fmapbase.cpp:177
+msgid "Windows/DOS OEM (CP 437)"
+msgstr "विन्डोज /DOS OEM (CP 437)"
+
+#: ../src/common/fmapbase.cpp:178
+msgid "Unicode 7 bit (UTF-7)"
+msgstr "युनिकोड 7 bit (UTF-7)"
+
+#: ../src/common/fmapbase.cpp:179
+msgid "Unicode 8 bit (UTF-8)"
+msgstr "युनिकोड 8 bit (UTF-8)"
+
+#: ../src/common/fmapbase.cpp:181 ../src/common/fmapbase.cpp:187
+msgid "Unicode 16 bit (UTF-16)"
+msgstr "16 bit युनिकोड (UTF-16)"
+
+#: ../src/common/fmapbase.cpp:182
+msgid "Unicode 16 bit Little Endian (UTF-16LE)"
+msgstr "सानो भारतीय 16 bit युनिकोड (UTF-16LE)"
+
+#: ../src/common/fmapbase.cpp:183 ../src/common/fmapbase.cpp:189
+msgid "Unicode 32 bit (UTF-32)"
+msgstr "युनिकोड 32 bit (UTF-32)"
+
+#: ../src/common/fmapbase.cpp:184
+msgid "Unicode 32 bit Little Endian (UTF-32LE)"
+msgstr "युनिकोड 32 bit सानो भारतीय(UTF-32LE)"
+
+#: ../src/common/fmapbase.cpp:186
+msgid "Unicode 16 bit Big Endian (UTF-16BE)"
+msgstr "बृहत् भारतीय 16 bit युनिकोड (UTF-16BE)"
+
+#: ../src/common/fmapbase.cpp:188
+msgid "Unicode 32 bit Big Endian (UTF-32BE)"
+msgstr "युनिकोड 32 bit बृहत् भारतीय (UTF-32BE)"
+
+#: ../src/common/fmapbase.cpp:191
+msgid "Extended Unix Codepage for Japanese (EUC-JP)"
+msgstr "Extended Unix Codepage for Japanese (EUC-JP)"
+
+#: ../src/common/fmapbase.cpp:192
+msgid "US-ASCII"
+msgstr "US-ASCII"
+
+#: ../src/common/fmapbase.cpp:193
+msgid "ISO-2022-JP"
+msgstr "ISO-2022-JP"
+
+#: ../src/common/fmapbase.cpp:195
+msgid "MacRoman"
+msgstr "MacRoman"
+
+#: ../src/common/fmapbase.cpp:196
+msgid "MacJapanese"
+msgstr "MacJapanese"
+
+#: ../src/common/fmapbase.cpp:197
+msgid "MacChineseTrad"
+msgstr "MacChineseTrad"
+
+#: ../src/common/fmapbase.cpp:198
+msgid "MacKorean"
+msgstr "MacKorean"
+
+#: ../src/common/fmapbase.cpp:199
+msgid "MacArabic"
+msgstr "MacArabic"
+
+#: ../src/common/fmapbase.cpp:200
+msgid "MacHebrew"
+msgstr "MacHebrew"
+
+#: ../src/common/fmapbase.cpp:201
+msgid "MacGreek"
+msgstr "MacGreek"
+
+#: ../src/common/fmapbase.cpp:202
+msgid "MacCyrillic"
+msgstr "MacCyrillic"
+
+#: ../src/common/fmapbase.cpp:203
+msgid "MacDevanagari"
+msgstr "MacDevanagari"
+
+#: ../src/common/fmapbase.cpp:204
+msgid "MacGurmukhi"
+msgstr "MacGurmukhi"
+
+#: ../src/common/fmapbase.cpp:205
+msgid "MacGujarati"
+msgstr "MacGujarati"
+
+#: ../src/common/fmapbase.cpp:206
+msgid "MacOriya"
+msgstr "MacOriya"
+
+#: ../src/common/fmapbase.cpp:207
+msgid "MacBengali"
+msgstr "MacBengali"
+
+#: ../src/common/fmapbase.cpp:208
+msgid "MacTamil"
+msgstr "MacTamil"
+
+#: ../src/common/fmapbase.cpp:209
+msgid "MacTelugu"
+msgstr "MacTelugu"
+
+#: ../src/common/fmapbase.cpp:210
+msgid "MacKannada"
+msgstr "MacKannada"
+
+#: ../src/common/fmapbase.cpp:211
+msgid "MacMalayalam"
+msgstr "MacMalayalam"
+
+#: ../src/common/fmapbase.cpp:212
+msgid "MacSinhalese"
+msgstr "MacSinhalese"
+
+#: ../src/common/fmapbase.cpp:213
+msgid "MacBurmese"
+msgstr "MacBurmese"
+
+#: ../src/common/fmapbase.cpp:214
+msgid "MacKhmer"
+msgstr "MacKhmer"
+
+#: ../src/common/fmapbase.cpp:215
+msgid "MacThai"
+msgstr "MacThai"
+
+#: ../src/common/fmapbase.cpp:216
+msgid "MacLaotian"
+msgstr "MacLaotian"
+
+#: ../src/common/fmapbase.cpp:217
+msgid "MacGeorgian"
+msgstr "MacGeorgian"
+
+#: ../src/common/fmapbase.cpp:218
+msgid "MacArmenian"
+msgstr "MacArmenian"
+
+#: ../src/common/fmapbase.cpp:219
+msgid "MacChineseSimp"
+msgstr "MacChineseSimp"
+
+#: ../src/common/fmapbase.cpp:220
+msgid "MacTibetan"
+msgstr "MacTibetan"
+
+#: ../src/common/fmapbase.cpp:221
+msgid "MacMongolian"
+msgstr "MacMongolian"
+
+#: ../src/common/fmapbase.cpp:222
+msgid "MacEthiopic"
+msgstr "MacEthiopic"
+
+#: ../src/common/fmapbase.cpp:223
+msgid "MacCentralEurRoman"
+msgstr "MacCentralEurRoman"
+
+#: ../src/common/fmapbase.cpp:224
+msgid "MacVietnamese"
+msgstr "MacVietnamese"
+
+#: ../src/common/fmapbase.cpp:225
+msgid "MacExtArabic"
+msgstr "MacExtArabic"
+
+#: ../src/common/fmapbase.cpp:226
+msgid "MacSymbol"
+msgstr "MacSymbol"
+
+#: ../src/common/fmapbase.cpp:227
+msgid "MacDingbats"
+msgstr "MacDingbats"
+
+#: ../src/common/fmapbase.cpp:228
+msgid "MacTurkish"
+msgstr "MacTurkish"
+
+#: ../src/common/fmapbase.cpp:229
+msgid "MacCroatian"
+msgstr "MacCroatian"
+
+#: ../src/common/fmapbase.cpp:230
+msgid "MacIcelandic"
+msgstr "MacIcelandic"
+
+#: ../src/common/fmapbase.cpp:231
+msgid "MacRomanian"
+msgstr "MacRomanian"
+
+#: ../src/common/fmapbase.cpp:232
+msgid "MacCeltic"
+msgstr "MacCeltic"
+
+#: ../src/common/fmapbase.cpp:233
+msgid "MacGaelic"
+msgstr "MacGaelic"
+
+#: ../src/common/fmapbase.cpp:234
+msgid "MacKeyboardGlyphs"
+msgstr "MacKeyboardGlyphs"
+
+#: ../src/common/fmapbase.cpp:791
+msgid "Default encoding"
+msgstr "निर्धारित अनुसंहिता"
+
+#: ../src/common/fmapbase.cpp:805
+#, c-format
+msgid "Unknown encoding (%d)"
+msgstr "अज्ञात अनुसंहिता (%d)"
+
+#: ../src/common/fmapbase.cpp:815 ../src/richtext/richtextstyles.cpp:776
+msgid "default"
+msgstr "निर्धारित"
+
+#: ../src/common/fmapbase.cpp:829
+#, c-format
+msgid "unknown-%d"
+msgstr "अज्ञात -%d"
+
+#: ../src/common/fontcmn.cpp:924 ../src/common/fontcmn.cpp:1130
+msgid "underlined"
+msgstr "अधोरेखाङ्कित"
+
+#: ../src/common/fontcmn.cpp:929
+#, fuzzy
+msgid " strikethrough"
+msgstr "strikethrough"
+
+#: ../src/common/fontcmn.cpp:942
+msgid " thin"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:946
+#, fuzzy
+msgid " extra light"
+msgstr "हलुको"
+
+#: ../src/common/fontcmn.cpp:950
+msgid " light"
+msgstr "हलुको"
+
+#: ../src/common/fontcmn.cpp:954
+msgid " medium"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:958
+#, fuzzy
+msgid " semi bold"
+msgstr "मोटो"
+
+#: ../src/common/fontcmn.cpp:962
+msgid " bold"
+msgstr "मोटो"
+
+#: ../src/common/fontcmn.cpp:966
+#, fuzzy
+msgid " extra bold"
+msgstr "मोटो"
+
+#: ../src/common/fontcmn.cpp:970
+msgid " heavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:974
+msgid " extra heavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:990
+msgid " italic"
+msgstr "डल्केको"
+
+#: ../src/common/fontcmn.cpp:1134
+msgid "strikethrough"
+msgstr "strikethrough"
+
+#: ../src/common/fontcmn.cpp:1143
+msgid "thin"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1156
+#, fuzzy
+msgid "extralight"
+msgstr "हलुको"
+
+#: ../src/common/fontcmn.cpp:1161
+msgid "light"
+msgstr "हलुको"
+
+#: ../src/common/fontcmn.cpp:1169 ../src/richtext/richtextstyles.cpp:775
+msgid "normal"
+msgstr "सामान्य"
+
+#: ../src/common/fontcmn.cpp:1174
+msgid "medium"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1179 ../src/common/fontcmn.cpp:1199
+#, fuzzy
+msgid "semibold"
+msgstr "मोटो"
+
+#: ../src/common/fontcmn.cpp:1184
+msgid "bold"
+msgstr "मोटो"
+
+#: ../src/common/fontcmn.cpp:1194
+#, fuzzy
+msgid "extrabold"
+msgstr "मोटो"
+
+#: ../src/common/fontcmn.cpp:1204
+msgid "heavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1212
+msgid "extraheavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1217
+msgid "italic"
+msgstr "डल्केको"
+
+#: ../src/common/fontmap.cpp:195
+msgid ": unknown charset"
+msgstr ": अज्ञात पाठ समूह"
+
+#: ../src/common/fontmap.cpp:199
+#, c-format
+msgid ""
+"The charset '%s' is unknown. You may select\n"
+"another charset to replace it with or choose\n"
+"[Cancel] if it cannot be replaced"
+msgstr ""
+"वर्णसेट '%s' चिन्न सकिएन । \n"
+" तपाइले यसको सट्टामा अर्को वर्णसेट छान्न सक्नु हुन्छ।\n"
+" अथवा अर्को साट्न सकिदैन भने [Cancel] गर्नु होस् । "
+
+#: ../src/common/fontmap.cpp:241
+#, c-format
+msgid "Failed to remember the encoding for the charset '%s'."
+msgstr "वर्णसेट '%s' को अनुसंहिता सम्झन सकिएन ।"
+
+#: ../src/common/fontmap.cpp:321
+msgid "can't load any font, aborting"
+msgstr "कुनै पनि वरणाकृतिलाई वहन गर्न सकिँदैन, परित्याग गरिदैं छ"
+
+#: ../src/common/fontmap.cpp:409
+msgid ": unknown encoding"
+msgstr ": अज्ञात अनुसंहिता"
+
+#: ../src/common/fontmap.cpp:417
+#, c-format
+msgid ""
+"No font for displaying text in encoding '%s' found,\n"
+"but an alternative encoding '%s' is available.\n"
+"Do you want to use this encoding (otherwise you will have to choose another "
+"one)?"
+msgstr ""
+"encoding '%s' मा पाठहरूलाई देखाउन कुनै पनि वर्णाकृति पाइएन । \n"
+"तर वैकल्पिक अनुसंहिता '%s' भने उपलब्ध छ । \n"
+"के तपाइ यो अनुसंहिता लाई प्रयोग गर्न चाहनु हुन्छ (अन्यथा तपाइले अर्कै छान्नु पर्छ)?"
+
+#: ../src/common/fontmap.cpp:422
+#, c-format
+msgid ""
+"No font for displaying text in encoding '%s' found.\n"
+"Would you like to select a font to be used for this encoding\n"
+"(otherwise the text in this encoding will not be shown correctly)?"
+msgstr ""
+"अनुसंहिता '%s' मा पाठहरू देखाउन कुनै पनि वर्णाकृति पाईएन ।\n"
+"के तपाई यो अनुसंहितामा धेखाउनका लागि कुनै वर्णाकृति चयन गर्नु हुन्छ? \n"
+"(अन्यथा यो अनुसंहितामा कुनै पनि पाठ शुद्ध रूपमा देखाउन सकिदैन)?"
+
+#: ../src/common/fs_mem.cpp:169
+#, c-format
+msgid "Memory VFS already contains file '%s'!"
+msgstr "भण्डार VFS मा पहिले नै फाइल '%s' राखिएको छ!"
+
+#: ../src/common/fs_mem.cpp:232
+#, c-format
+msgid "Trying to remove file '%s' from memory VFS, but it is not loaded!"
+msgstr "फाइल '%s' लाई VFS भण्डारबाट हटाउन कोसिस हुँदैछ, तर यो वहन भएकै छैन!"
+
+#: ../src/common/fs_mem.cpp:262
+#, c-format
+msgid "Failed to store image '%s' to memory VFS!"
+msgstr "तस्विर '%s' लाई VFS भण्डारमा सञ्चय गर्न सकिएन ।!"
+
+#: ../src/common/ftp.cpp:197
+msgid "Timeout while waiting for FTP server to connect, try passive mode."
+msgstr "FTP सर्बरको जडानलाई पर्ख दा समय सकियो, पास मुद्रा कोसिस गर्नु होस् ।"
+
+#: ../src/common/ftp.cpp:399
+#, c-format
+msgid "Failed to set FTP transfer mode to %s."
+msgstr "FTP सरुवा मुद्रालाई %s मा तय गर्न सकिएन ।"
+
+#: ../src/common/ftp.cpp:400 ../src/richtext/richtextsymboldlg.cpp:432
+msgid "ASCII"
+msgstr "ASCII"
+
+#: ../src/common/ftp.cpp:400
+msgid "binary"
+msgstr "binary"
+
+#: ../src/common/ftp.cpp:608
+msgid "The FTP server doesn't support the PORT command."
+msgstr "FTP सर्बरले पोर्ट आदेश समर्थन गर्दैन ।"
+
+#: ../src/common/ftp.cpp:622
+msgid "The FTP server doesn't support passive mode."
+msgstr "FTP सर्बरले निष्क्रिय मुद्रा समर्थन गर्दैन ।"
+
+#: ../src/common/gifdecod.cpp:822
+#, c-format
+msgid "Incorrect GIF frame size (%u, %d) for the frame #%u"
+msgstr "अशुद्ध GIF फ्रेम आकार (%u, %d) (फ्रेम #%u का लागि ) "
+
+#: ../src/common/glcmn.cpp:108
+msgid "Failed to allocate colour for OpenGL"
+msgstr "OpenGL को लागि रङ्ग उपलब्ध गराउन सकिएन ।"
+
+#: ../src/common/headerctrlcmn.cpp:57
+msgid "Please select the columns to show and define their order:"
+msgstr "कृपया देखाउने महलहरू चयन गरेर तिनिहरूको क्रम उल्लेख गर्नु होस्:"
+
+#: ../src/common/headerctrlcmn.cpp:58
+msgid "Customize Columns"
+msgstr "आफ्नो अनुकूलको महल बनाउ "
+
+#: ../src/common/headerctrlcmn.cpp:304
+msgid "&Customize..."
+msgstr "&आफू अनुकूल बनाउ.."
+
+#: ../src/common/hyperlnkcmn.cpp:132
+#, fuzzy, c-format
+msgid "Failed to open URL \"%s\" in the default browser"
+msgstr "निर्धारित Browser मा \"%s\" खोल्न सकिएन ।"
+
+#: ../src/common/iconbndl.cpp:195
+#, c-format
+msgid "Failed to load image %%d from file '%s'."
+msgstr "तस्विर %%d फाइल'%s' बाट वहन गर्न सकिएन "
+
+#: ../src/common/iconbndl.cpp:203
+#, c-format
+msgid "Failed to load image %d from stream."
+msgstr "stream बाट %d तस्विर वहन गर्न सकिएन "
+
+#: ../src/common/iconbndl.cpp:221
+#, fuzzy, c-format
+msgid "Failed to load icons from resource '%s'."
+msgstr "श्रोतबाट %s प्रतिमा वहन गर्न सकिएन "
+
+#: ../src/common/imagbmp.cpp:97
+msgid "BMP: Couldn't save invalid image."
+msgstr "BMP: चित्र गल्ती भएकोले बचत भएन ।"
+
+#: ../src/common/imagbmp.cpp:137
+msgid "BMP: wxImage doesn't have own wxPalette."
+msgstr "BMP: wxImage को आफ्नै wxPalette छैन ।"
+
+#: ../src/common/imagbmp.cpp:243
+msgid "BMP: Couldn't write the file (Bitmap) header."
+msgstr "BMP: फाइल (Bitmap) को शीर्षक लेख्न सकिएन ।"
+
+#: ../src/common/imagbmp.cpp:266
+msgid "BMP: Couldn't write the file (BitmapInfo) header."
+msgstr "BMP: फाइल (Bitmap जानकारी) शीर्षक लेख्न सकिएन ।"
+
+#: ../src/common/imagbmp.cpp:353
+msgid "BMP: Couldn't write RGB color map."
+msgstr "BMP: RGB रङ्गिन नक्सा लेख्न सकेन"
+
+#: ../src/common/imagbmp.cpp:487
+msgid "BMP: Couldn't write data."
+msgstr "BMP: तथ्याङ्क लेख्न सकिएन ।"
+
+#: ../src/common/imagbmp.cpp:561 ../src/common/imagbmp.cpp:642
+msgid "BMP: Couldn't allocate memory."
+msgstr "BMP: भण्डार उपलब्ध गराउन सकेन ।"
+
+#: ../src/common/imagbmp.cpp:1041
+msgid "DIB Header: Image width > 32767 pixels for file."
+msgstr "DIB शीर्षक: फाइलको लागि तस्विर छोडाइ >32767 pixels"
+
+#: ../src/common/imagbmp.cpp:1049
+msgid "DIB Header: Image height > 32767 pixels for file."
+msgstr "DIB शीर्षक: फाइलको लागि तस्विरको उचाइ > 32767 pixels "
+
+#: ../src/common/imagbmp.cpp:1081
+msgid "DIB Header: Unknown bitdepth in file."
+msgstr "DIB शीर्षक: फाइलमा अज्ञात bitdepth "
+
+#: ../src/common/imagbmp.cpp:1156
+msgid "DIB Header: Unknown encoding in file."
+msgstr "DIB शीर्षक: फाइलमा अज्ञात अनुसंहिता"
+
+#: ../src/common/imagbmp.cpp:1165
+msgid "DIB Header: Encoding doesn't match bitdepth."
+msgstr "DIB शीर्षक: अनुसंहिता bitdepth सित मिल्दैन "
+
+#: ../src/common/imagbmp.cpp:1180
+#, c-format
+msgid "BMP Header: Invalid number of colors (%d)."
+msgstr ""
+
+#: ../src/common/imagbmp.cpp:1273
+msgid "Error in reading image DIB."
+msgstr "तस्विरको डिपो ट पढ्न गल्ती भयो ।"
+
+#: ../src/common/imagbmp.cpp:1294
+msgid "ICO: Error in reading mask DIB."
+msgstr "ICO: मखुन्डो खण्ड पढाइमा गल्ती "
+
+#: ../src/common/imagbmp.cpp:1353
+msgid "ICO: Image too tall for an icon."
+msgstr "ICO: प्रतिमाको लागि तस्विर धेरै अग्लो भयो"
+
+#: ../src/common/imagbmp.cpp:1361
+msgid "ICO: Image too wide for an icon."
+msgstr "ICO: प्रतिमाको लागि तस्विर धेरै चौडा भयो"
+
+#: ../src/common/imagbmp.cpp:1388 ../src/common/imagbmp.cpp:1488
+#: ../src/common/imagbmp.cpp:1503 ../src/common/imagbmp.cpp:1514
+#: ../src/common/imagbmp.cpp:1528 ../src/common/imagbmp.cpp:1576
+#: ../src/common/imagbmp.cpp:1591 ../src/common/imagbmp.cpp:1605
+#: ../src/common/imagbmp.cpp:1616
+msgid "ICO: Error writing the image file!"
+msgstr "ICO: तस्विर फाइल लेखाइमा गल्ती !"
+
+#: ../src/common/imagbmp.cpp:1701
+msgid "ICO: Invalid icon index."
+msgstr "ICO: प्रतिमा अनुक्रमणिका मिलेन"
+
+#: ../src/common/image.cpp:2410
+msgid "Image and mask have different sizes."
+msgstr "तस्विर र मखुन्डो फरक फरक आकारका छन् ।"
+
+#: ../src/common/image.cpp:2418 ../src/common/image.cpp:2459
+msgid "No unused colour in image being masked."
+msgstr "तस्विरमा प्रयोग नगरिएको रङ्ग मकुन्डोमा चलाएन ।"
+
+#: ../src/common/image.cpp:2641
+#, c-format
+msgid "Failed to load bitmap \"%s\" from resources."
+msgstr "श्रोतबाट %s BitMap वहन गर्न सकिएन "
+
+#: ../src/common/image.cpp:2650
+#, c-format
+msgid "Failed to load icon \"%s\" from resources."
+msgstr "श्रोतबाट %s प्रतिमा वहन गर्न सकिएन "
+
+#: ../src/common/image.cpp:2728 ../src/common/image.cpp:2747
+#, c-format
+msgid "Failed to load image from file \"%s\"."
+msgstr "फाइल \"%s\" बाट तस्विर वहन गर्न सकिएन "
+
+#: ../src/common/image.cpp:2761
+#, c-format
+msgid "Can't save image to file '%s': unknown extension."
+msgstr "अज्ञात Extension भएको फाइल '%s' मा चित्र बचत गर्न सकिँदैन ।"
+
+#: ../src/common/image.cpp:2869
+msgid "No handler found for image type."
+msgstr "तस्विर किसिमको लागि कुनै चालक पाइ एन ।"
+
+#: ../src/common/image.cpp:2877 ../src/common/image.cpp:3000
+#: ../src/common/image.cpp:3066
+#, c-format
+msgid "No image handler for type %d defined."
+msgstr "तोकिएको %d किसिमका लागि तस्विर चालक छैन ।"
+
+#: ../src/common/image.cpp:2887
+#, c-format
+msgid "Image file is not of type %d."
+msgstr "तस्विर फाइल %d किसिमको छैन ।"
+
+#: ../src/common/image.cpp:2970
+msgid "Can't automatically determine the image format for non-seekable input."
+msgstr "खोज्न नसकिने Input चित्रको बनोट आफै पता लगाउन सकिँदैन ।"
+
+#: ../src/common/image.cpp:2988
+msgid "Unknown image data format."
+msgstr "अज्ञात तस्विर तथ्याङ्क बनोट"
+
+#: ../src/common/image.cpp:3009
+#, c-format
+msgid "This is not a %s."
+msgstr "यो %s होइन ।"
+
+#: ../src/common/image.cpp:3032 ../src/common/image.cpp:3080
+#, c-format
+msgid "No image handler for type %s defined."
+msgstr "तोकिएको %s किसिमका लागि तस्विर चालक छैन ।"
+
+#: ../src/common/image.cpp:3041
+#, c-format
+msgid "Image is not of type %s."
+msgstr "तस्विर %s किसिमको छैन ।"
+
+#: ../src/common/image.cpp:3509
+#, c-format
+msgid "Failed to check format of image file \"%s\"."
+msgstr "तस्विर फाइल \"%s\" को स्वरूप जाँच्न सकिएन ।"
+
+#: ../src/common/imaggif.cpp:124
+msgid "GIF: error in GIF image format."
+msgstr "GIF: GIF तस्विरको स्वरूप मिलेन"
+
+#: ../src/common/imaggif.cpp:129
+msgid "GIF: not enough memory."
+msgstr "GIF: यथेष्ट भण्डार छैन"
+
+#: ../src/common/imaggif.cpp:134
+msgid "GIF: data stream seems to be truncated."
+msgstr "GIF: तथ्याङ्क काटकुट गरेको जस्तो छ ।"
+
+#: ../src/common/imaggif.cpp:240
+msgid "Couldn't initialize GIF hash table."
+msgstr "GIF hash तालिका सुरु गर्न सकिएन"
+
+#: ../src/common/imagiff.cpp:739
+msgid "IFF: error in IFF image format."
+msgstr "IFF: IFF तस्विर स्वरूपमा गल्ती"
+
+#: ../src/common/imagiff.cpp:742
+msgid "IFF: not enough memory."
+msgstr "IFF: यथेष्ट भण्डार छैन "
+
+#: ../src/common/imagiff.cpp:745
+msgid "IFF: unknown error!!!"
+msgstr "IFF: अज्ञात गल्ती!!!"
+
+#: ../src/common/imagiff.cpp:755
+msgid "IFF: data stream seems to be truncated."
+msgstr "IFF: तथ्याङ्क काटकुट भए जस्तो छ ।"
+
+#: ../src/common/imagjpeg.cpp:258
+msgid "JPEG: Couldn't load - file is probably corrupted."
+msgstr "JPEG: वहन गर्न सकिएन- सम्भवतः फाइल बिग्रिएको छ ।"
+
+#: ../src/common/imagjpeg.cpp:437
+msgid "JPEG: Couldn't save image."
+msgstr "JPEG: तस्विर बचत गर्न सकिएन ।"
+
+#: ../src/common/imagpcx.cpp:439
+msgid "PCX: this is not a PCX file."
+msgstr "PCX: यो PCX फाइल होइन ।"
+
+#: ../src/common/imagpcx.cpp:453
+msgid "PCX: image format unsupported"
+msgstr "PCX: तस्विर स्वरूप समर्थित छैन ।"
+
+#: ../src/common/imagpcx.cpp:454 ../src/common/imagpcx.cpp:477
+msgid "PCX: couldn't allocate memory"
+msgstr "PCX: भण्डार छुट्याउन सकेन ।"
+
+#: ../src/common/imagpcx.cpp:455
+msgid "PCX: version number too low"
+msgstr "PCX: संस्करण सङ्ख्या धेरै सानो भयो ।"
+
+#: ../src/common/imagpcx.cpp:456 ../src/common/imagpcx.cpp:478
+msgid "PCX: unknown error !!!"
+msgstr "PCX: अज्ञात गल्ती !!!"
+
+#: ../src/common/imagpcx.cpp:476
+msgid "PCX: invalid image"
+msgstr "PCX: नमिल्दो तस्विर "
+
+#: ../src/common/imagpng.cpp:385
+#, c-format
+msgid "Unknown PNG resolution unit %d"
+msgstr "अज्ञात PNG resolution एकाइ %d"
+
+#: ../src/common/imagpng.cpp:439
+msgid "Couldn't load a PNG image - file is corrupted or not enough memory."
+msgstr "PNG तस्विर- फाइल बिग्रिएको छ अथवा चाहिने जति भण्डार छैन"
+
+#: ../src/common/imagpng.cpp:513 ../src/common/imagpng.cpp:524
+#: ../src/common/imagpng.cpp:534
+msgid "Couldn't save PNG image."
+msgstr "PNG तस्विर बचत गर्न सकिएन"
+
+#: ../src/common/imagpnm.cpp:71
+msgid "PNM: File format is not recognized."
+msgstr "PNM: फाइलको स्वरूप पहिचान गर्न सकिएन ।"
+
+#: ../src/common/imagpnm.cpp:89
+msgid "PNM: Couldn't allocate memory."
+msgstr "PNM: भण्डार छुट्याउन सकिएन ।"
+
+#: ../src/common/imagpnm.cpp:111 ../src/common/imagpnm.cpp:134
+#: ../src/common/imagpnm.cpp:156
+msgid "PNM: File seems truncated."
+msgstr "PNM: फाइल काटकुट भए जस्तो छ ।"
+
+#: ../src/common/imagtiff.cpp:69
+#, c-format
+msgid " (in module \"%s\")"
+msgstr "(Module \"%s\"मा)"
+
+#: ../src/common/imagtiff.cpp:304
+msgid "TIFF: Error loading image."
+msgstr "TIFF: तस्विर वहनमा गल्ती"
+
+#: ../src/common/imagtiff.cpp:314
+msgid "Invalid TIFF image index."
+msgstr "नमिल्दो TIFF तस्विर अनुक्रमणिका"
+
+#: ../src/common/imagtiff.cpp:358
+msgid "TIFF: Image size is abnormally big."
+msgstr "TIFF: तस्विरको आकार असाधारण ठूलो छ ।"
+
+#: ../src/common/imagtiff.cpp:372 ../src/common/imagtiff.cpp:385
+#: ../src/common/imagtiff.cpp:769
+msgid "TIFF: Couldn't allocate memory."
+msgstr "TIFF: भण्डार उपलब्ध गराउन सकिएन ।"
+
+#: ../src/common/imagtiff.cpp:471
+msgid "TIFF: Error reading image."
+msgstr "TIFF: तस्विर पढ्नमा गल्ती "
+
+#: ../src/common/imagtiff.cpp:532
+#, c-format
+msgid "Unknown TIFF resolution unit %d ignored"
+msgstr "अज्ञात TIFF resolution एकाइ %d लाई बेवास्ता गरियो "
+
+#: ../src/common/imagtiff.cpp:611
+msgid "TIFF: Error saving image."
+msgstr "TIFF: तस्विर बचतमा गल्ती "
+
+#: ../src/common/imagtiff.cpp:868
+msgid "TIFF: Error writing image."
+msgstr "TIFF: तस्विर लेखाइमा गल्ती "
+
+#: ../src/common/imagtiff.cpp:881
+#, fuzzy
+msgid "TIFF: Error flushing data."
+msgstr "TIFF: तस्विर बचतमा गल्ती "
+
+#: ../src/common/imagwebp.cpp:56
+msgid "WebP: Invalid data (failed to get features)."
+msgstr ""
+
+#: ../src/common/imagwebp.cpp:65
+msgid "WebP: Allocating image memory failed."
+msgstr ""
+
+#: ../src/common/imagwebp.cpp:82
+msgid "WebP: Decoding RGBA image data failed."
+msgstr ""
+
+#: ../src/common/imagwebp.cpp:98
+msgid "WebP: Decoding RGB image data failed."
+msgstr ""
+
+#: ../src/common/imagwebp.cpp:113 ../src/common/imagwebp.cpp:201
+msgid "WebP: Allocating stream buffer failed."
+msgstr ""
+
+#: ../src/common/imagwebp.cpp:131
+#, fuzzy
+msgid "WebP: Failed to parse container data."
+msgstr "क्लिप पाटीमा तथ्याङ्क तय गर्न सकिएन ।"
+
+#: ../src/common/imagwebp.cpp:222
+#, fuzzy
+msgid "WebP: Error decoding animation."
+msgstr "config विकल्प पढ्न गल्ती भयो ।"
+
+#: ../src/common/imagwebp.cpp:240
+msgid "WebP: Error getting next animation frame."
+msgstr ""
+
+#: ../src/common/init.cpp:172
+#, c-format
+msgid ""
+"Command line argument %d couldn't be converted to Unicode and will be "
+"ignored."
+msgstr "आदेश लाइन argument %d लाई युनिकोडमा फेर्न नसकि एकोले बेवास्ता गरियो ।"
+
+#: ../src/common/init.cpp:344
+msgid "Initialization failed in post init, aborting."
+msgstr "post init मा सुरुवात असफल भयो, त्यसैले तुहिधै छ"
+
+#: ../src/common/intl.cpp:378
+#, c-format
+msgid "Cannot set locale to language \"%s\"."
+msgstr "भाषा \"%s\" लाइ स्थानीयतामा सेट गर्न सकिँदैन ।"
+
+#: ../src/common/log.cpp:232
+msgid "Error: "
+msgstr "गल्ती: "
+
+#: ../src/common/log.cpp:236
+msgid "Warning: "
+msgstr "चेतावनी: "
+
+#: ../src/common/log.cpp:284
+msgid "The previous message repeated once."
+msgstr " पछिल्लो सन्देश एक पटक दोहोरियो ।"
+
+#: ../src/common/log.cpp:291
+#, fuzzy, c-format
+msgid "The previous message repeated %u time."
+msgid_plural "The previous message repeated %u times."
+msgstr[0] "अघिल्लो सन्देश %lu पटक दोहोरियो ।"
+msgstr[1] "अघिल्लो सन्देश %lu पटक दोहोरियो ।"
+
+#: ../src/common/log.cpp:319
+#, fuzzy, c-format
+msgid "Last repeated message (\"%s\", %u time) wasn't output"
+msgid_plural "Last repeated message (\"%s\", %u times) wasn't output"
+msgstr[0] "दोहोरिएको अन्तिम सन्देश (\"%s\", %lu पटक) प्रतिफल थिएन"
+msgstr[1] "दोहोरिएको अन्तिम सन्देश (\"%s\", %lu पटकमात्र) प्रतिफल थिएन"
+
+#: ../src/common/log.cpp:435
+#, c-format
+msgid " (error %ld: %s)"
+msgstr " (गल्ती %ld: %s)"
+
+#: ../src/common/lzmastream.cpp:121
+#, fuzzy
+msgid "Failed to allocate memory for LZMA decompression."
+msgstr "OpenGL को लागि रङ्ग उपलब्ध गराउन सकिएन ।"
+
+#: ../src/common/lzmastream.cpp:125
+#, c-format
+msgid "Failed to initialize LZMA decompression: unexpected error %u."
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:179
+msgid "input is not in XZ format"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:183
+msgid "input compressed using unknown XZ option"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:188
+msgid "input is corrupted"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:192
+#, fuzzy
+msgid "unknown decompression error"
+msgstr "दबाब विहीनता गल्ती"
+
+#: ../src/common/lzmastream.cpp:196
+#, fuzzy, c-format
+msgid "LZMA decompression error: %s"
+msgstr "दबाब विहीनता गल्ती"
+
+#: ../src/common/lzmastream.cpp:231
+#, fuzzy
+msgid "Failed to allocate memory for LZMA compression."
+msgstr "OpenGL को लागि रङ्ग उपलब्ध गराउन सकिएन ।"
+
+#: ../src/common/lzmastream.cpp:235
+#, c-format
+msgid "Failed to initialize LZMA compression: unexpected error %u."
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:267 ../src/common/lzmastream.cpp:342
+#: ../src/html/chm.cpp:336
+msgid "out of memory"
+msgstr "भण्डार क्षमता भन्दा बाहिर"
+
+#: ../src/common/lzmastream.cpp:276 ../src/common/lzmastream.cpp:346
+#, fuzzy
+msgid "unknown compression error"
+msgstr "दबाब गल्ती"
+
+#: ../src/common/lzmastream.cpp:280
+#, fuzzy, c-format
+msgid "LZMA compression error: %s"
+msgstr "दबाब गल्ती"
+
+#: ../src/common/lzmastream.cpp:350
+#, c-format
+msgid "LZMA compression error when flushing output: %s"
+msgstr ""
+
+#: ../src/common/mimecmn.cpp:167
+#, c-format
+msgid "Unmatched '{' in an entry for mime type %s."
+msgstr "Mime किसिम %s को entry मा '{' मल्दैन ।"
+
+#: ../src/common/module.cpp:76
+#, c-format
+msgid "Circular dependency involving module \"%s\" detected."
+msgstr "चक्री य module \"%s\" पाइयो"
+
+#: ../src/common/module.cpp:128
+#, c-format
+msgid "Dependency \"%s\" of module \"%s\" doesn't exist."
+msgstr "आश्रय \"%s\" मोड्युल \"%s\" मा छदै छैन"
+
+#: ../src/common/module.cpp:137
+#, c-format
+msgid "Module \"%s\" initialization failed"
+msgstr "Module \"%s\" को सुरुवात असफल भयो ।failed"
+
+#: ../src/common/msgout.cpp:96
+msgid "Message"
+msgstr "सन्देश"
+
+#: ../src/common/paper.cpp:70
+msgid "Letter, 8 1/2 x 11 in"
+msgstr "Letter, 8 1/2 x 11इन्च"
+
+#: ../src/common/paper.cpp:71
+msgid "Legal, 8 1/2 x 14 in"
+msgstr "Legal, 8 1/2 x 14इन्च"
+
+#: ../src/common/paper.cpp:72
+msgid "A4 sheet, 210 x 297 mm"
+msgstr "A4 शीट, 210 x 297 मिमी"
+
+#: ../src/common/paper.cpp:73
+msgid "C sheet, 17 x 22 in"
+msgstr "C शीट, 17 x 22 इन्च"
+
+#: ../src/common/paper.cpp:74
+msgid "D sheet, 22 x 34 in"
+msgstr "D शीट, 22 x 34इन्च"
+
+#: ../src/common/paper.cpp:75
+msgid "E sheet, 34 x 44 in"
+msgstr "E शीट, 34 x 44इन्च"
+
+#: ../src/common/paper.cpp:76
+msgid "Letter Small, 8 1/2 x 11 in"
+msgstr "Letter Small, 8 1/2 x 11इन्च"
+
+#: ../src/common/paper.cpp:77
+msgid "Tabloid, 11 x 17 in"
+msgstr "Tabloid, 11 x 17इन्च"
+
+#: ../src/common/paper.cpp:78
+msgid "Ledger, 17 x 11 in"
+msgstr "लेजर , 17 x 11इन्च"
+
+#: ../src/common/paper.cpp:79
+msgid "Statement, 5 1/2 x 8 1/2 in"
+msgstr "बयान, 5 1/2 x 8 1/2इन्च"
+
+#: ../src/common/paper.cpp:80
+msgid "Executive, 7 1/4 x 10 1/2 in"
+msgstr "Executive, 7 1/4 x 10 1/2इन्च"
+
+#: ../src/common/paper.cpp:81
+msgid "A3 sheet, 297 x 420 mm"
+msgstr "A3 शीट, 297 x 420 मिमी"
+
+#: ../src/common/paper.cpp:82
+msgid "A4 small sheet, 210 x 297 mm"
+msgstr "A4 small शीट, 210 x 297 मिमी"
+
+#: ../src/common/paper.cpp:83
+msgid "A5 sheet, 148 x 210 mm"
+msgstr "A5 शीट, 148 x 210 मिमी"
+
+#: ../src/common/paper.cpp:84
+msgid "B4 sheet, 250 x 354 mm"
+msgstr "B4 शीट, 250 x 354 मिमी"
+
+#: ../src/common/paper.cpp:85
+msgid "B5 sheet, 182 x 257 millimeter"
+msgstr "B5 शीट, 182 x 257 millimeter"
+
+#: ../src/common/paper.cpp:86
+msgid "Folio, 8 1/2 x 13 in"
+msgstr "Folio, 8 1/2 x 13इन्च"
+
+#: ../src/common/paper.cpp:87
+msgid "Quarto, 215 x 275 mm"
+msgstr "Quarto, 215 x 275 मिमी"
+
+#: ../src/common/paper.cpp:88
+msgid "10 x 14 in"
+msgstr "10 x 14इन्च"
+
+#: ../src/common/paper.cpp:89
+msgid "11 x 17 in"
+msgstr "11 x 17इन्च"
+
+#: ../src/common/paper.cpp:90
+msgid "Note, 8 1/2 x 11 in"
+msgstr "टिप्पणी, 8 1/2 x 11इन्च"
+
+#: ../src/common/paper.cpp:91
+msgid "#9 Envelope, 3 7/8 x 8 7/8 in"
+msgstr "#9 खाम, 3 7/8 x 8 7/8 इन्च"
+
+#: ../src/common/paper.cpp:92
+msgid "#10 Envelope, 4 1/8 x 9 1/2 in"
+msgstr "#10 खाम, 4 1/8 x 9 1/2 इन्च"
+
+#: ../src/common/paper.cpp:93
+msgid "#11 Envelope, 4 1/2 x 10 3/8 in"
+msgstr "#11 खाम, 4 1/2 x 10 3/8 इन्च"
+
+#: ../src/common/paper.cpp:94
+msgid "#12 Envelope, 4 3/4 x 11 in"
+msgstr "#12 खाम, 4 3/4 x 11 इन्च"
+
+#: ../src/common/paper.cpp:95
+msgid "#14 Envelope, 5 x 11 1/2 in"
+msgstr "#14 खाम, 5 x 11 1/2 इन्च"
+
+#: ../src/common/paper.cpp:96
+msgid "DL Envelope, 110 x 220 mm"
+msgstr "DL खाम, 110 x 220 मिमी"
+
+#: ../src/common/paper.cpp:97
+msgid "C5 Envelope, 162 x 229 mm"
+msgstr "C5 खाम, 162 x 229 मिमी"
+
+#: ../src/common/paper.cpp:98
+msgid "C3 Envelope, 324 x 458 mm"
+msgstr "C3 खाम, 324 x 458 मिमी"
+
+#: ../src/common/paper.cpp:99
+msgid "C4 Envelope, 229 x 324 mm"
+msgstr "C4 खाम, 229 x 324 मिमी"
+
+#: ../src/common/paper.cpp:100
+msgid "C6 Envelope, 114 x 162 mm"
+msgstr "C6 खाम, 114 x 162 मिमी"
+
+#: ../src/common/paper.cpp:101
+msgid "C65 Envelope, 114 x 229 mm"
+msgstr "C65 खाम, 114 x 229 मिमी"
+
+#: ../src/common/paper.cpp:102
+msgid "B4 Envelope, 250 x 353 mm"
+msgstr "B4 खाम, 250 x 353 मिमी"
+
+#: ../src/common/paper.cpp:103
+msgid "B5 Envelope, 176 x 250 mm"
+msgstr "B5 खाम, 176 x 250 मिमी"
+
+#: ../src/common/paper.cpp:104
+msgid "B6 Envelope, 176 x 125 mm"
+msgstr "B6 खाम, 176 x 125 मिमी"
+
+#: ../src/common/paper.cpp:105
+msgid "Italy Envelope, 110 x 230 mm"
+msgstr "Italy खाम, 110 x 230 मिमी"
+
+#: ../src/common/paper.cpp:106
+msgid "Monarch Envelope, 3 7/8 x 7 1/2 in"
+msgstr "आधुनिक खाम, 3 7/8 x 7 1/2इन्च"
+
+#: ../src/common/paper.cpp:107
+msgid "6 3/4 Envelope, 3 5/8 x 6 1/2 in"
+msgstr "6 3/4 खाम, 3 5/8 x 6 1/2 इन्च"
+
+#: ../src/common/paper.cpp:108
+msgid "US Std Fanfold, 14 7/8 x 11 in"
+msgstr "US Std Fanfold, 14 7/8 x 11इन्च"
+
+#: ../src/common/paper.cpp:109
+msgid "German Std Fanfold, 8 1/2 x 12 in"
+msgstr "जर्मनी Std Fanfold, 8 1/2 x 12इन्च"
+
+#: ../src/common/paper.cpp:110
+msgid "German Legal Fanfold, 8 1/2 x 13 in"
+msgstr "जर्मनी Legal Fanfold, 8 1/2 x 13इन्च"
+
+#: ../src/common/paper.cpp:112
+msgid "B4 (ISO) 250 x 353 mm"
+msgstr "B4 (ISO) 250 x 353 मिमी"
+
+#: ../src/common/paper.cpp:113
+msgid "Japanese Postcard 100 x 148 mm"
+msgstr "जापानी पोस्टकार्ड Postcard 100 x 148 मिमी"
+
+#: ../src/common/paper.cpp:114
+msgid "9 x 11 in"
+msgstr "9 x 11इन्च"
+
+#: ../src/common/paper.cpp:115
+msgid "10 x 11 in"
+msgstr "10 x 11इन्च"
+
+#: ../src/common/paper.cpp:116
+msgid "15 x 11 in"
+msgstr "15 x 11इन्च"
+
+#: ../src/common/paper.cpp:117
+msgid "Envelope Invite 220 x 220 mm"
+msgstr "खाम Invite 220 x 220 मिमी"
+
+#: ../src/common/paper.cpp:118
+msgid "Letter Extra 9 1/2 x 12 in"
+msgstr "Letter Extra 9 1/2 x 12इन्च"
+
+#: ../src/common/paper.cpp:119
+msgid "Legal Extra 9 1/2 x 15 in"
+msgstr "Legal Extra 9 1/2 x 15इन्च"
+
+#: ../src/common/paper.cpp:120
+msgid "Tabloid Extra 11.69 x 18 in"
+msgstr "Tabloid Extra 11.69 x 18इन्च"
+
+#: ../src/common/paper.cpp:121
+msgid "A4 Extra 9.27 x 12.69 in"
+msgstr "A4 Extra 9.27 x 12.69इन्च"
+
+#: ../src/common/paper.cpp:122
+msgid "Letter Transverse 8 1/2 x 11 in"
+msgstr "Letter Transverse 8 1/2 x 11इन्च"
+
+#: ../src/common/paper.cpp:123
+msgid "A4 Transverse 210 x 297 mm"
+msgstr "A4 Transverse 210 x 297 मिमी"
+
+#: ../src/common/paper.cpp:124
+msgid "Letter Extra Transverse 9.275 x 12 in"
+msgstr "Letter Extra Transverse 9.275 x 12इन्च"
+
+#: ../src/common/paper.cpp:125
+msgid "SuperA/SuperA/A4 227 x 356 mm"
+msgstr "SuperA/SuperA/A4 227 x 356 mm"
+
+#: ../src/common/paper.cpp:126
+msgid "SuperB/SuperB/A3 305 x 487 mm"
+msgstr "SuperB/SuperB/A3 305 x 487 mm"
+
+#: ../src/common/paper.cpp:127
+msgid "Letter Plus 8 1/2 x 12.69 in"
+msgstr "Letter Plus 8 1/2 x 12.69इन्च"
+
+#: ../src/common/paper.cpp:128
+msgid "A4 Plus 210 x 330 mm"
+msgstr "A4 Plus 210 x 330 मिमी"
+
+#: ../src/common/paper.cpp:129
+msgid "A5 Transverse 148 x 210 mm"
+msgstr "A5 Transverse 148 x 210 मिमी"
+
+#: ../src/common/paper.cpp:130
+msgid "B5 (JIS) Transverse 182 x 257 mm"
+msgstr "B5 (JIS) Transverse 182 x 257 मिमी"
+
+#: ../src/common/paper.cpp:131
+msgid "A3 Extra 322 x 445 mm"
+msgstr "A3 Extra 322 x 445 मिमी"
+
+#: ../src/common/paper.cpp:132
+msgid "A5 Extra 174 x 235 mm"
+msgstr "A5 Extra 174 x 235 मिमी"
+
+#: ../src/common/paper.cpp:133
+msgid "B5 (ISO) Extra 201 x 276 mm"
+msgstr "B5 (ISO) Extra 201 x 276 मिमी"
+
+#: ../src/common/paper.cpp:134
+msgid "A2 420 x 594 mm"
+msgstr "A2 420 x 594 मिमी"
+
+#: ../src/common/paper.cpp:135
+msgid "A3 Transverse 297 x 420 mm"
+msgstr "A3 Transverse 297 x 420 मिमी"
+
+#: ../src/common/paper.cpp:136
+msgid "A3 Extra Transverse 322 x 445 mm"
+msgstr "A3 Extra Transverse 322 x 445 मिमी"
+
+#: ../src/common/paper.cpp:138
+msgid "Japanese Double Postcard 200 x 148 mm"
+msgstr "जापानी दोबर पोस्टकार्ड 200 x 148 मिमी"
+
+#: ../src/common/paper.cpp:139
+msgid "A6 105 x 148 mm"
+msgstr "A6 105 x 148 मिमी"
+
+#: ../src/common/paper.cpp:140
+msgid "Japanese Envelope Kaku #2"
+msgstr "जापानी खाम Kaku #2"
+
+#: ../src/common/paper.cpp:141
+msgid "Japanese Envelope Kaku #3"
+msgstr "जापानी खाम Kaku #3"
+
+#: ../src/common/paper.cpp:142
+msgid "Japanese Envelope Chou #3"
+msgstr "जापानी खाम Chou #3"
+
+#: ../src/common/paper.cpp:143
+msgid "Japanese Envelope Chou #4"
+msgstr "जापानी खाम Chou #4"
+
+#: ../src/common/paper.cpp:144
+msgid "Letter Rotated 11 x 8 1/2 in"
+msgstr "Letter Rounded 11 x 8 1/2इन्च"
+
+#: ../src/common/paper.cpp:145
+msgid "A3 Rotated 420 x 297 mm"
+msgstr "A3 rotated 420 x 297 मिमी"
+
+#: ../src/common/paper.cpp:146
+msgid "A4 Rotated 297 x 210 mm"
+msgstr "A4 rotated 297 x 210 मिमी"
+
+#: ../src/common/paper.cpp:147
+msgid "A5 Rotated 210 x 148 mm"
+msgstr "A5 Rotated 210 x 148 मिमी"
+
+#: ../src/common/paper.cpp:148
+msgid "B4 (JIS) Rotated 364 x 257 mm"
+msgstr "B4 (JIS) घुसाइयो 364 x 257 मिमी"
+
+#: ../src/common/paper.cpp:149
+msgid "B5 (JIS) Rotated 257 x 182 mm"
+msgstr "B5 (JIS) Rounded 257 x 182 मिमी"
+
+#: ../src/common/paper.cpp:150
+msgid "Japanese Postcard Rotated 148 x 100 mm"
+msgstr "जापानी पोस्टकार्ड Rounded 148 x 100 मिमी"
+
+#: ../src/common/paper.cpp:151
+msgid "Double Japanese Postcard Rotated 148 x 200 mm"
+msgstr "दोबर जापानी गोलो पोस्टकार्ड 148 x 200 मिमी"
+
+#: ../src/common/paper.cpp:152
+msgid "A6 Rotated 148 x 105 mm"
+msgstr "A6 Rotated 148 x 105 मिमी"
+
+#: ../src/common/paper.cpp:153
+msgid "Japanese Envelope Kaku #2 Rotated"
+msgstr "जापानी खाम Kaku #2 Rounded"
+
+#: ../src/common/paper.cpp:154
+msgid "Japanese Envelope Kaku #3 Rotated"
+msgstr "जापानी खाम Kaku #3 Rounded"
+
+#: ../src/common/paper.cpp:155
+msgid "Japanese Envelope Chou #3 Rotated"
+msgstr "जापानी खाम Chou #3 Rounded"
+
+#: ../src/common/paper.cpp:156
+msgid "Japanese Envelope Chou #4 Rotated"
+msgstr "जापानी खाम Chou #4 Rounded"
+
+#: ../src/common/paper.cpp:157
+msgid "B6 (JIS) 128 x 182 mm"
+msgstr "B6 (JIS) 128 x 182 मिमी"
+
+#: ../src/common/paper.cpp:158
+msgid "B6 (JIS) Rotated 182 x 128 mm"
+msgstr "B6 (JIS) Rounded 182 x 128 मिमी"
+
+#: ../src/common/paper.cpp:159
+msgid "12 x 11 in"
+msgstr "12 x 11इन्च"
+
+#: ../src/common/paper.cpp:160
+msgid "Japanese Envelope You #4"
+msgstr "जापानी खाम You #4"
+
+#: ../src/common/paper.cpp:161
+msgid "Japanese Envelope You #4 Rotated"
+msgstr "जापानी खाम You #4 Rounded"
+
+#: ../src/common/paper.cpp:162
+msgid "PRC 16K 146 x 215 mm"
+msgstr "PRC 16K 146 x 215 मिमी"
+
+#: ../src/common/paper.cpp:163
+msgid "PRC 32K 97 x 151 mm"
+msgstr "PRC 32K 97 x 151 मिमी"
+
+#: ../src/common/paper.cpp:164
+msgid "PRC 32K(Big) 97 x 151 mm"
+msgstr "PRC 32K(Big) 97 x 151 मिमी"
+
+#: ../src/common/paper.cpp:165
+msgid "PRC Envelope #1 102 x 165 mm"
+msgstr "PRC खाम #1 102 x 165 मिमी"
+
+#: ../src/common/paper.cpp:166
+msgid "PRC Envelope #2 102 x 176 mm"
+msgstr "PRC खाम #2 102 x 176 मिमी"
+
+#: ../src/common/paper.cpp:167
+msgid "PRC Envelope #3 125 x 176 mm"
+msgstr "PRC खाम #3 125 x 176 मिमी"
+
+#: ../src/common/paper.cpp:168
+msgid "PRC Envelope #4 110 x 208 mm"
+msgstr "PRC खाम #4 110 x 208 मिमी"
+
+#: ../src/common/paper.cpp:169
+msgid "PRC Envelope #5 110 x 220 mm"
+msgstr "PRC खाम #5 110 x 220 मिमी"
+
+#: ../src/common/paper.cpp:170
+msgid "PRC Envelope #6 120 x 230 mm"
+msgstr "PRC खाम #6 120 x 230 मिमी"
+
+#: ../src/common/paper.cpp:171
+msgid "PRC Envelope #7 160 x 230 mm"
+msgstr "PRC खाम #7 160 x 230 मिमी"
+
+#: ../src/common/paper.cpp:172
+msgid "PRC Envelope #8 120 x 309 mm"
+msgstr "PRC खाम #8 120 x 309 मिमी"
+
+#: ../src/common/paper.cpp:173
+msgid "PRC Envelope #9 229 x 324 mm"
+msgstr "PRC खाम #9 229 x 324 मिमी"
+
+#: ../src/common/paper.cpp:174
+msgid "PRC Envelope #10 324 x 458 mm"
+msgstr "PRC खाम #10 324 x 458 मिमी"
+
+#: ../src/common/paper.cpp:175
+msgid "PRC 16K Rotated"
+msgstr "PRC 16K Rounded"
+
+#: ../src/common/paper.cpp:176
+msgid "PRC 32K Rotated"
+msgstr "PRC 32K Rounded"
+
+#: ../src/common/paper.cpp:177
+msgid "PRC 32K(Big) Rotated"
+msgstr "PRC 32K(Big) Rounded"
+
+#: ../src/common/paper.cpp:178
+msgid "PRC Envelope #1 Rotated 165 x 102 mm"
+msgstr "PRC खाम #1 Rounded 165 x 102 मिमी"
+
+#: ../src/common/paper.cpp:179
+msgid "PRC Envelope #2 Rotated 176 x 102 mm"
+msgstr "PRC खाम #2 Rounded 176 x 102 मिमी"
+
+#: ../src/common/paper.cpp:180
+msgid "PRC Envelope #3 Rotated 176 x 125 mm"
+msgstr "PRC खाम #3 Rounded 176 x 125 मिमी"
+
+#: ../src/common/paper.cpp:181
+msgid "PRC Envelope #4 Rotated 208 x 110 mm"
+msgstr "PRC खाम #4 Rounded 208 x 110 मिमी"
+
+#: ../src/common/paper.cpp:182
+msgid "PRC Envelope #5 Rotated 220 x 110 mm"
+msgstr "PRC खाम #5 Rounded 220 x 110 मिमी"
+
+#: ../src/common/paper.cpp:183
+msgid "PRC Envelope #6 Rotated 230 x 120 mm"
+msgstr "PRC खाम #6 Rounded 230 x 120 मिमी"
+
+#: ../src/common/paper.cpp:184
+msgid "PRC Envelope #7 Rotated 230 x 160 mm"
+msgstr "PRC खाम #7 Rounded 230 x 160 मिमी"
+
+#: ../src/common/paper.cpp:185
+msgid "PRC Envelope #8 Rotated 309 x 120 mm"
+msgstr "PRC खाम #8 Rounded 309 x 120 मिमी"
+
+#: ../src/common/paper.cpp:186
+msgid "PRC Envelope #9 Rotated 324 x 229 mm"
+msgstr "PRC खाम #9 Rounded 324 x 229 मिमी"
+
+#: ../src/common/paper.cpp:187
+msgid "PRC Envelope #10 Rotated 458 x 324 mm"
+msgstr "PRC खाम #10 Rounded 458 x 324 मिमी"
+
+#: ../src/common/paper.cpp:192
+msgid "A0 sheet, 841 x 1189 mm"
+msgstr "A0 शीट, 841 x 1189 मिमी"
+
+#: ../src/common/paper.cpp:193
+msgid "A1 sheet, 594 x 841 mm"
+msgstr "A1 शीट, 594 x 841 मिमी"
+
+#: ../src/common/preferencescmn.cpp:37
+msgid "General"
+msgstr "&सामान्य"
+
+#: ../src/common/preferencescmn.cpp:40
+msgid "Advanced"
+msgstr "समृद्ध"
+
+#: ../src/common/prntbase.cpp:245
+msgid "Generic PostScript"
+msgstr "Generic PostScript"
+
+#: ../src/common/prntbase.cpp:259
+msgid "Ready"
+msgstr "तयार"
+
+#: ../src/common/prntbase.cpp:331
+msgid "Printing Error"
+msgstr "छपाइमा गल्ती"
+
+#: ../src/common/prntbase.cpp:413 ../src/common/prntbase.cpp:1597
+#: ../src/generic/prntdlgg.cpp:135 ../src/generic/prntdlgg.cpp:149
+#: ../src/gtk/print.cpp:628 ../src/gtk/print.cpp:646
+msgid "Print"
+msgstr "छाप्ने काम गर"
+
+#: ../src/common/prntbase.cpp:471 ../src/generic/prntdlgg.cpp:809
+msgid "Page setup"
+msgstr "पृष्ट मिलाउ"
+
+#: ../src/common/prntbase.cpp:525
+msgid "Please wait while printing..."
+msgstr "कृपया पर्खनु होस् है छाप्ने काम हुँदैछ ।"
+
+#: ../src/common/prntbase.cpp:529
+msgid "Document:"
+msgstr "कागजात"
+
+#: ../src/common/prntbase.cpp:532
+msgid "Progress:"
+msgstr "प्रगति"
+
+#: ../src/common/prntbase.cpp:533
+msgid "Preparing"
+msgstr "तयारी हुदैछ ।"
+
+#: ../src/common/prntbase.cpp:552
+#, fuzzy, c-format
+msgid "Printing page %d"
+msgstr "पृष्ट %d.. छापिँदै छ ।"
+
+#: ../src/common/prntbase.cpp:557
+#, c-format
+msgid "Printing page %d of %d"
+msgstr "पृष्ट %d बट्टा %d छापिँदै छ ।"
+
+#: ../src/common/prntbase.cpp:560
+#, c-format
+msgid " (copy %d of %d)"
+msgstr "%d बट्टा %d को नक्कल"
+
+#: ../src/common/prntbase.cpp:1604
+msgid "First page"
+msgstr "प्रथम पृष्ट"
+
+#: ../src/common/prntbase.cpp:1609 ../src/html/helpwnd.cpp:659
+msgid "Previous page"
+msgstr "पछिल्लो पृष्ट"
+
+#: ../src/common/prntbase.cpp:1623 ../src/html/helpwnd.cpp:660
+msgid "Next page"
+msgstr "अघिल्लो पृष्ट"
+
+#: ../src/common/prntbase.cpp:1628
+msgid "Last page"
+msgstr "अन्तिम पृष्ट"
+
+#: ../src/common/prntbase.cpp:1636 ../src/common/stockitem.cpp:215
+msgid "Zoom Out"
+msgstr "सानो पार"
+
+#: ../src/common/prntbase.cpp:1650 ../src/common/stockitem.cpp:214
+msgid "Zoom In"
+msgstr "ठूलो पार"
+
+#: ../src/common/prntbase.cpp:1656 ../src/common/stockitem.cpp:153
+#: ../src/generic/logg.cpp:553 ../src/univ/themes/win32.cpp:3752
+msgid "&Close"
+msgstr "&बन्द गर"
+
+#: ../src/common/prntbase.cpp:2085
+msgid "Could not start document preview."
+msgstr "कागजातको चेहरा सुरु गर्न सकिएन"
+
+#: ../src/common/prntbase.cpp:2085 ../src/common/prntbase.cpp:2129
+#: ../src/common/prntbase.cpp:2137
+msgid "Print Preview Failure"
+msgstr "छापिने चेहरा देखाउन सकिएन"
+
+#: ../src/common/prntbase.cpp:2129 ../src/common/prntbase.cpp:2137
+msgid "Sorry, not enough memory to create a preview."
+msgstr "माफ गर्नु होस्, चेहरा सिर्जना गर्न यथेष्ट भण्डार छैन ।"
+
+#: ../src/common/prntbase.cpp:2144
+#, c-format
+msgid "Page %d of %d"
+msgstr "पृष्ट %d बट्टा %d"
+
+#: ../src/common/prntbase.cpp:2146
+#, c-format
+msgid "Page %d"
+msgstr "पृष्ट %d"
+
+#: ../src/common/regex.cpp:382 ../src/html/chm.cpp:348
+msgid "unknown error"
+msgstr "अज्ञात गल्ती"
+
+#: ../src/common/regex.cpp:995
+#, c-format
+msgid "Invalid regular expression '%s': %s"
+msgstr "नमिल्दो नियमित अभिव्यक्ति %s': %s"
+
+#: ../src/common/regex.cpp:1059
+#, c-format
+msgid "Failed to find match for regular expression: %s"
+msgstr "नियमित अभिव्यक्ति%s सित मिल्ने शब्द पाइ एन ।"
+
+#: ../src/common/rendcmn.cpp:188
+#, c-format
+msgid "Renderer \"%s\" has incompatible version %d.%d and couldn't be loaded."
+msgstr "Renderer \"%s\" सित मिलान गर्न नसकिने संस्करण %d.%d भएकोले वहन गर्न सकिएन ।"
+
+#: ../src/common/secretstore.cpp:162
+msgid "Not available for this platform"
+msgstr ""
+
+#: ../src/common/secretstore.cpp:183
+#, fuzzy, c-format
+msgid "Saving password for \"%s\" failed: %s."
+msgstr "'%s' लाई '%s' मा खिच्ने काम असफल भयो ।"
+
+#: ../src/common/secretstore.cpp:205
+#, fuzzy, c-format
+msgid "Reading password for \"%s\" failed: %s."
+msgstr "'%s' लाई '%s' मा खिच्ने काम असफल भयो ।"
+
+#: ../src/common/secretstore.cpp:228
+#, fuzzy, c-format
+msgid "Deleting password for \"%s\" failed: %s."
+msgstr "'%s' लाई '%s' मा खिच्ने काम असफल भयो ।"
+
+#: ../src/common/selectdispatcher.cpp:254
+msgid "Failed to monitor I/O channels"
+msgstr "लगानी/प्रतिफल मार्ग अनुगमन गर्न सकिएन ।"
+
+#: ../src/common/sizer.cpp:3054 ../src/common/stockitem.cpp:195
+msgid "Save"
+msgstr "बचत गर"
+
+#: ../src/common/sizer.cpp:3056
+msgid "Don't Save"
+msgstr "बचत नगर"
+
+#: ../src/common/socket.cpp:870
+msgid "Cannot initialize sockets"
+msgstr "sockets लाइ सुरु गर्न सकिँदैन ।"
+
+#: ../src/common/stockitem.cpp:127
+#, fuzzy
+msgctxt "standard Windows menu"
+msgid "&Help"
+msgstr "&सहयोग"
+
+#: ../src/common/stockitem.cpp:144
+msgid "&About"
+msgstr "&बारेमा"
+
+#: ../src/common/stockitem.cpp:144
+msgid "About"
+msgstr "बारेमा"
+
+#: ../src/common/stockitem.cpp:145
+msgid "Add"
+msgstr "थप"
+
+#: ../src/common/stockitem.cpp:146
+msgid "&Apply"
+msgstr "&लागू गर"
+
+#: ../src/common/stockitem.cpp:146
+msgid "Apply"
+msgstr "लागू गर"
+
+#: ../src/common/stockitem.cpp:147
+msgid "&Back"
+msgstr "&पछाडि"
+
+#: ../src/common/stockitem.cpp:147
+msgid "Back"
+msgstr "पछाडी"
+
+#: ../src/common/stockitem.cpp:148
+msgid "&Bold"
+msgstr "&मोटो"
+
+#: ../src/common/stockitem.cpp:148 ../src/generic/fontdlgg.cpp:326
+#: ../src/richtext/richtextfontpage.cpp:354
+msgid "Bold"
+msgstr "मोटो"
+
+#: ../src/common/stockitem.cpp:149
+msgid "&Bottom"
+msgstr "&पुछार"
+
+#: ../src/common/stockitem.cpp:149 ../src/richtext/richtextsizepage.cpp:287
+msgid "Bottom"
+msgstr "पुछार"
+
+#: ../src/common/stockitem.cpp:150 ../src/generic/fontdlgg.cpp:462
+#: ../src/generic/fontdlgg.cpp:481 ../src/generic/wizard.cpp:415
+msgid "&Cancel"
+msgstr "&रद्द"
+
+#: ../src/common/stockitem.cpp:151
+#, fuzzy
+msgid "&CD-ROM"
+msgstr "&CD-Rom"
+
+#: ../src/common/stockitem.cpp:151
+#, fuzzy
+msgid "CD-ROM"
+msgstr "CD-Rom"
+
+#: ../src/common/stockitem.cpp:152
+msgid "&Clear"
+msgstr "&सफा गर"
+
+#: ../src/common/stockitem.cpp:152
+msgid "Clear"
+msgstr "मेटाउ"
+
+#: ../src/common/stockitem.cpp:153 ../src/generic/dbgrptg.cpp:93
+#: ../src/generic/progdlgg.cpp:778 ../src/html/helpdlg.cpp:86
+#: ../src/msw/progdlg.cpp:209 ../src/msw/progdlg.cpp:890
+#: ../src/richtext/richtextstyledlg.cpp:272
+#: ../src/richtext/richtextsymboldlg.cpp:448
+msgid "Close"
+msgstr "बन्द गर"
+
+#: ../src/common/stockitem.cpp:154
+msgid "&Convert"
+msgstr "&रूपान्तरण गर"
+
+#: ../src/common/stockitem.cpp:154
+msgid "Convert"
+msgstr "बदलि देउ"
+
+#: ../src/common/stockitem.cpp:155 ../src/msw/textctrl.cpp:2884
+#: ../src/osx/textctrl_osx.cpp:653 ../src/richtext/richtextctrl.cpp:331
+msgid "&Copy"
+msgstr "&नक्कल उतार"
+
+#: ../src/common/stockitem.cpp:155 ../src/stc/stc_i18n.cpp:18
+msgid "Copy"
+msgstr "नक्कल उतार"
+
+#: ../src/common/stockitem.cpp:156 ../src/msw/textctrl.cpp:2883
+#: ../src/osx/textctrl_osx.cpp:652 ../src/richtext/richtextctrl.cpp:330
+msgid "Cu&t"
+msgstr "&काट्नु होस्"
+
+#: ../src/common/stockitem.cpp:156 ../src/stc/stc_i18n.cpp:17
+msgid "Cut"
+msgstr "काट"
+
+#: ../src/common/stockitem.cpp:157 ../src/msw/textctrl.cpp:2886
+#: ../src/osx/textctrl_osx.cpp:655 ../src/richtext/richtextctrl.cpp:333
+#: ../src/richtext/richtexttabspage.cpp:137
+msgid "&Delete"
+msgstr "&मेटाइ देउ"
+
+#: ../src/common/stockitem.cpp:157 ../src/richtext/richtextbuffer.cpp:8266
+#: ../src/stc/stc_i18n.cpp:20
+msgid "Delete"
+msgstr "मेटाइ देउ"
+
+#: ../src/common/stockitem.cpp:158
+msgid "&Down"
+msgstr "&तल"
+
+#: ../src/common/stockitem.cpp:158 ../src/generic/fdrepdlg.cpp:148
+msgid "Down"
+msgstr "तल"
+
+#: ../src/common/stockitem.cpp:159
+msgid "&Edit"
+msgstr "&सम्पादन"
+
+#: ../src/common/stockitem.cpp:159
+msgid "Edit"
+msgstr "सम्पादन"
+
+#: ../src/common/stockitem.cpp:160
+msgid "&Execute"
+msgstr "&कार्यान्वयन गर"
+
+#: ../src/common/stockitem.cpp:160
+msgid "Execute"
+msgstr "कार्यान्वयन गर"
+
+#: ../src/common/stockitem.cpp:161
+msgid "&Quit"
+msgstr "&त्यागि देउ"
+
+#: ../src/common/stockitem.cpp:161
+msgid "Quit"
+msgstr "त्यागि देउ"
+
+#: ../src/common/stockitem.cpp:162
+msgid "&File"
+msgstr "&फाइल"
+
+#: ../src/common/stockitem.cpp:162
+msgid "File"
+msgstr "फाइल"
+
+#: ../src/common/stockitem.cpp:163
+#, fuzzy
+msgid "&Find..."
+msgstr "&फेला पार"
+
+#: ../src/common/stockitem.cpp:163
+#, fuzzy
+msgid "Find..."
+msgstr "फेला पार"
+
+#: ../src/common/stockitem.cpp:164
+msgid "&First"
+msgstr "&पहिलो"
+
+#: ../src/common/stockitem.cpp:164
+msgid "First"
+msgstr "प्रथम"
+
+#: ../src/common/stockitem.cpp:165
+msgid "&Floppy"
+msgstr "&फ्लपी"
+
+#: ../src/common/stockitem.cpp:165
+msgid "Floppy"
+msgstr "फ्लपी"
+
+#: ../src/common/stockitem.cpp:166
+msgid "&Forward"
+msgstr "&प्रेषित गर"
+
+#: ../src/common/stockitem.cpp:166
+msgid "Forward"
+msgstr "प्रेषित गर"
+
+#: ../src/common/stockitem.cpp:167
+msgid "&Harddisk"
+msgstr "&Harddisk"
+
+#: ../src/common/stockitem.cpp:167
+msgid "Harddisk"
+msgstr "Harddisk"
+
+#: ../src/common/stockitem.cpp:168 ../src/generic/wizard.cpp:418
+#: ../src/osx/cocoa/menu.mm:225 ../src/richtext/richtextstyledlg.cpp:298
+#: ../src/richtext/richtextsymboldlg.cpp:451
+msgid "&Help"
+msgstr "&सहयोग"
+
+#: ../src/common/stockitem.cpp:169
+msgid "&Home"
+msgstr "&गृह"
+
+#: ../src/common/stockitem.cpp:169
+msgid "Home"
+msgstr "गृह"
+
+#: ../src/common/stockitem.cpp:170
+msgid "Indent"
+msgstr "Indent"
+
+#: ../src/common/stockitem.cpp:171
+msgid "&Index"
+msgstr "&अनुक्रमणिका"
+
+#: ../src/common/stockitem.cpp:171 ../src/html/helpwnd.cpp:510
+msgid "Index"
+msgstr "अनुक्रमणिका"
+
+#: ../src/common/stockitem.cpp:172
+msgid "&Info"
+msgstr "&जानकारी"
+
+#: ../src/common/stockitem.cpp:172
+msgid "Info"
+msgstr "जानकारी"
+
+#: ../src/common/stockitem.cpp:173
+msgid "&Italic"
+msgstr "&डल्केको"
+
+#: ../src/common/stockitem.cpp:173 ../src/generic/fontdlgg.cpp:322
+#: ../src/richtext/richtextfontpage.cpp:350
+msgid "Italic"
+msgstr "डल्केको"
+
+#: ../src/common/stockitem.cpp:174
+msgid "&Jump to"
+msgstr "मा &फड्को मार "
+
+#: ../src/common/stockitem.cpp:174
+msgid "Jump to"
+msgstr "फड्को मार "
+
+#: ../src/common/stockitem.cpp:175
+msgid "Centered"
+msgstr "केन्द्र"
+
+#: ../src/common/stockitem.cpp:176
+msgid "Justified"
+msgstr "धुबै सिमाना"
+
+#: ../src/common/stockitem.cpp:177
+msgid "Align Left"
+msgstr " देब्रे पङ्क्ति"
+
+#: ../src/common/stockitem.cpp:178
+msgid "Align Right"
+msgstr "दाहिने पङ्ति"
+
+#: ../src/common/stockitem.cpp:179
+msgid "&Last"
+msgstr "&अन्तिम"
+
+#: ../src/common/stockitem.cpp:179
+msgid "Last"
+msgstr "अन्तिम"
+
+#: ../src/common/stockitem.cpp:180
+msgid "&Network"
+msgstr "&सञ्जाल "
+
+#: ../src/common/stockitem.cpp:180
+msgid "Network"
+msgstr "सञ्जाल"
+
+#: ../src/common/stockitem.cpp:181 ../src/richtext/richtexttabspage.cpp:131
+msgid "&New"
+msgstr "&नया"
+
+#: ../src/common/stockitem.cpp:181
+msgid "New"
+msgstr "नया"
+
+#: ../src/common/stockitem.cpp:182 ../src/msw/msgdlg.cpp:417
+msgid "&No"
+msgstr "&होइन"
+
+#: ../src/common/stockitem.cpp:183 ../src/generic/fontdlgg.cpp:467
+#: ../src/generic/fontdlgg.cpp:474
+msgid "&OK"
+msgstr "&ठीक"
+
+#: ../src/common/stockitem.cpp:184 ../src/generic/dbgrptg.cpp:341
+msgid "&Open..."
+msgstr "&खोली देउ"
+
+#: ../src/common/stockitem.cpp:184
+msgid "Open..."
+msgstr "पल्टाउ.."
+
+#: ../src/common/stockitem.cpp:185 ../src/msw/textctrl.cpp:2885
+#: ../src/osx/textctrl_osx.cpp:654 ../src/richtext/richtextctrl.cpp:332
+msgid "&Paste"
+msgstr "&टाँसि देउ"
+
+#: ../src/common/stockitem.cpp:185 ../src/richtext/richtextctrl.cpp:3484
+#: ../src/stc/stc_i18n.cpp:19
+msgid "Paste"
+msgstr "टाँसि देउ"
+
+#: ../src/common/stockitem.cpp:186
+msgid "&Preferences"
+msgstr "&प्राथमिकताहरू"
+
+#: ../src/common/stockitem.cpp:186 ../src/osx/cocoa/preferences.mm:304
+msgid "Preferences"
+msgstr "प्राथमिकताहरू"
+
+#: ../src/common/stockitem.cpp:187
+msgid "Print previe&w..."
+msgstr "&छापिने चेहरा"
+
+#: ../src/common/stockitem.cpp:187
+msgid "Print preview..."
+msgstr "छापिने चेहरा"
+
+#: ../src/common/stockitem.cpp:188
+msgid "&Print..."
+msgstr "&छापी देउ.."
+
+#: ../src/common/stockitem.cpp:188
+msgid "Print..."
+msgstr "छापी देउ.."
+
+#: ../src/common/stockitem.cpp:189 ../src/richtext/richtextctrl.cpp:337
+#: ../src/richtext/richtextctrl.cpp:5479
+msgid "&Properties"
+msgstr "&गुणहरू"
+
+#: ../src/common/stockitem.cpp:189
+msgid "Properties"
+msgstr "गुणहरू"
+
+#: ../src/common/stockitem.cpp:190 ../src/stc/stc_i18n.cpp:16
+msgid "Redo"
+msgstr "फेरि गर"
+
+#: ../src/common/stockitem.cpp:191
+msgid "Refresh"
+msgstr "ताजकी य"
+
+#: ../src/common/stockitem.cpp:192
+msgid "Remove"
+msgstr "हटाउ"
+
+#: ../src/common/stockitem.cpp:193
+#, fuzzy
+msgid "Rep&lace..."
+msgstr "&बदलि देउ"
+
+#: ../src/common/stockitem.cpp:193
+#, fuzzy
+msgid "Replace..."
+msgstr "प्रतिस्थापन गर"
+
+#: ../src/common/stockitem.cpp:194
+msgid "Revert to Saved"
+msgstr "बचत उल्टियो "
+
+#: ../src/common/stockitem.cpp:196 ../src/generic/logg.cpp:549
+msgid "Save &As..."
+msgstr "&यसरी बचत गर"
+
+#: ../src/common/stockitem.cpp:196
+#, fuzzy
+msgid "Save As..."
+msgstr "&यसरी बचत गर"
+
+#: ../src/common/stockitem.cpp:197 ../src/msw/textctrl.cpp:2888
+#: ../src/osx/textctrl_osx.cpp:657 ../src/richtext/richtextctrl.cpp:335
+msgid "Select &All"
+msgstr "&सबैलाई चयन गर"
+
+#: ../src/common/stockitem.cpp:197 ../src/stc/stc_i18n.cpp:21
+msgid "Select All"
+msgstr "सबै चयन गर"
+
+#: ../src/common/stockitem.cpp:198
+msgid "&Color"
+msgstr "&रङ्ग"
+
+#: ../src/common/stockitem.cpp:198
+msgid "Color"
+msgstr "रङ्ग"
+
+#: ../src/common/stockitem.cpp:199
+msgid "&Font"
+msgstr "&वरणाकृति"
+
+#: ../src/common/stockitem.cpp:199 ../src/richtext/richtextformatdlg.cpp:336
+msgid "Font"
+msgstr "वरणाकृति"
+
+#: ../src/common/stockitem.cpp:200
+msgid "&Ascending"
+msgstr "&बढ्दो वर्णानुक्रमिक"
+
+#: ../src/common/stockitem.cpp:200
+msgid "Ascending"
+msgstr "बढ्दो वर्णानुक्रमिक"
+
+#: ../src/common/stockitem.cpp:201
+msgid "&Descending"
+msgstr "&घट्दो क्रममा वर्णानुक्रमिक"
+
+#: ../src/common/stockitem.cpp:201
+msgid "Descending"
+msgstr "घट्दो क्रममा वर्णानुक्रमिक"
+
+#: ../src/common/stockitem.cpp:202
+msgid "&Spell Check"
+msgstr "&हिज्जे जाँच"
+
+#: ../src/common/stockitem.cpp:202
+msgid "Spell Check"
+msgstr "हिज्जे जाँच"
+
+#: ../src/common/stockitem.cpp:203
+msgid "&Stop"
+msgstr "&रोकि देउ"
+
+#: ../src/common/stockitem.cpp:203
+msgid "Stop"
+msgstr "रोकि देउ"
+
+#: ../src/common/stockitem.cpp:204 ../src/richtext/richtextfontpage.cpp:274
+msgid "&Strikethrough"
+msgstr "&Strikethrough"
+
+#: ../src/common/stockitem.cpp:204
+msgid "Strikethrough"
+msgstr "Strikethrough"
+
+#: ../src/common/stockitem.cpp:205
+msgid "&Top"
+msgstr "&सिरान"
+
+#: ../src/common/stockitem.cpp:205 ../src/richtext/richtextsizepage.cpp:285
+#: ../src/richtext/richtextsizepage.cpp:289
+msgid "Top"
+msgstr "सिरान"
+
+#: ../src/common/stockitem.cpp:206
+msgid "Undelete"
+msgstr "नमेटाउ"
+
+#: ../src/common/stockitem.cpp:207 ../src/generic/fontdlgg.cpp:437
+msgid "&Underline"
+msgstr "&अधोरेखाङ्कन"
+
+#: ../src/common/stockitem.cpp:207
+msgid "Underline"
+msgstr "अधोरेखाङ्कन"
+
+#: ../src/common/stockitem.cpp:208 ../src/stc/stc_i18n.cpp:15
+msgid "Undo"
+msgstr "उल्टाउ"
+
+#: ../src/common/stockitem.cpp:209
+msgid "&Unindent"
+msgstr "&Unindent"
+
+#: ../src/common/stockitem.cpp:209
+msgid "Unindent"
+msgstr "Unindent"
+
+#: ../src/common/stockitem.cpp:210
+msgid "&Up"
+msgstr "&माथि"
+
+#: ../src/common/stockitem.cpp:210 ../src/generic/fdrepdlg.cpp:148
+msgid "Up"
+msgstr "माथि"
+
+#: ../src/common/stockitem.cpp:211 ../src/msw/msgdlg.cpp:417
+msgid "&Yes"
+msgstr "&हो"
+
+#: ../src/common/stockitem.cpp:212
+msgid "&Actual Size"
+msgstr "&वास्तविक आकार"
+
+#: ../src/common/stockitem.cpp:212
+msgid "Actual Size"
+msgstr "वास्तविक आकार"
+
+#: ../src/common/stockitem.cpp:213
+msgid "Zoom to &Fit"
+msgstr "&मिल्दो आकारमा ल्याउ"
+
+#: ../src/common/stockitem.cpp:213
+msgid "Zoom to Fit"
+msgstr "मिल्दो आकारमा ल्याउ"
+
+#: ../src/common/stockitem.cpp:214
+msgid "Zoom &In"
+msgstr "&ठूलो पार्ने"
+
+#: ../src/common/stockitem.cpp:215
+msgid "Zoom &Out"
+msgstr "&सानो पार्ने"
+
+#: ../src/common/stockitem.cpp:262
+msgid "Show about dialog"
+msgstr "पातोको बारेमा देखाउ "
+
+#: ../src/common/stockitem.cpp:263
+msgid "Copy selection"
+msgstr "चयनको नक्कल उतार "
+
+#: ../src/common/stockitem.cpp:264
+msgid "Cut selection"
+msgstr "चयन काट"
+
+#: ../src/common/stockitem.cpp:265
+msgid "Delete selection"
+msgstr "चयन मेटाइ देउ "
+
+#: ../src/common/stockitem.cpp:266
+#, fuzzy
+msgid "Find in document"
+msgstr "HTML कागजात पल्टाउ "
+
+#: ../src/common/stockitem.cpp:267
+msgid "Find and replace in document"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:268
+msgid "Paste selection"
+msgstr "चयन टाँसि देउ "
+
+#: ../src/common/stockitem.cpp:269
+msgid "Quit this program"
+msgstr "यो कार्यक्रमलाई त्यागि देउ "
+
+#: ../src/common/stockitem.cpp:270
+msgid "Redo last action"
+msgstr "अन्तिम कार्य फेरि गर "
+
+#: ../src/common/stockitem.cpp:271
+msgid "Undo last action"
+msgstr "अन्तिमको काम उल्टाउ "
+
+#: ../src/common/stockitem.cpp:272
+#, fuzzy
+msgid "Create new document"
+msgstr "नया घर्राको सिर्जना गर्नु होस्"
+
+#: ../src/common/stockitem.cpp:273
+#, fuzzy
+msgid "Open an existing document"
+msgstr "HTML कागजात पल्टाउ "
+
+#: ../src/common/stockitem.cpp:274
+msgid "Close current document"
+msgstr "चालू कागजात बन्द गर "
+
+#: ../src/common/stockitem.cpp:275
+msgid "Save current document"
+msgstr "चालू कागजातलाई बचत गर "
+
+#: ../src/common/stockitem.cpp:276
+msgid "Save current document with a different filename"
+msgstr "चालू कागजातलाई अर्कै फाइल नाम दिएर बचत गर "
+
+#: ../src/common/strconv.cpp:2324
+#, c-format
+msgid "Conversion to charset '%s' doesn't work."
+msgstr "वर्ण समूह '%s' मा परिवर्तन हुन सक्दैन"
+
+#: ../src/common/tarstrm.cpp:352 ../src/common/tarstrm.cpp:375
+#: ../src/common/tarstrm.cpp:406 ../src/generic/progdlgg.cpp:373
+msgid "unknown"
+msgstr "अज्ञात"
+
+#: ../src/common/tarstrm.cpp:774
+msgid "incomplete header block in tar"
+msgstr "tar मा अपूरो header हिस्सा"
+
+#: ../src/common/tarstrm.cpp:798
+msgid "checksum failure reading tar header block"
+msgstr "tar header हिस्सा असफलता जाँच सुची "
+
+#: ../src/common/tarstrm.cpp:971
+msgid "invalid data in extended tar header"
+msgstr "विस्तारित tar header मा अवैध तथ्याङ्क छ ।"
+
+#: ../src/common/tarstrm.cpp:981 ../src/common/tarstrm.cpp:1003
+#: ../src/common/tarstrm.cpp:1477 ../src/common/tarstrm.cpp:1499
+msgid "tar entry not open"
+msgstr "tar प्रविष्टि नपल्टाउ"
+
+#: ../src/common/tarstrm.cpp:1023
+msgid "unexpected end of file"
+msgstr "फाइलको अनपेक्षित अन्त"
+
+#: ../src/common/tarstrm.cpp:1297
+#, c-format
+msgid "%s did not fit the tar header for entry '%s'"
+msgstr "%s tar header '%s' प्रविष्टिको लागि मिलेन ।"
+
+#: ../src/common/tarstrm.cpp:1359
+msgid "incorrect size given for tar entry"
+msgstr "tar प्रविष्टिका लागि दिइएको आकार असुद्धी छ ।"
+
+#: ../src/common/textbuf.cpp:232
+#, c-format
+msgid "'%s' is probably a binary buffer."
+msgstr "'%s' सम्भवता binary buffer हो ।"
+
+#: ../src/common/textcmn.cpp:1006 ../src/richtext/richtextctrl.cpp:3053
+msgid "File couldn't be loaded."
+msgstr "फाइल वहन गर्न सकिएन ।"
+
+#: ../src/common/textfile.cpp:95
+#, fuzzy, c-format
+msgid "Failed to read text file \"%s\"."
+msgstr "फाइल \"%s\". बाट कागजात पढ्न सकिएन ।"
+
+#: ../src/common/textfile.cpp:160
+#, c-format
+msgid "can't write buffer '%s' to disk."
+msgstr "buffer '%s' लाई disk मा लेख्न सकिँदैन ।"
+
+#: ../src/common/time.cpp:212
+msgid "Failed to get the local system time"
+msgstr "कम्प्युटर प्रणालीमा स्थानीय समय भेटिएन ।"
+
+#: ../src/common/time.cpp:279
+msgid "wxGetTimeOfDay failed."
+msgstr "wxGetTimeOfDay असफल भयो ।"
+
+#: ../src/common/translation.cpp:929
+#, c-format
+msgid "'%s' is not a valid message catalog."
+msgstr "'%s' सहि सन्देश सूची होइन"
+
+#: ../src/common/translation.cpp:954
+msgid "Invalid message catalog."
+msgstr "नमिल्दो सन्देश सूची"
+
+#: ../src/common/translation.cpp:1013
+#, c-format
+msgid "Failed to parse Plural-Forms: '%s'"
+msgstr "बहुवचन स्वरूप '%s' पठाउन सकिएन ।"
+
+#: ../src/common/translation.cpp:1723
+#, c-format
+msgid "using catalog '%s' from '%s'."
+msgstr "'%s' सूचि प्रयोग हुदैछ (%s' वाट ) ।"
+
+#: ../src/common/translation.cpp:1816
+#, c-format
+msgid "Resource '%s' is not a valid message catalog."
+msgstr "श्रोत '%s' वैध सन्देश सूचि होइन ।"
+
+#: ../src/common/translation.cpp:1865
+msgid "Couldn't enumerate translations"
+msgstr "अनुवाद को लेखाजोखा गर्न सकिएन"
+
+#: ../src/common/utilscmn.cpp:1145
+msgid "No default application configured for HTML files."
+msgstr "HTML फाइलहरूका लागि निर्धारित अनुप्रयोग अनियोजित छैन ।"
+
+#: ../src/common/utilscmn.cpp:1190
+#, c-format
+msgid "Failed to open URL \"%s\" in default browser."
+msgstr "निर्धारित Browser मा \"%s\" खोल्न सकिएन ।"
+
+#: ../src/common/valtext.cpp:144
+msgid "Validation conflict"
+msgstr "वैधता को विवाद"
+
+#: ../src/common/valtext.cpp:186
+msgid "Required information entry is empty."
+msgstr "चाहिएको सूचना प्रविष्टि खालि छ ।"
+
+#: ../src/common/valtext.cpp:188
+#, c-format
+msgid "'%s' is one of the invalid strings"
+msgstr "अवैध पदावलीहरू मद्धे '%s'  एउटा हो ।"
+
+#: ../src/common/valtext.cpp:190
+#, c-format
+msgid "'%s' is not one of the valid strings"
+msgstr "'%s' कुनै वैध पदावली होइन ।"
+
+#: ../src/common/valtext.cpp:199
+#, fuzzy, c-format
+msgid "'%s' contains invalid character(s)"
+msgstr "'%s' मा अवैध वर्णहरू छन् ।"
+
+#: ../src/common/webrequest.cpp:139
+#, fuzzy, c-format
+msgid "Error: %s (%d)"
+msgstr "गल्ती: "
+
+#: ../src/common/webrequest.cpp:655
+#, c-format
+msgid ""
+"Not enough free disk space for download: %llu needed but only %llu available."
+msgstr ""
+
+#: ../src/common/webrequest.cpp:669
+#, fuzzy, c-format
+msgid "Failed to create temporary file in %s"
+msgstr "अस्ताई फाइलको नाम सिर्जना गर्न सकिएन ।"
+
+#: ../src/common/webrequest_curl.cpp:1106
+#, fuzzy
+msgid "libcurl could not be initialized"
+msgstr "महलको बयान सुरु भएन"
+
+#: ../src/common/webview.cpp:392
+msgid "RunScriptAsync not supported"
+msgstr ""
+
+#: ../src/common/webview.cpp:403 ../src/msw/webview_ie.cpp:1073
+#, c-format
+msgid "Error running JavaScript: %s"
+msgstr ""
+
+#: ../src/common/webview_chromium.cpp:858
+#, fuzzy, c-format
+msgid "Failed to set proxy \"%s\": %s"
+msgstr "घर्रा \"%s\" सिर्जना गर्न सकिएन ।"
+
+#: ../src/common/webview_chromium.cpp:989
+msgid ""
+"Chromium can't be used because libcef.so wasn't loaded early enough; please "
+"relink the application or use LD_PRELOAD to load it earlier."
+msgstr ""
+
+#: ../src/common/webview_chromium.cpp:1108
+#, fuzzy
+msgid "Could not initialize Chromium"
+msgstr "पङ्क्ति बद्धता तय गर्न सकिएन"
+
+#: ../src/common/webview_chromium.cpp:1616
+msgid "Show DevTools"
+msgstr ""
+
+#: ../src/common/webview_chromium.cpp:1617
+#, fuzzy
+msgid "Close DevTools"
+msgstr "सबै बन्द गर "
+
+#: ../src/common/webview_chromium.cpp:1623
+msgid "Inspect"
+msgstr ""
+
+#: ../src/common/wincmn.cpp:1628
+msgid "This platform does not support background transparency."
+msgstr "यो platform ले पृष्ठभूमि पारदर्शितालाई समर्थन गर्दैन ।"
+
+#: ../src/common/wincmn.cpp:2097
+msgid "Could not transfer data to window"
+msgstr "विन्डोमा तथ्याङ्क सार्न सकिएन"
+
+#: ../src/common/windowid.cpp:240
+msgid "Out of window IDs.  Recommend shutting down application."
+msgstr "विन्डोज IDs भन्दा बाहिर । अनुप्रयोग बन्द गर्न सुझावित ।"
+
+#: ../src/common/xpmdecod.cpp:678
+msgid "XPM: incorrect header format!"
+msgstr "XPM: शीर्ष बनोटमा अशुद्धता!"
+
+#: ../src/common/xpmdecod.cpp:703
+#, c-format
+msgid "XPM: incorrect colour description in line %d"
+msgstr "XPM: लाइन %d मा अशुद्ध रङ्गको विवरण"
+
+#: ../src/common/xpmdecod.cpp:715 ../src/common/xpmdecod.cpp:724
+#, c-format
+msgid "XPM: malformed colour definition '%s' at line %d!"
+msgstr "XPM: नमिल्दो रङ्गको परिभाषा '%s' ! (लाइन %d मा ) "
+
+#: ../src/common/xpmdecod.cpp:754
+msgid "XPM: no colors left to use for mask!"
+msgstr "XPM: मखुन्डोको लागि कुनै रङ्ग छैन ।"
+
+#: ../src/common/xpmdecod.cpp:781
+#, c-format
+msgid "XPM: truncated image data at line %d!"
+msgstr "XPM: %d लाइनमा काटिएको तस्विर तथ्याङ्क !"
+
+#: ../src/common/xpmdecod.cpp:795
+msgid "XPM: Malformed pixel data!"
+msgstr "XPM: नमिल्दो pixel तथ्याङ्क !"
+
+#: ../src/common/xti.cpp:492
+msgid "Illegal Parameter Count for Create Method"
+msgstr "सिर्जना विधिको लागि अवैध Parameter को गणना"
+
+#: ../src/common/xti.cpp:504
+msgid "Illegal Parameter Count for ConstructObject Method"
+msgstr "ConstructObject विधिको लागि अवैध Parameter को गणना"
+
+#: ../src/common/xtistrm.cpp:161
+#, c-format
+msgid "Create Parameter %s not found in declared RTTI Parameters"
+msgstr "%s मापकहरूको सिर्जना घोषित RTTI मापकमा पाइ एन "
+
+#: ../src/common/xtistrm.cpp:290
+msgid "Illegal Object Class (Non-wxEvtHandler) as Event Source"
+msgstr "घटना श्रोतको रूपमा अवैध वस्तु वर्ग (Non-wxEvtHandler) "
+
+#: ../src/common/xtistrm.cpp:313 ../src/common/xtixml.cpp:345
+#: ../src/common/xtixml.cpp:498
+msgid "Type must have enum - long conversion"
+msgstr "Type must have enum - long conversion"
+
+#: ../src/common/xtistrm.cpp:400 ../src/common/xtistrm.cpp:415
+msgid "Invalid or Null Object ID passed to GetObjectClassInfo"
+msgstr "नमिल्दो अथवा शून्य वस्तु ID GetObjectClassInfo मा पठाइयो ।"
+
+#: ../src/common/xtistrm.cpp:405
+msgid "Unknown Object passed to GetObjectClassInfo"
+msgstr "अज्ञात वस्तु GetObjectClassInfo मा पठाइयो"
+
+#: ../src/common/xtistrm.cpp:420
+msgid "Already Registered Object passed to SetObjectClassInfo"
+msgstr "पहिले नै दर्ता भएको वस्तु SetObjectClass Info मा पठाइयो ।"
+
+#: ../src/common/xtistrm.cpp:430
+msgid "Invalid or Null Object ID passed to HasObjectClassInfo"
+msgstr "नमिल्दो अथवा शून्य वस्तु ID HasObjectClassInfo मा पठाइयो ।"
+
+#: ../src/common/xtistrm.cpp:460
+msgid "Passing a already registered object to SetObject"
+msgstr "पहिले नै दर्ता भएको वस्तु SetObject मा पठाउँदै ।"
+
+#: ../src/common/xtistrm.cpp:471
+msgid "Passing an unknown object to GetObject"
+msgstr "अज्ञात वस्तुलाई GetObject मा पठाइँदै छ "
+
+#: ../src/common/xtixml.cpp:229
+msgid "Forward hrefs are not supported"
+msgstr "hrefs प्रेषण समर्थन गर्न सकिँदैन ।"
+
+#: ../src/common/xtixml.cpp:247
+#, c-format
+msgid "unknown class %s"
+msgstr "अज्ञात class %s"
+
+#: ../src/common/xtixml.cpp:253
+msgid "objects cannot have XML Text Nodes"
+msgstr "वस्तु को XML पाठ टिप्पणी हुन सक्दैन ।"
+
+#: ../src/common/xtixml.cpp:258
+msgid "Objects must have an id attribute"
+msgstr "वस्तुको id attribute हुनै पर्दछ "
+
+#: ../src/common/xtixml.cpp:267
+#, c-format
+msgid "Doubly used id : %d"
+msgstr "दोहोरिएर प्रयोग भएको id : %d"
+
+#: ../src/common/xtixml.cpp:316
+#, c-format
+msgid "Unknown Property %s"
+msgstr "अज्ञात गुण %s"
+
+#: ../src/common/xtixml.cpp:407
+msgid "A non empty collection must consist of 'element' nodes"
+msgstr "खालि नभएको सङ्ग्रहमा 'Element' टिप्पणी हुनै पर्दछ ।"
+
+#: ../src/common/xtixml.cpp:478
+msgid "incorrect event handler string, missing dot"
+msgstr "अशुद्ध घटना सञ्चालक , थोप्लो छुटेको छ ।"
+
+#: ../src/common/zipstrm.cpp:559
+msgid "can't re-initialize zlib deflate stream"
+msgstr "zlib deflate stream लाई पुनः सुरुवात गर्न सकिँदैन ।"
+
+#: ../src/common/zipstrm.cpp:584
+msgid "can't re-initialize zlib inflate stream"
+msgstr "zlib inflate stream लाई पुनः सुरुवात गर्न सकिँदैन ।"
+
+#: ../src/common/zipstrm.cpp:1023
+msgid "Ignoring malformed extra data record, ZIP file may be corrupted"
+msgstr ""
+
+#: ../src/common/zipstrm.cpp:1502
+msgid "assuming this is a multi-part zip concatenated"
+msgstr "यो बहू-टुक्रा जोडजाड गरेर बनाइएको zip मानियो । "
+
+#: ../src/common/zipstrm.cpp:1664
+msgid "invalid zip file"
+msgstr "अवैध zip फाइल"
+
+#: ../src/common/zipstrm.cpp:1723
+msgid "can't find central directory in zip"
+msgstr "zip मा केन्द्रीय घर्रा फेला पार्न सकिँदैन ।"
+
+#: ../src/common/zipstrm.cpp:1812
+msgid "error reading zip central directory"
+msgstr "केन्द्रीय घर्रा पढ्दा गल्ती "
+
+#: ../src/common/zipstrm.cpp:1916
+msgid "error reading zip local header"
+msgstr "स्थानीय header पढ्दा गल्ती "
+
+#: ../src/common/zipstrm.cpp:1964
+msgid "bad zipfile offset to entry"
+msgstr "प्रविष्टिका लागि गलत zip फाइलको हातो"
+
+#: ../src/common/zipstrm.cpp:2031
+msgid "stored file length not in Zip header"
+msgstr "फाइलको लम्बाइ Zip header भन्दा अन्तै भण्डार गर"
+
+#: ../src/common/zipstrm.cpp:2045 ../src/common/zipstrm.cpp:2362
+msgid "unsupported Zip compression method"
+msgstr "असमर्थित Zip दबाब विधि "
+
+#: ../src/common/zipstrm.cpp:2126
+#, c-format
+msgid "reading zip stream (entry %s): bad length"
+msgstr "zip stream (प्रविष्टि %s) पढिँदै: गलत लम्बाइ"
+
+#: ../src/common/zipstrm.cpp:2131
+#, c-format
+msgid "reading zip stream (entry %s): bad crc"
+msgstr "zip stream (प्रविष्टि %s) पढिँदै: गलत crc"
+
+#: ../src/common/zipstrm.cpp:2578
+#, fuzzy, c-format
+msgid "error writing zip entry '%s': file too large without ZIP64"
+msgstr "zip प्रविष्टि '%s' लेखाइमा गल्ती: गलत crc अथवा लम्बाइ"
+
+#: ../src/common/zipstrm.cpp:2585
+#, c-format
+msgid "error writing zip entry '%s': bad crc or length"
+msgstr "zip प्रविष्टि '%s' लेखाइमा गल्ती: गलत crc अथवा लम्बाइ"
+
+#: ../src/common/zstream.cpp:155 ../src/common/zstream.cpp:315
+msgid "Gzip not supported by this version of zlib"
+msgstr "यो zlib को संस्करणले Gzip समर्थन गर्दैन ।"
+
+#: ../src/common/zstream.cpp:182
+msgid "Can't initialize zlib inflate stream."
+msgstr "zlib inflate stream लाइ सुर गर्न सकिँदैन ।"
+
+#: ../src/common/zstream.cpp:241
+msgid "Can't read inflate stream: unexpected EOF in underlying stream."
+msgstr "inflate stream पढ्न सकिँदैन: अनपेक्षित रूपले फाइलको अन्तिममा पुगियो ।"
+
+#: ../src/common/zstream.cpp:248 ../src/common/zstream.cpp:423
+#, c-format
+msgid "zlib error %d"
+msgstr "zlib गल्ती %d"
+
+#: ../src/common/zstream.cpp:249
+#, c-format
+msgid "Can't read from inflate stream: %s"
+msgstr "inflate stream: %s बाट पढ्न सकिँदैन ।"
+
+#: ../src/common/zstream.cpp:343
+msgid "Can't initialize zlib deflate stream."
+msgstr "zlib deflate stream लाइ सुरु गर् सकिँदैन ।"
+
+#: ../src/common/zstream.cpp:424
+#, c-format
+msgid "Can't write to deflate stream: %s"
+msgstr "deflate stream: %s मा लेख्न सकिँदैन"
+
+#: ../src/dfb/bitmap.cpp:633 ../src/dfb/bitmap.cpp:667
+#, c-format
+msgid "No bitmap handler for type %d defined."
+msgstr "%d किसिमको लागि कुनै पनि bitmap सञ्चालक परिभाषित गरिएको छैन।"
+
+#: ../src/dfb/evtloop.cpp:99
+msgid "Failed to read event from DirectFB pipe"
+msgstr "DirectFB pipe बाट घटना पढ्न सकिएन ।"
+
+#: ../src/dfb/evtloop.cpp:171
+msgid "Failed to switch DirectFB pipe to non-blocking mode"
+msgstr "DirectFB pipe लाई न टालिएको मुद्रामा लान सकिएन ।"
+
+#: ../src/dfb/fontmgr.cpp:171
+#, c-format
+msgid "no fonts found in %s, using builtin font"
+msgstr "%s मा वरणाकृतिहरू छैनन्, बनि बनाउ वरणाकृति को प्रयोग गरिदैं छ"
+
+#: ../src/dfb/fontmgr.cpp:177
+msgid "Default font"
+msgstr "निर्धारित वरणाकृति"
+
+#: ../src/dfb/fontmgr.cpp:195
+#, c-format
+msgid "Fonts index file %s disappeared while loading fonts."
+msgstr "वरणाकृति अनुक्रमणिका फाइल %s वरणाकृति वहन गर्ने क्रममा हरायो ।"
+
+#: ../src/dfb/wrapdfb.cpp:60
+#, c-format
+msgid "DirectFB error %d occurred."
+msgstr "DirectFB %d गल्ती हुन पुग्यो ।"
+
+#: ../src/generic/aboutdlgg.cpp:69
+msgid "Developed by "
+msgstr "विकास कर्ता"
+
+#: ../src/generic/aboutdlgg.cpp:72
+msgid "Documentation by "
+msgstr "अभिलेखन कर्ता"
+
+#: ../src/generic/aboutdlgg.cpp:75
+msgid "Graphics art by "
+msgstr "चित्रकाव्यकन कलाकार"
+
+#: ../src/generic/aboutdlgg.cpp:78
+msgid "Translations by "
+msgstr "अनुवादन कर्ता "
+
+#: ../src/generic/aboutdlgg.cpp:133 ../src/osx/cocoa/aboutdlg.mm:83
+msgid "Version "
+msgstr "संस्करण"
+
+#. TRANSLATORS: %s is application name
+#: ../src/generic/aboutdlgg.cpp:146 ../src/msw/aboutdlg.cpp:60
+#, c-format
+msgid "About %s"
+msgstr "%s को बारेमा"
+
+#: ../src/generic/aboutdlgg.cpp:181
+msgid "License"
+msgstr "इजाजत"
+
+#: ../src/generic/aboutdlgg.cpp:184
+msgid "Developers"
+msgstr "विकास कर्मी"
+
+#: ../src/generic/aboutdlgg.cpp:188
+msgid "Documentation writers"
+msgstr "कागजातहरूका लेखकहरू"
+
+#: ../src/generic/aboutdlgg.cpp:192
+msgid "Artists"
+msgstr "कलाकारहरू"
+
+#: ../src/generic/aboutdlgg.cpp:196
+msgid "Translators"
+msgstr "अनुवादकहरू"
+
+#: ../src/generic/animateg.cpp:125
+msgid "No handler found for animation type."
+msgstr "चलायमान किसिमको लागि कुनै चालक पाइ एन ।"
+
+#: ../src/generic/animateg.cpp:133
+#, c-format
+msgid "No animation handler for type %ld defined."
+msgstr "चलायमान सञ्चालक %ld जस्ताका लागि परिभाषित गरिएको छैन ।"
+
+#: ../src/generic/animateg.cpp:145
+#, c-format
+msgid "Animation file is not of type %ld."
+msgstr "चलायमान फाइल %ld प्रकृतिको होइन ।"
+
+#: ../src/generic/colrdlgg.cpp:154 ../src/gtk/colordlg.cpp:47
+msgid "Choose colour"
+msgstr "रङ्ग छान्नु होस्"
+
+#: ../src/generic/colrdlgg.cpp:357
+msgid "Red:"
+msgstr ""
+
+#: ../src/generic/colrdlgg.cpp:360
+#, fuzzy
+msgid "Green:"
+msgstr "हरियो"
+
+#: ../src/generic/colrdlgg.cpp:363
+#, fuzzy
+msgid "Blue:"
+msgstr "नीलो"
+
+#: ../src/generic/colrdlgg.cpp:372
+msgid "Opacity:"
+msgstr ""
+
+#: ../src/generic/colrdlgg.cpp:384
+msgid "Add to custom colours"
+msgstr "प्रचलित रङ्गहरूमा थप गर"
+
+#: ../src/generic/creddlgg.cpp:56
+msgid "Username:"
+msgstr ""
+
+#: ../src/generic/creddlgg.cpp:63
+msgid "Password:"
+msgstr ""
+
+#. TRANSLATORS: Name of Boolean true value
+#: ../src/generic/datavgen.cpp:1178
+msgid "true"
+msgstr ""
+
+#. TRANSLATORS: Name of Boolean false value
+#: ../src/generic/datavgen.cpp:1180
+#, fuzzy
+msgid "false"
+msgstr "असत्य"
+
+#: ../src/generic/datavgen.cpp:6897
+#, c-format
+msgid "Row %i"
+msgstr ""
+
+#. TRANSLATORS: Action for manipulating a tree control
+#: ../src/generic/datavgen.cpp:6987
+msgid "Collapse"
+msgstr ""
+
+#. TRANSLATORS: Action for manipulating a tree control
+#: ../src/generic/datavgen.cpp:6990
+msgid "Expand"
+msgstr ""
+
+#. TRANSLATORS: Name of data view control and number of rows
+#: ../src/generic/datavgen.cpp:7011
+#, fuzzy, c-format
+msgid "%s (%d items)"
+msgstr "%s (अथवा %s)"
+
+#: ../src/generic/datavgen.cpp:7062
+#, fuzzy, c-format
+msgid "Column %u"
+msgstr "महल थप"
+
+#. TRANSLATORS: Keystroke for manipulating a tree control
+#: ../src/generic/datavgen.cpp:7131 ../src/richtext/richtextbulletspage.cpp:189
+#: ../src/richtext/richtextbulletspage.cpp:192
+#: ../src/richtext/richtextbulletspage.cpp:193
+#: ../src/richtext/richtextliststylepage.cpp:252
+#: ../src/richtext/richtextliststylepage.cpp:255
+#: ../src/richtext/richtextliststylepage.cpp:256
+#: ../src/richtext/richtextsizepage.cpp:248
+msgid "Left"
+msgstr "देब्रे"
+
+#. TRANSLATORS: Keystroke for manipulating a tree control
+#: ../src/generic/datavgen.cpp:7134 ../src/richtext/richtextbulletspage.cpp:191
+#: ../src/richtext/richtextliststylepage.cpp:254
+#: ../src/richtext/richtextsizepage.cpp:249
+msgid "Right"
+msgstr "दाहिने"
+
+#: ../src/generic/datectlg.cpp:90
+#, c-format
+msgid ""
+"\"%s\" is not in the expected date format, please enter it as e.g. \"%s\"."
+msgstr ""
+
+#: ../src/generic/datectlg.cpp:94
+#, fuzzy
+msgid "Invalid date"
+msgstr "नमिल्दो तथ्याङ्क दृश्य सामाग्री"
+
+#: ../src/generic/dbgrptg.cpp:159
+#, c-format
+msgid "Open file \"%s\""
+msgstr "फाइल \"%s\" पल्टाउ "
+
+#: ../src/generic/dbgrptg.cpp:170
+#, c-format
+msgid "Enter command to open file \"%s\":"
+msgstr "फाइल \"%s\" पल्टाउन आदेश लेख:"
+
+#: ../src/generic/dbgrptg.cpp:230
+msgid "Executable files (*.exe)|*.exe|"
+msgstr "Executable फाइलहरू(*.exe)|*.exe|"
+
+#: ../src/generic/dbgrptg.cpp:300
+#, c-format
+msgid "Debug report \"%s\""
+msgstr "खान तलासी प्रतिवेदन \"%s\" "
+
+#: ../src/generic/dbgrptg.cpp:316
+msgid "A debug report has been generated in the directory\n"
+msgstr "खानतलासी प्रतिवेदन गर्रामा सिर्जना गरियो । \n"
+
+#: ../src/generic/dbgrptg.cpp:317
+msgid "The following debug report will be generated\n"
+msgstr ""
+
+#: ../src/generic/dbgrptg.cpp:321
+msgid ""
+"The report contains the files listed below. If any of these files contain "
+"private information,\n"
+"please uncheck them and they will be removed from the report.\n"
+msgstr ""
+"निम्न लिखित फाइलहरू प्रतिवेदनमा समाबेस छन् ।. यदि यी फाइलहरुमा निजी सूचना छ भने\n"
+"कृपया टिक नगर्नु होला । यसो गरेमा यीनिहरूलाई प्रतिवेदनबाट हटाइने छ । \n"
+
+#: ../src/generic/dbgrptg.cpp:323
+msgid ""
+"If you wish to suppress this debug report completely, please choose the "
+"\"Cancel\" button,\n"
+"but be warned that it may hinder improving the program, so if\n"
+"at all possible please do continue with the report generation.\n"
+msgstr ""
+"यदि तपाई यो खान तलासी प्रतिवेदनलाई पूरै दबाउन चाहनु हुन्छ भने \"रद्द गर\" भन्ने टाँकलाई "
+"दबाउनु होला \n"
+"तर ख्याल राख्नु होस्, यसले कार्यक्रमको स्तरलाई प्रभावित पनि पार्न सक्छ । \n"
+"सम्भव भएसम्म प्रतिवेदन उत्पादन गर्नु उचित हुन्छ ।\n"
+
+#: ../src/generic/dbgrptg.cpp:325
+msgid "              Thank you and we're sorry for the inconvenience!\n"
+msgstr "धन्यवाद र असुविधाका लागि क्षमा प्रार्थी छौं ।!\n"
+
+#: ../src/generic/dbgrptg.cpp:333
+msgid "&Debug report preview:"
+msgstr "प्रतिवेदन चेहराको &खानतलासी :"
+
+#: ../src/generic/dbgrptg.cpp:339
+msgid "&View..."
+msgstr "&दृश्य.."
+
+#: ../src/generic/dbgrptg.cpp:359
+msgid "&Notes:"
+msgstr "&टिप्पणीहरू:"
+
+#: ../src/generic/dbgrptg.cpp:361
+msgid ""
+"If you have any additional information pertaining to this bug\n"
+"report, please enter it here and it will be joined to it:"
+msgstr ""
+"यदि तपाइसित यो उडुस सित सम्बन्धित कुनै थप जानकारी छ भने \n"
+"खबर दिनुहोस्, कृपया यसलाई यहाँ प्रविष्टी गरेमा यहाँ जोडिने छ:"
+
+#: ../src/generic/dcpsg.cpp:1627
+msgid "Cannot open file for PostScript printing!"
+msgstr "PostScript प्रिन्टिङ गर्न फाइल खोल्न सकिँदैन ।"
+
+#: ../src/generic/dirctrlg.cpp:402
+msgid "Computer"
+msgstr "कम्प्युटर"
+
+#: ../src/generic/dirctrlg.cpp:404
+msgid "Sections"
+msgstr "खण्ड"
+
+#: ../src/generic/dirctrlg.cpp:482
+msgid "Home directory"
+msgstr "गृह घर्रा"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/generic/dirctrlg.cpp:484 ../src/propgrid/advprops.cpp:811
+msgid "Desktop"
+msgstr "डेस्कटप"
+
+#: ../src/generic/dirctrlg.cpp:528 ../src/generic/filectrlg.cpp:752
+msgid "Illegal directory name."
+msgstr "अवैध घर्राको नाम"
+
+#: ../src/generic/dirctrlg.cpp:528 ../src/generic/dirctrlg.cpp:546
+#: ../src/generic/dirctrlg.cpp:557 ../src/generic/dirdlgg.cpp:317
+#: ../src/generic/filectrlg.cpp:638 ../src/generic/filectrlg.cpp:752
+#: ../src/generic/filectrlg.cpp:766 ../src/generic/filectrlg.cpp:782
+#: ../src/generic/filectrlg.cpp:1356 ../src/generic/filectrlg.cpp:1387
+#: ../src/generic/filedlgg.cpp:362 ../src/gtk/filedlg.cpp:76
+msgid "Error"
+msgstr "गल्ती"
+
+#: ../src/generic/dirctrlg.cpp:546 ../src/generic/filectrlg.cpp:766
+msgid "File name exists already."
+msgstr "फाइल को नाम पहिले देखि नै छ ।"
+
+#: ../src/generic/dirctrlg.cpp:557 ../src/generic/dirdlgg.cpp:317
+#: ../src/generic/filectrlg.cpp:638 ../src/generic/filectrlg.cpp:782
+msgid "Operation not permitted."
+msgstr "सञ्चालनको अनुमति छैन ।"
+
+#: ../src/generic/dirdlgg.cpp:107 ../src/generic/filedlgg.cpp:207
+msgid "Create new directory"
+msgstr "नया घर्राको सिर्जना गर्नु होस्"
+
+#: ../src/generic/dirdlgg.cpp:112 ../src/generic/filedlgg.cpp:203
+msgid "Go to home directory"
+msgstr "गृह गर्रामा जाउ "
+
+#: ../src/generic/dirdlgg.cpp:143
+msgid "Show &hidden directories"
+msgstr "&लुकाएका घर्राहरू देखाउ "
+
+#: ../src/generic/dirdlgg.cpp:196
+#, c-format
+msgid ""
+"The directory '%s' does not exist\n"
+"Create it now?"
+msgstr ""
+"घर्रा '%s' भेट्टिएन ।\n"
+"नयाँ सिर्जना गर्ने हो?"
+
+#: ../src/generic/dirdlgg.cpp:198
+msgid "Directory does not exist"
+msgstr "घर्रा छदै छैन"
+
+#: ../src/generic/dirdlgg.cpp:214
+#, c-format
+msgid ""
+"Failed to create directory '%s'\n"
+"(Do you have the required permissions?)"
+msgstr ""
+"घर्रा '%s' सिर्जना गर्न सकिएन । \n"
+"(केतपाइ सित आवश्यक स्वीकृती छ?)"
+
+#: ../src/generic/dirdlgg.cpp:216
+msgid "Error creating directory"
+msgstr "घर्रा सिर्जनामा गल्ती "
+
+#: ../src/generic/dirdlgg.cpp:281
+msgid "You cannot add a new directory to this section."
+msgstr "तपाइले यो खण्डमा नया घर्रा थप्न सक्नु हुन्न ।"
+
+#: ../src/generic/dirdlgg.cpp:282
+msgid "Create directory"
+msgstr "घर्राको सिर्जना गर्नु होस्"
+
+#: ../src/generic/dirdlgg.cpp:291 ../src/generic/dirdlgg.cpp:301
+#: ../src/generic/filectrlg.cpp:614 ../src/generic/filectrlg.cpp:623
+msgid "NewName"
+msgstr "नया नाम"
+
+#: ../src/generic/editlbox.cpp:135
+msgid "Edit item"
+msgstr "सम्पादन सामाग्री"
+
+#: ../src/generic/editlbox.cpp:143
+msgid "New item"
+msgstr "नया सामाग्री"
+
+#: ../src/generic/editlbox.cpp:151
+msgid "Delete item"
+msgstr "सामाग्री मेटाइ देउ "
+
+#: ../src/generic/editlbox.cpp:159
+msgid "Move up"
+msgstr "माथि जाउ "
+
+#: ../src/generic/editlbox.cpp:164
+msgid "Move down"
+msgstr "तल जाउ "
+
+#: ../src/generic/fdrepdlg.cpp:108
+msgid "Search for:"
+msgstr "यसलाई खोज्ने:"
+
+#: ../src/generic/fdrepdlg.cpp:120
+msgid "Replace with:"
+msgstr "यसमा बदलि देउ :"
+
+#: ../src/generic/fdrepdlg.cpp:140
+msgid "Whole word"
+msgstr "पुरै शब्द"
+
+#: ../src/generic/fdrepdlg.cpp:143
+msgid "Match case"
+msgstr "वर्ण मिलान"
+
+#: ../src/generic/fdrepdlg.cpp:156
+msgid "Search direction"
+msgstr "खोजी दिशा"
+
+#: ../src/generic/fdrepdlg.cpp:175
+msgid "&Replace"
+msgstr "&प्रतिस्थापन"
+
+#: ../src/generic/fdrepdlg.cpp:178
+msgid "Replace &all"
+msgstr "&सबैको प्रतिस्थापन "
+
+#: ../src/generic/filectrlg.cpp:246 ../src/generic/filectrlg.cpp:269
+msgid "<DIR>"
+msgstr "<DIR>"
+
+#: ../src/generic/filectrlg.cpp:248 ../src/generic/filectrlg.cpp:271
+msgid "<LINK>"
+msgstr "<LINK>"
+
+#: ../src/generic/filectrlg.cpp:250 ../src/generic/filectrlg.cpp:273
+msgid "<DRIVE>"
+msgstr "<DRIVE>"
+
+#: ../src/generic/filectrlg.cpp:275
+#, c-format
+msgid "%ld byte"
+msgid_plural "%ld bytes"
+msgstr[0] "%ld बाइट"
+msgstr[1] "%ld बाइटहरू"
+
+#: ../src/generic/filectrlg.cpp:420
+msgid "Name"
+msgstr "नाम"
+
+#: ../src/generic/filectrlg.cpp:421 ../src/richtext/richtextformatdlg.cpp:361
+#: ../src/richtext/richtextsizepage.cpp:298
+msgid "Size"
+msgstr "आकार"
+
+#: ../src/generic/filectrlg.cpp:422
+msgid "Type"
+msgstr "टङ्कण"
+
+#: ../src/generic/filectrlg.cpp:423
+msgid "Modified"
+msgstr "परिवर्तित"
+
+#: ../src/generic/filectrlg.cpp:426
+msgid "Permissions"
+msgstr "अनुमति"
+
+#: ../src/generic/filectrlg.cpp:429
+msgid "Attributes"
+msgstr "Attributes"
+
+#: ../src/generic/filectrlg.cpp:936
+msgid "Current directory:"
+msgstr "चालू घर्रा:"
+
+#: ../src/generic/filectrlg.cpp:979
+msgid "Show &hidden files"
+msgstr "&लुकाएका फाइलहरू देखाउ "
+
+#: ../src/generic/filectrlg.cpp:1355
+msgid "Illegal file specification."
+msgstr "अवैध फाइल मानकहरू"
+
+#: ../src/generic/filectrlg.cpp:1387
+msgid "Directory doesn't exist."
+msgstr "घर्रा छदै छैन"
+
+#: ../src/generic/filedlgg.cpp:195
+msgid "View files as a list view"
+msgstr "सूचि दृश्यको रूपमा फाइल हेर्नु होस् "
+
+#: ../src/generic/filedlgg.cpp:197
+msgid "View files as a detailed view"
+msgstr "विस्तृत दृश्यको रूपमा फाइल हेर्नु होस् "
+
+#: ../src/generic/filedlgg.cpp:200
+msgid "Go to parent directory"
+msgstr "उपल्लो गर्रामा जाउ"
+
+#: ../src/generic/filedlgg.cpp:351 ../src/gtk/filedlg.cpp:59
+#, c-format
+msgid "File '%s' already exists, do you really want to overwrite it?"
+msgstr ""
+"फाइल '%s' पहिले देखि नै छ, के तपाइ वास्तवमा नै यसलाई मेटाएर नया राख्न चाहनु हुन्छ?"
+
+#: ../src/generic/filedlgg.cpp:354 ../src/gtk/filedlg.cpp:62
+msgid "Confirm"
+msgstr "यकिन गर्नु होस्"
+
+#: ../src/generic/filedlgg.cpp:362 ../src/gtk/filedlg.cpp:75
+msgid "Please choose an existing file."
+msgstr "भण्डारमा भएको फाइल छान्नु होस् ।"
+
+#: ../src/generic/filepickerg.cpp:64
+msgid "..."
+msgstr ".."
+
+#: ../src/generic/fontdlgg.cpp:76 ../src/richtext/richtextformatdlg.cpp:519
+msgid "ABCDEFGabcdefg12345"
+msgstr "ABCDEFGabcdefg12345"
+
+#: ../src/generic/fontdlgg.cpp:315
+msgid "Roman"
+msgstr "रोमन"
+
+#: ../src/generic/fontdlgg.cpp:316
+msgid "Decorative"
+msgstr "श्रृङ्गार युक्त"
+
+#: ../src/generic/fontdlgg.cpp:317
+msgid "Modern"
+msgstr "आधुनिक"
+
+#: ../src/generic/fontdlgg.cpp:318
+msgid "Script"
+msgstr "Script"
+
+#: ../src/generic/fontdlgg.cpp:319
+msgid "Swiss"
+msgstr "Swiss"
+
+#: ../src/generic/fontdlgg.cpp:320
+msgid "Teletype"
+msgstr "Teletype"
+
+#: ../src/generic/fontdlgg.cpp:321 ../src/generic/fontdlgg.cpp:324
+msgid "Normal"
+msgstr "साधारण"
+
+#: ../src/generic/fontdlgg.cpp:323
+msgid "Slant"
+msgstr "छड्के"
+
+#: ../src/generic/fontdlgg.cpp:325
+msgid "Light"
+msgstr "हलुको"
+
+#: ../src/generic/fontdlgg.cpp:363
+msgid "&Font family:"
+msgstr "&वरणाकृति परिवार:"
+
+#: ../src/generic/fontdlgg.cpp:367 ../src/generic/fontdlgg.cpp:369
+msgid "The font family."
+msgstr "वरणाकृतिको परिवार"
+
+#: ../src/generic/fontdlgg.cpp:374 ../src/richtext/richtextstylepage.cpp:105
+msgid "&Style:"
+msgstr "&शैली:"
+
+#: ../src/generic/fontdlgg.cpp:378 ../src/generic/fontdlgg.cpp:380
+msgid "The font style."
+msgstr "वरणाकृतिको शैली"
+
+#: ../src/generic/fontdlgg.cpp:385
+msgid "&Weight:"
+msgstr "&भार:"
+
+#: ../src/generic/fontdlgg.cpp:389 ../src/generic/fontdlgg.cpp:391
+msgid "The font weight."
+msgstr "वरणाकृतिको भार"
+
+#: ../src/generic/fontdlgg.cpp:399
+msgid "C&olour:"
+msgstr " &रङ्ग:"
+
+#: ../src/generic/fontdlgg.cpp:407 ../src/generic/fontdlgg.cpp:409
+msgid "The font colour."
+msgstr "वरणाकृतिको रङ्ग"
+
+#: ../src/generic/fontdlgg.cpp:415
+msgid "&Point size:"
+msgstr "&थोप्लोको आकार:"
+
+#: ../src/generic/fontdlgg.cpp:420 ../src/generic/fontdlgg.cpp:422
+#: ../src/generic/fontdlgg.cpp:426 ../src/generic/fontdlgg.cpp:428
+msgid "The font point size."
+msgstr "वरणाकृतिको आकार (थोप्लोमा)"
+
+#: ../src/generic/fontdlgg.cpp:439 ../src/generic/fontdlgg.cpp:441
+msgid "Whether the font is underlined."
+msgstr "वरणाकृति अधोरेखाङ्कित छ वा चैन ।"
+
+#: ../src/generic/fontdlgg.cpp:448 ../src/html/helpwnd.cpp:1215
+msgid "Preview:"
+msgstr "चेहरा:"
+
+#: ../src/generic/fontdlgg.cpp:452 ../src/generic/fontdlgg.cpp:454
+msgid "Shows the font preview."
+msgstr "वरणाकृति चेहरा देखाउ छ ।"
+
+#: ../src/generic/fontdlgg.cpp:464 ../src/generic/fontdlgg.cpp:483
+msgid "Click to cancel the font selection."
+msgstr "वरणाकृतिको चयन रद्द गर्न किटिक्क पार्नु होस्"
+
+#: ../src/generic/fontdlgg.cpp:469 ../src/generic/fontdlgg.cpp:471
+#: ../src/generic/fontdlgg.cpp:476 ../src/generic/fontdlgg.cpp:478
+msgid "Click to confirm the font selection."
+msgstr "वरणाकृतिको चयन यकिन गर्न किटिक्क पार्नु होस्"
+
+#: ../src/generic/fontpickerg.cpp:50 ../src/gtk/fontdlg.cpp:77
+msgid "Choose font"
+msgstr "वरणाकृति छान्नु होस्"
+
+#: ../src/generic/grid.cpp:6542
+msgid ""
+"Error copying grid to the clipboard. Either selected cells were not "
+"contiguous or no cell was selected."
+msgstr ""
+
+#: ../src/generic/grid.cpp:12739
+#, fuzzy
+msgid "Grid Corner"
+msgstr "कोण"
+
+#: ../src/generic/grid.cpp:12741
+#, fuzzy, c-format
+msgid "Column %s Header"
+msgstr "महल थप"
+
+#: ../src/generic/grid.cpp:12743
+#, c-format
+msgid "Row %s Header"
+msgstr ""
+
+#: ../src/generic/grid.cpp:12745
+#, fuzzy, c-format
+msgid "Column %s: %s"
+msgstr "महल थप"
+
+#: ../src/generic/grid.cpp:12749
+#, c-format
+msgid "Row %s: %s"
+msgstr ""
+
+#: ../src/generic/grid.cpp:12753
+#, c-format
+msgid "Row %s, Column %s: %s"
+msgstr ""
+
+#: ../src/generic/helpext.cpp:257
+#, c-format
+msgid "Help directory \"%s\" not found."
+msgstr "सहयोग घर्रा \"%s\" पाइ एन ।"
+
+#: ../src/generic/helpext.cpp:265
+#, c-format
+msgid "Help file \"%s\" not found."
+msgstr "सहयोग फाइल \"%s\" पाइ एन ।"
+
+#: ../src/generic/helpext.cpp:284
+#, c-format
+msgid "Line %lu of map file \"%s\" has invalid syntax, skipped."
+msgstr "लाइन %lu मा (नक्सा फाइल \"%s\" ) नमिल्दो लेखाइ छ, फड्को मारेर जाउ"
+
+#: ../src/generic/helpext.cpp:292
+#, c-format
+msgid "No valid mappings found in the file \"%s\"."
+msgstr "फाइल \"%s\" मा वैध रङ्गिन नक्सा पाइ एन ।"
+
+#: ../src/generic/helpext.cpp:435
+msgid "No entries found."
+msgstr "कुनै प्रविष्टि पाइ एन"
+
+#: ../src/generic/helpext.cpp:444 ../src/generic/helpext.cpp:445
+msgid "Help Index"
+msgstr "सहयोग अनुक्रमणिका"
+
+#: ../src/generic/helpext.cpp:448
+msgid "Relevant entries:"
+msgstr "सन्दर्भित प्रविष्टि:"
+
+#: ../src/generic/helpext.cpp:449
+msgid "Entries found"
+msgstr "प्रविष्टि पाइयो"
+
+#: ../src/generic/hyperlinkg.cpp:170
+msgid "&Copy URL"
+msgstr "Url को &नक्कल उतार "
+
+#: ../src/generic/infobar.cpp:119
+msgid "Hide this notification message."
+msgstr "सूचना सन्देश लुकाउ "
+
+#. TRANSLATORS: %s will be either the application name or "Application"
+#: ../src/generic/logg.cpp:257
+#, c-format
+msgid "%s Error"
+msgstr "%s गल्ती"
+
+#. TRANSLATORS: %s will be either the application name or "Application"
+#: ../src/generic/logg.cpp:263
+#, c-format
+msgid "%s Warning"
+msgstr "%s चेतावनी"
+
+#. TRANSLATORS: %s will be either the application name or "Application"
+#: ../src/generic/logg.cpp:273
+#, c-format
+msgid "%s Information"
+msgstr "%s सूचना"
+
+#: ../src/generic/logg.cpp:276
+msgid "Application"
+msgstr "अनुप्रयोग"
+
+#: ../src/generic/logg.cpp:549
+msgid "Save log contents to file"
+msgstr "लग पुस्तिकाको सामाग्रीलाई फाइलमा बचत गर"
+
+#: ../src/generic/logg.cpp:551
+msgid "C&lear"
+msgstr "&मेटाउ"
+
+#: ../src/generic/logg.cpp:551
+msgid "Clear the log contents"
+msgstr "लग पुस्तिका का सामाग्रीहरू मेटाउ "
+
+#: ../src/generic/logg.cpp:553
+msgid "Close this window"
+msgstr "यो विन्डो बन्द गर "
+
+#: ../src/generic/logg.cpp:554
+msgid "&Log"
+msgstr "&पुस्तिका"
+
+#: ../src/generic/logg.cpp:610 ../src/generic/logg.cpp:992
+msgid "Can't save log contents to file."
+msgstr "लग पुस्तिकाका सामाग्रीहरूलाई बचत गर्न सकिँदैन ।"
+
+#: ../src/generic/logg.cpp:613
+#, c-format
+msgid "Log saved to the file '%s'."
+msgstr "लग फाइल '%s' मा बचत भयो ।"
+
+#: ../src/generic/logg.cpp:719
+msgid "&Details"
+msgstr "विस्तृत"
+
+#: ../src/generic/logg.cpp:972
+msgid "Failed to copy dialog contents to the clipboard."
+msgstr "पर्दामा भएका सामाग्रीहरू लाई क्लिप पाटीमा उतार्न सकिएन ।"
+
+#: ../src/generic/logg.cpp:1022
+#, c-format
+msgid "Append log to file '%s' (choosing [No] will overwrite it)?"
+msgstr "फाइल '%s' मा लग पुस्तिका थपेर लेख ।([NO] छानेमा यसै माथि लेख्ने छ ।"
+
+#: ../src/generic/logg.cpp:1024
+msgid "Question"
+msgstr "प्रश्न"
+
+#: ../src/generic/logg.cpp:1038
+msgid "invalid message box return value"
+msgstr "सन्देश बाकसको मान अवैध छ । "
+
+#: ../src/generic/notifmsgg.cpp:129
+msgid "Notice"
+msgstr "सूचना"
+
+#: ../src/generic/preferencesg.cpp:118
+#, c-format
+msgid "%s Preferences"
+msgstr " %s प्राथमिकताहरू "
+
+#: ../src/generic/printps.cpp:143
+msgid "Printing..."
+msgstr "छाप्ने काम दुदै च.."
+
+#: ../src/generic/printps.cpp:160 ../src/gtk/print.cpp:1076
+#: ../src/msw/printwin.cpp:235
+msgid "Could not start printing."
+msgstr "प्रिन्टिङ सुरु गर्न सकिएन"
+
+#: ../src/generic/printps.cpp:183
+#, c-format
+msgid "Printing page %d..."
+msgstr "पृष्ट %d.. छापिँदै छ ।"
+
+#: ../src/generic/prntdlgg.cpp:171
+msgid "Printer options"
+msgstr "प्रिन्टर विकल्पहरू"
+
+#: ../src/generic/prntdlgg.cpp:176
+msgid "Print to File"
+msgstr "फाइलमा लेख ।"
+
+#: ../src/generic/prntdlgg.cpp:179
+msgid "Setup..."
+msgstr "स्थापक"
+
+#: ../src/generic/prntdlgg.cpp:187
+msgid "Printer:"
+msgstr "प्रिन्टर:"
+
+#: ../src/generic/prntdlgg.cpp:195
+msgid "Status:"
+msgstr "स्थिति:"
+
+#: ../src/generic/prntdlgg.cpp:206
+msgid "All"
+msgstr "सबै"
+
+#: ../src/generic/prntdlgg.cpp:207
+msgid "Pages"
+msgstr "पानाहरू "
+
+#: ../src/generic/prntdlgg.cpp:215
+msgid "Print Range"
+msgstr "कति छाप्ने हो"
+
+#: ../src/generic/prntdlgg.cpp:229
+msgid "From:"
+msgstr "बाट:"
+
+#: ../src/generic/prntdlgg.cpp:233
+msgid "To:"
+msgstr "लाई:"
+
+#: ../src/generic/prntdlgg.cpp:238
+msgid "Copies:"
+msgstr "प्रतिहरू:"
+
+#: ../src/generic/prntdlgg.cpp:288
+msgid "PostScript file"
+msgstr "PostScript फाइल"
+
+#: ../src/generic/prntdlgg.cpp:439
+msgid "Print Setup"
+msgstr "छाप्ने रूप"
+
+#: ../src/generic/prntdlgg.cpp:483
+msgid "Printer"
+msgstr "प्रिन्टर"
+
+#: ../src/generic/prntdlgg.cpp:501
+msgid "Default printer"
+msgstr "निर्धारित प्रिन्टर"
+
+#: ../src/generic/prntdlgg.cpp:595 ../src/generic/prntdlgg.cpp:782
+#: ../src/generic/prntdlgg.cpp:822 ../src/generic/prntdlgg.cpp:835
+#: ../src/generic/prntdlgg.cpp:1031 ../src/generic/prntdlgg.cpp:1036
+msgid "Paper size"
+msgstr "कागजको आकार"
+
+#: ../src/generic/prntdlgg.cpp:604 ../src/generic/prntdlgg.cpp:847
+msgid "Portrait"
+msgstr "ठाडो"
+
+#: ../src/generic/prntdlgg.cpp:605 ../src/generic/prntdlgg.cpp:848
+msgid "Landscape"
+msgstr "तेर्सो"
+
+#: ../src/generic/prntdlgg.cpp:607 ../src/generic/prntdlgg.cpp:849
+msgid "Orientation"
+msgstr "झुकाव"
+
+#: ../src/generic/prntdlgg.cpp:610
+msgid "Options"
+msgstr "विकल्पहरू"
+
+#: ../src/generic/prntdlgg.cpp:612
+msgid "Print in colour"
+msgstr "रङ्गिन छाप्ने काम"
+
+#: ../src/generic/prntdlgg.cpp:621
+msgid "Print spooling"
+msgstr "छापिने काम बिग्रयो ।"
+
+#: ../src/generic/prntdlgg.cpp:623
+msgid "Printer command:"
+msgstr "प्रिन्टर आदेश:"
+
+#: ../src/generic/prntdlgg.cpp:631
+msgid "Printer options:"
+msgstr "प्रिन्टर विकल्पहरू:"
+
+#: ../src/generic/prntdlgg.cpp:860
+msgid "Left margin (mm):"
+msgstr "देब्रे सिमान्त(मिमी):"
+
+#: ../src/generic/prntdlgg.cpp:861
+msgid "Top margin (mm):"
+msgstr "सिरान किनार (मिमि):"
+
+#: ../src/generic/prntdlgg.cpp:872
+msgid "Right margin (mm):"
+msgstr "दाहिने सिमान्त (मिमि):"
+
+#: ../src/generic/prntdlgg.cpp:873
+msgid "Bottom margin (mm):"
+msgstr "तलको सिमान्त (मिमि):"
+
+#: ../src/generic/prntdlgg.cpp:896
+msgid "Printer..."
+msgstr "प्रिन्टर.."
+
+#: ../src/generic/progdlgg.cpp:246
+msgid "&Skip"
+msgstr "&उफ्र"
+
+#: ../src/generic/progdlgg.cpp:347 ../src/generic/progdlgg.cpp:626
+msgid "Unknown"
+msgstr "अज्ञात"
+
+#: ../src/generic/progdlgg.cpp:451 ../src/msw/progdlg.cpp:526
+msgid "Done."
+msgstr "सकियो"
+
+#: ../src/generic/srchctlg.cpp:55 ../src/gtk/srchctrl.cpp:206
+#: ../src/html/helpwnd.cpp:530 ../src/html/helpwnd.cpp:545
+msgid "Search"
+msgstr "खोजतलास"
+
+#: ../src/generic/tabg.cpp:1026
+msgid "Could not find tab for id"
+msgstr "ID का लागि tab फेला परेन"
+
+#: ../src/generic/tipdlg.cpp:136
+msgid "Tips not available, sorry!"
+msgstr "कुनै तौर तरिका उपलब्ध छैन ।!"
+
+#: ../src/generic/tipdlg.cpp:197
+msgid "Tip of the Day"
+msgstr "आजको विशेष कुरा"
+
+#: ../src/generic/tipdlg.cpp:207
+msgid "Did you know..."
+msgstr "के तपाइलाई थाहा छ?"
+
+#: ../src/generic/tipdlg.cpp:232
+msgid "&Show tips at startup"
+msgstr "&सुरु हुँदा टिपोट देखाउ"
+
+#: ../src/generic/tipdlg.cpp:236
+msgid "&Next Tip"
+msgstr "&अघिल्लो टिपोट"
+
+#: ../src/generic/wizard.cpp:411
+msgid "&Next >"
+msgstr "&अघिल्लो >"
+
+#: ../src/generic/wizard.cpp:412
+msgid "&Finish"
+msgstr "&समाप्त"
+
+#: ../src/generic/wizard.cpp:420
+msgid "< &Back"
+msgstr "< &पछाडि"
+
+#: ../src/gtk/aboutdlg.cpp:204
+msgid "translator-credits"
+msgstr "अणुवादकन-श्रेय"
+
+#: ../src/gtk/app.cpp:517
+msgid ""
+"WARNING: using XIM input method is unsupported and may result in problems "
+"with input handling and flickering. Consider unsetting GTK_IM_MODULE or "
+"setting to \"ibus\"."
+msgstr ""
+
+#: ../src/gtk/app.cpp:569
+msgid "Unable to initialize GTK+, is DISPLAY set properly?"
+msgstr "GTK+ लाई सुरुवात गर्न सकिएन, के दृश्यक त राम्ररी मिलाएको छ ?"
+
+#: ../src/gtk/filedlg.cpp:89 ../src/gtk/filepicker.cpp:255
+#, fuzzy, c-format
+msgid "Changing current directory to \"%s\" failed"
+msgstr "घर्रा \"%s\" सिर्जना गर्न सकिएन ।"
+
+#: ../src/gtk/font.cpp:548
+msgid ""
+"Using private fonts is not supported on this system: Pango library is too "
+"old, 1.38 or later required."
+msgstr ""
+
+#: ../src/gtk/font.cpp:558
+#, fuzzy
+msgid "Failed to create font configuration object."
+msgstr "उपभोक्ता अभियोजन फाइल अद्यावधि करण गर्न सकिएन ।"
+
+#: ../src/gtk/font.cpp:568
+#, fuzzy, c-format
+msgid "Failed to add custom font \"%s\"."
+msgstr "फाइल \"%s\". बाट कागजात पढ्न सकिएन ।"
+
+#: ../src/gtk/font.cpp:576
+#, fuzzy
+msgid "Failed to register font configuration using private fonts."
+msgstr "उपभोक्ता अभियोजन फाइल अद्यावधि करण गर्न सकिएन ।"
+
+#: ../src/gtk/glcanvas.cpp:117 ../src/gtk/glcanvas.cpp:132
+#, fuzzy
+msgid "Fatal Error"
+msgstr "फाइलको गल्ती"
+
+#: ../src/gtk/glcanvas.cpp:117
+msgid ""
+"This program wasn't compiled with EGL support required under Wayland, "
+"either\n"
+"install EGL libraries and rebuild or run it under X11 backend by setting\n"
+"environment variable GDK_BACKEND=x11 before starting your program."
+msgstr ""
+
+#: ../src/gtk/glcanvas.cpp:132
+msgid ""
+"wxGLCanvas is only supported on Wayland and X11 currently.  You may be able "
+"to\n"
+"work around this by setting environment variable GDK_BACKEND=x11 before\n"
+"starting your program."
+msgstr ""
+
+#: ../src/gtk/mdi.cpp:433
+msgid "MDI child"
+msgstr "MDI शिशु"
+
+#: ../src/gtk/power.cpp:188
+#, fuzzy, c-format
+msgid "Failed to open D-Bus connection to the login manager: %s"
+msgstr "सर्बर '%s' मा शीर्षक '%s' सित सम्बन्ध गाँस्न सकिएन ।"
+
+#: ../src/gtk/power.cpp:214
+#, fuzzy
+msgid "wxWidgets application"
+msgstr "अनुप्रयोग"
+
+#: ../src/gtk/power.cpp:226
+msgid "Application needs to keep running"
+msgstr ""
+
+#: ../src/gtk/power.cpp:233
+msgid "Clean up before suspend"
+msgstr ""
+
+#: ../src/gtk/power.cpp:259
+#, fuzzy, c-format
+msgid "Failed to inhibit sleep: %s"
+msgstr "%s डायलअप जडान गराउन सकिएन ।"
+
+#: ../src/gtk/power.cpp:265
+msgid "Unexpected response to D-Bus \"Inhibit\" request."
+msgstr ""
+
+#: ../src/gtk/print.cpp:218
+msgid "Custom size"
+msgstr "चल्तीको आकार"
+
+#: ../src/gtk/print.cpp:752
+#, fuzzy, c-format
+msgid "Error while printing: %s"
+msgstr "प्रिन्टिङ गर्दा गल्ती भयो : "
+
+#: ../src/gtk/print.cpp:816
+msgid "Page Setup"
+msgstr "पृष्ट मिलाउ"
+
+#: ../src/gtk/webview_webkit.cpp:932
+msgid "Retrieving JavaScript script output is not supported with WebKit v1"
+msgstr ""
+
+#: ../src/gtk/webview_webkit2.cpp:1098
+msgid ""
+"Setting proxy is not supported by WebKit, at least version 2.16 is required."
+msgstr ""
+
+#: ../src/gtk/webview_webkit2.cpp:1104
+msgid "This program was compiled without support for setting WebKit proxy."
+msgstr ""
+
+#: ../src/gtk/window.cpp:6289
+msgid ""
+"GTK+ installed on this machine is too old to support screen compositing, "
+"please install GTK+ 2.12 or later."
+msgstr ""
+"यो कम्प्युटरमा स्थापित GTK+ धेरै पुरानो रहेछ पर्दाको पूर्तिको लागि GTK+ 2.12 अथवा यो "
+"भन्दा नयाँ संस्करण स्थापित गर्नु होला ।"
+
+#: ../src/gtk/window.cpp:6307
+msgid ""
+"Compositing not supported by this system, please enable it in your Window "
+"Manager."
+msgstr ""
+"यो प्रणालीले क्षतिपूर्ति लाइ समर्थन गर्दैन । कृपया तपाइको विन्डो व्यवस्थापकमा यसलाई सक्षम "
+"बनाउनु होस् "
+
+#: ../src/gtk/window.cpp:6318
+msgid ""
+"This program was compiled with a too old version of GTK+, please rebuild "
+"with GTK+ 2.12 or newer."
+msgstr ""
+"यो कार्यक्रम निकै पुरानो GTK+ संस्करणमा प्रशोधन गरियो । कृपया GTK+ 2.12 अथवा यो भन्दा "
+"नया संस्करण राख्नु होला ।"
+
+#: ../src/html/chm.cpp:138
+#, c-format
+msgid "Failed to open CHM archive '%s'."
+msgstr "सङ्ग्रह '%s' खोल्न सकिएन ।"
+
+#: ../src/html/chm.cpp:270
+#, c-format
+msgid "Could not extract %s into %s: %s"
+msgstr "%s लाई %s मा तान्न सकिएन: %s"
+
+#: ../src/html/chm.cpp:324
+msgid "no error"
+msgstr "गल्ती छैन"
+
+#: ../src/html/chm.cpp:326
+msgid "bad arguments to library function"
+msgstr "पुस्तकालय function का लागि नमिल्ने तर्क "
+
+#: ../src/html/chm.cpp:328
+msgid "error opening file"
+msgstr "फाइल खोल्दा गल्ती"
+
+#: ../src/html/chm.cpp:330
+msgid "read error"
+msgstr "पढ्नमा गल्ती"
+
+#: ../src/html/chm.cpp:332
+msgid "write error"
+msgstr "लेखाइमा गल्ती"
+
+#: ../src/html/chm.cpp:334
+msgid "seek error"
+msgstr "खोजीको गल्ती "
+
+#: ../src/html/chm.cpp:338
+msgid "bad signature"
+msgstr "गलत हस्ताक्षर"
+
+#: ../src/html/chm.cpp:340
+msgid "error in data format"
+msgstr "तथ्याङ्क बनोटमा गल्ती "
+
+#: ../src/html/chm.cpp:342
+msgid "checksum error"
+msgstr "गल्ती जाँच सूचि"
+
+#: ../src/html/chm.cpp:344
+msgid "compression error"
+msgstr "दबाब गल्ती"
+
+#: ../src/html/chm.cpp:346
+msgid "decompression error"
+msgstr "दबाब विहीनता गल्ती"
+
+#: ../src/html/chm.cpp:437
+#, c-format
+msgid "Could not locate file '%s'."
+msgstr "फाइल '%s' पत्तो लागेन"
+
+#: ../src/html/chm.cpp:711
+#, c-format
+msgid "Could not create temporary file '%s'"
+msgstr "अस्ताइ फाइल '%s' सिर्जना गर्न सकिएन "
+
+#: ../src/html/chm.cpp:718
+#, c-format
+msgid "Extraction of '%s' into '%s' failed."
+msgstr "'%s' लाई '%s' मा खिच्ने काम असफल भयो ।"
+
+#: ../src/html/chm.cpp:806 ../src/html/chm.cpp:863
+msgid "CHM handler currently supports only local files!"
+msgstr "CHM handler ले हाल स्थानीय फाइललाई मात्र समर्थन गर्छ ।"
+
+#: ../src/html/chm.cpp:827
+msgid "Link contained '//', converted to absolute link."
+msgstr "लिङ्क मा '//' छ, पुर्ण लिङ्कमा बदलियो ।"
+
+#: ../src/html/helpctrl.cpp:59
+#, c-format
+msgid "Help: %s"
+msgstr "सहयोग: %s"
+
+#: ../src/html/helpctrl.cpp:155
+#, c-format
+msgid "Adding book %s"
+msgstr "किताब %s थिदै"
+
+#: ../src/html/helpdata.cpp:295
+#, c-format
+msgid "Cannot open contents file: %s"
+msgstr "विषय सुची फाइल: %s लाइ खोल्न सकिँदैन"
+
+#: ../src/html/helpdata.cpp:309
+#, c-format
+msgid "Cannot open index file: %s"
+msgstr "अनुक्रमणिका फाइल: %s खोल्न सकिँदैन ।"
+
+#: ../src/html/helpdata.cpp:643
+msgid "noname"
+msgstr "बैनामै "
+
+#: ../src/html/helpdata.cpp:652
+#, c-format
+msgid "Cannot open HTML help book: %s"
+msgstr "HTML सहयोग किताब: %s लाइ खोल्न सकिँदैन ।"
+
+#: ../src/html/helpwnd.cpp:315
+msgid "Displays help as you browse the books on the left."
+msgstr "किताब पल्टाउँदा देब्रे पट्टि सहयोग देखाउँछ "
+
+#: ../src/html/helpwnd.cpp:411 ../src/html/helpwnd.cpp:1100
+#: ../src/html/helpwnd.cpp:1735
+msgid "(bookmarks)"
+msgstr "(बुकमार्क)"
+
+#: ../src/html/helpwnd.cpp:424
+msgid "Add current page to bookmarks"
+msgstr "चालू पृष्टलाई बुकमार्कमा थप गर"
+
+#: ../src/html/helpwnd.cpp:425
+msgid "Remove current page from bookmarks"
+msgstr "पृष्ट लाई बुकमार्कबाट हटाउ"
+
+#: ../src/html/helpwnd.cpp:470
+msgid "Contents"
+msgstr "सामाग्रीहरू"
+
+#: ../src/html/helpwnd.cpp:485
+msgid "Find"
+msgstr "फेला पार"
+
+#: ../src/html/helpwnd.cpp:487
+msgid "Show all"
+msgstr " सबै देखाउ "
+
+#: ../src/html/helpwnd.cpp:497
+msgid ""
+"Display all index items that contain given substring. Search is case "
+"insensitive."
+msgstr ""
+"प्रदान गरिएको शब्द भएका सबै अनुसूची लाई देखाउ । खोज तलासले ठूलो वा सानो वर्णको वास्ता "
+"गर्दैन । "
+
+#: ../src/html/helpwnd.cpp:498
+msgid "Show all items in index"
+msgstr "सबै सामाग्रीलाई अनुक्रमणिकामा देखाउ "
+
+#: ../src/html/helpwnd.cpp:528
+msgid "Case sensitive"
+msgstr "Case सम्बेदनसिल "
+
+#: ../src/html/helpwnd.cpp:529
+msgid "Whole words only"
+msgstr "पुरै शब्दहरू मात्र"
+
+#: ../src/html/helpwnd.cpp:532
+msgid ""
+"Search contents of help book(s) for all occurrences of the text you typed "
+"above"
+msgstr "सहयोग किताब (s) का सबै सामाग्रीमा यस अघि टङ्कण गरेको पाठहरू लाई खोज ।"
+
+#: ../src/html/helpwnd.cpp:653
+msgid "Show/hide navigation panel"
+msgstr "आवागमन कक्ष देखाउ/लुकाउ "
+
+#: ../src/html/helpwnd.cpp:655
+msgid "Go back"
+msgstr "फर्केर जाउ"
+
+#: ../src/html/helpwnd.cpp:656
+msgid "Go forward"
+msgstr "अगाडी जाउ"
+
+#: ../src/html/helpwnd.cpp:658
+msgid "Go one level up in document hierarchy"
+msgstr "कागजातको मर्यादामा एक तह माथि जाउ"
+
+#: ../src/html/helpwnd.cpp:666 ../src/html/helpwnd.cpp:1547
+msgid "Open HTML document"
+msgstr "HTML कागजात पल्टाउ "
+
+#: ../src/html/helpwnd.cpp:670
+msgid "Print this page"
+msgstr "यो पृष्ट छापी देउ"
+
+#: ../src/html/helpwnd.cpp:674
+msgid "Display options dialog"
+msgstr "विकल्प पातो देखाउ"
+
+#: ../src/html/helpwnd.cpp:795
+msgid "Please choose the page to display:"
+msgstr "कृपया देखाइने पृष्ट छान्नु होस् ।"
+
+#: ../src/html/helpwnd.cpp:796
+msgid "Help Topics"
+msgstr "सहयोग शीर्षक"
+
+#: ../src/html/helpwnd.cpp:852
+msgid "Searching..."
+msgstr "खोजतलास हुँदैछ "
+
+#: ../src/html/helpwnd.cpp:853
+msgid "No matching page found yet"
+msgstr "मिल्दो पृष्ट अझसम्म पाइ एन ।"
+
+#: ../src/html/helpwnd.cpp:870
+#, c-format
+msgid "Found %i matches"
+msgstr "%i मिल्दो झुल्दो पाइयो ।"
+
+#: ../src/html/helpwnd.cpp:958
+msgid "(Help)"
+msgstr "(सहयोग)"
+
+#: ../src/html/helpwnd.cpp:1026
+#, c-format
+msgid "%d of %lu"
+msgstr "%d को %lu"
+
+#: ../src/html/helpwnd.cpp:1028
+#, c-format
+msgid "%lu of %lu"
+msgstr "%lu को %lu"
+
+#: ../src/html/helpwnd.cpp:1047
+msgid "Search in all books"
+msgstr "सबै किताबहरूमा खोज ।"
+
+#: ../src/html/helpwnd.cpp:1193
+msgid "Help Browser Options"
+msgstr "सहयोगी Browser विकल्पहरू"
+
+#: ../src/html/helpwnd.cpp:1198
+msgid "Normal font:"
+msgstr "साधारण वरणाकृति:"
+
+#: ../src/html/helpwnd.cpp:1199
+msgid "Fixed font:"
+msgstr "निश्चित वरणाकृति:"
+
+#: ../src/html/helpwnd.cpp:1200
+msgid "Font size:"
+msgstr "वरणाकृतिको आकार:"
+
+#: ../src/html/helpwnd.cpp:1245
+msgid "font size"
+msgstr "वरणाकृतिको आकार"
+
+#: ../src/html/helpwnd.cpp:1256
+msgid "Normal face<br>and <u>underlined</u>. "
+msgstr "साधारण अनुहार<br>and <u> अधोरेखाङ्कित </u>. "
+
+#: ../src/html/helpwnd.cpp:1257
+msgid "<i>Italic face.</i> "
+msgstr "<i>डल्केको .</i> "
+
+#: ../src/html/helpwnd.cpp:1258
+msgid "<b>Bold face.</b> "
+msgstr "<b>मोटो .</b> "
+
+#: ../src/html/helpwnd.cpp:1259
+msgid "<b><i>Bold italic face.</i></b><br>"
+msgstr "<b><i>मोटो डल्केको </i></b><br>"
+
+#: ../src/html/helpwnd.cpp:1262
+msgid "Fixed size face.<br> <b>bold</b> <i>italic</i> "
+msgstr "निश्चित आकार face.<br> <b>मोटो</b> <i>डल्केको</i> "
+
+#: ../src/html/helpwnd.cpp:1263
+msgid "<b><i>bold italic <u>underlined</u></i></b><br>"
+msgstr "<b><i> मोटो डल्केको <u> अधोरेखाङ्कित </u></i></b><br>"
+
+#: ../src/html/helpwnd.cpp:1524
+msgid "Help Printing"
+msgstr "सहयोग छापिँदै "
+
+#: ../src/html/helpwnd.cpp:1527
+msgid "Cannot print empty page."
+msgstr "खाली पृष्ट छाप्न सकिँदैन ।"
+
+#: ../src/html/helpwnd.cpp:1540
+msgid "HTML files (*.html;*.htm)|*.html;*.htm|"
+msgstr "HTML फाइलहरू (*.html;*.htm)|*.html;*.htm|"
+
+#: ../src/html/helpwnd.cpp:1541
+msgid "Help books (*.htb)|*.htb|Help books (*.zip)|*.zip|"
+msgstr "सहयोग किताबहरू (*.htb)|*.htb|सहयोग किताबहरू (*.zip)|*.zip|"
+
+#: ../src/html/helpwnd.cpp:1542
+msgid "HTML Help Project (*.hhp)|*.hhp|"
+msgstr "HTML सहयोग योजना (*.hhp)|*.hhp|"
+
+#: ../src/html/helpwnd.cpp:1544
+msgid "Compressed HTML Help file (*.chm)|*.chm|"
+msgstr "खाँदिएको HTML सहयोग फाइल (*.chm)|*.chm|"
+
+#: ../src/html/helpwnd.cpp:1671
+#, c-format
+msgid "%i of %u"
+msgstr "%i - %u को"
+
+#: ../src/html/helpwnd.cpp:1709
+#, c-format
+msgid "%u of %u"
+msgstr "%u को %u"
+
+#: ../src/html/htmlfilt.cpp:134
+#, c-format
+msgid "Cannot open HTML document: %s"
+msgstr "HTML कागजात: %s खोल्न सकिँदैन ।"
+
+#: ../src/html/htmlwin.cpp:599
+msgid "Connecting..."
+msgstr "जोड्दै छु"
+
+#: ../src/html/htmlwin.cpp:616
+#, c-format
+msgid "Unable to open requested HTML document: %s"
+msgstr "अनुरोध गरिएको HTML कागजात: %s लाई खोल्न सकिएन ।"
+
+#: ../src/html/htmlwin.cpp:630
+msgid "Loading : "
+msgstr "वहन गरिदैं : "
+
+#: ../src/html/htmlwin.cpp:673
+msgid "Done"
+msgstr "सकियो"
+
+#: ../src/html/htmlwin.cpp:723
+#, c-format
+msgid "HTML anchor %s does not exist."
+msgstr "HTML anchor %s छदै छैन ।"
+
+#: ../src/html/htmlwin.cpp:1057
+#, c-format
+msgid "Copied to clipboard:\"%s\""
+msgstr "क्लिप पाटीमा उतारियो:\"%s\""
+
+#: ../src/html/htmprint.cpp:269
+msgid ""
+"This document doesn't fit on the page horizontally and will be truncated "
+"when it is printed."
+msgstr "यो कागजातका सबै सामाग्री पृष्टको तेर्सो तर्फ आँटेन, Print गर्दा केही काटिने छ ।"
+
+#: ../src/html/htmprint.cpp:285
+#, c-format
+msgid ""
+"The document \"%s\" doesn't fit on the page horizontally and will be "
+"truncated if printed.\n"
+"\n"
+"Would you like to proceed with printing it nevertheless?"
+msgstr ""
+"\"%s\" कागजातका सबै सामाग्री पृष्टको तेर्सो तर्फ आँटेन, यदि छाप्ने कार्य गरियो भने केही अंश "
+"काटिने छ । \n"
+"\n"
+"के तपाई जस्तो सुकै भए पनि छाप्न चाहनु हुन्छ?"
+
+#: ../src/html/htmprint.cpp:296
+msgid ""
+"If possible, try changing the layout parameters to make the printout more "
+"narrow."
+msgstr "छाप्ने सामाग्री लाइ खाँद्न सम्भव छ भने रूपरेखा लाइ बदल्न कशिस गर्नु होला ।"
+
+#: ../src/html/htmprint.cpp:445
+msgid ": file does not exist!"
+msgstr ": फाइल छैन ।"
+
+#. TRANSLATORS: %s may be a document title.
+#: ../src/html/htmprint.cpp:717
+#, fuzzy, c-format
+msgid "%s Preview"
+msgstr "चेहरा"
+
+#: ../src/html/htmprint.cpp:755 ../src/richtext/richtextprint.cpp:618
+msgid ""
+"There was a problem during page setup: you may need to set a default printer."
+msgstr "पृष्ट मिलाउँदा समस्या आयो: तपाइले निर्धारित प्रिन्टर नै रोज्नु राम्रो होला ।"
+
+#: ../src/msw/clipbrd.cpp:80
+msgid "Failed to open the clipboard."
+msgstr "क्लिप पाटी खोल्न सकिएन ।"
+
+#: ../src/msw/clipbrd.cpp:101
+msgid "Failed to close the clipboard."
+msgstr "क्लिप पाटी बन्द गर्न सकिएन ।"
+
+#: ../src/msw/clipbrd.cpp:113
+msgid "Failed to empty the clipboard."
+msgstr "क्लिप पाटी रित्याउन सकिएन ।"
+
+#: ../src/msw/clipbrd.cpp:284
+msgid "Failed to put data on the clipboard"
+msgstr "क्लिप पाटीमा तथ्याङ्क राख्न सकिएन ।"
+
+#: ../src/msw/clipbrd.cpp:326
+msgid "Failed to get data from the clipboard"
+msgstr "क्लिप पाटीबाट केही पनि पाउन सकिएन ।"
+
+#: ../src/msw/clipbrd.cpp:363
+msgid "Failed to retrieve the supported clipboard formats"
+msgstr "समर्थन गर्ने क्लिप पाटीको स्वरूप लिन सकिएन ।"
+
+#: ../src/msw/colordlg.cpp:228
+#, c-format
+msgid "Colour selection dialog failed with error %0lx."
+msgstr "रङ्ग चयन पातो %0lx गल्तीले गर्दा असफल भयो ।"
+
+#: ../src/msw/cursor.cpp:141
+msgid "Failed to create cursor."
+msgstr "कर्सर सिर्जना गर्न सकिएन ।"
+
+#: ../src/msw/dde.cpp:279
+#, c-format
+msgid "Failed to register DDE server '%s'"
+msgstr "DDE सर्भर '%s' दर्ता गर्न सकिएन ।"
+
+#: ../src/msw/dde.cpp:300
+#, c-format
+msgid "Failed to unregister DDE server '%s'"
+msgstr "DDE सर्भर '%s' को दर्ता खारेज गर्न सकिएन ।"
+
+#: ../src/msw/dde.cpp:428
+#, c-format
+msgid "Failed to create connection to server '%s' on topic '%s'"
+msgstr "सर्बर '%s' मा शीर्षक '%s' सित सम्बन्ध गाँस्न सकिएन ।"
+
+#: ../src/msw/dde.cpp:655
+msgid "DDE poke request failed"
+msgstr "DDE poke अनुरोध असफल भयो"
+
+#: ../src/msw/dde.cpp:674
+msgid "Failed to establish an advise loop with DDE server"
+msgstr "DDE सर्भर सित advise loop सम्बन्ध राख्न सकिएन ।"
+
+#: ../src/msw/dde.cpp:693
+msgid "Failed to terminate the advise loop with DDE server"
+msgstr "advise loop with DDE server बन्द गर्न सकिएन ।"
+
+#: ../src/msw/dde.cpp:768
+msgid "Failed to send DDE advise notification"
+msgstr "DDE सूचना सल्लाह पठाउन सकिएन ।"
+
+#: ../src/msw/dde.cpp:1085
+msgid "Failed to create DDE string"
+msgstr "DDE string को सिर्जना गर्न सकिएन ।"
+
+#: ../src/msw/dde.cpp:1131
+msgid "no DDE error."
+msgstr "DDE गल्ती छैन"
+
+#: ../src/msw/dde.cpp:1135
+msgid "a request for a synchronous advise transaction has timed out."
+msgstr "व्यवस्थित सल्लाह कारोबारका लागि अनुरोध समय सकियो ।"
+
+#: ../src/msw/dde.cpp:1138
+msgid "the response to the transaction caused the DDE_FBUSY bit to be set."
+msgstr "कारोबारको प्रतिक्रियाले DDE_FBUSY bit लाइ तय गर्नु पर्ने बनायो ।"
+
+#: ../src/msw/dde.cpp:1141
+msgid "a request for a synchronous data transaction has timed out."
+msgstr "व्यवस्थित तथ्याङ्क कारोबारका लागि अनुरोध समय सकियो ।"
+
+#: ../src/msw/dde.cpp:1144
+msgid ""
+"a DDEML function was called without first calling the DdeInitialize "
+"function,\n"
+"or an invalid instance identifier\n"
+"was passed to a DDEML function."
+msgstr ""
+"पहिले DdeInitialize function लाई आह्वान नगरी DDEML function लाई आह्वान गरियो "
+"। \n"
+"अथवा \n"
+"अवैध परिचायक लाई DDEML function मा पटाइयो ।"
+
+#: ../src/msw/dde.cpp:1147
+msgid ""
+"an application initialized as APPCLASS_MONITOR has\n"
+"attempted to perform a DDE transaction,\n"
+"or an application initialized as APPCMD_CLIENTONLY has \n"
+"attempted to perform server transactions."
+msgstr ""
+"अनुप्रयोगले APPCLASS_MONITOR को रूपमा DDE कारोबारको प्रयास आरम्भ गर्‍यो । \n"
+"अथवा \n"
+" अनुप्रयोगले APPCMD_CLIENTONLY को रूपमा सर्बर कारोबार को प्रयास आरम्भ गरायो।"
+
+#: ../src/msw/dde.cpp:1150
+msgid "a request for a synchronous execute transaction has timed out."
+msgstr "व्यवस्थित कार्यकारी कारोबारका लागि अनुरोध समय सकियो ।"
+
+#: ../src/msw/dde.cpp:1153
+msgid "a parameter failed to be validated by the DDEML."
+msgstr "एउटा parameter DDEML वाट वैधता पाउन असफल भयो ।"
+
+#: ../src/msw/dde.cpp:1156
+msgid "a DDEML application has created a prolonged race condition."
+msgstr "DDEML अनुप्रयोगले लम्बिएको दौडको सिर्जना गरेको छ ।"
+
+#: ../src/msw/dde.cpp:1159
+msgid "a memory allocation failed."
+msgstr "भण्डार उपलब्ध गराउने प्रयास असफल भयो ।"
+
+#: ../src/msw/dde.cpp:1162
+msgid "a client's attempt to establish a conversation has failed."
+msgstr "वार्तालापको लागि ग्राहकको जडान प्रयास असफल भयो ।"
+
+#: ../src/msw/dde.cpp:1165
+msgid "a transaction failed."
+msgstr "कारोबार असफल भयो ।"
+
+#: ../src/msw/dde.cpp:1168
+msgid "a request for a synchronous poke transaction has timed out."
+msgstr "व्यवस्थित poke कारोबारका लागि अनुरोध समय सकियो ।"
+
+#: ../src/msw/dde.cpp:1171
+msgid "an internal call to the PostMessage function has failed. "
+msgstr ""
+"PostMessage function को आन्तरिक बोलावट असफल भयो । an internal call to the has "
+"failed. "
+
+#: ../src/msw/dde.cpp:1174
+msgid "reentrancy problem."
+msgstr "पुनः प्रविष्टिको समस्या"
+
+#: ../src/msw/dde.cpp:1177
+msgid ""
+"a server-side transaction was attempted on a conversation\n"
+"that was terminated by the client, or the server\n"
+"terminated before completing a transaction."
+msgstr ""
+"सर्बर-फक्षको कारोबारको प्रयास गरेकोले कुराकानिको क्रम ग्राहकले काटि दियो । \n"
+" अथवा \n"
+"सर्बरले नै कारोबार समाप्त हुनु अगावै काटि दियो ।"
+
+#: ../src/msw/dde.cpp:1180
+msgid "an internal error has occurred in the DDEML."
+msgstr "आन्तरिक रूपमा DDEML मा गल्ती भयो ।"
+
+#: ../src/msw/dde.cpp:1183
+msgid "a request to end an advise transaction has timed out."
+msgstr "व्यवस्थित सल्लाह कारोबार समाप्तिको लागि अनुरोध समय सकियो ।"
+
+#: ../src/msw/dde.cpp:1186
+msgid ""
+"an invalid transaction identifier was passed to a DDEML function.\n"
+"Once the application has returned from an XTYP_XACT_COMPLETE callback,\n"
+"the transaction identifier for that callback is no longer valid."
+msgstr ""
+"अवैध कारोबार परिचायकलाई DDEML function मा पठाइयो । \n"
+" एक पटक अनुप्रयोगले XTYP_XACT_COMPLETE लाई \n"
+" फिर्ता पठाइ सके पछि, \n"
+" कारोबार परिचायक लाई फिर्ता बोलाउने कार्य मान्य हुने छैन । "
+
+#: ../src/msw/dde.cpp:1189
+#, c-format
+msgid "Unknown DDE error %08x"
+msgstr "अज्ञात DDE गल्ती %08x"
+
+#: ../src/msw/dialup.cpp:343
+msgid ""
+"Dial up functions are unavailable because the remote access service (RAS) is "
+"not installed on this machine. Please install it."
+msgstr ""
+"यो कम्प्युटरमा दूर पहुँच सेवा (RAS) स्थापना नघरैकोले डायल सेवा उपलब्ध हुन सकेन । कृपया "
+"यसलाई स्थापना गर्नु होला ।"
+
+#: ../src/msw/dialup.cpp:402
+#, c-format
+msgid ""
+"The version of remote access service (RAS) installed on this machine is too "
+"old, please upgrade (the following required function is missing: %s)."
+msgstr ""
+"यो कम्प्युटरमा स्थापित दूर पहुँच सेवा (RAS) निकै पुरानो संस्करण रहेछ, कृपया स्तर वृद्धि गर्नु "
+"होला (आवश्यक पर्ने Function %s यसमा छैन: )"
+
+#: ../src/msw/dialup.cpp:437
+msgid "Failed to retrieve text of RAS error message"
+msgstr "RAS गल्ती सन् देसको पाठहरू लिन सकिएन ।"
+
+#: ../src/msw/dialup.cpp:440
+#, c-format
+msgid "unknown error (error code %08x)."
+msgstr "अज्ञात गल्ती (गल्ती कोड %08x)"
+
+#: ../src/msw/dialup.cpp:492
+#, c-format
+msgid "Cannot find active dialup connection: %s"
+msgstr "सक्रिय डायलअप जडान फेला पार्न सकिँदैन ।: %s"
+
+#: ../src/msw/dialup.cpp:513
+msgid "Several active dialup connections found, choosing one randomly."
+msgstr "धेरै वटा सक्रिय डायल अप जडान भएको पाइयो । कुनै एउटालाई चयन गरिदैं छ ।"
+
+#: ../src/msw/dialup.cpp:598 ../src/msw/dialup.cpp:832
+#, c-format
+msgid "Failed to establish dialup connection: %s"
+msgstr "डायलअप जडान %s स्थापित गर्न सकिएन ।"
+
+#: ../src/msw/dialup.cpp:664
+#, c-format
+msgid "Failed to get ISP names: %s"
+msgstr "ISP नामहरू %s पाउन सकिएन ।"
+
+#: ../src/msw/dialup.cpp:712
+msgid "Failed to connect: no ISP to dial."
+msgstr "जोड्न सकिएन: डायल गर्न ISP छैन"
+
+#: ../src/msw/dialup.cpp:732
+msgid "Choose ISP to dial"
+msgstr "डायल गर्न ISP छान्नु होस्"
+
+#: ../src/msw/dialup.cpp:733
+msgid "Please choose which ISP do you want to connect to"
+msgstr "कृपया जुन ISP मा जोड्ने हो उही छान्नु होस् "
+
+#: ../src/msw/dialup.cpp:766
+msgid "Failed to connect: missing username/password."
+msgstr "जोड्न सकिएन: ग्राहकको नाम/पाल्सीशब्द छैन ।"
+
+#: ../src/msw/dialup.cpp:796
+msgid "Cannot find the location of address book file"
+msgstr "ठेगाना किताब फाइलको स्थान फेला पार्न सकिँदैन ।"
+
+#: ../src/msw/dialup.cpp:827
+#, c-format
+msgid "Failed to initiate dialup connection: %s"
+msgstr "%s डायलअप जडान गराउन सकिएन ।"
+
+#: ../src/msw/dialup.cpp:897
+msgid "Cannot hang up - no active dialup connection."
+msgstr "सक्रिय डायल जडान पाउन सकिँदैन ।"
+
+#: ../src/msw/dialup.cpp:907
+#, c-format
+msgid "Failed to terminate the dialup connection: %s"
+msgstr "डायलअप जडान %s बन्द गर्न सकिएन ।"
+
+#: ../src/msw/dib.cpp:313
+#, c-format
+msgid "Failed to save the bitmap image to file \"%s\"."
+msgstr "फाइल \"%s\" मा bitmap तस्विर बचत गर्न सकिएन ।"
+
+#: ../src/msw/dib.cpp:543
+#, c-format
+msgid "Failed to allocate %luKb of memory for bitmap data."
+msgstr "bitmap तथ्याङ्कको लागि %luKb को भण्डार उपलब्ध गराउन सकिएन ।"
+
+#: ../src/msw/dir.cpp:241
+#, c-format
+msgid "Cannot enumerate files in directory '%s'"
+msgstr "'%s' घर्रामा भएको गल्ती गणना गर्न सकिँदैन ।"
+
+#: ../src/msw/dirdlg.cpp:368
+msgid "Couldn't obtain folder name"
+msgstr "थैलीको नाम पाउनसकिएन"
+
+#: ../src/msw/dlmsw.cpp:163
+#, fuzzy, c-format
+msgid "(error %d: %s)"
+msgstr " (गल्ती %ld: %s)"
+
+#: ../src/msw/dragimag.cpp:143 ../src/msw/dragimag.cpp:178
+#: ../src/msw/imaglist.cpp:309 ../src/msw/imaglist.cpp:331
+msgid "Couldn't add an image to the image list."
+msgstr "तस्विर सुचीमा तस्विर थप्न सकिएन"
+
+#: ../src/msw/enhmeta.cpp:94
+#, c-format
+msgid "Failed to load metafile from file \"%s\"."
+msgstr "फाइल \"%s\" बाट metafile तस्विर वहन गर्न सकिएन "
+
+#: ../src/msw/fdrepdlg.cpp:412
+#, c-format
+msgid "Failed to create the standard find/replace dialog (error code %d)"
+msgstr "स्तरीय फेला पार्ने/प्रतिस्थापित गर्ने पातो (गल्ती संहिता %d) सिर्जना गर्न सकिएन ।"
+
+#: ../src/msw/filedlg.cpp:1241
+msgid "Access to the file system is not allowed from secure desktop."
+msgstr ""
+
+#: ../src/msw/filedlg.cpp:1242
+msgid "Security warning"
+msgstr ""
+
+#: ../src/msw/filedlg.cpp:1533
+#, c-format
+msgid "File dialog failed with error code %0lx."
+msgstr "फाइल पाटी गल्ती कोड %0lx ले असफल भयो ।"
+
+#: ../src/msw/font.cpp:1120
+#, fuzzy, c-format
+msgid "Font file \"%s\" couldn't be loaded"
+msgstr "फाइल वहन गर्न सकिएन ।"
+
+#: ../src/msw/fontdlg.cpp:220
+#, c-format
+msgid "Common dialog failed with error code %0lx."
+msgstr "गल्ती कोड %0lx ले गर्दा साझा पातो असफल भयो ।"
+
+#: ../src/msw/fswatcher.cpp:67
+msgid "Ungraceful worker thread termination"
+msgstr "Ungraceful worker thread termination"
+
+#: ../src/msw/fswatcher.cpp:81
+msgid "Unable to create IOCP worker thread"
+msgstr "IOCP worker सिर्जना गर्न सकिएन ।"
+
+#: ../src/msw/fswatcher.cpp:88
+msgid "Unable to start IOCP worker thread"
+msgstr "IOCP worker thread लाई सुरुवात गर्न सकिएन ।"
+
+#: ../src/msw/fswatcher.cpp:140
+msgid "Monitoring individual files for changes is not supported currently."
+msgstr "हाल व्यक्तिगत फाइलको परिवर्तन अनुगमनलाई समर्थन गर्दैन ।"
+
+#: ../src/msw/fswatcher.cpp:165
+#, c-format
+msgid "Unable to set up watch for '%s'"
+msgstr "घडी '%s' लाई कायम गर्न सकिएन ।"
+
+#: ../src/msw/fswatcher.cpp:466
+#, c-format
+msgid "Can't monitor non-existent directory \"%s\" for changes."
+msgstr "परिवर्तनको लागी भनेर हुँदै नभएको घर्रा \"%s\" लाइ अनुगमन गर्न सकिँदैन ।"
+
+#: ../src/msw/glcanvas.cpp:577 ../src/unix/glx11.cpp:507
+#, fuzzy
+msgid "OpenGL 3.0 or later is not supported by the OpenGL driver."
+msgstr "भित्रि OpenGL पार्श्वचित्रलाई OpenGL driver ले समर्थन गर्दैन."
+
+#: ../src/msw/glcanvas.cpp:601 ../src/osx/glcanvas_osx.cpp:395
+#: ../src/unix/glegl.cpp:304 ../src/unix/glx11.cpp:553
+#, fuzzy
+msgid "Couldn't create OpenGL context"
+msgstr "टाइम र सिर्जना गर्न सकिएन"
+
+#: ../src/msw/glcanvas.cpp:1294
+msgid "Failed to initialize OpenGL"
+msgstr "OpenGL सुरु गर्न सकिएन ।"
+
+#: ../src/msw/graphicsd2d.cpp:607
+msgid "Could not register custom DirectWrite font loader."
+msgstr ""
+
+#: ../src/msw/helpchm.cpp:48
+msgid ""
+"MS HTML Help functions are unavailable because the MS HTML Help library is "
+"not installed on this machine. Please install it."
+msgstr ""
+"यो कम्प्युटरमा MS HTML सहयोग पुस्तकालय स्थापित नभएकोले MS HTML सहयोग उपलब्ध भएन । "
+"कृपया यसलाई स्थापना गर्नु होला ।"
+
+#: ../src/msw/helpchm.cpp:55
+msgid "Failed to initialize MS HTML Help."
+msgstr "MS HTML सहयोग सुरु गर्न सकिएन ।"
+
+#: ../src/msw/iniconf.cpp:458
+#, c-format
+msgid "Can't delete the INI file '%s'"
+msgstr "INI फाइल '%s' लाई मेटाउन सकिँदैन ।"
+
+#: ../src/msw/listctrl.cpp:995
+#, c-format
+msgid "Couldn't retrieve information about list control item %d."
+msgstr "सूचि नियन्त्रण सामाग्री %d को बारेमा सूचना पाउन सकिएन "
+
+#: ../src/msw/mdi.cpp:170 ../src/qt/mdi.cpp:253
+msgid "&Cascade"
+msgstr "&Cascade"
+
+#: ../src/msw/mdi.cpp:171
+msgid "Tile &Horizontally"
+msgstr "&तेर्सो पारेर राख"
+
+#: ../src/msw/mdi.cpp:172
+msgid "Tile &Vertically"
+msgstr "&ठाडो पारेर राख"
+
+#: ../src/msw/mdi.cpp:174
+msgid "&Arrange Icons"
+msgstr "&प्रतिमा मिलाउ"
+
+#: ../src/msw/mdi.cpp:621
+msgid "Failed to create MDI parent frame."
+msgstr "MDI parent frame को सिर्जना गर्न सकिएन ।"
+
+#: ../src/msw/mimetype.cpp:234
+#, c-format
+msgid "Failed to create registry entry for '%s' files."
+msgstr "फाइलहरू '%s' का लागि registry प्रविष्टि सिर्जना गर्न सकिएन ।"
+
+#: ../src/msw/ole/automtn.cpp:495
+#, c-format
+msgid "Failed to find CLSID of \"%s\""
+msgstr "\"%s\" को CLSID फेला पार्न सकिएन ।"
+
+#: ../src/msw/ole/automtn.cpp:512
+#, c-format
+msgid "Failed to create an instance of \"%s\""
+msgstr "instance \"%s\" को सिर्जना गर्न सकिएन ।"
+
+#: ../src/msw/ole/automtn.cpp:552
+#, c-format
+msgid "Cannot get an active instance of \"%s\""
+msgstr "सक्रिय instance \"%s\" लाइ फेला पार्न सकिँदैन ।"
+
+#: ../src/msw/ole/automtn.cpp:564
+#, c-format
+msgid "Failed to get OLE automation interface for \"%s\""
+msgstr "\"%s\" का लागि पुराना स्वचालित interface पाउन सकिएन ।"
+
+#: ../src/msw/ole/automtn.cpp:621
+msgid "Unknown name or named argument."
+msgstr "अज्ञात नाम अथवा नामाङ्कित तर्क"
+
+#: ../src/msw/ole/automtn.cpp:625
+msgid "Incorrect number of arguments."
+msgstr "अशुद्ध arguments सङ्ख्या "
+
+#: ../src/msw/ole/automtn.cpp:637
+msgid "Unknown exception"
+msgstr "अज्ञात नमिल्दो अवस्था"
+
+#: ../src/msw/ole/automtn.cpp:642
+msgid "Method or property not found."
+msgstr "विधि अथवा गुण पाइ एन ।"
+
+#: ../src/msw/ole/automtn.cpp:646
+msgid "Overflow while coercing argument values."
+msgstr "Overflow while coercing argument values"
+
+#: ../src/msw/ole/automtn.cpp:650
+msgid "Object implementation does not support named arguments."
+msgstr "वस्तु कार्यान्वयनले नामाङ्कित तर्कलाई समर्थन गर्दैन ।"
+
+#: ../src/msw/ole/automtn.cpp:654
+msgid "The locale ID is unknown."
+msgstr "स्थानीय ID थाहा भएन"
+
+#: ../src/msw/ole/automtn.cpp:658
+msgid "Missing a required parameter."
+msgstr "आवश्यक parameter छुडेको छ"
+
+#: ../src/msw/ole/automtn.cpp:662
+#, c-format
+msgid "Argument %u not found."
+msgstr "तर्क %u भेटिएन ।"
+
+#: ../src/msw/ole/automtn.cpp:666
+#, c-format
+msgid "Type mismatch in argument %u."
+msgstr "Type mismatch in argument %u"
+
+#: ../src/msw/ole/automtn.cpp:670
+msgid "The system cannot find the file specified."
+msgstr "यो प्रणालीले तोकिएको फाइल फेला पार्न सक्दैन ।"
+
+#: ../src/msw/ole/automtn.cpp:674
+msgid "Class not registered."
+msgstr "Class दर्ता छैन"
+
+#: ../src/msw/ole/automtn.cpp:678
+#, c-format
+msgid "Unknown error %08x"
+msgstr "अज्ञात गल्ती %08x"
+
+#: ../src/msw/ole/automtn.cpp:682
+#, c-format
+msgid "OLE Automation error in %s: %s"
+msgstr "%s मा OLE स्वचालित गल्ती : %s "
+
+#: ../src/msw/ole/dataobj.cpp:385
+#, c-format
+msgid "Couldn't register clipboard format '%s'."
+msgstr "क्लिप पाटीको स्वरूप '%s' दर्ता गर्न सकिएन"
+
+#: ../src/msw/ole/dataobj.cpp:402
+#, c-format
+msgid "The clipboard format '%d' doesn't exist."
+msgstr "क्लिप पाटी बनोट '%d' अस्तित्वमा छैन ।"
+
+#: ../src/msw/progdlg.cpp:1025
+msgid "Skip"
+msgstr "उफ्र"
+
+#: ../src/msw/registry.cpp:141
+#, fuzzy, c-format
+msgid "unknown (%lu)"
+msgstr "अज्ञात"
+
+#: ../src/msw/registry.cpp:409
+#, c-format
+msgid "Can't get info about registry key '%s'"
+msgstr "registry कुञ्जी '%s' को बारेमा जानकारी पाउन सकिँदैन ।"
+
+#: ../src/msw/registry.cpp:445
+#, c-format
+msgid "Can't open registry key '%s'"
+msgstr "registry कुञ्जी '%s लाइ खोल्न सकिँदैन ।'"
+
+#: ../src/msw/registry.cpp:478
+#, c-format
+msgid "Can't create registry key '%s'"
+msgstr "registry कुञ्जी '%s' सिर्जना गर्न सकिँदैन ।"
+
+#: ../src/msw/registry.cpp:497
+#, c-format
+msgid "Can't close registry key '%s'"
+msgstr "registry key '%s' लाइ बन्द गर्न सकिँदैन ।"
+
+#: ../src/msw/registry.cpp:512
+#, c-format
+msgid "Registry value '%s' already exists."
+msgstr "Registry मान '%s' पहिले देखि नै छ ।"
+
+#: ../src/msw/registry.cpp:520
+#, c-format
+msgid "Failed to rename registry value '%s' to '%s'."
+msgstr "registry मान '%s' लाई '%s' मा नामा करण गर्न सकिएन ।"
+
+#: ../src/msw/registry.cpp:575
+#, c-format
+msgid "Can't copy values of unsupported type %d."
+msgstr "असमर्थित किसिमको %d मान उतार्न सकिँदैन । "
+
+#: ../src/msw/registry.cpp:586
+#, c-format
+msgid "Registry key '%s' does not exist, cannot rename it."
+msgstr "Registry कुञ्जी '%s' नभएकोले नाम फेर्न सकिँदैन ।"
+
+#: ../src/msw/registry.cpp:617
+#, c-format
+msgid "Registry key '%s' already exists."
+msgstr "Registry कुञ्जी '%s' पहिले देखि नै छ ।"
+
+#: ../src/msw/registry.cpp:625
+#, c-format
+msgid "Failed to rename the registry key '%s' to '%s'."
+msgstr "registry कुञ्जी '%s' लाई '%s' मा नामा करण गर्न सकिएन ।"
+
+#: ../src/msw/registry.cpp:670
+#, c-format
+msgid "Failed to copy the registry subkey '%s' to '%s'."
+msgstr "registry उप-कुञ्जी '%s' को नक्कल '%s' मा उतार्न सकिएन ।"
+
+#: ../src/msw/registry.cpp:683
+#, c-format
+msgid "Failed to copy registry value '%s'"
+msgstr "registry मान '%s' को नक्कल उतार्न सकिएन ।"
+
+#: ../src/msw/registry.cpp:692
+#, c-format
+msgid "Failed to copy the contents of registry key '%s' to '%s'."
+msgstr "registry कुञ्जीको सामाग्री '%s' को नक्कल '%s' मा उतार्न सकिएन ।"
+
+#: ../src/msw/registry.cpp:718
+#, c-format
+msgid ""
+"Registry key '%s' is needed for normal system operation,\n"
+"deleting it will leave your system in unusable state:\n"
+"operation aborted."
+msgstr ""
+"सामान्य रूपमा यस प्रणालीलेकाम गर्नका लागि Registry कुञ्जी '%s' चाहिन्छ ।\n"
+"यसलाई मेट्नु भयो भने यो प्रणाली निकम्मा हुने छ ।सञ्चालन त तुहियो!"
+
+#: ../src/msw/registry.cpp:754
+#, c-format
+msgid "Can't delete key '%s'"
+msgstr "'%s' कुञ्जीलाई मेटाउन सकिँदैन ।"
+
+#: ../src/msw/registry.cpp:782
+#, c-format
+msgid "Can't delete value '%s' from key '%s'"
+msgstr "मान '%s' लाई कुञ्जी '%s' बाट मेटाउन सकिँदैन ।"
+
+#: ../src/msw/registry.cpp:855 ../src/msw/registry.cpp:887
+#: ../src/msw/registry.cpp:929 ../src/msw/registry.cpp:1000
+#, c-format
+msgid "Can't read value of key '%s'"
+msgstr "कुञ्जी '%s' को मान पढ्न सकिँदैन ।"
+
+#: ../src/msw/registry.cpp:873 ../src/msw/registry.cpp:915
+#: ../src/msw/registry.cpp:963 ../src/msw/registry.cpp:1106
+#, c-format
+msgid "Can't set value of '%s'"
+msgstr "'%s' को मान सेट गर्न सकिँदैन ।"
+
+#: ../src/msw/registry.cpp:894 ../src/msw/registry.cpp:943
+#, c-format
+msgid "Registry value \"%s\" is not numeric (but of type %s)"
+msgstr ""
+
+#: ../src/msw/registry.cpp:979
+#, c-format
+msgid "Registry value \"%s\" is not binary (but of type %s)"
+msgstr ""
+
+#: ../src/msw/registry.cpp:1028
+#, c-format
+msgid "Registry value \"%s\" is not text (but of type %s)"
+msgstr ""
+
+#: ../src/msw/registry.cpp:1089
+#, c-format
+msgid "Can't read value of '%s'"
+msgstr "'%s' को मान पड्न सकिँदैन ।"
+
+#: ../src/msw/registry.cpp:1157
+#, c-format
+msgid "Can't enumerate values of key '%s'"
+msgstr "%s' कुञ्जीको मान लेखाजोखा गर्न सकिँदैन ।"
+
+#: ../src/msw/registry.cpp:1196
+#, c-format
+msgid "Can't enumerate subkeys of key '%s'"
+msgstr "%s' कुञ्जीको उप कुञ्जी लेखाजोखा गर्न सकिँदैन ।"
+
+#: ../src/msw/registry.cpp:1262
+#, c-format
+msgid ""
+"Exporting registry key: file \"%s\" already exists and won't be overwritten."
+msgstr "registry कुञ्जी निर्यात हुँदैछ: फाइल\"%s\" छदै च त्यसैले फेरी लेखिने काम हुँदैन ।"
+
+#: ../src/msw/registry.cpp:1411
+#, c-format
+msgid "Can't export value of unsupported type %d."
+msgstr "%d किसिमको असमर्थित मान निर्यात गर्न सकिँदैन ।"
+
+#: ../src/msw/registry.cpp:1427
+#, c-format
+msgid "Ignoring value \"%s\" of the key \"%s\"."
+msgstr "मान \"%s\" लाई (कुञ्जी \"%s\" ko ) बेवास्ता गरिदै छ ।"
+
+#: ../src/msw/textctrl.cpp:596
+msgid ""
+"Impossible to create a rich edit control, using simple text control instead. "
+"Please reinstall riched32.dll"
+msgstr ""
+"सामान्य पाठ नियन्त्रकको प्रयोग गरी rich edit control सिर्जना गर्न सम्भव छैन, कृपया "
+"riched32.dll लाई फेरी स्थापित गर्नु होला ।"
+
+#: ../src/msw/thread.cpp:522 ../src/unix/threadpsx.cpp:850
+msgid "Cannot start thread: error writing TLS."
+msgstr "thread सुरु गर्न सकिँदैन: TLS लेखाइमा गल्ती भयो ।"
+
+#: ../src/msw/thread.cpp:613
+msgid "Can't set thread priority"
+msgstr "thread प्राथमिकता सेट गर्न सकिँदैन ।"
+
+#: ../src/msw/thread.cpp:649
+msgid "Can't create thread"
+msgstr "thread सिर्जना गर्न सकिँदैन ।"
+
+#: ../src/msw/thread.cpp:668
+msgid "Couldn't terminate thread"
+msgstr "thread बन्द गर्न सकिएन"
+
+#: ../src/msw/thread.cpp:799
+msgid "Cannot wait for thread termination"
+msgstr "thread को समाप्ति पर्खन सकिँदैन ।"
+
+#: ../src/msw/thread.cpp:873
+#, c-format
+msgid "Cannot suspend thread %lx"
+msgstr "%lx धागो निलम्बन गर्न सकिएन ।"
+
+#: ../src/msw/thread.cpp:903
+#, c-format
+msgid "Cannot resume thread %lx"
+msgstr "%lx धागो सुभारम्भ गर्न सकिएन।"
+
+#: ../src/msw/thread.cpp:932
+msgid "Couldn't get the current thread pointer"
+msgstr "चालू thread Adder पाउन सकिएन"
+
+#: ../src/msw/thread.cpp:1333
+msgid ""
+"Thread module initialization failed: impossible to allocate index in thread "
+"local storage"
+msgstr "Thread module सुरु हुन सकेन: स्थानीय thread भण्डारमा सुची राख्न सम्भव छैन ।"
+
+#: ../src/msw/thread.cpp:1345
+msgid ""
+"Thread module initialization failed: cannot store value in thread local "
+"storage"
+msgstr "Thread module सुरु हुन सकेन: स्थानीय Thread भण्डारमा कुनै मान राख्न सकिँदैन ।"
+
+#: ../src/msw/timer.cpp:133
+msgid "Couldn't create a timer"
+msgstr "टाइम र सिर्जना गर्न सकिएन"
+
+#: ../src/msw/utils.cpp:372
+msgid "can't find user's HOME, using current directory."
+msgstr "चालू घर्राको प्रयोग गरेर उपभोक्ताको गृह फेला पार्न सकिँदैन ।"
+
+#: ../src/msw/utils.cpp:662
+#, c-format
+msgid "Failed to kill process %d"
+msgstr "प्रक्रिया %d लाई मार्न सकिएन ।"
+
+#: ../src/msw/utils.cpp:986
+#, c-format
+msgid "Failed to load resource \"%s\"."
+msgstr "श्रोत \"%s\" वहन गर्न सकिएन "
+
+#: ../src/msw/utils.cpp:993
+#, c-format
+msgid "Failed to lock resource \"%s\"."
+msgstr "श्रोत \"%s\" लाई चाबी लगाउन सकिएन ।"
+
+#. TRANSLATORS: MS Windows build number
+#: ../src/msw/utils.cpp:1209
+#, c-format
+msgid "build %lu"
+msgstr "निर्माण %lu"
+
+#: ../src/msw/utils.cpp:1218
+msgid ", 64-bit edition"
+msgstr ", 64-bit संस्करण"
+
+#: ../src/msw/utilsexc.cpp:224
+msgid "Failed to create an anonymous pipe"
+msgstr "anonymous pipe को सिर्जना गर्न सकिएन ।"
+
+#: ../src/msw/utilsexc.cpp:697
+msgid "Failed to redirect the child process IO"
+msgstr "बाल प्रक्रिया लगानी/प्रतिफल फेरि पठाउन सकिएन ।"
+
+#: ../src/msw/utilsexc.cpp:870
+#, c-format
+msgid "Execution of command '%s' failed"
+msgstr "आदेश '%s' को कार्यान्वयन असफल भयो ।"
+
+#: ../src/msw/volume.cpp:337
+msgid "Failed to load mpr.dll."
+msgstr "mpr.dll वहन गर्न सकिएन "
+
+#: ../src/msw/volume.cpp:506
+#, c-format
+msgid "Cannot read typename from '%s'!"
+msgstr "'%s' बाट typename पढ्न सकिँदैन ।"
+
+#: ../src/msw/volume.cpp:615
+#, c-format
+msgid "Cannot load icon from '%s'."
+msgstr "'%s' बाट प्रतिमा वहन गर्न सकिँदैन ।"
+
+#: ../src/msw/webview_edge.cpp:285
+msgid "This program was compiled without support for setting Edge proxy."
+msgstr ""
+
+#: ../src/msw/webview_ie.cpp:1010
+msgid "Failed to find web view emulation level in the registry"
+msgstr ""
+
+#: ../src/msw/webview_ie.cpp:1019
+msgid "Failed to set web view to modern emulation level"
+msgstr ""
+
+#: ../src/msw/webview_ie.cpp:1027
+msgid "Failed to reset web view to standard emulation level"
+msgstr ""
+
+#: ../src/msw/webview_ie.cpp:1049
+msgid "Can't run JavaScript script without a valid HTML document"
+msgstr ""
+
+#: ../src/msw/webview_ie.cpp:1056
+#, fuzzy
+msgid "Can't get the JavaScript object"
+msgstr "thread प्राथमिकता सेट गर्न सकिँदैन ।"
+
+#: ../src/msw/webview_ie.cpp:1070
+#, fuzzy
+msgid "failed to evaluate"
+msgstr "'%s' कार्यान्वयन गर्न सकिएन ।\n"
+
+#: ../src/osx/cocoa/filedlg.mm:412
+#, fuzzy
+msgid "File type:"
+msgstr "Teletype"
+
+#: ../src/osx/cocoa/menu.mm:242
+#, fuzzy
+msgctxt "macOS menu name"
+msgid "Window"
+msgstr "सन्झ्याल"
+
+#: ../src/osx/cocoa/menu.mm:259
+#, fuzzy
+msgctxt "macOS menu name"
+msgid "Help"
+msgstr "सहयोग"
+
+#: ../src/osx/cocoa/menu.mm:298
+#, fuzzy
+msgctxt "macOS menu item"
+msgid "Minimize"
+msgstr "&सूक्ष्म बनाउ"
+
+#: ../src/osx/cocoa/menu.mm:303
+#, fuzzy
+msgctxt "macOS menu item"
+msgid "Zoom"
+msgstr "ठूलो पार"
+
+#: ../src/osx/cocoa/menu.mm:309
+msgctxt "macOS menu item"
+msgid "Bring All to Front"
+msgstr ""
+
+#: ../src/osx/core/sound.cpp:143
+#, c-format
+msgid "Failed to load sound from \"%s\" (error %d)."
+msgstr "\"%s\" (त्रुटि %d). बाट ध्वनिलाई  बहन गर्न सकिएन "
+
+#: ../src/osx/fontutil.cpp:80
+#, fuzzy, c-format
+msgid "Font file \"%s\" doesn't exist."
+msgstr ": फाइल छैन ।"
+
+#: ../src/osx/fontutil.cpp:88
+#, c-format
+msgid ""
+"Font file \"%s\" cannot be used as it is not inside the font directory "
+"\"%s\"."
+msgstr ""
+
+#: ../src/osx/menu_osx.cpp:496
+#, c-format
+msgctxt "macOS menu item"
+msgid "About %s"
+msgstr "%s को बारेमा"
+
+#: ../src/osx/menu_osx.cpp:499
+msgctxt "macOS menu item"
+msgid "About..."
+msgstr "बारेमा"
+
+#: ../src/osx/menu_osx.cpp:508
+msgctxt "macOS menu item"
+msgid "Preferences..."
+msgstr "प्राथमिकताहरू.."
+
+#: ../src/osx/menu_osx.cpp:512
+msgctxt "macOS menu item"
+msgid "Services"
+msgstr "सेवा"
+
+#: ../src/osx/menu_osx.cpp:519
+#, c-format
+msgctxt "macOS menu item"
+msgid "Hide %s"
+msgstr "%s लुकाउ "
+
+#: ../src/osx/menu_osx.cpp:522
+#, fuzzy
+msgctxt "macOS menu item"
+msgid "Hide Application"
+msgstr "अनुप्रयोग"
+
+#: ../src/osx/menu_osx.cpp:526
+msgctxt "macOS menu item"
+msgid "Hide Others"
+msgstr "अरूलाई पनि लुकाउ "
+
+#: ../src/osx/menu_osx.cpp:528
+msgctxt "macOS menu item"
+msgid "Show All"
+msgstr "सबै देखाउ "
+
+#: ../src/osx/menu_osx.cpp:534
+#, c-format
+msgctxt "macOS menu item"
+msgid "Quit %s"
+msgstr "%s लाई त्यागि देउ "
+
+#: ../src/osx/menu_osx.cpp:537
+#, fuzzy
+msgctxt "macOS menu item"
+msgid "Quit Application"
+msgstr "अनुप्रयोग"
+
+#: ../src/osx/webview_webkit.mm:444
+#, fuzzy
+msgid "Printing is not supported by the system web control"
+msgstr "यो zlib को संस्करणले Gzip समर्थन गर्दैन ।"
+
+#: ../src/osx/webview_webkit.mm:453
+#, fuzzy
+msgid "Print operation could not be initialized"
+msgstr "महलको बयान सुरु भएन"
+
+#. TRANSLATORS: Label of font point size
+#: ../src/propgrid/advprops.cpp:605
+msgid "Point Size"
+msgstr "थोप्लोको आकार"
+
+#. TRANSLATORS: Label of font face name
+#: ../src/propgrid/advprops.cpp:615
+msgid "Face Name"
+msgstr "अनुहारको नाम"
+
+#. TRANSLATORS: Label of font style
+#: ../src/propgrid/advprops.cpp:623 ../src/richtext/richtextformatdlg.cpp:331
+msgid "Style"
+msgstr "शैली"
+
+#. TRANSLATORS: Label of font weight
+#: ../src/propgrid/advprops.cpp:628
+msgid "Weight"
+msgstr "भार"
+
+#. TRANSLATORS: Label of underlined font
+#: ../src/propgrid/advprops.cpp:633 ../src/richtext/richtextfontpage.cpp:358
+msgid "Underlined"
+msgstr "अधोरेखाङ्कित"
+
+#. TRANSLATORS: Label of font family
+#: ../src/propgrid/advprops.cpp:637
+msgid "Family"
+msgstr "परिवार"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:801
+msgid "AppWorkspace"
+msgstr "एपकार्यस्थल"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:802
+msgid "ActiveBorder"
+msgstr "सक्रिय सिमाना"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:803
+msgid "ActiveCaption"
+msgstr "सक्रिय शिर्षक"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:804
+msgid "ButtonFace"
+msgstr "टाँकचेहरा"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:805
+msgid "ButtonHighlight"
+msgstr "उज्यालोटाक"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:806
+msgid "ButtonShadow"
+msgstr "विम्वटाँक"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:807
+msgid "ButtonText"
+msgstr "टाँकपाठ"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:808
+msgid "CaptionText"
+msgstr "शिर्षकपाठ"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:809
+msgid "ControlDark"
+msgstr "अध्यारोनियन्त्रण"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:810
+msgid "ControlLight"
+msgstr "उज्यालोनियन्त्रण"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:812
+msgid "GrayText"
+msgstr "खैरोपाठ"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:813
+msgid "Highlight"
+msgstr "प्रकासीकरण"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:814
+msgid "HighlightText"
+msgstr "प्रकासयुक्त पाठ"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:815
+msgid "InactiveBorder"
+msgstr "निस्क्रिय सिमाना"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:816
+msgid "InactiveCaption"
+msgstr "निस्क्रियशिर्षक"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:817
+msgid "InactiveCaptionText"
+msgstr "निस्क्रियशिर्षकपाठ"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:818
+msgid "Menu"
+msgstr "मेनु"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:819
+msgid "Scrollbar"
+msgstr "घिसार्नेपट्टी"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:820
+msgid "Tooltip"
+msgstr "औजारपट्टी"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:821
+msgid "TooltipText"
+msgstr "औजारपट्टीपाठ"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:822
+msgid "Window"
+msgstr "सन्झ्याल"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:823
+msgid "WindowFrame"
+msgstr "विन्डोफ्रेम"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:824
+msgid "WindowText"
+msgstr "विन्डोपाठ"
+
+#. TRANSLATORS: Custom colour choice entry
+#: ../src/propgrid/advprops.cpp:825 ../src/propgrid/advprops.cpp:1532
+#: ../src/propgrid/advprops.cpp:1576
+msgid "Custom"
+msgstr "प्रचलित"
+
+#: ../src/propgrid/advprops.cpp:1558
+msgid "Black"
+msgstr "कालो"
+
+#: ../src/propgrid/advprops.cpp:1559
+msgid "Maroon"
+msgstr "गम्भिर"
+
+#: ../src/propgrid/advprops.cpp:1560
+msgid "Navy"
+msgstr "समुन्द्री नीलो"
+
+#: ../src/propgrid/advprops.cpp:1561
+msgid "Purple"
+msgstr "बैजनी"
+
+#: ../src/propgrid/advprops.cpp:1562
+msgid "Teal"
+msgstr "गाढा नीलो"
+
+#: ../src/propgrid/advprops.cpp:1563
+msgid "Gray"
+msgstr "खैरो"
+
+#: ../src/propgrid/advprops.cpp:1564
+msgid "Green"
+msgstr "हरियो"
+
+#: ../src/propgrid/advprops.cpp:1565
+msgid "Olive"
+msgstr "जैतुन"
+
+#: ../src/propgrid/advprops.cpp:1566
+msgid "Brown"
+msgstr "खैरो"
+
+#: ../src/propgrid/advprops.cpp:1567
+msgid "Blue"
+msgstr "नीलो"
+
+#: ../src/propgrid/advprops.cpp:1568
+msgid "Fuchsia"
+msgstr "अबिरे"
+
+#: ../src/propgrid/advprops.cpp:1569
+msgid "Red"
+msgstr "रातो"
+
+#: ../src/propgrid/advprops.cpp:1570
+msgid "Orange"
+msgstr "सुन्तला"
+
+#: ../src/propgrid/advprops.cpp:1571
+msgid "Silver"
+msgstr "चाँदी"
+
+#: ../src/propgrid/advprops.cpp:1572
+msgid "Lime"
+msgstr "कागती"
+
+#: ../src/propgrid/advprops.cpp:1573
+msgid "Aqua"
+msgstr "पानी रङ्ग"
+
+#: ../src/propgrid/advprops.cpp:1574
+msgid "Yellow"
+msgstr "पहेँलो"
+
+#: ../src/propgrid/advprops.cpp:1575
+msgid "White"
+msgstr "सेतो"
+
+#: ../src/propgrid/advprops.cpp:1718
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Default"
+msgstr "निर्धारित"
+
+#: ../src/propgrid/advprops.cpp:1719
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Arrow"
+msgstr "वाण"
+
+#: ../src/propgrid/advprops.cpp:1720
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Right Arrow"
+msgstr "दायाँ वाण"
+
+#: ../src/propgrid/advprops.cpp:1721
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Blank"
+msgstr "रित्तो"
+
+#: ../src/propgrid/advprops.cpp:1722
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Bullseye"
+msgstr "Bullseye"
+
+#: ../src/propgrid/advprops.cpp:1723
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Character"
+msgstr "वर्ण"
+
+#: ../src/propgrid/advprops.cpp:1724
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Cross"
+msgstr "क्रस"
+
+#: ../src/propgrid/advprops.cpp:1725
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Hand"
+msgstr "हात"
+
+#: ../src/propgrid/advprops.cpp:1726
+#, fuzzy
+msgctxt "system cursor name"
+msgid "I-Beam"
+msgstr "i-बलो"
+
+#: ../src/propgrid/advprops.cpp:1727
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Left Button"
+msgstr "वाञाँ टाँक"
+
+#: ../src/propgrid/advprops.cpp:1728
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Magnifier"
+msgstr "अभिबर्धक"
+
+#: ../src/propgrid/advprops.cpp:1729
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Middle Button"
+msgstr "मध्य टाँक"
+
+#: ../src/propgrid/advprops.cpp:1730
+#, fuzzy
+msgctxt "system cursor name"
+msgid "No Entry"
+msgstr "प्रविष्टि हिन "
+
+#: ../src/propgrid/advprops.cpp:1731
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Paint Brush"
+msgstr "पोत्ने बुरुस"
+
+#: ../src/propgrid/advprops.cpp:1732
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Pencil"
+msgstr "पेन्सिल"
+
+#: ../src/propgrid/advprops.cpp:1733
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Point Left"
+msgstr "थोप्लो वायाँ"
+
+#: ../src/propgrid/advprops.cpp:1734
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Point Right"
+msgstr "थोप्लो दाया"
+
+#: ../src/propgrid/advprops.cpp:1735
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Question Arrow"
+msgstr "जिज्ञासा वाण"
+
+#: ../src/propgrid/advprops.cpp:1736
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Right Button"
+msgstr "दायाँ टाँक"
+
+#: ../src/propgrid/advprops.cpp:1737
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Sizing NE-SW"
+msgstr "पूउ-पद तर्फ आकारकरण"
+
+#: ../src/propgrid/advprops.cpp:1738
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Sizing N-S"
+msgstr "उ-द तर्फ आकारकरण"
+
+#: ../src/propgrid/advprops.cpp:1739
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Sizing NW-SE"
+msgstr "उप-दपू तर्फ आकारकरण"
+
+#: ../src/propgrid/advprops.cpp:1740
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Sizing W-E"
+msgstr "पूप तर्फ आकारकरण"
+
+#: ../src/propgrid/advprops.cpp:1741
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Sizing"
+msgstr "आकारकरण"
+
+#: ../src/propgrid/advprops.cpp:1742
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Spraycan"
+msgstr "Spraycan"
+
+#: ../src/propgrid/advprops.cpp:1743
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Wait"
+msgstr "प्रतिक्षा"
+
+#: ../src/propgrid/advprops.cpp:1744
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Watch"
+msgstr "घडी"
+
+#: ../src/propgrid/advprops.cpp:1745
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Wait Arrow"
+msgstr "प्रतिक्षा वाण"
+
+#: ../src/propgrid/advprops.cpp:2109
+msgid "Make a selection:"
+msgstr "चयन गर"
+
+#: ../src/propgrid/manager.cpp:394
+msgid "Property"
+msgstr "गुण"
+
+#: ../src/propgrid/manager.cpp:395
+msgid "Value"
+msgstr "मान"
+
+#: ../src/propgrid/manager.cpp:1683
+msgid "Categorized Mode"
+msgstr "निर्दिष्ट मुद्रा"
+
+#: ../src/propgrid/manager.cpp:1709
+msgid "Alphabetic Mode"
+msgstr "वर्णीय मुद्रा"
+
+#. TRANSLATORS: Name of Boolean false value
+#: ../src/propgrid/propgrid.cpp:230
+msgid "False"
+msgstr "असत्य"
+
+#. TRANSLATORS: Name of Boolean true value
+#: ../src/propgrid/propgrid.cpp:232
+msgid "True"
+msgstr "True"
+
+#. TRANSLATORS: Text  displayed for unspecified value
+#: ../src/propgrid/propgrid.cpp:428
+msgid "Unspecified"
+msgstr "नतोकिएको"
+
+#. TRANSLATORS: Caption of message box displaying any property error
+#: ../src/propgrid/propgrid.cpp:3145 ../src/propgrid/propgrid.cpp:3282
+msgid "Property Error"
+msgstr "गुणको गल्ती"
+
+#: ../src/propgrid/propgrid.cpp:3259
+msgid "You have entered invalid value. Press ESC to cancel editing."
+msgstr "तपाइले गल्ती मान राख्नु भयो । सम्पादनलाई रद्द गर्न ESC दबाउनु होस् ।"
+
+#: ../src/propgrid/propgrid.cpp:6608
+#, c-format
+msgid "Error in resource: %s"
+msgstr "श्रोतमा गल्ती: : %s"
+
+#: ../src/propgrid/propgridiface.cpp:377
+#, c-format
+msgid ""
+"Type operation \"%s\" failed: Property labeled \"%s\" is of type \"%s\", NOT "
+"\"%s\"."
+msgstr ""
+"टङ्कण सञ्चालन \"%s\" असफल भयो: सम् पति तह \"%s\" \"%s\" खालको छ, \"%s\" किसिमको "
+"होइन"
+
+#: ../src/propgrid/props.cpp:159
+#, c-format
+msgid "Unknown base %d. Base 10 will be used."
+msgstr ""
+
+#: ../src/propgrid/props.cpp:324
+#, c-format
+msgid "Value must be %s or higher."
+msgstr "मान %s अथवा यो भन्दा बढि हुनै पर्दछ ।"
+
+#: ../src/propgrid/props.cpp:329 ../src/propgrid/props.cpp:356
+#, c-format
+msgid "Value must be between %s and %s."
+msgstr "मान %s र %s को बीचमा हुनै पर्दछ ।"
+
+#: ../src/propgrid/props.cpp:351
+#, c-format
+msgid "Value must be %s or less."
+msgstr "मान %s अथवा यो भन्दा घटि हुनै पर्दछ ।"
+
+#: ../src/propgrid/props.cpp:1058
+#, c-format
+msgid "Not %s"
+msgstr "%s होइन"
+
+#: ../src/propgrid/props.cpp:1770
+msgid "Choose a directory:"
+msgstr "एउटा घर्रा छान्नु होस्:"
+
+#: ../src/propgrid/props.cpp:2055
+msgid "Choose a file"
+msgstr "एउटा फाइल छान्नु होस्"
+
+#: ../src/qt/mdi.cpp:254
+msgid "&Tile"
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:147
+#: ../src/richtext/richtextformatdlg.cpp:376
+msgid "Background"
+msgstr "पृष्ठभूमि"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:159
+msgid "Background &colour:"
+msgstr "पृष्ठभूमि &रङ्ग:"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:161
+#: ../src/richtext/richtextbackgroundpage.cpp:163
+msgid "Enables a background colour."
+msgstr "पृष्ठभूमि रङ्ग लाई योग्य बनाउ"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:167
+#: ../src/richtext/richtextbackgroundpage.cpp:169
+msgid "The background colour."
+msgstr "पृष्ठभूमिको रङ्ग"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:178
+#, fuzzy
+msgid "Shadow"
+msgstr "विम्वटाँक"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:193
+msgid "Use &shadow"
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:195
+#: ../src/richtext/richtextbackgroundpage.cpp:197
+#, fuzzy
+msgid "Enables a shadow."
+msgstr "पृष्ठभूमि रङ्ग लाई योग्य बनाउ"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:211
+msgid "&Horizontal offset:"
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:218
+#: ../src/richtext/richtextbackgroundpage.cpp:220
+#, fuzzy
+msgid "The horizontal offset."
+msgstr "&तेर्सो पारेर राख"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:224
+#: ../src/richtext/richtextbackgroundpage.cpp:227
+#: ../src/richtext/richtextbackgroundpage.cpp:228
+#: ../src/richtext/richtextbackgroundpage.cpp:247
+#: ../src/richtext/richtextbackgroundpage.cpp:250
+#: ../src/richtext/richtextbackgroundpage.cpp:251
+#: ../src/richtext/richtextbackgroundpage.cpp:287
+#: ../src/richtext/richtextbackgroundpage.cpp:290
+#: ../src/richtext/richtextbackgroundpage.cpp:291
+#: ../src/richtext/richtextbackgroundpage.cpp:314
+#: ../src/richtext/richtextbackgroundpage.cpp:317
+#: ../src/richtext/richtextbackgroundpage.cpp:318
+#: ../src/richtext/richtextborderspage.cpp:252
+#: ../src/richtext/richtextborderspage.cpp:255
+#: ../src/richtext/richtextborderspage.cpp:256
+#: ../src/richtext/richtextborderspage.cpp:286
+#: ../src/richtext/richtextborderspage.cpp:289
+#: ../src/richtext/richtextborderspage.cpp:290
+#: ../src/richtext/richtextborderspage.cpp:320
+#: ../src/richtext/richtextborderspage.cpp:323
+#: ../src/richtext/richtextborderspage.cpp:324
+#: ../src/richtext/richtextborderspage.cpp:354
+#: ../src/richtext/richtextborderspage.cpp:357
+#: ../src/richtext/richtextborderspage.cpp:358
+#: ../src/richtext/richtextborderspage.cpp:420
+#: ../src/richtext/richtextborderspage.cpp:423
+#: ../src/richtext/richtextborderspage.cpp:424
+#: ../src/richtext/richtextborderspage.cpp:454
+#: ../src/richtext/richtextborderspage.cpp:457
+#: ../src/richtext/richtextborderspage.cpp:458
+#: ../src/richtext/richtextborderspage.cpp:488
+#: ../src/richtext/richtextborderspage.cpp:491
+#: ../src/richtext/richtextborderspage.cpp:492
+#: ../src/richtext/richtextborderspage.cpp:522
+#: ../src/richtext/richtextborderspage.cpp:525
+#: ../src/richtext/richtextborderspage.cpp:526
+#: ../src/richtext/richtextborderspage.cpp:590
+#: ../src/richtext/richtextborderspage.cpp:593
+#: ../src/richtext/richtextborderspage.cpp:594
+#: ../src/richtext/richtextfontpage.cpp:177
+#: ../src/richtext/richtextmarginspage.cpp:199
+#: ../src/richtext/richtextmarginspage.cpp:201
+#: ../src/richtext/richtextmarginspage.cpp:202
+#: ../src/richtext/richtextmarginspage.cpp:224
+#: ../src/richtext/richtextmarginspage.cpp:226
+#: ../src/richtext/richtextmarginspage.cpp:227
+#: ../src/richtext/richtextmarginspage.cpp:247
+#: ../src/richtext/richtextmarginspage.cpp:249
+#: ../src/richtext/richtextmarginspage.cpp:250
+#: ../src/richtext/richtextmarginspage.cpp:272
+#: ../src/richtext/richtextmarginspage.cpp:274
+#: ../src/richtext/richtextmarginspage.cpp:275
+#: ../src/richtext/richtextmarginspage.cpp:313
+#: ../src/richtext/richtextmarginspage.cpp:315
+#: ../src/richtext/richtextmarginspage.cpp:316
+#: ../src/richtext/richtextmarginspage.cpp:338
+#: ../src/richtext/richtextmarginspage.cpp:340
+#: ../src/richtext/richtextmarginspage.cpp:341
+#: ../src/richtext/richtextmarginspage.cpp:361
+#: ../src/richtext/richtextmarginspage.cpp:363
+#: ../src/richtext/richtextmarginspage.cpp:364
+#: ../src/richtext/richtextmarginspage.cpp:386
+#: ../src/richtext/richtextmarginspage.cpp:388
+#: ../src/richtext/richtextmarginspage.cpp:389
+#: ../src/richtext/richtextsizepage.cpp:337
+#: ../src/richtext/richtextsizepage.cpp:340
+#: ../src/richtext/richtextsizepage.cpp:341
+#: ../src/richtext/richtextsizepage.cpp:371
+#: ../src/richtext/richtextsizepage.cpp:374
+#: ../src/richtext/richtextsizepage.cpp:375
+#: ../src/richtext/richtextsizepage.cpp:398
+#: ../src/richtext/richtextsizepage.cpp:401
+#: ../src/richtext/richtextsizepage.cpp:402
+#: ../src/richtext/richtextsizepage.cpp:425
+#: ../src/richtext/richtextsizepage.cpp:428
+#: ../src/richtext/richtextsizepage.cpp:429
+#: ../src/richtext/richtextsizepage.cpp:452
+#: ../src/richtext/richtextsizepage.cpp:455
+#: ../src/richtext/richtextsizepage.cpp:456
+#: ../src/richtext/richtextsizepage.cpp:479
+#: ../src/richtext/richtextsizepage.cpp:482
+#: ../src/richtext/richtextsizepage.cpp:483
+#: ../src/richtext/richtextsizepage.cpp:553
+#: ../src/richtext/richtextsizepage.cpp:556
+#: ../src/richtext/richtextsizepage.cpp:557
+#: ../src/richtext/richtextsizepage.cpp:588
+#: ../src/richtext/richtextsizepage.cpp:591
+#: ../src/richtext/richtextsizepage.cpp:592
+#: ../src/richtext/richtextsizepage.cpp:623
+#: ../src/richtext/richtextsizepage.cpp:626
+#: ../src/richtext/richtextsizepage.cpp:627
+#: ../src/richtext/richtextsizepage.cpp:658
+#: ../src/richtext/richtextsizepage.cpp:661
+#: ../src/richtext/richtextsizepage.cpp:662
+msgid "px"
+msgstr "px"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:225
+#: ../src/richtext/richtextbackgroundpage.cpp:248
+#: ../src/richtext/richtextbackgroundpage.cpp:288
+#: ../src/richtext/richtextbackgroundpage.cpp:315
+#: ../src/richtext/richtextborderspage.cpp:253
+#: ../src/richtext/richtextborderspage.cpp:287
+#: ../src/richtext/richtextborderspage.cpp:321
+#: ../src/richtext/richtextborderspage.cpp:355
+#: ../src/richtext/richtextborderspage.cpp:421
+#: ../src/richtext/richtextborderspage.cpp:455
+#: ../src/richtext/richtextborderspage.cpp:489
+#: ../src/richtext/richtextborderspage.cpp:523
+#: ../src/richtext/richtextborderspage.cpp:591
+#: ../src/richtext/richtextmarginspage.cpp:200
+#: ../src/richtext/richtextmarginspage.cpp:225
+#: ../src/richtext/richtextmarginspage.cpp:248
+#: ../src/richtext/richtextmarginspage.cpp:273
+#: ../src/richtext/richtextmarginspage.cpp:314
+#: ../src/richtext/richtextmarginspage.cpp:339
+#: ../src/richtext/richtextmarginspage.cpp:362
+#: ../src/richtext/richtextmarginspage.cpp:387
+#: ../src/richtext/richtextsizepage.cpp:338
+#: ../src/richtext/richtextsizepage.cpp:372
+#: ../src/richtext/richtextsizepage.cpp:399
+#: ../src/richtext/richtextsizepage.cpp:426
+#: ../src/richtext/richtextsizepage.cpp:453
+#: ../src/richtext/richtextsizepage.cpp:480
+#: ../src/richtext/richtextsizepage.cpp:554
+#: ../src/richtext/richtextsizepage.cpp:589
+#: ../src/richtext/richtextsizepage.cpp:624
+#: ../src/richtext/richtextsizepage.cpp:659
+msgid "cm"
+msgstr "सेमी"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:226
+#: ../src/richtext/richtextbackgroundpage.cpp:249
+#: ../src/richtext/richtextbackgroundpage.cpp:289
+#: ../src/richtext/richtextbackgroundpage.cpp:316
+#: ../src/richtext/richtextborderspage.cpp:254
+#: ../src/richtext/richtextborderspage.cpp:288
+#: ../src/richtext/richtextborderspage.cpp:322
+#: ../src/richtext/richtextborderspage.cpp:356
+#: ../src/richtext/richtextborderspage.cpp:422
+#: ../src/richtext/richtextborderspage.cpp:456
+#: ../src/richtext/richtextborderspage.cpp:490
+#: ../src/richtext/richtextborderspage.cpp:524
+#: ../src/richtext/richtextborderspage.cpp:592
+#: ../src/richtext/richtextfontpage.cpp:176
+#: ../src/richtext/richtextfontpage.cpp:179
+msgid "pt"
+msgstr "pt"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:229
+#: ../src/richtext/richtextbackgroundpage.cpp:231
+#: ../src/richtext/richtextbackgroundpage.cpp:252
+#: ../src/richtext/richtextbackgroundpage.cpp:254
+#: ../src/richtext/richtextbackgroundpage.cpp:292
+#: ../src/richtext/richtextbackgroundpage.cpp:294
+#: ../src/richtext/richtextbackgroundpage.cpp:319
+#: ../src/richtext/richtextbackgroundpage.cpp:321
+#, fuzzy
+msgid "Units for this value."
+msgstr "देब्रे सिमान्तको एकाइ"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:234
+#, fuzzy
+msgid "&Vertical offset:"
+msgstr "&ठाडो पङ्‌क्तिबद्धता:"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:241
+#: ../src/richtext/richtextbackgroundpage.cpp:243
+#, fuzzy
+msgid "The vertical offset."
+msgstr "ठाडो पङ्क्ति बद्धता लाई योग्य बनाउ"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:257
+#, fuzzy
+msgid "Shadow c&olour:"
+msgstr "रङ्ग छान्नु होस्"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:259
+#: ../src/richtext/richtextbackgroundpage.cpp:261
+#, fuzzy
+msgid "Enables the shadow colour."
+msgstr "पृष्ठभूमि रङ्ग लाई योग्य बनाउ"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:265
+#: ../src/richtext/richtextbackgroundpage.cpp:267
+#, fuzzy
+msgid "The shadow colour."
+msgstr "वरणाकृतिको रङ्ग"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:270
+msgid "Sh&adow spread:"
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:272
+#: ../src/richtext/richtextbackgroundpage.cpp:274
+#, fuzzy
+msgid "Enables the shadow spread."
+msgstr "छोडाइ मान लाई योग्य बनाउ"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:281
+#: ../src/richtext/richtextbackgroundpage.cpp:283
+msgid "The shadow spread."
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:297
+msgid "&Blur distance:"
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:299
+#: ../src/richtext/richtextbackgroundpage.cpp:301
+#, fuzzy
+msgid "Enables the blur distance."
+msgstr "छोडाइ मान लाई योग्य बनाउ"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:308
+#: ../src/richtext/richtextbackgroundpage.cpp:310
+msgid "The shadow blur distance."
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:324
+msgid "Opaci&ty:"
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:326
+#: ../src/richtext/richtextbackgroundpage.cpp:328
+#, fuzzy
+msgid "Enables the shadow opacity."
+msgstr "छोडाइ मान लाई योग्य बनाउ"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:335
+#: ../src/richtext/richtextbackgroundpage.cpp:337
+msgid "The shadow opacity."
+msgstr ""
+
+#. TRANSLATORS: Rich text page units (percentage)
+#: ../src/richtext/richtextbackgroundpage.cpp:340
+#: ../src/richtext/richtextsizepage.cpp:339
+#: ../src/richtext/richtextsizepage.cpp:373
+#: ../src/richtext/richtextsizepage.cpp:400
+#: ../src/richtext/richtextsizepage.cpp:427
+#: ../src/richtext/richtextsizepage.cpp:454
+#: ../src/richtext/richtextsizepage.cpp:481
+#: ../src/richtext/richtextsizepage.cpp:555
+#: ../src/richtext/richtextsizepage.cpp:590
+#: ../src/richtext/richtextsizepage.cpp:625
+#: ../src/richtext/richtextsizepage.cpp:660
+msgid "%"
+msgstr "%"
+
+#: ../src/richtext/richtextborderspage.cpp:229
+#: ../src/richtext/richtextborderspage.cpp:387
+msgid "Border"
+msgstr "सिमाना"
+
+#: ../src/richtext/richtextborderspage.cpp:242
+#: ../src/richtext/richtextborderspage.cpp:410
+#: ../src/richtext/richtextindentspage.cpp:194
+#: ../src/richtext/richtextliststylepage.cpp:384
+#: ../src/richtext/richtextmarginspage.cpp:185
+#: ../src/richtext/richtextmarginspage.cpp:299
+#: ../src/richtext/richtextsizepage.cpp:531
+#: ../src/richtext/richtextsizepage.cpp:538
+msgid "&Left:"
+msgstr "&देब्रे:"
+
+#: ../src/richtext/richtextborderspage.cpp:257
+#: ../src/richtext/richtextborderspage.cpp:259
+msgid "Units for the left border width."
+msgstr "देब्रे सिमाना छोडाइको एकाइ"
+
+#: ../src/richtext/richtextborderspage.cpp:266
+#: ../src/richtext/richtextborderspage.cpp:268
+#: ../src/richtext/richtextborderspage.cpp:300
+#: ../src/richtext/richtextborderspage.cpp:302
+#: ../src/richtext/richtextborderspage.cpp:334
+#: ../src/richtext/richtextborderspage.cpp:336
+#: ../src/richtext/richtextborderspage.cpp:368
+#: ../src/richtext/richtextborderspage.cpp:370
+#: ../src/richtext/richtextborderspage.cpp:434
+#: ../src/richtext/richtextborderspage.cpp:436
+#: ../src/richtext/richtextborderspage.cpp:468
+#: ../src/richtext/richtextborderspage.cpp:470
+#: ../src/richtext/richtextborderspage.cpp:502
+#: ../src/richtext/richtextborderspage.cpp:504
+#: ../src/richtext/richtextborderspage.cpp:536
+#: ../src/richtext/richtextborderspage.cpp:538
+msgid "The border line style."
+msgstr "सिमाना रेखा शैली"
+
+#: ../src/richtext/richtextborderspage.cpp:276
+#: ../src/richtext/richtextborderspage.cpp:444
+#: ../src/richtext/richtextindentspage.cpp:212
+#: ../src/richtext/richtextliststylepage.cpp:402
+#: ../src/richtext/richtextmarginspage.cpp:210
+#: ../src/richtext/richtextmarginspage.cpp:324
+#: ../src/richtext/richtextsizepage.cpp:601
+#: ../src/richtext/richtextsizepage.cpp:608
+msgid "&Right:"
+msgstr "&दाहिने:"
+
+#: ../src/richtext/richtextborderspage.cpp:291
+#: ../src/richtext/richtextborderspage.cpp:293
+msgid "Units for the right border width."
+msgstr "दाहिने सिमाना छोडाइको एकाइ"
+
+#: ../src/richtext/richtextborderspage.cpp:310
+#: ../src/richtext/richtextborderspage.cpp:478
+#: ../src/richtext/richtextmarginspage.cpp:233
+#: ../src/richtext/richtextmarginspage.cpp:347
+#: ../src/richtext/richtextsizepage.cpp:566
+#: ../src/richtext/richtextsizepage.cpp:573
+msgid "&Top:"
+msgstr "&सिरान:"
+
+#: ../src/richtext/richtextborderspage.cpp:325
+#: ../src/richtext/richtextborderspage.cpp:327
+msgid "Units for the top border width."
+msgstr "सिरान सिमाना छोडाइको एकाइ"
+
+#: ../src/richtext/richtextborderspage.cpp:344
+#: ../src/richtext/richtextborderspage.cpp:512
+#: ../src/richtext/richtextmarginspage.cpp:258
+#: ../src/richtext/richtextmarginspage.cpp:372
+#: ../src/richtext/richtextsizepage.cpp:636
+#: ../src/richtext/richtextsizepage.cpp:643
+msgid "&Bottom:"
+msgstr "&पुछार:"
+
+#: ../src/richtext/richtextborderspage.cpp:359
+#: ../src/richtext/richtextborderspage.cpp:361
+msgid "Units for the bottom border width."
+msgstr "पुछार सिमाना छोडाइ को एकाइ "
+
+#: ../src/richtext/richtextborderspage.cpp:380
+#: ../src/richtext/richtextborderspage.cpp:548
+msgid "&Synchronize values"
+msgstr "&संयोजित मानहरू"
+
+#: ../src/richtext/richtextborderspage.cpp:382
+#: ../src/richtext/richtextborderspage.cpp:384
+#: ../src/richtext/richtextborderspage.cpp:550
+#: ../src/richtext/richtextborderspage.cpp:552
+msgid "Check to edit all borders simultaneously."
+msgstr "एकै साथ सबै सिमानाको सम्पादन गर्न टिक लगाउ "
+
+#: ../src/richtext/richtextborderspage.cpp:397
+#: ../src/richtext/richtextborderspage.cpp:555
+msgid "Outline"
+msgstr "बाह्यरेखा"
+
+#: ../src/richtext/richtextborderspage.cpp:425
+#: ../src/richtext/richtextborderspage.cpp:427
+msgid "Units for the left outline width."
+msgstr "देब्रे बाह्य रेखा छोडाइको एकाइ"
+
+#: ../src/richtext/richtextborderspage.cpp:459
+#: ../src/richtext/richtextborderspage.cpp:461
+msgid "Units for the right outline width."
+msgstr "दाहिने बाह्य रेखा छोडाइको एकाइ"
+
+#: ../src/richtext/richtextborderspage.cpp:493
+#: ../src/richtext/richtextborderspage.cpp:495
+msgid "Units for the top outline width."
+msgstr "सिरान बाह्य रेखा छोडाइको एकाइ"
+
+#: ../src/richtext/richtextborderspage.cpp:527
+#: ../src/richtext/richtextborderspage.cpp:529
+msgid "Units for the bottom outline width."
+msgstr "पुछार बाह्य रेखा छोडाइको एकाइ "
+
+#: ../src/richtext/richtextborderspage.cpp:565
+#: ../src/richtext/richtextborderspage.cpp:600
+msgid "Corner"
+msgstr "कोण"
+
+#: ../src/richtext/richtextborderspage.cpp:574
+msgid "Corner &radius:"
+msgstr "कोण र अर्धव्यास:"
+
+#: ../src/richtext/richtextborderspage.cpp:576
+#: ../src/richtext/richtextborderspage.cpp:578
+msgid "An optional corner radius for adding rounded corners."
+msgstr "गोलो कोण थप्ने वैकल्पित कोणिय अर्ध व्यास ।"
+
+#: ../src/richtext/richtextborderspage.cpp:584
+#: ../src/richtext/richtextborderspage.cpp:586
+msgid "The value of the corner radius."
+msgstr "कोणीय अर्धव्यासको मान "
+
+#: ../src/richtext/richtextborderspage.cpp:595
+#: ../src/richtext/richtextborderspage.cpp:597
+msgid "Units for the corner radius."
+msgstr "कोणीय अर्धव्यासको एकाइ "
+
+#: ../src/richtext/richtextborderspage.cpp:609
+#: ../src/richtext/richtextsizepage.cpp:247
+#: ../src/richtext/richtextsizepage.cpp:251
+msgid "None"
+msgstr "कुनै पनि होइन"
+
+#: ../src/richtext/richtextborderspage.cpp:610
+msgid "Solid"
+msgstr "ठोस"
+
+#: ../src/richtext/richtextborderspage.cpp:611
+msgid "Dotted"
+msgstr "थोप्लो थोप्लो"
+
+#: ../src/richtext/richtextborderspage.cpp:612
+msgid "Dashed"
+msgstr "Dashed"
+
+#: ../src/richtext/richtextborderspage.cpp:613
+msgid "Double"
+msgstr "दुई वटा"
+
+#: ../src/richtext/richtextborderspage.cpp:614
+msgid "Groove"
+msgstr "दाँती"
+
+#: ../src/richtext/richtextborderspage.cpp:615
+msgid "Ridge"
+msgstr "धुरी"
+
+#: ../src/richtext/richtextborderspage.cpp:616
+msgid "Inset"
+msgstr "चित्र भित्रको चित्र"
+
+#: ../src/richtext/richtextborderspage.cpp:617
+msgid "Outset"
+msgstr "बाहिरी चित्र"
+
+#: ../src/richtext/richtextbuffer.cpp:3518
+msgid "Change Style"
+msgstr "शैलीको परिवर्तन"
+
+#: ../src/richtext/richtextbuffer.cpp:3701
+msgid "Change Object Style"
+msgstr "वस्तुको शैली परिवर्तन"
+
+#: ../src/richtext/richtextbuffer.cpp:3974
+#: ../src/richtext/richtextbuffer.cpp:8174
+msgid "Change Properties"
+msgstr "गुणहरूको परिवर्तन "
+
+#: ../src/richtext/richtextbuffer.cpp:4346
+msgid "Change List Style"
+msgstr "सूचिको शैली परिवर्तन "
+
+#: ../src/richtext/richtextbuffer.cpp:4519
+msgid "Renumber List"
+msgstr "फेरि सङ्ख्या राख"
+
+#: ../src/richtext/richtextbuffer.cpp:7867
+#: ../src/richtext/richtextbuffer.cpp:7897
+#: ../src/richtext/richtextbuffer.cpp:7939
+#: ../src/richtext/richtextctrl.cpp:1279 ../src/richtext/richtextctrl.cpp:1473
+msgid "Insert Text"
+msgstr "पाठ घुसाउ"
+
+#: ../src/richtext/richtextbuffer.cpp:8023
+#: ../src/richtext/richtextbuffer.cpp:8979
+msgid "Insert Image"
+msgstr "तस्विर घुसाउ"
+
+#: ../src/richtext/richtextbuffer.cpp:8070
+msgid "Insert Object"
+msgstr "वस्तु घुसाउ"
+
+#: ../src/richtext/richtextbuffer.cpp:8112
+msgid "Insert Field"
+msgstr "क्षेत्र घुसाउ"
+
+#: ../src/richtext/richtextbuffer.cpp:8410
+msgid "Too many EndStyle calls!"
+msgstr "धेरै अन्त शैली बोलावट!"
+
+#: ../src/richtext/richtextbuffer.cpp:8785
+msgid "files"
+msgstr "फाइलहरू"
+
+#: ../src/richtext/richtextbuffer.cpp:9380
+msgid "standard/circle"
+msgstr "स्तरीय/वृत"
+
+#: ../src/richtext/richtextbuffer.cpp:9381
+msgid "standard/circle-outline"
+msgstr "स्तरीय/वृत-बाह्यरेखा"
+
+#: ../src/richtext/richtextbuffer.cpp:9382
+msgid "standard/square"
+msgstr "वर्ग/वर्ग"
+
+#: ../src/richtext/richtextbuffer.cpp:9383
+msgid "standard/diamond"
+msgstr "हिरा/हिरा"
+
+#: ../src/richtext/richtextbuffer.cpp:9384
+msgid "standard/triangle"
+msgstr "स्तरीय/त्रिभुज"
+
+#: ../src/richtext/richtextbuffer.cpp:9423
+msgid "Box Properties"
+msgstr "बाकसका गुणहरू"
+
+#: ../src/richtext/richtextbuffer.cpp:10006
+msgid "Multiple Cell Properties"
+msgstr "बहु कोशिका गुणहरू"
+
+#: ../src/richtext/richtextbuffer.cpp:10008
+msgid "Cell Properties"
+msgstr "कोशिका गुणहरू"
+
+#: ../src/richtext/richtextbuffer.cpp:11256
+msgid "Set Cell Style"
+msgstr "कोशिका शैली तय गर्नु होस् ।"
+
+#: ../src/richtext/richtextbuffer.cpp:11330
+msgid "Delete Row"
+msgstr "हरफ हटाउ"
+
+#: ../src/richtext/richtextbuffer.cpp:11380
+msgid "Delete Column"
+msgstr "महल हटाउ"
+
+#: ../src/richtext/richtextbuffer.cpp:11431
+msgid "Add Row"
+msgstr "हरफ थप"
+
+#: ../src/richtext/richtextbuffer.cpp:11494
+msgid "Add Column"
+msgstr "महल थप"
+
+#: ../src/richtext/richtextbuffer.cpp:11537
+msgid "Table Properties"
+msgstr "तालिका गुणहरू"
+
+#: ../src/richtext/richtextbuffer.cpp:12899
+msgid "Picture Properties"
+msgstr "तस्विरका गुणहरू"
+
+#: ../src/richtext/richtextbuffer.cpp:13169
+#: ../src/richtext/richtextbuffer.cpp:13279
+msgid "image"
+msgstr "तस्विर"
+
+#: ../src/richtext/richtextbulletspage.cpp:145
+#: ../src/richtext/richtextliststylepage.cpp:209
+msgid "&Bullet style:"
+msgstr "&गोलिछिन्हको शैली:"
+
+#: ../src/richtext/richtextbulletspage.cpp:150
+#: ../src/richtext/richtextbulletspage.cpp:152
+#: ../src/richtext/richtextliststylepage.cpp:214
+#: ../src/richtext/richtextliststylepage.cpp:216
+msgid "The available bullet styles."
+msgstr "उपलब्ध गोलि चिन्हका शैलीहरू "
+
+#: ../src/richtext/richtextbulletspage.cpp:158
+#: ../src/richtext/richtextliststylepage.cpp:221
+msgid "Peri&od"
+msgstr "&थोप्लो"
+
+#: ../src/richtext/richtextbulletspage.cpp:160
+#: ../src/richtext/richtextbulletspage.cpp:162
+#: ../src/richtext/richtextliststylepage.cpp:223
+#: ../src/richtext/richtextliststylepage.cpp:225
+msgid "Check to add a period after the bullet."
+msgstr "गोलि पछि थोप्लो थप्ने हो भने टिक लगाउ "
+
+#. TRANSLATORS: Bullet point in parentheses option
+#: ../src/richtext/richtextbulletspage.cpp:167
+#: ../src/richtext/richtextliststylepage.cpp:230
+msgid "(*)"
+msgstr "(*)"
+
+#: ../src/richtext/richtextbulletspage.cpp:169
+#: ../src/richtext/richtextbulletspage.cpp:171
+#: ../src/richtext/richtextliststylepage.cpp:232
+#: ../src/richtext/richtextliststylepage.cpp:234
+msgid "Check to enclose the bullet in parentheses."
+msgstr "गोलीलाई कोष्ठ भित्र राख्ने हो भने टिक लगाउ"
+
+#. TRANSLATORS: Right parenthesis bullet point option
+#: ../src/richtext/richtextbulletspage.cpp:176
+#: ../src/richtext/richtextliststylepage.cpp:239
+msgid "*)"
+msgstr "*)"
+
+#: ../src/richtext/richtextbulletspage.cpp:178
+#: ../src/richtext/richtextbulletspage.cpp:180
+#: ../src/richtext/richtextliststylepage.cpp:241
+#: ../src/richtext/richtextliststylepage.cpp:243
+msgid "Check to add a right parenthesis."
+msgstr "दाहिने कोष्ठ थप्ने हो भने टिक लगाउ"
+
+#: ../src/richtext/richtextbulletspage.cpp:185
+#: ../src/richtext/richtextliststylepage.cpp:248
+msgid "Bullet &Alignment:"
+msgstr "थोप्लो &पङ्क्तिsवद्धता:"
+
+#: ../src/richtext/richtextbulletspage.cpp:190
+#: ../src/richtext/richtextliststylepage.cpp:253
+msgid "Centre"
+msgstr "केन्द्र"
+
+#: ../src/richtext/richtextbulletspage.cpp:194
+#: ../src/richtext/richtextbulletspage.cpp:196
+#: ../src/richtext/richtextbulletspage.cpp:217
+#: ../src/richtext/richtextbulletspage.cpp:219
+#: ../src/richtext/richtextliststylepage.cpp:257
+#: ../src/richtext/richtextliststylepage.cpp:259
+#: ../src/richtext/richtextliststylepage.cpp:278
+#: ../src/richtext/richtextliststylepage.cpp:280
+msgid "The bullet character."
+msgstr "गोलि चिन्हको वर्ण"
+
+#: ../src/richtext/richtextbulletspage.cpp:212
+#: ../src/richtext/richtextliststylepage.cpp:271
+msgid "&Symbol:"
+msgstr "&चिन्ह:"
+
+#: ../src/richtext/richtextbulletspage.cpp:222
+#: ../src/richtext/richtextliststylepage.cpp:283
+msgid "Ch&oose..."
+msgstr "&रोजाई.."
+
+#: ../src/richtext/richtextbulletspage.cpp:223
+#: ../src/richtext/richtextbulletspage.cpp:225
+#: ../src/richtext/richtextliststylepage.cpp:284
+#: ../src/richtext/richtextliststylepage.cpp:286
+msgid "Click to browse for a symbol."
+msgstr "चिन्ह खोतल्न किटिक्क पार्नु होस"
+
+#: ../src/richtext/richtextbulletspage.cpp:230
+#: ../src/richtext/richtextliststylepage.cpp:291
+msgid "Symbol &font:"
+msgstr "चिन्ह &वरणाकृति:"
+
+#: ../src/richtext/richtextbulletspage.cpp:235
+#: ../src/richtext/richtextbulletspage.cpp:237
+#: ../src/richtext/richtextliststylepage.cpp:297
+msgid "Available fonts."
+msgstr "उपलब्ध वरणाकृतिहरू"
+
+#: ../src/richtext/richtextbulletspage.cpp:242
+#: ../src/richtext/richtextliststylepage.cpp:302
+msgid "S&tandard bullet name:"
+msgstr "&स्तरीय गोलीको नाम:"
+
+#: ../src/richtext/richtextbulletspage.cpp:247
+#: ../src/richtext/richtextbulletspage.cpp:249
+#: ../src/richtext/richtextliststylepage.cpp:307
+#: ../src/richtext/richtextliststylepage.cpp:309
+msgid "A standard bullet name."
+msgstr "स्तरीय थोप्लोको नाम"
+
+#: ../src/richtext/richtextbulletspage.cpp:254
+msgid "&Number:"
+msgstr "&सङ्ख्या:"
+
+#: ../src/richtext/richtextbulletspage.cpp:258
+#: ../src/richtext/richtextbulletspage.cpp:260
+msgid "The list item number."
+msgstr "सूचि सामाग्रीको सङ्ख्या"
+
+#: ../src/richtext/richtextbulletspage.cpp:266
+#: ../src/richtext/richtextbulletspage.cpp:268
+#: ../src/richtext/richtextliststylepage.cpp:475
+#: ../src/richtext/richtextliststylepage.cpp:477
+msgid "Shows a preview of the bullet settings."
+msgstr "गोलि चिन्ह अनुकूलताको चेहरा देखाउ छ ।"
+
+#: ../src/richtext/richtextbulletspage.cpp:276
+#: ../src/richtext/richtextliststylepage.cpp:484
+msgid "(None)"
+msgstr "(कुनै पनि होइन)"
+
+#: ../src/richtext/richtextbulletspage.cpp:277
+#: ../src/richtext/richtextliststylepage.cpp:485
+msgid "Arabic"
+msgstr "अरबी"
+
+#: ../src/richtext/richtextbulletspage.cpp:278
+#: ../src/richtext/richtextliststylepage.cpp:486
+msgid "Upper case letters"
+msgstr "ठूलो खालको पाठ"
+
+#: ../src/richtext/richtextbulletspage.cpp:279
+#: ../src/richtext/richtextliststylepage.cpp:487
+msgid "Lower case letters"
+msgstr "सानो वर्णहरू"
+
+#: ../src/richtext/richtextbulletspage.cpp:280
+#: ../src/richtext/richtextliststylepage.cpp:488
+msgid "Upper case roman numerals"
+msgstr "ठूलो खालको रोमन सङ्ख्या"
+
+#: ../src/richtext/richtextbulletspage.cpp:281
+#: ../src/richtext/richtextliststylepage.cpp:489
+msgid "Lower case roman numerals"
+msgstr "सानो वर्ण रोमन सङ्ख्या"
+
+#: ../src/richtext/richtextbulletspage.cpp:282
+#: ../src/richtext/richtextliststylepage.cpp:490
+msgid "Numbered outline"
+msgstr "सङ्ख्यात्मक बाह्यरेखा"
+
+#: ../src/richtext/richtextbulletspage.cpp:283
+#: ../src/richtext/richtextliststylepage.cpp:491
+msgid "Symbol"
+msgstr "चिन्ह"
+
+#: ../src/richtext/richtextbulletspage.cpp:284
+#: ../src/richtext/richtextliststylepage.cpp:492
+msgid "Bitmap"
+msgstr "Bitmap"
+
+#: ../src/richtext/richtextbulletspage.cpp:285
+#: ../src/richtext/richtextliststylepage.cpp:493
+msgid "Standard"
+msgstr "स्तरीय"
+
+#: ../src/richtext/richtextbulletspage.cpp:287
+#: ../src/richtext/richtextliststylepage.cpp:495
+msgid "*"
+msgstr "*"
+
+#: ../src/richtext/richtextbulletspage.cpp:288
+#: ../src/richtext/richtextliststylepage.cpp:496
+msgid "-"
+msgstr "-"
+
+#: ../src/richtext/richtextbulletspage.cpp:289
+#: ../src/richtext/richtextliststylepage.cpp:497
+msgid ">"
+msgstr ">"
+
+#: ../src/richtext/richtextbulletspage.cpp:290
+#: ../src/richtext/richtextliststylepage.cpp:498
+msgid "+"
+msgstr "+"
+
+#: ../src/richtext/richtextbulletspage.cpp:291
+#: ../src/richtext/richtextliststylepage.cpp:499
+msgid "~"
+msgstr "~"
+
+#: ../src/richtext/richtextctrl.cpp:859
+msgid "Drag"
+msgstr "घिसार्नू"
+
+#: ../src/richtext/richtextctrl.cpp:1338 ../src/richtext/richtextctrl.cpp:1559
+msgid "Delete Text"
+msgstr "पाठ मेटाइ देउ "
+
+#: ../src/richtext/richtextctrl.cpp:1537
+msgid "Remove Bullet"
+msgstr "गोली चिन्ह हटाउ"
+
+#: ../src/richtext/richtextctrl.cpp:3070
+msgid "The text couldn't be saved."
+msgstr "पाठलाई बचत गर्न सकेन"
+
+#: ../src/richtext/richtextctrl.cpp:3644
+msgid "Replace"
+msgstr "प्रतिस्थापन गर"
+
+#: ../src/richtext/richtextfontpage.cpp:146
+#: ../src/richtext/richtextsymboldlg.cpp:384
+msgid "&Font:"
+msgstr "&वरणाकृति:"
+
+#: ../src/richtext/richtextfontpage.cpp:150
+#: ../src/richtext/richtextfontpage.cpp:152
+msgid "Type a font name."
+msgstr "वरणाकृतिको नाम टङ्कण गर"
+
+#: ../src/richtext/richtextfontpage.cpp:158
+msgid "&Size:"
+msgstr "&आकार:"
+
+#: ../src/richtext/richtextfontpage.cpp:165
+#: ../src/richtext/richtextfontpage.cpp:167
+msgid "Type a size in points."
+msgstr "थोप्लोमा आकारलाई टङ्कण गर"
+
+#: ../src/richtext/richtextfontpage.cpp:180
+#: ../src/richtext/richtextfontpage.cpp:182
+msgid "The font size units, points or pixels."
+msgstr "वरणाकृति आकारको एकाई, विन्दु अथवा पिक्सेल"
+
+#: ../src/richtext/richtextfontpage.cpp:189
+#: ../src/richtext/richtextfontpage.cpp:191
+msgid "Lists the available fonts."
+msgstr "उपलब्ध वरणाकृतिहरूको सुची"
+
+#: ../src/richtext/richtextfontpage.cpp:196
+#: ../src/richtext/richtextfontpage.cpp:198
+msgid "Lists font sizes in points."
+msgstr "वरणाकृतिका आकारहरूको सुची (Points)"
+
+#: ../src/richtext/richtextfontpage.cpp:207
+msgid "Font st&yle:"
+msgstr "वरणाकृतिको &शैली:"
+
+#: ../src/richtext/richtextfontpage.cpp:212
+#: ../src/richtext/richtextfontpage.cpp:214
+msgid "Select regular or italic style."
+msgstr "नियमित अथवा डल्केको शैली कुनै एकलाई चयन गर"
+
+#: ../src/richtext/richtextfontpage.cpp:220
+msgid "Font &weight:"
+msgstr "वरणाकृति &भार:"
+
+#: ../src/richtext/richtextfontpage.cpp:225
+#: ../src/richtext/richtextfontpage.cpp:227
+msgid "Select regular or bold."
+msgstr "नियमित अथवा मोटो कुनै लाई चयन गर"
+
+#: ../src/richtext/richtextfontpage.cpp:233
+msgid "&Underlining:"
+msgstr "&अदोरेखाङ्करण:"
+
+#: ../src/richtext/richtextfontpage.cpp:238
+#: ../src/richtext/richtextfontpage.cpp:240
+msgid "Select underlining or no underlining."
+msgstr "अदोरेखाङ्करण अथवा गैह्र अदोरेखाङ्करण लाई चयन गर ।"
+
+#: ../src/richtext/richtextfontpage.cpp:248
+msgid "&Colour:"
+msgstr "&रङ्ग:"
+
+#: ../src/richtext/richtextfontpage.cpp:253
+#: ../src/richtext/richtextfontpage.cpp:255
+msgid "Click to change the text colour."
+msgstr "पाठको रङ्ग फेर्न किटिक्क पार्नु होस्"
+
+#: ../src/richtext/richtextfontpage.cpp:261
+msgid "&Bg colour:"
+msgstr "&पृष्ठभूमि रङ्ग:"
+
+#: ../src/richtext/richtextfontpage.cpp:266
+#: ../src/richtext/richtextfontpage.cpp:268
+msgid "Click to change the text background colour."
+msgstr "पाठको पृष्ठभूमि रङ्ग फेर्न किटिक्क पार्नु होस्"
+
+#: ../src/richtext/richtextfontpage.cpp:276
+#: ../src/richtext/richtextfontpage.cpp:278
+msgid "Check to show a line through the text."
+msgstr "पाठको आधारमा हरफ देखाउने हो भने टिक लगाउ"
+
+#: ../src/richtext/richtextfontpage.cpp:281
+msgid "Ca&pitals"
+msgstr "Ca&pitals"
+
+#: ../src/richtext/richtextfontpage.cpp:283
+#: ../src/richtext/richtextfontpage.cpp:285
+msgid "Check to show the text in capitals."
+msgstr "पाठलाई capitals मा देखाउने हो भने टिक लगाउ"
+
+#: ../src/richtext/richtextfontpage.cpp:288
+msgid "Small C&apitals"
+msgstr "सानो &ठूलो वर्ण"
+
+#: ../src/richtext/richtextfontpage.cpp:290
+#: ../src/richtext/richtextfontpage.cpp:292
+msgid "Check to show the text in small capitals."
+msgstr "सानो ठूलो वर्णमा पाठ देखाउन टिक लगाउ"
+
+#: ../src/richtext/richtextfontpage.cpp:295
+msgid "Supe&rscript"
+msgstr "&टाउकोमा"
+
+#: ../src/richtext/richtextfontpage.cpp:297
+#: ../src/richtext/richtextfontpage.cpp:299
+msgid "Check to show the text in superscript."
+msgstr "टाउकोमा पाठ देखाउने हो भने टिक लगाउ"
+
+#: ../src/richtext/richtextfontpage.cpp:302
+msgid "Subscrip&t"
+msgstr "&पैतालोमा"
+
+#: ../src/richtext/richtextfontpage.cpp:304
+#: ../src/richtext/richtextfontpage.cpp:306
+msgid "Check to show the text in subscript."
+msgstr "पैतालोमा पाठ देखाउने हो भने टिक लगाउ"
+
+#: ../src/richtext/richtextfontpage.cpp:312
+msgid "Rig&ht-to-left"
+msgstr "&दायाँ -देखि वायाँ"
+
+#: ../src/richtext/richtextfontpage.cpp:314
+#: ../src/richtext/richtextfontpage.cpp:316
+msgid "Check to indicate right-to-left text layout."
+msgstr "दाँया देखि वाँया पाठ रुपरेखा जनाउन  टिक लगाउ"
+
+#: ../src/richtext/richtextfontpage.cpp:319
+msgid "Suppress hyphe&nation"
+msgstr "हाइपरनेशनलाई &दबाउ"
+
+#: ../src/richtext/richtextfontpage.cpp:321
+#: ../src/richtext/richtextfontpage.cpp:323
+msgid "Check to suppress hyphenation."
+msgstr "हाइफरनेसन दबाउन टिक लगाउनु होला ।."
+
+#: ../src/richtext/richtextfontpage.cpp:329
+#: ../src/richtext/richtextfontpage.cpp:331
+msgid "Shows a preview of the font settings."
+msgstr "वरणाकृति अनुकूलताको चेहरा देखाउ छ ।"
+
+#: ../src/richtext/richtextfontpage.cpp:348
+#: ../src/richtext/richtextfontpage.cpp:352
+#: ../src/richtext/richtextfontpage.cpp:356
+#: ../src/richtext/richtextformatdlg.cpp:873
+#: ../src/richtext/richtextindentspage.cpp:273
+#: ../src/richtext/richtextindentspage.cpp:285
+#: ../src/richtext/richtextindentspage.cpp:286
+#: ../src/richtext/richtextindentspage.cpp:310
+#: ../src/richtext/richtextindentspage.cpp:325
+#: ../src/richtext/richtextliststylepage.cpp:451
+#: ../src/richtext/richtextliststylepage.cpp:463
+#: ../src/richtext/richtextliststylepage.cpp:464
+msgid "(none)"
+msgstr "(कुनै पनि होइन)"
+
+#: ../src/richtext/richtextfontpage.cpp:349
+#: ../src/richtext/richtextfontpage.cpp:353
+msgid "Regular"
+msgstr "नियमित"
+
+#: ../src/richtext/richtextfontpage.cpp:357
+msgid "Not underlined"
+msgstr "अधोरेखाङ्कित होइन"
+
+#: ../src/richtext/richtextformatdlg.cpp:341
+msgid "Indents && Spacing"
+msgstr "Indents र खालि स्थान"
+
+#: ../src/richtext/richtextformatdlg.cpp:346
+msgid "Tabs"
+msgstr "Tabs"
+
+#: ../src/richtext/richtextformatdlg.cpp:351
+msgid "Bullets"
+msgstr "थोप्लोहरू"
+
+#: ../src/richtext/richtextformatdlg.cpp:356
+msgid "List Style"
+msgstr "शैलीको सुची"
+
+#: ../src/richtext/richtextformatdlg.cpp:366
+#: ../src/richtext/richtextmarginspage.cpp:170
+msgid "Margins"
+msgstr "सिमान्त"
+
+#: ../src/richtext/richtextformatdlg.cpp:371
+msgid "Borders"
+msgstr "सिमानाहरू"
+
+#: ../src/richtext/richtextformatdlg.cpp:765
+msgid "Colour"
+msgstr "रङ्ग"
+
+#: ../src/richtext/richtextindentspage.cpp:127
+#: ../src/richtext/richtextliststylepage.cpp:322
+msgid "&Alignment"
+msgstr "&पङ्क्तिणवद्धता"
+
+#: ../src/richtext/richtextindentspage.cpp:138
+#: ../src/richtext/richtextliststylepage.cpp:331
+msgid "&Left"
+msgstr "&देब्रे"
+
+#: ../src/richtext/richtextindentspage.cpp:140
+#: ../src/richtext/richtextindentspage.cpp:142
+#: ../src/richtext/richtextliststylepage.cpp:333
+#: ../src/richtext/richtextliststylepage.cpp:335
+msgid "Left-align text."
+msgstr "देब्रे-पङ्क्ति पाठ"
+
+#: ../src/richtext/richtextindentspage.cpp:145
+#: ../src/richtext/richtextliststylepage.cpp:338
+msgid "&Right"
+msgstr "&दाहिने"
+
+#: ../src/richtext/richtextindentspage.cpp:147
+#: ../src/richtext/richtextindentspage.cpp:149
+#: ../src/richtext/richtextliststylepage.cpp:340
+#: ../src/richtext/richtextliststylepage.cpp:342
+msgid "Right-align text."
+msgstr "दाहिने-पङ्क्तिबद्ध पाठ"
+
+#: ../src/richtext/richtextindentspage.cpp:152
+#: ../src/richtext/richtextliststylepage.cpp:345
+msgid "&Justified"
+msgstr "&छेउ मिलेको"
+
+#: ../src/richtext/richtextindentspage.cpp:154
+#: ../src/richtext/richtextindentspage.cpp:156
+#: ../src/richtext/richtextliststylepage.cpp:347
+#: ../src/richtext/richtextliststylepage.cpp:349
+msgid "Justify text left and right."
+msgstr "पाठलाई देब्रे र दाहिने किनारमा मिलाउ ।"
+
+#: ../src/richtext/richtextindentspage.cpp:159
+#: ../src/richtext/richtextliststylepage.cpp:352
+msgid "Cen&tred"
+msgstr "&केन्द्रित"
+
+#: ../src/richtext/richtextindentspage.cpp:161
+#: ../src/richtext/richtextindentspage.cpp:163
+#: ../src/richtext/richtextliststylepage.cpp:354
+#: ../src/richtext/richtextliststylepage.cpp:356
+msgid "Centre text."
+msgstr "बीचको पाठ"
+
+#: ../src/richtext/richtextindentspage.cpp:166
+#: ../src/richtext/richtextliststylepage.cpp:359
+msgid "&Indeterminate"
+msgstr "&निकाल्न नसकिने"
+
+#: ../src/richtext/richtextindentspage.cpp:168
+#: ../src/richtext/richtextindentspage.cpp:170
+#: ../src/richtext/richtextliststylepage.cpp:361
+#: ../src/richtext/richtextliststylepage.cpp:363
+msgid "Use the current alignment setting."
+msgstr "चालू पङ्क्ति बद्ध अनुकूलताको प्रयोग गर"
+
+#: ../src/richtext/richtextindentspage.cpp:183
+#: ../src/richtext/richtextliststylepage.cpp:375
+msgid "&Indentation (tenths of a mm)"
+msgstr "&Indentation (मिलि मिटरको दसौँ भाग)"
+
+#: ../src/richtext/richtextindentspage.cpp:198
+#: ../src/richtext/richtextindentspage.cpp:200
+#: ../src/richtext/richtextliststylepage.cpp:388
+#: ../src/richtext/richtextliststylepage.cpp:390
+msgid "The left indent."
+msgstr "देब्रे indent"
+
+#: ../src/richtext/richtextindentspage.cpp:203
+#: ../src/richtext/richtextliststylepage.cpp:393
+msgid "Left (&first line):"
+msgstr "देब्रे (&प्रथम line):"
+
+#: ../src/richtext/richtextindentspage.cpp:207
+#: ../src/richtext/richtextindentspage.cpp:209
+#: ../src/richtext/richtextliststylepage.cpp:397
+#: ../src/richtext/richtextliststylepage.cpp:399
+msgid "The first line indent."
+msgstr "पहिलो लाइनको indent"
+
+#: ../src/richtext/richtextindentspage.cpp:216
+#: ../src/richtext/richtextindentspage.cpp:218
+#: ../src/richtext/richtextliststylepage.cpp:406
+#: ../src/richtext/richtextliststylepage.cpp:408
+msgid "The right indent."
+msgstr "दाहिने indent"
+
+#: ../src/richtext/richtextindentspage.cpp:221
+msgid "&Outline level:"
+msgstr "&बाह्य रेखा तह:"
+
+#: ../src/richtext/richtextindentspage.cpp:226
+#: ../src/richtext/richtextindentspage.cpp:228
+msgid "The outline level."
+msgstr "बाहिरी तह"
+
+#: ../src/richtext/richtextindentspage.cpp:241
+#: ../src/richtext/richtextliststylepage.cpp:420
+msgid "&Spacing (tenths of a mm)"
+msgstr "&फरक (मिलि मिटरको दसौँ भाग)"
+
+#: ../src/richtext/richtextindentspage.cpp:252
+msgid "&Before a paragraph:"
+msgstr "&अनुच्छेद अगाडि:"
+
+#: ../src/richtext/richtextindentspage.cpp:256
+#: ../src/richtext/richtextindentspage.cpp:258
+#: ../src/richtext/richtextliststylepage.cpp:433
+#: ../src/richtext/richtextliststylepage.cpp:435
+msgid "The spacing before the paragraph."
+msgstr "अनुच्छेद अघिको परक "
+
+#: ../src/richtext/richtextindentspage.cpp:261
+msgid "&After a paragraph:"
+msgstr "&अनुच्छेद पछि"
+
+#: ../src/richtext/richtextindentspage.cpp:266
+#: ../src/richtext/richtextliststylepage.cpp:442
+#: ../src/richtext/richtextliststylepage.cpp:444
+msgid "The spacing after the paragraph."
+msgstr "अनुच्छेद पछिको परक"
+
+#: ../src/richtext/richtextindentspage.cpp:269
+msgid "L&ine spacing:"
+msgstr "&रेखा को फरक:"
+
+#: ../src/richtext/richtextindentspage.cpp:274
+#: ../src/richtext/richtextliststylepage.cpp:452
+msgid "Single"
+msgstr "एउटा"
+
+#: ../src/richtext/richtextindentspage.cpp:275
+#: ../src/richtext/richtextliststylepage.cpp:453
+msgid "1.1"
+msgstr "1.1"
+
+#: ../src/richtext/richtextindentspage.cpp:276
+#: ../src/richtext/richtextliststylepage.cpp:454
+msgid "1.2"
+msgstr "1.2"
+
+#: ../src/richtext/richtextindentspage.cpp:277
+#: ../src/richtext/richtextliststylepage.cpp:455
+msgid "1.3"
+msgstr "1.3"
+
+#: ../src/richtext/richtextindentspage.cpp:278
+#: ../src/richtext/richtextliststylepage.cpp:456
+msgid "1.4"
+msgstr "1.4"
+
+#: ../src/richtext/richtextindentspage.cpp:279
+#: ../src/richtext/richtextliststylepage.cpp:457
+msgid "1.5"
+msgstr "1.5"
+
+#: ../src/richtext/richtextindentspage.cpp:280
+#: ../src/richtext/richtextliststylepage.cpp:458
+msgid "1.6"
+msgstr "1.6"
+
+#: ../src/richtext/richtextindentspage.cpp:281
+#: ../src/richtext/richtextliststylepage.cpp:459
+msgid "1.7"
+msgstr "1.7"
+
+#: ../src/richtext/richtextindentspage.cpp:282
+#: ../src/richtext/richtextliststylepage.cpp:460
+msgid "1.8"
+msgstr "1.8"
+
+#: ../src/richtext/richtextindentspage.cpp:283
+#: ../src/richtext/richtextliststylepage.cpp:461
+msgid "1.9"
+msgstr "1.9"
+
+#: ../src/richtext/richtextindentspage.cpp:284
+#: ../src/richtext/richtextliststylepage.cpp:462
+msgid "2"
+msgstr "2"
+
+#: ../src/richtext/richtextindentspage.cpp:287
+#: ../src/richtext/richtextindentspage.cpp:289
+#: ../src/richtext/richtextliststylepage.cpp:465
+#: ../src/richtext/richtextliststylepage.cpp:467
+msgid "The line spacing."
+msgstr "हरफको अन्तर"
+
+#: ../src/richtext/richtextindentspage.cpp:292
+msgid "&Page Break"
+msgstr "&पृष्ट विच्छेद"
+
+#: ../src/richtext/richtextindentspage.cpp:294
+#: ../src/richtext/richtextindentspage.cpp:296
+msgid "Inserts a page break before the paragraph."
+msgstr "अनुच्छेद अगाडि पृष्ट विच्छेद गर।"
+
+#: ../src/richtext/richtextindentspage.cpp:302
+#: ../src/richtext/richtextindentspage.cpp:304
+msgid "Shows a preview of the paragraph settings."
+msgstr "अनुच्छेद अनुकूलताको चेहरा देखाउ छ ।"
+
+#: ../src/richtext/richtextliststylepage.cpp:182
+msgid "&List level:"
+msgstr "&सूचि तह:"
+
+#: ../src/richtext/richtextliststylepage.cpp:186
+#: ../src/richtext/richtextliststylepage.cpp:188
+msgid "Selects the list level to edit."
+msgstr "सम्पादनका लागि सूचि तह चयन गर्छ ।"
+
+#: ../src/richtext/richtextliststylepage.cpp:193
+msgid "&Font for Level..."
+msgstr "&वरणाकृति for तह.."
+
+#: ../src/richtext/richtextliststylepage.cpp:194
+#: ../src/richtext/richtextliststylepage.cpp:196
+msgid "Click to choose the font for this level."
+msgstr "यो तहमा वरणाकृति छान्न किटिक्क पार्नु होस्"
+
+#: ../src/richtext/richtextliststylepage.cpp:312
+msgid "Bullet style"
+msgstr "थोप्ले शैली"
+
+#: ../src/richtext/richtextliststylepage.cpp:429
+msgid "Before a paragraph:"
+msgstr " अनुच्छेद अगाडि:"
+
+#: ../src/richtext/richtextliststylepage.cpp:438
+msgid "After a paragraph:"
+msgstr " अनुच्छेद पछि:"
+
+#: ../src/richtext/richtextliststylepage.cpp:447
+msgid "Line spacing:"
+msgstr "लाइनको फरक:"
+
+#: ../src/richtext/richtextliststylepage.cpp:470
+msgid "Spacing"
+msgstr "Spacing"
+
+#: ../src/richtext/richtextmarginspage.cpp:193
+#: ../src/richtext/richtextmarginspage.cpp:195
+msgid "The left margin size."
+msgstr "देब्रे सिमान्तको आकार"
+
+#: ../src/richtext/richtextmarginspage.cpp:203
+#: ../src/richtext/richtextmarginspage.cpp:205
+msgid "Units for the left margin."
+msgstr "देब्रे सिमान्तको एकाइ"
+
+#: ../src/richtext/richtextmarginspage.cpp:218
+#: ../src/richtext/richtextmarginspage.cpp:220
+msgid "The right margin size."
+msgstr "दाहिने सिमान्तको आकार"
+
+#: ../src/richtext/richtextmarginspage.cpp:228
+#: ../src/richtext/richtextmarginspage.cpp:230
+msgid "Units for the right margin."
+msgstr "दाहिने सिमान्तको एकाइ"
+
+#: ../src/richtext/richtextmarginspage.cpp:241
+#: ../src/richtext/richtextmarginspage.cpp:243
+msgid "The top margin size."
+msgstr "सिरान सिमान्तको आकार"
+
+#: ../src/richtext/richtextmarginspage.cpp:251
+#: ../src/richtext/richtextmarginspage.cpp:253
+msgid "Units for the top margin."
+msgstr "सिरान सिमान्तको एकाइ"
+
+#: ../src/richtext/richtextmarginspage.cpp:266
+#: ../src/richtext/richtextmarginspage.cpp:268
+msgid "The bottom margin size."
+msgstr "पुछार सिमान्तको आकार"
+
+#: ../src/richtext/richtextmarginspage.cpp:276
+#: ../src/richtext/richtextmarginspage.cpp:278
+msgid "Units for the bottom margin."
+msgstr "पुछार सिमान्तको एकाइ "
+
+#: ../src/richtext/richtextmarginspage.cpp:284
+msgid "Padding"
+msgstr "ख्रेस्रा"
+
+#: ../src/richtext/richtextmarginspage.cpp:307
+#: ../src/richtext/richtextmarginspage.cpp:309
+msgid "The left padding size."
+msgstr "देब्रे ख्रेस्रा को आकार"
+
+#: ../src/richtext/richtextmarginspage.cpp:317
+#: ../src/richtext/richtextmarginspage.cpp:319
+msgid "Units for the left padding."
+msgstr "देब्रे ख्रेस्रा को एकाइ"
+
+#: ../src/richtext/richtextmarginspage.cpp:332
+#: ../src/richtext/richtextmarginspage.cpp:334
+msgid "The right padding size."
+msgstr "दाहिने ख्रेस्रा को आकार"
+
+#: ../src/richtext/richtextmarginspage.cpp:342
+#: ../src/richtext/richtextmarginspage.cpp:344
+msgid "Units for the right padding."
+msgstr "दाहिने ख्रेस्राको एकाइ"
+
+#: ../src/richtext/richtextmarginspage.cpp:355
+#: ../src/richtext/richtextmarginspage.cpp:357
+msgid "The top padding size."
+msgstr "सिरान ख्रेस्रा को आकार"
+
+#: ../src/richtext/richtextmarginspage.cpp:365
+#: ../src/richtext/richtextmarginspage.cpp:367
+msgid "Units for the top padding."
+msgstr "सिरान ख्रेस्राको एकाइ"
+
+#: ../src/richtext/richtextmarginspage.cpp:380
+#: ../src/richtext/richtextmarginspage.cpp:382
+msgid "The bottom padding size."
+msgstr "पुछार ख्रेस्रा को आकार"
+
+#: ../src/richtext/richtextmarginspage.cpp:390
+#: ../src/richtext/richtextmarginspage.cpp:392
+msgid "Units for the bottom padding."
+msgstr "पुछार ख्रेस्रा को एकाइ"
+
+#: ../src/richtext/richtextprint.cpp:592
+msgid " Preview"
+msgstr "चेहरा"
+
+#: ../src/richtext/richtextsizepage.cpp:228
+msgid "Floating"
+msgstr "तैरि रहेको"
+
+#: ../src/richtext/richtextsizepage.cpp:243
+msgid "&Floating mode:"
+msgstr "&तैरि रहेको मुद्रा:"
+
+#: ../src/richtext/richtextsizepage.cpp:252
+#: ../src/richtext/richtextsizepage.cpp:254
+msgid "How the object will float relative to the text."
+msgstr "पाठको सापेक्षतामा कसरी वस्तु वहन गर्ला?"
+
+#: ../src/richtext/richtextsizepage.cpp:265
+msgid "Alignment"
+msgstr "पङ्‌क्तिबद्धता"
+
+#: ../src/richtext/richtextsizepage.cpp:277
+msgid "&Vertical alignment:"
+msgstr "&ठाडो पङ्‌क्तिबद्धता:"
+
+#: ../src/richtext/richtextsizepage.cpp:279
+#: ../src/richtext/richtextsizepage.cpp:281
+msgid "Enable vertical alignment."
+msgstr "ठाडो पङ्क्ति बद्धता लाई योग्य बनाउ"
+
+#: ../src/richtext/richtextsizepage.cpp:286
+msgid "Centred"
+msgstr "केन्द्रित"
+
+#: ../src/richtext/richtextsizepage.cpp:290
+#: ../src/richtext/richtextsizepage.cpp:292
+msgid "Vertical alignment."
+msgstr "ठाडो पङ्‌क्तिबद्धता"
+
+#: ../src/richtext/richtextsizepage.cpp:316
+#: ../src/richtext/richtextsizepage.cpp:323
+msgid "&Width:"
+msgstr "&छोडाइ:"
+
+#: ../src/richtext/richtextsizepage.cpp:318
+#: ../src/richtext/richtextsizepage.cpp:320
+msgid "Enable the width value."
+msgstr "छोडाइ मान लाई योग्य बनाउ"
+
+#: ../src/richtext/richtextsizepage.cpp:331
+#: ../src/richtext/richtextsizepage.cpp:333
+msgid "The object width."
+msgstr "वस्तुको छोडाइ"
+
+#: ../src/richtext/richtextsizepage.cpp:342
+#: ../src/richtext/richtextsizepage.cpp:344
+msgid "Units for the object width."
+msgstr "वस्तु छोडाइको एकाइ"
+
+#: ../src/richtext/richtextsizepage.cpp:350
+#: ../src/richtext/richtextsizepage.cpp:357
+msgid "&Height:"
+msgstr "&उचाइ:"
+
+#: ../src/richtext/richtextsizepage.cpp:352
+#: ../src/richtext/richtextsizepage.cpp:354
+#: ../src/richtext/richtextsizepage.cpp:464
+#: ../src/richtext/richtextsizepage.cpp:466
+msgid "Enable the height value."
+msgstr "उचाइ मान लाई योग्य बनाउ"
+
+#: ../src/richtext/richtextsizepage.cpp:365
+#: ../src/richtext/richtextsizepage.cpp:367
+msgid "The object height."
+msgstr "वस्तुको उचाइ"
+
+#: ../src/richtext/richtextsizepage.cpp:376
+#: ../src/richtext/richtextsizepage.cpp:378
+msgid "Units for the object height."
+msgstr "वस्तु उचाइको एकाइ"
+
+#: ../src/richtext/richtextsizepage.cpp:381
+msgid "Min width:"
+msgstr "न्यून छोडाइ:"
+
+#: ../src/richtext/richtextsizepage.cpp:383
+#: ../src/richtext/richtextsizepage.cpp:385
+msgid "Enable the minimum width value."
+msgstr "न्यूनतम छोडाइ मान लाई योग्य बनाउ"
+
+#: ../src/richtext/richtextsizepage.cpp:392
+#: ../src/richtext/richtextsizepage.cpp:394
+msgid "The object minimum width."
+msgstr "वस्तुको न्यूनतम छोडाइ"
+
+#: ../src/richtext/richtextsizepage.cpp:403
+#: ../src/richtext/richtextsizepage.cpp:405
+msgid "Units for the minimum object width."
+msgstr "न्यूनतम वस्तु छोडाइको एकाइ"
+
+#: ../src/richtext/richtextsizepage.cpp:408
+msgid "Min height:"
+msgstr "न्यून उचाइ:"
+
+#: ../src/richtext/richtextsizepage.cpp:410
+#: ../src/richtext/richtextsizepage.cpp:412
+msgid "Enable the minimum height value."
+msgstr "न्यूनतम उचाइ मान लाई योग्य बनाउ"
+
+#: ../src/richtext/richtextsizepage.cpp:419
+#: ../src/richtext/richtextsizepage.cpp:421
+msgid "The object minimum height."
+msgstr "वस्तुको न्यूनतम उचाइ"
+
+#: ../src/richtext/richtextsizepage.cpp:430
+#: ../src/richtext/richtextsizepage.cpp:432
+msgid "Units for the minimum object height."
+msgstr "न्यूनतम वस्तु उचाइको एकाइ"
+
+#: ../src/richtext/richtextsizepage.cpp:435
+msgid "Max width:"
+msgstr "अधिकतम छोडाइ:"
+
+#: ../src/richtext/richtextsizepage.cpp:437
+#: ../src/richtext/richtextsizepage.cpp:439
+msgid "Enable the maximum width value."
+msgstr "अधिकतम छोडाइ मान लाई योग्य बनाउ"
+
+#: ../src/richtext/richtextsizepage.cpp:446
+#: ../src/richtext/richtextsizepage.cpp:448
+msgid "The object maximum width."
+msgstr "वस्तुको अधिकतम छोडाइ"
+
+#: ../src/richtext/richtextsizepage.cpp:457
+#: ../src/richtext/richtextsizepage.cpp:459
+msgid "Units for the maximum object width."
+msgstr "अधिकतम वस्तु छोडाइको एकाइ"
+
+#: ../src/richtext/richtextsizepage.cpp:462
+msgid "Max height:"
+msgstr "अधिकतम उचाइ:"
+
+#: ../src/richtext/richtextsizepage.cpp:473
+#: ../src/richtext/richtextsizepage.cpp:475
+msgid "The object maximum height."
+msgstr "वस्तुको अधिकतम उचाइ"
+
+#: ../src/richtext/richtextsizepage.cpp:484
+#: ../src/richtext/richtextsizepage.cpp:486
+msgid "Units for the maximum object height."
+msgstr "अधिकतम वस्तु उचाइको एकाइ"
+
+#: ../src/richtext/richtextsizepage.cpp:495
+msgid "Position"
+msgstr "स्थान"
+
+#: ../src/richtext/richtextsizepage.cpp:513
+msgid "&Position mode:"
+msgstr "&अवस्था मुद्रा:"
+
+#: ../src/richtext/richtextsizepage.cpp:517
+#: ../src/richtext/richtextsizepage.cpp:522
+msgid "Static"
+msgstr "स्थिर"
+
+#: ../src/richtext/richtextsizepage.cpp:518
+msgid "Relative"
+msgstr "सापेक्षित"
+
+#: ../src/richtext/richtextsizepage.cpp:519
+msgid "Absolute"
+msgstr "निरपेक्ष"
+
+#: ../src/richtext/richtextsizepage.cpp:520
+msgid "Fixed"
+msgstr "निश्चित "
+
+#: ../src/richtext/richtextsizepage.cpp:533
+#: ../src/richtext/richtextsizepage.cpp:535
+#: ../src/richtext/richtextsizepage.cpp:547
+#: ../src/richtext/richtextsizepage.cpp:549
+msgid "The left position."
+msgstr "देब्रे स्थान "
+
+#: ../src/richtext/richtextsizepage.cpp:558
+#: ../src/richtext/richtextsizepage.cpp:560
+msgid "Units for the left position."
+msgstr "देब्रे स्थानको एकाइ"
+
+#: ../src/richtext/richtextsizepage.cpp:568
+#: ../src/richtext/richtextsizepage.cpp:570
+#: ../src/richtext/richtextsizepage.cpp:582
+#: ../src/richtext/richtextsizepage.cpp:584
+msgid "The top position."
+msgstr "सिरान स्थान "
+
+#: ../src/richtext/richtextsizepage.cpp:593
+#: ../src/richtext/richtextsizepage.cpp:595
+msgid "Units for the top position."
+msgstr "सिरान स्थानकोएकाइ"
+
+#: ../src/richtext/richtextsizepage.cpp:603
+#: ../src/richtext/richtextsizepage.cpp:605
+#: ../src/richtext/richtextsizepage.cpp:617
+#: ../src/richtext/richtextsizepage.cpp:619
+msgid "The right position."
+msgstr "दाहिने स्थान "
+
+#: ../src/richtext/richtextsizepage.cpp:628
+#: ../src/richtext/richtextsizepage.cpp:630
+msgid "Units for the right position."
+msgstr "दाहिने स्थानको एकाइ"
+
+#: ../src/richtext/richtextsizepage.cpp:638
+#: ../src/richtext/richtextsizepage.cpp:640
+#: ../src/richtext/richtextsizepage.cpp:652
+#: ../src/richtext/richtextsizepage.cpp:654
+msgid "The bottom position."
+msgstr "पुछार स्थान "
+
+#: ../src/richtext/richtextsizepage.cpp:663
+#: ../src/richtext/richtextsizepage.cpp:665
+msgid "Units for the bottom position."
+msgstr "पुछार स्थानको एकाइ"
+
+#: ../src/richtext/richtextsizepage.cpp:671
+msgid "&Move the object to:"
+msgstr "&वस्तुमा जाउ"
+
+#: ../src/richtext/richtextsizepage.cpp:674
+msgid "&Previous Paragraph"
+msgstr "&पछिल्लो अनुच्छेद"
+
+#: ../src/richtext/richtextsizepage.cpp:675
+#: ../src/richtext/richtextsizepage.cpp:677
+msgid "Moves the object to the previous paragraph."
+msgstr "पछिल्लो अनुच्छेदमा वस्तुलाई लैजान्छ । "
+
+#: ../src/richtext/richtextsizepage.cpp:680
+msgid "&Next Paragraph"
+msgstr "&अघिल्लो अनुच्छेद"
+
+#: ../src/richtext/richtextsizepage.cpp:681
+#: ../src/richtext/richtextsizepage.cpp:683
+msgid "Moves the object to the next paragraph."
+msgstr "अघिल्लो अनुच्छेदमा वस्तुलाई लैजान्छ ।"
+
+#: ../src/richtext/richtextstyledlg.cpp:193
+msgid "&Styles:"
+msgstr "&शैलीहरू:"
+
+#: ../src/richtext/richtextstyledlg.cpp:197
+#: ../src/richtext/richtextstyledlg.cpp:199
+msgid "The available styles."
+msgstr "उपलब्ध शैलीहरू"
+
+#: ../src/richtext/richtextstyledlg.cpp:205
+#: ../src/richtext/richtextstyledlg.cpp:217
+msgid " "
+msgstr " "
+
+#: ../src/richtext/richtextstyledlg.cpp:209
+#: ../src/richtext/richtextstyledlg.cpp:211
+msgid "The style preview."
+msgstr "शैलीको चेहरा"
+
+#: ../src/richtext/richtextstyledlg.cpp:220
+msgid "New &Character Style..."
+msgstr "नया &वर्ण शैली.."
+
+#: ../src/richtext/richtextstyledlg.cpp:221
+#: ../src/richtext/richtextstyledlg.cpp:223
+msgid "Click to create a new character style."
+msgstr "नया वर्ण शैली सिर्जना गर्न किटिक्क पार्नु होस्"
+
+#: ../src/richtext/richtextstyledlg.cpp:226
+msgid "New &Paragraph Style..."
+msgstr "नया &अनुच्छेद शैली.."
+
+#: ../src/richtext/richtextstyledlg.cpp:227
+#: ../src/richtext/richtextstyledlg.cpp:229
+msgid "Click to create a new paragraph style."
+msgstr "नया अनुच्छेद शैली सिर्जना गर्न किटिक्क पार्नु होस्"
+
+#: ../src/richtext/richtextstyledlg.cpp:232
+msgid "New &List Style..."
+msgstr "नया &सूचि शैली.."
+
+#: ../src/richtext/richtextstyledlg.cpp:233
+#: ../src/richtext/richtextstyledlg.cpp:235
+msgid "Click to create a new list style."
+msgstr "Click to create a नया सूचि शैली सिर्जना गर्न किटिक्क पार्नु होस्"
+
+#: ../src/richtext/richtextstyledlg.cpp:238
+msgid "New &Box Style..."
+msgstr "नया &बाकस शैली.."
+
+#: ../src/richtext/richtextstyledlg.cpp:239
+#: ../src/richtext/richtextstyledlg.cpp:241
+msgid "Click to create a new box style."
+msgstr "नया बाकस शैली सिर्जना गर्न किटिक्क पार्नु होस्"
+
+#: ../src/richtext/richtextstyledlg.cpp:246
+msgid "&Apply Style"
+msgstr "&शैली लागू गर"
+
+#: ../src/richtext/richtextstyledlg.cpp:247
+#: ../src/richtext/richtextstyledlg.cpp:249
+msgid "Click to apply the selected style."
+msgstr "चयन गरिएको शैली लागू गर्न किटिक्क पार्नु होस्"
+
+#: ../src/richtext/richtextstyledlg.cpp:252
+msgid "&Rename Style..."
+msgstr " शैली को&नाम फेर.."
+
+#: ../src/richtext/richtextstyledlg.cpp:253
+#: ../src/richtext/richtextstyledlg.cpp:255
+msgid "Click to rename the selected style."
+msgstr "चयन गरेको शैलीको नाम फेर्न किटिक्क पार्नु होस्"
+
+#: ../src/richtext/richtextstyledlg.cpp:258
+msgid "&Edit Style..."
+msgstr "शैलीको &सम्पादन .."
+
+#: ../src/richtext/richtextstyledlg.cpp:259
+#: ../src/richtext/richtextstyledlg.cpp:261
+msgid "Click to edit the selected style."
+msgstr "चयन गरेको शैली सम्पादन गर्न किटिक्क पार्नु होस्"
+
+#: ../src/richtext/richtextstyledlg.cpp:264
+msgid "&Delete Style..."
+msgstr "शैली &मेटाइ देउ ."
+
+#: ../src/richtext/richtextstyledlg.cpp:265
+#: ../src/richtext/richtextstyledlg.cpp:267
+msgid "Click to delete the selected style."
+msgstr "चयन गरेको शैली मेटाउन किटिक्क पार्नु होस्"
+
+#: ../src/richtext/richtextstyledlg.cpp:274
+#: ../src/richtext/richtextstyledlg.cpp:276
+msgid "Click to close this window."
+msgstr "यो विन्डो बन्द गर्न किटिक्क पार्नु होस्"
+
+#: ../src/richtext/richtextstyledlg.cpp:282
+msgid "&Restart numbering"
+msgstr "&फेरि सङ्ख्या राख्न सुरु गर "
+
+#: ../src/richtext/richtextstyledlg.cpp:284
+#: ../src/richtext/richtextstyledlg.cpp:286
+msgid "Check to restart numbering."
+msgstr "फेरि सङ्ख्या सुरु गर्ने हो भने टिक लगाउ"
+
+#: ../src/richtext/richtextstyledlg.cpp:601
+msgid "Enter a character style name"
+msgstr "वर्ण शैलीको नाम लेख"
+
+#: ../src/richtext/richtextstyledlg.cpp:601
+#: ../src/richtext/richtextstyledlg.cpp:606
+#: ../src/richtext/richtextstyledlg.cpp:649
+#: ../src/richtext/richtextstyledlg.cpp:654
+#: ../src/richtext/richtextstyledlg.cpp:815
+#: ../src/richtext/richtextstyledlg.cpp:820
+#: ../src/richtext/richtextstyledlg.cpp:888
+#: ../src/richtext/richtextstyledlg.cpp:896
+#: ../src/richtext/richtextstyledlg.cpp:929
+#: ../src/richtext/richtextstyledlg.cpp:934
+msgid "New Style"
+msgstr "नया शैली"
+
+#: ../src/richtext/richtextstyledlg.cpp:606
+#: ../src/richtext/richtextstyledlg.cpp:654
+#: ../src/richtext/richtextstyledlg.cpp:820
+#: ../src/richtext/richtextstyledlg.cpp:896
+#: ../src/richtext/richtextstyledlg.cpp:934
+msgid "Sorry, that name is taken. Please choose another."
+msgstr "माफ गर्नु होस्, त्यो नाम लिइ सकियो । कृपया अर्को छान्नु होस् ।"
+
+#: ../src/richtext/richtextstyledlg.cpp:649
+msgid "Enter a paragraph style name"
+msgstr "अनुच्छेद शैलीको नाम लेख"
+
+#: ../src/richtext/richtextstyledlg.cpp:777
+#, c-format
+msgid "Delete style %s?"
+msgstr "शैली %s मेटाउने हो?"
+
+#: ../src/richtext/richtextstyledlg.cpp:777
+msgid "Delete Style"
+msgstr "शैली मेटाइ देउ "
+
+#: ../src/richtext/richtextstyledlg.cpp:815
+msgid "Enter a list style name"
+msgstr "सूचि शैलीको नाम लेख"
+
+#: ../src/richtext/richtextstyledlg.cpp:888
+msgid "Enter a new style name"
+msgstr "नया शैलीको नाम लेख"
+
+#: ../src/richtext/richtextstyledlg.cpp:929
+msgid "Enter a box style name"
+msgstr "बाकस शैलीको नाम लेख"
+
+#: ../src/richtext/richtextstylepage.cpp:109
+#: ../src/richtext/richtextstylepage.cpp:111
+msgid "The style name."
+msgstr "शैलीको name"
+
+#: ../src/richtext/richtextstylepage.cpp:114
+msgid "&Based on:"
+msgstr "&आधारित"
+
+#: ../src/richtext/richtextstylepage.cpp:119
+#: ../src/richtext/richtextstylepage.cpp:121
+msgid "The style on which this style is based."
+msgstr "त्यो शैली जसमा यो शैली आधारित छ ।"
+
+#: ../src/richtext/richtextstylepage.cpp:124
+msgid "&Next style:"
+msgstr "&अघिल्लो शैली:"
+
+#: ../src/richtext/richtextstylepage.cpp:129
+#: ../src/richtext/richtextstylepage.cpp:131
+msgid "The default style for the next paragraph."
+msgstr "अघिल्लो अनुच्छेदका लागि निर्धारित शैली "
+
+#: ../src/richtext/richtextstyles.cpp:1057
+msgid "All styles"
+msgstr "सबै शैलीहरू"
+
+#: ../src/richtext/richtextstyles.cpp:1058
+msgid "Paragraph styles"
+msgstr "अनुच्छेद शैलीहरू "
+
+#: ../src/richtext/richtextstyles.cpp:1059
+msgid "Character styles"
+msgstr "वर्ण शैलीहरू"
+
+#: ../src/richtext/richtextstyles.cpp:1060
+msgid "List styles"
+msgstr "शैलीहरूको सुची"
+
+#: ../src/richtext/richtextstyles.cpp:1061
+msgid "Box styles"
+msgstr "बाकसका शैलीहरू"
+
+#: ../src/richtext/richtextsymboldlg.cpp:389
+#: ../src/richtext/richtextsymboldlg.cpp:391
+msgid "The font from which to take the symbol."
+msgstr "त्यो वरणाकृति जसबाट चिन्ह लिइन्छ ।"
+
+#: ../src/richtext/richtextsymboldlg.cpp:396
+msgid "&Subset:"
+msgstr "&उप समूह"
+
+#: ../src/richtext/richtextsymboldlg.cpp:401
+#: ../src/richtext/richtextsymboldlg.cpp:403
+msgid "Shows a Unicode subset."
+msgstr "युनिकोड subset देखाउ छ ।"
+
+#: ../src/richtext/richtextsymboldlg.cpp:412
+msgid "xxxx"
+msgstr "xxxx"
+
+#: ../src/richtext/richtextsymboldlg.cpp:417
+msgid "&Character code:"
+msgstr "&वर्ण संहिता"
+
+#: ../src/richtext/richtextsymboldlg.cpp:421
+#: ../src/richtext/richtextsymboldlg.cpp:423
+msgid "The character code."
+msgstr "वर्ण कोड "
+
+#: ../src/richtext/richtextsymboldlg.cpp:428
+msgid "&From:"
+msgstr "&बाट:"
+
+#: ../src/richtext/richtextsymboldlg.cpp:433
+#: ../src/richtext/richtextsymboldlg.cpp:434
+#: ../src/richtext/richtextsymboldlg.cpp:435
+msgid "Unicode"
+msgstr "युनिकोड"
+
+#: ../src/richtext/richtextsymboldlg.cpp:436
+#: ../src/richtext/richtextsymboldlg.cpp:438
+msgid "The range to show."
+msgstr "देखाउने तह"
+
+#: ../src/richtext/richtextsymboldlg.cpp:444
+msgid "Insert"
+msgstr "घुसाउ"
+
+#: ../src/richtext/richtextsymboldlg.cpp:478
+msgid "(Normal text)"
+msgstr "(सामान्य पाठ)"
+
+#: ../src/richtext/richtexttabspage.cpp:109
+msgid "&Position (tenths of a mm):"
+msgstr "&स्थान (मिलि मिटरको दसौँ भाग):"
+
+#: ../src/richtext/richtexttabspage.cpp:113
+#: ../src/richtext/richtexttabspage.cpp:115
+msgid "The tab position."
+msgstr "tab को स्थान "
+
+#: ../src/richtext/richtexttabspage.cpp:119
+msgid "The tab positions."
+msgstr "tab का स्थानहरू"
+
+#: ../src/richtext/richtexttabspage.cpp:132
+#: ../src/richtext/richtexttabspage.cpp:134
+msgid "Click to create a new tab position."
+msgstr "नया tab स्थान सिर्जना गर्न किटिक्क पार्नु होस्"
+
+#: ../src/richtext/richtexttabspage.cpp:138
+#: ../src/richtext/richtexttabspage.cpp:140
+msgid "Click to delete the selected tab position."
+msgstr "चयन गरेको tab स्थान मेटाउन किटिक्क पार्नु होस्"
+
+#: ../src/richtext/richtexttabspage.cpp:143
+msgid "Delete A&ll"
+msgstr "&सबै मेटाइ देउ "
+
+#: ../src/richtext/richtexttabspage.cpp:144
+#: ../src/richtext/richtexttabspage.cpp:146
+msgid "Click to delete all tab positions."
+msgstr "सबै tab स्थानहरू मेटाउन किटिक्क पार्नु होस्"
+
+#: ../src/univ/theme.cpp:110
+msgid "Failed to initialize GUI: no built-in themes found."
+msgstr "GUI सुरुवात गर्न सकिएन: बनी बनाउ themes पाइ एन ।"
+
+#: ../src/univ/themes/gtk.cpp:521
+msgid "GTK+ theme"
+msgstr "GTK+ theme"
+
+#: ../src/univ/themes/metal.cpp:164
+msgid "Metal theme"
+msgstr "धातु theme"
+
+#: ../src/univ/themes/mono.cpp:512
+msgid "Simple monochrome theme"
+msgstr "साधारण एकल रङ्गिन theme"
+
+#: ../src/univ/themes/win32.cpp:1098
+msgid "Win32 theme"
+msgstr "Win32 theme"
+
+#: ../src/univ/themes/win32.cpp:3743
+msgid "&Restore"
+msgstr "&फेरि स्थापित गर"
+
+#: ../src/univ/themes/win32.cpp:3744
+msgid "&Move"
+msgstr "&जाउ"
+
+#: ../src/univ/themes/win32.cpp:3746
+msgid "&Size"
+msgstr "&आकार"
+
+#: ../src/univ/themes/win32.cpp:3748
+msgid "Mi&nimize"
+msgstr "&सूक्ष्म बनाउ"
+
+#: ../src/univ/themes/win32.cpp:3750
+msgid "Ma&ximize"
+msgstr "&ठूलो बनाउ"
+
+#: ../src/univ/themes/win32.cpp:3752
+msgid "Alt+"
+msgstr "Alt+"
+
+#: ../src/unix/appunix.cpp:178
+msgid "Failed to install signal handler"
+msgstr "सङ्केत चालक स्थापित गर्न सकिएन ।"
+
+#: ../src/unix/dialup.cpp:351
+msgid "Already dialling ISP."
+msgstr "पहिले देखी नै ISP डायल गर्दै छु ।"
+
+#: ../src/unix/dlunix.cpp:93
+#, fuzzy
+msgid "Failed to unload shared library"
+msgstr "साझा पुस्तकालय '%s' वहन गर्न सकिएन "
+
+#: ../src/unix/dlunix.cpp:121
+msgid "Unknown dynamic library error"
+msgstr "अज्ञात गतिसित पुस्तकालय गल्ती"
+
+#: ../src/unix/epolldispatcher.cpp:84
+msgid "Failed to create epoll descriptor"
+msgstr "epoll ब्याख्याकार को सिर्जना गर्न सकिएन ।"
+
+#: ../src/unix/epolldispatcher.cpp:103
+msgid "Error closing epoll descriptor"
+msgstr "गल्ती भएकोले epoll ब्याख्याकार बन्द हुँदै छ ।"
+
+#: ../src/unix/epolldispatcher.cpp:116
+#, c-format
+msgid "Failed to add descriptor %d to epoll descriptor %d"
+msgstr "ब्याख्याकार %d लाई epoll ब्याख्याकार %d मा थप्न सकिएन ।"
+
+#: ../src/unix/epolldispatcher.cpp:136
+#, c-format
+msgid "Failed to modify descriptor %d in epoll descriptor %d"
+msgstr "ब्याख्याकार %d (epoll ब्याख्याकार %d मा ) फेर बदल गर्न सकिएन ।"
+
+#: ../src/unix/epolldispatcher.cpp:155
+#, c-format
+msgid "Failed to unregister descriptor %d from epoll descriptor %d"
+msgstr "ब्याख्याकार %d को दर्ता epoll ब्याख्याकार %d वाट खारेज गर्न सकिएन ।"
+
+#: ../src/unix/epolldispatcher.cpp:213
+#, c-format
+msgid "Waiting for IO on epoll descriptor %d failed"
+msgstr " epoll ब्याख्याकार %d मा IO को पर्खाइ असफल भयो ।"
+
+#: ../src/unix/fswatcher_inotify.cpp:71
+msgid "Unable to create inotify instance"
+msgstr "inotify instance लाई सिर्जना गर्न सकिएन ।Unable to create "
+
+#: ../src/unix/fswatcher_inotify.cpp:94
+msgid "Unable to close inotify instance"
+msgstr "inotify instance लाइ बन्द गर्न सकिएन ।"
+
+#: ../src/unix/fswatcher_inotify.cpp:106
+msgid "Unable to add inotify watch"
+msgstr "inotify घडी थप्न सकिएन ।"
+
+#: ../src/unix/fswatcher_inotify.cpp:138
+#, fuzzy, c-format
+msgid "Unable to remove inotify watch %i"
+msgstr "inotify घडी हटाउन सकिएन ।"
+
+#: ../src/unix/fswatcher_inotify.cpp:271
+#, c-format
+msgid "Unexpected event for \"%s\": no matching watch descriptor."
+msgstr "अनुमान नगरेको घटना \"%s\": कुनै मिल्दो घडि व्याख्याकार छैन ।"
+
+#: ../src/unix/fswatcher_inotify.cpp:320
+#, c-format
+msgid "Invalid inotify event for \"%s\""
+msgstr "\"%s\" का लागि  सूचीत अवैध  घटना ।"
+
+#: ../src/unix/fswatcher_inotify.cpp:553
+msgid "Unable to read from inotify descriptor"
+msgstr "inotify descriptor बाट पढ्न सकिएन ।"
+
+#: ../src/unix/fswatcher_inotify.cpp:558
+msgid "EOF while reading from inotify descriptor"
+msgstr "inotify ब्याख्याकारबाट पढ्दा फाइलको अन्तमा पुगियो । "
+
+#: ../src/unix/fswatcher_kqueue.cpp:114
+msgid "Unable to create kqueue instance"
+msgstr "kqueue instance लाई सिर्जना गर्न सकिएन ।"
+
+#: ../src/unix/fswatcher_kqueue.cpp:131
+msgid "Error closing kqueue instance"
+msgstr "गल्ती भएकोले kqueue instance बन्द हुँदैछ ।"
+
+#: ../src/unix/fswatcher_kqueue.cpp:153
+msgid "Unable to add kqueue watch"
+msgstr "kqueue घडी थप्न सकिएन ।"
+
+#: ../src/unix/fswatcher_kqueue.cpp:170
+msgid "Unable to remove kqueue watch"
+msgstr "kqueue घडीलाई हटाउन सकिएन ।"
+
+#: ../src/unix/fswatcher_kqueue.cpp:202
+msgid "Unable to get events from kqueue"
+msgstr "kqueue बाट घटना पाउन सकिएन ।"
+
+#: ../src/unix/mediactrl.cpp:966
+#, c-format
+msgid "Media playback error: %s"
+msgstr "श्रव्य सामाग्री पृष्ठध्वनी त्रुटी: %s"
+
+#: ../src/unix/mediactrl.cpp:1228
+#, c-format
+msgid "Failed to prepare playing \"%s\"."
+msgstr "\"%s\" लाई बजाउने तयारी असफल भयो ।"
+
+#: ../src/unix/snglinst.cpp:164
+#, c-format
+msgid "Failed to write to lock file '%s'"
+msgstr "चाबी फाइल '%s' मा लेख्न सकिएन ।"
+
+#: ../src/unix/snglinst.cpp:177
+#, c-format
+msgid "Failed to set permissions on lock file '%s'"
+msgstr "चाबी फाइलमा '%s' अनुमति राख्न सकिएन ।"
+
+#: ../src/unix/snglinst.cpp:194
+#, c-format
+msgid "Failed to lock the lock file '%s'"
+msgstr "चाबी फाइल '%s' मा चाबी लगाउन सकिएन ।"
+
+#: ../src/unix/snglinst.cpp:237
+#, c-format
+msgid "Failed to inspect the lock file '%s'"
+msgstr "'%s' चाबी फाइल जाँच्न सकिएन ।"
+
+#: ../src/unix/snglinst.cpp:242
+#, c-format
+msgid "Lock file '%s' has incorrect owner."
+msgstr "चाबी फाइल '%s' को नमिल्दो owner छ ।"
+
+#: ../src/unix/snglinst.cpp:247
+#, c-format
+msgid "Lock file '%s' has incorrect permissions."
+msgstr "चाबी फाइल '%s' को अनुमति अवैध छ ।"
+
+#: ../src/unix/snglinst.cpp:265
+msgid "Failed to access lock file."
+msgstr "चाबी फाइल हेर्न सकिएन ।"
+
+#: ../src/unix/snglinst.cpp:274
+msgid "Failed to read PID from lock file."
+msgstr "चाबी फाइलबाट PID पढ्न सकिएन ।"
+
+#: ../src/unix/snglinst.cpp:284
+#, c-format
+msgid "Failed to remove stale lock file '%s'."
+msgstr "बासी चाबी फाइल '%s'. हटाउन सकिएन ।"
+
+#: ../src/unix/snglinst.cpp:297
+#, c-format
+msgid "Deleted stale lock file '%s'."
+msgstr "बासी चाबी फाइल '%s'. हटाइयो ।"
+
+#: ../src/unix/snglinst.cpp:308
+#, c-format
+msgid "Invalid lock file '%s'."
+msgstr "नमिल्दो चाबी फाइल '%s'"
+
+#: ../src/unix/snglinst.cpp:324
+#, c-format
+msgid "Failed to remove lock file '%s'"
+msgstr "चाबी फाइल '%s' हटाउन सकिएन ।"
+
+#: ../src/unix/snglinst.cpp:330
+#, c-format
+msgid "Failed to unlock lock file '%s'"
+msgstr "चाबी लागेको फाइल '%s' को चाबी खोल्न सकिएन ।"
+
+#: ../src/unix/snglinst.cpp:336
+#, c-format
+msgid "Failed to close lock file '%s'"
+msgstr "चाबी फाइल '%s' बन्द गर्न सकिएन ।"
+
+#: ../src/unix/sound.cpp:77
+msgid "No sound"
+msgstr "आवाज छैन "
+
+#: ../src/unix/sound.cpp:364
+msgid "Unable to play sound asynchronously."
+msgstr "ध्वनिलाई सिलसिला मिलाएर बजाउन सकिएन ।"
+
+#: ../src/unix/sound.cpp:458
+#, c-format
+msgid "Couldn't load sound data from '%s'."
+msgstr "आवाज '%s' को तथ्याङ्क वहन गर्न सकिएन"
+
+#: ../src/unix/sound.cpp:465
+#, c-format
+msgid "Sound file '%s' is in unsupported format."
+msgstr "ध्वनि फाइल '%s' असमर्थित बनोटमा छ ।"
+
+#: ../src/unix/sound.cpp:480
+msgid "Sound data are in unsupported format."
+msgstr "ध्वनि तथ्याङ्क असमर्थित बनोटमा छन् ।"
+
+#: ../src/unix/sound_sdl.cpp:226
+#, c-format
+msgid "Couldn't open audio: %s"
+msgstr "श्रव्य हटाउन सकिएन: %s"
+
+#: ../src/unix/threadpsx.cpp:1033
+msgid "Cannot retrieve thread scheduling policy."
+msgstr "thread कार्य सुची नीति प्राप्त गर्न सकिँदैन ।"
+
+#: ../src/unix/threadpsx.cpp:1058
+#, c-format
+msgid "Cannot get priority range for scheduling policy %d."
+msgstr "प्राथमिकता तह for कार्यसूची नीति %d पाउन सकिँदैन ।"
+
+#: ../src/unix/threadpsx.cpp:1066
+msgid "Thread priority setting is ignored."
+msgstr "Thread प्राथमिकता कायम लाइ बेवास्ता गरियो"
+
+#: ../src/unix/threadpsx.cpp:1221
+msgid ""
+"Failed to join a thread, potential memory leak detected - please restart the "
+"program"
+msgstr "Thread जोड्न सकिएन, भण्डार चुहावट प्रबल छ- कृपया कार्यक्रम फेरी सुरु गर्नु होला"
+
+#: ../src/unix/threadpsx.cpp:1352
+#, c-format
+msgid "Failed to set thread concurrency level to %lu"
+msgstr "thread स्वीकृति तहलाई %lu मा तय गर्न सकिएन ।"
+
+#: ../src/unix/threadpsx.cpp:1481
+#, c-format
+msgid "Failed to set thread priority %d."
+msgstr "thread प्राथमिकता %d कायम गर्न सकिएन ।"
+
+#: ../src/unix/threadpsx.cpp:1666
+msgid "Failed to terminate a thread."
+msgstr "thread लाई बन्द गर्न सकिएन ।"
+
+#: ../src/unix/threadpsx.cpp:1893
+msgid "Thread module initialization failed: failed to create thread key"
+msgstr "Thread module को सुरुवात असफल भयो : thread कुञ्जी सिर्जना गर्न असफल भयो ।"
+
+#: ../src/unix/utilsunx.cpp:340
+msgid "Impossible to get child process input"
+msgstr "शिशु प्रक्रिया लगानी प्राप्त गर्न सम्भव छैन ।"
+
+#: ../src/unix/utilsunx.cpp:390
+msgid "Can't write to child process's stdin"
+msgstr "सीसु प्रक्रिया s stdin मा लेख्न सकिँदैन ।"
+
+#: ../src/unix/utilsunx.cpp:644
+#, c-format
+msgid "Failed to execute '%s'\n"
+msgstr "'%s' कार्यान्वयन गर्न सकिएन ।\n"
+
+#: ../src/unix/utilsunx.cpp:678
+msgid "Fork failed"
+msgstr "Fork असफल भयो ।"
+
+#: ../src/unix/utilsunx.cpp:701
+msgid "Failed to set process priority"
+msgstr "प्रक्रिया प्राथमिकता क्रम तोक्न सकिएन ।"
+
+#: ../src/unix/utilsunx.cpp:712
+msgid "Failed to redirect child process input/output"
+msgstr "बाल प्रक्रिया लगानी/प्रतिफल फेरि पठाउन सकिएन ।"
+
+#: ../src/unix/utilsunx.cpp:816
+msgid "Failed to set up non-blocking pipe, the program might hang."
+msgstr "न टालिएको पाइप जडान गर्न सकिएन, कार्यक्रम निष्क्रिय हुन सक्छ ।"
+
+#: ../src/unix/utilsunx.cpp:1023
+msgid "Cannot get the hostname"
+msgstr "सत्कार कर्ताको नाम पाउन सकिँदैन ।"
+
+#: ../src/unix/utilsunx.cpp:1059
+msgid "Cannot get the official hostname"
+msgstr "अतिरिक्त सत्कार कर्ताको नाम पाउन सकिँदैन ।"
+
+#: ../src/unix/wakeuppipe.cpp:49
+msgid "Failed to create wake up pipe used by event loop."
+msgstr "event loop ले प्रयोग गर्ने Wake Up Pipe सिर्जना गर्न सकिएन ।"
+
+#: ../src/unix/wakeuppipe.cpp:56
+msgid "Failed to switch wake up pipe to non-blocking mode"
+msgstr "wake Up pipe लाई न टालिएको मुद्रामा लान सकिएन ।"
+
+#: ../src/unix/wakeuppipe.cpp:117
+msgid "Failed to read from wake-up pipe"
+msgstr "Wake-Up pipe बाट पढ्न सकिएन ।"
+
+#: ../src/x11/app.cpp:124
+#, c-format
+msgid "Invalid geometry specification '%s'"
+msgstr "नमिल्दो ज्यामिति मानक '%s'"
+
+#: ../src/x11/app.cpp:167
+msgid "wxWidgets could not open display. Exiting."
+msgstr "wxWidgets ले दृश्यक खोल्न सकेन: बहिर्गमन गरिदैं छ ।"
+
+#: ../src/x11/utils.cpp:169
+#, c-format
+msgid "Failed to close the display \"%s\""
+msgstr "दृश्य \"%s\" बन्द गर्न सकिएन ।"
+
+#: ../src/x11/utils.cpp:188
+#, c-format
+msgid "Failed to open display \"%s\"."
+msgstr "दृश्य \"%s\" खोल्न सकिएन ।"
+
+#: ../src/xml/xml.cpp:868
+#, c-format
+msgid "XML parsing error: '%s' at line %d"
+msgstr "XML पठाउन मा गल्ती: '%s' (%d लाइनमा)"
+
+#: ../src/xrc/xh_propgrid.cpp:239
+#, fuzzy, c-format
+msgid "Page %i"
+msgstr "पृष्ट %d"
+
+#: ../src/xrc/xmlres.cpp:448
+#, c-format
+msgid "Cannot load resources from '%s'."
+msgstr "'%s' बाट श्रोत वहन गर्न सकिँदैन ।"
+
+#: ../src/xrc/xmlres.cpp:799
+#, c-format
+msgid "Cannot open resources file '%s'."
+msgstr "श्रोत फाइल '%s' खोल्न सकिँदैन ।"
+
+#: ../src/xrc/xmlres.cpp:806
+#, c-format
+msgid "Cannot load resources from file '%s'."
+msgstr "फाइल '%s' बाट श्रोत वहन गर्न सकिँदैन ।"
+
+#: ../src/xrc/xmlres.cpp:2767
+#, fuzzy, c-format
+msgid "Creating %s \"%s\" failed."
+msgstr "'%s' लाई '%s' मा खिच्ने काम असफल भयो ।"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Alt+"
+#~ msgstr "Alt+"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Ctrl+"
+#~ msgstr "Ctrl+"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Shift+"
+#~ msgstr "Shift+"
+
+#~ msgctxt "keyboard key"
+#~ msgid "RawCtrl+"
+#~ msgstr "RawCtrl+"
+
+#~ msgid "Unsupported clipboard format."
+#~ msgstr "असमर्थित क्लिप पाटी बनोट"
+
+#~ msgid "Background colour"
+#~ msgstr "पृष्ठभूमिको रङ्ग"
+
+#~ msgid "Font:"
+#~ msgstr "वरणाकृति:"
+
+#~ msgid "Size:"
+#~ msgstr "आकार:"
+
+#~ msgid "The font size in points."
+#~ msgstr "वरणाकृतिको आकार (थोप्लोमा).वरणाकृतिको आकार in थोप्लोs"
+
+#~ msgid "Style:"
+#~ msgstr "शैली:"
+
+#~ msgid "Check to make the font bold."
+#~ msgstr "वरणाकृति मोटो बनाउने हो भने टिक लगाउ"
+
+#~ msgid "Check to make the font italic."
+#~ msgstr "वरणाकृति डल्केको बनाउने हो भने टिक लगाउ"
+
+#~ msgid "Check to make the font underlined."
+#~ msgstr "वरणाकृति अधोरेखाङ्कित बनाउने हो भने टिक लगाउ"
+
+#~ msgid "Colour:"
+#~ msgstr "रङ्ग:"
+
+#~ msgid "Click to change the font colour."
+#~ msgstr "वरणाकृतिको रङ्ग फेर्न किटिक्क पार्नु होस्"
+
+#~ msgid "Shows a preview of the font."
+#~ msgstr "वरणाकृतिको चेहरा देखाउ छ ।"
+
+#~ msgid "Click to cancel changes to the font."
+#~ msgstr "वरणाकृति परिवर्तन रद्द गर्न किटिक्क पार्नु होस्"
+
+#~ msgid "Click to confirm changes to the font."
+#~ msgstr "वरणाकृति परिवर्तन यकिन गर्न किटिक्क पार्नु होस्"
+
+#~ msgid "<Any>"
+#~ msgstr "<कुनै>"
+
+#~ msgid "<Any Roman>"
+#~ msgstr "<कुनै रोमन>"
+
+#~ msgid "<Any Decorative>"
+#~ msgstr "<कुनै सजावट>"
+
+#~ msgid "<Any Modern>"
+#~ msgstr "<कुनै मोडेम >"
+
+#~ msgid "<Any Script>"
+#~ msgstr "<कुनै Script>"
+
+#~ msgid "<Any Swiss>"
+#~ msgstr "<कुनै Swiss>"
+
+#~ msgid "<Any Teletype>"
+#~ msgstr "<कुनै Teletype>"
+
+#~ msgid "Printing "
+#~ msgstr "छाप्ने काम हुँदैछ ।"
+
+#~ msgid "Failed to insert text in the control."
+#~ msgstr "नियन्त्रणमा पाठ लेख्न सकिएन ।"
+
+#~ msgid "Please choose a valid font."
+#~ msgstr "कृपया वैध वरणाकृति छान्नु होस् ।"
+
+#, c-format
+#~ msgid "Failed to display HTML document in %s encoding"
+#~ msgstr "%s अनुसंहितामा html कागजात सिर्जना गर्न सकिएन ।"
+
+#, c-format
+#~ msgid "wxWidgets could not open display for '%s': exiting."
+#~ msgstr "wxWidgets ले दृश्यक '%s' लाइ खोल्न सकेन: बहिर्गमन गरिदैं छ ।"
+
+#~ msgid "Filter"
+#~ msgstr "फिल्टर"
+
+#~ msgid "Directories"
+#~ msgstr "घर्रा"
+
+#~ msgid "Files"
+#~ msgstr "फाइलहरू"
+
+#~ msgid "Selection"
+#~ msgstr "चयन"
+
+#~ msgid "conversion to 8-bit encoding failed"
+#~ msgstr "8-bit अनुसंहिता मा रूपान्तरण असफल भयो ।"
+
+#, fuzzy
+#~ msgid "failed to retrieve execution result"
+#~ msgstr "RAS गल्ती सन् देसको पाठहरू लिन सकिएन ।"
+
+#~ msgid "&Save as"
+#~ msgstr "&यसरी बचत गर"
+
+#~ msgid "'%s' doesn't consist only of valid characters"
+#~ msgstr "'%s' मा केवल वैध मानहरू मात्रै छैनन् ।"
+
+#~ msgid "'%s' should be numeric."
+#~ msgstr "'%s' सङ्ख्यात्मक हुनै पर्छ ।"
+
+#~ msgid "'%s' should only contain ASCII characters."
+#~ msgstr "'%s' मा ASCII वर्णहरू मात्रै हुन सक्छ ।"
+
+#~ msgid "'%s' should only contain alphabetic characters."
+#~ msgstr "'%s' मा वर्णहरू मात्रै हु सक्छ ।"
+
+#~ msgid "'%s' should only contain alphabetic or numeric characters."
+#~ msgstr "'%s' मा पाठिय अथवा सङ्ख्यात्मक वर्णहरू मात्रै हुन सक्छ ।"
+
+#~ msgid "'%s' should only contain digits."
+#~ msgstr "'%s' मा सङ्ख्या मात्रै हुन सक्छ ।"
+
+#~ msgid "Can't create window of class %s"
+#~ msgstr "विन्डो class %s सिर्जना गर्न सकिँदैन ।"
+
+#~ msgid "Couldn't create the overlay window"
+#~ msgstr "खप्टिएको विन्डो सिर्जना गर्न सकिएन"
+
+#~ msgid "Couldn't init the context on the overlay window"
+#~ msgstr "खप्टिएको विन्डोका सामाग्री पाउन सकिएन"
+
+#~ msgid "Failed to convert file \"%s\" to Unicode."
+#~ msgstr "फाइल \"%s\" लाई युनिकोडमा परिवर्तन गर्न सकिएन ।"
+
+#~ msgid "Failed to set text in the text control."
+#~ msgstr "पाठ नियन्त्रक मा पाठ राख्न सकिएन ।"
+
+#~ msgid "Invalid GTK+ command line option, use \"%s --help\""
+#~ msgstr "नमिल्दो GTK+ आदेश लाइन विकल्प, \"%s --सहयोग\" को प्रयोग गर्नु होस् ।"
+
+#~ msgid "No unused colour in image."
+#~ msgstr "तस्विरमा प्रयोग नगरेको रङ्ग छैन ।"
+
+#~ msgid "Not available"
+#~ msgstr "उपलब्ध छैन"
+
+#~ msgid "Replace selection"
+#~ msgstr "चयनको प्रतिस्थापन"
+
+#~ msgid "Save as"
+#~ msgstr "यसरी बचत गर "
+
+#~ msgid "Style Organiser"
+#~ msgstr "शैली व्यवस्थापक"
+
+#~ msgid "The following standard GTK+ options are also supported:\n"
+#~ msgstr "तलको स्तरीय GTK+ विकल्प पनि समर्थन गरिन्छ:\n"
+
+#~ msgid "You cannot Clear an overlay that is not inited"
+#~ msgstr "पोतिएको होइन भने तपाइले खप्टिएको स्थानमा सफा गर्न सक्नु हुन्न ।"
+
+#~ msgid "You cannot Init an overlay twice"
+#~ msgstr "तपाइले खप्टिएको स्थानमा दुई पटक पोत्न सक्नु हुन्न ।"
+
+#~ msgid "locale '%s' cannot be set."
+#~ msgstr "स्थानीयता '%s' कायम गर्न सकिँदैन ।"
+
+#~ msgid "Adding flavor TEXT failed"
+#~ msgstr "flavor TEXT थप्न सकिएन"
+
+#~ msgid "Adding flavor utxt failed"
+#~ msgstr "flavor utxt थप्न सकिएन"
+
+#~ msgid "Bitmap renderer cannot render value; value type: "
+#~ msgstr "Bitmap renderer ले मान खोज्न सक्दैन; मानको किसिम: "
+
+#~ msgid ""
+#~ "Cannot create new column's ID. Probably max. number of columns reached."
+#~ msgstr ""
+#~ " नया महलको ID सिर्जना गर्न सकिँदैन । सम्भवतः अधिकतम महलको सङ्ख्या पुगेर होला ।"
+
+#~ msgid "Column could not be added."
+#~ msgstr "महल थप्न सकिएन"
+
+#~ msgid "Column index not found."
+#~ msgstr "महलको अनुक्रमणिका भेटिएन"
+
+#~ msgid "Column width could not be determined"
+#~ msgstr "महलको छोडाइ यकिन भएन"
+
+#~ msgid "Column width could not be set."
+#~ msgstr "महलको छोडाइ तय गर्न सकिएन"
+
+#~ msgid "Confirm registry update"
+#~ msgstr "registry अद्यावधिक यकिन गर्नु होस्"
+
+#~ msgid "Could not determine column index."
+#~ msgstr "महलको अनुक्रमणिका पत्ता लागेन"
+
+#~ msgid "Could not determine column's position"
+#~ msgstr "महलको स्थान पत्ता लागेन"
+
+#~ msgid "Could not determine number of columns."
+#~ msgstr "महलको सङ्ख्या पत्तो लागेन"
+
+#~ msgid "Could not determine number of items"
+#~ msgstr "सामाग्रीको सङ्ख्या पत्ता लागेन"
+
+#~ msgid "Could not get header description."
+#~ msgstr "शीर्षक बयान भेटिएन"
+
+#~ msgid "Could not get items."
+#~ msgstr "सामाग्री फेला परेन"
+
+#~ msgid "Could not get property flags."
+#~ msgstr "गुणहरूको झण्डा पाइ एन"
+
+#~ msgid "Could not get selected items."
+#~ msgstr "चयन गरेको सामाग्री फेला परेन"
+
+#~ msgid "Could not remove column."
+#~ msgstr "महल हटाउन सकिएन"
+
+#~ msgid "Could not retrieve number of items"
+#~ msgstr "सामाग्रीको सङ्ख्या प्राप्त गर्न सकिएन"
+
+#~ msgid "Could not set column width."
+#~ msgstr "महलको छोडाइ तय गर्न सकिएन"
+
+#~ msgid "Could not set header description."
+#~ msgstr "शीर्षक बयान तय गर्न सकिएन"
+
+#~ msgid "Could not set icon."
+#~ msgstr "प्रतिमा तय गर्न सकिएन"
+
+#~ msgid "Could not set maximum width."
+#~ msgstr "अधिकतम छोडाइ तय गर्न सकिएन"
+
+#~ msgid "Could not set minimum width."
+#~ msgstr "न्यूनतम छोडाइ तय गर्न सकिएन"
+
+#~ msgid "Could not set property flags."
+#~ msgstr "गुणहरूको झण्डा तय गर्न सकिएन"
+
+#~ msgid "Data object has invalid data format"
+#~ msgstr "तथ्याङ्क वस्तुको स्वरूप अमान्य किसिमको छ ।"
+
+#~ msgid "Date renderer cannot render value; value type: "
+#~ msgstr "मिति खोज्नाले मान पाइ एन ; मान को किसिम: "
+
+#~ msgid ""
+#~ "Do you want to overwrite the command used to %s files with extension "
+#~ "\"%s\" ?\n"
+#~ "Current value is \n"
+#~ "%s, \n"
+#~ "New value is \n"
+#~ "%s %1"
+#~ msgstr ""
+#~ "के तपाई \"%2$s\"विस्तार भएका %१$s फाइलहरूलाई दिइएको आदेश मेटाएर फेरी लेख्न चाहनु "
+#~ "हुन्छ? \n"
+#~ "हालको मान \n"
+#~ "%s, \n"
+#~ "नयाँ मान \n"
+#~ "%s %1"
+
+#~ msgid "Failed to retrieve data from the clipboard."
+#~ msgstr "क्लिप पाटीबाट तथ्याङ्क लिन सकिएन ।"
+
+#~ msgid "GIF: Invalid gif index."
+#~ msgstr "GIF: gif अनुक्रमणिका मिलेन"
+
+#~ msgid "GIF: unknown error!!!"
+#~ msgstr "GIF: अज्ञात गल्ती!!!"
+
+#~ msgid "Icon & text renderer cannot render value; value type: "
+#~ msgstr "प्रतिमा र पाठ renderer cannot render value; मानको किसिम: "
+
+#~ msgid "New directory"
+#~ msgstr "नया घर्रा"
+
+#~ msgid "Next"
+#~ msgstr "अघिल्लो"
+
+#~ msgid "No column existing."
+#~ msgstr "महल छदै छैन"
+
+#~ msgid "No column for the specified column existing."
+#~ msgstr "भनिएको महलका लागि कुनै महल छैन ।"
+
+#~ msgid "No column for the specified column position existing."
+#~ msgstr "भनिएको महलको स्थानमा कुनै महल छैन ।"
+
+#~ msgid ""
+#~ "No renderer or invalid renderer type specified for custom data column."
+#~ msgstr ""
+#~ "तोकिएको चलन चल्तीको तथ्याङ्क महल दोहोरो छैन अथवा नमिल्दो किसिमले गोहोरो छ ।"
+
+#~ msgid "No renderer specified for column."
+#~ msgstr "तोकिएको महल दोहोरिएको छैन"
+
+#~ msgid "Number of columns could not be determined."
+#~ msgstr "महलहरूको सङ्ख्या थाहा पाउन सकिएन ।"
+
+#~ msgid "OpenGL function \"%s\" failed: %s (error %d)"
+#~ msgstr "OpenGL function \"%s\" असफल भयो : %s (गल्ती %d)"
+
+#~ msgid ""
+#~ "Please install a newer version of comctl32.dll\n"
+#~ "(at least version 4.70 is required but you have %d.%02d)\n"
+#~ "or this program won't operate correctly."
+#~ msgstr ""
+#~ "कृपया comctl32.dll को नयाँ संस्करण भित्रयाउनु होला \n"
+#~ "(कम्तिमा संस्करण ४.७० आवश्यक देखिन्छ तर तपाई सित त %d %02d मात्रै रहेछ)\n"
+#~ "अन्यथा यो कार्यक्रमले राम्ररी काम गर्ने छैन ।"
+
+#~ msgid "Pointer to data view control not set correctly."
+#~ msgstr "तथ्याङ्क देखाउने नियन्त्रकको चुच्चो ठीक सित मिलाइएको छैन ।"
+
+#~ msgid "Pointer to model not set correctly."
+#~ msgstr "नमुना चुच्चो राम्ररी मिलाइएको छैन ।"
+
+#~ msgid "Progress renderer cannot render value type; value type: "
+#~ msgstr "प्रगति दोहोरो पन मान दोहोर्यादउन सकिँदैन; मानको किसिम: "
+
+#~ msgid "Rendering failed."
+#~ msgstr "दोहोरो पना असफल भयो ।"
+
+#~ msgid ""
+#~ "Setting directory access times is not supported under this OS version"
+#~ msgstr "घर्रा खोलेको समय अभिलेखनको कार्य यो सञ्चालन प्रणालीको संस्करणले समर्थन गर्दैन ।"
+
+#~ msgid "Show hidden directories"
+#~ msgstr "लुकाएका घर्राहरू देखाउ "
+
+#~ msgid "Text renderer cannot render value; value type: "
+#~ msgstr "पाठ renderer ले मान दोहोर्या उन सक्दैन; मानको किसिम: "
+
+#~ msgid "There is no column or renderer for the specified column index."
+#~ msgstr "महल छैन अथवा तोकिएको महलको अनुक्रमणिका दोहोरियो ।"
+
+#~ msgid ""
+#~ "This system doesn't support date controls, please upgrade your version of "
+#~ "comctl32.dll"
+#~ msgstr ""
+#~ "यो प्रणालीले मिति नियन्त्रक लिदैन, कृपया यसलाई comctl32.dll मा स्तर वृद्धि गर्नु "
+#~ "होला ।"
+
+#~ msgid "Toggle renderer cannot render value; value type: "
+#~ msgstr "Toggle renderer cannot render value; value type: "
+
+#~ msgid "Too many colours in PNG, the image may be slightly blurred."
+#~ msgstr "PNG मा धेरै रङ्गहरू छन्, तस्विर थोरै फिक्का होला ।"
+
+#~ msgid "Unable to handle native drag&drop data"
+#~ msgstr "स्थानीय घिसार्दै राखिने तथ्याङ्क चलाउन सकिएन ।"
+
+#~ msgid "Unable to initialize Hildon program"
+#~ msgstr "Hildon program लाई सुरुवात गर्न सकिएन ।"
+
+#~ msgid "Unknown data format"
+#~ msgstr "अज्ञात तथ्याङ्क बनोट"
+
+#~ msgid "Valid pointer to native data view control does not exist"
+#~ msgstr "स्थानीय तथ्याङ्क दृश्य नियन्त्रकका लागि वैध चुच्चो छैन ।"
+
+#~ msgid "Win32s on Windows 3.1"
+#~ msgstr "विन्डोज 3.1 को Win32s "
+
+#, fuzzy
+#~ msgid "Windows 10"
+#~ msgstr "विन्डोज ८.१"
+
+#~ msgid "Windows 2000"
+#~ msgstr "विन्डोज 2000"
+
+#~ msgid "Windows 7"
+#~ msgstr "विन्डोज 7"
+
+#~ msgid "Windows 8"
+#~ msgstr "विन्डोज ८"
+
+#~ msgid "Windows 8.1"
+#~ msgstr "विन्डोज ८.१"
+
+#~ msgid "Windows 95"
+#~ msgstr "विन्डोज 95"
+
+#~ msgid "Windows 95 OSR2"
+#~ msgstr "विन्डोज 95 OSR2"
+
+#~ msgid "Windows 98"
+#~ msgstr "विन्डोज 98"
+
+#~ msgid "Windows 98 SE"
+#~ msgstr "विन्डोज 98 SE"
+
+#~ msgid "Windows 9x (%d.%d)"
+#~ msgstr "विन्डोज 9x (%d.%d)"
+
+#~ msgid "Windows CE (%d.%d)"
+#~ msgstr "विन्डोज CE (%d.%d)"
+
+#~ msgid "Windows ME"
+#~ msgstr "विन्डोज ME"
+
+#~ msgid "Windows NT %lu.%lu"
+#~ msgstr "विन्डोज NT %lu.%lu"
+
+#, fuzzy
+#~ msgid "Windows Server 10"
+#~ msgstr "विन्डोज सर्बर 2003"
+
+#~ msgid "Windows Server 2003"
+#~ msgstr "विन्डोज सर्बर 2003"
+
+#~ msgid "Windows Server 2008"
+#~ msgstr "विन्डोज सर्बर 2008"
+
+#~ msgid "Windows Server 2008 R2"
+#~ msgstr "विन्डोज सर्बर 2008 R2"
+
+#~ msgid "Windows Server 2012"
+#~ msgstr "विन्डोज सर्वर २०१२"
+
+#~ msgid "Windows Server 2012 R2"
+#~ msgstr "विन्डोज सर्वर २०१२ R2"
+
+#~ msgid "Windows Vista"
+#~ msgstr "विन्डोज Vista"
+
+#~ msgid "Windows XP"
+#~ msgstr "विन्डोज XP"
+
+#~ msgid "can't execute '%s'"
+#~ msgstr "'%s' लाई कार्यान्वयन गर्न सकिँदैन ।"
+
+#~ msgid "error opening '%s'"
+#~ msgstr "'%s' खोल्दा गल्ती "
+
+#~ msgid "unknown seek origin"
+#~ msgstr "खोजीको मूल थलो थाहा भएन "
+
+#~ msgid "wxWidget control pointer is not a data view pointer"
+#~ msgstr "wxWidget नियन्त्रक चुच्चो तथ्याङ्क दृश्य चुच्चो होइन ।"
+
+#~ msgid "wxWidget's control not initialized."
+#~ msgstr "wxWidget's नियन्त्रक सुरुवात गरिएको छैन ।"

--- a/po_wxstd/nl.po
+++ b/po_wxstd/nl.po
@@ -1,0 +1,9510 @@
+# wxWidgets translations to Dutch
+# Copyright (C) 2014 wxWidgets developers
+# This file is distributed under the same license as the wxWidgets package.
+#
+# Translators:
+# Thomas De Rocker, 2013-2014, G. van Melle 2009-2015
+msgid ""
+msgstr ""
+"Project-Id-Version: wxWidgets 3.3\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-05-14 20:23+0200\n"
+"PO-Revision-Date: 2022-02-28 20:39+0100\n"
+"Last-Translator: gvmelle <translations@gvmelle.com>\n"
+"Language-Team: Dutch (http://www.transifex.com/projects/p/"
+"wxwidgets_unofficial/language/nl/)\n"
+"Language: nl\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Poedit 3.0.1\n"
+
+#: ../include/wx/defs.h:2582
+msgid "All files (*.*)|*.*"
+msgstr "Alle bestanden (*.*)|*.*"
+
+#: ../include/wx/defs.h:2585
+msgid "All files (*)|*"
+msgstr "Alle bestanden (*)|*"
+
+#: ../include/wx/generic/progdlgg.h:85
+msgid "Elapsed time:"
+msgstr "Verstreken tijd:"
+
+#: ../include/wx/generic/progdlgg.h:86
+msgid "Estimated time:"
+msgstr "Geschatte tijd:"
+
+#: ../include/wx/generic/progdlgg.h:87
+msgid "Remaining time:"
+msgstr "Resterende tijd:"
+
+#. TRANSLATORS: HTML printout default title.
+#: ../include/wx/html/htmprint.h:121 ../include/wx/prntbase.h:273
+#: ../include/wx/richtext/richtextprint.h:109 ../src/common/docview.cpp:2161
+msgid "Printout"
+msgstr "Afdruk"
+
+#. TRANSLATORS: HTML easy print default title.
+#: ../include/wx/html/htmprint.h:234 ../include/wx/richtext/richtextprint.h:163
+#: ../src/common/prntbase.cpp:522 ../src/html/htmprint.cpp:291
+msgid "Printing"
+msgstr "Bezig met afdrukken"
+
+#: ../include/wx/msgdlg.h:277 ../src/common/stockitem.cpp:211
+msgid "Yes"
+msgstr "Ja"
+
+#: ../include/wx/msgdlg.h:278 ../src/common/stockitem.cpp:182
+msgid "No"
+msgstr "Nee"
+
+#: ../include/wx/msgdlg.h:279 ../src/common/stockitem.cpp:183
+#: ../src/msw/msgdlg.cpp:430 ../src/msw/msgdlg.cpp:734
+#: ../src/richtext/richtextstyledlg.cpp:292
+msgid "OK"
+msgstr "OK"
+
+#: ../include/wx/msgdlg.h:280 ../src/common/stockitem.cpp:150
+#: ../src/msw/msgdlg.cpp:430 ../src/msw/progdlg.cpp:884
+#: ../src/richtext/richtextstyledlg.cpp:295
+msgid "Cancel"
+msgstr "Annuleer"
+
+#: ../include/wx/msgdlg.h:281 ../src/common/stockitem.cpp:168
+#: ../src/html/helpdlg.cpp:63 ../src/html/helpfrm.cpp:108
+#: ../src/osx/button_osx.cpp:38
+msgid "Help"
+msgstr "Help"
+
+#: ../include/wx/msw/ole/oleutils.h:52
+msgid "Cannot initialize OLE"
+msgstr "Kan OLE niet initialiseren"
+
+#: ../include/wx/msw/private/fswatcher.h:48
+#, c-format
+msgid "Unable to close the handle for '%s'"
+msgstr "Sluiten van de ingang voor '%s' niet mogelijk."
+
+#: ../include/wx/msw/private/fswatcher.h:92
+#, c-format
+msgid "Failed to open directory \"%s\" for monitoring."
+msgstr "Openen van map \"%s\"  voor controleren mislukt."
+
+#: ../include/wx/msw/private/fswatcher.h:125
+msgid "Unable to close I/O completion port handle"
+msgstr "Sluiten van I/O voltooiingspoort ingang niet mogelijk"
+
+#: ../include/wx/msw/private/fswatcher.h:142
+msgid "Unable to associate handle with I/O completion port"
+msgstr "Kan handle niet associëren met I/O voltooiingspoort"
+
+#: ../include/wx/msw/private/fswatcher.h:148
+msgid "Unexpectedly new I/O completion port was created"
+msgstr "Er is onverwacht een nieuwe I/O voltooiingspoort aangemaakt"
+
+#: ../include/wx/msw/private/fswatcher.h:213
+msgid "Unable to post completion status"
+msgstr "Kan voltooiingstatus niet plaatsen"
+
+#: ../include/wx/msw/private/fswatcher.h:262
+msgid "Unable to dequeue completion packet"
+msgstr "Kan voltooiingspakket niet uit de wachtrij halen"
+
+#: ../include/wx/msw/private/fswatcher.h:273
+msgid "Unable to create I/O completion port"
+msgstr "Niet mogelijk een I/O voltooiingspoort aan te maken"
+
+#: ../include/wx/richmsgdlg.h:29
+msgid "&See details"
+msgstr "&Zie details"
+
+#: ../include/wx/richmsgdlg.h:30
+msgid "&Hide details"
+msgstr "&Verbergen details"
+
+#: ../include/wx/richtext/richtextbuffer.h:3864
+msgid "&Box"
+msgstr "&Vak"
+
+#: ../include/wx/richtext/richtextbuffer.h:5008
+msgid "&Picture"
+msgstr "&Afbeelding"
+
+#: ../include/wx/richtext/richtextbuffer.h:5958
+msgid "&Cell"
+msgstr "&Cel"
+
+#: ../include/wx/richtext/richtextbuffer.h:6067
+msgid "&Table"
+msgstr "&Tabel"
+
+#: ../include/wx/richtext/richtextimagedlg.h:37
+msgid "Object Properties"
+msgstr "Object eigenschappen"
+
+#: ../include/wx/richtext/richtextsymboldlg.h:39
+msgid "Symbols"
+msgstr "Symbolen"
+
+#: ../include/wx/unix/pipe.h:46
+msgid "Pipe creation failed"
+msgstr "Maken van pipe mislukt"
+
+#: ../include/wx/unix/private/displayx11.h:65
+msgid "Failed to enumerate video modes"
+msgstr "Enumereren van video modes mislukt"
+
+#: ../include/wx/unix/private/displayx11.h:89
+msgid "Failed to change video mode"
+msgstr "Kon video modus niet veranderen"
+
+#: ../include/wx/unix/private/fswatcher_kqueue.h:57
+#, c-format
+msgid "Unable to open path '%s'"
+msgstr "Niet mogelijk pad '%s' te openen"
+
+#: ../include/wx/unix/private/fswatcher_kqueue.h:74
+#, c-format
+msgid "Unable to close path '%s'"
+msgstr "Sluiten van pad '%s' niet mogelijk"
+
+#: ../include/wx/xtiprop.h:175
+msgid "SetProperty called w/o valid setter"
+msgstr "SetProperty aangeroepen zonder geldige \"setter\""
+
+#: ../include/wx/xtiprop.h:184
+msgid "GetProperty called w/o valid getter"
+msgstr "GetProperty aangeroepen zonder geldige “getter”"
+
+#: ../include/wx/xtiprop.h:193
+msgid "AddToPropertyCollection called w/o valid adder"
+msgstr "AddToPropertyCollection deed een aanroep zonder geldige 'adder'"
+
+#: ../include/wx/xtiprop.h:202
+msgid "GetPropertyCollection called w/o valid collection getter"
+msgstr "GetPropertyCollection aangeroepen zonder geldige “collection getter”"
+
+#: ../include/wx/xtiprop.h:255
+msgid "AddToPropertyCollection called on a generic accessor"
+msgstr "AddToPropertyCollection riep een generieke 'accessor' aan"
+
+#: ../include/wx/xtiprop.h:262
+msgid "GetPropertyCollection called on a generic accessor"
+msgstr "GetPropertyCollection aangeroepen op een generieke “accessor”"
+
+#: ../src/aui/tabmdi.cpp:106 ../src/generic/mdig.cpp:94
+msgid "Cl&ose"
+msgstr "Sl&uiten"
+
+#: ../src/aui/tabmdi.cpp:107 ../src/generic/mdig.cpp:95
+msgid "Close All"
+msgstr "Alles Sluiten"
+
+#: ../src/aui/tabmdi.cpp:109 ../src/generic/mdig.cpp:97 ../src/msw/mdi.cpp:175
+#: ../src/qt/mdi.cpp:258
+msgid "&Next"
+msgstr "&Volgende"
+
+#: ../src/aui/tabmdi.cpp:110 ../src/generic/mdig.cpp:98 ../src/msw/mdi.cpp:176
+#: ../src/qt/mdi.cpp:259
+msgid "&Previous"
+msgstr "&Vorig"
+
+#: ../src/aui/tabmdi.cpp:332 ../src/aui/tabmdi.cpp:348
+#: ../src/aui/tabmdi.cpp:350 ../src/generic/mdig.cpp:291
+#: ../src/generic/mdig.cpp:307 ../src/generic/mdig.cpp:311
+#: ../src/msw/mdi.cpp:337 ../src/qt/mdi.cpp:462
+msgid "&Window"
+msgstr "&Venster"
+
+#: ../src/common/accelcmn.cpp:47
+msgctxt "keyboard key"
+msgid "Delete"
+msgstr "Verwijderen"
+
+#: ../src/common/accelcmn.cpp:48
+msgctxt "keyboard key"
+msgid "Del"
+msgstr "Del"
+
+#: ../src/common/accelcmn.cpp:49
+msgctxt "keyboard key"
+msgid "Back"
+msgstr "Terug"
+
+#: ../src/common/accelcmn.cpp:49
+msgctxt "keyboard key"
+msgid "Backspace"
+msgstr "Backspace"
+
+#: ../src/common/accelcmn.cpp:50
+msgctxt "keyboard key"
+msgid "Insert"
+msgstr "Invoegen"
+
+#: ../src/common/accelcmn.cpp:51
+msgctxt "keyboard key"
+msgid "Ins"
+msgstr "Ins"
+
+#: ../src/common/accelcmn.cpp:52
+msgctxt "keyboard key"
+msgid "Enter"
+msgstr "Enter"
+
+#: ../src/common/accelcmn.cpp:53
+msgctxt "keyboard key"
+msgid "Return"
+msgstr "Terugtoets"
+
+#: ../src/common/accelcmn.cpp:54
+msgctxt "keyboard key"
+msgid "PageUp"
+msgstr "PageUp"
+
+#: ../src/common/accelcmn.cpp:54
+msgctxt "keyboard key"
+msgid "Page Up"
+msgstr "Page Up"
+
+#: ../src/common/accelcmn.cpp:55
+msgctxt "keyboard key"
+msgid "PageDown"
+msgstr "PageDown"
+
+#: ../src/common/accelcmn.cpp:55
+msgctxt "keyboard key"
+msgid "Page Down"
+msgstr "Page Down"
+
+#: ../src/common/accelcmn.cpp:56
+msgctxt "keyboard key"
+msgid "PgUp"
+msgstr "PgUp"
+
+#: ../src/common/accelcmn.cpp:57
+msgctxt "keyboard key"
+msgid "PgDn"
+msgstr "PgDn"
+
+#: ../src/common/accelcmn.cpp:58
+msgctxt "keyboard key"
+msgid "Left"
+msgstr "Links"
+
+#: ../src/common/accelcmn.cpp:59
+msgctxt "keyboard key"
+msgid "Right"
+msgstr "Rechts"
+
+#: ../src/common/accelcmn.cpp:60
+msgctxt "keyboard key"
+msgid "Up"
+msgstr "Omhoog"
+
+#: ../src/common/accelcmn.cpp:61
+msgctxt "keyboard key"
+msgid "Down"
+msgstr "Omlaag"
+
+#: ../src/common/accelcmn.cpp:62
+msgctxt "keyboard key"
+msgid "Home"
+msgstr "Thuis"
+
+#: ../src/common/accelcmn.cpp:63
+msgctxt "keyboard key"
+msgid "End"
+msgstr "End"
+
+#: ../src/common/accelcmn.cpp:64
+msgctxt "keyboard key"
+msgid "Space"
+msgstr "Spatie"
+
+#: ../src/common/accelcmn.cpp:65
+msgctxt "keyboard key"
+msgid "Tab"
+msgstr "Tab"
+
+#: ../src/common/accelcmn.cpp:66
+msgctxt "keyboard key"
+msgid "Esc"
+msgstr "Esc"
+
+#: ../src/common/accelcmn.cpp:67
+msgctxt "keyboard key"
+msgid "Escape"
+msgstr "Escape"
+
+#: ../src/common/accelcmn.cpp:68
+msgctxt "keyboard key"
+msgid "Cancel"
+msgstr "Annuleer"
+
+#: ../src/common/accelcmn.cpp:69
+msgctxt "keyboard key"
+msgid "Clear"
+msgstr "Wissen"
+
+#: ../src/common/accelcmn.cpp:70
+msgctxt "keyboard key"
+msgid "Menu"
+msgstr "Menu"
+
+#: ../src/common/accelcmn.cpp:71
+msgctxt "keyboard key"
+msgid "Pause"
+msgstr "Pause"
+
+#: ../src/common/accelcmn.cpp:72
+msgctxt "keyboard key"
+msgid "Capital"
+msgstr "Hoofdletter"
+
+#: ../src/common/accelcmn.cpp:73
+msgctxt "keyboard key"
+msgid "Select"
+msgstr "Selecteer"
+
+#: ../src/common/accelcmn.cpp:74
+msgctxt "keyboard key"
+msgid "Print"
+msgstr "Afdrukken"
+
+#: ../src/common/accelcmn.cpp:75
+msgctxt "keyboard key"
+msgid "Execute"
+msgstr "Uitvoeren"
+
+#: ../src/common/accelcmn.cpp:76
+msgctxt "keyboard key"
+msgid "Snapshot"
+msgstr "Momentopname"
+
+#: ../src/common/accelcmn.cpp:77
+msgctxt "keyboard key"
+msgid "Help"
+msgstr "Help"
+
+#: ../src/common/accelcmn.cpp:78
+msgctxt "keyboard key"
+msgid "Add"
+msgstr "Toevoegen"
+
+#: ../src/common/accelcmn.cpp:79
+msgctxt "keyboard key"
+msgid "Separator"
+msgstr "Scheidingsteken"
+
+#: ../src/common/accelcmn.cpp:80
+msgctxt "keyboard key"
+msgid "Subtract"
+msgstr "Aftrekken"
+
+#: ../src/common/accelcmn.cpp:81
+msgctxt "keyboard key"
+msgid "Decimal"
+msgstr "Decimaal"
+
+#: ../src/common/accelcmn.cpp:82
+msgctxt "keyboard key"
+msgid "Multiply"
+msgstr "Vermenigvuldigen"
+
+#: ../src/common/accelcmn.cpp:83
+msgctxt "keyboard key"
+msgid "Divide"
+msgstr "Scheiding"
+
+#: ../src/common/accelcmn.cpp:84
+msgctxt "keyboard key"
+msgid "Num_lock"
+msgstr "Num_lock"
+
+#: ../src/common/accelcmn.cpp:84
+msgctxt "keyboard key"
+msgid "Num Lock"
+msgstr "Num Lock"
+
+#: ../src/common/accelcmn.cpp:85
+msgctxt "keyboard key"
+msgid "Scroll_lock"
+msgstr "Scroll_lock"
+
+#: ../src/common/accelcmn.cpp:85
+msgctxt "keyboard key"
+msgid "Scroll Lock"
+msgstr "Scroll Lock"
+
+#: ../src/common/accelcmn.cpp:86
+msgctxt "keyboard key"
+msgid "KP_Space"
+msgstr "KP_Space"
+
+#: ../src/common/accelcmn.cpp:86
+msgctxt "keyboard key"
+msgid "Num Space"
+msgstr "Num Space"
+
+#: ../src/common/accelcmn.cpp:87
+msgctxt "keyboard key"
+msgid "KP_Tab"
+msgstr "KP_Tab"
+
+#: ../src/common/accelcmn.cpp:87
+msgctxt "keyboard key"
+msgid "Num Tab"
+msgstr "Num Tab"
+
+#: ../src/common/accelcmn.cpp:88
+msgctxt "keyboard key"
+msgid "KP_Enter"
+msgstr "KP_Enter"
+
+#: ../src/common/accelcmn.cpp:88
+msgctxt "keyboard key"
+msgid "Num Enter"
+msgstr "Num Enter"
+
+#: ../src/common/accelcmn.cpp:89
+msgctxt "keyboard key"
+msgid "KP_Home"
+msgstr "KP_Home"
+
+#: ../src/common/accelcmn.cpp:89
+msgctxt "keyboard key"
+msgid "Num Home"
+msgstr "Num Home"
+
+#: ../src/common/accelcmn.cpp:90
+msgctxt "keyboard key"
+msgid "KP_Left"
+msgstr "KP_Left"
+
+#: ../src/common/accelcmn.cpp:90
+msgctxt "keyboard key"
+msgid "Num left"
+msgstr "Num left"
+
+#: ../src/common/accelcmn.cpp:91
+msgctxt "keyboard key"
+msgid "KP_Up"
+msgstr "KP_Up"
+
+#: ../src/common/accelcmn.cpp:91
+msgctxt "keyboard key"
+msgid "Num Up"
+msgstr "Num Up"
+
+#: ../src/common/accelcmn.cpp:92
+msgctxt "keyboard key"
+msgid "KP_Right"
+msgstr "KP_Right"
+
+#: ../src/common/accelcmn.cpp:92
+msgctxt "keyboard key"
+msgid "Num Right"
+msgstr "Num Right"
+
+#: ../src/common/accelcmn.cpp:93
+msgctxt "keyboard key"
+msgid "KP_Down"
+msgstr "KP_Down"
+
+#: ../src/common/accelcmn.cpp:93
+msgctxt "keyboard key"
+msgid "Num Down"
+msgstr "Num Down"
+
+#: ../src/common/accelcmn.cpp:94
+msgctxt "keyboard key"
+msgid "KP_PageUp"
+msgstr "KP_PageUp"
+
+#: ../src/common/accelcmn.cpp:94
+msgctxt "keyboard key"
+msgid "Num Page Up"
+msgstr "Num Page Up"
+
+#: ../src/common/accelcmn.cpp:95
+msgctxt "keyboard key"
+msgid "KP_PageDown"
+msgstr "KP_PageDown"
+
+#: ../src/common/accelcmn.cpp:95
+msgctxt "keyboard key"
+msgid "Num Page Down"
+msgstr "Num Page Down"
+
+#: ../src/common/accelcmn.cpp:96
+msgctxt "keyboard key"
+msgid "KP_Prior"
+msgstr "KP_Prior"
+
+#: ../src/common/accelcmn.cpp:97
+msgctxt "keyboard key"
+msgid "KP_Next"
+msgstr "KP_Next"
+
+#: ../src/common/accelcmn.cpp:98
+msgctxt "keyboard key"
+msgid "KP_End"
+msgstr "KP_End"
+
+#: ../src/common/accelcmn.cpp:98
+msgctxt "keyboard key"
+msgid "Num End"
+msgstr "Num End"
+
+#: ../src/common/accelcmn.cpp:99
+msgctxt "keyboard key"
+msgid "KP_Begin"
+msgstr "KP_Begin"
+
+#: ../src/common/accelcmn.cpp:99
+msgctxt "keyboard key"
+msgid "Num Begin"
+msgstr "Num Begin"
+
+#: ../src/common/accelcmn.cpp:100
+msgctxt "keyboard key"
+msgid "KP_Insert"
+msgstr "KP_Insert"
+
+#: ../src/common/accelcmn.cpp:100
+msgctxt "keyboard key"
+msgid "Num Insert"
+msgstr "Num Insert"
+
+#: ../src/common/accelcmn.cpp:101
+msgctxt "keyboard key"
+msgid "KP_Delete"
+msgstr "KP_Delete"
+
+#: ../src/common/accelcmn.cpp:101
+msgctxt "keyboard key"
+msgid "Num Delete"
+msgstr "Num Delete"
+
+#: ../src/common/accelcmn.cpp:102
+msgctxt "keyboard key"
+msgid "KP_Equal"
+msgstr "KP_Equal"
+
+#: ../src/common/accelcmn.cpp:102
+msgctxt "keyboard key"
+msgid "Num ="
+msgstr "Num ="
+
+#: ../src/common/accelcmn.cpp:103
+msgctxt "keyboard key"
+msgid "KP_Multiply"
+msgstr "KP_Multiply"
+
+#: ../src/common/accelcmn.cpp:103
+msgctxt "keyboard key"
+msgid "Num *"
+msgstr "Num *"
+
+#: ../src/common/accelcmn.cpp:104
+msgctxt "keyboard key"
+msgid "KP_Add"
+msgstr "KP_Add"
+
+#: ../src/common/accelcmn.cpp:104
+msgctxt "keyboard key"
+msgid "Num +"
+msgstr "Num +"
+
+#: ../src/common/accelcmn.cpp:105
+msgctxt "keyboard key"
+msgid "KP_Separator"
+msgstr "KP_Separator"
+
+#: ../src/common/accelcmn.cpp:105
+msgctxt "keyboard key"
+msgid "Num ,"
+msgstr "Num ,"
+
+#: ../src/common/accelcmn.cpp:106
+msgctxt "keyboard key"
+msgid "KP_Subtract"
+msgstr "KP_Subtract"
+
+#: ../src/common/accelcmn.cpp:106
+msgctxt "keyboard key"
+msgid "Num -"
+msgstr "Num -"
+
+#: ../src/common/accelcmn.cpp:107
+msgctxt "keyboard key"
+msgid "KP_Decimal"
+msgstr "KP_Decimal"
+
+#: ../src/common/accelcmn.cpp:107
+msgctxt "keyboard key"
+msgid "Num ."
+msgstr "Num ."
+
+#: ../src/common/accelcmn.cpp:108
+msgctxt "keyboard key"
+msgid "KP_Divide"
+msgstr "KP_Divide"
+
+#: ../src/common/accelcmn.cpp:108
+msgctxt "keyboard key"
+msgid "Num /"
+msgstr "Num /"
+
+#: ../src/common/accelcmn.cpp:109
+msgctxt "keyboard key"
+msgid "Windows_Left"
+msgstr "Windows_Left"
+
+#: ../src/common/accelcmn.cpp:110
+msgctxt "keyboard key"
+msgid "Windows_Right"
+msgstr "Windows_Right"
+
+#: ../src/common/accelcmn.cpp:111
+msgctxt "keyboard key"
+msgid "Windows_Menu"
+msgstr "Windows_Menu"
+
+#: ../src/common/accelcmn.cpp:112
+msgctxt "keyboard key"
+msgid "Command"
+msgstr "Commando"
+
+#: ../src/common/accelcmn.cpp:186 ../src/common/accelcmn.cpp:359
+msgctxt "keyboard key"
+msgid "Ctrl"
+msgstr "Ctrl"
+
+#: ../src/common/accelcmn.cpp:188 ../src/common/accelcmn.cpp:363
+msgctxt "keyboard key"
+msgid "Alt"
+msgstr "Alt"
+
+#: ../src/common/accelcmn.cpp:190 ../src/common/accelcmn.cpp:361
+msgctxt "keyboard key"
+msgid "Shift"
+msgstr "Shift"
+
+#: ../src/common/accelcmn.cpp:196
+msgctxt "keyboard key"
+msgid "num "
+msgstr "num "
+
+#: ../src/common/accelcmn.cpp:260 ../src/common/accelcmn.cpp:382
+msgctxt "keyboard key"
+msgid "F"
+msgstr "F"
+
+#: ../src/common/accelcmn.cpp:277 ../src/common/accelcmn.cpp:385
+msgctxt "keyboard key"
+msgid "KP_F"
+msgstr "KP_F"
+
+#: ../src/common/accelcmn.cpp:280 ../src/common/accelcmn.cpp:388
+msgctxt "keyboard key"
+msgid "KP_"
+msgstr "KP_"
+
+#: ../src/common/accelcmn.cpp:283 ../src/common/accelcmn.cpp:391
+msgctxt "keyboard key"
+msgid "SPECIAL"
+msgstr "SPECIAAL"
+
+#: ../src/common/accelcmn.cpp:373
+#, fuzzy
+msgid "Ctrl"
+msgstr "Ctrl"
+
+#: ../src/common/appbase.cpp:786
+msgid "show this help message"
+msgstr "dit helpbericht weergeven"
+
+#: ../src/common/appbase.cpp:796
+msgid "generate verbose log messages"
+msgstr "genereer uitgebreide log meldingen"
+
+#: ../src/common/appcmn.cpp:256
+msgid "specify the theme to use"
+msgstr "kies het te gebruiken thema"
+
+#: ../src/common/appcmn.cpp:270
+msgid "specify display mode to use (e.g. 640x480-16)"
+msgstr "kies de te gebruiken beeldscherm mode (B.V. 640x480-16)"
+
+#: ../src/common/appcmn.cpp:292
+#, c-format
+msgid "Unsupported theme '%s'."
+msgstr "Niet ondersteund thema '%s'."
+
+#: ../src/common/appcmn.cpp:309
+#, c-format
+msgid "Invalid display mode specification '%s'."
+msgstr "Ongeldige beeldscherm mode specificatie. '%s'."
+
+#: ../src/common/cmdline.cpp:875
+#, c-format
+msgid "Option '%s' can't be negated"
+msgstr "Optie '%s' kon niet worden genegeerd"
+
+#: ../src/common/cmdline.cpp:889
+#, c-format
+msgid "Unknown long option '%s'"
+msgstr "Onbekende lange optie '%s'"
+
+#: ../src/common/cmdline.cpp:904 ../src/common/cmdline.cpp:926
+#, c-format
+msgid "Unknown option '%s'"
+msgstr "Onbekende optie '%s'"
+
+#: ../src/common/cmdline.cpp:1004
+#, c-format
+msgid "Unexpected characters following option '%s'."
+msgstr "Onverwachte lettertekens na de optie '%s'."
+
+#: ../src/common/cmdline.cpp:1039
+#, c-format
+msgid "Option '%s' requires a value."
+msgstr "Optie '%s' vereist een waarde."
+
+#: ../src/common/cmdline.cpp:1058
+#, c-format
+msgid "Separator expected after the option '%s'."
+msgstr "Scheidingsteken verwacht na de optie '%s'."
+
+#: ../src/common/cmdline.cpp:1088 ../src/common/cmdline.cpp:1106
+#, c-format
+msgid "'%s' is not a correct numeric value for option '%s'."
+msgstr "'%s' is geen geldige numerieke waarde voor optie '%s'."
+
+#: ../src/common/cmdline.cpp:1122
+#, c-format
+msgid "Option '%s': '%s' cannot be converted to a date."
+msgstr "Optie '%s': '%s' kan niet naar een datum worden geconverteerd."
+
+#: ../src/common/cmdline.cpp:1170
+#, c-format
+msgid "Unexpected parameter '%s'"
+msgstr "Onverwachte parameter '%s'"
+
+#. TRANSLATORS: Short name and long name for a command line option
+#: ../src/common/cmdline.cpp:1197
+#, c-format
+msgid "%s (or %s)"
+msgstr "%s (of %s)"
+
+#: ../src/common/cmdline.cpp:1208
+#, c-format
+msgid "The value for the option '%s' must be specified."
+msgstr "De waarde voor de optie '%s' moet worden opgegeven."
+
+#: ../src/common/cmdline.cpp:1230
+#, c-format
+msgid "The required parameter '%s' was not specified."
+msgstr "De benodigde parameter '%s' was niet gespecificeerd."
+
+#: ../src/common/cmdline.cpp:1289
+#, c-format
+msgid "Usage: %s"
+msgstr "Gebruik: %s"
+
+#: ../src/common/cmdline.cpp:1498
+msgid "str"
+msgstr "str"
+
+#: ../src/common/cmdline.cpp:1502
+msgid "num"
+msgstr "num"
+
+#: ../src/common/cmdline.cpp:1506
+msgid "double"
+msgstr "dubbel"
+
+#: ../src/common/cmdline.cpp:1510
+msgid "date"
+msgstr "datum"
+
+#: ../src/common/cmdproc.cpp:250 ../src/common/cmdproc.cpp:276
+#: ../src/common/cmdproc.cpp:296
+msgid "Unnamed command"
+msgstr "Naamloze opdracht"
+
+#: ../src/common/cmdproc.cpp:253
+msgid "&Undo "
+msgstr "Maak &ongedaan: "
+
+#: ../src/common/cmdproc.cpp:255
+msgid "Can't &Undo "
+msgstr "Kan niet &ongedaan maken: "
+
+#: ../src/common/cmdproc.cpp:259 ../src/common/stockitem.cpp:208
+#: ../src/msw/textctrl.cpp:2880 ../src/osx/textctrl_osx.cpp:649
+#: ../src/richtext/richtextctrl.cpp:327
+msgid "&Undo"
+msgstr "&Ongedaan maken"
+
+#: ../src/common/cmdproc.cpp:277 ../src/common/cmdproc.cpp:297
+msgid "&Redo "
+msgstr "Opnie&uw "
+
+#: ../src/common/cmdproc.cpp:281 ../src/common/cmdproc.cpp:288
+#: ../src/common/stockitem.cpp:190 ../src/msw/textctrl.cpp:2881
+#: ../src/osx/textctrl_osx.cpp:650 ../src/richtext/richtextctrl.cpp:328
+msgid "&Redo"
+msgstr "Opnie&uw"
+
+#: ../src/common/colourcmn.cpp:41
+#, c-format
+msgid "String To Colour : Incorrect colour specification : %s"
+msgstr "Tekenreeks Naar Kleur : Incorrecte kleur specificatie: %s"
+
+#: ../src/common/config.cpp:259
+#, c-format
+msgid "Invalid value %ld for a boolean key \"%s\" in config file."
+msgstr ""
+"Ongeldige waarde %ld voor een boolean sleutel \"%s\" in config bestand."
+
+#: ../src/common/config.cpp:526
+#, c-format
+msgid ""
+"Environment variables expansion failed: missing '%c' at position %u in '%s'."
+msgstr ""
+"Uitbreiding van omgevingsvariabelen mislukt: ontbrekende '%c' op positie %u "
+"in '%s'."
+
+#: ../src/common/config.cpp:576 ../src/msw/regconf.cpp:272
+#, c-format
+msgid "'%s' has extra '..', ignored."
+msgstr "'%s' heeft extra '..', genegeerd."
+
+#. TRANSLATORS: Checkbox state name
+#: ../src/common/datavcmn.cpp:2166 ../src/generic/datavgen.cpp:1430
+msgid "checked"
+msgstr "aangevinkt"
+
+#. TRANSLATORS: Checkbox state name
+#: ../src/common/datavcmn.cpp:2170 ../src/generic/datavgen.cpp:1432
+msgid "unchecked"
+msgstr "niet aangevinkt"
+
+#. TRANSLATORS: Checkbox state name
+#: ../src/common/datavcmn.cpp:2174
+msgid "undetermined"
+msgstr "onbepaald"
+
+#: ../src/common/datetimefmt.cpp:1875
+msgid "today"
+msgstr "vandaag"
+
+#: ../src/common/datetimefmt.cpp:1876
+msgid "yesterday"
+msgstr "gisteren"
+
+#: ../src/common/datetimefmt.cpp:1877
+msgid "tomorrow"
+msgstr "morgen"
+
+#: ../src/common/datetimefmt.cpp:2071
+msgid "first"
+msgstr "eerste"
+
+#: ../src/common/datetimefmt.cpp:2072
+msgid "second"
+msgstr "tweede"
+
+#: ../src/common/datetimefmt.cpp:2073
+msgid "third"
+msgstr "derde"
+
+#: ../src/common/datetimefmt.cpp:2074
+msgid "fourth"
+msgstr "vierde"
+
+#: ../src/common/datetimefmt.cpp:2075
+msgid "fifth"
+msgstr "vijfde"
+
+#: ../src/common/datetimefmt.cpp:2076
+msgid "sixth"
+msgstr "zesde"
+
+#: ../src/common/datetimefmt.cpp:2077
+msgid "seventh"
+msgstr "zevende"
+
+#: ../src/common/datetimefmt.cpp:2078
+msgid "eighth"
+msgstr "achtste"
+
+#: ../src/common/datetimefmt.cpp:2079
+msgid "ninth"
+msgstr "negende"
+
+#: ../src/common/datetimefmt.cpp:2080
+msgid "tenth"
+msgstr "tiende"
+
+#: ../src/common/datetimefmt.cpp:2081
+msgid "eleventh"
+msgstr "elfde"
+
+#: ../src/common/datetimefmt.cpp:2082
+msgid "twelfth"
+msgstr "twaalfde"
+
+#: ../src/common/datetimefmt.cpp:2083
+msgid "thirteenth"
+msgstr "dertiende"
+
+#: ../src/common/datetimefmt.cpp:2084
+msgid "fourteenth"
+msgstr "veertiende"
+
+#: ../src/common/datetimefmt.cpp:2085
+msgid "fifteenth"
+msgstr "vijftiende"
+
+#: ../src/common/datetimefmt.cpp:2086
+msgid "sixteenth"
+msgstr "zestiende"
+
+#: ../src/common/datetimefmt.cpp:2087
+msgid "seventeenth"
+msgstr "zeventiende"
+
+#: ../src/common/datetimefmt.cpp:2088
+msgid "eighteenth"
+msgstr "achttiende"
+
+#: ../src/common/datetimefmt.cpp:2089
+msgid "nineteenth"
+msgstr "negentiende"
+
+#: ../src/common/datetimefmt.cpp:2090
+msgid "twentieth"
+msgstr "twintigste"
+
+#: ../src/common/datetimefmt.cpp:2248
+msgid "noon"
+msgstr "middag"
+
+#: ../src/common/datetimefmt.cpp:2249
+msgid "midnight"
+msgstr "middernacht"
+
+#: ../src/common/debugrpt.cpp:209
+#, c-format
+msgid "Failed to create directory \"%s\""
+msgstr "Aanmaken map \"%s\" mislukt"
+
+#: ../src/common/debugrpt.cpp:210
+msgid "Debug report couldn't be created."
+msgstr "Foutopsporingsrapport kon niet worden gemaakt."
+
+#: ../src/common/debugrpt.cpp:227
+#, c-format
+msgid "Failed to remove debug report file \"%s\""
+msgstr "Verwijderen van foutopsporingsrapport bestand \"%s\" is mislukt."
+
+#: ../src/common/debugrpt.cpp:239
+#, c-format
+msgid "Failed to clean up debug report directory \"%s\""
+msgstr "Opschonen van de foutopsporingsrapportage map  \"%s\" is mislukt"
+
+#: ../src/common/debugrpt.cpp:514
+msgid "process context description"
+msgstr "procesinhoud beschrijving"
+
+#: ../src/common/debugrpt.cpp:538
+msgid "dump of the process state (binary)"
+msgstr "dump van de proces status (binair)"
+
+#: ../src/common/debugrpt.cpp:553
+msgid "Debug report generation has failed."
+msgstr "Genereren van foutopsporingsrapport mislukt."
+
+#: ../src/common/debugrpt.cpp:560
+#, c-format
+msgid ""
+"Processing debug report has failed, leaving the files in \"%s\" directory."
+msgstr ""
+"Verwerking van foutopsporingsrapport mislukt. Bestanden zijn achtergelaten "
+"in de \"%s\" map."
+
+#: ../src/common/debugrpt.cpp:573
+msgid "A debug report has been generated. It can be found in"
+msgstr "Er is een foutopsporingsrapport gemaakt. Het kan gevonden worden in"
+
+#: ../src/common/debugrpt.cpp:576
+msgid "And includes the following files:\n"
+msgstr "En omvat de volgende bestanden:\n"
+
+#: ../src/common/debugrpt.cpp:586
+msgid ""
+"\n"
+"Please send this report to the program maintainer, thank you!\n"
+msgstr ""
+"\n"
+"Zend dit rapport naar de programmabeheerder, bedankt!\n"
+
+#: ../src/common/debugrpt.cpp:729
+msgid "Failed to execute curl, please install it in PATH."
+msgstr "Uitvoeren van curl mislukt, installeer het alstublieft in PATH."
+
+#: ../src/common/debugrpt.cpp:742
+#, c-format
+msgid "Failed to upload the debug report (error code %d)."
+msgstr "Uploaden van het foutopsporingsrapport is mislukt (foutcode %d)."
+
+#: ../src/common/docview.cpp:366
+msgid "Save As"
+msgstr "Opslaan Als"
+
+#: ../src/common/docview.cpp:457
+msgid "Discard changes and reload the last saved version?"
+msgstr "Wijzigingen negeren en laatst opgeslagen versie herladen?"
+
+#: ../src/common/docview.cpp:488
+msgid "unnamed"
+msgstr "naamloos"
+
+#: ../src/common/docview.cpp:513
+#, c-format
+msgid "Do you want to save changes to %s?"
+msgstr "Wilt u de veranderingen aan %s opslaan?"
+
+#: ../src/common/docview.cpp:521 ../src/common/docview.cpp:560
+#: ../src/common/stockitem.cpp:195
+msgid "&Save"
+msgstr "Op&slaan"
+
+#: ../src/common/docview.cpp:522 ../src/common/docview.cpp:560
+msgid "&Discard changes"
+msgstr ""
+
+#: ../src/common/docview.cpp:523
+#, fuzzy
+msgid "Do&n't close"
+msgstr "Niet Opslaan"
+
+#: ../src/common/docview.cpp:553
+#, fuzzy, c-format
+msgid "Do you want to save changes to %s before closing it?"
+msgstr "Wilt u de veranderingen aan %s opslaan?"
+
+#: ../src/common/docview.cpp:559
+#, fuzzy
+msgid "The document must be closed."
+msgstr "De tekst kon niet worden opgeslagen."
+
+#: ../src/common/docview.cpp:571
+#, c-format
+msgid "Saving %s failed, would you like to retry?"
+msgstr ""
+
+#: ../src/common/docview.cpp:577
+msgid "Retry"
+msgstr ""
+
+#: ../src/common/docview.cpp:577
+msgid "Discard changes"
+msgstr ""
+
+#: ../src/common/docview.cpp:679
+#, c-format
+msgid "File \"%s\" could not be opened for writing."
+msgstr "Openen van bestand \"%s\" voor schrijven mislukt."
+
+#: ../src/common/docview.cpp:685
+#, c-format
+msgid "Failed to save document to the file \"%s\"."
+msgstr "Opslaan van document naar het bestand \"%s\" mislukt."
+
+#: ../src/common/docview.cpp:702
+#, c-format
+msgid "File \"%s\" could not be opened for reading."
+msgstr "Openen van bestand \"%s\"  voor lezen mislukt."
+
+#: ../src/common/docview.cpp:714
+#, c-format
+msgid "Failed to read document from the file \"%s\"."
+msgstr "Lezen van document van het bestand \"%s\" mislukt."
+
+#: ../src/common/docview.cpp:1236
+#, c-format
+msgid ""
+"The file '%s' doesn't exist and couldn't be opened.\n"
+"It has been removed from the most recently used files list."
+msgstr ""
+"Het bestand '%s' bestaat niet en kon niet geopend worden.\n"
+"Het is verwijderd van de lijst 'recente bestanden'."
+
+#: ../src/common/docview.cpp:1296
+msgid "Print preview creation failed."
+msgstr "Maken afdrukvoorbeeld mislukt."
+
+#: ../src/common/docview.cpp:1302
+msgid "Print Preview"
+msgstr "Afdrukvoorbeeld"
+
+#: ../src/common/docview.cpp:1517
+#, c-format
+msgid "The format of file '%s' couldn't be determined."
+msgstr "Het formaat van bestand '%s' kan niet worden bepaald."
+
+#: ../src/common/docview.cpp:1643
+#, c-format
+msgid "unnamed%d"
+msgstr "naamloos%d"
+
+#: ../src/common/docview.cpp:1660
+msgid " - "
+msgstr " - "
+
+#: ../src/common/docview.cpp:1791 ../src/common/docview.cpp:1844
+msgid "Open File"
+msgstr "Open Bestand"
+
+#: ../src/common/docview.cpp:1807
+msgid "File error"
+msgstr "Bestandsfout"
+
+#: ../src/common/docview.cpp:1809
+msgid "Sorry, could not open this file."
+msgstr "Sorry, kon dit bestand niet openen."
+
+#: ../src/common/docview.cpp:1843
+msgid "Sorry, the format for this file is unknown."
+msgstr "Helaas, het formaat van dit bestand is onbekend."
+
+#: ../src/common/docview.cpp:1924
+msgid "Select a document template"
+msgstr "Selecteer een documentsjabloon"
+
+#: ../src/common/docview.cpp:1925
+msgid "Templates"
+msgstr "Sjablonen"
+
+#: ../src/common/docview.cpp:1998
+msgid "Select a document view"
+msgstr "Selecteer een documentweergave"
+
+#: ../src/common/docview.cpp:1999
+msgid "Views"
+msgstr "Weergaven"
+
+#: ../src/common/dynlib.cpp:81
+#, c-format
+msgid "Failed to load shared library '%s'"
+msgstr "Laden van gedeelde bibliotheek '%s' mislukt"
+
+#: ../src/common/dynlib.cpp:105
+#, c-format
+msgid "Couldn't find symbol '%s' in a dynamic library"
+msgstr "Kon symbool %s niet vinden in een dynamische bibliotheek"
+
+#: ../src/common/ffile.cpp:56 ../src/common/file.cpp:215
+#, c-format
+msgid "can't open file '%s'"
+msgstr "kan bestand '%s' niet openen"
+
+#: ../src/common/ffile.cpp:72
+#, c-format
+msgid "can't close file '%s'"
+msgstr "kan bestand '%s' niet sluiten"
+
+#: ../src/common/ffile.cpp:106 ../src/common/ffile.cpp:131
+#, c-format
+msgid "Read error on file '%s'"
+msgstr "Leesfout bij bestand '%s'"
+
+#: ../src/common/ffile.cpp:148
+#, c-format
+msgid "Write error on file '%s'"
+msgstr "Schrijffout bij bestand '%s'"
+
+#: ../src/common/ffile.cpp:182
+#, c-format
+msgid "failed to flush the file '%s'"
+msgstr "legen van bestand '%s' mislukt"
+
+#: ../src/common/ffile.cpp:222
+#, c-format
+msgid "Seek error on file '%s' (large files not supported by stdio)"
+msgstr ""
+"Zoek fout in bestand '%s' (grote bestanden die niet worden ondersteund door "
+"stdio)"
+
+#: ../src/common/ffile.cpp:232
+#, c-format
+msgid "Seek error on file '%s'"
+msgstr "Zoekfout bij bestand '%s'"
+
+#: ../src/common/ffile.cpp:248
+#, c-format
+msgid "Can't find current position in file '%s'"
+msgstr "Kan huidige positie in bestand '%s' niet vinden"
+
+#: ../src/common/ffile.cpp:349 ../src/common/file.cpp:569
+msgid "Failed to set temporary file permissions"
+msgstr "Instellen van machtigingen van tijdelijk bestand mislukt"
+
+#: ../src/common/ffile.cpp:371
+#, c-format
+msgid "can't remove file '%s'"
+msgstr "kan bestand '%s' niet verwijderen"
+
+#: ../src/common/ffile.cpp:376 ../src/common/file.cpp:591
+#, c-format
+msgid "can't commit changes to file '%s'"
+msgstr "kan verandering niet doorvoeren in bestand '%s'"
+
+#: ../src/common/ffile.cpp:388 ../src/common/file.cpp:603
+#, c-format
+msgid "can't remove temporary file '%s'"
+msgstr "kan tijdelijk bestand '%s' niet verwijderen"
+
+#: ../src/common/file.cpp:162
+#, c-format
+msgid "can't create file '%s'"
+msgstr "kan bestand '%s' niet maken"
+
+#: ../src/common/file.cpp:229
+#, c-format
+msgid "can't close file descriptor %d"
+msgstr "kan bestandsbeschrijving %d niet sluiten"
+
+#: ../src/common/file.cpp:332
+#, c-format
+msgid "can't read from file descriptor %d"
+msgstr "kan niet lezen van bestandsbeschrijving %d"
+
+#: ../src/common/file.cpp:351
+#, c-format
+msgid "can't write to file descriptor %d"
+msgstr "kan niet schrijven naar bestandsbeschrijving %d"
+
+#: ../src/common/file.cpp:390
+#, c-format
+msgid "can't flush file descriptor %d"
+msgstr "kan bestandsbeschrijving %d niet legen"
+
+#: ../src/common/file.cpp:432
+#, c-format
+msgid "can't seek on file descriptor %d"
+msgstr "kan niet zoeken bij bestandsbeschrijving %d"
+
+#: ../src/common/file.cpp:446
+#, c-format
+msgid "can't get seek position on file descriptor %d"
+msgstr "kan zoekpositie niet verkrijgen bij bestandsbeschrijving %d"
+
+#: ../src/common/file.cpp:475
+#, c-format
+msgid "can't find length of file on file descriptor %d"
+msgstr "kan bestandslengte niet vinden bij bestandsbeschrijving %d"
+
+#: ../src/common/file.cpp:505
+#, c-format
+msgid "can't determine if the end of file is reached on descriptor %d"
+msgstr ""
+"kan niet bepalen of bestandseinde is bereikt bij bestandsbeschrijving %d"
+
+#: ../src/common/fileconf.cpp:352
+#, c-format
+msgid ""
+" and additionally, the existing configuration file was renamed to \"%s\" and "
+"couldn't be renamed back, please rename it to its original path \"%s\""
+msgstr ""
+
+#: ../src/common/fileconf.cpp:389
+#, fuzzy
+msgid " due to the following error:\n"
+msgstr "En omvat de volgende bestanden:\n"
+
+#: ../src/common/fileconf.cpp:412
+#, fuzzy
+msgid "failed to rename the existing file"
+msgstr "Lezen van tekstbestand \"%s\" mislukt."
+
+#: ../src/common/fileconf.cpp:421
+#, fuzzy
+msgid "failed to create the new file directory"
+msgstr "Verkrijgen van de werk map mislukt"
+
+#: ../src/common/fileconf.cpp:428
+#, fuzzy
+msgid "failed to move the file to the new location"
+msgstr "Kan webweergave niet instellen op modern emulatieniveau"
+
+#: ../src/common/fileconf.cpp:462
+#, c-format
+msgid "can't open global configuration file '%s'."
+msgstr "kan globaal configuratiebestand '%s' niet openen."
+
+#: ../src/common/fileconf.cpp:478
+#, c-format
+msgid "can't open user configuration file '%s'."
+msgstr "kan gebruikers-configuratiebestand '%s' niet openen."
+
+#: ../src/common/fileconf.cpp:483
+#, c-format
+msgid "Changes won't be saved to avoid overwriting the existing file \"%s\""
+msgstr ""
+"Wijzigingen worden niet opgeslagen om te vermijden dat het bestaande bestand "
+"\"%s\" zal worden overschreven"
+
+#: ../src/common/fileconf.cpp:583
+msgid "Error reading config options."
+msgstr "Fout bij lezen van configuratie opties."
+
+#: ../src/common/fileconf.cpp:593
+msgid "Failed to read config options."
+msgstr "Lezen van config opties mislukt."
+
+#: ../src/common/fileconf.cpp:700
+#, c-format
+msgid "file '%s': unexpected character %c at line %zu."
+msgstr "bestand '%s': onverwacht teken %c bij regel %zu."
+
+#: ../src/common/fileconf.cpp:736
+#, c-format
+msgid "file '%s', line %zu: '%s' ignored after group header."
+msgstr "bestand '%s', regel %zu: '%s' genegeerd na groepskoptekst."
+
+#: ../src/common/fileconf.cpp:765
+#, c-format
+msgid "file '%s', line %zu: '=' expected."
+msgstr "bestand '%s', regel %zu: '=' verwacht."
+
+#: ../src/common/fileconf.cpp:778
+#, c-format
+msgid "file '%s', line %zu: value for immutable key '%s' ignored."
+msgstr ""
+"bestand '%s', regel %zu: waarde voor onveranderlijke toets '%s' genegeerd."
+
+#: ../src/common/fileconf.cpp:788
+#, c-format
+msgid "file '%s', line %zu: key '%s' was first found at line %d."
+msgstr ""
+"bestand '%s', regel %zu: key '%s' werd voor het eerst gevonden op regel %d."
+
+#: ../src/common/fileconf.cpp:1091
+#, c-format
+msgid "Config entry name cannot start with '%c'."
+msgstr "Naam van configuratie-ingang kan niet beginnen met '%c'."
+
+#: ../src/common/fileconf.cpp:1146
+#, fuzzy
+msgid "Failed to create configuration file directory."
+msgstr "Kan lettertype configuratieobject niet maken."
+
+#: ../src/common/fileconf.cpp:1158
+msgid "can't open user configuration file."
+msgstr "kan gebruikers-configuratiebestand niet openen."
+
+#: ../src/common/fileconf.cpp:1172
+msgid "can't write user configuration file."
+msgstr "kan gebruikers-configuratiebestand niet schrijven."
+
+#: ../src/common/fileconf.cpp:1178
+msgid "Failed to update user configuration file."
+msgstr "Updaten van gebruikersconfiguratie bestand is mislukt."
+
+#: ../src/common/fileconf.cpp:1201
+msgid "Error saving user configuration data."
+msgstr "Fout van bij het opslaan van de instellingsgegevens."
+
+#: ../src/common/fileconf.cpp:1313
+#, c-format
+msgid "can't delete user configuration file '%s'"
+msgstr "kan bestand met gebruikersinstellingen '%s' niet wissen"
+
+#: ../src/common/fileconf.cpp:2007
+#, c-format
+msgid "entry '%s' appears more than once in group '%s'"
+msgstr "ingang '%s' komt meer dan één keer voor in groep '%s'"
+
+#: ../src/common/fileconf.cpp:2021
+#, c-format
+msgid "attempt to change immutable key '%s' ignored."
+msgstr "poging tot wijzigen van onveranderbare sleutel '%s' genegeerd."
+
+#: ../src/common/fileconf.cpp:2118
+#, c-format
+msgid "trailing backslash ignored in '%s'"
+msgstr "trailing backslash genegeerd in '%s'"
+
+#: ../src/common/fileconf.cpp:2153
+#, c-format
+msgid "unexpected \" at position %d in '%s'."
+msgstr "onverwachte \" op positie %d in '%s'."
+
+#: ../src/common/filefn.cpp:474
+#, c-format
+msgid "Failed to copy the file '%s' to '%s'"
+msgstr "Kopiëren van bestand '%s' naar '%s' mislukt"
+
+#: ../src/common/filefn.cpp:487
+#, c-format
+msgid "Impossible to get permissions for file '%s'"
+msgstr "Onmogelijk om machtigingen voor bestand '%s' te krijgen"
+
+#: ../src/common/filefn.cpp:501
+#, c-format
+msgid "Impossible to overwrite the file '%s'"
+msgstr "Overschrijven van bestand '%s' mislukt"
+
+#: ../src/common/filefn.cpp:508
+#, c-format
+msgid "Error copying the file '%s' to '%s'."
+msgstr "Fout bij het kopiëren van het bestand '%s' naar '%s'."
+
+#: ../src/common/filefn.cpp:556
+#, c-format
+msgid "Impossible to set permissions for the file '%s'"
+msgstr "Onmogelijk om machtigingen voor het bestand '%s' in te stellen"
+
+#: ../src/common/filefn.cpp:606
+#, c-format
+msgid ""
+"Failed to rename the file '%s' to '%s' because the destination file already "
+"exists."
+msgstr ""
+"Hernoemen van het bestand ‘%s’ naar ‘%s’ mislukt omdat het doelbestand al "
+"bestaat."
+
+#: ../src/common/filefn.cpp:623
+#, c-format
+msgid "File '%s' couldn't be renamed '%s'"
+msgstr "Bestand '%s' kon niet worden hernoemd naar '%s'"
+
+#: ../src/common/filefn.cpp:639
+#, c-format
+msgid "File '%s' couldn't be removed"
+msgstr "Bestand '%s' kon niet worden verwijderd"
+
+#: ../src/common/filefn.cpp:666
+#, c-format
+msgid "Directory '%s' couldn't be created"
+msgstr "Map '%s' kon niet worden gemaakt"
+
+#: ../src/common/filefn.cpp:680
+#, c-format
+msgid "Directory '%s' couldn't be deleted"
+msgstr "Map '%s' kon niet worden verwijderd"
+
+#: ../src/common/filefn.cpp:714
+#, c-format
+msgid "Cannot enumerate files '%s'"
+msgstr "Kan bestanden in map '%s' niet opsommen"
+
+#: ../src/common/filefn.cpp:798
+msgid "Failed to get the working directory"
+msgstr "Verkrijgen van de werk map mislukt"
+
+#: ../src/common/filefn.cpp:843
+msgid "Could not set current working directory"
+msgstr "Instellen van huidige werk map mislukt"
+
+#: ../src/common/filefn.cpp:974
+#, c-format
+msgid "Files (%s)"
+msgstr "Bestanden (%s)"
+
+#: ../src/common/filename.cpp:182
+#, c-format
+msgid "Failed to open '%s' for reading"
+msgstr "Openen van '%s'  voor lezen mislukt"
+
+#: ../src/common/filename.cpp:187
+#, c-format
+msgid "Failed to open '%s' for writing"
+msgstr "Openen van '%s'  voor schrijven mislukt"
+
+#: ../src/common/filename.cpp:199
+msgid "Failed to close file handle"
+msgstr "Sluiten van bestandshandle mislukt"
+
+#: ../src/common/filename.cpp:1046
+msgid "Failed to create a temporary file name"
+msgstr "Maken van een tijdelijke bestandsnaam mislukt"
+
+#: ../src/common/filename.cpp:1081
+msgid "Failed to open temporary file."
+msgstr "Openen van tijdelijk bestand mislukt."
+
+#: ../src/common/filename.cpp:2862
+#, c-format
+msgid "Failed to modify file times for '%s'"
+msgstr "Veranderen van bestandstijden van '%s' mislukt"
+
+#: ../src/common/filename.cpp:2877
+#, c-format
+msgid "Failed to touch the file '%s'"
+msgstr "Touchen van bestand '%s' mislukt"
+
+#: ../src/common/filename.cpp:2958
+#, c-format
+msgid "Failed to retrieve file times for '%s'"
+msgstr "Verkrijgen van bestandstijden voor '%s' mislukt"
+
+#: ../src/common/filepickercmn.cpp:39 ../src/common/filepickercmn.cpp:40
+msgid "Browse"
+msgstr "Bladeren"
+
+#: ../src/common/fldlgcmn.cpp:792 ../src/generic/filectrlg.cpp:1185
+#, c-format
+msgid "All files (%s)|%s"
+msgstr "Alle bestanden (%s)|%s"
+
+#. TRANSLATORS: %s are a file extension used to build a file wildcard string
+#: ../src/common/fldlgcmn.cpp:810
+#, c-format
+msgid "%s files (%s)|%s"
+msgstr "%s bestanden (%s)|%s"
+
+#: ../src/common/fldlgcmn.cpp:1072
+#, c-format
+msgid "Load %s file"
+msgstr "Laad %s-bestand"
+
+#: ../src/common/fldlgcmn.cpp:1074
+#, c-format
+msgid "Save %s file"
+msgstr "Sla %s-bestand op"
+
+#: ../src/common/fmapbase.cpp:144
+msgid "Western European (ISO-8859-1)"
+msgstr "West-Europees (ISO-8859-1)"
+
+#: ../src/common/fmapbase.cpp:145
+msgid "Central European (ISO-8859-2)"
+msgstr "Centraal-Europees (ISO-8859-2)"
+
+#: ../src/common/fmapbase.cpp:146
+msgid "Esperanto (ISO-8859-3)"
+msgstr "Esperanto (ISO-8859-3)"
+
+#: ../src/common/fmapbase.cpp:147
+msgid "Baltic (old) (ISO-8859-4)"
+msgstr "Baltisch (oud) (ISO-8859-4)"
+
+#: ../src/common/fmapbase.cpp:148
+msgid "Cyrillic (ISO-8859-5)"
+msgstr "Cyrillic (ISO-8859-5)"
+
+#: ../src/common/fmapbase.cpp:149
+msgid "Arabic (ISO-8859-6)"
+msgstr "Arabisch (ISO-8859-6)"
+
+#: ../src/common/fmapbase.cpp:150
+msgid "Greek (ISO-8859-7)"
+msgstr "Grieks (ISO-8859-7)"
+
+#: ../src/common/fmapbase.cpp:151
+msgid "Hebrew (ISO-8859-8)"
+msgstr "Hebreeuws (ISO-8859-8)"
+
+#: ../src/common/fmapbase.cpp:152
+msgid "Turkish (ISO-8859-9)"
+msgstr "Turks (ISO-8859-9)"
+
+#: ../src/common/fmapbase.cpp:153
+msgid "Nordic (ISO-8859-10)"
+msgstr "Noors (ISO-8859-10)"
+
+#: ../src/common/fmapbase.cpp:154
+msgid "Thai (ISO-8859-11)"
+msgstr "Thais (ISO-8859-11)"
+
+#: ../src/common/fmapbase.cpp:155
+msgid "Indian (ISO-8859-12)"
+msgstr "Indisch (ISO-8859-12)"
+
+#: ../src/common/fmapbase.cpp:156
+msgid "Baltic (ISO-8859-13)"
+msgstr "Baltisch (ISO-8859-13)"
+
+#: ../src/common/fmapbase.cpp:157
+msgid "Celtic (ISO-8859-14)"
+msgstr "Celtic (ISO-8859-14)"
+
+#: ../src/common/fmapbase.cpp:158
+msgid "Western European with Euro (ISO-8859-15)"
+msgstr "West-Europees met Euro teken (ISO-8859-15)"
+
+#: ../src/common/fmapbase.cpp:159
+msgid "KOI8-R"
+msgstr "KOI8-R"
+
+#: ../src/common/fmapbase.cpp:160
+msgid "KOI8-U"
+msgstr "KOI8-U"
+
+#: ../src/common/fmapbase.cpp:161
+msgid "Windows/DOS OEM Cyrillic (CP 866)"
+msgstr "Windows/DOS OEM Cyrillic (CP 866)"
+
+#: ../src/common/fmapbase.cpp:162
+msgid "Windows Thai (CP 874)"
+msgstr "Windows Thai (CP 874)"
+
+#: ../src/common/fmapbase.cpp:163
+msgid "Windows Japanese (CP 932) or Shift-JIS"
+msgstr "Windows Japans (CP 932) of Shift-JIS"
+
+#: ../src/common/fmapbase.cpp:164
+msgid "Windows Chinese Simplified (CP 936) or GB-2312"
+msgstr "Windows Chinees Gesimplificeerd (CP 936) of GB-2312"
+
+#: ../src/common/fmapbase.cpp:165
+msgid "Windows Korean (CP 949)"
+msgstr "Windows Koreaans (CP 949)"
+
+#: ../src/common/fmapbase.cpp:166
+msgid "Windows Chinese Traditional (CP 950) or Big-5"
+msgstr "Windows Traditioneel Chinees (CP 950) of Big-5"
+
+#: ../src/common/fmapbase.cpp:167
+msgid "Windows Central European (CP 1250)"
+msgstr "Windows Centraal Europees (CP 1250)"
+
+#: ../src/common/fmapbase.cpp:168
+msgid "Windows Cyrillic (CP 1251)"
+msgstr "Windows Cyrillisch (CP 1251)"
+
+#: ../src/common/fmapbase.cpp:169
+msgid "Windows Western European (CP 1252)"
+msgstr "Windows West Europees (CP 1252)"
+
+#: ../src/common/fmapbase.cpp:170
+msgid "Windows Greek (CP 1253)"
+msgstr "Windows Grieks (CP 1253)"
+
+#: ../src/common/fmapbase.cpp:171
+msgid "Windows Turkish (CP 1254)"
+msgstr "Windows Turks (CP 1254)"
+
+#: ../src/common/fmapbase.cpp:172
+msgid "Windows Hebrew (CP 1255)"
+msgstr "Windows Hebreeuws (CP 1255)"
+
+#: ../src/common/fmapbase.cpp:173
+msgid "Windows Arabic (CP 1256)"
+msgstr "Windows Arabisch (CP 1256)"
+
+#: ../src/common/fmapbase.cpp:174
+msgid "Windows Baltic (CP 1257)"
+msgstr "Windows Baltisch (CP 1257)"
+
+#: ../src/common/fmapbase.cpp:175
+msgid "Windows Vietnamese (CP 1258)"
+msgstr "Windows Vietnamees (CP 1258)"
+
+#: ../src/common/fmapbase.cpp:176
+msgid "Windows Johab (CP 1361)"
+msgstr "Windows Johab (CP 1361)"
+
+#: ../src/common/fmapbase.cpp:177
+msgid "Windows/DOS OEM (CP 437)"
+msgstr "Windows/DOS OEM (CP 437)"
+
+#: ../src/common/fmapbase.cpp:178
+msgid "Unicode 7 bit (UTF-7)"
+msgstr "Unicode 7 bit (UTF-7)"
+
+#: ../src/common/fmapbase.cpp:179
+msgid "Unicode 8 bit (UTF-8)"
+msgstr "Unicode 8 bit (UTF-8)"
+
+#: ../src/common/fmapbase.cpp:181 ../src/common/fmapbase.cpp:187
+msgid "Unicode 16 bit (UTF-16)"
+msgstr "Unicode 16 bit (UTF-16)"
+
+#: ../src/common/fmapbase.cpp:182
+msgid "Unicode 16 bit Little Endian (UTF-16LE)"
+msgstr "Unicode 16 bit Little Endian (UTF-16LE)"
+
+#: ../src/common/fmapbase.cpp:183 ../src/common/fmapbase.cpp:189
+msgid "Unicode 32 bit (UTF-32)"
+msgstr "Unicode 32 bit (UTF-32)"
+
+#: ../src/common/fmapbase.cpp:184
+msgid "Unicode 32 bit Little Endian (UTF-32LE)"
+msgstr "Unicode 32 bit Little Endian (UTF-32LE)"
+
+#: ../src/common/fmapbase.cpp:186
+msgid "Unicode 16 bit Big Endian (UTF-16BE)"
+msgstr "Unicode 16 bit Big Endian (UTF-16BE)"
+
+#: ../src/common/fmapbase.cpp:188
+msgid "Unicode 32 bit Big Endian (UTF-32BE)"
+msgstr "Unicode 32 bit Big Endian (UTF-32BE)"
+
+#: ../src/common/fmapbase.cpp:191
+msgid "Extended Unix Codepage for Japanese (EUC-JP)"
+msgstr "Extended Unix Codepage voor Japans (EUC-JP)"
+
+#: ../src/common/fmapbase.cpp:192
+msgid "US-ASCII"
+msgstr "US-ASCII"
+
+#: ../src/common/fmapbase.cpp:193
+msgid "ISO-2022-JP"
+msgstr "ISO-2022-JP"
+
+#: ../src/common/fmapbase.cpp:195
+msgid "MacRoman"
+msgstr "MacRoman"
+
+#: ../src/common/fmapbase.cpp:196
+msgid "MacJapanese"
+msgstr "MacJapanese"
+
+#: ../src/common/fmapbase.cpp:197
+msgid "MacChineseTrad"
+msgstr "MacChineseTrad"
+
+#: ../src/common/fmapbase.cpp:198
+msgid "MacKorean"
+msgstr "MacKorean"
+
+#: ../src/common/fmapbase.cpp:199
+msgid "MacArabic"
+msgstr "MacArabic"
+
+#: ../src/common/fmapbase.cpp:200
+msgid "MacHebrew"
+msgstr "MacHebrew"
+
+#: ../src/common/fmapbase.cpp:201
+msgid "MacGreek"
+msgstr "MacGreek"
+
+#: ../src/common/fmapbase.cpp:202
+msgid "MacCyrillic"
+msgstr "MacCyrillic"
+
+#: ../src/common/fmapbase.cpp:203
+msgid "MacDevanagari"
+msgstr "MacDevanagari"
+
+#: ../src/common/fmapbase.cpp:204
+msgid "MacGurmukhi"
+msgstr "MacGurmukhi"
+
+#: ../src/common/fmapbase.cpp:205
+msgid "MacGujarati"
+msgstr "MacGujarati"
+
+#: ../src/common/fmapbase.cpp:206
+msgid "MacOriya"
+msgstr "MacOriya"
+
+#: ../src/common/fmapbase.cpp:207
+msgid "MacBengali"
+msgstr "MacBengali"
+
+#: ../src/common/fmapbase.cpp:208
+msgid "MacTamil"
+msgstr "MacTamil"
+
+#: ../src/common/fmapbase.cpp:209
+msgid "MacTelugu"
+msgstr "MacTelugu"
+
+#: ../src/common/fmapbase.cpp:210
+msgid "MacKannada"
+msgstr "MacKannada"
+
+#: ../src/common/fmapbase.cpp:211
+msgid "MacMalayalam"
+msgstr "MacMalayalam"
+
+#: ../src/common/fmapbase.cpp:212
+msgid "MacSinhalese"
+msgstr "MacSinhalese"
+
+#: ../src/common/fmapbase.cpp:213
+msgid "MacBurmese"
+msgstr "MacBurmese"
+
+#: ../src/common/fmapbase.cpp:214
+msgid "MacKhmer"
+msgstr "MacKhmer"
+
+#: ../src/common/fmapbase.cpp:215
+msgid "MacThai"
+msgstr "MacThai"
+
+#: ../src/common/fmapbase.cpp:216
+msgid "MacLaotian"
+msgstr "MacLaotian"
+
+#: ../src/common/fmapbase.cpp:217
+msgid "MacGeorgian"
+msgstr "MacGeorgian"
+
+#: ../src/common/fmapbase.cpp:218
+msgid "MacArmenian"
+msgstr "MacArmenian"
+
+#: ../src/common/fmapbase.cpp:219
+msgid "MacChineseSimp"
+msgstr "MacChineseSimp"
+
+#: ../src/common/fmapbase.cpp:220
+msgid "MacTibetan"
+msgstr "MacTibetan"
+
+#: ../src/common/fmapbase.cpp:221
+msgid "MacMongolian"
+msgstr "MacMongolian"
+
+#: ../src/common/fmapbase.cpp:222
+msgid "MacEthiopic"
+msgstr "MacEthiopic"
+
+#: ../src/common/fmapbase.cpp:223
+msgid "MacCentralEurRoman"
+msgstr "MacCentralEurRoman"
+
+#: ../src/common/fmapbase.cpp:224
+msgid "MacVietnamese"
+msgstr "MacVietnamese"
+
+#: ../src/common/fmapbase.cpp:225
+msgid "MacExtArabic"
+msgstr "MacExtArabic"
+
+#: ../src/common/fmapbase.cpp:226
+msgid "MacSymbol"
+msgstr "MacSymbol"
+
+#: ../src/common/fmapbase.cpp:227
+msgid "MacDingbats"
+msgstr "MacDingbats"
+
+#: ../src/common/fmapbase.cpp:228
+msgid "MacTurkish"
+msgstr "MacTurkish"
+
+#: ../src/common/fmapbase.cpp:229
+msgid "MacCroatian"
+msgstr "MacCroatian"
+
+#: ../src/common/fmapbase.cpp:230
+msgid "MacIcelandic"
+msgstr "MacIcelandic"
+
+#: ../src/common/fmapbase.cpp:231
+msgid "MacRomanian"
+msgstr "MacRomanian"
+
+#: ../src/common/fmapbase.cpp:232
+msgid "MacCeltic"
+msgstr "MacCeltic"
+
+#: ../src/common/fmapbase.cpp:233
+msgid "MacGaelic"
+msgstr "MacGaelic"
+
+#: ../src/common/fmapbase.cpp:234
+msgid "MacKeyboardGlyphs"
+msgstr "MacKeyboardGlyphs"
+
+#: ../src/common/fmapbase.cpp:791
+msgid "Default encoding"
+msgstr "Standaardcodering"
+
+#: ../src/common/fmapbase.cpp:805
+#, c-format
+msgid "Unknown encoding (%d)"
+msgstr "Onbekende codering (%d)"
+
+#: ../src/common/fmapbase.cpp:815 ../src/richtext/richtextstyles.cpp:776
+msgid "default"
+msgstr "standaard"
+
+#: ../src/common/fmapbase.cpp:829
+#, c-format
+msgid "unknown-%d"
+msgstr "onbekend-%d"
+
+#: ../src/common/fontcmn.cpp:924 ../src/common/fontcmn.cpp:1130
+msgid "underlined"
+msgstr "onderstreept"
+
+#: ../src/common/fontcmn.cpp:929
+msgid " strikethrough"
+msgstr " doorhalen"
+
+#: ../src/common/fontcmn.cpp:942
+msgid " thin"
+msgstr " dun"
+
+#: ../src/common/fontcmn.cpp:946
+msgid " extra light"
+msgstr " extra licht"
+
+#: ../src/common/fontcmn.cpp:950
+msgid " light"
+msgstr " licht"
+
+#: ../src/common/fontcmn.cpp:954
+msgid " medium"
+msgstr " Gemiddeld"
+
+#: ../src/common/fontcmn.cpp:958
+msgid " semi bold"
+msgstr " halfvet"
+
+#: ../src/common/fontcmn.cpp:962
+msgid " bold"
+msgstr " vet"
+
+#: ../src/common/fontcmn.cpp:966
+msgid " extra bold"
+msgstr " extravet"
+
+#: ../src/common/fontcmn.cpp:970
+msgid " heavy"
+msgstr " zwaar"
+
+#: ../src/common/fontcmn.cpp:974
+msgid " extra heavy"
+msgstr " extra zwaar"
+
+#: ../src/common/fontcmn.cpp:990
+msgid " italic"
+msgstr " cursief"
+
+#: ../src/common/fontcmn.cpp:1134
+msgid "strikethrough"
+msgstr "doorhalen"
+
+#: ../src/common/fontcmn.cpp:1143
+msgid "thin"
+msgstr "dun"
+
+#: ../src/common/fontcmn.cpp:1156
+msgid "extralight"
+msgstr "extralicht"
+
+#: ../src/common/fontcmn.cpp:1161
+msgid "light"
+msgstr "licht"
+
+#: ../src/common/fontcmn.cpp:1169 ../src/richtext/richtextstyles.cpp:775
+msgid "normal"
+msgstr "normaal"
+
+#: ../src/common/fontcmn.cpp:1174
+msgid "medium"
+msgstr "medium"
+
+#: ../src/common/fontcmn.cpp:1179 ../src/common/fontcmn.cpp:1199
+msgid "semibold"
+msgstr "halfvet"
+
+#: ../src/common/fontcmn.cpp:1184
+msgid "bold"
+msgstr "vet"
+
+#: ../src/common/fontcmn.cpp:1194
+msgid "extrabold"
+msgstr "extravet"
+
+#: ../src/common/fontcmn.cpp:1204
+msgid "heavy"
+msgstr "zwaar"
+
+#: ../src/common/fontcmn.cpp:1212
+msgid "extraheavy"
+msgstr "extra zwaar"
+
+#: ../src/common/fontcmn.cpp:1217
+msgid "italic"
+msgstr "cursief"
+
+#: ../src/common/fontmap.cpp:195
+msgid ": unknown charset"
+msgstr ": onbekende tekenset"
+
+#: ../src/common/fontmap.cpp:199
+#, c-format
+msgid ""
+"The charset '%s' is unknown. You may select\n"
+"another charset to replace it with or choose\n"
+"[Cancel] if it cannot be replaced"
+msgstr ""
+"De tekenset '%s' is onbekend. U kunt een andere\n"
+"tekenset kiezen om te vervangen of kies [Annuleer]\n"
+"als het niet vervangen kan worden"
+
+#: ../src/common/fontmap.cpp:241
+#, c-format
+msgid "Failed to remember the encoding for the charset '%s'."
+msgstr "Onthouden van codering voor tekenset '%s' mislukt."
+
+#: ../src/common/fontmap.cpp:321
+msgid "can't load any font, aborting"
+msgstr "kan geen lettertype laden, wordt afgebroken"
+
+#: ../src/common/fontmap.cpp:409
+msgid ": unknown encoding"
+msgstr ": onbekende codering"
+
+#: ../src/common/fontmap.cpp:417
+#, c-format
+msgid ""
+"No font for displaying text in encoding '%s' found,\n"
+"but an alternative encoding '%s' is available.\n"
+"Do you want to use this encoding (otherwise you will have to choose another "
+"one)?"
+msgstr ""
+"Er is geen lettertype gevonden voor het tonen van tekst in de versleuteling "
+"'%s',\n"
+"maar een alternatieve versleuteling '%s' is beschikbaar.\n"
+"Wilt u deze versleuteling gebruiken (Anders moet u een andere kiezen)?"
+
+#: ../src/common/fontmap.cpp:422
+#, c-format
+msgid ""
+"No font for displaying text in encoding '%s' found.\n"
+"Would you like to select a font to be used for this encoding\n"
+"(otherwise the text in this encoding will not be shown correctly)?"
+msgstr ""
+"Geen lettertype voor het tonen van tekst in versleuteling '%s' gevonden.\n"
+"Wilt u een lettertype selecteren voor deze versleuteling \n"
+"(anders zal de tekst in deze versleuteling niet correct weergegeven worden)?"
+
+#: ../src/common/fs_mem.cpp:169
+#, c-format
+msgid "Memory VFS already contains file '%s'!"
+msgstr "Geheugen VFS bevat al bestand '%s'!"
+
+#: ../src/common/fs_mem.cpp:232
+#, c-format
+msgid "Trying to remove file '%s' from memory VFS, but it is not loaded!"
+msgstr ""
+"Bezig met poging om bestand '%s' uit geheugen VFS te verwijderen, maar het "
+"is niet geladen!"
+
+#: ../src/common/fs_mem.cpp:262
+#, c-format
+msgid "Failed to store image '%s' to memory VFS!"
+msgstr "Opslaan van afbeelding '%s' in geheugen VFS mislukt!"
+
+#: ../src/common/ftp.cpp:197
+msgid "Timeout while waiting for FTP server to connect, try passive mode."
+msgstr ""
+"Time-out tijdens het wachten op FTP server verbinding: probeer de passieve "
+"modus."
+
+#: ../src/common/ftp.cpp:399
+#, c-format
+msgid "Failed to set FTP transfer mode to %s."
+msgstr "Instellen van FTP transfer mode naar %s mislukt."
+
+#: ../src/common/ftp.cpp:400 ../src/richtext/richtextsymboldlg.cpp:432
+msgid "ASCII"
+msgstr "ASCII"
+
+#: ../src/common/ftp.cpp:400
+msgid "binary"
+msgstr "binair"
+
+#: ../src/common/ftp.cpp:608
+msgid "The FTP server doesn't support the PORT command."
+msgstr "De FTP server ondersteunt het PORT commando niet."
+
+#: ../src/common/ftp.cpp:622
+msgid "The FTP server doesn't support passive mode."
+msgstr "De FTP server ondersteunt niet passieve mode."
+
+#: ../src/common/gifdecod.cpp:822
+#, c-format
+msgid "Incorrect GIF frame size (%u, %d) for the frame #%u"
+msgstr "Onjuiste GIF frame grootte (%u, %d) voor het frame #%u"
+
+#: ../src/common/glcmn.cpp:108
+msgid "Failed to allocate colour for OpenGL"
+msgstr "Kon geen kleur allokeren voor OpenGL"
+
+#: ../src/common/headerctrlcmn.cpp:57
+msgid "Please select the columns to show and define their order:"
+msgstr "Selecteer de kolommen voor weergeven en definiëren van hun volgorde:"
+
+#: ../src/common/headerctrlcmn.cpp:58
+msgid "Customize Columns"
+msgstr "Kolommen aanpassen"
+
+#: ../src/common/headerctrlcmn.cpp:304
+msgid "&Customize..."
+msgstr "&Aanpassen..."
+
+#: ../src/common/hyperlnkcmn.cpp:132
+#, c-format
+msgid "Failed to open URL \"%s\" in the default browser"
+msgstr "Openen van URL \"%s\" in standaard browser mislukt"
+
+#: ../src/common/iconbndl.cpp:195
+#, c-format
+msgid "Failed to load image %%d from file '%s'."
+msgstr "Laden van afbeelding %%d van bestand '%s' mislukt."
+
+#: ../src/common/iconbndl.cpp:203
+#, c-format
+msgid "Failed to load image %d from stream."
+msgstr "Laden van afbeelding %d van stream mislukt."
+
+#: ../src/common/iconbndl.cpp:221
+#, c-format
+msgid "Failed to load icons from resource '%s'."
+msgstr "Kan geen pictogrammen laden van resource '%s'."
+
+#: ../src/common/imagbmp.cpp:97
+msgid "BMP: Couldn't save invalid image."
+msgstr "BMP: kon ongeldige afbeelding niet opslaan."
+
+#: ../src/common/imagbmp.cpp:137
+msgid "BMP: wxImage doesn't have own wxPalette."
+msgstr "BMP: wxImage heeft geen eigen wxPalette."
+
+#: ../src/common/imagbmp.cpp:243
+msgid "BMP: Couldn't write the file (Bitmap) header."
+msgstr "BMP: Kon koptekst van bestand (Bitmap) niet schrijven."
+
+#: ../src/common/imagbmp.cpp:266
+msgid "BMP: Couldn't write the file (BitmapInfo) header."
+msgstr "BMP: kon de bestandsheader niet schrijven."
+
+#: ../src/common/imagbmp.cpp:353
+msgid "BMP: Couldn't write RGB color map."
+msgstr "BMP: Kon RGB kleur map niet schrijven."
+
+#: ../src/common/imagbmp.cpp:487
+msgid "BMP: Couldn't write data."
+msgstr "BMP: kon gegevens niet wegschrijven."
+
+#: ../src/common/imagbmp.cpp:561 ../src/common/imagbmp.cpp:642
+msgid "BMP: Couldn't allocate memory."
+msgstr "BMP: kon geen geheugen reserveren."
+
+#: ../src/common/imagbmp.cpp:1041
+msgid "DIB Header: Image width > 32767 pixels for file."
+msgstr "DIB Header: Afbeeldingsbreedte > 32767 pixels in bestand."
+
+#: ../src/common/imagbmp.cpp:1049
+msgid "DIB Header: Image height > 32767 pixels for file."
+msgstr "DIB Header: Afbeeldingshoogte > 32767 pixels in bestand."
+
+#: ../src/common/imagbmp.cpp:1081
+msgid "DIB Header: Unknown bitdepth in file."
+msgstr "DIB Header: Onbekende bitdiepte in bestand."
+
+#: ../src/common/imagbmp.cpp:1156
+msgid "DIB Header: Unknown encoding in file."
+msgstr "DIB Header: Onbekende codering in bestand."
+
+#: ../src/common/imagbmp.cpp:1165
+msgid "DIB Header: Encoding doesn't match bitdepth."
+msgstr "DIB Header: Codering komt niet overeen met bit-diepte."
+
+#: ../src/common/imagbmp.cpp:1180
+#, c-format
+msgid "BMP Header: Invalid number of colors (%d)."
+msgstr ""
+
+#: ../src/common/imagbmp.cpp:1273
+msgid "Error in reading image DIB."
+msgstr "Fout bij lezen afbeelding DIB."
+
+#: ../src/common/imagbmp.cpp:1294
+msgid "ICO: Error in reading mask DIB."
+msgstr "ICO: Fout bij lezen masker DIB."
+
+#: ../src/common/imagbmp.cpp:1353
+msgid "ICO: Image too tall for an icon."
+msgstr "ICO: Afbeelding is te hoog voor een pictogram."
+
+#: ../src/common/imagbmp.cpp:1361
+msgid "ICO: Image too wide for an icon."
+msgstr "ICO: Afbeelding is te breed voor een pictogram."
+
+#: ../src/common/imagbmp.cpp:1388 ../src/common/imagbmp.cpp:1488
+#: ../src/common/imagbmp.cpp:1503 ../src/common/imagbmp.cpp:1514
+#: ../src/common/imagbmp.cpp:1528 ../src/common/imagbmp.cpp:1576
+#: ../src/common/imagbmp.cpp:1591 ../src/common/imagbmp.cpp:1605
+#: ../src/common/imagbmp.cpp:1616
+msgid "ICO: Error writing the image file!"
+msgstr "ICO: Fout bij het wegschrijven van de afbeelding!"
+
+#: ../src/common/imagbmp.cpp:1701
+msgid "ICO: Invalid icon index."
+msgstr "ICO: Ongeldige pictogram index."
+
+#: ../src/common/image.cpp:2410
+msgid "Image and mask have different sizes."
+msgstr "Afbeelding en masker hebben verschillende afmetingen."
+
+#: ../src/common/image.cpp:2418 ../src/common/image.cpp:2459
+msgid "No unused colour in image being masked."
+msgstr "Geen ongebruikte kleur in afbeelding gemaskeerd."
+
+#: ../src/common/image.cpp:2641
+#, c-format
+msgid "Failed to load bitmap \"%s\" from resources."
+msgstr "Laden van bitmap \"%s\" van bronnen mislukt."
+
+#: ../src/common/image.cpp:2650
+#, c-format
+msgid "Failed to load icon \"%s\" from resources."
+msgstr "Laden van icoon \"%s\" van bronnen mislukt."
+
+#: ../src/common/image.cpp:2728 ../src/common/image.cpp:2747
+#, c-format
+msgid "Failed to load image from file \"%s\"."
+msgstr "Laden van afbeelding van bestand \"'%s\" mislukt."
+
+#: ../src/common/image.cpp:2761
+#, c-format
+msgid "Can't save image to file '%s': unknown extension."
+msgstr "Kan afbeelding niet opslaan naar bestand '%s': Onbekende extensie."
+
+#: ../src/common/image.cpp:2869
+msgid "No handler found for image type."
+msgstr "Geen handler gevonden voor afbeeldingstype."
+
+#: ../src/common/image.cpp:2877 ../src/common/image.cpp:3000
+#: ../src/common/image.cpp:3066
+#, c-format
+msgid "No image handler for type %d defined."
+msgstr "Geen afbeeldingshandler voor het type %d gedefinieerd."
+
+#: ../src/common/image.cpp:2887
+#, c-format
+msgid "Image file is not of type %d."
+msgstr "Afbeeldingsbestand is niet van type %d."
+
+#: ../src/common/image.cpp:2970
+msgid "Can't automatically determine the image format for non-seekable input."
+msgstr ""
+"Kan niet automatisch het afbeeldingsformaat bepalen voor niet vindbare input."
+
+#: ../src/common/image.cpp:2988
+msgid "Unknown image data format."
+msgstr "Onbekende afbeelding gegevensformaat."
+
+#: ../src/common/image.cpp:3009
+#, c-format
+msgid "This is not a %s."
+msgstr "Dit is niet een %s."
+
+#: ../src/common/image.cpp:3032 ../src/common/image.cpp:3080
+#, c-format
+msgid "No image handler for type %s defined."
+msgstr "Geen afbeeldingshandler voor het type %s gedefinieerd."
+
+#: ../src/common/image.cpp:3041
+#, c-format
+msgid "Image is not of type %s."
+msgstr "Afbeelding is niet van type %s."
+
+#: ../src/common/image.cpp:3509
+#, c-format
+msgid "Failed to check format of image file \"%s\"."
+msgstr "Controleren van formaat afbeeldingsbestand \"%s\" mislukt."
+
+#: ../src/common/imaggif.cpp:124
+msgid "GIF: error in GIF image format."
+msgstr "GIF: fout in GIF-bestandsformaat."
+
+#: ../src/common/imaggif.cpp:129
+msgid "GIF: not enough memory."
+msgstr "GIF: onvoldoende geheugen."
+
+#: ../src/common/imaggif.cpp:134
+msgid "GIF: data stream seems to be truncated."
+msgstr "GIF: gegevensstroom lijkt afgekapt."
+
+#: ../src/common/imaggif.cpp:240
+msgid "Couldn't initialize GIF hash table."
+msgstr "Kon GIF hash-tabel niet initiëren."
+
+#: ../src/common/imagiff.cpp:739
+msgid "IFF: error in IFF image format."
+msgstr "IFF: fout in IFF bestandsformaat."
+
+#: ../src/common/imagiff.cpp:742
+msgid "IFF: not enough memory."
+msgstr "IFF: onvoldoende geheugen."
+
+#: ../src/common/imagiff.cpp:745
+msgid "IFF: unknown error!!!"
+msgstr "IFF: onbekende fout!!!"
+
+#: ../src/common/imagiff.cpp:755
+msgid "IFF: data stream seems to be truncated."
+msgstr "IFFF: gegevensstroom lijkt afgekapt."
+
+#: ../src/common/imagjpeg.cpp:258
+msgid "JPEG: Couldn't load - file is probably corrupted."
+msgstr "JPEG: kon niet laden - bestand is waarschijnlijk corrupt."
+
+#: ../src/common/imagjpeg.cpp:437
+msgid "JPEG: Couldn't save image."
+msgstr "JPEG: kon afbeelding niet opslaan."
+
+#: ../src/common/imagpcx.cpp:439
+msgid "PCX: this is not a PCX file."
+msgstr "PCX: dit is geen PCX-bestand."
+
+#: ../src/common/imagpcx.cpp:453
+msgid "PCX: image format unsupported"
+msgstr "PCX: bestandsformaat niet ondersteund"
+
+#: ../src/common/imagpcx.cpp:454 ../src/common/imagpcx.cpp:477
+msgid "PCX: couldn't allocate memory"
+msgstr "PCX: kon geen geheugen reserveren"
+
+#: ../src/common/imagpcx.cpp:455
+msgid "PCX: version number too low"
+msgstr "PCX: versienummer te laag"
+
+#: ../src/common/imagpcx.cpp:456 ../src/common/imagpcx.cpp:478
+msgid "PCX: unknown error !!!"
+msgstr "PCX: onbekende fout!"
+
+#: ../src/common/imagpcx.cpp:476
+msgid "PCX: invalid image"
+msgstr "PCX: ongeldige afbeelding"
+
+#: ../src/common/imagpng.cpp:385
+#, c-format
+msgid "Unknown PNG resolution unit %d"
+msgstr "Onbekende PNG resolutie eenheid %d"
+
+#: ../src/common/imagpng.cpp:439
+msgid "Couldn't load a PNG image - file is corrupted or not enough memory."
+msgstr ""
+"Kon PNG-afbeelding niet laden: bestand is corrupt of onvoldoende geheugen."
+
+#: ../src/common/imagpng.cpp:513 ../src/common/imagpng.cpp:524
+#: ../src/common/imagpng.cpp:534
+msgid "Couldn't save PNG image."
+msgstr "Kon PNG afbeelding niet opslaan."
+
+#: ../src/common/imagpnm.cpp:71
+msgid "PNM: File format is not recognized."
+msgstr "PNM: Bestandsindeling wordt niet herkend."
+
+#: ../src/common/imagpnm.cpp:89
+msgid "PNM: Couldn't allocate memory."
+msgstr "PNM: kon geen geheugen reserveren."
+
+#: ../src/common/imagpnm.cpp:111 ../src/common/imagpnm.cpp:134
+#: ../src/common/imagpnm.cpp:156
+msgid "PNM: File seems truncated."
+msgstr "PNM: bestand lijkt afgekapt."
+
+#: ../src/common/imagtiff.cpp:69
+#, c-format
+msgid " (in module \"%s\")"
+msgstr " (in module \"%s\")"
+
+#: ../src/common/imagtiff.cpp:304
+msgid "TIFF: Error loading image."
+msgstr "TIFF: fout bij laden van afbeelding."
+
+#: ../src/common/imagtiff.cpp:314
+msgid "Invalid TIFF image index."
+msgstr "Ongeldige TIFF-afbeeldingsindex."
+
+#: ../src/common/imagtiff.cpp:358
+msgid "TIFF: Image size is abnormally big."
+msgstr "TIFF: Afbeeldingsgrootte is abnormaal groot."
+
+#: ../src/common/imagtiff.cpp:372 ../src/common/imagtiff.cpp:385
+#: ../src/common/imagtiff.cpp:769
+msgid "TIFF: Couldn't allocate memory."
+msgstr "TIFF: kon geen geheugen reserveren."
+
+#: ../src/common/imagtiff.cpp:471
+msgid "TIFF: Error reading image."
+msgstr "TIFF: fout bij lezen van afbeelding."
+
+#: ../src/common/imagtiff.cpp:532
+#, c-format
+msgid "Unknown TIFF resolution unit %d ignored"
+msgstr "Onbekende TIFF resolutie eenheid%d genegeerd"
+
+#: ../src/common/imagtiff.cpp:611
+msgid "TIFF: Error saving image."
+msgstr "TIFF: fout bij opslaan van afbeelding."
+
+#: ../src/common/imagtiff.cpp:868
+msgid "TIFF: Error writing image."
+msgstr "TIFF: fout bij schrijven van afbeelding."
+
+#: ../src/common/imagtiff.cpp:881
+#, fuzzy
+msgid "TIFF: Error flushing data."
+msgstr "TIFF: fout bij opslaan van afbeelding."
+
+#: ../src/common/imagwebp.cpp:56
+msgid "WebP: Invalid data (failed to get features)."
+msgstr ""
+
+#: ../src/common/imagwebp.cpp:65
+msgid "WebP: Allocating image memory failed."
+msgstr ""
+
+#: ../src/common/imagwebp.cpp:82
+msgid "WebP: Decoding RGBA image data failed."
+msgstr ""
+
+#: ../src/common/imagwebp.cpp:98
+msgid "WebP: Decoding RGB image data failed."
+msgstr ""
+
+#: ../src/common/imagwebp.cpp:113 ../src/common/imagwebp.cpp:201
+msgid "WebP: Allocating stream buffer failed."
+msgstr ""
+
+#: ../src/common/imagwebp.cpp:131
+#, fuzzy
+msgid "WebP: Failed to parse container data."
+msgstr "Instellen van klembordgegevens mislukt."
+
+#: ../src/common/imagwebp.cpp:222
+#, fuzzy
+msgid "WebP: Error decoding animation."
+msgstr "Fout bij lezen van configuratie opties."
+
+#: ../src/common/imagwebp.cpp:240
+msgid "WebP: Error getting next animation frame."
+msgstr ""
+
+#: ../src/common/init.cpp:172
+#, c-format
+msgid ""
+"Command line argument %d couldn't be converted to Unicode and will be "
+"ignored."
+msgstr ""
+"Commandoregel argument %d kon niet omgezet worden naar Unicode en zal worden "
+"genegeerd."
+
+#: ../src/common/init.cpp:344
+msgid "Initialization failed in post init, aborting."
+msgstr "Initialisatie mislukt in post init: voortijdig beëindigd.."
+
+#: ../src/common/intl.cpp:378
+#, c-format
+msgid "Cannot set locale to language \"%s\"."
+msgstr "Kan de lokale niet naar Taal \"%s\" omzetten."
+
+#: ../src/common/log.cpp:232
+msgid "Error: "
+msgstr "Fout: "
+
+#: ../src/common/log.cpp:236
+msgid "Warning: "
+msgstr "Waarschuwing: "
+
+#: ../src/common/log.cpp:284
+msgid "The previous message repeated once."
+msgstr "Het vorige bericht eenmaal herhaald."
+
+#: ../src/common/log.cpp:291
+#, c-format
+msgid "The previous message repeated %u time."
+msgid_plural "The previous message repeated %u times."
+msgstr[0] "Het vorige bericht  is %u keer herhaald."
+msgstr[1] "Het vorige berichten zijn  %u keer herhaald."
+
+#: ../src/common/log.cpp:319
+#, c-format
+msgid "Last repeated message (\"%s\", %u time) wasn't output"
+msgid_plural "Last repeated message (\"%s\", %u times) wasn't output"
+msgstr[0] "Laatst herhaald bericht (\"%s\", %u keer) is niet uitgevoerd"
+msgstr[1] "Laatst herhaald berichten (\"%s\", %u keer) zijn niet uitgevoerd"
+
+#: ../src/common/log.cpp:435
+#, c-format
+msgid " (error %ld: %s)"
+msgstr " (fout %ld: %s)"
+
+#: ../src/common/lzmastream.cpp:121
+msgid "Failed to allocate memory for LZMA decompression."
+msgstr "Kan geen geheugen toewijzen voor LZMA-decompressie."
+
+#: ../src/common/lzmastream.cpp:125
+#, c-format
+msgid "Failed to initialize LZMA decompression: unexpected error %u."
+msgstr "Initiëring LZMA decompressie mislukt: onverwachte fout %u."
+
+#: ../src/common/lzmastream.cpp:179
+msgid "input is not in XZ format"
+msgstr "input is niet in XZ formaat"
+
+#: ../src/common/lzmastream.cpp:183
+msgid "input compressed using unknown XZ option"
+msgstr "input gecomprimeerd met gebruik van onbekende XZ optie"
+
+#: ../src/common/lzmastream.cpp:188
+msgid "input is corrupted"
+msgstr "input is gecorrumpeerd"
+
+#: ../src/common/lzmastream.cpp:192
+msgid "unknown decompression error"
+msgstr "onbekende decompressiefout"
+
+#: ../src/common/lzmastream.cpp:196
+#, c-format
+msgid "LZMA decompression error: %s"
+msgstr "LZMA decompressie fout: %s"
+
+#: ../src/common/lzmastream.cpp:231
+msgid "Failed to allocate memory for LZMA compression."
+msgstr "Kan geen geheugen toewijzen voor LZMA-compressie."
+
+#: ../src/common/lzmastream.cpp:235
+#, c-format
+msgid "Failed to initialize LZMA compression: unexpected error %u."
+msgstr "Initiëring LZMA compressie mislukt: onverwachte fout %u."
+
+#: ../src/common/lzmastream.cpp:267 ../src/common/lzmastream.cpp:342
+#: ../src/html/chm.cpp:336
+msgid "out of memory"
+msgstr "geheugen uitgeput"
+
+#: ../src/common/lzmastream.cpp:276 ../src/common/lzmastream.cpp:346
+msgid "unknown compression error"
+msgstr "onbekende compressiefout"
+
+#: ../src/common/lzmastream.cpp:280
+#, c-format
+msgid "LZMA compression error: %s"
+msgstr "LZMA-compressiefout: %s"
+
+#: ../src/common/lzmastream.cpp:350
+#, c-format
+msgid "LZMA compression error when flushing output: %s"
+msgstr "LZMA compressiefout tijdens wurging van de output: %s"
+
+#: ../src/common/mimecmn.cpp:167
+#, c-format
+msgid "Unmatched '{' in an entry for mime type %s."
+msgstr "Niet afgesloten '{' in ingang voor mime-type %s."
+
+#: ../src/common/module.cpp:76
+#, c-format
+msgid "Circular dependency involving module \"%s\" detected."
+msgstr ""
+"Circulaire afhankelijkheid met betrekking tot module ‘%s’ gedetecteerd."
+
+#: ../src/common/module.cpp:128
+#, c-format
+msgid "Dependency \"%s\" of module \"%s\" doesn't exist."
+msgstr "Afhankelijkheid \"%s\" van module \"%s\" bestaat niet."
+
+#: ../src/common/module.cpp:137
+#, c-format
+msgid "Module \"%s\" initialization failed"
+msgstr "Initialisatie Module \"%s\" mislukt"
+
+#: ../src/common/msgout.cpp:96
+msgid "Message"
+msgstr "Bericht"
+
+#: ../src/common/paper.cpp:70
+msgid "Letter, 8 1/2 x 11 in"
+msgstr "Letter, 8 1/2 x 11 inch"
+
+#: ../src/common/paper.cpp:71
+msgid "Legal, 8 1/2 x 14 in"
+msgstr "USA Legal, 8 1/2 x 14 inch"
+
+#: ../src/common/paper.cpp:72
+msgid "A4 sheet, 210 x 297 mm"
+msgstr "A4, 210 x 297 mm"
+
+#: ../src/common/paper.cpp:73
+msgid "C sheet, 17 x 22 in"
+msgstr "C, 17 x 22 inch"
+
+#: ../src/common/paper.cpp:74
+msgid "D sheet, 22 x 34 in"
+msgstr "D, 22 x34 inch"
+
+#: ../src/common/paper.cpp:75
+msgid "E sheet, 34 x 44 in"
+msgstr "E, 34 x 44 inch"
+
+#: ../src/common/paper.cpp:76
+msgid "Letter Small, 8 1/2 x 11 in"
+msgstr "Letter Klein, 8 1/2 x 11 inch"
+
+#: ../src/common/paper.cpp:77
+msgid "Tabloid, 11 x 17 in"
+msgstr "USA Tabloid, 11 x 17 inch"
+
+#: ../src/common/paper.cpp:78
+msgid "Ledger, 17 x 11 in"
+msgstr "USA Ledger, 17 x 11 inch"
+
+#: ../src/common/paper.cpp:79
+msgid "Statement, 5 1/2 x 8 1/2 in"
+msgstr "USA Statement, 5 1/2 x 8 1/2 inch"
+
+#: ../src/common/paper.cpp:80
+msgid "Executive, 7 1/4 x 10 1/2 in"
+msgstr "USA Executive, 7 1/4 x 10 1/2 inch"
+
+#: ../src/common/paper.cpp:81
+msgid "A3 sheet, 297 x 420 mm"
+msgstr "A3, 297 x 420 mm"
+
+#: ../src/common/paper.cpp:82
+msgid "A4 small sheet, 210 x 297 mm"
+msgstr "A4 klein, 210 x 297 mm"
+
+#: ../src/common/paper.cpp:83
+msgid "A5 sheet, 148 x 210 mm"
+msgstr "A5, 148 x 210 mm"
+
+#: ../src/common/paper.cpp:84
+msgid "B4 sheet, 250 x 354 mm"
+msgstr "B4, 250 x 354 mm"
+
+#: ../src/common/paper.cpp:85
+msgid "B5 sheet, 182 x 257 millimeter"
+msgstr "B5, 182, 257 mm"
+
+#: ../src/common/paper.cpp:86
+msgid "Folio, 8 1/2 x 13 in"
+msgstr "Folio, 8 1/2 x 13 inch"
+
+#: ../src/common/paper.cpp:87
+msgid "Quarto, 215 x 275 mm"
+msgstr "Kwarto, 215 x 275 mm"
+
+#: ../src/common/paper.cpp:88
+msgid "10 x 14 in"
+msgstr "10 x 14 inch"
+
+#: ../src/common/paper.cpp:89
+msgid "11 x 17 in"
+msgstr "11 x 17 inch"
+
+#: ../src/common/paper.cpp:90
+msgid "Note, 8 1/2 x 11 in"
+msgstr "Notitie, 8 1/2 x 11 inch"
+
+#: ../src/common/paper.cpp:91
+msgid "#9 Envelope, 3 7/8 x 8 7/8 in"
+msgstr "Envelop nr.9, 3 7/8 x 8 7/8 inch"
+
+#: ../src/common/paper.cpp:92
+msgid "#10 Envelope, 4 1/8 x 9 1/2 in"
+msgstr "Envelop nr.10, 4 1/8 x 9 1/2 inch"
+
+#: ../src/common/paper.cpp:93
+msgid "#11 Envelope, 4 1/2 x 10 3/8 in"
+msgstr "Envelop nr.11, 4 1/2 x 10 3/8 inch"
+
+#: ../src/common/paper.cpp:94
+msgid "#12 Envelope, 4 3/4 x 11 in"
+msgstr "Envelop nr.12, 4 3/4 x 11 inch"
+
+#: ../src/common/paper.cpp:95
+msgid "#14 Envelope, 5 x 11 1/2 in"
+msgstr "Envelop nr.14, 5 x 11 1/2 inch"
+
+#: ../src/common/paper.cpp:96
+msgid "DL Envelope, 110 x 220 mm"
+msgstr "Envelop DL, 110 x 220 mm"
+
+#: ../src/common/paper.cpp:97
+msgid "C5 Envelope, 162 x 229 mm"
+msgstr "Envelop C5, 162 x 229 mm"
+
+#: ../src/common/paper.cpp:98
+msgid "C3 Envelope, 324 x 458 mm"
+msgstr "Envelop C3, 324 x 458 mm"
+
+#: ../src/common/paper.cpp:99
+msgid "C4 Envelope, 229 x 324 mm"
+msgstr "Envelop C4, 229 x 324 mm"
+
+#: ../src/common/paper.cpp:100
+msgid "C6 Envelope, 114 x 162 mm"
+msgstr "Envelop C6, 114 x 162 mm"
+
+#: ../src/common/paper.cpp:101
+msgid "C65 Envelope, 114 x 229 mm"
+msgstr "Envelop C65, 114 x 229 mm"
+
+#: ../src/common/paper.cpp:102
+msgid "B4 Envelope, 250 x 353 mm"
+msgstr "Envelop B4, 250 x 353 mm"
+
+#: ../src/common/paper.cpp:103
+msgid "B5 Envelope, 176 x 250 mm"
+msgstr "Envelop B5, 176 x 250 mm"
+
+#: ../src/common/paper.cpp:104
+msgid "B6 Envelope, 176 x 125 mm"
+msgstr "Envelop B6, 176 x 125 mm"
+
+#: ../src/common/paper.cpp:105
+msgid "Italy Envelope, 110 x 230 mm"
+msgstr "Envelop 'Italy', 110 x 230 mm"
+
+#: ../src/common/paper.cpp:106
+msgid "Monarch Envelope, 3 7/8 x 7 1/2 in"
+msgstr "Envelop 'Monarch', 3 7/8 x 7 1/2 inch"
+
+#: ../src/common/paper.cpp:107
+msgid "6 3/4 Envelope, 3 5/8 x 6 1/2 in"
+msgstr "6 3/4 envelop, 3 5/8 x 6 1/2 inch"
+
+#: ../src/common/paper.cpp:108
+msgid "US Std Fanfold, 14 7/8 x 11 in"
+msgstr "USA Std Fanfold, 14 7/8 x 11 inch"
+
+#: ../src/common/paper.cpp:109
+msgid "German Std Fanfold, 8 1/2 x 12 in"
+msgstr "Duitse Std Fanfold, 8 1/2 x 12 inch"
+
+#: ../src/common/paper.cpp:110
+msgid "German Legal Fanfold, 8 1/2 x 13 in"
+msgstr "Duitse Legal Fanfold, 8 1/2 x 13 inch"
+
+#: ../src/common/paper.cpp:112
+msgid "B4 (ISO) 250 x 353 mm"
+msgstr "B4 (ISO) 250 x 353 mm"
+
+#: ../src/common/paper.cpp:113
+msgid "Japanese Postcard 100 x 148 mm"
+msgstr "Japanse Briefkaart 100 x 148 mm"
+
+#: ../src/common/paper.cpp:114
+msgid "9 x 11 in"
+msgstr "9 x 11 inch"
+
+#: ../src/common/paper.cpp:115
+msgid "10 x 11 in"
+msgstr "10 x 11 inch"
+
+#: ../src/common/paper.cpp:116
+msgid "15 x 11 in"
+msgstr "15 x 11 inch"
+
+#: ../src/common/paper.cpp:117
+msgid "Envelope Invite 220 x 220 mm"
+msgstr "Envelop Invite 220 x 220 mm"
+
+#: ../src/common/paper.cpp:118
+msgid "Letter Extra 9 1/2 x 12 in"
+msgstr "Letter Extra 9 1/2 x 12 in"
+
+#: ../src/common/paper.cpp:119
+msgid "Legal Extra 9 1/2 x 15 in"
+msgstr "Legal Extra 9 1/2 x 15 in"
+
+#: ../src/common/paper.cpp:120
+msgid "Tabloid Extra 11.69 x 18 in"
+msgstr "Tabloid Extra 11.69 x 18 in"
+
+#: ../src/common/paper.cpp:121
+msgid "A4 Extra 9.27 x 12.69 in"
+msgstr "A4 Extra 9.27 x 12.69 inch"
+
+#: ../src/common/paper.cpp:122
+msgid "Letter Transverse 8 1/2 x 11 in"
+msgstr "Letter Transverse 8 1/2 x 11 in"
+
+#: ../src/common/paper.cpp:123
+msgid "A4 Transverse 210 x 297 mm"
+msgstr "A4 Transverse 210 x 297 mm"
+
+#: ../src/common/paper.cpp:124
+msgid "Letter Extra Transverse 9.275 x 12 in"
+msgstr "Letter Extra Transverse 9.275 x 12 in"
+
+#: ../src/common/paper.cpp:125
+msgid "SuperA/SuperA/A4 227 x 356 mm"
+msgstr "SuperA/SuperA/A4 227 x 356 mm"
+
+#: ../src/common/paper.cpp:126
+msgid "SuperB/SuperB/A3 305 x 487 mm"
+msgstr "SuperB/SuperB/A3 305 x 487 mm"
+
+#: ../src/common/paper.cpp:127
+msgid "Letter Plus 8 1/2 x 12.69 in"
+msgstr "Letter Plus 8 1/2 x 12.69 in"
+
+#: ../src/common/paper.cpp:128
+msgid "A4 Plus 210 x 330 mm"
+msgstr "A4 Plus 210 x 330 mm"
+
+#: ../src/common/paper.cpp:129
+msgid "A5 Transverse 148 x 210 mm"
+msgstr "A5 Transverse 148 x 210 mm"
+
+#: ../src/common/paper.cpp:130
+msgid "B5 (JIS) Transverse 182 x 257 mm"
+msgstr "B5 (JIS) Transverse 182 x 257 mm"
+
+#: ../src/common/paper.cpp:131
+msgid "A3 Extra 322 x 445 mm"
+msgstr "A3 Extra 322 x 445 mm"
+
+#: ../src/common/paper.cpp:132
+msgid "A5 Extra 174 x 235 mm"
+msgstr "A5 Extra 174 x 235 mm"
+
+#: ../src/common/paper.cpp:133
+msgid "B5 (ISO) Extra 201 x 276 mm"
+msgstr "B5 (ISO) Extra 201 x 276 mm"
+
+#: ../src/common/paper.cpp:134
+msgid "A2 420 x 594 mm"
+msgstr "A2 420 x 594 mm"
+
+#: ../src/common/paper.cpp:135
+msgid "A3 Transverse 297 x 420 mm"
+msgstr "A3 Transverse 297 x 420 mm"
+
+#: ../src/common/paper.cpp:136
+msgid "A3 Extra Transverse 322 x 445 mm"
+msgstr "A3 Extra Transverse 322 x 445 mm"
+
+#: ../src/common/paper.cpp:138
+msgid "Japanese Double Postcard 200 x 148 mm"
+msgstr "Japanse Dubbele Briefkaart 200 x 148 mm"
+
+#: ../src/common/paper.cpp:139
+msgid "A6 105 x 148 mm"
+msgstr "A6 105 x 148 mm"
+
+#: ../src/common/paper.cpp:140
+msgid "Japanese Envelope Kaku #2"
+msgstr "Japanse Envelop Kaku #2"
+
+#: ../src/common/paper.cpp:141
+msgid "Japanese Envelope Kaku #3"
+msgstr "Japanse Envelop Kaku #3"
+
+#: ../src/common/paper.cpp:142
+msgid "Japanese Envelope Chou #3"
+msgstr "Japanse Envelop Chou #3"
+
+#: ../src/common/paper.cpp:143
+msgid "Japanese Envelope Chou #4"
+msgstr "Japanse Envelop Chou #4"
+
+#: ../src/common/paper.cpp:144
+msgid "Letter Rotated 11 x 8 1/2 in"
+msgstr "Letter Gedraaid 11 x 8 1/2 in"
+
+#: ../src/common/paper.cpp:145
+msgid "A3 Rotated 420 x 297 mm"
+msgstr "A3 gedraaid 420 x 297 mm"
+
+#: ../src/common/paper.cpp:146
+msgid "A4 Rotated 297 x 210 mm"
+msgstr "A4 gedraaid 297 x 210 mm"
+
+#: ../src/common/paper.cpp:147
+msgid "A5 Rotated 210 x 148 mm"
+msgstr "A5 gedraaid 210 x 148 mm"
+
+#: ../src/common/paper.cpp:148
+msgid "B4 (JIS) Rotated 364 x 257 mm"
+msgstr "B4 (JIS) gedraaid 364 x 257 mm"
+
+#: ../src/common/paper.cpp:149
+msgid "B5 (JIS) Rotated 257 x 182 mm"
+msgstr "B5 (JIS) gedraaid 257 x 182 mm"
+
+#: ../src/common/paper.cpp:150
+msgid "Japanese Postcard Rotated 148 x 100 mm"
+msgstr "Japanse Breifkaart Gedraaid 148 x 100 mm"
+
+#: ../src/common/paper.cpp:151
+msgid "Double Japanese Postcard Rotated 148 x 200 mm"
+msgstr "Dubbele Japanse briefkaart gedraaid 148 x 200 mm"
+
+#: ../src/common/paper.cpp:152
+msgid "A6 Rotated 148 x 105 mm"
+msgstr "A6 gedraaid 148 x 105 mm"
+
+#: ../src/common/paper.cpp:153
+msgid "Japanese Envelope Kaku #2 Rotated"
+msgstr "Japanse Envelop Kaku #2 Gedraaid"
+
+#: ../src/common/paper.cpp:154
+msgid "Japanese Envelope Kaku #3 Rotated"
+msgstr "Japanse Envelop Kaku #3 Gedraaid"
+
+#: ../src/common/paper.cpp:155
+msgid "Japanese Envelope Chou #3 Rotated"
+msgstr "Japanse Envelop Chou #3 gedraaid"
+
+#: ../src/common/paper.cpp:156
+msgid "Japanese Envelope Chou #4 Rotated"
+msgstr "Japanse Envelop Chou #4 Gedraaid"
+
+#: ../src/common/paper.cpp:157
+msgid "B6 (JIS) 128 x 182 mm"
+msgstr "B6 (JIS) 128 x 182 mm"
+
+#: ../src/common/paper.cpp:158
+msgid "B6 (JIS) Rotated 182 x 128 mm"
+msgstr "B6 (JIS) gedraaid 182 x 128 mm"
+
+#: ../src/common/paper.cpp:159
+msgid "12 x 11 in"
+msgstr "12 x 11 inch"
+
+#: ../src/common/paper.cpp:160
+msgid "Japanese Envelope You #4"
+msgstr "Japanse Envelop You #4"
+
+#: ../src/common/paper.cpp:161
+msgid "Japanese Envelope You #4 Rotated"
+msgstr "Japanse Envelop You #4 Gedraaid"
+
+#: ../src/common/paper.cpp:162
+msgid "PRC 16K 146 x 215 mm"
+msgstr "PRC 16K 146 x 215 mm"
+
+#: ../src/common/paper.cpp:163
+msgid "PRC 32K 97 x 151 mm"
+msgstr "PRC 32K 97 x 151 mm"
+
+#: ../src/common/paper.cpp:164
+msgid "PRC 32K(Big) 97 x 151 mm"
+msgstr "PRC 32K(Big) 97 x 151 mm"
+
+#: ../src/common/paper.cpp:165
+msgid "PRC Envelope #1 102 x 165 mm"
+msgstr "PRC Envelop #1 102 x 165 mm"
+
+#: ../src/common/paper.cpp:166
+msgid "PRC Envelope #2 102 x 176 mm"
+msgstr "PRC Envelop #2 102 x 176 mm"
+
+#: ../src/common/paper.cpp:167
+msgid "PRC Envelope #3 125 x 176 mm"
+msgstr "PRC Envelop #3 125 x 176 mm"
+
+#: ../src/common/paper.cpp:168
+msgid "PRC Envelope #4 110 x 208 mm"
+msgstr "PRC Envelop #4 110 x 208 mm"
+
+#: ../src/common/paper.cpp:169
+msgid "PRC Envelope #5 110 x 220 mm"
+msgstr "PRC Envelop #5 110 x 220 mm"
+
+#: ../src/common/paper.cpp:170
+msgid "PRC Envelope #6 120 x 230 mm"
+msgstr "PRC Envelop #6 120 x 230 mm"
+
+#: ../src/common/paper.cpp:171
+msgid "PRC Envelope #7 160 x 230 mm"
+msgstr "PRC Envelop #7 160 x 230 mm"
+
+#: ../src/common/paper.cpp:172
+msgid "PRC Envelope #8 120 x 309 mm"
+msgstr "PRC Envelop #8 120 x 309 mm"
+
+#: ../src/common/paper.cpp:173
+msgid "PRC Envelope #9 229 x 324 mm"
+msgstr "PRC Envelop #9 229 x 324 mm"
+
+#: ../src/common/paper.cpp:174
+msgid "PRC Envelope #10 324 x 458 mm"
+msgstr "PRC Envelop #10 324 x 458 mm"
+
+#: ../src/common/paper.cpp:175
+msgid "PRC 16K Rotated"
+msgstr "PRC 16K Gedraaid"
+
+#: ../src/common/paper.cpp:176
+msgid "PRC 32K Rotated"
+msgstr "PRC 32K Gedraaid"
+
+#: ../src/common/paper.cpp:177
+msgid "PRC 32K(Big) Rotated"
+msgstr "PRC 32K(Groot) Gedraaid"
+
+#: ../src/common/paper.cpp:178
+msgid "PRC Envelope #1 Rotated 165 x 102 mm"
+msgstr "PRC Envelop #1 Gedraaid 165 x 102 mm"
+
+#: ../src/common/paper.cpp:179
+msgid "PRC Envelope #2 Rotated 176 x 102 mm"
+msgstr "PRC Envelop #2 Gedraaid 176 x 102 mm"
+
+#: ../src/common/paper.cpp:180
+msgid "PRC Envelope #3 Rotated 176 x 125 mm"
+msgstr "PRC Envelop #3 Gedraaid 176 x 125 mm"
+
+#: ../src/common/paper.cpp:181
+msgid "PRC Envelope #4 Rotated 208 x 110 mm"
+msgstr "PRC Envelop #4 Gedraaid 208 x 110 mm"
+
+#: ../src/common/paper.cpp:182
+msgid "PRC Envelope #5 Rotated 220 x 110 mm"
+msgstr "PRC Envelop #5 Gedraaid 220 x 110 mm"
+
+#: ../src/common/paper.cpp:183
+msgid "PRC Envelope #6 Rotated 230 x 120 mm"
+msgstr "PRC Envelop #6 Gedraaid 230 x 120 mm"
+
+#: ../src/common/paper.cpp:184
+msgid "PRC Envelope #7 Rotated 230 x 160 mm"
+msgstr "PRC Envelop #7 Gedraaid 230 x 160 mm"
+
+#: ../src/common/paper.cpp:185
+msgid "PRC Envelope #8 Rotated 309 x 120 mm"
+msgstr "PRC Envelop #8 Gedraaid 309 x 120 mm"
+
+#: ../src/common/paper.cpp:186
+msgid "PRC Envelope #9 Rotated 324 x 229 mm"
+msgstr "PRC Envelop #9 Gedraaid 324 x 229 mm"
+
+#: ../src/common/paper.cpp:187
+msgid "PRC Envelope #10 Rotated 458 x 324 mm"
+msgstr "PRC Envelop #10 Gedraaid 458 x 324 mm"
+
+#: ../src/common/paper.cpp:192
+msgid "A0 sheet, 841 x 1189 mm"
+msgstr "A0, 841 x 1189 mm"
+
+#: ../src/common/paper.cpp:193
+msgid "A1 sheet, 594 x 841 mm"
+msgstr "A1, 594 x 841 mm"
+
+#: ../src/common/preferencescmn.cpp:37
+msgid "General"
+msgstr "Algemeen"
+
+#: ../src/common/preferencescmn.cpp:40
+msgid "Advanced"
+msgstr "Geavanceerd"
+
+#: ../src/common/prntbase.cpp:245
+msgid "Generic PostScript"
+msgstr "Generiek Postscript"
+
+#: ../src/common/prntbase.cpp:259
+msgid "Ready"
+msgstr "Gereed"
+
+#: ../src/common/prntbase.cpp:331
+msgid "Printing Error"
+msgstr "Afdrukfout"
+
+#: ../src/common/prntbase.cpp:413 ../src/common/prntbase.cpp:1597
+#: ../src/generic/prntdlgg.cpp:135 ../src/generic/prntdlgg.cpp:149
+#: ../src/gtk/print.cpp:628 ../src/gtk/print.cpp:646
+msgid "Print"
+msgstr "Afdrukken"
+
+#: ../src/common/prntbase.cpp:471 ../src/generic/prntdlgg.cpp:809
+msgid "Page setup"
+msgstr "Pagina instellingen"
+
+#: ../src/common/prntbase.cpp:525
+msgid "Please wait while printing..."
+msgstr "Een ogenblik geduld. Bezig met printen..."
+
+#: ../src/common/prntbase.cpp:529
+msgid "Document:"
+msgstr "Document:"
+
+#: ../src/common/prntbase.cpp:532
+msgid "Progress:"
+msgstr "Voortgang:"
+
+#: ../src/common/prntbase.cpp:533
+msgid "Preparing"
+msgstr "Voorbereiden"
+
+#: ../src/common/prntbase.cpp:552
+#, c-format
+msgid "Printing page %d"
+msgstr "Bezig met afdrukken van pagina %d"
+
+#: ../src/common/prntbase.cpp:557
+#, c-format
+msgid "Printing page %d of %d"
+msgstr "Bezig met afdrukken van pagina %d van %d"
+
+#: ../src/common/prntbase.cpp:560
+#, c-format
+msgid " (copy %d of %d)"
+msgstr " (%d van %d kopiëren)"
+
+#: ../src/common/prntbase.cpp:1604
+msgid "First page"
+msgstr "Eerste pagina"
+
+#: ../src/common/prntbase.cpp:1609 ../src/html/helpwnd.cpp:659
+msgid "Previous page"
+msgstr "Vorige pagina"
+
+#: ../src/common/prntbase.cpp:1623 ../src/html/helpwnd.cpp:660
+msgid "Next page"
+msgstr "Volgende pagina"
+
+#: ../src/common/prntbase.cpp:1628
+msgid "Last page"
+msgstr "Laatste pagina"
+
+#: ../src/common/prntbase.cpp:1636 ../src/common/stockitem.cpp:215
+msgid "Zoom Out"
+msgstr "Uitzoomen"
+
+#: ../src/common/prntbase.cpp:1650 ../src/common/stockitem.cpp:214
+msgid "Zoom In"
+msgstr "Inzoomen"
+
+#: ../src/common/prntbase.cpp:1656 ../src/common/stockitem.cpp:153
+#: ../src/generic/logg.cpp:553 ../src/univ/themes/win32.cpp:3752
+msgid "&Close"
+msgstr "&Sluiten"
+
+#: ../src/common/prntbase.cpp:2085
+msgid "Could not start document preview."
+msgstr "Kon afdrukvoorbeeld niet starten."
+
+#: ../src/common/prntbase.cpp:2085 ../src/common/prntbase.cpp:2129
+#: ../src/common/prntbase.cpp:2137
+msgid "Print Preview Failure"
+msgstr "Afdrukvoorbeeld mislukt"
+
+#: ../src/common/prntbase.cpp:2129 ../src/common/prntbase.cpp:2137
+msgid "Sorry, not enough memory to create a preview."
+msgstr "Sorry, onvoldoende geheugen voor afdrukweergave."
+
+#: ../src/common/prntbase.cpp:2144
+#, c-format
+msgid "Page %d of %d"
+msgstr "Pagina %d van %d"
+
+#: ../src/common/prntbase.cpp:2146
+#, c-format
+msgid "Page %d"
+msgstr "Pagina %d"
+
+#: ../src/common/regex.cpp:382 ../src/html/chm.cpp:348
+msgid "unknown error"
+msgstr "onbekende fout"
+
+#: ../src/common/regex.cpp:995
+#, c-format
+msgid "Invalid regular expression '%s': %s"
+msgstr "Ongeldige reguliere expressie '%s': %s"
+
+#: ../src/common/regex.cpp:1059
+#, c-format
+msgid "Failed to find match for regular expression: %s"
+msgstr "Vinden van overeenkomst voor reguliere expressie '%s' mislukt"
+
+#: ../src/common/rendcmn.cpp:188
+#, c-format
+msgid "Renderer \"%s\" has incompatible version %d.%d and couldn't be loaded."
+msgstr ""
+"Renderer \"%s\" heeft incompatibele versie %d.%d en kan niet worden geladen."
+
+#: ../src/common/secretstore.cpp:162
+msgid "Not available for this platform"
+msgstr "Niet beschikbaar op dit platform"
+
+#: ../src/common/secretstore.cpp:183
+#, c-format
+msgid "Saving password for \"%s\" failed: %s."
+msgstr "Het opslaan van wachtwoord voor “%s” is mislukt: %s."
+
+#: ../src/common/secretstore.cpp:205
+#, c-format
+msgid "Reading password for \"%s\" failed: %s."
+msgstr "Het lezen van wachtwoord voor \"%s\" is mislukt: %s."
+
+#: ../src/common/secretstore.cpp:228
+#, c-format
+msgid "Deleting password for \"%s\" failed: %s."
+msgstr "Het verwijderen van het wachtwoord voor \"%s\" is mislukt: %s."
+
+#: ../src/common/selectdispatcher.cpp:254
+msgid "Failed to monitor I/O channels"
+msgstr "Toezicht houden op I/O kanalen mislukt"
+
+#: ../src/common/sizer.cpp:3054 ../src/common/stockitem.cpp:195
+msgid "Save"
+msgstr "Bewaren"
+
+#: ../src/common/sizer.cpp:3056
+msgid "Don't Save"
+msgstr "Niet Opslaan"
+
+#: ../src/common/socket.cpp:870
+msgid "Cannot initialize sockets"
+msgstr "Kan sockets niet initiëren"
+
+#: ../src/common/stockitem.cpp:127
+msgctxt "standard Windows menu"
+msgid "&Help"
+msgstr "&Help"
+
+#: ../src/common/stockitem.cpp:144
+msgid "&About"
+msgstr "&Over"
+
+#: ../src/common/stockitem.cpp:144
+msgid "About"
+msgstr "Over"
+
+#: ../src/common/stockitem.cpp:145
+msgid "Add"
+msgstr "Toevoegen"
+
+#: ../src/common/stockitem.cpp:146
+msgid "&Apply"
+msgstr "Toe&passen"
+
+#: ../src/common/stockitem.cpp:146
+msgid "Apply"
+msgstr "Toepassen"
+
+#: ../src/common/stockitem.cpp:147
+msgid "&Back"
+msgstr "&Terug"
+
+#: ../src/common/stockitem.cpp:147
+msgid "Back"
+msgstr "Terug"
+
+#: ../src/common/stockitem.cpp:148
+msgid "&Bold"
+msgstr "&Vet"
+
+#: ../src/common/stockitem.cpp:148 ../src/generic/fontdlgg.cpp:326
+#: ../src/richtext/richtextfontpage.cpp:354
+msgid "Bold"
+msgstr "Vet"
+
+#: ../src/common/stockitem.cpp:149
+msgid "&Bottom"
+msgstr "&Bodem"
+
+#: ../src/common/stockitem.cpp:149 ../src/richtext/richtextsizepage.cpp:287
+msgid "Bottom"
+msgstr "Bodem"
+
+#: ../src/common/stockitem.cpp:150 ../src/generic/fontdlgg.cpp:462
+#: ../src/generic/fontdlgg.cpp:481 ../src/generic/wizard.cpp:415
+msgid "&Cancel"
+msgstr "&Annuleren"
+
+#: ../src/common/stockitem.cpp:151
+msgid "&CD-ROM"
+msgstr "&CD-rom"
+
+#: ../src/common/stockitem.cpp:151
+msgid "CD-ROM"
+msgstr "CD-Rom"
+
+#: ../src/common/stockitem.cpp:152
+msgid "&Clear"
+msgstr "&Wissen"
+
+#: ../src/common/stockitem.cpp:152
+msgid "Clear"
+msgstr "Wissen"
+
+#: ../src/common/stockitem.cpp:153 ../src/generic/dbgrptg.cpp:93
+#: ../src/generic/progdlgg.cpp:778 ../src/html/helpdlg.cpp:86
+#: ../src/msw/progdlg.cpp:209 ../src/msw/progdlg.cpp:890
+#: ../src/richtext/richtextstyledlg.cpp:272
+#: ../src/richtext/richtextsymboldlg.cpp:448
+msgid "Close"
+msgstr "Sluiten"
+
+#: ../src/common/stockitem.cpp:154
+msgid "&Convert"
+msgstr "&Converteren"
+
+#: ../src/common/stockitem.cpp:154
+msgid "Convert"
+msgstr "Converteren"
+
+#: ../src/common/stockitem.cpp:155 ../src/msw/textctrl.cpp:2884
+#: ../src/osx/textctrl_osx.cpp:653 ../src/richtext/richtextctrl.cpp:331
+msgid "&Copy"
+msgstr "&Kopiëren"
+
+#: ../src/common/stockitem.cpp:155 ../src/stc/stc_i18n.cpp:18
+msgid "Copy"
+msgstr "Kopiëren"
+
+#: ../src/common/stockitem.cpp:156 ../src/msw/textctrl.cpp:2883
+#: ../src/osx/textctrl_osx.cpp:652 ../src/richtext/richtextctrl.cpp:330
+msgid "Cu&t"
+msgstr "Kni&ppen"
+
+#: ../src/common/stockitem.cpp:156 ../src/stc/stc_i18n.cpp:17
+msgid "Cut"
+msgstr "Knippen"
+
+#: ../src/common/stockitem.cpp:157 ../src/msw/textctrl.cpp:2886
+#: ../src/osx/textctrl_osx.cpp:655 ../src/richtext/richtextctrl.cpp:333
+#: ../src/richtext/richtexttabspage.cpp:137
+msgid "&Delete"
+msgstr "&Verwijderen"
+
+#: ../src/common/stockitem.cpp:157 ../src/richtext/richtextbuffer.cpp:8266
+#: ../src/stc/stc_i18n.cpp:20
+msgid "Delete"
+msgstr "Verwijderen"
+
+#: ../src/common/stockitem.cpp:158
+msgid "&Down"
+msgstr "O&mlaag"
+
+#: ../src/common/stockitem.cpp:158 ../src/generic/fdrepdlg.cpp:148
+msgid "Down"
+msgstr "Omlaag"
+
+#: ../src/common/stockitem.cpp:159
+msgid "&Edit"
+msgstr "Be&werken"
+
+#: ../src/common/stockitem.cpp:159
+msgid "Edit"
+msgstr "Bewerken"
+
+#: ../src/common/stockitem.cpp:160
+msgid "&Execute"
+msgstr "&Uitvoeren"
+
+#: ../src/common/stockitem.cpp:160
+msgid "Execute"
+msgstr "Uitvoeren"
+
+#: ../src/common/stockitem.cpp:161
+msgid "&Quit"
+msgstr "A&fsluiten"
+
+#: ../src/common/stockitem.cpp:161
+msgid "Quit"
+msgstr "Afsluiten"
+
+#: ../src/common/stockitem.cpp:162
+msgid "&File"
+msgstr "&Bestand"
+
+#: ../src/common/stockitem.cpp:162
+msgid "File"
+msgstr "Bestand"
+
+#: ../src/common/stockitem.cpp:163
+msgid "&Find..."
+msgstr "&Zoeken…"
+
+#: ../src/common/stockitem.cpp:163
+msgid "Find..."
+msgstr "Zoeken…"
+
+#: ../src/common/stockitem.cpp:164
+msgid "&First"
+msgstr "&Eerste"
+
+#: ../src/common/stockitem.cpp:164
+msgid "First"
+msgstr "Eerste"
+
+#: ../src/common/stockitem.cpp:165
+msgid "&Floppy"
+msgstr "&Diskette"
+
+#: ../src/common/stockitem.cpp:165
+msgid "Floppy"
+msgstr "Diskette"
+
+#: ../src/common/stockitem.cpp:166
+msgid "&Forward"
+msgstr "&Verder"
+
+#: ../src/common/stockitem.cpp:166
+msgid "Forward"
+msgstr "Verder"
+
+#: ../src/common/stockitem.cpp:167
+msgid "&Harddisk"
+msgstr "&Hardeschijf"
+
+#: ../src/common/stockitem.cpp:167
+msgid "Harddisk"
+msgstr "Hardeschijf"
+
+#: ../src/common/stockitem.cpp:168 ../src/generic/wizard.cpp:418
+#: ../src/osx/cocoa/menu.mm:225 ../src/richtext/richtextstyledlg.cpp:298
+#: ../src/richtext/richtextsymboldlg.cpp:451
+msgid "&Help"
+msgstr "&Help"
+
+#: ../src/common/stockitem.cpp:169
+msgid "&Home"
+msgstr "S&tart"
+
+#: ../src/common/stockitem.cpp:169
+msgid "Home"
+msgstr "Thuis"
+
+#: ../src/common/stockitem.cpp:170
+msgid "Indent"
+msgstr "Inspringen"
+
+#: ../src/common/stockitem.cpp:171
+msgid "&Index"
+msgstr "&Index"
+
+#: ../src/common/stockitem.cpp:171 ../src/html/helpwnd.cpp:510
+msgid "Index"
+msgstr "Index"
+
+#: ../src/common/stockitem.cpp:172
+msgid "&Info"
+msgstr "&Info"
+
+#: ../src/common/stockitem.cpp:172
+msgid "Info"
+msgstr "Info"
+
+#: ../src/common/stockitem.cpp:173
+msgid "&Italic"
+msgstr "C&ursief"
+
+#: ../src/common/stockitem.cpp:173 ../src/generic/fontdlgg.cpp:322
+#: ../src/richtext/richtextfontpage.cpp:350
+msgid "Italic"
+msgstr "Cursief"
+
+#: ../src/common/stockitem.cpp:174
+msgid "&Jump to"
+msgstr "&Spring naar"
+
+#: ../src/common/stockitem.cpp:174
+msgid "Jump to"
+msgstr "Spring naar"
+
+#: ../src/common/stockitem.cpp:175
+msgid "Centered"
+msgstr "Gecentreerd"
+
+#: ../src/common/stockitem.cpp:176
+msgid "Justified"
+msgstr "Uitgevuld"
+
+#: ../src/common/stockitem.cpp:177
+msgid "Align Left"
+msgstr "Links uitlijnen"
+
+#: ../src/common/stockitem.cpp:178
+msgid "Align Right"
+msgstr "Rechts uitlijnen"
+
+#: ../src/common/stockitem.cpp:179
+msgid "&Last"
+msgstr "&Laatste"
+
+#: ../src/common/stockitem.cpp:179
+msgid "Last"
+msgstr "Laatste"
+
+#: ../src/common/stockitem.cpp:180
+msgid "&Network"
+msgstr "&Netwerk"
+
+#: ../src/common/stockitem.cpp:180
+msgid "Network"
+msgstr "Netwerk"
+
+#: ../src/common/stockitem.cpp:181 ../src/richtext/richtexttabspage.cpp:131
+msgid "&New"
+msgstr "&Nieuw"
+
+#: ../src/common/stockitem.cpp:181
+msgid "New"
+msgstr "Nieuw"
+
+#: ../src/common/stockitem.cpp:182 ../src/msw/msgdlg.cpp:417
+msgid "&No"
+msgstr "&Nee"
+
+#: ../src/common/stockitem.cpp:183 ../src/generic/fontdlgg.cpp:467
+#: ../src/generic/fontdlgg.cpp:474
+msgid "&OK"
+msgstr "&OK"
+
+#: ../src/common/stockitem.cpp:184 ../src/generic/dbgrptg.cpp:341
+msgid "&Open..."
+msgstr "&Openen..."
+
+#: ../src/common/stockitem.cpp:184
+msgid "Open..."
+msgstr "Openen..."
+
+#: ../src/common/stockitem.cpp:185 ../src/msw/textctrl.cpp:2885
+#: ../src/osx/textctrl_osx.cpp:654 ../src/richtext/richtextctrl.cpp:332
+msgid "&Paste"
+msgstr "&Plakken"
+
+#: ../src/common/stockitem.cpp:185 ../src/richtext/richtextctrl.cpp:3484
+#: ../src/stc/stc_i18n.cpp:19
+msgid "Paste"
+msgstr "Plakken"
+
+#: ../src/common/stockitem.cpp:186
+msgid "&Preferences"
+msgstr "&Voorkeuren"
+
+#: ../src/common/stockitem.cpp:186 ../src/osx/cocoa/preferences.mm:304
+msgid "Preferences"
+msgstr "Voorkeuren"
+
+#: ../src/common/stockitem.cpp:187
+msgid "Print previe&w..."
+msgstr "&Afdrukvoorbeeld..."
+
+#: ../src/common/stockitem.cpp:187
+msgid "Print preview..."
+msgstr "Afdrukvoorbeeld..."
+
+#: ../src/common/stockitem.cpp:188
+msgid "&Print..."
+msgstr "Af&drukken..."
+
+#: ../src/common/stockitem.cpp:188
+msgid "Print..."
+msgstr "Afdrukken..."
+
+#: ../src/common/stockitem.cpp:189 ../src/richtext/richtextctrl.cpp:337
+#: ../src/richtext/richtextctrl.cpp:5479
+msgid "&Properties"
+msgstr "Eigenscha&ppen"
+
+#: ../src/common/stockitem.cpp:189
+msgid "Properties"
+msgstr "Eigenschappen"
+
+#: ../src/common/stockitem.cpp:190 ../src/stc/stc_i18n.cpp:16
+msgid "Redo"
+msgstr "Opnieuw"
+
+#: ../src/common/stockitem.cpp:191
+msgid "Refresh"
+msgstr "Verversen"
+
+#: ../src/common/stockitem.cpp:192
+msgid "Remove"
+msgstr "Weghalen"
+
+#: ../src/common/stockitem.cpp:193
+msgid "Rep&lace..."
+msgstr "&Vervangen…"
+
+#: ../src/common/stockitem.cpp:193
+msgid "Replace..."
+msgstr "Vervangen…"
+
+#: ../src/common/stockitem.cpp:194
+msgid "Revert to Saved"
+msgstr "Terug naar Opgeslagen"
+
+#: ../src/common/stockitem.cpp:196 ../src/generic/logg.cpp:549
+msgid "Save &As..."
+msgstr "Opslaan &Als..."
+
+#: ../src/common/stockitem.cpp:196
+msgid "Save As..."
+msgstr "Opslaan Als..."
+
+#: ../src/common/stockitem.cpp:197 ../src/msw/textctrl.cpp:2888
+#: ../src/osx/textctrl_osx.cpp:657 ../src/richtext/richtextctrl.cpp:335
+msgid "Select &All"
+msgstr "Selecteer alles"
+
+#: ../src/common/stockitem.cpp:197 ../src/stc/stc_i18n.cpp:21
+msgid "Select All"
+msgstr "Selecteer alles"
+
+#: ../src/common/stockitem.cpp:198
+msgid "&Color"
+msgstr "&Kleur"
+
+#: ../src/common/stockitem.cpp:198
+msgid "Color"
+msgstr "Kleur"
+
+#: ../src/common/stockitem.cpp:199
+msgid "&Font"
+msgstr "&Lettertype"
+
+#: ../src/common/stockitem.cpp:199 ../src/richtext/richtextformatdlg.cpp:336
+msgid "Font"
+msgstr "Lettertype"
+
+#: ../src/common/stockitem.cpp:200
+msgid "&Ascending"
+msgstr "&Oplopend"
+
+#: ../src/common/stockitem.cpp:200
+msgid "Ascending"
+msgstr "Oplopend"
+
+#: ../src/common/stockitem.cpp:201
+msgid "&Descending"
+msgstr "&Aflopend"
+
+#: ../src/common/stockitem.cpp:201
+msgid "Descending"
+msgstr "Aflopend"
+
+#: ../src/common/stockitem.cpp:202
+msgid "&Spell Check"
+msgstr "&Spellingscontrole"
+
+#: ../src/common/stockitem.cpp:202
+msgid "Spell Check"
+msgstr "Spellingscontrole"
+
+#: ../src/common/stockitem.cpp:203
+msgid "&Stop"
+msgstr "&Stoppen"
+
+#: ../src/common/stockitem.cpp:203
+msgid "Stop"
+msgstr "Stoppen"
+
+#: ../src/common/stockitem.cpp:204 ../src/richtext/richtextfontpage.cpp:274
+msgid "&Strikethrough"
+msgstr "&Doorhalen"
+
+#: ../src/common/stockitem.cpp:204
+msgid "Strikethrough"
+msgstr "Doorhalen"
+
+#: ../src/common/stockitem.cpp:205
+msgid "&Top"
+msgstr "&Top"
+
+#: ../src/common/stockitem.cpp:205 ../src/richtext/richtextsizepage.cpp:285
+#: ../src/richtext/richtextsizepage.cpp:289
+msgid "Top"
+msgstr "Top"
+
+#: ../src/common/stockitem.cpp:206
+msgid "Undelete"
+msgstr "Terugzetten"
+
+#: ../src/common/stockitem.cpp:207 ../src/generic/fontdlgg.cpp:437
+msgid "&Underline"
+msgstr "Onderstre&pen"
+
+#: ../src/common/stockitem.cpp:207
+msgid "Underline"
+msgstr "Onderstrepen"
+
+#: ../src/common/stockitem.cpp:208 ../src/stc/stc_i18n.cpp:15
+msgid "Undo"
+msgstr "Ongedaan maken"
+
+#: ../src/common/stockitem.cpp:209
+msgid "&Unindent"
+msgstr "&Niet Inspringen"
+
+#: ../src/common/stockitem.cpp:209
+msgid "Unindent"
+msgstr "Inspringing opheffen"
+
+#: ../src/common/stockitem.cpp:210
+msgid "&Up"
+msgstr "&Omhoog"
+
+#: ../src/common/stockitem.cpp:210 ../src/generic/fdrepdlg.cpp:148
+msgid "Up"
+msgstr "Omhoog"
+
+#: ../src/common/stockitem.cpp:211 ../src/msw/msgdlg.cpp:417
+msgid "&Yes"
+msgstr "&Ja"
+
+#: ../src/common/stockitem.cpp:212
+msgid "&Actual Size"
+msgstr "&Werkelijke grootte"
+
+#: ../src/common/stockitem.cpp:212
+msgid "Actual Size"
+msgstr "Werkelijke grootte"
+
+#: ../src/common/stockitem.cpp:213
+msgid "Zoom to &Fit"
+msgstr "Inzoomen tot &Passend"
+
+#: ../src/common/stockitem.cpp:213
+msgid "Zoom to Fit"
+msgstr "Inzoomen tot Passend"
+
+#: ../src/common/stockitem.cpp:214
+msgid "Zoom &In"
+msgstr "In&zoomen"
+
+#: ../src/common/stockitem.cpp:215
+msgid "Zoom &Out"
+msgstr "&Uitzoomen"
+
+#: ../src/common/stockitem.cpp:262
+msgid "Show about dialog"
+msgstr "Toon 'Over' dialoogvenster"
+
+#: ../src/common/stockitem.cpp:263
+msgid "Copy selection"
+msgstr "Selectie kopiëren"
+
+#: ../src/common/stockitem.cpp:264
+msgid "Cut selection"
+msgstr "Selectie knippen"
+
+#: ../src/common/stockitem.cpp:265
+msgid "Delete selection"
+msgstr "Selectie verwijderen"
+
+#: ../src/common/stockitem.cpp:266
+msgid "Find in document"
+msgstr "Zoeken in document"
+
+#: ../src/common/stockitem.cpp:267
+msgid "Find and replace in document"
+msgstr "Zoek en vervang in document"
+
+#: ../src/common/stockitem.cpp:268
+msgid "Paste selection"
+msgstr "Selectie plakken"
+
+#: ../src/common/stockitem.cpp:269
+msgid "Quit this program"
+msgstr "Dit programma afsluiten"
+
+#: ../src/common/stockitem.cpp:270
+msgid "Redo last action"
+msgstr "Herhaal laatste actie"
+
+#: ../src/common/stockitem.cpp:271
+msgid "Undo last action"
+msgstr "Laatste actie ongedaan maken"
+
+#: ../src/common/stockitem.cpp:272
+msgid "Create new document"
+msgstr "Maak nieuwe document"
+
+#: ../src/common/stockitem.cpp:273
+msgid "Open an existing document"
+msgstr "Open een bestaand document"
+
+#: ../src/common/stockitem.cpp:274
+msgid "Close current document"
+msgstr "Huidig document sluiten"
+
+#: ../src/common/stockitem.cpp:275
+msgid "Save current document"
+msgstr "Huidig document opslaan"
+
+#: ../src/common/stockitem.cpp:276
+msgid "Save current document with a different filename"
+msgstr "Het huidige bestand onder een nieuwe naam opslaan"
+
+#: ../src/common/strconv.cpp:2324
+#, c-format
+msgid "Conversion to charset '%s' doesn't work."
+msgstr "Conversie naar karakterset '%s' werkt niet."
+
+#: ../src/common/tarstrm.cpp:352 ../src/common/tarstrm.cpp:375
+#: ../src/common/tarstrm.cpp:406 ../src/generic/progdlgg.cpp:373
+msgid "unknown"
+msgstr "onbekend"
+
+#: ../src/common/tarstrm.cpp:774
+msgid "incomplete header block in tar"
+msgstr "onvolledige header blok in tar"
+
+#: ../src/common/tarstrm.cpp:798
+msgid "checksum failure reading tar header block"
+msgstr "checksum mislukt tijdens lezen tar header blok"
+
+#: ../src/common/tarstrm.cpp:971
+msgid "invalid data in extended tar header"
+msgstr "ongeldige data in extended tar header"
+
+#: ../src/common/tarstrm.cpp:981 ../src/common/tarstrm.cpp:1003
+#: ../src/common/tarstrm.cpp:1477 ../src/common/tarstrm.cpp:1499
+msgid "tar entry not open"
+msgstr "tar ingang niet open"
+
+#: ../src/common/tarstrm.cpp:1023
+msgid "unexpected end of file"
+msgstr "onverwacht einde van bestand"
+
+#: ../src/common/tarstrm.cpp:1297
+#, c-format
+msgid "%s did not fit the tar header for entry '%s'"
+msgstr "%s paste niet bij de tar-header voor regel '%s'"
+
+#: ../src/common/tarstrm.cpp:1359
+msgid "incorrect size given for tar entry"
+msgstr "onjuiste grootte aangegeven voor tar invoer"
+
+#: ../src/common/textbuf.cpp:232
+#, c-format
+msgid "'%s' is probably a binary buffer."
+msgstr "'%s' is waarschijnlijk een binaire buffer."
+
+#: ../src/common/textcmn.cpp:1006 ../src/richtext/richtextctrl.cpp:3053
+msgid "File couldn't be loaded."
+msgstr "Bestand kon niet worden geladen."
+
+#: ../src/common/textfile.cpp:95
+#, c-format
+msgid "Failed to read text file \"%s\"."
+msgstr "Lezen van tekstbestand \"%s\" mislukt."
+
+#: ../src/common/textfile.cpp:160
+#, c-format
+msgid "can't write buffer '%s' to disk."
+msgstr "kan buffer '%s' niet naar schijf schrijven."
+
+#: ../src/common/time.cpp:212
+msgid "Failed to get the local system time"
+msgstr "Verkrijgen van lokale systeemtijd mislukt"
+
+#: ../src/common/time.cpp:279
+msgid "wxGetTimeOfDay failed."
+msgstr "wxGetTimeOfDay mislukt."
+
+#: ../src/common/translation.cpp:929
+#, c-format
+msgid "'%s' is not a valid message catalog."
+msgstr "'%s' is geen geldige berichtcatalogus."
+
+#: ../src/common/translation.cpp:954
+msgid "Invalid message catalog."
+msgstr "Ongeldige berichtencatalogus."
+
+#: ../src/common/translation.cpp:1013
+#, c-format
+msgid "Failed to parse Plural-Forms: '%s'"
+msgstr "Kan Plural-Forms:'%s' niet parseren"
+
+#: ../src/common/translation.cpp:1723
+#, c-format
+msgid "using catalog '%s' from '%s'."
+msgstr "catalogus '%s' van '%s' wordt gebruikt."
+
+#: ../src/common/translation.cpp:1816
+#, c-format
+msgid "Resource '%s' is not a valid message catalog."
+msgstr "Bronbestand '%s' is geen geldige berichtencatalogus."
+
+#: ../src/common/translation.cpp:1865
+msgid "Couldn't enumerate translations"
+msgstr "Kon vertalingen niet opsommen"
+
+#: ../src/common/utilscmn.cpp:1145
+msgid "No default application configured for HTML files."
+msgstr "Er is geen standaard toepassing geconfigureerd voor HTML bestanden."
+
+#: ../src/common/utilscmn.cpp:1190
+#, c-format
+msgid "Failed to open URL \"%s\" in default browser."
+msgstr "Openen van URL \"%s\" in standaard browser mislukt."
+
+#: ../src/common/valtext.cpp:144
+msgid "Validation conflict"
+msgstr "Validatie-conflict"
+
+#: ../src/common/valtext.cpp:186
+msgid "Required information entry is empty."
+msgstr "Vereiste informatieregel is leeg."
+
+#: ../src/common/valtext.cpp:188
+#, c-format
+msgid "'%s' is one of the invalid strings"
+msgstr "'%s' is een van de ongeldige strings"
+
+#: ../src/common/valtext.cpp:190
+#, c-format
+msgid "'%s' is not one of the valid strings"
+msgstr "'%s' is niet een van de geldige strings"
+
+#: ../src/common/valtext.cpp:199
+#, c-format
+msgid "'%s' contains invalid character(s)"
+msgstr "'%s' bevat ongeldig(e) teken(s)"
+
+#: ../src/common/webrequest.cpp:139
+#, c-format
+msgid "Error: %s (%d)"
+msgstr "Fout: %s (%d)"
+
+#: ../src/common/webrequest.cpp:655
+#, fuzzy, c-format
+msgid ""
+"Not enough free disk space for download: %llu needed but only %llu available."
+msgstr "Niet genoeg vrije schijfruimte voor downloaden."
+
+#: ../src/common/webrequest.cpp:669
+#, fuzzy, c-format
+msgid "Failed to create temporary file in %s"
+msgstr "Maken van een tijdelijke bestandsnaam mislukt"
+
+#: ../src/common/webrequest_curl.cpp:1106
+msgid "libcurl could not be initialized"
+msgstr "libcurl kan niet worden geïnitialiseerd"
+
+#: ../src/common/webview.cpp:392
+msgid "RunScriptAsync not supported"
+msgstr ""
+
+#: ../src/common/webview.cpp:403 ../src/msw/webview_ie.cpp:1073
+#, c-format
+msgid "Error running JavaScript: %s"
+msgstr "Fout bij het uitvoeren van JavaScript: %s"
+
+#: ../src/common/webview_chromium.cpp:858
+#, fuzzy, c-format
+msgid "Failed to set proxy \"%s\": %s"
+msgstr "Aanmaken map \"%s\" mislukt"
+
+#: ../src/common/webview_chromium.cpp:989
+msgid ""
+"Chromium can't be used because libcef.so wasn't loaded early enough; please "
+"relink the application or use LD_PRELOAD to load it earlier."
+msgstr ""
+
+#: ../src/common/webview_chromium.cpp:1108
+#, fuzzy
+msgid "Could not initialize Chromium"
+msgstr "Kan OLE niet initialiseren"
+
+#: ../src/common/webview_chromium.cpp:1616
+msgid "Show DevTools"
+msgstr ""
+
+#: ../src/common/webview_chromium.cpp:1617
+#, fuzzy
+msgid "Close DevTools"
+msgstr "Alles Sluiten"
+
+#: ../src/common/webview_chromium.cpp:1623
+msgid "Inspect"
+msgstr ""
+
+#: ../src/common/wincmn.cpp:1628
+msgid "This platform does not support background transparency."
+msgstr "Dit platform ondersteunt  geen transparante achtergrond."
+
+#: ../src/common/wincmn.cpp:2097
+msgid "Could not transfer data to window"
+msgstr "Kon gegevens niet naar venster overdragen"
+
+#: ../src/common/windowid.cpp:240
+msgid "Out of window IDs.  Recommend shutting down application."
+msgstr "Geen Venster ID's meer. Aanbevolen de toepassing af te sluiten."
+
+#: ../src/common/xpmdecod.cpp:678
+msgid "XPM: incorrect header format!"
+msgstr "XPM: incorrecte header formaat!"
+
+#: ../src/common/xpmdecod.cpp:703
+#, c-format
+msgid "XPM: incorrect colour description in line %d"
+msgstr "XPM: incorrecte kleurbeschrijving in regel %d"
+
+#: ../src/common/xpmdecod.cpp:715 ../src/common/xpmdecod.cpp:724
+#, c-format
+msgid "XPM: malformed colour definition '%s' at line %d!"
+msgstr "XPM: misvormde kleur definitie '%s' op regel %d!"
+
+#: ../src/common/xpmdecod.cpp:754
+msgid "XPM: no colors left to use for mask!"
+msgstr "XPM: geen kleuren over voor maskering!"
+
+#: ../src/common/xpmdecod.cpp:781
+#, c-format
+msgid "XPM: truncated image data at line %d!"
+msgstr "XPM: afgeknotte afbeeldingsgegevens op regel %d!"
+
+#: ../src/common/xpmdecod.cpp:795
+msgid "XPM: Malformed pixel data!"
+msgstr "XPM: Misvormde pixel gegevens!"
+
+#: ../src/common/xti.cpp:492
+msgid "Illegal Parameter Count for Create Method"
+msgstr "Ilegale aantal Parameters voor Create Methode"
+
+#: ../src/common/xti.cpp:504
+msgid "Illegal Parameter Count for ConstructObject Method"
+msgstr "Ilegale aantal Parameters voor ConstructObject Methode"
+
+#: ../src/common/xtistrm.cpp:161
+#, c-format
+msgid "Create Parameter %s not found in declared RTTI Parameters"
+msgstr "Create Parameter %s niet gevonden in gedeclareerde RTTI Parameters"
+
+#: ../src/common/xtistrm.cpp:290
+msgid "Illegal Object Class (Non-wxEvtHandler) as Event Source"
+msgstr "Illegale Object Class (Non-wxEvtHandler) als Event Source"
+
+#: ../src/common/xtistrm.cpp:313 ../src/common/xtixml.cpp:345
+#: ../src/common/xtixml.cpp:498
+msgid "Type must have enum - long conversion"
+msgstr "Type moet enum hebben - lange conversie"
+
+#: ../src/common/xtistrm.cpp:400 ../src/common/xtistrm.cpp:415
+msgid "Invalid or Null Object ID passed to GetObjectClassInfo"
+msgstr "Ongeldig of Null Object ID doorgegeven naar GetObjectClassInfo"
+
+#: ../src/common/xtistrm.cpp:405
+msgid "Unknown Object passed to GetObjectClassInfo"
+msgstr "Onbekend  Object doorgegeven aan GetObjectClassInfo"
+
+#: ../src/common/xtistrm.cpp:420
+msgid "Already Registered Object passed to SetObjectClassInfo"
+msgstr "Al geregistreerd object doorgegeven aan SetObjectClassInfo"
+
+#: ../src/common/xtistrm.cpp:430
+msgid "Invalid or Null Object ID passed to HasObjectClassInfo"
+msgstr "Ongeldig of Null Object ID doorgegeven naar HasObjectClassInfo"
+
+#: ../src/common/xtistrm.cpp:460
+msgid "Passing a already registered object to SetObject"
+msgstr "Al geregistreerd object doorgegeven aan SetObject"
+
+#: ../src/common/xtistrm.cpp:471
+msgid "Passing an unknown object to GetObject"
+msgstr "Doorgave van een onbekend object naar GetObject"
+
+#: ../src/common/xtixml.cpp:229
+msgid "Forward hrefs are not supported"
+msgstr "Doorsturen van hrefs wordt niet ondersteund"
+
+#: ../src/common/xtixml.cpp:247
+#, c-format
+msgid "unknown class %s"
+msgstr "onbekende klasse %s"
+
+#: ../src/common/xtixml.cpp:253
+msgid "objects cannot have XML Text Nodes"
+msgstr "objecten kunnen geen XML teskt Nodes hebben"
+
+#: ../src/common/xtixml.cpp:258
+msgid "Objects must have an id attribute"
+msgstr "Objecten moeten een id attribuut hebben"
+
+#: ../src/common/xtixml.cpp:267
+#, c-format
+msgid "Doubly used id : %d"
+msgstr "Dubbel gebruikt ID: %d"
+
+#: ../src/common/xtixml.cpp:316
+#, c-format
+msgid "Unknown Property %s"
+msgstr "Onbekende Eigenschap %s"
+
+#: ../src/common/xtixml.cpp:407
+msgid "A non empty collection must consist of 'element' nodes"
+msgstr "Een niet lege verzameling moet bestaan uit 'element'-knopen"
+
+#: ../src/common/xtixml.cpp:478
+msgid "incorrect event handler string, missing dot"
+msgstr "onjuiste gebeurtenishandlerreeks, ontbrekende stip"
+
+#: ../src/common/zipstrm.cpp:559
+msgid "can't re-initialize zlib deflate stream"
+msgstr "kan zlib deflate stream niet opnieuw starten"
+
+#: ../src/common/zipstrm.cpp:584
+msgid "can't re-initialize zlib inflate stream"
+msgstr "kan zlib inflate stream niet opnieuw starten"
+
+#: ../src/common/zipstrm.cpp:1023
+msgid "Ignoring malformed extra data record, ZIP file may be corrupted"
+msgstr "Negeren van misvormde extra dataregel, ZIP-bestand kan corrupt zijn"
+
+#: ../src/common/zipstrm.cpp:1502
+msgid "assuming this is a multi-part zip concatenated"
+msgstr "aangenomen dat dit een multi-part zip concatenatie is"
+
+#: ../src/common/zipstrm.cpp:1664
+msgid "invalid zip file"
+msgstr "ongeldig zip-bestand"
+
+#: ../src/common/zipstrm.cpp:1723
+msgid "can't find central directory in zip"
+msgstr "kan centrale map in zipbestand niet vinden"
+
+#: ../src/common/zipstrm.cpp:1812
+msgid "error reading zip central directory"
+msgstr "fout bij het lezen van zip centrale map"
+
+#: ../src/common/zipstrm.cpp:1916
+msgid "error reading zip local header"
+msgstr "fout lezen zip lokale header"
+
+#: ../src/common/zipstrm.cpp:1964
+msgid "bad zipfile offset to entry"
+msgstr "slechte zipfile offset naar binnenkomst"
+
+#: ../src/common/zipstrm.cpp:2031
+msgid "stored file length not in Zip header"
+msgstr "opgeslagen bestandslengte niet in Zip header"
+
+#: ../src/common/zipstrm.cpp:2045 ../src/common/zipstrm.cpp:2362
+msgid "unsupported Zip compression method"
+msgstr "niet ondersteunde Zip-compressiemethode"
+
+#: ../src/common/zipstrm.cpp:2126
+#, c-format
+msgid "reading zip stream (entry %s): bad length"
+msgstr "inlezen van zip stream (regel %s): foute lengte"
+
+#: ../src/common/zipstrm.cpp:2131
+#, c-format
+msgid "reading zip stream (entry %s): bad crc"
+msgstr "inlezen van zip stream (regel %s): foute crc"
+
+#: ../src/common/zipstrm.cpp:2578
+#, c-format
+msgid "error writing zip entry '%s': file too large without ZIP64"
+msgstr ""
+"fout bij het wegschrijven van zip-invoer ‘%s’: bestand te groot zonder ZIP64"
+
+#: ../src/common/zipstrm.cpp:2585
+#, c-format
+msgid "error writing zip entry '%s': bad crc or length"
+msgstr "fout schrijven zip invoer '%s': foute crc of lengte"
+
+#: ../src/common/zstream.cpp:155 ../src/common/zstream.cpp:315
+msgid "Gzip not supported by this version of zlib"
+msgstr "Gzip niet ondersteund door deze versie van zlib"
+
+#: ../src/common/zstream.cpp:182
+msgid "Can't initialize zlib inflate stream."
+msgstr "Kan zlib inflate stream niet initialiseren."
+
+#: ../src/common/zstream.cpp:241
+msgid "Can't read inflate stream: unexpected EOF in underlying stream."
+msgstr ""
+"Kan stream niet uitpakken: onverwacht einde-van-bestand in onderliggende "
+"stream."
+
+#: ../src/common/zstream.cpp:248 ../src/common/zstream.cpp:423
+#, c-format
+msgid "zlib error %d"
+msgstr "zlib-fout %d"
+
+#: ../src/common/zstream.cpp:249
+#, c-format
+msgid "Can't read from inflate stream: %s"
+msgstr "Kan niet lezen van opblazen stroom: %s"
+
+#: ../src/common/zstream.cpp:343
+msgid "Can't initialize zlib deflate stream."
+msgstr "Kan zlib deflate stream niet initialiseren."
+
+#: ../src/common/zstream.cpp:424
+#, c-format
+msgid "Can't write to deflate stream: %s"
+msgstr "Kan niet schrijven naar deflate stream: %s"
+
+#: ../src/dfb/bitmap.cpp:633 ../src/dfb/bitmap.cpp:667
+#, c-format
+msgid "No bitmap handler for type %d defined."
+msgstr "Geen bitmap handler voor type %d gedefinieerd."
+
+#: ../src/dfb/evtloop.cpp:99
+msgid "Failed to read event from DirectFB pipe"
+msgstr "Lezen van gebeurtenis uit DirectFB pipe mislukt"
+
+#: ../src/dfb/evtloop.cpp:171
+msgid "Failed to switch DirectFB pipe to non-blocking mode"
+msgstr "Kan directfb-pijp niet overschakelen naar niet-blokkerende modus"
+
+#: ../src/dfb/fontmgr.cpp:171
+#, c-format
+msgid "no fonts found in %s, using builtin font"
+msgstr "geen lettertypes gevonden in %s. Gebruik ingebouwde lettertype"
+
+#: ../src/dfb/fontmgr.cpp:177
+msgid "Default font"
+msgstr "Standaard lettertype"
+
+#: ../src/dfb/fontmgr.cpp:195
+#, c-format
+msgid "Fonts index file %s disappeared while loading fonts."
+msgstr ""
+"Lettertype index bestand %s verdwenen tijdens het laden van lettertypes."
+
+#: ../src/dfb/wrapdfb.cpp:60
+#, c-format
+msgid "DirectFB error %d occurred."
+msgstr "DirectFB fout %d opgetreden."
+
+#: ../src/generic/aboutdlgg.cpp:69
+msgid "Developed by "
+msgstr "Ontwikkeld door "
+
+#: ../src/generic/aboutdlgg.cpp:72
+msgid "Documentation by "
+msgstr "Documentatie door "
+
+#: ../src/generic/aboutdlgg.cpp:75
+msgid "Graphics art by "
+msgstr "Grafische kunst door "
+
+#: ../src/generic/aboutdlgg.cpp:78
+msgid "Translations by "
+msgstr "Vertalingen door "
+
+#: ../src/generic/aboutdlgg.cpp:133 ../src/osx/cocoa/aboutdlg.mm:83
+msgid "Version "
+msgstr "Versie "
+
+#. TRANSLATORS: %s is application name
+#: ../src/generic/aboutdlgg.cpp:146 ../src/msw/aboutdlg.cpp:60
+#, c-format
+msgid "About %s"
+msgstr "Over %s"
+
+#: ../src/generic/aboutdlgg.cpp:181
+msgid "License"
+msgstr "Licentie"
+
+#: ../src/generic/aboutdlgg.cpp:184
+msgid "Developers"
+msgstr "Ontwikkelaars"
+
+#: ../src/generic/aboutdlgg.cpp:188
+msgid "Documentation writers"
+msgstr "Documentatie schrijvers"
+
+#: ../src/generic/aboutdlgg.cpp:192
+msgid "Artists"
+msgstr "Kunstenaars"
+
+#: ../src/generic/aboutdlgg.cpp:196
+msgid "Translators"
+msgstr "Vertalers"
+
+#: ../src/generic/animateg.cpp:125
+msgid "No handler found for animation type."
+msgstr "Geen handler gevonden voor animatietype."
+
+#: ../src/generic/animateg.cpp:133
+#, c-format
+msgid "No animation handler for type %ld defined."
+msgstr "Geen animatie handler voor type %ld gedefinieerd."
+
+#: ../src/generic/animateg.cpp:145
+#, c-format
+msgid "Animation file is not of type %ld."
+msgstr "Animatiebestand is niet van type %ld."
+
+#: ../src/generic/colrdlgg.cpp:154 ../src/gtk/colordlg.cpp:47
+msgid "Choose colour"
+msgstr "Kies Kleur"
+
+#: ../src/generic/colrdlgg.cpp:357
+msgid "Red:"
+msgstr "Red:"
+
+#: ../src/generic/colrdlgg.cpp:360
+msgid "Green:"
+msgstr "Groen:"
+
+#: ../src/generic/colrdlgg.cpp:363
+msgid "Blue:"
+msgstr "Blauw:"
+
+#: ../src/generic/colrdlgg.cpp:372
+msgid "Opacity:"
+msgstr "Ondoorzichtigheid:"
+
+#: ../src/generic/colrdlgg.cpp:384
+msgid "Add to custom colours"
+msgstr "Voeg toe aan aangepaste kleuren"
+
+#: ../src/generic/creddlgg.cpp:56
+msgid "Username:"
+msgstr "Gebruikersnaam:"
+
+#: ../src/generic/creddlgg.cpp:63
+msgid "Password:"
+msgstr "Wachtwoord:"
+
+#. TRANSLATORS: Name of Boolean true value
+#: ../src/generic/datavgen.cpp:1178
+msgid "true"
+msgstr "true"
+
+#. TRANSLATORS: Name of Boolean false value
+#: ../src/generic/datavgen.cpp:1180
+msgid "false"
+msgstr "onwaar"
+
+#: ../src/generic/datavgen.cpp:6897
+#, c-format
+msgid "Row %i"
+msgstr "Rij %i"
+
+#. TRANSLATORS: Action for manipulating a tree control
+#: ../src/generic/datavgen.cpp:6987
+msgid "Collapse"
+msgstr "Inklappen"
+
+#. TRANSLATORS: Action for manipulating a tree control
+#: ../src/generic/datavgen.cpp:6990
+msgid "Expand"
+msgstr "Uitvouwen"
+
+#. TRANSLATORS: Name of data view control and number of rows
+#: ../src/generic/datavgen.cpp:7011
+#, c-format
+msgid "%s (%d items)"
+msgstr "%s ( %d elementen)"
+
+#: ../src/generic/datavgen.cpp:7062
+#, c-format
+msgid "Column %u"
+msgstr "Kolom %u"
+
+#. TRANSLATORS: Keystroke for manipulating a tree control
+#: ../src/generic/datavgen.cpp:7131 ../src/richtext/richtextbulletspage.cpp:189
+#: ../src/richtext/richtextbulletspage.cpp:192
+#: ../src/richtext/richtextbulletspage.cpp:193
+#: ../src/richtext/richtextliststylepage.cpp:252
+#: ../src/richtext/richtextliststylepage.cpp:255
+#: ../src/richtext/richtextliststylepage.cpp:256
+#: ../src/richtext/richtextsizepage.cpp:248
+msgid "Left"
+msgstr "Links"
+
+#. TRANSLATORS: Keystroke for manipulating a tree control
+#: ../src/generic/datavgen.cpp:7134 ../src/richtext/richtextbulletspage.cpp:191
+#: ../src/richtext/richtextliststylepage.cpp:254
+#: ../src/richtext/richtextsizepage.cpp:249
+msgid "Right"
+msgstr "Rechts"
+
+#: ../src/generic/datectlg.cpp:90
+#, c-format
+msgid ""
+"\"%s\" is not in the expected date format, please enter it as e.g. \"%s\"."
+msgstr ""
+
+#: ../src/generic/datectlg.cpp:94
+#, fuzzy
+msgid "Invalid date"
+msgstr "PCX: ongeldige afbeelding"
+
+#: ../src/generic/dbgrptg.cpp:159
+#, c-format
+msgid "Open file \"%s\""
+msgstr "Open bestand \"%s\""
+
+#: ../src/generic/dbgrptg.cpp:170
+#, c-format
+msgid "Enter command to open file \"%s\":"
+msgstr "Opdracht invoeren voor openen van bestand  \"%s\":"
+
+#: ../src/generic/dbgrptg.cpp:230
+msgid "Executable files (*.exe)|*.exe|"
+msgstr "Uitvoerbare bestanden (*.exe)|*.exe|"
+
+#: ../src/generic/dbgrptg.cpp:300
+#, c-format
+msgid "Debug report \"%s\""
+msgstr "Futopsporingsrapport \"%s\""
+
+#: ../src/generic/dbgrptg.cpp:316
+msgid "A debug report has been generated in the directory\n"
+msgstr "Een foutopsporingsrapport is aangemaakt in de map\n"
+
+#: ../src/generic/dbgrptg.cpp:317
+msgid "The following debug report will be generated\n"
+msgstr "Het volgende debug-rapport zal worden aangemaakt\n"
+
+#: ../src/generic/dbgrptg.cpp:321
+msgid ""
+"The report contains the files listed below. If any of these files contain "
+"private information,\n"
+"please uncheck them and they will be removed from the report.\n"
+msgstr ""
+"Het rapport bevat de hieronder opgesomde bestanden. Wanneer een van deze "
+"bestanden persoonlijke informatie bevat,\n"
+"haal dan het vinkje weg en ze zullen verwijderd worden uit het rapport.\n"
+
+#: ../src/generic/dbgrptg.cpp:323
+msgid ""
+"If you wish to suppress this debug report completely, please choose the "
+"\"Cancel\" button,\n"
+"but be warned that it may hinder improving the program, so if\n"
+"at all possible please do continue with the report generation.\n"
+msgstr ""
+"Als u dit foutopsporingsrapport totaal wilt onderdrukken, kies dan de "
+"\"Annuleren\" knop,\n"
+"maar wees gewaarschuwd dat het 't verbeteren van het programma kan "
+"verhinderen, dus als\n"
+"het enigszins mogelijk is, ga dan door met het genereren van het rapport.\n"
+
+#: ../src/generic/dbgrptg.cpp:325
+msgid "              Thank you and we're sorry for the inconvenience!\n"
+msgstr "              Dank u en onze excuses voor het ongemak!\n"
+
+#: ../src/generic/dbgrptg.cpp:333
+msgid "&Debug report preview:"
+msgstr "Voorbeeld &foutopsporingsrapport:"
+
+#: ../src/generic/dbgrptg.cpp:339
+msgid "&View..."
+msgstr "&Beeld..."
+
+#: ../src/generic/dbgrptg.cpp:359
+msgid "&Notes:"
+msgstr "&Notities:"
+
+#: ../src/generic/dbgrptg.cpp:361
+msgid ""
+"If you have any additional information pertaining to this bug\n"
+"report, please enter it here and it will be joined to it:"
+msgstr ""
+"Als u additionele informatie heeft met betrekking tot deze fout,\n"
+"rapporteer dit, voer het hier in en het zal er worden bijgevoegd:"
+
+#: ../src/generic/dcpsg.cpp:1627
+msgid "Cannot open file for PostScript printing!"
+msgstr "Kan bestand voor PostScript-afdrukken niet openen!"
+
+#: ../src/generic/dirctrlg.cpp:402
+msgid "Computer"
+msgstr "Computer"
+
+#: ../src/generic/dirctrlg.cpp:404
+msgid "Sections"
+msgstr "Secties"
+
+#: ../src/generic/dirctrlg.cpp:482
+msgid "Home directory"
+msgstr "Thuismap"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/generic/dirctrlg.cpp:484 ../src/propgrid/advprops.cpp:811
+msgid "Desktop"
+msgstr "Bureaublad"
+
+#: ../src/generic/dirctrlg.cpp:528 ../src/generic/filectrlg.cpp:752
+msgid "Illegal directory name."
+msgstr "Ongeldige mapnaam."
+
+#: ../src/generic/dirctrlg.cpp:528 ../src/generic/dirctrlg.cpp:546
+#: ../src/generic/dirctrlg.cpp:557 ../src/generic/dirdlgg.cpp:317
+#: ../src/generic/filectrlg.cpp:638 ../src/generic/filectrlg.cpp:752
+#: ../src/generic/filectrlg.cpp:766 ../src/generic/filectrlg.cpp:782
+#: ../src/generic/filectrlg.cpp:1356 ../src/generic/filectrlg.cpp:1387
+#: ../src/generic/filedlgg.cpp:362 ../src/gtk/filedlg.cpp:76
+msgid "Error"
+msgstr "Fout"
+
+#: ../src/generic/dirctrlg.cpp:546 ../src/generic/filectrlg.cpp:766
+msgid "File name exists already."
+msgstr "Bestandsnaam bestaat al."
+
+#: ../src/generic/dirctrlg.cpp:557 ../src/generic/dirdlgg.cpp:317
+#: ../src/generic/filectrlg.cpp:638 ../src/generic/filectrlg.cpp:782
+msgid "Operation not permitted."
+msgstr "Bewerking niet toegestaan."
+
+#: ../src/generic/dirdlgg.cpp:107 ../src/generic/filedlgg.cpp:207
+msgid "Create new directory"
+msgstr "Maak nieuwe map"
+
+#: ../src/generic/dirdlgg.cpp:112 ../src/generic/filedlgg.cpp:203
+msgid "Go to home directory"
+msgstr "Ga naar startmap"
+
+#: ../src/generic/dirdlgg.cpp:143
+msgid "Show &hidden directories"
+msgstr "Toon &verborgen mappen"
+
+#: ../src/generic/dirdlgg.cpp:196
+#, c-format
+msgid ""
+"The directory '%s' does not exist\n"
+"Create it now?"
+msgstr ""
+"De map '%s' bestaat niet\n"
+"Nu maken?"
+
+#: ../src/generic/dirdlgg.cpp:198
+msgid "Directory does not exist"
+msgstr "Map bestaat niet"
+
+#: ../src/generic/dirdlgg.cpp:214
+#, c-format
+msgid ""
+"Failed to create directory '%s'\n"
+"(Do you have the required permissions?)"
+msgstr ""
+"Maken van map '%s' mislukt\n"
+"(Heeft u de benodigde machtiging?)"
+
+#: ../src/generic/dirdlgg.cpp:216
+msgid "Error creating directory"
+msgstr "Fout bij het maken van map"
+
+#: ../src/generic/dirdlgg.cpp:281
+msgid "You cannot add a new directory to this section."
+msgstr "U kunt geen nieuwe map aan deze sectie toevoegen."
+
+#: ../src/generic/dirdlgg.cpp:282
+msgid "Create directory"
+msgstr "Maak map"
+
+#: ../src/generic/dirdlgg.cpp:291 ../src/generic/dirdlgg.cpp:301
+#: ../src/generic/filectrlg.cpp:614 ../src/generic/filectrlg.cpp:623
+msgid "NewName"
+msgstr "Nieuwe map"
+
+#: ../src/generic/editlbox.cpp:135
+msgid "Edit item"
+msgstr "Element bewerken"
+
+#: ../src/generic/editlbox.cpp:143
+msgid "New item"
+msgstr "Nieuw element"
+
+#: ../src/generic/editlbox.cpp:151
+msgid "Delete item"
+msgstr "Element verwijderen"
+
+#: ../src/generic/editlbox.cpp:159
+msgid "Move up"
+msgstr "Verplaats naar boven"
+
+#: ../src/generic/editlbox.cpp:164
+msgid "Move down"
+msgstr "Verplaats omlaag"
+
+#: ../src/generic/fdrepdlg.cpp:108
+msgid "Search for:"
+msgstr "Zoeken naar:"
+
+#: ../src/generic/fdrepdlg.cpp:120
+msgid "Replace with:"
+msgstr "Vervangen met:"
+
+#: ../src/generic/fdrepdlg.cpp:140
+msgid "Whole word"
+msgstr "Alleen hele woorden"
+
+#: ../src/generic/fdrepdlg.cpp:143
+msgid "Match case"
+msgstr "Hoofdlettergevoelig"
+
+#: ../src/generic/fdrepdlg.cpp:156
+msgid "Search direction"
+msgstr "Zoek richting"
+
+#: ../src/generic/fdrepdlg.cpp:175
+msgid "&Replace"
+msgstr "&Vervangen"
+
+#: ../src/generic/fdrepdlg.cpp:178
+msgid "Replace &all"
+msgstr "Allemaal vervangen"
+
+#: ../src/generic/filectrlg.cpp:246 ../src/generic/filectrlg.cpp:269
+msgid "<DIR>"
+msgstr "<DIR>"
+
+#: ../src/generic/filectrlg.cpp:248 ../src/generic/filectrlg.cpp:271
+msgid "<LINK>"
+msgstr "<LINK>"
+
+#: ../src/generic/filectrlg.cpp:250 ../src/generic/filectrlg.cpp:273
+msgid "<DRIVE>"
+msgstr "<STATION>"
+
+#: ../src/generic/filectrlg.cpp:275
+#, c-format
+msgid "%ld byte"
+msgid_plural "%ld bytes"
+msgstr[0] "%ld byte"
+msgstr[1] "%ld bytes"
+
+#: ../src/generic/filectrlg.cpp:420
+msgid "Name"
+msgstr "Naam"
+
+#: ../src/generic/filectrlg.cpp:421 ../src/richtext/richtextformatdlg.cpp:361
+#: ../src/richtext/richtextsizepage.cpp:298
+msgid "Size"
+msgstr "Formaat"
+
+#: ../src/generic/filectrlg.cpp:422
+msgid "Type"
+msgstr "Type"
+
+#: ../src/generic/filectrlg.cpp:423
+msgid "Modified"
+msgstr "Gewijzigd"
+
+#: ../src/generic/filectrlg.cpp:426
+msgid "Permissions"
+msgstr "Machtigingen"
+
+#: ../src/generic/filectrlg.cpp:429
+msgid "Attributes"
+msgstr "Attributen"
+
+#: ../src/generic/filectrlg.cpp:936
+msgid "Current directory:"
+msgstr "Huidige map:"
+
+#: ../src/generic/filectrlg.cpp:979
+msgid "Show &hidden files"
+msgstr "Toon &Verborgen bestanden"
+
+#: ../src/generic/filectrlg.cpp:1355
+msgid "Illegal file specification."
+msgstr "Ongeldige bestandsspecificatie."
+
+#: ../src/generic/filectrlg.cpp:1387
+msgid "Directory doesn't exist."
+msgstr "Map bestaat niet."
+
+#: ../src/generic/filedlgg.cpp:195
+msgid "View files as a list view"
+msgstr "Toon bestanden in lijst-weergave"
+
+#: ../src/generic/filedlgg.cpp:197
+msgid "View files as a detailed view"
+msgstr "Toon bestanden in detail-weergave"
+
+#: ../src/generic/filedlgg.cpp:200
+msgid "Go to parent directory"
+msgstr "Ga naar bovenliggende map"
+
+#: ../src/generic/filedlgg.cpp:351 ../src/gtk/filedlg.cpp:59
+#, c-format
+msgid "File '%s' already exists, do you really want to overwrite it?"
+msgstr "Bestand '%s' bestaat al, overschrijven?"
+
+#: ../src/generic/filedlgg.cpp:354 ../src/gtk/filedlg.cpp:62
+msgid "Confirm"
+msgstr "Bevestig"
+
+#: ../src/generic/filedlgg.cpp:362 ../src/gtk/filedlg.cpp:75
+msgid "Please choose an existing file."
+msgstr "Kies a.u.b. een bestaand bestand."
+
+#: ../src/generic/filepickerg.cpp:64
+msgid "..."
+msgstr "..."
+
+#: ../src/generic/fontdlgg.cpp:76 ../src/richtext/richtextformatdlg.cpp:519
+msgid "ABCDEFGabcdefg12345"
+msgstr "ABCDEFGabcdefg12345"
+
+#: ../src/generic/fontdlgg.cpp:315
+msgid "Roman"
+msgstr "Romein"
+
+#: ../src/generic/fontdlgg.cpp:316
+msgid "Decorative"
+msgstr "Decoratief"
+
+#: ../src/generic/fontdlgg.cpp:317
+msgid "Modern"
+msgstr "Modern"
+
+#: ../src/generic/fontdlgg.cpp:318
+msgid "Script"
+msgstr "Script"
+
+#: ../src/generic/fontdlgg.cpp:319
+msgid "Swiss"
+msgstr "Schreefloos"
+
+#: ../src/generic/fontdlgg.cpp:320
+msgid "Teletype"
+msgstr "Niet proportioneel (Teletype)"
+
+#: ../src/generic/fontdlgg.cpp:321 ../src/generic/fontdlgg.cpp:324
+msgid "Normal"
+msgstr "Normaal"
+
+#: ../src/generic/fontdlgg.cpp:323
+msgid "Slant"
+msgstr "Schuin"
+
+#: ../src/generic/fontdlgg.cpp:325
+msgid "Light"
+msgstr "Licht"
+
+#: ../src/generic/fontdlgg.cpp:363
+msgid "&Font family:"
+msgstr "&Lettertypefamilie:"
+
+#: ../src/generic/fontdlgg.cpp:367 ../src/generic/fontdlgg.cpp:369
+msgid "The font family."
+msgstr "De lettertypefamilie."
+
+#: ../src/generic/fontdlgg.cpp:374 ../src/richtext/richtextstylepage.cpp:105
+msgid "&Style:"
+msgstr "&Stijl:"
+
+#: ../src/generic/fontdlgg.cpp:378 ../src/generic/fontdlgg.cpp:380
+msgid "The font style."
+msgstr "De lettertypestijl."
+
+#: ../src/generic/fontdlgg.cpp:385
+msgid "&Weight:"
+msgstr "Ge&wicht:"
+
+#: ../src/generic/fontdlgg.cpp:389 ../src/generic/fontdlgg.cpp:391
+msgid "The font weight."
+msgstr "De lettertypegewicht."
+
+#: ../src/generic/fontdlgg.cpp:399
+msgid "C&olour:"
+msgstr "&Kleur:"
+
+#: ../src/generic/fontdlgg.cpp:407 ../src/generic/fontdlgg.cpp:409
+msgid "The font colour."
+msgstr "De lettertypekleur."
+
+#: ../src/generic/fontdlgg.cpp:415
+msgid "&Point size:"
+msgstr "&Puntgrootte:"
+
+#: ../src/generic/fontdlgg.cpp:420 ../src/generic/fontdlgg.cpp:422
+#: ../src/generic/fontdlgg.cpp:426 ../src/generic/fontdlgg.cpp:428
+msgid "The font point size."
+msgstr "De lettertype puntgrootte."
+
+#: ../src/generic/fontdlgg.cpp:439 ../src/generic/fontdlgg.cpp:441
+msgid "Whether the font is underlined."
+msgstr "Of het lettertype is onderstreept."
+
+#: ../src/generic/fontdlgg.cpp:448 ../src/html/helpwnd.cpp:1215
+msgid "Preview:"
+msgstr "Afdrukvoorbeeld:"
+
+#: ../src/generic/fontdlgg.cpp:452 ../src/generic/fontdlgg.cpp:454
+msgid "Shows the font preview."
+msgstr "Toont het lettertype voorbeeld."
+
+#: ../src/generic/fontdlgg.cpp:464 ../src/generic/fontdlgg.cpp:483
+msgid "Click to cancel the font selection."
+msgstr "Klik voor het annuleren van lettertypekeuze."
+
+#: ../src/generic/fontdlgg.cpp:469 ../src/generic/fontdlgg.cpp:471
+#: ../src/generic/fontdlgg.cpp:476 ../src/generic/fontdlgg.cpp:478
+msgid "Click to confirm the font selection."
+msgstr "Klik voor bevestiging van lettertypeselectie."
+
+#: ../src/generic/fontpickerg.cpp:50 ../src/gtk/fontdlg.cpp:77
+msgid "Choose font"
+msgstr "Kies lettertype"
+
+#: ../src/generic/grid.cpp:6542
+msgid ""
+"Error copying grid to the clipboard. Either selected cells were not "
+"contiguous or no cell was selected."
+msgstr ""
+
+#: ../src/generic/grid.cpp:12739
+#, fuzzy
+msgid "Grid Corner"
+msgstr "Hoek"
+
+#: ../src/generic/grid.cpp:12741
+#, fuzzy, c-format
+msgid "Column %s Header"
+msgstr "Kolom %u"
+
+#: ../src/generic/grid.cpp:12743
+#, c-format
+msgid "Row %s Header"
+msgstr ""
+
+#: ../src/generic/grid.cpp:12745
+#, fuzzy, c-format
+msgid "Column %s: %s"
+msgstr "Kolom %u"
+
+#: ../src/generic/grid.cpp:12749
+#, fuzzy, c-format
+msgid "Row %s: %s"
+msgstr "Rij %i"
+
+#: ../src/generic/grid.cpp:12753
+#, c-format
+msgid "Row %s, Column %s: %s"
+msgstr ""
+
+#: ../src/generic/helpext.cpp:257
+#, c-format
+msgid "Help directory \"%s\" not found."
+msgstr "Helpmap \"%s\" niet gevonden."
+
+#: ../src/generic/helpext.cpp:265
+#, c-format
+msgid "Help file \"%s\" not found."
+msgstr "Helpbestand \"%s\" niet gevonden."
+
+#: ../src/generic/helpext.cpp:284
+#, c-format
+msgid "Line %lu of map file \"%s\" has invalid syntax, skipped."
+msgstr ""
+"Line %lu van mappingbestand \"%s\" heeft een ongeldige syntax: overgeslagen."
+
+#: ../src/generic/helpext.cpp:292
+#, c-format
+msgid "No valid mappings found in the file \"%s\"."
+msgstr "Geen geldige mappingen gevonden in het bestand \"%s\"."
+
+#: ../src/generic/helpext.cpp:435
+msgid "No entries found."
+msgstr "Geen ingangen gevonden."
+
+#: ../src/generic/helpext.cpp:444 ../src/generic/helpext.cpp:445
+msgid "Help Index"
+msgstr "Help Index"
+
+#: ../src/generic/helpext.cpp:448
+msgid "Relevant entries:"
+msgstr "Relevante ingangen:"
+
+#: ../src/generic/helpext.cpp:449
+msgid "Entries found"
+msgstr "Ingangen gevonden"
+
+#: ../src/generic/hyperlinkg.cpp:170
+msgid "&Copy URL"
+msgstr "URL &kopiëren"
+
+#: ../src/generic/infobar.cpp:119
+msgid "Hide this notification message."
+msgstr "Verberg dit notificatiebericht."
+
+#. TRANSLATORS: %s will be either the application name or "Application"
+#: ../src/generic/logg.cpp:257
+#, c-format
+msgid "%s Error"
+msgstr "%s Fout"
+
+#. TRANSLATORS: %s will be either the application name or "Application"
+#: ../src/generic/logg.cpp:263
+#, c-format
+msgid "%s Warning"
+msgstr "%s Waarschuwing"
+
+#. TRANSLATORS: %s will be either the application name or "Application"
+#: ../src/generic/logg.cpp:273
+#, c-format
+msgid "%s Information"
+msgstr "%s Informatie"
+
+#: ../src/generic/logg.cpp:276
+msgid "Application"
+msgstr "Applicatie"
+
+#: ../src/generic/logg.cpp:549
+msgid "Save log contents to file"
+msgstr "Sla log-gegevens op in bestand"
+
+#: ../src/generic/logg.cpp:551
+msgid "C&lear"
+msgstr "&Wissen"
+
+#: ../src/generic/logg.cpp:551
+msgid "Clear the log contents"
+msgstr "Wis de inhoud van het logbestand"
+
+#: ../src/generic/logg.cpp:553
+msgid "Close this window"
+msgstr "Sluit dit venster"
+
+#: ../src/generic/logg.cpp:554
+msgid "&Log"
+msgstr "&Log"
+
+#: ../src/generic/logg.cpp:610 ../src/generic/logg.cpp:992
+msgid "Can't save log contents to file."
+msgstr "Kan log inhoud niet in bestand opslaan."
+
+#: ../src/generic/logg.cpp:613
+#, c-format
+msgid "Log saved to the file '%s'."
+msgstr "Log opgeslagen in bestand '%s'."
+
+#: ../src/generic/logg.cpp:719
+msgid "&Details"
+msgstr "&Details"
+
+#: ../src/generic/logg.cpp:972
+msgid "Failed to copy dialog contents to the clipboard."
+msgstr "Kopiëren inhoud dialoogvenster naar klembord mislukt."
+
+#: ../src/generic/logg.cpp:1022
+#, c-format
+msgid "Append log to file '%s' (choosing [No] will overwrite it)?"
+msgstr "Voeg log toe aan bestand '%s' (kies [Nee] om te overschrijven)?"
+
+#: ../src/generic/logg.cpp:1024
+msgid "Question"
+msgstr "Vraag"
+
+#: ../src/generic/logg.cpp:1038
+msgid "invalid message box return value"
+msgstr "ongeldige return-waarde van berichtvenster"
+
+#: ../src/generic/notifmsgg.cpp:129
+msgid "Notice"
+msgstr "Notitie"
+
+#: ../src/generic/preferencesg.cpp:118
+#, c-format
+msgid "%s Preferences"
+msgstr "%s voorkeuren"
+
+#: ../src/generic/printps.cpp:143
+msgid "Printing..."
+msgstr "Bezig met afdrukken..."
+
+#: ../src/generic/printps.cpp:160 ../src/gtk/print.cpp:1076
+#: ../src/msw/printwin.cpp:235
+msgid "Could not start printing."
+msgstr "Kon printen niet starten."
+
+#: ../src/generic/printps.cpp:183
+#, c-format
+msgid "Printing page %d..."
+msgstr "Bezig met afdrukken van pagina %d..."
+
+#: ../src/generic/prntdlgg.cpp:171
+msgid "Printer options"
+msgstr "Printer-opties"
+
+#: ../src/generic/prntdlgg.cpp:176
+msgid "Print to File"
+msgstr "Naar bestand afdrukken"
+
+#: ../src/generic/prntdlgg.cpp:179
+msgid "Setup..."
+msgstr "Instellingen..."
+
+#: ../src/generic/prntdlgg.cpp:187
+msgid "Printer:"
+msgstr "Printer:"
+
+#: ../src/generic/prntdlgg.cpp:195
+msgid "Status:"
+msgstr "Status:"
+
+#: ../src/generic/prntdlgg.cpp:206
+msgid "All"
+msgstr "Alles"
+
+#: ../src/generic/prntdlgg.cpp:207
+msgid "Pages"
+msgstr "Pagina's"
+
+#: ../src/generic/prntdlgg.cpp:215
+msgid "Print Range"
+msgstr "Afdrukbereik"
+
+#: ../src/generic/prntdlgg.cpp:229
+msgid "From:"
+msgstr "Van:"
+
+#: ../src/generic/prntdlgg.cpp:233
+msgid "To:"
+msgstr "Aan:"
+
+#: ../src/generic/prntdlgg.cpp:238
+msgid "Copies:"
+msgstr "Kopieën:"
+
+#: ../src/generic/prntdlgg.cpp:288
+msgid "PostScript file"
+msgstr "PostScript-bestand"
+
+#: ../src/generic/prntdlgg.cpp:439
+msgid "Print Setup"
+msgstr "Afdrukinstellingen"
+
+#: ../src/generic/prntdlgg.cpp:483
+msgid "Printer"
+msgstr "Printer"
+
+#: ../src/generic/prntdlgg.cpp:501
+msgid "Default printer"
+msgstr "Standaardprinter"
+
+#: ../src/generic/prntdlgg.cpp:595 ../src/generic/prntdlgg.cpp:782
+#: ../src/generic/prntdlgg.cpp:822 ../src/generic/prntdlgg.cpp:835
+#: ../src/generic/prntdlgg.cpp:1031 ../src/generic/prntdlgg.cpp:1036
+msgid "Paper size"
+msgstr "Papierformaat"
+
+#: ../src/generic/prntdlgg.cpp:604 ../src/generic/prntdlgg.cpp:847
+msgid "Portrait"
+msgstr "Staand"
+
+#: ../src/generic/prntdlgg.cpp:605 ../src/generic/prntdlgg.cpp:848
+msgid "Landscape"
+msgstr "Liggend"
+
+#: ../src/generic/prntdlgg.cpp:607 ../src/generic/prntdlgg.cpp:849
+msgid "Orientation"
+msgstr "Oriëntatie"
+
+#: ../src/generic/prntdlgg.cpp:610
+msgid "Options"
+msgstr "Instellingen"
+
+#: ../src/generic/prntdlgg.cpp:612
+msgid "Print in colour"
+msgstr "In kleur afdrukken"
+
+#: ../src/generic/prntdlgg.cpp:621
+msgid "Print spooling"
+msgstr "Afdruk-spoolen"
+
+#: ../src/generic/prntdlgg.cpp:623
+msgid "Printer command:"
+msgstr "Printercommando:"
+
+#: ../src/generic/prntdlgg.cpp:631
+msgid "Printer options:"
+msgstr "Printer-opties:"
+
+#: ../src/generic/prntdlgg.cpp:860
+msgid "Left margin (mm):"
+msgstr "Linkermarge (mm):"
+
+#: ../src/generic/prntdlgg.cpp:861
+msgid "Top margin (mm):"
+msgstr "Bovenmarge (mm):"
+
+#: ../src/generic/prntdlgg.cpp:872
+msgid "Right margin (mm):"
+msgstr "Rechtermarge (mm):"
+
+#: ../src/generic/prntdlgg.cpp:873
+msgid "Bottom margin (mm):"
+msgstr "Ondermarge (mm):"
+
+#: ../src/generic/prntdlgg.cpp:896
+msgid "Printer..."
+msgstr "Printer..."
+
+#: ../src/generic/progdlgg.cpp:246
+msgid "&Skip"
+msgstr "Over&slaan"
+
+#: ../src/generic/progdlgg.cpp:347 ../src/generic/progdlgg.cpp:626
+msgid "Unknown"
+msgstr "Unknown"
+
+#: ../src/generic/progdlgg.cpp:451 ../src/msw/progdlg.cpp:526
+msgid "Done."
+msgstr "Klaar."
+
+#: ../src/generic/srchctlg.cpp:55 ../src/gtk/srchctrl.cpp:206
+#: ../src/html/helpwnd.cpp:530 ../src/html/helpwnd.cpp:545
+msgid "Search"
+msgstr "Zoeken"
+
+#: ../src/generic/tabg.cpp:1026
+msgid "Could not find tab for id"
+msgstr "Kon tabblad niet vinden voor id"
+
+#: ../src/generic/tipdlg.cpp:136
+msgid "Tips not available, sorry!"
+msgstr "Geen tips beschikbaar, sorry!"
+
+#: ../src/generic/tipdlg.cpp:197
+msgid "Tip of the Day"
+msgstr "Tip van de dag"
+
+#: ../src/generic/tipdlg.cpp:207
+msgid "Did you know..."
+msgstr "Wist u dat..."
+
+#: ../src/generic/tipdlg.cpp:232
+msgid "&Show tips at startup"
+msgstr "&Toon tips bij opstarten"
+
+#: ../src/generic/tipdlg.cpp:236
+msgid "&Next Tip"
+msgstr "&Volgende tip"
+
+#: ../src/generic/wizard.cpp:411
+msgid "&Next >"
+msgstr "&Volgende >"
+
+#: ../src/generic/wizard.cpp:412
+msgid "&Finish"
+msgstr "&Voltooien"
+
+#: ../src/generic/wizard.cpp:420
+msgid "< &Back"
+msgstr "< &Terug"
+
+#: ../src/gtk/aboutdlg.cpp:204
+msgid "translator-credits"
+msgstr "vertaling credits"
+
+#: ../src/gtk/app.cpp:517
+msgid ""
+"WARNING: using XIM input method is unsupported and may result in problems "
+"with input handling and flickering. Consider unsetting GTK_IM_MODULE or "
+"setting to \"ibus\"."
+msgstr ""
+"WAARSCHUWING: het gebruik van de XIM-invoermethode wordt niet ondersteund en "
+"kan leiden tot problemen met invoerverwerking en flikkering. Overweeg om "
+"GTK_IM_MODULE uit te schakelen of in te stellen op “ibus”."
+
+#: ../src/gtk/app.cpp:569
+msgid "Unable to initialize GTK+, is DISPLAY set properly?"
+msgstr "Niet in staat GTK+ te initialiseren. Is DISPLAY juist ingesteld?"
+
+#: ../src/gtk/filedlg.cpp:89 ../src/gtk/filepicker.cpp:255
+#, c-format
+msgid "Changing current directory to \"%s\" failed"
+msgstr "Het veranderen van de huidige directory naar \"%s\" is mislukt"
+
+#: ../src/gtk/font.cpp:548
+msgid ""
+"Using private fonts is not supported on this system: Pango library is too "
+"old, 1.38 or later required."
+msgstr ""
+"Het gebruik van privélettertypen wordt niet ondersteund op dit systeem: "
+"Pango-bibliotheek is te oud, 1.38 of later vereist."
+
+#: ../src/gtk/font.cpp:558
+msgid "Failed to create font configuration object."
+msgstr "Kan lettertype configuratieobject niet maken."
+
+#: ../src/gtk/font.cpp:568
+#, c-format
+msgid "Failed to add custom font \"%s\"."
+msgstr "Kan aangepast lettertype “%s” niet toevoegen."
+
+#: ../src/gtk/font.cpp:576
+msgid "Failed to register font configuration using private fonts."
+msgstr "Kan lettertypeconfiguratie niet registreren met privélettertypen."
+
+#: ../src/gtk/glcanvas.cpp:117 ../src/gtk/glcanvas.cpp:132
+msgid "Fatal Error"
+msgstr "Fatale fout"
+
+#: ../src/gtk/glcanvas.cpp:117
+msgid ""
+"This program wasn't compiled with EGL support required under Wayland, "
+"either\n"
+"install EGL libraries and rebuild or run it under X11 backend by setting\n"
+"environment variable GDK_BACKEND=x11 before starting your program."
+msgstr ""
+"Dit programma is ook niet gecompileerd met EGL-ondersteuning die vereist is "
+"onder Wayland, óf\n"
+"installeer EGL-bibliotheken en herbouw óf voer het uit onder X11-backend "
+"door instelling\n"
+"omgevingsvariabele GDK_BACKEND=x11 voordat u uw programma start."
+
+#: ../src/gtk/glcanvas.cpp:132
+msgid ""
+"wxGLCanvas is only supported on Wayland and X11 currently.  You may be able "
+"to\n"
+"work around this by setting environment variable GDK_BACKEND=x11 before\n"
+"starting your program."
+msgstr ""
+"wxGLCanvas wordt momenteel alleen ondersteund op Wayland en X11. Mogelijk "
+"kunt u\n"
+"dit omzeilen door omgevingsvariabele GDK_BACKEND=x11 in te stellen voor\n"
+"het starten van uw programma."
+
+#: ../src/gtk/mdi.cpp:433
+msgid "MDI child"
+msgstr "MDI subvenster"
+
+#: ../src/gtk/power.cpp:188
+#, fuzzy, c-format
+msgid "Failed to open D-Bus connection to the login manager: %s"
+msgstr "Maken van verbinding met server '%s' voor onderwerp '%s' mislukt"
+
+#: ../src/gtk/power.cpp:214
+#, fuzzy
+msgid "wxWidgets application"
+msgstr "Applicatie"
+
+#: ../src/gtk/power.cpp:226
+msgid "Application needs to keep running"
+msgstr ""
+
+#: ../src/gtk/power.cpp:233
+msgid "Clean up before suspend"
+msgstr ""
+
+#: ../src/gtk/power.cpp:259
+#, fuzzy, c-format
+msgid "Failed to inhibit sleep: %s"
+msgstr "Maken van inbelverbinding mislukt: %s"
+
+#: ../src/gtk/power.cpp:265
+msgid "Unexpected response to D-Bus \"Inhibit\" request."
+msgstr ""
+
+#: ../src/gtk/print.cpp:218
+msgid "Custom size"
+msgstr "Aangepaste grootte"
+
+#: ../src/gtk/print.cpp:752
+#, fuzzy, c-format
+msgid "Error while printing: %s"
+msgstr "Fout bij het printen: "
+
+#: ../src/gtk/print.cpp:816
+msgid "Page Setup"
+msgstr "Pagina-instellingen"
+
+#: ../src/gtk/webview_webkit.cpp:932
+msgid "Retrieving JavaScript script output is not supported with WebKit v1"
+msgstr ""
+"Het ophalen van JavaScript scriptuitvoer wordt niet ondersteund met WebKit v1"
+
+#: ../src/gtk/webview_webkit2.cpp:1098
+msgid ""
+"Setting proxy is not supported by WebKit, at least version 2.16 is required."
+msgstr ""
+
+#: ../src/gtk/webview_webkit2.cpp:1104
+msgid "This program was compiled without support for setting WebKit proxy."
+msgstr ""
+
+#: ../src/gtk/window.cpp:6289
+msgid ""
+"GTK+ installed on this machine is too old to support screen compositing, "
+"please install GTK+ 2.12 or later."
+msgstr ""
+"GTK+ geïnstalleerd op deze machine is te oud om schermsamenstellingen te "
+"ondersteunen. Installeer GTK+ 2.12 of nieuwer."
+
+#: ../src/gtk/window.cpp:6307
+msgid ""
+"Compositing not supported by this system, please enable it in your Window "
+"Manager."
+msgstr ""
+"Samenstellen niet ondersteund door dit systeem. U kunt dit inschakelen in uw "
+"Vensterbeheer."
+
+#: ../src/gtk/window.cpp:6318
+msgid ""
+"This program was compiled with a too old version of GTK+, please rebuild "
+"with GTK+ 2.12 or newer."
+msgstr ""
+"Dit programma is gecompileerd met een te oude versie van GTK+. Herbouw het "
+"met GTK+ 2.12 of nieuwer."
+
+#: ../src/html/chm.cpp:138
+#, c-format
+msgid "Failed to open CHM archive '%s'."
+msgstr "Openen van CHM archief  '%s' mislukt."
+
+#: ../src/html/chm.cpp:270
+#, c-format
+msgid "Could not extract %s into %s: %s"
+msgstr "Kon %s niet extraheren in %s: %s"
+
+#: ../src/html/chm.cpp:324
+msgid "no error"
+msgstr "geen fout"
+
+#: ../src/html/chm.cpp:326
+msgid "bad arguments to library function"
+msgstr "foute argumenten voor bibliotheek functie"
+
+#: ../src/html/chm.cpp:328
+msgid "error opening file"
+msgstr "fout bij openen bestand"
+
+#: ../src/html/chm.cpp:330
+msgid "read error"
+msgstr "fout bij lezen"
+
+#: ../src/html/chm.cpp:332
+msgid "write error"
+msgstr "fout bij schrijven"
+
+#: ../src/html/chm.cpp:334
+msgid "seek error"
+msgstr "zoekfout"
+
+#: ../src/html/chm.cpp:338
+msgid "bad signature"
+msgstr "slechte handtekening"
+
+#: ../src/html/chm.cpp:340
+msgid "error in data format"
+msgstr "fout in gegevens formaat"
+
+#: ../src/html/chm.cpp:342
+msgid "checksum error"
+msgstr "checksum fout"
+
+#: ../src/html/chm.cpp:344
+msgid "compression error"
+msgstr "compressie fout"
+
+#: ../src/html/chm.cpp:346
+msgid "decompression error"
+msgstr "decompressie fout"
+
+#: ../src/html/chm.cpp:437
+#, c-format
+msgid "Could not locate file '%s'."
+msgstr "Kon niet vinden bestand '%s'."
+
+#: ../src/html/chm.cpp:711
+#, c-format
+msgid "Could not create temporary file '%s'"
+msgstr "Kon tijdelijk bestand '%s' niet aanmaken"
+
+#: ../src/html/chm.cpp:718
+#, c-format
+msgid "Extraction of '%s' into '%s' failed."
+msgstr "Extractie van '%s' in '%s' mislukt."
+
+#: ../src/html/chm.cpp:806 ../src/html/chm.cpp:863
+msgid "CHM handler currently supports only local files!"
+msgstr "CHM-afhandeling ondersteunt momenteel alleen lokale bestanden!"
+
+#: ../src/html/chm.cpp:827
+msgid "Link contained '//', converted to absolute link."
+msgstr "Koppeling bevatte '//': omgezet naar absolute koppeling."
+
+#: ../src/html/helpctrl.cpp:59
+#, c-format
+msgid "Help: %s"
+msgstr "Help: %s"
+
+#: ../src/html/helpctrl.cpp:155
+#, c-format
+msgid "Adding book %s"
+msgstr "Bezig met toevoegen van boek %s"
+
+#: ../src/html/helpdata.cpp:295
+#, c-format
+msgid "Cannot open contents file: %s"
+msgstr "Kon inhoudsopgave-bestand niet openen: %s"
+
+#: ../src/html/helpdata.cpp:309
+#, c-format
+msgid "Cannot open index file: %s"
+msgstr "Kan index-bestand niet openen: %s"
+
+#: ../src/html/helpdata.cpp:643
+msgid "noname"
+msgstr "naamloos"
+
+#: ../src/html/helpdata.cpp:652
+#, c-format
+msgid "Cannot open HTML help book: %s"
+msgstr "Kan HTML-helpbestand '%s' niet openen"
+
+#: ../src/html/helpwnd.cpp:315
+msgid "Displays help as you browse the books on the left."
+msgstr "Toont hulptekst terwijl u de boeken aan de linkerzijde doorbladert."
+
+#: ../src/html/helpwnd.cpp:411 ../src/html/helpwnd.cpp:1100
+#: ../src/html/helpwnd.cpp:1735
+msgid "(bookmarks)"
+msgstr "(favorieten)"
+
+#: ../src/html/helpwnd.cpp:424
+msgid "Add current page to bookmarks"
+msgstr "Voeg huidige pagina toe aan favorieten"
+
+#: ../src/html/helpwnd.cpp:425
+msgid "Remove current page from bookmarks"
+msgstr "Verwijder huidige pagina uit favorieten"
+
+#: ../src/html/helpwnd.cpp:470
+msgid "Contents"
+msgstr "Inhoud"
+
+#: ../src/html/helpwnd.cpp:485
+msgid "Find"
+msgstr "Zoeken"
+
+#: ../src/html/helpwnd.cpp:487
+msgid "Show all"
+msgstr "Toon alles"
+
+#: ../src/html/helpwnd.cpp:497
+msgid ""
+"Display all index items that contain given substring. Search is case "
+"insensitive."
+msgstr ""
+"Toon alle index elementen die de gegeven subtekenreeks bevatten. Niet "
+"hoofdlettergevoelig."
+
+#: ../src/html/helpwnd.cpp:498
+msgid "Show all items in index"
+msgstr "Toon alle elementen in de index"
+
+#: ../src/html/helpwnd.cpp:528
+msgid "Case sensitive"
+msgstr "Hoofdlettergevoelig"
+
+#: ../src/html/helpwnd.cpp:529
+msgid "Whole words only"
+msgstr "Alleen hele woorden"
+
+#: ../src/html/helpwnd.cpp:532
+msgid ""
+"Search contents of help book(s) for all occurrences of the text you typed "
+"above"
+msgstr ""
+"Zoek in inhoudsopgave van helpbestand(en) naar alle plaatsen waar de tekst "
+"die u boven heeft getypt voorkomt"
+
+#: ../src/html/helpwnd.cpp:653
+msgid "Show/hide navigation panel"
+msgstr "Toon/verberg navigatie-paneel"
+
+#: ../src/html/helpwnd.cpp:655
+msgid "Go back"
+msgstr "Ga terug"
+
+#: ../src/html/helpwnd.cpp:656
+msgid "Go forward"
+msgstr "Ga vooruit"
+
+#: ../src/html/helpwnd.cpp:658
+msgid "Go one level up in document hierarchy"
+msgstr "Ga niveau hoger in document-hiërarchie"
+
+#: ../src/html/helpwnd.cpp:666 ../src/html/helpwnd.cpp:1547
+msgid "Open HTML document"
+msgstr "HTML-document openen"
+
+#: ../src/html/helpwnd.cpp:670
+msgid "Print this page"
+msgstr "Deze pagina afdrukken"
+
+#: ../src/html/helpwnd.cpp:674
+msgid "Display options dialog"
+msgstr "Toon optie-dialoog"
+
+#: ../src/html/helpwnd.cpp:795
+msgid "Please choose the page to display:"
+msgstr "Selecteer een pagina om te tonen:"
+
+#: ../src/html/helpwnd.cpp:796
+msgid "Help Topics"
+msgstr "Hulp-onderwerpen"
+
+#: ../src/html/helpwnd.cpp:852
+msgid "Searching..."
+msgstr "Bezig met zoeken..."
+
+#: ../src/html/helpwnd.cpp:853
+msgid "No matching page found yet"
+msgstr "Nog geen overeenkomende pagina gevonden"
+
+#: ../src/html/helpwnd.cpp:870
+#, c-format
+msgid "Found %i matches"
+msgstr "%i Overeenkomsten gevonden"
+
+#: ../src/html/helpwnd.cpp:958
+msgid "(Help)"
+msgstr "(Help)"
+
+#: ../src/html/helpwnd.cpp:1026
+#, c-format
+msgid "%d of %lu"
+msgstr "%d of %lu"
+
+#: ../src/html/helpwnd.cpp:1028
+#, c-format
+msgid "%lu of %lu"
+msgstr "%lu van %lu"
+
+#: ../src/html/helpwnd.cpp:1047
+msgid "Search in all books"
+msgstr "Zoek in alle boeken"
+
+#: ../src/html/helpwnd.cpp:1193
+msgid "Help Browser Options"
+msgstr "Help Browser Instellingen"
+
+#: ../src/html/helpwnd.cpp:1198
+msgid "Normal font:"
+msgstr "Normaal lettertype:"
+
+#: ../src/html/helpwnd.cpp:1199
+msgid "Fixed font:"
+msgstr "Niet proportioneel lettertype:"
+
+#: ../src/html/helpwnd.cpp:1200
+msgid "Font size:"
+msgstr "Lettertype-grootte:"
+
+#: ../src/html/helpwnd.cpp:1245
+msgid "font size"
+msgstr "lettertype grootte"
+
+#: ../src/html/helpwnd.cpp:1256
+msgid "Normal face<br>and <u>underlined</u>. "
+msgstr "Normale letter<br>en <u>onderstreept</u>. "
+
+#: ../src/html/helpwnd.cpp:1257
+msgid "<i>Italic face.</i> "
+msgstr "<i>Cursief lettertype.</i> "
+
+#: ../src/html/helpwnd.cpp:1258
+msgid "<b>Bold face.</b> "
+msgstr "<b>Vet lettertype.</b> "
+
+#: ../src/html/helpwnd.cpp:1259
+msgid "<b><i>Bold italic face.</i></b><br>"
+msgstr "<b><i>Vet cursief lettertype.</i></b><br>"
+
+#: ../src/html/helpwnd.cpp:1262
+msgid "Fixed size face.<br> <b>bold</b> <i>italic</i> "
+msgstr "Lettertype met vaste breedte.<br> <b>vet</b> <i>cursief</i> "
+
+#: ../src/html/helpwnd.cpp:1263
+msgid "<b><i>bold italic <u>underlined</u></i></b><br>"
+msgstr "<b><i>vet cursief <u>onderstreept</u></i></b><br>"
+
+#: ../src/html/helpwnd.cpp:1524
+msgid "Help Printing"
+msgstr "Help Afdrukken"
+
+#: ../src/html/helpwnd.cpp:1527
+msgid "Cannot print empty page."
+msgstr "Kan geen lege pagina afdrukken."
+
+#: ../src/html/helpwnd.cpp:1540
+msgid "HTML files (*.html;*.htm)|*.html;*.htm|"
+msgstr "HTML bestanden (*.html;*.htm)|*.html;*.htm|"
+
+#: ../src/html/helpwnd.cpp:1541
+msgid "Help books (*.htb)|*.htb|Help books (*.zip)|*.zip|"
+msgstr "Helpboeken (*.htb)|*.htb|Helpboeken (*.zip)|*.zip|"
+
+#: ../src/html/helpwnd.cpp:1542
+msgid "HTML Help Project (*.hhp)|*.hhp|"
+msgstr "HTML Help Project (*.hhp)|*.hhp|"
+
+#: ../src/html/helpwnd.cpp:1544
+msgid "Compressed HTML Help file (*.chm)|*.chm|"
+msgstr "Gecomprimeerd HTML-hulpbestand (*.chm)|*.chm|"
+
+#: ../src/html/helpwnd.cpp:1671
+#, c-format
+msgid "%i of %u"
+msgstr "%i van %u"
+
+#: ../src/html/helpwnd.cpp:1709
+#, c-format
+msgid "%u of %u"
+msgstr "%u van %u"
+
+#: ../src/html/htmlfilt.cpp:134
+#, c-format
+msgid "Cannot open HTML document: %s"
+msgstr "Kan HTML-document '%s' niet openen"
+
+#: ../src/html/htmlwin.cpp:599
+msgid "Connecting..."
+msgstr "Bezig te verbinden..."
+
+#: ../src/html/htmlwin.cpp:616
+#, c-format
+msgid "Unable to open requested HTML document: %s"
+msgstr "Kan gevraagd HTML-document niet openen: %s"
+
+#: ../src/html/htmlwin.cpp:630
+msgid "Loading : "
+msgstr "Bezig met laden: "
+
+#: ../src/html/htmlwin.cpp:673
+msgid "Done"
+msgstr "Klaar"
+
+#: ../src/html/htmlwin.cpp:723
+#, c-format
+msgid "HTML anchor %s does not exist."
+msgstr "HTML-anchor %s bestaat niet."
+
+#: ../src/html/htmlwin.cpp:1057
+#, c-format
+msgid "Copied to clipboard:\"%s\""
+msgstr "Gekopieerd naar klembord:\"%s\""
+
+#: ../src/html/htmprint.cpp:269
+msgid ""
+"This document doesn't fit on the page horizontally and will be truncated "
+"when it is printed."
+msgstr ""
+"Dit document pas horizontaal niet op de pagina en zal worden afgekapt als "
+"het wordt afgedrukt."
+
+#: ../src/html/htmprint.cpp:285
+#, c-format
+msgid ""
+"The document \"%s\" doesn't fit on the page horizontally and will be "
+"truncated if printed.\n"
+"\n"
+"Would you like to proceed with printing it nevertheless?"
+msgstr ""
+"Het document \"%s\" past niet horizontaal op de pagina en zal worden "
+"afgekapt bij het afdrukken.\n"
+"\n"
+"Wilt u ondanks dat toch doorgaan met afdrukken?"
+
+#: ../src/html/htmprint.cpp:296
+msgid ""
+"If possible, try changing the layout parameters to make the printout more "
+"narrow."
+msgstr ""
+"Indien mogelijk, probeer de opmaakparameters te veranderen om de afdruk "
+"smaller te maken."
+
+#: ../src/html/htmprint.cpp:445
+msgid ": file does not exist!"
+msgstr ": bestand bestaat niet!"
+
+#. TRANSLATORS: %s may be a document title.
+#: ../src/html/htmprint.cpp:717
+#, fuzzy, c-format
+msgid "%s Preview"
+msgstr " Voorbeeld"
+
+#: ../src/html/htmprint.cpp:755 ../src/richtext/richtextprint.cpp:618
+msgid ""
+"There was a problem during page setup: you may need to set a default printer."
+msgstr ""
+"Er was een probleem tijdens pagina-instellingen: u moet mogelijk een "
+"standaard printer instellen."
+
+#: ../src/msw/clipbrd.cpp:80
+msgid "Failed to open the clipboard."
+msgstr "Openen van klembord mislukt."
+
+#: ../src/msw/clipbrd.cpp:101
+msgid "Failed to close the clipboard."
+msgstr "Sluiten van klembord mislukt."
+
+#: ../src/msw/clipbrd.cpp:113
+msgid "Failed to empty the clipboard."
+msgstr "Legen van klembord mislukt."
+
+#: ../src/msw/clipbrd.cpp:284
+msgid "Failed to put data on the clipboard"
+msgstr "Bewaren van gegevens op klembord mislukt"
+
+#: ../src/msw/clipbrd.cpp:326
+msgid "Failed to get data from the clipboard"
+msgstr "Gegevens van klembord ophalen mislukt"
+
+#: ../src/msw/clipbrd.cpp:363
+msgid "Failed to retrieve the supported clipboard formats"
+msgstr "Verkrijgen van ondersteunde klembord-formaten mislukt"
+
+#: ../src/msw/colordlg.cpp:228
+#, c-format
+msgid "Colour selection dialog failed with error %0lx."
+msgstr "Kleurenselectie dialoog mislukt met fout %0lx."
+
+#: ../src/msw/cursor.cpp:141
+msgid "Failed to create cursor."
+msgstr "Cursor aanmaken mislukt."
+
+#: ../src/msw/dde.cpp:279
+#, c-format
+msgid "Failed to register DDE server '%s'"
+msgstr "Registratie van DDE-server '%s' mislukt"
+
+#: ../src/msw/dde.cpp:300
+#, c-format
+msgid "Failed to unregister DDE server '%s'"
+msgstr "Deregistreren van DDE-server %s mislukt"
+
+#: ../src/msw/dde.cpp:428
+#, c-format
+msgid "Failed to create connection to server '%s' on topic '%s'"
+msgstr "Maken van verbinding met server '%s' voor onderwerp '%s' mislukt"
+
+#: ../src/msw/dde.cpp:655
+msgid "DDE poke request failed"
+msgstr "DDE poke verzoek mislukt"
+
+#: ../src/msw/dde.cpp:674
+msgid "Failed to establish an advise loop with DDE server"
+msgstr "Opzetten van advies-lus met de DDE-server mislukt"
+
+#: ../src/msw/dde.cpp:693
+msgid "Failed to terminate the advise loop with DDE server"
+msgstr "Beëindigen van advies-lus met de DDE-server mislukt"
+
+#: ../src/msw/dde.cpp:768
+msgid "Failed to send DDE advise notification"
+msgstr "Versturen van DDE-adviesnotificatie mislukt"
+
+#: ../src/msw/dde.cpp:1085
+msgid "Failed to create DDE string"
+msgstr "Maken van DDE-string mislukt"
+
+#: ../src/msw/dde.cpp:1131
+msgid "no DDE error."
+msgstr "geen DDE-fout."
+
+#: ../src/msw/dde.cpp:1135
+msgid "a request for a synchronous advise transaction has timed out."
+msgstr ""
+"aanvraag voor synchrone adviestransactie heeft een time-out veroorzaakt."
+
+#: ../src/msw/dde.cpp:1138
+msgid "the response to the transaction caused the DDE_FBUSY bit to be set."
+msgstr "het antwoord op de transactie heeft de DDE_FBUSY-bit op 1 gezet."
+
+#: ../src/msw/dde.cpp:1141
+msgid "a request for a synchronous data transaction has timed out."
+msgstr ""
+"aanvraag voor synchrone gegevenstransactie heeft een time-out veroorzaakt."
+
+#: ../src/msw/dde.cpp:1144
+msgid ""
+"a DDEML function was called without first calling the DdeInitialize "
+"function,\n"
+"or an invalid instance identifier\n"
+"was passed to a DDEML function."
+msgstr ""
+"een DDEML-functie was aangeroepen zonder eerst de DdeInitialize-functie aan "
+"te roepen\n"
+"of een ongeldige applicatie-pid was doorgegeven aan een DDEML-functie."
+
+#: ../src/msw/dde.cpp:1147
+msgid ""
+"an application initialized as APPCLASS_MONITOR has\n"
+"attempted to perform a DDE transaction,\n"
+"or an application initialized as APPCMD_CLIENTONLY has \n"
+"attempted to perform server transactions."
+msgstr ""
+"een applicatie die als APPCLASS_MONITOR is gestart heeft geprobeerd\n"
+"een DDE-transactie uit te voeren of een applicatie die als APPCMD_CLIENTONLY "
+"is\n"
+"gestart heeft geprobeerd een server-transactie uit te voeren."
+
+#: ../src/msw/dde.cpp:1150
+msgid "a request for a synchronous execute transaction has timed out."
+msgstr ""
+"aanvraag voor synchrone uitvoeringstransactie heeft een time-out veroorzaakt."
+
+#: ../src/msw/dde.cpp:1153
+msgid "a parameter failed to be validated by the DDEML."
+msgstr "een parameter kon niet door de DDEML gevalideerd worden."
+
+#: ../src/msw/dde.cpp:1156
+msgid "a DDEML application has created a prolonged race condition."
+msgstr ""
+"een DDEML-applicatie heeft door een 'race'-conditie geheugengebrek "
+"veroorzaakt."
+
+#: ../src/msw/dde.cpp:1159
+msgid "a memory allocation failed."
+msgstr "een geheugenreservering is mislukt."
+
+#: ../src/msw/dde.cpp:1162
+msgid "a client's attempt to establish a conversation has failed."
+msgstr "een poging van een cliënt om een conversatie op te zetten is mislukt."
+
+#: ../src/msw/dde.cpp:1165
+msgid "a transaction failed."
+msgstr "een transactie is mislukt."
+
+#: ../src/msw/dde.cpp:1168
+msgid "a request for a synchronous poke transaction has timed out."
+msgstr ""
+"aanvraag voor synchrone 'poke' transactie heeft een time-out veroorzaakt."
+
+#: ../src/msw/dde.cpp:1171
+msgid "an internal call to the PostMessage function has failed. "
+msgstr "een interne oproep van de PostMessage-functie is mislukt "
+
+#: ../src/msw/dde.cpp:1174
+msgid "reentrancy problem."
+msgstr "probleem met 'reentrancy'."
+
+#: ../src/msw/dde.cpp:1177
+msgid ""
+"a server-side transaction was attempted on a conversation\n"
+"that was terminated by the client, or the server\n"
+"terminated before completing a transaction."
+msgstr ""
+"vanaf de server werd een transactie geprobeerd op een conversatie\n"
+"die door de cliënt was beëindigd of de server heeft afgebroken\n"
+"voordat de transactie was afgerond."
+
+#: ../src/msw/dde.cpp:1180
+msgid "an internal error has occurred in the DDEML."
+msgstr "een interne fout is opgetreden in de DDEML."
+
+#: ../src/msw/dde.cpp:1183
+msgid "a request to end an advise transaction has timed out."
+msgstr ""
+"aanvraag voor beëindigen  van adviestransactie heeft een time-out "
+"veroorzaakt."
+
+#: ../src/msw/dde.cpp:1186
+msgid ""
+"an invalid transaction identifier was passed to a DDEML function.\n"
+"Once the application has returned from an XTYP_XACT_COMPLETE callback,\n"
+"the transaction identifier for that callback is no longer valid."
+msgstr ""
+"een ongeldige transactie-id werd doorgegeven aan een DDEML-functie.\n"
+"Als de applicatie verdergaat na een XTYP_XACT_COMPLETE-callback dan is\n"
+"de transactie-id voor die callback niet meer geldig."
+
+#: ../src/msw/dde.cpp:1189
+#, c-format
+msgid "Unknown DDE error %08x"
+msgstr "Onbekende DDE-fout %08x"
+
+#: ../src/msw/dialup.cpp:343
+msgid ""
+"Dial up functions are unavailable because the remote access service (RAS) is "
+"not installed on this machine. Please install it."
+msgstr ""
+"Inbelfuncties zijn niet beschikbaar omdat de inbelverbindingsoftware (RAS) "
+"niet op deze machine is geïnstalleerd. Installeer het a.u.b."
+
+#: ../src/msw/dialup.cpp:402
+#, c-format
+msgid ""
+"The version of remote access service (RAS) installed on this machine is too "
+"old, please upgrade (the following required function is missing: %s)."
+msgstr ""
+"De versie van de inbelverbindingsoftware (RAS) op deze machine is te oud. "
+"Bijwerken naar nieuwere versie is aanbevolen (de volgende benodigde functie "
+"ontbreekt: %s)."
+
+#: ../src/msw/dialup.cpp:437
+msgid "Failed to retrieve text of RAS error message"
+msgstr "Verkrijgen van tekst van inbel-foutmelding mislukt"
+
+#: ../src/msw/dialup.cpp:440
+#, c-format
+msgid "unknown error (error code %08x)."
+msgstr "onbekende fout (foutnummer %08x)."
+
+#: ../src/msw/dialup.cpp:492
+#, c-format
+msgid "Cannot find active dialup connection: %s"
+msgstr "Kan geen actieve inbelverbinding vinden: %s"
+
+#: ../src/msw/dialup.cpp:513
+msgid "Several active dialup connections found, choosing one randomly."
+msgstr ""
+"Meerdere actieve inbelverbindingen gevonden, willekeurige keuze gemaakt."
+
+#: ../src/msw/dialup.cpp:598 ../src/msw/dialup.cpp:832
+#, c-format
+msgid "Failed to establish dialup connection: %s"
+msgstr "Maken van inbelverbinding mislukt: %s"
+
+#: ../src/msw/dialup.cpp:664
+#, c-format
+msgid "Failed to get ISP names: %s"
+msgstr "Verkrijgen van namen van internetaanbieders mislukt: %s"
+
+#: ../src/msw/dialup.cpp:712
+msgid "Failed to connect: no ISP to dial."
+msgstr "Verbinding mislukt: geen internetaanbieder om te bellen."
+
+#: ../src/msw/dialup.cpp:732
+msgid "Choose ISP to dial"
+msgstr "Kies internetaanbieder om te bellen"
+
+#: ../src/msw/dialup.cpp:733
+msgid "Please choose which ISP do you want to connect to"
+msgstr "Kies a.u.b. een internetaanbieder waarmee u verbinding wilt maken"
+
+#: ../src/msw/dialup.cpp:766
+msgid "Failed to connect: missing username/password."
+msgstr "Verbinding mislukt: gebruikersnaam/wachtwoord ontbreekt."
+
+#: ../src/msw/dialup.cpp:796
+msgid "Cannot find the location of address book file"
+msgstr "Kan locatie van adresboek niet vinden"
+
+#: ../src/msw/dialup.cpp:827
+#, c-format
+msgid "Failed to initiate dialup connection: %s"
+msgstr "Maken van inbelverbinding mislukt: %s"
+
+#: ../src/msw/dialup.cpp:897
+msgid "Cannot hang up - no active dialup connection."
+msgstr "Kan niet ophangen - geen actieve inbelverbinding."
+
+#: ../src/msw/dialup.cpp:907
+#, c-format
+msgid "Failed to terminate the dialup connection: %s"
+msgstr "Ophangen van inbelverbinding mislukt: %s"
+
+#: ../src/msw/dib.cpp:313
+#, c-format
+msgid "Failed to save the bitmap image to file \"%s\"."
+msgstr "Opslaan van bitmap afbeelding naar bestand \"%s\" mislukt."
+
+#: ../src/msw/dib.cpp:543
+#, c-format
+msgid "Failed to allocate %luKb of memory for bitmap data."
+msgstr "Allokeren van %luKb geheugen voor bitmap-data is mislukt."
+
+#: ../src/msw/dir.cpp:241
+#, c-format
+msgid "Cannot enumerate files in directory '%s'"
+msgstr "Kan bestanden in map '%s' niet opsommen"
+
+#: ../src/msw/dirdlg.cpp:368
+msgid "Couldn't obtain folder name"
+msgstr "Kon de mapnaam niet verkrijgen"
+
+#: ../src/msw/dlmsw.cpp:163
+#, c-format
+msgid "(error %d: %s)"
+msgstr "(Fout %d: %s)"
+
+#: ../src/msw/dragimag.cpp:143 ../src/msw/dragimag.cpp:178
+#: ../src/msw/imaglist.cpp:309 ../src/msw/imaglist.cpp:331
+msgid "Couldn't add an image to the image list."
+msgstr "Kon geen afbeelding aan de lijst toevoegen."
+
+#: ../src/msw/enhmeta.cpp:94
+#, c-format
+msgid "Failed to load metafile from file \"%s\"."
+msgstr "Laden van metabestand uit bestand \"%s\" mislukt."
+
+#: ../src/msw/fdrepdlg.cpp:412
+#, c-format
+msgid "Failed to create the standard find/replace dialog (error code %d)"
+msgstr "Maken van het standaard zoek/vervang dialoog mislukt (foutcode %d)"
+
+#: ../src/msw/filedlg.cpp:1241
+msgid "Access to the file system is not allowed from secure desktop."
+msgstr ""
+
+#: ../src/msw/filedlg.cpp:1242
+msgid "Security warning"
+msgstr ""
+
+#: ../src/msw/filedlg.cpp:1533
+#, c-format
+msgid "File dialog failed with error code %0lx."
+msgstr "Bestandsdialoog mislukt met foutcode %0lx."
+
+#: ../src/msw/font.cpp:1120
+#, c-format
+msgid "Font file \"%s\" couldn't be loaded"
+msgstr "Lettertypebestand “%s” kan niet worden geladen"
+
+#: ../src/msw/fontdlg.cpp:220
+#, c-format
+msgid "Common dialog failed with error code %0lx."
+msgstr "Common dialoog mislukt met fout %0lx."
+
+#: ../src/msw/fswatcher.cpp:67
+msgid "Ungraceful worker thread termination"
+msgstr "Onbevallige WorkerThread beëindiging"
+
+#: ../src/msw/fswatcher.cpp:81
+msgid "Unable to create IOCP worker thread"
+msgstr "Niet mogelijk een IOCP WorklerThread aan te maken"
+
+#: ../src/msw/fswatcher.cpp:88
+msgid "Unable to start IOCP worker thread"
+msgstr "Kan IOCP WorkerThread niet opstarten"
+
+#: ../src/msw/fswatcher.cpp:140
+msgid "Monitoring individual files for changes is not supported currently."
+msgstr ""
+"Controleren van individuele bestanden op veranderingen wordt nog niet "
+"ondersteund."
+
+#: ../src/msw/fswatcher.cpp:165
+#, c-format
+msgid "Unable to set up watch for '%s'"
+msgstr "Kan controle op '%s' niet instellen"
+
+#: ../src/msw/fswatcher.cpp:466
+#, c-format
+msgid "Can't monitor non-existent directory \"%s\" for changes."
+msgstr "Kan niet bestaande map \"%s\" niet controleren op veranderingen."
+
+#: ../src/msw/glcanvas.cpp:577 ../src/unix/glx11.cpp:507
+msgid "OpenGL 3.0 or later is not supported by the OpenGL driver."
+msgstr "OpenGL 3.0 of hoger wordt niet ondersteund door de OpenGL driver."
+
+#: ../src/msw/glcanvas.cpp:601 ../src/osx/glcanvas_osx.cpp:395
+#: ../src/unix/glegl.cpp:304 ../src/unix/glx11.cpp:553
+msgid "Couldn't create OpenGL context"
+msgstr "Kan geen OpenGL-context maken"
+
+#: ../src/msw/glcanvas.cpp:1294
+msgid "Failed to initialize OpenGL"
+msgstr "Initialiseren van OpenGL mislukt"
+
+#: ../src/msw/graphicsd2d.cpp:607
+msgid "Could not register custom DirectWrite font loader."
+msgstr "Kan aangepaste DirectWrite-lettertypelader niet registreren."
+
+#: ../src/msw/helpchm.cpp:48
+msgid ""
+"MS HTML Help functions are unavailable because the MS HTML Help library is "
+"not installed on this machine. Please install it."
+msgstr ""
+"MS HTML Help functies zijn niet beschikbaar omdat de MS HTML Help "
+"bibliotheek niet op deze machine is geïnstalleerd. Installeer het a.u.b."
+
+#: ../src/msw/helpchm.cpp:55
+msgid "Failed to initialize MS HTML Help."
+msgstr "Initialiseren van MS HTML Help mislukt."
+
+#: ../src/msw/iniconf.cpp:458
+#, c-format
+msgid "Can't delete the INI file '%s'"
+msgstr "Kan INI-bestand '%s' niet verwijderen"
+
+#: ../src/msw/listctrl.cpp:995
+#, c-format
+msgid "Couldn't retrieve information about list control item %d."
+msgstr "Kon geen informatie verkrijgen over lijst-control element %d."
+
+#: ../src/msw/mdi.cpp:170 ../src/qt/mdi.cpp:253
+msgid "&Cascade"
+msgstr "&Trapsgewijs"
+
+#: ../src/msw/mdi.cpp:171
+msgid "Tile &Horizontally"
+msgstr "Onder elkaar"
+
+#: ../src/msw/mdi.cpp:172
+msgid "Tile &Vertically"
+msgstr "Naast elkaar"
+
+#: ../src/msw/mdi.cpp:174
+msgid "&Arrange Icons"
+msgstr "&Pictogrammen Schikken"
+
+#: ../src/msw/mdi.cpp:621
+msgid "Failed to create MDI parent frame."
+msgstr "Maken van MDI-hoofdvenster mislukt."
+
+#: ../src/msw/mimetype.cpp:234
+#, c-format
+msgid "Failed to create registry entry for '%s' files."
+msgstr "Maken van registersleutel '%s' mislukt."
+
+#: ../src/msw/ole/automtn.cpp:495
+#, c-format
+msgid "Failed to find CLSID of \"%s\""
+msgstr "Vinden van CLSID \"%s\" mislukt."
+
+#: ../src/msw/ole/automtn.cpp:512
+#, c-format
+msgid "Failed to create an instance of \"%s\""
+msgstr "Aanmaken exemplaarset van \"%s\" mislukt"
+
+#: ../src/msw/ole/automtn.cpp:552
+#, c-format
+msgid "Cannot get an active instance of \"%s\""
+msgstr "Kan geen actief exemplaarset verkrijgen van \"%s\""
+
+#: ../src/msw/ole/automtn.cpp:564
+#, c-format
+msgid "Failed to get OLE automation interface for \"%s\""
+msgstr "Verkrijgen van OLE automation interface voor \"%s\" mislukt"
+
+#: ../src/msw/ole/automtn.cpp:621
+msgid "Unknown name or named argument."
+msgstr "Onbekende naam of benoemd argument."
+
+#: ../src/msw/ole/automtn.cpp:625
+msgid "Incorrect number of arguments."
+msgstr "Onjuist aantal argumenten."
+
+#: ../src/msw/ole/automtn.cpp:637
+msgid "Unknown exception"
+msgstr "Onbekende uitzondering"
+
+#: ../src/msw/ole/automtn.cpp:642
+msgid "Method or property not found."
+msgstr "Methode of eigenschap niet gevonden."
+
+#: ../src/msw/ole/automtn.cpp:646
+msgid "Overflow while coercing argument values."
+msgstr "Overloop tijdens afdwingen argument waarden."
+
+#: ../src/msw/ole/automtn.cpp:650
+msgid "Object implementation does not support named arguments."
+msgstr "Object implementatie ondersteunt geen benoemde argumenten."
+
+#: ../src/msw/ole/automtn.cpp:654
+msgid "The locale ID is unknown."
+msgstr "De lokale ID is onbekend."
+
+#: ../src/msw/ole/automtn.cpp:658
+msgid "Missing a required parameter."
+msgstr "Er ontbreekt een vereiste parameter."
+
+#: ../src/msw/ole/automtn.cpp:662
+#, c-format
+msgid "Argument %u not found."
+msgstr "Argument %u niet gevonden."
+
+#: ../src/msw/ole/automtn.cpp:666
+#, c-format
+msgid "Type mismatch in argument %u."
+msgstr "Type komt niet overeen in argument %u."
+
+#: ../src/msw/ole/automtn.cpp:670
+msgid "The system cannot find the file specified."
+msgstr "Het systeem kan het opgegeven bestand niet vinden."
+
+#: ../src/msw/ole/automtn.cpp:674
+msgid "Class not registered."
+msgstr "Klasse niet geregistreerd."
+
+#: ../src/msw/ole/automtn.cpp:678
+#, c-format
+msgid "Unknown error %08x"
+msgstr "Onbekende fout %08x"
+
+#: ../src/msw/ole/automtn.cpp:682
+#, c-format
+msgid "OLE Automation error in %s: %s"
+msgstr "OLE Automatiseringsfout in %s: %s"
+
+#: ../src/msw/ole/dataobj.cpp:385
+#, c-format
+msgid "Couldn't register clipboard format '%s'."
+msgstr "Kon klembord-formaat '%s' niet registreren."
+
+#: ../src/msw/ole/dataobj.cpp:402
+#, c-format
+msgid "The clipboard format '%d' doesn't exist."
+msgstr "Het klembord-formaat '%d' bestaat niet."
+
+#: ../src/msw/progdlg.cpp:1025
+msgid "Skip"
+msgstr "Overslaan"
+
+#: ../src/msw/registry.cpp:141
+#, c-format
+msgid "unknown (%lu)"
+msgstr "onbekend (%lu)"
+
+#: ../src/msw/registry.cpp:409
+#, c-format
+msgid "Can't get info about registry key '%s'"
+msgstr "Kan geen informatie krijgen over registersleutel '%s'"
+
+#: ../src/msw/registry.cpp:445
+#, c-format
+msgid "Can't open registry key '%s'"
+msgstr "Kan registersleutel '%s' niet openen"
+
+#: ../src/msw/registry.cpp:478
+#, c-format
+msgid "Can't create registry key '%s'"
+msgstr "Kan registersleutel '%s' niet maken"
+
+#: ../src/msw/registry.cpp:497
+#, c-format
+msgid "Can't close registry key '%s'"
+msgstr "Kan registersleutel '%s' niet sluiten"
+
+#: ../src/msw/registry.cpp:512
+#, c-format
+msgid "Registry value '%s' already exists."
+msgstr "Registerwaarde '%s' bestaat al."
+
+#: ../src/msw/registry.cpp:520
+#, c-format
+msgid "Failed to rename registry value '%s' to '%s'."
+msgstr "Kan de naam van de registerwaarde '%s' niet wijzigen in '%s'."
+
+#: ../src/msw/registry.cpp:575
+#, c-format
+msgid "Can't copy values of unsupported type %d."
+msgstr "Kan geen waarden van niet-ondersteund type %d kopiëren."
+
+#: ../src/msw/registry.cpp:586
+#, c-format
+msgid "Registry key '%s' does not exist, cannot rename it."
+msgstr "Registersleutel '%s' bestaat niet, kan niet hernoemen."
+
+#: ../src/msw/registry.cpp:617
+#, c-format
+msgid "Registry key '%s' already exists."
+msgstr "Registersleutel '%s' bestaat al."
+
+#: ../src/msw/registry.cpp:625
+#, c-format
+msgid "Failed to rename the registry key '%s' to '%s'."
+msgstr "Kan de naam van de registersleutel '%s' niet wijzigen in '%s'."
+
+#: ../src/msw/registry.cpp:670
+#, c-format
+msgid "Failed to copy the registry subkey '%s' to '%s'."
+msgstr "Kopiëren van registersubsleutel '%s' naar '%s' mislukt."
+
+#: ../src/msw/registry.cpp:683
+#, c-format
+msgid "Failed to copy registry value '%s'"
+msgstr "Kopiëren van registerwaarde '%s' mislukt"
+
+#: ../src/msw/registry.cpp:692
+#, c-format
+msgid "Failed to copy the contents of registry key '%s' to '%s'."
+msgstr "Kopiëren van registersleutel '%s' naar '%s' mislukt."
+
+#: ../src/msw/registry.cpp:718
+#, c-format
+msgid ""
+"Registry key '%s' is needed for normal system operation,\n"
+"deleting it will leave your system in unusable state:\n"
+"operation aborted."
+msgstr ""
+"Registersleutel '%s' is nodig voor normaal systeemgebruik,\n"
+"wissen maakt uw systeem onbruikbaar:\n"
+"bewerking afgebroken."
+
+#: ../src/msw/registry.cpp:754
+#, c-format
+msgid "Can't delete key '%s'"
+msgstr "Kan sleutel '%s' niet verwijderen"
+
+#: ../src/msw/registry.cpp:782
+#, c-format
+msgid "Can't delete value '%s' from key '%s'"
+msgstr "Kan waarde '%s' niet verwijderen uit sleutel '%s'"
+
+#: ../src/msw/registry.cpp:855 ../src/msw/registry.cpp:887
+#: ../src/msw/registry.cpp:929 ../src/msw/registry.cpp:1000
+#, c-format
+msgid "Can't read value of key '%s'"
+msgstr "Kan waarde van sleutel '%s' niet lezen"
+
+#: ../src/msw/registry.cpp:873 ../src/msw/registry.cpp:915
+#: ../src/msw/registry.cpp:963 ../src/msw/registry.cpp:1106
+#, c-format
+msgid "Can't set value of '%s'"
+msgstr "Kan waarde van '%s' niet instellen"
+
+#: ../src/msw/registry.cpp:894 ../src/msw/registry.cpp:943
+#, c-format
+msgid "Registry value \"%s\" is not numeric (but of type %s)"
+msgstr "Registerwaarde “%s” is niet numeriek (maar van het type %s)"
+
+#: ../src/msw/registry.cpp:979
+#, c-format
+msgid "Registry value \"%s\" is not binary (but of type %s)"
+msgstr "Registerwaarde “%s” is niet binair (maar van het type %s)"
+
+#: ../src/msw/registry.cpp:1028
+#, c-format
+msgid "Registry value \"%s\" is not text (but of type %s)"
+msgstr "Registerwaarde “%s” is geen tekst (maar van het type %s)"
+
+#: ../src/msw/registry.cpp:1089
+#, c-format
+msgid "Can't read value of '%s'"
+msgstr "Kan waarde van '%s' niet lezen"
+
+#: ../src/msw/registry.cpp:1157
+#, c-format
+msgid "Can't enumerate values of key '%s'"
+msgstr "Kan waarden van sleutel '%s' niet opsommen"
+
+#: ../src/msw/registry.cpp:1196
+#, c-format
+msgid "Can't enumerate subkeys of key '%s'"
+msgstr "Kan subsleutels van sleutel '%s' niet opsommen"
+
+#: ../src/msw/registry.cpp:1262
+#, c-format
+msgid ""
+"Exporting registry key: file \"%s\" already exists and won't be overwritten."
+msgstr ""
+"Exporteren registersleutel: bestand \"%s\" bestaat al en wordt niet "
+"overschreven."
+
+#: ../src/msw/registry.cpp:1411
+#, c-format
+msgid "Can't export value of unsupported type %d."
+msgstr "Kan geen waarde van niet-ondersteund type %d exporteren."
+
+#: ../src/msw/registry.cpp:1427
+#, c-format
+msgid "Ignoring value \"%s\" of the key \"%s\"."
+msgstr "Negeren van waarde \"%s\" van de sleutel \"%s\"."
+
+#: ../src/msw/textctrl.cpp:596
+msgid ""
+"Impossible to create a rich edit control, using simple text control instead. "
+"Please reinstall riched32.dll"
+msgstr ""
+"Niet mogelijk om Rich Edit control te maken, gewone tekst wordt gebruikt. "
+"Installeer riched32.dll a.u.b. opnieuw"
+
+#: ../src/msw/thread.cpp:522 ../src/unix/threadpsx.cpp:850
+msgid "Cannot start thread: error writing TLS."
+msgstr "Kan thread niet starten: fout bij schrijven TLS."
+
+#: ../src/msw/thread.cpp:613
+msgid "Can't set thread priority"
+msgstr "Kan thread-prioriteit niet instellen"
+
+#: ../src/msw/thread.cpp:649
+msgid "Can't create thread"
+msgstr "Kan thread niet maken"
+
+#: ../src/msw/thread.cpp:668
+msgid "Couldn't terminate thread"
+msgstr "Kon thread niet beëindigen"
+
+#: ../src/msw/thread.cpp:799
+msgid "Cannot wait for thread termination"
+msgstr "Kan niet wachten op thread-beëindiging"
+
+#: ../src/msw/thread.cpp:873
+#, c-format
+msgid "Cannot suspend thread %lx"
+msgstr "Kan thread %lx niet tijdelijk buiten dienst stellen"
+
+#: ../src/msw/thread.cpp:903
+#, c-format
+msgid "Cannot resume thread %lx"
+msgstr "Kan thread %lx niet voortzetten"
+
+#: ../src/msw/thread.cpp:932
+msgid "Couldn't get the current thread pointer"
+msgstr "Kon pointer naar huidige thread niet verkrijgen"
+
+#: ../src/msw/thread.cpp:1333
+msgid ""
+"Thread module initialization failed: impossible to allocate index in thread "
+"local storage"
+msgstr ""
+"Threadmodule-initialisatie mislukt: niet mogelijk een index te reserveren in "
+"lokale thread-geheugenruimte"
+
+#: ../src/msw/thread.cpp:1345
+msgid ""
+"Thread module initialization failed: cannot store value in thread local "
+"storage"
+msgstr ""
+"Threadmodule-initialisatie mislukt: kan geen waarde opslaan in lokale thread-"
+"geheugenruimte"
+
+#: ../src/msw/timer.cpp:133
+msgid "Couldn't create a timer"
+msgstr "Kon geen timer creëren"
+
+#: ../src/msw/utils.cpp:372
+msgid "can't find user's HOME, using current directory."
+msgstr "kan gebruikers startlocatie niet vinden, gebruik huidige map."
+
+#: ../src/msw/utils.cpp:662
+#, c-format
+msgid "Failed to kill process %d"
+msgstr "Abrupt afsluiten van proces %d mislukt"
+
+#: ../src/msw/utils.cpp:986
+#, c-format
+msgid "Failed to load resource \"%s\"."
+msgstr "Laden van bronbestand \"%s\" mislukt."
+
+#: ../src/msw/utils.cpp:993
+#, c-format
+msgid "Failed to lock resource \"%s\"."
+msgstr "Vergrendelen van bronbestand \"%s\" mislukt."
+
+#. TRANSLATORS: MS Windows build number
+#: ../src/msw/utils.cpp:1209
+#, c-format
+msgid "build %lu"
+msgstr "build %lu"
+
+#: ../src/msw/utils.cpp:1218
+msgid ", 64-bit edition"
+msgstr ", 64-bit editie"
+
+#: ../src/msw/utilsexc.cpp:224
+msgid "Failed to create an anonymous pipe"
+msgstr "Maken van een anonieme pipe mislukt"
+
+#: ../src/msw/utilsexc.cpp:697
+msgid "Failed to redirect the child process IO"
+msgstr "Omleiden van I/O van child proces mislukt"
+
+#: ../src/msw/utilsexc.cpp:870
+#, c-format
+msgid "Execution of command '%s' failed"
+msgstr "Uitvoering van opdracht '%s' mislukt"
+
+#: ../src/msw/volume.cpp:337
+msgid "Failed to load mpr.dll."
+msgstr "Laden van mpr.dll mislukt."
+
+#: ../src/msw/volume.cpp:506
+#, c-format
+msgid "Cannot read typename from '%s'!"
+msgstr "Kan typenaam van '%s' niet lezen!"
+
+#: ../src/msw/volume.cpp:615
+#, c-format
+msgid "Cannot load icon from '%s'."
+msgstr "Kan pictogram niet laden van '%s'."
+
+#: ../src/msw/webview_edge.cpp:285
+msgid "This program was compiled without support for setting Edge proxy."
+msgstr ""
+
+#: ../src/msw/webview_ie.cpp:1010
+msgid "Failed to find web view emulation level in the registry"
+msgstr "Kan emulatieniveau voor webweergave niet vinden in het register"
+
+#: ../src/msw/webview_ie.cpp:1019
+msgid "Failed to set web view to modern emulation level"
+msgstr "Kan webweergave niet instellen op modern emulatieniveau"
+
+#: ../src/msw/webview_ie.cpp:1027
+msgid "Failed to reset web view to standard emulation level"
+msgstr "Kan webweergave niet resetten naar standaard emulatieniveau"
+
+#: ../src/msw/webview_ie.cpp:1049
+msgid "Can't run JavaScript script without a valid HTML document"
+msgstr "Kan geen JavaScript-script uitvoeren zonder een geldig HTML-document"
+
+#: ../src/msw/webview_ie.cpp:1056
+msgid "Can't get the JavaScript object"
+msgstr "Kan het JavaScript-object niet ophalen"
+
+#: ../src/msw/webview_ie.cpp:1070
+msgid "failed to evaluate"
+msgstr "evalueren mislukt"
+
+#: ../src/osx/cocoa/filedlg.mm:412
+msgid "File type:"
+msgstr "Bestandstype:"
+
+#: ../src/osx/cocoa/menu.mm:242
+#, fuzzy
+msgctxt "macOS menu name"
+msgid "Window"
+msgstr "Venster"
+
+#: ../src/osx/cocoa/menu.mm:259
+#, fuzzy
+msgctxt "macOS menu name"
+msgid "Help"
+msgstr "Help"
+
+#: ../src/osx/cocoa/menu.mm:298
+#, fuzzy
+msgctxt "macOS menu item"
+msgid "Minimize"
+msgstr "Minimaliseren"
+
+#: ../src/osx/cocoa/menu.mm:303
+#, fuzzy
+msgctxt "macOS menu item"
+msgid "Zoom"
+msgstr "Inzoomen"
+
+#: ../src/osx/cocoa/menu.mm:309
+#, fuzzy
+msgctxt "macOS menu item"
+msgid "Bring All to Front"
+msgstr "Breng alles naar voren"
+
+#: ../src/osx/core/sound.cpp:143
+#, c-format
+msgid "Failed to load sound from \"%s\" (error %d)."
+msgstr "Laden van geluid \"%s\" mislukt (fout %d)."
+
+#: ../src/osx/fontutil.cpp:80
+#, c-format
+msgid "Font file \"%s\" doesn't exist."
+msgstr "Lettertypebestand “%s” bestaat niet."
+
+#: ../src/osx/fontutil.cpp:88
+#, c-format
+msgid ""
+"Font file \"%s\" cannot be used as it is not inside the font directory "
+"\"%s\"."
+msgstr ""
+"Lettertypebestand “%s” kan niet worden gebruikt omdat het zich niet in de "
+"lettertypemap “%s” bevindt."
+
+#: ../src/osx/menu_osx.cpp:496
+#, c-format
+msgctxt "macOS menu item"
+msgid "About %s"
+msgstr "Over %s"
+
+#: ../src/osx/menu_osx.cpp:499
+msgctxt "macOS menu item"
+msgid "About..."
+msgstr "Over..."
+
+#: ../src/osx/menu_osx.cpp:508
+msgctxt "macOS menu item"
+msgid "Preferences..."
+msgstr "Voorkeuren..."
+
+#: ../src/osx/menu_osx.cpp:512
+msgctxt "macOS menu item"
+msgid "Services"
+msgstr "Diensten"
+
+#: ../src/osx/menu_osx.cpp:519
+#, c-format
+msgctxt "macOS menu item"
+msgid "Hide %s"
+msgstr "Verberg %s"
+
+#: ../src/osx/menu_osx.cpp:522
+#, fuzzy
+msgctxt "macOS menu item"
+msgid "Hide Application"
+msgstr "Applicatie"
+
+#: ../src/osx/menu_osx.cpp:526
+msgctxt "macOS menu item"
+msgid "Hide Others"
+msgstr "Verberg anderen"
+
+#: ../src/osx/menu_osx.cpp:528
+msgctxt "macOS menu item"
+msgid "Show All"
+msgstr "Toon alles"
+
+#: ../src/osx/menu_osx.cpp:534
+#, c-format
+msgctxt "macOS menu item"
+msgid "Quit %s"
+msgstr "Stop %s"
+
+#: ../src/osx/menu_osx.cpp:537
+#, fuzzy
+msgctxt "macOS menu item"
+msgid "Quit Application"
+msgstr "Applicatie"
+
+#: ../src/osx/webview_webkit.mm:444
+msgid "Printing is not supported by the system web control"
+msgstr "Afdrukken wordt niet ondersteund door de webbesturing van het systeem"
+
+#: ../src/osx/webview_webkit.mm:453
+msgid "Print operation could not be initialized"
+msgstr "Afdrukbewerking kon niet worden geïnitialiseerd"
+
+#. TRANSLATORS: Label of font point size
+#: ../src/propgrid/advprops.cpp:605
+msgid "Point Size"
+msgstr "Puntgrootte"
+
+#. TRANSLATORS: Label of font face name
+#: ../src/propgrid/advprops.cpp:615
+msgid "Face Name"
+msgstr "Letterbeeld Naam"
+
+#. TRANSLATORS: Label of font style
+#: ../src/propgrid/advprops.cpp:623 ../src/richtext/richtextformatdlg.cpp:331
+msgid "Style"
+msgstr "Stijl"
+
+#. TRANSLATORS: Label of font weight
+#: ../src/propgrid/advprops.cpp:628
+msgid "Weight"
+msgstr "Gewicht"
+
+#. TRANSLATORS: Label of underlined font
+#: ../src/propgrid/advprops.cpp:633 ../src/richtext/richtextfontpage.cpp:358
+msgid "Underlined"
+msgstr "Onderstreept"
+
+#. TRANSLATORS: Label of font family
+#: ../src/propgrid/advprops.cpp:637
+msgid "Family"
+msgstr "Familie"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:801
+msgid "AppWorkspace"
+msgstr "AppWorkspace"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:802
+msgid "ActiveBorder"
+msgstr "ActiveBorder"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:803
+msgid "ActiveCaption"
+msgstr "ActiveCaption"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:804
+msgid "ButtonFace"
+msgstr "ButtonFace"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:805
+msgid "ButtonHighlight"
+msgstr "ButtonHighlight"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:806
+msgid "ButtonShadow"
+msgstr "ButtonShadow"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:807
+msgid "ButtonText"
+msgstr "ButtonText"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:808
+msgid "CaptionText"
+msgstr "CaptionText"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:809
+msgid "ControlDark"
+msgstr "ControlDark"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:810
+msgid "ControlLight"
+msgstr "ControlLight"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:812
+msgid "GrayText"
+msgstr "GrayText"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:813
+msgid "Highlight"
+msgstr "Markeer"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:814
+msgid "HighlightText"
+msgstr "Gemarkeerde tekst"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:815
+msgid "InactiveBorder"
+msgstr "InactiveBorder"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:816
+msgid "InactiveCaption"
+msgstr "InactiveCaption"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:817
+msgid "InactiveCaptionText"
+msgstr "InactiveCaptionText"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:818
+msgid "Menu"
+msgstr "Menu"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:819
+msgid "Scrollbar"
+msgstr "Scrollbar"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:820
+msgid "Tooltip"
+msgstr "Tooltip"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:821
+msgid "TooltipText"
+msgstr "TooltipText"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:822
+msgid "Window"
+msgstr "Venster"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:823
+msgid "WindowFrame"
+msgstr "WindowFrame"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:824
+msgid "WindowText"
+msgstr "WindowText"
+
+#. TRANSLATORS: Custom colour choice entry
+#: ../src/propgrid/advprops.cpp:825 ../src/propgrid/advprops.cpp:1532
+#: ../src/propgrid/advprops.cpp:1576
+msgid "Custom"
+msgstr "Aangepast"
+
+#: ../src/propgrid/advprops.cpp:1558
+msgid "Black"
+msgstr "Zwart"
+
+#: ../src/propgrid/advprops.cpp:1559
+msgid "Maroon"
+msgstr "Kastanjebruin"
+
+#: ../src/propgrid/advprops.cpp:1560
+msgid "Navy"
+msgstr "Marineblauw"
+
+#: ../src/propgrid/advprops.cpp:1561
+msgid "Purple"
+msgstr "Paars"
+
+#: ../src/propgrid/advprops.cpp:1562
+msgid "Teal"
+msgstr "Blauwgroen"
+
+#: ../src/propgrid/advprops.cpp:1563
+msgid "Gray"
+msgstr "Grijs"
+
+#: ../src/propgrid/advprops.cpp:1564
+msgid "Green"
+msgstr "Groen"
+
+#: ../src/propgrid/advprops.cpp:1565
+msgid "Olive"
+msgstr "Olijfgroen"
+
+#: ../src/propgrid/advprops.cpp:1566
+msgid "Brown"
+msgstr "Bruin"
+
+#: ../src/propgrid/advprops.cpp:1567
+msgid "Blue"
+msgstr "Blauw"
+
+#: ../src/propgrid/advprops.cpp:1568
+msgid "Fuchsia"
+msgstr "Fuchsiapaars"
+
+#: ../src/propgrid/advprops.cpp:1569
+msgid "Red"
+msgstr "Rood"
+
+#: ../src/propgrid/advprops.cpp:1570
+msgid "Orange"
+msgstr "Oranje"
+
+#: ../src/propgrid/advprops.cpp:1571
+msgid "Silver"
+msgstr "Zilver"
+
+#: ../src/propgrid/advprops.cpp:1572
+msgid "Lime"
+msgstr "Citroengeel"
+
+#: ../src/propgrid/advprops.cpp:1573
+msgid "Aqua"
+msgstr "Agua"
+
+#: ../src/propgrid/advprops.cpp:1574
+msgid "Yellow"
+msgstr "Geel"
+
+#: ../src/propgrid/advprops.cpp:1575
+msgid "White"
+msgstr "Wit"
+
+#: ../src/propgrid/advprops.cpp:1718
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Default"
+msgstr "Standaard"
+
+#: ../src/propgrid/advprops.cpp:1719
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Arrow"
+msgstr "Pijl"
+
+#: ../src/propgrid/advprops.cpp:1720
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Right Arrow"
+msgstr "Right Arrow"
+
+#: ../src/propgrid/advprops.cpp:1721
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Blank"
+msgstr "Blanco"
+
+#: ../src/propgrid/advprops.cpp:1722
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Bullseye"
+msgstr "Roos"
+
+#: ../src/propgrid/advprops.cpp:1723
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Character"
+msgstr "Letterteken"
+
+#: ../src/propgrid/advprops.cpp:1724
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Cross"
+msgstr "Kruis"
+
+#: ../src/propgrid/advprops.cpp:1725
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Hand"
+msgstr "Hand"
+
+#: ../src/propgrid/advprops.cpp:1726
+#, fuzzy
+msgctxt "system cursor name"
+msgid "I-Beam"
+msgstr "I-Beam"
+
+#: ../src/propgrid/advprops.cpp:1727
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Left Button"
+msgstr "Linker knop"
+
+#: ../src/propgrid/advprops.cpp:1728
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Magnifier"
+msgstr "Vergrootglas"
+
+#: ../src/propgrid/advprops.cpp:1729
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Middle Button"
+msgstr "Middelste knop"
+
+#: ../src/propgrid/advprops.cpp:1730
+#, fuzzy
+msgctxt "system cursor name"
+msgid "No Entry"
+msgstr "Geen toegang"
+
+#: ../src/propgrid/advprops.cpp:1731
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Paint Brush"
+msgstr "Penseel"
+
+#: ../src/propgrid/advprops.cpp:1732
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Pencil"
+msgstr "Potlood"
+
+#: ../src/propgrid/advprops.cpp:1733
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Point Left"
+msgstr "Wijs links"
+
+#: ../src/propgrid/advprops.cpp:1734
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Point Right"
+msgstr "Wijs rechts"
+
+#: ../src/propgrid/advprops.cpp:1735
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Question Arrow"
+msgstr "Vraagteken pijl"
+
+#: ../src/propgrid/advprops.cpp:1736
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Right Button"
+msgstr "Rechter knop"
+
+#: ../src/propgrid/advprops.cpp:1737
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Sizing NE-SW"
+msgstr "Dimensionering NO-ZW"
+
+#: ../src/propgrid/advprops.cpp:1738
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Sizing N-S"
+msgstr "Dimensionering N-Z"
+
+#: ../src/propgrid/advprops.cpp:1739
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Sizing NW-SE"
+msgstr "Dimensionering NW-ZO"
+
+#: ../src/propgrid/advprops.cpp:1740
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Sizing W-E"
+msgstr "Dimensionering W-O"
+
+#: ../src/propgrid/advprops.cpp:1741
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Sizing"
+msgstr "Dimensionering"
+
+#: ../src/propgrid/advprops.cpp:1742
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Spraycan"
+msgstr "Spuitbus"
+
+#: ../src/propgrid/advprops.cpp:1743
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Wait"
+msgstr "Wacht"
+
+#: ../src/propgrid/advprops.cpp:1744
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Watch"
+msgstr "Bekijk"
+
+#: ../src/propgrid/advprops.cpp:1745
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Wait Arrow"
+msgstr "Wacht pijl"
+
+#: ../src/propgrid/advprops.cpp:2109
+msgid "Make a selection:"
+msgstr "Maak een selectie:"
+
+#: ../src/propgrid/manager.cpp:394
+msgid "Property"
+msgstr "Eigenschap"
+
+#: ../src/propgrid/manager.cpp:395
+msgid "Value"
+msgstr "Waarde"
+
+#: ../src/propgrid/manager.cpp:1683
+msgid "Categorized Mode"
+msgstr "Gecatogoriseerde modus"
+
+#: ../src/propgrid/manager.cpp:1709
+msgid "Alphabetic Mode"
+msgstr "Alfabetische modus"
+
+#. TRANSLATORS: Name of Boolean false value
+#: ../src/propgrid/propgrid.cpp:230
+msgid "False"
+msgstr "Onwaar"
+
+#. TRANSLATORS: Name of Boolean true value
+#: ../src/propgrid/propgrid.cpp:232
+msgid "True"
+msgstr "Waar"
+
+#. TRANSLATORS: Text  displayed for unspecified value
+#: ../src/propgrid/propgrid.cpp:428
+msgid "Unspecified"
+msgstr "Ongespecifieerd"
+
+#. TRANSLATORS: Caption of message box displaying any property error
+#: ../src/propgrid/propgrid.cpp:3145 ../src/propgrid/propgrid.cpp:3282
+msgid "Property Error"
+msgstr "Eigenschapsfout"
+
+#: ../src/propgrid/propgrid.cpp:3259
+msgid "You have entered invalid value. Press ESC to cancel editing."
+msgstr ""
+"U heeft een ongeldige waarde ingevoerd. Druk op Esc om de bewerking te "
+"annuleren."
+
+#: ../src/propgrid/propgrid.cpp:6608
+#, c-format
+msgid "Error in resource: %s"
+msgstr "Fout in bron: %s"
+
+#: ../src/propgrid/propgridiface.cpp:377
+#, c-format
+msgid ""
+"Type operation \"%s\" failed: Property labeled \"%s\" is of type \"%s\", NOT "
+"\"%s\"."
+msgstr ""
+"Type handeling \"%s\" mislukt: Eigenschap met label \"%s\" is van type "
+"\"%s\", NIET \"%s\"."
+
+#: ../src/propgrid/props.cpp:159
+#, c-format
+msgid "Unknown base %d. Base 10 will be used."
+msgstr "Onbekende basis %d. Basis 10 zal worden gebruikt."
+
+#: ../src/propgrid/props.cpp:324
+#, c-format
+msgid "Value must be %s or higher."
+msgstr "Waarde moet %s zijn of meer."
+
+#: ../src/propgrid/props.cpp:329 ../src/propgrid/props.cpp:356
+#, c-format
+msgid "Value must be between %s and %s."
+msgstr "Waarde moet tussen %s en %s liggen."
+
+#: ../src/propgrid/props.cpp:351
+#, c-format
+msgid "Value must be %s or less."
+msgstr "Waarde moet %s zijn of minder."
+
+#: ../src/propgrid/props.cpp:1058
+#, c-format
+msgid "Not %s"
+msgstr "Niet %s"
+
+#: ../src/propgrid/props.cpp:1770
+msgid "Choose a directory:"
+msgstr "Kies een map:"
+
+#: ../src/propgrid/props.cpp:2055
+msgid "Choose a file"
+msgstr "Kies een bestand"
+
+#: ../src/qt/mdi.cpp:254
+msgid "&Tile"
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:147
+#: ../src/richtext/richtextformatdlg.cpp:376
+msgid "Background"
+msgstr "Achtergrond"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:159
+msgid "Background &colour:"
+msgstr "Achtergrond&kleur:"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:161
+#: ../src/richtext/richtextbackgroundpage.cpp:163
+msgid "Enables a background colour."
+msgstr "Achtergrondkleur inschakelen."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:167
+#: ../src/richtext/richtextbackgroundpage.cpp:169
+msgid "The background colour."
+msgstr "De achtergrondkleur."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:178
+msgid "Shadow"
+msgstr "Schaduw"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:193
+msgid "Use &shadow"
+msgstr "Gebruik &schaduw"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:195
+#: ../src/richtext/richtextbackgroundpage.cpp:197
+msgid "Enables a shadow."
+msgstr "Schakelt een schaduw in."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:211
+msgid "&Horizontal offset:"
+msgstr "&Horizontale verschuiving:"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:218
+#: ../src/richtext/richtextbackgroundpage.cpp:220
+msgid "The horizontal offset."
+msgstr "De horizontale verschuiving."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:224
+#: ../src/richtext/richtextbackgroundpage.cpp:227
+#: ../src/richtext/richtextbackgroundpage.cpp:228
+#: ../src/richtext/richtextbackgroundpage.cpp:247
+#: ../src/richtext/richtextbackgroundpage.cpp:250
+#: ../src/richtext/richtextbackgroundpage.cpp:251
+#: ../src/richtext/richtextbackgroundpage.cpp:287
+#: ../src/richtext/richtextbackgroundpage.cpp:290
+#: ../src/richtext/richtextbackgroundpage.cpp:291
+#: ../src/richtext/richtextbackgroundpage.cpp:314
+#: ../src/richtext/richtextbackgroundpage.cpp:317
+#: ../src/richtext/richtextbackgroundpage.cpp:318
+#: ../src/richtext/richtextborderspage.cpp:252
+#: ../src/richtext/richtextborderspage.cpp:255
+#: ../src/richtext/richtextborderspage.cpp:256
+#: ../src/richtext/richtextborderspage.cpp:286
+#: ../src/richtext/richtextborderspage.cpp:289
+#: ../src/richtext/richtextborderspage.cpp:290
+#: ../src/richtext/richtextborderspage.cpp:320
+#: ../src/richtext/richtextborderspage.cpp:323
+#: ../src/richtext/richtextborderspage.cpp:324
+#: ../src/richtext/richtextborderspage.cpp:354
+#: ../src/richtext/richtextborderspage.cpp:357
+#: ../src/richtext/richtextborderspage.cpp:358
+#: ../src/richtext/richtextborderspage.cpp:420
+#: ../src/richtext/richtextborderspage.cpp:423
+#: ../src/richtext/richtextborderspage.cpp:424
+#: ../src/richtext/richtextborderspage.cpp:454
+#: ../src/richtext/richtextborderspage.cpp:457
+#: ../src/richtext/richtextborderspage.cpp:458
+#: ../src/richtext/richtextborderspage.cpp:488
+#: ../src/richtext/richtextborderspage.cpp:491
+#: ../src/richtext/richtextborderspage.cpp:492
+#: ../src/richtext/richtextborderspage.cpp:522
+#: ../src/richtext/richtextborderspage.cpp:525
+#: ../src/richtext/richtextborderspage.cpp:526
+#: ../src/richtext/richtextborderspage.cpp:590
+#: ../src/richtext/richtextborderspage.cpp:593
+#: ../src/richtext/richtextborderspage.cpp:594
+#: ../src/richtext/richtextfontpage.cpp:177
+#: ../src/richtext/richtextmarginspage.cpp:199
+#: ../src/richtext/richtextmarginspage.cpp:201
+#: ../src/richtext/richtextmarginspage.cpp:202
+#: ../src/richtext/richtextmarginspage.cpp:224
+#: ../src/richtext/richtextmarginspage.cpp:226
+#: ../src/richtext/richtextmarginspage.cpp:227
+#: ../src/richtext/richtextmarginspage.cpp:247
+#: ../src/richtext/richtextmarginspage.cpp:249
+#: ../src/richtext/richtextmarginspage.cpp:250
+#: ../src/richtext/richtextmarginspage.cpp:272
+#: ../src/richtext/richtextmarginspage.cpp:274
+#: ../src/richtext/richtextmarginspage.cpp:275
+#: ../src/richtext/richtextmarginspage.cpp:313
+#: ../src/richtext/richtextmarginspage.cpp:315
+#: ../src/richtext/richtextmarginspage.cpp:316
+#: ../src/richtext/richtextmarginspage.cpp:338
+#: ../src/richtext/richtextmarginspage.cpp:340
+#: ../src/richtext/richtextmarginspage.cpp:341
+#: ../src/richtext/richtextmarginspage.cpp:361
+#: ../src/richtext/richtextmarginspage.cpp:363
+#: ../src/richtext/richtextmarginspage.cpp:364
+#: ../src/richtext/richtextmarginspage.cpp:386
+#: ../src/richtext/richtextmarginspage.cpp:388
+#: ../src/richtext/richtextmarginspage.cpp:389
+#: ../src/richtext/richtextsizepage.cpp:337
+#: ../src/richtext/richtextsizepage.cpp:340
+#: ../src/richtext/richtextsizepage.cpp:341
+#: ../src/richtext/richtextsizepage.cpp:371
+#: ../src/richtext/richtextsizepage.cpp:374
+#: ../src/richtext/richtextsizepage.cpp:375
+#: ../src/richtext/richtextsizepage.cpp:398
+#: ../src/richtext/richtextsizepage.cpp:401
+#: ../src/richtext/richtextsizepage.cpp:402
+#: ../src/richtext/richtextsizepage.cpp:425
+#: ../src/richtext/richtextsizepage.cpp:428
+#: ../src/richtext/richtextsizepage.cpp:429
+#: ../src/richtext/richtextsizepage.cpp:452
+#: ../src/richtext/richtextsizepage.cpp:455
+#: ../src/richtext/richtextsizepage.cpp:456
+#: ../src/richtext/richtextsizepage.cpp:479
+#: ../src/richtext/richtextsizepage.cpp:482
+#: ../src/richtext/richtextsizepage.cpp:483
+#: ../src/richtext/richtextsizepage.cpp:553
+#: ../src/richtext/richtextsizepage.cpp:556
+#: ../src/richtext/richtextsizepage.cpp:557
+#: ../src/richtext/richtextsizepage.cpp:588
+#: ../src/richtext/richtextsizepage.cpp:591
+#: ../src/richtext/richtextsizepage.cpp:592
+#: ../src/richtext/richtextsizepage.cpp:623
+#: ../src/richtext/richtextsizepage.cpp:626
+#: ../src/richtext/richtextsizepage.cpp:627
+#: ../src/richtext/richtextsizepage.cpp:658
+#: ../src/richtext/richtextsizepage.cpp:661
+#: ../src/richtext/richtextsizepage.cpp:662
+msgid "px"
+msgstr "px"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:225
+#: ../src/richtext/richtextbackgroundpage.cpp:248
+#: ../src/richtext/richtextbackgroundpage.cpp:288
+#: ../src/richtext/richtextbackgroundpage.cpp:315
+#: ../src/richtext/richtextborderspage.cpp:253
+#: ../src/richtext/richtextborderspage.cpp:287
+#: ../src/richtext/richtextborderspage.cpp:321
+#: ../src/richtext/richtextborderspage.cpp:355
+#: ../src/richtext/richtextborderspage.cpp:421
+#: ../src/richtext/richtextborderspage.cpp:455
+#: ../src/richtext/richtextborderspage.cpp:489
+#: ../src/richtext/richtextborderspage.cpp:523
+#: ../src/richtext/richtextborderspage.cpp:591
+#: ../src/richtext/richtextmarginspage.cpp:200
+#: ../src/richtext/richtextmarginspage.cpp:225
+#: ../src/richtext/richtextmarginspage.cpp:248
+#: ../src/richtext/richtextmarginspage.cpp:273
+#: ../src/richtext/richtextmarginspage.cpp:314
+#: ../src/richtext/richtextmarginspage.cpp:339
+#: ../src/richtext/richtextmarginspage.cpp:362
+#: ../src/richtext/richtextmarginspage.cpp:387
+#: ../src/richtext/richtextsizepage.cpp:338
+#: ../src/richtext/richtextsizepage.cpp:372
+#: ../src/richtext/richtextsizepage.cpp:399
+#: ../src/richtext/richtextsizepage.cpp:426
+#: ../src/richtext/richtextsizepage.cpp:453
+#: ../src/richtext/richtextsizepage.cpp:480
+#: ../src/richtext/richtextsizepage.cpp:554
+#: ../src/richtext/richtextsizepage.cpp:589
+#: ../src/richtext/richtextsizepage.cpp:624
+#: ../src/richtext/richtextsizepage.cpp:659
+msgid "cm"
+msgstr "cm"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:226
+#: ../src/richtext/richtextbackgroundpage.cpp:249
+#: ../src/richtext/richtextbackgroundpage.cpp:289
+#: ../src/richtext/richtextbackgroundpage.cpp:316
+#: ../src/richtext/richtextborderspage.cpp:254
+#: ../src/richtext/richtextborderspage.cpp:288
+#: ../src/richtext/richtextborderspage.cpp:322
+#: ../src/richtext/richtextborderspage.cpp:356
+#: ../src/richtext/richtextborderspage.cpp:422
+#: ../src/richtext/richtextborderspage.cpp:456
+#: ../src/richtext/richtextborderspage.cpp:490
+#: ../src/richtext/richtextborderspage.cpp:524
+#: ../src/richtext/richtextborderspage.cpp:592
+#: ../src/richtext/richtextfontpage.cpp:176
+#: ../src/richtext/richtextfontpage.cpp:179
+msgid "pt"
+msgstr "pt"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:229
+#: ../src/richtext/richtextbackgroundpage.cpp:231
+#: ../src/richtext/richtextbackgroundpage.cpp:252
+#: ../src/richtext/richtextbackgroundpage.cpp:254
+#: ../src/richtext/richtextbackgroundpage.cpp:292
+#: ../src/richtext/richtextbackgroundpage.cpp:294
+#: ../src/richtext/richtextbackgroundpage.cpp:319
+#: ../src/richtext/richtextbackgroundpage.cpp:321
+msgid "Units for this value."
+msgstr "Eenheden voor deze waarde."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:234
+msgid "&Vertical offset:"
+msgstr "&Verticale verschuiving:"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:241
+#: ../src/richtext/richtextbackgroundpage.cpp:243
+msgid "The vertical offset."
+msgstr "De verticale verschuiving."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:257
+msgid "Shadow c&olour:"
+msgstr "Schad&uwkleur:"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:259
+#: ../src/richtext/richtextbackgroundpage.cpp:261
+msgid "Enables the shadow colour."
+msgstr "Schakelt de schaduwkleur in."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:265
+#: ../src/richtext/richtextbackgroundpage.cpp:267
+msgid "The shadow colour."
+msgstr "De schaduwkleur."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:270
+msgid "Sh&adow spread:"
+msgstr "Sch&aduwbreedte:"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:272
+#: ../src/richtext/richtextbackgroundpage.cpp:274
+msgid "Enables the shadow spread."
+msgstr "Schakelt de schaduwbreedte in."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:281
+#: ../src/richtext/richtextbackgroundpage.cpp:283
+msgid "The shadow spread."
+msgstr "De schaduwspreiding."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:297
+msgid "&Blur distance:"
+msgstr "&Vervagingsafstand:"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:299
+#: ../src/richtext/richtextbackgroundpage.cpp:301
+msgid "Enables the blur distance."
+msgstr "Schakelt de vervagingsafstand in."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:308
+#: ../src/richtext/richtextbackgroundpage.cpp:310
+msgid "The shadow blur distance."
+msgstr "De vervagingsafstand van de schaduw."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:324
+msgid "Opaci&ty:"
+msgstr "Ondoorzich&tigheid:"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:326
+#: ../src/richtext/richtextbackgroundpage.cpp:328
+msgid "Enables the shadow opacity."
+msgstr "Schakelt de schaduwondoorzichtigheid in."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:335
+#: ../src/richtext/richtextbackgroundpage.cpp:337
+msgid "The shadow opacity."
+msgstr "De schaduwondoorzichtigheid."
+
+#. TRANSLATORS: Rich text page units (percentage)
+#: ../src/richtext/richtextbackgroundpage.cpp:340
+#: ../src/richtext/richtextsizepage.cpp:339
+#: ../src/richtext/richtextsizepage.cpp:373
+#: ../src/richtext/richtextsizepage.cpp:400
+#: ../src/richtext/richtextsizepage.cpp:427
+#: ../src/richtext/richtextsizepage.cpp:454
+#: ../src/richtext/richtextsizepage.cpp:481
+#: ../src/richtext/richtextsizepage.cpp:555
+#: ../src/richtext/richtextsizepage.cpp:590
+#: ../src/richtext/richtextsizepage.cpp:625
+#: ../src/richtext/richtextsizepage.cpp:660
+msgid "%"
+msgstr "%"
+
+#: ../src/richtext/richtextborderspage.cpp:229
+#: ../src/richtext/richtextborderspage.cpp:387
+msgid "Border"
+msgstr "Rand"
+
+#: ../src/richtext/richtextborderspage.cpp:242
+#: ../src/richtext/richtextborderspage.cpp:410
+#: ../src/richtext/richtextindentspage.cpp:194
+#: ../src/richtext/richtextliststylepage.cpp:384
+#: ../src/richtext/richtextmarginspage.cpp:185
+#: ../src/richtext/richtextmarginspage.cpp:299
+#: ../src/richtext/richtextsizepage.cpp:531
+#: ../src/richtext/richtextsizepage.cpp:538
+msgid "&Left:"
+msgstr "&Links:"
+
+#: ../src/richtext/richtextborderspage.cpp:257
+#: ../src/richtext/richtextborderspage.cpp:259
+msgid "Units for the left border width."
+msgstr "Eenheden voor de linkerrand breedte."
+
+#: ../src/richtext/richtextborderspage.cpp:266
+#: ../src/richtext/richtextborderspage.cpp:268
+#: ../src/richtext/richtextborderspage.cpp:300
+#: ../src/richtext/richtextborderspage.cpp:302
+#: ../src/richtext/richtextborderspage.cpp:334
+#: ../src/richtext/richtextborderspage.cpp:336
+#: ../src/richtext/richtextborderspage.cpp:368
+#: ../src/richtext/richtextborderspage.cpp:370
+#: ../src/richtext/richtextborderspage.cpp:434
+#: ../src/richtext/richtextborderspage.cpp:436
+#: ../src/richtext/richtextborderspage.cpp:468
+#: ../src/richtext/richtextborderspage.cpp:470
+#: ../src/richtext/richtextborderspage.cpp:502
+#: ../src/richtext/richtextborderspage.cpp:504
+#: ../src/richtext/richtextborderspage.cpp:536
+#: ../src/richtext/richtextborderspage.cpp:538
+msgid "The border line style."
+msgstr "Lijnstijl van de rand."
+
+#: ../src/richtext/richtextborderspage.cpp:276
+#: ../src/richtext/richtextborderspage.cpp:444
+#: ../src/richtext/richtextindentspage.cpp:212
+#: ../src/richtext/richtextliststylepage.cpp:402
+#: ../src/richtext/richtextmarginspage.cpp:210
+#: ../src/richtext/richtextmarginspage.cpp:324
+#: ../src/richtext/richtextsizepage.cpp:601
+#: ../src/richtext/richtextsizepage.cpp:608
+msgid "&Right:"
+msgstr "&Rechts:"
+
+#: ../src/richtext/richtextborderspage.cpp:291
+#: ../src/richtext/richtextborderspage.cpp:293
+msgid "Units for the right border width."
+msgstr "Eenheden voor de rechter randbreedte."
+
+#: ../src/richtext/richtextborderspage.cpp:310
+#: ../src/richtext/richtextborderspage.cpp:478
+#: ../src/richtext/richtextmarginspage.cpp:233
+#: ../src/richtext/richtextmarginspage.cpp:347
+#: ../src/richtext/richtextsizepage.cpp:566
+#: ../src/richtext/richtextsizepage.cpp:573
+msgid "&Top:"
+msgstr "&Top:"
+
+#: ../src/richtext/richtextborderspage.cpp:325
+#: ../src/richtext/richtextborderspage.cpp:327
+msgid "Units for the top border width."
+msgstr "Eenheden voor de bovenrand breedte."
+
+#: ../src/richtext/richtextborderspage.cpp:344
+#: ../src/richtext/richtextborderspage.cpp:512
+#: ../src/richtext/richtextmarginspage.cpp:258
+#: ../src/richtext/richtextmarginspage.cpp:372
+#: ../src/richtext/richtextsizepage.cpp:636
+#: ../src/richtext/richtextsizepage.cpp:643
+msgid "&Bottom:"
+msgstr "&Bodem:"
+
+#: ../src/richtext/richtextborderspage.cpp:359
+#: ../src/richtext/richtextborderspage.cpp:361
+msgid "Units for the bottom border width."
+msgstr "Eenheden voor de bodemrand breedte."
+
+#: ../src/richtext/richtextborderspage.cpp:380
+#: ../src/richtext/richtextborderspage.cpp:548
+msgid "&Synchronize values"
+msgstr "Waarden &synchroniseren"
+
+#: ../src/richtext/richtextborderspage.cpp:382
+#: ../src/richtext/richtextborderspage.cpp:384
+#: ../src/richtext/richtextborderspage.cpp:550
+#: ../src/richtext/richtextborderspage.cpp:552
+msgid "Check to edit all borders simultaneously."
+msgstr "Aanvinken om alle hoeken tegelijk te bewerken."
+
+#: ../src/richtext/richtextborderspage.cpp:397
+#: ../src/richtext/richtextborderspage.cpp:555
+msgid "Outline"
+msgstr "Outline"
+
+#: ../src/richtext/richtextborderspage.cpp:425
+#: ../src/richtext/richtextborderspage.cpp:427
+msgid "Units for the left outline width."
+msgstr "Eenheden voor de linker outline breedte."
+
+#: ../src/richtext/richtextborderspage.cpp:459
+#: ../src/richtext/richtextborderspage.cpp:461
+msgid "Units for the right outline width."
+msgstr "Eenheden voor de rechter outline breedte."
+
+#: ../src/richtext/richtextborderspage.cpp:493
+#: ../src/richtext/richtextborderspage.cpp:495
+msgid "Units for the top outline width."
+msgstr "Eenheden voor de boven outline breedte."
+
+#: ../src/richtext/richtextborderspage.cpp:527
+#: ../src/richtext/richtextborderspage.cpp:529
+msgid "Units for the bottom outline width."
+msgstr "Eenheden voor de bodem outline breedte."
+
+#: ../src/richtext/richtextborderspage.cpp:565
+#: ../src/richtext/richtextborderspage.cpp:600
+msgid "Corner"
+msgstr "Hoek"
+
+#: ../src/richtext/richtextborderspage.cpp:574
+msgid "Corner &radius:"
+msgstr "Hoek-st&raal:"
+
+#: ../src/richtext/richtextborderspage.cpp:576
+#: ../src/richtext/richtextborderspage.cpp:578
+msgid "An optional corner radius for adding rounded corners."
+msgstr "Een optionele hoek-straal om afgeronde hoeken toe te voegen."
+
+#: ../src/richtext/richtextborderspage.cpp:584
+#: ../src/richtext/richtextborderspage.cpp:586
+msgid "The value of the corner radius."
+msgstr "Waarde van de hoek-straal."
+
+#: ../src/richtext/richtextborderspage.cpp:595
+#: ../src/richtext/richtextborderspage.cpp:597
+msgid "Units for the corner radius."
+msgstr "Eenheid van de hoek-straal."
+
+#: ../src/richtext/richtextborderspage.cpp:609
+#: ../src/richtext/richtextsizepage.cpp:247
+#: ../src/richtext/richtextsizepage.cpp:251
+msgid "None"
+msgstr "Geen"
+
+#: ../src/richtext/richtextborderspage.cpp:610
+msgid "Solid"
+msgstr "Solide"
+
+#: ../src/richtext/richtextborderspage.cpp:611
+msgid "Dotted"
+msgstr "Gestippeld"
+
+#: ../src/richtext/richtextborderspage.cpp:612
+msgid "Dashed"
+msgstr "Gestreept"
+
+#: ../src/richtext/richtextborderspage.cpp:613
+msgid "Double"
+msgstr "Dubbel"
+
+#: ../src/richtext/richtextborderspage.cpp:614
+msgid "Groove"
+msgstr "Groef"
+
+#: ../src/richtext/richtextborderspage.cpp:615
+msgid "Ridge"
+msgstr "Rug"
+
+#: ../src/richtext/richtextborderspage.cpp:616
+msgid "Inset"
+msgstr "Invoeging"
+
+#: ../src/richtext/richtextborderspage.cpp:617
+msgid "Outset"
+msgstr "Aanvang"
+
+#: ../src/richtext/richtextbuffer.cpp:3518
+msgid "Change Style"
+msgstr "Verander Stijl"
+
+#: ../src/richtext/richtextbuffer.cpp:3701
+msgid "Change Object Style"
+msgstr "Verander lijst Stijl"
+
+#: ../src/richtext/richtextbuffer.cpp:3974
+#: ../src/richtext/richtextbuffer.cpp:8174
+msgid "Change Properties"
+msgstr "Wijzig Eigenschappen"
+
+#: ../src/richtext/richtextbuffer.cpp:4346
+msgid "Change List Style"
+msgstr "Verander lijst Stijl"
+
+#: ../src/richtext/richtextbuffer.cpp:4519
+msgid "Renumber List"
+msgstr "Hernummer lijst"
+
+#: ../src/richtext/richtextbuffer.cpp:7867
+#: ../src/richtext/richtextbuffer.cpp:7897
+#: ../src/richtext/richtextbuffer.cpp:7939
+#: ../src/richtext/richtextctrl.cpp:1279 ../src/richtext/richtextctrl.cpp:1473
+msgid "Insert Text"
+msgstr "Tekst invoegen"
+
+#: ../src/richtext/richtextbuffer.cpp:8023
+#: ../src/richtext/richtextbuffer.cpp:8979
+msgid "Insert Image"
+msgstr "Afbeelding Invoegen"
+
+#: ../src/richtext/richtextbuffer.cpp:8070
+msgid "Insert Object"
+msgstr "Object invoegen"
+
+#: ../src/richtext/richtextbuffer.cpp:8112
+msgid "Insert Field"
+msgstr "Veld invoegen"
+
+#: ../src/richtext/richtextbuffer.cpp:8410
+msgid "Too many EndStyle calls!"
+msgstr "Te veel EindStijl aanroepen!"
+
+#: ../src/richtext/richtextbuffer.cpp:8785
+msgid "files"
+msgstr "bestanden"
+
+#: ../src/richtext/richtextbuffer.cpp:9380
+msgid "standard/circle"
+msgstr "standaard/circel"
+
+#: ../src/richtext/richtextbuffer.cpp:9381
+msgid "standard/circle-outline"
+msgstr "standaard/circel-buitenrand"
+
+#: ../src/richtext/richtextbuffer.cpp:9382
+msgid "standard/square"
+msgstr "standaard/vierkant"
+
+#: ../src/richtext/richtextbuffer.cpp:9383
+msgid "standard/diamond"
+msgstr "standaard/diamant"
+
+#: ../src/richtext/richtextbuffer.cpp:9384
+msgid "standard/triangle"
+msgstr "standaard/driehoek"
+
+#: ../src/richtext/richtextbuffer.cpp:9423
+msgid "Box Properties"
+msgstr "Vak Eigenschappen"
+
+#: ../src/richtext/richtextbuffer.cpp:10006
+msgid "Multiple Cell Properties"
+msgstr "Mutiple Cel eigenschappen"
+
+#: ../src/richtext/richtextbuffer.cpp:10008
+msgid "Cell Properties"
+msgstr "Cel Eigenschappen"
+
+#: ../src/richtext/richtextbuffer.cpp:11256
+msgid "Set Cell Style"
+msgstr "Cel stijl instellen"
+
+#: ../src/richtext/richtextbuffer.cpp:11330
+msgid "Delete Row"
+msgstr "Rij verwijderen"
+
+#: ../src/richtext/richtextbuffer.cpp:11380
+msgid "Delete Column"
+msgstr "Kolom verwijderen"
+
+#: ../src/richtext/richtextbuffer.cpp:11431
+msgid "Add Row"
+msgstr "Rij toevoegen"
+
+#: ../src/richtext/richtextbuffer.cpp:11494
+msgid "Add Column"
+msgstr "Kolom toevoegen"
+
+#: ../src/richtext/richtextbuffer.cpp:11537
+msgid "Table Properties"
+msgstr "Tabel eigenschappen"
+
+#: ../src/richtext/richtextbuffer.cpp:12899
+msgid "Picture Properties"
+msgstr "Afbeelding Eigenschappen"
+
+#: ../src/richtext/richtextbuffer.cpp:13169
+#: ../src/richtext/richtextbuffer.cpp:13279
+msgid "image"
+msgstr "afbeelding"
+
+#: ../src/richtext/richtextbulletspage.cpp:145
+#: ../src/richtext/richtextliststylepage.cpp:209
+msgid "&Bullet style:"
+msgstr "&Opsommingstijl:"
+
+#: ../src/richtext/richtextbulletspage.cpp:150
+#: ../src/richtext/richtextbulletspage.cpp:152
+#: ../src/richtext/richtextliststylepage.cpp:214
+#: ../src/richtext/richtextliststylepage.cpp:216
+msgid "The available bullet styles."
+msgstr "De beschikbare opsommingsteken stijlen."
+
+#: ../src/richtext/richtextbulletspage.cpp:158
+#: ../src/richtext/richtextliststylepage.cpp:221
+msgid "Peri&od"
+msgstr "Peri&ode"
+
+#: ../src/richtext/richtextbulletspage.cpp:160
+#: ../src/richtext/richtextbulletspage.cpp:162
+#: ../src/richtext/richtextliststylepage.cpp:223
+#: ../src/richtext/richtextliststylepage.cpp:225
+msgid "Check to add a period after the bullet."
+msgstr "Klik om een punt toe te voegen na het opsommingsteken."
+
+#. TRANSLATORS: Bullet point in parentheses option
+#: ../src/richtext/richtextbulletspage.cpp:167
+#: ../src/richtext/richtextliststylepage.cpp:230
+msgid "(*)"
+msgstr "(*)"
+
+#: ../src/richtext/richtextbulletspage.cpp:169
+#: ../src/richtext/richtextbulletspage.cpp:171
+#: ../src/richtext/richtextliststylepage.cpp:232
+#: ../src/richtext/richtextliststylepage.cpp:234
+msgid "Check to enclose the bullet in parentheses."
+msgstr "Klik om het opsommingsteken tussen haakjes te zetten."
+
+#. TRANSLATORS: Right parenthesis bullet point option
+#: ../src/richtext/richtextbulletspage.cpp:176
+#: ../src/richtext/richtextliststylepage.cpp:239
+msgid "*)"
+msgstr "*)"
+
+#: ../src/richtext/richtextbulletspage.cpp:178
+#: ../src/richtext/richtextbulletspage.cpp:180
+#: ../src/richtext/richtextliststylepage.cpp:241
+#: ../src/richtext/richtextliststylepage.cpp:243
+msgid "Check to add a right parenthesis."
+msgstr "Klik om een rechterhaakje toe te voegen."
+
+#: ../src/richtext/richtextbulletspage.cpp:185
+#: ../src/richtext/richtextliststylepage.cpp:248
+msgid "Bullet &Alignment:"
+msgstr "Opsommings&teken-uitlijning:"
+
+#: ../src/richtext/richtextbulletspage.cpp:190
+#: ../src/richtext/richtextliststylepage.cpp:253
+msgid "Centre"
+msgstr "Centrum"
+
+#: ../src/richtext/richtextbulletspage.cpp:194
+#: ../src/richtext/richtextbulletspage.cpp:196
+#: ../src/richtext/richtextbulletspage.cpp:217
+#: ../src/richtext/richtextbulletspage.cpp:219
+#: ../src/richtext/richtextliststylepage.cpp:257
+#: ../src/richtext/richtextliststylepage.cpp:259
+#: ../src/richtext/richtextliststylepage.cpp:278
+#: ../src/richtext/richtextliststylepage.cpp:280
+msgid "The bullet character."
+msgstr "Het opsommingsteken letterteken."
+
+#: ../src/richtext/richtextbulletspage.cpp:212
+#: ../src/richtext/richtextliststylepage.cpp:271
+msgid "&Symbol:"
+msgstr "&Symbool:"
+
+#: ../src/richtext/richtextbulletspage.cpp:222
+#: ../src/richtext/richtextliststylepage.cpp:283
+msgid "Ch&oose..."
+msgstr "K&iezen..."
+
+#: ../src/richtext/richtextbulletspage.cpp:223
+#: ../src/richtext/richtextbulletspage.cpp:225
+#: ../src/richtext/richtextliststylepage.cpp:284
+#: ../src/richtext/richtextliststylepage.cpp:286
+msgid "Click to browse for a symbol."
+msgstr "Klik voor zoeken naar symbool."
+
+#: ../src/richtext/richtextbulletspage.cpp:230
+#: ../src/richtext/richtextliststylepage.cpp:291
+msgid "Symbol &font:"
+msgstr "Symbool &-lettertype:"
+
+#: ../src/richtext/richtextbulletspage.cpp:235
+#: ../src/richtext/richtextbulletspage.cpp:237
+#: ../src/richtext/richtextliststylepage.cpp:297
+msgid "Available fonts."
+msgstr "Beschikbare lettertypen."
+
+#: ../src/richtext/richtextbulletspage.cpp:242
+#: ../src/richtext/richtextliststylepage.cpp:302
+msgid "S&tandard bullet name:"
+msgstr "S&tandaard naam opsommingsteken:"
+
+#: ../src/richtext/richtextbulletspage.cpp:247
+#: ../src/richtext/richtextbulletspage.cpp:249
+#: ../src/richtext/richtextliststylepage.cpp:307
+#: ../src/richtext/richtextliststylepage.cpp:309
+msgid "A standard bullet name."
+msgstr "Een standaard opsommingstekennaam."
+
+#: ../src/richtext/richtextbulletspage.cpp:254
+msgid "&Number:"
+msgstr "&Nummer:"
+
+#: ../src/richtext/richtextbulletspage.cpp:258
+#: ../src/richtext/richtextbulletspage.cpp:260
+msgid "The list item number."
+msgstr "Het nummer van de elementenlijst."
+
+#: ../src/richtext/richtextbulletspage.cpp:266
+#: ../src/richtext/richtextbulletspage.cpp:268
+#: ../src/richtext/richtextliststylepage.cpp:475
+#: ../src/richtext/richtextliststylepage.cpp:477
+msgid "Shows a preview of the bullet settings."
+msgstr "Toont een voorbeeld van de opsommingtekens instellingen."
+
+#: ../src/richtext/richtextbulletspage.cpp:276
+#: ../src/richtext/richtextliststylepage.cpp:484
+msgid "(None)"
+msgstr "(Geen)"
+
+#: ../src/richtext/richtextbulletspage.cpp:277
+#: ../src/richtext/richtextliststylepage.cpp:485
+msgid "Arabic"
+msgstr "Arabisch"
+
+#: ../src/richtext/richtextbulletspage.cpp:278
+#: ../src/richtext/richtextliststylepage.cpp:486
+msgid "Upper case letters"
+msgstr "Hoofdletters"
+
+#: ../src/richtext/richtextbulletspage.cpp:279
+#: ../src/richtext/richtextliststylepage.cpp:487
+msgid "Lower case letters"
+msgstr "Kleineletters"
+
+#: ../src/richtext/richtextbulletspage.cpp:280
+#: ../src/richtext/richtextliststylepage.cpp:488
+msgid "Upper case roman numerals"
+msgstr "Kapitale Romeinse cijfers"
+
+#: ../src/richtext/richtextbulletspage.cpp:281
+#: ../src/richtext/richtextliststylepage.cpp:489
+msgid "Lower case roman numerals"
+msgstr "Kleineletters Romeinse telwoorden"
+
+#: ../src/richtext/richtextbulletspage.cpp:282
+#: ../src/richtext/richtextliststylepage.cpp:490
+msgid "Numbered outline"
+msgstr "Genummerde outline"
+
+#: ../src/richtext/richtextbulletspage.cpp:283
+#: ../src/richtext/richtextliststylepage.cpp:491
+msgid "Symbol"
+msgstr "Symbool"
+
+#: ../src/richtext/richtextbulletspage.cpp:284
+#: ../src/richtext/richtextliststylepage.cpp:492
+msgid "Bitmap"
+msgstr "Bitmap"
+
+#: ../src/richtext/richtextbulletspage.cpp:285
+#: ../src/richtext/richtextliststylepage.cpp:493
+msgid "Standard"
+msgstr "Standaard"
+
+#: ../src/richtext/richtextbulletspage.cpp:287
+#: ../src/richtext/richtextliststylepage.cpp:495
+msgid "*"
+msgstr "*"
+
+#: ../src/richtext/richtextbulletspage.cpp:288
+#: ../src/richtext/richtextliststylepage.cpp:496
+msgid "-"
+msgstr "-"
+
+#: ../src/richtext/richtextbulletspage.cpp:289
+#: ../src/richtext/richtextliststylepage.cpp:497
+msgid ">"
+msgstr ">"
+
+#: ../src/richtext/richtextbulletspage.cpp:290
+#: ../src/richtext/richtextliststylepage.cpp:498
+msgid "+"
+msgstr "+"
+
+#: ../src/richtext/richtextbulletspage.cpp:291
+#: ../src/richtext/richtextliststylepage.cpp:499
+msgid "~"
+msgstr "~"
+
+#: ../src/richtext/richtextctrl.cpp:859
+msgid "Drag"
+msgstr "Slepen"
+
+#: ../src/richtext/richtextctrl.cpp:1338 ../src/richtext/richtextctrl.cpp:1559
+msgid "Delete Text"
+msgstr "Tekst verwijderen"
+
+#: ../src/richtext/richtextctrl.cpp:1537
+msgid "Remove Bullet"
+msgstr "Bolletje weghalen"
+
+#: ../src/richtext/richtextctrl.cpp:3070
+msgid "The text couldn't be saved."
+msgstr "De tekst kon niet worden opgeslagen."
+
+#: ../src/richtext/richtextctrl.cpp:3644
+msgid "Replace"
+msgstr "Vervangen"
+
+#: ../src/richtext/richtextfontpage.cpp:146
+#: ../src/richtext/richtextsymboldlg.cpp:384
+msgid "&Font:"
+msgstr "&Lettertype:"
+
+#: ../src/richtext/richtextfontpage.cpp:150
+#: ../src/richtext/richtextfontpage.cpp:152
+msgid "Type a font name."
+msgstr "Typ een lettertype naam."
+
+#: ../src/richtext/richtextfontpage.cpp:158
+msgid "&Size:"
+msgstr "&Grootte:"
+
+#: ../src/richtext/richtextfontpage.cpp:165
+#: ../src/richtext/richtextfontpage.cpp:167
+msgid "Type a size in points."
+msgstr "Typ een grootte in punten."
+
+#: ../src/richtext/richtextfontpage.cpp:180
+#: ../src/richtext/richtextfontpage.cpp:182
+msgid "The font size units, points or pixels."
+msgstr "De lettertypegrootte in units, punten of pixels."
+
+#: ../src/richtext/richtextfontpage.cpp:189
+#: ../src/richtext/richtextfontpage.cpp:191
+msgid "Lists the available fonts."
+msgstr "Geef overzicht beschikbare lettertypes."
+
+#: ../src/richtext/richtextfontpage.cpp:196
+#: ../src/richtext/richtextfontpage.cpp:198
+msgid "Lists font sizes in points."
+msgstr "Maakt overzicht van lettertypegroottes in punten."
+
+#: ../src/richtext/richtextfontpage.cpp:207
+msgid "Font st&yle:"
+msgstr "Lettertype st&ijl:"
+
+#: ../src/richtext/richtextfontpage.cpp:212
+#: ../src/richtext/richtextfontpage.cpp:214
+msgid "Select regular or italic style."
+msgstr "Selecteer normale of cursieve stijl."
+
+#: ../src/richtext/richtextfontpage.cpp:220
+msgid "Font &weight:"
+msgstr "Lettertype z&waarte:"
+
+#: ../src/richtext/richtextfontpage.cpp:225
+#: ../src/richtext/richtextfontpage.cpp:227
+msgid "Select regular or bold."
+msgstr "Selecteer Normaal of Vet."
+
+#: ../src/richtext/richtextfontpage.cpp:233
+msgid "&Underlining:"
+msgstr "Onderstre&ping:"
+
+#: ../src/richtext/richtextfontpage.cpp:238
+#: ../src/richtext/richtextfontpage.cpp:240
+msgid "Select underlining or no underlining."
+msgstr "Selecteer onderstreept of normaal."
+
+#: ../src/richtext/richtextfontpage.cpp:248
+msgid "&Colour:"
+msgstr "&Kleur:"
+
+#: ../src/richtext/richtextfontpage.cpp:253
+#: ../src/richtext/richtextfontpage.cpp:255
+msgid "Click to change the text colour."
+msgstr "Klik voor het veranderen van tekstkleur."
+
+#: ../src/richtext/richtextfontpage.cpp:261
+msgid "&Bg colour:"
+msgstr "&Bg kleur:"
+
+#: ../src/richtext/richtextfontpage.cpp:266
+#: ../src/richtext/richtextfontpage.cpp:268
+msgid "Click to change the text background colour."
+msgstr "Klik voor het veranderen van tekst achtergrondkleur."
+
+#: ../src/richtext/richtextfontpage.cpp:276
+#: ../src/richtext/richtextfontpage.cpp:278
+msgid "Check to show a line through the text."
+msgstr "Aanvinken voor doorgehaalde tekst."
+
+#: ../src/richtext/richtextfontpage.cpp:281
+msgid "Ca&pitals"
+msgstr "&Hoofdletters"
+
+#: ../src/richtext/richtextfontpage.cpp:283
+#: ../src/richtext/richtextfontpage.cpp:285
+msgid "Check to show the text in capitals."
+msgstr "Aanvinken voor tekst in Hoofdletters."
+
+#: ../src/richtext/richtextfontpage.cpp:288
+msgid "Small C&apitals"
+msgstr "Klein kapitaal"
+
+#: ../src/richtext/richtextfontpage.cpp:290
+#: ../src/richtext/richtextfontpage.cpp:292
+msgid "Check to show the text in small capitals."
+msgstr "Aanvinken voor tekst in klein kapitaal."
+
+#: ../src/richtext/richtextfontpage.cpp:295
+msgid "Supe&rscript"
+msgstr "Bovensch&rift"
+
+#: ../src/richtext/richtextfontpage.cpp:297
+#: ../src/richtext/richtextfontpage.cpp:299
+msgid "Check to show the text in superscript."
+msgstr "Aanvinken voor tekst in bovenschrift."
+
+#: ../src/richtext/richtextfontpage.cpp:302
+msgid "Subscrip&t"
+msgstr "Onderschrif&t"
+
+#: ../src/richtext/richtextfontpage.cpp:304
+#: ../src/richtext/richtextfontpage.cpp:306
+msgid "Check to show the text in subscript."
+msgstr "Aanvinken voor tekst in onderschrift."
+
+#: ../src/richtext/richtextfontpage.cpp:312
+msgid "Rig&ht-to-left"
+msgstr "Rech&ts-naar-links"
+
+#: ../src/richtext/richtextfontpage.cpp:314
+#: ../src/richtext/richtextfontpage.cpp:316
+msgid "Check to indicate right-to-left text layout."
+msgstr "Aanvinken om rechts-naar-links tekst lay-out aan te geven."
+
+#: ../src/richtext/richtextfontpage.cpp:319
+msgid "Suppress hyphe&nation"
+msgstr "Woordafbreking onderdrukken"
+
+#: ../src/richtext/richtextfontpage.cpp:321
+#: ../src/richtext/richtextfontpage.cpp:323
+msgid "Check to suppress hyphenation."
+msgstr "Aanvinken om woordafbreking te onderdrukken."
+
+#: ../src/richtext/richtextfontpage.cpp:329
+#: ../src/richtext/richtextfontpage.cpp:331
+msgid "Shows a preview of the font settings."
+msgstr "Toon een voorbeeld van de lettertype instellingen."
+
+#: ../src/richtext/richtextfontpage.cpp:348
+#: ../src/richtext/richtextfontpage.cpp:352
+#: ../src/richtext/richtextfontpage.cpp:356
+#: ../src/richtext/richtextformatdlg.cpp:873
+#: ../src/richtext/richtextindentspage.cpp:273
+#: ../src/richtext/richtextindentspage.cpp:285
+#: ../src/richtext/richtextindentspage.cpp:286
+#: ../src/richtext/richtextindentspage.cpp:310
+#: ../src/richtext/richtextindentspage.cpp:325
+#: ../src/richtext/richtextliststylepage.cpp:451
+#: ../src/richtext/richtextliststylepage.cpp:463
+#: ../src/richtext/richtextliststylepage.cpp:464
+msgid "(none)"
+msgstr "(geen)"
+
+#: ../src/richtext/richtextfontpage.cpp:349
+#: ../src/richtext/richtextfontpage.cpp:353
+msgid "Regular"
+msgstr "Normaal"
+
+#: ../src/richtext/richtextfontpage.cpp:357
+msgid "Not underlined"
+msgstr "Niet onderstreept"
+
+#: ../src/richtext/richtextformatdlg.cpp:341
+msgid "Indents && Spacing"
+msgstr "Inspringingen && Tussenruimtes"
+
+#: ../src/richtext/richtextformatdlg.cpp:346
+msgid "Tabs"
+msgstr "Tabs"
+
+#: ../src/richtext/richtextformatdlg.cpp:351
+msgid "Bullets"
+msgstr "Opsommingtekens"
+
+#: ../src/richtext/richtextformatdlg.cpp:356
+msgid "List Style"
+msgstr "Lijst Stijl"
+
+#: ../src/richtext/richtextformatdlg.cpp:366
+#: ../src/richtext/richtextmarginspage.cpp:170
+msgid "Margins"
+msgstr "Marges"
+
+#: ../src/richtext/richtextformatdlg.cpp:371
+msgid "Borders"
+msgstr "Randen"
+
+#: ../src/richtext/richtextformatdlg.cpp:765
+msgid "Colour"
+msgstr "Kleur"
+
+#: ../src/richtext/richtextindentspage.cpp:127
+#: ../src/richtext/richtextliststylepage.cpp:322
+msgid "&Alignment"
+msgstr "&Uitlijning"
+
+#: ../src/richtext/richtextindentspage.cpp:138
+#: ../src/richtext/richtextliststylepage.cpp:331
+msgid "&Left"
+msgstr "&Links"
+
+#: ../src/richtext/richtextindentspage.cpp:140
+#: ../src/richtext/richtextindentspage.cpp:142
+#: ../src/richtext/richtextliststylepage.cpp:333
+#: ../src/richtext/richtextliststylepage.cpp:335
+msgid "Left-align text."
+msgstr "Links uitgelijnde tekst."
+
+#: ../src/richtext/richtextindentspage.cpp:145
+#: ../src/richtext/richtextliststylepage.cpp:338
+msgid "&Right"
+msgstr "&Rechts"
+
+#: ../src/richtext/richtextindentspage.cpp:147
+#: ../src/richtext/richtextindentspage.cpp:149
+#: ../src/richtext/richtextliststylepage.cpp:340
+#: ../src/richtext/richtextliststylepage.cpp:342
+msgid "Right-align text."
+msgstr "Rechtsuitgelijnde tekst."
+
+#: ../src/richtext/richtextindentspage.cpp:152
+#: ../src/richtext/richtextliststylepage.cpp:345
+msgid "&Justified"
+msgstr "Uit&gevuld"
+
+#: ../src/richtext/richtextindentspage.cpp:154
+#: ../src/richtext/richtextindentspage.cpp:156
+#: ../src/richtext/richtextliststylepage.cpp:347
+#: ../src/richtext/richtextliststylepage.cpp:349
+msgid "Justify text left and right."
+msgstr "Tekst Links en rechts uitlijnen."
+
+#: ../src/richtext/richtextindentspage.cpp:159
+#: ../src/richtext/richtextliststylepage.cpp:352
+msgid "Cen&tred"
+msgstr "Gecen&treerd"
+
+#: ../src/richtext/richtextindentspage.cpp:161
+#: ../src/richtext/richtextindentspage.cpp:163
+#: ../src/richtext/richtextliststylepage.cpp:354
+#: ../src/richtext/richtextliststylepage.cpp:356
+msgid "Centre text."
+msgstr "Tekst Centreren."
+
+#: ../src/richtext/richtextindentspage.cpp:166
+#: ../src/richtext/richtextliststylepage.cpp:359
+msgid "&Indeterminate"
+msgstr "&Onduidelijk"
+
+#: ../src/richtext/richtextindentspage.cpp:168
+#: ../src/richtext/richtextindentspage.cpp:170
+#: ../src/richtext/richtextliststylepage.cpp:361
+#: ../src/richtext/richtextliststylepage.cpp:363
+msgid "Use the current alignment setting."
+msgstr "Gebruik de actuele uitlijningsinstelling."
+
+#: ../src/richtext/richtextindentspage.cpp:183
+#: ../src/richtext/richtextliststylepage.cpp:375
+msgid "&Indentation (tenths of a mm)"
+msgstr "I&nspringing (tienden van een mm)"
+
+#: ../src/richtext/richtextindentspage.cpp:198
+#: ../src/richtext/richtextindentspage.cpp:200
+#: ../src/richtext/richtextliststylepage.cpp:388
+#: ../src/richtext/richtextliststylepage.cpp:390
+msgid "The left indent."
+msgstr "De Linkse inspringing."
+
+#: ../src/richtext/richtextindentspage.cpp:203
+#: ../src/richtext/richtextliststylepage.cpp:393
+msgid "Left (&first line):"
+msgstr "Links (&eerste regel):"
+
+#: ../src/richtext/richtextindentspage.cpp:207
+#: ../src/richtext/richtextindentspage.cpp:209
+#: ../src/richtext/richtextliststylepage.cpp:397
+#: ../src/richtext/richtextliststylepage.cpp:399
+msgid "The first line indent."
+msgstr "De eerste regel inspringing."
+
+#: ../src/richtext/richtextindentspage.cpp:216
+#: ../src/richtext/richtextindentspage.cpp:218
+#: ../src/richtext/richtextliststylepage.cpp:406
+#: ../src/richtext/richtextliststylepage.cpp:408
+msgid "The right indent."
+msgstr "De rechts inspringing."
+
+#: ../src/richtext/richtextindentspage.cpp:221
+msgid "&Outline level:"
+msgstr "&Outline niveau:"
+
+#: ../src/richtext/richtextindentspage.cpp:226
+#: ../src/richtext/richtextindentspage.cpp:228
+msgid "The outline level."
+msgstr "Het Outline niveau."
+
+#: ../src/richtext/richtextindentspage.cpp:241
+#: ../src/richtext/richtextliststylepage.cpp:420
+msgid "&Spacing (tenths of a mm)"
+msgstr "&Tussenruimte (tienden van een mm)"
+
+#: ../src/richtext/richtextindentspage.cpp:252
+msgid "&Before a paragraph:"
+msgstr "&Voor een paragraaf:"
+
+#: ../src/richtext/richtextindentspage.cpp:256
+#: ../src/richtext/richtextindentspage.cpp:258
+#: ../src/richtext/richtextliststylepage.cpp:433
+#: ../src/richtext/richtextliststylepage.cpp:435
+msgid "The spacing before the paragraph."
+msgstr "De tussenruimte voor de paragraaf."
+
+#: ../src/richtext/richtextindentspage.cpp:261
+msgid "&After a paragraph:"
+msgstr "&Na een paragraaf:"
+
+#: ../src/richtext/richtextindentspage.cpp:266
+#: ../src/richtext/richtextliststylepage.cpp:442
+#: ../src/richtext/richtextliststylepage.cpp:444
+msgid "The spacing after the paragraph."
+msgstr "De ruimte na de paragraaf."
+
+#: ../src/richtext/richtextindentspage.cpp:269
+msgid "L&ine spacing:"
+msgstr "R&egel tussenruimte:"
+
+#: ../src/richtext/richtextindentspage.cpp:274
+#: ../src/richtext/richtextliststylepage.cpp:452
+msgid "Single"
+msgstr "Enkel"
+
+#: ../src/richtext/richtextindentspage.cpp:275
+#: ../src/richtext/richtextliststylepage.cpp:453
+msgid "1.1"
+msgstr "1.1"
+
+#: ../src/richtext/richtextindentspage.cpp:276
+#: ../src/richtext/richtextliststylepage.cpp:454
+msgid "1.2"
+msgstr "1.2"
+
+#: ../src/richtext/richtextindentspage.cpp:277
+#: ../src/richtext/richtextliststylepage.cpp:455
+msgid "1.3"
+msgstr "1.3"
+
+#: ../src/richtext/richtextindentspage.cpp:278
+#: ../src/richtext/richtextliststylepage.cpp:456
+msgid "1.4"
+msgstr "1.4"
+
+#: ../src/richtext/richtextindentspage.cpp:279
+#: ../src/richtext/richtextliststylepage.cpp:457
+msgid "1.5"
+msgstr "1.5"
+
+#: ../src/richtext/richtextindentspage.cpp:280
+#: ../src/richtext/richtextliststylepage.cpp:458
+msgid "1.6"
+msgstr "1.6"
+
+#: ../src/richtext/richtextindentspage.cpp:281
+#: ../src/richtext/richtextliststylepage.cpp:459
+msgid "1.7"
+msgstr "1.7"
+
+#: ../src/richtext/richtextindentspage.cpp:282
+#: ../src/richtext/richtextliststylepage.cpp:460
+msgid "1.8"
+msgstr "1.8"
+
+#: ../src/richtext/richtextindentspage.cpp:283
+#: ../src/richtext/richtextliststylepage.cpp:461
+msgid "1.9"
+msgstr "1.9"
+
+#: ../src/richtext/richtextindentspage.cpp:284
+#: ../src/richtext/richtextliststylepage.cpp:462
+msgid "2"
+msgstr "2"
+
+#: ../src/richtext/richtextindentspage.cpp:287
+#: ../src/richtext/richtextindentspage.cpp:289
+#: ../src/richtext/richtextliststylepage.cpp:465
+#: ../src/richtext/richtextliststylepage.cpp:467
+msgid "The line spacing."
+msgstr "De regeltussenruimte."
+
+#: ../src/richtext/richtextindentspage.cpp:292
+msgid "&Page Break"
+msgstr "&Pagina-einde"
+
+#: ../src/richtext/richtextindentspage.cpp:294
+#: ../src/richtext/richtextindentspage.cpp:296
+msgid "Inserts a page break before the paragraph."
+msgstr "Een pagina-einde invoegen voor de paragraaf."
+
+#: ../src/richtext/richtextindentspage.cpp:302
+#: ../src/richtext/richtextindentspage.cpp:304
+msgid "Shows a preview of the paragraph settings."
+msgstr "Toont een voorbeeld van de paragraaf instellingen."
+
+#: ../src/richtext/richtextliststylepage.cpp:182
+msgid "&List level:"
+msgstr "&Lijstniveau:"
+
+#: ../src/richtext/richtextliststylepage.cpp:186
+#: ../src/richtext/richtextliststylepage.cpp:188
+msgid "Selects the list level to edit."
+msgstr "Selecteert het lijstniveau voor bewerking."
+
+#: ../src/richtext/richtextliststylepage.cpp:193
+msgid "&Font for Level..."
+msgstr "&Lettertype voor niveau..."
+
+#: ../src/richtext/richtextliststylepage.cpp:194
+#: ../src/richtext/richtextliststylepage.cpp:196
+msgid "Click to choose the font for this level."
+msgstr "Klik voor het kiezen van het lettertype voor dit niveau."
+
+#: ../src/richtext/richtextliststylepage.cpp:312
+msgid "Bullet style"
+msgstr "Opsommingsteken-stijl"
+
+#: ../src/richtext/richtextliststylepage.cpp:429
+msgid "Before a paragraph:"
+msgstr "Vóór een alinea:"
+
+#: ../src/richtext/richtextliststylepage.cpp:438
+msgid "After a paragraph:"
+msgstr "Na een alinea:"
+
+#: ../src/richtext/richtextliststylepage.cpp:447
+msgid "Line spacing:"
+msgstr "Regel tussenruimte:"
+
+#: ../src/richtext/richtextliststylepage.cpp:470
+msgid "Spacing"
+msgstr "Tussenruimtebepaling"
+
+#: ../src/richtext/richtextmarginspage.cpp:193
+#: ../src/richtext/richtextmarginspage.cpp:195
+msgid "The left margin size."
+msgstr "De grootte van de linkermarge."
+
+#: ../src/richtext/richtextmarginspage.cpp:203
+#: ../src/richtext/richtextmarginspage.cpp:205
+msgid "Units for the left margin."
+msgstr "Eenheden voor de linkermarge breedte."
+
+#: ../src/richtext/richtextmarginspage.cpp:218
+#: ../src/richtext/richtextmarginspage.cpp:220
+msgid "The right margin size."
+msgstr "De grootte van de rechtermarge."
+
+#: ../src/richtext/richtextmarginspage.cpp:228
+#: ../src/richtext/richtextmarginspage.cpp:230
+msgid "Units for the right margin."
+msgstr "Eenheden voor de rechter marge breedte."
+
+#: ../src/richtext/richtextmarginspage.cpp:241
+#: ../src/richtext/richtextmarginspage.cpp:243
+msgid "The top margin size."
+msgstr "De grootte van de bovenmarge."
+
+#: ../src/richtext/richtextmarginspage.cpp:251
+#: ../src/richtext/richtextmarginspage.cpp:253
+msgid "Units for the top margin."
+msgstr "Eenheden voor de bovenmarge."
+
+#: ../src/richtext/richtextmarginspage.cpp:266
+#: ../src/richtext/richtextmarginspage.cpp:268
+msgid "The bottom margin size."
+msgstr "De grootte van de bodem marge."
+
+#: ../src/richtext/richtextmarginspage.cpp:276
+#: ../src/richtext/richtextmarginspage.cpp:278
+msgid "Units for the bottom margin."
+msgstr "Eenheden voor de bodemmarge breedte."
+
+#: ../src/richtext/richtextmarginspage.cpp:284
+msgid "Padding"
+msgstr "Uitvulling"
+
+#: ../src/richtext/richtextmarginspage.cpp:307
+#: ../src/richtext/richtextmarginspage.cpp:309
+msgid "The left padding size."
+msgstr "De grootte van de linker uitvulruimte."
+
+#: ../src/richtext/richtextmarginspage.cpp:317
+#: ../src/richtext/richtextmarginspage.cpp:319
+msgid "Units for the left padding."
+msgstr "Eenheden voor de linker uitvulbreedte."
+
+#: ../src/richtext/richtextmarginspage.cpp:332
+#: ../src/richtext/richtextmarginspage.cpp:334
+msgid "The right padding size."
+msgstr "De grootte van de rechteruitvulruimte."
+
+#: ../src/richtext/richtextmarginspage.cpp:342
+#: ../src/richtext/richtextmarginspage.cpp:344
+msgid "Units for the right padding."
+msgstr "Eenheden voor de rechter uitvulbreedte."
+
+#: ../src/richtext/richtextmarginspage.cpp:355
+#: ../src/richtext/richtextmarginspage.cpp:357
+msgid "The top padding size."
+msgstr "De grootte van de bovenuitvulruimte."
+
+#: ../src/richtext/richtextmarginspage.cpp:365
+#: ../src/richtext/richtextmarginspage.cpp:367
+msgid "Units for the top padding."
+msgstr "Eenheden voor de boven uitvulbreedte."
+
+#: ../src/richtext/richtextmarginspage.cpp:380
+#: ../src/richtext/richtextmarginspage.cpp:382
+msgid "The bottom padding size."
+msgstr "De grootte van de bodem uitvulruimte."
+
+#: ../src/richtext/richtextmarginspage.cpp:390
+#: ../src/richtext/richtextmarginspage.cpp:392
+msgid "Units for the bottom padding."
+msgstr "Eenheden voor de bodem uitvulbreedte."
+
+#: ../src/richtext/richtextprint.cpp:592
+msgid " Preview"
+msgstr " Voorbeeld"
+
+#: ../src/richtext/richtextsizepage.cpp:228
+msgid "Floating"
+msgstr "Zwevend"
+
+#: ../src/richtext/richtextsizepage.cpp:243
+msgid "&Floating mode:"
+msgstr "&Zwevende modus:"
+
+#: ../src/richtext/richtextsizepage.cpp:252
+#: ../src/richtext/richtextsizepage.cpp:254
+msgid "How the object will float relative to the text."
+msgstr "Hoe het object zweeft relatief t.o.v. de tekst."
+
+#: ../src/richtext/richtextsizepage.cpp:265
+msgid "Alignment"
+msgstr "Uitlijning"
+
+#: ../src/richtext/richtextsizepage.cpp:277
+msgid "&Vertical alignment:"
+msgstr "&Vertikale uitlijning:"
+
+#: ../src/richtext/richtextsizepage.cpp:279
+#: ../src/richtext/richtextsizepage.cpp:281
+msgid "Enable vertical alignment."
+msgstr "Vertikale uitlijning inschakelen."
+
+#: ../src/richtext/richtextsizepage.cpp:286
+msgid "Centred"
+msgstr "Gecentreerd"
+
+#: ../src/richtext/richtextsizepage.cpp:290
+#: ../src/richtext/richtextsizepage.cpp:292
+msgid "Vertical alignment."
+msgstr "Vertikale uitlijning."
+
+#: ../src/richtext/richtextsizepage.cpp:316
+#: ../src/richtext/richtextsizepage.cpp:323
+msgid "&Width:"
+msgstr "&Breedte:"
+
+#: ../src/richtext/richtextsizepage.cpp:318
+#: ../src/richtext/richtextsizepage.cpp:320
+msgid "Enable the width value."
+msgstr "De breedte-waarde inschakelen."
+
+#: ../src/richtext/richtextsizepage.cpp:331
+#: ../src/richtext/richtextsizepage.cpp:333
+msgid "The object width."
+msgstr "De breedte van het object."
+
+#: ../src/richtext/richtextsizepage.cpp:342
+#: ../src/richtext/richtextsizepage.cpp:344
+msgid "Units for the object width."
+msgstr "Eenheden voor de objectbreedte."
+
+#: ../src/richtext/richtextsizepage.cpp:350
+#: ../src/richtext/richtextsizepage.cpp:357
+msgid "&Height:"
+msgstr "&Hoogte:"
+
+#: ../src/richtext/richtextsizepage.cpp:352
+#: ../src/richtext/richtextsizepage.cpp:354
+#: ../src/richtext/richtextsizepage.cpp:464
+#: ../src/richtext/richtextsizepage.cpp:466
+msgid "Enable the height value."
+msgstr "De hoogte-waarde inschakelen."
+
+#: ../src/richtext/richtextsizepage.cpp:365
+#: ../src/richtext/richtextsizepage.cpp:367
+msgid "The object height."
+msgstr "De hoogte van het object."
+
+#: ../src/richtext/richtextsizepage.cpp:376
+#: ../src/richtext/richtextsizepage.cpp:378
+msgid "Units for the object height."
+msgstr "Eenheden voor de objecthoogte."
+
+#: ../src/richtext/richtextsizepage.cpp:381
+msgid "Min width:"
+msgstr "Minimale breedte:"
+
+#: ../src/richtext/richtextsizepage.cpp:383
+#: ../src/richtext/richtextsizepage.cpp:385
+msgid "Enable the minimum width value."
+msgstr "Minimum breedte inschakelen."
+
+#: ../src/richtext/richtextsizepage.cpp:392
+#: ../src/richtext/richtextsizepage.cpp:394
+msgid "The object minimum width."
+msgstr "De minimale breedte van het object."
+
+#: ../src/richtext/richtextsizepage.cpp:403
+#: ../src/richtext/richtextsizepage.cpp:405
+msgid "Units for the minimum object width."
+msgstr "Eenheden voor de minimale object breedte."
+
+#: ../src/richtext/richtextsizepage.cpp:408
+msgid "Min height:"
+msgstr "Minimale hoogte:"
+
+#: ../src/richtext/richtextsizepage.cpp:410
+#: ../src/richtext/richtextsizepage.cpp:412
+msgid "Enable the minimum height value."
+msgstr "De minimale hoogte-waarde inschakelen."
+
+#: ../src/richtext/richtextsizepage.cpp:419
+#: ../src/richtext/richtextsizepage.cpp:421
+msgid "The object minimum height."
+msgstr "De minimale hoogte van het object."
+
+#: ../src/richtext/richtextsizepage.cpp:430
+#: ../src/richtext/richtextsizepage.cpp:432
+msgid "Units for the minimum object height."
+msgstr "Eenheden voor de minimale object hoogte."
+
+#: ../src/richtext/richtextsizepage.cpp:435
+msgid "Max width:"
+msgstr "Maximale breedte:"
+
+#: ../src/richtext/richtextsizepage.cpp:437
+#: ../src/richtext/richtextsizepage.cpp:439
+msgid "Enable the maximum width value."
+msgstr "Maximum breedte inschakelen."
+
+#: ../src/richtext/richtextsizepage.cpp:446
+#: ../src/richtext/richtextsizepage.cpp:448
+msgid "The object maximum width."
+msgstr "De maximale breedte van het object."
+
+#: ../src/richtext/richtextsizepage.cpp:457
+#: ../src/richtext/richtextsizepage.cpp:459
+msgid "Units for the maximum object width."
+msgstr "Eenheden voor de maximale object breedte."
+
+#: ../src/richtext/richtextsizepage.cpp:462
+msgid "Max height:"
+msgstr "Maximale hoogte:"
+
+#: ../src/richtext/richtextsizepage.cpp:473
+#: ../src/richtext/richtextsizepage.cpp:475
+msgid "The object maximum height."
+msgstr "De maximale hoogte van het object."
+
+#: ../src/richtext/richtextsizepage.cpp:484
+#: ../src/richtext/richtextsizepage.cpp:486
+msgid "Units for the maximum object height."
+msgstr "Eenheden voor de maximale object hoogte."
+
+#: ../src/richtext/richtextsizepage.cpp:495
+msgid "Position"
+msgstr "Positie"
+
+#: ../src/richtext/richtextsizepage.cpp:513
+msgid "&Position mode:"
+msgstr "&Positiemodus:"
+
+#: ../src/richtext/richtextsizepage.cpp:517
+#: ../src/richtext/richtextsizepage.cpp:522
+msgid "Static"
+msgstr "Statisch"
+
+#: ../src/richtext/richtextsizepage.cpp:518
+msgid "Relative"
+msgstr "Relatief"
+
+#: ../src/richtext/richtextsizepage.cpp:519
+msgid "Absolute"
+msgstr "Absoluut"
+
+#: ../src/richtext/richtextsizepage.cpp:520
+msgid "Fixed"
+msgstr "Vast"
+
+#: ../src/richtext/richtextsizepage.cpp:533
+#: ../src/richtext/richtextsizepage.cpp:535
+#: ../src/richtext/richtextsizepage.cpp:547
+#: ../src/richtext/richtextsizepage.cpp:549
+msgid "The left position."
+msgstr "De linkerpositie."
+
+#: ../src/richtext/richtextsizepage.cpp:558
+#: ../src/richtext/richtextsizepage.cpp:560
+msgid "Units for the left position."
+msgstr "Eenheden voor de linkerpositie."
+
+#: ../src/richtext/richtextsizepage.cpp:568
+#: ../src/richtext/richtextsizepage.cpp:570
+#: ../src/richtext/richtextsizepage.cpp:582
+#: ../src/richtext/richtextsizepage.cpp:584
+msgid "The top position."
+msgstr "De bovenpositie."
+
+#: ../src/richtext/richtextsizepage.cpp:593
+#: ../src/richtext/richtextsizepage.cpp:595
+msgid "Units for the top position."
+msgstr "Eenheden voor de bovenpositie."
+
+#: ../src/richtext/richtextsizepage.cpp:603
+#: ../src/richtext/richtextsizepage.cpp:605
+#: ../src/richtext/richtextsizepage.cpp:617
+#: ../src/richtext/richtextsizepage.cpp:619
+msgid "The right position."
+msgstr "De rechterpositie."
+
+#: ../src/richtext/richtextsizepage.cpp:628
+#: ../src/richtext/richtextsizepage.cpp:630
+msgid "Units for the right position."
+msgstr "Eenheden voor de rechterpositie."
+
+#: ../src/richtext/richtextsizepage.cpp:638
+#: ../src/richtext/richtextsizepage.cpp:640
+#: ../src/richtext/richtextsizepage.cpp:652
+#: ../src/richtext/richtextsizepage.cpp:654
+msgid "The bottom position."
+msgstr "De onderpositie."
+
+#: ../src/richtext/richtextsizepage.cpp:663
+#: ../src/richtext/richtextsizepage.cpp:665
+msgid "Units for the bottom position."
+msgstr "Eenheden voor de onderpositie."
+
+#: ../src/richtext/richtextsizepage.cpp:671
+msgid "&Move the object to:"
+msgstr "&Verplaats object naar:"
+
+#: ../src/richtext/richtextsizepage.cpp:674
+msgid "&Previous Paragraph"
+msgstr "&Vorige paragraaf"
+
+#: ../src/richtext/richtextsizepage.cpp:675
+#: ../src/richtext/richtextsizepage.cpp:677
+msgid "Moves the object to the previous paragraph."
+msgstr "Verplaatst het object naar de vorige paragraaf."
+
+#: ../src/richtext/richtextsizepage.cpp:680
+msgid "&Next Paragraph"
+msgstr "&Volgende paragraaf"
+
+#: ../src/richtext/richtextsizepage.cpp:681
+#: ../src/richtext/richtextsizepage.cpp:683
+msgid "Moves the object to the next paragraph."
+msgstr "Verplaatst het object naar de volgende paragraaf."
+
+#: ../src/richtext/richtextstyledlg.cpp:193
+msgid "&Styles:"
+msgstr "&Stijlen:"
+
+#: ../src/richtext/richtextstyledlg.cpp:197
+#: ../src/richtext/richtextstyledlg.cpp:199
+msgid "The available styles."
+msgstr "De beschikbare Stijlen."
+
+#: ../src/richtext/richtextstyledlg.cpp:205
+#: ../src/richtext/richtextstyledlg.cpp:217
+msgid " "
+msgstr " "
+
+#: ../src/richtext/richtextstyledlg.cpp:209
+#: ../src/richtext/richtextstyledlg.cpp:211
+msgid "The style preview."
+msgstr "Afdrukvoorbeeld van de stijl."
+
+#: ../src/richtext/richtextstyledlg.cpp:220
+msgid "New &Character Style..."
+msgstr "Nieuw &Letterteken Stijl..."
+
+#: ../src/richtext/richtextstyledlg.cpp:221
+#: ../src/richtext/richtextstyledlg.cpp:223
+msgid "Click to create a new character style."
+msgstr "Klik voor het maken van een nieuwe letterteken stijl."
+
+#: ../src/richtext/richtextstyledlg.cpp:226
+msgid "New &Paragraph Style..."
+msgstr "Nieuwe &Paragraaf Stijl..."
+
+#: ../src/richtext/richtextstyledlg.cpp:227
+#: ../src/richtext/richtextstyledlg.cpp:229
+msgid "Click to create a new paragraph style."
+msgstr "Klik voor het maken van een nieuwe paragraaf stijl."
+
+#: ../src/richtext/richtextstyledlg.cpp:232
+msgid "New &List Style..."
+msgstr "Nieuwe &Lijst Stijl..."
+
+#: ../src/richtext/richtextstyledlg.cpp:233
+#: ../src/richtext/richtextstyledlg.cpp:235
+msgid "Click to create a new list style."
+msgstr "Klik voor het maken van een nieuwe lijst stijl."
+
+#: ../src/richtext/richtextstyledlg.cpp:238
+msgid "New &Box Style..."
+msgstr "Nieuwe &Vak Stijl..."
+
+#: ../src/richtext/richtextstyledlg.cpp:239
+#: ../src/richtext/richtextstyledlg.cpp:241
+msgid "Click to create a new box style."
+msgstr "Klik voor het maken van een nieuwe vak stijl."
+
+#: ../src/richtext/richtextstyledlg.cpp:246
+msgid "&Apply Style"
+msgstr "Stijl toe&passen"
+
+#: ../src/richtext/richtextstyledlg.cpp:247
+#: ../src/richtext/richtextstyledlg.cpp:249
+msgid "Click to apply the selected style."
+msgstr "Klik voor toepassen geselecteerde stijl."
+
+#: ../src/richtext/richtextstyledlg.cpp:252
+msgid "&Rename Style..."
+msgstr "Stijl he&rnoemen…"
+
+#: ../src/richtext/richtextstyledlg.cpp:253
+#: ../src/richtext/richtextstyledlg.cpp:255
+msgid "Click to rename the selected style."
+msgstr "Klik voor het hernoemen van geselecteerde stijl."
+
+#: ../src/richtext/richtextstyledlg.cpp:258
+msgid "&Edit Style..."
+msgstr "S&tijl bewerken..."
+
+#: ../src/richtext/richtextstyledlg.cpp:259
+#: ../src/richtext/richtextstyledlg.cpp:261
+msgid "Click to edit the selected style."
+msgstr "Klik voor het bewerken van geselecteerde stijl."
+
+#: ../src/richtext/richtextstyledlg.cpp:264
+msgid "&Delete Style..."
+msgstr "Stijl &verwijderen..."
+
+#: ../src/richtext/richtextstyledlg.cpp:265
+#: ../src/richtext/richtextstyledlg.cpp:267
+msgid "Click to delete the selected style."
+msgstr "Klik voor het verwijderen van geselecteerde stijl."
+
+#: ../src/richtext/richtextstyledlg.cpp:274
+#: ../src/richtext/richtextstyledlg.cpp:276
+msgid "Click to close this window."
+msgstr "Klik om dit venster te sluiten."
+
+#: ../src/richtext/richtextstyledlg.cpp:282
+msgid "&Restart numbering"
+msgstr "Nummering he&rstarten"
+
+#: ../src/richtext/richtextstyledlg.cpp:284
+#: ../src/richtext/richtextstyledlg.cpp:286
+msgid "Check to restart numbering."
+msgstr "Aanvinken voor herstart nummering."
+
+#: ../src/richtext/richtextstyledlg.cpp:601
+msgid "Enter a character style name"
+msgstr "Vul een lettertekenstijlnaam in"
+
+#: ../src/richtext/richtextstyledlg.cpp:601
+#: ../src/richtext/richtextstyledlg.cpp:606
+#: ../src/richtext/richtextstyledlg.cpp:649
+#: ../src/richtext/richtextstyledlg.cpp:654
+#: ../src/richtext/richtextstyledlg.cpp:815
+#: ../src/richtext/richtextstyledlg.cpp:820
+#: ../src/richtext/richtextstyledlg.cpp:888
+#: ../src/richtext/richtextstyledlg.cpp:896
+#: ../src/richtext/richtextstyledlg.cpp:929
+#: ../src/richtext/richtextstyledlg.cpp:934
+msgid "New Style"
+msgstr "Nieuw Stijl"
+
+#: ../src/richtext/richtextstyledlg.cpp:606
+#: ../src/richtext/richtextstyledlg.cpp:654
+#: ../src/richtext/richtextstyledlg.cpp:820
+#: ../src/richtext/richtextstyledlg.cpp:896
+#: ../src/richtext/richtextstyledlg.cpp:934
+msgid "Sorry, that name is taken. Please choose another."
+msgstr "Helaas, die naam bestaat al. Kies een andere."
+
+#: ../src/richtext/richtextstyledlg.cpp:649
+msgid "Enter a paragraph style name"
+msgstr "Vul een paragraafstijl in"
+
+#: ../src/richtext/richtextstyledlg.cpp:777
+#, c-format
+msgid "Delete style %s?"
+msgstr "Stijl %s verwijderen?"
+
+#: ../src/richtext/richtextstyledlg.cpp:777
+msgid "Delete Style"
+msgstr "Stijl verwijderen"
+
+#: ../src/richtext/richtextstyledlg.cpp:815
+msgid "Enter a list style name"
+msgstr "Vul een lijststijl in"
+
+#: ../src/richtext/richtextstyledlg.cpp:888
+msgid "Enter a new style name"
+msgstr "Vul een nieuwe stijlnaam in"
+
+#: ../src/richtext/richtextstyledlg.cpp:929
+msgid "Enter a box style name"
+msgstr "Vul een vak stijlnaam in"
+
+#: ../src/richtext/richtextstylepage.cpp:109
+#: ../src/richtext/richtextstylepage.cpp:111
+msgid "The style name."
+msgstr "De stijl naam."
+
+#: ../src/richtext/richtextstylepage.cpp:114
+msgid "&Based on:"
+msgstr "Ge&baseerd op:"
+
+#: ../src/richtext/richtextstylepage.cpp:119
+#: ../src/richtext/richtextstylepage.cpp:121
+msgid "The style on which this style is based."
+msgstr "De stijl waarop deze stijl is gebaseerd."
+
+#: ../src/richtext/richtextstylepage.cpp:124
+msgid "&Next style:"
+msgstr "Volge&nde stijl:"
+
+#: ../src/richtext/richtextstylepage.cpp:129
+#: ../src/richtext/richtextstylepage.cpp:131
+msgid "The default style for the next paragraph."
+msgstr "De standaard stijl voor de volgende paragraaf."
+
+#: ../src/richtext/richtextstyles.cpp:1057
+msgid "All styles"
+msgstr "Alle stijlen"
+
+#: ../src/richtext/richtextstyles.cpp:1058
+msgid "Paragraph styles"
+msgstr "Paragraaf stijlen"
+
+#: ../src/richtext/richtextstyles.cpp:1059
+msgid "Character styles"
+msgstr "Letterteken Stijlen"
+
+#: ../src/richtext/richtextstyles.cpp:1060
+msgid "List styles"
+msgstr "Lijst stijlen"
+
+#: ../src/richtext/richtextstyles.cpp:1061
+msgid "Box styles"
+msgstr "Vak stijlen"
+
+#: ../src/richtext/richtextsymboldlg.cpp:389
+#: ../src/richtext/richtextsymboldlg.cpp:391
+msgid "The font from which to take the symbol."
+msgstr "Het lettertype waar het symbool van wordt genomen."
+
+#: ../src/richtext/richtextsymboldlg.cpp:396
+msgid "&Subset:"
+msgstr "&Subset:"
+
+#: ../src/richtext/richtextsymboldlg.cpp:401
+#: ../src/richtext/richtextsymboldlg.cpp:403
+msgid "Shows a Unicode subset."
+msgstr "Toont een Unicode subset."
+
+#: ../src/richtext/richtextsymboldlg.cpp:412
+msgid "xxxx"
+msgstr "xxxx"
+
+#: ../src/richtext/richtextsymboldlg.cpp:417
+msgid "&Character code:"
+msgstr "&Lettertekencode:"
+
+#: ../src/richtext/richtextsymboldlg.cpp:421
+#: ../src/richtext/richtextsymboldlg.cpp:423
+msgid "The character code."
+msgstr "De Letterteken code."
+
+#: ../src/richtext/richtextsymboldlg.cpp:428
+msgid "&From:"
+msgstr "&Van:"
+
+#: ../src/richtext/richtextsymboldlg.cpp:433
+#: ../src/richtext/richtextsymboldlg.cpp:434
+#: ../src/richtext/richtextsymboldlg.cpp:435
+msgid "Unicode"
+msgstr "Unicode"
+
+#: ../src/richtext/richtextsymboldlg.cpp:436
+#: ../src/richtext/richtextsymboldlg.cpp:438
+msgid "The range to show."
+msgstr "De te tonen range."
+
+#: ../src/richtext/richtextsymboldlg.cpp:444
+msgid "Insert"
+msgstr "Invoegen"
+
+#: ../src/richtext/richtextsymboldlg.cpp:478
+msgid "(Normal text)"
+msgstr "(Normale tekst)"
+
+#: ../src/richtext/richtexttabspage.cpp:109
+msgid "&Position (tenths of a mm):"
+msgstr "&Positie (tienden van een mm):"
+
+#: ../src/richtext/richtexttabspage.cpp:113
+#: ../src/richtext/richtexttabspage.cpp:115
+msgid "The tab position."
+msgstr "De tab positie."
+
+#: ../src/richtext/richtexttabspage.cpp:119
+msgid "The tab positions."
+msgstr "De tab posities."
+
+#: ../src/richtext/richtexttabspage.cpp:132
+#: ../src/richtext/richtexttabspage.cpp:134
+msgid "Click to create a new tab position."
+msgstr "Klik voor het maken van een nieuwe tab positie."
+
+#: ../src/richtext/richtexttabspage.cpp:138
+#: ../src/richtext/richtexttabspage.cpp:140
+msgid "Click to delete the selected tab position."
+msgstr "Klik voor het verwijderen van geselecteerd tab positie."
+
+#: ../src/richtext/richtexttabspage.cpp:143
+msgid "Delete A&ll"
+msgstr "A&lles verwijderen"
+
+#: ../src/richtext/richtexttabspage.cpp:144
+#: ../src/richtext/richtexttabspage.cpp:146
+msgid "Click to delete all tab positions."
+msgstr "Klik om alle tabposities te verwijderen."
+
+#: ../src/univ/theme.cpp:110
+msgid "Failed to initialize GUI: no built-in themes found."
+msgstr "Initialiseren van GUI mislukt: Geen ingebouwd thema gevonden."
+
+#: ../src/univ/themes/gtk.cpp:521
+msgid "GTK+ theme"
+msgstr "GTK+ thema"
+
+#: ../src/univ/themes/metal.cpp:164
+msgid "Metal theme"
+msgstr "Metaal thema"
+
+#: ../src/univ/themes/mono.cpp:512
+msgid "Simple monochrome theme"
+msgstr "Eenvoudig monochroom thema"
+
+#: ../src/univ/themes/win32.cpp:1098
+msgid "Win32 theme"
+msgstr "Win32 thema"
+
+#: ../src/univ/themes/win32.cpp:3743
+msgid "&Restore"
+msgstr "&Herstellen"
+
+#: ../src/univ/themes/win32.cpp:3744
+msgid "&Move"
+msgstr "&Verplaatsen"
+
+#: ../src/univ/themes/win32.cpp:3746
+msgid "&Size"
+msgstr "&Grootte"
+
+#: ../src/univ/themes/win32.cpp:3748
+msgid "Mi&nimize"
+msgstr "Minimaliseren"
+
+#: ../src/univ/themes/win32.cpp:3750
+msgid "Ma&ximize"
+msgstr "Maximaliseren"
+
+#: ../src/univ/themes/win32.cpp:3752
+msgid "Alt+"
+msgstr "Alt+"
+
+#: ../src/unix/appunix.cpp:178
+msgid "Failed to install signal handler"
+msgstr "Installeren van signaal handler mislukt"
+
+#: ../src/unix/dialup.cpp:351
+msgid "Already dialling ISP."
+msgstr "Al bezig internetaanbieder te bellen."
+
+#: ../src/unix/dlunix.cpp:93
+msgid "Failed to unload shared library"
+msgstr "Kan gedeelde bibliotheek niet verwijderen"
+
+#: ../src/unix/dlunix.cpp:121
+msgid "Unknown dynamic library error"
+msgstr "Onbekende dynamische bibliotheek fout"
+
+#: ../src/unix/epolldispatcher.cpp:84
+msgid "Failed to create epoll descriptor"
+msgstr "Aanmaken epoll descriptor mislukt"
+
+#: ../src/unix/epolldispatcher.cpp:103
+msgid "Error closing epoll descriptor"
+msgstr "Fout bij sluiten van epoll descriptor"
+
+#: ../src/unix/epolldispatcher.cpp:116
+#, c-format
+msgid "Failed to add descriptor %d to epoll descriptor %d"
+msgstr "Kon geen descriptor %d toevoegen aan epoll descriptor %d"
+
+#: ../src/unix/epolldispatcher.cpp:136
+#, c-format
+msgid "Failed to modify descriptor %d in epoll descriptor %d"
+msgstr "Modificeren van descriptor %d in epoll descriptor %d mislukt"
+
+#: ../src/unix/epolldispatcher.cpp:155
+#, c-format
+msgid "Failed to unregister descriptor %d from epoll descriptor %d"
+msgstr ""
+"Registratie teniet doen van descriptor %d van epoll descriptor %d mislukt"
+
+#: ../src/unix/epolldispatcher.cpp:213
+#, c-format
+msgid "Waiting for IO on epoll descriptor %d failed"
+msgstr "Het wachten op IO voor epoll beschrijver %d mislukte"
+
+#: ../src/unix/fswatcher_inotify.cpp:71
+msgid "Unable to create inotify instance"
+msgstr "Niet mogelijk een inotify exemplaarset aan te maken"
+
+#: ../src/unix/fswatcher_inotify.cpp:94
+msgid "Unable to close inotify instance"
+msgstr "Sluiten van inotify exemplaarset niet mogelijk"
+
+#: ../src/unix/fswatcher_inotify.cpp:106
+msgid "Unable to add inotify watch"
+msgstr "Kan geen inotify controle toevoegen"
+
+#: ../src/unix/fswatcher_inotify.cpp:138
+#, c-format
+msgid "Unable to remove inotify watch %i"
+msgstr "Kan inotify horloge %i niet verwijderen"
+
+#: ../src/unix/fswatcher_inotify.cpp:271
+#, c-format
+msgid "Unexpected event for \"%s\": no matching watch descriptor."
+msgstr ""
+"Onverwachte gebeurtenis voor \"%s\": geen overeenkomende watch descriptor."
+
+#: ../src/unix/fswatcher_inotify.cpp:320
+#, c-format
+msgid "Invalid inotify event for \"%s\""
+msgstr "Ongeldige inotify-gebeurtenis voor \"%s\""
+
+#: ../src/unix/fswatcher_inotify.cpp:553
+msgid "Unable to read from inotify descriptor"
+msgstr "Kan niet lezen van inotify descriptor"
+
+#: ../src/unix/fswatcher_inotify.cpp:558
+msgid "EOF while reading from inotify descriptor"
+msgstr "EOF tijdens lezen van inotify descriptor"
+
+#: ../src/unix/fswatcher_kqueue.cpp:114
+msgid "Unable to create kqueue instance"
+msgstr "Niet mogelijk een kqueue exemplaarset aan te maken"
+
+#: ../src/unix/fswatcher_kqueue.cpp:131
+msgid "Error closing kqueue instance"
+msgstr "Fout bij sluiten van kqueue exemplaarset"
+
+#: ../src/unix/fswatcher_kqueue.cpp:153
+msgid "Unable to add kqueue watch"
+msgstr "Kan geen kqueue controle toevoegen"
+
+#: ../src/unix/fswatcher_kqueue.cpp:170
+msgid "Unable to remove kqueue watch"
+msgstr "Kan kqueue controle niet verwijderen"
+
+#: ../src/unix/fswatcher_kqueue.cpp:202
+msgid "Unable to get events from kqueue"
+msgstr "Kan gebeurtenissen niet uit kqueue halen"
+
+#: ../src/unix/mediactrl.cpp:966
+#, c-format
+msgid "Media playback error: %s"
+msgstr "Media-afspeelfout: %s"
+
+#: ../src/unix/mediactrl.cpp:1228
+#, c-format
+msgid "Failed to prepare playing \"%s\"."
+msgstr "Voorbereiden om \"%s\" af te spelen mislukt."
+
+#: ../src/unix/snglinst.cpp:164
+#, c-format
+msgid "Failed to write to lock file '%s'"
+msgstr "Schrijven naar vergrendeld bestand '%s' mislukt"
+
+#: ../src/unix/snglinst.cpp:177
+#, c-format
+msgid "Failed to set permissions on lock file '%s'"
+msgstr "Instellen van permissies op grendelbestand '%s' mislukt"
+
+#: ../src/unix/snglinst.cpp:194
+#, c-format
+msgid "Failed to lock the lock file '%s'"
+msgstr "Vergrendelen van het vergrendelde bestand '%s' mislukt"
+
+#: ../src/unix/snglinst.cpp:237
+#, c-format
+msgid "Failed to inspect the lock file '%s'"
+msgstr "Inspecteren van grendelbestand '%s' mislukt"
+
+#: ../src/unix/snglinst.cpp:242
+#, c-format
+msgid "Lock file '%s' has incorrect owner."
+msgstr "Lock-bestand '%s' heeft onjuiste eigenaar."
+
+#: ../src/unix/snglinst.cpp:247
+#, c-format
+msgid "Lock file '%s' has incorrect permissions."
+msgstr "Vergrendelingsbestand '%s' heeft onjuiste machtigingen."
+
+#: ../src/unix/snglinst.cpp:265
+msgid "Failed to access lock file."
+msgstr "Toegang naar beveiligd bestand mislukt."
+
+#: ../src/unix/snglinst.cpp:274
+msgid "Failed to read PID from lock file."
+msgstr "Lezen van PID van vergrendeld bestand mislukt."
+
+#: ../src/unix/snglinst.cpp:284
+#, c-format
+msgid "Failed to remove stale lock file '%s'."
+msgstr "Verwijderen van verouderd vergrendeld bestand '%s' mislukt."
+
+#: ../src/unix/snglinst.cpp:297
+#, c-format
+msgid "Deleted stale lock file '%s'."
+msgstr "Verouderd vergrendeld bestand '%s' verwijderd."
+
+#: ../src/unix/snglinst.cpp:308
+#, c-format
+msgid "Invalid lock file '%s'."
+msgstr "Ongeldig vergrendeld bestand '%s'."
+
+#: ../src/unix/snglinst.cpp:324
+#, c-format
+msgid "Failed to remove lock file '%s'"
+msgstr "Verwijderen van vergrendeld bestand '%s' mislukt"
+
+#: ../src/unix/snglinst.cpp:330
+#, c-format
+msgid "Failed to unlock lock file '%s'"
+msgstr "Ontgrendelen van het vergrendelde bestand '%s' mislukt"
+
+#: ../src/unix/snglinst.cpp:336
+#, c-format
+msgid "Failed to close lock file '%s'"
+msgstr "Sluiten van vergrendeld bestand '%s' mislukt"
+
+#: ../src/unix/sound.cpp:77
+msgid "No sound"
+msgstr "Geen geluid"
+
+#: ../src/unix/sound.cpp:364
+msgid "Unable to play sound asynchronously."
+msgstr "Niet in staat geluid asynchroon af te spelen."
+
+#: ../src/unix/sound.cpp:458
+#, c-format
+msgid "Couldn't load sound data from '%s'."
+msgstr "Kon geen geluidsgegevens laden van '%s'."
+
+#: ../src/unix/sound.cpp:465
+#, c-format
+msgid "Sound file '%s' is in unsupported format."
+msgstr "Geluidsbestand '%s' heeft een niet ondersteund formaat."
+
+#: ../src/unix/sound.cpp:480
+msgid "Sound data are in unsupported format."
+msgstr "De geluidsdata zijn in een niet ondersteund formaat."
+
+#: ../src/unix/sound_sdl.cpp:226
+#, c-format
+msgid "Couldn't open audio: %s"
+msgstr "Kon audio: %s niet openen"
+
+#: ../src/unix/threadpsx.cpp:1033
+msgid "Cannot retrieve thread scheduling policy."
+msgstr "Kan thread-planningstrategie niet verkrijgen."
+
+#: ../src/unix/threadpsx.cpp:1058
+#, c-format
+msgid "Cannot get priority range for scheduling policy %d."
+msgstr "Kan prioriteitbereik niet verkrijgen voor planningstrategie %d."
+
+#: ../src/unix/threadpsx.cpp:1066
+msgid "Thread priority setting is ignored."
+msgstr "Thread-prioriteitsinstelling is genegeerd."
+
+#: ../src/unix/threadpsx.cpp:1221
+msgid ""
+"Failed to join a thread, potential memory leak detected - please restart the "
+"program"
+msgstr ""
+"Aansluiten bij een draadje mislukt, mogelijk geheugenlek aangetroffen - "
+"herstart het programma a.u.b"
+
+#: ../src/unix/threadpsx.cpp:1352
+#, c-format
+msgid "Failed to set thread concurrency level to %lu"
+msgstr "Instellen van concurrency-niveau van thread op %lu mislukt"
+
+#: ../src/unix/threadpsx.cpp:1481
+#, c-format
+msgid "Failed to set thread priority %d."
+msgstr "Instellen van prioriteit van thread %d mislukt."
+
+#: ../src/unix/threadpsx.cpp:1666
+msgid "Failed to terminate a thread."
+msgstr "Beëindigen van thread mislukt."
+
+#: ../src/unix/threadpsx.cpp:1893
+msgid "Thread module initialization failed: failed to create thread key"
+msgstr "Threadmodule-initialisatie mislukt: maken van thread-sleutel mislukt"
+
+#: ../src/unix/utilsunx.cpp:340
+msgid "Impossible to get child process input"
+msgstr "Onmogelijk om child proces input te verkrijgen"
+
+#: ../src/unix/utilsunx.cpp:390
+msgid "Can't write to child process's stdin"
+msgstr "Kan niet schrijven naar child proces's stdin"
+
+#: ../src/unix/utilsunx.cpp:644
+#, c-format
+msgid "Failed to execute '%s'\n"
+msgstr "Uitvoeren van '%s' mislukt\n"
+
+#: ../src/unix/utilsunx.cpp:678
+msgid "Fork failed"
+msgstr "Vork mislukt"
+
+#: ../src/unix/utilsunx.cpp:701
+msgid "Failed to set process priority"
+msgstr "Instellen van prioriteit van proces mislukt"
+
+#: ../src/unix/utilsunx.cpp:712
+msgid "Failed to redirect child process input/output"
+msgstr "Omleiden van I/O van child proces mislukt"
+
+#: ../src/unix/utilsunx.cpp:816
+msgid "Failed to set up non-blocking pipe, the program might hang."
+msgstr "Niet-blokkerende pipe instellen mislukt. Het programma kan hangen."
+
+#: ../src/unix/utilsunx.cpp:1023
+msgid "Cannot get the hostname"
+msgstr "Kan hostnaam niet verkrijgen"
+
+#: ../src/unix/utilsunx.cpp:1059
+msgid "Cannot get the official hostname"
+msgstr "Kan officiële hostnaam niet verkrijgen"
+
+#: ../src/unix/wakeuppipe.cpp:49
+msgid "Failed to create wake up pipe used by event loop."
+msgstr "Aanmaken wake-up pipe gebruikt door gebeurtenis-lus mislukt."
+
+#: ../src/unix/wakeuppipe.cpp:56
+msgid "Failed to switch wake up pipe to non-blocking mode"
+msgstr "Kan de wake-up-pipe niet overschakelen naar de niet-blokkerende modus"
+
+#: ../src/unix/wakeuppipe.cpp:117
+msgid "Failed to read from wake-up pipe"
+msgstr "Lezen van wake-up pipe mislukt"
+
+#: ../src/x11/app.cpp:124
+#, c-format
+msgid "Invalid geometry specification '%s'"
+msgstr "Ongeldige geometrie specificatie '%s'"
+
+#: ../src/x11/app.cpp:167
+msgid "wxWidgets could not open display. Exiting."
+msgstr "wxWidgets kon beeldscherm niet openen. Afbreken."
+
+#: ../src/x11/utils.cpp:169
+#, c-format
+msgid "Failed to close the display \"%s\""
+msgstr "Kon de display \"%s\" niet sluiten"
+
+#: ../src/x11/utils.cpp:188
+#, c-format
+msgid "Failed to open display \"%s\"."
+msgstr "Openen van display \"%s\" mislukt."
+
+#: ../src/xml/xml.cpp:868
+#, c-format
+msgid "XML parsing error: '%s' at line %d"
+msgstr "XML ontleed fout: '%s' in lijn %d"
+
+#: ../src/xrc/xh_propgrid.cpp:239
+#, fuzzy, c-format
+msgid "Page %i"
+msgstr "Pagina %d"
+
+#: ../src/xrc/xmlres.cpp:448
+#, c-format
+msgid "Cannot load resources from '%s'."
+msgstr "Kan bronnen niet laden uit '%s'."
+
+#: ../src/xrc/xmlres.cpp:799
+#, c-format
+msgid "Cannot open resources file '%s'."
+msgstr "Kan bronbestand '%s' niet openen."
+
+#: ../src/xrc/xmlres.cpp:806
+#, c-format
+msgid "Cannot load resources from file '%s'."
+msgstr "Kan bronnen niet laden uit bestand '%s'."
+
+#: ../src/xrc/xmlres.cpp:2767
+#, c-format
+msgid "Creating %s \"%s\" failed."
+msgstr "Aanmaken van '%s' in '%s' mislukte."
+
+#~ msgctxt "keyboard key"
+#~ msgid "Alt+"
+#~ msgstr "Alt+"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Ctrl+"
+#~ msgstr "Ctrl+"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Shift+"
+#~ msgstr "Shift+"
+
+#~ msgctxt "keyboard key"
+#~ msgid "RawCtrl+"
+#~ msgstr "RawCtrl+"
+
+#~ msgid "Copying more than one selected block to clipboard is not supported."
+#~ msgstr ""
+#~ "Het kopiëren van meer dan één geselecteerd blok naar het klembord wordt "
+#~ "niet ondersteund."
+
+#~ msgid "Unsupported clipboard format."
+#~ msgstr "Niet ondersteund klembord-formaat."
+
+#~ msgid "Background colour"
+#~ msgstr "Achtergrondkleur"
+
+#~ msgid "Font:"
+#~ msgstr "Lettertype:"
+
+#~ msgid "Size:"
+#~ msgstr "Grootte:"
+
+#~ msgid "The font size in points."
+#~ msgstr "De lettertypegrootte in punten."
+
+#~ msgid "Style:"
+#~ msgstr "Stijl:"
+
+#~ msgid "Check to make the font bold."
+#~ msgstr "Aanvinken voor Vet Lettertype."
+
+#~ msgid "Check to make the font italic."
+#~ msgstr "Aanvinken voor Cursief Lettertype."
+
+#~ msgid "Check to make the font underlined."
+#~ msgstr "Aanvinken voor Onderstreept Lettertype."
+
+#~ msgid "Colour:"
+#~ msgstr "Kleur:"
+
+#~ msgid "Click to change the font colour."
+#~ msgstr "Klik voor het veranderen van lettertypekleur."
+
+#~ msgid "Shows a preview of the font."
+#~ msgstr "Toont een voorbeeld van het lettertype."
+
+#~ msgid "Click to cancel changes to the font."
+#~ msgstr "Klik om lettertype veranderingen te annuleren."
+
+#~ msgid "Click to confirm changes to the font."
+#~ msgstr "Klik voor bevestiging van lettertypeveranderingen."
+
+#~ msgid "<Any>"
+#~ msgstr "<Elke>"
+
+#~ msgid "<Any Roman>"
+#~ msgstr "<Elke Romaans>"
+
+#~ msgid "<Any Decorative>"
+#~ msgstr "<Elke Decoratief>"
+
+#~ msgid "<Any Modern>"
+#~ msgstr "<Elke Modern>"
+
+#~ msgid "<Any Script>"
+#~ msgstr "<Elke Script>"
+
+#~ msgid "<Any Swiss>"
+#~ msgstr "<Elke Helvetica>"
+
+#~ msgid "<Any Teletype>"
+#~ msgstr "<Elke Teletype>"
+
+#~ msgid "Printing "
+#~ msgstr "Bezig met afdrukken "
+
+#~ msgid "Failed to insert text in the control."
+#~ msgstr "Kan geen tekst aanbrengen in de control."
+
+#~ msgid "Please choose a valid font."
+#~ msgstr "Kies a.u.b. een geldig lettertype."
+
+#, c-format
+#~ msgid "Failed to display HTML document in %s encoding"
+#~ msgstr "Weergeven van HTML-document in %s-codering mislukt"
+
+#, c-format
+#~ msgid "wxWidgets could not open display for '%s': exiting."
+#~ msgstr "wxWidgets kon beeldscherm niet openen voor '%s': afbreken."
+
+#~ msgid "Filter"
+#~ msgstr "Filter"
+
+#~ msgid "Directories"
+#~ msgstr "Mappen"
+
+#~ msgid "Files"
+#~ msgstr "Bestanden"
+
+#~ msgid "Selection"
+#~ msgstr "Selectie"
+
+#~ msgid "conversion to 8-bit encoding failed"
+#~ msgstr "conversie naar 8-bit versleuteling mislukt"
+
+#~ msgid "failed to retrieve execution result"
+#~ msgstr "kan uitvoeringsresultaat niet ophalen"

--- a/po_wxstd/pl.po
+++ b/po_wxstd/pl.po
@@ -1,0 +1,10782 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: wxWidgets 3.3\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-05-14 20:23+0200\n"
+"PO-Revision-Date: 2014-06-04 16:19+1200\n"
+"Last-Translator: Mariusz Drozdowski <schemedit@wp.pl>\n"
+"Language-Team: wxWidgets translators <wx-translators@wxwidgets.org>\n"
+"Language: pl\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 "
+"|| n%100>=20) ? 1 : 2;\n"
+"X-Generator: Poedit 1.6.5\n"
+
+#: ../include/wx/defs.h:2582
+msgid "All files (*.*)|*.*"
+msgstr "Wszystkie pliki (*.*)|*.*"
+
+#: ../include/wx/defs.h:2585
+msgid "All files (*)|*"
+msgstr "Wszystkie pliki (*)|*"
+
+#: ../include/wx/generic/progdlgg.h:85
+msgid "Elapsed time:"
+msgstr "Upłynęło już:"
+
+#: ../include/wx/generic/progdlgg.h:86
+msgid "Estimated time:"
+msgstr "Szacowany czas:"
+
+#: ../include/wx/generic/progdlgg.h:87
+msgid "Remaining time:"
+msgstr "Pozostały czas:"
+
+#. TRANSLATORS: HTML printout default title.
+#: ../include/wx/html/htmprint.h:121 ../include/wx/prntbase.h:273
+#: ../include/wx/richtext/richtextprint.h:109 ../src/common/docview.cpp:2161
+msgid "Printout"
+msgstr "Wydruk"
+
+#. TRANSLATORS: HTML easy print default title.
+#: ../include/wx/html/htmprint.h:234 ../include/wx/richtext/richtextprint.h:163
+#: ../src/common/prntbase.cpp:522 ../src/html/htmprint.cpp:291
+msgid "Printing"
+msgstr "Drukowanie"
+
+#: ../include/wx/msgdlg.h:277 ../src/common/stockitem.cpp:211
+msgid "Yes"
+msgstr "Tak"
+
+#: ../include/wx/msgdlg.h:278 ../src/common/stockitem.cpp:182
+msgid "No"
+msgstr "Nie"
+
+#: ../include/wx/msgdlg.h:279 ../src/common/stockitem.cpp:183
+#: ../src/msw/msgdlg.cpp:430 ../src/msw/msgdlg.cpp:734
+#: ../src/richtext/richtextstyledlg.cpp:292
+msgid "OK"
+msgstr "OK"
+
+#: ../include/wx/msgdlg.h:280 ../src/common/stockitem.cpp:150
+#: ../src/msw/msgdlg.cpp:430 ../src/msw/progdlg.cpp:884
+#: ../src/richtext/richtextstyledlg.cpp:295
+msgid "Cancel"
+msgstr "Zrezygnuj"
+
+#: ../include/wx/msgdlg.h:281 ../src/common/stockitem.cpp:168
+#: ../src/html/helpdlg.cpp:63 ../src/html/helpfrm.cpp:108
+#: ../src/osx/button_osx.cpp:38
+msgid "Help"
+msgstr "Pomoc"
+
+#: ../include/wx/msw/ole/oleutils.h:52
+msgid "Cannot initialize OLE"
+msgstr "Nie można zainicjować OLE"
+
+# uchwyt chyba zbędny
+#: ../include/wx/msw/private/fswatcher.h:48
+#, c-format
+msgid "Unable to close the handle for '%s'"
+msgstr "Nie moża zamknąć uchwytu '%s'"
+
+#: ../include/wx/msw/private/fswatcher.h:92
+#, c-format
+msgid "Failed to open directory \"%s\" for monitoring."
+msgstr "Nie udało się otwarcie monitoringu katalogu \"%s\"."
+
+# uchwyt chyba zbędny
+#: ../include/wx/msw/private/fswatcher.h:125
+msgid "Unable to close I/O completion port handle"
+msgstr "Nie można zamknąć portu zakończenia I/O."
+
+#: ../include/wx/msw/private/fswatcher.h:142
+msgid "Unable to associate handle with I/O completion port"
+msgstr "Nie można skojarzyć uchwytu z portem kompletności We/Wy"
+
+#: ../include/wx/msw/private/fswatcher.h:148
+msgid "Unexpectedly new I/O completion port was created"
+msgstr "Nieoczekiwanie został utworzony nowy port zakończenia I/O"
+
+#: ../include/wx/msw/private/fswatcher.h:213
+msgid "Unable to post completion status"
+msgstr "Nie można wysłać stanu zakończenia"
+
+#: ../include/wx/msw/private/fswatcher.h:262
+msgid "Unable to dequeue completion packet"
+msgstr "Nie można odkolejkować pakietu zakończenia"
+
+#: ../include/wx/msw/private/fswatcher.h:273
+msgid "Unable to create I/O completion port"
+msgstr "Nie można utworzyć portu zakończenia I/O."
+
+#: ../include/wx/richmsgdlg.h:29
+msgid "&See details"
+msgstr "&Zobacz szczegóły"
+
+#: ../include/wx/richmsgdlg.h:30
+msgid "&Hide details"
+msgstr "&Ukryj szczegóły"
+
+#: ../include/wx/richtext/richtextbuffer.h:3864
+msgid "&Box"
+msgstr "&Blok"
+
+#: ../include/wx/richtext/richtextbuffer.h:5008
+msgid "&Picture"
+msgstr "&Obraz"
+
+#: ../include/wx/richtext/richtextbuffer.h:5958
+msgid "&Cell"
+msgstr "&Komórka"
+
+#: ../include/wx/richtext/richtextbuffer.h:6067
+msgid "&Table"
+msgstr "&Tabela"
+
+#: ../include/wx/richtext/richtextimagedlg.h:37
+msgid "Object Properties"
+msgstr "&Właściwości obiektu"
+
+#: ../include/wx/richtext/richtextsymboldlg.h:39
+msgid "Symbols"
+msgstr "Symbole"
+
+#: ../include/wx/unix/pipe.h:46
+msgid "Pipe creation failed"
+msgstr "Nie udało się utworzyć potoku."
+
+#: ../include/wx/unix/private/displayx11.h:65
+msgid "Failed to enumerate video modes"
+msgstr "Nie udało się pobranie listy trybów video"
+
+# uchwyt chyba zbędny
+#: ../include/wx/unix/private/displayx11.h:89
+msgid "Failed to change video mode"
+msgstr "Nie udało się zmienić trybu video"
+
+#: ../include/wx/unix/private/fswatcher_kqueue.h:57
+#, c-format
+msgid "Unable to open path '%s'"
+msgstr "Nie można otworzyć '%s'"
+
+#: ../include/wx/unix/private/fswatcher_kqueue.h:74
+#, c-format
+msgid "Unable to close path '%s'"
+msgstr "Nie moża zamknąć '%s'"
+
+#: ../include/wx/xtiprop.h:175
+msgid "SetProperty called w/o valid setter"
+msgstr ""
+"Funkcja SetProperty wywołana bez poprawnej moduły ustawiającego właściwość"
+
+#: ../include/wx/xtiprop.h:184
+msgid "GetProperty called w/o valid getter"
+msgstr "Funkcja GetProperty wywołana bez poprawnego modułu pobierającego"
+
+#: ../include/wx/xtiprop.h:193
+msgid "AddToPropertyCollection called w/o valid adder"
+msgstr ""
+"Funkcja GetPropertyCollection wywołana bez poprawnego modułu pobierającego"
+
+#: ../include/wx/xtiprop.h:202
+msgid "GetPropertyCollection called w/o valid collection getter"
+msgstr ""
+"Funkcja GetPropertyCollection wywołana bez poprawnego modułu pobierającego"
+
+#: ../include/wx/xtiprop.h:255
+msgid "AddToPropertyCollection called on a generic accessor"
+msgstr "Funkcja GetPropertyCollection wywołana w ogólnym akcesorze"
+
+#: ../include/wx/xtiprop.h:262
+msgid "GetPropertyCollection called on a generic accessor"
+msgstr "Funkcja GetPropertyCollection wywołana w ogólnym akcesorze"
+
+#: ../src/aui/tabmdi.cpp:106 ../src/generic/mdig.cpp:94
+msgid "Cl&ose"
+msgstr "Zam&knij"
+
+#: ../src/aui/tabmdi.cpp:107 ../src/generic/mdig.cpp:95
+msgid "Close All"
+msgstr "Zamknij wszystko"
+
+#: ../src/aui/tabmdi.cpp:109 ../src/generic/mdig.cpp:97 ../src/msw/mdi.cpp:175
+#: ../src/qt/mdi.cpp:258
+msgid "&Next"
+msgstr "&Następne"
+
+#: ../src/aui/tabmdi.cpp:110 ../src/generic/mdig.cpp:98 ../src/msw/mdi.cpp:176
+#: ../src/qt/mdi.cpp:259
+msgid "&Previous"
+msgstr "&Poprzednie"
+
+#: ../src/aui/tabmdi.cpp:332 ../src/aui/tabmdi.cpp:348
+#: ../src/aui/tabmdi.cpp:350 ../src/generic/mdig.cpp:291
+#: ../src/generic/mdig.cpp:307 ../src/generic/mdig.cpp:311
+#: ../src/msw/mdi.cpp:337 ../src/qt/mdi.cpp:462
+msgid "&Window"
+msgstr "&Okno"
+
+#: ../src/common/accelcmn.cpp:47
+msgctxt "keyboard key"
+msgid "Delete"
+msgstr "Usuń"
+
+#: ../src/common/accelcmn.cpp:48
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Del"
+msgstr "Usuń"
+
+#: ../src/common/accelcmn.cpp:49
+msgctxt "keyboard key"
+msgid "Back"
+msgstr "Wstecz"
+
+#: ../src/common/accelcmn.cpp:49
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Backspace"
+msgstr "Wstecz"
+
+#: ../src/common/accelcmn.cpp:50
+msgctxt "keyboard key"
+msgid "Insert"
+msgstr "Wstawić"
+
+#: ../src/common/accelcmn.cpp:51
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Ins"
+msgstr "Wstawka"
+
+#: ../src/common/accelcmn.cpp:52
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Enter"
+msgstr "Drukarka"
+
+#: ../src/common/accelcmn.cpp:53
+msgctxt "keyboard key"
+msgid "Return"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:54
+#, fuzzy
+msgctxt "keyboard key"
+msgid "PageUp"
+msgstr "Strony"
+
+#: ../src/common/accelcmn.cpp:54
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Page Up"
+msgstr "Strona %d"
+
+#: ../src/common/accelcmn.cpp:55
+#, fuzzy
+msgctxt "keyboard key"
+msgid "PageDown"
+msgstr "W dół"
+
+#: ../src/common/accelcmn.cpp:55
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Page Down"
+msgstr "Strona %d"
+
+#: ../src/common/accelcmn.cpp:56
+msgctxt "keyboard key"
+msgid "PgUp"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:57
+msgctxt "keyboard key"
+msgid "PgDn"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:58
+msgctxt "keyboard key"
+msgid "Left"
+msgstr "Lewo"
+
+#: ../src/common/accelcmn.cpp:59
+msgctxt "keyboard key"
+msgid "Right"
+msgstr "Prawy"
+
+#: ../src/common/accelcmn.cpp:60
+msgctxt "keyboard key"
+msgid "Up"
+msgstr "W górę"
+
+#: ../src/common/accelcmn.cpp:61
+msgctxt "keyboard key"
+msgid "Down"
+msgstr "W dół"
+
+#: ../src/common/accelcmn.cpp:62
+msgctxt "keyboard key"
+msgid "Home"
+msgstr "Katalog początkowy"
+
+#: ../src/common/accelcmn.cpp:63
+msgctxt "keyboard key"
+msgid "End"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:64
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Space"
+msgstr "Odstępy"
+
+#: ../src/common/accelcmn.cpp:65
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Tab"
+msgstr "Karty"
+
+#: ../src/common/accelcmn.cpp:66
+msgctxt "keyboard key"
+msgid "Esc"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:67
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Escape"
+msgstr "Pejzaż"
+
+#: ../src/common/accelcmn.cpp:68
+msgctxt "keyboard key"
+msgid "Cancel"
+msgstr "Zrezygnuj"
+
+#: ../src/common/accelcmn.cpp:69
+msgctxt "keyboard key"
+msgid "Clear"
+msgstr "Wyczyść"
+
+#: ../src/common/accelcmn.cpp:70
+msgctxt "keyboard key"
+msgid "Menu"
+msgstr "Menu"
+
+#: ../src/common/accelcmn.cpp:71
+msgctxt "keyboard key"
+msgid "Pause"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:72
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Capital"
+msgstr "&Duże litery"
+
+#: ../src/common/accelcmn.cpp:73
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Select"
+msgstr "Wybór"
+
+#: ../src/common/accelcmn.cpp:74
+msgctxt "keyboard key"
+msgid "Print"
+msgstr "Drukuj"
+
+#: ../src/common/accelcmn.cpp:75
+msgctxt "keyboard key"
+msgid "Execute"
+msgstr "Uruchom"
+
+#: ../src/common/accelcmn.cpp:76
+msgctxt "keyboard key"
+msgid "Snapshot"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:77
+msgctxt "keyboard key"
+msgid "Help"
+msgstr "Pomoc"
+
+#: ../src/common/accelcmn.cpp:78
+msgctxt "keyboard key"
+msgid "Add"
+msgstr "Dodaj"
+
+#: ../src/common/accelcmn.cpp:79
+msgctxt "keyboard key"
+msgid "Separator"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:80
+msgctxt "keyboard key"
+msgid "Subtract"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:81
+msgctxt "keyboard key"
+msgid "Decimal"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:82
+msgctxt "keyboard key"
+msgid "Multiply"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:83
+msgctxt "keyboard key"
+msgid "Divide"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:84
+msgctxt "keyboard key"
+msgid "Num_lock"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:84
+msgctxt "keyboard key"
+msgid "Num Lock"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:85
+msgctxt "keyboard key"
+msgid "Scroll_lock"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:85
+msgctxt "keyboard key"
+msgid "Scroll Lock"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:86
+msgctxt "keyboard key"
+msgid "KP_Space"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:86
+msgctxt "keyboard key"
+msgid "Num Space"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:87
+#, fuzzy
+msgctxt "keyboard key"
+msgid "KP_Tab"
+msgstr "KP_TAB"
+
+#: ../src/common/accelcmn.cpp:87
+msgctxt "keyboard key"
+msgid "Num Tab"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:88
+#, fuzzy
+msgctxt "keyboard key"
+msgid "KP_Enter"
+msgstr "Drukarka"
+
+#: ../src/common/accelcmn.cpp:88
+msgctxt "keyboard key"
+msgid "Num Enter"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:89
+#, fuzzy
+msgctxt "keyboard key"
+msgid "KP_Home"
+msgstr "Katalog początkowy"
+
+#: ../src/common/accelcmn.cpp:89
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Num Home"
+msgstr "Katalog początkowy"
+
+#: ../src/common/accelcmn.cpp:90
+#, fuzzy
+msgctxt "keyboard key"
+msgid "KP_Left"
+msgstr "Lewo"
+
+#: ../src/common/accelcmn.cpp:90
+msgctxt "keyboard key"
+msgid "Num left"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:91
+#, fuzzy
+msgctxt "keyboard key"
+msgid "KP_Up"
+msgstr "KP_UP"
+
+#: ../src/common/accelcmn.cpp:91
+msgctxt "keyboard key"
+msgid "Num Up"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:92
+#, fuzzy
+msgctxt "keyboard key"
+msgid "KP_Right"
+msgstr "Prawy"
+
+#: ../src/common/accelcmn.cpp:92
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Num Right"
+msgstr "Prawy"
+
+#: ../src/common/accelcmn.cpp:93
+#, fuzzy
+msgctxt "keyboard key"
+msgid "KP_Down"
+msgstr "W dół"
+
+#: ../src/common/accelcmn.cpp:93
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Num Down"
+msgstr "W dół"
+
+#: ../src/common/accelcmn.cpp:94
+msgctxt "keyboard key"
+msgid "KP_PageUp"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:94
+msgctxt "keyboard key"
+msgid "Num Page Up"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:95
+msgctxt "keyboard key"
+msgid "KP_PageDown"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:95
+msgctxt "keyboard key"
+msgid "Num Page Down"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:96
+msgctxt "keyboard key"
+msgid "KP_Prior"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:97
+#, fuzzy
+msgctxt "keyboard key"
+msgid "KP_Next"
+msgstr "Dalej"
+
+#: ../src/common/accelcmn.cpp:98
+#, fuzzy
+msgctxt "keyboard key"
+msgid "KP_End"
+msgstr "KP_END"
+
+#: ../src/common/accelcmn.cpp:98
+msgctxt "keyboard key"
+msgid "Num End"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:99
+msgctxt "keyboard key"
+msgid "KP_Begin"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:99
+msgctxt "keyboard key"
+msgid "Num Begin"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:100
+#, fuzzy
+msgctxt "keyboard key"
+msgid "KP_Insert"
+msgstr "Wstawić"
+
+#: ../src/common/accelcmn.cpp:100
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Num Insert"
+msgstr "Wstawić"
+
+#: ../src/common/accelcmn.cpp:101
+#, fuzzy
+msgctxt "keyboard key"
+msgid "KP_Delete"
+msgstr "Usuń"
+
+#: ../src/common/accelcmn.cpp:101
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Num Delete"
+msgstr "Usuń"
+
+#: ../src/common/accelcmn.cpp:102
+msgctxt "keyboard key"
+msgid "KP_Equal"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:102
+msgctxt "keyboard key"
+msgid "Num ="
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:103
+msgctxt "keyboard key"
+msgid "KP_Multiply"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:103
+msgctxt "keyboard key"
+msgid "Num *"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:104
+#, fuzzy
+msgctxt "keyboard key"
+msgid "KP_Add"
+msgstr "KP_ADD"
+
+#: ../src/common/accelcmn.cpp:104
+msgctxt "keyboard key"
+msgid "Num +"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:105
+msgctxt "keyboard key"
+msgid "KP_Separator"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:105
+msgctxt "keyboard key"
+msgid "Num ,"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:106
+msgctxt "keyboard key"
+msgid "KP_Subtract"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:106
+msgctxt "keyboard key"
+msgid "Num -"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:107
+msgctxt "keyboard key"
+msgid "KP_Decimal"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:107
+msgctxt "keyboard key"
+msgid "Num ."
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:108
+msgctxt "keyboard key"
+msgid "KP_Divide"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:108
+msgctxt "keyboard key"
+msgid "Num /"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:109
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Windows_Left"
+msgstr "Windows 7"
+
+#: ../src/common/accelcmn.cpp:110
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Windows_Right"
+msgstr "Windows Vista"
+
+#: ../src/common/accelcmn.cpp:111
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Windows_Menu"
+msgstr "Windows ME"
+
+#: ../src/common/accelcmn.cpp:112
+msgctxt "keyboard key"
+msgid "Command"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:186 ../src/common/accelcmn.cpp:359
+msgctxt "keyboard key"
+msgid "Ctrl"
+msgstr "Ctrl"
+
+#: ../src/common/accelcmn.cpp:188 ../src/common/accelcmn.cpp:363
+msgctxt "keyboard key"
+msgid "Alt"
+msgstr "Alt"
+
+#: ../src/common/accelcmn.cpp:190 ../src/common/accelcmn.cpp:361
+msgctxt "keyboard key"
+msgid "Shift"
+msgstr "Shift"
+
+#: ../src/common/accelcmn.cpp:196
+msgctxt "keyboard key"
+msgid "num "
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:260 ../src/common/accelcmn.cpp:382
+msgctxt "keyboard key"
+msgid "F"
+msgstr "F"
+
+#: ../src/common/accelcmn.cpp:277 ../src/common/accelcmn.cpp:385
+msgctxt "keyboard key"
+msgid "KP_F"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:280 ../src/common/accelcmn.cpp:388
+msgctxt "keyboard key"
+msgid "KP_"
+msgstr "KP_"
+
+#: ../src/common/accelcmn.cpp:283 ../src/common/accelcmn.cpp:391
+msgctxt "keyboard key"
+msgid "SPECIAL"
+msgstr "SPECJALNY"
+
+#: ../src/common/accelcmn.cpp:373
+#, fuzzy
+msgid "Ctrl"
+msgstr "Ctrl"
+
+#: ../src/common/appbase.cpp:786
+msgid "show this help message"
+msgstr "wyświetla ten komunikat"
+
+# inaczej
+#: ../src/common/appbase.cpp:796
+msgid "generate verbose log messages"
+msgstr "generuje listę komunikatów"
+
+#: ../src/common/appcmn.cpp:256
+msgid "specify the theme to use"
+msgstr "określa kompozycję, który ma być użyta"
+
+#: ../src/common/appcmn.cpp:270
+msgid "specify display mode to use (e.g. 640x480-16)"
+msgstr "określa tryb wyświetlania, który ma być użyty (np. 640x480-16)"
+
+#: ../src/common/appcmn.cpp:292
+#, c-format
+msgid "Unsupported theme '%s'."
+msgstr "Nieobsługiwana kompozycja '%s'."
+
+#: ../src/common/appcmn.cpp:309
+#, c-format
+msgid "Invalid display mode specification '%s'."
+msgstr "Błędna specyfikacja trybu wyświetlania '%s'."
+
+#: ../src/common/cmdline.cpp:875
+#, c-format
+msgid "Option '%s' can't be negated"
+msgstr "Opcja '%s' nie może zostać zanegowana"
+
+#: ../src/common/cmdline.cpp:889
+#, c-format
+msgid "Unknown long option '%s'"
+msgstr "Nieznana długa opcja '%s'"
+
+#: ../src/common/cmdline.cpp:904 ../src/common/cmdline.cpp:926
+#, c-format
+msgid "Unknown option '%s'"
+msgstr "Nieznana opcja '%s'"
+
+#: ../src/common/cmdline.cpp:1004
+#, c-format
+msgid "Unexpected characters following option '%s'."
+msgstr "Nieoczekiwane znaki następujących opcji '%s'."
+
+#: ../src/common/cmdline.cpp:1039
+#, c-format
+msgid "Option '%s' requires a value."
+msgstr "Opcja '%s' wymaga podania wartości."
+
+#: ../src/common/cmdline.cpp:1058
+#, c-format
+msgid "Separator expected after the option '%s'."
+msgstr "Oczekiwano separatora po opcji '%s'."
+
+#: ../src/common/cmdline.cpp:1088 ../src/common/cmdline.cpp:1106
+#, c-format
+msgid "'%s' is not a correct numeric value for option '%s'."
+msgstr "'%s' nie jest poprawną wartością numeryczną opcji '%s'."
+
+#: ../src/common/cmdline.cpp:1122
+#, c-format
+msgid "Option '%s': '%s' cannot be converted to a date."
+msgstr "Opcja '%s': nie można przekształcić '%s' na datę."
+
+#: ../src/common/cmdline.cpp:1170
+#, c-format
+msgid "Unexpected parameter '%s'"
+msgstr "Nieoczekiwany parametr '%s'"
+
+#. TRANSLATORS: Short name and long name for a command line option
+#: ../src/common/cmdline.cpp:1197
+#, c-format
+msgid "%s (or %s)"
+msgstr "%s (lub %s)"
+
+#: ../src/common/cmdline.cpp:1208
+#, c-format
+msgid "The value for the option '%s' must be specified."
+msgstr "Wartość opcji '%s' musi zostać podana."
+
+#: ../src/common/cmdline.cpp:1230
+#, c-format
+msgid "The required parameter '%s' was not specified."
+msgstr "Wymagany parametr '%s' nie został podany."
+
+# hm
+#: ../src/common/cmdline.cpp:1289
+#, c-format
+msgid "Usage: %s"
+msgstr "Użycie: %s"
+
+#: ../src/common/cmdline.cpp:1498
+msgid "str"
+msgstr "tekst"
+
+#: ../src/common/cmdline.cpp:1502
+msgid "num"
+msgstr "liczba"
+
+#: ../src/common/cmdline.cpp:1506
+msgid "double"
+msgstr "podwójnie"
+
+#: ../src/common/cmdline.cpp:1510
+msgid "date"
+msgstr "data"
+
+#: ../src/common/cmdproc.cpp:250 ../src/common/cmdproc.cpp:276
+#: ../src/common/cmdproc.cpp:296
+msgid "Unnamed command"
+msgstr "Polecenie bez nazwy"
+
+#: ../src/common/cmdproc.cpp:253
+msgid "&Undo "
+msgstr "&Cofnij "
+
+#: ../src/common/cmdproc.cpp:255
+msgid "Can't &Undo "
+msgstr "Nie można &cofnąć "
+
+#: ../src/common/cmdproc.cpp:259 ../src/common/stockitem.cpp:208
+#: ../src/msw/textctrl.cpp:2880 ../src/osx/textctrl_osx.cpp:649
+#: ../src/richtext/richtextctrl.cpp:327
+msgid "&Undo"
+msgstr "&Cofnij"
+
+#: ../src/common/cmdproc.cpp:277 ../src/common/cmdproc.cpp:297
+msgid "&Redo "
+msgstr "&Ponów "
+
+#: ../src/common/cmdproc.cpp:281 ../src/common/cmdproc.cpp:288
+#: ../src/common/stockitem.cpp:190 ../src/msw/textctrl.cpp:2881
+#: ../src/osx/textctrl_osx.cpp:650 ../src/richtext/richtextctrl.cpp:328
+msgid "&Redo"
+msgstr "&Ponów"
+
+#: ../src/common/colourcmn.cpp:41
+#, c-format
+msgid "String To Colour : Incorrect colour specification : %s"
+msgstr "Nieprawidłowa specyfikacja koloru : %s"
+
+#: ../src/common/config.cpp:259
+#, c-format
+msgid "Invalid value %ld for a boolean key \"%s\" in config file."
+msgstr ""
+"Nieprawidłowa wartość %ld dla klucza logicznego\"%s\" w pliku "
+"konfiguracyjnym."
+
+#: ../src/common/config.cpp:526
+#, c-format
+msgid ""
+"Environment variables expansion failed: missing '%c' at position %u in '%s'."
+msgstr ""
+"Rozwinięcie zmiennych środowiskowych nie powiodło się: zabrakło '%c' na "
+"pozycji '%u' w '%s'."
+
+#: ../src/common/config.cpp:576 ../src/msw/regconf.cpp:272
+#, c-format
+msgid "'%s' has extra '..', ignored."
+msgstr "'%s' ma nadmiarowe '..', zignorowane."
+
+#. TRANSLATORS: Checkbox state name
+#: ../src/common/datavcmn.cpp:2166 ../src/generic/datavgen.cpp:1430
+msgid "checked"
+msgstr ""
+
+#. TRANSLATORS: Checkbox state name
+#: ../src/common/datavcmn.cpp:2170 ../src/generic/datavgen.cpp:1432
+msgid "unchecked"
+msgstr ""
+
+#. TRANSLATORS: Checkbox state name
+#: ../src/common/datavcmn.cpp:2174
+#, fuzzy
+msgid "undetermined"
+msgstr "podkreślony"
+
+#: ../src/common/datetimefmt.cpp:1875
+msgid "today"
+msgstr "dziś"
+
+#: ../src/common/datetimefmt.cpp:1876
+msgid "yesterday"
+msgstr "wczoraj"
+
+#: ../src/common/datetimefmt.cpp:1877
+msgid "tomorrow"
+msgstr "jutro"
+
+#: ../src/common/datetimefmt.cpp:2071
+msgid "first"
+msgstr "pierwszy"
+
+#: ../src/common/datetimefmt.cpp:2072
+msgid "second"
+msgstr "drugi"
+
+#: ../src/common/datetimefmt.cpp:2073
+msgid "third"
+msgstr "trzeci"
+
+#: ../src/common/datetimefmt.cpp:2074
+msgid "fourth"
+msgstr "czwarty"
+
+#: ../src/common/datetimefmt.cpp:2075
+msgid "fifth"
+msgstr "piąty"
+
+#: ../src/common/datetimefmt.cpp:2076
+msgid "sixth"
+msgstr "szósty"
+
+#: ../src/common/datetimefmt.cpp:2077
+msgid "seventh"
+msgstr "siódmy"
+
+#: ../src/common/datetimefmt.cpp:2078
+msgid "eighth"
+msgstr "ósmy"
+
+#: ../src/common/datetimefmt.cpp:2079
+msgid "ninth"
+msgstr "dziewiąty"
+
+#: ../src/common/datetimefmt.cpp:2080
+msgid "tenth"
+msgstr "dziesiąty"
+
+#: ../src/common/datetimefmt.cpp:2081
+msgid "eleventh"
+msgstr "jedenasty"
+
+#: ../src/common/datetimefmt.cpp:2082
+msgid "twelfth"
+msgstr "dwunasty"
+
+#: ../src/common/datetimefmt.cpp:2083
+msgid "thirteenth"
+msgstr "trzynasty"
+
+#: ../src/common/datetimefmt.cpp:2084
+msgid "fourteenth"
+msgstr "czternasty"
+
+#: ../src/common/datetimefmt.cpp:2085
+msgid "fifteenth"
+msgstr "piętnasty"
+
+#: ../src/common/datetimefmt.cpp:2086
+msgid "sixteenth"
+msgstr "szesnasty"
+
+#: ../src/common/datetimefmt.cpp:2087
+msgid "seventeenth"
+msgstr "siedemnasty"
+
+#: ../src/common/datetimefmt.cpp:2088
+msgid "eighteenth"
+msgstr "osiemnasty"
+
+#: ../src/common/datetimefmt.cpp:2089
+msgid "nineteenth"
+msgstr "dziewiętnasty"
+
+#: ../src/common/datetimefmt.cpp:2090
+msgid "twentieth"
+msgstr "dwudziesty"
+
+#: ../src/common/datetimefmt.cpp:2248
+msgid "noon"
+msgstr "południe"
+
+#: ../src/common/datetimefmt.cpp:2249
+msgid "midnight"
+msgstr "północ"
+
+#: ../src/common/debugrpt.cpp:209
+#, c-format
+msgid "Failed to create directory \"%s\""
+msgstr "Nie udało się utworzenie katalogu \"%s\""
+
+#: ../src/common/debugrpt.cpp:210
+msgid "Debug report couldn't be created."
+msgstr "Wygenerowanie raport błędów nie powiodło się."
+
+#: ../src/common/debugrpt.cpp:227
+#, c-format
+msgid "Failed to remove debug report file \"%s\""
+msgstr "Nie udało się usunięcie pliku raportu błędów \"%s\""
+
+#: ../src/common/debugrpt.cpp:239
+#, c-format
+msgid "Failed to clean up debug report directory \"%s\""
+msgstr "Nie udało się czyszczenie katalogu raportu błędów \"%s\""
+
+#: ../src/common/debugrpt.cpp:514
+msgid "process context description"
+msgstr "opis kontekstu procesu"
+
+#: ../src/common/debugrpt.cpp:538
+msgid "dump of the process state (binary)"
+msgstr "kopia stanu procesu (binarnie)"
+
+#: ../src/common/debugrpt.cpp:553
+msgid "Debug report generation has failed."
+msgstr "Generowanie raportu błędów nie powiodło się."
+
+#: ../src/common/debugrpt.cpp:560
+#, c-format
+msgid ""
+"Processing debug report has failed, leaving the files in \"%s\" directory."
+msgstr ""
+"Przetwarzanie raportu błędów nie powiodło się, pozostawiając pliku w "
+"katalogu \"%s\"."
+
+#: ../src/common/debugrpt.cpp:573
+msgid "A debug report has been generated. It can be found in"
+msgstr "Raport błędów został wygenerowany. Znajduje się w"
+
+#: ../src/common/debugrpt.cpp:576
+msgid "And includes the following files:\n"
+msgstr "I zawiera następujące pliki:\n"
+
+#: ../src/common/debugrpt.cpp:586
+msgid ""
+"\n"
+"Please send this report to the program maintainer, thank you!\n"
+msgstr ""
+"\n"
+"Proszę przesłać ten raport do autora programu, dziękuję!\n"
+
+#: ../src/common/debugrpt.cpp:729
+msgid "Failed to execute curl, please install it in PATH."
+msgstr ""
+"Nie udało się uruchomienie curl, proszę zainstalować go w dostępnym katalogu "
+"(PATH)."
+
+#: ../src/common/debugrpt.cpp:742
+#, c-format
+msgid "Failed to upload the debug report (error code %d)."
+msgstr "Nie udało się przesłanie raportu błędów (kod błędu %d)"
+
+#: ../src/common/docview.cpp:366
+msgid "Save As"
+msgstr "Zapisz Jako"
+
+#: ../src/common/docview.cpp:457
+msgid "Discard changes and reload the last saved version?"
+msgstr "Odrzucić zmiany i wczytać ponownie ostatnio zapisaną wersję?"
+
+#: ../src/common/docview.cpp:488
+msgid "unnamed"
+msgstr "beznazwy"
+
+#: ../src/common/docview.cpp:513
+#, c-format
+msgid "Do you want to save changes to %s?"
+msgstr "Chcesz zapisać zmiany w dokumencie %s?"
+
+#: ../src/common/docview.cpp:521 ../src/common/docview.cpp:560
+#: ../src/common/stockitem.cpp:195
+msgid "&Save"
+msgstr "Zapi&sz"
+
+#: ../src/common/docview.cpp:522 ../src/common/docview.cpp:560
+msgid "&Discard changes"
+msgstr ""
+
+#: ../src/common/docview.cpp:523
+#, fuzzy
+msgid "Do&n't close"
+msgstr "Nie Zapisuj"
+
+#: ../src/common/docview.cpp:553
+#, fuzzy, c-format
+msgid "Do you want to save changes to %s before closing it?"
+msgstr "Chcesz zapisać zmiany w dokumencie %s?"
+
+#: ../src/common/docview.cpp:559
+#, fuzzy
+msgid "The document must be closed."
+msgstr "Tekst nie może być zapisany.."
+
+#: ../src/common/docview.cpp:571
+#, c-format
+msgid "Saving %s failed, would you like to retry?"
+msgstr ""
+
+#: ../src/common/docview.cpp:577
+msgid "Retry"
+msgstr ""
+
+#: ../src/common/docview.cpp:577
+msgid "Discard changes"
+msgstr ""
+
+#: ../src/common/docview.cpp:679
+#, c-format
+msgid "File \"%s\" could not be opened for writing."
+msgstr "Nie udało się otworzyć pliku '%s' do zapisu"
+
+#: ../src/common/docview.cpp:685
+#, c-format
+msgid "Failed to save document to the file \"%s\"."
+msgstr "Nie udało się zapisać dokumentu do pliku \"%s\"."
+
+#: ../src/common/docview.cpp:702
+#, c-format
+msgid "File \"%s\" could not be opened for reading."
+msgstr "Nie udało się otworzyć pliku '%s' do odczytu."
+
+#: ../src/common/docview.cpp:714
+#, c-format
+msgid "Failed to read document from the file \"%s\"."
+msgstr "Nie udało się wczytanie dokumentu z pliku \"%s\"."
+
+#: ../src/common/docview.cpp:1236
+#, c-format
+msgid ""
+"The file '%s' doesn't exist and couldn't be opened.\n"
+"It has been removed from the most recently used files list."
+msgstr ""
+"Plik '%s' nie istnieje i nie można go otworzyć.\n"
+"Informacja o nim została usunięta z listy ostatnio używanych plików."
+
+#: ../src/common/docview.cpp:1296
+msgid "Print preview creation failed."
+msgstr "Nie udało się utworzyć podglądu wydruku."
+
+#: ../src/common/docview.cpp:1302
+msgid "Print Preview"
+msgstr "Podgląd wydruku"
+
+#: ../src/common/docview.cpp:1517
+#, c-format
+msgid "The format of file '%s' couldn't be determined."
+msgstr "Nie można wykryć formatu pliku '%s' ."
+
+#: ../src/common/docview.cpp:1643
+#, c-format
+msgid "unnamed%d"
+msgstr "beznazwy%d"
+
+#: ../src/common/docview.cpp:1660
+msgid " - "
+msgstr " - "
+
+#: ../src/common/docview.cpp:1791 ../src/common/docview.cpp:1844
+msgid "Open File"
+msgstr "Otwieranie Pliku"
+
+#: ../src/common/docview.cpp:1807
+msgid "File error"
+msgstr "Błąd plikowy"
+
+#: ../src/common/docview.cpp:1809
+msgid "Sorry, could not open this file."
+msgstr "Niestety nie można otworzyć tego pliku."
+
+#: ../src/common/docview.cpp:1843
+msgid "Sorry, the format for this file is unknown."
+msgstr "Niestety, nieznany format pliku."
+
+#: ../src/common/docview.cpp:1924
+msgid "Select a document template"
+msgstr "Wybierz szablon dokumentu"
+
+#: ../src/common/docview.cpp:1925
+msgid "Templates"
+msgstr "Szablony"
+
+# perspektywę?
+#: ../src/common/docview.cpp:1998
+msgid "Select a document view"
+msgstr "Wybierz widok dokumentu"
+
+#: ../src/common/docview.cpp:1999
+msgid "Views"
+msgstr "Widoki"
+
+#: ../src/common/dynlib.cpp:81
+#, c-format
+msgid "Failed to load shared library '%s'"
+msgstr "Nie udało się wczytać biblioteki '%s'."
+
+# dynamicznej? nieładne, a chyba zbędne
+#: ../src/common/dynlib.cpp:105
+#, c-format
+msgid "Couldn't find symbol '%s' in a dynamic library"
+msgstr "Nie można znaleźć symbolu '%s' w bibliotece"
+
+#: ../src/common/ffile.cpp:56 ../src/common/file.cpp:215
+#, c-format
+msgid "can't open file '%s'"
+msgstr "nie można otworzyć pliku '%s'"
+
+#: ../src/common/ffile.cpp:72
+#, c-format
+msgid "can't close file '%s'"
+msgstr "nie można zamknąć pliku '%s'"
+
+#: ../src/common/ffile.cpp:106 ../src/common/ffile.cpp:131
+#, c-format
+msgid "Read error on file '%s'"
+msgstr "Błąd odczytu pliku '%s'"
+
+#: ../src/common/ffile.cpp:148
+#, c-format
+msgid "Write error on file '%s'"
+msgstr "Błąd zapisu do pliku '%s'"
+
+# nie do końca...
+#: ../src/common/ffile.cpp:182
+#, c-format
+msgid "failed to flush the file '%s'"
+msgstr "nie udało się opróżnić (flush) pliku '%s'"
+
+#: ../src/common/ffile.cpp:222
+#, c-format
+msgid "Seek error on file '%s' (large files not supported by stdio)"
+msgstr "Błąd wyszukiwania w pliku '%s' (stdio nie wspiera olbrzymich plików)"
+
+#: ../src/common/ffile.cpp:232
+#, c-format
+msgid "Seek error on file '%s'"
+msgstr "Błąd pozycjonowania w pliku '%s'"
+
+#: ../src/common/ffile.cpp:248
+#, c-format
+msgid "Can't find current position in file '%s'"
+msgstr "Nie można znaleźć bieżącej pozycji w pliku '%s'"
+
+#: ../src/common/ffile.cpp:349 ../src/common/file.cpp:569
+msgid "Failed to set temporary file permissions"
+msgstr "Nie udało się nadać praw dostępu pliku tymczasowemu"
+
+#: ../src/common/ffile.cpp:371
+#, c-format
+msgid "can't remove file '%s'"
+msgstr "nie można usunąć pliku '%s'"
+
+#: ../src/common/ffile.cpp:376 ../src/common/file.cpp:591
+#, c-format
+msgid "can't commit changes to file '%s'"
+msgstr "nie można zatwierdzić zmian w pliku '%s'"
+
+#: ../src/common/ffile.cpp:388 ../src/common/file.cpp:603
+#, c-format
+msgid "can't remove temporary file '%s'"
+msgstr "nie można usunąć tymczasowego pliku '%s'"
+
+#: ../src/common/file.cpp:162
+#, c-format
+msgid "can't create file '%s'"
+msgstr "nie można utworzyć pliku '%s'"
+
+#: ../src/common/file.cpp:229
+#, c-format
+msgid "can't close file descriptor %d"
+msgstr "nie można zamknąć deskryptora pliku %d"
+
+#: ../src/common/file.cpp:332
+#, c-format
+msgid "can't read from file descriptor %d"
+msgstr "nie można czytać z deskryptora pliku %d"
+
+#: ../src/common/file.cpp:351
+#, c-format
+msgid "can't write to file descriptor %d"
+msgstr "nie można zapisać do deskryptora pliku %d"
+
+#: ../src/common/file.cpp:390
+#, c-format
+msgid "can't flush file descriptor %d"
+msgstr "nie można opróżnić deskryptora pliku %d"
+
+#: ../src/common/file.cpp:432
+#, c-format
+msgid "can't seek on file descriptor %d"
+msgstr "nie można ustawić pozycji w deskryptorze pliku %d"
+
+#: ../src/common/file.cpp:446
+#, c-format
+msgid "can't get seek position on file descriptor %d"
+msgstr "nie można odczytać bieżącej pozycji w deskryptorze pliku %d"
+
+#: ../src/common/file.cpp:475
+#, c-format
+msgid "can't find length of file on file descriptor %d"
+msgstr "nie można znaleźć rozmiaru pliku w deskryptorze pliku %d"
+
+#: ../src/common/file.cpp:505
+#, c-format
+msgid "can't determine if the end of file is reached on descriptor %d"
+msgstr "nie można określić czy osiągnięto koniec pliku w deskryptorze %d"
+
+#: ../src/common/fileconf.cpp:352
+#, c-format
+msgid ""
+" and additionally, the existing configuration file was renamed to \"%s\" and "
+"couldn't be renamed back, please rename it to its original path \"%s\""
+msgstr ""
+
+#: ../src/common/fileconf.cpp:389
+#, fuzzy
+msgid " due to the following error:\n"
+msgstr "I zawiera następujące pliki:\n"
+
+#: ../src/common/fileconf.cpp:412
+#, fuzzy
+msgid "failed to rename the existing file"
+msgstr "Nie udało się wczytanie dokumentu z pliku \"%s\"."
+
+#: ../src/common/fileconf.cpp:421
+#, fuzzy
+msgid "failed to create the new file directory"
+msgstr "Nie udało się uzyskać katalogu roboczego"
+
+#: ../src/common/fileconf.cpp:428
+#, fuzzy
+msgid "failed to move the file to the new location"
+msgstr "Nie udało się zakończyć połączenia dialup: %s"
+
+# globalnej?
+#: ../src/common/fileconf.cpp:462
+#, c-format
+msgid "can't open global configuration file '%s'."
+msgstr "nie można otworzyć globalnego pliku konfiguracji '%s'."
+
+#: ../src/common/fileconf.cpp:478
+#, c-format
+msgid "can't open user configuration file '%s'."
+msgstr "nie można otworzyć pliku konfiguracyjnego użytkownika '%s'."
+
+#: ../src/common/fileconf.cpp:483
+#, c-format
+msgid "Changes won't be saved to avoid overwriting the existing file \"%s\""
+msgstr ""
+"Zmiany nie zostaną zapisane, aby uniknąć nadpisania istniejącego pliku \"%s\""
+
+#: ../src/common/fileconf.cpp:583
+msgid "Error reading config options."
+msgstr "Błąd odczytu opcji konfiguracji."
+
+#: ../src/common/fileconf.cpp:593
+msgid "Failed to read config options."
+msgstr "Nie udało się odczytać opcji konfiguracji."
+
+#: ../src/common/fileconf.cpp:700
+#, fuzzy, c-format
+msgid "file '%s': unexpected character %c at line %zu."
+msgstr "plik '%s': nieoczekiwany znak %c w lini %d."
+
+#: ../src/common/fileconf.cpp:736
+#, fuzzy, c-format
+msgid "file '%s', line %zu: '%s' ignored after group header."
+msgstr "plik '%s', linia %d: zignorowano '%s' po nagłówku grupy."
+
+#: ../src/common/fileconf.cpp:765
+#, fuzzy, c-format
+msgid "file '%s', line %zu: '=' expected."
+msgstr "plik '%s', linia %d: oczekiwano '='."
+
+# niezmiennego?
+#: ../src/common/fileconf.cpp:778
+#, fuzzy, c-format
+msgid "file '%s', line %zu: value for immutable key '%s' ignored."
+msgstr "plik '%s', linia %d: zignorowano wartość dla niezmiennego klucza '%s'."
+
+#: ../src/common/fileconf.cpp:788
+#, fuzzy, c-format
+msgid "file '%s', line %zu: key '%s' was first found at line %d."
+msgstr "plik '%s', linia %d: klucz '%s' wystąpił po raz pierwszy w lini %d."
+
+#: ../src/common/fileconf.cpp:1091
+#, c-format
+msgid "Config entry name cannot start with '%c'."
+msgstr "Nazwa pozycji konfiguracji nie może zaczynać się od '%c'."
+
+#: ../src/common/fileconf.cpp:1146
+#, fuzzy
+msgid "Failed to create configuration file directory."
+msgstr "Nie udała się aktualizacja pliku konfiguracyjnego użytkownika."
+
+#: ../src/common/fileconf.cpp:1158
+msgid "can't open user configuration file."
+msgstr "nie można otworzyć pliku konfiguracyjnego użytkownika."
+
+#: ../src/common/fileconf.cpp:1172
+msgid "can't write user configuration file."
+msgstr "nie można zapisać pliku konfiguracyjnego użytkownika."
+
+#: ../src/common/fileconf.cpp:1178
+msgid "Failed to update user configuration file."
+msgstr "Nie udała się aktualizacja pliku konfiguracyjnego użytkownika."
+
+#: ../src/common/fileconf.cpp:1201
+msgid "Error saving user configuration data."
+msgstr "Błąd zapisu konfiguracji użytkownika."
+
+#: ../src/common/fileconf.cpp:1313
+#, c-format
+msgid "can't delete user configuration file '%s'"
+msgstr "nie można usunąć pliku konfiguracyjnego użytkownika '%s'"
+
+#: ../src/common/fileconf.cpp:2007
+#, c-format
+msgid "entry '%s' appears more than once in group '%s'"
+msgstr "pozycja '%s' występuje w grupie '%s' więcej niż jeden raz"
+
+#: ../src/common/fileconf.cpp:2021
+#, c-format
+msgid "attempt to change immutable key '%s' ignored."
+msgstr "zignorowano próbę zmiany niezmiennego klucza '%s'."
+
+#: ../src/common/fileconf.cpp:2118
+#, c-format
+msgid "trailing backslash ignored in '%s'"
+msgstr "końcowy ukośnik odwrotny zignorowany w '%s'"
+
+#: ../src/common/fileconf.cpp:2153
+#, c-format
+msgid "unexpected \" at position %d in '%s'."
+msgstr "nieoczekiwany \" na pozycji %d w '%s'."
+
+#: ../src/common/filefn.cpp:474
+#, c-format
+msgid "Failed to copy the file '%s' to '%s'"
+msgstr "Nie udało się skopiować pliku '%s' do '%s'."
+
+#: ../src/common/filefn.cpp:487
+#, c-format
+msgid "Impossible to get permissions for file '%s'"
+msgstr "Uzyskanie praw dostępu do pliku '%s' jest niemożliwe"
+
+#: ../src/common/filefn.cpp:501
+#, c-format
+msgid "Impossible to overwrite the file '%s'"
+msgstr "Zastąpienie pliku '%s' jest niemożliwe"
+
+#: ../src/common/filefn.cpp:508
+#, fuzzy, c-format
+msgid "Error copying the file '%s' to '%s'."
+msgstr "Nie udało się skopiować pliku '%s' do '%s'."
+
+#: ../src/common/filefn.cpp:556
+#, c-format
+msgid "Impossible to set permissions for the file '%s'"
+msgstr "Nie jest możliwe nadanie praw dostępu plikowi '%s'"
+
+#: ../src/common/filefn.cpp:606
+#, c-format
+msgid ""
+"Failed to rename the file '%s' to '%s' because the destination file already "
+"exists."
+msgstr ""
+"Nie udało się zmienić nazwy pliku '%s' na '%s', ponieważ plik docelowy już "
+"istnieje."
+
+#: ../src/common/filefn.cpp:623
+#, c-format
+msgid "File '%s' couldn't be renamed '%s'"
+msgstr "Nazwa pliku '%s' nie mogła zostać zmieniona '%s'"
+
+#: ../src/common/filefn.cpp:639
+#, c-format
+msgid "File '%s' couldn't be removed"
+msgstr "Plik '%s' nie mógł zostać usunięty"
+
+#: ../src/common/filefn.cpp:666
+#, c-format
+msgid "Directory '%s' couldn't be created"
+msgstr "Nie można utworzyć katalogu '%s'"
+
+#: ../src/common/filefn.cpp:680
+#, c-format
+msgid "Directory '%s' couldn't be deleted"
+msgstr "Nie można usunąć katalogu '%s'"
+
+#: ../src/common/filefn.cpp:714
+#, c-format
+msgid "Cannot enumerate files '%s'"
+msgstr "Nie można wyliczyć plików '%s'"
+
+#: ../src/common/filefn.cpp:798
+msgid "Failed to get the working directory"
+msgstr "Nie udało się uzyskać katalogu roboczego"
+
+#: ../src/common/filefn.cpp:843
+msgid "Could not set current working directory"
+msgstr "Nie udało się ustawić katalogu roboczego"
+
+#: ../src/common/filefn.cpp:974
+#, c-format
+msgid "Files (%s)"
+msgstr "Pliki (%s)"
+
+#: ../src/common/filename.cpp:182
+#, c-format
+msgid "Failed to open '%s' for reading"
+msgstr "Nie udało się otworzyć '%s' do odczytu"
+
+#: ../src/common/filename.cpp:187
+#, c-format
+msgid "Failed to open '%s' for writing"
+msgstr "Nie udało się otworzyć '%s' do zapisu"
+
+# uchwyt chyba zbędny
+#: ../src/common/filename.cpp:199
+msgid "Failed to close file handle"
+msgstr "Nie udało się zamknąć pliku."
+
+#: ../src/common/filename.cpp:1046
+msgid "Failed to create a temporary file name"
+msgstr "Nie udało się wygenerować nazwy dla pliku tymczasowego"
+
+#: ../src/common/filename.cpp:1081
+msgid "Failed to open temporary file."
+msgstr "Nie udało się otworzyć pliku tymczasowego."
+
+# nieładne
+#: ../src/common/filename.cpp:2862
+#, c-format
+msgid "Failed to modify file times for '%s'"
+msgstr "Nie udało się zmodyfikować czasów pliku '%s'"
+
+#: ../src/common/filename.cpp:2877
+#, c-format
+msgid "Failed to touch the file '%s'"
+msgstr "Nie udało się zmienić czasów pliku '%s'"
+
+#: ../src/common/filename.cpp:2958
+#, c-format
+msgid "Failed to retrieve file times for '%s'"
+msgstr "Nie udało się odczytać czasów pliku '%s'"
+
+#: ../src/common/filepickercmn.cpp:39 ../src/common/filepickercmn.cpp:40
+msgid "Browse"
+msgstr "Przeglądaj"
+
+#: ../src/common/fldlgcmn.cpp:792 ../src/generic/filectrlg.cpp:1185
+#, c-format
+msgid "All files (%s)|%s"
+msgstr "Wszystkie pliki (%s)|%s"
+
+#. TRANSLATORS: %s are a file extension used to build a file wildcard string
+#: ../src/common/fldlgcmn.cpp:810
+#, c-format
+msgid "%s files (%s)|%s"
+msgstr "%s pliki (%s)|%s"
+
+#: ../src/common/fldlgcmn.cpp:1072
+#, c-format
+msgid "Load %s file"
+msgstr "Wczytaj plik %s"
+
+#: ../src/common/fldlgcmn.cpp:1074
+#, c-format
+msgid "Save %s file"
+msgstr "Zapisz plik %s"
+
+#: ../src/common/fmapbase.cpp:144
+msgid "Western European (ISO-8859-1)"
+msgstr "Zachodnioeuropejski (ISO-8859-1)"
+
+#: ../src/common/fmapbase.cpp:145
+msgid "Central European (ISO-8859-2)"
+msgstr "Środkowoeuropejski (ISO-8859-2)"
+
+#: ../src/common/fmapbase.cpp:146
+msgid "Esperanto (ISO-8859-3)"
+msgstr "Esperanto (ISO-8859-3)"
+
+#: ../src/common/fmapbase.cpp:147
+msgid "Baltic (old) (ISO-8859-4)"
+msgstr "Bałtycki (stary) (ISO-8859-4)"
+
+#: ../src/common/fmapbase.cpp:148
+msgid "Cyrillic (ISO-8859-5)"
+msgstr "Cyrylica (ISO-8859-5)"
+
+#: ../src/common/fmapbase.cpp:149
+msgid "Arabic (ISO-8859-6)"
+msgstr "Arabski (ISO-8859-6)"
+
+#: ../src/common/fmapbase.cpp:150
+msgid "Greek (ISO-8859-7)"
+msgstr "Grecki (ISO-8859-7)"
+
+#: ../src/common/fmapbase.cpp:151
+msgid "Hebrew (ISO-8859-8)"
+msgstr "Hebrajski (ISO-8859-8)"
+
+#: ../src/common/fmapbase.cpp:152
+msgid "Turkish (ISO-8859-9)"
+msgstr "Turecki (ISO-8859-9)"
+
+#: ../src/common/fmapbase.cpp:153
+msgid "Nordic (ISO-8859-10)"
+msgstr "Nordycki (ISO-8859-10)"
+
+#: ../src/common/fmapbase.cpp:154
+msgid "Thai (ISO-8859-11)"
+msgstr "Tajski (ISO-8859-11)"
+
+#: ../src/common/fmapbase.cpp:155
+msgid "Indian (ISO-8859-12)"
+msgstr "Hinduski (ISO-8859-12)"
+
+#: ../src/common/fmapbase.cpp:156
+msgid "Baltic (ISO-8859-13)"
+msgstr "Bałtycki (ISO-8859-13)"
+
+#: ../src/common/fmapbase.cpp:157
+msgid "Celtic (ISO-8859-14)"
+msgstr "Celtycki (ISO-8859-14)"
+
+#: ../src/common/fmapbase.cpp:158
+msgid "Western European with Euro (ISO-8859-15)"
+msgstr "Zachodnioeuropejski z Euro (ISO-8859-15)"
+
+#: ../src/common/fmapbase.cpp:159
+msgid "KOI8-R"
+msgstr "KOI8-R"
+
+#: ../src/common/fmapbase.cpp:160
+msgid "KOI8-U"
+msgstr "KOI8-U"
+
+#: ../src/common/fmapbase.cpp:161
+msgid "Windows/DOS OEM Cyrillic (CP 866)"
+msgstr "Windows/DOS OEM Cyrylica (CP 866)"
+
+#: ../src/common/fmapbase.cpp:162
+msgid "Windows Thai (CP 874)"
+msgstr "Windows Thai (CP 874)"
+
+#: ../src/common/fmapbase.cpp:163
+msgid "Windows Japanese (CP 932) or Shift-JIS"
+msgstr "Windows japoński (CP 932) lub Shift-JIS"
+
+#: ../src/common/fmapbase.cpp:164
+msgid "Windows Chinese Simplified (CP 936) or GB-2312"
+msgstr "Windows chiński uproszczony (CP 936) lub GB-2312"
+
+#: ../src/common/fmapbase.cpp:165
+msgid "Windows Korean (CP 949)"
+msgstr "Windows koreański (CP 949)"
+
+#: ../src/common/fmapbase.cpp:166
+msgid "Windows Chinese Traditional (CP 950) or Big-5"
+msgstr "Windows chiński tradycyjny (CP 950) lub Big-5"
+
+#: ../src/common/fmapbase.cpp:167
+msgid "Windows Central European (CP 1250)"
+msgstr "Windows środkowoeuropejski (CP 1250)"
+
+#: ../src/common/fmapbase.cpp:168
+msgid "Windows Cyrillic (CP 1251)"
+msgstr "Windows cyrylica (CP 1251)"
+
+#: ../src/common/fmapbase.cpp:169
+msgid "Windows Western European (CP 1252)"
+msgstr "Windows zachodnioeuropejski (CP 1252)"
+
+#: ../src/common/fmapbase.cpp:170
+msgid "Windows Greek (CP 1253)"
+msgstr "Windows grecki (CP 1253)"
+
+#: ../src/common/fmapbase.cpp:171
+msgid "Windows Turkish (CP 1254)"
+msgstr "Windows turecki (CP 1254)"
+
+#: ../src/common/fmapbase.cpp:172
+msgid "Windows Hebrew (CP 1255)"
+msgstr "Windows hebrajski (CP 1255)"
+
+#: ../src/common/fmapbase.cpp:173
+msgid "Windows Arabic (CP 1256)"
+msgstr "Windows arabski (CP 1256)"
+
+#: ../src/common/fmapbase.cpp:174
+msgid "Windows Baltic (CP 1257)"
+msgstr "Windows bałtycki (CP 1257)"
+
+#: ../src/common/fmapbase.cpp:175
+msgid "Windows Vietnamese (CP 1258)"
+msgstr "Windows Wietnamski (CP 1258)"
+
+#: ../src/common/fmapbase.cpp:176
+msgid "Windows Johab (CP 1361)"
+msgstr "Windows Johab (CP 1361)"
+
+#: ../src/common/fmapbase.cpp:177
+msgid "Windows/DOS OEM (CP 437)"
+msgstr "Windows/DOS OEM (CP 437)"
+
+#: ../src/common/fmapbase.cpp:178
+msgid "Unicode 7 bit (UTF-7)"
+msgstr "Unicode 7 bit (UTF-7)"
+
+#: ../src/common/fmapbase.cpp:179
+msgid "Unicode 8 bit (UTF-8)"
+msgstr "Unicode 8 bit (UTF-8)"
+
+#: ../src/common/fmapbase.cpp:181 ../src/common/fmapbase.cpp:187
+msgid "Unicode 16 bit (UTF-16)"
+msgstr "Unicode 16 bit (UTF-16)"
+
+#: ../src/common/fmapbase.cpp:182
+msgid "Unicode 16 bit Little Endian (UTF-16LE)"
+msgstr "Unicode 16 bit Little Endian (UTF-16LE)"
+
+#: ../src/common/fmapbase.cpp:183 ../src/common/fmapbase.cpp:189
+msgid "Unicode 32 bit (UTF-32)"
+msgstr "Unicode 32 bit (UTF-32)"
+
+#: ../src/common/fmapbase.cpp:184
+msgid "Unicode 32 bit Little Endian (UTF-32LE)"
+msgstr "Unicode 32 bit Little Endian (UTF-32LE)"
+
+#: ../src/common/fmapbase.cpp:186
+msgid "Unicode 16 bit Big Endian (UTF-16BE)"
+msgstr "Unicode 16 bit Big Endian (UTF-16BE)"
+
+#: ../src/common/fmapbase.cpp:188
+msgid "Unicode 32 bit Big Endian (UTF-32BE)"
+msgstr "Unicode 32 bit Big Endian (UTF-32BE)"
+
+#: ../src/common/fmapbase.cpp:191
+msgid "Extended Unix Codepage for Japanese (EUC-JP)"
+msgstr "Japońska rozszerzona strona kodowa UNIX (EUC-JP)"
+
+#: ../src/common/fmapbase.cpp:192
+msgid "US-ASCII"
+msgstr "US-ASCII"
+
+#: ../src/common/fmapbase.cpp:193
+msgid "ISO-2022-JP"
+msgstr "ISO-2022-JP"
+
+#: ../src/common/fmapbase.cpp:195
+msgid "MacRoman"
+msgstr "MacRoman"
+
+#: ../src/common/fmapbase.cpp:196
+msgid "MacJapanese"
+msgstr "MacJapoński"
+
+#: ../src/common/fmapbase.cpp:197
+msgid "MacChineseTrad"
+msgstr "MacChińskiTrad"
+
+#: ../src/common/fmapbase.cpp:198
+msgid "MacKorean"
+msgstr "MacKoreański"
+
+#: ../src/common/fmapbase.cpp:199
+msgid "MacArabic"
+msgstr "MacArabic"
+
+#: ../src/common/fmapbase.cpp:200
+msgid "MacHebrew"
+msgstr "MacHebrajski"
+
+#: ../src/common/fmapbase.cpp:201
+msgid "MacGreek"
+msgstr "MacGrecki"
+
+#: ../src/common/fmapbase.cpp:202
+msgid "MacCyrillic"
+msgstr "MacCyrylica"
+
+#: ../src/common/fmapbase.cpp:203
+msgid "MacDevanagari"
+msgstr "MacDevanagari"
+
+#: ../src/common/fmapbase.cpp:204
+msgid "MacGurmukhi"
+msgstr "MacGurmukhi"
+
+#: ../src/common/fmapbase.cpp:205
+msgid "MacGujarati"
+msgstr "MacGudżarati"
+
+#: ../src/common/fmapbase.cpp:206
+msgid "MacOriya"
+msgstr "MacOriya"
+
+#: ../src/common/fmapbase.cpp:207
+msgid "MacBengali"
+msgstr "MacBengalski"
+
+#: ../src/common/fmapbase.cpp:208
+msgid "MacTamil"
+msgstr "MacTamilski"
+
+#: ../src/common/fmapbase.cpp:209
+msgid "MacTelugu"
+msgstr "MacTelugu"
+
+#: ../src/common/fmapbase.cpp:210
+msgid "MacKannada"
+msgstr "MacKannada"
+
+#: ../src/common/fmapbase.cpp:211
+msgid "MacMalayalam"
+msgstr "MacMalayalam"
+
+#: ../src/common/fmapbase.cpp:212
+msgid "MacSinhalese"
+msgstr "MacSinhalese"
+
+#: ../src/common/fmapbase.cpp:213
+msgid "MacBurmese"
+msgstr "MacBirmański"
+
+#: ../src/common/fmapbase.cpp:214
+msgid "MacKhmer"
+msgstr "MacKhmer"
+
+#: ../src/common/fmapbase.cpp:215
+msgid "MacThai"
+msgstr "MacTajski"
+
+#: ../src/common/fmapbase.cpp:216
+msgid "MacLaotian"
+msgstr "MacLaotian"
+
+#: ../src/common/fmapbase.cpp:217
+msgid "MacGeorgian"
+msgstr "MacGruziński"
+
+#: ../src/common/fmapbase.cpp:218
+msgid "MacArmenian"
+msgstr "MacOrmiański"
+
+#: ../src/common/fmapbase.cpp:219
+msgid "MacChineseSimp"
+msgstr "MacChińskiUpr"
+
+#: ../src/common/fmapbase.cpp:220
+msgid "MacTibetan"
+msgstr "MacTybetański"
+
+#: ../src/common/fmapbase.cpp:221
+msgid "MacMongolian"
+msgstr "MacMongolski"
+
+#: ../src/common/fmapbase.cpp:222
+msgid "MacEthiopic"
+msgstr "MacEtiopski"
+
+#: ../src/common/fmapbase.cpp:223
+msgid "MacCentralEurRoman"
+msgstr "MacŚrodkowoEuroRzymski"
+
+#: ../src/common/fmapbase.cpp:224
+msgid "MacVietnamese"
+msgstr "MacWietnamski"
+
+#: ../src/common/fmapbase.cpp:225
+msgid "MacExtArabic"
+msgstr "MacExtArabic"
+
+#: ../src/common/fmapbase.cpp:226
+msgid "MacSymbol"
+msgstr "MacSymbol"
+
+#: ../src/common/fmapbase.cpp:227
+msgid "MacDingbats"
+msgstr "MacDingbats"
+
+#: ../src/common/fmapbase.cpp:228
+msgid "MacTurkish"
+msgstr "MacTurecki"
+
+#: ../src/common/fmapbase.cpp:229
+msgid "MacCroatian"
+msgstr "MacChorwacki"
+
+#: ../src/common/fmapbase.cpp:230
+msgid "MacIcelandic"
+msgstr "MacIslandzki"
+
+#: ../src/common/fmapbase.cpp:231
+msgid "MacRomanian"
+msgstr "MacRomanian"
+
+#: ../src/common/fmapbase.cpp:232
+msgid "MacCeltic"
+msgstr "MacCeltic"
+
+#: ../src/common/fmapbase.cpp:233
+msgid "MacGaelic"
+msgstr "MacCeltycki"
+
+#: ../src/common/fmapbase.cpp:234
+msgid "MacKeyboardGlyphs"
+msgstr "MacKeyboardGlyphs"
+
+#: ../src/common/fmapbase.cpp:791
+msgid "Default encoding"
+msgstr "Kodowanie domyślne"
+
+#: ../src/common/fmapbase.cpp:805
+#, c-format
+msgid "Unknown encoding (%d)"
+msgstr "Nieznane kodowanie (%d)"
+
+#: ../src/common/fmapbase.cpp:815 ../src/richtext/richtextstyles.cpp:776
+msgid "default"
+msgstr "domyślny"
+
+#: ../src/common/fmapbase.cpp:829
+#, c-format
+msgid "unknown-%d"
+msgstr "nieznany-%d"
+
+#: ../src/common/fontcmn.cpp:924 ../src/common/fontcmn.cpp:1130
+msgid "underlined"
+msgstr "podkreślony"
+
+#: ../src/common/fontcmn.cpp:929
+msgid " strikethrough"
+msgstr " przekreślenie"
+
+#: ../src/common/fontcmn.cpp:942
+msgid " thin"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:946
+#, fuzzy
+msgid " extra light"
+msgstr "lekki"
+
+#: ../src/common/fontcmn.cpp:950
+msgid " light"
+msgstr "lekki"
+
+#: ../src/common/fontcmn.cpp:954
+msgid " medium"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:958
+#, fuzzy
+msgid " semi bold"
+msgstr "pogrubiony"
+
+#: ../src/common/fontcmn.cpp:962
+msgid " bold"
+msgstr "pogrubiony"
+
+#: ../src/common/fontcmn.cpp:966
+#, fuzzy
+msgid " extra bold"
+msgstr "pogrubiony"
+
+#: ../src/common/fontcmn.cpp:970
+msgid " heavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:974
+msgid " extra heavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:990
+msgid " italic"
+msgstr "kursywa"
+
+#: ../src/common/fontcmn.cpp:1134
+msgid "strikethrough"
+msgstr "Przekreślenie"
+
+#: ../src/common/fontcmn.cpp:1143
+msgid "thin"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1156
+#, fuzzy
+msgid "extralight"
+msgstr "lekki"
+
+#: ../src/common/fontcmn.cpp:1161
+msgid "light"
+msgstr "lekki"
+
+#: ../src/common/fontcmn.cpp:1169 ../src/richtext/richtextstyles.cpp:775
+msgid "normal"
+msgstr "Normalny"
+
+#: ../src/common/fontcmn.cpp:1174
+msgid "medium"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1179 ../src/common/fontcmn.cpp:1199
+#, fuzzy
+msgid "semibold"
+msgstr "pogrubiony"
+
+#: ../src/common/fontcmn.cpp:1184
+msgid "bold"
+msgstr "pogrubiony"
+
+#: ../src/common/fontcmn.cpp:1194
+#, fuzzy
+msgid "extrabold"
+msgstr "pogrubiony"
+
+#: ../src/common/fontcmn.cpp:1204
+msgid "heavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1212
+msgid "extraheavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1217
+msgid "italic"
+msgstr "kursywa"
+
+#: ../src/common/fontmap.cpp:195
+msgid ": unknown charset"
+msgstr ": nieznany zestaw znaków"
+
+#: ../src/common/fontmap.cpp:199
+#, c-format
+msgid ""
+"The charset '%s' is unknown. You may select\n"
+"another charset to replace it with or choose\n"
+"[Cancel] if it cannot be replaced"
+msgstr ""
+"Nieznany zestaw znaków '%s'. Możesz wybrać\n"
+"inny zestaw aby go zastąpić lub wybierz\n"
+"[Anuluj] jeśli nie można go zastąpić."
+
+#: ../src/common/fontmap.cpp:241
+#, c-format
+msgid "Failed to remember the encoding for the charset '%s'."
+msgstr "Nie udało się zapamiętać kodowania dla zestawu znaków '%s'."
+
+#: ../src/common/fontmap.cpp:321
+msgid "can't load any font, aborting"
+msgstr "nie można załadować żadnej czcionki, program kończy pracę"
+
+#: ../src/common/fontmap.cpp:409
+msgid ": unknown encoding"
+msgstr ": nieznane kodowanie"
+
+#: ../src/common/fontmap.cpp:417
+#, c-format
+msgid ""
+"No font for displaying text in encoding '%s' found,\n"
+"but an alternative encoding '%s' is available.\n"
+"Do you want to use this encoding (otherwise you will have to choose another "
+"one)?"
+msgstr ""
+"Brak czcionki do wyświelenia tekstu w kodowaniu '%s',\n"
+"jednak dostępne jest alternatywne kodowanie '%s'.\n"
+"Chesz użyć tego kodowania (możesz także wybrać inne)?"
+
+#: ../src/common/fontmap.cpp:422
+#, c-format
+msgid ""
+"No font for displaying text in encoding '%s' found.\n"
+"Would you like to select a font to be used for this encoding\n"
+"(otherwise the text in this encoding will not be shown correctly)?"
+msgstr ""
+"Brak czcionki do wyświelenia tekstu w kodowaniu '%s'.\n"
+"Chcesz wskazać czcionkę do użycia\n"
+"(inaczej tekst może nie być wyświetlony poprawnie)?"
+
+#: ../src/common/fs_mem.cpp:169
+#, c-format
+msgid "Memory VFS already contains file '%s'!"
+msgstr "Pamięć VFS już zawiera plik '%s'!"
+
+#: ../src/common/fs_mem.cpp:232
+#, c-format
+msgid "Trying to remove file '%s' from memory VFS, but it is not loaded!"
+msgstr "Próbą usunięcia pliku '%s' z pamięci VFS, który nie został wczytany!"
+
+#: ../src/common/fs_mem.cpp:262
+#, c-format
+msgid "Failed to store image '%s' to memory VFS!"
+msgstr "Nie udało się odłożyć obrazu '%s' do pamięci VFS!"
+
+#: ../src/common/ftp.cpp:197
+msgid "Timeout while waiting for FTP server to connect, try passive mode."
+msgstr ""
+"Przekroczono czas oczekiwania dla serwera FTP, spróbuj trybu pasywnego."
+
+#: ../src/common/ftp.cpp:399
+#, c-format
+msgid "Failed to set FTP transfer mode to %s."
+msgstr "FTP: Nie udało się ustawić trybu transmisji na '%s'."
+
+#: ../src/common/ftp.cpp:400 ../src/richtext/richtextsymboldlg.cpp:432
+msgid "ASCII"
+msgstr "ASCII"
+
+#: ../src/common/ftp.cpp:400
+msgid "binary"
+msgstr "binarny"
+
+#: ../src/common/ftp.cpp:608
+msgid "The FTP server doesn't support the PORT command."
+msgstr "Serwer FTP nie obsługuje komendy PORT."
+
+#: ../src/common/ftp.cpp:622
+msgid "The FTP server doesn't support passive mode."
+msgstr "Serwer FTP nie obsługuje trybu pasywnego."
+
+#: ../src/common/gifdecod.cpp:822
+#, c-format
+msgid "Incorrect GIF frame size (%u, %d) for the frame #%u"
+msgstr "Nieprawidłowy rozmiar ramki GIF (%u, %d) dla ramki #%u"
+
+#: ../src/common/glcmn.cpp:108
+msgid "Failed to allocate colour for OpenGL"
+msgstr "Nie udało się przydzielić koloru dla OpenGL"
+
+#: ../src/common/headerctrlcmn.cpp:57
+msgid "Please select the columns to show and define their order:"
+msgstr "Proszę wybrać kolumny do pokazania i określić ich kolejność:"
+
+#: ../src/common/headerctrlcmn.cpp:58
+msgid "Customize Columns"
+msgstr "Dostosuj kolumny"
+
+#: ../src/common/headerctrlcmn.cpp:304
+msgid "&Customize..."
+msgstr "&Dostosuj..."
+
+#: ../src/common/hyperlnkcmn.cpp:132
+#, fuzzy, c-format
+msgid "Failed to open URL \"%s\" in the default browser"
+msgstr "Nie udało się otworzyć URL \"%s\" w domyślnej przeglądarce."
+
+#: ../src/common/iconbndl.cpp:195
+#, c-format
+msgid "Failed to load image %%d from file '%s'."
+msgstr "Nie udało się wczytanie obrazu %%d z pliku '%s'."
+
+#: ../src/common/iconbndl.cpp:203
+#, c-format
+msgid "Failed to load image %d from stream."
+msgstr "Nie udało się wczytanie obrazu %d ze strumienia."
+
+#: ../src/common/iconbndl.cpp:221
+#, fuzzy, c-format
+msgid "Failed to load icons from resource '%s'."
+msgstr "Nie udało się wczytanie ikony \"%s\" z zasobów."
+
+#: ../src/common/imagbmp.cpp:97
+msgid "BMP: Couldn't save invalid image."
+msgstr "BMP: Nie można zapisać nieprawidłowego obrazu.."
+
+#: ../src/common/imagbmp.cpp:137
+msgid "BMP: wxImage doesn't have own wxPalette."
+msgstr "BMP: wxImage nie ma własnej wxPalette."
+
+#: ../src/common/imagbmp.cpp:243
+msgid "BMP: Couldn't write the file (Bitmap) header."
+msgstr "BMP: Nie można zapisać nagłówka pliku (Bitmap)."
+
+#: ../src/common/imagbmp.cpp:266
+msgid "BMP: Couldn't write the file (BitmapInfo) header."
+msgstr "BMP: Nie można zapisać nagłówka pliku (BitmapInfo)."
+
+#: ../src/common/imagbmp.cpp:353
+msgid "BMP: Couldn't write RGB color map."
+msgstr "BMP: Nie można zapisać mapy kolorów RGB."
+
+#: ../src/common/imagbmp.cpp:487
+msgid "BMP: Couldn't write data."
+msgstr "BMP: Nie można zapisać danych."
+
+#: ../src/common/imagbmp.cpp:561 ../src/common/imagbmp.cpp:642
+msgid "BMP: Couldn't allocate memory."
+msgstr "BMP: Nie można przydzielić pamięci."
+
+# dla pliku? moim zdaniem zbędne
+#: ../src/common/imagbmp.cpp:1041
+msgid "DIB Header: Image width > 32767 pixels for file."
+msgstr "Nagłówek DIB: Szerokość obrazu > 32767 pikseli."
+
+#: ../src/common/imagbmp.cpp:1049
+msgid "DIB Header: Image height > 32767 pixels for file."
+msgstr "DIB nagłówek: Wysokość obrazu > 32767 pikseli."
+
+#: ../src/common/imagbmp.cpp:1081
+msgid "DIB Header: Unknown bitdepth in file."
+msgstr "Nagłówek DIB: Plik z nieznaną rozdzielczością."
+
+#: ../src/common/imagbmp.cpp:1156
+msgid "DIB Header: Unknown encoding in file."
+msgstr "Nagłówek DIB: Plik z nieznanym kodowaniem."
+
+#: ../src/common/imagbmp.cpp:1165
+msgid "DIB Header: Encoding doesn't match bitdepth."
+msgstr "Nagłówek DIB: kodowanie nie odpowiada rozdzielczości."
+
+#: ../src/common/imagbmp.cpp:1180
+#, c-format
+msgid "BMP Header: Invalid number of colors (%d)."
+msgstr ""
+
+#: ../src/common/imagbmp.cpp:1273
+msgid "Error in reading image DIB."
+msgstr "Błąd odczytu obrazu DIB."
+
+#: ../src/common/imagbmp.cpp:1294
+msgid "ICO: Error in reading mask DIB."
+msgstr "ICO: Błąd odczytu maski DIB."
+
+#: ../src/common/imagbmp.cpp:1353
+msgid "ICO: Image too tall for an icon."
+msgstr "ICO: Obraz jest zbyt wysoki jak na ikonę."
+
+#: ../src/common/imagbmp.cpp:1361
+msgid "ICO: Image too wide for an icon."
+msgstr "ICO: Obraz jest zbyt szeroki jak na ikonę."
+
+#: ../src/common/imagbmp.cpp:1388 ../src/common/imagbmp.cpp:1488
+#: ../src/common/imagbmp.cpp:1503 ../src/common/imagbmp.cpp:1514
+#: ../src/common/imagbmp.cpp:1528 ../src/common/imagbmp.cpp:1576
+#: ../src/common/imagbmp.cpp:1591 ../src/common/imagbmp.cpp:1605
+#: ../src/common/imagbmp.cpp:1616
+msgid "ICO: Error writing the image file!"
+msgstr "ICO: Błąd przy zapisie do pliku."
+
+# ...indeks w grafice (?)
+# ideks - katalog, wskanik?
+#: ../src/common/imagbmp.cpp:1701
+msgid "ICO: Invalid icon index."
+msgstr "ICO: Brak ikony o podanym indeksie.."
+
+#: ../src/common/image.cpp:2410
+msgid "Image and mask have different sizes."
+msgstr "Obraz i maska mają różne rozmiary."
+
+#: ../src/common/image.cpp:2418 ../src/common/image.cpp:2459
+msgid "No unused colour in image being masked."
+msgstr "Brak nieużywanych kolorów w maskowanym obrazie."
+
+#: ../src/common/image.cpp:2641
+#, c-format
+msgid "Failed to load bitmap \"%s\" from resources."
+msgstr "Nie udało się wczytanie obrazu \"%s\" z zasobów."
+
+#: ../src/common/image.cpp:2650
+#, c-format
+msgid "Failed to load icon \"%s\" from resources."
+msgstr "Nie udało się wczytanie ikony \"%s\" z zasobów."
+
+#: ../src/common/image.cpp:2728 ../src/common/image.cpp:2747
+#, c-format
+msgid "Failed to load image from file \"%s\"."
+msgstr "Nie udało się wczytanie obrazu z pliku \"%s\"."
+
+#: ../src/common/image.cpp:2761
+#, c-format
+msgid "Can't save image to file '%s': unknown extension."
+msgstr "Nie można zapisać obrazu do pliku '%s': nieznane rozszerzenie."
+
+#: ../src/common/image.cpp:2869
+msgid "No handler found for image type."
+msgstr "Brak procedury obsługi grafiki."
+
+#: ../src/common/image.cpp:2877 ../src/common/image.cpp:3000
+#: ../src/common/image.cpp:3066
+#, c-format
+msgid "No image handler for type %d defined."
+msgstr "Brak procedury obsługi obrazów typu %d."
+
+#: ../src/common/image.cpp:2887
+#, c-format
+msgid "Image file is not of type %d."
+msgstr "Nie jest to obraz typu %d."
+
+#: ../src/common/image.cpp:2970
+msgid "Can't automatically determine the image format for non-seekable input."
+msgstr ""
+"Nie można automatycznie określić formatu obrazu dla nieprzeszukiwalnego "
+"wejścia."
+
+#: ../src/common/image.cpp:2988
+msgid "Unknown image data format."
+msgstr "Nieznany format graficzny"
+
+#: ../src/common/image.cpp:3009
+#, c-format
+msgid "This is not a %s."
+msgstr "To nie jest %s."
+
+#: ../src/common/image.cpp:3032 ../src/common/image.cpp:3080
+#, c-format
+msgid "No image handler for type %s defined."
+msgstr "Brak procedury obsługi obrazów typu %s."
+
+#: ../src/common/image.cpp:3041
+#, c-format
+msgid "Image is not of type %s."
+msgstr "Nie jest to obraz typu %s."
+
+#: ../src/common/image.cpp:3509
+#, c-format
+msgid "Failed to check format of image file \"%s\"."
+msgstr "Nie sprawdzić format obrazu z pliku \"%s\"."
+
+#: ../src/common/imaggif.cpp:124
+msgid "GIF: error in GIF image format."
+msgstr "GIF: błąd w formacie obrazu GIF."
+
+#: ../src/common/imaggif.cpp:129
+msgid "GIF: not enough memory."
+msgstr "GIF: za mało pamięci."
+
+#: ../src/common/imaggif.cpp:134
+msgid "GIF: data stream seems to be truncated."
+msgstr "GIF: strumień daych wygląda na obcięty."
+
+#: ../src/common/imaggif.cpp:240
+msgid "Couldn't initialize GIF hash table."
+msgstr "Błąd podczas inicjalizacji tablicy haszującej GIF."
+
+#: ../src/common/imagiff.cpp:739
+msgid "IFF: error in IFF image format."
+msgstr "IFF: błąd w formacie obrazu IFF."
+
+#: ../src/common/imagiff.cpp:742
+msgid "IFF: not enough memory."
+msgstr "IFF: za mało pamięci."
+
+#: ../src/common/imagiff.cpp:745
+msgid "IFF: unknown error!!!"
+msgstr "IFF: nieznany błąd !!!"
+
+#: ../src/common/imagiff.cpp:755
+msgid "IFF: data stream seems to be truncated."
+msgstr "IFF: strumień daych wygląda na obcięty."
+
+#: ../src/common/imagjpeg.cpp:258
+msgid "JPEG: Couldn't load - file is probably corrupted."
+msgstr "JPEG: Nie można wczytać - prawdopodobnie plik jest uszkodzony."
+
+#: ../src/common/imagjpeg.cpp:437
+msgid "JPEG: Couldn't save image."
+msgstr "JPEG: Nie można zapisać obrazu."
+
+#: ../src/common/imagpcx.cpp:439
+msgid "PCX: this is not a PCX file."
+msgstr "PCX: To nie jest plik w formacie PCX."
+
+#: ../src/common/imagpcx.cpp:453
+msgid "PCX: image format unsupported"
+msgstr "PCX: nieobsługiwany format obrazu."
+
+#: ../src/common/imagpcx.cpp:454 ../src/common/imagpcx.cpp:477
+msgid "PCX: couldn't allocate memory"
+msgstr "PCX: Nie można przydzielić pamięci."
+
+#: ../src/common/imagpcx.cpp:455
+msgid "PCX: version number too low"
+msgstr "PCX: zbyt niski numer wersji."
+
+#: ../src/common/imagpcx.cpp:456 ../src/common/imagpcx.cpp:478
+msgid "PCX: unknown error !!!"
+msgstr "PCX: nieznany błąd !!!"
+
+#: ../src/common/imagpcx.cpp:476
+msgid "PCX: invalid image"
+msgstr "PCX: nieprawidłowy obraz"
+
+#: ../src/common/imagpng.cpp:385
+#, c-format
+msgid "Unknown PNG resolution unit %d"
+msgstr "Nieznana jednostka rozdzielczości PNG: %d"
+
+#: ../src/common/imagpng.cpp:439
+msgid "Couldn't load a PNG image - file is corrupted or not enough memory."
+msgstr ""
+"Nie można wczytać obrazu PNG - plik jest uszkodzony lub zabrakło pamięci."
+
+#: ../src/common/imagpng.cpp:513 ../src/common/imagpng.cpp:524
+#: ../src/common/imagpng.cpp:534
+msgid "Couldn't save PNG image."
+msgstr "Nie można zapisać obrazu PNG."
+
+#: ../src/common/imagpnm.cpp:71
+msgid "PNM: File format is not recognized."
+msgstr "PNM: Nieznany format pliku."
+
+#: ../src/common/imagpnm.cpp:89
+msgid "PNM: Couldn't allocate memory."
+msgstr "PNM: Nie można przydzielić pamięci."
+
+#: ../src/common/imagpnm.cpp:111 ../src/common/imagpnm.cpp:134
+#: ../src/common/imagpnm.cpp:156
+msgid "PNM: File seems truncated."
+msgstr "PNM: Plik wygląda na obcięty."
+
+#: ../src/common/imagtiff.cpp:69
+#, c-format
+msgid " (in module \"%s\")"
+msgstr " (w module \"%s\")"
+
+#: ../src/common/imagtiff.cpp:304
+msgid "TIFF: Error loading image."
+msgstr "TIFF: Błąd przy wczytywaniu obrazu."
+
+# ...indeks w grafice (?)
+# ideks - katalog, wska?nik?
+#: ../src/common/imagtiff.cpp:314
+msgid "Invalid TIFF image index."
+msgstr "TIFF: Brak obrazu o podanym indeksie."
+
+#: ../src/common/imagtiff.cpp:358
+msgid "TIFF: Image size is abnormally big."
+msgstr "TIFF: Rozmiar obrazu jest wyjątkowo duży."
+
+#: ../src/common/imagtiff.cpp:372 ../src/common/imagtiff.cpp:385
+#: ../src/common/imagtiff.cpp:769
+msgid "TIFF: Couldn't allocate memory."
+msgstr "TIFF: Nie można przydzielić pamięci."
+
+#: ../src/common/imagtiff.cpp:471
+msgid "TIFF: Error reading image."
+msgstr "TIFF: Błąd odczytu."
+
+#: ../src/common/imagtiff.cpp:532
+#, c-format
+msgid "Unknown TIFF resolution unit %d ignored"
+msgstr "Zignorowana nieznana jednostka %d rozdzielczości TIFF"
+
+#: ../src/common/imagtiff.cpp:611
+msgid "TIFF: Error saving image."
+msgstr "TIFF: Wystąpił błąd przy zapisie."
+
+#: ../src/common/imagtiff.cpp:868
+msgid "TIFF: Error writing image."
+msgstr "TIFF: Błąd zapisu."
+
+#: ../src/common/imagtiff.cpp:881
+#, fuzzy
+msgid "TIFF: Error flushing data."
+msgstr "TIFF: Wystąpił błąd przy zapisie."
+
+#: ../src/common/imagwebp.cpp:56
+msgid "WebP: Invalid data (failed to get features)."
+msgstr ""
+
+#: ../src/common/imagwebp.cpp:65
+msgid "WebP: Allocating image memory failed."
+msgstr ""
+
+#: ../src/common/imagwebp.cpp:82
+msgid "WebP: Decoding RGBA image data failed."
+msgstr ""
+
+#: ../src/common/imagwebp.cpp:98
+msgid "WebP: Decoding RGB image data failed."
+msgstr ""
+
+#: ../src/common/imagwebp.cpp:113 ../src/common/imagwebp.cpp:201
+msgid "WebP: Allocating stream buffer failed."
+msgstr ""
+
+#: ../src/common/imagwebp.cpp:131
+#, fuzzy
+msgid "WebP: Failed to parse container data."
+msgstr "Nie udało się skorzystać ze schowka."
+
+#: ../src/common/imagwebp.cpp:222
+#, fuzzy
+msgid "WebP: Error decoding animation."
+msgstr "Błąd odczytu opcji konfiguracji."
+
+#: ../src/common/imagwebp.cpp:240
+msgid "WebP: Error getting next animation frame."
+msgstr ""
+
+#: ../src/common/init.cpp:172
+#, c-format
+msgid ""
+"Command line argument %d couldn't be converted to Unicode and will be "
+"ignored."
+msgstr ""
+"Argument wiersza polecenia %d nie może zostać zamieniony na Unicode i "
+"zostanie zignorowany."
+
+#: ../src/common/init.cpp:344
+msgid "Initialization failed in post init, aborting."
+msgstr "Inicjalizacja nie powiodła się powodując wyjście."
+
+#: ../src/common/intl.cpp:378
+#, c-format
+msgid "Cannot set locale to language \"%s\"."
+msgstr "Nie można ustawić lokalizacji na język \"%s\"."
+
+#: ../src/common/log.cpp:232
+msgid "Error: "
+msgstr "Błąd: "
+
+#: ../src/common/log.cpp:236
+msgid "Warning: "
+msgstr "Ostrzeżenie: "
+
+#: ../src/common/log.cpp:284
+msgid "The previous message repeated once."
+msgstr "Poprzednia wiadomość była raz powtórzona."
+
+#: ../src/common/log.cpp:291
+#, fuzzy, c-format
+msgid "The previous message repeated %u time."
+msgid_plural "The previous message repeated %u times."
+msgstr[0] "Poprzedni komunikat powtórzył się %lu raz."
+msgstr[1] "Poprzedni komunikat powtórzył się %lu razy."
+msgstr[2] "Poprzedni komunikat powtórzył się %lu razy."
+
+#: ../src/common/log.cpp:319
+#, fuzzy, c-format
+msgid "Last repeated message (\"%s\", %u time) wasn't output"
+msgid_plural "Last repeated message (\"%s\", %u times) wasn't output"
+msgstr[0] "Last repeated message (\"%s\", %lu time) wasn't output"
+msgstr[1] "Last repeated message (\"%s\", %lu times) wasn't output"
+msgstr[2] "Last repeated message (\"%s\", %lu times) wasn't output"
+
+#: ../src/common/log.cpp:435
+#, c-format
+msgid " (error %ld: %s)"
+msgstr " (błąd %ld: %s)"
+
+#: ../src/common/lzmastream.cpp:121
+#, fuzzy
+msgid "Failed to allocate memory for LZMA decompression."
+msgstr "Nie udało się przydzielić koloru dla OpenGL"
+
+#: ../src/common/lzmastream.cpp:125
+#, c-format
+msgid "Failed to initialize LZMA decompression: unexpected error %u."
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:179
+msgid "input is not in XZ format"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:183
+msgid "input compressed using unknown XZ option"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:188
+msgid "input is corrupted"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:192
+#, fuzzy
+msgid "unknown decompression error"
+msgstr "błąd dekompresji"
+
+#: ../src/common/lzmastream.cpp:196
+#, fuzzy, c-format
+msgid "LZMA decompression error: %s"
+msgstr "błąd dekompresji"
+
+#: ../src/common/lzmastream.cpp:231
+#, fuzzy
+msgid "Failed to allocate memory for LZMA compression."
+msgstr "Nie udało się przydzielić koloru dla OpenGL"
+
+#: ../src/common/lzmastream.cpp:235
+#, c-format
+msgid "Failed to initialize LZMA compression: unexpected error %u."
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:267 ../src/common/lzmastream.cpp:342
+#: ../src/html/chm.cpp:336
+msgid "out of memory"
+msgstr "brak wolnej pamięci"
+
+#: ../src/common/lzmastream.cpp:276 ../src/common/lzmastream.cpp:346
+#, fuzzy
+msgid "unknown compression error"
+msgstr "błąd kompresji"
+
+#: ../src/common/lzmastream.cpp:280
+#, fuzzy, c-format
+msgid "LZMA compression error: %s"
+msgstr "błąd kompresji"
+
+#: ../src/common/lzmastream.cpp:350
+#, c-format
+msgid "LZMA compression error when flushing output: %s"
+msgstr ""
+
+# inaczej
+#: ../src/common/mimecmn.cpp:167
+#, c-format
+msgid "Unmatched '{' in an entry for mime type %s."
+msgstr "Nieodpowiedni '{' w pozycji dla typu mime %s."
+
+#: ../src/common/module.cpp:76
+#, c-format
+msgid "Circular dependency involving module \"%s\" detected."
+msgstr "Wykryto kołową zależność w związku z modułem \"%s\""
+
+#: ../src/common/module.cpp:128
+#, c-format
+msgid "Dependency \"%s\" of module \"%s\" doesn't exist."
+msgstr "Zależność \"%s\" z modułu \"%s\" nie istnieje."
+
+#: ../src/common/module.cpp:137
+#, c-format
+msgid "Module \"%s\" initialization failed"
+msgstr "Inicjalizacja modułu \"%s\" nie powiodła się"
+
+#: ../src/common/msgout.cpp:96
+msgid "Message"
+msgstr "Komunikat"
+
+#: ../src/common/paper.cpp:70
+msgid "Letter, 8 1/2 x 11 in"
+msgstr "List, 8 1/2 x 11 cali"
+
+#: ../src/common/paper.cpp:71
+msgid "Legal, 8 1/2 x 14 in"
+msgstr "Legal, 8 1/2 x 14 cali"
+
+#: ../src/common/paper.cpp:72
+msgid "A4 sheet, 210 x 297 mm"
+msgstr "Arkusz A4, 210 x 297 mm"
+
+#: ../src/common/paper.cpp:73
+msgid "C sheet, 17 x 22 in"
+msgstr "Arkusz C, 17 x 22 cali"
+
+#: ../src/common/paper.cpp:74
+msgid "D sheet, 22 x 34 in"
+msgstr "Arkusz D, 22 x 34 cali"
+
+#: ../src/common/paper.cpp:75
+msgid "E sheet, 34 x 44 in"
+msgstr "Arkusz E, 34 x 44 cale"
+
+#: ../src/common/paper.cpp:76
+msgid "Letter Small, 8 1/2 x 11 in"
+msgstr "Mały list, 8 1/2 x 11 cali"
+
+#: ../src/common/paper.cpp:77
+msgid "Tabloid, 11 x 17 in"
+msgstr "Tabloid, 11 x 17 cali"
+
+#: ../src/common/paper.cpp:78
+msgid "Ledger, 17 x 11 in"
+msgstr "Ledger, 17 x 11 cali"
+
+#: ../src/common/paper.cpp:79
+msgid "Statement, 5 1/2 x 8 1/2 in"
+msgstr "Statement, 5 1/2 x 8 1/2 cala"
+
+#: ../src/common/paper.cpp:80
+msgid "Executive, 7 1/4 x 10 1/2 in"
+msgstr "Executive, 7 1/4 x 10 1/2 cali"
+
+#: ../src/common/paper.cpp:81
+msgid "A3 sheet, 297 x 420 mm"
+msgstr "Arkusz A3, 297 x 420 mm"
+
+#: ../src/common/paper.cpp:82
+msgid "A4 small sheet, 210 x 297 mm"
+msgstr "Mały arkusz A4, 210 x 297 mm"
+
+#: ../src/common/paper.cpp:83
+msgid "A5 sheet, 148 x 210 mm"
+msgstr "Arkusz A5, 148 x 210 mm"
+
+#: ../src/common/paper.cpp:84
+msgid "B4 sheet, 250 x 354 mm"
+msgstr "Arkusz B4, 250 x 354 mm"
+
+#: ../src/common/paper.cpp:85
+msgid "B5 sheet, 182 x 257 millimeter"
+msgstr "Arkusz B5, 182 x 257 mm"
+
+#: ../src/common/paper.cpp:86
+msgid "Folio, 8 1/2 x 13 in"
+msgstr "Folio, 8 1/2 x 13 cali"
+
+#: ../src/common/paper.cpp:87
+msgid "Quarto, 215 x 275 mm"
+msgstr "Quarto, 215 x 275 mm"
+
+#: ../src/common/paper.cpp:88
+msgid "10 x 14 in"
+msgstr "10 x 14 cali"
+
+#: ../src/common/paper.cpp:89
+msgid "11 x 17 in"
+msgstr "11 x 17 cali"
+
+#: ../src/common/paper.cpp:90
+msgid "Note, 8 1/2 x 11 in"
+msgstr "Note, 8 1/2 x 11 cali"
+
+#: ../src/common/paper.cpp:91
+msgid "#9 Envelope, 3 7/8 x 8 7/8 in"
+msgstr "Koperta #9, 3 7/8 x 8 7/8 cali"
+
+#: ../src/common/paper.cpp:92
+msgid "#10 Envelope, 4 1/8 x 9 1/2 in"
+msgstr "Koperta #10, 4 1/8 x 9 1/2 cali"
+
+#: ../src/common/paper.cpp:93
+msgid "#11 Envelope, 4 1/2 x 10 3/8 in"
+msgstr "Koperta #11, 4 1/2 x 10 3/8 cali"
+
+#: ../src/common/paper.cpp:94
+msgid "#12 Envelope, 4 3/4 x 11 in"
+msgstr "Koperta #12, 4 3/4 x 11 cali"
+
+#: ../src/common/paper.cpp:95
+msgid "#14 Envelope, 5 x 11 1/2 in"
+msgstr "Koperta #14, 5 x 11 1/2 cali"
+
+#: ../src/common/paper.cpp:96
+msgid "DL Envelope, 110 x 220 mm"
+msgstr "Koperta DL, 110 x 220 mm"
+
+#: ../src/common/paper.cpp:97
+msgid "C5 Envelope, 162 x 229 mm"
+msgstr "Koperta C5, 162 x 229 mm"
+
+#: ../src/common/paper.cpp:98
+msgid "C3 Envelope, 324 x 458 mm"
+msgstr "Koperta C3, 324 x 458 mm"
+
+#: ../src/common/paper.cpp:99
+msgid "C4 Envelope, 229 x 324 mm"
+msgstr "Koperta C4, 229 x 324 mm"
+
+#: ../src/common/paper.cpp:100
+msgid "C6 Envelope, 114 x 162 mm"
+msgstr "Koperta C6, 114 x 162 mm"
+
+#: ../src/common/paper.cpp:101
+msgid "C65 Envelope, 114 x 229 mm"
+msgstr "Koperta C65, 114 x 229 mm"
+
+#: ../src/common/paper.cpp:102
+msgid "B4 Envelope, 250 x 353 mm"
+msgstr "Koperta B4, 250 x 353 mm"
+
+#: ../src/common/paper.cpp:103
+msgid "B5 Envelope, 176 x 250 mm"
+msgstr "Koperta B5, 176 x 250 mm"
+
+#: ../src/common/paper.cpp:104
+msgid "B6 Envelope, 176 x 125 mm"
+msgstr "Koperta B6, 176 x 125 mm"
+
+#: ../src/common/paper.cpp:105
+msgid "Italy Envelope, 110 x 230 mm"
+msgstr "Koperta włoska, 110 x 230 mm"
+
+#: ../src/common/paper.cpp:106
+msgid "Monarch Envelope, 3 7/8 x 7 1/2 in"
+msgstr "Koperta Monarch, 3 7/8 x 7 1/2 cala"
+
+#: ../src/common/paper.cpp:107
+msgid "6 3/4 Envelope, 3 5/8 x 6 1/2 in"
+msgstr "Koperta 6 3/4, 3 5/8 x 6 1/2 cali"
+
+#: ../src/common/paper.cpp:108
+msgid "US Std Fanfold, 14 7/8 x 11 in"
+msgstr "Składanka US Std, 14 7/8 x 11 cali"
+
+#: ../src/common/paper.cpp:109
+msgid "German Std Fanfold, 8 1/2 x 12 in"
+msgstr "Składanka German Std, 8 1/2 x 12 cali"
+
+#: ../src/common/paper.cpp:110
+msgid "German Legal Fanfold, 8 1/2 x 13 in"
+msgstr "Składanka German Legal, 8 1/2 x 13 cali"
+
+#: ../src/common/paper.cpp:112
+msgid "B4 (ISO) 250 x 353 mm"
+msgstr "B4 (ISO) 250 x 353 mm"
+
+#: ../src/common/paper.cpp:113
+msgid "Japanese Postcard 100 x 148 mm"
+msgstr "Japońska Pocztówka 100 x 148 mm"
+
+#: ../src/common/paper.cpp:114
+msgid "9 x 11 in"
+msgstr "9 x 11 cali"
+
+#: ../src/common/paper.cpp:115
+msgid "10 x 11 in"
+msgstr "10 x 11 cali"
+
+#: ../src/common/paper.cpp:116
+msgid "15 x 11 in"
+msgstr "15 x 11 cali"
+
+#: ../src/common/paper.cpp:117
+msgid "Envelope Invite 220 x 220 mm"
+msgstr "Koperta Invite 220 x 220 mm"
+
+#: ../src/common/paper.cpp:118
+msgid "Letter Extra 9 1/2 x 12 in"
+msgstr "List Extra 9 1/2 x 12 cali"
+
+#: ../src/common/paper.cpp:119
+msgid "Legal Extra 9 1/2 x 15 in"
+msgstr "Legal Extra 9 1/2 x 15 cali"
+
+#: ../src/common/paper.cpp:120
+msgid "Tabloid Extra 11.69 x 18 in"
+msgstr "Tabloid Extra 11.69 x 18 cali"
+
+#: ../src/common/paper.cpp:121
+msgid "A4 Extra 9.27 x 12.69 in"
+msgstr "A4 Extra 9.27 x 12.69 cali"
+
+#: ../src/common/paper.cpp:122
+msgid "Letter Transverse 8 1/2 x 11 in"
+msgstr "List Poprzecznie 8 1/2 x 11 cali"
+
+#: ../src/common/paper.cpp:123
+msgid "A4 Transverse 210 x 297 mm"
+msgstr "A4 Poprzecznie 210 x 297 mm"
+
+#: ../src/common/paper.cpp:124
+msgid "Letter Extra Transverse 9.275 x 12 in"
+msgstr "List Extra Poprzecznie 9.275 x 12 cali"
+
+#: ../src/common/paper.cpp:125
+msgid "SuperA/SuperA/A4 227 x 356 mm"
+msgstr "SuperA/SuperA/A4 227 x 356 mm"
+
+#: ../src/common/paper.cpp:126
+msgid "SuperB/SuperB/A3 305 x 487 mm"
+msgstr "SuperB/SuperB/A3 305 x 487 mm"
+
+#: ../src/common/paper.cpp:127
+msgid "Letter Plus 8 1/2 x 12.69 in"
+msgstr "List Plus 8 1/2 x 12.69 cala"
+
+#: ../src/common/paper.cpp:128
+msgid "A4 Plus 210 x 330 mm"
+msgstr "A4 Plus 210 x 330 mm"
+
+#: ../src/common/paper.cpp:129
+msgid "A5 Transverse 148 x 210 mm"
+msgstr "A5 Poprzecznie 148 x 210 mm"
+
+#: ../src/common/paper.cpp:130
+msgid "B5 (JIS) Transverse 182 x 257 mm"
+msgstr "B5 (JIS) Poprzecznie 182 x 257 mm"
+
+#: ../src/common/paper.cpp:131
+msgid "A3 Extra 322 x 445 mm"
+msgstr "A3 Extra 322 x 445 mm"
+
+#: ../src/common/paper.cpp:132
+msgid "A5 Extra 174 x 235 mm"
+msgstr "A5 Extra 174 x 235 mm"
+
+#: ../src/common/paper.cpp:133
+msgid "B5 (ISO) Extra 201 x 276 mm"
+msgstr "B5 (ISO) Extra 201 x 276 mm"
+
+#: ../src/common/paper.cpp:134
+msgid "A2 420 x 594 mm"
+msgstr "A2 420 x 594 mm"
+
+#: ../src/common/paper.cpp:135
+msgid "A3 Transverse 297 x 420 mm"
+msgstr "A3 Poprzecznie 297 x 420 mm"
+
+#: ../src/common/paper.cpp:136
+msgid "A3 Extra Transverse 322 x 445 mm"
+msgstr "A3 Extra Poprzecznie 322 x 445 mm"
+
+#: ../src/common/paper.cpp:138
+msgid "Japanese Double Postcard 200 x 148 mm"
+msgstr "Japońska Podwójna Pocztówka 200 x 148 mm"
+
+#: ../src/common/paper.cpp:139
+msgid "A6 105 x 148 mm"
+msgstr "A6 105 x 148 mm"
+
+#: ../src/common/paper.cpp:140
+msgid "Japanese Envelope Kaku #2"
+msgstr "Japońska Koperta Kaku #2"
+
+#: ../src/common/paper.cpp:141
+msgid "Japanese Envelope Kaku #3"
+msgstr "Japońska Koperta Kaku #3"
+
+#: ../src/common/paper.cpp:142
+msgid "Japanese Envelope Chou #3"
+msgstr "Japońska Koperta Chou #3"
+
+#: ../src/common/paper.cpp:143
+msgid "Japanese Envelope Chou #4"
+msgstr "Japońska Koperta Chou #4"
+
+#: ../src/common/paper.cpp:144
+msgid "Letter Rotated 11 x 8 1/2 in"
+msgstr "List Obrócony 11 x 8 1/2 cala"
+
+#: ../src/common/paper.cpp:145
+msgid "A3 Rotated 420 x 297 mm"
+msgstr "A3 Obrócone 420 x 297 mm"
+
+#: ../src/common/paper.cpp:146
+msgid "A4 Rotated 297 x 210 mm"
+msgstr "A4 Obrócone 297 x 210 mm"
+
+#: ../src/common/paper.cpp:147
+msgid "A5 Rotated 210 x 148 mm"
+msgstr "A5 Obrócone 210 x 148 mm"
+
+#: ../src/common/paper.cpp:148
+msgid "B4 (JIS) Rotated 364 x 257 mm"
+msgstr "B4 (JIS) Obrócone 364 x 257 mm"
+
+#: ../src/common/paper.cpp:149
+msgid "B5 (JIS) Rotated 257 x 182 mm"
+msgstr "B5 (JIS) Obrócone 257 x 182 mm"
+
+#: ../src/common/paper.cpp:150
+msgid "Japanese Postcard Rotated 148 x 100 mm"
+msgstr "Japońska Pocztówka Obrócona 148 x 100 mm"
+
+#: ../src/common/paper.cpp:151
+msgid "Double Japanese Postcard Rotated 148 x 200 mm"
+msgstr "Podwójna Japońska Pocztówka Obrócona 148 x 200 mm"
+
+#: ../src/common/paper.cpp:152
+msgid "A6 Rotated 148 x 105 mm"
+msgstr "A6 Obrócone 148 x 105 mm"
+
+#: ../src/common/paper.cpp:153
+msgid "Japanese Envelope Kaku #2 Rotated"
+msgstr "Japońska Koperta Kaku #2 Obrócona"
+
+#: ../src/common/paper.cpp:154
+msgid "Japanese Envelope Kaku #3 Rotated"
+msgstr "Japońska Koperta Kaku #3 Obrócona"
+
+#: ../src/common/paper.cpp:155
+msgid "Japanese Envelope Chou #3 Rotated"
+msgstr "Japońska Koperta Chou #3 Obrócona"
+
+#: ../src/common/paper.cpp:156
+msgid "Japanese Envelope Chou #4 Rotated"
+msgstr "Japońska Koperta Chou #4 Obrócona"
+
+#: ../src/common/paper.cpp:157
+msgid "B6 (JIS) 128 x 182 mm"
+msgstr "B6 (JIS) 128 x 182 mm"
+
+#: ../src/common/paper.cpp:158
+msgid "B6 (JIS) Rotated 182 x 128 mm"
+msgstr "B6 (JIS) Obrócone 182 x 128 mm"
+
+#: ../src/common/paper.cpp:159
+msgid "12 x 11 in"
+msgstr "12 x 11 cali"
+
+#: ../src/common/paper.cpp:160
+msgid "Japanese Envelope You #4"
+msgstr "Japońska Koperta You #4"
+
+#: ../src/common/paper.cpp:161
+msgid "Japanese Envelope You #4 Rotated"
+msgstr "Japońska Koperta You #4 Obrócona"
+
+#: ../src/common/paper.cpp:162
+msgid "PRC 16K 146 x 215 mm"
+msgstr "PRC 16K 146 x 215 mm"
+
+#: ../src/common/paper.cpp:163
+msgid "PRC 32K 97 x 151 mm"
+msgstr "PRC 32K 97 x 151 mm"
+
+#: ../src/common/paper.cpp:164
+msgid "PRC 32K(Big) 97 x 151 mm"
+msgstr "PRC 32K(Big) 97 x 151 mm"
+
+#: ../src/common/paper.cpp:165
+msgid "PRC Envelope #1 102 x 165 mm"
+msgstr "Koperta PRC #1, 102 x 165 mm"
+
+#: ../src/common/paper.cpp:166
+msgid "PRC Envelope #2 102 x 176 mm"
+msgstr "Koperta PRC #2 102 x 176 mm"
+
+#: ../src/common/paper.cpp:167
+msgid "PRC Envelope #3 125 x 176 mm"
+msgstr "Koperta PRC #3 125 x 176 mm"
+
+#: ../src/common/paper.cpp:168
+msgid "PRC Envelope #4 110 x 208 mm"
+msgstr "Koperta PRC #4 110 x 208 mm"
+
+#: ../src/common/paper.cpp:169
+msgid "PRC Envelope #5 110 x 220 mm"
+msgstr "Koperta PRC #5 110 x 220 mm"
+
+#: ../src/common/paper.cpp:170
+msgid "PRC Envelope #6 120 x 230 mm"
+msgstr "Koperta PRC #6 120 x 230 mm"
+
+#: ../src/common/paper.cpp:171
+msgid "PRC Envelope #7 160 x 230 mm"
+msgstr "Koperta PRC #7 160 x 230 mm"
+
+#: ../src/common/paper.cpp:172
+msgid "PRC Envelope #8 120 x 309 mm"
+msgstr "Koperta PRC #8 120 x 309 mm"
+
+#: ../src/common/paper.cpp:173
+msgid "PRC Envelope #9 229 x 324 mm"
+msgstr "Koperta PRC #9 229 x 324 mm"
+
+#: ../src/common/paper.cpp:174
+msgid "PRC Envelope #10 324 x 458 mm"
+msgstr "Koperta PRC #10 324 x 458 mm"
+
+#: ../src/common/paper.cpp:175
+msgid "PRC 16K Rotated"
+msgstr "PRC 16K Obrócony"
+
+#: ../src/common/paper.cpp:176
+msgid "PRC 32K Rotated"
+msgstr "PRC 32K Obrócony"
+
+#: ../src/common/paper.cpp:177
+msgid "PRC 32K(Big) Rotated"
+msgstr "PRC 32K(Big) Obrócony"
+
+#: ../src/common/paper.cpp:178
+msgid "PRC Envelope #1 Rotated 165 x 102 mm"
+msgstr "Koperta PRC #1 Obrócona, 165 x 102 mm"
+
+#: ../src/common/paper.cpp:179
+msgid "PRC Envelope #2 Rotated 176 x 102 mm"
+msgstr "Koperta PRC #2 Obrócona 176 x 102 mm"
+
+#: ../src/common/paper.cpp:180
+msgid "PRC Envelope #3 Rotated 176 x 125 mm"
+msgstr "Koperta PRC #3 Obrócona 176 x 125 mm"
+
+#: ../src/common/paper.cpp:181
+msgid "PRC Envelope #4 Rotated 208 x 110 mm"
+msgstr "Koperta PRC #4 Obrócona 208 x 110 mm"
+
+#: ../src/common/paper.cpp:182
+msgid "PRC Envelope #5 Rotated 220 x 110 mm"
+msgstr "Koperta PRC #5 Obrócona 220 x 110 mm"
+
+#: ../src/common/paper.cpp:183
+msgid "PRC Envelope #6 Rotated 230 x 120 mm"
+msgstr "Koperta PRC #6 Obrócona 230 x 120 mm"
+
+#: ../src/common/paper.cpp:184
+msgid "PRC Envelope #7 Rotated 230 x 160 mm"
+msgstr "Koperta PRC #7 Obrócona 230 x 160 mm"
+
+#: ../src/common/paper.cpp:185
+msgid "PRC Envelope #8 Rotated 309 x 120 mm"
+msgstr "Koperta PRC #8 Obrócona 309 x 120 mm"
+
+#: ../src/common/paper.cpp:186
+msgid "PRC Envelope #9 Rotated 324 x 229 mm"
+msgstr "Koperta PRC #9 Obrócona 324 x 229 mm"
+
+#: ../src/common/paper.cpp:187
+msgid "PRC Envelope #10 Rotated 458 x 324 mm"
+msgstr "Koperta PRC #10 Obrócona 458 x 324 mm"
+
+#: ../src/common/paper.cpp:192
+msgid "A0 sheet, 841 x 1189 mm"
+msgstr "Arkusz A0, 841 x 1189 mm"
+
+#: ../src/common/paper.cpp:193
+msgid "A1 sheet, 594 x 841 mm"
+msgstr "Arkusz A1, 594 x 841 mm"
+
+#: ../src/common/preferencescmn.cpp:37
+msgid "General"
+msgstr "Ogólne"
+
+#: ../src/common/preferencescmn.cpp:40
+msgid "Advanced"
+msgstr "Zaawansowane"
+
+#: ../src/common/prntbase.cpp:245
+msgid "Generic PostScript"
+msgstr "PostScript"
+
+#: ../src/common/prntbase.cpp:259
+msgid "Ready"
+msgstr "Gotowy"
+
+#: ../src/common/prntbase.cpp:331
+msgid "Printing Error"
+msgstr "Błąd wydruku"
+
+#: ../src/common/prntbase.cpp:413 ../src/common/prntbase.cpp:1597
+#: ../src/generic/prntdlgg.cpp:135 ../src/generic/prntdlgg.cpp:149
+#: ../src/gtk/print.cpp:628 ../src/gtk/print.cpp:646
+msgid "Print"
+msgstr "Drukuj"
+
+#: ../src/common/prntbase.cpp:471 ../src/generic/prntdlgg.cpp:809
+msgid "Page setup"
+msgstr "Ustawienia strony"
+
+#: ../src/common/prntbase.cpp:525
+msgid "Please wait while printing..."
+msgstr "Proszę czekać, trwa drukowanie..."
+
+#: ../src/common/prntbase.cpp:529
+msgid "Document:"
+msgstr "Dokument:"
+
+#: ../src/common/prntbase.cpp:532
+msgid "Progress:"
+msgstr "Postęp:"
+
+#: ../src/common/prntbase.cpp:533
+msgid "Preparing"
+msgstr "Przygotowywanie"
+
+#: ../src/common/prntbase.cpp:552
+#, fuzzy, c-format
+msgid "Printing page %d"
+msgstr "Drukowanie strony %d..."
+
+#: ../src/common/prntbase.cpp:557
+#, c-format
+msgid "Printing page %d of %d"
+msgstr "Drukowanie strony %d z %d"
+
+#: ../src/common/prntbase.cpp:560
+#, c-format
+msgid " (copy %d of %d)"
+msgstr " (kopia %d z %d)"
+
+#: ../src/common/prntbase.cpp:1604
+msgid "First page"
+msgstr "Pierwsza strona"
+
+#: ../src/common/prntbase.cpp:1609 ../src/html/helpwnd.cpp:659
+msgid "Previous page"
+msgstr "Poprzednia strona"
+
+#: ../src/common/prntbase.cpp:1623 ../src/html/helpwnd.cpp:660
+msgid "Next page"
+msgstr "Następna strona"
+
+#: ../src/common/prntbase.cpp:1628
+msgid "Last page"
+msgstr "Ostatnia strona"
+
+#: ../src/common/prntbase.cpp:1636 ../src/common/stockitem.cpp:215
+msgid "Zoom Out"
+msgstr "Pomniejszenie"
+
+#: ../src/common/prntbase.cpp:1650 ../src/common/stockitem.cpp:214
+msgid "Zoom In"
+msgstr "Powiększenie"
+
+#: ../src/common/prntbase.cpp:1656 ../src/common/stockitem.cpp:153
+#: ../src/generic/logg.cpp:553 ../src/univ/themes/win32.cpp:3752
+msgid "&Close"
+msgstr "Zam&knij"
+
+#: ../src/common/prntbase.cpp:2085
+msgid "Could not start document preview."
+msgstr "Nie można wystartować podglądu dokumentu."
+
+#: ../src/common/prntbase.cpp:2085 ../src/common/prntbase.cpp:2129
+#: ../src/common/prntbase.cpp:2137
+msgid "Print Preview Failure"
+msgstr "Awaria podglądu wydruku"
+
+#: ../src/common/prntbase.cpp:2129 ../src/common/prntbase.cpp:2137
+msgid "Sorry, not enough memory to create a preview."
+msgstr "Niestety za mało pamięci aby przygotować podgląd."
+
+#: ../src/common/prntbase.cpp:2144
+#, c-format
+msgid "Page %d of %d"
+msgstr "Strona %d z %d"
+
+#: ../src/common/prntbase.cpp:2146
+#, c-format
+msgid "Page %d"
+msgstr "Strona %d"
+
+#: ../src/common/regex.cpp:382 ../src/html/chm.cpp:348
+msgid "unknown error"
+msgstr "nieznany błąd"
+
+#: ../src/common/regex.cpp:995
+#, c-format
+msgid "Invalid regular expression '%s': %s"
+msgstr "Nieprawidłowe wyrażenie regularne '%s': %s"
+
+#: ../src/common/regex.cpp:1059
+#, c-format
+msgid "Failed to find match for regular expression: %s"
+msgstr "Nie udało się znaleźć połączenia dla regularnego wyrażenia: %s"
+
+#: ../src/common/rendcmn.cpp:188
+#, c-format
+msgid "Renderer \"%s\" has incompatible version %d.%d and couldn't be loaded."
+msgstr ""
+"Wizualizator \"%s\" ma niezgodną wersję %d.%d i nie może być załadowany."
+
+#: ../src/common/secretstore.cpp:162
+msgid "Not available for this platform"
+msgstr ""
+
+#: ../src/common/secretstore.cpp:183
+#, fuzzy, c-format
+msgid "Saving password for \"%s\" failed: %s."
+msgstr "Pobranie '%s' do '%s' nie powiodło się."
+
+#: ../src/common/secretstore.cpp:205
+#, fuzzy, c-format
+msgid "Reading password for \"%s\" failed: %s."
+msgstr "Pobranie '%s' do '%s' nie powiodło się."
+
+#: ../src/common/secretstore.cpp:228
+#, fuzzy, c-format
+msgid "Deleting password for \"%s\" failed: %s."
+msgstr "Pobranie '%s' do '%s' nie powiodło się."
+
+#: ../src/common/selectdispatcher.cpp:254
+msgid "Failed to monitor I/O channels"
+msgstr "Nie udało się monitorować kanałów wejściowych/wyjściowych"
+
+#: ../src/common/sizer.cpp:3054 ../src/common/stockitem.cpp:195
+msgid "Save"
+msgstr "Zapisz"
+
+#: ../src/common/sizer.cpp:3056
+msgid "Don't Save"
+msgstr "Nie Zapisuj"
+
+#: ../src/common/socket.cpp:870
+msgid "Cannot initialize sockets"
+msgstr "Nie można zainicjować gniazd"
+
+#: ../src/common/stockitem.cpp:127
+#, fuzzy
+msgctxt "standard Windows menu"
+msgid "&Help"
+msgstr "&Pomoc"
+
+#: ../src/common/stockitem.cpp:144
+msgid "&About"
+msgstr "Inform&acje"
+
+#: ../src/common/stockitem.cpp:144
+msgid "About"
+msgstr "Inform&acje"
+
+#: ../src/common/stockitem.cpp:145
+msgid "Add"
+msgstr "Dodaj"
+
+#: ../src/common/stockitem.cpp:146
+msgid "&Apply"
+msgstr "Z&astosuj"
+
+#: ../src/common/stockitem.cpp:146
+msgid "Apply"
+msgstr "Zastosuj"
+
+#: ../src/common/stockitem.cpp:147
+msgid "&Back"
+msgstr "&Wstecz"
+
+#: ../src/common/stockitem.cpp:147
+msgid "Back"
+msgstr "Wstecz"
+
+#: ../src/common/stockitem.cpp:148
+msgid "&Bold"
+msgstr "Pogru&biony"
+
+#: ../src/common/stockitem.cpp:148 ../src/generic/fontdlgg.cpp:326
+#: ../src/richtext/richtextfontpage.cpp:354
+msgid "Bold"
+msgstr "Pogrubiony"
+
+#: ../src/common/stockitem.cpp:149
+msgid "&Bottom"
+msgstr "&Dolny"
+
+#: ../src/common/stockitem.cpp:149 ../src/richtext/richtextsizepage.cpp:287
+msgid "Bottom"
+msgstr "Dolny"
+
+#: ../src/common/stockitem.cpp:150 ../src/generic/fontdlgg.cpp:462
+#: ../src/generic/fontdlgg.cpp:481 ../src/generic/wizard.cpp:415
+msgid "&Cancel"
+msgstr "&Anuluj"
+
+#: ../src/common/stockitem.cpp:151
+#, fuzzy
+msgid "&CD-ROM"
+msgstr "&CD-Rom"
+
+#: ../src/common/stockitem.cpp:151
+#, fuzzy
+msgid "CD-ROM"
+msgstr "CD-Rom"
+
+#: ../src/common/stockitem.cpp:152
+msgid "&Clear"
+msgstr "Wy&czyść"
+
+#: ../src/common/stockitem.cpp:152
+msgid "Clear"
+msgstr "Wyczyść"
+
+#: ../src/common/stockitem.cpp:153 ../src/generic/dbgrptg.cpp:93
+#: ../src/generic/progdlgg.cpp:778 ../src/html/helpdlg.cpp:86
+#: ../src/msw/progdlg.cpp:209 ../src/msw/progdlg.cpp:890
+#: ../src/richtext/richtextstyledlg.cpp:272
+#: ../src/richtext/richtextsymboldlg.cpp:448
+msgid "Close"
+msgstr "Zamknij"
+
+#: ../src/common/stockitem.cpp:154
+msgid "&Convert"
+msgstr "&Konwertuj"
+
+#: ../src/common/stockitem.cpp:154
+msgid "Convert"
+msgstr "KonwertujZawartość"
+
+#: ../src/common/stockitem.cpp:155 ../src/msw/textctrl.cpp:2884
+#: ../src/osx/textctrl_osx.cpp:653 ../src/richtext/richtextctrl.cpp:331
+msgid "&Copy"
+msgstr "&Kopiuj"
+
+#: ../src/common/stockitem.cpp:155 ../src/stc/stc_i18n.cpp:18
+msgid "Copy"
+msgstr "Kopiuj"
+
+#: ../src/common/stockitem.cpp:156 ../src/msw/textctrl.cpp:2883
+#: ../src/osx/textctrl_osx.cpp:652 ../src/richtext/richtextctrl.cpp:330
+msgid "Cu&t"
+msgstr "&Wytnij"
+
+#: ../src/common/stockitem.cpp:156 ../src/stc/stc_i18n.cpp:17
+msgid "Cut"
+msgstr "Wytnij"
+
+#: ../src/common/stockitem.cpp:157 ../src/msw/textctrl.cpp:2886
+#: ../src/osx/textctrl_osx.cpp:655 ../src/richtext/richtextctrl.cpp:333
+#: ../src/richtext/richtexttabspage.cpp:137
+msgid "&Delete"
+msgstr "&Usuń"
+
+#: ../src/common/stockitem.cpp:157 ../src/richtext/richtextbuffer.cpp:8266
+#: ../src/stc/stc_i18n.cpp:20
+msgid "Delete"
+msgstr "Usuń"
+
+#: ../src/common/stockitem.cpp:158
+msgid "&Down"
+msgstr "W &dół"
+
+#: ../src/common/stockitem.cpp:158 ../src/generic/fdrepdlg.cpp:148
+msgid "Down"
+msgstr "W dół"
+
+#: ../src/common/stockitem.cpp:159
+msgid "&Edit"
+msgstr "&Edytuj"
+
+#: ../src/common/stockitem.cpp:159
+msgid "Edit"
+msgstr "Edytuj"
+
+#: ../src/common/stockitem.cpp:160
+msgid "&Execute"
+msgstr "&Uruchom"
+
+#: ../src/common/stockitem.cpp:160
+msgid "Execute"
+msgstr "Uruchom"
+
+#: ../src/common/stockitem.cpp:161
+msgid "&Quit"
+msgstr "&Wyjście"
+
+#: ../src/common/stockitem.cpp:161
+msgid "Quit"
+msgstr "Wyjście"
+
+#: ../src/common/stockitem.cpp:162
+msgid "&File"
+msgstr "&Plik"
+
+#: ../src/common/stockitem.cpp:162
+msgid "File"
+msgstr "Plik"
+
+#: ../src/common/stockitem.cpp:163
+#, fuzzy
+msgid "&Find..."
+msgstr "&Znajdź"
+
+#: ../src/common/stockitem.cpp:163
+#, fuzzy
+msgid "Find..."
+msgstr "Znajdź"
+
+#: ../src/common/stockitem.cpp:164
+msgid "&First"
+msgstr "Pierwszy"
+
+#: ../src/common/stockitem.cpp:164
+msgid "First"
+msgstr "Pierwszy"
+
+#: ../src/common/stockitem.cpp:165
+msgid "&Floppy"
+msgstr "&Dyskietka"
+
+#: ../src/common/stockitem.cpp:165
+msgid "Floppy"
+msgstr "Dyskietka"
+
+#: ../src/common/stockitem.cpp:166
+msgid "&Forward"
+msgstr "&Dalej"
+
+#: ../src/common/stockitem.cpp:166
+msgid "Forward"
+msgstr "Dalej"
+
+#: ../src/common/stockitem.cpp:167
+msgid "&Harddisk"
+msgstr "&Dysk twardy"
+
+#: ../src/common/stockitem.cpp:167
+msgid "Harddisk"
+msgstr "Dysk twardy"
+
+#: ../src/common/stockitem.cpp:168 ../src/generic/wizard.cpp:418
+#: ../src/osx/cocoa/menu.mm:225 ../src/richtext/richtextstyledlg.cpp:298
+#: ../src/richtext/richtextsymboldlg.cpp:451
+msgid "&Help"
+msgstr "&Pomoc"
+
+#: ../src/common/stockitem.cpp:169
+msgid "&Home"
+msgstr "&Początek"
+
+#: ../src/common/stockitem.cpp:169
+msgid "Home"
+msgstr "Katalog początkowy"
+
+#: ../src/common/stockitem.cpp:170
+msgid "Indent"
+msgstr "Wcięcie"
+
+#: ../src/common/stockitem.cpp:171
+msgid "&Index"
+msgstr "&Indeks"
+
+#: ../src/common/stockitem.cpp:171 ../src/html/helpwnd.cpp:510
+msgid "Index"
+msgstr "Indeks"
+
+#: ../src/common/stockitem.cpp:172
+msgid "&Info"
+msgstr "&Info"
+
+#: ../src/common/stockitem.cpp:172
+msgid "Info"
+msgstr "Info"
+
+#: ../src/common/stockitem.cpp:173
+msgid "&Italic"
+msgstr "&Kursywa"
+
+#: ../src/common/stockitem.cpp:173 ../src/generic/fontdlgg.cpp:322
+#: ../src/richtext/richtextfontpage.cpp:350
+msgid "Italic"
+msgstr "Kursywa"
+
+#: ../src/common/stockitem.cpp:174
+msgid "&Jump to"
+msgstr "&Skocz do"
+
+#: ../src/common/stockitem.cpp:174
+msgid "Jump to"
+msgstr "Skocz do"
+
+#: ../src/common/stockitem.cpp:175
+msgid "Centered"
+msgstr "Wyrównanie do środka"
+
+#: ../src/common/stockitem.cpp:176
+msgid "Justified"
+msgstr "Wyrównanie obustronne"
+
+#: ../src/common/stockitem.cpp:177
+msgid "Align Left"
+msgstr "Wyrównanie do lewej"
+
+#: ../src/common/stockitem.cpp:178
+msgid "Align Right"
+msgstr "Wyrównanie do prawej"
+
+#: ../src/common/stockitem.cpp:179
+msgid "&Last"
+msgstr "&Ostatni"
+
+#: ../src/common/stockitem.cpp:179
+msgid "Last"
+msgstr "Ostatni"
+
+#: ../src/common/stockitem.cpp:180
+msgid "&Network"
+msgstr "&Sieć"
+
+#: ../src/common/stockitem.cpp:180
+msgid "Network"
+msgstr "Sieć"
+
+#: ../src/common/stockitem.cpp:181 ../src/richtext/richtexttabspage.cpp:131
+msgid "&New"
+msgstr "&Nowy"
+
+#: ../src/common/stockitem.cpp:181
+msgid "New"
+msgstr "Nowy"
+
+#: ../src/common/stockitem.cpp:182 ../src/msw/msgdlg.cpp:417
+msgid "&No"
+msgstr "&Nie"
+
+#: ../src/common/stockitem.cpp:183 ../src/generic/fontdlgg.cpp:467
+#: ../src/generic/fontdlgg.cpp:474
+msgid "&OK"
+msgstr "&OK"
+
+#: ../src/common/stockitem.cpp:184 ../src/generic/dbgrptg.cpp:341
+msgid "&Open..."
+msgstr "&Otwórz..."
+
+#: ../src/common/stockitem.cpp:184
+msgid "Open..."
+msgstr "Otwórz..."
+
+#: ../src/common/stockitem.cpp:185 ../src/msw/textctrl.cpp:2885
+#: ../src/osx/textctrl_osx.cpp:654 ../src/richtext/richtextctrl.cpp:332
+msgid "&Paste"
+msgstr "Wkl&ej"
+
+#: ../src/common/stockitem.cpp:185 ../src/richtext/richtextctrl.cpp:3484
+#: ../src/stc/stc_i18n.cpp:19
+msgid "Paste"
+msgstr "Wklej"
+
+#: ../src/common/stockitem.cpp:186
+msgid "&Preferences"
+msgstr "&Preferencje"
+
+#: ../src/common/stockitem.cpp:186 ../src/osx/cocoa/preferences.mm:304
+msgid "Preferences"
+msgstr "Preferencje"
+
+#: ../src/common/stockitem.cpp:187
+msgid "Print previe&w..."
+msgstr "Podgląd &wydruku..."
+
+#: ../src/common/stockitem.cpp:187
+msgid "Print preview..."
+msgstr "Podgląd wydruku..."
+
+#: ../src/common/stockitem.cpp:188
+msgid "&Print..."
+msgstr "&Drukuj..."
+
+#: ../src/common/stockitem.cpp:188
+msgid "Print..."
+msgstr "Drukuj..."
+
+#: ../src/common/stockitem.cpp:189 ../src/richtext/richtextctrl.cpp:337
+#: ../src/richtext/richtextctrl.cpp:5479
+msgid "&Properties"
+msgstr "&Właściwości"
+
+#: ../src/common/stockitem.cpp:189
+msgid "Properties"
+msgstr "Właściwości"
+
+#: ../src/common/stockitem.cpp:190 ../src/stc/stc_i18n.cpp:16
+msgid "Redo"
+msgstr "Ponów"
+
+#: ../src/common/stockitem.cpp:191
+msgid "Refresh"
+msgstr "Odśwież"
+
+#: ../src/common/stockitem.cpp:192
+msgid "Remove"
+msgstr "Usuń"
+
+#: ../src/common/stockitem.cpp:193
+#, fuzzy
+msgid "Rep&lace..."
+msgstr "&Zastąp"
+
+#: ../src/common/stockitem.cpp:193
+#, fuzzy
+msgid "Replace..."
+msgstr "Zastąp"
+
+#: ../src/common/stockitem.cpp:194
+msgid "Revert to Saved"
+msgstr "Przywróć zapisany"
+
+#: ../src/common/stockitem.cpp:196 ../src/generic/logg.cpp:549
+msgid "Save &As..."
+msgstr "Zapisz J&ako..."
+
+#: ../src/common/stockitem.cpp:196
+#, fuzzy
+msgid "Save As..."
+msgstr "Zapisz J&ako..."
+
+#: ../src/common/stockitem.cpp:197 ../src/msw/textctrl.cpp:2888
+#: ../src/osx/textctrl_osx.cpp:657 ../src/richtext/richtextctrl.cpp:335
+msgid "Select &All"
+msgstr "&Zaznacz wszystko"
+
+#: ../src/common/stockitem.cpp:197 ../src/stc/stc_i18n.cpp:21
+msgid "Select All"
+msgstr "Zaznacz wszystko"
+
+#: ../src/common/stockitem.cpp:198
+msgid "&Color"
+msgstr "K&olor"
+
+#: ../src/common/stockitem.cpp:198
+msgid "Color"
+msgstr "Kolor"
+
+#: ../src/common/stockitem.cpp:199
+msgid "&Font"
+msgstr "&Czcionka"
+
+#: ../src/common/stockitem.cpp:199 ../src/richtext/richtextformatdlg.cpp:336
+msgid "Font"
+msgstr "Czcionka"
+
+#: ../src/common/stockitem.cpp:200
+msgid "&Ascending"
+msgstr "&Rosnąco"
+
+#: ../src/common/stockitem.cpp:200
+msgid "Ascending"
+msgstr "Rosnąco"
+
+#: ../src/common/stockitem.cpp:201
+msgid "&Descending"
+msgstr "&Malejąco"
+
+#: ../src/common/stockitem.cpp:201
+msgid "Descending"
+msgstr "MalejącoKodowanie domyślne"
+
+#: ../src/common/stockitem.cpp:202
+msgid "&Spell Check"
+msgstr "&Sprawdzanie pisowni"
+
+#: ../src/common/stockitem.cpp:202
+msgid "Spell Check"
+msgstr "Sprawdzanie pisowni"
+
+#: ../src/common/stockitem.cpp:203
+msgid "&Stop"
+msgstr "&Stop"
+
+#: ../src/common/stockitem.cpp:203
+msgid "Stop"
+msgstr "Stop"
+
+#: ../src/common/stockitem.cpp:204 ../src/richtext/richtextfontpage.cpp:274
+msgid "&Strikethrough"
+msgstr "&Przekreślenie"
+
+#: ../src/common/stockitem.cpp:204
+msgid "Strikethrough"
+msgstr "Przekreślenie"
+
+#: ../src/common/stockitem.cpp:205
+msgid "&Top"
+msgstr "&Góra"
+
+#: ../src/common/stockitem.cpp:205 ../src/richtext/richtextsizepage.cpp:285
+#: ../src/richtext/richtextsizepage.cpp:289
+msgid "Top"
+msgstr "Góra"
+
+#: ../src/common/stockitem.cpp:206
+msgid "Undelete"
+msgstr "Odzyskaj"
+
+#: ../src/common/stockitem.cpp:207 ../src/generic/fontdlgg.cpp:437
+msgid "&Underline"
+msgstr "&Podkreślony"
+
+#: ../src/common/stockitem.cpp:207
+msgid "Underline"
+msgstr "Podkreślenie"
+
+#: ../src/common/stockitem.cpp:208 ../src/stc/stc_i18n.cpp:15
+msgid "Undo"
+msgstr "Cofnij"
+
+#: ../src/common/stockitem.cpp:209
+msgid "&Unindent"
+msgstr "&Cofnij wcięcie"
+
+#: ../src/common/stockitem.cpp:209
+msgid "Unindent"
+msgstr "Cofnij wcięcie"
+
+#: ../src/common/stockitem.cpp:210
+msgid "&Up"
+msgstr "&W górę"
+
+#: ../src/common/stockitem.cpp:210 ../src/generic/fdrepdlg.cpp:148
+msgid "Up"
+msgstr "W górę"
+
+#: ../src/common/stockitem.cpp:211 ../src/msw/msgdlg.cpp:417
+msgid "&Yes"
+msgstr "&Tak"
+
+#: ../src/common/stockitem.cpp:212
+msgid "&Actual Size"
+msgstr "&Bieżący rozmiar"
+
+#: ../src/common/stockitem.cpp:212
+msgid "Actual Size"
+msgstr "Bieżący rozmiar"
+
+#: ../src/common/stockitem.cpp:213
+msgid "Zoom to &Fit"
+msgstr "&Dopasowanie powiększenia"
+
+#: ../src/common/stockitem.cpp:213
+msgid "Zoom to Fit"
+msgstr "Dopasowanie powiększenia"
+
+#: ../src/common/stockitem.cpp:214
+msgid "Zoom &In"
+msgstr "Powiększen&ie"
+
+#: ../src/common/stockitem.cpp:215
+msgid "Zoom &Out"
+msgstr "P&omniejszenie"
+
+#: ../src/common/stockitem.cpp:262
+msgid "Show about dialog"
+msgstr "Pokazuje okno O"
+
+#: ../src/common/stockitem.cpp:263
+msgid "Copy selection"
+msgstr "Kopiuj wybór"
+
+#: ../src/common/stockitem.cpp:264
+msgid "Cut selection"
+msgstr "Wytnij wybór"
+
+#: ../src/common/stockitem.cpp:265
+msgid "Delete selection"
+msgstr "Usuń wybór"
+
+#: ../src/common/stockitem.cpp:266
+#, fuzzy
+msgid "Find in document"
+msgstr "Otwórz dokument HTML"
+
+#: ../src/common/stockitem.cpp:267
+msgid "Find and replace in document"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:268
+msgid "Paste selection"
+msgstr "Wklej wybór"
+
+#: ../src/common/stockitem.cpp:269
+msgid "Quit this program"
+msgstr "Zamknij program"
+
+#: ../src/common/stockitem.cpp:270
+msgid "Redo last action"
+msgstr "Powtórz ostatnią czynność"
+
+#: ../src/common/stockitem.cpp:271
+msgid "Undo last action"
+msgstr "Cofnij ostatnią czynność"
+
+#: ../src/common/stockitem.cpp:272
+#, fuzzy
+msgid "Create new document"
+msgstr "Utwórz nowy katalog"
+
+#: ../src/common/stockitem.cpp:273
+#, fuzzy
+msgid "Open an existing document"
+msgstr "Otwórz dokument HTML"
+
+#: ../src/common/stockitem.cpp:274
+msgid "Close current document"
+msgstr "Zamknij bieżący dokument"
+
+# perspektywę?
+#: ../src/common/stockitem.cpp:275
+msgid "Save current document"
+msgstr "Zapisz bieżący dokument"
+
+#: ../src/common/stockitem.cpp:276
+msgid "Save current document with a different filename"
+msgstr "Zapisz bieżący dokument pod inną nazwą pliku"
+
+#: ../src/common/strconv.cpp:2324
+#, c-format
+msgid "Conversion to charset '%s' doesn't work."
+msgstr "Nie działa konwersja do zestawu znaków '%s'."
+
+#: ../src/common/tarstrm.cpp:352 ../src/common/tarstrm.cpp:375
+#: ../src/common/tarstrm.cpp:406 ../src/generic/progdlgg.cpp:373
+msgid "unknown"
+msgstr "nieznany"
+
+#: ../src/common/tarstrm.cpp:774
+msgid "incomplete header block in tar"
+msgstr "niekompletny blok nagłówka w tar"
+
+#: ../src/common/tarstrm.cpp:798
+msgid "checksum failure reading tar header block"
+msgstr "Niepowodzenie sumy kontrolnej czytania nagłówka bloku tar"
+
+#: ../src/common/tarstrm.cpp:971
+msgid "invalid data in extended tar header"
+msgstr "nieprawidłowe dane w rozszerzonym nagłówku tar"
+
+#: ../src/common/tarstrm.cpp:981 ../src/common/tarstrm.cpp:1003
+#: ../src/common/tarstrm.cpp:1477 ../src/common/tarstrm.cpp:1499
+msgid "tar entry not open"
+msgstr "wpis tar nie otwarty"
+
+#: ../src/common/tarstrm.cpp:1023
+msgid "unexpected end of file"
+msgstr "nieoczekiwany koniec pliku"
+
+#: ../src/common/tarstrm.cpp:1297
+#, c-format
+msgid "%s did not fit the tar header for entry '%s'"
+msgstr "%s nie pasuje nagłówek tar do wpisu '%s'"
+
+#: ../src/common/tarstrm.cpp:1359
+msgid "incorrect size given for tar entry"
+msgstr "nieprawidłowy rozmiar podany w wpisie tar"
+
+#: ../src/common/textbuf.cpp:232
+#, c-format
+msgid "'%s' is probably a binary buffer."
+msgstr "'%s' jest prawdopodobnie buforem binarnym."
+
+#: ../src/common/textcmn.cpp:1006 ../src/richtext/richtextctrl.cpp:3053
+msgid "File couldn't be loaded."
+msgstr "Plik nie może być wczytany."
+
+#: ../src/common/textfile.cpp:95
+#, fuzzy, c-format
+msgid "Failed to read text file \"%s\"."
+msgstr "Nie udało się wczytanie dokumentu z pliku \"%s\"."
+
+#: ../src/common/textfile.cpp:160
+#, c-format
+msgid "can't write buffer '%s' to disk."
+msgstr "nie można zapisać bufora '%s' na dysk."
+
+#: ../src/common/time.cpp:212
+msgid "Failed to get the local system time"
+msgstr "Nie udało się pobrać lokalnego czasu systemowego"
+
+#: ../src/common/time.cpp:279
+msgid "wxGetTimeOfDay failed."
+msgstr "wxGetTimeOfDay zwróciło błąd."
+
+#: ../src/common/translation.cpp:929
+#, c-format
+msgid "'%s' is not a valid message catalog."
+msgstr "'%s' nie jest prawidłowym katalogiem komunikatów."
+
+#: ../src/common/translation.cpp:954
+msgid "Invalid message catalog."
+msgstr "Nieprawidłowy katalog komunikatów."
+
+#: ../src/common/translation.cpp:1013
+#, c-format
+msgid "Failed to parse Plural-Forms: '%s'"
+msgstr "Nie można przetworzyć formy liczby mnogiej: '%s'"
+
+#: ../src/common/translation.cpp:1723
+#, c-format
+msgid "using catalog '%s' from '%s'."
+msgstr "użycie katalogu '%s' z '%s'."
+
+#: ../src/common/translation.cpp:1816
+#, c-format
+msgid "Resource '%s' is not a valid message catalog."
+msgstr "Zasób '%s' nie jest prawidłowym katalogiem komunikatów."
+
+#: ../src/common/translation.cpp:1865
+msgid "Couldn't enumerate translations"
+msgstr "Nie można policzyć tłumaczeń"
+
+#: ../src/common/utilscmn.cpp:1145
+msgid "No default application configured for HTML files."
+msgstr "Nie ma ustawionej domyślnej aplikacji dla plików HTML."
+
+#: ../src/common/utilscmn.cpp:1190
+#, c-format
+msgid "Failed to open URL \"%s\" in default browser."
+msgstr "Nie udało się otworzyć URL \"%s\" w domyślnej przeglądarce."
+
+#: ../src/common/valtext.cpp:144
+msgid "Validation conflict"
+msgstr "Konflikt kontroli poprawności"
+
+#: ../src/common/valtext.cpp:186
+msgid "Required information entry is empty."
+msgstr "Wymagane pole informacji jest puste."
+
+#: ../src/common/valtext.cpp:188
+#, fuzzy, c-format
+msgid "'%s' is one of the invalid strings"
+msgstr "'%s' jest nieprawidłowy"
+
+#: ../src/common/valtext.cpp:190
+#, fuzzy, c-format
+msgid "'%s' is not one of the valid strings"
+msgstr "'%s' nie jest prawidłowym katalogiem komunikatów."
+
+#: ../src/common/valtext.cpp:199
+#, fuzzy, c-format
+msgid "'%s' contains invalid character(s)"
+msgstr "'%s' powinien zawierać tylko wartości znakowe."
+
+#: ../src/common/webrequest.cpp:139
+#, fuzzy, c-format
+msgid "Error: %s (%d)"
+msgstr "Błąd: "
+
+#: ../src/common/webrequest.cpp:655
+#, c-format
+msgid ""
+"Not enough free disk space for download: %llu needed but only %llu available."
+msgstr ""
+
+#: ../src/common/webrequest.cpp:669
+#, fuzzy, c-format
+msgid "Failed to create temporary file in %s"
+msgstr "Nie udało się wygenerować nazwy dla pliku tymczasowego"
+
+#: ../src/common/webrequest_curl.cpp:1106
+#, fuzzy
+msgid "libcurl could not be initialized"
+msgstr "Opis kolumny nie może być zainicjowany."
+
+#: ../src/common/webview.cpp:392
+#, fuzzy
+msgid "RunScriptAsync not supported"
+msgstr "Konwersja tekstu nie jest wspierana"
+
+#: ../src/common/webview.cpp:403 ../src/msw/webview_ie.cpp:1073
+#, c-format
+msgid "Error running JavaScript: %s"
+msgstr ""
+
+#: ../src/common/webview_chromium.cpp:858
+#, fuzzy, c-format
+msgid "Failed to set proxy \"%s\": %s"
+msgstr "Nie udało się utworzenie katalogu \"%s\""
+
+#: ../src/common/webview_chromium.cpp:989
+msgid ""
+"Chromium can't be used because libcef.so wasn't loaded early enough; please "
+"relink the application or use LD_PRELOAD to load it earlier."
+msgstr ""
+
+#: ../src/common/webview_chromium.cpp:1108
+#, fuzzy
+msgid "Could not initialize Chromium"
+msgstr "Nie można ustawić wyrównania."
+
+#: ../src/common/webview_chromium.cpp:1616
+msgid "Show DevTools"
+msgstr ""
+
+#: ../src/common/webview_chromium.cpp:1617
+#, fuzzy
+msgid "Close DevTools"
+msgstr "Zamknij wszystko"
+
+#: ../src/common/webview_chromium.cpp:1623
+msgid "Inspect"
+msgstr ""
+
+#: ../src/common/wincmn.cpp:1628
+msgid "This platform does not support background transparency."
+msgstr "Ta platforma nie obsługuje przezroczystości tła."
+
+# przenieść?
+#: ../src/common/wincmn.cpp:2097
+msgid "Could not transfer data to window"
+msgstr "Nie można przenieść danych do okna"
+
+#: ../src/common/windowid.cpp:240
+msgid "Out of window IDs.  Recommend shutting down application."
+msgstr "Po za identyfikatorami okna. Zalecane jest zamknięcie aplikacji."
+
+#: ../src/common/xpmdecod.cpp:678
+msgid "XPM: incorrect header format!"
+msgstr "XPM: niepoprawna nagłówka formatu!"
+
+#: ../src/common/xpmdecod.cpp:703
+#, c-format
+msgid "XPM: incorrect colour description in line %d"
+msgstr "XPM: niepoprawny opis koloru w linijce %d"
+
+#: ../src/common/xpmdecod.cpp:715 ../src/common/xpmdecod.cpp:724
+#, c-format
+msgid "XPM: malformed colour definition '%s' at line %d!"
+msgstr "XPM: niepoprawna definicja koloru '%s 'w linijce %d!"
+
+#: ../src/common/xpmdecod.cpp:754
+msgid "XPM: no colors left to use for mask!"
+msgstr "XPM: nie zostało kolorów dla maski!"
+
+#: ../src/common/xpmdecod.cpp:781
+#, c-format
+msgid "XPM: truncated image data at line %d!"
+msgstr "XPM: obcięte dane obrazu w linijce %d!"
+
+#: ../src/common/xpmdecod.cpp:795
+msgid "XPM: Malformed pixel data!"
+msgstr "XPM: Zniekształcone dane obrazu!"
+
+#: ../src/common/xti.cpp:492
+msgid "Illegal Parameter Count for Create Method"
+msgstr "Nieprawidłowa Liczba Parametrów w Metodzie Create"
+
+#: ../src/common/xti.cpp:504
+msgid "Illegal Parameter Count for ConstructObject Method"
+msgstr "Nieprawidłowa Liczba Parametrów w Metodzie ConstructObject"
+
+#: ../src/common/xtistrm.cpp:161
+#, c-format
+msgid "Create Parameter %s not found in declared RTTI Parameters"
+msgstr "NIe odnaleziono parametru %s w zadeklarowanych parametrach RTTI"
+
+#: ../src/common/xtistrm.cpp:290
+msgid "Illegal Object Class (Non-wxEvtHandler) as Event Source"
+msgstr "Błędna Klasa Obiekty (nie typu wxEvtHandler) jako Źródło Zdarzenia"
+
+#: ../src/common/xtistrm.cpp:313 ../src/common/xtixml.cpp:345
+#: ../src/common/xtixml.cpp:498
+msgid "Type must have enum - long conversion"
+msgstr "Typ musi umożliwiać konswersję enum - long"
+
+#: ../src/common/xtistrm.cpp:400 ../src/common/xtistrm.cpp:415
+msgid "Invalid or Null Object ID passed to GetObjectClassInfo"
+msgstr ""
+"Błędny lub Pusty Identyfikator Obiektu przekazany do funkcji "
+"GetObjectClassInfo"
+
+#: ../src/common/xtistrm.cpp:405
+msgid "Unknown Object passed to GetObjectClassInfo"
+msgstr "Nieznany obiekt przekazany do funkcji GetObjectClassInfo"
+
+#: ../src/common/xtistrm.cpp:420
+msgid "Already Registered Object passed to SetObjectClassInfo"
+msgstr ""
+"Zarejestrowany wcześniej obiekt przekazany do funkcji SetObjectClassInfo"
+
+#: ../src/common/xtistrm.cpp:430
+msgid "Invalid or Null Object ID passed to HasObjectClassInfo"
+msgstr ""
+"Błędny lub Pusty Identyfikator Obiektu przekazany do funkcji "
+"HasObjectClassInfo"
+
+#: ../src/common/xtistrm.cpp:460
+msgid "Passing a already registered object to SetObject"
+msgstr "Przekazano już zarejestrowany obiekt do funkcji SetObject"
+
+#: ../src/common/xtistrm.cpp:471
+msgid "Passing an unknown object to GetObject"
+msgstr "Przekazanie nieznanego obiektu do funkcji GetObject"
+
+#: ../src/common/xtixml.cpp:229
+msgid "Forward hrefs are not supported"
+msgstr "Przekazywanie właściwości 'href' nie jest wspierane"
+
+#: ../src/common/xtixml.cpp:247
+#, c-format
+msgid "unknown class %s"
+msgstr "nieznana klasa %s"
+
+#: ../src/common/xtixml.cpp:253
+msgid "objects cannot have XML Text Nodes"
+msgstr "obiekty nie może mieć węzłów typu 'XML Text'"
+
+#: ../src/common/xtixml.cpp:258
+msgid "Objects must have an id attribute"
+msgstr "Obiekty muszą posiadać właściwość typu 'id'"
+
+#: ../src/common/xtixml.cpp:267
+#, c-format
+msgid "Doubly used id : %d"
+msgstr "Dwukrotnie użyty identyfikator : %d"
+
+#: ../src/common/xtixml.cpp:316
+#, c-format
+msgid "Unknown Property %s"
+msgstr "Nieznana właściwość %s"
+
+#: ../src/common/xtixml.cpp:407
+msgid "A non empty collection must consist of 'element' nodes"
+msgstr "Nie pusta kolekcja musi składać się z węzłów typu 'element'"
+
+#: ../src/common/xtixml.cpp:478
+msgid "incorrect event handler string, missing dot"
+msgstr "nieprawidłowy uchwyt zdarzenia, brak kropki w nazwie"
+
+#: ../src/common/zipstrm.cpp:559
+msgid "can't re-initialize zlib deflate stream"
+msgstr "nie można ponownie zainicjować strumienia kompresji biblioteki zlib"
+
+#: ../src/common/zipstrm.cpp:584
+msgid "can't re-initialize zlib inflate stream"
+msgstr "nie można ponownie zainicjować strumienia dekompresji biblioteki zlib"
+
+#: ../src/common/zipstrm.cpp:1023
+msgid "Ignoring malformed extra data record, ZIP file may be corrupted"
+msgstr ""
+
+#: ../src/common/zipstrm.cpp:1502
+msgid "assuming this is a multi-part zip concatenated"
+msgstr "założenie że jest to połączony wieloczęściowy zip"
+
+#: ../src/common/zipstrm.cpp:1664
+msgid "invalid zip file"
+msgstr "nieprawidłowy plik zip"
+
+#: ../src/common/zipstrm.cpp:1723
+msgid "can't find central directory in zip"
+msgstr "nie można znaleźć centralnego katalogu zip"
+
+#: ../src/common/zipstrm.cpp:1812
+msgid "error reading zip central directory"
+msgstr "błąd przy odczycie centralnego katalogu zip"
+
+#: ../src/common/zipstrm.cpp:1916
+msgid "error reading zip local header"
+msgstr "błąd odczytu lokalnego nagłówka zip"
+
+#: ../src/common/zipstrm.cpp:1964
+msgid "bad zipfile offset to entry"
+msgstr "błędne przemieszczenie w pliku zip"
+
+#: ../src/common/zipstrm.cpp:2031
+msgid "stored file length not in Zip header"
+msgstr "długość pliku nie w nagłówku Zip"
+
+#: ../src/common/zipstrm.cpp:2045 ../src/common/zipstrm.cpp:2362
+msgid "unsupported Zip compression method"
+msgstr "niewspierana metoda kompresji Zip"
+
+#: ../src/common/zipstrm.cpp:2126
+#, c-format
+msgid "reading zip stream (entry %s): bad length"
+msgstr "odczyt strumienia zip (%s): niepoprawna długość"
+
+#: ../src/common/zipstrm.cpp:2131
+#, c-format
+msgid "reading zip stream (entry %s): bad crc"
+msgstr "odczyt strumienia zip (%s): niepoprawna sygnatura crc"
+
+#: ../src/common/zipstrm.cpp:2578
+#, fuzzy, c-format
+msgid "error writing zip entry '%s': file too large without ZIP64"
+msgstr "błąd zapisu zip '%s': niepoprawna sygnatura crc lub długość"
+
+#: ../src/common/zipstrm.cpp:2585
+#, c-format
+msgid "error writing zip entry '%s': bad crc or length"
+msgstr "błąd zapisu zip '%s': niepoprawna sygnatura crc lub długość"
+
+#: ../src/common/zstream.cpp:155 ../src/common/zstream.cpp:315
+msgid "Gzip not supported by this version of zlib"
+msgstr "Format Gzip nie jest wspierany przez tę wersję biblioteki zlib"
+
+#: ../src/common/zstream.cpp:182
+msgid "Can't initialize zlib inflate stream."
+msgstr "Nie można zainicjować strumienia dekompresji biblioteki zlib."
+
+#: ../src/common/zstream.cpp:241
+msgid "Can't read inflate stream: unexpected EOF in underlying stream."
+msgstr ""
+"Nie można odczytać dekompresowanego strumienia: nieoczekiwany koniec w "
+"strumieniu."
+
+#: ../src/common/zstream.cpp:248 ../src/common/zstream.cpp:423
+#, c-format
+msgid "zlib error %d"
+msgstr "błąd biblioteki zlib %d"
+
+#: ../src/common/zstream.cpp:249
+#, c-format
+msgid "Can't read from inflate stream: %s"
+msgstr "Nie można czytać z dekompresowanego strumienia: %s"
+
+#: ../src/common/zstream.cpp:343
+msgid "Can't initialize zlib deflate stream."
+msgstr "Nie można zainicjować strumienia kompresji biblioteki zlib."
+
+#: ../src/common/zstream.cpp:424
+#, c-format
+msgid "Can't write to deflate stream: %s"
+msgstr "Nie można zapisywać do kompresowanego strumienia: %s"
+
+#: ../src/dfb/bitmap.cpp:633 ../src/dfb/bitmap.cpp:667
+#, c-format
+msgid "No bitmap handler for type %d defined."
+msgstr "Brak procedury obsługi bitmapy dla typu %d."
+
+#: ../src/dfb/evtloop.cpp:99
+msgid "Failed to read event from DirectFB pipe"
+msgstr "Błąd odczytu z potoku DirectFB"
+
+#: ../src/dfb/evtloop.cpp:171
+msgid "Failed to switch DirectFB pipe to non-blocking mode"
+msgstr "Błąd podczas próby zmiany potoku DirectFB na tryb nieblokujący"
+
+#: ../src/dfb/fontmgr.cpp:171
+#, c-format
+msgid "no fonts found in %s, using builtin font"
+msgstr "nie znaleziono czcionek w %s, wykorzystując czcionki wypunktowania"
+
+#: ../src/dfb/fontmgr.cpp:177
+msgid "Default font"
+msgstr "Domyślna czcionka"
+
+#: ../src/dfb/fontmgr.cpp:195
+#, c-format
+msgid "Fonts index file %s disappeared while loading fonts."
+msgstr "Plik indeksu czcionek %s znikł podczas ładowania czcionek."
+
+#: ../src/dfb/wrapdfb.cpp:60
+#, c-format
+msgid "DirectFB error %d occurred."
+msgstr "Wystąpił błąd DirectFB: %d"
+
+#: ../src/generic/aboutdlgg.cpp:69
+msgid "Developed by "
+msgstr "Opracowane przez "
+
+#: ../src/generic/aboutdlgg.cpp:72
+msgid "Documentation by "
+msgstr "Dokumentacja autorstwa"
+
+#: ../src/generic/aboutdlgg.cpp:75
+msgid "Graphics art by "
+msgstr "Grafika autorstwa "
+
+#: ../src/generic/aboutdlgg.cpp:78
+msgid "Translations by "
+msgstr "Tłumaczenia autorstwa "
+
+# prawa?
+#: ../src/generic/aboutdlgg.cpp:133 ../src/osx/cocoa/aboutdlg.mm:83
+msgid "Version "
+msgstr "Wersja"
+
+#. TRANSLATORS: %s is application name
+#: ../src/generic/aboutdlgg.cpp:146 ../src/msw/aboutdlg.cpp:60
+#, c-format
+msgid "About %s"
+msgstr "O %s"
+
+#: ../src/generic/aboutdlgg.cpp:181
+msgid "License"
+msgstr "Licencja"
+
+#: ../src/generic/aboutdlgg.cpp:184
+msgid "Developers"
+msgstr "Programiści"
+
+#: ../src/generic/aboutdlgg.cpp:188
+msgid "Documentation writers"
+msgstr "Autorzy dokumentacji"
+
+#: ../src/generic/aboutdlgg.cpp:192
+msgid "Artists"
+msgstr "Artyści"
+
+#: ../src/generic/aboutdlgg.cpp:196
+msgid "Translators"
+msgstr "Tłumacze"
+
+#: ../src/generic/animateg.cpp:125
+msgid "No handler found for animation type."
+msgstr "Brak procedury obsługi typu animacji."
+
+#: ../src/generic/animateg.cpp:133
+#, c-format
+msgid "No animation handler for type %ld defined."
+msgstr "Brak procedury obsługi animacji dla typu %ld."
+
+#: ../src/generic/animateg.cpp:145
+#, c-format
+msgid "Animation file is not of type %ld."
+msgstr "Plik animacyjny nie jest typu %ld."
+
+#: ../src/generic/colrdlgg.cpp:154 ../src/gtk/colordlg.cpp:47
+msgid "Choose colour"
+msgstr "Wybierz kolor"
+
+#: ../src/generic/colrdlgg.cpp:357
+msgid "Red:"
+msgstr ""
+
+#: ../src/generic/colrdlgg.cpp:360
+#, fuzzy
+msgid "Green:"
+msgstr "MacGrecki"
+
+#: ../src/generic/colrdlgg.cpp:363
+msgid "Blue:"
+msgstr ""
+
+#: ../src/generic/colrdlgg.cpp:372
+msgid "Opacity:"
+msgstr ""
+
+#: ../src/generic/colrdlgg.cpp:384
+msgid "Add to custom colours"
+msgstr "Dodaj do kolorów niestandardowych"
+
+#: ../src/generic/creddlgg.cpp:56
+msgid "Username:"
+msgstr ""
+
+#: ../src/generic/creddlgg.cpp:63
+msgid "Password:"
+msgstr ""
+
+#. TRANSLATORS: Name of Boolean true value
+#: ../src/generic/datavgen.cpp:1178
+msgid "true"
+msgstr ""
+
+#. TRANSLATORS: Name of Boolean false value
+#: ../src/generic/datavgen.cpp:1180
+#, fuzzy
+msgid "false"
+msgstr "Fałsz"
+
+#: ../src/generic/datavgen.cpp:6897
+#, c-format
+msgid "Row %i"
+msgstr ""
+
+#. TRANSLATORS: Action for manipulating a tree control
+#: ../src/generic/datavgen.cpp:6987
+msgid "Collapse"
+msgstr ""
+
+#. TRANSLATORS: Action for manipulating a tree control
+#: ../src/generic/datavgen.cpp:6990
+msgid "Expand"
+msgstr ""
+
+#. TRANSLATORS: Name of data view control and number of rows
+#: ../src/generic/datavgen.cpp:7011
+#, fuzzy, c-format
+msgid "%s (%d items)"
+msgstr "%s (lub %s)"
+
+#: ../src/generic/datavgen.cpp:7062
+#, fuzzy, c-format
+msgid "Column %u"
+msgstr "Dodaj kolumnę"
+
+#. TRANSLATORS: Keystroke for manipulating a tree control
+#: ../src/generic/datavgen.cpp:7131 ../src/richtext/richtextbulletspage.cpp:189
+#: ../src/richtext/richtextbulletspage.cpp:192
+#: ../src/richtext/richtextbulletspage.cpp:193
+#: ../src/richtext/richtextliststylepage.cpp:252
+#: ../src/richtext/richtextliststylepage.cpp:255
+#: ../src/richtext/richtextliststylepage.cpp:256
+#: ../src/richtext/richtextsizepage.cpp:248
+msgid "Left"
+msgstr "Lewo"
+
+#. TRANSLATORS: Keystroke for manipulating a tree control
+#: ../src/generic/datavgen.cpp:7134 ../src/richtext/richtextbulletspage.cpp:191
+#: ../src/richtext/richtextliststylepage.cpp:254
+#: ../src/richtext/richtextsizepage.cpp:249
+msgid "Right"
+msgstr "Prawy"
+
+#: ../src/generic/datectlg.cpp:90
+#, c-format
+msgid ""
+"\"%s\" is not in the expected date format, please enter it as e.g. \"%s\"."
+msgstr ""
+
+#: ../src/generic/datectlg.cpp:94
+#, fuzzy
+msgid "Invalid date"
+msgstr "Nieprawidłowa pozycja widoku danych"
+
+#: ../src/generic/dbgrptg.cpp:159
+#, c-format
+msgid "Open file \"%s\""
+msgstr "Otwieranie pliku \"%s\""
+
+#: ../src/generic/dbgrptg.cpp:170
+#, c-format
+msgid "Enter command to open file \"%s\":"
+msgstr "Wprowadź komendę otwierającą plik \"%s\":"
+
+#: ../src/generic/dbgrptg.cpp:230
+msgid "Executable files (*.exe)|*.exe|"
+msgstr "Pliki wykonywalne (*.exe)|*.exe|"
+
+#: ../src/generic/dbgrptg.cpp:300
+#, c-format
+msgid "Debug report \"%s\""
+msgstr "Raport błędów \"%s\""
+
+#: ../src/generic/dbgrptg.cpp:316
+msgid "A debug report has been generated in the directory\n"
+msgstr "Raport błędów został wygenerowany w katalogu\n"
+
+#: ../src/generic/dbgrptg.cpp:317
+#, fuzzy
+msgid "The following debug report will be generated\n"
+msgstr "*** Raport błędów został wygenerowany\n"
+
+#: ../src/generic/dbgrptg.cpp:321
+msgid ""
+"The report contains the files listed below. If any of these files contain "
+"private information,\n"
+"please uncheck them and they will be removed from the report.\n"
+msgstr ""
+"Raport zawiera pliki wymienione niżej. Jeśli którykolwiek z tych plików "
+"zawiera prywatne informacje,\n"
+"proszę odznacz go w celu usunięcia go z raportu.\n"
+
+#: ../src/generic/dbgrptg.cpp:323
+msgid ""
+"If you wish to suppress this debug report completely, please choose the "
+"\"Cancel\" button,\n"
+"but be warned that it may hinder improving the program, so if\n"
+"at all possible please do continue with the report generation.\n"
+msgstr ""
+"Jeśli chcesz całkowicie pominąć raport błędów, wybierz \"Anuluj\",\n"
+"ale rozważ że to może utrudnić usprawnianie oprogramowania,\n"
+"w związku z tym zachęcamy do kontynuowania raportowania błędów.\n"
+
+#: ../src/generic/dbgrptg.cpp:325
+msgid "              Thank you and we're sorry for the inconvenience!\n"
+msgstr "              Dziękujemy i przepraszamy za niedogodności!\n"
+
+#: ../src/generic/dbgrptg.cpp:333
+msgid "&Debug report preview:"
+msgstr "Po&dgląd raportu błędów:"
+
+#: ../src/generic/dbgrptg.cpp:339
+msgid "&View..."
+msgstr "&Widok..."
+
+#: ../src/generic/dbgrptg.cpp:359
+msgid "&Notes:"
+msgstr "&Uwagi:"
+
+#: ../src/generic/dbgrptg.cpp:361
+msgid ""
+"If you have any additional information pertaining to this bug\n"
+"report, please enter it here and it will be joined to it:"
+msgstr ""
+"Jeśli masz jakiekolwiek dodatkowe informacje odnośnie\n"
+"raportowanego błędu, proszę dołącz je tu:"
+
+#: ../src/generic/dcpsg.cpp:1627
+msgid "Cannot open file for PostScript printing!"
+msgstr "Nie można otworzyć pliku dla drukowania postscriptowego!"
+
+#: ../src/generic/dirctrlg.cpp:402
+msgid "Computer"
+msgstr "Komputer"
+
+#: ../src/generic/dirctrlg.cpp:404
+msgid "Sections"
+msgstr "Sekcje"
+
+#: ../src/generic/dirctrlg.cpp:482
+msgid "Home directory"
+msgstr "Katalog początkowy"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/generic/dirctrlg.cpp:484 ../src/propgrid/advprops.cpp:811
+msgid "Desktop"
+msgstr "Pulpit"
+
+#: ../src/generic/dirctrlg.cpp:528 ../src/generic/filectrlg.cpp:752
+msgid "Illegal directory name."
+msgstr "Niedozwolona nazwa katalogu."
+
+#: ../src/generic/dirctrlg.cpp:528 ../src/generic/dirctrlg.cpp:546
+#: ../src/generic/dirctrlg.cpp:557 ../src/generic/dirdlgg.cpp:317
+#: ../src/generic/filectrlg.cpp:638 ../src/generic/filectrlg.cpp:752
+#: ../src/generic/filectrlg.cpp:766 ../src/generic/filectrlg.cpp:782
+#: ../src/generic/filectrlg.cpp:1356 ../src/generic/filectrlg.cpp:1387
+#: ../src/generic/filedlgg.cpp:362 ../src/gtk/filedlg.cpp:76
+msgid "Error"
+msgstr "Błąd"
+
+#: ../src/generic/dirctrlg.cpp:546 ../src/generic/filectrlg.cpp:766
+msgid "File name exists already."
+msgstr "Plik o tej nazwie już istnieje."
+
+#: ../src/generic/dirctrlg.cpp:557 ../src/generic/dirdlgg.cpp:317
+#: ../src/generic/filectrlg.cpp:638 ../src/generic/filectrlg.cpp:782
+msgid "Operation not permitted."
+msgstr "Operacja nie jest dozwolona."
+
+#: ../src/generic/dirdlgg.cpp:107 ../src/generic/filedlgg.cpp:207
+msgid "Create new directory"
+msgstr "Utwórz nowy katalog"
+
+#: ../src/generic/dirdlgg.cpp:112 ../src/generic/filedlgg.cpp:203
+msgid "Go to home directory"
+msgstr "Idź do katalogu domowego"
+
+#: ../src/generic/dirdlgg.cpp:143
+msgid "Show &hidden directories"
+msgstr "Pokaż &ukryte katalogi"
+
+#: ../src/generic/dirdlgg.cpp:196
+#, c-format
+msgid ""
+"The directory '%s' does not exist\n"
+"Create it now?"
+msgstr ""
+"Katalog '%s' nie istnieje\n"
+"Utworzyć go teraz?"
+
+#: ../src/generic/dirdlgg.cpp:198
+msgid "Directory does not exist"
+msgstr "Katalog nie istnieje"
+
+#: ../src/generic/dirdlgg.cpp:214
+#, c-format
+msgid ""
+"Failed to create directory '%s'\n"
+"(Do you have the required permissions?)"
+msgstr ""
+"Nie udało się utworzyć katalogu '%s'\n"
+"(Posiadasz wymagane prawa dostępu?)"
+
+#: ../src/generic/dirdlgg.cpp:216
+msgid "Error creating directory"
+msgstr "Błąd przy tworzeniu katalogu"
+
+#: ../src/generic/dirdlgg.cpp:281
+msgid "You cannot add a new directory to this section."
+msgstr "Nie możesz dodać nowego katalogu do tej sekcji."
+
+#: ../src/generic/dirdlgg.cpp:282
+msgid "Create directory"
+msgstr "Tworzenie katalogu"
+
+# To jest maska do tworzenia nazw typu NowaNaz1 itd
+#: ../src/generic/dirdlgg.cpp:291 ../src/generic/dirdlgg.cpp:301
+#: ../src/generic/filectrlg.cpp:614 ../src/generic/filectrlg.cpp:623
+msgid "NewName"
+msgstr "NowaNaz"
+
+#: ../src/generic/editlbox.cpp:135
+msgid "Edit item"
+msgstr "Edytuj pozycję"
+
+#: ../src/generic/editlbox.cpp:143
+msgid "New item"
+msgstr "Nowa pozycja"
+
+#: ../src/generic/editlbox.cpp:151
+msgid "Delete item"
+msgstr "Usuń pozycję"
+
+#: ../src/generic/editlbox.cpp:159
+msgid "Move up"
+msgstr "Przenieś w górę"
+
+#: ../src/generic/editlbox.cpp:164
+msgid "Move down"
+msgstr "Przenieś w dół"
+
+#: ../src/generic/fdrepdlg.cpp:108
+msgid "Search for:"
+msgstr "Znajdź:"
+
+#: ../src/generic/fdrepdlg.cpp:120
+msgid "Replace with:"
+msgstr "Zastąp przez:"
+
+#: ../src/generic/fdrepdlg.cpp:140
+msgid "Whole word"
+msgstr "Całe słowo"
+
+#: ../src/generic/fdrepdlg.cpp:143
+msgid "Match case"
+msgstr "Uwzględniaj wielkość liter"
+
+#: ../src/generic/fdrepdlg.cpp:156
+msgid "Search direction"
+msgstr "Kierunek szukania"
+
+#: ../src/generic/fdrepdlg.cpp:175
+msgid "&Replace"
+msgstr "&Zastąp"
+
+#: ../src/generic/fdrepdlg.cpp:178
+msgid "Replace &all"
+msgstr "Zastąp &wszystko"
+
+#: ../src/generic/filectrlg.cpp:246 ../src/generic/filectrlg.cpp:269
+msgid "<DIR>"
+msgstr "<KATALOG>"
+
+#: ../src/generic/filectrlg.cpp:248 ../src/generic/filectrlg.cpp:271
+msgid "<LINK>"
+msgstr "<ŁĄCZE>"
+
+#: ../src/generic/filectrlg.cpp:250 ../src/generic/filectrlg.cpp:273
+msgid "<DRIVE>"
+msgstr "<NAPĘD>"
+
+#: ../src/generic/filectrlg.cpp:275
+#, c-format
+msgid "%ld byte"
+msgid_plural "%ld bytes"
+msgstr[0] "%ld bajt"
+msgstr[1] "%ld bajty"
+msgstr[2] "%ld bajtów"
+
+#: ../src/generic/filectrlg.cpp:420
+msgid "Name"
+msgstr "Nazwa"
+
+#: ../src/generic/filectrlg.cpp:421 ../src/richtext/richtextformatdlg.cpp:361
+#: ../src/richtext/richtextsizepage.cpp:298
+msgid "Size"
+msgstr "Rozmiar"
+
+#: ../src/generic/filectrlg.cpp:422
+msgid "Type"
+msgstr "Typ"
+
+#: ../src/generic/filectrlg.cpp:423
+msgid "Modified"
+msgstr "Zmodyfikowany"
+
+# prawa?
+#: ../src/generic/filectrlg.cpp:426
+msgid "Permissions"
+msgstr "Uprawnienia"
+
+#: ../src/generic/filectrlg.cpp:429
+msgid "Attributes"
+msgstr "Właściwości"
+
+#: ../src/generic/filectrlg.cpp:936
+msgid "Current directory:"
+msgstr "Bieżący katalog:"
+
+#: ../src/generic/filectrlg.cpp:979
+msgid "Show &hidden files"
+msgstr "Pokazuj &ukryte pliki"
+
+#: ../src/generic/filectrlg.cpp:1355
+msgid "Illegal file specification."
+msgstr "Niedozwolona specyfikacja pliku."
+
+#: ../src/generic/filectrlg.cpp:1387
+msgid "Directory doesn't exist."
+msgstr "Katalog nie istnieje."
+
+#: ../src/generic/filedlgg.cpp:195
+msgid "View files as a list view"
+msgstr "Przeglądaj pliki w formie listy"
+
+#: ../src/generic/filedlgg.cpp:197
+msgid "View files as a detailed view"
+msgstr "Przeglądaj pliki w formie szczegółowej listy"
+
+#: ../src/generic/filedlgg.cpp:200
+msgid "Go to parent directory"
+msgstr "Idź do katalogu nadrzędnego"
+
+#: ../src/generic/filedlgg.cpp:351 ../src/gtk/filedlg.cpp:59
+#, c-format
+msgid "File '%s' already exists, do you really want to overwrite it?"
+msgstr "Plik '%s' już istnieje, naprawdę chcesz go zastąpić?"
+
+#: ../src/generic/filedlgg.cpp:354 ../src/gtk/filedlg.cpp:62
+msgid "Confirm"
+msgstr "Potwierdź"
+
+#: ../src/generic/filedlgg.cpp:362 ../src/gtk/filedlg.cpp:75
+msgid "Please choose an existing file."
+msgstr "Proszę wybrać istniejący plik."
+
+#: ../src/generic/filepickerg.cpp:64
+msgid "..."
+msgstr "..."
+
+#: ../src/generic/fontdlgg.cpp:76 ../src/richtext/richtextformatdlg.cpp:519
+msgid "ABCDEFGabcdefg12345"
+msgstr "ABCDEFGabcdefg12345"
+
+#: ../src/generic/fontdlgg.cpp:315
+msgid "Roman"
+msgstr "Roman"
+
+#: ../src/generic/fontdlgg.cpp:316
+msgid "Decorative"
+msgstr "Decorative"
+
+#: ../src/generic/fontdlgg.cpp:317
+msgid "Modern"
+msgstr "Modern"
+
+#: ../src/generic/fontdlgg.cpp:318
+msgid "Script"
+msgstr "Script"
+
+#: ../src/generic/fontdlgg.cpp:319
+msgid "Swiss"
+msgstr "Swiss"
+
+#: ../src/generic/fontdlgg.cpp:320
+msgid "Teletype"
+msgstr "Teletype"
+
+#: ../src/generic/fontdlgg.cpp:321 ../src/generic/fontdlgg.cpp:324
+msgid "Normal"
+msgstr "Normalny"
+
+#: ../src/generic/fontdlgg.cpp:323
+msgid "Slant"
+msgstr "Pochylony"
+
+#: ../src/generic/fontdlgg.cpp:325
+msgid "Light"
+msgstr "Cieńszy"
+
+#: ../src/generic/fontdlgg.cpp:363
+msgid "&Font family:"
+msgstr "&Rozmiar czcionki:"
+
+#: ../src/generic/fontdlgg.cpp:367 ../src/generic/fontdlgg.cpp:369
+msgid "The font family."
+msgstr "Rodzina czcionki."
+
+#: ../src/generic/fontdlgg.cpp:374 ../src/richtext/richtextstylepage.cpp:105
+msgid "&Style:"
+msgstr "&Styl:"
+
+#: ../src/generic/fontdlgg.cpp:378 ../src/generic/fontdlgg.cpp:380
+msgid "The font style."
+msgstr "Styl czcionki."
+
+#: ../src/generic/fontdlgg.cpp:385
+msgid "&Weight:"
+msgstr "&Waga"
+
+#: ../src/generic/fontdlgg.cpp:389 ../src/generic/fontdlgg.cpp:391
+msgid "The font weight."
+msgstr "Waga czcionki."
+
+#: ../src/generic/fontdlgg.cpp:399
+msgid "C&olour:"
+msgstr "K&olor:"
+
+#: ../src/generic/fontdlgg.cpp:407 ../src/generic/fontdlgg.cpp:409
+msgid "The font colour."
+msgstr "Kolor czcionki."
+
+#: ../src/generic/fontdlgg.cpp:415
+msgid "&Point size:"
+msgstr "&Rozmiar punktu:"
+
+#: ../src/generic/fontdlgg.cpp:420 ../src/generic/fontdlgg.cpp:422
+#: ../src/generic/fontdlgg.cpp:426 ../src/generic/fontdlgg.cpp:428
+msgid "The font point size."
+msgstr "Rozmiar czcionki."
+
+#: ../src/generic/fontdlgg.cpp:439 ../src/generic/fontdlgg.cpp:441
+msgid "Whether the font is underlined."
+msgstr "Określenie podkreślenia."
+
+#: ../src/generic/fontdlgg.cpp:448 ../src/html/helpwnd.cpp:1215
+msgid "Preview:"
+msgstr "Podgląd:"
+
+#: ../src/generic/fontdlgg.cpp:452 ../src/generic/fontdlgg.cpp:454
+msgid "Shows the font preview."
+msgstr "Podgląd czcionki."
+
+#: ../src/generic/fontdlgg.cpp:464 ../src/generic/fontdlgg.cpp:483
+msgid "Click to cancel the font selection."
+msgstr "Anulowanie wyboru czcionki"
+
+#: ../src/generic/fontdlgg.cpp:469 ../src/generic/fontdlgg.cpp:471
+#: ../src/generic/fontdlgg.cpp:476 ../src/generic/fontdlgg.cpp:478
+msgid "Click to confirm the font selection."
+msgstr "Potwierdzenie wyboru czcionki."
+
+#: ../src/generic/fontpickerg.cpp:50 ../src/gtk/fontdlg.cpp:77
+msgid "Choose font"
+msgstr "Wybierz czcionkę"
+
+#: ../src/generic/grid.cpp:6542
+msgid ""
+"Error copying grid to the clipboard. Either selected cells were not "
+"contiguous or no cell was selected."
+msgstr ""
+
+#: ../src/generic/grid.cpp:12739
+msgid "Grid Corner"
+msgstr ""
+
+#: ../src/generic/grid.cpp:12741
+#, fuzzy, c-format
+msgid "Column %s Header"
+msgstr "Dodaj kolumnę"
+
+#: ../src/generic/grid.cpp:12743
+#, c-format
+msgid "Row %s Header"
+msgstr ""
+
+#: ../src/generic/grid.cpp:12745
+#, fuzzy, c-format
+msgid "Column %s: %s"
+msgstr "Dodaj kolumnę"
+
+#: ../src/generic/grid.cpp:12749
+#, fuzzy, c-format
+msgid "Row %s: %s"
+msgstr "\t%s: %s\n"
+
+#: ../src/generic/grid.cpp:12753
+#, c-format
+msgid "Row %s, Column %s: %s"
+msgstr ""
+
+#: ../src/generic/helpext.cpp:257
+#, c-format
+msgid "Help directory \"%s\" not found."
+msgstr "Nie znaleziono katalogu pomocy \"%s\"."
+
+# catalog file --> ?
+# domain --> ?
+#: ../src/generic/helpext.cpp:265
+#, c-format
+msgid "Help file \"%s\" not found."
+msgstr "Nie znaleziono pliku pomocy \"%s\"."
+
+#: ../src/generic/helpext.cpp:284
+#, c-format
+msgid "Line %lu of map file \"%s\" has invalid syntax, skipped."
+msgstr ""
+"Linijka %lu pliku mapy \"%s\" posiada nieprawidłową składnię, pominięta."
+
+#: ../src/generic/helpext.cpp:292
+#, c-format
+msgid "No valid mappings found in the file \"%s\"."
+msgstr "Znaleziono nie ważne mapowania w pliku \"%s\"."
+
+#: ../src/generic/helpext.cpp:435
+msgid "No entries found."
+msgstr "Nie znaleziono pozycji."
+
+#: ../src/generic/helpext.cpp:444 ../src/generic/helpext.cpp:445
+msgid "Help Index"
+msgstr "Spis treści"
+
+#: ../src/generic/helpext.cpp:448
+msgid "Relevant entries:"
+msgstr "Pozycje związane:"
+
+#: ../src/generic/helpext.cpp:449
+msgid "Entries found"
+msgstr "Znalezione pozycje"
+
+#: ../src/generic/hyperlinkg.cpp:170
+msgid "&Copy URL"
+msgstr "&Kopiuj URL"
+
+#: ../src/generic/infobar.cpp:119
+msgid "Hide this notification message."
+msgstr "Ukryj to powiadomienie."
+
+#. TRANSLATORS: %s will be either the application name or "Application"
+#: ../src/generic/logg.cpp:257
+#, c-format
+msgid "%s Error"
+msgstr "%s Błąd"
+
+#. TRANSLATORS: %s will be either the application name or "Application"
+#: ../src/generic/logg.cpp:263
+#, c-format
+msgid "%s Warning"
+msgstr "%s Ostrzeżenie"
+
+#. TRANSLATORS: %s will be either the application name or "Application"
+#: ../src/generic/logg.cpp:273
+#, c-format
+msgid "%s Information"
+msgstr "%s Informacja"
+
+#: ../src/generic/logg.cpp:276
+msgid "Application"
+msgstr "Aplikacja"
+
+#: ../src/generic/logg.cpp:549
+msgid "Save log contents to file"
+msgstr "Zapisz zawartość dziennika do pliku"
+
+#: ../src/generic/logg.cpp:551
+msgid "C&lear"
+msgstr "&Wyczyść"
+
+#: ../src/generic/logg.cpp:551
+msgid "Clear the log contents"
+msgstr "Wyczyść zawartość dziennika"
+
+#: ../src/generic/logg.cpp:553
+msgid "Close this window"
+msgstr "Zamknij to okno"
+
+#: ../src/generic/logg.cpp:554
+msgid "&Log"
+msgstr "&Dziennik"
+
+#: ../src/generic/logg.cpp:610 ../src/generic/logg.cpp:992
+msgid "Can't save log contents to file."
+msgstr "Nie można zapisać zawartości dziennika w pliku."
+
+#: ../src/generic/logg.cpp:613
+#, c-format
+msgid "Log saved to the file '%s'."
+msgstr "Log został zapisany do pliku '%s'."
+
+#: ../src/generic/logg.cpp:719
+msgid "&Details"
+msgstr "&Szczegóły"
+
+#: ../src/generic/logg.cpp:972
+msgid "Failed to copy dialog contents to the clipboard."
+msgstr "Nie udało się skopiować treści dialogu do schowka."
+
+#: ../src/generic/logg.cpp:1022
+#, c-format
+msgid "Append log to file '%s' (choosing [No] will overwrite it)?"
+msgstr "Dołączyć dziennik do pliku '%s' (wybierając [Nie] zastąpisz go)?"
+
+#: ../src/generic/logg.cpp:1024
+msgid "Question"
+msgstr "Pytanie"
+
+#: ../src/generic/logg.cpp:1038
+msgid "invalid message box return value"
+msgstr "wartość zwrócona przez okno komunikatu jest nieprawidłowa"
+
+#: ../src/generic/notifmsgg.cpp:129
+msgid "Notice"
+msgstr "Uwaga"
+
+#: ../src/generic/preferencesg.cpp:118
+#, c-format
+msgid "%s Preferences"
+msgstr "Preferencje %s"
+
+#: ../src/generic/printps.cpp:143
+msgid "Printing..."
+msgstr "Drukowanie..."
+
+#: ../src/generic/printps.cpp:160 ../src/gtk/print.cpp:1076
+#: ../src/msw/printwin.cpp:235
+msgid "Could not start printing."
+msgstr "Nie można rozpocząć drukowania."
+
+#: ../src/generic/printps.cpp:183
+#, c-format
+msgid "Printing page %d..."
+msgstr "Drukowanie strony %d..."
+
+#: ../src/generic/prntdlgg.cpp:171
+msgid "Printer options"
+msgstr "Opcje drukarki"
+
+#: ../src/generic/prntdlgg.cpp:176
+msgid "Print to File"
+msgstr "Drukuj do pliku"
+
+#: ../src/generic/prntdlgg.cpp:179
+msgid "Setup..."
+msgstr "Ustawienia..."
+
+#: ../src/generic/prntdlgg.cpp:187
+msgid "Printer:"
+msgstr "Drukarka:"
+
+#: ../src/generic/prntdlgg.cpp:195
+msgid "Status:"
+msgstr "Status:"
+
+#: ../src/generic/prntdlgg.cpp:206
+msgid "All"
+msgstr "Wszystko"
+
+#: ../src/generic/prntdlgg.cpp:207
+msgid "Pages"
+msgstr "Strony"
+
+#: ../src/generic/prntdlgg.cpp:215
+msgid "Print Range"
+msgstr "Zakres wydruku"
+
+#: ../src/generic/prntdlgg.cpp:229
+msgid "From:"
+msgstr "Od:"
+
+#: ../src/generic/prntdlgg.cpp:233
+msgid "To:"
+msgstr "Do:"
+
+#: ../src/generic/prntdlgg.cpp:238
+msgid "Copies:"
+msgstr "Kopie:"
+
+#: ../src/generic/prntdlgg.cpp:288
+msgid "PostScript file"
+msgstr "plik PostScript"
+
+#: ../src/generic/prntdlgg.cpp:439
+msgid "Print Setup"
+msgstr "Ustawienia wydruku"
+
+#: ../src/generic/prntdlgg.cpp:483
+msgid "Printer"
+msgstr "Drukarka"
+
+#: ../src/generic/prntdlgg.cpp:501
+msgid "Default printer"
+msgstr "Domyślna drukarka"
+
+#: ../src/generic/prntdlgg.cpp:595 ../src/generic/prntdlgg.cpp:782
+#: ../src/generic/prntdlgg.cpp:822 ../src/generic/prntdlgg.cpp:835
+#: ../src/generic/prntdlgg.cpp:1031 ../src/generic/prntdlgg.cpp:1036
+msgid "Paper size"
+msgstr "Rozmiar papieru"
+
+#: ../src/generic/prntdlgg.cpp:604 ../src/generic/prntdlgg.cpp:847
+msgid "Portrait"
+msgstr "Portret"
+
+#: ../src/generic/prntdlgg.cpp:605 ../src/generic/prntdlgg.cpp:848
+msgid "Landscape"
+msgstr "Pejzaż"
+
+#: ../src/generic/prntdlgg.cpp:607 ../src/generic/prntdlgg.cpp:849
+msgid "Orientation"
+msgstr "Orientacja"
+
+#: ../src/generic/prntdlgg.cpp:610
+msgid "Options"
+msgstr "Opcje"
+
+#: ../src/generic/prntdlgg.cpp:612
+msgid "Print in colour"
+msgstr "Wydruk w kolorze"
+
+#: ../src/generic/prntdlgg.cpp:621
+msgid "Print spooling"
+msgstr "Kolejkowanie wydruków"
+
+#: ../src/generic/prntdlgg.cpp:623
+msgid "Printer command:"
+msgstr "Polecenie drukarki:"
+
+#: ../src/generic/prntdlgg.cpp:631
+msgid "Printer options:"
+msgstr "Opcje drukarki:"
+
+#: ../src/generic/prntdlgg.cpp:860
+msgid "Left margin (mm):"
+msgstr "Lewy margines (mm):"
+
+#: ../src/generic/prntdlgg.cpp:861
+msgid "Top margin (mm):"
+msgstr "Górny margines (mm):"
+
+#: ../src/generic/prntdlgg.cpp:872
+msgid "Right margin (mm):"
+msgstr "Prawy margines (mm):"
+
+#: ../src/generic/prntdlgg.cpp:873
+msgid "Bottom margin (mm):"
+msgstr "Dolny margines (mm):"
+
+#: ../src/generic/prntdlgg.cpp:896
+msgid "Printer..."
+msgstr "Drukarka..."
+
+#: ../src/generic/progdlgg.cpp:246
+msgid "&Skip"
+msgstr "&Pomiń"
+
+#: ../src/generic/progdlgg.cpp:347 ../src/generic/progdlgg.cpp:626
+msgid "Unknown"
+msgstr "Nieznany"
+
+#: ../src/generic/progdlgg.cpp:451 ../src/msw/progdlg.cpp:526
+msgid "Done."
+msgstr "Zrobione."
+
+#: ../src/generic/srchctlg.cpp:55 ../src/gtk/srchctrl.cpp:206
+#: ../src/html/helpwnd.cpp:530 ../src/html/helpwnd.cpp:545
+msgid "Search"
+msgstr "Szukaj"
+
+#: ../src/generic/tabg.cpp:1026
+msgid "Could not find tab for id"
+msgstr "Nie można znaleźć (tab) dla (id)"
+
+#: ../src/generic/tipdlg.cpp:136
+msgid "Tips not available, sorry!"
+msgstr "Niestety, porady nie są dostępne!"
+
+#: ../src/generic/tipdlg.cpp:197
+msgid "Tip of the Day"
+msgstr "Porada dnia"
+
+#: ../src/generic/tipdlg.cpp:207
+msgid "Did you know..."
+msgstr "Czy wiesz że..."
+
+#: ../src/generic/tipdlg.cpp:232
+msgid "&Show tips at startup"
+msgstr "&Pokazuj porady przy uruchamianiu"
+
+#: ../src/generic/tipdlg.cpp:236
+msgid "&Next Tip"
+msgstr "&Następna porada"
+
+#: ../src/generic/wizard.cpp:411
+msgid "&Next >"
+msgstr "&Dalej >"
+
+#: ../src/generic/wizard.cpp:412
+msgid "&Finish"
+msgstr "Za&kończ"
+
+#: ../src/generic/wizard.cpp:420
+msgid "< &Back"
+msgstr "< &Wstecz"
+
+#: ../src/gtk/aboutdlg.cpp:204
+msgid "translator-credits"
+msgstr "Michał Trzebiatowski"
+
+#: ../src/gtk/app.cpp:517
+msgid ""
+"WARNING: using XIM input method is unsupported and may result in problems "
+"with input handling and flickering. Consider unsetting GTK_IM_MODULE or "
+"setting to \"ibus\"."
+msgstr ""
+
+#: ../src/gtk/app.cpp:569
+msgid "Unable to initialize GTK+, is DISPLAY set properly?"
+msgstr "Nie można ustawić GTK+, czy jest prawidłowo ustawiony EKRAN?"
+
+#: ../src/gtk/filedlg.cpp:89 ../src/gtk/filepicker.cpp:255
+#, fuzzy, c-format
+msgid "Changing current directory to \"%s\" failed"
+msgstr "Nie udało się utworzenie katalogu \"%s\""
+
+#: ../src/gtk/font.cpp:548
+msgid ""
+"Using private fonts is not supported on this system: Pango library is too "
+"old, 1.38 or later required."
+msgstr ""
+
+#: ../src/gtk/font.cpp:558
+#, fuzzy
+msgid "Failed to create font configuration object."
+msgstr "Nie udała się aktualizacja pliku konfiguracyjnego użytkownika."
+
+#: ../src/gtk/font.cpp:568
+#, fuzzy, c-format
+msgid "Failed to add custom font \"%s\"."
+msgstr "Nie udało się wczytanie dokumentu z pliku \"%s\"."
+
+#: ../src/gtk/font.cpp:576
+#, fuzzy
+msgid "Failed to register font configuration using private fonts."
+msgstr "Nie udała się aktualizacja pliku konfiguracyjnego użytkownika."
+
+#: ../src/gtk/glcanvas.cpp:117 ../src/gtk/glcanvas.cpp:132
+#, fuzzy
+msgid "Fatal Error"
+msgstr "Błąd krytyczny "
+
+#: ../src/gtk/glcanvas.cpp:117
+msgid ""
+"This program wasn't compiled with EGL support required under Wayland, "
+"either\n"
+"install EGL libraries and rebuild or run it under X11 backend by setting\n"
+"environment variable GDK_BACKEND=x11 before starting your program."
+msgstr ""
+
+#: ../src/gtk/glcanvas.cpp:132
+msgid ""
+"wxGLCanvas is only supported on Wayland and X11 currently.  You may be able "
+"to\n"
+"work around this by setting environment variable GDK_BACKEND=x11 before\n"
+"starting your program."
+msgstr ""
+
+#: ../src/gtk/mdi.cpp:433
+msgid "MDI child"
+msgstr "potomek MDI"
+
+#: ../src/gtk/power.cpp:188
+#, fuzzy, c-format
+msgid "Failed to open D-Bus connection to the login manager: %s"
+msgstr "Nie udało połączyć się do menedżera sesji: %s"
+
+#: ../src/gtk/power.cpp:214
+#, fuzzy
+msgid "wxWidgets application"
+msgstr "Aplikacja"
+
+#: ../src/gtk/power.cpp:226
+msgid "Application needs to keep running"
+msgstr ""
+
+#: ../src/gtk/power.cpp:233
+msgid "Clean up before suspend"
+msgstr ""
+
+#: ../src/gtk/power.cpp:259
+#, fuzzy, c-format
+msgid "Failed to inhibit sleep: %s"
+msgstr "Nie udało się rozpocząć połączenia dialup: %s"
+
+#: ../src/gtk/power.cpp:265
+msgid "Unexpected response to D-Bus \"Inhibit\" request."
+msgstr ""
+
+#: ../src/gtk/print.cpp:218
+msgid "Custom size"
+msgstr "Rozmiar użytkownika"
+
+#: ../src/gtk/print.cpp:752
+#, fuzzy, c-format
+msgid "Error while printing: %s"
+msgstr "Błąd podczas drukowania:"
+
+#: ../src/gtk/print.cpp:816
+msgid "Page Setup"
+msgstr "Ustawienia strony"
+
+#: ../src/gtk/webview_webkit.cpp:932
+msgid "Retrieving JavaScript script output is not supported with WebKit v1"
+msgstr ""
+
+#: ../src/gtk/webview_webkit2.cpp:1098
+msgid ""
+"Setting proxy is not supported by WebKit, at least version 2.16 is required."
+msgstr ""
+
+#: ../src/gtk/webview_webkit2.cpp:1104
+msgid "This program was compiled without support for setting WebKit proxy."
+msgstr ""
+
+#: ../src/gtk/window.cpp:6289
+msgid ""
+"GTK+ installed on this machine is too old to support screen compositing, "
+"please install GTK+ 2.12 or later."
+msgstr ""
+"GTK+ zainstalowana na tej maszynie jest zbyt stara i nie wspiera kompozycji "
+"ekranu, proszę zainstalować GTK+ 2.12 lub nowszą."
+
+#: ../src/gtk/window.cpp:6307
+msgid ""
+"Compositing not supported by this system, please enable it in your Window "
+"Manager."
+msgstr ""
+"Kompozycje nie są wspierane w tym systemie, proszę je włączyć w managerze."
+
+#: ../src/gtk/window.cpp:6318
+msgid ""
+"This program was compiled with a too old version of GTK+, please rebuild "
+"with GTK+ 2.12 or newer."
+msgstr ""
+"Ten program został skompilowany przy użyciu zbyt starej wersji GTK+, proszę "
+"skompilować ponownie z użyciem GTK+ 2.12 or nowszej."
+
+#: ../src/html/chm.cpp:138
+#, c-format
+msgid "Failed to open CHM archive '%s'."
+msgstr "Nie udało się otworzyć archiwum CHM '%s'."
+
+#: ../src/html/chm.cpp:270
+#, c-format
+msgid "Could not extract %s into %s: %s"
+msgstr "Nie można wydzielić %s do %s: %s"
+
+#: ../src/html/chm.cpp:324
+msgid "no error"
+msgstr "brak błędu"
+
+#: ../src/html/chm.cpp:326
+msgid "bad arguments to library function"
+msgstr "błędne argumenty funkcji bibliotecznej"
+
+#: ../src/html/chm.cpp:328
+msgid "error opening file"
+msgstr "błąd otwarcia pliku"
+
+#: ../src/html/chm.cpp:330
+msgid "read error"
+msgstr "błąd odczytu"
+
+#: ../src/html/chm.cpp:332
+msgid "write error"
+msgstr "błąd zapisu"
+
+#: ../src/html/chm.cpp:334
+msgid "seek error"
+msgstr "błąd przeszukiwania"
+
+#: ../src/html/chm.cpp:338
+msgid "bad signature"
+msgstr "błędne oznaczenie"
+
+#: ../src/html/chm.cpp:340
+msgid "error in data format"
+msgstr "błąd w formacie"
+
+#: ../src/html/chm.cpp:342
+msgid "checksum error"
+msgstr "błąd sumy kontrolnej"
+
+#: ../src/html/chm.cpp:344
+msgid "compression error"
+msgstr "błąd kompresji"
+
+#: ../src/html/chm.cpp:346
+msgid "decompression error"
+msgstr "błąd dekompresji"
+
+#: ../src/html/chm.cpp:437
+#, c-format
+msgid "Could not locate file '%s'."
+msgstr "Nie odnaleziono pliku '%s'."
+
+#: ../src/html/chm.cpp:711
+#, c-format
+msgid "Could not create temporary file '%s'"
+msgstr "Nie można utworzyć tymczasowego pliku '%s'"
+
+#: ../src/html/chm.cpp:718
+#, c-format
+msgid "Extraction of '%s' into '%s' failed."
+msgstr "Pobranie '%s' do '%s' nie powiodło się."
+
+#: ../src/html/chm.cpp:806 ../src/html/chm.cpp:863
+msgid "CHM handler currently supports only local files!"
+msgstr "Obsługa CHM obecnie wspiera tylko pliki lokalne!"
+
+#: ../src/html/chm.cpp:827
+msgid "Link contained '//', converted to absolute link."
+msgstr "Odsyłacz zawierający '//' przekonwertowano do adresu bezwzględnego."
+
+#: ../src/html/helpctrl.cpp:59
+#, c-format
+msgid "Help: %s"
+msgstr "Pomoc: %s"
+
+#: ../src/html/helpctrl.cpp:155
+#, c-format
+msgid "Adding book %s"
+msgstr "Dodawanie książki %s"
+
+#: ../src/html/helpdata.cpp:295
+#, c-format
+msgid "Cannot open contents file: %s"
+msgstr "Nie można otworzyć pliku spisu treści: %s"
+
+#: ../src/html/helpdata.cpp:309
+#, c-format
+msgid "Cannot open index file: %s"
+msgstr "Nie można otworzyć pliku indeksowego: %s"
+
+#: ../src/html/helpdata.cpp:643
+msgid "noname"
+msgstr "beznazwy"
+
+#: ../src/html/helpdata.cpp:652
+#, c-format
+msgid "Cannot open HTML help book: %s"
+msgstr "Nie można otworzyć książki pomocy HTML: %s"
+
+#: ../src/html/helpwnd.cpp:315
+msgid "Displays help as you browse the books on the left."
+msgstr "Wyświetla pomoc podczas przeglądania książek po lewej."
+
+#: ../src/html/helpwnd.cpp:411 ../src/html/helpwnd.cpp:1100
+#: ../src/html/helpwnd.cpp:1735
+msgid "(bookmarks)"
+msgstr "(zakładki)"
+
+#: ../src/html/helpwnd.cpp:424
+msgid "Add current page to bookmarks"
+msgstr "Dodaj bieżącą stronę do listy zakładek"
+
+#: ../src/html/helpwnd.cpp:425
+msgid "Remove current page from bookmarks"
+msgstr "Usuń bieżącą stronę z listy zakładek"
+
+#: ../src/html/helpwnd.cpp:470
+msgid "Contents"
+msgstr "Zawartość"
+
+#: ../src/html/helpwnd.cpp:485
+msgid "Find"
+msgstr "Znajdź"
+
+#: ../src/html/helpwnd.cpp:487
+msgid "Show all"
+msgstr "Pokaż wszystko"
+
+#: ../src/html/helpwnd.cpp:497
+msgid ""
+"Display all index items that contain given substring. Search is case "
+"insensitive."
+msgstr ""
+"Wyświetla wszystkie elementy indeksu zawierające podany łańcuch. Szuka bez "
+"uwzględniania wielkości liter."
+
+#: ../src/html/helpwnd.cpp:498
+msgid "Show all items in index"
+msgstr "Pokaż wszystkie elementy indeksu"
+
+#: ../src/html/helpwnd.cpp:528
+msgid "Case sensitive"
+msgstr "Uwzględniaj wielkość liter"
+
+#: ../src/html/helpwnd.cpp:529
+msgid "Whole words only"
+msgstr "Tylko całe słowa"
+
+#: ../src/html/helpwnd.cpp:532
+msgid ""
+"Search contents of help book(s) for all occurrences of the text you typed "
+"above"
+msgstr ""
+"Przeszukuje zawartość pliku(ów) pomocy dla wszystkich wystąpień "
+"wprowadzonego powyżej tekstu"
+
+#: ../src/html/helpwnd.cpp:653
+msgid "Show/hide navigation panel"
+msgstr "Pokaż/ukryj panel sterowania"
+
+#: ../src/html/helpwnd.cpp:655
+msgid "Go back"
+msgstr "Idź wstecz"
+
+#: ../src/html/helpwnd.cpp:656
+msgid "Go forward"
+msgstr "Idź dalej"
+
+#: ../src/html/helpwnd.cpp:658
+msgid "Go one level up in document hierarchy"
+msgstr "Idź poziom wyżej w hierarchi dokumentu"
+
+#: ../src/html/helpwnd.cpp:666 ../src/html/helpwnd.cpp:1547
+msgid "Open HTML document"
+msgstr "Otwórz dokument HTML"
+
+#: ../src/html/helpwnd.cpp:670
+msgid "Print this page"
+msgstr "Drukuj stronę"
+
+#: ../src/html/helpwnd.cpp:674
+msgid "Display options dialog"
+msgstr "Wyświetl okno dialogowe opcji"
+
+#: ../src/html/helpwnd.cpp:795
+msgid "Please choose the page to display:"
+msgstr "Wybierz stronę do wyświetlenia:"
+
+#: ../src/html/helpwnd.cpp:796
+msgid "Help Topics"
+msgstr "Tematy Pomocy"
+
+#: ../src/html/helpwnd.cpp:852
+msgid "Searching..."
+msgstr "Wyszukiwanie..."
+
+#: ../src/html/helpwnd.cpp:853
+msgid "No matching page found yet"
+msgstr "Jeszcze nie znaleziono pasującej strony"
+
+#: ../src/html/helpwnd.cpp:870
+#, c-format
+msgid "Found %i matches"
+msgstr "Znaleziono %i odpowiednik(i/ów)"
+
+#: ../src/html/helpwnd.cpp:958
+msgid "(Help)"
+msgstr "(Pomoc)"
+
+#: ../src/html/helpwnd.cpp:1026
+#, c-format
+msgid "%d of %lu"
+msgstr "%d z %lu"
+
+#: ../src/html/helpwnd.cpp:1028
+#, c-format
+msgid "%lu of %lu"
+msgstr "%lu z %lu"
+
+# spisach?
+#: ../src/html/helpwnd.cpp:1047
+msgid "Search in all books"
+msgstr "Szukaj we wszystkich plikach pomocy"
+
+#: ../src/html/helpwnd.cpp:1193
+msgid "Help Browser Options"
+msgstr "Opcje przeglądarki pomocy"
+
+#: ../src/html/helpwnd.cpp:1198
+msgid "Normal font:"
+msgstr "Normalna czcionka:"
+
+#: ../src/html/helpwnd.cpp:1199
+msgid "Fixed font:"
+msgstr "Czcionka o stałej szerokości:"
+
+#: ../src/html/helpwnd.cpp:1200
+msgid "Font size:"
+msgstr "Rozmiar czcionki:"
+
+#: ../src/html/helpwnd.cpp:1245
+msgid "font size"
+msgstr "rozmiar czcionki"
+
+#: ../src/html/helpwnd.cpp:1256
+msgid "Normal face<br>and <u>underlined</u>. "
+msgstr "Zwykły tekst<br>i <u>podkreślony</u>. "
+
+#: ../src/html/helpwnd.cpp:1257
+msgid "<i>Italic face.</i> "
+msgstr "<i>Kursywa.</i> "
+
+#: ../src/html/helpwnd.cpp:1258
+msgid "<b>Bold face.</b> "
+msgstr "<b>Pogrubienie.</b> "
+
+#: ../src/html/helpwnd.cpp:1259
+msgid "<b><i>Bold italic face.</i></b><br>"
+msgstr "<b><i>Pogrubiona kursywa.</i></b><br>"
+
+#: ../src/html/helpwnd.cpp:1262
+msgid "Fixed size face.<br> <b>bold</b> <i>italic</i> "
+msgstr "Ustalony rozmiar tekstu.<br> <b>pogrubienie</b> <i>kursywa</i> "
+
+#: ../src/html/helpwnd.cpp:1263
+msgid "<b><i>bold italic <u>underlined</u></i></b><br>"
+msgstr "<b><i>pogrubiona kursywa <u>z podkreśleniem</u></i></b><br>"
+
+# pomoc do drukowania?
+#: ../src/html/helpwnd.cpp:1524
+msgid "Help Printing"
+msgstr "Drukowanie pomocy"
+
+#: ../src/html/helpwnd.cpp:1527
+msgid "Cannot print empty page."
+msgstr "Nie można wydrukować pustej strony."
+
+#: ../src/html/helpwnd.cpp:1540
+msgid "HTML files (*.html;*.htm)|*.html;*.htm|"
+msgstr "Pliki HTML (*.html;*.htm)|*.html;*.htm|"
+
+#: ../src/html/helpwnd.cpp:1541
+msgid "Help books (*.htb)|*.htb|Help books (*.zip)|*.zip|"
+msgstr "Pakiety pomocy (*.htb)|*.htb|Pakiety pomocy (*.zip)|*.zip|"
+
+#: ../src/html/helpwnd.cpp:1542
+msgid "HTML Help Project (*.hhp)|*.hhp|"
+msgstr "Plik projektu pomocy HTML Help (*.hhp)|*.hhp|"
+
+#: ../src/html/helpwnd.cpp:1544
+msgid "Compressed HTML Help file (*.chm)|*.chm|"
+msgstr "Skompresowane pliki pomocy HTML Help (*.chm)|*.chm|"
+
+#: ../src/html/helpwnd.cpp:1671
+#, fuzzy, c-format
+msgid "%i of %u"
+msgstr "%i z %i"
+
+#: ../src/html/helpwnd.cpp:1709
+#, fuzzy, c-format
+msgid "%u of %u"
+msgstr "%lu z %lu"
+
+#: ../src/html/htmlfilt.cpp:134
+#, c-format
+msgid "Cannot open HTML document: %s"
+msgstr "Nie można otworzyć dokumentu HTML: %s"
+
+#: ../src/html/htmlwin.cpp:599
+msgid "Connecting..."
+msgstr "Łączenie..."
+
+#: ../src/html/htmlwin.cpp:616
+#, c-format
+msgid "Unable to open requested HTML document: %s"
+msgstr "Nie można otworzyć wskazanego dokumentu HTML: %s"
+
+#: ../src/html/htmlwin.cpp:630
+msgid "Loading : "
+msgstr "Wczytywanie : "
+
+#: ../src/html/htmlwin.cpp:673
+msgid "Done"
+msgstr "Zrobione"
+
+# Kotwica?
+#: ../src/html/htmlwin.cpp:723
+#, c-format
+msgid "HTML anchor %s does not exist."
+msgstr "HTML: kotwica %s ie istnieje."
+
+#: ../src/html/htmlwin.cpp:1057
+#, c-format
+msgid "Copied to clipboard:\"%s\""
+msgstr "Skopiowano do schowka:\"%s\""
+
+#: ../src/html/htmprint.cpp:269
+msgid ""
+"This document doesn't fit on the page horizontally and will be truncated "
+"when it is printed."
+msgstr ""
+"Ten dokument nie mieści się poziomo na stronie i będzie ucięty na wydruku."
+
+#: ../src/html/htmprint.cpp:285
+#, c-format
+msgid ""
+"The document \"%s\" doesn't fit on the page horizontally and will be "
+"truncated if printed.\n"
+"\n"
+"Would you like to proceed with printing it nevertheless?"
+msgstr ""
+"Dokument \"%s\" nie mieści się na stronie poziomo i będzie ucięty na "
+"wydruku.\n"
+"\n"
+"Chcesz kontynuować drukowanie mimo to?"
+
+#: ../src/html/htmprint.cpp:296
+msgid ""
+"If possible, try changing the layout parameters to make the printout more "
+"narrow."
+msgstr ""
+"Jeżeli to możliwe, spróbuj zmodyfikować parametry układu, aby uczynić wydruk "
+"węższy."
+
+#: ../src/html/htmprint.cpp:445
+msgid ": file does not exist!"
+msgstr ": plik nie istnieje!"
+
+#. TRANSLATORS: %s may be a document title.
+#: ../src/html/htmprint.cpp:717
+#, fuzzy, c-format
+msgid "%s Preview"
+msgstr " Podgląd"
+
+#: ../src/html/htmprint.cpp:755 ../src/richtext/richtextprint.cpp:618
+msgid ""
+"There was a problem during page setup: you may need to set a default printer."
+msgstr ""
+"Wystąpił błąd podczas konfigurowania strony: powinieneś określić domyślną "
+"drukarkę."
+
+#: ../src/msw/clipbrd.cpp:80
+msgid "Failed to open the clipboard."
+msgstr "Nie udało się otworzyć schowka."
+
+#: ../src/msw/clipbrd.cpp:101
+msgid "Failed to close the clipboard."
+msgstr "Nie udało się zamknąć schowka."
+
+#: ../src/msw/clipbrd.cpp:113
+msgid "Failed to empty the clipboard."
+msgstr "Nie udało się opróżnić schowka."
+
+#: ../src/msw/clipbrd.cpp:284
+msgid "Failed to put data on the clipboard"
+msgstr "Nie udało się umieścić danych w schowku"
+
+#: ../src/msw/clipbrd.cpp:326
+msgid "Failed to get data from the clipboard"
+msgstr "Nie udało się pobrać danych ze schowka"
+
+#: ../src/msw/clipbrd.cpp:363
+msgid "Failed to retrieve the supported clipboard formats"
+msgstr "Nie udało się uzyskać listy formatów obsługiwanych przez schowek"
+
+#: ../src/msw/colordlg.cpp:228
+#, c-format
+msgid "Colour selection dialog failed with error %0lx."
+msgstr "Okno wyboru koloru nie powiodło się z błędem %0lx."
+
+#: ../src/msw/cursor.cpp:141
+msgid "Failed to create cursor."
+msgstr "Nie udało się utworzyć kursora."
+
+#: ../src/msw/dde.cpp:279
+#, c-format
+msgid "Failed to register DDE server '%s'"
+msgstr "Nie udało się zarejestrować serwera DDE '%s'"
+
+#: ../src/msw/dde.cpp:300
+#, c-format
+msgid "Failed to unregister DDE server '%s'"
+msgstr "Nie udało się wyrejestrować serwera DDE '%s'"
+
+#: ../src/msw/dde.cpp:428
+#, c-format
+msgid "Failed to create connection to server '%s' on topic '%s'"
+msgstr "Nie udało się utworzyć połączenia do serwera '%s' na temat '%s'"
+
+#: ../src/msw/dde.cpp:655
+msgid "DDE poke request failed"
+msgstr "żądanie danych z serwera DDE nie powiodło się"
+
+# to moja swobodna interpretacja
+#: ../src/msw/dde.cpp:674
+msgid "Failed to establish an advise loop with DDE server"
+msgstr ""
+"Nie udało się rozpocząć transakcji doradzającej (advise) z serwerem DDE"
+
+#: ../src/msw/dde.cpp:693
+msgid "Failed to terminate the advise loop with DDE server"
+msgstr ""
+"Nie udało się zakończyć transakcji doradzającej (advise) z serwerem DDE"
+
+#: ../src/msw/dde.cpp:768
+msgid "Failed to send DDE advise notification"
+msgstr "Nie udało się wysłać powiadomienia DDE"
+
+#: ../src/msw/dde.cpp:1085
+msgid "Failed to create DDE string"
+msgstr "Nie udało się utworzyć łańcucha DDE"
+
+#: ../src/msw/dde.cpp:1131
+msgid "no DDE error."
+msgstr "bez błędu DDE."
+
+#: ../src/msw/dde.cpp:1135
+msgid "a request for a synchronous advise transaction has timed out."
+msgstr ""
+"upłynął czas oczekiwania na rozpoczęcie synchronicznej transakcji advise."
+
+# niezręczne
+#: ../src/msw/dde.cpp:1138
+msgid "the response to the transaction caused the DDE_FBUSY bit to be set."
+msgstr "odpowiedź na transakcję spowodowała ustawienie bitu DDE_FBUSY."
+
+#: ../src/msw/dde.cpp:1141
+msgid "a request for a synchronous data transaction has timed out."
+msgstr ""
+"upłynął czas oczekiwania na rozpoczęcie synchronicznej transakcji data."
+
+# instance -->
+#: ../src/msw/dde.cpp:1144
+msgid ""
+"a DDEML function was called without first calling the DdeInitialize "
+"function,\n"
+"or an invalid instance identifier\n"
+"was passed to a DDEML function."
+msgstr ""
+"została wywołana funkcja DDEML bez wcześniejszego wywołania funkcji "
+"DdeInitialize,\n"
+"lub do funkcji DDEML przesłano\n"
+"nieprawidłowy identyfikator instancji."
+
+# transakcję normalnie wykonywaną przez serwer, inaczej
+#: ../src/msw/dde.cpp:1147
+msgid ""
+"an application initialized as APPCLASS_MONITOR has\n"
+"attempted to perform a DDE transaction,\n"
+"or an application initialized as APPCMD_CLIENTONLY has \n"
+"attempted to perform server transactions."
+msgstr ""
+"aplikacja zainicjowana jako APPCLASS_MONITOR\n"
+"usiłowała wykonać transakcję DDE,\n"
+"lub aplikacja zainicjowana jako APPCMD_CLIENTONLY\n"
+"usiłowała wykonać transakcję serwera."
+
+#: ../src/msw/dde.cpp:1150
+msgid "a request for a synchronous execute transaction has timed out."
+msgstr ""
+"upłynął czas oczekiwania na rozpoczęcie synchronicznej transakcji execute."
+
+#: ../src/msw/dde.cpp:1153
+msgid "a parameter failed to be validated by the DDEML."
+msgstr "parametr nie przeszedł kontroli poprawności DDEML"
+
+#: ../src/msw/dde.cpp:1156
+msgid "a DDEML application has created a prolonged race condition."
+msgstr "Aplikacja DDEML utworzyła przedłużony wyścig (race condition)."
+
+#: ../src/msw/dde.cpp:1159
+msgid "a memory allocation failed."
+msgstr "przydzielenie pamięci nie powiodło się."
+
+#: ../src/msw/dde.cpp:1162
+msgid "a client's attempt to establish a conversation has failed."
+msgstr "próba nawiązania konwersacji przez klienta nie powiodła się."
+
+#: ../src/msw/dde.cpp:1165
+msgid "a transaction failed."
+msgstr "transakcja nie powiodła się."
+
+#: ../src/msw/dde.cpp:1168
+msgid "a request for a synchronous poke transaction has timed out."
+msgstr ""
+"upłynął czas oczekiwania na rozpoczęcie synchronicznej transakcji poke."
+
+#: ../src/msw/dde.cpp:1171
+msgid "an internal call to the PostMessage function has failed. "
+msgstr "wewnętrzne wywołanie funkcji PostMessage zakończyło się niepowodzeniem"
+
+#: ../src/msw/dde.cpp:1174
+msgid "reentrancy problem."
+msgstr "problem współbieżności"
+
+#: ../src/msw/dde.cpp:1177
+msgid ""
+"a server-side transaction was attempted on a conversation\n"
+"that was terminated by the client, or the server\n"
+"terminated before completing a transaction."
+msgstr ""
+"transakcja server-side próbowała kontynuować konwersację\n"
+"zakończoną przez klienta, lub serwer\n"
+"zakończył pracę przez zakończeniem transakcji."
+
+#: ../src/msw/dde.cpp:1180
+msgid "an internal error has occurred in the DDEML."
+msgstr "wystąpił wewnętrzny błąd w DDEML."
+
+#: ../src/msw/dde.cpp:1183
+msgid "a request to end an advise transaction has timed out."
+msgstr "upłynął czas oczekiwania na zakończenie trancakcji advise."
+
+#: ../src/msw/dde.cpp:1186
+msgid ""
+"an invalid transaction identifier was passed to a DDEML function.\n"
+"Once the application has returned from an XTYP_XACT_COMPLETE callback,\n"
+"the transaction identifier for that callback is no longer valid."
+msgstr ""
+"do funkcji DDEML przesłano nieprawidłowy identyfikator transakcji.\n"
+"Kiedy aplikacja kończy połączenie zwrotne XTYP_XACT_COMPLETE,\n"
+"identyfikator transakcji dla tego połączenia nie jest dłużej ważny."
+
+#: ../src/msw/dde.cpp:1189
+#, c-format
+msgid "Unknown DDE error %08x"
+msgstr "Nieznany błąd DDE %08x"
+
+#: ../src/msw/dialup.cpp:343
+msgid ""
+"Dial up functions are unavailable because the remote access service (RAS) is "
+"not installed on this machine. Please install it."
+msgstr ""
+"Funkcje Dial up nie są dostępne, ponieważ serwis zdalnego dostępu (RAS) nie "
+"jest zainstalowany na tej maszynie. Zainstaluj go."
+
+#: ../src/msw/dialup.cpp:402
+#, c-format
+msgid ""
+"The version of remote access service (RAS) installed on this machine is too "
+"old, please upgrade (the following required function is missing: %s)."
+msgstr ""
+"Zainstalowana wersja serwisu zdalnego dostępu (RAS) jest zbyt stara, "
+"zainstaluj nowszą (brakująca funkcja to: %s)."
+
+#: ../src/msw/dialup.cpp:437
+msgid "Failed to retrieve text of RAS error message"
+msgstr "Nie udało się uzyskać tekstu komunikatu błędu RAS"
+
+#: ../src/msw/dialup.cpp:440
+#, c-format
+msgid "unknown error (error code %08x)."
+msgstr "nieznany błąd (kod błędu %08x)."
+
+#: ../src/msw/dialup.cpp:492
+#, c-format
+msgid "Cannot find active dialup connection: %s"
+msgstr "Nie można znaleźć aktywnego połączenia dialup: %s"
+
+#: ../src/msw/dialup.cpp:513
+msgid "Several active dialup connections found, choosing one randomly."
+msgstr "Znalezione kilka dostępnych połączeń dialup, zostanie użyte pierwsze."
+
+#: ../src/msw/dialup.cpp:598 ../src/msw/dialup.cpp:832
+#, c-format
+msgid "Failed to establish dialup connection: %s"
+msgstr "Nie udało się nawiązać połączenia dialup: %s"
+
+#: ../src/msw/dialup.cpp:664
+#, c-format
+msgid "Failed to get ISP names: %s"
+msgstr "Nie udało się usyskać listy ISP: %s"
+
+#: ../src/msw/dialup.cpp:712
+msgid "Failed to connect: no ISP to dial."
+msgstr "Nie udało się połączyć: brak ISP."
+
+#: ../src/msw/dialup.cpp:732
+msgid "Choose ISP to dial"
+msgstr "Wybierz ISP do połączenia"
+
+#: ../src/msw/dialup.cpp:733
+msgid "Please choose which ISP do you want to connect to"
+msgstr "Wybierz ISP, z którym chcesz się połączyć"
+
+#: ../src/msw/dialup.cpp:766
+msgid "Failed to connect: missing username/password."
+msgstr "Nie udało się połączyć: brakuje użytkownika/hasła."
+
+#: ../src/msw/dialup.cpp:796
+msgid "Cannot find the location of address book file"
+msgstr "Nie można znaleźć lokalizacji pliku książki adresowej"
+
+#: ../src/msw/dialup.cpp:827
+#, c-format
+msgid "Failed to initiate dialup connection: %s"
+msgstr "Nie udało się rozpocząć połączenia dialup: %s"
+
+#: ../src/msw/dialup.cpp:897
+msgid "Cannot hang up - no active dialup connection."
+msgstr "Nie można rozłączyć - brak aktywnego połączenia dialup."
+
+#: ../src/msw/dialup.cpp:907
+#, c-format
+msgid "Failed to terminate the dialup connection: %s"
+msgstr "Nie udało się zakończyć połączenia dialup: %s"
+
+#: ../src/msw/dib.cpp:313
+#, c-format
+msgid "Failed to save the bitmap image to file \"%s\"."
+msgstr "Nie udało się zapisać obrazu do pliku \"%s\"."
+
+#: ../src/msw/dib.cpp:543
+#, c-format
+msgid "Failed to allocate %luKb of memory for bitmap data."
+msgstr "Nie udała się rezerwacja %luKb pamięci na dane obrazu."
+
+#: ../src/msw/dir.cpp:241
+#, c-format
+msgid "Cannot enumerate files in directory '%s'"
+msgstr "Nie można wyliczyć plików w katalogu '%s'"
+
+#: ../src/msw/dirdlg.cpp:368
+msgid "Couldn't obtain folder name"
+msgstr "Nie można pobrać nazwy folderu"
+
+#: ../src/msw/dlmsw.cpp:163
+#, fuzzy, c-format
+msgid "(error %d: %s)"
+msgstr " (błąd %ld: %s)"
+
+#: ../src/msw/dragimag.cpp:143 ../src/msw/dragimag.cpp:178
+#: ../src/msw/imaglist.cpp:309 ../src/msw/imaglist.cpp:331
+msgid "Couldn't add an image to the image list."
+msgstr "Nie można dodać obrazu do listy obrazów."
+
+#: ../src/msw/enhmeta.cpp:94
+#, c-format
+msgid "Failed to load metafile from file \"%s\"."
+msgstr "Nie udało się załadowanie pliku meta \"%s\"."
+
+#: ../src/msw/fdrepdlg.cpp:412
+#, c-format
+msgid "Failed to create the standard find/replace dialog (error code %d)"
+msgstr ""
+"Nie udało się utworzyć standardowego okna dialogowego wyszukaj/zastąp (kod "
+"błędu %d)"
+
+#: ../src/msw/filedlg.cpp:1241
+msgid "Access to the file system is not allowed from secure desktop."
+msgstr ""
+
+#: ../src/msw/filedlg.cpp:1242
+msgid "Security warning"
+msgstr ""
+
+#: ../src/msw/filedlg.cpp:1533
+#, c-format
+msgid "File dialog failed with error code %0lx."
+msgstr "Dialog zawiódł zwracając kod błędu %0lx."
+
+#: ../src/msw/font.cpp:1120
+#, fuzzy, c-format
+msgid "Font file \"%s\" couldn't be loaded"
+msgstr "Plik nie może być wczytany."
+
+#: ../src/msw/fontdlg.cpp:220
+#, c-format
+msgid "Common dialog failed with error code %0lx."
+msgstr "Dialog zawiódł, kod błędu: %0lx"
+
+#: ../src/msw/fswatcher.cpp:67
+msgid "Ungraceful worker thread termination"
+msgstr "Wątek roboczy zakończył się błędem"
+
+#: ../src/msw/fswatcher.cpp:81
+msgid "Unable to create IOCP worker thread"
+msgstr "Nie można utworzyć wątku IOCP"
+
+#: ../src/msw/fswatcher.cpp:88
+msgid "Unable to start IOCP worker thread"
+msgstr "Nie można uruchomić wątku IOCP"
+
+#: ../src/msw/fswatcher.cpp:140
+msgid "Monitoring individual files for changes is not supported currently."
+msgstr ""
+"Monitorowanie zmian pojedynczych plików nie jest aktualnie obsługiwane."
+
+#: ../src/msw/fswatcher.cpp:165
+#, c-format
+msgid "Unable to set up watch for '%s'"
+msgstr "Nie można zacząć obserwować '%s'"
+
+#: ../src/msw/fswatcher.cpp:466
+#, c-format
+msgid "Can't monitor non-existent directory \"%s\" for changes."
+msgstr "Nie można monitorować zmian w nieistniejącym folderze \"%s\"."
+
+#: ../src/msw/glcanvas.cpp:577 ../src/unix/glx11.cpp:507
+msgid "OpenGL 3.0 or later is not supported by the OpenGL driver."
+msgstr ""
+
+#: ../src/msw/glcanvas.cpp:601 ../src/osx/glcanvas_osx.cpp:395
+#: ../src/unix/glegl.cpp:304 ../src/unix/glx11.cpp:553
+#, fuzzy
+msgid "Couldn't create OpenGL context"
+msgstr "Nie można utworzyć stopera"
+
+#: ../src/msw/glcanvas.cpp:1294
+msgid "Failed to initialize OpenGL"
+msgstr "Nie udało się zainicjować OpenGL"
+
+#: ../src/msw/graphicsd2d.cpp:607
+msgid "Could not register custom DirectWrite font loader."
+msgstr ""
+
+#: ../src/msw/helpchm.cpp:48
+msgid ""
+"MS HTML Help functions are unavailable because the MS HTML Help library is "
+"not installed on this machine. Please install it."
+msgstr ""
+"Funkcje pomocy dla MS HTML Help nie są dostępne, ponieważ biblioteka MS HTML "
+"Help nie jest zainstalowana na tej maszynie. Zainstaluj ją."
+
+#: ../src/msw/helpchm.cpp:55
+msgid "Failed to initialize MS HTML Help."
+msgstr "Nie udało się zainicjować pomocy MS HTML."
+
+#: ../src/msw/iniconf.cpp:458
+#, c-format
+msgid "Can't delete the INI file '%s'"
+msgstr "Nie można usunąć pliku INI '%s'"
+
+#: ../src/msw/listctrl.cpp:995
+#, c-format
+msgid "Couldn't retrieve information about list control item %d."
+msgstr "Nie można pobrać informacji o elemencie listy kontroli %d."
+
+#: ../src/msw/mdi.cpp:170 ../src/qt/mdi.cpp:253
+msgid "&Cascade"
+msgstr "&Kaskada"
+
+#: ../src/msw/mdi.cpp:171
+msgid "Tile &Horizontally"
+msgstr "&Sąsiadująco w poziomie"
+
+#: ../src/msw/mdi.cpp:172
+msgid "Tile &Vertically"
+msgstr "Sąsi&adująco w pionie"
+
+#: ../src/msw/mdi.cpp:174
+msgid "&Arrange Icons"
+msgstr "&Rozmieść ikony"
+
+#: ../src/msw/mdi.cpp:621
+msgid "Failed to create MDI parent frame."
+msgstr "Nie udało się utworzyć ramki rodzica MDI."
+
+#: ../src/msw/mimetype.cpp:234
+#, c-format
+msgid "Failed to create registry entry for '%s' files."
+msgstr "Nie udało się utworzyć pozycji rejestru dla plików '%s'."
+
+#: ../src/msw/ole/automtn.cpp:495
+#, c-format
+msgid "Failed to find CLSID of \"%s\""
+msgstr "Nie znaleziono CLSID dla \"%s\""
+
+#: ../src/msw/ole/automtn.cpp:512
+#, c-format
+msgid "Failed to create an instance of \"%s\""
+msgstr "Nie udało się utworzenie instancji \"%s\""
+
+#: ../src/msw/ole/automtn.cpp:552
+#, c-format
+msgid "Cannot get an active instance of \"%s\""
+msgstr "NIe można znaleźć aktywnej instancji \"%s\""
+
+#: ../src/msw/ole/automtn.cpp:564
+#, c-format
+msgid "Failed to get OLE automation interface for \"%s\""
+msgstr "Nie udało się uzyskać interface'u OLE dla \"%s\""
+
+#: ../src/msw/ole/automtn.cpp:621
+msgid "Unknown name or named argument."
+msgstr "Nieprawidłowa nazwa lub nazwany argument."
+
+#: ../src/msw/ole/automtn.cpp:625
+msgid "Incorrect number of arguments."
+msgstr "Nieprawidłowa liczba argumentów."
+
+#: ../src/msw/ole/automtn.cpp:637
+msgid "Unknown exception"
+msgstr "Nieznany wyjątek"
+
+#: ../src/msw/ole/automtn.cpp:642
+msgid "Method or property not found."
+msgstr "Nie odnaleziono metody lub właściwości."
+
+#: ../src/msw/ole/automtn.cpp:646
+msgid "Overflow while coercing argument values."
+msgstr "Przepełnienie podczas wymuszania wartości argumentów."
+
+#: ../src/msw/ole/automtn.cpp:650
+msgid "Object implementation does not support named arguments."
+msgstr "Implementacja obiektu nie obsługuje nazywanych argumentów."
+
+#: ../src/msw/ole/automtn.cpp:654
+msgid "The locale ID is unknown."
+msgstr "Nieznany identyfikator ustawień lokalizacyjnych."
+
+#: ../src/msw/ole/automtn.cpp:658
+msgid "Missing a required parameter."
+msgstr "Brak wymaganego parametru."
+
+# catalog file --> ?
+# domain --> ?
+#: ../src/msw/ole/automtn.cpp:662
+#, c-format
+msgid "Argument %u not found."
+msgstr "Nie znaleziono argumentu %u."
+
+#: ../src/msw/ole/automtn.cpp:666
+#, c-format
+msgid "Type mismatch in argument %u."
+msgstr "Niezgodność typów argumentu %u."
+
+#: ../src/msw/ole/automtn.cpp:670
+msgid "The system cannot find the file specified."
+msgstr "System nie może odnaleźć określonego pliku."
+
+#: ../src/msw/ole/automtn.cpp:674
+msgid "Class not registered."
+msgstr "Klasa niezarejestrowana."
+
+#: ../src/msw/ole/automtn.cpp:678
+#, c-format
+msgid "Unknown error %08x"
+msgstr "Nieznany błąd %08x"
+
+#: ../src/msw/ole/automtn.cpp:682
+#, c-format
+msgid "OLE Automation error in %s: %s"
+msgstr "Błąd automatyzacji OLE w %s: %s"
+
+#: ../src/msw/ole/dataobj.cpp:385
+#, c-format
+msgid "Couldn't register clipboard format '%s'."
+msgstr "Nie można zarejestrować formatu schowka '%s'."
+
+#: ../src/msw/ole/dataobj.cpp:402
+#, c-format
+msgid "The clipboard format '%d' doesn't exist."
+msgstr "Format schowka '%d' nie istnieje."
+
+#: ../src/msw/progdlg.cpp:1025
+msgid "Skip"
+msgstr "Pomiń"
+
+#: ../src/msw/registry.cpp:141
+#, fuzzy, c-format
+msgid "unknown (%lu)"
+msgstr "nieznany"
+
+#: ../src/msw/registry.cpp:409
+#, c-format
+msgid "Can't get info about registry key '%s'"
+msgstr "Nie można uzyskać informacji o kluczu rejestru '%s'"
+
+#: ../src/msw/registry.cpp:445
+#, c-format
+msgid "Can't open registry key '%s'"
+msgstr "Nie można otworzyć klucza rejestru '%s'"
+
+#: ../src/msw/registry.cpp:478
+#, c-format
+msgid "Can't create registry key '%s'"
+msgstr "Nie można utworzyć klucza rejestru '%s'"
+
+#: ../src/msw/registry.cpp:497
+#, c-format
+msgid "Can't close registry key '%s'"
+msgstr "Nie można zamknąć klucza rejestru '%s'"
+
+#: ../src/msw/registry.cpp:512
+#, c-format
+msgid "Registry value '%s' already exists."
+msgstr "Wartość rejestru '%s' już istnieje."
+
+#: ../src/msw/registry.cpp:520
+#, c-format
+msgid "Failed to rename registry value '%s' to '%s'."
+msgstr "Nie udało się zmienić nazwy wartości rejestru '%s' do '%s'."
+
+#: ../src/msw/registry.cpp:575
+#, c-format
+msgid "Can't copy values of unsupported type %d."
+msgstr "Nie można kopiować wartości nieobsługiwanego typu %d."
+
+#: ../src/msw/registry.cpp:586
+#, c-format
+msgid "Registry key '%s' does not exist, cannot rename it."
+msgstr "Klucz rejestru '%s' nie istnieje, nie można zmienić jego nazwy."
+
+#: ../src/msw/registry.cpp:617
+#, c-format
+msgid "Registry key '%s' already exists."
+msgstr "Klucz rejestru '%s' już istnieje."
+
+#: ../src/msw/registry.cpp:625
+#, c-format
+msgid "Failed to rename the registry key '%s' to '%s'."
+msgstr "Nie udało się zmienić nazwy klucza rejestru '%s' na '%s'."
+
+#: ../src/msw/registry.cpp:670
+#, c-format
+msgid "Failed to copy the registry subkey '%s' to '%s'."
+msgstr "Nie udało się kopiowanie klucza rejestru '%s' na '%s'."
+
+#: ../src/msw/registry.cpp:683
+#, c-format
+msgid "Failed to copy registry value '%s'"
+msgstr "Nie udało się skopiować wartości rejestru '%s'"
+
+#: ../src/msw/registry.cpp:692
+#, c-format
+msgid "Failed to copy the contents of registry key '%s' to '%s'."
+msgstr "Nie udało się skopiować zawartości klucza rejestru '%s' do '%s'."
+
+#: ../src/msw/registry.cpp:718
+#, c-format
+msgid ""
+"Registry key '%s' is needed for normal system operation,\n"
+"deleting it will leave your system in unusable state:\n"
+"operation aborted."
+msgstr ""
+"Klucz rejestru '%s' jest potrzebny do normalnego funkcjonowania systemu,\n"
+"usunięcie go zdestabilizowałoby system:\n"
+"operacja została przerwana."
+
+#: ../src/msw/registry.cpp:754
+#, c-format
+msgid "Can't delete key '%s'"
+msgstr "Nie można usunąć klucza '%s'"
+
+#: ../src/msw/registry.cpp:782
+#, c-format
+msgid "Can't delete value '%s' from key '%s'"
+msgstr "Nie można usunąć wartości '%s' z klucza '%s'"
+
+#: ../src/msw/registry.cpp:855 ../src/msw/registry.cpp:887
+#: ../src/msw/registry.cpp:929 ../src/msw/registry.cpp:1000
+#, c-format
+msgid "Can't read value of key '%s'"
+msgstr "Nie można odczytać wartości klucza '%s'"
+
+#: ../src/msw/registry.cpp:873 ../src/msw/registry.cpp:915
+#: ../src/msw/registry.cpp:963 ../src/msw/registry.cpp:1106
+#, c-format
+msgid "Can't set value of '%s'"
+msgstr "Nie można nadać wartości '%s'"
+
+#: ../src/msw/registry.cpp:894 ../src/msw/registry.cpp:943
+#, c-format
+msgid "Registry value \"%s\" is not numeric (but of type %s)"
+msgstr ""
+
+#: ../src/msw/registry.cpp:979
+#, c-format
+msgid "Registry value \"%s\" is not binary (but of type %s)"
+msgstr ""
+
+#: ../src/msw/registry.cpp:1028
+#, c-format
+msgid "Registry value \"%s\" is not text (but of type %s)"
+msgstr ""
+
+#: ../src/msw/registry.cpp:1089
+#, c-format
+msgid "Can't read value of '%s'"
+msgstr "Nie można odczytać wartości '%s'"
+
+#: ../src/msw/registry.cpp:1157
+#, c-format
+msgid "Can't enumerate values of key '%s'"
+msgstr "Nie można wyliczyć wartości klucza '%s'"
+
+#: ../src/msw/registry.cpp:1196
+#, c-format
+msgid "Can't enumerate subkeys of key '%s'"
+msgstr "Nie można wyliczyć podkluczy klucza '%s'"
+
+#: ../src/msw/registry.cpp:1262
+#, c-format
+msgid ""
+"Exporting registry key: file \"%s\" already exists and won't be overwritten."
+msgstr ""
+"Eksport klucza rejestrów: plik \"%s\" już istnieje i nie może zostać "
+"nadpisany."
+
+#: ../src/msw/registry.cpp:1411
+#, c-format
+msgid "Can't export value of unsupported type %d."
+msgstr "Nie można wyeksportować wartości nieobsługiwanego typu %d."
+
+#: ../src/msw/registry.cpp:1427
+#, c-format
+msgid "Ignoring value \"%s\" of the key \"%s\"."
+msgstr "Wartiść \"%s\" klucza \"%s\" zignorowana."
+
+#: ../src/msw/textctrl.cpp:596
+msgid ""
+"Impossible to create a rich edit control, using simple text control instead. "
+"Please reinstall riched32.dll"
+msgstr ""
+"Nie jest możliwe utworzenie kontrolki rich edit, użyj zamiast tego prostego "
+"'text control'. Przeinstaluj riched32.dll"
+
+#: ../src/msw/thread.cpp:522 ../src/unix/threadpsx.cpp:850
+msgid "Cannot start thread: error writing TLS."
+msgstr "Nie można wystartować wątku: błąd zapisu TLS."
+
+# ustalić?
+#: ../src/msw/thread.cpp:613
+msgid "Can't set thread priority"
+msgstr "Nie można zmienić priorytetu wątku"
+
+#: ../src/msw/thread.cpp:649
+msgid "Can't create thread"
+msgstr "Nie można utworzyć wątku"
+
+#: ../src/msw/thread.cpp:668
+msgid "Couldn't terminate thread"
+msgstr "Nie można zakończyć wątku"
+
+#: ../src/msw/thread.cpp:799
+msgid "Cannot wait for thread termination"
+msgstr "Nie można czekać na zakończenie wątku"
+
+#: ../src/msw/thread.cpp:873
+#, c-format
+msgid "Cannot suspend thread %lx"
+msgstr "Nie można zawiesić wątku %lx"
+
+#: ../src/msw/thread.cpp:903
+#, c-format
+msgid "Cannot resume thread %lx"
+msgstr "Nie można wznowić wątku %lx"
+
+#: ../src/msw/thread.cpp:932
+msgid "Couldn't get the current thread pointer"
+msgstr "Nie można pobrać wskaźnika aktualnego wątku"
+
+#: ../src/msw/thread.cpp:1333
+msgid ""
+"Thread module initialization failed: impossible to allocate index in thread "
+"local storage"
+msgstr ""
+"Zainicjowanie modułu wątków nie powiodło się: nie jest możliwe przydzielenie "
+"indeksu w lokalnej pamięci wątków."
+
+#: ../src/msw/thread.cpp:1345
+msgid ""
+"Thread module initialization failed: cannot store value in thread local "
+"storage"
+msgstr ""
+"Zainicjowanie modułu wątków nie powiodło się: nie można odłożyć wartości do "
+"lokalnej pamięci wątków"
+
+#: ../src/msw/timer.cpp:133
+msgid "Couldn't create a timer"
+msgstr "Nie można utworzyć stopera"
+
+#: ../src/msw/utils.cpp:372
+msgid "can't find user's HOME, using current directory."
+msgstr "nie można znaleźć katalogu domowego, zostanie użyty bieżący."
+
+#: ../src/msw/utils.cpp:662
+#, c-format
+msgid "Failed to kill process %d"
+msgstr "Nie udało się zabić procesu %d"
+
+#: ../src/msw/utils.cpp:986
+#, c-format
+msgid "Failed to load resource \"%s\"."
+msgstr "Nie udało się wczytanie zasobu \"%s\"."
+
+#: ../src/msw/utils.cpp:993
+#, c-format
+msgid "Failed to lock resource \"%s\"."
+msgstr "Nie udało się zablokowanie zasobu \"%s\"."
+
+#. TRANSLATORS: MS Windows build number
+#: ../src/msw/utils.cpp:1209
+#, c-format
+msgid "build %lu"
+msgstr "budowa %lu"
+
+#: ../src/msw/utils.cpp:1218
+msgid ", 64-bit edition"
+msgstr ", wydanie 64-bitowe"
+
+# dlaczego anonimowego?
+#: ../src/msw/utilsexc.cpp:224
+msgid "Failed to create an anonymous pipe"
+msgstr "Nie udało się utworzyć potoku"
+
+#: ../src/msw/utilsexc.cpp:697
+msgid "Failed to redirect the child process IO"
+msgstr "Nie udało się przekierować wejścia/wyjścia procesu potomnego"
+
+#: ../src/msw/utilsexc.cpp:870
+#, c-format
+msgid "Execution of command '%s' failed"
+msgstr "Wykonanie polecenia '%s' nie powiodło się"
+
+#: ../src/msw/volume.cpp:337
+msgid "Failed to load mpr.dll."
+msgstr "Nie udało się wczytać mpr.dll."
+
+#: ../src/msw/volume.cpp:506
+#, c-format
+msgid "Cannot read typename from '%s'!"
+msgstr "Nie można odczytać nazwy typu z  '%s'!"
+
+#: ../src/msw/volume.cpp:615
+#, c-format
+msgid "Cannot load icon from '%s'."
+msgstr "Nie można wczytać ikony z '%s'."
+
+#: ../src/msw/webview_edge.cpp:285
+msgid "This program was compiled without support for setting Edge proxy."
+msgstr ""
+
+#: ../src/msw/webview_ie.cpp:1010
+msgid "Failed to find web view emulation level in the registry"
+msgstr ""
+
+#: ../src/msw/webview_ie.cpp:1019
+msgid "Failed to set web view to modern emulation level"
+msgstr ""
+
+#: ../src/msw/webview_ie.cpp:1027
+msgid "Failed to reset web view to standard emulation level"
+msgstr ""
+
+#: ../src/msw/webview_ie.cpp:1049
+msgid "Can't run JavaScript script without a valid HTML document"
+msgstr ""
+
+# ustalić?
+#: ../src/msw/webview_ie.cpp:1056
+#, fuzzy
+msgid "Can't get the JavaScript object"
+msgstr "Nie można zmienić priorytetu wątku"
+
+#: ../src/msw/webview_ie.cpp:1070
+#, fuzzy
+msgid "failed to evaluate"
+msgstr "Nie udało się wykonać '%s'\n"
+
+#: ../src/osx/cocoa/filedlg.mm:412
+#, fuzzy
+msgid "File type:"
+msgstr "Teletype"
+
+#: ../src/osx/cocoa/menu.mm:242
+#, fuzzy
+msgctxt "macOS menu name"
+msgid "Window"
+msgstr "&Okno"
+
+#: ../src/osx/cocoa/menu.mm:259
+#, fuzzy
+msgctxt "macOS menu name"
+msgid "Help"
+msgstr "Pomoc"
+
+#: ../src/osx/cocoa/menu.mm:298
+#, fuzzy
+msgctxt "macOS menu item"
+msgid "Minimize"
+msgstr "Mi&nimalizuj"
+
+#: ../src/osx/cocoa/menu.mm:303
+#, fuzzy
+msgctxt "macOS menu item"
+msgid "Zoom"
+msgstr "Powiększenie"
+
+#: ../src/osx/cocoa/menu.mm:309
+msgctxt "macOS menu item"
+msgid "Bring All to Front"
+msgstr ""
+
+#: ../src/osx/core/sound.cpp:143
+#, fuzzy, c-format
+msgid "Failed to load sound from \"%s\" (error %d)."
+msgstr "Nie udało się wczytanie zasobu \"%s\"."
+
+#: ../src/osx/fontutil.cpp:80
+#, fuzzy, c-format
+msgid "Font file \"%s\" doesn't exist."
+msgstr "Plik %s nie istnieje."
+
+#: ../src/osx/fontutil.cpp:88
+#, c-format
+msgid ""
+"Font file \"%s\" cannot be used as it is not inside the font directory "
+"\"%s\"."
+msgstr ""
+
+#: ../src/osx/menu_osx.cpp:496
+#, c-format
+msgctxt "macOS menu item"
+msgid "About %s"
+msgstr "O %s"
+
+#: ../src/osx/menu_osx.cpp:499
+#, fuzzy
+msgctxt "macOS menu item"
+msgid "About..."
+msgstr "Inform&acje"
+
+#: ../src/osx/menu_osx.cpp:508
+msgctxt "macOS menu item"
+msgid "Preferences..."
+msgstr "&Preferencje..."
+
+#: ../src/osx/menu_osx.cpp:512
+msgctxt "macOS menu item"
+msgid "Services"
+msgstr ""
+
+#: ../src/osx/menu_osx.cpp:519
+#, c-format
+msgctxt "macOS menu item"
+msgid "Hide %s"
+msgstr "Ukryj %s"
+
+#: ../src/osx/menu_osx.cpp:522
+#, fuzzy
+msgctxt "macOS menu item"
+msgid "Hide Application"
+msgstr "Aplikacja"
+
+#: ../src/osx/menu_osx.cpp:526
+msgctxt "macOS menu item"
+msgid "Hide Others"
+msgstr "Ukryj inne"
+
+#: ../src/osx/menu_osx.cpp:528
+msgctxt "macOS menu item"
+msgid "Show All"
+msgstr "Pokaż wszystko"
+
+#: ../src/osx/menu_osx.cpp:534
+#, c-format
+msgctxt "macOS menu item"
+msgid "Quit %s"
+msgstr "&Wyjście z %s"
+
+#: ../src/osx/menu_osx.cpp:537
+#, fuzzy
+msgctxt "macOS menu item"
+msgid "Quit Application"
+msgstr "Aplikacja"
+
+#: ../src/osx/webview_webkit.mm:444
+#, fuzzy
+msgid "Printing is not supported by the system web control"
+msgstr "Format Gzip nie jest wspierany przez tę wersję biblioteki zlib"
+
+#: ../src/osx/webview_webkit.mm:453
+#, fuzzy
+msgid "Print operation could not be initialized"
+msgstr "Opis kolumny nie może być zainicjowany."
+
+#. TRANSLATORS: Label of font point size
+#: ../src/propgrid/advprops.cpp:605
+msgid "Point Size"
+msgstr "&Rozmiar punktu:"
+
+# To jest maska do tworzenia nazw typu NowaNaz1 itd
+#. TRANSLATORS: Label of font face name
+#: ../src/propgrid/advprops.cpp:615
+msgid "Face Name"
+msgstr "Nazwa"
+
+#. TRANSLATORS: Label of font style
+#: ../src/propgrid/advprops.cpp:623 ../src/richtext/richtextformatdlg.cpp:331
+msgid "Style"
+msgstr "Styl"
+
+#. TRANSLATORS: Label of font weight
+#: ../src/propgrid/advprops.cpp:628
+msgid "Weight"
+msgstr "Waga"
+
+#. TRANSLATORS: Label of underlined font
+#: ../src/propgrid/advprops.cpp:633 ../src/richtext/richtextfontpage.cpp:358
+msgid "Underlined"
+msgstr "Podkreślony"
+
+#. TRANSLATORS: Label of font family
+#: ../src/propgrid/advprops.cpp:637
+msgid "Family"
+msgstr "Rodzina czcionki"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:801
+msgid "AppWorkspace"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:802
+#, fuzzy
+msgid "ActiveBorder"
+msgstr "Obramowanie"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:803
+msgid "ActiveCaption"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:804
+msgid "ButtonFace"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:805
+msgid "ButtonHighlight"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:806
+msgid "ButtonShadow"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:807
+msgid "ButtonText"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:808
+msgid "CaptionText"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:809
+msgid "ControlDark"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:810
+msgid "ControlLight"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:812
+msgid "GrayText"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:813
+#, fuzzy
+msgid "Highlight"
+msgstr "lekki"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:814
+#, fuzzy
+msgid "HighlightText"
+msgstr "Prawe dostosowanie tekstu."
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:815
+#, fuzzy
+msgid "InactiveBorder"
+msgstr "Obramowanie"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:816
+msgid "InactiveCaption"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:817
+msgid "InactiveCaptionText"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:818
+msgid "Menu"
+msgstr "Menu"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:819
+msgid "Scrollbar"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:820
+msgid "Tooltip"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:821
+msgid "TooltipText"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:822
+#, fuzzy
+msgid "Window"
+msgstr "&Okno"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:823
+#, fuzzy
+msgid "WindowFrame"
+msgstr "&Okno"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:824
+#, fuzzy
+msgid "WindowText"
+msgstr "&Okno"
+
+#. TRANSLATORS: Custom colour choice entry
+#: ../src/propgrid/advprops.cpp:825 ../src/propgrid/advprops.cpp:1532
+#: ../src/propgrid/advprops.cpp:1576
+#, fuzzy
+msgid "Custom"
+msgstr "Rozmiar użytkownika"
+
+#: ../src/propgrid/advprops.cpp:1558
+msgid "Black"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1559
+msgid "Maroon"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1560
+msgid "Navy"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1561
+msgid "Purple"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1562
+msgid "Teal"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1563
+msgid "Gray"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1564
+#, fuzzy
+msgid "Green"
+msgstr "MacGrecki"
+
+#: ../src/propgrid/advprops.cpp:1565
+msgid "Olive"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1566
+#, fuzzy
+msgid "Brown"
+msgstr "Przeglądaj"
+
+#: ../src/propgrid/advprops.cpp:1567
+msgid "Blue"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1568
+msgid "Fuchsia"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1569
+#, fuzzy
+msgid "Red"
+msgstr "Ponów"
+
+#: ../src/propgrid/advprops.cpp:1570
+msgid "Orange"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1571
+msgid "Silver"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1572
+msgid "Lime"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1573
+msgid "Aqua"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1574
+msgid "Yellow"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1575
+msgid "White"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1718
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Default"
+msgstr "domyślny"
+
+#: ../src/propgrid/advprops.cpp:1719
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Arrow"
+msgstr "jutro"
+
+#: ../src/propgrid/advprops.cpp:1720
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Right Arrow"
+msgstr "Prawy"
+
+#: ../src/propgrid/advprops.cpp:1721
+msgctxt "system cursor name"
+msgid "Blank"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1722
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Bullseye"
+msgstr "Styl wypunktowania"
+
+#: ../src/propgrid/advprops.cpp:1723
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Character"
+msgstr "&Kod znaku:"
+
+#: ../src/propgrid/advprops.cpp:1724
+msgctxt "system cursor name"
+msgid "Cross"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1725
+msgctxt "system cursor name"
+msgid "Hand"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1726
+msgctxt "system cursor name"
+msgid "I-Beam"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1727
+msgctxt "system cursor name"
+msgid "Left Button"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1728
+msgctxt "system cursor name"
+msgid "Magnifier"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1729
+msgctxt "system cursor name"
+msgid "Middle Button"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1730
+msgctxt "system cursor name"
+msgid "No Entry"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1731
+msgctxt "system cursor name"
+msgid "Paint Brush"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1732
+msgctxt "system cursor name"
+msgid "Pencil"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1733
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Point Left"
+msgstr "&Rozmiar punktu:"
+
+#: ../src/propgrid/advprops.cpp:1734
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Point Right"
+msgstr "Wyrównanie do prawej"
+
+#: ../src/propgrid/advprops.cpp:1735
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Question Arrow"
+msgstr "Pytanie"
+
+#: ../src/propgrid/advprops.cpp:1736
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Right Button"
+msgstr "Prawy"
+
+#: ../src/propgrid/advprops.cpp:1737
+msgctxt "system cursor name"
+msgid "Sizing NE-SW"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1738
+msgctxt "system cursor name"
+msgid "Sizing N-S"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1739
+msgctxt "system cursor name"
+msgid "Sizing NW-SE"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1740
+msgctxt "system cursor name"
+msgid "Sizing W-E"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1741
+msgctxt "system cursor name"
+msgid "Sizing"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1742
+msgctxt "system cursor name"
+msgid "Spraycan"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1743
+msgctxt "system cursor name"
+msgid "Wait"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1744
+msgctxt "system cursor name"
+msgid "Watch"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1745
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Wait Arrow"
+msgstr "Prawy"
+
+#: ../src/propgrid/advprops.cpp:2109
+msgid "Make a selection:"
+msgstr "Dokonaj wyboru:"
+
+#: ../src/propgrid/manager.cpp:394
+msgid "Property"
+msgstr "Właściwość"
+
+#: ../src/propgrid/manager.cpp:395
+msgid "Value"
+msgstr "Wartość"
+
+#: ../src/propgrid/manager.cpp:1683
+msgid "Categorized Mode"
+msgstr "Tryb skategoryzowany"
+
+#: ../src/propgrid/manager.cpp:1709
+msgid "Alphabetic Mode"
+msgstr "Tryb Alfabetyczny"
+
+#. TRANSLATORS: Name of Boolean false value
+#: ../src/propgrid/propgrid.cpp:230
+msgid "False"
+msgstr "Fałsz"
+
+#. TRANSLATORS: Name of Boolean true value
+#: ../src/propgrid/propgrid.cpp:232
+msgid "True"
+msgstr "Prawda"
+
+#. TRANSLATORS: Text  displayed for unspecified value
+#: ../src/propgrid/propgrid.cpp:428
+msgid "Unspecified"
+msgstr "Nieokreślony"
+
+#. TRANSLATORS: Caption of message box displaying any property error
+#: ../src/propgrid/propgrid.cpp:3145 ../src/propgrid/propgrid.cpp:3282
+msgid "Property Error"
+msgstr "Błąd właściwości"
+
+#: ../src/propgrid/propgrid.cpp:3259
+msgid "You have entered invalid value. Press ESC to cancel editing."
+msgstr "Wprowadzono nieprawidłową wartość. Naciśnij ESC by anulować edycję."
+
+#: ../src/propgrid/propgrid.cpp:6608
+#, c-format
+msgid "Error in resource: %s"
+msgstr "Błąd w zasobie: %s"
+
+#: ../src/propgrid/propgridiface.cpp:377
+#, c-format
+msgid ""
+"Type operation \"%s\" failed: Property labeled \"%s\" is of type \"%s\", NOT "
+"\"%s\"."
+msgstr ""
+"Niepowodzenie operacji typu \"%s\": właściwość nazwana  \"%s\" jest typu "
+"\"%s\", nie \"%s\"."
+
+#: ../src/propgrid/props.cpp:159
+#, c-format
+msgid "Unknown base %d. Base 10 will be used."
+msgstr ""
+
+#: ../src/propgrid/props.cpp:324
+#, c-format
+msgid "Value must be %s or higher."
+msgstr "Wartość musi wynosić %s lub więcej."
+
+#: ../src/propgrid/props.cpp:329 ../src/propgrid/props.cpp:356
+#, c-format
+msgid "Value must be between %s and %s."
+msgstr "Wartość musi zawierać się pomiędzy %s i %s."
+
+#: ../src/propgrid/props.cpp:351
+#, c-format
+msgid "Value must be %s or less."
+msgstr "Wartość musi wynosić %s lub mniej."
+
+#: ../src/propgrid/props.cpp:1058
+#, c-format
+msgid "Not %s"
+msgstr "Nie %s"
+
+#: ../src/propgrid/props.cpp:1770
+msgid "Choose a directory:"
+msgstr "Wybierz katalog"
+
+#: ../src/propgrid/props.cpp:2055
+msgid "Choose a file"
+msgstr "Wybierz plik"
+
+#: ../src/qt/mdi.cpp:254
+msgid "&Tile"
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:147
+#: ../src/richtext/richtextformatdlg.cpp:376
+msgid "Background"
+msgstr "Tło"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:159
+msgid "Background &colour:"
+msgstr "Kolor &tła"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:161
+#: ../src/richtext/richtextbackgroundpage.cpp:163
+msgid "Enables a background colour."
+msgstr "Włącza kolor tła"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:167
+#: ../src/richtext/richtextbackgroundpage.cpp:169
+msgid "The background colour."
+msgstr "Kolor tła."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:178
+msgid "Shadow"
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:193
+msgid "Use &shadow"
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:195
+#: ../src/richtext/richtextbackgroundpage.cpp:197
+#, fuzzy
+msgid "Enables a shadow."
+msgstr "Włącza kolor tła"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:211
+msgid "&Horizontal offset:"
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:218
+#: ../src/richtext/richtextbackgroundpage.cpp:220
+#, fuzzy
+msgid "The horizontal offset."
+msgstr "&Sąsiadująco w poziomie"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:224
+#: ../src/richtext/richtextbackgroundpage.cpp:227
+#: ../src/richtext/richtextbackgroundpage.cpp:228
+#: ../src/richtext/richtextbackgroundpage.cpp:247
+#: ../src/richtext/richtextbackgroundpage.cpp:250
+#: ../src/richtext/richtextbackgroundpage.cpp:251
+#: ../src/richtext/richtextbackgroundpage.cpp:287
+#: ../src/richtext/richtextbackgroundpage.cpp:290
+#: ../src/richtext/richtextbackgroundpage.cpp:291
+#: ../src/richtext/richtextbackgroundpage.cpp:314
+#: ../src/richtext/richtextbackgroundpage.cpp:317
+#: ../src/richtext/richtextbackgroundpage.cpp:318
+#: ../src/richtext/richtextborderspage.cpp:252
+#: ../src/richtext/richtextborderspage.cpp:255
+#: ../src/richtext/richtextborderspage.cpp:256
+#: ../src/richtext/richtextborderspage.cpp:286
+#: ../src/richtext/richtextborderspage.cpp:289
+#: ../src/richtext/richtextborderspage.cpp:290
+#: ../src/richtext/richtextborderspage.cpp:320
+#: ../src/richtext/richtextborderspage.cpp:323
+#: ../src/richtext/richtextborderspage.cpp:324
+#: ../src/richtext/richtextborderspage.cpp:354
+#: ../src/richtext/richtextborderspage.cpp:357
+#: ../src/richtext/richtextborderspage.cpp:358
+#: ../src/richtext/richtextborderspage.cpp:420
+#: ../src/richtext/richtextborderspage.cpp:423
+#: ../src/richtext/richtextborderspage.cpp:424
+#: ../src/richtext/richtextborderspage.cpp:454
+#: ../src/richtext/richtextborderspage.cpp:457
+#: ../src/richtext/richtextborderspage.cpp:458
+#: ../src/richtext/richtextborderspage.cpp:488
+#: ../src/richtext/richtextborderspage.cpp:491
+#: ../src/richtext/richtextborderspage.cpp:492
+#: ../src/richtext/richtextborderspage.cpp:522
+#: ../src/richtext/richtextborderspage.cpp:525
+#: ../src/richtext/richtextborderspage.cpp:526
+#: ../src/richtext/richtextborderspage.cpp:590
+#: ../src/richtext/richtextborderspage.cpp:593
+#: ../src/richtext/richtextborderspage.cpp:594
+#: ../src/richtext/richtextfontpage.cpp:177
+#: ../src/richtext/richtextmarginspage.cpp:199
+#: ../src/richtext/richtextmarginspage.cpp:201
+#: ../src/richtext/richtextmarginspage.cpp:202
+#: ../src/richtext/richtextmarginspage.cpp:224
+#: ../src/richtext/richtextmarginspage.cpp:226
+#: ../src/richtext/richtextmarginspage.cpp:227
+#: ../src/richtext/richtextmarginspage.cpp:247
+#: ../src/richtext/richtextmarginspage.cpp:249
+#: ../src/richtext/richtextmarginspage.cpp:250
+#: ../src/richtext/richtextmarginspage.cpp:272
+#: ../src/richtext/richtextmarginspage.cpp:274
+#: ../src/richtext/richtextmarginspage.cpp:275
+#: ../src/richtext/richtextmarginspage.cpp:313
+#: ../src/richtext/richtextmarginspage.cpp:315
+#: ../src/richtext/richtextmarginspage.cpp:316
+#: ../src/richtext/richtextmarginspage.cpp:338
+#: ../src/richtext/richtextmarginspage.cpp:340
+#: ../src/richtext/richtextmarginspage.cpp:341
+#: ../src/richtext/richtextmarginspage.cpp:361
+#: ../src/richtext/richtextmarginspage.cpp:363
+#: ../src/richtext/richtextmarginspage.cpp:364
+#: ../src/richtext/richtextmarginspage.cpp:386
+#: ../src/richtext/richtextmarginspage.cpp:388
+#: ../src/richtext/richtextmarginspage.cpp:389
+#: ../src/richtext/richtextsizepage.cpp:337
+#: ../src/richtext/richtextsizepage.cpp:340
+#: ../src/richtext/richtextsizepage.cpp:341
+#: ../src/richtext/richtextsizepage.cpp:371
+#: ../src/richtext/richtextsizepage.cpp:374
+#: ../src/richtext/richtextsizepage.cpp:375
+#: ../src/richtext/richtextsizepage.cpp:398
+#: ../src/richtext/richtextsizepage.cpp:401
+#: ../src/richtext/richtextsizepage.cpp:402
+#: ../src/richtext/richtextsizepage.cpp:425
+#: ../src/richtext/richtextsizepage.cpp:428
+#: ../src/richtext/richtextsizepage.cpp:429
+#: ../src/richtext/richtextsizepage.cpp:452
+#: ../src/richtext/richtextsizepage.cpp:455
+#: ../src/richtext/richtextsizepage.cpp:456
+#: ../src/richtext/richtextsizepage.cpp:479
+#: ../src/richtext/richtextsizepage.cpp:482
+#: ../src/richtext/richtextsizepage.cpp:483
+#: ../src/richtext/richtextsizepage.cpp:553
+#: ../src/richtext/richtextsizepage.cpp:556
+#: ../src/richtext/richtextsizepage.cpp:557
+#: ../src/richtext/richtextsizepage.cpp:588
+#: ../src/richtext/richtextsizepage.cpp:591
+#: ../src/richtext/richtextsizepage.cpp:592
+#: ../src/richtext/richtextsizepage.cpp:623
+#: ../src/richtext/richtextsizepage.cpp:626
+#: ../src/richtext/richtextsizepage.cpp:627
+#: ../src/richtext/richtextsizepage.cpp:658
+#: ../src/richtext/richtextsizepage.cpp:661
+#: ../src/richtext/richtextsizepage.cpp:662
+msgid "px"
+msgstr "px"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:225
+#: ../src/richtext/richtextbackgroundpage.cpp:248
+#: ../src/richtext/richtextbackgroundpage.cpp:288
+#: ../src/richtext/richtextbackgroundpage.cpp:315
+#: ../src/richtext/richtextborderspage.cpp:253
+#: ../src/richtext/richtextborderspage.cpp:287
+#: ../src/richtext/richtextborderspage.cpp:321
+#: ../src/richtext/richtextborderspage.cpp:355
+#: ../src/richtext/richtextborderspage.cpp:421
+#: ../src/richtext/richtextborderspage.cpp:455
+#: ../src/richtext/richtextborderspage.cpp:489
+#: ../src/richtext/richtextborderspage.cpp:523
+#: ../src/richtext/richtextborderspage.cpp:591
+#: ../src/richtext/richtextmarginspage.cpp:200
+#: ../src/richtext/richtextmarginspage.cpp:225
+#: ../src/richtext/richtextmarginspage.cpp:248
+#: ../src/richtext/richtextmarginspage.cpp:273
+#: ../src/richtext/richtextmarginspage.cpp:314
+#: ../src/richtext/richtextmarginspage.cpp:339
+#: ../src/richtext/richtextmarginspage.cpp:362
+#: ../src/richtext/richtextmarginspage.cpp:387
+#: ../src/richtext/richtextsizepage.cpp:338
+#: ../src/richtext/richtextsizepage.cpp:372
+#: ../src/richtext/richtextsizepage.cpp:399
+#: ../src/richtext/richtextsizepage.cpp:426
+#: ../src/richtext/richtextsizepage.cpp:453
+#: ../src/richtext/richtextsizepage.cpp:480
+#: ../src/richtext/richtextsizepage.cpp:554
+#: ../src/richtext/richtextsizepage.cpp:589
+#: ../src/richtext/richtextsizepage.cpp:624
+#: ../src/richtext/richtextsizepage.cpp:659
+msgid "cm"
+msgstr "cm"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:226
+#: ../src/richtext/richtextbackgroundpage.cpp:249
+#: ../src/richtext/richtextbackgroundpage.cpp:289
+#: ../src/richtext/richtextbackgroundpage.cpp:316
+#: ../src/richtext/richtextborderspage.cpp:254
+#: ../src/richtext/richtextborderspage.cpp:288
+#: ../src/richtext/richtextborderspage.cpp:322
+#: ../src/richtext/richtextborderspage.cpp:356
+#: ../src/richtext/richtextborderspage.cpp:422
+#: ../src/richtext/richtextborderspage.cpp:456
+#: ../src/richtext/richtextborderspage.cpp:490
+#: ../src/richtext/richtextborderspage.cpp:524
+#: ../src/richtext/richtextborderspage.cpp:592
+#: ../src/richtext/richtextfontpage.cpp:176
+#: ../src/richtext/richtextfontpage.cpp:179
+msgid "pt"
+msgstr "pt"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:229
+#: ../src/richtext/richtextbackgroundpage.cpp:231
+#: ../src/richtext/richtextbackgroundpage.cpp:252
+#: ../src/richtext/richtextbackgroundpage.cpp:254
+#: ../src/richtext/richtextbackgroundpage.cpp:292
+#: ../src/richtext/richtextbackgroundpage.cpp:294
+#: ../src/richtext/richtextbackgroundpage.cpp:319
+#: ../src/richtext/richtextbackgroundpage.cpp:321
+#, fuzzy
+msgid "Units for this value."
+msgstr "Jednostki lewego marginesu."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:234
+#, fuzzy
+msgid "&Vertical offset:"
+msgstr "&Wyrównanie pionowe:"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:241
+#: ../src/richtext/richtextbackgroundpage.cpp:243
+#, fuzzy
+msgid "The vertical offset."
+msgstr "Włącz wyrównanie w pionie."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:257
+#, fuzzy
+msgid "Shadow c&olour:"
+msgstr "Wybierz kolor"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:259
+#: ../src/richtext/richtextbackgroundpage.cpp:261
+#, fuzzy
+msgid "Enables the shadow colour."
+msgstr "Włącza kolor tła"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:265
+#: ../src/richtext/richtextbackgroundpage.cpp:267
+#, fuzzy
+msgid "The shadow colour."
+msgstr "Kolor czcionki."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:270
+msgid "Sh&adow spread:"
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:272
+#: ../src/richtext/richtextbackgroundpage.cpp:274
+#, fuzzy
+msgid "Enables the shadow spread."
+msgstr "Włącz wartość szerokości."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:281
+#: ../src/richtext/richtextbackgroundpage.cpp:283
+msgid "The shadow spread."
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:297
+msgid "&Blur distance:"
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:299
+#: ../src/richtext/richtextbackgroundpage.cpp:301
+#, fuzzy
+msgid "Enables the blur distance."
+msgstr "Włącz wartość szerokości."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:308
+#: ../src/richtext/richtextbackgroundpage.cpp:310
+msgid "The shadow blur distance."
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:324
+msgid "Opaci&ty:"
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:326
+#: ../src/richtext/richtextbackgroundpage.cpp:328
+#, fuzzy
+msgid "Enables the shadow opacity."
+msgstr "Włącz wartość szerokości."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:335
+#: ../src/richtext/richtextbackgroundpage.cpp:337
+msgid "The shadow opacity."
+msgstr ""
+
+#. TRANSLATORS: Rich text page units (percentage)
+#: ../src/richtext/richtextbackgroundpage.cpp:340
+#: ../src/richtext/richtextsizepage.cpp:339
+#: ../src/richtext/richtextsizepage.cpp:373
+#: ../src/richtext/richtextsizepage.cpp:400
+#: ../src/richtext/richtextsizepage.cpp:427
+#: ../src/richtext/richtextsizepage.cpp:454
+#: ../src/richtext/richtextsizepage.cpp:481
+#: ../src/richtext/richtextsizepage.cpp:555
+#: ../src/richtext/richtextsizepage.cpp:590
+#: ../src/richtext/richtextsizepage.cpp:625
+#: ../src/richtext/richtextsizepage.cpp:660
+#, fuzzy
+msgid "%"
+msgstr "%s"
+
+#: ../src/richtext/richtextborderspage.cpp:229
+#: ../src/richtext/richtextborderspage.cpp:387
+msgid "Border"
+msgstr "Obramowanie"
+
+#: ../src/richtext/richtextborderspage.cpp:242
+#: ../src/richtext/richtextborderspage.cpp:410
+#: ../src/richtext/richtextindentspage.cpp:194
+#: ../src/richtext/richtextliststylepage.cpp:384
+#: ../src/richtext/richtextmarginspage.cpp:185
+#: ../src/richtext/richtextmarginspage.cpp:299
+#: ../src/richtext/richtextsizepage.cpp:531
+#: ../src/richtext/richtextsizepage.cpp:538
+msgid "&Left:"
+msgstr "&Lewy:"
+
+#: ../src/richtext/richtextborderspage.cpp:257
+#: ../src/richtext/richtextborderspage.cpp:259
+msgid "Units for the left border width."
+msgstr "Jednostki szerokości lewej ramki."
+
+#: ../src/richtext/richtextborderspage.cpp:266
+#: ../src/richtext/richtextborderspage.cpp:268
+#: ../src/richtext/richtextborderspage.cpp:300
+#: ../src/richtext/richtextborderspage.cpp:302
+#: ../src/richtext/richtextborderspage.cpp:334
+#: ../src/richtext/richtextborderspage.cpp:336
+#: ../src/richtext/richtextborderspage.cpp:368
+#: ../src/richtext/richtextborderspage.cpp:370
+#: ../src/richtext/richtextborderspage.cpp:434
+#: ../src/richtext/richtextborderspage.cpp:436
+#: ../src/richtext/richtextborderspage.cpp:468
+#: ../src/richtext/richtextborderspage.cpp:470
+#: ../src/richtext/richtextborderspage.cpp:502
+#: ../src/richtext/richtextborderspage.cpp:504
+#: ../src/richtext/richtextborderspage.cpp:536
+#: ../src/richtext/richtextborderspage.cpp:538
+#, fuzzy
+msgid "The border line style."
+msgstr "Styl czcionki."
+
+#: ../src/richtext/richtextborderspage.cpp:276
+#: ../src/richtext/richtextborderspage.cpp:444
+#: ../src/richtext/richtextindentspage.cpp:212
+#: ../src/richtext/richtextliststylepage.cpp:402
+#: ../src/richtext/richtextmarginspage.cpp:210
+#: ../src/richtext/richtextmarginspage.cpp:324
+#: ../src/richtext/richtextsizepage.cpp:601
+#: ../src/richtext/richtextsizepage.cpp:608
+msgid "&Right:"
+msgstr "&Prawy:"
+
+#: ../src/richtext/richtextborderspage.cpp:291
+#: ../src/richtext/richtextborderspage.cpp:293
+msgid "Units for the right border width."
+msgstr "Jednostki szerokości prawej ramki."
+
+#: ../src/richtext/richtextborderspage.cpp:310
+#: ../src/richtext/richtextborderspage.cpp:478
+#: ../src/richtext/richtextmarginspage.cpp:233
+#: ../src/richtext/richtextmarginspage.cpp:347
+#: ../src/richtext/richtextsizepage.cpp:566
+#: ../src/richtext/richtextsizepage.cpp:573
+msgid "&Top:"
+msgstr "&Góra:"
+
+#: ../src/richtext/richtextborderspage.cpp:325
+#: ../src/richtext/richtextborderspage.cpp:327
+msgid "Units for the top border width."
+msgstr "Jednostki szerokości górnej ramki."
+
+#: ../src/richtext/richtextborderspage.cpp:344
+#: ../src/richtext/richtextborderspage.cpp:512
+#: ../src/richtext/richtextmarginspage.cpp:258
+#: ../src/richtext/richtextmarginspage.cpp:372
+#: ../src/richtext/richtextsizepage.cpp:636
+#: ../src/richtext/richtextsizepage.cpp:643
+msgid "&Bottom:"
+msgstr "&Dolny:"
+
+#: ../src/richtext/richtextborderspage.cpp:359
+#: ../src/richtext/richtextborderspage.cpp:361
+msgid "Units for the bottom border width."
+msgstr "jednostki szerokości dolnej ramki."
+
+#: ../src/richtext/richtextborderspage.cpp:380
+#: ../src/richtext/richtextborderspage.cpp:548
+msgid "&Synchronize values"
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:382
+#: ../src/richtext/richtextborderspage.cpp:384
+#: ../src/richtext/richtextborderspage.cpp:550
+#: ../src/richtext/richtextborderspage.cpp:552
+msgid "Check to edit all borders simultaneously."
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:397
+#: ../src/richtext/richtextborderspage.cpp:555
+msgid "Outline"
+msgstr "kontur"
+
+#: ../src/richtext/richtextborderspage.cpp:425
+#: ../src/richtext/richtextborderspage.cpp:427
+msgid "Units for the left outline width."
+msgstr "Jednostki szerokości lewego konturu."
+
+#: ../src/richtext/richtextborderspage.cpp:459
+#: ../src/richtext/richtextborderspage.cpp:461
+msgid "Units for the right outline width."
+msgstr "Jednostki szerokości prawego konturu."
+
+#: ../src/richtext/richtextborderspage.cpp:493
+#: ../src/richtext/richtextborderspage.cpp:495
+msgid "Units for the top outline width."
+msgstr "Jednostki szerokości prawego konturu."
+
+#: ../src/richtext/richtextborderspage.cpp:527
+#: ../src/richtext/richtextborderspage.cpp:529
+msgid "Units for the bottom outline width."
+msgstr "Jednostki szerokości dolnego konturu."
+
+#: ../src/richtext/richtextborderspage.cpp:565
+#: ../src/richtext/richtextborderspage.cpp:600
+msgid "Corner"
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:574
+msgid "Corner &radius:"
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:576
+#: ../src/richtext/richtextborderspage.cpp:578
+msgid "An optional corner radius for adding rounded corners."
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:584
+#: ../src/richtext/richtextborderspage.cpp:586
+msgid "The value of the corner radius."
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:595
+#: ../src/richtext/richtextborderspage.cpp:597
+#, fuzzy
+msgid "Units for the corner radius."
+msgstr "Jednostki dopełnienia od góry."
+
+#: ../src/richtext/richtextborderspage.cpp:609
+#: ../src/richtext/richtextsizepage.cpp:247
+#: ../src/richtext/richtextsizepage.cpp:251
+msgid "None"
+msgstr "(Brak)"
+
+#: ../src/richtext/richtextborderspage.cpp:610
+msgid "Solid"
+msgstr "Pełne"
+
+#: ../src/richtext/richtextborderspage.cpp:611
+msgid "Dotted"
+msgstr "Kropkowany"
+
+#: ../src/richtext/richtextborderspage.cpp:612
+msgid "Dashed"
+msgstr "Linia przerywana"
+
+#: ../src/richtext/richtextborderspage.cpp:613
+msgid "Double"
+msgstr "Podwójnie"
+
+#: ../src/richtext/richtextborderspage.cpp:614
+msgid "Groove"
+msgstr "Groove"
+
+#: ../src/richtext/richtextborderspage.cpp:615
+msgid "Ridge"
+msgstr "Krawędź"
+
+#: ../src/richtext/richtextborderspage.cpp:616
+msgid "Inset"
+msgstr "Wstawka"
+
+#: ../src/richtext/richtextborderspage.cpp:617
+msgid "Outset"
+msgstr "Otoczenie"
+
+#: ../src/richtext/richtextbuffer.cpp:3518
+msgid "Change Style"
+msgstr "Zmień styl"
+
+#: ../src/richtext/richtextbuffer.cpp:3701
+msgid "Change Object Style"
+msgstr "Zmień styl obiektu"
+
+#: ../src/richtext/richtextbuffer.cpp:3974
+#: ../src/richtext/richtextbuffer.cpp:8174
+msgid "Change Properties"
+msgstr "Zmień właściwości"
+
+#: ../src/richtext/richtextbuffer.cpp:4346
+msgid "Change List Style"
+msgstr "Zmień styl listy"
+
+#: ../src/richtext/richtextbuffer.cpp:4519
+msgid "Renumber List"
+msgstr "Zmień numerację listy"
+
+#: ../src/richtext/richtextbuffer.cpp:7867
+#: ../src/richtext/richtextbuffer.cpp:7897
+#: ../src/richtext/richtextbuffer.cpp:7939
+#: ../src/richtext/richtextctrl.cpp:1279 ../src/richtext/richtextctrl.cpp:1473
+msgid "Insert Text"
+msgstr "Wstaw tekst"
+
+#: ../src/richtext/richtextbuffer.cpp:8023
+#: ../src/richtext/richtextbuffer.cpp:8979
+msgid "Insert Image"
+msgstr "Wstaw obraz"
+
+#: ../src/richtext/richtextbuffer.cpp:8070
+msgid "Insert Object"
+msgstr "Wstaw obiekt"
+
+#: ../src/richtext/richtextbuffer.cpp:8112
+msgid "Insert Field"
+msgstr "Wstaw pole"
+
+#: ../src/richtext/richtextbuffer.cpp:8410
+msgid "Too many EndStyle calls!"
+msgstr "Zbyt wiele wezwań EndStyle!"
+
+#: ../src/richtext/richtextbuffer.cpp:8785
+msgid "files"
+msgstr "pliki"
+
+#: ../src/richtext/richtextbuffer.cpp:9380
+msgid "standard/circle"
+msgstr "standardowy/okrągły"
+
+#: ../src/richtext/richtextbuffer.cpp:9381
+msgid "standard/circle-outline"
+msgstr "standardowy/okrągły-kontur"
+
+#: ../src/richtext/richtextbuffer.cpp:9382
+msgid "standard/square"
+msgstr "standardowy/prostokątny"
+
+#: ../src/richtext/richtextbuffer.cpp:9383
+msgid "standard/diamond"
+msgstr "standardowy/kątowy"
+
+#: ../src/richtext/richtextbuffer.cpp:9384
+msgid "standard/triangle"
+msgstr "standardowy/trójkątny"
+
+#: ../src/richtext/richtextbuffer.cpp:9423
+msgid "Box Properties"
+msgstr "&Właściwości bloku"
+
+#: ../src/richtext/richtextbuffer.cpp:10006
+msgid "Multiple Cell Properties"
+msgstr "Właściwości wielu komórek"
+
+#: ../src/richtext/richtextbuffer.cpp:10008
+msgid "Cell Properties"
+msgstr "&Właściwości komórki"
+
+#: ../src/richtext/richtextbuffer.cpp:11256
+msgid "Set Cell Style"
+msgstr "Usuń styl komórki"
+
+#: ../src/richtext/richtextbuffer.cpp:11330
+#, fuzzy
+msgid "Delete Row"
+msgstr "Usuń wiersz"
+
+#: ../src/richtext/richtextbuffer.cpp:11380
+#, fuzzy
+msgid "Delete Column"
+msgstr "Usuń kolumnęUsuń wybór"
+
+#: ../src/richtext/richtextbuffer.cpp:11431
+#, fuzzy
+msgid "Add Row"
+msgstr "Dodaj wiersz"
+
+#: ../src/richtext/richtextbuffer.cpp:11494
+#, fuzzy
+msgid "Add Column"
+msgstr "Dodaj kolumnę"
+
+#: ../src/richtext/richtextbuffer.cpp:11537
+msgid "Table Properties"
+msgstr "&Właściwości tabeli"
+
+#: ../src/richtext/richtextbuffer.cpp:12899
+msgid "Picture Properties"
+msgstr "&Właściwości obrazu"
+
+#: ../src/richtext/richtextbuffer.cpp:13169
+#: ../src/richtext/richtextbuffer.cpp:13279
+msgid "image"
+msgstr "obraz"
+
+#: ../src/richtext/richtextbulletspage.cpp:145
+#: ../src/richtext/richtextliststylepage.cpp:209
+msgid "&Bullet style:"
+msgstr "&Styl wypunktowania:"
+
+#: ../src/richtext/richtextbulletspage.cpp:150
+#: ../src/richtext/richtextbulletspage.cpp:152
+#: ../src/richtext/richtextliststylepage.cpp:214
+#: ../src/richtext/richtextliststylepage.cpp:216
+msgid "The available bullet styles."
+msgstr "Dostępne style wypunktowania."
+
+#: ../src/richtext/richtextbulletspage.cpp:158
+#: ../src/richtext/richtextliststylepage.cpp:221
+msgid "Peri&od"
+msgstr "&Okres"
+
+#: ../src/richtext/richtextbulletspage.cpp:160
+#: ../src/richtext/richtextbulletspage.cpp:162
+#: ../src/richtext/richtextliststylepage.cpp:223
+#: ../src/richtext/richtextliststylepage.cpp:225
+msgid "Check to add a period after the bullet."
+msgstr "Zaznacz aby dodać kropkę po wypunktowaniu."
+
+#. TRANSLATORS: Bullet point in parentheses option
+#: ../src/richtext/richtextbulletspage.cpp:167
+#: ../src/richtext/richtextliststylepage.cpp:230
+msgid "(*)"
+msgstr "(*)"
+
+#: ../src/richtext/richtextbulletspage.cpp:169
+#: ../src/richtext/richtextbulletspage.cpp:171
+#: ../src/richtext/richtextliststylepage.cpp:232
+#: ../src/richtext/richtextliststylepage.cpp:234
+msgid "Check to enclose the bullet in parentheses."
+msgstr "Zaznacz aby dołączyć wypunktowanie w nawiasach."
+
+#. TRANSLATORS: Right parenthesis bullet point option
+#: ../src/richtext/richtextbulletspage.cpp:176
+#: ../src/richtext/richtextliststylepage.cpp:239
+msgid "*)"
+msgstr "*)"
+
+#: ../src/richtext/richtextbulletspage.cpp:178
+#: ../src/richtext/richtextbulletspage.cpp:180
+#: ../src/richtext/richtextliststylepage.cpp:241
+#: ../src/richtext/richtextliststylepage.cpp:243
+msgid "Check to add a right parenthesis."
+msgstr "Zaznacz aby dodać prawy nawias."
+
+#: ../src/richtext/richtextbulletspage.cpp:185
+#: ../src/richtext/richtextliststylepage.cpp:248
+msgid "Bullet &Alignment:"
+msgstr "&Wyrównanie wypunktowania:"
+
+#: ../src/richtext/richtextbulletspage.cpp:190
+#: ../src/richtext/richtextliststylepage.cpp:253
+msgid "Centre"
+msgstr "Wyrównanie do środka"
+
+#: ../src/richtext/richtextbulletspage.cpp:194
+#: ../src/richtext/richtextbulletspage.cpp:196
+#: ../src/richtext/richtextbulletspage.cpp:217
+#: ../src/richtext/richtextbulletspage.cpp:219
+#: ../src/richtext/richtextliststylepage.cpp:257
+#: ../src/richtext/richtextliststylepage.cpp:259
+#: ../src/richtext/richtextliststylepage.cpp:278
+#: ../src/richtext/richtextliststylepage.cpp:280
+msgid "The bullet character."
+msgstr "Znak wypunktowania."
+
+#: ../src/richtext/richtextbulletspage.cpp:212
+#: ../src/richtext/richtextliststylepage.cpp:271
+msgid "&Symbol:"
+msgstr "&Symbol:"
+
+#: ../src/richtext/richtextbulletspage.cpp:222
+#: ../src/richtext/richtextliststylepage.cpp:283
+msgid "Ch&oose..."
+msgstr "&Wybierz..."
+
+#: ../src/richtext/richtextbulletspage.cpp:223
+#: ../src/richtext/richtextbulletspage.cpp:225
+#: ../src/richtext/richtextliststylepage.cpp:284
+#: ../src/richtext/richtextliststylepage.cpp:286
+msgid "Click to browse for a symbol."
+msgstr "Kliknij, aby wyszukać symbol."
+
+#: ../src/richtext/richtextbulletspage.cpp:230
+#: ../src/richtext/richtextliststylepage.cpp:291
+msgid "Symbol &font:"
+msgstr "&Czcionka symbolu:"
+
+#: ../src/richtext/richtextbulletspage.cpp:235
+#: ../src/richtext/richtextbulletspage.cpp:237
+#: ../src/richtext/richtextliststylepage.cpp:297
+msgid "Available fonts."
+msgstr "Dostępne czcionki."
+
+#: ../src/richtext/richtextbulletspage.cpp:242
+#: ../src/richtext/richtextliststylepage.cpp:302
+msgid "S&tandard bullet name:"
+msgstr "Standardowy styl wypunktowania:"
+
+#: ../src/richtext/richtextbulletspage.cpp:247
+#: ../src/richtext/richtextbulletspage.cpp:249
+#: ../src/richtext/richtextliststylepage.cpp:307
+#: ../src/richtext/richtextliststylepage.cpp:309
+msgid "A standard bullet name."
+msgstr "Standardowa nazwa wypunktowania."
+
+#: ../src/richtext/richtextbulletspage.cpp:254
+msgid "&Number:"
+msgstr "&Numer:"
+
+#: ../src/richtext/richtextbulletspage.cpp:258
+#: ../src/richtext/richtextbulletspage.cpp:260
+msgid "The list item number."
+msgstr "Numer pozycji listy."
+
+#: ../src/richtext/richtextbulletspage.cpp:266
+#: ../src/richtext/richtextbulletspage.cpp:268
+#: ../src/richtext/richtextliststylepage.cpp:475
+#: ../src/richtext/richtextliststylepage.cpp:477
+msgid "Shows a preview of the bullet settings."
+msgstr "Pokazuje podgląd ustawień wypunktowania."
+
+#: ../src/richtext/richtextbulletspage.cpp:276
+#: ../src/richtext/richtextliststylepage.cpp:484
+msgid "(None)"
+msgstr "(Brak)"
+
+#: ../src/richtext/richtextbulletspage.cpp:277
+#: ../src/richtext/richtextliststylepage.cpp:485
+msgid "Arabic"
+msgstr "Arabski"
+
+#: ../src/richtext/richtextbulletspage.cpp:278
+#: ../src/richtext/richtextliststylepage.cpp:486
+msgid "Upper case letters"
+msgstr "Duże litery"
+
+#: ../src/richtext/richtextbulletspage.cpp:279
+#: ../src/richtext/richtextliststylepage.cpp:487
+msgid "Lower case letters"
+msgstr "Małe litery"
+
+#: ../src/richtext/richtextbulletspage.cpp:280
+#: ../src/richtext/richtextliststylepage.cpp:488
+msgid "Upper case roman numerals"
+msgstr "Duże litery cyframi rzymskimi"
+
+#: ../src/richtext/richtextbulletspage.cpp:281
+#: ../src/richtext/richtextliststylepage.cpp:489
+msgid "Lower case roman numerals"
+msgstr "Małe litery cyframi rzymskimi"
+
+#: ../src/richtext/richtextbulletspage.cpp:282
+#: ../src/richtext/richtextliststylepage.cpp:490
+msgid "Numbered outline"
+msgstr "Numerowane kontury"
+
+#: ../src/richtext/richtextbulletspage.cpp:283
+#: ../src/richtext/richtextliststylepage.cpp:491
+msgid "Symbol"
+msgstr "Symbol"
+
+#: ../src/richtext/richtextbulletspage.cpp:284
+#: ../src/richtext/richtextliststylepage.cpp:492
+msgid "Bitmap"
+msgstr "Bitmap"
+
+#: ../src/richtext/richtextbulletspage.cpp:285
+#: ../src/richtext/richtextliststylepage.cpp:493
+msgid "Standard"
+msgstr "Standard"
+
+#: ../src/richtext/richtextbulletspage.cpp:287
+#: ../src/richtext/richtextliststylepage.cpp:495
+msgid "*"
+msgstr "*"
+
+#: ../src/richtext/richtextbulletspage.cpp:288
+#: ../src/richtext/richtextliststylepage.cpp:496
+msgid "-"
+msgstr "-"
+
+#: ../src/richtext/richtextbulletspage.cpp:289
+#: ../src/richtext/richtextliststylepage.cpp:497
+msgid ">"
+msgstr ">"
+
+#: ../src/richtext/richtextbulletspage.cpp:290
+#: ../src/richtext/richtextliststylepage.cpp:498
+msgid "+"
+msgstr "+"
+
+#: ../src/richtext/richtextbulletspage.cpp:291
+#: ../src/richtext/richtextliststylepage.cpp:499
+msgid "~"
+msgstr "~"
+
+#: ../src/richtext/richtextctrl.cpp:859
+msgid "Drag"
+msgstr "Przeciągnij"
+
+#: ../src/richtext/richtextctrl.cpp:1338 ../src/richtext/richtextctrl.cpp:1559
+msgid "Delete Text"
+msgstr "Usuń tekst"
+
+#: ../src/richtext/richtextctrl.cpp:1537
+msgid "Remove Bullet"
+msgstr "Usuń wypunktowanie"
+
+#: ../src/richtext/richtextctrl.cpp:3070
+msgid "The text couldn't be saved."
+msgstr "Tekst nie może być zapisany.."
+
+#: ../src/richtext/richtextctrl.cpp:3644
+msgid "Replace"
+msgstr "Zastąp"
+
+#: ../src/richtext/richtextfontpage.cpp:146
+#: ../src/richtext/richtextsymboldlg.cpp:384
+msgid "&Font:"
+msgstr "&Czcionka:"
+
+#: ../src/richtext/richtextfontpage.cpp:150
+#: ../src/richtext/richtextfontpage.cpp:152
+msgid "Type a font name."
+msgstr "Wpisz nazwę czcionki."
+
+#: ../src/richtext/richtextfontpage.cpp:158
+msgid "&Size:"
+msgstr "&Rozmiar:"
+
+#: ../src/richtext/richtextfontpage.cpp:165
+#: ../src/richtext/richtextfontpage.cpp:167
+msgid "Type a size in points."
+msgstr "Wpisz rozmiar w punktach."
+
+#: ../src/richtext/richtextfontpage.cpp:180
+#: ../src/richtext/richtextfontpage.cpp:182
+msgid "The font size units, points or pixels."
+msgstr "Rozmiar czcionki w punktach lub  pikselach ."
+
+#: ../src/richtext/richtextfontpage.cpp:189
+#: ../src/richtext/richtextfontpage.cpp:191
+msgid "Lists the available fonts."
+msgstr "Lista dostępnych czcionek."
+
+#: ../src/richtext/richtextfontpage.cpp:196
+#: ../src/richtext/richtextfontpage.cpp:198
+msgid "Lists font sizes in points."
+msgstr "Wielkość czcionki listy w punktach."
+
+#: ../src/richtext/richtextfontpage.cpp:207
+msgid "Font st&yle:"
+msgstr "&Styl czcionki:"
+
+#: ../src/richtext/richtextfontpage.cpp:212
+#: ../src/richtext/richtextfontpage.cpp:214
+msgid "Select regular or italic style."
+msgstr "Wybierz regularny lub kursywny styl."
+
+#: ../src/richtext/richtextfontpage.cpp:220
+msgid "Font &weight:"
+msgstr "&Waga czcionki:"
+
+#: ../src/richtext/richtextfontpage.cpp:225
+#: ../src/richtext/richtextfontpage.cpp:227
+msgid "Select regular or bold."
+msgstr "Wybierz regularną lub pogrubioną czcionkę."
+
+#: ../src/richtext/richtextfontpage.cpp:233
+msgid "&Underlining:"
+msgstr "&Podkreślenie:"
+
+#: ../src/richtext/richtextfontpage.cpp:238
+#: ../src/richtext/richtextfontpage.cpp:240
+msgid "Select underlining or no underlining."
+msgstr "Wybierz podkreślanie lub bez podkreślania."
+
+#: ../src/richtext/richtextfontpage.cpp:248
+msgid "&Colour:"
+msgstr "K&olor:"
+
+#: ../src/richtext/richtextfontpage.cpp:253
+#: ../src/richtext/richtextfontpage.cpp:255
+msgid "Click to change the text colour."
+msgstr "Kliknij, aby zmienić kolor tekstu."
+
+#: ../src/richtext/richtextfontpage.cpp:261
+msgid "&Bg colour:"
+msgstr "Kolor &tła:"
+
+#: ../src/richtext/richtextfontpage.cpp:266
+#: ../src/richtext/richtextfontpage.cpp:268
+msgid "Click to change the text background colour."
+msgstr "Kliknij, aby zmienić kolor tła tekstu."
+
+#: ../src/richtext/richtextfontpage.cpp:276
+#: ../src/richtext/richtextfontpage.cpp:278
+msgid "Check to show a line through the text."
+msgstr "Zaznacz aby pokazać linię poprzez tekst."
+
+#: ../src/richtext/richtextfontpage.cpp:281
+msgid "Ca&pitals"
+msgstr "&Duże litery"
+
+#: ../src/richtext/richtextfontpage.cpp:283
+#: ../src/richtext/richtextfontpage.cpp:285
+msgid "Check to show the text in capitals."
+msgstr "Zaznacz aby wyświetlić tekst w dużych literach."
+
+#: ../src/richtext/richtextfontpage.cpp:288
+msgid "Small C&apitals"
+msgstr "K&apitaliki"
+
+#: ../src/richtext/richtextfontpage.cpp:290
+#: ../src/richtext/richtextfontpage.cpp:292
+msgid "Check to show the text in small capitals."
+msgstr "Zaznacz aby wyświetlić tekst w dużych literach."
+
+#: ../src/richtext/richtextfontpage.cpp:295
+msgid "Supe&rscript"
+msgstr "Indeks &górny"
+
+#: ../src/richtext/richtextfontpage.cpp:297
+#: ../src/richtext/richtextfontpage.cpp:299
+msgid "Check to show the text in superscript."
+msgstr "Zaznacz aby wyświetlić tekst w indeksie górnym."
+
+#: ../src/richtext/richtextfontpage.cpp:302
+msgid "Subscrip&t"
+msgstr "Indeks &dolny"
+
+#: ../src/richtext/richtextfontpage.cpp:304
+#: ../src/richtext/richtextfontpage.cpp:306
+msgid "Check to show the text in subscript."
+msgstr "Zaznacz aby wyświetlić tekst w indeksie dolnym."
+
+#: ../src/richtext/richtextfontpage.cpp:312
+msgid "Rig&ht-to-left"
+msgstr ""
+
+#: ../src/richtext/richtextfontpage.cpp:314
+#: ../src/richtext/richtextfontpage.cpp:316
+#, fuzzy
+msgid "Check to indicate right-to-left text layout."
+msgstr "Kliknij, aby zmienić kolor tekstu."
+
+#: ../src/richtext/richtextfontpage.cpp:319
+msgid "Suppress hyphe&nation"
+msgstr ""
+
+#: ../src/richtext/richtextfontpage.cpp:321
+#: ../src/richtext/richtextfontpage.cpp:323
+msgid "Check to suppress hyphenation."
+msgstr ""
+
+#: ../src/richtext/richtextfontpage.cpp:329
+#: ../src/richtext/richtextfontpage.cpp:331
+msgid "Shows a preview of the font settings."
+msgstr "Pokazuje podgląd ustawień czcionki."
+
+#: ../src/richtext/richtextfontpage.cpp:348
+#: ../src/richtext/richtextfontpage.cpp:352
+#: ../src/richtext/richtextfontpage.cpp:356
+#: ../src/richtext/richtextformatdlg.cpp:873
+#: ../src/richtext/richtextindentspage.cpp:273
+#: ../src/richtext/richtextindentspage.cpp:285
+#: ../src/richtext/richtextindentspage.cpp:286
+#: ../src/richtext/richtextindentspage.cpp:310
+#: ../src/richtext/richtextindentspage.cpp:325
+#: ../src/richtext/richtextliststylepage.cpp:451
+#: ../src/richtext/richtextliststylepage.cpp:463
+#: ../src/richtext/richtextliststylepage.cpp:464
+msgid "(none)"
+msgstr "(beznazwy)"
+
+#: ../src/richtext/richtextfontpage.cpp:349
+#: ../src/richtext/richtextfontpage.cpp:353
+msgid "Regular"
+msgstr "Regularne"
+
+#: ../src/richtext/richtextfontpage.cpp:357
+msgid "Not underlined"
+msgstr "Nie podkreślony"
+
+#: ../src/richtext/richtextformatdlg.cpp:341
+msgid "Indents && Spacing"
+msgstr "Wcięcia i odstępy"
+
+#: ../src/richtext/richtextformatdlg.cpp:346
+msgid "Tabs"
+msgstr "Karty"
+
+#: ../src/richtext/richtextformatdlg.cpp:351
+msgid "Bullets"
+msgstr "Wypunktowania"
+
+#: ../src/richtext/richtextformatdlg.cpp:356
+msgid "List Style"
+msgstr "Styl listy"
+
+#: ../src/richtext/richtextformatdlg.cpp:366
+#: ../src/richtext/richtextmarginspage.cpp:170
+msgid "Margins"
+msgstr "Marginesy"
+
+#: ../src/richtext/richtextformatdlg.cpp:371
+msgid "Borders"
+msgstr "Ramki"
+
+#: ../src/richtext/richtextformatdlg.cpp:765
+msgid "Colour"
+msgstr "Kolor"
+
+#: ../src/richtext/richtextindentspage.cpp:127
+#: ../src/richtext/richtextliststylepage.cpp:322
+msgid "&Alignment"
+msgstr "&Wyrównanie"
+
+#: ../src/richtext/richtextindentspage.cpp:138
+#: ../src/richtext/richtextliststylepage.cpp:331
+msgid "&Left"
+msgstr "&Lewy"
+
+#: ../src/richtext/richtextindentspage.cpp:140
+#: ../src/richtext/richtextindentspage.cpp:142
+#: ../src/richtext/richtextliststylepage.cpp:333
+#: ../src/richtext/richtextliststylepage.cpp:335
+msgid "Left-align text."
+msgstr "Lewe dostosowanie tekstu."
+
+#: ../src/richtext/richtextindentspage.cpp:145
+#: ../src/richtext/richtextliststylepage.cpp:338
+msgid "&Right"
+msgstr "&Prawy"
+
+#: ../src/richtext/richtextindentspage.cpp:147
+#: ../src/richtext/richtextindentspage.cpp:149
+#: ../src/richtext/richtextliststylepage.cpp:340
+#: ../src/richtext/richtextliststylepage.cpp:342
+msgid "Right-align text."
+msgstr "Prawe dostosowanie tekstu."
+
+#: ../src/richtext/richtextindentspage.cpp:152
+#: ../src/richtext/richtextliststylepage.cpp:345
+msgid "&Justified"
+msgstr "&Wyrównanie obustronne"
+
+#: ../src/richtext/richtextindentspage.cpp:154
+#: ../src/richtext/richtextindentspage.cpp:156
+#: ../src/richtext/richtextliststylepage.cpp:347
+#: ../src/richtext/richtextliststylepage.cpp:349
+msgid "Justify text left and right."
+msgstr "Wyjustuj tekst w lewo i w prawo."
+
+#: ../src/richtext/richtextindentspage.cpp:159
+#: ../src/richtext/richtextliststylepage.cpp:352
+msgid "Cen&tred"
+msgstr "wyś&rodkowany"
+
+#: ../src/richtext/richtextindentspage.cpp:161
+#: ../src/richtext/richtextindentspage.cpp:163
+#: ../src/richtext/richtextliststylepage.cpp:354
+#: ../src/richtext/richtextliststylepage.cpp:356
+msgid "Centre text."
+msgstr "Wyśrodkowanie tekstu."
+
+#: ../src/richtext/richtextindentspage.cpp:166
+#: ../src/richtext/richtextliststylepage.cpp:359
+msgid "&Indeterminate"
+msgstr "&Nieokreślony"
+
+#: ../src/richtext/richtextindentspage.cpp:168
+#: ../src/richtext/richtextindentspage.cpp:170
+#: ../src/richtext/richtextliststylepage.cpp:361
+#: ../src/richtext/richtextliststylepage.cpp:363
+msgid "Use the current alignment setting."
+msgstr "Użyj bieżącego dostosowywania ustawień."
+
+#: ../src/richtext/richtextindentspage.cpp:183
+#: ../src/richtext/richtextliststylepage.cpp:375
+msgid "&Indentation (tenths of a mm)"
+msgstr "&Wcięcia (w dziesiątych częściach mm)"
+
+#: ../src/richtext/richtextindentspage.cpp:198
+#: ../src/richtext/richtextindentspage.cpp:200
+#: ../src/richtext/richtextliststylepage.cpp:388
+#: ../src/richtext/richtextliststylepage.cpp:390
+msgid "The left indent."
+msgstr "Lewe wcięcie."
+
+#: ../src/richtext/richtextindentspage.cpp:203
+#: ../src/richtext/richtextliststylepage.cpp:393
+msgid "Left (&first line):"
+msgstr "Lewo (&pierwsza linijka):"
+
+#: ../src/richtext/richtextindentspage.cpp:207
+#: ../src/richtext/richtextindentspage.cpp:209
+#: ../src/richtext/richtextliststylepage.cpp:397
+#: ../src/richtext/richtextliststylepage.cpp:399
+msgid "The first line indent."
+msgstr "Wcięcie pierwszego wierszu."
+
+#: ../src/richtext/richtextindentspage.cpp:216
+#: ../src/richtext/richtextindentspage.cpp:218
+#: ../src/richtext/richtextliststylepage.cpp:406
+#: ../src/richtext/richtextliststylepage.cpp:408
+msgid "The right indent."
+msgstr "Prawidłowe wcięcie."
+
+#: ../src/richtext/richtextindentspage.cpp:221
+msgid "&Outline level:"
+msgstr "Poziom &kontur:"
+
+#: ../src/richtext/richtextindentspage.cpp:226
+#: ../src/richtext/richtextindentspage.cpp:228
+msgid "The outline level."
+msgstr "Poziom kontur."
+
+#: ../src/richtext/richtextindentspage.cpp:241
+#: ../src/richtext/richtextliststylepage.cpp:420
+msgid "&Spacing (tenths of a mm)"
+msgstr "&Odstępy (w dziesiątych częściach mm)"
+
+#: ../src/richtext/richtextindentspage.cpp:252
+msgid "&Before a paragraph:"
+msgstr "&Przed paragrafem:"
+
+#: ../src/richtext/richtextindentspage.cpp:256
+#: ../src/richtext/richtextindentspage.cpp:258
+#: ../src/richtext/richtextliststylepage.cpp:433
+#: ../src/richtext/richtextliststylepage.cpp:435
+msgid "The spacing before the paragraph."
+msgstr "Odstępy przed paragrafem."
+
+#: ../src/richtext/richtextindentspage.cpp:261
+msgid "&After a paragraph:"
+msgstr "&Po paragrafie:"
+
+#: ../src/richtext/richtextindentspage.cpp:266
+#: ../src/richtext/richtextliststylepage.cpp:442
+#: ../src/richtext/richtextliststylepage.cpp:444
+msgid "The spacing after the paragraph."
+msgstr "Odstępy po paragrafie."
+
+#: ../src/richtext/richtextindentspage.cpp:269
+msgid "L&ine spacing:"
+msgstr "&Odstęp między wierszami:"
+
+#: ../src/richtext/richtextindentspage.cpp:274
+#: ../src/richtext/richtextliststylepage.cpp:452
+msgid "Single"
+msgstr "Pojedynczy"
+
+#: ../src/richtext/richtextindentspage.cpp:275
+#: ../src/richtext/richtextliststylepage.cpp:453
+msgid "1.1"
+msgstr "1.1"
+
+#: ../src/richtext/richtextindentspage.cpp:276
+#: ../src/richtext/richtextliststylepage.cpp:454
+msgid "1.2"
+msgstr "1.2"
+
+#: ../src/richtext/richtextindentspage.cpp:277
+#: ../src/richtext/richtextliststylepage.cpp:455
+msgid "1.3"
+msgstr "1.3"
+
+#: ../src/richtext/richtextindentspage.cpp:278
+#: ../src/richtext/richtextliststylepage.cpp:456
+msgid "1.4"
+msgstr "1.4"
+
+#: ../src/richtext/richtextindentspage.cpp:279
+#: ../src/richtext/richtextliststylepage.cpp:457
+msgid "1.5"
+msgstr "1.5"
+
+#: ../src/richtext/richtextindentspage.cpp:280
+#: ../src/richtext/richtextliststylepage.cpp:458
+msgid "1.6"
+msgstr "1.6"
+
+#: ../src/richtext/richtextindentspage.cpp:281
+#: ../src/richtext/richtextliststylepage.cpp:459
+msgid "1.7"
+msgstr "1.7"
+
+#: ../src/richtext/richtextindentspage.cpp:282
+#: ../src/richtext/richtextliststylepage.cpp:460
+msgid "1.8"
+msgstr "1.8"
+
+#: ../src/richtext/richtextindentspage.cpp:283
+#: ../src/richtext/richtextliststylepage.cpp:461
+msgid "1.9"
+msgstr "1.9"
+
+#: ../src/richtext/richtextindentspage.cpp:284
+#: ../src/richtext/richtextliststylepage.cpp:462
+msgid "2"
+msgstr "2"
+
+#: ../src/richtext/richtextindentspage.cpp:287
+#: ../src/richtext/richtextindentspage.cpp:289
+#: ../src/richtext/richtextliststylepage.cpp:465
+#: ../src/richtext/richtextliststylepage.cpp:467
+msgid "The line spacing."
+msgstr "Odstęp między wierszami."
+
+#: ../src/richtext/richtextindentspage.cpp:292
+msgid "&Page Break"
+msgstr "&Podział strony"
+
+#: ../src/richtext/richtextindentspage.cpp:294
+#: ../src/richtext/richtextindentspage.cpp:296
+msgid "Inserts a page break before the paragraph."
+msgstr "Wstawia łamanie strony przed akapitem."
+
+#: ../src/richtext/richtextindentspage.cpp:302
+#: ../src/richtext/richtextindentspage.cpp:304
+msgid "Shows a preview of the paragraph settings."
+msgstr "Pokazuje podgląd ustawień paragrafu."
+
+#: ../src/richtext/richtextliststylepage.cpp:182
+msgid "&List level:"
+msgstr "Poziom &listy:"
+
+#: ../src/richtext/richtextliststylepage.cpp:186
+#: ../src/richtext/richtextliststylepage.cpp:188
+msgid "Selects the list level to edit."
+msgstr "Wybiera poziom listy do edycji."
+
+#: ../src/richtext/richtextliststylepage.cpp:193
+msgid "&Font for Level..."
+msgstr "&Czcionka dla poziomu..."
+
+#: ../src/richtext/richtextliststylepage.cpp:194
+#: ../src/richtext/richtextliststylepage.cpp:196
+msgid "Click to choose the font for this level."
+msgstr "Kliknij, aby wybrać czcionkę dla tego poziomu."
+
+#: ../src/richtext/richtextliststylepage.cpp:312
+msgid "Bullet style"
+msgstr "Styl wypunktowania"
+
+#: ../src/richtext/richtextliststylepage.cpp:429
+msgid "Before a paragraph:"
+msgstr "Przed paragrafem:"
+
+#: ../src/richtext/richtextliststylepage.cpp:438
+msgid "After a paragraph:"
+msgstr "Za paragrafem:"
+
+#: ../src/richtext/richtextliststylepage.cpp:447
+msgid "Line spacing:"
+msgstr "Odstęp między wierszami:"
+
+#: ../src/richtext/richtextliststylepage.cpp:470
+msgid "Spacing"
+msgstr "Odstępy"
+
+#: ../src/richtext/richtextmarginspage.cpp:193
+#: ../src/richtext/richtextmarginspage.cpp:195
+msgid "The left margin size."
+msgstr "Rozmiar lewego marginesu."
+
+#: ../src/richtext/richtextmarginspage.cpp:203
+#: ../src/richtext/richtextmarginspage.cpp:205
+msgid "Units for the left margin."
+msgstr "Jednostki lewego marginesu."
+
+#: ../src/richtext/richtextmarginspage.cpp:218
+#: ../src/richtext/richtextmarginspage.cpp:220
+msgid "The right margin size."
+msgstr "Rozmiar prawego marginesu."
+
+#: ../src/richtext/richtextmarginspage.cpp:228
+#: ../src/richtext/richtextmarginspage.cpp:230
+msgid "Units for the right margin."
+msgstr "Jednostki prawego marginesu."
+
+#: ../src/richtext/richtextmarginspage.cpp:241
+#: ../src/richtext/richtextmarginspage.cpp:243
+msgid "The top margin size."
+msgstr "Rozmiar górnego marginesu."
+
+#: ../src/richtext/richtextmarginspage.cpp:251
+#: ../src/richtext/richtextmarginspage.cpp:253
+msgid "Units for the top margin."
+msgstr "Jednostki szerokości górnego marginesu."
+
+#: ../src/richtext/richtextmarginspage.cpp:266
+#: ../src/richtext/richtextmarginspage.cpp:268
+msgid "The bottom margin size."
+msgstr "Rozmiar dolnego marginesu."
+
+#: ../src/richtext/richtextmarginspage.cpp:276
+#: ../src/richtext/richtextmarginspage.cpp:278
+msgid "Units for the bottom margin."
+msgstr "Jednostki dolnego marginesu."
+
+#: ../src/richtext/richtextmarginspage.cpp:284
+msgid "Padding"
+msgstr "Dopełnienie"
+
+#: ../src/richtext/richtextmarginspage.cpp:307
+#: ../src/richtext/richtextmarginspage.cpp:309
+msgid "The left padding size."
+msgstr "Rozmiar dopełnienia z lewej. "
+
+#: ../src/richtext/richtextmarginspage.cpp:317
+#: ../src/richtext/richtextmarginspage.cpp:319
+msgid "Units for the left padding."
+msgstr "Jednostka dopełnienia od lewej."
+
+#: ../src/richtext/richtextmarginspage.cpp:332
+#: ../src/richtext/richtextmarginspage.cpp:334
+msgid "The right padding size."
+msgstr "Rozmiar dopełnienia z prawej."
+
+#: ../src/richtext/richtextmarginspage.cpp:342
+#: ../src/richtext/richtextmarginspage.cpp:344
+msgid "Units for the right padding."
+msgstr "Jednostki dopełnienia z prawej."
+
+#: ../src/richtext/richtextmarginspage.cpp:355
+#: ../src/richtext/richtextmarginspage.cpp:357
+msgid "The top padding size."
+msgstr "Rozmiar dopełnienia od góry."
+
+#: ../src/richtext/richtextmarginspage.cpp:365
+#: ../src/richtext/richtextmarginspage.cpp:367
+msgid "Units for the top padding."
+msgstr "Jednostki dopełnienia od góry."
+
+#: ../src/richtext/richtextmarginspage.cpp:380
+#: ../src/richtext/richtextmarginspage.cpp:382
+msgid "The bottom padding size."
+msgstr "Rozmiar dopełnienia na dole."
+
+#: ../src/richtext/richtextmarginspage.cpp:390
+#: ../src/richtext/richtextmarginspage.cpp:392
+msgid "Units for the bottom padding."
+msgstr "Jednostka dopełnienia od dołu."
+
+#: ../src/richtext/richtextprint.cpp:592
+msgid " Preview"
+msgstr " Podgląd"
+
+#: ../src/richtext/richtextsizepage.cpp:228
+msgid "Floating"
+msgstr "Pływający"
+
+#: ../src/richtext/richtextsizepage.cpp:243
+msgid "&Floating mode:"
+msgstr "Tryb &ruchomy:"
+
+#: ../src/richtext/richtextsizepage.cpp:252
+#: ../src/richtext/richtextsizepage.cpp:254
+msgid "How the object will float relative to the text."
+msgstr "Jak obiekt będzie pływać względem tekstu."
+
+#: ../src/richtext/richtextsizepage.cpp:265
+msgid "Alignment"
+msgstr "Wyrównanie"
+
+#: ../src/richtext/richtextsizepage.cpp:277
+msgid "&Vertical alignment:"
+msgstr "&Wyrównanie pionowe:"
+
+#: ../src/richtext/richtextsizepage.cpp:279
+#: ../src/richtext/richtextsizepage.cpp:281
+msgid "Enable vertical alignment."
+msgstr "Włącz wyrównanie w pionie."
+
+#: ../src/richtext/richtextsizepage.cpp:286
+msgid "Centred"
+msgstr "wyśrodkowany"
+
+#: ../src/richtext/richtextsizepage.cpp:290
+#: ../src/richtext/richtextsizepage.cpp:292
+msgid "Vertical alignment."
+msgstr "Wyrównanie pionowe."
+
+#: ../src/richtext/richtextsizepage.cpp:316
+#: ../src/richtext/richtextsizepage.cpp:323
+msgid "&Width:"
+msgstr "&Szerokość:"
+
+#: ../src/richtext/richtextsizepage.cpp:318
+#: ../src/richtext/richtextsizepage.cpp:320
+msgid "Enable the width value."
+msgstr "Włącz wartość szerokości."
+
+#: ../src/richtext/richtextsizepage.cpp:331
+#: ../src/richtext/richtextsizepage.cpp:333
+msgid "The object width."
+msgstr "Szerokość obiektu."
+
+#: ../src/richtext/richtextsizepage.cpp:342
+#: ../src/richtext/richtextsizepage.cpp:344
+msgid "Units for the object width."
+msgstr "Jednostki szerokości obiektu."
+
+#: ../src/richtext/richtextsizepage.cpp:350
+#: ../src/richtext/richtextsizepage.cpp:357
+msgid "&Height:"
+msgstr "&Wysokość:"
+
+#: ../src/richtext/richtextsizepage.cpp:352
+#: ../src/richtext/richtextsizepage.cpp:354
+#: ../src/richtext/richtextsizepage.cpp:464
+#: ../src/richtext/richtextsizepage.cpp:466
+msgid "Enable the height value."
+msgstr "Włącz wartość wysokości."
+
+#: ../src/richtext/richtextsizepage.cpp:365
+#: ../src/richtext/richtextsizepage.cpp:367
+msgid "The object height."
+msgstr "Wysokość obiektu"
+
+#: ../src/richtext/richtextsizepage.cpp:376
+#: ../src/richtext/richtextsizepage.cpp:378
+msgid "Units for the object height."
+msgstr "Jednostki wysokości obiektu."
+
+#: ../src/richtext/richtextsizepage.cpp:381
+msgid "Min width:"
+msgstr "Min szerokość:"
+
+#: ../src/richtext/richtextsizepage.cpp:383
+#: ../src/richtext/richtextsizepage.cpp:385
+msgid "Enable the minimum width value."
+msgstr "Włącz wartość minimalnej szerokości."
+
+#: ../src/richtext/richtextsizepage.cpp:392
+#: ../src/richtext/richtextsizepage.cpp:394
+msgid "The object minimum width."
+msgstr "Minimalna szerokość obiektu."
+
+#: ../src/richtext/richtextsizepage.cpp:403
+#: ../src/richtext/richtextsizepage.cpp:405
+msgid "Units for the minimum object width."
+msgstr "Jednostki minimalnej szerokości obiektu."
+
+#: ../src/richtext/richtextsizepage.cpp:408
+msgid "Min height:"
+msgstr "Minimalna wysokość:"
+
+#: ../src/richtext/richtextsizepage.cpp:410
+#: ../src/richtext/richtextsizepage.cpp:412
+msgid "Enable the minimum height value."
+msgstr "Włącz minimalną wartość wysokości."
+
+#: ../src/richtext/richtextsizepage.cpp:419
+#: ../src/richtext/richtextsizepage.cpp:421
+msgid "The object minimum height."
+msgstr "Minimalna wysokość obiektu"
+
+#: ../src/richtext/richtextsizepage.cpp:430
+#: ../src/richtext/richtextsizepage.cpp:432
+msgid "Units for the minimum object height."
+msgstr "Jednostki minimalnej wysokości obiektu."
+
+#: ../src/richtext/richtextsizepage.cpp:435
+msgid "Max width:"
+msgstr "Maksymalna szerokość:"
+
+#: ../src/richtext/richtextsizepage.cpp:437
+#: ../src/richtext/richtextsizepage.cpp:439
+msgid "Enable the maximum width value."
+msgstr "Włącz wartość maksymalnej szerokości."
+
+#: ../src/richtext/richtextsizepage.cpp:446
+#: ../src/richtext/richtextsizepage.cpp:448
+msgid "The object maximum width."
+msgstr "Maksymalna szerokość obiektu"
+
+#: ../src/richtext/richtextsizepage.cpp:457
+#: ../src/richtext/richtextsizepage.cpp:459
+msgid "Units for the maximum object width."
+msgstr "Jednostki maksymalnej szerokości obiektu."
+
+#: ../src/richtext/richtextsizepage.cpp:462
+msgid "Max height:"
+msgstr "Maksymalna wysokość:"
+
+#: ../src/richtext/richtextsizepage.cpp:473
+#: ../src/richtext/richtextsizepage.cpp:475
+msgid "The object maximum height."
+msgstr "Maksymalna wysokość obiektu"
+
+#: ../src/richtext/richtextsizepage.cpp:484
+#: ../src/richtext/richtextsizepage.cpp:486
+msgid "Units for the maximum object height."
+msgstr "Jednostki maksymalnej wysokości obiektu."
+
+#: ../src/richtext/richtextsizepage.cpp:495
+msgid "Position"
+msgstr "PozycjaPytanie"
+
+#: ../src/richtext/richtextsizepage.cpp:513
+msgid "&Position mode:"
+msgstr "&Tryb pozycji:"
+
+#: ../src/richtext/richtextsizepage.cpp:517
+#: ../src/richtext/richtextsizepage.cpp:522
+msgid "Static"
+msgstr "Statyczny"
+
+#: ../src/richtext/richtextsizepage.cpp:518
+msgid "Relative"
+msgstr "Względnie"
+
+#: ../src/richtext/richtextsizepage.cpp:519
+msgid "Absolute"
+msgstr "Absolutne"
+
+#: ../src/richtext/richtextsizepage.cpp:520
+msgid "Fixed"
+msgstr "Czcionka o stałej szerokości"
+
+#: ../src/richtext/richtextsizepage.cpp:533
+#: ../src/richtext/richtextsizepage.cpp:535
+#: ../src/richtext/richtextsizepage.cpp:547
+#: ../src/richtext/richtextsizepage.cpp:549
+msgid "The left position."
+msgstr "Pozycja z lewej."
+
+#: ../src/richtext/richtextsizepage.cpp:558
+#: ../src/richtext/richtextsizepage.cpp:560
+msgid "Units for the left position."
+msgstr "Jednostka pozycji z lewej."
+
+#: ../src/richtext/richtextsizepage.cpp:568
+#: ../src/richtext/richtextsizepage.cpp:570
+#: ../src/richtext/richtextsizepage.cpp:582
+#: ../src/richtext/richtextsizepage.cpp:584
+msgid "The top position."
+msgstr "Pozycja od góry."
+
+#: ../src/richtext/richtextsizepage.cpp:593
+#: ../src/richtext/richtextsizepage.cpp:595
+msgid "Units for the top position."
+msgstr "Jednostki pozycji od góry."
+
+#: ../src/richtext/richtextsizepage.cpp:603
+#: ../src/richtext/richtextsizepage.cpp:605
+#: ../src/richtext/richtextsizepage.cpp:617
+#: ../src/richtext/richtextsizepage.cpp:619
+msgid "The right position."
+msgstr "Pozycja z prawej."
+
+#: ../src/richtext/richtextsizepage.cpp:628
+#: ../src/richtext/richtextsizepage.cpp:630
+msgid "Units for the right position."
+msgstr "Jednostki pozycji od prawej."
+
+#: ../src/richtext/richtextsizepage.cpp:638
+#: ../src/richtext/richtextsizepage.cpp:640
+#: ../src/richtext/richtextsizepage.cpp:652
+#: ../src/richtext/richtextsizepage.cpp:654
+msgid "The bottom position."
+msgstr "Pozycja na dole."
+
+#: ../src/richtext/richtextsizepage.cpp:663
+#: ../src/richtext/richtextsizepage.cpp:665
+msgid "Units for the bottom position."
+msgstr "Jednostka pozycji od dołu."
+
+#: ../src/richtext/richtextsizepage.cpp:671
+msgid "&Move the object to:"
+msgstr "&Przenieś obiekt do:"
+
+#: ../src/richtext/richtextsizepage.cpp:674
+msgid "&Previous Paragraph"
+msgstr "&Poprzedni akapit"
+
+#: ../src/richtext/richtextsizepage.cpp:675
+#: ../src/richtext/richtextsizepage.cpp:677
+msgid "Moves the object to the previous paragraph."
+msgstr "Przenosi obiekt do poprzedniego paragrafu."
+
+#: ../src/richtext/richtextsizepage.cpp:680
+msgid "&Next Paragraph"
+msgstr "&Następny akapit"
+
+#: ../src/richtext/richtextsizepage.cpp:681
+#: ../src/richtext/richtextsizepage.cpp:683
+msgid "Moves the object to the next paragraph."
+msgstr "Przenosi obiekt do następnego akapitu."
+
+#: ../src/richtext/richtextstyledlg.cpp:193
+msgid "&Styles:"
+msgstr "&Style:"
+
+#: ../src/richtext/richtextstyledlg.cpp:197
+#: ../src/richtext/richtextstyledlg.cpp:199
+msgid "The available styles."
+msgstr "Dostępne style."
+
+#: ../src/richtext/richtextstyledlg.cpp:205
+#: ../src/richtext/richtextstyledlg.cpp:217
+msgid " "
+msgstr " "
+
+#: ../src/richtext/richtextstyledlg.cpp:209
+#: ../src/richtext/richtextstyledlg.cpp:211
+msgid "The style preview."
+msgstr "Podgląd stylu."
+
+#: ../src/richtext/richtextstyledlg.cpp:220
+msgid "New &Character Style..."
+msgstr "Nowy styl &znaku..."
+
+#: ../src/richtext/richtextstyledlg.cpp:221
+#: ../src/richtext/richtextstyledlg.cpp:223
+msgid "Click to create a new character style."
+msgstr "Kliknij, aby utworzyć nowy styl znaków."
+
+#: ../src/richtext/richtextstyledlg.cpp:226
+msgid "New &Paragraph Style..."
+msgstr "Nowy styl &paragrafu..."
+
+#: ../src/richtext/richtextstyledlg.cpp:227
+#: ../src/richtext/richtextstyledlg.cpp:229
+msgid "Click to create a new paragraph style."
+msgstr "Kliknij, aby utworzyć nowy styl paragrafu."
+
+#: ../src/richtext/richtextstyledlg.cpp:232
+msgid "New &List Style..."
+msgstr "Nowy styl &listy..."
+
+#: ../src/richtext/richtextstyledlg.cpp:233
+#: ../src/richtext/richtextstyledlg.cpp:235
+msgid "Click to create a new list style."
+msgstr "Kliknij, aby utworzyć nowy styl listy."
+
+#: ../src/richtext/richtextstyledlg.cpp:238
+msgid "New &Box Style..."
+msgstr "Nowy styl &bloku..."
+
+#: ../src/richtext/richtextstyledlg.cpp:239
+#: ../src/richtext/richtextstyledlg.cpp:241
+msgid "Click to create a new box style."
+msgstr "Kliknij, aby utworzyć nowy styl bloku."
+
+#: ../src/richtext/richtextstyledlg.cpp:246
+msgid "&Apply Style"
+msgstr "Z&astosuj styl"
+
+#: ../src/richtext/richtextstyledlg.cpp:247
+#: ../src/richtext/richtextstyledlg.cpp:249
+msgid "Click to apply the selected style."
+msgstr "Kliknij, aby zastosować wybrany styl."
+
+#: ../src/richtext/richtextstyledlg.cpp:252
+msgid "&Rename Style..."
+msgstr "&Zmień nazwę stylu..."
+
+#: ../src/richtext/richtextstyledlg.cpp:253
+#: ../src/richtext/richtextstyledlg.cpp:255
+msgid "Click to rename the selected style."
+msgstr "Kliknij, aby zmienić nazwę wybranego stylu."
+
+#: ../src/richtext/richtextstyledlg.cpp:258
+msgid "&Edit Style..."
+msgstr "&Edytuj styl..."
+
+#: ../src/richtext/richtextstyledlg.cpp:259
+#: ../src/richtext/richtextstyledlg.cpp:261
+msgid "Click to edit the selected style."
+msgstr "Kliknij, aby edytować wybrany styl."
+
+#: ../src/richtext/richtextstyledlg.cpp:264
+msgid "&Delete Style..."
+msgstr "&Usuń styl..."
+
+#: ../src/richtext/richtextstyledlg.cpp:265
+#: ../src/richtext/richtextstyledlg.cpp:267
+msgid "Click to delete the selected style."
+msgstr "Kliknij, aby usunąć wybrany styl."
+
+#: ../src/richtext/richtextstyledlg.cpp:274
+#: ../src/richtext/richtextstyledlg.cpp:276
+msgid "Click to close this window."
+msgstr "Kliknij, aby zamknąć to okno."
+
+#: ../src/richtext/richtextstyledlg.cpp:282
+msgid "&Restart numbering"
+msgstr "&Ponowienie numeracji"
+
+#: ../src/richtext/richtextstyledlg.cpp:284
+#: ../src/richtext/richtextstyledlg.cpp:286
+msgid "Check to restart numbering."
+msgstr "Zaznacz aby ponownie uruchomić numerację."
+
+#: ../src/richtext/richtextstyledlg.cpp:601
+msgid "Enter a character style name"
+msgstr "Wprowadź nazwę stylu znaku"
+
+#: ../src/richtext/richtextstyledlg.cpp:601
+#: ../src/richtext/richtextstyledlg.cpp:606
+#: ../src/richtext/richtextstyledlg.cpp:649
+#: ../src/richtext/richtextstyledlg.cpp:654
+#: ../src/richtext/richtextstyledlg.cpp:815
+#: ../src/richtext/richtextstyledlg.cpp:820
+#: ../src/richtext/richtextstyledlg.cpp:888
+#: ../src/richtext/richtextstyledlg.cpp:896
+#: ../src/richtext/richtextstyledlg.cpp:929
+#: ../src/richtext/richtextstyledlg.cpp:934
+msgid "New Style"
+msgstr "Nowy styl"
+
+#: ../src/richtext/richtextstyledlg.cpp:606
+#: ../src/richtext/richtextstyledlg.cpp:654
+#: ../src/richtext/richtextstyledlg.cpp:820
+#: ../src/richtext/richtextstyledlg.cpp:896
+#: ../src/richtext/richtextstyledlg.cpp:934
+msgid "Sorry, that name is taken. Please choose another."
+msgstr "Niestety, nazwa ta jest zajęta. Proszę wybrać inną."
+
+#: ../src/richtext/richtextstyledlg.cpp:649
+msgid "Enter a paragraph style name"
+msgstr "Wprowadź nazwę stylu paragrafu"
+
+#: ../src/richtext/richtextstyledlg.cpp:777
+#, c-format
+msgid "Delete style %s?"
+msgstr "Usuń styl %s?"
+
+#: ../src/richtext/richtextstyledlg.cpp:777
+msgid "Delete Style"
+msgstr "Usuń styl"
+
+#: ../src/richtext/richtextstyledlg.cpp:815
+msgid "Enter a list style name"
+msgstr "Wprowadź nazwę listy stylu"
+
+#: ../src/richtext/richtextstyledlg.cpp:888
+msgid "Enter a new style name"
+msgstr "Podaj nową nazwę stylu"
+
+#: ../src/richtext/richtextstyledlg.cpp:929
+msgid "Enter a box style name"
+msgstr "Podaj nową nazwę stylu bloku"
+
+#: ../src/richtext/richtextstylepage.cpp:109
+#: ../src/richtext/richtextstylepage.cpp:111
+msgid "The style name."
+msgstr "Nazwa stylu."
+
+#: ../src/richtext/richtextstylepage.cpp:114
+msgid "&Based on:"
+msgstr "&Na podstawie:"
+
+#: ../src/richtext/richtextstylepage.cpp:119
+#: ../src/richtext/richtextstylepage.cpp:121
+msgid "The style on which this style is based."
+msgstr "Styl, na którym ten styl jest oparty."
+
+#: ../src/richtext/richtextstylepage.cpp:124
+msgid "&Next style:"
+msgstr "&Następny styl:"
+
+#: ../src/richtext/richtextstylepage.cpp:129
+#: ../src/richtext/richtextstylepage.cpp:131
+msgid "The default style for the next paragraph."
+msgstr "Domyślny styl dla następnego paragrafu."
+
+#: ../src/richtext/richtextstyles.cpp:1057
+msgid "All styles"
+msgstr "Wszystkie style"
+
+#: ../src/richtext/richtextstyles.cpp:1058
+msgid "Paragraph styles"
+msgstr "Style paragrafu"
+
+#: ../src/richtext/richtextstyles.cpp:1059
+msgid "Character styles"
+msgstr "Style znaku"
+
+#: ../src/richtext/richtextstyles.cpp:1060
+msgid "List styles"
+msgstr "Style listy"
+
+#: ../src/richtext/richtextstyles.cpp:1061
+msgid "Box styles"
+msgstr "Style bloku"
+
+#: ../src/richtext/richtextsymboldlg.cpp:389
+#: ../src/richtext/richtextsymboldlg.cpp:391
+msgid "The font from which to take the symbol."
+msgstr "Czcionka z której pobrać symbol."
+
+#: ../src/richtext/richtextsymboldlg.cpp:396
+msgid "&Subset:"
+msgstr "&Podzbiór:"
+
+#: ../src/richtext/richtextsymboldlg.cpp:401
+#: ../src/richtext/richtextsymboldlg.cpp:403
+msgid "Shows a Unicode subset."
+msgstr "Pokazuje podzbiór Unicode."
+
+#: ../src/richtext/richtextsymboldlg.cpp:412
+msgid "xxxx"
+msgstr "xxxx"
+
+#: ../src/richtext/richtextsymboldlg.cpp:417
+msgid "&Character code:"
+msgstr "&Kod znaku:"
+
+#: ../src/richtext/richtextsymboldlg.cpp:421
+#: ../src/richtext/richtextsymboldlg.cpp:423
+msgid "The character code."
+msgstr "Kod znaku."
+
+#: ../src/richtext/richtextsymboldlg.cpp:428
+msgid "&From:"
+msgstr "&Od:"
+
+#: ../src/richtext/richtextsymboldlg.cpp:433
+#: ../src/richtext/richtextsymboldlg.cpp:434
+#: ../src/richtext/richtextsymboldlg.cpp:435
+msgid "Unicode"
+msgstr "Unicode"
+
+#: ../src/richtext/richtextsymboldlg.cpp:436
+#: ../src/richtext/richtextsymboldlg.cpp:438
+msgid "The range to show."
+msgstr "Zakres do pokazania."
+
+#: ../src/richtext/richtextsymboldlg.cpp:444
+msgid "Insert"
+msgstr "Wstawić"
+
+#: ../src/richtext/richtextsymboldlg.cpp:478
+msgid "(Normal text)"
+msgstr "(Normalny tekst)"
+
+#: ../src/richtext/richtexttabspage.cpp:109
+msgid "&Position (tenths of a mm):"
+msgstr "&Pozycja (w dziesiątych częściach mm):"
+
+#: ../src/richtext/richtexttabspage.cpp:113
+#: ../src/richtext/richtexttabspage.cpp:115
+msgid "The tab position."
+msgstr "Pozycja karty."
+
+#: ../src/richtext/richtexttabspage.cpp:119
+msgid "The tab positions."
+msgstr "Pozycje karty."
+
+#: ../src/richtext/richtexttabspage.cpp:132
+#: ../src/richtext/richtexttabspage.cpp:134
+msgid "Click to create a new tab position."
+msgstr "Kliknij, aby utworzyć nową pozycję karty."
+
+#: ../src/richtext/richtexttabspage.cpp:138
+#: ../src/richtext/richtexttabspage.cpp:140
+msgid "Click to delete the selected tab position."
+msgstr "Kliknij, aby usunąć wybraną pozycję karty."
+
+#: ../src/richtext/richtexttabspage.cpp:143
+msgid "Delete A&ll"
+msgstr "&Usuń wszystko"
+
+#: ../src/richtext/richtexttabspage.cpp:144
+#: ../src/richtext/richtexttabspage.cpp:146
+msgid "Click to delete all tab positions."
+msgstr "Kliknij, aby usunąć wszystkie pozycje kart."
+
+#: ../src/univ/theme.cpp:110
+msgid "Failed to initialize GUI: no built-in themes found."
+msgstr "Nie udało się zainicjować GUI: brak wbudowanych kompozycji."
+
+#: ../src/univ/themes/gtk.cpp:521
+msgid "GTK+ theme"
+msgstr "Kompozycja GTK+"
+
+#: ../src/univ/themes/metal.cpp:164
+msgid "Metal theme"
+msgstr "Kompozycja metalowa"
+
+#: ../src/univ/themes/mono.cpp:512
+msgid "Simple monochrome theme"
+msgstr "Prosty czarno-biały motyw"
+
+#: ../src/univ/themes/win32.cpp:1098
+msgid "Win32 theme"
+msgstr "Kompozycja Win32"
+
+#: ../src/univ/themes/win32.cpp:3743
+msgid "&Restore"
+msgstr "&Przywróć"
+
+#: ../src/univ/themes/win32.cpp:3744
+msgid "&Move"
+msgstr "Prz&enieś"
+
+#: ../src/univ/themes/win32.cpp:3746
+msgid "&Size"
+msgstr "&Rozmiar"
+
+#: ../src/univ/themes/win32.cpp:3748
+msgid "Mi&nimize"
+msgstr "Mi&nimalizuj"
+
+#: ../src/univ/themes/win32.cpp:3750
+msgid "Ma&ximize"
+msgstr "&Maksymalizuj"
+
+#: ../src/univ/themes/win32.cpp:3752
+msgid "Alt+"
+msgstr "Alt+"
+
+# uchwyt chyba zbędny
+#: ../src/unix/appunix.cpp:178
+msgid "Failed to install signal handler"
+msgstr "Nie udało się zainstalować obsługi sygnału"
+
+#: ../src/unix/dialup.cpp:351
+msgid "Already dialling ISP."
+msgstr "Już łączy z ISP."
+
+#: ../src/unix/dlunix.cpp:93
+#, fuzzy
+msgid "Failed to unload shared library"
+msgstr "Nie udało się wczytać biblioteki '%s'."
+
+#: ../src/unix/dlunix.cpp:121
+msgid "Unknown dynamic library error"
+msgstr "Nieznany błąd biblioteki dynamicznej"
+
+#: ../src/unix/epolldispatcher.cpp:84
+msgid "Failed to create epoll descriptor"
+msgstr "Nie udało się utworzyć deskryptora epoll"
+
+#: ../src/unix/epolldispatcher.cpp:103
+msgid "Error closing epoll descriptor"
+msgstr "Błąd zamknięcia deskryptora epoll"
+
+#: ../src/unix/epolldispatcher.cpp:116
+#, c-format
+msgid "Failed to add descriptor %d to epoll descriptor %d"
+msgstr "Nie udało się dodać deskryptora %d do deskryptora epoll %d"
+
+#: ../src/unix/epolldispatcher.cpp:136
+#, c-format
+msgid "Failed to modify descriptor %d in epoll descriptor %d"
+msgstr "Nie można zmienić hasła %d w deskryptorze epoll %d"
+
+#: ../src/unix/epolldispatcher.cpp:155
+#, c-format
+msgid "Failed to unregister descriptor %d from epoll descriptor %d"
+msgstr "Nie udało się wyrejestrować deskryptora %d z deskryptora epoll %d"
+
+#: ../src/unix/epolldispatcher.cpp:213
+#, c-format
+msgid "Waiting for IO on epoll descriptor %d failed"
+msgstr "Oczekiwanie na IO w deskryptorze epoll %d nie powiodło się"
+
+#: ../src/unix/fswatcher_inotify.cpp:71
+msgid "Unable to create inotify instance"
+msgstr "Nie można utworzyć instancji inotify"
+
+# uchwyt chyba zbędny
+#: ../src/unix/fswatcher_inotify.cpp:94
+msgid "Unable to close inotify instance"
+msgstr "Nie można zamknąć instancji inotify"
+
+#: ../src/unix/fswatcher_inotify.cpp:106
+msgid "Unable to add inotify watch"
+msgstr "Nie można dodać czujki inotify"
+
+#: ../src/unix/fswatcher_inotify.cpp:138
+#, fuzzy, c-format
+msgid "Unable to remove inotify watch %i"
+msgstr "Nie można usunąć czujki inotify"
+
+#: ../src/unix/fswatcher_inotify.cpp:271
+#, c-format
+msgid "Unexpected event for \"%s\": no matching watch descriptor."
+msgstr "NIeoczekiwane zdarzenie dla \"%s\": brak pasującego deskryptora."
+
+#: ../src/unix/fswatcher_inotify.cpp:320
+#, c-format
+msgid "Invalid inotify event for \"%s\""
+msgstr "Nieprawidłowe zdarzenie inotify dla \"%s\""
+
+#: ../src/unix/fswatcher_inotify.cpp:553
+msgid "Unable to read from inotify descriptor"
+msgstr "Błąd odczytu z deskryptora inotify"
+
+#: ../src/unix/fswatcher_inotify.cpp:558
+msgid "EOF while reading from inotify descriptor"
+msgstr "EOF podczas odczytu z deskryptora inotify"
+
+#: ../src/unix/fswatcher_kqueue.cpp:114
+msgid "Unable to create kqueue instance"
+msgstr "Nie można utworzyć instancji kqueue"
+
+#: ../src/unix/fswatcher_kqueue.cpp:131
+msgid "Error closing kqueue instance"
+msgstr "Błąd podczas zamykania instancji kqueue"
+
+#: ../src/unix/fswatcher_kqueue.cpp:153
+msgid "Unable to add kqueue watch"
+msgstr "Nie można dodać czujki kolejki"
+
+#: ../src/unix/fswatcher_kqueue.cpp:170
+msgid "Unable to remove kqueue watch"
+msgstr "Nie można usunąć czujki kolejki"
+
+#: ../src/unix/fswatcher_kqueue.cpp:202
+msgid "Unable to get events from kqueue"
+msgstr "Nie można pobrać zdarzeń z kolejki"
+
+#: ../src/unix/mediactrl.cpp:966
+#, c-format
+msgid "Media playback error: %s"
+msgstr "Błąd odtwarzania mediów: %s"
+
+#: ../src/unix/mediactrl.cpp:1228
+#, c-format
+msgid "Failed to prepare playing \"%s\"."
+msgstr "Nie udało się przygotowanie odtwarzania \"%s\"."
+
+# ze źródeł wynika że chodzi o PID
+#: ../src/unix/snglinst.cpp:164
+#, c-format
+msgid "Failed to write to lock file '%s'"
+msgstr "Nie udało się zapisać identyfikatora do pliku blokującego '%s'"
+
+#: ../src/unix/snglinst.cpp:177
+#, c-format
+msgid "Failed to set permissions on lock file '%s'"
+msgstr "Nie udało się nadanie praw dostępu na blokowanym pliku '%s'"
+
+#: ../src/unix/snglinst.cpp:194
+#, c-format
+msgid "Failed to lock the lock file '%s'"
+msgstr "Nie udało się zablokować pliku blokującego '%s'"
+
+#: ../src/unix/snglinst.cpp:237
+#, c-format
+msgid "Failed to inspect the lock file '%s'"
+msgstr "Nie udało się sprawdzenie blokady pliku '%s'"
+
+#: ../src/unix/snglinst.cpp:242
+#, c-format
+msgid "Lock file '%s' has incorrect owner."
+msgstr "Blokowany plik '%s' ma niewłaściwego właściciela."
+
+#: ../src/unix/snglinst.cpp:247
+#, c-format
+msgid "Lock file '%s' has incorrect permissions."
+msgstr "Blokowany plik '%s' ma niewłaściwe uprawnienia."
+
+#: ../src/unix/snglinst.cpp:265
+msgid "Failed to access lock file."
+msgstr "Nie udało się dostać do pliku blokującego."
+
+#: ../src/unix/snglinst.cpp:274
+msgid "Failed to read PID from lock file."
+msgstr "Nie udało sie odczytać identyfikatora z pliku blokującego."
+
+# stale --> ?
+#: ../src/unix/snglinst.cpp:284
+#, c-format
+msgid "Failed to remove stale lock file '%s'."
+msgstr "Nie udało się usunąć nieaktualnego pliku blokującego '%s'."
+
+#: ../src/unix/snglinst.cpp:297
+#, c-format
+msgid "Deleted stale lock file '%s'."
+msgstr "Nieaktualny plik blokujący '%s' został usunięty."
+
+#: ../src/unix/snglinst.cpp:308
+#, c-format
+msgid "Invalid lock file '%s'."
+msgstr "Nieprawidłowy plik blokujący '%s'."
+
+#: ../src/unix/snglinst.cpp:324
+#, c-format
+msgid "Failed to remove lock file '%s'"
+msgstr "Nie udało się usunąć pliku blokującego '%s'"
+
+#: ../src/unix/snglinst.cpp:330
+#, c-format
+msgid "Failed to unlock lock file '%s'"
+msgstr "Nie udało się odblokować pliku blokującego '%s'"
+
+#: ../src/unix/snglinst.cpp:336
+#, c-format
+msgid "Failed to close lock file '%s'"
+msgstr "Nie udało się zamknąć pliku blokującego '%s'"
+
+#: ../src/unix/sound.cpp:77
+msgid "No sound"
+msgstr "Brak dźwięku"
+
+#: ../src/unix/sound.cpp:364
+msgid "Unable to play sound asynchronously."
+msgstr "Nie można odtowrzyć dźwięku asynchronicznie."
+
+#: ../src/unix/sound.cpp:458
+#, c-format
+msgid "Couldn't load sound data from '%s'."
+msgstr "Nie można wczytać danych dźwiękowych '%s'."
+
+#: ../src/unix/sound.cpp:465
+#, c-format
+msgid "Sound file '%s' is in unsupported format."
+msgstr "Plik z dźwiękiem '%s' jest w formacie, który nie jest wspierany."
+
+#: ../src/unix/sound.cpp:480
+msgid "Sound data are in unsupported format."
+msgstr "Dane dźwiękowe są w formacie, który nie jest wspierany."
+
+#: ../src/unix/sound_sdl.cpp:226
+#, c-format
+msgid "Couldn't open audio: %s"
+msgstr "Nie można otworzyć dźwięku: %s"
+
+#: ../src/unix/threadpsx.cpp:1033
+msgid "Cannot retrieve thread scheduling policy."
+msgstr "Nie można uzyskać strategii harmonogramowania wątków."
+
+#: ../src/unix/threadpsx.cpp:1058
+#, c-format
+msgid "Cannot get priority range for scheduling policy %d."
+msgstr "Nie można uzyskać zakresu priorytetów strategii harmogramowania %d."
+
+#: ../src/unix/threadpsx.cpp:1066
+msgid "Thread priority setting is ignored."
+msgstr "Ustawienie priorytetu wątku jest ignorowane."
+
+# połączyć?
+# wyciek?
+#: ../src/unix/threadpsx.cpp:1221
+msgid ""
+"Failed to join a thread, potential memory leak detected - please restart the "
+"program"
+msgstr ""
+"Nie udało połączyć się z wątkiem, potencjalny wyciek pamięci - uruchom "
+"program ponownie"
+
+#: ../src/unix/threadpsx.cpp:1352
+#, c-format
+msgid "Failed to set thread concurrency level to %lu"
+msgstr "Błąd podczas ustawiania priorytetu wątku na %lu"
+
+#: ../src/unix/threadpsx.cpp:1481
+#, c-format
+msgid "Failed to set thread priority %d."
+msgstr "Nie udało się zmienić priorytetu wątku na %d."
+
+#: ../src/unix/threadpsx.cpp:1666
+msgid "Failed to terminate a thread."
+msgstr "Nie udało się zakończyć wątku."
+
+#: ../src/unix/threadpsx.cpp:1893
+msgid "Thread module initialization failed: failed to create thread key"
+msgstr ""
+"Zainicjowanie modułu wątków nie powiodło się: nie udało się utworzyć klucza "
+"wątków"
+
+#: ../src/unix/utilsunx.cpp:340
+msgid "Impossible to get child process input"
+msgstr "Nie jest możliwe uzyskanie wejścia procesu potomnego"
+
+#: ../src/unix/utilsunx.cpp:390
+msgid "Can't write to child process's stdin"
+msgstr ""
+"Błąd zapisu do standardowego strumienia wejściowego (stdin) procesu potomnego"
+
+#: ../src/unix/utilsunx.cpp:644
+#, c-format
+msgid "Failed to execute '%s'\n"
+msgstr "Nie udało się wykonać '%s'\n"
+
+#: ../src/unix/utilsunx.cpp:678
+msgid "Fork failed"
+msgstr "Rozwidlenie nie powiodło się"
+
+#: ../src/unix/utilsunx.cpp:701
+msgid "Failed to set process priority"
+msgstr "Błąd podczas ustawiania priorytetu procesu"
+
+#: ../src/unix/utilsunx.cpp:712
+msgid "Failed to redirect child process input/output"
+msgstr "Nie udało się przekierować wejścia/wyjścia procesu potomnego."
+
+#: ../src/unix/utilsunx.cpp:816
+msgid "Failed to set up non-blocking pipe, the program might hang."
+msgstr "Nie udało się ustawić nieblokowego potoku, program może się zawiesić."
+
+#: ../src/unix/utilsunx.cpp:1023
+msgid "Cannot get the hostname"
+msgstr "Nie można pobrać nazwy serwera"
+
+#: ../src/unix/utilsunx.cpp:1059
+msgid "Cannot get the official hostname"
+msgstr "Nie można pobrać oficjalnej nazwy serwera"
+
+#: ../src/unix/wakeuppipe.cpp:49
+msgid "Failed to create wake up pipe used by event loop."
+msgstr "Nie udało się utworzyć potoku budzącego używanego przez pętlę zdarzeń."
+
+#: ../src/unix/wakeuppipe.cpp:56
+msgid "Failed to switch wake up pipe to non-blocking mode"
+msgstr "Nie udało się przełączyć potoku budzącego na modus nie-blokujący"
+
+#: ../src/unix/wakeuppipe.cpp:117
+msgid "Failed to read from wake-up pipe"
+msgstr "Nie udało się czytać z potoku budzącego"
+
+# Pytanie X11
+#: ../src/x11/app.cpp:124
+#, c-format
+msgid "Invalid geometry specification '%s'"
+msgstr "Niedozwolona specyfikacja \"geometry\" '%s'."
+
+#: ../src/x11/app.cpp:167
+msgid "wxWidgets could not open display. Exiting."
+msgstr "Nie można zainicjować wyświetlania. Program kończy pracę."
+
+#: ../src/x11/utils.cpp:169
+#, c-format
+msgid "Failed to close the display \"%s\""
+msgstr "Nie udało się zamknąć ekranu \"%s\""
+
+#: ../src/x11/utils.cpp:188
+#, c-format
+msgid "Failed to open display \"%s\"."
+msgstr "Nie udało się otworzyć ekranu \"%s\"."
+
+#: ../src/xml/xml.cpp:868
+#, c-format
+msgid "XML parsing error: '%s' at line %d"
+msgstr "Błąd parsowania XML: '%s' w linii %d"
+
+#: ../src/xrc/xh_propgrid.cpp:239
+#, fuzzy, c-format
+msgid "Page %i"
+msgstr "Strona %d"
+
+#: ../src/xrc/xmlres.cpp:448
+#, c-format
+msgid "Cannot load resources from '%s'."
+msgstr "Nie można wczytać zasobów z pliku '%s'."
+
+#: ../src/xrc/xmlres.cpp:799
+#, c-format
+msgid "Cannot open resources file '%s'."
+msgstr "Nie można wczytać zasobów z pliku '%s'."
+
+#: ../src/xrc/xmlres.cpp:806
+#, c-format
+msgid "Cannot load resources from file '%s'."
+msgstr "Nie można wczytać zasobów z pliku '%s'."
+
+#: ../src/xrc/xmlres.cpp:2767
+#, fuzzy, c-format
+msgid "Creating %s \"%s\" failed."
+msgstr "Pobranie '%s' do '%s' nie powiodło się."
+
+#~ msgctxt "keyboard key"
+#~ msgid "Alt+"
+#~ msgstr "Alt+"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Ctrl+"
+#~ msgstr "Ctrl+"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Shift+"
+#~ msgstr "Shift+"
+
+#~ msgctxt "keyboard key"
+#~ msgid "RawCtrl+"
+#~ msgstr "RawCtrl+"
+
+#~ msgid "Unsupported clipboard format."
+#~ msgstr "Nieobsługiwany format schowka."
+
+#~ msgid "Background colour"
+#~ msgstr "Kolor tła"
+
+#~ msgid "Font:"
+#~ msgstr "Czcionka:"
+
+#~ msgid "Size:"
+#~ msgstr "Rozmiar:"
+
+#~ msgid "The font size in points."
+#~ msgstr "Rozmiar czcionki w punktach."
+
+#~ msgid "Style:"
+#~ msgstr "Styl:"
+
+#~ msgid "Check to make the font bold."
+#~ msgstr "Zaznacz aby pogrubić czcionkę."
+
+#~ msgid "Check to make the font italic."
+#~ msgstr "Zaznacz aby uzyskać kursywę czcionki."
+
+#~ msgid "Check to make the font underlined."
+#~ msgstr "Zaznacz aby podkreślić czcionkę."
+
+#~ msgid "Colour:"
+#~ msgstr "Kolor:"
+
+#~ msgid "Click to change the font colour."
+#~ msgstr "Kliknij, aby zmienić kolor czcionki."
+
+#~ msgid "Shows a preview of the font."
+#~ msgstr "Pokazuje podgląd czcionki."
+
+#~ msgid "Click to cancel changes to the font."
+#~ msgstr "Kliknij, aby anulować zmiany czcionki."
+
+#~ msgid "Click to confirm changes to the font."
+#~ msgstr "Kliknij, aby potwierdzić zmiany czcionki."
+
+#~ msgid "<Any>"
+#~ msgstr "<dowolny>"
+
+#~ msgid "<Any Roman>"
+#~ msgstr "<dowolny rzymski>"
+
+#~ msgid "<Any Decorative>"
+#~ msgstr "<dowolny ozdobny>"
+
+#~ msgid "<Any Modern>"
+#~ msgstr "<dowolny współczesny>"
+
+#~ msgid "<Any Script>"
+#~ msgstr "<dowolny Skrypt>"
+
+#~ msgid "<Any Swiss>"
+#~ msgstr "<dowolny szwajcarski>"
+
+#~ msgid "<Any Teletype>"
+#~ msgstr "<dowolny Teletype>"
+
+#~ msgid "Printing "
+#~ msgstr "Drukowanie "
+
+#~ msgid "Failed to insert text in the control."
+#~ msgstr "Nie udało się  wstawić tekstu w kontroli."
+
+#~ msgid "Please choose a valid font."
+#~ msgstr "Proszę wybrać poprawną czcionkę."
+
+#, c-format
+#~ msgid "Failed to display HTML document in %s encoding"
+#~ msgstr "Nie udało się wyświelić dokumentu HTML w kodowaniu %s"
+
+#, c-format
+#~ msgid "wxWidgets could not open display for '%s': exiting."
+#~ msgstr "Nie można zainicjować wyświetlania dla '%s': program kończy pracę."
+
+#~ msgid "Filter"
+#~ msgstr "Filtr"
+
+#~ msgid "Directories"
+#~ msgstr "Katalogi"
+
+#~ msgid "Files"
+#~ msgstr "Pliki"
+
+#~ msgid "Selection"
+#~ msgstr "Wybór"
+
+#~ msgid "conversion to 8-bit encoding failed"
+#~ msgstr "nie powiodła się konwersja do kodowania '8-bit'"
+
+#, fuzzy
+#~ msgid "failed to retrieve execution result"
+#~ msgstr "Nie udało się uzyskać tekstu komunikatu błędu RAS"
+
+#~ msgid "&Save as"
+#~ msgstr "Zapisz &Jako"
+
+#, fuzzy
+#~ msgid "'%s' doesn't consist only of valid characters"
+#~ msgstr "'%s' powinien zawierać tylko wartości znakowe."
+
+#~ msgid "'%s' should be numeric."
+#~ msgstr "'%s' powinno być numeryczne."
+
+#~ msgid "'%s' should only contain ASCII characters."
+#~ msgstr "'%s' powinien zawierać tylko znaki ASCII."
+
+#~ msgid "'%s' should only contain alphabetic characters."
+#~ msgstr "'%s' powinien zawierać tylko wartości znakowe."
+
+#~ msgid "'%s' should only contain alphabetic or numeric characters."
+#~ msgstr "'%s' powinien zawierać tylko wartości znakowe lub numeryczne."
+
+#~ msgid "'%s' should only contain digits."
+#~ msgstr "'%s' powinien zawierać tylko cyfry."
+
+#~ msgid "Can't create window of class %s"
+#~ msgstr "Nie można utworzyć okna klasy '%s'"
+
+#~ msgid "Couldn't create the overlay window"
+#~ msgstr "Nie można utworzyć okna nakładki"
+
+#~ msgid "Couldn't init the context on the overlay window"
+#~ msgstr "Nie można zainicjować kontekstu w oknie nakładki"
+
+# uchwyt chyba zbędny
+#~ msgid "Failed to convert file \"%s\" to Unicode."
+#~ msgstr "Nie udało się zamienić pliku \"%s\" na Unicode."
+
+#~ msgid "Failed to set text in the text control."
+#~ msgstr "Nie udało się ustawić tekstu w kontroli tekstu."
+
+#~ msgid "Invalid GTK+ command line option, use \"%s --help\""
+#~ msgstr "Nieprawidłowa opcja GTK+ wiersza poleceń, należy użyć \"%s --help\""
+
+#~ msgid "No unused colour in image."
+#~ msgstr "Brak wolnych kolorów w obrazie."
+
+#~ msgid "Not available"
+#~ msgstr "Niedostępne"
+
+#~ msgid "Replace selection"
+#~ msgstr "Zastąp wybór"
+
+#~ msgid "Save as"
+#~ msgstr "Zapisz jako"
+
+#~ msgid "Style Organiser"
+#~ msgstr "Organizator stylu"
+
+#~ msgid "The following standard GTK+ options are also supported:\n"
+#~ msgstr "Następujące opcje standardowe GTK+ także są obsługiwane:\n"
+
+#~ msgid "You cannot Clear an overlay that is not inited"
+#~ msgstr "Nie można wyczyścić nakładki, która nie jest zainicjowana"
+
+#~ msgid "You cannot Init an overlay twice"
+#~ msgstr "Nie można uruchomić nakładki podwójnie"
+
+#~ msgid "locale '%s' cannot be set."
+#~ msgstr "lokalizacja '%s' nie może być ustawiona."
+
+#~ msgid "Adding flavor TEXT failed"
+#~ msgstr "Dodanie rodzaju TEXT zawiodło"
+
+#~ msgid "Adding flavor utxt failed"
+#~ msgstr "Dodanie rodzaju utxt zawiodło"
+
+#~ msgid "Bitmap renderer cannot render value; value type: "
+#~ msgstr "Bitmap renderer nie mógł wyświetlić wartości; typ wartości:"
+
+#~ msgid ""
+#~ "Cannot create new column's ID. Probably max. number of columns reached."
+#~ msgstr ""
+#~ "Nie można utworzyć nowego ID kolumny. Prawdopodobnie została osiągnięta "
+#~ "maks. liczba kolumn."
+
+#~ msgid "Column could not be added."
+#~ msgstr "Kolumna nie mogła być dodana."
+
+# catalog file --> ?
+# domain --> ?
+#~ msgid "Column index not found."
+#~ msgstr "Nie znaleziono indeksu kolumny."
+
+#~ msgid "Column width could not be determined"
+#~ msgstr "Szerokość kolumny nie może być ustalona"
+
+#~ msgid "Column width could not be set."
+#~ msgstr "Szerokość kolumny nie może być ustawiona."
+
+#~ msgid "Confirm registry update"
+#~ msgstr "Potwierdź uaktualnienie rejestru"
+
+#~ msgid "Could not determine column index."
+#~ msgstr "Nie można określić indeksu kolumny."
+
+#~ msgid "Could not determine column's position"
+#~ msgstr "Nie można określić pozycji kolumny"
+
+#~ msgid "Could not determine number of columns."
+#~ msgstr "Nie można określić ilości kolumn"
+
+#~ msgid "Could not determine number of items"
+#~ msgstr "Nie można określić ilości elementów"
+
+#~ msgid "Could not get header description."
+#~ msgstr "Nie można uzyskać opisu nagłówku."
+
+#~ msgid "Could not get items."
+#~ msgstr "Nie można uzyskać elementów."
+
+#~ msgid "Could not get property flags."
+#~ msgstr "Nie można pobrać flag właściwości."
+
+#~ msgid "Could not get selected items."
+#~ msgstr "Nie można pobrać wybranych elementów."
+
+#~ msgid "Could not remove column."
+#~ msgstr "Nie można usunąć kolumny."
+
+#~ msgid "Could not retrieve number of items"
+#~ msgstr "Nie można pobrać ilości elementów"
+
+#~ msgid "Could not set column width."
+#~ msgstr "Nie można ustawić szerokości kolumny."
+
+#~ msgid "Could not set header description."
+#~ msgstr "Nie można ustawić opisu nagłówka."
+
+#~ msgid "Could not set icon."
+#~ msgstr "Nie można ustawić ikony."
+
+#~ msgid "Could not set maximum width."
+#~ msgstr "Nie można ustawić maksymalnej szerokości."
+
+#~ msgid "Could not set minimum width."
+#~ msgstr "Nie można ustawić minimalnej szerokości."
+
+#~ msgid "Could not set property flags."
+#~ msgstr "Nie można ustawić flag własności."
+
+#~ msgid "Data object has invalid data format"
+#~ msgstr "Obiekt danych ma nieprawidłowy format"
+
+#~ msgid "Date renderer cannot render value; value type: "
+#~ msgstr "Render daty nie może renderować wartości; typ wartości:"
+
+#~ msgid ""
+#~ "Do you want to overwrite the command used to %s files with extension "
+#~ "\"%s\" ?\n"
+#~ "Current value is \n"
+#~ "%s, \n"
+#~ "New value is \n"
+#~ "%s %1"
+#~ msgstr ""
+#~ "Chcesz zastąpić polecenie używane do plików %s z rozszerzeniem \"%s\" ?\n"
+#~ "Bieżaca wartość to \n"
+#~ "%s, \n"
+#~ "Nowa wartość to \n"
+#~ "%s %1"
+
+#~ msgid "Failed to retrieve data from the clipboard."
+#~ msgstr "Nie udało się odzyskać danych ze schowka."
+
+# ...indeks w grafice (?)
+# ideks - katalog, wska?nik?
+#~ msgid "GIF: Invalid gif index."
+#~ msgstr "GIF: Brak obrazu o podanym indeksie."
+
+#~ msgid "GIF: unknown error!!!"
+#~ msgstr "GIF: neznany błąd !!!"
+
+#~ msgid "Icon & text renderer cannot render value; value type: "
+#~ msgstr "Renderer ikony i tekstu nie może renderować wartości; typ wartości:"
+
+#~ msgid "New directory"
+#~ msgstr "Nowy katalog"
+
+#~ msgid "Next"
+#~ msgstr "Dalej"
+
+#~ msgid "No column existing."
+#~ msgstr "Nie istnieje kolumny."
+
+#~ msgid "No column for the specified column existing."
+#~ msgstr "Nie odnaleziono podanej kolumny."
+
+#~ msgid "No column for the specified column position existing."
+#~ msgstr "Nie istnieje kolumny dla określonej pozycji kolumny."
+
+#~ msgid ""
+#~ "No renderer or invalid renderer type specified for custom data column."
+#~ msgstr ""
+#~ "Nie ma rendera lub nieprawidłowy typ rendera określonego dla własnych "
+#~ "danych kolumny."
+
+#~ msgid "No renderer specified for column."
+#~ msgstr "Nie określono rendera dla kolumny."
+
+#~ msgid "Number of columns could not be determined."
+#~ msgstr "Ilość kolumn nie może być ustalona"
+
+#~ msgid "OpenGL function \"%s\" failed: %s (error %d)"
+#~ msgstr "Nie powiodła się funkcja \"%s\" OpenGL: %s (błąd %d)"
+
+#~ msgid ""
+#~ "Please install a newer version of comctl32.dll\n"
+#~ "(at least version 4.70 is required but you have %d.%02d)\n"
+#~ "or this program won't operate correctly."
+#~ msgstr ""
+#~ "Proszę zainstalować nowszą wersję bliblioteki comctl32.dll\n"
+#~ "(wymagana co najmniej 4.70, zainstalowana %d.%02d)\n"
+#~ "inaczej program nie będzie działał poprawnie."
+
+#~ msgid "Pointer to data view control not set correctly."
+#~ msgstr "Wskaźnik do kontroli widoku danych nie jest prawidłowo ustawiony."
+
+#~ msgid "Pointer to model not set correctly."
+#~ msgstr "Wskaźnik do modelu nie jest prawidłowo ustawiony."
+
+#~ msgid "Progress renderer cannot render value type; value type: "
+#~ msgstr "Render postępu nie może renderować typu wartości; typ wartości:"
+
+#~ msgid "Rendering failed."
+#~ msgstr "Rendering nie powiodł się."
+
+#~ msgid ""
+#~ "Setting directory access times is not supported under this OS version"
+#~ msgstr ""
+#~ "Ustawienie czasu dostępu do katalogów nie jest obsługiwane w tej wersji "
+#~ "systemu operacyjnego."
+
+#~ msgid "Show hidden directories"
+#~ msgstr "Pokaż ukryte katalogi"
+
+#~ msgid "Text renderer cannot render value; value type: "
+#~ msgstr "Render tekstu nie może renderować wartości; typ wartości:"
+
+#~ msgid "There is no column or renderer for the specified column index."
+#~ msgstr "Nie ma kolumny lub rendera dla określonej kolumny indeksu."
+
+#~ msgid ""
+#~ "This system doesn't support date controls, please upgrade your version of "
+#~ "comctl32.dll"
+#~ msgstr ""
+#~ "Ten system nie wspiera wyboru daty, należy zaktualizować bibliotekę "
+#~ "comctl32.dll"
+
+#~ msgid "Toggle renderer cannot render value; value type: "
+#~ msgstr "Aktywny render nie może renderować wartości; typ wartości:"
+
+#~ msgid "Too many colours in PNG, the image may be slightly blurred."
+#~ msgstr "Zbyt wiele kolorów w formacie PNG, obraz może być zamazany."
+
+#~ msgid "Unable to handle native drag&drop data"
+#~ msgstr "Nie można przetworzyć systemowych danych przeciągnij / upuść"
+
+#~ msgid "Unable to initialize Hildon program"
+#~ msgstr "Nie udało się zainicjować programu Hildon"
+
+#~ msgid "Unknown data format"
+#~ msgstr "Nieznany format danych"
+
+#~ msgid "Valid pointer to native data view control does not exist"
+#~ msgstr "Aktualny wskaźnik do rodzimego widoku danych kontroli nie istnieje"
+
+#~ msgid "Win32s on Windows 3.1"
+#~ msgstr "Win32s na Windows 3.1"
+
+#, fuzzy
+#~ msgid "Windows 10"
+#~ msgstr "Windows 98"
+
+#~ msgid "Windows 2000"
+#~ msgstr "Windows 2000"
+
+#~ msgid "Windows 7"
+#~ msgstr "Windows 7"
+
+#, fuzzy
+#~ msgid "Windows 8"
+#~ msgstr "Windows 98"
+
+#, fuzzy
+#~ msgid "Windows 8.1"
+#~ msgstr "Windows 98"
+
+#~ msgid "Windows 95"
+#~ msgstr "Windows 95"
+
+#~ msgid "Windows 95 OSR2"
+#~ msgstr "Windows 95 OSR2"
+
+#~ msgid "Windows 98"
+#~ msgstr "Windows 98"
+
+#~ msgid "Windows 98 SE"
+#~ msgstr "Windows 98 SE"
+
+#~ msgid "Windows 9x (%d.%d)"
+#~ msgstr "Windows 9x (%d.%d)"
+
+#~ msgid "Windows CE (%d.%d)"
+#~ msgstr "Windows CE (%d.%d)"
+
+#~ msgid "Windows ME"
+#~ msgstr "Windows ME"
+
+#~ msgid "Windows NT %lu.%lu"
+#~ msgstr "Windows NT %lu.%lu"
+
+#, fuzzy
+#~ msgid "Windows Server 10"
+#~ msgstr "Windows Server 2003"
+
+#~ msgid "Windows Server 2003"
+#~ msgstr "Windows Server 2003"
+
+#~ msgid "Windows Server 2008"
+#~ msgstr "Windows Server 2008"
+
+#~ msgid "Windows Server 2008 R2"
+#~ msgstr "Windows Server 2008 R2"
+
+#, fuzzy
+#~ msgid "Windows Server 2012"
+#~ msgstr "Windows Server 2003"
+
+#, fuzzy
+#~ msgid "Windows Server 2012 R2"
+#~ msgstr "Windows Server 2008 R2"
+
+#~ msgid "Windows Vista"
+#~ msgstr "Windows Vista"
+
+#~ msgid "Windows XP"
+#~ msgstr "Windows XP"
+
+#~ msgid "can't execute '%s'"
+#~ msgstr "nie udało się wykonać '%s'"
+
+#~ msgid "error opening '%s'"
+#~ msgstr "błąd otwarcia '%s'"
+
+#~ msgid "unknown seek origin"
+#~ msgstr "nieznany odnośnik pozycjonowania"
+
+#~ msgid "wxWidget control pointer is not a data view pointer"
+#~ msgstr "Wskaźnik kontroli wxWidget nie jest wskaźnikiem widoku danych"
+
+#~ msgid "wxWidget's control not initialized."
+#~ msgstr "Kontrolka wxWidget's nie została zainicjowana."
+
+#~ msgid "ADD"
+#~ msgstr "DODAJ"
+
+#~ msgid "BACK"
+#~ msgstr "WSTECZ"
+
+#~ msgid "CANCEL"
+#~ msgstr "ANULUJ"
+
+#~ msgid "CAPITAL"
+#~ msgstr "CAPS"
+
+#~ msgid "CLEAR"
+#~ msgstr "WYCZYŚĆ"
+
+#~ msgid "COMMAND"
+#~ msgstr "POLECENIE"
+
+#~ msgid "Cannot create mutex."
+#~ msgstr "Nie można utworzyć muteksu."
+
+#~ msgid "Cannot resume thread %lu"
+#~ msgstr "Nie można wznowić wątku %lu"
+
+#~ msgid "Cannot suspend thread %lu"
+#~ msgstr "Nie można zawiesić wątku %lu"
+
+#~ msgid "Couldn't acquire a mutex lock"
+#~ msgstr "Nie można przechwycić muteksu"
+
+#~ msgid "Couldn't get hatch style from wxBrush."
+#~ msgstr "Nie można uzyskać stylów kreskowania z wxBrush."
+
+#~ msgid "Couldn't release a mutex"
+#~ msgstr "Muteks nie mógł być uwolniony"
+
+#~ msgid "DECIMAL"
+#~ msgstr "DECIMAL"
+
+#~ msgid "DEL"
+#~ msgstr "DEL"
+
+#~ msgid "DELETE"
+#~ msgstr "DELETE"
+
+#~ msgid "DIVIDE"
+#~ msgstr "DZIELIĆ"
+
+#~ msgid "DOWN"
+#~ msgstr "DÓŁ"
+
+#~ msgid "END"
+#~ msgstr "END"
+
+#~ msgid "ENTER"
+#~ msgstr "ENTER"
+
+#~ msgid "ESC"
+#~ msgstr "ESC"
+
+#~ msgid "ESCAPE"
+#~ msgstr "ESCAPE"
+
+#~ msgid "EXECUTE"
+#~ msgstr "WYKONAĆ"
+
+#~ msgid "Event queue overflowed"
+#~ msgstr "Przepełniona kolejka zdarzeń"
+
+#~ msgid "Execution of command '%s' failed with error: %ul"
+#~ msgstr "Wykonanie polecenia '%s' nie powiodło się; błąd: %ul"
+
+#~ msgid ""
+#~ "File '%s' already exists.\n"
+#~ "Do you want to replace it?"
+#~ msgstr ""
+#~ "Plik '%s' już istnieje.\n"
+#~ "Chcesz go zastąpić?"
+
+#~ msgid "HELP"
+#~ msgstr "POMOC"
+
+#~ msgid "HOME"
+#~ msgstr "HOME"
+
+#~ msgid "INS"
+#~ msgstr "INS"
+
+#~ msgid "INSERT"
+#~ msgstr "WSTAW"
+
+#~ msgid "KP_BEGIN"
+#~ msgstr "KP_BEGIN"
+
+#~ msgid "KP_DECIMAL"
+#~ msgstr "KP_DECIMAL"
+
+#~ msgid "KP_DELETE"
+#~ msgstr "KP_DELETE"
+
+#~ msgid "KP_DIVIDE"
+#~ msgstr "KP_DIVIDE"
+
+#~ msgid "KP_DOWN"
+#~ msgstr "KP_DOWN"
+
+#~ msgid "KP_ENTER"
+#~ msgstr "KP_ENTER"
+
+#~ msgid "KP_EQUAL"
+#~ msgstr "KP_EQUAL"
+
+#~ msgid "KP_HOME"
+#~ msgstr "KP_HOME"
+
+#~ msgid "KP_INSERT"
+#~ msgstr "KP_INSERT"
+
+#~ msgid "KP_LEFT"
+#~ msgstr "KP_LEFT"
+
+#~ msgid "KP_MULTIPLY"
+#~ msgstr "KP_MULTIPLY"
+
+#~ msgid "KP_NEXT"
+#~ msgstr "KP_NEXT"
+
+#~ msgid "KP_PAGEDOWN"
+#~ msgstr "KP_PAGEDOWN"
+
+#~ msgid "KP_PAGEUP"
+#~ msgstr "KP_PAGEUP"
+
+#~ msgid "KP_PRIOR"
+#~ msgstr "KP_PRIOR"
+
+#~ msgid "KP_RIGHT"
+#~ msgstr "KP_RIGHT"
+
+#~ msgid "KP_SEPARATOR"
+#~ msgstr "KP_SEPARATOR"
+
+#~ msgid "KP_SPACE"
+#~ msgstr "KP_SPACE"
+
+#~ msgid "KP_SUBTRACT"
+#~ msgstr "KP_SUBTRACT"
+
+#~ msgid "LEFT"
+#~ msgstr "LEWO"
+
+#~ msgid "MENU"
+#~ msgstr "MENU"
+
+#~ msgid "NUM_LOCK"
+#~ msgstr "NUM_LOCK"
+
+#~ msgid "PAGEDOWN"
+#~ msgstr "PAGEDOWN"
+
+#~ msgid "PAGEUP"
+#~ msgstr "PAGEUP"
+
+#~ msgid "PAUSE"
+#~ msgstr "PAUZA"
+
+#~ msgid "PGDN"
+#~ msgstr "PGDN"
+
+#~ msgid "PGUP"
+#~ msgstr "PGUP"
+
+#~ msgid "PRINT"
+#~ msgstr "WYDRUK"
+
+#~ msgid "Print preview"
+#~ msgstr "Podgląd wydruku"
+
+#~ msgid "RETURN"
+#~ msgstr "RETURN"
+
+#~ msgid "RIGHT"
+#~ msgstr "PRAWO"
+
+#~ msgid "SCROLL_LOCK"
+#~ msgstr "SCROLL_LOCK"
+
+#~ msgid "SELECT"
+#~ msgstr "WYBÓR"
+
+#~ msgid "SEPARATOR"
+#~ msgstr "SEPARATOR"
+
+#~ msgid "SNAPSHOT"
+#~ msgstr "ZRZUT EKRANU"
+
+#~ msgid "SPACE"
+#~ msgstr "SPACJA"
+
+#~ msgid "SUBTRACT"
+#~ msgstr "DZIELENIE"
+
+#~ msgid "TAB"
+#~ msgstr "TAB"
+
+#~ msgid "The print dialog returned an error."
+#~ msgstr "Okno dialogowe drukowania zwróciło błąd."
+
+#~ msgid "The wxGtkPrinterDC cannot be used."
+#~ msgstr "wxGtkPrinterDC nie może być używany."
+
+#~ msgid "Timer creation failed."
+#~ msgstr "Nie powiodło się utworzenie stopera."
+
+#~ msgid "UP"
+#~ msgstr "GÓRA"
+
+#~ msgid "WINDOWS_LEFT"
+#~ msgstr "WINDOWS_LEWO"
+
+#~ msgid "WINDOWS_MENU"
+#~ msgstr "WINDOWS_MENU"
+
+#~ msgid "WINDOWS_RIGHT"
+#~ msgstr "WINDOWS_PRAWO"
+
+#~ msgid "buffer is too small for Windows directory."
+#~ msgstr "bufor jest zbyt mały na katalog Windows."
+
+#~ msgid "not implemented"
+#~ msgstr "nie zaimplementowany"
+
+#~ msgid "percent"
+#~ msgstr "procent"
+
+#~ msgid "wxPrintout::GetPageInfo gives a null maxPage."
+#~ msgstr "wxPrintout: GetPageInfo daje zero maxPage."
+
+#~ msgid "1"
+#~ msgstr "1"
+
+#, fuzzy
+#~ msgid "10"
+#~ msgstr "1"
+
+#~ msgid "3"
+#~ msgstr "3"
+
+#~ msgid "4"
+#~ msgstr "4"
+
+#~ msgid "5"
+#~ msgstr "5"
+
+#~ msgid "6"
+#~ msgstr "6"
+
+#~ msgid "7"
+#~ msgstr "7"
+
+#~ msgid "8"
+#~ msgstr "8"
+
+#~ msgid "9"
+#~ msgstr "9"
+
+#, fuzzy
+#~ msgid "&Preview..."
+#~ msgstr " Podgląd"
+
+#, fuzzy
+#~ msgid "Preview..."
+#~ msgstr " Podgląd"
+
+#, fuzzy
+#~ msgid "The vertical offset relative to the paragraph."
+#~ msgstr "Domyślny styl dla następnego paragrafu."
+
+#~ msgid "&Save..."
+#~ msgstr "&Zapisz..."
+
+#~ msgid "About "
+#~ msgstr "O"
+
+#~ msgid "All files (*.*)|*"
+#~ msgstr "Wszystkie pliki (*.*)|*"
+
+#~ msgid "Cannot initialize SciTech MGL!"
+#~ msgstr "Nie można zainicjować SciTech MGL!"
+
+#~ msgid "Cannot initialize display."
+#~ msgstr "Nie można zainicjować obsługi wyświetlania."
+
+#~ msgid "Cannot start thread: error writing TLS"
+#~ msgstr "Nie można wystartować wątku: błąd zapisu TLS"
+
+#~ msgid "Close\tAlt-F4"
+#~ msgstr "Zamknij\tAlt-F4"
+
+#~ msgid "Couldn't create cursor."
+#~ msgstr "Nie można utworzyć kursora."
+
+#~ msgid "Directory '%s' doesn't exist!"
+#~ msgstr "Katalog '%s' nie istnieje!"
+
+# sprawdzić "tryb", może "nie jest", "nie" - razem czy osobno,
+#~ msgid "Mode %ix%i-%i not available."
+#~ msgstr "Tryb %ix%i-%i nie jest dostępny."
+
+#~ msgid "Paper Size"
+#~ msgstr "Rozmiar papieru"
+
+#~ msgid "%.*f GB"
+#~ msgstr "%.*f GB"
+
+#~ msgid "%.*f MB"
+#~ msgstr "%.*f MB"
+
+#~ msgid "%.*f TB"
+#~ msgstr "%.*f TB"
+
+#~ msgid "%.*f kB"
+#~ msgstr "%.*f kB"
+
+#~ msgid "%s B"
+#~ msgstr "%s B"
+
+#~ msgid "&Goto..."
+#~ msgstr "&Przejdź do..."
+
+#~ msgid "<<"
+#~ msgstr "<<"
+
+#~ msgid ">>"
+#~ msgstr ">>"
+
+#~ msgid ">>|"
+#~ msgstr ">>|"
+
+#~ msgid "Added item is invalid."
+#~ msgstr "Dodana pozycja jest nieprawidłowa."
+
+#~ msgid "Archive doesnt contain #SYSTEM file"
+#~ msgstr "Archiwum nie zawiera pliku #SYSTEM"
+
+#~ msgid "BIG5"
+#~ msgstr "BIG5"
+
+#~ msgid "Can't check image format of file '%s': file does not exist."
+#~ msgstr ""
+#~ "Nie można sprawdzić formatu graficznego pliku '%s': plik nie istnieje."
+
+#~ msgid "Can't load image from file '%s': file does not exist."
+#~ msgstr "Nie można wczytać obrazu z pliku '%s': plik nie istnieje."
+
+# units --> ?
+#~ msgid "Cannot convert dialog units: dialog unknown."
+#~ msgstr ""
+#~ "Nie można wykonać konwersji okien dialogowych: nieznane okno dialogowe."
+
+#~ msgid "Cannot convert from the charset '%s'!"
+#~ msgstr "Nie można dokonać konwersji z tablicy '%s'!"
+
+#~ msgid "Cannot find container for unknown control '%s'."
+#~ msgstr "NIe można znaleźć kontenera dla nieznanej kontrolki '%s'."
+
+#~ msgid "Cannot find font node '%s'."
+#~ msgstr "Nie można znaleźć węzła czcionki '%s'."
+
+#~ msgid "Cannot open file '%s'."
+#~ msgstr "Nie można otworzyć pliku '%s'."
+
+#~ msgid "Cannot parse coordinates from '%s'."
+#~ msgstr "Nie można wyciągnąć koordynatów z '%s'."
+
+#~ msgid "Cannot parse dimension from '%s'."
+#~ msgstr "Nie można wyciągnąć wymiaru z '%s'."
+
+#~ msgid "Cant create the thread event queue"
+#~ msgstr "Nie można utworzyć kolejki zdarzeń wątku"
+
+#~ msgid "Changed item is invalid."
+#~ msgstr "Zmieniona pozycja jest nieprawidłowa."
+
+#~ msgid "Click to cancel this window."
+#~ msgstr "Kliknij, aby anulować to okno."
+
+#~ msgid "Click to confirm your selection."
+#~ msgstr "Kliknij, aby potwierdzić wybór."
+
+#~ msgid "Column does not have a renderer."
+#~ msgstr "Kolumna nie ma rendera."
+
+#~ msgid "Column pointer must not be NULL."
+#~ msgstr "Wskaźnik kolumny nie może być ZERO."
+
+#~ msgid "Column's model column has no equivalent in the associated model."
+#~ msgstr "Kolumna modelu kolumny nie ma odpowiednika w powiązanym modelu."
+
+#~ msgid "Control is wrongly initialized."
+#~ msgstr "Kontrola jest niesłusznie zainicjalizowana."
+
+#~ msgid "Could not add column to internal structures."
+#~ msgstr "Nie można dodać kolumny do wewnętrznych struktur."
+
+#~ msgid "Could not unlock mutex"
+#~ msgstr "Nie odblokowano muteksu"
+
+#~ msgid "Data view control is not correctly initialized"
+#~ msgstr "Widok kontroli danych nie jest poprawnie inicjowany"
+
+#~ msgid "Error while waiting on semaphore"
+#~ msgstr "Błąd oczekiwania na semafor"
+
+#~ msgid "Failed to create a status bar."
+#~ msgstr "Nie udało się utworzyć paska statusu."
+
+#~ msgid "Failed to register OpenGL window class."
+#~ msgstr "Nie udała się rejestracja klasy okna OpenGL."
+
+#~ msgid "Fatal error: "
+#~ msgstr "Błąd krytyczny: "
+
+#~ msgid "GB-2312"
+#~ msgstr "GB-2312"
+
+#~ msgid "Go forward to the next HTML page"
+#~ msgstr "Przejdź do następnej strony HTML"
+
+#~ msgid "Goto Page"
+#~ msgstr "Skocz do strony"
+
+#~ msgid ""
+#~ "HTML pagination algorithm generated more than the allowed maximum number "
+#~ "of pages and it can't continue any longer!"
+#~ msgstr ""
+#~ "Algorytm paginacji HTML generował więcej niż dozwoloną maksymalną liczbę "
+#~ "stron i nie może być dłużej kontynuowany!"
+
+#~ msgid "Help : %s"
+#~ msgstr "Pomoc : %s"
+
+#~ msgid "I64"
+#~ msgstr "I64"
+
+#~ msgid "Internal error, illegal wxCustomTypeInfo"
+#~ msgstr "Błąd wewnętrzny, nieprawidłowości w wxCustomTypeInfo"
+
+# korzenia?
+#~ msgid "Invalid XRC resource '%s': doesn't have root node 'resource'."
+#~ msgstr "Nieprawidłowy zasób XRC '%s': brakuje głównego węzła 'resource'."
+
+#~ msgid "No handler found for XML node '%s', class '%s'!"
+#~ msgstr "Brak procedury obsługi dla węzła XML '%s', klasa '%s'!"
+
+#~ msgid "No image handler for type %ld defined."
+#~ msgstr "Brak procedury obsługi obrazów typu %ld."
+
+#~ msgid "No model associated with control."
+#~ msgstr "Nie ma modelu powiązanego z kontrolą."
+
+#~ msgid "Owner not initialized."
+#~ msgstr "Właściciel niezainicjowany."
+
+#~ msgid "Passed item is invalid."
+#~ msgstr "Ostatni element jest nieprawidłowy."
+
+#~ msgid "Passing a already registered object to SetObjectName"
+#~ msgstr "Przekazano już zarejestrowany obiekt do funkcji SetObjectName"
+
+#~ msgid "Preparing help window..."
+#~ msgstr "Przygotowanie okna pomocy..."
+
+#~ msgid "Program aborted."
+#~ msgstr "Program przerwany."
+
+#~ msgid "Referenced object node with ref=\"%s\" not found!"
+#~ msgstr "Nie znalezione węzła obiektu, do którego odwołuje się ref=\"%s\"!"
+
+#~ msgid "Resource files must have same version number!"
+#~ msgstr "Pliki zasobów muszę mieć zgodny numer wersji!"
+
+#~ msgid "SHIFT-JIS"
+#~ msgstr "SHIFT-JIS"
+
+#~ msgid "Search!"
+#~ msgstr "Szukaj!"
+
+#~ msgid "Sorry, could not open this file for saving."
+#~ msgstr "Niestety nie można otworzyć tego pliku do zapisu."
+
+#~ msgid "Sorry, could not save this file."
+#~ msgstr "Niestety nie można zapisać tego pliku."
+
+#~ msgid "Sorry, print preview needs a printer to be installed."
+#~ msgstr "Niestety, podgląd wydruku wymaga zainstalowania drukarki."
+
+#~ msgid "Status: "
+#~ msgstr "Status: "
+
+#~ msgid ""
+#~ "Streaming delegates for not already streamed objects not yet supported"
+#~ msgstr ""
+#~ "Delegacja w strumieniu dlaobiektu który nie jest już w strumieniu nie "
+#~ "jest jeszcze wspierana"
+
+#~ msgid "Subclass '%s' not found for resource '%s', not subclassing!"
+#~ msgstr "Nie znaleziono podklasy '%s' dla zasobu '%s', bez podklas!"
+
+#~ msgid "TIFF library error."
+#~ msgstr "Błąd biblioteki TIFF."
+
+#~ msgid "TIFF library warning."
+#~ msgstr "Ostrzeżenie biblioteki TIFF."
+
+#~ msgid ""
+#~ "The file '%s' couldn't be opened.\n"
+#~ "It has been removed from the most recently used files list."
+#~ msgstr ""
+#~ "Nie można otworzyć pliku '%s'.\n"
+#~ "Informacja o nim została usunięta z listy ostatnio używanych plików."
+
+#~ msgid "The path '%s' contains too many \"..\"!"
+#~ msgstr "Ścieżka '%s' zawiera za dużo \"..\"!"
+
+#~ msgid "Trying to solve a NULL hostname: giving up"
+#~ msgstr "próba użycia niezdefiniowej (NULL) nazwy serwera: rezygnacja"
+
+#~ msgid "Unknown style flag "
+#~ msgstr "Nieznana flaga stylu"
+
+#~ msgid "Warning"
+#~ msgstr "Ostrzeżenie"
+
+#~ msgid "Windows 2000 (build %lu"
+#~ msgstr "Windows 2000 (kompilacja %lu"
+
+#~ msgid "XRC resource '%s' (class '%s') not found!"
+#~ msgstr "Nie znaleziono zasobu XRC '%s' (klasa '%s')!"
+
+#~ msgid "XRC resource: Cannot create animation from '%s'."
+#~ msgstr "Zasoby XRC: Nie można utworzyć animacji z '%s'."
+
+#~ msgid "XRC resource: Cannot create bitmap from '%s'."
+#~ msgstr "Zasoby XRC: Nie można utworzyć mapy bitowej z '%s'."
+
+#~ msgid ""
+#~ "XRC resource: Incorrect colour specification '%s' for attribute '%s'."
+#~ msgstr ""
+#~ "Zasoby XRC: Nieprawidłowa specyfikacja koloru '%s' dla atrybutu '%s'."
+
+#~ msgid "[EMPTY]"
+#~ msgstr "[PUSTY]"
+
+# catalog file --> ?
+# domain --> ?
+#~ msgid "catalog file for domain '%s' not found."
+#~ msgstr "Nie znaleziono pliku katalogowego dla domeny '%s'."
+
+#~ msgid "delegate has no type info"
+#~ msgstr "brak informacji o delegowanym typie"
+
+#~ msgid "encoding %i"
+#~ msgstr "kodowanie %i"
+
+# w ścieżce - nieładne
+#~ msgid "looking for catalog '%s' in path '%s'."
+#~ msgstr "szukanie katalogu '%s' w ścieżce '%s'."
+
+#~ msgid "m_peer is not or incorrectly initialized"
+#~ msgstr "m_peer nie jest lub nieprawidłowo zainicjowany"
+
+#~ msgid "wxRichTextFontPage"
+#~ msgstr "wxRichTextFontPage"
+
+#~ msgid "wxSearchEngine::LookFor must be called before scanning!"
+#~ msgstr "wxSearchEngine::LookFor musi być wywołane przed skanowaniem!"
+
+#~ msgid "wxSocket: invalid signature in ReadMsg."
+#~ msgstr "wxSocket: błędna sygnatura w ReadMsg."
+
+#~ msgid "wxSocket: unknown event!."
+#~ msgstr "wxSocket: nieznane zdarzenie!"
+
+#~ msgid "|<<"
+#~ msgstr "|<<"
+
+#, fuzzy
+#~ msgid " Couldn't create the UnicodeConverter"
+#~ msgstr "Nie można utworzyć stopera"
+
+#~ msgid "#define %s must be an integer."
+#~ msgstr "#define %s musi być liczbą całkowitą."
+
+#~ msgid "%s not a bitmap resource specification."
+#~ msgstr "%s nie jest specyfikacją zasobu mapy bitowej."
+
+#~ msgid "%s not an icon resource specification."
+#~ msgstr "%s nie jest specyfikacją zasobu ikony."
+
+#~ msgid "%s: ill-formed resource file syntax."
+#~ msgstr "%s: błędna składnia pliku zasobu."
+
+#~ msgid "&Open"
+#~ msgstr "&Otwórz"
+
+#~ msgid "&Print"
+#~ msgstr "&Drukuj"
+
+#~ msgid "*** It can be found in \"%s\"\n"
+#~ msgstr "*** Znajduje się w \"%s\"\n"
+
+#~ msgid ""
+#~ ", expected static, #include or #define\n"
+#~ "while parsing resource."
+#~ msgstr ""
+#~ ", oczekiwano static, #include or #define\n"
+#~ "podczas przetwarzania zasobu."
+
+#~ msgid "Bitmap resource specification %s not found."
+#~ msgstr "Nie znaleziono specyfikacji %s zasobu mapy bitowej."
+
+#~ msgid ""
+#~ "Could not resolve control class or id '%s'. Use (non-zero) integer "
+#~ "instead\n"
+#~ " or provide #define (see manual for caveats)"
+#~ msgstr ""
+#~ "Nie rozpoznano klasy lub identyfikatora '%s'. Użyj (niezerową) liczbę "
+#~ "całkowitą \n"
+#~ " lub #define (szukaj szczegółów w dokumentacji)"
+
+#~ msgid ""
+#~ "Could not resolve menu id '%s'. Use (non-zero) integer instead\n"
+#~ "or provide #define (see manual for caveats)"
+#~ msgstr ""
+#~ "Nie rozpoznano identyfikatora menu '%s'. Użyj (niezerową) liczbę "
+#~ "całkowitą \n"
+#~ " lub #define (szukaj szczegółów w dokumentacji)"
+
+#, fuzzy
+#~ msgid "Couldn't end the context on the overlay window"
+#~ msgstr "Nie można pobrać wskaźnika aktualnego wątku"
+
+#~ msgid "Expected '*' while parsing resource."
+#~ msgstr "Przetwarzając zasób oczekiwano '*'."
+
+#~ msgid "Expected '=' while parsing resource."
+#~ msgstr "Przetwarzając zasób oczekiwano '='."
+
+#~ msgid "Expected 'char' while parsing resource."
+#~ msgstr "Przetwarzając zasób oczekiwano 'char'."
+
+#~ msgid ""
+#~ "Failed to find XBM resource %s.\n"
+#~ "Forgot to use wxResourceLoadBitmapData?"
+#~ msgstr ""
+#~ "Brak zasobu XBM %s.\n"
+#~ "Nie wywołano wxResourceLoadBitmapData?"
+
+#~ msgid ""
+#~ "Failed to find XBM resource %s.\n"
+#~ "Forgot to use wxResourceLoadIconData?"
+#~ msgstr ""
+#~ "Brak zasobu XBM %s.\n"
+#~ "Nie wywołano wxResourceLoadIconData?"
+
+#~ msgid ""
+#~ "Failed to find XPM resource %s.\n"
+#~ "Forgot to use wxResourceLoadBitmapData?"
+#~ msgstr ""
+#~ "Brak zasobu XBM %s.\n"
+#~ "Nie wywołano wxResourceLoadBitmapData?"
+
+#~ msgid "Failed to get clipboard data."
+#~ msgstr "Nie udało się pobrać danych ze schowka."
+
+# shared -->?
+#~ msgid "Failed to load shared library '%s' Error '%s'"
+#~ msgstr "Nie udało się wczytać biblioteki '%s': błąd '%s'"
+
+#~ msgid "Found "
+#~ msgstr "Znaleziono "
+
+#~ msgid "Icon resource specification %s not found."
+#~ msgstr "Specyfikacja zasobu ikony %s nie znaleziona."
+
+#~ msgid "Ill-formed resource file syntax."
+#~ msgstr "Błędna składnia pliku zasobu"
+
+#~ msgid "Long Conversions not supported"
+#~ msgstr "Konwersja typu 'Long' nie jest wspierana."
+
+#~ msgid "No XPM icon facility available!"
+#~ msgstr "Brak wsparcia dla ikon XPM!"
+
+#~ msgid "Option '%s' requires a value, '=' expected."
+#~ msgstr "Opcja '%s' wymaga wartości, oczekiwane: '='."
+
+#, fuzzy
+#~ msgid "Select all"
+#~ msgstr "&Zaznacz wszystko"
+
+#~ msgid "Unexpected end of file while parsing resource."
+#~ msgstr "Nieoczekiwany koniec pliku podczas przetwarzania zasobu."
+
+#~ msgid "Unrecognized style %s while parsing resource."
+#~ msgstr "Nierozpoznany styl %s podczas przetwarzania zasobu."
+
+#~ msgid "Video Output"
+#~ msgstr "Wyjście Video"
+
+#~ msgid "Warning: attempt to remove HTML tag handler from empty stack."
+#~ msgstr ""
+#~ "Ostrzeżenie: próba usunięcia procedury obsługi znacznika HTML z pustego "
+#~ "stosu."
+
+# ustalić? ustanowić?
+#~ msgid "establish"
+#~ msgstr "nawiązać"
+
+#~ msgid "initiate"
+#~ msgstr "zainicjować"
+
+#~ msgid "invalid eof() return value."
+#~ msgstr "błędna wartość znacznika końca pliku."
+
+#~ msgid "unknown line terminator"
+#~ msgstr "nieznany znacznik końca linii"
+
+#~ msgid "writing"
+#~ msgstr "zapisu"
+
+#~ msgid "."
+#~ msgstr "."
+
+#~ msgid "Cannot open URL '%s'"
+#~ msgstr "Nie można otworzyć URL '%s'"
+
+#~ msgid "Error "
+#~ msgstr "Błąd "
+
+#~ msgid "Failed to create directory %s/.gnome."
+#~ msgstr "Nie udało się utworzyć katalogu %s/.gnome"
+
+#~ msgid "Failed to create directory %s/mime-info."
+#~ msgstr "Nie udało się utworzyć katalogu %s/mime-info."
+
+#~ msgid "MP Thread Support is not available on this System"
+#~ msgstr "MP Thread Support jest niedostępny w tym systemie"
+
+#~ msgid "Mailcap file %s, line %d: incomplete entry ignored."
+#~ msgstr "Plik mailcap %s, linia %d: zignorowano niekompletny wpis."
+
+#~ msgid "Mime.types file %s, line %d: unterminated quoted string."
+#~ msgstr "Plik typów mime %s, linia %d: brak zamykającego cudzysłowu."
+
+#~ msgid "Unknown field in file %s, line %d: '%s'."
+#~ msgstr "Nieznane pole w pliku %s, linia %d: '%s'."
+
+#~ msgid "bold "
+#~ msgstr "pogrubiony "
+
+#~ msgid "can't query for GUI plugins name in console applications"
+#~ msgstr ""
+#~ "nie można pobierać nazw wtyczek interfejsu graficznego w aplikacji "
+#~ "przeznaczonej dla trybu tekstowego"
+
+#~ msgid "light "
+#~ msgstr "lekki "
+
+#~ msgid "underlined "
+#~ msgstr "podkreślony "
+
+#~ msgid "unsupported zip archive"
+#~ msgstr "niewspierane archiwum zip"
+
+#, fuzzy
+#~ msgid ""
+#~ "Failed to get stack backtrace:\n"
+#~ "%s"
+#~ msgstr "Nie udało się usyskać listy ISP: %s"
+
+#~ msgid "Loading Grey Ascii PNM image is not yet implemented."
+#~ msgstr "Ładowanie obrazów Grey Ascii PNM nie jest jeszcze zaimplementowane."
+
+#~ msgid "Loading Grey Raw PNM image is not yet implemented."
+#~ msgstr "Ładowanie obrazów Grey Raw PNM nie jest jeszcze zaimplementowane."
+
+#, fuzzy
+#~ msgid "Cannot wait on thread to exit."
+#~ msgstr "Nie można czekać na zakończenie wątku"
+
+#~ msgid "Could not load Rich Edit DLL '%s'"
+#~ msgstr "Nie można wczytać biblioteki Rich Edit '%s'"
+
+#~ msgid "ZIP handler currently supports only local files!"
+#~ msgstr "Obsługiwane są tylko lokalne pliki ZIP!"
+
+#, fuzzy
+#~ msgid ""
+#~ "can't seek on file descriptor %d, large files support is not enabled."
+#~ msgstr "nie można ustawić pozycji w deskryptorze pliku %d"
+
+#~ msgid "More..."
+#~ msgstr "Więcej..."
+
+#~ msgid "Setup"
+#~ msgstr "Ustawienia"
+
+#~ msgid "/#SYSTEM"
+#~ msgstr "/#SYSTEM"
+
+#~ msgid "Backward"
+#~ msgstr "Wstecz"
+
+#~ msgid "GetUnusedColour:: No Unused Color in image "
+#~ msgstr "Brak wolnych kolorów w obrazie (GetUnusedColour)"

--- a/po_wxstd/pt.po
+++ b/po_wxstd/pt.po
@@ -1,0 +1,10699 @@
+# translation of wxstd.pt.po to Portuguese
+# Copyright (C) 2007 wxWidgets Development Team
+# This file is distributed under wxWindows licence.
+# Mario Pereira <marionrpereira76@hotmail.com>, 2007.
+# Antonio Cardoso Martins <digiplan.pt@gmail.com>, 2007.
+# Carlos Gonçalves <mail@cgoncalves.info>, 2007.
+# Alfredo and Manuela Silva <manuela.silva@sky.com>, 2014.
+msgid ""
+msgstr ""
+"Project-Id-Version: wxWidgets 3.3\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-05-14 20:23+0200\n"
+"PO-Revision-Date: 2014-03-07 16:07+0100\n"
+"Last-Translator: Alfredo <.>\n"
+"Language-Team: Portuguese <opensuse-pt@opensuse.org>\n"
+"Language: pt\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Virtaal 0.7.1\n"
+
+#: ../include/wx/defs.h:2582
+msgid "All files (*.*)|*.*"
+msgstr "Todos os ficheiros (*.*)|*.*"
+
+#: ../include/wx/defs.h:2585
+msgid "All files (*)|*"
+msgstr "Todos os ficheiros (*)|*"
+
+#: ../include/wx/generic/progdlgg.h:85
+msgid "Elapsed time:"
+msgstr "Tempo decorrido: "
+
+#: ../include/wx/generic/progdlgg.h:86
+msgid "Estimated time:"
+msgstr "Tempo estimado: "
+
+#: ../include/wx/generic/progdlgg.h:87
+#, fuzzy
+msgid "Remaining time:"
+msgstr "Tempo restante : "
+
+#. TRANSLATORS: HTML printout default title.
+#: ../include/wx/html/htmprint.h:121 ../include/wx/prntbase.h:273
+#: ../include/wx/richtext/richtextprint.h:109 ../src/common/docview.cpp:2161
+msgid "Printout"
+msgstr "Impressão"
+
+#. TRANSLATORS: HTML easy print default title.
+#: ../include/wx/html/htmprint.h:234 ../include/wx/richtext/richtextprint.h:163
+#: ../src/common/prntbase.cpp:522 ../src/html/htmprint.cpp:291
+msgid "Printing"
+msgstr "A Imprimir  ..."
+
+#: ../include/wx/msgdlg.h:277 ../src/common/stockitem.cpp:211
+msgid "Yes"
+msgstr "Sim"
+
+#: ../include/wx/msgdlg.h:278 ../src/common/stockitem.cpp:182
+msgid "No"
+msgstr "Não"
+
+#: ../include/wx/msgdlg.h:279 ../src/common/stockitem.cpp:183
+#: ../src/msw/msgdlg.cpp:430 ../src/msw/msgdlg.cpp:734
+#: ../src/richtext/richtextstyledlg.cpp:292
+msgid "OK"
+msgstr "CONFIRMAR"
+
+#: ../include/wx/msgdlg.h:280 ../src/common/stockitem.cpp:150
+#: ../src/msw/msgdlg.cpp:430 ../src/msw/progdlg.cpp:884
+#: ../src/richtext/richtextstyledlg.cpp:295
+msgid "Cancel"
+msgstr "Cancelar"
+
+#: ../include/wx/msgdlg.h:281 ../src/common/stockitem.cpp:168
+#: ../src/html/helpdlg.cpp:63 ../src/html/helpfrm.cpp:108
+#: ../src/osx/button_osx.cpp:38
+msgid "Help"
+msgstr "Ajuda"
+
+#: ../include/wx/msw/ole/oleutils.h:52
+msgid "Cannot initialize OLE"
+msgstr "Não foi possível inicializar o OLE"
+
+#: ../include/wx/msw/private/fswatcher.h:48
+#, fuzzy, c-format
+msgid "Unable to close the handle for '%s'"
+msgstr "Falha ao fechar manuseador de ficheiro"
+
+#: ../include/wx/msw/private/fswatcher.h:92
+#, fuzzy, c-format
+msgid "Failed to open directory \"%s\" for monitoring."
+msgstr "Falha ao abrir '%s' para %s"
+
+#: ../include/wx/msw/private/fswatcher.h:125
+#, fuzzy
+msgid "Unable to close I/O completion port handle"
+msgstr "Falha ao fechar manuseador de ficheiro"
+
+#: ../include/wx/msw/private/fswatcher.h:142
+msgid "Unable to associate handle with I/O completion port"
+msgstr ""
+
+#: ../include/wx/msw/private/fswatcher.h:148
+msgid "Unexpectedly new I/O completion port was created"
+msgstr ""
+
+#: ../include/wx/msw/private/fswatcher.h:213
+msgid "Unable to post completion status"
+msgstr ""
+
+#: ../include/wx/msw/private/fswatcher.h:262
+msgid "Unable to dequeue completion packet"
+msgstr ""
+
+#: ../include/wx/msw/private/fswatcher.h:273
+#, fuzzy
+msgid "Unable to create I/O completion port"
+msgstr "Não foi possível criar TextEncodingConverter"
+
+#: ../include/wx/richmsgdlg.h:29
+msgid "&See details"
+msgstr "&Ver Detalhes"
+
+#: ../include/wx/richmsgdlg.h:30
+msgid "&Hide details"
+msgstr "Ocultar &Detalhes"
+
+#: ../include/wx/richtext/richtextbuffer.h:3864
+#, fuzzy
+msgid "&Box"
+msgstr "&Destacado"
+
+#: ../include/wx/richtext/richtextbuffer.h:5008
+msgid "&Picture"
+msgstr "I&magem"
+
+#: ../include/wx/richtext/richtextbuffer.h:5958
+msgid "&Cell"
+msgstr "&Célula"
+
+#: ../include/wx/richtext/richtextbuffer.h:6067
+msgid "&Table"
+msgstr "&Tabela"
+
+#: ../include/wx/richtext/richtextimagedlg.h:37
+#, fuzzy
+msgid "Object Properties"
+msgstr "&Propriedades do Objeto"
+
+#: ../include/wx/richtext/richtextsymboldlg.h:39
+msgid "Symbols"
+msgstr "Símbolos"
+
+#: ../include/wx/unix/pipe.h:46
+msgid "Pipe creation failed"
+msgstr "Falha na criação do pipe"
+
+#: ../include/wx/unix/private/displayx11.h:65
+msgid "Failed to enumerate video modes"
+msgstr "Falha a enumerar modos de vídeo"
+
+#: ../include/wx/unix/private/displayx11.h:89
+msgid "Failed to change video mode"
+msgstr "Falha ao alterar o modo de vídeo"
+
+#: ../include/wx/unix/private/fswatcher_kqueue.h:57
+#, fuzzy, c-format
+msgid "Unable to open path '%s'"
+msgstr "Falha na abertura do arquivo CHM '%s'."
+
+#: ../include/wx/unix/private/fswatcher_kqueue.h:74
+#, fuzzy, c-format
+msgid "Unable to close path '%s'"
+msgstr "Falha ao fechar o ficheiro de bloqueio '%s'"
+
+#: ../include/wx/xtiprop.h:175
+msgid "SetProperty called w/o valid setter"
+msgstr "SetProperty chamado sem 'set' válido"
+
+#: ../include/wx/xtiprop.h:184
+msgid "GetProperty called w/o valid getter"
+msgstr "GetProperty chamado sem 'get' válido"
+
+#: ../include/wx/xtiprop.h:193
+msgid "AddToPropertyCollection called w/o valid adder"
+msgstr "AddToPropertyCollection chamando com ou sem adicionador válido"
+
+#: ../include/wx/xtiprop.h:202
+msgid "GetPropertyCollection called w/o valid collection getter"
+msgstr "GetPropertyCollection chamado sem colecção de getter válido"
+
+#: ../include/wx/xtiprop.h:255
+msgid "AddToPropertyCollection called on a generic accessor"
+msgstr "AddToPropertyCollection chamando num acessor genérico"
+
+#: ../include/wx/xtiprop.h:262
+msgid "GetPropertyCollection called on a generic accessor"
+msgstr "GetPropertyCollection chamado num acessor genérico"
+
+#: ../src/aui/tabmdi.cpp:106 ../src/generic/mdig.cpp:94
+msgid "Cl&ose"
+msgstr "F&echar"
+
+#: ../src/aui/tabmdi.cpp:107 ../src/generic/mdig.cpp:95
+msgid "Close All"
+msgstr "Fechar Tudo"
+
+#: ../src/aui/tabmdi.cpp:109 ../src/generic/mdig.cpp:97 ../src/msw/mdi.cpp:175
+#: ../src/qt/mdi.cpp:258
+msgid "&Next"
+msgstr "&Próximo"
+
+#: ../src/aui/tabmdi.cpp:110 ../src/generic/mdig.cpp:98 ../src/msw/mdi.cpp:176
+#: ../src/qt/mdi.cpp:259
+msgid "&Previous"
+msgstr "&Anterior"
+
+#: ../src/aui/tabmdi.cpp:332 ../src/aui/tabmdi.cpp:348
+#: ../src/aui/tabmdi.cpp:350 ../src/generic/mdig.cpp:291
+#: ../src/generic/mdig.cpp:307 ../src/generic/mdig.cpp:311
+#: ../src/msw/mdi.cpp:337 ../src/qt/mdi.cpp:462
+msgid "&Window"
+msgstr "&Janela"
+
+#: ../src/common/accelcmn.cpp:47
+msgctxt "keyboard key"
+msgid "Delete"
+msgstr "Apagar"
+
+#: ../src/common/accelcmn.cpp:48
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Del"
+msgstr "Apagar"
+
+#: ../src/common/accelcmn.cpp:49
+msgctxt "keyboard key"
+msgid "Back"
+msgstr "Voltar"
+
+#: ../src/common/accelcmn.cpp:49
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Backspace"
+msgstr "Voltar"
+
+#: ../src/common/accelcmn.cpp:50
+msgctxt "keyboard key"
+msgid "Insert"
+msgstr "Inserir"
+
+#: ../src/common/accelcmn.cpp:51
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Ins"
+msgstr "Inserir"
+
+#: ../src/common/accelcmn.cpp:52
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Enter"
+msgstr "Impressora"
+
+#: ../src/common/accelcmn.cpp:53
+msgctxt "keyboard key"
+msgid "Return"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:54
+#, fuzzy
+msgctxt "keyboard key"
+msgid "PageUp"
+msgstr "Páginas"
+
+#: ../src/common/accelcmn.cpp:54
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Page Up"
+msgstr "Página %d"
+
+#: ../src/common/accelcmn.cpp:55
+#, fuzzy
+msgctxt "keyboard key"
+msgid "PageDown"
+msgstr "Baixo"
+
+#: ../src/common/accelcmn.cpp:55
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Page Down"
+msgstr "Página %d"
+
+#: ../src/common/accelcmn.cpp:56
+msgctxt "keyboard key"
+msgid "PgUp"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:57
+msgctxt "keyboard key"
+msgid "PgDn"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:58
+msgctxt "keyboard key"
+msgid "Left"
+msgstr "Esquerda"
+
+#: ../src/common/accelcmn.cpp:59
+msgctxt "keyboard key"
+msgid "Right"
+msgstr "Direita"
+
+#: ../src/common/accelcmn.cpp:60
+msgctxt "keyboard key"
+msgid "Up"
+msgstr "Cima"
+
+#: ../src/common/accelcmn.cpp:61
+msgctxt "keyboard key"
+msgid "Down"
+msgstr "Baixo"
+
+#: ../src/common/accelcmn.cpp:62
+msgctxt "keyboard key"
+msgid "Home"
+msgstr "Pasta Pessoal"
+
+#: ../src/common/accelcmn.cpp:63
+msgctxt "keyboard key"
+msgid "End"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:64
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Space"
+msgstr "Espaçamento"
+
+#: ../src/common/accelcmn.cpp:65
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Tab"
+msgstr "Tabs"
+
+#: ../src/common/accelcmn.cpp:66
+msgctxt "keyboard key"
+msgid "Esc"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:67
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Escape"
+msgstr "Paisagem"
+
+#: ../src/common/accelcmn.cpp:68
+msgctxt "keyboard key"
+msgid "Cancel"
+msgstr "Cancelar"
+
+#: ../src/common/accelcmn.cpp:69
+msgctxt "keyboard key"
+msgid "Clear"
+msgstr "Limpar"
+
+#: ../src/common/accelcmn.cpp:70
+msgctxt "keyboard key"
+msgid "Menu"
+msgstr "Menu"
+
+#: ../src/common/accelcmn.cpp:71
+msgctxt "keyboard key"
+msgid "Pause"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:72
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Capital"
+msgstr "Maiúsculas"
+
+#: ../src/common/accelcmn.cpp:73
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Select"
+msgstr "Selecção"
+
+#: ../src/common/accelcmn.cpp:74
+msgctxt "keyboard key"
+msgid "Print"
+msgstr "Imprimir"
+
+#: ../src/common/accelcmn.cpp:75
+msgctxt "keyboard key"
+msgid "Execute"
+msgstr "Executar"
+
+#: ../src/common/accelcmn.cpp:76
+msgctxt "keyboard key"
+msgid "Snapshot"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:77
+msgctxt "keyboard key"
+msgid "Help"
+msgstr "Ajuda"
+
+#: ../src/common/accelcmn.cpp:78
+msgctxt "keyboard key"
+msgid "Add"
+msgstr "Adicionar"
+
+#: ../src/common/accelcmn.cpp:79
+msgctxt "keyboard key"
+msgid "Separator"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:80
+msgctxt "keyboard key"
+msgid "Subtract"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:81
+msgctxt "keyboard key"
+msgid "Decimal"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:82
+msgctxt "keyboard key"
+msgid "Multiply"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:83
+msgctxt "keyboard key"
+msgid "Divide"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:84
+msgctxt "keyboard key"
+msgid "Num_lock"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:84
+msgctxt "keyboard key"
+msgid "Num Lock"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:85
+msgctxt "keyboard key"
+msgid "Scroll_lock"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:85
+msgctxt "keyboard key"
+msgid "Scroll Lock"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:86
+msgctxt "keyboard key"
+msgid "KP_Space"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:86
+msgctxt "keyboard key"
+msgid "Num Space"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:87
+#, fuzzy
+msgctxt "keyboard key"
+msgid "KP_Tab"
+msgstr "KP_TAB"
+
+#: ../src/common/accelcmn.cpp:87
+msgctxt "keyboard key"
+msgid "Num Tab"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:88
+#, fuzzy
+msgctxt "keyboard key"
+msgid "KP_Enter"
+msgstr "Impressora"
+
+#: ../src/common/accelcmn.cpp:88
+msgctxt "keyboard key"
+msgid "Num Enter"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:89
+#, fuzzy
+msgctxt "keyboard key"
+msgid "KP_Home"
+msgstr "Pasta Pessoal"
+
+#: ../src/common/accelcmn.cpp:89
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Num Home"
+msgstr "Pasta Pessoal"
+
+#: ../src/common/accelcmn.cpp:90
+#, fuzzy
+msgctxt "keyboard key"
+msgid "KP_Left"
+msgstr "Esquerda"
+
+#: ../src/common/accelcmn.cpp:90
+msgctxt "keyboard key"
+msgid "Num left"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:91
+#, fuzzy
+msgctxt "keyboard key"
+msgid "KP_Up"
+msgstr "KP_UP"
+
+#: ../src/common/accelcmn.cpp:91
+msgctxt "keyboard key"
+msgid "Num Up"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:92
+#, fuzzy
+msgctxt "keyboard key"
+msgid "KP_Right"
+msgstr "Direita"
+
+#: ../src/common/accelcmn.cpp:92
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Num Right"
+msgstr "Direita"
+
+#: ../src/common/accelcmn.cpp:93
+#, fuzzy
+msgctxt "keyboard key"
+msgid "KP_Down"
+msgstr "Baixo"
+
+#: ../src/common/accelcmn.cpp:93
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Num Down"
+msgstr "Baixo"
+
+#: ../src/common/accelcmn.cpp:94
+msgctxt "keyboard key"
+msgid "KP_PageUp"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:94
+msgctxt "keyboard key"
+msgid "Num Page Up"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:95
+msgctxt "keyboard key"
+msgid "KP_PageDown"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:95
+msgctxt "keyboard key"
+msgid "Num Page Down"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:96
+msgctxt "keyboard key"
+msgid "KP_Prior"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:97
+#, fuzzy
+msgctxt "keyboard key"
+msgid "KP_Next"
+msgstr "Seguinte"
+
+#: ../src/common/accelcmn.cpp:98
+#, fuzzy
+msgctxt "keyboard key"
+msgid "KP_End"
+msgstr "KP_END"
+
+#: ../src/common/accelcmn.cpp:98
+msgctxt "keyboard key"
+msgid "Num End"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:99
+msgctxt "keyboard key"
+msgid "KP_Begin"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:99
+msgctxt "keyboard key"
+msgid "Num Begin"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:100
+#, fuzzy
+msgctxt "keyboard key"
+msgid "KP_Insert"
+msgstr "Inserir"
+
+#: ../src/common/accelcmn.cpp:100
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Num Insert"
+msgstr "Inserir"
+
+#: ../src/common/accelcmn.cpp:101
+#, fuzzy
+msgctxt "keyboard key"
+msgid "KP_Delete"
+msgstr "Apagar"
+
+#: ../src/common/accelcmn.cpp:101
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Num Delete"
+msgstr "Apagar"
+
+#: ../src/common/accelcmn.cpp:102
+msgctxt "keyboard key"
+msgid "KP_Equal"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:102
+msgctxt "keyboard key"
+msgid "Num ="
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:103
+msgctxt "keyboard key"
+msgid "KP_Multiply"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:103
+msgctxt "keyboard key"
+msgid "Num *"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:104
+#, fuzzy
+msgctxt "keyboard key"
+msgid "KP_Add"
+msgstr "KP_ADD"
+
+#: ../src/common/accelcmn.cpp:104
+msgctxt "keyboard key"
+msgid "Num +"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:105
+msgctxt "keyboard key"
+msgid "KP_Separator"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:105
+msgctxt "keyboard key"
+msgid "Num ,"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:106
+msgctxt "keyboard key"
+msgid "KP_Subtract"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:106
+msgctxt "keyboard key"
+msgid "Num -"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:107
+msgctxt "keyboard key"
+msgid "KP_Decimal"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:107
+msgctxt "keyboard key"
+msgid "Num ."
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:108
+msgctxt "keyboard key"
+msgid "KP_Divide"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:108
+msgctxt "keyboard key"
+msgid "Num /"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:109
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Windows_Left"
+msgstr "Windows 95"
+
+#: ../src/common/accelcmn.cpp:110
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Windows_Right"
+msgstr "Windows 95"
+
+#: ../src/common/accelcmn.cpp:111
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Windows_Menu"
+msgstr "Windows ME"
+
+#: ../src/common/accelcmn.cpp:112
+msgctxt "keyboard key"
+msgid "Command"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:186 ../src/common/accelcmn.cpp:359
+msgctxt "keyboard key"
+msgid "Ctrl"
+msgstr "Ctrl"
+
+#: ../src/common/accelcmn.cpp:188 ../src/common/accelcmn.cpp:363
+msgctxt "keyboard key"
+msgid "Alt"
+msgstr "Alt"
+
+#: ../src/common/accelcmn.cpp:190 ../src/common/accelcmn.cpp:361
+msgctxt "keyboard key"
+msgid "Shift"
+msgstr "Deslocar"
+
+#: ../src/common/accelcmn.cpp:196
+msgctxt "keyboard key"
+msgid "num "
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:260 ../src/common/accelcmn.cpp:382
+msgctxt "keyboard key"
+msgid "F"
+msgstr "F"
+
+#: ../src/common/accelcmn.cpp:277 ../src/common/accelcmn.cpp:385
+msgctxt "keyboard key"
+msgid "KP_F"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:280 ../src/common/accelcmn.cpp:388
+msgctxt "keyboard key"
+msgid "KP_"
+msgstr "KP_"
+
+#: ../src/common/accelcmn.cpp:283 ../src/common/accelcmn.cpp:391
+msgctxt "keyboard key"
+msgid "SPECIAL"
+msgstr "SPECIAL"
+
+#: ../src/common/accelcmn.cpp:373
+#, fuzzy
+msgid "Ctrl"
+msgstr "Ctrl"
+
+#: ../src/common/appbase.cpp:786
+msgid "show this help message"
+msgstr "mostra esta mensagem de ajuda"
+
+#: ../src/common/appbase.cpp:796
+msgid "generate verbose log messages"
+msgstr "gerar mensagens de registo verbosas"
+
+#: ../src/common/appcmn.cpp:256
+msgid "specify the theme to use"
+msgstr "especifica o tema a utilizar"
+
+#: ../src/common/appcmn.cpp:270
+msgid "specify display mode to use (e.g. 640x480-16)"
+msgstr "especificar modo de ecrã a utilizar (ex: 640x480-16)"
+
+#: ../src/common/appcmn.cpp:292
+#, c-format
+msgid "Unsupported theme '%s'."
+msgstr "Tema não suportado '%s'."
+
+#: ../src/common/appcmn.cpp:309
+#, c-format
+msgid "Invalid display mode specification '%s'."
+msgstr "Especificação de modo de ecrã inválida '%s'."
+
+#: ../src/common/cmdline.cpp:875
+#, fuzzy, c-format
+msgid "Option '%s' can't be negated"
+msgstr "A opção '%s'não pode ser nagada"
+
+#: ../src/common/cmdline.cpp:889
+#, c-format
+msgid "Unknown long option '%s'"
+msgstr "Opção longa desconhecida '%s'"
+
+#: ../src/common/cmdline.cpp:904 ../src/common/cmdline.cpp:926
+#, c-format
+msgid "Unknown option '%s'"
+msgstr "Opção desconhecida '%s'"
+
+#: ../src/common/cmdline.cpp:1004
+#, c-format
+msgid "Unexpected characters following option '%s'."
+msgstr "Caracteres inesperados a seguir à opção '%s'."
+
+#: ../src/common/cmdline.cpp:1039
+#, c-format
+msgid "Option '%s' requires a value."
+msgstr "A opção '%s' requer um valor."
+
+#: ../src/common/cmdline.cpp:1058
+#, c-format
+msgid "Separator expected after the option '%s'."
+msgstr "Separador esperado depois da opção '%s'."
+
+#: ../src/common/cmdline.cpp:1088 ../src/common/cmdline.cpp:1106
+#, c-format
+msgid "'%s' is not a correct numeric value for option '%s'."
+msgstr "'%s' não é um valor numérico correcto para a opção '%s'."
+
+#: ../src/common/cmdline.cpp:1122
+#, c-format
+msgid "Option '%s': '%s' cannot be converted to a date."
+msgstr "A opção '%s': '%s' não pode ser convertida para uma data."
+
+#: ../src/common/cmdline.cpp:1170
+#, c-format
+msgid "Unexpected parameter '%s'"
+msgstr "Parâmetro inesperado '%s'"
+
+#. TRANSLATORS: Short name and long name for a command line option
+#: ../src/common/cmdline.cpp:1197
+#, c-format
+msgid "%s (or %s)"
+msgstr "%s (ou %s)"
+
+#: ../src/common/cmdline.cpp:1208
+#, c-format
+msgid "The value for the option '%s' must be specified."
+msgstr "O valor para a opção '%s' tem de ser especificado."
+
+#: ../src/common/cmdline.cpp:1230
+#, c-format
+msgid "The required parameter '%s' was not specified."
+msgstr "O parâmetro requerido '%s' não foi especificado."
+
+#: ../src/common/cmdline.cpp:1289
+#, c-format
+msgid "Usage: %s"
+msgstr "Utilização: %s"
+
+#: ../src/common/cmdline.cpp:1498
+msgid "str"
+msgstr "str"
+
+#: ../src/common/cmdline.cpp:1502
+msgid "num"
+msgstr "num"
+
+#: ../src/common/cmdline.cpp:1506
+msgid "double"
+msgstr "duplo"
+
+#: ../src/common/cmdline.cpp:1510
+msgid "date"
+msgstr "data"
+
+#: ../src/common/cmdproc.cpp:250 ../src/common/cmdproc.cpp:276
+#: ../src/common/cmdproc.cpp:296
+msgid "Unnamed command"
+msgstr "Comando não nomeado"
+
+#: ../src/common/cmdproc.cpp:253
+msgid "&Undo "
+msgstr "&Desfazer "
+
+#: ../src/common/cmdproc.cpp:255
+msgid "Can't &Undo "
+msgstr "Não é possível &Desfazer "
+
+#: ../src/common/cmdproc.cpp:259 ../src/common/stockitem.cpp:208
+#: ../src/msw/textctrl.cpp:2880 ../src/osx/textctrl_osx.cpp:649
+#: ../src/richtext/richtextctrl.cpp:327
+msgid "&Undo"
+msgstr "&Desfazer"
+
+#: ../src/common/cmdproc.cpp:277 ../src/common/cmdproc.cpp:297
+msgid "&Redo "
+msgstr "&Refazer "
+
+#: ../src/common/cmdproc.cpp:281 ../src/common/cmdproc.cpp:288
+#: ../src/common/stockitem.cpp:190 ../src/msw/textctrl.cpp:2881
+#: ../src/osx/textctrl_osx.cpp:650 ../src/richtext/richtextctrl.cpp:328
+msgid "&Redo"
+msgstr "&Refazer"
+
+#: ../src/common/colourcmn.cpp:41
+#, c-format
+msgid "String To Colour : Incorrect colour specification : %s"
+msgstr "Cadeia de Carateres para a Cor : Especificação de cor incorreta : %s"
+
+#: ../src/common/config.cpp:259
+#, c-format
+msgid "Invalid value %ld for a boolean key \"%s\" in config file."
+msgstr ""
+
+#: ../src/common/config.cpp:526
+#, c-format
+msgid ""
+"Environment variables expansion failed: missing '%c' at position %u in '%s'."
+msgstr ""
+"Falhou a expansão das variáveis de ambiente: falta %c na posição %u em '%s'."
+
+#: ../src/common/config.cpp:576 ../src/msw/regconf.cpp:272
+#, c-format
+msgid "'%s' has extra '..', ignored."
+msgstr "'%s' tem extra '..', ignorado."
+
+#. TRANSLATORS: Checkbox state name
+#: ../src/common/datavcmn.cpp:2166 ../src/generic/datavgen.cpp:1430
+msgid "checked"
+msgstr ""
+
+#. TRANSLATORS: Checkbox state name
+#: ../src/common/datavcmn.cpp:2170 ../src/generic/datavgen.cpp:1432
+msgid "unchecked"
+msgstr ""
+
+#. TRANSLATORS: Checkbox state name
+#: ../src/common/datavcmn.cpp:2174
+#, fuzzy
+msgid "undetermined"
+msgstr "sublinhado"
+
+#: ../src/common/datetimefmt.cpp:1875
+msgid "today"
+msgstr "hoje"
+
+#: ../src/common/datetimefmt.cpp:1876
+msgid "yesterday"
+msgstr "ontem"
+
+#: ../src/common/datetimefmt.cpp:1877
+msgid "tomorrow"
+msgstr "amanhã"
+
+#: ../src/common/datetimefmt.cpp:2071
+msgid "first"
+msgstr "primeiro"
+
+#: ../src/common/datetimefmt.cpp:2072
+msgid "second"
+msgstr "segundo"
+
+#: ../src/common/datetimefmt.cpp:2073
+msgid "third"
+msgstr "terceiro"
+
+#: ../src/common/datetimefmt.cpp:2074
+msgid "fourth"
+msgstr "quarto"
+
+#: ../src/common/datetimefmt.cpp:2075
+msgid "fifth"
+msgstr "quinto"
+
+#: ../src/common/datetimefmt.cpp:2076
+msgid "sixth"
+msgstr "sexto"
+
+#: ../src/common/datetimefmt.cpp:2077
+msgid "seventh"
+msgstr "sétimo"
+
+#: ../src/common/datetimefmt.cpp:2078
+msgid "eighth"
+msgstr "oitavo"
+
+#: ../src/common/datetimefmt.cpp:2079
+msgid "ninth"
+msgstr "nono"
+
+#: ../src/common/datetimefmt.cpp:2080
+msgid "tenth"
+msgstr "décimo"
+
+#: ../src/common/datetimefmt.cpp:2081
+msgid "eleventh"
+msgstr "décimo primeiro"
+
+#: ../src/common/datetimefmt.cpp:2082
+msgid "twelfth"
+msgstr "décimo segundo"
+
+#: ../src/common/datetimefmt.cpp:2083
+msgid "thirteenth"
+msgstr "décimo terceiro"
+
+#: ../src/common/datetimefmt.cpp:2084
+msgid "fourteenth"
+msgstr "décimo quarto"
+
+#: ../src/common/datetimefmt.cpp:2085
+msgid "fifteenth"
+msgstr "décimo quinto"
+
+#: ../src/common/datetimefmt.cpp:2086
+msgid "sixteenth"
+msgstr "décimo sexto"
+
+#: ../src/common/datetimefmt.cpp:2087
+msgid "seventeenth"
+msgstr "décimo sétimo"
+
+#: ../src/common/datetimefmt.cpp:2088
+msgid "eighteenth"
+msgstr "décimo oitavo"
+
+#: ../src/common/datetimefmt.cpp:2089
+msgid "nineteenth"
+msgstr "décimo nono"
+
+#: ../src/common/datetimefmt.cpp:2090
+msgid "twentieth"
+msgstr "vigésimo"
+
+#: ../src/common/datetimefmt.cpp:2248
+msgid "noon"
+msgstr "meio-dia"
+
+#: ../src/common/datetimefmt.cpp:2249
+msgid "midnight"
+msgstr "meia noite"
+
+#: ../src/common/debugrpt.cpp:209
+#, c-format
+msgid "Failed to create directory \"%s\""
+msgstr "Falha de criação de directório \"%s\""
+
+#: ../src/common/debugrpt.cpp:210
+msgid "Debug report couldn't be created."
+msgstr "Relatório de depuração não pode ser criado."
+
+#: ../src/common/debugrpt.cpp:227
+#, c-format
+msgid "Failed to remove debug report file \"%s\""
+msgstr "Falha ao remover ficheiro \"%s\" do relatório de depuração "
+
+#: ../src/common/debugrpt.cpp:239
+#, c-format
+msgid "Failed to clean up debug report directory \"%s\""
+msgstr "Falha ao limpar a diretoria \"%s\" do relatório de depuração"
+
+#: ../src/common/debugrpt.cpp:514
+msgid "process context description"
+msgstr "descrição de contexto do processo"
+
+#: ../src/common/debugrpt.cpp:538
+msgid "dump of the process state (binary)"
+msgstr "dump do estado do processo (binário)"
+
+#: ../src/common/debugrpt.cpp:553
+msgid "Debug report generation has failed."
+msgstr "Falhou a geração do relatório de depuração."
+
+#: ../src/common/debugrpt.cpp:560
+#, c-format
+msgid ""
+"Processing debug report has failed, leaving the files in \"%s\" directory."
+msgstr ""
+"O processamento do relatório de depuração falhou, a colocar os ficheiros na "
+"directoria \"%s\"."
+
+#: ../src/common/debugrpt.cpp:573
+msgid "A debug report has been generated. It can be found in"
+msgstr "Foi gerado um relatório de depuração. Este pode ser encontrado em"
+
+#: ../src/common/debugrpt.cpp:576
+#, fuzzy
+msgid "And includes the following files:\n"
+msgstr "*** E inclui os seguintes ficheiros:\n"
+
+#: ../src/common/debugrpt.cpp:586
+msgid ""
+"\n"
+"Please send this report to the program maintainer, thank you!\n"
+msgstr ""
+"\n"
+"Por favor, envie este relatório para o programador, obrigado!\n"
+
+#: ../src/common/debugrpt.cpp:729
+msgid "Failed to execute curl, please install it in PATH."
+msgstr "Falha a executar curl, por favor instale-o no PATH."
+
+#: ../src/common/debugrpt.cpp:742
+#, c-format
+msgid "Failed to upload the debug report (error code %d)."
+msgstr "Falha ao enviar o relatório de depuração (código do erro %d)."
+
+#: ../src/common/docview.cpp:366
+msgid "Save As"
+msgstr "Gravar Como"
+
+#: ../src/common/docview.cpp:457
+msgid "Discard changes and reload the last saved version?"
+msgstr ""
+
+#: ../src/common/docview.cpp:488
+msgid "unnamed"
+msgstr "sem nome"
+
+#: ../src/common/docview.cpp:513
+#, fuzzy, c-format
+msgid "Do you want to save changes to %s?"
+msgstr "Deseja gravar as alterações ao documento %s?"
+
+#: ../src/common/docview.cpp:521 ../src/common/docview.cpp:560
+#: ../src/common/stockitem.cpp:195
+msgid "&Save"
+msgstr "&Guardar"
+
+#: ../src/common/docview.cpp:522 ../src/common/docview.cpp:560
+msgid "&Discard changes"
+msgstr ""
+
+#: ../src/common/docview.cpp:523
+#, fuzzy
+msgid "Do&n't close"
+msgstr "Não Gravar"
+
+#: ../src/common/docview.cpp:553
+#, fuzzy, c-format
+msgid "Do you want to save changes to %s before closing it?"
+msgstr "Deseja gravar as alterações ao documento %s?"
+
+#: ../src/common/docview.cpp:559
+#, fuzzy
+msgid "The document must be closed."
+msgstr "O texto não pode ser gravado."
+
+#: ../src/common/docview.cpp:571
+#, c-format
+msgid "Saving %s failed, would you like to retry?"
+msgstr ""
+
+#: ../src/common/docview.cpp:577
+msgid "Retry"
+msgstr ""
+
+#: ../src/common/docview.cpp:577
+msgid "Discard changes"
+msgstr ""
+
+#: ../src/common/docview.cpp:679
+#, fuzzy, c-format
+msgid "File \"%s\" could not be opened for writing."
+msgstr "Falha ao abrir '%s' para %s"
+
+#: ../src/common/docview.cpp:685
+#, fuzzy, c-format
+msgid "Failed to save document to the file \"%s\"."
+msgstr "Falha ao gravar imagem de bitmap para ficheiro \"%s\"."
+
+#: ../src/common/docview.cpp:702
+#, fuzzy, c-format
+msgid "File \"%s\" could not be opened for reading."
+msgstr "Falha ao abrir '%s' para %s"
+
+#: ../src/common/docview.cpp:714
+#, fuzzy, c-format
+msgid "Failed to read document from the file \"%s\"."
+msgstr "Falha na leitura de metafile do ficheiro \"%s\"."
+
+#: ../src/common/docview.cpp:1236
+#, c-format
+msgid ""
+"The file '%s' doesn't exist and couldn't be opened.\n"
+"It has been removed from the most recently used files list."
+msgstr ""
+"O ficheiro '%s' não existe e não pode ser aberto.\n"
+"Este foi removido da lista de ficheiros usados mais recentemente."
+
+#: ../src/common/docview.cpp:1296
+msgid "Print preview creation failed."
+msgstr "Falha na criação da pré-visualização da impressão."
+
+#: ../src/common/docview.cpp:1302
+msgid "Print Preview"
+msgstr "Pré-visualizar Impressão"
+
+#: ../src/common/docview.cpp:1517
+#, fuzzy, c-format
+msgid "The format of file '%s' couldn't be determined."
+msgstr "Não foi possível criar o directório '%s'"
+
+#: ../src/common/docview.cpp:1643
+#, c-format
+msgid "unnamed%d"
+msgstr "sem nome%d"
+
+#: ../src/common/docview.cpp:1660
+msgid " - "
+msgstr " - "
+
+#: ../src/common/docview.cpp:1791 ../src/common/docview.cpp:1844
+msgid "Open File"
+msgstr "Abrir Ficheiro"
+
+#: ../src/common/docview.cpp:1807
+msgid "File error"
+msgstr "Erro de ficheiro"
+
+#: ../src/common/docview.cpp:1809
+msgid "Sorry, could not open this file."
+msgstr "Lamento, não foi possível abrir este ficheiro."
+
+#: ../src/common/docview.cpp:1843
+msgid "Sorry, the format for this file is unknown."
+msgstr "Lamento, o formato deste ficheiro é desconhecido."
+
+#: ../src/common/docview.cpp:1924
+msgid "Select a document template"
+msgstr "Selecionar um modelo de documento"
+
+#: ../src/common/docview.cpp:1925
+msgid "Templates"
+msgstr "Modelos"
+
+#: ../src/common/docview.cpp:1998
+msgid "Select a document view"
+msgstr "Selecionar uma vista de documento"
+
+#: ../src/common/docview.cpp:1999
+msgid "Views"
+msgstr "Vistas"
+
+#: ../src/common/dynlib.cpp:81
+#, c-format
+msgid "Failed to load shared library '%s'"
+msgstr "Falha na abertura da livraria partilhada '%s'"
+
+#: ../src/common/dynlib.cpp:105
+#, c-format
+msgid "Couldn't find symbol '%s' in a dynamic library"
+msgstr "Não foi possível encontrar o símbolo '%s' numa livraria dinâmica"
+
+#: ../src/common/ffile.cpp:56 ../src/common/file.cpp:215
+#, c-format
+msgid "can't open file '%s'"
+msgstr "impossível abrir ficheiro '%s'"
+
+#: ../src/common/ffile.cpp:72
+#, c-format
+msgid "can't close file '%s'"
+msgstr "impossível fechar o ficheiro '%s'"
+
+#: ../src/common/ffile.cpp:106 ../src/common/ffile.cpp:131
+#, c-format
+msgid "Read error on file '%s'"
+msgstr "Erro de leitura no ficheiro '%s'"
+
+#: ../src/common/ffile.cpp:148
+#, c-format
+msgid "Write error on file '%s'"
+msgstr "Erro de escrita no ficheiro '%s'"
+
+#: ../src/common/ffile.cpp:182
+#, c-format
+msgid "failed to flush the file '%s'"
+msgstr "Falha a escoar o ficheiro '%s'"
+
+#: ../src/common/ffile.cpp:222
+#, c-format
+msgid "Seek error on file '%s' (large files not supported by stdio)"
+msgstr ""
+"Erro de pesquisa no ficheiro '%s' (ficheiros grandes não são suportados pelo "
+"stdio)"
+
+#: ../src/common/ffile.cpp:232
+#, c-format
+msgid "Seek error on file '%s'"
+msgstr "Erro de pesquisa no ficheiro '%s'"
+
+#: ../src/common/ffile.cpp:248
+#, c-format
+msgid "Can't find current position in file '%s'"
+msgstr "Não foi possível encontrar a posição atual no ficheiro '%s'"
+
+#: ../src/common/ffile.cpp:349 ../src/common/file.cpp:569
+msgid "Failed to set temporary file permissions"
+msgstr "Falha ao definir permissões do ficheiro temporário"
+
+#: ../src/common/ffile.cpp:371
+#, c-format
+msgid "can't remove file '%s'"
+msgstr "impossível remover ficheiro '%s'"
+
+#: ../src/common/ffile.cpp:376 ../src/common/file.cpp:591
+#, c-format
+msgid "can't commit changes to file '%s'"
+msgstr "não é possível garantir as alterações ao ficheiro '%s'"
+
+#: ../src/common/ffile.cpp:388 ../src/common/file.cpp:603
+#, c-format
+msgid "can't remove temporary file '%s'"
+msgstr "Não foi possível remover ficheiro temporário '%s'"
+
+#: ../src/common/file.cpp:162
+#, c-format
+msgid "can't create file '%s'"
+msgstr "impossível criar o ficheiro '%s'"
+
+#: ../src/common/file.cpp:229
+#, c-format
+msgid "can't close file descriptor %d"
+msgstr "impossível fechar o descritor do ficheiro %d"
+
+#: ../src/common/file.cpp:332
+#, c-format
+msgid "can't read from file descriptor %d"
+msgstr "não foi possível ler do descritor do ficheiro %d"
+
+#: ../src/common/file.cpp:351
+#, c-format
+msgid "can't write to file descriptor %d"
+msgstr "Não foi possível escrever no descritor de ficheiro %d"
+
+#: ../src/common/file.cpp:390
+#, c-format
+msgid "can't flush file descriptor %d"
+msgstr "Não foi possível escoar o descritor do ficheiro %d"
+
+#: ../src/common/file.cpp:432
+#, c-format
+msgid "can't seek on file descriptor %d"
+msgstr "Não foi possível pesquisar no descritor de ficheiro %d"
+
+#: ../src/common/file.cpp:446
+#, c-format
+msgid "can't get seek position on file descriptor %d"
+msgstr "Não foi possível obter posição de pesquisa no descritor do ficheiro %d"
+
+#: ../src/common/file.cpp:475
+#, c-format
+msgid "can't find length of file on file descriptor %d"
+msgstr ""
+"Não foi possível encontrar o comprimento do ficheiro no descritor do "
+"ficheiro %d"
+
+#: ../src/common/file.cpp:505
+#, c-format
+msgid "can't determine if the end of file is reached on descriptor %d"
+msgstr ""
+"impossível determinar se o fim do ficheiro foi alcançado no descritor %d"
+
+#: ../src/common/fileconf.cpp:352
+#, c-format
+msgid ""
+" and additionally, the existing configuration file was renamed to \"%s\" and "
+"couldn't be renamed back, please rename it to its original path \"%s\""
+msgstr ""
+
+#: ../src/common/fileconf.cpp:389
+#, fuzzy
+msgid " due to the following error:\n"
+msgstr "*** E inclui os seguintes ficheiros:\n"
+
+#: ../src/common/fileconf.cpp:412
+#, fuzzy
+msgid "failed to rename the existing file"
+msgstr "Falha na leitura de metafile do ficheiro \"%s\"."
+
+#: ../src/common/fileconf.cpp:421
+#, fuzzy
+msgid "failed to create the new file directory"
+msgstr "Falha na obtenção do directório de trabalho"
+
+#: ../src/common/fileconf.cpp:428
+#, fuzzy
+msgid "failed to move the file to the new location"
+msgstr "Falha ao terminar a ligação telefónica: %s "
+
+#: ../src/common/fileconf.cpp:462
+#, c-format
+msgid "can't open global configuration file '%s'."
+msgstr "não foi possível abrir o ficheiro '%s' global de configuração."
+
+#: ../src/common/fileconf.cpp:478
+#, c-format
+msgid "can't open user configuration file '%s'."
+msgstr "não foi possível abrir o ficheiro '%s' de configuração do utilizador."
+
+#: ../src/common/fileconf.cpp:483
+#, c-format
+msgid "Changes won't be saved to avoid overwriting the existing file \"%s\""
+msgstr ""
+
+#: ../src/common/fileconf.cpp:583
+msgid "Error reading config options."
+msgstr "Erro ao ler opções de configuração."
+
+#: ../src/common/fileconf.cpp:593
+#, fuzzy
+msgid "Failed to read config options."
+msgstr "Erro ao ler opções de configuração."
+
+#: ../src/common/fileconf.cpp:700
+#, fuzzy, c-format
+msgid "file '%s': unexpected character %c at line %zu."
+msgstr "ficheiro '%s': caracter inesperado %c na linha %d."
+
+#: ../src/common/fileconf.cpp:736
+#, fuzzy, c-format
+msgid "file '%s', line %zu: '%s' ignored after group header."
+msgstr "ficheiro '%s', linha %d: '%s' ignorado após cabeçalho de grupo."
+
+#: ../src/common/fileconf.cpp:765
+#, fuzzy, c-format
+msgid "file '%s', line %zu: '=' expected."
+msgstr "ficheiro '%s', linha %d: '=' esperado."
+
+#: ../src/common/fileconf.cpp:778
+#, fuzzy, c-format
+msgid "file '%s', line %zu: value for immutable key '%s' ignored."
+msgstr "ficheiro '%s', linha %d: valor para chave imutável '%s' ignorado."
+
+#: ../src/common/fileconf.cpp:788
+#, fuzzy, c-format
+msgid "file '%s', line %zu: key '%s' was first found at line %d."
+msgstr ""
+"ficheiro '%s', linha %d: chave '%s' foi inicialmente encontrada na linha %d."
+
+#: ../src/common/fileconf.cpp:1091
+#, c-format
+msgid "Config entry name cannot start with '%c'."
+msgstr "Nome de entrada de configuração não pode começar por '%c'."
+
+#: ../src/common/fileconf.cpp:1146
+#, fuzzy
+msgid "Failed to create configuration file directory."
+msgstr "Falha na atualização do ficheiro de configuração do utilizador."
+
+#: ../src/common/fileconf.cpp:1158
+msgid "can't open user configuration file."
+msgstr "não foi possível abrir o ficheiro de configuração do utilizador."
+
+#: ../src/common/fileconf.cpp:1172
+msgid "can't write user configuration file."
+msgstr "Não foi possível gravar o ficheiro de configuração do utilizador."
+
+#: ../src/common/fileconf.cpp:1178
+msgid "Failed to update user configuration file."
+msgstr "Falha na atualização do ficheiro de configuração do utilizador."
+
+#: ../src/common/fileconf.cpp:1201
+msgid "Error saving user configuration data."
+msgstr "Erro ao gravar dados de configuração do utilizador."
+
+#: ../src/common/fileconf.cpp:1313
+#, c-format
+msgid "can't delete user configuration file '%s'"
+msgstr "não foi possível apagar o ficheiro de configuração do utilizador '%s'"
+
+#: ../src/common/fileconf.cpp:2007
+#, c-format
+msgid "entry '%s' appears more than once in group '%s'"
+msgstr "a entrada '%s' aparece mais do uma vez no grupo '%s'"
+
+#: ../src/common/fileconf.cpp:2021
+#, c-format
+msgid "attempt to change immutable key '%s' ignored."
+msgstr "tentativa de alteração da chave imutável '%s' ignorada."
+
+#: ../src/common/fileconf.cpp:2118
+#, c-format
+msgid "trailing backslash ignored in '%s'"
+msgstr ""
+
+#: ../src/common/fileconf.cpp:2153
+#, c-format
+msgid "unexpected \" at position %d in '%s'."
+msgstr "\" inesperado na posição %d em '%s'."
+
+#: ../src/common/filefn.cpp:474
+#, c-format
+msgid "Failed to copy the file '%s' to '%s'"
+msgstr "Falha ao copiar o ficheiro '%s' para '%s'"
+
+#: ../src/common/filefn.cpp:487
+#, c-format
+msgid "Impossible to get permissions for file '%s'"
+msgstr "Não foi possível obter permissões do ficheiro '%s'"
+
+#: ../src/common/filefn.cpp:501
+#, c-format
+msgid "Impossible to overwrite the file '%s'"
+msgstr "Não foi possível sobrepor o ficheiro '%s'"
+
+#: ../src/common/filefn.cpp:508
+#, fuzzy, c-format
+msgid "Error copying the file '%s' to '%s'."
+msgstr "Falha ao copiar o ficheiro '%s' para '%s'"
+
+#: ../src/common/filefn.cpp:556
+#, c-format
+msgid "Impossible to set permissions for the file '%s'"
+msgstr "Não foi possível definir as permissões do ficheiro '%s'"
+
+#: ../src/common/filefn.cpp:606
+#, c-format
+msgid ""
+"Failed to rename the file '%s' to '%s' because the destination file already "
+"exists."
+msgstr ""
+"Falha ao renomear o ficheiro de '%s' para '%s' porque o ficheiro de destino "
+"já existe."
+
+#: ../src/common/filefn.cpp:623
+#, fuzzy, c-format
+msgid "File '%s' couldn't be renamed '%s'"
+msgstr "Não foi possível criar o directório '%s'"
+
+#: ../src/common/filefn.cpp:639
+#, fuzzy, c-format
+msgid "File '%s' couldn't be removed"
+msgstr "Não foi possível criar o directório '%s'"
+
+#: ../src/common/filefn.cpp:666
+#, c-format
+msgid "Directory '%s' couldn't be created"
+msgstr "Não foi possível criar o directório '%s'"
+
+#: ../src/common/filefn.cpp:680
+#, fuzzy, c-format
+msgid "Directory '%s' couldn't be deleted"
+msgstr "Não foi possível criar o directório '%s'"
+
+#: ../src/common/filefn.cpp:714
+#, c-format
+msgid "Cannot enumerate files '%s'"
+msgstr "Não foi possível enumerar os ficheiros '%s'"
+
+#: ../src/common/filefn.cpp:798
+msgid "Failed to get the working directory"
+msgstr "Falha na obtenção do directório de trabalho"
+
+#: ../src/common/filefn.cpp:843
+#, fuzzy
+msgid "Could not set current working directory"
+msgstr "Falha na obtenção do directório de trabalho"
+
+#: ../src/common/filefn.cpp:974
+#, c-format
+msgid "Files (%s)"
+msgstr "Ficheiros (%s)"
+
+#: ../src/common/filename.cpp:182
+#, fuzzy, c-format
+msgid "Failed to open '%s' for reading"
+msgstr "Falha ao abrir '%s' para %s"
+
+#: ../src/common/filename.cpp:187
+#, fuzzy, c-format
+msgid "Failed to open '%s' for writing"
+msgstr "Falha ao abrir '%s' para %s"
+
+#: ../src/common/filename.cpp:199
+msgid "Failed to close file handle"
+msgstr "Falha ao fechar manuseador de ficheiro"
+
+#: ../src/common/filename.cpp:1046
+msgid "Failed to create a temporary file name"
+msgstr "Falha a criar nome de ficheiro temporário"
+
+#: ../src/common/filename.cpp:1081
+msgid "Failed to open temporary file."
+msgstr "Falha na abertura de ficheiro temporário."
+
+#: ../src/common/filename.cpp:2862
+#, c-format
+msgid "Failed to modify file times for '%s'"
+msgstr "Falha a modificar o tempo do ficheiro para '%s'"
+
+#: ../src/common/filename.cpp:2877
+#, c-format
+msgid "Failed to touch the file '%s'"
+msgstr "Falha ao tocar no ficheiro '%s'"
+
+#: ../src/common/filename.cpp:2958
+#, c-format
+msgid "Failed to retrieve file times for '%s'"
+msgstr "Falha ao obter tempos do ficheiro para '%s'"
+
+#: ../src/common/filepickercmn.cpp:39 ../src/common/filepickercmn.cpp:40
+msgid "Browse"
+msgstr "Explorar"
+
+#: ../src/common/fldlgcmn.cpp:792 ../src/generic/filectrlg.cpp:1185
+#, c-format
+msgid "All files (%s)|%s"
+msgstr "Todos os ficheiros (%s)|%s"
+
+#. TRANSLATORS: %s are a file extension used to build a file wildcard string
+#: ../src/common/fldlgcmn.cpp:810
+#, c-format
+msgid "%s files (%s)|%s"
+msgstr "%s ficheiros (%s)|%s"
+
+#: ../src/common/fldlgcmn.cpp:1072
+#, c-format
+msgid "Load %s file"
+msgstr "Abrir %s ficheiros"
+
+#: ../src/common/fldlgcmn.cpp:1074
+#, c-format
+msgid "Save %s file"
+msgstr "Gravar %s ficheiro"
+
+#: ../src/common/fmapbase.cpp:144
+msgid "Western European (ISO-8859-1)"
+msgstr "Europa Ocidental (ISO-8859-1)"
+
+#: ../src/common/fmapbase.cpp:145
+msgid "Central European (ISO-8859-2)"
+msgstr "Europa Central (ISO-8859-2)"
+
+#: ../src/common/fmapbase.cpp:146
+msgid "Esperanto (ISO-8859-3)"
+msgstr "Esperanto (ISO-8859-3)"
+
+#: ../src/common/fmapbase.cpp:147
+msgid "Baltic (old) (ISO-8859-4)"
+msgstr "Báltico (antigo) (ISO-8859-4)"
+
+#: ../src/common/fmapbase.cpp:148
+msgid "Cyrillic (ISO-8859-5)"
+msgstr "Cirílico (ISO-8859-5)"
+
+#: ../src/common/fmapbase.cpp:149
+msgid "Arabic (ISO-8859-6)"
+msgstr "Árabe (ISO-8859-6)"
+
+#: ../src/common/fmapbase.cpp:150
+msgid "Greek (ISO-8859-7)"
+msgstr "Grêgo (ISO-8859-7)"
+
+#: ../src/common/fmapbase.cpp:151
+msgid "Hebrew (ISO-8859-8)"
+msgstr "Hebreu (ISO-8859-8)"
+
+#: ../src/common/fmapbase.cpp:152
+msgid "Turkish (ISO-8859-9)"
+msgstr "Turco (ISO-8859-9)"
+
+#: ../src/common/fmapbase.cpp:153
+msgid "Nordic (ISO-8859-10)"
+msgstr "Nórdico (ISO-8859-10)"
+
+#: ../src/common/fmapbase.cpp:154
+msgid "Thai (ISO-8859-11)"
+msgstr "Tailandês (ISO-8859-11)"
+
+#: ../src/common/fmapbase.cpp:155
+msgid "Indian (ISO-8859-12)"
+msgstr "Indiano (ISO-8859-12)"
+
+#: ../src/common/fmapbase.cpp:156
+msgid "Baltic (ISO-8859-13)"
+msgstr "Báltico (ISO-8859-13)"
+
+#: ../src/common/fmapbase.cpp:157
+msgid "Celtic (ISO-8859-14)"
+msgstr "Céltico (ISO-8859-14)"
+
+#: ../src/common/fmapbase.cpp:158
+msgid "Western European with Euro (ISO-8859-15)"
+msgstr "Europa Ocidental com Euro (ISO-8859-15)"
+
+#: ../src/common/fmapbase.cpp:159
+msgid "KOI8-R"
+msgstr "KOI8-R"
+
+#: ../src/common/fmapbase.cpp:160
+msgid "KOI8-U"
+msgstr "KOI8-U"
+
+#: ../src/common/fmapbase.cpp:161
+#, fuzzy
+msgid "Windows/DOS OEM Cyrillic (CP 866)"
+msgstr "Cirílico de Windows (CP 1251)"
+
+#: ../src/common/fmapbase.cpp:162
+msgid "Windows Thai (CP 874)"
+msgstr "Tailandês de Windows (CP 874)"
+
+#: ../src/common/fmapbase.cpp:163
+#, fuzzy
+msgid "Windows Japanese (CP 932) or Shift-JIS"
+msgstr "Japonês de Windows (CP 932)"
+
+#: ../src/common/fmapbase.cpp:164
+#, fuzzy
+msgid "Windows Chinese Simplified (CP 936) or GB-2312"
+msgstr "Chinês Simplificado de Windows (CP 936)"
+
+#: ../src/common/fmapbase.cpp:165
+msgid "Windows Korean (CP 949)"
+msgstr "Coreano de Windows (CP 949)"
+
+#: ../src/common/fmapbase.cpp:166
+#, fuzzy
+msgid "Windows Chinese Traditional (CP 950) or Big-5"
+msgstr "Chinês Tradicional de Windows (CP 950)"
+
+#: ../src/common/fmapbase.cpp:167
+msgid "Windows Central European (CP 1250)"
+msgstr "Europeu Central de Windows (CP 1250)"
+
+#: ../src/common/fmapbase.cpp:168
+msgid "Windows Cyrillic (CP 1251)"
+msgstr "Cirílico de Windows (CP 1251)"
+
+#: ../src/common/fmapbase.cpp:169
+msgid "Windows Western European (CP 1252)"
+msgstr "Europeu Ocidental de Windows (CP 1252)"
+
+#: ../src/common/fmapbase.cpp:170
+msgid "Windows Greek (CP 1253)"
+msgstr "Grêgo de Windows (CP 1253)"
+
+#: ../src/common/fmapbase.cpp:171
+msgid "Windows Turkish (CP 1254)"
+msgstr "Turco de Windows (CP 1254)"
+
+#: ../src/common/fmapbase.cpp:172
+msgid "Windows Hebrew (CP 1255)"
+msgstr "Hebreu de Windows (CP 1255)"
+
+#: ../src/common/fmapbase.cpp:173
+msgid "Windows Arabic (CP 1256)"
+msgstr "Árabe de Windows (CP 1256)"
+
+#: ../src/common/fmapbase.cpp:174
+msgid "Windows Baltic (CP 1257)"
+msgstr "Báltico de Windows (CP 1257)"
+
+#: ../src/common/fmapbase.cpp:175
+#, fuzzy
+msgid "Windows Vietnamese (CP 1258)"
+msgstr "Grêgo de Windows (CP 1253)"
+
+#: ../src/common/fmapbase.cpp:176
+#, fuzzy
+msgid "Windows Johab (CP 1361)"
+msgstr "Árabe de Windows (CP 1256)"
+
+#: ../src/common/fmapbase.cpp:177
+msgid "Windows/DOS OEM (CP 437)"
+msgstr "Windows/DOS OEM (CP 437)"
+
+#: ../src/common/fmapbase.cpp:178
+msgid "Unicode 7 bit (UTF-7)"
+msgstr "Unicode 7 bit (UTF-7)"
+
+#: ../src/common/fmapbase.cpp:179
+msgid "Unicode 8 bit (UTF-8)"
+msgstr "Unicode 8 bit (UTF-8)"
+
+#: ../src/common/fmapbase.cpp:181 ../src/common/fmapbase.cpp:187
+msgid "Unicode 16 bit (UTF-16)"
+msgstr "Unicode 16 bit (UTF-16)"
+
+#: ../src/common/fmapbase.cpp:182
+msgid "Unicode 16 bit Little Endian (UTF-16LE)"
+msgstr "Unicode 16 bit Little Endian (UTF-16LE)"
+
+#: ../src/common/fmapbase.cpp:183 ../src/common/fmapbase.cpp:189
+msgid "Unicode 32 bit (UTF-32)"
+msgstr "Unicode 32 bit (UTF-32)"
+
+#: ../src/common/fmapbase.cpp:184
+msgid "Unicode 32 bit Little Endian (UTF-32LE)"
+msgstr "Unicode 32 bit Little Endian (UTF-32LE)"
+
+#: ../src/common/fmapbase.cpp:186
+msgid "Unicode 16 bit Big Endian (UTF-16BE)"
+msgstr "Unicode 16 bit Big Endian (UTF-16BE)"
+
+#: ../src/common/fmapbase.cpp:188
+msgid "Unicode 32 bit Big Endian (UTF-32BE)"
+msgstr "Unicode 32 bit Big Endian (UTF-32BE)"
+
+#: ../src/common/fmapbase.cpp:191
+msgid "Extended Unix Codepage for Japanese (EUC-JP)"
+msgstr "Código de Página Extendido para Japonês (EUC-JP)"
+
+#: ../src/common/fmapbase.cpp:192
+msgid "US-ASCII"
+msgstr "US-ASCII"
+
+#: ../src/common/fmapbase.cpp:193
+msgid "ISO-2022-JP"
+msgstr "ISO-2022-JP"
+
+#: ../src/common/fmapbase.cpp:195
+#, fuzzy
+msgid "MacRoman"
+msgstr "Roman"
+
+#: ../src/common/fmapbase.cpp:196
+msgid "MacJapanese"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:197
+msgid "MacChineseTrad"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:198
+msgid "MacKorean"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:199
+#, fuzzy
+msgid "MacArabic"
+msgstr "Árabe"
+
+#: ../src/common/fmapbase.cpp:200
+msgid "MacHebrew"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:201
+msgid "MacGreek"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:202
+msgid "MacCyrillic"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:203
+msgid "MacDevanagari"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:204
+msgid "MacGurmukhi"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:205
+msgid "MacGujarati"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:206
+msgid "MacOriya"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:207
+msgid "MacBengali"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:208
+msgid "MacTamil"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:209
+msgid "MacTelugu"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:210
+msgid "MacKannada"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:211
+msgid "MacMalayalam"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:212
+#, fuzzy
+msgid "MacSinhalese"
+msgstr "Coincidir capitulação"
+
+#: ../src/common/fmapbase.cpp:213
+msgid "MacBurmese"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:214
+msgid "MacKhmer"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:215
+msgid "MacThai"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:216
+msgid "MacLaotian"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:217
+msgid "MacGeorgian"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:218
+msgid "MacArmenian"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:219
+msgid "MacChineseSimp"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:220
+msgid "MacTibetan"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:221
+msgid "MacMongolian"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:222
+msgid "MacEthiopic"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:223
+msgid "MacCentralEurRoman"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:224
+msgid "MacVietnamese"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:225
+#, fuzzy
+msgid "MacExtArabic"
+msgstr "Árabe"
+
+#: ../src/common/fmapbase.cpp:226
+#, fuzzy
+msgid "MacSymbol"
+msgstr "Symbol"
+
+#: ../src/common/fmapbase.cpp:227
+msgid "MacDingbats"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:228
+msgid "MacTurkish"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:229
+msgid "MacCroatian"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:230
+msgid "MacIcelandic"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:231
+#, fuzzy
+msgid "MacRomanian"
+msgstr "Roman"
+
+#: ../src/common/fmapbase.cpp:232
+msgid "MacCeltic"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:233
+msgid "MacGaelic"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:234
+msgid "MacKeyboardGlyphs"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:791
+msgid "Default encoding"
+msgstr "Codificação pré-definida"
+
+#: ../src/common/fmapbase.cpp:805
+#, c-format
+msgid "Unknown encoding (%d)"
+msgstr "Codificação desconhecida (%d)"
+
+#: ../src/common/fmapbase.cpp:815 ../src/richtext/richtextstyles.cpp:776
+msgid "default"
+msgstr "pré-definição"
+
+#: ../src/common/fmapbase.cpp:829
+#, c-format
+msgid "unknown-%d"
+msgstr "desconhecido %d"
+
+#: ../src/common/fontcmn.cpp:924 ../src/common/fontcmn.cpp:1130
+msgid "underlined"
+msgstr "sublinhado"
+
+#: ../src/common/fontcmn.cpp:929
+msgid " strikethrough"
+msgstr " rasurado"
+
+#: ../src/common/fontcmn.cpp:942
+msgid " thin"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:946
+#, fuzzy
+msgid " extra light"
+msgstr " leve"
+
+#: ../src/common/fontcmn.cpp:950
+msgid " light"
+msgstr " leve"
+
+#: ../src/common/fontcmn.cpp:954
+msgid " medium"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:958
+#, fuzzy
+msgid " semi bold"
+msgstr " negrito"
+
+#: ../src/common/fontcmn.cpp:962
+msgid " bold"
+msgstr " negrito"
+
+#: ../src/common/fontcmn.cpp:966
+#, fuzzy
+msgid " extra bold"
+msgstr " negrito"
+
+#: ../src/common/fontcmn.cpp:970
+msgid " heavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:974
+msgid " extra heavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:990
+msgid " italic"
+msgstr " itálico"
+
+#: ../src/common/fontcmn.cpp:1134
+msgid "strikethrough"
+msgstr "Rasurado"
+
+#: ../src/common/fontcmn.cpp:1143
+msgid "thin"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1156
+#, fuzzy
+msgid "extralight"
+msgstr "leve"
+
+#: ../src/common/fontcmn.cpp:1161
+msgid "light"
+msgstr "leve"
+
+#: ../src/common/fontcmn.cpp:1169 ../src/richtext/richtextstyles.cpp:775
+#, fuzzy
+msgid "normal"
+msgstr "Normal"
+
+#: ../src/common/fontcmn.cpp:1174
+msgid "medium"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1179 ../src/common/fontcmn.cpp:1199
+#, fuzzy
+msgid "semibold"
+msgstr "negrito"
+
+#: ../src/common/fontcmn.cpp:1184
+msgid "bold"
+msgstr "negrito"
+
+#: ../src/common/fontcmn.cpp:1194
+#, fuzzy
+msgid "extrabold"
+msgstr "negrito"
+
+#: ../src/common/fontcmn.cpp:1204
+msgid "heavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1212
+msgid "extraheavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1217
+msgid "italic"
+msgstr "itálico"
+
+#: ../src/common/fontmap.cpp:195
+msgid ": unknown charset"
+msgstr ": conjunto de caracteres desconhecido"
+
+#: ../src/common/fontmap.cpp:199
+#, c-format
+msgid ""
+"The charset '%s' is unknown. You may select\n"
+"another charset to replace it with or choose\n"
+"[Cancel] if it cannot be replaced"
+msgstr ""
+"O conjunto de caracteres '%s' é desconhecido. Pode Selecionar\n"
+"outro conjunto de caracteres para substituir, ou escolher\n"
+"[Cancelar] se não puder ser trocado"
+
+#: ../src/common/fontmap.cpp:241
+#, c-format
+msgid "Failed to remember the encoding for the charset '%s'."
+msgstr "Falha ao recordar a codificação para o conjunto de caracteres '%s'."
+
+#: ../src/common/fontmap.cpp:321
+msgid "can't load any font, aborting"
+msgstr "não foi possível carregar nenhuma fonte, a abortar"
+
+#: ../src/common/fontmap.cpp:409
+msgid ": unknown encoding"
+msgstr ": codificação desconhecida"
+
+#: ../src/common/fontmap.cpp:417
+#, c-format
+msgid ""
+"No font for displaying text in encoding '%s' found,\n"
+"but an alternative encoding '%s' is available.\n"
+"Do you want to use this encoding (otherwise you will have to choose another "
+"one)?"
+msgstr ""
+"Não foi encontrada uma fonte para mostrar texto na codificação '%s',\n"
+"mas uma codificação alternativa '%s' está disponível.\n"
+"Pretende utilizar esta codificação (caso contrário terá de escolher outra)?"
+
+#: ../src/common/fontmap.cpp:422
+#, c-format
+msgid ""
+"No font for displaying text in encoding '%s' found.\n"
+"Would you like to select a font to be used for this encoding\n"
+"(otherwise the text in this encoding will not be shown correctly)?"
+msgstr ""
+"Não foi encontrado nenhum tipo de letra para mostrar o texto na codificação "
+"'%s',\n"
+"Deseja selecionar um tipo de letra para ser usado nesta codificação\n"
+"(caso contrário o texto nesta codificação não será apresentado "
+"correctamente)?"
+
+#: ../src/common/fs_mem.cpp:169
+#, c-format
+msgid "Memory VFS already contains file '%s'!"
+msgstr "A memória VFS já contém o ficheiro '%s'!"
+
+#: ../src/common/fs_mem.cpp:232
+#, c-format
+msgid "Trying to remove file '%s' from memory VFS, but it is not loaded!"
+msgstr ""
+"A Tentar remover o ficheiro '%s' da memória VFS, mas não foi carregado!"
+
+#: ../src/common/fs_mem.cpp:262
+#, c-format
+msgid "Failed to store image '%s' to memory VFS!"
+msgstr "Falha ao armazenar imagem '%s' para memória VFS!"
+
+#: ../src/common/ftp.cpp:197
+msgid "Timeout while waiting for FTP server to connect, try passive mode."
+msgstr ""
+"Tempo excedido enquanto esperava a ligação do servidor FTP, tente o modo "
+"passivo."
+
+#: ../src/common/ftp.cpp:399
+#, c-format
+msgid "Failed to set FTP transfer mode to %s."
+msgstr "Falha ao definir modo de transferência FTP para %s."
+
+#: ../src/common/ftp.cpp:400 ../src/richtext/richtextsymboldlg.cpp:432
+msgid "ASCII"
+msgstr "ASCII"
+
+#: ../src/common/ftp.cpp:400
+msgid "binary"
+msgstr "binário"
+
+#: ../src/common/ftp.cpp:608
+msgid "The FTP server doesn't support the PORT command."
+msgstr "O servidor de FTP não suporta o comando PORT."
+
+#: ../src/common/ftp.cpp:622
+msgid "The FTP server doesn't support passive mode."
+msgstr "O servidor do FTP não suporta modo passivo."
+
+#: ../src/common/gifdecod.cpp:822
+#, c-format
+msgid "Incorrect GIF frame size (%u, %d) for the frame #%u"
+msgstr ""
+
+#: ../src/common/glcmn.cpp:108
+#, fuzzy
+msgid "Failed to allocate colour for OpenGL"
+msgstr "Falha de criação de cursor."
+
+#: ../src/common/headerctrlcmn.cpp:57
+msgid "Please select the columns to show and define their order:"
+msgstr ""
+
+#: ../src/common/headerctrlcmn.cpp:58
+msgid "Customize Columns"
+msgstr "Personalizar Colunas"
+
+#: ../src/common/headerctrlcmn.cpp:304
+msgid "&Customize..."
+msgstr "&Personalizar ..."
+
+#: ../src/common/hyperlnkcmn.cpp:132
+#, fuzzy, c-format
+msgid "Failed to open URL \"%s\" in the default browser"
+msgstr "Falha ao abrir '%s' para %s"
+
+#: ../src/common/iconbndl.cpp:195
+#, fuzzy, c-format
+msgid "Failed to load image %%d from file '%s'."
+msgstr "Falha na abertura da imagem %d do ficheiro '%s'."
+
+#: ../src/common/iconbndl.cpp:203
+#, fuzzy, c-format
+msgid "Failed to load image %d from stream."
+msgstr "Falha na abertura da imagem %d do ficheiro '%s'."
+
+#: ../src/common/iconbndl.cpp:221
+#, fuzzy, c-format
+msgid "Failed to load icons from resource '%s'."
+msgstr "Falha na abertura da imagem %d do ficheiro '%s'."
+
+#: ../src/common/imagbmp.cpp:97
+msgid "BMP: Couldn't save invalid image."
+msgstr "BMP: Impossível gravar imagem inválida."
+
+#: ../src/common/imagbmp.cpp:137
+msgid "BMP: wxImage doesn't have own wxPalette."
+msgstr "BMP: wxImage não tem a sua wxPalette."
+
+#: ../src/common/imagbmp.cpp:243
+msgid "BMP: Couldn't write the file (Bitmap) header."
+msgstr "BMP: Impossível escrever o cabeçalho do ficheiro (Bitmap)."
+
+#: ../src/common/imagbmp.cpp:266
+msgid "BMP: Couldn't write the file (BitmapInfo) header."
+msgstr "BMP: Impossível escrever o cabeçalho do ficheiro (BitmapInfo)."
+
+#: ../src/common/imagbmp.cpp:353
+msgid "BMP: Couldn't write RGB color map."
+msgstr "BMP: Impossível escrever mapa de cores RGB."
+
+#: ../src/common/imagbmp.cpp:487
+msgid "BMP: Couldn't write data."
+msgstr "BMP: Impossível escrever data."
+
+#: ../src/common/imagbmp.cpp:561 ../src/common/imagbmp.cpp:642
+msgid "BMP: Couldn't allocate memory."
+msgstr "BMP: Impossível alocar memória."
+
+#: ../src/common/imagbmp.cpp:1041
+msgid "DIB Header: Image width > 32767 pixels for file."
+msgstr "Cabeçalho DIB: Largura da imagem > 32767 pixeis para o ficheiro."
+
+#: ../src/common/imagbmp.cpp:1049
+msgid "DIB Header: Image height > 32767 pixels for file."
+msgstr "Cabeçalho DIB: Altura da imagem > 32767 pixeis para o ficheiro."
+
+#: ../src/common/imagbmp.cpp:1081
+msgid "DIB Header: Unknown bitdepth in file."
+msgstr "Cabeçalho DIB: Bitdepth desconhecido no ficheiro."
+
+#: ../src/common/imagbmp.cpp:1156
+msgid "DIB Header: Unknown encoding in file."
+msgstr "Cabeçalho DIB: Codificação desconhecida no ficheiro."
+
+#: ../src/common/imagbmp.cpp:1165
+msgid "DIB Header: Encoding doesn't match bitdepth."
+msgstr "Cabeçalho DIB: Codificação não coincide com o bitdepth."
+
+#: ../src/common/imagbmp.cpp:1180
+#, c-format
+msgid "BMP Header: Invalid number of colors (%d)."
+msgstr ""
+
+#: ../src/common/imagbmp.cpp:1273
+msgid "Error in reading image DIB."
+msgstr "Erro na leitura do DIB da imagem."
+
+#: ../src/common/imagbmp.cpp:1294
+msgid "ICO: Error in reading mask DIB."
+msgstr "ICO: Erro a ler máscara DIB."
+
+#: ../src/common/imagbmp.cpp:1353
+msgid "ICO: Image too tall for an icon."
+msgstr "ICO: Imagem alta demais para um ícone."
+
+#: ../src/common/imagbmp.cpp:1361
+msgid "ICO: Image too wide for an icon."
+msgstr "ICO: Imagem larga demais para um ícone."
+
+#: ../src/common/imagbmp.cpp:1388 ../src/common/imagbmp.cpp:1488
+#: ../src/common/imagbmp.cpp:1503 ../src/common/imagbmp.cpp:1514
+#: ../src/common/imagbmp.cpp:1528 ../src/common/imagbmp.cpp:1576
+#: ../src/common/imagbmp.cpp:1591 ../src/common/imagbmp.cpp:1605
+#: ../src/common/imagbmp.cpp:1616
+msgid "ICO: Error writing the image file!"
+msgstr "ICO: Erro a escrever ficheiro de imagem!"
+
+#: ../src/common/imagbmp.cpp:1701
+msgid "ICO: Invalid icon index."
+msgstr "ICO: Índice inválido de ícone."
+
+#: ../src/common/image.cpp:2410
+msgid "Image and mask have different sizes."
+msgstr "A imagem e a máscara têm tamanhos diferentes."
+
+#: ../src/common/image.cpp:2418 ../src/common/image.cpp:2459
+msgid "No unused colour in image being masked."
+msgstr "Sem cor usada na imagem a ser mascarada."
+
+#: ../src/common/image.cpp:2641
+#, fuzzy, c-format
+msgid "Failed to load bitmap \"%s\" from resources."
+msgstr "Falha na abertura da imagem %d do ficheiro '%s'."
+
+#: ../src/common/image.cpp:2650
+#, fuzzy, c-format
+msgid "Failed to load icon \"%s\" from resources."
+msgstr "Falha na abertura da imagem %d do ficheiro '%s'."
+
+#: ../src/common/image.cpp:2728 ../src/common/image.cpp:2747
+#, fuzzy, c-format
+msgid "Failed to load image from file \"%s\"."
+msgstr "Falha na abertura da imagem %d do ficheiro '%s'."
+
+#: ../src/common/image.cpp:2761
+#, c-format
+msgid "Can't save image to file '%s': unknown extension."
+msgstr ""
+"Não foi possível gravar imagem para ficheiro '%s': extensão desconhecida."
+
+#: ../src/common/image.cpp:2869
+msgid "No handler found for image type."
+msgstr "Não foi encontrado um manuseador para o tipo de imagem."
+
+#: ../src/common/image.cpp:2877 ../src/common/image.cpp:3000
+#: ../src/common/image.cpp:3066
+#, c-format
+msgid "No image handler for type %d defined."
+msgstr "Não existe um manuseador para o tipo %d definido."
+
+#: ../src/common/image.cpp:2887
+#, fuzzy, c-format
+msgid "Image file is not of type %d."
+msgstr "O ficheiro de imagem não é do tipo %ld."
+
+#: ../src/common/image.cpp:2970
+msgid "Can't automatically determine the image format for non-seekable input."
+msgstr ""
+"Não é possível determinar automaticamente o formato da imagem para entrada "
+"não pesquisável."
+
+#: ../src/common/image.cpp:2988
+#, fuzzy
+msgid "Unknown image data format."
+msgstr "erro no formato do dado"
+
+#: ../src/common/image.cpp:3009
+#, fuzzy, c-format
+msgid "This is not a %s."
+msgstr "PCX: este não é um ficheiro PCX."
+
+#: ../src/common/image.cpp:3032 ../src/common/image.cpp:3080
+#, c-format
+msgid "No image handler for type %s defined."
+msgstr "Não existe um manuseador de imagem para o tipo %s definido."
+
+#: ../src/common/image.cpp:3041
+#, fuzzy, c-format
+msgid "Image is not of type %s."
+msgstr "O ficheiro de imagem não é do tipo %s."
+
+#: ../src/common/image.cpp:3509
+#, fuzzy, c-format
+msgid "Failed to check format of image file \"%s\"."
+msgstr "Falha ao gravar imagem de bitmap para ficheiro \"%s\"."
+
+#: ../src/common/imaggif.cpp:124
+msgid "GIF: error in GIF image format."
+msgstr "GIF: erro no formato de imagem GIF."
+
+#: ../src/common/imaggif.cpp:129
+msgid "GIF: not enough memory."
+msgstr "GIF: sem memória suficiente."
+
+#: ../src/common/imaggif.cpp:134
+msgid "GIF: data stream seems to be truncated."
+msgstr "GIF: corrente de dados parece estar truncada."
+
+#: ../src/common/imaggif.cpp:240
+#, fuzzy
+msgid "Couldn't initialize GIF hash table."
+msgstr "Não é possível inicializar o zlib deflate stream."
+
+#: ../src/common/imagiff.cpp:739
+msgid "IFF: error in IFF image format."
+msgstr "IFF: erro no formato de imagem IFF."
+
+#: ../src/common/imagiff.cpp:742
+msgid "IFF: not enough memory."
+msgstr "IFF: sem memória suficiente."
+
+#: ../src/common/imagiff.cpp:745
+msgid "IFF: unknown error!!!"
+msgstr "IFF: erro desconhecido!!!"
+
+#: ../src/common/imagiff.cpp:755
+msgid "IFF: data stream seems to be truncated."
+msgstr "IFF: Corrente de dados parece estar truncada."
+
+#: ../src/common/imagjpeg.cpp:258
+msgid "JPEG: Couldn't load - file is probably corrupted."
+msgstr "JPEG: Impossível ler - o ficheiro provavelmente está corrupto."
+
+#: ../src/common/imagjpeg.cpp:437
+msgid "JPEG: Couldn't save image."
+msgstr "JPEG: Impossível gravar imagem."
+
+#: ../src/common/imagpcx.cpp:439
+msgid "PCX: this is not a PCX file."
+msgstr "PCX: este não é um ficheiro PCX."
+
+#: ../src/common/imagpcx.cpp:453
+msgid "PCX: image format unsupported"
+msgstr "PCX: formato de imagem não suportado"
+
+#: ../src/common/imagpcx.cpp:454 ../src/common/imagpcx.cpp:477
+msgid "PCX: couldn't allocate memory"
+msgstr "PCX: não é possível alocar memória"
+
+#: ../src/common/imagpcx.cpp:455
+msgid "PCX: version number too low"
+msgstr "PCX: número de versão muito baixo"
+
+#: ../src/common/imagpcx.cpp:456 ../src/common/imagpcx.cpp:478
+msgid "PCX: unknown error !!!"
+msgstr "PCX: erro desconhecido!!!"
+
+#: ../src/common/imagpcx.cpp:476
+msgid "PCX: invalid image"
+msgstr "PCX: imagem inválida"
+
+#: ../src/common/imagpng.cpp:385
+#, fuzzy, c-format
+msgid "Unknown PNG resolution unit %d"
+msgstr "Opção desconhecida '%s'"
+
+#: ../src/common/imagpng.cpp:439
+msgid "Couldn't load a PNG image - file is corrupted or not enough memory."
+msgstr ""
+"Não foi possível carregar uma imagem PNG - Ficheiro corrupto ou memória "
+"insuficiente."
+
+#: ../src/common/imagpng.cpp:513 ../src/common/imagpng.cpp:524
+#: ../src/common/imagpng.cpp:534
+msgid "Couldn't save PNG image."
+msgstr "Não foi possível gravar a imagem PNG."
+
+#: ../src/common/imagpnm.cpp:71
+msgid "PNM: File format is not recognized."
+msgstr "PNM: Formato do ficheiro não é reconhecido."
+
+#: ../src/common/imagpnm.cpp:89
+msgid "PNM: Couldn't allocate memory."
+msgstr "PNM: Não é possível alocar memória."
+
+#: ../src/common/imagpnm.cpp:111 ../src/common/imagpnm.cpp:134
+#: ../src/common/imagpnm.cpp:156
+msgid "PNM: File seems truncated."
+msgstr "PNM: O ficheiro parece estar truncado."
+
+#: ../src/common/imagtiff.cpp:69
+#, c-format
+msgid " (in module \"%s\")"
+msgstr " (no módulo \"%s\")"
+
+#: ../src/common/imagtiff.cpp:304
+msgid "TIFF: Error loading image."
+msgstr "TIFF: Erro ao carregar imagem."
+
+#: ../src/common/imagtiff.cpp:314
+msgid "Invalid TIFF image index."
+msgstr "Índice inválido para imagem TIFF."
+
+#: ../src/common/imagtiff.cpp:358
+msgid "TIFF: Image size is abnormally big."
+msgstr ""
+
+#: ../src/common/imagtiff.cpp:372 ../src/common/imagtiff.cpp:385
+#: ../src/common/imagtiff.cpp:769
+msgid "TIFF: Couldn't allocate memory."
+msgstr "TIFF: Não é possível alocar memória."
+
+#: ../src/common/imagtiff.cpp:471
+msgid "TIFF: Error reading image."
+msgstr "TIFF: Erro ao ler imagem."
+
+#: ../src/common/imagtiff.cpp:532
+#, c-format
+msgid "Unknown TIFF resolution unit %d ignored"
+msgstr ""
+
+#: ../src/common/imagtiff.cpp:611
+msgid "TIFF: Error saving image."
+msgstr "TIFF: Erro ao gravar imagem."
+
+#: ../src/common/imagtiff.cpp:868
+msgid "TIFF: Error writing image."
+msgstr "TIFF: Erro ao escrever imagem."
+
+#: ../src/common/imagtiff.cpp:881
+#, fuzzy
+msgid "TIFF: Error flushing data."
+msgstr "TIFF: Erro ao gravar imagem."
+
+#: ../src/common/imagwebp.cpp:56
+msgid "WebP: Invalid data (failed to get features)."
+msgstr ""
+
+#: ../src/common/imagwebp.cpp:65
+msgid "WebP: Allocating image memory failed."
+msgstr ""
+
+#: ../src/common/imagwebp.cpp:82
+msgid "WebP: Decoding RGBA image data failed."
+msgstr ""
+
+#: ../src/common/imagwebp.cpp:98
+msgid "WebP: Decoding RGB image data failed."
+msgstr ""
+
+#: ../src/common/imagwebp.cpp:113 ../src/common/imagwebp.cpp:201
+msgid "WebP: Allocating stream buffer failed."
+msgstr ""
+
+#: ../src/common/imagwebp.cpp:131
+#, fuzzy
+msgid "WebP: Failed to parse container data."
+msgstr "Falha ao definir dados da área de transferência."
+
+#: ../src/common/imagwebp.cpp:222
+#, fuzzy
+msgid "WebP: Error decoding animation."
+msgstr "Erro ao ler opções de configuração."
+
+#: ../src/common/imagwebp.cpp:240
+msgid "WebP: Error getting next animation frame."
+msgstr ""
+
+#: ../src/common/init.cpp:172
+#, c-format
+msgid ""
+"Command line argument %d couldn't be converted to Unicode and will be "
+"ignored."
+msgstr ""
+
+#: ../src/common/init.cpp:344
+msgid "Initialization failed in post init, aborting."
+msgstr "Falha de inicialização no post init, a interromper."
+
+#: ../src/common/intl.cpp:378
+#, c-format
+msgid "Cannot set locale to language \"%s\"."
+msgstr ""
+
+#: ../src/common/log.cpp:232
+msgid "Error: "
+msgstr "Erro: "
+
+#: ../src/common/log.cpp:236
+msgid "Warning: "
+msgstr "Aviso: "
+
+#: ../src/common/log.cpp:284
+#, fuzzy
+msgid "The previous message repeated once."
+msgstr "A mensagem anterior repetida uma vez."
+
+#: ../src/common/log.cpp:291
+#, fuzzy, c-format
+msgid "The previous message repeated %u time."
+msgid_plural "The previous message repeated %u times."
+msgstr[0] "A mensagem anterior repetida uma vez."
+msgstr[1] "A mensagem anterior repetida %lu vezes."
+
+#: ../src/common/log.cpp:319
+#, c-format
+msgid "Last repeated message (\"%s\", %u time) wasn't output"
+msgid_plural "Last repeated message (\"%s\", %u times) wasn't output"
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../src/common/log.cpp:435
+#, c-format
+msgid " (error %ld: %s)"
+msgstr " (erro %ld: %s)"
+
+#: ../src/common/lzmastream.cpp:121
+#, fuzzy
+msgid "Failed to allocate memory for LZMA decompression."
+msgstr "Falha de criação de cursor."
+
+#: ../src/common/lzmastream.cpp:125
+#, c-format
+msgid "Failed to initialize LZMA decompression: unexpected error %u."
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:179
+msgid "input is not in XZ format"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:183
+msgid "input compressed using unknown XZ option"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:188
+msgid "input is corrupted"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:192
+#, fuzzy
+msgid "unknown decompression error"
+msgstr "erro de descompressão"
+
+#: ../src/common/lzmastream.cpp:196
+#, fuzzy, c-format
+msgid "LZMA decompression error: %s"
+msgstr "erro de descompressão"
+
+#: ../src/common/lzmastream.cpp:231
+#, fuzzy
+msgid "Failed to allocate memory for LZMA compression."
+msgstr "Falha de criação de cursor."
+
+#: ../src/common/lzmastream.cpp:235
+#, c-format
+msgid "Failed to initialize LZMA compression: unexpected error %u."
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:267 ../src/common/lzmastream.cpp:342
+#: ../src/html/chm.cpp:336
+msgid "out of memory"
+msgstr "memória esgotada"
+
+#: ../src/common/lzmastream.cpp:276 ../src/common/lzmastream.cpp:346
+#, fuzzy
+msgid "unknown compression error"
+msgstr "erro de compressão"
+
+#: ../src/common/lzmastream.cpp:280
+#, fuzzy, c-format
+msgid "LZMA compression error: %s"
+msgstr "erro de compressão"
+
+#: ../src/common/lzmastream.cpp:350
+#, c-format
+msgid "LZMA compression error when flushing output: %s"
+msgstr ""
+
+#: ../src/common/mimecmn.cpp:167
+#, c-format
+msgid "Unmatched '{' in an entry for mime type %s."
+msgstr "Correspondência não encontrada de '{' numa entrada do tipo mime %s."
+
+#: ../src/common/module.cpp:76
+#, c-format
+msgid "Circular dependency involving module \"%s\" detected."
+msgstr "Foi detectada uma dependência circular envolvendo o módulo \"%s\"."
+
+#: ../src/common/module.cpp:128
+#, c-format
+msgid "Dependency \"%s\" of module \"%s\" doesn't exist."
+msgstr "Dependência  \"%s\" do módulo \"%s\" não existe."
+
+#: ../src/common/module.cpp:137
+#, c-format
+msgid "Module \"%s\" initialization failed"
+msgstr "Falha de inicialização do Módulo \"%s\""
+
+#: ../src/common/msgout.cpp:96
+#, fuzzy
+msgid "Message"
+msgstr "%s mensagem"
+
+#: ../src/common/paper.cpp:70
+msgid "Letter, 8 1/2 x 11 in"
+msgstr "Letter, 8 1/2 x 11 pol."
+
+#: ../src/common/paper.cpp:71
+msgid "Legal, 8 1/2 x 14 in"
+msgstr "Legal, 8 1/2 x 14 pol."
+
+#: ../src/common/paper.cpp:72
+msgid "A4 sheet, 210 x 297 mm"
+msgstr "Folha A4, 210 x 297 mm"
+
+#: ../src/common/paper.cpp:73
+msgid "C sheet, 17 x 22 in"
+msgstr "Folha C, 17 x 22 pol."
+
+#: ../src/common/paper.cpp:74
+msgid "D sheet, 22 x 34 in"
+msgstr "Folha D, 22 x 34 pol."
+
+#: ../src/common/paper.cpp:75
+msgid "E sheet, 34 x 44 in"
+msgstr "Folha E, 34 x 44 pol."
+
+#: ../src/common/paper.cpp:76
+msgid "Letter Small, 8 1/2 x 11 in"
+msgstr "Letter Pequena, 8 1/2 x 11 pol."
+
+#: ../src/common/paper.cpp:77
+msgid "Tabloid, 11 x 17 in"
+msgstr "Tabloid, 11 x 17 pol."
+
+#: ../src/common/paper.cpp:78
+msgid "Ledger, 17 x 11 in"
+msgstr "Agenda, 17 x 11 pol."
+
+#: ../src/common/paper.cpp:79
+msgid "Statement, 5 1/2 x 8 1/2 in"
+msgstr "Statement, 5 1/2 x 8 1/2 pol."
+
+#: ../src/common/paper.cpp:80
+msgid "Executive, 7 1/4 x 10 1/2 in"
+msgstr "Executivo, 7 1/4 x 10 1/2 pol."
+
+#: ../src/common/paper.cpp:81
+msgid "A3 sheet, 297 x 420 mm"
+msgstr "Folha A3, 297 x 420 mm"
+
+#: ../src/common/paper.cpp:82
+msgid "A4 small sheet, 210 x 297 mm"
+msgstr "A4 folha pequena, 210x297 mm"
+
+#: ../src/common/paper.cpp:83
+msgid "A5 sheet, 148 x 210 mm"
+msgstr "A5 folha, 148 x 210 mm"
+
+#: ../src/common/paper.cpp:84
+msgid "B4 sheet, 250 x 354 mm"
+msgstr "Folha B4, 250 x 354 mm"
+
+#: ../src/common/paper.cpp:85
+msgid "B5 sheet, 182 x 257 millimeter"
+msgstr "B5 folha, 182 x 257 millimeter"
+
+#: ../src/common/paper.cpp:86
+msgid "Folio, 8 1/2 x 13 in"
+msgstr "Folio, 8 1/2 x 13 pol."
+
+#: ../src/common/paper.cpp:87
+msgid "Quarto, 215 x 275 mm"
+msgstr "Quarto, 215 x 275 mm"
+
+#: ../src/common/paper.cpp:88
+msgid "10 x 14 in"
+msgstr "10 x 14 pol."
+
+#: ../src/common/paper.cpp:89
+msgid "11 x 17 in"
+msgstr "11 x 17 pol."
+
+#: ../src/common/paper.cpp:90
+msgid "Note, 8 1/2 x 11 in"
+msgstr "Nota, 8 1/2 x 11 pol."
+
+#: ../src/common/paper.cpp:91
+msgid "#9 Envelope, 3 7/8 x 8 7/8 in"
+msgstr "Envelope #9, 3 7/8 x 8 7/8 pol."
+
+#: ../src/common/paper.cpp:92
+msgid "#10 Envelope, 4 1/8 x 9 1/2 in"
+msgstr "Envelope #10, 4 1/8 x 9 1/2 pol."
+
+#: ../src/common/paper.cpp:93
+msgid "#11 Envelope, 4 1/2 x 10 3/8 in"
+msgstr "Envelope #11, 4 1/2 x 10 3/8 pol."
+
+#: ../src/common/paper.cpp:94
+msgid "#12 Envelope, 4 3/4 x 11 in"
+msgstr "Envelope #12, 4 3/4 x 11 pol."
+
+#: ../src/common/paper.cpp:95
+msgid "#14 Envelope, 5 x 11 1/2 in"
+msgstr "Envelope #14, 5 x 11 1/2 pol."
+
+#: ../src/common/paper.cpp:96
+msgid "DL Envelope, 110 x 220 mm"
+msgstr "Envelope DL, 110 x 220 mm"
+
+#: ../src/common/paper.cpp:97
+msgid "C5 Envelope, 162 x 229 mm"
+msgstr "Envelope C5, 162 x 229 mm"
+
+#: ../src/common/paper.cpp:98
+msgid "C3 Envelope, 324 x 458 mm"
+msgstr "Envelope C3, 324 x 458 mm"
+
+#: ../src/common/paper.cpp:99
+msgid "C4 Envelope, 229 x 324 mm"
+msgstr "Envelope C4, 229 x 324 mm"
+
+#: ../src/common/paper.cpp:100
+msgid "C6 Envelope, 114 x 162 mm"
+msgstr "Envelope C6, 114 x 162 mm"
+
+#: ../src/common/paper.cpp:101
+msgid "C65 Envelope, 114 x 229 mm"
+msgstr "Envelope C65, 114 x 229 mm"
+
+#: ../src/common/paper.cpp:102
+msgid "B4 Envelope, 250 x 353 mm"
+msgstr "Envelope B4, 250x353 mm"
+
+#: ../src/common/paper.cpp:103
+msgid "B5 Envelope, 176 x 250 mm"
+msgstr "Envelope B5, 176 x 250 mm"
+
+#: ../src/common/paper.cpp:104
+msgid "B6 Envelope, 176 x 125 mm"
+msgstr "Envelope B6, 176 x 125 mm"
+
+#: ../src/common/paper.cpp:105
+msgid "Italy Envelope, 110 x 230 mm"
+msgstr "Envelope Italiano, 110 x 230 mm"
+
+#: ../src/common/paper.cpp:106
+msgid "Monarch Envelope, 3 7/8 x 7 1/2 in"
+msgstr "Envelope Monarch, 3 7/8 x 7 1/2 pol."
+
+#: ../src/common/paper.cpp:107
+msgid "6 3/4 Envelope, 3 5/8 x 6 1/2 in"
+msgstr "Envelope 6 3/4, 3 5/8 x 6 1/2 pol."
+
+#: ../src/common/paper.cpp:108
+msgid "US Std Fanfold, 14 7/8 x 11 in"
+msgstr "US Std Fanfold, 14 7/8 x 11 pol."
+
+#: ../src/common/paper.cpp:109
+msgid "German Std Fanfold, 8 1/2 x 12 in"
+msgstr "Std Fanfold Alemão, 8 1/2 x 12 pol."
+
+#: ../src/common/paper.cpp:110
+msgid "German Legal Fanfold, 8 1/2 x 13 in"
+msgstr "Legal Fanfold Alemão, 8 1/2 x 13 pol."
+
+#: ../src/common/paper.cpp:112
+msgid "B4 (ISO) 250 x 353 mm"
+msgstr "B4 (ISO) 250 x 353 mm"
+
+#: ../src/common/paper.cpp:113
+msgid "Japanese Postcard 100 x 148 mm"
+msgstr "Postal Japonês 100 x 148 mm"
+
+#: ../src/common/paper.cpp:114
+msgid "9 x 11 in"
+msgstr "9 x 11 pol."
+
+#: ../src/common/paper.cpp:115
+msgid "10 x 11 in"
+msgstr "10 x 11 pol."
+
+#: ../src/common/paper.cpp:116
+msgid "15 x 11 in"
+msgstr "15 x 11 pol."
+
+#: ../src/common/paper.cpp:117
+msgid "Envelope Invite 220 x 220 mm"
+msgstr "Envelope de Convite 220 x 220 mm"
+
+#: ../src/common/paper.cpp:118
+msgid "Letter Extra 9 1/2 x 12 in"
+msgstr "Letter Extra 9 1/2 x 12 pol."
+
+#: ../src/common/paper.cpp:119
+msgid "Legal Extra 9 1/2 x 15 in"
+msgstr "Legal Extra 9 1/2 x 15 pol."
+
+#: ../src/common/paper.cpp:120
+msgid "Tabloid Extra 11.69 x 18 in"
+msgstr "Tabloid Extra 11.69 x 18 pol."
+
+#: ../src/common/paper.cpp:121
+msgid "A4 Extra 9.27 x 12.69 in"
+msgstr "A4 Extra 9.27 x 12.69 pol."
+
+#: ../src/common/paper.cpp:122
+msgid "Letter Transverse 8 1/2 x 11 in"
+msgstr "Letter Transversal 8 1/2 x 11 pol."
+
+#: ../src/common/paper.cpp:123
+msgid "A4 Transverse 210 x 297 mm"
+msgstr "A4 Transverso 210 x 297 mm"
+
+#: ../src/common/paper.cpp:124
+msgid "Letter Extra Transverse 9.275 x 12 in"
+msgstr "Letter Extra Transversal 9.275 x 12 pol."
+
+#: ../src/common/paper.cpp:125
+msgid "SuperA/SuperA/A4 227 x 356 mm"
+msgstr "SuperA/SuperA/A4 227 x 356 mm"
+
+#: ../src/common/paper.cpp:126
+msgid "SuperB/SuperB/A3 305 x 487 mm"
+msgstr "SuperB/SuperB/A3 305 x 487 mm"
+
+#: ../src/common/paper.cpp:127
+msgid "Letter Plus 8 1/2 x 12.69 in"
+msgstr "Letter Plus 8 1/2 x 12.69 pol."
+
+#: ../src/common/paper.cpp:128
+msgid "A4 Plus 210 x 330 mm"
+msgstr "A4+ 210 x 330 mm"
+
+#: ../src/common/paper.cpp:129
+msgid "A5 Transverse 148 x 210 mm"
+msgstr "A5 Transverso 148 x 210 mm"
+
+#: ../src/common/paper.cpp:130
+msgid "B5 (JIS) Transverse 182 x 257 mm"
+msgstr "B5 (JIS) Transverso 182 x 257 mm"
+
+#: ../src/common/paper.cpp:131
+msgid "A3 Extra 322 x 445 mm"
+msgstr "A3 Extra 322 x 445 mm"
+
+#: ../src/common/paper.cpp:132
+msgid "A5 Extra 174 x 235 mm"
+msgstr "A5 Extra 174 x 235 mm"
+
+#: ../src/common/paper.cpp:133
+msgid "B5 (ISO) Extra 201 x 276 mm"
+msgstr "B5 (ISO) Extra 201 x 276 mm"
+
+#: ../src/common/paper.cpp:134
+msgid "A2 420 x 594 mm"
+msgstr "A2 420 x 594 mm"
+
+#: ../src/common/paper.cpp:135
+msgid "A3 Transverse 297 x 420 mm"
+msgstr "A3 Transverso 297 x 420 mm"
+
+#: ../src/common/paper.cpp:136
+msgid "A3 Extra Transverse 322 x 445 mm"
+msgstr "A3 Extra Transverso 322 x 445 mm"
+
+#: ../src/common/paper.cpp:138
+msgid "Japanese Double Postcard 200 x 148 mm"
+msgstr "Postal Duplo Japonês 200 x 148 mm"
+
+#: ../src/common/paper.cpp:139
+msgid "A6 105 x 148 mm"
+msgstr "A6 105 x 148 mm"
+
+#: ../src/common/paper.cpp:140
+msgid "Japanese Envelope Kaku #2"
+msgstr "Envelope Japonês Kaku #2"
+
+#: ../src/common/paper.cpp:141
+msgid "Japanese Envelope Kaku #3"
+msgstr "Envelope Japonês Kaku #3"
+
+#: ../src/common/paper.cpp:142
+msgid "Japanese Envelope Chou #3"
+msgstr "Envelope Japonês Chou #3"
+
+#: ../src/common/paper.cpp:143
+msgid "Japanese Envelope Chou #4"
+msgstr "Envelope Japonês Chou #4"
+
+#: ../src/common/paper.cpp:144
+msgid "Letter Rotated 11 x 8 1/2 in"
+msgstr "Letter Rodada 11 x 8 1/2 pol."
+
+#: ../src/common/paper.cpp:145
+msgid "A3 Rotated 420 x 297 mm"
+msgstr "A3 Rodado 420 x 297 mm"
+
+#: ../src/common/paper.cpp:146
+msgid "A4 Rotated 297 x 210 mm"
+msgstr "A4 Rodado 297 x 210 mm"
+
+#: ../src/common/paper.cpp:147
+msgid "A5 Rotated 210 x 148 mm"
+msgstr "A5 Rodado 210 x 148 mm"
+
+#: ../src/common/paper.cpp:148
+msgid "B4 (JIS) Rotated 364 x 257 mm"
+msgstr "B4 (JIS) Rodado 364 x 257 mm"
+
+#: ../src/common/paper.cpp:149
+msgid "B5 (JIS) Rotated 257 x 182 mm"
+msgstr "B5 (JIS) Rodado 257 x 182 mm"
+
+#: ../src/common/paper.cpp:150
+msgid "Japanese Postcard Rotated 148 x 100 mm"
+msgstr "Postal Japonês Rodado 148 x 100 mm"
+
+#: ../src/common/paper.cpp:151
+msgid "Double Japanese Postcard Rotated 148 x 200 mm"
+msgstr "Postal Japonês Duplo Rodado 148 x 200 mm"
+
+#: ../src/common/paper.cpp:152
+msgid "A6 Rotated 148 x 105 mm"
+msgstr "A6 Rodado 148 x 105 mm"
+
+#: ../src/common/paper.cpp:153
+msgid "Japanese Envelope Kaku #2 Rotated"
+msgstr "Envelope Japonês Kaku #2 Rodado"
+
+#: ../src/common/paper.cpp:154
+msgid "Japanese Envelope Kaku #3 Rotated"
+msgstr "Envelope Japonês Kaku #3 Rodado"
+
+#: ../src/common/paper.cpp:155
+msgid "Japanese Envelope Chou #3 Rotated"
+msgstr "Envelope Japonês Chou #3 Rodado"
+
+#: ../src/common/paper.cpp:156
+msgid "Japanese Envelope Chou #4 Rotated"
+msgstr "Envelope Japonês Chou #4 Rodado"
+
+#: ../src/common/paper.cpp:157
+msgid "B6 (JIS) 128 x 182 mm"
+msgstr "B6 (JIS) 128 x 182 mm"
+
+#: ../src/common/paper.cpp:158
+msgid "B6 (JIS) Rotated 182 x 128 mm"
+msgstr "B6 (JIS) Rodado 182 x 128 mm"
+
+#: ../src/common/paper.cpp:159
+msgid "12 x 11 in"
+msgstr "12 x 11 pol."
+
+#: ../src/common/paper.cpp:160
+msgid "Japanese Envelope You #4"
+msgstr "Envelope Japonês You #4"
+
+#: ../src/common/paper.cpp:161
+msgid "Japanese Envelope You #4 Rotated"
+msgstr "Envelope Japonês You #4 Rodado"
+
+#: ../src/common/paper.cpp:162
+msgid "PRC 16K 146 x 215 mm"
+msgstr "PRC 16K 146 x 215 mm"
+
+#: ../src/common/paper.cpp:163
+msgid "PRC 32K 97 x 151 mm"
+msgstr "PRC 32K 97 x 151 mm"
+
+#: ../src/common/paper.cpp:164
+msgid "PRC 32K(Big) 97 x 151 mm"
+msgstr "PRC 32K(Grande) 97 x 151 mm"
+
+#: ../src/common/paper.cpp:165
+msgid "PRC Envelope #1 102 x 165 mm"
+msgstr "Envelope PRC #1 102 x 165 mm"
+
+#: ../src/common/paper.cpp:166
+msgid "PRC Envelope #2 102 x 176 mm"
+msgstr "Envelope PRC #2 102 x 176 mm"
+
+#: ../src/common/paper.cpp:167
+msgid "PRC Envelope #3 125 x 176 mm"
+msgstr "Envelope PRC #3 125 x 176 mm"
+
+#: ../src/common/paper.cpp:168
+msgid "PRC Envelope #4 110 x 208 mm"
+msgstr "Envelope PRC #4 110 x 208 mm"
+
+#: ../src/common/paper.cpp:169
+msgid "PRC Envelope #5 110 x 220 mm"
+msgstr "Envelope PRC #5 110 x 220 mm"
+
+#: ../src/common/paper.cpp:170
+msgid "PRC Envelope #6 120 x 230 mm"
+msgstr "Envelope PRC #6 120 x 230 mm"
+
+#: ../src/common/paper.cpp:171
+msgid "PRC Envelope #7 160 x 230 mm"
+msgstr "Envelope PRC #7 160 x 230 mm"
+
+#: ../src/common/paper.cpp:172
+msgid "PRC Envelope #8 120 x 309 mm"
+msgstr "Envelope PRC #8 120 x 309 mm"
+
+#: ../src/common/paper.cpp:173
+msgid "PRC Envelope #9 229 x 324 mm"
+msgstr "Envelope PRC #9 229 x 324 mm"
+
+#: ../src/common/paper.cpp:174
+msgid "PRC Envelope #10 324 x 458 mm"
+msgstr "Envelope PRC #10 324 x 458 mm"
+
+#: ../src/common/paper.cpp:175
+msgid "PRC 16K Rotated"
+msgstr "PRC 16K Rodado"
+
+#: ../src/common/paper.cpp:176
+msgid "PRC 32K Rotated"
+msgstr "PRC 32K Rodado"
+
+#: ../src/common/paper.cpp:177
+msgid "PRC 32K(Big) Rotated"
+msgstr "PRC 32K(Grande) Rodado"
+
+#: ../src/common/paper.cpp:178
+msgid "PRC Envelope #1 Rotated 165 x 102 mm"
+msgstr "Envelope PRC #1 Rodado 165 x 102 mm"
+
+#: ../src/common/paper.cpp:179
+msgid "PRC Envelope #2 Rotated 176 x 102 mm"
+msgstr "Envelope PRC #2 Rodado 176 x 102 mm"
+
+#: ../src/common/paper.cpp:180
+msgid "PRC Envelope #3 Rotated 176 x 125 mm"
+msgstr "Envelope PRC #3 Rodado 176 x 125 mm"
+
+#: ../src/common/paper.cpp:181
+msgid "PRC Envelope #4 Rotated 208 x 110 mm"
+msgstr "Envelope PRC #4 Rodado 208 x 110 mm"
+
+#: ../src/common/paper.cpp:182
+msgid "PRC Envelope #5 Rotated 220 x 110 mm"
+msgstr "Envelope PRC #5 Rodado 220 x 110 mm"
+
+#: ../src/common/paper.cpp:183
+msgid "PRC Envelope #6 Rotated 230 x 120 mm"
+msgstr "Envelope PRC #6 Rodado 230 x 120 mm"
+
+#: ../src/common/paper.cpp:184
+msgid "PRC Envelope #7 Rotated 230 x 160 mm"
+msgstr "Envelope PRC #7 Rodado 230 x 160 mm"
+
+#: ../src/common/paper.cpp:185
+msgid "PRC Envelope #8 Rotated 309 x 120 mm"
+msgstr "Envelope PRC #8 Rodado 309 x 120 mm"
+
+#: ../src/common/paper.cpp:186
+msgid "PRC Envelope #9 Rotated 324 x 229 mm"
+msgstr "Envelope PRC #9 Rodado 324 x 229 mm"
+
+#: ../src/common/paper.cpp:187
+msgid "PRC Envelope #10 Rotated 458 x 324 mm"
+msgstr "Envelope PRC #10 Rodado 458 x 324 mm"
+
+#: ../src/common/paper.cpp:192
+msgid "A0 sheet, 841 x 1189 mm"
+msgstr "Folha A0, 841 x 1189 mm"
+
+#: ../src/common/paper.cpp:193
+msgid "A1 sheet, 594 x 841 mm"
+msgstr "Folha A1, 594 x 841 mm"
+
+#: ../src/common/preferencescmn.cpp:37
+msgid "General"
+msgstr "Geral"
+
+#: ../src/common/preferencescmn.cpp:40
+msgid "Advanced"
+msgstr "Avançado"
+
+#: ../src/common/prntbase.cpp:245
+msgid "Generic PostScript"
+msgstr "PostScript Genérico"
+
+#: ../src/common/prntbase.cpp:259
+msgid "Ready"
+msgstr "Preparado"
+
+#: ../src/common/prntbase.cpp:331
+msgid "Printing Error"
+msgstr "Erro de Impressão"
+
+#: ../src/common/prntbase.cpp:413 ../src/common/prntbase.cpp:1597
+#: ../src/generic/prntdlgg.cpp:135 ../src/generic/prntdlgg.cpp:149
+#: ../src/gtk/print.cpp:628 ../src/gtk/print.cpp:646
+msgid "Print"
+msgstr "Imprimir"
+
+#: ../src/common/prntbase.cpp:471 ../src/generic/prntdlgg.cpp:809
+msgid "Page setup"
+msgstr "Configuração de página"
+
+#: ../src/common/prntbase.cpp:525
+#, fuzzy
+msgid "Please wait while printing..."
+msgstr "Por favor aguarde enquanto imprime\n"
+
+#: ../src/common/prntbase.cpp:529
+#, fuzzy
+msgid "Document:"
+msgstr "Documentado por "
+
+#: ../src/common/prntbase.cpp:532
+msgid "Progress:"
+msgstr "Progresso:"
+
+#: ../src/common/prntbase.cpp:533
+msgid "Preparing"
+msgstr "A preparar"
+
+#: ../src/common/prntbase.cpp:552
+#, fuzzy, c-format
+msgid "Printing page %d"
+msgstr "A imprimir a página %d ..."
+
+#: ../src/common/prntbase.cpp:557
+#, c-format
+msgid "Printing page %d of %d"
+msgstr "A imprimir página %d de %d ..."
+
+#: ../src/common/prntbase.cpp:560
+#, c-format
+msgid " (copy %d of %d)"
+msgstr " (cópia %d de %d)"
+
+#: ../src/common/prntbase.cpp:1604
+msgid "First page"
+msgstr "Primeira Página"
+
+#: ../src/common/prntbase.cpp:1609 ../src/html/helpwnd.cpp:659
+msgid "Previous page"
+msgstr "Página anterior"
+
+#: ../src/common/prntbase.cpp:1623 ../src/html/helpwnd.cpp:660
+msgid "Next page"
+msgstr "Página seguinte"
+
+#: ../src/common/prntbase.cpp:1628
+#, fuzzy
+msgid "Last page"
+msgstr "Página seguinte"
+
+#: ../src/common/prntbase.cpp:1636 ../src/common/stockitem.cpp:215
+#, fuzzy
+msgid "Zoom Out"
+msgstr "Red&uzir"
+
+#: ../src/common/prntbase.cpp:1650 ../src/common/stockitem.cpp:214
+#, fuzzy
+msgid "Zoom In"
+msgstr "Ampl&iar"
+
+#: ../src/common/prntbase.cpp:1656 ../src/common/stockitem.cpp:153
+#: ../src/generic/logg.cpp:553 ../src/univ/themes/win32.cpp:3752
+msgid "&Close"
+msgstr "&Fechar"
+
+#: ../src/common/prntbase.cpp:2085
+msgid "Could not start document preview."
+msgstr "Não foi possível iniciar antevisão do documento."
+
+#: ../src/common/prntbase.cpp:2085 ../src/common/prntbase.cpp:2129
+#: ../src/common/prntbase.cpp:2137
+msgid "Print Preview Failure"
+msgstr "Falha na Pré-visualização da Impressão"
+
+#: ../src/common/prntbase.cpp:2129 ../src/common/prntbase.cpp:2137
+msgid "Sorry, not enough memory to create a preview."
+msgstr "Lamento, não existe memória suficiente para criar a antevisão."
+
+#: ../src/common/prntbase.cpp:2144
+#, c-format
+msgid "Page %d of %d"
+msgstr "Página %d de %d"
+
+#: ../src/common/prntbase.cpp:2146
+#, c-format
+msgid "Page %d"
+msgstr "Página %d"
+
+#: ../src/common/regex.cpp:382 ../src/html/chm.cpp:348
+msgid "unknown error"
+msgstr "erro desconhecido"
+
+#: ../src/common/regex.cpp:995
+#, c-format
+msgid "Invalid regular expression '%s': %s"
+msgstr "Expressão regular inválida '%s': %s"
+
+#: ../src/common/regex.cpp:1059
+#, c-format
+msgid "Failed to find match for regular expression: %s"
+msgstr "Falha a encontrar resultados na procura por expressão regular: %s"
+
+#: ../src/common/rendcmn.cpp:188
+#, c-format
+msgid "Renderer \"%s\" has incompatible version %d.%d and couldn't be loaded."
+msgstr ""
+"Renderizador \"%s\" tem uma versão incompatível %d.%d e não pode ser "
+"carregado."
+
+#: ../src/common/secretstore.cpp:162
+msgid "Not available for this platform"
+msgstr ""
+
+#: ../src/common/secretstore.cpp:183
+#, fuzzy, c-format
+msgid "Saving password for \"%s\" failed: %s."
+msgstr "Falhou a extracção de '%s' para '%s'."
+
+#: ../src/common/secretstore.cpp:205
+#, fuzzy, c-format
+msgid "Reading password for \"%s\" failed: %s."
+msgstr "Falhou a extracção de '%s' para '%s'."
+
+#: ../src/common/secretstore.cpp:228
+#, fuzzy, c-format
+msgid "Deleting password for \"%s\" failed: %s."
+msgstr "Falhou a extracção de '%s' para '%s'."
+
+#: ../src/common/selectdispatcher.cpp:254
+msgid "Failed to monitor I/O channels"
+msgstr ""
+
+#: ../src/common/sizer.cpp:3054 ../src/common/stockitem.cpp:195
+msgid "Save"
+msgstr "Gravar"
+
+#: ../src/common/sizer.cpp:3056
+msgid "Don't Save"
+msgstr "Não Gravar"
+
+#: ../src/common/socket.cpp:870
+#, fuzzy
+msgid "Cannot initialize sockets"
+msgstr "Não foi possível inicializar o OLE"
+
+#: ../src/common/stockitem.cpp:127
+#, fuzzy
+msgctxt "standard Windows menu"
+msgid "&Help"
+msgstr "&Ajuda"
+
+#: ../src/common/stockitem.cpp:144
+msgid "&About"
+msgstr "&Sobre"
+
+#: ../src/common/stockitem.cpp:144
+msgid "About"
+msgstr "&Sobre o ..."
+
+#: ../src/common/stockitem.cpp:145
+msgid "Add"
+msgstr "Adicionar"
+
+#: ../src/common/stockitem.cpp:146
+msgid "&Apply"
+msgstr "&Aplicar"
+
+#: ../src/common/stockitem.cpp:146
+msgid "Apply"
+msgstr "Aplicar"
+
+#: ../src/common/stockitem.cpp:147
+msgid "&Back"
+msgstr "&Retroceder"
+
+#: ../src/common/stockitem.cpp:147
+msgid "Back"
+msgstr "Voltar"
+
+#: ../src/common/stockitem.cpp:148
+msgid "&Bold"
+msgstr "&Negrito"
+
+#: ../src/common/stockitem.cpp:148 ../src/generic/fontdlgg.cpp:326
+#: ../src/richtext/richtextfontpage.cpp:354
+msgid "Bold"
+msgstr "Negrito"
+
+#: ../src/common/stockitem.cpp:149
+msgid "&Bottom"
+msgstr "&Base"
+
+#: ../src/common/stockitem.cpp:149 ../src/richtext/richtextsizepage.cpp:287
+msgid "Bottom"
+msgstr "Base"
+
+#: ../src/common/stockitem.cpp:150 ../src/generic/fontdlgg.cpp:462
+#: ../src/generic/fontdlgg.cpp:481 ../src/generic/wizard.cpp:415
+msgid "&Cancel"
+msgstr "&Cancelar"
+
+#: ../src/common/stockitem.cpp:151
+#, fuzzy
+msgid "&CD-ROM"
+msgstr "&CD-Rom"
+
+#: ../src/common/stockitem.cpp:151
+#, fuzzy
+msgid "CD-ROM"
+msgstr "CD-Rom"
+
+#: ../src/common/stockitem.cpp:152
+msgid "&Clear"
+msgstr "&Limpar"
+
+#: ../src/common/stockitem.cpp:152
+msgid "Clear"
+msgstr "Limpar"
+
+#: ../src/common/stockitem.cpp:153 ../src/generic/dbgrptg.cpp:93
+#: ../src/generic/progdlgg.cpp:778 ../src/html/helpdlg.cpp:86
+#: ../src/msw/progdlg.cpp:209 ../src/msw/progdlg.cpp:890
+#: ../src/richtext/richtextstyledlg.cpp:272
+#: ../src/richtext/richtextsymboldlg.cpp:448
+msgid "Close"
+msgstr "Fechar"
+
+#: ../src/common/stockitem.cpp:154
+msgid "&Convert"
+msgstr "&Converter"
+
+#: ../src/common/stockitem.cpp:154
+msgid "Convert"
+msgstr "Converter"
+
+#: ../src/common/stockitem.cpp:155 ../src/msw/textctrl.cpp:2884
+#: ../src/osx/textctrl_osx.cpp:653 ../src/richtext/richtextctrl.cpp:331
+msgid "&Copy"
+msgstr "&Copiar"
+
+#: ../src/common/stockitem.cpp:155 ../src/stc/stc_i18n.cpp:18
+msgid "Copy"
+msgstr "Copiar"
+
+#: ../src/common/stockitem.cpp:156 ../src/msw/textctrl.cpp:2883
+#: ../src/osx/textctrl_osx.cpp:652 ../src/richtext/richtextctrl.cpp:330
+msgid "Cu&t"
+msgstr "Cor&tar"
+
+#: ../src/common/stockitem.cpp:156 ../src/stc/stc_i18n.cpp:17
+msgid "Cut"
+msgstr "Cortar"
+
+#: ../src/common/stockitem.cpp:157 ../src/msw/textctrl.cpp:2886
+#: ../src/osx/textctrl_osx.cpp:655 ../src/richtext/richtextctrl.cpp:333
+#: ../src/richtext/richtexttabspage.cpp:137
+msgid "&Delete"
+msgstr "&Apagar"
+
+#: ../src/common/stockitem.cpp:157 ../src/richtext/richtextbuffer.cpp:8266
+#: ../src/stc/stc_i18n.cpp:20
+msgid "Delete"
+msgstr "Apagar"
+
+#: ../src/common/stockitem.cpp:158
+msgid "&Down"
+msgstr "&Baixo"
+
+#: ../src/common/stockitem.cpp:158 ../src/generic/fdrepdlg.cpp:148
+msgid "Down"
+msgstr "Baixo"
+
+#: ../src/common/stockitem.cpp:159
+msgid "&Edit"
+msgstr "&Editar"
+
+#: ../src/common/stockitem.cpp:159
+msgid "Edit"
+msgstr "Editar"
+
+#: ../src/common/stockitem.cpp:160
+msgid "&Execute"
+msgstr "&Executar"
+
+#: ../src/common/stockitem.cpp:160
+msgid "Execute"
+msgstr "Executar"
+
+#: ../src/common/stockitem.cpp:161
+msgid "&Quit"
+msgstr "&Desistir"
+
+#: ../src/common/stockitem.cpp:161
+#, fuzzy
+msgid "Quit"
+msgstr "&Desistir"
+
+#: ../src/common/stockitem.cpp:162
+msgid "&File"
+msgstr "&Ficheiro"
+
+#: ../src/common/stockitem.cpp:162
+msgid "File"
+msgstr "Ficheiro"
+
+#: ../src/common/stockitem.cpp:163
+#, fuzzy
+msgid "&Find..."
+msgstr "&Procurar"
+
+#: ../src/common/stockitem.cpp:163
+#, fuzzy
+msgid "Find..."
+msgstr "Procurar"
+
+#: ../src/common/stockitem.cpp:164
+msgid "&First"
+msgstr "&Primeiro"
+
+#: ../src/common/stockitem.cpp:164
+msgid "First"
+msgstr "Primeiro"
+
+#: ../src/common/stockitem.cpp:165
+msgid "&Floppy"
+msgstr "&Disquete"
+
+#: ../src/common/stockitem.cpp:165
+msgid "Floppy"
+msgstr "Disquete"
+
+#: ../src/common/stockitem.cpp:166
+msgid "&Forward"
+msgstr "&Avançar"
+
+#: ../src/common/stockitem.cpp:166
+msgid "Forward"
+msgstr "Avançar"
+
+#: ../src/common/stockitem.cpp:167
+msgid "&Harddisk"
+msgstr "Disco &Rígido"
+
+#: ../src/common/stockitem.cpp:167
+msgid "Harddisk"
+msgstr "Disco Rígido"
+
+#: ../src/common/stockitem.cpp:168 ../src/generic/wizard.cpp:418
+#: ../src/osx/cocoa/menu.mm:225 ../src/richtext/richtextstyledlg.cpp:298
+#: ../src/richtext/richtextsymboldlg.cpp:451
+msgid "&Help"
+msgstr "&Ajuda"
+
+#: ../src/common/stockitem.cpp:169
+msgid "&Home"
+msgstr "&Início"
+
+#: ../src/common/stockitem.cpp:169
+msgid "Home"
+msgstr "Pasta Pessoal"
+
+#: ../src/common/stockitem.cpp:170
+msgid "Indent"
+msgstr "Indentar"
+
+#: ../src/common/stockitem.cpp:171
+msgid "&Index"
+msgstr "&Índice"
+
+#: ../src/common/stockitem.cpp:171 ../src/html/helpwnd.cpp:510
+msgid "Index"
+msgstr "Índice"
+
+#: ../src/common/stockitem.cpp:172
+msgid "&Info"
+msgstr "&Informação"
+
+#: ../src/common/stockitem.cpp:172
+msgid "Info"
+msgstr "Informação"
+
+#: ../src/common/stockitem.cpp:173
+msgid "&Italic"
+msgstr "&Itálico"
+
+#: ../src/common/stockitem.cpp:173 ../src/generic/fontdlgg.cpp:322
+#: ../src/richtext/richtextfontpage.cpp:350
+msgid "Italic"
+msgstr "Itálico"
+
+#: ../src/common/stockitem.cpp:174
+msgid "&Jump to"
+msgstr "&Ir para"
+
+#: ../src/common/stockitem.cpp:174
+msgid "Jump to"
+msgstr "Ir para"
+
+#: ../src/common/stockitem.cpp:175
+msgid "Centered"
+msgstr "Centrado"
+
+#: ../src/common/stockitem.cpp:176
+msgid "Justified"
+msgstr "Justificado"
+
+#: ../src/common/stockitem.cpp:177
+msgid "Align Left"
+msgstr "Alinhar à Esquerda"
+
+#: ../src/common/stockitem.cpp:178
+msgid "Align Right"
+msgstr "Alinhar à Direita"
+
+#: ../src/common/stockitem.cpp:179
+msgid "&Last"
+msgstr "&Último"
+
+#: ../src/common/stockitem.cpp:179
+#, fuzzy
+msgid "Last"
+msgstr "Colar"
+
+#: ../src/common/stockitem.cpp:180
+msgid "&Network"
+msgstr "&Rede"
+
+#: ../src/common/stockitem.cpp:180
+msgid "Network"
+msgstr "Rede"
+
+#: ../src/common/stockitem.cpp:181 ../src/richtext/richtexttabspage.cpp:131
+msgid "&New"
+msgstr "&Novo"
+
+#: ../src/common/stockitem.cpp:181
+msgid "New"
+msgstr "Novo"
+
+#: ../src/common/stockitem.cpp:182 ../src/msw/msgdlg.cpp:417
+msgid "&No"
+msgstr "&Não"
+
+#: ../src/common/stockitem.cpp:183 ../src/generic/fontdlgg.cpp:467
+#: ../src/generic/fontdlgg.cpp:474
+msgid "&OK"
+msgstr "&OK"
+
+#: ../src/common/stockitem.cpp:184 ../src/generic/dbgrptg.cpp:341
+msgid "&Open..."
+msgstr "&Abrir..."
+
+#: ../src/common/stockitem.cpp:184
+#, fuzzy
+msgid "Open..."
+msgstr "&Abrir ..."
+
+#: ../src/common/stockitem.cpp:185 ../src/msw/textctrl.cpp:2885
+#: ../src/osx/textctrl_osx.cpp:654 ../src/richtext/richtextctrl.cpp:332
+msgid "&Paste"
+msgstr "&Colar"
+
+#: ../src/common/stockitem.cpp:185 ../src/richtext/richtextctrl.cpp:3484
+#: ../src/stc/stc_i18n.cpp:19
+msgid "Paste"
+msgstr "Colar"
+
+#: ../src/common/stockitem.cpp:186
+msgid "&Preferences"
+msgstr "&Preferências"
+
+#: ../src/common/stockitem.cpp:186 ../src/osx/cocoa/preferences.mm:304
+#, fuzzy
+msgid "Preferences"
+msgstr "&Preferências"
+
+#: ../src/common/stockitem.cpp:187
+msgid "Print previe&w..."
+msgstr "&Pré-visualizar Impressão ..."
+
+#: ../src/common/stockitem.cpp:187
+msgid "Print preview..."
+msgstr "Pré-visualizar impressão ..."
+
+#: ../src/common/stockitem.cpp:188
+msgid "&Print..."
+msgstr "&Imprimir..."
+
+#: ../src/common/stockitem.cpp:188
+msgid "Print..."
+msgstr "&Imprimir ..."
+
+#: ../src/common/stockitem.cpp:189 ../src/richtext/richtextctrl.cpp:337
+#: ../src/richtext/richtextctrl.cpp:5479
+msgid "&Properties"
+msgstr "&Propriedades"
+
+#: ../src/common/stockitem.cpp:189
+#, fuzzy
+msgid "Properties"
+msgstr "&Propriedades"
+
+#: ../src/common/stockitem.cpp:190 ../src/stc/stc_i18n.cpp:16
+#, fuzzy
+msgid "Redo"
+msgstr "&Refazer"
+
+#: ../src/common/stockitem.cpp:191
+msgid "Refresh"
+msgstr "Refrescar"
+
+#: ../src/common/stockitem.cpp:192
+msgid "Remove"
+msgstr "Remover"
+
+#: ../src/common/stockitem.cpp:193
+#, fuzzy
+msgid "Rep&lace..."
+msgstr "Su&bstituir"
+
+#: ../src/common/stockitem.cpp:193
+#, fuzzy
+msgid "Replace..."
+msgstr "Substituir"
+
+#: ../src/common/stockitem.cpp:194
+msgid "Revert to Saved"
+msgstr "Reverter para o Gravado"
+
+#: ../src/common/stockitem.cpp:196 ../src/generic/logg.cpp:549
+msgid "Save &As..."
+msgstr "Gravar &Como..."
+
+#: ../src/common/stockitem.cpp:196
+#, fuzzy
+msgid "Save As..."
+msgstr "Gravar &Como..."
+
+#: ../src/common/stockitem.cpp:197 ../src/msw/textctrl.cpp:2888
+#: ../src/osx/textctrl_osx.cpp:657 ../src/richtext/richtextctrl.cpp:335
+msgid "Select &All"
+msgstr "Selecion&ar Todos"
+
+#: ../src/common/stockitem.cpp:197 ../src/stc/stc_i18n.cpp:21
+#, fuzzy
+msgid "Select All"
+msgstr "Selecion&ar Todos"
+
+#: ../src/common/stockitem.cpp:198
+#, fuzzy
+msgid "&Color"
+msgstr "&Cor:"
+
+#: ../src/common/stockitem.cpp:198
+msgid "Color"
+msgstr "Cor"
+
+#: ../src/common/stockitem.cpp:199
+msgid "&Font"
+msgstr "&Tipo de letra:"
+
+#: ../src/common/stockitem.cpp:199 ../src/richtext/richtextformatdlg.cpp:336
+msgid "Font"
+msgstr "Fonte"
+
+#: ../src/common/stockitem.cpp:200
+msgid "&Ascending"
+msgstr "&Ascendente"
+
+#: ../src/common/stockitem.cpp:200
+msgid "Ascending"
+msgstr "Ascendente"
+
+#: ../src/common/stockitem.cpp:201
+msgid "&Descending"
+msgstr "&Descendente"
+
+#: ../src/common/stockitem.cpp:201
+msgid "Descending"
+msgstr "Descendente"
+
+#: ../src/common/stockitem.cpp:202
+msgid "&Spell Check"
+msgstr "Corretor &Ortográfico"
+
+#: ../src/common/stockitem.cpp:202
+msgid "Spell Check"
+msgstr "Corretor Ortográfico"
+
+#: ../src/common/stockitem.cpp:203
+msgid "&Stop"
+msgstr "&Parar"
+
+#: ../src/common/stockitem.cpp:203
+#, fuzzy
+msgid "Stop"
+msgstr "&Parar"
+
+#: ../src/common/stockitem.cpp:204 ../src/richtext/richtextfontpage.cpp:274
+msgid "&Strikethrough"
+msgstr "&Rasurado"
+
+#: ../src/common/stockitem.cpp:204
+msgid "Strikethrough"
+msgstr "Rasurado"
+
+#: ../src/common/stockitem.cpp:205
+msgid "&Top"
+msgstr "&Topo"
+
+#: ../src/common/stockitem.cpp:205 ../src/richtext/richtextsizepage.cpp:285
+#: ../src/richtext/richtextsizepage.cpp:289
+#, fuzzy
+msgid "Top"
+msgstr "Para:"
+
+#: ../src/common/stockitem.cpp:206
+msgid "Undelete"
+msgstr "Recuperar"
+
+#: ../src/common/stockitem.cpp:207 ../src/generic/fontdlgg.cpp:437
+msgid "&Underline"
+msgstr "S&ublinhado"
+
+#: ../src/common/stockitem.cpp:207
+#, fuzzy
+msgid "Underline"
+msgstr "S&ublinhado"
+
+#: ../src/common/stockitem.cpp:208 ../src/stc/stc_i18n.cpp:15
+#, fuzzy
+msgid "Undo"
+msgstr "&Desfazer"
+
+#: ../src/common/stockitem.cpp:209
+msgid "&Unindent"
+msgstr "&Desindentar"
+
+#: ../src/common/stockitem.cpp:209
+#, fuzzy
+msgid "Unindent"
+msgstr "&Desindentar"
+
+#: ../src/common/stockitem.cpp:210
+msgid "&Up"
+msgstr "&Cima"
+
+#: ../src/common/stockitem.cpp:210 ../src/generic/fdrepdlg.cpp:148
+msgid "Up"
+msgstr "Cima"
+
+#: ../src/common/stockitem.cpp:211 ../src/msw/msgdlg.cpp:417
+msgid "&Yes"
+msgstr "&Sim"
+
+#: ../src/common/stockitem.cpp:212
+msgid "&Actual Size"
+msgstr "T&amanho Atual"
+
+#: ../src/common/stockitem.cpp:212
+msgid "Actual Size"
+msgstr "T&amanho Atual"
+
+#: ../src/common/stockitem.cpp:213
+msgid "Zoom to &Fit"
+msgstr "Ampliar para &Caber"
+
+#: ../src/common/stockitem.cpp:213
+#, fuzzy
+msgid "Zoom to Fit"
+msgstr "Ampliar para &Caber"
+
+#: ../src/common/stockitem.cpp:214
+msgid "Zoom &In"
+msgstr "Ampl&iar"
+
+#: ../src/common/stockitem.cpp:215
+msgid "Zoom &Out"
+msgstr "Red&uzir"
+
+#: ../src/common/stockitem.cpp:262
+msgid "Show about dialog"
+msgstr "Mostrar janela sobre"
+
+#: ../src/common/stockitem.cpp:263
+msgid "Copy selection"
+msgstr "Copiar selecção"
+
+#: ../src/common/stockitem.cpp:264
+msgid "Cut selection"
+msgstr "Cortar selecção"
+
+#: ../src/common/stockitem.cpp:265
+msgid "Delete selection"
+msgstr "Apagar selecção"
+
+#: ../src/common/stockitem.cpp:266
+#, fuzzy
+msgid "Find in document"
+msgstr "Abrir documento HTML"
+
+#: ../src/common/stockitem.cpp:267
+msgid "Find and replace in document"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:268
+msgid "Paste selection"
+msgstr "Colar selecção"
+
+#: ../src/common/stockitem.cpp:269
+msgid "Quit this program"
+msgstr "Terminar deste programa"
+
+#: ../src/common/stockitem.cpp:270
+msgid "Redo last action"
+msgstr "Refazer última acção"
+
+#: ../src/common/stockitem.cpp:271
+msgid "Undo last action"
+msgstr "Desfazer última acção"
+
+#: ../src/common/stockitem.cpp:272
+#, fuzzy
+msgid "Create new document"
+msgstr "Criar novo directório"
+
+#: ../src/common/stockitem.cpp:273
+#, fuzzy
+msgid "Open an existing document"
+msgstr "Abrir documento HTML"
+
+#: ../src/common/stockitem.cpp:274
+msgid "Close current document"
+msgstr "Fechar documento atual"
+
+#: ../src/common/stockitem.cpp:275
+msgid "Save current document"
+msgstr "Gravar documento atual"
+
+#: ../src/common/stockitem.cpp:276
+msgid "Save current document with a different filename"
+msgstr "Gravar documento atual com nome diferente"
+
+#: ../src/common/strconv.cpp:2324
+#, c-format
+msgid "Conversion to charset '%s' doesn't work."
+msgstr "Conversão código de caracteres '%s' não funciona."
+
+#: ../src/common/tarstrm.cpp:352 ../src/common/tarstrm.cpp:375
+#: ../src/common/tarstrm.cpp:406 ../src/generic/progdlgg.cpp:373
+msgid "unknown"
+msgstr "desconhecido"
+
+#: ../src/common/tarstrm.cpp:774
+msgid "incomplete header block in tar"
+msgstr "bloco de cabeçalho incompleto no tar"
+
+#: ../src/common/tarstrm.cpp:798
+msgid "checksum failure reading tar header block"
+msgstr "falha de checksum a ler bloco de cabeçalho tar"
+
+#: ../src/common/tarstrm.cpp:971
+msgid "invalid data in extended tar header"
+msgstr "dados inválidos no cabeçalho tar estendido"
+
+#: ../src/common/tarstrm.cpp:981 ../src/common/tarstrm.cpp:1003
+#: ../src/common/tarstrm.cpp:1477 ../src/common/tarstrm.cpp:1499
+msgid "tar entry not open"
+msgstr "entrada tar não aberta"
+
+#: ../src/common/tarstrm.cpp:1023
+msgid "unexpected end of file"
+msgstr "fim de ficheiro inesperado"
+
+#: ../src/common/tarstrm.cpp:1297
+#, c-format
+msgid "%s did not fit the tar header for entry '%s'"
+msgstr "%s não coube no cabeçalho tar para a entrada '%s'"
+
+#: ../src/common/tarstrm.cpp:1359
+msgid "incorrect size given for tar entry"
+msgstr "tamanho incorrecto dado a entrada do tar"
+
+#: ../src/common/textbuf.cpp:232
+#, c-format
+msgid "'%s' is probably a binary buffer."
+msgstr "'%s' é capaz de ser um buffer binário."
+
+#: ../src/common/textcmn.cpp:1006 ../src/richtext/richtextctrl.cpp:3053
+msgid "File couldn't be loaded."
+msgstr "Não foi possível carregar o ficheiro."
+
+#: ../src/common/textfile.cpp:95
+#, fuzzy, c-format
+msgid "Failed to read text file \"%s\"."
+msgstr "Falha na leitura de metafile do ficheiro \"%s\"."
+
+#: ../src/common/textfile.cpp:160
+#, c-format
+msgid "can't write buffer '%s' to disk."
+msgstr "Não foi possível escrever o buffer '%s' para o disco."
+
+#: ../src/common/time.cpp:212
+msgid "Failed to get the local system time"
+msgstr "Falha na obtenção da hora local do sistema"
+
+#: ../src/common/time.cpp:279
+msgid "wxGetTimeOfDay failed."
+msgstr "falhou o wxGetTimeOfDay."
+
+#: ../src/common/translation.cpp:929
+#, c-format
+msgid "'%s' is not a valid message catalog."
+msgstr "'%s' não é uma mensagem válida do catálogo."
+
+#: ../src/common/translation.cpp:954
+#, fuzzy
+msgid "Invalid message catalog."
+msgstr "'%s' não é uma mensagem válida do catálogo."
+
+#: ../src/common/translation.cpp:1013
+#, fuzzy, c-format
+msgid "Failed to parse Plural-Forms: '%s'"
+msgstr "Não foi possível analisar gramaticalmente Plural-Forms: '%s'"
+
+#: ../src/common/translation.cpp:1723
+#, c-format
+msgid "using catalog '%s' from '%s'."
+msgstr "a utilizar catálogo '%s' de '%s'."
+
+#: ../src/common/translation.cpp:1816
+#, fuzzy, c-format
+msgid "Resource '%s' is not a valid message catalog."
+msgstr "'%s' não é uma mensagem válida do catálogo."
+
+#: ../src/common/translation.cpp:1865
+#, fuzzy
+msgid "Couldn't enumerate translations"
+msgstr "Não foi possível terminar a thread"
+
+#: ../src/common/utilscmn.cpp:1145
+msgid "No default application configured for HTML files."
+msgstr ""
+
+#: ../src/common/utilscmn.cpp:1190
+#, fuzzy, c-format
+msgid "Failed to open URL \"%s\" in default browser."
+msgstr "Falha ao abrir '%s' para %s"
+
+#: ../src/common/valtext.cpp:144
+msgid "Validation conflict"
+msgstr "Conflito de validação"
+
+#: ../src/common/valtext.cpp:186
+msgid "Required information entry is empty."
+msgstr "A entrada da informação necessária está em branco."
+
+#: ../src/common/valtext.cpp:188
+#, fuzzy, c-format
+msgid "'%s' is one of the invalid strings"
+msgstr "'%s' é inválido"
+
+#: ../src/common/valtext.cpp:190
+#, fuzzy, c-format
+msgid "'%s' is not one of the valid strings"
+msgstr "'%s' não é uma mensagem válida do catálogo."
+
+#: ../src/common/valtext.cpp:199
+#, fuzzy, c-format
+msgid "'%s' contains invalid character(s)"
+msgstr "'%s' deve apenas conter caracteres alfabéticos."
+
+#: ../src/common/webrequest.cpp:139
+#, fuzzy, c-format
+msgid "Error: %s (%d)"
+msgstr "Erro: "
+
+#: ../src/common/webrequest.cpp:655
+#, c-format
+msgid ""
+"Not enough free disk space for download: %llu needed but only %llu available."
+msgstr ""
+
+#: ../src/common/webrequest.cpp:669
+#, fuzzy, c-format
+msgid "Failed to create temporary file in %s"
+msgstr "Falha a criar nome de ficheiro temporário"
+
+#: ../src/common/webrequest_curl.cpp:1106
+#, fuzzy
+msgid "libcurl could not be initialized"
+msgstr "Não foi possível carregar o ficheiro."
+
+#: ../src/common/webview.cpp:392
+#, fuzzy
+msgid "RunScriptAsync not supported"
+msgstr "Não são suportadas conversões de cadeias de caracteres"
+
+#: ../src/common/webview.cpp:403 ../src/msw/webview_ie.cpp:1073
+#, c-format
+msgid "Error running JavaScript: %s"
+msgstr ""
+
+#: ../src/common/webview_chromium.cpp:858
+#, fuzzy, c-format
+msgid "Failed to set proxy \"%s\": %s"
+msgstr "Falha de criação de directório \"%s\""
+
+#: ../src/common/webview_chromium.cpp:989
+msgid ""
+"Chromium can't be used because libcef.so wasn't loaded early enough; please "
+"relink the application or use LD_PRELOAD to load it earlier."
+msgstr ""
+
+#: ../src/common/webview_chromium.cpp:1108
+#, fuzzy
+msgid "Could not initialize Chromium"
+msgstr "Não foi possível inicia a impressão."
+
+#: ../src/common/webview_chromium.cpp:1616
+msgid "Show DevTools"
+msgstr ""
+
+#: ../src/common/webview_chromium.cpp:1617
+#, fuzzy
+msgid "Close DevTools"
+msgstr "Fechar Tudo"
+
+#: ../src/common/webview_chromium.cpp:1623
+msgid "Inspect"
+msgstr ""
+
+#: ../src/common/wincmn.cpp:1628
+msgid "This platform does not support background transparency."
+msgstr ""
+
+#: ../src/common/wincmn.cpp:2097
+msgid "Could not transfer data to window"
+msgstr "Não foi possível transferir dados para a janela"
+
+#: ../src/common/windowid.cpp:240
+msgid "Out of window IDs.  Recommend shutting down application."
+msgstr ""
+
+#: ../src/common/xpmdecod.cpp:678
+msgid "XPM: incorrect header format!"
+msgstr "XPM: formato de cabeçalho incorrecto!"
+
+#: ../src/common/xpmdecod.cpp:703
+#, c-format
+msgid "XPM: incorrect colour description in line %d"
+msgstr "XPM: descrição incorrecta de cor na linha %d"
+
+#: ../src/common/xpmdecod.cpp:715 ../src/common/xpmdecod.cpp:724
+#, c-format
+msgid "XPM: malformed colour definition '%s' at line %d!"
+msgstr "XPM: definição de cor '%s' mal formada na linha %d!"
+
+#: ../src/common/xpmdecod.cpp:754
+#, fuzzy
+msgid "XPM: no colors left to use for mask!"
+msgstr "XPM: formato de cabeçalho incorrecto!"
+
+#: ../src/common/xpmdecod.cpp:781
+#, c-format
+msgid "XPM: truncated image data at line %d!"
+msgstr "XPM: dados de imagem truncados na linha %d!"
+
+#: ../src/common/xpmdecod.cpp:795
+msgid "XPM: Malformed pixel data!"
+msgstr "XPM: Dados de pixeis mal formados!"
+
+#: ../src/common/xti.cpp:492
+msgid "Illegal Parameter Count for Create Method"
+msgstr "Parâmetro de Contador Ilegal para o Método Create"
+
+#: ../src/common/xti.cpp:504
+msgid "Illegal Parameter Count for ConstructObject Method"
+msgstr "Parâmetro de Contador Ilegal para o Método ConstructObject"
+
+#: ../src/common/xtistrm.cpp:161
+#, fuzzy, c-format
+msgid "Create Parameter %s not found in declared RTTI Parameters"
+msgstr "Create Parameter não encontrado nos Parâmetros RTTI declarados"
+
+#: ../src/common/xtistrm.cpp:290
+msgid "Illegal Object Class (Non-wxEvtHandler) as Event Source"
+msgstr "Classe de objecto ilegal (Não-wxEvtHandler) como EventSource"
+
+#: ../src/common/xtistrm.cpp:313 ../src/common/xtixml.cpp:345
+#: ../src/common/xtixml.cpp:498
+msgid "Type must have enum - long conversion"
+msgstr "Tipo deve ter conversão enum - long"
+
+#: ../src/common/xtistrm.cpp:400 ../src/common/xtistrm.cpp:415
+msgid "Invalid or Null Object ID passed to GetObjectClassInfo"
+msgstr "ID Nulo de Objecto ou inválido passado para GetObjectClassInfo"
+
+#: ../src/common/xtistrm.cpp:405
+msgid "Unknown Object passed to GetObjectClassInfo"
+msgstr "Objecto desconhecido passado para GetObjectClassInfo"
+
+#: ../src/common/xtistrm.cpp:420
+msgid "Already Registered Object passed to SetObjectClassInfo"
+msgstr "Objecto Já Registado passado para SetObjectClassInfo"
+
+#: ../src/common/xtistrm.cpp:430
+msgid "Invalid or Null Object ID passed to HasObjectClassInfo"
+msgstr "ID Nulo de Objecto ou inválido passado para HasObjectClassInfo"
+
+#: ../src/common/xtistrm.cpp:460
+msgid "Passing a already registered object to SetObject"
+msgstr "A passar um objecto já registado para SetObject"
+
+#: ../src/common/xtistrm.cpp:471
+#, fuzzy
+msgid "Passing an unknown object to GetObject"
+msgstr "A passar um objecto desconhecido para GetObject"
+
+#: ../src/common/xtixml.cpp:229
+msgid "Forward hrefs are not supported"
+msgstr "hrefs avançados não são suportados"
+
+#: ../src/common/xtixml.cpp:247
+#, c-format
+msgid "unknown class %s"
+msgstr "classe %s desconhecida"
+
+#: ../src/common/xtixml.cpp:253
+msgid "objects cannot have XML Text Nodes"
+msgstr "os objectos não podem ter TextNodes XML"
+
+#: ../src/common/xtixml.cpp:258
+msgid "Objects must have an id attribute"
+msgstr "Os objetos devem ter um atributo de id."
+
+#: ../src/common/xtixml.cpp:267
+#, c-format
+msgid "Doubly used id : %d"
+msgstr "Id usado duplamente : %d"
+
+#: ../src/common/xtixml.cpp:316
+#, fuzzy, c-format
+msgid "Unknown Property %s"
+msgstr "Propriedade desconhecida %s"
+
+#: ../src/common/xtixml.cpp:407
+msgid "A non empty collection must consist of 'element' nodes"
+msgstr "uma colecção não vazia deve consistir em nós de 'element'"
+
+#: ../src/common/xtixml.cpp:478
+msgid "incorrect event handler string, missing dot"
+msgstr ""
+"cadeia de caracteres de manuseamento de eventos incorrecta, falta um ponto"
+
+#: ../src/common/zipstrm.cpp:559
+msgid "can't re-initialize zlib deflate stream"
+msgstr "não foi possível re-inicializar o 'zlib deflate stream'"
+
+#: ../src/common/zipstrm.cpp:584
+msgid "can't re-initialize zlib inflate stream"
+msgstr "não foi possível re-inicializar o 'zlib inflate stream'"
+
+#: ../src/common/zipstrm.cpp:1023
+msgid "Ignoring malformed extra data record, ZIP file may be corrupted"
+msgstr ""
+
+#: ../src/common/zipstrm.cpp:1502
+msgid "assuming this is a multi-part zip concatenated"
+msgstr "a assumir que este é um ficheiro zip multi-partes concatenado"
+
+#: ../src/common/zipstrm.cpp:1664
+msgid "invalid zip file"
+msgstr "ficheiro zip inválido"
+
+#: ../src/common/zipstrm.cpp:1723
+msgid "can't find central directory in zip"
+msgstr "não foi possível localizar o directório central no zip"
+
+#: ../src/common/zipstrm.cpp:1812
+msgid "error reading zip central directory"
+msgstr "erro a ler directório central de zip"
+
+#: ../src/common/zipstrm.cpp:1916
+msgid "error reading zip local header"
+msgstr "erro ao ler cabeçalho local de zip"
+
+#: ../src/common/zipstrm.cpp:1964
+msgid "bad zipfile offset to entry"
+msgstr "mau offset de entrada de ficheiro zip"
+
+#: ../src/common/zipstrm.cpp:2031
+msgid "stored file length not in Zip header"
+msgstr "guardado tamanho do ficheiro não no cabeçalho Zip"
+
+#: ../src/common/zipstrm.cpp:2045 ../src/common/zipstrm.cpp:2362
+msgid "unsupported Zip compression method"
+msgstr "método de compressão Zip não suportado"
+
+#: ../src/common/zipstrm.cpp:2126
+#, c-format
+msgid "reading zip stream (entry %s): bad length"
+msgstr "a ler corrente de dados zip (entrada %s): mau comprimento"
+
+#: ../src/common/zipstrm.cpp:2131
+#, c-format
+msgid "reading zip stream (entry %s): bad crc"
+msgstr "a ler corrente de dados zip (entrada %s): mau crc"
+
+#: ../src/common/zipstrm.cpp:2578
+#, fuzzy, c-format
+msgid "error writing zip entry '%s': file too large without ZIP64"
+msgstr "erro ao escrever entrada zip '%s': mau comprimento ou crc"
+
+#: ../src/common/zipstrm.cpp:2585
+#, c-format
+msgid "error writing zip entry '%s': bad crc or length"
+msgstr "erro ao escrever entrada zip '%s': mau comprimento ou crc"
+
+#: ../src/common/zstream.cpp:155 ../src/common/zstream.cpp:315
+msgid "Gzip not supported by this version of zlib"
+msgstr "Gzip não suportado nesta versão do zlib"
+
+#: ../src/common/zstream.cpp:182
+msgid "Can't initialize zlib inflate stream."
+msgstr "Não é possível inicializar o zlib inflate stream."
+
+#: ../src/common/zstream.cpp:241
+msgid "Can't read inflate stream: unexpected EOF in underlying stream."
+msgstr ""
+"Não foi possível ler o inflate stream: EOF inexperado no stream subjacente."
+
+#: ../src/common/zstream.cpp:248 ../src/common/zstream.cpp:423
+#, c-format
+msgid "zlib error %d"
+msgstr "erro zlib %d"
+
+#: ../src/common/zstream.cpp:249
+#, c-format
+msgid "Can't read from inflate stream: %s"
+msgstr "Não foi possível ler do inflate stream: %s"
+
+#: ../src/common/zstream.cpp:343
+msgid "Can't initialize zlib deflate stream."
+msgstr "Não é possível inicializar o zlib deflate stream."
+
+#: ../src/common/zstream.cpp:424
+#, c-format
+msgid "Can't write to deflate stream: %s"
+msgstr "Não foi possível escrever no edeflate stream: %s"
+
+#: ../src/dfb/bitmap.cpp:633 ../src/dfb/bitmap.cpp:667
+#, fuzzy, c-format
+msgid "No bitmap handler for type %d defined."
+msgstr "Não existe um manuseador para o tipo %d definido."
+
+#: ../src/dfb/evtloop.cpp:99
+#, fuzzy
+msgid "Failed to read event from DirectFB pipe"
+msgstr "Falha na leitura do PID do ficheiro de bloqueio."
+
+#: ../src/dfb/evtloop.cpp:171
+msgid "Failed to switch DirectFB pipe to non-blocking mode"
+msgstr ""
+
+#: ../src/dfb/fontmgr.cpp:171
+#, c-format
+msgid "no fonts found in %s, using builtin font"
+msgstr ""
+
+#: ../src/dfb/fontmgr.cpp:177
+msgid "Default font"
+msgstr "Tipo de letra Predefinida"
+
+#: ../src/dfb/fontmgr.cpp:195
+#, c-format
+msgid "Fonts index file %s disappeared while loading fonts."
+msgstr ""
+
+#: ../src/dfb/wrapdfb.cpp:60
+#, fuzzy, c-format
+msgid "DirectFB error %d occurred."
+msgstr "Ocorreu um erro %d de DirectFB."
+
+#: ../src/generic/aboutdlgg.cpp:69
+msgid "Developed by "
+msgstr "Desenvolvido por "
+
+#: ../src/generic/aboutdlgg.cpp:72
+msgid "Documentation by "
+msgstr "Documentado por "
+
+#: ../src/generic/aboutdlgg.cpp:75
+msgid "Graphics art by "
+msgstr "Arte gráfica por "
+
+#: ../src/generic/aboutdlgg.cpp:78
+msgid "Translations by "
+msgstr "Traduções por "
+
+#: ../src/generic/aboutdlgg.cpp:133 ../src/osx/cocoa/aboutdlg.mm:83
+#, fuzzy
+msgid "Version "
+msgstr " Versão "
+
+#. TRANSLATORS: %s is application name
+#: ../src/generic/aboutdlgg.cpp:146 ../src/msw/aboutdlg.cpp:60
+#, c-format
+msgid "About %s"
+msgstr "Sobre o %s"
+
+#: ../src/generic/aboutdlgg.cpp:181
+msgid "License"
+msgstr "Licença"
+
+#: ../src/generic/aboutdlgg.cpp:184
+#, fuzzy
+msgid "Developers"
+msgstr "Desenvolvido por "
+
+#: ../src/generic/aboutdlgg.cpp:188
+#, fuzzy
+msgid "Documentation writers"
+msgstr "Documentado por "
+
+#: ../src/generic/aboutdlgg.cpp:192
+msgid "Artists"
+msgstr "Artistas"
+
+#: ../src/generic/aboutdlgg.cpp:196
+#, fuzzy
+msgid "Translators"
+msgstr "Traduções por "
+
+#: ../src/generic/animateg.cpp:125
+msgid "No handler found for animation type."
+msgstr "Não foi encontrado um manuseador para o tipo de animação."
+
+#: ../src/generic/animateg.cpp:133
+#, c-format
+msgid "No animation handler for type %ld defined."
+msgstr "Não existe um manuseador de animação definida para o tipo %ld."
+
+#: ../src/generic/animateg.cpp:145
+#, c-format
+msgid "Animation file is not of type %ld."
+msgstr "Ficheiro de animação não é do tipo %ld."
+
+#: ../src/generic/colrdlgg.cpp:154 ../src/gtk/colordlg.cpp:47
+msgid "Choose colour"
+msgstr "Escolher cor"
+
+#: ../src/generic/colrdlgg.cpp:357
+msgid "Red:"
+msgstr ""
+
+#: ../src/generic/colrdlgg.cpp:360
+msgid "Green:"
+msgstr ""
+
+#: ../src/generic/colrdlgg.cpp:363
+msgid "Blue:"
+msgstr ""
+
+#: ../src/generic/colrdlgg.cpp:372
+msgid "Opacity:"
+msgstr ""
+
+#: ../src/generic/colrdlgg.cpp:384
+msgid "Add to custom colours"
+msgstr "Adicionar às cores personalizadas"
+
+#: ../src/generic/creddlgg.cpp:56
+msgid "Username:"
+msgstr ""
+
+#: ../src/generic/creddlgg.cpp:63
+msgid "Password:"
+msgstr ""
+
+#. TRANSLATORS: Name of Boolean true value
+#: ../src/generic/datavgen.cpp:1178
+msgid "true"
+msgstr ""
+
+#. TRANSLATORS: Name of Boolean false value
+#: ../src/generic/datavgen.cpp:1180
+#, fuzzy
+msgid "false"
+msgstr "Falso"
+
+#: ../src/generic/datavgen.cpp:6897
+#, c-format
+msgid "Row %i"
+msgstr ""
+
+#. TRANSLATORS: Action for manipulating a tree control
+#: ../src/generic/datavgen.cpp:6987
+msgid "Collapse"
+msgstr ""
+
+#. TRANSLATORS: Action for manipulating a tree control
+#: ../src/generic/datavgen.cpp:6990
+msgid "Expand"
+msgstr ""
+
+#. TRANSLATORS: Name of data view control and number of rows
+#: ../src/generic/datavgen.cpp:7011
+#, fuzzy, c-format
+msgid "%s (%d items)"
+msgstr "%s (ou %s)"
+
+#: ../src/generic/datavgen.cpp:7062
+#, fuzzy, c-format
+msgid "Column %u"
+msgstr "Adicionar Coluna"
+
+#. TRANSLATORS: Keystroke for manipulating a tree control
+#: ../src/generic/datavgen.cpp:7131 ../src/richtext/richtextbulletspage.cpp:189
+#: ../src/richtext/richtextbulletspage.cpp:192
+#: ../src/richtext/richtextbulletspage.cpp:193
+#: ../src/richtext/richtextliststylepage.cpp:252
+#: ../src/richtext/richtextliststylepage.cpp:255
+#: ../src/richtext/richtextliststylepage.cpp:256
+#: ../src/richtext/richtextsizepage.cpp:248
+msgid "Left"
+msgstr "Esquerda"
+
+#. TRANSLATORS: Keystroke for manipulating a tree control
+#: ../src/generic/datavgen.cpp:7134 ../src/richtext/richtextbulletspage.cpp:191
+#: ../src/richtext/richtextliststylepage.cpp:254
+#: ../src/richtext/richtextsizepage.cpp:249
+msgid "Right"
+msgstr "Direita"
+
+#: ../src/generic/datectlg.cpp:90
+#, c-format
+msgid ""
+"\"%s\" is not in the expected date format, please enter it as e.g. \"%s\"."
+msgstr ""
+
+#: ../src/generic/datectlg.cpp:94
+#, fuzzy
+msgid "Invalid date"
+msgstr "PCX: imagem inválida"
+
+#: ../src/generic/dbgrptg.cpp:159
+#, c-format
+msgid "Open file \"%s\""
+msgstr "Abrir ficheiro \"%s\""
+
+#: ../src/generic/dbgrptg.cpp:170
+#, c-format
+msgid "Enter command to open file \"%s\":"
+msgstr "Introduza o comando para abrir o ficheiro \"%s\":"
+
+#: ../src/generic/dbgrptg.cpp:230
+msgid "Executable files (*.exe)|*.exe|"
+msgstr "Ficheiros Executáveis (*.exe)|*.exe|"
+
+#: ../src/generic/dbgrptg.cpp:300
+#, c-format
+msgid "Debug report \"%s\""
+msgstr "Relatório de depuração \"%s\""
+
+#: ../src/generic/dbgrptg.cpp:316
+msgid "A debug report has been generated in the directory\n"
+msgstr "Foi gerado um relatório de depuração na diretoria\n"
+
+#: ../src/generic/dbgrptg.cpp:317
+#, fuzzy
+msgid "The following debug report will be generated\n"
+msgstr "*** Foi gerado um relatório de depuração de erros\n"
+
+#: ../src/generic/dbgrptg.cpp:321
+msgid ""
+"The report contains the files listed below. If any of these files contain "
+"private information,\n"
+"please uncheck them and they will be removed from the report.\n"
+msgstr ""
+"O relatório os ficheiros listados abaixo. Se algum destes ficheiros contém "
+"informação privada,\n"
+"por favor desmarque-os e eles serão removidos do relatório.\n"
+
+#: ../src/generic/dbgrptg.cpp:323
+msgid ""
+"If you wish to suppress this debug report completely, please choose the "
+"\"Cancel\" button,\n"
+"but be warned that it may hinder improving the program, so if\n"
+"at all possible please do continue with the report generation.\n"
+msgstr ""
+"Se desejar suprimir completamente este relatorio de depuração, por favor, "
+"clique em \"Cancelar\",\n"
+"mas fique avisado que pode limitar a evolução do programa, sempre que "
+"possível\n"
+"por favor, continue com a geração do relatório .\n"
+
+#: ../src/generic/dbgrptg.cpp:325
+msgid "              Thank you and we're sorry for the inconvenience!\n"
+msgstr "              Obrigado e desculpe-nos pela inconveniência!\n"
+
+#: ../src/generic/dbgrptg.cpp:333
+msgid "&Debug report preview:"
+msgstr "Antevisão do relatório de &depuração:"
+
+#: ../src/generic/dbgrptg.cpp:339
+msgid "&View..."
+msgstr "&Visualizar ..."
+
+#: ../src/generic/dbgrptg.cpp:359
+msgid "&Notes:"
+msgstr "&Notas:"
+
+#: ../src/generic/dbgrptg.cpp:361
+msgid ""
+"If you have any additional information pertaining to this bug\n"
+"report, please enter it here and it will be joined to it:"
+msgstr ""
+"Se tiver alguma informação adicional relativa a este relatório de erro,\n"
+"por favor digite-a aqui e esta será adicionada a ele:"
+
+#: ../src/generic/dcpsg.cpp:1627
+msgid "Cannot open file for PostScript printing!"
+msgstr "Não foi possível abrir o ficheiro para impressão em PostScript!"
+
+#: ../src/generic/dirctrlg.cpp:402
+msgid "Computer"
+msgstr "Computador"
+
+#: ../src/generic/dirctrlg.cpp:404
+msgid "Sections"
+msgstr "Secções"
+
+#: ../src/generic/dirctrlg.cpp:482
+msgid "Home directory"
+msgstr "Directório pessoal"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/generic/dirctrlg.cpp:484 ../src/propgrid/advprops.cpp:811
+msgid "Desktop"
+msgstr "Ambiente de Trabalho"
+
+#: ../src/generic/dirctrlg.cpp:528 ../src/generic/filectrlg.cpp:752
+msgid "Illegal directory name."
+msgstr "Nome do directório ilegal."
+
+#: ../src/generic/dirctrlg.cpp:528 ../src/generic/dirctrlg.cpp:546
+#: ../src/generic/dirctrlg.cpp:557 ../src/generic/dirdlgg.cpp:317
+#: ../src/generic/filectrlg.cpp:638 ../src/generic/filectrlg.cpp:752
+#: ../src/generic/filectrlg.cpp:766 ../src/generic/filectrlg.cpp:782
+#: ../src/generic/filectrlg.cpp:1356 ../src/generic/filectrlg.cpp:1387
+#: ../src/generic/filedlgg.cpp:362 ../src/gtk/filedlg.cpp:76
+msgid "Error"
+msgstr "Erro"
+
+#: ../src/generic/dirctrlg.cpp:546 ../src/generic/filectrlg.cpp:766
+msgid "File name exists already."
+msgstr "Nome de ficheiro já existe."
+
+#: ../src/generic/dirctrlg.cpp:557 ../src/generic/dirdlgg.cpp:317
+#: ../src/generic/filectrlg.cpp:638 ../src/generic/filectrlg.cpp:782
+msgid "Operation not permitted."
+msgstr "Operação não permitida."
+
+#: ../src/generic/dirdlgg.cpp:107 ../src/generic/filedlgg.cpp:207
+msgid "Create new directory"
+msgstr "Criar novo directório"
+
+#: ../src/generic/dirdlgg.cpp:112 ../src/generic/filedlgg.cpp:203
+msgid "Go to home directory"
+msgstr "ir para o directório inicial"
+
+#: ../src/generic/dirdlgg.cpp:143
+msgid "Show &hidden directories"
+msgstr "Mostrar diretorias &ocultadas"
+
+#: ../src/generic/dirdlgg.cpp:196
+#, c-format
+msgid ""
+"The directory '%s' does not exist\n"
+"Create it now?"
+msgstr ""
+"O directório '%s' não existe\n"
+"Prtende criá-lo agora?"
+
+#: ../src/generic/dirdlgg.cpp:198
+msgid "Directory does not exist"
+msgstr "O directório não existe"
+
+#: ../src/generic/dirdlgg.cpp:214
+#, c-format
+msgid ""
+"Failed to create directory '%s'\n"
+"(Do you have the required permissions?)"
+msgstr ""
+"Falha ao criar o directório '%s'\n"
+"(Tem as permissões necessárias?)"
+
+#: ../src/generic/dirdlgg.cpp:216
+msgid "Error creating directory"
+msgstr "Erro ao criar directório"
+
+#: ../src/generic/dirdlgg.cpp:281
+msgid "You cannot add a new directory to this section."
+msgstr "Não pode adicionar um novo directório a esta secção."
+
+#: ../src/generic/dirdlgg.cpp:282
+msgid "Create directory"
+msgstr "Criar directório"
+
+#: ../src/generic/dirdlgg.cpp:291 ../src/generic/dirdlgg.cpp:301
+#: ../src/generic/filectrlg.cpp:614 ../src/generic/filectrlg.cpp:623
+msgid "NewName"
+msgstr "NovoNome"
+
+#: ../src/generic/editlbox.cpp:135
+msgid "Edit item"
+msgstr "Editar item"
+
+#: ../src/generic/editlbox.cpp:143
+msgid "New item"
+msgstr "Novo item"
+
+#: ../src/generic/editlbox.cpp:151
+msgid "Delete item"
+msgstr "Apagar Item"
+
+#: ../src/generic/editlbox.cpp:159
+msgid "Move up"
+msgstr "Mover para cima"
+
+#: ../src/generic/editlbox.cpp:164
+msgid "Move down"
+msgstr "Mover para baixo"
+
+#: ../src/generic/fdrepdlg.cpp:108
+msgid "Search for:"
+msgstr "Procurar por:"
+
+#: ../src/generic/fdrepdlg.cpp:120
+msgid "Replace with:"
+msgstr "Substituir por:"
+
+#: ../src/generic/fdrepdlg.cpp:140
+msgid "Whole word"
+msgstr "Palavra completa"
+
+#: ../src/generic/fdrepdlg.cpp:143
+msgid "Match case"
+msgstr "Coincidir capitulação"
+
+#: ../src/generic/fdrepdlg.cpp:156
+msgid "Search direction"
+msgstr "Direcção de procura"
+
+#: ../src/generic/fdrepdlg.cpp:175
+msgid "&Replace"
+msgstr "&Substituir"
+
+#: ../src/generic/fdrepdlg.cpp:178
+msgid "Replace &all"
+msgstr "Substituir &todos"
+
+#: ../src/generic/filectrlg.cpp:246 ../src/generic/filectrlg.cpp:269
+msgid "<DIR>"
+msgstr "<DIR>"
+
+#: ../src/generic/filectrlg.cpp:248 ../src/generic/filectrlg.cpp:271
+msgid "<LINK>"
+msgstr "<LINK>"
+
+#: ../src/generic/filectrlg.cpp:250 ../src/generic/filectrlg.cpp:273
+msgid "<DRIVE>"
+msgstr "<UNIDADE>"
+
+#: ../src/generic/filectrlg.cpp:275
+#, c-format
+msgid "%ld byte"
+msgid_plural "%ld bytes"
+msgstr[0] "%ld byte"
+msgstr[1] "%ld bytes"
+
+#: ../src/generic/filectrlg.cpp:420
+msgid "Name"
+msgstr "Nome"
+
+#: ../src/generic/filectrlg.cpp:421 ../src/richtext/richtextformatdlg.cpp:361
+#: ../src/richtext/richtextsizepage.cpp:298
+msgid "Size"
+msgstr "Tamanho"
+
+#: ../src/generic/filectrlg.cpp:422
+msgid "Type"
+msgstr "Tipo"
+
+#: ../src/generic/filectrlg.cpp:423
+msgid "Modified"
+msgstr "Modificado"
+
+#: ../src/generic/filectrlg.cpp:426
+msgid "Permissions"
+msgstr "Permissões"
+
+#: ../src/generic/filectrlg.cpp:429
+msgid "Attributes"
+msgstr "Atributos"
+
+#: ../src/generic/filectrlg.cpp:936
+msgid "Current directory:"
+msgstr "Directório atual:"
+
+#: ../src/generic/filectrlg.cpp:979
+msgid "Show &hidden files"
+msgstr "Mostrar fic&heiros escondidos"
+
+#: ../src/generic/filectrlg.cpp:1355
+msgid "Illegal file specification."
+msgstr "Especificação de ficheiro ilegal."
+
+#: ../src/generic/filectrlg.cpp:1387
+msgid "Directory doesn't exist."
+msgstr "O directório não existe."
+
+#: ../src/generic/filedlgg.cpp:195
+msgid "View files as a list view"
+msgstr "Ver ficheiros como uma vista em lista"
+
+#: ../src/generic/filedlgg.cpp:197
+msgid "View files as a detailed view"
+msgstr "Ver ficheiros como uma vista detalhada"
+
+#: ../src/generic/filedlgg.cpp:200
+msgid "Go to parent directory"
+msgstr "Ir para o directório superior"
+
+#: ../src/generic/filedlgg.cpp:351 ../src/gtk/filedlg.cpp:59
+#, c-format
+msgid "File '%s' already exists, do you really want to overwrite it?"
+msgstr "O ficheiro '%s' já existe, deseja substituí-lo?"
+
+#: ../src/generic/filedlgg.cpp:354 ../src/gtk/filedlg.cpp:62
+msgid "Confirm"
+msgstr "Confirmar"
+
+#: ../src/generic/filedlgg.cpp:362 ../src/gtk/filedlg.cpp:75
+msgid "Please choose an existing file."
+msgstr "Por favor escolha um ficheiro existente."
+
+#: ../src/generic/filepickerg.cpp:64
+msgid "..."
+msgstr "..."
+
+#: ../src/generic/fontdlgg.cpp:76 ../src/richtext/richtextformatdlg.cpp:519
+msgid "ABCDEFGabcdefg12345"
+msgstr "ABCDEFGabcdefg12345"
+
+#: ../src/generic/fontdlgg.cpp:315
+msgid "Roman"
+msgstr "Roman"
+
+#: ../src/generic/fontdlgg.cpp:316
+msgid "Decorative"
+msgstr "Decorative"
+
+#: ../src/generic/fontdlgg.cpp:317
+msgid "Modern"
+msgstr "Moderno"
+
+#: ../src/generic/fontdlgg.cpp:318
+msgid "Script"
+msgstr "Script"
+
+#: ../src/generic/fontdlgg.cpp:319
+msgid "Swiss"
+msgstr "Suíço"
+
+#: ../src/generic/fontdlgg.cpp:320
+msgid "Teletype"
+msgstr "Teletype"
+
+#: ../src/generic/fontdlgg.cpp:321 ../src/generic/fontdlgg.cpp:324
+msgid "Normal"
+msgstr "Normal"
+
+#: ../src/generic/fontdlgg.cpp:323
+msgid "Slant"
+msgstr "Inclinação"
+
+#: ../src/generic/fontdlgg.cpp:325
+msgid "Light"
+msgstr "Leve"
+
+#: ../src/generic/fontdlgg.cpp:363
+msgid "&Font family:"
+msgstr "Família de &fonte:"
+
+#: ../src/generic/fontdlgg.cpp:367 ../src/generic/fontdlgg.cpp:369
+msgid "The font family."
+msgstr "A família da fonte."
+
+#: ../src/generic/fontdlgg.cpp:374 ../src/richtext/richtextstylepage.cpp:105
+msgid "&Style:"
+msgstr "E&stilo:"
+
+#: ../src/generic/fontdlgg.cpp:378 ../src/generic/fontdlgg.cpp:380
+msgid "The font style."
+msgstr "O estilo da fonte."
+
+#: ../src/generic/fontdlgg.cpp:385
+msgid "&Weight:"
+msgstr "&Peso:"
+
+#: ../src/generic/fontdlgg.cpp:389 ../src/generic/fontdlgg.cpp:391
+msgid "The font weight."
+msgstr "O peso da fonte."
+
+#: ../src/generic/fontdlgg.cpp:399
+msgid "C&olour:"
+msgstr "C&or:"
+
+#: ../src/generic/fontdlgg.cpp:407 ../src/generic/fontdlgg.cpp:409
+msgid "The font colour."
+msgstr "A cor da fonte."
+
+#: ../src/generic/fontdlgg.cpp:415
+msgid "&Point size:"
+msgstr "Tamanho do &ponto:"
+
+#: ../src/generic/fontdlgg.cpp:420 ../src/generic/fontdlgg.cpp:422
+#: ../src/generic/fontdlgg.cpp:426 ../src/generic/fontdlgg.cpp:428
+msgid "The font point size."
+msgstr "O tamanho do ponto da fonte."
+
+#: ../src/generic/fontdlgg.cpp:439 ../src/generic/fontdlgg.cpp:441
+msgid "Whether the font is underlined."
+msgstr "Se a fonte está sublinhada."
+
+#: ../src/generic/fontdlgg.cpp:448 ../src/html/helpwnd.cpp:1215
+msgid "Preview:"
+msgstr "Antevisão:"
+
+#: ../src/generic/fontdlgg.cpp:452 ../src/generic/fontdlgg.cpp:454
+msgid "Shows the font preview."
+msgstr "Mostra a antevisão da fonte."
+
+#: ../src/generic/fontdlgg.cpp:464 ../src/generic/fontdlgg.cpp:483
+msgid "Click to cancel the font selection."
+msgstr "Clique para cancelar selecção de fonte."
+
+#: ../src/generic/fontdlgg.cpp:469 ../src/generic/fontdlgg.cpp:471
+#: ../src/generic/fontdlgg.cpp:476 ../src/generic/fontdlgg.cpp:478
+msgid "Click to confirm the font selection."
+msgstr "Clique para confirmar selecção de fonte."
+
+#: ../src/generic/fontpickerg.cpp:50 ../src/gtk/fontdlg.cpp:77
+msgid "Choose font"
+msgstr "Escolher fonte"
+
+#: ../src/generic/grid.cpp:6542
+msgid ""
+"Error copying grid to the clipboard. Either selected cells were not "
+"contiguous or no cell was selected."
+msgstr ""
+
+#: ../src/generic/grid.cpp:12739
+msgid "Grid Corner"
+msgstr ""
+
+#: ../src/generic/grid.cpp:12741
+#, fuzzy, c-format
+msgid "Column %s Header"
+msgstr "Adicionar Coluna"
+
+#: ../src/generic/grid.cpp:12743
+#, c-format
+msgid "Row %s Header"
+msgstr ""
+
+#: ../src/generic/grid.cpp:12745
+#, fuzzy, c-format
+msgid "Column %s: %s"
+msgstr "Adicionar Coluna"
+
+#: ../src/generic/grid.cpp:12749
+#, fuzzy, c-format
+msgid "Row %s: %s"
+msgstr "\t%s: %s\n"
+
+#: ../src/generic/grid.cpp:12753
+#, c-format
+msgid "Row %s, Column %s: %s"
+msgstr ""
+
+#: ../src/generic/helpext.cpp:257
+#, c-format
+msgid "Help directory \"%s\" not found."
+msgstr "Directório de ajuda \"%s\" não encontrado."
+
+#: ../src/generic/helpext.cpp:265
+#, c-format
+msgid "Help file \"%s\" not found."
+msgstr "Ficheiro de ajuda \"%s\" não encontrado."
+
+#: ../src/generic/helpext.cpp:284
+#, c-format
+msgid "Line %lu of map file \"%s\" has invalid syntax, skipped."
+msgstr ""
+"A linha %lu do ficheiro de mapa \"%s\" contém uma sintaxe inválida, saltado."
+
+#: ../src/generic/helpext.cpp:292
+#, c-format
+msgid "No valid mappings found in the file \"%s\"."
+msgstr "Não foram encontrados mapeamentos válidos no ficheiro \"%s\"."
+
+#: ../src/generic/helpext.cpp:435
+msgid "No entries found."
+msgstr "Não foram encontradas entradas."
+
+#: ../src/generic/helpext.cpp:444 ../src/generic/helpext.cpp:445
+msgid "Help Index"
+msgstr "Índice de Ajuda"
+
+#: ../src/generic/helpext.cpp:448
+msgid "Relevant entries:"
+msgstr "Entradas relevantes:"
+
+#: ../src/generic/helpext.cpp:449
+msgid "Entries found"
+msgstr "Entradas encontradas"
+
+#: ../src/generic/hyperlinkg.cpp:170
+msgid "&Copy URL"
+msgstr "&Copiar URL"
+
+#: ../src/generic/infobar.cpp:119
+msgid "Hide this notification message."
+msgstr "Ocultar esta mensagem de notificação."
+
+#. TRANSLATORS: %s will be either the application name or "Application"
+#: ../src/generic/logg.cpp:257
+#, c-format
+msgid "%s Error"
+msgstr "%s Erro"
+
+#. TRANSLATORS: %s will be either the application name or "Application"
+#: ../src/generic/logg.cpp:263
+#, c-format
+msgid "%s Warning"
+msgstr "%s Aviso"
+
+#. TRANSLATORS: %s will be either the application name or "Application"
+#: ../src/generic/logg.cpp:273
+#, c-format
+msgid "%s Information"
+msgstr "%s Informação"
+
+#: ../src/generic/logg.cpp:276
+msgid "Application"
+msgstr "Aplicação"
+
+#: ../src/generic/logg.cpp:549
+msgid "Save log contents to file"
+msgstr "Gravar conteúdos do registo para ficheiro"
+
+#: ../src/generic/logg.cpp:551
+msgid "C&lear"
+msgstr "&Limpar"
+
+#: ../src/generic/logg.cpp:551
+msgid "Clear the log contents"
+msgstr "Limpar o conteúdo do registo"
+
+#: ../src/generic/logg.cpp:553
+msgid "Close this window"
+msgstr "Fechar esta janela"
+
+#: ../src/generic/logg.cpp:554
+msgid "&Log"
+msgstr "&Registo"
+
+#: ../src/generic/logg.cpp:610 ../src/generic/logg.cpp:992
+msgid "Can't save log contents to file."
+msgstr "Não foi possível gravar conteúdo do registo para ficheiro."
+
+#: ../src/generic/logg.cpp:613
+#, c-format
+msgid "Log saved to the file '%s'."
+msgstr "Registo gravado no ficheiro '%s'."
+
+#: ../src/generic/logg.cpp:719
+msgid "&Details"
+msgstr "&Detalhes"
+
+#: ../src/generic/logg.cpp:972
+#, fuzzy
+msgid "Failed to copy dialog contents to the clipboard."
+msgstr "Falha na abertura da área de transferência."
+
+#: ../src/generic/logg.cpp:1022
+#, c-format
+msgid "Append log to file '%s' (choosing [No] will overwrite it)?"
+msgstr ""
+"Adicionar ao ficheiro de registo '%s' (escolher [Não] vai substitui-lo)?"
+
+#: ../src/generic/logg.cpp:1024
+msgid "Question"
+msgstr "Pergunta"
+
+#: ../src/generic/logg.cpp:1038
+msgid "invalid message box return value"
+msgstr "valor de retorno de caixa de diálogo inválido"
+
+#: ../src/generic/notifmsgg.cpp:129
+#, fuzzy
+msgid "Notice"
+msgstr "&Nota:"
+
+#: ../src/generic/preferencesg.cpp:118
+#, c-format
+msgid "%s Preferences"
+msgstr "%s Preferências"
+
+#: ../src/generic/printps.cpp:143
+msgid "Printing..."
+msgstr "A Imprimir ..."
+
+#: ../src/generic/printps.cpp:160 ../src/gtk/print.cpp:1076
+#: ../src/msw/printwin.cpp:235
+msgid "Could not start printing."
+msgstr "Não foi possível inicia a impressão."
+
+#: ../src/generic/printps.cpp:183
+#, c-format
+msgid "Printing page %d..."
+msgstr "A imprimir a página %d ..."
+
+#: ../src/generic/prntdlgg.cpp:171
+msgid "Printer options"
+msgstr "Opções da Impressora"
+
+#: ../src/generic/prntdlgg.cpp:176
+msgid "Print to File"
+msgstr "Imprimir para Ficheiro"
+
+#: ../src/generic/prntdlgg.cpp:179
+msgid "Setup..."
+msgstr "Configurar..."
+
+#: ../src/generic/prntdlgg.cpp:187
+msgid "Printer:"
+msgstr "Impressora:"
+
+#: ../src/generic/prntdlgg.cpp:195
+msgid "Status:"
+msgstr "Estado:"
+
+#: ../src/generic/prntdlgg.cpp:206
+msgid "All"
+msgstr "Todos"
+
+#: ../src/generic/prntdlgg.cpp:207
+msgid "Pages"
+msgstr "Páginas"
+
+#: ../src/generic/prntdlgg.cpp:215
+msgid "Print Range"
+msgstr "Páginas a Imprimir"
+
+#: ../src/generic/prntdlgg.cpp:229
+msgid "From:"
+msgstr "De:"
+
+#: ../src/generic/prntdlgg.cpp:233
+msgid "To:"
+msgstr "Para:"
+
+#: ../src/generic/prntdlgg.cpp:238
+msgid "Copies:"
+msgstr "Cópias:"
+
+#: ../src/generic/prntdlgg.cpp:288
+msgid "PostScript file"
+msgstr "Ficheiro PostScript"
+
+#: ../src/generic/prntdlgg.cpp:439
+msgid "Print Setup"
+msgstr "Configuração da Impressora"
+
+#: ../src/generic/prntdlgg.cpp:483
+msgid "Printer"
+msgstr "Impressora"
+
+#: ../src/generic/prntdlgg.cpp:501
+msgid "Default printer"
+msgstr "Impressora pré-definida"
+
+#: ../src/generic/prntdlgg.cpp:595 ../src/generic/prntdlgg.cpp:782
+#: ../src/generic/prntdlgg.cpp:822 ../src/generic/prntdlgg.cpp:835
+#: ../src/generic/prntdlgg.cpp:1031 ../src/generic/prntdlgg.cpp:1036
+msgid "Paper size"
+msgstr "Tamanho do papel"
+
+#: ../src/generic/prntdlgg.cpp:604 ../src/generic/prntdlgg.cpp:847
+msgid "Portrait"
+msgstr "Retrato"
+
+#: ../src/generic/prntdlgg.cpp:605 ../src/generic/prntdlgg.cpp:848
+msgid "Landscape"
+msgstr "Paisagem"
+
+#: ../src/generic/prntdlgg.cpp:607 ../src/generic/prntdlgg.cpp:849
+msgid "Orientation"
+msgstr "Orientação"
+
+#: ../src/generic/prntdlgg.cpp:610
+msgid "Options"
+msgstr "Opções"
+
+#: ../src/generic/prntdlgg.cpp:612
+msgid "Print in colour"
+msgstr "Imprimir a cores"
+
+#: ../src/generic/prntdlgg.cpp:621
+msgid "Print spooling"
+msgstr "Colocação da impressão no buffer"
+
+#: ../src/generic/prntdlgg.cpp:623
+msgid "Printer command:"
+msgstr "Comando da impressora:"
+
+#: ../src/generic/prntdlgg.cpp:631
+msgid "Printer options:"
+msgstr "Opções da impressora:"
+
+#: ../src/generic/prntdlgg.cpp:860
+msgid "Left margin (mm):"
+msgstr "Margem esquerda (mm):"
+
+#: ../src/generic/prntdlgg.cpp:861
+msgid "Top margin (mm):"
+msgstr "Margem de topo (mm):"
+
+#: ../src/generic/prntdlgg.cpp:872
+msgid "Right margin (mm):"
+msgstr "Margem direita (mm):"
+
+#: ../src/generic/prntdlgg.cpp:873
+msgid "Bottom margin (mm):"
+msgstr "Margem de rodapé (mm):"
+
+#: ../src/generic/prntdlgg.cpp:896
+msgid "Printer..."
+msgstr "Impressora ..."
+
+#: ../src/generic/progdlgg.cpp:246
+msgid "&Skip"
+msgstr "&Ignorar"
+
+#: ../src/generic/progdlgg.cpp:347 ../src/generic/progdlgg.cpp:626
+msgid "Unknown"
+msgstr "Desconhecido"
+
+#: ../src/generic/progdlgg.cpp:451 ../src/msw/progdlg.cpp:526
+msgid "Done."
+msgstr "Feito."
+
+#: ../src/generic/srchctlg.cpp:55 ../src/gtk/srchctrl.cpp:206
+#: ../src/html/helpwnd.cpp:530 ../src/html/helpwnd.cpp:545
+msgid "Search"
+msgstr "Procurar"
+
+#: ../src/generic/tabg.cpp:1026
+msgid "Could not find tab for id"
+msgstr "Não foi possível localizar a tabulação para o id"
+
+#: ../src/generic/tipdlg.cpp:136
+msgid "Tips not available, sorry!"
+msgstr "Dicas não disponíveis, desculpe!"
+
+#: ../src/generic/tipdlg.cpp:197
+msgid "Tip of the Day"
+msgstr "Dica do Dia"
+
+#: ../src/generic/tipdlg.cpp:207
+msgid "Did you know..."
+msgstr "Sabia que..."
+
+#: ../src/generic/tipdlg.cpp:232
+msgid "&Show tips at startup"
+msgstr "&Mostrar dicas no inicio"
+
+#: ../src/generic/tipdlg.cpp:236
+msgid "&Next Tip"
+msgstr "&Próxima Dica"
+
+#: ../src/generic/wizard.cpp:411
+msgid "&Next >"
+msgstr "&Próximo >"
+
+#: ../src/generic/wizard.cpp:412
+msgid "&Finish"
+msgstr "&Terminar"
+
+#: ../src/generic/wizard.cpp:420
+msgid "< &Back"
+msgstr "< &Atrás"
+
+#: ../src/gtk/aboutdlg.cpp:204
+msgid "translator-credits"
+msgstr "créditos dos tradutores"
+
+#: ../src/gtk/app.cpp:517
+msgid ""
+"WARNING: using XIM input method is unsupported and may result in problems "
+"with input handling and flickering. Consider unsetting GTK_IM_MODULE or "
+"setting to \"ibus\"."
+msgstr ""
+
+#: ../src/gtk/app.cpp:569
+msgid "Unable to initialize GTK+, is DISPLAY set properly?"
+msgstr ""
+
+#: ../src/gtk/filedlg.cpp:89 ../src/gtk/filepicker.cpp:255
+#, fuzzy, c-format
+msgid "Changing current directory to \"%s\" failed"
+msgstr "Falha de criação de directório \"%s\""
+
+#: ../src/gtk/font.cpp:548
+msgid ""
+"Using private fonts is not supported on this system: Pango library is too "
+"old, 1.38 or later required."
+msgstr ""
+
+#: ../src/gtk/font.cpp:558
+#, fuzzy
+msgid "Failed to create font configuration object."
+msgstr "Falha na atualização do ficheiro de configuração do utilizador."
+
+#: ../src/gtk/font.cpp:568
+#, fuzzy, c-format
+msgid "Failed to add custom font \"%s\"."
+msgstr "Falha na leitura de metafile do ficheiro \"%s\"."
+
+#: ../src/gtk/font.cpp:576
+#, fuzzy
+msgid "Failed to register font configuration using private fonts."
+msgstr "Falha na atualização do ficheiro de configuração do utilizador."
+
+#: ../src/gtk/glcanvas.cpp:117 ../src/gtk/glcanvas.cpp:132
+#, fuzzy
+msgid "Fatal Error"
+msgstr "Erro Fatal"
+
+#: ../src/gtk/glcanvas.cpp:117
+msgid ""
+"This program wasn't compiled with EGL support required under Wayland, "
+"either\n"
+"install EGL libraries and rebuild or run it under X11 backend by setting\n"
+"environment variable GDK_BACKEND=x11 before starting your program."
+msgstr ""
+
+#: ../src/gtk/glcanvas.cpp:132
+msgid ""
+"wxGLCanvas is only supported on Wayland and X11 currently.  You may be able "
+"to\n"
+"work around this by setting environment variable GDK_BACKEND=x11 before\n"
+"starting your program."
+msgstr ""
+
+#: ../src/gtk/mdi.cpp:433
+msgid "MDI child"
+msgstr "Fillho MDI"
+
+#: ../src/gtk/power.cpp:188
+#, fuzzy, c-format
+msgid "Failed to open D-Bus connection to the login manager: %s"
+msgstr "Falha ao %s a ligação telefónica: %s"
+
+#: ../src/gtk/power.cpp:214
+#, fuzzy
+msgid "wxWidgets application"
+msgstr "Aplicação"
+
+#: ../src/gtk/power.cpp:226
+msgid "Application needs to keep running"
+msgstr ""
+
+#: ../src/gtk/power.cpp:233
+msgid "Clean up before suspend"
+msgstr ""
+
+#: ../src/gtk/power.cpp:259
+#, fuzzy, c-format
+msgid "Failed to inhibit sleep: %s"
+msgstr "Falha ao terminar a ligação telefónica: %s "
+
+#: ../src/gtk/power.cpp:265
+msgid "Unexpected response to D-Bus \"Inhibit\" request."
+msgstr ""
+
+#: ../src/gtk/print.cpp:218
+msgid "Custom size"
+msgstr "Tamanho Personalizado"
+
+#: ../src/gtk/print.cpp:752
+#, fuzzy, c-format
+msgid "Error while printing: %s"
+msgstr "Erro durante a espera de um semáforo"
+
+#: ../src/gtk/print.cpp:816
+msgid "Page Setup"
+msgstr "Configuração de Página"
+
+#: ../src/gtk/webview_webkit.cpp:932
+msgid "Retrieving JavaScript script output is not supported with WebKit v1"
+msgstr ""
+
+#: ../src/gtk/webview_webkit2.cpp:1098
+msgid ""
+"Setting proxy is not supported by WebKit, at least version 2.16 is required."
+msgstr ""
+
+#: ../src/gtk/webview_webkit2.cpp:1104
+msgid "This program was compiled without support for setting WebKit proxy."
+msgstr ""
+
+#: ../src/gtk/window.cpp:6289
+msgid ""
+"GTK+ installed on this machine is too old to support screen compositing, "
+"please install GTK+ 2.12 or later."
+msgstr ""
+
+#: ../src/gtk/window.cpp:6307
+msgid ""
+"Compositing not supported by this system, please enable it in your Window "
+"Manager."
+msgstr ""
+
+#: ../src/gtk/window.cpp:6318
+msgid ""
+"This program was compiled with a too old version of GTK+, please rebuild "
+"with GTK+ 2.12 or newer."
+msgstr ""
+
+#: ../src/html/chm.cpp:138
+#, c-format
+msgid "Failed to open CHM archive '%s'."
+msgstr "Falha na abertura do arquivo CHM '%s'."
+
+#: ../src/html/chm.cpp:270
+#, c-format
+msgid "Could not extract %s into %s: %s"
+msgstr "Não foi possível extrair %s para %s: %s"
+
+#: ../src/html/chm.cpp:324
+msgid "no error"
+msgstr "sem erro"
+
+#: ../src/html/chm.cpp:326
+msgid "bad arguments to library function"
+msgstr "argumentos inválidos a uma função da livraria"
+
+#: ../src/html/chm.cpp:328
+msgid "error opening file"
+msgstr "erro ao abrir ficheiro"
+
+#: ../src/html/chm.cpp:330
+msgid "read error"
+msgstr "erro de leitura"
+
+#: ../src/html/chm.cpp:332
+msgid "write error"
+msgstr "erro de escrita"
+
+#: ../src/html/chm.cpp:334
+msgid "seek error"
+msgstr "erro de pesquisa"
+
+#: ../src/html/chm.cpp:338
+msgid "bad signature"
+msgstr "má assinatura"
+
+#: ../src/html/chm.cpp:340
+msgid "error in data format"
+msgstr "erro no formato do dado"
+
+#: ../src/html/chm.cpp:342
+msgid "checksum error"
+msgstr "erro de checksum"
+
+#: ../src/html/chm.cpp:344
+msgid "compression error"
+msgstr "erro de compressão"
+
+#: ../src/html/chm.cpp:346
+msgid "decompression error"
+msgstr "erro de descompressão"
+
+#: ../src/html/chm.cpp:437
+#, c-format
+msgid "Could not locate file '%s'."
+msgstr "Não foi possível localizar o ficheiro '%s'."
+
+#: ../src/html/chm.cpp:711
+#, c-format
+msgid "Could not create temporary file '%s'"
+msgstr "Não foi possível criar ficheiro temporário '%s'"
+
+#: ../src/html/chm.cpp:718
+#, c-format
+msgid "Extraction of '%s' into '%s' failed."
+msgstr "Falhou a extracção de '%s' para '%s'."
+
+#: ../src/html/chm.cpp:806 ../src/html/chm.cpp:863
+msgid "CHM handler currently supports only local files!"
+msgstr "O manuseador CHM atualmente apenas suporta ficheiros locais!"
+
+#: ../src/html/chm.cpp:827
+msgid "Link contained '//', converted to absolute link."
+msgstr "O link contém '//', foi convertido para um link absoluto."
+
+#: ../src/html/helpctrl.cpp:59
+#, c-format
+msgid "Help: %s"
+msgstr "Ajuda: %s"
+
+#: ../src/html/helpctrl.cpp:155
+#, c-format
+msgid "Adding book %s"
+msgstr "A adicionar livro %s"
+
+#: ../src/html/helpdata.cpp:295
+#, c-format
+msgid "Cannot open contents file: %s"
+msgstr "Não foi possível abrir o ficheiro de conteúdos: %s"
+
+#: ../src/html/helpdata.cpp:309
+#, c-format
+msgid "Cannot open index file: %s"
+msgstr "Não foi possível abrir ficheiro de índice: %s"
+
+#: ../src/html/helpdata.cpp:643
+msgid "noname"
+msgstr "sem nome"
+
+#: ../src/html/helpdata.cpp:652
+#, c-format
+msgid "Cannot open HTML help book: %s"
+msgstr "Não foi possível abrir o livro de ajuda HTML: %s"
+
+#: ../src/html/helpwnd.cpp:315
+msgid "Displays help as you browse the books on the left."
+msgstr "Mostrar ajuda à medida que navega nos livros à esquerda."
+
+#: ../src/html/helpwnd.cpp:411 ../src/html/helpwnd.cpp:1100
+#: ../src/html/helpwnd.cpp:1735
+msgid "(bookmarks)"
+msgstr "(marcadores)"
+
+#: ../src/html/helpwnd.cpp:424
+msgid "Add current page to bookmarks"
+msgstr "Adicionar página atual aos marcadores"
+
+#: ../src/html/helpwnd.cpp:425
+msgid "Remove current page from bookmarks"
+msgstr "Remover página atual dos marcadores"
+
+#: ../src/html/helpwnd.cpp:470
+msgid "Contents"
+msgstr "Conteúdos"
+
+#: ../src/html/helpwnd.cpp:485
+msgid "Find"
+msgstr "Procurar"
+
+#: ../src/html/helpwnd.cpp:487
+msgid "Show all"
+msgstr "Mostrar tudo"
+
+#: ../src/html/helpwnd.cpp:497
+msgid ""
+"Display all index items that contain given substring. Search is case "
+"insensitive."
+msgstr ""
+"Mostrar todos os items de índice que contenham a seguinte cadeia. A pesquisa "
+"é insensível à capitulação."
+
+#: ../src/html/helpwnd.cpp:498
+msgid "Show all items in index"
+msgstr "Mostrar todos os items no índice"
+
+#: ../src/html/helpwnd.cpp:528
+msgid "Case sensitive"
+msgstr "Sensível à capitulação"
+
+#: ../src/html/helpwnd.cpp:529
+msgid "Whole words only"
+msgstr "Apenas palavras completas"
+
+#: ../src/html/helpwnd.cpp:532
+#, fuzzy
+msgid ""
+"Search contents of help book(s) for all occurrences of the text you typed "
+"above"
+msgstr ""
+"Procurar conteúdos de livros de ajuda para todas as ocorrências do texto "
+"digitado acima"
+
+#: ../src/html/helpwnd.cpp:653
+msgid "Show/hide navigation panel"
+msgstr "Mostra/esconde painel de navegação"
+
+#: ../src/html/helpwnd.cpp:655
+msgid "Go back"
+msgstr "Ir para trás"
+
+#: ../src/html/helpwnd.cpp:656
+msgid "Go forward"
+msgstr "Ir para a frente"
+
+#: ../src/html/helpwnd.cpp:658
+msgid "Go one level up in document hierarchy"
+msgstr "Subir um nível na hierarquia do documento"
+
+#: ../src/html/helpwnd.cpp:666 ../src/html/helpwnd.cpp:1547
+msgid "Open HTML document"
+msgstr "Abrir documento HTML"
+
+#: ../src/html/helpwnd.cpp:670
+msgid "Print this page"
+msgstr "Imprimir esta página"
+
+#: ../src/html/helpwnd.cpp:674
+msgid "Display options dialog"
+msgstr "Caixa de diálogo do ecrã"
+
+#: ../src/html/helpwnd.cpp:795
+msgid "Please choose the page to display:"
+msgstr "Por favor escolha uma página para mostrar:"
+
+#: ../src/html/helpwnd.cpp:796
+msgid "Help Topics"
+msgstr "Tópicos de Ajuda"
+
+#: ../src/html/helpwnd.cpp:852
+msgid "Searching..."
+msgstr "A Procurar..."
+
+#: ../src/html/helpwnd.cpp:853
+msgid "No matching page found yet"
+msgstr "Ainda não foi encontrada uma página correspondente"
+
+#: ../src/html/helpwnd.cpp:870
+#, c-format
+msgid "Found %i matches"
+msgstr "Foram encontradas %i correspondências"
+
+#: ../src/html/helpwnd.cpp:958
+msgid "(Help)"
+msgstr "(Ajuda)"
+
+#: ../src/html/helpwnd.cpp:1026
+#, c-format
+msgid "%d of %lu"
+msgstr "%d de %lu"
+
+#: ../src/html/helpwnd.cpp:1028
+#, c-format
+msgid "%lu of %lu"
+msgstr "%lu de %lu"
+
+#: ../src/html/helpwnd.cpp:1047
+msgid "Search in all books"
+msgstr "Procurar em todos os livros"
+
+#: ../src/html/helpwnd.cpp:1193
+msgid "Help Browser Options"
+msgstr "Opções do Navegador de Ajuda"
+
+#: ../src/html/helpwnd.cpp:1198
+msgid "Normal font:"
+msgstr "Fonte normal:"
+
+#: ../src/html/helpwnd.cpp:1199
+msgid "Fixed font:"
+msgstr "Fonte Fixa:"
+
+#: ../src/html/helpwnd.cpp:1200
+msgid "Font size:"
+msgstr "Tamanho da Fonte:"
+
+#: ../src/html/helpwnd.cpp:1245
+msgid "font size"
+msgstr "tamanho da fonte"
+
+#: ../src/html/helpwnd.cpp:1256
+msgid "Normal face<br>and <u>underlined</u>. "
+msgstr "Face normal <br>e <u>sublinhado</u>. "
+
+#: ../src/html/helpwnd.cpp:1257
+msgid "<i>Italic face.</i> "
+msgstr "<i>Face itálico.</i> "
+
+#: ../src/html/helpwnd.cpp:1258
+msgid "<b>Bold face.</b> "
+msgstr "<b>Face negrito.</b> "
+
+#: ../src/html/helpwnd.cpp:1259
+msgid "<b><i>Bold italic face.</i></b><br>"
+msgstr "<b><i>Face negrito itálico.</i></b><br>"
+
+#: ../src/html/helpwnd.cpp:1262
+msgid "Fixed size face.<br> <b>bold</b> <i>italic</i> "
+msgstr "Tamanho fixo da face.<br> <b>negrito</b> <i>itálico</i> "
+
+#: ../src/html/helpwnd.cpp:1263
+msgid "<b><i>bold italic <u>underlined</u></i></b><br>"
+msgstr "<b><i>negrito itálico <u>sublinhado</u></i></b><br>"
+
+#: ../src/html/helpwnd.cpp:1524
+msgid "Help Printing"
+msgstr "Ajuda de Impressão"
+
+#: ../src/html/helpwnd.cpp:1527
+msgid "Cannot print empty page."
+msgstr "Não foi possível imprimir página vazia."
+
+#: ../src/html/helpwnd.cpp:1540
+msgid "HTML files (*.html;*.htm)|*.html;*.htm|"
+msgstr "Ficheiros HTML (*.html;*.htm)|*.html;*.htm|"
+
+#: ../src/html/helpwnd.cpp:1541
+msgid "Help books (*.htb)|*.htb|Help books (*.zip)|*.zip|"
+msgstr "Livros de ajuda(*.htb)|*.htb|Livros de ajuda(*.zip)|*.zip|"
+
+#: ../src/html/helpwnd.cpp:1542
+msgid "HTML Help Project (*.hhp)|*.hhp|"
+msgstr "HTML projecto de ajuda (*.hhp)|*.hhp|"
+
+#: ../src/html/helpwnd.cpp:1544
+msgid "Compressed HTML Help file (*.chm)|*.chm|"
+msgstr "Ficheiro de ajuda HTML comprimido (*.chm)|*.chm|"
+
+#: ../src/html/helpwnd.cpp:1671
+#, fuzzy, c-format
+msgid "%i of %u"
+msgstr "%i de %i"
+
+#: ../src/html/helpwnd.cpp:1709
+#, fuzzy, c-format
+msgid "%u of %u"
+msgstr "%lu de %lu"
+
+#: ../src/html/htmlfilt.cpp:134
+#, c-format
+msgid "Cannot open HTML document: %s"
+msgstr "Não foi possível abrir o documento HTML: %s"
+
+#: ../src/html/htmlwin.cpp:599
+msgid "Connecting..."
+msgstr "A ligar..."
+
+#: ../src/html/htmlwin.cpp:616
+#, c-format
+msgid "Unable to open requested HTML document: %s"
+msgstr "Não foi possível abrir documento HTML pretendido: %s"
+
+#: ../src/html/htmlwin.cpp:630
+msgid "Loading : "
+msgstr "A Abrir : "
+
+#: ../src/html/htmlwin.cpp:673
+msgid "Done"
+msgstr "Feito"
+
+#: ../src/html/htmlwin.cpp:723
+#, c-format
+msgid "HTML anchor %s does not exist."
+msgstr "Âncora HTML %s não existe."
+
+#: ../src/html/htmlwin.cpp:1057
+#, c-format
+msgid "Copied to clipboard:\"%s\""
+msgstr "Copiado para a área de transferência:\"%s\""
+
+#: ../src/html/htmprint.cpp:269
+msgid ""
+"This document doesn't fit on the page horizontally and will be truncated "
+"when it is printed."
+msgstr ""
+
+#: ../src/html/htmprint.cpp:285
+#, c-format
+msgid ""
+"The document \"%s\" doesn't fit on the page horizontally and will be "
+"truncated if printed.\n"
+"\n"
+"Would you like to proceed with printing it nevertheless?"
+msgstr ""
+
+#: ../src/html/htmprint.cpp:296
+msgid ""
+"If possible, try changing the layout parameters to make the printout more "
+"narrow."
+msgstr ""
+
+#: ../src/html/htmprint.cpp:445
+msgid ": file does not exist!"
+msgstr ": ficheiro inexistente!"
+
+#. TRANSLATORS: %s may be a document title.
+#: ../src/html/htmprint.cpp:717
+#, fuzzy, c-format
+msgid "%s Preview"
+msgstr " Antevisão"
+
+#: ../src/html/htmprint.cpp:755 ../src/richtext/richtextprint.cpp:618
+msgid ""
+"There was a problem during page setup: you may need to set a default printer."
+msgstr ""
+"Houve um problema durante a configuração da página: poderá necessitar de "
+"definir uma impressora pré-definida."
+
+#: ../src/msw/clipbrd.cpp:80
+msgid "Failed to open the clipboard."
+msgstr "Falha na abertura da área de transferência."
+
+#: ../src/msw/clipbrd.cpp:101
+msgid "Failed to close the clipboard."
+msgstr "Falha ao fechar a área de transferência."
+
+#: ../src/msw/clipbrd.cpp:113
+msgid "Failed to empty the clipboard."
+msgstr "Falha a limpar a área de transferência."
+
+#: ../src/msw/clipbrd.cpp:284
+msgid "Failed to put data on the clipboard"
+msgstr "Falha na inserção de dados na área de transferência"
+
+#: ../src/msw/clipbrd.cpp:326
+msgid "Failed to get data from the clipboard"
+msgstr "Falha na obtenção de dados da área de transferência"
+
+#: ../src/msw/clipbrd.cpp:363
+msgid "Failed to retrieve the supported clipboard formats"
+msgstr "Falha na obtenção dos formatos suportados pela área de transferência"
+
+#: ../src/msw/colordlg.cpp:228
+#, fuzzy, c-format
+msgid "Colour selection dialog failed with error %0lx."
+msgstr "Execução do comando '%s' terminou com o erro: %ul"
+
+#: ../src/msw/cursor.cpp:141
+msgid "Failed to create cursor."
+msgstr "Falha de criação de cursor."
+
+#: ../src/msw/dde.cpp:279
+#, c-format
+msgid "Failed to register DDE server '%s'"
+msgstr "Falha no registo do servidor DDE '%s'"
+
+#: ../src/msw/dde.cpp:300
+#, c-format
+msgid "Failed to unregister DDE server '%s'"
+msgstr "Falha ao desregistar servidor DDE '%s'"
+
+#: ../src/msw/dde.cpp:428
+#, c-format
+msgid "Failed to create connection to server '%s' on topic '%s'"
+msgstr "Falha ao criar ligação ao servidor '%s' no tópico '%s'"
+
+#: ../src/msw/dde.cpp:655
+msgid "DDE poke request failed"
+msgstr "Falhou o pedido de poke DDE"
+
+#: ../src/msw/dde.cpp:674
+msgid "Failed to establish an advise loop with DDE server"
+msgstr "Falha ao estabelecer um advise loop com o servidor DDE"
+
+#: ../src/msw/dde.cpp:693
+msgid "Failed to terminate the advise loop with DDE server"
+msgstr "Falha ao terminar o advise loop com o servidor DDE"
+
+#: ../src/msw/dde.cpp:768
+msgid "Failed to send DDE advise notification"
+msgstr "Falha ao enviar aviso de notificação DDE"
+
+#: ../src/msw/dde.cpp:1085
+msgid "Failed to create DDE string"
+msgstr "Falha ne criação da cadeia de caracteres DDE"
+
+#: ../src/msw/dde.cpp:1131
+msgid "no DDE error."
+msgstr "sem erro DDE."
+
+#: ../src/msw/dde.cpp:1135
+msgid "a request for a synchronous advise transaction has timed out."
+msgstr ""
+"um pedido para uma transacção de conselho síncrona excedeu o tempo limite."
+
+#: ../src/msw/dde.cpp:1138
+msgid "the response to the transaction caused the DDE_FBUSY bit to be set."
+msgstr "a resposta à transacção causou a definição do bit DDE_FBUSY."
+
+#: ../src/msw/dde.cpp:1141
+msgid "a request for a synchronous data transaction has timed out."
+msgstr ""
+"um pedido para uma transacção de dados síncrona excedeu o tempo limite."
+
+#: ../src/msw/dde.cpp:1144
+msgid ""
+"a DDEML function was called without first calling the DdeInitialize "
+"function,\n"
+"or an invalid instance identifier\n"
+"was passed to a DDEML function."
+msgstr ""
+"uma função DDEML foi chamada sem chamar primeiro a função DdeInitialize,\n"
+"ou um identificador inválido instância\n"
+"foi passado a uma função DDEML."
+
+#: ../src/msw/dde.cpp:1147
+msgid ""
+"an application initialized as APPCLASS_MONITOR has\n"
+"attempted to perform a DDE transaction,\n"
+"or an application initialized as APPCMD_CLIENTONLY has \n"
+"attempted to perform server transactions."
+msgstr ""
+"uma aplicação inicializada como APPCLASS_MONITOR tem\n"
+"tentado efectuar uma transacção DDE,\n"
+"ou uma aplicação inicaializada como APPCMD_CLIENTONLY tem\n"
+"tentado realizar transacções de servidor."
+
+#: ../src/msw/dde.cpp:1150
+msgid "a request for a synchronous execute transaction has timed out."
+msgstr ""
+"um pedido para uma transacção de execução síncrona excedeu o tempo limite."
+
+#: ../src/msw/dde.cpp:1153
+msgid "a parameter failed to be validated by the DDEML."
+msgstr "falhou a validação de um parâmetro pelo DDEML."
+
+#: ../src/msw/dde.cpp:1156
+msgid "a DDEML application has created a prolonged race condition."
+msgstr "uma aplicação DDEML criou uma condição de corrida prolongada."
+
+#: ../src/msw/dde.cpp:1159
+msgid "a memory allocation failed."
+msgstr "falhou uma alocação de memória."
+
+#: ../src/msw/dde.cpp:1162
+msgid "a client's attempt to establish a conversation has failed."
+msgstr ""
+"a tentativa por parte de um cliente de estabelecer uma conversação falhou."
+
+#: ../src/msw/dde.cpp:1165
+msgid "a transaction failed."
+msgstr "falhou uma transacção."
+
+#: ../src/msw/dde.cpp:1168
+msgid "a request for a synchronous poke transaction has timed out."
+msgstr ""
+"um pedido para uma transacção de 'poke' síncrona excedeu o tempo limite."
+
+#: ../src/msw/dde.cpp:1171
+msgid "an internal call to the PostMessage function has failed. "
+msgstr "falha numa chamada interna à função PostMessage. "
+
+#: ../src/msw/dde.cpp:1174
+msgid "reentrancy problem."
+msgstr "problema recursivo."
+
+#: ../src/msw/dde.cpp:1177
+msgid ""
+"a server-side transaction was attempted on a conversation\n"
+"that was terminated by the client, or the server\n"
+"terminated before completing a transaction."
+msgstr ""
+"foi tentada uma transacção do lado do servidor, numa conversação\n"
+"que foi terminada pelo cliente, ou o servidor\n"
+"terminou antes do fim da transacção."
+
+#: ../src/msw/dde.cpp:1180
+msgid "an internal error has occurred in the DDEML."
+msgstr "ocorreu um erro interno no DDEML."
+
+#: ../src/msw/dde.cpp:1183
+msgid "a request to end an advise transaction has timed out."
+msgstr ""
+"um pedido de término de uma transacção de conselho excedeu o tempo limite."
+
+#: ../src/msw/dde.cpp:1186
+msgid ""
+"an invalid transaction identifier was passed to a DDEML function.\n"
+"Once the application has returned from an XTYP_XACT_COMPLETE callback,\n"
+"the transaction identifier for that callback is no longer valid."
+msgstr ""
+"um identificador inválido de transacção foi passado a uma função DDEML.\n"
+"Uma vez que a aplicação retornou de uma chamada de um XTYP_XACT_COMPLETE,\n"
+"o identificador de transacção dessa chamada deixou de ser válido."
+
+#: ../src/msw/dde.cpp:1189
+#, c-format
+msgid "Unknown DDE error %08x"
+msgstr "Erro DDE desconhecido %08x"
+
+#: ../src/msw/dialup.cpp:343
+msgid ""
+"Dial up functions are unavailable because the remote access service (RAS) is "
+"not installed on this machine. Please install it."
+msgstr ""
+"Funções de ligação à telefónica não estão disponíveis, em virtude do serviço "
+"de acesso remoto (RAS) não estar instalado neste computador. Por favor "
+"Instale-o."
+
+#: ../src/msw/dialup.cpp:402
+#, fuzzy, c-format
+msgid ""
+"The version of remote access service (RAS) installed on this machine is too "
+"old, please upgrade (the following required function is missing: %s)."
+msgstr ""
+"A versão do serviço de acesso remoto (RAS) instalado nesta máquina é "
+"demasiado antigo, por favor atualize-o (as seguintes funções necessárias "
+"estão em falta: %s)."
+
+#: ../src/msw/dialup.cpp:437
+msgid "Failed to retrieve text of RAS error message"
+msgstr "Falha na obtenção do texto da mensagem de erro RAS"
+
+#: ../src/msw/dialup.cpp:440
+#, c-format
+msgid "unknown error (error code %08x)."
+msgstr "erro desconhecido ( código de erro %08x)."
+
+#: ../src/msw/dialup.cpp:492
+#, c-format
+msgid "Cannot find active dialup connection: %s"
+msgstr "Não foi possível encontrar a ligação telefónica ativa: %s"
+
+#: ../src/msw/dialup.cpp:513
+msgid "Several active dialup connections found, choosing one randomly."
+msgstr ""
+"Foram encontradas várias ligações telefónicas ativas, a escolher uma "
+"aleatoriamente."
+
+#: ../src/msw/dialup.cpp:598 ../src/msw/dialup.cpp:832
+#, c-format
+msgid "Failed to establish dialup connection: %s"
+msgstr "Falha ao estabelecer ligação telefónica: %s"
+
+#: ../src/msw/dialup.cpp:664
+#, c-format
+msgid "Failed to get ISP names: %s"
+msgstr "Falha ao obter nomes de ISP: %s"
+
+#: ../src/msw/dialup.cpp:712
+msgid "Failed to connect: no ISP to dial."
+msgstr "Falha na ligação: nenhum serviço ISP para marcar."
+
+#: ../src/msw/dialup.cpp:732
+msgid "Choose ISP to dial"
+msgstr "Escolha o ISP para marcar"
+
+#: ../src/msw/dialup.cpp:733
+msgid "Please choose which ISP do you want to connect to"
+msgstr "Por favor escolha ISP a que pretende ligar"
+
+#: ../src/msw/dialup.cpp:766
+msgid "Failed to connect: missing username/password."
+msgstr "Falha na ligação: falta nome de utilizador/palavra passe."
+
+#: ../src/msw/dialup.cpp:796
+msgid "Cannot find the location of address book file"
+msgstr ""
+"Não foi possível encontrar a localização do ficheiro do livro de endereços"
+
+#: ../src/msw/dialup.cpp:827
+#, fuzzy, c-format
+msgid "Failed to initiate dialup connection: %s"
+msgstr "Falha ao terminar a ligação telefónica: %s "
+
+#: ../src/msw/dialup.cpp:897
+msgid "Cannot hang up - no active dialup connection."
+msgstr "Não foi possível desligar - nenhuma ligação telefónica ativa."
+
+#: ../src/msw/dialup.cpp:907
+#, c-format
+msgid "Failed to terminate the dialup connection: %s"
+msgstr "Falha ao terminar a ligação telefónica: %s "
+
+#: ../src/msw/dib.cpp:313
+#, c-format
+msgid "Failed to save the bitmap image to file \"%s\"."
+msgstr "Falha ao gravar imagem de bitmap para ficheiro \"%s\"."
+
+#: ../src/msw/dib.cpp:543
+#, fuzzy, c-format
+msgid "Failed to allocate %luKb of memory for bitmap data."
+msgstr "Falha ao alocar %luKb de memória para dados bitmap."
+
+#: ../src/msw/dir.cpp:241
+#, c-format
+msgid "Cannot enumerate files in directory '%s'"
+msgstr "Não foi possível enumerar os ficheiros na diretoria '%s'"
+
+#: ../src/msw/dirdlg.cpp:368
+#, fuzzy
+msgid "Couldn't obtain folder name"
+msgstr "Não foi possível criar um temporizador"
+
+#: ../src/msw/dlmsw.cpp:163
+#, fuzzy, c-format
+msgid "(error %d: %s)"
+msgstr " (erro %ld: %s)"
+
+#: ../src/msw/dragimag.cpp:143 ../src/msw/dragimag.cpp:178
+#: ../src/msw/imaglist.cpp:309 ../src/msw/imaglist.cpp:331
+msgid "Couldn't add an image to the image list."
+msgstr "Não foi possível adicionar uma imagem à lista de imagens."
+
+#: ../src/msw/enhmeta.cpp:94
+#, c-format
+msgid "Failed to load metafile from file \"%s\"."
+msgstr "Falha na leitura de metafile do ficheiro \"%s\"."
+
+#: ../src/msw/fdrepdlg.cpp:412
+#, c-format
+msgid "Failed to create the standard find/replace dialog (error code %d)"
+msgstr ""
+"Falha a criar dialogo standard de procura/substitui (código de erro %d)"
+
+#: ../src/msw/filedlg.cpp:1241
+msgid "Access to the file system is not allowed from secure desktop."
+msgstr ""
+
+#: ../src/msw/filedlg.cpp:1242
+msgid "Security warning"
+msgstr ""
+
+#: ../src/msw/filedlg.cpp:1533
+#, fuzzy, c-format
+msgid "File dialog failed with error code %0lx."
+msgstr "Execução do comando '%s' terminou com o erro: %ul"
+
+#: ../src/msw/font.cpp:1120
+#, fuzzy, c-format
+msgid "Font file \"%s\" couldn't be loaded"
+msgstr "Não foi possível carregar o ficheiro."
+
+#: ../src/msw/fontdlg.cpp:220
+#, fuzzy, c-format
+msgid "Common dialog failed with error code %0lx."
+msgstr "Execução do comando '%s' terminou com o erro: %ul"
+
+#: ../src/msw/fswatcher.cpp:67
+#, fuzzy
+msgid "Ungraceful worker thread termination"
+msgstr "Não é possível esperar pela terminação da thread"
+
+#: ../src/msw/fswatcher.cpp:81
+#, fuzzy
+msgid "Unable to create IOCP worker thread"
+msgstr "Não foi possível criar TextEncodingConverter"
+
+#: ../src/msw/fswatcher.cpp:88
+msgid "Unable to start IOCP worker thread"
+msgstr ""
+
+#: ../src/msw/fswatcher.cpp:140
+msgid "Monitoring individual files for changes is not supported currently."
+msgstr ""
+
+#: ../src/msw/fswatcher.cpp:165
+#, fuzzy, c-format
+msgid "Unable to set up watch for '%s'"
+msgstr "Falha ao tocar no ficheiro '%s'"
+
+#: ../src/msw/fswatcher.cpp:466
+#, c-format
+msgid "Can't monitor non-existent directory \"%s\" for changes."
+msgstr ""
+"Não é possível monitorizar a diretoria inexistente \"%s\" para alterações."
+
+#: ../src/msw/glcanvas.cpp:577 ../src/unix/glx11.cpp:507
+msgid "OpenGL 3.0 or later is not supported by the OpenGL driver."
+msgstr ""
+
+#: ../src/msw/glcanvas.cpp:601 ../src/osx/glcanvas_osx.cpp:395
+#: ../src/unix/glegl.cpp:304 ../src/unix/glx11.cpp:553
+#, fuzzy
+msgid "Couldn't create OpenGL context"
+msgstr "Não foi possível criar um temporizador"
+
+#: ../src/msw/glcanvas.cpp:1294
+msgid "Failed to initialize OpenGL"
+msgstr "Falha ao inicializar o OpenGL"
+
+#: ../src/msw/graphicsd2d.cpp:607
+msgid "Could not register custom DirectWrite font loader."
+msgstr ""
+
+#: ../src/msw/helpchm.cpp:48
+msgid ""
+"MS HTML Help functions are unavailable because the MS HTML Help library is "
+"not installed on this machine. Please install it."
+msgstr ""
+"Funções de ajuda MS HTML não estão disponíveis devido à livraria de ajuda MS "
+"HTML não estar instalada neste computador. por favor instale-a."
+
+#: ../src/msw/helpchm.cpp:55
+msgid "Failed to initialize MS HTML Help."
+msgstr "Falha na inicialização da ajuda MS HTML."
+
+#: ../src/msw/iniconf.cpp:458
+#, c-format
+msgid "Can't delete the INI file '%s'"
+msgstr "Não é possível apagar o ficheiro INI '%s'"
+
+#: ../src/msw/listctrl.cpp:995
+#, c-format
+msgid "Couldn't retrieve information about list control item %d."
+msgstr ""
+"Não foi possível obter informação sobre o item da lista de controlo %d."
+
+#: ../src/msw/mdi.cpp:170 ../src/qt/mdi.cpp:253
+msgid "&Cascade"
+msgstr "&Cascata"
+
+#: ../src/msw/mdi.cpp:171
+msgid "Tile &Horizontally"
+msgstr "Dispor &Horizontalmente"
+
+#: ../src/msw/mdi.cpp:172
+msgid "Tile &Vertically"
+msgstr "Dispor &Verticalmente"
+
+#: ../src/msw/mdi.cpp:174
+msgid "&Arrange Icons"
+msgstr "&Organizar Ícones"
+
+#: ../src/msw/mdi.cpp:621
+msgid "Failed to create MDI parent frame."
+msgstr "Falha na criação da moldura MDI progenitora."
+
+#: ../src/msw/mimetype.cpp:234
+#, c-format
+msgid "Failed to create registry entry for '%s' files."
+msgstr "Falha de criação de entrada de registo para ficheiros '%s'."
+
+#: ../src/msw/ole/automtn.cpp:495
+#, fuzzy, c-format
+msgid "Failed to find CLSID of \"%s\""
+msgstr "Falha na abertura do ecrã \"%s\"."
+
+#: ../src/msw/ole/automtn.cpp:512
+#, fuzzy, c-format
+msgid "Failed to create an instance of \"%s\""
+msgstr "Falha de criação de directório \"%s\""
+
+#: ../src/msw/ole/automtn.cpp:552
+#, fuzzy, c-format
+msgid "Cannot get an active instance of \"%s\""
+msgstr "Não foi possível encontrar a ligação telefónica ativa: %s"
+
+#: ../src/msw/ole/automtn.cpp:564
+#, fuzzy, c-format
+msgid "Failed to get OLE automation interface for \"%s\""
+msgstr "Falha de criação de directório \"%s\""
+
+#: ../src/msw/ole/automtn.cpp:621
+msgid "Unknown name or named argument."
+msgstr ""
+
+#: ../src/msw/ole/automtn.cpp:625
+msgid "Incorrect number of arguments."
+msgstr "Número de argumentos incorretos."
+
+#: ../src/msw/ole/automtn.cpp:637
+#, fuzzy
+msgid "Unknown exception"
+msgstr "Opção desconhecida '%s'"
+
+#: ../src/msw/ole/automtn.cpp:642
+msgid "Method or property not found."
+msgstr "Método ou propriedade não encontrado."
+
+#: ../src/msw/ole/automtn.cpp:646
+msgid "Overflow while coercing argument values."
+msgstr ""
+
+#: ../src/msw/ole/automtn.cpp:650
+msgid "Object implementation does not support named arguments."
+msgstr ""
+
+#: ../src/msw/ole/automtn.cpp:654
+msgid "The locale ID is unknown."
+msgstr "A Id. do local é desconhecida."
+
+#: ../src/msw/ole/automtn.cpp:658
+msgid "Missing a required parameter."
+msgstr "Está em falta um parâmetro necessário."
+
+#: ../src/msw/ole/automtn.cpp:662
+#, fuzzy, c-format
+msgid "Argument %u not found."
+msgstr "Ficheiro de ajuda \"%s\" não encontrado."
+
+#: ../src/msw/ole/automtn.cpp:666
+#, c-format
+msgid "Type mismatch in argument %u."
+msgstr ""
+
+#: ../src/msw/ole/automtn.cpp:670
+msgid "The system cannot find the file specified."
+msgstr "O sistema não consegue encontrar o ficheiro indicado."
+
+#: ../src/msw/ole/automtn.cpp:674
+msgid "Class not registered."
+msgstr "Classe não registada."
+
+#: ../src/msw/ole/automtn.cpp:678
+#, fuzzy, c-format
+msgid "Unknown error %08x"
+msgstr "Erro DDE desconhecido %08x"
+
+#: ../src/msw/ole/automtn.cpp:682
+#, c-format
+msgid "OLE Automation error in %s: %s"
+msgstr ""
+
+#: ../src/msw/ole/dataobj.cpp:385
+#, c-format
+msgid "Couldn't register clipboard format '%s'."
+msgstr "Não foi possível registar o formato da área de transferência '%s'."
+
+#: ../src/msw/ole/dataobj.cpp:402
+#, c-format
+msgid "The clipboard format '%d' doesn't exist."
+msgstr "O formato da área de transferência '%d' não existe."
+
+#: ../src/msw/progdlg.cpp:1025
+msgid "Skip"
+msgstr "Saltar"
+
+#: ../src/msw/registry.cpp:141
+#, fuzzy, c-format
+msgid "unknown (%lu)"
+msgstr "desconhecido"
+
+#: ../src/msw/registry.cpp:409
+#, c-format
+msgid "Can't get info about registry key '%s'"
+msgstr "Não foi possível obter informação sobre a chave de registo '%s'"
+
+#: ../src/msw/registry.cpp:445
+#, c-format
+msgid "Can't open registry key '%s'"
+msgstr "Não foi possível abrir chave de registo '%s'"
+
+#: ../src/msw/registry.cpp:478
+#, c-format
+msgid "Can't create registry key '%s'"
+msgstr "Não foi possível criar a chave de registo '%s'"
+
+#: ../src/msw/registry.cpp:497
+#, c-format
+msgid "Can't close registry key '%s'"
+msgstr "Não foi possível fechar a chave de registo '%s'"
+
+#: ../src/msw/registry.cpp:512
+#, c-format
+msgid "Registry value '%s' already exists."
+msgstr "Valor de registo '%s' já existe."
+
+#: ../src/msw/registry.cpp:520
+#, c-format
+msgid "Failed to rename registry value '%s' to '%s'."
+msgstr "Falha ao renomear valor de registo de '%s' para '%s'."
+
+#: ../src/msw/registry.cpp:575
+#, c-format
+msgid "Can't copy values of unsupported type %d."
+msgstr "Não foi possível copiar valores do tipo %d não suportado."
+
+#: ../src/msw/registry.cpp:586
+#, c-format
+msgid "Registry key '%s' does not exist, cannot rename it."
+msgstr "Chave de registo '%s' não existe, impossível renomeá-la."
+
+#: ../src/msw/registry.cpp:617
+#, c-format
+msgid "Registry key '%s' already exists."
+msgstr "Chave de registo '%s' já existe."
+
+#: ../src/msw/registry.cpp:625
+#, c-format
+msgid "Failed to rename the registry key '%s' to '%s'."
+msgstr "Falha ao renomear a chave de registo de '%s' para '%s'."
+
+#: ../src/msw/registry.cpp:670
+#, c-format
+msgid "Failed to copy the registry subkey '%s' to '%s'."
+msgstr "Falha ao copiar a sub-chave de registo '%s' para '%s'."
+
+#: ../src/msw/registry.cpp:683
+#, c-format
+msgid "Failed to copy registry value '%s'"
+msgstr "Falha na cópia do valor do registo '%s'"
+
+#: ../src/msw/registry.cpp:692
+#, c-format
+msgid "Failed to copy the contents of registry key '%s' to '%s'."
+msgstr "Falha ao copiar os conteúdos da chave de registo '%s' para '%s'."
+
+#: ../src/msw/registry.cpp:718
+#, c-format
+msgid ""
+"Registry key '%s' is needed for normal system operation,\n"
+"deleting it will leave your system in unusable state:\n"
+"operation aborted."
+msgstr ""
+"A chave de registo '%s' é necessária para a operação normal do sistema,\n"
+"apagá-lo vai deixar o seu sistema num estado inutilizável:\n"
+"operação interrompida."
+
+#: ../src/msw/registry.cpp:754
+#, c-format
+msgid "Can't delete key '%s'"
+msgstr "Não é possível apagar a chave '%s'"
+
+#: ../src/msw/registry.cpp:782
+#, c-format
+msgid "Can't delete value '%s' from key '%s'"
+msgstr "Não é possível apagar valor '%s' da chave '%s'"
+
+#: ../src/msw/registry.cpp:855 ../src/msw/registry.cpp:887
+#: ../src/msw/registry.cpp:929 ../src/msw/registry.cpp:1000
+#, c-format
+msgid "Can't read value of key '%s'"
+msgstr "Não foi possível ler valor da chave '%s'"
+
+#: ../src/msw/registry.cpp:873 ../src/msw/registry.cpp:915
+#: ../src/msw/registry.cpp:963 ../src/msw/registry.cpp:1106
+#, c-format
+msgid "Can't set value of '%s'"
+msgstr "Não foi possível definir valor de '%s'"
+
+#: ../src/msw/registry.cpp:894 ../src/msw/registry.cpp:943
+#, c-format
+msgid "Registry value \"%s\" is not numeric (but of type %s)"
+msgstr ""
+
+#: ../src/msw/registry.cpp:979
+#, c-format
+msgid "Registry value \"%s\" is not binary (but of type %s)"
+msgstr ""
+
+#: ../src/msw/registry.cpp:1028
+#, c-format
+msgid "Registry value \"%s\" is not text (but of type %s)"
+msgstr ""
+
+#: ../src/msw/registry.cpp:1089
+#, c-format
+msgid "Can't read value of '%s'"
+msgstr "Não foi possível ler valor de '%s'"
+
+#: ../src/msw/registry.cpp:1157
+#, c-format
+msgid "Can't enumerate values of key '%s'"
+msgstr "Não é possível enumerar os valores da chave '%s'"
+
+#: ../src/msw/registry.cpp:1196
+#, c-format
+msgid "Can't enumerate subkeys of key '%s'"
+msgstr "Não é possível enumerar as sub-chaves da chave '%s'"
+
+#: ../src/msw/registry.cpp:1262
+#, c-format
+msgid ""
+"Exporting registry key: file \"%s\" already exists and won't be overwritten."
+msgstr ""
+"Exportação da chave de registo: o ficheiro \"%s\" já existe e não vai ser "
+"sobreposto."
+
+#: ../src/msw/registry.cpp:1411
+#, c-format
+msgid "Can't export value of unsupported type %d."
+msgstr "Não foi possível exportar valores de tipo %d não suportado."
+
+#: ../src/msw/registry.cpp:1427
+#, c-format
+msgid "Ignoring value \"%s\" of the key \"%s\"."
+msgstr "A ignorar valor \"%s\" da chave \"%s\"."
+
+#: ../src/msw/textctrl.cpp:596
+msgid ""
+"Impossible to create a rich edit control, using simple text control instead. "
+"Please reinstall riched32.dll"
+msgstr ""
+"Impossível criar um controlo de edição rico, alternativamente usar-se-á um "
+"controlo de texto simples. Por favor reinstale o riched32.dll"
+
+#: ../src/msw/thread.cpp:522 ../src/unix/threadpsx.cpp:850
+msgid "Cannot start thread: error writing TLS."
+msgstr "Não é possível iniciar a thread: erro ao escrever o TLS."
+
+#: ../src/msw/thread.cpp:613
+msgid "Can't set thread priority"
+msgstr "Não foi possível definir prioridade da thread"
+
+#: ../src/msw/thread.cpp:649
+msgid "Can't create thread"
+msgstr "Não é possível criar a thread"
+
+#: ../src/msw/thread.cpp:668
+msgid "Couldn't terminate thread"
+msgstr "Não foi possível terminar a thread"
+
+#: ../src/msw/thread.cpp:799
+msgid "Cannot wait for thread termination"
+msgstr "Não é possível esperar pela terminação da thread"
+
+#: ../src/msw/thread.cpp:873
+#, fuzzy, c-format
+msgid "Cannot suspend thread %lx"
+msgstr "Não é possível suspender a thread %x"
+
+#: ../src/msw/thread.cpp:903
+#, fuzzy, c-format
+msgid "Cannot resume thread %lx"
+msgstr "Não é possível retomar a thread %x"
+
+#: ../src/msw/thread.cpp:932
+msgid "Couldn't get the current thread pointer"
+msgstr "impossível obter o ponteiro atual da thread"
+
+#: ../src/msw/thread.cpp:1333
+msgid ""
+"Thread module initialization failed: impossible to allocate index in thread "
+"local storage"
+msgstr ""
+"Falhou a inicialização do módulo da thread: impossível alocar índice no "
+"armazenamento local da thread"
+
+#: ../src/msw/thread.cpp:1345
+msgid ""
+"Thread module initialization failed: cannot store value in thread local "
+"storage"
+msgstr ""
+"Falhou a inicialização do módulo da thread: não foi possível armazenar o "
+"valor no armazenamento local da thread"
+
+#: ../src/msw/timer.cpp:133
+msgid "Couldn't create a timer"
+msgstr "Não foi possível criar um temporizador"
+
+#: ../src/msw/utils.cpp:372
+msgid "can't find user's HOME, using current directory."
+msgstr ""
+"Não foi possível localizar a pasta pessoal do utilizador, a utilizar o "
+"directório atual."
+
+#: ../src/msw/utils.cpp:662
+#, c-format
+msgid "Failed to kill process %d"
+msgstr "Falha no encerramento do processo %d"
+
+#: ../src/msw/utils.cpp:986
+#, fuzzy, c-format
+msgid "Failed to load resource \"%s\"."
+msgstr "Falha na leitura de metafile do ficheiro \"%s\"."
+
+#: ../src/msw/utils.cpp:993
+#, fuzzy, c-format
+msgid "Failed to lock resource \"%s\"."
+msgstr "Falha no bloqueio do ficheiro de bloqueio '%s'"
+
+#. TRANSLATORS: MS Windows build number
+#: ../src/msw/utils.cpp:1209
+#, fuzzy, c-format
+msgid "build %lu"
+msgstr "Windows XP (build %lu"
+
+#: ../src/msw/utils.cpp:1218
+msgid ", 64-bit edition"
+msgstr ", edição 64 bits"
+
+#: ../src/msw/utilsexc.cpp:224
+msgid "Failed to create an anonymous pipe"
+msgstr "Falha ao criar pipeline anónimo"
+
+#: ../src/msw/utilsexc.cpp:697
+msgid "Failed to redirect the child process IO"
+msgstr "Falha no redireccionamento do processo filho ES"
+
+#: ../src/msw/utilsexc.cpp:870
+#, c-format
+msgid "Execution of command '%s' failed"
+msgstr "Falhou a execução do comando '%s'"
+
+#: ../src/msw/volume.cpp:337
+msgid "Failed to load mpr.dll."
+msgstr "Falha na abertura do mpr.dll."
+
+#: ../src/msw/volume.cpp:506
+#, c-format
+msgid "Cannot read typename from '%s'!"
+msgstr "Não foi possível ler tipo de nome de '%s'!"
+
+#: ../src/msw/volume.cpp:615
+#, c-format
+msgid "Cannot load icon from '%s'."
+msgstr "Não foi possível carregar ícone de '%s'."
+
+#: ../src/msw/webview_edge.cpp:285
+msgid "This program was compiled without support for setting Edge proxy."
+msgstr ""
+
+#: ../src/msw/webview_ie.cpp:1010
+msgid "Failed to find web view emulation level in the registry"
+msgstr ""
+
+#: ../src/msw/webview_ie.cpp:1019
+msgid "Failed to set web view to modern emulation level"
+msgstr ""
+
+#: ../src/msw/webview_ie.cpp:1027
+msgid "Failed to reset web view to standard emulation level"
+msgstr ""
+
+#: ../src/msw/webview_ie.cpp:1049
+msgid "Can't run JavaScript script without a valid HTML document"
+msgstr ""
+
+#: ../src/msw/webview_ie.cpp:1056
+#, fuzzy
+msgid "Can't get the JavaScript object"
+msgstr "Não foi possível definir prioridade da thread"
+
+#: ../src/msw/webview_ie.cpp:1070
+#, fuzzy
+msgid "failed to evaluate"
+msgstr "Falha ao executar '%s'\n"
+
+#: ../src/osx/cocoa/filedlg.mm:412
+#, fuzzy
+msgid "File type:"
+msgstr "Teletype"
+
+#: ../src/osx/cocoa/menu.mm:242
+#, fuzzy
+msgctxt "macOS menu name"
+msgid "Window"
+msgstr "&Janela"
+
+#: ../src/osx/cocoa/menu.mm:259
+#, fuzzy
+msgctxt "macOS menu name"
+msgid "Help"
+msgstr "Ajuda"
+
+#: ../src/osx/cocoa/menu.mm:298
+#, fuzzy
+msgctxt "macOS menu item"
+msgid "Minimize"
+msgstr "Mi&nimizar"
+
+#: ../src/osx/cocoa/menu.mm:303
+#, fuzzy
+msgctxt "macOS menu item"
+msgid "Zoom"
+msgstr "Ampl&iar"
+
+#: ../src/osx/cocoa/menu.mm:309
+msgctxt "macOS menu item"
+msgid "Bring All to Front"
+msgstr ""
+
+#: ../src/osx/core/sound.cpp:143
+#, fuzzy, c-format
+msgid "Failed to load sound from \"%s\" (error %d)."
+msgstr "Falha na leitura de metafile do ficheiro \"%s\"."
+
+#: ../src/osx/fontutil.cpp:80
+#, fuzzy, c-format
+msgid "Font file \"%s\" doesn't exist."
+msgstr "Ficheiro %s não existe."
+
+#: ../src/osx/fontutil.cpp:88
+#, c-format
+msgid ""
+"Font file \"%s\" cannot be used as it is not inside the font directory "
+"\"%s\"."
+msgstr ""
+
+#: ../src/osx/menu_osx.cpp:496
+#, c-format
+msgctxt "macOS menu item"
+msgid "About %s"
+msgstr "Sobre o %s"
+
+#: ../src/osx/menu_osx.cpp:499
+#, fuzzy
+msgctxt "macOS menu item"
+msgid "About..."
+msgstr "&Sobre o ..."
+
+#: ../src/osx/menu_osx.cpp:508
+#, fuzzy
+msgctxt "macOS menu item"
+msgid "Preferences..."
+msgstr "&Preferências"
+
+#: ../src/osx/menu_osx.cpp:512
+msgctxt "macOS menu item"
+msgid "Services"
+msgstr ""
+
+#: ../src/osx/menu_osx.cpp:519
+#, c-format
+msgctxt "macOS menu item"
+msgid "Hide %s"
+msgstr "Ocultar %s"
+
+#: ../src/osx/menu_osx.cpp:522
+#, fuzzy
+msgctxt "macOS menu item"
+msgid "Hide Application"
+msgstr "Aplicação"
+
+#: ../src/osx/menu_osx.cpp:526
+msgctxt "macOS menu item"
+msgid "Hide Others"
+msgstr "Ocultar Outros"
+
+#: ../src/osx/menu_osx.cpp:528
+msgctxt "macOS menu item"
+msgid "Show All"
+msgstr "Mostrar Tudo"
+
+#: ../src/osx/menu_osx.cpp:534
+#, fuzzy, c-format
+msgctxt "macOS menu item"
+msgid "Quit %s"
+msgstr "&Desistir"
+
+#: ../src/osx/menu_osx.cpp:537
+#, fuzzy
+msgctxt "macOS menu item"
+msgid "Quit Application"
+msgstr "Aplicação"
+
+#: ../src/osx/webview_webkit.mm:444
+#, fuzzy
+msgid "Printing is not supported by the system web control"
+msgstr "Gzip não suportado nesta versão do zlib"
+
+#: ../src/osx/webview_webkit.mm:453
+#, fuzzy
+msgid "Print operation could not be initialized"
+msgstr "Não foi possível inicializar o ecrã."
+
+#. TRANSLATORS: Label of font point size
+#: ../src/propgrid/advprops.cpp:605
+#, fuzzy
+msgid "Point Size"
+msgstr "Tamanho do &ponto:"
+
+#. TRANSLATORS: Label of font face name
+#: ../src/propgrid/advprops.cpp:615
+#, fuzzy
+msgid "Face Name"
+msgstr "NovoNome"
+
+#. TRANSLATORS: Label of font style
+#: ../src/propgrid/advprops.cpp:623 ../src/richtext/richtextformatdlg.cpp:331
+msgid "Style"
+msgstr "Estilo"
+
+#. TRANSLATORS: Label of font weight
+#: ../src/propgrid/advprops.cpp:628
+#, fuzzy
+msgid "Weight"
+msgstr "&Peso:"
+
+#. TRANSLATORS: Label of underlined font
+#: ../src/propgrid/advprops.cpp:633 ../src/richtext/richtextfontpage.cpp:358
+msgid "Underlined"
+msgstr "Sublinhado"
+
+#. TRANSLATORS: Label of font family
+#: ../src/propgrid/advprops.cpp:637
+msgid "Family"
+msgstr "Família"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:801
+msgid "AppWorkspace"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:802
+#, fuzzy
+msgid "ActiveBorder"
+msgstr "Margem"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:803
+msgid "ActiveCaption"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:804
+msgid "ButtonFace"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:805
+msgid "ButtonHighlight"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:806
+msgid "ButtonShadow"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:807
+msgid "ButtonText"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:808
+msgid "CaptionText"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:809
+msgid "ControlDark"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:810
+msgid "ControlLight"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:812
+msgid "GrayText"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:813
+#, fuzzy
+msgid "Highlight"
+msgstr "leve"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:814
+#, fuzzy
+msgid "HighlightText"
+msgstr "Alinhar texto à direita."
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:815
+#, fuzzy
+msgid "InactiveBorder"
+msgstr "Margem"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:816
+msgid "InactiveCaption"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:817
+msgid "InactiveCaptionText"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:818
+msgid "Menu"
+msgstr "Menu"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:819
+msgid "Scrollbar"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:820
+msgid "Tooltip"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:821
+msgid "TooltipText"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:822
+#, fuzzy
+msgid "Window"
+msgstr "&Janela"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:823
+#, fuzzy
+msgid "WindowFrame"
+msgstr "&Janela"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:824
+#, fuzzy
+msgid "WindowText"
+msgstr "&Janela"
+
+#. TRANSLATORS: Custom colour choice entry
+#: ../src/propgrid/advprops.cpp:825 ../src/propgrid/advprops.cpp:1532
+#: ../src/propgrid/advprops.cpp:1576
+#, fuzzy
+msgid "Custom"
+msgstr "Tamanho Personalizado"
+
+#: ../src/propgrid/advprops.cpp:1558
+msgid "Black"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1559
+msgid "Maroon"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1560
+msgid "Navy"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1561
+msgid "Purple"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1562
+msgid "Teal"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1563
+msgid "Gray"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1564
+msgid "Green"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1565
+msgid "Olive"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1566
+#, fuzzy
+msgid "Brown"
+msgstr "Explorar"
+
+#: ../src/propgrid/advprops.cpp:1567
+msgid "Blue"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1568
+msgid "Fuchsia"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1569
+#, fuzzy
+msgid "Red"
+msgstr "&Refazer"
+
+#: ../src/propgrid/advprops.cpp:1570
+msgid "Orange"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1571
+msgid "Silver"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1572
+msgid "Lime"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1573
+msgid "Aqua"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1574
+msgid "Yellow"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1575
+msgid "White"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1718
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Default"
+msgstr "pré-definição"
+
+#: ../src/propgrid/advprops.cpp:1719
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Arrow"
+msgstr "amanhã"
+
+#: ../src/propgrid/advprops.cpp:1720
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Right Arrow"
+msgstr "Direita"
+
+#: ../src/propgrid/advprops.cpp:1721
+msgctxt "system cursor name"
+msgid "Blank"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1722
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Bullseye"
+msgstr "Estilo de marcador"
+
+#: ../src/propgrid/advprops.cpp:1723
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Character"
+msgstr "Código de &Caracter:"
+
+#: ../src/propgrid/advprops.cpp:1724
+msgctxt "system cursor name"
+msgid "Cross"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1725
+msgctxt "system cursor name"
+msgid "Hand"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1726
+msgctxt "system cursor name"
+msgid "I-Beam"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1727
+msgctxt "system cursor name"
+msgid "Left Button"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1728
+msgctxt "system cursor name"
+msgid "Magnifier"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1729
+msgctxt "system cursor name"
+msgid "Middle Button"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1730
+msgctxt "system cursor name"
+msgid "No Entry"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1731
+msgctxt "system cursor name"
+msgid "Paint Brush"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1732
+msgctxt "system cursor name"
+msgid "Pencil"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1733
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Point Left"
+msgstr "Tamanho do &ponto:"
+
+#: ../src/propgrid/advprops.cpp:1734
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Point Right"
+msgstr "Alinhar à Direita"
+
+#: ../src/propgrid/advprops.cpp:1735
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Question Arrow"
+msgstr "Pergunta"
+
+#: ../src/propgrid/advprops.cpp:1736
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Right Button"
+msgstr "Direita"
+
+#: ../src/propgrid/advprops.cpp:1737
+msgctxt "system cursor name"
+msgid "Sizing NE-SW"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1738
+msgctxt "system cursor name"
+msgid "Sizing N-S"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1739
+msgctxt "system cursor name"
+msgid "Sizing NW-SE"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1740
+msgctxt "system cursor name"
+msgid "Sizing W-E"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1741
+msgctxt "system cursor name"
+msgid "Sizing"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1742
+msgctxt "system cursor name"
+msgid "Spraycan"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1743
+msgctxt "system cursor name"
+msgid "Wait"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1744
+msgctxt "system cursor name"
+msgid "Watch"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1745
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Wait Arrow"
+msgstr "Direita"
+
+#: ../src/propgrid/advprops.cpp:2109
+#, fuzzy
+msgid "Make a selection:"
+msgstr "Colar selecção"
+
+#: ../src/propgrid/manager.cpp:394
+#, fuzzy
+msgid "Property"
+msgstr "&Propriedades"
+
+#: ../src/propgrid/manager.cpp:395
+msgid "Value"
+msgstr "Valor"
+
+#: ../src/propgrid/manager.cpp:1683
+msgid "Categorized Mode"
+msgstr ""
+
+#: ../src/propgrid/manager.cpp:1709
+msgid "Alphabetic Mode"
+msgstr "Modo Alfabético"
+
+#. TRANSLATORS: Name of Boolean false value
+#: ../src/propgrid/propgrid.cpp:230
+msgid "False"
+msgstr "Falso"
+
+#. TRANSLATORS: Name of Boolean true value
+#: ../src/propgrid/propgrid.cpp:232
+msgid "True"
+msgstr "Verdadeiro"
+
+#. TRANSLATORS: Text  displayed for unspecified value
+#: ../src/propgrid/propgrid.cpp:428
+#, fuzzy
+msgid "Unspecified"
+msgstr "Justificado"
+
+#. TRANSLATORS: Caption of message box displaying any property error
+#: ../src/propgrid/propgrid.cpp:3145 ../src/propgrid/propgrid.cpp:3282
+#, fuzzy
+msgid "Property Error"
+msgstr "Erro de Impressão"
+
+#: ../src/propgrid/propgrid.cpp:3259
+msgid "You have entered invalid value. Press ESC to cancel editing."
+msgstr "Inseriu um valor inválido. Pressione ESC para cancelar a edição."
+
+#: ../src/propgrid/propgrid.cpp:6608
+#, c-format
+msgid "Error in resource: %s"
+msgstr ""
+
+#: ../src/propgrid/propgridiface.cpp:377
+#, c-format
+msgid ""
+"Type operation \"%s\" failed: Property labeled \"%s\" is of type \"%s\", NOT "
+"\"%s\"."
+msgstr ""
+
+#: ../src/propgrid/props.cpp:159
+#, c-format
+msgid "Unknown base %d. Base 10 will be used."
+msgstr ""
+
+#: ../src/propgrid/props.cpp:324
+#, c-format
+msgid "Value must be %s or higher."
+msgstr "O valor deve ser %s ou superior."
+
+#: ../src/propgrid/props.cpp:329 ../src/propgrid/props.cpp:356
+#, fuzzy, c-format
+msgid "Value must be between %s and %s."
+msgstr "Introduza um número de página entre %d e %d:"
+
+#: ../src/propgrid/props.cpp:351
+#, c-format
+msgid "Value must be %s or less."
+msgstr "O valor deve ser %s ou inferior."
+
+#: ../src/propgrid/props.cpp:1058
+#, fuzzy, c-format
+msgid "Not %s"
+msgstr "Não %s"
+
+#: ../src/propgrid/props.cpp:1770
+#, fuzzy
+msgid "Choose a directory:"
+msgstr "Criar directório"
+
+#: ../src/propgrid/props.cpp:2055
+msgid "Choose a file"
+msgstr "Escolher um ficheiro"
+
+#: ../src/qt/mdi.cpp:254
+msgid "&Tile"
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:147
+#: ../src/richtext/richtextformatdlg.cpp:376
+msgid "Background"
+msgstr "Fundo"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:159
+msgid "Background &colour:"
+msgstr "Cor de Fundo:"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:161
+#: ../src/richtext/richtextbackgroundpage.cpp:163
+#, fuzzy
+msgid "Enables a background colour."
+msgstr "Cor de fundo"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:167
+#: ../src/richtext/richtextbackgroundpage.cpp:169
+#, fuzzy
+msgid "The background colour."
+msgstr "Cor de fundo"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:178
+msgid "Shadow"
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:193
+msgid "Use &shadow"
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:195
+#: ../src/richtext/richtextbackgroundpage.cpp:197
+#, fuzzy
+msgid "Enables a shadow."
+msgstr "Cor de fundo"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:211
+msgid "&Horizontal offset:"
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:218
+#: ../src/richtext/richtextbackgroundpage.cpp:220
+#, fuzzy
+msgid "The horizontal offset."
+msgstr "Dispor &Horizontalmente"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:224
+#: ../src/richtext/richtextbackgroundpage.cpp:227
+#: ../src/richtext/richtextbackgroundpage.cpp:228
+#: ../src/richtext/richtextbackgroundpage.cpp:247
+#: ../src/richtext/richtextbackgroundpage.cpp:250
+#: ../src/richtext/richtextbackgroundpage.cpp:251
+#: ../src/richtext/richtextbackgroundpage.cpp:287
+#: ../src/richtext/richtextbackgroundpage.cpp:290
+#: ../src/richtext/richtextbackgroundpage.cpp:291
+#: ../src/richtext/richtextbackgroundpage.cpp:314
+#: ../src/richtext/richtextbackgroundpage.cpp:317
+#: ../src/richtext/richtextbackgroundpage.cpp:318
+#: ../src/richtext/richtextborderspage.cpp:252
+#: ../src/richtext/richtextborderspage.cpp:255
+#: ../src/richtext/richtextborderspage.cpp:256
+#: ../src/richtext/richtextborderspage.cpp:286
+#: ../src/richtext/richtextborderspage.cpp:289
+#: ../src/richtext/richtextborderspage.cpp:290
+#: ../src/richtext/richtextborderspage.cpp:320
+#: ../src/richtext/richtextborderspage.cpp:323
+#: ../src/richtext/richtextborderspage.cpp:324
+#: ../src/richtext/richtextborderspage.cpp:354
+#: ../src/richtext/richtextborderspage.cpp:357
+#: ../src/richtext/richtextborderspage.cpp:358
+#: ../src/richtext/richtextborderspage.cpp:420
+#: ../src/richtext/richtextborderspage.cpp:423
+#: ../src/richtext/richtextborderspage.cpp:424
+#: ../src/richtext/richtextborderspage.cpp:454
+#: ../src/richtext/richtextborderspage.cpp:457
+#: ../src/richtext/richtextborderspage.cpp:458
+#: ../src/richtext/richtextborderspage.cpp:488
+#: ../src/richtext/richtextborderspage.cpp:491
+#: ../src/richtext/richtextborderspage.cpp:492
+#: ../src/richtext/richtextborderspage.cpp:522
+#: ../src/richtext/richtextborderspage.cpp:525
+#: ../src/richtext/richtextborderspage.cpp:526
+#: ../src/richtext/richtextborderspage.cpp:590
+#: ../src/richtext/richtextborderspage.cpp:593
+#: ../src/richtext/richtextborderspage.cpp:594
+#: ../src/richtext/richtextfontpage.cpp:177
+#: ../src/richtext/richtextmarginspage.cpp:199
+#: ../src/richtext/richtextmarginspage.cpp:201
+#: ../src/richtext/richtextmarginspage.cpp:202
+#: ../src/richtext/richtextmarginspage.cpp:224
+#: ../src/richtext/richtextmarginspage.cpp:226
+#: ../src/richtext/richtextmarginspage.cpp:227
+#: ../src/richtext/richtextmarginspage.cpp:247
+#: ../src/richtext/richtextmarginspage.cpp:249
+#: ../src/richtext/richtextmarginspage.cpp:250
+#: ../src/richtext/richtextmarginspage.cpp:272
+#: ../src/richtext/richtextmarginspage.cpp:274
+#: ../src/richtext/richtextmarginspage.cpp:275
+#: ../src/richtext/richtextmarginspage.cpp:313
+#: ../src/richtext/richtextmarginspage.cpp:315
+#: ../src/richtext/richtextmarginspage.cpp:316
+#: ../src/richtext/richtextmarginspage.cpp:338
+#: ../src/richtext/richtextmarginspage.cpp:340
+#: ../src/richtext/richtextmarginspage.cpp:341
+#: ../src/richtext/richtextmarginspage.cpp:361
+#: ../src/richtext/richtextmarginspage.cpp:363
+#: ../src/richtext/richtextmarginspage.cpp:364
+#: ../src/richtext/richtextmarginspage.cpp:386
+#: ../src/richtext/richtextmarginspage.cpp:388
+#: ../src/richtext/richtextmarginspage.cpp:389
+#: ../src/richtext/richtextsizepage.cpp:337
+#: ../src/richtext/richtextsizepage.cpp:340
+#: ../src/richtext/richtextsizepage.cpp:341
+#: ../src/richtext/richtextsizepage.cpp:371
+#: ../src/richtext/richtextsizepage.cpp:374
+#: ../src/richtext/richtextsizepage.cpp:375
+#: ../src/richtext/richtextsizepage.cpp:398
+#: ../src/richtext/richtextsizepage.cpp:401
+#: ../src/richtext/richtextsizepage.cpp:402
+#: ../src/richtext/richtextsizepage.cpp:425
+#: ../src/richtext/richtextsizepage.cpp:428
+#: ../src/richtext/richtextsizepage.cpp:429
+#: ../src/richtext/richtextsizepage.cpp:452
+#: ../src/richtext/richtextsizepage.cpp:455
+#: ../src/richtext/richtextsizepage.cpp:456
+#: ../src/richtext/richtextsizepage.cpp:479
+#: ../src/richtext/richtextsizepage.cpp:482
+#: ../src/richtext/richtextsizepage.cpp:483
+#: ../src/richtext/richtextsizepage.cpp:553
+#: ../src/richtext/richtextsizepage.cpp:556
+#: ../src/richtext/richtextsizepage.cpp:557
+#: ../src/richtext/richtextsizepage.cpp:588
+#: ../src/richtext/richtextsizepage.cpp:591
+#: ../src/richtext/richtextsizepage.cpp:592
+#: ../src/richtext/richtextsizepage.cpp:623
+#: ../src/richtext/richtextsizepage.cpp:626
+#: ../src/richtext/richtextsizepage.cpp:627
+#: ../src/richtext/richtextsizepage.cpp:658
+#: ../src/richtext/richtextsizepage.cpp:661
+#: ../src/richtext/richtextsizepage.cpp:662
+msgid "px"
+msgstr "px"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:225
+#: ../src/richtext/richtextbackgroundpage.cpp:248
+#: ../src/richtext/richtextbackgroundpage.cpp:288
+#: ../src/richtext/richtextbackgroundpage.cpp:315
+#: ../src/richtext/richtextborderspage.cpp:253
+#: ../src/richtext/richtextborderspage.cpp:287
+#: ../src/richtext/richtextborderspage.cpp:321
+#: ../src/richtext/richtextborderspage.cpp:355
+#: ../src/richtext/richtextborderspage.cpp:421
+#: ../src/richtext/richtextborderspage.cpp:455
+#: ../src/richtext/richtextborderspage.cpp:489
+#: ../src/richtext/richtextborderspage.cpp:523
+#: ../src/richtext/richtextborderspage.cpp:591
+#: ../src/richtext/richtextmarginspage.cpp:200
+#: ../src/richtext/richtextmarginspage.cpp:225
+#: ../src/richtext/richtextmarginspage.cpp:248
+#: ../src/richtext/richtextmarginspage.cpp:273
+#: ../src/richtext/richtextmarginspage.cpp:314
+#: ../src/richtext/richtextmarginspage.cpp:339
+#: ../src/richtext/richtextmarginspage.cpp:362
+#: ../src/richtext/richtextmarginspage.cpp:387
+#: ../src/richtext/richtextsizepage.cpp:338
+#: ../src/richtext/richtextsizepage.cpp:372
+#: ../src/richtext/richtextsizepage.cpp:399
+#: ../src/richtext/richtextsizepage.cpp:426
+#: ../src/richtext/richtextsizepage.cpp:453
+#: ../src/richtext/richtextsizepage.cpp:480
+#: ../src/richtext/richtextsizepage.cpp:554
+#: ../src/richtext/richtextsizepage.cpp:589
+#: ../src/richtext/richtextsizepage.cpp:624
+#: ../src/richtext/richtextsizepage.cpp:659
+msgid "cm"
+msgstr "cm"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:226
+#: ../src/richtext/richtextbackgroundpage.cpp:249
+#: ../src/richtext/richtextbackgroundpage.cpp:289
+#: ../src/richtext/richtextbackgroundpage.cpp:316
+#: ../src/richtext/richtextborderspage.cpp:254
+#: ../src/richtext/richtextborderspage.cpp:288
+#: ../src/richtext/richtextborderspage.cpp:322
+#: ../src/richtext/richtextborderspage.cpp:356
+#: ../src/richtext/richtextborderspage.cpp:422
+#: ../src/richtext/richtextborderspage.cpp:456
+#: ../src/richtext/richtextborderspage.cpp:490
+#: ../src/richtext/richtextborderspage.cpp:524
+#: ../src/richtext/richtextborderspage.cpp:592
+#: ../src/richtext/richtextfontpage.cpp:176
+#: ../src/richtext/richtextfontpage.cpp:179
+msgid "pt"
+msgstr "pt"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:229
+#: ../src/richtext/richtextbackgroundpage.cpp:231
+#: ../src/richtext/richtextbackgroundpage.cpp:252
+#: ../src/richtext/richtextbackgroundpage.cpp:254
+#: ../src/richtext/richtextbackgroundpage.cpp:292
+#: ../src/richtext/richtextbackgroundpage.cpp:294
+#: ../src/richtext/richtextbackgroundpage.cpp:319
+#: ../src/richtext/richtextbackgroundpage.cpp:321
+#, fuzzy
+msgid "Units for this value."
+msgstr "Não é possível esperar pela terminação da thread."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:234
+#, fuzzy
+msgid "&Vertical offset:"
+msgstr "&Alinhamento Vertical:"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:241
+#: ../src/richtext/richtextbackgroundpage.cpp:243
+#, fuzzy
+msgid "The vertical offset."
+msgstr "Não foi possível inicia a impressão."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:257
+#, fuzzy
+msgid "Shadow c&olour:"
+msgstr "Escolher cor"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:259
+#: ../src/richtext/richtextbackgroundpage.cpp:261
+#, fuzzy
+msgid "Enables the shadow colour."
+msgstr "Cor de fundo"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:265
+#: ../src/richtext/richtextbackgroundpage.cpp:267
+#, fuzzy
+msgid "The shadow colour."
+msgstr "A cor da fonte."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:270
+msgid "Sh&adow spread:"
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:272
+#: ../src/richtext/richtextbackgroundpage.cpp:274
+msgid "Enables the shadow spread."
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:281
+#: ../src/richtext/richtextbackgroundpage.cpp:283
+msgid "The shadow spread."
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:297
+msgid "&Blur distance:"
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:299
+#: ../src/richtext/richtextbackgroundpage.cpp:301
+#, fuzzy
+msgid "Enables the blur distance."
+msgstr "Não foi possível inicia a impressão."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:308
+#: ../src/richtext/richtextbackgroundpage.cpp:310
+msgid "The shadow blur distance."
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:324
+msgid "Opaci&ty:"
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:326
+#: ../src/richtext/richtextbackgroundpage.cpp:328
+msgid "Enables the shadow opacity."
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:335
+#: ../src/richtext/richtextbackgroundpage.cpp:337
+msgid "The shadow opacity."
+msgstr ""
+
+#. TRANSLATORS: Rich text page units (percentage)
+#: ../src/richtext/richtextbackgroundpage.cpp:340
+#: ../src/richtext/richtextsizepage.cpp:339
+#: ../src/richtext/richtextsizepage.cpp:373
+#: ../src/richtext/richtextsizepage.cpp:400
+#: ../src/richtext/richtextsizepage.cpp:427
+#: ../src/richtext/richtextsizepage.cpp:454
+#: ../src/richtext/richtextsizepage.cpp:481
+#: ../src/richtext/richtextsizepage.cpp:555
+#: ../src/richtext/richtextsizepage.cpp:590
+#: ../src/richtext/richtextsizepage.cpp:625
+#: ../src/richtext/richtextsizepage.cpp:660
+#, fuzzy
+msgid "%"
+msgstr "%s B"
+
+#: ../src/richtext/richtextborderspage.cpp:229
+#: ../src/richtext/richtextborderspage.cpp:387
+msgid "Border"
+msgstr "Margem"
+
+#: ../src/richtext/richtextborderspage.cpp:242
+#: ../src/richtext/richtextborderspage.cpp:410
+#: ../src/richtext/richtextindentspage.cpp:194
+#: ../src/richtext/richtextliststylepage.cpp:384
+#: ../src/richtext/richtextmarginspage.cpp:185
+#: ../src/richtext/richtextmarginspage.cpp:299
+#: ../src/richtext/richtextsizepage.cpp:531
+#: ../src/richtext/richtextsizepage.cpp:538
+msgid "&Left:"
+msgstr "&Esquerda:"
+
+#: ../src/richtext/richtextborderspage.cpp:257
+#: ../src/richtext/richtextborderspage.cpp:259
+msgid "Units for the left border width."
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:266
+#: ../src/richtext/richtextborderspage.cpp:268
+#: ../src/richtext/richtextborderspage.cpp:300
+#: ../src/richtext/richtextborderspage.cpp:302
+#: ../src/richtext/richtextborderspage.cpp:334
+#: ../src/richtext/richtextborderspage.cpp:336
+#: ../src/richtext/richtextborderspage.cpp:368
+#: ../src/richtext/richtextborderspage.cpp:370
+#: ../src/richtext/richtextborderspage.cpp:434
+#: ../src/richtext/richtextborderspage.cpp:436
+#: ../src/richtext/richtextborderspage.cpp:468
+#: ../src/richtext/richtextborderspage.cpp:470
+#: ../src/richtext/richtextborderspage.cpp:502
+#: ../src/richtext/richtextborderspage.cpp:504
+#: ../src/richtext/richtextborderspage.cpp:536
+#: ../src/richtext/richtextborderspage.cpp:538
+#, fuzzy
+msgid "The border line style."
+msgstr "O estilo da fonte."
+
+#: ../src/richtext/richtextborderspage.cpp:276
+#: ../src/richtext/richtextborderspage.cpp:444
+#: ../src/richtext/richtextindentspage.cpp:212
+#: ../src/richtext/richtextliststylepage.cpp:402
+#: ../src/richtext/richtextmarginspage.cpp:210
+#: ../src/richtext/richtextmarginspage.cpp:324
+#: ../src/richtext/richtextsizepage.cpp:601
+#: ../src/richtext/richtextsizepage.cpp:608
+msgid "&Right:"
+msgstr "Di&reita:"
+
+#: ../src/richtext/richtextborderspage.cpp:291
+#: ../src/richtext/richtextborderspage.cpp:293
+msgid "Units for the right border width."
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:310
+#: ../src/richtext/richtextborderspage.cpp:478
+#: ../src/richtext/richtextmarginspage.cpp:233
+#: ../src/richtext/richtextmarginspage.cpp:347
+#: ../src/richtext/richtextsizepage.cpp:566
+#: ../src/richtext/richtextsizepage.cpp:573
+msgid "&Top:"
+msgstr "&Topo:"
+
+#: ../src/richtext/richtextborderspage.cpp:325
+#: ../src/richtext/richtextborderspage.cpp:327
+msgid "Units for the top border width."
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:344
+#: ../src/richtext/richtextborderspage.cpp:512
+#: ../src/richtext/richtextmarginspage.cpp:258
+#: ../src/richtext/richtextmarginspage.cpp:372
+#: ../src/richtext/richtextsizepage.cpp:636
+#: ../src/richtext/richtextsizepage.cpp:643
+msgid "&Bottom:"
+msgstr "&Base:"
+
+#: ../src/richtext/richtextborderspage.cpp:359
+#: ../src/richtext/richtextborderspage.cpp:361
+msgid "Units for the bottom border width."
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:380
+#: ../src/richtext/richtextborderspage.cpp:548
+msgid "&Synchronize values"
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:382
+#: ../src/richtext/richtextborderspage.cpp:384
+#: ../src/richtext/richtextborderspage.cpp:550
+#: ../src/richtext/richtextborderspage.cpp:552
+msgid "Check to edit all borders simultaneously."
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:397
+#: ../src/richtext/richtextborderspage.cpp:555
+#, fuzzy
+msgid "Outline"
+msgstr "&Contorno"
+
+#: ../src/richtext/richtextborderspage.cpp:425
+#: ../src/richtext/richtextborderspage.cpp:427
+msgid "Units for the left outline width."
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:459
+#: ../src/richtext/richtextborderspage.cpp:461
+msgid "Units for the right outline width."
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:493
+#: ../src/richtext/richtextborderspage.cpp:495
+msgid "Units for the top outline width."
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:527
+#: ../src/richtext/richtextborderspage.cpp:529
+msgid "Units for the bottom outline width."
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:565
+#: ../src/richtext/richtextborderspage.cpp:600
+msgid "Corner"
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:574
+msgid "Corner &radius:"
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:576
+#: ../src/richtext/richtextborderspage.cpp:578
+msgid "An optional corner radius for adding rounded corners."
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:584
+#: ../src/richtext/richtextborderspage.cpp:586
+msgid "The value of the corner radius."
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:595
+#: ../src/richtext/richtextborderspage.cpp:597
+#, fuzzy
+msgid "Units for the corner radius."
+msgstr "Não é possível esperar pela terminação da thread."
+
+#: ../src/richtext/richtextborderspage.cpp:609
+#: ../src/richtext/richtextsizepage.cpp:247
+#: ../src/richtext/richtextsizepage.cpp:251
+#, fuzzy
+msgid "None"
+msgstr "Nenhum"
+
+#: ../src/richtext/richtextborderspage.cpp:610
+#, fuzzy
+msgid "Solid"
+msgstr "Destacado"
+
+#: ../src/richtext/richtextborderspage.cpp:611
+#, fuzzy
+msgid "Dotted"
+msgstr "Feito"
+
+#: ../src/richtext/richtextborderspage.cpp:612
+msgid "Dashed"
+msgstr "Travessões"
+
+#: ../src/richtext/richtextborderspage.cpp:613
+msgid "Double"
+msgstr "Duplo"
+
+#: ../src/richtext/richtextborderspage.cpp:614
+msgid "Groove"
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:615
+#, fuzzy
+msgid "Ridge"
+msgstr "Direita"
+
+#: ../src/richtext/richtextborderspage.cpp:616
+#, fuzzy
+msgid "Inset"
+msgstr "Inserir"
+
+#: ../src/richtext/richtextborderspage.cpp:617
+msgid "Outset"
+msgstr ""
+
+#: ../src/richtext/richtextbuffer.cpp:3518
+msgid "Change Style"
+msgstr "Alterar Estilo"
+
+#: ../src/richtext/richtextbuffer.cpp:3701
+#, fuzzy
+msgid "Change Object Style"
+msgstr "Alterar Lista de Estilos"
+
+#: ../src/richtext/richtextbuffer.cpp:3974
+#: ../src/richtext/richtextbuffer.cpp:8174
+#, fuzzy
+msgid "Change Properties"
+msgstr "&Propriedades"
+
+#: ../src/richtext/richtextbuffer.cpp:4346
+msgid "Change List Style"
+msgstr "Alterar Lista de Estilos"
+
+#: ../src/richtext/richtextbuffer.cpp:4519
+msgid "Renumber List"
+msgstr "Renumerar Lista"
+
+#: ../src/richtext/richtextbuffer.cpp:7867
+#: ../src/richtext/richtextbuffer.cpp:7897
+#: ../src/richtext/richtextbuffer.cpp:7939
+#: ../src/richtext/richtextctrl.cpp:1279 ../src/richtext/richtextctrl.cpp:1473
+msgid "Insert Text"
+msgstr "Inserir Texto"
+
+#: ../src/richtext/richtextbuffer.cpp:8023
+#: ../src/richtext/richtextbuffer.cpp:8979
+msgid "Insert Image"
+msgstr "Inserir Imagem"
+
+#: ../src/richtext/richtextbuffer.cpp:8070
+#, fuzzy
+msgid "Insert Object"
+msgstr "Inserir Texto"
+
+#: ../src/richtext/richtextbuffer.cpp:8112
+#, fuzzy
+msgid "Insert Field"
+msgstr "Inserir Texto"
+
+#: ../src/richtext/richtextbuffer.cpp:8410
+msgid "Too many EndStyle calls!"
+msgstr "Demasiadas chamadas EndStyle!"
+
+#: ../src/richtext/richtextbuffer.cpp:8785
+msgid "files"
+msgstr "ficheiros"
+
+#: ../src/richtext/richtextbuffer.cpp:9380
+#, fuzzy
+msgid "standard/circle"
+msgstr "Standard"
+
+#: ../src/richtext/richtextbuffer.cpp:9381
+msgid "standard/circle-outline"
+msgstr ""
+
+#: ../src/richtext/richtextbuffer.cpp:9382
+#, fuzzy
+msgid "standard/square"
+msgstr "Standard"
+
+#: ../src/richtext/richtextbuffer.cpp:9383
+msgid "standard/diamond"
+msgstr ""
+
+#: ../src/richtext/richtextbuffer.cpp:9384
+msgid "standard/triangle"
+msgstr ""
+
+#: ../src/richtext/richtextbuffer.cpp:9423
+#, fuzzy
+msgid "Box Properties"
+msgstr "&Propriedades"
+
+#: ../src/richtext/richtextbuffer.cpp:10006
+msgid "Multiple Cell Properties"
+msgstr ""
+
+#: ../src/richtext/richtextbuffer.cpp:10008
+msgid "Cell Properties"
+msgstr "Propriedades da Célula"
+
+#: ../src/richtext/richtextbuffer.cpp:11256
+#, fuzzy
+msgid "Set Cell Style"
+msgstr "Apagar Estilo"
+
+#: ../src/richtext/richtextbuffer.cpp:11330
+msgid "Delete Row"
+msgstr "Apagar Fila"
+
+#: ../src/richtext/richtextbuffer.cpp:11380
+msgid "Delete Column"
+msgstr "Apagar Coluna"
+
+#: ../src/richtext/richtextbuffer.cpp:11431
+msgid "Add Row"
+msgstr "Adicionar Fila"
+
+#: ../src/richtext/richtextbuffer.cpp:11494
+msgid "Add Column"
+msgstr "Adicionar Coluna"
+
+#: ../src/richtext/richtextbuffer.cpp:11537
+#, fuzzy
+msgid "Table Properties"
+msgstr "&Propriedades"
+
+#: ../src/richtext/richtextbuffer.cpp:12899
+#, fuzzy
+msgid "Picture Properties"
+msgstr "&Propriedades"
+
+#: ../src/richtext/richtextbuffer.cpp:13169
+#: ../src/richtext/richtextbuffer.cpp:13279
+msgid "image"
+msgstr "imagem"
+
+#: ../src/richtext/richtextbulletspage.cpp:145
+#: ../src/richtext/richtextliststylepage.cpp:209
+msgid "&Bullet style:"
+msgstr "Estilo do &Marcador:"
+
+#: ../src/richtext/richtextbulletspage.cpp:150
+#: ../src/richtext/richtextbulletspage.cpp:152
+#: ../src/richtext/richtextliststylepage.cpp:214
+#: ../src/richtext/richtextliststylepage.cpp:216
+msgid "The available bullet styles."
+msgstr "Os estilos de marcador disponíveis."
+
+#: ../src/richtext/richtextbulletspage.cpp:158
+#: ../src/richtext/richtextliststylepage.cpp:221
+msgid "Peri&od"
+msgstr "Perí&odo"
+
+#: ../src/richtext/richtextbulletspage.cpp:160
+#: ../src/richtext/richtextbulletspage.cpp:162
+#: ../src/richtext/richtextliststylepage.cpp:223
+#: ../src/richtext/richtextliststylepage.cpp:225
+msgid "Check to add a period after the bullet."
+msgstr "Marcar para adicionar um ponto a seguir ao marcador."
+
+#. TRANSLATORS: Bullet point in parentheses option
+#: ../src/richtext/richtextbulletspage.cpp:167
+#: ../src/richtext/richtextliststylepage.cpp:230
+msgid "(*)"
+msgstr "(*)"
+
+#: ../src/richtext/richtextbulletspage.cpp:169
+#: ../src/richtext/richtextbulletspage.cpp:171
+#: ../src/richtext/richtextliststylepage.cpp:232
+#: ../src/richtext/richtextliststylepage.cpp:234
+msgid "Check to enclose the bullet in parentheses."
+msgstr "Marque para circundar o marcador entre parêntesis."
+
+#. TRANSLATORS: Right parenthesis bullet point option
+#: ../src/richtext/richtextbulletspage.cpp:176
+#: ../src/richtext/richtextliststylepage.cpp:239
+msgid "*)"
+msgstr "*)"
+
+#: ../src/richtext/richtextbulletspage.cpp:178
+#: ../src/richtext/richtextbulletspage.cpp:180
+#: ../src/richtext/richtextliststylepage.cpp:241
+#: ../src/richtext/richtextliststylepage.cpp:243
+msgid "Check to add a right parenthesis."
+msgstr "Marcar para adicionar um parêntesis à direita."
+
+#: ../src/richtext/richtextbulletspage.cpp:185
+#: ../src/richtext/richtextliststylepage.cpp:248
+msgid "Bullet &Alignment:"
+msgstr "&Alinhamento de Marcador:"
+
+#: ../src/richtext/richtextbulletspage.cpp:190
+#: ../src/richtext/richtextliststylepage.cpp:253
+msgid "Centre"
+msgstr "Centro"
+
+#: ../src/richtext/richtextbulletspage.cpp:194
+#: ../src/richtext/richtextbulletspage.cpp:196
+#: ../src/richtext/richtextbulletspage.cpp:217
+#: ../src/richtext/richtextbulletspage.cpp:219
+#: ../src/richtext/richtextliststylepage.cpp:257
+#: ../src/richtext/richtextliststylepage.cpp:259
+#: ../src/richtext/richtextliststylepage.cpp:278
+#: ../src/richtext/richtextliststylepage.cpp:280
+msgid "The bullet character."
+msgstr "O caracter do marcador."
+
+#: ../src/richtext/richtextbulletspage.cpp:212
+#: ../src/richtext/richtextliststylepage.cpp:271
+msgid "&Symbol:"
+msgstr "&Símbolo:"
+
+#: ../src/richtext/richtextbulletspage.cpp:222
+#: ../src/richtext/richtextliststylepage.cpp:283
+msgid "Ch&oose..."
+msgstr "Esc&olher..."
+
+#: ../src/richtext/richtextbulletspage.cpp:223
+#: ../src/richtext/richtextbulletspage.cpp:225
+#: ../src/richtext/richtextliststylepage.cpp:284
+#: ../src/richtext/richtextliststylepage.cpp:286
+msgid "Click to browse for a symbol."
+msgstr "Clique para procurar por um simbolo."
+
+#: ../src/richtext/richtextbulletspage.cpp:230
+#: ../src/richtext/richtextliststylepage.cpp:291
+msgid "Symbol &font:"
+msgstr "&Fonte Symbol:"
+
+#: ../src/richtext/richtextbulletspage.cpp:235
+#: ../src/richtext/richtextbulletspage.cpp:237
+#: ../src/richtext/richtextliststylepage.cpp:297
+msgid "Available fonts."
+msgstr "Fontes disponíveis."
+
+#: ../src/richtext/richtextbulletspage.cpp:242
+#: ../src/richtext/richtextliststylepage.cpp:302
+msgid "S&tandard bullet name:"
+msgstr "Nome de Marcador S&tandard:"
+
+#: ../src/richtext/richtextbulletspage.cpp:247
+#: ../src/richtext/richtextbulletspage.cpp:249
+#: ../src/richtext/richtextliststylepage.cpp:307
+#: ../src/richtext/richtextliststylepage.cpp:309
+msgid "A standard bullet name."
+msgstr "Um nome standard para o marcador."
+
+#: ../src/richtext/richtextbulletspage.cpp:254
+msgid "&Number:"
+msgstr "&Número:"
+
+#: ../src/richtext/richtextbulletspage.cpp:258
+#: ../src/richtext/richtextbulletspage.cpp:260
+msgid "The list item number."
+msgstr "O número de item da lista."
+
+#: ../src/richtext/richtextbulletspage.cpp:266
+#: ../src/richtext/richtextbulletspage.cpp:268
+#: ../src/richtext/richtextliststylepage.cpp:475
+#: ../src/richtext/richtextliststylepage.cpp:477
+msgid "Shows a preview of the bullet settings."
+msgstr "Mostra uma antevisão das definições de marcador."
+
+#: ../src/richtext/richtextbulletspage.cpp:276
+#: ../src/richtext/richtextliststylepage.cpp:484
+msgid "(None)"
+msgstr "(Nenhum)"
+
+#: ../src/richtext/richtextbulletspage.cpp:277
+#: ../src/richtext/richtextliststylepage.cpp:485
+msgid "Arabic"
+msgstr "Árabe"
+
+#: ../src/richtext/richtextbulletspage.cpp:278
+#: ../src/richtext/richtextliststylepage.cpp:486
+msgid "Upper case letters"
+msgstr "Letras maiúsculas"
+
+#: ../src/richtext/richtextbulletspage.cpp:279
+#: ../src/richtext/richtextliststylepage.cpp:487
+msgid "Lower case letters"
+msgstr "Letras minúsculas"
+
+#: ../src/richtext/richtextbulletspage.cpp:280
+#: ../src/richtext/richtextliststylepage.cpp:488
+msgid "Upper case roman numerals"
+msgstr "Números romanos em maiúsculas"
+
+#: ../src/richtext/richtextbulletspage.cpp:281
+#: ../src/richtext/richtextliststylepage.cpp:489
+msgid "Lower case roman numerals"
+msgstr "Números romanos em minúsculas"
+
+#: ../src/richtext/richtextbulletspage.cpp:282
+#: ../src/richtext/richtextliststylepage.cpp:490
+msgid "Numbered outline"
+msgstr "Contorno numerado"
+
+#: ../src/richtext/richtextbulletspage.cpp:283
+#: ../src/richtext/richtextliststylepage.cpp:491
+msgid "Symbol"
+msgstr "Symbol"
+
+#: ../src/richtext/richtextbulletspage.cpp:284
+#: ../src/richtext/richtextliststylepage.cpp:492
+msgid "Bitmap"
+msgstr "Bitmap"
+
+#: ../src/richtext/richtextbulletspage.cpp:285
+#: ../src/richtext/richtextliststylepage.cpp:493
+msgid "Standard"
+msgstr "Padrão"
+
+#: ../src/richtext/richtextbulletspage.cpp:287
+#: ../src/richtext/richtextliststylepage.cpp:495
+msgid "*"
+msgstr "*"
+
+#: ../src/richtext/richtextbulletspage.cpp:288
+#: ../src/richtext/richtextliststylepage.cpp:496
+msgid "-"
+msgstr "-"
+
+#: ../src/richtext/richtextbulletspage.cpp:289
+#: ../src/richtext/richtextliststylepage.cpp:497
+msgid ">"
+msgstr ">"
+
+#: ../src/richtext/richtextbulletspage.cpp:290
+#: ../src/richtext/richtextliststylepage.cpp:498
+msgid "+"
+msgstr "+"
+
+#: ../src/richtext/richtextbulletspage.cpp:291
+#: ../src/richtext/richtextliststylepage.cpp:499
+msgid "~"
+msgstr "~"
+
+#: ../src/richtext/richtextctrl.cpp:859
+msgid "Drag"
+msgstr "Arrastar"
+
+#: ../src/richtext/richtextctrl.cpp:1338 ../src/richtext/richtextctrl.cpp:1559
+msgid "Delete Text"
+msgstr "Apagar Texto"
+
+#: ../src/richtext/richtextctrl.cpp:1537
+#, fuzzy
+msgid "Remove Bullet"
+msgstr "Remover"
+
+#: ../src/richtext/richtextctrl.cpp:3070
+msgid "The text couldn't be saved."
+msgstr "O texto não pode ser gravado."
+
+#: ../src/richtext/richtextctrl.cpp:3644
+msgid "Replace"
+msgstr "Substituir"
+
+#: ../src/richtext/richtextfontpage.cpp:146
+#: ../src/richtext/richtextsymboldlg.cpp:384
+msgid "&Font:"
+msgstr "&Fonte:"
+
+#: ../src/richtext/richtextfontpage.cpp:150
+#: ../src/richtext/richtextfontpage.cpp:152
+msgid "Type a font name."
+msgstr "Escreva o nome da fonte."
+
+#: ../src/richtext/richtextfontpage.cpp:158
+msgid "&Size:"
+msgstr "&Tamanho:"
+
+#: ../src/richtext/richtextfontpage.cpp:165
+#: ../src/richtext/richtextfontpage.cpp:167
+msgid "Type a size in points."
+msgstr "Escreva um tamanho em pontos."
+
+#: ../src/richtext/richtextfontpage.cpp:180
+#: ../src/richtext/richtextfontpage.cpp:182
+#, fuzzy
+msgid "The font size units, points or pixels."
+msgstr "O tamanho da fonte em pontos."
+
+#: ../src/richtext/richtextfontpage.cpp:189
+#: ../src/richtext/richtextfontpage.cpp:191
+msgid "Lists the available fonts."
+msgstr "Lista as fontes disponíveis."
+
+#: ../src/richtext/richtextfontpage.cpp:196
+#: ../src/richtext/richtextfontpage.cpp:198
+msgid "Lists font sizes in points."
+msgstr "Lista o tamanho das fontes em pontos."
+
+#: ../src/richtext/richtextfontpage.cpp:207
+msgid "Font st&yle:"
+msgstr "Est&ilo da fonte:"
+
+#: ../src/richtext/richtextfontpage.cpp:212
+#: ../src/richtext/richtextfontpage.cpp:214
+msgid "Select regular or italic style."
+msgstr "Selecionar estilo normal ou itálico."
+
+#: ../src/richtext/richtextfontpage.cpp:220
+msgid "Font &weight:"
+msgstr "&Peso da fonte:"
+
+#: ../src/richtext/richtextfontpage.cpp:225
+#: ../src/richtext/richtextfontpage.cpp:227
+msgid "Select regular or bold."
+msgstr "Selecionar normal ou negrito."
+
+#: ../src/richtext/richtextfontpage.cpp:233
+msgid "&Underlining:"
+msgstr "S&ublinhar:"
+
+#: ../src/richtext/richtextfontpage.cpp:238
+#: ../src/richtext/richtextfontpage.cpp:240
+msgid "Select underlining or no underlining."
+msgstr "Selecionar sublinhado ou não sublinhado."
+
+#: ../src/richtext/richtextfontpage.cpp:248
+msgid "&Colour:"
+msgstr "&Cor:"
+
+#: ../src/richtext/richtextfontpage.cpp:253
+#: ../src/richtext/richtextfontpage.cpp:255
+msgid "Click to change the text colour."
+msgstr "Clique para alterar a cor do texto."
+
+#: ../src/richtext/richtextfontpage.cpp:261
+#, fuzzy
+msgid "&Bg colour:"
+msgstr "&Cor:"
+
+#: ../src/richtext/richtextfontpage.cpp:266
+#: ../src/richtext/richtextfontpage.cpp:268
+msgid "Click to change the text background colour."
+msgstr "Clique para alterar a cor de fundo do texto."
+
+#: ../src/richtext/richtextfontpage.cpp:276
+#: ../src/richtext/richtextfontpage.cpp:278
+#, fuzzy
+msgid "Check to show a line through the text."
+msgstr "Marcar para adicionar um ponto a seguir ao marcador."
+
+#: ../src/richtext/richtextfontpage.cpp:281
+msgid "Ca&pitals"
+msgstr "Maiúsculas"
+
+#: ../src/richtext/richtextfontpage.cpp:283
+#: ../src/richtext/richtextfontpage.cpp:285
+#, fuzzy
+msgid "Check to show the text in capitals."
+msgstr "Marque para tornar a letra itálica."
+
+#: ../src/richtext/richtextfontpage.cpp:288
+msgid "Small C&apitals"
+msgstr "&Minúsculas"
+
+#: ../src/richtext/richtextfontpage.cpp:290
+#: ../src/richtext/richtextfontpage.cpp:292
+#, fuzzy
+msgid "Check to show the text in small capitals."
+msgstr "Marque para tornar a letra itálica."
+
+#: ../src/richtext/richtextfontpage.cpp:295
+#, fuzzy
+msgid "Supe&rscript"
+msgstr "Ex&poente"
+
+#: ../src/richtext/richtextfontpage.cpp:297
+#: ../src/richtext/richtextfontpage.cpp:299
+#, fuzzy
+msgid "Check to show the text in superscript."
+msgstr "Marque para circundar o marcador entre parêntesis."
+
+#: ../src/richtext/richtextfontpage.cpp:302
+#, fuzzy
+msgid "Subscrip&t"
+msgstr "Subscri&to"
+
+#: ../src/richtext/richtextfontpage.cpp:304
+#: ../src/richtext/richtextfontpage.cpp:306
+#, fuzzy
+msgid "Check to show the text in subscript."
+msgstr "Clique para alterar a cor do texto."
+
+#: ../src/richtext/richtextfontpage.cpp:312
+msgid "Rig&ht-to-left"
+msgstr ""
+
+#: ../src/richtext/richtextfontpage.cpp:314
+#: ../src/richtext/richtextfontpage.cpp:316
+#, fuzzy
+msgid "Check to indicate right-to-left text layout."
+msgstr "Clique para alterar a cor do texto."
+
+#: ../src/richtext/richtextfontpage.cpp:319
+msgid "Suppress hyphe&nation"
+msgstr ""
+
+#: ../src/richtext/richtextfontpage.cpp:321
+#: ../src/richtext/richtextfontpage.cpp:323
+msgid "Check to suppress hyphenation."
+msgstr ""
+
+#: ../src/richtext/richtextfontpage.cpp:329
+#: ../src/richtext/richtextfontpage.cpp:331
+msgid "Shows a preview of the font settings."
+msgstr "Mostra uma antevisão das definições da fonte."
+
+#: ../src/richtext/richtextfontpage.cpp:348
+#: ../src/richtext/richtextfontpage.cpp:352
+#: ../src/richtext/richtextfontpage.cpp:356
+#: ../src/richtext/richtextformatdlg.cpp:873
+#: ../src/richtext/richtextindentspage.cpp:273
+#: ../src/richtext/richtextindentspage.cpp:285
+#: ../src/richtext/richtextindentspage.cpp:286
+#: ../src/richtext/richtextindentspage.cpp:310
+#: ../src/richtext/richtextindentspage.cpp:325
+#: ../src/richtext/richtextliststylepage.cpp:451
+#: ../src/richtext/richtextliststylepage.cpp:463
+#: ../src/richtext/richtextliststylepage.cpp:464
+msgid "(none)"
+msgstr "(nenhum)"
+
+#: ../src/richtext/richtextfontpage.cpp:349
+#: ../src/richtext/richtextfontpage.cpp:353
+msgid "Regular"
+msgstr "Regular"
+
+#: ../src/richtext/richtextfontpage.cpp:357
+msgid "Not underlined"
+msgstr "Não sublinhado"
+
+#: ../src/richtext/richtextformatdlg.cpp:341
+msgid "Indents && Spacing"
+msgstr "Indentações e Espaçamentos"
+
+#: ../src/richtext/richtextformatdlg.cpp:346
+msgid "Tabs"
+msgstr "Tabs"
+
+#: ../src/richtext/richtextformatdlg.cpp:351
+msgid "Bullets"
+msgstr "Marcadores"
+
+#: ../src/richtext/richtextformatdlg.cpp:356
+msgid "List Style"
+msgstr "Estilo da Lista"
+
+#: ../src/richtext/richtextformatdlg.cpp:366
+#: ../src/richtext/richtextmarginspage.cpp:170
+msgid "Margins"
+msgstr "Margens"
+
+#: ../src/richtext/richtextformatdlg.cpp:371
+msgid "Borders"
+msgstr "Margens"
+
+#: ../src/richtext/richtextformatdlg.cpp:765
+msgid "Colour"
+msgstr "Cor"
+
+#: ../src/richtext/richtextindentspage.cpp:127
+#: ../src/richtext/richtextliststylepage.cpp:322
+msgid "&Alignment"
+msgstr "&Alinhamento"
+
+#: ../src/richtext/richtextindentspage.cpp:138
+#: ../src/richtext/richtextliststylepage.cpp:331
+msgid "&Left"
+msgstr "&Esquerda"
+
+#: ../src/richtext/richtextindentspage.cpp:140
+#: ../src/richtext/richtextindentspage.cpp:142
+#: ../src/richtext/richtextliststylepage.cpp:333
+#: ../src/richtext/richtextliststylepage.cpp:335
+msgid "Left-align text."
+msgstr "Alinhar texto à esquerda."
+
+#: ../src/richtext/richtextindentspage.cpp:145
+#: ../src/richtext/richtextliststylepage.cpp:338
+msgid "&Right"
+msgstr "Di&reita"
+
+#: ../src/richtext/richtextindentspage.cpp:147
+#: ../src/richtext/richtextindentspage.cpp:149
+#: ../src/richtext/richtextliststylepage.cpp:340
+#: ../src/richtext/richtextliststylepage.cpp:342
+msgid "Right-align text."
+msgstr "Alinhar texto à direita."
+
+#: ../src/richtext/richtextindentspage.cpp:152
+#: ../src/richtext/richtextliststylepage.cpp:345
+msgid "&Justified"
+msgstr "&Justificado"
+
+#: ../src/richtext/richtextindentspage.cpp:154
+#: ../src/richtext/richtextindentspage.cpp:156
+#: ../src/richtext/richtextliststylepage.cpp:347
+#: ../src/richtext/richtextliststylepage.cpp:349
+msgid "Justify text left and right."
+msgstr "Justificar texto à esquerda e à direita."
+
+#: ../src/richtext/richtextindentspage.cpp:159
+#: ../src/richtext/richtextliststylepage.cpp:352
+msgid "Cen&tred"
+msgstr "Cen&trado"
+
+#: ../src/richtext/richtextindentspage.cpp:161
+#: ../src/richtext/richtextindentspage.cpp:163
+#: ../src/richtext/richtextliststylepage.cpp:354
+#: ../src/richtext/richtextliststylepage.cpp:356
+msgid "Centre text."
+msgstr "Centrar texto."
+
+#: ../src/richtext/richtextindentspage.cpp:166
+#: ../src/richtext/richtextliststylepage.cpp:359
+msgid "&Indeterminate"
+msgstr "&Indeterminado"
+
+#: ../src/richtext/richtextindentspage.cpp:168
+#: ../src/richtext/richtextindentspage.cpp:170
+#: ../src/richtext/richtextliststylepage.cpp:361
+#: ../src/richtext/richtextliststylepage.cpp:363
+msgid "Use the current alignment setting."
+msgstr "Utilizar a definição atual de alinhamento."
+
+#: ../src/richtext/richtextindentspage.cpp:183
+#: ../src/richtext/richtextliststylepage.cpp:375
+msgid "&Indentation (tenths of a mm)"
+msgstr "&Indentação (décimos de mm)"
+
+#: ../src/richtext/richtextindentspage.cpp:198
+#: ../src/richtext/richtextindentspage.cpp:200
+#: ../src/richtext/richtextliststylepage.cpp:388
+#: ../src/richtext/richtextliststylepage.cpp:390
+msgid "The left indent."
+msgstr "A indentação à esquerda."
+
+#: ../src/richtext/richtextindentspage.cpp:203
+#: ../src/richtext/richtextliststylepage.cpp:393
+msgid "Left (&first line):"
+msgstr "Esquerda (&primeira linha):"
+
+#: ../src/richtext/richtextindentspage.cpp:207
+#: ../src/richtext/richtextindentspage.cpp:209
+#: ../src/richtext/richtextliststylepage.cpp:397
+#: ../src/richtext/richtextliststylepage.cpp:399
+msgid "The first line indent."
+msgstr "A indentação da primeira linha."
+
+#: ../src/richtext/richtextindentspage.cpp:216
+#: ../src/richtext/richtextindentspage.cpp:218
+#: ../src/richtext/richtextliststylepage.cpp:406
+#: ../src/richtext/richtextliststylepage.cpp:408
+msgid "The right indent."
+msgstr "A indentação à direita."
+
+#: ../src/richtext/richtextindentspage.cpp:221
+#, fuzzy
+msgid "&Outline level:"
+msgstr "&Lista de nível:"
+
+#: ../src/richtext/richtextindentspage.cpp:226
+#: ../src/richtext/richtextindentspage.cpp:228
+#, fuzzy
+msgid "The outline level."
+msgstr "A antevisão do estilo."
+
+#: ../src/richtext/richtextindentspage.cpp:241
+#: ../src/richtext/richtextliststylepage.cpp:420
+msgid "&Spacing (tenths of a mm)"
+msgstr "E&spaçamento (décimos de mm)"
+
+#: ../src/richtext/richtextindentspage.cpp:252
+msgid "&Before a paragraph:"
+msgstr "&Antes de um parágrafo:"
+
+#: ../src/richtext/richtextindentspage.cpp:256
+#: ../src/richtext/richtextindentspage.cpp:258
+#: ../src/richtext/richtextliststylepage.cpp:433
+#: ../src/richtext/richtextliststylepage.cpp:435
+msgid "The spacing before the paragraph."
+msgstr "O espaçamento antes do parágrafo."
+
+#: ../src/richtext/richtextindentspage.cpp:261
+msgid "&After a paragraph:"
+msgstr "&Depois de um parágrafo:"
+
+#: ../src/richtext/richtextindentspage.cpp:266
+#: ../src/richtext/richtextliststylepage.cpp:442
+#: ../src/richtext/richtextliststylepage.cpp:444
+msgid "The spacing after the paragraph."
+msgstr "O espaçamento depois do parágrafo."
+
+#: ../src/richtext/richtextindentspage.cpp:269
+#, fuzzy
+msgid "L&ine spacing:"
+msgstr "Espaçamento de linhas:"
+
+#: ../src/richtext/richtextindentspage.cpp:274
+#: ../src/richtext/richtextliststylepage.cpp:452
+msgid "Single"
+msgstr "Único"
+
+#: ../src/richtext/richtextindentspage.cpp:275
+#: ../src/richtext/richtextliststylepage.cpp:453
+msgid "1.1"
+msgstr "1.1"
+
+#: ../src/richtext/richtextindentspage.cpp:276
+#: ../src/richtext/richtextliststylepage.cpp:454
+msgid "1.2"
+msgstr "1.2"
+
+#: ../src/richtext/richtextindentspage.cpp:277
+#: ../src/richtext/richtextliststylepage.cpp:455
+msgid "1.3"
+msgstr "1.3"
+
+#: ../src/richtext/richtextindentspage.cpp:278
+#: ../src/richtext/richtextliststylepage.cpp:456
+msgid "1.4"
+msgstr "1.4"
+
+#: ../src/richtext/richtextindentspage.cpp:279
+#: ../src/richtext/richtextliststylepage.cpp:457
+msgid "1.5"
+msgstr "1.5"
+
+#: ../src/richtext/richtextindentspage.cpp:280
+#: ../src/richtext/richtextliststylepage.cpp:458
+msgid "1.6"
+msgstr "1.6"
+
+#: ../src/richtext/richtextindentspage.cpp:281
+#: ../src/richtext/richtextliststylepage.cpp:459
+msgid "1.7"
+msgstr "1.7"
+
+#: ../src/richtext/richtextindentspage.cpp:282
+#: ../src/richtext/richtextliststylepage.cpp:460
+msgid "1.8"
+msgstr "1.8"
+
+#: ../src/richtext/richtextindentspage.cpp:283
+#: ../src/richtext/richtextliststylepage.cpp:461
+msgid "1.9"
+msgstr "1.9"
+
+#: ../src/richtext/richtextindentspage.cpp:284
+#: ../src/richtext/richtextliststylepage.cpp:462
+msgid "2"
+msgstr "2"
+
+#: ../src/richtext/richtextindentspage.cpp:287
+#: ../src/richtext/richtextindentspage.cpp:289
+#: ../src/richtext/richtextliststylepage.cpp:465
+#: ../src/richtext/richtextliststylepage.cpp:467
+msgid "The line spacing."
+msgstr "O espaçamento de linha."
+
+#: ../src/richtext/richtextindentspage.cpp:292
+msgid "&Page Break"
+msgstr "Quebra de &Página"
+
+#: ../src/richtext/richtextindentspage.cpp:294
+#: ../src/richtext/richtextindentspage.cpp:296
+#, fuzzy
+msgid "Inserts a page break before the paragraph."
+msgstr "O espaçamento antes do parágrafo."
+
+#: ../src/richtext/richtextindentspage.cpp:302
+#: ../src/richtext/richtextindentspage.cpp:304
+msgid "Shows a preview of the paragraph settings."
+msgstr "Mostra uma antevisão das definições do parágrafo."
+
+#: ../src/richtext/richtextliststylepage.cpp:182
+msgid "&List level:"
+msgstr "&Lista de nível:"
+
+#: ../src/richtext/richtextliststylepage.cpp:186
+#: ../src/richtext/richtextliststylepage.cpp:188
+msgid "Selects the list level to edit."
+msgstr "Seleciona o nível de lista a editar."
+
+#: ../src/richtext/richtextliststylepage.cpp:193
+msgid "&Font for Level..."
+msgstr "&Fonte para Nível..."
+
+#: ../src/richtext/richtextliststylepage.cpp:194
+#: ../src/richtext/richtextliststylepage.cpp:196
+msgid "Click to choose the font for this level."
+msgstr "Clique para escolher a fonte para este nível."
+
+#: ../src/richtext/richtextliststylepage.cpp:312
+msgid "Bullet style"
+msgstr "Estilo de marcador"
+
+#: ../src/richtext/richtextliststylepage.cpp:429
+msgid "Before a paragraph:"
+msgstr "Antes de um parágrafo:"
+
+#: ../src/richtext/richtextliststylepage.cpp:438
+msgid "After a paragraph:"
+msgstr "Depois de um parágrafo:"
+
+#: ../src/richtext/richtextliststylepage.cpp:447
+msgid "Line spacing:"
+msgstr "Espaçamento de linhas:"
+
+#: ../src/richtext/richtextliststylepage.cpp:470
+msgid "Spacing"
+msgstr "Espaçamento"
+
+#: ../src/richtext/richtextmarginspage.cpp:193
+#: ../src/richtext/richtextmarginspage.cpp:195
+#, fuzzy
+msgid "The left margin size."
+msgstr "O tamanho do ponto da fonte."
+
+#: ../src/richtext/richtextmarginspage.cpp:203
+#: ../src/richtext/richtextmarginspage.cpp:205
+msgid "Units for the left margin."
+msgstr ""
+
+#: ../src/richtext/richtextmarginspage.cpp:218
+#: ../src/richtext/richtextmarginspage.cpp:220
+#, fuzzy
+msgid "The right margin size."
+msgstr "A indentação à direita."
+
+#: ../src/richtext/richtextmarginspage.cpp:228
+#: ../src/richtext/richtextmarginspage.cpp:230
+msgid "Units for the right margin."
+msgstr ""
+
+#: ../src/richtext/richtextmarginspage.cpp:241
+#: ../src/richtext/richtextmarginspage.cpp:243
+#, fuzzy
+msgid "The top margin size."
+msgstr "O tamanho do ponto da fonte."
+
+#: ../src/richtext/richtextmarginspage.cpp:251
+#: ../src/richtext/richtextmarginspage.cpp:253
+#, fuzzy
+msgid "Units for the top margin."
+msgstr "Não é possível esperar pela terminação da thread."
+
+#: ../src/richtext/richtextmarginspage.cpp:266
+#: ../src/richtext/richtextmarginspage.cpp:268
+#, fuzzy
+msgid "The bottom margin size."
+msgstr "O tamanho do ponto da fonte."
+
+#: ../src/richtext/richtextmarginspage.cpp:276
+#: ../src/richtext/richtextmarginspage.cpp:278
+msgid "Units for the bottom margin."
+msgstr ""
+
+#: ../src/richtext/richtextmarginspage.cpp:284
+#, fuzzy
+msgid "Padding"
+msgstr "a ler"
+
+#: ../src/richtext/richtextmarginspage.cpp:307
+#: ../src/richtext/richtextmarginspage.cpp:309
+#, fuzzy
+msgid "The left padding size."
+msgstr "O tamanho do ponto da fonte."
+
+#: ../src/richtext/richtextmarginspage.cpp:317
+#: ../src/richtext/richtextmarginspage.cpp:319
+msgid "Units for the left padding."
+msgstr ""
+
+#: ../src/richtext/richtextmarginspage.cpp:332
+#: ../src/richtext/richtextmarginspage.cpp:334
+#, fuzzy
+msgid "The right padding size."
+msgstr "A indentação à direita."
+
+#: ../src/richtext/richtextmarginspage.cpp:342
+#: ../src/richtext/richtextmarginspage.cpp:344
+msgid "Units for the right padding."
+msgstr ""
+
+#: ../src/richtext/richtextmarginspage.cpp:355
+#: ../src/richtext/richtextmarginspage.cpp:357
+#, fuzzy
+msgid "The top padding size."
+msgstr "O tamanho do ponto da fonte."
+
+#: ../src/richtext/richtextmarginspage.cpp:365
+#: ../src/richtext/richtextmarginspage.cpp:367
+msgid "Units for the top padding."
+msgstr ""
+
+#: ../src/richtext/richtextmarginspage.cpp:380
+#: ../src/richtext/richtextmarginspage.cpp:382
+#, fuzzy
+msgid "The bottom padding size."
+msgstr "O tamanho do ponto da fonte."
+
+#: ../src/richtext/richtextmarginspage.cpp:390
+#: ../src/richtext/richtextmarginspage.cpp:392
+msgid "Units for the bottom padding."
+msgstr ""
+
+#: ../src/richtext/richtextprint.cpp:592
+msgid " Preview"
+msgstr " Antevisão"
+
+#: ../src/richtext/richtextsizepage.cpp:228
+#, fuzzy
+msgid "Floating"
+msgstr "A formatar"
+
+#: ../src/richtext/richtextsizepage.cpp:243
+msgid "&Floating mode:"
+msgstr "Modo &Flutuante:"
+
+#: ../src/richtext/richtextsizepage.cpp:252
+#: ../src/richtext/richtextsizepage.cpp:254
+msgid "How the object will float relative to the text."
+msgstr "Como é que o objeto irá flutuar em relação ao texto."
+
+#: ../src/richtext/richtextsizepage.cpp:265
+msgid "Alignment"
+msgstr "Alinhamento"
+
+#: ../src/richtext/richtextsizepage.cpp:277
+msgid "&Vertical alignment:"
+msgstr "&Alinhamento Vertical:"
+
+#: ../src/richtext/richtextsizepage.cpp:279
+#: ../src/richtext/richtextsizepage.cpp:281
+#, fuzzy
+msgid "Enable vertical alignment."
+msgstr "Não foi possível inicia a impressão."
+
+#: ../src/richtext/richtextsizepage.cpp:286
+msgid "Centred"
+msgstr "Centrado"
+
+#: ../src/richtext/richtextsizepage.cpp:290
+#: ../src/richtext/richtextsizepage.cpp:292
+#, fuzzy
+msgid "Vertical alignment."
+msgstr "Não foi possível inicia a impressão."
+
+#: ../src/richtext/richtextsizepage.cpp:316
+#: ../src/richtext/richtextsizepage.cpp:323
+msgid "&Width:"
+msgstr "&Largura:"
+
+#: ../src/richtext/richtextsizepage.cpp:318
+#: ../src/richtext/richtextsizepage.cpp:320
+msgid "Enable the width value."
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:331
+#: ../src/richtext/richtextsizepage.cpp:333
+#, fuzzy
+msgid "The object width."
+msgstr "O peso da fonte."
+
+#: ../src/richtext/richtextsizepage.cpp:342
+#: ../src/richtext/richtextsizepage.cpp:344
+msgid "Units for the object width."
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:350
+#: ../src/richtext/richtextsizepage.cpp:357
+msgid "&Height:"
+msgstr "&Altura:"
+
+#: ../src/richtext/richtextsizepage.cpp:352
+#: ../src/richtext/richtextsizepage.cpp:354
+#: ../src/richtext/richtextsizepage.cpp:464
+#: ../src/richtext/richtextsizepage.cpp:466
+msgid "Enable the height value."
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:365
+#: ../src/richtext/richtextsizepage.cpp:367
+#, fuzzy
+msgid "The object height."
+msgstr "O peso da fonte."
+
+#: ../src/richtext/richtextsizepage.cpp:376
+#: ../src/richtext/richtextsizepage.cpp:378
+msgid "Units for the object height."
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:381
+msgid "Min width:"
+msgstr "Largura min.:"
+
+#: ../src/richtext/richtextsizepage.cpp:383
+#: ../src/richtext/richtextsizepage.cpp:385
+#, fuzzy
+msgid "Enable the minimum width value."
+msgstr "Não foi possível inicia a impressão."
+
+#: ../src/richtext/richtextsizepage.cpp:392
+#: ../src/richtext/richtextsizepage.cpp:394
+#, fuzzy
+msgid "The object minimum width."
+msgstr "O peso da fonte."
+
+#: ../src/richtext/richtextsizepage.cpp:403
+#: ../src/richtext/richtextsizepage.cpp:405
+#, fuzzy
+msgid "Units for the minimum object width."
+msgstr "O peso da fonte."
+
+#: ../src/richtext/richtextsizepage.cpp:408
+#, fuzzy
+msgid "Min height:"
+msgstr "&Peso da fonte:"
+
+#: ../src/richtext/richtextsizepage.cpp:410
+#: ../src/richtext/richtextsizepage.cpp:412
+msgid "Enable the minimum height value."
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:419
+#: ../src/richtext/richtextsizepage.cpp:421
+#, fuzzy
+msgid "The object minimum height."
+msgstr "O peso da fonte."
+
+#: ../src/richtext/richtextsizepage.cpp:430
+#: ../src/richtext/richtextsizepage.cpp:432
+#, fuzzy
+msgid "Units for the minimum object height."
+msgstr "O peso da fonte."
+
+#: ../src/richtext/richtextsizepage.cpp:435
+#, fuzzy
+msgid "Max width:"
+msgstr "Substituir por:"
+
+#: ../src/richtext/richtextsizepage.cpp:437
+#: ../src/richtext/richtextsizepage.cpp:439
+#, fuzzy
+msgid "Enable the maximum width value."
+msgstr "Não foi possível inicia a impressão."
+
+#: ../src/richtext/richtextsizepage.cpp:446
+#: ../src/richtext/richtextsizepage.cpp:448
+#, fuzzy
+msgid "The object maximum width."
+msgstr "O peso da fonte."
+
+#: ../src/richtext/richtextsizepage.cpp:457
+#: ../src/richtext/richtextsizepage.cpp:459
+#, fuzzy
+msgid "Units for the maximum object width."
+msgstr "O peso da fonte."
+
+#: ../src/richtext/richtextsizepage.cpp:462
+#, fuzzy
+msgid "Max height:"
+msgstr "&Peso:"
+
+#: ../src/richtext/richtextsizepage.cpp:473
+#: ../src/richtext/richtextsizepage.cpp:475
+#, fuzzy
+msgid "The object maximum height."
+msgstr "O peso da fonte."
+
+#: ../src/richtext/richtextsizepage.cpp:484
+#: ../src/richtext/richtextsizepage.cpp:486
+#, fuzzy
+msgid "Units for the maximum object height."
+msgstr "O peso da fonte."
+
+#: ../src/richtext/richtextsizepage.cpp:495
+#, fuzzy
+msgid "Position"
+msgstr "Pergunta"
+
+#: ../src/richtext/richtextsizepage.cpp:513
+msgid "&Position mode:"
+msgstr "Modo de &Posição:"
+
+#: ../src/richtext/richtextsizepage.cpp:517
+#: ../src/richtext/richtextsizepage.cpp:522
+#, fuzzy
+msgid "Static"
+msgstr "Estático"
+
+#: ../src/richtext/richtextsizepage.cpp:518
+#, fuzzy
+msgid "Relative"
+msgstr "Decorative"
+
+#: ../src/richtext/richtextsizepage.cpp:519
+msgid "Absolute"
+msgstr "Absoluto"
+
+#: ../src/richtext/richtextsizepage.cpp:520
+#, fuzzy
+msgid "Fixed"
+msgstr "Fonte Fixa:"
+
+#: ../src/richtext/richtextsizepage.cpp:533
+#: ../src/richtext/richtextsizepage.cpp:535
+#: ../src/richtext/richtextsizepage.cpp:547
+#: ../src/richtext/richtextsizepage.cpp:549
+#, fuzzy
+msgid "The left position."
+msgstr "A posição de tabulação."
+
+#: ../src/richtext/richtextsizepage.cpp:558
+#: ../src/richtext/richtextsizepage.cpp:560
+#, fuzzy
+msgid "Units for the left position."
+msgstr "Não é possível esperar pela terminação da thread."
+
+#: ../src/richtext/richtextsizepage.cpp:568
+#: ../src/richtext/richtextsizepage.cpp:570
+#: ../src/richtext/richtextsizepage.cpp:582
+#: ../src/richtext/richtextsizepage.cpp:584
+#, fuzzy
+msgid "The top position."
+msgstr "A posição de tabulação."
+
+#: ../src/richtext/richtextsizepage.cpp:593
+#: ../src/richtext/richtextsizepage.cpp:595
+#, fuzzy
+msgid "Units for the top position."
+msgstr "Não é possível esperar pela terminação da thread."
+
+#: ../src/richtext/richtextsizepage.cpp:603
+#: ../src/richtext/richtextsizepage.cpp:605
+#: ../src/richtext/richtextsizepage.cpp:617
+#: ../src/richtext/richtextsizepage.cpp:619
+#, fuzzy
+msgid "The right position."
+msgstr "A posição de tabulação."
+
+#: ../src/richtext/richtextsizepage.cpp:628
+#: ../src/richtext/richtextsizepage.cpp:630
+#, fuzzy
+msgid "Units for the right position."
+msgstr "Não é possível esperar pela terminação da thread."
+
+#: ../src/richtext/richtextsizepage.cpp:638
+#: ../src/richtext/richtextsizepage.cpp:640
+#: ../src/richtext/richtextsizepage.cpp:652
+#: ../src/richtext/richtextsizepage.cpp:654
+#, fuzzy
+msgid "The bottom position."
+msgstr "A posição de tabulação."
+
+#: ../src/richtext/richtextsizepage.cpp:663
+#: ../src/richtext/richtextsizepage.cpp:665
+#, fuzzy
+msgid "Units for the bottom position."
+msgstr "Não é possível esperar pela terminação da thread."
+
+#: ../src/richtext/richtextsizepage.cpp:671
+msgid "&Move the object to:"
+msgstr "&Mover o objeto para:"
+
+#: ../src/richtext/richtextsizepage.cpp:674
+msgid "&Previous Paragraph"
+msgstr "Parágrafo &Anterior"
+
+#: ../src/richtext/richtextsizepage.cpp:675
+#: ../src/richtext/richtextsizepage.cpp:677
+#, fuzzy
+msgid "Moves the object to the previous paragraph."
+msgstr "Voltar para página HTML anterior"
+
+#: ../src/richtext/richtextsizepage.cpp:680
+#, fuzzy
+msgid "&Next Paragraph"
+msgstr "Depois de um parágrafo:"
+
+#: ../src/richtext/richtextsizepage.cpp:681
+#: ../src/richtext/richtextsizepage.cpp:683
+#, fuzzy
+msgid "Moves the object to the next paragraph."
+msgstr "O estilo pré-definido para o próximo parágrafo."
+
+#: ../src/richtext/richtextstyledlg.cpp:193
+msgid "&Styles:"
+msgstr "E&stilos:"
+
+#: ../src/richtext/richtextstyledlg.cpp:197
+#: ../src/richtext/richtextstyledlg.cpp:199
+msgid "The available styles."
+msgstr "Os estilos disponíveis."
+
+#: ../src/richtext/richtextstyledlg.cpp:205
+#: ../src/richtext/richtextstyledlg.cpp:217
+msgid " "
+msgstr " "
+
+#: ../src/richtext/richtextstyledlg.cpp:209
+#: ../src/richtext/richtextstyledlg.cpp:211
+msgid "The style preview."
+msgstr "A antevisão do estilo."
+
+#: ../src/richtext/richtextstyledlg.cpp:220
+msgid "New &Character Style..."
+msgstr "Novo Estilo de &Caracter..."
+
+#: ../src/richtext/richtextstyledlg.cpp:221
+#: ../src/richtext/richtextstyledlg.cpp:223
+msgid "Click to create a new character style."
+msgstr "Clique para criar um novo estilo de caracter."
+
+#: ../src/richtext/richtextstyledlg.cpp:226
+msgid "New &Paragraph Style..."
+msgstr "Novo Estilo de &Parágrafo..."
+
+#: ../src/richtext/richtextstyledlg.cpp:227
+#: ../src/richtext/richtextstyledlg.cpp:229
+msgid "Click to create a new paragraph style."
+msgstr "Clique para criar um novo estilo de parágrafo."
+
+#: ../src/richtext/richtextstyledlg.cpp:232
+msgid "New &List Style..."
+msgstr "Novo &Estilo de Lista..."
+
+#: ../src/richtext/richtextstyledlg.cpp:233
+#: ../src/richtext/richtextstyledlg.cpp:235
+msgid "Click to create a new list style."
+msgstr "Clique para criar uma nova lista de estilos."
+
+#: ../src/richtext/richtextstyledlg.cpp:238
+#, fuzzy
+msgid "New &Box Style..."
+msgstr "Novo &Estilo de Lista..."
+
+#: ../src/richtext/richtextstyledlg.cpp:239
+#: ../src/richtext/richtextstyledlg.cpp:241
+msgid "Click to create a new box style."
+msgstr "Clique para criar um novo estilo de caixa."
+
+#: ../src/richtext/richtextstyledlg.cpp:246
+msgid "&Apply Style"
+msgstr "&Aplicar Estilo"
+
+#: ../src/richtext/richtextstyledlg.cpp:247
+#: ../src/richtext/richtextstyledlg.cpp:249
+msgid "Click to apply the selected style."
+msgstr "Clique para aplicar o estilo Selecionado."
+
+#: ../src/richtext/richtextstyledlg.cpp:252
+msgid "&Rename Style..."
+msgstr "&Renomear Estilo..."
+
+#: ../src/richtext/richtextstyledlg.cpp:253
+#: ../src/richtext/richtextstyledlg.cpp:255
+msgid "Click to rename the selected style."
+msgstr "Clique para renomear estilo Selecionado."
+
+#: ../src/richtext/richtextstyledlg.cpp:258
+msgid "&Edit Style..."
+msgstr "&Editar Estilo..."
+
+#: ../src/richtext/richtextstyledlg.cpp:259
+#: ../src/richtext/richtextstyledlg.cpp:261
+msgid "Click to edit the selected style."
+msgstr "Clique para editar estilo Selecionado."
+
+#: ../src/richtext/richtextstyledlg.cpp:264
+msgid "&Delete Style..."
+msgstr "&Apagar Estilo..."
+
+#: ../src/richtext/richtextstyledlg.cpp:265
+#: ../src/richtext/richtextstyledlg.cpp:267
+msgid "Click to delete the selected style."
+msgstr "Clique para apagar o estilo Selecionado."
+
+#: ../src/richtext/richtextstyledlg.cpp:274
+#: ../src/richtext/richtextstyledlg.cpp:276
+msgid "Click to close this window."
+msgstr "Clique para fechar esta janela."
+
+#: ../src/richtext/richtextstyledlg.cpp:282
+msgid "&Restart numbering"
+msgstr "&Recomeçar numeração"
+
+#: ../src/richtext/richtextstyledlg.cpp:284
+#: ../src/richtext/richtextstyledlg.cpp:286
+msgid "Check to restart numbering."
+msgstr "Marque para reiniciar a numeração."
+
+#: ../src/richtext/richtextstyledlg.cpp:601
+msgid "Enter a character style name"
+msgstr "Introduza um nome de estilo de caracter"
+
+#: ../src/richtext/richtextstyledlg.cpp:601
+#: ../src/richtext/richtextstyledlg.cpp:606
+#: ../src/richtext/richtextstyledlg.cpp:649
+#: ../src/richtext/richtextstyledlg.cpp:654
+#: ../src/richtext/richtextstyledlg.cpp:815
+#: ../src/richtext/richtextstyledlg.cpp:820
+#: ../src/richtext/richtextstyledlg.cpp:888
+#: ../src/richtext/richtextstyledlg.cpp:896
+#: ../src/richtext/richtextstyledlg.cpp:929
+#: ../src/richtext/richtextstyledlg.cpp:934
+msgid "New Style"
+msgstr "Novo Estilo"
+
+#: ../src/richtext/richtextstyledlg.cpp:606
+#: ../src/richtext/richtextstyledlg.cpp:654
+#: ../src/richtext/richtextstyledlg.cpp:820
+#: ../src/richtext/richtextstyledlg.cpp:896
+#: ../src/richtext/richtextstyledlg.cpp:934
+msgid "Sorry, that name is taken. Please choose another."
+msgstr "Lamento, este nome já está escolhido. Por favor escolha outro."
+
+#: ../src/richtext/richtextstyledlg.cpp:649
+msgid "Enter a paragraph style name"
+msgstr "Introduza um nome de estilo de parágrafo"
+
+#: ../src/richtext/richtextstyledlg.cpp:777
+#, c-format
+msgid "Delete style %s?"
+msgstr "Apagar estilo %s?"
+
+#: ../src/richtext/richtextstyledlg.cpp:777
+msgid "Delete Style"
+msgstr "Apagar Estilo"
+
+#: ../src/richtext/richtextstyledlg.cpp:815
+msgid "Enter a list style name"
+msgstr "Introduza um nome de estilo de lista"
+
+#: ../src/richtext/richtextstyledlg.cpp:888
+#, fuzzy
+msgid "Enter a new style name"
+msgstr "Introduza um nome de estilo de lista"
+
+#: ../src/richtext/richtextstyledlg.cpp:929
+#, fuzzy
+msgid "Enter a box style name"
+msgstr "Introduza um nome de estilo de lista"
+
+#: ../src/richtext/richtextstylepage.cpp:109
+#: ../src/richtext/richtextstylepage.cpp:111
+msgid "The style name."
+msgstr "O nome do estilo."
+
+#: ../src/richtext/richtextstylepage.cpp:114
+msgid "&Based on:"
+msgstr "&Baseado em:"
+
+#: ../src/richtext/richtextstylepage.cpp:119
+#: ../src/richtext/richtextstylepage.cpp:121
+msgid "The style on which this style is based."
+msgstr "O estilo do qual este estilo é baseado."
+
+#: ../src/richtext/richtextstylepage.cpp:124
+msgid "&Next style:"
+msgstr "&Próximo estilo:"
+
+#: ../src/richtext/richtextstylepage.cpp:129
+#: ../src/richtext/richtextstylepage.cpp:131
+msgid "The default style for the next paragraph."
+msgstr "O estilo pré-definido para o próximo parágrafo."
+
+#: ../src/richtext/richtextstyles.cpp:1057
+msgid "All styles"
+msgstr "Todos os estilos"
+
+#: ../src/richtext/richtextstyles.cpp:1058
+msgid "Paragraph styles"
+msgstr "Estilos de parágrafo"
+
+#: ../src/richtext/richtextstyles.cpp:1059
+msgid "Character styles"
+msgstr "Estilos de Caracteres"
+
+#: ../src/richtext/richtextstyles.cpp:1060
+msgid "List styles"
+msgstr "Estilos da lista"
+
+#: ../src/richtext/richtextstyles.cpp:1061
+#, fuzzy
+msgid "Box styles"
+msgstr "Todos os estilos"
+
+#: ../src/richtext/richtextsymboldlg.cpp:389
+#: ../src/richtext/richtextsymboldlg.cpp:391
+msgid "The font from which to take the symbol."
+msgstr "A fonte de onde se retira o símbolo."
+
+#: ../src/richtext/richtextsymboldlg.cpp:396
+msgid "&Subset:"
+msgstr "&Subconjunto:"
+
+#: ../src/richtext/richtextsymboldlg.cpp:401
+#: ../src/richtext/richtextsymboldlg.cpp:403
+msgid "Shows a Unicode subset."
+msgstr "Mostra um sub-conjunto Unicode."
+
+#: ../src/richtext/richtextsymboldlg.cpp:412
+msgid "xxxx"
+msgstr "xxxx"
+
+#: ../src/richtext/richtextsymboldlg.cpp:417
+msgid "&Character code:"
+msgstr "Código de &Caracter:"
+
+#: ../src/richtext/richtextsymboldlg.cpp:421
+#: ../src/richtext/richtextsymboldlg.cpp:423
+msgid "The character code."
+msgstr "Código do caracter."
+
+#: ../src/richtext/richtextsymboldlg.cpp:428
+msgid "&From:"
+msgstr "&De:"
+
+#: ../src/richtext/richtextsymboldlg.cpp:433
+#: ../src/richtext/richtextsymboldlg.cpp:434
+#: ../src/richtext/richtextsymboldlg.cpp:435
+msgid "Unicode"
+msgstr "Unicode"
+
+#: ../src/richtext/richtextsymboldlg.cpp:436
+#: ../src/richtext/richtextsymboldlg.cpp:438
+msgid "The range to show."
+msgstr "O alcance a mostrar."
+
+#: ../src/richtext/richtextsymboldlg.cpp:444
+msgid "Insert"
+msgstr "Inserir"
+
+#: ../src/richtext/richtextsymboldlg.cpp:478
+msgid "(Normal text)"
+msgstr "(Texto normal)"
+
+#: ../src/richtext/richtexttabspage.cpp:109
+msgid "&Position (tenths of a mm):"
+msgstr "&Posição (décimos de mm):"
+
+#: ../src/richtext/richtexttabspage.cpp:113
+#: ../src/richtext/richtexttabspage.cpp:115
+msgid "The tab position."
+msgstr "A posição de tabulação."
+
+#: ../src/richtext/richtexttabspage.cpp:119
+msgid "The tab positions."
+msgstr "As posições de tabulação."
+
+#: ../src/richtext/richtexttabspage.cpp:132
+#: ../src/richtext/richtexttabspage.cpp:134
+msgid "Click to create a new tab position."
+msgstr "Clique para criar uma nova posição de tabulação."
+
+#: ../src/richtext/richtexttabspage.cpp:138
+#: ../src/richtext/richtexttabspage.cpp:140
+msgid "Click to delete the selected tab position."
+msgstr "Clique para apagar a posição de tabulação Selecionada."
+
+#: ../src/richtext/richtexttabspage.cpp:143
+msgid "Delete A&ll"
+msgstr "Apagar T&udo"
+
+#: ../src/richtext/richtexttabspage.cpp:144
+#: ../src/richtext/richtexttabspage.cpp:146
+msgid "Click to delete all tab positions."
+msgstr "Clique para apagar todas as posições de tabulação."
+
+#: ../src/univ/theme.cpp:110
+msgid "Failed to initialize GUI: no built-in themes found."
+msgstr "Falha ao inicializar o GUI: não foram encontrados temas integrados."
+
+#: ../src/univ/themes/gtk.cpp:521
+msgid "GTK+ theme"
+msgstr "Tema GTK+"
+
+#: ../src/univ/themes/metal.cpp:164
+msgid "Metal theme"
+msgstr "Tema Metal"
+
+#: ../src/univ/themes/mono.cpp:512
+msgid "Simple monochrome theme"
+msgstr "Tema monocromático simples"
+
+#: ../src/univ/themes/win32.cpp:1098
+msgid "Win32 theme"
+msgstr "Tema Win32"
+
+#: ../src/univ/themes/win32.cpp:3743
+msgid "&Restore"
+msgstr "&Restaurar"
+
+#: ../src/univ/themes/win32.cpp:3744
+msgid "&Move"
+msgstr "&Mover"
+
+#: ../src/univ/themes/win32.cpp:3746
+msgid "&Size"
+msgstr "&Tamanho"
+
+#: ../src/univ/themes/win32.cpp:3748
+msgid "Mi&nimize"
+msgstr "Mi&nimizar"
+
+#: ../src/univ/themes/win32.cpp:3750
+msgid "Ma&ximize"
+msgstr "Ma&ximizar"
+
+#: ../src/univ/themes/win32.cpp:3752
+msgid "Alt+"
+msgstr "Alt+"
+
+#: ../src/unix/appunix.cpp:178
+#, fuzzy
+msgid "Failed to install signal handler"
+msgstr "Falha ao fechar manuseador de ficheiro"
+
+#: ../src/unix/dialup.cpp:351
+msgid "Already dialling ISP."
+msgstr "Já está a ligar ao serviço ISP."
+
+#: ../src/unix/dlunix.cpp:93
+#, fuzzy
+msgid "Failed to unload shared library"
+msgstr "Falha na abertura da livraria partilhada '%s'"
+
+#: ../src/unix/dlunix.cpp:121
+msgid "Unknown dynamic library error"
+msgstr "Erro desconhecido de livraria dinâmica"
+
+#: ../src/unix/epolldispatcher.cpp:84
+#, fuzzy
+msgid "Failed to create epoll descriptor"
+msgstr "Falha de criação de cursor."
+
+#: ../src/unix/epolldispatcher.cpp:103
+#, fuzzy
+msgid "Error closing epoll descriptor"
+msgstr "Erro ao criar directório"
+
+#: ../src/unix/epolldispatcher.cpp:116
+#, fuzzy, c-format
+msgid "Failed to add descriptor %d to epoll descriptor %d"
+msgstr "Não foi possível escrever no descritor de ficheiro %d"
+
+#: ../src/unix/epolldispatcher.cpp:136
+#, c-format
+msgid "Failed to modify descriptor %d in epoll descriptor %d"
+msgstr ""
+
+#: ../src/unix/epolldispatcher.cpp:155
+#, fuzzy, c-format
+msgid "Failed to unregister descriptor %d from epoll descriptor %d"
+msgstr "Falha na obtenção dos dados da área de transferência."
+
+#: ../src/unix/epolldispatcher.cpp:213
+#, fuzzy, c-format
+msgid "Waiting for IO on epoll descriptor %d failed"
+msgstr "Falha na espera do fim do subprocesso"
+
+#: ../src/unix/fswatcher_inotify.cpp:71
+#, fuzzy
+msgid "Unable to create inotify instance"
+msgstr "Não foi possível criar TextEncodingConverter"
+
+#: ../src/unix/fswatcher_inotify.cpp:94
+#, fuzzy
+msgid "Unable to close inotify instance"
+msgstr "Falha ao fechar manuseador de ficheiro"
+
+#: ../src/unix/fswatcher_inotify.cpp:106
+msgid "Unable to add inotify watch"
+msgstr ""
+
+#: ../src/unix/fswatcher_inotify.cpp:138
+#, fuzzy, c-format
+msgid "Unable to remove inotify watch %i"
+msgstr "Não foi possível criar TextEncodingConverter"
+
+#: ../src/unix/fswatcher_inotify.cpp:271
+#, c-format
+msgid "Unexpected event for \"%s\": no matching watch descriptor."
+msgstr ""
+
+#: ../src/unix/fswatcher_inotify.cpp:320
+#, c-format
+msgid "Invalid inotify event for \"%s\""
+msgstr ""
+
+#: ../src/unix/fswatcher_inotify.cpp:553
+#, fuzzy
+msgid "Unable to read from inotify descriptor"
+msgstr "não foi possível ler do descritor do ficheiro %d"
+
+#: ../src/unix/fswatcher_inotify.cpp:558
+#, fuzzy
+msgid "EOF while reading from inotify descriptor"
+msgstr "não foi possível ler do descritor do ficheiro %d"
+
+#: ../src/unix/fswatcher_kqueue.cpp:114
+#, fuzzy
+msgid "Unable to create kqueue instance"
+msgstr "Não foi possível criar TextEncodingConverter"
+
+#: ../src/unix/fswatcher_kqueue.cpp:131
+#, fuzzy
+msgid "Error closing kqueue instance"
+msgstr "Erro ao criar directório"
+
+#: ../src/unix/fswatcher_kqueue.cpp:153
+msgid "Unable to add kqueue watch"
+msgstr ""
+
+#: ../src/unix/fswatcher_kqueue.cpp:170
+msgid "Unable to remove kqueue watch"
+msgstr ""
+
+#: ../src/unix/fswatcher_kqueue.cpp:202
+msgid "Unable to get events from kqueue"
+msgstr ""
+
+#: ../src/unix/mediactrl.cpp:966
+#, c-format
+msgid "Media playback error: %s"
+msgstr "Erro de reprodução de multimédia: %s"
+
+#: ../src/unix/mediactrl.cpp:1228
+#, fuzzy, c-format
+msgid "Failed to prepare playing \"%s\"."
+msgstr "Falha na abertura do ecrã \"%s\"."
+
+#: ../src/unix/snglinst.cpp:164
+#, c-format
+msgid "Failed to write to lock file '%s'"
+msgstr "Falha ao escrever para o ficheiro de bloqueio '%s'"
+
+#: ../src/unix/snglinst.cpp:177
+#, c-format
+msgid "Failed to set permissions on lock file '%s'"
+msgstr "Falha ao definir permissões no ficheiro de bloqueio '%s'"
+
+#: ../src/unix/snglinst.cpp:194
+#, c-format
+msgid "Failed to lock the lock file '%s'"
+msgstr "Falha no bloqueio do ficheiro de bloqueio '%s'"
+
+#: ../src/unix/snglinst.cpp:237
+#, c-format
+msgid "Failed to inspect the lock file '%s'"
+msgstr "Falha de inspecção no ficheiro de bloqueio '%s'"
+
+#: ../src/unix/snglinst.cpp:242
+#, c-format
+msgid "Lock file '%s' has incorrect owner."
+msgstr "Ficheiro de bloqueio '%s' tem proprietário incorrecto."
+
+#: ../src/unix/snglinst.cpp:247
+#, c-format
+msgid "Lock file '%s' has incorrect permissions."
+msgstr "Ficheiro de bloqueio '%s' tem permissões incorrectas."
+
+#: ../src/unix/snglinst.cpp:265
+msgid "Failed to access lock file."
+msgstr "Falha no acesso ao ficheiro de bloqueio."
+
+#: ../src/unix/snglinst.cpp:274
+msgid "Failed to read PID from lock file."
+msgstr "Falha na leitura do PID do ficheiro de bloqueio."
+
+#: ../src/unix/snglinst.cpp:284
+#, c-format
+msgid "Failed to remove stale lock file '%s'."
+msgstr "Falha ao remover ficheiro de bloqueio estagnado'%s'."
+
+#: ../src/unix/snglinst.cpp:297
+#, c-format
+msgid "Deleted stale lock file '%s'."
+msgstr "Ficheiro de bloqueio apagado '%s'."
+
+#: ../src/unix/snglinst.cpp:308
+#, c-format
+msgid "Invalid lock file '%s'."
+msgstr "Ficheiro de bloqueio inválido '%s'."
+
+#: ../src/unix/snglinst.cpp:324
+#, c-format
+msgid "Failed to remove lock file '%s'"
+msgstr "Falha ao remover ficheiro de bloqueio '%s'"
+
+#: ../src/unix/snglinst.cpp:330
+#, c-format
+msgid "Failed to unlock lock file '%s'"
+msgstr "Falha ao desbloquear ficheiro de bloqueio '%s'"
+
+#: ../src/unix/snglinst.cpp:336
+#, c-format
+msgid "Failed to close lock file '%s'"
+msgstr "Falha ao fechar o ficheiro de bloqueio '%s'"
+
+#: ../src/unix/sound.cpp:77
+msgid "No sound"
+msgstr "Sem som"
+
+#: ../src/unix/sound.cpp:364
+msgid "Unable to play sound asynchronously."
+msgstr "Não foi possível reproduzir som assincronamente."
+
+#: ../src/unix/sound.cpp:458
+#, c-format
+msgid "Couldn't load sound data from '%s'."
+msgstr "Não foi possível carregar dados de som a partir de '%s'."
+
+#: ../src/unix/sound.cpp:465
+#, c-format
+msgid "Sound file '%s' is in unsupported format."
+msgstr "O ficheiro de som '%s' está num formato não suportado."
+
+#: ../src/unix/sound.cpp:480
+msgid "Sound data are in unsupported format."
+msgstr "Dados de som estão num formato não suportado."
+
+#: ../src/unix/sound_sdl.cpp:226
+#, c-format
+msgid "Couldn't open audio: %s"
+msgstr "Não foi possível abrir o áudio: %s"
+
+#: ../src/unix/threadpsx.cpp:1033
+msgid "Cannot retrieve thread scheduling policy."
+msgstr "Não foi possível obter thread de política de agendamento."
+
+#: ../src/unix/threadpsx.cpp:1058
+#, c-format
+msgid "Cannot get priority range for scheduling policy %d."
+msgstr ""
+"Não foi possível obter a gama de prioridade para a política de agendamento "
+"%d."
+
+#: ../src/unix/threadpsx.cpp:1066
+msgid "Thread priority setting is ignored."
+msgstr "A definição de prioridade da thread é ignorada."
+
+#: ../src/unix/threadpsx.cpp:1221
+msgid ""
+"Failed to join a thread, potential memory leak detected - please restart the "
+"program"
+msgstr ""
+"Falha na associação a uma thread, foi detectada uma potencial fuga de "
+"memória - por favor reinicie o programa"
+
+#: ../src/unix/threadpsx.cpp:1352
+#, fuzzy, c-format
+msgid "Failed to set thread concurrency level to %lu"
+msgstr "Falha ao definir prioridade de thread %d."
+
+#: ../src/unix/threadpsx.cpp:1481
+#, c-format
+msgid "Failed to set thread priority %d."
+msgstr "Falha ao definir prioridade de thread %d."
+
+#: ../src/unix/threadpsx.cpp:1666
+msgid "Failed to terminate a thread."
+msgstr "Falha ao matar a thread."
+
+#: ../src/unix/threadpsx.cpp:1893
+msgid "Thread module initialization failed: failed to create thread key"
+msgstr ""
+"Falhou a inicialização do módulo da thread: falhou a criação da chave da "
+"thread"
+
+#: ../src/unix/utilsunx.cpp:340
+msgid "Impossible to get child process input"
+msgstr "Não foi possível obter a entrada do processo filho"
+
+#: ../src/unix/utilsunx.cpp:390
+#, fuzzy
+msgid "Can't write to child process's stdin"
+msgstr "Falha no encerramento do processo %d"
+
+#: ../src/unix/utilsunx.cpp:644
+#, c-format
+msgid "Failed to execute '%s'\n"
+msgstr "Falha ao executar '%s'\n"
+
+#: ../src/unix/utilsunx.cpp:678
+msgid "Fork failed"
+msgstr "Falha no fork"
+
+#: ../src/unix/utilsunx.cpp:701
+#, fuzzy
+msgid "Failed to set process priority"
+msgstr "Falha ao definir prioridade de thread %d."
+
+#: ../src/unix/utilsunx.cpp:712
+msgid "Failed to redirect child process input/output"
+msgstr "Falha no redireccionamento do processo filho de entrada/saída"
+
+#: ../src/unix/utilsunx.cpp:816
+msgid "Failed to set up non-blocking pipe, the program might hang."
+msgstr ""
+
+#: ../src/unix/utilsunx.cpp:1023
+msgid "Cannot get the hostname"
+msgstr "Não foi possível obter o nome de computador"
+
+#: ../src/unix/utilsunx.cpp:1059
+msgid "Cannot get the official hostname"
+msgstr "Não foi possível obter o nome de computador oficial"
+
+#: ../src/unix/wakeuppipe.cpp:49
+#, fuzzy
+msgid "Failed to create wake up pipe used by event loop."
+msgstr "Falha de criação de barra de estado."
+
+#: ../src/unix/wakeuppipe.cpp:56
+msgid "Failed to switch wake up pipe to non-blocking mode"
+msgstr ""
+
+#: ../src/unix/wakeuppipe.cpp:117
+#, fuzzy
+msgid "Failed to read from wake-up pipe"
+msgstr "Falha na leitura do PID do ficheiro de bloqueio."
+
+#: ../src/x11/app.cpp:124
+#, c-format
+msgid "Invalid geometry specification '%s'"
+msgstr "Especificação de geometria inválida '%s'"
+
+#: ../src/x11/app.cpp:167
+msgid "wxWidgets could not open display. Exiting."
+msgstr "wxWidgets não foi possível abrir o ecrã. A sair."
+
+#: ../src/x11/utils.cpp:169
+#, c-format
+msgid "Failed to close the display \"%s\""
+msgstr "Falha ao fechar o ecrã \"%s\""
+
+#: ../src/x11/utils.cpp:188
+#, c-format
+msgid "Failed to open display \"%s\"."
+msgstr "Falha na abertura do ecrã \"%s\"."
+
+#: ../src/xml/xml.cpp:868
+#, c-format
+msgid "XML parsing error: '%s' at line %d"
+msgstr "XML erro de verificação gramatical: '%s' na linha %d"
+
+#: ../src/xrc/xh_propgrid.cpp:239
+#, fuzzy, c-format
+msgid "Page %i"
+msgstr "Página %d"
+
+#: ../src/xrc/xmlres.cpp:448
+#, fuzzy, c-format
+msgid "Cannot load resources from '%s'."
+msgstr "Não foi possível carregar recursos do ficheiro '%s'."
+
+#: ../src/xrc/xmlres.cpp:799
+#, fuzzy, c-format
+msgid "Cannot open resources file '%s'."
+msgstr "Não foi possível carregar recursos do ficheiro '%s'."
+
+#: ../src/xrc/xmlres.cpp:806
+#, c-format
+msgid "Cannot load resources from file '%s'."
+msgstr "Não foi possível carregar recursos do ficheiro '%s'."
+
+#: ../src/xrc/xmlres.cpp:2767
+#, fuzzy, c-format
+msgid "Creating %s \"%s\" failed."
+msgstr "Falhou a extracção de '%s' para '%s'."
+
+#~ msgctxt "keyboard key"
+#~ msgid "Alt+"
+#~ msgstr "Alt+"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Ctrl+"
+#~ msgstr "Ctrl+"
+
+#, fuzzy
+#~ msgctxt "keyboard key"
+#~ msgid "Shift+"
+#~ msgstr "Shift-"
+
+#, fuzzy
+#~ msgctxt "keyboard key"
+#~ msgid "RawCtrl+"
+#~ msgstr "Ctrl-"
+
+#~ msgid "Unsupported clipboard format."
+#~ msgstr "Formato da área de transferência não suportado."
+
+#~ msgid "Background colour"
+#~ msgstr "Cor de fundo"
+
+#~ msgid "Font:"
+#~ msgstr "Fonte:"
+
+#~ msgid "Size:"
+#~ msgstr "Tamanho:"
+
+#~ msgid "The font size in points."
+#~ msgstr "O tamanho da fonte em pontos."
+
+#~ msgid "Style:"
+#~ msgstr "Estilo:"
+
+#~ msgid "Check to make the font bold."
+#~ msgstr "Marque para tornar a letra destacada."
+
+#~ msgid "Check to make the font italic."
+#~ msgstr "Marque para tornar a letra itálica."
+
+#~ msgid "Check to make the font underlined."
+#~ msgstr "Marque para tornar a letra sublinhada."
+
+#~ msgid "Colour:"
+#~ msgstr "Cor:"
+
+#~ msgid "Click to change the font colour."
+#~ msgstr "Clique para alterar a cor da fonte."
+
+#~ msgid "Shows a preview of the font."
+#~ msgstr "Mostrar uma antevisão da fonte."
+
+#~ msgid "Click to cancel changes to the font."
+#~ msgstr "Clique para cancelar as alterações à fonte."
+
+#~ msgid "Click to confirm changes to the font."
+#~ msgstr "Clique para confirmar alterações a fonte."
+
+#~ msgid "<Any>"
+#~ msgstr "<Qualquer>"
+
+#~ msgid "<Any Roman>"
+#~ msgstr "<Qualquer Roman>"
+
+#~ msgid "<Any Decorative>"
+#~ msgstr "<Qualquer Decorative>"
+
+#~ msgid "<Any Modern>"
+#~ msgstr "<Qualquer Modern>"
+
+#~ msgid "<Any Script>"
+#~ msgstr "<Qualquer Script>"
+
+#~ msgid "<Any Swiss>"
+#~ msgstr "<Qualquer Swiss>"
+
+#~ msgid "<Any Teletype>"
+#~ msgstr "<Qualquer Teletype>"
+
+#~ msgid "Printing "
+#~ msgstr "A Imprimir ..."
+
+#~ msgid "Failed to insert text in the control."
+#~ msgstr "Falha de inserção de texto no controlo."
+
+#~ msgid "Please choose a valid font."
+#~ msgstr "Por favor escolha uma fonte válida."
+
+#, c-format
+#~ msgid "Failed to display HTML document in %s encoding"
+#~ msgstr "Falha a mostrar documento HTML na codificação %s"
+
+#, c-format
+#~ msgid "wxWidgets could not open display for '%s': exiting."
+#~ msgstr "wxWidgets não foi possível abrir ecrã para '%s': a sair."
+
+#~ msgid "Filter"
+#~ msgstr "Filtro"
+
+#~ msgid "Directories"
+#~ msgstr "Directórios"
+
+#~ msgid "Files"
+#~ msgstr "Ficheiros"
+
+#~ msgid "Selection"
+#~ msgstr "Selecção"
+
+#~ msgid "conversion to 8-bit encoding failed"
+#~ msgstr "falhou a conversão para codificação de 8-bits"
+
+#, fuzzy
+#~ msgid "failed to retrieve execution result"
+#~ msgstr "Falha na obtenção do texto da mensagem de erro RAS"
+
+#~ msgid "&Save as"
+#~ msgstr "&Guardar Como"
+
+#, fuzzy
+#~ msgid "'%s' doesn't consist only of valid characters"
+#~ msgstr "'%s' deve apenas conter caracteres alfabéticos."
+
+#~ msgid "'%s' should be numeric."
+#~ msgstr "'%s' deve ser numérico."
+
+#~ msgid "'%s' should only contain ASCII characters."
+#~ msgstr "'%s' apenas deve conter caracteres ASCII."
+
+#~ msgid "'%s' should only contain alphabetic characters."
+#~ msgstr "'%s' deve apenas conter caracteres alfabéticos."
+
+#~ msgid "'%s' should only contain alphabetic or numeric characters."
+#~ msgstr "'%s' deve apenas conter caracteres alfabéticos e numéricos."
+
+#, fuzzy
+#~ msgid "'%s' should only contain digits."
+#~ msgstr "'%s' apenas deve conter caracteres ASCII."
+
+#~ msgid "Can't create window of class %s"
+#~ msgstr "Não é possível criar janela da classe %s"
+
+#~ msgid "Couldn't create the overlay window"
+#~ msgstr "Não foi possível criar a janela de sobreposição"
+
+#~ msgid "Couldn't init the context on the overlay window"
+#~ msgstr "Não foi possível inicializar o contexto na janela de sobreposição"
+
+#, fuzzy
+#~ msgid "Failed to convert file \"%s\" to Unicode."
+#~ msgstr "Falha ao converter conteúdo do ficheiro para Unicode."
+
+#~ msgid "Failed to set text in the text control."
+#~ msgstr "Falha ao definir texto no controlo de texto."
+
+#~ msgid "No unused colour in image."
+#~ msgstr "Nenhuma cor na imagem por utilizar."
+
+#, fuzzy
+#~ msgid "Not available"
+#~ msgstr "Não disponível!"
+
+#~ msgid "Replace selection"
+#~ msgstr "Substituir selecção"
+
+#, fuzzy
+#~ msgid "Save as"
+#~ msgstr "Gravar Como"
+
+#~ msgid "Style Organiser"
+#~ msgstr "Organizador de Estilos"
+
+#~ msgid "You cannot Clear an overlay that is not inited"
+#~ msgstr "Não pode Limpar uma sobreposição que não está inicializada"
+
+#~ msgid "You cannot Init an overlay twice"
+#~ msgstr "Não pode Inicializar uma sobreposição duas vezes"
+
+#~ msgid "locale '%s' cannot be set."
+#~ msgstr "localização '%s' não pode ser definida."
+
+#, fuzzy
+#~ msgid "Column index not found."
+#~ msgstr "Ficheiro de ajuda \"%s\" não encontrado."
+
+#~ msgid "Confirm registry update"
+#~ msgstr "Confirmar atualização de registo"
+
+#, fuzzy
+#~ msgid "Could not determine column index."
+#~ msgstr "Não foi possível iniciar antevisão do documento."
+
+#, fuzzy
+#~ msgid "Could not determine number of columns."
+#~ msgstr "Não foi possível encontrar recursos de ficheiro incluído %s."
+
+#, fuzzy
+#~ msgid "Could not determine number of items"
+#~ msgstr "Não foi possível encontrar recursos de ficheiro incluído %s."
+
+#, fuzzy
+#~ msgid "Could not get header description."
+#~ msgstr "Não foi possível inicia a impressão."
+
+#, fuzzy
+#~ msgid "Could not get items."
+#~ msgstr "Não foi possível localizar o ficheiro '%s'."
+
+#, fuzzy
+#~ msgid "Could not get property flags."
+#~ msgstr "Não foi possível criar ficheiro temporário '%s'"
+
+#, fuzzy
+#~ msgid "Could not get selected items."
+#~ msgstr "Não foi possível localizar o ficheiro '%s'."
+
+#, fuzzy
+#~ msgid "Could not remove column."
+#~ msgstr "Não foi possível criar um cursor."
+
+#, fuzzy
+#~ msgid "Could not retrieve number of items"
+#~ msgstr "Não foi possível criar ficheiro temporário '%s'"
+
+#, fuzzy
+#~ msgid "Could not set column width."
+#~ msgstr "Não foi possível iniciar antevisão do documento."
+
+#, fuzzy
+#~ msgid "Could not set header description."
+#~ msgstr "Não foi possível inicia a impressão."
+
+#, fuzzy
+#~ msgid "Could not set icon."
+#~ msgstr "Não foi possível inicia a impressão."
+
+#, fuzzy
+#~ msgid "Could not set maximum width."
+#~ msgstr "Não foi possível inicia a impressão."
+
+#, fuzzy
+#~ msgid "Could not set minimum width."
+#~ msgstr "Não foi possível inicia a impressão."
+
+#, fuzzy
+#~ msgid "Could not set property flags."
+#~ msgstr "Não foi possível inicia a impressão."
+
+#~ msgid ""
+#~ "Do you want to overwrite the command used to %s files with extension "
+#~ "\"%s\" ?\n"
+#~ "Current value is \n"
+#~ "%s, \n"
+#~ "New value is \n"
+#~ "%s %1"
+#~ msgstr ""
+#~ "Pretende substituir o comando utilizado para %s ficheiros com extensão "
+#~ "\"%s\" ?\n"
+#~ "O valor atual é \n"
+#~ "%s, \n"
+#~ "O novo valor é \n"
+#~ "%s %1"
+
+#~ msgid "Failed to retrieve data from the clipboard."
+#~ msgstr "Falha na obtenção dos dados da área de transferência."
+
+#~ msgid "GIF: Invalid gif index."
+#~ msgstr "GIF: Índice gif inválido."
+
+#~ msgid "GIF: unknown error!!!"
+#~ msgstr "GIF: erro desconhecido!!!"
+
+#~ msgid "New directory"
+#~ msgstr "Novo directório"
+
+#~ msgid "Next"
+#~ msgstr "Seguinte"
+
+#~ msgid ""
+#~ "No renderer or invalid renderer type specified for custom data column."
+#~ msgstr ""
+#~ "Nenhum renderizador ou tipo de renderizador inválido para a coluna de "
+#~ "dados personalizada. "
+
+#~ msgid "No renderer specified for column."
+#~ msgstr "Nenhum renderizador para a coluna."
+
+#, fuzzy
+#~ msgid "Number of columns could not be determined."
+#~ msgstr "Não foi possível determinar o número de colunas."
+
+#~ msgid ""
+#~ "Please install a newer version of comctl32.dll\n"
+#~ "(at least version 4.70 is required but you have %d.%02d)\n"
+#~ "or this program won't operate correctly."
+#~ msgstr ""
+#~ "Por favor instale uma versão mais recente do comctl32.dll\n"
+#~ "(no mínimo a versão 4.70 é necessária, mas atualmente tem a %d.%02d)\n"
+#~ "ou este programa não operará correctamente."
+
+#~ msgid "Progress renderer cannot render value type; value type: "
+#~ msgstr ""
+#~ "A renderização em progresso não consegue renderizar o tipo de valor; tipo "
+#~ "de valor: "
+
+#, fuzzy
+#~ msgid "Rendering failed."
+#~ msgstr "Falha na criação do temporizador."
+
+#~ msgid "Show hidden directories"
+#~ msgstr "Mostrar diretorias ocultadas"
+
+#, fuzzy
+#~ msgid ""
+#~ "This system doesn't support date controls, please upgrade your version of "
+#~ "comctl32.dll"
+#~ msgstr ""
+#~ "Este sistema não suporta o controlo de selecção de data, por favor "
+#~ "atualize a versão do comctl32.dll"
+
+#~ msgid "Too many colours in PNG, the image may be slightly blurred."
+#~ msgstr ""
+#~ "Demasiadas cores no PNG, a imagem pode ficar ligeiramente desfocada."
+
+#, fuzzy
+#~ msgid "Unable to initialize Hildon program"
+#~ msgstr "Falha ao inicializar o OpenGL"
+
+#, fuzzy
+#~ msgid "Unknown data format"
+#~ msgstr "erro no formato do dado"
+
+#~ msgid "Win32s on Windows 3.1"
+#~ msgstr "Win32s em Windows 3.1"
+
+#, fuzzy
+#~ msgid "Windows 10"
+#~ msgstr "Windows 95"
+
+#, fuzzy
+#~ msgid "Windows 2000"
+#~ msgstr "Windows 95"
+
+#, fuzzy
+#~ msgid "Windows 7"
+#~ msgstr "Windows 95"
+
+#, fuzzy
+#~ msgid "Windows 8"
+#~ msgstr "Windows 98"
+
+#, fuzzy
+#~ msgid "Windows 8.1"
+#~ msgstr "Windows 98"
+
+#~ msgid "Windows 95"
+#~ msgstr "Windows 95"
+
+#~ msgid "Windows 95 OSR2"
+#~ msgstr "Windows 95 OSR2"
+
+#~ msgid "Windows 98"
+#~ msgstr "Windows 98"
+
+#~ msgid "Windows 98 SE"
+#~ msgstr "Windows 98 SE"
+
+#~ msgid "Windows 9x (%d.%d)"
+#~ msgstr "Windows 9x (%d.%d)"
+
+#~ msgid "Windows CE (%d.%d)"
+#~ msgstr "Windows CE (%d.%d)"
+
+#~ msgid "Windows ME"
+#~ msgstr "Windows ME"
+
+#, fuzzy
+#~ msgid "Windows NT %lu.%lu"
+#~ msgstr "Windows NT %lu.%lu (build %lu"
+
+#, fuzzy
+#~ msgid "Windows Server 10"
+#~ msgstr "Windows Server 2003 (build %lu"
+
+#, fuzzy
+#~ msgid "Windows Server 2003"
+#~ msgstr "Windows Server 2003 (build %lu"
+
+#, fuzzy
+#~ msgid "Windows Server 2008"
+#~ msgstr "Windows Server 2003 (build %lu"
+
+#, fuzzy
+#~ msgid "Windows Server 2008 R2"
+#~ msgstr "Windows Server 2003 (build %lu"
+
+#, fuzzy
+#~ msgid "Windows Server 2012"
+#~ msgstr "Windows Server 2003 (build %lu"
+
+#, fuzzy
+#~ msgid "Windows Server 2012 R2"
+#~ msgstr "Windows Server 2003 (build %lu"
+
+#, fuzzy
+#~ msgid "Windows Vista"
+#~ msgstr "Windows 95"
+
+#, fuzzy
+#~ msgid "Windows XP"
+#~ msgstr "Windows 95"
+
+#~ msgid "can't execute '%s'"
+#~ msgstr "impossível executar '%s'"
+
+#~ msgid "error opening '%s'"
+#~ msgstr "erro ao abrir '%s'"
+
+#~ msgid "unknown seek origin"
+#~ msgstr "origem de pesquisa desconhecida"
+
+#~ msgid "ADD"
+#~ msgstr "ADICIONAR"
+
+#~ msgid "BACK"
+#~ msgstr "RETROCEDER"
+
+#~ msgid "CANCEL"
+#~ msgstr "CANCELAR"
+
+#~ msgid "CAPITAL"
+#~ msgstr "MAIÚSCULA"
+
+#~ msgid "CLEAR"
+#~ msgstr "LIMPAR"
+
+#~ msgid "COMMAND"
+#~ msgstr "COMANDO"
+
+#~ msgid "Cannot create mutex."
+#~ msgstr "Não foi possível criar o mutex."
+
+#~ msgid "Cannot resume thread %lu"
+#~ msgstr "Não é possível retomar a thread %lu"
+
+#~ msgid "Cannot suspend thread %lu"
+#~ msgstr "Não é possível suspender a thread %lu"
+
+#~ msgid "Couldn't acquire a mutex lock"
+#~ msgstr "Não foi possível adquirir um bloqueio à mutex"
+
+#~ msgid "Couldn't release a mutex"
+#~ msgstr "Não foi possível libertar a mutex"
+
+#~ msgid "DECIMAL"
+#~ msgstr "DÉCIMAL"
+
+#~ msgid "DEL"
+#~ msgstr "APAGAR"
+
+#~ msgid "DELETE"
+#~ msgstr "APAGAR"
+
+#~ msgid "DIVIDE"
+#~ msgstr "DIVIDIR"
+
+#~ msgid "DOWN"
+#~ msgstr "BAIXO"
+
+#~ msgid "END"
+#~ msgstr "END"
+
+#~ msgid "ENTER"
+#~ msgstr "ENTER"
+
+#~ msgid "ESC"
+#~ msgstr "ESC"
+
+#~ msgid "ESCAPE"
+#~ msgstr "ESCAPE"
+
+#~ msgid "EXECUTE"
+#~ msgstr "EXECUTAR"
+
+#~ msgid "Execution of command '%s' failed with error: %ul"
+#~ msgstr "Execução do comando '%s' terminou com o erro: %ul"
+
+#~ msgid ""
+#~ "File '%s' already exists.\n"
+#~ "Do you want to replace it?"
+#~ msgstr ""
+#~ "O ficheiro '%s' já existe.\n"
+#~ "Deseja substituí-lo?"
+
+#~ msgid "HELP"
+#~ msgstr "AJUDA"
+
+#~ msgid "HOME"
+#~ msgstr "HOME"
+
+#~ msgid "INS"
+#~ msgstr "INS"
+
+#~ msgid "INSERT"
+#~ msgstr "INSERIR"
+
+#~ msgid "KP_BEGIN"
+#~ msgstr "KP_BEGIN"
+
+#~ msgid "KP_DECIMAL"
+#~ msgstr "KP_DECIMAL"
+
+#~ msgid "KP_DELETE"
+#~ msgstr "KP_DELETE"
+
+#~ msgid "KP_DIVIDE"
+#~ msgstr "KP_DIVIDE"
+
+#~ msgid "KP_DOWN"
+#~ msgstr "KP_DOWN"
+
+#~ msgid "KP_ENTER"
+#~ msgstr "KP_ENTER"
+
+#~ msgid "KP_EQUAL"
+#~ msgstr "KP_EQUAL"
+
+#~ msgid "KP_HOME"
+#~ msgstr "KP_HOME"
+
+#~ msgid "KP_INSERT"
+#~ msgstr "KP_INSERT"
+
+#~ msgid "KP_LEFT"
+#~ msgstr "KP_LEFT"
+
+#~ msgid "KP_MULTIPLY"
+#~ msgstr "KP_MULTIPLY"
+
+#~ msgid "KP_NEXT"
+#~ msgstr "KP_NEXT"
+
+#~ msgid "KP_PAGEDOWN"
+#~ msgstr "KP_PAGEDOWN"
+
+#~ msgid "KP_PAGEUP"
+#~ msgstr "KP_PAGEUP"
+
+#~ msgid "KP_PRIOR"
+#~ msgstr "KP_PRIOR"
+
+#~ msgid "KP_RIGHT"
+#~ msgstr "KP_RIGHT"
+
+#~ msgid "KP_SEPARATOR"
+#~ msgstr "KP_SEPARATOR"
+
+#~ msgid "KP_SPACE"
+#~ msgstr "KP_SPACE"
+
+#~ msgid "KP_SUBTRACT"
+#~ msgstr "KP_SUBTRACT"
+
+#~ msgid "LEFT"
+#~ msgstr "ESQUERDA"
+
+#~ msgid "MENU"
+#~ msgstr "MENU"
+
+#~ msgid "NUM_LOCK"
+#~ msgstr "NUM_LOCK"
+
+#~ msgid "PAGEDOWN"
+#~ msgstr "PAGEDOWN"
+
+#~ msgid "PAGEUP"
+#~ msgstr "PAGEUP"
+
+#~ msgid "PAUSE"
+#~ msgstr "PAUSE"
+
+#~ msgid "PGDN"
+#~ msgstr "PGDN"
+
+#~ msgid "PGUP"
+#~ msgstr "PGUP"
+
+#~ msgid "PRINT"
+#~ msgstr "IMPRIMIR"
+
+#~ msgid "RETURN"
+#~ msgstr "RETURN"
+
+#~ msgid "RIGHT"
+#~ msgstr "DIREITO"
+
+#~ msgid "SCROLL_LOCK"
+#~ msgstr "SCROLL_LOCK"
+
+#~ msgid "SELECT"
+#~ msgstr "SELECT"
+
+#~ msgid "SEPARATOR"
+#~ msgstr "SEPARADOR"
+
+#~ msgid "SNAPSHOT"
+#~ msgstr "SNAPSHOT"
+
+#~ msgid "SPACE"
+#~ msgstr "SPACE"
+
+#~ msgid "SUBTRACT"
+#~ msgstr "SUBTRAIR"
+
+#~ msgid "TAB"
+#~ msgstr "TAB"
+
+#~ msgid "The print dialog returned an error."
+#~ msgstr "A janela de impressão devolveu um erro."
+
+#~ msgid "Timer creation failed."
+#~ msgstr "Falha na criação do temporizador."
+
+#~ msgid "UP"
+#~ msgstr "CIMA"
+
+#~ msgid "WINDOWS_LEFT"
+#~ msgstr "WINDOWS_LEFT"
+
+#~ msgid "WINDOWS_MENU"
+#~ msgstr "WINDOWS_MENU"
+
+#~ msgid "WINDOWS_RIGHT"
+#~ msgstr "WINDOWS_RIGHT"
+
+#~ msgid "buffer is too small for Windows directory."
+#~ msgstr "buffer pequeno demais para directório Windows."
+
+#~ msgid "percent"
+#~ msgstr "percentagem"
+
+#~ msgid "Print preview"
+#~ msgstr "Antevisão de impressão"
+
+#, fuzzy
+#~ msgid "&Preview..."
+#~ msgstr " Antevisão"
+
+#, fuzzy
+#~ msgid "Preview..."
+#~ msgstr " Antevisão"
+
+#, fuzzy
+#~ msgid "The vertical offset relative to the paragraph."
+#~ msgstr "O estilo pré-definido para o próximo parágrafo."
+
+#~ msgid "&Save..."
+#~ msgstr "&Guardar..."
+
+#~ msgid "About "
+#~ msgstr "Sobre "
+
+#~ msgid "All files (*.*)|*"
+#~ msgstr "Todos os ficheiros (*.*)|*"
+
+#~ msgid "Cannot initialize SciTech MGL!"
+#~ msgstr "Não foi possível inicializar o SciTech MGL!"
+
+#~ msgid "Cannot initialize display."
+#~ msgstr "Não foi possível inicializar o ecrã."
+
+#~ msgid "Cannot start thread: error writing TLS"
+#~ msgstr "Não foi possível iniciar a thread: erro ao escrever o TLS"
+
+#~ msgid "Close\tAlt-F4"
+#~ msgstr "Fechar\tAlt+F4"
+
+#~ msgid "Couldn't create cursor."
+#~ msgstr "Não foi possível criar um cursor."
+
+#~ msgid "Directory '%s' doesn't exist!"
+#~ msgstr "O directório '%s' não existe!"
+
+#~ msgid "Mode %ix%i-%i not available."
+#~ msgstr "Modo %ix%i-%i não disponível."
+
+#~ msgid "Paper Size"
+#~ msgstr "Tamanho do Papel"
+
+#~ msgid "%.*f GB"
+#~ msgstr "%.*f GB"
+
+#~ msgid "%.*f MB"
+#~ msgstr "%.*f MB"
+
+#~ msgid "%.*f TB"
+#~ msgstr "%.*f TB"
+
+#~ msgid "%.*f kB"
+#~ msgstr "%.*f kB"
+
+#~ msgid "%s B"
+#~ msgstr "%s B"
+
+#~ msgid "&Goto..."
+#~ msgstr "&Ir para..."
+
+#~ msgid "<<"
+#~ msgstr "<<"
+
+#~ msgid ">>"
+#~ msgstr ">>"
+
+#~ msgid ">>|"
+#~ msgstr ">>|"
+
+#~ msgid "Archive doesnt contain #SYSTEM file"
+#~ msgstr "O arquivo não contém o ficheiro #SYSTEM"
+
+#~ msgid "BIG5"
+#~ msgstr "BIG5"
+
+#~ msgid "Can't check image format of file '%s': file does not exist."
+#~ msgstr ""
+#~ "Não foi possível verificar formato da imagem do ficheiro '%s':o ficheiro "
+#~ "não existe."
+
+#~ msgid "Can't load image from file '%s': file does not exist."
+#~ msgstr ""
+#~ "Não foi possível carregar imagem do ficheiro '%s': o ficheiro não existe."
+
+#~ msgid "Cannot convert dialog units: dialog unknown."
+#~ msgstr ""
+#~ "Não foi possível converter unidades de diálogo: diálogo desconhecido."
+
+#~ msgid "Cannot convert from the charset '%s'!"
+#~ msgstr "Não foi possível converter do código de caracteres '%s'!"
+
+#~ msgid "Cannot find container for unknown control '%s'."
+#~ msgstr ""
+#~ "Não foi possível encontrar o recipiente para controlo desconhecido '%s'."
+
+#~ msgid "Cannot find font node '%s'."
+#~ msgstr "Não foi possível encontrar o nodo de fonte '%s'."
+
+#~ msgid "Cannot open file '%s'."
+#~ msgstr "Não foi possível abrir o ficheiro '%s'."
+
+#~ msgid "Cannot parse coordinates from '%s'."
+#~ msgstr "Não foi possível analisar gramaticalmente coordenadas de '%s'."
+
+#~ msgid "Cannot parse dimension from '%s'."
+#~ msgstr "Não foi possível analisar gramaticalmente dimensões de '%s'."
+
+#~ msgid "Cant create the thread event queue"
+#~ msgstr "Não foi possível criar a fila de eventos da thread"
+
+#~ msgid "Click to cancel this window."
+#~ msgstr "Clique para cancelar esta janela."
+
+#~ msgid "Click to confirm your selection."
+#~ msgstr "Clique para confirmar a sua selecção."
+
+#~ msgid "Could not unlock mutex"
+#~ msgstr "Não foi possível desbloquear a mutex"
+
+#~ msgid "Error while waiting on semaphore"
+#~ msgstr "Erro durante a espera de um semáforo"
+
+#~ msgid "Failed to create a status bar."
+#~ msgstr "Falha de criação de barra de estado."
+
+#~ msgid "Failed to register OpenGL window class."
+#~ msgstr "Falha ao registar classe de janela OpenGL."
+
+#~ msgid "Fatal error: "
+#~ msgstr "Erro Fatal: "
+
+#~ msgid "GB-2312"
+#~ msgstr "GB-2312"
+
+#~ msgid "Go forward to the next HTML page"
+#~ msgstr "Ir para a página HTML seguinte"
+
+#~ msgid "Goto Page"
+#~ msgstr "Ir para a Página"
+
+#, fuzzy
+#~ msgid ""
+#~ "HTML pagination algorithm generated more than the allowed maximum number "
+#~ "of pages and it can't continue any longer!"
+#~ msgstr ""
+#~ "O algoritmo de paginação HTML gerou mais do que o número máximo permitido "
+#~ "de páginas e pode continuar ainda mais!"
+
+#~ msgid "Help : %s"
+#~ msgstr "Ajuda : %s"
+
+#~ msgid "I64"
+#~ msgstr "I64"
+
+#~ msgid "Internal error, illegal wxCustomTypeInfo"
+#~ msgstr "Erro Interno, wxCustomTypeInfo ilegal"
+
+#~ msgid "Invalid XRC resource '%s': doesn't have root node 'resource'."
+#~ msgstr "Recurso inválido de XRC '%s': não tem recursos de root."
+
+#~ msgid "No handler found for XML node '%s', class '%s'!"
+#~ msgstr "Não foi encontrado um manuseador para o nó XML '%s', classe '%s'!"
+
+#~ msgid "No image handler for type %ld defined."
+#~ msgstr "Não existe um manuseador de imagem para o tipo %ld definido."
+
+#, fuzzy
+#~ msgid "Owner not initialized."
+#~ msgstr "Não foi possível inicializar o ecrã."
+
+#, fuzzy
+#~ msgid "Passed item is invalid."
+#~ msgstr "'%s' é inválido"
+
+#~ msgid "Passing a already registered object to SetObjectName"
+#~ msgstr "A passar um objecto já registado para SetObjectName"
+
+#~ msgid "Preparing help window..."
+#~ msgstr "A preparar janela de ajuda..."
+
+#~ msgid "Program aborted."
+#~ msgstr "Programa interrompido."
+
+#~ msgid "Referenced object node with ref=\"%s\" not found!"
+#~ msgstr "Nó de objecto referenciado com ref=\"%s\" não encontrado!"
+
+#~ msgid "Resource files must have same version number!"
+#~ msgstr "Ficheiros de recurso devem ter a mesma versão!"
+
+#~ msgid "SHIFT-JIS"
+#~ msgstr "SHIFT-JIS"
+
+#~ msgid "Search!"
+#~ msgstr "Procurar!"
+
+#~ msgid "Sorry, could not open this file for saving."
+#~ msgstr "Lamento, não é possível abrir este ficheiro para escrita."
+
+#~ msgid "Sorry, could not save this file."
+#~ msgstr "Lamento, não foi possível gravar este ficheiro."
+
+#~ msgid "Sorry, print preview needs a printer to be installed."
+#~ msgstr ""
+#~ "Lamento, a antevisão de impressão necessita de uma impressora instalada."
+
+#~ msgid "Status: "
+#~ msgstr "Estado: "
+
+#~ msgid ""
+#~ "Streaming delegates for not already streamed objects not yet supported"
+#~ msgstr ""
+#~ "Delegações de 'streaming' para objectos ainda não 'streamed' não é ainda "
+#~ "suportado"
+
+#~ msgid "Subclass '%s' not found for resource '%s', not subclassing!"
+#~ msgstr ""
+#~ "Sub-Classe '%s' não encontrada para o recurso '%s', a sub-classe não é "
+#~ "criada!"
+
+#~ msgid "TIFF library error."
+#~ msgstr "Erro de livraria TIFF."
+
+#~ msgid "TIFF library warning."
+#~ msgstr "Aviso de livraria TIFF."
+
+#~ msgid ""
+#~ "The file '%s' couldn't be opened.\n"
+#~ "It has been removed from the most recently used files list."
+#~ msgstr ""
+#~ "O ficheiro '%s' não pode ser aberto.\n"
+#~ "Este foi removido da lista de ficheiros usados mais recentemente."
+
+#~ msgid "The path '%s' contains too many \"..\"!"
+#~ msgstr "O caminho '%s' contém demasiados \"..\"!"
+
+#~ msgid "Trying to solve a NULL hostname: giving up"
+#~ msgstr "Tentativa de resolver um nome de computador NULL: a desistir"
+
+#~ msgid "Unknown style flag "
+#~ msgstr "Bandeira de estilo desconhecida "
+
+#~ msgid "Warning"
+#~ msgstr "Aviso"
+
+#~ msgid "Windows 2000 (build %lu"
+#~ msgstr "Windows 2000 (build %lu"
+
+#~ msgid "XRC resource '%s' (class '%s') not found!"
+#~ msgstr "XRC recurso '%s' (classe '%s') não encontrada!"
+
+#~ msgid "XRC resource: Cannot create animation from '%s'."
+#~ msgstr "Recurso XRC: Não é possível criar animação a partir de '%s'."
+
+#~ msgid "XRC resource: Cannot create bitmap from '%s'."
+#~ msgstr "Recurso XRC: Não é possível criar bitmap a partir de '%s'."
+
+#, fuzzy
+#~ msgid ""
+#~ "XRC resource: Incorrect colour specification '%s' for attribute '%s'."
+#~ msgstr ""
+#~ "Recurso XRC: Especificação incorrecta de cor '%s' para a propriedade '%s'."
+
+#~ msgid "[EMPTY]"
+#~ msgstr "[VAZIO]"
+
+#~ msgid "catalog file for domain '%s' not found."
+#~ msgstr "ficheiro de catálogo para o domínio '%s' não foi encontrado."
+
+#~ msgid "delegate has no type info"
+#~ msgstr "delegado não tem informação de tipo"
+
+#~ msgid "encoding %i"
+#~ msgstr "a codificar %i"
+
+#~ msgid "looking for catalog '%s' in path '%s'."
+#~ msgstr "a localizar catálogo '%s' no caminho '%s'."
+
+#~ msgid "wxRichTextFontPage"
+#~ msgstr "wxRichTextFontPage"
+
+#~ msgid "wxSearchEngine::LookFor must be called before scanning!"
+#~ msgstr "wxSearchEngine::LookFor deve ser chamado antes do rastreio!"
+
+#~ msgid "wxSocket: invalid signature in ReadMsg."
+#~ msgstr "wxSocket: assinatura inválida em ReadMsg."
+
+#~ msgid "wxSocket: unknown event!."
+#~ msgstr "wxSocket: evento desconhecido!."
+
+#~ msgid "|<<"
+#~ msgstr "|<<"
+
+#~ msgid " Couldn't create the UnicodeConverter"
+#~ msgstr " Não foi possível criar o UnicodeConverter"
+
+#~ msgid "#define %s must be an integer."
+#~ msgstr "#define %s tem de ser um inteiro."
+
+#~ msgid "%s not a bitmap resource specification."
+#~ msgstr "%s não é uma especificação de recurso bitmap."
+
+#~ msgid "%s not an icon resource specification."
+#~ msgstr "%s não é uma especificação de recurso de ícone."
+
+#~ msgid "%s: ill-formed resource file syntax."
+#~ msgstr "%s sintaxe de ficheiro de recurso mal formado."
+
+#~ msgid "&Open"
+#~ msgstr "&Abrir"
+
+#~ msgid "&Print"
+#~ msgstr "&Imprimir"
+
+#~ msgid "*** It can be found in \"%s\"\n"
+#~ msgstr "***Pode ser encontrado em \"%s\"\n"
+
+#~ msgid ""
+#~ ", expected static, #include or #define\n"
+#~ "while parsing resource."
+#~ msgstr ""
+#~ ", esperáva-se static, #include ou #define\n"
+#~ "enquanto se analisou gramaticalmente o recurso."
+
+#~ msgid "Bitmap resource specification %s not found."
+#~ msgstr "Especificação de recursos Bitmap %s não encontrada."
+
+#~ msgid "Closes the dialog without inserting a symbol."
+#~ msgstr "Fecha a caixa de diáogo sem inserir símbolo."
+
+#~ msgid ""
+#~ "Could not resolve control class or id '%s'. Use (non-zero) integer "
+#~ "instead\n"
+#~ " or provide #define (see manual for caveats)"
+#~ msgstr ""
+#~ "Não foi possível resolver controlo de classe ou id '%s'. Use um inteiro "
+#~ "(não zero)\n"
+#~ " ou coloque um #define (ver manual para os detalhes)"
+
+#~ msgid ""
+#~ "Could not resolve menu id '%s'. Use (non-zero) integer instead\n"
+#~ "or provide #define (see manual for caveats)"
+#~ msgstr ""
+#~ "Não foi possível resolver menu id '%s'. Use um inteiro (não zero)\n"
+#~ "ou coloque um #define (ver manual para os detalhes)"
+
+#~ msgid "Couldn't end the context on the overlay window"
+#~ msgstr "Não foi possível terminar o contexto na janela de sobreposição"
+
+#~ msgid "Expected '*' while parsing resource."
+#~ msgstr "Esperado '*' durante a interpretação do recurso."
+
+#~ msgid "Expected '=' while parsing resource."
+#~ msgstr "Esperado '=' durante a interpretação do recurso."
+
+#~ msgid "Expected 'char' while parsing resource."
+#~ msgstr "Esperado 'char' durante a interpretação do recurso."
+
+#~ msgid ""
+#~ "Failed to find XBM resource %s.\n"
+#~ "Forgot to use wxResourceLoadBitmapData?"
+#~ msgstr ""
+#~ "Falha ao encontrar recurso XBM %s.\n"
+#~ "Esqueceu-se de usar wxResourceLoadBitmapData?"
+
+#~ msgid ""
+#~ "Failed to find XBM resource %s.\n"
+#~ "Forgot to use wxResourceLoadIconData?"
+#~ msgstr ""
+#~ "Falha ao encontrar recurso XBM %s.\n"
+#~ "Esqueceu-se de usar wxResourceLoadIconData?"
+
+#~ msgid ""
+#~ "Failed to find XPM resource %s.\n"
+#~ "Forgot to use wxResourceLoadBitmapData?"
+#~ msgstr ""
+#~ "Falha ao encontrar recurso XBM %s.\n"
+#~ "Esqueceu-se de usar wxResourceLoadBitmapData?"
+
+#~ msgid "Failed to get clipboard data."
+#~ msgstr "Falha na obtenção de dados da área de transferência."
+
+#~ msgid "Failed to load shared library '%s' Error '%s'"
+#~ msgstr "Falha na abertura da livraria partilhada '%s' Erro de '%s'"
+
+#~ msgid "Found "
+#~ msgstr "Encontrado "
+
+#~ msgid "Icon resource specification %s not found."
+#~ msgstr "Especificação de recurso de ícone %s não encontrado."
+
+#~ msgid "Ill-formed resource file syntax."
+#~ msgstr "Sintaxe do ficheiro de recurso mal formado."
+
+#~ msgid "Inserts the chosen symbol."
+#~ msgstr "Insere o símbolo escolhido."
+
+#~ msgid "Long Conversions not supported"
+#~ msgstr "Conversões longas não suportadas"
+
+#~ msgid "No XPM icon facility available!"
+#~ msgstr "Nenhuma funcionalidade de ícone XPM disponível!"
+
+#~ msgid "Option '%s' requires a value, '=' expected."
+#~ msgstr "A opção '%s' requer um valor, '=' esperado."
+
+#~ msgid "Select all"
+#~ msgstr "Seleccionar todos"
+
+#~ msgid ""
+#~ "Sorry, docking is not supported for ports other than wxMSW, wxMac and "
+#~ "wxGTK"
+#~ msgstr ""
+#~ "Lamento, docking não é suportado por plataformas que não sejam wxMSW, "
+#~ "wxMac e wxGTK"
+
+#~ msgid "Unexpected end of file while parsing resource."
+#~ msgstr ""
+#~ "Fim de ficheiro inesperado enquanto se analisava gramaticalmente o "
+#~ "recurso."
+
+#~ msgid "Unrecognized style %s while parsing resource."
+#~ msgstr ""
+#~ "Estilo %s não reconhecido enquanto se analisava gramaticalmente o recurso."
+
+#~ msgid "Video Output"
+#~ msgstr "Saída de Vídeo"
+
+#~ msgid "Warning: attempt to remove HTML tag handler from empty stack."
+#~ msgstr ""
+#~ "Aviso: tentativa de remover um manuseador de 'tag HTML' de uma pilha "
+#~ "vazia."
+
+#~ msgid "establish"
+#~ msgstr "estabelecer"
+
+#~ msgid "initiate"
+#~ msgstr "iniciar"
+
+#~ msgid "invalid eof() return value."
+#~ msgstr "valor inválido de retorno de eof()."
+
+#~ msgid "unknown line terminator"
+#~ msgstr "terminador de linha desconhecido"
+
+#~ msgid "writing"
+#~ msgstr "a escrever"
+
+#~ msgid "wxRichTextBulletsPage"
+#~ msgstr "wxRichTextBulletsPage"
+
+#~ msgid "wxRichTextListStylePage"
+#~ msgstr "wxRichTextListStylePage"
+
+#~ msgid "wxRichTextStylePage"
+#~ msgstr "wxRichTextStylePage"

--- a/po_wxstd/pt_BR.po
+++ b/po_wxstd/pt_BR.po
@@ -1,0 +1,10622 @@
+# translation of pt_BR2.po to
+# Adiel Mittmann <adiel@inf.ufsc.br>, 2007.
+# Allann Jones <allanjos@gmail.com>, 2009.
+# translation of pt_BR.po to
+msgid ""
+msgstr ""
+"Project-Id-Version: wxWidgets 3.2.8.1\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-05-14 20:23+0200\n"
+"PO-Revision-Date: 2025-05-28 18:23-0300\n"
+"Last-Translator: Felipe <felipefplzx@gmail.com>\n"
+"Language-Team: Felipe <felipefplzx@gmail.com>\n"
+"Language: pt_BR\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=n > 1;\n"
+"X-Generator: Poedit 3.6\n"
+"X-Poedit-SourceCharset: UTF-8\n"
+
+#: ../include/wx/defs.h:2582
+msgid "All files (*.*)|*.*"
+msgstr "Todos os arquivos (*.*)|*.*"
+
+#: ../include/wx/defs.h:2585
+msgid "All files (*)|*"
+msgstr "Todos os arquivos (*)|*"
+
+#: ../include/wx/generic/progdlgg.h:85
+msgid "Elapsed time:"
+msgstr "Tempo decorrido:"
+
+#: ../include/wx/generic/progdlgg.h:86
+msgid "Estimated time:"
+msgstr "Tempo estimado:"
+
+#: ../include/wx/generic/progdlgg.h:87
+msgid "Remaining time:"
+msgstr "Tempo restante:"
+
+#. TRANSLATORS: HTML printout default title.
+#: ../include/wx/html/htmprint.h:121 ../include/wx/prntbase.h:273
+#: ../include/wx/richtext/richtextprint.h:109 ../src/common/docview.cpp:2161
+msgid "Printout"
+msgstr "Imprimir"
+
+#. TRANSLATORS: HTML easy print default title.
+#: ../include/wx/html/htmprint.h:234 ../include/wx/richtext/richtextprint.h:163
+#: ../src/common/prntbase.cpp:522 ../src/html/htmprint.cpp:291
+msgid "Printing"
+msgstr "Imprimindo"
+
+#: ../include/wx/msgdlg.h:277 ../src/common/stockitem.cpp:211
+msgid "Yes"
+msgstr "Sim"
+
+#: ../include/wx/msgdlg.h:278 ../src/common/stockitem.cpp:182
+msgid "No"
+msgstr "Não"
+
+#: ../include/wx/msgdlg.h:279 ../src/common/stockitem.cpp:183
+#: ../src/msw/msgdlg.cpp:430 ../src/msw/msgdlg.cpp:734
+#: ../src/richtext/richtextstyledlg.cpp:292
+msgid "OK"
+msgstr "Ok"
+
+#: ../include/wx/msgdlg.h:280 ../src/common/stockitem.cpp:150
+#: ../src/msw/msgdlg.cpp:430 ../src/msw/progdlg.cpp:884
+#: ../src/richtext/richtextstyledlg.cpp:295
+msgid "Cancel"
+msgstr "Cancelar"
+
+#: ../include/wx/msgdlg.h:281 ../src/common/stockitem.cpp:168
+#: ../src/html/helpdlg.cpp:63 ../src/html/helpfrm.cpp:108
+#: ../src/osx/button_osx.cpp:38
+msgid "Help"
+msgstr "Ajuda"
+
+#: ../include/wx/msw/ole/oleutils.h:52
+msgid "Cannot initialize OLE"
+msgstr "Não consegue inicializar o OLE"
+
+#: ../include/wx/msw/private/fswatcher.h:48
+#, c-format
+msgid "Unable to close the handle for '%s'"
+msgstr "Incapaz de fechar o manejamento para '%s'"
+
+#: ../include/wx/msw/private/fswatcher.h:92
+#, c-format
+msgid "Failed to open directory \"%s\" for monitoring."
+msgstr "Falhou em abrir o diretório \"%s\" pro monitoramento."
+
+#: ../include/wx/msw/private/fswatcher.h:125
+msgid "Unable to close I/O completion port handle"
+msgstr "Incapaz de fechar o manejamento do término da porta de E/S"
+
+#: ../include/wx/msw/private/fswatcher.h:142
+msgid "Unable to associate handle with I/O completion port"
+msgstr "Incapaz de associar o manejar com a porta de término de E/S"
+
+#: ../include/wx/msw/private/fswatcher.h:148
+msgid "Unexpectedly new I/O completion port was created"
+msgstr "Inesperadamente a nova porta do término de E/S foi criada"
+
+#: ../include/wx/msw/private/fswatcher.h:213
+msgid "Unable to post completion status"
+msgstr "Incapaz de postar o status do término"
+
+#: ../include/wx/msw/private/fswatcher.h:262
+msgid "Unable to dequeue completion packet"
+msgstr "Incapaz de tirar da fila o pacote do término"
+
+#: ../include/wx/msw/private/fswatcher.h:273
+msgid "Unable to create I/O completion port"
+msgstr "Incapaz de criar a porta do término da E/S"
+
+#: ../include/wx/richmsgdlg.h:29
+msgid "&See details"
+msgstr "&Ver detalhes"
+
+#: ../include/wx/richmsgdlg.h:30
+msgid "&Hide details"
+msgstr "&Esconder detalhes"
+
+#: ../include/wx/richtext/richtextbuffer.h:3864
+msgid "&Box"
+msgstr "&Caixa"
+
+#: ../include/wx/richtext/richtextbuffer.h:5008
+msgid "&Picture"
+msgstr "&Foto"
+
+#: ../include/wx/richtext/richtextbuffer.h:5958
+msgid "&Cell"
+msgstr "&Célula"
+
+#: ../include/wx/richtext/richtextbuffer.h:6067
+msgid "&Table"
+msgstr "&Tabela"
+
+#: ../include/wx/richtext/richtextimagedlg.h:37
+msgid "Object Properties"
+msgstr "Propriedades do Objeto"
+
+#: ../include/wx/richtext/richtextsymboldlg.h:39
+msgid "Symbols"
+msgstr "Símbolos"
+
+#: ../include/wx/unix/pipe.h:46
+msgid "Pipe creation failed"
+msgstr "A criação do pipe falhou"
+
+#: ../include/wx/unix/private/displayx11.h:65
+msgid "Failed to enumerate video modes"
+msgstr "Falhou em enumerar os modos de vídeo"
+
+#: ../include/wx/unix/private/displayx11.h:89
+msgid "Failed to change video mode"
+msgstr "Falhou em mudar o modo de vídeo"
+
+#: ../include/wx/unix/private/fswatcher_kqueue.h:57
+#, c-format
+msgid "Unable to open path '%s'"
+msgstr "Incapaz de abrir o caminho '%s'"
+
+#: ../include/wx/unix/private/fswatcher_kqueue.h:74
+#, c-format
+msgid "Unable to close path '%s'"
+msgstr "Incapaz de fechar o caminho '%s'"
+
+#: ../include/wx/xtiprop.h:175
+msgid "SetProperty called w/o valid setter"
+msgstr "SetProperty chamada sem um \"setter\" válido"
+
+#: ../include/wx/xtiprop.h:184
+msgid "GetProperty called w/o valid getter"
+msgstr "GetProperty chamada com ou sem um getter válido"
+
+#: ../include/wx/xtiprop.h:193
+msgid "AddToPropertyCollection called w/o valid adder"
+msgstr "AddToPropertyCollection chamado com ou sem adicionador válido"
+
+#: ../include/wx/xtiprop.h:202
+msgid "GetPropertyCollection called w/o valid collection getter"
+msgstr "GetPropertyCollection chamada com ou sem um collection getter válido"
+
+#: ../include/wx/xtiprop.h:255
+msgid "AddToPropertyCollection called on a generic accessor"
+msgstr "AddToPropertyCollection chamado num acessor genérico"
+
+#: ../include/wx/xtiprop.h:262
+msgid "GetPropertyCollection called on a generic accessor"
+msgstr "GetPropertyCollection chamada num acessor genérico"
+
+#: ../src/aui/tabmdi.cpp:106 ../src/generic/mdig.cpp:94
+msgid "Cl&ose"
+msgstr "Fe&char"
+
+#: ../src/aui/tabmdi.cpp:107 ../src/generic/mdig.cpp:95
+msgid "Close All"
+msgstr "Fechar Tudo"
+
+#: ../src/aui/tabmdi.cpp:109 ../src/generic/mdig.cpp:97 ../src/msw/mdi.cpp:175
+#: ../src/qt/mdi.cpp:258
+msgid "&Next"
+msgstr "&Próximo"
+
+#: ../src/aui/tabmdi.cpp:110 ../src/generic/mdig.cpp:98 ../src/msw/mdi.cpp:176
+#: ../src/qt/mdi.cpp:259
+msgid "&Previous"
+msgstr "&Anterior"
+
+#: ../src/aui/tabmdi.cpp:332 ../src/aui/tabmdi.cpp:348
+#: ../src/aui/tabmdi.cpp:350 ../src/generic/mdig.cpp:291
+#: ../src/generic/mdig.cpp:307 ../src/generic/mdig.cpp:311
+#: ../src/msw/mdi.cpp:337 ../src/qt/mdi.cpp:462
+msgid "&Window"
+msgstr "&Janela"
+
+#: ../src/common/accelcmn.cpp:47
+msgctxt "keyboard key"
+msgid "Delete"
+msgstr "Apagar"
+
+#: ../src/common/accelcmn.cpp:48
+msgctxt "keyboard key"
+msgid "Del"
+msgstr "Del"
+
+#: ../src/common/accelcmn.cpp:49
+msgctxt "keyboard key"
+msgid "Back"
+msgstr "Voltar"
+
+#: ../src/common/accelcmn.cpp:49
+msgctxt "keyboard key"
+msgid "Backspace"
+msgstr "Backspace"
+
+#: ../src/common/accelcmn.cpp:50
+msgctxt "keyboard key"
+msgid "Insert"
+msgstr "Insert"
+
+#: ../src/common/accelcmn.cpp:51
+msgctxt "keyboard key"
+msgid "Ins"
+msgstr "Ins"
+
+#: ../src/common/accelcmn.cpp:52
+msgctxt "keyboard key"
+msgid "Enter"
+msgstr "Enter"
+
+#: ../src/common/accelcmn.cpp:53
+msgctxt "keyboard key"
+msgid "Return"
+msgstr "Retornar"
+
+#: ../src/common/accelcmn.cpp:54
+msgctxt "keyboard key"
+msgid "PageUp"
+msgstr "PageUp"
+
+#: ../src/common/accelcmn.cpp:54
+msgctxt "keyboard key"
+msgid "Page Up"
+msgstr "Page Up"
+
+#: ../src/common/accelcmn.cpp:55
+msgctxt "keyboard key"
+msgid "PageDown"
+msgstr "PageDown"
+
+#: ../src/common/accelcmn.cpp:55
+msgctxt "keyboard key"
+msgid "Page Down"
+msgstr "Page Down"
+
+#: ../src/common/accelcmn.cpp:56
+msgctxt "keyboard key"
+msgid "PgUp"
+msgstr "PgUp"
+
+#: ../src/common/accelcmn.cpp:57
+msgctxt "keyboard key"
+msgid "PgDn"
+msgstr "PgDn"
+
+#: ../src/common/accelcmn.cpp:58
+msgctxt "keyboard key"
+msgid "Left"
+msgstr "Esquerda"
+
+#: ../src/common/accelcmn.cpp:59
+msgctxt "keyboard key"
+msgid "Right"
+msgstr "Direita"
+
+#: ../src/common/accelcmn.cpp:60
+msgctxt "keyboard key"
+msgid "Up"
+msgstr "Pra cima"
+
+#: ../src/common/accelcmn.cpp:61
+msgctxt "keyboard key"
+msgid "Down"
+msgstr "Pra baixo"
+
+#: ../src/common/accelcmn.cpp:62
+msgctxt "keyboard key"
+msgid "Home"
+msgstr "Home"
+
+#: ../src/common/accelcmn.cpp:63
+msgctxt "keyboard key"
+msgid "End"
+msgstr "End"
+
+#: ../src/common/accelcmn.cpp:64
+msgctxt "keyboard key"
+msgid "Space"
+msgstr "Barra de espaço"
+
+#: ../src/common/accelcmn.cpp:65
+msgctxt "keyboard key"
+msgid "Tab"
+msgstr "Aba"
+
+#: ../src/common/accelcmn.cpp:66
+msgctxt "keyboard key"
+msgid "Esc"
+msgstr "Esc"
+
+#: ../src/common/accelcmn.cpp:67
+msgctxt "keyboard key"
+msgid "Escape"
+msgstr "Escape"
+
+#: ../src/common/accelcmn.cpp:68
+msgctxt "keyboard key"
+msgid "Cancel"
+msgstr "Cancelar"
+
+#: ../src/common/accelcmn.cpp:69
+msgctxt "keyboard key"
+msgid "Clear"
+msgstr "Limpar"
+
+#: ../src/common/accelcmn.cpp:70
+msgctxt "keyboard key"
+msgid "Menu"
+msgstr "Menu"
+
+#: ../src/common/accelcmn.cpp:71
+msgctxt "keyboard key"
+msgid "Pause"
+msgstr "Pausa"
+
+#: ../src/common/accelcmn.cpp:72
+msgctxt "keyboard key"
+msgid "Capital"
+msgstr "Maiúscula"
+
+#: ../src/common/accelcmn.cpp:73
+msgctxt "keyboard key"
+msgid "Select"
+msgstr "Selecionar"
+
+#: ../src/common/accelcmn.cpp:74
+msgctxt "keyboard key"
+msgid "Print"
+msgstr "Imprimir"
+
+#: ../src/common/accelcmn.cpp:75
+msgctxt "keyboard key"
+msgid "Execute"
+msgstr "Executar"
+
+#: ../src/common/accelcmn.cpp:76
+msgctxt "keyboard key"
+msgid "Snapshot"
+msgstr "Snapshot"
+
+#: ../src/common/accelcmn.cpp:77
+msgctxt "keyboard key"
+msgid "Help"
+msgstr "Ajuda"
+
+#: ../src/common/accelcmn.cpp:78
+msgctxt "keyboard key"
+msgid "Add"
+msgstr "Adicionar"
+
+#: ../src/common/accelcmn.cpp:79
+msgctxt "keyboard key"
+msgid "Separator"
+msgstr "Separador"
+
+#: ../src/common/accelcmn.cpp:80
+msgctxt "keyboard key"
+msgid "Subtract"
+msgstr "Subtrair"
+
+#: ../src/common/accelcmn.cpp:81
+msgctxt "keyboard key"
+msgid "Decimal"
+msgstr "Decimal"
+
+#: ../src/common/accelcmn.cpp:82
+msgctxt "keyboard key"
+msgid "Multiply"
+msgstr "Multiplicar"
+
+#: ../src/common/accelcmn.cpp:83
+msgctxt "keyboard key"
+msgid "Divide"
+msgstr "Dividir"
+
+#: ../src/common/accelcmn.cpp:84
+msgctxt "keyboard key"
+msgid "Num_lock"
+msgstr "Num_lock"
+
+#: ../src/common/accelcmn.cpp:84
+msgctxt "keyboard key"
+msgid "Num Lock"
+msgstr "Num Lock"
+
+#: ../src/common/accelcmn.cpp:85
+msgctxt "keyboard key"
+msgid "Scroll_lock"
+msgstr "Scroll_lock"
+
+#: ../src/common/accelcmn.cpp:85
+msgctxt "keyboard key"
+msgid "Scroll Lock"
+msgstr "Scroll Lock"
+
+#: ../src/common/accelcmn.cpp:86
+msgctxt "keyboard key"
+msgid "KP_Space"
+msgstr "KP_Barra de Espaço"
+
+#: ../src/common/accelcmn.cpp:86
+msgctxt "keyboard key"
+msgid "Num Space"
+msgstr "Num Barra de Espaço"
+
+#: ../src/common/accelcmn.cpp:87
+msgctxt "keyboard key"
+msgid "KP_Tab"
+msgstr "KP_Aba"
+
+#: ../src/common/accelcmn.cpp:87
+msgctxt "keyboard key"
+msgid "Num Tab"
+msgstr "Num Aba"
+
+#: ../src/common/accelcmn.cpp:88
+msgctxt "keyboard key"
+msgid "KP_Enter"
+msgstr "KP_Enter"
+
+#: ../src/common/accelcmn.cpp:88
+msgctxt "keyboard key"
+msgid "Num Enter"
+msgstr "Num Enter"
+
+#: ../src/common/accelcmn.cpp:89
+msgctxt "keyboard key"
+msgid "KP_Home"
+msgstr "KP_Home"
+
+#: ../src/common/accelcmn.cpp:89
+msgctxt "keyboard key"
+msgid "Num Home"
+msgstr "Num Home"
+
+#: ../src/common/accelcmn.cpp:90
+msgctxt "keyboard key"
+msgid "KP_Left"
+msgstr "KP_Esquerda"
+
+#: ../src/common/accelcmn.cpp:90
+msgctxt "keyboard key"
+msgid "Num left"
+msgstr "Num Esquerda"
+
+#: ../src/common/accelcmn.cpp:91
+msgctxt "keyboard key"
+msgid "KP_Up"
+msgstr "KP_Pra Cima"
+
+#: ../src/common/accelcmn.cpp:91
+msgctxt "keyboard key"
+msgid "Num Up"
+msgstr "Num Pra Cima"
+
+#: ../src/common/accelcmn.cpp:92
+msgctxt "keyboard key"
+msgid "KP_Right"
+msgstr "KP_Direita"
+
+#: ../src/common/accelcmn.cpp:92
+msgctxt "keyboard key"
+msgid "Num Right"
+msgstr "Num Direita"
+
+#: ../src/common/accelcmn.cpp:93
+msgctxt "keyboard key"
+msgid "KP_Down"
+msgstr "KP_Pra Baixo"
+
+#: ../src/common/accelcmn.cpp:93
+msgctxt "keyboard key"
+msgid "Num Down"
+msgstr "Num Pra Baixo"
+
+#: ../src/common/accelcmn.cpp:94
+msgctxt "keyboard key"
+msgid "KP_PageUp"
+msgstr "KP_PageUp"
+
+#: ../src/common/accelcmn.cpp:94
+msgctxt "keyboard key"
+msgid "Num Page Up"
+msgstr "Num Page Up"
+
+#: ../src/common/accelcmn.cpp:95
+msgctxt "keyboard key"
+msgid "KP_PageDown"
+msgstr "KP_PageDown"
+
+#: ../src/common/accelcmn.cpp:95
+msgctxt "keyboard key"
+msgid "Num Page Down"
+msgstr "Num Page Down"
+
+#: ../src/common/accelcmn.cpp:96
+msgctxt "keyboard key"
+msgid "KP_Prior"
+msgstr "KP_Anterior"
+
+#: ../src/common/accelcmn.cpp:97
+msgctxt "keyboard key"
+msgid "KP_Next"
+msgstr "KP_Próximo"
+
+#: ../src/common/accelcmn.cpp:98
+msgctxt "keyboard key"
+msgid "KP_End"
+msgstr "KP_End"
+
+#: ../src/common/accelcmn.cpp:98
+msgctxt "keyboard key"
+msgid "Num End"
+msgstr "Num End"
+
+#: ../src/common/accelcmn.cpp:99
+msgctxt "keyboard key"
+msgid "KP_Begin"
+msgstr "KP_Começar"
+
+#: ../src/common/accelcmn.cpp:99
+msgctxt "keyboard key"
+msgid "Num Begin"
+msgstr "Num Começar"
+
+#: ../src/common/accelcmn.cpp:100
+msgctxt "keyboard key"
+msgid "KP_Insert"
+msgstr "KP_Insert"
+
+#: ../src/common/accelcmn.cpp:100
+msgctxt "keyboard key"
+msgid "Num Insert"
+msgstr "Num Insert"
+
+#: ../src/common/accelcmn.cpp:101
+msgctxt "keyboard key"
+msgid "KP_Delete"
+msgstr "KP_Apagar"
+
+#: ../src/common/accelcmn.cpp:101
+msgctxt "keyboard key"
+msgid "Num Delete"
+msgstr "Num Apagar"
+
+#: ../src/common/accelcmn.cpp:102
+msgctxt "keyboard key"
+msgid "KP_Equal"
+msgstr "KP_Igual"
+
+#: ../src/common/accelcmn.cpp:102
+msgctxt "keyboard key"
+msgid "Num ="
+msgstr "Num ="
+
+#: ../src/common/accelcmn.cpp:103
+msgctxt "keyboard key"
+msgid "KP_Multiply"
+msgstr "KP_Multiplicar"
+
+#: ../src/common/accelcmn.cpp:103
+msgctxt "keyboard key"
+msgid "Num *"
+msgstr "Num *"
+
+#: ../src/common/accelcmn.cpp:104
+msgctxt "keyboard key"
+msgid "KP_Add"
+msgstr "KP_Adicionar"
+
+#: ../src/common/accelcmn.cpp:104
+msgctxt "keyboard key"
+msgid "Num +"
+msgstr "Num +"
+
+#: ../src/common/accelcmn.cpp:105
+msgctxt "keyboard key"
+msgid "KP_Separator"
+msgstr "KP_Separador"
+
+#: ../src/common/accelcmn.cpp:105
+msgctxt "keyboard key"
+msgid "Num ,"
+msgstr "Num ,"
+
+#: ../src/common/accelcmn.cpp:106
+msgctxt "keyboard key"
+msgid "KP_Subtract"
+msgstr "KP_Subtrair"
+
+#: ../src/common/accelcmn.cpp:106
+msgctxt "keyboard key"
+msgid "Num -"
+msgstr "Num -"
+
+#: ../src/common/accelcmn.cpp:107
+msgctxt "keyboard key"
+msgid "KP_Decimal"
+msgstr "KP_Decimal"
+
+#: ../src/common/accelcmn.cpp:107
+msgctxt "keyboard key"
+msgid "Num ."
+msgstr "Num ."
+
+#: ../src/common/accelcmn.cpp:108
+msgctxt "keyboard key"
+msgid "KP_Divide"
+msgstr "KP_Dividir"
+
+#: ../src/common/accelcmn.cpp:108
+msgctxt "keyboard key"
+msgid "Num /"
+msgstr "Num /"
+
+#: ../src/common/accelcmn.cpp:109
+msgctxt "keyboard key"
+msgid "Windows_Left"
+msgstr "Janelas_Esquerda"
+
+#: ../src/common/accelcmn.cpp:110
+msgctxt "keyboard key"
+msgid "Windows_Right"
+msgstr "Janelas_Direita"
+
+#: ../src/common/accelcmn.cpp:111
+msgctxt "keyboard key"
+msgid "Windows_Menu"
+msgstr "Janelas_Menu"
+
+#: ../src/common/accelcmn.cpp:112
+msgctxt "keyboard key"
+msgid "Command"
+msgstr "Comando"
+
+#: ../src/common/accelcmn.cpp:186 ../src/common/accelcmn.cpp:359
+msgctxt "keyboard key"
+msgid "Ctrl"
+msgstr "Ctrl"
+
+#: ../src/common/accelcmn.cpp:188 ../src/common/accelcmn.cpp:363
+msgctxt "keyboard key"
+msgid "Alt"
+msgstr "Alt"
+
+#: ../src/common/accelcmn.cpp:190 ../src/common/accelcmn.cpp:361
+msgctxt "keyboard key"
+msgid "Shift"
+msgstr "Shift"
+
+#: ../src/common/accelcmn.cpp:196
+msgctxt "keyboard key"
+msgid "num "
+msgstr "num "
+
+#: ../src/common/accelcmn.cpp:260 ../src/common/accelcmn.cpp:382
+msgctxt "keyboard key"
+msgid "F"
+msgstr "F"
+
+#: ../src/common/accelcmn.cpp:277 ../src/common/accelcmn.cpp:385
+msgctxt "keyboard key"
+msgid "KP_F"
+msgstr "KP_F"
+
+#: ../src/common/accelcmn.cpp:280 ../src/common/accelcmn.cpp:388
+msgctxt "keyboard key"
+msgid "KP_"
+msgstr "KP_"
+
+#: ../src/common/accelcmn.cpp:283 ../src/common/accelcmn.cpp:391
+msgctxt "keyboard key"
+msgid "SPECIAL"
+msgstr "ESPECIAL"
+
+#: ../src/common/accelcmn.cpp:373
+#| msgctxt "keyboard key"
+#| msgid "Ctrl"
+msgid "Ctrl"
+msgstr "Ctrl"
+
+#: ../src/common/appbase.cpp:786
+msgid "show this help message"
+msgstr "mostrar esta mensagem de ajuda"
+
+#: ../src/common/appbase.cpp:796
+msgid "generate verbose log messages"
+msgstr "gerar mensagens de log prolixas"
+
+#: ../src/common/appcmn.cpp:256
+msgid "specify the theme to use"
+msgstr "especificar o tema a usar"
+
+#: ../src/common/appcmn.cpp:270
+msgid "specify display mode to use (e.g. 640x480-16)"
+msgstr "especificar o modo de exibição a usar (ex: 640x480-16)"
+
+#: ../src/common/appcmn.cpp:292
+#, c-format
+msgid "Unsupported theme '%s'."
+msgstr "Tema não suportado '%s'."
+
+#: ../src/common/appcmn.cpp:309
+#, c-format
+msgid "Invalid display mode specification '%s'."
+msgstr "Especificação do modo de exibição '%s' inválida."
+
+#: ../src/common/cmdline.cpp:875
+#, c-format
+msgid "Option '%s' can't be negated"
+msgstr "A opção '%s' não pode ser negada"
+
+#: ../src/common/cmdline.cpp:889
+#, c-format
+msgid "Unknown long option '%s'"
+msgstr "Opção longa desconhecida '%s'"
+
+#: ../src/common/cmdline.cpp:904 ../src/common/cmdline.cpp:926
+#, c-format
+msgid "Unknown option '%s'"
+msgstr "Opção desconhecida '%s'"
+
+#: ../src/common/cmdline.cpp:1004
+#, c-format
+msgid "Unexpected characters following option '%s'."
+msgstr "Caracteres inesperados seguindo a opção '%s'."
+
+#: ../src/common/cmdline.cpp:1039
+#, c-format
+msgid "Option '%s' requires a value."
+msgstr "A opção '%s' requer um valor."
+
+#: ../src/common/cmdline.cpp:1058
+#, c-format
+msgid "Separator expected after the option '%s'."
+msgstr "Separador esperado após a opção '%s'."
+
+#: ../src/common/cmdline.cpp:1088 ../src/common/cmdline.cpp:1106
+#, c-format
+msgid "'%s' is not a correct numeric value for option '%s'."
+msgstr "'%s' não é um valor numérico correto para a opção '%s'."
+
+#: ../src/common/cmdline.cpp:1122
+#, c-format
+msgid "Option '%s': '%s' cannot be converted to a date."
+msgstr "A opção '%s': '%s' não pode ser convertida para uma data."
+
+#: ../src/common/cmdline.cpp:1170
+#, c-format
+msgid "Unexpected parameter '%s'"
+msgstr "Parâmetro inesperado '%s'"
+
+#. TRANSLATORS: Short name and long name for a command line option
+#: ../src/common/cmdline.cpp:1197
+#, c-format
+msgid "%s (or %s)"
+msgstr "%s (ou %s)"
+
+#: ../src/common/cmdline.cpp:1208
+#, c-format
+msgid "The value for the option '%s' must be specified."
+msgstr "O valor para a opção '%s' deve ser especificado."
+
+#: ../src/common/cmdline.cpp:1230
+#, c-format
+msgid "The required parameter '%s' was not specified."
+msgstr "O parâmetro requerido '%s' não foi especificado."
+
+#: ../src/common/cmdline.cpp:1289
+#, c-format
+msgid "Usage: %s"
+msgstr "Uso: %s"
+
+#: ../src/common/cmdline.cpp:1498
+msgid "str"
+msgstr "str"
+
+#: ../src/common/cmdline.cpp:1502
+msgid "num"
+msgstr "num"
+
+#: ../src/common/cmdline.cpp:1506
+msgid "double"
+msgstr "duplo"
+
+#: ../src/common/cmdline.cpp:1510
+msgid "date"
+msgstr "data"
+
+#: ../src/common/cmdproc.cpp:250 ../src/common/cmdproc.cpp:276
+#: ../src/common/cmdproc.cpp:296
+msgid "Unnamed command"
+msgstr "Comando sem nome"
+
+#: ../src/common/cmdproc.cpp:253
+msgid "&Undo "
+msgstr "&Desfazer "
+
+#: ../src/common/cmdproc.cpp:255
+msgid "Can't &Undo "
+msgstr "Não Consegue &Desfazer "
+
+#: ../src/common/cmdproc.cpp:259 ../src/common/stockitem.cpp:208
+#: ../src/msw/textctrl.cpp:2880 ../src/osx/textctrl_osx.cpp:649
+#: ../src/richtext/richtextctrl.cpp:327
+msgid "&Undo"
+msgstr "&Desfazer"
+
+#: ../src/common/cmdproc.cpp:277 ../src/common/cmdproc.cpp:297
+msgid "&Redo "
+msgstr "&Refazer "
+
+#: ../src/common/cmdproc.cpp:281 ../src/common/cmdproc.cpp:288
+#: ../src/common/stockitem.cpp:190 ../src/msw/textctrl.cpp:2881
+#: ../src/osx/textctrl_osx.cpp:650 ../src/richtext/richtextctrl.cpp:328
+msgid "&Redo"
+msgstr "&Refazer"
+
+#: ../src/common/colourcmn.cpp:41
+#, c-format
+msgid "String To Colour : Incorrect colour specification : %s"
+msgstr "String pra Cor: Especificação da cor incorreta: %s"
+
+#: ../src/common/config.cpp:259
+#, c-format
+msgid "Invalid value %ld for a boolean key \"%s\" in config file."
+msgstr "Valor inválido %ld pra uma chave booleana \"%s\" no arquivo da config."
+
+#: ../src/common/config.cpp:526
+#, c-format
+msgid ""
+"Environment variables expansion failed: missing '%c' at position %u in '%s'."
+msgstr ""
+"A expansão das variáveis do ambiente falhou: '%c' ausente na posição %u em "
+"'%s'."
+
+#: ../src/common/config.cpp:576 ../src/msw/regconf.cpp:272
+#, c-format
+msgid "'%s' has extra '..', ignored."
+msgstr "'%s' tem extras '..'; ignorados."
+
+#. TRANSLATORS: Checkbox state name
+#: ../src/common/datavcmn.cpp:2166 ../src/generic/datavgen.cpp:1430
+msgid "checked"
+msgstr "verificado"
+
+#. TRANSLATORS: Checkbox state name
+#: ../src/common/datavcmn.cpp:2170 ../src/generic/datavgen.cpp:1432
+msgid "unchecked"
+msgstr "não verificado"
+
+#. TRANSLATORS: Checkbox state name
+#: ../src/common/datavcmn.cpp:2174
+msgid "undetermined"
+msgstr "não determinado"
+
+#: ../src/common/datetimefmt.cpp:1875
+msgid "today"
+msgstr "hoje"
+
+#: ../src/common/datetimefmt.cpp:1876
+msgid "yesterday"
+msgstr "ontem"
+
+#: ../src/common/datetimefmt.cpp:1877
+msgid "tomorrow"
+msgstr "amanhã"
+
+#: ../src/common/datetimefmt.cpp:2071
+msgid "first"
+msgstr "primeiro"
+
+#: ../src/common/datetimefmt.cpp:2072
+msgid "second"
+msgstr "segundo"
+
+#: ../src/common/datetimefmt.cpp:2073
+msgid "third"
+msgstr "terceiro"
+
+#: ../src/common/datetimefmt.cpp:2074
+msgid "fourth"
+msgstr "quarto"
+
+#: ../src/common/datetimefmt.cpp:2075
+msgid "fifth"
+msgstr "quinto"
+
+#: ../src/common/datetimefmt.cpp:2076
+msgid "sixth"
+msgstr "sexto"
+
+#: ../src/common/datetimefmt.cpp:2077
+msgid "seventh"
+msgstr "sétimo"
+
+#: ../src/common/datetimefmt.cpp:2078
+msgid "eighth"
+msgstr "oitavo"
+
+#: ../src/common/datetimefmt.cpp:2079
+msgid "ninth"
+msgstr "nono"
+
+#: ../src/common/datetimefmt.cpp:2080
+msgid "tenth"
+msgstr "décimo"
+
+#: ../src/common/datetimefmt.cpp:2081
+msgid "eleventh"
+msgstr "décimo-primeiro"
+
+#: ../src/common/datetimefmt.cpp:2082
+msgid "twelfth"
+msgstr "décimo-segundo"
+
+#: ../src/common/datetimefmt.cpp:2083
+msgid "thirteenth"
+msgstr "décimo-terceiro"
+
+#: ../src/common/datetimefmt.cpp:2084
+msgid "fourteenth"
+msgstr "décimo-quarto"
+
+#: ../src/common/datetimefmt.cpp:2085
+msgid "fifteenth"
+msgstr "décimo-quinto"
+
+#: ../src/common/datetimefmt.cpp:2086
+msgid "sixteenth"
+msgstr "décimo-sexto"
+
+#: ../src/common/datetimefmt.cpp:2087
+msgid "seventeenth"
+msgstr "décimo-sétimo"
+
+#: ../src/common/datetimefmt.cpp:2088
+msgid "eighteenth"
+msgstr "décimo-oitavo"
+
+#: ../src/common/datetimefmt.cpp:2089
+msgid "nineteenth"
+msgstr "décimo-nono"
+
+#: ../src/common/datetimefmt.cpp:2090
+msgid "twentieth"
+msgstr "vigésimo"
+
+#: ../src/common/datetimefmt.cpp:2248
+msgid "noon"
+msgstr "meio-dia"
+
+#: ../src/common/datetimefmt.cpp:2249
+msgid "midnight"
+msgstr "meia-noite"
+
+#: ../src/common/debugrpt.cpp:209
+#, c-format
+msgid "Failed to create directory \"%s\""
+msgstr "Falhou em criar o diretório \"%s\""
+
+#: ../src/common/debugrpt.cpp:210
+msgid "Debug report couldn't be created."
+msgstr "O relatório de debug não pôde ser criado."
+
+#: ../src/common/debugrpt.cpp:227
+#, c-format
+msgid "Failed to remove debug report file \"%s\""
+msgstr "Falhou em remover o arquivo do relatório do debug \"%s\""
+
+#: ../src/common/debugrpt.cpp:239
+#, c-format
+msgid "Failed to clean up debug report directory \"%s\""
+msgstr "Falhou em limpar o diretório do relatório de debug \"%s\""
+
+#: ../src/common/debugrpt.cpp:514
+msgid "process context description"
+msgstr "descrição do contexto do processo"
+
+#: ../src/common/debugrpt.cpp:538
+msgid "dump of the process state (binary)"
+msgstr "dump do estado do processo (binário)"
+
+#: ../src/common/debugrpt.cpp:553
+msgid "Debug report generation has failed."
+msgstr "A geração do relatório de debug falhou."
+
+#: ../src/common/debugrpt.cpp:560
+#, c-format
+msgid ""
+"Processing debug report has failed, leaving the files in \"%s\" directory."
+msgstr ""
+"O processamento do relatório do debug falhou, deixando os arquivos no "
+"diretório \"%s\"."
+
+#: ../src/common/debugrpt.cpp:573
+msgid "A debug report has been generated. It can be found in"
+msgstr "Um relatório de debug foi gerado. Ele pode ser achado em"
+
+#: ../src/common/debugrpt.cpp:576
+msgid "And includes the following files:\n"
+msgstr "E inclui os seguintes arquivos:\n"
+
+#: ../src/common/debugrpt.cpp:586
+msgid ""
+"\n"
+"Please send this report to the program maintainer, thank you!\n"
+msgstr ""
+"\n"
+"Por favor envie este relatório ao mantedor do programa, obrigado!\n"
+
+#: ../src/common/debugrpt.cpp:729
+msgid "Failed to execute curl, please install it in PATH."
+msgstr "Falhou em executar o curl, por favor instale-o no PATH."
+
+#: ../src/common/debugrpt.cpp:742
+#, c-format
+msgid "Failed to upload the debug report (error code %d)."
+msgstr "Falhou em enviar o relatório de debug (código do erro %d)."
+
+#: ../src/common/docview.cpp:366
+msgid "Save As"
+msgstr "Salvar Como"
+
+#: ../src/common/docview.cpp:457
+msgid "Discard changes and reload the last saved version?"
+msgstr "Descartar mudanças e recarregar a última versão salva?"
+
+#: ../src/common/docview.cpp:488
+msgid "unnamed"
+msgstr "sem nome"
+
+#: ../src/common/docview.cpp:513
+#, c-format
+msgid "Do you want to save changes to %s?"
+msgstr "Você quer salvar as mudanças em %s?"
+
+#: ../src/common/docview.cpp:521 ../src/common/docview.cpp:560
+#: ../src/common/stockitem.cpp:195
+msgid "&Save"
+msgstr "&Salvar"
+
+#: ../src/common/docview.cpp:522 ../src/common/docview.cpp:560
+msgid "&Discard changes"
+msgstr "&Descartar mudanças"
+
+#: ../src/common/docview.cpp:523
+msgid "Do&n't close"
+msgstr "Nã&o fechar"
+
+#: ../src/common/docview.cpp:553
+#, c-format
+msgid "Do you want to save changes to %s before closing it?"
+msgstr "Você quer salvar as mudanças em %s? antes de fechá-lo?"
+
+#: ../src/common/docview.cpp:559
+msgid "The document must be closed."
+msgstr "O documento deve ser fechado."
+
+#: ../src/common/docview.cpp:571
+#, c-format
+msgid "Saving %s failed, would you like to retry?"
+msgstr "Falhou em salvar o %s, você gostaria de tentar de novo?"
+
+#: ../src/common/docview.cpp:577
+msgid "Retry"
+msgstr "Tentar de novo"
+
+#: ../src/common/docview.cpp:577
+msgid "Discard changes"
+msgstr "Descartar mudanças"
+
+#: ../src/common/docview.cpp:679
+#, c-format
+msgid "File \"%s\" could not be opened for writing."
+msgstr "O arquivo \"%s\" não pôde ser aberto para gravação."
+
+#: ../src/common/docview.cpp:685
+#, c-format
+msgid "Failed to save document to the file \"%s\"."
+msgstr "Falhou em salvar o documento como arquivo \"%s\"."
+
+#: ../src/common/docview.cpp:702
+#, c-format
+msgid "File \"%s\" could not be opened for reading."
+msgstr "O arquivo \"%s\" não pôde ser aberto pra leitura."
+
+#: ../src/common/docview.cpp:714
+#, c-format
+msgid "Failed to read document from the file \"%s\"."
+msgstr "Falhou em ler o documento do arquivo \"%s\"."
+
+#: ../src/common/docview.cpp:1236
+#, c-format
+msgid ""
+"The file '%s' doesn't exist and couldn't be opened.\n"
+"It has been removed from the most recently used files list."
+msgstr ""
+"O arquivo '%s' não existe e não pôde ser aberto.\n"
+"Ele foi removido da lista dos arquivos mais usados recentemente."
+
+#: ../src/common/docview.cpp:1296
+msgid "Print preview creation failed."
+msgstr "A criação da pré-visualização da impressão falhou."
+
+#: ../src/common/docview.cpp:1302
+msgid "Print Preview"
+msgstr "Pré-visualização da Impressão"
+
+#: ../src/common/docview.cpp:1517
+#, c-format
+msgid "The format of file '%s' couldn't be determined."
+msgstr "O formato do arquivo '%s' não pôde ser determinado."
+
+#: ../src/common/docview.cpp:1643
+#, c-format
+msgid "unnamed%d"
+msgstr "%d sem nome"
+
+#: ../src/common/docview.cpp:1660
+msgid " - "
+msgstr " - "
+
+#: ../src/common/docview.cpp:1791 ../src/common/docview.cpp:1844
+msgid "Open File"
+msgstr "Abrir Arquivo"
+
+#: ../src/common/docview.cpp:1807
+msgid "File error"
+msgstr "Erro do arquivo"
+
+#: ../src/common/docview.cpp:1809
+msgid "Sorry, could not open this file."
+msgstr "Lamento, não pude abrir este arquivo."
+
+#: ../src/common/docview.cpp:1843
+msgid "Sorry, the format for this file is unknown."
+msgstr "Lamento, o formato pra este arquivo é desconhecido."
+
+#: ../src/common/docview.cpp:1924
+msgid "Select a document template"
+msgstr "Selecione um modelo de documento"
+
+#: ../src/common/docview.cpp:1925
+msgid "Templates"
+msgstr "Modelos"
+
+#: ../src/common/docview.cpp:1998
+msgid "Select a document view"
+msgstr "Selecione uma visualização do documento"
+
+#: ../src/common/docview.cpp:1999
+msgid "Views"
+msgstr "Visualizações"
+
+#: ../src/common/dynlib.cpp:81
+#, c-format
+msgid "Failed to load shared library '%s'"
+msgstr "Falhou em carregar a biblioteca compartilhada '%s'"
+
+#: ../src/common/dynlib.cpp:105
+#, c-format
+msgid "Couldn't find symbol '%s' in a dynamic library"
+msgstr "Não pôde achar o símbolo '%s' em uma biblioteca dinâmica"
+
+#: ../src/common/ffile.cpp:56 ../src/common/file.cpp:215
+#, c-format
+msgid "can't open file '%s'"
+msgstr "não pode abrir o arquivo '%s'"
+
+#: ../src/common/ffile.cpp:72
+#, c-format
+msgid "can't close file '%s'"
+msgstr "não pode fechar o arquivo '%s'"
+
+#: ../src/common/ffile.cpp:106 ../src/common/ffile.cpp:131
+#, c-format
+msgid "Read error on file '%s'"
+msgstr "Erro de leitura no arquivo '%s'"
+
+#: ../src/common/ffile.cpp:148
+#, c-format
+msgid "Write error on file '%s'"
+msgstr "Erro de gravação no arquivo '%s'"
+
+#: ../src/common/ffile.cpp:182
+#, c-format
+msgid "failed to flush the file '%s'"
+msgstr "falhou em limpar o arquivo '%s'"
+
+#: ../src/common/ffile.cpp:222
+#, c-format
+msgid "Seek error on file '%s' (large files not supported by stdio)"
+msgstr ""
+"Erro de busca no arquivo '%s' (arquivos grandes não suportados pela stdio)"
+
+#: ../src/common/ffile.cpp:232
+#, c-format
+msgid "Seek error on file '%s'"
+msgstr "Erro de busca no arquivo '%s'"
+
+#: ../src/common/ffile.cpp:248
+#, c-format
+msgid "Can't find current position in file '%s'"
+msgstr "Não consegue achar a posição atual no arquivo '%s'"
+
+#: ../src/common/ffile.cpp:349 ../src/common/file.cpp:569
+msgid "Failed to set temporary file permissions"
+msgstr "Falhou em definir as permissões do arquivo temporário"
+
+#: ../src/common/ffile.cpp:371
+#, c-format
+msgid "can't remove file '%s'"
+msgstr "não consegue remover o arquivo '%s'"
+
+#: ../src/common/ffile.cpp:376 ../src/common/file.cpp:591
+#, c-format
+msgid "can't commit changes to file '%s'"
+msgstr "não consegue fazer as mudanças no arquivo '%s'"
+
+#: ../src/common/ffile.cpp:388 ../src/common/file.cpp:603
+#, c-format
+msgid "can't remove temporary file '%s'"
+msgstr "não consegue remover o arquivo temporário '%s'"
+
+#: ../src/common/file.cpp:162
+#, c-format
+msgid "can't create file '%s'"
+msgstr "não consegue criar o arquivo '%s'"
+
+#: ../src/common/file.cpp:229
+#, c-format
+msgid "can't close file descriptor %d"
+msgstr "não consegue fechar o descritor do arquivo %d"
+
+#: ../src/common/file.cpp:332
+#, c-format
+msgid "can't read from file descriptor %d"
+msgstr "não consegue ler do descritor de arquivos %d"
+
+#: ../src/common/file.cpp:351
+#, c-format
+msgid "can't write to file descriptor %d"
+msgstr "não consegue gravar no descritor de arquivos %d"
+
+#: ../src/common/file.cpp:390
+#, c-format
+msgid "can't flush file descriptor %d"
+msgstr "não consegue limpar o descritor de arquivos %d"
+
+#: ../src/common/file.cpp:432
+#, c-format
+msgid "can't seek on file descriptor %d"
+msgstr "não consegue procurar no descritor de arquivos %d"
+
+#: ../src/common/file.cpp:446
+#, c-format
+msgid "can't get seek position on file descriptor %d"
+msgstr "não consegue obter a posição da busca no descritor de arquivos %d"
+
+#: ../src/common/file.cpp:475
+#, c-format
+msgid "can't find length of file on file descriptor %d"
+msgstr "não consegue achar o tamanho do arquivo no descritor de arquivos %d"
+
+#: ../src/common/file.cpp:505
+#, c-format
+msgid "can't determine if the end of file is reached on descriptor %d"
+msgstr ""
+"não consegue determinar se o final do arquivo é alcançado no descritor %d"
+
+#: ../src/common/fileconf.cpp:352
+#, c-format
+msgid ""
+" and additionally, the existing configuration file was renamed to \"%s\" and "
+"couldn't be renamed back, please rename it to its original path \"%s\""
+msgstr ""
+" E adicionalmente, o arquivo de configuração existente foi renomeado pra "
+"\"%s\" e não pôde ser renomeado de novo, por favor renomeie-o pro seu "
+"caminho original \"%s\""
+
+#: ../src/common/fileconf.cpp:389
+msgid " due to the following error:\n"
+msgstr " devido ao seguinte erro:\n"
+
+#: ../src/common/fileconf.cpp:412
+msgid "failed to rename the existing file"
+msgstr "Falhou em renomear o arquivo existente"
+
+#: ../src/common/fileconf.cpp:421
+msgid "failed to create the new file directory"
+msgstr "Falhou em criar o novo diretório do arquivo"
+
+#: ../src/common/fileconf.cpp:428
+msgid "failed to move the file to the new location"
+msgstr "Falhou em mover o arquivo para o novo local"
+
+#: ../src/common/fileconf.cpp:462
+#, c-format
+msgid "can't open global configuration file '%s'."
+msgstr "não consegue abrir o arquivo de configuração global '%s'."
+
+#: ../src/common/fileconf.cpp:478
+#, c-format
+msgid "can't open user configuration file '%s'."
+msgstr "não consegue abrir o arquivo de configuração do usuário '%s'."
+
+#: ../src/common/fileconf.cpp:483
+#, c-format
+msgid "Changes won't be saved to avoid overwriting the existing file \"%s\""
+msgstr ""
+"As mudanças não serão salvas pra evitar sobrescrever o arquivo existente "
+"\"%s\""
+
+#: ../src/common/fileconf.cpp:583
+msgid "Error reading config options."
+msgstr "Erro ao ler as opções da config."
+
+#: ../src/common/fileconf.cpp:593
+msgid "Failed to read config options."
+msgstr "Falhou em ler as opções de config."
+
+#: ../src/common/fileconf.cpp:700
+#, c-format
+msgid "file '%s': unexpected character %c at line %zu."
+msgstr "arquivo '%s': caractere ineperado %c na linha %zu."
+
+#: ../src/common/fileconf.cpp:736
+#, c-format
+msgid "file '%s', line %zu: '%s' ignored after group header."
+msgstr "arquivo '%s', linha %zu: '%s' ignorado após o cabeçalho do grupo."
+
+#: ../src/common/fileconf.cpp:765
+#, c-format
+msgid "file '%s', line %zu: '=' expected."
+msgstr "arquivo '%s', linha %zu: '=' esperado."
+
+#: ../src/common/fileconf.cpp:778
+#, c-format
+msgid "file '%s', line %zu: value for immutable key '%s' ignored."
+msgstr "arquivo '%s', linha %zu: valor para a chave imutável '%s' ignorado."
+
+#: ../src/common/fileconf.cpp:788
+#, c-format
+msgid "file '%s', line %zu: key '%s' was first found at line %d."
+msgstr "arquivo '%s', linha %zu: chave '%s' foi achada primeiro na linha %d."
+
+#: ../src/common/fileconf.cpp:1091
+#, c-format
+msgid "Config entry name cannot start with '%c'."
+msgstr "O nome da entrada da config não pode iniciar com '%c'."
+
+#: ../src/common/fileconf.cpp:1146
+msgid "Failed to create configuration file directory."
+msgstr "Falhou em criar o diretório do arquivo de configuração."
+
+#: ../src/common/fileconf.cpp:1158
+msgid "can't open user configuration file."
+msgstr "não pode abrir o arquivo de configuração do usuário."
+
+#: ../src/common/fileconf.cpp:1172
+msgid "can't write user configuration file."
+msgstr "não pode gravar o arquivo de configuração do usuário."
+
+#: ../src/common/fileconf.cpp:1178
+msgid "Failed to update user configuration file."
+msgstr "Falhou em atualizar o arquivo de configuração do usuário."
+
+#: ../src/common/fileconf.cpp:1201
+msgid "Error saving user configuration data."
+msgstr "Erro ao salvar os dados de configuração do usuário."
+
+#: ../src/common/fileconf.cpp:1313
+#, c-format
+msgid "can't delete user configuration file '%s'"
+msgstr "não pode apagar o arquivo de configuração do usuário '%s'"
+
+#: ../src/common/fileconf.cpp:2007
+#, c-format
+msgid "entry '%s' appears more than once in group '%s'"
+msgstr "a entrada '%s' aparece mais do que uma vez no grupo '%s'"
+
+#: ../src/common/fileconf.cpp:2021
+#, c-format
+msgid "attempt to change immutable key '%s' ignored."
+msgstr "tentativa de mudar a chave imutável '%s' ignorada."
+
+#: ../src/common/fileconf.cpp:2118
+#, c-format
+msgid "trailing backslash ignored in '%s'"
+msgstr "barra invertida do rastreamento ignorada em '%s'"
+
+#: ../src/common/fileconf.cpp:2153
+#, c-format
+msgid "unexpected \" at position %d in '%s'."
+msgstr "inesperado \" na posição %d em '%s'."
+
+#: ../src/common/filefn.cpp:474
+#, c-format
+msgid "Failed to copy the file '%s' to '%s'"
+msgstr "Falhou em copiar o arquivo '%s' pra '%s'"
+
+#: ../src/common/filefn.cpp:487
+#, c-format
+msgid "Impossible to get permissions for file '%s'"
+msgstr "Impossível obter as permissões pro arquivo '%s'"
+
+#: ../src/common/filefn.cpp:501
+#, c-format
+msgid "Impossible to overwrite the file '%s'"
+msgstr "Impossível sobrescrever o arquivo '%s'"
+
+#: ../src/common/filefn.cpp:508
+#, c-format
+msgid "Error copying the file '%s' to '%s'."
+msgstr "Erro ao copiar o arquivo '%s' para '%s'."
+
+#: ../src/common/filefn.cpp:556
+#, c-format
+msgid "Impossible to set permissions for the file '%s'"
+msgstr "Impossível definir as permissões para o arquivo '%s'"
+
+#: ../src/common/filefn.cpp:606
+#, c-format
+msgid ""
+"Failed to rename the file '%s' to '%s' because the destination file already "
+"exists."
+msgstr ""
+"Falhou em renomear o arquivo '%s' para '%s' porque o arquivo destino já "
+"existe."
+
+#: ../src/common/filefn.cpp:623
+#, c-format
+msgid "File '%s' couldn't be renamed '%s'"
+msgstr "O arquivo '%s' não pôde ser renomeado '%s'"
+
+#: ../src/common/filefn.cpp:639
+#, c-format
+msgid "File '%s' couldn't be removed"
+msgstr "O arquivo '%s' não pôde ser removido"
+
+#: ../src/common/filefn.cpp:666
+#, c-format
+msgid "Directory '%s' couldn't be created"
+msgstr "O diretório '%s' não pôde ser criado"
+
+#: ../src/common/filefn.cpp:680
+#, c-format
+msgid "Directory '%s' couldn't be deleted"
+msgstr "O diretório '%s' não pôde ser apagado"
+
+#: ../src/common/filefn.cpp:714
+#, c-format
+msgid "Cannot enumerate files '%s'"
+msgstr "Não consegue enumerar os arquivos '%s'"
+
+#: ../src/common/filefn.cpp:798
+msgid "Failed to get the working directory"
+msgstr "Falhou em obter o diretório de trabalho"
+
+#: ../src/common/filefn.cpp:843
+msgid "Could not set current working directory"
+msgstr "Não pôde definir o diretório de trabalho atual"
+
+#: ../src/common/filefn.cpp:974
+#, c-format
+msgid "Files (%s)"
+msgstr "Arquivos (%s)"
+
+#: ../src/common/filename.cpp:182
+#, c-format
+msgid "Failed to open '%s' for reading"
+msgstr "Falhou em abrir '%s' para leitura"
+
+#: ../src/common/filename.cpp:187
+#, c-format
+msgid "Failed to open '%s' for writing"
+msgstr "Falhou em abrir '%s' para gravação"
+
+#: ../src/common/filename.cpp:199
+msgid "Failed to close file handle"
+msgstr "Falhou em fechar o manejamento dos arquivos"
+
+#: ../src/common/filename.cpp:1046
+msgid "Failed to create a temporary file name"
+msgstr "Falhou em criar um nome de arquivo temporário"
+
+#: ../src/common/filename.cpp:1081
+msgid "Failed to open temporary file."
+msgstr "Falhou em abrir o arquivo temporário."
+
+#: ../src/common/filename.cpp:2862
+#, c-format
+msgid "Failed to modify file times for '%s'"
+msgstr "Falhou em modificar as horas do arquivo para '%s'"
+
+#: ../src/common/filename.cpp:2877
+#, c-format
+msgid "Failed to touch the file '%s'"
+msgstr "Falhou em tocar o arquivo '%s'"
+
+#: ../src/common/filename.cpp:2958
+#, c-format
+msgid "Failed to retrieve file times for '%s'"
+msgstr "Falhou em recuperar as horas do arquivo para '%s'"
+
+#: ../src/common/filepickercmn.cpp:39 ../src/common/filepickercmn.cpp:40
+msgid "Browse"
+msgstr "Procurar"
+
+#: ../src/common/fldlgcmn.cpp:792 ../src/generic/filectrlg.cpp:1185
+#, c-format
+msgid "All files (%s)|%s"
+msgstr "Todos os arquivos (%s)|%s"
+
+#. TRANSLATORS: %s are a file extension used to build a file wildcard string
+#: ../src/common/fldlgcmn.cpp:810
+#, c-format
+msgid "%s files (%s)|%s"
+msgstr "Arquivos %s (%s)|%s"
+
+#: ../src/common/fldlgcmn.cpp:1072
+#, c-format
+msgid "Load %s file"
+msgstr "Carrega o arquivo %s"
+
+#: ../src/common/fldlgcmn.cpp:1074
+#, c-format
+msgid "Save %s file"
+msgstr "Salvar arquivo %s"
+
+#: ../src/common/fmapbase.cpp:144
+msgid "Western European (ISO-8859-1)"
+msgstr "Europeu Ocidental (ISO-8859-1)"
+
+#: ../src/common/fmapbase.cpp:145
+msgid "Central European (ISO-8859-2)"
+msgstr "Europeu Central (ISO-8859-2)"
+
+#: ../src/common/fmapbase.cpp:146
+msgid "Esperanto (ISO-8859-3)"
+msgstr "Esperanto (ISO-8859-3)"
+
+#: ../src/common/fmapbase.cpp:147
+msgid "Baltic (old) (ISO-8859-4)"
+msgstr "Báltico (antigo) (ISO-8859-4)"
+
+#: ../src/common/fmapbase.cpp:148
+msgid "Cyrillic (ISO-8859-5)"
+msgstr "Cirílico (ISO-8859-5)"
+
+#: ../src/common/fmapbase.cpp:149
+msgid "Arabic (ISO-8859-6)"
+msgstr "Árabe (ISO-8859-6)"
+
+#: ../src/common/fmapbase.cpp:150
+msgid "Greek (ISO-8859-7)"
+msgstr "Grego (ISO-8859-7)"
+
+#: ../src/common/fmapbase.cpp:151
+msgid "Hebrew (ISO-8859-8)"
+msgstr "Hebraico (ISO-8859-8)"
+
+#: ../src/common/fmapbase.cpp:152
+msgid "Turkish (ISO-8859-9)"
+msgstr "Turco (ISO-8859-9)"
+
+#: ../src/common/fmapbase.cpp:153
+msgid "Nordic (ISO-8859-10)"
+msgstr "Nórdico (ISO-8859-10)"
+
+#: ../src/common/fmapbase.cpp:154
+msgid "Thai (ISO-8859-11)"
+msgstr "Tailandês (ISO-8859-11)"
+
+#: ../src/common/fmapbase.cpp:155
+msgid "Indian (ISO-8859-12)"
+msgstr "Indiano (ISO-8859-12)"
+
+#: ../src/common/fmapbase.cpp:156
+msgid "Baltic (ISO-8859-13)"
+msgstr "Báltico (ISO-8859-13)"
+
+#: ../src/common/fmapbase.cpp:157
+msgid "Celtic (ISO-8859-14)"
+msgstr "Celta (ISO-8859-14)"
+
+#: ../src/common/fmapbase.cpp:158
+msgid "Western European with Euro (ISO-8859-15)"
+msgstr "Europeu Ocidental com o Euro (ISO-8859-15)"
+
+#: ../src/common/fmapbase.cpp:159
+msgid "KOI8-R"
+msgstr "KOI8-R"
+
+#: ../src/common/fmapbase.cpp:160
+msgid "KOI8-U"
+msgstr "KOI8-U"
+
+#: ../src/common/fmapbase.cpp:161
+msgid "Windows/DOS OEM Cyrillic (CP 866)"
+msgstr "Windows/DOS OEM Cirílico (CP 866)"
+
+#: ../src/common/fmapbase.cpp:162
+msgid "Windows Thai (CP 874)"
+msgstr "Windows Tailandês (CP 874)"
+
+#: ../src/common/fmapbase.cpp:163
+msgid "Windows Japanese (CP 932) or Shift-JIS"
+msgstr "Windows Japonês (CP 932) ou Shift-JIS"
+
+#: ../src/common/fmapbase.cpp:164
+msgid "Windows Chinese Simplified (CP 936) or GB-2312"
+msgstr "Windows Chinês Simplificado (CP 936) ou GB-2312"
+
+#: ../src/common/fmapbase.cpp:165
+msgid "Windows Korean (CP 949)"
+msgstr "Windows Coreano (CP 949)"
+
+#: ../src/common/fmapbase.cpp:166
+msgid "Windows Chinese Traditional (CP 950) or Big-5"
+msgstr "Windows Chinês Tradicional (CP 950) ou Big-5"
+
+#: ../src/common/fmapbase.cpp:167
+msgid "Windows Central European (CP 1250)"
+msgstr "Windows Europeu Central (CP 1250)"
+
+#: ../src/common/fmapbase.cpp:168
+msgid "Windows Cyrillic (CP 1251)"
+msgstr "Windows Cirílico (CP 1251)"
+
+#: ../src/common/fmapbase.cpp:169
+msgid "Windows Western European (CP 1252)"
+msgstr "Windows Europeu Ocidental (CP 1252)"
+
+#: ../src/common/fmapbase.cpp:170
+msgid "Windows Greek (CP 1253)"
+msgstr "Windows Grego (CP 1253)"
+
+#: ../src/common/fmapbase.cpp:171
+msgid "Windows Turkish (CP 1254)"
+msgstr "Windows Turco (CP 1254)"
+
+#: ../src/common/fmapbase.cpp:172
+msgid "Windows Hebrew (CP 1255)"
+msgstr "Windows Hebraico (CP 1255)"
+
+#: ../src/common/fmapbase.cpp:173
+msgid "Windows Arabic (CP 1256)"
+msgstr "Windows Árabe (CP 1256)"
+
+#: ../src/common/fmapbase.cpp:174
+msgid "Windows Baltic (CP 1257)"
+msgstr "Windows Báltico (CP 1257)"
+
+#: ../src/common/fmapbase.cpp:175
+msgid "Windows Vietnamese (CP 1258)"
+msgstr "Windows Vietnamita (CP 1258)"
+
+#: ../src/common/fmapbase.cpp:176
+msgid "Windows Johab (CP 1361)"
+msgstr "Windows Johab (CP 1361)"
+
+#: ../src/common/fmapbase.cpp:177
+msgid "Windows/DOS OEM (CP 437)"
+msgstr "Windows/DOS OEM (CP 437)"
+
+#: ../src/common/fmapbase.cpp:178
+msgid "Unicode 7 bit (UTF-7)"
+msgstr "Unicode 7 bits (UTF-7)"
+
+#: ../src/common/fmapbase.cpp:179
+msgid "Unicode 8 bit (UTF-8)"
+msgstr "Unicode 8 bits (UTF-8)"
+
+#: ../src/common/fmapbase.cpp:181 ../src/common/fmapbase.cpp:187
+msgid "Unicode 16 bit (UTF-16)"
+msgstr "Unicode 16 bits (UTF-16)"
+
+#: ../src/common/fmapbase.cpp:182
+msgid "Unicode 16 bit Little Endian (UTF-16LE)"
+msgstr "Unicode 16 bits Little Endian (UTF-16LE)"
+
+#: ../src/common/fmapbase.cpp:183 ../src/common/fmapbase.cpp:189
+msgid "Unicode 32 bit (UTF-32)"
+msgstr "Unicode 32 bits (UTF-32)"
+
+#: ../src/common/fmapbase.cpp:184
+msgid "Unicode 32 bit Little Endian (UTF-32LE)"
+msgstr "Unicode 32 bits Little Endian (UTF-32LE)"
+
+#: ../src/common/fmapbase.cpp:186
+msgid "Unicode 16 bit Big Endian (UTF-16BE)"
+msgstr "Unicode 16 bits Big Endian (UTF-16BE)"
+
+#: ../src/common/fmapbase.cpp:188
+msgid "Unicode 32 bit Big Endian (UTF-32BE)"
+msgstr "Unicode 32 bits Big Endian (UTF-32BE)"
+
+#: ../src/common/fmapbase.cpp:191
+msgid "Extended Unix Codepage for Japanese (EUC-JP)"
+msgstr "Página do Código Unix Extendida pro Japonês (EUC-JP)"
+
+#: ../src/common/fmapbase.cpp:192
+msgid "US-ASCII"
+msgstr "US-ASCII"
+
+#: ../src/common/fmapbase.cpp:193
+msgid "ISO-2022-JP"
+msgstr "ISO-2022-JP"
+
+#: ../src/common/fmapbase.cpp:195
+msgid "MacRoman"
+msgstr "MacRomano"
+
+#: ../src/common/fmapbase.cpp:196
+msgid "MacJapanese"
+msgstr "MacJaponês"
+
+#: ../src/common/fmapbase.cpp:197
+msgid "MacChineseTrad"
+msgstr "MacChinêsTradicional"
+
+#: ../src/common/fmapbase.cpp:198
+msgid "MacKorean"
+msgstr "MacCoreano"
+
+#: ../src/common/fmapbase.cpp:199
+msgid "MacArabic"
+msgstr "MacÁrabe"
+
+#: ../src/common/fmapbase.cpp:200
+msgid "MacHebrew"
+msgstr "MacHebreu"
+
+#: ../src/common/fmapbase.cpp:201
+msgid "MacGreek"
+msgstr "MacGrego"
+
+#: ../src/common/fmapbase.cpp:202
+msgid "MacCyrillic"
+msgstr "MacCirílico"
+
+#: ../src/common/fmapbase.cpp:203
+msgid "MacDevanagari"
+msgstr "MacDevanagari"
+
+#: ../src/common/fmapbase.cpp:204
+msgid "MacGurmukhi"
+msgstr "MacGurmukhi"
+
+#: ../src/common/fmapbase.cpp:205
+msgid "MacGujarati"
+msgstr "MacGuzerate"
+
+#: ../src/common/fmapbase.cpp:206
+msgid "MacOriya"
+msgstr "MacOriá"
+
+#: ../src/common/fmapbase.cpp:207
+msgid "MacBengali"
+msgstr "MacBengalês"
+
+#: ../src/common/fmapbase.cpp:208
+msgid "MacTamil"
+msgstr "MacTâmil"
+
+#: ../src/common/fmapbase.cpp:209
+msgid "MacTelugu"
+msgstr "MacTelugu"
+
+#: ../src/common/fmapbase.cpp:210
+msgid "MacKannada"
+msgstr "MacKannada"
+
+#: ../src/common/fmapbase.cpp:211
+msgid "MacMalayalam"
+msgstr "MacMalaio"
+
+#: ../src/common/fmapbase.cpp:212
+msgid "MacSinhalese"
+msgstr "MacCingalês"
+
+#: ../src/common/fmapbase.cpp:213
+msgid "MacBurmese"
+msgstr "MacBirmanês"
+
+#: ../src/common/fmapbase.cpp:214
+msgid "MacKhmer"
+msgstr "MacKhmer"
+
+#: ../src/common/fmapbase.cpp:215
+msgid "MacThai"
+msgstr "MacTailandês"
+
+#: ../src/common/fmapbase.cpp:216
+msgid "MacLaotian"
+msgstr "MacLaociano"
+
+#: ../src/common/fmapbase.cpp:217
+msgid "MacGeorgian"
+msgstr "MacGeorgiano"
+
+#: ../src/common/fmapbase.cpp:218
+msgid "MacArmenian"
+msgstr "MacArmênio"
+
+#: ../src/common/fmapbase.cpp:219
+msgid "MacChineseSimp"
+msgstr "MacChinêsSimplificado"
+
+#: ../src/common/fmapbase.cpp:220
+msgid "MacTibetan"
+msgstr "MacTibetano"
+
+#: ../src/common/fmapbase.cpp:221
+msgid "MacMongolian"
+msgstr "MacMongol"
+
+#: ../src/common/fmapbase.cpp:222
+msgid "MacEthiopic"
+msgstr "MacEtíope"
+
+#: ../src/common/fmapbase.cpp:223
+msgid "MacCentralEurRoman"
+msgstr "MacEuropeuCentralRomano"
+
+#: ../src/common/fmapbase.cpp:224
+msgid "MacVietnamese"
+msgstr "MacVietnamita"
+
+#: ../src/common/fmapbase.cpp:225
+msgid "MacExtArabic"
+msgstr "MacExtÁrabe"
+
+#: ../src/common/fmapbase.cpp:226
+msgid "MacSymbol"
+msgstr "MacSímbolo"
+
+#: ../src/common/fmapbase.cpp:227
+msgid "MacDingbats"
+msgstr "MacDingbats"
+
+#: ../src/common/fmapbase.cpp:228
+msgid "MacTurkish"
+msgstr "MacTurco"
+
+#: ../src/common/fmapbase.cpp:229
+msgid "MacCroatian"
+msgstr "MacCroata"
+
+#: ../src/common/fmapbase.cpp:230
+msgid "MacIcelandic"
+msgstr "MacIslandês"
+
+#: ../src/common/fmapbase.cpp:231
+msgid "MacRomanian"
+msgstr "MacRomeno"
+
+#: ../src/common/fmapbase.cpp:232
+msgid "MacCeltic"
+msgstr "MacCelta"
+
+#: ../src/common/fmapbase.cpp:233
+msgid "MacGaelic"
+msgstr "MacGaélico"
+
+#: ../src/common/fmapbase.cpp:234
+msgid "MacKeyboardGlyphs"
+msgstr "MacGlifosdoTeclado"
+
+#: ../src/common/fmapbase.cpp:791
+msgid "Default encoding"
+msgstr "Codificação padrão"
+
+#: ../src/common/fmapbase.cpp:805
+#, c-format
+msgid "Unknown encoding (%d)"
+msgstr "Codificação desconhecida (%d)"
+
+#: ../src/common/fmapbase.cpp:815 ../src/richtext/richtextstyles.cpp:776
+msgid "default"
+msgstr "padrão"
+
+#: ../src/common/fmapbase.cpp:829
+#, c-format
+msgid "unknown-%d"
+msgstr "desconhecido- %d"
+
+#: ../src/common/fontcmn.cpp:924 ../src/common/fontcmn.cpp:1130
+msgid "underlined"
+msgstr "sublinhado"
+
+#: ../src/common/fontcmn.cpp:929
+msgid " strikethrough"
+msgstr " sublinhado"
+
+#: ../src/common/fontcmn.cpp:942
+msgid " thin"
+msgstr " magro"
+
+#: ../src/common/fontcmn.cpp:946
+msgid " extra light"
+msgstr " extra-leve"
+
+#: ../src/common/fontcmn.cpp:950
+msgid " light"
+msgstr " leve"
+
+#: ../src/common/fontcmn.cpp:954
+msgid " medium"
+msgstr " médio"
+
+#: ../src/common/fontcmn.cpp:958
+msgid " semi bold"
+msgstr " semi-negrito"
+
+#: ../src/common/fontcmn.cpp:962
+msgid " bold"
+msgstr " negrito"
+
+#: ../src/common/fontcmn.cpp:966
+msgid " extra bold"
+msgstr " extra-negrito"
+
+#: ../src/common/fontcmn.cpp:970
+msgid " heavy"
+msgstr " pesado"
+
+#: ../src/common/fontcmn.cpp:974
+msgid " extra heavy"
+msgstr " extra-pesado"
+
+#: ../src/common/fontcmn.cpp:990
+msgid " italic"
+msgstr " itálico"
+
+#: ../src/common/fontcmn.cpp:1134
+msgid "strikethrough"
+msgstr "riscar"
+
+#: ../src/common/fontcmn.cpp:1143
+msgid "thin"
+msgstr "magro"
+
+#: ../src/common/fontcmn.cpp:1156
+msgid "extralight"
+msgstr "extra-leve"
+
+#: ../src/common/fontcmn.cpp:1161
+msgid "light"
+msgstr "leve"
+
+#: ../src/common/fontcmn.cpp:1169 ../src/richtext/richtextstyles.cpp:775
+msgid "normal"
+msgstr "normal"
+
+#: ../src/common/fontcmn.cpp:1174
+msgid "medium"
+msgstr "médio"
+
+#: ../src/common/fontcmn.cpp:1179 ../src/common/fontcmn.cpp:1199
+msgid "semibold"
+msgstr "semi-negrito"
+
+#: ../src/common/fontcmn.cpp:1184
+msgid "bold"
+msgstr "negrito"
+
+#: ../src/common/fontcmn.cpp:1194
+msgid "extrabold"
+msgstr "extra-negrito"
+
+#: ../src/common/fontcmn.cpp:1204
+msgid "heavy"
+msgstr "pesado"
+
+#: ../src/common/fontcmn.cpp:1212
+msgid "extraheavy"
+msgstr "extra-pesado"
+
+#: ../src/common/fontcmn.cpp:1217
+msgid "italic"
+msgstr "itálico"
+
+#: ../src/common/fontmap.cpp:195
+msgid ": unknown charset"
+msgstr ": conjunto de caracteres desconhecido"
+
+#: ../src/common/fontmap.cpp:199
+#, c-format
+msgid ""
+"The charset '%s' is unknown. You may select\n"
+"another charset to replace it with or choose\n"
+"[Cancel] if it cannot be replaced"
+msgstr ""
+"O conjunto de caracteres '%s' é desconhecido. Você pode selecionar\n"
+"outro conjunto de caracteres pra substituí-lo ou escolher\n"
+"[Cancelar] se ele não pode ser substituído"
+
+#: ../src/common/fontmap.cpp:241
+#, c-format
+msgid "Failed to remember the encoding for the charset '%s'."
+msgstr "Falhou em lembrar a codificação do conjunto de caracteres '%s'."
+
+#: ../src/common/fontmap.cpp:321
+msgid "can't load any font, aborting"
+msgstr "não pode carregar qualquer fonte, abortando"
+
+#: ../src/common/fontmap.cpp:409
+msgid ": unknown encoding"
+msgstr ": codificação desconhecida"
+
+#: ../src/common/fontmap.cpp:417
+#, c-format
+msgid ""
+"No font for displaying text in encoding '%s' found,\n"
+"but an alternative encoding '%s' is available.\n"
+"Do you want to use this encoding (otherwise you will have to choose another "
+"one)?"
+msgstr ""
+"Nenhuma fonte pra exibir o texto na codificação '%s' achada,\n"
+"mas uma codificação alternativa '%s' está disponível.\n"
+"Você quer usar esta codificação (de outro modo você terá que escolher outra)?"
+
+#: ../src/common/fontmap.cpp:422
+#, c-format
+msgid ""
+"No font for displaying text in encoding '%s' found.\n"
+"Would you like to select a font to be used for this encoding\n"
+"(otherwise the text in this encoding will not be shown correctly)?"
+msgstr ""
+"Nenhuma fonte pra exibir o texto na codificação '%s' foi achada.\n"
+"Você gostaria de selecionar a fonte a ser usada para esta codificação?\n"
+"(de outro modo o texto nesta codificação não será mostrado corretamente)"
+
+#: ../src/common/fs_mem.cpp:169
+#, c-format
+msgid "Memory VFS already contains file '%s'!"
+msgstr "A memória VFS já contém o arquivo '%s'!"
+
+#: ../src/common/fs_mem.cpp:232
+#, c-format
+msgid "Trying to remove file '%s' from memory VFS, but it is not loaded!"
+msgstr ""
+"Tentando remover o arquivo '%s' da memória VFS mas ele não está carregado!"
+
+#: ../src/common/fs_mem.cpp:262
+#, c-format
+msgid "Failed to store image '%s' to memory VFS!"
+msgstr "Falhou em armazenar a imagem '%s' na memória VFS!"
+
+#: ../src/common/ftp.cpp:197
+msgid "Timeout while waiting for FTP server to connect, try passive mode."
+msgstr ""
+"Tempo pra esgotar enquanto espera o servidor FTP se conectar, tente o modo "
+"passivo."
+
+#: ../src/common/ftp.cpp:399
+#, c-format
+msgid "Failed to set FTP transfer mode to %s."
+msgstr "Falhou em definir o modo de transferência do FTP para %s."
+
+#: ../src/common/ftp.cpp:400 ../src/richtext/richtextsymboldlg.cpp:432
+msgid "ASCII"
+msgstr "ASCII"
+
+#: ../src/common/ftp.cpp:400
+msgid "binary"
+msgstr "binário"
+
+#: ../src/common/ftp.cpp:608
+msgid "The FTP server doesn't support the PORT command."
+msgstr "O servidor FTP não suporta o comando \"PORT\"."
+
+#: ../src/common/ftp.cpp:622
+msgid "The FTP server doesn't support passive mode."
+msgstr "O servidor FTP não suporta o modo passivo."
+
+#: ../src/common/gifdecod.cpp:822
+#, c-format
+msgid "Incorrect GIF frame size (%u, %d) for the frame #%u"
+msgstr "Tamanho do frame do GIF incorreto (%u, %d) para o frame #%u"
+
+#: ../src/common/glcmn.cpp:108
+msgid "Failed to allocate colour for OpenGL"
+msgstr "Falhou em distribuir a côr pro OpenGL"
+
+#: ../src/common/headerctrlcmn.cpp:57
+msgid "Please select the columns to show and define their order:"
+msgstr "Por favor selecione as colunas a mostrar e defina a ordem delas:"
+
+#: ../src/common/headerctrlcmn.cpp:58
+msgid "Customize Columns"
+msgstr "Personalizar Colunas"
+
+#: ../src/common/headerctrlcmn.cpp:304
+msgid "&Customize..."
+msgstr "&Personalizar..."
+
+#: ../src/common/hyperlnkcmn.cpp:132
+#, c-format
+msgid "Failed to open URL \"%s\" in the default browser"
+msgstr "Falhou em abrir a URL '%s' no navegador padrão"
+
+#: ../src/common/iconbndl.cpp:195
+#, c-format
+msgid "Failed to load image %%d from file '%s'."
+msgstr "Falhou em carregar a imagem %%d do arquivo '%s'."
+
+#: ../src/common/iconbndl.cpp:203
+#, c-format
+msgid "Failed to load image %d from stream."
+msgstr "Falhou em carregar a imagem %d do fluxo."
+
+#: ../src/common/iconbndl.cpp:221
+#, c-format
+msgid "Failed to load icons from resource '%s'."
+msgstr "Falhou em carregar os ícones do recurso '%s'."
+
+#: ../src/common/imagbmp.cpp:97
+msgid "BMP: Couldn't save invalid image."
+msgstr "BMP: Não consegue salvar a imagem inválida."
+
+#: ../src/common/imagbmp.cpp:137
+msgid "BMP: wxImage doesn't have own wxPalette."
+msgstr "BMP: o wxImage não tem uma wxPalette própria."
+
+#: ../src/common/imagbmp.cpp:243
+msgid "BMP: Couldn't write the file (Bitmap) header."
+msgstr "BMP: Não consegue gravar o cabeçalho do arquivo (Bitmap)."
+
+#: ../src/common/imagbmp.cpp:266
+msgid "BMP: Couldn't write the file (BitmapInfo) header."
+msgstr "BMP: Não consegue gravar o cabeçalho do arquivo (BitmapInfo)."
+
+#: ../src/common/imagbmp.cpp:353
+msgid "BMP: Couldn't write RGB color map."
+msgstr "BMP: Não consegue gravar o mapa das cores RGB."
+
+#: ../src/common/imagbmp.cpp:487
+msgid "BMP: Couldn't write data."
+msgstr "BMP: Não consegue gravar os dados."
+
+#: ../src/common/imagbmp.cpp:561 ../src/common/imagbmp.cpp:642
+msgid "BMP: Couldn't allocate memory."
+msgstr "BMP: Não consegue distribuir a memória."
+
+#: ../src/common/imagbmp.cpp:1041
+msgid "DIB Header: Image width > 32767 pixels for file."
+msgstr "Cabeçalho do DIB: Largura da imagem > 32767 pixels no arquivo."
+
+#: ../src/common/imagbmp.cpp:1049
+msgid "DIB Header: Image height > 32767 pixels for file."
+msgstr "Cabeçalho do DIB: Altura da imagem > 32767 pixels no arquivo."
+
+#: ../src/common/imagbmp.cpp:1081
+msgid "DIB Header: Unknown bitdepth in file."
+msgstr "Cabeçalho do DIB: Profundidade dos bits desconhecida no arquivo."
+
+#: ../src/common/imagbmp.cpp:1156
+msgid "DIB Header: Unknown encoding in file."
+msgstr "Cabeçalho do DIB: Codificação desconhecida no arquivo."
+
+#: ../src/common/imagbmp.cpp:1165
+msgid "DIB Header: Encoding doesn't match bitdepth."
+msgstr ""
+"Cabeçalho do DIB: A codificação não combina com a profundidade dos bits."
+
+#: ../src/common/imagbmp.cpp:1180
+#, c-format
+msgid "BMP Header: Invalid number of colors (%d)."
+msgstr "Cabeçalho BMP: número inválido de cores (%d)."
+
+#: ../src/common/imagbmp.cpp:1273
+msgid "Error in reading image DIB."
+msgstr "Erro ao ler a imagem do DIB."
+
+#: ../src/common/imagbmp.cpp:1294
+msgid "ICO: Error in reading mask DIB."
+msgstr "ICO: Erro ao ler a máscara do DIB."
+
+#: ../src/common/imagbmp.cpp:1353
+msgid "ICO: Image too tall for an icon."
+msgstr "ICO: Imagem muito alta para um ícone."
+
+#: ../src/common/imagbmp.cpp:1361
+msgid "ICO: Image too wide for an icon."
+msgstr "ICO: Imagem muito larga para um ícone."
+
+#: ../src/common/imagbmp.cpp:1388 ../src/common/imagbmp.cpp:1488
+#: ../src/common/imagbmp.cpp:1503 ../src/common/imagbmp.cpp:1514
+#: ../src/common/imagbmp.cpp:1528 ../src/common/imagbmp.cpp:1576
+#: ../src/common/imagbmp.cpp:1591 ../src/common/imagbmp.cpp:1605
+#: ../src/common/imagbmp.cpp:1616
+msgid "ICO: Error writing the image file!"
+msgstr "ICO: Erro ao gravar o arquivo de imagem!"
+
+#: ../src/common/imagbmp.cpp:1701
+msgid "ICO: Invalid icon index."
+msgstr "ICO: Índice do ícone inválido ."
+
+#: ../src/common/image.cpp:2410
+msgid "Image and mask have different sizes."
+msgstr "Imagem e máscara tem tamanhos diferentes."
+
+#: ../src/common/image.cpp:2418 ../src/common/image.cpp:2459
+msgid "No unused colour in image being masked."
+msgstr "Nenhuma côr sem uso na imagem sendo mascarada."
+
+#: ../src/common/image.cpp:2641
+#, c-format
+msgid "Failed to load bitmap \"%s\" from resources."
+msgstr "Falhou em carregar o bitmap \"%s\" dos recursos."
+
+#: ../src/common/image.cpp:2650
+#, c-format
+msgid "Failed to load icon \"%s\" from resources."
+msgstr "Falhou em carregar o ícone \"%s\" dos recursos."
+
+#: ../src/common/image.cpp:2728 ../src/common/image.cpp:2747
+#, c-format
+msgid "Failed to load image from file \"%s\"."
+msgstr "Falhou em carregar a imagem do arquivo \"%s\"."
+
+#: ../src/common/image.cpp:2761
+#, c-format
+msgid "Can't save image to file '%s': unknown extension."
+msgstr "Nâo consegue salvar a imagem no arquivo '%s': extensão desconhecida."
+
+#: ../src/common/image.cpp:2869
+msgid "No handler found for image type."
+msgstr "Nenhum manipulador achado para o tipo de imagem."
+
+#: ../src/common/image.cpp:2877 ../src/common/image.cpp:3000
+#: ../src/common/image.cpp:3066
+#, c-format
+msgid "No image handler for type %d defined."
+msgstr "Nenhum manipulador de imagem para o tipo %d definido."
+
+#: ../src/common/image.cpp:2887
+#, c-format
+msgid "Image file is not of type %d."
+msgstr "O arquivo de imagem não é do tipo %d."
+
+#: ../src/common/image.cpp:2970
+msgid "Can't automatically determine the image format for non-seekable input."
+msgstr ""
+"Não consegue determinar automaticamente o formato da imagem para entrada de "
+"dados não-procuráveis."
+
+#: ../src/common/image.cpp:2988
+msgid "Unknown image data format."
+msgstr "Formato desconhecido dos dados da imagem."
+
+#: ../src/common/image.cpp:3009
+#, c-format
+msgid "This is not a %s."
+msgstr "Isto não é um %s."
+
+#: ../src/common/image.cpp:3032 ../src/common/image.cpp:3080
+#, c-format
+msgid "No image handler for type %s defined."
+msgstr "Nenhum manipulador de imagem para o tipo %s definido."
+
+#: ../src/common/image.cpp:3041
+#, c-format
+msgid "Image is not of type %s."
+msgstr "A imagem não é do tipo %s."
+
+#: ../src/common/image.cpp:3509
+#, c-format
+msgid "Failed to check format of image file \"%s\"."
+msgstr "Falhou em verificar o formato do arquivo de imagem \"%s\"."
+
+#: ../src/common/imaggif.cpp:124
+msgid "GIF: error in GIF image format."
+msgstr "GIF: erro no formato da imagem GIF."
+
+#: ../src/common/imaggif.cpp:129
+msgid "GIF: not enough memory."
+msgstr "GIF: memória insuficiente."
+
+#: ../src/common/imaggif.cpp:134
+msgid "GIF: data stream seems to be truncated."
+msgstr "GIF: fluxo de dados parece estar truncado."
+
+#: ../src/common/imaggif.cpp:240
+msgid "Couldn't initialize GIF hash table."
+msgstr "Não pôde inicializar a tabela de hashes do GIF."
+
+#: ../src/common/imagiff.cpp:739
+msgid "IFF: error in IFF image format."
+msgstr "IFF: erro no formato da imagem IFF."
+
+#: ../src/common/imagiff.cpp:742
+msgid "IFF: not enough memory."
+msgstr "IFF: memória insuficiente."
+
+#: ../src/common/imagiff.cpp:745
+msgid "IFF: unknown error!!!"
+msgstr "IFF: erro desconhecido!!!"
+
+#: ../src/common/imagiff.cpp:755
+msgid "IFF: data stream seems to be truncated."
+msgstr "IFF: o fluxo de dados parece estar truncado."
+
+#: ../src/common/imagjpeg.cpp:258
+msgid "JPEG: Couldn't load - file is probably corrupted."
+msgstr ""
+"JPEG: Não conseguiu carregar - o arquivo está provavelmente corrompido."
+
+#: ../src/common/imagjpeg.cpp:437
+msgid "JPEG: Couldn't save image."
+msgstr "JPEG: Não pôde salvar a imagem."
+
+#: ../src/common/imagpcx.cpp:439
+msgid "PCX: this is not a PCX file."
+msgstr "PCX: este não é um arquivo PCX."
+
+#: ../src/common/imagpcx.cpp:453
+msgid "PCX: image format unsupported"
+msgstr "PCX: formato da imagem não suportado"
+
+#: ../src/common/imagpcx.cpp:454 ../src/common/imagpcx.cpp:477
+msgid "PCX: couldn't allocate memory"
+msgstr "PCX: não pôde distribuir a memória"
+
+#: ../src/common/imagpcx.cpp:455
+msgid "PCX: version number too low"
+msgstr "PCX: número de versão muito baixo"
+
+#: ../src/common/imagpcx.cpp:456 ../src/common/imagpcx.cpp:478
+msgid "PCX: unknown error !!!"
+msgstr "PCX: erro desconhecido !!!"
+
+#: ../src/common/imagpcx.cpp:476
+msgid "PCX: invalid image"
+msgstr "PCX: imagem inválida"
+
+#: ../src/common/imagpng.cpp:385
+#, c-format
+msgid "Unknown PNG resolution unit %d"
+msgstr "Unidade de resolução do PNG %d desconhecida"
+
+#: ../src/common/imagpng.cpp:439
+msgid "Couldn't load a PNG image - file is corrupted or not enough memory."
+msgstr ""
+"Não pôde carregar uma imagem PNG - o arquivo está corrompido ou não tem "
+"memória o bastante."
+
+#: ../src/common/imagpng.cpp:513 ../src/common/imagpng.cpp:524
+#: ../src/common/imagpng.cpp:534
+msgid "Couldn't save PNG image."
+msgstr "Não pôde salvar a imagem PNG."
+
+#: ../src/common/imagpnm.cpp:71
+msgid "PNM: File format is not recognized."
+msgstr "PNM: O formato do arquivo não é reconhecido."
+
+#: ../src/common/imagpnm.cpp:89
+msgid "PNM: Couldn't allocate memory."
+msgstr "PNM: Não pôde distribuir a memória."
+
+#: ../src/common/imagpnm.cpp:111 ../src/common/imagpnm.cpp:134
+#: ../src/common/imagpnm.cpp:156
+msgid "PNM: File seems truncated."
+msgstr "PNM: O arquivo parece truncado."
+
+#: ../src/common/imagtiff.cpp:69
+#, c-format
+msgid " (in module \"%s\")"
+msgstr " (no módulo \"%s\")"
+
+#: ../src/common/imagtiff.cpp:304
+msgid "TIFF: Error loading image."
+msgstr "TIFF: Erro ao carregar a imagem."
+
+#: ../src/common/imagtiff.cpp:314
+msgid "Invalid TIFF image index."
+msgstr "Índice da imagem TIFF inválido."
+
+#: ../src/common/imagtiff.cpp:358
+msgid "TIFF: Image size is abnormally big."
+msgstr "TiFF: O tamanho da imagem é anormalmente grande."
+
+#: ../src/common/imagtiff.cpp:372 ../src/common/imagtiff.cpp:385
+#: ../src/common/imagtiff.cpp:769
+msgid "TIFF: Couldn't allocate memory."
+msgstr "TIFF: Não pôde distribuir a memória."
+
+#: ../src/common/imagtiff.cpp:471
+msgid "TIFF: Error reading image."
+msgstr "TIFF: Erro ao ler a imagem."
+
+#: ../src/common/imagtiff.cpp:532
+#, c-format
+msgid "Unknown TIFF resolution unit %d ignored"
+msgstr "Unidade de resolução do TIFF desconhecida %d ignorada"
+
+#: ../src/common/imagtiff.cpp:611
+msgid "TIFF: Error saving image."
+msgstr "TIFF: Erro ao salvar a imagem."
+
+#: ../src/common/imagtiff.cpp:868
+msgid "TIFF: Error writing image."
+msgstr "TIFF: Erro ao gravar a imagem."
+
+#: ../src/common/imagtiff.cpp:881
+msgid "TIFF: Error flushing data."
+msgstr "TIFF: Erro ao limpar os dados."
+
+#: ../src/common/imagwebp.cpp:56
+msgid "WebP: Invalid data (failed to get features)."
+msgstr "WebP: Dados inválidos (falhou em obter recursos)."
+
+#: ../src/common/imagwebp.cpp:65
+msgid "WebP: Allocating image memory failed."
+msgstr "WebP: Falhou em alocar a memória da imagem."
+
+#: ../src/common/imagwebp.cpp:82
+msgid "WebP: Decoding RGBA image data failed."
+msgstr "WebP: Falhou em decodificar os dados da imagem RGBA."
+
+#: ../src/common/imagwebp.cpp:98
+msgid "WebP: Decoding RGB image data failed."
+msgstr "WebP: Falhou em decodificar os dados da imagem RGB."
+
+#: ../src/common/imagwebp.cpp:113 ../src/common/imagwebp.cpp:201
+msgid "WebP: Allocating stream buffer failed."
+msgstr "WebP: Falhou em alocar o buffer do fluxo."
+
+#: ../src/common/imagwebp.cpp:131
+msgid "WebP: Failed to parse container data."
+msgstr "WebP: Falhou em analisar os dados do contêiner."
+
+#: ../src/common/imagwebp.cpp:222
+msgid "WebP: Error decoding animation."
+msgstr "WebP: Erro ao decodificar a animação."
+
+#: ../src/common/imagwebp.cpp:240
+msgid "WebP: Error getting next animation frame."
+msgstr "WebP: Erro ao obter o próximo frame de animação."
+
+#: ../src/common/init.cpp:172
+#, c-format
+msgid ""
+"Command line argument %d couldn't be converted to Unicode and will be "
+"ignored."
+msgstr ""
+"O argumento da linha de comando %d não pôde ser convertido pro Unicode e "
+"será ignorado."
+
+#: ../src/common/init.cpp:344
+msgid "Initialization failed in post init, aborting."
+msgstr "A inicialização falhou no post init, abortando."
+
+#: ../src/common/intl.cpp:378
+#, c-format
+msgid "Cannot set locale to language \"%s\"."
+msgstr "Não consegue definir o locale pro idioma \"%s\"."
+
+#: ../src/common/log.cpp:232
+msgid "Error: "
+msgstr "Erro: "
+
+#: ../src/common/log.cpp:236
+msgid "Warning: "
+msgstr "Aviso: "
+
+#: ../src/common/log.cpp:284
+msgid "The previous message repeated once."
+msgstr "A mensagem anterior repetida uma vez."
+
+#: ../src/common/log.cpp:291
+#, c-format
+msgid "The previous message repeated %u time."
+msgid_plural "The previous message repeated %u times."
+msgstr[0] "A mensagem anterior repetida %u vez."
+msgstr[1] "A mensagem anterior repetida %u vezes."
+
+#: ../src/common/log.cpp:319
+#, c-format
+msgid "Last repeated message (\"%s\", %u time) wasn't output"
+msgid_plural "Last repeated message (\"%s\", %u times) wasn't output"
+msgstr[0] ""
+"A última mensagens repetida (\"%s\", %u vez) não era da saída de dados"
+msgstr[1] ""
+"As últimas mensagens repetidas (\"%s\", %u vezes) não eram da saída de dados"
+
+#: ../src/common/log.cpp:435
+#, c-format
+msgid " (error %ld: %s)"
+msgstr " (erro %ld: %s)"
+
+#: ../src/common/lzmastream.cpp:121
+msgid "Failed to allocate memory for LZMA decompression."
+msgstr "Falhou em distribuir a memória para a descompressão do LZMA."
+
+#: ../src/common/lzmastream.cpp:125
+#, c-format
+msgid "Failed to initialize LZMA decompression: unexpected error %u."
+msgstr "Falhou em inicializar a descompressão do LZMA: erro inesperado %u."
+
+#: ../src/common/lzmastream.cpp:179
+msgid "input is not in XZ format"
+msgstr "a entrada dos dados não está no formato XZ"
+
+#: ../src/common/lzmastream.cpp:183
+msgid "input compressed using unknown XZ option"
+msgstr "entrada dos dados comprimida usando a opção XZ desconhecida"
+
+#: ../src/common/lzmastream.cpp:188
+msgid "input is corrupted"
+msgstr "a entrada dos dados está corrompida"
+
+#: ../src/common/lzmastream.cpp:192
+msgid "unknown decompression error"
+msgstr "erro de descompressão desconhecido"
+
+#: ../src/common/lzmastream.cpp:196
+#, c-format
+msgid "LZMA decompression error: %s"
+msgstr "Erro de descompressão do LZMA: %s"
+
+#: ../src/common/lzmastream.cpp:231
+msgid "Failed to allocate memory for LZMA compression."
+msgstr "Falhou em distribuir memória para a compressão do LZMA."
+
+#: ../src/common/lzmastream.cpp:235
+#, c-format
+msgid "Failed to initialize LZMA compression: unexpected error %u."
+msgstr "Falhou em inicializar a compressão do LZMA: erro inesperado %u."
+
+#: ../src/common/lzmastream.cpp:267 ../src/common/lzmastream.cpp:342
+#: ../src/html/chm.cpp:336
+msgid "out of memory"
+msgstr "sem memória"
+
+#: ../src/common/lzmastream.cpp:276 ../src/common/lzmastream.cpp:346
+msgid "unknown compression error"
+msgstr "erro de compressão desconhecido"
+
+#: ../src/common/lzmastream.cpp:280
+#, c-format
+msgid "LZMA compression error: %s"
+msgstr "Erro de compressão do LZMA: %s"
+
+#: ../src/common/lzmastream.cpp:350
+#, c-format
+msgid "LZMA compression error when flushing output: %s"
+msgstr "Erro de compressão do LZMA quando limpa a saída dos dados: %s"
+
+#: ../src/common/mimecmn.cpp:167
+#, c-format
+msgid "Unmatched '{' in an entry for mime type %s."
+msgstr "'{' incomparável em uma entrada pro tipo mime %s."
+
+#: ../src/common/module.cpp:76
+#, c-format
+msgid "Circular dependency involving module \"%s\" detected."
+msgstr "Dependência circular envolvendo o módulo \"%s\" detectada."
+
+#: ../src/common/module.cpp:128
+#, c-format
+msgid "Dependency \"%s\" of module \"%s\" doesn't exist."
+msgstr "A dependência \"%s\" do módulo \"%s\" não existe."
+
+#: ../src/common/module.cpp:137
+#, c-format
+msgid "Module \"%s\" initialization failed"
+msgstr "A inicialização do módulo \"%s\" falhou"
+
+#: ../src/common/msgout.cpp:96
+msgid "Message"
+msgstr "Mensagem"
+
+#: ../src/common/paper.cpp:70
+msgid "Letter, 8 1/2 x 11 in"
+msgstr "Carta, 8 1/2 x 11 em"
+
+#: ../src/common/paper.cpp:71
+msgid "Legal, 8 1/2 x 14 in"
+msgstr "Legal, 8 1/2 x 14 em"
+
+#: ../src/common/paper.cpp:72
+msgid "A4 sheet, 210 x 297 mm"
+msgstr "Folha A4 210 x 297 mm"
+
+#: ../src/common/paper.cpp:73
+msgid "C sheet, 17 x 22 in"
+msgstr "Folha C, 17 x 22 em"
+
+#: ../src/common/paper.cpp:74
+msgid "D sheet, 22 x 34 in"
+msgstr "Folha D, 22 x 34 em"
+
+#: ../src/common/paper.cpp:75
+msgid "E sheet, 34 x 44 in"
+msgstr "Folha E, 34 x 44"
+
+#: ../src/common/paper.cpp:76
+msgid "Letter Small, 8 1/2 x 11 in"
+msgstr "Carta Pequena, 8 1/2 x 11 em"
+
+#: ../src/common/paper.cpp:77
+msgid "Tabloid, 11 x 17 in"
+msgstr "Tablóide, 11 x 17 em"
+
+#: ../src/common/paper.cpp:78
+msgid "Ledger, 17 x 11 in"
+msgstr "Ledger, 17 x 11 em"
+
+#: ../src/common/paper.cpp:79
+msgid "Statement, 5 1/2 x 8 1/2 in"
+msgstr "Declaração, 5 1/2 x 8 1/2 em"
+
+#: ../src/common/paper.cpp:80
+msgid "Executive, 7 1/4 x 10 1/2 in"
+msgstr "Executivo, 7 1/4 x 10 1/2 em"
+
+#: ../src/common/paper.cpp:81
+msgid "A3 sheet, 297 x 420 mm"
+msgstr "Folha A3, 297 x 420 mm"
+
+#: ../src/common/paper.cpp:82
+msgid "A4 small sheet, 210 x 297 mm"
+msgstr "Folha A4 pequena, 210 x 297 mm"
+
+#: ../src/common/paper.cpp:83
+msgid "A5 sheet, 148 x 210 mm"
+msgstr "Folha A5, 148 x 210 mm"
+
+#: ../src/common/paper.cpp:84
+msgid "B4 sheet, 250 x 354 mm"
+msgstr "Folha B4, 250 x 354 mm"
+
+#: ../src/common/paper.cpp:85
+msgid "B5 sheet, 182 x 257 millimeter"
+msgstr "Folha B5, 182 x 257 milímetros"
+
+#: ../src/common/paper.cpp:86
+msgid "Folio, 8 1/2 x 13 in"
+msgstr "Folio, 8 1/2 x 13 em"
+
+#: ../src/common/paper.cpp:87
+msgid "Quarto, 215 x 275 mm"
+msgstr "Quarto, 215 x 275 mm"
+
+#: ../src/common/paper.cpp:88
+msgid "10 x 14 in"
+msgstr "10 x 14 em"
+
+#: ../src/common/paper.cpp:89
+msgid "11 x 17 in"
+msgstr "11 x 17 em"
+
+#: ../src/common/paper.cpp:90
+msgid "Note, 8 1/2 x 11 in"
+msgstr "Nota, 8 1/2 x 11 em"
+
+#: ../src/common/paper.cpp:91
+msgid "#9 Envelope, 3 7/8 x 8 7/8 in"
+msgstr "#9 Envelope 3 7/8 x 8 7/8 em"
+
+#: ../src/common/paper.cpp:92
+msgid "#10 Envelope, 4 1/8 x 9 1/2 in"
+msgstr "#10 Envelope, 4 1/8 x 9 1/2 em"
+
+#: ../src/common/paper.cpp:93
+msgid "#11 Envelope, 4 1/2 x 10 3/8 in"
+msgstr "#11 Envelope 4 1/2 x 10 3/8 em"
+
+#: ../src/common/paper.cpp:94
+msgid "#12 Envelope, 4 3/4 x 11 in"
+msgstr "#12 Envelope 4 3/4 x 11 em"
+
+#: ../src/common/paper.cpp:95
+msgid "#14 Envelope, 5 x 11 1/2 in"
+msgstr "#14 Envelope 5 x 11 1/2 em"
+
+#: ../src/common/paper.cpp:96
+msgid "DL Envelope, 110 x 220 mm"
+msgstr "Envelope DL, 110 x 220 mm"
+
+#: ../src/common/paper.cpp:97
+msgid "C5 Envelope, 162 x 229 mm"
+msgstr "Envelope C5, 162 x 229 mm"
+
+#: ../src/common/paper.cpp:98
+msgid "C3 Envelope, 324 x 458 mm"
+msgstr "Envelope C3, 324 x 458 mm"
+
+#: ../src/common/paper.cpp:99
+msgid "C4 Envelope, 229 x 324 mm"
+msgstr "Envelope C4, 229 x 324 mm"
+
+#: ../src/common/paper.cpp:100
+msgid "C6 Envelope, 114 x 162 mm"
+msgstr "Envelope C6, 114 x 162 mm"
+
+#: ../src/common/paper.cpp:101
+msgid "C65 Envelope, 114 x 229 mm"
+msgstr "Envelope C65, 114 x 229 mm"
+
+#: ../src/common/paper.cpp:102
+msgid "B4 Envelope, 250 x 353 mm"
+msgstr "Envelope B4, 250 x 353 mm"
+
+#: ../src/common/paper.cpp:103
+msgid "B5 Envelope, 176 x 250 mm"
+msgstr "Envelope B5, 176 x 250 mm"
+
+#: ../src/common/paper.cpp:104
+msgid "B6 Envelope, 176 x 125 mm"
+msgstr "Envelope B6, 176 x 125 mm"
+
+#: ../src/common/paper.cpp:105
+msgid "Italy Envelope, 110 x 230 mm"
+msgstr "Envelope da Itália, 110 x 230 mm"
+
+#: ../src/common/paper.cpp:106
+msgid "Monarch Envelope, 3 7/8 x 7 1/2 in"
+msgstr "Envelope Monarca, 3 7/8 x 7 1/2 em"
+
+#: ../src/common/paper.cpp:107
+msgid "6 3/4 Envelope, 3 5/8 x 6 1/2 in"
+msgstr "Envelope 6 3/4, 3 5/8 x 6 1/2 em"
+
+#: ../src/common/paper.cpp:108
+msgid "US Std Fanfold, 14 7/8 x 11 in"
+msgstr "Fanfold Std US, 14 7/8 x 11 em"
+
+#: ../src/common/paper.cpp:109
+msgid "German Std Fanfold, 8 1/2 x 12 in"
+msgstr "Fanfold Std Alemão, 8 1/2 x 12 em"
+
+#: ../src/common/paper.cpp:110
+msgid "German Legal Fanfold, 8 1/2 x 13 in"
+msgstr "Fanfold Legal Alemão, 8 1/2 x 13 em"
+
+#: ../src/common/paper.cpp:112
+msgid "B4 (ISO) 250 x 353 mm"
+msgstr "B4 (ISO) 250 x 353 mm"
+
+#: ../src/common/paper.cpp:113
+msgid "Japanese Postcard 100 x 148 mm"
+msgstr "Cartão Postal Japonês 100 x 148 mm"
+
+#: ../src/common/paper.cpp:114
+msgid "9 x 11 in"
+msgstr "9 x 11 em"
+
+#: ../src/common/paper.cpp:115
+msgid "10 x 11 in"
+msgstr "10 x 11 em"
+
+#: ../src/common/paper.cpp:116
+msgid "15 x 11 in"
+msgstr "15 x 11 em"
+
+#: ../src/common/paper.cpp:117
+msgid "Envelope Invite 220 x 220 mm"
+msgstr "Envelope de Convite 220 x 220 mm"
+
+#: ../src/common/paper.cpp:118
+msgid "Letter Extra 9 1/2 x 12 in"
+msgstr "Carta Extra 9 1/2 x 12 em"
+
+#: ../src/common/paper.cpp:119
+msgid "Legal Extra 9 1/2 x 15 in"
+msgstr "Extra Legal, 9 1/2 x 15 em"
+
+#: ../src/common/paper.cpp:120
+msgid "Tabloid Extra 11.69 x 18 in"
+msgstr "Tablóide Extra 11.69 x 18 em"
+
+#: ../src/common/paper.cpp:121
+msgid "A4 Extra 9.27 x 12.69 in"
+msgstr "A4 Extra 9.27 x 12.69 em"
+
+#: ../src/common/paper.cpp:122
+msgid "Letter Transverse 8 1/2 x 11 in"
+msgstr "Carta Transversal 8 1/2 x 11 em"
+
+#: ../src/common/paper.cpp:123
+msgid "A4 Transverse 210 x 297 mm"
+msgstr "A4 Transversal 210 x 297 mm"
+
+#: ../src/common/paper.cpp:124
+msgid "Letter Extra Transverse 9.275 x 12 in"
+msgstr "Carta Extra Transversal 9.275 x 12 em"
+
+#: ../src/common/paper.cpp:125
+msgid "SuperA/SuperA/A4 227 x 356 mm"
+msgstr "SuperA/SuperA/A4 227 x 356 mm"
+
+#: ../src/common/paper.cpp:126
+msgid "SuperB/SuperB/A3 305 x 487 mm"
+msgstr "SuperB/SuperB/A3 305 x 487 mm"
+
+#: ../src/common/paper.cpp:127
+msgid "Letter Plus 8 1/2 x 12.69 in"
+msgstr "Carta Plus, 8 1/2 x 12.69 em"
+
+#: ../src/common/paper.cpp:128
+msgid "A4 Plus 210 x 330 mm"
+msgstr "A4 Plus 210 x 330 mm"
+
+#: ../src/common/paper.cpp:129
+msgid "A5 Transverse 148 x 210 mm"
+msgstr "A5 Tranversal 148 x 210 mm"
+
+#: ../src/common/paper.cpp:130
+msgid "B5 (JIS) Transverse 182 x 257 mm"
+msgstr "B5 (JIS) Transversal 182 x 257 mm"
+
+#: ../src/common/paper.cpp:131
+msgid "A3 Extra 322 x 445 mm"
+msgstr "A3 Extra 322 x 445 mm"
+
+#: ../src/common/paper.cpp:132
+msgid "A5 Extra 174 x 235 mm"
+msgstr "A5 Extra 174 x 235 mm"
+
+#: ../src/common/paper.cpp:133
+msgid "B5 (ISO) Extra 201 x 276 mm"
+msgstr "B5 (ISO) Extra 201 x 276 mm"
+
+#: ../src/common/paper.cpp:134
+msgid "A2 420 x 594 mm"
+msgstr "A2 420 x 594 mm"
+
+#: ../src/common/paper.cpp:135
+msgid "A3 Transverse 297 x 420 mm"
+msgstr "A3 transversal 297 x 420 mm"
+
+#: ../src/common/paper.cpp:136
+msgid "A3 Extra Transverse 322 x 445 mm"
+msgstr "A3 Extra transversal 322 x 445 mm"
+
+#: ../src/common/paper.cpp:138
+msgid "Japanese Double Postcard 200 x 148 mm"
+msgstr "Cartão Postal Japonês Duplo 200 x 148 mm"
+
+#: ../src/common/paper.cpp:139
+msgid "A6 105 x 148 mm"
+msgstr "A6 105 x 148 mm"
+
+#: ../src/common/paper.cpp:140
+msgid "Japanese Envelope Kaku #2"
+msgstr "Envelope Japonês Kaku #2"
+
+#: ../src/common/paper.cpp:141
+msgid "Japanese Envelope Kaku #3"
+msgstr "Envelope Japonês Kaku #3"
+
+#: ../src/common/paper.cpp:142
+msgid "Japanese Envelope Chou #3"
+msgstr "Envelope Japonês Chou #3"
+
+#: ../src/common/paper.cpp:143
+msgid "Japanese Envelope Chou #4"
+msgstr "Envelope Japonês Chou #4"
+
+#: ../src/common/paper.cpp:144
+msgid "Letter Rotated 11 x 8 1/2 in"
+msgstr "Carta Rotacionada 11 x 8 1/2 em"
+
+#: ../src/common/paper.cpp:145
+msgid "A3 Rotated 420 x 297 mm"
+msgstr "A3 Rotacionada 420 x 297 mm"
+
+#: ../src/common/paper.cpp:146
+msgid "A4 Rotated 297 x 210 mm"
+msgstr "A4 Rotacionada 297 x 210 mm"
+
+#: ../src/common/paper.cpp:147
+msgid "A5 Rotated 210 x 148 mm"
+msgstr "A5 Rotacionada 210 x 148 mm"
+
+#: ../src/common/paper.cpp:148
+msgid "B4 (JIS) Rotated 364 x 257 mm"
+msgstr "B4 (JIS) Rotacionada 364 x 257 mm"
+
+#: ../src/common/paper.cpp:149
+msgid "B5 (JIS) Rotated 257 x 182 mm"
+msgstr "B5 (JIS) Rotacionada 257 x 182 mm"
+
+#: ../src/common/paper.cpp:150
+msgid "Japanese Postcard Rotated 148 x 100 mm"
+msgstr "Cartão Postal Japonês Rotacionado 148 x 100 mm"
+
+#: ../src/common/paper.cpp:151
+msgid "Double Japanese Postcard Rotated 148 x 200 mm"
+msgstr "Cartão Postal Japonês Duplo Rotacionado 148 x 200 mm"
+
+#: ../src/common/paper.cpp:152
+msgid "A6 Rotated 148 x 105 mm"
+msgstr "A6 Rotacionada 148 x 105 mm"
+
+#: ../src/common/paper.cpp:153
+msgid "Japanese Envelope Kaku #2 Rotated"
+msgstr "Envelope Japonês Kaku #2 Rotacionado"
+
+#: ../src/common/paper.cpp:154
+msgid "Japanese Envelope Kaku #3 Rotated"
+msgstr "Envelope Japonês Kaku #3 Rotacionado"
+
+#: ../src/common/paper.cpp:155
+msgid "Japanese Envelope Chou #3 Rotated"
+msgstr "Envelope Japonês Chou #3 Rotacionado"
+
+#: ../src/common/paper.cpp:156
+msgid "Japanese Envelope Chou #4 Rotated"
+msgstr "Envelope Japonês Chou #4 Rotacionado"
+
+#: ../src/common/paper.cpp:157
+msgid "B6 (JIS) 128 x 182 mm"
+msgstr "B6 (JIS) 128 x 182 mm"
+
+#: ../src/common/paper.cpp:158
+msgid "B6 (JIS) Rotated 182 x 128 mm"
+msgstr "B6 (JIS) Rotacionada 182 x 128 mm"
+
+#: ../src/common/paper.cpp:159
+msgid "12 x 11 in"
+msgstr "12 x 11 em"
+
+#: ../src/common/paper.cpp:160
+msgid "Japanese Envelope You #4"
+msgstr "Envelope Japonês You #4"
+
+#: ../src/common/paper.cpp:161
+msgid "Japanese Envelope You #4 Rotated"
+msgstr "Envelope Japonês You #4 Rotacionado"
+
+#: ../src/common/paper.cpp:162
+msgid "PRC 16K 146 x 215 mm"
+msgstr "PRC 16K 146 x 215 mm"
+
+#: ../src/common/paper.cpp:163
+msgid "PRC 32K 97 x 151 mm"
+msgstr "PRC 32K 97 x 151 mm"
+
+#: ../src/common/paper.cpp:164
+msgid "PRC 32K(Big) 97 x 151 mm"
+msgstr "PRC 32K (Grande) 97 x 151 mm"
+
+#: ../src/common/paper.cpp:165
+msgid "PRC Envelope #1 102 x 165 mm"
+msgstr "Envelope PRC #1 102 x 165 mm"
+
+#: ../src/common/paper.cpp:166
+msgid "PRC Envelope #2 102 x 176 mm"
+msgstr "Envelope PRC #2 102 x 176 mm"
+
+#: ../src/common/paper.cpp:167
+msgid "PRC Envelope #3 125 x 176 mm"
+msgstr "Envelope PRC #3 125 x 176 mm"
+
+#: ../src/common/paper.cpp:168
+msgid "PRC Envelope #4 110 x 208 mm"
+msgstr "Envelope PRC #4 110 x 208 mm"
+
+#: ../src/common/paper.cpp:169
+msgid "PRC Envelope #5 110 x 220 mm"
+msgstr "Envelope PRC #5 110 x 220 mm"
+
+#: ../src/common/paper.cpp:170
+msgid "PRC Envelope #6 120 x 230 mm"
+msgstr "Envelope PRC #6 120 x 230 mm"
+
+#: ../src/common/paper.cpp:171
+msgid "PRC Envelope #7 160 x 230 mm"
+msgstr "Envelope PRC #7 160 x 230 mm"
+
+#: ../src/common/paper.cpp:172
+msgid "PRC Envelope #8 120 x 309 mm"
+msgstr "Envelope PRC #8 120 x 309 mm"
+
+#: ../src/common/paper.cpp:173
+msgid "PRC Envelope #9 229 x 324 mm"
+msgstr "Envelope PRC #9 229 x 324 mm"
+
+#: ../src/common/paper.cpp:174
+msgid "PRC Envelope #10 324 x 458 mm"
+msgstr "Envelope PRC #10 324 x 458 mm"
+
+#: ../src/common/paper.cpp:175
+msgid "PRC 16K Rotated"
+msgstr "PRC 16K Rotacionado"
+
+#: ../src/common/paper.cpp:176
+msgid "PRC 32K Rotated"
+msgstr "PRC 32K Rotacionado"
+
+#: ../src/common/paper.cpp:177
+msgid "PRC 32K(Big) Rotated"
+msgstr "PRC 32K (Grande) Rotacionado"
+
+#: ../src/common/paper.cpp:178
+msgid "PRC Envelope #1 Rotated 165 x 102 mm"
+msgstr "Envelope PRC #1 Rotacionado 165 x 102 mm"
+
+#: ../src/common/paper.cpp:179
+msgid "PRC Envelope #2 Rotated 176 x 102 mm"
+msgstr "Envelope PRC #2 Rotacionado 176 x 102 mm"
+
+#: ../src/common/paper.cpp:180
+msgid "PRC Envelope #3 Rotated 176 x 125 mm"
+msgstr "Envelope PRC #3 Rotacionado 176 x 125 mm"
+
+#: ../src/common/paper.cpp:181
+msgid "PRC Envelope #4 Rotated 208 x 110 mm"
+msgstr "Envelope PRC #4 Rotacionado 208 x 110 mm"
+
+#: ../src/common/paper.cpp:182
+msgid "PRC Envelope #5 Rotated 220 x 110 mm"
+msgstr "Envelope PRC #5 Rotacionado 220 x 110 mm"
+
+#: ../src/common/paper.cpp:183
+msgid "PRC Envelope #6 Rotated 230 x 120 mm"
+msgstr "Envelope PRC #6 Rotacionado 230 x 120 mm"
+
+#: ../src/common/paper.cpp:184
+msgid "PRC Envelope #7 Rotated 230 x 160 mm"
+msgstr "Envelope PRC #7 Rotacionado 230 x 160 mm"
+
+#: ../src/common/paper.cpp:185
+msgid "PRC Envelope #8 Rotated 309 x 120 mm"
+msgstr "Envelope PRC #8 Rotacionado 309 x 120 mm"
+
+#: ../src/common/paper.cpp:186
+msgid "PRC Envelope #9 Rotated 324 x 229 mm"
+msgstr "Envelope PRC #9 Rotacionado 324 x 229 mm"
+
+#: ../src/common/paper.cpp:187
+msgid "PRC Envelope #10 Rotated 458 x 324 mm"
+msgstr "Envelope PRC #10 Rotacionado 458 x 324 mm"
+
+#: ../src/common/paper.cpp:192
+msgid "A0 sheet, 841 x 1189 mm"
+msgstr "Folha A0, 841 x 1189 mm"
+
+#: ../src/common/paper.cpp:193
+msgid "A1 sheet, 594 x 841 mm"
+msgstr "Folha A1, 594 x 841 mm"
+
+#: ../src/common/preferencescmn.cpp:37
+msgid "General"
+msgstr "Geral"
+
+#: ../src/common/preferencescmn.cpp:40
+msgid "Advanced"
+msgstr "Avançado"
+
+#: ../src/common/prntbase.cpp:245
+msgid "Generic PostScript"
+msgstr "PostScript Genérico"
+
+#: ../src/common/prntbase.cpp:259
+msgid "Ready"
+msgstr "Pronto"
+
+#: ../src/common/prntbase.cpp:331
+msgid "Printing Error"
+msgstr "Erro ao imprimir"
+
+#: ../src/common/prntbase.cpp:413 ../src/common/prntbase.cpp:1597
+#: ../src/generic/prntdlgg.cpp:135 ../src/generic/prntdlgg.cpp:149
+#: ../src/gtk/print.cpp:628 ../src/gtk/print.cpp:646
+msgid "Print"
+msgstr "Imprimir"
+
+#: ../src/common/prntbase.cpp:471 ../src/generic/prntdlgg.cpp:809
+msgid "Page setup"
+msgstr "Configuração da página"
+
+#: ../src/common/prntbase.cpp:525
+msgid "Please wait while printing..."
+msgstr "Por favor espere enquanto imprime..."
+
+#: ../src/common/prntbase.cpp:529
+msgid "Document:"
+msgstr "Documento:"
+
+#: ../src/common/prntbase.cpp:532
+msgid "Progress:"
+msgstr "Progresso:"
+
+#: ../src/common/prntbase.cpp:533
+msgid "Preparing"
+msgstr "Preparando"
+
+#: ../src/common/prntbase.cpp:552
+#, c-format
+msgid "Printing page %d"
+msgstr "Imprimindo a página %d"
+
+#: ../src/common/prntbase.cpp:557
+#, c-format
+msgid "Printing page %d of %d"
+msgstr "Imprimindo a página %d de %d"
+
+#: ../src/common/prntbase.cpp:560
+#, c-format
+msgid " (copy %d of %d)"
+msgstr " (cópia %d de %d)"
+
+#: ../src/common/prntbase.cpp:1604
+msgid "First page"
+msgstr "Primeira página"
+
+#: ../src/common/prntbase.cpp:1609 ../src/html/helpwnd.cpp:659
+msgid "Previous page"
+msgstr "Página anterior"
+
+#: ../src/common/prntbase.cpp:1623 ../src/html/helpwnd.cpp:660
+msgid "Next page"
+msgstr "Próxima página"
+
+#: ../src/common/prntbase.cpp:1628
+msgid "Last page"
+msgstr "Última página"
+
+#: ../src/common/prntbase.cpp:1636 ../src/common/stockitem.cpp:215
+msgid "Zoom Out"
+msgstr "Diminuir Zoom"
+
+#: ../src/common/prntbase.cpp:1650 ../src/common/stockitem.cpp:214
+msgid "Zoom In"
+msgstr "Aumentar Zoom"
+
+#: ../src/common/prntbase.cpp:1656 ../src/common/stockitem.cpp:153
+#: ../src/generic/logg.cpp:553 ../src/univ/themes/win32.cpp:3752
+msgid "&Close"
+msgstr "&Fechar"
+
+#: ../src/common/prntbase.cpp:2085
+msgid "Could not start document preview."
+msgstr "Não pôde iniciar a pré-visualização do documento."
+
+#: ../src/common/prntbase.cpp:2085 ../src/common/prntbase.cpp:2129
+#: ../src/common/prntbase.cpp:2137
+msgid "Print Preview Failure"
+msgstr "Falha ao Pré-Visualizar a Impressão"
+
+#: ../src/common/prntbase.cpp:2129 ../src/common/prntbase.cpp:2137
+msgid "Sorry, not enough memory to create a preview."
+msgstr "Lamento, não há memória o bastante pra criar uma pré-visualização."
+
+#: ../src/common/prntbase.cpp:2144
+#, c-format
+msgid "Page %d of %d"
+msgstr "Página %d de %d"
+
+#: ../src/common/prntbase.cpp:2146
+#, c-format
+msgid "Page %d"
+msgstr "Página %d"
+
+#: ../src/common/regex.cpp:382 ../src/html/chm.cpp:348
+msgid "unknown error"
+msgstr "erro desconhecido"
+
+#: ../src/common/regex.cpp:995
+#, c-format
+msgid "Invalid regular expression '%s': %s"
+msgstr "Expressão regular '%s' inválida: %s"
+
+#: ../src/common/regex.cpp:1059
+#, c-format
+msgid "Failed to find match for regular expression: %s"
+msgstr "Falhou em achar a combinação para a expressão regular: %s"
+
+#: ../src/common/rendcmn.cpp:188
+#, c-format
+msgid "Renderer \"%s\" has incompatible version %d.%d and couldn't be loaded."
+msgstr ""
+"O renderizador \"%s\" tem uma versão incompatível, %d.%d; e não pôde ser "
+"carregado."
+
+#: ../src/common/secretstore.cpp:162
+msgid "Not available for this platform"
+msgstr "Não disponível pra esta plataforma"
+
+#: ../src/common/secretstore.cpp:183
+#, c-format
+msgid "Saving password for \"%s\" failed: %s."
+msgstr "Falhou em salvar a senha pro \"%s\": %s."
+
+#: ../src/common/secretstore.cpp:205
+#, c-format
+msgid "Reading password for \"%s\" failed: %s."
+msgstr "Falhou em ler a senha do \"%s\": %s."
+
+#: ../src/common/secretstore.cpp:228
+#, c-format
+msgid "Deleting password for \"%s\" failed: %s."
+msgstr "Falhou em apagar a senha do \"%s\": %s."
+
+#: ../src/common/selectdispatcher.cpp:254
+msgid "Failed to monitor I/O channels"
+msgstr "Falhou em monitorar os canais de E/S"
+
+#: ../src/common/sizer.cpp:3054 ../src/common/stockitem.cpp:195
+msgid "Save"
+msgstr "Salvar"
+
+#: ../src/common/sizer.cpp:3056
+msgid "Don't Save"
+msgstr "Não Salvar"
+
+#: ../src/common/socket.cpp:870
+msgid "Cannot initialize sockets"
+msgstr "Não consegue inicializar os sockets"
+
+#: ../src/common/stockitem.cpp:127
+msgctxt "standard Windows menu"
+msgid "&Help"
+msgstr "&Ajuda"
+
+#: ../src/common/stockitem.cpp:144
+msgid "&About"
+msgstr "&Sobre"
+
+#: ../src/common/stockitem.cpp:144
+msgid "About"
+msgstr "Sobre"
+
+#: ../src/common/stockitem.cpp:145
+msgid "Add"
+msgstr "Adicionar"
+
+#: ../src/common/stockitem.cpp:146
+msgid "&Apply"
+msgstr "&Aplicar"
+
+#: ../src/common/stockitem.cpp:146
+msgid "Apply"
+msgstr "Aplicar"
+
+#: ../src/common/stockitem.cpp:147
+msgid "&Back"
+msgstr "&Voltar"
+
+#: ../src/common/stockitem.cpp:147
+msgid "Back"
+msgstr "Voltar"
+
+#: ../src/common/stockitem.cpp:148
+msgid "&Bold"
+msgstr "&Negrito"
+
+#: ../src/common/stockitem.cpp:148 ../src/generic/fontdlgg.cpp:326
+#: ../src/richtext/richtextfontpage.cpp:354
+msgid "Bold"
+msgstr "Negrito"
+
+#: ../src/common/stockitem.cpp:149
+msgid "&Bottom"
+msgstr "&Fundo"
+
+#: ../src/common/stockitem.cpp:149 ../src/richtext/richtextsizepage.cpp:287
+msgid "Bottom"
+msgstr "Rodapé"
+
+#: ../src/common/stockitem.cpp:150 ../src/generic/fontdlgg.cpp:462
+#: ../src/generic/fontdlgg.cpp:481 ../src/generic/wizard.cpp:415
+msgid "&Cancel"
+msgstr "&Cancelar"
+
+#: ../src/common/stockitem.cpp:151
+msgid "&CD-ROM"
+msgstr "&CD-ROM"
+
+#: ../src/common/stockitem.cpp:151
+msgid "CD-ROM"
+msgstr "CD-ROM"
+
+#: ../src/common/stockitem.cpp:152
+msgid "&Clear"
+msgstr "&Limpar"
+
+#: ../src/common/stockitem.cpp:152
+msgid "Clear"
+msgstr "Limpar"
+
+#: ../src/common/stockitem.cpp:153 ../src/generic/dbgrptg.cpp:93
+#: ../src/generic/progdlgg.cpp:778 ../src/html/helpdlg.cpp:86
+#: ../src/msw/progdlg.cpp:209 ../src/msw/progdlg.cpp:890
+#: ../src/richtext/richtextstyledlg.cpp:272
+#: ../src/richtext/richtextsymboldlg.cpp:448
+msgid "Close"
+msgstr "Fechar"
+
+#: ../src/common/stockitem.cpp:154
+msgid "&Convert"
+msgstr "&Converter"
+
+#: ../src/common/stockitem.cpp:154
+msgid "Convert"
+msgstr "Converter"
+
+#: ../src/common/stockitem.cpp:155 ../src/msw/textctrl.cpp:2884
+#: ../src/osx/textctrl_osx.cpp:653 ../src/richtext/richtextctrl.cpp:331
+msgid "&Copy"
+msgstr "&Copiar"
+
+#: ../src/common/stockitem.cpp:155 ../src/stc/stc_i18n.cpp:18
+msgid "Copy"
+msgstr "Copiar"
+
+#: ../src/common/stockitem.cpp:156 ../src/msw/textctrl.cpp:2883
+#: ../src/osx/textctrl_osx.cpp:652 ../src/richtext/richtextctrl.cpp:330
+msgid "Cu&t"
+msgstr "Co&rtar"
+
+#: ../src/common/stockitem.cpp:156 ../src/stc/stc_i18n.cpp:17
+msgid "Cut"
+msgstr "Cortar"
+
+#: ../src/common/stockitem.cpp:157 ../src/msw/textctrl.cpp:2886
+#: ../src/osx/textctrl_osx.cpp:655 ../src/richtext/richtextctrl.cpp:333
+#: ../src/richtext/richtexttabspage.cpp:137
+msgid "&Delete"
+msgstr "&Apagar"
+
+#: ../src/common/stockitem.cpp:157 ../src/richtext/richtextbuffer.cpp:8266
+#: ../src/stc/stc_i18n.cpp:20
+msgid "Delete"
+msgstr "Apagar"
+
+#: ../src/common/stockitem.cpp:158
+msgid "&Down"
+msgstr "&Pra baixo"
+
+#: ../src/common/stockitem.cpp:158 ../src/generic/fdrepdlg.cpp:148
+msgid "Down"
+msgstr "Pra baixo"
+
+#: ../src/common/stockitem.cpp:159
+msgid "&Edit"
+msgstr "&Editar"
+
+#: ../src/common/stockitem.cpp:159
+msgid "Edit"
+msgstr "Editar"
+
+#: ../src/common/stockitem.cpp:160
+msgid "&Execute"
+msgstr "&Executar"
+
+#: ../src/common/stockitem.cpp:160
+msgid "Execute"
+msgstr "Executar"
+
+#: ../src/common/stockitem.cpp:161
+msgid "&Quit"
+msgstr "&Sair"
+
+#: ../src/common/stockitem.cpp:161
+msgid "Quit"
+msgstr "Sair"
+
+#: ../src/common/stockitem.cpp:162
+msgid "&File"
+msgstr "&Arquivo"
+
+#: ../src/common/stockitem.cpp:162
+msgid "File"
+msgstr "Arquivo"
+
+#: ../src/common/stockitem.cpp:163
+msgid "&Find..."
+msgstr "&Achar..."
+
+#: ../src/common/stockitem.cpp:163
+msgid "Find..."
+msgstr "Achar..."
+
+#: ../src/common/stockitem.cpp:164
+msgid "&First"
+msgstr "&Primeiro"
+
+#: ../src/common/stockitem.cpp:164
+msgid "First"
+msgstr "Primeiro"
+
+#: ../src/common/stockitem.cpp:165
+msgid "&Floppy"
+msgstr "&Disquete"
+
+#: ../src/common/stockitem.cpp:165
+msgid "Floppy"
+msgstr "Disquete"
+
+#: ../src/common/stockitem.cpp:166
+msgid "&Forward"
+msgstr "&Pra frente"
+
+#: ../src/common/stockitem.cpp:166
+msgid "Forward"
+msgstr "Pra frente"
+
+#: ../src/common/stockitem.cpp:167
+msgid "&Harddisk"
+msgstr "&Disco rígido"
+
+#: ../src/common/stockitem.cpp:167
+msgid "Harddisk"
+msgstr "Disco rígido"
+
+#: ../src/common/stockitem.cpp:168 ../src/generic/wizard.cpp:418
+#: ../src/osx/cocoa/menu.mm:225 ../src/richtext/richtextstyledlg.cpp:298
+#: ../src/richtext/richtextsymboldlg.cpp:451
+msgid "&Help"
+msgstr "&Ajuda"
+
+#: ../src/common/stockitem.cpp:169
+msgid "&Home"
+msgstr "&Home"
+
+#: ../src/common/stockitem.cpp:169
+msgid "Home"
+msgstr "Home"
+
+#: ../src/common/stockitem.cpp:170
+msgid "Indent"
+msgstr "Recuo"
+
+#: ../src/common/stockitem.cpp:171
+msgid "&Index"
+msgstr "&Índice"
+
+#: ../src/common/stockitem.cpp:171 ../src/html/helpwnd.cpp:510
+msgid "Index"
+msgstr "Índice"
+
+#: ../src/common/stockitem.cpp:172
+msgid "&Info"
+msgstr "&Info"
+
+#: ../src/common/stockitem.cpp:172
+msgid "Info"
+msgstr "Info"
+
+#: ../src/common/stockitem.cpp:173
+msgid "&Italic"
+msgstr "&Itálico"
+
+#: ../src/common/stockitem.cpp:173 ../src/generic/fontdlgg.cpp:322
+#: ../src/richtext/richtextfontpage.cpp:350
+msgid "Italic"
+msgstr "Itálico"
+
+#: ../src/common/stockitem.cpp:174
+msgid "&Jump to"
+msgstr "&Pular para"
+
+#: ../src/common/stockitem.cpp:174
+msgid "Jump to"
+msgstr "Pular para"
+
+#: ../src/common/stockitem.cpp:175
+msgid "Centered"
+msgstr "Centralizado"
+
+#: ../src/common/stockitem.cpp:176
+msgid "Justified"
+msgstr "Justificado"
+
+#: ../src/common/stockitem.cpp:177
+msgid "Align Left"
+msgstr "Alinhar a Esquerda"
+
+#: ../src/common/stockitem.cpp:178
+msgid "Align Right"
+msgstr "Alinhar a Direita"
+
+#: ../src/common/stockitem.cpp:179
+msgid "&Last"
+msgstr "&Último"
+
+#: ../src/common/stockitem.cpp:179
+msgid "Last"
+msgstr "Último"
+
+#: ../src/common/stockitem.cpp:180
+msgid "&Network"
+msgstr "&Rede"
+
+#: ../src/common/stockitem.cpp:180
+msgid "Network"
+msgstr "Rede"
+
+#: ../src/common/stockitem.cpp:181 ../src/richtext/richtexttabspage.cpp:131
+msgid "&New"
+msgstr "&Novo"
+
+#: ../src/common/stockitem.cpp:181
+msgid "New"
+msgstr "Novo"
+
+#: ../src/common/stockitem.cpp:182 ../src/msw/msgdlg.cpp:417
+msgid "&No"
+msgstr "&Não"
+
+#: ../src/common/stockitem.cpp:183 ../src/generic/fontdlgg.cpp:467
+#: ../src/generic/fontdlgg.cpp:474
+msgid "&OK"
+msgstr "&OK"
+
+#: ../src/common/stockitem.cpp:184 ../src/generic/dbgrptg.cpp:341
+msgid "&Open..."
+msgstr "&Abrir..."
+
+#: ../src/common/stockitem.cpp:184
+msgid "Open..."
+msgstr "Abrir..."
+
+#: ../src/common/stockitem.cpp:185 ../src/msw/textctrl.cpp:2885
+#: ../src/osx/textctrl_osx.cpp:654 ../src/richtext/richtextctrl.cpp:332
+msgid "&Paste"
+msgstr "&Colar"
+
+#: ../src/common/stockitem.cpp:185 ../src/richtext/richtextctrl.cpp:3484
+#: ../src/stc/stc_i18n.cpp:19
+msgid "Paste"
+msgstr "Colar"
+
+#: ../src/common/stockitem.cpp:186
+msgid "&Preferences"
+msgstr "&Preferências"
+
+#: ../src/common/stockitem.cpp:186 ../src/osx/cocoa/preferences.mm:304
+msgid "Preferences"
+msgstr "Preferências"
+
+#: ../src/common/stockitem.cpp:187
+msgid "Print previe&w..."
+msgstr "Pré-visualização da impressã&o..."
+
+#: ../src/common/stockitem.cpp:187
+msgid "Print preview..."
+msgstr "Pré-visualização da impressão..."
+
+#: ../src/common/stockitem.cpp:188
+msgid "&Print..."
+msgstr "&Imprimir..."
+
+#: ../src/common/stockitem.cpp:188
+msgid "Print..."
+msgstr "Imprimir..."
+
+#: ../src/common/stockitem.cpp:189 ../src/richtext/richtextctrl.cpp:337
+#: ../src/richtext/richtextctrl.cpp:5479
+msgid "&Properties"
+msgstr "&Propriedades"
+
+#: ../src/common/stockitem.cpp:189
+msgid "Properties"
+msgstr "Propriedades"
+
+#: ../src/common/stockitem.cpp:190 ../src/stc/stc_i18n.cpp:16
+msgid "Redo"
+msgstr "Refazer"
+
+#: ../src/common/stockitem.cpp:191
+msgid "Refresh"
+msgstr "Atualizar"
+
+#: ../src/common/stockitem.cpp:192
+msgid "Remove"
+msgstr "Remover"
+
+#: ../src/common/stockitem.cpp:193
+msgid "Rep&lace..."
+msgstr "Sub&stituir..."
+
+#: ../src/common/stockitem.cpp:193
+msgid "Replace..."
+msgstr "Substituir..."
+
+#: ../src/common/stockitem.cpp:194
+msgid "Revert to Saved"
+msgstr "Reverter pro Salvo"
+
+#: ../src/common/stockitem.cpp:196 ../src/generic/logg.cpp:549
+msgid "Save &As..."
+msgstr "Salvar &Como..."
+
+#: ../src/common/stockitem.cpp:196
+msgid "Save As..."
+msgstr "Salvar Como..."
+
+#: ../src/common/stockitem.cpp:197 ../src/msw/textctrl.cpp:2888
+#: ../src/osx/textctrl_osx.cpp:657 ../src/richtext/richtextctrl.cpp:335
+msgid "Select &All"
+msgstr "Selecionar &Tudo"
+
+#: ../src/common/stockitem.cpp:197 ../src/stc/stc_i18n.cpp:21
+msgid "Select All"
+msgstr "Selecionar Tudo"
+
+#: ../src/common/stockitem.cpp:198
+msgid "&Color"
+msgstr "&Côr"
+
+#: ../src/common/stockitem.cpp:198
+msgid "Color"
+msgstr "Côr"
+
+#: ../src/common/stockitem.cpp:199
+msgid "&Font"
+msgstr "&Fonte"
+
+#: ../src/common/stockitem.cpp:199 ../src/richtext/richtextformatdlg.cpp:336
+msgid "Font"
+msgstr "Fonte"
+
+#: ../src/common/stockitem.cpp:200
+msgid "&Ascending"
+msgstr "&Ascendente"
+
+#: ../src/common/stockitem.cpp:200
+msgid "Ascending"
+msgstr "Ascendente"
+
+#: ../src/common/stockitem.cpp:201
+msgid "&Descending"
+msgstr "&Descendente"
+
+#: ../src/common/stockitem.cpp:201
+msgid "Descending"
+msgstr "Descendente"
+
+#: ../src/common/stockitem.cpp:202
+msgid "&Spell Check"
+msgstr "&Verificação da Ortografia"
+
+#: ../src/common/stockitem.cpp:202
+msgid "Spell Check"
+msgstr "&Verificação da Ortografia"
+
+#: ../src/common/stockitem.cpp:203
+msgid "&Stop"
+msgstr "&Parar"
+
+#: ../src/common/stockitem.cpp:203
+msgid "Stop"
+msgstr "Parar"
+
+#: ../src/common/stockitem.cpp:204 ../src/richtext/richtextfontpage.cpp:274
+msgid "&Strikethrough"
+msgstr "&Sublinhado"
+
+#: ../src/common/stockitem.cpp:204
+msgid "Strikethrough"
+msgstr "Riscar"
+
+#: ../src/common/stockitem.cpp:205
+msgid "&Top"
+msgstr "&Topo"
+
+#: ../src/common/stockitem.cpp:205 ../src/richtext/richtextsizepage.cpp:285
+#: ../src/richtext/richtextsizepage.cpp:289
+msgid "Top"
+msgstr "Topo"
+
+#: ../src/common/stockitem.cpp:206
+msgid "Undelete"
+msgstr "Restaurar"
+
+#: ../src/common/stockitem.cpp:207 ../src/generic/fontdlgg.cpp:437
+msgid "&Underline"
+msgstr "&Sublinhar"
+
+#: ../src/common/stockitem.cpp:207
+msgid "Underline"
+msgstr "Sublinhar"
+
+#: ../src/common/stockitem.cpp:208 ../src/stc/stc_i18n.cpp:15
+msgid "Undo"
+msgstr "Desfazer"
+
+#: ../src/common/stockitem.cpp:209
+msgid "&Unindent"
+msgstr "&Sem parágrafo"
+
+#: ../src/common/stockitem.cpp:209
+msgid "Unindent"
+msgstr "Sem parágrafo"
+
+#: ../src/common/stockitem.cpp:210
+msgid "&Up"
+msgstr "&Pra cima"
+
+#: ../src/common/stockitem.cpp:210 ../src/generic/fdrepdlg.cpp:148
+msgid "Up"
+msgstr "Pra cima"
+
+#: ../src/common/stockitem.cpp:211 ../src/msw/msgdlg.cpp:417
+msgid "&Yes"
+msgstr "&Sim"
+
+#: ../src/common/stockitem.cpp:212
+msgid "&Actual Size"
+msgstr "&Tamanho Real"
+
+#: ../src/common/stockitem.cpp:212
+msgid "Actual Size"
+msgstr "Tamanho Real"
+
+#: ../src/common/stockitem.cpp:213
+msgid "Zoom to &Fit"
+msgstr "Zoom para &Encaixar"
+
+#: ../src/common/stockitem.cpp:213
+msgid "Zoom to Fit"
+msgstr "Zoom pra Encaixar"
+
+#: ../src/common/stockitem.cpp:214
+msgid "Zoom &In"
+msgstr "Aumentar &Zoom"
+
+#: ../src/common/stockitem.cpp:215
+msgid "Zoom &Out"
+msgstr "Diminuir &Zoom"
+
+#: ../src/common/stockitem.cpp:262
+msgid "Show about dialog"
+msgstr "Mostrar o diálogo sobre"
+
+#: ../src/common/stockitem.cpp:263
+msgid "Copy selection"
+msgstr "Copiar a seleção"
+
+#: ../src/common/stockitem.cpp:264
+msgid "Cut selection"
+msgstr "Cortar a seleção"
+
+#: ../src/common/stockitem.cpp:265
+msgid "Delete selection"
+msgstr "Apagar a seleção"
+
+#: ../src/common/stockitem.cpp:266
+msgid "Find in document"
+msgstr "Achar no documento"
+
+#: ../src/common/stockitem.cpp:267
+msgid "Find and replace in document"
+msgstr "Achar e substituir no documento"
+
+#: ../src/common/stockitem.cpp:268
+msgid "Paste selection"
+msgstr "Colar a seleção"
+
+#: ../src/common/stockitem.cpp:269
+msgid "Quit this program"
+msgstr "Sair deste programa"
+
+#: ../src/common/stockitem.cpp:270
+msgid "Redo last action"
+msgstr "Refazer a última ação"
+
+#: ../src/common/stockitem.cpp:271
+msgid "Undo last action"
+msgstr "Desfazer a última ação"
+
+#: ../src/common/stockitem.cpp:272
+msgid "Create new document"
+msgstr "Criar novo documento"
+
+#: ../src/common/stockitem.cpp:273
+msgid "Open an existing document"
+msgstr "Abrir um documento existente"
+
+#: ../src/common/stockitem.cpp:274
+msgid "Close current document"
+msgstr "Fechar o documento atual"
+
+#: ../src/common/stockitem.cpp:275
+msgid "Save current document"
+msgstr "Salvar o documento atual"
+
+#: ../src/common/stockitem.cpp:276
+msgid "Save current document with a different filename"
+msgstr "Salvar o documento atual com um nome de arquivo diferente"
+
+#: ../src/common/strconv.cpp:2324
+#, c-format
+msgid "Conversion to charset '%s' doesn't work."
+msgstr "A conversão para o conjunto de caracteres '%s' não funciona."
+
+#: ../src/common/tarstrm.cpp:352 ../src/common/tarstrm.cpp:375
+#: ../src/common/tarstrm.cpp:406 ../src/generic/progdlgg.cpp:373
+msgid "unknown"
+msgstr "desconhecido"
+
+#: ../src/common/tarstrm.cpp:774
+msgid "incomplete header block in tar"
+msgstr "bloco do cabeçalho incompleto no tar"
+
+#: ../src/common/tarstrm.cpp:798
+msgid "checksum failure reading tar header block"
+msgstr "falha do checksum ao ler o bloco do cabeçalho tar"
+
+#: ../src/common/tarstrm.cpp:971
+msgid "invalid data in extended tar header"
+msgstr "dados inválidos no cabeçalho estendido do tar"
+
+#: ../src/common/tarstrm.cpp:981 ../src/common/tarstrm.cpp:1003
+#: ../src/common/tarstrm.cpp:1477 ../src/common/tarstrm.cpp:1499
+msgid "tar entry not open"
+msgstr "entrada do tar não aberta"
+
+#: ../src/common/tarstrm.cpp:1023
+msgid "unexpected end of file"
+msgstr "fim inesperado do arquivo"
+
+#: ../src/common/tarstrm.cpp:1297
+#, c-format
+msgid "%s did not fit the tar header for entry '%s'"
+msgstr "%s não encaixou no cabeçalho tar para a entrada '%s'"
+
+#: ../src/common/tarstrm.cpp:1359
+msgid "incorrect size given for tar entry"
+msgstr "tamanho incorreto dado para a entrada do tar"
+
+#: ../src/common/textbuf.cpp:232
+#, c-format
+msgid "'%s' is probably a binary buffer."
+msgstr "'%s' é provavelmente um buffer binário."
+
+#: ../src/common/textcmn.cpp:1006 ../src/richtext/richtextctrl.cpp:3053
+msgid "File couldn't be loaded."
+msgstr "O arquivo não pôde ser carregado."
+
+#: ../src/common/textfile.cpp:95
+#, c-format
+msgid "Failed to read text file \"%s\"."
+msgstr "Falhou em ler o arquivo do texto \"%s\"."
+
+#: ../src/common/textfile.cpp:160
+#, c-format
+msgid "can't write buffer '%s' to disk."
+msgstr "não pode gravar o buffer '%s' no disco."
+
+#: ../src/common/time.cpp:212
+msgid "Failed to get the local system time"
+msgstr "Falhou em obter a hora local do sistema"
+
+#: ../src/common/time.cpp:279
+msgid "wxGetTimeOfDay failed."
+msgstr "o wxGetTimeOfDay falhou."
+
+#: ../src/common/translation.cpp:929
+#, c-format
+msgid "'%s' is not a valid message catalog."
+msgstr "'%s' não é um catálogo de mensagens válido."
+
+#: ../src/common/translation.cpp:954
+msgid "Invalid message catalog."
+msgstr "Catálogo de mensagens inválido."
+
+#: ../src/common/translation.cpp:1013
+#, c-format
+msgid "Failed to parse Plural-Forms: '%s'"
+msgstr "Falhou em analisar as Formas-do-Plural: '%s'"
+
+#: ../src/common/translation.cpp:1723
+#, c-format
+msgid "using catalog '%s' from '%s'."
+msgstr "usando o catálogo '%s' de '%s'."
+
+#: ../src/common/translation.cpp:1816
+#, c-format
+msgid "Resource '%s' is not a valid message catalog."
+msgstr "O recurso '%s' não é um catálogo de mensagens válido."
+
+#: ../src/common/translation.cpp:1865
+msgid "Couldn't enumerate translations"
+msgstr "Não pôde enumerar as traduções"
+
+#: ../src/common/utilscmn.cpp:1145
+msgid "No default application configured for HTML files."
+msgstr "Nenhum aplicativo padrão configurado para os arquivos HTML."
+
+#: ../src/common/utilscmn.cpp:1190
+#, c-format
+msgid "Failed to open URL \"%s\" in default browser."
+msgstr "Falhou em abrir a URL '%s' no navegador padrão."
+
+#: ../src/common/valtext.cpp:144
+msgid "Validation conflict"
+msgstr "Conflito de validação"
+
+#: ../src/common/valtext.cpp:186
+msgid "Required information entry is empty."
+msgstr "O espaço da informação requerida está vazio."
+
+#: ../src/common/valtext.cpp:188
+#, c-format
+msgid "'%s' is one of the invalid strings"
+msgstr "'%s' é uma das sequências inválidas"
+
+#: ../src/common/valtext.cpp:190
+#, c-format
+msgid "'%s' is not one of the valid strings"
+msgstr "'%s' não é uma das sequências válidas"
+
+#: ../src/common/valtext.cpp:199
+#, c-format
+msgid "'%s' contains invalid character(s)"
+msgstr "'%s' contém caractere(s) inválido(s)"
+
+#: ../src/common/webrequest.cpp:139
+#, c-format
+msgid "Error: %s (%d)"
+msgstr "Erro: %s (%d)"
+
+#: ../src/common/webrequest.cpp:655
+#, c-format
+msgid ""
+"Not enough free disk space for download: %llu needed but only %llu available."
+msgstr ""
+"Não há espaço livre no disco o bastante pro download: %llu necessários mas "
+"só %llu disponíveis."
+
+#: ../src/common/webrequest.cpp:669
+#, c-format
+msgid "Failed to create temporary file in %s"
+msgstr "Falhou em criar um arquivo temporário no %s"
+
+#: ../src/common/webrequest_curl.cpp:1106
+msgid "libcurl could not be initialized"
+msgstr "O libcurl não pôde ser inicializado"
+
+#: ../src/common/webview.cpp:392
+msgid "RunScriptAsync not supported"
+msgstr "O RunScriptAsync não é suportado"
+
+#: ../src/common/webview.cpp:403 ../src/msw/webview_ie.cpp:1073
+#, c-format
+msgid "Error running JavaScript: %s"
+msgstr "Erro ao executar o JavaScript: %s"
+
+#: ../src/common/webview_chromium.cpp:858
+#, c-format
+msgid "Failed to set proxy \"%s\": %s"
+msgstr "Falhou em definir o proxy \"%s\": %s"
+
+#: ../src/common/webview_chromium.cpp:989
+msgid ""
+"Chromium can't be used because libcef.so wasn't loaded early enough; please "
+"relink the application or use LD_PRELOAD to load it earlier."
+msgstr ""
+"O Chromium não pôde ser usado porque o libcef.so não foi carregado cedo o "
+"bastante; por favor vincule o aplicativo de novo ou use o LD_PRELOAD pra "
+"carregá-lo mais cedo."
+
+#: ../src/common/webview_chromium.cpp:1108
+msgid "Could not initialize Chromium"
+msgstr "Não pôde inicializar o Chromium"
+
+#: ../src/common/webview_chromium.cpp:1616
+msgid "Show DevTools"
+msgstr "Mostrar DevTools"
+
+#: ../src/common/webview_chromium.cpp:1617
+msgid "Close DevTools"
+msgstr "Fechar DevTools"
+
+#: ../src/common/webview_chromium.cpp:1623
+msgid "Inspect"
+msgstr "Inspecionar"
+
+#: ../src/common/wincmn.cpp:1628
+msgid "This platform does not support background transparency."
+msgstr "Esta plataforma não suporta transparência de 2º plano."
+
+#: ../src/common/wincmn.cpp:2097
+msgid "Could not transfer data to window"
+msgstr "Não pôde transferir os dados para a janela"
+
+#: ../src/common/windowid.cpp:240
+msgid "Out of window IDs.  Recommend shutting down application."
+msgstr "IDs fora da janela. Recomendar o fechamento do aplicativo."
+
+#: ../src/common/xpmdecod.cpp:678
+msgid "XPM: incorrect header format!"
+msgstr "XPM: formato do cabeçalho inválido!"
+
+#: ../src/common/xpmdecod.cpp:703
+#, c-format
+msgid "XPM: incorrect colour description in line %d"
+msgstr "XPM: descrição da côr incorreta na linha %d"
+
+#: ../src/common/xpmdecod.cpp:715 ../src/common/xpmdecod.cpp:724
+#, c-format
+msgid "XPM: malformed colour definition '%s' at line %d!"
+msgstr "XPM: definição da côr mal formada '%s' na linha %d!"
+
+#: ../src/common/xpmdecod.cpp:754
+msgid "XPM: no colors left to use for mask!"
+msgstr "XPM: nenhuma côr restou pra usar na máscara!"
+
+#: ../src/common/xpmdecod.cpp:781
+#, c-format
+msgid "XPM: truncated image data at line %d!"
+msgstr "XPM: dados da imagem truncados na linha %d!"
+
+#: ../src/common/xpmdecod.cpp:795
+msgid "XPM: Malformed pixel data!"
+msgstr "XPM: Dados dos pixels mal formados!"
+
+#: ../src/common/xti.cpp:492
+msgid "Illegal Parameter Count for Create Method"
+msgstr "Contagem Ilegal dos Parâmetros pro Metodo Create"
+
+#: ../src/common/xti.cpp:504
+msgid "Illegal Parameter Count for ConstructObject Method"
+msgstr "Contagem Ilegal dos Parâmetros pro Método ConstructObject"
+
+#: ../src/common/xtistrm.cpp:161
+#, c-format
+msgid "Create Parameter %s not found in declared RTTI Parameters"
+msgstr "Criar Parâmetro %s não achado nos Parâmetros RTTI declarados"
+
+#: ../src/common/xtistrm.cpp:290
+msgid "Illegal Object Class (Non-wxEvtHandler) as Event Source"
+msgstr "Classe de Objeto Ilegal (Não-wxEvtHandler) como Fonte do Evento"
+
+#: ../src/common/xtistrm.cpp:313 ../src/common/xtixml.cpp:345
+#: ../src/common/xtixml.cpp:498
+msgid "Type must have enum - long conversion"
+msgstr "O tipo precisa ter conversão enum - long"
+
+#: ../src/common/xtistrm.cpp:400 ../src/common/xtistrm.cpp:415
+msgid "Invalid or Null Object ID passed to GetObjectClassInfo"
+msgstr "ID do Objeto passada para o GetObjectClassInfo Inválida ou Nula"
+
+#: ../src/common/xtistrm.cpp:405
+msgid "Unknown Object passed to GetObjectClassInfo"
+msgstr "Objeto Desconhecido passado para o GetObjectClassInfo"
+
+#: ../src/common/xtistrm.cpp:420
+msgid "Already Registered Object passed to SetObjectClassInfo"
+msgstr "Objeto Já Registrado passado para o SetObjectClassInfo"
+
+#: ../src/common/xtistrm.cpp:430
+msgid "Invalid or Null Object ID passed to HasObjectClassInfo"
+msgstr "ID do Objeto passada para o HasObjectClassInfo Inválida ou Nula"
+
+#: ../src/common/xtistrm.cpp:460
+msgid "Passing a already registered object to SetObject"
+msgstr "Passando um objeto já registrado pro SetObject"
+
+#: ../src/common/xtistrm.cpp:471
+msgid "Passing an unknown object to GetObject"
+msgstr "Passando um objeto desconhecido pro GetObject"
+
+#: ../src/common/xtixml.cpp:229
+msgid "Forward hrefs are not supported"
+msgstr "As hrefs adiantadas não são suportadas"
+
+#: ../src/common/xtixml.cpp:247
+#, c-format
+msgid "unknown class %s"
+msgstr "classe %s desconhecida"
+
+#: ../src/common/xtixml.cpp:253
+msgid "objects cannot have XML Text Nodes"
+msgstr "objetos não podem ter os Nodes de Texto do XML"
+
+#: ../src/common/xtixml.cpp:258
+msgid "Objects must have an id attribute"
+msgstr "Os objetos devem ter um atributo id"
+
+#: ../src/common/xtixml.cpp:267
+#, c-format
+msgid "Doubly used id : %d"
+msgstr "ID usada duas vezes : %d"
+
+#: ../src/common/xtixml.cpp:316
+#, c-format
+msgid "Unknown Property %s"
+msgstr "Propriedade %s Desconhecida"
+
+#: ../src/common/xtixml.cpp:407
+msgid "A non empty collection must consist of 'element' nodes"
+msgstr "Uma coleção não vazia deve consistir de nodes do elemento"
+
+#: ../src/common/xtixml.cpp:478
+msgid "incorrect event handler string, missing dot"
+msgstr "sequência do manipulador de eventos incorreta; ponto desaparecido"
+
+#: ../src/common/zipstrm.cpp:559
+msgid "can't re-initialize zlib deflate stream"
+msgstr "não pode reinicializar o fluxo de deflação do zlib"
+
+#: ../src/common/zipstrm.cpp:584
+msgid "can't re-initialize zlib inflate stream"
+msgstr "não pode reinicializar o sistema de inflação do zlib"
+
+#: ../src/common/zipstrm.cpp:1023
+msgid "Ignoring malformed extra data record, ZIP file may be corrupted"
+msgstr ""
+"Ignorando o registro dos dados extras mal-formados, o arquivo ZIP pode estar "
+"corrompido"
+
+#: ../src/common/zipstrm.cpp:1502
+msgid "assuming this is a multi-part zip concatenated"
+msgstr "assumindo que este é um zip multi-partes concatenado"
+
+#: ../src/common/zipstrm.cpp:1664
+msgid "invalid zip file"
+msgstr "arquivo zip inválido"
+
+#: ../src/common/zipstrm.cpp:1723
+msgid "can't find central directory in zip"
+msgstr "não pode achar o diretório central no zip"
+
+#: ../src/common/zipstrm.cpp:1812
+msgid "error reading zip central directory"
+msgstr "erro lendo o diretório central do zip"
+
+#: ../src/common/zipstrm.cpp:1916
+msgid "error reading zip local header"
+msgstr "erro lendo o cabeçalho local do zip"
+
+#: ../src/common/zipstrm.cpp:1964
+msgid "bad zipfile offset to entry"
+msgstr "offset ruim do arquivo zip para a entrada"
+
+#: ../src/common/zipstrm.cpp:2031
+msgid "stored file length not in Zip header"
+msgstr "tamanho do arquivo armazenado não está no cabeçalho do Zip"
+
+#: ../src/common/zipstrm.cpp:2045 ../src/common/zipstrm.cpp:2362
+msgid "unsupported Zip compression method"
+msgstr "método de compressão do Zip não suportado"
+
+#: ../src/common/zipstrm.cpp:2126
+#, c-format
+msgid "reading zip stream (entry %s): bad length"
+msgstr "lendo o fluxo do zip (entrada %s): tamanho ruim"
+
+#: ../src/common/zipstrm.cpp:2131
+#, c-format
+msgid "reading zip stream (entry %s): bad crc"
+msgstr "lendo o fluxo do zip (entrada %s): crc ruim"
+
+#: ../src/common/zipstrm.cpp:2578
+#, c-format
+msgid "error writing zip entry '%s': file too large without ZIP64"
+msgstr ""
+"erro ao gravar a entrada do zip '%s': o arquivo é muito grande sem o ZIP64"
+
+#: ../src/common/zipstrm.cpp:2585
+#, c-format
+msgid "error writing zip entry '%s': bad crc or length"
+msgstr "erro gravando a entrada do zip '%s': crc ou tamanho ruim"
+
+#: ../src/common/zstream.cpp:155 ../src/common/zstream.cpp:315
+msgid "Gzip not supported by this version of zlib"
+msgstr "Gzip não suportado por esta versão do zlib"
+
+#: ../src/common/zstream.cpp:182
+msgid "Can't initialize zlib inflate stream."
+msgstr "Não consegue inicializar o fluxo de inflação do zlib."
+
+#: ../src/common/zstream.cpp:241
+msgid "Can't read inflate stream: unexpected EOF in underlying stream."
+msgstr "Não consegue ler o fluxo da inflação: EOF inexperado no fluxo básico."
+
+#: ../src/common/zstream.cpp:248 ../src/common/zstream.cpp:423
+#, c-format
+msgid "zlib error %d"
+msgstr "erro do zlib %d"
+
+#: ../src/common/zstream.cpp:249
+#, c-format
+msgid "Can't read from inflate stream: %s"
+msgstr "Não consegue ler do fluxo de inflação: %s"
+
+#: ../src/common/zstream.cpp:343
+msgid "Can't initialize zlib deflate stream."
+msgstr "Não consegue inicializar o fluxo de deflação do zlib."
+
+#: ../src/common/zstream.cpp:424
+#, c-format
+msgid "Can't write to deflate stream: %s"
+msgstr "Não consegue gravar no fluxo de deflação: %s"
+
+#: ../src/dfb/bitmap.cpp:633 ../src/dfb/bitmap.cpp:667
+#, c-format
+msgid "No bitmap handler for type %d defined."
+msgstr "Nenhum manipulador de bitmap para o tipo %d definido."
+
+#: ../src/dfb/evtloop.cpp:99
+msgid "Failed to read event from DirectFB pipe"
+msgstr "Falhou em ler o evento do DirectFB pipe"
+
+#: ../src/dfb/evtloop.cpp:171
+msgid "Failed to switch DirectFB pipe to non-blocking mode"
+msgstr "Falhou em trocar o DirectFB pipe pro modo não bloqueador"
+
+#: ../src/dfb/fontmgr.cpp:171
+#, c-format
+msgid "no fonts found in %s, using builtin font"
+msgstr "nenhuma fonte achada em %s, usando a fonte embutida"
+
+#: ../src/dfb/fontmgr.cpp:177
+msgid "Default font"
+msgstr "Fonte padrão"
+
+#: ../src/dfb/fontmgr.cpp:195
+#, c-format
+msgid "Fonts index file %s disappeared while loading fonts."
+msgstr ""
+"O arquivo do índice das fontes %s desapareceu enquanto carregava as fontes."
+
+#: ../src/dfb/wrapdfb.cpp:60
+#, c-format
+msgid "DirectFB error %d occurred."
+msgstr "Ocorreu um erro do DirectFB %d."
+
+#: ../src/generic/aboutdlgg.cpp:69
+msgid "Developed by "
+msgstr "Desenvolvido por "
+
+#: ../src/generic/aboutdlgg.cpp:72
+msgid "Documentation by "
+msgstr "Documentação de "
+
+#: ../src/generic/aboutdlgg.cpp:75
+msgid "Graphics art by "
+msgstr "Arte gráfica de "
+
+#: ../src/generic/aboutdlgg.cpp:78
+msgid "Translations by "
+msgstr "Traduções de "
+
+#: ../src/generic/aboutdlgg.cpp:133 ../src/osx/cocoa/aboutdlg.mm:83
+msgid "Version "
+msgstr "Versão "
+
+#. TRANSLATORS: %s is application name
+#: ../src/generic/aboutdlgg.cpp:146 ../src/msw/aboutdlg.cpp:60
+#, c-format
+msgid "About %s"
+msgstr "Sobre o %s"
+
+#: ../src/generic/aboutdlgg.cpp:181
+msgid "License"
+msgstr "Licença"
+
+#: ../src/generic/aboutdlgg.cpp:184
+msgid "Developers"
+msgstr "Desenvolvedores"
+
+#: ../src/generic/aboutdlgg.cpp:188
+msgid "Documentation writers"
+msgstr "Escritores da documentação"
+
+#: ../src/generic/aboutdlgg.cpp:192
+msgid "Artists"
+msgstr "Artistas"
+
+#: ../src/generic/aboutdlgg.cpp:196
+msgid "Translators"
+msgstr "Tradutores"
+
+#: ../src/generic/animateg.cpp:125
+msgid "No handler found for animation type."
+msgstr "Nenhum manipulador achado para o tipo de animação."
+
+#: ../src/generic/animateg.cpp:133
+#, c-format
+msgid "No animation handler for type %ld defined."
+msgstr "Nenhum manipulador de animação pro tipo %ld definido."
+
+#: ../src/generic/animateg.cpp:145
+#, c-format
+msgid "Animation file is not of type %ld."
+msgstr "O arquivo de animação não é do tipo %ld."
+
+#: ../src/generic/colrdlgg.cpp:154 ../src/gtk/colordlg.cpp:47
+msgid "Choose colour"
+msgstr "Escolha uma côr"
+
+#: ../src/generic/colrdlgg.cpp:357
+msgid "Red:"
+msgstr "Vermelho:"
+
+#: ../src/generic/colrdlgg.cpp:360
+msgid "Green:"
+msgstr "Verde:"
+
+#: ../src/generic/colrdlgg.cpp:363
+msgid "Blue:"
+msgstr "Azul:"
+
+#: ../src/generic/colrdlgg.cpp:372
+msgid "Opacity:"
+msgstr "Opacidade:"
+
+#: ../src/generic/colrdlgg.cpp:384
+msgid "Add to custom colours"
+msgstr "Adicionar as cores personalizadas"
+
+#: ../src/generic/creddlgg.cpp:56
+msgid "Username:"
+msgstr "Nome de Usuário:"
+
+#: ../src/generic/creddlgg.cpp:63
+msgid "Password:"
+msgstr "Senha:"
+
+#. TRANSLATORS: Name of Boolean true value
+#: ../src/generic/datavgen.cpp:1178
+msgid "true"
+msgstr "verdadeiro"
+
+#. TRANSLATORS: Name of Boolean false value
+#: ../src/generic/datavgen.cpp:1180
+msgid "false"
+msgstr "falso"
+
+#: ../src/generic/datavgen.cpp:6897
+#, c-format
+msgid "Row %i"
+msgstr "Fileira %i"
+
+#. TRANSLATORS: Action for manipulating a tree control
+#: ../src/generic/datavgen.cpp:6987
+msgid "Collapse"
+msgstr "Retrair"
+
+#. TRANSLATORS: Action for manipulating a tree control
+#: ../src/generic/datavgen.cpp:6990
+msgid "Expand"
+msgstr "Expandir"
+
+#. TRANSLATORS: Name of data view control and number of rows
+#: ../src/generic/datavgen.cpp:7011
+#, c-format
+msgid "%s (%d items)"
+msgstr "%s (%d itens)"
+
+#: ../src/generic/datavgen.cpp:7062
+#, c-format
+msgid "Column %u"
+msgstr "Coluna %u"
+
+#. TRANSLATORS: Keystroke for manipulating a tree control
+#: ../src/generic/datavgen.cpp:7131 ../src/richtext/richtextbulletspage.cpp:189
+#: ../src/richtext/richtextbulletspage.cpp:192
+#: ../src/richtext/richtextbulletspage.cpp:193
+#: ../src/richtext/richtextliststylepage.cpp:252
+#: ../src/richtext/richtextliststylepage.cpp:255
+#: ../src/richtext/richtextliststylepage.cpp:256
+#: ../src/richtext/richtextsizepage.cpp:248
+msgid "Left"
+msgstr "Esquerda"
+
+#. TRANSLATORS: Keystroke for manipulating a tree control
+#: ../src/generic/datavgen.cpp:7134 ../src/richtext/richtextbulletspage.cpp:191
+#: ../src/richtext/richtextliststylepage.cpp:254
+#: ../src/richtext/richtextsizepage.cpp:249
+msgid "Right"
+msgstr "Direita"
+
+#: ../src/generic/datectlg.cpp:90
+#, c-format
+msgid ""
+"\"%s\" is not in the expected date format, please enter it as e.g. \"%s\"."
+msgstr ""
+"O \"%s\" não está no formato de data esperado, por favor insira-o como no "
+"ex: \"%s\"."
+
+#: ../src/generic/datectlg.cpp:94
+msgid "Invalid date"
+msgstr "Data inválida"
+
+#: ../src/generic/dbgrptg.cpp:159
+#, c-format
+msgid "Open file \"%s\""
+msgstr "Abrir arquivo \"%s\""
+
+#: ../src/generic/dbgrptg.cpp:170
+#, c-format
+msgid "Enter command to open file \"%s\":"
+msgstr "Insira o comando pra abrir o arquivo \"%s\":"
+
+#: ../src/generic/dbgrptg.cpp:230
+msgid "Executable files (*.exe)|*.exe|"
+msgstr "Arquivos executáveis (*.exe)|*.exe|"
+
+#: ../src/generic/dbgrptg.cpp:300
+#, c-format
+msgid "Debug report \"%s\""
+msgstr "Relatório do debug \"%s\""
+
+#: ../src/generic/dbgrptg.cpp:316
+msgid "A debug report has been generated in the directory\n"
+msgstr "Um relatório de debug foi gerado no diretório\n"
+
+#: ../src/generic/dbgrptg.cpp:317
+msgid "The following debug report will be generated\n"
+msgstr "O seguinte relatório de debug será gerado\n"
+
+#: ../src/generic/dbgrptg.cpp:321
+msgid ""
+"The report contains the files listed below. If any of these files contain "
+"private information,\n"
+"please uncheck them and they will be removed from the report.\n"
+msgstr ""
+"O relatório contém os arquivos listados abaixo. Se alguns destes arquivos "
+"contém informação privada,\n"
+"por favor desmarque-os e eles serão removidos do relatório.\n"
+
+#: ../src/generic/dbgrptg.cpp:323
+msgid ""
+"If you wish to suppress this debug report completely, please choose the "
+"\"Cancel\" button,\n"
+"but be warned that it may hinder improving the program, so if\n"
+"at all possible please do continue with the report generation.\n"
+msgstr ""
+"Se você deseja suprimir este relatório de debug completamente por favor "
+"escolha o botão \"Cancelar\",\n"
+"mas esteja avisado que pode impedir de melhorar o programa, então se\n"
+"possível de algum modo por favor continue com a geração do relatório.\n"
+
+#: ../src/generic/dbgrptg.cpp:325
+msgid "              Thank you and we're sorry for the inconvenience!\n"
+msgstr "              Obrigado a você e nós lamentamos pela inconveniência!\n"
+
+#: ../src/generic/dbgrptg.cpp:333
+msgid "&Debug report preview:"
+msgstr "&Pré-visualizar o relatório do debug:"
+
+#: ../src/generic/dbgrptg.cpp:339
+msgid "&View..."
+msgstr "&Visualizar..."
+
+#: ../src/generic/dbgrptg.cpp:359
+msgid "&Notes:"
+msgstr "&Notas:"
+
+#: ../src/generic/dbgrptg.cpp:361
+msgid ""
+"If you have any additional information pertaining to this bug\n"
+"report, please enter it here and it will be joined to it:"
+msgstr ""
+"Se você tem qualquer informação adicional pertinente a este relatório\n"
+"de erro, por favor insira-a aqui e ela será adicionada a ele:"
+
+#: ../src/generic/dcpsg.cpp:1627
+msgid "Cannot open file for PostScript printing!"
+msgstr "Não consegue abrir o arquivo para a impressão PostScript!"
+
+#: ../src/generic/dirctrlg.cpp:402
+msgid "Computer"
+msgstr "Computador"
+
+#: ../src/generic/dirctrlg.cpp:404
+msgid "Sections"
+msgstr "Seções"
+
+#: ../src/generic/dirctrlg.cpp:482
+msgid "Home directory"
+msgstr "Diretório home"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/generic/dirctrlg.cpp:484 ../src/propgrid/advprops.cpp:811
+msgid "Desktop"
+msgstr "Área de trabalho"
+
+#: ../src/generic/dirctrlg.cpp:528 ../src/generic/filectrlg.cpp:752
+msgid "Illegal directory name."
+msgstr "Nome ilegal de diretório."
+
+#: ../src/generic/dirctrlg.cpp:528 ../src/generic/dirctrlg.cpp:546
+#: ../src/generic/dirctrlg.cpp:557 ../src/generic/dirdlgg.cpp:317
+#: ../src/generic/filectrlg.cpp:638 ../src/generic/filectrlg.cpp:752
+#: ../src/generic/filectrlg.cpp:766 ../src/generic/filectrlg.cpp:782
+#: ../src/generic/filectrlg.cpp:1356 ../src/generic/filectrlg.cpp:1387
+#: ../src/generic/filedlgg.cpp:362 ../src/gtk/filedlg.cpp:76
+msgid "Error"
+msgstr "Erro"
+
+#: ../src/generic/dirctrlg.cpp:546 ../src/generic/filectrlg.cpp:766
+msgid "File name exists already."
+msgstr "O nome do arquivo já existe."
+
+#: ../src/generic/dirctrlg.cpp:557 ../src/generic/dirdlgg.cpp:317
+#: ../src/generic/filectrlg.cpp:638 ../src/generic/filectrlg.cpp:782
+msgid "Operation not permitted."
+msgstr "Operação não permitida."
+
+#: ../src/generic/dirdlgg.cpp:107 ../src/generic/filedlgg.cpp:207
+msgid "Create new directory"
+msgstr "Criar novo diretório"
+
+#: ../src/generic/dirdlgg.cpp:112 ../src/generic/filedlgg.cpp:203
+msgid "Go to home directory"
+msgstr "Ir para o diretório home"
+
+#: ../src/generic/dirdlgg.cpp:143
+msgid "Show &hidden directories"
+msgstr "Mostrar &diretórios ocultos"
+
+#: ../src/generic/dirdlgg.cpp:196
+#, c-format
+msgid ""
+"The directory '%s' does not exist\n"
+"Create it now?"
+msgstr ""
+"O diretório '%s' não existe\n"
+"Criá-lo agora?"
+
+#: ../src/generic/dirdlgg.cpp:198
+msgid "Directory does not exist"
+msgstr "O diretório não existe"
+
+#: ../src/generic/dirdlgg.cpp:214
+#, c-format
+msgid ""
+"Failed to create directory '%s'\n"
+"(Do you have the required permissions?)"
+msgstr ""
+"Falhou em criar o diretório '%s'\n"
+"(Você tem as permissões requeridas?)"
+
+#: ../src/generic/dirdlgg.cpp:216
+msgid "Error creating directory"
+msgstr "Erro ao criar o diretório"
+
+#: ../src/generic/dirdlgg.cpp:281
+msgid "You cannot add a new directory to this section."
+msgstr "Você não pode adicionar um novo diretório a esta seção."
+
+#: ../src/generic/dirdlgg.cpp:282
+msgid "Create directory"
+msgstr "Criar diretório"
+
+#: ../src/generic/dirdlgg.cpp:291 ../src/generic/dirdlgg.cpp:301
+#: ../src/generic/filectrlg.cpp:614 ../src/generic/filectrlg.cpp:623
+msgid "NewName"
+msgstr "NovoNome"
+
+#: ../src/generic/editlbox.cpp:135
+msgid "Edit item"
+msgstr "Editar item"
+
+#: ../src/generic/editlbox.cpp:143
+msgid "New item"
+msgstr "Novo item"
+
+#: ../src/generic/editlbox.cpp:151
+msgid "Delete item"
+msgstr "Apagar o item"
+
+#: ../src/generic/editlbox.cpp:159
+msgid "Move up"
+msgstr "Mover pra cima"
+
+#: ../src/generic/editlbox.cpp:164
+msgid "Move down"
+msgstr "Mover pra baixo"
+
+#: ../src/generic/fdrepdlg.cpp:108
+msgid "Search for:"
+msgstr "Procurar por:"
+
+#: ../src/generic/fdrepdlg.cpp:120
+msgid "Replace with:"
+msgstr "Substituir por:"
+
+#: ../src/generic/fdrepdlg.cpp:140
+msgid "Whole word"
+msgstr "Palavra inteira"
+
+#: ../src/generic/fdrepdlg.cpp:143
+msgid "Match case"
+msgstr "Combinar com maiúsculas ou minúsculas"
+
+#: ../src/generic/fdrepdlg.cpp:156
+msgid "Search direction"
+msgstr "Direção da busca"
+
+#: ../src/generic/fdrepdlg.cpp:175
+msgid "&Replace"
+msgstr "&Substituir"
+
+#: ../src/generic/fdrepdlg.cpp:178
+msgid "Replace &all"
+msgstr "Substituir &tudo"
+
+#: ../src/generic/filectrlg.cpp:246 ../src/generic/filectrlg.cpp:269
+msgid "<DIR>"
+msgstr "<DIR>"
+
+#: ../src/generic/filectrlg.cpp:248 ../src/generic/filectrlg.cpp:271
+msgid "<LINK>"
+msgstr "<LINK>"
+
+#: ../src/generic/filectrlg.cpp:250 ../src/generic/filectrlg.cpp:273
+msgid "<DRIVE>"
+msgstr "<DRIVE>"
+
+#: ../src/generic/filectrlg.cpp:275
+#, c-format
+msgid "%ld byte"
+msgid_plural "%ld bytes"
+msgstr[0] "%ld byte"
+msgstr[1] "%ld bytes"
+
+#: ../src/generic/filectrlg.cpp:420
+msgid "Name"
+msgstr "Nome"
+
+#: ../src/generic/filectrlg.cpp:421 ../src/richtext/richtextformatdlg.cpp:361
+#: ../src/richtext/richtextsizepage.cpp:298
+msgid "Size"
+msgstr "Tamanho"
+
+#: ../src/generic/filectrlg.cpp:422
+msgid "Type"
+msgstr "Tipo"
+
+#: ../src/generic/filectrlg.cpp:423
+msgid "Modified"
+msgstr "Modificado"
+
+#: ../src/generic/filectrlg.cpp:426
+msgid "Permissions"
+msgstr "Permissões"
+
+#: ../src/generic/filectrlg.cpp:429
+msgid "Attributes"
+msgstr "Atributos"
+
+#: ../src/generic/filectrlg.cpp:936
+msgid "Current directory:"
+msgstr "Diretório atual:"
+
+#: ../src/generic/filectrlg.cpp:979
+msgid "Show &hidden files"
+msgstr "Mostrar &arquivos ocultos"
+
+#: ../src/generic/filectrlg.cpp:1355
+msgid "Illegal file specification."
+msgstr "Especificação ilegal do arquivo."
+
+#: ../src/generic/filectrlg.cpp:1387
+msgid "Directory doesn't exist."
+msgstr "O diretório não existe."
+
+#: ../src/generic/filedlgg.cpp:195
+msgid "View files as a list view"
+msgstr "Visualizar arquivos numa visualização de lista"
+
+#: ../src/generic/filedlgg.cpp:197
+msgid "View files as a detailed view"
+msgstr "Visualizar arquivos numa visualização detalhada"
+
+#: ../src/generic/filedlgg.cpp:200
+msgid "Go to parent directory"
+msgstr "Ir para o diretório pai"
+
+#: ../src/generic/filedlgg.cpp:351 ../src/gtk/filedlg.cpp:59
+#, c-format
+msgid "File '%s' already exists, do you really want to overwrite it?"
+msgstr "O arquivo '%s' já existe; você realmente quer sobrescrevê-lo?"
+
+#: ../src/generic/filedlgg.cpp:354 ../src/gtk/filedlg.cpp:62
+msgid "Confirm"
+msgstr "Confirmar"
+
+#: ../src/generic/filedlgg.cpp:362 ../src/gtk/filedlg.cpp:75
+msgid "Please choose an existing file."
+msgstr "Por favor escolha um arquivo existente."
+
+#: ../src/generic/filepickerg.cpp:64
+msgid "..."
+msgstr "..."
+
+#: ../src/generic/fontdlgg.cpp:76 ../src/richtext/richtextformatdlg.cpp:519
+msgid "ABCDEFGabcdefg12345"
+msgstr "ABCDEFGabcdefg12345"
+
+#: ../src/generic/fontdlgg.cpp:315
+msgid "Roman"
+msgstr "Romano"
+
+#: ../src/generic/fontdlgg.cpp:316
+msgid "Decorative"
+msgstr "Decorativo"
+
+#: ../src/generic/fontdlgg.cpp:317
+msgid "Modern"
+msgstr "Moderno"
+
+#: ../src/generic/fontdlgg.cpp:318
+msgid "Script"
+msgstr "Script"
+
+#: ../src/generic/fontdlgg.cpp:319
+msgid "Swiss"
+msgstr "Suíço"
+
+#: ../src/generic/fontdlgg.cpp:320
+msgid "Teletype"
+msgstr "Teletipo"
+
+#: ../src/generic/fontdlgg.cpp:321 ../src/generic/fontdlgg.cpp:324
+msgid "Normal"
+msgstr "Normal"
+
+#: ../src/generic/fontdlgg.cpp:323
+msgid "Slant"
+msgstr "Inclinar"
+
+#: ../src/generic/fontdlgg.cpp:325
+msgid "Light"
+msgstr "Leve"
+
+#: ../src/generic/fontdlgg.cpp:363
+msgid "&Font family:"
+msgstr "&Família da fonte:"
+
+#: ../src/generic/fontdlgg.cpp:367 ../src/generic/fontdlgg.cpp:369
+msgid "The font family."
+msgstr "A família da fonte."
+
+#: ../src/generic/fontdlgg.cpp:374 ../src/richtext/richtextstylepage.cpp:105
+msgid "&Style:"
+msgstr "&Estilo:"
+
+#: ../src/generic/fontdlgg.cpp:378 ../src/generic/fontdlgg.cpp:380
+msgid "The font style."
+msgstr "O estilo da fonte."
+
+#: ../src/generic/fontdlgg.cpp:385
+msgid "&Weight:"
+msgstr "&Peso:"
+
+#: ../src/generic/fontdlgg.cpp:389 ../src/generic/fontdlgg.cpp:391
+msgid "The font weight."
+msgstr "O peso da fonte."
+
+#: ../src/generic/fontdlgg.cpp:399
+msgid "C&olour:"
+msgstr "C&ôr:"
+
+#: ../src/generic/fontdlgg.cpp:407 ../src/generic/fontdlgg.cpp:409
+msgid "The font colour."
+msgstr "A côr da fonte."
+
+#: ../src/generic/fontdlgg.cpp:415
+msgid "&Point size:"
+msgstr "&Tamanho do ponto:"
+
+#: ../src/generic/fontdlgg.cpp:420 ../src/generic/fontdlgg.cpp:422
+#: ../src/generic/fontdlgg.cpp:426 ../src/generic/fontdlgg.cpp:428
+msgid "The font point size."
+msgstr "O tamanho do ponto da fonte."
+
+#: ../src/generic/fontdlgg.cpp:439 ../src/generic/fontdlgg.cpp:441
+msgid "Whether the font is underlined."
+msgstr "Se a fonte está sublinhada."
+
+#: ../src/generic/fontdlgg.cpp:448 ../src/html/helpwnd.cpp:1215
+msgid "Preview:"
+msgstr "Pré-visualização:"
+
+#: ../src/generic/fontdlgg.cpp:452 ../src/generic/fontdlgg.cpp:454
+msgid "Shows the font preview."
+msgstr "Mostra a pré-visualização da fonte."
+
+#: ../src/generic/fontdlgg.cpp:464 ../src/generic/fontdlgg.cpp:483
+msgid "Click to cancel the font selection."
+msgstr "Clique pra cancelar a seleção da fonte."
+
+#: ../src/generic/fontdlgg.cpp:469 ../src/generic/fontdlgg.cpp:471
+#: ../src/generic/fontdlgg.cpp:476 ../src/generic/fontdlgg.cpp:478
+msgid "Click to confirm the font selection."
+msgstr "Clique pra confirmar a seleção da fonte."
+
+#: ../src/generic/fontpickerg.cpp:50 ../src/gtk/fontdlg.cpp:77
+msgid "Choose font"
+msgstr "Escolha uma fonte"
+
+#: ../src/generic/grid.cpp:6542
+msgid ""
+"Error copying grid to the clipboard. Either selected cells were not "
+"contiguous or no cell was selected."
+msgstr ""
+"Erro ao copiar a grade para a área de transferência. Ou as células "
+"selecionadas não eram contíguas ou nenhuma célula foi selecionada."
+
+#: ../src/generic/grid.cpp:12739
+msgid "Grid Corner"
+msgstr "Canto da Grade"
+
+#: ../src/generic/grid.cpp:12741
+#, c-format
+msgid "Column %s Header"
+msgstr "Coluna %s Cabeçalho"
+
+#: ../src/generic/grid.cpp:12743
+#, c-format
+msgid "Row %s Header"
+msgstr "Linha %s cabeçalho"
+
+#: ../src/generic/grid.cpp:12745
+#, c-format
+msgid "Column %s: %s"
+msgstr "Coluna %s: %s"
+
+#: ../src/generic/grid.cpp:12749
+#, c-format
+msgid "Row %s: %s"
+msgstr "Linha %s: %s"
+
+#: ../src/generic/grid.cpp:12753
+#, c-format
+msgid "Row %s, Column %s: %s"
+msgstr "Linha %s, Coluna %s: %s"
+
+#: ../src/generic/helpext.cpp:257
+#, c-format
+msgid "Help directory \"%s\" not found."
+msgstr "O diretório da ajuda \"%s\" não foi achado."
+
+#: ../src/generic/helpext.cpp:265
+#, c-format
+msgid "Help file \"%s\" not found."
+msgstr "O arquivo de ajuda \"%s\" não foi achado."
+
+#: ../src/generic/helpext.cpp:284
+#, c-format
+msgid "Line %lu of map file \"%s\" has invalid syntax, skipped."
+msgstr "A linha %lu do arquivo do mapa \"%s\" tem sintaxe inválida, ignorada."
+
+#: ../src/generic/helpext.cpp:292
+#, c-format
+msgid "No valid mappings found in the file \"%s\"."
+msgstr "Nenhum mapeamento válido achado no arquivo \"%s\"."
+
+#: ../src/generic/helpext.cpp:435
+msgid "No entries found."
+msgstr "Não foram achadas entradas."
+
+#: ../src/generic/helpext.cpp:444 ../src/generic/helpext.cpp:445
+msgid "Help Index"
+msgstr "Índice da Ajuda"
+
+#: ../src/generic/helpext.cpp:448
+msgid "Relevant entries:"
+msgstr "Entradas relevantes:"
+
+#: ../src/generic/helpext.cpp:449
+msgid "Entries found"
+msgstr "Entradas achadas"
+
+#: ../src/generic/hyperlinkg.cpp:170
+msgid "&Copy URL"
+msgstr "&Copiar URL"
+
+#: ../src/generic/infobar.cpp:119
+msgid "Hide this notification message."
+msgstr "Esconder esta mensagem de notificação."
+
+#. TRANSLATORS: %s will be either the application name or "Application"
+#: ../src/generic/logg.cpp:257
+#, c-format
+msgid "%s Error"
+msgstr "Erro do %s"
+
+#. TRANSLATORS: %s will be either the application name or "Application"
+#: ../src/generic/logg.cpp:263
+#, c-format
+msgid "%s Warning"
+msgstr "Aviso do %s"
+
+#. TRANSLATORS: %s will be either the application name or "Application"
+#: ../src/generic/logg.cpp:273
+#, c-format
+msgid "%s Information"
+msgstr "Informação do %s"
+
+#: ../src/generic/logg.cpp:276
+msgid "Application"
+msgstr "Aplicativo"
+
+#: ../src/generic/logg.cpp:549
+msgid "Save log contents to file"
+msgstr "Salvar os conteúdos do log num arquivo"
+
+#: ../src/generic/logg.cpp:551
+msgid "C&lear"
+msgstr "L&impar"
+
+#: ../src/generic/logg.cpp:551
+msgid "Clear the log contents"
+msgstr "Limpar os conteúdos do log"
+
+#: ../src/generic/logg.cpp:553
+msgid "Close this window"
+msgstr "Fechar esta janela"
+
+#: ../src/generic/logg.cpp:554
+msgid "&Log"
+msgstr "&Log"
+
+#: ../src/generic/logg.cpp:610 ../src/generic/logg.cpp:992
+msgid "Can't save log contents to file."
+msgstr "Não consegue salvar os conteúdos do log no arquivo."
+
+#: ../src/generic/logg.cpp:613
+#, c-format
+msgid "Log saved to the file '%s'."
+msgstr "Log salvo no arquivo '%s'."
+
+#: ../src/generic/logg.cpp:719
+msgid "&Details"
+msgstr "&Detalhes"
+
+#: ../src/generic/logg.cpp:972
+msgid "Failed to copy dialog contents to the clipboard."
+msgstr "Falhou em copiar os conteúdos do diálogo pra área de transferência."
+
+#: ../src/generic/logg.cpp:1022
+#, c-format
+msgid "Append log to file '%s' (choosing [No] will overwrite it)?"
+msgstr "Anexar o log ao arquivo '%s'? (escolher [Não] sobrescreverá ele)?"
+
+#: ../src/generic/logg.cpp:1024
+msgid "Question"
+msgstr "Pergunta"
+
+#: ../src/generic/logg.cpp:1038
+msgid "invalid message box return value"
+msgstr "valor de retorno da caixa de mensagem inválido"
+
+#: ../src/generic/notifmsgg.cpp:129
+msgid "Notice"
+msgstr "Nota"
+
+#: ../src/generic/preferencesg.cpp:118
+#, c-format
+msgid "%s Preferences"
+msgstr "Preferências da %s"
+
+#: ../src/generic/printps.cpp:143
+msgid "Printing..."
+msgstr "Imprimindo..."
+
+#: ../src/generic/printps.cpp:160 ../src/gtk/print.cpp:1076
+#: ../src/msw/printwin.cpp:235
+msgid "Could not start printing."
+msgstr "Não pôde iniciar a impressão."
+
+#: ../src/generic/printps.cpp:183
+#, c-format
+msgid "Printing page %d..."
+msgstr "Imprimindo a página %d..."
+
+#: ../src/generic/prntdlgg.cpp:171
+msgid "Printer options"
+msgstr "Opções da impressora"
+
+#: ../src/generic/prntdlgg.cpp:176
+msgid "Print to File"
+msgstr "Imprimir pro Arquivo"
+
+#: ../src/generic/prntdlgg.cpp:179
+msgid "Setup..."
+msgstr "Configurar..."
+
+#: ../src/generic/prntdlgg.cpp:187
+msgid "Printer:"
+msgstr "Impressora:"
+
+#: ../src/generic/prntdlgg.cpp:195
+msgid "Status:"
+msgstr "Status:"
+
+#: ../src/generic/prntdlgg.cpp:206
+msgid "All"
+msgstr "Tudo"
+
+#: ../src/generic/prntdlgg.cpp:207
+msgid "Pages"
+msgstr "Páginas"
+
+#: ../src/generic/prntdlgg.cpp:215
+msgid "Print Range"
+msgstr "Alcance da Impressão"
+
+#: ../src/generic/prntdlgg.cpp:229
+msgid "From:"
+msgstr "De:"
+
+#: ../src/generic/prntdlgg.cpp:233
+msgid "To:"
+msgstr "Para:"
+
+#: ../src/generic/prntdlgg.cpp:238
+msgid "Copies:"
+msgstr "Cópias:"
+
+#: ../src/generic/prntdlgg.cpp:288
+msgid "PostScript file"
+msgstr "Arquivo do PostScript"
+
+#: ../src/generic/prntdlgg.cpp:439
+msgid "Print Setup"
+msgstr "Configuração da Impressão"
+
+#: ../src/generic/prntdlgg.cpp:483
+msgid "Printer"
+msgstr "Impressora"
+
+#: ../src/generic/prntdlgg.cpp:501
+msgid "Default printer"
+msgstr "Impressora padrão"
+
+#: ../src/generic/prntdlgg.cpp:595 ../src/generic/prntdlgg.cpp:782
+#: ../src/generic/prntdlgg.cpp:822 ../src/generic/prntdlgg.cpp:835
+#: ../src/generic/prntdlgg.cpp:1031 ../src/generic/prntdlgg.cpp:1036
+msgid "Paper size"
+msgstr "Tamanho do papel"
+
+#: ../src/generic/prntdlgg.cpp:604 ../src/generic/prntdlgg.cpp:847
+msgid "Portrait"
+msgstr "Retrato"
+
+#: ../src/generic/prntdlgg.cpp:605 ../src/generic/prntdlgg.cpp:848
+msgid "Landscape"
+msgstr "Paisagem"
+
+#: ../src/generic/prntdlgg.cpp:607 ../src/generic/prntdlgg.cpp:849
+msgid "Orientation"
+msgstr "Orientação"
+
+#: ../src/generic/prntdlgg.cpp:610
+msgid "Options"
+msgstr "Opções"
+
+#: ../src/generic/prntdlgg.cpp:612
+msgid "Print in colour"
+msgstr "Imprimir em cores"
+
+#: ../src/generic/prntdlgg.cpp:621
+msgid "Print spooling"
+msgstr "Buffering da impressão"
+
+#: ../src/generic/prntdlgg.cpp:623
+msgid "Printer command:"
+msgstr "Comando da impressora:"
+
+#: ../src/generic/prntdlgg.cpp:631
+msgid "Printer options:"
+msgstr "Opções da impressora:"
+
+#: ../src/generic/prntdlgg.cpp:860
+msgid "Left margin (mm):"
+msgstr "Margem esquerda (mm):"
+
+#: ../src/generic/prntdlgg.cpp:861
+msgid "Top margin (mm):"
+msgstr "Margem superior (mm):"
+
+#: ../src/generic/prntdlgg.cpp:872
+msgid "Right margin (mm):"
+msgstr "Margem direita (mm):"
+
+#: ../src/generic/prntdlgg.cpp:873
+msgid "Bottom margin (mm):"
+msgstr "Margem do rodapé (mm):"
+
+#: ../src/generic/prntdlgg.cpp:896
+msgid "Printer..."
+msgstr "Impressora..."
+
+#: ../src/generic/progdlgg.cpp:246
+msgid "&Skip"
+msgstr "&Pular"
+
+#: ../src/generic/progdlgg.cpp:347 ../src/generic/progdlgg.cpp:626
+msgid "Unknown"
+msgstr "Desconhecido"
+
+#: ../src/generic/progdlgg.cpp:451 ../src/msw/progdlg.cpp:526
+msgid "Done."
+msgstr "Feito."
+
+#: ../src/generic/srchctlg.cpp:55 ../src/gtk/srchctrl.cpp:206
+#: ../src/html/helpwnd.cpp:530 ../src/html/helpwnd.cpp:545
+msgid "Search"
+msgstr "Procurar"
+
+#: ../src/generic/tabg.cpp:1026
+msgid "Could not find tab for id"
+msgstr "Não pôde achar a aba pela id"
+
+#: ../src/generic/tipdlg.cpp:136
+msgid "Tips not available, sorry!"
+msgstr "Dicas não disponíveis, lamento!"
+
+#: ../src/generic/tipdlg.cpp:197
+msgid "Tip of the Day"
+msgstr "Dica do Dia"
+
+#: ../src/generic/tipdlg.cpp:207
+msgid "Did you know..."
+msgstr "Você sabia..."
+
+#: ../src/generic/tipdlg.cpp:232
+msgid "&Show tips at startup"
+msgstr "&Mostrar dicas ao iniciar"
+
+#: ../src/generic/tipdlg.cpp:236
+msgid "&Next Tip"
+msgstr "&Próxima Dica"
+
+#: ../src/generic/wizard.cpp:411
+msgid "&Next >"
+msgstr "&Próximo >"
+
+#: ../src/generic/wizard.cpp:412
+msgid "&Finish"
+msgstr "&Concluir"
+
+#: ../src/generic/wizard.cpp:420
+msgid "< &Back"
+msgstr "< &Voltar"
+
+#: ../src/gtk/aboutdlg.cpp:204
+msgid "translator-credits"
+msgstr "tradutor-créditos"
+
+#: ../src/gtk/app.cpp:517
+msgid ""
+"WARNING: using XIM input method is unsupported and may result in problems "
+"with input handling and flickering. Consider unsetting GTK_IM_MODULE or "
+"setting to \"ibus\"."
+msgstr ""
+"AVISO: Não é suportado usar o método de entrada do XIM e pode resultar em "
+"problemas com o manejamento e oscilação da entrada dos dados. Considere "
+"remover a definição GTK_IM_MODULE ou defina como \"ibus\"."
+
+#: ../src/gtk/app.cpp:569
+msgid "Unable to initialize GTK+, is DISPLAY set properly?"
+msgstr ""
+"Incapaz de inicializar o GTK+, o DISPLAY está configurado apropriadamente?"
+
+#: ../src/gtk/filedlg.cpp:89 ../src/gtk/filepicker.cpp:255
+#, c-format
+msgid "Changing current directory to \"%s\" failed"
+msgstr "Falhou em mudar o diretório atual para %s"
+
+#: ../src/gtk/font.cpp:548
+msgid ""
+"Using private fonts is not supported on this system: Pango library is too "
+"old, 1.38 or later required."
+msgstr ""
+"Usar fontes privadas não é suportado neste sistema: A biblioteca do Pango é "
+"muito antiga, 1.38 ou superior requerido."
+
+#: ../src/gtk/font.cpp:558
+msgid "Failed to create font configuration object."
+msgstr "Falhou em criar o objeto da configuração da fonte."
+
+#: ../src/gtk/font.cpp:568
+#, c-format
+msgid "Failed to add custom font \"%s\"."
+msgstr "Falhou em adicionar a fonte personalizada \"%s\"."
+
+#: ../src/gtk/font.cpp:576
+msgid "Failed to register font configuration using private fonts."
+msgstr "Falhou em registrar a configuração da fonte usando fontes privadas."
+
+#: ../src/gtk/glcanvas.cpp:117 ../src/gtk/glcanvas.cpp:132
+msgid "Fatal Error"
+msgstr "Erro Fatal"
+
+#: ../src/gtk/glcanvas.cpp:117
+msgid ""
+"This program wasn't compiled with EGL support required under Wayland, "
+"either\n"
+"install EGL libraries and rebuild or run it under X11 backend by setting\n"
+"environment variable GDK_BACKEND=x11 before starting your program."
+msgstr ""
+"Este programa não foi compilado com suporte a EGL requerido pelo Wayland, "
+"ou\n"
+"instale as bibliotecas do EGL e reconstrua ou execute-o pelo backend do X11 "
+"definindo\n"
+"a variável do ambiente como GDK_BACKEND=x11 antes de iniciar seu programa."
+
+#: ../src/gtk/glcanvas.cpp:132
+msgid ""
+"wxGLCanvas is only supported on Wayland and X11 currently.  You may be able "
+"to\n"
+"work around this by setting environment variable GDK_BACKEND=x11 before\n"
+"starting your program."
+msgstr ""
+"O wxGLCanvas só é suportado no Wayland e X11 atualmente.  Você pode ser "
+"capaz de\n"
+"trabalhar ao redor disto definindo a variável do ambiente como "
+"GDK_BACKEND=x11\n"
+"antes de iniciar seu programa."
+
+#: ../src/gtk/mdi.cpp:433
+msgid "MDI child"
+msgstr "Filho do MDI"
+
+#: ../src/gtk/power.cpp:188
+#, c-format
+msgid "Failed to open D-Bus connection to the login manager: %s"
+msgstr "Falhou em abrir a conexão D-Bus com o gerenciador de login: %s"
+
+#: ../src/gtk/power.cpp:214
+msgid "wxWidgets application"
+msgstr "Aplicativo do wxWidgets"
+
+#: ../src/gtk/power.cpp:226
+msgid "Application needs to keep running"
+msgstr "O aplicativo precisa continuar executando"
+
+#: ../src/gtk/power.cpp:233
+msgid "Clean up before suspend"
+msgstr "Limpar antes de suspender"
+
+#: ../src/gtk/power.cpp:259
+#, c-format
+msgid "Failed to inhibit sleep: %s"
+msgstr "Falhou em inibir a suspensão: %s"
+
+#: ../src/gtk/power.cpp:265
+msgid "Unexpected response to D-Bus \"Inhibit\" request."
+msgstr "Resposta inesperada a requisição de \"Inibição\" do D-Bus."
+
+#: ../src/gtk/print.cpp:218
+msgid "Custom size"
+msgstr "Tamanho personalizado"
+
+#: ../src/gtk/print.cpp:752
+#, c-format
+msgid "Error while printing: %s"
+msgstr "Erro enquanto imprimia: %s"
+
+#: ../src/gtk/print.cpp:816
+msgid "Page Setup"
+msgstr "Configuração da Página"
+
+#: ../src/gtk/webview_webkit.cpp:932
+msgid "Retrieving JavaScript script output is not supported with WebKit v1"
+msgstr ""
+"A recuperação da saída dos dados do script do JavaScript não é suportada com "
+"o WebKit v1"
+
+#: ../src/gtk/webview_webkit2.cpp:1098
+msgid ""
+"Setting proxy is not supported by WebKit, at least version 2.16 is required."
+msgstr ""
+"A configuração do proxy não é suportada pelo WebKit, pelo menos a versão "
+"2.16 é requerida."
+
+#: ../src/gtk/webview_webkit2.cpp:1104
+msgid "This program was compiled without support for setting WebKit proxy."
+msgstr ""
+"Este programa foi compilado sem suporte pra configuração do proxy do WebKit."
+
+#: ../src/gtk/window.cpp:6289
+msgid ""
+"GTK+ installed on this machine is too old to support screen compositing, "
+"please install GTK+ 2.12 or later."
+msgstr ""
+"O GTK+ instalado nesta máquina é muito antigo pra suportar a composição de "
+"tela, por favor instale o GTK+ 2.12 ou superior."
+
+#: ../src/gtk/window.cpp:6307
+msgid ""
+"Compositing not supported by this system, please enable it in your Window "
+"Manager."
+msgstr ""
+"Composição não suportada por este sistema, por favor ative-a no seu "
+"Gerenciador de Janelas."
+
+#: ../src/gtk/window.cpp:6318
+msgid ""
+"This program was compiled with a too old version of GTK+, please rebuild "
+"with GTK+ 2.12 or newer."
+msgstr ""
+"Este programa foi compilado com uma versão muito velha do GTK+, por favor "
+"reconstrua com o GTK+ 2.12 ou mais novo."
+
+#: ../src/html/chm.cpp:138
+#, c-format
+msgid "Failed to open CHM archive '%s'."
+msgstr "Falhou em abrir o arquivo CHM '%s'."
+
+#: ../src/html/chm.cpp:270
+#, c-format
+msgid "Could not extract %s into %s: %s"
+msgstr "Não pôde extrair o %s para %s: %s"
+
+#: ../src/html/chm.cpp:324
+msgid "no error"
+msgstr "nenhum erro"
+
+#: ../src/html/chm.cpp:326
+msgid "bad arguments to library function"
+msgstr "argumentos ruins para a função da biblioteca"
+
+#: ../src/html/chm.cpp:328
+msgid "error opening file"
+msgstr "erro ao abrir o arquivo"
+
+#: ../src/html/chm.cpp:330
+msgid "read error"
+msgstr "erro de leitura"
+
+#: ../src/html/chm.cpp:332
+msgid "write error"
+msgstr "erro de gravação"
+
+#: ../src/html/chm.cpp:334
+msgid "seek error"
+msgstr "erro de busca"
+
+#: ../src/html/chm.cpp:338
+msgid "bad signature"
+msgstr "assinatura ruim"
+
+#: ../src/html/chm.cpp:340
+msgid "error in data format"
+msgstr "erro no formato dos dados"
+
+#: ../src/html/chm.cpp:342
+msgid "checksum error"
+msgstr "erro de checksum"
+
+#: ../src/html/chm.cpp:344
+msgid "compression error"
+msgstr "erro de compressão"
+
+#: ../src/html/chm.cpp:346
+msgid "decompression error"
+msgstr "erro de descompressão"
+
+#: ../src/html/chm.cpp:437
+#, c-format
+msgid "Could not locate file '%s'."
+msgstr "Não pôde localizar o arquivo '%s'."
+
+#: ../src/html/chm.cpp:711
+#, c-format
+msgid "Could not create temporary file '%s'"
+msgstr "Não pôde criar o arquivo temporário '%s'"
+
+#: ../src/html/chm.cpp:718
+#, c-format
+msgid "Extraction of '%s' into '%s' failed."
+msgstr "A extração de '%s' para '%s' falhou."
+
+#: ../src/html/chm.cpp:806 ../src/html/chm.cpp:863
+msgid "CHM handler currently supports only local files!"
+msgstr "O manipulador CHM suporta atualmente apenas arquivos locais!"
+
+#: ../src/html/chm.cpp:827
+msgid "Link contained '//', converted to absolute link."
+msgstr "O link continha '//'; convertido pra link absoluto."
+
+#: ../src/html/helpctrl.cpp:59
+#, c-format
+msgid "Help: %s"
+msgstr "Ajuda: %s"
+
+#: ../src/html/helpctrl.cpp:155
+#, c-format
+msgid "Adding book %s"
+msgstr "Adicionando o livro %s"
+
+#: ../src/html/helpdata.cpp:295
+#, c-format
+msgid "Cannot open contents file: %s"
+msgstr "Não consegue abrir o arquivo dos conteúdos: %s"
+
+#: ../src/html/helpdata.cpp:309
+#, c-format
+msgid "Cannot open index file: %s"
+msgstr "Não consegue abrir o arquivo do índice: %s"
+
+#: ../src/html/helpdata.cpp:643
+msgid "noname"
+msgstr "sem nome"
+
+#: ../src/html/helpdata.cpp:652
+#, c-format
+msgid "Cannot open HTML help book: %s"
+msgstr "Não consegue abrir o livro de ajuda em HTML: %s"
+
+#: ../src/html/helpwnd.cpp:315
+msgid "Displays help as you browse the books on the left."
+msgstr "Exibe a ajuda conforme você navega pelos livros a esquerda."
+
+#: ../src/html/helpwnd.cpp:411 ../src/html/helpwnd.cpp:1100
+#: ../src/html/helpwnd.cpp:1735
+msgid "(bookmarks)"
+msgstr "(favoritos)"
+
+#: ../src/html/helpwnd.cpp:424
+msgid "Add current page to bookmarks"
+msgstr "Adicionar a página atual aos favoritos"
+
+#: ../src/html/helpwnd.cpp:425
+msgid "Remove current page from bookmarks"
+msgstr "Remover a página atual dos favoritos"
+
+#: ../src/html/helpwnd.cpp:470
+msgid "Contents"
+msgstr "Conteúdos"
+
+#: ../src/html/helpwnd.cpp:485
+msgid "Find"
+msgstr "Achar"
+
+#: ../src/html/helpwnd.cpp:487
+msgid "Show all"
+msgstr "Mostrar tudo"
+
+#: ../src/html/helpwnd.cpp:497
+msgid ""
+"Display all index items that contain given substring. Search is case "
+"insensitive."
+msgstr ""
+"Exibe todos os itens do índice que contém a sub-sequência dada. A busca é "
+"caso sensitivo."
+
+#: ../src/html/helpwnd.cpp:498
+msgid "Show all items in index"
+msgstr "Mostrar todos os itens no índice"
+
+#: ../src/html/helpwnd.cpp:528
+msgid "Case sensitive"
+msgstr "Caso sensitivo"
+
+#: ../src/html/helpwnd.cpp:529
+msgid "Whole words only"
+msgstr "Só palavras inteiras"
+
+#: ../src/html/helpwnd.cpp:532
+msgid ""
+"Search contents of help book(s) for all occurrences of the text you typed "
+"above"
+msgstr ""
+"Pesquisar conteúdos do(s) livro(s) de ajuda pra todas as ocorrências do "
+"texto que você digitou acima"
+
+#: ../src/html/helpwnd.cpp:653
+msgid "Show/hide navigation panel"
+msgstr "Mostrar/ocultar o painel de navegação"
+
+#: ../src/html/helpwnd.cpp:655
+msgid "Go back"
+msgstr "Voltar"
+
+#: ../src/html/helpwnd.cpp:656
+msgid "Go forward"
+msgstr "Avançar"
+
+#: ../src/html/helpwnd.cpp:658
+msgid "Go one level up in document hierarchy"
+msgstr "Ir um nível acima na hierarquia do documento"
+
+#: ../src/html/helpwnd.cpp:666 ../src/html/helpwnd.cpp:1547
+msgid "Open HTML document"
+msgstr "Abrir documento HTML"
+
+#: ../src/html/helpwnd.cpp:670
+msgid "Print this page"
+msgstr "Imprimir esta página"
+
+#: ../src/html/helpwnd.cpp:674
+msgid "Display options dialog"
+msgstr "Exibir o diálogo das opções"
+
+#: ../src/html/helpwnd.cpp:795
+msgid "Please choose the page to display:"
+msgstr "Por favor escolha a página a exibir:"
+
+#: ../src/html/helpwnd.cpp:796
+msgid "Help Topics"
+msgstr "Tópicos da Ajuda"
+
+#: ../src/html/helpwnd.cpp:852
+msgid "Searching..."
+msgstr "Procurando..."
+
+#: ../src/html/helpwnd.cpp:853
+msgid "No matching page found yet"
+msgstr "Nenhuma página que combine ainda foi achada"
+
+#: ../src/html/helpwnd.cpp:870
+#, c-format
+msgid "Found %i matches"
+msgstr "Achou %i combinações"
+
+#: ../src/html/helpwnd.cpp:958
+msgid "(Help)"
+msgstr "(Ajuda)"
+
+#: ../src/html/helpwnd.cpp:1026
+#, c-format
+msgid "%d of %lu"
+msgstr "%d de %lu"
+
+#: ../src/html/helpwnd.cpp:1028
+#, c-format
+msgid "%lu of %lu"
+msgstr "%lu de %lu"
+
+#: ../src/html/helpwnd.cpp:1047
+msgid "Search in all books"
+msgstr "Procurar em todos os livros"
+
+#: ../src/html/helpwnd.cpp:1193
+msgid "Help Browser Options"
+msgstr "Opções de Ajuda do Navegador"
+
+#: ../src/html/helpwnd.cpp:1198
+msgid "Normal font:"
+msgstr "Fonte normal:"
+
+#: ../src/html/helpwnd.cpp:1199
+msgid "Fixed font:"
+msgstr "Fonte fixa:"
+
+#: ../src/html/helpwnd.cpp:1200
+msgid "Font size:"
+msgstr "Tamanho da fonte:"
+
+#: ../src/html/helpwnd.cpp:1245
+msgid "font size"
+msgstr "tamanho da fonte"
+
+#: ../src/html/helpwnd.cpp:1256
+msgid "Normal face<br>and <u>underlined</u>. "
+msgstr "Face normal<br>e <u>sublinhado</u>. "
+
+#: ../src/html/helpwnd.cpp:1257
+msgid "<i>Italic face.</i> "
+msgstr "<i>Face em itálico.</i> "
+
+#: ../src/html/helpwnd.cpp:1258
+msgid "<b>Bold face.</b> "
+msgstr "<b>Face em negrito.</b> "
+
+#: ../src/html/helpwnd.cpp:1259
+msgid "<b><i>Bold italic face.</i></b><br>"
+msgstr "<b><i>Face em negrito itálico.</i></b><br>"
+
+#: ../src/html/helpwnd.cpp:1262
+msgid "Fixed size face.<br> <b>bold</b> <i>italic</i> "
+msgstr "Face do tamanho fixo.<br> <b>negrito</b> <i>itálico</i> "
+
+#: ../src/html/helpwnd.cpp:1263
+msgid "<b><i>bold italic <u>underlined</u></i></b><br>"
+msgstr "<b><i>negrito itálico <u>sublinhado</u></i></b><br>"
+
+#: ../src/html/helpwnd.cpp:1524
+msgid "Help Printing"
+msgstr "Ajuda com a Impressão"
+
+#: ../src/html/helpwnd.cpp:1527
+msgid "Cannot print empty page."
+msgstr "Não consegue imprimir a página vazia."
+
+#: ../src/html/helpwnd.cpp:1540
+msgid "HTML files (*.html;*.htm)|*.html;*.htm|"
+msgstr "Arquivos HTML (*.html;*.htm)|*.html;*.htm|"
+
+#: ../src/html/helpwnd.cpp:1541
+msgid "Help books (*.htb)|*.htb|Help books (*.zip)|*.zip|"
+msgstr "Livros de ajuda (*.htb)|*.htb|Livros de ajuda (*.zip)|*.zip|"
+
+#: ../src/html/helpwnd.cpp:1542
+msgid "HTML Help Project (*.hhp)|*.hhp|"
+msgstr "Projeto de Ajuda em HTML (*.hhp)|*.hhp|"
+
+#: ../src/html/helpwnd.cpp:1544
+msgid "Compressed HTML Help file (*.chm)|*.chm|"
+msgstr "Arquivo de ajuda em HTML Compactado (*.chm)|*.chm|"
+
+#: ../src/html/helpwnd.cpp:1671
+#, c-format
+msgid "%i of %u"
+msgstr "%i de %u"
+
+#: ../src/html/helpwnd.cpp:1709
+#, c-format
+msgid "%u of %u"
+msgstr "%u de %u"
+
+#: ../src/html/htmlfilt.cpp:134
+#, c-format
+msgid "Cannot open HTML document: %s"
+msgstr "Não consegue abrir o documento HTML: %s"
+
+#: ../src/html/htmlwin.cpp:599
+msgid "Connecting..."
+msgstr "Conectando..."
+
+#: ../src/html/htmlwin.cpp:616
+#, c-format
+msgid "Unable to open requested HTML document: %s"
+msgstr "Incapaz de abrir o documento HTML requisitado: %s"
+
+#: ../src/html/htmlwin.cpp:630
+msgid "Loading : "
+msgstr "Carregando : "
+
+#: ../src/html/htmlwin.cpp:673
+msgid "Done"
+msgstr "Feito"
+
+#: ../src/html/htmlwin.cpp:723
+#, c-format
+msgid "HTML anchor %s does not exist."
+msgstr "A âncora HTML %s não existe."
+
+#: ../src/html/htmlwin.cpp:1057
+#, c-format
+msgid "Copied to clipboard:\"%s\""
+msgstr "Copiado pra área de transferência:\"%s\""
+
+#: ../src/html/htmprint.cpp:269
+msgid ""
+"This document doesn't fit on the page horizontally and will be truncated "
+"when it is printed."
+msgstr ""
+"Este documento não se encaixa na página horizontalmente e será truncado "
+"quando for impresso."
+
+#: ../src/html/htmprint.cpp:285
+#, c-format
+msgid ""
+"The document \"%s\" doesn't fit on the page horizontally and will be "
+"truncated if printed.\n"
+"\n"
+"Would you like to proceed with printing it nevertheless?"
+msgstr ""
+"O documento \"%s\" não se encaixa na página horizontalmente e será truncado "
+"se impresso.\n"
+"\n"
+"Você gostaria de prosseguir com a impressão apesar disso?"
+
+#: ../src/html/htmprint.cpp:296
+msgid ""
+"If possible, try changing the layout parameters to make the printout more "
+"narrow."
+msgstr ""
+"Se possível, tente mudar os parâmetros do layout pra tornar a impressão mais "
+"reduzida."
+
+#: ../src/html/htmprint.cpp:445
+msgid ": file does not exist!"
+msgstr ": o arquivo não existe!"
+
+#. TRANSLATORS: %s may be a document title.
+#: ../src/html/htmprint.cpp:717
+#, c-format
+msgid "%s Preview"
+msgstr "%s Pré-visualização"
+
+#: ../src/html/htmprint.cpp:755 ../src/richtext/richtextprint.cpp:618
+msgid ""
+"There was a problem during page setup: you may need to set a default printer."
+msgstr ""
+"Houve um problema durante a configuração da página: você pode precisar "
+"definir uma impressora padrão."
+
+#: ../src/msw/clipbrd.cpp:80
+msgid "Failed to open the clipboard."
+msgstr "Falhou em abrir a área de transferência."
+
+#: ../src/msw/clipbrd.cpp:101
+msgid "Failed to close the clipboard."
+msgstr "Falhou em fechar a área de transferência."
+
+#: ../src/msw/clipbrd.cpp:113
+msgid "Failed to empty the clipboard."
+msgstr "Falhou em esvaziar a área de transferência."
+
+#: ../src/msw/clipbrd.cpp:284
+msgid "Failed to put data on the clipboard"
+msgstr "Falhou em pôr os dados na área de transferência"
+
+#: ../src/msw/clipbrd.cpp:326
+msgid "Failed to get data from the clipboard"
+msgstr "Falhou em obter os dados da área de transferência"
+
+#: ../src/msw/clipbrd.cpp:363
+msgid "Failed to retrieve the supported clipboard formats"
+msgstr "Falhou em recuperar os formatos da área de transferência suportados"
+
+#: ../src/msw/colordlg.cpp:228
+#, c-format
+msgid "Colour selection dialog failed with error %0lx."
+msgstr "O diálogo da seleção de cores falhou com o erro %0lx."
+
+#: ../src/msw/cursor.cpp:141
+msgid "Failed to create cursor."
+msgstr "Falhou em criar o cursor."
+
+#: ../src/msw/dde.cpp:279
+#, c-format
+msgid "Failed to register DDE server '%s'"
+msgstr "Falhou em registrar o servidor DDE '%s'"
+
+#: ../src/msw/dde.cpp:300
+#, c-format
+msgid "Failed to unregister DDE server '%s'"
+msgstr "Falhou em des-registrar o servidor DDE '%s'"
+
+#: ../src/msw/dde.cpp:428
+#, c-format
+msgid "Failed to create connection to server '%s' on topic '%s'"
+msgstr "Falhou em criar uma conexão com o servidor '%s' no tópico '%s'"
+
+#: ../src/msw/dde.cpp:655
+msgid "DDE poke request failed"
+msgstr "O pedido para cutucar do DDE falhou"
+
+#: ../src/msw/dde.cpp:674
+msgid "Failed to establish an advise loop with DDE server"
+msgstr "Falhou em estabelecer um loop de recomendação com o servidor DDE"
+
+#: ../src/msw/dde.cpp:693
+msgid "Failed to terminate the advise loop with DDE server"
+msgstr "Falhou em concluir o loop de recomendação com o servidor DDE"
+
+#: ../src/msw/dde.cpp:768
+msgid "Failed to send DDE advise notification"
+msgstr "Falhou em enviar a notificação de recomendação do DDE"
+
+#: ../src/msw/dde.cpp:1085
+msgid "Failed to create DDE string"
+msgstr "Falhou em criar a sequência do DDE"
+
+#: ../src/msw/dde.cpp:1131
+msgid "no DDE error."
+msgstr "nenhum erro do DDE."
+
+#: ../src/msw/dde.cpp:1135
+msgid "a request for a synchronous advise transaction has timed out."
+msgstr ""
+"o tempo de um pedido pra uma transação de recomendação síncrona se esgotou."
+
+#: ../src/msw/dde.cpp:1138
+msgid "the response to the transaction caused the DDE_FBUSY bit to be set."
+msgstr "a resposta para a transação fez o bit do DDE_FBUSY ser definido."
+
+#: ../src/msw/dde.cpp:1141
+msgid "a request for a synchronous data transaction has timed out."
+msgstr "o tempo de um pedido pra uma transação de dados síncrona se esgotou."
+
+#: ../src/msw/dde.cpp:1144
+msgid ""
+"a DDEML function was called without first calling the DdeInitialize "
+"function,\n"
+"or an invalid instance identifier\n"
+"was passed to a DDEML function."
+msgstr ""
+"uma função DDEML foi chamada sem primeiro chamar a função DdeInitialize\n"
+"ou um identificador de instância inválido\n"
+"foi passado para uma função DDEML."
+
+#: ../src/msw/dde.cpp:1147
+msgid ""
+"an application initialized as APPCLASS_MONITOR has\n"
+"attempted to perform a DDE transaction,\n"
+"or an application initialized as APPCMD_CLIENTONLY has \n"
+"attempted to perform server transactions."
+msgstr ""
+"um aplicativo inicializado como APPCLASS_MONITOR tentou\n"
+"realizar uma transação DDE ou\n"
+"um aplicativo inicializado como APPCMD_CLIENTONLY tentou \n"
+"realizar transações de servidor."
+
+#: ../src/msw/dde.cpp:1150
+msgid "a request for a synchronous execute transaction has timed out."
+msgstr ""
+"o tempo de um pedido pra uma transação de execução síncrona se esgotou."
+
+#: ../src/msw/dde.cpp:1153
+msgid "a parameter failed to be validated by the DDEML."
+msgstr "um parâmetro falhou em ser validado pelo DDEML."
+
+#: ../src/msw/dde.cpp:1156
+msgid "a DDEML application has created a prolonged race condition."
+msgstr "um aplicativo DDEML criou uma condição de corrida prolongada."
+
+#: ../src/msw/dde.cpp:1159
+msgid "a memory allocation failed."
+msgstr "uma distribuição de memória falhou."
+
+#: ../src/msw/dde.cpp:1162
+msgid "a client's attempt to establish a conversation has failed."
+msgstr "uma tentativa de um cliente de estabelecer uma conversação falhou."
+
+#: ../src/msw/dde.cpp:1165
+msgid "a transaction failed."
+msgstr "um transação falhou."
+
+#: ../src/msw/dde.cpp:1168
+msgid "a request for a synchronous poke transaction has timed out."
+msgstr "o tempo de um pedido pra uma transação de cutucão síncrona se esgotou."
+
+#: ../src/msw/dde.cpp:1171
+msgid "an internal call to the PostMessage function has failed. "
+msgstr "uma chamada interna para a função PostMessage falhou. "
+
+#: ../src/msw/dde.cpp:1174
+msgid "reentrancy problem."
+msgstr "problema na re-entrada."
+
+#: ../src/msw/dde.cpp:1177
+msgid ""
+"a server-side transaction was attempted on a conversation\n"
+"that was terminated by the client, or the server\n"
+"terminated before completing a transaction."
+msgstr ""
+"uma transação do lado do servidor foi tentada em uma conversa\n"
+"que foi encerrada pelo cliente ou o servidor\n"
+"encerrou antes de completar uma transação."
+
+#: ../src/msw/dde.cpp:1180
+msgid "an internal error has occurred in the DDEML."
+msgstr "Um erro interno ocorreu no DDEML."
+
+#: ../src/msw/dde.cpp:1183
+msgid "a request to end an advise transaction has timed out."
+msgstr "o tempo pra encerrar uma transação de recomendação se esgotou."
+
+#: ../src/msw/dde.cpp:1186
+msgid ""
+"an invalid transaction identifier was passed to a DDEML function.\n"
+"Once the application has returned from an XTYP_XACT_COMPLETE callback,\n"
+"the transaction identifier for that callback is no longer valid."
+msgstr ""
+"Um identificador de transação inválido foi passado pra uma função DDEML.\n"
+"Uma vez que o aplicativo retornou de um callback XTYP_XACT_COMPLETE\n"
+"o identificador da transação para aquele callback não é mais válido."
+
+#: ../src/msw/dde.cpp:1189
+#, c-format
+msgid "Unknown DDE error %08x"
+msgstr "Erro DDE desconhecido %08x"
+
+#: ../src/msw/dialup.cpp:343
+msgid ""
+"Dial up functions are unavailable because the remote access service (RAS) is "
+"not installed on this machine. Please install it."
+msgstr ""
+"As funções de discagem estão indisponíveis porque o serviço de acesso remoto "
+"(RAS) não está instalado nesta máquina. Por favor instale-o."
+
+#: ../src/msw/dialup.cpp:402
+#, c-format
+msgid ""
+"The version of remote access service (RAS) installed on this machine is too "
+"old, please upgrade (the following required function is missing: %s)."
+msgstr ""
+"A versão do serviço de acesso remoto (RAS) instalado nesta máquina é muito "
+"antiga, por favor atualize (a seguinte função requerida está desaparecida: "
+"%s)."
+
+#: ../src/msw/dialup.cpp:437
+msgid "Failed to retrieve text of RAS error message"
+msgstr "Falhou em recuperar o texto da mensagem de erro do RAS"
+
+#: ../src/msw/dialup.cpp:440
+#, c-format
+msgid "unknown error (error code %08x)."
+msgstr "Erro desconhecido (código do erro %08x)."
+
+#: ../src/msw/dialup.cpp:492
+#, c-format
+msgid "Cannot find active dialup connection: %s"
+msgstr "Não consegue achar uma conexão dial-up ativa: %s"
+
+#: ../src/msw/dialup.cpp:513
+msgid "Several active dialup connections found, choosing one randomly."
+msgstr "Várias conexões dial-up ativas achadas, escolhendo uma aleatoriamente."
+
+#: ../src/msw/dialup.cpp:598 ../src/msw/dialup.cpp:832
+#, c-format
+msgid "Failed to establish dialup connection: %s"
+msgstr "Falhou em estabelecer uma conexão dial-up: %s"
+
+#: ../src/msw/dialup.cpp:664
+#, c-format
+msgid "Failed to get ISP names: %s"
+msgstr "Falhou em obter os nomes dos ISPs: %s"
+
+#: ../src/msw/dialup.cpp:712
+msgid "Failed to connect: no ISP to dial."
+msgstr "Falhou em conectar: nenhum ISP para discar."
+
+#: ../src/msw/dialup.cpp:732
+msgid "Choose ISP to dial"
+msgstr "Escolha um ISP pra discar"
+
+#: ../src/msw/dialup.cpp:733
+msgid "Please choose which ISP do you want to connect to"
+msgstr "Por favor escolha com qual ISP vocé quer se conectar"
+
+#: ../src/msw/dialup.cpp:766
+msgid "Failed to connect: missing username/password."
+msgstr "Falhou em conectar: faltando o nome de usuário/senha."
+
+#: ../src/msw/dialup.cpp:796
+msgid "Cannot find the location of address book file"
+msgstr "Não consegue achar o local do arquivo do livro de endereços"
+
+#: ../src/msw/dialup.cpp:827
+#, c-format
+msgid "Failed to initiate dialup connection: %s"
+msgstr "Falhou em iniciar a conexão dial-up: %s"
+
+#: ../src/msw/dialup.cpp:897
+msgid "Cannot hang up - no active dialup connection."
+msgstr "Não consegue desligar - nenhuma conexão dial-up ativa."
+
+#: ../src/msw/dialup.cpp:907
+#, c-format
+msgid "Failed to terminate the dialup connection: %s"
+msgstr "Falhou em finalizar a conexão dial-up: %s"
+
+#: ../src/msw/dib.cpp:313
+#, c-format
+msgid "Failed to save the bitmap image to file \"%s\"."
+msgstr "Falhou em salvar a imagem bitmap como arquivo \"%s\"."
+
+#: ../src/msw/dib.cpp:543
+#, c-format
+msgid "Failed to allocate %luKb of memory for bitmap data."
+msgstr "Falhou em distribuir %luKb de memória pros dados do bitmap."
+
+#: ../src/msw/dir.cpp:241
+#, c-format
+msgid "Cannot enumerate files in directory '%s'"
+msgstr "Não consegue enumerar os arquivos no diretório '%s'"
+
+#: ../src/msw/dirdlg.cpp:368
+msgid "Couldn't obtain folder name"
+msgstr "Não pôde obter o nome da pasta"
+
+#: ../src/msw/dlmsw.cpp:163
+#, c-format
+msgid "(error %d: %s)"
+msgstr "(erro %d: %s)"
+
+#: ../src/msw/dragimag.cpp:143 ../src/msw/dragimag.cpp:178
+#: ../src/msw/imaglist.cpp:309 ../src/msw/imaglist.cpp:331
+msgid "Couldn't add an image to the image list."
+msgstr "Não pôde adicionar uma imagem a lista de imagens."
+
+#: ../src/msw/enhmeta.cpp:94
+#, c-format
+msgid "Failed to load metafile from file \"%s\"."
+msgstr "Falhou em carregar o metafile do arquivo \"%s\"."
+
+#: ../src/msw/fdrepdlg.cpp:412
+#, c-format
+msgid "Failed to create the standard find/replace dialog (error code %d)"
+msgstr "Falhou em criar o diálogo achar/substituir padrão (código do erro %d)"
+
+#: ../src/msw/filedlg.cpp:1241
+msgid "Access to the file system is not allowed from secure desktop."
+msgstr ""
+"O acesso ao sistema de arquivos não é permitido a partir da área de trabalho "
+"segura."
+
+#: ../src/msw/filedlg.cpp:1242
+msgid "Security warning"
+msgstr "Aviso de segurança"
+
+#: ../src/msw/filedlg.cpp:1533
+#, c-format
+msgid "File dialog failed with error code %0lx."
+msgstr "O diálogo do arquivo falhou com o código de erro %0lx."
+
+#: ../src/msw/font.cpp:1120
+#, c-format
+msgid "Font file \"%s\" couldn't be loaded"
+msgstr "O arquivo da fonte \"%s\" não pôde ser carregado"
+
+#: ../src/msw/fontdlg.cpp:220
+#, c-format
+msgid "Common dialog failed with error code %0lx."
+msgstr "O diálogo comum falhou com o código do erro %0lx."
+
+#: ../src/msw/fswatcher.cpp:67
+msgid "Ungraceful worker thread termination"
+msgstr "Término deselegante do thread do trabalhador"
+
+#: ../src/msw/fswatcher.cpp:81
+msgid "Unable to create IOCP worker thread"
+msgstr "Incapaz de criar o thread do trabalhador IOCP"
+
+#: ../src/msw/fswatcher.cpp:88
+msgid "Unable to start IOCP worker thread"
+msgstr "Incapaz de iniciar o thread do trabalhador IOCP"
+
+#: ../src/msw/fswatcher.cpp:140
+msgid "Monitoring individual files for changes is not supported currently."
+msgstr ""
+"Atualmente não é suportado monitorar arquivos individuais por mudanças."
+
+#: ../src/msw/fswatcher.cpp:165
+#, c-format
+msgid "Unable to set up watch for '%s'"
+msgstr "Incapaz de configurar a observação para '%s'"
+
+#: ../src/msw/fswatcher.cpp:466
+#, c-format
+msgid "Can't monitor non-existent directory \"%s\" for changes."
+msgstr "Não consegue monitorar o diretório não-existente \"%s\" por mudanças."
+
+#: ../src/msw/glcanvas.cpp:577 ../src/unix/glx11.cpp:507
+msgid "OpenGL 3.0 or later is not supported by the OpenGL driver."
+msgstr "O OpenGL 3.0 ou superior não é suportado pelo driver do OpenGL."
+
+#: ../src/msw/glcanvas.cpp:601 ../src/osx/glcanvas_osx.cpp:395
+#: ../src/unix/glegl.cpp:304 ../src/unix/glx11.cpp:553
+msgid "Couldn't create OpenGL context"
+msgstr "Não pôde criar o contexto do OpenGL"
+
+#: ../src/msw/glcanvas.cpp:1294
+msgid "Failed to initialize OpenGL"
+msgstr "Falhou em inicializar o OpenGL"
+
+#: ../src/msw/graphicsd2d.cpp:607
+msgid "Could not register custom DirectWrite font loader."
+msgstr ""
+"Não pôde registrar o carregador das fontes do DirectWrite personalizado."
+
+#: ../src/msw/helpchm.cpp:48
+msgid ""
+"MS HTML Help functions are unavailable because the MS HTML Help library is "
+"not installed on this machine. Please install it."
+msgstr ""
+"As funções de Ajuda do MS HTML não estão disponíveis porque a biblioteca de "
+"Ajuda do MS HTML não está instalada nesta máquina. Por favor instale-a."
+
+#: ../src/msw/helpchm.cpp:55
+msgid "Failed to initialize MS HTML Help."
+msgstr "Falhou em inicializar a Ajuda do MS HTML."
+
+#: ../src/msw/iniconf.cpp:458
+#, c-format
+msgid "Can't delete the INI file '%s'"
+msgstr "Não consegue apagar o arquivo INI '%s'"
+
+#: ../src/msw/listctrl.cpp:995
+#, c-format
+msgid "Couldn't retrieve information about list control item %d."
+msgstr ""
+"Não pôde recuperar a informação sobre o item de controle das listas %d."
+
+#: ../src/msw/mdi.cpp:170 ../src/qt/mdi.cpp:253
+msgid "&Cascade"
+msgstr "&Em cascata"
+
+#: ../src/msw/mdi.cpp:171
+msgid "Tile &Horizontally"
+msgstr "Lado a Lado &Horizontalmente"
+
+#: ../src/msw/mdi.cpp:172
+msgid "Tile &Vertically"
+msgstr "Lado a Lado &Verticalmente"
+
+#: ../src/msw/mdi.cpp:174
+msgid "&Arrange Icons"
+msgstr "&Organizar Ícones"
+
+#: ../src/msw/mdi.cpp:621
+msgid "Failed to create MDI parent frame."
+msgstr "Falhou em criar o frame pai do MDI."
+
+#: ../src/msw/mimetype.cpp:234
+#, c-format
+msgid "Failed to create registry entry for '%s' files."
+msgstr "Falhou em criar a entrada no registro para os arquivos '%s'."
+
+#: ../src/msw/ole/automtn.cpp:495
+#, c-format
+msgid "Failed to find CLSID of \"%s\""
+msgstr "Falhou em achar a CLSID do \"%s\""
+
+#: ../src/msw/ole/automtn.cpp:512
+#, c-format
+msgid "Failed to create an instance of \"%s\""
+msgstr "Falhou em criar uma instância do \"%s\""
+
+#: ../src/msw/ole/automtn.cpp:552
+#, c-format
+msgid "Cannot get an active instance of \"%s\""
+msgstr "Não consegue obter uma instância ativa do \"%s\""
+
+#: ../src/msw/ole/automtn.cpp:564
+#, c-format
+msgid "Failed to get OLE automation interface for \"%s\""
+msgstr "Falhou em obter a interface de automação do OLE pro \"%s\""
+
+#: ../src/msw/ole/automtn.cpp:621
+msgid "Unknown name or named argument."
+msgstr "Nome ou argumento nomeado desconhecido."
+
+#: ../src/msw/ole/automtn.cpp:625
+msgid "Incorrect number of arguments."
+msgstr "Número incorreto de argumentos."
+
+#: ../src/msw/ole/automtn.cpp:637
+msgid "Unknown exception"
+msgstr "Exceção desconhecida"
+
+#: ../src/msw/ole/automtn.cpp:642
+msgid "Method or property not found."
+msgstr "Método ou propriedade não achada."
+
+#: ../src/msw/ole/automtn.cpp:646
+msgid "Overflow while coercing argument values."
+msgstr "Sobrecarga enquanto força os valores do argumento."
+
+#: ../src/msw/ole/automtn.cpp:650
+msgid "Object implementation does not support named arguments."
+msgstr "A implementação do objeto não suporta argumentos nomeados."
+
+#: ../src/msw/ole/automtn.cpp:654
+msgid "The locale ID is unknown."
+msgstr "A ID do idioma é desconhecida."
+
+#: ../src/msw/ole/automtn.cpp:658
+msgid "Missing a required parameter."
+msgstr "Está faltando um parâmetro requerido."
+
+#: ../src/msw/ole/automtn.cpp:662
+#, c-format
+msgid "Argument %u not found."
+msgstr "Argumento %u não achado."
+
+#: ../src/msw/ole/automtn.cpp:666
+#, c-format
+msgid "Type mismatch in argument %u."
+msgstr "Incompatibilidade do tipo no argumento %u."
+
+#: ../src/msw/ole/automtn.cpp:670
+msgid "The system cannot find the file specified."
+msgstr "O sistema não consegue achar o arquivo especificado."
+
+#: ../src/msw/ole/automtn.cpp:674
+msgid "Class not registered."
+msgstr "Classe não registrada."
+
+#: ../src/msw/ole/automtn.cpp:678
+#, c-format
+msgid "Unknown error %08x"
+msgstr "Erro %08x desconhecido"
+
+#: ../src/msw/ole/automtn.cpp:682
+#, c-format
+msgid "OLE Automation error in %s: %s"
+msgstr "Erro de automação do OLE em %s: %s"
+
+#: ../src/msw/ole/dataobj.cpp:385
+#, c-format
+msgid "Couldn't register clipboard format '%s'."
+msgstr "Não pôde registrar o formato da área de transferência '%s'."
+
+#: ../src/msw/ole/dataobj.cpp:402
+#, c-format
+msgid "The clipboard format '%d' doesn't exist."
+msgstr "O formato '%d' da área de transferência não existe."
+
+#: ../src/msw/progdlg.cpp:1025
+msgid "Skip"
+msgstr "Ignorar"
+
+#: ../src/msw/registry.cpp:141
+#, c-format
+msgid "unknown (%lu)"
+msgstr "desconhecido (%lu)"
+
+#: ../src/msw/registry.cpp:409
+#, c-format
+msgid "Can't get info about registry key '%s'"
+msgstr "Não consegue obter a info sobre a chave de registro '%s'"
+
+#: ../src/msw/registry.cpp:445
+#, c-format
+msgid "Can't open registry key '%s'"
+msgstr "Não consegue abrir a chave do registro '%s'"
+
+#: ../src/msw/registry.cpp:478
+#, c-format
+msgid "Can't create registry key '%s'"
+msgstr "Não consegue criar a chave de registro '%s'"
+
+#: ../src/msw/registry.cpp:497
+#, c-format
+msgid "Can't close registry key '%s'"
+msgstr "Não consegue fechar a chave de registro '%s'"
+
+#: ../src/msw/registry.cpp:512
+#, c-format
+msgid "Registry value '%s' already exists."
+msgstr "O valor do registro '%s' já existe."
+
+#: ../src/msw/registry.cpp:520
+#, c-format
+msgid "Failed to rename registry value '%s' to '%s'."
+msgstr "Falhou em renomear o valor do registro de '%s' para '%s'."
+
+#: ../src/msw/registry.cpp:575
+#, c-format
+msgid "Can't copy values of unsupported type %d."
+msgstr "Não consegue copiar os valores dos tipos não suportados %d."
+
+#: ../src/msw/registry.cpp:586
+#, c-format
+msgid "Registry key '%s' does not exist, cannot rename it."
+msgstr "A chave de registro '%s' não existe; não pode renomeá-la."
+
+#: ../src/msw/registry.cpp:617
+#, c-format
+msgid "Registry key '%s' already exists."
+msgstr "A chave de registro '%s' já existe."
+
+#: ../src/msw/registry.cpp:625
+#, c-format
+msgid "Failed to rename the registry key '%s' to '%s'."
+msgstr "Falhou em renomear a chave do registro de '%s' para '%s'."
+
+#: ../src/msw/registry.cpp:670
+#, c-format
+msgid "Failed to copy the registry subkey '%s' to '%s'."
+msgstr "Falhou em copiar a sub-chave do registro '%s' para '%s'."
+
+#: ../src/msw/registry.cpp:683
+#, c-format
+msgid "Failed to copy registry value '%s'"
+msgstr "Falhou em copiar o valor do registro '%s'"
+
+#: ../src/msw/registry.cpp:692
+#, c-format
+msgid "Failed to copy the contents of registry key '%s' to '%s'."
+msgstr "Falhou em copiar os conteúdos da chave de registro '%s' para '%s'."
+
+#: ../src/msw/registry.cpp:718
+#, c-format
+msgid ""
+"Registry key '%s' is needed for normal system operation,\n"
+"deleting it will leave your system in unusable state:\n"
+"operation aborted."
+msgstr ""
+"A chave do registro '%s' é necessária para a operação normal do sistema,\n"
+"apagando-a deixará seu sistema num estado inutilizável:\n"
+"operação abortada."
+
+#: ../src/msw/registry.cpp:754
+#, c-format
+msgid "Can't delete key '%s'"
+msgstr "Não consegue apagar a chave '%s'"
+
+#: ../src/msw/registry.cpp:782
+#, c-format
+msgid "Can't delete value '%s' from key '%s'"
+msgstr "Não consegue apagar o valor '%s' da chave '%s'"
+
+#: ../src/msw/registry.cpp:855 ../src/msw/registry.cpp:887
+#: ../src/msw/registry.cpp:929 ../src/msw/registry.cpp:1000
+#, c-format
+msgid "Can't read value of key '%s'"
+msgstr "Não consegue ler o valor da chave '%s'"
+
+#: ../src/msw/registry.cpp:873 ../src/msw/registry.cpp:915
+#: ../src/msw/registry.cpp:963 ../src/msw/registry.cpp:1106
+#, c-format
+msgid "Can't set value of '%s'"
+msgstr "Não consegue definir o valor de '%s'"
+
+#: ../src/msw/registry.cpp:894 ../src/msw/registry.cpp:943
+#, c-format
+msgid "Registry value \"%s\" is not numeric (but of type %s)"
+msgstr "O valor do registro \"%s\" não é numérico (mas do tipo %s)"
+
+#: ../src/msw/registry.cpp:979
+#, c-format
+msgid "Registry value \"%s\" is not binary (but of type %s)"
+msgstr "O valor do registro \"%s\" não é binário (mas do tipo %s)"
+
+#: ../src/msw/registry.cpp:1028
+#, c-format
+msgid "Registry value \"%s\" is not text (but of type %s)"
+msgstr "O valor do registro \"%s\" não é de texto (mas do tipo %s)"
+
+#: ../src/msw/registry.cpp:1089
+#, c-format
+msgid "Can't read value of '%s'"
+msgstr "Não consegue ler o valor de '%s'"
+
+#: ../src/msw/registry.cpp:1157
+#, c-format
+msgid "Can't enumerate values of key '%s'"
+msgstr "Não consegue enumerar os valores da chave '%s'"
+
+#: ../src/msw/registry.cpp:1196
+#, c-format
+msgid "Can't enumerate subkeys of key '%s'"
+msgstr "Não consegue enumerar as sub-chaves da chave '%s'"
+
+#: ../src/msw/registry.cpp:1262
+#, c-format
+msgid ""
+"Exporting registry key: file \"%s\" already exists and won't be overwritten."
+msgstr ""
+"Exportando a chave de registro: o arquivo \"%s\" já existe e não será "
+"sobrescrito."
+
+#: ../src/msw/registry.cpp:1411
+#, c-format
+msgid "Can't export value of unsupported type %d."
+msgstr "Não consegue exportar o valor do tipo não suportado %d."
+
+#: ../src/msw/registry.cpp:1427
+#, c-format
+msgid "Ignoring value \"%s\" of the key \"%s\"."
+msgstr "Ignorando o valor \"%s\" da chave \"%s\"."
+
+#: ../src/msw/textctrl.cpp:596
+msgid ""
+"Impossible to create a rich edit control, using simple text control instead. "
+"Please reinstall riched32.dll"
+msgstr ""
+"Impossível criar um controle de edição rico, usando o controle de texto "
+"simples ao invés disso. Por favor reinstale o riched32.dll"
+
+#: ../src/msw/thread.cpp:522 ../src/unix/threadpsx.cpp:850
+msgid "Cannot start thread: error writing TLS."
+msgstr "Não consegue iniciar o thread: erro ao gravar o TLS."
+
+#: ../src/msw/thread.cpp:613
+msgid "Can't set thread priority"
+msgstr "Não consegue definir a prioridade do thread"
+
+#: ../src/msw/thread.cpp:649
+msgid "Can't create thread"
+msgstr "Não consegue criar o thread"
+
+#: ../src/msw/thread.cpp:668
+msgid "Couldn't terminate thread"
+msgstr "Não pôde encerrar o thread"
+
+#: ../src/msw/thread.cpp:799
+msgid "Cannot wait for thread termination"
+msgstr "Não consegue esperar pelo término do thread"
+
+#: ../src/msw/thread.cpp:873
+#, c-format
+msgid "Cannot suspend thread %lx"
+msgstr "Não consegue suspender o thread %lx"
+
+#: ../src/msw/thread.cpp:903
+#, c-format
+msgid "Cannot resume thread %lx"
+msgstr "Não consegue resumir o thread %lx"
+
+#: ../src/msw/thread.cpp:932
+msgid "Couldn't get the current thread pointer"
+msgstr "Não pôde obter o ponteiro atual do thread"
+
+#: ../src/msw/thread.cpp:1333
+msgid ""
+"Thread module initialization failed: impossible to allocate index in thread "
+"local storage"
+msgstr ""
+"A inicialização do módulo dos threads falhou: impossível distribuir o índice "
+"no armazém local dos threads"
+
+#: ../src/msw/thread.cpp:1345
+msgid ""
+"Thread module initialization failed: cannot store value in thread local "
+"storage"
+msgstr ""
+"O módulo de inicialização do thread falhou: não pôde armazenar o valor no "
+"armazém local do thread"
+
+#: ../src/msw/timer.cpp:133
+msgid "Couldn't create a timer"
+msgstr "Não pôde criar um cronômetro"
+
+#: ../src/msw/utils.cpp:372
+msgid "can't find user's HOME, using current directory."
+msgstr "não pôde achar o HOME do usuário, usando o diretório atual."
+
+#: ../src/msw/utils.cpp:662
+#, c-format
+msgid "Failed to kill process %d"
+msgstr "Falhou em matar o processo %d"
+
+#: ../src/msw/utils.cpp:986
+#, c-format
+msgid "Failed to load resource \"%s\"."
+msgstr "Falhou em carregar o recurso \"%s\"."
+
+#: ../src/msw/utils.cpp:993
+#, c-format
+msgid "Failed to lock resource \"%s\"."
+msgstr "Falhou em trancar o recurso \"%s\"."
+
+#. TRANSLATORS: MS Windows build number
+#: ../src/msw/utils.cpp:1209
+#, c-format
+msgid "build %lu"
+msgstr "build %lu"
+
+#: ../src/msw/utils.cpp:1218
+msgid ", 64-bit edition"
+msgstr ", edição de 64 bits"
+
+#: ../src/msw/utilsexc.cpp:224
+msgid "Failed to create an anonymous pipe"
+msgstr "Falhou em criar um pipe anônimo"
+
+#: ../src/msw/utilsexc.cpp:697
+msgid "Failed to redirect the child process IO"
+msgstr "Falhou em redirecionar a E/S do processo filho"
+
+#: ../src/msw/utilsexc.cpp:870
+#, c-format
+msgid "Execution of command '%s' failed"
+msgstr "A execução do comando '%s' falhou"
+
+#: ../src/msw/volume.cpp:337
+msgid "Failed to load mpr.dll."
+msgstr "Falhou em carregar o mpr.dll."
+
+#: ../src/msw/volume.cpp:506
+#, c-format
+msgid "Cannot read typename from '%s'!"
+msgstr "Não consegue ler o nome do tipo de '%s'!"
+
+#: ../src/msw/volume.cpp:615
+#, c-format
+msgid "Cannot load icon from '%s'."
+msgstr "Não consegue carregar o ícone do '%s'."
+
+#: ../src/msw/webview_edge.cpp:285
+msgid "This program was compiled without support for setting Edge proxy."
+msgstr ""
+"Este programa foi compilado sem suporte pra configuração de proxy do Edge."
+
+#: ../src/msw/webview_ie.cpp:1010
+msgid "Failed to find web view emulation level in the registry"
+msgstr "Falhou em achar o nível da emulação da visualização da web no registro"
+
+#: ../src/msw/webview_ie.cpp:1019
+msgid "Failed to set web view to modern emulation level"
+msgstr "Falhou em definir a visualização da web como nível da emulação moderna"
+
+#: ../src/msw/webview_ie.cpp:1027
+msgid "Failed to reset web view to standard emulation level"
+msgstr "Falhou em resetar a visualização da web pro nível de emulação padrão"
+
+#: ../src/msw/webview_ie.cpp:1049
+msgid "Can't run JavaScript script without a valid HTML document"
+msgstr "Não pode executar o script do JavaScript sem um documento HTML válido"
+
+#: ../src/msw/webview_ie.cpp:1056
+msgid "Can't get the JavaScript object"
+msgstr "Não pôde obter o objeto do JavaScript"
+
+#: ../src/msw/webview_ie.cpp:1070
+msgid "failed to evaluate"
+msgstr "falhou em avaliar"
+
+#: ../src/osx/cocoa/filedlg.mm:412
+msgid "File type:"
+msgstr "Tipo de Arquivo:"
+
+#: ../src/osx/cocoa/menu.mm:242
+msgctxt "macOS menu name"
+msgid "Window"
+msgstr "Janela"
+
+#: ../src/osx/cocoa/menu.mm:259
+msgctxt "macOS menu name"
+msgid "Help"
+msgstr "Ajuda"
+
+#: ../src/osx/cocoa/menu.mm:298
+msgctxt "macOS menu item"
+msgid "Minimize"
+msgstr "Minimizar"
+
+#: ../src/osx/cocoa/menu.mm:303
+msgctxt "macOS menu item"
+msgid "Zoom"
+msgstr "Zoom"
+
+#: ../src/osx/cocoa/menu.mm:309
+msgctxt "macOS menu item"
+msgid "Bring All to Front"
+msgstr "Trazer Tudo pra Frente"
+
+#: ../src/osx/core/sound.cpp:143
+#, c-format
+msgid "Failed to load sound from \"%s\" (error %d)."
+msgstr "Falhou em carregar o som do \"%s\" (erro %d)."
+
+#: ../src/osx/fontutil.cpp:80
+#, c-format
+msgid "Font file \"%s\" doesn't exist."
+msgstr "O arquivo da fonte \"%s\" não existe."
+
+#: ../src/osx/fontutil.cpp:88
+#, c-format
+msgid ""
+"Font file \"%s\" cannot be used as it is not inside the font directory "
+"\"%s\"."
+msgstr ""
+"O arquivo fonte \"%s\" não pode ser usado como não está dentro do diretório "
+"fonte \"%s\"."
+
+#: ../src/osx/menu_osx.cpp:496
+#, c-format
+msgctxt "macOS menu item"
+msgid "About %s"
+msgstr "Sobre o %s"
+
+#: ../src/osx/menu_osx.cpp:499
+msgctxt "macOS menu item"
+msgid "About..."
+msgstr "Sobre..."
+
+#: ../src/osx/menu_osx.cpp:508
+msgctxt "macOS menu item"
+msgid "Preferences..."
+msgstr "Preferências..."
+
+#: ../src/osx/menu_osx.cpp:512
+msgctxt "macOS menu item"
+msgid "Services"
+msgstr "Serviços"
+
+#: ../src/osx/menu_osx.cpp:519
+#, c-format
+msgctxt "macOS menu item"
+msgid "Hide %s"
+msgstr "Esconder %s"
+
+#: ../src/osx/menu_osx.cpp:522
+msgctxt "macOS menu item"
+msgid "Hide Application"
+msgstr "Esconder Aplicativo"
+
+#: ../src/osx/menu_osx.cpp:526
+msgctxt "macOS menu item"
+msgid "Hide Others"
+msgstr "Esconder os Outros"
+
+#: ../src/osx/menu_osx.cpp:528
+msgctxt "macOS menu item"
+msgid "Show All"
+msgstr "Mostrar Tudo"
+
+#: ../src/osx/menu_osx.cpp:534
+#, c-format
+msgctxt "macOS menu item"
+msgid "Quit %s"
+msgstr "Sair %s"
+
+#: ../src/osx/menu_osx.cpp:537
+msgctxt "macOS menu item"
+msgid "Quit Application"
+msgstr "Sair do Aplicativo"
+
+#: ../src/osx/webview_webkit.mm:444
+msgid "Printing is not supported by the system web control"
+msgstr "A impressão não é suportada pelo controle da rede do sistema"
+
+#: ../src/osx/webview_webkit.mm:453
+msgid "Print operation could not be initialized"
+msgstr "A operação de impressão não pôde ser inicializada"
+
+#. TRANSLATORS: Label of font point size
+#: ../src/propgrid/advprops.cpp:605
+msgid "Point Size"
+msgstr "Tamanho do Ponto"
+
+#. TRANSLATORS: Label of font face name
+#: ../src/propgrid/advprops.cpp:615
+msgid "Face Name"
+msgstr "Nome da Face"
+
+#. TRANSLATORS: Label of font style
+#: ../src/propgrid/advprops.cpp:623 ../src/richtext/richtextformatdlg.cpp:331
+msgid "Style"
+msgstr "Estilo"
+
+#. TRANSLATORS: Label of font weight
+#: ../src/propgrid/advprops.cpp:628
+msgid "Weight"
+msgstr "Peso"
+
+#. TRANSLATORS: Label of underlined font
+#: ../src/propgrid/advprops.cpp:633 ../src/richtext/richtextfontpage.cpp:358
+msgid "Underlined"
+msgstr "&Sublinhado"
+
+#. TRANSLATORS: Label of font family
+#: ../src/propgrid/advprops.cpp:637
+msgid "Family"
+msgstr "Família"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:801
+msgid "AppWorkspace"
+msgstr "AppWorkspace"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:802
+msgid "ActiveBorder"
+msgstr "BordaAtiva"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:803
+msgid "ActiveCaption"
+msgstr "CaptionAtivo"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:804
+msgid "ButtonFace"
+msgstr "FaceDoBotão"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:805
+msgid "ButtonHighlight"
+msgstr "DestaqueDoBotão"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:806
+msgid "ButtonShadow"
+msgstr "SombraDoBotão"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:807
+msgid "ButtonText"
+msgstr "TextoDoBotão"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:808
+msgid "CaptionText"
+msgstr "TextoDoCaption"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:809
+msgid "ControlDark"
+msgstr "ControlEscuro"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:810
+msgid "ControlLight"
+msgstr "ControlClaro"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:812
+msgid "GrayText"
+msgstr "TextoCinza"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:813
+msgid "Highlight"
+msgstr "Destacar"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:814
+msgid "HighlightText"
+msgstr "DestacarTexto"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:815
+msgid "InactiveBorder"
+msgstr "BordaInativa"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:816
+msgid "InactiveCaption"
+msgstr "CaptionInativo"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:817
+msgid "InactiveCaptionText"
+msgstr "TextoDoCaptionInativo"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:818
+msgid "Menu"
+msgstr "Menu"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:819
+msgid "Scrollbar"
+msgstr "Barra de Rolagem"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:820
+msgid "Tooltip"
+msgstr "Dica da ferramenta"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:821
+msgid "TooltipText"
+msgstr "TextoDaDicaDaFerramenta"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:822
+msgid "Window"
+msgstr "Janela"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:823
+msgid "WindowFrame"
+msgstr "FrameDaJanela"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:824
+msgid "WindowText"
+msgstr "TextoDaJanela"
+
+#. TRANSLATORS: Custom colour choice entry
+#: ../src/propgrid/advprops.cpp:825 ../src/propgrid/advprops.cpp:1532
+#: ../src/propgrid/advprops.cpp:1576
+msgid "Custom"
+msgstr "Personalizado"
+
+#: ../src/propgrid/advprops.cpp:1558
+msgid "Black"
+msgstr "Preto"
+
+#: ../src/propgrid/advprops.cpp:1559
+msgid "Maroon"
+msgstr "Castanho"
+
+#: ../src/propgrid/advprops.cpp:1560
+msgid "Navy"
+msgstr "Marinho"
+
+#: ../src/propgrid/advprops.cpp:1561
+msgid "Purple"
+msgstr "Púrpura"
+
+#: ../src/propgrid/advprops.cpp:1562
+msgid "Teal"
+msgstr "Azul petróleo"
+
+#: ../src/propgrid/advprops.cpp:1563
+msgid "Gray"
+msgstr "Cinza"
+
+#: ../src/propgrid/advprops.cpp:1564
+msgid "Green"
+msgstr "Verde"
+
+#: ../src/propgrid/advprops.cpp:1565
+msgid "Olive"
+msgstr "Oliva"
+
+#: ../src/propgrid/advprops.cpp:1566
+msgid "Brown"
+msgstr "Marrom"
+
+#: ../src/propgrid/advprops.cpp:1567
+msgid "Blue"
+msgstr "Azul"
+
+#: ../src/propgrid/advprops.cpp:1568
+msgid "Fuchsia"
+msgstr "Fúcsia"
+
+#: ../src/propgrid/advprops.cpp:1569
+msgid "Red"
+msgstr "Vermelho"
+
+#: ../src/propgrid/advprops.cpp:1570
+msgid "Orange"
+msgstr "Laranja"
+
+#: ../src/propgrid/advprops.cpp:1571
+msgid "Silver"
+msgstr "Prata"
+
+#: ../src/propgrid/advprops.cpp:1572
+msgid "Lime"
+msgstr "Lima"
+
+#: ../src/propgrid/advprops.cpp:1573
+msgid "Aqua"
+msgstr "Aqua"
+
+#: ../src/propgrid/advprops.cpp:1574
+msgid "Yellow"
+msgstr "Amarelo"
+
+#: ../src/propgrid/advprops.cpp:1575
+msgid "White"
+msgstr "Branco"
+
+#: ../src/propgrid/advprops.cpp:1718
+msgctxt "system cursor name"
+msgid "Default"
+msgstr "Padrão"
+
+#: ../src/propgrid/advprops.cpp:1719
+msgctxt "system cursor name"
+msgid "Arrow"
+msgstr "Seta"
+
+#: ../src/propgrid/advprops.cpp:1720
+msgctxt "system cursor name"
+msgid "Right Arrow"
+msgstr "Seta Direita"
+
+#: ../src/propgrid/advprops.cpp:1721
+msgctxt "system cursor name"
+msgid "Blank"
+msgstr "Em branco"
+
+#: ../src/propgrid/advprops.cpp:1722
+msgctxt "system cursor name"
+msgid "Bullseye"
+msgstr "Alvo"
+
+#: ../src/propgrid/advprops.cpp:1723
+msgctxt "system cursor name"
+msgid "Character"
+msgstr "Caractere"
+
+#: ../src/propgrid/advprops.cpp:1724
+msgctxt "system cursor name"
+msgid "Cross"
+msgstr "Cruz"
+
+#: ../src/propgrid/advprops.cpp:1725
+msgctxt "system cursor name"
+msgid "Hand"
+msgstr "Mão"
+
+#: ../src/propgrid/advprops.cpp:1726
+msgctxt "system cursor name"
+msgid "I-Beam"
+msgstr "I-Beam"
+
+#: ../src/propgrid/advprops.cpp:1727
+msgctxt "system cursor name"
+msgid "Left Button"
+msgstr "Botão Esquerdo"
+
+#: ../src/propgrid/advprops.cpp:1728
+msgctxt "system cursor name"
+msgid "Magnifier"
+msgstr "Lupa"
+
+#: ../src/propgrid/advprops.cpp:1729
+msgctxt "system cursor name"
+msgid "Middle Button"
+msgstr "Botão do Meio"
+
+#: ../src/propgrid/advprops.cpp:1730
+msgctxt "system cursor name"
+msgid "No Entry"
+msgstr "Nenhuma Entrada"
+
+#: ../src/propgrid/advprops.cpp:1731
+msgctxt "system cursor name"
+msgid "Paint Brush"
+msgstr "Pincel do Paint"
+
+#: ../src/propgrid/advprops.cpp:1732
+msgctxt "system cursor name"
+msgid "Pencil"
+msgstr "Lápis"
+
+#: ../src/propgrid/advprops.cpp:1733
+msgctxt "system cursor name"
+msgid "Point Left"
+msgstr "Ponto a Esquerda"
+
+#: ../src/propgrid/advprops.cpp:1734
+msgctxt "system cursor name"
+msgid "Point Right"
+msgstr "Ponto a Direita"
+
+#: ../src/propgrid/advprops.cpp:1735
+msgctxt "system cursor name"
+msgid "Question Arrow"
+msgstr "Seta da Pergunta"
+
+#: ../src/propgrid/advprops.cpp:1736
+msgctxt "system cursor name"
+msgid "Right Button"
+msgstr "Botão Direito"
+
+#: ../src/propgrid/advprops.cpp:1737
+msgctxt "system cursor name"
+msgid "Sizing NE-SW"
+msgstr "Dimensionamento NE-SO"
+
+#: ../src/propgrid/advprops.cpp:1738
+msgctxt "system cursor name"
+msgid "Sizing N-S"
+msgstr "Dimensionamento N-S"
+
+#: ../src/propgrid/advprops.cpp:1739
+msgctxt "system cursor name"
+msgid "Sizing NW-SE"
+msgstr "Dimensionamento NO-SE"
+
+#: ../src/propgrid/advprops.cpp:1740
+msgctxt "system cursor name"
+msgid "Sizing W-E"
+msgstr "Dimensionamento O-L"
+
+#: ../src/propgrid/advprops.cpp:1741
+msgctxt "system cursor name"
+msgid "Sizing"
+msgstr "Dimensionamento"
+
+#: ../src/propgrid/advprops.cpp:1742
+msgctxt "system cursor name"
+msgid "Spraycan"
+msgstr "Lata de spray"
+
+#: ../src/propgrid/advprops.cpp:1743
+msgctxt "system cursor name"
+msgid "Wait"
+msgstr "Aguardar"
+
+#: ../src/propgrid/advprops.cpp:1744
+msgctxt "system cursor name"
+msgid "Watch"
+msgstr "Observar"
+
+#: ../src/propgrid/advprops.cpp:1745
+msgctxt "system cursor name"
+msgid "Wait Arrow"
+msgstr "Seta de Espera"
+
+#: ../src/propgrid/advprops.cpp:2109
+msgid "Make a selection:"
+msgstr "Fazer uma seleção:"
+
+#: ../src/propgrid/manager.cpp:394
+msgid "Property"
+msgstr "Propriedade"
+
+#: ../src/propgrid/manager.cpp:395
+msgid "Value"
+msgstr "Valor"
+
+#: ../src/propgrid/manager.cpp:1683
+msgid "Categorized Mode"
+msgstr "Modo Categorizado"
+
+#: ../src/propgrid/manager.cpp:1709
+msgid "Alphabetic Mode"
+msgstr "Modo Alfabético"
+
+#. TRANSLATORS: Name of Boolean false value
+#: ../src/propgrid/propgrid.cpp:230
+msgid "False"
+msgstr "Falso"
+
+#. TRANSLATORS: Name of Boolean true value
+#: ../src/propgrid/propgrid.cpp:232
+msgid "True"
+msgstr "Verdadeiro"
+
+#. TRANSLATORS: Text  displayed for unspecified value
+#: ../src/propgrid/propgrid.cpp:428
+msgid "Unspecified"
+msgstr "Não especificado"
+
+#. TRANSLATORS: Caption of message box displaying any property error
+#: ../src/propgrid/propgrid.cpp:3145 ../src/propgrid/propgrid.cpp:3282
+msgid "Property Error"
+msgstr "Erro da Propriedade"
+
+#: ../src/propgrid/propgrid.cpp:3259
+msgid "You have entered invalid value. Press ESC to cancel editing."
+msgstr "Você inseriu um valor inválido. Pressione ESC pra cancelar a edição."
+
+#: ../src/propgrid/propgrid.cpp:6608
+#, c-format
+msgid "Error in resource: %s"
+msgstr "Erro no recurso: %s"
+
+#: ../src/propgrid/propgridiface.cpp:377
+#, c-format
+msgid ""
+"Type operation \"%s\" failed: Property labeled \"%s\" is of type \"%s\", NOT "
+"\"%s\"."
+msgstr ""
+"A operação do tipo \"%s\" falhou: A propriedade rotulada \"%s\" é do tipo "
+"\"%s\", NÃO \"%s\"."
+
+#: ../src/propgrid/props.cpp:159
+#, c-format
+msgid "Unknown base %d. Base 10 will be used."
+msgstr "Base desconhecida %d. A base 10 será usada."
+
+#: ../src/propgrid/props.cpp:324
+#, c-format
+msgid "Value must be %s or higher."
+msgstr "O valor deve ser %s ou maior."
+
+#: ../src/propgrid/props.cpp:329 ../src/propgrid/props.cpp:356
+#, c-format
+msgid "Value must be between %s and %s."
+msgstr "O valor deve estar entre %s e %s."
+
+#: ../src/propgrid/props.cpp:351
+#, c-format
+msgid "Value must be %s or less."
+msgstr "O valor deve ser %s ou menor."
+
+#: ../src/propgrid/props.cpp:1058
+#, c-format
+msgid "Not %s"
+msgstr "Não %s"
+
+#: ../src/propgrid/props.cpp:1770
+msgid "Choose a directory:"
+msgstr "Escolha um diretório:"
+
+#: ../src/propgrid/props.cpp:2055
+msgid "Choose a file"
+msgstr "Escolha um arquivo"
+
+#: ../src/qt/mdi.cpp:254
+msgid "&Tile"
+msgstr "&Mosaico"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:147
+#: ../src/richtext/richtextformatdlg.cpp:376
+msgid "Background"
+msgstr "2º plano"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:159
+msgid "Background &colour:"
+msgstr "Côr do &2º plano:"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:161
+#: ../src/richtext/richtextbackgroundpage.cpp:163
+msgid "Enables a background colour."
+msgstr "Ativar uma côr de fundo."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:167
+#: ../src/richtext/richtextbackgroundpage.cpp:169
+msgid "The background colour."
+msgstr "A côr de fundo."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:178
+msgid "Shadow"
+msgstr "Sombra"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:193
+msgid "Use &shadow"
+msgstr "Usar &sombra"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:195
+#: ../src/richtext/richtextbackgroundpage.cpp:197
+msgid "Enables a shadow."
+msgstr "Ativa uma sombra."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:211
+msgid "&Horizontal offset:"
+msgstr "&Offset horizontal:"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:218
+#: ../src/richtext/richtextbackgroundpage.cpp:220
+msgid "The horizontal offset."
+msgstr "O offset horizontal."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:224
+#: ../src/richtext/richtextbackgroundpage.cpp:227
+#: ../src/richtext/richtextbackgroundpage.cpp:228
+#: ../src/richtext/richtextbackgroundpage.cpp:247
+#: ../src/richtext/richtextbackgroundpage.cpp:250
+#: ../src/richtext/richtextbackgroundpage.cpp:251
+#: ../src/richtext/richtextbackgroundpage.cpp:287
+#: ../src/richtext/richtextbackgroundpage.cpp:290
+#: ../src/richtext/richtextbackgroundpage.cpp:291
+#: ../src/richtext/richtextbackgroundpage.cpp:314
+#: ../src/richtext/richtextbackgroundpage.cpp:317
+#: ../src/richtext/richtextbackgroundpage.cpp:318
+#: ../src/richtext/richtextborderspage.cpp:252
+#: ../src/richtext/richtextborderspage.cpp:255
+#: ../src/richtext/richtextborderspage.cpp:256
+#: ../src/richtext/richtextborderspage.cpp:286
+#: ../src/richtext/richtextborderspage.cpp:289
+#: ../src/richtext/richtextborderspage.cpp:290
+#: ../src/richtext/richtextborderspage.cpp:320
+#: ../src/richtext/richtextborderspage.cpp:323
+#: ../src/richtext/richtextborderspage.cpp:324
+#: ../src/richtext/richtextborderspage.cpp:354
+#: ../src/richtext/richtextborderspage.cpp:357
+#: ../src/richtext/richtextborderspage.cpp:358
+#: ../src/richtext/richtextborderspage.cpp:420
+#: ../src/richtext/richtextborderspage.cpp:423
+#: ../src/richtext/richtextborderspage.cpp:424
+#: ../src/richtext/richtextborderspage.cpp:454
+#: ../src/richtext/richtextborderspage.cpp:457
+#: ../src/richtext/richtextborderspage.cpp:458
+#: ../src/richtext/richtextborderspage.cpp:488
+#: ../src/richtext/richtextborderspage.cpp:491
+#: ../src/richtext/richtextborderspage.cpp:492
+#: ../src/richtext/richtextborderspage.cpp:522
+#: ../src/richtext/richtextborderspage.cpp:525
+#: ../src/richtext/richtextborderspage.cpp:526
+#: ../src/richtext/richtextborderspage.cpp:590
+#: ../src/richtext/richtextborderspage.cpp:593
+#: ../src/richtext/richtextborderspage.cpp:594
+#: ../src/richtext/richtextfontpage.cpp:177
+#: ../src/richtext/richtextmarginspage.cpp:199
+#: ../src/richtext/richtextmarginspage.cpp:201
+#: ../src/richtext/richtextmarginspage.cpp:202
+#: ../src/richtext/richtextmarginspage.cpp:224
+#: ../src/richtext/richtextmarginspage.cpp:226
+#: ../src/richtext/richtextmarginspage.cpp:227
+#: ../src/richtext/richtextmarginspage.cpp:247
+#: ../src/richtext/richtextmarginspage.cpp:249
+#: ../src/richtext/richtextmarginspage.cpp:250
+#: ../src/richtext/richtextmarginspage.cpp:272
+#: ../src/richtext/richtextmarginspage.cpp:274
+#: ../src/richtext/richtextmarginspage.cpp:275
+#: ../src/richtext/richtextmarginspage.cpp:313
+#: ../src/richtext/richtextmarginspage.cpp:315
+#: ../src/richtext/richtextmarginspage.cpp:316
+#: ../src/richtext/richtextmarginspage.cpp:338
+#: ../src/richtext/richtextmarginspage.cpp:340
+#: ../src/richtext/richtextmarginspage.cpp:341
+#: ../src/richtext/richtextmarginspage.cpp:361
+#: ../src/richtext/richtextmarginspage.cpp:363
+#: ../src/richtext/richtextmarginspage.cpp:364
+#: ../src/richtext/richtextmarginspage.cpp:386
+#: ../src/richtext/richtextmarginspage.cpp:388
+#: ../src/richtext/richtextmarginspage.cpp:389
+#: ../src/richtext/richtextsizepage.cpp:337
+#: ../src/richtext/richtextsizepage.cpp:340
+#: ../src/richtext/richtextsizepage.cpp:341
+#: ../src/richtext/richtextsizepage.cpp:371
+#: ../src/richtext/richtextsizepage.cpp:374
+#: ../src/richtext/richtextsizepage.cpp:375
+#: ../src/richtext/richtextsizepage.cpp:398
+#: ../src/richtext/richtextsizepage.cpp:401
+#: ../src/richtext/richtextsizepage.cpp:402
+#: ../src/richtext/richtextsizepage.cpp:425
+#: ../src/richtext/richtextsizepage.cpp:428
+#: ../src/richtext/richtextsizepage.cpp:429
+#: ../src/richtext/richtextsizepage.cpp:452
+#: ../src/richtext/richtextsizepage.cpp:455
+#: ../src/richtext/richtextsizepage.cpp:456
+#: ../src/richtext/richtextsizepage.cpp:479
+#: ../src/richtext/richtextsizepage.cpp:482
+#: ../src/richtext/richtextsizepage.cpp:483
+#: ../src/richtext/richtextsizepage.cpp:553
+#: ../src/richtext/richtextsizepage.cpp:556
+#: ../src/richtext/richtextsizepage.cpp:557
+#: ../src/richtext/richtextsizepage.cpp:588
+#: ../src/richtext/richtextsizepage.cpp:591
+#: ../src/richtext/richtextsizepage.cpp:592
+#: ../src/richtext/richtextsizepage.cpp:623
+#: ../src/richtext/richtextsizepage.cpp:626
+#: ../src/richtext/richtextsizepage.cpp:627
+#: ../src/richtext/richtextsizepage.cpp:658
+#: ../src/richtext/richtextsizepage.cpp:661
+#: ../src/richtext/richtextsizepage.cpp:662
+msgid "px"
+msgstr "px"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:225
+#: ../src/richtext/richtextbackgroundpage.cpp:248
+#: ../src/richtext/richtextbackgroundpage.cpp:288
+#: ../src/richtext/richtextbackgroundpage.cpp:315
+#: ../src/richtext/richtextborderspage.cpp:253
+#: ../src/richtext/richtextborderspage.cpp:287
+#: ../src/richtext/richtextborderspage.cpp:321
+#: ../src/richtext/richtextborderspage.cpp:355
+#: ../src/richtext/richtextborderspage.cpp:421
+#: ../src/richtext/richtextborderspage.cpp:455
+#: ../src/richtext/richtextborderspage.cpp:489
+#: ../src/richtext/richtextborderspage.cpp:523
+#: ../src/richtext/richtextborderspage.cpp:591
+#: ../src/richtext/richtextmarginspage.cpp:200
+#: ../src/richtext/richtextmarginspage.cpp:225
+#: ../src/richtext/richtextmarginspage.cpp:248
+#: ../src/richtext/richtextmarginspage.cpp:273
+#: ../src/richtext/richtextmarginspage.cpp:314
+#: ../src/richtext/richtextmarginspage.cpp:339
+#: ../src/richtext/richtextmarginspage.cpp:362
+#: ../src/richtext/richtextmarginspage.cpp:387
+#: ../src/richtext/richtextsizepage.cpp:338
+#: ../src/richtext/richtextsizepage.cpp:372
+#: ../src/richtext/richtextsizepage.cpp:399
+#: ../src/richtext/richtextsizepage.cpp:426
+#: ../src/richtext/richtextsizepage.cpp:453
+#: ../src/richtext/richtextsizepage.cpp:480
+#: ../src/richtext/richtextsizepage.cpp:554
+#: ../src/richtext/richtextsizepage.cpp:589
+#: ../src/richtext/richtextsizepage.cpp:624
+#: ../src/richtext/richtextsizepage.cpp:659
+msgid "cm"
+msgstr "cm"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:226
+#: ../src/richtext/richtextbackgroundpage.cpp:249
+#: ../src/richtext/richtextbackgroundpage.cpp:289
+#: ../src/richtext/richtextbackgroundpage.cpp:316
+#: ../src/richtext/richtextborderspage.cpp:254
+#: ../src/richtext/richtextborderspage.cpp:288
+#: ../src/richtext/richtextborderspage.cpp:322
+#: ../src/richtext/richtextborderspage.cpp:356
+#: ../src/richtext/richtextborderspage.cpp:422
+#: ../src/richtext/richtextborderspage.cpp:456
+#: ../src/richtext/richtextborderspage.cpp:490
+#: ../src/richtext/richtextborderspage.cpp:524
+#: ../src/richtext/richtextborderspage.cpp:592
+#: ../src/richtext/richtextfontpage.cpp:176
+#: ../src/richtext/richtextfontpage.cpp:179
+msgid "pt"
+msgstr "pt"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:229
+#: ../src/richtext/richtextbackgroundpage.cpp:231
+#: ../src/richtext/richtextbackgroundpage.cpp:252
+#: ../src/richtext/richtextbackgroundpage.cpp:254
+#: ../src/richtext/richtextbackgroundpage.cpp:292
+#: ../src/richtext/richtextbackgroundpage.cpp:294
+#: ../src/richtext/richtextbackgroundpage.cpp:319
+#: ../src/richtext/richtextbackgroundpage.cpp:321
+msgid "Units for this value."
+msgstr "Unidades pra este valor."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:234
+msgid "&Vertical offset:"
+msgstr "&Offset Vertical:"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:241
+#: ../src/richtext/richtextbackgroundpage.cpp:243
+msgid "The vertical offset."
+msgstr "O offset vertical."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:257
+msgid "Shadow c&olour:"
+msgstr "Côr da S&ombra:"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:259
+#: ../src/richtext/richtextbackgroundpage.cpp:261
+msgid "Enables the shadow colour."
+msgstr "Ativa a côr da sombra."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:265
+#: ../src/richtext/richtextbackgroundpage.cpp:267
+msgid "The shadow colour."
+msgstr "A côr da sombra."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:270
+msgid "Sh&adow spread:"
+msgstr "Es&palhar sombra:"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:272
+#: ../src/richtext/richtextbackgroundpage.cpp:274
+msgid "Enables the shadow spread."
+msgstr "Ativa o espalhar da sombra."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:281
+#: ../src/richtext/richtextbackgroundpage.cpp:283
+msgid "The shadow spread."
+msgstr "O espalhar da sombra."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:297
+msgid "&Blur distance:"
+msgstr "&Distância do blur:"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:299
+#: ../src/richtext/richtextbackgroundpage.cpp:301
+msgid "Enables the blur distance."
+msgstr "Ativa a distância do blur."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:308
+#: ../src/richtext/richtextbackgroundpage.cpp:310
+msgid "The shadow blur distance."
+msgstr "A distância do blur da sombra."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:324
+msgid "Opaci&ty:"
+msgstr "Opaci&dade:"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:326
+#: ../src/richtext/richtextbackgroundpage.cpp:328
+msgid "Enables the shadow opacity."
+msgstr "Ativa a opacidade da sombra."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:335
+#: ../src/richtext/richtextbackgroundpage.cpp:337
+msgid "The shadow opacity."
+msgstr "A opacidade da sombra."
+
+#. TRANSLATORS: Rich text page units (percentage)
+#: ../src/richtext/richtextbackgroundpage.cpp:340
+#: ../src/richtext/richtextsizepage.cpp:339
+#: ../src/richtext/richtextsizepage.cpp:373
+#: ../src/richtext/richtextsizepage.cpp:400
+#: ../src/richtext/richtextsizepage.cpp:427
+#: ../src/richtext/richtextsizepage.cpp:454
+#: ../src/richtext/richtextsizepage.cpp:481
+#: ../src/richtext/richtextsizepage.cpp:555
+#: ../src/richtext/richtextsizepage.cpp:590
+#: ../src/richtext/richtextsizepage.cpp:625
+#: ../src/richtext/richtextsizepage.cpp:660
+msgid "%"
+msgstr "%"
+
+#: ../src/richtext/richtextborderspage.cpp:229
+#: ../src/richtext/richtextborderspage.cpp:387
+msgid "Border"
+msgstr "Borda"
+
+#: ../src/richtext/richtextborderspage.cpp:242
+#: ../src/richtext/richtextborderspage.cpp:410
+#: ../src/richtext/richtextindentspage.cpp:194
+#: ../src/richtext/richtextliststylepage.cpp:384
+#: ../src/richtext/richtextmarginspage.cpp:185
+#: ../src/richtext/richtextmarginspage.cpp:299
+#: ../src/richtext/richtextsizepage.cpp:531
+#: ../src/richtext/richtextsizepage.cpp:538
+msgid "&Left:"
+msgstr "&Esquerda:"
+
+#: ../src/richtext/richtextborderspage.cpp:257
+#: ../src/richtext/richtextborderspage.cpp:259
+msgid "Units for the left border width."
+msgstr "Unidades para a largura da borda a esquerda."
+
+#: ../src/richtext/richtextborderspage.cpp:266
+#: ../src/richtext/richtextborderspage.cpp:268
+#: ../src/richtext/richtextborderspage.cpp:300
+#: ../src/richtext/richtextborderspage.cpp:302
+#: ../src/richtext/richtextborderspage.cpp:334
+#: ../src/richtext/richtextborderspage.cpp:336
+#: ../src/richtext/richtextborderspage.cpp:368
+#: ../src/richtext/richtextborderspage.cpp:370
+#: ../src/richtext/richtextborderspage.cpp:434
+#: ../src/richtext/richtextborderspage.cpp:436
+#: ../src/richtext/richtextborderspage.cpp:468
+#: ../src/richtext/richtextborderspage.cpp:470
+#: ../src/richtext/richtextborderspage.cpp:502
+#: ../src/richtext/richtextborderspage.cpp:504
+#: ../src/richtext/richtextborderspage.cpp:536
+#: ../src/richtext/richtextborderspage.cpp:538
+msgid "The border line style."
+msgstr "O estilo da linha da borda."
+
+#: ../src/richtext/richtextborderspage.cpp:276
+#: ../src/richtext/richtextborderspage.cpp:444
+#: ../src/richtext/richtextindentspage.cpp:212
+#: ../src/richtext/richtextliststylepage.cpp:402
+#: ../src/richtext/richtextmarginspage.cpp:210
+#: ../src/richtext/richtextmarginspage.cpp:324
+#: ../src/richtext/richtextsizepage.cpp:601
+#: ../src/richtext/richtextsizepage.cpp:608
+msgid "&Right:"
+msgstr "&Direita:"
+
+#: ../src/richtext/richtextborderspage.cpp:291
+#: ../src/richtext/richtextborderspage.cpp:293
+msgid "Units for the right border width."
+msgstr "Unidades para a largura da borda a direita."
+
+#: ../src/richtext/richtextborderspage.cpp:310
+#: ../src/richtext/richtextborderspage.cpp:478
+#: ../src/richtext/richtextmarginspage.cpp:233
+#: ../src/richtext/richtextmarginspage.cpp:347
+#: ../src/richtext/richtextsizepage.cpp:566
+#: ../src/richtext/richtextsizepage.cpp:573
+msgid "&Top:"
+msgstr "&Topo:"
+
+#: ../src/richtext/richtextborderspage.cpp:325
+#: ../src/richtext/richtextborderspage.cpp:327
+msgid "Units for the top border width."
+msgstr "Unidades para a largura da borda do topo."
+
+#: ../src/richtext/richtextborderspage.cpp:344
+#: ../src/richtext/richtextborderspage.cpp:512
+#: ../src/richtext/richtextmarginspage.cpp:258
+#: ../src/richtext/richtextmarginspage.cpp:372
+#: ../src/richtext/richtextsizepage.cpp:636
+#: ../src/richtext/richtextsizepage.cpp:643
+msgid "&Bottom:"
+msgstr "&Fundo:"
+
+#: ../src/richtext/richtextborderspage.cpp:359
+#: ../src/richtext/richtextborderspage.cpp:361
+msgid "Units for the bottom border width."
+msgstr "Unidades para a largura da borda do rodapé."
+
+#: ../src/richtext/richtextborderspage.cpp:380
+#: ../src/richtext/richtextborderspage.cpp:548
+msgid "&Synchronize values"
+msgstr "&Sincronizar valores"
+
+#: ../src/richtext/richtextborderspage.cpp:382
+#: ../src/richtext/richtextborderspage.cpp:384
+#: ../src/richtext/richtextborderspage.cpp:550
+#: ../src/richtext/richtextborderspage.cpp:552
+msgid "Check to edit all borders simultaneously."
+msgstr "Marque pra editar todas as bordas simultâneamente."
+
+#: ../src/richtext/richtextborderspage.cpp:397
+#: ../src/richtext/richtextborderspage.cpp:555
+msgid "Outline"
+msgstr "Contorno"
+
+#: ../src/richtext/richtextborderspage.cpp:425
+#: ../src/richtext/richtextborderspage.cpp:427
+msgid "Units for the left outline width."
+msgstr "Unidades para a largura do contorno a esquerda."
+
+#: ../src/richtext/richtextborderspage.cpp:459
+#: ../src/richtext/richtextborderspage.cpp:461
+msgid "Units for the right outline width."
+msgstr "Unidades para a largura do contorno a direita."
+
+#: ../src/richtext/richtextborderspage.cpp:493
+#: ../src/richtext/richtextborderspage.cpp:495
+msgid "Units for the top outline width."
+msgstr "Unidades para a largura do contorno do topo."
+
+#: ../src/richtext/richtextborderspage.cpp:527
+#: ../src/richtext/richtextborderspage.cpp:529
+msgid "Units for the bottom outline width."
+msgstr "Unidades para a largura do contorno do rodapé."
+
+#: ../src/richtext/richtextborderspage.cpp:565
+#: ../src/richtext/richtextborderspage.cpp:600
+msgid "Corner"
+msgstr "Canto"
+
+#: ../src/richtext/richtextborderspage.cpp:574
+msgid "Corner &radius:"
+msgstr "Raio do &canto:"
+
+#: ../src/richtext/richtextborderspage.cpp:576
+#: ../src/richtext/richtextborderspage.cpp:578
+msgid "An optional corner radius for adding rounded corners."
+msgstr "Um raio adicional do canto para adicionar cantos arredondados."
+
+#: ../src/richtext/richtextborderspage.cpp:584
+#: ../src/richtext/richtextborderspage.cpp:586
+msgid "The value of the corner radius."
+msgstr "O valor do raio do canto."
+
+#: ../src/richtext/richtextborderspage.cpp:595
+#: ../src/richtext/richtextborderspage.cpp:597
+msgid "Units for the corner radius."
+msgstr "Unidades para o raio do canto."
+
+#: ../src/richtext/richtextborderspage.cpp:609
+#: ../src/richtext/richtextsizepage.cpp:247
+#: ../src/richtext/richtextsizepage.cpp:251
+msgid "None"
+msgstr "Nenhum"
+
+#: ../src/richtext/richtextborderspage.cpp:610
+msgid "Solid"
+msgstr "Sólido"
+
+#: ../src/richtext/richtextborderspage.cpp:611
+msgid "Dotted"
+msgstr "Pontilhado"
+
+#: ../src/richtext/richtextborderspage.cpp:612
+msgid "Dashed"
+msgstr "Tracejado"
+
+#: ../src/richtext/richtextborderspage.cpp:613
+msgid "Double"
+msgstr "Duplo"
+
+#: ../src/richtext/richtextborderspage.cpp:614
+msgid "Groove"
+msgstr "Ranhura"
+
+#: ../src/richtext/richtextborderspage.cpp:615
+msgid "Ridge"
+msgstr "Cume"
+
+#: ../src/richtext/richtextborderspage.cpp:616
+msgid "Inset"
+msgstr "Inserir"
+
+#: ../src/richtext/richtextborderspage.cpp:617
+msgid "Outset"
+msgstr "Começo"
+
+#: ../src/richtext/richtextbuffer.cpp:3518
+msgid "Change Style"
+msgstr "Mudar o Estilo"
+
+#: ../src/richtext/richtextbuffer.cpp:3701
+msgid "Change Object Style"
+msgstr "Mudar o Estilo do Objeto"
+
+#: ../src/richtext/richtextbuffer.cpp:3974
+#: ../src/richtext/richtextbuffer.cpp:8174
+msgid "Change Properties"
+msgstr "Mudar Propriedades"
+
+#: ../src/richtext/richtextbuffer.cpp:4346
+msgid "Change List Style"
+msgstr "Mudar o Estilo da Lista"
+
+#: ../src/richtext/richtextbuffer.cpp:4519
+msgid "Renumber List"
+msgstr "Renumerar a Lista"
+
+#: ../src/richtext/richtextbuffer.cpp:7867
+#: ../src/richtext/richtextbuffer.cpp:7897
+#: ../src/richtext/richtextbuffer.cpp:7939
+#: ../src/richtext/richtextctrl.cpp:1279 ../src/richtext/richtextctrl.cpp:1473
+msgid "Insert Text"
+msgstr "Inserir Texto"
+
+#: ../src/richtext/richtextbuffer.cpp:8023
+#: ../src/richtext/richtextbuffer.cpp:8979
+msgid "Insert Image"
+msgstr "Inserir Imagem"
+
+#: ../src/richtext/richtextbuffer.cpp:8070
+msgid "Insert Object"
+msgstr "Inserir Objeto"
+
+#: ../src/richtext/richtextbuffer.cpp:8112
+msgid "Insert Field"
+msgstr "Inserir Campo"
+
+#: ../src/richtext/richtextbuffer.cpp:8410
+msgid "Too many EndStyle calls!"
+msgstr "Chamadas demais do EndStyle!"
+
+#: ../src/richtext/richtextbuffer.cpp:8785
+msgid "files"
+msgstr "arquivos"
+
+#: ../src/richtext/richtextbuffer.cpp:9380
+msgid "standard/circle"
+msgstr "padrão/círculo"
+
+#: ../src/richtext/richtextbuffer.cpp:9381
+msgid "standard/circle-outline"
+msgstr "padrão/círculo-contorno"
+
+#: ../src/richtext/richtextbuffer.cpp:9382
+msgid "standard/square"
+msgstr "padrão/quadrado"
+
+#: ../src/richtext/richtextbuffer.cpp:9383
+msgid "standard/diamond"
+msgstr "padrão/diamante"
+
+#: ../src/richtext/richtextbuffer.cpp:9384
+msgid "standard/triangle"
+msgstr "padrão/triângulo"
+
+#: ../src/richtext/richtextbuffer.cpp:9423
+msgid "Box Properties"
+msgstr "Propriedades da Caixa"
+
+#: ../src/richtext/richtextbuffer.cpp:10006
+msgid "Multiple Cell Properties"
+msgstr "Propriedades Múltiplas das Células"
+
+#: ../src/richtext/richtextbuffer.cpp:10008
+msgid "Cell Properties"
+msgstr "Propriedades da Célula"
+
+#: ../src/richtext/richtextbuffer.cpp:11256
+msgid "Set Cell Style"
+msgstr "Definir o Estilo da Célula"
+
+#: ../src/richtext/richtextbuffer.cpp:11330
+msgid "Delete Row"
+msgstr "Apagar a Fileira"
+
+#: ../src/richtext/richtextbuffer.cpp:11380
+msgid "Delete Column"
+msgstr "Apagar a Coluna"
+
+#: ../src/richtext/richtextbuffer.cpp:11431
+msgid "Add Row"
+msgstr "Adicionar Fileira"
+
+#: ../src/richtext/richtextbuffer.cpp:11494
+msgid "Add Column"
+msgstr "Adicionar Coluna"
+
+#: ../src/richtext/richtextbuffer.cpp:11537
+msgid "Table Properties"
+msgstr "Propriedades da Tabela"
+
+#: ../src/richtext/richtextbuffer.cpp:12899
+msgid "Picture Properties"
+msgstr "Propriedades da Foto"
+
+#: ../src/richtext/richtextbuffer.cpp:13169
+#: ../src/richtext/richtextbuffer.cpp:13279
+msgid "image"
+msgstr "imagem"
+
+#: ../src/richtext/richtextbulletspage.cpp:145
+#: ../src/richtext/richtextliststylepage.cpp:209
+msgid "&Bullet style:"
+msgstr "&Estilo da projétil:"
+
+#: ../src/richtext/richtextbulletspage.cpp:150
+#: ../src/richtext/richtextbulletspage.cpp:152
+#: ../src/richtext/richtextliststylepage.cpp:214
+#: ../src/richtext/richtextliststylepage.cpp:216
+msgid "The available bullet styles."
+msgstr "Os estilos dos projéteis disponíveis."
+
+#: ../src/richtext/richtextbulletspage.cpp:158
+#: ../src/richtext/richtextliststylepage.cpp:221
+msgid "Peri&od"
+msgstr "Pon&to"
+
+#: ../src/richtext/richtextbulletspage.cpp:160
+#: ../src/richtext/richtextbulletspage.cpp:162
+#: ../src/richtext/richtextliststylepage.cpp:223
+#: ../src/richtext/richtextliststylepage.cpp:225
+msgid "Check to add a period after the bullet."
+msgstr "Marque pra adicionar um período após a projétil."
+
+#. TRANSLATORS: Bullet point in parentheses option
+#: ../src/richtext/richtextbulletspage.cpp:167
+#: ../src/richtext/richtextliststylepage.cpp:230
+msgid "(*)"
+msgstr "(*)"
+
+#: ../src/richtext/richtextbulletspage.cpp:169
+#: ../src/richtext/richtextbulletspage.cpp:171
+#: ../src/richtext/richtextliststylepage.cpp:232
+#: ../src/richtext/richtextliststylepage.cpp:234
+msgid "Check to enclose the bullet in parentheses."
+msgstr "Marque pra cercar a projétil com parênteses."
+
+#. TRANSLATORS: Right parenthesis bullet point option
+#: ../src/richtext/richtextbulletspage.cpp:176
+#: ../src/richtext/richtextliststylepage.cpp:239
+msgid "*)"
+msgstr "*)"
+
+#: ../src/richtext/richtextbulletspage.cpp:178
+#: ../src/richtext/richtextbulletspage.cpp:180
+#: ../src/richtext/richtextliststylepage.cpp:241
+#: ../src/richtext/richtextliststylepage.cpp:243
+msgid "Check to add a right parenthesis."
+msgstr "Marque pra adicionar um parêntese direito."
+
+#: ../src/richtext/richtextbulletspage.cpp:185
+#: ../src/richtext/richtextliststylepage.cpp:248
+msgid "Bullet &Alignment:"
+msgstr "Alinhamento da &Bala:"
+
+#: ../src/richtext/richtextbulletspage.cpp:190
+#: ../src/richtext/richtextliststylepage.cpp:253
+msgid "Centre"
+msgstr "Centro"
+
+#: ../src/richtext/richtextbulletspage.cpp:194
+#: ../src/richtext/richtextbulletspage.cpp:196
+#: ../src/richtext/richtextbulletspage.cpp:217
+#: ../src/richtext/richtextbulletspage.cpp:219
+#: ../src/richtext/richtextliststylepage.cpp:257
+#: ../src/richtext/richtextliststylepage.cpp:259
+#: ../src/richtext/richtextliststylepage.cpp:278
+#: ../src/richtext/richtextliststylepage.cpp:280
+msgid "The bullet character."
+msgstr "O caractere do projétil."
+
+#: ../src/richtext/richtextbulletspage.cpp:212
+#: ../src/richtext/richtextliststylepage.cpp:271
+msgid "&Symbol:"
+msgstr "&Símbolo:"
+
+#: ../src/richtext/richtextbulletspage.cpp:222
+#: ../src/richtext/richtextliststylepage.cpp:283
+msgid "Ch&oose..."
+msgstr "Es&colher..."
+
+#: ../src/richtext/richtextbulletspage.cpp:223
+#: ../src/richtext/richtextbulletspage.cpp:225
+#: ../src/richtext/richtextliststylepage.cpp:284
+#: ../src/richtext/richtextliststylepage.cpp:286
+msgid "Click to browse for a symbol."
+msgstr "Clique pra procurar por um símbolo."
+
+#: ../src/richtext/richtextbulletspage.cpp:230
+#: ../src/richtext/richtextliststylepage.cpp:291
+msgid "Symbol &font:"
+msgstr "Fonte dos &símbolos:"
+
+#: ../src/richtext/richtextbulletspage.cpp:235
+#: ../src/richtext/richtextbulletspage.cpp:237
+#: ../src/richtext/richtextliststylepage.cpp:297
+msgid "Available fonts."
+msgstr "Fontes disponíveis."
+
+#: ../src/richtext/richtextbulletspage.cpp:242
+#: ../src/richtext/richtextliststylepage.cpp:302
+msgid "S&tandard bullet name:"
+msgstr "N&ome padrão da projétil:"
+
+#: ../src/richtext/richtextbulletspage.cpp:247
+#: ../src/richtext/richtextbulletspage.cpp:249
+#: ../src/richtext/richtextliststylepage.cpp:307
+#: ../src/richtext/richtextliststylepage.cpp:309
+msgid "A standard bullet name."
+msgstr "Um nome padrão para a projétil."
+
+#: ../src/richtext/richtextbulletspage.cpp:254
+msgid "&Number:"
+msgstr "&Número:"
+
+#: ../src/richtext/richtextbulletspage.cpp:258
+#: ../src/richtext/richtextbulletspage.cpp:260
+msgid "The list item number."
+msgstr "O número do item da lista."
+
+#: ../src/richtext/richtextbulletspage.cpp:266
+#: ../src/richtext/richtextbulletspage.cpp:268
+#: ../src/richtext/richtextliststylepage.cpp:475
+#: ../src/richtext/richtextliststylepage.cpp:477
+msgid "Shows a preview of the bullet settings."
+msgstr "Mostra uma pré-visualização das configurações das projéteis."
+
+#: ../src/richtext/richtextbulletspage.cpp:276
+#: ../src/richtext/richtextliststylepage.cpp:484
+msgid "(None)"
+msgstr "(Nenhum)"
+
+#: ../src/richtext/richtextbulletspage.cpp:277
+#: ../src/richtext/richtextliststylepage.cpp:485
+msgid "Arabic"
+msgstr "Árabe"
+
+#: ../src/richtext/richtextbulletspage.cpp:278
+#: ../src/richtext/richtextliststylepage.cpp:486
+msgid "Upper case letters"
+msgstr "Letras maiúsculas"
+
+#: ../src/richtext/richtextbulletspage.cpp:279
+#: ../src/richtext/richtextliststylepage.cpp:487
+msgid "Lower case letters"
+msgstr "Letras minúsculas"
+
+#: ../src/richtext/richtextbulletspage.cpp:280
+#: ../src/richtext/richtextliststylepage.cpp:488
+msgid "Upper case roman numerals"
+msgstr "Numerais romanos maiúsculos"
+
+#: ../src/richtext/richtextbulletspage.cpp:281
+#: ../src/richtext/richtextliststylepage.cpp:489
+msgid "Lower case roman numerals"
+msgstr "Numerais romanos minúsculos"
+
+#: ../src/richtext/richtextbulletspage.cpp:282
+#: ../src/richtext/richtextliststylepage.cpp:490
+msgid "Numbered outline"
+msgstr "Contornos numerados"
+
+#: ../src/richtext/richtextbulletspage.cpp:283
+#: ../src/richtext/richtextliststylepage.cpp:491
+msgid "Symbol"
+msgstr "Símbolo"
+
+#: ../src/richtext/richtextbulletspage.cpp:284
+#: ../src/richtext/richtextliststylepage.cpp:492
+msgid "Bitmap"
+msgstr "Bitmap"
+
+#: ../src/richtext/richtextbulletspage.cpp:285
+#: ../src/richtext/richtextliststylepage.cpp:493
+msgid "Standard"
+msgstr "Padrão"
+
+#: ../src/richtext/richtextbulletspage.cpp:287
+#: ../src/richtext/richtextliststylepage.cpp:495
+msgid "*"
+msgstr "*"
+
+#: ../src/richtext/richtextbulletspage.cpp:288
+#: ../src/richtext/richtextliststylepage.cpp:496
+msgid "-"
+msgstr "-"
+
+#: ../src/richtext/richtextbulletspage.cpp:289
+#: ../src/richtext/richtextliststylepage.cpp:497
+msgid ">"
+msgstr ">"
+
+#: ../src/richtext/richtextbulletspage.cpp:290
+#: ../src/richtext/richtextliststylepage.cpp:498
+msgid "+"
+msgstr "+"
+
+#: ../src/richtext/richtextbulletspage.cpp:291
+#: ../src/richtext/richtextliststylepage.cpp:499
+msgid "~"
+msgstr "~"
+
+#: ../src/richtext/richtextctrl.cpp:859
+msgid "Drag"
+msgstr "Arrastar"
+
+#: ../src/richtext/richtextctrl.cpp:1338 ../src/richtext/richtextctrl.cpp:1559
+msgid "Delete Text"
+msgstr "Apagar o Texto"
+
+#: ../src/richtext/richtextctrl.cpp:1537
+msgid "Remove Bullet"
+msgstr "Remover a Bala"
+
+#: ../src/richtext/richtextctrl.cpp:3070
+msgid "The text couldn't be saved."
+msgstr "O texto não pôde ser salvo."
+
+#: ../src/richtext/richtextctrl.cpp:3644
+msgid "Replace"
+msgstr "Substituir"
+
+#: ../src/richtext/richtextfontpage.cpp:146
+#: ../src/richtext/richtextsymboldlg.cpp:384
+msgid "&Font:"
+msgstr "&Fonte:"
+
+#: ../src/richtext/richtextfontpage.cpp:150
+#: ../src/richtext/richtextfontpage.cpp:152
+msgid "Type a font name."
+msgstr "Digite um nome de fonte."
+
+#: ../src/richtext/richtextfontpage.cpp:158
+msgid "&Size:"
+msgstr "&Tamanho:"
+
+#: ../src/richtext/richtextfontpage.cpp:165
+#: ../src/richtext/richtextfontpage.cpp:167
+msgid "Type a size in points."
+msgstr "Digite um tamanho em pontos."
+
+#: ../src/richtext/richtextfontpage.cpp:180
+#: ../src/richtext/richtextfontpage.cpp:182
+msgid "The font size units, points or pixels."
+msgstr "As unidades de tamanho da fonte, pontos ou pixels."
+
+#: ../src/richtext/richtextfontpage.cpp:189
+#: ../src/richtext/richtextfontpage.cpp:191
+msgid "Lists the available fonts."
+msgstr "Lista as fontes disponíveis."
+
+#: ../src/richtext/richtextfontpage.cpp:196
+#: ../src/richtext/richtextfontpage.cpp:198
+msgid "Lists font sizes in points."
+msgstr "Lista os tamanhos das fontes em pontos."
+
+#: ../src/richtext/richtextfontpage.cpp:207
+msgid "Font st&yle:"
+msgstr "Estilo da f&onte:"
+
+#: ../src/richtext/richtextfontpage.cpp:212
+#: ../src/richtext/richtextfontpage.cpp:214
+msgid "Select regular or italic style."
+msgstr "Selecione o estilo regular ou itálico."
+
+#: ../src/richtext/richtextfontpage.cpp:220
+msgid "Font &weight:"
+msgstr "Peso da &fonte:"
+
+#: ../src/richtext/richtextfontpage.cpp:225
+#: ../src/richtext/richtextfontpage.cpp:227
+msgid "Select regular or bold."
+msgstr "Selecione regular ou negrito."
+
+#: ../src/richtext/richtextfontpage.cpp:233
+msgid "&Underlining:"
+msgstr "&Sublinhado:"
+
+#: ../src/richtext/richtextfontpage.cpp:238
+#: ../src/richtext/richtextfontpage.cpp:240
+msgid "Select underlining or no underlining."
+msgstr "Selecione sublinhado ou sem sublinhado."
+
+#: ../src/richtext/richtextfontpage.cpp:248
+msgid "&Colour:"
+msgstr "&Côr:"
+
+#: ../src/richtext/richtextfontpage.cpp:253
+#: ../src/richtext/richtextfontpage.cpp:255
+msgid "Click to change the text colour."
+msgstr "Clique pra mudar a côr do texto."
+
+#: ../src/richtext/richtextfontpage.cpp:261
+msgid "&Bg colour:"
+msgstr "&Côr de fundo:"
+
+#: ../src/richtext/richtextfontpage.cpp:266
+#: ../src/richtext/richtextfontpage.cpp:268
+msgid "Click to change the text background colour."
+msgstr "Clique pra mudar a côr do texto em 2º Plano."
+
+#: ../src/richtext/richtextfontpage.cpp:276
+#: ../src/richtext/richtextfontpage.cpp:278
+msgid "Check to show a line through the text."
+msgstr "Marque para mostrar uma linha através do texto."
+
+#: ../src/richtext/richtextfontpage.cpp:281
+msgid "Ca&pitals"
+msgstr "Ma&iúsculas"
+
+#: ../src/richtext/richtextfontpage.cpp:283
+#: ../src/richtext/richtextfontpage.cpp:285
+msgid "Check to show the text in capitals."
+msgstr "Marque para mostrar o texto em maiúsculas."
+
+#: ../src/richtext/richtextfontpage.cpp:288
+msgid "Small C&apitals"
+msgstr "Mi&núsculas"
+
+#: ../src/richtext/richtextfontpage.cpp:290
+#: ../src/richtext/richtextfontpage.cpp:292
+msgid "Check to show the text in small capitals."
+msgstr "Marque para mostrar o texto em minúsculas."
+
+#: ../src/richtext/richtextfontpage.cpp:295
+msgid "Supe&rscript"
+msgstr "Supe&rscript"
+
+#: ../src/richtext/richtextfontpage.cpp:297
+#: ../src/richtext/richtextfontpage.cpp:299
+msgid "Check to show the text in superscript."
+msgstr "Marque para mostrar o texto em superscript."
+
+#: ../src/richtext/richtextfontpage.cpp:302
+msgid "Subscrip&t"
+msgstr "Subscrip&t"
+
+#: ../src/richtext/richtextfontpage.cpp:304
+#: ../src/richtext/richtextfontpage.cpp:306
+msgid "Check to show the text in subscript."
+msgstr "Marque para mostrar o texto no subscript."
+
+#: ../src/richtext/richtextfontpage.cpp:312
+msgid "Rig&ht-to-left"
+msgstr "Dir&eita-pra-esquerda"
+
+#: ../src/richtext/richtextfontpage.cpp:314
+#: ../src/richtext/richtextfontpage.cpp:316
+msgid "Check to indicate right-to-left text layout."
+msgstr "Marque pra indicar o layout do texto da direita-pra-esquerda."
+
+#: ../src/richtext/richtextfontpage.cpp:319
+msgid "Suppress hyphe&nation"
+msgstr "Suprimir hifen&ação"
+
+#: ../src/richtext/richtextfontpage.cpp:321
+#: ../src/richtext/richtextfontpage.cpp:323
+msgid "Check to suppress hyphenation."
+msgstr "Marque pra suprimir a hifenação."
+
+#: ../src/richtext/richtextfontpage.cpp:329
+#: ../src/richtext/richtextfontpage.cpp:331
+msgid "Shows a preview of the font settings."
+msgstr "Mostra uma pré-visualização das configurações da fonte."
+
+#: ../src/richtext/richtextfontpage.cpp:348
+#: ../src/richtext/richtextfontpage.cpp:352
+#: ../src/richtext/richtextfontpage.cpp:356
+#: ../src/richtext/richtextformatdlg.cpp:873
+#: ../src/richtext/richtextindentspage.cpp:273
+#: ../src/richtext/richtextindentspage.cpp:285
+#: ../src/richtext/richtextindentspage.cpp:286
+#: ../src/richtext/richtextindentspage.cpp:310
+#: ../src/richtext/richtextindentspage.cpp:325
+#: ../src/richtext/richtextliststylepage.cpp:451
+#: ../src/richtext/richtextliststylepage.cpp:463
+#: ../src/richtext/richtextliststylepage.cpp:464
+msgid "(none)"
+msgstr "(nenhum)"
+
+#: ../src/richtext/richtextfontpage.cpp:349
+#: ../src/richtext/richtextfontpage.cpp:353
+msgid "Regular"
+msgstr "Regular"
+
+#: ../src/richtext/richtextfontpage.cpp:357
+msgid "Not underlined"
+msgstr "Não sublinhado"
+
+#: ../src/richtext/richtextformatdlg.cpp:341
+msgid "Indents && Spacing"
+msgstr "Recuos && Espaçamento"
+
+#: ../src/richtext/richtextformatdlg.cpp:346
+msgid "Tabs"
+msgstr "Abas"
+
+#: ../src/richtext/richtextformatdlg.cpp:351
+msgid "Bullets"
+msgstr "Balas"
+
+#: ../src/richtext/richtextformatdlg.cpp:356
+msgid "List Style"
+msgstr "Estilo das Listas"
+
+#: ../src/richtext/richtextformatdlg.cpp:366
+#: ../src/richtext/richtextmarginspage.cpp:170
+msgid "Margins"
+msgstr "Margens"
+
+#: ../src/richtext/richtextformatdlg.cpp:371
+msgid "Borders"
+msgstr "Bordas"
+
+#: ../src/richtext/richtextformatdlg.cpp:765
+msgid "Colour"
+msgstr "Côr"
+
+#: ../src/richtext/richtextindentspage.cpp:127
+#: ../src/richtext/richtextliststylepage.cpp:322
+msgid "&Alignment"
+msgstr "&Alinhamento"
+
+#: ../src/richtext/richtextindentspage.cpp:138
+#: ../src/richtext/richtextliststylepage.cpp:331
+msgid "&Left"
+msgstr "&Esquerda"
+
+#: ../src/richtext/richtextindentspage.cpp:140
+#: ../src/richtext/richtextindentspage.cpp:142
+#: ../src/richtext/richtextliststylepage.cpp:333
+#: ../src/richtext/richtextliststylepage.cpp:335
+msgid "Left-align text."
+msgstr "Alinhar o texto a esquerda."
+
+#: ../src/richtext/richtextindentspage.cpp:145
+#: ../src/richtext/richtextliststylepage.cpp:338
+msgid "&Right"
+msgstr "&Direita"
+
+#: ../src/richtext/richtextindentspage.cpp:147
+#: ../src/richtext/richtextindentspage.cpp:149
+#: ../src/richtext/richtextliststylepage.cpp:340
+#: ../src/richtext/richtextliststylepage.cpp:342
+msgid "Right-align text."
+msgstr "Alinhar o texto a direita."
+
+#: ../src/richtext/richtextindentspage.cpp:152
+#: ../src/richtext/richtextliststylepage.cpp:345
+msgid "&Justified"
+msgstr "&Justificado"
+
+#: ../src/richtext/richtextindentspage.cpp:154
+#: ../src/richtext/richtextindentspage.cpp:156
+#: ../src/richtext/richtextliststylepage.cpp:347
+#: ../src/richtext/richtextliststylepage.cpp:349
+msgid "Justify text left and right."
+msgstr "Justificar o texto a esquerda e a direita."
+
+#: ../src/richtext/richtextindentspage.cpp:159
+#: ../src/richtext/richtextliststylepage.cpp:352
+msgid "Cen&tred"
+msgstr "Cen&tralizado"
+
+#: ../src/richtext/richtextindentspage.cpp:161
+#: ../src/richtext/richtextindentspage.cpp:163
+#: ../src/richtext/richtextliststylepage.cpp:354
+#: ../src/richtext/richtextliststylepage.cpp:356
+msgid "Centre text."
+msgstr "Centralizar texto."
+
+#: ../src/richtext/richtextindentspage.cpp:166
+#: ../src/richtext/richtextliststylepage.cpp:359
+msgid "&Indeterminate"
+msgstr "&Indeterminado"
+
+#: ../src/richtext/richtextindentspage.cpp:168
+#: ../src/richtext/richtextindentspage.cpp:170
+#: ../src/richtext/richtextliststylepage.cpp:361
+#: ../src/richtext/richtextliststylepage.cpp:363
+msgid "Use the current alignment setting."
+msgstr "Usar a configuração de alinhamento atual."
+
+#: ../src/richtext/richtextindentspage.cpp:183
+#: ../src/richtext/richtextliststylepage.cpp:375
+msgid "&Indentation (tenths of a mm)"
+msgstr "&Recorte (décimos de um mm)"
+
+#: ../src/richtext/richtextindentspage.cpp:198
+#: ../src/richtext/richtextindentspage.cpp:200
+#: ../src/richtext/richtextliststylepage.cpp:388
+#: ../src/richtext/richtextliststylepage.cpp:390
+msgid "The left indent."
+msgstr "O recuo a esquerda."
+
+#: ../src/richtext/richtextindentspage.cpp:203
+#: ../src/richtext/richtextliststylepage.cpp:393
+msgid "Left (&first line):"
+msgstr "Esquerda (&primeira linha):"
+
+#: ../src/richtext/richtextindentspage.cpp:207
+#: ../src/richtext/richtextindentspage.cpp:209
+#: ../src/richtext/richtextliststylepage.cpp:397
+#: ../src/richtext/richtextliststylepage.cpp:399
+msgid "The first line indent."
+msgstr "O recuo da primeira linha."
+
+#: ../src/richtext/richtextindentspage.cpp:216
+#: ../src/richtext/richtextindentspage.cpp:218
+#: ../src/richtext/richtextliststylepage.cpp:406
+#: ../src/richtext/richtextliststylepage.cpp:408
+msgid "The right indent."
+msgstr "O recuo a direita."
+
+#: ../src/richtext/richtextindentspage.cpp:221
+msgid "&Outline level:"
+msgstr "&Nível do contorno:"
+
+#: ../src/richtext/richtextindentspage.cpp:226
+#: ../src/richtext/richtextindentspage.cpp:228
+msgid "The outline level."
+msgstr "O nível do contorno."
+
+#: ../src/richtext/richtextindentspage.cpp:241
+#: ../src/richtext/richtextliststylepage.cpp:420
+msgid "&Spacing (tenths of a mm)"
+msgstr "&Espaçamento (décimos de um mm)"
+
+#: ../src/richtext/richtextindentspage.cpp:252
+msgid "&Before a paragraph:"
+msgstr "&Antes de um parágrafo:"
+
+#: ../src/richtext/richtextindentspage.cpp:256
+#: ../src/richtext/richtextindentspage.cpp:258
+#: ../src/richtext/richtextliststylepage.cpp:433
+#: ../src/richtext/richtextliststylepage.cpp:435
+msgid "The spacing before the paragraph."
+msgstr "O espaçamento antes do parágrafo."
+
+#: ../src/richtext/richtextindentspage.cpp:261
+msgid "&After a paragraph:"
+msgstr "&Após um parágrafo:"
+
+#: ../src/richtext/richtextindentspage.cpp:266
+#: ../src/richtext/richtextliststylepage.cpp:442
+#: ../src/richtext/richtextliststylepage.cpp:444
+msgid "The spacing after the paragraph."
+msgstr "O espaçamento após o parágrafo."
+
+#: ../src/richtext/richtextindentspage.cpp:269
+msgid "L&ine spacing:"
+msgstr "E&spaçamento das linhas:"
+
+#: ../src/richtext/richtextindentspage.cpp:274
+#: ../src/richtext/richtextliststylepage.cpp:452
+msgid "Single"
+msgstr "Único"
+
+#: ../src/richtext/richtextindentspage.cpp:275
+#: ../src/richtext/richtextliststylepage.cpp:453
+msgid "1.1"
+msgstr "1.1"
+
+#: ../src/richtext/richtextindentspage.cpp:276
+#: ../src/richtext/richtextliststylepage.cpp:454
+msgid "1.2"
+msgstr "1.2"
+
+#: ../src/richtext/richtextindentspage.cpp:277
+#: ../src/richtext/richtextliststylepage.cpp:455
+msgid "1.3"
+msgstr "1.3"
+
+#: ../src/richtext/richtextindentspage.cpp:278
+#: ../src/richtext/richtextliststylepage.cpp:456
+msgid "1.4"
+msgstr "1.4"
+
+#: ../src/richtext/richtextindentspage.cpp:279
+#: ../src/richtext/richtextliststylepage.cpp:457
+msgid "1.5"
+msgstr "1.5"
+
+#: ../src/richtext/richtextindentspage.cpp:280
+#: ../src/richtext/richtextliststylepage.cpp:458
+msgid "1.6"
+msgstr "1.6"
+
+#: ../src/richtext/richtextindentspage.cpp:281
+#: ../src/richtext/richtextliststylepage.cpp:459
+msgid "1.7"
+msgstr "1.7"
+
+#: ../src/richtext/richtextindentspage.cpp:282
+#: ../src/richtext/richtextliststylepage.cpp:460
+msgid "1.8"
+msgstr "1.8"
+
+#: ../src/richtext/richtextindentspage.cpp:283
+#: ../src/richtext/richtextliststylepage.cpp:461
+msgid "1.9"
+msgstr "1.9"
+
+#: ../src/richtext/richtextindentspage.cpp:284
+#: ../src/richtext/richtextliststylepage.cpp:462
+msgid "2"
+msgstr "2"
+
+#: ../src/richtext/richtextindentspage.cpp:287
+#: ../src/richtext/richtextindentspage.cpp:289
+#: ../src/richtext/richtextliststylepage.cpp:465
+#: ../src/richtext/richtextliststylepage.cpp:467
+msgid "The line spacing."
+msgstr "O espaçamento da linha."
+
+#: ../src/richtext/richtextindentspage.cpp:292
+msgid "&Page Break"
+msgstr "&Quebra da Página"
+
+#: ../src/richtext/richtextindentspage.cpp:294
+#: ../src/richtext/richtextindentspage.cpp:296
+msgid "Inserts a page break before the paragraph."
+msgstr "Insere uma quebra de página antes do parágrafo."
+
+#: ../src/richtext/richtextindentspage.cpp:302
+#: ../src/richtext/richtextindentspage.cpp:304
+msgid "Shows a preview of the paragraph settings."
+msgstr "Mostra uma pré-visualização das configurações do parágrafo."
+
+#: ../src/richtext/richtextliststylepage.cpp:182
+msgid "&List level:"
+msgstr "&Nível da lista:"
+
+#: ../src/richtext/richtextliststylepage.cpp:186
+#: ../src/richtext/richtextliststylepage.cpp:188
+msgid "Selects the list level to edit."
+msgstr "Seleciona o nível da lista para editar."
+
+#: ../src/richtext/richtextliststylepage.cpp:193
+msgid "&Font for Level..."
+msgstr "&Fonte para o Nível..."
+
+#: ../src/richtext/richtextliststylepage.cpp:194
+#: ../src/richtext/richtextliststylepage.cpp:196
+msgid "Click to choose the font for this level."
+msgstr "Clique pra escolher a fonte para este nível."
+
+#: ../src/richtext/richtextliststylepage.cpp:312
+msgid "Bullet style"
+msgstr "Estilo da projétil"
+
+#: ../src/richtext/richtextliststylepage.cpp:429
+msgid "Before a paragraph:"
+msgstr "Antes de um parágrafo:"
+
+#: ../src/richtext/richtextliststylepage.cpp:438
+msgid "After a paragraph:"
+msgstr "Após um parágrafo:"
+
+#: ../src/richtext/richtextliststylepage.cpp:447
+msgid "Line spacing:"
+msgstr "Espaçamento das linhas:"
+
+#: ../src/richtext/richtextliststylepage.cpp:470
+msgid "Spacing"
+msgstr "Espaçamento"
+
+#: ../src/richtext/richtextmarginspage.cpp:193
+#: ../src/richtext/richtextmarginspage.cpp:195
+msgid "The left margin size."
+msgstr "O tamanho da margem esquerda."
+
+#: ../src/richtext/richtextmarginspage.cpp:203
+#: ../src/richtext/richtextmarginspage.cpp:205
+msgid "Units for the left margin."
+msgstr "Unidades para a margem esquerda."
+
+#: ../src/richtext/richtextmarginspage.cpp:218
+#: ../src/richtext/richtextmarginspage.cpp:220
+msgid "The right margin size."
+msgstr "O tamanho da margem a direita."
+
+#: ../src/richtext/richtextmarginspage.cpp:228
+#: ../src/richtext/richtextmarginspage.cpp:230
+msgid "Units for the right margin."
+msgstr "Unidades para a margem a direita."
+
+#: ../src/richtext/richtextmarginspage.cpp:241
+#: ../src/richtext/richtextmarginspage.cpp:243
+msgid "The top margin size."
+msgstr "O tamanho da margem do topo."
+
+#: ../src/richtext/richtextmarginspage.cpp:251
+#: ../src/richtext/richtextmarginspage.cpp:253
+msgid "Units for the top margin."
+msgstr "Unidades para a margem do topo."
+
+#: ../src/richtext/richtextmarginspage.cpp:266
+#: ../src/richtext/richtextmarginspage.cpp:268
+msgid "The bottom margin size."
+msgstr "O tamanho da margem do rodapé."
+
+#: ../src/richtext/richtextmarginspage.cpp:276
+#: ../src/richtext/richtextmarginspage.cpp:278
+msgid "Units for the bottom margin."
+msgstr "Unidades para a margem do rodapé."
+
+#: ../src/richtext/richtextmarginspage.cpp:284
+msgid "Padding"
+msgstr "Enchimento"
+
+#: ../src/richtext/richtextmarginspage.cpp:307
+#: ../src/richtext/richtextmarginspage.cpp:309
+msgid "The left padding size."
+msgstr "O tamanho do preenchimento a esquerda."
+
+#: ../src/richtext/richtextmarginspage.cpp:317
+#: ../src/richtext/richtextmarginspage.cpp:319
+msgid "Units for the left padding."
+msgstr "Unidades para o preenchimento a esquerda."
+
+#: ../src/richtext/richtextmarginspage.cpp:332
+#: ../src/richtext/richtextmarginspage.cpp:334
+msgid "The right padding size."
+msgstr "O tamanho do preenchimento a direita."
+
+#: ../src/richtext/richtextmarginspage.cpp:342
+#: ../src/richtext/richtextmarginspage.cpp:344
+msgid "Units for the right padding."
+msgstr "Unidades para o preenchimento a direita."
+
+#: ../src/richtext/richtextmarginspage.cpp:355
+#: ../src/richtext/richtextmarginspage.cpp:357
+msgid "The top padding size."
+msgstr "O tamanho do preenchimento do topo."
+
+#: ../src/richtext/richtextmarginspage.cpp:365
+#: ../src/richtext/richtextmarginspage.cpp:367
+msgid "Units for the top padding."
+msgstr "Unidades para o preenchimento do topo."
+
+#: ../src/richtext/richtextmarginspage.cpp:380
+#: ../src/richtext/richtextmarginspage.cpp:382
+msgid "The bottom padding size."
+msgstr "O tamanho do preenchimento do rodapé."
+
+#: ../src/richtext/richtextmarginspage.cpp:390
+#: ../src/richtext/richtextmarginspage.cpp:392
+msgid "Units for the bottom padding."
+msgstr "Unidades para o preenchimento do rodapé."
+
+#: ../src/richtext/richtextprint.cpp:592
+msgid " Preview"
+msgstr " Pré-visualizar"
+
+#: ../src/richtext/richtextsizepage.cpp:228
+msgid "Floating"
+msgstr "Flutuante"
+
+#: ../src/richtext/richtextsizepage.cpp:243
+msgid "&Floating mode:"
+msgstr "&Modo flutuante:"
+
+#: ../src/richtext/richtextsizepage.cpp:252
+#: ../src/richtext/richtextsizepage.cpp:254
+msgid "How the object will float relative to the text."
+msgstr "Como o objeto flutuará relativo ao texto."
+
+#: ../src/richtext/richtextsizepage.cpp:265
+msgid "Alignment"
+msgstr "Alinhamento"
+
+#: ../src/richtext/richtextsizepage.cpp:277
+msgid "&Vertical alignment:"
+msgstr "&Alinhamento vertical:"
+
+#: ../src/richtext/richtextsizepage.cpp:279
+#: ../src/richtext/richtextsizepage.cpp:281
+msgid "Enable vertical alignment."
+msgstr "Ativar alinhamento vertical."
+
+#: ../src/richtext/richtextsizepage.cpp:286
+msgid "Centred"
+msgstr "Centralizado"
+
+#: ../src/richtext/richtextsizepage.cpp:290
+#: ../src/richtext/richtextsizepage.cpp:292
+msgid "Vertical alignment."
+msgstr "Alinhamento vertical."
+
+#: ../src/richtext/richtextsizepage.cpp:316
+#: ../src/richtext/richtextsizepage.cpp:323
+msgid "&Width:"
+msgstr "&Largura:"
+
+#: ../src/richtext/richtextsizepage.cpp:318
+#: ../src/richtext/richtextsizepage.cpp:320
+msgid "Enable the width value."
+msgstr "Ativar o valor largura."
+
+#: ../src/richtext/richtextsizepage.cpp:331
+#: ../src/richtext/richtextsizepage.cpp:333
+msgid "The object width."
+msgstr "A largura do objeto."
+
+#: ../src/richtext/richtextsizepage.cpp:342
+#: ../src/richtext/richtextsizepage.cpp:344
+msgid "Units for the object width."
+msgstr "Unidades para a largura do objeto."
+
+#: ../src/richtext/richtextsizepage.cpp:350
+#: ../src/richtext/richtextsizepage.cpp:357
+msgid "&Height:"
+msgstr "&Altura:"
+
+#: ../src/richtext/richtextsizepage.cpp:352
+#: ../src/richtext/richtextsizepage.cpp:354
+#: ../src/richtext/richtextsizepage.cpp:464
+#: ../src/richtext/richtextsizepage.cpp:466
+msgid "Enable the height value."
+msgstr "Ativar o valor altura."
+
+#: ../src/richtext/richtextsizepage.cpp:365
+#: ../src/richtext/richtextsizepage.cpp:367
+msgid "The object height."
+msgstr "A altura do objeto."
+
+#: ../src/richtext/richtextsizepage.cpp:376
+#: ../src/richtext/richtextsizepage.cpp:378
+msgid "Units for the object height."
+msgstr "Unidades para a altura do objeto."
+
+#: ../src/richtext/richtextsizepage.cpp:381
+msgid "Min width:"
+msgstr "Largura mín:"
+
+#: ../src/richtext/richtextsizepage.cpp:383
+#: ../src/richtext/richtextsizepage.cpp:385
+msgid "Enable the minimum width value."
+msgstr "Ativar o valor mínimo da largura."
+
+#: ../src/richtext/richtextsizepage.cpp:392
+#: ../src/richtext/richtextsizepage.cpp:394
+msgid "The object minimum width."
+msgstr "A largura mínima do objeto."
+
+#: ../src/richtext/richtextsizepage.cpp:403
+#: ../src/richtext/richtextsizepage.cpp:405
+msgid "Units for the minimum object width."
+msgstr "Unidades para a largura mínima do objeto."
+
+#: ../src/richtext/richtextsizepage.cpp:408
+msgid "Min height:"
+msgstr "Altura mín:"
+
+#: ../src/richtext/richtextsizepage.cpp:410
+#: ../src/richtext/richtextsizepage.cpp:412
+msgid "Enable the minimum height value."
+msgstr "Ativar o valor mínimo da altura."
+
+#: ../src/richtext/richtextsizepage.cpp:419
+#: ../src/richtext/richtextsizepage.cpp:421
+msgid "The object minimum height."
+msgstr "A altura mínima do objeto."
+
+#: ../src/richtext/richtextsizepage.cpp:430
+#: ../src/richtext/richtextsizepage.cpp:432
+msgid "Units for the minimum object height."
+msgstr "Unidades para a altura mínima do objeto."
+
+#: ../src/richtext/richtextsizepage.cpp:435
+msgid "Max width:"
+msgstr "Largura máx:"
+
+#: ../src/richtext/richtextsizepage.cpp:437
+#: ../src/richtext/richtextsizepage.cpp:439
+msgid "Enable the maximum width value."
+msgstr "Ativar o valor máximo da largura."
+
+#: ../src/richtext/richtextsizepage.cpp:446
+#: ../src/richtext/richtextsizepage.cpp:448
+msgid "The object maximum width."
+msgstr "A largura máxima do objeto."
+
+#: ../src/richtext/richtextsizepage.cpp:457
+#: ../src/richtext/richtextsizepage.cpp:459
+msgid "Units for the maximum object width."
+msgstr "Unidades para a largura máxima do objeto."
+
+#: ../src/richtext/richtextsizepage.cpp:462
+msgid "Max height:"
+msgstr "Altura máx:"
+
+#: ../src/richtext/richtextsizepage.cpp:473
+#: ../src/richtext/richtextsizepage.cpp:475
+msgid "The object maximum height."
+msgstr "A altura máxima do objeto."
+
+#: ../src/richtext/richtextsizepage.cpp:484
+#: ../src/richtext/richtextsizepage.cpp:486
+msgid "Units for the maximum object height."
+msgstr "Unidades para a altura máxima do objeto."
+
+#: ../src/richtext/richtextsizepage.cpp:495
+msgid "Position"
+msgstr "Posição"
+
+#: ../src/richtext/richtextsizepage.cpp:513
+msgid "&Position mode:"
+msgstr "&Modo da posição:"
+
+#: ../src/richtext/richtextsizepage.cpp:517
+#: ../src/richtext/richtextsizepage.cpp:522
+msgid "Static"
+msgstr "Estático"
+
+#: ../src/richtext/richtextsizepage.cpp:518
+msgid "Relative"
+msgstr "Relativo"
+
+#: ../src/richtext/richtextsizepage.cpp:519
+msgid "Absolute"
+msgstr "Absoluto"
+
+#: ../src/richtext/richtextsizepage.cpp:520
+msgid "Fixed"
+msgstr "Fixo"
+
+#: ../src/richtext/richtextsizepage.cpp:533
+#: ../src/richtext/richtextsizepage.cpp:535
+#: ../src/richtext/richtextsizepage.cpp:547
+#: ../src/richtext/richtextsizepage.cpp:549
+msgid "The left position."
+msgstr "A posição da esquerda."
+
+#: ../src/richtext/richtextsizepage.cpp:558
+#: ../src/richtext/richtextsizepage.cpp:560
+msgid "Units for the left position."
+msgstr "Unidades para a posição da esquerda."
+
+#: ../src/richtext/richtextsizepage.cpp:568
+#: ../src/richtext/richtextsizepage.cpp:570
+#: ../src/richtext/richtextsizepage.cpp:582
+#: ../src/richtext/richtextsizepage.cpp:584
+msgid "The top position."
+msgstr "A posição do topo."
+
+#: ../src/richtext/richtextsizepage.cpp:593
+#: ../src/richtext/richtextsizepage.cpp:595
+msgid "Units for the top position."
+msgstr "Unidades para a posição do topo."
+
+#: ../src/richtext/richtextsizepage.cpp:603
+#: ../src/richtext/richtextsizepage.cpp:605
+#: ../src/richtext/richtextsizepage.cpp:617
+#: ../src/richtext/richtextsizepage.cpp:619
+msgid "The right position."
+msgstr "A posição da direta."
+
+#: ../src/richtext/richtextsizepage.cpp:628
+#: ../src/richtext/richtextsizepage.cpp:630
+msgid "Units for the right position."
+msgstr "Unidades para a posição da direita."
+
+#: ../src/richtext/richtextsizepage.cpp:638
+#: ../src/richtext/richtextsizepage.cpp:640
+#: ../src/richtext/richtextsizepage.cpp:652
+#: ../src/richtext/richtextsizepage.cpp:654
+msgid "The bottom position."
+msgstr "A posição do rodapé."
+
+#: ../src/richtext/richtextsizepage.cpp:663
+#: ../src/richtext/richtextsizepage.cpp:665
+msgid "Units for the bottom position."
+msgstr "Unidades para a posição do rodapé."
+
+#: ../src/richtext/richtextsizepage.cpp:671
+msgid "&Move the object to:"
+msgstr "&Mover o objeto para:"
+
+#: ../src/richtext/richtextsizepage.cpp:674
+msgid "&Previous Paragraph"
+msgstr "&Parágrafo Anterior"
+
+#: ../src/richtext/richtextsizepage.cpp:675
+#: ../src/richtext/richtextsizepage.cpp:677
+msgid "Moves the object to the previous paragraph."
+msgstr "Move o objeto para o parágrafo anterior."
+
+#: ../src/richtext/richtextsizepage.cpp:680
+msgid "&Next Paragraph"
+msgstr "&Parágrafo Seguinte"
+
+#: ../src/richtext/richtextsizepage.cpp:681
+#: ../src/richtext/richtextsizepage.cpp:683
+msgid "Moves the object to the next paragraph."
+msgstr "Move o objeto para o próximo parágrafo."
+
+#: ../src/richtext/richtextstyledlg.cpp:193
+msgid "&Styles:"
+msgstr "&Estilos:"
+
+#: ../src/richtext/richtextstyledlg.cpp:197
+#: ../src/richtext/richtextstyledlg.cpp:199
+msgid "The available styles."
+msgstr "Os estilos disponíveis."
+
+#: ../src/richtext/richtextstyledlg.cpp:205
+#: ../src/richtext/richtextstyledlg.cpp:217
+msgid " "
+msgstr " "
+
+#: ../src/richtext/richtextstyledlg.cpp:209
+#: ../src/richtext/richtextstyledlg.cpp:211
+msgid "The style preview."
+msgstr "A pré-visualização do estilo."
+
+#: ../src/richtext/richtextstyledlg.cpp:220
+msgid "New &Character Style..."
+msgstr "Novo &Estilo de Caractere..."
+
+#: ../src/richtext/richtextstyledlg.cpp:221
+#: ../src/richtext/richtextstyledlg.cpp:223
+msgid "Click to create a new character style."
+msgstr "Clique pra criar um novo estilo de caracteres."
+
+#: ../src/richtext/richtextstyledlg.cpp:226
+msgid "New &Paragraph Style..."
+msgstr "Novo &Estilo de Parágrafo..."
+
+#: ../src/richtext/richtextstyledlg.cpp:227
+#: ../src/richtext/richtextstyledlg.cpp:229
+msgid "Click to create a new paragraph style."
+msgstr "Clique pra criar um novo estilo de parágrafo."
+
+#: ../src/richtext/richtextstyledlg.cpp:232
+msgid "New &List Style..."
+msgstr "Novo &Estilo de Lista..."
+
+#: ../src/richtext/richtextstyledlg.cpp:233
+#: ../src/richtext/richtextstyledlg.cpp:235
+msgid "Click to create a new list style."
+msgstr "Clique pra criar um novo estilo de listas."
+
+#: ../src/richtext/richtextstyledlg.cpp:238
+msgid "New &Box Style..."
+msgstr "Novo &Estilo da Caixa..."
+
+#: ../src/richtext/richtextstyledlg.cpp:239
+#: ../src/richtext/richtextstyledlg.cpp:241
+msgid "Click to create a new box style."
+msgstr "Clique pra criar um novo estilo de caixas."
+
+#: ../src/richtext/richtextstyledlg.cpp:246
+msgid "&Apply Style"
+msgstr "&Aplicar Estilo"
+
+#: ../src/richtext/richtextstyledlg.cpp:247
+#: ../src/richtext/richtextstyledlg.cpp:249
+msgid "Click to apply the selected style."
+msgstr "Clique pra aplicar o estilo selecionado."
+
+#: ../src/richtext/richtextstyledlg.cpp:252
+msgid "&Rename Style..."
+msgstr "&Renomear Estilo..."
+
+#: ../src/richtext/richtextstyledlg.cpp:253
+#: ../src/richtext/richtextstyledlg.cpp:255
+msgid "Click to rename the selected style."
+msgstr "Clique pra renomear o estilo selecionado."
+
+#: ../src/richtext/richtextstyledlg.cpp:258
+msgid "&Edit Style..."
+msgstr "&Editar Estilo..."
+
+#: ../src/richtext/richtextstyledlg.cpp:259
+#: ../src/richtext/richtextstyledlg.cpp:261
+msgid "Click to edit the selected style."
+msgstr "Clique pra editar o estilo selecionado."
+
+#: ../src/richtext/richtextstyledlg.cpp:264
+msgid "&Delete Style..."
+msgstr "&Apagar o Estilo..."
+
+#: ../src/richtext/richtextstyledlg.cpp:265
+#: ../src/richtext/richtextstyledlg.cpp:267
+msgid "Click to delete the selected style."
+msgstr "Clique pra apagar o estilo selecionado."
+
+#: ../src/richtext/richtextstyledlg.cpp:274
+#: ../src/richtext/richtextstyledlg.cpp:276
+msgid "Click to close this window."
+msgstr "Clique pra fechar esta janela."
+
+#: ../src/richtext/richtextstyledlg.cpp:282
+msgid "&Restart numbering"
+msgstr "&Reiniciar a numeração"
+
+#: ../src/richtext/richtextstyledlg.cpp:284
+#: ../src/richtext/richtextstyledlg.cpp:286
+msgid "Check to restart numbering."
+msgstr "Marque pra reiniciar a numeração."
+
+#: ../src/richtext/richtextstyledlg.cpp:601
+msgid "Enter a character style name"
+msgstr "Insira um nome de estilo de caracteres"
+
+#: ../src/richtext/richtextstyledlg.cpp:601
+#: ../src/richtext/richtextstyledlg.cpp:606
+#: ../src/richtext/richtextstyledlg.cpp:649
+#: ../src/richtext/richtextstyledlg.cpp:654
+#: ../src/richtext/richtextstyledlg.cpp:815
+#: ../src/richtext/richtextstyledlg.cpp:820
+#: ../src/richtext/richtextstyledlg.cpp:888
+#: ../src/richtext/richtextstyledlg.cpp:896
+#: ../src/richtext/richtextstyledlg.cpp:929
+#: ../src/richtext/richtextstyledlg.cpp:934
+msgid "New Style"
+msgstr "Novo Estilo"
+
+#: ../src/richtext/richtextstyledlg.cpp:606
+#: ../src/richtext/richtextstyledlg.cpp:654
+#: ../src/richtext/richtextstyledlg.cpp:820
+#: ../src/richtext/richtextstyledlg.cpp:896
+#: ../src/richtext/richtextstyledlg.cpp:934
+msgid "Sorry, that name is taken. Please choose another."
+msgstr "Lamento, este nome está tomado. Por favor escolha outro."
+
+#: ../src/richtext/richtextstyledlg.cpp:649
+msgid "Enter a paragraph style name"
+msgstr "Insira um nome de estilo do parágrafo"
+
+#: ../src/richtext/richtextstyledlg.cpp:777
+#, c-format
+msgid "Delete style %s?"
+msgstr "Apagar o estilo %s?"
+
+#: ../src/richtext/richtextstyledlg.cpp:777
+msgid "Delete Style"
+msgstr "Apagar o Estilo"
+
+#: ../src/richtext/richtextstyledlg.cpp:815
+msgid "Enter a list style name"
+msgstr "Insira um nome de estilo de listas"
+
+#: ../src/richtext/richtextstyledlg.cpp:888
+msgid "Enter a new style name"
+msgstr "Insira um novo nome de estilo"
+
+#: ../src/richtext/richtextstyledlg.cpp:929
+msgid "Enter a box style name"
+msgstr "Insira um nome de estilo da caixa"
+
+#: ../src/richtext/richtextstylepage.cpp:109
+#: ../src/richtext/richtextstylepage.cpp:111
+msgid "The style name."
+msgstr "O nome do estilo."
+
+#: ../src/richtext/richtextstylepage.cpp:114
+msgid "&Based on:"
+msgstr "&Baseado em:"
+
+#: ../src/richtext/richtextstylepage.cpp:119
+#: ../src/richtext/richtextstylepage.cpp:121
+msgid "The style on which this style is based."
+msgstr "O estilo no qual este estilo é baseado."
+
+#: ../src/richtext/richtextstylepage.cpp:124
+msgid "&Next style:"
+msgstr "&Próximo estilo:"
+
+#: ../src/richtext/richtextstylepage.cpp:129
+#: ../src/richtext/richtextstylepage.cpp:131
+msgid "The default style for the next paragraph."
+msgstr "O estilo padrão para o próximo parágrafo."
+
+#: ../src/richtext/richtextstyles.cpp:1057
+msgid "All styles"
+msgstr "Todos os estilos"
+
+#: ../src/richtext/richtextstyles.cpp:1058
+msgid "Paragraph styles"
+msgstr "Estilos de parágrafo"
+
+#: ../src/richtext/richtextstyles.cpp:1059
+msgid "Character styles"
+msgstr "Estilos dos caracteres"
+
+#: ../src/richtext/richtextstyles.cpp:1060
+msgid "List styles"
+msgstr "Estilos das listas"
+
+#: ../src/richtext/richtextstyles.cpp:1061
+msgid "Box styles"
+msgstr "Estilos de caixa"
+
+#: ../src/richtext/richtextsymboldlg.cpp:389
+#: ../src/richtext/richtextsymboldlg.cpp:391
+msgid "The font from which to take the symbol."
+msgstr "A fonte da qual tomar o símbolo."
+
+#: ../src/richtext/richtextsymboldlg.cpp:396
+msgid "&Subset:"
+msgstr "&Subset:"
+
+#: ../src/richtext/richtextsymboldlg.cpp:401
+#: ../src/richtext/richtextsymboldlg.cpp:403
+msgid "Shows a Unicode subset."
+msgstr "Mostra um subset do Unicode."
+
+#: ../src/richtext/richtextsymboldlg.cpp:412
+msgid "xxxx"
+msgstr "xxxx"
+
+#: ../src/richtext/richtextsymboldlg.cpp:417
+msgid "&Character code:"
+msgstr "&Código dos caracteres:"
+
+#: ../src/richtext/richtextsymboldlg.cpp:421
+#: ../src/richtext/richtextsymboldlg.cpp:423
+msgid "The character code."
+msgstr "O código do caractere."
+
+#: ../src/richtext/richtextsymboldlg.cpp:428
+msgid "&From:"
+msgstr "&De:"
+
+#: ../src/richtext/richtextsymboldlg.cpp:433
+#: ../src/richtext/richtextsymboldlg.cpp:434
+#: ../src/richtext/richtextsymboldlg.cpp:435
+msgid "Unicode"
+msgstr "Unicode"
+
+#: ../src/richtext/richtextsymboldlg.cpp:436
+#: ../src/richtext/richtextsymboldlg.cpp:438
+msgid "The range to show."
+msgstr "O alcance a mostrar."
+
+#: ../src/richtext/richtextsymboldlg.cpp:444
+msgid "Insert"
+msgstr "Insert"
+
+#: ../src/richtext/richtextsymboldlg.cpp:478
+msgid "(Normal text)"
+msgstr "(Texto normal)"
+
+#: ../src/richtext/richtexttabspage.cpp:109
+msgid "&Position (tenths of a mm):"
+msgstr "&Posição (décimos de um milímetro):"
+
+#: ../src/richtext/richtexttabspage.cpp:113
+#: ../src/richtext/richtexttabspage.cpp:115
+msgid "The tab position."
+msgstr "A posição da aba."
+
+#: ../src/richtext/richtexttabspage.cpp:119
+msgid "The tab positions."
+msgstr "As posições das abas."
+
+#: ../src/richtext/richtexttabspage.cpp:132
+#: ../src/richtext/richtexttabspage.cpp:134
+msgid "Click to create a new tab position."
+msgstr "Clique pra criar uma nova posição da aba."
+
+#: ../src/richtext/richtexttabspage.cpp:138
+#: ../src/richtext/richtexttabspage.cpp:140
+msgid "Click to delete the selected tab position."
+msgstr "Clique para apagar a posição da aba selecionada."
+
+#: ../src/richtext/richtexttabspage.cpp:143
+msgid "Delete A&ll"
+msgstr "Apagar T&udo"
+
+#: ../src/richtext/richtexttabspage.cpp:144
+#: ../src/richtext/richtexttabspage.cpp:146
+msgid "Click to delete all tab positions."
+msgstr "Clique para apagar todas as posições da aba."
+
+#: ../src/univ/theme.cpp:110
+msgid "Failed to initialize GUI: no built-in themes found."
+msgstr "Falhou em inicializar a GUI: não foram achados temas embutidos."
+
+#: ../src/univ/themes/gtk.cpp:521
+msgid "GTK+ theme"
+msgstr "Tema do GTK+"
+
+#: ../src/univ/themes/metal.cpp:164
+msgid "Metal theme"
+msgstr "Tema Metal"
+
+#: ../src/univ/themes/mono.cpp:512
+msgid "Simple monochrome theme"
+msgstr "Tema Monocromático Simples"
+
+#: ../src/univ/themes/win32.cpp:1098
+msgid "Win32 theme"
+msgstr "Tema do Win32"
+
+#: ../src/univ/themes/win32.cpp:3743
+msgid "&Restore"
+msgstr "&Restaurar"
+
+#: ../src/univ/themes/win32.cpp:3744
+msgid "&Move"
+msgstr "&Mover"
+
+#: ../src/univ/themes/win32.cpp:3746
+msgid "&Size"
+msgstr "&Tamanho"
+
+#: ../src/univ/themes/win32.cpp:3748
+msgid "Mi&nimize"
+msgstr "Mi&nimizar"
+
+#: ../src/univ/themes/win32.cpp:3750
+msgid "Ma&ximize"
+msgstr "Ma&ximizar"
+
+#: ../src/univ/themes/win32.cpp:3752
+msgid "Alt+"
+msgstr "Alt+"
+
+#: ../src/unix/appunix.cpp:178
+msgid "Failed to install signal handler"
+msgstr "Falhou em instalar o manipulador do sinal"
+
+#: ../src/unix/dialup.cpp:351
+msgid "Already dialling ISP."
+msgstr "Já discando pro ISP."
+
+#: ../src/unix/dlunix.cpp:93
+msgid "Failed to unload shared library"
+msgstr "Falhou em descarregar a biblioteca compartilhada"
+
+#: ../src/unix/dlunix.cpp:121
+msgid "Unknown dynamic library error"
+msgstr "Erro desconhecido da biblioteca dinâmica"
+
+#: ../src/unix/epolldispatcher.cpp:84
+msgid "Failed to create epoll descriptor"
+msgstr "Falhou em criar o descritor epoll"
+
+#: ../src/unix/epolldispatcher.cpp:103
+msgid "Error closing epoll descriptor"
+msgstr "Erro ao fechar o descritor epoll"
+
+#: ../src/unix/epolldispatcher.cpp:116
+#, c-format
+msgid "Failed to add descriptor %d to epoll descriptor %d"
+msgstr "Falhou em adicionar o descritor %d ao descritor epoll %d"
+
+#: ../src/unix/epolldispatcher.cpp:136
+#, c-format
+msgid "Failed to modify descriptor %d in epoll descriptor %d"
+msgstr "Falhou em modificar o descritor %d no descritor epoll %d"
+
+#: ../src/unix/epolldispatcher.cpp:155
+#, c-format
+msgid "Failed to unregister descriptor %d from epoll descriptor %d"
+msgstr "Falhou em remover o registro do descritor %d do descritor epoll %d"
+
+#: ../src/unix/epolldispatcher.cpp:213
+#, c-format
+msgid "Waiting for IO on epoll descriptor %d failed"
+msgstr "Falhou em esperar pelo IO no descritor epoll %d"
+
+#: ../src/unix/fswatcher_inotify.cpp:71
+msgid "Unable to create inotify instance"
+msgstr "Incapaz de criar a instância do inotify"
+
+#: ../src/unix/fswatcher_inotify.cpp:94
+msgid "Unable to close inotify instance"
+msgstr "Incapaz de fechar a instância do inotify"
+
+#: ../src/unix/fswatcher_inotify.cpp:106
+msgid "Unable to add inotify watch"
+msgstr "Incapaz de adicionar a observação do inotify"
+
+#: ../src/unix/fswatcher_inotify.cpp:138
+#, c-format
+msgid "Unable to remove inotify watch %i"
+msgstr "Incapaz de remover a observação do inotify %i"
+
+#: ../src/unix/fswatcher_inotify.cpp:271
+#, c-format
+msgid "Unexpected event for \"%s\": no matching watch descriptor."
+msgstr ""
+"Evento inesperado para \"%s\": sem descritor de observação que combine."
+
+#: ../src/unix/fswatcher_inotify.cpp:320
+#, c-format
+msgid "Invalid inotify event for \"%s\""
+msgstr "Evento inotify inválido para \"%s\""
+
+#: ../src/unix/fswatcher_inotify.cpp:553
+msgid "Unable to read from inotify descriptor"
+msgstr "Incapaz de ler do descritor do inotify"
+
+#: ../src/unix/fswatcher_inotify.cpp:558
+msgid "EOF while reading from inotify descriptor"
+msgstr "EOF enquanto lia do descritor inotify"
+
+#: ../src/unix/fswatcher_kqueue.cpp:114
+msgid "Unable to create kqueue instance"
+msgstr "Incapaz de criar a instância do kqueue"
+
+#: ../src/unix/fswatcher_kqueue.cpp:131
+msgid "Error closing kqueue instance"
+msgstr "Erro ao fechar a instância kqueue"
+
+#: ../src/unix/fswatcher_kqueue.cpp:153
+msgid "Unable to add kqueue watch"
+msgstr "Incapaz de adicionar a observação do kqueue"
+
+#: ../src/unix/fswatcher_kqueue.cpp:170
+msgid "Unable to remove kqueue watch"
+msgstr "Incapaz de removar a observação do kqueue"
+
+#: ../src/unix/fswatcher_kqueue.cpp:202
+msgid "Unable to get events from kqueue"
+msgstr "Incapaz de obter eventos do kqueue"
+
+#: ../src/unix/mediactrl.cpp:966
+#, c-format
+msgid "Media playback error: %s"
+msgstr "Erro do playback da mídia: %s"
+
+#: ../src/unix/mediactrl.cpp:1228
+#, c-format
+msgid "Failed to prepare playing \"%s\"."
+msgstr "Falhou em preparar a reprodução do \"%s\"."
+
+#: ../src/unix/snglinst.cpp:164
+#, c-format
+msgid "Failed to write to lock file '%s'"
+msgstr "Falhou em gravar no arquivo da tranca '%s'"
+
+#: ../src/unix/snglinst.cpp:177
+#, c-format
+msgid "Failed to set permissions on lock file '%s'"
+msgstr "Falhou em definir as permissões sobre o arquivo da tranca '%s'"
+
+#: ../src/unix/snglinst.cpp:194
+#, c-format
+msgid "Failed to lock the lock file '%s'"
+msgstr "Falhou em trancar o arquivo da tranca '%s'"
+
+#: ../src/unix/snglinst.cpp:237
+#, c-format
+msgid "Failed to inspect the lock file '%s'"
+msgstr "Falhou em inspecionar o arquivo da tranca '%s'"
+
+#: ../src/unix/snglinst.cpp:242
+#, c-format
+msgid "Lock file '%s' has incorrect owner."
+msgstr "O arquivo da tranca '%s' tem um dono incorreto."
+
+#: ../src/unix/snglinst.cpp:247
+#, c-format
+msgid "Lock file '%s' has incorrect permissions."
+msgstr "O arquivo da tranca '%s' tem permissões incorretas."
+
+#: ../src/unix/snglinst.cpp:265
+msgid "Failed to access lock file."
+msgstr "Falhou em acessar o arquivo da tranca."
+
+#: ../src/unix/snglinst.cpp:274
+msgid "Failed to read PID from lock file."
+msgstr "Falhou em ler o PID do arquivo da tranca."
+
+#: ../src/unix/snglinst.cpp:284
+#, c-format
+msgid "Failed to remove stale lock file '%s'."
+msgstr "Falhou em remover o arquivo do stale lock '%s'."
+
+#: ../src/unix/snglinst.cpp:297
+#, c-format
+msgid "Deleted stale lock file '%s'."
+msgstr "Arquivo do stale lock apagado '%s'."
+
+#: ../src/unix/snglinst.cpp:308
+#, c-format
+msgid "Invalid lock file '%s'."
+msgstr "Arquivo da tranca '%s' inválido."
+
+#: ../src/unix/snglinst.cpp:324
+#, c-format
+msgid "Failed to remove lock file '%s'"
+msgstr "Falhou em remover o arquivo da tranca '%s'"
+
+#: ../src/unix/snglinst.cpp:330
+#, c-format
+msgid "Failed to unlock lock file '%s'"
+msgstr "Falhou em destrancar o arquivo da tranca '%s'"
+
+#: ../src/unix/snglinst.cpp:336
+#, c-format
+msgid "Failed to close lock file '%s'"
+msgstr "Falhou em fechar o arquivo da tranca '%s'"
+
+#: ../src/unix/sound.cpp:77
+msgid "No sound"
+msgstr "Sem som"
+
+#: ../src/unix/sound.cpp:364
+msgid "Unable to play sound asynchronously."
+msgstr "Incapaz de reproduzir o som de forma assíncrona."
+
+#: ../src/unix/sound.cpp:458
+#, c-format
+msgid "Couldn't load sound data from '%s'."
+msgstr "Não pôde carregar os dados do som do '%s'."
+
+#: ../src/unix/sound.cpp:465
+#, c-format
+msgid "Sound file '%s' is in unsupported format."
+msgstr "O arquivo de som '%s' está num formato não suportado."
+
+#: ../src/unix/sound.cpp:480
+msgid "Sound data are in unsupported format."
+msgstr "Os dados do som estão num formato não suportado."
+
+#: ../src/unix/sound_sdl.cpp:226
+#, c-format
+msgid "Couldn't open audio: %s"
+msgstr "Não pôde abrir o áudio: %s"
+
+#: ../src/unix/threadpsx.cpp:1033
+msgid "Cannot retrieve thread scheduling policy."
+msgstr "Não consegue recuperar a norma de conduta do agendamento dos threads."
+
+#: ../src/unix/threadpsx.cpp:1058
+#, c-format
+msgid "Cannot get priority range for scheduling policy %d."
+msgstr ""
+"Não consegue obter o alcance da prioridade para a norma de conduta do "
+"agendamento do %d."
+
+#: ../src/unix/threadpsx.cpp:1066
+msgid "Thread priority setting is ignored."
+msgstr "A configuração da prioridade do thread é ignorada."
+
+#: ../src/unix/threadpsx.cpp:1221
+msgid ""
+"Failed to join a thread, potential memory leak detected - please restart the "
+"program"
+msgstr ""
+"Falhou em se juntar a um thread, vazamento potencial de memória detectado - "
+"por favor reinicie o programa"
+
+#: ../src/unix/threadpsx.cpp:1352
+#, c-format
+msgid "Failed to set thread concurrency level to %lu"
+msgstr "Falhou em definir o nível de concordância do thread em %lu"
+
+#: ../src/unix/threadpsx.cpp:1481
+#, c-format
+msgid "Failed to set thread priority %d."
+msgstr "Falhou em definir a prioridade do thread %d."
+
+#: ../src/unix/threadpsx.cpp:1666
+msgid "Failed to terminate a thread."
+msgstr "Falhou em concluir um thread."
+
+#: ../src/unix/threadpsx.cpp:1893
+msgid "Thread module initialization failed: failed to create thread key"
+msgstr ""
+"A inicialização do módulo dos threads falhou: falhou em criar a chave do "
+"thread"
+
+#: ../src/unix/utilsunx.cpp:340
+msgid "Impossible to get child process input"
+msgstr "Impossível obter a entrada do processo filho"
+
+#: ../src/unix/utilsunx.cpp:390
+msgid "Can't write to child process's stdin"
+msgstr "Não consegue gravar como processo criança do stdin"
+
+#: ../src/unix/utilsunx.cpp:644
+#, c-format
+msgid "Failed to execute '%s'\n"
+msgstr "Falhou em executar o '%s'\n"
+
+#: ../src/unix/utilsunx.cpp:678
+msgid "Fork failed"
+msgstr "A bifurcação falhou"
+
+#: ../src/unix/utilsunx.cpp:701
+msgid "Failed to set process priority"
+msgstr "Falhou em definir a prioridade do processo"
+
+#: ../src/unix/utilsunx.cpp:712
+msgid "Failed to redirect child process input/output"
+msgstr "Falhou em redirecionar a entrada/saída do processo filho"
+
+#: ../src/unix/utilsunx.cpp:816
+msgid "Failed to set up non-blocking pipe, the program might hang."
+msgstr "Falhou em configurar o pipe não-bloqueador, o programa poderia travar."
+
+#: ../src/unix/utilsunx.cpp:1023
+msgid "Cannot get the hostname"
+msgstr "Não consegue obter o nome do host"
+
+#: ../src/unix/utilsunx.cpp:1059
+msgid "Cannot get the official hostname"
+msgstr "Não consegue obter o nome oficial do host"
+
+#: ../src/unix/wakeuppipe.cpp:49
+msgid "Failed to create wake up pipe used by event loop."
+msgstr "Falhou em criar o wake up pipe usado pelo loop de eventos."
+
+#: ../src/unix/wakeuppipe.cpp:56
+msgid "Failed to switch wake up pipe to non-blocking mode"
+msgstr "Falhou em trocar o wake up pipe para o modo não bloqueador"
+
+#: ../src/unix/wakeuppipe.cpp:117
+msgid "Failed to read from wake-up pipe"
+msgstr "Falhou em ler do wake-up pipe"
+
+#: ../src/x11/app.cpp:124
+#, c-format
+msgid "Invalid geometry specification '%s'"
+msgstr "Inválida a especificação da geometria '%s'"
+
+#: ../src/x11/app.cpp:167
+msgid "wxWidgets could not open display. Exiting."
+msgstr "O wxWidgets não pôde abrir a tela. Saindo."
+
+#: ../src/x11/utils.cpp:169
+#, c-format
+msgid "Failed to close the display \"%s\""
+msgstr "Falhou em fechar a exibição \"%s\""
+
+#: ../src/x11/utils.cpp:188
+#, c-format
+msgid "Failed to open display \"%s\"."
+msgstr "Falhou em abrir a exibição \"%s\"."
+
+#: ../src/xml/xml.cpp:868
+#, c-format
+msgid "XML parsing error: '%s' at line %d"
+msgstr "Erro de análise do XML: '%s' na linha %d"
+
+#: ../src/xrc/xh_propgrid.cpp:239
+#, c-format
+msgid "Page %i"
+msgstr "Página %i"
+
+#: ../src/xrc/xmlres.cpp:448
+#, c-format
+msgid "Cannot load resources from '%s'."
+msgstr "Não consegue carregar os recursos de '%s'."
+
+#: ../src/xrc/xmlres.cpp:799
+#, c-format
+msgid "Cannot open resources file '%s'."
+msgstr "Não consegue abrir os recursos de '%s'."
+
+#: ../src/xrc/xmlres.cpp:806
+#, c-format
+msgid "Cannot load resources from file '%s'."
+msgstr "Não consegue carregar os recursos do arquivo '%s'."
+
+#: ../src/xrc/xmlres.cpp:2767
+#, c-format
+msgid "Creating %s \"%s\" failed."
+msgstr "Falhou em criar %s \"%s\"."
+
+#~ msgctxt "keyboard key"
+#~ msgid "Alt+"
+#~ msgstr "Alt+"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Ctrl+"
+#~ msgstr "Ctrl+"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Shift+"
+#~ msgstr "Shift+"
+
+#~ msgctxt "keyboard key"
+#~ msgid "RawCtrl+"
+#~ msgstr "RawCtrl+"
+
+#, c-format
+#~ msgid "BMP: header has biClrUsed=%d when biBitCount=%d."
+#~ msgstr "BMP: o cabeçalho tem biClrUsed=%d quando o biBitCount=%d."
+
+#~| msgid "ctrl"
+#~ msgctxt "keyboard key"
+#~ msgid "ctrl"
+#~ msgstr "ctrl"
+
+#~| msgid "alt"
+#~ msgctxt "keyboard key"
+#~ msgid "alt"
+#~ msgstr "alt"
+
+#~| msgid "shift"
+#~ msgctxt "keyboard key"
+#~ msgid "shift"
+#~ msgstr "shift"
+
+#~| msgid "rawctrl"
+#~ msgctxt "keyboard key"
+#~ msgid "rawctrl"
+#~ msgstr "rawctrl"
+
+#~ msgid "Copying more than one selected block to clipboard is not supported."
+#~ msgstr ""
+#~ "Não é suportado copiar mais do que um bloco selecionado pra área de "
+#~ "trabalho."
+
+#~ msgid "Unsupported clipboard format."
+#~ msgstr "Formato da área de transferência não suportado."
+
+#~ msgid "Background colour"
+#~ msgstr "Côr do 2º plano"
+
+#~ msgid "Font:"
+#~ msgstr "Fonte:"
+
+#~ msgid "Size:"
+#~ msgstr "Tamanho:"
+
+#~ msgid "The font size in points."
+#~ msgstr "O tamanho da fonte em pontos."
+
+#~ msgid "Style:"
+#~ msgstr "Estilo:"
+
+#~ msgid "Check to make the font bold."
+#~ msgstr "Marque pra fazer a fonte ficar em negrito."
+
+#~ msgid "Check to make the font italic."
+#~ msgstr "Marque pra fazer a fonte ficar em itálico."
+
+#~ msgid "Check to make the font underlined."
+#~ msgstr "Marque pra fazer a fonte ficar sublinhada."
+
+#~ msgid "Colour:"
+#~ msgstr "Côr:"
+
+#~ msgid "Click to change the font colour."
+#~ msgstr "Clique pra mudar a côr da fonte."
+
+#~ msgid "Shows a preview of the font."
+#~ msgstr "Mostra uma pré-visualização da fonte."
+
+#~ msgid "Click to cancel changes to the font."
+#~ msgstr "Clique pra cancelar as mudanças na fonte."
+
+#~ msgid "Click to confirm changes to the font."
+#~ msgstr "Clique pra confirmar as mudanças na fonte."
+
+#~ msgid "<Any>"
+#~ msgstr "<Qualquer>"
+
+#~ msgid "<Any Roman>"
+#~ msgstr "<Qualquer Romano>"
+
+#~ msgid "<Any Decorative>"
+#~ msgstr "<Qualquer Decorativo>"
+
+#~ msgid "<Any Modern>"
+#~ msgstr "<Qualquer Moderno>"
+
+#~ msgid "<Any Script>"
+#~ msgstr "<Qualquer Script>"
+
+#~ msgid "<Any Swiss>"
+#~ msgstr "<Qualquer Suíço>"
+
+#~ msgid "<Any Teletype>"
+#~ msgstr "<Qualquer Teletipo>"
+
+#~ msgid "Printing "
+#~ msgstr "Imprimindo "
+
+#~ msgid "conversion to 8-bit encoding failed"
+#~ msgstr "conversão para a codificação de 8 bits falhou"
+
+#~ msgid "Failed to insert text in the control."
+#~ msgstr "Falhou em inserir o texto no controle."
+
+#~ msgid "Please choose a valid font."
+#~ msgstr "Por favor escolha uma fonte válida."
+
+#, c-format
+#~ msgid "Failed to display HTML document in %s encoding"
+#~ msgstr "Falhou em exibir o documento em HTML na codificação %s"
+
+#, c-format
+#~ msgid "wxWidgets could not open display for '%s': exiting."
+#~ msgstr "O wxWidgets não pôde abrir a tela pro '%s': saindo."
+
+#~ msgid "Filter"
+#~ msgstr "Filtro"
+
+#~ msgid "Directories"
+#~ msgstr "Diretórios"
+
+#~ msgid "Files"
+#~ msgstr "Arquivos"
+
+#~ msgid "Selection"
+#~ msgstr "Seleção"
+
+#~ msgid "failed to retrieve execution result"
+#~ msgstr "falhou em recuperar o resultado da execução"
+
+#~ msgid " (while overwriting an existing item)"
+#~ msgstr " (enquanto sobrescrevendo um item existente)"
+
+#~ msgid "&Save as"
+#~ msgstr "&Salvar como"
+
+#, c-format
+#~ msgid "'%s' doesn't consist only of valid characters"
+#~ msgstr "'%s' não consiste apenas de caracteres válidos"
+
+#, c-format
+#~ msgid "'%s' should be numeric."
+#~ msgstr "'%s' deve ser numérico."
+
+#, c-format
+#~ msgid "'%s' should only contain ASCII characters."
+#~ msgstr "'%s' deve conter apenas caracteres ASCII."
+
+#, c-format
+#~ msgid "'%s' should only contain alphabetic characters."
+#~ msgstr "'%s' deve conter apenas caracteres alfabéticos."
+
+#, c-format
+#~ msgid "'%s' should only contain alphabetic or numeric characters."
+#~ msgstr "'%s' deve conter apenas caracteres alfabéticos ou numéricos."
+
+#, c-format
+#~ msgid "'%s' should only contain digits."
+#~ msgstr "'%s' deve conter apenas dígitos."
+
+#, c-format
+#~ msgid "Can't create window of class %s"
+#~ msgstr "Não consegue criar a janela da classe %s"
+
+#~ msgid "Couldn't create the overlay window"
+#~ msgstr "Não pôde criar a janela do overlay"
+
+#~ msgid "Couldn't init the context on the overlay window"
+#~ msgstr "Não pôde inicializar o contexto na janela do overlay"
+
+#, c-format
+#~ msgid "Failed to convert file \"%s\" to Unicode."
+#~ msgstr "Falhou em converter o arquivo \"%s\" para o Unicode."
+
+#~ msgid "Failed to set text in the text control."
+#~ msgstr "Falhou em definir o texto no controle de texto."
+
+#, c-format
+#~ msgid "Invalid GTK+ command line option, use \"%s --help\""
+#~ msgstr "Opção da linha de comando do GTK+ inválida, use \"%s --help\""
+
+#~ msgid "No unused colour in image."
+#~ msgstr "Nenhuma côr sem uso na imagem."
+
+#~ msgid "Not available"
+#~ msgstr "Não disponível"
+
+#~ msgid "Replace selection"
+#~ msgstr "Substituir a seleção"
+
+#~ msgid "Save as"
+#~ msgstr "Salvar como"
+
+#~ msgid "Style Organiser"
+#~ msgstr "Organizador de Estilos"
+
+#~ msgid "The following standard GTK+ options are also supported:\n"
+#~ msgstr "As seguintes opções padrão do GTK+ também são suportadas:\n"
+
+#~ msgid "You cannot Clear an overlay that is not inited"
+#~ msgstr "Você não pode limpar um overlay que não está iniciado"
+
+#~ msgid "You cannot Init an overlay twice"
+#~ msgstr "Você não pode iniciar um overlay duas vezes"
+
+#, c-format
+#~ msgid "locale '%s' cannot be set."
+#~ msgstr "o idioma '%s' não pode ser definido."
+
+#~ msgid "Adding flavor TEXT failed"
+#~ msgstr "Falhou em adicionar o sabor TEXT"
+
+#~ msgid "Adding flavor utxt failed"
+#~ msgstr "Falhou em adicionar o sabor utxt"
+
+#~ msgid "Bitmap renderer cannot render value; value type: "
+#~ msgstr ""
+#~ "O renderizador do bitmap não pode renderizar o valor; tipo de valor:"
+
+#~ msgid ""
+#~ "Cannot create new column's ID. Probably max. number of columns reached."
+#~ msgstr ""
+#~ "Não consegue criar a ID da nova coluna. Provavelmente o nº máx. de "
+#~ "colunas foi alcançado."
+
+#~ msgid "Column could not be added."
+#~ msgstr "A coluna não pôde ser adicionada."
+
+#~ msgid "Column index not found."
+#~ msgstr "Índice da coluna não achado."
+
+#~ msgid "Column width could not be determined"
+#~ msgstr "A largura da coluna não pôde ser determinada"
+
+#~ msgid "Column width could not be set."
+#~ msgstr "A largura da coluna não pôde ser definida."
+
+#~ msgid "Confirm registry update"
+#~ msgstr "Confirmar a atualização do registro"
+
+#~ msgid "Could not determine column index."
+#~ msgstr "Não pôde determinar o índice da coluna."
+
+#~ msgid "Could not determine column's position"
+#~ msgstr "Não pôde determinar a posição da coluna"
+
+#~ msgid "Could not determine number of columns."
+#~ msgstr "Não pôde determinar o número de colunas."
+
+#~ msgid "Could not determine number of items"
+#~ msgstr "Não pôde determinar o número de itens"
+
+#~ msgid "Could not get header description."
+#~ msgstr "Não pôde obter a descrição do cabeçalho."
+
+#~ msgid "Could not get items."
+#~ msgstr "Não pôde obter os itens."
+
+#~ msgid "Could not get property flags."
+#~ msgstr "Não pôde obter as bandeiras da propriedade."
+
+#~ msgid "Could not get selected items."
+#~ msgstr "Não pôde obter os itens selecionados."
+
+#~ msgid "Could not remove column."
+#~ msgstr "Não pôde remover a coluna."
+
+#~ msgid "Could not retrieve number of items"
+#~ msgstr "Não pôde recuperar o número de itens"
+
+#~ msgid "Could not set column width."
+#~ msgstr "Não pôde definir a largura da coluna."
+
+#~ msgid "Could not set header description."
+#~ msgstr "Não pôde definir a descrição do cabeçalho."
+
+#~ msgid "Could not set icon."
+#~ msgstr "Não pôde definir o ícone."
+
+#~ msgid "Could not set maximum width."
+#~ msgstr "Não pôde definir a largura máxima."
+
+#~ msgid "Could not set minimum width."
+#~ msgstr "Não pôde definir a largura mínima."
+
+#~ msgid "Could not set property flags."
+#~ msgstr "Não pôde definir as bandeiras da propriedade."
+
+#~ msgid "Data object has invalid data format"
+#~ msgstr "Objeto dos dados tem o formato dos dados inválido"
+
+#~ msgid "Date renderer cannot render value; value type: "
+#~ msgstr "O renderizador da data não pode renderizar o valor; tipo de valor:"
+
+#~ msgid ""
+#~ "Do you want to overwrite the command used to %s files with extension "
+#~ "\"%s\" ?\n"
+#~ "Current value is \n"
+#~ "%s, \n"
+#~ "New value is \n"
+#~ "%s %1"
+#~ msgstr ""
+#~ "Você quer sobrescrever o comando usado para %s arquivos com a extensão "
+#~ "\"%s\" ?\n"
+#~ "O valor atual é \n"
+#~ "%s, \n"
+#~ "O novo valor é \n"
+#~ "%s %1"
+
+#~ msgid "Failed to retrieve data from the clipboard."
+#~ msgstr "Falhou em recuperar os dados da área de transferência."
+
+#~ msgid "GIF: Invalid gif index."
+#~ msgstr "GIF: Índice do gif inválido."
+
+#~ msgid "GIF: unknown error!!!"
+#~ msgstr "GIF: erro desconhecido!!!"
+
+#~ msgid "Icon & text renderer cannot render value; value type: "
+#~ msgstr ""
+#~ "Renderizador de ícone & texto não pode renderizar o valor; tipo de valor:"
+
+#~ msgid "New directory"
+#~ msgstr "Novo diretório"
+
+#~ msgid "Next"
+#~ msgstr "&Próximo"
+
+#~ msgid "No column existing."
+#~ msgstr "Nenhuma coluna existente."
+
+#~ msgid "No column for the specified column existing."
+#~ msgstr "Nenhuma coluna para a coluna especificada existente."
+
+#~ msgid "No column for the specified column position existing."
+#~ msgstr "Nenhuma coluna para a posição da coluna especificada existente."
+
+#~ msgid ""
+#~ "No renderer or invalid renderer type specified for custom data column."
+#~ msgstr ""
+#~ "Nenhum renderizador ou tipo de renderizador inválido especificado para a "
+#~ "coluna de dados personalizada."
+
+#~ msgid "No renderer specified for column."
+#~ msgstr "Nenhum renderizador especificado para a coluna."
+
+#~ msgid "Number of columns could not be determined."
+#~ msgstr "O número de colunas não pôde ser determinado."
+
+#~ msgid "OpenGL function \"%s\" failed: %s (error %d)"
+#~ msgstr "A função do OpenGL \"%s\" falhou: %s (erro %d)"
+
+#~ msgid ""
+#~ "Please install a newer version of comctl32.dll\n"
+#~ "(at least version 4.70 is required but you have %d.%02d)\n"
+#~ "or this program won't operate correctly."
+#~ msgstr ""
+#~ "Por favor instale uma versão mais nova do comctl32.dll\n"
+#~ "(no mínimo a versão 4.70 é requerida mas você tem %d.%02d)\n"
+#~ "ou este programa não operará corretamente."
+
+#~ msgid "Pointer to data view control not set correctly."
+#~ msgstr ""
+#~ "Ponteiro para o controle da visualização dos dados não definido "
+#~ "corretamente."
+
+#~ msgid "Pointer to model not set correctly."
+#~ msgstr "Ponteiro para o modelo não definido corretamente."
+
+#~ msgid "Progress renderer cannot render value type; value type: "
+#~ msgstr ""
+#~ "O renderizador do progresso não pode renderizar o tipo de valor; tipo de "
+#~ "valor:"
+
+#~ msgid "Rendering failed."
+#~ msgstr "A renderização falhou."
+
+#~ msgid ""
+#~ "Setting directory access times is not supported under this OS version"
+#~ msgstr ""
+#~ "Configurar os tempos de acesso do diretório não é suportado por esta "
+#~ "versão do SO"
+
+#~ msgid "Show hidden directories"
+#~ msgstr "Mostrar diretórios ocultos"
+
+#~ msgid "Text renderer cannot render value; value type: "
+#~ msgstr "O renderizador de texto não pode renderizar o valor; tipo de valor:"
+
+#~ msgid "There is no column or renderer for the specified column index."
+#~ msgstr "Não há coluna ou renderizador para o índice da coluna especificado."
+
+#~ msgid ""
+#~ "This system doesn't support date controls, please upgrade your version of "
+#~ "comctl32.dll"
+#~ msgstr ""
+#~ "Este sistema não suporta os controles de data, por favor atualize sua "
+#~ "versão do comctl32.dll"
+
+#~ msgid "Toggle renderer cannot render value; value type: "
+#~ msgstr "O renderizador ativado não pode renderizar o valor; tipo de valor:"
+
+#~ msgid "Too many colours in PNG, the image may be slightly blurred."
+#~ msgstr "Cores demais no PNG; a imagem pode ficar levemente borrada."
+
+#~ msgid "Unable to handle native drag&drop data"
+#~ msgstr "Incapaz de manejar o arrastar&soltar dos dados nativos"
+
+#~ msgid "Unable to initialize Hildon program"
+#~ msgstr "Incapaz de inicializar o programa Hildon"
+
+#~ msgid "Unknown data format"
+#~ msgstr "Formato dos dados desconhecido"
+
+#~ msgid "Valid pointer to native data view control does not exist"
+#~ msgstr ""
+#~ "O ponteiro válido pro controle de visualização dos dados nativos não "
+#~ "existe"
+
+#~ msgid "Win32s on Windows 3.1"
+#~ msgstr "Win32s no Windows 3.1"
+
+#~ msgid "Windows 10"
+#~ msgstr "Windows 10"
+
+#~ msgid "Windows 2000"
+#~ msgstr "Windows 2000"
+
+#~ msgid "Windows 7"
+#~ msgstr "Windows 7"
+
+#~ msgid "Windows 8"
+#~ msgstr "Windows 8"
+
+#~ msgid "Windows 8.1"
+#~ msgstr "Windows 8.1"
+
+#~ msgid "Windows 95"
+#~ msgstr "Windows 95"
+
+#~ msgid "Windows 95 OSR2"
+#~ msgstr "Windows 95 OSR2"
+
+#~ msgid "Windows 98"
+#~ msgstr "Windows 98"
+
+#~ msgid "Windows 98 SE"
+#~ msgstr "Windows 98 SE"
+
+#~ msgid "Windows 9x (%d.%d)"
+#~ msgstr "Windows 9x (%d %d)"
+
+#~ msgid "Windows CE (%d.%d)"
+#~ msgstr "Windows CE (%d %d)"
+
+#~ msgid "Windows ME"
+#~ msgstr "Windows ME"
+
+#~ msgid "Windows NT %lu.%lu"
+#~ msgstr "Windows NT %lu.%lu"
+
+#~ msgid "Windows Server 10"
+#~ msgstr "Windows Server 10"
+
+#~ msgid "Windows Server 2003"
+#~ msgstr "Windows Server 2003"
+
+#~ msgid "Windows Server 2008"
+#~ msgstr "Windows Server 2008"
+
+#~ msgid "Windows Server 2008 R2"
+#~ msgstr "Windows Server 2008 R2"
+
+#~ msgid "Windows Server 2012"
+#~ msgstr "Windows Server 2012"
+
+#~ msgid "Windows Server 2012 R2"
+#~ msgstr "Windows Server 2012 R2"
+
+#~ msgid "Windows Vista"
+#~ msgstr "Windows Vista"
+
+#~ msgid "Windows XP"
+#~ msgstr "Windows XP"
+
+#~ msgid "can't execute '%s'"
+#~ msgstr "não pode executar '%s'"
+
+#~ msgid "error opening '%s'"
+#~ msgstr "erro ao abrir '%s'"
+
+#~ msgid "unknown seek origin"
+#~ msgstr "origem da busca desconhecida"
+
+#~ msgid "wxWidget control pointer is not a data view pointer"
+#~ msgstr ""
+#~ "O ponteiro do controle do wxWidget não é um ponteiro de visualização dos "
+#~ "dados"
+
+#~ msgid "wxWidget's control not initialized."
+#~ msgstr "Controle do wxWidgets não inicializado."
+
+#~ msgid "ADD"
+#~ msgstr "ADICIONAR"
+
+#~ msgid "BACK"
+#~ msgstr "BACK"
+
+#~ msgid "CANCEL"
+#~ msgstr "CANCELAR"
+
+#~ msgid "CAPITAL"
+#~ msgstr "MAIÚSCULAS"
+
+#~ msgid "CLEAR"
+#~ msgstr "LIMPAR"
+
+#~ msgid "COMMAND"
+#~ msgstr "COMANDO"
+
+#~ msgid "Cannot create mutex."
+#~ msgstr "Não pôde criar o mutex."
+
+#~ msgid "Cannot resume thread %lu"
+#~ msgstr "Não pôde resumir o thread %lu"
+
+#~ msgid "Cannot suspend thread %lu"
+#~ msgstr "Não pôde suspender o thread %lu"
+
+#~ msgid "Couldn't acquire a mutex lock"
+#~ msgstr "Não pôde adquirir uma tranca mutex"
+
+#~ msgid "Couldn't get hatch style from wxBrush."
+#~ msgstr "Não pôde obter o estilo hatch do wxBrush."
+
+#~ msgid "Couldn't release a mutex"
+#~ msgstr "Não pôde liberar um mutex"
+
+#~ msgid "DECIMAL"
+#~ msgstr "DECIMAL"
+
+#~ msgid "DEL"
+#~ msgstr "DEL"
+
+#~ msgid "DELETE"
+#~ msgstr "APAGAR"
+
+#~ msgid "DIVIDE"
+#~ msgstr "DIVIDIR"
+
+#~ msgid "DOWN"
+#~ msgstr "PARA_BAIXO"
+
+#~ msgid "END"
+#~ msgstr "END"
+
+#~ msgid "ENTER"
+#~ msgstr "ENTER"
+
+#~ msgid "ESC"
+#~ msgstr "ESC"
+
+#~ msgid "ESCAPE"
+#~ msgstr "ESCAPE"
+
+#~ msgid "EXECUTE"
+#~ msgstr "EXECUTAR"
+
+#~ msgid "Event queue overflowed"
+#~ msgstr "Fila do evento sobrecarregada"
+
+#~ msgid "Execution of command '%s' failed with error: %ul"
+#~ msgstr "A execução do comando '%s' falhou com o erro: %ul"
+
+#~ msgid ""
+#~ "File '%s' already exists.\n"
+#~ "Do you want to replace it?"
+#~ msgstr ""
+#~ "O arquivo '%s' já existe.\n"
+#~ "Você quer substituí-lo?"
+
+#~ msgid "HELP"
+#~ msgstr "AJUDA"
+
+#~ msgid "HOME"
+#~ msgstr "HOME"
+
+#~ msgid "INS"
+#~ msgstr "INS"
+
+#~ msgid "INSERT"
+#~ msgstr "INSERT"
+
+#~ msgid "KP_BEGIN"
+#~ msgstr "KP_BEGIN"
+
+#~ msgid "KP_DECIMAL"
+#~ msgstr "KP_DECIMAL"
+
+#~ msgid "KP_DELETE"
+#~ msgstr "KP_DELETE"
+
+#~ msgid "KP_DIVIDE"
+#~ msgstr "KP_DIVIDE"
+
+#~ msgid "KP_DOWN"
+#~ msgstr "KP_DOWN"
+
+#~ msgid "KP_ENTER"
+#~ msgstr "KP_ENTER"
+
+#~ msgid "KP_EQUAL"
+#~ msgstr "KP_EQUAL"
+
+#~ msgid "KP_HOME"
+#~ msgstr "KP_HOME"
+
+#~ msgid "KP_INSERT"
+#~ msgstr "KP_INSERT"
+
+#~ msgid "KP_LEFT"
+#~ msgstr "KP_LEFT"
+
+#~ msgid "KP_MULTIPLY"
+#~ msgstr "KP_MULTIPLY"
+
+#~ msgid "KP_NEXT"
+#~ msgstr "KP_NEXT"
+
+#~ msgid "KP_PAGEDOWN"
+#~ msgstr "KP_PAGEDOWN"
+
+#~ msgid "KP_PAGEUP"
+#~ msgstr "KP_PAGEUP"
+
+#~ msgid "KP_PRIOR"
+#~ msgstr "KP_PRIOR"
+
+#~ msgid "KP_RIGHT"
+#~ msgstr "KP_RIGHT"
+
+#~ msgid "KP_SEPARATOR"
+#~ msgstr "KP_SEPARATOR"
+
+#~ msgid "KP_SPACE"
+#~ msgstr "KP_SPACE"
+
+#~ msgid "KP_SUBTRACT"
+#~ msgstr "KP_SUBTRACT"
+
+#~ msgid "LEFT"
+#~ msgstr "ESQUERDA"
+
+#~ msgid "MENU"
+#~ msgstr "MENU"
+
+#~ msgid "NUM_LOCK"
+#~ msgstr "NUM_LOCK"
+
+#~ msgid "PAGEDOWN"
+#~ msgstr "PAGEDOWN"
+
+#~ msgid "PAGEUP"
+#~ msgstr "PAGEUP"
+
+#~ msgid "PAUSE"
+#~ msgstr "PAUSE"
+
+#~ msgid "PGDN"
+#~ msgstr "PGDN"
+
+#~ msgid "PGUP"
+#~ msgstr "PGUP"
+
+#~ msgid "PRINT"
+#~ msgstr "PRINT"
+
+#~ msgid "RETURN"
+#~ msgstr "RETURN"
+
+#~ msgid "RIGHT"
+#~ msgstr "RIGHT"
+
+#~ msgid "SCROLL_LOCK"
+#~ msgstr "SCROLL_LOCK"
+
+#~ msgid "SELECT"
+#~ msgstr "SELECT"
+
+#~ msgid "SEPARATOR"
+#~ msgstr "SEPARATOR"
+
+#~ msgid "SNAPSHOT"
+#~ msgstr "SNAPSHOT"
+
+#~ msgid "SPACE"
+#~ msgstr "SPACE"
+
+#~ msgid "SUBTRACT"
+#~ msgstr "SUBTRACT"
+
+#~ msgid "TAB"
+#~ msgstr "TAB"
+
+#~ msgid "The print dialog returned an error."
+#~ msgstr "O diálogo da impressão retornou um erro."
+
+#~ msgid "The wxGtkPrinterDC cannot be used."
+#~ msgstr "O wxGtkPrinterDC não pode ser usado."
+
+#~ msgid "Timer creation failed."
+#~ msgstr "A criação do timer falhou."
+
+#~ msgid "UP"
+#~ msgstr "UP"
+
+#~ msgid "WINDOWS_LEFT"
+#~ msgstr "WINDOWS_LEFT"
+
+#~ msgid "WINDOWS_MENU"
+#~ msgstr "WINDOWS_MENU"
+
+#~ msgid "WINDOWS_RIGHT"
+#~ msgstr "WINDOWS_RIGHT"
+
+#~ msgid "buffer is too small for Windows directory."
+#~ msgstr "o buffer é muito pequeno para o diretório do Windows"
+
+#~ msgid "not implemented"
+#~ msgstr "não implementado"
+
+#~ msgid "percent"
+#~ msgstr "por cento"
+
+#~ msgid "wxPrintout::GetPageInfo gives a null maxPage."
+#~ msgstr "wxPrintout::GetPageInfo dá um maxPage nulo."
+
+#~ msgid "Print preview"
+#~ msgstr "Pré-visualização da impressão"
+
+#~ msgid "'"
+#~ msgstr "'"
+
+#~ msgid "1"
+#~ msgstr "1"
+
+#~ msgid "10"
+#~ msgstr "10"
+
+#~ msgid "3"
+#~ msgstr "3"
+
+#~ msgid "4"
+#~ msgstr "4"
+
+#~ msgid "5"
+#~ msgstr "5"
+
+#~ msgid "6"
+#~ msgstr "6"
+
+#~ msgid "7"
+#~ msgstr "7"
+
+#~ msgid "8"
+#~ msgstr "8"
+
+#~ msgid "9"
+#~ msgstr "9"
+
+#~ msgid "Can't monitor non-existent path \"%s\" for changes."
+#~ msgstr "Não consegue monitorar o caminho não-existente \"%s\" por mudanças."
+
+#~ msgid "File system containing watched object was unmounted"
+#~ msgstr "O sistema de arquivos contendo o objeto observado foi desmontado"
+
+#~ msgid "&Preview..."
+#~ msgstr "&Pré-visualização..."
+
+#~ msgid "Preview..."
+#~ msgstr "Pré-visualização..."
+
+#~ msgid "The vertical offset relative to the paragraph."
+#~ msgstr "O offset vertical relativo ao parágrafo."
+
+#~ msgid "Units for the object offset."
+#~ msgstr "Unidades para o offset do objeto."
+
+#~ msgid "&About..."
+#~ msgstr "&Sobre..."
+
+#~ msgid "&Save..."
+#~ msgstr "&Salvar..."
+
+#~ msgid "About "
+#~ msgstr "Sobre"
+
+#~ msgid "All files (*.*)|*"
+#~ msgstr "Todos os arquivos (*.*)|*"
+
+#~ msgid "Cannot initialize SciTech MGL!"
+#~ msgstr "Não pode inicializar o SciTech MGL!"
+
+#~ msgid "Cannot initialize display."
+#~ msgstr "Não pode inicializar a exibição."
+
+#~ msgid "Cannot start thread: error writing TLS"
+#~ msgstr "Não pode iniciar o thread: erro ao escrever o TLS"
+
+#~ msgid "Close\tAlt-F4"
+#~ msgstr "Fechar\tAlt-F4"
+
+#~ msgid "Couldn't create cursor."
+#~ msgstr "Não pôde criar o cursor."
+
+#~ msgid "Directory '%s' doesn't exist!"
+#~ msgstr "O diretório '%s' não existe!"
+
+#~ msgid "Mode %ix%i-%i not available."
+#~ msgstr "Modo %ix%i-%i não disponível."
+
+#~ msgid "Paper Size"
+#~ msgstr "Tamanho do Papel"
+
+#~ msgid "%.*f GB"
+#~ msgstr "%.*f GB"
+
+#~ msgid "%.*f MB"
+#~ msgstr "%.*f MB"
+
+#~ msgid "%.*f TB"
+#~ msgstr "%.*f TB"
+
+#~ msgid "%.*f kB"
+#~ msgstr "%.*f kB"
+
+#~ msgid "%s B"
+#~ msgstr "%s B"
+
+#~ msgid "&Goto..."
+#~ msgstr "&Ir para..."
+
+#~ msgid "<<"
+#~ msgstr "<<"
+
+#~ msgid ">>"
+#~ msgstr ">>"
+
+#~ msgid ">>|"
+#~ msgstr ">>|"
+
+#~ msgid "Added item is invalid."
+#~ msgstr "O item adicionado é inválido."
+
+#~ msgid "Archive doesnt contain #SYSTEM file"
+#~ msgstr "O arquivo não contém o arquivo #SYSTEM"
+
+#~ msgid "BIG5"
+#~ msgstr "BIG5"
+
+#~ msgid "Can't check image format of file '%s': file does not exist."
+#~ msgstr ""
+#~ "Não pode verificar o formato da imagem do arquivo '%s': o arquivo não "
+#~ "existe."
+
+#~ msgid "Can't load image from file '%s': file does not exist."
+#~ msgstr "Não pode carregar a imagem do arquivo '%s': o arquivo não existe."
+
+#~ msgid "Cannot convert dialog units: dialog unknown."
+#~ msgstr "Não pode converter as unidades do diálogo: diálogo desconhecido."
+
+#~ msgid "Cannot convert from the charset '%s'!"
+#~ msgstr "Não pode converter do conjunto de caracteres '%s'!"
+
+#~ msgid "Cannot find container for unknown control '%s'."
+#~ msgstr "Não pode achar o recipiente para o controle desconhecido '%s'."
+
+#~ msgid "Cannot find font node '%s'."
+#~ msgstr "Não pode achar o node da fonte '%s'."
+
+#~ msgid "Cannot open file '%s'."
+#~ msgstr "Não pode abrir o arquivo '%s'."
+
+#~ msgid "Cannot parse coordinates from '%s'."
+#~ msgstr "Não pode analisar as coordenadas de '%s'."
+
+#~ msgid "Cannot parse dimension from '%s'."
+#~ msgstr "Não pode analisar a dimensão de '%s'."
+
+#~ msgid "Cant create the thread event queue"
+#~ msgstr "Não pode criar a fila de eventos do thread"
+
+#~ msgid "Changed item is invalid."
+#~ msgstr "O item mudado é inválido."
+
+#~ msgid "Click to cancel this window."
+#~ msgstr "Clique para cancelar esta janela."
+
+#~ msgid "Click to confirm your selection."
+#~ msgstr "Clique para confirmar a sua seleção."
+
+#~ msgid "Column does not have a renderer."
+#~ msgstr "A coluna não tem um renderizador."
+
+#~ msgid "Column pointer must not be NULL."
+#~ msgstr "O ponteiro da coluna não dever ser NULO."
+
+#~ msgid "Column's model column has no equivalent in the associated model."
+#~ msgstr "A coluna modelo da coluna não tem equivalente no modelo associado."
+
+#~ msgid "Control is wrongly initialized."
+#~ msgstr "O controle foi inicializado erroneamente."
+
+#~ msgid "Could not add column to internal structures."
+#~ msgstr "Não pôde adicionar a coluna as estruturas internas."
+
+#~ msgid "Could not unlock mutex"
+#~ msgstr "Não pôde destrancar o mutex"
+
+#~ msgid "Data view control is not correctly initialized"
+#~ msgstr ""
+#~ "O controle da visualização dos dados não foi inicializado corretamente"
+
+#~ msgid "Error while waiting on semaphore"
+#~ msgstr "Erro enquanto esperando no semáforo"
+
+#~ msgid "Failed to create a status bar."
+#~ msgstr "Falhou em criar uma barra de status."
+
+#~ msgid "Failed to register OpenGL window class."
+#~ msgstr "Falhou em registrar a classe de janela do OpenGL."
+
+#~ msgid "Fatal error: "
+#~ msgstr "Erro fatal: "
+
+#~ msgid "GB-2312"
+#~ msgstr "GB-2312"
+
+#~ msgid "Go forward to the next HTML page"
+#~ msgstr "Ir adiante para a próxima página HTML"
+
+#~ msgid "Goto Page"
+#~ msgstr "Ir para a página"
+
+#~ msgid ""
+#~ "HTML pagination algorithm generated more than the allowed maximum number "
+#~ "of pages and it can't continue any longer!"
+#~ msgstr ""
+#~ "O algorítmo de paginação HTML gerou mais do que o número máximo de "
+#~ "páginas permitidas e não pode mais continuar!"
+
+#~ msgid "Help : %s"
+#~ msgstr "Ajuda : %s"
+
+#~ msgid "I64"
+#~ msgstr "I64"
+
+#~ msgid "Internal error, illegal wxCustomTypeInfo"
+#~ msgstr "Erro interno; wxCustomTypeInfo ilegal"
+
+#~ msgid "Invalid XRC resource '%s': doesn't have root node 'resource'."
+#~ msgstr "Recurso XRC '%s' inválido: não tem o node da raiz 'resource'."
+
+#~ msgid "No handler found for XML node '%s', class '%s'!"
+#~ msgstr "Nenhum manejador achado para o node XML '%s', classe '%s'!"
+
+#~ msgid "No image handler for type %ld defined."
+#~ msgstr "Nenhum manipulador de imagem para o tipo %ld definido."
+
+#~ msgid "No model associated with control."
+#~ msgstr "Nenhum modelo associado com o controle."
+
+#~ msgid "Owner not initialized."
+#~ msgstr "Proprietário não inicializado."
+
+#~ msgid "Passed item is invalid."
+#~ msgstr "O item passado é inválido."
+
+#~ msgid "Passing a already registered object to SetObjectName"
+#~ msgstr "Passando um objeto já registrado para o SetObjectName"
+
+#~ msgid "Preparing help window..."
+#~ msgstr "Preparando a janela de ajuda..."
+
+#~ msgid "Program aborted."
+#~ msgstr "Programa abortado."
+
+#~ msgid "Referenced object node with ref=\"%s\" not found!"
+#~ msgstr "Node do objeto referenciado com ref=\"%s\" não achado!"
+
+#~ msgid "Resource files must have same version number!"
+#~ msgstr "Os arquivos de recurso devem ter o mesmo número da versão!"
+
+#~ msgid "SHIFT-JIS"
+#~ msgstr "SHIFT-JIS"
+
+#~ msgid "Search!"
+#~ msgstr "Procurar!"
+
+#~ msgid "Sorry, could not open this file for saving."
+#~ msgstr "Lamento, não pôde abrir este arquivo para salvar."
+
+#~ msgid "Sorry, could not save this file."
+#~ msgstr "Lamento, não pude salvar este arquivo."
+
+#~ msgid "Sorry, print preview needs a printer to be installed."
+#~ msgstr ""
+#~ "Lamento, a pré-visualização da impressão precisa que uma impressora "
+#~ "esteja instalada."
+
+#~ msgid "Status: "
+#~ msgstr "Status: "
+
+#~ msgid ""
+#~ "Streaming delegates for not already streamed objects not yet supported"
+#~ msgstr "O streaming delega para objetos não já streamed ainda não suportado"
+
+#~ msgid "Subclass '%s' not found for resource '%s', not subclassing!"
+#~ msgstr ""
+#~ "Sub-classe '%s' não achada para o recurso '%s'; não sub-classificando!"
+
+#~ msgid "TIFF library error."
+#~ msgstr "Erro da biblioteca TIFF."
+
+#~ msgid "TIFF library warning."
+#~ msgstr "Aviso da biblioteca TIFF."
+
+#~ msgid ""
+#~ "The file '%s' couldn't be opened.\n"
+#~ "It has been removed from the most recently used files list."
+#~ msgstr ""
+#~ "O arquivo '%s' não pôde ser aberto.\n"
+#~ "Foi removido da lista dos arquivos mais usados recentemente."
+
+#~ msgid "The path '%s' contains too many \"..\"!"
+#~ msgstr "O caminho '%s' contém \"..\" demais!"
+
+#~ msgid "Trying to solve a NULL hostname: giving up"
+#~ msgstr "Tentandoe resolver um nome de host NULO: desistindo"
+
+#~ msgid "Unknown style flag "
+#~ msgstr "Bandeira do estilo desconhecida"
+
+#~ msgid "Warning"
+#~ msgstr "Aviso"
+
+#~ msgid "Windows 2000 (build %lu"
+#~ msgstr "Windows 2000 (build %lu)"
+
+#~ msgid "XRC resource '%s' (class '%s') not found!"
+#~ msgstr "Recurso XRC '%s' (classe '%s') não achado!"
+
+#~ msgid "XRC resource: Cannot create animation from '%s'."
+#~ msgstr "Recurso XRC: Não pode criar a animação de '%s'."
+
+#~ msgid "XRC resource: Cannot create bitmap from '%s'."
+#~ msgstr "Recurso XRC: Não pode criar o bitmap de '%s'."
+
+#~ msgid ""
+#~ "XRC resource: Incorrect colour specification '%s' for attribute '%s'."
+#~ msgstr ""
+#~ "Recurso XRC: Especificação das cores '%s' incorreta para o atributo '%s'."
+
+#~ msgid "[EMPTY]"
+#~ msgstr "[VAZIO]"
+
+#~ msgid "catalog file for domain '%s' not found."
+#~ msgstr "arquivo do catálogo para o domínio '%s' não achado."
+
+#~ msgid "delegate has no type info"
+#~ msgstr "o delegate não tem info sobre o tipo"
+
+#~ msgid "encoding %i"
+#~ msgstr "codificação %i"
+
+#~ msgid "looking for catalog '%s' in path '%s'."
+#~ msgstr "procurando pelo catálogo '%s' no caminho '%s'."
+
+#~ msgid "m_peer is not or incorrectly initialized"
+#~ msgstr "m_peer não está ou foi incorretamente inicializado"
+
+#~ msgid "wxRichTextFontPage"
+#~ msgstr "wxRichTextFontPage"
+
+#~ msgid "wxSearchEngine::LookFor must be called before scanning!"
+#~ msgstr "wxSearchEngine::LookFor deve ser chamado antes de escanear!"
+
+#~ msgid "wxSocket: invalid signature in ReadMsg."
+#~ msgstr "wxSocket: assinatura inválida em ReadMsg."
+
+#~ msgid "wxSocket: unknown event!."
+#~ msgstr "wxSocket: evento desconhecido!"
+
+#~ msgid "|<<"
+#~ msgstr "|<<"
+
+#~ msgid " Couldn't create the UnicodeConverter"
+#~ msgstr "Impossï¿½vel criar o UnicodeConverter"
+
+#~ msgid "#define %s must be an integer."
+#~ msgstr "#define %s deve ser um inteiro."
+
+#~ msgid "%s not a bitmap resource specification."
+#~ msgstr "%s nï¿½o ï¿½ uma especificaï¿½ï¿½o de um recurso de bitmap."
+
+#~ msgid "%s not an icon resource specification."
+#~ msgstr "%s nï¿½o ï¿½ uma especificaï¿½ï¿½o de um recurso de ï¿½cone."
+
+#~ msgid "%s: ill-formed resource file syntax."
+#~ msgstr "%s: sintaxe de arquivo de recurso mal-formada."
+
+#~ msgid "&Open"
+#~ msgstr "&Abrir"
+
+#~ msgid "&Print"
+#~ msgstr "&Imprimir"
+
+#~ msgid ""
+#~ ", expected static, #include or #define\n"
+#~ "while parsing resource."
+#~ msgstr ""
+#~ ", era esperado static, #include ou #define\n"
+#~ "durante anï¿½lise do recurso."
+
+#~ msgid "Bitmap resource specification %s not found."
+#~ msgstr "A especificaï¿½ï¿½o de recurso de bitmap %s nï¿½o foi encontrada."
+
+#~ msgid "Closes the dialog without inserting a symbol."
+#~ msgstr "Fecha o diï¿½logo sem inserir o sï¿½mbolo."
+
+#~ msgid ""
+#~ "Could not resolve control class or id '%s'. Use (non-zero) integer "
+#~ "instead\n"
+#~ " or provide #define (see manual for caveats)"
+#~ msgstr ""
+#~ "Controle da classe ou id '%s' nï¿½o resolvido. Use inteiros (diferentes "
+#~ "zero)\n"
+#~ " ou disponibilize um #define (veja o manual para precauï¿½ï¿½es)"
+
+#~ msgid ""
+#~ "Could not resolve menu id '%s'. Use (non-zero) integer instead\n"
+#~ "or provide #define (see manual for caveats)"
+#~ msgstr ""
+#~ "Nï¿½o foi possï¿½vel resolver id de menu '%s'. Use inteiros (diferentes "
+#~ "de zero)\n"
+#~ " ou disponibilize um #define (veja o manual para precauï¿½ï¿½es)"
+
+#~ msgid "Couldn't end the context on the overlay window"
+#~ msgstr "Impossï¿½vel finalizar o contexto na janela \"overlay\""
+
+#~ msgid "Expected '*' while parsing resource."
+#~ msgstr "Era esperado '*' durante a anï¿½lise do recurso."
+
+#~ msgid "Expected '=' while parsing resource."
+#~ msgstr "Era esperado '=' durante a anï¿½lise do recurso."
+
+#~ msgid "Expected 'char' while parsing resource."
+#~ msgstr "Era esperado 'char' durante a anï¿½lise do recurso."
+
+#~ msgid ""
+#~ "Failed to find XBM resource %s.\n"
+#~ "Forgot to use wxResourceLoadBitmapData?"
+#~ msgstr ""
+#~ "Nï¿½o foi possï¿½vel encontrar o recurso XBM %s.\n"
+#~ "Esqueceu-se de usar o wxResourceLoadBitmapData?"
+
+#~ msgid ""
+#~ "Failed to find XBM resource %s.\n"
+#~ "Forgot to use wxResourceLoadIconData?"
+#~ msgstr ""
+#~ "Nï¿½o foi possï¿½vel encontrar o recurso XBM %s.\n"
+#~ "Esqueceu-se de usar o wxResourceLoadIconData?"
+
+#~ msgid ""
+#~ "Failed to find XPM resource %s.\n"
+#~ "Forgot to use wxResourceLoadBitmapData?"
+#~ msgstr ""
+#~ "Nï¿½o foi possï¿½vel encontrar o recurso XPM %s.\n"
+#~ "Esqueceu-se de usar o wxResourceLoadBitmapData?"
+
+#~ msgid "Failed to get clipboard data."
+#~ msgstr "Falha ao obter dados da ï¿½rea de transferï¿½ncia."
+
+#~ msgid "Failed to load shared library '%s' Error '%s'"
+#~ msgstr "Falha ao carregar biblioteca compartilhada '%s' Erro '%s'"
+
+#~ msgid "Found "
+#~ msgstr "Encontrado"
+
+#~ msgid "Icon resource specification %s not found."
+#~ msgstr "Especificaï¿½ï¿½o de recurso de ï¿½cone '%s' nï¿½o encontrada."
+
+#~ msgid "Ill-formed resource file syntax."
+#~ msgstr "Sintaxe do arquivo de recursos mal-formada."
+
+#~ msgid "Inserts the chosen symbol."
+#~ msgstr "Insere o sï¿½mbolo escolhido."
+
+#~ msgid "Long Conversions not supported"
+#~ msgstr "Conversï¿½es do tipo \"long\" nï¿½o suportadas"
+
+#~ msgid "No XPM icon facility available!"
+#~ msgstr "ï¿½cones XPM ainda nï¿½o estï¿½o disponï¿½ves no wxWidgets!"
+
+#~ msgid "Option '%s' requires a value, '=' expected."
+#~ msgstr "Opï¿½ï¿½o '%s' precisa de um valor, '=' era esperado."
+
+#~ msgid "Select all"
+#~ msgstr "Selecionar &tudo"
+
+#~ msgid ""
+#~ "Sorry, docking is not supported for ports other than wxMSW, wxMac and "
+#~ "wxGTK"
+#~ msgstr ""
+#~ "O encaixamento sï¿½ ï¿½ suportado nas versï¿½es wxMSW, wxMac e wxGTK"
+
+#~ msgid "Unexpected end of file while parsing resource."
+#~ msgstr ""
+#~ "Fim de arquivo encontrado inesperadamento durante anï¿½lise do recurso."
+
+#~ msgid "Unrecognized style %s while parsing resource."
+#~ msgstr "Estilo %s nï¿½o foi reconhecido durante anï¿½lise do recurso."
+
+#~ msgid "Video Output"
+#~ msgstr "Saï¿½da de vï¿½deo"
+
+#~ msgid "Warning: attempt to remove HTML tag handler from empty stack."
+#~ msgstr ""
+#~ "Aviso: tentativa de remoï¿½ï¿½o de manipulador de tag HTML de uma pilha "
+#~ "vazia."
+
+#~ msgid "establish"
+#~ msgstr "estabelecer"
+
+#~ msgid "initiate"
+#~ msgstr "iniciar"
+
+#~ msgid "invalid eof() return value."
+#~ msgstr "valor de retorno de eof() invï¿½lido."
+
+#~ msgid "unknown line terminator"
+#~ msgstr "finalizador de linha desconhecido"
+
+#~ msgid "writing"
+#~ msgstr "gravando"
+
+#~ msgid "wxRichTextBulletsPage"
+#~ msgstr "wxRichTextBulletsPage"
+
+#~ msgid "wxRichTextListStylePage"
+#~ msgstr "wxRichTextListStylePage"
+
+#~ msgid "wxRichTextStylePage"
+#~ msgstr "wxRichTextStylePage"

--- a/po_wxstd/ro.po
+++ b/po_wxstd/ro.po
@@ -1,0 +1,10342 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: wxWidgets 3.3\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-05-14 20:23+0200\n"
+"PO-Revision-Date: \n"
+"Last-Translator: Cătălin Răceanu <cata_sr@yahoo.com>\n"
+"Language-Team: ro.ro\n"
+"Language: ro_RO\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=n==1 ? 0 : (n==0 || (n%100 > 0 && n%100 < "
+"20)) ? 1 : 2;\n"
+"X-Poedit-SourceCharset: utf-8\n"
+"X-Poedit-KeywordsList: _\n"
+"X-Generator: Poedit 3.6\n"
+
+#: ../include/wx/defs.h:2582
+msgid "All files (*.*)|*.*"
+msgstr "Toate fișierele (*.*)|*.*"
+
+#: ../include/wx/defs.h:2585
+msgid "All files (*)|*"
+msgstr "Toate fișierele (*)|*"
+
+#: ../include/wx/generic/progdlgg.h:85
+msgid "Elapsed time:"
+msgstr "Timp scurs:"
+
+#: ../include/wx/generic/progdlgg.h:86
+msgid "Estimated time:"
+msgstr "Timp estimat:"
+
+#: ../include/wx/generic/progdlgg.h:87
+msgid "Remaining time:"
+msgstr "Timp rămas:"
+
+#. TRANSLATORS: HTML printout default title.
+#: ../include/wx/html/htmprint.h:121 ../include/wx/prntbase.h:273
+#: ../include/wx/richtext/richtextprint.h:109 ../src/common/docview.cpp:2161
+msgid "Printout"
+msgstr "Tipărire"
+
+#. TRANSLATORS: HTML easy print default title.
+#: ../include/wx/html/htmprint.h:234 ../include/wx/richtext/richtextprint.h:163
+#: ../src/common/prntbase.cpp:522 ../src/html/htmprint.cpp:291
+msgid "Printing"
+msgstr "Tipărește"
+
+#: ../include/wx/msgdlg.h:277 ../src/common/stockitem.cpp:211
+msgid "Yes"
+msgstr "Da"
+
+#: ../include/wx/msgdlg.h:278 ../src/common/stockitem.cpp:182
+msgid "No"
+msgstr "Nu"
+
+#: ../include/wx/msgdlg.h:279 ../src/common/stockitem.cpp:183
+#: ../src/msw/msgdlg.cpp:430 ../src/msw/msgdlg.cpp:734
+#: ../src/richtext/richtextstyledlg.cpp:292
+msgid "OK"
+msgstr "OK"
+
+#: ../include/wx/msgdlg.h:280 ../src/common/stockitem.cpp:150
+#: ../src/msw/msgdlg.cpp:430 ../src/msw/progdlg.cpp:884
+#: ../src/richtext/richtextstyledlg.cpp:295
+msgid "Cancel"
+msgstr "Anulează"
+
+#: ../include/wx/msgdlg.h:281 ../src/common/stockitem.cpp:168
+#: ../src/html/helpdlg.cpp:63 ../src/html/helpfrm.cpp:108
+#: ../src/osx/button_osx.cpp:38
+msgid "Help"
+msgstr "Ajutor"
+
+#: ../include/wx/msw/ole/oleutils.h:52
+msgid "Cannot initialize OLE"
+msgstr "Nu se poate inițializa OLE"
+
+#: ../include/wx/msw/private/fswatcher.h:48
+#, c-format
+msgid "Unable to close the handle for '%s'"
+msgstr "Nu se poate închide operatorul pentru '%s'"
+
+#: ../include/wx/msw/private/fswatcher.h:92
+#, c-format
+msgid "Failed to open directory \"%s\" for monitoring."
+msgstr "A eșuat deschiderea directorului \"%s\" pentru monitorizare."
+
+#: ../include/wx/msw/private/fswatcher.h:125
+msgid "Unable to close I/O completion port handle"
+msgstr "Nu se poate închide operatorul pentru portul I/O de completare"
+
+#: ../include/wx/msw/private/fswatcher.h:142
+msgid "Unable to associate handle with I/O completion port"
+msgstr "Nu se poate asocia operator cu portul I/O de completare"
+
+#: ../include/wx/msw/private/fswatcher.h:148
+msgid "Unexpectedly new I/O completion port was created"
+msgstr "Un nou port I/O pentru completare a fost creat într-un mod neașteptat"
+
+#: ../include/wx/msw/private/fswatcher.h:213
+msgid "Unable to post completion status"
+msgstr "Nu se poate trimite statusul completării"
+
+#: ../include/wx/msw/private/fswatcher.h:262
+msgid "Unable to dequeue completion packet"
+msgstr "Pachetul de completare nu poate fi eliminat"
+
+#: ../include/wx/msw/private/fswatcher.h:273
+msgid "Unable to create I/O completion port"
+msgstr "Nu se poate crea portul I/O de completare"
+
+#: ../include/wx/richmsgdlg.h:29
+msgid "&See details"
+msgstr "&Vezi detalii"
+
+#: ../include/wx/richmsgdlg.h:30
+msgid "&Hide details"
+msgstr "&Ascunde detalii"
+
+#: ../include/wx/richtext/richtextbuffer.h:3864
+msgid "&Box"
+msgstr "&Casetă"
+
+#: ../include/wx/richtext/richtextbuffer.h:5008
+msgid "&Picture"
+msgstr "&Imagine"
+
+#: ../include/wx/richtext/richtextbuffer.h:5958
+msgid "&Cell"
+msgstr "&Celulă"
+
+#: ../include/wx/richtext/richtextbuffer.h:6067
+msgid "&Table"
+msgstr "&Tabela"
+
+#: ../include/wx/richtext/richtextimagedlg.h:37
+msgid "Object Properties"
+msgstr "Proprietăți Obiect"
+
+#: ../include/wx/richtext/richtextsymboldlg.h:39
+msgid "Symbols"
+msgstr "Simboluri"
+
+#: ../include/wx/unix/pipe.h:46
+msgid "Pipe creation failed"
+msgstr "Crearea canalului de comunicare (pipe) a eșuat"
+
+#: ../include/wx/unix/private/displayx11.h:65
+msgid "Failed to enumerate video modes"
+msgstr "A eșuat enumerarea modurilor video"
+
+#: ../include/wx/unix/private/displayx11.h:89
+msgid "Failed to change video mode"
+msgstr "A eșuat schimbarea modului video"
+
+#: ../include/wx/unix/private/fswatcher_kqueue.h:57
+#, c-format
+msgid "Unable to open path '%s'"
+msgstr "Nu se poate deschide calea '%s'"
+
+#: ../include/wx/unix/private/fswatcher_kqueue.h:74
+#, c-format
+msgid "Unable to close path '%s'"
+msgstr "Nu se poate închide calea '%s'"
+
+#: ../include/wx/xtiprop.h:175
+msgid "SetProperty called w/o valid setter"
+msgstr "SetProperty apelat fără setter valid"
+
+#: ../include/wx/xtiprop.h:184
+msgid "GetProperty called w/o valid getter"
+msgstr "GetProperty apelat fără getter valid"
+
+#: ../include/wx/xtiprop.h:193
+msgid "AddToPropertyCollection called w/o valid adder"
+msgstr "AddToPropertyCollection apelat fără adder valid"
+
+#: ../include/wx/xtiprop.h:202
+msgid "GetPropertyCollection called w/o valid collection getter"
+msgstr "GetPropertyCollection apelat fără getter de colecție valid"
+
+#: ../include/wx/xtiprop.h:255
+msgid "AddToPropertyCollection called on a generic accessor"
+msgstr "AddToPropertyCollection apelat pentru un accesor generic"
+
+#: ../include/wx/xtiprop.h:262
+msgid "GetPropertyCollection called on a generic accessor"
+msgstr "GetPropertyCollection apelat pentru un accesor generic"
+
+#: ../src/aui/tabmdi.cpp:106 ../src/generic/mdig.cpp:94
+msgid "Cl&ose"
+msgstr "Î&nchide"
+
+#: ../src/aui/tabmdi.cpp:107 ../src/generic/mdig.cpp:95
+msgid "Close All"
+msgstr "Închide tot"
+
+#: ../src/aui/tabmdi.cpp:109 ../src/generic/mdig.cpp:97 ../src/msw/mdi.cpp:175
+#: ../src/qt/mdi.cpp:258
+msgid "&Next"
+msgstr "&Următor"
+
+#: ../src/aui/tabmdi.cpp:110 ../src/generic/mdig.cpp:98 ../src/msw/mdi.cpp:176
+#: ../src/qt/mdi.cpp:259
+msgid "&Previous"
+msgstr "&Anterior"
+
+#: ../src/aui/tabmdi.cpp:332 ../src/aui/tabmdi.cpp:348
+#: ../src/aui/tabmdi.cpp:350 ../src/generic/mdig.cpp:291
+#: ../src/generic/mdig.cpp:307 ../src/generic/mdig.cpp:311
+#: ../src/msw/mdi.cpp:337 ../src/qt/mdi.cpp:462
+msgid "&Window"
+msgstr "&Fereastră"
+
+#: ../src/common/accelcmn.cpp:47
+msgctxt "keyboard key"
+msgid "Delete"
+msgstr "Șterge"
+
+#: ../src/common/accelcmn.cpp:48
+msgctxt "keyboard key"
+msgid "Del"
+msgstr "Del"
+
+#: ../src/common/accelcmn.cpp:49
+msgctxt "keyboard key"
+msgid "Back"
+msgstr "Înapoi"
+
+#: ../src/common/accelcmn.cpp:49
+msgctxt "keyboard key"
+msgid "Backspace"
+msgstr "Backspace"
+
+#: ../src/common/accelcmn.cpp:50
+msgctxt "keyboard key"
+msgid "Insert"
+msgstr "Inserează"
+
+#: ../src/common/accelcmn.cpp:51
+msgctxt "keyboard key"
+msgid "Ins"
+msgstr "Ins"
+
+#: ../src/common/accelcmn.cpp:52
+msgctxt "keyboard key"
+msgid "Enter"
+msgstr "Enter"
+
+#: ../src/common/accelcmn.cpp:53
+msgctxt "keyboard key"
+msgid "Return"
+msgstr "Return"
+
+#: ../src/common/accelcmn.cpp:54
+msgctxt "keyboard key"
+msgid "PageUp"
+msgstr "PageUp"
+
+#: ../src/common/accelcmn.cpp:54
+msgctxt "keyboard key"
+msgid "Page Up"
+msgstr "Page Up"
+
+#: ../src/common/accelcmn.cpp:55
+msgctxt "keyboard key"
+msgid "PageDown"
+msgstr "PageDown"
+
+#: ../src/common/accelcmn.cpp:55
+msgctxt "keyboard key"
+msgid "Page Down"
+msgstr "Page Down"
+
+#: ../src/common/accelcmn.cpp:56
+msgctxt "keyboard key"
+msgid "PgUp"
+msgstr "PgUp"
+
+#: ../src/common/accelcmn.cpp:57
+msgctxt "keyboard key"
+msgid "PgDn"
+msgstr "PgDn"
+
+#: ../src/common/accelcmn.cpp:58
+msgctxt "keyboard key"
+msgid "Left"
+msgstr "Stânga"
+
+#: ../src/common/accelcmn.cpp:59
+msgctxt "keyboard key"
+msgid "Right"
+msgstr "Dreapta"
+
+#: ../src/common/accelcmn.cpp:60
+msgctxt "keyboard key"
+msgid "Up"
+msgstr "Sus"
+
+#: ../src/common/accelcmn.cpp:61
+msgctxt "keyboard key"
+msgid "Down"
+msgstr "Jos"
+
+#: ../src/common/accelcmn.cpp:62
+msgctxt "keyboard key"
+msgid "Home"
+msgstr "Acasă"
+
+#: ../src/common/accelcmn.cpp:63
+msgctxt "keyboard key"
+msgid "End"
+msgstr "Sfârșit"
+
+#: ../src/common/accelcmn.cpp:64
+msgctxt "keyboard key"
+msgid "Space"
+msgstr "Spațiu"
+
+#: ../src/common/accelcmn.cpp:65
+msgctxt "keyboard key"
+msgid "Tab"
+msgstr "Tab"
+
+#: ../src/common/accelcmn.cpp:66
+msgctxt "keyboard key"
+msgid "Esc"
+msgstr "Esc"
+
+#: ../src/common/accelcmn.cpp:67
+msgctxt "keyboard key"
+msgid "Escape"
+msgstr "Escape"
+
+#: ../src/common/accelcmn.cpp:68
+msgctxt "keyboard key"
+msgid "Cancel"
+msgstr "Anulează"
+
+#: ../src/common/accelcmn.cpp:69
+msgctxt "keyboard key"
+msgid "Clear"
+msgstr "Clear"
+
+#: ../src/common/accelcmn.cpp:70
+msgctxt "keyboard key"
+msgid "Menu"
+msgstr "Meniu"
+
+#: ../src/common/accelcmn.cpp:71
+msgctxt "keyboard key"
+msgid "Pause"
+msgstr "Pauză"
+
+#: ../src/common/accelcmn.cpp:72
+msgctxt "keyboard key"
+msgid "Capital"
+msgstr "Caps"
+
+#: ../src/common/accelcmn.cpp:73
+msgctxt "keyboard key"
+msgid "Select"
+msgstr "Select"
+
+#: ../src/common/accelcmn.cpp:74
+msgctxt "keyboard key"
+msgid "Print"
+msgstr "Printează"
+
+#: ../src/common/accelcmn.cpp:75
+msgctxt "keyboard key"
+msgid "Execute"
+msgstr "Execută"
+
+#: ../src/common/accelcmn.cpp:76
+msgctxt "keyboard key"
+msgid "Snapshot"
+msgstr "Instantaneu"
+
+#: ../src/common/accelcmn.cpp:77
+msgctxt "keyboard key"
+msgid "Help"
+msgstr "Ajutor"
+
+#: ../src/common/accelcmn.cpp:78
+msgctxt "keyboard key"
+msgid "Add"
+msgstr "Plus"
+
+#: ../src/common/accelcmn.cpp:79
+msgctxt "keyboard key"
+msgid "Separator"
+msgstr "Separator"
+
+#: ../src/common/accelcmn.cpp:80
+msgctxt "keyboard key"
+msgid "Subtract"
+msgstr "Minus"
+
+#: ../src/common/accelcmn.cpp:81
+msgctxt "keyboard key"
+msgid "Decimal"
+msgstr "Zecimal"
+
+#: ../src/common/accelcmn.cpp:82
+msgctxt "keyboard key"
+msgid "Multiply"
+msgstr "Înmulțire"
+
+#: ../src/common/accelcmn.cpp:83
+msgctxt "keyboard key"
+msgid "Divide"
+msgstr "Împărțire"
+
+#: ../src/common/accelcmn.cpp:84
+msgctxt "keyboard key"
+msgid "Num_lock"
+msgstr "Num_lock"
+
+#: ../src/common/accelcmn.cpp:84
+msgctxt "keyboard key"
+msgid "Num Lock"
+msgstr "Num Lock"
+
+#: ../src/common/accelcmn.cpp:85
+msgctxt "keyboard key"
+msgid "Scroll_lock"
+msgstr "Scroll_lock"
+
+#: ../src/common/accelcmn.cpp:85
+msgctxt "keyboard key"
+msgid "Scroll Lock"
+msgstr "Scroll Lock"
+
+#: ../src/common/accelcmn.cpp:86
+msgctxt "keyboard key"
+msgid "KP_Space"
+msgstr "KP_Space"
+
+#: ../src/common/accelcmn.cpp:86
+msgctxt "keyboard key"
+msgid "Num Space"
+msgstr "Num Space"
+
+#: ../src/common/accelcmn.cpp:87
+msgctxt "keyboard key"
+msgid "KP_Tab"
+msgstr "KP_Tab"
+
+#: ../src/common/accelcmn.cpp:87
+msgctxt "keyboard key"
+msgid "Num Tab"
+msgstr "Num Tab"
+
+#: ../src/common/accelcmn.cpp:88
+msgctxt "keyboard key"
+msgid "KP_Enter"
+msgstr "KP_Enter"
+
+#: ../src/common/accelcmn.cpp:88
+msgctxt "keyboard key"
+msgid "Num Enter"
+msgstr "Num Enter"
+
+#: ../src/common/accelcmn.cpp:89
+msgctxt "keyboard key"
+msgid "KP_Home"
+msgstr "KP_Home"
+
+#: ../src/common/accelcmn.cpp:89
+msgctxt "keyboard key"
+msgid "Num Home"
+msgstr "Num Home"
+
+#: ../src/common/accelcmn.cpp:90
+msgctxt "keyboard key"
+msgid "KP_Left"
+msgstr "KP_Left"
+
+#: ../src/common/accelcmn.cpp:90
+msgctxt "keyboard key"
+msgid "Num left"
+msgstr "Num left"
+
+#: ../src/common/accelcmn.cpp:91
+msgctxt "keyboard key"
+msgid "KP_Up"
+msgstr "KP_Up"
+
+#: ../src/common/accelcmn.cpp:91
+msgctxt "keyboard key"
+msgid "Num Up"
+msgstr "Num Up"
+
+#: ../src/common/accelcmn.cpp:92
+msgctxt "keyboard key"
+msgid "KP_Right"
+msgstr "KP_Right"
+
+#: ../src/common/accelcmn.cpp:92
+msgctxt "keyboard key"
+msgid "Num Right"
+msgstr "Num Right"
+
+#: ../src/common/accelcmn.cpp:93
+msgctxt "keyboard key"
+msgid "KP_Down"
+msgstr "KP_Down"
+
+#: ../src/common/accelcmn.cpp:93
+msgctxt "keyboard key"
+msgid "Num Down"
+msgstr "Num Down"
+
+#: ../src/common/accelcmn.cpp:94
+msgctxt "keyboard key"
+msgid "KP_PageUp"
+msgstr "KP_PageUp"
+
+#: ../src/common/accelcmn.cpp:94
+msgctxt "keyboard key"
+msgid "Num Page Up"
+msgstr "Num Page Up"
+
+#: ../src/common/accelcmn.cpp:95
+msgctxt "keyboard key"
+msgid "KP_PageDown"
+msgstr "KP_PageDown"
+
+#: ../src/common/accelcmn.cpp:95
+msgctxt "keyboard key"
+msgid "Num Page Down"
+msgstr "Num Page Down"
+
+#: ../src/common/accelcmn.cpp:96
+msgctxt "keyboard key"
+msgid "KP_Prior"
+msgstr "KP_Prior"
+
+#: ../src/common/accelcmn.cpp:97
+msgctxt "keyboard key"
+msgid "KP_Next"
+msgstr "KP_Next"
+
+#: ../src/common/accelcmn.cpp:98
+msgctxt "keyboard key"
+msgid "KP_End"
+msgstr "KP_End"
+
+#: ../src/common/accelcmn.cpp:98
+msgctxt "keyboard key"
+msgid "Num End"
+msgstr "Num End"
+
+#: ../src/common/accelcmn.cpp:99
+msgctxt "keyboard key"
+msgid "KP_Begin"
+msgstr "KP_Begin"
+
+#: ../src/common/accelcmn.cpp:99
+msgctxt "keyboard key"
+msgid "Num Begin"
+msgstr "Num Begin"
+
+#: ../src/common/accelcmn.cpp:100
+msgctxt "keyboard key"
+msgid "KP_Insert"
+msgstr "KP_Insert"
+
+#: ../src/common/accelcmn.cpp:100
+msgctxt "keyboard key"
+msgid "Num Insert"
+msgstr "Num Insert"
+
+#: ../src/common/accelcmn.cpp:101
+msgctxt "keyboard key"
+msgid "KP_Delete"
+msgstr "KP_Delete"
+
+#: ../src/common/accelcmn.cpp:101
+msgctxt "keyboard key"
+msgid "Num Delete"
+msgstr "Num Delete"
+
+#: ../src/common/accelcmn.cpp:102
+msgctxt "keyboard key"
+msgid "KP_Equal"
+msgstr "KP_Equal"
+
+#: ../src/common/accelcmn.cpp:102
+msgctxt "keyboard key"
+msgid "Num ="
+msgstr "Num ="
+
+#: ../src/common/accelcmn.cpp:103
+msgctxt "keyboard key"
+msgid "KP_Multiply"
+msgstr "KP_Multiply"
+
+#: ../src/common/accelcmn.cpp:103
+msgctxt "keyboard key"
+msgid "Num *"
+msgstr "Num *"
+
+#: ../src/common/accelcmn.cpp:104
+msgctxt "keyboard key"
+msgid "KP_Add"
+msgstr "KP_Add"
+
+#: ../src/common/accelcmn.cpp:104
+msgctxt "keyboard key"
+msgid "Num +"
+msgstr "Num +"
+
+#: ../src/common/accelcmn.cpp:105
+msgctxt "keyboard key"
+msgid "KP_Separator"
+msgstr "KP_Separator"
+
+#: ../src/common/accelcmn.cpp:105
+msgctxt "keyboard key"
+msgid "Num ,"
+msgstr "Num ,"
+
+#: ../src/common/accelcmn.cpp:106
+msgctxt "keyboard key"
+msgid "KP_Subtract"
+msgstr "KP_Subtract"
+
+#: ../src/common/accelcmn.cpp:106
+msgctxt "keyboard key"
+msgid "Num -"
+msgstr "Num -"
+
+#: ../src/common/accelcmn.cpp:107
+msgctxt "keyboard key"
+msgid "KP_Decimal"
+msgstr "KP_Decimal"
+
+#: ../src/common/accelcmn.cpp:107
+msgctxt "keyboard key"
+msgid "Num ."
+msgstr "Num ."
+
+#: ../src/common/accelcmn.cpp:108
+msgctxt "keyboard key"
+msgid "KP_Divide"
+msgstr "KP_Divide"
+
+#: ../src/common/accelcmn.cpp:108
+msgctxt "keyboard key"
+msgid "Num /"
+msgstr "Num /"
+
+#: ../src/common/accelcmn.cpp:109
+msgctxt "keyboard key"
+msgid "Windows_Left"
+msgstr "Windows_Left"
+
+#: ../src/common/accelcmn.cpp:110
+msgctxt "keyboard key"
+msgid "Windows_Right"
+msgstr "Windows_Right"
+
+#: ../src/common/accelcmn.cpp:111
+msgctxt "keyboard key"
+msgid "Windows_Menu"
+msgstr "Windows_Menu"
+
+#: ../src/common/accelcmn.cpp:112
+msgctxt "keyboard key"
+msgid "Command"
+msgstr "Command"
+
+#: ../src/common/accelcmn.cpp:186 ../src/common/accelcmn.cpp:359
+msgctxt "keyboard key"
+msgid "Ctrl"
+msgstr "Ctrl"
+
+#: ../src/common/accelcmn.cpp:188 ../src/common/accelcmn.cpp:363
+msgctxt "keyboard key"
+msgid "Alt"
+msgstr "Alt"
+
+#: ../src/common/accelcmn.cpp:190 ../src/common/accelcmn.cpp:361
+msgctxt "keyboard key"
+msgid "Shift"
+msgstr "Shift"
+
+#: ../src/common/accelcmn.cpp:196
+msgctxt "keyboard key"
+msgid "num "
+msgstr "num "
+
+#: ../src/common/accelcmn.cpp:260 ../src/common/accelcmn.cpp:382
+msgctxt "keyboard key"
+msgid "F"
+msgstr "F"
+
+#: ../src/common/accelcmn.cpp:277 ../src/common/accelcmn.cpp:385
+msgctxt "keyboard key"
+msgid "KP_F"
+msgstr "KP_F"
+
+#: ../src/common/accelcmn.cpp:280 ../src/common/accelcmn.cpp:388
+msgctxt "keyboard key"
+msgid "KP_"
+msgstr "KP_"
+
+#: ../src/common/accelcmn.cpp:283 ../src/common/accelcmn.cpp:391
+msgctxt "keyboard key"
+msgid "SPECIAL"
+msgstr "SPECIAL"
+
+#: ../src/common/accelcmn.cpp:373
+msgid "Ctrl"
+msgstr "Ctrl"
+
+#: ../src/common/appbase.cpp:786
+msgid "show this help message"
+msgstr "afișează acest mesaj de ajutor"
+
+#: ../src/common/appbase.cpp:796
+msgid "generate verbose log messages"
+msgstr "generează mesaje detaliate pentru jurnal"
+
+#: ../src/common/appcmn.cpp:256
+msgid "specify the theme to use"
+msgstr "specifică tema ce va fi folosită"
+
+#: ../src/common/appcmn.cpp:270
+msgid "specify display mode to use (e.g. 640x480-16)"
+msgstr "specifică modul de afișare (ex. 640x480-16)"
+
+#: ../src/common/appcmn.cpp:292
+#, c-format
+msgid "Unsupported theme '%s'."
+msgstr "Temă nesuportată '%s'."
+
+#: ../src/common/appcmn.cpp:309
+#, c-format
+msgid "Invalid display mode specification '%s'."
+msgstr "Specificația de afișare '%s' este invalidă."
+
+#: ../src/common/cmdline.cpp:875
+#, c-format
+msgid "Option '%s' can't be negated"
+msgstr "Opțiunea '%s' nu poate fi negată"
+
+#: ../src/common/cmdline.cpp:889
+#, c-format
+msgid "Unknown long option '%s'"
+msgstr "Opțiunea lungă '%s' este necunoscută"
+
+#: ../src/common/cmdline.cpp:904 ../src/common/cmdline.cpp:926
+#, c-format
+msgid "Unknown option '%s'"
+msgstr "Opțiune necunoscută %s"
+
+#: ../src/common/cmdline.cpp:1004
+#, c-format
+msgid "Unexpected characters following option '%s'."
+msgstr "Caractere neașteptate după opțiunea '%s'."
+
+#: ../src/common/cmdline.cpp:1039
+#, c-format
+msgid "Option '%s' requires a value."
+msgstr "Opțiunea '%s' necesită o valoare."
+
+#: ../src/common/cmdline.cpp:1058
+#, c-format
+msgid "Separator expected after the option '%s'."
+msgstr "Lipsește separatorul după opțiunea '%s'."
+
+#: ../src/common/cmdline.cpp:1088 ../src/common/cmdline.cpp:1106
+#, c-format
+msgid "'%s' is not a correct numeric value for option '%s'."
+msgstr "'%s' este o valoare numerică incorectă pentru opțiunea '%s'."
+
+#: ../src/common/cmdline.cpp:1122
+#, c-format
+msgid "Option '%s': '%s' cannot be converted to a date."
+msgstr "Opțiunea '%s': '%s' nu poate fi convertită la o dată."
+
+#: ../src/common/cmdline.cpp:1170
+#, c-format
+msgid "Unexpected parameter '%s'"
+msgstr "Parametru neașteptat '%s'"
+
+#. TRANSLATORS: Short name and long name for a command line option
+#: ../src/common/cmdline.cpp:1197
+#, c-format
+msgid "%s (or %s)"
+msgstr "%s (sau %s)"
+
+#: ../src/common/cmdline.cpp:1208
+#, c-format
+msgid "The value for the option '%s' must be specified."
+msgstr "Valoarea pentru opțiunea '%s' trebuie specificată."
+
+#: ../src/common/cmdline.cpp:1230
+#, c-format
+msgid "The required parameter '%s' was not specified."
+msgstr "Parametrul necesar '%s' nu a fost specificat."
+
+#: ../src/common/cmdline.cpp:1289
+#, c-format
+msgid "Usage: %s"
+msgstr "Utlizare: %s"
+
+#: ../src/common/cmdline.cpp:1498
+msgid "str"
+msgstr "str"
+
+#: ../src/common/cmdline.cpp:1502
+msgid "num"
+msgstr "numeric"
+
+#: ../src/common/cmdline.cpp:1506
+msgid "double"
+msgstr "double"
+
+#: ../src/common/cmdline.cpp:1510
+msgid "date"
+msgstr "dată"
+
+#: ../src/common/cmdproc.cpp:250 ../src/common/cmdproc.cpp:276
+#: ../src/common/cmdproc.cpp:296
+msgid "Unnamed command"
+msgstr "Comandă fără nume"
+
+#: ../src/common/cmdproc.cpp:253
+msgid "&Undo "
+msgstr "An&ulează "
+
+#: ../src/common/cmdproc.cpp:255
+msgid "Can't &Undo "
+msgstr "Nu se poate an&ula "
+
+#: ../src/common/cmdproc.cpp:259 ../src/common/stockitem.cpp:208
+#: ../src/msw/textctrl.cpp:2880 ../src/osx/textctrl_osx.cpp:649
+#: ../src/richtext/richtextctrl.cpp:327
+msgid "&Undo"
+msgstr "An&ulează"
+
+#: ../src/common/cmdproc.cpp:277 ../src/common/cmdproc.cpp:297
+msgid "&Redo "
+msgstr "&Repetă "
+
+#: ../src/common/cmdproc.cpp:281 ../src/common/cmdproc.cpp:288
+#: ../src/common/stockitem.cpp:190 ../src/msw/textctrl.cpp:2881
+#: ../src/osx/textctrl_osx.cpp:650 ../src/richtext/richtextctrl.cpp:328
+msgid "&Redo"
+msgstr "&Repetă"
+
+#: ../src/common/colourcmn.cpp:41
+#, c-format
+msgid "String To Colour : Incorrect colour specification : %s"
+msgstr ""
+"Din șir de caractere în culoare : Specificație de culoare incorectă : %s"
+
+#: ../src/common/config.cpp:259
+#, c-format
+msgid "Invalid value %ld for a boolean key \"%s\" in config file."
+msgstr ""
+"Valoarea %ld este invalidă pentru cheia boolean \"%s\" din fișierul de "
+"configurare."
+
+#: ../src/common/config.cpp:526
+#, c-format
+msgid ""
+"Environment variables expansion failed: missing '%c' at position %u in '%s'."
+msgstr ""
+"Expandarea variabilelor de mediu a eșuat: lipsește '%c' la poziția %u în "
+"'%s'."
+
+#: ../src/common/config.cpp:576 ../src/msw/regconf.cpp:272
+#, c-format
+msgid "'%s' has extra '..', ignored."
+msgstr "'%s' are '..' în plus, sunt ignorate."
+
+#. TRANSLATORS: Checkbox state name
+#: ../src/common/datavcmn.cpp:2166 ../src/generic/datavgen.cpp:1430
+msgid "checked"
+msgstr "bifată"
+
+#. TRANSLATORS: Checkbox state name
+#: ../src/common/datavcmn.cpp:2170 ../src/generic/datavgen.cpp:1432
+msgid "unchecked"
+msgstr "debifată"
+
+#. TRANSLATORS: Checkbox state name
+#: ../src/common/datavcmn.cpp:2174
+msgid "undetermined"
+msgstr "nedeterminată"
+
+#: ../src/common/datetimefmt.cpp:1875
+msgid "today"
+msgstr "astăzi"
+
+#: ../src/common/datetimefmt.cpp:1876
+msgid "yesterday"
+msgstr "ieri"
+
+#: ../src/common/datetimefmt.cpp:1877
+msgid "tomorrow"
+msgstr "mâine"
+
+#: ../src/common/datetimefmt.cpp:2071
+msgid "first"
+msgstr "primul(prima)"
+
+#: ../src/common/datetimefmt.cpp:2072
+msgid "second"
+msgstr "al(a) doilea(doua)"
+
+#: ../src/common/datetimefmt.cpp:2073
+msgid "third"
+msgstr "al(a) treilea(treia)"
+
+#: ../src/common/datetimefmt.cpp:2074
+msgid "fourth"
+msgstr "al(a) patrulea(patra)"
+
+#: ../src/common/datetimefmt.cpp:2075
+msgid "fifth"
+msgstr "al(a) cincelea(cincea)"
+
+#: ../src/common/datetimefmt.cpp:2076
+msgid "sixth"
+msgstr "al(a) șaselea(șasea)"
+
+#: ../src/common/datetimefmt.cpp:2077
+msgid "seventh"
+msgstr "al(a) șaptelea(șaptea)"
+
+#: ../src/common/datetimefmt.cpp:2078
+msgid "eighth"
+msgstr "al(a) optulea(opta)"
+
+#: ../src/common/datetimefmt.cpp:2079
+msgid "ninth"
+msgstr "al(a) nouălea(noua)"
+
+#: ../src/common/datetimefmt.cpp:2080
+msgid "tenth"
+msgstr "al(a) zecelea(zecea)"
+
+#: ../src/common/datetimefmt.cpp:2081
+msgid "eleventh"
+msgstr "al(a) unsprezecelea(unsprezecea)"
+
+#: ../src/common/datetimefmt.cpp:2082
+msgid "twelfth"
+msgstr "al(a) doisprezecelea(doisprezecea)"
+
+#: ../src/common/datetimefmt.cpp:2083
+msgid "thirteenth"
+msgstr "al(a) treisprezecelea(treisprezecea)"
+
+#: ../src/common/datetimefmt.cpp:2084
+msgid "fourteenth"
+msgstr "al(a) paisprezecelea(paisprezecea)"
+
+#: ../src/common/datetimefmt.cpp:2085
+msgid "fifteenth"
+msgstr "al(a) cincisprezecealea(cincisprezecea)"
+
+#: ../src/common/datetimefmt.cpp:2086
+msgid "sixteenth"
+msgstr "al(a) șaisprezecelea(șaisprezecea)"
+
+#: ../src/common/datetimefmt.cpp:2087
+msgid "seventeenth"
+msgstr "al(a) șaptesprezecelea(șaptesprezecea)"
+
+#: ../src/common/datetimefmt.cpp:2088
+msgid "eighteenth"
+msgstr "al(a) optsprezecelea(optsprezecea)"
+
+#: ../src/common/datetimefmt.cpp:2089
+msgid "nineteenth"
+msgstr "al(a) nouăsprezecelea(nouăsprezecea)"
+
+#: ../src/common/datetimefmt.cpp:2090
+msgid "twentieth"
+msgstr "al(a) douăzecelea(douăzecea)"
+
+#: ../src/common/datetimefmt.cpp:2248
+msgid "noon"
+msgstr "amiază"
+
+#: ../src/common/datetimefmt.cpp:2249
+msgid "midnight"
+msgstr "miezul nopții"
+
+#: ../src/common/debugrpt.cpp:209
+#, c-format
+msgid "Failed to create directory \"%s\""
+msgstr "A eșuat crearea directorului \"%s\""
+
+#: ../src/common/debugrpt.cpp:210
+msgid "Debug report couldn't be created."
+msgstr "Raportul de depanare nu a putut fi creat."
+
+#: ../src/common/debugrpt.cpp:227
+#, c-format
+msgid "Failed to remove debug report file \"%s\""
+msgstr "A eșuat ștergerea fișierului raport de depanare \"%s\""
+
+#: ../src/common/debugrpt.cpp:239
+#, c-format
+msgid "Failed to clean up debug report directory \"%s\""
+msgstr "A eșuat curățarea directorului de rapoarte de depanare \"%s\""
+
+#: ../src/common/debugrpt.cpp:514
+msgid "process context description"
+msgstr "descriere în contextul procesului"
+
+#: ../src/common/debugrpt.cpp:538
+msgid "dump of the process state (binary)"
+msgstr "copie a stării procesului (binară)"
+
+#: ../src/common/debugrpt.cpp:553
+msgid "Debug report generation has failed."
+msgstr "Generarea raportului de depanare a eșuat."
+
+#: ../src/common/debugrpt.cpp:560
+#, c-format
+msgid ""
+"Processing debug report has failed, leaving the files in \"%s\" directory."
+msgstr ""
+"Procesarea raportului de depanare a eșuat, fișierele au rămas în directorul "
+"\"%s\"."
+
+#: ../src/common/debugrpt.cpp:573
+msgid "A debug report has been generated. It can be found in"
+msgstr "Un raport de depanare a fost generat. Poate fi găsit în"
+
+#: ../src/common/debugrpt.cpp:576
+msgid "And includes the following files:\n"
+msgstr "Și include următoarele fișiere:\n"
+
+#: ../src/common/debugrpt.cpp:586
+msgid ""
+"\n"
+"Please send this report to the program maintainer, thank you!\n"
+msgstr ""
+"\n"
+"Trimiteți acest raport dezvoltatorului programului, mulțumim!\n"
+
+#: ../src/common/debugrpt.cpp:729
+msgid "Failed to execute curl, please install it in PATH."
+msgstr "A eșuat executarea curl, trebuie instalat în PATH."
+
+#: ../src/common/debugrpt.cpp:742
+#, c-format
+msgid "Failed to upload the debug report (error code %d)."
+msgstr "A eșuat transferul raportului de depanare (cod de eroare %d)."
+
+#: ../src/common/docview.cpp:366
+msgid "Save As"
+msgstr "Salvează ca"
+
+#: ../src/common/docview.cpp:457
+msgid "Discard changes and reload the last saved version?"
+msgstr "Anulează modificările și reîncarcă ultima versiune salvată?"
+
+#: ../src/common/docview.cpp:488
+msgid "unnamed"
+msgstr "nedenumit"
+
+#: ../src/common/docview.cpp:513
+#, c-format
+msgid "Do you want to save changes to %s?"
+msgstr "Vreți să salvați modificările în %s?"
+
+#: ../src/common/docview.cpp:521 ../src/common/docview.cpp:560
+#: ../src/common/stockitem.cpp:195
+msgid "&Save"
+msgstr "&Salvează"
+
+#: ../src/common/docview.cpp:522 ../src/common/docview.cpp:560
+msgid "&Discard changes"
+msgstr "&Anulează modificările"
+
+#: ../src/common/docview.cpp:523
+msgid "Do&n't close"
+msgstr "&Nu închide"
+
+#: ../src/common/docview.cpp:553
+#, c-format
+msgid "Do you want to save changes to %s before closing it?"
+msgstr "Vreți să salvați modificările în %s înainte să închideți?"
+
+#: ../src/common/docview.cpp:559
+msgid "The document must be closed."
+msgstr "Documentul trebuie închis."
+
+#: ../src/common/docview.cpp:571
+#, c-format
+msgid "Saving %s failed, would you like to retry?"
+msgstr "Salvarea %s a eșuat, doriți să încercați din nou?"
+
+#: ../src/common/docview.cpp:577
+msgid "Retry"
+msgstr "Reîncearcă"
+
+#: ../src/common/docview.cpp:577
+msgid "Discard changes"
+msgstr "Anulează modificările"
+
+#: ../src/common/docview.cpp:679
+#, c-format
+msgid "File \"%s\" could not be opened for writing."
+msgstr "Fișierul \"%s\" nu a putut fi deschis pentru scriere."
+
+#: ../src/common/docview.cpp:685
+#, c-format
+msgid "Failed to save document to the file \"%s\"."
+msgstr "A eșuat salvarea documentului în fișierul \"%s\"."
+
+#: ../src/common/docview.cpp:702
+#, c-format
+msgid "File \"%s\" could not be opened for reading."
+msgstr "Fișierul \"%s\" nu a putut fi deschis pentru citire."
+
+#: ../src/common/docview.cpp:714
+#, c-format
+msgid "Failed to read document from the file \"%s\"."
+msgstr "A eșuat citirea documentului din fișierul \"%s\"."
+
+#: ../src/common/docview.cpp:1236
+#, c-format
+msgid ""
+"The file '%s' doesn't exist and couldn't be opened.\n"
+"It has been removed from the most recently used files list."
+msgstr ""
+"Fișierul '%s' nu există și nu a putut fi deschis\n"
+"A fost șters din lista fișierelor recent folosite."
+
+#: ../src/common/docview.cpp:1296
+msgid "Print preview creation failed."
+msgstr "Previzualizarea tipăririi a eșuat."
+
+#: ../src/common/docview.cpp:1302
+msgid "Print Preview"
+msgstr "Previzualizare tipărire"
+
+#: ../src/common/docview.cpp:1517
+#, c-format
+msgid "The format of file '%s' couldn't be determined."
+msgstr "Formatul fișierului '%s' nu a putut fi determinat."
+
+#: ../src/common/docview.cpp:1643
+#, c-format
+msgid "unnamed%d"
+msgstr "nedenumit%d"
+
+#: ../src/common/docview.cpp:1660
+msgid " - "
+msgstr " - "
+
+#: ../src/common/docview.cpp:1791 ../src/common/docview.cpp:1844
+msgid "Open File"
+msgstr "Deschide fișier"
+
+#: ../src/common/docview.cpp:1807
+msgid "File error"
+msgstr "Eroare de fișier"
+
+#: ../src/common/docview.cpp:1809
+msgid "Sorry, could not open this file."
+msgstr "Nu a putut fi deschis acest fișier."
+
+#: ../src/common/docview.cpp:1843
+msgid "Sorry, the format for this file is unknown."
+msgstr "Formatul pentru acest fișier este necunoscut."
+
+#: ../src/common/docview.cpp:1924
+msgid "Select a document template"
+msgstr "Selectează un șablon de document"
+
+#: ../src/common/docview.cpp:1925
+msgid "Templates"
+msgstr "Șabloane"
+
+#: ../src/common/docview.cpp:1998
+msgid "Select a document view"
+msgstr "Selectează o vizualizare pentru document"
+
+#: ../src/common/docview.cpp:1999
+msgid "Views"
+msgstr "Vizualizări"
+
+#: ../src/common/dynlib.cpp:81
+#, c-format
+msgid "Failed to load shared library '%s'"
+msgstr "A eșuat încărcarea bibliotecii partajate '%s'"
+
+#: ../src/common/dynlib.cpp:105
+#, c-format
+msgid "Couldn't find symbol '%s' in a dynamic library"
+msgstr "Nu a fost găsit simbolul '%s' într-o bibliotecă dinamică"
+
+#: ../src/common/ffile.cpp:56 ../src/common/file.cpp:215
+#, c-format
+msgid "can't open file '%s'"
+msgstr "nu poate fi deschis fișierul '%s'"
+
+#: ../src/common/ffile.cpp:72
+#, c-format
+msgid "can't close file '%s'"
+msgstr "nu poate fi închis fișierul '%s'"
+
+#: ../src/common/ffile.cpp:106 ../src/common/ffile.cpp:131
+#, c-format
+msgid "Read error on file '%s'"
+msgstr "Eroare la citire din fișierul '%s'"
+
+#: ../src/common/ffile.cpp:148
+#, c-format
+msgid "Write error on file '%s'"
+msgstr "Eroare la scriere în fișierul '%s'"
+
+#: ../src/common/ffile.cpp:182
+#, c-format
+msgid "failed to flush the file '%s'"
+msgstr "transmitere eșuată către fișierul '%s'"
+
+#: ../src/common/ffile.cpp:222
+#, c-format
+msgid "Seek error on file '%s' (large files not supported by stdio)"
+msgstr ""
+"Eroare la căutare în fișierul '%s' (fișierele mari nu sunt suportate de "
+"stdio)"
+
+#: ../src/common/ffile.cpp:232
+#, c-format
+msgid "Seek error on file '%s'"
+msgstr "Eroare la căutare în fișierul '%s'"
+
+#: ../src/common/ffile.cpp:248
+#, c-format
+msgid "Can't find current position in file '%s'"
+msgstr "Nu se poate determina poziția curentă în fișierul '%s'"
+
+#: ../src/common/ffile.cpp:349 ../src/common/file.cpp:569
+msgid "Failed to set temporary file permissions"
+msgstr "A eșuat setarea permisiunilor pentru fișierul temporar"
+
+#: ../src/common/ffile.cpp:371
+#, c-format
+msgid "can't remove file '%s'"
+msgstr "nu poate fi șters fișierul '%s'"
+
+#: ../src/common/ffile.cpp:376 ../src/common/file.cpp:591
+#, c-format
+msgid "can't commit changes to file '%s'"
+msgstr "nu pot fi memorate schimbările în fișierul '%s'"
+
+#: ../src/common/ffile.cpp:388 ../src/common/file.cpp:603
+#, c-format
+msgid "can't remove temporary file '%s'"
+msgstr "nu poate fi șters fișierul temporar '%s'"
+
+#: ../src/common/file.cpp:162
+#, c-format
+msgid "can't create file '%s'"
+msgstr "nu poate fi creat fișierul '%s'"
+
+#: ../src/common/file.cpp:229
+#, c-format
+msgid "can't close file descriptor %d"
+msgstr "nu poate fi închis descriptorul de fișier %d"
+
+#: ../src/common/file.cpp:332
+#, c-format
+msgid "can't read from file descriptor %d"
+msgstr "nu se poate citi din descriptorul de fișier %d"
+
+#: ../src/common/file.cpp:351
+#, c-format
+msgid "can't write to file descriptor %d"
+msgstr "nu se poate scrie în descriptorul de fișier %d"
+
+#: ../src/common/file.cpp:390
+#, c-format
+msgid "can't flush file descriptor %d"
+msgstr "nu se poate transmite către descriptorul de fisier %d"
+
+#: ../src/common/file.cpp:432
+#, c-format
+msgid "can't seek on file descriptor %d"
+msgstr "nu se poate căuta în descriptorul de fișier %d"
+
+#: ../src/common/file.cpp:446
+#, c-format
+msgid "can't get seek position on file descriptor %d"
+msgstr "nu se poate obține poziția de căutare pentru descriptorul de fișier %d"
+
+#: ../src/common/file.cpp:475
+#, c-format
+msgid "can't find length of file on file descriptor %d"
+msgstr ""
+"nu poate fi determinată lungimea fișierului pentru descriptorul de fișier %d"
+
+#: ../src/common/file.cpp:505
+#, c-format
+msgid "can't determine if the end of file is reached on descriptor %d"
+msgstr ""
+"nu se poate determina dacă sfârșitul fișierului a fost atins în descriptorul "
+"%d"
+
+#: ../src/common/fileconf.cpp:352
+#, c-format
+msgid ""
+" and additionally, the existing configuration file was renamed to \"%s\" and "
+"couldn't be renamed back, please rename it to its original path \"%s\""
+msgstr ""
+" și în plus, fișierul de configurare existent a fost redenumit în \"%s\" și "
+"nu a putut fi redenumit înapoi, vă rugăm să îl redenumiți în calea sa "
+"originală \"%s\""
+
+#: ../src/common/fileconf.cpp:389
+msgid " due to the following error:\n"
+msgstr " datorită următoarei erori:\n"
+
+#: ../src/common/fileconf.cpp:412
+msgid "failed to rename the existing file"
+msgstr "a eșuat redenumirea fișierului existent"
+
+#: ../src/common/fileconf.cpp:421
+msgid "failed to create the new file directory"
+msgstr "a eșuat crearea directorului pentru fișierul nou"
+
+#: ../src/common/fileconf.cpp:428
+msgid "failed to move the file to the new location"
+msgstr "a eșuat mutarea fișierului în locația nouă"
+
+#: ../src/common/fileconf.cpp:462
+#, c-format
+msgid "can't open global configuration file '%s'."
+msgstr "nu poate fi deschis fișierul global de configurare '%s'."
+
+#: ../src/common/fileconf.cpp:478
+#, c-format
+msgid "can't open user configuration file '%s'."
+msgstr "nu poate fi deschis fișierul de configurare '%s' al utilizatrului."
+
+#: ../src/common/fileconf.cpp:483
+#, c-format
+msgid "Changes won't be saved to avoid overwriting the existing file \"%s\""
+msgstr ""
+"Schimbările nu vor fi salvate pentru a evita suprascrierea fișierului "
+"existent \"%s\""
+
+#: ../src/common/fileconf.cpp:583
+msgid "Error reading config options."
+msgstr "Eroare la citirea opțiunilor de configurare."
+
+#: ../src/common/fileconf.cpp:593
+msgid "Failed to read config options."
+msgstr "A eșuat citirea opțiunilor de configurare."
+
+#: ../src/common/fileconf.cpp:700
+#, c-format
+msgid "file '%s': unexpected character %c at line %zu."
+msgstr "fișierul '%s': caracter neașteptat %c la linia %zu."
+
+#: ../src/common/fileconf.cpp:736
+#, c-format
+msgid "file '%s', line %zu: '%s' ignored after group header."
+msgstr "fișierul '%s', linia %zu: '%s' ignorat după antetul de grup."
+
+#: ../src/common/fileconf.cpp:765
+#, c-format
+msgid "file '%s', line %zu: '=' expected."
+msgstr "fișierul '%s', linia %zu: '=' era așteptat."
+
+#: ../src/common/fileconf.cpp:778
+#, c-format
+msgid "file '%s', line %zu: value for immutable key '%s' ignored."
+msgstr "fișierul '%s', linia %zu: valoarea cheii imuabile '%s' ignorată."
+
+#: ../src/common/fileconf.cpp:788
+#, c-format
+msgid "file '%s', line %zu: key '%s' was first found at line %d."
+msgstr ""
+"fișierul '%s', linia %zu: cheia '%s' a fost găsită mai întâi la linia %d."
+
+#: ../src/common/fileconf.cpp:1091
+#, c-format
+msgid "Config entry name cannot start with '%c'."
+msgstr "Numele intrării de configurare nu poate începe cu '%c'."
+
+#: ../src/common/fileconf.cpp:1146
+msgid "Failed to create configuration file directory."
+msgstr "A eșuat crearea directorului pentru fișierul de configurare."
+
+#: ../src/common/fileconf.cpp:1158
+msgid "can't open user configuration file."
+msgstr "nu poate fi deschis fișierul de configurare al utilizatrului."
+
+#: ../src/common/fileconf.cpp:1172
+msgid "can't write user configuration file."
+msgstr "nu poate fi scris fișierul de configurare al utilizatorului."
+
+#: ../src/common/fileconf.cpp:1178
+msgid "Failed to update user configuration file."
+msgstr "A eșuat actualizarea fișierului de configurare al utilizatorului."
+
+#: ../src/common/fileconf.cpp:1201
+msgid "Error saving user configuration data."
+msgstr "Eroare la salvarea datelor de configurare ale utilizatorului."
+
+#: ../src/common/fileconf.cpp:1313
+#, c-format
+msgid "can't delete user configuration file '%s'"
+msgstr "nu poate fi șters fișierul de configurare '%s' al utilizatorului"
+
+#: ../src/common/fileconf.cpp:2007
+#, c-format
+msgid "entry '%s' appears more than once in group '%s'"
+msgstr "intrarea '%s' apare de mai multe ori în grupul '%s'"
+
+#: ../src/common/fileconf.cpp:2021
+#, c-format
+msgid "attempt to change immutable key '%s' ignored."
+msgstr "tentativă ignorată de a schimba cheia imuabilă '%s'."
+
+#: ../src/common/fileconf.cpp:2118
+#, c-format
+msgid "trailing backslash ignored in '%s'"
+msgstr "caracter final \\ ignorat în '%s'"
+
+#: ../src/common/fileconf.cpp:2153
+#, c-format
+msgid "unexpected \" at position %d in '%s'."
+msgstr "caracter \" neașteptat la poziția %d în '%s'."
+
+#: ../src/common/filefn.cpp:474
+#, c-format
+msgid "Failed to copy the file '%s' to '%s'"
+msgstr "A eșuat copierea fișierului '%s' la '%s'"
+
+#: ../src/common/filefn.cpp:487
+#, c-format
+msgid "Impossible to get permissions for file '%s'"
+msgstr "Sunt imposibil de obținut permisiunile pentru fișierul '%s'"
+
+#: ../src/common/filefn.cpp:501
+#, c-format
+msgid "Impossible to overwrite the file '%s'"
+msgstr "Este imposibilă suprascrierea fișierul '%s'"
+
+#: ../src/common/filefn.cpp:508
+#, c-format
+msgid "Error copying the file '%s' to '%s'."
+msgstr "Erorare la copierea fișierului '%s' la '%s'."
+
+#: ../src/common/filefn.cpp:556
+#, c-format
+msgid "Impossible to set permissions for the file '%s'"
+msgstr "Este imposibilă setarea permisiunilor pentru fișierul '%s'"
+
+#: ../src/common/filefn.cpp:606
+#, c-format
+msgid ""
+"Failed to rename the file '%s' to '%s' because the destination file already "
+"exists."
+msgstr ""
+"A eșuat redenumirea fișierului '%s' în '%s' pentru că fișierul destinație "
+"există deja."
+
+#: ../src/common/filefn.cpp:623
+#, c-format
+msgid "File '%s' couldn't be renamed '%s'"
+msgstr "Fișierul '%s' nu a putut fi redenumit '%s'."
+
+#: ../src/common/filefn.cpp:639
+#, c-format
+msgid "File '%s' couldn't be removed"
+msgstr "Fișierul '%s' nu a putut fi șters"
+
+#: ../src/common/filefn.cpp:666
+#, c-format
+msgid "Directory '%s' couldn't be created"
+msgstr "Directorul '%s' nu a putut fi creat"
+
+#: ../src/common/filefn.cpp:680
+#, c-format
+msgid "Directory '%s' couldn't be deleted"
+msgstr "Directorul '%s' nu a putut fi șters"
+
+#: ../src/common/filefn.cpp:714
+#, c-format
+msgid "Cannot enumerate files '%s'"
+msgstr "Nu pot fi enumerate fișierele '%s'"
+
+#: ../src/common/filefn.cpp:798
+msgid "Failed to get the working directory"
+msgstr "A eșuat obținerea directorului de lucru"
+
+#: ../src/common/filefn.cpp:843
+msgid "Could not set current working directory"
+msgstr "A eșuat setarea directorului de lucru"
+
+#: ../src/common/filefn.cpp:974
+#, c-format
+msgid "Files (%s)"
+msgstr "Fișiere (%s)"
+
+#: ../src/common/filename.cpp:182
+#, c-format
+msgid "Failed to open '%s' for reading"
+msgstr "A eșuat deschiderea '%s' pentru citire"
+
+#: ../src/common/filename.cpp:187
+#, c-format
+msgid "Failed to open '%s' for writing"
+msgstr "A eșuat deschiderea '%s' pentru scriere"
+
+#: ../src/common/filename.cpp:199
+msgid "Failed to close file handle"
+msgstr "A eșuat închiderea operatorului de fișiere"
+
+#: ../src/common/filename.cpp:1046
+msgid "Failed to create a temporary file name"
+msgstr "A eșuat crearea unui nume de fișier temporar"
+
+#: ../src/common/filename.cpp:1081
+msgid "Failed to open temporary file."
+msgstr "A eșuat deschiderea fișierului temporar."
+
+#: ../src/common/filename.cpp:2862
+#, c-format
+msgid "Failed to modify file times for '%s'"
+msgstr "A eșuat modificarea timpilor fișierului pentru '%s'"
+
+#: ../src/common/filename.cpp:2877
+#, c-format
+msgid "Failed to touch the file '%s'"
+msgstr "A eșuat modificarea timpilor fișierului '%s'"
+
+#: ../src/common/filename.cpp:2958
+#, c-format
+msgid "Failed to retrieve file times for '%s'"
+msgstr "A eșuat obținerea timpilor fișierului pentru '%s'"
+
+#: ../src/common/filepickercmn.cpp:39 ../src/common/filepickercmn.cpp:40
+msgid "Browse"
+msgstr "Răsfoiește"
+
+#: ../src/common/fldlgcmn.cpp:792 ../src/generic/filectrlg.cpp:1185
+#, c-format
+msgid "All files (%s)|%s"
+msgstr "Toate fișierele (%s)|%s"
+
+#. TRANSLATORS: %s are a file extension used to build a file wildcard string
+#: ../src/common/fldlgcmn.cpp:810
+#, c-format
+msgid "%s files (%s)|%s"
+msgstr "fișiere %s (%s)|%s"
+
+#: ../src/common/fldlgcmn.cpp:1072
+#, c-format
+msgid "Load %s file"
+msgstr "Încarcă fișier %s"
+
+#: ../src/common/fldlgcmn.cpp:1074
+#, c-format
+msgid "Save %s file"
+msgstr "Salvează fișier %s"
+
+#: ../src/common/fmapbase.cpp:144
+msgid "Western European (ISO-8859-1)"
+msgstr "Vest Europeană (ISO-8859-1)"
+
+#: ../src/common/fmapbase.cpp:145
+msgid "Central European (ISO-8859-2)"
+msgstr "Central-europeană (ISO-8859-2)"
+
+#: ../src/common/fmapbase.cpp:146
+msgid "Esperanto (ISO-8859-3)"
+msgstr "Esperanto (ISO-8859-3)"
+
+#: ../src/common/fmapbase.cpp:147
+msgid "Baltic (old) (ISO-8859-4)"
+msgstr "Baltică (veche) (ISO-8859-4)"
+
+#: ../src/common/fmapbase.cpp:148
+msgid "Cyrillic (ISO-8859-5)"
+msgstr "Chirilică (ISO-8859-5)"
+
+#: ../src/common/fmapbase.cpp:149
+msgid "Arabic (ISO-8859-6)"
+msgstr "Arabă (ISO-8859-6)"
+
+#: ../src/common/fmapbase.cpp:150
+msgid "Greek (ISO-8859-7)"
+msgstr "Greacă (ISO-8859-7)"
+
+#: ../src/common/fmapbase.cpp:151
+msgid "Hebrew (ISO-8859-8)"
+msgstr "Ebraică (ISO-8859-8)"
+
+#: ../src/common/fmapbase.cpp:152
+msgid "Turkish (ISO-8859-9)"
+msgstr "Turcă (ISO-8859-9)"
+
+#: ../src/common/fmapbase.cpp:153
+msgid "Nordic (ISO-8859-10)"
+msgstr "Nordică (ISO-8859-10)"
+
+#: ../src/common/fmapbase.cpp:154
+msgid "Thai (ISO-8859-11)"
+msgstr "Tailandeză (ISO-8859-11)"
+
+#: ../src/common/fmapbase.cpp:155
+msgid "Indian (ISO-8859-12)"
+msgstr "Indian (ISO-8859-12)"
+
+#: ../src/common/fmapbase.cpp:156
+msgid "Baltic (ISO-8859-13)"
+msgstr "Baltică (ISO-8859-13)"
+
+#: ../src/common/fmapbase.cpp:157
+msgid "Celtic (ISO-8859-14)"
+msgstr "Celtică (ISO-8859-14)"
+
+#: ../src/common/fmapbase.cpp:158
+msgid "Western European with Euro (ISO-8859-15)"
+msgstr "Vest Europeană cu Euro (ISO-8859-15)"
+
+#: ../src/common/fmapbase.cpp:159
+msgid "KOI8-R"
+msgstr "KOI8-R"
+
+#: ../src/common/fmapbase.cpp:160
+msgid "KOI8-U"
+msgstr "KOI8-U"
+
+#: ../src/common/fmapbase.cpp:161
+msgid "Windows/DOS OEM Cyrillic (CP 866)"
+msgstr "Windows/DOS OEM Chirilică (CP 866)"
+
+#: ../src/common/fmapbase.cpp:162
+msgid "Windows Thai (CP 874)"
+msgstr "Windows Tailandeză (CP 874)"
+
+#: ../src/common/fmapbase.cpp:163
+msgid "Windows Japanese (CP 932) or Shift-JIS"
+msgstr "Windows Japoneză (CP 932) sau Shift-JIS"
+
+#: ../src/common/fmapbase.cpp:164
+msgid "Windows Chinese Simplified (CP 936) or GB-2312"
+msgstr "Windows Chineză Simplificată (CP 936) sau GB-2312"
+
+#: ../src/common/fmapbase.cpp:165
+msgid "Windows Korean (CP 949)"
+msgstr "Windows Coreeană (CP 949)"
+
+#: ../src/common/fmapbase.cpp:166
+msgid "Windows Chinese Traditional (CP 950) or Big-5"
+msgstr "Windows Chineză Traditională (CP 950) sau Big-5"
+
+#: ../src/common/fmapbase.cpp:167
+msgid "Windows Central European (CP 1250)"
+msgstr "Windows Central Europeană (CP 1250)"
+
+#: ../src/common/fmapbase.cpp:168
+msgid "Windows Cyrillic (CP 1251)"
+msgstr "Windows Chirilică (CP 1251)"
+
+#: ../src/common/fmapbase.cpp:169
+msgid "Windows Western European (CP 1252)"
+msgstr "Windows Vest Europeană (CP 1252)"
+
+#: ../src/common/fmapbase.cpp:170
+msgid "Windows Greek (CP 1253)"
+msgstr "Windows Greacă (CP 1253)"
+
+#: ../src/common/fmapbase.cpp:171
+msgid "Windows Turkish (CP 1254)"
+msgstr "Windows Turcă (CP 1254)"
+
+#: ../src/common/fmapbase.cpp:172
+msgid "Windows Hebrew (CP 1255)"
+msgstr "Windows Ebraică (CP 1255)"
+
+#: ../src/common/fmapbase.cpp:173
+msgid "Windows Arabic (CP 1256)"
+msgstr "Windows Arabică (CP 1256)"
+
+#: ../src/common/fmapbase.cpp:174
+msgid "Windows Baltic (CP 1257)"
+msgstr "Windows Baltică (CP 1257)"
+
+#: ../src/common/fmapbase.cpp:175
+msgid "Windows Vietnamese (CP 1258)"
+msgstr "Windows Vietnameză (CP 1258)"
+
+#: ../src/common/fmapbase.cpp:176
+msgid "Windows Johab (CP 1361)"
+msgstr "Windows Johab (CP 1361)"
+
+#: ../src/common/fmapbase.cpp:177
+msgid "Windows/DOS OEM (CP 437)"
+msgstr "Windows/DOS OEM (CP 437)"
+
+#: ../src/common/fmapbase.cpp:178
+msgid "Unicode 7 bit (UTF-7)"
+msgstr "Unicode 7 bit (UTF-7)"
+
+#: ../src/common/fmapbase.cpp:179
+msgid "Unicode 8 bit (UTF-8)"
+msgstr "Unicode 8 bit (UTF-8)"
+
+#: ../src/common/fmapbase.cpp:181 ../src/common/fmapbase.cpp:187
+msgid "Unicode 16 bit (UTF-16)"
+msgstr "Unicode 16 bit (UTF-16)"
+
+#: ../src/common/fmapbase.cpp:182
+msgid "Unicode 16 bit Little Endian (UTF-16LE)"
+msgstr "Unicode 16 bit Little Endian (UTF-16LE)"
+
+#: ../src/common/fmapbase.cpp:183 ../src/common/fmapbase.cpp:189
+msgid "Unicode 32 bit (UTF-32)"
+msgstr "Unicode 32 bit (UTF-32)"
+
+#: ../src/common/fmapbase.cpp:184
+msgid "Unicode 32 bit Little Endian (UTF-32LE)"
+msgstr "Unicode 32 bit Little Endian (UTF-32LE)"
+
+#: ../src/common/fmapbase.cpp:186
+msgid "Unicode 16 bit Big Endian (UTF-16BE)"
+msgstr "Unicode 16 bit Big Endian (UTF-16BE)"
+
+#: ../src/common/fmapbase.cpp:188
+msgid "Unicode 32 bit Big Endian (UTF-32BE)"
+msgstr "Unicode 32 bit Big Endian (UTF-32BE)"
+
+#: ../src/common/fmapbase.cpp:191
+msgid "Extended Unix Codepage for Japanese (EUC-JP)"
+msgstr "Pagina Unix de coduri extinse pentru limba japoneză (EUC-JP)"
+
+#: ../src/common/fmapbase.cpp:192
+msgid "US-ASCII"
+msgstr "US-ASCII"
+
+#: ../src/common/fmapbase.cpp:193
+msgid "ISO-2022-JP"
+msgstr "ISO-2022-JP"
+
+#: ../src/common/fmapbase.cpp:195
+msgid "MacRoman"
+msgstr "MacRoman"
+
+#: ../src/common/fmapbase.cpp:196
+msgid "MacJapanese"
+msgstr "MacJapanese"
+
+#: ../src/common/fmapbase.cpp:197
+msgid "MacChineseTrad"
+msgstr "MacChineseTrad"
+
+#: ../src/common/fmapbase.cpp:198
+msgid "MacKorean"
+msgstr "MacKorean"
+
+#: ../src/common/fmapbase.cpp:199
+msgid "MacArabic"
+msgstr "MacArabic"
+
+#: ../src/common/fmapbase.cpp:200
+msgid "MacHebrew"
+msgstr "MacHebrew"
+
+#: ../src/common/fmapbase.cpp:201
+msgid "MacGreek"
+msgstr "MacGreek"
+
+#: ../src/common/fmapbase.cpp:202
+msgid "MacCyrillic"
+msgstr "MacCyrillic"
+
+#: ../src/common/fmapbase.cpp:203
+msgid "MacDevanagari"
+msgstr "MacDevanagari"
+
+#: ../src/common/fmapbase.cpp:204
+msgid "MacGurmukhi"
+msgstr "MacGurmukhi"
+
+#: ../src/common/fmapbase.cpp:205
+msgid "MacGujarati"
+msgstr "MacGujarati"
+
+#: ../src/common/fmapbase.cpp:206
+msgid "MacOriya"
+msgstr "MacOriya"
+
+#: ../src/common/fmapbase.cpp:207
+msgid "MacBengali"
+msgstr "MacBengali"
+
+#: ../src/common/fmapbase.cpp:208
+msgid "MacTamil"
+msgstr "MacTamil"
+
+#: ../src/common/fmapbase.cpp:209
+msgid "MacTelugu"
+msgstr "MacTelugu"
+
+#: ../src/common/fmapbase.cpp:210
+msgid "MacKannada"
+msgstr "MacKannada"
+
+#: ../src/common/fmapbase.cpp:211
+msgid "MacMalayalam"
+msgstr "MacMalayalam"
+
+#: ../src/common/fmapbase.cpp:212
+msgid "MacSinhalese"
+msgstr "MacSinhalese"
+
+#: ../src/common/fmapbase.cpp:213
+msgid "MacBurmese"
+msgstr "MacBurmese"
+
+#: ../src/common/fmapbase.cpp:214
+msgid "MacKhmer"
+msgstr "MacKhmer"
+
+#: ../src/common/fmapbase.cpp:215
+msgid "MacThai"
+msgstr "MacThai"
+
+#: ../src/common/fmapbase.cpp:216
+msgid "MacLaotian"
+msgstr "MacLaotian"
+
+#: ../src/common/fmapbase.cpp:217
+msgid "MacGeorgian"
+msgstr "MacGeorgian"
+
+#: ../src/common/fmapbase.cpp:218
+msgid "MacArmenian"
+msgstr "MacArmenian"
+
+#: ../src/common/fmapbase.cpp:219
+msgid "MacChineseSimp"
+msgstr "MacChineseSimp"
+
+#: ../src/common/fmapbase.cpp:220
+msgid "MacTibetan"
+msgstr "MacTibetan"
+
+#: ../src/common/fmapbase.cpp:221
+msgid "MacMongolian"
+msgstr "MacMongolian"
+
+#: ../src/common/fmapbase.cpp:222
+msgid "MacEthiopic"
+msgstr "MacEthiopic"
+
+#: ../src/common/fmapbase.cpp:223
+msgid "MacCentralEurRoman"
+msgstr "MacCentralEurRoman"
+
+#: ../src/common/fmapbase.cpp:224
+msgid "MacVietnamese"
+msgstr "MacVietnamese"
+
+#: ../src/common/fmapbase.cpp:225
+msgid "MacExtArabic"
+msgstr "MacExtArabic"
+
+#: ../src/common/fmapbase.cpp:226
+msgid "MacSymbol"
+msgstr "MacSymbol"
+
+#: ../src/common/fmapbase.cpp:227
+msgid "MacDingbats"
+msgstr "MacDingbats"
+
+#: ../src/common/fmapbase.cpp:228
+msgid "MacTurkish"
+msgstr "MacTurkish"
+
+#: ../src/common/fmapbase.cpp:229
+msgid "MacCroatian"
+msgstr "MacCroatian"
+
+#: ../src/common/fmapbase.cpp:230
+msgid "MacIcelandic"
+msgstr "MacIcelandic"
+
+#: ../src/common/fmapbase.cpp:231
+msgid "MacRomanian"
+msgstr "MacRomanian"
+
+#: ../src/common/fmapbase.cpp:232
+msgid "MacCeltic"
+msgstr "MacCeltic"
+
+#: ../src/common/fmapbase.cpp:233
+msgid "MacGaelic"
+msgstr "MacGaelic"
+
+#: ../src/common/fmapbase.cpp:234
+msgid "MacKeyboardGlyphs"
+msgstr "MacKeyboardGlyphs"
+
+#: ../src/common/fmapbase.cpp:791
+msgid "Default encoding"
+msgstr "Codificare implicită"
+
+#: ../src/common/fmapbase.cpp:805
+#, c-format
+msgid "Unknown encoding (%d)"
+msgstr "Codificare necunoscută (%d)"
+
+#: ../src/common/fmapbase.cpp:815 ../src/richtext/richtextstyles.cpp:776
+msgid "default"
+msgstr "implicit"
+
+#: ../src/common/fmapbase.cpp:829
+#, c-format
+msgid "unknown-%d"
+msgstr "necunoscut-%d"
+
+#: ../src/common/fontcmn.cpp:924 ../src/common/fontcmn.cpp:1130
+msgid "underlined"
+msgstr "subliniat"
+
+#: ../src/common/fontcmn.cpp:929
+msgid " strikethrough"
+msgstr " tăiat"
+
+#: ../src/common/fontcmn.cpp:942
+msgid " thin"
+msgstr " subțire"
+
+#: ../src/common/fontcmn.cpp:946
+msgid " extra light"
+msgstr " foarte ușor"
+
+#: ../src/common/fontcmn.cpp:950
+msgid " light"
+msgstr " ușor"
+
+#: ../src/common/fontcmn.cpp:954
+msgid " medium"
+msgstr " mediu"
+
+#: ../src/common/fontcmn.cpp:958
+msgid " semi bold"
+msgstr " ușor îngroșat"
+
+#: ../src/common/fontcmn.cpp:962
+msgid " bold"
+msgstr " îngroșat"
+
+#: ../src/common/fontcmn.cpp:966
+msgid " extra bold"
+msgstr " foarte îngroșat"
+
+#: ../src/common/fontcmn.cpp:970
+msgid " heavy"
+msgstr " apăsat"
+
+#: ../src/common/fontcmn.cpp:974
+msgid " extra heavy"
+msgstr " foarte apăsat"
+
+#: ../src/common/fontcmn.cpp:990
+msgid " italic"
+msgstr " cursiv"
+
+#: ../src/common/fontcmn.cpp:1134
+msgid "strikethrough"
+msgstr "tăiat"
+
+#: ../src/common/fontcmn.cpp:1143
+msgid "thin"
+msgstr "subțire"
+
+#: ../src/common/fontcmn.cpp:1156
+msgid "extralight"
+msgstr "foarte ușor"
+
+#: ../src/common/fontcmn.cpp:1161
+msgid "light"
+msgstr "ușor"
+
+#: ../src/common/fontcmn.cpp:1169 ../src/richtext/richtextstyles.cpp:775
+msgid "normal"
+msgstr "normal"
+
+#: ../src/common/fontcmn.cpp:1174
+msgid "medium"
+msgstr "mediu"
+
+#: ../src/common/fontcmn.cpp:1179 ../src/common/fontcmn.cpp:1199
+msgid "semibold"
+msgstr "ușor îngroșat"
+
+#: ../src/common/fontcmn.cpp:1184
+msgid "bold"
+msgstr "îngroșat"
+
+#: ../src/common/fontcmn.cpp:1194
+msgid "extrabold"
+msgstr "foarte îngroșat"
+
+#: ../src/common/fontcmn.cpp:1204
+msgid "heavy"
+msgstr "apăsat"
+
+#: ../src/common/fontcmn.cpp:1212
+msgid "extraheavy"
+msgstr "foarte apăsat"
+
+#: ../src/common/fontcmn.cpp:1217
+msgid "italic"
+msgstr "cursiv"
+
+#: ../src/common/fontmap.cpp:195
+msgid ": unknown charset"
+msgstr ": set de caractere necunoscut"
+
+#: ../src/common/fontmap.cpp:199
+#, c-format
+msgid ""
+"The charset '%s' is unknown. You may select\n"
+"another charset to replace it with or choose\n"
+"[Cancel] if it cannot be replaced"
+msgstr ""
+"Setul de caractere '%s' este necunoscut. Puteți selecta\n"
+"alt set de caractere care să-l înlocuiască sau alegeți\n"
+"[Anulează] dacă nu poate fi înlocuit"
+
+#: ../src/common/fontmap.cpp:241
+#, c-format
+msgid "Failed to remember the encoding for the charset '%s'."
+msgstr "A eșuat memorarea codificării setului de caractere '%s'."
+
+#: ../src/common/fontmap.cpp:321
+msgid "can't load any font, aborting"
+msgstr "nu poate fi încărcat niciun font, se abandonează"
+
+#: ../src/common/fontmap.cpp:409
+msgid ": unknown encoding"
+msgstr ": codificare necunoscută"
+
+#: ../src/common/fontmap.cpp:417
+#, c-format
+msgid ""
+"No font for displaying text in encoding '%s' found,\n"
+"but an alternative encoding '%s' is available.\n"
+"Do you want to use this encoding (otherwise you will have to choose another "
+"one)?"
+msgstr ""
+"Nu există font pentru afișarea textului în codificarea '%s',\n"
+"dar o codificare alternativă '%s' este disponibilă.\n"
+"Vreți să folosiți această codificare (altfel va trebui aleasă alta diferită)?"
+
+#: ../src/common/fontmap.cpp:422
+#, c-format
+msgid ""
+"No font for displaying text in encoding '%s' found.\n"
+"Would you like to select a font to be used for this encoding\n"
+"(otherwise the text in this encoding will not be shown correctly)?"
+msgstr ""
+"Nu există font pentru afișarea textului în codificarea '%s'.\n"
+"Vreți să alegeți un font pentru a fi folosit cu această codificare\n"
+"(altfel textul folosind această codificare nu va fi afișat corect)?"
+
+#: ../src/common/fs_mem.cpp:169
+#, c-format
+msgid "Memory VFS already contains file '%s'!"
+msgstr "VFS din memorie conține deja fișierul '%s'!"
+
+#: ../src/common/fs_mem.cpp:232
+#, c-format
+msgid "Trying to remove file '%s' from memory VFS, but it is not loaded!"
+msgstr ""
+"Se încearcă eliminarea fișierului '%s' din memoria VFS, dar acesta nu este "
+"încărcat!"
+
+#: ../src/common/fs_mem.cpp:262
+#, c-format
+msgid "Failed to store image '%s' to memory VFS!"
+msgstr "A eșuat stocarea imaginii '%s' în VFS din memorie!"
+
+#: ../src/common/ftp.cpp:197
+msgid "Timeout while waiting for FTP server to connect, try passive mode."
+msgstr ""
+"Timpul a expirat așteptând serverul FTP să se conecteze, încercați modul "
+"pasiv."
+
+#: ../src/common/ftp.cpp:399
+#, c-format
+msgid "Failed to set FTP transfer mode to %s."
+msgstr "A eșuat setarea modului de transfer FTP la %s."
+
+#: ../src/common/ftp.cpp:400 ../src/richtext/richtextsymboldlg.cpp:432
+msgid "ASCII"
+msgstr "ASCII"
+
+#: ../src/common/ftp.cpp:400
+msgid "binary"
+msgstr "binar"
+
+#: ../src/common/ftp.cpp:608
+msgid "The FTP server doesn't support the PORT command."
+msgstr "Serverul FTP nu suportă comanda PORT."
+
+#: ../src/common/ftp.cpp:622
+msgid "The FTP server doesn't support passive mode."
+msgstr "Serverul FTP nu suportă modul pasiv."
+
+#: ../src/common/gifdecod.cpp:822
+#, c-format
+msgid "Incorrect GIF frame size (%u, %d) for the frame #%u"
+msgstr "Cadru GIF cu dimensiunea (%u, %d) incorectă pentru cadrul #%u"
+
+#: ../src/common/glcmn.cpp:108
+msgid "Failed to allocate colour for OpenGL"
+msgstr "A eșuat alocarea culorii pentru OpenGL"
+
+#: ../src/common/headerctrlcmn.cpp:57
+msgid "Please select the columns to show and define their order:"
+msgstr "Alegeți coloanele ce trebuiesc afișate și stabiliți-le ordinea:"
+
+#: ../src/common/headerctrlcmn.cpp:58
+msgid "Customize Columns"
+msgstr "Personalizează coloane"
+
+#: ../src/common/headerctrlcmn.cpp:304
+msgid "&Customize..."
+msgstr "&Personalizează..."
+
+#: ../src/common/hyperlnkcmn.cpp:132
+#, c-format
+msgid "Failed to open URL \"%s\" in the default browser"
+msgstr "A eșuat deschiderea URL-ului \"%s\" in browser-ul implicit"
+
+#: ../src/common/iconbndl.cpp:195
+#, c-format
+msgid "Failed to load image %%d from file '%s'."
+msgstr "A eșuat încărcarea imaginii %%d din fișierul '%s'."
+
+#: ../src/common/iconbndl.cpp:203
+#, c-format
+msgid "Failed to load image %d from stream."
+msgstr "A eșuat încărcarea imaginii %d din fluxul de date."
+
+#: ../src/common/iconbndl.cpp:221
+#, c-format
+msgid "Failed to load icons from resource '%s'."
+msgstr "A eșuat încărcarea iconiței din resursa \"%s\"."
+
+#: ../src/common/imagbmp.cpp:97
+msgid "BMP: Couldn't save invalid image."
+msgstr "BMP: Nu a putut fi salvată imaginea invalidă."
+
+#: ../src/common/imagbmp.cpp:137
+msgid "BMP: wxImage doesn't have own wxPalette."
+msgstr "BMP: wxImage nu are un obiect wxPalette propriu."
+
+#: ../src/common/imagbmp.cpp:243
+msgid "BMP: Couldn't write the file (Bitmap) header."
+msgstr "BMP: Nu a putut fi scris antetul (Bitmap) fișierului."
+
+#: ../src/common/imagbmp.cpp:266
+msgid "BMP: Couldn't write the file (BitmapInfo) header."
+msgstr "BMP: Nu a putut fi scris antetul (BitmapInfo) fișierului."
+
+#: ../src/common/imagbmp.cpp:353
+msgid "BMP: Couldn't write RGB color map."
+msgstr "BMP: Nu a putut fi scrisă harta RGB."
+
+#: ../src/common/imagbmp.cpp:487
+msgid "BMP: Couldn't write data."
+msgstr "BMP: Nu au putut fi scrise datele."
+
+#: ../src/common/imagbmp.cpp:561 ../src/common/imagbmp.cpp:642
+msgid "BMP: Couldn't allocate memory."
+msgstr "BMP: Nu a putut fi alocată memorie."
+
+#: ../src/common/imagbmp.cpp:1041
+msgid "DIB Header: Image width > 32767 pixels for file."
+msgstr "Antet DIB: Lațimea imaginii > 32767 pixeli pentru fișier."
+
+#: ../src/common/imagbmp.cpp:1049
+msgid "DIB Header: Image height > 32767 pixels for file."
+msgstr "Antet DIB: Inălțimea imaginii > 32767 pixeli pentru fișier."
+
+#: ../src/common/imagbmp.cpp:1081
+msgid "DIB Header: Unknown bitdepth in file."
+msgstr "Antet DIB: Adâncime de biți necunoscută în fișier."
+
+#: ../src/common/imagbmp.cpp:1156
+msgid "DIB Header: Unknown encoding in file."
+msgstr "Antet DIB: Codificare necunoscută in fișier."
+
+#: ../src/common/imagbmp.cpp:1165
+msgid "DIB Header: Encoding doesn't match bitdepth."
+msgstr "Antet DIB: Codificarea nu corespunde adâncimii de biți."
+
+#: ../src/common/imagbmp.cpp:1180
+#, c-format
+msgid "BMP Header: Invalid number of colors (%d)."
+msgstr "Antet BMP: Număr de culori (%d) invalid."
+
+#: ../src/common/imagbmp.cpp:1273
+msgid "Error in reading image DIB."
+msgstr "Eroare la citirea DIB pentru imagine."
+
+#: ../src/common/imagbmp.cpp:1294
+msgid "ICO: Error in reading mask DIB."
+msgstr "ICO: Eroare la citirea maștii DIB."
+
+#: ../src/common/imagbmp.cpp:1353
+msgid "ICO: Image too tall for an icon."
+msgstr "ICO: Imagine prea înaltă pentru o pictogramă."
+
+#: ../src/common/imagbmp.cpp:1361
+msgid "ICO: Image too wide for an icon."
+msgstr "ICO: Imagine prea lată pentru o pictogramă."
+
+#: ../src/common/imagbmp.cpp:1388 ../src/common/imagbmp.cpp:1488
+#: ../src/common/imagbmp.cpp:1503 ../src/common/imagbmp.cpp:1514
+#: ../src/common/imagbmp.cpp:1528 ../src/common/imagbmp.cpp:1576
+#: ../src/common/imagbmp.cpp:1591 ../src/common/imagbmp.cpp:1605
+#: ../src/common/imagbmp.cpp:1616
+msgid "ICO: Error writing the image file!"
+msgstr "ICO: Eroare la scrierea fișierului imagine!"
+
+#: ../src/common/imagbmp.cpp:1701
+msgid "ICO: Invalid icon index."
+msgstr "ICO: Index de pictogramă invalid."
+
+#: ../src/common/image.cpp:2410
+msgid "Image and mask have different sizes."
+msgstr "Imaginea și masca au dimensiuni diferite."
+
+#: ../src/common/image.cpp:2418 ../src/common/image.cpp:2459
+msgid "No unused colour in image being masked."
+msgstr "Nicio culoare nefolosită din imagine nu este mascată."
+
+#: ../src/common/image.cpp:2641
+#, c-format
+msgid "Failed to load bitmap \"%s\" from resources."
+msgstr "A eșuat încărcarea imaginii \"%s\" din resurse."
+
+#: ../src/common/image.cpp:2650
+#, c-format
+msgid "Failed to load icon \"%s\" from resources."
+msgstr "A eșuat încărcarea iconiței \"%s\" din resurse."
+
+#: ../src/common/image.cpp:2728 ../src/common/image.cpp:2747
+#, c-format
+msgid "Failed to load image from file \"%s\"."
+msgstr "A eșuat încărcarea imaginii din fișierul \"%s\"."
+
+#: ../src/common/image.cpp:2761
+#, c-format
+msgid "Can't save image to file '%s': unknown extension."
+msgstr "Nu se poate salva imaginea în fișierul '%s': extensie necunoscută."
+
+#: ../src/common/image.cpp:2869
+msgid "No handler found for image type."
+msgstr "Nu a fost găsit niciun operator pentru tipul de imagine."
+
+#: ../src/common/image.cpp:2877 ../src/common/image.cpp:3000
+#: ../src/common/image.cpp:3066
+#, c-format
+msgid "No image handler for type %d defined."
+msgstr "Nu a fost definit niciun operator de imagine pentru tipul %d."
+
+#: ../src/common/image.cpp:2887
+#, c-format
+msgid "Image file is not of type %d."
+msgstr "Fișierul imagine nu e de tipul %d."
+
+#: ../src/common/image.cpp:2970
+msgid "Can't automatically determine the image format for non-seekable input."
+msgstr ""
+"Formatul imaginii nu poate fi determinat automat pentru input ce nu poate fi "
+"examinat."
+
+#: ../src/common/image.cpp:2988
+msgid "Unknown image data format."
+msgstr "Format de imagine necunoscut."
+
+#: ../src/common/image.cpp:3009
+#, c-format
+msgid "This is not a %s."
+msgstr "Acesta nu este un %s."
+
+#: ../src/common/image.cpp:3032 ../src/common/image.cpp:3080
+#, c-format
+msgid "No image handler for type %s defined."
+msgstr "Nu a fost definit niciun operator de imagine pentru tipul %s."
+
+#: ../src/common/image.cpp:3041
+#, c-format
+msgid "Image is not of type %s."
+msgstr "Imaginea nu e de tipul %s."
+
+#: ../src/common/image.cpp:3509
+#, c-format
+msgid "Failed to check format of image file \"%s\"."
+msgstr "A eșuat detectarea formatului fișierului imagine \"%s\"."
+
+#: ../src/common/imaggif.cpp:124
+msgid "GIF: error in GIF image format."
+msgstr "GIF: eroare în formatul de imagine GIF."
+
+#: ../src/common/imaggif.cpp:129
+msgid "GIF: not enough memory."
+msgstr "GIF: memorie insuficientă."
+
+#: ../src/common/imaggif.cpp:134
+msgid "GIF: data stream seems to be truncated."
+msgstr "GIF: fluxul de date pare să fie trunchiat."
+
+#: ../src/common/imaggif.cpp:240
+msgid "Couldn't initialize GIF hash table."
+msgstr "Tabela de dispersie GIF nu a putut fi inițializată."
+
+#: ../src/common/imagiff.cpp:739
+msgid "IFF: error in IFF image format."
+msgstr "IFF: eroare în formatul imaginii IFF."
+
+#: ../src/common/imagiff.cpp:742
+msgid "IFF: not enough memory."
+msgstr "IFF: memorie insuficientă."
+
+#: ../src/common/imagiff.cpp:745
+msgid "IFF: unknown error!!!"
+msgstr "IFF: eroare necunoscută!!!"
+
+#: ../src/common/imagiff.cpp:755
+msgid "IFF: data stream seems to be truncated."
+msgstr "IFF: fluxul de date pare a fi trunchiat."
+
+#: ../src/common/imagjpeg.cpp:258
+msgid "JPEG: Couldn't load - file is probably corrupted."
+msgstr "JPEG: Nu a putut fi încărcat - fișierul este probabil corupt."
+
+#: ../src/common/imagjpeg.cpp:437
+msgid "JPEG: Couldn't save image."
+msgstr "JPEG: Nu a putut fi salvată imaginea."
+
+#: ../src/common/imagpcx.cpp:439
+msgid "PCX: this is not a PCX file."
+msgstr "PCX: acesta nu este un fișier PCX."
+
+#: ../src/common/imagpcx.cpp:453
+msgid "PCX: image format unsupported"
+msgstr "PCX: format de imagine nesuportat"
+
+#: ../src/common/imagpcx.cpp:454 ../src/common/imagpcx.cpp:477
+msgid "PCX: couldn't allocate memory"
+msgstr "PCX: nu s-a putut aloca memorie"
+
+#: ../src/common/imagpcx.cpp:455
+msgid "PCX: version number too low"
+msgstr "PCX: numărul versiunii prea mic"
+
+#: ../src/common/imagpcx.cpp:456 ../src/common/imagpcx.cpp:478
+msgid "PCX: unknown error !!!"
+msgstr "PCX: eroare necunoscută !!!"
+
+#: ../src/common/imagpcx.cpp:476
+msgid "PCX: invalid image"
+msgstr "PCX: imagine invalidă"
+
+#: ../src/common/imagpng.cpp:385
+#, c-format
+msgid "Unknown PNG resolution unit %d"
+msgstr "Unitatea %d de rezoluție pentru PNG necunoscută"
+
+#: ../src/common/imagpng.cpp:439
+msgid "Couldn't load a PNG image - file is corrupted or not enough memory."
+msgstr ""
+"Nu s-a putut încărca o imagine PNG - fișierul este corupt sau nu este "
+"suficientă memorie."
+
+#: ../src/common/imagpng.cpp:513 ../src/common/imagpng.cpp:524
+#: ../src/common/imagpng.cpp:534
+msgid "Couldn't save PNG image."
+msgstr "Nu a putut fi salvată imaginea PNG."
+
+#: ../src/common/imagpnm.cpp:71
+msgid "PNM: File format is not recognized."
+msgstr "PNM: Formatul fișierului nu este recunoscut."
+
+#: ../src/common/imagpnm.cpp:89
+msgid "PNM: Couldn't allocate memory."
+msgstr "PNM: Nu s-a putut aloca memorie."
+
+#: ../src/common/imagpnm.cpp:111 ../src/common/imagpnm.cpp:134
+#: ../src/common/imagpnm.cpp:156
+msgid "PNM: File seems truncated."
+msgstr "PNM: Fișierul pare trunchiat."
+
+#: ../src/common/imagtiff.cpp:69
+#, c-format
+msgid " (in module \"%s\")"
+msgstr " (în modulul \"%s\")"
+
+#: ../src/common/imagtiff.cpp:304
+msgid "TIFF: Error loading image."
+msgstr "TIFF: Eroare la încărcarea imaginii."
+
+#: ../src/common/imagtiff.cpp:314
+msgid "Invalid TIFF image index."
+msgstr "Indexul imaginii TIFF este invalid."
+
+#: ../src/common/imagtiff.cpp:358
+msgid "TIFF: Image size is abnormally big."
+msgstr "TIFF: Dimensiunea imaginii este anormal de mare."
+
+#: ../src/common/imagtiff.cpp:372 ../src/common/imagtiff.cpp:385
+#: ../src/common/imagtiff.cpp:769
+msgid "TIFF: Couldn't allocate memory."
+msgstr "TIFF: Nu s-a putut aloca memorie."
+
+#: ../src/common/imagtiff.cpp:471
+msgid "TIFF: Error reading image."
+msgstr "TIFF: Eroare la citirea imaginii."
+
+#: ../src/common/imagtiff.cpp:532
+#, c-format
+msgid "Unknown TIFF resolution unit %d ignored"
+msgstr "Unitatea de rezoluție TIFF necunoscută %d ignorată"
+
+#: ../src/common/imagtiff.cpp:611
+msgid "TIFF: Error saving image."
+msgstr "TIFF: Eroare la salvarea imaginii."
+
+#: ../src/common/imagtiff.cpp:868
+msgid "TIFF: Error writing image."
+msgstr "TIFF: Eroare la scrierea imaginii."
+
+#: ../src/common/imagtiff.cpp:881
+msgid "TIFF: Error flushing data."
+msgstr "TIFF: Eroare la scrierea datelor."
+
+#: ../src/common/imagwebp.cpp:56
+msgid "WebP: Invalid data (failed to get features)."
+msgstr "WebP: Date invalide (a eșuat obținerea caracteristicilor)."
+
+#: ../src/common/imagwebp.cpp:65
+msgid "WebP: Allocating image memory failed."
+msgstr "WebP: A eșuat alocarea de memorie pentru imagine."
+
+#: ../src/common/imagwebp.cpp:82
+msgid "WebP: Decoding RGBA image data failed."
+msgstr "WebP: A eșuat decodificarea conținutului RGBA al imaginii."
+
+#: ../src/common/imagwebp.cpp:98
+msgid "WebP: Decoding RGB image data failed."
+msgstr "WebP: A eșuat decodificarea conținutului RGB al imaginii."
+
+#: ../src/common/imagwebp.cpp:113 ../src/common/imagwebp.cpp:201
+msgid "WebP: Allocating stream buffer failed."
+msgstr "WebP: A eșuat alocarea de memorie tampon pentru fluxul de date."
+
+#: ../src/common/imagwebp.cpp:131
+msgid "WebP: Failed to parse container data."
+msgstr "WebP: A eșuat parcurgerea datelor din container."
+
+#: ../src/common/imagwebp.cpp:222
+msgid "WebP: Error decoding animation."
+msgstr "WebP: Eroare la decodificarea animației."
+
+#: ../src/common/imagwebp.cpp:240
+msgid "WebP: Error getting next animation frame."
+msgstr "WebP: Eroare la obținerea urmatorului cadru de animație."
+
+#: ../src/common/init.cpp:172
+#, c-format
+msgid ""
+"Command line argument %d couldn't be converted to Unicode and will be "
+"ignored."
+msgstr ""
+"Argumentul %d din linia de comandă nu a putut fi convertit la Unicode și va "
+"fi ignorat."
+
+#: ../src/common/init.cpp:344
+msgid "Initialization failed in post init, aborting."
+msgstr "Inițializare eșuată în post-init, se anulează."
+
+#: ../src/common/intl.cpp:378
+#, c-format
+msgid "Cannot set locale to language \"%s\"."
+msgstr "Nu se poate seta locala la limba \"%s\"."
+
+#: ../src/common/log.cpp:232
+msgid "Error: "
+msgstr "Eroare: "
+
+#: ../src/common/log.cpp:236
+msgid "Warning: "
+msgstr "Avertisment: "
+
+#: ../src/common/log.cpp:284
+msgid "The previous message repeated once."
+msgstr "Mesajul anterior e repetat o dată."
+
+#: ../src/common/log.cpp:291
+#, c-format
+msgid "The previous message repeated %u time."
+msgid_plural "The previous message repeated %u times."
+msgstr[0] "Mesajul anterior e repetat %u dată."
+msgstr[1] "Mesajul anterior e repetat de %u ori."
+msgstr[2] "Mesajul anterior e repetat de %u de ori."
+
+#: ../src/common/log.cpp:319
+#, c-format
+msgid "Last repeated message (\"%s\", %u time) wasn't output"
+msgid_plural "Last repeated message (\"%s\", %u times) wasn't output"
+msgstr[0] "Ultimul mesaj repetat (\"%s\", %u data) nu a fost afișat"
+msgstr[1] "Ultimul mesaj repetat (\"%s\", %u ori) nu a fost afișat"
+msgstr[2] "Ultimul mesaj repetat (\"%s\", %u de ori) nu a fost afișat"
+
+#: ../src/common/log.cpp:435
+#, c-format
+msgid " (error %ld: %s)"
+msgstr " (eroarea %ld: %s)"
+
+#: ../src/common/lzmastream.cpp:121
+msgid "Failed to allocate memory for LZMA decompression."
+msgstr "A eșuat alocarea de memorie pentru decompresia LZMA."
+
+#: ../src/common/lzmastream.cpp:125
+#, c-format
+msgid "Failed to initialize LZMA decompression: unexpected error %u."
+msgstr "A eșuat inițializarea decompresiei LZMA: erorare neașteptată %u."
+
+#: ../src/common/lzmastream.cpp:179
+msgid "input is not in XZ format"
+msgstr "inputul nu este în format XZ"
+
+#: ../src/common/lzmastream.cpp:183
+msgid "input compressed using unknown XZ option"
+msgstr "input comprimat folosind o opțiune XZ necunoscută"
+
+#: ../src/common/lzmastream.cpp:188
+msgid "input is corrupted"
+msgstr "inputul este compromis"
+
+#: ../src/common/lzmastream.cpp:192
+msgid "unknown decompression error"
+msgstr "eroare necunoscută de decomprimare"
+
+#: ../src/common/lzmastream.cpp:196
+#, c-format
+msgid "LZMA decompression error: %s"
+msgstr "Eroare de decomprimare LZMA: %s"
+
+#: ../src/common/lzmastream.cpp:231
+msgid "Failed to allocate memory for LZMA compression."
+msgstr "A eșuat alocarea de memorie pentru compresia LZMA."
+
+#: ../src/common/lzmastream.cpp:235
+#, c-format
+msgid "Failed to initialize LZMA compression: unexpected error %u."
+msgstr "A eșuat inițializarea compresiei LZMA: erorare neașteptată %u."
+
+#: ../src/common/lzmastream.cpp:267 ../src/common/lzmastream.cpp:342
+#: ../src/html/chm.cpp:336
+msgid "out of memory"
+msgstr "memorie epuizată"
+
+#: ../src/common/lzmastream.cpp:276 ../src/common/lzmastream.cpp:346
+msgid "unknown compression error"
+msgstr "eroare necunoscută de comprimare"
+
+#: ../src/common/lzmastream.cpp:280
+#, c-format
+msgid "LZMA compression error: %s"
+msgstr "Eroare de comprimare LZMA: %s"
+
+#: ../src/common/lzmastream.cpp:350
+#, c-format
+msgid "LZMA compression error when flushing output: %s"
+msgstr "Eroare de comprimare LZMA la transmiterea către output: %s"
+
+#: ../src/common/mimecmn.cpp:167
+#, c-format
+msgid "Unmatched '{' in an entry for mime type %s."
+msgstr "'{' fără pereche într-o intrare pentru tipul mime %s."
+
+#: ../src/common/module.cpp:76
+#, c-format
+msgid "Circular dependency involving module \"%s\" detected."
+msgstr "A fost detectată o dependență circulară care implică modulul \"%s\"."
+
+#: ../src/common/module.cpp:128
+#, c-format
+msgid "Dependency \"%s\" of module \"%s\" doesn't exist."
+msgstr "Dependința \"%s\" a modulului \"%s\" nu există."
+
+#: ../src/common/module.cpp:137
+#, c-format
+msgid "Module \"%s\" initialization failed"
+msgstr "Inițializarea modulului \"%s\" a eșuat"
+
+#: ../src/common/msgout.cpp:96
+msgid "Message"
+msgstr "Mesaj"
+
+#: ../src/common/paper.cpp:70
+msgid "Letter, 8 1/2 x 11 in"
+msgstr "Letter, 8 1/2 x 11 in"
+
+#: ../src/common/paper.cpp:71
+msgid "Legal, 8 1/2 x 14 in"
+msgstr "Legal, 8 1/2 x 14 in"
+
+#: ../src/common/paper.cpp:72
+msgid "A4 sheet, 210 x 297 mm"
+msgstr "A4 foaie, 210 x 297 mm"
+
+#: ../src/common/paper.cpp:73
+msgid "C sheet, 17 x 22 in"
+msgstr "C foaie, 17 x 22 in"
+
+#: ../src/common/paper.cpp:74
+msgid "D sheet, 22 x 34 in"
+msgstr "D foaie, 22 x 34 in"
+
+#: ../src/common/paper.cpp:75
+msgid "E sheet, 34 x 44 in"
+msgstr "E foaie, 34 x 44 in"
+
+#: ../src/common/paper.cpp:76
+msgid "Letter Small, 8 1/2 x 11 in"
+msgstr "Letter mic, 8 1/2 x 11 in"
+
+#: ../src/common/paper.cpp:77
+msgid "Tabloid, 11 x 17 in"
+msgstr "Tabloid, 11 x 17 in"
+
+#: ../src/common/paper.cpp:78
+msgid "Ledger, 17 x 11 in"
+msgstr "Registru, 17 x 11 in"
+
+#: ../src/common/paper.cpp:79
+msgid "Statement, 5 1/2 x 8 1/2 in"
+msgstr "Declarație, 5 1/2 x 8 1/2 in"
+
+#: ../src/common/paper.cpp:80
+msgid "Executive, 7 1/4 x 10 1/2 in"
+msgstr "Executiv, 7 1/4 x 10 1/2 in"
+
+#: ../src/common/paper.cpp:81
+msgid "A3 sheet, 297 x 420 mm"
+msgstr "A3 foaie, 297 x 420 mm"
+
+#: ../src/common/paper.cpp:82
+msgid "A4 small sheet, 210 x 297 mm"
+msgstr "A4 foaie mică, 210 x 297 mm"
+
+#: ../src/common/paper.cpp:83
+msgid "A5 sheet, 148 x 210 mm"
+msgstr "A5 foaie, 148 x 210 mm"
+
+#: ../src/common/paper.cpp:84
+msgid "B4 sheet, 250 x 354 mm"
+msgstr "B4 foaie, 250 x 354 mm"
+
+#: ../src/common/paper.cpp:85
+msgid "B5 sheet, 182 x 257 millimeter"
+msgstr "B5 foaie, 182 x 257 milimetri"
+
+#: ../src/common/paper.cpp:86
+msgid "Folio, 8 1/2 x 13 in"
+msgstr "Folio, 8 1/2 x 13 in"
+
+#: ../src/common/paper.cpp:87
+msgid "Quarto, 215 x 275 mm"
+msgstr "Quarto, 215 x 275 mm"
+
+#: ../src/common/paper.cpp:88
+msgid "10 x 14 in"
+msgstr "10 x 14 in"
+
+#: ../src/common/paper.cpp:89
+msgid "11 x 17 in"
+msgstr "11 x 17 in"
+
+#: ../src/common/paper.cpp:90
+msgid "Note, 8 1/2 x 11 in"
+msgstr "Note, 8 1/2 x 11 in"
+
+#: ../src/common/paper.cpp:91
+msgid "#9 Envelope, 3 7/8 x 8 7/8 in"
+msgstr "#9 Plic, 3 7/8 x 8 7/8 in"
+
+#: ../src/common/paper.cpp:92
+msgid "#10 Envelope, 4 1/8 x 9 1/2 in"
+msgstr "#10 Plic, 4 1/8 x 9 1/2 in"
+
+#: ../src/common/paper.cpp:93
+msgid "#11 Envelope, 4 1/2 x 10 3/8 in"
+msgstr "#11 Plic, 4 1/2 x 10 3/8 in"
+
+#: ../src/common/paper.cpp:94
+msgid "#12 Envelope, 4 3/4 x 11 in"
+msgstr "#12 Plic, 4 3/4 x 11 in"
+
+#: ../src/common/paper.cpp:95
+msgid "#14 Envelope, 5 x 11 1/2 in"
+msgstr "#14 Plic, 5 x 11 1/2 in"
+
+#: ../src/common/paper.cpp:96
+msgid "DL Envelope, 110 x 220 mm"
+msgstr "DL Plic, 110 x 220 mm"
+
+#: ../src/common/paper.cpp:97
+msgid "C5 Envelope, 162 x 229 mm"
+msgstr "C5 Plic, 162 x 229 mm"
+
+#: ../src/common/paper.cpp:98
+msgid "C3 Envelope, 324 x 458 mm"
+msgstr "C3 Plic, 324 x 458 mm"
+
+#: ../src/common/paper.cpp:99
+msgid "C4 Envelope, 229 x 324 mm"
+msgstr "C4 Plic, 229 x 324 mm"
+
+#: ../src/common/paper.cpp:100
+msgid "C6 Envelope, 114 x 162 mm"
+msgstr "C6 Plic, 114 x 162 mm"
+
+#: ../src/common/paper.cpp:101
+msgid "C65 Envelope, 114 x 229 mm"
+msgstr "C65 Plic, 114 x 229 mm"
+
+#: ../src/common/paper.cpp:102
+msgid "B4 Envelope, 250 x 353 mm"
+msgstr "B4 Plic, 250 x 353 mm"
+
+#: ../src/common/paper.cpp:103
+msgid "B5 Envelope, 176 x 250 mm"
+msgstr "B5 Plic, 176 x 250 mm"
+
+#: ../src/common/paper.cpp:104
+msgid "B6 Envelope, 176 x 125 mm"
+msgstr "B6 Plic, 176 x 125 mm"
+
+#: ../src/common/paper.cpp:105
+msgid "Italy Envelope, 110 x 230 mm"
+msgstr "Italy Plic, 110 x 230 mm"
+
+#: ../src/common/paper.cpp:106
+msgid "Monarch Envelope, 3 7/8 x 7 1/2 in"
+msgstr "Monarch Plic, 3 7/8 x 7 1/2 in"
+
+#: ../src/common/paper.cpp:107
+msgid "6 3/4 Envelope, 3 5/8 x 6 1/2 in"
+msgstr "6 3/4 Plic, 3 5/8 x 6 1/2 in"
+
+#: ../src/common/paper.cpp:108
+msgid "US Std Fanfold, 14 7/8 x 11 in"
+msgstr "US Std Fanfold, 14 7/8 x 11 in"
+
+#: ../src/common/paper.cpp:109
+msgid "German Std Fanfold, 8 1/2 x 12 in"
+msgstr "German Std Fanfold, 8 1/2 x 12 in"
+
+#: ../src/common/paper.cpp:110
+msgid "German Legal Fanfold, 8 1/2 x 13 in"
+msgstr "German Legal Fanfold, 8 1/2 x 13 in"
+
+#: ../src/common/paper.cpp:112
+msgid "B4 (ISO) 250 x 353 mm"
+msgstr "B4 (ISO) 250 x 353 mm"
+
+#: ../src/common/paper.cpp:113
+msgid "Japanese Postcard 100 x 148 mm"
+msgstr "Japoneză, carte postală 100 x 148 mm"
+
+#: ../src/common/paper.cpp:114
+msgid "9 x 11 in"
+msgstr "9 x 11 in"
+
+#: ../src/common/paper.cpp:115
+msgid "10 x 11 in"
+msgstr "10 x 11 in"
+
+#: ../src/common/paper.cpp:116
+msgid "15 x 11 in"
+msgstr "15 x 11 in"
+
+#: ../src/common/paper.cpp:117
+msgid "Envelope Invite 220 x 220 mm"
+msgstr "Plic Invitație 220 x 220 mm"
+
+#: ../src/common/paper.cpp:118
+msgid "Letter Extra 9 1/2 x 12 in"
+msgstr "Letter Extra 9 1/2 x 12 in"
+
+#: ../src/common/paper.cpp:119
+msgid "Legal Extra 9 1/2 x 15 in"
+msgstr "Legal Extra 9 1/2 x 15 in"
+
+#: ../src/common/paper.cpp:120
+msgid "Tabloid Extra 11.69 x 18 in"
+msgstr "Tabloid Extra 11.69 x 18 in"
+
+#: ../src/common/paper.cpp:121
+msgid "A4 Extra 9.27 x 12.69 in"
+msgstr "A4 Extra 9.27 x 12.69 in"
+
+#: ../src/common/paper.cpp:122
+msgid "Letter Transverse 8 1/2 x 11 in"
+msgstr "Letter Transverse 8 1/2 x 11 in"
+
+#: ../src/common/paper.cpp:123
+msgid "A4 Transverse 210 x 297 mm"
+msgstr "A4 Transversal 210 x 297 mm"
+
+#: ../src/common/paper.cpp:124
+msgid "Letter Extra Transverse 9.275 x 12 in"
+msgstr "Letter Extra Transverse 9.275 x 12 in"
+
+#: ../src/common/paper.cpp:125
+msgid "SuperA/SuperA/A4 227 x 356 mm"
+msgstr "SuperA/SuperA/A4 227 x 356 mm"
+
+#: ../src/common/paper.cpp:126
+msgid "SuperB/SuperB/A3 305 x 487 mm"
+msgstr "SuperB/SuperB/A3 305 x 487 mm"
+
+#: ../src/common/paper.cpp:127
+msgid "Letter Plus 8 1/2 x 12.69 in"
+msgstr "Letter Plus 8 1/2 x 12.69 in"
+
+#: ../src/common/paper.cpp:128
+msgid "A4 Plus 210 x 330 mm"
+msgstr "A4 Plus 210 x 330 mm"
+
+#: ../src/common/paper.cpp:129
+msgid "A5 Transverse 148 x 210 mm"
+msgstr "A5 Transversal 148 x 210 mm"
+
+#: ../src/common/paper.cpp:130
+msgid "B5 (JIS) Transverse 182 x 257 mm"
+msgstr "B5 (JIS) Transversal 182 x 257 mm"
+
+#: ../src/common/paper.cpp:131
+msgid "A3 Extra 322 x 445 mm"
+msgstr "A3 Extra 322 x 445 mm"
+
+#: ../src/common/paper.cpp:132
+msgid "A5 Extra 174 x 235 mm"
+msgstr "A5 Extra 174 x 235 mm"
+
+#: ../src/common/paper.cpp:133
+msgid "B5 (ISO) Extra 201 x 276 mm"
+msgstr "B5 (ISO) Extra 201 x 276 mm"
+
+#: ../src/common/paper.cpp:134
+msgid "A2 420 x 594 mm"
+msgstr "A2 420 x 594 mm"
+
+#: ../src/common/paper.cpp:135
+msgid "A3 Transverse 297 x 420 mm"
+msgstr "A3 Transversal 297 x 420 mm"
+
+#: ../src/common/paper.cpp:136
+msgid "A3 Extra Transverse 322 x 445 mm"
+msgstr "A3 Extra Transversal 322 x 445 mm"
+
+#: ../src/common/paper.cpp:138
+msgid "Japanese Double Postcard 200 x 148 mm"
+msgstr "Japoneză, carte poștală dublă 200 x 148 mm"
+
+#: ../src/common/paper.cpp:139
+msgid "A6 105 x 148 mm"
+msgstr "A6 105 x 148 mm"
+
+#: ../src/common/paper.cpp:140
+msgid "Japanese Envelope Kaku #2"
+msgstr "Japoneză, Plic Kaku #2"
+
+#: ../src/common/paper.cpp:141
+msgid "Japanese Envelope Kaku #3"
+msgstr "Japoneză, Plic Kaku #3"
+
+#: ../src/common/paper.cpp:142
+msgid "Japanese Envelope Chou #3"
+msgstr "Japoneză, Plic Chou #3"
+
+#: ../src/common/paper.cpp:143
+msgid "Japanese Envelope Chou #4"
+msgstr "Japoneză, Plic Chou #4"
+
+#: ../src/common/paper.cpp:144
+msgid "Letter Rotated 11 x 8 1/2 in"
+msgstr "Letter rotit 11 x 8 1/2 in"
+
+#: ../src/common/paper.cpp:145
+msgid "A3 Rotated 420 x 297 mm"
+msgstr "A3 Rotit 420 x 297 mm"
+
+#: ../src/common/paper.cpp:146
+msgid "A4 Rotated 297 x 210 mm"
+msgstr "A4 Rotit 297 x 210 mm"
+
+#: ../src/common/paper.cpp:147
+msgid "A5 Rotated 210 x 148 mm"
+msgstr "A5 Rotit 210 x 148 mm"
+
+#: ../src/common/paper.cpp:148
+msgid "B4 (JIS) Rotated 364 x 257 mm"
+msgstr "B4 (JIS) Rotit 364 x 257 mm"
+
+#: ../src/common/paper.cpp:149
+msgid "B5 (JIS) Rotated 257 x 182 mm"
+msgstr "B5 (JIS) Rotit 257 x 182 mm"
+
+#: ../src/common/paper.cpp:150
+msgid "Japanese Postcard Rotated 148 x 100 mm"
+msgstr "Japoneză, Carte Postală Rotită 148 x 100 mm"
+
+#: ../src/common/paper.cpp:151
+msgid "Double Japanese Postcard Rotated 148 x 200 mm"
+msgstr "Carte Poștală Japoneză Dublă Rotită 148 x 200 mm"
+
+#: ../src/common/paper.cpp:152
+msgid "A6 Rotated 148 x 105 mm"
+msgstr "A6 Rotit 148 x 105 mm"
+
+#: ../src/common/paper.cpp:153
+msgid "Japanese Envelope Kaku #2 Rotated"
+msgstr "Japoneză, Plic Kaku #2 Rotit"
+
+#: ../src/common/paper.cpp:154
+msgid "Japanese Envelope Kaku #3 Rotated"
+msgstr "Japoneză, Plic Kaku #3 Rotit"
+
+#: ../src/common/paper.cpp:155
+msgid "Japanese Envelope Chou #3 Rotated"
+msgstr "Japoneză, Plic Chou #3 Rotit"
+
+#: ../src/common/paper.cpp:156
+msgid "Japanese Envelope Chou #4 Rotated"
+msgstr "Japoneză, Plic Chou #4 Rotit"
+
+#: ../src/common/paper.cpp:157
+msgid "B6 (JIS) 128 x 182 mm"
+msgstr "B6 (JIS) 128 x 182 mm"
+
+#: ../src/common/paper.cpp:158
+msgid "B6 (JIS) Rotated 182 x 128 mm"
+msgstr "B6 (JIS) Rotit 182 x 128 mm"
+
+#: ../src/common/paper.cpp:159
+msgid "12 x 11 in"
+msgstr "12 x 11 in"
+
+#: ../src/common/paper.cpp:160
+msgid "Japanese Envelope You #4"
+msgstr "Japoneză, Plic You #4"
+
+#: ../src/common/paper.cpp:161
+msgid "Japanese Envelope You #4 Rotated"
+msgstr "Japoneză, Plic You #4 Rotit"
+
+#: ../src/common/paper.cpp:162
+msgid "PRC 16K 146 x 215 mm"
+msgstr "PRC 16K 146 x 215 mm"
+
+#: ../src/common/paper.cpp:163
+msgid "PRC 32K 97 x 151 mm"
+msgstr "PRC 32K 97 x 151 mm"
+
+#: ../src/common/paper.cpp:164
+msgid "PRC 32K(Big) 97 x 151 mm"
+msgstr "PRC 32K(Mare) 97 x 151 mm"
+
+#: ../src/common/paper.cpp:165
+msgid "PRC Envelope #1 102 x 165 mm"
+msgstr "PRC Plic #1 102 x 165 mm"
+
+#: ../src/common/paper.cpp:166
+msgid "PRC Envelope #2 102 x 176 mm"
+msgstr "PRC Plic #2 102 x 176 mm"
+
+#: ../src/common/paper.cpp:167
+msgid "PRC Envelope #3 125 x 176 mm"
+msgstr "PRC Plic #3 125 x 176 mm"
+
+#: ../src/common/paper.cpp:168
+msgid "PRC Envelope #4 110 x 208 mm"
+msgstr "PRC Plic #4 110 x 208 mm"
+
+#: ../src/common/paper.cpp:169
+msgid "PRC Envelope #5 110 x 220 mm"
+msgstr "PRC Plic #5 110 x 220 mm"
+
+#: ../src/common/paper.cpp:170
+msgid "PRC Envelope #6 120 x 230 mm"
+msgstr "PRC Plic #6 120 x 230 mm"
+
+#: ../src/common/paper.cpp:171
+msgid "PRC Envelope #7 160 x 230 mm"
+msgstr "PRC Plic #7 160 x 230 mm"
+
+#: ../src/common/paper.cpp:172
+msgid "PRC Envelope #8 120 x 309 mm"
+msgstr "PRC Plic #8 120 x 309 mm"
+
+#: ../src/common/paper.cpp:173
+msgid "PRC Envelope #9 229 x 324 mm"
+msgstr "PRC Plic #9 229 x 324 mm"
+
+#: ../src/common/paper.cpp:174
+msgid "PRC Envelope #10 324 x 458 mm"
+msgstr "PRC Plic #10 324 x 458 mm"
+
+#: ../src/common/paper.cpp:175
+msgid "PRC 16K Rotated"
+msgstr "PRC 16K Rotit"
+
+#: ../src/common/paper.cpp:176
+msgid "PRC 32K Rotated"
+msgstr "PRC 32K Rotit"
+
+#: ../src/common/paper.cpp:177
+msgid "PRC 32K(Big) Rotated"
+msgstr "PRC 32K(Mare) Rotit"
+
+#: ../src/common/paper.cpp:178
+msgid "PRC Envelope #1 Rotated 165 x 102 mm"
+msgstr "PRC Plic #1 Rotit 165 x 102 mm"
+
+#: ../src/common/paper.cpp:179
+msgid "PRC Envelope #2 Rotated 176 x 102 mm"
+msgstr "PRC Plic #2 Rotit 176 x 102 mm"
+
+#: ../src/common/paper.cpp:180
+msgid "PRC Envelope #3 Rotated 176 x 125 mm"
+msgstr "PRC Plic #3 Rotit 176 x 125 mm"
+
+#: ../src/common/paper.cpp:181
+msgid "PRC Envelope #4 Rotated 208 x 110 mm"
+msgstr "PRC Plic #4 Rotit 208 x 110 mm"
+
+#: ../src/common/paper.cpp:182
+msgid "PRC Envelope #5 Rotated 220 x 110 mm"
+msgstr "PRC Plic #5 Rotit 220 x 110 mm"
+
+#: ../src/common/paper.cpp:183
+msgid "PRC Envelope #6 Rotated 230 x 120 mm"
+msgstr "PRC Plic #6 Rotit 230 x 120 mm"
+
+#: ../src/common/paper.cpp:184
+msgid "PRC Envelope #7 Rotated 230 x 160 mm"
+msgstr "PRC Plic #7 Rotit 230 x 160 mm"
+
+#: ../src/common/paper.cpp:185
+msgid "PRC Envelope #8 Rotated 309 x 120 mm"
+msgstr "PRC Plic #8 Rotit 309 x 120 mm"
+
+#: ../src/common/paper.cpp:186
+msgid "PRC Envelope #9 Rotated 324 x 229 mm"
+msgstr "PRC Plic #9 Rotit 324 x 229 mm"
+
+#: ../src/common/paper.cpp:187
+msgid "PRC Envelope #10 Rotated 458 x 324 mm"
+msgstr "PRC Plic #10 Rotit 458 x 324 mm"
+
+#: ../src/common/paper.cpp:192
+msgid "A0 sheet, 841 x 1189 mm"
+msgstr "A0 foaie, 841 x 1189 mm"
+
+#: ../src/common/paper.cpp:193
+msgid "A1 sheet, 594 x 841 mm"
+msgstr "A1 foaie, 594 x 841 mm"
+
+#: ../src/common/preferencescmn.cpp:37
+msgid "General"
+msgstr "General"
+
+#: ../src/common/preferencescmn.cpp:40
+msgid "Advanced"
+msgstr "Avansat"
+
+#: ../src/common/prntbase.cpp:245
+msgid "Generic PostScript"
+msgstr "PostScript generic"
+
+#: ../src/common/prntbase.cpp:259
+msgid "Ready"
+msgstr "Gata"
+
+#: ../src/common/prntbase.cpp:331
+msgid "Printing Error"
+msgstr "Eroare de tipărire"
+
+#: ../src/common/prntbase.cpp:413 ../src/common/prntbase.cpp:1597
+#: ../src/generic/prntdlgg.cpp:135 ../src/generic/prntdlgg.cpp:149
+#: ../src/gtk/print.cpp:628 ../src/gtk/print.cpp:646
+msgid "Print"
+msgstr "Tipărește"
+
+#: ../src/common/prntbase.cpp:471 ../src/generic/prntdlgg.cpp:809
+msgid "Page setup"
+msgstr "Setări pagină"
+
+#: ../src/common/prntbase.cpp:525
+msgid "Please wait while printing..."
+msgstr "Așteptați cât timp se tipărește..."
+
+#: ../src/common/prntbase.cpp:529
+msgid "Document:"
+msgstr "Documentul:"
+
+#: ../src/common/prntbase.cpp:532
+msgid "Progress:"
+msgstr "Progres:"
+
+#: ../src/common/prntbase.cpp:533
+msgid "Preparing"
+msgstr "Pregătire"
+
+#: ../src/common/prntbase.cpp:552
+#, c-format
+msgid "Printing page %d"
+msgstr "Tipărire pagina %d"
+
+#: ../src/common/prntbase.cpp:557
+#, c-format
+msgid "Printing page %d of %d"
+msgstr "Tipărire pagina %d din %d"
+
+#: ../src/common/prntbase.cpp:560
+#, c-format
+msgid " (copy %d of %d)"
+msgstr " (copia %d din %d)"
+
+#: ../src/common/prntbase.cpp:1604
+msgid "First page"
+msgstr "Prima pagină"
+
+#: ../src/common/prntbase.cpp:1609 ../src/html/helpwnd.cpp:659
+msgid "Previous page"
+msgstr "Pagina anterioară"
+
+#: ../src/common/prntbase.cpp:1623 ../src/html/helpwnd.cpp:660
+msgid "Next page"
+msgstr "Pagina următoare"
+
+#: ../src/common/prntbase.cpp:1628
+msgid "Last page"
+msgstr "Ultima pagină"
+
+#: ../src/common/prntbase.cpp:1636 ../src/common/stockitem.cpp:215
+msgid "Zoom Out"
+msgstr "Micșorează"
+
+#: ../src/common/prntbase.cpp:1650 ../src/common/stockitem.cpp:214
+msgid "Zoom In"
+msgstr "Mărește"
+
+#: ../src/common/prntbase.cpp:1656 ../src/common/stockitem.cpp:153
+#: ../src/generic/logg.cpp:553 ../src/univ/themes/win32.cpp:3752
+msgid "&Close"
+msgstr "În&chide"
+
+#: ../src/common/prntbase.cpp:2085
+msgid "Could not start document preview."
+msgstr "Nu a putut fi pornită previzualizarea documentului."
+
+#: ../src/common/prntbase.cpp:2085 ../src/common/prntbase.cpp:2129
+#: ../src/common/prntbase.cpp:2137
+msgid "Print Preview Failure"
+msgstr "Eroare la previzualizarea tipăririi"
+
+#: ../src/common/prntbase.cpp:2129 ../src/common/prntbase.cpp:2137
+msgid "Sorry, not enough memory to create a preview."
+msgstr "Nu este suficientă memorie pentru a crea o previzualizare."
+
+#: ../src/common/prntbase.cpp:2144
+#, c-format
+msgid "Page %d of %d"
+msgstr "Pagina %d din %d"
+
+#: ../src/common/prntbase.cpp:2146
+#, c-format
+msgid "Page %d"
+msgstr "Pagina %d"
+
+#: ../src/common/regex.cpp:382 ../src/html/chm.cpp:348
+msgid "unknown error"
+msgstr "eroare necunoscută"
+
+#: ../src/common/regex.cpp:995
+#, c-format
+msgid "Invalid regular expression '%s': %s"
+msgstr "Expresie regulată invalidă '%s': %s"
+
+#: ../src/common/regex.cpp:1059
+#, c-format
+msgid "Failed to find match for regular expression: %s"
+msgstr "A eșuat găsirea unui rezultat pentru expresia regulată: %s"
+
+#: ../src/common/rendcmn.cpp:188
+#, c-format
+msgid "Renderer \"%s\" has incompatible version %d.%d and couldn't be loaded."
+msgstr ""
+"Renderer-ul \"%s\" are versiunea incompatibilă %d.%d și nu a putut fi "
+"încărcat."
+
+#: ../src/common/secretstore.cpp:162
+msgid "Not available for this platform"
+msgstr "Indisponibil pentru această platformă"
+
+#: ../src/common/secretstore.cpp:183
+#, c-format
+msgid "Saving password for \"%s\" failed: %s."
+msgstr "Salvarea parolei pentru '%s' a eșuat: '%s'."
+
+#: ../src/common/secretstore.cpp:205
+#, c-format
+msgid "Reading password for \"%s\" failed: %s."
+msgstr "Citirea parolei pentru '%s' a eșuat: '%s'."
+
+#: ../src/common/secretstore.cpp:228
+#, c-format
+msgid "Deleting password for \"%s\" failed: %s."
+msgstr "Ștergerea parolei pentru '%s' a eșuat: '%s'."
+
+#: ../src/common/selectdispatcher.cpp:254
+msgid "Failed to monitor I/O channels"
+msgstr "A eșuat monitorizarea canalelor I/O"
+
+#: ../src/common/sizer.cpp:3054 ../src/common/stockitem.cpp:195
+msgid "Save"
+msgstr "Salvează"
+
+#: ../src/common/sizer.cpp:3056
+msgid "Don't Save"
+msgstr "Nu salva"
+
+#: ../src/common/socket.cpp:870
+msgid "Cannot initialize sockets"
+msgstr "Nu se pot inițializa socket-i"
+
+#: ../src/common/stockitem.cpp:127
+msgctxt "standard Windows menu"
+msgid "&Help"
+msgstr "&Ajutor"
+
+#: ../src/common/stockitem.cpp:144
+msgid "&About"
+msgstr "&Despre"
+
+#: ../src/common/stockitem.cpp:144
+msgid "About"
+msgstr "Despre"
+
+#: ../src/common/stockitem.cpp:145
+msgid "Add"
+msgstr "Adaugă"
+
+#: ../src/common/stockitem.cpp:146
+msgid "&Apply"
+msgstr "&Aplică"
+
+#: ../src/common/stockitem.cpp:146
+msgid "Apply"
+msgstr "Aplică"
+
+#: ../src/common/stockitem.cpp:147
+msgid "&Back"
+msgstr "Î&napoi"
+
+#: ../src/common/stockitem.cpp:147
+msgid "Back"
+msgstr "Înapoi"
+
+#: ../src/common/stockitem.cpp:148
+msgid "&Bold"
+msgstr "În&groșat"
+
+#: ../src/common/stockitem.cpp:148 ../src/generic/fontdlgg.cpp:326
+#: ../src/richtext/richtextfontpage.cpp:354
+msgid "Bold"
+msgstr "Îngroșat"
+
+#: ../src/common/stockitem.cpp:149
+msgid "&Bottom"
+msgstr "&Jos"
+
+#: ../src/common/stockitem.cpp:149 ../src/richtext/richtextsizepage.cpp:287
+msgid "Bottom"
+msgstr "Jos"
+
+#: ../src/common/stockitem.cpp:150 ../src/generic/fontdlgg.cpp:462
+#: ../src/generic/fontdlgg.cpp:481 ../src/generic/wizard.cpp:415
+msgid "&Cancel"
+msgstr "&Renunță"
+
+#: ../src/common/stockitem.cpp:151
+msgid "&CD-ROM"
+msgstr "&CD-ROM"
+
+#: ../src/common/stockitem.cpp:151
+msgid "CD-ROM"
+msgstr "CD-ROM"
+
+#: ../src/common/stockitem.cpp:152
+msgid "&Clear"
+msgstr "&Curăță"
+
+#: ../src/common/stockitem.cpp:152
+msgid "Clear"
+msgstr "Curăță"
+
+#: ../src/common/stockitem.cpp:153 ../src/generic/dbgrptg.cpp:93
+#: ../src/generic/progdlgg.cpp:778 ../src/html/helpdlg.cpp:86
+#: ../src/msw/progdlg.cpp:209 ../src/msw/progdlg.cpp:890
+#: ../src/richtext/richtextstyledlg.cpp:272
+#: ../src/richtext/richtextsymboldlg.cpp:448
+msgid "Close"
+msgstr "Închide"
+
+#: ../src/common/stockitem.cpp:154
+msgid "&Convert"
+msgstr "&Transformă"
+
+#: ../src/common/stockitem.cpp:154
+msgid "Convert"
+msgstr "Transformă"
+
+#: ../src/common/stockitem.cpp:155 ../src/msw/textctrl.cpp:2884
+#: ../src/osx/textctrl_osx.cpp:653 ../src/richtext/richtextctrl.cpp:331
+msgid "&Copy"
+msgstr "&Copiază"
+
+#: ../src/common/stockitem.cpp:155 ../src/stc/stc_i18n.cpp:18
+msgid "Copy"
+msgstr "Copiază"
+
+#: ../src/common/stockitem.cpp:156 ../src/msw/textctrl.cpp:2883
+#: ../src/osx/textctrl_osx.cpp:652 ../src/richtext/richtextctrl.cpp:330
+msgid "Cu&t"
+msgstr "&Decupează"
+
+#: ../src/common/stockitem.cpp:156 ../src/stc/stc_i18n.cpp:17
+msgid "Cut"
+msgstr "Decupează"
+
+#: ../src/common/stockitem.cpp:157 ../src/msw/textctrl.cpp:2886
+#: ../src/osx/textctrl_osx.cpp:655 ../src/richtext/richtextctrl.cpp:333
+#: ../src/richtext/richtexttabspage.cpp:137
+msgid "&Delete"
+msgstr "Ște&rge"
+
+#: ../src/common/stockitem.cpp:157 ../src/richtext/richtextbuffer.cpp:8266
+#: ../src/stc/stc_i18n.cpp:20
+msgid "Delete"
+msgstr "Șterge"
+
+#: ../src/common/stockitem.cpp:158
+msgid "&Down"
+msgstr "&Jos"
+
+#: ../src/common/stockitem.cpp:158 ../src/generic/fdrepdlg.cpp:148
+msgid "Down"
+msgstr "Jos"
+
+#: ../src/common/stockitem.cpp:159
+msgid "&Edit"
+msgstr "&Editează"
+
+#: ../src/common/stockitem.cpp:159
+msgid "Edit"
+msgstr "Editează"
+
+#: ../src/common/stockitem.cpp:160
+msgid "&Execute"
+msgstr "&Execută"
+
+#: ../src/common/stockitem.cpp:160
+msgid "Execute"
+msgstr "Execută"
+
+#: ../src/common/stockitem.cpp:161
+msgid "&Quit"
+msgstr "&Ieșire"
+
+#: ../src/common/stockitem.cpp:161
+msgid "Quit"
+msgstr "Ieșire"
+
+#: ../src/common/stockitem.cpp:162
+msgid "&File"
+msgstr "&Fișier"
+
+#: ../src/common/stockitem.cpp:162
+msgid "File"
+msgstr "Fișier"
+
+#: ../src/common/stockitem.cpp:163
+msgid "&Find..."
+msgstr "&Caută..."
+
+#: ../src/common/stockitem.cpp:163
+msgid "Find..."
+msgstr "Caută..."
+
+#: ../src/common/stockitem.cpp:164
+msgid "&First"
+msgstr "&Primul"
+
+#: ../src/common/stockitem.cpp:164
+msgid "First"
+msgstr "Primul"
+
+#: ../src/common/stockitem.cpp:165
+msgid "&Floppy"
+msgstr "&Dischetă"
+
+#: ../src/common/stockitem.cpp:165
+msgid "Floppy"
+msgstr "Dischetă"
+
+#: ../src/common/stockitem.cpp:166
+msgid "&Forward"
+msgstr "În&ainte"
+
+#: ../src/common/stockitem.cpp:166
+msgid "Forward"
+msgstr "Înainte"
+
+#: ../src/common/stockitem.cpp:167
+msgid "&Harddisk"
+msgstr "&Harddisk"
+
+#: ../src/common/stockitem.cpp:167
+msgid "Harddisk"
+msgstr "Harddisk"
+
+#: ../src/common/stockitem.cpp:168 ../src/generic/wizard.cpp:418
+#: ../src/osx/cocoa/menu.mm:225 ../src/richtext/richtextstyledlg.cpp:298
+#: ../src/richtext/richtextsymboldlg.cpp:451
+msgid "&Help"
+msgstr "&Ajutor"
+
+#: ../src/common/stockitem.cpp:169
+msgid "&Home"
+msgstr "&Acasă"
+
+#: ../src/common/stockitem.cpp:169
+msgid "Home"
+msgstr "Acasă"
+
+#: ../src/common/stockitem.cpp:170
+msgid "Indent"
+msgstr "Indentare"
+
+#: ../src/common/stockitem.cpp:171
+msgid "&Index"
+msgstr "&Index"
+
+#: ../src/common/stockitem.cpp:171 ../src/html/helpwnd.cpp:510
+msgid "Index"
+msgstr "Index"
+
+#: ../src/common/stockitem.cpp:172
+msgid "&Info"
+msgstr "&Info"
+
+#: ../src/common/stockitem.cpp:172
+msgid "Info"
+msgstr "Info"
+
+#: ../src/common/stockitem.cpp:173
+msgid "&Italic"
+msgstr "Curs&iv"
+
+#: ../src/common/stockitem.cpp:173 ../src/generic/fontdlgg.cpp:322
+#: ../src/richtext/richtextfontpage.cpp:350
+msgid "Italic"
+msgstr "Cursiv"
+
+#: ../src/common/stockitem.cpp:174
+msgid "&Jump to"
+msgstr "&Mergi la"
+
+#: ../src/common/stockitem.cpp:174
+msgid "Jump to"
+msgstr "Mergi la"
+
+#: ../src/common/stockitem.cpp:175
+msgid "Centered"
+msgstr "Centrat"
+
+#: ../src/common/stockitem.cpp:176
+msgid "Justified"
+msgstr "Aliniere la margini"
+
+#: ../src/common/stockitem.cpp:177
+msgid "Align Left"
+msgstr "Aliniere la stânga"
+
+#: ../src/common/stockitem.cpp:178
+msgid "Align Right"
+msgstr "Aliniere la dreapta"
+
+#: ../src/common/stockitem.cpp:179
+msgid "&Last"
+msgstr "&Ultimul"
+
+#: ../src/common/stockitem.cpp:179
+msgid "Last"
+msgstr "Ultimul"
+
+#: ../src/common/stockitem.cpp:180
+msgid "&Network"
+msgstr "&Rețea"
+
+#: ../src/common/stockitem.cpp:180
+msgid "Network"
+msgstr "Rețea"
+
+#: ../src/common/stockitem.cpp:181 ../src/richtext/richtexttabspage.cpp:131
+msgid "&New"
+msgstr "&Nou"
+
+#: ../src/common/stockitem.cpp:181
+msgid "New"
+msgstr "Nou"
+
+#: ../src/common/stockitem.cpp:182 ../src/msw/msgdlg.cpp:417
+msgid "&No"
+msgstr "&Nu"
+
+#: ../src/common/stockitem.cpp:183 ../src/generic/fontdlgg.cpp:467
+#: ../src/generic/fontdlgg.cpp:474
+msgid "&OK"
+msgstr "&OK"
+
+#: ../src/common/stockitem.cpp:184 ../src/generic/dbgrptg.cpp:341
+msgid "&Open..."
+msgstr "&Deschide..."
+
+#: ../src/common/stockitem.cpp:184
+msgid "Open..."
+msgstr "Deschide..."
+
+#: ../src/common/stockitem.cpp:185 ../src/msw/textctrl.cpp:2885
+#: ../src/osx/textctrl_osx.cpp:654 ../src/richtext/richtextctrl.cpp:332
+msgid "&Paste"
+msgstr "Li&pire"
+
+#: ../src/common/stockitem.cpp:185 ../src/richtext/richtextctrl.cpp:3484
+#: ../src/stc/stc_i18n.cpp:19
+msgid "Paste"
+msgstr "Lipire"
+
+#: ../src/common/stockitem.cpp:186
+msgid "&Preferences"
+msgstr "&Preferințe"
+
+#: ../src/common/stockitem.cpp:186 ../src/osx/cocoa/preferences.mm:304
+msgid "Preferences"
+msgstr "Preferințe"
+
+#: ../src/common/stockitem.cpp:187
+msgid "Print previe&w..."
+msgstr "Pre&vizualizare tipărire..."
+
+#: ../src/common/stockitem.cpp:187
+msgid "Print preview..."
+msgstr "Previzualizare tipărire..."
+
+#: ../src/common/stockitem.cpp:188
+msgid "&Print..."
+msgstr "Ti&părire..."
+
+#: ../src/common/stockitem.cpp:188
+msgid "Print..."
+msgstr "Tipărire..."
+
+#: ../src/common/stockitem.cpp:189 ../src/richtext/richtextctrl.cpp:337
+#: ../src/richtext/richtextctrl.cpp:5479
+msgid "&Properties"
+msgstr "&Proprietăți"
+
+#: ../src/common/stockitem.cpp:189
+msgid "Properties"
+msgstr "Proprietăți"
+
+#: ../src/common/stockitem.cpp:190 ../src/stc/stc_i18n.cpp:16
+msgid "Redo"
+msgstr "Repetare acțiune"
+
+#: ../src/common/stockitem.cpp:191
+msgid "Refresh"
+msgstr "Actualizare"
+
+#: ../src/common/stockitem.cpp:192
+msgid "Remove"
+msgstr "Eliminare"
+
+#: ../src/common/stockitem.cpp:193
+msgid "Rep&lace..."
+msgstr "Înl&ocuire..."
+
+#: ../src/common/stockitem.cpp:193
+msgid "Replace..."
+msgstr "Înlocuire..."
+
+#: ../src/common/stockitem.cpp:194
+msgid "Revert to Saved"
+msgstr "Revenire la versiunea salvată"
+
+#: ../src/common/stockitem.cpp:196 ../src/generic/logg.cpp:549
+msgid "Save &As..."
+msgstr "S&alvare ca..."
+
+#: ../src/common/stockitem.cpp:196
+msgid "Save As..."
+msgstr "Salvare ca..."
+
+#: ../src/common/stockitem.cpp:197 ../src/msw/textctrl.cpp:2888
+#: ../src/osx/textctrl_osx.cpp:657 ../src/richtext/richtextctrl.cpp:335
+msgid "Select &All"
+msgstr "Selecte&ază tot"
+
+#: ../src/common/stockitem.cpp:197 ../src/stc/stc_i18n.cpp:21
+msgid "Select All"
+msgstr "Selectează tot"
+
+#: ../src/common/stockitem.cpp:198
+msgid "&Color"
+msgstr "&Culoare"
+
+#: ../src/common/stockitem.cpp:198
+msgid "Color"
+msgstr "Culoare"
+
+#: ../src/common/stockitem.cpp:199
+msgid "&Font"
+msgstr "&Font"
+
+#: ../src/common/stockitem.cpp:199 ../src/richtext/richtextformatdlg.cpp:336
+msgid "Font"
+msgstr "Font"
+
+#: ../src/common/stockitem.cpp:200
+msgid "&Ascending"
+msgstr "&Crescător"
+
+#: ../src/common/stockitem.cpp:200
+msgid "Ascending"
+msgstr "Crescător"
+
+#: ../src/common/stockitem.cpp:201
+msgid "&Descending"
+msgstr "&Descrescător"
+
+#: ../src/common/stockitem.cpp:201
+msgid "Descending"
+msgstr "Descrescător"
+
+#: ../src/common/stockitem.cpp:202
+msgid "&Spell Check"
+msgstr "&Verificare ortografie"
+
+#: ../src/common/stockitem.cpp:202
+msgid "Spell Check"
+msgstr "Verificare ortografie"
+
+#: ../src/common/stockitem.cpp:203
+msgid "&Stop"
+msgstr "&Stop"
+
+#: ../src/common/stockitem.cpp:203
+msgid "Stop"
+msgstr "Stop"
+
+#: ../src/common/stockitem.cpp:204 ../src/richtext/richtextfontpage.cpp:274
+msgid "&Strikethrough"
+msgstr "&Tăiat"
+
+#: ../src/common/stockitem.cpp:204
+msgid "Strikethrough"
+msgstr "Tăiat"
+
+#: ../src/common/stockitem.cpp:205
+msgid "&Top"
+msgstr "&Sus"
+
+#: ../src/common/stockitem.cpp:205 ../src/richtext/richtextsizepage.cpp:285
+#: ../src/richtext/richtextsizepage.cpp:289
+msgid "Top"
+msgstr "Sus"
+
+#: ../src/common/stockitem.cpp:206
+msgid "Undelete"
+msgstr "Restaurează"
+
+#: ../src/common/stockitem.cpp:207 ../src/generic/fontdlgg.cpp:437
+msgid "&Underline"
+msgstr "S&ubliniat"
+
+#: ../src/common/stockitem.cpp:207
+msgid "Underline"
+msgstr "Subliniat"
+
+#: ../src/common/stockitem.cpp:208 ../src/stc/stc_i18n.cpp:15
+msgid "Undo"
+msgstr "Anulare acțiune"
+
+#: ../src/common/stockitem.cpp:209
+msgid "&Unindent"
+msgstr "An&ulare indentare"
+
+#: ../src/common/stockitem.cpp:209
+msgid "Unindent"
+msgstr "Anulare indentare"
+
+#: ../src/common/stockitem.cpp:210
+msgid "&Up"
+msgstr "S&us"
+
+#: ../src/common/stockitem.cpp:210 ../src/generic/fdrepdlg.cpp:148
+msgid "Up"
+msgstr "Sus"
+
+#: ../src/common/stockitem.cpp:211 ../src/msw/msgdlg.cpp:417
+msgid "&Yes"
+msgstr "&Da"
+
+#: ../src/common/stockitem.cpp:212
+msgid "&Actual Size"
+msgstr "Dimensiune re&ală"
+
+#: ../src/common/stockitem.cpp:212
+msgid "Actual Size"
+msgstr "Dimensiune reală"
+
+#: ../src/common/stockitem.cpp:213
+msgid "Zoom to &Fit"
+msgstr "Redimensione&ază cât să încapă"
+
+#: ../src/common/stockitem.cpp:213
+msgid "Zoom to Fit"
+msgstr "Redimensionează cât să încapă"
+
+#: ../src/common/stockitem.cpp:214
+msgid "Zoom &In"
+msgstr "Mă&rește"
+
+#: ../src/common/stockitem.cpp:215
+msgid "Zoom &Out"
+msgstr "Mi&cșorează"
+
+#: ../src/common/stockitem.cpp:262
+msgid "Show about dialog"
+msgstr "Arată dialog informativ"
+
+#: ../src/common/stockitem.cpp:263
+msgid "Copy selection"
+msgstr "Copiază selecția"
+
+#: ../src/common/stockitem.cpp:264
+msgid "Cut selection"
+msgstr "Decupează selecție"
+
+#: ../src/common/stockitem.cpp:265
+msgid "Delete selection"
+msgstr "Șterge selecție"
+
+#: ../src/common/stockitem.cpp:266
+msgid "Find in document"
+msgstr "Caută în document"
+
+#: ../src/common/stockitem.cpp:267
+msgid "Find and replace in document"
+msgstr "Caută și înlocuiește în document"
+
+#: ../src/common/stockitem.cpp:268
+msgid "Paste selection"
+msgstr "Lipește selecția"
+
+#: ../src/common/stockitem.cpp:269
+msgid "Quit this program"
+msgstr "Părăsește acest program"
+
+#: ../src/common/stockitem.cpp:270
+msgid "Redo last action"
+msgstr "Repetă ultima acțiune"
+
+#: ../src/common/stockitem.cpp:271
+msgid "Undo last action"
+msgstr "Anulează ultima acțiune"
+
+#: ../src/common/stockitem.cpp:272
+msgid "Create new document"
+msgstr "Creează document nou"
+
+#: ../src/common/stockitem.cpp:273
+msgid "Open an existing document"
+msgstr "Deschide un document existent"
+
+#: ../src/common/stockitem.cpp:274
+msgid "Close current document"
+msgstr "Închide documentul curent"
+
+#: ../src/common/stockitem.cpp:275
+msgid "Save current document"
+msgstr "Salvează documentul curent"
+
+#: ../src/common/stockitem.cpp:276
+msgid "Save current document with a different filename"
+msgstr "Salvează documentul curent cu un nume diferit de fișier"
+
+#: ../src/common/strconv.cpp:2324
+#, c-format
+msgid "Conversion to charset '%s' doesn't work."
+msgstr "Conversia la setul de caractere '%s' nu funcționează."
+
+#: ../src/common/tarstrm.cpp:352 ../src/common/tarstrm.cpp:375
+#: ../src/common/tarstrm.cpp:406 ../src/generic/progdlgg.cpp:373
+msgid "unknown"
+msgstr "necunoscut"
+
+#: ../src/common/tarstrm.cpp:774
+msgid "incomplete header block in tar"
+msgstr "bloc de antet incomplet în tar"
+
+#: ../src/common/tarstrm.cpp:798
+msgid "checksum failure reading tar header block"
+msgstr "suma de control eronată în blocul antet pentru tar"
+
+#: ../src/common/tarstrm.cpp:971
+msgid "invalid data in extended tar header"
+msgstr "date incorecte în antetul extins tar"
+
+#: ../src/common/tarstrm.cpp:981 ../src/common/tarstrm.cpp:1003
+#: ../src/common/tarstrm.cpp:1477 ../src/common/tarstrm.cpp:1499
+msgid "tar entry not open"
+msgstr "intrarea tar nu a fost deschisă"
+
+#: ../src/common/tarstrm.cpp:1023
+msgid "unexpected end of file"
+msgstr "sfârșit de fișier neașteptat"
+
+#: ../src/common/tarstrm.cpp:1297
+#, c-format
+msgid "%s did not fit the tar header for entry '%s'"
+msgstr "%s nu a corespuns antetului tar pentru intrarea '%s'"
+
+#: ../src/common/tarstrm.cpp:1359
+msgid "incorrect size given for tar entry"
+msgstr "dimensiune incorectă dată pentru intrarea tar"
+
+#: ../src/common/textbuf.cpp:232
+#, c-format
+msgid "'%s' is probably a binary buffer."
+msgstr "'%s' este probabil un buffer binar."
+
+#: ../src/common/textcmn.cpp:1006 ../src/richtext/richtextctrl.cpp:3053
+msgid "File couldn't be loaded."
+msgstr "Fișierul nu a putut fi încărcat."
+
+#: ../src/common/textfile.cpp:95
+#, c-format
+msgid "Failed to read text file \"%s\"."
+msgstr "A eșuat citirea fișierului text \"%s\"."
+
+#: ../src/common/textfile.cpp:160
+#, c-format
+msgid "can't write buffer '%s' to disk."
+msgstr "nu se poate scrie buffer-ul '%s' pe disc."
+
+#: ../src/common/time.cpp:212
+msgid "Failed to get the local system time"
+msgstr "A eșuat obținerea timpului local al sistemului"
+
+#: ../src/common/time.cpp:279
+msgid "wxGetTimeOfDay failed."
+msgstr "wxGetTimeOfDay a eșuat."
+
+#: ../src/common/translation.cpp:929
+#, c-format
+msgid "'%s' is not a valid message catalog."
+msgstr "'%s' nu este un catalog de mesaje valid."
+
+#: ../src/common/translation.cpp:954
+msgid "Invalid message catalog."
+msgstr "Catalog de mesaje invalid."
+
+#: ../src/common/translation.cpp:1013
+#, c-format
+msgid "Failed to parse Plural-Forms: '%s'"
+msgstr "Nu se pot interpreta formele de plural:'%s'"
+
+#: ../src/common/translation.cpp:1723
+#, c-format
+msgid "using catalog '%s' from '%s'."
+msgstr "folosește catalogul '%s' din '%s'."
+
+#: ../src/common/translation.cpp:1816
+#, c-format
+msgid "Resource '%s' is not a valid message catalog."
+msgstr "Resursa '%s' nu este un catalog de mesaje valid."
+
+#: ../src/common/translation.cpp:1865
+msgid "Couldn't enumerate translations"
+msgstr "Nu au putut fi enumerate traducerile"
+
+#: ../src/common/utilscmn.cpp:1145
+msgid "No default application configured for HTML files."
+msgstr "Nu există aplicație implicită configurată pentru fișierele HTML."
+
+#: ../src/common/utilscmn.cpp:1190
+#, c-format
+msgid "Failed to open URL \"%s\" in default browser."
+msgstr "A eșuat deschiderea URL-ului \"%s\" în browser-ul implicit."
+
+#: ../src/common/valtext.cpp:144
+msgid "Validation conflict"
+msgstr "Conflict la validare"
+
+#: ../src/common/valtext.cpp:186
+msgid "Required information entry is empty."
+msgstr "Intrarea pentru informația necesară este goală."
+
+#: ../src/common/valtext.cpp:188
+#, c-format
+msgid "'%s' is one of the invalid strings"
+msgstr "'%s' este unul dintre șirurile de caractere invalide"
+
+#: ../src/common/valtext.cpp:190
+#, c-format
+msgid "'%s' is not one of the valid strings"
+msgstr "'%s' nu este unul dintre șirurile de caractere valide"
+
+#: ../src/common/valtext.cpp:199
+#, c-format
+msgid "'%s' contains invalid character(s)"
+msgstr "'%s' conține caracter(e) invalid(e)"
+
+#: ../src/common/webrequest.cpp:139
+#, c-format
+msgid "Error: %s (%d)"
+msgstr "Eroare: %s (%d)"
+
+#: ../src/common/webrequest.cpp:655
+#, c-format
+msgid ""
+"Not enough free disk space for download: %llu needed but only %llu available."
+msgstr ""
+"Spațiul liber pe disc insuficient pentru descărcare: %llu necesar însă doar "
+"%llu disponibil."
+
+#: ../src/common/webrequest.cpp:669
+#, c-format
+msgid "Failed to create temporary file in %s"
+msgstr "A eșuat crearea unui fișier temporar în %s"
+
+#: ../src/common/webrequest_curl.cpp:1106
+msgid "libcurl could not be initialized"
+msgstr "libcurl nu a putut fi inițializat"
+
+#: ../src/common/webview.cpp:392
+msgid "RunScriptAsync not supported"
+msgstr "RunScriptAsync nu este suportat"
+
+#: ../src/common/webview.cpp:403 ../src/msw/webview_ie.cpp:1073
+#, c-format
+msgid "Error running JavaScript: %s"
+msgstr "Eroare la rularea JavaScript: %s"
+
+#: ../src/common/webview_chromium.cpp:858
+#, c-format
+msgid "Failed to set proxy \"%s\": %s"
+msgstr "A eșuat setarea de proxy \"%s\": %s"
+
+#: ../src/common/webview_chromium.cpp:989
+msgid ""
+"Chromium can't be used because libcef.so wasn't loaded early enough; please "
+"relink the application or use LD_PRELOAD to load it earlier."
+msgstr ""
+"Chromium nu poate fi folosit pentru că libcef.so nu a fost încărcat "
+"suficient de devreme; trebuie legată din nou aplicația cu bibliotecile sau "
+"folosește LD_PRELOAD pentru a o încărca mai devreme."
+
+#: ../src/common/webview_chromium.cpp:1108
+msgid "Could not initialize Chromium"
+msgstr "Chromium nu a putut fi inițializat"
+
+#: ../src/common/webview_chromium.cpp:1616
+msgid "Show DevTools"
+msgstr "Arată DevTools"
+
+#: ../src/common/webview_chromium.cpp:1617
+msgid "Close DevTools"
+msgstr "Închide DevTools"
+
+#: ../src/common/webview_chromium.cpp:1623
+msgid "Inspect"
+msgstr "Inspectează"
+
+#: ../src/common/wincmn.cpp:1628
+msgid "This platform does not support background transparency."
+msgstr "Această platformă nu suportă transparență pentru fundal."
+
+#: ../src/common/wincmn.cpp:2097
+msgid "Could not transfer data to window"
+msgstr "Nu s-au putut transfera datele către fereastră"
+
+#: ../src/common/windowid.cpp:240
+msgid "Out of window IDs.  Recommend shutting down application."
+msgstr ""
+"Nu mai sunt ID-uri de ferestre disponibile. Se recomandă închiderea "
+"aplicației."
+
+#: ../src/common/xpmdecod.cpp:678
+msgid "XPM: incorrect header format!"
+msgstr "XPM: format incorect pentru antet!"
+
+#: ../src/common/xpmdecod.cpp:703
+#, c-format
+msgid "XPM: incorrect colour description in line %d"
+msgstr "XPM: descriere incorectă a culorii la linia %d"
+
+#: ../src/common/xpmdecod.cpp:715 ../src/common/xpmdecod.cpp:724
+#, c-format
+msgid "XPM: malformed colour definition '%s' at line %d!"
+msgstr "XPM: definiție incorectă a culorii '%s' la linia %d!"
+
+#: ../src/common/xpmdecod.cpp:754
+msgid "XPM: no colors left to use for mask!"
+msgstr "XPM: nu a rămas nicio culoare pentru a se folosi drept mască!"
+
+#: ../src/common/xpmdecod.cpp:781
+#, c-format
+msgid "XPM: truncated image data at line %d!"
+msgstr "XPM: datele imaginii sunt trunchiate la linia %d!"
+
+#: ../src/common/xpmdecod.cpp:795
+msgid "XPM: Malformed pixel data!"
+msgstr "XPM: Date de pixel eronate!"
+
+#: ../src/common/xti.cpp:492
+msgid "Illegal Parameter Count for Create Method"
+msgstr "Număr de parametri incorect pentru metoda Create"
+
+#: ../src/common/xti.cpp:504
+msgid "Illegal Parameter Count for ConstructObject Method"
+msgstr "Număr incorect de parametri pentru metoda ConstructObject"
+
+#: ../src/common/xtistrm.cpp:161
+#, c-format
+msgid "Create Parameter %s not found in declared RTTI Parameters"
+msgstr "Create Parameter %s nu a fost găsit între parametrii RTTI declarați"
+
+#: ../src/common/xtistrm.cpp:290
+msgid "Illegal Object Class (Non-wxEvtHandler) as Event Source"
+msgstr "Obiect de tip nepermis (Non-wxEvtHandler) ca Sursă a Evenimentului"
+
+#: ../src/common/xtistrm.cpp:313 ../src/common/xtixml.cpp:345
+#: ../src/common/xtixml.cpp:498
+msgid "Type must have enum - long conversion"
+msgstr "Tipul trebuie să aibă o conversie enum - long"
+
+#: ../src/common/xtistrm.cpp:400 ../src/common/xtistrm.cpp:415
+msgid "Invalid or Null Object ID passed to GetObjectClassInfo"
+msgstr ""
+"ID-ul obiectului transmis către GetObjectClassInfo este invalid sau Null"
+
+#: ../src/common/xtistrm.cpp:405
+msgid "Unknown Object passed to GetObjectClassInfo"
+msgstr "Obiect necunoscut transmis către GetObjectClassInfo"
+
+#: ../src/common/xtistrm.cpp:420
+msgid "Already Registered Object passed to SetObjectClassInfo"
+msgstr "Obiect deja înregistrat transmis către metoda SetObjectClassInfo"
+
+#: ../src/common/xtistrm.cpp:430
+msgid "Invalid or Null Object ID passed to HasObjectClassInfo"
+msgstr ""
+"ID-ul obiectului transmis către HasObjectClassInfo este invalid sau Null"
+
+#: ../src/common/xtistrm.cpp:460
+msgid "Passing a already registered object to SetObject"
+msgstr "S-a transmis un obiect deja înregistrat către SetObject"
+
+#: ../src/common/xtistrm.cpp:471
+msgid "Passing an unknown object to GetObject"
+msgstr "S-a transmis un obiect necunoscut către GetObject"
+
+#: ../src/common/xtixml.cpp:229
+msgid "Forward hrefs are not supported"
+msgstr "Nu sunt acceptate declarații în avans pentru href"
+
+#: ../src/common/xtixml.cpp:247
+#, c-format
+msgid "unknown class %s"
+msgstr "clasă necunoscută %s"
+
+#: ../src/common/xtixml.cpp:253
+msgid "objects cannot have XML Text Nodes"
+msgstr "obiectele nu pot avea noduri de text XML"
+
+#: ../src/common/xtixml.cpp:258
+msgid "Objects must have an id attribute"
+msgstr "Obiectele trebuie să aibă un atribut id"
+
+#: ../src/common/xtixml.cpp:267
+#, c-format
+msgid "Doubly used id : %d"
+msgstr "Id folosit de două ori : %d"
+
+#: ../src/common/xtixml.cpp:316
+#, c-format
+msgid "Unknown Property %s"
+msgstr "Proprietate %s necunoscută"
+
+#: ../src/common/xtixml.cpp:407
+msgid "A non empty collection must consist of 'element' nodes"
+msgstr "O colecție care nu e goală trebuie să conțină noduri 'element'"
+
+#: ../src/common/xtixml.cpp:478
+msgid "incorrect event handler string, missing dot"
+msgstr ""
+"șir de caractere incorect pentru un operator de evenimente, lipsește un punct"
+
+#: ../src/common/zipstrm.cpp:559
+msgid "can't re-initialize zlib deflate stream"
+msgstr "nu se poate reinițializa fluxul de compresie zlib"
+
+#: ../src/common/zipstrm.cpp:584
+msgid "can't re-initialize zlib inflate stream"
+msgstr "nu se poate reinițializa fluxul de decompresie zlib"
+
+#: ../src/common/zipstrm.cpp:1023
+msgid "Ignoring malformed extra data record, ZIP file may be corrupted"
+msgstr ""
+"Intrarea în plus și malformată este ignorată, fișierul ZIP poate fi compromis"
+
+#: ../src/common/zipstrm.cpp:1502
+msgid "assuming this is a multi-part zip concatenated"
+msgstr "presupunând că acesta este un zip concatenat din mai multe părți"
+
+#: ../src/common/zipstrm.cpp:1664
+msgid "invalid zip file"
+msgstr "fișier zip invalid"
+
+#: ../src/common/zipstrm.cpp:1723
+msgid "can't find central directory in zip"
+msgstr "nu a găsit directorul central in zip"
+
+#: ../src/common/zipstrm.cpp:1812
+msgid "error reading zip central directory"
+msgstr "eroare la citirea directorului central din zip"
+
+#: ../src/common/zipstrm.cpp:1916
+msgid "error reading zip local header"
+msgstr "eroare la citirea antetului local din zip"
+
+#: ../src/common/zipstrm.cpp:1964
+msgid "bad zipfile offset to entry"
+msgstr "deplasament eronat pentru intrarea fișierului zip"
+
+#: ../src/common/zipstrm.cpp:2031
+msgid "stored file length not in Zip header"
+msgstr "lungimea fișierului conținut nu este in antetul Zip"
+
+#: ../src/common/zipstrm.cpp:2045 ../src/common/zipstrm.cpp:2362
+msgid "unsupported Zip compression method"
+msgstr "metodă de comprimare Zip nesuportată"
+
+#: ../src/common/zipstrm.cpp:2126
+#, c-format
+msgid "reading zip stream (entry %s): bad length"
+msgstr "citire flux zip (intrarea %s): lungime eronată"
+
+#: ../src/common/zipstrm.cpp:2131
+#, c-format
+msgid "reading zip stream (entry %s): bad crc"
+msgstr "citire flux zip (intrarea %s): crc eronat"
+
+#: ../src/common/zipstrm.cpp:2578
+#, c-format
+msgid "error writing zip entry '%s': file too large without ZIP64"
+msgstr "eroare la scrierea intrării zip '%s': fișier prea mare fără ZIP64"
+
+#: ../src/common/zipstrm.cpp:2585
+#, c-format
+msgid "error writing zip entry '%s': bad crc or length"
+msgstr "eroare la scrierea intrării zip '%s': eroare de crc sau lungime"
+
+#: ../src/common/zstream.cpp:155 ../src/common/zstream.cpp:315
+msgid "Gzip not supported by this version of zlib"
+msgstr "Gzip nu e suportat de această versiune de zlib"
+
+#: ../src/common/zstream.cpp:182
+msgid "Can't initialize zlib inflate stream."
+msgstr "Nu poate fi inițializat fluxul de decompresie zlib."
+
+#: ../src/common/zstream.cpp:241
+msgid "Can't read inflate stream: unexpected EOF in underlying stream."
+msgstr ""
+"Nu poate fi citit fluxul de decompresie: EOF neașteptat în fluxul de bază."
+
+#: ../src/common/zstream.cpp:248 ../src/common/zstream.cpp:423
+#, c-format
+msgid "zlib error %d"
+msgstr "eroare zlib %d"
+
+#: ../src/common/zstream.cpp:249
+#, c-format
+msgid "Can't read from inflate stream: %s"
+msgstr "Nu poate fi citit fluxul de decompresie: %s"
+
+#: ../src/common/zstream.cpp:343
+msgid "Can't initialize zlib deflate stream."
+msgstr "Nu poate fi inițializat fluxul de compresie zlib."
+
+#: ../src/common/zstream.cpp:424
+#, c-format
+msgid "Can't write to deflate stream: %s"
+msgstr "Nu se poate scrie în fluxul de decompresie: %s"
+
+#: ../src/dfb/bitmap.cpp:633 ../src/dfb/bitmap.cpp:667
+#, c-format
+msgid "No bitmap handler for type %d defined."
+msgstr "Niciun operator de imagine definit pentru tipul %d."
+
+#: ../src/dfb/evtloop.cpp:99
+msgid "Failed to read event from DirectFB pipe"
+msgstr "A eșuat citirea evenimentului din canalul (pipe) DirectFB"
+
+#: ../src/dfb/evtloop.cpp:171
+msgid "Failed to switch DirectFB pipe to non-blocking mode"
+msgstr "A eșuat trecerea canalului (pipe) DirectFB în mod non-blocant"
+
+#: ../src/dfb/fontmgr.cpp:171
+#, c-format
+msgid "no fonts found in %s, using builtin font"
+msgstr "niciun font găsit în %s, se va folosi fontul încorporat"
+
+#: ../src/dfb/fontmgr.cpp:177
+msgid "Default font"
+msgstr "Font implicit"
+
+#: ../src/dfb/fontmgr.cpp:195
+#, c-format
+msgid "Fonts index file %s disappeared while loading fonts."
+msgstr ""
+"Fișierul index de fonturi %s a dispărut în timp ce se încărcau fonturile."
+
+#: ../src/dfb/wrapdfb.cpp:60
+#, c-format
+msgid "DirectFB error %d occurred."
+msgstr "A intervenit eroarea %d de DirectFB."
+
+#: ../src/generic/aboutdlgg.cpp:69
+msgid "Developed by "
+msgstr "Dezvoltat de "
+
+#: ../src/generic/aboutdlgg.cpp:72
+msgid "Documentation by "
+msgstr "Documentație de "
+
+#: ../src/generic/aboutdlgg.cpp:75
+msgid "Graphics art by "
+msgstr "Arta grafică de "
+
+#: ../src/generic/aboutdlgg.cpp:78
+msgid "Translations by "
+msgstr "Traduceri de "
+
+#: ../src/generic/aboutdlgg.cpp:133 ../src/osx/cocoa/aboutdlg.mm:83
+msgid "Version "
+msgstr "Versiunea "
+
+#. TRANSLATORS: %s is application name
+#: ../src/generic/aboutdlgg.cpp:146 ../src/msw/aboutdlg.cpp:60
+#, c-format
+msgid "About %s"
+msgstr "Despre %s"
+
+#: ../src/generic/aboutdlgg.cpp:181
+msgid "License"
+msgstr "Licență"
+
+#: ../src/generic/aboutdlgg.cpp:184
+msgid "Developers"
+msgstr "Dezvoltatori"
+
+#: ../src/generic/aboutdlgg.cpp:188
+msgid "Documentation writers"
+msgstr "Autorii documentației"
+
+#: ../src/generic/aboutdlgg.cpp:192
+msgid "Artists"
+msgstr "Artiști"
+
+#: ../src/generic/aboutdlgg.cpp:196
+msgid "Translators"
+msgstr "Traducători"
+
+#: ../src/generic/animateg.cpp:125
+msgid "No handler found for animation type."
+msgstr "Niciun operator nu a fost găsit pentru tipul animație."
+
+#: ../src/generic/animateg.cpp:133
+#, c-format
+msgid "No animation handler for type %ld defined."
+msgstr "Nu există operator de animație pentru tipul %ld definit."
+
+#: ../src/generic/animateg.cpp:145
+#, c-format
+msgid "Animation file is not of type %ld."
+msgstr "Fișierul de animație nu este de tipul %ld."
+
+#: ../src/generic/colrdlgg.cpp:154 ../src/gtk/colordlg.cpp:47
+msgid "Choose colour"
+msgstr "Alege culoare"
+
+#: ../src/generic/colrdlgg.cpp:357
+msgid "Red:"
+msgstr "Roșu:"
+
+#: ../src/generic/colrdlgg.cpp:360
+msgid "Green:"
+msgstr "Verde:"
+
+#: ../src/generic/colrdlgg.cpp:363
+msgid "Blue:"
+msgstr "Albastru:"
+
+#: ../src/generic/colrdlgg.cpp:372
+msgid "Opacity:"
+msgstr "Opacitate:"
+
+#: ../src/generic/colrdlgg.cpp:384
+msgid "Add to custom colours"
+msgstr "Adaugă la culori personalizate"
+
+#: ../src/generic/creddlgg.cpp:56
+msgid "Username:"
+msgstr "Utilizator:"
+
+#: ../src/generic/creddlgg.cpp:63
+msgid "Password:"
+msgstr "Parolă:"
+
+#. TRANSLATORS: Name of Boolean true value
+#: ../src/generic/datavgen.cpp:1178
+msgid "true"
+msgstr "adevărat"
+
+#. TRANSLATORS: Name of Boolean false value
+#: ../src/generic/datavgen.cpp:1180
+msgid "false"
+msgstr "fals"
+
+#: ../src/generic/datavgen.cpp:6897
+#, c-format
+msgid "Row %i"
+msgstr "Rândul %i"
+
+#. TRANSLATORS: Action for manipulating a tree control
+#: ../src/generic/datavgen.cpp:6987
+msgid "Collapse"
+msgstr "Contractă"
+
+#. TRANSLATORS: Action for manipulating a tree control
+#: ../src/generic/datavgen.cpp:6990
+msgid "Expand"
+msgstr "Expandează"
+
+#. TRANSLATORS: Name of data view control and number of rows
+#: ../src/generic/datavgen.cpp:7011
+#, c-format
+msgid "%s (%d items)"
+msgstr "%s (%d elemente)"
+
+#: ../src/generic/datavgen.cpp:7062
+#, c-format
+msgid "Column %u"
+msgstr "Coloana %u"
+
+#. TRANSLATORS: Keystroke for manipulating a tree control
+#: ../src/generic/datavgen.cpp:7131 ../src/richtext/richtextbulletspage.cpp:189
+#: ../src/richtext/richtextbulletspage.cpp:192
+#: ../src/richtext/richtextbulletspage.cpp:193
+#: ../src/richtext/richtextliststylepage.cpp:252
+#: ../src/richtext/richtextliststylepage.cpp:255
+#: ../src/richtext/richtextliststylepage.cpp:256
+#: ../src/richtext/richtextsizepage.cpp:248
+msgid "Left"
+msgstr "Stânga"
+
+#. TRANSLATORS: Keystroke for manipulating a tree control
+#: ../src/generic/datavgen.cpp:7134 ../src/richtext/richtextbulletspage.cpp:191
+#: ../src/richtext/richtextliststylepage.cpp:254
+#: ../src/richtext/richtextsizepage.cpp:249
+msgid "Right"
+msgstr "Dreapta"
+
+#: ../src/generic/datectlg.cpp:90
+#, c-format
+msgid ""
+"\"%s\" is not in the expected date format, please enter it as e.g. \"%s\"."
+msgstr ""
+"\"%s\" nu este în formatul de dată așteptat, reintroduceți-l vă rog ca e.g. "
+"\"%s\"."
+
+#: ../src/generic/datectlg.cpp:94
+msgid "Invalid date"
+msgstr "Dată invalidă"
+
+#: ../src/generic/dbgrptg.cpp:159
+#, c-format
+msgid "Open file \"%s\""
+msgstr "Deschide fișierul \"%s\""
+
+#: ../src/generic/dbgrptg.cpp:170
+#, c-format
+msgid "Enter command to open file \"%s\":"
+msgstr "Introduceți comanda pentru a deschide fișierul \"%s\":"
+
+#: ../src/generic/dbgrptg.cpp:230
+msgid "Executable files (*.exe)|*.exe|"
+msgstr "Fișiere executabile (*.exe)|*.exe|"
+
+#: ../src/generic/dbgrptg.cpp:300
+#, c-format
+msgid "Debug report \"%s\""
+msgstr "Raport de depanare \"%s\""
+
+#: ../src/generic/dbgrptg.cpp:316
+msgid "A debug report has been generated in the directory\n"
+msgstr "Un raport de depanare a fost generat în directorul\n"
+
+#: ../src/generic/dbgrptg.cpp:317
+msgid "The following debug report will be generated\n"
+msgstr "Următorul raport debug va fi generat\n"
+
+#: ../src/generic/dbgrptg.cpp:321
+msgid ""
+"The report contains the files listed below. If any of these files contain "
+"private information,\n"
+"please uncheck them and they will be removed from the report.\n"
+msgstr ""
+"Raportul conține fișierele enumerate mai jos. Dacă unele din ele conțin "
+"informații private,\n"
+"debifați-le și vor fi eliminate din raport.\n"
+
+#: ../src/generic/dbgrptg.cpp:323
+msgid ""
+"If you wish to suppress this debug report completely, please choose the "
+"\"Cancel\" button,\n"
+"but be warned that it may hinder improving the program, so if\n"
+"at all possible please do continue with the report generation.\n"
+msgstr ""
+"Pentru suprimarea definitivă a acestui raport de depanare apăsați butonul "
+"\"Anulează\",\n"
+"dar atenție, aceasta ar putea împiedica îmbunătățirea programului, astfel "
+"că\n"
+"dacă se poate este indicat să fie permisă generarea raportului.\n"
+
+#: ../src/generic/dbgrptg.cpp:325
+msgid "              Thank you and we're sorry for the inconvenience!\n"
+msgstr "              Mulțumim și ne pare rău pentru inconveniență!\n"
+
+#: ../src/generic/dbgrptg.cpp:333
+msgid "&Debug report preview:"
+msgstr "Previzualizare raport de &depanare (debug):"
+
+#: ../src/generic/dbgrptg.cpp:339
+msgid "&View..."
+msgstr "&Vizualizare..."
+
+#: ../src/generic/dbgrptg.cpp:359
+msgid "&Notes:"
+msgstr "&Note:"
+
+#: ../src/generic/dbgrptg.cpp:361
+msgid ""
+"If you have any additional information pertaining to this bug\n"
+"report, please enter it here and it will be joined to it:"
+msgstr ""
+"Dacă aveți informații adiționale cu privire la acest raport de\n"
+"defecte, introduceți-le aici și îi vor fi adăugate:"
+
+#: ../src/generic/dcpsg.cpp:1627
+msgid "Cannot open file for PostScript printing!"
+msgstr "Nu se poate deschide fișierul pentru tipărire cu PostScript!"
+
+#: ../src/generic/dirctrlg.cpp:402
+msgid "Computer"
+msgstr "Computer"
+
+#: ../src/generic/dirctrlg.cpp:404
+msgid "Sections"
+msgstr "Secțiuni"
+
+#: ../src/generic/dirctrlg.cpp:482
+msgid "Home directory"
+msgstr "Director acasă"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/generic/dirctrlg.cpp:484 ../src/propgrid/advprops.cpp:811
+msgid "Desktop"
+msgstr "Spațiu de lucru"
+
+#: ../src/generic/dirctrlg.cpp:528 ../src/generic/filectrlg.cpp:752
+msgid "Illegal directory name."
+msgstr "Nume ilegal de director."
+
+#: ../src/generic/dirctrlg.cpp:528 ../src/generic/dirctrlg.cpp:546
+#: ../src/generic/dirctrlg.cpp:557 ../src/generic/dirdlgg.cpp:317
+#: ../src/generic/filectrlg.cpp:638 ../src/generic/filectrlg.cpp:752
+#: ../src/generic/filectrlg.cpp:766 ../src/generic/filectrlg.cpp:782
+#: ../src/generic/filectrlg.cpp:1356 ../src/generic/filectrlg.cpp:1387
+#: ../src/generic/filedlgg.cpp:362 ../src/gtk/filedlg.cpp:76
+msgid "Error"
+msgstr "Eroare"
+
+#: ../src/generic/dirctrlg.cpp:546 ../src/generic/filectrlg.cpp:766
+msgid "File name exists already."
+msgstr "Numele de fișier există deja."
+
+#: ../src/generic/dirctrlg.cpp:557 ../src/generic/dirdlgg.cpp:317
+#: ../src/generic/filectrlg.cpp:638 ../src/generic/filectrlg.cpp:782
+msgid "Operation not permitted."
+msgstr "Operațiune nepermisă."
+
+#: ../src/generic/dirdlgg.cpp:107 ../src/generic/filedlgg.cpp:207
+msgid "Create new directory"
+msgstr "Creează director nou"
+
+#: ../src/generic/dirdlgg.cpp:112 ../src/generic/filedlgg.cpp:203
+msgid "Go to home directory"
+msgstr "Spre directorul inițial"
+
+#: ../src/generic/dirdlgg.cpp:143
+msgid "Show &hidden directories"
+msgstr "Arată &directoare ascunse"
+
+#: ../src/generic/dirdlgg.cpp:196
+#, c-format
+msgid ""
+"The directory '%s' does not exist\n"
+"Create it now?"
+msgstr ""
+"Directorul '%s' nu există\n"
+"Să fie creat acum?"
+
+#: ../src/generic/dirdlgg.cpp:198
+msgid "Directory does not exist"
+msgstr "Directorul nu există"
+
+#: ../src/generic/dirdlgg.cpp:214
+#, c-format
+msgid ""
+"Failed to create directory '%s'\n"
+"(Do you have the required permissions?)"
+msgstr ""
+"A eșuat crearea directorului '%s'\n"
+"(Aveți permisiunile necesare?)"
+
+#: ../src/generic/dirdlgg.cpp:216
+msgid "Error creating directory"
+msgstr "Eroare la crearea directorului"
+
+#: ../src/generic/dirdlgg.cpp:281
+msgid "You cannot add a new directory to this section."
+msgstr "Nu se poate adăuga un nou director la această secțiune."
+
+#: ../src/generic/dirdlgg.cpp:282
+msgid "Create directory"
+msgstr "Creează director"
+
+#: ../src/generic/dirdlgg.cpp:291 ../src/generic/dirdlgg.cpp:301
+#: ../src/generic/filectrlg.cpp:614 ../src/generic/filectrlg.cpp:623
+msgid "NewName"
+msgstr "NumeNou"
+
+#: ../src/generic/editlbox.cpp:135
+msgid "Edit item"
+msgstr "Modifică element"
+
+#: ../src/generic/editlbox.cpp:143
+msgid "New item"
+msgstr "Element nou"
+
+#: ../src/generic/editlbox.cpp:151
+msgid "Delete item"
+msgstr "Șterge element"
+
+#: ../src/generic/editlbox.cpp:159
+msgid "Move up"
+msgstr "Mută în sus"
+
+#: ../src/generic/editlbox.cpp:164
+msgid "Move down"
+msgstr "Mută în jos"
+
+#: ../src/generic/fdrepdlg.cpp:108
+msgid "Search for:"
+msgstr "Caută:"
+
+#: ../src/generic/fdrepdlg.cpp:120
+msgid "Replace with:"
+msgstr "Înlocuiește cu:"
+
+#: ../src/generic/fdrepdlg.cpp:140
+msgid "Whole word"
+msgstr "Cuvânt întreg"
+
+#: ../src/generic/fdrepdlg.cpp:143
+msgid "Match case"
+msgstr "Conform majuscule/minuscule"
+
+#: ../src/generic/fdrepdlg.cpp:156
+msgid "Search direction"
+msgstr "Direcție căutare"
+
+#: ../src/generic/fdrepdlg.cpp:175
+msgid "&Replace"
+msgstr "Înl&ocuiește"
+
+#: ../src/generic/fdrepdlg.cpp:178
+msgid "Replace &all"
+msgstr "Înlocuiește peste &tot"
+
+#: ../src/generic/filectrlg.cpp:246 ../src/generic/filectrlg.cpp:269
+msgid "<DIR>"
+msgstr "<DIRECTOR>"
+
+#: ../src/generic/filectrlg.cpp:248 ../src/generic/filectrlg.cpp:271
+msgid "<LINK>"
+msgstr "<LEGĂTURĂ>"
+
+#: ../src/generic/filectrlg.cpp:250 ../src/generic/filectrlg.cpp:273
+msgid "<DRIVE>"
+msgstr "<DISC>"
+
+#: ../src/generic/filectrlg.cpp:275
+#, c-format
+msgid "%ld byte"
+msgid_plural "%ld bytes"
+msgstr[0] "%ld byte"
+msgstr[1] "%ld byte-i"
+msgstr[2] "%ld byte-i"
+
+#: ../src/generic/filectrlg.cpp:420
+msgid "Name"
+msgstr "Nume"
+
+#: ../src/generic/filectrlg.cpp:421 ../src/richtext/richtextformatdlg.cpp:361
+#: ../src/richtext/richtextsizepage.cpp:298
+msgid "Size"
+msgstr "Dimensiune"
+
+#: ../src/generic/filectrlg.cpp:422
+msgid "Type"
+msgstr "Tip"
+
+#: ../src/generic/filectrlg.cpp:423
+msgid "Modified"
+msgstr "Modificat"
+
+#: ../src/generic/filectrlg.cpp:426
+msgid "Permissions"
+msgstr "Permisiuni"
+
+#: ../src/generic/filectrlg.cpp:429
+msgid "Attributes"
+msgstr "Atribute"
+
+#: ../src/generic/filectrlg.cpp:936
+msgid "Current directory:"
+msgstr "Directorul curent:"
+
+#: ../src/generic/filectrlg.cpp:979
+msgid "Show &hidden files"
+msgstr "Arată &fișiere ascunse"
+
+#: ../src/generic/filectrlg.cpp:1355
+msgid "Illegal file specification."
+msgstr "Specificație ilegală de fișier."
+
+#: ../src/generic/filectrlg.cpp:1387
+msgid "Directory doesn't exist."
+msgstr "Directorul nu există."
+
+#: ../src/generic/filedlgg.cpp:195
+msgid "View files as a list view"
+msgstr "Afișează fișierele ca listă"
+
+#: ../src/generic/filedlgg.cpp:197
+msgid "View files as a detailed view"
+msgstr "Afișează detaliat fișierele"
+
+#: ../src/generic/filedlgg.cpp:200
+msgid "Go to parent directory"
+msgstr "Spre directorul părinte"
+
+#: ../src/generic/filedlgg.cpp:351 ../src/gtk/filedlg.cpp:59
+#, c-format
+msgid "File '%s' already exists, do you really want to overwrite it?"
+msgstr "Fișierul '%s' există deja, sigur vreți să fie suprascris?"
+
+#: ../src/generic/filedlgg.cpp:354 ../src/gtk/filedlg.cpp:62
+msgid "Confirm"
+msgstr "Confirmă"
+
+#: ../src/generic/filedlgg.cpp:362 ../src/gtk/filedlg.cpp:75
+msgid "Please choose an existing file."
+msgstr "Alegeți un fișier existent."
+
+#: ../src/generic/filepickerg.cpp:64
+msgid "..."
+msgstr "..."
+
+#: ../src/generic/fontdlgg.cpp:76 ../src/richtext/richtextformatdlg.cpp:519
+msgid "ABCDEFGabcdefg12345"
+msgstr "ABCDEFGabcdefg12345"
+
+#: ../src/generic/fontdlgg.cpp:315
+msgid "Roman"
+msgstr "Roman"
+
+#: ../src/generic/fontdlgg.cpp:316
+msgid "Decorative"
+msgstr "Decorativ"
+
+#: ../src/generic/fontdlgg.cpp:317
+msgid "Modern"
+msgstr "Modern"
+
+#: ../src/generic/fontdlgg.cpp:318
+msgid "Script"
+msgstr "Script"
+
+#: ../src/generic/fontdlgg.cpp:319
+msgid "Swiss"
+msgstr "Swiss"
+
+#: ../src/generic/fontdlgg.cpp:320
+msgid "Teletype"
+msgstr "Teletype"
+
+#: ../src/generic/fontdlgg.cpp:321 ../src/generic/fontdlgg.cpp:324
+msgid "Normal"
+msgstr "Normal"
+
+#: ../src/generic/fontdlgg.cpp:323
+msgid "Slant"
+msgstr "Înclinat"
+
+#: ../src/generic/fontdlgg.cpp:325
+msgid "Light"
+msgstr "Subțiat"
+
+#: ../src/generic/fontdlgg.cpp:363
+msgid "&Font family:"
+msgstr "&Familie font:"
+
+#: ../src/generic/fontdlgg.cpp:367 ../src/generic/fontdlgg.cpp:369
+msgid "The font family."
+msgstr "Familia fontului."
+
+#: ../src/generic/fontdlgg.cpp:374 ../src/richtext/richtextstylepage.cpp:105
+msgid "&Style:"
+msgstr "&Stil:"
+
+#: ../src/generic/fontdlgg.cpp:378 ../src/generic/fontdlgg.cpp:380
+msgid "The font style."
+msgstr "Stilul fontului."
+
+#: ../src/generic/fontdlgg.cpp:385
+msgid "&Weight:"
+msgstr "În&groșare:"
+
+#: ../src/generic/fontdlgg.cpp:389 ../src/generic/fontdlgg.cpp:391
+msgid "The font weight."
+msgstr "Îngroșarea fontului."
+
+#: ../src/generic/fontdlgg.cpp:399
+msgid "C&olour:"
+msgstr "Cul&oare:"
+
+#: ../src/generic/fontdlgg.cpp:407 ../src/generic/fontdlgg.cpp:409
+msgid "The font colour."
+msgstr "Culoarea fontului."
+
+#: ../src/generic/fontdlgg.cpp:415
+msgid "&Point size:"
+msgstr "Dimensiune în &puncte:"
+
+#: ../src/generic/fontdlgg.cpp:420 ../src/generic/fontdlgg.cpp:422
+#: ../src/generic/fontdlgg.cpp:426 ../src/generic/fontdlgg.cpp:428
+msgid "The font point size."
+msgstr "Dimensiunea în puncte a fontului."
+
+#: ../src/generic/fontdlgg.cpp:439 ../src/generic/fontdlgg.cpp:441
+msgid "Whether the font is underlined."
+msgstr "Determină sublinierea fontului."
+
+#: ../src/generic/fontdlgg.cpp:448 ../src/html/helpwnd.cpp:1215
+msgid "Preview:"
+msgstr "Previzualizare:"
+
+#: ../src/generic/fontdlgg.cpp:452 ../src/generic/fontdlgg.cpp:454
+msgid "Shows the font preview."
+msgstr "Afișează previzualizarea fontului."
+
+#: ../src/generic/fontdlgg.cpp:464 ../src/generic/fontdlgg.cpp:483
+msgid "Click to cancel the font selection."
+msgstr "Clic pentru a anula selectarea fontului."
+
+#: ../src/generic/fontdlgg.cpp:469 ../src/generic/fontdlgg.cpp:471
+#: ../src/generic/fontdlgg.cpp:476 ../src/generic/fontdlgg.cpp:478
+msgid "Click to confirm the font selection."
+msgstr "Clic pentru a confirma selectarea fontului."
+
+#: ../src/generic/fontpickerg.cpp:50 ../src/gtk/fontdlg.cpp:77
+msgid "Choose font"
+msgstr "Alege font"
+
+#: ../src/generic/grid.cpp:6542
+msgid ""
+"Error copying grid to the clipboard. Either selected cells were not "
+"contiguous or no cell was selected."
+msgstr ""
+"Eroare la copierea grilei în memoria temporară. Fie celulele selectate nu au "
+"fost contigue, fie nicio celulă nu a fost selectată."
+
+#: ../src/generic/grid.cpp:12739
+msgid "Grid Corner"
+msgstr "Colțul grilei"
+
+#: ../src/generic/grid.cpp:12741
+#, c-format
+msgid "Column %s Header"
+msgstr "Titlul coloanei %s"
+
+#: ../src/generic/grid.cpp:12743
+#, c-format
+msgid "Row %s Header"
+msgstr "Titlul rândului %s"
+
+#: ../src/generic/grid.cpp:12745
+#, c-format
+msgid "Column %s: %s"
+msgstr "Coloana %s: %s"
+
+#: ../src/generic/grid.cpp:12749
+#, c-format
+msgid "Row %s: %s"
+msgstr "Rândul %s: %s"
+
+#: ../src/generic/grid.cpp:12753
+#, c-format
+msgid "Row %s, Column %s: %s"
+msgstr "Rândul %s, Coloana %s: %s"
+
+#: ../src/generic/helpext.cpp:257
+#, c-format
+msgid "Help directory \"%s\" not found."
+msgstr "Directorul de ajutor \"%s\" nu a fost găsit."
+
+#: ../src/generic/helpext.cpp:265
+#, c-format
+msgid "Help file \"%s\" not found."
+msgstr "Fișierul de ajutor \"%s\" nu a fost găsit."
+
+#: ../src/generic/helpext.cpp:284
+#, c-format
+msgid "Line %lu of map file \"%s\" has invalid syntax, skipped."
+msgstr "Linia %lu a fișierului hartă \"%s\" are sintaxa incorectă, sărită."
+
+#: ../src/generic/helpext.cpp:292
+#, c-format
+msgid "No valid mappings found in the file \"%s\"."
+msgstr "Nu au fost găsite asocieri valide în fișierul \"%s\"."
+
+#: ../src/generic/helpext.cpp:435
+msgid "No entries found."
+msgstr "Nu s-au găsit intrări."
+
+#: ../src/generic/helpext.cpp:444 ../src/generic/helpext.cpp:445
+msgid "Help Index"
+msgstr "Index ajutor"
+
+#: ../src/generic/helpext.cpp:448
+msgid "Relevant entries:"
+msgstr "Intrări relevante:"
+
+#: ../src/generic/helpext.cpp:449
+msgid "Entries found"
+msgstr "Intrări găsite"
+
+#: ../src/generic/hyperlinkg.cpp:170
+msgid "&Copy URL"
+msgstr "&Copiază URL"
+
+#: ../src/generic/infobar.cpp:119
+msgid "Hide this notification message."
+msgstr "Ascunde această notificare."
+
+#. TRANSLATORS: %s will be either the application name or "Application"
+#: ../src/generic/logg.cpp:257
+#, c-format
+msgid "%s Error"
+msgstr "%s Eroare"
+
+#. TRANSLATORS: %s will be either the application name or "Application"
+#: ../src/generic/logg.cpp:263
+#, c-format
+msgid "%s Warning"
+msgstr "%s Avertizare"
+
+#. TRANSLATORS: %s will be either the application name or "Application"
+#: ../src/generic/logg.cpp:273
+#, c-format
+msgid "%s Information"
+msgstr "%s Informație"
+
+#: ../src/generic/logg.cpp:276
+msgid "Application"
+msgstr "Aplicație"
+
+#: ../src/generic/logg.cpp:549
+msgid "Save log contents to file"
+msgstr "Salvează conținutul raportului în fișier"
+
+#: ../src/generic/logg.cpp:551
+msgid "C&lear"
+msgstr "&Curăță"
+
+#: ../src/generic/logg.cpp:551
+msgid "Clear the log contents"
+msgstr "Curăță conținutul jurnalului"
+
+#: ../src/generic/logg.cpp:553
+msgid "Close this window"
+msgstr "Închide această fereastră"
+
+#: ../src/generic/logg.cpp:554
+msgid "&Log"
+msgstr "&Jurnal"
+
+#: ../src/generic/logg.cpp:610 ../src/generic/logg.cpp:992
+msgid "Can't save log contents to file."
+msgstr "Nu se poate salva conținutul raportului în fișier."
+
+#: ../src/generic/logg.cpp:613
+#, c-format
+msgid "Log saved to the file '%s'."
+msgstr "Raport salvat în fișierul '%s'."
+
+#: ../src/generic/logg.cpp:719
+msgid "&Details"
+msgstr "&Detalii"
+
+#: ../src/generic/logg.cpp:972
+msgid "Failed to copy dialog contents to the clipboard."
+msgstr "A eșuat copierea conținutului dialogului în memoria clipboard."
+
+#: ../src/generic/logg.cpp:1022
+#, c-format
+msgid "Append log to file '%s' (choosing [No] will overwrite it)?"
+msgstr ""
+"Să fie adăugat raportul la fișierul '%s' (alegând [Nu] îl va suprascrie)?"
+
+#: ../src/generic/logg.cpp:1024
+msgid "Question"
+msgstr "Întrebare"
+
+#: ../src/generic/logg.cpp:1038
+msgid "invalid message box return value"
+msgstr "valoare invalidă returnată de caseta de mesaje"
+
+#: ../src/generic/notifmsgg.cpp:129
+msgid "Notice"
+msgstr "Notificare"
+
+#: ../src/generic/preferencesg.cpp:118
+#, c-format
+msgid "%s Preferences"
+msgstr "%s, Preferințe"
+
+#: ../src/generic/printps.cpp:143
+msgid "Printing..."
+msgstr "Se tipărește..."
+
+#: ../src/generic/printps.cpp:160 ../src/gtk/print.cpp:1076
+#: ../src/msw/printwin.cpp:235
+msgid "Could not start printing."
+msgstr "Nu a putut începe tipărirea."
+
+#: ../src/generic/printps.cpp:183
+#, c-format
+msgid "Printing page %d..."
+msgstr "Se tipărește pagina %d..."
+
+#: ../src/generic/prntdlgg.cpp:171
+msgid "Printer options"
+msgstr "Opțiuni imprimantă"
+
+#: ../src/generic/prntdlgg.cpp:176
+msgid "Print to File"
+msgstr "Tipărește în fișier"
+
+#: ../src/generic/prntdlgg.cpp:179
+msgid "Setup..."
+msgstr "Setări..."
+
+#: ../src/generic/prntdlgg.cpp:187
+msgid "Printer:"
+msgstr "Imprimantă:"
+
+#: ../src/generic/prntdlgg.cpp:195
+msgid "Status:"
+msgstr "Stare:"
+
+#: ../src/generic/prntdlgg.cpp:206
+msgid "All"
+msgstr "Tot"
+
+#: ../src/generic/prntdlgg.cpp:207
+msgid "Pages"
+msgstr "Pagini"
+
+#: ../src/generic/prntdlgg.cpp:215
+msgid "Print Range"
+msgstr "Interval de tipărire"
+
+#: ../src/generic/prntdlgg.cpp:229
+msgid "From:"
+msgstr "De la:"
+
+#: ../src/generic/prntdlgg.cpp:233
+msgid "To:"
+msgstr "Către:"
+
+#: ../src/generic/prntdlgg.cpp:238
+msgid "Copies:"
+msgstr "Copii:"
+
+#: ../src/generic/prntdlgg.cpp:288
+msgid "PostScript file"
+msgstr "Fișier PostScript"
+
+#: ../src/generic/prntdlgg.cpp:439
+msgid "Print Setup"
+msgstr "Setări tipărire"
+
+#: ../src/generic/prntdlgg.cpp:483
+msgid "Printer"
+msgstr "Imprimantă"
+
+#: ../src/generic/prntdlgg.cpp:501
+msgid "Default printer"
+msgstr "Imprimantă implicită"
+
+#: ../src/generic/prntdlgg.cpp:595 ../src/generic/prntdlgg.cpp:782
+#: ../src/generic/prntdlgg.cpp:822 ../src/generic/prntdlgg.cpp:835
+#: ../src/generic/prntdlgg.cpp:1031 ../src/generic/prntdlgg.cpp:1036
+msgid "Paper size"
+msgstr "Dimensiune hârtie"
+
+#: ../src/generic/prntdlgg.cpp:604 ../src/generic/prntdlgg.cpp:847
+msgid "Portrait"
+msgstr "Vertical"
+
+#: ../src/generic/prntdlgg.cpp:605 ../src/generic/prntdlgg.cpp:848
+msgid "Landscape"
+msgstr "Orizontal"
+
+#: ../src/generic/prntdlgg.cpp:607 ../src/generic/prntdlgg.cpp:849
+msgid "Orientation"
+msgstr "Orientare"
+
+#: ../src/generic/prntdlgg.cpp:610
+msgid "Options"
+msgstr "Opțiuni"
+
+#: ../src/generic/prntdlgg.cpp:612
+msgid "Print in colour"
+msgstr "Tipărește color"
+
+#: ../src/generic/prntdlgg.cpp:621
+msgid "Print spooling"
+msgstr "Tipărire cu buffer"
+
+#: ../src/generic/prntdlgg.cpp:623
+msgid "Printer command:"
+msgstr "Comandă imprimantă:"
+
+#: ../src/generic/prntdlgg.cpp:631
+msgid "Printer options:"
+msgstr "Opțiuni imprimantă:"
+
+#: ../src/generic/prntdlgg.cpp:860
+msgid "Left margin (mm):"
+msgstr "Margine stânga (mm):"
+
+#: ../src/generic/prntdlgg.cpp:861
+msgid "Top margin (mm):"
+msgstr "Margine sus (mm):"
+
+#: ../src/generic/prntdlgg.cpp:872
+msgid "Right margin (mm):"
+msgstr "Margine dreapta (mm):"
+
+#: ../src/generic/prntdlgg.cpp:873
+msgid "Bottom margin (mm):"
+msgstr "Margine jos (mm):"
+
+#: ../src/generic/prntdlgg.cpp:896
+msgid "Printer..."
+msgstr "Imprimantă..."
+
+#: ../src/generic/progdlgg.cpp:246
+msgid "&Skip"
+msgstr "&Omite"
+
+#: ../src/generic/progdlgg.cpp:347 ../src/generic/progdlgg.cpp:626
+msgid "Unknown"
+msgstr "Necunoscut"
+
+#: ../src/generic/progdlgg.cpp:451 ../src/msw/progdlg.cpp:526
+msgid "Done."
+msgstr "Gata."
+
+#: ../src/generic/srchctlg.cpp:55 ../src/gtk/srchctrl.cpp:206
+#: ../src/html/helpwnd.cpp:530 ../src/html/helpwnd.cpp:545
+msgid "Search"
+msgstr "Caută"
+
+#: ../src/generic/tabg.cpp:1026
+msgid "Could not find tab for id"
+msgstr "Nu s-a putut găsi indentarea pentru id"
+
+#: ../src/generic/tipdlg.cpp:136
+msgid "Tips not available, sorry!"
+msgstr "Sfaturile nu sunt disponibile, ne pare rău!"
+
+#: ../src/generic/tipdlg.cpp:197
+msgid "Tip of the Day"
+msgstr "Sfatul zilei"
+
+#: ../src/generic/tipdlg.cpp:207
+msgid "Did you know..."
+msgstr "Știați că..."
+
+#: ../src/generic/tipdlg.cpp:232
+msgid "&Show tips at startup"
+msgstr "Arată &sfaturi la pornire"
+
+#: ../src/generic/tipdlg.cpp:236
+msgid "&Next Tip"
+msgstr "Sfatul &următor"
+
+#: ../src/generic/wizard.cpp:411
+msgid "&Next >"
+msgstr "&Următor >"
+
+#: ../src/generic/wizard.cpp:412
+msgid "&Finish"
+msgstr "&Termină"
+
+#: ../src/generic/wizard.cpp:420
+msgid "< &Back"
+msgstr "< Î&napoi"
+
+#: ../src/gtk/aboutdlg.cpp:204
+msgid "translator-credits"
+msgstr "merite de traducere"
+
+#: ../src/gtk/app.cpp:517
+msgid ""
+"WARNING: using XIM input method is unsupported and may result in problems "
+"with input handling and flickering. Consider unsetting GTK_IM_MODULE or "
+"setting to \"ibus\"."
+msgstr ""
+"ATENTIE: folosirea metodei de input XIM nu este suportată și poate rezulta "
+"în probleme de input și pâlpâire. Considerați resetarea GTK_IM_MODULE sau "
+"setarea la \"ibus\"."
+
+#: ../src/gtk/app.cpp:569
+msgid "Unable to initialize GTK+, is DISPLAY set properly?"
+msgstr "Nu se poate inițializa GTK+, este variabila DISPLAY setată corect?"
+
+#: ../src/gtk/filedlg.cpp:89 ../src/gtk/filepicker.cpp:255
+#, c-format
+msgid "Changing current directory to \"%s\" failed"
+msgstr "Schimbarea directorului curent la \"%s\" a eșuat"
+
+#: ../src/gtk/font.cpp:548
+msgid ""
+"Using private fonts is not supported on this system: Pango library is too "
+"old, 1.38 or later required."
+msgstr ""
+"Folosirea fonturilor private nu este suportată pe acest sistem: Pango este "
+"prea vechi, necesită 1.38 sau mai recent."
+
+#: ../src/gtk/font.cpp:558
+msgid "Failed to create font configuration object."
+msgstr "Obiectul de configurare a fontului nu a putut fi creat."
+
+#: ../src/gtk/font.cpp:568
+#, c-format
+msgid "Failed to add custom font \"%s\"."
+msgstr "A eșuat adăugarea fontului personalizat \"%s\"."
+
+#: ../src/gtk/font.cpp:576
+msgid "Failed to register font configuration using private fonts."
+msgstr ""
+"A eșuat înregistrarea configurării de font ce folosește fonturi private."
+
+#: ../src/gtk/glcanvas.cpp:117 ../src/gtk/glcanvas.cpp:132
+msgid "Fatal Error"
+msgstr "Eroare Fatală"
+
+#: ../src/gtk/glcanvas.cpp:117
+msgid ""
+"This program wasn't compiled with EGL support required under Wayland, "
+"either\n"
+"install EGL libraries and rebuild or run it under X11 backend by setting\n"
+"environment variable GDK_BACKEND=x11 before starting your program."
+msgstr ""
+"Acest program nu a fost compilat cu suportul EGL necesar pentru Wayland,\n"
+"trebuie instalate bibliotecile EGL și recompilat sau rulat sub X11 setând\n"
+"variabila de mediu GDK_BACKEND=x11 înainte de a porni programul."
+
+#: ../src/gtk/glcanvas.cpp:132
+msgid ""
+"wxGLCanvas is only supported on Wayland and X11 currently.  You may be able "
+"to\n"
+"work around this by setting environment variable GDK_BACKEND=x11 before\n"
+"starting your program."
+msgstr ""
+"wxGLCanvas este suportat doar pentru Wayland și X11. Ar putea fi ocolită "
+"această\n"
+"limitare setând variabila de mediu GDK_BACKEND=x11 înaintea pornirii "
+"programului."
+
+#: ../src/gtk/mdi.cpp:433
+msgid "MDI child"
+msgstr "Copil MDI"
+
+#: ../src/gtk/power.cpp:188
+#, c-format
+msgid "Failed to open D-Bus connection to the login manager: %s"
+msgstr ""
+"A eșuat deschiderea conexiunii D-Bus către managerul de autentificare: %s"
+
+#: ../src/gtk/power.cpp:214
+msgid "wxWidgets application"
+msgstr "aplicație wxWidgets"
+
+#: ../src/gtk/power.cpp:226
+msgid "Application needs to keep running"
+msgstr "Aplicația trebui să continue să ruleze"
+
+#: ../src/gtk/power.cpp:233
+msgid "Clean up before suspend"
+msgstr "Curățenie înainte de suspendare"
+
+#: ../src/gtk/power.cpp:259
+#, c-format
+msgid "Failed to inhibit sleep: %s"
+msgstr "A eșuat inhibarea repaosului: %s"
+
+#: ../src/gtk/power.cpp:265
+msgid "Unexpected response to D-Bus \"Inhibit\" request."
+msgstr "Răspuns neașteptat la cererea D-Bus de \"inhibare\"."
+
+#: ../src/gtk/print.cpp:218
+msgid "Custom size"
+msgstr "Dimensiune personalizată"
+
+#: ../src/gtk/print.cpp:752
+#, c-format
+msgid "Error while printing: %s"
+msgstr "Eroare la tipărire: %s"
+
+#: ../src/gtk/print.cpp:816
+msgid "Page Setup"
+msgstr "Setări pagină"
+
+#: ../src/gtk/webview_webkit.cpp:932
+msgid "Retrieving JavaScript script output is not supported with WebKit v1"
+msgstr ""
+"Obținerea outputului de la scriptul JavaScript nu este suportată cu WebKit v1"
+
+#: ../src/gtk/webview_webkit2.cpp:1098
+msgid ""
+"Setting proxy is not supported by WebKit, at least version 2.16 is required."
+msgstr ""
+"Setarea unui proxy nu este suportată de WebKit, este necesară cel puțin "
+"versiunea 2.16."
+
+#: ../src/gtk/webview_webkit2.cpp:1104
+msgid "This program was compiled without support for setting WebKit proxy."
+msgstr ""
+"Acest program a fost compilat fară suport pentru setarea de proxy pentru "
+"WebKit."
+
+#: ../src/gtk/window.cpp:6289
+msgid ""
+"GTK+ installed on this machine is too old to support screen compositing, "
+"please install GTK+ 2.12 or later."
+msgstr ""
+"GTK+ instalat pe această mașină este prea vechi pentru a suporta compunerea "
+"ecranului, instalați GTK+ 2.12 sau ulterior."
+
+#: ../src/gtk/window.cpp:6307
+msgid ""
+"Compositing not supported by this system, please enable it in your Window "
+"Manager."
+msgstr ""
+"Compunerea nu este suportată de acest sistem, trebuie activată din Managerul "
+"de Ferestre."
+
+#: ../src/gtk/window.cpp:6318
+msgid ""
+"This program was compiled with a too old version of GTK+, please rebuild "
+"with GTK+ 2.12 or newer."
+msgstr ""
+"Acest program a fost compilat cu o versiune de GTK+ prea veche, recompilați "
+"cu GTK+ 2.12 sau mai recent."
+
+#: ../src/html/chm.cpp:138
+#, c-format
+msgid "Failed to open CHM archive '%s'."
+msgstr "A eșuat deschiderea arhivei CHM '%s'."
+
+#: ../src/html/chm.cpp:270
+#, c-format
+msgid "Could not extract %s into %s: %s"
+msgstr "Nu s-a putut extrage %s în %s: %s"
+
+#: ../src/html/chm.cpp:324
+msgid "no error"
+msgstr "nicio eroare"
+
+#: ../src/html/chm.cpp:326
+msgid "bad arguments to library function"
+msgstr "argumente eronate date unei funcții din bibliotecă"
+
+#: ../src/html/chm.cpp:328
+msgid "error opening file"
+msgstr "eroare la deschiderea fișierului"
+
+#: ../src/html/chm.cpp:330
+msgid "read error"
+msgstr "eroare la citire"
+
+#: ../src/html/chm.cpp:332
+msgid "write error"
+msgstr "eroare la scriere"
+
+#: ../src/html/chm.cpp:334
+msgid "seek error"
+msgstr "eroare la căutare"
+
+#: ../src/html/chm.cpp:338
+msgid "bad signature"
+msgstr "semnătură incorectă"
+
+#: ../src/html/chm.cpp:340
+msgid "error in data format"
+msgstr "eroare în formatul de date"
+
+#: ../src/html/chm.cpp:342
+msgid "checksum error"
+msgstr "suma de control eronată"
+
+#: ../src/html/chm.cpp:344
+msgid "compression error"
+msgstr "eroare la comprimare"
+
+#: ../src/html/chm.cpp:346
+msgid "decompression error"
+msgstr "eroare la decomprimare"
+
+#: ../src/html/chm.cpp:437
+#, c-format
+msgid "Could not locate file '%s'."
+msgstr "Nu a putut fi localizat fișierul '%s'."
+
+#: ../src/html/chm.cpp:711
+#, c-format
+msgid "Could not create temporary file '%s'"
+msgstr "Nu a putut fi creat fișierul temporar '%s'"
+
+#: ../src/html/chm.cpp:718
+#, c-format
+msgid "Extraction of '%s' into '%s' failed."
+msgstr "Extragerea '%s' în '%s' a eșuat."
+
+#: ../src/html/chm.cpp:806 ../src/html/chm.cpp:863
+msgid "CHM handler currently supports only local files!"
+msgstr "Funcționalitatea pentru CHM suportă numai fișiere locale!"
+
+#: ../src/html/chm.cpp:827
+msgid "Link contained '//', converted to absolute link."
+msgstr "Legătura conținea '//', a fost convertită la legătură absolută."
+
+#: ../src/html/helpctrl.cpp:59
+#, c-format
+msgid "Help: %s"
+msgstr "Ajutor: %s"
+
+#: ../src/html/helpctrl.cpp:155
+#, c-format
+msgid "Adding book %s"
+msgstr "Adaugă cartea %s"
+
+#: ../src/html/helpdata.cpp:295
+#, c-format
+msgid "Cannot open contents file: %s"
+msgstr "Nu se poate deschide fișierul de cuprins: %s"
+
+#: ../src/html/helpdata.cpp:309
+#, c-format
+msgid "Cannot open index file: %s"
+msgstr "Nu se poate deschide fișierul index: %s"
+
+#: ../src/html/helpdata.cpp:643
+msgid "noname"
+msgstr "nedenumit"
+
+#: ../src/html/helpdata.cpp:652
+#, c-format
+msgid "Cannot open HTML help book: %s"
+msgstr "Nu se poate deschide manualul HTML: %s"
+
+#: ../src/html/helpwnd.cpp:315
+msgid "Displays help as you browse the books on the left."
+msgstr "Afișează manualul de ajutor în timp ce răsfoiești cărțile din stânga."
+
+#: ../src/html/helpwnd.cpp:411 ../src/html/helpwnd.cpp:1100
+#: ../src/html/helpwnd.cpp:1735
+msgid "(bookmarks)"
+msgstr "(semne de carte)"
+
+#: ../src/html/helpwnd.cpp:424
+msgid "Add current page to bookmarks"
+msgstr "Adaugă pagina curentă la semnele de carte"
+
+#: ../src/html/helpwnd.cpp:425
+msgid "Remove current page from bookmarks"
+msgstr "Șterge pagina curentă dintre semnele de carte"
+
+#: ../src/html/helpwnd.cpp:470
+msgid "Contents"
+msgstr "Cuprins"
+
+#: ../src/html/helpwnd.cpp:485
+msgid "Find"
+msgstr "Caută"
+
+#: ../src/html/helpwnd.cpp:487
+msgid "Show all"
+msgstr "Arată tot"
+
+#: ../src/html/helpwnd.cpp:497
+msgid ""
+"Display all index items that contain given substring. Search is case "
+"insensitive."
+msgstr ""
+"Afișează toate elementele index care conțin șirul de caractere dat. "
+"Majusculele nu sunt semnificative pentru căutare."
+
+#: ../src/html/helpwnd.cpp:498
+msgid "Show all items in index"
+msgstr "Afișează toate elementele din index"
+
+#: ../src/html/helpwnd.cpp:528
+msgid "Case sensitive"
+msgstr "Cu majuscule semnificative"
+
+#: ../src/html/helpwnd.cpp:529
+msgid "Whole words only"
+msgstr "Numai cuvinte întregi"
+
+#: ../src/html/helpwnd.cpp:532
+msgid ""
+"Search contents of help book(s) for all occurrences of the text you typed "
+"above"
+msgstr ""
+"Caută în conținutul cărții(-lor) de ajutor toate aparițiile textului "
+"introdus mai sus"
+
+#: ../src/html/helpwnd.cpp:653
+msgid "Show/hide navigation panel"
+msgstr "Afișează/ascunde panoul de navigare"
+
+#: ../src/html/helpwnd.cpp:655
+msgid "Go back"
+msgstr "Înapoi"
+
+#: ../src/html/helpwnd.cpp:656
+msgid "Go forward"
+msgstr "Înainte"
+
+#: ../src/html/helpwnd.cpp:658
+msgid "Go one level up in document hierarchy"
+msgstr "În sus un nivel în ierarhia documentelor"
+
+#: ../src/html/helpwnd.cpp:666 ../src/html/helpwnd.cpp:1547
+msgid "Open HTML document"
+msgstr "Deschide document HTML"
+
+#: ../src/html/helpwnd.cpp:670
+msgid "Print this page"
+msgstr "Tipărește această pagină"
+
+#: ../src/html/helpwnd.cpp:674
+msgid "Display options dialog"
+msgstr "Afișează dialogul de opțiuni"
+
+#: ../src/html/helpwnd.cpp:795
+msgid "Please choose the page to display:"
+msgstr "Alegeți pagina de afișat:"
+
+#: ../src/html/helpwnd.cpp:796
+msgid "Help Topics"
+msgstr "Subiecte de ajutor"
+
+#: ../src/html/helpwnd.cpp:852
+msgid "Searching..."
+msgstr "Caută..."
+
+#: ../src/html/helpwnd.cpp:853
+msgid "No matching page found yet"
+msgstr "Nicio pagină corespunzătoare găsită încă"
+
+#: ../src/html/helpwnd.cpp:870
+#, c-format
+msgid "Found %i matches"
+msgstr "S-au găsit %i rezultate"
+
+#: ../src/html/helpwnd.cpp:958
+msgid "(Help)"
+msgstr "(Ajutor)"
+
+#: ../src/html/helpwnd.cpp:1026
+#, c-format
+msgid "%d of %lu"
+msgstr "%d din %lu"
+
+#: ../src/html/helpwnd.cpp:1028
+#, c-format
+msgid "%lu of %lu"
+msgstr "%lu din %lu"
+
+#: ../src/html/helpwnd.cpp:1047
+msgid "Search in all books"
+msgstr "Caută în toate cărțile"
+
+#: ../src/html/helpwnd.cpp:1193
+msgid "Help Browser Options"
+msgstr "Ajutor pentru opțiunile bowser-ului"
+
+#: ../src/html/helpwnd.cpp:1198
+msgid "Normal font:"
+msgstr "Font normal:"
+
+#: ../src/html/helpwnd.cpp:1199
+msgid "Fixed font:"
+msgstr "Font fix:"
+
+#: ../src/html/helpwnd.cpp:1200
+msgid "Font size:"
+msgstr "Dimensiune font:"
+
+#: ../src/html/helpwnd.cpp:1245
+msgid "font size"
+msgstr "dimensiune font"
+
+#: ../src/html/helpwnd.cpp:1256
+msgid "Normal face<br>and <u>underlined</u>. "
+msgstr "Font normal<br>și <u>subliniat</u>. "
+
+#: ../src/html/helpwnd.cpp:1257
+msgid "<i>Italic face.</i> "
+msgstr "<i>Cursiv.</i> "
+
+#: ../src/html/helpwnd.cpp:1258
+msgid "<b>Bold face.</b> "
+msgstr "<b>Îngroșat.</b> "
+
+#: ../src/html/helpwnd.cpp:1259
+msgid "<b><i>Bold italic face.</i></b><br>"
+msgstr "<b><i>Îngroșat cursiv.</i></b><br>"
+
+#: ../src/html/helpwnd.cpp:1262
+msgid "Fixed size face.<br> <b>bold</b> <i>italic</i> "
+msgstr "Font cu dimensiune fixă.<br> <b>îngroșat</b> <i>cursiv</i> "
+
+#: ../src/html/helpwnd.cpp:1263
+msgid "<b><i>bold italic <u>underlined</u></i></b><br>"
+msgstr "<b><i>îngroșat cursiv <u>subliniat</u></i></b><br>"
+
+#: ../src/html/helpwnd.cpp:1524
+msgid "Help Printing"
+msgstr "Ajutor pentru tipărire"
+
+#: ../src/html/helpwnd.cpp:1527
+msgid "Cannot print empty page."
+msgstr "Nu se poate tipări o pagină goală."
+
+#: ../src/html/helpwnd.cpp:1540
+msgid "HTML files (*.html;*.htm)|*.html;*.htm|"
+msgstr "Fișiere HTML (*.html;*.htm)|*.html;*.htm|"
+
+#: ../src/html/helpwnd.cpp:1541
+msgid "Help books (*.htb)|*.htb|Help books (*.zip)|*.zip|"
+msgstr "Manuale de ajutor (*.htb)|*.htb|Manuale de ajutor (*.zip)|*.zip|"
+
+#: ../src/html/helpwnd.cpp:1542
+msgid "HTML Help Project (*.hhp)|*.hhp|"
+msgstr "HTML Help Project (*.hhp)|*.hhp|"
+
+#: ../src/html/helpwnd.cpp:1544
+msgid "Compressed HTML Help file (*.chm)|*.chm|"
+msgstr "Fișier HTML Manual comprimat (*.chm)|*.chm|"
+
+#: ../src/html/helpwnd.cpp:1671
+#, c-format
+msgid "%i of %u"
+msgstr "%i din %u"
+
+#: ../src/html/helpwnd.cpp:1709
+#, c-format
+msgid "%u of %u"
+msgstr "%u din %u"
+
+#: ../src/html/htmlfilt.cpp:134
+#, c-format
+msgid "Cannot open HTML document: %s"
+msgstr "Nu se poate deschide documentul HTML: %s"
+
+#: ../src/html/htmlwin.cpp:599
+msgid "Connecting..."
+msgstr "Se conectează..."
+
+#: ../src/html/htmlwin.cpp:616
+#, c-format
+msgid "Unable to open requested HTML document: %s"
+msgstr "Nu se poate deschide documentul HTML cerut: %s"
+
+#: ../src/html/htmlwin.cpp:630
+msgid "Loading : "
+msgstr "Se încarcă : "
+
+#: ../src/html/htmlwin.cpp:673
+msgid "Done"
+msgstr "Gata"
+
+#: ../src/html/htmlwin.cpp:723
+#, c-format
+msgid "HTML anchor %s does not exist."
+msgstr "Ancora HTML %s nu există."
+
+#: ../src/html/htmlwin.cpp:1057
+#, c-format
+msgid "Copied to clipboard:\"%s\""
+msgstr "Copiat în clipboard: \"%s\""
+
+#: ../src/html/htmprint.cpp:269
+msgid ""
+"This document doesn't fit on the page horizontally and will be truncated "
+"when it is printed."
+msgstr ""
+"Acest document nu încape în pagină pe orizontală și va fi trunchiat la "
+"tipărire."
+
+#: ../src/html/htmprint.cpp:285
+#, c-format
+msgid ""
+"The document \"%s\" doesn't fit on the page horizontally and will be "
+"truncated if printed.\n"
+"\n"
+"Would you like to proceed with printing it nevertheless?"
+msgstr ""
+"Documentul \"%s\" nu încape în pagină pe orizontală și va fi trunchiat la "
+"tipărire.\n"
+"\n"
+"Doriți să fie tipărit oricum?"
+
+#: ../src/html/htmprint.cpp:296
+msgid ""
+"If possible, try changing the layout parameters to make the printout more "
+"narrow."
+msgstr ""
+"Dacă este posibil, schimbați parametrii de formatare pentru a ingusta zona "
+"tiparită."
+
+#: ../src/html/htmprint.cpp:445
+msgid ": file does not exist!"
+msgstr ": fișierul nu există!"
+
+#. TRANSLATORS: %s may be a document title.
+#: ../src/html/htmprint.cpp:717
+#, c-format
+msgid "%s Preview"
+msgstr "%s Previzualizare"
+
+#: ../src/html/htmprint.cpp:755 ../src/richtext/richtextprint.cpp:618
+msgid ""
+"There was a problem during page setup: you may need to set a default printer."
+msgstr ""
+"A fost o problemă în timpul setării paginii: se poate să trebuiască setată o "
+"imprimantă implicită."
+
+#: ../src/msw/clipbrd.cpp:80
+msgid "Failed to open the clipboard."
+msgstr "A eșuat deschiderea memoriei clipboard."
+
+#: ../src/msw/clipbrd.cpp:101
+msgid "Failed to close the clipboard."
+msgstr "A eșuat închiderea memoriei clipboard."
+
+#: ../src/msw/clipbrd.cpp:113
+msgid "Failed to empty the clipboard."
+msgstr "A eșuat golirea memoriei clipboard."
+
+#: ../src/msw/clipbrd.cpp:284
+msgid "Failed to put data on the clipboard"
+msgstr "A eșuat punerea datelor în memoria clipboard"
+
+#: ../src/msw/clipbrd.cpp:326
+msgid "Failed to get data from the clipboard"
+msgstr "A eșuat obținerea datelor din memoria clipboard"
+
+#: ../src/msw/clipbrd.cpp:363
+msgid "Failed to retrieve the supported clipboard formats"
+msgstr "A eșuat obținerea formatelor suportate de memoria clipboard"
+
+#: ../src/msw/colordlg.cpp:228
+#, c-format
+msgid "Colour selection dialog failed with error %0lx."
+msgstr "Dialogul de selecție a culorii a eșuat cu eroarea %0lx."
+
+#: ../src/msw/cursor.cpp:141
+msgid "Failed to create cursor."
+msgstr "A eșuat crearea unui cursor."
+
+#: ../src/msw/dde.cpp:279
+#, c-format
+msgid "Failed to register DDE server '%s'"
+msgstr "A eșuat înregistrarea server-ului DDE '%s'"
+
+#: ../src/msw/dde.cpp:300
+#, c-format
+msgid "Failed to unregister DDE server '%s'"
+msgstr "A eșuat înlăturarea înregistrării serverului DDE '%s'"
+
+#: ../src/msw/dde.cpp:428
+#, c-format
+msgid "Failed to create connection to server '%s' on topic '%s'"
+msgstr "A eșuat crearea conexiunii cu serverul '%s' pentru subiectul '%s'"
+
+#: ../src/msw/dde.cpp:655
+msgid "DDE poke request failed"
+msgstr "Cererea DDE de test a eșuat"
+
+#: ../src/msw/dde.cpp:674
+msgid "Failed to establish an advise loop with DDE server"
+msgstr "A eșuat stabilirea unei bucle de informare cu serverul DDE"
+
+#: ../src/msw/dde.cpp:693
+msgid "Failed to terminate the advise loop with DDE server"
+msgstr "A eșuat terminarea buclei de informare cu serverul DDE"
+
+#: ../src/msw/dde.cpp:768
+msgid "Failed to send DDE advise notification"
+msgstr "A eșuat trimiterea notificării DDE"
+
+#: ../src/msw/dde.cpp:1085
+msgid "Failed to create DDE string"
+msgstr "A eșuat crearea șirului DDE de caractere"
+
+#: ../src/msw/dde.cpp:1131
+msgid "no DDE error."
+msgstr "nicio eroare DDE."
+
+#: ../src/msw/dde.cpp:1135
+msgid "a request for a synchronous advise transaction has timed out."
+msgstr "o cerere pentru o tranzacție sincronă de informare a expirat."
+
+#: ../src/msw/dde.cpp:1138
+msgid "the response to the transaction caused the DDE_FBUSY bit to be set."
+msgstr "răspunsul la tranzacție a determinat ca bit-ul DDE_FBUSY să fie setat."
+
+#: ../src/msw/dde.cpp:1141
+msgid "a request for a synchronous data transaction has timed out."
+msgstr "o cerere pentru o tranzacție sincronă de date a expirat."
+
+#: ../src/msw/dde.cpp:1144
+msgid ""
+"a DDEML function was called without first calling the DdeInitialize "
+"function,\n"
+"or an invalid instance identifier\n"
+"was passed to a DDEML function."
+msgstr ""
+"o funcție DDEML a fost apelată fără ca mai intâi să fie apelată funcția "
+"DdeInitialize,\n"
+"sau un identificator de instanță invalid\n"
+"a fost trimis unei funcții DDEML."
+
+#: ../src/msw/dde.cpp:1147
+msgid ""
+"an application initialized as APPCLASS_MONITOR has\n"
+"attempted to perform a DDE transaction,\n"
+"or an application initialized as APPCMD_CLIENTONLY has \n"
+"attempted to perform server transactions."
+msgstr ""
+"o aplicație inițializată ca APPCLASS_MONITOR\n"
+"a încercat să execute o tranzacție DDE,\n"
+"sau o aplicație inițializată ca APPCMD_CLIENTONLY\n"
+"a încercat să execute o tranzacție de server."
+
+#: ../src/msw/dde.cpp:1150
+msgid "a request for a synchronous execute transaction has timed out."
+msgstr "o cerere pentru o tranzacție sincronă de execuție a expirat."
+
+#: ../src/msw/dde.cpp:1153
+msgid "a parameter failed to be validated by the DDEML."
+msgstr "un parametru nu a fost validat de DDEML."
+
+#: ../src/msw/dde.cpp:1156
+msgid "a DDEML application has created a prolonged race condition."
+msgstr "o aplicație DDEML a creat o condiție de rulare concurentă prelungită."
+
+#: ../src/msw/dde.cpp:1159
+msgid "a memory allocation failed."
+msgstr "o alocare de memorie a eșuat."
+
+#: ../src/msw/dde.cpp:1162
+msgid "a client's attempt to establish a conversation has failed."
+msgstr "o tentativă a unui client de a stabili o conversație a eșuat."
+
+#: ../src/msw/dde.cpp:1165
+msgid "a transaction failed."
+msgstr "o tranzacție a eșuat."
+
+#: ../src/msw/dde.cpp:1168
+msgid "a request for a synchronous poke transaction has timed out."
+msgstr "o cerere pentru o tranzacție sincronă de test a expirat."
+
+#: ../src/msw/dde.cpp:1171
+msgid "an internal call to the PostMessage function has failed. "
+msgstr "un apel intern către funcția PostMessage a eșuat. "
+
+#: ../src/msw/dde.cpp:1174
+msgid "reentrancy problem."
+msgstr "problemă de reentranță."
+
+#: ../src/msw/dde.cpp:1177
+msgid ""
+"a server-side transaction was attempted on a conversation\n"
+"that was terminated by the client, or the server\n"
+"terminated before completing a transaction."
+msgstr ""
+"o tranzacție din partea serverului a fost inițiată\n"
+"într-o conversație întreruptă de client, sau serverul\n"
+"a terminat înainte de încheierea tranzacției."
+
+#: ../src/msw/dde.cpp:1180
+msgid "an internal error has occurred in the DDEML."
+msgstr "o eroare internă a survenit în DDEML."
+
+#: ../src/msw/dde.cpp:1183
+msgid "a request to end an advise transaction has timed out."
+msgstr "o cerere de încheiere a unei tranzacții de informare a expirat."
+
+#: ../src/msw/dde.cpp:1186
+msgid ""
+"an invalid transaction identifier was passed to a DDEML function.\n"
+"Once the application has returned from an XTYP_XACT_COMPLETE callback,\n"
+"the transaction identifier for that callback is no longer valid."
+msgstr ""
+"un identificator de tranzacție invalid a fost transmis unei funcții DDEML.\n"
+"La revenirea din funcția de apel invers XTYP_XACT_COMPLETE,\n"
+"identificatorul de tranzacție al funcției de apel invers nu mai este valid."
+
+#: ../src/msw/dde.cpp:1189
+#, c-format
+msgid "Unknown DDE error %08x"
+msgstr "Eroare DDE necunoscută %08x"
+
+#: ../src/msw/dialup.cpp:343
+msgid ""
+"Dial up functions are unavailable because the remote access service (RAS) is "
+"not installed on this machine. Please install it."
+msgstr ""
+"Funcțiile de dialup nu sunt disponibile pentru că serviciul de acces la "
+"distanță (RAS) nu este instalat. Trebuie să îl instalați."
+
+#: ../src/msw/dialup.cpp:402
+#, c-format
+msgid ""
+"The version of remote access service (RAS) installed on this machine is too "
+"old, please upgrade (the following required function is missing: %s)."
+msgstr ""
+"Versiunea serviciului de acces de la distanță (RAS) instalat pe această "
+"mașină este prea veche, trebuie să îl actualizați (următoarea funcție "
+"necesară lipsește: %s)."
+
+#: ../src/msw/dialup.cpp:437
+msgid "Failed to retrieve text of RAS error message"
+msgstr "A eșuat obținerea textului din mesajul de eroare RAS"
+
+#: ../src/msw/dialup.cpp:440
+#, c-format
+msgid "unknown error (error code %08x)."
+msgstr "eroare necunoscută (cod de eroare %08x)."
+
+#: ../src/msw/dialup.cpp:492
+#, c-format
+msgid "Cannot find active dialup connection: %s"
+msgstr "Nu se poate determina conexiunea dialup activă: %s"
+
+#: ../src/msw/dialup.cpp:513
+msgid "Several active dialup connections found, choosing one randomly."
+msgstr ""
+"S-au găsit mai multe conexiuni dialup active, se alege una la întâmplare."
+
+#: ../src/msw/dialup.cpp:598 ../src/msw/dialup.cpp:832
+#, c-format
+msgid "Failed to establish dialup connection: %s"
+msgstr "A eșuat stabilirea unei conexiuni dialup: %s"
+
+#: ../src/msw/dialup.cpp:664
+#, c-format
+msgid "Failed to get ISP names: %s"
+msgstr "A eșuat obținerea numelor ISP: %s"
+
+#: ../src/msw/dialup.cpp:712
+msgid "Failed to connect: no ISP to dial."
+msgstr "A eșuat conectarea: nu există niciun ISP pentru apelare."
+
+#: ../src/msw/dialup.cpp:732
+msgid "Choose ISP to dial"
+msgstr "Alege ISP pentru a forma"
+
+#: ../src/msw/dialup.cpp:733
+msgid "Please choose which ISP do you want to connect to"
+msgstr "Alegeți ISP-ul la care vreți să vă conectați"
+
+#: ../src/msw/dialup.cpp:766
+msgid "Failed to connect: missing username/password."
+msgstr "A eșuat conectarea: lipsește utilizator/parola."
+
+#: ../src/msw/dialup.cpp:796
+msgid "Cannot find the location of address book file"
+msgstr "Nu se poate determina locația fișierului agendă"
+
+#: ../src/msw/dialup.cpp:827
+#, c-format
+msgid "Failed to initiate dialup connection: %s"
+msgstr "A eșuat inițializarea conexiunii dialup: %s"
+
+#: ../src/msw/dialup.cpp:897
+msgid "Cannot hang up - no active dialup connection."
+msgstr "Nu se poate închide - nu există o conexiune dialup activă."
+
+#: ../src/msw/dialup.cpp:907
+#, c-format
+msgid "Failed to terminate the dialup connection: %s"
+msgstr "A eșuat terminarea conexiunii dialup: %s"
+
+#: ../src/msw/dib.cpp:313
+#, c-format
+msgid "Failed to save the bitmap image to file \"%s\"."
+msgstr "A eșuat salvarea imaginii de tip bitmap în fișierul \"%s\"."
+
+#: ../src/msw/dib.cpp:543
+#, c-format
+msgid "Failed to allocate %luKb of memory for bitmap data."
+msgstr "A eșuat alocarea a %luKb de memorie pentru bitmap."
+
+#: ../src/msw/dir.cpp:241
+#, c-format
+msgid "Cannot enumerate files in directory '%s'"
+msgstr "Nu se pot enumera fișierele din directorul '%s'"
+
+#: ../src/msw/dirdlg.cpp:368
+msgid "Couldn't obtain folder name"
+msgstr "Nu a putut fi obținut numele directorului"
+
+#: ../src/msw/dlmsw.cpp:163
+#, c-format
+msgid "(error %d: %s)"
+msgstr "(eroarea %d: %s)"
+
+#: ../src/msw/dragimag.cpp:143 ../src/msw/dragimag.cpp:178
+#: ../src/msw/imaglist.cpp:309 ../src/msw/imaglist.cpp:331
+msgid "Couldn't add an image to the image list."
+msgstr "Nu s-a putut adăuga o imagine la lista de imagini."
+
+#: ../src/msw/enhmeta.cpp:94
+#, c-format
+msgid "Failed to load metafile from file \"%s\"."
+msgstr "A eșuat încărcarea meta-informației din fișierul \"%s\"."
+
+#: ../src/msw/fdrepdlg.cpp:412
+#, c-format
+msgid "Failed to create the standard find/replace dialog (error code %d)"
+msgstr ""
+"A eșuat crearea dialogului standard de căutare/înlocuire (cod de eroare %d)"
+
+#: ../src/msw/filedlg.cpp:1241
+msgid "Access to the file system is not allowed from secure desktop."
+msgstr ""
+"Accesul la sistemul de fișiere nu este permis de pe o platformă securizată."
+
+#: ../src/msw/filedlg.cpp:1242
+msgid "Security warning"
+msgstr "Avertisment de securitate"
+
+#: ../src/msw/filedlg.cpp:1533
+#, c-format
+msgid "File dialog failed with error code %0lx."
+msgstr "Dialogul pentru fișiere a eșuat cu eroarea %0lx."
+
+#: ../src/msw/font.cpp:1120
+#, c-format
+msgid "Font file \"%s\" couldn't be loaded"
+msgstr "Fișierul de font \"%s\" nu a putut fi încărcat"
+
+#: ../src/msw/fontdlg.cpp:220
+#, c-format
+msgid "Common dialog failed with error code %0lx."
+msgstr "Dialogul comun a eșuat cu eroarea %0lx."
+
+#: ../src/msw/fswatcher.cpp:67
+msgid "Ungraceful worker thread termination"
+msgstr "Terminare neelegantă a firului de execuție lucrător"
+
+#: ../src/msw/fswatcher.cpp:81
+msgid "Unable to create IOCP worker thread"
+msgstr "Nu se poate crea firul de execuție IOCP lucrător"
+
+#: ../src/msw/fswatcher.cpp:88
+msgid "Unable to start IOCP worker thread"
+msgstr "Firul de execuție IOCP lucrător nu poate fi pornit"
+
+#: ../src/msw/fswatcher.cpp:140
+msgid "Monitoring individual files for changes is not supported currently."
+msgstr ""
+"Monitorizarea fișierelor individuale pentru schimbări nu este suportată."
+
+#: ../src/msw/fswatcher.cpp:165
+#, c-format
+msgid "Unable to set up watch for '%s'"
+msgstr "Nu se poate seta monitor pentru '%s'"
+
+#: ../src/msw/fswatcher.cpp:466
+#, c-format
+msgid "Can't monitor non-existent directory \"%s\" for changes."
+msgstr "Directorul inexistent \"%s\" nu poate fi monitorizat pentru schimbări."
+
+#: ../src/msw/glcanvas.cpp:577 ../src/unix/glx11.cpp:507
+msgid "OpenGL 3.0 or later is not supported by the OpenGL driver."
+msgstr "OpenGL 3.0 sau ulterior nu este suportat de driverul OpenGL."
+
+#: ../src/msw/glcanvas.cpp:601 ../src/osx/glcanvas_osx.cpp:395
+#: ../src/unix/glegl.cpp:304 ../src/unix/glx11.cpp:553
+msgid "Couldn't create OpenGL context"
+msgstr "Nu a putut fi creat un context OpenGL"
+
+#: ../src/msw/glcanvas.cpp:1294
+msgid "Failed to initialize OpenGL"
+msgstr "A eșuat inițializarea OpenGL"
+
+#: ../src/msw/graphicsd2d.cpp:607
+msgid "Could not register custom DirectWrite font loader."
+msgstr ""
+"Nu a putut fi înregistrat încărcătorul de fonturi personalizat pentru "
+"DirectWrite."
+
+#: ../src/msw/helpchm.cpp:48
+msgid ""
+"MS HTML Help functions are unavailable because the MS HTML Help library is "
+"not installed on this machine. Please install it."
+msgstr ""
+"Funcțiile MS HTML Help nu sunt disponibile pentru că biblioteca MS HTML Help "
+"nu este instalată pe această mașină. Trebuie instalată."
+
+#: ../src/msw/helpchm.cpp:55
+msgid "Failed to initialize MS HTML Help."
+msgstr "A eșuat inițializarea sistemului de ajutor MS HTML Help."
+
+#: ../src/msw/iniconf.cpp:458
+#, c-format
+msgid "Can't delete the INI file '%s'"
+msgstr "Nu se poate șterge fișierul INI '%s'"
+
+#: ../src/msw/listctrl.cpp:995
+#, c-format
+msgid "Couldn't retrieve information about list control item %d."
+msgstr ""
+"Nu s-au putut obține informații despre elementul %d din controlul de tip "
+"listă."
+
+#: ../src/msw/mdi.cpp:170 ../src/qt/mdi.cpp:253
+msgid "&Cascade"
+msgstr "&Cascadă"
+
+#: ../src/msw/mdi.cpp:171
+msgid "Tile &Horizontally"
+msgstr "Rețea pe &orizontală"
+
+#: ../src/msw/mdi.cpp:172
+msgid "Tile &Vertically"
+msgstr "Rețea pe &verticală"
+
+#: ../src/msw/mdi.cpp:174
+msgid "&Arrange Icons"
+msgstr "&Aranjează pictograme"
+
+#: ../src/msw/mdi.cpp:621
+msgid "Failed to create MDI parent frame."
+msgstr "A eșuat crearea ramei părinte MDI."
+
+#: ../src/msw/mimetype.cpp:234
+#, c-format
+msgid "Failed to create registry entry for '%s' files."
+msgstr "A eșuat crearea intrării în regiștri pentru fișierele '%s'."
+
+#: ../src/msw/ole/automtn.cpp:495
+#, c-format
+msgid "Failed to find CLSID of \"%s\""
+msgstr "Nu a fost găsit CLSID al \"%s\""
+
+#: ../src/msw/ole/automtn.cpp:512
+#, c-format
+msgid "Failed to create an instance of \"%s\""
+msgstr "A eșuat crearea unei instanțe \"%s\""
+
+#: ../src/msw/ole/automtn.cpp:552
+#, c-format
+msgid "Cannot get an active instance of \"%s\""
+msgstr "Nu se poate obține o instanță activă pentru \"%s\""
+
+#: ../src/msw/ole/automtn.cpp:564
+#, c-format
+msgid "Failed to get OLE automation interface for \"%s\""
+msgstr "Nu a fost gasită interfața de automatizare OLE a \"%s\""
+
+#: ../src/msw/ole/automtn.cpp:621
+msgid "Unknown name or named argument."
+msgstr "Nume sau denumire de argument necunoscute."
+
+#: ../src/msw/ole/automtn.cpp:625
+msgid "Incorrect number of arguments."
+msgstr "Numar de argumente incorect."
+
+#: ../src/msw/ole/automtn.cpp:637
+msgid "Unknown exception"
+msgstr "Exceptie necunoscută"
+
+#: ../src/msw/ole/automtn.cpp:642
+msgid "Method or property not found."
+msgstr "Metoda sau proprietatea nu a fost găsită."
+
+#: ../src/msw/ole/automtn.cpp:646
+msgid "Overflow while coercing argument values."
+msgstr "Depășire limită maximă în timpul validării valorilor argumentelor."
+
+#: ../src/msw/ole/automtn.cpp:650
+msgid "Object implementation does not support named arguments."
+msgstr "Implementearea obiectului nu suportă argumente cu denumire."
+
+#: ../src/msw/ole/automtn.cpp:654
+msgid "The locale ID is unknown."
+msgstr "ID-ul pentru localizare este necunoscut."
+
+#: ../src/msw/ole/automtn.cpp:658
+msgid "Missing a required parameter."
+msgstr "Lipsește un parametru necesar."
+
+#: ../src/msw/ole/automtn.cpp:662
+#, c-format
+msgid "Argument %u not found."
+msgstr "Argumentul %u nu a fost găsit."
+
+#: ../src/msw/ole/automtn.cpp:666
+#, c-format
+msgid "Type mismatch in argument %u."
+msgstr "Tip nepotrivit pentru argumentul %u."
+
+#: ../src/msw/ole/automtn.cpp:670
+msgid "The system cannot find the file specified."
+msgstr "Sistemul nu poate găsi fișierul specificat."
+
+#: ../src/msw/ole/automtn.cpp:674
+msgid "Class not registered."
+msgstr "Clasa nu este inregistrată."
+
+#: ../src/msw/ole/automtn.cpp:678
+#, c-format
+msgid "Unknown error %08x"
+msgstr "Eroare necunoscută %08x"
+
+#: ../src/msw/ole/automtn.cpp:682
+#, c-format
+msgid "OLE Automation error in %s: %s"
+msgstr "Eroare de automatizare OLE în %s: %s"
+
+#: ../src/msw/ole/dataobj.cpp:385
+#, c-format
+msgid "Couldn't register clipboard format '%s'."
+msgstr "Nu s-a putut înregistra formatul de clipboard '%s'."
+
+#: ../src/msw/ole/dataobj.cpp:402
+#, c-format
+msgid "The clipboard format '%d' doesn't exist."
+msgstr "Formatul '%d' pentru memoria clipboard nu există."
+
+#: ../src/msw/progdlg.cpp:1025
+msgid "Skip"
+msgstr "Omite"
+
+#: ../src/msw/registry.cpp:141
+#, c-format
+msgid "unknown (%lu)"
+msgstr "necunoscut (%lu)"
+
+#: ../src/msw/registry.cpp:409
+#, c-format
+msgid "Can't get info about registry key '%s'"
+msgstr "Nu se pot obține informații despre cheia de regiștri '%s'"
+
+#: ../src/msw/registry.cpp:445
+#, c-format
+msgid "Can't open registry key '%s'"
+msgstr "Nu se poate deschide cheia de regiștri '%s'"
+
+#: ../src/msw/registry.cpp:478
+#, c-format
+msgid "Can't create registry key '%s'"
+msgstr "Nu se poate crea cheia de regiștri '%s'"
+
+#: ../src/msw/registry.cpp:497
+#, c-format
+msgid "Can't close registry key '%s'"
+msgstr "Nu se poate închide cheia de regiștri '%s'"
+
+#: ../src/msw/registry.cpp:512
+#, c-format
+msgid "Registry value '%s' already exists."
+msgstr "Valoarea de regiștri '%s' există deja."
+
+#: ../src/msw/registry.cpp:520
+#, c-format
+msgid "Failed to rename registry value '%s' to '%s'."
+msgstr "A eșuat redenumirea valorii de regiștri '%s' în '%s'."
+
+#: ../src/msw/registry.cpp:575
+#, c-format
+msgid "Can't copy values of unsupported type %d."
+msgstr "Nu se pot copia valorile de tipul nesuportat %d."
+
+#: ../src/msw/registry.cpp:586
+#, c-format
+msgid "Registry key '%s' does not exist, cannot rename it."
+msgstr "Cheia de regiștri '%s' nu există, nu poate fi redenumită."
+
+#: ../src/msw/registry.cpp:617
+#, c-format
+msgid "Registry key '%s' already exists."
+msgstr "Cheia de regiștri '%s' există deja."
+
+#: ../src/msw/registry.cpp:625
+#, c-format
+msgid "Failed to rename the registry key '%s' to '%s'."
+msgstr "A eșuat redenumirea cheii de regiștri '%s' în '%s'."
+
+#: ../src/msw/registry.cpp:670
+#, c-format
+msgid "Failed to copy the registry subkey '%s' to '%s'."
+msgstr "A eșuat copierea sub-cheii de regiștri '%s' în '%s'."
+
+#: ../src/msw/registry.cpp:683
+#, c-format
+msgid "Failed to copy registry value '%s'"
+msgstr "A eșuat copierea valorii de regiștri '%s'"
+
+#: ../src/msw/registry.cpp:692
+#, c-format
+msgid "Failed to copy the contents of registry key '%s' to '%s'."
+msgstr "A eșuat copierea conținutului cheii de regiștri '%s' în '%s'."
+
+#: ../src/msw/registry.cpp:718
+#, c-format
+msgid ""
+"Registry key '%s' is needed for normal system operation,\n"
+"deleting it will leave your system in unusable state:\n"
+"operation aborted."
+msgstr ""
+"Cheia de regiștri '%s' este necesară pentru funcționarea normală a "
+"sistemului,\n"
+"ștergerea ei va lăsa sistemul într-o stare inutilizabilă:\n"
+"operație anulată."
+
+#: ../src/msw/registry.cpp:754
+#, c-format
+msgid "Can't delete key '%s'"
+msgstr "Nu pot șterge cheia '%s'"
+
+#: ../src/msw/registry.cpp:782
+#, c-format
+msgid "Can't delete value '%s' from key '%s'"
+msgstr "Nu pot șterge valoarea '%s' din cheia '%s'"
+
+#: ../src/msw/registry.cpp:855 ../src/msw/registry.cpp:887
+#: ../src/msw/registry.cpp:929 ../src/msw/registry.cpp:1000
+#, c-format
+msgid "Can't read value of key '%s'"
+msgstr "Nu pot citi valoarea cheii '%s'"
+
+#: ../src/msw/registry.cpp:873 ../src/msw/registry.cpp:915
+#: ../src/msw/registry.cpp:963 ../src/msw/registry.cpp:1106
+#, c-format
+msgid "Can't set value of '%s'"
+msgstr "Nu pot seta valoarea '%s'"
+
+#: ../src/msw/registry.cpp:894 ../src/msw/registry.cpp:943
+#, c-format
+msgid "Registry value \"%s\" is not numeric (but of type %s)"
+msgstr "Valoarea \"%s\" din Registry nu este numerică (ci de tip %s)"
+
+#: ../src/msw/registry.cpp:979
+#, c-format
+msgid "Registry value \"%s\" is not binary (but of type %s)"
+msgstr "Valoarea \"%s\" din Registry nu este binară (ci de tip %s)"
+
+#: ../src/msw/registry.cpp:1028
+#, c-format
+msgid "Registry value \"%s\" is not text (but of type %s)"
+msgstr "Valoarea \"%s\" din Registry nu este text (ci de tip %s)"
+
+#: ../src/msw/registry.cpp:1089
+#, c-format
+msgid "Can't read value of '%s'"
+msgstr "Nu pot citi valoarea lui '%s'"
+
+#: ../src/msw/registry.cpp:1157
+#, c-format
+msgid "Can't enumerate values of key '%s'"
+msgstr "Nu pot enumera valorile cheii '%s'"
+
+#: ../src/msw/registry.cpp:1196
+#, c-format
+msgid "Can't enumerate subkeys of key '%s'"
+msgstr "Nu pot enumera sub-cheile cheii '%s'"
+
+#: ../src/msw/registry.cpp:1262
+#, c-format
+msgid ""
+"Exporting registry key: file \"%s\" already exists and won't be overwritten."
+msgstr ""
+"Exportare cheie de regiștri: fișierul \"%s\" există deja și nu va fi "
+"suprascris."
+
+#: ../src/msw/registry.cpp:1411
+#, c-format
+msgid "Can't export value of unsupported type %d."
+msgstr "Nu poate fi exportată valoarea de tipul nesuportat %d."
+
+#: ../src/msw/registry.cpp:1427
+#, c-format
+msgid "Ignoring value \"%s\" of the key \"%s\"."
+msgstr "Este ignorată valoarea \"%s\" a cheii \"%s\"."
+
+#: ../src/msw/textctrl.cpp:596
+msgid ""
+"Impossible to create a rich edit control, using simple text control instead. "
+"Please reinstall riched32.dll"
+msgstr ""
+"Este imposibilă crearea unui control de tip rich edit, se înlocuiește cu un "
+"control simplu de text. Trebuie reinstalat riched32.dll"
+
+#: ../src/msw/thread.cpp:522 ../src/unix/threadpsx.cpp:850
+msgid "Cannot start thread: error writing TLS."
+msgstr "Nu poate fi pornit firul de execuție: eroare la scrierea TLS."
+
+#: ../src/msw/thread.cpp:613
+msgid "Can't set thread priority"
+msgstr "Nu poate fi setată prioritatea pentru fire de execuție"
+
+#: ../src/msw/thread.cpp:649
+msgid "Can't create thread"
+msgstr "Nu poate fi creat firul de execuție"
+
+#: ../src/msw/thread.cpp:668
+msgid "Couldn't terminate thread"
+msgstr "Nu a putut fi terminat firul de execuție"
+
+#: ../src/msw/thread.cpp:799
+msgid "Cannot wait for thread termination"
+msgstr "Nu poate fi așteptată terminarea firului de execuție"
+
+#: ../src/msw/thread.cpp:873
+#, c-format
+msgid "Cannot suspend thread %lx"
+msgstr "Nu poate fi suspendat firul de execuție %lx"
+
+#: ../src/msw/thread.cpp:903
+#, c-format
+msgid "Cannot resume thread %lx"
+msgstr "Nu poate fi reluat firul de execuție %lx"
+
+#: ../src/msw/thread.cpp:932
+msgid "Couldn't get the current thread pointer"
+msgstr "Nu s-a putut obține pointerul pentru firul de execuție curent"
+
+#: ../src/msw/thread.cpp:1333
+msgid ""
+"Thread module initialization failed: impossible to allocate index in thread "
+"local storage"
+msgstr ""
+"Inițializarea modulului pentru fire de execuție a eșuat: indexul nu poate fi "
+"alocat în memoria locală a firului de execuție"
+
+#: ../src/msw/thread.cpp:1345
+msgid ""
+"Thread module initialization failed: cannot store value in thread local "
+"storage"
+msgstr ""
+"Inițializarea modulului pentru fire de execuție a eșuat: valoarea nu poate "
+"fi memorată în memoria locală a firului de execuție"
+
+#: ../src/msw/timer.cpp:133
+msgid "Couldn't create a timer"
+msgstr "Nu a putut fi creat un cronometru"
+
+#: ../src/msw/utils.cpp:372
+msgid "can't find user's HOME, using current directory."
+msgstr ""
+"nu poate fi găsit directorul ACASĂ al utilizatorului, se folosește "
+"directorul curent."
+
+#: ../src/msw/utils.cpp:662
+#, c-format
+msgid "Failed to kill process %d"
+msgstr "A eșuat terminarea forțată a procesului %d"
+
+#: ../src/msw/utils.cpp:986
+#, c-format
+msgid "Failed to load resource \"%s\"."
+msgstr "A eșuat încărcarea resursei \"%s\"."
+
+#: ../src/msw/utils.cpp:993
+#, c-format
+msgid "Failed to lock resource \"%s\"."
+msgstr "A eșuat blocarea resursei \"%s\"."
+
+#. TRANSLATORS: MS Windows build number
+#: ../src/msw/utils.cpp:1209
+#, c-format
+msgid "build %lu"
+msgstr "build %lu"
+
+#: ../src/msw/utils.cpp:1218
+msgid ", 64-bit edition"
+msgstr ", ediție 64-bit"
+
+#: ../src/msw/utilsexc.cpp:224
+msgid "Failed to create an anonymous pipe"
+msgstr "A eșuat crearea unui canal (pipe) anonim"
+
+#: ../src/msw/utilsexc.cpp:697
+msgid "Failed to redirect the child process IO"
+msgstr "A eșuat redirectarea IO ale procesului copil"
+
+#: ../src/msw/utilsexc.cpp:870
+#, c-format
+msgid "Execution of command '%s' failed"
+msgstr "Executarea comenzii '%s' a eșuat"
+
+#: ../src/msw/volume.cpp:337
+msgid "Failed to load mpr.dll."
+msgstr "A eșuat încărcarea mpr.dll."
+
+#: ../src/msw/volume.cpp:506
+#, c-format
+msgid "Cannot read typename from '%s'!"
+msgstr "Nu se poate citi numele tipului din '%s'!"
+
+#: ../src/msw/volume.cpp:615
+#, c-format
+msgid "Cannot load icon from '%s'."
+msgstr "Nu se poate încărca pictograma din '%s'."
+
+#: ../src/msw/webview_edge.cpp:285
+msgid "This program was compiled without support for setting Edge proxy."
+msgstr ""
+"Acest program a fost compilat fară suport pentru setarea de proxy pentru "
+"Edge."
+
+#: ../src/msw/webview_ie.cpp:1010
+msgid "Failed to find web view emulation level in the registry"
+msgstr "Nu a fost găsit nivelul de emulare pentru web view în Registry"
+
+#: ../src/msw/webview_ie.cpp:1019
+msgid "Failed to set web view to modern emulation level"
+msgstr "A eșuat setarea web view-ului la un nivel de emulare modern"
+
+#: ../src/msw/webview_ie.cpp:1027
+msgid "Failed to reset web view to standard emulation level"
+msgstr "A eșuat resetarea web view-ului la un nivel de emulare modern"
+
+#: ../src/msw/webview_ie.cpp:1049
+msgid "Can't run JavaScript script without a valid HTML document"
+msgstr "Nu poate fi rulat un script JavaScript fără un document HTML valid"
+
+#: ../src/msw/webview_ie.cpp:1056
+msgid "Can't get the JavaScript object"
+msgstr "Nu poate fi obținut obiectul JavaScript"
+
+#: ../src/msw/webview_ie.cpp:1070
+msgid "failed to evaluate"
+msgstr "a eșuat evaluarea"
+
+#: ../src/osx/cocoa/filedlg.mm:412
+msgid "File type:"
+msgstr "Tip de fișier:"
+
+#: ../src/osx/cocoa/menu.mm:242
+msgctxt "macOS menu name"
+msgid "Window"
+msgstr "Fereastră"
+
+#: ../src/osx/cocoa/menu.mm:259
+msgctxt "macOS menu name"
+msgid "Help"
+msgstr "Ajutor"
+
+#: ../src/osx/cocoa/menu.mm:298
+msgctxt "macOS menu item"
+msgid "Minimize"
+msgstr "Minimizare"
+
+#: ../src/osx/cocoa/menu.mm:303
+msgctxt "macOS menu item"
+msgid "Zoom"
+msgstr "Redimensionare"
+
+#: ../src/osx/cocoa/menu.mm:309
+msgctxt "macOS menu item"
+msgid "Bring All to Front"
+msgstr "Adu totul în față"
+
+#: ../src/osx/core/sound.cpp:143
+#, c-format
+msgid "Failed to load sound from \"%s\" (error %d)."
+msgstr "A eșuat încărcarea sunetului din \"%s\" (eroarea %d)."
+
+#: ../src/osx/fontutil.cpp:80
+#, c-format
+msgid "Font file \"%s\" doesn't exist."
+msgstr "Fișierul de font \"%s\" nu există."
+
+#: ../src/osx/fontutil.cpp:88
+#, c-format
+msgid ""
+"Font file \"%s\" cannot be used as it is not inside the font directory "
+"\"%s\"."
+msgstr ""
+"Fișierul de font \"%s\" nu poate fi folosit pentru că nu este în directorul "
+"de fonturi \"%s\"."
+
+#: ../src/osx/menu_osx.cpp:496
+#, c-format
+msgctxt "macOS menu item"
+msgid "About %s"
+msgstr "Despre %s"
+
+#: ../src/osx/menu_osx.cpp:499
+msgctxt "macOS menu item"
+msgid "About..."
+msgstr "Despre..."
+
+#: ../src/osx/menu_osx.cpp:508
+msgctxt "macOS menu item"
+msgid "Preferences..."
+msgstr "Preferințe..."
+
+#: ../src/osx/menu_osx.cpp:512
+msgctxt "macOS menu item"
+msgid "Services"
+msgstr "Servicii"
+
+#: ../src/osx/menu_osx.cpp:519
+#, c-format
+msgctxt "macOS menu item"
+msgid "Hide %s"
+msgstr "Ascunde %s"
+
+#: ../src/osx/menu_osx.cpp:522
+msgctxt "macOS menu item"
+msgid "Hide Application"
+msgstr "Ascunde Aplicația"
+
+#: ../src/osx/menu_osx.cpp:526
+msgctxt "macOS menu item"
+msgid "Hide Others"
+msgstr "Ascunde Restul"
+
+#: ../src/osx/menu_osx.cpp:528
+msgctxt "macOS menu item"
+msgid "Show All"
+msgstr "Arată Tot"
+
+#: ../src/osx/menu_osx.cpp:534
+#, c-format
+msgctxt "macOS menu item"
+msgid "Quit %s"
+msgstr "Părăsește %s"
+
+#: ../src/osx/menu_osx.cpp:537
+msgctxt "macOS menu item"
+msgid "Quit Application"
+msgstr "Părăsește Aplicația"
+
+#: ../src/osx/webview_webkit.mm:444
+msgid "Printing is not supported by the system web control"
+msgstr "Tipărirea nu este suportată de controlul web al sistemului"
+
+#: ../src/osx/webview_webkit.mm:453
+msgid "Print operation could not be initialized"
+msgstr "Operațiunea de tipărire nu a putut fi inițializată"
+
+#. TRANSLATORS: Label of font point size
+#: ../src/propgrid/advprops.cpp:605
+msgid "Point Size"
+msgstr "Dimensiune în puncte"
+
+#. TRANSLATORS: Label of font face name
+#: ../src/propgrid/advprops.cpp:615
+msgid "Face Name"
+msgstr "Nume font"
+
+#. TRANSLATORS: Label of font style
+#: ../src/propgrid/advprops.cpp:623 ../src/richtext/richtextformatdlg.cpp:331
+msgid "Style"
+msgstr "Stil"
+
+#. TRANSLATORS: Label of font weight
+#: ../src/propgrid/advprops.cpp:628
+msgid "Weight"
+msgstr "Grosime"
+
+#. TRANSLATORS: Label of underlined font
+#: ../src/propgrid/advprops.cpp:633 ../src/richtext/richtextfontpage.cpp:358
+msgid "Underlined"
+msgstr "Subliniat"
+
+#. TRANSLATORS: Label of font family
+#: ../src/propgrid/advprops.cpp:637
+msgid "Family"
+msgstr "Familie"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:801
+msgid "AppWorkspace"
+msgstr "AppWorkspace"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:802
+msgid "ActiveBorder"
+msgstr "ActiveBorder"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:803
+msgid "ActiveCaption"
+msgstr "ActiveCaption"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:804
+msgid "ButtonFace"
+msgstr "ButtonFace"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:805
+msgid "ButtonHighlight"
+msgstr "ButtonHighlight"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:806
+msgid "ButtonShadow"
+msgstr "ButtonShadow"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:807
+msgid "ButtonText"
+msgstr "ButtonText"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:808
+msgid "CaptionText"
+msgstr "CaptionText"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:809
+msgid "ControlDark"
+msgstr "ControlDark"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:810
+msgid "ControlLight"
+msgstr "ControlLight"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:812
+msgid "GrayText"
+msgstr "GrayText"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:813
+msgid "Highlight"
+msgstr "Evidențiere"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:814
+msgid "HighlightText"
+msgstr "HighlightText"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:815
+msgid "InactiveBorder"
+msgstr "InactiveBorder"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:816
+msgid "InactiveCaption"
+msgstr "InactiveCaption"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:817
+msgid "InactiveCaptionText"
+msgstr "InactiveCaptionText"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:818
+msgid "Menu"
+msgstr "Meniu"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:819
+msgid "Scrollbar"
+msgstr "Scrollbar"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:820
+msgid "Tooltip"
+msgstr "Tooltip"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:821
+msgid "TooltipText"
+msgstr "TooltipText"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:822
+msgid "Window"
+msgstr "Window"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:823
+msgid "WindowFrame"
+msgstr "WindowFrame"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:824
+msgid "WindowText"
+msgstr "WindowText"
+
+#. TRANSLATORS: Custom colour choice entry
+#: ../src/propgrid/advprops.cpp:825 ../src/propgrid/advprops.cpp:1532
+#: ../src/propgrid/advprops.cpp:1576
+msgid "Custom"
+msgstr "Personalizare"
+
+#: ../src/propgrid/advprops.cpp:1558
+msgid "Black"
+msgstr "Negru"
+
+#: ../src/propgrid/advprops.cpp:1559
+msgid "Maroon"
+msgstr "Grena"
+
+#: ../src/propgrid/advprops.cpp:1560
+msgid "Navy"
+msgstr "Bleumarin"
+
+#: ../src/propgrid/advprops.cpp:1561
+msgid "Purple"
+msgstr "Mov"
+
+#: ../src/propgrid/advprops.cpp:1562
+msgid "Teal"
+msgstr "Bej"
+
+#: ../src/propgrid/advprops.cpp:1563
+msgid "Gray"
+msgstr "Gri"
+
+#: ../src/propgrid/advprops.cpp:1564
+msgid "Green"
+msgstr "Verde"
+
+#: ../src/propgrid/advprops.cpp:1565
+msgid "Olive"
+msgstr "Măsliniu"
+
+#: ../src/propgrid/advprops.cpp:1566
+msgid "Brown"
+msgstr "Maro"
+
+#: ../src/propgrid/advprops.cpp:1567
+msgid "Blue"
+msgstr "Albastru"
+
+#: ../src/propgrid/advprops.cpp:1568
+msgid "Fuchsia"
+msgstr "Fuchsia"
+
+#: ../src/propgrid/advprops.cpp:1569
+msgid "Red"
+msgstr "Roșu"
+
+#: ../src/propgrid/advprops.cpp:1570
+msgid "Orange"
+msgstr "Portocaliu"
+
+#: ../src/propgrid/advprops.cpp:1571
+msgid "Silver"
+msgstr "Argintiu"
+
+#: ../src/propgrid/advprops.cpp:1572
+msgid "Lime"
+msgstr "Lime"
+
+#: ../src/propgrid/advprops.cpp:1573
+msgid "Aqua"
+msgstr "Albastru deschis"
+
+#: ../src/propgrid/advprops.cpp:1574
+msgid "Yellow"
+msgstr "Galben"
+
+#: ../src/propgrid/advprops.cpp:1575
+msgid "White"
+msgstr "Alb"
+
+#: ../src/propgrid/advprops.cpp:1718
+msgctxt "system cursor name"
+msgid "Default"
+msgstr "Implicit"
+
+#: ../src/propgrid/advprops.cpp:1719
+msgctxt "system cursor name"
+msgid "Arrow"
+msgstr "Săgeată"
+
+#: ../src/propgrid/advprops.cpp:1720
+msgctxt "system cursor name"
+msgid "Right Arrow"
+msgstr "Săgeată dreapta"
+
+#: ../src/propgrid/advprops.cpp:1721
+msgctxt "system cursor name"
+msgid "Blank"
+msgstr "Gol"
+
+#: ../src/propgrid/advprops.cpp:1722
+msgctxt "system cursor name"
+msgid "Bullseye"
+msgstr "Țintă"
+
+#: ../src/propgrid/advprops.cpp:1723
+msgctxt "system cursor name"
+msgid "Character"
+msgstr "Cursor"
+
+#: ../src/propgrid/advprops.cpp:1724
+msgctxt "system cursor name"
+msgid "Cross"
+msgstr "Cruce"
+
+#: ../src/propgrid/advprops.cpp:1725
+msgctxt "system cursor name"
+msgid "Hand"
+msgstr "Mână"
+
+#: ../src/propgrid/advprops.cpp:1726
+msgctxt "system cursor name"
+msgid "I-Beam"
+msgstr "I-Beam"
+
+#: ../src/propgrid/advprops.cpp:1727
+msgctxt "system cursor name"
+msgid "Left Button"
+msgstr "Buton stânga"
+
+#: ../src/propgrid/advprops.cpp:1728
+msgctxt "system cursor name"
+msgid "Magnifier"
+msgstr "Lupă"
+
+#: ../src/propgrid/advprops.cpp:1729
+msgctxt "system cursor name"
+msgid "Middle Button"
+msgstr "Buton mijloc"
+
+#: ../src/propgrid/advprops.cpp:1730
+msgctxt "system cursor name"
+msgid "No Entry"
+msgstr "Nicio intrare"
+
+#: ../src/propgrid/advprops.cpp:1731
+msgctxt "system cursor name"
+msgid "Paint Brush"
+msgstr "Pensulă"
+
+#: ../src/propgrid/advprops.cpp:1732
+msgctxt "system cursor name"
+msgid "Pencil"
+msgstr "Creion"
+
+#: ../src/propgrid/advprops.cpp:1733
+msgctxt "system cursor name"
+msgid "Point Left"
+msgstr "Punct stânga"
+
+#: ../src/propgrid/advprops.cpp:1734
+msgctxt "system cursor name"
+msgid "Point Right"
+msgstr "Punct dreapta"
+
+#: ../src/propgrid/advprops.cpp:1735
+msgctxt "system cursor name"
+msgid "Question Arrow"
+msgstr "Săgeată cu întrebare"
+
+#: ../src/propgrid/advprops.cpp:1736
+msgctxt "system cursor name"
+msgid "Right Button"
+msgstr "Buton dreapta"
+
+#: ../src/propgrid/advprops.cpp:1737
+msgctxt "system cursor name"
+msgid "Sizing NE-SW"
+msgstr "Redimensionare NE-SV"
+
+#: ../src/propgrid/advprops.cpp:1738
+msgctxt "system cursor name"
+msgid "Sizing N-S"
+msgstr "Redimensionare N-S"
+
+#: ../src/propgrid/advprops.cpp:1739
+msgctxt "system cursor name"
+msgid "Sizing NW-SE"
+msgstr "Redimensionare NV-SE"
+
+#: ../src/propgrid/advprops.cpp:1740
+msgctxt "system cursor name"
+msgid "Sizing W-E"
+msgstr "Redimensionare V-E"
+
+#: ../src/propgrid/advprops.cpp:1741
+msgctxt "system cursor name"
+msgid "Sizing"
+msgstr "Redimensionare"
+
+#: ../src/propgrid/advprops.cpp:1742
+msgctxt "system cursor name"
+msgid "Spraycan"
+msgstr "Tub spray"
+
+#: ../src/propgrid/advprops.cpp:1743
+msgctxt "system cursor name"
+msgid "Wait"
+msgstr "Așteptare"
+
+#: ../src/propgrid/advprops.cpp:1744
+msgctxt "system cursor name"
+msgid "Watch"
+msgstr "Urmărire"
+
+#: ../src/propgrid/advprops.cpp:1745
+msgctxt "system cursor name"
+msgid "Wait Arrow"
+msgstr "Săgeată cu așteptare"
+
+#: ../src/propgrid/advprops.cpp:2109
+msgid "Make a selection:"
+msgstr "Selectează:"
+
+#: ../src/propgrid/manager.cpp:394
+msgid "Property"
+msgstr "Proprietate"
+
+#: ../src/propgrid/manager.cpp:395
+msgid "Value"
+msgstr "Valoare"
+
+#: ../src/propgrid/manager.cpp:1683
+msgid "Categorized Mode"
+msgstr "Mod categorie"
+
+#: ../src/propgrid/manager.cpp:1709
+msgid "Alphabetic Mode"
+msgstr "Mod alfabetic"
+
+#. TRANSLATORS: Name of Boolean false value
+#: ../src/propgrid/propgrid.cpp:230
+msgid "False"
+msgstr "Fals"
+
+#. TRANSLATORS: Name of Boolean true value
+#: ../src/propgrid/propgrid.cpp:232
+msgid "True"
+msgstr "Adevărat"
+
+#. TRANSLATORS: Text  displayed for unspecified value
+#: ../src/propgrid/propgrid.cpp:428
+msgid "Unspecified"
+msgstr "Nespecificat"
+
+#. TRANSLATORS: Caption of message box displaying any property error
+#: ../src/propgrid/propgrid.cpp:3145 ../src/propgrid/propgrid.cpp:3282
+msgid "Property Error"
+msgstr "Proprietate eronată"
+
+#: ../src/propgrid/propgrid.cpp:3259
+msgid "You have entered invalid value. Press ESC to cancel editing."
+msgstr "Ați introdus o valoare invalidă. Apăsati ESC pentru anularea editării."
+
+#: ../src/propgrid/propgrid.cpp:6608
+#, c-format
+msgid "Error in resource: %s"
+msgstr "Eroare în resurse: %s"
+
+#: ../src/propgrid/propgridiface.cpp:377
+#, c-format
+msgid ""
+"Type operation \"%s\" failed: Property labeled \"%s\" is of type \"%s\", NOT "
+"\"%s\"."
+msgstr ""
+"Operația de tipul \"%s\" a eșuat: Proprietatea denumită \"%s\" este de tipul "
+"\"%s\", NU \"%s\"."
+
+#: ../src/propgrid/props.cpp:159
+#, c-format
+msgid "Unknown base %d. Base 10 will be used."
+msgstr "Baza %d necunoscută. Baza 10 va fi folosită."
+
+#: ../src/propgrid/props.cpp:324
+#, c-format
+msgid "Value must be %s or higher."
+msgstr "Valoarea trebuie să fie %s sau mai mare."
+
+#: ../src/propgrid/props.cpp:329 ../src/propgrid/props.cpp:356
+#, c-format
+msgid "Value must be between %s and %s."
+msgstr "Valoarea trebuie să fie între %s și %s."
+
+#: ../src/propgrid/props.cpp:351
+#, c-format
+msgid "Value must be %s or less."
+msgstr "Valoarea trebuie să fie %s sau mai mică."
+
+#: ../src/propgrid/props.cpp:1058
+#, c-format
+msgid "Not %s"
+msgstr "Nu %s"
+
+#: ../src/propgrid/props.cpp:1770
+msgid "Choose a directory:"
+msgstr "Alege un director:"
+
+#: ../src/propgrid/props.cpp:2055
+msgid "Choose a file"
+msgstr "Alege un fișier"
+
+#: ../src/qt/mdi.cpp:254
+msgid "&Tile"
+msgstr "&Titlu"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:147
+#: ../src/richtext/richtextformatdlg.cpp:376
+msgid "Background"
+msgstr "Fundal"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:159
+msgid "Background &colour:"
+msgstr "&Culoare de fundal:"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:161
+#: ../src/richtext/richtextbackgroundpage.cpp:163
+msgid "Enables a background colour."
+msgstr "Activează o culoare de fundal."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:167
+#: ../src/richtext/richtextbackgroundpage.cpp:169
+msgid "The background colour."
+msgstr "Culoarea de fundal."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:178
+msgid "Shadow"
+msgstr "Umbră"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:193
+msgid "Use &shadow"
+msgstr "Folosește &umbră"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:195
+#: ../src/richtext/richtextbackgroundpage.cpp:197
+msgid "Enables a shadow."
+msgstr "Activează o umbră."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:211
+msgid "&Horizontal offset:"
+msgstr "Deplasare &orizontală:"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:218
+#: ../src/richtext/richtextbackgroundpage.cpp:220
+msgid "The horizontal offset."
+msgstr "Deplasarea orizontală."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:224
+#: ../src/richtext/richtextbackgroundpage.cpp:227
+#: ../src/richtext/richtextbackgroundpage.cpp:228
+#: ../src/richtext/richtextbackgroundpage.cpp:247
+#: ../src/richtext/richtextbackgroundpage.cpp:250
+#: ../src/richtext/richtextbackgroundpage.cpp:251
+#: ../src/richtext/richtextbackgroundpage.cpp:287
+#: ../src/richtext/richtextbackgroundpage.cpp:290
+#: ../src/richtext/richtextbackgroundpage.cpp:291
+#: ../src/richtext/richtextbackgroundpage.cpp:314
+#: ../src/richtext/richtextbackgroundpage.cpp:317
+#: ../src/richtext/richtextbackgroundpage.cpp:318
+#: ../src/richtext/richtextborderspage.cpp:252
+#: ../src/richtext/richtextborderspage.cpp:255
+#: ../src/richtext/richtextborderspage.cpp:256
+#: ../src/richtext/richtextborderspage.cpp:286
+#: ../src/richtext/richtextborderspage.cpp:289
+#: ../src/richtext/richtextborderspage.cpp:290
+#: ../src/richtext/richtextborderspage.cpp:320
+#: ../src/richtext/richtextborderspage.cpp:323
+#: ../src/richtext/richtextborderspage.cpp:324
+#: ../src/richtext/richtextborderspage.cpp:354
+#: ../src/richtext/richtextborderspage.cpp:357
+#: ../src/richtext/richtextborderspage.cpp:358
+#: ../src/richtext/richtextborderspage.cpp:420
+#: ../src/richtext/richtextborderspage.cpp:423
+#: ../src/richtext/richtextborderspage.cpp:424
+#: ../src/richtext/richtextborderspage.cpp:454
+#: ../src/richtext/richtextborderspage.cpp:457
+#: ../src/richtext/richtextborderspage.cpp:458
+#: ../src/richtext/richtextborderspage.cpp:488
+#: ../src/richtext/richtextborderspage.cpp:491
+#: ../src/richtext/richtextborderspage.cpp:492
+#: ../src/richtext/richtextborderspage.cpp:522
+#: ../src/richtext/richtextborderspage.cpp:525
+#: ../src/richtext/richtextborderspage.cpp:526
+#: ../src/richtext/richtextborderspage.cpp:590
+#: ../src/richtext/richtextborderspage.cpp:593
+#: ../src/richtext/richtextborderspage.cpp:594
+#: ../src/richtext/richtextfontpage.cpp:177
+#: ../src/richtext/richtextmarginspage.cpp:199
+#: ../src/richtext/richtextmarginspage.cpp:201
+#: ../src/richtext/richtextmarginspage.cpp:202
+#: ../src/richtext/richtextmarginspage.cpp:224
+#: ../src/richtext/richtextmarginspage.cpp:226
+#: ../src/richtext/richtextmarginspage.cpp:227
+#: ../src/richtext/richtextmarginspage.cpp:247
+#: ../src/richtext/richtextmarginspage.cpp:249
+#: ../src/richtext/richtextmarginspage.cpp:250
+#: ../src/richtext/richtextmarginspage.cpp:272
+#: ../src/richtext/richtextmarginspage.cpp:274
+#: ../src/richtext/richtextmarginspage.cpp:275
+#: ../src/richtext/richtextmarginspage.cpp:313
+#: ../src/richtext/richtextmarginspage.cpp:315
+#: ../src/richtext/richtextmarginspage.cpp:316
+#: ../src/richtext/richtextmarginspage.cpp:338
+#: ../src/richtext/richtextmarginspage.cpp:340
+#: ../src/richtext/richtextmarginspage.cpp:341
+#: ../src/richtext/richtextmarginspage.cpp:361
+#: ../src/richtext/richtextmarginspage.cpp:363
+#: ../src/richtext/richtextmarginspage.cpp:364
+#: ../src/richtext/richtextmarginspage.cpp:386
+#: ../src/richtext/richtextmarginspage.cpp:388
+#: ../src/richtext/richtextmarginspage.cpp:389
+#: ../src/richtext/richtextsizepage.cpp:337
+#: ../src/richtext/richtextsizepage.cpp:340
+#: ../src/richtext/richtextsizepage.cpp:341
+#: ../src/richtext/richtextsizepage.cpp:371
+#: ../src/richtext/richtextsizepage.cpp:374
+#: ../src/richtext/richtextsizepage.cpp:375
+#: ../src/richtext/richtextsizepage.cpp:398
+#: ../src/richtext/richtextsizepage.cpp:401
+#: ../src/richtext/richtextsizepage.cpp:402
+#: ../src/richtext/richtextsizepage.cpp:425
+#: ../src/richtext/richtextsizepage.cpp:428
+#: ../src/richtext/richtextsizepage.cpp:429
+#: ../src/richtext/richtextsizepage.cpp:452
+#: ../src/richtext/richtextsizepage.cpp:455
+#: ../src/richtext/richtextsizepage.cpp:456
+#: ../src/richtext/richtextsizepage.cpp:479
+#: ../src/richtext/richtextsizepage.cpp:482
+#: ../src/richtext/richtextsizepage.cpp:483
+#: ../src/richtext/richtextsizepage.cpp:553
+#: ../src/richtext/richtextsizepage.cpp:556
+#: ../src/richtext/richtextsizepage.cpp:557
+#: ../src/richtext/richtextsizepage.cpp:588
+#: ../src/richtext/richtextsizepage.cpp:591
+#: ../src/richtext/richtextsizepage.cpp:592
+#: ../src/richtext/richtextsizepage.cpp:623
+#: ../src/richtext/richtextsizepage.cpp:626
+#: ../src/richtext/richtextsizepage.cpp:627
+#: ../src/richtext/richtextsizepage.cpp:658
+#: ../src/richtext/richtextsizepage.cpp:661
+#: ../src/richtext/richtextsizepage.cpp:662
+msgid "px"
+msgstr "px"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:225
+#: ../src/richtext/richtextbackgroundpage.cpp:248
+#: ../src/richtext/richtextbackgroundpage.cpp:288
+#: ../src/richtext/richtextbackgroundpage.cpp:315
+#: ../src/richtext/richtextborderspage.cpp:253
+#: ../src/richtext/richtextborderspage.cpp:287
+#: ../src/richtext/richtextborderspage.cpp:321
+#: ../src/richtext/richtextborderspage.cpp:355
+#: ../src/richtext/richtextborderspage.cpp:421
+#: ../src/richtext/richtextborderspage.cpp:455
+#: ../src/richtext/richtextborderspage.cpp:489
+#: ../src/richtext/richtextborderspage.cpp:523
+#: ../src/richtext/richtextborderspage.cpp:591
+#: ../src/richtext/richtextmarginspage.cpp:200
+#: ../src/richtext/richtextmarginspage.cpp:225
+#: ../src/richtext/richtextmarginspage.cpp:248
+#: ../src/richtext/richtextmarginspage.cpp:273
+#: ../src/richtext/richtextmarginspage.cpp:314
+#: ../src/richtext/richtextmarginspage.cpp:339
+#: ../src/richtext/richtextmarginspage.cpp:362
+#: ../src/richtext/richtextmarginspage.cpp:387
+#: ../src/richtext/richtextsizepage.cpp:338
+#: ../src/richtext/richtextsizepage.cpp:372
+#: ../src/richtext/richtextsizepage.cpp:399
+#: ../src/richtext/richtextsizepage.cpp:426
+#: ../src/richtext/richtextsizepage.cpp:453
+#: ../src/richtext/richtextsizepage.cpp:480
+#: ../src/richtext/richtextsizepage.cpp:554
+#: ../src/richtext/richtextsizepage.cpp:589
+#: ../src/richtext/richtextsizepage.cpp:624
+#: ../src/richtext/richtextsizepage.cpp:659
+msgid "cm"
+msgstr "cm"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:226
+#: ../src/richtext/richtextbackgroundpage.cpp:249
+#: ../src/richtext/richtextbackgroundpage.cpp:289
+#: ../src/richtext/richtextbackgroundpage.cpp:316
+#: ../src/richtext/richtextborderspage.cpp:254
+#: ../src/richtext/richtextborderspage.cpp:288
+#: ../src/richtext/richtextborderspage.cpp:322
+#: ../src/richtext/richtextborderspage.cpp:356
+#: ../src/richtext/richtextborderspage.cpp:422
+#: ../src/richtext/richtextborderspage.cpp:456
+#: ../src/richtext/richtextborderspage.cpp:490
+#: ../src/richtext/richtextborderspage.cpp:524
+#: ../src/richtext/richtextborderspage.cpp:592
+#: ../src/richtext/richtextfontpage.cpp:176
+#: ../src/richtext/richtextfontpage.cpp:179
+msgid "pt"
+msgstr "pt"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:229
+#: ../src/richtext/richtextbackgroundpage.cpp:231
+#: ../src/richtext/richtextbackgroundpage.cpp:252
+#: ../src/richtext/richtextbackgroundpage.cpp:254
+#: ../src/richtext/richtextbackgroundpage.cpp:292
+#: ../src/richtext/richtextbackgroundpage.cpp:294
+#: ../src/richtext/richtextbackgroundpage.cpp:319
+#: ../src/richtext/richtextbackgroundpage.cpp:321
+msgid "Units for this value."
+msgstr "Unități pentru această valoare."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:234
+msgid "&Vertical offset:"
+msgstr "Deplasare &verticală:"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:241
+#: ../src/richtext/richtextbackgroundpage.cpp:243
+msgid "The vertical offset."
+msgstr "Deplasarea verticală."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:257
+msgid "Shadow c&olour:"
+msgstr "Cul&oare umbră:"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:259
+#: ../src/richtext/richtextbackgroundpage.cpp:261
+msgid "Enables the shadow colour."
+msgstr "Activează culoarea umbrei."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:265
+#: ../src/richtext/richtextbackgroundpage.cpp:267
+msgid "The shadow colour."
+msgstr "Culoarea umbrei."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:270
+msgid "Sh&adow spread:"
+msgstr "Acoperire&a umbrei:"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:272
+#: ../src/richtext/richtextbackgroundpage.cpp:274
+msgid "Enables the shadow spread."
+msgstr "Activează acoperirea umbrei."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:281
+#: ../src/richtext/richtextbackgroundpage.cpp:283
+msgid "The shadow spread."
+msgstr "Acoperirea umbrei."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:297
+msgid "&Blur distance:"
+msgstr "Distanță &neclaritate:"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:299
+#: ../src/richtext/richtextbackgroundpage.cpp:301
+msgid "Enables the blur distance."
+msgstr "Activează distanța de neclaritate."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:308
+#: ../src/richtext/richtextbackgroundpage.cpp:310
+msgid "The shadow blur distance."
+msgstr "Distanța de neclaritate pentru umbră."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:324
+msgid "Opaci&ty:"
+msgstr "Opacita&te:"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:326
+#: ../src/richtext/richtextbackgroundpage.cpp:328
+msgid "Enables the shadow opacity."
+msgstr "Activează opacitatea umbrei."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:335
+#: ../src/richtext/richtextbackgroundpage.cpp:337
+msgid "The shadow opacity."
+msgstr "Opacitatea umbrei."
+
+#. TRANSLATORS: Rich text page units (percentage)
+#: ../src/richtext/richtextbackgroundpage.cpp:340
+#: ../src/richtext/richtextsizepage.cpp:339
+#: ../src/richtext/richtextsizepage.cpp:373
+#: ../src/richtext/richtextsizepage.cpp:400
+#: ../src/richtext/richtextsizepage.cpp:427
+#: ../src/richtext/richtextsizepage.cpp:454
+#: ../src/richtext/richtextsizepage.cpp:481
+#: ../src/richtext/richtextsizepage.cpp:555
+#: ../src/richtext/richtextsizepage.cpp:590
+#: ../src/richtext/richtextsizepage.cpp:625
+#: ../src/richtext/richtextsizepage.cpp:660
+msgid "%"
+msgstr "%"
+
+#: ../src/richtext/richtextborderspage.cpp:229
+#: ../src/richtext/richtextborderspage.cpp:387
+msgid "Border"
+msgstr "Bordură"
+
+#: ../src/richtext/richtextborderspage.cpp:242
+#: ../src/richtext/richtextborderspage.cpp:410
+#: ../src/richtext/richtextindentspage.cpp:194
+#: ../src/richtext/richtextliststylepage.cpp:384
+#: ../src/richtext/richtextmarginspage.cpp:185
+#: ../src/richtext/richtextmarginspage.cpp:299
+#: ../src/richtext/richtextsizepage.cpp:531
+#: ../src/richtext/richtextsizepage.cpp:538
+msgid "&Left:"
+msgstr "&Stânga:"
+
+#: ../src/richtext/richtextborderspage.cpp:257
+#: ../src/richtext/richtextborderspage.cpp:259
+msgid "Units for the left border width."
+msgstr "Unități pentru lățimea bordurii stângi."
+
+#: ../src/richtext/richtextborderspage.cpp:266
+#: ../src/richtext/richtextborderspage.cpp:268
+#: ../src/richtext/richtextborderspage.cpp:300
+#: ../src/richtext/richtextborderspage.cpp:302
+#: ../src/richtext/richtextborderspage.cpp:334
+#: ../src/richtext/richtextborderspage.cpp:336
+#: ../src/richtext/richtextborderspage.cpp:368
+#: ../src/richtext/richtextborderspage.cpp:370
+#: ../src/richtext/richtextborderspage.cpp:434
+#: ../src/richtext/richtextborderspage.cpp:436
+#: ../src/richtext/richtextborderspage.cpp:468
+#: ../src/richtext/richtextborderspage.cpp:470
+#: ../src/richtext/richtextborderspage.cpp:502
+#: ../src/richtext/richtextborderspage.cpp:504
+#: ../src/richtext/richtextborderspage.cpp:536
+#: ../src/richtext/richtextborderspage.cpp:538
+msgid "The border line style."
+msgstr "Stilul liniei de bordură."
+
+#: ../src/richtext/richtextborderspage.cpp:276
+#: ../src/richtext/richtextborderspage.cpp:444
+#: ../src/richtext/richtextindentspage.cpp:212
+#: ../src/richtext/richtextliststylepage.cpp:402
+#: ../src/richtext/richtextmarginspage.cpp:210
+#: ../src/richtext/richtextmarginspage.cpp:324
+#: ../src/richtext/richtextsizepage.cpp:601
+#: ../src/richtext/richtextsizepage.cpp:608
+msgid "&Right:"
+msgstr "&Dreapta:"
+
+#: ../src/richtext/richtextborderspage.cpp:291
+#: ../src/richtext/richtextborderspage.cpp:293
+msgid "Units for the right border width."
+msgstr "Unități pentru lățimea bordurii drepte."
+
+#: ../src/richtext/richtextborderspage.cpp:310
+#: ../src/richtext/richtextborderspage.cpp:478
+#: ../src/richtext/richtextmarginspage.cpp:233
+#: ../src/richtext/richtextmarginspage.cpp:347
+#: ../src/richtext/richtextsizepage.cpp:566
+#: ../src/richtext/richtextsizepage.cpp:573
+msgid "&Top:"
+msgstr "&Superior:"
+
+#: ../src/richtext/richtextborderspage.cpp:325
+#: ../src/richtext/richtextborderspage.cpp:327
+msgid "Units for the top border width."
+msgstr "Unități pentru lățimea bordurii superioare."
+
+#: ../src/richtext/richtextborderspage.cpp:344
+#: ../src/richtext/richtextborderspage.cpp:512
+#: ../src/richtext/richtextmarginspage.cpp:258
+#: ../src/richtext/richtextmarginspage.cpp:372
+#: ../src/richtext/richtextsizepage.cpp:636
+#: ../src/richtext/richtextsizepage.cpp:643
+msgid "&Bottom:"
+msgstr "&Inferior:"
+
+#: ../src/richtext/richtextborderspage.cpp:359
+#: ../src/richtext/richtextborderspage.cpp:361
+msgid "Units for the bottom border width."
+msgstr "Unități pentru lățimea bordurii inferioare."
+
+#: ../src/richtext/richtextborderspage.cpp:380
+#: ../src/richtext/richtextborderspage.cpp:548
+msgid "&Synchronize values"
+msgstr "&Sincronizează valorile"
+
+#: ../src/richtext/richtextborderspage.cpp:382
+#: ../src/richtext/richtextborderspage.cpp:384
+#: ../src/richtext/richtextborderspage.cpp:550
+#: ../src/richtext/richtextborderspage.cpp:552
+msgid "Check to edit all borders simultaneously."
+msgstr "Bifează pentru a edita simultan toate bordurile."
+
+#: ../src/richtext/richtextborderspage.cpp:397
+#: ../src/richtext/richtextborderspage.cpp:555
+msgid "Outline"
+msgstr "Contur"
+
+#: ../src/richtext/richtextborderspage.cpp:425
+#: ../src/richtext/richtextborderspage.cpp:427
+msgid "Units for the left outline width."
+msgstr "Unități pentru lățimea conturului în stânga."
+
+#: ../src/richtext/richtextborderspage.cpp:459
+#: ../src/richtext/richtextborderspage.cpp:461
+msgid "Units for the right outline width."
+msgstr "Unități pentru lățimea conturului în dreapta."
+
+#: ../src/richtext/richtextborderspage.cpp:493
+#: ../src/richtext/richtextborderspage.cpp:495
+msgid "Units for the top outline width."
+msgstr "Unități pentru lățimea conturului superior."
+
+#: ../src/richtext/richtextborderspage.cpp:527
+#: ../src/richtext/richtextborderspage.cpp:529
+msgid "Units for the bottom outline width."
+msgstr "Unități pentru lățimea conturului inferior."
+
+#: ../src/richtext/richtextborderspage.cpp:565
+#: ../src/richtext/richtextborderspage.cpp:600
+msgid "Corner"
+msgstr "Colț"
+
+#: ../src/richtext/richtextborderspage.cpp:574
+msgid "Corner &radius:"
+msgstr "&Raza colțului rotunjit:"
+
+#: ../src/richtext/richtextborderspage.cpp:576
+#: ../src/richtext/richtextborderspage.cpp:578
+msgid "An optional corner radius for adding rounded corners."
+msgstr "Rază optională pentru adăugat colțuri rotunjite."
+
+#: ../src/richtext/richtextborderspage.cpp:584
+#: ../src/richtext/richtextborderspage.cpp:586
+msgid "The value of the corner radius."
+msgstr "Valoarea razei colțului rotunjit."
+
+#: ../src/richtext/richtextborderspage.cpp:595
+#: ../src/richtext/richtextborderspage.cpp:597
+msgid "Units for the corner radius."
+msgstr "Unități pentru raza colțului rotunjit."
+
+#: ../src/richtext/richtextborderspage.cpp:609
+#: ../src/richtext/richtextsizepage.cpp:247
+#: ../src/richtext/richtextsizepage.cpp:251
+msgid "None"
+msgstr "Niciuna"
+
+#: ../src/richtext/richtextborderspage.cpp:610
+msgid "Solid"
+msgstr "Îngroșată"
+
+#: ../src/richtext/richtextborderspage.cpp:611
+msgid "Dotted"
+msgstr "Punctată"
+
+#: ../src/richtext/richtextborderspage.cpp:612
+msgid "Dashed"
+msgstr "Întreruptă"
+
+#: ../src/richtext/richtextborderspage.cpp:613
+msgid "Double"
+msgstr "Dublă"
+
+#: ../src/richtext/richtextborderspage.cpp:614
+msgid "Groove"
+msgstr "Canelată"
+
+#: ../src/richtext/richtextborderspage.cpp:615
+msgid "Ridge"
+msgstr "Crestată"
+
+#: ../src/richtext/richtextborderspage.cpp:616
+msgid "Inset"
+msgstr "Interior"
+
+#: ../src/richtext/richtextborderspage.cpp:617
+msgid "Outset"
+msgstr "Exterior"
+
+#: ../src/richtext/richtextbuffer.cpp:3518
+msgid "Change Style"
+msgstr "Schimbă stilul"
+
+#: ../src/richtext/richtextbuffer.cpp:3701
+msgid "Change Object Style"
+msgstr "Schimbă stilul obiectului"
+
+#: ../src/richtext/richtextbuffer.cpp:3974
+#: ../src/richtext/richtextbuffer.cpp:8174
+msgid "Change Properties"
+msgstr "Schimbă proprietățile"
+
+#: ../src/richtext/richtextbuffer.cpp:4346
+msgid "Change List Style"
+msgstr "Schimbă stilul listei"
+
+#: ../src/richtext/richtextbuffer.cpp:4519
+msgid "Renumber List"
+msgstr "Renumerotează lista"
+
+#: ../src/richtext/richtextbuffer.cpp:7867
+#: ../src/richtext/richtextbuffer.cpp:7897
+#: ../src/richtext/richtextbuffer.cpp:7939
+#: ../src/richtext/richtextctrl.cpp:1279 ../src/richtext/richtextctrl.cpp:1473
+msgid "Insert Text"
+msgstr "Inserează text"
+
+#: ../src/richtext/richtextbuffer.cpp:8023
+#: ../src/richtext/richtextbuffer.cpp:8979
+msgid "Insert Image"
+msgstr "Inserează imagine"
+
+#: ../src/richtext/richtextbuffer.cpp:8070
+msgid "Insert Object"
+msgstr "Inserează obiect"
+
+#: ../src/richtext/richtextbuffer.cpp:8112
+msgid "Insert Field"
+msgstr "Inserează câmp"
+
+#: ../src/richtext/richtextbuffer.cpp:8410
+msgid "Too many EndStyle calls!"
+msgstr "Prea multe apeluri către EndStyle!"
+
+#: ../src/richtext/richtextbuffer.cpp:8785
+msgid "files"
+msgstr "fișiere"
+
+#: ../src/richtext/richtextbuffer.cpp:9380
+msgid "standard/circle"
+msgstr "standard/cerc"
+
+#: ../src/richtext/richtextbuffer.cpp:9381
+msgid "standard/circle-outline"
+msgstr "standard/contur-cerc"
+
+#: ../src/richtext/richtextbuffer.cpp:9382
+msgid "standard/square"
+msgstr "standard/pătrat"
+
+#: ../src/richtext/richtextbuffer.cpp:9383
+msgid "standard/diamond"
+msgstr "standard/romb"
+
+#: ../src/richtext/richtextbuffer.cpp:9384
+msgid "standard/triangle"
+msgstr "standard/triunghi"
+
+#: ../src/richtext/richtextbuffer.cpp:9423
+msgid "Box Properties"
+msgstr "Proprietăți casetă"
+
+#: ../src/richtext/richtextbuffer.cpp:10006
+msgid "Multiple Cell Properties"
+msgstr "Proprietăți pentru celule multiple"
+
+#: ../src/richtext/richtextbuffer.cpp:10008
+msgid "Cell Properties"
+msgstr "Proprietăți pentru celulă"
+
+#: ../src/richtext/richtextbuffer.cpp:11256
+msgid "Set Cell Style"
+msgstr "Aplică stilul pentru celulă"
+
+#: ../src/richtext/richtextbuffer.cpp:11330
+msgid "Delete Row"
+msgstr "Șterge rând"
+
+#: ../src/richtext/richtextbuffer.cpp:11380
+msgid "Delete Column"
+msgstr "Șterge coloană"
+
+#: ../src/richtext/richtextbuffer.cpp:11431
+msgid "Add Row"
+msgstr "Adaugă rând"
+
+#: ../src/richtext/richtextbuffer.cpp:11494
+msgid "Add Column"
+msgstr "Adaugă coloană"
+
+#: ../src/richtext/richtextbuffer.cpp:11537
+msgid "Table Properties"
+msgstr "Proprietăți tabelă"
+
+#: ../src/richtext/richtextbuffer.cpp:12899
+msgid "Picture Properties"
+msgstr "Proprietăți imagine"
+
+#: ../src/richtext/richtextbuffer.cpp:13169
+#: ../src/richtext/richtextbuffer.cpp:13279
+msgid "image"
+msgstr "imagine"
+
+#: ../src/richtext/richtextbulletspage.cpp:145
+#: ../src/richtext/richtextliststylepage.cpp:209
+msgid "&Bullet style:"
+msgstr "Stil &marcator:"
+
+#: ../src/richtext/richtextbulletspage.cpp:150
+#: ../src/richtext/richtextbulletspage.cpp:152
+#: ../src/richtext/richtextliststylepage.cpp:214
+#: ../src/richtext/richtextliststylepage.cpp:216
+msgid "The available bullet styles."
+msgstr "Stilurile de marcatori disponibile."
+
+#: ../src/richtext/richtextbulletspage.cpp:158
+#: ../src/richtext/richtextliststylepage.cpp:221
+msgid "Peri&od"
+msgstr "P&unct"
+
+#: ../src/richtext/richtextbulletspage.cpp:160
+#: ../src/richtext/richtextbulletspage.cpp:162
+#: ../src/richtext/richtextliststylepage.cpp:223
+#: ../src/richtext/richtextliststylepage.cpp:225
+msgid "Check to add a period after the bullet."
+msgstr "Bifează pentru a adăuga punct după marcator."
+
+#. TRANSLATORS: Bullet point in parentheses option
+#: ../src/richtext/richtextbulletspage.cpp:167
+#: ../src/richtext/richtextliststylepage.cpp:230
+msgid "(*)"
+msgstr "(*)"
+
+#: ../src/richtext/richtextbulletspage.cpp:169
+#: ../src/richtext/richtextbulletspage.cpp:171
+#: ../src/richtext/richtextliststylepage.cpp:232
+#: ../src/richtext/richtextliststylepage.cpp:234
+msgid "Check to enclose the bullet in parentheses."
+msgstr "Bifează pentru a încadra marcatorul între paranteze."
+
+#. TRANSLATORS: Right parenthesis bullet point option
+#: ../src/richtext/richtextbulletspage.cpp:176
+#: ../src/richtext/richtextliststylepage.cpp:239
+msgid "*)"
+msgstr "*)"
+
+#: ../src/richtext/richtextbulletspage.cpp:178
+#: ../src/richtext/richtextbulletspage.cpp:180
+#: ../src/richtext/richtextliststylepage.cpp:241
+#: ../src/richtext/richtextliststylepage.cpp:243
+msgid "Check to add a right parenthesis."
+msgstr "Bifează pentru a adăuga paranteză închisă."
+
+#: ../src/richtext/richtextbulletspage.cpp:185
+#: ../src/richtext/richtextliststylepage.cpp:248
+msgid "Bullet &Alignment:"
+msgstr "&Aliniere marcatori:"
+
+#: ../src/richtext/richtextbulletspage.cpp:190
+#: ../src/richtext/richtextliststylepage.cpp:253
+msgid "Centre"
+msgstr "Centru"
+
+#: ../src/richtext/richtextbulletspage.cpp:194
+#: ../src/richtext/richtextbulletspage.cpp:196
+#: ../src/richtext/richtextbulletspage.cpp:217
+#: ../src/richtext/richtextbulletspage.cpp:219
+#: ../src/richtext/richtextliststylepage.cpp:257
+#: ../src/richtext/richtextliststylepage.cpp:259
+#: ../src/richtext/richtextliststylepage.cpp:278
+#: ../src/richtext/richtextliststylepage.cpp:280
+msgid "The bullet character."
+msgstr "Caracterul pentru marcator."
+
+#: ../src/richtext/richtextbulletspage.cpp:212
+#: ../src/richtext/richtextliststylepage.cpp:271
+msgid "&Symbol:"
+msgstr "&Simbol:"
+
+#: ../src/richtext/richtextbulletspage.cpp:222
+#: ../src/richtext/richtextliststylepage.cpp:283
+msgid "Ch&oose..."
+msgstr "&Alege..."
+
+#: ../src/richtext/richtextbulletspage.cpp:223
+#: ../src/richtext/richtextbulletspage.cpp:225
+#: ../src/richtext/richtextliststylepage.cpp:284
+#: ../src/richtext/richtextliststylepage.cpp:286
+msgid "Click to browse for a symbol."
+msgstr "Clic pentru a căuta un simbol."
+
+#: ../src/richtext/richtextbulletspage.cpp:230
+#: ../src/richtext/richtextliststylepage.cpp:291
+msgid "Symbol &font:"
+msgstr "&Font simbol:"
+
+#: ../src/richtext/richtextbulletspage.cpp:235
+#: ../src/richtext/richtextbulletspage.cpp:237
+#: ../src/richtext/richtextliststylepage.cpp:297
+msgid "Available fonts."
+msgstr "Fonturi disponibile."
+
+#: ../src/richtext/richtextbulletspage.cpp:242
+#: ../src/richtext/richtextliststylepage.cpp:302
+msgid "S&tandard bullet name:"
+msgstr "Nume de marcator s&tandard:"
+
+#: ../src/richtext/richtextbulletspage.cpp:247
+#: ../src/richtext/richtextbulletspage.cpp:249
+#: ../src/richtext/richtextliststylepage.cpp:307
+#: ../src/richtext/richtextliststylepage.cpp:309
+msgid "A standard bullet name."
+msgstr "Un nume de marcator standard."
+
+#: ../src/richtext/richtextbulletspage.cpp:254
+msgid "&Number:"
+msgstr "&Număr:"
+
+#: ../src/richtext/richtextbulletspage.cpp:258
+#: ../src/richtext/richtextbulletspage.cpp:260
+msgid "The list item number."
+msgstr "Numărul elementului din listă."
+
+#: ../src/richtext/richtextbulletspage.cpp:266
+#: ../src/richtext/richtextbulletspage.cpp:268
+#: ../src/richtext/richtextliststylepage.cpp:475
+#: ../src/richtext/richtextliststylepage.cpp:477
+msgid "Shows a preview of the bullet settings."
+msgstr "Afișează o previzualizare a setărilor pentru marcatori."
+
+#: ../src/richtext/richtextbulletspage.cpp:276
+#: ../src/richtext/richtextliststylepage.cpp:484
+msgid "(None)"
+msgstr "(Nimic)"
+
+#: ../src/richtext/richtextbulletspage.cpp:277
+#: ../src/richtext/richtextliststylepage.cpp:485
+msgid "Arabic"
+msgstr "Arabă"
+
+#: ../src/richtext/richtextbulletspage.cpp:278
+#: ../src/richtext/richtextliststylepage.cpp:486
+msgid "Upper case letters"
+msgstr "Majuscule"
+
+#: ../src/richtext/richtextbulletspage.cpp:279
+#: ../src/richtext/richtextliststylepage.cpp:487
+msgid "Lower case letters"
+msgstr "Litere mici"
+
+#: ../src/richtext/richtextbulletspage.cpp:280
+#: ../src/richtext/richtextliststylepage.cpp:488
+msgid "Upper case roman numerals"
+msgstr "Numere romane în majuscule"
+
+#: ../src/richtext/richtextbulletspage.cpp:281
+#: ../src/richtext/richtextliststylepage.cpp:489
+msgid "Lower case roman numerals"
+msgstr "Numere romane în litere mici"
+
+#: ../src/richtext/richtextbulletspage.cpp:282
+#: ../src/richtext/richtextliststylepage.cpp:490
+msgid "Numbered outline"
+msgstr "Listare numerotată"
+
+#: ../src/richtext/richtextbulletspage.cpp:283
+#: ../src/richtext/richtextliststylepage.cpp:491
+msgid "Symbol"
+msgstr "Simbol"
+
+#: ../src/richtext/richtextbulletspage.cpp:284
+#: ../src/richtext/richtextliststylepage.cpp:492
+msgid "Bitmap"
+msgstr "Imagine rastru"
+
+#: ../src/richtext/richtextbulletspage.cpp:285
+#: ../src/richtext/richtextliststylepage.cpp:493
+msgid "Standard"
+msgstr "Standard"
+
+#: ../src/richtext/richtextbulletspage.cpp:287
+#: ../src/richtext/richtextliststylepage.cpp:495
+msgid "*"
+msgstr "*"
+
+#: ../src/richtext/richtextbulletspage.cpp:288
+#: ../src/richtext/richtextliststylepage.cpp:496
+msgid "-"
+msgstr "-"
+
+#: ../src/richtext/richtextbulletspage.cpp:289
+#: ../src/richtext/richtextliststylepage.cpp:497
+msgid ">"
+msgstr ">"
+
+#: ../src/richtext/richtextbulletspage.cpp:290
+#: ../src/richtext/richtextliststylepage.cpp:498
+msgid "+"
+msgstr "+"
+
+#: ../src/richtext/richtextbulletspage.cpp:291
+#: ../src/richtext/richtextliststylepage.cpp:499
+msgid "~"
+msgstr "~"
+
+#: ../src/richtext/richtextctrl.cpp:859
+msgid "Drag"
+msgstr "Trage"
+
+#: ../src/richtext/richtextctrl.cpp:1338 ../src/richtext/richtextctrl.cpp:1559
+msgid "Delete Text"
+msgstr "Șterge text"
+
+#: ../src/richtext/richtextctrl.cpp:1537
+msgid "Remove Bullet"
+msgstr "Elimină marcator"
+
+#: ../src/richtext/richtextctrl.cpp:3070
+msgid "The text couldn't be saved."
+msgstr "Textul nu a putut fi salvat."
+
+#: ../src/richtext/richtextctrl.cpp:3644
+msgid "Replace"
+msgstr "Înlocuiește"
+
+#: ../src/richtext/richtextfontpage.cpp:146
+#: ../src/richtext/richtextsymboldlg.cpp:384
+msgid "&Font:"
+msgstr "&Font:"
+
+#: ../src/richtext/richtextfontpage.cpp:150
+#: ../src/richtext/richtextfontpage.cpp:152
+msgid "Type a font name."
+msgstr "Tastați un nume de font."
+
+#: ../src/richtext/richtextfontpage.cpp:158
+msgid "&Size:"
+msgstr "Dimen&siune:"
+
+#: ../src/richtext/richtextfontpage.cpp:165
+#: ../src/richtext/richtextfontpage.cpp:167
+msgid "Type a size in points."
+msgstr "Tastați o dimensiune în puncte."
+
+#: ../src/richtext/richtextfontpage.cpp:180
+#: ../src/richtext/richtextfontpage.cpp:182
+msgid "The font size units, points or pixels."
+msgstr "Unitățile de măsura pentru font, puncte sau pixeli."
+
+#: ../src/richtext/richtextfontpage.cpp:189
+#: ../src/richtext/richtextfontpage.cpp:191
+msgid "Lists the available fonts."
+msgstr "Afișează fonturile disponibile."
+
+#: ../src/richtext/richtextfontpage.cpp:196
+#: ../src/richtext/richtextfontpage.cpp:198
+msgid "Lists font sizes in points."
+msgstr "Afișează dimensiunile fonturilor în puncte."
+
+#: ../src/richtext/richtextfontpage.cpp:207
+msgid "Font st&yle:"
+msgstr "St&il font:"
+
+#: ../src/richtext/richtextfontpage.cpp:212
+#: ../src/richtext/richtextfontpage.cpp:214
+msgid "Select regular or italic style."
+msgstr "Selectează stil normal sau cursiv."
+
+#: ../src/richtext/richtextfontpage.cpp:220
+msgid "Font &weight:"
+msgstr "Îngroșare fon&t:"
+
+#: ../src/richtext/richtextfontpage.cpp:225
+#: ../src/richtext/richtextfontpage.cpp:227
+msgid "Select regular or bold."
+msgstr "Selectează normal sau îngroșat."
+
+#: ../src/richtext/richtextfontpage.cpp:233
+msgid "&Underlining:"
+msgstr "S&ubliniere:"
+
+#: ../src/richtext/richtextfontpage.cpp:238
+#: ../src/richtext/richtextfontpage.cpp:240
+msgid "Select underlining or no underlining."
+msgstr "Selectează subliniat sau nesubliniat."
+
+#: ../src/richtext/richtextfontpage.cpp:248
+msgid "&Colour:"
+msgstr "&Culoare:"
+
+#: ../src/richtext/richtextfontpage.cpp:253
+#: ../src/richtext/richtextfontpage.cpp:255
+msgid "Click to change the text colour."
+msgstr "Clic pentru a schimba culoarea textului."
+
+#: ../src/richtext/richtextfontpage.cpp:261
+msgid "&Bg colour:"
+msgstr "Culoare de &fundal:"
+
+#: ../src/richtext/richtextfontpage.cpp:266
+#: ../src/richtext/richtextfontpage.cpp:268
+msgid "Click to change the text background colour."
+msgstr "Clic pentru a schimba culoarea de fundal a textului."
+
+#: ../src/richtext/richtextfontpage.cpp:276
+#: ../src/richtext/richtextfontpage.cpp:278
+msgid "Check to show a line through the text."
+msgstr "Bifează pentru a tăia textul."
+
+#: ../src/richtext/richtextfontpage.cpp:281
+msgid "Ca&pitals"
+msgstr "&Majuscule"
+
+#: ../src/richtext/richtextfontpage.cpp:283
+#: ../src/richtext/richtextfontpage.cpp:285
+msgid "Check to show the text in capitals."
+msgstr "Bifează pentru a afișa textul cu majuscule."
+
+#: ../src/richtext/richtextfontpage.cpp:288
+msgid "Small C&apitals"
+msgstr "&Majuscule de format mic"
+
+#: ../src/richtext/richtextfontpage.cpp:290
+#: ../src/richtext/richtextfontpage.cpp:292
+msgid "Check to show the text in small capitals."
+msgstr "Bifează pentru a afișa textul cu majuscule de format mic."
+
+#: ../src/richtext/richtextfontpage.cpp:295
+msgid "Supe&rscript"
+msgstr "Indice supe&rior"
+
+#: ../src/richtext/richtextfontpage.cpp:297
+#: ../src/richtext/richtextfontpage.cpp:299
+msgid "Check to show the text in superscript."
+msgstr "Bifează pentru a afișa textul ca indice superior (superscript)."
+
+#: ../src/richtext/richtextfontpage.cpp:302
+msgid "Subscrip&t"
+msgstr "Indice i&nferior"
+
+#: ../src/richtext/richtextfontpage.cpp:304
+#: ../src/richtext/richtextfontpage.cpp:306
+msgid "Check to show the text in subscript."
+msgstr "Bifează pentru a afișa textul ca indice inferior (subscript)."
+
+#: ../src/richtext/richtextfontpage.cpp:312
+msgid "Rig&ht-to-left"
+msgstr "De la &stânga la dreapta"
+
+#: ../src/richtext/richtextfontpage.cpp:314
+#: ../src/richtext/richtextfontpage.cpp:316
+msgid "Check to indicate right-to-left text layout."
+msgstr "Bifează pentru a indica afișarea textului de la stânga la dreapta."
+
+#: ../src/richtext/richtextfontpage.cpp:319
+msgid "Suppress hyphe&nation"
+msgstr "&Suprimă despărțirea în silabe"
+
+#: ../src/richtext/richtextfontpage.cpp:321
+#: ../src/richtext/richtextfontpage.cpp:323
+msgid "Check to suppress hyphenation."
+msgstr "Bifează pentru a suprima despărțirea în silabe."
+
+#: ../src/richtext/richtextfontpage.cpp:329
+#: ../src/richtext/richtextfontpage.cpp:331
+msgid "Shows a preview of the font settings."
+msgstr "Afișează o previzualizare a setărilor pentru font."
+
+#: ../src/richtext/richtextfontpage.cpp:348
+#: ../src/richtext/richtextfontpage.cpp:352
+#: ../src/richtext/richtextfontpage.cpp:356
+#: ../src/richtext/richtextformatdlg.cpp:873
+#: ../src/richtext/richtextindentspage.cpp:273
+#: ../src/richtext/richtextindentspage.cpp:285
+#: ../src/richtext/richtextindentspage.cpp:286
+#: ../src/richtext/richtextindentspage.cpp:310
+#: ../src/richtext/richtextindentspage.cpp:325
+#: ../src/richtext/richtextliststylepage.cpp:451
+#: ../src/richtext/richtextliststylepage.cpp:463
+#: ../src/richtext/richtextliststylepage.cpp:464
+msgid "(none)"
+msgstr "(nimic)"
+
+#: ../src/richtext/richtextfontpage.cpp:349
+#: ../src/richtext/richtextfontpage.cpp:353
+msgid "Regular"
+msgstr "Normal"
+
+#: ../src/richtext/richtextfontpage.cpp:357
+msgid "Not underlined"
+msgstr "Nesubliniat"
+
+#: ../src/richtext/richtextformatdlg.cpp:341
+msgid "Indents && Spacing"
+msgstr "Indentări && Spațieri"
+
+#: ../src/richtext/richtextformatdlg.cpp:346
+msgid "Tabs"
+msgstr "Tabulatori"
+
+#: ../src/richtext/richtextformatdlg.cpp:351
+msgid "Bullets"
+msgstr "Marcatori"
+
+#: ../src/richtext/richtextformatdlg.cpp:356
+msgid "List Style"
+msgstr "Stil de listă"
+
+#: ../src/richtext/richtextformatdlg.cpp:366
+#: ../src/richtext/richtextmarginspage.cpp:170
+msgid "Margins"
+msgstr "Margini"
+
+#: ../src/richtext/richtextformatdlg.cpp:371
+msgid "Borders"
+msgstr "Borduri"
+
+#: ../src/richtext/richtextformatdlg.cpp:765
+msgid "Colour"
+msgstr "Culoare"
+
+#: ../src/richtext/richtextindentspage.cpp:127
+#: ../src/richtext/richtextliststylepage.cpp:322
+msgid "&Alignment"
+msgstr "&Aliniere"
+
+#: ../src/richtext/richtextindentspage.cpp:138
+#: ../src/richtext/richtextliststylepage.cpp:331
+msgid "&Left"
+msgstr "&Stânga"
+
+#: ../src/richtext/richtextindentspage.cpp:140
+#: ../src/richtext/richtextindentspage.cpp:142
+#: ../src/richtext/richtextliststylepage.cpp:333
+#: ../src/richtext/richtextliststylepage.cpp:335
+msgid "Left-align text."
+msgstr "Aliniază text la stânga."
+
+#: ../src/richtext/richtextindentspage.cpp:145
+#: ../src/richtext/richtextliststylepage.cpp:338
+msgid "&Right"
+msgstr "&Dreapta"
+
+#: ../src/richtext/richtextindentspage.cpp:147
+#: ../src/richtext/richtextindentspage.cpp:149
+#: ../src/richtext/richtextliststylepage.cpp:340
+#: ../src/richtext/richtextliststylepage.cpp:342
+msgid "Right-align text."
+msgstr "Aliniază text la dreapta."
+
+#: ../src/richtext/richtextindentspage.cpp:152
+#: ../src/richtext/richtextliststylepage.cpp:345
+msgid "&Justified"
+msgstr "&Aliniat la ambele margini"
+
+#: ../src/richtext/richtextindentspage.cpp:154
+#: ../src/richtext/richtextindentspage.cpp:156
+#: ../src/richtext/richtextliststylepage.cpp:347
+#: ../src/richtext/richtextliststylepage.cpp:349
+msgid "Justify text left and right."
+msgstr "Aliniază text la stânga și la dreapta."
+
+#: ../src/richtext/richtextindentspage.cpp:159
+#: ../src/richtext/richtextliststylepage.cpp:352
+msgid "Cen&tred"
+msgstr "Cen&trat"
+
+#: ../src/richtext/richtextindentspage.cpp:161
+#: ../src/richtext/richtextindentspage.cpp:163
+#: ../src/richtext/richtextliststylepage.cpp:354
+#: ../src/richtext/richtextliststylepage.cpp:356
+msgid "Centre text."
+msgstr "Centrează textul."
+
+#: ../src/richtext/richtextindentspage.cpp:166
+#: ../src/richtext/richtextliststylepage.cpp:359
+msgid "&Indeterminate"
+msgstr "&Nedeterminat"
+
+#: ../src/richtext/richtextindentspage.cpp:168
+#: ../src/richtext/richtextindentspage.cpp:170
+#: ../src/richtext/richtextliststylepage.cpp:361
+#: ../src/richtext/richtextliststylepage.cpp:363
+msgid "Use the current alignment setting."
+msgstr "Folosește setările curente pentru aliniere."
+
+#: ../src/richtext/richtextindentspage.cpp:183
+#: ../src/richtext/richtextliststylepage.cpp:375
+msgid "&Indentation (tenths of a mm)"
+msgstr "&Indentare (zecimi de mm)"
+
+#: ../src/richtext/richtextindentspage.cpp:198
+#: ../src/richtext/richtextindentspage.cpp:200
+#: ../src/richtext/richtextliststylepage.cpp:388
+#: ../src/richtext/richtextliststylepage.cpp:390
+msgid "The left indent."
+msgstr "Indentare stânga."
+
+#: ../src/richtext/richtextindentspage.cpp:203
+#: ../src/richtext/richtextliststylepage.cpp:393
+msgid "Left (&first line):"
+msgstr "Stânga (pri&ma linie):"
+
+#: ../src/richtext/richtextindentspage.cpp:207
+#: ../src/richtext/richtextindentspage.cpp:209
+#: ../src/richtext/richtextliststylepage.cpp:397
+#: ../src/richtext/richtextliststylepage.cpp:399
+msgid "The first line indent."
+msgstr "Indentarea primei linii."
+
+#: ../src/richtext/richtextindentspage.cpp:216
+#: ../src/richtext/richtextindentspage.cpp:218
+#: ../src/richtext/richtextliststylepage.cpp:406
+#: ../src/richtext/richtextliststylepage.cpp:408
+msgid "The right indent."
+msgstr "Indentare dreapta."
+
+#: ../src/richtext/richtextindentspage.cpp:221
+msgid "&Outline level:"
+msgstr "Nivel de &schiță:"
+
+#: ../src/richtext/richtextindentspage.cpp:226
+#: ../src/richtext/richtextindentspage.cpp:228
+msgid "The outline level."
+msgstr "Nivelul de schiță."
+
+#: ../src/richtext/richtextindentspage.cpp:241
+#: ../src/richtext/richtextliststylepage.cpp:420
+msgid "&Spacing (tenths of a mm)"
+msgstr "&Spațiere (zecimi de mm)"
+
+#: ../src/richtext/richtextindentspage.cpp:252
+msgid "&Before a paragraph:"
+msgstr "În&aintea unui paragraf:"
+
+#: ../src/richtext/richtextindentspage.cpp:256
+#: ../src/richtext/richtextindentspage.cpp:258
+#: ../src/richtext/richtextliststylepage.cpp:433
+#: ../src/richtext/richtextliststylepage.cpp:435
+msgid "The spacing before the paragraph."
+msgstr "Spațierea înainte de paragraf."
+
+#: ../src/richtext/richtextindentspage.cpp:261
+msgid "&After a paragraph:"
+msgstr "&După un paragraf:"
+
+#: ../src/richtext/richtextindentspage.cpp:266
+#: ../src/richtext/richtextliststylepage.cpp:442
+#: ../src/richtext/richtextliststylepage.cpp:444
+msgid "The spacing after the paragraph."
+msgstr "Spațierea după paragraf."
+
+#: ../src/richtext/richtextindentspage.cpp:269
+msgid "L&ine spacing:"
+msgstr "&Spațiere linii:"
+
+#: ../src/richtext/richtextindentspage.cpp:274
+#: ../src/richtext/richtextliststylepage.cpp:452
+msgid "Single"
+msgstr "Singur"
+
+#: ../src/richtext/richtextindentspage.cpp:275
+#: ../src/richtext/richtextliststylepage.cpp:453
+msgid "1.1"
+msgstr "1.1"
+
+#: ../src/richtext/richtextindentspage.cpp:276
+#: ../src/richtext/richtextliststylepage.cpp:454
+msgid "1.2"
+msgstr "1.2"
+
+#: ../src/richtext/richtextindentspage.cpp:277
+#: ../src/richtext/richtextliststylepage.cpp:455
+msgid "1.3"
+msgstr "1.3"
+
+#: ../src/richtext/richtextindentspage.cpp:278
+#: ../src/richtext/richtextliststylepage.cpp:456
+msgid "1.4"
+msgstr "1.4"
+
+#: ../src/richtext/richtextindentspage.cpp:279
+#: ../src/richtext/richtextliststylepage.cpp:457
+msgid "1.5"
+msgstr "1.5"
+
+#: ../src/richtext/richtextindentspage.cpp:280
+#: ../src/richtext/richtextliststylepage.cpp:458
+msgid "1.6"
+msgstr "1.6"
+
+#: ../src/richtext/richtextindentspage.cpp:281
+#: ../src/richtext/richtextliststylepage.cpp:459
+msgid "1.7"
+msgstr "1.7"
+
+#: ../src/richtext/richtextindentspage.cpp:282
+#: ../src/richtext/richtextliststylepage.cpp:460
+msgid "1.8"
+msgstr "1.8"
+
+#: ../src/richtext/richtextindentspage.cpp:283
+#: ../src/richtext/richtextliststylepage.cpp:461
+msgid "1.9"
+msgstr "1.9"
+
+#: ../src/richtext/richtextindentspage.cpp:284
+#: ../src/richtext/richtextliststylepage.cpp:462
+msgid "2"
+msgstr "2"
+
+#: ../src/richtext/richtextindentspage.cpp:287
+#: ../src/richtext/richtextindentspage.cpp:289
+#: ../src/richtext/richtextliststylepage.cpp:465
+#: ../src/richtext/richtextliststylepage.cpp:467
+msgid "The line spacing."
+msgstr "Spațierea între linii."
+
+#: ../src/richtext/richtextindentspage.cpp:292
+msgid "&Page Break"
+msgstr "Întrerupere de &pagină"
+
+#: ../src/richtext/richtextindentspage.cpp:294
+#: ../src/richtext/richtextindentspage.cpp:296
+msgid "Inserts a page break before the paragraph."
+msgstr "Inserează o intrerupere de pagină înaintea paragrafului."
+
+#: ../src/richtext/richtextindentspage.cpp:302
+#: ../src/richtext/richtextindentspage.cpp:304
+msgid "Shows a preview of the paragraph settings."
+msgstr "Afișează o previzualizare a setărilor pentru paragraf."
+
+#: ../src/richtext/richtextliststylepage.cpp:182
+msgid "&List level:"
+msgstr "Nivel &listă:"
+
+#: ../src/richtext/richtextliststylepage.cpp:186
+#: ../src/richtext/richtextliststylepage.cpp:188
+msgid "Selects the list level to edit."
+msgstr "Selectează nivelul din listă care să fie modificat."
+
+#: ../src/richtext/richtextliststylepage.cpp:193
+msgid "&Font for Level..."
+msgstr "&Font pentru Nivelul..."
+
+#: ../src/richtext/richtextliststylepage.cpp:194
+#: ../src/richtext/richtextliststylepage.cpp:196
+msgid "Click to choose the font for this level."
+msgstr "Clic pentru a alege fontul pentru acest nivel."
+
+#: ../src/richtext/richtextliststylepage.cpp:312
+msgid "Bullet style"
+msgstr "Stil marcatori"
+
+#: ../src/richtext/richtextliststylepage.cpp:429
+msgid "Before a paragraph:"
+msgstr "Înainte de un paragraf:"
+
+#: ../src/richtext/richtextliststylepage.cpp:438
+msgid "After a paragraph:"
+msgstr "După un paragraf:"
+
+#: ../src/richtext/richtextliststylepage.cpp:447
+msgid "Line spacing:"
+msgstr "Spațiere linii:"
+
+#: ../src/richtext/richtextliststylepage.cpp:470
+msgid "Spacing"
+msgstr "Spațiere"
+
+#: ../src/richtext/richtextmarginspage.cpp:193
+#: ../src/richtext/richtextmarginspage.cpp:195
+msgid "The left margin size."
+msgstr "Dimensiunea marginii stângi."
+
+#: ../src/richtext/richtextmarginspage.cpp:203
+#: ../src/richtext/richtextmarginspage.cpp:205
+msgid "Units for the left margin."
+msgstr "Unități pentru marginea stângă."
+
+#: ../src/richtext/richtextmarginspage.cpp:218
+#: ../src/richtext/richtextmarginspage.cpp:220
+msgid "The right margin size."
+msgstr "Dimensiunea marginii drepte."
+
+#: ../src/richtext/richtextmarginspage.cpp:228
+#: ../src/richtext/richtextmarginspage.cpp:230
+msgid "Units for the right margin."
+msgstr "Unități pentru marginea dreaptă."
+
+#: ../src/richtext/richtextmarginspage.cpp:241
+#: ../src/richtext/richtextmarginspage.cpp:243
+msgid "The top margin size."
+msgstr "Dimensiunea marginii superioare."
+
+#: ../src/richtext/richtextmarginspage.cpp:251
+#: ../src/richtext/richtextmarginspage.cpp:253
+msgid "Units for the top margin."
+msgstr "Unități pentru marginea superioară."
+
+#: ../src/richtext/richtextmarginspage.cpp:266
+#: ../src/richtext/richtextmarginspage.cpp:268
+msgid "The bottom margin size."
+msgstr "Dimensiunea marginii inferioare."
+
+#: ../src/richtext/richtextmarginspage.cpp:276
+#: ../src/richtext/richtextmarginspage.cpp:278
+msgid "Units for the bottom margin."
+msgstr "Unități pentru marginea inferioară."
+
+#: ../src/richtext/richtextmarginspage.cpp:284
+msgid "Padding"
+msgstr "Umplutură"
+
+#: ../src/richtext/richtextmarginspage.cpp:307
+#: ../src/richtext/richtextmarginspage.cpp:309
+msgid "The left padding size."
+msgstr "Dimensiunea umpluturii din stânga."
+
+#: ../src/richtext/richtextmarginspage.cpp:317
+#: ../src/richtext/richtextmarginspage.cpp:319
+msgid "Units for the left padding."
+msgstr "Unități pentru umplutura din stânga."
+
+#: ../src/richtext/richtextmarginspage.cpp:332
+#: ../src/richtext/richtextmarginspage.cpp:334
+msgid "The right padding size."
+msgstr "Dimensiunea umpluturii din dreapta."
+
+#: ../src/richtext/richtextmarginspage.cpp:342
+#: ../src/richtext/richtextmarginspage.cpp:344
+msgid "Units for the right padding."
+msgstr "Unități pentru umplutura din dreapta."
+
+#: ../src/richtext/richtextmarginspage.cpp:355
+#: ../src/richtext/richtextmarginspage.cpp:357
+msgid "The top padding size."
+msgstr "Dimensiunea umpluturii superioare."
+
+#: ../src/richtext/richtextmarginspage.cpp:365
+#: ../src/richtext/richtextmarginspage.cpp:367
+msgid "Units for the top padding."
+msgstr "Unități pentru umplutura superioară."
+
+#: ../src/richtext/richtextmarginspage.cpp:380
+#: ../src/richtext/richtextmarginspage.cpp:382
+msgid "The bottom padding size."
+msgstr "Dimensiunea umpluturii inferioare."
+
+#: ../src/richtext/richtextmarginspage.cpp:390
+#: ../src/richtext/richtextmarginspage.cpp:392
+msgid "Units for the bottom padding."
+msgstr "Unități pentru umplutura inferioară."
+
+#: ../src/richtext/richtextprint.cpp:592
+msgid " Preview"
+msgstr " Previzualizare"
+
+#: ../src/richtext/richtextsizepage.cpp:228
+msgid "Floating"
+msgstr "În mișcare"
+
+#: ../src/richtext/richtextsizepage.cpp:243
+msgid "&Floating mode:"
+msgstr "&Mod mișcare:"
+
+#: ../src/richtext/richtextsizepage.cpp:252
+#: ../src/richtext/richtextsizepage.cpp:254
+msgid "How the object will float relative to the text."
+msgstr "Cum se va mișca obiectul relativ la text."
+
+#: ../src/richtext/richtextsizepage.cpp:265
+msgid "Alignment"
+msgstr "Aliniere"
+
+#: ../src/richtext/richtextsizepage.cpp:277
+msgid "&Vertical alignment:"
+msgstr "Aliniere &verticală:"
+
+#: ../src/richtext/richtextsizepage.cpp:279
+#: ../src/richtext/richtextsizepage.cpp:281
+msgid "Enable vertical alignment."
+msgstr "Activează alinierea verticală."
+
+#: ../src/richtext/richtextsizepage.cpp:286
+msgid "Centred"
+msgstr "Centrat"
+
+#: ../src/richtext/richtextsizepage.cpp:290
+#: ../src/richtext/richtextsizepage.cpp:292
+msgid "Vertical alignment."
+msgstr "Aliniere verticală."
+
+#: ../src/richtext/richtextsizepage.cpp:316
+#: ../src/richtext/richtextsizepage.cpp:323
+msgid "&Width:"
+msgstr "&Lățime:"
+
+#: ../src/richtext/richtextsizepage.cpp:318
+#: ../src/richtext/richtextsizepage.cpp:320
+msgid "Enable the width value."
+msgstr "Activează valoarea pentru lățime."
+
+#: ../src/richtext/richtextsizepage.cpp:331
+#: ../src/richtext/richtextsizepage.cpp:333
+msgid "The object width."
+msgstr "Lățimea obiectului."
+
+#: ../src/richtext/richtextsizepage.cpp:342
+#: ../src/richtext/richtextsizepage.cpp:344
+msgid "Units for the object width."
+msgstr "Unități pentru lățimea obiectului."
+
+#: ../src/richtext/richtextsizepage.cpp:350
+#: ../src/richtext/richtextsizepage.cpp:357
+msgid "&Height:"
+msgstr "Î&nălțime:"
+
+#: ../src/richtext/richtextsizepage.cpp:352
+#: ../src/richtext/richtextsizepage.cpp:354
+#: ../src/richtext/richtextsizepage.cpp:464
+#: ../src/richtext/richtextsizepage.cpp:466
+msgid "Enable the height value."
+msgstr "Activează valoarea pentru înălțime."
+
+#: ../src/richtext/richtextsizepage.cpp:365
+#: ../src/richtext/richtextsizepage.cpp:367
+msgid "The object height."
+msgstr "Înălțimea obiectului."
+
+#: ../src/richtext/richtextsizepage.cpp:376
+#: ../src/richtext/richtextsizepage.cpp:378
+msgid "Units for the object height."
+msgstr "Unități pentru înălțimea obiectului."
+
+#: ../src/richtext/richtextsizepage.cpp:381
+msgid "Min width:"
+msgstr "Lățime minimă:"
+
+#: ../src/richtext/richtextsizepage.cpp:383
+#: ../src/richtext/richtextsizepage.cpp:385
+msgid "Enable the minimum width value."
+msgstr "Activează valoarea minimă pentru lățime."
+
+#: ../src/richtext/richtextsizepage.cpp:392
+#: ../src/richtext/richtextsizepage.cpp:394
+msgid "The object minimum width."
+msgstr "Lățimea minimă a obiectului."
+
+#: ../src/richtext/richtextsizepage.cpp:403
+#: ../src/richtext/richtextsizepage.cpp:405
+msgid "Units for the minimum object width."
+msgstr "Unități pentru lățimea minimă a obiectului."
+
+#: ../src/richtext/richtextsizepage.cpp:408
+msgid "Min height:"
+msgstr "Înălțime minimă:"
+
+#: ../src/richtext/richtextsizepage.cpp:410
+#: ../src/richtext/richtextsizepage.cpp:412
+msgid "Enable the minimum height value."
+msgstr "Activeaza valoarea minimă pentru înălțime."
+
+#: ../src/richtext/richtextsizepage.cpp:419
+#: ../src/richtext/richtextsizepage.cpp:421
+msgid "The object minimum height."
+msgstr "Înălțimea minimă a obiectului."
+
+#: ../src/richtext/richtextsizepage.cpp:430
+#: ../src/richtext/richtextsizepage.cpp:432
+msgid "Units for the minimum object height."
+msgstr "Unități pentru înălțimea minimă a obiectului."
+
+#: ../src/richtext/richtextsizepage.cpp:435
+msgid "Max width:"
+msgstr "Lățime maximă:"
+
+#: ../src/richtext/richtextsizepage.cpp:437
+#: ../src/richtext/richtextsizepage.cpp:439
+msgid "Enable the maximum width value."
+msgstr "Activează valoarea maximă pentru lățime."
+
+#: ../src/richtext/richtextsizepage.cpp:446
+#: ../src/richtext/richtextsizepage.cpp:448
+msgid "The object maximum width."
+msgstr "Lățimea maximă a obiectului."
+
+#: ../src/richtext/richtextsizepage.cpp:457
+#: ../src/richtext/richtextsizepage.cpp:459
+msgid "Units for the maximum object width."
+msgstr "Unități pentru lățimea maximă a obiectului."
+
+#: ../src/richtext/richtextsizepage.cpp:462
+msgid "Max height:"
+msgstr "Înălțime maximă:"
+
+#: ../src/richtext/richtextsizepage.cpp:473
+#: ../src/richtext/richtextsizepage.cpp:475
+msgid "The object maximum height."
+msgstr "Înălțimea maximă a obiectului."
+
+#: ../src/richtext/richtextsizepage.cpp:484
+#: ../src/richtext/richtextsizepage.cpp:486
+msgid "Units for the maximum object height."
+msgstr "Unități pentru înălțimea maximă a obiectului."
+
+#: ../src/richtext/richtextsizepage.cpp:495
+msgid "Position"
+msgstr "Poziție"
+
+#: ../src/richtext/richtextsizepage.cpp:513
+msgid "&Position mode:"
+msgstr "&Mod de poziționare:"
+
+#: ../src/richtext/richtextsizepage.cpp:517
+#: ../src/richtext/richtextsizepage.cpp:522
+msgid "Static"
+msgstr "Statică"
+
+#: ../src/richtext/richtextsizepage.cpp:518
+msgid "Relative"
+msgstr "Relativă"
+
+#: ../src/richtext/richtextsizepage.cpp:519
+msgid "Absolute"
+msgstr "Absolută"
+
+#: ../src/richtext/richtextsizepage.cpp:520
+msgid "Fixed"
+msgstr "Fixă"
+
+#: ../src/richtext/richtextsizepage.cpp:533
+#: ../src/richtext/richtextsizepage.cpp:535
+#: ../src/richtext/richtextsizepage.cpp:547
+#: ../src/richtext/richtextsizepage.cpp:549
+msgid "The left position."
+msgstr "Poziția din stânga."
+
+#: ../src/richtext/richtextsizepage.cpp:558
+#: ../src/richtext/richtextsizepage.cpp:560
+msgid "Units for the left position."
+msgstr "Unitățile pentru poziția din stânga."
+
+#: ../src/richtext/richtextsizepage.cpp:568
+#: ../src/richtext/richtextsizepage.cpp:570
+#: ../src/richtext/richtextsizepage.cpp:582
+#: ../src/richtext/richtextsizepage.cpp:584
+msgid "The top position."
+msgstr "Poziția superioară."
+
+#: ../src/richtext/richtextsizepage.cpp:593
+#: ../src/richtext/richtextsizepage.cpp:595
+msgid "Units for the top position."
+msgstr "Unități pentru poziția superioară."
+
+#: ../src/richtext/richtextsizepage.cpp:603
+#: ../src/richtext/richtextsizepage.cpp:605
+#: ../src/richtext/richtextsizepage.cpp:617
+#: ../src/richtext/richtextsizepage.cpp:619
+msgid "The right position."
+msgstr "Poziția din dreapta."
+
+#: ../src/richtext/richtextsizepage.cpp:628
+#: ../src/richtext/richtextsizepage.cpp:630
+msgid "Units for the right position."
+msgstr "Unități pentru poziția din dreapta."
+
+#: ../src/richtext/richtextsizepage.cpp:638
+#: ../src/richtext/richtextsizepage.cpp:640
+#: ../src/richtext/richtextsizepage.cpp:652
+#: ../src/richtext/richtextsizepage.cpp:654
+msgid "The bottom position."
+msgstr "Poziția inferioară."
+
+#: ../src/richtext/richtextsizepage.cpp:663
+#: ../src/richtext/richtextsizepage.cpp:665
+msgid "Units for the bottom position."
+msgstr "Unitățile pentru poziția inferioară."
+
+#: ../src/richtext/richtextsizepage.cpp:671
+msgid "&Move the object to:"
+msgstr "&Mută obiectul în:"
+
+#: ../src/richtext/richtextsizepage.cpp:674
+msgid "&Previous Paragraph"
+msgstr "&Paragraful anterior"
+
+#: ../src/richtext/richtextsizepage.cpp:675
+#: ../src/richtext/richtextsizepage.cpp:677
+msgid "Moves the object to the previous paragraph."
+msgstr "Mută obiectul în paragraful anterior."
+
+#: ../src/richtext/richtextsizepage.cpp:680
+msgid "&Next Paragraph"
+msgstr "&Paragraful următor"
+
+#: ../src/richtext/richtextsizepage.cpp:681
+#: ../src/richtext/richtextsizepage.cpp:683
+msgid "Moves the object to the next paragraph."
+msgstr "Mută obiectul în următorul paragraf."
+
+#: ../src/richtext/richtextstyledlg.cpp:193
+msgid "&Styles:"
+msgstr "&Stiluri:"
+
+#: ../src/richtext/richtextstyledlg.cpp:197
+#: ../src/richtext/richtextstyledlg.cpp:199
+msgid "The available styles."
+msgstr "Stilurile disponibile."
+
+#: ../src/richtext/richtextstyledlg.cpp:205
+#: ../src/richtext/richtextstyledlg.cpp:217
+msgid " "
+msgstr " "
+
+#: ../src/richtext/richtextstyledlg.cpp:209
+#: ../src/richtext/richtextstyledlg.cpp:211
+msgid "The style preview."
+msgstr "Previzualizarea stilului."
+
+#: ../src/richtext/richtextstyledlg.cpp:220
+msgid "New &Character Style..."
+msgstr "Stil nou de &caractere..."
+
+#: ../src/richtext/richtextstyledlg.cpp:221
+#: ../src/richtext/richtextstyledlg.cpp:223
+msgid "Click to create a new character style."
+msgstr "Clic pentru a crea un nou stil de caracter."
+
+#: ../src/richtext/richtextstyledlg.cpp:226
+msgid "New &Paragraph Style..."
+msgstr "Stil nou de &paragraf..."
+
+#: ../src/richtext/richtextstyledlg.cpp:227
+#: ../src/richtext/richtextstyledlg.cpp:229
+msgid "Click to create a new paragraph style."
+msgstr "Clic pentru a crea un nou stil de paragraf."
+
+#: ../src/richtext/richtextstyledlg.cpp:232
+msgid "New &List Style..."
+msgstr "Stil nou de &listă..."
+
+#: ../src/richtext/richtextstyledlg.cpp:233
+#: ../src/richtext/richtextstyledlg.cpp:235
+msgid "Click to create a new list style."
+msgstr "Clic pentru a crea un nou stil de listă."
+
+#: ../src/richtext/richtextstyledlg.cpp:238
+msgid "New &Box Style..."
+msgstr "Stil nou de &casetă..."
+
+#: ../src/richtext/richtextstyledlg.cpp:239
+#: ../src/richtext/richtextstyledlg.cpp:241
+msgid "Click to create a new box style."
+msgstr "Clic pentru a crea un nou stil de casetă."
+
+#: ../src/richtext/richtextstyledlg.cpp:246
+msgid "&Apply Style"
+msgstr "&Aplică stil"
+
+#: ../src/richtext/richtextstyledlg.cpp:247
+#: ../src/richtext/richtextstyledlg.cpp:249
+msgid "Click to apply the selected style."
+msgstr "Clic pentru a aplica stilul selectat."
+
+#: ../src/richtext/richtextstyledlg.cpp:252
+msgid "&Rename Style..."
+msgstr "&Redenumește stil..."
+
+#: ../src/richtext/richtextstyledlg.cpp:253
+#: ../src/richtext/richtextstyledlg.cpp:255
+msgid "Click to rename the selected style."
+msgstr "Clic pentru a redenumi stilul selectat."
+
+#: ../src/richtext/richtextstyledlg.cpp:258
+msgid "&Edit Style..."
+msgstr "&Editează Stil..."
+
+#: ../src/richtext/richtextstyledlg.cpp:259
+#: ../src/richtext/richtextstyledlg.cpp:261
+msgid "Click to edit the selected style."
+msgstr "Clic pentru a modifica stilul selectat."
+
+#: ../src/richtext/richtextstyledlg.cpp:264
+msgid "&Delete Style..."
+msgstr "Ște&rge Stil..."
+
+#: ../src/richtext/richtextstyledlg.cpp:265
+#: ../src/richtext/richtextstyledlg.cpp:267
+msgid "Click to delete the selected style."
+msgstr "Clic pentru a șterge stilul selectat."
+
+#: ../src/richtext/richtextstyledlg.cpp:274
+#: ../src/richtext/richtextstyledlg.cpp:276
+msgid "Click to close this window."
+msgstr "Clic pentru a închide această fereastră."
+
+#: ../src/richtext/richtextstyledlg.cpp:282
+msgid "&Restart numbering"
+msgstr "&Reîncepe numerotarea"
+
+#: ../src/richtext/richtextstyledlg.cpp:284
+#: ../src/richtext/richtextstyledlg.cpp:286
+msgid "Check to restart numbering."
+msgstr "Bifează pentru a reîncepe numărătoarea."
+
+#: ../src/richtext/richtextstyledlg.cpp:601
+msgid "Enter a character style name"
+msgstr "Introduceți numele unui stil de caractere"
+
+#: ../src/richtext/richtextstyledlg.cpp:601
+#: ../src/richtext/richtextstyledlg.cpp:606
+#: ../src/richtext/richtextstyledlg.cpp:649
+#: ../src/richtext/richtextstyledlg.cpp:654
+#: ../src/richtext/richtextstyledlg.cpp:815
+#: ../src/richtext/richtextstyledlg.cpp:820
+#: ../src/richtext/richtextstyledlg.cpp:888
+#: ../src/richtext/richtextstyledlg.cpp:896
+#: ../src/richtext/richtextstyledlg.cpp:929
+#: ../src/richtext/richtextstyledlg.cpp:934
+msgid "New Style"
+msgstr "Stil nou"
+
+#: ../src/richtext/richtextstyledlg.cpp:606
+#: ../src/richtext/richtextstyledlg.cpp:654
+#: ../src/richtext/richtextstyledlg.cpp:820
+#: ../src/richtext/richtextstyledlg.cpp:896
+#: ../src/richtext/richtextstyledlg.cpp:934
+msgid "Sorry, that name is taken. Please choose another."
+msgstr "Acel nume este luat. Alegeți altul."
+
+#: ../src/richtext/richtextstyledlg.cpp:649
+msgid "Enter a paragraph style name"
+msgstr "Introduceți un nume de stil de paragraf"
+
+#: ../src/richtext/richtextstyledlg.cpp:777
+#, c-format
+msgid "Delete style %s?"
+msgstr "Ștergeți stilul %s?"
+
+#: ../src/richtext/richtextstyledlg.cpp:777
+msgid "Delete Style"
+msgstr "Șterge stil"
+
+#: ../src/richtext/richtextstyledlg.cpp:815
+msgid "Enter a list style name"
+msgstr "Introduceți numele unui stil de listă"
+
+#: ../src/richtext/richtextstyledlg.cpp:888
+msgid "Enter a new style name"
+msgstr "Introduceți un nou nume de stil"
+
+#: ../src/richtext/richtextstyledlg.cpp:929
+msgid "Enter a box style name"
+msgstr "Introduceți un nume de stil pentru casetă"
+
+#: ../src/richtext/richtextstylepage.cpp:109
+#: ../src/richtext/richtextstylepage.cpp:111
+msgid "The style name."
+msgstr "Numele stilului."
+
+#: ../src/richtext/richtextstylepage.cpp:114
+msgid "&Based on:"
+msgstr "&Bazat pe:"
+
+#: ../src/richtext/richtextstylepage.cpp:119
+#: ../src/richtext/richtextstylepage.cpp:121
+msgid "The style on which this style is based."
+msgstr "Stilul de bază pentru acest stil."
+
+#: ../src/richtext/richtextstylepage.cpp:124
+msgid "&Next style:"
+msgstr "Stilul &următor:"
+
+#: ../src/richtext/richtextstylepage.cpp:129
+#: ../src/richtext/richtextstylepage.cpp:131
+msgid "The default style for the next paragraph."
+msgstr "Stilul implicit pentru următorul paragraf."
+
+#: ../src/richtext/richtextstyles.cpp:1057
+msgid "All styles"
+msgstr "Toate stilurile"
+
+#: ../src/richtext/richtextstyles.cpp:1058
+msgid "Paragraph styles"
+msgstr "Stiluri de paragraf"
+
+#: ../src/richtext/richtextstyles.cpp:1059
+msgid "Character styles"
+msgstr "Stiluri de caractere"
+
+#: ../src/richtext/richtextstyles.cpp:1060
+msgid "List styles"
+msgstr "Stiluri de listă"
+
+#: ../src/richtext/richtextstyles.cpp:1061
+msgid "Box styles"
+msgstr "Stiluri casetă"
+
+#: ../src/richtext/richtextsymboldlg.cpp:389
+#: ../src/richtext/richtextsymboldlg.cpp:391
+msgid "The font from which to take the symbol."
+msgstr "Fontul din care se va extrage simbolul."
+
+#: ../src/richtext/richtextsymboldlg.cpp:396
+msgid "&Subset:"
+msgstr "&Subset:"
+
+#: ../src/richtext/richtextsymboldlg.cpp:401
+#: ../src/richtext/richtextsymboldlg.cpp:403
+msgid "Shows a Unicode subset."
+msgstr "Afișează un subset Unicode."
+
+#: ../src/richtext/richtextsymboldlg.cpp:412
+msgid "xxxx"
+msgstr "xxxx"
+
+#: ../src/richtext/richtextsymboldlg.cpp:417
+msgid "&Character code:"
+msgstr "&Cod caracter:"
+
+#: ../src/richtext/richtextsymboldlg.cpp:421
+#: ../src/richtext/richtextsymboldlg.cpp:423
+msgid "The character code."
+msgstr "Codul caracterului."
+
+#: ../src/richtext/richtextsymboldlg.cpp:428
+msgid "&From:"
+msgstr "&De la:"
+
+#: ../src/richtext/richtextsymboldlg.cpp:433
+#: ../src/richtext/richtextsymboldlg.cpp:434
+#: ../src/richtext/richtextsymboldlg.cpp:435
+msgid "Unicode"
+msgstr "Unicode"
+
+#: ../src/richtext/richtextsymboldlg.cpp:436
+#: ../src/richtext/richtextsymboldlg.cpp:438
+msgid "The range to show."
+msgstr "Intervalul de afișat."
+
+#: ../src/richtext/richtextsymboldlg.cpp:444
+msgid "Insert"
+msgstr "Inserează"
+
+#: ../src/richtext/richtextsymboldlg.cpp:478
+msgid "(Normal text)"
+msgstr "(Text normal)"
+
+#: ../src/richtext/richtexttabspage.cpp:109
+msgid "&Position (tenths of a mm):"
+msgstr "&Poziție (zecimi de mm):"
+
+#: ../src/richtext/richtexttabspage.cpp:113
+#: ../src/richtext/richtexttabspage.cpp:115
+msgid "The tab position."
+msgstr "Poziția de indentare."
+
+#: ../src/richtext/richtexttabspage.cpp:119
+msgid "The tab positions."
+msgstr "Pozițiile de indentare."
+
+#: ../src/richtext/richtexttabspage.cpp:132
+#: ../src/richtext/richtexttabspage.cpp:134
+msgid "Click to create a new tab position."
+msgstr "Clic pentru a crea o nouă poziție de indentare."
+
+#: ../src/richtext/richtexttabspage.cpp:138
+#: ../src/richtext/richtexttabspage.cpp:140
+msgid "Click to delete the selected tab position."
+msgstr "Clic pentru a șterge poziția de indentare selectată."
+
+#: ../src/richtext/richtexttabspage.cpp:143
+msgid "Delete A&ll"
+msgstr "Șter&ge tot"
+
+#: ../src/richtext/richtexttabspage.cpp:144
+#: ../src/richtext/richtexttabspage.cpp:146
+msgid "Click to delete all tab positions."
+msgstr "Clic pentru a șterge toate pozițiile de indentare."
+
+#: ../src/univ/theme.cpp:110
+msgid "Failed to initialize GUI: no built-in themes found."
+msgstr ""
+"A eșuat inițializarea interfeței grafice (GUI): nu s-a găsit nicio temă "
+"integrată."
+
+#: ../src/univ/themes/gtk.cpp:521
+msgid "GTK+ theme"
+msgstr "Temă GTK+"
+
+#: ../src/univ/themes/metal.cpp:164
+msgid "Metal theme"
+msgstr "Tema Metal"
+
+#: ../src/univ/themes/mono.cpp:512
+msgid "Simple monochrome theme"
+msgstr "Temă monocromă simplă"
+
+#: ../src/univ/themes/win32.cpp:1098
+msgid "Win32 theme"
+msgstr "Tema Win32"
+
+#: ../src/univ/themes/win32.cpp:3743
+msgid "&Restore"
+msgstr "&Restaurează"
+
+#: ../src/univ/themes/win32.cpp:3744
+msgid "&Move"
+msgstr "&Mută"
+
+#: ../src/univ/themes/win32.cpp:3746
+msgid "&Size"
+msgstr "Dimen&siune"
+
+#: ../src/univ/themes/win32.cpp:3748
+msgid "Mi&nimize"
+msgstr "Mi&nimizează"
+
+#: ../src/univ/themes/win32.cpp:3750
+msgid "Ma&ximize"
+msgstr "Ma&ximizează"
+
+#: ../src/univ/themes/win32.cpp:3752
+msgid "Alt+"
+msgstr "Alt+"
+
+#: ../src/unix/appunix.cpp:178
+msgid "Failed to install signal handler"
+msgstr "A eșuat instalarea operatorului de semnale"
+
+#: ../src/unix/dialup.cpp:351
+msgid "Already dialling ISP."
+msgstr "Deja se apelează ISP-ul."
+
+#: ../src/unix/dlunix.cpp:93
+msgid "Failed to unload shared library"
+msgstr "A eșuat descărcarea bibliotecii partajate"
+
+#: ../src/unix/dlunix.cpp:121
+msgid "Unknown dynamic library error"
+msgstr "Eroare necunoscută de bibliotecă dinamică"
+
+#: ../src/unix/epolldispatcher.cpp:84
+msgid "Failed to create epoll descriptor"
+msgstr "A eșuat crearea descriptorului epoll"
+
+#: ../src/unix/epolldispatcher.cpp:103
+msgid "Error closing epoll descriptor"
+msgstr "Eroare la închiderea descriptorului epoll"
+
+#: ../src/unix/epolldispatcher.cpp:116
+#, c-format
+msgid "Failed to add descriptor %d to epoll descriptor %d"
+msgstr "A eșuat adăugarea descriptorului %d la descriptorul epoll %d"
+
+#: ../src/unix/epolldispatcher.cpp:136
+#, c-format
+msgid "Failed to modify descriptor %d in epoll descriptor %d"
+msgstr "A eșuat modificarea descriptorului %d în descriptorul epoll %d"
+
+#: ../src/unix/epolldispatcher.cpp:155
+#, c-format
+msgid "Failed to unregister descriptor %d from epoll descriptor %d"
+msgstr ""
+"A eșuat înlăturarea înregistrării descriptorului %d din descriptorul epoll %d"
+
+#: ../src/unix/epolldispatcher.cpp:213
+#, c-format
+msgid "Waiting for IO on epoll descriptor %d failed"
+msgstr "Așteptarea pentru IO pe descriptorul epoll %d a eșuat"
+
+#: ../src/unix/fswatcher_inotify.cpp:71
+msgid "Unable to create inotify instance"
+msgstr "Nu se poate crea instanța inotify"
+
+#: ../src/unix/fswatcher_inotify.cpp:94
+msgid "Unable to close inotify instance"
+msgstr "Nu se poate închide instanța inotify"
+
+#: ../src/unix/fswatcher_inotify.cpp:106
+msgid "Unable to add inotify watch"
+msgstr "Monitorul inotify nu poate fi adăugat"
+
+#: ../src/unix/fswatcher_inotify.cpp:138
+#, c-format
+msgid "Unable to remove inotify watch %i"
+msgstr "Monitorul inotify %i nu poate fi eliminat"
+
+#: ../src/unix/fswatcher_inotify.cpp:271
+#, c-format
+msgid "Unexpected event for \"%s\": no matching watch descriptor."
+msgstr ""
+"Eveniment neașteptat pentru \"%s\": nu există descriptor de monitorizare "
+"potrivit."
+
+#: ../src/unix/fswatcher_inotify.cpp:320
+#, c-format
+msgid "Invalid inotify event for \"%s\""
+msgstr "Eveniment inotify invalid pentru \"%s\""
+
+#: ../src/unix/fswatcher_inotify.cpp:553
+msgid "Unable to read from inotify descriptor"
+msgstr "Nu se poate citi din descriptorul inotify"
+
+#: ../src/unix/fswatcher_inotify.cpp:558
+msgid "EOF while reading from inotify descriptor"
+msgstr "EOF în timpul citirii din descriptorul inotify"
+
+#: ../src/unix/fswatcher_kqueue.cpp:114
+msgid "Unable to create kqueue instance"
+msgstr "Nu se poate crea instanță kqueue"
+
+#: ../src/unix/fswatcher_kqueue.cpp:131
+msgid "Error closing kqueue instance"
+msgstr "Eroare la închiderea instanței kqueue"
+
+#: ../src/unix/fswatcher_kqueue.cpp:153
+msgid "Unable to add kqueue watch"
+msgstr "Monitorul kqueue nu poate fi adăugat"
+
+#: ../src/unix/fswatcher_kqueue.cpp:170
+msgid "Unable to remove kqueue watch"
+msgstr "Monitorul kqueue nu poate fi eliminat"
+
+#: ../src/unix/fswatcher_kqueue.cpp:202
+msgid "Unable to get events from kqueue"
+msgstr "Nu se pot obține evenimente din kqueue"
+
+#: ../src/unix/mediactrl.cpp:966
+#, c-format
+msgid "Media playback error: %s"
+msgstr "Eroare de redare media: %s"
+
+#: ../src/unix/mediactrl.cpp:1228
+#, c-format
+msgid "Failed to prepare playing \"%s\"."
+msgstr "A eșuat pregătirea redării \"%s\"."
+
+#: ../src/unix/snglinst.cpp:164
+#, c-format
+msgid "Failed to write to lock file '%s'"
+msgstr "A eșuat scrierea în fișierul de blocaj '%s'"
+
+#: ../src/unix/snglinst.cpp:177
+#, c-format
+msgid "Failed to set permissions on lock file '%s'"
+msgstr "A eșuat setarea permisiunilor pentru fișierul de blocaj '%s'"
+
+#: ../src/unix/snglinst.cpp:194
+#, c-format
+msgid "Failed to lock the lock file '%s'"
+msgstr "A eșuat blocarea fișierului de blocaj '%s'"
+
+#: ../src/unix/snglinst.cpp:237
+#, c-format
+msgid "Failed to inspect the lock file '%s'"
+msgstr "A eșuat inspectarea fișierului de blocaj '%s'"
+
+#: ../src/unix/snglinst.cpp:242
+#, c-format
+msgid "Lock file '%s' has incorrect owner."
+msgstr "Fișierul de blocaj '%s' are proprietar incorect."
+
+#: ../src/unix/snglinst.cpp:247
+#, c-format
+msgid "Lock file '%s' has incorrect permissions."
+msgstr "Fișierul de blocaj '%s' are permisiuni incorecte."
+
+#: ../src/unix/snglinst.cpp:265
+msgid "Failed to access lock file."
+msgstr "A eșuat accesarea fișierului de blocaj."
+
+#: ../src/unix/snglinst.cpp:274
+msgid "Failed to read PID from lock file."
+msgstr "A eșuat citirea PID-ului din fișierul de blocaj."
+
+#: ../src/unix/snglinst.cpp:284
+#, c-format
+msgid "Failed to remove stale lock file '%s'."
+msgstr "A eșuat înlăturarea fișier de blocaj '%s' rămas."
+
+#: ../src/unix/snglinst.cpp:297
+#, c-format
+msgid "Deleted stale lock file '%s'."
+msgstr "Fișier de blocaj '%s' rămas a fost șters."
+
+#: ../src/unix/snglinst.cpp:308
+#, c-format
+msgid "Invalid lock file '%s'."
+msgstr "Fișier de blocaj '%s' invalid."
+
+#: ../src/unix/snglinst.cpp:324
+#, c-format
+msgid "Failed to remove lock file '%s'"
+msgstr "A eșuat înlăturarea fișierului de blocaj '%s'"
+
+#: ../src/unix/snglinst.cpp:330
+#, c-format
+msgid "Failed to unlock lock file '%s'"
+msgstr "A eșuat deblocarea fișierului de blocaj '%s'"
+
+#: ../src/unix/snglinst.cpp:336
+#, c-format
+msgid "Failed to close lock file '%s'"
+msgstr "A eșuat închiderea fișierului de blocaj '%s'"
+
+#: ../src/unix/sound.cpp:77
+msgid "No sound"
+msgstr "Fără sunet"
+
+#: ../src/unix/sound.cpp:364
+msgid "Unable to play sound asynchronously."
+msgstr "Nu se poate reda sunet asincron."
+
+#: ../src/unix/sound.cpp:458
+#, c-format
+msgid "Couldn't load sound data from '%s'."
+msgstr "Nu s-a putut încărca sunetul din '%s'."
+
+#: ../src/unix/sound.cpp:465
+#, c-format
+msgid "Sound file '%s' is in unsupported format."
+msgstr "Fișierul cu sunet '%s' nu este într-un format suportat."
+
+#: ../src/unix/sound.cpp:480
+msgid "Sound data are in unsupported format."
+msgstr "Formatul datelor de sunet nu este suportat."
+
+#: ../src/unix/sound_sdl.cpp:226
+#, c-format
+msgid "Couldn't open audio: %s"
+msgstr "Nu s-a putut deschide fișierul audio: %s"
+
+#: ../src/unix/threadpsx.cpp:1033
+msgid "Cannot retrieve thread scheduling policy."
+msgstr "Nu se poate obține politica de planificare a firului de execuție."
+
+#: ../src/unix/threadpsx.cpp:1058
+#, c-format
+msgid "Cannot get priority range for scheduling policy %d."
+msgstr ""
+"Nu se poate obține intervalul de priorități pentru politica de planificare "
+"%d."
+
+#: ../src/unix/threadpsx.cpp:1066
+msgid "Thread priority setting is ignored."
+msgstr "Prioritatea setată pentru firul de excuție este ignorată."
+
+#: ../src/unix/threadpsx.cpp:1221
+msgid ""
+"Failed to join a thread, potential memory leak detected - please restart the "
+"program"
+msgstr ""
+"A eșuat sincronizarea cu un fir de execuție, posibilă scurgere de memorie "
+"detectată - programul trebuie repornit"
+
+#: ../src/unix/threadpsx.cpp:1352
+#, c-format
+msgid "Failed to set thread concurrency level to %lu"
+msgstr "A eșuat setarea nivelului de concurență la %lu"
+
+#: ../src/unix/threadpsx.cpp:1481
+#, c-format
+msgid "Failed to set thread priority %d."
+msgstr "A eșuat setarea priorității %d pentru firul de execuție."
+
+#: ../src/unix/threadpsx.cpp:1666
+msgid "Failed to terminate a thread."
+msgstr "A eșuat terminarea unui fir de execuție."
+
+#: ../src/unix/threadpsx.cpp:1893
+msgid "Thread module initialization failed: failed to create thread key"
+msgstr ""
+"Inițializarea modulului pentru fire de execuție a eșuat: cheia pentru firul "
+"de execuție nu a putut fi creată"
+
+#: ../src/unix/utilsunx.cpp:340
+msgid "Impossible to get child process input"
+msgstr "Sunt imposibil de obținut intrările procesului copil"
+
+#: ../src/unix/utilsunx.cpp:390
+msgid "Can't write to child process's stdin"
+msgstr "Nu se poate scrie la stdin-ul procesului copil"
+
+#: ../src/unix/utilsunx.cpp:644
+#, c-format
+msgid "Failed to execute '%s'\n"
+msgstr "A eșuat executarea '%s'\n"
+
+#: ../src/unix/utilsunx.cpp:678
+msgid "Fork failed"
+msgstr "Fork a eșuat"
+
+#: ../src/unix/utilsunx.cpp:701
+msgid "Failed to set process priority"
+msgstr "A eșuat setarea priorității procesului"
+
+#: ../src/unix/utilsunx.cpp:712
+msgid "Failed to redirect child process input/output"
+msgstr "A eșuat redirectarea intrărilor/ieșirilor pentru procesul copil"
+
+#: ../src/unix/utilsunx.cpp:816
+msgid "Failed to set up non-blocking pipe, the program might hang."
+msgstr ""
+"A eșuat setarea unui canal (pipe) non-blocant, programul poate rămâne "
+"suspendat."
+
+#: ../src/unix/utilsunx.cpp:1023
+msgid "Cannot get the hostname"
+msgstr "Nu se poate obține numele mașinii gazdă"
+
+#: ../src/unix/utilsunx.cpp:1059
+msgid "Cannot get the official hostname"
+msgstr "Nu se poate obține numele oficial al mașinii gazdă"
+
+#: ../src/unix/wakeuppipe.cpp:49
+msgid "Failed to create wake up pipe used by event loop."
+msgstr ""
+"A eșuat crearea canalului de răspuns (wake up pipe) folosit de bucla de "
+"evenimente."
+
+#: ../src/unix/wakeuppipe.cpp:56
+msgid "Failed to switch wake up pipe to non-blocking mode"
+msgstr ""
+"A eșuat trecerea canalului de răspuns (wake up pipe) în mod non-blocant"
+
+#: ../src/unix/wakeuppipe.cpp:117
+msgid "Failed to read from wake-up pipe"
+msgstr "A eșuat citirea din canalul de răspuns (wake-up pipe)"
+
+#: ../src/x11/app.cpp:124
+#, c-format
+msgid "Invalid geometry specification '%s'"
+msgstr "Specificația de geometrie '%s' este invalidă"
+
+#: ../src/x11/app.cpp:167
+msgid "wxWidgets could not open display. Exiting."
+msgstr "wxWidgets nu a putut deschide ecranul. Se închide."
+
+#: ../src/x11/utils.cpp:169
+#, c-format
+msgid "Failed to close the display \"%s\""
+msgstr "A eșuat închiderea ecranului \"%s\""
+
+#: ../src/x11/utils.cpp:188
+#, c-format
+msgid "Failed to open display \"%s\"."
+msgstr "A eșuat deschiderea ecranului \"%s\"."
+
+#: ../src/xml/xml.cpp:868
+#, c-format
+msgid "XML parsing error: '%s' at line %d"
+msgstr "Eroare la traversarea XML: '%s' la linia %d"
+
+#: ../src/xrc/xh_propgrid.cpp:239
+#, c-format
+msgid "Page %i"
+msgstr "Pagina %i"
+
+#: ../src/xrc/xmlres.cpp:448
+#, c-format
+msgid "Cannot load resources from '%s'."
+msgstr "Nu se pot încărca resursele din '%s'."
+
+#: ../src/xrc/xmlres.cpp:799
+#, c-format
+msgid "Cannot open resources file '%s'."
+msgstr "Nu se poatet deschide fișierul resursă '%s'."
+
+#: ../src/xrc/xmlres.cpp:806
+#, c-format
+msgid "Cannot load resources from file '%s'."
+msgstr "Nu se pot încărca resursele din fișierul '%s'."
+
+#: ../src/xrc/xmlres.cpp:2767
+#, c-format
+msgid "Creating %s \"%s\" failed."
+msgstr "Crearea %s \"%s\" a eșuat."
+
+#, c-format
+#~ msgid "BMP: header has biClrUsed=%d when biBitCount=%d."
+#~ msgstr "BMP: antetul are biClrUsed=%d când biBitCount=%d."
+
+#~ msgctxt "keyboard key"
+#~ msgid "Alt+"
+#~ msgstr "Alt+"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Ctrl+"
+#~ msgstr "Ctrl+"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Shift+"
+#~ msgstr "Shift+"
+
+#~ msgctxt "keyboard key"
+#~ msgid "RawCtrl+"
+#~ msgstr "RawCtrl+"
+
+#~ msgid "Copying more than one selected block to clipboard is not supported."
+#~ msgstr ""
+#~ "Copierea în clipboard a mai multor blocuri selectate nu este suportată."
+
+#~ msgid "Unsupported clipboard format."
+#~ msgstr "Format de clipboard nesuportat."
+
+#~ msgid "Background colour"
+#~ msgstr "Culoare de fundal"
+
+#~ msgid "Font:"
+#~ msgstr "Font:"
+
+#~ msgid "Size:"
+#~ msgstr "Dimensiune:"
+
+#~ msgid "The font size in points."
+#~ msgstr "Dimensiunea fontului în puncte."
+
+#~ msgid "Style:"
+#~ msgstr "Stil:"
+
+#~ msgid "Check to make the font bold."
+#~ msgstr "Bifează pentru a îngroșa fontul."
+
+#~ msgid "Check to make the font italic."
+#~ msgstr "Bifează pentru a face fontul cursiv."
+
+#~ msgid "Check to make the font underlined."
+#~ msgstr "Bifează pentru a face fontul subliniat."
+
+#~ msgid "Colour:"
+#~ msgstr "Culoare:"
+
+#~ msgid "Click to change the font colour."
+#~ msgstr "Clic pentru a schimba culoarea fontului."
+
+#~ msgid "Shows a preview of the font."
+#~ msgstr "Afișează o previzualizare a fontului."
+
+#~ msgid "Click to cancel changes to the font."
+#~ msgstr "Clic pentru a anula modificările aduse fontului."
+
+#~ msgid "Click to confirm changes to the font."
+#~ msgstr "Clic pentru a confirma modificările aduse fontului."
+
+#~ msgid "<Any>"
+#~ msgstr "<Oricare>"
+
+#~ msgid "<Any Roman>"
+#~ msgstr "<Oricare Roman>"
+
+#~ msgid "<Any Decorative>"
+#~ msgstr "<Oricare Decorativ>"
+
+#~ msgid "<Any Modern>"
+#~ msgstr "<Oricare Modern>"
+
+#~ msgid "<Any Script>"
+#~ msgstr "<Oricare Script>"
+
+#~ msgid "<Any Swiss>"
+#~ msgstr "<Oricare Swiss>"
+
+#~ msgid "<Any Teletype>"
+#~ msgstr "<Oricare Teletype>"
+
+#~ msgid "Printing "
+#~ msgstr "Tipărire "
+
+#~ msgid "Failed to insert text in the control."
+#~ msgstr "A eșuat inserarea textului în control."
+
+#~ msgid "Please choose a valid font."
+#~ msgstr "Alegeți un font valid."
+
+#, c-format
+#~ msgid "Failed to display HTML document in %s encoding"
+#~ msgstr "A eșuat afișarea documentului HTML în codificarea %s"
+
+#, c-format
+#~ msgid "wxWidgets could not open display for '%s': exiting."
+#~ msgstr "wxWidgets nu a putut deschide ecranul pentru '%s': se închide."
+
+#~ msgid "Filter"
+#~ msgstr "Filtru"
+
+#~ msgid "Directories"
+#~ msgstr "Directoare"
+
+#~ msgid "Files"
+#~ msgstr "Fișiere"
+
+#~ msgid "Selection"
+#~ msgstr "Selecție"
+
+#~ msgid "conversion to 8-bit encoding failed"
+#~ msgstr "conversia la codificare pe 8 biți a eșuat"
+
+#~ msgid "failed to retrieve execution result"
+#~ msgstr "a eșuat obținerea rezultatului execuției"
+
+#~ msgid "&Save as"
+#~ msgstr "&Salvează ca"
+
+#~ msgid "'%s' doesn't consist only of valid characters"
+#~ msgstr "'%s' nu conține numai caractere valide"
+
+#~ msgid "'%s' should be numeric."
+#~ msgstr "'%s' ar trebui să fie număr."
+
+#~ msgid "'%s' should only contain ASCII characters."
+#~ msgstr "'%s' ar trebui să conțină doar caractere ASCII."
+
+#~ msgid "'%s' should only contain alphabetic characters."
+#~ msgstr "'%s' ar trebui să conțină doar caractere alfabetice."
+
+#~ msgid "'%s' should only contain alphabetic or numeric characters."
+#~ msgstr "'%s' ar trebui să conțină doar caractere alfabetice sau numerice."
+
+#~ msgid "'%s' should only contain digits."
+#~ msgstr "'%s' ar trebui să conțină doar cifre."
+
+#~ msgid "Can't create window of class %s"
+#~ msgstr "Nu se poate crea fereastra de clasa %s"
+
+#~ msgid "Couldn't create the overlay window"
+#~ msgstr "Nu a putut fi creată fereastra de acoperire (overlay)"
+
+#~ msgid "Couldn't init the context on the overlay window"
+#~ msgstr ""
+#~ "Nu a putut fi inițializat contextul ferestrei de acoperire (overlay)"
+
+#~ msgid "Failed to convert file \"%s\" to Unicode."
+#~ msgstr "A eșuat conversia fișierului \"%s\" la Unicode."
+
+#~ msgid "Failed to set text in the text control."
+#~ msgstr "A eșuat setarea textului în controlul de text."
+
+#~ msgid "Invalid GTK+ command line option, use \"%s --help\""
+#~ msgstr ""
+#~ "Opțiune invalidă pentru linia de comandă GTK+, folosește \"%s --help\""
+
+#~ msgid "No unused colour in image."
+#~ msgstr "Nu există culoare nefolosită în imagine."
+
+#~ msgid "Not available"
+#~ msgstr "Indisponibil"
+
+#~ msgid "Replace selection"
+#~ msgstr "Înlocuiește selecția"
+
+#~ msgid "Save as"
+#~ msgstr "Salvează ca"
+
+#~ msgid "Style Organiser"
+#~ msgstr "Organizator de stiluri"
+
+#~ msgid "The following standard GTK+ options are also supported:\n"
+#~ msgstr "Următoarele opțiuni GTK+ standard sunt de asemenea suportate:\n"
+
+#~ msgid "You cannot Clear an overlay that is not inited"
+#~ msgstr ""
+#~ "Nu se poate curăța o suprafață de acoperire (overlay) care nu a fost "
+#~ "inițializată"
+
+#~ msgid "You cannot Init an overlay twice"
+#~ msgstr ""
+#~ "O suprafață de acoperire (overlay) nu se poate inițializa de două ori"
+
+#~ msgid "locale '%s' cannot be set."
+#~ msgstr "locala '%s' nu poate fi setată."
+
+#~ msgid "Adding flavor TEXT failed"
+#~ msgstr "Adăugarea de TEXT a eșuat"
+
+#~ msgid "Adding flavor utxt failed"
+#~ msgstr "Adăugarea de utxt a eșuat"
+
+#~ msgid "Bitmap renderer cannot render value; value type: "
+#~ msgstr ""
+#~ "Interpretorul pentru Bitmap nu poate interpreta valoarea; tipul valorii: "
+
+#~ msgid ""
+#~ "Cannot create new column's ID. Probably max. number of columns reached."
+#~ msgstr ""
+#~ "Nu se poate crea ID-ul coloanei noi. Probabil a fost atins numărul maxim "
+#~ "de coloane."
+
+#~ msgid "Column could not be added."
+#~ msgstr "Coloana nu a putut fi adăugată."
+
+#~ msgid "Column index not found."
+#~ msgstr "Indexul coloanei nu a fost găsit."
+
+#~ msgid "Column width could not be determined"
+#~ msgstr "Lățimea coloanei nu a putut fi determinată"
+
+#~ msgid "Column width could not be set."
+#~ msgstr "Lățimea coloanei nu a putut fi setată."
+
+#~ msgid "Confirm registry update"
+#~ msgstr "Confirmă modificările regiștrilor"
+
+#~ msgid "Could not determine column index."
+#~ msgstr "Nu s-a putut determina index-ul coloanei."
+
+#~ msgid "Could not determine column's position"
+#~ msgstr "Nu s-a putut determina poziția coloanei"
+
+#~ msgid "Could not determine number of columns."
+#~ msgstr "Nu s-a putut determina numărul de coloane."
+
+#~ msgid "Could not determine number of items"
+#~ msgstr "Nu s-a putut determina numărul de elemente"
+
+#~ msgid "Could not get header description."
+#~ msgstr "Nu s-a putut obține descrierea antetului."
+
+#~ msgid "Could not get items."
+#~ msgstr "Nu s-au putut obține elemente."
+
+#~ msgid "Could not get property flags."
+#~ msgstr "Nu s-au putut obține însemnele de proprietăți."
+
+#~ msgid "Could not get selected items."
+#~ msgstr "Nu s-au putut obține elementele selectate."
+
+#~ msgid "Could not remove column."
+#~ msgstr "Nu a putut fi eliminată coloana."
+
+#~ msgid "Could not retrieve number of items"
+#~ msgstr "Nu a putut fi obținut numărul de elemente"
+
+#~ msgid "Could not set column width."
+#~ msgstr "Nu a putut fi setată lățimea coloanei."
+
+#~ msgid "Could not set header description."
+#~ msgstr "Nu a putut fi setată descrierea antetului."
+
+#~ msgid "Could not set icon."
+#~ msgstr "Nu a putut fi setată pictograma."
+
+#~ msgid "Could not set maximum width."
+#~ msgstr "Nu a putut fi setată lățimea maximă."
+
+#~ msgid "Could not set minimum width."
+#~ msgstr "Nu a putut fi setată lățimea minimă."
+
+#~ msgid "Could not set property flags."
+#~ msgstr "Nu au putut fi setate însemnele de proprietăți."
+
+#~ msgid "Data object has invalid data format"
+#~ msgstr "Obiectul are un format de date invalid"
+
+#~ msgid "Date renderer cannot render value; value type: "
+#~ msgstr "Renderer-ul de date nu poate reda valoarea; tipul valorii: "
+
+#~ msgid ""
+#~ "Do you want to overwrite the command used to %s files with extension "
+#~ "\"%s\" ?\n"
+#~ "Current value is \n"
+#~ "%s, \n"
+#~ "New value is \n"
+#~ "%s %1"
+#~ msgstr ""
+#~ "Vreți să suprascrieți comanda folosită la fișierele %s cu extensia "
+#~ "\"%s\" ?\n"
+#~ "Valoarea curentă este \n"
+#~ "%s, \n"
+#~ "Valoarea nouă este \n"
+#~ "%s %1"
+
+#~ msgid "Failed to retrieve data from the clipboard."
+#~ msgstr "A eșuat obținerea datelor din memoria clipboard."
+
+#~ msgid "GIF: Invalid gif index."
+#~ msgstr "GIF: Index gif invalid."
+
+#~ msgid "GIF: unknown error!!!"
+#~ msgstr "GIF: eroare necunoscută!!!"
+
+#~ msgid "Icon & text renderer cannot render value; value type: "
+#~ msgstr ""
+#~ "Renderer-ul de pictograme & text nu poate reda valoarea; tipul valorii: "
+
+#~ msgid "New directory"
+#~ msgstr "Director nou"
+
+#~ msgid "Next"
+#~ msgstr "Următorul"
+
+#~ msgid "No column existing."
+#~ msgstr "Nici o coloană existentă."
+
+#~ msgid "No column for the specified column existing."
+#~ msgstr "Nu există coloană pentru coloana specificată."
+
+#~ msgid "No column for the specified column position existing."
+#~ msgstr "Nu există coloană pentru poziția de coloană specificată."
+
+#~ msgid ""
+#~ "No renderer or invalid renderer type specified for custom data column."
+#~ msgstr ""
+#~ "Renderer nespecificat sau tip invalid de renderer specificat pentru "
+#~ "coloana de date personalizată."
+
+#~ msgid "No renderer specified for column."
+#~ msgstr "Niciun renderer specificat pentru coloană."
+
+#~ msgid "Number of columns could not be determined."
+#~ msgstr "Numarul de coloane nu a putut fi determinat."
+
+#~ msgid "OpenGL function \"%s\" failed: %s (error %d)"
+#~ msgstr "Funcția OpenGL \"%s\" a eșuat: %s (eroare %d)"
+
+#~ msgid ""
+#~ "Please install a newer version of comctl32.dll\n"
+#~ "(at least version 4.70 is required but you have %d.%02d)\n"
+#~ "or this program won't operate correctly."
+#~ msgstr ""
+#~ "Instalați o versiune mai nouă a comctl32.dll\n"
+#~ "(este necesară minim versiunea 4.70, dar aveți %d.%02d)\n"
+#~ "sau acest program nu va funcționa corect."
+
+#~ msgid "Pointer to data view control not set correctly."
+#~ msgstr ""
+#~ "Pointerul către controlul de vizualizare a datelor nu este setat corect."
+
+#~ msgid "Pointer to model not set correctly."
+#~ msgstr "Pointerul către model nu este setat corect."
+
+#~ msgid "Progress renderer cannot render value type; value type: "
+#~ msgstr ""
+#~ "Renderul de progres nu poate reda tipul de valoare; tipul de valoare: "
+
+#~ msgid "Rendering failed."
+#~ msgstr "Redarea a eșuat."
+
+#~ msgid ""
+#~ "Setting directory access times is not supported under this OS version"
+#~ msgstr ""
+#~ "Setarea timpilor de acces pentru directoare nu este suportată de această "
+#~ "versiune de OS"
+
+#~ msgid "Show hidden directories"
+#~ msgstr "Afișează directoare ascunse"
+
+#~ msgid "Text renderer cannot render value; value type: "
+#~ msgstr "Renderer-ul de text nu poate reda valoarea; tipul valorii: "
+
+#~ msgid "There is no column or renderer for the specified column index."
+#~ msgstr ""
+#~ "Nu este nicio coloană sau renderer pentru indexul de coloană specificat."
+
+#~ msgid ""
+#~ "This system doesn't support date controls, please upgrade your version of "
+#~ "comctl32.dll"
+#~ msgstr ""
+#~ "Acest sistem nu suportă controale de tip dată, trebuie să actualizați "
+#~ "comctl32.dll la o versiune mai nouă"
+
+#~ msgid "Toggle renderer cannot render value; value type: "
+#~ msgstr "Renderer-ul de comutare nu poate reda valoarea; tipul valorii: "
+
+#~ msgid "Too many colours in PNG, the image may be slightly blurred."
+#~ msgstr "Prea multe culori in PNG, imaginea poate fi ușor neclară."
+
+#~ msgid "Unable to handle native drag&drop data"
+#~ msgstr "Nu se poate lucra cu date drag&drop native"
+
+#~ msgid "Unable to initialize Hildon program"
+#~ msgstr "Nu se poate inițializa programul Hildon"
+
+#~ msgid "Unknown data format"
+#~ msgstr "Format de date necunoscut"
+
+#~ msgid "Valid pointer to native data view control does not exist"
+#~ msgstr ""
+#~ "Nu există un pointer valid către un control nativ de vizualizare date"
+
+#~ msgid "Win32s on Windows 3.1"
+#~ msgstr "Win32 pe Windows 3.1"
+
+#, fuzzy
+#~ msgid "Windows 10"
+#~ msgstr "Windows 8.1"
+
+#~ msgid "Windows 2000"
+#~ msgstr "Windows 2000"
+
+#~ msgid "Windows 7"
+#~ msgstr "Windows 7"
+
+#~ msgid "Windows 8"
+#~ msgstr "Windows 8"
+
+#~ msgid "Windows 8.1"
+#~ msgstr "Windows 8.1"
+
+#~ msgid "Windows 95"
+#~ msgstr "Windows 95"
+
+#~ msgid "Windows 95 OSR2"
+#~ msgstr "Windows 95 OSR2"
+
+#~ msgid "Windows 98"
+#~ msgstr "Windows 98"
+
+#~ msgid "Windows 98 SE"
+#~ msgstr "Windows 98 SE"
+
+#~ msgid "Windows 9x (%d.%d)"
+#~ msgstr "Windows 9x (%d.%d)"
+
+#~ msgid "Windows CE (%d.%d)"
+#~ msgstr "Windows CE (%d.%d)"
+
+#~ msgid "Windows ME"
+#~ msgstr "Windows ME"
+
+#~ msgid "Windows NT %lu.%lu"
+#~ msgstr "Windows NT %lu.%lu"
+
+#, fuzzy
+#~ msgid "Windows Server 10"
+#~ msgstr "Windows Server 2003"
+
+#~ msgid "Windows Server 2003"
+#~ msgstr "Windows Server 2003"
+
+#~ msgid "Windows Server 2008"
+#~ msgstr "Windows Server 2003"
+
+#~ msgid "Windows Server 2008 R2"
+#~ msgstr "Windows Server 2008 R2"
+
+#~ msgid "Windows Server 2012"
+#~ msgstr "Windows Server 2012"
+
+#~ msgid "Windows Server 2012 R2"
+#~ msgstr "Windows Server 2012 R2"
+
+#~ msgid "Windows Vista"
+#~ msgstr "Windows Vista"
+
+#~ msgid "Windows XP"
+#~ msgstr "Windows XP"
+
+#~ msgid "can't execute '%s'"
+#~ msgstr "nu se poate executa '%s'"
+
+#~ msgid "error opening '%s'"
+#~ msgstr "eroare la deschiderea '%s'"
+
+#~ msgid "unknown seek origin"
+#~ msgstr "origine necunoscută pentru căutare"
+
+#~ msgid "wxWidget control pointer is not a data view pointer"
+#~ msgstr ""
+#~ "Pointerul de control pentru wxWidget nu este un pointer pentru "
+#~ "vizualizare date"
+
+#~ msgid "wxWidget's control not initialized."
+#~ msgstr "Controlul pentru wxWidgets nu a fost inițializat."
+
+#~ msgid "ADD"
+#~ msgstr "ADD"
+
+#~ msgid "BACK"
+#~ msgstr "BACK"
+
+#~ msgid "CANCEL"
+#~ msgstr "CANCEL"
+
+#~ msgid "CAPITAL"
+#~ msgstr "CAPITAL"
+
+#~ msgid "CLEAR"
+#~ msgstr "CLEAR"
+
+#~ msgid "COMMAND"
+#~ msgstr "COMMAND"
+
+#~ msgid "Cannot create mutex."
+#~ msgstr "Nu se poate crea mutex."
+
+#~ msgid "Cannot resume thread %lu"
+#~ msgstr "Nu se poate continua firul de execuție %lu"
+
+#~ msgid "Cannot suspend thread %lu"
+#~ msgstr "Nu se poate suspenda firul de execuție %lu"
+
+#~ msgid "Couldn't acquire a mutex lock"
+#~ msgstr "Nu s-a putut bloca mutex-ul"
+
+#~ msgid "Couldn't get hatch style from wxBrush."
+#~ msgstr "Nu s-a putut obține stilul de hașurare din wxBrush."
+
+#~ msgid "Couldn't release a mutex"
+#~ msgstr "Nu s-a putut elibera un mutex"
+
+#~ msgid "DECIMAL"
+#~ msgstr "DECIMAL"
+
+#~ msgid "DEL"
+#~ msgstr "DEL"
+
+#~ msgid "DELETE"
+#~ msgstr "DELETE"
+
+#~ msgid "DIVIDE"
+#~ msgstr "DIVIDE"
+
+#~ msgid "DOWN"
+#~ msgstr "DOWN"
+
+#~ msgid "END"
+#~ msgstr "END"
+
+#~ msgid "ENTER"
+#~ msgstr "ENTER"
+
+#~ msgid "ESC"
+#~ msgstr "ESC"
+
+#~ msgid "ESCAPE"
+#~ msgstr "ESCAPE"
+
+#~ msgid "EXECUTE"
+#~ msgstr "EXECUTE"
+
+#~ msgid "Execution of command '%s' failed with error: %ul"
+#~ msgstr "Executarea comenzii '%s' a eșuat cu eroarea: %ul"
+
+#~ msgid ""
+#~ "File '%s' already exists.\n"
+#~ "Do you want to replace it?"
+#~ msgstr ""
+#~ "Fișierul '%s' există deja.\n"
+#~ "Vreți să fie înlocuit?"
+
+#~ msgid "HELP"
+#~ msgstr "HELP"
+
+#~ msgid "HOME"
+#~ msgstr "HOME"
+
+#~ msgid "INS"
+#~ msgstr "INS"
+
+#~ msgid "INSERT"
+#~ msgstr "INSERT"
+
+#~ msgid "KP_BEGIN"
+#~ msgstr "KP_BEGIN"
+
+#~ msgid "KP_DECIMAL"
+#~ msgstr "KP_DECIMAL"
+
+#~ msgid "KP_DELETE"
+#~ msgstr "KP_DELETE"
+
+#~ msgid "KP_DIVIDE"
+#~ msgstr "KP_DIVIDE"
+
+#~ msgid "KP_DOWN"
+#~ msgstr "KP_DOWN"
+
+#~ msgid "KP_ENTER"
+#~ msgstr "KP_ENTER"
+
+#~ msgid "KP_EQUAL"
+#~ msgstr "KP_EQUAL"
+
+#~ msgid "KP_HOME"
+#~ msgstr "KP_HOME"
+
+#~ msgid "KP_INSERT"
+#~ msgstr "KP_INSERT"
+
+#~ msgid "KP_LEFT"
+#~ msgstr "KP_LEFT"
+
+#~ msgid "KP_MULTIPLY"
+#~ msgstr "KP_MULTIPLY"
+
+#~ msgid "KP_NEXT"
+#~ msgstr "KP_NEXT"
+
+#~ msgid "KP_PAGEDOWN"
+#~ msgstr "KP_PAGEDOWN"
+
+#~ msgid "KP_PAGEUP"
+#~ msgstr "KP_PAGEUP"
+
+#~ msgid "KP_PRIOR"
+#~ msgstr "KP_PRIOR"
+
+#~ msgid "KP_RIGHT"
+#~ msgstr "KP_RIGHT"
+
+#~ msgid "KP_SEPARATOR"
+#~ msgstr "KP_SEPARATOR"
+
+#~ msgid "KP_SPACE"
+#~ msgstr "KP_SPACE"
+
+#~ msgid "KP_SUBTRACT"
+#~ msgstr "KP_SUBTRACT"
+
+#~ msgid "LEFT"
+#~ msgstr "LEFT"
+
+#~ msgid "MENU"
+#~ msgstr "MENU"
+
+#~ msgid "NUM_LOCK"
+#~ msgstr "NUM_LOCK"
+
+#~ msgid "PAGEDOWN"
+#~ msgstr "PAGEDOWN"
+
+#~ msgid "PAGEUP"
+#~ msgstr "PAGEUP"
+
+#~ msgid "PAUSE"
+#~ msgstr "PAUSE"
+
+#~ msgid "PGDN"
+#~ msgstr "PGDN"
+
+#~ msgid "PGUP"
+#~ msgstr "PGUP"
+
+#~ msgid "PRINT"
+#~ msgstr "PRINT"
+
+#~ msgid "RETURN"
+#~ msgstr "RETURN"
+
+#~ msgid "RIGHT"
+#~ msgstr "RIGHT"
+
+#~ msgid "SCROLL_LOCK"
+#~ msgstr "SCROLL_LOCK"
+
+#~ msgid "SELECT"
+#~ msgstr "SELECT"
+
+#~ msgid "SEPARATOR"
+#~ msgstr "SEPARATOR"
+
+#~ msgid "SNAPSHOT"
+#~ msgstr "SNAPSHOT"
+
+#~ msgid "SPACE"
+#~ msgstr "SPACE"
+
+#~ msgid "SUBTRACT"
+#~ msgstr "SUBTRACT"
+
+#~ msgid "TAB"
+#~ msgstr "TAB"
+
+#~ msgid "The print dialog returned an error."
+#~ msgstr "Dialogul de tipărire a returnat o eroare."
+
+#~ msgid "The wxGtkPrinterDC cannot be used."
+#~ msgstr "wxGtkPrinterDC nu poate fi folosit."
+
+#~ msgid "Timer creation failed."
+#~ msgstr "Crearea temporizatorului a eșuat."
+
+#~ msgid "UP"
+#~ msgstr "UP"
+
+#~ msgid "WINDOWS_LEFT"
+#~ msgstr "WINDOWS_LEFT"
+
+#~ msgid "WINDOWS_MENU"
+#~ msgstr "WINDOWS_MENU"
+
+#~ msgid "WINDOWS_RIGHT"
+#~ msgstr "WINDOWS_RIGHT"
+
+#~ msgid "buffer is too small for Windows directory."
+#~ msgstr "bufferul este prea mic pentru directorul Windows."
+
+#~ msgid "not implemented"
+#~ msgstr "neimplementat"
+
+#~ msgid "wxPrintout::GetPageInfo gives a null maxPage."
+#~ msgstr "wxPrintout::GetPageInfo dă valoarea maxPage nulă."
+
+#~ msgid "Event queue overflowed"
+#~ msgstr "Coadă de evenimente supraîncărcată"
+
+#~ msgid "percent"
+#~ msgstr "la suta"
+
+#~ msgid "Print preview"
+#~ msgstr "Previzualizează tipărire"
+
+#~ msgid "'"
+#~ msgstr "'"
+
+#~ msgid "1"
+#~ msgstr "1"
+
+#, fuzzy
+#~ msgid "10"
+#~ msgstr "1"
+
+#~ msgid "3"
+#~ msgstr "3"
+
+#~ msgid "4"
+#~ msgstr "4"
+
+#~ msgid "5"
+#~ msgstr "5"
+
+#~ msgid "6"
+#~ msgstr "6"
+
+#~ msgid "7"
+#~ msgstr "7"
+
+#~ msgid "8"
+#~ msgstr "8"
+
+#~ msgid "9"
+#~ msgstr "9"
+
+#~ msgid "File system containing watched object was unmounted"
+#~ msgstr "Sistemul de fișiere ce conține obiectul urmărit a fost demontat"
+
+#, fuzzy
+#~ msgid "&Preview..."
+#~ msgstr " Previzualizare"
+
+#~ msgid "Passing an unkown object to GetObject"
+#~ msgstr "S-a pasat un obiect necunoscut către GetObject"
+
+#, fuzzy
+#~ msgid "Preview..."
+#~ msgstr " Previzualizare"
+
+#, fuzzy
+#~ msgid "The vertical offset relative to the paragraph."
+#~ msgstr "Stilul implicit pentru următorul paragraf."
+
+#~ msgid "&Save..."
+#~ msgstr "&Salvează..."
+
+#~ msgid "About "
+#~ msgstr "Despre "
+
+#~ msgid "All files (*.*)|*"
+#~ msgstr "Toate fișierele (*.*)|*"
+
+#~ msgid "Cannot initialize SciTech MGL!"
+#~ msgstr "Nu se poate inițializa SciTech MGL!"
+
+#~ msgid "Cannot initialize display."
+#~ msgstr "Nu se poate inițializa afișarea."
+
+#~ msgid "Cannot start thread: error writing TLS"
+#~ msgstr "Nu se poate porni firul de execuție: eroare la scrierea TLS"
+
+#~ msgid "Close\tAlt-F4"
+#~ msgstr "Închide\tAlt-F4"
+
+#~ msgid "Couldn't create cursor."
+#~ msgstr "Nu s-a putut crea cursor."
+
+#~ msgid "Directory '%s' doesn't exist!"
+#~ msgstr "Directorul '%s' nu există!"
+
+#~ msgid "Mode %ix%i-%i not available."
+#~ msgstr "Modul %ix%i-%i nu este disponibil."
+
+#~ msgid "Paper Size"
+#~ msgstr "Dimensiune hârtie"
+
+#~ msgid "&Goto..."
+#~ msgstr "&Mergi la..."
+
+#~ msgid "<<"
+#~ msgstr "<<"
+
+#~ msgid ">>"
+#~ msgstr ">>"
+
+#~ msgid ">>|"
+#~ msgstr ">>|"
+
+#~ msgid "Added item is invalid."
+#~ msgstr "Elementul adăugat este invalid."
+
+#~ msgid "BIG5"
+#~ msgstr "BIG5"
+
+#~ msgid "Can't check image format of file '%s': file does not exist."
+#~ msgstr ""
+#~ "Nu se poate verifica formatul imaginii din fișierul '%s': fișierul nu "
+#~ "există."
+
+#~ msgid "Can't load image from file '%s': file does not exist."
+#~ msgstr "Nu se poate încărca imaginea din fișierul '%s': fișierul nu există."
+
+#~ msgid "Cannot open file '%s'."
+#~ msgstr "Nu se poate deschide fișierul '%s'."
+
+#~ msgid "Changed item is invalid."
+#~ msgstr "Elementul schimbat este invalid."
+
+#~ msgid "Click to cancel this window."
+#~ msgstr "Clic pentru a anula această fereastră."
+
+#~ msgid "Click to confirm your selection."
+#~ msgstr "Clic pentru a confirma selecția."
+
+#~ msgid "Column could not be added to native control."
+#~ msgstr "Coloana nu a putut fi adăugată la controlul nativ."
+
+#~ msgid "Column does not have a renderer."
+#~ msgstr "Coloana nu are renderer."
+
+#~ msgid "Column pointer must not be NULL."
+#~ msgstr "Pointer-ul coloanei nu poate fi NULL."
+
+#~ msgid "Column's model column has no equivalent in the associated model."
+#~ msgstr ""
+#~ "Modelul de coloană al coloanei nu are un echivalent în modelul asociat."
+
+#~ msgid "Could not add column to internal structures."
+#~ msgstr "Nu s-a putut adăuga coloana la structurile interne."
+
+#~ msgid "Enter a page number between %d and %d:"
+#~ msgstr "Introduceți un număr de pagină între %d și %d:"
+
+#~ msgid "Failed to create a status bar."
+#~ msgstr "A eșuat crearea unei bare de status."
+
+#~ msgid "GB-2312"
+#~ msgstr "GB-2312"
+
+#~ msgid "Goto Page"
+#~ msgstr "Spre pagina"
+
+#~ msgid ""
+#~ "HTML pagination algorithm generated more than the allowed maximum number "
+#~ "of pages and it can't continue any longer!"
+#~ msgstr ""
+#~ "Algoritmul de paginare HTML a generat mai multe pagini decât numărul "
+#~ "maxim și nu mai poate continua!"
+
+#~ msgid "I64"
+#~ msgstr "I64"
+
+#~ msgid "Internal error, illegal wxCustomTypeInfo"
+#~ msgstr "Eroare internă, wxCustomTypeInfo ilegal"
+
+#~ msgid "Model pointer not initialized."
+#~ msgstr "Pointerul de model nu a fost inițializat."
+
+#~ msgid "No image handler for type %ld defined."
+#~ msgstr "Nu a fost definit niciun manipulator de imagine pentru tipul %ld."
+
+#~ msgid "No model associated with control."
+#~ msgstr "Niciun model asociat cu controlul."
+
+#~ msgid "Owner not initialized."
+#~ msgstr "Proprietar neinițializat."
+
+#~ msgid "Passed item is invalid."
+#~ msgstr "Elementul pasat este invalid."
+
+#~ msgid "Passing a already registered object to SetObjectName"
+#~ msgstr "S-a pasat un obiect deja înregistrat către SetObjectName"
+
+#~ msgid "Pointer to dataview control must not be NULL"
+#~ msgstr "Pointerul către controlul de vizualizare a datelor nu poate fi NULL"
+
+#~ msgid "Pointer to native control must not be NULL."
+#~ msgstr "Pointerul către controlul nativ nu poate fi NULL."
+
+#~ msgid "SHIFT-JIS"
+#~ msgstr "SHIFT-JIS"
+
+#~ msgid ""
+#~ "Streaming delegates for not already streamed objects not yet supported"
+#~ msgstr ""
+#~ "Delegările pentru fluxurile de date ale obiectelor netransmise nu sunt "
+#~ "suportate încă"
+
+#~ msgid ""
+#~ "The data format for the GET-direction of the to be added data object "
+#~ "already exists"
+#~ msgstr ""
+#~ "Formatul de date pentru direcția GET a obiectului de adaugat există deja"
+
+#~ msgid ""
+#~ "The data format for the SET-direction of the to be added data object "
+#~ "already exists"
+#~ msgstr ""
+#~ "Formatul de date pentru direcția SET a obiectului de adaugat există deja"
+
+#~ msgid "The file '%s' doesn't exist and couldn't be opened."
+#~ msgstr "Fișierul '%s' nu există și nu a putut fi deschis."
+
+#~ msgid "The path '%s' contains too many \"..\"!"
+#~ msgstr "Calea '%s' conține prea multe \"..\"!"
+
+#~ msgid "To be deleted item is invalid."
+#~ msgstr "Elementul de șters este invalid."
+
+#~ msgid "Update"
+#~ msgstr "Actualizează"
+
+#~ msgid "Value must be %lld or higher"
+#~ msgstr "Valoarea trebuie să fie %lld sau mai mare"
+
+#~ msgid "Value must be %llu or higher"
+#~ msgstr "Valoarea trebuie să fie %llu sau mai mare"
+
+#~ msgid "Value must be %llu or less"
+#~ msgstr "Valoarea trebuie să fie %llu sau mai mică"
+
+#~ msgid "Warning"
+#~ msgstr "Avertisment"
+
+#~ msgid "Windows 2000 (build %lu"
+#~ msgstr "Windows 2000 (build %lu"
+
+#~ msgid "delegate has no type info"
+#~ msgstr "delegatul nu are informații despre tip"
+
+#~ msgid "wxSearchEngine::LookFor must be called before scanning!"
+#~ msgstr "wxSearchEngine::LookFor trebuie apelată înainte de scanare!"
+
+#~ msgid "|<<"
+#~ msgstr "|<<"

--- a/po_wxstd/ru.po
+++ b/po_wxstd/ru.po
@@ -1,0 +1,9566 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# Dmitry Levichev <d.levichev@gmail.com>, 2014.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-05-14 20:23+0200\n"
+"PO-Revision-Date: 2018-09-06 07:55+0500\n"
+"Last-Translator: Alexander Kovalenko <nktch@yandex.ru>\n"
+"Language-Team: wxWidgets translators <wx-translators@wxwidgets.org>\n"
+"Language: ru_RU\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"n%10<=4 && (n%100<12 || n%100>14) ? 1 : 2);\n"
+"X-Generator: Poedit 2.1.1\n"
+
+#: ../include/wx/defs.h:2582
+msgid "All files (*.*)|*.*"
+msgstr "Все файлы (*.*)|*.*"
+
+#: ../include/wx/defs.h:2585
+msgid "All files (*)|*"
+msgstr "Все файлы (*)|*"
+
+#: ../include/wx/generic/progdlgg.h:85
+msgid "Elapsed time:"
+msgstr "Прошло времени:"
+
+#: ../include/wx/generic/progdlgg.h:86
+msgid "Estimated time:"
+msgstr "Расчётное время:"
+
+#: ../include/wx/generic/progdlgg.h:87
+msgid "Remaining time:"
+msgstr "Оставшееся время:"
+
+#. TRANSLATORS: HTML printout default title.
+#: ../include/wx/html/htmprint.h:121 ../include/wx/prntbase.h:273
+#: ../include/wx/richtext/richtextprint.h:109 ../src/common/docview.cpp:2161
+msgid "Printout"
+msgstr "Распечатка"
+
+#. TRANSLATORS: HTML easy print default title.
+#: ../include/wx/html/htmprint.h:234 ../include/wx/richtext/richtextprint.h:163
+#: ../src/common/prntbase.cpp:522 ../src/html/htmprint.cpp:291
+msgid "Printing"
+msgstr "Печать"
+
+#: ../include/wx/msgdlg.h:277 ../src/common/stockitem.cpp:211
+msgid "Yes"
+msgstr "Да"
+
+#: ../include/wx/msgdlg.h:278 ../src/common/stockitem.cpp:182
+msgid "No"
+msgstr "Нет"
+
+#: ../include/wx/msgdlg.h:279 ../src/common/stockitem.cpp:183
+#: ../src/msw/msgdlg.cpp:430 ../src/msw/msgdlg.cpp:734
+#: ../src/richtext/richtextstyledlg.cpp:292
+msgid "OK"
+msgstr "OK"
+
+#: ../include/wx/msgdlg.h:280 ../src/common/stockitem.cpp:150
+#: ../src/msw/msgdlg.cpp:430 ../src/msw/progdlg.cpp:884
+#: ../src/richtext/richtextstyledlg.cpp:295
+msgid "Cancel"
+msgstr "Отмена"
+
+#: ../include/wx/msgdlg.h:281 ../src/common/stockitem.cpp:168
+#: ../src/html/helpdlg.cpp:63 ../src/html/helpfrm.cpp:108
+#: ../src/osx/button_osx.cpp:38
+msgid "Help"
+msgstr "Справка"
+
+#: ../include/wx/msw/ole/oleutils.h:52
+msgid "Cannot initialize OLE"
+msgstr "Невозможно инициализировать OLE"
+
+#: ../include/wx/msw/private/fswatcher.h:48
+#, c-format
+msgid "Unable to close the handle for '%s'"
+msgstr "Не удалось закрыть дескриптор для '%s'"
+
+#: ../include/wx/msw/private/fswatcher.h:92
+#, c-format
+msgid "Failed to open directory \"%s\" for monitoring."
+msgstr "Не удалось открыть каталог \"%s\" для мониторинга."
+
+#: ../include/wx/msw/private/fswatcher.h:125
+msgid "Unable to close I/O completion port handle"
+msgstr "Невозможно закрыть дескриптор порта завершения ввода-вывода"
+
+#: ../include/wx/msw/private/fswatcher.h:142
+msgid "Unable to associate handle with I/O completion port"
+msgstr "Не удалось связать дескриптор с портом завершения ввода-вывода"
+
+#: ../include/wx/msw/private/fswatcher.h:148
+msgid "Unexpectedly new I/O completion port was created"
+msgstr "Неожиданно был создан новый порт завершения ввода-вывода"
+
+#: ../include/wx/msw/private/fswatcher.h:213
+msgid "Unable to post completion status"
+msgstr "Не удалось разместить статус завершения"
+
+#: ../include/wx/msw/private/fswatcher.h:262
+msgid "Unable to dequeue completion packet"
+msgstr "Не удалось удалить пакет завершения очереди"
+
+#: ../include/wx/msw/private/fswatcher.h:273
+msgid "Unable to create I/O completion port"
+msgstr "Невозможно создать порт завершения ввода/вывода"
+
+#: ../include/wx/richmsgdlg.h:29
+msgid "&See details"
+msgstr "&Просмотр деталей"
+
+#: ../include/wx/richmsgdlg.h:30
+msgid "&Hide details"
+msgstr "&Скрыть подробности"
+
+#: ../include/wx/richtext/richtextbuffer.h:3864
+msgid "&Box"
+msgstr "&Поле"
+
+#: ../include/wx/richtext/richtextbuffer.h:5008
+msgid "&Picture"
+msgstr "&Рисунок"
+
+#: ../include/wx/richtext/richtextbuffer.h:5958
+msgid "&Cell"
+msgstr "&Ячейка"
+
+#: ../include/wx/richtext/richtextbuffer.h:6067
+msgid "&Table"
+msgstr "&Таблица"
+
+#: ../include/wx/richtext/richtextimagedlg.h:37
+msgid "Object Properties"
+msgstr "Свойства объекта"
+
+#: ../include/wx/richtext/richtextsymboldlg.h:39
+msgid "Symbols"
+msgstr "Символы"
+
+#: ../include/wx/unix/pipe.h:46
+msgid "Pipe creation failed"
+msgstr "Ошибка создания потока ввода-вывода"
+
+#: ../include/wx/unix/private/displayx11.h:65
+msgid "Failed to enumerate video modes"
+msgstr "Не удалось перечислить режимы видео"
+
+#: ../include/wx/unix/private/displayx11.h:89
+msgid "Failed to change video mode"
+msgstr "Не удалось изменить видео-режим"
+
+#: ../include/wx/unix/private/fswatcher_kqueue.h:57
+#, c-format
+msgid "Unable to open path '%s'"
+msgstr "Не удалось открыть путь '%s'"
+
+#: ../include/wx/unix/private/fswatcher_kqueue.h:74
+#, c-format
+msgid "Unable to close path '%s'"
+msgstr "Невозможно закрыть путь '%s'"
+
+#: ../include/wx/xtiprop.h:175
+msgid "SetProperty called w/o valid setter"
+msgstr "SetProperty вызывается без действительного сеттера"
+
+#: ../include/wx/xtiprop.h:184
+msgid "GetProperty called w/o valid getter"
+msgstr "GetProperty вызыватся без допустимого получателя"
+
+#: ../include/wx/xtiprop.h:193
+msgid "AddToPropertyCollection called w/o valid adder"
+msgstr "AddToPropertyCollection вызывается без действительного сумматора"
+
+#: ../include/wx/xtiprop.h:202
+msgid "GetPropertyCollection called w/o valid collection getter"
+msgstr ""
+"GetPropertyCollection вызывается без действительного получателя коллекции"
+
+#: ../include/wx/xtiprop.h:255
+msgid "AddToPropertyCollection called on a generic accessor"
+msgstr "AddToPropertyCollection  вызывается для универсального метода доступа"
+
+#: ../include/wx/xtiprop.h:262
+msgid "GetPropertyCollection called on a generic accessor"
+msgstr "GetPropertyCollection вызывается для универсального метода доступа"
+
+#: ../src/aui/tabmdi.cpp:106 ../src/generic/mdig.cpp:94
+msgid "Cl&ose"
+msgstr "&Закрыть"
+
+#: ../src/aui/tabmdi.cpp:107 ../src/generic/mdig.cpp:95
+msgid "Close All"
+msgstr "Закрыть всё"
+
+#: ../src/aui/tabmdi.cpp:109 ../src/generic/mdig.cpp:97 ../src/msw/mdi.cpp:175
+#: ../src/qt/mdi.cpp:258
+msgid "&Next"
+msgstr "&Следующий"
+
+#: ../src/aui/tabmdi.cpp:110 ../src/generic/mdig.cpp:98 ../src/msw/mdi.cpp:176
+#: ../src/qt/mdi.cpp:259
+msgid "&Previous"
+msgstr "&Предыдущий"
+
+#: ../src/aui/tabmdi.cpp:332 ../src/aui/tabmdi.cpp:348
+#: ../src/aui/tabmdi.cpp:350 ../src/generic/mdig.cpp:291
+#: ../src/generic/mdig.cpp:307 ../src/generic/mdig.cpp:311
+#: ../src/msw/mdi.cpp:337 ../src/qt/mdi.cpp:462
+msgid "&Window"
+msgstr "&Окно"
+
+#: ../src/common/accelcmn.cpp:47
+msgctxt "keyboard key"
+msgid "Delete"
+msgstr "Удалить"
+
+#: ../src/common/accelcmn.cpp:48
+msgctxt "keyboard key"
+msgid "Del"
+msgstr "Del"
+
+#: ../src/common/accelcmn.cpp:49
+msgctxt "keyboard key"
+msgid "Back"
+msgstr "Назад"
+
+#: ../src/common/accelcmn.cpp:49
+msgctxt "keyboard key"
+msgid "Backspace"
+msgstr "Backspace"
+
+#: ../src/common/accelcmn.cpp:50
+msgctxt "keyboard key"
+msgid "Insert"
+msgstr "Insert"
+
+#: ../src/common/accelcmn.cpp:51
+msgctxt "keyboard key"
+msgid "Ins"
+msgstr "INS"
+
+#: ../src/common/accelcmn.cpp:52
+msgctxt "keyboard key"
+msgid "Enter"
+msgstr "Enter"
+
+#: ../src/common/accelcmn.cpp:53
+msgctxt "keyboard key"
+msgid "Return"
+msgstr "Возврат"
+
+#: ../src/common/accelcmn.cpp:54
+msgctxt "keyboard key"
+msgid "PageUp"
+msgstr "PageUp"
+
+#: ../src/common/accelcmn.cpp:54
+msgctxt "keyboard key"
+msgid "Page Up"
+msgstr "Page Up"
+
+#: ../src/common/accelcmn.cpp:55
+msgctxt "keyboard key"
+msgid "PageDown"
+msgstr "PageDown"
+
+#: ../src/common/accelcmn.cpp:55
+msgctxt "keyboard key"
+msgid "Page Down"
+msgstr "Page Down"
+
+#: ../src/common/accelcmn.cpp:56
+msgctxt "keyboard key"
+msgid "PgUp"
+msgstr "PgUp"
+
+#: ../src/common/accelcmn.cpp:57
+msgctxt "keyboard key"
+msgid "PgDn"
+msgstr "PgDn"
+
+#: ../src/common/accelcmn.cpp:58
+msgctxt "keyboard key"
+msgid "Left"
+msgstr "Слева"
+
+#: ../src/common/accelcmn.cpp:59
+msgctxt "keyboard key"
+msgid "Right"
+msgstr "Направо"
+
+#: ../src/common/accelcmn.cpp:60
+msgctxt "keyboard key"
+msgid "Up"
+msgstr "Выше"
+
+#: ../src/common/accelcmn.cpp:61
+msgctxt "keyboard key"
+msgid "Down"
+msgstr "Вниз"
+
+#: ../src/common/accelcmn.cpp:62
+msgctxt "keyboard key"
+msgid "Home"
+msgstr "В начало"
+
+#: ../src/common/accelcmn.cpp:63
+msgctxt "keyboard key"
+msgid "End"
+msgstr "END"
+
+#: ../src/common/accelcmn.cpp:64
+msgctxt "keyboard key"
+msgid "Space"
+msgstr "ПРОБЕЛ"
+
+#: ../src/common/accelcmn.cpp:65
+msgctxt "keyboard key"
+msgid "Tab"
+msgstr "Tab"
+
+#: ../src/common/accelcmn.cpp:66
+msgctxt "keyboard key"
+msgid "Esc"
+msgstr "ESC"
+
+#: ../src/common/accelcmn.cpp:67
+msgctxt "keyboard key"
+msgid "Escape"
+msgstr "ESCAPE"
+
+#: ../src/common/accelcmn.cpp:68
+msgctxt "keyboard key"
+msgid "Cancel"
+msgstr "Отмена"
+
+#: ../src/common/accelcmn.cpp:69
+msgctxt "keyboard key"
+msgid "Clear"
+msgstr "Очистить"
+
+#: ../src/common/accelcmn.cpp:70
+msgctxt "keyboard key"
+msgid "Menu"
+msgstr "Меню"
+
+#: ../src/common/accelcmn.cpp:71
+msgctxt "keyboard key"
+msgid "Pause"
+msgstr "Пауза"
+
+#: ../src/common/accelcmn.cpp:72
+msgctxt "keyboard key"
+msgid "Capital"
+msgstr "Заглавная"
+
+#: ../src/common/accelcmn.cpp:73
+msgctxt "keyboard key"
+msgid "Select"
+msgstr "Выделить"
+
+#: ../src/common/accelcmn.cpp:74
+msgctxt "keyboard key"
+msgid "Print"
+msgstr "Печать"
+
+#: ../src/common/accelcmn.cpp:75
+msgctxt "keyboard key"
+msgid "Execute"
+msgstr "Выполнить"
+
+#: ../src/common/accelcmn.cpp:76
+msgctxt "keyboard key"
+msgid "Snapshot"
+msgstr "Снимок"
+
+#: ../src/common/accelcmn.cpp:77
+msgctxt "keyboard key"
+msgid "Help"
+msgstr "Справка"
+
+#: ../src/common/accelcmn.cpp:78
+msgctxt "keyboard key"
+msgid "Add"
+msgstr "Добавить"
+
+#: ../src/common/accelcmn.cpp:79
+msgctxt "keyboard key"
+msgid "Separator"
+msgstr "Разделитель"
+
+#: ../src/common/accelcmn.cpp:80
+msgctxt "keyboard key"
+msgid "Subtract"
+msgstr "Вычесть"
+
+#: ../src/common/accelcmn.cpp:81
+msgctxt "keyboard key"
+msgid "Decimal"
+msgstr "Десятичная дробь"
+
+#: ../src/common/accelcmn.cpp:82
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Multiply"
+msgstr "KP_Multiply"
+
+#: ../src/common/accelcmn.cpp:83
+msgctxt "keyboard key"
+msgid "Divide"
+msgstr "Разделить"
+
+#: ../src/common/accelcmn.cpp:84
+msgctxt "keyboard key"
+msgid "Num_lock"
+msgstr "Num_lock"
+
+#: ../src/common/accelcmn.cpp:84
+msgctxt "keyboard key"
+msgid "Num Lock"
+msgstr "Num Lock"
+
+#: ../src/common/accelcmn.cpp:85
+msgctxt "keyboard key"
+msgid "Scroll_lock"
+msgstr "Scroll_lock"
+
+#: ../src/common/accelcmn.cpp:85
+msgctxt "keyboard key"
+msgid "Scroll Lock"
+msgstr "Блок прокрутки"
+
+#: ../src/common/accelcmn.cpp:86
+msgctxt "keyboard key"
+msgid "KP_Space"
+msgstr "KP_пробел"
+
+#: ../src/common/accelcmn.cpp:86
+msgctxt "keyboard key"
+msgid "Num Space"
+msgstr "Num Space"
+
+#: ../src/common/accelcmn.cpp:87
+msgctxt "keyboard key"
+msgid "KP_Tab"
+msgstr "KP_Tab"
+
+#: ../src/common/accelcmn.cpp:87
+msgctxt "keyboard key"
+msgid "Num Tab"
+msgstr "Num Tab"
+
+#: ../src/common/accelcmn.cpp:88
+msgctxt "keyboard key"
+msgid "KP_Enter"
+msgstr "KP_Enter"
+
+#: ../src/common/accelcmn.cpp:88
+msgctxt "keyboard key"
+msgid "Num Enter"
+msgstr "Num Enter"
+
+#: ../src/common/accelcmn.cpp:89
+msgctxt "keyboard key"
+msgid "KP_Home"
+msgstr "KP_Home"
+
+#: ../src/common/accelcmn.cpp:89
+msgctxt "keyboard key"
+msgid "Num Home"
+msgstr "Num Home"
+
+#: ../src/common/accelcmn.cpp:90
+msgctxt "keyboard key"
+msgid "KP_Left"
+msgstr "KP_Left"
+
+#: ../src/common/accelcmn.cpp:90
+msgctxt "keyboard key"
+msgid "Num left"
+msgstr "Num left"
+
+#: ../src/common/accelcmn.cpp:91
+msgctxt "keyboard key"
+msgid "KP_Up"
+msgstr "KP_Up"
+
+#: ../src/common/accelcmn.cpp:91
+msgctxt "keyboard key"
+msgid "Num Up"
+msgstr "Num Up"
+
+#: ../src/common/accelcmn.cpp:92
+msgctxt "keyboard key"
+msgid "KP_Right"
+msgstr "KP_Right"
+
+#: ../src/common/accelcmn.cpp:92
+msgctxt "keyboard key"
+msgid "Num Right"
+msgstr "Num Right"
+
+#: ../src/common/accelcmn.cpp:93
+msgctxt "keyboard key"
+msgid "KP_Down"
+msgstr "KP_Down"
+
+#: ../src/common/accelcmn.cpp:93
+msgctxt "keyboard key"
+msgid "Num Down"
+msgstr "Num Down"
+
+#: ../src/common/accelcmn.cpp:94
+msgctxt "keyboard key"
+msgid "KP_PageUp"
+msgstr "PageUp"
+
+#: ../src/common/accelcmn.cpp:94
+msgctxt "keyboard key"
+msgid "Num Page Up"
+msgstr "Page Up"
+
+#: ../src/common/accelcmn.cpp:95
+msgctxt "keyboard key"
+msgid "KP_PageDown"
+msgstr "PageDown"
+
+#: ../src/common/accelcmn.cpp:95
+msgctxt "keyboard key"
+msgid "Num Page Down"
+msgstr "Page Down"
+
+#: ../src/common/accelcmn.cpp:96
+msgctxt "keyboard key"
+msgid "KP_Prior"
+msgstr "KP_Prior"
+
+#: ../src/common/accelcmn.cpp:97
+msgctxt "keyboard key"
+msgid "KP_Next"
+msgstr "KP_Next"
+
+#: ../src/common/accelcmn.cpp:98
+msgctxt "keyboard key"
+msgid "KP_End"
+msgstr "KP_End"
+
+#: ../src/common/accelcmn.cpp:98
+msgctxt "keyboard key"
+msgid "Num End"
+msgstr "Num End"
+
+#: ../src/common/accelcmn.cpp:99
+msgctxt "keyboard key"
+msgid "KP_Begin"
+msgstr "KP_Begin"
+
+#: ../src/common/accelcmn.cpp:99
+msgctxt "keyboard key"
+msgid "Num Begin"
+msgstr "Num Begin"
+
+#: ../src/common/accelcmn.cpp:100
+msgctxt "keyboard key"
+msgid "KP_Insert"
+msgstr "KP_Insert"
+
+#: ../src/common/accelcmn.cpp:100
+msgctxt "keyboard key"
+msgid "Num Insert"
+msgstr "Num Insert"
+
+#: ../src/common/accelcmn.cpp:101
+msgctxt "keyboard key"
+msgid "KP_Delete"
+msgstr "KP_Delete"
+
+#: ../src/common/accelcmn.cpp:101
+msgctxt "keyboard key"
+msgid "Num Delete"
+msgstr "Num Delete"
+
+#: ../src/common/accelcmn.cpp:102
+msgctxt "keyboard key"
+msgid "KP_Equal"
+msgstr "KP_Equal"
+
+#: ../src/common/accelcmn.cpp:102
+msgctxt "keyboard key"
+msgid "Num ="
+msgstr "Num ="
+
+#: ../src/common/accelcmn.cpp:103
+msgctxt "keyboard key"
+msgid "KP_Multiply"
+msgstr "KP_Multiply"
+
+#: ../src/common/accelcmn.cpp:103
+msgctxt "keyboard key"
+msgid "Num *"
+msgstr "Num *"
+
+#: ../src/common/accelcmn.cpp:104
+msgctxt "keyboard key"
+msgid "KP_Add"
+msgstr "KP_Add"
+
+#: ../src/common/accelcmn.cpp:104
+msgctxt "keyboard key"
+msgid "Num +"
+msgstr "Num +"
+
+#: ../src/common/accelcmn.cpp:105
+msgctxt "keyboard key"
+msgid "KP_Separator"
+msgstr "KP_Separator"
+
+#: ../src/common/accelcmn.cpp:105
+msgctxt "keyboard key"
+msgid "Num ,"
+msgstr "Num ,"
+
+#: ../src/common/accelcmn.cpp:106
+msgctxt "keyboard key"
+msgid "KP_Subtract"
+msgstr "KP_Subtract"
+
+#: ../src/common/accelcmn.cpp:106
+msgctxt "keyboard key"
+msgid "Num -"
+msgstr "Num -"
+
+#: ../src/common/accelcmn.cpp:107
+msgctxt "keyboard key"
+msgid "KP_Decimal"
+msgstr "KP_десятичная дробь"
+
+#: ../src/common/accelcmn.cpp:107
+msgctxt "keyboard key"
+msgid "Num ."
+msgstr "Num ."
+
+#: ../src/common/accelcmn.cpp:108
+msgctxt "keyboard key"
+msgid "KP_Divide"
+msgstr "KP_Divide"
+
+#: ../src/common/accelcmn.cpp:108
+msgctxt "keyboard key"
+msgid "Num /"
+msgstr "Num /"
+
+#: ../src/common/accelcmn.cpp:109
+msgctxt "keyboard key"
+msgid "Windows_Left"
+msgstr "Windows_Left"
+
+#: ../src/common/accelcmn.cpp:110
+msgctxt "keyboard key"
+msgid "Windows_Right"
+msgstr "Windows_Right"
+
+#: ../src/common/accelcmn.cpp:111
+msgctxt "keyboard key"
+msgid "Windows_Menu"
+msgstr "Windows_Menu"
+
+#: ../src/common/accelcmn.cpp:112
+msgctxt "keyboard key"
+msgid "Command"
+msgstr "&Команда"
+
+#: ../src/common/accelcmn.cpp:186 ../src/common/accelcmn.cpp:359
+msgctxt "keyboard key"
+msgid "Ctrl"
+msgstr "Ctrl"
+
+#: ../src/common/accelcmn.cpp:188 ../src/common/accelcmn.cpp:363
+msgctxt "keyboard key"
+msgid "Alt"
+msgstr "Alt"
+
+#: ../src/common/accelcmn.cpp:190 ../src/common/accelcmn.cpp:361
+msgctxt "keyboard key"
+msgid "Shift"
+msgstr "Shift"
+
+#: ../src/common/accelcmn.cpp:196
+msgctxt "keyboard key"
+msgid "num "
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:260 ../src/common/accelcmn.cpp:382
+msgctxt "keyboard key"
+msgid "F"
+msgstr "F"
+
+#: ../src/common/accelcmn.cpp:277 ../src/common/accelcmn.cpp:385
+msgctxt "keyboard key"
+msgid "KP_F"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:280 ../src/common/accelcmn.cpp:388
+msgctxt "keyboard key"
+msgid "KP_"
+msgstr "KP_"
+
+#: ../src/common/accelcmn.cpp:283 ../src/common/accelcmn.cpp:391
+msgctxt "keyboard key"
+msgid "SPECIAL"
+msgstr "СПЕЦИАЛЬНЫЕ"
+
+#: ../src/common/accelcmn.cpp:373
+#, fuzzy
+msgid "Ctrl"
+msgstr "Ctrl"
+
+#: ../src/common/appbase.cpp:786
+msgid "show this help message"
+msgstr "показать это справочное сообщение"
+
+#: ../src/common/appbase.cpp:796
+msgid "generate verbose log messages"
+msgstr "генерировать подробные сообщения отладки"
+
+#: ../src/common/appcmn.cpp:256
+msgid "specify the theme to use"
+msgstr "укажите тему для использования"
+
+#: ../src/common/appcmn.cpp:270
+msgid "specify display mode to use (e.g. 640x480-16)"
+msgstr "укажите используемый режим экрана (например, 640x480-16)"
+
+#: ../src/common/appcmn.cpp:292
+#, c-format
+msgid "Unsupported theme '%s'."
+msgstr "Неподдерживаемая тема '%s'."
+
+#: ../src/common/appcmn.cpp:309
+#, c-format
+msgid "Invalid display mode specification '%s'."
+msgstr "Неправильная спецификация режима экрана '%s'."
+
+#: ../src/common/cmdline.cpp:875
+#, c-format
+msgid "Option '%s' can't be negated"
+msgstr "Параметр '%s' не может быть отрицательным"
+
+#: ../src/common/cmdline.cpp:889
+#, c-format
+msgid "Unknown long option '%s'"
+msgstr "Неизвестный длинный параметр '%s'"
+
+#: ../src/common/cmdline.cpp:904 ../src/common/cmdline.cpp:926
+#, c-format
+msgid "Unknown option '%s'"
+msgstr "Неизвестный параметр '%s'"
+
+#: ../src/common/cmdline.cpp:1004
+#, c-format
+msgid "Unexpected characters following option '%s'."
+msgstr "Неожиданные символы, следующие за опцией '%s'."
+
+#: ../src/common/cmdline.cpp:1039
+#, c-format
+msgid "Option '%s' requires a value."
+msgstr "Параметр '%s' требует значение."
+
+#: ../src/common/cmdline.cpp:1058
+#, c-format
+msgid "Separator expected after the option '%s'."
+msgstr "Разделитель, ожидаемый после параметра '%s'."
+
+#: ../src/common/cmdline.cpp:1088 ../src/common/cmdline.cpp:1106
+#, c-format
+msgid "'%s' is not a correct numeric value for option '%s'."
+msgstr "'%s' - некорректное числовое значение для параметра '%s'."
+
+#: ../src/common/cmdline.cpp:1122
+#, c-format
+msgid "Option '%s': '%s' cannot be converted to a date."
+msgstr "Параметр '%s': '%s' не может быть преобразован в дату."
+
+#: ../src/common/cmdline.cpp:1170
+#, c-format
+msgid "Unexpected parameter '%s'"
+msgstr "Неожиданный параметр '%s'"
+
+#. TRANSLATORS: Short name and long name for a command line option
+#: ../src/common/cmdline.cpp:1197
+#, c-format
+msgid "%s (or %s)"
+msgstr "%s (или %s)"
+
+#: ../src/common/cmdline.cpp:1208
+#, c-format
+msgid "The value for the option '%s' must be specified."
+msgstr "Значение параметра '%s' должно быть определено."
+
+#: ../src/common/cmdline.cpp:1230
+#, c-format
+msgid "The required parameter '%s' was not specified."
+msgstr "Обязательный параметр '%s' не определён."
+
+#: ../src/common/cmdline.cpp:1289
+#, c-format
+msgid "Usage: %s"
+msgstr "Использование: %s"
+
+#: ../src/common/cmdline.cpp:1498
+msgid "str"
+msgstr "str"
+
+#: ../src/common/cmdline.cpp:1502
+msgid "num"
+msgstr "num"
+
+#: ../src/common/cmdline.cpp:1506
+msgid "double"
+msgstr "двухместный"
+
+#: ../src/common/cmdline.cpp:1510
+msgid "date"
+msgstr "дата"
+
+#: ../src/common/cmdproc.cpp:250 ../src/common/cmdproc.cpp:276
+#: ../src/common/cmdproc.cpp:296
+msgid "Unnamed command"
+msgstr "Команда без имени"
+
+#: ../src/common/cmdproc.cpp:253
+msgid "&Undo "
+msgstr "&Отменить "
+
+#: ../src/common/cmdproc.cpp:255
+msgid "Can't &Undo "
+msgstr "О&тменить невозможно "
+
+#: ../src/common/cmdproc.cpp:259 ../src/common/stockitem.cpp:208
+#: ../src/msw/textctrl.cpp:2880 ../src/osx/textctrl_osx.cpp:649
+#: ../src/richtext/richtextctrl.cpp:327
+msgid "&Undo"
+msgstr "&Отменить"
+
+#: ../src/common/cmdproc.cpp:277 ../src/common/cmdproc.cpp:297
+msgid "&Redo "
+msgstr "&Вернуть "
+
+#: ../src/common/cmdproc.cpp:281 ../src/common/cmdproc.cpp:288
+#: ../src/common/stockitem.cpp:190 ../src/msw/textctrl.cpp:2881
+#: ../src/osx/textctrl_osx.cpp:650 ../src/richtext/richtextctrl.cpp:328
+msgid "&Redo"
+msgstr "&Вернуть"
+
+#: ../src/common/colourcmn.cpp:41
+#, c-format
+msgid "String To Colour : Incorrect colour specification : %s"
+msgstr "Строка в цвет : неверная спецификация цвета : %s"
+
+#: ../src/common/config.cpp:259
+#, c-format
+msgid "Invalid value %ld for a boolean key \"%s\" in config file."
+msgstr ""
+"Недопустимое значение %ld для логического ключа  '%s' в файле конфигурации."
+
+#: ../src/common/config.cpp:526
+#, c-format
+msgid ""
+"Environment variables expansion failed: missing '%c' at position %u in '%s'."
+msgstr ""
+"Ошибка расширения переменных окружения: отсутствует '%c' в позиции %u в '%s'."
+
+#: ../src/common/config.cpp:576 ../src/msw/regconf.cpp:272
+#, c-format
+msgid "'%s' has extra '..', ignored."
+msgstr "'%s' содержит лишние '..', игнорировано."
+
+#. TRANSLATORS: Checkbox state name
+#: ../src/common/datavcmn.cpp:2166 ../src/generic/datavgen.cpp:1430
+msgid "checked"
+msgstr "выбрано"
+
+#. TRANSLATORS: Checkbox state name
+#: ../src/common/datavcmn.cpp:2170 ../src/generic/datavgen.cpp:1432
+msgid "unchecked"
+msgstr "сброшенный"
+
+#. TRANSLATORS: Checkbox state name
+#: ../src/common/datavcmn.cpp:2174
+msgid "undetermined"
+msgstr "неопределён"
+
+#: ../src/common/datetimefmt.cpp:1875
+msgid "today"
+msgstr "сегодня"
+
+#: ../src/common/datetimefmt.cpp:1876
+msgid "yesterday"
+msgstr "вчера"
+
+#: ../src/common/datetimefmt.cpp:1877
+msgid "tomorrow"
+msgstr "завтра"
+
+#: ../src/common/datetimefmt.cpp:2071
+msgid "first"
+msgstr "первый"
+
+#: ../src/common/datetimefmt.cpp:2072
+msgid "second"
+msgstr "второй"
+
+#: ../src/common/datetimefmt.cpp:2073
+msgid "third"
+msgstr "третий"
+
+#: ../src/common/datetimefmt.cpp:2074
+msgid "fourth"
+msgstr "четвёртый"
+
+#: ../src/common/datetimefmt.cpp:2075
+msgid "fifth"
+msgstr "пятый"
+
+#: ../src/common/datetimefmt.cpp:2076
+msgid "sixth"
+msgstr "шестой"
+
+#: ../src/common/datetimefmt.cpp:2077
+msgid "seventh"
+msgstr "седьмой"
+
+#: ../src/common/datetimefmt.cpp:2078
+msgid "eighth"
+msgstr "восьмой"
+
+#: ../src/common/datetimefmt.cpp:2079
+msgid "ninth"
+msgstr "девятый"
+
+#: ../src/common/datetimefmt.cpp:2080
+msgid "tenth"
+msgstr "десятый"
+
+#: ../src/common/datetimefmt.cpp:2081
+msgid "eleventh"
+msgstr "одиннадцатый"
+
+#: ../src/common/datetimefmt.cpp:2082
+msgid "twelfth"
+msgstr "двенадцатый"
+
+#: ../src/common/datetimefmt.cpp:2083
+msgid "thirteenth"
+msgstr "тринадцатый"
+
+#: ../src/common/datetimefmt.cpp:2084
+msgid "fourteenth"
+msgstr "четырнадцатый"
+
+#: ../src/common/datetimefmt.cpp:2085
+msgid "fifteenth"
+msgstr "пятнадцатый"
+
+#: ../src/common/datetimefmt.cpp:2086
+msgid "sixteenth"
+msgstr "шестнадцатый"
+
+#: ../src/common/datetimefmt.cpp:2087
+msgid "seventeenth"
+msgstr "семнадцатый"
+
+#: ../src/common/datetimefmt.cpp:2088
+msgid "eighteenth"
+msgstr "восемнадцатый"
+
+#: ../src/common/datetimefmt.cpp:2089
+msgid "nineteenth"
+msgstr "девятнадцатый"
+
+#: ../src/common/datetimefmt.cpp:2090
+msgid "twentieth"
+msgstr "двадцатый"
+
+#: ../src/common/datetimefmt.cpp:2248
+msgid "noon"
+msgstr "полдень"
+
+#: ../src/common/datetimefmt.cpp:2249
+msgid "midnight"
+msgstr "полночь"
+
+#: ../src/common/debugrpt.cpp:209
+#, c-format
+msgid "Failed to create directory \"%s\""
+msgstr "Ошибка создания каталога \"%s\""
+
+#: ../src/common/debugrpt.cpp:210
+msgid "Debug report couldn't be created."
+msgstr "Отчёт об отладке не может быть создан."
+
+#: ../src/common/debugrpt.cpp:227
+#, c-format
+msgid "Failed to remove debug report file \"%s\""
+msgstr "Не удалось удалить файл отчёта об отладке \"%s\""
+
+#: ../src/common/debugrpt.cpp:239
+#, c-format
+msgid "Failed to clean up debug report directory \"%s\""
+msgstr "Ошибка очистки каталога отчёта об отладке \"%s\""
+
+#: ../src/common/debugrpt.cpp:514
+msgid "process context description"
+msgstr "описание контекста процесса"
+
+#: ../src/common/debugrpt.cpp:538
+msgid "dump of the process state (binary)"
+msgstr "дамп состояния процесса (двоичный)"
+
+#: ../src/common/debugrpt.cpp:553
+msgid "Debug report generation has failed."
+msgstr "Создание отчёта завершилось с ошибкой."
+
+#: ../src/common/debugrpt.cpp:560
+#, c-format
+msgid ""
+"Processing debug report has failed, leaving the files in \"%s\" directory."
+msgstr ""
+"Обработка отчёта об отладке завершена с ошибкой, файлы остались в каталоге "
+"'%s'."
+
+#: ../src/common/debugrpt.cpp:573
+msgid "A debug report has been generated. It can be found in"
+msgstr "Отладочный отчёт был сформирован. Его можно найти в"
+
+#: ../src/common/debugrpt.cpp:576
+msgid "And includes the following files:\n"
+msgstr "И включает в себя следующие файлы:\n"
+
+#: ../src/common/debugrpt.cpp:586
+msgid ""
+"\n"
+"Please send this report to the program maintainer, thank you!\n"
+msgstr ""
+"\n"
+"Отправьте этот отчёт сопровождающему программы. Заранее спасибо.\n"
+
+#: ../src/common/debugrpt.cpp:729
+msgid "Failed to execute curl, please install it in PATH."
+msgstr "Невозможно выполнить curl, установите его в PATH."
+
+#: ../src/common/debugrpt.cpp:742
+#, c-format
+msgid "Failed to upload the debug report (error code %d)."
+msgstr "Не удалось отправить отчёт об отладке (код ошибки %d)."
+
+#: ../src/common/docview.cpp:366
+msgid "Save As"
+msgstr "Сохранить как"
+
+#: ../src/common/docview.cpp:457
+msgid "Discard changes and reload the last saved version?"
+msgstr "Отменить изменения и загрузить повторно последнюю сохранённую версию?"
+
+#: ../src/common/docview.cpp:488
+msgid "unnamed"
+msgstr "без_имени"
+
+#: ../src/common/docview.cpp:513
+#, c-format
+msgid "Do you want to save changes to %s?"
+msgstr "Сохранить изменения в %s?"
+
+#: ../src/common/docview.cpp:521 ../src/common/docview.cpp:560
+#: ../src/common/stockitem.cpp:195
+msgid "&Save"
+msgstr "&Сохранить"
+
+#: ../src/common/docview.cpp:522 ../src/common/docview.cpp:560
+msgid "&Discard changes"
+msgstr ""
+
+#: ../src/common/docview.cpp:523
+#, fuzzy
+msgid "Do&n't close"
+msgstr "Не сохранять"
+
+#: ../src/common/docview.cpp:553
+#, fuzzy, c-format
+msgid "Do you want to save changes to %s before closing it?"
+msgstr "Сохранить изменения в %s?"
+
+#: ../src/common/docview.cpp:559
+#, fuzzy
+msgid "The document must be closed."
+msgstr "Не удалось сохранить текст."
+
+#: ../src/common/docview.cpp:571
+#, c-format
+msgid "Saving %s failed, would you like to retry?"
+msgstr ""
+
+#: ../src/common/docview.cpp:577
+msgid "Retry"
+msgstr ""
+
+#: ../src/common/docview.cpp:577
+msgid "Discard changes"
+msgstr ""
+
+#: ../src/common/docview.cpp:679
+#, c-format
+msgid "File \"%s\" could not be opened for writing."
+msgstr "Невозможно открыть файл '%s' для записи."
+
+#: ../src/common/docview.cpp:685
+#, c-format
+msgid "Failed to save document to the file \"%s\"."
+msgstr "Не удалось сохранить документ в файл \"%s\"."
+
+#: ../src/common/docview.cpp:702
+#, c-format
+msgid "File \"%s\" could not be opened for reading."
+msgstr "Не удалось открыть файл '%s' для чтения."
+
+#: ../src/common/docview.cpp:714
+#, c-format
+msgid "Failed to read document from the file \"%s\"."
+msgstr "Не удалось прочесть документ из файла \"%s\"."
+
+#: ../src/common/docview.cpp:1236
+#, c-format
+msgid ""
+"The file '%s' doesn't exist and couldn't be opened.\n"
+"It has been removed from the most recently used files list."
+msgstr ""
+"Файл '%s' не существует и его открыть нельзя.\n"
+"Он был удалён из списка последних использованных файлов."
+
+#: ../src/common/docview.cpp:1296
+msgid "Print preview creation failed."
+msgstr "Сбой при создании предпросмотра печати."
+
+#: ../src/common/docview.cpp:1302
+msgid "Print Preview"
+msgstr "Предпросмотр печати"
+
+#: ../src/common/docview.cpp:1517
+#, c-format
+msgid "The format of file '%s' couldn't be determined."
+msgstr "Не удалось определить формат файла '%s' ."
+
+#: ../src/common/docview.cpp:1643
+#, c-format
+msgid "unnamed%d"
+msgstr "без_имени%d"
+
+#: ../src/common/docview.cpp:1660
+msgid " - "
+msgstr " - "
+
+#: ../src/common/docview.cpp:1791 ../src/common/docview.cpp:1844
+msgid "Open File"
+msgstr "Открыть файл"
+
+#: ../src/common/docview.cpp:1807
+msgid "File error"
+msgstr "Ошибка файла"
+
+#: ../src/common/docview.cpp:1809
+msgid "Sorry, could not open this file."
+msgstr "Этот файл открыть нельзя."
+
+#: ../src/common/docview.cpp:1843
+msgid "Sorry, the format for this file is unknown."
+msgstr "Формат этого файла неизвестен."
+
+#: ../src/common/docview.cpp:1924
+msgid "Select a document template"
+msgstr "Выбрать шаблон документа"
+
+#: ../src/common/docview.cpp:1925
+msgid "Templates"
+msgstr "Шаблоны"
+
+#: ../src/common/docview.cpp:1998
+msgid "Select a document view"
+msgstr "Выбрать вид документа"
+
+#: ../src/common/docview.cpp:1999
+msgid "Views"
+msgstr "Виды"
+
+#: ../src/common/dynlib.cpp:81
+#, c-format
+msgid "Failed to load shared library '%s'"
+msgstr "Ошибка загрузки разделяемой библиотеки '%s'"
+
+#: ../src/common/dynlib.cpp:105
+#, c-format
+msgid "Couldn't find symbol '%s' in a dynamic library"
+msgstr "Невозможно найти символ '%s' в динамической библиотеке"
+
+#: ../src/common/ffile.cpp:56 ../src/common/file.cpp:215
+#, c-format
+msgid "can't open file '%s'"
+msgstr "невозможно открыть файл '%s'"
+
+#: ../src/common/ffile.cpp:72
+#, c-format
+msgid "can't close file '%s'"
+msgstr "невозможно закрыть файл '%s'"
+
+#: ../src/common/ffile.cpp:106 ../src/common/ffile.cpp:131
+#, c-format
+msgid "Read error on file '%s'"
+msgstr "Ошибка чтения файла '%s'"
+
+#: ../src/common/ffile.cpp:148
+#, c-format
+msgid "Write error on file '%s'"
+msgstr "Ошибка записи в файл '%s'"
+
+#: ../src/common/ffile.cpp:182
+#, c-format
+msgid "failed to flush the file '%s'"
+msgstr "ошибка сброса буфера файла '%s'."
+
+#: ../src/common/ffile.cpp:222
+#, c-format
+msgid "Seek error on file '%s' (large files not supported by stdio)"
+msgstr "Ошибка смещения в файле '%s' (большие строки не поддерживаются stdio)"
+
+#: ../src/common/ffile.cpp:232
+#, c-format
+msgid "Seek error on file '%s'"
+msgstr "Ошибка смещения в файле '%s'"
+
+#: ../src/common/ffile.cpp:248
+#, c-format
+msgid "Can't find current position in file '%s'"
+msgstr "Не удаётся найти текущую позицию в файле '%s'"
+
+#: ../src/common/ffile.cpp:349 ../src/common/file.cpp:569
+msgid "Failed to set temporary file permissions"
+msgstr "Невозможно установить разрешения временному файлу"
+
+#: ../src/common/ffile.cpp:371
+#, c-format
+msgid "can't remove file '%s'"
+msgstr "ошибка удаления файла '%s'"
+
+#: ../src/common/ffile.cpp:376 ../src/common/file.cpp:591
+#, c-format
+msgid "can't commit changes to file '%s'"
+msgstr "невозможно записать изменения в файл '%s'"
+
+#: ../src/common/ffile.cpp:388 ../src/common/file.cpp:603
+#, c-format
+msgid "can't remove temporary file '%s'"
+msgstr "ошибка удаления временного файла '%s'"
+
+#: ../src/common/file.cpp:162
+#, c-format
+msgid "can't create file '%s'"
+msgstr "невозможно создать файл '%s'"
+
+#: ../src/common/file.cpp:229
+#, c-format
+msgid "can't close file descriptor %d"
+msgstr "невозможно закрыть дескриптор файла %d"
+
+#: ../src/common/file.cpp:332
+#, c-format
+msgid "can't read from file descriptor %d"
+msgstr "ошибка чтения файла с дескриптором %d"
+
+#: ../src/common/file.cpp:351
+#, c-format
+msgid "can't write to file descriptor %d"
+msgstr "невозможно записать в файл с дескриптором %d"
+
+#: ../src/common/file.cpp:390
+#, c-format
+msgid "can't flush file descriptor %d"
+msgstr "невозможно сбросить буфер файла с дескриптором %d"
+
+#: ../src/common/file.cpp:432
+#, c-format
+msgid "can't seek on file descriptor %d"
+msgstr "невозможно переместиться по файлу с дескриптором %d"
+
+#: ../src/common/file.cpp:446
+#, c-format
+msgid "can't get seek position on file descriptor %d"
+msgstr "невозможно получить текущую позицию файла с дескриптором %d"
+
+#: ../src/common/file.cpp:475
+#, c-format
+msgid "can't find length of file on file descriptor %d"
+msgstr "невозможно найти длину файла с дескриптором %d"
+
+#: ../src/common/file.cpp:505
+#, c-format
+msgid "can't determine if the end of file is reached on descriptor %d"
+msgstr "невозможно определить достижение конца файла с дескриптором %d"
+
+#: ../src/common/fileconf.cpp:352
+#, c-format
+msgid ""
+" and additionally, the existing configuration file was renamed to \"%s\" and "
+"couldn't be renamed back, please rename it to its original path \"%s\""
+msgstr ""
+
+#: ../src/common/fileconf.cpp:389
+#, fuzzy
+msgid " due to the following error:\n"
+msgstr "И включает в себя следующие файлы:\n"
+
+#: ../src/common/fileconf.cpp:412
+#, fuzzy
+msgid "failed to rename the existing file"
+msgstr "Не удалось прочесть документ из файла \"%s\"."
+
+#: ../src/common/fileconf.cpp:421
+#, fuzzy
+msgid "failed to create the new file directory"
+msgstr "Не удалось получить рабочий каталог"
+
+#: ../src/common/fileconf.cpp:428
+#, fuzzy
+msgid "failed to move the file to the new location"
+msgstr "Не удалось завершить модемное подключение: %s"
+
+#: ../src/common/fileconf.cpp:462
+#, c-format
+msgid "can't open global configuration file '%s'."
+msgstr "невозможно открыть глобальный файл конфигурации '%s'."
+
+#: ../src/common/fileconf.cpp:478
+#, c-format
+msgid "can't open user configuration file '%s'."
+msgstr "невозможно открыть файл конфигурации пользователя '%s'."
+
+#: ../src/common/fileconf.cpp:483
+#, c-format
+msgid "Changes won't be saved to avoid overwriting the existing file \"%s\""
+msgstr ""
+"Изменения не будут сохранены во избежание перезаписи существующего файла '%s'"
+
+#: ../src/common/fileconf.cpp:583
+msgid "Error reading config options."
+msgstr "Ошибка чтения параметров настройки."
+
+#: ../src/common/fileconf.cpp:593
+msgid "Failed to read config options."
+msgstr "Не удалось прочесть параметры конфигурации."
+
+#: ../src/common/fileconf.cpp:700
+#, c-format
+msgid "file '%s': unexpected character %c at line %zu."
+msgstr "файл '%s': непредвиденный символ %c в строке %zu."
+
+#: ../src/common/fileconf.cpp:736
+#, c-format
+msgid "file '%s', line %zu: '%s' ignored after group header."
+msgstr "файл '%s', строка %zu: '%s' игнорируется после заголовка группы."
+
+#: ../src/common/fileconf.cpp:765
+#, c-format
+msgid "file '%s', line %zu: '=' expected."
+msgstr "файл '%s', строка %zu: '=' ожидается."
+
+#: ../src/common/fileconf.cpp:778
+#, c-format
+msgid "file '%s', line %zu: value for immutable key '%s' ignored."
+msgstr ""
+"файл '%s', строка %zu: значение для неизменяемого ключа '%s' игнорируется."
+
+#: ../src/common/fileconf.cpp:788
+#, c-format
+msgid "file '%s', line %zu: key '%s' was first found at line %d."
+msgstr "файл '%s', строка %zu: ключ '%s' был впервые найден в строке %d."
+
+#: ../src/common/fileconf.cpp:1091
+#, c-format
+msgid "Config entry name cannot start with '%c'."
+msgstr "Имя поля в файле конфигурации не может начинаться с '%c'."
+
+#: ../src/common/fileconf.cpp:1146
+#, fuzzy
+msgid "Failed to create configuration file directory."
+msgstr "Не удалось обновить пользовательский файл конфигурации."
+
+#: ../src/common/fileconf.cpp:1158
+msgid "can't open user configuration file."
+msgstr "невозможно открыть файл конфигурации пользователя."
+
+#: ../src/common/fileconf.cpp:1172
+msgid "can't write user configuration file."
+msgstr "невозможно записать файл конфигурации пользователя."
+
+#: ../src/common/fileconf.cpp:1178
+msgid "Failed to update user configuration file."
+msgstr "Не удалось обновить пользовательский файл конфигурации."
+
+#: ../src/common/fileconf.cpp:1201
+msgid "Error saving user configuration data."
+msgstr "Ошибка сохранения данных конфигурации пользователя."
+
+#: ../src/common/fileconf.cpp:1313
+#, c-format
+msgid "can't delete user configuration file '%s'"
+msgstr "невозможно удалить файл конфигурации пользователя '%s'"
+
+#: ../src/common/fileconf.cpp:2007
+#, c-format
+msgid "entry '%s' appears more than once in group '%s'"
+msgstr "запись '%s' появляется более одного раза в группе '%s'"
+
+#: ../src/common/fileconf.cpp:2021
+#, c-format
+msgid "attempt to change immutable key '%s' ignored."
+msgstr "попытка изменить неизменяемый ключ '%s' проигнорирована."
+
+#: ../src/common/fileconf.cpp:2118
+#, c-format
+msgid "trailing backslash ignored in '%s'"
+msgstr "косая черта в '%s' игнорируется"
+
+#: ../src/common/fileconf.cpp:2153
+#, c-format
+msgid "unexpected \" at position %d in '%s'."
+msgstr "неожиданный \" в позиции %d в '%s'."
+
+#: ../src/common/filefn.cpp:474
+#, c-format
+msgid "Failed to copy the file '%s' to '%s'"
+msgstr "Сбой копирования файла '%s' в '%s'."
+
+#: ../src/common/filefn.cpp:487
+#, c-format
+msgid "Impossible to get permissions for file '%s'"
+msgstr "Невозможно получить разрешения файла '%s'"
+
+#: ../src/common/filefn.cpp:501
+#, c-format
+msgid "Impossible to overwrite the file '%s'"
+msgstr "Невозможно переписать файл '%s'"
+
+#: ../src/common/filefn.cpp:508
+#, c-format
+msgid "Error copying the file '%s' to '%s'."
+msgstr "Ошибка копирования файла '%s' в '%s'."
+
+#: ../src/common/filefn.cpp:556
+#, c-format
+msgid "Impossible to set permissions for the file '%s'"
+msgstr "Невозможно установить разрешения файлу '%s'"
+
+#: ../src/common/filefn.cpp:606
+#, c-format
+msgid ""
+"Failed to rename the file '%s' to '%s' because the destination file already "
+"exists."
+msgstr ""
+"Не удалось переименовать файл '%s' в '%s' - файл назначения уже существует."
+
+#: ../src/common/filefn.cpp:623
+#, c-format
+msgid "File '%s' couldn't be renamed '%s'"
+msgstr "Файл '%s' не может быть переименован в '%s'"
+
+#: ../src/common/filefn.cpp:639
+#, c-format
+msgid "File '%s' couldn't be removed"
+msgstr "Не удалось записать в файл: %s"
+
+#: ../src/common/filefn.cpp:666
+#, c-format
+msgid "Directory '%s' couldn't be created"
+msgstr "Не удалось создать каталог  '%s'"
+
+#: ../src/common/filefn.cpp:680
+#, c-format
+msgid "Directory '%s' couldn't be deleted"
+msgstr "Не удалось удалить каталог  '%s'"
+
+#: ../src/common/filefn.cpp:714
+#, c-format
+msgid "Cannot enumerate files '%s'"
+msgstr "Не удаётся перечислить файлы '%s'"
+
+#: ../src/common/filefn.cpp:798
+msgid "Failed to get the working directory"
+msgstr "Не удалось получить рабочий каталог"
+
+#: ../src/common/filefn.cpp:843
+msgid "Could not set current working directory"
+msgstr "Не удалось установить текущий рабочий каталог"
+
+#: ../src/common/filefn.cpp:974
+#, c-format
+msgid "Files (%s)"
+msgstr "Файлы (%s)"
+
+#: ../src/common/filename.cpp:182
+#, c-format
+msgid "Failed to open '%s' for reading"
+msgstr "Не удалось открыть '%s' для чтения"
+
+#: ../src/common/filename.cpp:187
+#, c-format
+msgid "Failed to open '%s' for writing"
+msgstr "Не удалось открыть '%s' для записи"
+
+#: ../src/common/filename.cpp:199
+msgid "Failed to close file handle"
+msgstr "Не удалось закрыть дескриптор файла"
+
+#: ../src/common/filename.cpp:1046
+msgid "Failed to create a temporary file name"
+msgstr "Сбой формирования имени временного файла"
+
+#: ../src/common/filename.cpp:1081
+msgid "Failed to open temporary file."
+msgstr "Не удалось открыть временный файл."
+
+#: ../src/common/filename.cpp:2862
+#, c-format
+msgid "Failed to modify file times for '%s'"
+msgstr "Ошибка изменения времени файла '%s'"
+
+#: ../src/common/filename.cpp:2877
+#, c-format
+msgid "Failed to touch the file '%s'"
+msgstr "Не удалось открыть файл '%s'"
+
+#: ../src/common/filename.cpp:2958
+#, c-format
+msgid "Failed to retrieve file times for '%s'"
+msgstr "Не удалось извлечь время файла '%s'"
+
+#: ../src/common/filepickercmn.cpp:39 ../src/common/filepickercmn.cpp:40
+msgid "Browse"
+msgstr "Обзор"
+
+#: ../src/common/fldlgcmn.cpp:792 ../src/generic/filectrlg.cpp:1185
+#, c-format
+msgid "All files (%s)|%s"
+msgstr "Все файлы (%s)|%s"
+
+#. TRANSLATORS: %s are a file extension used to build a file wildcard string
+#: ../src/common/fldlgcmn.cpp:810
+#, c-format
+msgid "%s files (%s)|%s"
+msgstr "%s файлы (%s)|%s"
+
+#: ../src/common/fldlgcmn.cpp:1072
+#, c-format
+msgid "Load %s file"
+msgstr "Загрузить файл %s"
+
+#: ../src/common/fldlgcmn.cpp:1074
+#, c-format
+msgid "Save %s file"
+msgstr "Сохранить файл %s"
+
+#: ../src/common/fmapbase.cpp:144
+msgid "Western European (ISO-8859-1)"
+msgstr "Западно-европейский (ISO-8859-1)"
+
+#: ../src/common/fmapbase.cpp:145
+msgid "Central European (ISO-8859-2)"
+msgstr "Центрально-европейский (ISO-8859-2)"
+
+#: ../src/common/fmapbase.cpp:146
+msgid "Esperanto (ISO-8859-3)"
+msgstr "Эсперанто (ISO-8859-3)"
+
+#: ../src/common/fmapbase.cpp:147
+msgid "Baltic (old) (ISO-8859-4)"
+msgstr "Балтийский (старый) (ISO-8859-4)"
+
+#: ../src/common/fmapbase.cpp:148
+msgid "Cyrillic (ISO-8859-5)"
+msgstr "Кириллица (ISO-8859-5)"
+
+#: ../src/common/fmapbase.cpp:149
+msgid "Arabic (ISO-8859-6)"
+msgstr "Арабский (ISO-8859-6)"
+
+#: ../src/common/fmapbase.cpp:150
+msgid "Greek (ISO-8859-7)"
+msgstr "Греческий (ISO-8859-7)"
+
+#: ../src/common/fmapbase.cpp:151
+msgid "Hebrew (ISO-8859-8)"
+msgstr "Иврит (ISO-8859-8)"
+
+#: ../src/common/fmapbase.cpp:152
+msgid "Turkish (ISO-8859-9)"
+msgstr "Турецкий (ISO-8859-9)"
+
+#: ../src/common/fmapbase.cpp:153
+msgid "Nordic (ISO-8859-10)"
+msgstr "Скандинавский (ISO-8859-10)"
+
+#: ../src/common/fmapbase.cpp:154
+msgid "Thai (ISO-8859-11)"
+msgstr "Тайский (ISO-8859-11)"
+
+#: ../src/common/fmapbase.cpp:155
+msgid "Indian (ISO-8859-12)"
+msgstr "Индийский (ISO-8859-12)"
+
+#: ../src/common/fmapbase.cpp:156
+msgid "Baltic (ISO-8859-13)"
+msgstr "Балтийский (ISO-8859-13)"
+
+#: ../src/common/fmapbase.cpp:157
+msgid "Celtic (ISO-8859-14)"
+msgstr "Кельтский (ISO-8859-14)"
+
+#: ../src/common/fmapbase.cpp:158
+msgid "Western European with Euro (ISO-8859-15)"
+msgstr "Западно-европейский с символом Евро (ISO-8859-15)"
+
+#: ../src/common/fmapbase.cpp:159
+msgid "KOI8-R"
+msgstr "KOI8-R"
+
+#: ../src/common/fmapbase.cpp:160
+msgid "KOI8-U"
+msgstr "KOI8-U"
+
+#: ../src/common/fmapbase.cpp:161
+msgid "Windows/DOS OEM Cyrillic (CP 866)"
+msgstr "Кириллица Windows/DOS OEM (CP 866)"
+
+#: ../src/common/fmapbase.cpp:162
+msgid "Windows Thai (CP 874)"
+msgstr "Тайский Windows (CP 874)"
+
+#: ../src/common/fmapbase.cpp:163
+msgid "Windows Japanese (CP 932) or Shift-JIS"
+msgstr "Японский Windows (CP 932) или Shift-JIS"
+
+#: ../src/common/fmapbase.cpp:164
+msgid "Windows Chinese Simplified (CP 936) or GB-2312"
+msgstr "Китайский упрощенный Windows (CP 936) или GB-2312"
+
+#: ../src/common/fmapbase.cpp:165
+msgid "Windows Korean (CP 949)"
+msgstr "Корейский Windows (CP 949)"
+
+#: ../src/common/fmapbase.cpp:166
+msgid "Windows Chinese Traditional (CP 950) or Big-5"
+msgstr "Китайский традиционный Windows (CP 950) или Big-5"
+
+#: ../src/common/fmapbase.cpp:167
+msgid "Windows Central European (CP 1250)"
+msgstr "Центрально-европейский Windows (CP 1250)"
+
+#: ../src/common/fmapbase.cpp:168
+msgid "Windows Cyrillic (CP 1251)"
+msgstr "Кириллица Windows (CP 1251)"
+
+#: ../src/common/fmapbase.cpp:169
+msgid "Windows Western European (CP 1252)"
+msgstr "Западно-европейский Windows (CP 1252)"
+
+#: ../src/common/fmapbase.cpp:170
+msgid "Windows Greek (CP 1253)"
+msgstr "Греческий Windows (CP 1253)"
+
+#: ../src/common/fmapbase.cpp:171
+msgid "Windows Turkish (CP 1254)"
+msgstr "Турецкий Windows (CP 1254)"
+
+#: ../src/common/fmapbase.cpp:172
+msgid "Windows Hebrew (CP 1255)"
+msgstr "Иврит Windows (CP 1255)"
+
+#: ../src/common/fmapbase.cpp:173
+msgid "Windows Arabic (CP 1256)"
+msgstr "Арабский Windows (CP 1256)"
+
+#: ../src/common/fmapbase.cpp:174
+msgid "Windows Baltic (CP 1257)"
+msgstr "Балтийский Windows (CP 1257)"
+
+#: ../src/common/fmapbase.cpp:175
+msgid "Windows Vietnamese (CP 1258)"
+msgstr "Вьетнамский Windows (CP 1258)"
+
+#: ../src/common/fmapbase.cpp:176
+msgid "Windows Johab (CP 1361)"
+msgstr "Windows Johab (CP 1361)"
+
+#: ../src/common/fmapbase.cpp:177
+msgid "Windows/DOS OEM (CP 437)"
+msgstr "Windows/DOS OEM (CP 437)"
+
+#: ../src/common/fmapbase.cpp:178
+msgid "Unicode 7 bit (UTF-7)"
+msgstr "7-бит юникод (UTF-7)"
+
+#: ../src/common/fmapbase.cpp:179
+msgid "Unicode 8 bit (UTF-8)"
+msgstr "8-бит юникод (UTF-8)"
+
+#: ../src/common/fmapbase.cpp:181 ../src/common/fmapbase.cpp:187
+msgid "Unicode 16 bit (UTF-16)"
+msgstr "16-бит юникод (UTF-16)"
+
+#: ../src/common/fmapbase.cpp:182
+msgid "Unicode 16 bit Little Endian (UTF-16LE)"
+msgstr "16-бит юникод Little Endian (UTF-16LE)"
+
+#: ../src/common/fmapbase.cpp:183 ../src/common/fmapbase.cpp:189
+msgid "Unicode 32 bit (UTF-32)"
+msgstr "32-бит юникод (UTF-32)"
+
+#: ../src/common/fmapbase.cpp:184
+msgid "Unicode 32 bit Little Endian (UTF-32LE)"
+msgstr "32-бит юникод Little Endian (UTF-32LE)"
+
+#: ../src/common/fmapbase.cpp:186
+msgid "Unicode 16 bit Big Endian (UTF-16BE)"
+msgstr "16-бит юникод Big Endian (UTF-16BE)"
+
+#: ../src/common/fmapbase.cpp:188
+msgid "Unicode 32 bit Big Endian (UTF-32BE)"
+msgstr "32-бит юникод Big Endian (UTF-32BE)"
+
+#: ../src/common/fmapbase.cpp:191
+msgid "Extended Unix Codepage for Japanese (EUC-JP)"
+msgstr "Расширенная кодировка Unix для Японского (EUC-JP)"
+
+#: ../src/common/fmapbase.cpp:192
+msgid "US-ASCII"
+msgstr "US-ASCII"
+
+#: ../src/common/fmapbase.cpp:193
+msgid "ISO-2022-JP"
+msgstr "ISO-2022-JP"
+
+#: ../src/common/fmapbase.cpp:195
+msgid "MacRoman"
+msgstr "MacRoman"
+
+#: ../src/common/fmapbase.cpp:196
+msgid "MacJapanese"
+msgstr "MacJapanese"
+
+#: ../src/common/fmapbase.cpp:197
+msgid "MacChineseTrad"
+msgstr "MacChineseTrad"
+
+#: ../src/common/fmapbase.cpp:198
+msgid "MacKorean"
+msgstr "MacKorean"
+
+#: ../src/common/fmapbase.cpp:199
+msgid "MacArabic"
+msgstr "MacArabic"
+
+#: ../src/common/fmapbase.cpp:200
+msgid "MacHebrew"
+msgstr "MacHebrew"
+
+#: ../src/common/fmapbase.cpp:201
+msgid "MacGreek"
+msgstr "MacGreek"
+
+#: ../src/common/fmapbase.cpp:202
+msgid "MacCyrillic"
+msgstr "MacCyrillic"
+
+#: ../src/common/fmapbase.cpp:203
+msgid "MacDevanagari"
+msgstr "MacDevanagari"
+
+#: ../src/common/fmapbase.cpp:204
+msgid "MacGurmukhi"
+msgstr "MacGurmukhi"
+
+#: ../src/common/fmapbase.cpp:205
+msgid "MacGujarati"
+msgstr "MacGujarati"
+
+#: ../src/common/fmapbase.cpp:206
+msgid "MacOriya"
+msgstr "MacOriya"
+
+#: ../src/common/fmapbase.cpp:207
+msgid "MacBengali"
+msgstr "MacBengali"
+
+#: ../src/common/fmapbase.cpp:208
+msgid "MacTamil"
+msgstr "MacTamil"
+
+#: ../src/common/fmapbase.cpp:209
+msgid "MacTelugu"
+msgstr "MacTelugu"
+
+#: ../src/common/fmapbase.cpp:210
+msgid "MacKannada"
+msgstr "MacKannada"
+
+#: ../src/common/fmapbase.cpp:211
+msgid "MacMalayalam"
+msgstr "MacMalayalam"
+
+#: ../src/common/fmapbase.cpp:212
+msgid "MacSinhalese"
+msgstr "MacSinhalese"
+
+#: ../src/common/fmapbase.cpp:213
+msgid "MacBurmese"
+msgstr "MacBurmese"
+
+#: ../src/common/fmapbase.cpp:214
+msgid "MacKhmer"
+msgstr "MacKhmer"
+
+#: ../src/common/fmapbase.cpp:215
+msgid "MacThai"
+msgstr "MacThai"
+
+#: ../src/common/fmapbase.cpp:216
+msgid "MacLaotian"
+msgstr "MacLaotian"
+
+#: ../src/common/fmapbase.cpp:217
+msgid "MacGeorgian"
+msgstr "MacGeorgian"
+
+#: ../src/common/fmapbase.cpp:218
+msgid "MacArmenian"
+msgstr "MacArmenian"
+
+#: ../src/common/fmapbase.cpp:219
+msgid "MacChineseSimp"
+msgstr "MacChineseSimp"
+
+#: ../src/common/fmapbase.cpp:220
+msgid "MacTibetan"
+msgstr "MacTibetan"
+
+#: ../src/common/fmapbase.cpp:221
+msgid "MacMongolian"
+msgstr "MacMongolian"
+
+#: ../src/common/fmapbase.cpp:222
+msgid "MacEthiopic"
+msgstr "MacEthiopic"
+
+#: ../src/common/fmapbase.cpp:223
+msgid "MacCentralEurRoman"
+msgstr "MacCentralEurRoman"
+
+#: ../src/common/fmapbase.cpp:224
+msgid "MacVietnamese"
+msgstr "MacVietnamese"
+
+#: ../src/common/fmapbase.cpp:225
+msgid "MacExtArabic"
+msgstr "MacExtArabic"
+
+#: ../src/common/fmapbase.cpp:226
+msgid "MacSymbol"
+msgstr "MacSymbol"
+
+#: ../src/common/fmapbase.cpp:227
+msgid "MacDingbats"
+msgstr "MacDingbats"
+
+#: ../src/common/fmapbase.cpp:228
+msgid "MacTurkish"
+msgstr "MacTurkish"
+
+#: ../src/common/fmapbase.cpp:229
+msgid "MacCroatian"
+msgstr "MacCroatian"
+
+#: ../src/common/fmapbase.cpp:230
+msgid "MacIcelandic"
+msgstr "MacIcelandic"
+
+#: ../src/common/fmapbase.cpp:231
+msgid "MacRomanian"
+msgstr "MacRomanian"
+
+#: ../src/common/fmapbase.cpp:232
+msgid "MacCeltic"
+msgstr "MacCeltic"
+
+#: ../src/common/fmapbase.cpp:233
+msgid "MacGaelic"
+msgstr "MacGaelic"
+
+#: ../src/common/fmapbase.cpp:234
+msgid "MacKeyboardGlyphs"
+msgstr "MacKeyboardGlyphs"
+
+#: ../src/common/fmapbase.cpp:791
+msgid "Default encoding"
+msgstr "Кодировка по-умолчанию"
+
+#: ../src/common/fmapbase.cpp:805
+#, c-format
+msgid "Unknown encoding (%d)"
+msgstr "Неизвестная кодировка (%d)"
+
+#: ../src/common/fmapbase.cpp:815 ../src/richtext/richtextstyles.cpp:776
+msgid "default"
+msgstr "по-умолчанию"
+
+#: ../src/common/fmapbase.cpp:829
+#, c-format
+msgid "unknown-%d"
+msgstr "неизвестный-%d"
+
+#: ../src/common/fontcmn.cpp:924 ../src/common/fontcmn.cpp:1130
+msgid "underlined"
+msgstr "подчёркнутый"
+
+#: ../src/common/fontcmn.cpp:929
+msgid " strikethrough"
+msgstr " перечёркивание"
+
+#: ../src/common/fontcmn.cpp:942
+msgid " thin"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:946
+#, fuzzy
+msgid " extra light"
+msgstr " лёгкий"
+
+#: ../src/common/fontcmn.cpp:950
+msgid " light"
+msgstr " лёгкий"
+
+#: ../src/common/fontcmn.cpp:954
+msgid " medium"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:958
+#, fuzzy
+msgid " semi bold"
+msgstr " полужирный"
+
+#: ../src/common/fontcmn.cpp:962
+msgid " bold"
+msgstr " полужирный"
+
+#: ../src/common/fontcmn.cpp:966
+#, fuzzy
+msgid " extra bold"
+msgstr " полужирный"
+
+#: ../src/common/fontcmn.cpp:970
+msgid " heavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:974
+msgid " extra heavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:990
+msgid " italic"
+msgstr " курсив"
+
+#: ../src/common/fontcmn.cpp:1134
+msgid "strikethrough"
+msgstr "перечёркивание"
+
+#: ../src/common/fontcmn.cpp:1143
+msgid "thin"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1156
+#, fuzzy
+msgid "extralight"
+msgstr "светлый"
+
+#: ../src/common/fontcmn.cpp:1161
+msgid "light"
+msgstr "светлый"
+
+#: ../src/common/fontcmn.cpp:1169 ../src/richtext/richtextstyles.cpp:775
+msgid "normal"
+msgstr "нормальный"
+
+#: ../src/common/fontcmn.cpp:1174
+msgid "medium"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1179 ../src/common/fontcmn.cpp:1199
+#, fuzzy
+msgid "semibold"
+msgstr "жирный"
+
+#: ../src/common/fontcmn.cpp:1184
+msgid "bold"
+msgstr "жирный"
+
+#: ../src/common/fontcmn.cpp:1194
+#, fuzzy
+msgid "extrabold"
+msgstr "жирный"
+
+#: ../src/common/fontcmn.cpp:1204
+msgid "heavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1212
+msgid "extraheavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1217
+msgid "italic"
+msgstr "курсив"
+
+#: ../src/common/fontmap.cpp:195
+msgid ": unknown charset"
+msgstr ": неизвестный набор символов"
+
+#: ../src/common/fontmap.cpp:199
+#, c-format
+msgid ""
+"The charset '%s' is unknown. You may select\n"
+"another charset to replace it with or choose\n"
+"[Cancel] if it cannot be replaced"
+msgstr ""
+"Набор символов '%s' неизвестен. Вы можете выбрать\n"
+"вместо него другой набор или нажать [Отмена] \n"
+"если он не может быть заменён"
+
+#: ../src/common/fontmap.cpp:241
+#, c-format
+msgid "Failed to remember the encoding for the charset '%s'."
+msgstr "Не удалось запомнить кодировку для набора символов '%s'."
+
+#: ../src/common/fontmap.cpp:321
+msgid "can't load any font, aborting"
+msgstr "не удаётся загрузить любой шрифт, прерывая"
+
+#: ../src/common/fontmap.cpp:409
+msgid ": unknown encoding"
+msgstr ": неизвестная кодировка"
+
+#: ../src/common/fontmap.cpp:417
+#, c-format
+msgid ""
+"No font for displaying text in encoding '%s' found,\n"
+"but an alternative encoding '%s' is available.\n"
+"Do you want to use this encoding (otherwise you will have to choose another "
+"one)?"
+msgstr ""
+"Не найден шрифт для отображения текста в кодировке '%s',\n"
+"но доступна альтернативная кодировка '%s'.\n"
+"Хотите использовать эту кодировку (в противном случае надо выбрать другую)?"
+
+#: ../src/common/fontmap.cpp:422
+#, c-format
+msgid ""
+"No font for displaying text in encoding '%s' found.\n"
+"Would you like to select a font to be used for this encoding\n"
+"(otherwise the text in this encoding will not be shown correctly)?"
+msgstr ""
+"Не найден шрифт для отображения текста в кодировке '%s'.\n"
+"Хотите выбрать шрифт, который будет использоваться для этой кодировки\n"
+"(инаече текст в этой кодировке будет отображаться некорректно)?"
+
+#: ../src/common/fs_mem.cpp:169
+#, c-format
+msgid "Memory VFS already contains file '%s'!"
+msgstr "Память VFS уже содержит файл '%s'!"
+
+#: ../src/common/fs_mem.cpp:232
+#, c-format
+msgid "Trying to remove file '%s' from memory VFS, but it is not loaded!"
+msgstr "Попытка удаления файла '%s' из памяти VFS, но он не загружен!"
+
+#: ../src/common/fs_mem.cpp:262
+#, c-format
+msgid "Failed to store image '%s' to memory VFS!"
+msgstr "Не удалось сохранить изображение '%s' в памяти VFS!"
+
+#: ../src/common/ftp.cpp:197
+msgid "Timeout while waiting for FTP server to connect, try passive mode."
+msgstr ""
+"При ожидании подключения к FTP серверу возник тайм-аут, попробуйте пассивный "
+"режим."
+
+#: ../src/common/ftp.cpp:399
+#, c-format
+msgid "Failed to set FTP transfer mode to %s."
+msgstr "Не удалось установить режим передачи FTP в %s."
+
+#: ../src/common/ftp.cpp:400 ../src/richtext/richtextsymboldlg.cpp:432
+msgid "ASCII"
+msgstr "ASCII"
+
+#: ../src/common/ftp.cpp:400
+msgid "binary"
+msgstr "двоичный"
+
+#: ../src/common/ftp.cpp:608
+msgid "The FTP server doesn't support the PORT command."
+msgstr "Сервер FTP не поддерживает команду PORT."
+
+#: ../src/common/ftp.cpp:622
+msgid "The FTP server doesn't support passive mode."
+msgstr "Сервер FTP не поддерживает пассивный режим."
+
+#: ../src/common/gifdecod.cpp:822
+#, c-format
+msgid "Incorrect GIF frame size (%u, %d) for the frame #%u"
+msgstr "Неправильный GIF размер кадра (%u, %d) для frame #%u"
+
+#: ../src/common/glcmn.cpp:108
+msgid "Failed to allocate colour for OpenGL"
+msgstr "Не удалось разместить цвет для OpenGL"
+
+#: ../src/common/headerctrlcmn.cpp:57
+msgid "Please select the columns to show and define their order:"
+msgstr "Выберите колонки для отображения и определите их порядок:"
+
+#: ../src/common/headerctrlcmn.cpp:58
+msgid "Customize Columns"
+msgstr "Настроить столбцы"
+
+#: ../src/common/headerctrlcmn.cpp:304
+msgid "&Customize..."
+msgstr "&Настроить..."
+
+#: ../src/common/hyperlnkcmn.cpp:132
+#, fuzzy, c-format
+msgid "Failed to open URL \"%s\" in the default browser"
+msgstr "Не удалось открыть URL-адрес \"%s\" в браузере по умолчанию."
+
+#: ../src/common/iconbndl.cpp:195
+#, c-format
+msgid "Failed to load image %%d from file '%s'."
+msgstr "Не удалось загрузить изображение %%d из файла '%s'."
+
+#: ../src/common/iconbndl.cpp:203
+#, c-format
+msgid "Failed to load image %d from stream."
+msgstr "Не удалось загрузить изображение %d из потока."
+
+#: ../src/common/iconbndl.cpp:221
+#, c-format
+msgid "Failed to load icons from resource '%s'."
+msgstr "Не удалось загрузить значки из ресурса '%s'."
+
+#: ../src/common/imagbmp.cpp:97
+msgid "BMP: Couldn't save invalid image."
+msgstr "BMP: невозможно сохранить недействительное изображение."
+
+#: ../src/common/imagbmp.cpp:137
+msgid "BMP: wxImage doesn't have own wxPalette."
+msgstr "BMP: wxImage не имеет собственного wxPalette."
+
+#: ../src/common/imagbmp.cpp:243
+msgid "BMP: Couldn't write the file (Bitmap) header."
+msgstr "BMP: невозможно записать заголовок файла (Bitmap)."
+
+#: ../src/common/imagbmp.cpp:266
+msgid "BMP: Couldn't write the file (BitmapInfo) header."
+msgstr "BMP: невозможно записать заголовок файла (BitmapInfo)."
+
+#: ../src/common/imagbmp.cpp:353
+msgid "BMP: Couldn't write RGB color map."
+msgstr "BMP: невозможно записать цветовую карту RGB."
+
+#: ../src/common/imagbmp.cpp:487
+msgid "BMP: Couldn't write data."
+msgstr "BMP: невозможно записать данные."
+
+#: ../src/common/imagbmp.cpp:561 ../src/common/imagbmp.cpp:642
+msgid "BMP: Couldn't allocate memory."
+msgstr "BMP: невозможно выделить память."
+
+#: ../src/common/imagbmp.cpp:1041
+msgid "DIB Header: Image width > 32767 pixels for file."
+msgstr "Заголовок DIB: ширина изображения > 32767 пикселей для файла."
+
+#: ../src/common/imagbmp.cpp:1049
+msgid "DIB Header: Image height > 32767 pixels for file."
+msgstr "Заголовок DIB: высота изображения > 32767 пикселей для файла."
+
+#: ../src/common/imagbmp.cpp:1081
+msgid "DIB Header: Unknown bitdepth in file."
+msgstr "Заголовок DIB: неизвестная битовая глубина в файле."
+
+#: ../src/common/imagbmp.cpp:1156
+msgid "DIB Header: Unknown encoding in file."
+msgstr "Заголовок DIB: неизвестная кодировка файла."
+
+#: ../src/common/imagbmp.cpp:1165
+msgid "DIB Header: Encoding doesn't match bitdepth."
+msgstr "Заголовок DIB: кодировка не совпадает с битовойглубиной."
+
+#: ../src/common/imagbmp.cpp:1180
+#, c-format
+msgid "BMP Header: Invalid number of colors (%d)."
+msgstr ""
+
+#: ../src/common/imagbmp.cpp:1273
+msgid "Error in reading image DIB."
+msgstr "Ошибка при чтении изображения DIB."
+
+#: ../src/common/imagbmp.cpp:1294
+msgid "ICO: Error in reading mask DIB."
+msgstr "ICO: ошибка чтения маски DIB."
+
+#: ../src/common/imagbmp.cpp:1353
+msgid "ICO: Image too tall for an icon."
+msgstr "ICO: изображение слишком высоко для значка."
+
+#: ../src/common/imagbmp.cpp:1361
+msgid "ICO: Image too wide for an icon."
+msgstr "ICO: изображение слишком широкое для значка."
+
+#: ../src/common/imagbmp.cpp:1388 ../src/common/imagbmp.cpp:1488
+#: ../src/common/imagbmp.cpp:1503 ../src/common/imagbmp.cpp:1514
+#: ../src/common/imagbmp.cpp:1528 ../src/common/imagbmp.cpp:1576
+#: ../src/common/imagbmp.cpp:1591 ../src/common/imagbmp.cpp:1605
+#: ../src/common/imagbmp.cpp:1616
+msgid "ICO: Error writing the image file!"
+msgstr "ICO: ошибка записи файла изображения!"
+
+#: ../src/common/imagbmp.cpp:1701
+msgid "ICO: Invalid icon index."
+msgstr "ICO: неверный индекс значка."
+
+#: ../src/common/image.cpp:2410
+msgid "Image and mask have different sizes."
+msgstr "Изображение и маска имеют различные размеры."
+
+#: ../src/common/image.cpp:2418 ../src/common/image.cpp:2459
+msgid "No unused colour in image being masked."
+msgstr "Нет неиспользованного цвета в маскируемом изображении."
+
+#: ../src/common/image.cpp:2641
+#, c-format
+msgid "Failed to load bitmap \"%s\" from resources."
+msgstr "Не удалось загрузить растровое изображение '%s' из ресурсов."
+
+#: ../src/common/image.cpp:2650
+#, c-format
+msgid "Failed to load icon \"%s\" from resources."
+msgstr "Невозможно загрузить значок '%s' из ресурсов."
+
+#: ../src/common/image.cpp:2728 ../src/common/image.cpp:2747
+#, c-format
+msgid "Failed to load image from file \"%s\"."
+msgstr "Не удалось загрузить изображение из файла '%s'."
+
+#: ../src/common/image.cpp:2761
+#, c-format
+msgid "Can't save image to file '%s': unknown extension."
+msgstr ""
+"Невозможно сохранить изображение в файл '%s': неизвестное расширение файла."
+
+#: ../src/common/image.cpp:2869
+msgid "No handler found for image type."
+msgstr "Не найден обработчик для этого типа изображения."
+
+#: ../src/common/image.cpp:2877 ../src/common/image.cpp:3000
+#: ../src/common/image.cpp:3066
+#, c-format
+msgid "No image handler for type %d defined."
+msgstr "Не определён обработчик для изображения типа %d."
+
+#: ../src/common/image.cpp:2887
+#, c-format
+msgid "Image file is not of type %d."
+msgstr "Файл изображения не тип %d."
+
+#: ../src/common/image.cpp:2970
+msgid "Can't automatically determine the image format for non-seekable input."
+msgstr "Не удаётся автоопределить формат изображения для ввода без поиска."
+
+#: ../src/common/image.cpp:2988
+msgid "Unknown image data format."
+msgstr "Неизвестный формат данных изображения."
+
+#: ../src/common/image.cpp:3009
+#, c-format
+msgid "This is not a %s."
+msgstr "Это не %s."
+
+#: ../src/common/image.cpp:3032 ../src/common/image.cpp:3080
+#, c-format
+msgid "No image handler for type %s defined."
+msgstr "Не определён обработчик для изображения типа %s."
+
+#: ../src/common/image.cpp:3041
+#, c-format
+msgid "Image is not of type %s."
+msgstr "Изображение не тип %s."
+
+#: ../src/common/image.cpp:3509
+#, c-format
+msgid "Failed to check format of image file \"%s\"."
+msgstr "Не удалось проверить Формат файла изображения \"%s'."
+
+#: ../src/common/imaggif.cpp:124
+msgid "GIF: error in GIF image format."
+msgstr "GIF: ошибка в формате изображения GIF."
+
+#: ../src/common/imaggif.cpp:129
+msgid "GIF: not enough memory."
+msgstr "GIF: недостаточно памяти."
+
+#: ../src/common/imaggif.cpp:134
+msgid "GIF: data stream seems to be truncated."
+msgstr "GIF: поток данных кажется усечённым."
+
+#: ../src/common/imaggif.cpp:240
+msgid "Couldn't initialize GIF hash table."
+msgstr "Не удалось инициализировать хэш-таблицу GIF."
+
+#: ../src/common/imagiff.cpp:739
+msgid "IFF: error in IFF image format."
+msgstr "IFF: ошибка в формате изображения IFF."
+
+#: ../src/common/imagiff.cpp:742
+msgid "IFF: not enough memory."
+msgstr "IFF: недостаточно памяти."
+
+#: ../src/common/imagiff.cpp:745
+msgid "IFF: unknown error!!!"
+msgstr "IIF: неизвестная ошибка!!!"
+
+#: ../src/common/imagiff.cpp:755
+msgid "IFF: data stream seems to be truncated."
+msgstr "IFF: поток данных кажется усечённым."
+
+#: ../src/common/imagjpeg.cpp:258
+msgid "JPEG: Couldn't load - file is probably corrupted."
+msgstr "JPEG: невозможно загрузить - возможно файл повреждён."
+
+#: ../src/common/imagjpeg.cpp:437
+msgid "JPEG: Couldn't save image."
+msgstr "JPEG: невозможно сохранить изображение."
+
+#: ../src/common/imagpcx.cpp:439
+msgid "PCX: this is not a PCX file."
+msgstr "PCX: это не файл PCX."
+
+#: ../src/common/imagpcx.cpp:453
+msgid "PCX: image format unsupported"
+msgstr "PCX: формат изображения не поддерживается"
+
+#: ../src/common/imagpcx.cpp:454 ../src/common/imagpcx.cpp:477
+msgid "PCX: couldn't allocate memory"
+msgstr "PCX: не удалось выделить память"
+
+#: ../src/common/imagpcx.cpp:455
+msgid "PCX: version number too low"
+msgstr "PCX: номер версии слишком мал"
+
+#: ../src/common/imagpcx.cpp:456 ../src/common/imagpcx.cpp:478
+msgid "PCX: unknown error !!!"
+msgstr "PCX: неизвестная ошибка !!!"
+
+#: ../src/common/imagpcx.cpp:476
+msgid "PCX: invalid image"
+msgstr "PCX: недопустимое изображение"
+
+#: ../src/common/imagpng.cpp:385
+#, c-format
+msgid "Unknown PNG resolution unit %d"
+msgstr "Неизвестный блок разрешения PNG %d"
+
+#: ../src/common/imagpng.cpp:439
+msgid "Couldn't load a PNG image - file is corrupted or not enough memory."
+msgstr ""
+"Невозможно загрузить изображение PNG - возможно повреждён файл или "
+"недостаточно памяти."
+
+#: ../src/common/imagpng.cpp:513 ../src/common/imagpng.cpp:524
+#: ../src/common/imagpng.cpp:534
+msgid "Couldn't save PNG image."
+msgstr "Невозможно сохранить изображение PNG."
+
+#: ../src/common/imagpnm.cpp:71
+msgid "PNM: File format is not recognized."
+msgstr "PNM: формат файла не распознан."
+
+#: ../src/common/imagpnm.cpp:89
+msgid "PNM: Couldn't allocate memory."
+msgstr "PNM: не удалось выделить память."
+
+#: ../src/common/imagpnm.cpp:111 ../src/common/imagpnm.cpp:134
+#: ../src/common/imagpnm.cpp:156
+msgid "PNM: File seems truncated."
+msgstr "PNM: файл кажется усечённым."
+
+#: ../src/common/imagtiff.cpp:69
+#, c-format
+msgid " (in module \"%s\")"
+msgstr " (в модуле \"%s\")"
+
+#: ../src/common/imagtiff.cpp:304
+msgid "TIFF: Error loading image."
+msgstr "TIFF: ошибка загрузки изображения."
+
+#: ../src/common/imagtiff.cpp:314
+msgid "Invalid TIFF image index."
+msgstr "Недопустимый индекс изображения TIFF."
+
+#: ../src/common/imagtiff.cpp:358
+msgid "TIFF: Image size is abnormally big."
+msgstr "TIFF: размер изображения ненормально большой."
+
+#: ../src/common/imagtiff.cpp:372 ../src/common/imagtiff.cpp:385
+#: ../src/common/imagtiff.cpp:769
+msgid "TIFF: Couldn't allocate memory."
+msgstr "TIFF: не удалось выделить память."
+
+#: ../src/common/imagtiff.cpp:471
+msgid "TIFF: Error reading image."
+msgstr "TIFF: ошибка чтения изображения."
+
+#: ../src/common/imagtiff.cpp:532
+#, c-format
+msgid "Unknown TIFF resolution unit %d ignored"
+msgstr "Неизвестная единица разрешения TIFF %d игнорирована"
+
+#: ../src/common/imagtiff.cpp:611
+msgid "TIFF: Error saving image."
+msgstr "TIFF: ошибка сохранения изображения."
+
+#: ../src/common/imagtiff.cpp:868
+msgid "TIFF: Error writing image."
+msgstr "TIFF: ошибка записи изображения."
+
+#: ../src/common/imagtiff.cpp:881
+#, fuzzy
+msgid "TIFF: Error flushing data."
+msgstr "TIFF: ошибка сохранения изображения."
+
+#: ../src/common/imagwebp.cpp:56
+msgid "WebP: Invalid data (failed to get features)."
+msgstr ""
+
+#: ../src/common/imagwebp.cpp:65
+msgid "WebP: Allocating image memory failed."
+msgstr ""
+
+#: ../src/common/imagwebp.cpp:82
+msgid "WebP: Decoding RGBA image data failed."
+msgstr ""
+
+#: ../src/common/imagwebp.cpp:98
+msgid "WebP: Decoding RGB image data failed."
+msgstr ""
+
+#: ../src/common/imagwebp.cpp:113 ../src/common/imagwebp.cpp:201
+msgid "WebP: Allocating stream buffer failed."
+msgstr ""
+
+#: ../src/common/imagwebp.cpp:131
+#, fuzzy
+msgid "WebP: Failed to parse container data."
+msgstr "Не удалось установить данные буфера обмена."
+
+#: ../src/common/imagwebp.cpp:222
+#, fuzzy
+msgid "WebP: Error decoding animation."
+msgstr "Ошибка чтения параметров настройки."
+
+#: ../src/common/imagwebp.cpp:240
+msgid "WebP: Error getting next animation frame."
+msgstr ""
+
+#: ../src/common/init.cpp:172
+#, c-format
+msgid ""
+"Command line argument %d couldn't be converted to Unicode and will be "
+"ignored."
+msgstr ""
+"Аргумент командной строки %d не может быть преобразован в Юникод и "
+"проигнорирован."
+
+#: ../src/common/init.cpp:344
+msgid "Initialization failed in post init, aborting."
+msgstr "Сбой инициализации в post init, прерывание."
+
+#: ../src/common/intl.cpp:378
+#, c-format
+msgid "Cannot set locale to language \"%s\"."
+msgstr "Не удалось установить локали для языка \"%s\"."
+
+#: ../src/common/log.cpp:232
+msgid "Error: "
+msgstr "Ошибка: "
+
+#: ../src/common/log.cpp:236
+msgid "Warning: "
+msgstr "Предупреждение: "
+
+#: ../src/common/log.cpp:284
+msgid "The previous message repeated once."
+msgstr "Предыдущее сообщение повторено один раз."
+
+#: ../src/common/log.cpp:291
+#, c-format
+msgid "The previous message repeated %u time."
+msgid_plural "The previous message repeated %u times."
+msgstr[0] "Предыдущее сообщение повторено %u раз."
+msgstr[1] "Предыдущее сообщение повторено %u раза."
+msgstr[2] "Предыдущее сообщение повторено %u раз."
+
+#: ../src/common/log.cpp:319
+#, c-format
+msgid "Last repeated message (\"%s\", %u time) wasn't output"
+msgid_plural "Last repeated message (\"%s\", %u times) wasn't output"
+msgstr[0] "Последнее повторяющееся сообщение ('%s', %u раз) не выводится"
+msgstr[1] "Последнее повторяющееся сообщение ('%s', %u раза) не выводится"
+msgstr[2] "Последнее повторяющееся сообщение ('%s', %u раз) не выводится"
+
+#: ../src/common/log.cpp:435
+#, c-format
+msgid " (error %ld: %s)"
+msgstr " (ошибка %ld: %s)"
+
+#: ../src/common/lzmastream.cpp:121
+#, fuzzy
+msgid "Failed to allocate memory for LZMA decompression."
+msgstr "Не удалось разместить цвет для OpenGL"
+
+#: ../src/common/lzmastream.cpp:125
+#, c-format
+msgid "Failed to initialize LZMA decompression: unexpected error %u."
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:179
+msgid "input is not in XZ format"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:183
+msgid "input compressed using unknown XZ option"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:188
+msgid "input is corrupted"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:192
+#, fuzzy
+msgid "unknown decompression error"
+msgstr "ошибка распаковки"
+
+#: ../src/common/lzmastream.cpp:196
+#, fuzzy, c-format
+msgid "LZMA decompression error: %s"
+msgstr "ошибка распаковки"
+
+#: ../src/common/lzmastream.cpp:231
+#, fuzzy
+msgid "Failed to allocate memory for LZMA compression."
+msgstr "Не удалось разместить цвет для OpenGL"
+
+#: ../src/common/lzmastream.cpp:235
+#, c-format
+msgid "Failed to initialize LZMA compression: unexpected error %u."
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:267 ../src/common/lzmastream.cpp:342
+#: ../src/html/chm.cpp:336
+msgid "out of memory"
+msgstr "недостаточно памяти"
+
+#: ../src/common/lzmastream.cpp:276 ../src/common/lzmastream.cpp:346
+#, fuzzy
+msgid "unknown compression error"
+msgstr "ошибка сжатия"
+
+#: ../src/common/lzmastream.cpp:280
+#, fuzzy, c-format
+msgid "LZMA compression error: %s"
+msgstr "ошибка сжатия"
+
+#: ../src/common/lzmastream.cpp:350
+#, c-format
+msgid "LZMA compression error when flushing output: %s"
+msgstr ""
+
+#: ../src/common/mimecmn.cpp:167
+#, c-format
+msgid "Unmatched '{' in an entry for mime type %s."
+msgstr "Незакрытая скобка '{' в записи для mime типа %s."
+
+#: ../src/common/module.cpp:76
+#, c-format
+msgid "Circular dependency involving module \"%s\" detected."
+msgstr "Обнаружена циклическая зависимость с модулем '%s'."
+
+#: ../src/common/module.cpp:128
+#, c-format
+msgid "Dependency \"%s\" of module \"%s\" doesn't exist."
+msgstr "Зависимость \"%s\" модуль \"%s\" не существует."
+
+#: ../src/common/module.cpp:137
+#, c-format
+msgid "Module \"%s\" initialization failed"
+msgstr "Ошибка инициализации модуля '%s'"
+
+#: ../src/common/msgout.cpp:96
+msgid "Message"
+msgstr "Сообщение"
+
+#: ../src/common/paper.cpp:70
+msgid "Letter, 8 1/2 x 11 in"
+msgstr "Письмо, 8 1/2 x 11 дюйма"
+
+#: ../src/common/paper.cpp:71
+msgid "Legal, 8 1/2 x 14 in"
+msgstr "Правовая, 8 1/2 x 14 дюймов"
+
+#: ../src/common/paper.cpp:72
+msgid "A4 sheet, 210 x 297 mm"
+msgstr "Лист A4, 210 x 297 мм"
+
+#: ../src/common/paper.cpp:73
+msgid "C sheet, 17 x 22 in"
+msgstr "Лист C, 17 x 22 дюйма"
+
+#: ../src/common/paper.cpp:74
+msgid "D sheet, 22 x 34 in"
+msgstr "Лист D, 22 x 34 дюйма"
+
+#: ../src/common/paper.cpp:75
+msgid "E sheet, 34 x 44 in"
+msgstr "Лист E, 34 x 44 дюйма"
+
+#: ../src/common/paper.cpp:76
+msgid "Letter Small, 8 1/2 x 11 in"
+msgstr "Маленькое письмо 8 1/2 x 11 дюйма"
+
+#: ../src/common/paper.cpp:77
+msgid "Tabloid, 11 x 17 in"
+msgstr "Таблоид, 11 x 17  дюйма"
+
+#: ../src/common/paper.cpp:78
+msgid "Ledger, 17 x 11 in"
+msgstr "Леджер, 17 x 11 дюйма"
+
+#: ../src/common/paper.cpp:79
+msgid "Statement, 5 1/2 x 8 1/2 in"
+msgstr "Заявление, 5 1/2 x 8 1/2 дюйма"
+
+#: ../src/common/paper.cpp:80
+msgid "Executive, 7 1/4 x 10 1/2 in"
+msgstr "Исполнительный, 7 1/4 x 10 1/2 дюйма"
+
+#: ../src/common/paper.cpp:81
+msgid "A3 sheet, 297 x 420 mm"
+msgstr "Лист A3 297 x 420 мм"
+
+#: ../src/common/paper.cpp:82
+msgid "A4 small sheet, 210 x 297 mm"
+msgstr "Малый лист A4, 210 x 297 мм"
+
+#: ../src/common/paper.cpp:83
+msgid "A5 sheet, 148 x 210 mm"
+msgstr "Лист A5, 148 x 210 мм"
+
+#: ../src/common/paper.cpp:84
+msgid "B4 sheet, 250 x 354 mm"
+msgstr "Лист B4, 250 x 354 мм"
+
+#: ../src/common/paper.cpp:85
+msgid "B5 sheet, 182 x 257 millimeter"
+msgstr "Лист B5, 182 x 257 мм"
+
+#: ../src/common/paper.cpp:86
+msgid "Folio, 8 1/2 x 13 in"
+msgstr "Фолио, 8 1/2 x 13 дюймов"
+
+#: ../src/common/paper.cpp:87
+msgid "Quarto, 215 x 275 mm"
+msgstr "Кварто, 215 x 275 мм"
+
+#: ../src/common/paper.cpp:88
+msgid "10 x 14 in"
+msgstr "10 x 14 дюйма"
+
+#: ../src/common/paper.cpp:89
+msgid "11 x 17 in"
+msgstr "11 x 17 дюйма"
+
+#: ../src/common/paper.cpp:90
+msgid "Note, 8 1/2 x 11 in"
+msgstr "Примечание, 8 1/2 x 11 дюйма"
+
+#: ../src/common/paper.cpp:91
+msgid "#9 Envelope, 3 7/8 x 8 7/8 in"
+msgstr "Конверт #9, 3 7/8 x 8 7/8 дюйма"
+
+#: ../src/common/paper.cpp:92
+msgid "#10 Envelope, 4 1/8 x 9 1/2 in"
+msgstr "Конверт #10, 4 1/8 x 9 1/2 дюйма"
+
+#: ../src/common/paper.cpp:93
+msgid "#11 Envelope, 4 1/2 x 10 3/8 in"
+msgstr "Конверт #11, 4 1/2 x 10 3/8 дюйма"
+
+#: ../src/common/paper.cpp:94
+msgid "#12 Envelope, 4 3/4 x 11 in"
+msgstr "Конверт #12, 4 3/4 x 11 дюйма"
+
+#: ../src/common/paper.cpp:95
+msgid "#14 Envelope, 5 x 11 1/2 in"
+msgstr "Конверт #14, 5 x 11 1/2 дюйма"
+
+#: ../src/common/paper.cpp:96
+msgid "DL Envelope, 110 x 220 mm"
+msgstr "Конверт DL, 110 x 220 мм"
+
+#: ../src/common/paper.cpp:97
+msgid "C5 Envelope, 162 x 229 mm"
+msgstr "Конверт C5, 162 x 229 мм"
+
+#: ../src/common/paper.cpp:98
+msgid "C3 Envelope, 324 x 458 mm"
+msgstr "Конверт C3, 324 x 458 мм"
+
+#: ../src/common/paper.cpp:99
+msgid "C4 Envelope, 229 x 324 mm"
+msgstr "Конверт C4, 229 x 324 мм"
+
+#: ../src/common/paper.cpp:100
+msgid "C6 Envelope, 114 x 162 mm"
+msgstr "Конверт C6, 114 x 162 мм"
+
+#: ../src/common/paper.cpp:101
+msgid "C65 Envelope, 114 x 229 mm"
+msgstr "Конверт C65, 114 x 229 мм"
+
+#: ../src/common/paper.cpp:102
+msgid "B4 Envelope, 250 x 353 mm"
+msgstr "Конверт B4, 250 x 353 мм"
+
+#: ../src/common/paper.cpp:103
+msgid "B5 Envelope, 176 x 250 mm"
+msgstr "Конверт B5, 176 x 250 мм"
+
+#: ../src/common/paper.cpp:104
+msgid "B6 Envelope, 176 x 125 mm"
+msgstr "Конверт B6, 176 x 125 мм"
+
+#: ../src/common/paper.cpp:105
+msgid "Italy Envelope, 110 x 230 mm"
+msgstr "Итальянский конверт, 110 x 230 мм"
+
+#: ../src/common/paper.cpp:106
+msgid "Monarch Envelope, 3 7/8 x 7 1/2 in"
+msgstr "Конверт монарха, 3 7/8 x 7 1/2 дюйма"
+
+#: ../src/common/paper.cpp:107
+msgid "6 3/4 Envelope, 3 5/8 x 6 1/2 in"
+msgstr "Конверт 6 3/4, 3 5/8 x 6 1/2 дюйма"
+
+#: ../src/common/paper.cpp:108
+msgid "US Std Fanfold, 14 7/8 x 11 in"
+msgstr "US Std фальцованный, 14 7/8 x 11 дюйма"
+
+#: ../src/common/paper.cpp:109
+msgid "German Std Fanfold, 8 1/2 x 12 in"
+msgstr "Немецкий STD фальцованный, 8 1/2 x 12 дюйма"
+
+#: ../src/common/paper.cpp:110
+msgid "German Legal Fanfold, 8 1/2 x 13 in"
+msgstr "Немецкий правовой фальцованный, 8 1/2 x 13 дюйма"
+
+#: ../src/common/paper.cpp:112
+msgid "B4 (ISO) 250 x 353 mm"
+msgstr "B4 (ISO) 250 х 353 мм"
+
+#: ../src/common/paper.cpp:113
+msgid "Japanese Postcard 100 x 148 mm"
+msgstr "Японские открытки (100 x 148 мм"
+
+#: ../src/common/paper.cpp:114
+msgid "9 x 11 in"
+msgstr "9 x 11 дюймов"
+
+#: ../src/common/paper.cpp:115
+msgid "10 x 11 in"
+msgstr "10 x 11 дюймов"
+
+#: ../src/common/paper.cpp:116
+msgid "15 x 11 in"
+msgstr "15 x 11 дюймов"
+
+#: ../src/common/paper.cpp:117
+msgid "Envelope Invite 220 x 220 mm"
+msgstr "Конверт приглашение 220 x 220 мм"
+
+#: ../src/common/paper.cpp:118
+msgid "Letter Extra 9 1/2 x 12 in"
+msgstr "Письмо экстра 9 1/2 x 12 дюймов"
+
+#: ../src/common/paper.cpp:119
+msgid "Legal Extra 9 1/2 x 15 in"
+msgstr "Правовая экстра, 9 1/2 x 15 дюйма"
+
+#: ../src/common/paper.cpp:120
+msgid "Tabloid Extra 11.69 x 18 in"
+msgstr "Таблоид экстра 11,69 x 18  дюйма"
+
+#: ../src/common/paper.cpp:121
+msgid "A4 Extra 9.27 x 12.69 in"
+msgstr "A4 Экстра 9.27 x в 12.69"
+
+#: ../src/common/paper.cpp:122
+msgid "Letter Transverse 8 1/2 x 11 in"
+msgstr "Письмо поперечное 8 1/2 x 11 дюймов"
+
+#: ../src/common/paper.cpp:123
+msgid "A4 Transverse 210 x 297 mm"
+msgstr "A4 Поперечный 210 x 297 мм"
+
+#: ../src/common/paper.cpp:124
+msgid "Letter Extra Transverse 9.275 x 12 in"
+msgstr "Письмо экстра Поперечое 9.275 x 12 в"
+
+#: ../src/common/paper.cpp:125
+msgid "SuperA/SuperA/A4 227 x 356 mm"
+msgstr "СуперA/СуперA/A4 227 x 356 мм"
+
+#: ../src/common/paper.cpp:126
+msgid "SuperB/SuperB/A3 305 x 487 mm"
+msgstr "СуперB/СуперB/A3 305 x 487 мм"
+
+#: ../src/common/paper.cpp:127
+msgid "Letter Plus 8 1/2 x 12.69 in"
+msgstr "Письмо плюс 8 1/2 x 12.69 дюймов"
+
+#: ../src/common/paper.cpp:128
+msgid "A4 Plus 210 x 330 mm"
+msgstr "A4 Плюс 210 x 330 мм"
+
+#: ../src/common/paper.cpp:129
+msgid "A5 Transverse 148 x 210 mm"
+msgstr "A5 Поперечный 148 x 210 мм"
+
+#: ../src/common/paper.cpp:130
+msgid "B5 (JIS) Transverse 182 x 257 mm"
+msgstr "B5 (JIS) Поперечный 182 x 257 мм"
+
+#: ../src/common/paper.cpp:131
+msgid "A3 Extra 322 x 445 mm"
+msgstr "A3 Экстра 322 x 445 мм"
+
+#: ../src/common/paper.cpp:132
+msgid "A5 Extra 174 x 235 mm"
+msgstr "A5 Экстра 174 x 235 мм"
+
+#: ../src/common/paper.cpp:133
+msgid "B5 (ISO) Extra 201 x 276 mm"
+msgstr "B5 (ISO) Экстра 201 x 276 мм"
+
+#: ../src/common/paper.cpp:134
+msgid "A2 420 x 594 mm"
+msgstr "A2 420 х 594 мм"
+
+#: ../src/common/paper.cpp:135
+msgid "A3 Transverse 297 x 420 mm"
+msgstr "A3 Поперечный 297 x 420 мм"
+
+#: ../src/common/paper.cpp:136
+msgid "A3 Extra Transverse 322 x 445 mm"
+msgstr "A3 Экстра поперечный 322 x 445 мм"
+
+#: ../src/common/paper.cpp:138
+msgid "Japanese Double Postcard 200 x 148 mm"
+msgstr "Японская двойная открытка 200 x 148 мм"
+
+#: ../src/common/paper.cpp:139
+msgid "A6 105 x 148 mm"
+msgstr "A6 105 х 148 мм"
+
+#: ../src/common/paper.cpp:140
+msgid "Japanese Envelope Kaku #2"
+msgstr "Японский конверт Kaku #2"
+
+#: ../src/common/paper.cpp:141
+msgid "Japanese Envelope Kaku #3"
+msgstr "Японский конверт Kaku #3"
+
+#: ../src/common/paper.cpp:142
+msgid "Japanese Envelope Chou #3"
+msgstr "Японский конверт  Chou #3"
+
+#: ../src/common/paper.cpp:143
+msgid "Japanese Envelope Chou #4"
+msgstr "Японский конверт Chou #4"
+
+#: ../src/common/paper.cpp:144
+msgid "Letter Rotated 11 x 8 1/2 in"
+msgstr "Письмо повёрнуто 11 х 8 1/2 дюймов"
+
+#: ../src/common/paper.cpp:145
+msgid "A3 Rotated 420 x 297 mm"
+msgstr "A3 Повёрнут 420 х 297 мм"
+
+#: ../src/common/paper.cpp:146
+msgid "A4 Rotated 297 x 210 mm"
+msgstr "A4 Повёрнут 297 x 210 мм"
+
+#: ../src/common/paper.cpp:147
+msgid "A5 Rotated 210 x 148 mm"
+msgstr "A5 Повёрнут 210 х 148 мм"
+
+#: ../src/common/paper.cpp:148
+msgid "B4 (JIS) Rotated 364 x 257 mm"
+msgstr "B4 (JIS) Повёрнут 364 x 257 мм"
+
+#: ../src/common/paper.cpp:149
+msgid "B5 (JIS) Rotated 257 x 182 mm"
+msgstr "B5 (JIS) Повёрнут 257 x 182 мм"
+
+#: ../src/common/paper.cpp:150
+msgid "Japanese Postcard Rotated 148 x 100 mm"
+msgstr "Японская открытка повёрнута 148 x 100 мм"
+
+#: ../src/common/paper.cpp:151
+msgid "Double Japanese Postcard Rotated 148 x 200 mm"
+msgstr "Двухместный японская Открытка Повёрнута 148 x 200 мм"
+
+#: ../src/common/paper.cpp:152
+msgid "A6 Rotated 148 x 105 mm"
+msgstr "A6 Развёрнут 148 x 105 мм"
+
+#: ../src/common/paper.cpp:153
+msgid "Japanese Envelope Kaku #2 Rotated"
+msgstr "Японский конверт Kaku #2 Повёрнут"
+
+#: ../src/common/paper.cpp:154
+msgid "Japanese Envelope Kaku #3 Rotated"
+msgstr "Японский конверт Kaku #3 повёрнут"
+
+#: ../src/common/paper.cpp:155
+msgid "Japanese Envelope Chou #3 Rotated"
+msgstr "Японский конверт Chou #3 повёрнут"
+
+#: ../src/common/paper.cpp:156
+msgid "Japanese Envelope Chou #4 Rotated"
+msgstr "Японский конверт Chou #4 повёрнут"
+
+#: ../src/common/paper.cpp:157
+msgid "B6 (JIS) 128 x 182 mm"
+msgstr "В6 (JIS) 128 x 182 мм"
+
+#: ../src/common/paper.cpp:158
+msgid "B6 (JIS) Rotated 182 x 128 mm"
+msgstr "В6 (JIS) Повёрнут 182 x 128 мм"
+
+#: ../src/common/paper.cpp:159
+msgid "12 x 11 in"
+msgstr "12 x 11 дюймов"
+
+#: ../src/common/paper.cpp:160
+msgid "Japanese Envelope You #4"
+msgstr "Японский конверт You # 4"
+
+#: ../src/common/paper.cpp:161
+msgid "Japanese Envelope You #4 Rotated"
+msgstr "Японский конверт You #4 повёрнут"
+
+#: ../src/common/paper.cpp:162
+msgid "PRC 16K 146 x 215 mm"
+msgstr "КНР 16K 146 x 215 мм"
+
+#: ../src/common/paper.cpp:163
+msgid "PRC 32K 97 x 151 mm"
+msgstr "КНР 32K 97 x 151 мм"
+
+#: ../src/common/paper.cpp:164
+msgid "PRC 32K(Big) 97 x 151 mm"
+msgstr "КНР 32K(большой) : 97 x 151 мм"
+
+#: ../src/common/paper.cpp:165
+msgid "PRC Envelope #1 102 x 165 mm"
+msgstr "КНР Конверт №1 102 х 165 мм"
+
+#: ../src/common/paper.cpp:166
+msgid "PRC Envelope #2 102 x 176 mm"
+msgstr "КНР Конверт №2 102 x 176 мм"
+
+#: ../src/common/paper.cpp:167
+msgid "PRC Envelope #3 125 x 176 mm"
+msgstr "КНР Конверт №3 125 x 176 мм"
+
+#: ../src/common/paper.cpp:168
+msgid "PRC Envelope #4 110 x 208 mm"
+msgstr "КНР Конверт №4 110 x 208 мм"
+
+#: ../src/common/paper.cpp:169
+msgid "PRC Envelope #5 110 x 220 mm"
+msgstr "КНР Конверт №5 110 x 220 мм"
+
+#: ../src/common/paper.cpp:170
+msgid "PRC Envelope #6 120 x 230 mm"
+msgstr "КНР Конверт №6 120 x 230 мм"
+
+#: ../src/common/paper.cpp:171
+msgid "PRC Envelope #7 160 x 230 mm"
+msgstr "КНР Конверт №7 160 x 230 мм"
+
+#: ../src/common/paper.cpp:172
+msgid "PRC Envelope #8 120 x 309 mm"
+msgstr "КНР Конверт №8 120 x 309 мм"
+
+#: ../src/common/paper.cpp:173
+msgid "PRC Envelope #9 229 x 324 mm"
+msgstr "КНР Конверт №9 229 x 324 мм"
+
+#: ../src/common/paper.cpp:174
+msgid "PRC Envelope #10 324 x 458 mm"
+msgstr "КНР Конверт №10 324 х 458 мм"
+
+#: ../src/common/paper.cpp:175
+msgid "PRC 16K Rotated"
+msgstr "КНР 16K Повёрнут"
+
+#: ../src/common/paper.cpp:176
+msgid "PRC 32K Rotated"
+msgstr "КНР Повёрнут 32K"
+
+#: ../src/common/paper.cpp:177
+msgid "PRC 32K(Big) Rotated"
+msgstr "КНР 32K(большой) повёрнут"
+
+#: ../src/common/paper.cpp:178
+msgid "PRC Envelope #1 Rotated 165 x 102 mm"
+msgstr "КНР Конверт №1 повёрнут 165 x 102 мм"
+
+#: ../src/common/paper.cpp:179
+msgid "PRC Envelope #2 Rotated 176 x 102 mm"
+msgstr "КНР Конверт №2 повёрнут 176 102 мм"
+
+#: ../src/common/paper.cpp:180
+msgid "PRC Envelope #3 Rotated 176 x 125 mm"
+msgstr "КНР Конверт №3 повёрнут 176 x 125 мм"
+
+#: ../src/common/paper.cpp:181
+msgid "PRC Envelope #4 Rotated 208 x 110 mm"
+msgstr "КНР Конверт №4 повёрнут 208 x 110 мм"
+
+#: ../src/common/paper.cpp:182
+msgid "PRC Envelope #5 Rotated 220 x 110 mm"
+msgstr "КНР Конверт №5 повёрнут 220 x 110 мм"
+
+#: ../src/common/paper.cpp:183
+msgid "PRC Envelope #6 Rotated 230 x 120 mm"
+msgstr "КНР Конверт №6 повёрнут 230 x 120 мм"
+
+#: ../src/common/paper.cpp:184
+msgid "PRC Envelope #7 Rotated 230 x 160 mm"
+msgstr "КНР Конверт №7 повёрнут 230 х 160 мм"
+
+#: ../src/common/paper.cpp:185
+msgid "PRC Envelope #8 Rotated 309 x 120 mm"
+msgstr "КНР Конверт №8 повёрнут 309 x 120 мм"
+
+#: ../src/common/paper.cpp:186
+msgid "PRC Envelope #9 Rotated 324 x 229 mm"
+msgstr "КНР Конверт №9 повёрнут 324 x 229 мм"
+
+#: ../src/common/paper.cpp:187
+msgid "PRC Envelope #10 Rotated 458 x 324 mm"
+msgstr "КНР Конверт №10 повёрнут 458 x 324 мм"
+
+#: ../src/common/paper.cpp:192
+msgid "A0 sheet, 841 x 1189 mm"
+msgstr "A0 лист, 841 х 1189 мм"
+
+#: ../src/common/paper.cpp:193
+msgid "A1 sheet, 594 x 841 mm"
+msgstr "А1 лист, 594 х 841 мм"
+
+#: ../src/common/preferencescmn.cpp:37
+msgid "General"
+msgstr "Общие"
+
+#: ../src/common/preferencescmn.cpp:40
+msgid "Advanced"
+msgstr "Дополнительно"
+
+#: ../src/common/prntbase.cpp:245
+msgid "Generic PostScript"
+msgstr "Общий PostScript"
+
+#: ../src/common/prntbase.cpp:259
+msgid "Ready"
+msgstr "Готов"
+
+#: ../src/common/prntbase.cpp:331
+msgid "Printing Error"
+msgstr "Ошибка печати"
+
+#: ../src/common/prntbase.cpp:413 ../src/common/prntbase.cpp:1597
+#: ../src/generic/prntdlgg.cpp:135 ../src/generic/prntdlgg.cpp:149
+#: ../src/gtk/print.cpp:628 ../src/gtk/print.cpp:646
+msgid "Print"
+msgstr "Печать"
+
+#: ../src/common/prntbase.cpp:471 ../src/generic/prntdlgg.cpp:809
+msgid "Page setup"
+msgstr "Настройки страницы"
+
+#: ../src/common/prntbase.cpp:525
+msgid "Please wait while printing..."
+msgstr "Дождитесь окончания печати..."
+
+#: ../src/common/prntbase.cpp:529
+msgid "Document:"
+msgstr "Документ:"
+
+#: ../src/common/prntbase.cpp:532
+msgid "Progress:"
+msgstr "Выполнение:"
+
+#: ../src/common/prntbase.cpp:533
+msgid "Preparing"
+msgstr "Подготовка"
+
+#: ../src/common/prntbase.cpp:552
+#, c-format
+msgid "Printing page %d"
+msgstr "Печать страницы %d"
+
+#: ../src/common/prntbase.cpp:557
+#, c-format
+msgid "Printing page %d of %d"
+msgstr "Печать страницы %d из %d"
+
+#: ../src/common/prntbase.cpp:560
+#, c-format
+msgid " (copy %d of %d)"
+msgstr " (копия %d из %d)"
+
+#: ../src/common/prntbase.cpp:1604
+msgid "First page"
+msgstr "Первая страница"
+
+#: ../src/common/prntbase.cpp:1609 ../src/html/helpwnd.cpp:659
+msgid "Previous page"
+msgstr "Предыдущая страница"
+
+#: ../src/common/prntbase.cpp:1623 ../src/html/helpwnd.cpp:660
+msgid "Next page"
+msgstr "Следующая станица"
+
+#: ../src/common/prntbase.cpp:1628
+msgid "Last page"
+msgstr "Последняя станица"
+
+#: ../src/common/prntbase.cpp:1636 ../src/common/stockitem.cpp:215
+msgid "Zoom Out"
+msgstr "Уменьшить"
+
+#: ../src/common/prntbase.cpp:1650 ../src/common/stockitem.cpp:214
+msgid "Zoom In"
+msgstr "Увеличить"
+
+#: ../src/common/prntbase.cpp:1656 ../src/common/stockitem.cpp:153
+#: ../src/generic/logg.cpp:553 ../src/univ/themes/win32.cpp:3752
+msgid "&Close"
+msgstr "&Закрыть"
+
+#: ../src/common/prntbase.cpp:2085
+msgid "Could not start document preview."
+msgstr "Невозможно начать предпросмотр документа."
+
+#: ../src/common/prntbase.cpp:2085 ../src/common/prntbase.cpp:2129
+#: ../src/common/prntbase.cpp:2137
+msgid "Print Preview Failure"
+msgstr "Ошибка предпросмотра печати"
+
+#: ../src/common/prntbase.cpp:2129 ../src/common/prntbase.cpp:2137
+msgid "Sorry, not enough memory to create a preview."
+msgstr "Недостаточно памяти для создания окна предпросмотра."
+
+#: ../src/common/prntbase.cpp:2144
+#, c-format
+msgid "Page %d of %d"
+msgstr "Страница %d из %d"
+
+#: ../src/common/prntbase.cpp:2146
+#, c-format
+msgid "Page %d"
+msgstr "Страница %d"
+
+#: ../src/common/regex.cpp:382 ../src/html/chm.cpp:348
+msgid "unknown error"
+msgstr "неизвестная ошибка"
+
+#: ../src/common/regex.cpp:995
+#, c-format
+msgid "Invalid regular expression '%s': %s"
+msgstr "Неверное регулярное выражение '%s': %s"
+
+#: ../src/common/regex.cpp:1059
+#, c-format
+msgid "Failed to find match for regular expression: %s"
+msgstr "Не удалось найти соответствие для регулярного выражения: %s"
+
+#: ../src/common/rendcmn.cpp:188
+#, c-format
+msgid "Renderer \"%s\" has incompatible version %d.%d and couldn't be loaded."
+msgstr ""
+"Визуализатор '%s' имеет несовместимую версию %d.%d и не может быть загружен."
+
+#: ../src/common/secretstore.cpp:162
+msgid "Not available for this platform"
+msgstr ""
+
+#: ../src/common/secretstore.cpp:183
+#, fuzzy, c-format
+msgid "Saving password for \"%s\" failed: %s."
+msgstr "Не удалось сохранить пароль для  '%s/%s': %s."
+
+#: ../src/common/secretstore.cpp:205
+#, fuzzy, c-format
+msgid "Reading password for \"%s\" failed: %s."
+msgstr "Не удалось прочесть пароль для  '%s/%s': %s."
+
+#: ../src/common/secretstore.cpp:228
+#, fuzzy, c-format
+msgid "Deleting password for \"%s\" failed: %s."
+msgstr "Не удалось удалить пароль для  '%s/%s': %s."
+
+#: ../src/common/selectdispatcher.cpp:254
+msgid "Failed to monitor I/O channels"
+msgstr "Не удалось отследить каналы ввода-вывода"
+
+#: ../src/common/sizer.cpp:3054 ../src/common/stockitem.cpp:195
+msgid "Save"
+msgstr "Сохранить"
+
+#: ../src/common/sizer.cpp:3056
+msgid "Don't Save"
+msgstr "Не сохранять"
+
+#: ../src/common/socket.cpp:870
+msgid "Cannot initialize sockets"
+msgstr "Не удалось инициализировать сокеты"
+
+#: ../src/common/stockitem.cpp:127
+#, fuzzy
+msgctxt "standard Windows menu"
+msgid "&Help"
+msgstr "&Справка"
+
+#: ../src/common/stockitem.cpp:144
+msgid "&About"
+msgstr "&О программе"
+
+#: ../src/common/stockitem.cpp:144
+msgid "About"
+msgstr "О программе"
+
+#: ../src/common/stockitem.cpp:145
+msgid "Add"
+msgstr "Добавить"
+
+#: ../src/common/stockitem.cpp:146
+msgid "&Apply"
+msgstr "&Применить"
+
+#: ../src/common/stockitem.cpp:146
+msgid "Apply"
+msgstr "Применить"
+
+#: ../src/common/stockitem.cpp:147
+msgid "&Back"
+msgstr "&Назад"
+
+#: ../src/common/stockitem.cpp:147
+msgid "Back"
+msgstr "Назад"
+
+#: ../src/common/stockitem.cpp:148
+msgid "&Bold"
+msgstr "&Жирный"
+
+#: ../src/common/stockitem.cpp:148 ../src/generic/fontdlgg.cpp:326
+#: ../src/richtext/richtextfontpage.cpp:354
+msgid "Bold"
+msgstr "Жирный"
+
+#: ../src/common/stockitem.cpp:149
+msgid "&Bottom"
+msgstr "В&низу"
+
+#: ../src/common/stockitem.cpp:149 ../src/richtext/richtextsizepage.cpp:287
+msgid "Bottom"
+msgstr "Внизу"
+
+#: ../src/common/stockitem.cpp:150 ../src/generic/fontdlgg.cpp:462
+#: ../src/generic/fontdlgg.cpp:481 ../src/generic/wizard.cpp:415
+msgid "&Cancel"
+msgstr "&Отмена"
+
+#: ../src/common/stockitem.cpp:151
+#, fuzzy
+msgid "&CD-ROM"
+msgstr "&CD-Rom"
+
+#: ../src/common/stockitem.cpp:151
+#, fuzzy
+msgid "CD-ROM"
+msgstr "CD-Rom"
+
+#: ../src/common/stockitem.cpp:152
+msgid "&Clear"
+msgstr "О&чистить"
+
+#: ../src/common/stockitem.cpp:152
+msgid "Clear"
+msgstr "Очистить"
+
+#: ../src/common/stockitem.cpp:153 ../src/generic/dbgrptg.cpp:93
+#: ../src/generic/progdlgg.cpp:778 ../src/html/helpdlg.cpp:86
+#: ../src/msw/progdlg.cpp:209 ../src/msw/progdlg.cpp:890
+#: ../src/richtext/richtextstyledlg.cpp:272
+#: ../src/richtext/richtextsymboldlg.cpp:448
+msgid "Close"
+msgstr "Закрыть"
+
+#: ../src/common/stockitem.cpp:154
+msgid "&Convert"
+msgstr "&Конвертировать"
+
+#: ../src/common/stockitem.cpp:154
+msgid "Convert"
+msgstr "Преобразовать"
+
+#: ../src/common/stockitem.cpp:155 ../src/msw/textctrl.cpp:2884
+#: ../src/osx/textctrl_osx.cpp:653 ../src/richtext/richtextctrl.cpp:331
+msgid "&Copy"
+msgstr "&Копировать"
+
+#: ../src/common/stockitem.cpp:155 ../src/stc/stc_i18n.cpp:18
+msgid "Copy"
+msgstr "Копировать"
+
+#: ../src/common/stockitem.cpp:156 ../src/msw/textctrl.cpp:2883
+#: ../src/osx/textctrl_osx.cpp:652 ../src/richtext/richtextctrl.cpp:330
+msgid "Cu&t"
+msgstr "&Вырезать"
+
+#: ../src/common/stockitem.cpp:156 ../src/stc/stc_i18n.cpp:17
+msgid "Cut"
+msgstr "Вырезать"
+
+#: ../src/common/stockitem.cpp:157 ../src/msw/textctrl.cpp:2886
+#: ../src/osx/textctrl_osx.cpp:655 ../src/richtext/richtextctrl.cpp:333
+#: ../src/richtext/richtexttabspage.cpp:137
+msgid "&Delete"
+msgstr "&Удалить"
+
+#: ../src/common/stockitem.cpp:157 ../src/richtext/richtextbuffer.cpp:8266
+#: ../src/stc/stc_i18n.cpp:20
+msgid "Delete"
+msgstr "Удалить"
+
+#: ../src/common/stockitem.cpp:158
+msgid "&Down"
+msgstr "&Вниз"
+
+#: ../src/common/stockitem.cpp:158 ../src/generic/fdrepdlg.cpp:148
+msgid "Down"
+msgstr "Вниз"
+
+#: ../src/common/stockitem.cpp:159
+msgid "&Edit"
+msgstr "&Правка"
+
+#: ../src/common/stockitem.cpp:159
+msgid "Edit"
+msgstr "Правка"
+
+#: ../src/common/stockitem.cpp:160
+msgid "&Execute"
+msgstr "&Выполнить"
+
+#: ../src/common/stockitem.cpp:160
+msgid "Execute"
+msgstr "Выполнить"
+
+#: ../src/common/stockitem.cpp:161
+msgid "&Quit"
+msgstr "Вы&ход"
+
+#: ../src/common/stockitem.cpp:161
+msgid "Quit"
+msgstr "Выход"
+
+#: ../src/common/stockitem.cpp:162
+msgid "&File"
+msgstr "&Файл"
+
+#: ../src/common/stockitem.cpp:162
+msgid "File"
+msgstr "Файл"
+
+#: ../src/common/stockitem.cpp:163
+#, fuzzy
+msgid "&Find..."
+msgstr "&Найти"
+
+#: ../src/common/stockitem.cpp:163
+#, fuzzy
+msgid "Find..."
+msgstr "Найти"
+
+#: ../src/common/stockitem.cpp:164
+msgid "&First"
+msgstr "&Первый"
+
+#: ../src/common/stockitem.cpp:164
+msgid "First"
+msgstr "Первый"
+
+#: ../src/common/stockitem.cpp:165
+msgid "&Floppy"
+msgstr "&Дискета"
+
+#: ../src/common/stockitem.cpp:165
+msgid "Floppy"
+msgstr "Дискета"
+
+#: ../src/common/stockitem.cpp:166
+msgid "&Forward"
+msgstr "&Вперёд"
+
+#: ../src/common/stockitem.cpp:166
+msgid "Forward"
+msgstr "Вперёд"
+
+#: ../src/common/stockitem.cpp:167
+msgid "&Harddisk"
+msgstr "&Жёсткий диск"
+
+#: ../src/common/stockitem.cpp:167
+msgid "Harddisk"
+msgstr "Жёсткий диск"
+
+#: ../src/common/stockitem.cpp:168 ../src/generic/wizard.cpp:418
+#: ../src/osx/cocoa/menu.mm:225 ../src/richtext/richtextstyledlg.cpp:298
+#: ../src/richtext/richtextsymboldlg.cpp:451
+msgid "&Help"
+msgstr "&Справка"
+
+#: ../src/common/stockitem.cpp:169
+msgid "&Home"
+msgstr "В &начало"
+
+#: ../src/common/stockitem.cpp:169
+msgid "Home"
+msgstr "В начало"
+
+#: ../src/common/stockitem.cpp:170
+msgid "Indent"
+msgstr "Отступ"
+
+#: ../src/common/stockitem.cpp:171
+msgid "&Index"
+msgstr "&Индекс"
+
+#: ../src/common/stockitem.cpp:171 ../src/html/helpwnd.cpp:510
+msgid "Index"
+msgstr "Индекс"
+
+#: ../src/common/stockitem.cpp:172
+msgid "&Info"
+msgstr "&Инфо"
+
+#: ../src/common/stockitem.cpp:172
+msgid "Info"
+msgstr "Инфо"
+
+#: ../src/common/stockitem.cpp:173
+msgid "&Italic"
+msgstr "&Курсив"
+
+#: ../src/common/stockitem.cpp:173 ../src/generic/fontdlgg.cpp:322
+#: ../src/richtext/richtextfontpage.cpp:350
+msgid "Italic"
+msgstr "Курсив"
+
+#: ../src/common/stockitem.cpp:174
+msgid "&Jump to"
+msgstr "&Перейти к"
+
+#: ../src/common/stockitem.cpp:174
+msgid "Jump to"
+msgstr "Перейти к"
+
+#: ../src/common/stockitem.cpp:175
+msgid "Centered"
+msgstr "Центрированный"
+
+#: ../src/common/stockitem.cpp:176
+msgid "Justified"
+msgstr "Выровненный"
+
+#: ../src/common/stockitem.cpp:177
+msgid "Align Left"
+msgstr "Выровнять слева"
+
+#: ../src/common/stockitem.cpp:178
+msgid "Align Right"
+msgstr "Выровнять справа"
+
+#: ../src/common/stockitem.cpp:179
+msgid "&Last"
+msgstr "&Последний"
+
+#: ../src/common/stockitem.cpp:179
+msgid "Last"
+msgstr "Последний"
+
+#: ../src/common/stockitem.cpp:180
+msgid "&Network"
+msgstr "&Сеть"
+
+#: ../src/common/stockitem.cpp:180
+msgid "Network"
+msgstr "Сеть"
+
+#: ../src/common/stockitem.cpp:181 ../src/richtext/richtexttabspage.cpp:131
+msgid "&New"
+msgstr "&Новый"
+
+#: ../src/common/stockitem.cpp:181
+msgid "New"
+msgstr "Новый"
+
+#: ../src/common/stockitem.cpp:182 ../src/msw/msgdlg.cpp:417
+msgid "&No"
+msgstr "&Нет"
+
+#: ../src/common/stockitem.cpp:183 ../src/generic/fontdlgg.cpp:467
+#: ../src/generic/fontdlgg.cpp:474
+msgid "&OK"
+msgstr "&ОК"
+
+#: ../src/common/stockitem.cpp:184 ../src/generic/dbgrptg.cpp:341
+msgid "&Open..."
+msgstr "&Открыть..."
+
+#: ../src/common/stockitem.cpp:184
+msgid "Open..."
+msgstr "Открыть..."
+
+#: ../src/common/stockitem.cpp:185 ../src/msw/textctrl.cpp:2885
+#: ../src/osx/textctrl_osx.cpp:654 ../src/richtext/richtextctrl.cpp:332
+msgid "&Paste"
+msgstr "Вст&авить"
+
+#: ../src/common/stockitem.cpp:185 ../src/richtext/richtextctrl.cpp:3484
+#: ../src/stc/stc_i18n.cpp:19
+msgid "Paste"
+msgstr "Вставить"
+
+#: ../src/common/stockitem.cpp:186
+msgid "&Preferences"
+msgstr "&Настройки"
+
+#: ../src/common/stockitem.cpp:186 ../src/osx/cocoa/preferences.mm:304
+msgid "Preferences"
+msgstr "Настройки"
+
+#: ../src/common/stockitem.cpp:187
+msgid "Print previe&w..."
+msgstr "П&редпросмотр печати..."
+
+#: ../src/common/stockitem.cpp:187
+msgid "Print preview..."
+msgstr "Предпросмотр печати..."
+
+#: ../src/common/stockitem.cpp:188
+msgid "&Print..."
+msgstr "&Печать..."
+
+#: ../src/common/stockitem.cpp:188
+msgid "Print..."
+msgstr "Печать..."
+
+#: ../src/common/stockitem.cpp:189 ../src/richtext/richtextctrl.cpp:337
+#: ../src/richtext/richtextctrl.cpp:5479
+msgid "&Properties"
+msgstr "&Свойства"
+
+#: ../src/common/stockitem.cpp:189
+msgid "Properties"
+msgstr "Свойства"
+
+#: ../src/common/stockitem.cpp:190 ../src/stc/stc_i18n.cpp:16
+msgid "Redo"
+msgstr "Повторить"
+
+#: ../src/common/stockitem.cpp:191
+msgid "Refresh"
+msgstr "Обновить"
+
+#: ../src/common/stockitem.cpp:192
+msgid "Remove"
+msgstr "Удалить"
+
+#: ../src/common/stockitem.cpp:193
+#, fuzzy
+msgid "Rep&lace..."
+msgstr "За&менить"
+
+#: ../src/common/stockitem.cpp:193
+#, fuzzy
+msgid "Replace..."
+msgstr "Заменить"
+
+#: ../src/common/stockitem.cpp:194
+msgid "Revert to Saved"
+msgstr "Откатить к сохранённому"
+
+#: ../src/common/stockitem.cpp:196 ../src/generic/logg.cpp:549
+msgid "Save &As..."
+msgstr "Сохранить &как..."
+
+#: ../src/common/stockitem.cpp:196
+#, fuzzy
+msgid "Save As..."
+msgstr "Сохранить &как..."
+
+#: ../src/common/stockitem.cpp:197 ../src/msw/textctrl.cpp:2888
+#: ../src/osx/textctrl_osx.cpp:657 ../src/richtext/richtextctrl.cpp:335
+msgid "Select &All"
+msgstr "Выделить вс&ё"
+
+#: ../src/common/stockitem.cpp:197 ../src/stc/stc_i18n.cpp:21
+msgid "Select All"
+msgstr "Выделить всё"
+
+#: ../src/common/stockitem.cpp:198
+msgid "&Color"
+msgstr "&Цвет"
+
+#: ../src/common/stockitem.cpp:198
+msgid "Color"
+msgstr "Цвет"
+
+#: ../src/common/stockitem.cpp:199
+msgid "&Font"
+msgstr "&Шрифт"
+
+#: ../src/common/stockitem.cpp:199 ../src/richtext/richtextformatdlg.cpp:336
+msgid "Font"
+msgstr "Шрифт"
+
+#: ../src/common/stockitem.cpp:200
+msgid "&Ascending"
+msgstr "По &возрастанию"
+
+#: ../src/common/stockitem.cpp:200
+msgid "Ascending"
+msgstr "По возрастанию"
+
+#: ../src/common/stockitem.cpp:201
+msgid "&Descending"
+msgstr "По &убыванию"
+
+#: ../src/common/stockitem.cpp:201
+msgid "Descending"
+msgstr "По убыванию"
+
+#: ../src/common/stockitem.cpp:202
+msgid "&Spell Check"
+msgstr "&Проверка правописания"
+
+#: ../src/common/stockitem.cpp:202
+msgid "Spell Check"
+msgstr "Проверка правописания"
+
+#: ../src/common/stockitem.cpp:203
+msgid "&Stop"
+msgstr "&Остановить"
+
+#: ../src/common/stockitem.cpp:203
+msgid "Stop"
+msgstr "Остановить"
+
+#: ../src/common/stockitem.cpp:204 ../src/richtext/richtextfontpage.cpp:274
+msgid "&Strikethrough"
+msgstr "&Зачёркивание"
+
+#: ../src/common/stockitem.cpp:204
+msgid "Strikethrough"
+msgstr "Перечёркивание"
+
+#: ../src/common/stockitem.cpp:205
+msgid "&Top"
+msgstr "С&верху"
+
+#: ../src/common/stockitem.cpp:205 ../src/richtext/richtextsizepage.cpp:285
+#: ../src/richtext/richtextsizepage.cpp:289
+msgid "Top"
+msgstr "Верх"
+
+#: ../src/common/stockitem.cpp:206
+msgid "Undelete"
+msgstr "Отмена удаления"
+
+#: ../src/common/stockitem.cpp:207 ../src/generic/fontdlgg.cpp:437
+msgid "&Underline"
+msgstr "&Подчёркивание"
+
+#: ../src/common/stockitem.cpp:207
+msgid "Underline"
+msgstr "Подчёркивание"
+
+#: ../src/common/stockitem.cpp:208 ../src/stc/stc_i18n.cpp:15
+msgid "Undo"
+msgstr "Отменить"
+
+#: ../src/common/stockitem.cpp:209
+msgid "&Unindent"
+msgstr "Убрать &отступ"
+
+#: ../src/common/stockitem.cpp:209
+msgid "Unindent"
+msgstr "Убрать отступ"
+
+#: ../src/common/stockitem.cpp:210
+msgid "&Up"
+msgstr "&Вверх"
+
+#: ../src/common/stockitem.cpp:210 ../src/generic/fdrepdlg.cpp:148
+msgid "Up"
+msgstr "Выше"
+
+#: ../src/common/stockitem.cpp:211 ../src/msw/msgdlg.cpp:417
+msgid "&Yes"
+msgstr "&Да"
+
+#: ../src/common/stockitem.cpp:212
+msgid "&Actual Size"
+msgstr "&Исходный размер"
+
+#: ../src/common/stockitem.cpp:212
+msgid "Actual Size"
+msgstr "Исходный размер"
+
+#: ../src/common/stockitem.cpp:213
+msgid "Zoom to &Fit"
+msgstr "&Вписать"
+
+#: ../src/common/stockitem.cpp:213
+msgid "Zoom to Fit"
+msgstr "Вписать"
+
+#: ../src/common/stockitem.cpp:214
+msgid "Zoom &In"
+msgstr "&Увеличить"
+
+#: ../src/common/stockitem.cpp:215
+msgid "Zoom &Out"
+msgstr "У&меньшить"
+
+#: ../src/common/stockitem.cpp:262
+msgid "Show about dialog"
+msgstr "Посмотреть в окне о программе"
+
+#: ../src/common/stockitem.cpp:263
+msgid "Copy selection"
+msgstr "Копировать выбранное"
+
+#: ../src/common/stockitem.cpp:264
+msgid "Cut selection"
+msgstr "Вырезать выделение"
+
+#: ../src/common/stockitem.cpp:265
+msgid "Delete selection"
+msgstr "Удалить выделение"
+
+#: ../src/common/stockitem.cpp:266
+#, fuzzy
+msgid "Find in document"
+msgstr "Открыть документ HTML"
+
+#: ../src/common/stockitem.cpp:267
+msgid "Find and replace in document"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:268
+msgid "Paste selection"
+msgstr "Вставить выбранное"
+
+#: ../src/common/stockitem.cpp:269
+msgid "Quit this program"
+msgstr "Завершить работу программы"
+
+#: ../src/common/stockitem.cpp:270
+msgid "Redo last action"
+msgstr "Повторить последнее действие"
+
+#: ../src/common/stockitem.cpp:271
+msgid "Undo last action"
+msgstr "Отмеить последне действие"
+
+#: ../src/common/stockitem.cpp:272
+#, fuzzy
+msgid "Create new document"
+msgstr "Создать новый каталог"
+
+#: ../src/common/stockitem.cpp:273
+#, fuzzy
+msgid "Open an existing document"
+msgstr "Открыть документ HTML"
+
+#: ../src/common/stockitem.cpp:274
+msgid "Close current document"
+msgstr "Закрыть текущий документ"
+
+#: ../src/common/stockitem.cpp:275
+msgid "Save current document"
+msgstr "Сохранить текущий документ"
+
+#: ../src/common/stockitem.cpp:276
+msgid "Save current document with a different filename"
+msgstr "Сохранить текущий документ с другим именем"
+
+#: ../src/common/strconv.cpp:2324
+#, c-format
+msgid "Conversion to charset '%s' doesn't work."
+msgstr "Преобразование кодировки в '%s' не работает."
+
+#: ../src/common/tarstrm.cpp:352 ../src/common/tarstrm.cpp:375
+#: ../src/common/tarstrm.cpp:406 ../src/generic/progdlgg.cpp:373
+msgid "unknown"
+msgstr "неизвестный"
+
+#: ../src/common/tarstrm.cpp:774
+msgid "incomplete header block in tar"
+msgstr "неполный заголовок блока tar"
+
+#: ../src/common/tarstrm.cpp:798
+msgid "checksum failure reading tar header block"
+msgstr "ошибка контрольной суммы читая заголовок блока tar"
+
+#: ../src/common/tarstrm.cpp:971
+msgid "invalid data in extended tar header"
+msgstr "недопустимые данные в расширенном заголовке tar"
+
+#: ../src/common/tarstrm.cpp:981 ../src/common/tarstrm.cpp:1003
+#: ../src/common/tarstrm.cpp:1477 ../src/common/tarstrm.cpp:1499
+msgid "tar entry not open"
+msgstr "запись tar не открыта"
+
+#: ../src/common/tarstrm.cpp:1023
+msgid "unexpected end of file"
+msgstr "неожиданный конец файла"
+
+#: ../src/common/tarstrm.cpp:1297
+#, c-format
+msgid "%s did not fit the tar header for entry '%s'"
+msgstr "%s не соответствует заголовок tar для записи '%s'"
+
+#: ../src/common/tarstrm.cpp:1359
+msgid "incorrect size given for tar entry"
+msgstr "неправильные размеры даны для записи tar"
+
+#: ../src/common/textbuf.cpp:232
+#, c-format
+msgid "'%s' is probably a binary buffer."
+msgstr "'%s' возможно является двоичным буфером."
+
+#: ../src/common/textcmn.cpp:1006 ../src/richtext/richtextctrl.cpp:3053
+msgid "File couldn't be loaded."
+msgstr "Не удалось загрузить файл."
+
+#: ../src/common/textfile.cpp:95
+#, fuzzy, c-format
+msgid "Failed to read text file \"%s\"."
+msgstr "Не удалось прочесть документ из файла \"%s\"."
+
+#: ../src/common/textfile.cpp:160
+#, c-format
+msgid "can't write buffer '%s' to disk."
+msgstr "ошибка записи буфера '%s' на диск."
+
+#: ../src/common/time.cpp:212
+msgid "Failed to get the local system time"
+msgstr "Не удалось получить локальное системное время"
+
+#: ../src/common/time.cpp:279
+msgid "wxGetTimeOfDay failed."
+msgstr "ошибка wxGetTimeOfDay."
+
+#: ../src/common/translation.cpp:929
+#, c-format
+msgid "'%s' is not a valid message catalog."
+msgstr "'%s' - неверный каталог сообщений."
+
+#: ../src/common/translation.cpp:954
+msgid "Invalid message catalog."
+msgstr "Неверный каталог сообщений."
+
+#: ../src/common/translation.cpp:1013
+#, c-format
+msgid "Failed to parse Plural-Forms: '%s'"
+msgstr "Не удалось разобрать формы нножественного числа: '%s'"
+
+#: ../src/common/translation.cpp:1723
+#, c-format
+msgid "using catalog '%s' from '%s'."
+msgstr "используется каталог '%s' из '%s'."
+
+#: ../src/common/translation.cpp:1816
+#, c-format
+msgid "Resource '%s' is not a valid message catalog."
+msgstr "Ресурс '%s' не является допустимым каталогом сообщений."
+
+#: ../src/common/translation.cpp:1865
+msgid "Couldn't enumerate translations"
+msgstr "Не удалось перечислить переводы"
+
+#: ../src/common/utilscmn.cpp:1145
+msgid "No default application configured for HTML files."
+msgstr "Приложение по умолчанию не настроено для HTML-файлов."
+
+#: ../src/common/utilscmn.cpp:1190
+#, c-format
+msgid "Failed to open URL \"%s\" in default browser."
+msgstr "Не удалось открыть URL-адрес \"%s\" в браузере по умолчанию."
+
+#: ../src/common/valtext.cpp:144
+msgid "Validation conflict"
+msgstr "Конфликт проверки"
+
+#: ../src/common/valtext.cpp:186
+msgid "Required information entry is empty."
+msgstr "Необходимая запись информации пуста."
+
+#: ../src/common/valtext.cpp:188
+#, c-format
+msgid "'%s' is one of the invalid strings"
+msgstr "'%s' - недопустимая строка"
+
+#: ../src/common/valtext.cpp:190
+#, c-format
+msgid "'%s' is not one of the valid strings"
+msgstr "'%s' - недопустимая строка"
+
+#: ../src/common/valtext.cpp:199
+#, fuzzy, c-format
+msgid "'%s' contains invalid character(s)"
+msgstr "'%s' содержит недопустмые знаки"
+
+#: ../src/common/webrequest.cpp:139
+#, fuzzy, c-format
+msgid "Error: %s (%d)"
+msgstr "Ошибка: "
+
+#: ../src/common/webrequest.cpp:655
+#, c-format
+msgid ""
+"Not enough free disk space for download: %llu needed but only %llu available."
+msgstr ""
+
+#: ../src/common/webrequest.cpp:669
+#, fuzzy, c-format
+msgid "Failed to create temporary file in %s"
+msgstr "Сбой формирования имени временного файла"
+
+#: ../src/common/webrequest_curl.cpp:1106
+#, fuzzy
+msgid "libcurl could not be initialized"
+msgstr "Не удалось загрузить файл."
+
+#: ../src/common/webview.cpp:392
+msgid "RunScriptAsync not supported"
+msgstr ""
+
+#: ../src/common/webview.cpp:403 ../src/msw/webview_ie.cpp:1073
+#, c-format
+msgid "Error running JavaScript: %s"
+msgstr ""
+
+#: ../src/common/webview_chromium.cpp:858
+#, fuzzy, c-format
+msgid "Failed to set proxy \"%s\": %s"
+msgstr "Ошибка создания каталога \"%s\""
+
+#: ../src/common/webview_chromium.cpp:989
+msgid ""
+"Chromium can't be used because libcef.so wasn't loaded early enough; please "
+"relink the application or use LD_PRELOAD to load it earlier."
+msgstr ""
+
+#: ../src/common/webview_chromium.cpp:1108
+#, fuzzy
+msgid "Could not initialize Chromium"
+msgstr "Не удалось инициализировать libnotify."
+
+#: ../src/common/webview_chromium.cpp:1616
+msgid "Show DevTools"
+msgstr ""
+
+#: ../src/common/webview_chromium.cpp:1617
+#, fuzzy
+msgid "Close DevTools"
+msgstr "Закрыть всё"
+
+#: ../src/common/webview_chromium.cpp:1623
+msgid "Inspect"
+msgstr ""
+
+#: ../src/common/wincmn.cpp:1628
+msgid "This platform does not support background transparency."
+msgstr "Эта платформа не поддерживает прозрачность фона."
+
+#: ../src/common/wincmn.cpp:2097
+msgid "Could not transfer data to window"
+msgstr "Невозможно передать данные в окно"
+
+#: ../src/common/windowid.cpp:240
+msgid "Out of window IDs.  Recommend shutting down application."
+msgstr "Идентификаторы вне окна. Рекомендуем закрыть приложениея."
+
+#: ../src/common/xpmdecod.cpp:678
+msgid "XPM: incorrect header format!"
+msgstr "XPM: неверный формат заголовка!"
+
+#: ../src/common/xpmdecod.cpp:703
+#, c-format
+msgid "XPM: incorrect colour description in line %d"
+msgstr "XPM: неправильное описание цвета в строке %d"
+
+#: ../src/common/xpmdecod.cpp:715 ../src/common/xpmdecod.cpp:724
+#, c-format
+msgid "XPM: malformed colour definition '%s' at line %d!"
+msgstr "XPM: некорректное определение цвета '%s' в строке %d!"
+
+#: ../src/common/xpmdecod.cpp:754
+msgid "XPM: no colors left to use for mask!"
+msgstr "XPM: нет цвета слева для использования в маске!"
+
+#: ../src/common/xpmdecod.cpp:781
+#, c-format
+msgid "XPM: truncated image data at line %d!"
+msgstr "XPM: усечённые данные изображения в строке %d!"
+
+#: ../src/common/xpmdecod.cpp:795
+msgid "XPM: Malformed pixel data!"
+msgstr "XPM: искажённые пиксельные данные!"
+
+#: ../src/common/xti.cpp:492
+msgid "Illegal Parameter Count for Create Method"
+msgstr "Недопустимое число параметров для метода Create"
+
+#: ../src/common/xti.cpp:504
+msgid "Illegal Parameter Count for ConstructObject Method"
+msgstr "Недопустимое число параметров для метода ConstructObject"
+
+#: ../src/common/xtistrm.cpp:161
+#, c-format
+msgid "Create Parameter %s not found in declared RTTI Parameters"
+msgstr "Параметр создания %s не найден в объявленных параметрах RTTI"
+
+#: ../src/common/xtistrm.cpp:290
+msgid "Illegal Object Class (Non-wxEvtHandler) as Event Source"
+msgstr "Недопустимый класс объекта (не wxEvtHandler) как источник события"
+
+#: ../src/common/xtistrm.cpp:313 ../src/common/xtixml.cpp:345
+#: ../src/common/xtixml.cpp:498
+msgid "Type must have enum - long conversion"
+msgstr "Тип должен иметь преобразование enum-long"
+
+#: ../src/common/xtistrm.cpp:400 ../src/common/xtistrm.cpp:415
+msgid "Invalid or Null Object ID passed to GetObjectClassInfo"
+msgstr ""
+"Неверный или нулевой идентификатор объекта передан в GetObjectClassInfo"
+
+#: ../src/common/xtistrm.cpp:405
+msgid "Unknown Object passed to GetObjectClassInfo"
+msgstr "Неизвестный объект передан в GetObjectClassInfo"
+
+#: ../src/common/xtistrm.cpp:420
+msgid "Already Registered Object passed to SetObjectClassInfo"
+msgstr "Уже зарегистрированный объект передан в SetObjectClassInfo"
+
+#: ../src/common/xtistrm.cpp:430
+msgid "Invalid or Null Object ID passed to HasObjectClassInfo"
+msgstr ""
+"Неверный или нулевой идентификатор объекта передан в HasObjectClassInfo"
+
+#: ../src/common/xtistrm.cpp:460
+msgid "Passing a already registered object to SetObject"
+msgstr "Передача уже зарегистрированного объекта в SetObject"
+
+#: ../src/common/xtistrm.cpp:471
+msgid "Passing an unknown object to GetObject"
+msgstr "Передача неизвестного объекта в GetObject"
+
+#: ../src/common/xtixml.cpp:229
+msgid "Forward hrefs are not supported"
+msgstr "Перекрёстные ссылки не поддерживаются"
+
+#: ../src/common/xtixml.cpp:247
+#, c-format
+msgid "unknown class %s"
+msgstr "неизвестный класс %s"
+
+#: ../src/common/xtixml.cpp:253
+msgid "objects cannot have XML Text Nodes"
+msgstr "объекты не могут иметь текстовые узлы XML"
+
+#: ../src/common/xtixml.cpp:258
+msgid "Objects must have an id attribute"
+msgstr "Объекты должны иметь атрибут id"
+
+#: ../src/common/xtixml.cpp:267
+#, c-format
+msgid "Doubly used id : %d"
+msgstr "Повторно используемый id : %d"
+
+#: ../src/common/xtixml.cpp:316
+#, c-format
+msgid "Unknown Property %s"
+msgstr "Неизвестное свойство %s"
+
+#: ../src/common/xtixml.cpp:407
+msgid "A non empty collection must consist of 'element' nodes"
+msgstr "Непустая коллекция должна состоять из узлов 'element'"
+
+#: ../src/common/xtixml.cpp:478
+msgid "incorrect event handler string, missing dot"
+msgstr "неверная строка обработчика события, отсутствует точка"
+
+#: ../src/common/zipstrm.cpp:559
+msgid "can't re-initialize zlib deflate stream"
+msgstr "невозможно переинициализировать поток распаковки zlib"
+
+#: ../src/common/zipstrm.cpp:584
+msgid "can't re-initialize zlib inflate stream"
+msgstr "невозможно переинициализировать поток сжатия zlib"
+
+#: ../src/common/zipstrm.cpp:1023
+msgid "Ignoring malformed extra data record, ZIP file may be corrupted"
+msgstr ""
+
+#: ../src/common/zipstrm.cpp:1502
+msgid "assuming this is a multi-part zip concatenated"
+msgstr "подразумевается, что это объединение многотомного zip-архива"
+
+#: ../src/common/zipstrm.cpp:1664
+msgid "invalid zip file"
+msgstr "неверный zip-файл"
+
+#: ../src/common/zipstrm.cpp:1723
+msgid "can't find central directory in zip"
+msgstr "невозможно найти центральный каталог в zip"
+
+#: ../src/common/zipstrm.cpp:1812
+msgid "error reading zip central directory"
+msgstr "ошибка чтения центрального каталога zip"
+
+#: ../src/common/zipstrm.cpp:1916
+msgid "error reading zip local header"
+msgstr "ошибка чтения локального заголовка zip"
+
+#: ../src/common/zipstrm.cpp:1964
+msgid "bad zipfile offset to entry"
+msgstr "неверное смещение zip-файла к записи"
+
+#: ../src/common/zipstrm.cpp:2031
+msgid "stored file length not in Zip header"
+msgstr "сохранённая длина файла не находится в заголовке Zip"
+
+#: ../src/common/zipstrm.cpp:2045 ../src/common/zipstrm.cpp:2362
+msgid "unsupported Zip compression method"
+msgstr "неподдерживаемый метод сжатия Zip"
+
+#: ../src/common/zipstrm.cpp:2126
+#, c-format
+msgid "reading zip stream (entry %s): bad length"
+msgstr "чтение потока zip (точка входа %s): неверная длина"
+
+#: ../src/common/zipstrm.cpp:2131
+#, c-format
+msgid "reading zip stream (entry %s): bad crc"
+msgstr "чтение потока zip (точка входа %s): неверная контрольная сумма"
+
+#: ../src/common/zipstrm.cpp:2578
+#, fuzzy, c-format
+msgid "error writing zip entry '%s': file too large without ZIP64"
+msgstr "ошибка записи элемента zip '%s': неверная длина или контрольная сумма"
+
+#: ../src/common/zipstrm.cpp:2585
+#, c-format
+msgid "error writing zip entry '%s': bad crc or length"
+msgstr "ошибка записи элемента zip '%s': неверная длина или контрольная сумма"
+
+#: ../src/common/zstream.cpp:155 ../src/common/zstream.cpp:315
+msgid "Gzip not supported by this version of zlib"
+msgstr "Gzip не поддерживается этой версией zlib"
+
+#: ../src/common/zstream.cpp:182
+msgid "Can't initialize zlib inflate stream."
+msgstr "Невозможно инициализировать сжатие данных zlib."
+
+#: ../src/common/zstream.cpp:241
+msgid "Can't read inflate stream: unexpected EOF in underlying stream."
+msgstr ""
+"Невозможно чтение сжимаемого потока: неожиданный EOF в нижлежащем потоке."
+
+#: ../src/common/zstream.cpp:248 ../src/common/zstream.cpp:423
+#, c-format
+msgid "zlib error %d"
+msgstr "ошибка zlib %d"
+
+#: ../src/common/zstream.cpp:249
+#, c-format
+msgid "Can't read from inflate stream: %s"
+msgstr "Невозможно чтение сжимаемого потока: %s"
+
+#: ../src/common/zstream.cpp:343
+msgid "Can't initialize zlib deflate stream."
+msgstr "Невозможно инициализировать распаковку данных zlib."
+
+#: ../src/common/zstream.cpp:424
+#, c-format
+msgid "Can't write to deflate stream: %s"
+msgstr "Невозможно записать в разжимаемый поток: %s"
+
+#: ../src/dfb/bitmap.cpp:633 ../src/dfb/bitmap.cpp:667
+#, c-format
+msgid "No bitmap handler for type %d defined."
+msgstr "Не определён обработчик растрового рисунка для типа %d."
+
+#: ../src/dfb/evtloop.cpp:99
+msgid "Failed to read event from DirectFB pipe"
+msgstr "Не удалось выполнить чтение событий из канала DirectFB"
+
+#: ../src/dfb/evtloop.cpp:171
+msgid "Failed to switch DirectFB pipe to non-blocking mode"
+msgstr "Не удалось переключить канал DirectFB в неблокирующий режим"
+
+#: ../src/dfb/fontmgr.cpp:171
+#, c-format
+msgid "no fonts found in %s, using builtin font"
+msgstr "в %s шрифты не найдены, используется встроенный шрифт"
+
+#: ../src/dfb/fontmgr.cpp:177
+msgid "Default font"
+msgstr "Шрифт по умолчанию"
+
+#: ../src/dfb/fontmgr.cpp:195
+#, c-format
+msgid "Fonts index file %s disappeared while loading fonts."
+msgstr "Файл индекса шрифтов %s исчез при загрузке шрифтов."
+
+#: ../src/dfb/wrapdfb.cpp:60
+#, c-format
+msgid "DirectFB error %d occurred."
+msgstr "Ошибка DirectFB %d."
+
+#: ../src/generic/aboutdlgg.cpp:69
+msgid "Developed by "
+msgstr "Разработка "
+
+#: ../src/generic/aboutdlgg.cpp:72
+msgid "Documentation by "
+msgstr "Документацию по "
+
+#: ../src/generic/aboutdlgg.cpp:75
+msgid "Graphics art by "
+msgstr "Графика "
+
+#: ../src/generic/aboutdlgg.cpp:78
+msgid "Translations by "
+msgstr "Переводы "
+
+#: ../src/generic/aboutdlgg.cpp:133 ../src/osx/cocoa/aboutdlg.mm:83
+msgid "Version "
+msgstr "Версия "
+
+#. TRANSLATORS: %s is application name
+#: ../src/generic/aboutdlgg.cpp:146 ../src/msw/aboutdlg.cpp:60
+#, c-format
+msgid "About %s"
+msgstr "О программе %s"
+
+#: ../src/generic/aboutdlgg.cpp:181
+msgid "License"
+msgstr "Лицензии"
+
+#: ../src/generic/aboutdlgg.cpp:184
+msgid "Developers"
+msgstr "Разработчики"
+
+#: ../src/generic/aboutdlgg.cpp:188
+msgid "Documentation writers"
+msgstr "Авторы документации"
+
+#: ../src/generic/aboutdlgg.cpp:192
+msgid "Artists"
+msgstr "Художники"
+
+#: ../src/generic/aboutdlgg.cpp:196
+msgid "Translators"
+msgstr "Переводчики"
+
+#: ../src/generic/animateg.cpp:125
+msgid "No handler found for animation type."
+msgstr "Не найден обработчик для эого типа анимации."
+
+#: ../src/generic/animateg.cpp:133
+#, c-format
+msgid "No animation handler for type %ld defined."
+msgstr "Не определён обработчик анимации для типа %ld."
+
+#: ../src/generic/animateg.cpp:145
+#, c-format
+msgid "Animation file is not of type %ld."
+msgstr "Файл анимации не имеет типа %ld."
+
+#: ../src/generic/colrdlgg.cpp:154 ../src/gtk/colordlg.cpp:47
+msgid "Choose colour"
+msgstr "Выберите цвет"
+
+#: ../src/generic/colrdlgg.cpp:357
+msgid "Red:"
+msgstr "Красный:"
+
+#: ../src/generic/colrdlgg.cpp:360
+msgid "Green:"
+msgstr "Зелёный:"
+
+#: ../src/generic/colrdlgg.cpp:363
+msgid "Blue:"
+msgstr "Голубой:"
+
+#: ../src/generic/colrdlgg.cpp:372
+msgid "Opacity:"
+msgstr "Непрозрачность:"
+
+#: ../src/generic/colrdlgg.cpp:384
+msgid "Add to custom colours"
+msgstr "Добавить к цветам пользователя"
+
+#: ../src/generic/creddlgg.cpp:56
+msgid "Username:"
+msgstr ""
+
+#: ../src/generic/creddlgg.cpp:63
+msgid "Password:"
+msgstr ""
+
+#. TRANSLATORS: Name of Boolean true value
+#: ../src/generic/datavgen.cpp:1178
+msgid "true"
+msgstr "истинно"
+
+#. TRANSLATORS: Name of Boolean false value
+#: ../src/generic/datavgen.cpp:1180
+msgid "false"
+msgstr "ложно"
+
+#: ../src/generic/datavgen.cpp:6897
+#, c-format
+msgid "Row %i"
+msgstr "Строка %i"
+
+#. TRANSLATORS: Action for manipulating a tree control
+#: ../src/generic/datavgen.cpp:6987
+msgid "Collapse"
+msgstr "Свернуть"
+
+#. TRANSLATORS: Action for manipulating a tree control
+#: ../src/generic/datavgen.cpp:6990
+msgid "Expand"
+msgstr "Расширить"
+
+#. TRANSLATORS: Name of data view control and number of rows
+#: ../src/generic/datavgen.cpp:7011
+#, c-format
+msgid "%s (%d items)"
+msgstr "%s (%d элементов)"
+
+#: ../src/generic/datavgen.cpp:7062
+#, c-format
+msgid "Column %u"
+msgstr "Колонка %u"
+
+#. TRANSLATORS: Keystroke for manipulating a tree control
+#: ../src/generic/datavgen.cpp:7131 ../src/richtext/richtextbulletspage.cpp:189
+#: ../src/richtext/richtextbulletspage.cpp:192
+#: ../src/richtext/richtextbulletspage.cpp:193
+#: ../src/richtext/richtextliststylepage.cpp:252
+#: ../src/richtext/richtextliststylepage.cpp:255
+#: ../src/richtext/richtextliststylepage.cpp:256
+#: ../src/richtext/richtextsizepage.cpp:248
+msgid "Left"
+msgstr "Слева"
+
+#. TRANSLATORS: Keystroke for manipulating a tree control
+#: ../src/generic/datavgen.cpp:7134 ../src/richtext/richtextbulletspage.cpp:191
+#: ../src/richtext/richtextliststylepage.cpp:254
+#: ../src/richtext/richtextsizepage.cpp:249
+msgid "Right"
+msgstr "Направо"
+
+#: ../src/generic/datectlg.cpp:90
+#, c-format
+msgid ""
+"\"%s\" is not in the expected date format, please enter it as e.g. \"%s\"."
+msgstr ""
+
+#: ../src/generic/datectlg.cpp:94
+#, fuzzy
+msgid "Invalid date"
+msgstr "PCX: недопустимое изображение"
+
+#: ../src/generic/dbgrptg.cpp:159
+#, c-format
+msgid "Open file \"%s\""
+msgstr "Открыть файл \"%s\""
+
+#: ../src/generic/dbgrptg.cpp:170
+#, c-format
+msgid "Enter command to open file \"%s\":"
+msgstr "Введите команду для открытия файла \"%s\":"
+
+#: ../src/generic/dbgrptg.cpp:230
+msgid "Executable files (*.exe)|*.exe|"
+msgstr "Исполняемые файлы (*.exe)|*.exe|"
+
+#: ../src/generic/dbgrptg.cpp:300
+#, c-format
+msgid "Debug report \"%s\""
+msgstr "Отчёт об отладке \"%s\""
+
+#: ../src/generic/dbgrptg.cpp:316
+msgid "A debug report has been generated in the directory\n"
+msgstr "Отчёт об отладке был создан в папке\n"
+
+#: ../src/generic/dbgrptg.cpp:317
+msgid "The following debug report will be generated\n"
+msgstr ""
+
+#: ../src/generic/dbgrptg.cpp:321
+msgid ""
+"The report contains the files listed below. If any of these files contain "
+"private information,\n"
+"please uncheck them and they will be removed from the report.\n"
+msgstr ""
+"Отчёт содержит перечисленные ниже файлы. Если любой из этих файлов содержит "
+"личную информацию,\n"
+"снимите с них флажки, и они будут удалены из отчёта.\n"
+
+#: ../src/generic/dbgrptg.cpp:323
+msgid ""
+"If you wish to suppress this debug report completely, please choose the "
+"\"Cancel\" button,\n"
+"but be warned that it may hinder improving the program, so if\n"
+"at all possible please do continue with the report generation.\n"
+msgstr ""
+"Если хотите полностью отказаться от этого отчёта об ошибке, выберите кнопку "
+"'Отмена',\n"
+"но учтите, что это может воспрепятствовать улучшению программы.\n"
+"Если это возможно, продолжайте создание отчёта.\n"
+
+#: ../src/generic/dbgrptg.cpp:325
+msgid "              Thank you and we're sorry for the inconvenience!\n"
+msgstr "              Приносим извинения за доставленные неудобства.\n"
+
+#: ../src/generic/dbgrptg.cpp:333
+msgid "&Debug report preview:"
+msgstr "Предпросмотр отчёта &отладки:"
+
+#: ../src/generic/dbgrptg.cpp:339
+msgid "&View..."
+msgstr "&Вид..."
+
+#: ../src/generic/dbgrptg.cpp:359
+msgid "&Notes:"
+msgstr "&Заметки:"
+
+#: ../src/generic/dbgrptg.cpp:361
+msgid ""
+"If you have any additional information pertaining to this bug\n"
+"report, please enter it here and it will be joined to it:"
+msgstr ""
+"Если у вас есть дополнительная информация, относящаяся к этому отчёту\n"
+"об ошибке, введите её здесь и она к отчёту будет присоединена:"
+
+#: ../src/generic/dcpsg.cpp:1627
+msgid "Cannot open file for PostScript printing!"
+msgstr "Невозможно открыть файл для печати в PostScript!"
+
+#: ../src/generic/dirctrlg.cpp:402
+msgid "Computer"
+msgstr "Компьютер"
+
+#: ../src/generic/dirctrlg.cpp:404
+msgid "Sections"
+msgstr "Разделы"
+
+#: ../src/generic/dirctrlg.cpp:482
+msgid "Home directory"
+msgstr "Начальный каталог"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/generic/dirctrlg.cpp:484 ../src/propgrid/advprops.cpp:811
+msgid "Desktop"
+msgstr "Рабочий стол"
+
+#: ../src/generic/dirctrlg.cpp:528 ../src/generic/filectrlg.cpp:752
+msgid "Illegal directory name."
+msgstr "Недопустимое имя каталога."
+
+#: ../src/generic/dirctrlg.cpp:528 ../src/generic/dirctrlg.cpp:546
+#: ../src/generic/dirctrlg.cpp:557 ../src/generic/dirdlgg.cpp:317
+#: ../src/generic/filectrlg.cpp:638 ../src/generic/filectrlg.cpp:752
+#: ../src/generic/filectrlg.cpp:766 ../src/generic/filectrlg.cpp:782
+#: ../src/generic/filectrlg.cpp:1356 ../src/generic/filectrlg.cpp:1387
+#: ../src/generic/filedlgg.cpp:362 ../src/gtk/filedlg.cpp:76
+msgid "Error"
+msgstr "Ошибка"
+
+#: ../src/generic/dirctrlg.cpp:546 ../src/generic/filectrlg.cpp:766
+msgid "File name exists already."
+msgstr "Имя файла уже существует."
+
+#: ../src/generic/dirctrlg.cpp:557 ../src/generic/dirdlgg.cpp:317
+#: ../src/generic/filectrlg.cpp:638 ../src/generic/filectrlg.cpp:782
+msgid "Operation not permitted."
+msgstr "Операция не разрешена."
+
+#: ../src/generic/dirdlgg.cpp:107 ../src/generic/filedlgg.cpp:207
+msgid "Create new directory"
+msgstr "Создать новый каталог"
+
+#: ../src/generic/dirdlgg.cpp:112 ../src/generic/filedlgg.cpp:203
+msgid "Go to home directory"
+msgstr "В начальный каталог"
+
+#: ../src/generic/dirdlgg.cpp:143
+msgid "Show &hidden directories"
+msgstr "Показать &скрытые каталоги"
+
+#: ../src/generic/dirdlgg.cpp:196
+#, c-format
+msgid ""
+"The directory '%s' does not exist\n"
+"Create it now?"
+msgstr ""
+"Каталог '%s' не существует\n"
+"Создать его сейчас?"
+
+#: ../src/generic/dirdlgg.cpp:198
+msgid "Directory does not exist"
+msgstr "Каталог не существует"
+
+#: ../src/generic/dirdlgg.cpp:214
+#, c-format
+msgid ""
+"Failed to create directory '%s'\n"
+"(Do you have the required permissions?)"
+msgstr ""
+"Ошибка создания каталога '%s'\n"
+"(у вас есть необходимые разрешения?)"
+
+#: ../src/generic/dirdlgg.cpp:216
+msgid "Error creating directory"
+msgstr "Ошибка создания каталога"
+
+#: ../src/generic/dirdlgg.cpp:281
+msgid "You cannot add a new directory to this section."
+msgstr "Нельзя добавить новый каталог в эту секцию."
+
+#: ../src/generic/dirdlgg.cpp:282
+msgid "Create directory"
+msgstr "Создать каталог"
+
+#: ../src/generic/dirdlgg.cpp:291 ../src/generic/dirdlgg.cpp:301
+#: ../src/generic/filectrlg.cpp:614 ../src/generic/filectrlg.cpp:623
+msgid "NewName"
+msgstr "НовоеИмя"
+
+#: ../src/generic/editlbox.cpp:135
+msgid "Edit item"
+msgstr "Правка элемента"
+
+#: ../src/generic/editlbox.cpp:143
+msgid "New item"
+msgstr "Новый элемент"
+
+#: ../src/generic/editlbox.cpp:151
+msgid "Delete item"
+msgstr "Удалить элемент"
+
+#: ../src/generic/editlbox.cpp:159
+msgid "Move up"
+msgstr "Перейти вверх"
+
+#: ../src/generic/editlbox.cpp:164
+msgid "Move down"
+msgstr "Перейти вниз"
+
+#: ../src/generic/fdrepdlg.cpp:108
+msgid "Search for:"
+msgstr "Найти:"
+
+#: ../src/generic/fdrepdlg.cpp:120
+msgid "Replace with:"
+msgstr "Заменить на:"
+
+#: ../src/generic/fdrepdlg.cpp:140
+msgid "Whole word"
+msgstr "Слово целиком"
+
+#: ../src/generic/fdrepdlg.cpp:143
+msgid "Match case"
+msgstr "С учётом регистра"
+
+#: ../src/generic/fdrepdlg.cpp:156
+msgid "Search direction"
+msgstr "Направление поиска"
+
+#: ../src/generic/fdrepdlg.cpp:175
+msgid "&Replace"
+msgstr "&Заменить"
+
+#: ../src/generic/fdrepdlg.cpp:178
+msgid "Replace &all"
+msgstr "Заменить вс&ё"
+
+#: ../src/generic/filectrlg.cpp:246 ../src/generic/filectrlg.cpp:269
+msgid "<DIR>"
+msgstr "<КАТАЛОГ>"
+
+#: ../src/generic/filectrlg.cpp:248 ../src/generic/filectrlg.cpp:271
+msgid "<LINK>"
+msgstr "<ССЫЛКА>"
+
+#: ../src/generic/filectrlg.cpp:250 ../src/generic/filectrlg.cpp:273
+msgid "<DRIVE>"
+msgstr "<ДИСК>"
+
+#: ../src/generic/filectrlg.cpp:275
+#, c-format
+msgid "%ld byte"
+msgid_plural "%ld bytes"
+msgstr[0] "%ld байт"
+msgstr[1] "%ld байта"
+msgstr[2] "%ld байт"
+
+#: ../src/generic/filectrlg.cpp:420
+msgid "Name"
+msgstr "Имя"
+
+#: ../src/generic/filectrlg.cpp:421 ../src/richtext/richtextformatdlg.cpp:361
+#: ../src/richtext/richtextsizepage.cpp:298
+msgid "Size"
+msgstr "Размер"
+
+#: ../src/generic/filectrlg.cpp:422
+msgid "Type"
+msgstr "Тип"
+
+#: ../src/generic/filectrlg.cpp:423
+msgid "Modified"
+msgstr "Изменён"
+
+#: ../src/generic/filectrlg.cpp:426
+msgid "Permissions"
+msgstr "Разрешения"
+
+#: ../src/generic/filectrlg.cpp:429
+msgid "Attributes"
+msgstr "Атрибуты"
+
+#: ../src/generic/filectrlg.cpp:936
+msgid "Current directory:"
+msgstr "Текущий каталог:"
+
+#: ../src/generic/filectrlg.cpp:979
+msgid "Show &hidden files"
+msgstr "Показать &скрытые файлы"
+
+#: ../src/generic/filectrlg.cpp:1355
+msgid "Illegal file specification."
+msgstr "Неправильная спецификация файла."
+
+#: ../src/generic/filectrlg.cpp:1387
+msgid "Directory doesn't exist."
+msgstr "Каталог не существует."
+
+#: ../src/generic/filedlgg.cpp:195
+msgid "View files as a list view"
+msgstr "Просмотр файлов в виде списка"
+
+#: ../src/generic/filedlgg.cpp:197
+msgid "View files as a detailed view"
+msgstr "Просмотр файлов в виде подробного списка"
+
+#: ../src/generic/filedlgg.cpp:200
+msgid "Go to parent directory"
+msgstr "Перейти в родительский каталог"
+
+#: ../src/generic/filedlgg.cpp:351 ../src/gtk/filedlg.cpp:59
+#, c-format
+msgid "File '%s' already exists, do you really want to overwrite it?"
+msgstr "Файл '%s' уже существует, вы точно хотите его переписать?"
+
+#: ../src/generic/filedlgg.cpp:354 ../src/gtk/filedlg.cpp:62
+msgid "Confirm"
+msgstr "Подтвердите"
+
+#: ../src/generic/filedlgg.cpp:362 ../src/gtk/filedlg.cpp:75
+msgid "Please choose an existing file."
+msgstr "Выберите существующий файл."
+
+#: ../src/generic/filepickerg.cpp:64
+msgid "..."
+msgstr "..."
+
+#: ../src/generic/fontdlgg.cpp:76 ../src/richtext/richtextformatdlg.cpp:519
+msgid "ABCDEFGabcdefg12345"
+msgstr "ABCDEFGabcdefg12345"
+
+#: ../src/generic/fontdlgg.cpp:315
+msgid "Roman"
+msgstr "Римский"
+
+#: ../src/generic/fontdlgg.cpp:316
+msgid "Decorative"
+msgstr "Декоративный"
+
+#: ../src/generic/fontdlgg.cpp:317
+msgid "Modern"
+msgstr "Современный"
+
+#: ../src/generic/fontdlgg.cpp:318
+msgid "Script"
+msgstr "Скрипт"
+
+#: ../src/generic/fontdlgg.cpp:319
+msgid "Swiss"
+msgstr "Швейцарский"
+
+#: ../src/generic/fontdlgg.cpp:320
+msgid "Teletype"
+msgstr "Телетайп"
+
+#: ../src/generic/fontdlgg.cpp:321 ../src/generic/fontdlgg.cpp:324
+msgid "Normal"
+msgstr "Нормальный"
+
+#: ../src/generic/fontdlgg.cpp:323
+msgid "Slant"
+msgstr "Наклонный"
+
+#: ../src/generic/fontdlgg.cpp:325
+msgid "Light"
+msgstr "Светлый"
+
+#: ../src/generic/fontdlgg.cpp:363
+msgid "&Font family:"
+msgstr "&Семейство шрифтов::"
+
+#: ../src/generic/fontdlgg.cpp:367 ../src/generic/fontdlgg.cpp:369
+msgid "The font family."
+msgstr "Название шрифта."
+
+#: ../src/generic/fontdlgg.cpp:374 ../src/richtext/richtextstylepage.cpp:105
+msgid "&Style:"
+msgstr "&Стиль:"
+
+#: ../src/generic/fontdlgg.cpp:378 ../src/generic/fontdlgg.cpp:380
+msgid "The font style."
+msgstr "Стиль шрифта."
+
+#: ../src/generic/fontdlgg.cpp:385
+msgid "&Weight:"
+msgstr "&Толщина:"
+
+#: ../src/generic/fontdlgg.cpp:389 ../src/generic/fontdlgg.cpp:391
+msgid "The font weight."
+msgstr "Толщина шрифта."
+
+#: ../src/generic/fontdlgg.cpp:399
+msgid "C&olour:"
+msgstr "&Цвет:"
+
+#: ../src/generic/fontdlgg.cpp:407 ../src/generic/fontdlgg.cpp:409
+msgid "The font colour."
+msgstr "Цвет шрифта."
+
+#: ../src/generic/fontdlgg.cpp:415
+msgid "&Point size:"
+msgstr "&Размер шрифта:"
+
+#: ../src/generic/fontdlgg.cpp:420 ../src/generic/fontdlgg.cpp:422
+#: ../src/generic/fontdlgg.cpp:426 ../src/generic/fontdlgg.cpp:428
+msgid "The font point size."
+msgstr "Размер шрифта."
+
+#: ../src/generic/fontdlgg.cpp:439 ../src/generic/fontdlgg.cpp:441
+msgid "Whether the font is underlined."
+msgstr "Либо шрифт подчёркнут."
+
+#: ../src/generic/fontdlgg.cpp:448 ../src/html/helpwnd.cpp:1215
+msgid "Preview:"
+msgstr "Предпросмотр:"
+
+#: ../src/generic/fontdlgg.cpp:452 ../src/generic/fontdlgg.cpp:454
+msgid "Shows the font preview."
+msgstr "Показывает предпросмотр шрифта."
+
+#: ../src/generic/fontdlgg.cpp:464 ../src/generic/fontdlgg.cpp:483
+msgid "Click to cancel the font selection."
+msgstr "Щёлкните для отмены выбора шрифта'."
+
+#: ../src/generic/fontdlgg.cpp:469 ../src/generic/fontdlgg.cpp:471
+#: ../src/generic/fontdlgg.cpp:476 ../src/generic/fontdlgg.cpp:478
+msgid "Click to confirm the font selection."
+msgstr "Щёлкните 'подтвердить смену шрифта'."
+
+#: ../src/generic/fontpickerg.cpp:50 ../src/gtk/fontdlg.cpp:77
+msgid "Choose font"
+msgstr "Выберите шрифт"
+
+#: ../src/generic/grid.cpp:6542
+msgid ""
+"Error copying grid to the clipboard. Either selected cells were not "
+"contiguous or no cell was selected."
+msgstr ""
+
+#: ../src/generic/grid.cpp:12739
+#, fuzzy
+msgid "Grid Corner"
+msgstr "Угол"
+
+#: ../src/generic/grid.cpp:12741
+#, fuzzy, c-format
+msgid "Column %s Header"
+msgstr "Колонка %u"
+
+#: ../src/generic/grid.cpp:12743
+#, c-format
+msgid "Row %s Header"
+msgstr ""
+
+#: ../src/generic/grid.cpp:12745
+#, fuzzy, c-format
+msgid "Column %s: %s"
+msgstr "Колонка %u"
+
+#: ../src/generic/grid.cpp:12749
+#, fuzzy, c-format
+msgid "Row %s: %s"
+msgstr "Строка %i"
+
+#: ../src/generic/grid.cpp:12753
+#, c-format
+msgid "Row %s, Column %s: %s"
+msgstr ""
+
+#: ../src/generic/helpext.cpp:257
+#, c-format
+msgid "Help directory \"%s\" not found."
+msgstr "Каталог справки '%s' не найден."
+
+#: ../src/generic/helpext.cpp:265
+#, c-format
+msgid "Help file \"%s\" not found."
+msgstr "Файл справки '%s' не найден."
+
+#: ../src/generic/helpext.cpp:284
+#, c-format
+msgid "Line %lu of map file \"%s\" has invalid syntax, skipped."
+msgstr ""
+"Строка %lu файла сопоставления  '%s' имеет неверный синтаксис и пропущена."
+
+#: ../src/generic/helpext.cpp:292
+#, c-format
+msgid "No valid mappings found in the file \"%s\"."
+msgstr "Не найдены допустимые сопоставления в файле '%s'."
+
+#: ../src/generic/helpext.cpp:435
+msgid "No entries found."
+msgstr "Запись не найдена."
+
+#: ../src/generic/helpext.cpp:444 ../src/generic/helpext.cpp:445
+msgid "Help Index"
+msgstr "Индекс справки"
+
+#: ../src/generic/helpext.cpp:448
+msgid "Relevant entries:"
+msgstr "Подходящие записи:"
+
+#: ../src/generic/helpext.cpp:449
+msgid "Entries found"
+msgstr "Найдено записей"
+
+#: ../src/generic/hyperlinkg.cpp:170
+msgid "&Copy URL"
+msgstr "&Копировать URL"
+
+#: ../src/generic/infobar.cpp:119
+msgid "Hide this notification message."
+msgstr "Скрыть это сообщение уведомления."
+
+#. TRANSLATORS: %s will be either the application name or "Application"
+#: ../src/generic/logg.cpp:257
+#, c-format
+msgid "%s Error"
+msgstr "Ошибка %s"
+
+#. TRANSLATORS: %s will be either the application name or "Application"
+#: ../src/generic/logg.cpp:263
+#, c-format
+msgid "%s Warning"
+msgstr "Предупреждение %s"
+
+#. TRANSLATORS: %s will be either the application name or "Application"
+#: ../src/generic/logg.cpp:273
+#, c-format
+msgid "%s Information"
+msgstr "Информация %s"
+
+#: ../src/generic/logg.cpp:276
+msgid "Application"
+msgstr "Приложение"
+
+#: ../src/generic/logg.cpp:549
+msgid "Save log contents to file"
+msgstr "Сохранить содержание журнала в файл"
+
+#: ../src/generic/logg.cpp:551
+msgid "C&lear"
+msgstr "О&чистить"
+
+#: ../src/generic/logg.cpp:551
+msgid "Clear the log contents"
+msgstr "Очистить содержимое журнала"
+
+#: ../src/generic/logg.cpp:553
+msgid "Close this window"
+msgstr "Закрыть это окно"
+
+#: ../src/generic/logg.cpp:554
+msgid "&Log"
+msgstr "&Журнал"
+
+#: ../src/generic/logg.cpp:610 ../src/generic/logg.cpp:992
+msgid "Can't save log contents to file."
+msgstr "Невозможно сохранение содержания журнала в файл."
+
+#: ../src/generic/logg.cpp:613
+#, c-format
+msgid "Log saved to the file '%s'."
+msgstr "Журнал записан в файл '%s'."
+
+#: ../src/generic/logg.cpp:719
+msgid "&Details"
+msgstr "&Подробности"
+
+#: ../src/generic/logg.cpp:972
+msgid "Failed to copy dialog contents to the clipboard."
+msgstr "Не удалось скопировать содержимое диалога в буфер обмена."
+
+#: ../src/generic/logg.cpp:1022
+#, c-format
+msgid "Append log to file '%s' (choosing [No] will overwrite it)?"
+msgstr "Добавить в файл журнала '%s' (выбор [Нет] его перепишет)?"
+
+#: ../src/generic/logg.cpp:1024
+msgid "Question"
+msgstr "Вопрос"
+
+#: ../src/generic/logg.cpp:1038
+msgid "invalid message box return value"
+msgstr "недопустимое значение возврата из окна сообщения"
+
+#: ../src/generic/notifmsgg.cpp:129
+msgid "Notice"
+msgstr "Уведомление"
+
+#: ../src/generic/preferencesg.cpp:118
+#, c-format
+msgid "%s Preferences"
+msgstr "Настройки %s"
+
+#: ../src/generic/printps.cpp:143
+msgid "Printing..."
+msgstr "Печать..."
+
+#: ../src/generic/printps.cpp:160 ../src/gtk/print.cpp:1076
+#: ../src/msw/printwin.cpp:235
+msgid "Could not start printing."
+msgstr "Невозможно начать печать."
+
+#: ../src/generic/printps.cpp:183
+#, c-format
+msgid "Printing page %d..."
+msgstr "Печать страницы %d..."
+
+#: ../src/generic/prntdlgg.cpp:171
+msgid "Printer options"
+msgstr "Параметры принтера"
+
+#: ../src/generic/prntdlgg.cpp:176
+msgid "Print to File"
+msgstr "Печать в файл"
+
+#: ../src/generic/prntdlgg.cpp:179
+msgid "Setup..."
+msgstr "Настройки..."
+
+#: ../src/generic/prntdlgg.cpp:187
+msgid "Printer:"
+msgstr "Принтер:"
+
+#: ../src/generic/prntdlgg.cpp:195
+msgid "Status:"
+msgstr "Состояние:"
+
+#: ../src/generic/prntdlgg.cpp:206
+msgid "All"
+msgstr "Всё"
+
+#: ../src/generic/prntdlgg.cpp:207
+msgid "Pages"
+msgstr "Страницы"
+
+#: ../src/generic/prntdlgg.cpp:215
+msgid "Print Range"
+msgstr "Интервал печати"
+
+#: ../src/generic/prntdlgg.cpp:229
+msgid "From:"
+msgstr "От:"
+
+#: ../src/generic/prntdlgg.cpp:233
+msgid "To:"
+msgstr "До:"
+
+#: ../src/generic/prntdlgg.cpp:238
+msgid "Copies:"
+msgstr "Копии:"
+
+#: ../src/generic/prntdlgg.cpp:288
+msgid "PostScript file"
+msgstr "Файл PostScript"
+
+#: ../src/generic/prntdlgg.cpp:439
+msgid "Print Setup"
+msgstr "Настройки печати"
+
+#: ../src/generic/prntdlgg.cpp:483
+msgid "Printer"
+msgstr "Принтер"
+
+#: ../src/generic/prntdlgg.cpp:501
+msgid "Default printer"
+msgstr "Принтер по-умолчанию"
+
+#: ../src/generic/prntdlgg.cpp:595 ../src/generic/prntdlgg.cpp:782
+#: ../src/generic/prntdlgg.cpp:822 ../src/generic/prntdlgg.cpp:835
+#: ../src/generic/prntdlgg.cpp:1031 ../src/generic/prntdlgg.cpp:1036
+msgid "Paper size"
+msgstr "Размер бумаги"
+
+#: ../src/generic/prntdlgg.cpp:604 ../src/generic/prntdlgg.cpp:847
+msgid "Portrait"
+msgstr "Портрет"
+
+#: ../src/generic/prntdlgg.cpp:605 ../src/generic/prntdlgg.cpp:848
+msgid "Landscape"
+msgstr "Пейзаж"
+
+#: ../src/generic/prntdlgg.cpp:607 ../src/generic/prntdlgg.cpp:849
+msgid "Orientation"
+msgstr "Ориентация"
+
+#: ../src/generic/prntdlgg.cpp:610
+msgid "Options"
+msgstr "Параметры"
+
+#: ../src/generic/prntdlgg.cpp:612
+msgid "Print in colour"
+msgstr "Печать в цвете"
+
+#: ../src/generic/prntdlgg.cpp:621
+msgid "Print spooling"
+msgstr "Очередь печати"
+
+#: ../src/generic/prntdlgg.cpp:623
+msgid "Printer command:"
+msgstr "Команда принтера:"
+
+#: ../src/generic/prntdlgg.cpp:631
+msgid "Printer options:"
+msgstr "Параметры принтера:"
+
+#: ../src/generic/prntdlgg.cpp:860
+msgid "Left margin (mm):"
+msgstr "Левое поле (мм):"
+
+#: ../src/generic/prntdlgg.cpp:861
+msgid "Top margin (mm):"
+msgstr "Верхняя граница (мм):"
+
+#: ../src/generic/prntdlgg.cpp:872
+msgid "Right margin (mm):"
+msgstr "Правое поле (мм):"
+
+#: ../src/generic/prntdlgg.cpp:873
+msgid "Bottom margin (mm):"
+msgstr "Нижнее поле (мм):"
+
+#: ../src/generic/prntdlgg.cpp:896
+msgid "Printer..."
+msgstr "Принтер..."
+
+#: ../src/generic/progdlgg.cpp:246
+msgid "&Skip"
+msgstr "&Пропустить"
+
+#: ../src/generic/progdlgg.cpp:347 ../src/generic/progdlgg.cpp:626
+msgid "Unknown"
+msgstr "Неизвестно"
+
+#: ../src/generic/progdlgg.cpp:451 ../src/msw/progdlg.cpp:526
+msgid "Done."
+msgstr "Готово."
+
+#: ../src/generic/srchctlg.cpp:55 ../src/gtk/srchctrl.cpp:206
+#: ../src/html/helpwnd.cpp:530 ../src/html/helpwnd.cpp:545
+msgid "Search"
+msgstr "Поиск"
+
+#: ../src/generic/tabg.cpp:1026
+msgid "Could not find tab for id"
+msgstr "Невозможно найти закладку для id"
+
+#: ../src/generic/tipdlg.cpp:136
+msgid "Tips not available, sorry!"
+msgstr "Подсказки недоступны!"
+
+#: ../src/generic/tipdlg.cpp:197
+msgid "Tip of the Day"
+msgstr "Совет на день"
+
+#: ../src/generic/tipdlg.cpp:207
+msgid "Did you know..."
+msgstr "А вы знаете, что..."
+
+#: ../src/generic/tipdlg.cpp:232
+msgid "&Show tips at startup"
+msgstr "&Показывать советы при запуске"
+
+#: ../src/generic/tipdlg.cpp:236
+msgid "&Next Tip"
+msgstr "&Следующий совет"
+
+#: ../src/generic/wizard.cpp:411
+msgid "&Next >"
+msgstr "&Далее >"
+
+#: ../src/generic/wizard.cpp:412
+msgid "&Finish"
+msgstr "&Завершить"
+
+#: ../src/generic/wizard.cpp:420
+msgid "< &Back"
+msgstr "< &Назад"
+
+#: ../src/gtk/aboutdlg.cpp:204
+msgid "translator-credits"
+msgstr "Список переводчиков"
+
+#: ../src/gtk/app.cpp:517
+msgid ""
+"WARNING: using XIM input method is unsupported and may result in problems "
+"with input handling and flickering. Consider unsetting GTK_IM_MODULE or "
+"setting to \"ibus\"."
+msgstr ""
+
+#: ../src/gtk/app.cpp:569
+msgid "Unable to initialize GTK+, is DISPLAY set properly?"
+msgstr "Не удалось инициализировать GTK+, ДИСПЛЕЙ настроен правильно?"
+
+#: ../src/gtk/filedlg.cpp:89 ../src/gtk/filepicker.cpp:255
+#, c-format
+msgid "Changing current directory to \"%s\" failed"
+msgstr "Ошибка смены текущего каталога на '%s'"
+
+#: ../src/gtk/font.cpp:548
+msgid ""
+"Using private fonts is not supported on this system: Pango library is too "
+"old, 1.38 or later required."
+msgstr ""
+
+#: ../src/gtk/font.cpp:558
+#, fuzzy
+msgid "Failed to create font configuration object."
+msgstr "Не удалось обновить пользовательский файл конфигурации."
+
+#: ../src/gtk/font.cpp:568
+#, fuzzy, c-format
+msgid "Failed to add custom font \"%s\"."
+msgstr "Не удалось прочесть документ из файла \"%s\"."
+
+#: ../src/gtk/font.cpp:576
+#, fuzzy
+msgid "Failed to register font configuration using private fonts."
+msgstr "Не удалось обновить пользовательский файл конфигурации."
+
+#: ../src/gtk/glcanvas.cpp:117 ../src/gtk/glcanvas.cpp:132
+#, fuzzy
+msgid "Fatal Error"
+msgstr "Ошибка файла"
+
+#: ../src/gtk/glcanvas.cpp:117
+msgid ""
+"This program wasn't compiled with EGL support required under Wayland, "
+"either\n"
+"install EGL libraries and rebuild or run it under X11 backend by setting\n"
+"environment variable GDK_BACKEND=x11 before starting your program."
+msgstr ""
+
+#: ../src/gtk/glcanvas.cpp:132
+msgid ""
+"wxGLCanvas is only supported on Wayland and X11 currently.  You may be able "
+"to\n"
+"work around this by setting environment variable GDK_BACKEND=x11 before\n"
+"starting your program."
+msgstr ""
+
+#: ../src/gtk/mdi.cpp:433
+msgid "MDI child"
+msgstr "Дочерний MDI"
+
+#: ../src/gtk/power.cpp:188
+#, fuzzy, c-format
+msgid "Failed to open D-Bus connection to the login manager: %s"
+msgstr "Невозможно создать подключение к серверу '%s' по теме '%s'"
+
+#: ../src/gtk/power.cpp:214
+#, fuzzy
+msgid "wxWidgets application"
+msgstr "Приложение"
+
+#: ../src/gtk/power.cpp:226
+msgid "Application needs to keep running"
+msgstr ""
+
+#: ../src/gtk/power.cpp:233
+msgid "Clean up before suspend"
+msgstr ""
+
+#: ../src/gtk/power.cpp:259
+#, fuzzy, c-format
+msgid "Failed to inhibit sleep: %s"
+msgstr "Не удалось установить модемное соединение: %s"
+
+#: ../src/gtk/power.cpp:265
+msgid "Unexpected response to D-Bus \"Inhibit\" request."
+msgstr ""
+
+#: ../src/gtk/print.cpp:218
+msgid "Custom size"
+msgstr "Задать размер"
+
+#: ../src/gtk/print.cpp:752
+#, fuzzy, c-format
+msgid "Error while printing: %s"
+msgstr "Ошибка при печати: "
+
+#: ../src/gtk/print.cpp:816
+msgid "Page Setup"
+msgstr "Настройки страницы"
+
+#: ../src/gtk/webview_webkit.cpp:932
+msgid "Retrieving JavaScript script output is not supported with WebKit v1"
+msgstr ""
+
+#: ../src/gtk/webview_webkit2.cpp:1098
+msgid ""
+"Setting proxy is not supported by WebKit, at least version 2.16 is required."
+msgstr ""
+
+#: ../src/gtk/webview_webkit2.cpp:1104
+msgid "This program was compiled without support for setting WebKit proxy."
+msgstr ""
+
+#: ../src/gtk/window.cpp:6289
+msgid ""
+"GTK+ installed on this machine is too old to support screen compositing, "
+"please install GTK+ 2.12 or later."
+msgstr ""
+"GTK + установленный на этом компьютере слишком стар для поддержки композиции "
+"экрана, установите GTK + 2,12 или новее."
+
+#: ../src/gtk/window.cpp:6307
+msgid ""
+"Compositing not supported by this system, please enable it in your Window "
+"Manager."
+msgstr ""
+"Композитинг не поддерживается этой системой, включите его в своём оконном "
+"менеджере."
+
+#: ../src/gtk/window.cpp:6318
+msgid ""
+"This program was compiled with a too old version of GTK+, please rebuild "
+"with GTK+ 2.12 or newer."
+msgstr ""
+"Эта программа была скомпилирована со слишком старой версией GTK+,  "
+"пересоберите её с GTK+ 2.12 или новее."
+
+#: ../src/html/chm.cpp:138
+#, c-format
+msgid "Failed to open CHM archive '%s'."
+msgstr "Не удалось открыть архив CHM '%s'."
+
+#: ../src/html/chm.cpp:270
+#, c-format
+msgid "Could not extract %s into %s: %s"
+msgstr "Невозможно извлечь %s в %s: %s"
+
+#: ../src/html/chm.cpp:324
+msgid "no error"
+msgstr "нет ошибки"
+
+#: ../src/html/chm.cpp:326
+msgid "bad arguments to library function"
+msgstr "неверные аргументы у библиотечной функции"
+
+#: ../src/html/chm.cpp:328
+msgid "error opening file"
+msgstr "ошибка открытия файла"
+
+#: ../src/html/chm.cpp:330
+msgid "read error"
+msgstr "ошибка чтения"
+
+#: ../src/html/chm.cpp:332
+msgid "write error"
+msgstr "ошибка записи"
+
+#: ../src/html/chm.cpp:334
+msgid "seek error"
+msgstr "ошибка поиска"
+
+#: ../src/html/chm.cpp:338
+msgid "bad signature"
+msgstr "неверная подпись"
+
+#: ../src/html/chm.cpp:340
+msgid "error in data format"
+msgstr "ошибка в формате данных"
+
+#: ../src/html/chm.cpp:342
+msgid "checksum error"
+msgstr "ошибка контрольной суммы"
+
+#: ../src/html/chm.cpp:344
+msgid "compression error"
+msgstr "ошибка сжатия"
+
+#: ../src/html/chm.cpp:346
+msgid "decompression error"
+msgstr "ошибка распаковки"
+
+#: ../src/html/chm.cpp:437
+#, c-format
+msgid "Could not locate file '%s'."
+msgstr "Невозможно найти файл '%s'."
+
+#: ../src/html/chm.cpp:711
+#, c-format
+msgid "Could not create temporary file '%s'"
+msgstr "Невозможно создать временный файл '%s'"
+
+#: ../src/html/chm.cpp:718
+#, c-format
+msgid "Extraction of '%s' into '%s' failed."
+msgstr "Извлечение '%s' в '%s' завершилось неудачно."
+
+#: ../src/html/chm.cpp:806 ../src/html/chm.cpp:863
+msgid "CHM handler currently supports only local files!"
+msgstr "В настоящее время обработчик CHM поддерживает только локальные файлы!"
+
+#: ../src/html/chm.cpp:827
+msgid "Link contained '//', converted to absolute link."
+msgstr "Ссылка содержит '//', преобразована в абсолютную ссылку."
+
+#: ../src/html/helpctrl.cpp:59
+#, c-format
+msgid "Help: %s"
+msgstr "Справка: %s"
+
+#: ../src/html/helpctrl.cpp:155
+#, c-format
+msgid "Adding book %s"
+msgstr "Добавление книги %s"
+
+#: ../src/html/helpdata.cpp:295
+#, c-format
+msgid "Cannot open contents file: %s"
+msgstr "Невозможно открыть файл содержания: %s"
+
+#: ../src/html/helpdata.cpp:309
+#, c-format
+msgid "Cannot open index file: %s"
+msgstr "Невозможно открыть файл индекса: %s"
+
+#: ../src/html/helpdata.cpp:643
+msgid "noname"
+msgstr "без имени"
+
+#: ../src/html/helpdata.cpp:652
+#, c-format
+msgid "Cannot open HTML help book: %s"
+msgstr "Невозможно открыть книгу справки HTML: %s"
+
+#: ../src/html/helpwnd.cpp:315
+msgid "Displays help as you browse the books on the left."
+msgstr "Отображает справку при просмотре книг слева."
+
+#: ../src/html/helpwnd.cpp:411 ../src/html/helpwnd.cpp:1100
+#: ../src/html/helpwnd.cpp:1735
+msgid "(bookmarks)"
+msgstr "(закладки)"
+
+#: ../src/html/helpwnd.cpp:424
+msgid "Add current page to bookmarks"
+msgstr "Добавить текущую страницу в закладки"
+
+#: ../src/html/helpwnd.cpp:425
+msgid "Remove current page from bookmarks"
+msgstr "Удалить текущую страницу из закладок"
+
+#: ../src/html/helpwnd.cpp:470
+msgid "Contents"
+msgstr "Содержание"
+
+#: ../src/html/helpwnd.cpp:485
+msgid "Find"
+msgstr "Найти"
+
+#: ../src/html/helpwnd.cpp:487
+msgid "Show all"
+msgstr "Показать всё"
+
+#: ../src/html/helpwnd.cpp:497
+msgid ""
+"Display all index items that contain given substring. Search is case "
+"insensitive."
+msgstr ""
+"Показать все элементы индекса с заданной подстрокой. При поиске регистр не "
+"учитывается."
+
+#: ../src/html/helpwnd.cpp:498
+msgid "Show all items in index"
+msgstr "Показать все элементы в индексе"
+
+#: ../src/html/helpwnd.cpp:528
+msgid "Case sensitive"
+msgstr "Чувствителен к регистру"
+
+#: ../src/html/helpwnd.cpp:529
+msgid "Whole words only"
+msgstr "Только слова целиком"
+
+#: ../src/html/helpwnd.cpp:532
+msgid ""
+"Search contents of help book(s) for all occurrences of the text you typed "
+"above"
+msgstr "Поиск содержимого книги справки для всех вхождений введённого текста"
+
+#: ../src/html/helpwnd.cpp:653
+msgid "Show/hide navigation panel"
+msgstr "Показать/скрыть панель навигации"
+
+#: ../src/html/helpwnd.cpp:655
+msgid "Go back"
+msgstr "Перейти назад"
+
+#: ../src/html/helpwnd.cpp:656
+msgid "Go forward"
+msgstr "Перейти вперёд"
+
+#: ../src/html/helpwnd.cpp:658
+msgid "Go one level up in document hierarchy"
+msgstr "Перейти на один уровень вверх в иерархии документа"
+
+#: ../src/html/helpwnd.cpp:666 ../src/html/helpwnd.cpp:1547
+msgid "Open HTML document"
+msgstr "Открыть документ HTML"
+
+#: ../src/html/helpwnd.cpp:670
+msgid "Print this page"
+msgstr "Напечатать эту страницу"
+
+#: ../src/html/helpwnd.cpp:674
+msgid "Display options dialog"
+msgstr "Открыть диалог настройки параметров"
+
+#: ../src/html/helpwnd.cpp:795
+msgid "Please choose the page to display:"
+msgstr "Выберите страницу для отображения:"
+
+#: ../src/html/helpwnd.cpp:796
+msgid "Help Topics"
+msgstr "Содержание справки"
+
+#: ../src/html/helpwnd.cpp:852
+msgid "Searching..."
+msgstr "Поиск..."
+
+#: ../src/html/helpwnd.cpp:853
+msgid "No matching page found yet"
+msgstr "Не найдена соответствующая страница"
+
+#: ../src/html/helpwnd.cpp:870
+#, c-format
+msgid "Found %i matches"
+msgstr "Найдено %i соответствий"
+
+#: ../src/html/helpwnd.cpp:958
+msgid "(Help)"
+msgstr "(Справка)"
+
+#: ../src/html/helpwnd.cpp:1026
+#, c-format
+msgid "%d of %lu"
+msgstr "%d из %lu"
+
+#: ../src/html/helpwnd.cpp:1028
+#, c-format
+msgid "%lu of %lu"
+msgstr "%lu из %lu"
+
+#: ../src/html/helpwnd.cpp:1047
+msgid "Search in all books"
+msgstr "Поиск во всех книгах"
+
+#: ../src/html/helpwnd.cpp:1193
+msgid "Help Browser Options"
+msgstr "Параметры просмотра помощи"
+
+#: ../src/html/helpwnd.cpp:1198
+msgid "Normal font:"
+msgstr "Нормальный шрифт:"
+
+#: ../src/html/helpwnd.cpp:1199
+msgid "Fixed font:"
+msgstr "Фиксированный шрифт:"
+
+#: ../src/html/helpwnd.cpp:1200
+msgid "Font size:"
+msgstr "Размер шрифта:"
+
+#: ../src/html/helpwnd.cpp:1245
+msgid "font size"
+msgstr "размер шрифта"
+
+#: ../src/html/helpwnd.cpp:1256
+msgid "Normal face<br>and <u>underlined</u>. "
+msgstr "Нормальный шрифт<br>и <u>подчёркнутый</u>. "
+
+#: ../src/html/helpwnd.cpp:1257
+msgid "<i>Italic face.</i> "
+msgstr "<i>Курсив.</i> "
+
+#: ../src/html/helpwnd.cpp:1258
+msgid "<b>Bold face.</b> "
+msgstr "<b>Жирный.</b> "
+
+#: ../src/html/helpwnd.cpp:1259
+msgid "<b><i>Bold italic face.</i></b><br>"
+msgstr "<b><i>Жирный курсив.</i></b><br>"
+
+#: ../src/html/helpwnd.cpp:1262
+msgid "Fixed size face.<br> <b>bold</b> <i>italic</i> "
+msgstr "Шрифт фиксированного размера.<br> <b>жирный</b> <i>курсив</i> "
+
+#: ../src/html/helpwnd.cpp:1263
+msgid "<b><i>bold italic <u>underlined</u></i></b><br>"
+msgstr "<b><i>жирный курсив <u>подчёркнутый</u></i></b><br>"
+
+#: ../src/html/helpwnd.cpp:1524
+msgid "Help Printing"
+msgstr "Печать помощи"
+
+#: ../src/html/helpwnd.cpp:1527
+msgid "Cannot print empty page."
+msgstr "Невозможно напечатать пустую страницу."
+
+#: ../src/html/helpwnd.cpp:1540
+msgid "HTML files (*.html;*.htm)|*.html;*.htm|"
+msgstr "Файлы HTML (*.html;*.htm)|*.html;*.htm|"
+
+#: ../src/html/helpwnd.cpp:1541
+msgid "Help books (*.htb)|*.htb|Help books (*.zip)|*.zip|"
+msgstr "Книги справки (*.htb)|*.htb|Книги справки (*.zip)|*.zip|"
+
+#: ../src/html/helpwnd.cpp:1542
+msgid "HTML Help Project (*.hhp)|*.hhp|"
+msgstr "Проект справки HTML (*.hhp)|*.hhp|"
+
+#: ../src/html/helpwnd.cpp:1544
+msgid "Compressed HTML Help file (*.chm)|*.chm|"
+msgstr "Сжатый файл справки HTML (*.chm)|*.chm|"
+
+#: ../src/html/helpwnd.cpp:1671
+#, c-format
+msgid "%i of %u"
+msgstr "%i из %u"
+
+#: ../src/html/helpwnd.cpp:1709
+#, c-format
+msgid "%u of %u"
+msgstr "%u из %u"
+
+#: ../src/html/htmlfilt.cpp:134
+#, c-format
+msgid "Cannot open HTML document: %s"
+msgstr "Невозможно открыть HTML документ: %s"
+
+#: ../src/html/htmlwin.cpp:599
+msgid "Connecting..."
+msgstr "Соединение..."
+
+#: ../src/html/htmlwin.cpp:616
+#, c-format
+msgid "Unable to open requested HTML document: %s"
+msgstr "Невозможно открыть запрошенный документ HTML: %s"
+
+#: ../src/html/htmlwin.cpp:630
+msgid "Loading : "
+msgstr "Загрузка : "
+
+#: ../src/html/htmlwin.cpp:673
+msgid "Done"
+msgstr "Готово"
+
+#: ../src/html/htmlwin.cpp:723
+#, c-format
+msgid "HTML anchor %s does not exist."
+msgstr "HTML-якорь %s не существует."
+
+#: ../src/html/htmlwin.cpp:1057
+#, c-format
+msgid "Copied to clipboard:\"%s\""
+msgstr "Скопировано в буфер обмена: '%s'"
+
+#: ../src/html/htmprint.cpp:269
+msgid ""
+"This document doesn't fit on the page horizontally and will be truncated "
+"when it is printed."
+msgstr ""
+"Этот документ не помещается на странице горизонтально и будет обрезан при "
+"печати."
+
+#: ../src/html/htmprint.cpp:285
+#, c-format
+msgid ""
+"The document \"%s\" doesn't fit on the page horizontally and will be "
+"truncated if printed.\n"
+"\n"
+"Would you like to proceed with printing it nevertheless?"
+msgstr ""
+"Документ '%s' не помещается на странице горизонтально и будет обрезан при "
+"печати.\n"
+"\n"
+"Тем не менее, вы  точно хотите продолжить печать?"
+
+#: ../src/html/htmprint.cpp:296
+msgid ""
+"If possible, try changing the layout parameters to make the printout more "
+"narrow."
+msgstr ""
+"Если возможно, попробуйте изменить параметры макета, чтобы сделать печать "
+"более узкой."
+
+#: ../src/html/htmprint.cpp:445
+msgid ": file does not exist!"
+msgstr ": файл не существует!"
+
+#. TRANSLATORS: %s may be a document title.
+#: ../src/html/htmprint.cpp:717
+#, fuzzy, c-format
+msgid "%s Preview"
+msgstr " Предпросмотр"
+
+#: ../src/html/htmprint.cpp:755 ../src/richtext/richtextprint.cpp:618
+msgid ""
+"There was a problem during page setup: you may need to set a default printer."
+msgstr ""
+"Возникла проблема при настройке страницы: необходимо задать принтер по-"
+"умолчанию."
+
+#: ../src/msw/clipbrd.cpp:80
+msgid "Failed to open the clipboard."
+msgstr "Не удалось открыть буфер обмена."
+
+#: ../src/msw/clipbrd.cpp:101
+msgid "Failed to close the clipboard."
+msgstr "Не удалось закрыть буфер обмена."
+
+#: ../src/msw/clipbrd.cpp:113
+msgid "Failed to empty the clipboard."
+msgstr "Не удалось очистить буфер обмена."
+
+#: ../src/msw/clipbrd.cpp:284
+msgid "Failed to put data on the clipboard"
+msgstr "Не удалось поместить данные в буфер обмена"
+
+#: ../src/msw/clipbrd.cpp:326
+msgid "Failed to get data from the clipboard"
+msgstr "Не удалось получить данные из буфера обмена"
+
+#: ../src/msw/clipbrd.cpp:363
+msgid "Failed to retrieve the supported clipboard formats"
+msgstr "Не удалось найти форматы, поддерживаемые буфером обмена"
+
+#: ../src/msw/colordlg.cpp:228
+#, c-format
+msgid "Colour selection dialog failed with error %0lx."
+msgstr "В диалоговом окне выбора цвета произошла ошибка %0lx."
+
+#: ../src/msw/cursor.cpp:141
+msgid "Failed to create cursor."
+msgstr "Ошибка создания курсора."
+
+#: ../src/msw/dde.cpp:279
+#, c-format
+msgid "Failed to register DDE server '%s'"
+msgstr "Не удалось зарегистрировать сервер DDE '%s'"
+
+#: ../src/msw/dde.cpp:300
+#, c-format
+msgid "Failed to unregister DDE server '%s'"
+msgstr "Не удалось отменить регистрацию DDE сервера '%s'"
+
+#: ../src/msw/dde.cpp:428
+#, c-format
+msgid "Failed to create connection to server '%s' on topic '%s'"
+msgstr "Невозможно создать подключение к серверу '%s' по теме '%s'"
+
+#: ../src/msw/dde.cpp:655
+msgid "DDE poke request failed"
+msgstr "Ошибка запроса DDE poke"
+
+#: ../src/msw/dde.cpp:674
+msgid "Failed to establish an advise loop with DDE server"
+msgstr "Невозможно установить 'advise loop' с DDE сервером"
+
+#: ../src/msw/dde.cpp:693
+msgid "Failed to terminate the advise loop with DDE server"
+msgstr "Не удалось завершить 'advise loop' у DDE сервера"
+
+#: ../src/msw/dde.cpp:768
+msgid "Failed to send DDE advise notification"
+msgstr "Невозможно послать advise уведомление DDE"
+
+#: ../src/msw/dde.cpp:1085
+msgid "Failed to create DDE string"
+msgstr "Ошибка создания строки DDE"
+
+#: ../src/msw/dde.cpp:1131
+msgid "no DDE error."
+msgstr "нет ошибки DDE."
+
+#: ../src/msw/dde.cpp:1135
+msgid "a request for a synchronous advise transaction has timed out."
+msgstr "тайм-аут запроса для синхронной консультации."
+
+#: ../src/msw/dde.cpp:1138
+msgid "the response to the transaction caused the DDE_FBUSY bit to be set."
+msgstr "ответ на транзакцию вызвал бит DDE_FBUSY."
+
+#: ../src/msw/dde.cpp:1141
+msgid "a request for a synchronous data transaction has timed out."
+msgstr "тайм-аут запроса на синхронную транзакцию данных."
+
+#: ../src/msw/dde.cpp:1144
+msgid ""
+"a DDEML function was called without first calling the DdeInitialize "
+"function,\n"
+"or an invalid instance identifier\n"
+"was passed to a DDEML function."
+msgstr ""
+"функция DDEML была вызвана без первоначального вызова функции "
+"DdeInitialize,\n"
+"или неверный идентификатор экземпляра\n"
+"был передан в функцию DDEML."
+
+#: ../src/msw/dde.cpp:1147
+msgid ""
+"an application initialized as APPCLASS_MONITOR has\n"
+"attempted to perform a DDE transaction,\n"
+"or an application initialized as APPCMD_CLIENTONLY has \n"
+"attempted to perform server transactions."
+msgstr ""
+"приложение, инициализированное как APPCLASS_MONITOR,\n"
+"пыталось выполнить транзакцию DDE\n"
+"или приложение, инициализированное как APPCMD_CLIENTONLY,\n"
+"пыталось осуществить серверную транзакцию."
+
+#: ../src/msw/dde.cpp:1150
+msgid "a request for a synchronous execute transaction has timed out."
+msgstr "тайм-аут запроса для синхронной транзакции Execute."
+
+#: ../src/msw/dde.cpp:1153
+msgid "a parameter failed to be validated by the DDEML."
+msgstr "не удалось проверить параметр с помощью DDEML."
+
+#: ../src/msw/dde.cpp:1156
+msgid "a DDEML application has created a prolonged race condition."
+msgstr "приложение DDEML создало длительный race condition."
+
+#: ../src/msw/dde.cpp:1159
+msgid "a memory allocation failed."
+msgstr "ошибка выделения памяти."
+
+#: ../src/msw/dde.cpp:1162
+msgid "a client's attempt to establish a conversation has failed."
+msgstr "не удалась попытка клиента установить диалог."
+
+#: ../src/msw/dde.cpp:1165
+msgid "a transaction failed."
+msgstr "транзакция завершилась с ошибкой."
+
+#: ../src/msw/dde.cpp:1168
+msgid "a request for a synchronous poke transaction has timed out."
+msgstr "тайм-аут запроса на синхронную транзакцию."
+
+#: ../src/msw/dde.cpp:1171
+msgid "an internal call to the PostMessage function has failed. "
+msgstr "внутренний вызов функции PostMessage не удался. "
+
+#: ../src/msw/dde.cpp:1174
+msgid "reentrancy problem."
+msgstr "проблема повторного входа."
+
+#: ../src/msw/dde.cpp:1177
+msgid ""
+"a server-side transaction was attempted on a conversation\n"
+"that was terminated by the client, or the server\n"
+"terminated before completing a transaction."
+msgstr ""
+"транзакция на стороне сервера попыталась произвести диалог,\n"
+"который был прерван клиентом, либо работа сервера\n"
+"была остановлена до завершения транзакции."
+
+#: ../src/msw/dde.cpp:1180
+msgid "an internal error has occurred in the DDEML."
+msgstr "в DDEML произошла внутренняя ошибка."
+
+#: ../src/msw/dde.cpp:1183
+msgid "a request to end an advise transaction has timed out."
+msgstr "тайм-аут запроса на завершение проводки рекомендаций."
+
+#: ../src/msw/dde.cpp:1186
+msgid ""
+"an invalid transaction identifier was passed to a DDEML function.\n"
+"Once the application has returned from an XTYP_XACT_COMPLETE callback,\n"
+"the transaction identifier for that callback is no longer valid."
+msgstr ""
+"неверный идентификатор транзакции был передан функции DDEML.\n"
+"Как только приложение вернётся из обратного вызова XTYP_XACT_COMPLETE,\n"
+"идентификатор транзакции для этого обратного вызова более недействителен."
+
+#: ../src/msw/dde.cpp:1189
+#, c-format
+msgid "Unknown DDE error %08x"
+msgstr "Неизвестная ошибка DDE %08x"
+
+#: ../src/msw/dialup.cpp:343
+msgid ""
+"Dial up functions are unavailable because the remote access service (RAS) is "
+"not installed on this machine. Please install it."
+msgstr ""
+"Функции набора номера недоступны, так как сервис удалённого доступа (RAS) не "
+"установлен на этой машине. Установите его."
+
+#: ../src/msw/dialup.cpp:402
+#, c-format
+msgid ""
+"The version of remote access service (RAS) installed on this machine is too "
+"old, please upgrade (the following required function is missing: %s)."
+msgstr ""
+"Версия службы удаленного доступа (RAS), установленная на этом компьютере, "
+"слишком старая, обновите её (отсутствует следующая необходимая функция: %s)."
+
+#: ../src/msw/dialup.cpp:437
+msgid "Failed to retrieve text of RAS error message"
+msgstr "Не удалось получить текст сообщения об ошибке RAS"
+
+#: ../src/msw/dialup.cpp:440
+#, c-format
+msgid "unknown error (error code %08x)."
+msgstr "неизвестная ошибка (код ошибки %08x)"
+
+#: ../src/msw/dialup.cpp:492
+#, c-format
+msgid "Cannot find active dialup connection: %s"
+msgstr "Невозможно найти активное модемное соединение: %s"
+
+#: ../src/msw/dialup.cpp:513
+msgid "Several active dialup connections found, choosing one randomly."
+msgstr ""
+"Найдено несколько активных соединений, выбираем одно случайным образом."
+
+#: ../src/msw/dialup.cpp:598 ../src/msw/dialup.cpp:832
+#, c-format
+msgid "Failed to establish dialup connection: %s"
+msgstr "Невозможно установить модемное соединение: %s"
+
+#: ../src/msw/dialup.cpp:664
+#, c-format
+msgid "Failed to get ISP names: %s"
+msgstr "Не удалось получить имена ISP: %s"
+
+#: ../src/msw/dialup.cpp:712
+msgid "Failed to connect: no ISP to dial."
+msgstr "Невозможно подключиться: нет ISP для набора номера."
+
+#: ../src/msw/dialup.cpp:732
+msgid "Choose ISP to dial"
+msgstr "Выберите провайдера для набора номера"
+
+#: ../src/msw/dialup.cpp:733
+msgid "Please choose which ISP do you want to connect to"
+msgstr "Выберите ISP, к которому хотите подключиться"
+
+#: ../src/msw/dialup.cpp:766
+msgid "Failed to connect: missing username/password."
+msgstr "Невозможно подключиться: отсутствует имя/пароль."
+
+#: ../src/msw/dialup.cpp:796
+msgid "Cannot find the location of address book file"
+msgstr "Файл с адресной книжкой не найден"
+
+#: ../src/msw/dialup.cpp:827
+#, c-format
+msgid "Failed to initiate dialup connection: %s"
+msgstr "Не удалось установить модемное соединение: %s"
+
+#: ../src/msw/dialup.cpp:897
+msgid "Cannot hang up - no active dialup connection."
+msgstr "Невозможно повесить трубку - нет активного модемного соединения."
+
+#: ../src/msw/dialup.cpp:907
+#, c-format
+msgid "Failed to terminate the dialup connection: %s"
+msgstr "Не удалось завершить модемное подключение: %s"
+
+#: ../src/msw/dib.cpp:313
+#, c-format
+msgid "Failed to save the bitmap image to file \"%s\"."
+msgstr "Невозможно сохранить изображение в файл \"%s\"."
+
+#: ../src/msw/dib.cpp:543
+#, c-format
+msgid "Failed to allocate %luKb of memory for bitmap data."
+msgstr "Не удалось выделить %lu Кб памяти для растровых данных."
+
+#: ../src/msw/dir.cpp:241
+#, c-format
+msgid "Cannot enumerate files in directory '%s'"
+msgstr "Не удаётся перечислить файлы в каталоге '%s'"
+
+#: ../src/msw/dirdlg.cpp:368
+msgid "Couldn't obtain folder name"
+msgstr "Не удалось получить имя папки"
+
+#: ../src/msw/dlmsw.cpp:163
+#, fuzzy, c-format
+msgid "(error %d: %s)"
+msgstr " (ошибка %ld: %s)"
+
+#: ../src/msw/dragimag.cpp:143 ../src/msw/dragimag.cpp:178
+#: ../src/msw/imaglist.cpp:309 ../src/msw/imaglist.cpp:331
+msgid "Couldn't add an image to the image list."
+msgstr "Невозможно добавить изображение в список изображений."
+
+#: ../src/msw/enhmeta.cpp:94
+#, c-format
+msgid "Failed to load metafile from file \"%s\"."
+msgstr "Невозможно загрузить метафайл из файла \"%s\"."
+
+#: ../src/msw/fdrepdlg.cpp:412
+#, c-format
+msgid "Failed to create the standard find/replace dialog (error code %d)"
+msgstr "Невозможно создать стандартный диалог поиска/замены (код ошибки %d)"
+
+#: ../src/msw/filedlg.cpp:1241
+msgid "Access to the file system is not allowed from secure desktop."
+msgstr ""
+
+#: ../src/msw/filedlg.cpp:1242
+msgid "Security warning"
+msgstr ""
+
+#: ../src/msw/filedlg.cpp:1533
+#, c-format
+msgid "File dialog failed with error code %0lx."
+msgstr "В файловом диалоговом окне произошла ошибка с кодом %0lx."
+
+#: ../src/msw/font.cpp:1120
+#, fuzzy, c-format
+msgid "Font file \"%s\" couldn't be loaded"
+msgstr "Не удалось загрузить файл."
+
+#: ../src/msw/fontdlg.cpp:220
+#, c-format
+msgid "Common dialog failed with error code %0lx."
+msgstr "В общим диалоговом окне произошла ошибка с кодом %0lx."
+
+#: ../src/msw/fswatcher.cpp:67
+msgid "Ungraceful worker thread termination"
+msgstr "Неизящное завершение рабочего потока"
+
+#: ../src/msw/fswatcher.cpp:81
+msgid "Unable to create IOCP worker thread"
+msgstr "Невозможно создать рабочий поток IOCP"
+
+#: ../src/msw/fswatcher.cpp:88
+msgid "Unable to start IOCP worker thread"
+msgstr "Не удалось запустить IOCP Рабочий поток"
+
+#: ../src/msw/fswatcher.cpp:140
+msgid "Monitoring individual files for changes is not supported currently."
+msgstr ""
+"Мониторинг измененй отдельных файлов  в настоящее время не поддерживается."
+
+#: ../src/msw/fswatcher.cpp:165
+#, c-format
+msgid "Unable to set up watch for '%s'"
+msgstr "Не удалось настроить отслеживание '%s'"
+
+#: ../src/msw/fswatcher.cpp:466
+#, c-format
+msgid "Can't monitor non-existent directory \"%s\" for changes."
+msgstr "Невозможно контролировать несуществующий каталог '%s' для изменений."
+
+#: ../src/msw/glcanvas.cpp:577 ../src/unix/glx11.cpp:507
+msgid "OpenGL 3.0 or later is not supported by the OpenGL driver."
+msgstr ""
+"OpenGL 3,0 или более поздней версии не поддерживается драйвером OpenGL."
+
+#: ../src/msw/glcanvas.cpp:601 ../src/osx/glcanvas_osx.cpp:395
+#: ../src/unix/glegl.cpp:304 ../src/unix/glx11.cpp:553
+msgid "Couldn't create OpenGL context"
+msgstr "Не удалось создать контекст OpenGL"
+
+#: ../src/msw/glcanvas.cpp:1294
+msgid "Failed to initialize OpenGL"
+msgstr "Невозможно инициализировать OpenGL"
+
+#: ../src/msw/graphicsd2d.cpp:607
+msgid "Could not register custom DirectWrite font loader."
+msgstr ""
+
+#: ../src/msw/helpchm.cpp:48
+msgid ""
+"MS HTML Help functions are unavailable because the MS HTML Help library is "
+"not installed on this machine. Please install it."
+msgstr ""
+"Функции справки MS HTML недоступны, так как библиотека справки MS HTML не "
+"установлена на этой машине. Установите её."
+
+#: ../src/msw/helpchm.cpp:55
+msgid "Failed to initialize MS HTML Help."
+msgstr "Ошибка инициализации справки MS HTML."
+
+#: ../src/msw/iniconf.cpp:458
+#, c-format
+msgid "Can't delete the INI file '%s'"
+msgstr "Невозможно удалить INI-файл '%s'"
+
+#: ../src/msw/listctrl.cpp:995
+#, c-format
+msgid "Couldn't retrieve information about list control item %d."
+msgstr "Невозможно получить информацию об элементе списка %d."
+
+#: ../src/msw/mdi.cpp:170 ../src/qt/mdi.cpp:253
+msgid "&Cascade"
+msgstr "&Каскадом"
+
+#: ../src/msw/mdi.cpp:171
+msgid "Tile &Horizontally"
+msgstr "Плитка по &горизонтали"
+
+#: ../src/msw/mdi.cpp:172
+msgid "Tile &Vertically"
+msgstr "Плитка &вертикально"
+
+#: ../src/msw/mdi.cpp:174
+msgid "&Arrange Icons"
+msgstr "&Упорядочить значки"
+
+#: ../src/msw/mdi.cpp:621
+msgid "Failed to create MDI parent frame."
+msgstr "Ошибка создания родительского фрейма MDI."
+
+#: ../src/msw/mimetype.cpp:234
+#, c-format
+msgid "Failed to create registry entry for '%s' files."
+msgstr "Невозможно создать элемент реестра для '%s' файлов."
+
+#: ../src/msw/ole/automtn.cpp:495
+#, c-format
+msgid "Failed to find CLSID of \"%s\""
+msgstr "Не удалось найти CLSID '%s'"
+
+#: ../src/msw/ole/automtn.cpp:512
+#, c-format
+msgid "Failed to create an instance of \"%s\""
+msgstr "Ошибка создания экземпляра  '%s'"
+
+#: ../src/msw/ole/automtn.cpp:552
+#, c-format
+msgid "Cannot get an active instance of \"%s\""
+msgstr "Не удается получить активный экземпляр '%s'"
+
+#: ../src/msw/ole/automtn.cpp:564
+#, c-format
+msgid "Failed to get OLE automation interface for \"%s\""
+msgstr "Не удалось получить интерфейс OLE-автоматизации для \" %s\""
+
+#: ../src/msw/ole/automtn.cpp:621
+msgid "Unknown name or named argument."
+msgstr "Неизвестное имя или именованный аргумент."
+
+#: ../src/msw/ole/automtn.cpp:625
+msgid "Incorrect number of arguments."
+msgstr "Неверное количество аргументов."
+
+#: ../src/msw/ole/automtn.cpp:637
+msgid "Unknown exception"
+msgstr "Неизвестное исключение"
+
+#: ../src/msw/ole/automtn.cpp:642
+msgid "Method or property not found."
+msgstr "Метод или свойство не найдено."
+
+#: ../src/msw/ole/automtn.cpp:646
+msgid "Overflow while coercing argument values."
+msgstr "Переполнение при принудительном значении аргументов."
+
+#: ../src/msw/ole/automtn.cpp:650
+msgid "Object implementation does not support named arguments."
+msgstr "Реализация объекта не поддерживает именованные аргументы."
+
+#: ../src/msw/ole/automtn.cpp:654
+msgid "The locale ID is unknown."
+msgstr "ID языкового стандарта неизвестен."
+
+#: ../src/msw/ole/automtn.cpp:658
+msgid "Missing a required parameter."
+msgstr "Отсутствует обязательный параметр."
+
+#: ../src/msw/ole/automtn.cpp:662
+#, c-format
+msgid "Argument %u not found."
+msgstr "Аргумент %u не найден."
+
+#: ../src/msw/ole/automtn.cpp:666
+#, c-format
+msgid "Type mismatch in argument %u."
+msgstr "Несоответствие типов в аргументе %u."
+
+#: ../src/msw/ole/automtn.cpp:670
+msgid "The system cannot find the file specified."
+msgstr "Система не может найти указанный файл."
+
+#: ../src/msw/ole/automtn.cpp:674
+msgid "Class not registered."
+msgstr "Класс не зарегистрирован."
+
+#: ../src/msw/ole/automtn.cpp:678
+#, c-format
+msgid "Unknown error %08x"
+msgstr "Неизвестная ошибка %08x"
+
+#: ../src/msw/ole/automtn.cpp:682
+#, c-format
+msgid "OLE Automation error in %s: %s"
+msgstr "Ошибка OLE-автоматизации в %s: %s"
+
+#: ../src/msw/ole/dataobj.cpp:385
+#, c-format
+msgid "Couldn't register clipboard format '%s'."
+msgstr "Невозможно зарегистрировать формат буфера обмена '%s'."
+
+#: ../src/msw/ole/dataobj.cpp:402
+#, c-format
+msgid "The clipboard format '%d' doesn't exist."
+msgstr "Формат буфера обмена '%d' не существует."
+
+#: ../src/msw/progdlg.cpp:1025
+msgid "Skip"
+msgstr "Пропустить"
+
+#: ../src/msw/registry.cpp:141
+#, c-format
+msgid "unknown (%lu)"
+msgstr "неизвестно (%lu)"
+
+#: ../src/msw/registry.cpp:409
+#, c-format
+msgid "Can't get info about registry key '%s'"
+msgstr "Невозможно получить информацию о ключе реестра '%s'"
+
+#: ../src/msw/registry.cpp:445
+#, c-format
+msgid "Can't open registry key '%s'"
+msgstr "Невозможно открыть ключ реестра '%s'"
+
+#: ../src/msw/registry.cpp:478
+#, c-format
+msgid "Can't create registry key '%s'"
+msgstr "Невозможно создать ключ реестра '%s'"
+
+#: ../src/msw/registry.cpp:497
+#, c-format
+msgid "Can't close registry key '%s'"
+msgstr "Невозможно закрыть ключ реестра '%s'"
+
+#: ../src/msw/registry.cpp:512
+#, c-format
+msgid "Registry value '%s' already exists."
+msgstr "Значение реестра '%s' уже существует."
+
+#: ../src/msw/registry.cpp:520
+#, c-format
+msgid "Failed to rename registry value '%s' to '%s'."
+msgstr "Невозможно переименовать значение реестра из '%s' в '%s'."
+
+#: ../src/msw/registry.cpp:575
+#, c-format
+msgid "Can't copy values of unsupported type %d."
+msgstr "Невозможно скопировать значения неподдерживаемого типа %d."
+
+#: ../src/msw/registry.cpp:586
+#, c-format
+msgid "Registry key '%s' does not exist, cannot rename it."
+msgstr "Ключ реестра '%s' не существует, невозможно его переименовать."
+
+#: ../src/msw/registry.cpp:617
+#, c-format
+msgid "Registry key '%s' already exists."
+msgstr "Ключ реестра '%s' уже существует."
+
+#: ../src/msw/registry.cpp:625
+#, c-format
+msgid "Failed to rename the registry key '%s' to '%s'."
+msgstr "Невозможно переименовать ключ реестра из '%s' в '%s'."
+
+#: ../src/msw/registry.cpp:670
+#, c-format
+msgid "Failed to copy the registry subkey '%s' to '%s'."
+msgstr "Невозможно скопировать подключ реестра '%s' в '%s."
+
+#: ../src/msw/registry.cpp:683
+#, c-format
+msgid "Failed to copy registry value '%s'"
+msgstr "Невозможно скопировать значение реестра '%s'"
+
+#: ../src/msw/registry.cpp:692
+#, c-format
+msgid "Failed to copy the contents of registry key '%s' to '%s'."
+msgstr "Невозможно копировать содержимое ключа реестра '%s' в '%s'."
+
+#: ../src/msw/registry.cpp:718
+#, c-format
+msgid ""
+"Registry key '%s' is needed for normal system operation,\n"
+"deleting it will leave your system in unusable state:\n"
+"operation aborted."
+msgstr ""
+"Ключ реестра '%s' необходим для нормальной работы системы,\n"
+"его удаление приведёт вашу систему в нерабочее состояние:\n"
+"операция прервана."
+
+#: ../src/msw/registry.cpp:754
+#, c-format
+msgid "Can't delete key '%s'"
+msgstr "Невозможно удалить ключ '%s'"
+
+#: ../src/msw/registry.cpp:782
+#, c-format
+msgid "Can't delete value '%s' from key '%s'"
+msgstr "Невозможно удалить значение '%s' из ключа '%s'"
+
+#: ../src/msw/registry.cpp:855 ../src/msw/registry.cpp:887
+#: ../src/msw/registry.cpp:929 ../src/msw/registry.cpp:1000
+#, c-format
+msgid "Can't read value of key '%s'"
+msgstr "Невозможно прочесть значение ключа '%s'"
+
+#: ../src/msw/registry.cpp:873 ../src/msw/registry.cpp:915
+#: ../src/msw/registry.cpp:963 ../src/msw/registry.cpp:1106
+#, c-format
+msgid "Can't set value of '%s'"
+msgstr "Невозможно установить значение '%s'"
+
+#: ../src/msw/registry.cpp:894 ../src/msw/registry.cpp:943
+#, c-format
+msgid "Registry value \"%s\" is not numeric (but of type %s)"
+msgstr "Значение реестре '%s' не числовое (но имеет тип %s)"
+
+#: ../src/msw/registry.cpp:979
+#, c-format
+msgid "Registry value \"%s\" is not binary (but of type %s)"
+msgstr "Значение реестра  '%s' не является двоичным (но имеет тип %s)"
+
+#: ../src/msw/registry.cpp:1028
+#, c-format
+msgid "Registry value \"%s\" is not text (but of type %s)"
+msgstr "Значение реестра  '%s' не является текстом (но имеет тип %s)"
+
+#: ../src/msw/registry.cpp:1089
+#, c-format
+msgid "Can't read value of '%s'"
+msgstr "Невозможно прочесть значение '%s'"
+
+#: ../src/msw/registry.cpp:1157
+#, c-format
+msgid "Can't enumerate values of key '%s'"
+msgstr "Невозможно пересчитать значения ключа '%s'"
+
+#: ../src/msw/registry.cpp:1196
+#, c-format
+msgid "Can't enumerate subkeys of key '%s'"
+msgstr "Невозможно пересчитать подключи ключа '%s'"
+
+#: ../src/msw/registry.cpp:1262
+#, c-format
+msgid ""
+"Exporting registry key: file \"%s\" already exists and won't be overwritten."
+msgstr ""
+"Экспорт ключа реестра: файл '%s' уже существует и не будет перезаписан."
+
+#: ../src/msw/registry.cpp:1411
+#, c-format
+msgid "Can't export value of unsupported type %d."
+msgstr "Экспорт значения неподдерживаемого типа %d невозможен."
+
+#: ../src/msw/registry.cpp:1427
+#, c-format
+msgid "Ignoring value \"%s\" of the key \"%s\"."
+msgstr "Значение \"%s\" ключа \"%s\" проигнорировано."
+
+#: ../src/msw/textctrl.cpp:596
+msgid ""
+"Impossible to create a rich edit control, using simple text control instead. "
+"Please reinstall riched32.dll"
+msgstr ""
+"Невозможно создать расширенный элемент управления редактированием с помощью "
+"простого текстового элемента управления. Переустановите riched32.dll"
+
+#: ../src/msw/thread.cpp:522 ../src/unix/threadpsx.cpp:850
+msgid "Cannot start thread: error writing TLS."
+msgstr "Невозможно запустить выполнение потока: ошибка записи TLS."
+
+#: ../src/msw/thread.cpp:613
+msgid "Can't set thread priority"
+msgstr "Невозможно установить приоритет потока"
+
+#: ../src/msw/thread.cpp:649
+msgid "Can't create thread"
+msgstr "Невозможно создать поток"
+
+#: ../src/msw/thread.cpp:668
+msgid "Couldn't terminate thread"
+msgstr "Не могу завершить поток"
+
+#: ../src/msw/thread.cpp:799
+msgid "Cannot wait for thread termination"
+msgstr "Невозможно дождаться окончания выполнения потока"
+
+#: ../src/msw/thread.cpp:873
+#, c-format
+msgid "Cannot suspend thread %lx"
+msgstr "Не удалось приостановить поток %lx"
+
+#: ../src/msw/thread.cpp:903
+#, c-format
+msgid "Cannot resume thread %lx"
+msgstr "Не удалось возобновить поток %lx"
+
+#: ../src/msw/thread.cpp:932
+msgid "Couldn't get the current thread pointer"
+msgstr "Невозможно получить указатель на текущий поток"
+
+#: ../src/msw/thread.cpp:1333
+msgid ""
+"Thread module initialization failed: impossible to allocate index in thread "
+"local storage"
+msgstr ""
+"Ошибка инициализации модуля потоков: невозможно выделить индекс в локальном "
+"пространстве потока"
+
+#: ../src/msw/thread.cpp:1345
+msgid ""
+"Thread module initialization failed: cannot store value in thread local "
+"storage"
+msgstr ""
+"Ошибка инициализации модуля потоков: невозможно сохранить значение в "
+"локальном пространстве потока"
+
+#: ../src/msw/timer.cpp:133
+msgid "Couldn't create a timer"
+msgstr "Невозможно создать таймер"
+
+#: ../src/msw/utils.cpp:372
+msgid "can't find user's HOME, using current directory."
+msgstr "не удалось найи домашний каталог, используется текущий каталог."
+
+#: ../src/msw/utils.cpp:662
+#, c-format
+msgid "Failed to kill process %d"
+msgstr "Не удалось завершить процесс %d"
+
+#: ../src/msw/utils.cpp:986
+#, c-format
+msgid "Failed to load resource \"%s\"."
+msgstr "Не удалось загрузить ресурс \"%s\"."
+
+#: ../src/msw/utils.cpp:993
+#, c-format
+msgid "Failed to lock resource \"%s\"."
+msgstr "Не удалось заблокировать ресурс \"%s\"."
+
+#. TRANSLATORS: MS Windows build number
+#: ../src/msw/utils.cpp:1209
+#, c-format
+msgid "build %lu"
+msgstr "сборка %lu"
+
+#: ../src/msw/utils.cpp:1218
+msgid ", 64-bit edition"
+msgstr ", 64-бит редакция"
+
+#: ../src/msw/utilsexc.cpp:224
+msgid "Failed to create an anonymous pipe"
+msgstr "Ошибка при создании anonymous pipe"
+
+#: ../src/msw/utilsexc.cpp:697
+msgid "Failed to redirect the child process IO"
+msgstr "Не удалось перенаправить ввод/вывод порожденного процесса"
+
+#: ../src/msw/utilsexc.cpp:870
+#, c-format
+msgid "Execution of command '%s' failed"
+msgstr "Ошибка выполнения команды '%s'"
+
+#: ../src/msw/volume.cpp:337
+msgid "Failed to load mpr.dll."
+msgstr "Невозможно загрузить mpr.dll."
+
+#: ../src/msw/volume.cpp:506
+#, c-format
+msgid "Cannot read typename from '%s'!"
+msgstr "Чтение имени типа из '%s' невозможно!"
+
+#: ../src/msw/volume.cpp:615
+#, c-format
+msgid "Cannot load icon from '%s'."
+msgstr "Невозможно загрузить значок из '%s'."
+
+#: ../src/msw/webview_edge.cpp:285
+msgid "This program was compiled without support for setting Edge proxy."
+msgstr ""
+
+#: ../src/msw/webview_ie.cpp:1010
+msgid "Failed to find web view emulation level in the registry"
+msgstr ""
+
+#: ../src/msw/webview_ie.cpp:1019
+msgid "Failed to set web view to modern emulation level"
+msgstr ""
+
+#: ../src/msw/webview_ie.cpp:1027
+msgid "Failed to reset web view to standard emulation level"
+msgstr ""
+
+#: ../src/msw/webview_ie.cpp:1049
+msgid "Can't run JavaScript script without a valid HTML document"
+msgstr ""
+
+#: ../src/msw/webview_ie.cpp:1056
+#, fuzzy
+msgid "Can't get the JavaScript object"
+msgstr "Невозможно установить приоритет потока"
+
+#: ../src/msw/webview_ie.cpp:1070
+#, fuzzy
+msgid "failed to evaluate"
+msgstr "Не удалось выполнить '%s'\n"
+
+#: ../src/osx/cocoa/filedlg.mm:412
+#, fuzzy
+msgid "File type:"
+msgstr "Телетайп"
+
+#: ../src/osx/cocoa/menu.mm:242
+#, fuzzy
+msgctxt "macOS menu name"
+msgid "Window"
+msgstr "Окно"
+
+#: ../src/osx/cocoa/menu.mm:259
+#, fuzzy
+msgctxt "macOS menu name"
+msgid "Help"
+msgstr "Справка"
+
+#: ../src/osx/cocoa/menu.mm:298
+#, fuzzy
+msgctxt "macOS menu item"
+msgid "Minimize"
+msgstr "&Свернуть"
+
+#: ../src/osx/cocoa/menu.mm:303
+#, fuzzy
+msgctxt "macOS menu item"
+msgid "Zoom"
+msgstr "Увеличить"
+
+#: ../src/osx/cocoa/menu.mm:309
+msgctxt "macOS menu item"
+msgid "Bring All to Front"
+msgstr ""
+
+#: ../src/osx/core/sound.cpp:143
+#, c-format
+msgid "Failed to load sound from \"%s\" (error %d)."
+msgstr "Не удалось загрузить звук из '%s' (ошибка %d)."
+
+#: ../src/osx/fontutil.cpp:80
+#, fuzzy, c-format
+msgid "Font file \"%s\" doesn't exist."
+msgstr ": файл не существует!"
+
+#: ../src/osx/fontutil.cpp:88
+#, c-format
+msgid ""
+"Font file \"%s\" cannot be used as it is not inside the font directory "
+"\"%s\"."
+msgstr ""
+
+#: ../src/osx/menu_osx.cpp:496
+#, c-format
+msgctxt "macOS menu item"
+msgid "About %s"
+msgstr "О программе %s"
+
+#: ../src/osx/menu_osx.cpp:499
+msgctxt "macOS menu item"
+msgid "About..."
+msgstr "О программе..."
+
+#: ../src/osx/menu_osx.cpp:508
+msgctxt "macOS menu item"
+msgid "Preferences..."
+msgstr "Параметры..."
+
+#: ../src/osx/menu_osx.cpp:512
+msgctxt "macOS menu item"
+msgid "Services"
+msgstr "Службы"
+
+#: ../src/osx/menu_osx.cpp:519
+#, c-format
+msgctxt "macOS menu item"
+msgid "Hide %s"
+msgstr "Скрыть %s"
+
+#: ../src/osx/menu_osx.cpp:522
+#, fuzzy
+msgctxt "macOS menu item"
+msgid "Hide Application"
+msgstr "Приложение"
+
+#: ../src/osx/menu_osx.cpp:526
+msgctxt "macOS menu item"
+msgid "Hide Others"
+msgstr "Скрыть остальные"
+
+#: ../src/osx/menu_osx.cpp:528
+msgctxt "macOS menu item"
+msgid "Show All"
+msgstr "Показать всё"
+
+#: ../src/osx/menu_osx.cpp:534
+#, c-format
+msgctxt "macOS menu item"
+msgid "Quit %s"
+msgstr "Выход из %s"
+
+#: ../src/osx/menu_osx.cpp:537
+#, fuzzy
+msgctxt "macOS menu item"
+msgid "Quit Application"
+msgstr "Приложение"
+
+#: ../src/osx/webview_webkit.mm:444
+#, fuzzy
+msgid "Printing is not supported by the system web control"
+msgstr "Gzip не поддерживается этой версией zlib"
+
+#: ../src/osx/webview_webkit.mm:453
+msgid "Print operation could not be initialized"
+msgstr ""
+
+#. TRANSLATORS: Label of font point size
+#: ../src/propgrid/advprops.cpp:605
+msgid "Point Size"
+msgstr "Размер точки"
+
+#. TRANSLATORS: Label of font face name
+#: ../src/propgrid/advprops.cpp:615
+msgid "Face Name"
+msgstr "Название семейства"
+
+#. TRANSLATORS: Label of font style
+#: ../src/propgrid/advprops.cpp:623 ../src/richtext/richtextformatdlg.cpp:331
+msgid "Style"
+msgstr "Стиль"
+
+#. TRANSLATORS: Label of font weight
+#: ../src/propgrid/advprops.cpp:628
+msgid "Weight"
+msgstr "Вес"
+
+#. TRANSLATORS: Label of underlined font
+#: ../src/propgrid/advprops.cpp:633 ../src/richtext/richtextfontpage.cpp:358
+msgid "Underlined"
+msgstr "Подчёркнутый"
+
+#. TRANSLATORS: Label of font family
+#: ../src/propgrid/advprops.cpp:637
+msgid "Family"
+msgstr "Семейство"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:801
+msgid "AppWorkspace"
+msgstr "AppWorkspace"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:802
+msgid "ActiveBorder"
+msgstr "АктивнаяГраница"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:803
+msgid "ActiveCaption"
+msgstr "АктивныйЗаголовок"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:804
+msgid "ButtonFace"
+msgstr "ВерхКнопки"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:805
+msgid "ButtonHighlight"
+msgstr "ПодсветкаКнопки"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:806
+msgid "ButtonShadow"
+msgstr "ТеньКнопки"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:807
+msgid "ButtonText"
+msgstr "ButtonText"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:808
+msgid "CaptionText"
+msgstr "CaptionText"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:809
+msgid "ControlDark"
+msgstr "ControlDark"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:810
+msgid "ControlLight"
+msgstr "ControlLight"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:812
+msgid "GrayText"
+msgstr "СерыйТекст"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:813
+msgid "Highlight"
+msgstr "Подсветка"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:814
+msgid "HighlightText"
+msgstr "Выделить текст"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:815
+msgid "InactiveBorder"
+msgstr "НеактивнаяГраница"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:816
+msgid "InactiveCaption"
+msgstr "InactiveCaption"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:817
+msgid "InactiveCaptionText"
+msgstr "InactiveCaptionText"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:818
+msgid "Menu"
+msgstr "Меню"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:819
+msgid "Scrollbar"
+msgstr "Полоса прокрутки"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:820
+msgid "Tooltip"
+msgstr "Подсказка"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:821
+msgid "TooltipText"
+msgstr "ТекстПодсказки"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:822
+msgid "Window"
+msgstr "Окно"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:823
+msgid "WindowFrame"
+msgstr "РамкаОкна"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:824
+msgid "WindowText"
+msgstr "WindowText"
+
+#. TRANSLATORS: Custom colour choice entry
+#: ../src/propgrid/advprops.cpp:825 ../src/propgrid/advprops.cpp:1532
+#: ../src/propgrid/advprops.cpp:1576
+msgid "Custom"
+msgstr "Задать"
+
+#: ../src/propgrid/advprops.cpp:1558
+msgid "Black"
+msgstr "Чёрный"
+
+#: ../src/propgrid/advprops.cpp:1559
+msgid "Maroon"
+msgstr "Каштановый"
+
+#: ../src/propgrid/advprops.cpp:1560
+msgid "Navy"
+msgstr "Синий"
+
+#: ../src/propgrid/advprops.cpp:1561
+msgid "Purple"
+msgstr "Фиолетовый"
+
+#: ../src/propgrid/advprops.cpp:1562
+msgid "Teal"
+msgstr "Сине-зелёный"
+
+#: ../src/propgrid/advprops.cpp:1563
+msgid "Gray"
+msgstr "Серый"
+
+#: ../src/propgrid/advprops.cpp:1564
+msgid "Green"
+msgstr "Зелёный"
+
+#: ../src/propgrid/advprops.cpp:1565
+msgid "Olive"
+msgstr "Оливковый"
+
+#: ../src/propgrid/advprops.cpp:1566
+msgid "Brown"
+msgstr "Коричневый"
+
+#: ../src/propgrid/advprops.cpp:1567
+msgid "Blue"
+msgstr "Голубой"
+
+#: ../src/propgrid/advprops.cpp:1568
+msgid "Fuchsia"
+msgstr "Пурпурный"
+
+#: ../src/propgrid/advprops.cpp:1569
+msgid "Red"
+msgstr "Красный"
+
+#: ../src/propgrid/advprops.cpp:1570
+msgid "Orange"
+msgstr "Оранжевый"
+
+#: ../src/propgrid/advprops.cpp:1571
+msgid "Silver"
+msgstr "Серебряный"
+
+#: ../src/propgrid/advprops.cpp:1572
+msgid "Lime"
+msgstr "Лайм"
+
+#: ../src/propgrid/advprops.cpp:1573
+msgid "Aqua"
+msgstr "Аква"
+
+#: ../src/propgrid/advprops.cpp:1574
+msgid "Yellow"
+msgstr "Жёлтый"
+
+#: ../src/propgrid/advprops.cpp:1575
+msgid "White"
+msgstr "Белый"
+
+#: ../src/propgrid/advprops.cpp:1718
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Default"
+msgstr "По умолчанию"
+
+#: ../src/propgrid/advprops.cpp:1719
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Arrow"
+msgstr "Стрелка"
+
+#: ../src/propgrid/advprops.cpp:1720
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Right Arrow"
+msgstr "Стрелка вправо"
+
+#: ../src/propgrid/advprops.cpp:1721
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Blank"
+msgstr "Поле имени должно быть заполнено"
+
+#: ../src/propgrid/advprops.cpp:1722
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Bullseye"
+msgstr "Яблочко"
+
+#: ../src/propgrid/advprops.cpp:1723
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Character"
+msgstr "Знак"
+
+#: ../src/propgrid/advprops.cpp:1724
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Cross"
+msgstr "Через"
+
+#: ../src/propgrid/advprops.cpp:1725
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Hand"
+msgstr "Рука"
+
+#: ../src/propgrid/advprops.cpp:1726
+#, fuzzy
+msgctxt "system cursor name"
+msgid "I-Beam"
+msgstr "I-Beam"
+
+#: ../src/propgrid/advprops.cpp:1727
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Left Button"
+msgstr "Левая кнопка"
+
+#: ../src/propgrid/advprops.cpp:1728
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Magnifier"
+msgstr "Лупа"
+
+#: ../src/propgrid/advprops.cpp:1729
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Middle Button"
+msgstr "Средняя кнопка"
+
+#: ../src/propgrid/advprops.cpp:1730
+#, fuzzy
+msgctxt "system cursor name"
+msgid "No Entry"
+msgstr "Нет записи"
+
+#: ../src/propgrid/advprops.cpp:1731
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Paint Brush"
+msgstr "Кисть отрисовки"
+
+#: ../src/propgrid/advprops.cpp:1732
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Pencil"
+msgstr "Карандаш"
+
+#: ../src/propgrid/advprops.cpp:1733
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Point Left"
+msgstr "Точка слева"
+
+#: ../src/propgrid/advprops.cpp:1734
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Point Right"
+msgstr "Точка вправо"
+
+#: ../src/propgrid/advprops.cpp:1735
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Question Arrow"
+msgstr "Вопрос"
+
+#: ../src/propgrid/advprops.cpp:1736
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Right Button"
+msgstr "Правая кнопка"
+
+#: ../src/propgrid/advprops.cpp:1737
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Sizing NE-SW"
+msgstr "Изменение размеров NE-SW"
+
+#: ../src/propgrid/advprops.cpp:1738
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Sizing N-S"
+msgstr "Размеры N-S"
+
+#: ../src/propgrid/advprops.cpp:1739
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Sizing NW-SE"
+msgstr "Изменение размеров NW-SE"
+
+#: ../src/propgrid/advprops.cpp:1740
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Sizing W-E"
+msgstr "D♯/E♭"
+
+#: ../src/propgrid/advprops.cpp:1741
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Sizing"
+msgstr "Изменение размеров"
+
+#: ../src/propgrid/advprops.cpp:1742
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Spraycan"
+msgstr "Аэрозоль"
+
+#: ../src/propgrid/advprops.cpp:1743
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Wait"
+msgstr "Подождите"
+
+#: ../src/propgrid/advprops.cpp:1744
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Watch"
+msgstr "Отслеживание"
+
+#: ../src/propgrid/advprops.cpp:1745
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Wait Arrow"
+msgstr "Стрелка ожидания"
+
+#: ../src/propgrid/advprops.cpp:2109
+msgid "Make a selection:"
+msgstr "Сделайте выбор:"
+
+#: ../src/propgrid/manager.cpp:394
+msgid "Property"
+msgstr "Свойство"
+
+#: ../src/propgrid/manager.cpp:395
+msgid "Value"
+msgstr "Значение"
+
+#: ../src/propgrid/manager.cpp:1683
+msgid "Categorized Mode"
+msgstr "Режим По категориям"
+
+#: ../src/propgrid/manager.cpp:1709
+msgid "Alphabetic Mode"
+msgstr "Алфавитный режим"
+
+#. TRANSLATORS: Name of Boolean false value
+#: ../src/propgrid/propgrid.cpp:230
+msgid "False"
+msgstr "Ложно"
+
+#. TRANSLATORS: Name of Boolean true value
+#: ../src/propgrid/propgrid.cpp:232
+msgid "True"
+msgstr "Истинное"
+
+#. TRANSLATORS: Text  displayed for unspecified value
+#: ../src/propgrid/propgrid.cpp:428
+msgid "Unspecified"
+msgstr "Не указано"
+
+#. TRANSLATORS: Caption of message box displaying any property error
+#: ../src/propgrid/propgrid.cpp:3145 ../src/propgrid/propgrid.cpp:3282
+msgid "Property Error"
+msgstr "Ошибка свойства"
+
+#: ../src/propgrid/propgrid.cpp:3259
+msgid "You have entered invalid value. Press ESC to cancel editing."
+msgstr ""
+"Вы ввели недопустимое значение. Нажмите  ESC, чтобы отменить изменения."
+
+#: ../src/propgrid/propgrid.cpp:6608
+#, c-format
+msgid "Error in resource: %s"
+msgstr "Ошибка в ресурс: %s"
+
+#: ../src/propgrid/propgridiface.cpp:377
+#, c-format
+msgid ""
+"Type operation \"%s\" failed: Property labeled \"%s\" is of type \"%s\", NOT "
+"\"%s\"."
+msgstr ""
+"Операция типа '%s' не удалась: свойство с меткой '%s' имеет тип '%s', а не "
+"'%s'."
+
+#: ../src/propgrid/props.cpp:159
+#, c-format
+msgid "Unknown base %d. Base 10 will be used."
+msgstr ""
+
+#: ../src/propgrid/props.cpp:324
+#, c-format
+msgid "Value must be %s or higher."
+msgstr "Значение должно быть %s или более."
+
+#: ../src/propgrid/props.cpp:329 ../src/propgrid/props.cpp:356
+#, c-format
+msgid "Value must be between %s and %s."
+msgstr "Значение должно быть между %s и %s."
+
+#: ../src/propgrid/props.cpp:351
+#, c-format
+msgid "Value must be %s or less."
+msgstr "Значение должно быть %s или менее."
+
+#: ../src/propgrid/props.cpp:1058
+#, c-format
+msgid "Not %s"
+msgstr "Не %s"
+
+#: ../src/propgrid/props.cpp:1770
+msgid "Choose a directory:"
+msgstr "Выберите каталог:"
+
+#: ../src/propgrid/props.cpp:2055
+msgid "Choose a file"
+msgstr "Выберите файл"
+
+#: ../src/qt/mdi.cpp:254
+msgid "&Tile"
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:147
+#: ../src/richtext/richtextformatdlg.cpp:376
+msgid "Background"
+msgstr "Фон"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:159
+msgid "Background &colour:"
+msgstr "&Цвет фона:"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:161
+#: ../src/richtext/richtextbackgroundpage.cpp:163
+msgid "Enables a background colour."
+msgstr "Включает цвет фона."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:167
+#: ../src/richtext/richtextbackgroundpage.cpp:169
+msgid "The background colour."
+msgstr "Цвет фона."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:178
+msgid "Shadow"
+msgstr "Тень"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:193
+msgid "Use &shadow"
+msgstr "Использовать &тень"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:195
+#: ../src/richtext/richtextbackgroundpage.cpp:197
+msgid "Enables a shadow."
+msgstr "Включает тень."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:211
+msgid "&Horizontal offset:"
+msgstr "&Горизонтальное смещение:"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:218
+#: ../src/richtext/richtextbackgroundpage.cpp:220
+msgid "The horizontal offset."
+msgstr "Смещение по горизонтали."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:224
+#: ../src/richtext/richtextbackgroundpage.cpp:227
+#: ../src/richtext/richtextbackgroundpage.cpp:228
+#: ../src/richtext/richtextbackgroundpage.cpp:247
+#: ../src/richtext/richtextbackgroundpage.cpp:250
+#: ../src/richtext/richtextbackgroundpage.cpp:251
+#: ../src/richtext/richtextbackgroundpage.cpp:287
+#: ../src/richtext/richtextbackgroundpage.cpp:290
+#: ../src/richtext/richtextbackgroundpage.cpp:291
+#: ../src/richtext/richtextbackgroundpage.cpp:314
+#: ../src/richtext/richtextbackgroundpage.cpp:317
+#: ../src/richtext/richtextbackgroundpage.cpp:318
+#: ../src/richtext/richtextborderspage.cpp:252
+#: ../src/richtext/richtextborderspage.cpp:255
+#: ../src/richtext/richtextborderspage.cpp:256
+#: ../src/richtext/richtextborderspage.cpp:286
+#: ../src/richtext/richtextborderspage.cpp:289
+#: ../src/richtext/richtextborderspage.cpp:290
+#: ../src/richtext/richtextborderspage.cpp:320
+#: ../src/richtext/richtextborderspage.cpp:323
+#: ../src/richtext/richtextborderspage.cpp:324
+#: ../src/richtext/richtextborderspage.cpp:354
+#: ../src/richtext/richtextborderspage.cpp:357
+#: ../src/richtext/richtextborderspage.cpp:358
+#: ../src/richtext/richtextborderspage.cpp:420
+#: ../src/richtext/richtextborderspage.cpp:423
+#: ../src/richtext/richtextborderspage.cpp:424
+#: ../src/richtext/richtextborderspage.cpp:454
+#: ../src/richtext/richtextborderspage.cpp:457
+#: ../src/richtext/richtextborderspage.cpp:458
+#: ../src/richtext/richtextborderspage.cpp:488
+#: ../src/richtext/richtextborderspage.cpp:491
+#: ../src/richtext/richtextborderspage.cpp:492
+#: ../src/richtext/richtextborderspage.cpp:522
+#: ../src/richtext/richtextborderspage.cpp:525
+#: ../src/richtext/richtextborderspage.cpp:526
+#: ../src/richtext/richtextborderspage.cpp:590
+#: ../src/richtext/richtextborderspage.cpp:593
+#: ../src/richtext/richtextborderspage.cpp:594
+#: ../src/richtext/richtextfontpage.cpp:177
+#: ../src/richtext/richtextmarginspage.cpp:199
+#: ../src/richtext/richtextmarginspage.cpp:201
+#: ../src/richtext/richtextmarginspage.cpp:202
+#: ../src/richtext/richtextmarginspage.cpp:224
+#: ../src/richtext/richtextmarginspage.cpp:226
+#: ../src/richtext/richtextmarginspage.cpp:227
+#: ../src/richtext/richtextmarginspage.cpp:247
+#: ../src/richtext/richtextmarginspage.cpp:249
+#: ../src/richtext/richtextmarginspage.cpp:250
+#: ../src/richtext/richtextmarginspage.cpp:272
+#: ../src/richtext/richtextmarginspage.cpp:274
+#: ../src/richtext/richtextmarginspage.cpp:275
+#: ../src/richtext/richtextmarginspage.cpp:313
+#: ../src/richtext/richtextmarginspage.cpp:315
+#: ../src/richtext/richtextmarginspage.cpp:316
+#: ../src/richtext/richtextmarginspage.cpp:338
+#: ../src/richtext/richtextmarginspage.cpp:340
+#: ../src/richtext/richtextmarginspage.cpp:341
+#: ../src/richtext/richtextmarginspage.cpp:361
+#: ../src/richtext/richtextmarginspage.cpp:363
+#: ../src/richtext/richtextmarginspage.cpp:364
+#: ../src/richtext/richtextmarginspage.cpp:386
+#: ../src/richtext/richtextmarginspage.cpp:388
+#: ../src/richtext/richtextmarginspage.cpp:389
+#: ../src/richtext/richtextsizepage.cpp:337
+#: ../src/richtext/richtextsizepage.cpp:340
+#: ../src/richtext/richtextsizepage.cpp:341
+#: ../src/richtext/richtextsizepage.cpp:371
+#: ../src/richtext/richtextsizepage.cpp:374
+#: ../src/richtext/richtextsizepage.cpp:375
+#: ../src/richtext/richtextsizepage.cpp:398
+#: ../src/richtext/richtextsizepage.cpp:401
+#: ../src/richtext/richtextsizepage.cpp:402
+#: ../src/richtext/richtextsizepage.cpp:425
+#: ../src/richtext/richtextsizepage.cpp:428
+#: ../src/richtext/richtextsizepage.cpp:429
+#: ../src/richtext/richtextsizepage.cpp:452
+#: ../src/richtext/richtextsizepage.cpp:455
+#: ../src/richtext/richtextsizepage.cpp:456
+#: ../src/richtext/richtextsizepage.cpp:479
+#: ../src/richtext/richtextsizepage.cpp:482
+#: ../src/richtext/richtextsizepage.cpp:483
+#: ../src/richtext/richtextsizepage.cpp:553
+#: ../src/richtext/richtextsizepage.cpp:556
+#: ../src/richtext/richtextsizepage.cpp:557
+#: ../src/richtext/richtextsizepage.cpp:588
+#: ../src/richtext/richtextsizepage.cpp:591
+#: ../src/richtext/richtextsizepage.cpp:592
+#: ../src/richtext/richtextsizepage.cpp:623
+#: ../src/richtext/richtextsizepage.cpp:626
+#: ../src/richtext/richtextsizepage.cpp:627
+#: ../src/richtext/richtextsizepage.cpp:658
+#: ../src/richtext/richtextsizepage.cpp:661
+#: ../src/richtext/richtextsizepage.cpp:662
+msgid "px"
+msgstr "px"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:225
+#: ../src/richtext/richtextbackgroundpage.cpp:248
+#: ../src/richtext/richtextbackgroundpage.cpp:288
+#: ../src/richtext/richtextbackgroundpage.cpp:315
+#: ../src/richtext/richtextborderspage.cpp:253
+#: ../src/richtext/richtextborderspage.cpp:287
+#: ../src/richtext/richtextborderspage.cpp:321
+#: ../src/richtext/richtextborderspage.cpp:355
+#: ../src/richtext/richtextborderspage.cpp:421
+#: ../src/richtext/richtextborderspage.cpp:455
+#: ../src/richtext/richtextborderspage.cpp:489
+#: ../src/richtext/richtextborderspage.cpp:523
+#: ../src/richtext/richtextborderspage.cpp:591
+#: ../src/richtext/richtextmarginspage.cpp:200
+#: ../src/richtext/richtextmarginspage.cpp:225
+#: ../src/richtext/richtextmarginspage.cpp:248
+#: ../src/richtext/richtextmarginspage.cpp:273
+#: ../src/richtext/richtextmarginspage.cpp:314
+#: ../src/richtext/richtextmarginspage.cpp:339
+#: ../src/richtext/richtextmarginspage.cpp:362
+#: ../src/richtext/richtextmarginspage.cpp:387
+#: ../src/richtext/richtextsizepage.cpp:338
+#: ../src/richtext/richtextsizepage.cpp:372
+#: ../src/richtext/richtextsizepage.cpp:399
+#: ../src/richtext/richtextsizepage.cpp:426
+#: ../src/richtext/richtextsizepage.cpp:453
+#: ../src/richtext/richtextsizepage.cpp:480
+#: ../src/richtext/richtextsizepage.cpp:554
+#: ../src/richtext/richtextsizepage.cpp:589
+#: ../src/richtext/richtextsizepage.cpp:624
+#: ../src/richtext/richtextsizepage.cpp:659
+msgid "cm"
+msgstr "см"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:226
+#: ../src/richtext/richtextbackgroundpage.cpp:249
+#: ../src/richtext/richtextbackgroundpage.cpp:289
+#: ../src/richtext/richtextbackgroundpage.cpp:316
+#: ../src/richtext/richtextborderspage.cpp:254
+#: ../src/richtext/richtextborderspage.cpp:288
+#: ../src/richtext/richtextborderspage.cpp:322
+#: ../src/richtext/richtextborderspage.cpp:356
+#: ../src/richtext/richtextborderspage.cpp:422
+#: ../src/richtext/richtextborderspage.cpp:456
+#: ../src/richtext/richtextborderspage.cpp:490
+#: ../src/richtext/richtextborderspage.cpp:524
+#: ../src/richtext/richtextborderspage.cpp:592
+#: ../src/richtext/richtextfontpage.cpp:176
+#: ../src/richtext/richtextfontpage.cpp:179
+msgid "pt"
+msgstr "pt"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:229
+#: ../src/richtext/richtextbackgroundpage.cpp:231
+#: ../src/richtext/richtextbackgroundpage.cpp:252
+#: ../src/richtext/richtextbackgroundpage.cpp:254
+#: ../src/richtext/richtextbackgroundpage.cpp:292
+#: ../src/richtext/richtextbackgroundpage.cpp:294
+#: ../src/richtext/richtextbackgroundpage.cpp:319
+#: ../src/richtext/richtextbackgroundpage.cpp:321
+msgid "Units for this value."
+msgstr "Единицы этого значения."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:234
+msgid "&Vertical offset:"
+msgstr "&Вертикальное смещение:"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:241
+#: ../src/richtext/richtextbackgroundpage.cpp:243
+msgid "The vertical offset."
+msgstr "Вертикальное смещение."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:257
+msgid "Shadow c&olour:"
+msgstr "Цвет &тени:"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:259
+#: ../src/richtext/richtextbackgroundpage.cpp:261
+msgid "Enables the shadow colour."
+msgstr "Включает цвет тени."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:265
+#: ../src/richtext/richtextbackgroundpage.cpp:267
+msgid "The shadow colour."
+msgstr "Цвет тени."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:270
+msgid "Sh&adow spread:"
+msgstr "Раз&брос тени:"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:272
+#: ../src/richtext/richtextbackgroundpage.cpp:274
+msgid "Enables the shadow spread."
+msgstr "Включает разброс тени."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:281
+#: ../src/richtext/richtextbackgroundpage.cpp:283
+msgid "The shadow spread."
+msgstr "Разброс тени."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:297
+msgid "&Blur distance:"
+msgstr "Расстояние &размытия:"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:299
+#: ../src/richtext/richtextbackgroundpage.cpp:301
+msgid "Enables the blur distance."
+msgstr "Включает расстояние размытия."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:308
+#: ../src/richtext/richtextbackgroundpage.cpp:310
+msgid "The shadow blur distance."
+msgstr "Расстояние размытия тени."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:324
+msgid "Opaci&ty:"
+msgstr "Не&прозрачность:"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:326
+#: ../src/richtext/richtextbackgroundpage.cpp:328
+msgid "Enables the shadow opacity."
+msgstr "Включает прозрачность тени."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:335
+#: ../src/richtext/richtextbackgroundpage.cpp:337
+msgid "The shadow opacity."
+msgstr "Непрозрачность тени."
+
+#. TRANSLATORS: Rich text page units (percentage)
+#: ../src/richtext/richtextbackgroundpage.cpp:340
+#: ../src/richtext/richtextsizepage.cpp:339
+#: ../src/richtext/richtextsizepage.cpp:373
+#: ../src/richtext/richtextsizepage.cpp:400
+#: ../src/richtext/richtextsizepage.cpp:427
+#: ../src/richtext/richtextsizepage.cpp:454
+#: ../src/richtext/richtextsizepage.cpp:481
+#: ../src/richtext/richtextsizepage.cpp:555
+#: ../src/richtext/richtextsizepage.cpp:590
+#: ../src/richtext/richtextsizepage.cpp:625
+#: ../src/richtext/richtextsizepage.cpp:660
+msgid "%"
+msgstr "%"
+
+#: ../src/richtext/richtextborderspage.cpp:229
+#: ../src/richtext/richtextborderspage.cpp:387
+msgid "Border"
+msgstr "Граница"
+
+#: ../src/richtext/richtextborderspage.cpp:242
+#: ../src/richtext/richtextborderspage.cpp:410
+#: ../src/richtext/richtextindentspage.cpp:194
+#: ../src/richtext/richtextliststylepage.cpp:384
+#: ../src/richtext/richtextmarginspage.cpp:185
+#: ../src/richtext/richtextmarginspage.cpp:299
+#: ../src/richtext/richtextsizepage.cpp:531
+#: ../src/richtext/richtextsizepage.cpp:538
+msgid "&Left:"
+msgstr "С&лева:"
+
+#: ../src/richtext/richtextborderspage.cpp:257
+#: ../src/richtext/richtextborderspage.cpp:259
+msgid "Units for the left border width."
+msgstr "Единицы ширины левой границы."
+
+#: ../src/richtext/richtextborderspage.cpp:266
+#: ../src/richtext/richtextborderspage.cpp:268
+#: ../src/richtext/richtextborderspage.cpp:300
+#: ../src/richtext/richtextborderspage.cpp:302
+#: ../src/richtext/richtextborderspage.cpp:334
+#: ../src/richtext/richtextborderspage.cpp:336
+#: ../src/richtext/richtextborderspage.cpp:368
+#: ../src/richtext/richtextborderspage.cpp:370
+#: ../src/richtext/richtextborderspage.cpp:434
+#: ../src/richtext/richtextborderspage.cpp:436
+#: ../src/richtext/richtextborderspage.cpp:468
+#: ../src/richtext/richtextborderspage.cpp:470
+#: ../src/richtext/richtextborderspage.cpp:502
+#: ../src/richtext/richtextborderspage.cpp:504
+#: ../src/richtext/richtextborderspage.cpp:536
+#: ../src/richtext/richtextborderspage.cpp:538
+msgid "The border line style."
+msgstr "Стиль границы."
+
+#: ../src/richtext/richtextborderspage.cpp:276
+#: ../src/richtext/richtextborderspage.cpp:444
+#: ../src/richtext/richtextindentspage.cpp:212
+#: ../src/richtext/richtextliststylepage.cpp:402
+#: ../src/richtext/richtextmarginspage.cpp:210
+#: ../src/richtext/richtextmarginspage.cpp:324
+#: ../src/richtext/richtextsizepage.cpp:601
+#: ../src/richtext/richtextsizepage.cpp:608
+msgid "&Right:"
+msgstr "Сп&рава:"
+
+#: ../src/richtext/richtextborderspage.cpp:291
+#: ../src/richtext/richtextborderspage.cpp:293
+msgid "Units for the right border width."
+msgstr "Единицы правой ширины границы."
+
+#: ../src/richtext/richtextborderspage.cpp:310
+#: ../src/richtext/richtextborderspage.cpp:478
+#: ../src/richtext/richtextmarginspage.cpp:233
+#: ../src/richtext/richtextmarginspage.cpp:347
+#: ../src/richtext/richtextsizepage.cpp:566
+#: ../src/richtext/richtextsizepage.cpp:573
+msgid "&Top:"
+msgstr "С&верху:"
+
+#: ../src/richtext/richtextborderspage.cpp:325
+#: ../src/richtext/richtextborderspage.cpp:327
+msgid "Units for the top border width."
+msgstr "Единицы ширины верхней границы."
+
+#: ../src/richtext/richtextborderspage.cpp:344
+#: ../src/richtext/richtextborderspage.cpp:512
+#: ../src/richtext/richtextmarginspage.cpp:258
+#: ../src/richtext/richtextmarginspage.cpp:372
+#: ../src/richtext/richtextsizepage.cpp:636
+#: ../src/richtext/richtextsizepage.cpp:643
+msgid "&Bottom:"
+msgstr "В&низу:"
+
+#: ../src/richtext/richtextborderspage.cpp:359
+#: ../src/richtext/richtextborderspage.cpp:361
+msgid "Units for the bottom border width."
+msgstr "Единицы ширины нижней границы."
+
+#: ../src/richtext/richtextborderspage.cpp:380
+#: ../src/richtext/richtextborderspage.cpp:548
+msgid "&Synchronize values"
+msgstr "&Синхронизация значений"
+
+#: ../src/richtext/richtextborderspage.cpp:382
+#: ../src/richtext/richtextborderspage.cpp:384
+#: ../src/richtext/richtextborderspage.cpp:550
+#: ../src/richtext/richtextborderspage.cpp:552
+msgid "Check to edit all borders simultaneously."
+msgstr "Установите флажок для правки всех границ одновременно."
+
+#: ../src/richtext/richtextborderspage.cpp:397
+#: ../src/richtext/richtextborderspage.cpp:555
+msgid "Outline"
+msgstr "Контур"
+
+#: ../src/richtext/richtextborderspage.cpp:425
+#: ../src/richtext/richtextborderspage.cpp:427
+msgid "Units for the left outline width."
+msgstr "Единицы ширины левого контура."
+
+#: ../src/richtext/richtextborderspage.cpp:459
+#: ../src/richtext/richtextborderspage.cpp:461
+msgid "Units for the right outline width."
+msgstr "Единицы правой ширины контура."
+
+#: ../src/richtext/richtextborderspage.cpp:493
+#: ../src/richtext/richtextborderspage.cpp:495
+msgid "Units for the top outline width."
+msgstr "Единицы ширины верхнего контура."
+
+#: ../src/richtext/richtextborderspage.cpp:527
+#: ../src/richtext/richtextborderspage.cpp:529
+msgid "Units for the bottom outline width."
+msgstr "Единицы ширины нижнего контура."
+
+#: ../src/richtext/richtextborderspage.cpp:565
+#: ../src/richtext/richtextborderspage.cpp:600
+msgid "Corner"
+msgstr "Угол"
+
+#: ../src/richtext/richtextborderspage.cpp:574
+msgid "Corner &radius:"
+msgstr "&Радиус угла:"
+
+#: ../src/richtext/richtextborderspage.cpp:576
+#: ../src/richtext/richtextborderspage.cpp:578
+msgid "An optional corner radius for adding rounded corners."
+msgstr "Дополнительный радиус закругления для добавления закруглённых углов."
+
+#: ../src/richtext/richtextborderspage.cpp:584
+#: ../src/richtext/richtextborderspage.cpp:586
+msgid "The value of the corner radius."
+msgstr "Значение радиуса угла."
+
+#: ../src/richtext/richtextborderspage.cpp:595
+#: ../src/richtext/richtextborderspage.cpp:597
+msgid "Units for the corner radius."
+msgstr "Единицы радиуса угла."
+
+#: ../src/richtext/richtextborderspage.cpp:609
+#: ../src/richtext/richtextsizepage.cpp:247
+#: ../src/richtext/richtextsizepage.cpp:251
+msgid "None"
+msgstr "Ничего"
+
+#: ../src/richtext/richtextborderspage.cpp:610
+msgid "Solid"
+msgstr "Сплошной"
+
+#: ../src/richtext/richtextborderspage.cpp:611
+msgid "Dotted"
+msgstr "Точечная"
+
+#: ../src/richtext/richtextborderspage.cpp:612
+msgid "Dashed"
+msgstr "Пунктирная"
+
+#: ../src/richtext/richtextborderspage.cpp:613
+msgid "Double"
+msgstr "Двойная"
+
+#: ../src/richtext/richtextborderspage.cpp:614
+msgid "Groove"
+msgstr "Слот"
+
+#: ../src/richtext/richtextborderspage.cpp:615
+msgid "Ridge"
+msgstr "Ребро"
+
+#: ../src/richtext/richtextborderspage.cpp:616
+msgid "Inset"
+msgstr "Вставка"
+
+#: ../src/richtext/richtextborderspage.cpp:617
+msgid "Outset"
+msgstr "Начальный этап"
+
+#: ../src/richtext/richtextbuffer.cpp:3518
+msgid "Change Style"
+msgstr "Изменение стиля"
+
+#: ../src/richtext/richtextbuffer.cpp:3701
+msgid "Change Object Style"
+msgstr "Изменить стиль объекта"
+
+#: ../src/richtext/richtextbuffer.cpp:3974
+#: ../src/richtext/richtextbuffer.cpp:8174
+msgid "Change Properties"
+msgstr "Изменить свойства"
+
+#: ../src/richtext/richtextbuffer.cpp:4346
+msgid "Change List Style"
+msgstr "Изменить стиль списка"
+
+#: ../src/richtext/richtextbuffer.cpp:4519
+msgid "Renumber List"
+msgstr "Перенумеровать список"
+
+#: ../src/richtext/richtextbuffer.cpp:7867
+#: ../src/richtext/richtextbuffer.cpp:7897
+#: ../src/richtext/richtextbuffer.cpp:7939
+#: ../src/richtext/richtextctrl.cpp:1279 ../src/richtext/richtextctrl.cpp:1473
+msgid "Insert Text"
+msgstr "Вставить текст"
+
+#: ../src/richtext/richtextbuffer.cpp:8023
+#: ../src/richtext/richtextbuffer.cpp:8979
+msgid "Insert Image"
+msgstr "Вставить изображение"
+
+#: ../src/richtext/richtextbuffer.cpp:8070
+msgid "Insert Object"
+msgstr "Вставить объект"
+
+#: ../src/richtext/richtextbuffer.cpp:8112
+msgid "Insert Field"
+msgstr "Вставить поле"
+
+#: ../src/richtext/richtextbuffer.cpp:8410
+msgid "Too many EndStyle calls!"
+msgstr "Слишком много звонков EndStyle !"
+
+#: ../src/richtext/richtextbuffer.cpp:8785
+msgid "files"
+msgstr "файлы"
+
+#: ../src/richtext/richtextbuffer.cpp:9380
+msgid "standard/circle"
+msgstr "стандартный/круг"
+
+#: ../src/richtext/richtextbuffer.cpp:9381
+msgid "standard/circle-outline"
+msgstr "стандартный/круг-контур"
+
+#: ../src/richtext/richtextbuffer.cpp:9382
+msgid "standard/square"
+msgstr "стандартный/квадрат"
+
+#: ../src/richtext/richtextbuffer.cpp:9383
+msgid "standard/diamond"
+msgstr "стандартный/ромб"
+
+#: ../src/richtext/richtextbuffer.cpp:9384
+msgid "standard/triangle"
+msgstr "стандартный/треугольник"
+
+#: ../src/richtext/richtextbuffer.cpp:9423
+msgid "Box Properties"
+msgstr "Свойства поля"
+
+#: ../src/richtext/richtextbuffer.cpp:10006
+msgid "Multiple Cell Properties"
+msgstr "Свойства нескольких ячеек"
+
+#: ../src/richtext/richtextbuffer.cpp:10008
+msgid "Cell Properties"
+msgstr "Свойства ячейки"
+
+#: ../src/richtext/richtextbuffer.cpp:11256
+msgid "Set Cell Style"
+msgstr "Задать стиль ячейки"
+
+#: ../src/richtext/richtextbuffer.cpp:11330
+msgid "Delete Row"
+msgstr "Удалить строку"
+
+#: ../src/richtext/richtextbuffer.cpp:11380
+msgid "Delete Column"
+msgstr "Удалить колонку"
+
+#: ../src/richtext/richtextbuffer.cpp:11431
+msgid "Add Row"
+msgstr "Добавить строку"
+
+#: ../src/richtext/richtextbuffer.cpp:11494
+msgid "Add Column"
+msgstr "Добавить колонку"
+
+#: ../src/richtext/richtextbuffer.cpp:11537
+msgid "Table Properties"
+msgstr "Свойства таблицы"
+
+#: ../src/richtext/richtextbuffer.cpp:12899
+msgid "Picture Properties"
+msgstr "Свойства рисунка"
+
+#: ../src/richtext/richtextbuffer.cpp:13169
+#: ../src/richtext/richtextbuffer.cpp:13279
+msgid "image"
+msgstr "изображения"
+
+#: ../src/richtext/richtextbulletspage.cpp:145
+#: ../src/richtext/richtextliststylepage.cpp:209
+msgid "&Bullet style:"
+msgstr "Стиль &маркера:"
+
+#: ../src/richtext/richtextbulletspage.cpp:150
+#: ../src/richtext/richtextbulletspage.cpp:152
+#: ../src/richtext/richtextliststylepage.cpp:214
+#: ../src/richtext/richtextliststylepage.cpp:216
+msgid "The available bullet styles."
+msgstr "Доступные стили списка."
+
+#: ../src/richtext/richtextbulletspage.cpp:158
+#: ../src/richtext/richtextliststylepage.cpp:221
+msgid "Peri&od"
+msgstr "Пери&od"
+
+#: ../src/richtext/richtextbulletspage.cpp:160
+#: ../src/richtext/richtextbulletspage.cpp:162
+#: ../src/richtext/richtextliststylepage.cpp:223
+#: ../src/richtext/richtextliststylepage.cpp:225
+msgid "Check to add a period after the bullet."
+msgstr "Установите флажок, чтобы добавить точку после маркера."
+
+#. TRANSLATORS: Bullet point in parentheses option
+#: ../src/richtext/richtextbulletspage.cpp:167
+#: ../src/richtext/richtextliststylepage.cpp:230
+msgid "(*)"
+msgstr "(*)"
+
+#: ../src/richtext/richtextbulletspage.cpp:169
+#: ../src/richtext/richtextbulletspage.cpp:171
+#: ../src/richtext/richtextliststylepage.cpp:232
+#: ../src/richtext/richtextliststylepage.cpp:234
+msgid "Check to enclose the bullet in parentheses."
+msgstr "Установите флажок для заключения маркера в круглые скобки."
+
+#. TRANSLATORS: Right parenthesis bullet point option
+#: ../src/richtext/richtextbulletspage.cpp:176
+#: ../src/richtext/richtextliststylepage.cpp:239
+msgid "*)"
+msgstr "*)"
+
+#: ../src/richtext/richtextbulletspage.cpp:178
+#: ../src/richtext/richtextbulletspage.cpp:180
+#: ../src/richtext/richtextliststylepage.cpp:241
+#: ../src/richtext/richtextliststylepage.cpp:243
+msgid "Check to add a right parenthesis."
+msgstr "Установите флажок, чтобы добавить правую скобку."
+
+#: ../src/richtext/richtextbulletspage.cpp:185
+#: ../src/richtext/richtextliststylepage.cpp:248
+msgid "Bullet &Alignment:"
+msgstr "&Выравнивание маркера:"
+
+#: ../src/richtext/richtextbulletspage.cpp:190
+#: ../src/richtext/richtextliststylepage.cpp:253
+msgid "Centre"
+msgstr "Центр"
+
+#: ../src/richtext/richtextbulletspage.cpp:194
+#: ../src/richtext/richtextbulletspage.cpp:196
+#: ../src/richtext/richtextbulletspage.cpp:217
+#: ../src/richtext/richtextbulletspage.cpp:219
+#: ../src/richtext/richtextliststylepage.cpp:257
+#: ../src/richtext/richtextliststylepage.cpp:259
+#: ../src/richtext/richtextliststylepage.cpp:278
+#: ../src/richtext/richtextliststylepage.cpp:280
+msgid "The bullet character."
+msgstr "Знак маркера."
+
+#: ../src/richtext/richtextbulletspage.cpp:212
+#: ../src/richtext/richtextliststylepage.cpp:271
+msgid "&Symbol:"
+msgstr "&Символ:"
+
+#: ../src/richtext/richtextbulletspage.cpp:222
+#: ../src/richtext/richtextliststylepage.cpp:283
+msgid "Ch&oose..."
+msgstr "Вы&брать..."
+
+#: ../src/richtext/richtextbulletspage.cpp:223
+#: ../src/richtext/richtextbulletspage.cpp:225
+#: ../src/richtext/richtextliststylepage.cpp:284
+#: ../src/richtext/richtextliststylepage.cpp:286
+msgid "Click to browse for a symbol."
+msgstr "Щёлкните, чтобы выбрать символ."
+
+#: ../src/richtext/richtextbulletspage.cpp:230
+#: ../src/richtext/richtextliststylepage.cpp:291
+msgid "Symbol &font:"
+msgstr "Шрифт &символов:"
+
+#: ../src/richtext/richtextbulletspage.cpp:235
+#: ../src/richtext/richtextbulletspage.cpp:237
+#: ../src/richtext/richtextliststylepage.cpp:297
+msgid "Available fonts."
+msgstr "Доступные шрифты."
+
+#: ../src/richtext/richtextbulletspage.cpp:242
+#: ../src/richtext/richtextliststylepage.cpp:302
+msgid "S&tandard bullet name:"
+msgstr "Стандартное название маркера:"
+
+#: ../src/richtext/richtextbulletspage.cpp:247
+#: ../src/richtext/richtextbulletspage.cpp:249
+#: ../src/richtext/richtextliststylepage.cpp:307
+#: ../src/richtext/richtextliststylepage.cpp:309
+msgid "A standard bullet name."
+msgstr "Стандартное название маркера."
+
+#: ../src/richtext/richtextbulletspage.cpp:254
+msgid "&Number:"
+msgstr "&Число:"
+
+#: ../src/richtext/richtextbulletspage.cpp:258
+#: ../src/richtext/richtextbulletspage.cpp:260
+msgid "The list item number."
+msgstr "Номер элемента списка."
+
+#: ../src/richtext/richtextbulletspage.cpp:266
+#: ../src/richtext/richtextbulletspage.cpp:268
+#: ../src/richtext/richtextliststylepage.cpp:475
+#: ../src/richtext/richtextliststylepage.cpp:477
+msgid "Shows a preview of the bullet settings."
+msgstr "Показывает пред просмотр параметров маркера."
+
+#: ../src/richtext/richtextbulletspage.cpp:276
+#: ../src/richtext/richtextliststylepage.cpp:484
+msgid "(None)"
+msgstr "(Ничего)"
+
+#: ../src/richtext/richtextbulletspage.cpp:277
+#: ../src/richtext/richtextliststylepage.cpp:485
+msgid "Arabic"
+msgstr "Арабский"
+
+#: ../src/richtext/richtextbulletspage.cpp:278
+#: ../src/richtext/richtextliststylepage.cpp:486
+msgid "Upper case letters"
+msgstr "Заглавные буквы"
+
+#: ../src/richtext/richtextbulletspage.cpp:279
+#: ../src/richtext/richtextliststylepage.cpp:487
+msgid "Lower case letters"
+msgstr "Строчные буквы"
+
+#: ../src/richtext/richtextbulletspage.cpp:280
+#: ../src/richtext/richtextliststylepage.cpp:488
+msgid "Upper case roman numerals"
+msgstr "Римские цифры в верхнем регистре"
+
+#: ../src/richtext/richtextbulletspage.cpp:281
+#: ../src/richtext/richtextliststylepage.cpp:489
+msgid "Lower case roman numerals"
+msgstr "Строчные римские цифры"
+
+#: ../src/richtext/richtextbulletspage.cpp:282
+#: ../src/richtext/richtextliststylepage.cpp:490
+msgid "Numbered outline"
+msgstr "Пронумерованный контур"
+
+#: ../src/richtext/richtextbulletspage.cpp:283
+#: ../src/richtext/richtextliststylepage.cpp:491
+msgid "Symbol"
+msgstr "Символ"
+
+#: ../src/richtext/richtextbulletspage.cpp:284
+#: ../src/richtext/richtextliststylepage.cpp:492
+msgid "Bitmap"
+msgstr "Растровое изображение"
+
+#: ../src/richtext/richtextbulletspage.cpp:285
+#: ../src/richtext/richtextliststylepage.cpp:493
+msgid "Standard"
+msgstr "Стандарт"
+
+#: ../src/richtext/richtextbulletspage.cpp:287
+#: ../src/richtext/richtextliststylepage.cpp:495
+msgid "*"
+msgstr "*"
+
+#: ../src/richtext/richtextbulletspage.cpp:288
+#: ../src/richtext/richtextliststylepage.cpp:496
+msgid "-"
+msgstr "-"
+
+#: ../src/richtext/richtextbulletspage.cpp:289
+#: ../src/richtext/richtextliststylepage.cpp:497
+msgid ">"
+msgstr ">"
+
+#: ../src/richtext/richtextbulletspage.cpp:290
+#: ../src/richtext/richtextliststylepage.cpp:498
+msgid "+"
+msgstr "+"
+
+#: ../src/richtext/richtextbulletspage.cpp:291
+#: ../src/richtext/richtextliststylepage.cpp:499
+msgid "~"
+msgstr "~"
+
+#: ../src/richtext/richtextctrl.cpp:859
+msgid "Drag"
+msgstr "Перетащить"
+
+#: ../src/richtext/richtextctrl.cpp:1338 ../src/richtext/richtextctrl.cpp:1559
+msgid "Delete Text"
+msgstr "Удалить текст"
+
+#: ../src/richtext/richtextctrl.cpp:1537
+msgid "Remove Bullet"
+msgstr "Удалить маркер"
+
+#: ../src/richtext/richtextctrl.cpp:3070
+msgid "The text couldn't be saved."
+msgstr "Не удалось сохранить текст."
+
+#: ../src/richtext/richtextctrl.cpp:3644
+msgid "Replace"
+msgstr "Заменить"
+
+#: ../src/richtext/richtextfontpage.cpp:146
+#: ../src/richtext/richtextsymboldlg.cpp:384
+msgid "&Font:"
+msgstr "&Шрифт:"
+
+#: ../src/richtext/richtextfontpage.cpp:150
+#: ../src/richtext/richtextfontpage.cpp:152
+msgid "Type a font name."
+msgstr "Введите имя шрифта."
+
+#: ../src/richtext/richtextfontpage.cpp:158
+msgid "&Size:"
+msgstr "&Размер:"
+
+#: ../src/richtext/richtextfontpage.cpp:165
+#: ../src/richtext/richtextfontpage.cpp:167
+msgid "Type a size in points."
+msgstr "Введите размер в точках."
+
+#: ../src/richtext/richtextfontpage.cpp:180
+#: ../src/richtext/richtextfontpage.cpp:182
+msgid "The font size units, points or pixels."
+msgstr "Единицы размера шрифта, точки или пиксели."
+
+#: ../src/richtext/richtextfontpage.cpp:189
+#: ../src/richtext/richtextfontpage.cpp:191
+msgid "Lists the available fonts."
+msgstr "Списки доступных шрифтов."
+
+#: ../src/richtext/richtextfontpage.cpp:196
+#: ../src/richtext/richtextfontpage.cpp:198
+msgid "Lists font sizes in points."
+msgstr "Списки размеров шрифта в пунктах."
+
+#: ../src/richtext/richtextfontpage.cpp:207
+msgid "Font st&yle:"
+msgstr "Ст&иль шрифта:"
+
+#: ../src/richtext/richtextfontpage.cpp:212
+#: ../src/richtext/richtextfontpage.cpp:214
+msgid "Select regular or italic style."
+msgstr "Выбрать регулярный или курсив."
+
+#: ../src/richtext/richtextfontpage.cpp:220
+msgid "Font &weight:"
+msgstr "&Толщина шрифта:"
+
+#: ../src/richtext/richtextfontpage.cpp:225
+#: ../src/richtext/richtextfontpage.cpp:227
+msgid "Select regular or bold."
+msgstr "Выбрать регулярный или жирный."
+
+#: ../src/richtext/richtextfontpage.cpp:233
+msgid "&Underlining:"
+msgstr "&Подчёркивание:"
+
+#: ../src/richtext/richtextfontpage.cpp:238
+#: ../src/richtext/richtextfontpage.cpp:240
+msgid "Select underlining or no underlining."
+msgstr "Выбрать подчёркивание или без подчёркивания."
+
+#: ../src/richtext/richtextfontpage.cpp:248
+msgid "&Colour:"
+msgstr "&Цвет:"
+
+#: ../src/richtext/richtextfontpage.cpp:253
+#: ../src/richtext/richtextfontpage.cpp:255
+msgid "Click to change the text colour."
+msgstr "Щёлкните, чтобы изменить цвет текста."
+
+#: ../src/richtext/richtextfontpage.cpp:261
+msgid "&Bg colour:"
+msgstr "Цвет &фона:"
+
+#: ../src/richtext/richtextfontpage.cpp:266
+#: ../src/richtext/richtextfontpage.cpp:268
+msgid "Click to change the text background colour."
+msgstr "Щёлкните, чтобы изменить цвет фона текста."
+
+#: ../src/richtext/richtextfontpage.cpp:276
+#: ../src/richtext/richtextfontpage.cpp:278
+msgid "Check to show a line through the text."
+msgstr "Установите флажок, чтобы отобразить текст перечёркнутым."
+
+#: ../src/richtext/richtextfontpage.cpp:281
+msgid "Ca&pitals"
+msgstr "Ca&pitals"
+
+#: ../src/richtext/richtextfontpage.cpp:283
+#: ../src/richtext/richtextfontpage.cpp:285
+msgid "Check to show the text in capitals."
+msgstr "Установите флажок, чтобы отобразить текст заглавными буквами."
+
+#: ../src/richtext/richtextfontpage.cpp:288
+msgid "Small C&apitals"
+msgstr "&Малые заглавные"
+
+#: ../src/richtext/richtextfontpage.cpp:290
+#: ../src/richtext/richtextfontpage.cpp:292
+msgid "Check to show the text in small capitals."
+msgstr "Установите флажок, чтобы отобразить текст в маленькими заглавными."
+
+#: ../src/richtext/richtextfontpage.cpp:295
+msgid "Supe&rscript"
+msgstr "&Верхний индекс"
+
+#: ../src/richtext/richtextfontpage.cpp:297
+#: ../src/richtext/richtextfontpage.cpp:299
+msgid "Check to show the text in superscript."
+msgstr "Установите флажок, чтобы отобразить текст в скрипте."
+
+#: ../src/richtext/richtextfontpage.cpp:302
+msgid "Subscrip&t"
+msgstr "&Субиндекс"
+
+#: ../src/richtext/richtextfontpage.cpp:304
+#: ../src/richtext/richtextfontpage.cpp:306
+msgid "Check to show the text in subscript."
+msgstr "Установите флажок, чтобы отобразить текст как нижний индекс."
+
+#: ../src/richtext/richtextfontpage.cpp:312
+msgid "Rig&ht-to-left"
+msgstr "&Слева направо"
+
+#: ../src/richtext/richtextfontpage.cpp:314
+#: ../src/richtext/richtextfontpage.cpp:316
+msgid "Check to indicate right-to-left text layout."
+msgstr "Установите флажок для указания макета текста справа налево."
+
+#: ../src/richtext/richtextfontpage.cpp:319
+msgid "Suppress hyphe&nation"
+msgstr "&Подавить переносы"
+
+#: ../src/richtext/richtextfontpage.cpp:321
+#: ../src/richtext/richtextfontpage.cpp:323
+msgid "Check to suppress hyphenation."
+msgstr "Установите флажок для подавления расстановки переносов."
+
+#: ../src/richtext/richtextfontpage.cpp:329
+#: ../src/richtext/richtextfontpage.cpp:331
+msgid "Shows a preview of the font settings."
+msgstr "Позволяет просмотреть параметры шрифта."
+
+#: ../src/richtext/richtextfontpage.cpp:348
+#: ../src/richtext/richtextfontpage.cpp:352
+#: ../src/richtext/richtextfontpage.cpp:356
+#: ../src/richtext/richtextformatdlg.cpp:873
+#: ../src/richtext/richtextindentspage.cpp:273
+#: ../src/richtext/richtextindentspage.cpp:285
+#: ../src/richtext/richtextindentspage.cpp:286
+#: ../src/richtext/richtextindentspage.cpp:310
+#: ../src/richtext/richtextindentspage.cpp:325
+#: ../src/richtext/richtextliststylepage.cpp:451
+#: ../src/richtext/richtextliststylepage.cpp:463
+#: ../src/richtext/richtextliststylepage.cpp:464
+msgid "(none)"
+msgstr "(ничего)"
+
+#: ../src/richtext/richtextfontpage.cpp:349
+#: ../src/richtext/richtextfontpage.cpp:353
+msgid "Regular"
+msgstr "Регулярные"
+
+#: ../src/richtext/richtextfontpage.cpp:357
+msgid "Not underlined"
+msgstr "Не подчёркнутый"
+
+#: ../src/richtext/richtextformatdlg.cpp:341
+msgid "Indents && Spacing"
+msgstr "Отступы и интервалы"
+
+#: ../src/richtext/richtextformatdlg.cpp:346
+msgid "Tabs"
+msgstr "Вкладки"
+
+#: ../src/richtext/richtextformatdlg.cpp:351
+msgid "Bullets"
+msgstr "Маркеры"
+
+#: ../src/richtext/richtextformatdlg.cpp:356
+msgid "List Style"
+msgstr "Стиль списка"
+
+#: ../src/richtext/richtextformatdlg.cpp:366
+#: ../src/richtext/richtextmarginspage.cpp:170
+msgid "Margins"
+msgstr "Поля"
+
+#: ../src/richtext/richtextformatdlg.cpp:371
+msgid "Borders"
+msgstr "Границы"
+
+#: ../src/richtext/richtextformatdlg.cpp:765
+msgid "Colour"
+msgstr "Цвет"
+
+#: ../src/richtext/richtextindentspage.cpp:127
+#: ../src/richtext/richtextliststylepage.cpp:322
+msgid "&Alignment"
+msgstr "&Выравнивание"
+
+#: ../src/richtext/richtextindentspage.cpp:138
+#: ../src/richtext/richtextliststylepage.cpp:331
+msgid "&Left"
+msgstr "С&лева"
+
+#: ../src/richtext/richtextindentspage.cpp:140
+#: ../src/richtext/richtextindentspage.cpp:142
+#: ../src/richtext/richtextliststylepage.cpp:333
+#: ../src/richtext/richtextliststylepage.cpp:335
+msgid "Left-align text."
+msgstr "Выровнять текст слева."
+
+#: ../src/richtext/richtextindentspage.cpp:145
+#: ../src/richtext/richtextliststylepage.cpp:338
+msgid "&Right"
+msgstr "Сп&рава"
+
+#: ../src/richtext/richtextindentspage.cpp:147
+#: ../src/richtext/richtextindentspage.cpp:149
+#: ../src/richtext/richtextliststylepage.cpp:340
+#: ../src/richtext/richtextliststylepage.cpp:342
+msgid "Right-align text."
+msgstr "Выровнять текст справа."
+
+#: ../src/richtext/richtextindentspage.cpp:152
+#: ../src/richtext/richtextliststylepage.cpp:345
+msgid "&Justified"
+msgstr "&По ширине"
+
+#: ../src/richtext/richtextindentspage.cpp:154
+#: ../src/richtext/richtextindentspage.cpp:156
+#: ../src/richtext/richtextliststylepage.cpp:347
+#: ../src/richtext/richtextliststylepage.cpp:349
+msgid "Justify text left and right."
+msgstr "Выравнивание текста слева и справа."
+
+#: ../src/richtext/richtextindentspage.cpp:159
+#: ../src/richtext/richtextliststylepage.cpp:352
+msgid "Cen&tred"
+msgstr "Цен&трировано"
+
+#: ../src/richtext/richtextindentspage.cpp:161
+#: ../src/richtext/richtextindentspage.cpp:163
+#: ../src/richtext/richtextliststylepage.cpp:354
+#: ../src/richtext/richtextliststylepage.cpp:356
+msgid "Centre text."
+msgstr "Центрировать текст."
+
+#: ../src/richtext/richtextindentspage.cpp:166
+#: ../src/richtext/richtextliststylepage.cpp:359
+msgid "&Indeterminate"
+msgstr "&Неопределённый"
+
+#: ../src/richtext/richtextindentspage.cpp:168
+#: ../src/richtext/richtextindentspage.cpp:170
+#: ../src/richtext/richtextliststylepage.cpp:361
+#: ../src/richtext/richtextliststylepage.cpp:363
+msgid "Use the current alignment setting."
+msgstr "Использовать текущий параметр выравнивания."
+
+#: ../src/richtext/richtextindentspage.cpp:183
+#: ../src/richtext/richtextliststylepage.cpp:375
+msgid "&Indentation (tenths of a mm)"
+msgstr "&Отступы (десятые доли мм)"
+
+#: ../src/richtext/richtextindentspage.cpp:198
+#: ../src/richtext/richtextindentspage.cpp:200
+#: ../src/richtext/richtextliststylepage.cpp:388
+#: ../src/richtext/richtextliststylepage.cpp:390
+msgid "The left indent."
+msgstr "Отступ слева."
+
+#: ../src/richtext/richtextindentspage.cpp:203
+#: ../src/richtext/richtextliststylepage.cpp:393
+msgid "Left (&first line):"
+msgstr "Слева (первые строки):"
+
+#: ../src/richtext/richtextindentspage.cpp:207
+#: ../src/richtext/richtextindentspage.cpp:209
+#: ../src/richtext/richtextliststylepage.cpp:397
+#: ../src/richtext/richtextliststylepage.cpp:399
+msgid "The first line indent."
+msgstr "Отступ первой строки."
+
+#: ../src/richtext/richtextindentspage.cpp:216
+#: ../src/richtext/richtextindentspage.cpp:218
+#: ../src/richtext/richtextliststylepage.cpp:406
+#: ../src/richtext/richtextliststylepage.cpp:408
+msgid "The right indent."
+msgstr "Отступ справа."
+
+#: ../src/richtext/richtextindentspage.cpp:221
+msgid "&Outline level:"
+msgstr "&Уровень структуры:"
+
+#: ../src/richtext/richtextindentspage.cpp:226
+#: ../src/richtext/richtextindentspage.cpp:228
+msgid "The outline level."
+msgstr "Уровень структуры."
+
+#: ../src/richtext/richtextindentspage.cpp:241
+#: ../src/richtext/richtextliststylepage.cpp:420
+msgid "&Spacing (tenths of a mm)"
+msgstr "&Интервал (десятые доли мм)"
+
+#: ../src/richtext/richtextindentspage.cpp:252
+msgid "&Before a paragraph:"
+msgstr "&Перед абзацем:"
+
+#: ../src/richtext/richtextindentspage.cpp:256
+#: ../src/richtext/richtextindentspage.cpp:258
+#: ../src/richtext/richtextliststylepage.cpp:433
+#: ../src/richtext/richtextliststylepage.cpp:435
+msgid "The spacing before the paragraph."
+msgstr "Интервал перед абзацем."
+
+#: ../src/richtext/richtextindentspage.cpp:261
+msgid "&After a paragraph:"
+msgstr "&После абзаца:"
+
+#: ../src/richtext/richtextindentspage.cpp:266
+#: ../src/richtext/richtextliststylepage.cpp:442
+#: ../src/richtext/richtextliststylepage.cpp:444
+msgid "The spacing after the paragraph."
+msgstr "Интервал после абзаца."
+
+#: ../src/richtext/richtextindentspage.cpp:269
+msgid "L&ine spacing:"
+msgstr "Ме&жстрочный интервал:"
+
+#: ../src/richtext/richtextindentspage.cpp:274
+#: ../src/richtext/richtextliststylepage.cpp:452
+msgid "Single"
+msgstr "Один"
+
+#: ../src/richtext/richtextindentspage.cpp:275
+#: ../src/richtext/richtextliststylepage.cpp:453
+msgid "1.1"
+msgstr "1.1"
+
+#: ../src/richtext/richtextindentspage.cpp:276
+#: ../src/richtext/richtextliststylepage.cpp:454
+msgid "1.2"
+msgstr "1.2"
+
+#: ../src/richtext/richtextindentspage.cpp:277
+#: ../src/richtext/richtextliststylepage.cpp:455
+msgid "1.3"
+msgstr "1.3"
+
+#: ../src/richtext/richtextindentspage.cpp:278
+#: ../src/richtext/richtextliststylepage.cpp:456
+msgid "1.4"
+msgstr "1.4"
+
+#: ../src/richtext/richtextindentspage.cpp:279
+#: ../src/richtext/richtextliststylepage.cpp:457
+msgid "1.5"
+msgstr "1.5"
+
+#: ../src/richtext/richtextindentspage.cpp:280
+#: ../src/richtext/richtextliststylepage.cpp:458
+msgid "1.6"
+msgstr "1.6"
+
+#: ../src/richtext/richtextindentspage.cpp:281
+#: ../src/richtext/richtextliststylepage.cpp:459
+msgid "1.7"
+msgstr "1.7"
+
+#: ../src/richtext/richtextindentspage.cpp:282
+#: ../src/richtext/richtextliststylepage.cpp:460
+msgid "1.8"
+msgstr "1.8"
+
+#: ../src/richtext/richtextindentspage.cpp:283
+#: ../src/richtext/richtextliststylepage.cpp:461
+msgid "1.9"
+msgstr "1.9"
+
+#: ../src/richtext/richtextindentspage.cpp:284
+#: ../src/richtext/richtextliststylepage.cpp:462
+msgid "2"
+msgstr "2"
+
+#: ../src/richtext/richtextindentspage.cpp:287
+#: ../src/richtext/richtextindentspage.cpp:289
+#: ../src/richtext/richtextliststylepage.cpp:465
+#: ../src/richtext/richtextliststylepage.cpp:467
+msgid "The line spacing."
+msgstr "Межстрочный интервал."
+
+#: ../src/richtext/richtextindentspage.cpp:292
+msgid "&Page Break"
+msgstr "&Разрыв страницы"
+
+#: ../src/richtext/richtextindentspage.cpp:294
+#: ../src/richtext/richtextindentspage.cpp:296
+msgid "Inserts a page break before the paragraph."
+msgstr "Вставляет разрыв страницы перед абзацем."
+
+#: ../src/richtext/richtextindentspage.cpp:302
+#: ../src/richtext/richtextindentspage.cpp:304
+msgid "Shows a preview of the paragraph settings."
+msgstr "Показывает предпросмотр параметров абзаца."
+
+#: ../src/richtext/richtextliststylepage.cpp:182
+msgid "&List level:"
+msgstr "&Уровень списка:"
+
+#: ../src/richtext/richtextliststylepage.cpp:186
+#: ../src/richtext/richtextliststylepage.cpp:188
+msgid "Selects the list level to edit."
+msgstr "Выбирает уровень списка для правки."
+
+#: ../src/richtext/richtextliststylepage.cpp:193
+msgid "&Font for Level..."
+msgstr "&Шрифт для уровня..."
+
+#: ../src/richtext/richtextliststylepage.cpp:194
+#: ../src/richtext/richtextliststylepage.cpp:196
+msgid "Click to choose the font for this level."
+msgstr "Щёлкните, чтобы выбрать шрифт для этого уровня."
+
+#: ../src/richtext/richtextliststylepage.cpp:312
+msgid "Bullet style"
+msgstr "Cтиль маркера"
+
+#: ../src/richtext/richtextliststylepage.cpp:429
+msgid "Before a paragraph:"
+msgstr "Перед абзацем:"
+
+#: ../src/richtext/richtextliststylepage.cpp:438
+msgid "After a paragraph:"
+msgstr "После абзаца:"
+
+#: ../src/richtext/richtextliststylepage.cpp:447
+msgid "Line spacing:"
+msgstr "Межстрочный интервал:"
+
+#: ../src/richtext/richtextliststylepage.cpp:470
+msgid "Spacing"
+msgstr "Интервал"
+
+#: ../src/richtext/richtextmarginspage.cpp:193
+#: ../src/richtext/richtextmarginspage.cpp:195
+msgid "The left margin size."
+msgstr "Размер левого поля."
+
+#: ../src/richtext/richtextmarginspage.cpp:203
+#: ../src/richtext/richtextmarginspage.cpp:205
+msgid "Units for the left margin."
+msgstr "Единицы левого поля."
+
+#: ../src/richtext/richtextmarginspage.cpp:218
+#: ../src/richtext/richtextmarginspage.cpp:220
+msgid "The right margin size."
+msgstr "Размер правого поля."
+
+#: ../src/richtext/richtextmarginspage.cpp:228
+#: ../src/richtext/richtextmarginspage.cpp:230
+msgid "Units for the right margin."
+msgstr "Единицы правого поля."
+
+#: ../src/richtext/richtextmarginspage.cpp:241
+#: ../src/richtext/richtextmarginspage.cpp:243
+msgid "The top margin size."
+msgstr "Размер верхнего поля."
+
+#: ../src/richtext/richtextmarginspage.cpp:251
+#: ../src/richtext/richtextmarginspage.cpp:253
+msgid "Units for the top margin."
+msgstr "Единицы верхнего поля."
+
+#: ../src/richtext/richtextmarginspage.cpp:266
+#: ../src/richtext/richtextmarginspage.cpp:268
+msgid "The bottom margin size."
+msgstr "Размер нижнего поля."
+
+#: ../src/richtext/richtextmarginspage.cpp:276
+#: ../src/richtext/richtextmarginspage.cpp:278
+msgid "Units for the bottom margin."
+msgstr "Единицы нижнего поля."
+
+#: ../src/richtext/richtextmarginspage.cpp:284
+msgid "Padding"
+msgstr "Заполнение"
+
+#: ../src/richtext/richtextmarginspage.cpp:307
+#: ../src/richtext/richtextmarginspage.cpp:309
+msgid "The left padding size."
+msgstr "Размер заполнения слева."
+
+#: ../src/richtext/richtextmarginspage.cpp:317
+#: ../src/richtext/richtextmarginspage.cpp:319
+msgid "Units for the left padding."
+msgstr "Единицы левого заполнения."
+
+#: ../src/richtext/richtextmarginspage.cpp:332
+#: ../src/richtext/richtextmarginspage.cpp:334
+msgid "The right padding size."
+msgstr "Размер заполнения справа."
+
+#: ../src/richtext/richtextmarginspage.cpp:342
+#: ../src/richtext/richtextmarginspage.cpp:344
+msgid "Units for the right padding."
+msgstr "Единицы правого заполнения."
+
+#: ../src/richtext/richtextmarginspage.cpp:355
+#: ../src/richtext/richtextmarginspage.cpp:357
+msgid "The top padding size."
+msgstr "Размер заполнения вверху."
+
+#: ../src/richtext/richtextmarginspage.cpp:365
+#: ../src/richtext/richtextmarginspage.cpp:367
+msgid "Units for the top padding."
+msgstr "Единицы верхнего заполнения."
+
+#: ../src/richtext/richtextmarginspage.cpp:380
+#: ../src/richtext/richtextmarginspage.cpp:382
+msgid "The bottom padding size."
+msgstr "Размер заполнения внизу."
+
+#: ../src/richtext/richtextmarginspage.cpp:390
+#: ../src/richtext/richtextmarginspage.cpp:392
+msgid "Units for the bottom padding."
+msgstr "Единицы нижнего заполнения."
+
+#: ../src/richtext/richtextprint.cpp:592
+msgid " Preview"
+msgstr " Предпросмотр"
+
+#: ../src/richtext/richtextsizepage.cpp:228
+msgid "Floating"
+msgstr "Плавающий"
+
+#: ../src/richtext/richtextsizepage.cpp:243
+msgid "&Floating mode:"
+msgstr "&Плавающий режим:"
+
+#: ../src/richtext/richtextsizepage.cpp:252
+#: ../src/richtext/richtextsizepage.cpp:254
+msgid "How the object will float relative to the text."
+msgstr "Как объект будет плавать относительно текста."
+
+#: ../src/richtext/richtextsizepage.cpp:265
+msgid "Alignment"
+msgstr "Выравнивание"
+
+#: ../src/richtext/richtextsizepage.cpp:277
+msgid "&Vertical alignment:"
+msgstr "Выравнивание по &вертикали:"
+
+#: ../src/richtext/richtextsizepage.cpp:279
+#: ../src/richtext/richtextsizepage.cpp:281
+msgid "Enable vertical alignment."
+msgstr "Включить выравнивание по вертикали."
+
+#: ../src/richtext/richtextsizepage.cpp:286
+msgid "Centred"
+msgstr "По центру"
+
+#: ../src/richtext/richtextsizepage.cpp:290
+#: ../src/richtext/richtextsizepage.cpp:292
+msgid "Vertical alignment."
+msgstr "Вертикальное выравнивание."
+
+#: ../src/richtext/richtextsizepage.cpp:316
+#: ../src/richtext/richtextsizepage.cpp:323
+msgid "&Width:"
+msgstr "&Ширина:"
+
+#: ../src/richtext/richtextsizepage.cpp:318
+#: ../src/richtext/richtextsizepage.cpp:320
+msgid "Enable the width value."
+msgstr "Включить значение ширины."
+
+#: ../src/richtext/richtextsizepage.cpp:331
+#: ../src/richtext/richtextsizepage.cpp:333
+msgid "The object width."
+msgstr "Ширина объекта."
+
+#: ../src/richtext/richtextsizepage.cpp:342
+#: ../src/richtext/richtextsizepage.cpp:344
+msgid "Units for the object width."
+msgstr "Единицы ширины объекта."
+
+#: ../src/richtext/richtextsizepage.cpp:350
+#: ../src/richtext/richtextsizepage.cpp:357
+msgid "&Height:"
+msgstr "&Высота:"
+
+#: ../src/richtext/richtextsizepage.cpp:352
+#: ../src/richtext/richtextsizepage.cpp:354
+#: ../src/richtext/richtextsizepage.cpp:464
+#: ../src/richtext/richtextsizepage.cpp:466
+msgid "Enable the height value."
+msgstr "Включите значение высоты."
+
+#: ../src/richtext/richtextsizepage.cpp:365
+#: ../src/richtext/richtextsizepage.cpp:367
+msgid "The object height."
+msgstr "Высота объекта."
+
+#: ../src/richtext/richtextsizepage.cpp:376
+#: ../src/richtext/richtextsizepage.cpp:378
+msgid "Units for the object height."
+msgstr "Единицы высоты объекта."
+
+#: ../src/richtext/richtextsizepage.cpp:381
+msgid "Min width:"
+msgstr "Мин. ширина:"
+
+#: ../src/richtext/richtextsizepage.cpp:383
+#: ../src/richtext/richtextsizepage.cpp:385
+msgid "Enable the minimum width value."
+msgstr "Включить минимальное значение ширины."
+
+#: ../src/richtext/richtextsizepage.cpp:392
+#: ../src/richtext/richtextsizepage.cpp:394
+msgid "The object minimum width."
+msgstr "Минимальная ширина объекта."
+
+#: ../src/richtext/richtextsizepage.cpp:403
+#: ../src/richtext/richtextsizepage.cpp:405
+msgid "Units for the minimum object width."
+msgstr "Единицы минимальной ширины объекта."
+
+#: ../src/richtext/richtextsizepage.cpp:408
+msgid "Min height:"
+msgstr "Мин. высота:"
+
+#: ../src/richtext/richtextsizepage.cpp:410
+#: ../src/richtext/richtextsizepage.cpp:412
+msgid "Enable the minimum height value."
+msgstr "Включить минимальное значение высоты."
+
+#: ../src/richtext/richtextsizepage.cpp:419
+#: ../src/richtext/richtextsizepage.cpp:421
+msgid "The object minimum height."
+msgstr "Минимальная высота объекта."
+
+#: ../src/richtext/richtextsizepage.cpp:430
+#: ../src/richtext/richtextsizepage.cpp:432
+msgid "Units for the minimum object height."
+msgstr "Единицы минимальной высоты объекта."
+
+#: ../src/richtext/richtextsizepage.cpp:435
+msgid "Max width:"
+msgstr "Макс. ширина:"
+
+#: ../src/richtext/richtextsizepage.cpp:437
+#: ../src/richtext/richtextsizepage.cpp:439
+msgid "Enable the maximum width value."
+msgstr "Включить максимальное значение ширины."
+
+#: ../src/richtext/richtextsizepage.cpp:446
+#: ../src/richtext/richtextsizepage.cpp:448
+msgid "The object maximum width."
+msgstr "Максимальная ширина объекта."
+
+#: ../src/richtext/richtextsizepage.cpp:457
+#: ../src/richtext/richtextsizepage.cpp:459
+msgid "Units for the maximum object width."
+msgstr "Единицы максимальной ширины объекта."
+
+#: ../src/richtext/richtextsizepage.cpp:462
+msgid "Max height:"
+msgstr "Макс. высота:"
+
+#: ../src/richtext/richtextsizepage.cpp:473
+#: ../src/richtext/richtextsizepage.cpp:475
+msgid "The object maximum height."
+msgstr "Максимальная высота объекта."
+
+#: ../src/richtext/richtextsizepage.cpp:484
+#: ../src/richtext/richtextsizepage.cpp:486
+msgid "Units for the maximum object height."
+msgstr "Единицы максимальной высоты объекта."
+
+#: ../src/richtext/richtextsizepage.cpp:495
+msgid "Position"
+msgstr "Позиция"
+
+#: ../src/richtext/richtextsizepage.cpp:513
+msgid "&Position mode:"
+msgstr "Режим &размещения:"
+
+#: ../src/richtext/richtextsizepage.cpp:517
+#: ../src/richtext/richtextsizepage.cpp:522
+msgid "Static"
+msgstr "Static"
+
+#: ../src/richtext/richtextsizepage.cpp:518
+msgid "Relative"
+msgstr "Относительно"
+
+#: ../src/richtext/richtextsizepage.cpp:519
+msgid "Absolute"
+msgstr "Абсолютный"
+
+#: ../src/richtext/richtextsizepage.cpp:520
+msgid "Fixed"
+msgstr "Фиксированный"
+
+#: ../src/richtext/richtextsizepage.cpp:533
+#: ../src/richtext/richtextsizepage.cpp:535
+#: ../src/richtext/richtextsizepage.cpp:547
+#: ../src/richtext/richtextsizepage.cpp:549
+msgid "The left position."
+msgstr "Слева от позиции проигрывания."
+
+#: ../src/richtext/richtextsizepage.cpp:558
+#: ../src/richtext/richtextsizepage.cpp:560
+msgid "Units for the left position."
+msgstr "Единицы левой позиции."
+
+#: ../src/richtext/richtextsizepage.cpp:568
+#: ../src/richtext/richtextsizepage.cpp:570
+#: ../src/richtext/richtextsizepage.cpp:582
+#: ../src/richtext/richtextsizepage.cpp:584
+msgid "The top position."
+msgstr "Верхняя позиция."
+
+#: ../src/richtext/richtextsizepage.cpp:593
+#: ../src/richtext/richtextsizepage.cpp:595
+msgid "Units for the top position."
+msgstr "Единицы верхней позиции."
+
+#: ../src/richtext/richtextsizepage.cpp:603
+#: ../src/richtext/richtextsizepage.cpp:605
+#: ../src/richtext/richtextsizepage.cpp:617
+#: ../src/richtext/richtextsizepage.cpp:619
+msgid "The right position."
+msgstr "Правая позиция."
+
+#: ../src/richtext/richtextsizepage.cpp:628
+#: ../src/richtext/richtextsizepage.cpp:630
+msgid "Units for the right position."
+msgstr "Единицы правой позиции."
+
+#: ../src/richtext/richtextsizepage.cpp:638
+#: ../src/richtext/richtextsizepage.cpp:640
+#: ../src/richtext/richtextsizepage.cpp:652
+#: ../src/richtext/richtextsizepage.cpp:654
+msgid "The bottom position."
+msgstr "Позиция внизу."
+
+#: ../src/richtext/richtextsizepage.cpp:663
+#: ../src/richtext/richtextsizepage.cpp:665
+msgid "Units for the bottom position."
+msgstr "Единицы нижней позиции."
+
+#: ../src/richtext/richtextsizepage.cpp:671
+msgid "&Move the object to:"
+msgstr "&Переместить объект в:"
+
+#: ../src/richtext/richtextsizepage.cpp:674
+msgid "&Previous Paragraph"
+msgstr "&Предыдущий абзац"
+
+#: ../src/richtext/richtextsizepage.cpp:675
+#: ../src/richtext/richtextsizepage.cpp:677
+msgid "Moves the object to the previous paragraph."
+msgstr "Перемещает объект в предыдущий абзац."
+
+#: ../src/richtext/richtextsizepage.cpp:680
+msgid "&Next Paragraph"
+msgstr "&Следующий абзац"
+
+#: ../src/richtext/richtextsizepage.cpp:681
+#: ../src/richtext/richtextsizepage.cpp:683
+msgid "Moves the object to the next paragraph."
+msgstr "Перемещает объект в следующий абзац."
+
+#: ../src/richtext/richtextstyledlg.cpp:193
+msgid "&Styles:"
+msgstr "&Стили:"
+
+#: ../src/richtext/richtextstyledlg.cpp:197
+#: ../src/richtext/richtextstyledlg.cpp:199
+msgid "The available styles."
+msgstr "Доступные стили."
+
+#: ../src/richtext/richtextstyledlg.cpp:205
+#: ../src/richtext/richtextstyledlg.cpp:217
+msgid " "
+msgstr " "
+
+#: ../src/richtext/richtextstyledlg.cpp:209
+#: ../src/richtext/richtextstyledlg.cpp:211
+msgid "The style preview."
+msgstr "Предпросмотр стиля."
+
+#: ../src/richtext/richtextstyledlg.cpp:220
+msgid "New &Character Style..."
+msgstr "Новый стиль &символа..."
+
+#: ../src/richtext/richtextstyledlg.cpp:221
+#: ../src/richtext/richtextstyledlg.cpp:223
+msgid "Click to create a new character style."
+msgstr "Щелкните, чтобы создать новый стиль символов."
+
+#: ../src/richtext/richtextstyledlg.cpp:226
+msgid "New &Paragraph Style..."
+msgstr "Новый стиль &абзаца..."
+
+#: ../src/richtext/richtextstyledlg.cpp:227
+#: ../src/richtext/richtextstyledlg.cpp:229
+msgid "Click to create a new paragraph style."
+msgstr "Щелкните, чтобы создать новый стиль абзаца."
+
+#: ../src/richtext/richtextstyledlg.cpp:232
+msgid "New &List Style..."
+msgstr "Новые стиль &списка..."
+
+#: ../src/richtext/richtextstyledlg.cpp:233
+#: ../src/richtext/richtextstyledlg.cpp:235
+msgid "Click to create a new list style."
+msgstr "Щёлкните, чтобы создать новый стиль списка."
+
+#: ../src/richtext/richtextstyledlg.cpp:238
+msgid "New &Box Style..."
+msgstr "Новый стиль &поля..."
+
+#: ../src/richtext/richtextstyledlg.cpp:239
+#: ../src/richtext/richtextstyledlg.cpp:241
+msgid "Click to create a new box style."
+msgstr "Щёлкните, чтобы создать новый стиль поля."
+
+#: ../src/richtext/richtextstyledlg.cpp:246
+msgid "&Apply Style"
+msgstr "&Применить стиль"
+
+#: ../src/richtext/richtextstyledlg.cpp:247
+#: ../src/richtext/richtextstyledlg.cpp:249
+msgid "Click to apply the selected style."
+msgstr "Щёлкните, чтобы применить выбранный стиль."
+
+#: ../src/richtext/richtextstyledlg.cpp:252
+msgid "&Rename Style..."
+msgstr "&Переименовать стиль..."
+
+#: ../src/richtext/richtextstyledlg.cpp:253
+#: ../src/richtext/richtextstyledlg.cpp:255
+msgid "Click to rename the selected style."
+msgstr "Щёлкните, чтобы переименовать выбранный стиль."
+
+#: ../src/richtext/richtextstyledlg.cpp:258
+msgid "&Edit Style..."
+msgstr "&Правка стиля..."
+
+#: ../src/richtext/richtextstyledlg.cpp:259
+#: ../src/richtext/richtextstyledlg.cpp:261
+msgid "Click to edit the selected style."
+msgstr "Щёлкните, чтобы изменить выбранный стиль."
+
+#: ../src/richtext/richtextstyledlg.cpp:264
+msgid "&Delete Style..."
+msgstr "&Удалить стиль..."
+
+#: ../src/richtext/richtextstyledlg.cpp:265
+#: ../src/richtext/richtextstyledlg.cpp:267
+msgid "Click to delete the selected style."
+msgstr "Щёлкните, чтобы удалить выбранный стиль."
+
+#: ../src/richtext/richtextstyledlg.cpp:274
+#: ../src/richtext/richtextstyledlg.cpp:276
+msgid "Click to close this window."
+msgstr "Щёлкните, чтобы закрыть это окно."
+
+#: ../src/richtext/richtextstyledlg.cpp:282
+msgid "&Restart numbering"
+msgstr "&Перезапустить нумерацию"
+
+#: ../src/richtext/richtextstyledlg.cpp:284
+#: ../src/richtext/richtextstyledlg.cpp:286
+msgid "Check to restart numbering."
+msgstr "Установите флажок для перезапуска нумерации."
+
+#: ../src/richtext/richtextstyledlg.cpp:601
+msgid "Enter a character style name"
+msgstr "Ввод символа с именем стиля"
+
+#: ../src/richtext/richtextstyledlg.cpp:601
+#: ../src/richtext/richtextstyledlg.cpp:606
+#: ../src/richtext/richtextstyledlg.cpp:649
+#: ../src/richtext/richtextstyledlg.cpp:654
+#: ../src/richtext/richtextstyledlg.cpp:815
+#: ../src/richtext/richtextstyledlg.cpp:820
+#: ../src/richtext/richtextstyledlg.cpp:888
+#: ../src/richtext/richtextstyledlg.cpp:896
+#: ../src/richtext/richtextstyledlg.cpp:929
+#: ../src/richtext/richtextstyledlg.cpp:934
+msgid "New Style"
+msgstr "Новый стиль"
+
+#: ../src/richtext/richtextstyledlg.cpp:606
+#: ../src/richtext/richtextstyledlg.cpp:654
+#: ../src/richtext/richtextstyledlg.cpp:820
+#: ../src/richtext/richtextstyledlg.cpp:896
+#: ../src/richtext/richtextstyledlg.cpp:934
+msgid "Sorry, that name is taken. Please choose another."
+msgstr "Это имя занято. Пожалуйста, выберите другое."
+
+#: ../src/richtext/richtextstyledlg.cpp:649
+msgid "Enter a paragraph style name"
+msgstr "Введите имя стиля абзаца"
+
+#: ../src/richtext/richtextstyledlg.cpp:777
+#, c-format
+msgid "Delete style %s?"
+msgstr "Удалить стиль %s?"
+
+#: ../src/richtext/richtextstyledlg.cpp:777
+msgid "Delete Style"
+msgstr "Удалить стиль"
+
+#: ../src/richtext/richtextstyledlg.cpp:815
+msgid "Enter a list style name"
+msgstr "Ввод списка имя стиля"
+
+#: ../src/richtext/richtextstyledlg.cpp:888
+msgid "Enter a new style name"
+msgstr "Введите имя нового стиля"
+
+#: ../src/richtext/richtextstyledlg.cpp:929
+msgid "Enter a box style name"
+msgstr "Введите в поле имя стиля"
+
+#: ../src/richtext/richtextstylepage.cpp:109
+#: ../src/richtext/richtextstylepage.cpp:111
+msgid "The style name."
+msgstr "Имя стиля."
+
+#: ../src/richtext/richtextstylepage.cpp:114
+msgid "&Based on:"
+msgstr "&На основе:"
+
+#: ../src/richtext/richtextstylepage.cpp:119
+#: ../src/richtext/richtextstylepage.cpp:121
+msgid "The style on which this style is based."
+msgstr "Стиль на котором этот стиль основывается."
+
+#: ../src/richtext/richtextstylepage.cpp:124
+msgid "&Next style:"
+msgstr "&Cледующий стиль:"
+
+#: ../src/richtext/richtextstylepage.cpp:129
+#: ../src/richtext/richtextstylepage.cpp:131
+msgid "The default style for the next paragraph."
+msgstr "Стиль по умолчанию для следующего абзаца."
+
+#: ../src/richtext/richtextstyles.cpp:1057
+msgid "All styles"
+msgstr "Все стили"
+
+#: ../src/richtext/richtextstyles.cpp:1058
+msgid "Paragraph styles"
+msgstr "Стили абзаца"
+
+#: ../src/richtext/richtextstyles.cpp:1059
+msgid "Character styles"
+msgstr "Стили знаков"
+
+#: ../src/richtext/richtextstyles.cpp:1060
+msgid "List styles"
+msgstr "Список стилей"
+
+#: ../src/richtext/richtextstyles.cpp:1061
+msgid "Box styles"
+msgstr "Стили полей"
+
+#: ../src/richtext/richtextsymboldlg.cpp:389
+#: ../src/richtext/richtextsymboldlg.cpp:391
+msgid "The font from which to take the symbol."
+msgstr "Шрифт, из которого следует взять символ."
+
+#: ../src/richtext/richtextsymboldlg.cpp:396
+msgid "&Subset:"
+msgstr "&Подмножество:"
+
+#: ../src/richtext/richtextsymboldlg.cpp:401
+#: ../src/richtext/richtextsymboldlg.cpp:403
+msgid "Shows a Unicode subset."
+msgstr "Показывает Unicode подмножество."
+
+#: ../src/richtext/richtextsymboldlg.cpp:412
+msgid "xxxx"
+msgstr "xxxx"
+
+#: ../src/richtext/richtextsymboldlg.cpp:417
+msgid "&Character code:"
+msgstr "Код &символа:"
+
+#: ../src/richtext/richtextsymboldlg.cpp:421
+#: ../src/richtext/richtextsymboldlg.cpp:423
+msgid "The character code."
+msgstr "Код символа."
+
+#: ../src/richtext/richtextsymboldlg.cpp:428
+msgid "&From:"
+msgstr "&От:"
+
+#: ../src/richtext/richtextsymboldlg.cpp:433
+#: ../src/richtext/richtextsymboldlg.cpp:434
+#: ../src/richtext/richtextsymboldlg.cpp:435
+msgid "Unicode"
+msgstr "Юникод"
+
+#: ../src/richtext/richtextsymboldlg.cpp:436
+#: ../src/richtext/richtextsymboldlg.cpp:438
+msgid "The range to show."
+msgstr "Диапазон отображения."
+
+#: ../src/richtext/richtextsymboldlg.cpp:444
+msgid "Insert"
+msgstr "Insert"
+
+#: ../src/richtext/richtextsymboldlg.cpp:478
+msgid "(Normal text)"
+msgstr "(Обычный текст)"
+
+#: ../src/richtext/richtexttabspage.cpp:109
+msgid "&Position (tenths of a mm):"
+msgstr "&Позиция (десятые доли мм):"
+
+#: ../src/richtext/richtexttabspage.cpp:113
+#: ../src/richtext/richtexttabspage.cpp:115
+msgid "The tab position."
+msgstr "Позиция табуляции."
+
+#: ../src/richtext/richtexttabspage.cpp:119
+msgid "The tab positions."
+msgstr "Позиции табуляции."
+
+#: ../src/richtext/richtexttabspage.cpp:132
+#: ../src/richtext/richtexttabspage.cpp:134
+msgid "Click to create a new tab position."
+msgstr "Щёлкните, чтобы создать новую позицию табуляции."
+
+#: ../src/richtext/richtexttabspage.cpp:138
+#: ../src/richtext/richtexttabspage.cpp:140
+msgid "Click to delete the selected tab position."
+msgstr "Щёлкните, чтобы удалить выбранную позицию табуляции."
+
+#: ../src/richtext/richtexttabspage.cpp:143
+msgid "Delete A&ll"
+msgstr "Удалить вс&ё"
+
+#: ../src/richtext/richtexttabspage.cpp:144
+#: ../src/richtext/richtexttabspage.cpp:146
+msgid "Click to delete all tab positions."
+msgstr "Щёлкните, чтобы удалить все позиции табуляции."
+
+#: ../src/univ/theme.cpp:110
+msgid "Failed to initialize GUI: no built-in themes found."
+msgstr "Ошибка при инициализации GUI: не найдено встроенных тем."
+
+#: ../src/univ/themes/gtk.cpp:521
+msgid "GTK+ theme"
+msgstr "Тема GTK+"
+
+#: ../src/univ/themes/metal.cpp:164
+msgid "Metal theme"
+msgstr "Тема Metal"
+
+#: ../src/univ/themes/mono.cpp:512
+msgid "Simple monochrome theme"
+msgstr "Простая одноцветная тема"
+
+#: ../src/univ/themes/win32.cpp:1098
+msgid "Win32 theme"
+msgstr "Тема Win32"
+
+#: ../src/univ/themes/win32.cpp:3743
+msgid "&Restore"
+msgstr "&Восстановить"
+
+#: ../src/univ/themes/win32.cpp:3744
+msgid "&Move"
+msgstr "П&ереместить"
+
+#: ../src/univ/themes/win32.cpp:3746
+msgid "&Size"
+msgstr "&Размер"
+
+#: ../src/univ/themes/win32.cpp:3748
+msgid "Mi&nimize"
+msgstr "&Свернуть"
+
+#: ../src/univ/themes/win32.cpp:3750
+msgid "Ma&ximize"
+msgstr "&Развернуть"
+
+#: ../src/univ/themes/win32.cpp:3752
+msgid "Alt+"
+msgstr "Alt+"
+
+#: ../src/unix/appunix.cpp:178
+msgid "Failed to install signal handler"
+msgstr "Не удалось установить обработчик сигнала"
+
+#: ../src/unix/dialup.cpp:351
+msgid "Already dialling ISP."
+msgstr "Уже звоним ISP."
+
+#: ../src/unix/dlunix.cpp:93
+#, fuzzy
+msgid "Failed to unload shared library"
+msgstr "Ошибка загрузки разделяемой библиотеки '%s'"
+
+#: ../src/unix/dlunix.cpp:121
+msgid "Unknown dynamic library error"
+msgstr "Неизвестная ошибка динамической библиотеки"
+
+#: ../src/unix/epolldispatcher.cpp:84
+msgid "Failed to create epoll descriptor"
+msgstr "Не удалось создать дескриптор epoll"
+
+#: ../src/unix/epolldispatcher.cpp:103
+msgid "Error closing epoll descriptor"
+msgstr "Ошибка при закрытии epoll дескриптора"
+
+#: ../src/unix/epolldispatcher.cpp:116
+#, c-format
+msgid "Failed to add descriptor %d to epoll descriptor %d"
+msgstr "Не удалось добавить дескриптор %d в epoll дескриптор %d"
+
+#: ../src/unix/epolldispatcher.cpp:136
+#, c-format
+msgid "Failed to modify descriptor %d in epoll descriptor %d"
+msgstr "Не удалось изменить дескриптором %d в epoll дескриптором %d"
+
+#: ../src/unix/epolldispatcher.cpp:155
+#, c-format
+msgid "Failed to unregister descriptor %d from epoll descriptor %d"
+msgstr "Не удалось отменить регистрацию дескриптора %d в epoll дескрипторе %d"
+
+#: ../src/unix/epolldispatcher.cpp:213
+#, c-format
+msgid "Waiting for IO on epoll descriptor %d failed"
+msgstr "Ошибка ожидания ввода/ввывода от epoll дескриптора %d"
+
+#: ../src/unix/fswatcher_inotify.cpp:71
+msgid "Unable to create inotify instance"
+msgstr "Невозможно создать экземпляр inotify"
+
+#: ../src/unix/fswatcher_inotify.cpp:94
+msgid "Unable to close inotify instance"
+msgstr "Невозможно закрыть экземпляр inotify"
+
+#: ../src/unix/fswatcher_inotify.cpp:106
+msgid "Unable to add inotify watch"
+msgstr "Не удалось добавить inotify"
+
+#: ../src/unix/fswatcher_inotify.cpp:138
+#, c-format
+msgid "Unable to remove inotify watch %i"
+msgstr "Невозможно удалить отслеживание inotify %i"
+
+#: ../src/unix/fswatcher_inotify.cpp:271
+#, c-format
+msgid "Unexpected event for \"%s\": no matching watch descriptor."
+msgstr ""
+"Непредвиденное событие для '%s': нет соответствующего дескриптора наблюдения."
+
+#: ../src/unix/fswatcher_inotify.cpp:320
+#, c-format
+msgid "Invalid inotify event for \"%s\""
+msgstr "Недопустимое событие inotify для '%s'"
+
+#: ../src/unix/fswatcher_inotify.cpp:553
+msgid "Unable to read from inotify descriptor"
+msgstr "Не удалось прочесть из inotify дескриптора"
+
+#: ../src/unix/fswatcher_inotify.cpp:558
+msgid "EOF while reading from inotify descriptor"
+msgstr "EOF при чтении из дескриптора inotify"
+
+#: ../src/unix/fswatcher_kqueue.cpp:114
+msgid "Unable to create kqueue instance"
+msgstr "Невозможно создать экземпляр kqueue"
+
+#: ../src/unix/fswatcher_kqueue.cpp:131
+msgid "Error closing kqueue instance"
+msgstr "Ошибка при закрытии экземпляра kqueue"
+
+#: ../src/unix/fswatcher_kqueue.cpp:153
+msgid "Unable to add kqueue watch"
+msgstr "Не удалось добавить отслеживание kqueue"
+
+#: ../src/unix/fswatcher_kqueue.cpp:170
+msgid "Unable to remove kqueue watch"
+msgstr "Не удалось удалить отслеживание kqueue"
+
+#: ../src/unix/fswatcher_kqueue.cpp:202
+msgid "Unable to get events from kqueue"
+msgstr "Не удалось получать события от kqueue"
+
+#: ../src/unix/mediactrl.cpp:966
+#, c-format
+msgid "Media playback error: %s"
+msgstr "Ошибка проигрывания мультимедиа: %s"
+
+#: ../src/unix/mediactrl.cpp:1228
+#, c-format
+msgid "Failed to prepare playing \"%s\"."
+msgstr "Не удалось подготовить проигрывание '%s'."
+
+#: ../src/unix/snglinst.cpp:164
+#, c-format
+msgid "Failed to write to lock file '%s'"
+msgstr "Не удалось записать файл блокировки '%s'"
+
+#: ../src/unix/snglinst.cpp:177
+#, c-format
+msgid "Failed to set permissions on lock file '%s'"
+msgstr "Невозможно установить разрешения файлу блокировки '%s'"
+
+#: ../src/unix/snglinst.cpp:194
+#, c-format
+msgid "Failed to lock the lock file '%s'"
+msgstr "Ошибка блокировки файла блокировки '%s'"
+
+#: ../src/unix/snglinst.cpp:237
+#, c-format
+msgid "Failed to inspect the lock file '%s'"
+msgstr "Ошибка проверки файла блокировки '%s'"
+
+#: ../src/unix/snglinst.cpp:242
+#, c-format
+msgid "Lock file '%s' has incorrect owner."
+msgstr "Файл блокировки '%s' имеет неверного владельца."
+
+#: ../src/unix/snglinst.cpp:247
+#, c-format
+msgid "Lock file '%s' has incorrect permissions."
+msgstr "Файл блокировки '%s' имеет неверные разрешения."
+
+#: ../src/unix/snglinst.cpp:265
+msgid "Failed to access lock file."
+msgstr "Не удалось обратиться к файлу блокировки."
+
+#: ../src/unix/snglinst.cpp:274
+msgid "Failed to read PID from lock file."
+msgstr "Не удалось прочесть PID из файла блокировки."
+
+#: ../src/unix/snglinst.cpp:284
+#, c-format
+msgid "Failed to remove stale lock file '%s'."
+msgstr "Не удалось удалить устаревший файл блокировки '%s'."
+
+#: ../src/unix/snglinst.cpp:297
+#, c-format
+msgid "Deleted stale lock file '%s'."
+msgstr "Удалён старый файл блокировки '%s'."
+
+#: ../src/unix/snglinst.cpp:308
+#, c-format
+msgid "Invalid lock file '%s'."
+msgstr "Неверный файл блокировки '%s'."
+
+#: ../src/unix/snglinst.cpp:324
+#, c-format
+msgid "Failed to remove lock file '%s'"
+msgstr "Ошибка удаления файла блокировки '%s'"
+
+#: ../src/unix/snglinst.cpp:330
+#, c-format
+msgid "Failed to unlock lock file '%s'"
+msgstr "Не удалось разблокировать файл блокировки '%s'"
+
+#: ../src/unix/snglinst.cpp:336
+#, c-format
+msgid "Failed to close lock file '%s'"
+msgstr "Ошибка закрытия файла блокировки '%s'"
+
+#: ../src/unix/sound.cpp:77
+msgid "No sound"
+msgstr "Нет звука"
+
+#: ../src/unix/sound.cpp:364
+msgid "Unable to play sound asynchronously."
+msgstr "Невозможно проиграть звук асинхронно."
+
+#: ../src/unix/sound.cpp:458
+#, c-format
+msgid "Couldn't load sound data from '%s'."
+msgstr "Невозможно загрузить звуковые данные из '%s'."
+
+#: ../src/unix/sound.cpp:465
+#, c-format
+msgid "Sound file '%s' is in unsupported format."
+msgstr "Звуковой файл '%s' неподдерживаемого формата."
+
+#: ../src/unix/sound.cpp:480
+msgid "Sound data are in unsupported format."
+msgstr "Данные звука имеют неподдерживаемый формат."
+
+#: ../src/unix/sound_sdl.cpp:226
+#, c-format
+msgid "Couldn't open audio: %s"
+msgstr "Невозможно открыть аудио: %s"
+
+#: ../src/unix/threadpsx.cpp:1033
+msgid "Cannot retrieve thread scheduling policy."
+msgstr "Невозможно извлечь политику планировки потока."
+
+#: ../src/unix/threadpsx.cpp:1058
+#, c-format
+msgid "Cannot get priority range for scheduling policy %d."
+msgstr "Невозможно получить диапазон приоритетов для политики планирования %d."
+
+#: ../src/unix/threadpsx.cpp:1066
+msgid "Thread priority setting is ignored."
+msgstr "Установка приоритета потока проигнорирована."
+
+#: ../src/unix/threadpsx.cpp:1221
+msgid ""
+"Failed to join a thread, potential memory leak detected - please restart the "
+"program"
+msgstr ""
+"Не удалось соединиться с потоком, обнаружена потенциальная утечка памяти - "
+"перезапустите программу"
+
+#: ../src/unix/threadpsx.cpp:1352
+#, c-format
+msgid "Failed to set thread concurrency level to %lu"
+msgstr "Не удалось задать уровень параллелизма потоков %lu"
+
+#: ../src/unix/threadpsx.cpp:1481
+#, c-format
+msgid "Failed to set thread priority %d."
+msgstr "Не удалось установить приоритет потока %d."
+
+#: ../src/unix/threadpsx.cpp:1666
+msgid "Failed to terminate a thread."
+msgstr "Не удалось завершить поток."
+
+#: ../src/unix/threadpsx.cpp:1893
+msgid "Thread module initialization failed: failed to create thread key"
+msgstr "Ошибка инициализации модуля потоков: не удалось создать ключ потока"
+
+#: ../src/unix/utilsunx.cpp:340
+msgid "Impossible to get child process input"
+msgstr "Невозможно получить ввод дочернего процесса"
+
+#: ../src/unix/utilsunx.cpp:390
+msgid "Can't write to child process's stdin"
+msgstr "Не удаётся записать в стандартный ввод дочернего процесса"
+
+#: ../src/unix/utilsunx.cpp:644
+#, c-format
+msgid "Failed to execute '%s'\n"
+msgstr "Не удалось выполнить '%s'\n"
+
+#: ../src/unix/utilsunx.cpp:678
+msgid "Fork failed"
+msgstr "Ветка не удалась"
+
+#: ../src/unix/utilsunx.cpp:701
+msgid "Failed to set process priority"
+msgstr "Не удалось установить приоритет процесса"
+
+#: ../src/unix/utilsunx.cpp:712
+msgid "Failed to redirect child process input/output"
+msgstr "Не удалось перенаправить ввод/вывод порожденного процесса"
+
+#: ../src/unix/utilsunx.cpp:816
+msgid "Failed to set up non-blocking pipe, the program might hang."
+msgstr "Не удалось настроить неблокирующий канал, программа может зависать."
+
+#: ../src/unix/utilsunx.cpp:1023
+msgid "Cannot get the hostname"
+msgstr "Невозможно получить имя хоста"
+
+#: ../src/unix/utilsunx.cpp:1059
+msgid "Cannot get the official hostname"
+msgstr "Невозможно получить официальное имя хоста"
+
+#: ../src/unix/wakeuppipe.cpp:49
+msgid "Failed to create wake up pipe used by event loop."
+msgstr "Не удалось создать канал пробуждения, используемый циклом событий."
+
+#: ../src/unix/wakeuppipe.cpp:56
+msgid "Failed to switch wake up pipe to non-blocking mode"
+msgstr "Не удалось переключить Звонок трубы неблокирующий режим"
+
+#: ../src/unix/wakeuppipe.cpp:117
+msgid "Failed to read from wake-up pipe"
+msgstr "Не удалось прочесть из канала пробуждения"
+
+#: ../src/x11/app.cpp:124
+#, c-format
+msgid "Invalid geometry specification '%s'"
+msgstr "Неправильная спецификация геометрии '%s'"
+
+#: ../src/x11/app.cpp:167
+msgid "wxWidgets could not open display. Exiting."
+msgstr "wxWidgets не удалось открыть дисплей. Выход."
+
+#: ../src/x11/utils.cpp:169
+#, c-format
+msgid "Failed to close the display \"%s\""
+msgstr "Не удалось закрыть дисплей \"%s\""
+
+#: ../src/x11/utils.cpp:188
+#, c-format
+msgid "Failed to open display \"%s\"."
+msgstr "Не удалось открыть дисплей \"%s\"."
+
+#: ../src/xml/xml.cpp:868
+#, c-format
+msgid "XML parsing error: '%s' at line %d"
+msgstr "Ошибка разбора XML: '%s' в строке %d"
+
+#: ../src/xrc/xh_propgrid.cpp:239
+#, fuzzy, c-format
+msgid "Page %i"
+msgstr "Страница %d"
+
+#: ../src/xrc/xmlres.cpp:448
+#, c-format
+msgid "Cannot load resources from '%s'."
+msgstr "Не удалось загрузить ресурсы из '%s'."
+
+#: ../src/xrc/xmlres.cpp:799
+#, c-format
+msgid "Cannot open resources file '%s'."
+msgstr "Невозможно открыть файл ресурсов '%s'."
+
+#: ../src/xrc/xmlres.cpp:806
+#, c-format
+msgid "Cannot load resources from file '%s'."
+msgstr "Невозможно загрузить ресурсы из файла '%s'."
+
+#: ../src/xrc/xmlres.cpp:2767
+#, c-format
+msgid "Creating %s \"%s\" failed."
+msgstr "Не удалось создать '%s' в '%s'."
+
+#~ msgctxt "keyboard key"
+#~ msgid "Alt+"
+#~ msgstr "Alt+"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Ctrl+"
+#~ msgstr "Ctrl+"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Shift+"
+#~ msgstr "Shift+"
+
+#~ msgctxt "keyboard key"
+#~ msgid "RawCtrl+"
+#~ msgstr "RawCtrl+"
+
+#~ msgid "Unsupported clipboard format."
+#~ msgstr "Неподдерживаемый формат буфера обмена."
+
+#~ msgid "Background colour"
+#~ msgstr "Цвет фона"
+
+#~ msgid "Font:"
+#~ msgstr "Шрифт:"
+
+#~ msgid "Size:"
+#~ msgstr "Размер:"
+
+#~ msgid "The font size in points."
+#~ msgstr "Размер шрифта в точках."
+
+#~ msgid "Style:"
+#~ msgstr "Стиль:"
+
+#~ msgid "Check to make the font bold."
+#~ msgstr "Установите флажок, чтобы сделать шрифт полужирным."
+
+#~ msgid "Check to make the font italic."
+#~ msgstr "Установите флажок, чтобы сделать шрифт курсивом."
+
+#~ msgid "Check to make the font underlined."
+#~ msgstr "Установите флажок, чтобы сделать шрифт подчёркнутым."
+
+#~ msgid "Colour:"
+#~ msgstr "Цвет:"
+
+#~ msgid "Click to change the font colour."
+#~ msgstr "Щёлкните, чтобы изменить цвет шрифта."
+
+#~ msgid "Shows a preview of the font."
+#~ msgstr "Показывает как выглядит шрифт."
+
+#~ msgid "Click to cancel changes to the font."
+#~ msgstr "Щёлкните, чтобы отменить изменения шрифта."
+
+#~ msgid "Click to confirm changes to the font."
+#~ msgstr "Щёлкните, чтобы подтвердить изменения в шрифте."
+
+#~ msgid "<Any>"
+#~ msgstr "<Всем>"
+
+#~ msgid "<Any Roman>"
+#~ msgstr "<Любой Римский>"
+
+#~ msgid "<Any Decorative>"
+#~ msgstr "<Любой декоративный>"
+
+#~ msgid "<Any Modern>"
+#~ msgstr "<Любой современный>"
+
+#~ msgid "<Any Script>"
+#~ msgstr "<Любой скрипт>"
+
+#~ msgid "<Any Swiss>"
+#~ msgstr "<Любой Швейцарский>"
+
+#~ msgid "<Any Teletype>"
+#~ msgstr "<Любой телетайп>"
+
+#~ msgid "Printing "
+#~ msgstr "Печать "
+
+#~ msgid "Failed to insert text in the control."
+#~ msgstr "Не удалось вставить текст в элемент управления."
+
+#~ msgid "Please choose a valid font."
+#~ msgstr "Выберите допустимый шрифт."
+
+#, c-format
+#~ msgid "Failed to display HTML document in %s encoding"
+#~ msgstr "Не удалось отобразить документ HTML в кодировке %s"
+
+#, c-format
+#~ msgid "wxWidgets could not open display for '%s': exiting."
+#~ msgstr "wxWidgets не удалось открыть дисплей для '%s': выход."
+
+#~ msgid "Filter"
+#~ msgstr "Фильтр"
+
+#~ msgid "Directories"
+#~ msgstr "Каталоги"
+
+#~ msgid "Files"
+#~ msgstr "Файлы"
+
+#~ msgid "Selection"
+#~ msgstr "Выделение"
+
+#~ msgid "conversion to 8-bit encoding failed"
+#~ msgstr "не удалось преобразование в 8-бит кодировку"
+
+#, fuzzy
+#~ msgid "failed to retrieve execution result"
+#~ msgstr "Не удалось получить текст сообщения об ошибке RAS"
+
+#~ msgid " (while overwriting an existing item)"
+#~ msgstr " (при перезаписи существующего элемента)"
+
+#~ msgid "&Save as"
+#~ msgstr "&Сохранить как"
+
+#~ msgid "'%s' doesn't consist only of valid characters"
+#~ msgstr "'%s' должно содержать только допустимые символы"
+
+#~ msgid "'%s' should be numeric."
+#~ msgstr "'%s' должно быть числом."
+
+#~ msgid "'%s' should only contain ASCII characters."
+#~ msgstr "'%s' должно содержать только символы ASCII."
+
+#~ msgid "'%s' should only contain alphabetic characters."
+#~ msgstr "'%s' должно содержать только символы алфавита."
+
+#~ msgid "'%s' should only contain alphabetic or numeric characters."
+#~ msgstr "'%s' должно содержать только символы алфавита или цифры."
+
+#~ msgid "'%s' should only contain digits."
+#~ msgstr "'%s' должно содержать только цифры."
+
+#~ msgid "Can't create window of class %s"
+#~ msgstr "Невозможно создать окно класса %s"
+
+#~ msgid "Couldn't create the overlay window"
+#~ msgstr "Не удалось создать перекрывающееся окно"
+
+#~ msgid "Couldn't init the context on the overlay window"
+#~ msgstr "Не удалось инициализировать контекст в перекрывающемся окне"
+
+#~ msgid "Failed to convert file \"%s\" to Unicode."
+#~ msgstr "Не удалось преобразовать файл \"%s\" в Unicode."
+
+#~ msgid "Failed to set text in the text control."
+#~ msgstr "Не удалось установить текст в текстовое поле."
+
+#~ msgid "Invalid GTK+ command line option, use \"%s --help\""
+#~ msgstr "Повреждены опции командной строки GTK+, используйте '%s --help'"
+
+#~ msgid "No unused colour in image."
+#~ msgstr "В изображении нет неиспользуемых цветов."
+
+#~ msgid "Not available"
+#~ msgstr "Не доступно"
+
+#~ msgid "Replace selection"
+#~ msgstr "Заменить выделенное"
+
+#~ msgid "Save as"
+#~ msgstr "Сохранить как"
+
+#~ msgid "Style Organiser"
+#~ msgstr "Органайзер стиля"
+
+#~ msgid "The following standard GTK+ options are also supported:\n"
+#~ msgstr "Также поддерживаются следующие стандартные параметры GTK+:\n"
+
+#~ msgid "You cannot Clear an overlay that is not inited"
+#~ msgstr "Нельзя очистить наложение на изображение без инициализации"
+
+#~ msgid "You cannot Init an overlay twice"
+#~ msgstr "Нельзя Init наложить два раза"
+
+#~ msgid "locale '%s' cannot be set."
+#~ msgstr "локаль '%s' установить нельзя."

--- a/po_wxstd/sk.po
+++ b/po_wxstd/sk.po
@@ -1,0 +1,10209 @@
+# Slovak translation of wxWidgets
+# Copyright (C) 2007 wxWidgets dev team
+# This file is distributed under the same license as the wxWidgets package.
+# Ivan Masar <helix84@centrum.sk>, 2007.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: wxWidgets 3.3\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-05-14 20:23+0200\n"
+"PO-Revision-Date: 2020-10-19 12:24+0200\n"
+"Last-Translator: Jozef Matta <jozef.m923@gmail.com>\n"
+"Language-Team: Slovak <sk-i18n@lists.linux.sk>\n"
+"Language: sk\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=(n==1 ? 0 : n>=2 && n<=4 ? 1 : 2);\n"
+"X-Generator: Poedit 2.4.1\n"
+"X-Poedit-Bookmarks: -1,1760,-1,-1,-1,-1,-1,-1,-1,-1\n"
+
+#: ../include/wx/defs.h:2582
+msgid "All files (*.*)|*.*"
+msgstr "Všetky súbory (*.*)|*.*"
+
+#: ../include/wx/defs.h:2585
+msgid "All files (*)|*"
+msgstr "Všetky súbory (*)|*"
+
+#: ../include/wx/generic/progdlgg.h:85
+msgid "Elapsed time:"
+msgstr "Uplynutý čas:"
+
+#: ../include/wx/generic/progdlgg.h:86
+msgid "Estimated time:"
+msgstr "Odhadovaný čas:"
+
+#: ../include/wx/generic/progdlgg.h:87
+msgid "Remaining time:"
+msgstr "Zostávajúci čas:"
+
+#. TRANSLATORS: HTML printout default title.
+#: ../include/wx/html/htmprint.h:121 ../include/wx/prntbase.h:273
+#: ../include/wx/richtext/richtextprint.h:109 ../src/common/docview.cpp:2161
+msgid "Printout"
+msgstr "Vytlačiť"
+
+#. TRANSLATORS: HTML easy print default title.
+#: ../include/wx/html/htmprint.h:234 ../include/wx/richtext/richtextprint.h:163
+#: ../src/common/prntbase.cpp:522 ../src/html/htmprint.cpp:291
+msgid "Printing"
+msgstr "Tlačí sa"
+
+#: ../include/wx/msgdlg.h:277 ../src/common/stockitem.cpp:211
+msgid "Yes"
+msgstr "Áno"
+
+#: ../include/wx/msgdlg.h:278 ../src/common/stockitem.cpp:182
+msgid "No"
+msgstr "Nie"
+
+#: ../include/wx/msgdlg.h:279 ../src/common/stockitem.cpp:183
+#: ../src/msw/msgdlg.cpp:430 ../src/msw/msgdlg.cpp:734
+#: ../src/richtext/richtextstyledlg.cpp:292
+msgid "OK"
+msgstr "OK"
+
+#: ../include/wx/msgdlg.h:280 ../src/common/stockitem.cpp:150
+#: ../src/msw/msgdlg.cpp:430 ../src/msw/progdlg.cpp:884
+#: ../src/richtext/richtextstyledlg.cpp:295
+msgid "Cancel"
+msgstr "Zrušiť"
+
+#: ../include/wx/msgdlg.h:281 ../src/common/stockitem.cpp:168
+#: ../src/html/helpdlg.cpp:63 ../src/html/helpfrm.cpp:108
+#: ../src/osx/button_osx.cpp:38
+msgid "Help"
+msgstr "Pomocník"
+
+#: ../include/wx/msw/ole/oleutils.h:52
+msgid "Cannot initialize OLE"
+msgstr "Nemožno inicializovať OLE"
+
+#: ../include/wx/msw/private/fswatcher.h:48
+#, c-format
+msgid "Unable to close the handle for '%s'"
+msgstr "Nemožno zatvoriť manipulátor pre '%s'"
+
+#: ../include/wx/msw/private/fswatcher.h:92
+#, c-format
+msgid "Failed to open directory \"%s\" for monitoring."
+msgstr "Zlyhalo otvorenie priečinka '%s' na sledovanie."
+
+#: ../include/wx/msw/private/fswatcher.h:125
+msgid "Unable to close I/O completion port handle"
+msgstr "Nemožno zatvoriť manipulátor I/O portu dokončenia"
+
+#: ../include/wx/msw/private/fswatcher.h:142
+msgid "Unable to associate handle with I/O completion port"
+msgstr "Nemožno priradiť manipulátor k I/O portu dokončenia"
+
+#: ../include/wx/msw/private/fswatcher.h:148
+msgid "Unexpectedly new I/O completion port was created"
+msgstr "Bol neočakávane vytvorený nový port dokončenia I/O"
+
+#: ../include/wx/msw/private/fswatcher.h:213
+msgid "Unable to post completion status"
+msgstr "Nemožno odoslať stav dokončenia"
+
+#: ../include/wx/msw/private/fswatcher.h:262
+msgid "Unable to dequeue completion packet"
+msgstr "Nemožno vyradiť paket"
+
+#: ../include/wx/msw/private/fswatcher.h:273
+msgid "Unable to create I/O completion port"
+msgstr "Nemožno vytvoriť port dokončenia I/O"
+
+#: ../include/wx/richmsgdlg.h:29
+msgid "&See details"
+msgstr "&Pozrieť detaily"
+
+#: ../include/wx/richmsgdlg.h:30
+msgid "&Hide details"
+msgstr "&Skryť detaily"
+
+#: ../include/wx/richtext/richtextbuffer.h:3864
+msgid "&Box"
+msgstr "&Box"
+
+#: ../include/wx/richtext/richtextbuffer.h:5008
+msgid "&Picture"
+msgstr "&Obrázok"
+
+#: ../include/wx/richtext/richtextbuffer.h:5958
+msgid "&Cell"
+msgstr "&Bunka"
+
+#: ../include/wx/richtext/richtextbuffer.h:6067
+msgid "&Table"
+msgstr "&Karta"
+
+#: ../include/wx/richtext/richtextimagedlg.h:37
+msgid "Object Properties"
+msgstr "Vlastnosti objektu"
+
+#: ../include/wx/richtext/richtextsymboldlg.h:39
+msgid "Symbols"
+msgstr "Symboly"
+
+#: ../include/wx/unix/pipe.h:46
+msgid "Pipe creation failed"
+msgstr "Vytvorenie potrubia zlyhalo"
+
+#: ../include/wx/unix/private/displayx11.h:65
+msgid "Failed to enumerate video modes"
+msgstr "Zlyhalo zistenie zoznamu video režimov"
+
+#: ../include/wx/unix/private/displayx11.h:89
+msgid "Failed to change video mode"
+msgstr "Zlyhala zmena video režimu"
+
+#: ../include/wx/unix/private/fswatcher_kqueue.h:57
+#, c-format
+msgid "Unable to open path '%s'"
+msgstr "Nemožno otvoriť cestu '%s'"
+
+#: ../include/wx/unix/private/fswatcher_kqueue.h:74
+#, c-format
+msgid "Unable to close path '%s'"
+msgstr "Nemožno zatvoriť cestu '%s'"
+
+#: ../include/wx/xtiprop.h:175
+msgid "SetProperty called w/o valid setter"
+msgstr "SetProperty volá w/o platný nastavovač"
+
+#: ../include/wx/xtiprop.h:184
+msgid "GetProperty called w/o valid getter"
+msgstr "GetProperty sa volá w/o platný getter"
+
+#: ../include/wx/xtiprop.h:193
+msgid "AddToPropertyCollection called w/o valid adder"
+msgstr "AddToPropertyCollection volaná bez platného pridávateľa"
+
+#: ../include/wx/xtiprop.h:202
+msgid "GetPropertyCollection called w/o valid collection getter"
+msgstr "GetPropertyCollection volá w/o platný getter kolekcie"
+
+#: ../include/wx/xtiprop.h:255
+msgid "AddToPropertyCollection called on a generic accessor"
+msgstr "AddToPropertyCollection volaná pri všeobecnom prístupe"
+
+#: ../include/wx/xtiprop.h:262
+msgid "GetPropertyCollection called on a generic accessor"
+msgstr "GetPropertyCollection volá všeobecný objekt príslušenstva"
+
+#: ../src/aui/tabmdi.cpp:106 ../src/generic/mdig.cpp:94
+msgid "Cl&ose"
+msgstr "&Zatvoriť"
+
+#: ../src/aui/tabmdi.cpp:107 ../src/generic/mdig.cpp:95
+msgid "Close All"
+msgstr "Zatvoriť všetky"
+
+#: ../src/aui/tabmdi.cpp:109 ../src/generic/mdig.cpp:97 ../src/msw/mdi.cpp:175
+#: ../src/qt/mdi.cpp:258
+msgid "&Next"
+msgstr "&Ďalej"
+
+#: ../src/aui/tabmdi.cpp:110 ../src/generic/mdig.cpp:98 ../src/msw/mdi.cpp:176
+#: ../src/qt/mdi.cpp:259
+msgid "&Previous"
+msgstr "&Predchádzajúci"
+
+#: ../src/aui/tabmdi.cpp:332 ../src/aui/tabmdi.cpp:348
+#: ../src/aui/tabmdi.cpp:350 ../src/generic/mdig.cpp:291
+#: ../src/generic/mdig.cpp:307 ../src/generic/mdig.cpp:311
+#: ../src/msw/mdi.cpp:337 ../src/qt/mdi.cpp:462
+msgid "&Window"
+msgstr "&Okno"
+
+#: ../src/common/accelcmn.cpp:47
+msgctxt "keyboard key"
+msgid "Delete"
+msgstr "Odstrániť"
+
+#: ../src/common/accelcmn.cpp:48
+msgctxt "keyboard key"
+msgid "Del"
+msgstr "Del"
+
+#: ../src/common/accelcmn.cpp:49
+msgctxt "keyboard key"
+msgid "Back"
+msgstr "Zo zadu"
+
+#: ../src/common/accelcmn.cpp:49
+msgctxt "keyboard key"
+msgid "Backspace"
+msgstr "Backspace"
+
+#: ../src/common/accelcmn.cpp:50
+msgctxt "keyboard key"
+msgid "Insert"
+msgstr "Vložiť"
+
+#: ../src/common/accelcmn.cpp:51
+msgctxt "keyboard key"
+msgid "Ins"
+msgstr "Ins"
+
+#: ../src/common/accelcmn.cpp:52
+msgctxt "keyboard key"
+msgid "Enter"
+msgstr "Enter"
+
+#: ../src/common/accelcmn.cpp:53
+msgctxt "keyboard key"
+msgid "Return"
+msgstr "Enter"
+
+#: ../src/common/accelcmn.cpp:54
+msgctxt "keyboard key"
+msgid "PageUp"
+msgstr "PageUp"
+
+#: ../src/common/accelcmn.cpp:54
+msgctxt "keyboard key"
+msgid "Page Up"
+msgstr "O stránku nahor"
+
+#: ../src/common/accelcmn.cpp:55
+msgctxt "keyboard key"
+msgid "PageDown"
+msgstr "PageDown"
+
+#: ../src/common/accelcmn.cpp:55
+msgctxt "keyboard key"
+msgid "Page Down"
+msgstr "O stránku nadol"
+
+#: ../src/common/accelcmn.cpp:56
+msgctxt "keyboard key"
+msgid "PgUp"
+msgstr "PgUp"
+
+#: ../src/common/accelcmn.cpp:57
+msgctxt "keyboard key"
+msgid "PgDn"
+msgstr "PgDn"
+
+#: ../src/common/accelcmn.cpp:58
+msgctxt "keyboard key"
+msgid "Left"
+msgstr "Zľava"
+
+#: ../src/common/accelcmn.cpp:59
+msgctxt "keyboard key"
+msgid "Right"
+msgstr "Vpravo"
+
+#: ../src/common/accelcmn.cpp:60
+msgctxt "keyboard key"
+msgid "Up"
+msgstr "Hore"
+
+#: ../src/common/accelcmn.cpp:61
+msgctxt "keyboard key"
+msgid "Down"
+msgstr "Dolu"
+
+#: ../src/common/accelcmn.cpp:62
+msgctxt "keyboard key"
+msgid "Home"
+msgstr "Domov"
+
+#: ../src/common/accelcmn.cpp:63
+msgctxt "keyboard key"
+msgid "End"
+msgstr "End"
+
+#: ../src/common/accelcmn.cpp:64
+msgctxt "keyboard key"
+msgid "Space"
+msgstr "Space"
+
+#: ../src/common/accelcmn.cpp:65
+msgctxt "keyboard key"
+msgid "Tab"
+msgstr "Tab"
+
+#: ../src/common/accelcmn.cpp:66
+msgctxt "keyboard key"
+msgid "Esc"
+msgstr "Esc"
+
+#: ../src/common/accelcmn.cpp:67
+msgctxt "keyboard key"
+msgid "Escape"
+msgstr "Escape"
+
+#: ../src/common/accelcmn.cpp:68
+msgctxt "keyboard key"
+msgid "Cancel"
+msgstr "Zrušiť"
+
+#: ../src/common/accelcmn.cpp:69
+msgctxt "keyboard key"
+msgid "Clear"
+msgstr "Zmazať"
+
+#: ../src/common/accelcmn.cpp:70
+msgctxt "keyboard key"
+msgid "Menu"
+msgstr "Ponuka"
+
+#: ../src/common/accelcmn.cpp:71
+msgctxt "keyboard key"
+msgid "Pause"
+msgstr "Pauza"
+
+#: ../src/common/accelcmn.cpp:72
+msgctxt "keyboard key"
+msgid "Capital"
+msgstr "Kapitálka"
+
+#: ../src/common/accelcmn.cpp:73
+msgctxt "keyboard key"
+msgid "Select"
+msgstr "Vybrať"
+
+#: ../src/common/accelcmn.cpp:74
+msgctxt "keyboard key"
+msgid "Print"
+msgstr "Tlačiť"
+
+#: ../src/common/accelcmn.cpp:75
+msgctxt "keyboard key"
+msgid "Execute"
+msgstr "Vykonať"
+
+#: ../src/common/accelcmn.cpp:76
+msgctxt "keyboard key"
+msgid "Snapshot"
+msgstr "Momentka"
+
+#: ../src/common/accelcmn.cpp:77
+msgctxt "keyboard key"
+msgid "Help"
+msgstr "Pomocník"
+
+#: ../src/common/accelcmn.cpp:78
+msgctxt "keyboard key"
+msgid "Add"
+msgstr "Pridať"
+
+#: ../src/common/accelcmn.cpp:79
+msgctxt "keyboard key"
+msgid "Separator"
+msgstr "Oddeľovač"
+
+#: ../src/common/accelcmn.cpp:80
+msgctxt "keyboard key"
+msgid "Subtract"
+msgstr "Odpočítať"
+
+#: ../src/common/accelcmn.cpp:81
+msgctxt "keyboard key"
+msgid "Decimal"
+msgstr "Desatinné"
+
+#: ../src/common/accelcmn.cpp:82
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Multiply"
+msgstr "KP_Multiply"
+
+#: ../src/common/accelcmn.cpp:83
+msgctxt "keyboard key"
+msgid "Divide"
+msgstr "Delenie"
+
+#: ../src/common/accelcmn.cpp:84
+msgctxt "keyboard key"
+msgid "Num_lock"
+msgstr "Num_lock"
+
+#: ../src/common/accelcmn.cpp:84
+msgctxt "keyboard key"
+msgid "Num Lock"
+msgstr "Num Lock"
+
+#: ../src/common/accelcmn.cpp:85
+msgctxt "keyboard key"
+msgid "Scroll_lock"
+msgstr "Scroll_lock"
+
+#: ../src/common/accelcmn.cpp:85
+msgctxt "keyboard key"
+msgid "Scroll Lock"
+msgstr "Scroll Lock"
+
+#: ../src/common/accelcmn.cpp:86
+msgctxt "keyboard key"
+msgid "KP_Space"
+msgstr "KP_Space"
+
+#: ../src/common/accelcmn.cpp:86
+msgctxt "keyboard key"
+msgid "Num Space"
+msgstr "Num Space"
+
+#: ../src/common/accelcmn.cpp:87
+msgctxt "keyboard key"
+msgid "KP_Tab"
+msgstr "KP_Tab"
+
+#: ../src/common/accelcmn.cpp:87
+msgctxt "keyboard key"
+msgid "Num Tab"
+msgstr "Num Tab"
+
+#: ../src/common/accelcmn.cpp:88
+msgctxt "keyboard key"
+msgid "KP_Enter"
+msgstr "KP_Enter"
+
+#: ../src/common/accelcmn.cpp:88
+msgctxt "keyboard key"
+msgid "Num Enter"
+msgstr "Num Enter"
+
+#: ../src/common/accelcmn.cpp:89
+msgctxt "keyboard key"
+msgid "KP_Home"
+msgstr "KP_Home"
+
+#: ../src/common/accelcmn.cpp:89
+msgctxt "keyboard key"
+msgid "Num Home"
+msgstr "Num Home"
+
+#: ../src/common/accelcmn.cpp:90
+msgctxt "keyboard key"
+msgid "KP_Left"
+msgstr "KP_Left"
+
+#: ../src/common/accelcmn.cpp:90
+msgctxt "keyboard key"
+msgid "Num left"
+msgstr "Num left"
+
+#: ../src/common/accelcmn.cpp:91
+msgctxt "keyboard key"
+msgid "KP_Up"
+msgstr "KP_Up"
+
+#: ../src/common/accelcmn.cpp:91
+msgctxt "keyboard key"
+msgid "Num Up"
+msgstr "Num Up"
+
+#: ../src/common/accelcmn.cpp:92
+msgctxt "keyboard key"
+msgid "KP_Right"
+msgstr "KP_Right"
+
+#: ../src/common/accelcmn.cpp:92
+msgctxt "keyboard key"
+msgid "Num Right"
+msgstr "Num Right"
+
+#: ../src/common/accelcmn.cpp:93
+msgctxt "keyboard key"
+msgid "KP_Down"
+msgstr "KP_Down"
+
+#: ../src/common/accelcmn.cpp:93
+msgctxt "keyboard key"
+msgid "Num Down"
+msgstr "Num Down"
+
+#: ../src/common/accelcmn.cpp:94
+msgctxt "keyboard key"
+msgid "KP_PageUp"
+msgstr "KP_PageUp"
+
+#: ../src/common/accelcmn.cpp:94
+msgctxt "keyboard key"
+msgid "Num Page Up"
+msgstr "Num Page Up"
+
+#: ../src/common/accelcmn.cpp:95
+msgctxt "keyboard key"
+msgid "KP_PageDown"
+msgstr "KP_PageDown"
+
+#: ../src/common/accelcmn.cpp:95
+msgctxt "keyboard key"
+msgid "Num Page Down"
+msgstr "Num Page Down"
+
+#: ../src/common/accelcmn.cpp:96
+msgctxt "keyboard key"
+msgid "KP_Prior"
+msgstr "KP_Prior"
+
+#: ../src/common/accelcmn.cpp:97
+msgctxt "keyboard key"
+msgid "KP_Next"
+msgstr "KP_Next"
+
+#: ../src/common/accelcmn.cpp:98
+msgctxt "keyboard key"
+msgid "KP_End"
+msgstr "KP_End"
+
+#: ../src/common/accelcmn.cpp:98
+msgctxt "keyboard key"
+msgid "Num End"
+msgstr "Num End"
+
+#: ../src/common/accelcmn.cpp:99
+msgctxt "keyboard key"
+msgid "KP_Begin"
+msgstr "KP_Begin"
+
+#: ../src/common/accelcmn.cpp:99
+msgctxt "keyboard key"
+msgid "Num Begin"
+msgstr "Num Begin"
+
+#: ../src/common/accelcmn.cpp:100
+msgctxt "keyboard key"
+msgid "KP_Insert"
+msgstr "KP_Insert"
+
+#: ../src/common/accelcmn.cpp:100
+msgctxt "keyboard key"
+msgid "Num Insert"
+msgstr "Num Insert"
+
+#: ../src/common/accelcmn.cpp:101
+msgctxt "keyboard key"
+msgid "KP_Delete"
+msgstr "KP_Delete"
+
+#: ../src/common/accelcmn.cpp:101
+msgctxt "keyboard key"
+msgid "Num Delete"
+msgstr "Num Delete"
+
+#: ../src/common/accelcmn.cpp:102
+msgctxt "keyboard key"
+msgid "KP_Equal"
+msgstr "KP_Equal"
+
+#: ../src/common/accelcmn.cpp:102
+msgctxt "keyboard key"
+msgid "Num ="
+msgstr "Num ="
+
+#: ../src/common/accelcmn.cpp:103
+msgctxt "keyboard key"
+msgid "KP_Multiply"
+msgstr "KP_Multiply"
+
+#: ../src/common/accelcmn.cpp:103
+msgctxt "keyboard key"
+msgid "Num *"
+msgstr "Num *"
+
+#: ../src/common/accelcmn.cpp:104
+msgctxt "keyboard key"
+msgid "KP_Add"
+msgstr "KP_Add"
+
+#: ../src/common/accelcmn.cpp:104
+msgctxt "keyboard key"
+msgid "Num +"
+msgstr "Num +"
+
+#: ../src/common/accelcmn.cpp:105
+msgctxt "keyboard key"
+msgid "KP_Separator"
+msgstr "KP_Separator"
+
+#: ../src/common/accelcmn.cpp:105
+msgctxt "keyboard key"
+msgid "Num ,"
+msgstr "Num ,"
+
+#: ../src/common/accelcmn.cpp:106
+msgctxt "keyboard key"
+msgid "KP_Subtract"
+msgstr "KP_Subtract"
+
+#: ../src/common/accelcmn.cpp:106
+msgctxt "keyboard key"
+msgid "Num -"
+msgstr "Num -"
+
+#: ../src/common/accelcmn.cpp:107
+msgctxt "keyboard key"
+msgid "KP_Decimal"
+msgstr "KP_Decimal"
+
+#: ../src/common/accelcmn.cpp:107
+msgctxt "keyboard key"
+msgid "Num ."
+msgstr "Num ."
+
+#: ../src/common/accelcmn.cpp:108
+msgctxt "keyboard key"
+msgid "KP_Divide"
+msgstr "KP_Divide"
+
+#: ../src/common/accelcmn.cpp:108
+msgctxt "keyboard key"
+msgid "Num /"
+msgstr "Num /"
+
+#: ../src/common/accelcmn.cpp:109
+msgctxt "keyboard key"
+msgid "Windows_Left"
+msgstr "Windows_vľavo"
+
+#: ../src/common/accelcmn.cpp:110
+msgctxt "keyboard key"
+msgid "Windows_Right"
+msgstr "Windows_vpravo"
+
+#: ../src/common/accelcmn.cpp:111
+msgctxt "keyboard key"
+msgid "Windows_Menu"
+msgstr "Windows_ponuka"
+
+#: ../src/common/accelcmn.cpp:112
+msgctxt "keyboard key"
+msgid "Command"
+msgstr "Prikaz"
+
+#: ../src/common/accelcmn.cpp:186 ../src/common/accelcmn.cpp:359
+msgctxt "keyboard key"
+msgid "Ctrl"
+msgstr "Ctrl"
+
+#: ../src/common/accelcmn.cpp:188 ../src/common/accelcmn.cpp:363
+msgctxt "keyboard key"
+msgid "Alt"
+msgstr "Alt"
+
+#: ../src/common/accelcmn.cpp:190 ../src/common/accelcmn.cpp:361
+msgctxt "keyboard key"
+msgid "Shift"
+msgstr "Shift"
+
+#: ../src/common/accelcmn.cpp:196
+msgctxt "keyboard key"
+msgid "num "
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:260 ../src/common/accelcmn.cpp:382
+msgctxt "keyboard key"
+msgid "F"
+msgstr "F"
+
+#: ../src/common/accelcmn.cpp:277 ../src/common/accelcmn.cpp:385
+msgctxt "keyboard key"
+msgid "KP_F"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:280 ../src/common/accelcmn.cpp:388
+msgctxt "keyboard key"
+msgid "KP_"
+msgstr "KP_"
+
+#: ../src/common/accelcmn.cpp:283 ../src/common/accelcmn.cpp:391
+msgctxt "keyboard key"
+msgid "SPECIAL"
+msgstr "ŠPECIÁLNE"
+
+#: ../src/common/accelcmn.cpp:373
+#, fuzzy
+msgid "Ctrl"
+msgstr "Ctrl"
+
+#: ../src/common/appbase.cpp:786
+msgid "show this help message"
+msgstr "zobrazovať túto správu Pomocníka"
+
+#: ../src/common/appbase.cpp:796
+msgid "generate verbose log messages"
+msgstr "tvoriť výrečné správy záznamu"
+
+#: ../src/common/appcmn.cpp:256
+msgid "specify the theme to use"
+msgstr "uveďte tému, ktorá sa má použiť"
+
+#: ../src/common/appcmn.cpp:270
+msgid "specify display mode to use (e.g. 640x480-16)"
+msgstr "uveďte zobrazovací režim, ktorý sa má použiť (napr. 640x480-16)"
+
+#: ../src/common/appcmn.cpp:292
+#, c-format
+msgid "Unsupported theme '%s'."
+msgstr "Nepodporovaná téma '%s'."
+
+#: ../src/common/appcmn.cpp:309
+#, c-format
+msgid "Invalid display mode specification '%s'."
+msgstr "Neplatná špecifikácia režimu zobrazenia '%s'."
+
+#: ../src/common/cmdline.cpp:875
+#, c-format
+msgid "Option '%s' can't be negated"
+msgstr "Možnosť '%s' nemôže byť negovaná"
+
+#: ../src/common/cmdline.cpp:889
+#, c-format
+msgid "Unknown long option '%s'"
+msgstr "Neznámy dlhý parameter '%s'"
+
+#: ../src/common/cmdline.cpp:904 ../src/common/cmdline.cpp:926
+#, c-format
+msgid "Unknown option '%s'"
+msgstr "Neznámy parameter '%s'"
+
+#: ../src/common/cmdline.cpp:1004
+#, c-format
+msgid "Unexpected characters following option '%s'."
+msgstr "Neočakávané znaky po voľbe '%s'."
+
+#: ../src/common/cmdline.cpp:1039
+#, c-format
+msgid "Option '%s' requires a value."
+msgstr "Možnosť '%s' vyžaduje hodnotu."
+
+#: ../src/common/cmdline.cpp:1058
+#, c-format
+msgid "Separator expected after the option '%s'."
+msgstr "Za voľbou '%s' sa očakáva oddeľovač."
+
+#: ../src/common/cmdline.cpp:1088 ../src/common/cmdline.cpp:1106
+#, c-format
+msgid "'%s' is not a correct numeric value for option '%s'."
+msgstr "'%s' nie je správna číselná hodnota voľby '%s'."
+
+#: ../src/common/cmdline.cpp:1122
+#, c-format
+msgid "Option '%s': '%s' cannot be converted to a date."
+msgstr "Možnosť '%s': '%s' nemožno konvertovať na dátum."
+
+#: ../src/common/cmdline.cpp:1170
+#, c-format
+msgid "Unexpected parameter '%s'"
+msgstr "Očakávaný parameter '%s'"
+
+#. TRANSLATORS: Short name and long name for a command line option
+#: ../src/common/cmdline.cpp:1197
+#, c-format
+msgid "%s (or %s)"
+msgstr "%s (alebo %s)"
+
+#: ../src/common/cmdline.cpp:1208
+#, c-format
+msgid "The value for the option '%s' must be specified."
+msgstr "Je potrebné zadať hodnotu voľby '%s'."
+
+#: ../src/common/cmdline.cpp:1230
+#, c-format
+msgid "The required parameter '%s' was not specified."
+msgstr "Požadovaný parameter '%s' nebol zadaný."
+
+#: ../src/common/cmdline.cpp:1289
+#, c-format
+msgid "Usage: %s"
+msgstr "Použitie: %s"
+
+#: ../src/common/cmdline.cpp:1498
+msgid "str"
+msgstr "str"
+
+#: ../src/common/cmdline.cpp:1502
+msgid "num"
+msgstr "počet"
+
+#: ../src/common/cmdline.cpp:1506
+msgid "double"
+msgstr "dvojité"
+
+#: ../src/common/cmdline.cpp:1510
+msgid "date"
+msgstr "dátum"
+
+#: ../src/common/cmdproc.cpp:250 ../src/common/cmdproc.cpp:276
+#: ../src/common/cmdproc.cpp:296
+msgid "Unnamed command"
+msgstr "Nepomenovaný príkaz"
+
+#: ../src/common/cmdproc.cpp:253
+msgid "&Undo "
+msgstr "&Späť "
+
+#: ../src/common/cmdproc.cpp:255
+msgid "Can't &Undo "
+msgstr "Nemožno &Späť "
+
+#: ../src/common/cmdproc.cpp:259 ../src/common/stockitem.cpp:208
+#: ../src/msw/textctrl.cpp:2880 ../src/osx/textctrl_osx.cpp:649
+#: ../src/richtext/richtextctrl.cpp:327
+msgid "&Undo"
+msgstr "&Späť"
+
+#: ../src/common/cmdproc.cpp:277 ../src/common/cmdproc.cpp:297
+msgid "&Redo "
+msgstr "&Vpred "
+
+#: ../src/common/cmdproc.cpp:281 ../src/common/cmdproc.cpp:288
+#: ../src/common/stockitem.cpp:190 ../src/msw/textctrl.cpp:2881
+#: ../src/osx/textctrl_osx.cpp:650 ../src/richtext/richtextctrl.cpp:328
+msgid "&Redo"
+msgstr "&Vpred"
+
+#: ../src/common/colourcmn.cpp:41
+#, c-format
+msgid "String To Colour : Incorrect colour specification : %s"
+msgstr "Reťazec na farbu : Nesprávna špecifikácia farby: %s"
+
+#: ../src/common/config.cpp:259
+#, c-format
+msgid "Invalid value %ld for a boolean key \"%s\" in config file."
+msgstr "Neplatná hodnota %ld pre booleovský kľúč '%s' v konfiguračnom súbore."
+
+#: ../src/common/config.cpp:526
+#, c-format
+msgid ""
+"Environment variables expansion failed: missing '%c' at position %u in '%s'."
+msgstr ""
+"Expanzia premenných prostredia zlyhala: chýba '%c' na pozícii %u v '%s'."
+
+#: ../src/common/config.cpp:576 ../src/msw/regconf.cpp:272
+#, c-format
+msgid "'%s' has extra '..', ignored."
+msgstr "'%s' obsahuje prebytočné '..', ignorované."
+
+#. TRANSLATORS: Checkbox state name
+#: ../src/common/datavcmn.cpp:2166 ../src/generic/datavgen.cpp:1430
+msgid "checked"
+msgstr "skontrolované"
+
+#. TRANSLATORS: Checkbox state name
+#: ../src/common/datavcmn.cpp:2170 ../src/generic/datavgen.cpp:1432
+msgid "unchecked"
+msgstr "nezaškrtnuté"
+
+#. TRANSLATORS: Checkbox state name
+#: ../src/common/datavcmn.cpp:2174
+msgid "undetermined"
+msgstr "neurčené"
+
+#: ../src/common/datetimefmt.cpp:1875
+msgid "today"
+msgstr "dnes"
+
+#: ../src/common/datetimefmt.cpp:1876
+msgid "yesterday"
+msgstr "včera"
+
+#: ../src/common/datetimefmt.cpp:1877
+msgid "tomorrow"
+msgstr "zajtra"
+
+#: ../src/common/datetimefmt.cpp:2071
+msgid "first"
+msgstr "prvý"
+
+#: ../src/common/datetimefmt.cpp:2072
+msgid "second"
+msgstr "sekunda"
+
+#: ../src/common/datetimefmt.cpp:2073
+msgid "third"
+msgstr "tretieho"
+
+#: ../src/common/datetimefmt.cpp:2074
+msgid "fourth"
+msgstr "štvrtého"
+
+#: ../src/common/datetimefmt.cpp:2075
+msgid "fifth"
+msgstr "piateho"
+
+#: ../src/common/datetimefmt.cpp:2076
+msgid "sixth"
+msgstr "šiesteho"
+
+#: ../src/common/datetimefmt.cpp:2077
+msgid "seventh"
+msgstr "siedmeho"
+
+#: ../src/common/datetimefmt.cpp:2078
+msgid "eighth"
+msgstr "ôsmeho"
+
+#: ../src/common/datetimefmt.cpp:2079
+msgid "ninth"
+msgstr "deviateho"
+
+#: ../src/common/datetimefmt.cpp:2080
+msgid "tenth"
+msgstr "desiateho"
+
+#: ../src/common/datetimefmt.cpp:2081
+msgid "eleventh"
+msgstr "deviateho"
+
+#: ../src/common/datetimefmt.cpp:2082
+msgid "twelfth"
+msgstr "dvanásteho"
+
+#: ../src/common/datetimefmt.cpp:2083
+msgid "thirteenth"
+msgstr "trinásteho"
+
+#: ../src/common/datetimefmt.cpp:2084
+msgid "fourteenth"
+msgstr "štrnásteho"
+
+#: ../src/common/datetimefmt.cpp:2085
+msgid "fifteenth"
+msgstr "pätnásteho"
+
+#: ../src/common/datetimefmt.cpp:2086
+msgid "sixteenth"
+msgstr "šestnásteho"
+
+#: ../src/common/datetimefmt.cpp:2087
+msgid "seventeenth"
+msgstr "sedemnásteho"
+
+#: ../src/common/datetimefmt.cpp:2088
+msgid "eighteenth"
+msgstr "osemnásteho"
+
+#: ../src/common/datetimefmt.cpp:2089
+msgid "nineteenth"
+msgstr "devätnásteho"
+
+#: ../src/common/datetimefmt.cpp:2090
+msgid "twentieth"
+msgstr "dvadsiateho"
+
+#: ../src/common/datetimefmt.cpp:2248
+msgid "noon"
+msgstr "poludnie"
+
+#: ../src/common/datetimefmt.cpp:2249
+msgid "midnight"
+msgstr "polnoc"
+
+#: ../src/common/debugrpt.cpp:209
+#, c-format
+msgid "Failed to create directory \"%s\""
+msgstr "Zlyhalo vytvorenie priečinku '%s'"
+
+#: ../src/common/debugrpt.cpp:210
+msgid "Debug report couldn't be created."
+msgstr "Nemožno vytvoriť hlásenie o chybe."
+
+#: ../src/common/debugrpt.cpp:227
+#, c-format
+msgid "Failed to remove debug report file \"%s\""
+msgstr "Zlyhalo odstránenie súboru hlásenia o chybe '%s'"
+
+#: ../src/common/debugrpt.cpp:239
+#, c-format
+msgid "Failed to clean up debug report directory \"%s\""
+msgstr "Zlyhalo vyčistenie priečinka pre hlásenia o chybe '%s'"
+
+#: ../src/common/debugrpt.cpp:514
+msgid "process context description"
+msgstr "opis kontextu procesu"
+
+#: ../src/common/debugrpt.cpp:538
+msgid "dump of the process state (binary)"
+msgstr "výpis stavu procesu (binárny)"
+
+#: ../src/common/debugrpt.cpp:553
+msgid "Debug report generation has failed."
+msgstr "Zlyhalo vytvorenie hlásenia o chybe."
+
+#: ../src/common/debugrpt.cpp:560
+#, c-format
+msgid ""
+"Processing debug report has failed, leaving the files in \"%s\" directory."
+msgstr "Spracovanie správy o chybe zlyhalo, nechávam súbory v priečinku '%s'."
+
+#: ../src/common/debugrpt.cpp:573
+msgid "A debug report has been generated. It can be found in"
+msgstr "Bola vygenerovaná správa o ladení. Nachádza sa v"
+
+#: ../src/common/debugrpt.cpp:576
+msgid "And includes the following files:\n"
+msgstr "Zahrnuté nasledujúce súbory:\n"
+
+#: ../src/common/debugrpt.cpp:586
+msgid ""
+"\n"
+"Please send this report to the program maintainer, thank you!\n"
+msgstr ""
+"\n"
+"Pošlite, prosím, toto hlásenie správcovi balíka, ďakujeme!\n"
+
+#: ../src/common/debugrpt.cpp:729
+msgid "Failed to execute curl, please install it in PATH."
+msgstr "Zlyhalo zvlnenie, nainštalujte ho, prosím, do premennej PATH."
+
+#: ../src/common/debugrpt.cpp:742
+#, c-format
+msgid "Failed to upload the debug report (error code %d)."
+msgstr "Zlyhalo vynovenie hlásenia o chybe (chybový kód %d)."
+
+#: ../src/common/docview.cpp:366
+msgid "Save As"
+msgstr "Uložiť ako"
+
+#: ../src/common/docview.cpp:457
+msgid "Discard changes and reload the last saved version?"
+msgstr "Zahodiť zmeny a znovu načítať poslednú uloženú verziu?"
+
+#: ../src/common/docview.cpp:488
+msgid "unnamed"
+msgstr "nepomenované"
+
+#: ../src/common/docview.cpp:513
+#, c-format
+msgid "Do you want to save changes to %s?"
+msgstr "Chcete uložiť zmeny do %s?"
+
+#: ../src/common/docview.cpp:521 ../src/common/docview.cpp:560
+#: ../src/common/stockitem.cpp:195
+msgid "&Save"
+msgstr "&Uložiť"
+
+#: ../src/common/docview.cpp:522 ../src/common/docview.cpp:560
+msgid "&Discard changes"
+msgstr ""
+
+#: ../src/common/docview.cpp:523
+#, fuzzy
+msgid "Do&n't close"
+msgstr "Neukladať"
+
+#: ../src/common/docview.cpp:553
+#, fuzzy, c-format
+msgid "Do you want to save changes to %s before closing it?"
+msgstr "Chcete uložiť zmeny do %s?"
+
+#: ../src/common/docview.cpp:559
+#, fuzzy
+msgid "The document must be closed."
+msgstr "Nemožno uložiť text."
+
+#: ../src/common/docview.cpp:571
+#, c-format
+msgid "Saving %s failed, would you like to retry?"
+msgstr ""
+
+#: ../src/common/docview.cpp:577
+msgid "Retry"
+msgstr ""
+
+#: ../src/common/docview.cpp:577
+msgid "Discard changes"
+msgstr ""
+
+#: ../src/common/docview.cpp:679
+#, c-format
+msgid "File \"%s\" could not be opened for writing."
+msgstr "Zlyhalo otvorenie súboru '%s' na zápis."
+
+#: ../src/common/docview.cpp:685
+#, c-format
+msgid "Failed to save document to the file \"%s\"."
+msgstr "Zlyhalo uloženie dokumentu do súboru '%s'."
+
+#: ../src/common/docview.cpp:702
+#, c-format
+msgid "File \"%s\" could not be opened for reading."
+msgstr "Zlyhalo otvorenie súboru '%s' na čítanie."
+
+#: ../src/common/docview.cpp:714
+#, c-format
+msgid "Failed to read document from the file \"%s\"."
+msgstr "Zlyhalo načítanie dokument zo súboru '%s'."
+
+#: ../src/common/docview.cpp:1236
+#, c-format
+msgid ""
+"The file '%s' doesn't exist and couldn't be opened.\n"
+"It has been removed from the most recently used files list."
+msgstr ""
+"Súbor '%s' neexistuje a nebolo možné ho otvoriť.\n"
+"Bol odstránený zo zoznamu naposledy použitých súborov."
+
+#: ../src/common/docview.cpp:1296
+msgid "Print preview creation failed."
+msgstr "Vytvorenie ukážky tlače zlyhalo."
+
+#: ../src/common/docview.cpp:1302
+msgid "Print Preview"
+msgstr "Náhľad pred tlačou"
+
+#: ../src/common/docview.cpp:1517
+#, c-format
+msgid "The format of file '%s' couldn't be determined."
+msgstr "Formát súboru '%s' sa nepodarilo určiť."
+
+#: ../src/common/docview.cpp:1643
+#, c-format
+msgid "unnamed%d"
+msgstr "nemenované%d"
+
+#: ../src/common/docview.cpp:1660
+msgid " - "
+msgstr " - "
+
+#: ../src/common/docview.cpp:1791 ../src/common/docview.cpp:1844
+msgid "Open File"
+msgstr "Otvoriť súbor"
+
+#: ../src/common/docview.cpp:1807
+msgid "File error"
+msgstr "Chyba súboru"
+
+#: ../src/common/docview.cpp:1809
+msgid "Sorry, could not open this file."
+msgstr "Prepáčte, nebolo možné otvoriť tento súbor."
+
+#: ../src/common/docview.cpp:1843
+msgid "Sorry, the format for this file is unknown."
+msgstr "Prepáčte, formát tohto súboru je neznámy."
+
+#: ../src/common/docview.cpp:1924
+msgid "Select a document template"
+msgstr "Vybrať šablónu dokumentu"
+
+#: ../src/common/docview.cpp:1925
+msgid "Templates"
+msgstr "Šablóny"
+
+#: ../src/common/docview.cpp:1998
+msgid "Select a document view"
+msgstr "Vybrať náhľad dokumentu"
+
+#: ../src/common/docview.cpp:1999
+msgid "Views"
+msgstr "Náhľady"
+
+#: ../src/common/dynlib.cpp:81
+#, c-format
+msgid "Failed to load shared library '%s'"
+msgstr "Zlyhalo načítanie zdieľanej knižnice '%s'"
+
+#: ../src/common/dynlib.cpp:105
+#, c-format
+msgid "Couldn't find symbol '%s' in a dynamic library"
+msgstr "Nemožno nájsť symbol '%s' v dynamickej knižnici"
+
+#: ../src/common/ffile.cpp:56 ../src/common/file.cpp:215
+#, c-format
+msgid "can't open file '%s'"
+msgstr "nemožno otvoriť súbor '%s'"
+
+#: ../src/common/ffile.cpp:72
+#, c-format
+msgid "can't close file '%s'"
+msgstr "nemožno zavrieť súbor '%s'"
+
+#: ../src/common/ffile.cpp:106 ../src/common/ffile.cpp:131
+#, c-format
+msgid "Read error on file '%s'"
+msgstr "Chyba pri čítaní súboru '%s'"
+
+#: ../src/common/ffile.cpp:148
+#, c-format
+msgid "Write error on file '%s'"
+msgstr "Chyba zápisu do súboru '%s'"
+
+#: ../src/common/ffile.cpp:182
+#, c-format
+msgid "failed to flush the file '%s'"
+msgstr "nepodarilo sa vyprázdniť súbor '%s'"
+
+#: ../src/common/ffile.cpp:222
+#, c-format
+msgid "Seek error on file '%s' (large files not supported by stdio)"
+msgstr ""
+"Chyba presunu na pozíciu v súbore '%s' (stdio nepodporuje veľké súbory)"
+
+#: ../src/common/ffile.cpp:232
+#, c-format
+msgid "Seek error on file '%s'"
+msgstr "Chyba presunu na pozíciu v súbore '%s'"
+
+#: ../src/common/ffile.cpp:248
+#, c-format
+msgid "Can't find current position in file '%s'"
+msgstr "Nemožno zistiť súčasnú pozíciu v súbore '%s'"
+
+#: ../src/common/ffile.cpp:349 ../src/common/file.cpp:569
+msgid "Failed to set temporary file permissions"
+msgstr "Zlyhalo nastavenie oprávnenia dočasného súboru"
+
+#: ../src/common/ffile.cpp:371
+#, c-format
+msgid "can't remove file '%s'"
+msgstr "nemožno odstrániť súbor '%s'"
+
+#: ../src/common/ffile.cpp:376 ../src/common/file.cpp:591
+#, c-format
+msgid "can't commit changes to file '%s'"
+msgstr "nemožno vykonať zmeny v súbore '%s'"
+
+#: ../src/common/ffile.cpp:388 ../src/common/file.cpp:603
+#, c-format
+msgid "can't remove temporary file '%s'"
+msgstr "nemožno odstrániť dočasný súbor '%s'"
+
+#: ../src/common/file.cpp:162
+#, c-format
+msgid "can't create file '%s'"
+msgstr "nemožno vytvoriť súbor '%s'"
+
+#: ../src/common/file.cpp:229
+#, c-format
+msgid "can't close file descriptor %d"
+msgstr "nemožno zavrieť popisovač súboru %d"
+
+#: ../src/common/file.cpp:332
+#, c-format
+msgid "can't read from file descriptor %d"
+msgstr "nemôže čítať z popisovača súborov %d"
+
+#: ../src/common/file.cpp:351
+#, c-format
+msgid "can't write to file descriptor %d"
+msgstr "nemožno zapisovať do popisovača súboru %d"
+
+#: ../src/common/file.cpp:390
+#, c-format
+msgid "can't flush file descriptor %d"
+msgstr "nemožno vyprázdniť popisovač súboru %d"
+
+#: ../src/common/file.cpp:432
+#, c-format
+msgid "can't seek on file descriptor %d"
+msgstr "nemožno hľadať v popisovači súboru %d"
+
+#: ../src/common/file.cpp:446
+#, c-format
+msgid "can't get seek position on file descriptor %d"
+msgstr "nemožno nájsť pozíciu v popisovači súboru %d"
+
+#: ../src/common/file.cpp:475
+#, c-format
+msgid "can't find length of file on file descriptor %d"
+msgstr "nemožno nájsť dĺžku súboru v popisovači súboru %d"
+
+#: ../src/common/file.cpp:505
+#, c-format
+msgid "can't determine if the end of file is reached on descriptor %d"
+msgstr "nemožno určiť, či sa v popisovači %d dosiahol koniec súboru"
+
+#: ../src/common/fileconf.cpp:352
+#, c-format
+msgid ""
+" and additionally, the existing configuration file was renamed to \"%s\" and "
+"couldn't be renamed back, please rename it to its original path \"%s\""
+msgstr ""
+
+#: ../src/common/fileconf.cpp:389
+#, fuzzy
+msgid " due to the following error:\n"
+msgstr "Zahrnuté nasledujúce súbory:\n"
+
+#: ../src/common/fileconf.cpp:412
+#, fuzzy
+msgid "failed to rename the existing file"
+msgstr "Zlyhalo načítanie dokument zo súboru '%s'."
+
+#: ../src/common/fileconf.cpp:421
+#, fuzzy
+msgid "failed to create the new file directory"
+msgstr "Zlyhalo zistenie pracovného priečinku"
+
+#: ../src/common/fileconf.cpp:428
+#, fuzzy
+msgid "failed to move the file to the new location"
+msgstr "Zlyhalo ukončenie vytáčaného spojenia: %s"
+
+#: ../src/common/fileconf.cpp:462
+#, c-format
+msgid "can't open global configuration file '%s'."
+msgstr "nemožno otvoriť globálny konfiguračný súbor '%s'."
+
+#: ../src/common/fileconf.cpp:478
+#, c-format
+msgid "can't open user configuration file '%s'."
+msgstr "nemožno otvoriť konfiguračný súbor používateľa '%s'."
+
+#: ../src/common/fileconf.cpp:483
+#, c-format
+msgid "Changes won't be saved to avoid overwriting the existing file \"%s\""
+msgstr "Zmeny nebudú uložené, aby sa zabránilo prepísaniu súboru '%s'"
+
+#: ../src/common/fileconf.cpp:583
+msgid "Error reading config options."
+msgstr "Chyba pri čítaní konfiguračných volieb."
+
+#: ../src/common/fileconf.cpp:593
+msgid "Failed to read config options."
+msgstr "Zlyhalo načítanie možností konfigurácie."
+
+#: ../src/common/fileconf.cpp:700
+#, c-format
+msgid "file '%s': unexpected character %c at line %zu."
+msgstr "súbor „%s“: neočakávaný znak %c v riadku %zu."
+
+#: ../src/common/fileconf.cpp:736
+#, c-format
+msgid "file '%s', line %zu: '%s' ignored after group header."
+msgstr "súbor '%s', riadok %zu: '%s' ignorovaný za hlavičkou skupiny."
+
+#: ../src/common/fileconf.cpp:765
+#, c-format
+msgid "file '%s', line %zu: '=' expected."
+msgstr "súbor '%s', riadok %zu: '=' sa očakáva."
+
+#: ../src/common/fileconf.cpp:778
+#, c-format
+msgid "file '%s', line %zu: value for immutable key '%s' ignored."
+msgstr "súbor '%s', riadok %zu: hodnota pre nemenný kľúč '%s' je ignorovaná."
+
+#: ../src/common/fileconf.cpp:788
+#, c-format
+msgid "file '%s', line %zu: key '%s' was first found at line %d."
+msgstr "súbor '%s', riadok %zu: kľúč '%s' bol prvýkrát nájdený na riadku %d."
+
+#: ../src/common/fileconf.cpp:1091
+#, c-format
+msgid "Config entry name cannot start with '%c'."
+msgstr "Záznam konfigurácie nemôže začínať '%c'."
+
+#: ../src/common/fileconf.cpp:1146
+#, fuzzy
+msgid "Failed to create configuration file directory."
+msgstr "Zlyhala aktualizácia používateľského konfiguračného súboru."
+
+#: ../src/common/fileconf.cpp:1158
+msgid "can't open user configuration file."
+msgstr "nemožno otvoriť konfiguračný súbor používateľa."
+
+#: ../src/common/fileconf.cpp:1172
+msgid "can't write user configuration file."
+msgstr "nemožno zapísať konfiguračný súbor používateľa."
+
+#: ../src/common/fileconf.cpp:1178
+msgid "Failed to update user configuration file."
+msgstr "Zlyhala aktualizácia používateľského konfiguračného súboru."
+
+#: ../src/common/fileconf.cpp:1201
+msgid "Error saving user configuration data."
+msgstr "Chyba pri ukladaní používateľských konfiguračných údajov."
+
+#: ../src/common/fileconf.cpp:1313
+#, c-format
+msgid "can't delete user configuration file '%s'"
+msgstr "nemožno odstrániť konfiguračný súbor používateľa '%s'"
+
+#: ../src/common/fileconf.cpp:2007
+#, c-format
+msgid "entry '%s' appears more than once in group '%s'"
+msgstr "položka '%s' sa v skupine '%s' vyskytuje viackrát"
+
+#: ../src/common/fileconf.cpp:2021
+#, c-format
+msgid "attempt to change immutable key '%s' ignored."
+msgstr "pokus o zmenu nemenného kľúča '%s' bol ignorovaný."
+
+#: ../src/common/fileconf.cpp:2118
+#, c-format
+msgid "trailing backslash ignored in '%s'"
+msgstr "koncová spätná lomka ignorovaná v ' %s'"
+
+#: ../src/common/fileconf.cpp:2153
+#, c-format
+msgid "unexpected \" at position %d in '%s'."
+msgstr "\"neočakávané\" na pozícii %d v '%s'."
+
+#: ../src/common/filefn.cpp:474
+#, c-format
+msgid "Failed to copy the file '%s' to '%s'"
+msgstr "Zlyhalo skopírovanie súboru '%s' do '%s'"
+
+#: ../src/common/filefn.cpp:487
+#, c-format
+msgid "Impossible to get permissions for file '%s'"
+msgstr "Nemožno získať povolenia pre súbor '%s'"
+
+#: ../src/common/filefn.cpp:501
+#, c-format
+msgid "Impossible to overwrite the file '%s'"
+msgstr "Nemožno prepísať súbor '%s'"
+
+#: ../src/common/filefn.cpp:508
+#, c-format
+msgid "Error copying the file '%s' to '%s'."
+msgstr "Chyba pri kopírovaní súboru '%s' do '%s'."
+
+#: ../src/common/filefn.cpp:556
+#, c-format
+msgid "Impossible to set permissions for the file '%s'"
+msgstr "Nemožno nastaviť povolenia pre súbor '%s'"
+
+#: ../src/common/filefn.cpp:606
+#, c-format
+msgid ""
+"Failed to rename the file '%s' to '%s' because the destination file already "
+"exists."
+msgstr ""
+"Zlyhalo premenovanie súboru '%s' na '%s', pretože cieľový názov súboru už "
+"existuje."
+
+#: ../src/common/filefn.cpp:623
+#, c-format
+msgid "File '%s' couldn't be renamed '%s'"
+msgstr "Súbor '%s' nemožno premenovať na '%s'"
+
+#: ../src/common/filefn.cpp:639
+#, c-format
+msgid "File '%s' couldn't be removed"
+msgstr "Súbor '%s' sa nepodarilo odstrániť"
+
+#: ../src/common/filefn.cpp:666
+#, c-format
+msgid "Directory '%s' couldn't be created"
+msgstr "Nemožno vytvoriť priečinok '%s'"
+
+#: ../src/common/filefn.cpp:680
+#, c-format
+msgid "Directory '%s' couldn't be deleted"
+msgstr "Nemožno odstrániť priečinok '%s'"
+
+#: ../src/common/filefn.cpp:714
+#, c-format
+msgid "Cannot enumerate files '%s'"
+msgstr "Nemožno vymenovať súbory '%s'"
+
+#: ../src/common/filefn.cpp:798
+msgid "Failed to get the working directory"
+msgstr "Zlyhalo zistenie pracovného priečinku"
+
+#: ../src/common/filefn.cpp:843
+msgid "Could not set current working directory"
+msgstr "Nemožno nastaviť súčasný pracovný priečinok"
+
+#: ../src/common/filefn.cpp:974
+#, c-format
+msgid "Files (%s)"
+msgstr "Súborov (%s)"
+
+#: ../src/common/filename.cpp:182
+#, c-format
+msgid "Failed to open '%s' for reading"
+msgstr "Zlyhalo otvorenie '%s' na čítanie"
+
+#: ../src/common/filename.cpp:187
+#, c-format
+msgid "Failed to open '%s' for writing"
+msgstr "Zlyhalo otvorenie '%s' na zápis"
+
+#: ../src/common/filename.cpp:199
+msgid "Failed to close file handle"
+msgstr "Zlyhalo zatvorenie súboru"
+
+#: ../src/common/filename.cpp:1046
+msgid "Failed to create a temporary file name"
+msgstr "Zlyhalo vytvorenie dočasného mena súboru"
+
+#: ../src/common/filename.cpp:1081
+msgid "Failed to open temporary file."
+msgstr "Zlyhalo otvorenie dočasného súboru."
+
+#: ../src/common/filename.cpp:2862
+#, c-format
+msgid "Failed to modify file times for '%s'"
+msgstr "Zlyhala zmena času súboru '%s'"
+
+#: ../src/common/filename.cpp:2877
+#, c-format
+msgid "Failed to touch the file '%s'"
+msgstr "Zlyhal styk so súborom '%s'"
+
+#: ../src/common/filename.cpp:2958
+#, c-format
+msgid "Failed to retrieve file times for '%s'"
+msgstr "Zlyhalo získanie čas súboru '%s'"
+
+#: ../src/common/filepickercmn.cpp:39 ../src/common/filepickercmn.cpp:40
+msgid "Browse"
+msgstr "Prehľadávať"
+
+#: ../src/common/fldlgcmn.cpp:792 ../src/generic/filectrlg.cpp:1185
+#, c-format
+msgid "All files (%s)|%s"
+msgstr "Všetky súbory (%s)|%s"
+
+#. TRANSLATORS: %s are a file extension used to build a file wildcard string
+#: ../src/common/fldlgcmn.cpp:810
+#, c-format
+msgid "%s files (%s)|%s"
+msgstr "%s súborov (%s)|%s"
+
+#: ../src/common/fldlgcmn.cpp:1072
+#, c-format
+msgid "Load %s file"
+msgstr "Načítať súbor %s"
+
+#: ../src/common/fldlgcmn.cpp:1074
+#, c-format
+msgid "Save %s file"
+msgstr "Uložiť súbor %s"
+
+#: ../src/common/fmapbase.cpp:144
+msgid "Western European (ISO-8859-1)"
+msgstr "Západoeurópske (ISO-8859-1)"
+
+#: ../src/common/fmapbase.cpp:145
+msgid "Central European (ISO-8859-2)"
+msgstr "Stredoeurópske (ISO-8859-2)"
+
+#: ../src/common/fmapbase.cpp:146
+msgid "Esperanto (ISO-8859-3)"
+msgstr "Esperanto (ISO-8859-3)"
+
+#: ../src/common/fmapbase.cpp:147
+msgid "Baltic (old) (ISO-8859-4)"
+msgstr "Baltské (staré) (ISO-8859-4)"
+
+#: ../src/common/fmapbase.cpp:148
+msgid "Cyrillic (ISO-8859-5)"
+msgstr "Cyrilika (ISO-8859-5)"
+
+#: ../src/common/fmapbase.cpp:149
+msgid "Arabic (ISO-8859-6)"
+msgstr "Arabské (ISO-8859-6)"
+
+#: ../src/common/fmapbase.cpp:150
+msgid "Greek (ISO-8859-7)"
+msgstr "Grécke (ISO-8859-7)"
+
+#: ../src/common/fmapbase.cpp:151
+msgid "Hebrew (ISO-8859-8)"
+msgstr "Hebrejské (ISO-8859-8)"
+
+#: ../src/common/fmapbase.cpp:152
+msgid "Turkish (ISO-8859-9)"
+msgstr "Turecké (ISO-8859-9)"
+
+#: ../src/common/fmapbase.cpp:153
+msgid "Nordic (ISO-8859-10)"
+msgstr "Severské (ISO-8859-10)"
+
+#: ../src/common/fmapbase.cpp:154
+msgid "Thai (ISO-8859-11)"
+msgstr "Thajské (ISO-8859-11)"
+
+#: ../src/common/fmapbase.cpp:155
+msgid "Indian (ISO-8859-12)"
+msgstr "Indické (ISO-8859-12)"
+
+#: ../src/common/fmapbase.cpp:156
+msgid "Baltic (ISO-8859-13)"
+msgstr "Baltské (ISO-8859-13)"
+
+#: ../src/common/fmapbase.cpp:157
+msgid "Celtic (ISO-8859-14)"
+msgstr "Keltské (ISO-8859-14)"
+
+#: ../src/common/fmapbase.cpp:158
+msgid "Western European with Euro (ISO-8859-15)"
+msgstr "Západoeurópske so znakom euro (ISO-8859-15)"
+
+#: ../src/common/fmapbase.cpp:159
+msgid "KOI8-R"
+msgstr "KOI8-R"
+
+#: ../src/common/fmapbase.cpp:160
+msgid "KOI8-U"
+msgstr "KOI8-U"
+
+#: ../src/common/fmapbase.cpp:161
+msgid "Windows/DOS OEM Cyrillic (CP 866)"
+msgstr "Windows/DOS OEM cyrilika (CP 866)"
+
+#: ../src/common/fmapbase.cpp:162
+msgid "Windows Thai (CP 874)"
+msgstr "Windows thaské (CP 874)"
+
+#: ../src/common/fmapbase.cpp:163
+msgid "Windows Japanese (CP 932) or Shift-JIS"
+msgstr "Windows japonské (CP 932) alebo Shift-JIS"
+
+#: ../src/common/fmapbase.cpp:164
+msgid "Windows Chinese Simplified (CP 936) or GB-2312"
+msgstr "Windows zjednodušená čínština (CP 936) or GB-2312"
+
+#: ../src/common/fmapbase.cpp:165
+msgid "Windows Korean (CP 949)"
+msgstr "Windows kórejské (CP 949)"
+
+#: ../src/common/fmapbase.cpp:166
+msgid "Windows Chinese Traditional (CP 950) or Big-5"
+msgstr "Windows tradičná čínština (CP 950) alebo Big-5"
+
+#: ../src/common/fmapbase.cpp:167
+msgid "Windows Central European (CP 1250)"
+msgstr "Windows stredoeurópske (CP 1250)"
+
+#: ../src/common/fmapbase.cpp:168
+msgid "Windows Cyrillic (CP 1251)"
+msgstr "Windows cyrilika (CP 1251)"
+
+#: ../src/common/fmapbase.cpp:169
+msgid "Windows Western European (CP 1252)"
+msgstr "Windows západoeurópske (CP 1252)"
+
+#: ../src/common/fmapbase.cpp:170
+msgid "Windows Greek (CP 1253)"
+msgstr "Windows grécke (CP 1253)"
+
+#: ../src/common/fmapbase.cpp:171
+msgid "Windows Turkish (CP 1254)"
+msgstr "Windows turecké (CP 1254)"
+
+#: ../src/common/fmapbase.cpp:172
+msgid "Windows Hebrew (CP 1255)"
+msgstr "Windows hebrejské (CP 1255)"
+
+#: ../src/common/fmapbase.cpp:173
+msgid "Windows Arabic (CP 1256)"
+msgstr "Windows arabské (CP 1256)"
+
+#: ../src/common/fmapbase.cpp:174
+msgid "Windows Baltic (CP 1257)"
+msgstr "Windows baltské (CP 1257)"
+
+#: ../src/common/fmapbase.cpp:175
+msgid "Windows Vietnamese (CP 1258)"
+msgstr "Windows vietnamské (CP 1258)"
+
+#: ../src/common/fmapbase.cpp:176
+msgid "Windows Johab (CP 1361)"
+msgstr "Windows johabské (CP 1361)"
+
+#: ../src/common/fmapbase.cpp:177
+msgid "Windows/DOS OEM (CP 437)"
+msgstr "Windows/DOS OEM (CP 437)"
+
+#: ../src/common/fmapbase.cpp:178
+msgid "Unicode 7 bit (UTF-7)"
+msgstr "Unicode 7-bitov (UTF-7)"
+
+#: ../src/common/fmapbase.cpp:179
+msgid "Unicode 8 bit (UTF-8)"
+msgstr "Unicode 8-bitov (UTF-8)"
+
+#: ../src/common/fmapbase.cpp:181 ../src/common/fmapbase.cpp:187
+msgid "Unicode 16 bit (UTF-16)"
+msgstr "Unicode 16-bitov (UTF-16)"
+
+#: ../src/common/fmapbase.cpp:182
+msgid "Unicode 16 bit Little Endian (UTF-16LE)"
+msgstr "Unicode 16-bitov Little Endian (UTF-16LE)"
+
+#: ../src/common/fmapbase.cpp:183 ../src/common/fmapbase.cpp:189
+msgid "Unicode 32 bit (UTF-32)"
+msgstr "Unicode 32-bitov (UTF-32)"
+
+#: ../src/common/fmapbase.cpp:184
+msgid "Unicode 32 bit Little Endian (UTF-32LE)"
+msgstr "Unicode 32-bitov Little Endian (UTF-32LE)"
+
+#: ../src/common/fmapbase.cpp:186
+msgid "Unicode 16 bit Big Endian (UTF-16BE)"
+msgstr "Unicode 16-bitov Big Endian (UTF-16BE)"
+
+#: ../src/common/fmapbase.cpp:188
+msgid "Unicode 32 bit Big Endian (UTF-32BE)"
+msgstr "Unicode 32-bitov Big Endian (UTF-32BE)"
+
+#: ../src/common/fmapbase.cpp:191
+msgid "Extended Unix Codepage for Japanese (EUC-JP)"
+msgstr "Rozšírená kódová stránka Unix pre japončinu (EUC-JP)"
+
+#: ../src/common/fmapbase.cpp:192
+msgid "US-ASCII"
+msgstr "US-ASCII"
+
+#: ../src/common/fmapbase.cpp:193
+msgid "ISO-2022-JP"
+msgstr "ISO-2022-JP"
+
+#: ../src/common/fmapbase.cpp:195
+msgid "MacRoman"
+msgstr "MacRoman"
+
+#: ../src/common/fmapbase.cpp:196
+msgid "MacJapanese"
+msgstr "MacJapanese"
+
+#: ../src/common/fmapbase.cpp:197
+msgid "MacChineseTrad"
+msgstr "MacChineseTrad"
+
+#: ../src/common/fmapbase.cpp:198
+msgid "MacKorean"
+msgstr "MacKorean"
+
+#: ../src/common/fmapbase.cpp:199
+msgid "MacArabic"
+msgstr "MacArabic"
+
+#: ../src/common/fmapbase.cpp:200
+msgid "MacHebrew"
+msgstr "MacHebrew"
+
+#: ../src/common/fmapbase.cpp:201
+msgid "MacGreek"
+msgstr "MacGreek"
+
+#: ../src/common/fmapbase.cpp:202
+msgid "MacCyrillic"
+msgstr "MacCyrillic"
+
+#: ../src/common/fmapbase.cpp:203
+msgid "MacDevanagari"
+msgstr "MacDevanagari"
+
+#: ../src/common/fmapbase.cpp:204
+msgid "MacGurmukhi"
+msgstr "MacGurmukhi"
+
+#: ../src/common/fmapbase.cpp:205
+msgid "MacGujarati"
+msgstr "MacGujarati"
+
+#: ../src/common/fmapbase.cpp:206
+msgid "MacOriya"
+msgstr "MacOriya"
+
+#: ../src/common/fmapbase.cpp:207
+msgid "MacBengali"
+msgstr "MacBengali"
+
+#: ../src/common/fmapbase.cpp:208
+msgid "MacTamil"
+msgstr "MacTamil"
+
+#: ../src/common/fmapbase.cpp:209
+msgid "MacTelugu"
+msgstr "MacTelugu"
+
+#: ../src/common/fmapbase.cpp:210
+msgid "MacKannada"
+msgstr "MacKannada"
+
+#: ../src/common/fmapbase.cpp:211
+msgid "MacMalayalam"
+msgstr "MacMalayalam"
+
+#: ../src/common/fmapbase.cpp:212
+msgid "MacSinhalese"
+msgstr "MacSinhalese"
+
+#: ../src/common/fmapbase.cpp:213
+msgid "MacBurmese"
+msgstr "MacBurmese"
+
+#: ../src/common/fmapbase.cpp:214
+msgid "MacKhmer"
+msgstr "MacKhmer"
+
+#: ../src/common/fmapbase.cpp:215
+msgid "MacThai"
+msgstr "MacThai"
+
+#: ../src/common/fmapbase.cpp:216
+msgid "MacLaotian"
+msgstr "MacLaotian"
+
+#: ../src/common/fmapbase.cpp:217
+msgid "MacGeorgian"
+msgstr "MacGeorgian"
+
+#: ../src/common/fmapbase.cpp:218
+msgid "MacArmenian"
+msgstr "MacArmenian"
+
+#: ../src/common/fmapbase.cpp:219
+msgid "MacChineseSimp"
+msgstr "MacChineseSimp"
+
+#: ../src/common/fmapbase.cpp:220
+msgid "MacTibetan"
+msgstr "MacTibetan"
+
+#: ../src/common/fmapbase.cpp:221
+msgid "MacMongolian"
+msgstr "MacMongolian"
+
+#: ../src/common/fmapbase.cpp:222
+msgid "MacEthiopic"
+msgstr "MacEthiopic"
+
+#: ../src/common/fmapbase.cpp:223
+msgid "MacCentralEurRoman"
+msgstr "MacCentralEurRoman"
+
+#: ../src/common/fmapbase.cpp:224
+msgid "MacVietnamese"
+msgstr "MacVietnamese"
+
+#: ../src/common/fmapbase.cpp:225
+msgid "MacExtArabic"
+msgstr "MacExtArabic"
+
+#: ../src/common/fmapbase.cpp:226
+msgid "MacSymbol"
+msgstr "MacSymbol"
+
+#: ../src/common/fmapbase.cpp:227
+msgid "MacDingbats"
+msgstr "MacDingbats"
+
+#: ../src/common/fmapbase.cpp:228
+msgid "MacTurkish"
+msgstr "MacTurkish"
+
+#: ../src/common/fmapbase.cpp:229
+msgid "MacCroatian"
+msgstr "MacCroatian"
+
+#: ../src/common/fmapbase.cpp:230
+msgid "MacIcelandic"
+msgstr "MacIcelandic"
+
+#: ../src/common/fmapbase.cpp:231
+msgid "MacRomanian"
+msgstr "MacRomanian"
+
+#: ../src/common/fmapbase.cpp:232
+msgid "MacCeltic"
+msgstr "MacCeltic"
+
+#: ../src/common/fmapbase.cpp:233
+msgid "MacGaelic"
+msgstr "MacGaelic"
+
+#: ../src/common/fmapbase.cpp:234
+msgid "MacKeyboardGlyphs"
+msgstr "MacKeyboardGlyphs"
+
+#: ../src/common/fmapbase.cpp:791
+msgid "Default encoding"
+msgstr "Predvolené kódovanie"
+
+#: ../src/common/fmapbase.cpp:805
+#, c-format
+msgid "Unknown encoding (%d)"
+msgstr "Neznáme kódovanie (%d)"
+
+#: ../src/common/fmapbase.cpp:815 ../src/richtext/richtextstyles.cpp:776
+msgid "default"
+msgstr "pôvodné"
+
+#: ../src/common/fmapbase.cpp:829
+#, c-format
+msgid "unknown-%d"
+msgstr "neznáme-%d"
+
+#: ../src/common/fontcmn.cpp:924 ../src/common/fontcmn.cpp:1130
+msgid "underlined"
+msgstr "podčiarknuté"
+
+#: ../src/common/fontcmn.cpp:929
+msgid " strikethrough"
+msgstr " preškrtnuté"
+
+#: ../src/common/fontcmn.cpp:942
+msgid " thin"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:946
+#, fuzzy
+msgid " extra light"
+msgstr " tenké"
+
+#: ../src/common/fontcmn.cpp:950
+msgid " light"
+msgstr " tenké"
+
+#: ../src/common/fontcmn.cpp:954
+msgid " medium"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:958
+#, fuzzy
+msgid " semi bold"
+msgstr " tučné"
+
+#: ../src/common/fontcmn.cpp:962
+msgid " bold"
+msgstr " tučné"
+
+#: ../src/common/fontcmn.cpp:966
+#, fuzzy
+msgid " extra bold"
+msgstr " tučné"
+
+#: ../src/common/fontcmn.cpp:970
+msgid " heavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:974
+msgid " extra heavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:990
+msgid " italic"
+msgstr " kurzíva"
+
+#: ../src/common/fontcmn.cpp:1134
+msgid "strikethrough"
+msgstr "preškrtnuté"
+
+#: ../src/common/fontcmn.cpp:1143
+msgid "thin"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1156
+#, fuzzy
+msgid "extralight"
+msgstr "tenké"
+
+#: ../src/common/fontcmn.cpp:1161
+msgid "light"
+msgstr "tenké"
+
+#: ../src/common/fontcmn.cpp:1169 ../src/richtext/richtextstyles.cpp:775
+msgid "normal"
+msgstr "normálne"
+
+#: ../src/common/fontcmn.cpp:1174
+msgid "medium"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1179 ../src/common/fontcmn.cpp:1199
+#, fuzzy
+msgid "semibold"
+msgstr "tučné"
+
+#: ../src/common/fontcmn.cpp:1184
+msgid "bold"
+msgstr "tučné"
+
+#: ../src/common/fontcmn.cpp:1194
+#, fuzzy
+msgid "extrabold"
+msgstr "tučné"
+
+#: ../src/common/fontcmn.cpp:1204
+msgid "heavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1212
+msgid "extraheavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1217
+msgid "italic"
+msgstr "kurzíva"
+
+#: ../src/common/fontmap.cpp:195
+msgid ": unknown charset"
+msgstr ": neznáma znaková sada"
+
+#: ../src/common/fontmap.cpp:199
+#, c-format
+msgid ""
+"The charset '%s' is unknown. You may select\n"
+"another charset to replace it with or choose\n"
+"[Cancel] if it cannot be replaced"
+msgstr ""
+"Znaková sada '%s' je neznáma. Môžete vybrať\n"
+"inú znakovú sadu, ktorá ju nahradí, alebo zvoliť\n"
+"[Zrušiť] ak ju nemožno nahradiť"
+
+#: ../src/common/fontmap.cpp:241
+#, c-format
+msgid "Failed to remember the encoding for the charset '%s'."
+msgstr "Zlyhalo zapamätanie kódovania znakovej sady '%s'."
+
+#: ../src/common/fontmap.cpp:321
+msgid "can't load any font, aborting"
+msgstr "nemožno načítať žiadne písmo, prerušuje sa"
+
+#: ../src/common/fontmap.cpp:409
+msgid ": unknown encoding"
+msgstr ": neznáme kódovanie"
+
+#: ../src/common/fontmap.cpp:417
+#, c-format
+msgid ""
+"No font for displaying text in encoding '%s' found,\n"
+"but an alternative encoding '%s' is available.\n"
+"Do you want to use this encoding (otherwise you will have to choose another "
+"one)?"
+msgstr ""
+"Nenašlo sa žiadne písmo na zobrazovanie textu v kódovaní '%s',\n"
+"ale je k dispozícii alternatívne kódovanie '%s'.\n"
+"Chcete použiť toto kódovanie (inak si budete musieť zvoliť iné)?"
+
+#: ../src/common/fontmap.cpp:422
+#, c-format
+msgid ""
+"No font for displaying text in encoding '%s' found.\n"
+"Would you like to select a font to be used for this encoding\n"
+"(otherwise the text in this encoding will not be shown correctly)?"
+msgstr ""
+"Nenašlo sa žiadne písmo na zobrazovanie textu v kódovaní '%s'.\n"
+"Prajete si zvoliť písmo, ktoré sa použije pre toto kódovanie\n"
+"(inak sa text v tomto kódovaní nebude zobrazovať správne)?"
+
+#: ../src/common/fs_mem.cpp:169
+#, c-format
+msgid "Memory VFS already contains file '%s'!"
+msgstr "Pamäť VFS už obsahuje súbor '%s'!"
+
+#: ../src/common/fs_mem.cpp:232
+#, c-format
+msgid "Trying to remove file '%s' from memory VFS, but it is not loaded!"
+msgstr "Pokúšam sa odstrániť súbor '%s' z pamäte VFS, ale nie je načítaný!"
+
+#: ../src/common/fs_mem.cpp:262
+#, c-format
+msgid "Failed to store image '%s' to memory VFS!"
+msgstr "Zlyhalo uloženie obrázok '%s' do pamäte VFS!"
+
+#: ../src/common/ftp.cpp:197
+msgid "Timeout while waiting for FTP server to connect, try passive mode."
+msgstr ""
+"Interval, počas ktorého sa čaká na pripojenie k FTP serveru, skúste pasívny "
+"režim."
+
+#: ../src/common/ftp.cpp:399
+#, c-format
+msgid "Failed to set FTP transfer mode to %s."
+msgstr "Zlyhalo nastavenie FTP prenosového režimu na %s."
+
+#: ../src/common/ftp.cpp:400 ../src/richtext/richtextsymboldlg.cpp:432
+msgid "ASCII"
+msgstr "ASCII"
+
+#: ../src/common/ftp.cpp:400
+msgid "binary"
+msgstr "binárne"
+
+#: ../src/common/ftp.cpp:608
+msgid "The FTP server doesn't support the PORT command."
+msgstr "FTP server nepodporuje príkaz PORT."
+
+#: ../src/common/ftp.cpp:622
+msgid "The FTP server doesn't support passive mode."
+msgstr "FTP server nepodporuje pasívny režim."
+
+#: ../src/common/gifdecod.cpp:822
+#, c-format
+msgid "Incorrect GIF frame size (%u, %d) for the frame #%u"
+msgstr "Nekorektná veľkosť snímky GIF (%u, %d) pre snímku #%u"
+
+#: ../src/common/glcmn.cpp:108
+msgid "Failed to allocate colour for OpenGL"
+msgstr "Zlyhalo vymedzenie farby pre OpenGL"
+
+#: ../src/common/headerctrlcmn.cpp:57
+msgid "Please select the columns to show and define their order:"
+msgstr ""
+"Vyberte, prosím, stĺpce, ktoré chcete zobraziť a definujte ich poradie:"
+
+#: ../src/common/headerctrlcmn.cpp:58
+msgid "Customize Columns"
+msgstr "Prispôsobiť stĺpce"
+
+#: ../src/common/headerctrlcmn.cpp:304
+msgid "&Customize..."
+msgstr "&Prispôsobiť ..."
+
+#: ../src/common/hyperlnkcmn.cpp:132
+#, fuzzy, c-format
+msgid "Failed to open URL \"%s\" in the default browser"
+msgstr "Zlyhalo otvorenie adresy URL '%s' v predvolenom prehliadači."
+
+#: ../src/common/iconbndl.cpp:195
+#, c-format
+msgid "Failed to load image %%d from file '%s'."
+msgstr "Zlyhalo načítanie obrázku %%d zo súboru '%s'."
+
+#: ../src/common/iconbndl.cpp:203
+#, c-format
+msgid "Failed to load image %d from stream."
+msgstr "Zlyhalo načítanie obrázok %d z prúdu."
+
+#: ../src/common/iconbndl.cpp:221
+#, c-format
+msgid "Failed to load icons from resource '%s'."
+msgstr "Zlyhalo načítanie ikony zo zdroja '%s'."
+
+#: ../src/common/imagbmp.cpp:97
+msgid "BMP: Couldn't save invalid image."
+msgstr "BMP: Nemožno uložiť neplatný obrázok."
+
+#: ../src/common/imagbmp.cpp:137
+msgid "BMP: wxImage doesn't have own wxPalette."
+msgstr "BMP: wxImage nemá vlastnú wxPalette."
+
+#: ../src/common/imagbmp.cpp:243
+msgid "BMP: Couldn't write the file (Bitmap) header."
+msgstr "BMP: Nemožno zapísať hlavičku (Bitmap) súboru."
+
+#: ../src/common/imagbmp.cpp:266
+msgid "BMP: Couldn't write the file (BitmapInfo) header."
+msgstr "BMP: Nemožno zapísať hlavičku (BitmapInfo) súboru."
+
+#: ../src/common/imagbmp.cpp:353
+msgid "BMP: Couldn't write RGB color map."
+msgstr "BMP: Nemožno zapísať mapu RGB farieb."
+
+#: ../src/common/imagbmp.cpp:487
+msgid "BMP: Couldn't write data."
+msgstr "BMP: Nemožno zapísať údaje."
+
+#: ../src/common/imagbmp.cpp:561 ../src/common/imagbmp.cpp:642
+msgid "BMP: Couldn't allocate memory."
+msgstr "BMP: Nemožno vymedziť pamäť."
+
+#: ../src/common/imagbmp.cpp:1041
+msgid "DIB Header: Image width > 32767 pixels for file."
+msgstr "Hlavička DIB: Šírka obrázka v súbore > 32767 pixelov."
+
+#: ../src/common/imagbmp.cpp:1049
+msgid "DIB Header: Image height > 32767 pixels for file."
+msgstr "Hlavička DIB: Výška obrázka v súbore > 32767 pixelov."
+
+#: ../src/common/imagbmp.cpp:1081
+msgid "DIB Header: Unknown bitdepth in file."
+msgstr "Hlavička DIB: Neznáma bitová hĺbka v súbore."
+
+#: ../src/common/imagbmp.cpp:1156
+msgid "DIB Header: Unknown encoding in file."
+msgstr "Hlavička DIB: Neznáme kódovanie v súbore."
+
+#: ../src/common/imagbmp.cpp:1165
+msgid "DIB Header: Encoding doesn't match bitdepth."
+msgstr "Hlavička DIB: Kódovanie nezodpovedá bitovej hĺbke."
+
+#: ../src/common/imagbmp.cpp:1180
+#, c-format
+msgid "BMP Header: Invalid number of colors (%d)."
+msgstr ""
+
+#: ../src/common/imagbmp.cpp:1273
+msgid "Error in reading image DIB."
+msgstr "Chyba pri čítaní obrázka DIB."
+
+#: ../src/common/imagbmp.cpp:1294
+msgid "ICO: Error in reading mask DIB."
+msgstr "ICO: Chyba pri čítaní masky DIB."
+
+#: ../src/common/imagbmp.cpp:1353
+msgid "ICO: Image too tall for an icon."
+msgstr "ICO: Obrázok je na ikonu príliš vysoký."
+
+#: ../src/common/imagbmp.cpp:1361
+msgid "ICO: Image too wide for an icon."
+msgstr "ICO: Obrázok je na ikonu príliš široký."
+
+#: ../src/common/imagbmp.cpp:1388 ../src/common/imagbmp.cpp:1488
+#: ../src/common/imagbmp.cpp:1503 ../src/common/imagbmp.cpp:1514
+#: ../src/common/imagbmp.cpp:1528 ../src/common/imagbmp.cpp:1576
+#: ../src/common/imagbmp.cpp:1591 ../src/common/imagbmp.cpp:1605
+#: ../src/common/imagbmp.cpp:1616
+msgid "ICO: Error writing the image file!"
+msgstr "ICO: Chyba pri zapisovaní súboru obrázka!"
+
+#: ../src/common/imagbmp.cpp:1701
+msgid "ICO: Invalid icon index."
+msgstr "ICO: Neplatný index ikony."
+
+#: ../src/common/image.cpp:2410
+msgid "Image and mask have different sizes."
+msgstr "Obrázok a maska majú rôzne veľkosti."
+
+#: ../src/common/image.cpp:2418 ../src/common/image.cpp:2459
+msgid "No unused colour in image being masked."
+msgstr "Na obrázku nie je namaskovaná žiadna nepoužitá farba."
+
+#: ../src/common/image.cpp:2641
+#, c-format
+msgid "Failed to load bitmap \"%s\" from resources."
+msgstr "Zlyhalo načítanie bitmapy '%s' zo zdrojov."
+
+#: ../src/common/image.cpp:2650
+#, c-format
+msgid "Failed to load icon \"%s\" from resources."
+msgstr "Zlyhalo načítanie ikony '%s' zo zdrojov."
+
+#: ../src/common/image.cpp:2728 ../src/common/image.cpp:2747
+#, c-format
+msgid "Failed to load image from file \"%s\"."
+msgstr "Zlyhalo načítanie obrázku zo súboru '%s'."
+
+#: ../src/common/image.cpp:2761
+#, c-format
+msgid "Can't save image to file '%s': unknown extension."
+msgstr "Nemožno uložiť obrázok do súboru '%s': neznáma prípona súboru."
+
+#: ../src/common/image.cpp:2869
+msgid "No handler found for image type."
+msgstr "Pre typ obrázka sa nenašiel žiadny obslužný program."
+
+#: ../src/common/image.cpp:2877 ../src/common/image.cpp:3000
+#: ../src/common/image.cpp:3066
+#, c-format
+msgid "No image handler for type %d defined."
+msgstr "Nie je definovaný žiadny obslužný program obrázkov pre typ %d."
+
+#: ../src/common/image.cpp:2887
+#, c-format
+msgid "Image file is not of type %d."
+msgstr "Súbor obrázka nie je typu %d."
+
+#: ../src/common/image.cpp:2970
+msgid "Can't automatically determine the image format for non-seekable input."
+msgstr "Nemožno automaticky určiť formát obrázka pre neviditeľný vstup."
+
+#: ../src/common/image.cpp:2988
+msgid "Unknown image data format."
+msgstr "Neznámy formát údajov obrázka."
+
+#: ../src/common/image.cpp:3009
+#, c-format
+msgid "This is not a %s."
+msgstr "Toto nie je %s."
+
+#: ../src/common/image.cpp:3032 ../src/common/image.cpp:3080
+#, c-format
+msgid "No image handler for type %s defined."
+msgstr "Nie je definovaný žiadny obslužný program obrázkov pre typ %s."
+
+#: ../src/common/image.cpp:3041
+#, c-format
+msgid "Image is not of type %s."
+msgstr "Obrázok nie je typu %s."
+
+#: ../src/common/image.cpp:3509
+#, c-format
+msgid "Failed to check format of image file \"%s\"."
+msgstr "Zlyhalo uloženie bitmapového obrázku do súboru '%s'."
+
+#: ../src/common/imaggif.cpp:124
+msgid "GIF: error in GIF image format."
+msgstr "GIF: chyba vo formáte obrázka GIF."
+
+#: ../src/common/imaggif.cpp:129
+msgid "GIF: not enough memory."
+msgstr "GIF: nedostatok pamäte."
+
+#: ../src/common/imaggif.cpp:134
+msgid "GIF: data stream seems to be truncated."
+msgstr "GIF: zdá sa, že údajový prúd bol prerušený."
+
+#: ../src/common/imaggif.cpp:240
+msgid "Couldn't initialize GIF hash table."
+msgstr "Nemožné inicializovať hash tabuľku GIF."
+
+#: ../src/common/imagiff.cpp:739
+msgid "IFF: error in IFF image format."
+msgstr "IFF: chyba v IFF formáte obrázka."
+
+#: ../src/common/imagiff.cpp:742
+msgid "IFF: not enough memory."
+msgstr "IFF: nedostatok pamäte."
+
+#: ../src/common/imagiff.cpp:745
+msgid "IFF: unknown error!!!"
+msgstr "IFF: neznáma chyba!!!"
+
+#: ../src/common/imagiff.cpp:755
+msgid "IFF: data stream seems to be truncated."
+msgstr "IFF: zdá sa, že dátový tok bol prerušený."
+
+#: ../src/common/imagjpeg.cpp:258
+msgid "JPEG: Couldn't load - file is probably corrupted."
+msgstr "JPEG: Nemožno načítať - súbor je pravdepodobne poškodený."
+
+#: ../src/common/imagjpeg.cpp:437
+msgid "JPEG: Couldn't save image."
+msgstr "JPEG: Nemožno uložiť obrázok."
+
+#: ../src/common/imagpcx.cpp:439
+msgid "PCX: this is not a PCX file."
+msgstr "PCX: toto nie je PCX súbor."
+
+#: ../src/common/imagpcx.cpp:453
+msgid "PCX: image format unsupported"
+msgstr "PCX: nepodporovaný formát obrázka"
+
+#: ../src/common/imagpcx.cpp:454 ../src/common/imagpcx.cpp:477
+msgid "PCX: couldn't allocate memory"
+msgstr "PCX: Nemožno alokovať pamäť"
+
+#: ../src/common/imagpcx.cpp:455
+msgid "PCX: version number too low"
+msgstr "PCX: príliš nízke číslo verzie"
+
+#: ../src/common/imagpcx.cpp:456 ../src/common/imagpcx.cpp:478
+msgid "PCX: unknown error !!!"
+msgstr "PCX: neznáma chyba !!!"
+
+#: ../src/common/imagpcx.cpp:476
+msgid "PCX: invalid image"
+msgstr "PCX: neplatný obrázok"
+
+#: ../src/common/imagpng.cpp:385
+#, c-format
+msgid "Unknown PNG resolution unit %d"
+msgstr "Neznáma jednotka rozlíšenia PNG %d"
+
+#: ../src/common/imagpng.cpp:439
+msgid "Couldn't load a PNG image - file is corrupted or not enough memory."
+msgstr ""
+"Nemožno načítať PNG obrázok - súbor je porušený alebo nie je dostatok pamäte."
+
+#: ../src/common/imagpng.cpp:513 ../src/common/imagpng.cpp:524
+#: ../src/common/imagpng.cpp:534
+msgid "Couldn't save PNG image."
+msgstr "Nemožno uložiť PNG obrázok."
+
+#: ../src/common/imagpnm.cpp:71
+msgid "PNM: File format is not recognized."
+msgstr "PNM: Nerozpoznaný formát súboru."
+
+#: ../src/common/imagpnm.cpp:89
+msgid "PNM: Couldn't allocate memory."
+msgstr "PNM: Nemožno vymedziť pamäť."
+
+#: ../src/common/imagpnm.cpp:111 ../src/common/imagpnm.cpp:134
+#: ../src/common/imagpnm.cpp:156
+msgid "PNM: File seems truncated."
+msgstr "PNM: Súbor vyzerá byť orezaný."
+
+#: ../src/common/imagtiff.cpp:69
+#, c-format
+msgid " (in module \"%s\")"
+msgstr " (v module '%s')"
+
+#: ../src/common/imagtiff.cpp:304
+msgid "TIFF: Error loading image."
+msgstr "TIFF: Chyba pri načítaní obrázka."
+
+#: ../src/common/imagtiff.cpp:314
+msgid "Invalid TIFF image index."
+msgstr "Neplatný index obrázka TIFF."
+
+#: ../src/common/imagtiff.cpp:358
+msgid "TIFF: Image size is abnormally big."
+msgstr "TIFF: Veľkosť obrázka je neobvykle veľká."
+
+#: ../src/common/imagtiff.cpp:372 ../src/common/imagtiff.cpp:385
+#: ../src/common/imagtiff.cpp:769
+msgid "TIFF: Couldn't allocate memory."
+msgstr "TIFF: Nemožno vymedziť pamäť."
+
+#: ../src/common/imagtiff.cpp:471
+msgid "TIFF: Error reading image."
+msgstr "TIFF: Chyba pri čítaní obrázka."
+
+#: ../src/common/imagtiff.cpp:532
+#, c-format
+msgid "Unknown TIFF resolution unit %d ignored"
+msgstr "Neznáma jednotka rozlíšenia TIFF %d je ignorovaná"
+
+#: ../src/common/imagtiff.cpp:611
+msgid "TIFF: Error saving image."
+msgstr "TIFF: Chyba pri ukladaní obrázka."
+
+#: ../src/common/imagtiff.cpp:868
+msgid "TIFF: Error writing image."
+msgstr "TIFF: Chyba pri zápise obrázka."
+
+#: ../src/common/imagtiff.cpp:881
+#, fuzzy
+msgid "TIFF: Error flushing data."
+msgstr "TIFF: Chyba pri ukladaní obrázka."
+
+#: ../src/common/imagwebp.cpp:56
+msgid "WebP: Invalid data (failed to get features)."
+msgstr ""
+
+#: ../src/common/imagwebp.cpp:65
+msgid "WebP: Allocating image memory failed."
+msgstr ""
+
+#: ../src/common/imagwebp.cpp:82
+msgid "WebP: Decoding RGBA image data failed."
+msgstr ""
+
+#: ../src/common/imagwebp.cpp:98
+msgid "WebP: Decoding RGB image data failed."
+msgstr ""
+
+#: ../src/common/imagwebp.cpp:113 ../src/common/imagwebp.cpp:201
+msgid "WebP: Allocating stream buffer failed."
+msgstr ""
+
+#: ../src/common/imagwebp.cpp:131
+#, fuzzy
+msgid "WebP: Failed to parse container data."
+msgstr "Zlyhalo nastavenie údajov do schránky."
+
+#: ../src/common/imagwebp.cpp:222
+#, fuzzy
+msgid "WebP: Error decoding animation."
+msgstr "Chyba pri čítaní konfiguračných volieb."
+
+#: ../src/common/imagwebp.cpp:240
+msgid "WebP: Error getting next animation frame."
+msgstr ""
+
+#: ../src/common/init.cpp:172
+#, c-format
+msgid ""
+"Command line argument %d couldn't be converted to Unicode and will be "
+"ignored."
+msgstr ""
+"Argument príkazového riadku %d nemožno previesť na Unicode a preto bude "
+"ignorovaný."
+
+#: ../src/common/init.cpp:344
+msgid "Initialization failed in post init, aborting."
+msgstr "Inicializácia zlyhala v príspevku init, prerušuje sa."
+
+#: ../src/common/intl.cpp:378
+#, c-format
+msgid "Cannot set locale to language \"%s\"."
+msgstr "Nemožno nastaviť miestne prostredie pre jazyk '%s'."
+
+#: ../src/common/log.cpp:232
+msgid "Error: "
+msgstr "Chyba: "
+
+#: ../src/common/log.cpp:236
+msgid "Warning: "
+msgstr "Varovanie: "
+
+#: ../src/common/log.cpp:284
+msgid "The previous message repeated once."
+msgstr "Predošlá správa sa opakovala raz."
+
+#: ../src/common/log.cpp:291
+#, c-format
+msgid "The previous message repeated %u time."
+msgid_plural "The previous message repeated %u times."
+msgstr[0] "Predchádzajúca správa sa opakovala %u krát."
+msgstr[1] "Predchádzajúca správa sa opakovala %u krát."
+msgstr[2] "Predchádzajúca správa sa opakovala %u krát."
+
+#: ../src/common/log.cpp:319
+#, c-format
+msgid "Last repeated message (\"%s\", %u time) wasn't output"
+msgid_plural "Last repeated message (\"%s\", %u times) wasn't output"
+msgstr[0] "Posledná opakovaná správa ('%s', %u krát) sa nevydala"
+msgstr[1] "Posledná opakovaná správa ('%s', %u krát) sa nevydala"
+msgstr[2] "Posledná opakovaná správa ('%s', %u krát) sa nevydala"
+
+#: ../src/common/log.cpp:435
+#, c-format
+msgid " (error %ld: %s)"
+msgstr " (chyba %ld: %s)"
+
+#: ../src/common/lzmastream.cpp:121
+#, fuzzy
+msgid "Failed to allocate memory for LZMA decompression."
+msgstr "Zlyhalo vymedzenie farby pre OpenGL"
+
+#: ../src/common/lzmastream.cpp:125
+#, c-format
+msgid "Failed to initialize LZMA decompression: unexpected error %u."
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:179
+msgid "input is not in XZ format"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:183
+msgid "input compressed using unknown XZ option"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:188
+msgid "input is corrupted"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:192
+#, fuzzy
+msgid "unknown decompression error"
+msgstr "chyba dekompresie"
+
+#: ../src/common/lzmastream.cpp:196
+#, fuzzy, c-format
+msgid "LZMA decompression error: %s"
+msgstr "chyba dekompresie"
+
+#: ../src/common/lzmastream.cpp:231
+#, fuzzy
+msgid "Failed to allocate memory for LZMA compression."
+msgstr "Zlyhalo vymedzenie farby pre OpenGL"
+
+#: ../src/common/lzmastream.cpp:235
+#, c-format
+msgid "Failed to initialize LZMA compression: unexpected error %u."
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:267 ../src/common/lzmastream.cpp:342
+#: ../src/html/chm.cpp:336
+msgid "out of memory"
+msgstr "nedostatok pamäte"
+
+#: ../src/common/lzmastream.cpp:276 ../src/common/lzmastream.cpp:346
+#, fuzzy
+msgid "unknown compression error"
+msgstr "chyba kompresie"
+
+#: ../src/common/lzmastream.cpp:280
+#, fuzzy, c-format
+msgid "LZMA compression error: %s"
+msgstr "chyba kompresie"
+
+#: ../src/common/lzmastream.cpp:350
+#, c-format
+msgid "LZMA compression error when flushing output: %s"
+msgstr ""
+
+#: ../src/common/mimecmn.cpp:167
+#, c-format
+msgid "Unmatched '{' in an entry for mime type %s."
+msgstr "Nespárovaná '{' v zázname mime typu %s."
+
+#: ../src/common/module.cpp:76
+#, c-format
+msgid "Circular dependency involving module \"%s\" detected."
+msgstr "Zistená kruhová závislosť zahrňujúca modul '%s'."
+
+#: ../src/common/module.cpp:128
+#, c-format
+msgid "Dependency \"%s\" of module \"%s\" doesn't exist."
+msgstr "Závislosť '%s' modulu '%s' neexistuje."
+
+#: ../src/common/module.cpp:137
+#, c-format
+msgid "Module \"%s\" initialization failed"
+msgstr "Inicializácia modulu '%s' zlyhala"
+
+#: ../src/common/msgout.cpp:96
+msgid "Message"
+msgstr "Správa"
+
+#: ../src/common/paper.cpp:70
+msgid "Letter, 8 1/2 x 11 in"
+msgstr "List, 8 1/2 x 11 in"
+
+#: ../src/common/paper.cpp:71
+msgid "Legal, 8 1/2 x 14 in"
+msgstr "Legal, 8 1/2 x 14 in"
+
+#: ../src/common/paper.cpp:72
+msgid "A4 sheet, 210 x 297 mm"
+msgstr "A4 hárok, 210 x 297 mm"
+
+#: ../src/common/paper.cpp:73
+msgid "C sheet, 17 x 22 in"
+msgstr "C hárok, 17 x 22 palca"
+
+#: ../src/common/paper.cpp:74
+msgid "D sheet, 22 x 34 in"
+msgstr "D hárok, 22 x 34 in"
+
+#: ../src/common/paper.cpp:75
+msgid "E sheet, 34 x 44 in"
+msgstr "E hárok, 34 x 44 in"
+
+#: ../src/common/paper.cpp:76
+msgid "Letter Small, 8 1/2 x 11 in"
+msgstr "List malý, 8 1/2 x 11 in"
+
+#: ../src/common/paper.cpp:77
+msgid "Tabloid, 11 x 17 in"
+msgstr "Zhustený, 11 x 17 palcov"
+
+#: ../src/common/paper.cpp:78
+msgid "Ledger, 17 x 11 in"
+msgstr "Ledger, 17 x 11 in"
+
+#: ../src/common/paper.cpp:79
+msgid "Statement, 5 1/2 x 8 1/2 in"
+msgstr "Vyhlásenie, 5 1/2 x 8 1/2 palca"
+
+#: ../src/common/paper.cpp:80
+msgid "Executive, 7 1/4 x 10 1/2 in"
+msgstr "Executive, 7 1/4 x 10 1/2 palcov"
+
+#: ../src/common/paper.cpp:81
+msgid "A3 sheet, 297 x 420 mm"
+msgstr "A3 hárok, 297 x 420 mm"
+
+#: ../src/common/paper.cpp:82
+msgid "A4 small sheet, 210 x 297 mm"
+msgstr "A4 malý hárok, 210 x 297 mm"
+
+#: ../src/common/paper.cpp:83
+msgid "A5 sheet, 148 x 210 mm"
+msgstr "A5 hárok, 148 x 210 mm"
+
+#: ../src/common/paper.cpp:84
+msgid "B4 sheet, 250 x 354 mm"
+msgstr "B4 hárok, 250 x 354 mm"
+
+#: ../src/common/paper.cpp:85
+msgid "B5 sheet, 182 x 257 millimeter"
+msgstr "B5 hárok, 182 x 257 millimeter"
+
+#: ../src/common/paper.cpp:86
+msgid "Folio, 8 1/2 x 13 in"
+msgstr "Folio, 8 1/2 x 13 in"
+
+#: ../src/common/paper.cpp:87
+msgid "Quarto, 215 x 275 mm"
+msgstr "Quarto, 215 x 275 mm"
+
+#: ../src/common/paper.cpp:88
+msgid "10 x 14 in"
+msgstr "10 x 14 palca"
+
+#: ../src/common/paper.cpp:89
+msgid "11 x 17 in"
+msgstr "11 x 17 palca"
+
+#: ../src/common/paper.cpp:90
+msgid "Note, 8 1/2 x 11 in"
+msgstr "Poznámka, 8 1/2 x 11 palcov"
+
+#: ../src/common/paper.cpp:91
+msgid "#9 Envelope, 3 7/8 x 8 7/8 in"
+msgstr "#9 obálka, 3 7/8 x 8 7/8 palca"
+
+#: ../src/common/paper.cpp:92
+msgid "#10 Envelope, 4 1/8 x 9 1/2 in"
+msgstr "#10 obálka, 4 1/8 x 9 1/2 palca"
+
+#: ../src/common/paper.cpp:93
+msgid "#11 Envelope, 4 1/2 x 10 3/8 in"
+msgstr "#11 obálka, 4 1/2 x 10 3/8 palca"
+
+#: ../src/common/paper.cpp:94
+msgid "#12 Envelope, 4 3/4 x 11 in"
+msgstr "#12 obálka, 4 3/4 x 11 palca"
+
+#: ../src/common/paper.cpp:95
+msgid "#14 Envelope, 5 x 11 1/2 in"
+msgstr "#14 obálka, 5 x 11 1/2 palca"
+
+#: ../src/common/paper.cpp:96
+msgid "DL Envelope, 110 x 220 mm"
+msgstr "DL obálka, 110 x 220 mm"
+
+#: ../src/common/paper.cpp:97
+msgid "C5 Envelope, 162 x 229 mm"
+msgstr "C5 obálka, 162 x 229 mm"
+
+#: ../src/common/paper.cpp:98
+msgid "C3 Envelope, 324 x 458 mm"
+msgstr "C3 obálka, 324 x 458 mm"
+
+#: ../src/common/paper.cpp:99
+msgid "C4 Envelope, 229 x 324 mm"
+msgstr "C4 obálka, 229 x 324 mm"
+
+#: ../src/common/paper.cpp:100
+msgid "C6 Envelope, 114 x 162 mm"
+msgstr "C6 obálka, 114 x 162 mm"
+
+#: ../src/common/paper.cpp:101
+msgid "C65 Envelope, 114 x 229 mm"
+msgstr "C65 obálka, 114 x 229 mm"
+
+#: ../src/common/paper.cpp:102
+msgid "B4 Envelope, 250 x 353 mm"
+msgstr "B4 obálka, 250 x 353 mm"
+
+#: ../src/common/paper.cpp:103
+msgid "B5 Envelope, 176 x 250 mm"
+msgstr "B5 obálka, 176 x 250 mm"
+
+#: ../src/common/paper.cpp:104
+msgid "B6 Envelope, 176 x 125 mm"
+msgstr "B6 obálka, 176 x 125 mm"
+
+#: ../src/common/paper.cpp:105
+msgid "Italy Envelope, 110 x 230 mm"
+msgstr "Talianska obálka, 110 x 230 mm"
+
+#: ../src/common/paper.cpp:106
+msgid "Monarch Envelope, 3 7/8 x 7 1/2 in"
+msgstr "Obálka Monarch, 3 7/8 x 7 1/2 palca"
+
+#: ../src/common/paper.cpp:107
+msgid "6 3/4 Envelope, 3 5/8 x 6 1/2 in"
+msgstr "6 3/4 obálka, 3 5/8 x 6 1/2 palca"
+
+#: ../src/common/paper.cpp:108
+msgid "US Std Fanfold, 14 7/8 x 11 in"
+msgstr "US Std Fanfold, 14 7/8 x 11 in"
+
+#: ../src/common/paper.cpp:109
+msgid "German Std Fanfold, 8 1/2 x 12 in"
+msgstr "German Std Fanfold, 8 1/2 x 12 in"
+
+#: ../src/common/paper.cpp:110
+msgid "German Legal Fanfold, 8 1/2 x 13 in"
+msgstr "German Legal Fanfold, 8 1/2 x 13 in"
+
+#: ../src/common/paper.cpp:112
+msgid "B4 (ISO) 250 x 353 mm"
+msgstr "B4 (ISO) 250 x 353 mm"
+
+#: ../src/common/paper.cpp:113
+msgid "Japanese Postcard 100 x 148 mm"
+msgstr "Japonská pohľadnica 100 x 148 mm"
+
+#: ../src/common/paper.cpp:114
+msgid "9 x 11 in"
+msgstr "9 x 11 palca"
+
+#: ../src/common/paper.cpp:115
+msgid "10 x 11 in"
+msgstr "10 x 11 palca"
+
+#: ../src/common/paper.cpp:116
+msgid "15 x 11 in"
+msgstr "15 x 11 palca"
+
+#: ../src/common/paper.cpp:117
+msgid "Envelope Invite 220 x 220 mm"
+msgstr "Obálka pozvánky 220 x 220 mm"
+
+#: ../src/common/paper.cpp:118
+msgid "Letter Extra 9 1/2 x 12 in"
+msgstr "List extra 9 1/2 x 12 in"
+
+#: ../src/common/paper.cpp:119
+msgid "Legal Extra 9 1/2 x 15 in"
+msgstr "Legal Extra 9 1/2 x 15 in"
+
+#: ../src/common/paper.cpp:120
+msgid "Tabloid Extra 11.69 x 18 in"
+msgstr "Zhustený extra 11.69 x 18 palcov"
+
+#: ../src/common/paper.cpp:121
+msgid "A4 Extra 9.27 x 12.69 in"
+msgstr "A4 extra 9.27 x 12.69 in"
+
+#: ../src/common/paper.cpp:122
+msgid "Letter Transverse 8 1/2 x 11 in"
+msgstr "List priečny 8 1/2 x 11 in"
+
+#: ../src/common/paper.cpp:123
+msgid "A4 Transverse 210 x 297 mm"
+msgstr "A4 priečny 210 x 297 mm"
+
+#: ../src/common/paper.cpp:124
+msgid "Letter Extra Transverse 9.275 x 12 in"
+msgstr "List extra priečny 9.275 x 12 in"
+
+#: ../src/common/paper.cpp:125
+msgid "SuperA/SuperA/A4 227 x 356 mm"
+msgstr "SuperA/SuperA/A4 227 x 356 mm"
+
+#: ../src/common/paper.cpp:126
+msgid "SuperB/SuperB/A3 305 x 487 mm"
+msgstr "SuperB/SuperB/A3 305 x 487 mm"
+
+#: ../src/common/paper.cpp:127
+msgid "Letter Plus 8 1/2 x 12.69 in"
+msgstr "List plus 8 1/2 x 12.69 in"
+
+#: ../src/common/paper.cpp:128
+msgid "A4 Plus 210 x 330 mm"
+msgstr "A4 plus 210 x 330 mm"
+
+#: ../src/common/paper.cpp:129
+msgid "A5 Transverse 148 x 210 mm"
+msgstr "A5 priečny 148 x 210 mm"
+
+#: ../src/common/paper.cpp:130
+msgid "B5 (JIS) Transverse 182 x 257 mm"
+msgstr "B5 (JIS) priečny 182 x 257 mm"
+
+#: ../src/common/paper.cpp:131
+msgid "A3 Extra 322 x 445 mm"
+msgstr "A3 extra 322 x 445 mm"
+
+#: ../src/common/paper.cpp:132
+msgid "A5 Extra 174 x 235 mm"
+msgstr "A5 extra 174 x 235 mm"
+
+#: ../src/common/paper.cpp:133
+msgid "B5 (ISO) Extra 201 x 276 mm"
+msgstr "B5 (ISO) extra 201 x 276 mm"
+
+#: ../src/common/paper.cpp:134
+msgid "A2 420 x 594 mm"
+msgstr "A2 420 x 594 mm"
+
+#: ../src/common/paper.cpp:135
+msgid "A3 Transverse 297 x 420 mm"
+msgstr "A3 priečny 297 x 420 mm"
+
+#: ../src/common/paper.cpp:136
+msgid "A3 Extra Transverse 322 x 445 mm"
+msgstr "A3 extra priečny 322 x 445 mm"
+
+#: ../src/common/paper.cpp:138
+msgid "Japanese Double Postcard 200 x 148 mm"
+msgstr "Japonská dvojitá pohľadnica 200 x 148 mm"
+
+#: ../src/common/paper.cpp:139
+msgid "A6 105 x 148 mm"
+msgstr "A6 105 x 148 mm"
+
+#: ../src/common/paper.cpp:140
+msgid "Japanese Envelope Kaku #2"
+msgstr "Japonská obálka Kaku #2"
+
+#: ../src/common/paper.cpp:141
+msgid "Japanese Envelope Kaku #3"
+msgstr "Japonská obálka Kaku #3"
+
+#: ../src/common/paper.cpp:142
+msgid "Japanese Envelope Chou #3"
+msgstr "Japonská obálka Chou #3"
+
+#: ../src/common/paper.cpp:143
+msgid "Japanese Envelope Chou #4"
+msgstr "Japonská obálka Chou #4"
+
+#: ../src/common/paper.cpp:144
+msgid "Letter Rotated 11 x 8 1/2 in"
+msgstr "List otočený 11 x 8 1/2 in"
+
+#: ../src/common/paper.cpp:145
+msgid "A3 Rotated 420 x 297 mm"
+msgstr "A3 otočený 420 x 297 mm"
+
+#: ../src/common/paper.cpp:146
+msgid "A4 Rotated 297 x 210 mm"
+msgstr "A4 otočený 297 x 210 mm"
+
+#: ../src/common/paper.cpp:147
+msgid "A5 Rotated 210 x 148 mm"
+msgstr "A5 otočený 210 x 148 mm"
+
+#: ../src/common/paper.cpp:148
+msgid "B4 (JIS) Rotated 364 x 257 mm"
+msgstr "B4 (JIS) otočený 364 x 257 mm"
+
+#: ../src/common/paper.cpp:149
+msgid "B5 (JIS) Rotated 257 x 182 mm"
+msgstr "B5 (JIS) otočený 257 x 182 mm"
+
+#: ../src/common/paper.cpp:150
+msgid "Japanese Postcard Rotated 148 x 100 mm"
+msgstr "Japonská pohľadnica Rotated 148 x 100 mm"
+
+#: ../src/common/paper.cpp:151
+msgid "Double Japanese Postcard Rotated 148 x 200 mm"
+msgstr "Dvojitá japonská pohľadnica otočená 148 x 200 mm"
+
+#: ../src/common/paper.cpp:152
+msgid "A6 Rotated 148 x 105 mm"
+msgstr "A6 otočený 148 x 105 mm"
+
+#: ../src/common/paper.cpp:153
+msgid "Japanese Envelope Kaku #2 Rotated"
+msgstr "Japonská obálka Kaku #2 Rotated"
+
+#: ../src/common/paper.cpp:154
+msgid "Japanese Envelope Kaku #3 Rotated"
+msgstr "Japonská obálka Kaku #3 Rotated"
+
+#: ../src/common/paper.cpp:155
+msgid "Japanese Envelope Chou #3 Rotated"
+msgstr "Japonská obálka Chou #3 Rotated"
+
+#: ../src/common/paper.cpp:156
+msgid "Japanese Envelope Chou #4 Rotated"
+msgstr "Japonská obálka Chou #4 Rotated"
+
+#: ../src/common/paper.cpp:157
+msgid "B6 (JIS) 128 x 182 mm"
+msgstr "B6 (JIS) 128 x 182 mm"
+
+#: ../src/common/paper.cpp:158
+msgid "B6 (JIS) Rotated 182 x 128 mm"
+msgstr "B6 (JIS) otočený 182 x 128 mm"
+
+#: ../src/common/paper.cpp:159
+msgid "12 x 11 in"
+msgstr "12 x 11 palca"
+
+#: ../src/common/paper.cpp:160
+msgid "Japanese Envelope You #4"
+msgstr "Japonská obálka You #4"
+
+#: ../src/common/paper.cpp:161
+msgid "Japanese Envelope You #4 Rotated"
+msgstr "Japonská obálka You #4 Rotated"
+
+#: ../src/common/paper.cpp:162
+msgid "PRC 16K 146 x 215 mm"
+msgstr "PRC 16K 146 x 215 mm"
+
+#: ../src/common/paper.cpp:163
+msgid "PRC 32K 97 x 151 mm"
+msgstr "PRC 32K 97 x 151 mm"
+
+#: ../src/common/paper.cpp:164
+msgid "PRC 32K(Big) 97 x 151 mm"
+msgstr "PRC 32K(Big) 97 x 151 mm"
+
+#: ../src/common/paper.cpp:165
+msgid "PRC Envelope #1 102 x 165 mm"
+msgstr "PRC obálka #1 102 x 165 mm"
+
+#: ../src/common/paper.cpp:166
+msgid "PRC Envelope #2 102 x 176 mm"
+msgstr "PRC obálka #2 102 x 176 mm"
+
+#: ../src/common/paper.cpp:167
+msgid "PRC Envelope #3 125 x 176 mm"
+msgstr "PRC obálka #3 125 x 176 mm"
+
+#: ../src/common/paper.cpp:168
+msgid "PRC Envelope #4 110 x 208 mm"
+msgstr "PRC obálka #4 110 x 208 mm"
+
+#: ../src/common/paper.cpp:169
+msgid "PRC Envelope #5 110 x 220 mm"
+msgstr "PRC obálka #5 110 x 220 mm"
+
+#: ../src/common/paper.cpp:170
+msgid "PRC Envelope #6 120 x 230 mm"
+msgstr "PRC obálka #6 120 x 230 mm"
+
+#: ../src/common/paper.cpp:171
+msgid "PRC Envelope #7 160 x 230 mm"
+msgstr "PRC obálka #7 160 x 230 mm"
+
+#: ../src/common/paper.cpp:172
+msgid "PRC Envelope #8 120 x 309 mm"
+msgstr "PRC obálka #8 120 x 309 mm"
+
+#: ../src/common/paper.cpp:173
+msgid "PRC Envelope #9 229 x 324 mm"
+msgstr "PRC obálka #9 229 x 324 mm"
+
+#: ../src/common/paper.cpp:174
+msgid "PRC Envelope #10 324 x 458 mm"
+msgstr "PRC obálka #10 324 x 458 mm"
+
+#: ../src/common/paper.cpp:175
+msgid "PRC 16K Rotated"
+msgstr "PRC 16K otočený"
+
+#: ../src/common/paper.cpp:176
+msgid "PRC 32K Rotated"
+msgstr "PRC 32K otočený"
+
+#: ../src/common/paper.cpp:177
+msgid "PRC 32K(Big) Rotated"
+msgstr "PRC 32K(Big) otočený"
+
+#: ../src/common/paper.cpp:178
+msgid "PRC Envelope #1 Rotated 165 x 102 mm"
+msgstr "PRC obálka #1 otočený 165 x 102 mm"
+
+#: ../src/common/paper.cpp:179
+msgid "PRC Envelope #2 Rotated 176 x 102 mm"
+msgstr "PRC obálka #2 otočený 176 x 102 mm"
+
+#: ../src/common/paper.cpp:180
+msgid "PRC Envelope #3 Rotated 176 x 125 mm"
+msgstr "PRC obálka #3 otočený 176 x 125 mm"
+
+#: ../src/common/paper.cpp:181
+msgid "PRC Envelope #4 Rotated 208 x 110 mm"
+msgstr "PRC obálka #4 otočený 208 x 110 mm"
+
+#: ../src/common/paper.cpp:182
+msgid "PRC Envelope #5 Rotated 220 x 110 mm"
+msgstr "PRC obálka #5 otočený 220 x 110 mm"
+
+#: ../src/common/paper.cpp:183
+msgid "PRC Envelope #6 Rotated 230 x 120 mm"
+msgstr "PRC obálka #6 otočený 230 x 120 mm"
+
+#: ../src/common/paper.cpp:184
+msgid "PRC Envelope #7 Rotated 230 x 160 mm"
+msgstr "PRC obálka #7 otočený 230 x 160 mm"
+
+#: ../src/common/paper.cpp:185
+msgid "PRC Envelope #8 Rotated 309 x 120 mm"
+msgstr "PRC obálka #8 otočený 309 x 120 mm"
+
+#: ../src/common/paper.cpp:186
+msgid "PRC Envelope #9 Rotated 324 x 229 mm"
+msgstr "PRC obálka #9 otočený 324 x 229 mm"
+
+#: ../src/common/paper.cpp:187
+msgid "PRC Envelope #10 Rotated 458 x 324 mm"
+msgstr "PRC obálka #10 otočený 458 x 324 mm"
+
+#: ../src/common/paper.cpp:192
+msgid "A0 sheet, 841 x 1189 mm"
+msgstr "Hárok A0, 841 x 1189 mm"
+
+#: ../src/common/paper.cpp:193
+msgid "A1 sheet, 594 x 841 mm"
+msgstr "Hárok A1, 594 x 841 mm"
+
+#: ../src/common/preferencescmn.cpp:37
+msgid "General"
+msgstr "Všeobecné"
+
+#: ../src/common/preferencescmn.cpp:40
+msgid "Advanced"
+msgstr "Pokročilé"
+
+#: ../src/common/prntbase.cpp:245
+msgid "Generic PostScript"
+msgstr "Všeobecný PostScript"
+
+#: ../src/common/prntbase.cpp:259
+msgid "Ready"
+msgstr "Priravený"
+
+#: ../src/common/prntbase.cpp:331
+msgid "Printing Error"
+msgstr "Chyba tlače"
+
+#: ../src/common/prntbase.cpp:413 ../src/common/prntbase.cpp:1597
+#: ../src/generic/prntdlgg.cpp:135 ../src/generic/prntdlgg.cpp:149
+#: ../src/gtk/print.cpp:628 ../src/gtk/print.cpp:646
+msgid "Print"
+msgstr "Tlačiť"
+
+#: ../src/common/prntbase.cpp:471 ../src/generic/prntdlgg.cpp:809
+msgid "Page setup"
+msgstr "Nastavenie strany"
+
+#: ../src/common/prntbase.cpp:525
+msgid "Please wait while printing..."
+msgstr "Počkajte, prosím, počas tlačenia ..."
+
+#: ../src/common/prntbase.cpp:529
+msgid "Document:"
+msgstr "Dokument:"
+
+#: ../src/common/prntbase.cpp:532
+msgid "Progress:"
+msgstr "Priebeh:"
+
+#: ../src/common/prntbase.cpp:533
+msgid "Preparing"
+msgstr "Príprava"
+
+#: ../src/common/prntbase.cpp:552
+#, c-format
+msgid "Printing page %d"
+msgstr "Tlačí sa stránka %d"
+
+#: ../src/common/prntbase.cpp:557
+#, c-format
+msgid "Printing page %d of %d"
+msgstr "Tlačí sa stránka %d z %d"
+
+#: ../src/common/prntbase.cpp:560
+#, c-format
+msgid " (copy %d of %d)"
+msgstr " (kópia %d z %d)"
+
+#: ../src/common/prntbase.cpp:1604
+msgid "First page"
+msgstr "Prvá stránka"
+
+#: ../src/common/prntbase.cpp:1609 ../src/html/helpwnd.cpp:659
+msgid "Previous page"
+msgstr "Predošlá strana"
+
+#: ../src/common/prntbase.cpp:1623 ../src/html/helpwnd.cpp:660
+msgid "Next page"
+msgstr "Ďalšia stránka"
+
+#: ../src/common/prntbase.cpp:1628
+msgid "Last page"
+msgstr "Posledná stránka"
+
+#: ../src/common/prntbase.cpp:1636 ../src/common/stockitem.cpp:215
+msgid "Zoom Out"
+msgstr "Oddialiť"
+
+#: ../src/common/prntbase.cpp:1650 ../src/common/stockitem.cpp:214
+msgid "Zoom In"
+msgstr "Priblížiť"
+
+#: ../src/common/prntbase.cpp:1656 ../src/common/stockitem.cpp:153
+#: ../src/generic/logg.cpp:553 ../src/univ/themes/win32.cpp:3752
+msgid "&Close"
+msgstr "&Zatvoriť"
+
+#: ../src/common/prntbase.cpp:2085
+msgid "Could not start document preview."
+msgstr "Nemožno spustiť náhľad dokumentu."
+
+#: ../src/common/prntbase.cpp:2085 ../src/common/prntbase.cpp:2129
+#: ../src/common/prntbase.cpp:2137
+msgid "Print Preview Failure"
+msgstr "Chyba náhľadu pred tlačou"
+
+#: ../src/common/prntbase.cpp:2129 ../src/common/prntbase.cpp:2137
+msgid "Sorry, not enough memory to create a preview."
+msgstr "Prepáčte, nie je dostatok pamäte pre vytvorenie náhľadu."
+
+#: ../src/common/prntbase.cpp:2144
+#, c-format
+msgid "Page %d of %d"
+msgstr "Strana %d z %d"
+
+#: ../src/common/prntbase.cpp:2146
+#, c-format
+msgid "Page %d"
+msgstr "Strana %d"
+
+#: ../src/common/regex.cpp:382 ../src/html/chm.cpp:348
+msgid "unknown error"
+msgstr "neznáma chyba"
+
+#: ../src/common/regex.cpp:995
+#, c-format
+msgid "Invalid regular expression '%s': %s"
+msgstr "Neplatný regulárny výraz '%s': %s"
+
+#: ../src/common/regex.cpp:1059
+#, c-format
+msgid "Failed to find match for regular expression: %s"
+msgstr "Zlyhalo nájdenie výsledku regulárneho výrazu : %s"
+
+#: ../src/common/rendcmn.cpp:188
+#, c-format
+msgid "Renderer \"%s\" has incompatible version %d.%d and couldn't be loaded."
+msgstr ""
+"Vykresľovacie jadro '%s' má nekompatibilnú verziu %d.%d a nemožno ho načítať."
+
+#: ../src/common/secretstore.cpp:162
+msgid "Not available for this platform"
+msgstr ""
+
+#: ../src/common/secretstore.cpp:183
+#, fuzzy, c-format
+msgid "Saving password for \"%s\" failed: %s."
+msgstr "Uloženie hesla pre \"%s / %s\" zlyhalo: %s."
+
+#: ../src/common/secretstore.cpp:205
+#, fuzzy, c-format
+msgid "Reading password for \"%s\" failed: %s."
+msgstr "Čítanie hesla pre \"%s / %s\" zlyhalo: %s."
+
+#: ../src/common/secretstore.cpp:228
+#, fuzzy, c-format
+msgid "Deleting password for \"%s\" failed: %s."
+msgstr "Odstránenie hesla pre \"%s / %s\" zlyhalo: %s."
+
+#: ../src/common/selectdispatcher.cpp:254
+msgid "Failed to monitor I/O channels"
+msgstr "Zlyhalo monitorovanie I/O kanálov"
+
+#: ../src/common/sizer.cpp:3054 ../src/common/stockitem.cpp:195
+msgid "Save"
+msgstr "Uložiť"
+
+#: ../src/common/sizer.cpp:3056
+msgid "Don't Save"
+msgstr "Neukladať"
+
+#: ../src/common/socket.cpp:870
+msgid "Cannot initialize sockets"
+msgstr "Nemožno inicializovať zásuvku"
+
+#: ../src/common/stockitem.cpp:127
+#, fuzzy
+msgctxt "standard Windows menu"
+msgid "&Help"
+msgstr "&Pomoc"
+
+#: ../src/common/stockitem.cpp:144
+msgid "&About"
+msgstr "&O aplikácii"
+
+#: ../src/common/stockitem.cpp:144
+msgid "About"
+msgstr "&O aplikácii"
+
+#: ../src/common/stockitem.cpp:145
+msgid "Add"
+msgstr "Pridať"
+
+#: ../src/common/stockitem.cpp:146
+msgid "&Apply"
+msgstr "&Použiť"
+
+#: ../src/common/stockitem.cpp:146
+msgid "Apply"
+msgstr "Použiť"
+
+#: ../src/common/stockitem.cpp:147
+msgid "&Back"
+msgstr "&Späť"
+
+#: ../src/common/stockitem.cpp:147
+msgid "Back"
+msgstr "Zo zadu"
+
+#: ../src/common/stockitem.cpp:148
+msgid "&Bold"
+msgstr "&Tučné"
+
+#: ../src/common/stockitem.cpp:148 ../src/generic/fontdlgg.cpp:326
+#: ../src/richtext/richtextfontpage.cpp:354
+msgid "Bold"
+msgstr "Hrubé"
+
+#: ../src/common/stockitem.cpp:149
+msgid "&Bottom"
+msgstr "&Dole"
+
+#: ../src/common/stockitem.cpp:149 ../src/richtext/richtextsizepage.cpp:287
+msgid "Bottom"
+msgstr "Zdola"
+
+#: ../src/common/stockitem.cpp:150 ../src/generic/fontdlgg.cpp:462
+#: ../src/generic/fontdlgg.cpp:481 ../src/generic/wizard.cpp:415
+msgid "&Cancel"
+msgstr "&Zrušiť"
+
+#: ../src/common/stockitem.cpp:151
+#, fuzzy
+msgid "&CD-ROM"
+msgstr "&CD-Rom"
+
+#: ../src/common/stockitem.cpp:151
+#, fuzzy
+msgid "CD-ROM"
+msgstr "CD-Rom"
+
+#: ../src/common/stockitem.cpp:152
+msgid "&Clear"
+msgstr "&Zmazať"
+
+#: ../src/common/stockitem.cpp:152
+msgid "Clear"
+msgstr "Zmazať"
+
+#: ../src/common/stockitem.cpp:153 ../src/generic/dbgrptg.cpp:93
+#: ../src/generic/progdlgg.cpp:778 ../src/html/helpdlg.cpp:86
+#: ../src/msw/progdlg.cpp:209 ../src/msw/progdlg.cpp:890
+#: ../src/richtext/richtextstyledlg.cpp:272
+#: ../src/richtext/richtextsymboldlg.cpp:448
+msgid "Close"
+msgstr "Zatvoriť"
+
+#: ../src/common/stockitem.cpp:154
+msgid "&Convert"
+msgstr "&Konvertovať"
+
+#: ../src/common/stockitem.cpp:154
+msgid "Convert"
+msgstr "Konvertovať"
+
+#: ../src/common/stockitem.cpp:155 ../src/msw/textctrl.cpp:2884
+#: ../src/osx/textctrl_osx.cpp:653 ../src/richtext/richtextctrl.cpp:331
+msgid "&Copy"
+msgstr "&Kopírovať"
+
+#: ../src/common/stockitem.cpp:155 ../src/stc/stc_i18n.cpp:18
+msgid "Copy"
+msgstr "Kopírovať"
+
+#: ../src/common/stockitem.cpp:156 ../src/msw/textctrl.cpp:2883
+#: ../src/osx/textctrl_osx.cpp:652 ../src/richtext/richtextctrl.cpp:330
+msgid "Cu&t"
+msgstr "&Vystrihnúť"
+
+#: ../src/common/stockitem.cpp:156 ../src/stc/stc_i18n.cpp:17
+msgid "Cut"
+msgstr "Vystrihnúť"
+
+#: ../src/common/stockitem.cpp:157 ../src/msw/textctrl.cpp:2886
+#: ../src/osx/textctrl_osx.cpp:655 ../src/richtext/richtextctrl.cpp:333
+#: ../src/richtext/richtexttabspage.cpp:137
+msgid "&Delete"
+msgstr "&Odstrániť"
+
+#: ../src/common/stockitem.cpp:157 ../src/richtext/richtextbuffer.cpp:8266
+#: ../src/stc/stc_i18n.cpp:20
+msgid "Delete"
+msgstr "Odstrániť"
+
+#: ../src/common/stockitem.cpp:158
+msgid "&Down"
+msgstr "&Dolu"
+
+#: ../src/common/stockitem.cpp:158 ../src/generic/fdrepdlg.cpp:148
+msgid "Down"
+msgstr "Dolu"
+
+#: ../src/common/stockitem.cpp:159
+msgid "&Edit"
+msgstr "&Upraviť"
+
+#: ../src/common/stockitem.cpp:159
+msgid "Edit"
+msgstr "Upraviť"
+
+#: ../src/common/stockitem.cpp:160
+msgid "&Execute"
+msgstr "&Vykonať"
+
+#: ../src/common/stockitem.cpp:160
+msgid "Execute"
+msgstr "Vykonať"
+
+#: ../src/common/stockitem.cpp:161
+msgid "&Quit"
+msgstr "&Skončiť"
+
+#: ../src/common/stockitem.cpp:161
+msgid "Quit"
+msgstr "Ukončiť"
+
+#: ../src/common/stockitem.cpp:162
+msgid "&File"
+msgstr "&Súbor"
+
+#: ../src/common/stockitem.cpp:162
+msgid "File"
+msgstr "Súbor"
+
+#: ../src/common/stockitem.cpp:163
+#, fuzzy
+msgid "&Find..."
+msgstr "&Hľadať"
+
+#: ../src/common/stockitem.cpp:163
+#, fuzzy
+msgid "Find..."
+msgstr "Hľadať"
+
+#: ../src/common/stockitem.cpp:164
+msgid "&First"
+msgstr "&Najprv"
+
+#: ../src/common/stockitem.cpp:164
+msgid "First"
+msgstr "Prvá"
+
+#: ../src/common/stockitem.cpp:165
+msgid "&Floppy"
+msgstr "&Disketa"
+
+#: ../src/common/stockitem.cpp:165
+msgid "Floppy"
+msgstr "Disketa"
+
+#: ../src/common/stockitem.cpp:166
+msgid "&Forward"
+msgstr "&Vpred"
+
+#: ../src/common/stockitem.cpp:166
+msgid "Forward"
+msgstr "Spredu"
+
+#: ../src/common/stockitem.cpp:167
+msgid "&Harddisk"
+msgstr "&Pevný disk"
+
+#: ../src/common/stockitem.cpp:167
+msgid "Harddisk"
+msgstr "Pevný disk"
+
+#: ../src/common/stockitem.cpp:168 ../src/generic/wizard.cpp:418
+#: ../src/osx/cocoa/menu.mm:225 ../src/richtext/richtextstyledlg.cpp:298
+#: ../src/richtext/richtextsymboldlg.cpp:451
+msgid "&Help"
+msgstr "&Pomoc"
+
+#: ../src/common/stockitem.cpp:169
+msgid "&Home"
+msgstr "&Domov"
+
+#: ../src/common/stockitem.cpp:169
+msgid "Home"
+msgstr "Domov"
+
+#: ../src/common/stockitem.cpp:170
+msgid "Indent"
+msgstr "Odsadenie"
+
+#: ../src/common/stockitem.cpp:171
+msgid "&Index"
+msgstr "&Index"
+
+#: ../src/common/stockitem.cpp:171 ../src/html/helpwnd.cpp:510
+msgid "Index"
+msgstr "Index"
+
+#: ../src/common/stockitem.cpp:172
+msgid "&Info"
+msgstr "&Info"
+
+#: ../src/common/stockitem.cpp:172
+msgid "Info"
+msgstr "Informácia"
+
+#: ../src/common/stockitem.cpp:173
+msgid "&Italic"
+msgstr "&Kurzíva"
+
+#: ../src/common/stockitem.cpp:173 ../src/generic/fontdlgg.cpp:322
+#: ../src/richtext/richtextfontpage.cpp:350
+msgid "Italic"
+msgstr "Kurzíva"
+
+#: ../src/common/stockitem.cpp:174
+msgid "&Jump to"
+msgstr "&Skoč na"
+
+#: ../src/common/stockitem.cpp:174
+msgid "Jump to"
+msgstr "Skoč na"
+
+#: ../src/common/stockitem.cpp:175
+msgid "Centered"
+msgstr "Centrovaný"
+
+#: ../src/common/stockitem.cpp:176
+msgid "Justified"
+msgstr "Zarovnaný"
+
+#: ../src/common/stockitem.cpp:177
+msgid "Align Left"
+msgstr "Zarovnať vľavo"
+
+#: ../src/common/stockitem.cpp:178
+msgid "Align Right"
+msgstr "Zarovnať vpravo"
+
+#: ../src/common/stockitem.cpp:179
+msgid "&Last"
+msgstr "&Posledný"
+
+#: ../src/common/stockitem.cpp:179
+msgid "Last"
+msgstr "Posledná"
+
+#: ../src/common/stockitem.cpp:180
+msgid "&Network"
+msgstr "&Sieť"
+
+#: ../src/common/stockitem.cpp:180
+msgid "Network"
+msgstr "Sieť"
+
+#: ../src/common/stockitem.cpp:181 ../src/richtext/richtexttabspage.cpp:131
+msgid "&New"
+msgstr "&Nový"
+
+#: ../src/common/stockitem.cpp:181
+msgid "New"
+msgstr "Nový"
+
+#: ../src/common/stockitem.cpp:182 ../src/msw/msgdlg.cpp:417
+msgid "&No"
+msgstr "&Nie"
+
+#: ../src/common/stockitem.cpp:183 ../src/generic/fontdlgg.cpp:467
+#: ../src/generic/fontdlgg.cpp:474
+msgid "&OK"
+msgstr "&OK"
+
+#: ../src/common/stockitem.cpp:184 ../src/generic/dbgrptg.cpp:341
+msgid "&Open..."
+msgstr "&Otvoriť..."
+
+#: ../src/common/stockitem.cpp:184
+msgid "Open..."
+msgstr "Otvoriť..."
+
+#: ../src/common/stockitem.cpp:185 ../src/msw/textctrl.cpp:2885
+#: ../src/osx/textctrl_osx.cpp:654 ../src/richtext/richtextctrl.cpp:332
+msgid "&Paste"
+msgstr "&Prilepiť"
+
+#: ../src/common/stockitem.cpp:185 ../src/richtext/richtextctrl.cpp:3484
+#: ../src/stc/stc_i18n.cpp:19
+msgid "Paste"
+msgstr "Prilepiť"
+
+#: ../src/common/stockitem.cpp:186
+msgid "&Preferences"
+msgstr "&Nastavenia"
+
+#: ../src/common/stockitem.cpp:186 ../src/osx/cocoa/preferences.mm:304
+msgid "Preferences"
+msgstr "Predvoľby"
+
+#: ../src/common/stockitem.cpp:187
+msgid "Print previe&w..."
+msgstr "Tlač náhľadu..."
+
+#: ../src/common/stockitem.cpp:187
+msgid "Print preview..."
+msgstr "Náhľad pred tlačou..."
+
+#: ../src/common/stockitem.cpp:188
+msgid "&Print..."
+msgstr "&Tlačiť..."
+
+#: ../src/common/stockitem.cpp:188
+msgid "Print..."
+msgstr "Tlačiť ..."
+
+#: ../src/common/stockitem.cpp:189 ../src/richtext/richtextctrl.cpp:337
+#: ../src/richtext/richtextctrl.cpp:5479
+msgid "&Properties"
+msgstr "&Vlastnosti"
+
+#: ../src/common/stockitem.cpp:189
+msgid "Properties"
+msgstr "Vlastnosti"
+
+#: ../src/common/stockitem.cpp:190 ../src/stc/stc_i18n.cpp:16
+msgid "Redo"
+msgstr "Vpred"
+
+#: ../src/common/stockitem.cpp:191
+msgid "Refresh"
+msgstr "Obnoviť"
+
+#: ../src/common/stockitem.cpp:192
+msgid "Remove"
+msgstr "Odstrániť"
+
+#: ../src/common/stockitem.cpp:193
+#, fuzzy
+msgid "Rep&lace..."
+msgstr "Nah&radiť"
+
+#: ../src/common/stockitem.cpp:193
+#, fuzzy
+msgid "Replace..."
+msgstr "Nahradiť"
+
+#: ../src/common/stockitem.cpp:194
+msgid "Revert to Saved"
+msgstr "Návrat k uloženej verzii"
+
+#: ../src/common/stockitem.cpp:196 ../src/generic/logg.cpp:549
+msgid "Save &As..."
+msgstr "Uložiť &ako..."
+
+#: ../src/common/stockitem.cpp:196
+#, fuzzy
+msgid "Save As..."
+msgstr "Uložiť &ako..."
+
+#: ../src/common/stockitem.cpp:197 ../src/msw/textctrl.cpp:2888
+#: ../src/osx/textctrl_osx.cpp:657 ../src/richtext/richtextctrl.cpp:335
+msgid "Select &All"
+msgstr "Vybrať &všetko"
+
+#: ../src/common/stockitem.cpp:197 ../src/stc/stc_i18n.cpp:21
+msgid "Select All"
+msgstr "Vybrať všetko"
+
+#: ../src/common/stockitem.cpp:198
+msgid "&Color"
+msgstr "&Farba"
+
+#: ../src/common/stockitem.cpp:198
+msgid "Color"
+msgstr "Farba"
+
+#: ../src/common/stockitem.cpp:199
+msgid "&Font"
+msgstr "&Písmo"
+
+#: ../src/common/stockitem.cpp:199 ../src/richtext/richtextformatdlg.cpp:336
+msgid "Font"
+msgstr "Písmo"
+
+#: ../src/common/stockitem.cpp:200
+msgid "&Ascending"
+msgstr "&Vzostupne"
+
+#: ../src/common/stockitem.cpp:200
+msgid "Ascending"
+msgstr "Vzostupne"
+
+#: ../src/common/stockitem.cpp:201
+msgid "&Descending"
+msgstr "&Zostupne"
+
+#: ../src/common/stockitem.cpp:201
+msgid "Descending"
+msgstr "Zostupne"
+
+#: ../src/common/stockitem.cpp:202
+msgid "&Spell Check"
+msgstr "&Kontrola pravopisu"
+
+#: ../src/common/stockitem.cpp:202
+msgid "Spell Check"
+msgstr "Kontrola pravopisu"
+
+#: ../src/common/stockitem.cpp:203
+msgid "&Stop"
+msgstr "&Stop"
+
+#: ../src/common/stockitem.cpp:203
+msgid "Stop"
+msgstr "Stop"
+
+#: ../src/common/stockitem.cpp:204 ../src/richtext/richtextfontpage.cpp:274
+msgid "&Strikethrough"
+msgstr "&Preškrtnuté"
+
+#: ../src/common/stockitem.cpp:204
+msgid "Strikethrough"
+msgstr "Preškrtnuté"
+
+#: ../src/common/stockitem.cpp:205
+msgid "&Top"
+msgstr "&Navrchu"
+
+#: ../src/common/stockitem.cpp:205 ../src/richtext/richtextsizepage.cpp:285
+#: ../src/richtext/richtextsizepage.cpp:289
+msgid "Top"
+msgstr "Zhora"
+
+#: ../src/common/stockitem.cpp:206
+msgid "Undelete"
+msgstr "Obnoviť zmazané"
+
+#: ../src/common/stockitem.cpp:207 ../src/generic/fontdlgg.cpp:437
+msgid "&Underline"
+msgstr "&Podčiarknuté"
+
+#: ../src/common/stockitem.cpp:207
+msgid "Underline"
+msgstr "Podčiarknuté"
+
+#: ../src/common/stockitem.cpp:208 ../src/stc/stc_i18n.cpp:15
+msgid "Undo"
+msgstr "Späť"
+
+#: ../src/common/stockitem.cpp:209
+msgid "&Unindent"
+msgstr "&Zrušiť odsadenie"
+
+#: ../src/common/stockitem.cpp:209
+msgid "Unindent"
+msgstr "Zrušiť odsadenie"
+
+#: ../src/common/stockitem.cpp:210
+msgid "&Up"
+msgstr "&Hore"
+
+#: ../src/common/stockitem.cpp:210 ../src/generic/fdrepdlg.cpp:148
+msgid "Up"
+msgstr "Hore"
+
+#: ../src/common/stockitem.cpp:211 ../src/msw/msgdlg.cpp:417
+msgid "&Yes"
+msgstr "Á&no"
+
+#: ../src/common/stockitem.cpp:212
+msgid "&Actual Size"
+msgstr "&Skutočná veľkosť"
+
+#: ../src/common/stockitem.cpp:212
+msgid "Actual Size"
+msgstr "&Skutočná veľkosť"
+
+#: ../src/common/stockitem.cpp:213
+msgid "Zoom to &Fit"
+msgstr "Prispôsobiť priblížením"
+
+#: ../src/common/stockitem.cpp:213
+msgid "Zoom to Fit"
+msgstr "Prispôsobiť priblížením"
+
+#: ../src/common/stockitem.cpp:214
+msgid "Zoom &In"
+msgstr "&Priblížiť"
+
+#: ../src/common/stockitem.cpp:215
+msgid "Zoom &Out"
+msgstr "&Oddialiť"
+
+#: ../src/common/stockitem.cpp:262
+msgid "Show about dialog"
+msgstr "Zobraziť dialóg O aplikácii"
+
+#: ../src/common/stockitem.cpp:263
+msgid "Copy selection"
+msgstr "Kopírovať výber"
+
+#: ../src/common/stockitem.cpp:264
+msgid "Cut selection"
+msgstr "Vystrihnúť výber"
+
+#: ../src/common/stockitem.cpp:265
+msgid "Delete selection"
+msgstr "Odstrániť výber"
+
+#: ../src/common/stockitem.cpp:266
+#, fuzzy
+msgid "Find in document"
+msgstr "Otvorte dokument HTML"
+
+#: ../src/common/stockitem.cpp:267
+msgid "Find and replace in document"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:268
+msgid "Paste selection"
+msgstr "Prilepiť výber"
+
+#: ../src/common/stockitem.cpp:269
+msgid "Quit this program"
+msgstr "Ukončí tento program"
+
+#: ../src/common/stockitem.cpp:270
+msgid "Redo last action"
+msgstr "Zopakuje poslednú vrátenú činnosť"
+
+#: ../src/common/stockitem.cpp:271
+msgid "Undo last action"
+msgstr "Vráti poslednú činnosť"
+
+#: ../src/common/stockitem.cpp:272
+#, fuzzy
+msgid "Create new document"
+msgstr "Vytvoriť nový priečinok"
+
+#: ../src/common/stockitem.cpp:273
+#, fuzzy
+msgid "Open an existing document"
+msgstr "Otvorte dokument HTML"
+
+#: ../src/common/stockitem.cpp:274
+msgid "Close current document"
+msgstr "Zatvoriť aktuálny dokument"
+
+#: ../src/common/stockitem.cpp:275
+msgid "Save current document"
+msgstr "Uložiť aktuálny dokument"
+
+#: ../src/common/stockitem.cpp:276
+msgid "Save current document with a different filename"
+msgstr "Uložiť aktuálny dokument pod odlišným názvom"
+
+#: ../src/common/strconv.cpp:2324
+#, c-format
+msgid "Conversion to charset '%s' doesn't work."
+msgstr "Konverzia do znakovej sady '%s' nefunguje."
+
+#: ../src/common/tarstrm.cpp:352 ../src/common/tarstrm.cpp:375
+#: ../src/common/tarstrm.cpp:406 ../src/generic/progdlgg.cpp:373
+msgid "unknown"
+msgstr "neznáme"
+
+#: ../src/common/tarstrm.cpp:774
+msgid "incomplete header block in tar"
+msgstr "neplatný blok hlavičky v tar"
+
+#: ../src/common/tarstrm.cpp:798
+msgid "checksum failure reading tar header block"
+msgstr "zlyhanie kontrolného súčtu pri čítaní bloku hlavičky tar"
+
+#: ../src/common/tarstrm.cpp:971
+msgid "invalid data in extended tar header"
+msgstr "neplatné dáta v rozšírenej tar hlavičke"
+
+#: ../src/common/tarstrm.cpp:981 ../src/common/tarstrm.cpp:1003
+#: ../src/common/tarstrm.cpp:1477 ../src/common/tarstrm.cpp:1499
+msgid "tar entry not open"
+msgstr "položka tar nebola otvorená"
+
+#: ../src/common/tarstrm.cpp:1023
+msgid "unexpected end of file"
+msgstr "neočakávaný koniec súboru"
+
+#: ../src/common/tarstrm.cpp:1297
+#, c-format
+msgid "%s did not fit the tar header for entry '%s'"
+msgstr "%s sa nehodilo do tar hlavičky záznamu '%s'"
+
+#: ../src/common/tarstrm.cpp:1359
+msgid "incorrect size given for tar entry"
+msgstr "bola zadaná neplatná veľkosť tar záznamu"
+
+#: ../src/common/textbuf.cpp:232
+#, c-format
+msgid "'%s' is probably a binary buffer."
+msgstr "'%s' je pravdepodobne binárny buffer."
+
+#: ../src/common/textcmn.cpp:1006 ../src/richtext/richtextctrl.cpp:3053
+msgid "File couldn't be loaded."
+msgstr "Súbor nmožno načítať."
+
+#: ../src/common/textfile.cpp:95
+#, fuzzy, c-format
+msgid "Failed to read text file \"%s\"."
+msgstr "Zlyhalo načítanie dokument zo súboru '%s'."
+
+#: ../src/common/textfile.cpp:160
+#, c-format
+msgid "can't write buffer '%s' to disk."
+msgstr "nemožno zapísať zásobník '%s' na disk."
+
+#: ../src/common/time.cpp:212
+msgid "Failed to get the local system time"
+msgstr "Zlyhalo zistenie miestneho systémového času"
+
+#: ../src/common/time.cpp:279
+msgid "wxGetTimeOfDay failed."
+msgstr "wxGetTimeOfDay zlyhal."
+
+#: ../src/common/translation.cpp:929
+#, c-format
+msgid "'%s' is not a valid message catalog."
+msgstr "'%s' nie je platný katalóg správ."
+
+#: ../src/common/translation.cpp:954
+msgid "Invalid message catalog."
+msgstr "Neplatný katalóg správ."
+
+#: ../src/common/translation.cpp:1013
+#, c-format
+msgid "Failed to parse Plural-Forms: '%s'"
+msgstr "Zlyhala analýza množného čísla: '%s'"
+
+#: ../src/common/translation.cpp:1723
+#, c-format
+msgid "using catalog '%s' from '%s'."
+msgstr "použitím katalógu '%s' z '%s'."
+
+#: ../src/common/translation.cpp:1816
+#, c-format
+msgid "Resource '%s' is not a valid message catalog."
+msgstr "Zdroj '%s' nie je platným katalógom správ."
+
+#: ../src/common/translation.cpp:1865
+msgid "Couldn't enumerate translations"
+msgstr "Nemožno vymenovať preklady"
+
+#: ../src/common/utilscmn.cpp:1145
+msgid "No default application configured for HTML files."
+msgstr "Pre súbory HTML nie je nakonfigurovaná žiadna predvolená aplikácia."
+
+#: ../src/common/utilscmn.cpp:1190
+#, c-format
+msgid "Failed to open URL \"%s\" in default browser."
+msgstr "Zlyhalo otvorenie adresy URL '%s' v predvolenom prehliadači."
+
+#: ../src/common/valtext.cpp:144
+msgid "Validation conflict"
+msgstr "Konflikt overovania"
+
+#: ../src/common/valtext.cpp:186
+msgid "Required information entry is empty."
+msgstr "Požadovaná položka informácie je prázdna."
+
+#: ../src/common/valtext.cpp:188
+#, c-format
+msgid "'%s' is one of the invalid strings"
+msgstr "'%s' je jeden z platných reťazcov"
+
+#: ../src/common/valtext.cpp:190
+#, c-format
+msgid "'%s' is not one of the valid strings"
+msgstr "'%s' nie je jeden z platných reťazcov"
+
+#: ../src/common/valtext.cpp:199
+#, fuzzy, c-format
+msgid "'%s' contains invalid character(s)"
+msgstr "'%s' obsahuje nepovolené znaky"
+
+#: ../src/common/webrequest.cpp:139
+#, fuzzy, c-format
+msgid "Error: %s (%d)"
+msgstr "Chyba: "
+
+#: ../src/common/webrequest.cpp:655
+#, c-format
+msgid ""
+"Not enough free disk space for download: %llu needed but only %llu available."
+msgstr ""
+
+#: ../src/common/webrequest.cpp:669
+#, fuzzy, c-format
+msgid "Failed to create temporary file in %s"
+msgstr "Zlyhalo vytvorenie dočasného mena súboru"
+
+#: ../src/common/webrequest_curl.cpp:1106
+#, fuzzy
+msgid "libcurl could not be initialized"
+msgstr "Súbor nie je možné načítať."
+
+#: ../src/common/webview.cpp:392
+#, fuzzy
+msgid "RunScriptAsync not supported"
+msgstr "Konverzie reťazcov nie sú podporované"
+
+#: ../src/common/webview.cpp:403 ../src/msw/webview_ie.cpp:1073
+#, c-format
+msgid "Error running JavaScript: %s"
+msgstr ""
+
+#: ../src/common/webview_chromium.cpp:858
+#, fuzzy, c-format
+msgid "Failed to set proxy \"%s\": %s"
+msgstr "Zlyhalo vytvorenie priečinku '%s'"
+
+#: ../src/common/webview_chromium.cpp:989
+msgid ""
+"Chromium can't be used because libcef.so wasn't loaded early enough; please "
+"relink the application or use LD_PRELOAD to load it earlier."
+msgstr ""
+
+#: ../src/common/webview_chromium.cpp:1108
+#, fuzzy
+msgid "Could not initialize Chromium"
+msgstr "Zlyhala inicializácia libnotify."
+
+#: ../src/common/webview_chromium.cpp:1616
+msgid "Show DevTools"
+msgstr ""
+
+#: ../src/common/webview_chromium.cpp:1617
+#, fuzzy
+msgid "Close DevTools"
+msgstr "Zatvoriť všetky"
+
+#: ../src/common/webview_chromium.cpp:1623
+msgid "Inspect"
+msgstr ""
+
+#: ../src/common/wincmn.cpp:1628
+msgid "This platform does not support background transparency."
+msgstr "Táto platforma nepodporuje priehľadnosť pozadia."
+
+#: ../src/common/wincmn.cpp:2097
+msgid "Could not transfer data to window"
+msgstr "Nemožno preniesť dáta do okna"
+
+#: ../src/common/windowid.cpp:240
+msgid "Out of window IDs.  Recommend shutting down application."
+msgstr "ID mimo okna.  Odporučte vypnúť aplikáciu."
+
+#: ../src/common/xpmdecod.cpp:678
+msgid "XPM: incorrect header format!"
+msgstr "XPM: nesprávny formát hlavičky!"
+
+#: ../src/common/xpmdecod.cpp:703
+#, c-format
+msgid "XPM: incorrect colour description in line %d"
+msgstr "XPM: nesprávny popis farby na riadku %d"
+
+#: ../src/common/xpmdecod.cpp:715 ../src/common/xpmdecod.cpp:724
+#, c-format
+msgid "XPM: malformed colour definition '%s' at line %d!"
+msgstr "XPM: zlá definícia farby '%s' na riadku %d!"
+
+#: ../src/common/xpmdecod.cpp:754
+msgid "XPM: no colors left to use for mask!"
+msgstr "XPM: pre masku už nie sú potrebné žiadne farby!"
+
+#: ../src/common/xpmdecod.cpp:781
+#, c-format
+msgid "XPM: truncated image data at line %d!"
+msgstr "XPM: orezané dáta obrázka na %d!"
+
+#: ../src/common/xpmdecod.cpp:795
+msgid "XPM: Malformed pixel data!"
+msgstr "XPM: Chybné údaje pixelov!"
+
+#: ../src/common/xti.cpp:492
+msgid "Illegal Parameter Count for Create Method"
+msgstr "Počet nelegálnych parametrov pre metódu vytvorenia"
+
+#: ../src/common/xti.cpp:504
+msgid "Illegal Parameter Count for ConstructObject Method"
+msgstr "Počet nelegálnych parametrov pre metódu ConstructObject"
+
+#: ../src/common/xtistrm.cpp:161
+#, c-format
+msgid "Create Parameter %s not found in declared RTTI Parameters"
+msgstr "Parameter vytvárania %s nebol nájdený v deklarovaných parametroch RTTI"
+
+#: ../src/common/xtistrm.cpp:290
+msgid "Illegal Object Class (Non-wxEvtHandler) as Event Source"
+msgstr "Trieda nelegálneho objektu (Non-wxEvtHandler) ako zdroj udalosti"
+
+#: ../src/common/xtistrm.cpp:313 ../src/common/xtixml.cpp:345
+#: ../src/common/xtixml.cpp:498
+msgid "Type must have enum - long conversion"
+msgstr "Typ musí mať enum - dlhú konverziu"
+
+#: ../src/common/xtistrm.cpp:400 ../src/common/xtistrm.cpp:415
+msgid "Invalid or Null Object ID passed to GetObjectClassInfo"
+msgstr "GetObjectClassInfo bolo odoslané neplatné alebo nulové ID objektu"
+
+#: ../src/common/xtistrm.cpp:405
+msgid "Unknown Object passed to GetObjectClassInfo"
+msgstr "GetObjectClassInfo bol daný ako parameter neznámy objekt"
+
+#: ../src/common/xtistrm.cpp:420
+msgid "Already Registered Object passed to SetObjectClassInfo"
+msgstr "Ako parameter SetObjectClassInfo bol zadaný už zaregistrovaný objekt"
+
+#: ../src/common/xtistrm.cpp:430
+msgid "Invalid or Null Object ID passed to HasObjectClassInfo"
+msgstr "HasObjectClassInfo sa odovzdalo neplatné alebo nulové ID objektu"
+
+#: ../src/common/xtistrm.cpp:460
+msgid "Passing a already registered object to SetObject"
+msgstr "Odovzdanie už registrovaného objektu do SetObject"
+
+#: ../src/common/xtistrm.cpp:471
+msgid "Passing an unknown object to GetObject"
+msgstr "Odovzdanie neznámeho objektu do GetObject"
+
+#: ../src/common/xtixml.cpp:229
+msgid "Forward hrefs are not supported"
+msgstr "Predné href odkazy nie sú podporované"
+
+#: ../src/common/xtixml.cpp:247
+#, c-format
+msgid "unknown class %s"
+msgstr "neznáma trieda %s"
+
+#: ../src/common/xtixml.cpp:253
+msgid "objects cannot have XML Text Nodes"
+msgstr "objekty nemôžu mať XML textové uzly"
+
+#: ../src/common/xtixml.cpp:258
+msgid "Objects must have an id attribute"
+msgstr "Objekty musia mať ID atribút"
+
+#: ../src/common/xtixml.cpp:267
+#, c-format
+msgid "Doubly used id : %d"
+msgstr "Duplicitne použitý id : %d"
+
+#: ../src/common/xtixml.cpp:316
+#, c-format
+msgid "Unknown Property %s"
+msgstr "Neznáme vlastnosť %s"
+
+#: ../src/common/xtixml.cpp:407
+msgid "A non empty collection must consist of 'element' nodes"
+msgstr "Neprázdna kolekcia musí pozostávať z uzlov 'element'"
+
+#: ../src/common/xtixml.cpp:478
+msgid "incorrect event handler string, missing dot"
+msgstr "nesprávny reťazec obsluhy udalosti, chýba bodka"
+
+#: ../src/common/zipstrm.cpp:559
+msgid "can't re-initialize zlib deflate stream"
+msgstr "nemožno znova inicializovať vypustený prúd zlib"
+
+#: ../src/common/zipstrm.cpp:584
+msgid "can't re-initialize zlib inflate stream"
+msgstr "nemožno znova inicializovať nafúknutý prúd zlib"
+
+#: ../src/common/zipstrm.cpp:1023
+msgid "Ignoring malformed extra data record, ZIP file may be corrupted"
+msgstr ""
+
+#: ../src/common/zipstrm.cpp:1502
+msgid "assuming this is a multi-part zip concatenated"
+msgstr "za predpokladu, že sa jedná o viacdielny zreťazený zips"
+
+#: ../src/common/zipstrm.cpp:1664
+msgid "invalid zip file"
+msgstr "neplatný zip súbor"
+
+#: ../src/common/zipstrm.cpp:1723
+msgid "can't find central directory in zip"
+msgstr "nemožno nájsť centrálny priečinok v zip"
+
+#: ../src/common/zipstrm.cpp:1812
+msgid "error reading zip central directory"
+msgstr "chyba pri čítaní zip centrálneho priečinka"
+
+#: ../src/common/zipstrm.cpp:1916
+msgid "error reading zip local header"
+msgstr "chyba pri čítaní zip miestnej hlavičky"
+
+#: ../src/common/zipstrm.cpp:1964
+msgid "bad zipfile offset to entry"
+msgstr "zlý posuv súboru zip pri vstupe"
+
+#: ../src/common/zipstrm.cpp:2031
+msgid "stored file length not in Zip header"
+msgstr "uložená dĺžka súboru nie je v hlavičke Zip"
+
+#: ../src/common/zipstrm.cpp:2045 ../src/common/zipstrm.cpp:2362
+msgid "unsupported Zip compression method"
+msgstr "nepodporovaná metóda kompresie Zip"
+
+#: ../src/common/zipstrm.cpp:2126
+#, c-format
+msgid "reading zip stream (entry %s): bad length"
+msgstr "čítanie toku zip (záznam %s): chybná dĺžka"
+
+#: ../src/common/zipstrm.cpp:2131
+#, c-format
+msgid "reading zip stream (entry %s): bad crc"
+msgstr "čítanie toku zip (záznam %s): chyba crc"
+
+#: ../src/common/zipstrm.cpp:2578
+#, fuzzy, c-format
+msgid "error writing zip entry '%s': file too large without ZIP64"
+msgstr "chyba pri zápise záznamu zip „%s“: zlý crc alebo dĺžka"
+
+#: ../src/common/zipstrm.cpp:2585
+#, c-format
+msgid "error writing zip entry '%s': bad crc or length"
+msgstr "chyba pri zápise záznamu zip „%s“: zlý crc alebo dĺžka"
+
+#: ../src/common/zstream.cpp:155 ../src/common/zstream.cpp:315
+msgid "Gzip not supported by this version of zlib"
+msgstr "Táto verzia zlib nepodporuje Gzip"
+
+#: ../src/common/zstream.cpp:182
+msgid "Can't initialize zlib inflate stream."
+msgstr "Nemožno inicializovať zlib inflate tok."
+
+#: ../src/common/zstream.cpp:241
+msgid "Can't read inflate stream: unexpected EOF in underlying stream."
+msgstr "Nemožno prečítať inflate tok: nočakávaný znak konca súboru v toku."
+
+#: ../src/common/zstream.cpp:248 ../src/common/zstream.cpp:423
+#, c-format
+msgid "zlib error %d"
+msgstr "chyba zlib %d"
+
+#: ../src/common/zstream.cpp:249
+#, c-format
+msgid "Can't read from inflate stream: %s"
+msgstr "Nemožno čítať z inflate toku: %s"
+
+#: ../src/common/zstream.cpp:343
+msgid "Can't initialize zlib deflate stream."
+msgstr "Nemožno inicializovať zlib deflate tok."
+
+#: ../src/common/zstream.cpp:424
+#, c-format
+msgid "Can't write to deflate stream: %s"
+msgstr "Nemožno zapísať do vypusteného prúdu: %s"
+
+#: ../src/dfb/bitmap.cpp:633 ../src/dfb/bitmap.cpp:667
+#, c-format
+msgid "No bitmap handler for type %d defined."
+msgstr "Nie je definovaný žiadny obslužný program bitmapy pre typ %d."
+
+#: ../src/dfb/evtloop.cpp:99
+msgid "Failed to read event from DirectFB pipe"
+msgstr "Nepodarilo sa načítať udalosť z kanálu DirectFB"
+
+#: ../src/dfb/evtloop.cpp:171
+msgid "Failed to switch DirectFB pipe to non-blocking mode"
+msgstr "Zlyhalo prepnutie potrubia DirectFB do neblokujúceho režimu"
+
+#: ../src/dfb/fontmgr.cpp:171
+#, c-format
+msgid "no fonts found in %s, using builtin font"
+msgstr "v jazyku %s sa nenašli žiadne písma, používajú sa zabudované písma"
+
+#: ../src/dfb/fontmgr.cpp:177
+msgid "Default font"
+msgstr "Predvolené písmo"
+
+#: ../src/dfb/fontmgr.cpp:195
+#, c-format
+msgid "Fonts index file %s disappeared while loading fonts."
+msgstr "Počas načítania písma zmizol indexový súbor typov písma %s."
+
+#: ../src/dfb/wrapdfb.cpp:60
+#, c-format
+msgid "DirectFB error %d occurred."
+msgstr "Vyskytla sa chyba DirectFB %d."
+
+#: ../src/generic/aboutdlgg.cpp:69
+msgid "Developed by "
+msgstr "Vyvinuté podľa "
+
+#: ../src/generic/aboutdlgg.cpp:72
+msgid "Documentation by "
+msgstr "Dokumentácia podľa "
+
+#: ../src/generic/aboutdlgg.cpp:75
+msgid "Graphics art by "
+msgstr "Grafické umenie podľa "
+
+#: ../src/generic/aboutdlgg.cpp:78
+msgid "Translations by "
+msgstr "Preložil "
+
+#: ../src/generic/aboutdlgg.cpp:133 ../src/osx/cocoa/aboutdlg.mm:83
+msgid "Version "
+msgstr "Verzia "
+
+#. TRANSLATORS: %s is application name
+#: ../src/generic/aboutdlgg.cpp:146 ../src/msw/aboutdlg.cpp:60
+#, c-format
+msgid "About %s"
+msgstr "O aplikácii %s"
+
+#: ../src/generic/aboutdlgg.cpp:181
+msgid "License"
+msgstr "Licencia"
+
+#: ../src/generic/aboutdlgg.cpp:184
+msgid "Developers"
+msgstr "Vývojári"
+
+#: ../src/generic/aboutdlgg.cpp:188
+msgid "Documentation writers"
+msgstr "Autori dokumentácie"
+
+#: ../src/generic/aboutdlgg.cpp:192
+msgid "Artists"
+msgstr "Účinkujúci"
+
+#: ../src/generic/aboutdlgg.cpp:196
+msgid "Translators"
+msgstr "Prekladatelia"
+
+#: ../src/generic/animateg.cpp:125
+msgid "No handler found for animation type."
+msgstr "Pre typ animácie sa nenašiel žiadny obslužný program."
+
+#: ../src/generic/animateg.cpp:133
+#, c-format
+msgid "No animation handler for type %ld defined."
+msgstr "Nie je definovaný žiadny obslužný program animácie pre typ %ld."
+
+#: ../src/generic/animateg.cpp:145
+#, c-format
+msgid "Animation file is not of type %ld."
+msgstr "Súbor s animáciou nie je typu %ld."
+
+#: ../src/generic/colrdlgg.cpp:154 ../src/gtk/colordlg.cpp:47
+msgid "Choose colour"
+msgstr "Vybrať farbu"
+
+#: ../src/generic/colrdlgg.cpp:357
+msgid "Red:"
+msgstr "Červená:"
+
+#: ../src/generic/colrdlgg.cpp:360
+msgid "Green:"
+msgstr "Zelená:"
+
+#: ../src/generic/colrdlgg.cpp:363
+msgid "Blue:"
+msgstr "Modrá:"
+
+#: ../src/generic/colrdlgg.cpp:372
+msgid "Opacity:"
+msgstr "Nepriehľadnosť:"
+
+#: ../src/generic/colrdlgg.cpp:384
+msgid "Add to custom colours"
+msgstr "Pridať k vlastným farbám"
+
+#: ../src/generic/creddlgg.cpp:56
+msgid "Username:"
+msgstr ""
+
+#: ../src/generic/creddlgg.cpp:63
+msgid "Password:"
+msgstr ""
+
+#. TRANSLATORS: Name of Boolean true value
+#: ../src/generic/datavgen.cpp:1178
+msgid "true"
+msgstr "pravda"
+
+#. TRANSLATORS: Name of Boolean false value
+#: ../src/generic/datavgen.cpp:1180
+msgid "false"
+msgstr "nepravda"
+
+#: ../src/generic/datavgen.cpp:6897
+#, c-format
+msgid "Row %i"
+msgstr "Riadok %i"
+
+#. TRANSLATORS: Action for manipulating a tree control
+#: ../src/generic/datavgen.cpp:6987
+msgid "Collapse"
+msgstr "Zvinúť"
+
+#. TRANSLATORS: Action for manipulating a tree control
+#: ../src/generic/datavgen.cpp:6990
+msgid "Expand"
+msgstr "Rozvinúť"
+
+#. TRANSLATORS: Name of data view control and number of rows
+#: ../src/generic/datavgen.cpp:7011
+#, c-format
+msgid "%s (%d items)"
+msgstr "%s (%d položiek)"
+
+#: ../src/generic/datavgen.cpp:7062
+#, c-format
+msgid "Column %u"
+msgstr "Stĺpec %u"
+
+#. TRANSLATORS: Keystroke for manipulating a tree control
+#: ../src/generic/datavgen.cpp:7131 ../src/richtext/richtextbulletspage.cpp:189
+#: ../src/richtext/richtextbulletspage.cpp:192
+#: ../src/richtext/richtextbulletspage.cpp:193
+#: ../src/richtext/richtextliststylepage.cpp:252
+#: ../src/richtext/richtextliststylepage.cpp:255
+#: ../src/richtext/richtextliststylepage.cpp:256
+#: ../src/richtext/richtextsizepage.cpp:248
+msgid "Left"
+msgstr "Zľava"
+
+#. TRANSLATORS: Keystroke for manipulating a tree control
+#: ../src/generic/datavgen.cpp:7134 ../src/richtext/richtextbulletspage.cpp:191
+#: ../src/richtext/richtextliststylepage.cpp:254
+#: ../src/richtext/richtextsizepage.cpp:249
+msgid "Right"
+msgstr "Vpravo"
+
+#: ../src/generic/datectlg.cpp:90
+#, c-format
+msgid ""
+"\"%s\" is not in the expected date format, please enter it as e.g. \"%s\"."
+msgstr ""
+
+#: ../src/generic/datectlg.cpp:94
+#, fuzzy
+msgid "Invalid date"
+msgstr "PCX: neplatný obrázok"
+
+#: ../src/generic/dbgrptg.cpp:159
+#, c-format
+msgid "Open file \"%s\""
+msgstr "Otvoriť súbor '%s'"
+
+#: ../src/generic/dbgrptg.cpp:170
+#, c-format
+msgid "Enter command to open file \"%s\":"
+msgstr "Zadajte príkaz pre otvorenie súboru '%s':"
+
+#: ../src/generic/dbgrptg.cpp:230
+msgid "Executable files (*.exe)|*.exe|"
+msgstr "Spustiteľné súbory (*.exe)|*.exe|"
+
+#: ../src/generic/dbgrptg.cpp:300
+#, c-format
+msgid "Debug report \"%s\""
+msgstr "Hlásenie o chybe '%s'"
+
+#: ../src/generic/dbgrptg.cpp:316
+msgid "A debug report has been generated in the directory\n"
+msgstr "V adresári bolo vytvorené hlásenie o chybe\n"
+
+#: ../src/generic/dbgrptg.cpp:317
+#, fuzzy
+msgid "The following debug report will be generated\n"
+msgstr "*** Bolo vytvorené hlásenie o chybe\n"
+
+#: ../src/generic/dbgrptg.cpp:321
+msgid ""
+"The report contains the files listed below. If any of these files contain "
+"private information,\n"
+"please uncheck them and they will be removed from the report.\n"
+msgstr ""
+"Správa obsahuje súbory uvedené nižšie. Ak niektorý z týchto súborov obsahuje "
+"súkromné informácie,\n"
+"zrušte ich zaškrtnutie a budú z prehľadu odstránené.\n"
+
+#: ../src/generic/dbgrptg.cpp:323
+msgid ""
+"If you wish to suppress this debug report completely, please choose the "
+"\"Cancel\" button,\n"
+"but be warned that it may hinder improving the program, so if\n"
+"at all possible please do continue with the report generation.\n"
+msgstr ""
+"Ak si želáte kompletne potlačiť toto hlásenie o chybe, zvoľte prosím "
+"tlačidlo \"Zrušiť\",\n"
+"ale buďte varovaní, že to môže zamedziť zlepšovanie programu, preto ak je "
+"to\n"
+"možné, pokračujte, prosím, v tvorbe hlásenia o chybe.\n"
+
+#: ../src/generic/dbgrptg.cpp:325
+msgid "              Thank you and we're sorry for the inconvenience!\n"
+msgstr "              Ďakujeme a prepáčte za nepríjemnosti!\n"
+
+#: ../src/generic/dbgrptg.cpp:333
+msgid "&Debug report preview:"
+msgstr "&Náhľad správy ladenia:"
+
+#: ../src/generic/dbgrptg.cpp:339
+msgid "&View..."
+msgstr "&Zobrazenie..."
+
+#: ../src/generic/dbgrptg.cpp:359
+msgid "&Notes:"
+msgstr "&Poznámky:"
+
+#: ../src/generic/dbgrptg.cpp:361
+msgid ""
+"If you have any additional information pertaining to this bug\n"
+"report, please enter it here and it will be joined to it:"
+msgstr ""
+"Ak máte dodatočné informácie týkajúce sa tohto hlásenia o chybe\n"
+"zadajte ich, prosím, sem a budú k nemu pripojené:"
+
+#: ../src/generic/dcpsg.cpp:1627
+msgid "Cannot open file for PostScript printing!"
+msgstr "Nemožno otvoriť súbor pre tlač PostScript!"
+
+#: ../src/generic/dirctrlg.cpp:402
+msgid "Computer"
+msgstr "Počítač"
+
+#: ../src/generic/dirctrlg.cpp:404
+msgid "Sections"
+msgstr "Sekcie"
+
+#: ../src/generic/dirctrlg.cpp:482
+msgid "Home directory"
+msgstr "Domáci priečinok"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/generic/dirctrlg.cpp:484 ../src/propgrid/advprops.cpp:811
+msgid "Desktop"
+msgstr "Plocha"
+
+#: ../src/generic/dirctrlg.cpp:528 ../src/generic/filectrlg.cpp:752
+msgid "Illegal directory name."
+msgstr "Neplatný názov adresára."
+
+#: ../src/generic/dirctrlg.cpp:528 ../src/generic/dirctrlg.cpp:546
+#: ../src/generic/dirctrlg.cpp:557 ../src/generic/dirdlgg.cpp:317
+#: ../src/generic/filectrlg.cpp:638 ../src/generic/filectrlg.cpp:752
+#: ../src/generic/filectrlg.cpp:766 ../src/generic/filectrlg.cpp:782
+#: ../src/generic/filectrlg.cpp:1356 ../src/generic/filectrlg.cpp:1387
+#: ../src/generic/filedlgg.cpp:362 ../src/gtk/filedlg.cpp:76
+msgid "Error"
+msgstr "Chyba"
+
+#: ../src/generic/dirctrlg.cpp:546 ../src/generic/filectrlg.cpp:766
+msgid "File name exists already."
+msgstr "Názov súboru už existuje."
+
+#: ../src/generic/dirctrlg.cpp:557 ../src/generic/dirdlgg.cpp:317
+#: ../src/generic/filectrlg.cpp:638 ../src/generic/filectrlg.cpp:782
+msgid "Operation not permitted."
+msgstr "Operácia nie je povolená."
+
+#: ../src/generic/dirdlgg.cpp:107 ../src/generic/filedlgg.cpp:207
+msgid "Create new directory"
+msgstr "Vytvoriť nový priečinok"
+
+#: ../src/generic/dirdlgg.cpp:112 ../src/generic/filedlgg.cpp:203
+msgid "Go to home directory"
+msgstr "Ísť do domáceho priečinka"
+
+#: ../src/generic/dirdlgg.cpp:143
+msgid "Show &hidden directories"
+msgstr "Zobraziť &skryté priečinky"
+
+#: ../src/generic/dirdlgg.cpp:196
+#, c-format
+msgid ""
+"The directory '%s' does not exist\n"
+"Create it now?"
+msgstr ""
+"Priečinok '%s' neexistuje\n"
+"Chcete ho teraz vytvoriť?"
+
+#: ../src/generic/dirdlgg.cpp:198
+msgid "Directory does not exist"
+msgstr "Priečinok neexistuje"
+
+#: ../src/generic/dirdlgg.cpp:214
+#, c-format
+msgid ""
+"Failed to create directory '%s'\n"
+"(Do you have the required permissions?)"
+msgstr ""
+"Zlyhalo vytvorenie priečinku '%s'\n"
+"(Máte potrebné oprávnenia?)"
+
+#: ../src/generic/dirdlgg.cpp:216
+msgid "Error creating directory"
+msgstr "Chyba pri vytváraní priečinka"
+
+#: ../src/generic/dirdlgg.cpp:281
+msgid "You cannot add a new directory to this section."
+msgstr "Do tejto sekcie nemôžete pridať nový priečinok."
+
+#: ../src/generic/dirdlgg.cpp:282
+msgid "Create directory"
+msgstr "Vytvoriť priečinok"
+
+#: ../src/generic/dirdlgg.cpp:291 ../src/generic/dirdlgg.cpp:301
+#: ../src/generic/filectrlg.cpp:614 ../src/generic/filectrlg.cpp:623
+msgid "NewName"
+msgstr "Nový názov"
+
+#: ../src/generic/editlbox.cpp:135
+msgid "Edit item"
+msgstr "Upraviť položku"
+
+#: ../src/generic/editlbox.cpp:143
+msgid "New item"
+msgstr "Nová položka"
+
+#: ../src/generic/editlbox.cpp:151
+msgid "Delete item"
+msgstr "Odstrániť položku"
+
+#: ../src/generic/editlbox.cpp:159
+msgid "Move up"
+msgstr "Posunúť hore"
+
+#: ../src/generic/editlbox.cpp:164
+msgid "Move down"
+msgstr "Posunúť dole"
+
+#: ../src/generic/fdrepdlg.cpp:108
+msgid "Search for:"
+msgstr "Hľadať pre:"
+
+#: ../src/generic/fdrepdlg.cpp:120
+msgid "Replace with:"
+msgstr "Nahradiť čím:"
+
+#: ../src/generic/fdrepdlg.cpp:140
+msgid "Whole word"
+msgstr "Celé slová"
+
+#: ../src/generic/fdrepdlg.cpp:143
+msgid "Match case"
+msgstr "Rozlišovať malé/veľké"
+
+#: ../src/generic/fdrepdlg.cpp:156
+msgid "Search direction"
+msgstr "Smer hľadania"
+
+#: ../src/generic/fdrepdlg.cpp:175
+msgid "&Replace"
+msgstr "&Nahradiť"
+
+#: ../src/generic/fdrepdlg.cpp:178
+msgid "Replace &all"
+msgstr "Nahradiť &všetko"
+
+#: ../src/generic/filectrlg.cpp:246 ../src/generic/filectrlg.cpp:269
+msgid "<DIR>"
+msgstr "<PRIEČINOK>"
+
+#: ../src/generic/filectrlg.cpp:248 ../src/generic/filectrlg.cpp:271
+msgid "<LINK>"
+msgstr "<ODKAZ>"
+
+#: ../src/generic/filectrlg.cpp:250 ../src/generic/filectrlg.cpp:273
+msgid "<DRIVE>"
+msgstr "<JEDNOTKA>"
+
+#: ../src/generic/filectrlg.cpp:275
+#, c-format
+msgid "%ld byte"
+msgid_plural "%ld bytes"
+msgstr[0] "%ld bajt"
+msgstr[1] "%ld bajty"
+msgstr[2] "%ld bajtov"
+
+#: ../src/generic/filectrlg.cpp:420
+msgid "Name"
+msgstr "Názov"
+
+#: ../src/generic/filectrlg.cpp:421 ../src/richtext/richtextformatdlg.cpp:361
+#: ../src/richtext/richtextsizepage.cpp:298
+msgid "Size"
+msgstr "Veľkosť"
+
+#: ../src/generic/filectrlg.cpp:422
+msgid "Type"
+msgstr "Typ"
+
+#: ../src/generic/filectrlg.cpp:423
+msgid "Modified"
+msgstr "Upravený"
+
+#: ../src/generic/filectrlg.cpp:426
+msgid "Permissions"
+msgstr "Povolenia"
+
+#: ../src/generic/filectrlg.cpp:429
+msgid "Attributes"
+msgstr "Atribúty"
+
+#: ../src/generic/filectrlg.cpp:936
+msgid "Current directory:"
+msgstr "Aktuálny priečinok:"
+
+#: ../src/generic/filectrlg.cpp:979
+msgid "Show &hidden files"
+msgstr "Zobraziť &skryté súbory"
+
+#: ../src/generic/filectrlg.cpp:1355
+msgid "Illegal file specification."
+msgstr "Neplatná špecifikácia súboru."
+
+#: ../src/generic/filectrlg.cpp:1387
+msgid "Directory doesn't exist."
+msgstr "Priečinok neexistuje."
+
+#: ../src/generic/filedlgg.cpp:195
+msgid "View files as a list view"
+msgstr "Zobraziť súbory v náhľade zoznamu"
+
+#: ../src/generic/filedlgg.cpp:197
+msgid "View files as a detailed view"
+msgstr "Zobraziť súbory v detailnom pohľade"
+
+#: ../src/generic/filedlgg.cpp:200
+msgid "Go to parent directory"
+msgstr "Ísť do nadradeného priečinka"
+
+#: ../src/generic/filedlgg.cpp:351 ../src/gtk/filedlg.cpp:59
+#, c-format
+msgid "File '%s' already exists, do you really want to overwrite it?"
+msgstr "Súbor '%s' už existuje, naozaj ho chcete prepísať?"
+
+#: ../src/generic/filedlgg.cpp:354 ../src/gtk/filedlg.cpp:62
+msgid "Confirm"
+msgstr "Potvrdiť"
+
+#: ../src/generic/filedlgg.cpp:362 ../src/gtk/filedlg.cpp:75
+msgid "Please choose an existing file."
+msgstr "Vyberte, prosím, existujúci súbor."
+
+#: ../src/generic/filepickerg.cpp:64
+msgid "..."
+msgstr "..."
+
+#: ../src/generic/fontdlgg.cpp:76 ../src/richtext/richtextformatdlg.cpp:519
+msgid "ABCDEFGabcdefg12345"
+msgstr "ABCDabcd12345žšťď$€¢"
+
+#: ../src/generic/fontdlgg.cpp:315
+msgid "Roman"
+msgstr "Rímske"
+
+#: ../src/generic/fontdlgg.cpp:316
+msgid "Decorative"
+msgstr "Okrasné"
+
+#: ../src/generic/fontdlgg.cpp:317
+msgid "Modern"
+msgstr "Moderný"
+
+#: ../src/generic/fontdlgg.cpp:318
+msgid "Script"
+msgstr "Skript"
+
+#: ../src/generic/fontdlgg.cpp:319
+msgid "Swiss"
+msgstr "Švajčiarske"
+
+#: ../src/generic/fontdlgg.cpp:320
+msgid "Teletype"
+msgstr "Ďalekopis"
+
+#: ../src/generic/fontdlgg.cpp:321 ../src/generic/fontdlgg.cpp:324
+msgid "Normal"
+msgstr "Normálna"
+
+#: ../src/generic/fontdlgg.cpp:323
+msgid "Slant"
+msgstr "Šikmý"
+
+#: ../src/generic/fontdlgg.cpp:325
+msgid "Light"
+msgstr "Svetlá"
+
+#: ../src/generic/fontdlgg.cpp:363
+msgid "&Font family:"
+msgstr "&Príbuzné písmo:"
+
+#: ../src/generic/fontdlgg.cpp:367 ../src/generic/fontdlgg.cpp:369
+msgid "The font family."
+msgstr "Príbuzné písma."
+
+#: ../src/generic/fontdlgg.cpp:374 ../src/richtext/richtextstylepage.cpp:105
+msgid "&Style:"
+msgstr "&Štýl:"
+
+#: ../src/generic/fontdlgg.cpp:378 ../src/generic/fontdlgg.cpp:380
+msgid "The font style."
+msgstr "Štýl písma."
+
+#: ../src/generic/fontdlgg.cpp:385
+msgid "&Weight:"
+msgstr "&Váha:"
+
+#: ../src/generic/fontdlgg.cpp:389 ../src/generic/fontdlgg.cpp:391
+msgid "The font weight."
+msgstr "Hrúbka písma."
+
+#: ../src/generic/fontdlgg.cpp:399
+msgid "C&olour:"
+msgstr "&Farba:"
+
+#: ../src/generic/fontdlgg.cpp:407 ../src/generic/fontdlgg.cpp:409
+msgid "The font colour."
+msgstr "Farba písma."
+
+#: ../src/generic/fontdlgg.cpp:415
+msgid "&Point size:"
+msgstr "&Veľkosť bodu:"
+
+#: ../src/generic/fontdlgg.cpp:420 ../src/generic/fontdlgg.cpp:422
+#: ../src/generic/fontdlgg.cpp:426 ../src/generic/fontdlgg.cpp:428
+msgid "The font point size."
+msgstr "Veľkosť bodu písma."
+
+#: ../src/generic/fontdlgg.cpp:439 ../src/generic/fontdlgg.cpp:441
+msgid "Whether the font is underlined."
+msgstr "Či je písmo podčiarknuté."
+
+#: ../src/generic/fontdlgg.cpp:448 ../src/html/helpwnd.cpp:1215
+msgid "Preview:"
+msgstr "Náhľad:"
+
+#: ../src/generic/fontdlgg.cpp:452 ../src/generic/fontdlgg.cpp:454
+msgid "Shows the font preview."
+msgstr "Zobrazí náhľad písma."
+
+#: ../src/generic/fontdlgg.cpp:464 ../src/generic/fontdlgg.cpp:483
+msgid "Click to cancel the font selection."
+msgstr "Kliknite pre zrušenie výberu písma."
+
+#: ../src/generic/fontdlgg.cpp:469 ../src/generic/fontdlgg.cpp:471
+#: ../src/generic/fontdlgg.cpp:476 ../src/generic/fontdlgg.cpp:478
+msgid "Click to confirm the font selection."
+msgstr "Kliknite pre potvrdenie výberu písma."
+
+#: ../src/generic/fontpickerg.cpp:50 ../src/gtk/fontdlg.cpp:77
+msgid "Choose font"
+msgstr "Vybrať písmo"
+
+#: ../src/generic/grid.cpp:6542
+msgid ""
+"Error copying grid to the clipboard. Either selected cells were not "
+"contiguous or no cell was selected."
+msgstr ""
+
+#: ../src/generic/grid.cpp:12739
+#, fuzzy
+msgid "Grid Corner"
+msgstr "Rohové"
+
+#: ../src/generic/grid.cpp:12741
+#, fuzzy, c-format
+msgid "Column %s Header"
+msgstr "Stĺpec %u"
+
+#: ../src/generic/grid.cpp:12743
+#, c-format
+msgid "Row %s Header"
+msgstr ""
+
+#: ../src/generic/grid.cpp:12745
+#, fuzzy, c-format
+msgid "Column %s: %s"
+msgstr "Stĺpec %u"
+
+#: ../src/generic/grid.cpp:12749
+#, fuzzy, c-format
+msgid "Row %s: %s"
+msgstr "\t%s: %s\n"
+
+#: ../src/generic/grid.cpp:12753
+#, c-format
+msgid "Row %s, Column %s: %s"
+msgstr ""
+
+#: ../src/generic/helpext.cpp:257
+#, c-format
+msgid "Help directory \"%s\" not found."
+msgstr "Priečinok Pomocníka '%s' nenájdený."
+
+#: ../src/generic/helpext.cpp:265
+#, c-format
+msgid "Help file \"%s\" not found."
+msgstr "Súbor Pomocníka '%s' nenájdený."
+
+#: ../src/generic/helpext.cpp:284
+#, c-format
+msgid "Line %lu of map file \"%s\" has invalid syntax, skipped."
+msgstr "Riadok %lu mapového súboru '%s' má neplatnú syntax, preskočené."
+
+#: ../src/generic/helpext.cpp:292
+#, c-format
+msgid "No valid mappings found in the file \"%s\"."
+msgstr "V súbore '%s' sa nenašli žiadne platné priradenia."
+
+#: ../src/generic/helpext.cpp:435
+msgid "No entries found."
+msgstr "Neboli nájdené žiadne záznamy."
+
+#: ../src/generic/helpext.cpp:444 ../src/generic/helpext.cpp:445
+msgid "Help Index"
+msgstr "Index Pomocníka"
+
+#: ../src/generic/helpext.cpp:448
+msgid "Relevant entries:"
+msgstr "Relevantné položky:"
+
+#: ../src/generic/helpext.cpp:449
+msgid "Entries found"
+msgstr "Nájdených záznamov"
+
+#: ../src/generic/hyperlinkg.cpp:170
+msgid "&Copy URL"
+msgstr "&Kopírovať URL"
+
+#: ../src/generic/infobar.cpp:119
+msgid "Hide this notification message."
+msgstr "Skryť túto správu s upozornením."
+
+#. TRANSLATORS: %s will be either the application name or "Application"
+#: ../src/generic/logg.cpp:257
+#, c-format
+msgid "%s Error"
+msgstr "%s Chyba"
+
+#. TRANSLATORS: %s will be either the application name or "Application"
+#: ../src/generic/logg.cpp:263
+#, c-format
+msgid "%s Warning"
+msgstr "%s Varovanie"
+
+#. TRANSLATORS: %s will be either the application name or "Application"
+#: ../src/generic/logg.cpp:273
+#, c-format
+msgid "%s Information"
+msgstr "%s Informácia"
+
+#: ../src/generic/logg.cpp:276
+msgid "Application"
+msgstr "Aplikácia"
+
+#: ../src/generic/logg.cpp:549
+msgid "Save log contents to file"
+msgstr "Uložiť obsah záznamu do súboru"
+
+#: ../src/generic/logg.cpp:551
+msgid "C&lear"
+msgstr "&Zmazať"
+
+#: ../src/generic/logg.cpp:551
+msgid "Clear the log contents"
+msgstr "Vymazať obsah záznamu"
+
+#: ../src/generic/logg.cpp:553
+msgid "Close this window"
+msgstr "Zatvoriť toto okno"
+
+#: ../src/generic/logg.cpp:554
+msgid "&Log"
+msgstr "&Záznam"
+
+#: ../src/generic/logg.cpp:610 ../src/generic/logg.cpp:992
+msgid "Can't save log contents to file."
+msgstr "Nemožno zapísať obsah záznamu do súboru."
+
+#: ../src/generic/logg.cpp:613
+#, c-format
+msgid "Log saved to the file '%s'."
+msgstr "Záznam bol uložený do súboru '%s'."
+
+#: ../src/generic/logg.cpp:719
+msgid "&Details"
+msgstr "&Podrobnosti"
+
+#: ../src/generic/logg.cpp:972
+msgid "Failed to copy dialog contents to the clipboard."
+msgstr "Zlyhalo skopírovanie obsahu dialógového okna do schránky."
+
+#: ../src/generic/logg.cpp:1022
+#, c-format
+msgid "Append log to file '%s' (choosing [No] will overwrite it)?"
+msgstr "Pridať záznam do súboru '%s' (voľba [Nie] ho prepíše)?"
+
+#: ../src/generic/logg.cpp:1024
+msgid "Question"
+msgstr "Otázka"
+
+#: ../src/generic/logg.cpp:1038
+msgid "invalid message box return value"
+msgstr "neplatná návratová hodnota okna so správou"
+
+#: ../src/generic/notifmsgg.cpp:129
+msgid "Notice"
+msgstr "Poznámky"
+
+#: ../src/generic/preferencesg.cpp:118
+#, c-format
+msgid "%s Preferences"
+msgstr "Predvoľby %s"
+
+#: ../src/generic/printps.cpp:143
+msgid "Printing..."
+msgstr "Tlačí sa..."
+
+#: ../src/generic/printps.cpp:160 ../src/gtk/print.cpp:1076
+#: ../src/msw/printwin.cpp:235
+msgid "Could not start printing."
+msgstr "Nemožno začať tlačiť."
+
+#: ../src/generic/printps.cpp:183
+#, c-format
+msgid "Printing page %d..."
+msgstr "Tlačí sa stránka %d..."
+
+#: ../src/generic/prntdlgg.cpp:171
+msgid "Printer options"
+msgstr "Voľby tlačiarne"
+
+#: ../src/generic/prntdlgg.cpp:176
+msgid "Print to File"
+msgstr "Tlačiť do súboru"
+
+#: ../src/generic/prntdlgg.cpp:179
+msgid "Setup..."
+msgstr "Nastavenie..."
+
+#: ../src/generic/prntdlgg.cpp:187
+msgid "Printer:"
+msgstr "Tlačiareň:"
+
+#: ../src/generic/prntdlgg.cpp:195
+msgid "Status:"
+msgstr "Stav:"
+
+#: ../src/generic/prntdlgg.cpp:206
+msgid "All"
+msgstr "Všetky"
+
+#: ../src/generic/prntdlgg.cpp:207
+msgid "Pages"
+msgstr "Strán"
+
+#: ../src/generic/prntdlgg.cpp:215
+msgid "Print Range"
+msgstr "Rozsah tlače"
+
+#: ../src/generic/prntdlgg.cpp:229
+msgid "From:"
+msgstr "Od:"
+
+#: ../src/generic/prntdlgg.cpp:233
+msgid "To:"
+msgstr "Do:"
+
+#: ../src/generic/prntdlgg.cpp:238
+msgid "Copies:"
+msgstr "Kópie:"
+
+#: ../src/generic/prntdlgg.cpp:288
+msgid "PostScript file"
+msgstr "Súbor PostScript"
+
+#: ../src/generic/prntdlgg.cpp:439
+msgid "Print Setup"
+msgstr "Nastavenie tlače"
+
+#: ../src/generic/prntdlgg.cpp:483
+msgid "Printer"
+msgstr "Tlačiareň"
+
+#: ../src/generic/prntdlgg.cpp:501
+msgid "Default printer"
+msgstr "Predvolená tlačiareň"
+
+#: ../src/generic/prntdlgg.cpp:595 ../src/generic/prntdlgg.cpp:782
+#: ../src/generic/prntdlgg.cpp:822 ../src/generic/prntdlgg.cpp:835
+#: ../src/generic/prntdlgg.cpp:1031 ../src/generic/prntdlgg.cpp:1036
+msgid "Paper size"
+msgstr "Paper size"
+
+#: ../src/generic/prntdlgg.cpp:604 ../src/generic/prntdlgg.cpp:847
+msgid "Portrait"
+msgstr "Portrét"
+
+#: ../src/generic/prntdlgg.cpp:605 ../src/generic/prntdlgg.cpp:848
+msgid "Landscape"
+msgstr "Krajinka"
+
+#: ../src/generic/prntdlgg.cpp:607 ../src/generic/prntdlgg.cpp:849
+msgid "Orientation"
+msgstr "Orientácia"
+
+#: ../src/generic/prntdlgg.cpp:610
+msgid "Options"
+msgstr "Možnosti"
+
+#: ../src/generic/prntdlgg.cpp:612
+msgid "Print in colour"
+msgstr "Tlačiť farebne"
+
+#: ../src/generic/prntdlgg.cpp:621
+msgid "Print spooling"
+msgstr "Zaradenie tlače"
+
+#: ../src/generic/prntdlgg.cpp:623
+msgid "Printer command:"
+msgstr "Príkaz tlačiarne:"
+
+#: ../src/generic/prntdlgg.cpp:631
+msgid "Printer options:"
+msgstr "Voľby tlačiarne:"
+
+#: ../src/generic/prntdlgg.cpp:860
+msgid "Left margin (mm):"
+msgstr "Ľavý okraj (mm):"
+
+#: ../src/generic/prntdlgg.cpp:861
+msgid "Top margin (mm):"
+msgstr "Horný okraj (mm):"
+
+#: ../src/generic/prntdlgg.cpp:872
+msgid "Right margin (mm):"
+msgstr "Pravý okraj (mm):"
+
+#: ../src/generic/prntdlgg.cpp:873
+msgid "Bottom margin (mm):"
+msgstr "Spodný okraj (mm):"
+
+#: ../src/generic/prntdlgg.cpp:896
+msgid "Printer..."
+msgstr "Tlačiareň..."
+
+#: ../src/generic/progdlgg.cpp:246
+msgid "&Skip"
+msgstr "&Preskočiť"
+
+#: ../src/generic/progdlgg.cpp:347 ../src/generic/progdlgg.cpp:626
+msgid "Unknown"
+msgstr "Neznámy"
+
+#: ../src/generic/progdlgg.cpp:451 ../src/msw/progdlg.cpp:526
+msgid "Done."
+msgstr "Hotovo."
+
+#: ../src/generic/srchctlg.cpp:55 ../src/gtk/srchctrl.cpp:206
+#: ../src/html/helpwnd.cpp:530 ../src/html/helpwnd.cpp:545
+msgid "Search"
+msgstr "Hľadať"
+
+#: ../src/generic/tabg.cpp:1026
+msgid "Could not find tab for id"
+msgstr "Nemožno nájsť tabulátor pre id"
+
+#: ../src/generic/tipdlg.cpp:136
+msgid "Tips not available, sorry!"
+msgstr "Tipy nie sú dostupné, prepáčte!"
+
+#: ../src/generic/tipdlg.cpp:197
+msgid "Tip of the Day"
+msgstr "Tip dňa"
+
+#: ../src/generic/tipdlg.cpp:207
+msgid "Did you know..."
+msgstr "Viete, že..."
+
+#: ../src/generic/tipdlg.cpp:232
+msgid "&Show tips at startup"
+msgstr "&Zobrazovať tipy pri spustení"
+
+#: ../src/generic/tipdlg.cpp:236
+msgid "&Next Tip"
+msgstr "&Ďalší tip"
+
+#: ../src/generic/wizard.cpp:411
+msgid "&Next >"
+msgstr "&Ďalej >"
+
+#: ../src/generic/wizard.cpp:412
+msgid "&Finish"
+msgstr "&Dokončiť"
+
+#: ../src/generic/wizard.cpp:420
+msgid "< &Back"
+msgstr "< &Späť"
+
+#: ../src/gtk/aboutdlg.cpp:204
+msgid "translator-credits"
+msgstr "prekladatelia"
+
+#: ../src/gtk/app.cpp:517
+msgid ""
+"WARNING: using XIM input method is unsupported and may result in problems "
+"with input handling and flickering. Consider unsetting GTK_IM_MODULE or "
+"setting to \"ibus\"."
+msgstr ""
+
+#: ../src/gtk/app.cpp:569
+msgid "Unable to initialize GTK+, is DISPLAY set properly?"
+msgstr "Nemožno inicializovať GTK+, je DISPLAY nastavený správne?"
+
+#: ../src/gtk/filedlg.cpp:89 ../src/gtk/filepicker.cpp:255
+#, c-format
+msgid "Changing current directory to \"%s\" failed"
+msgstr "Zmena súčasného priečinka na '%s' zlyhala"
+
+#: ../src/gtk/font.cpp:548
+msgid ""
+"Using private fonts is not supported on this system: Pango library is too "
+"old, 1.38 or later required."
+msgstr ""
+
+#: ../src/gtk/font.cpp:558
+#, fuzzy
+msgid "Failed to create font configuration object."
+msgstr "Zlyhala aktualizácia používateľského konfiguračného súboru."
+
+#: ../src/gtk/font.cpp:568
+#, fuzzy, c-format
+msgid "Failed to add custom font \"%s\"."
+msgstr "Zlyhalo načítanie dokument zo súboru '%s'."
+
+#: ../src/gtk/font.cpp:576
+#, fuzzy
+msgid "Failed to register font configuration using private fonts."
+msgstr "Zlyhala aktualizácia používateľského konfiguračného súboru."
+
+#: ../src/gtk/glcanvas.cpp:117 ../src/gtk/glcanvas.cpp:132
+#, fuzzy
+msgid "Fatal Error"
+msgstr "Osudová chyba"
+
+#: ../src/gtk/glcanvas.cpp:117
+msgid ""
+"This program wasn't compiled with EGL support required under Wayland, "
+"either\n"
+"install EGL libraries and rebuild or run it under X11 backend by setting\n"
+"environment variable GDK_BACKEND=x11 before starting your program."
+msgstr ""
+
+#: ../src/gtk/glcanvas.cpp:132
+msgid ""
+"wxGLCanvas is only supported on Wayland and X11 currently.  You may be able "
+"to\n"
+"work around this by setting environment variable GDK_BACKEND=x11 before\n"
+"starting your program."
+msgstr ""
+
+#: ../src/gtk/mdi.cpp:433
+msgid "MDI child"
+msgstr "MDI potomok"
+
+#: ../src/gtk/power.cpp:188
+#, fuzzy, c-format
+msgid "Failed to open D-Bus connection to the login manager: %s"
+msgstr "Nepodarilo sa %s vytáčané spojenie: %s"
+
+#: ../src/gtk/power.cpp:214
+#, fuzzy
+msgid "wxWidgets application"
+msgstr "Aplikácia"
+
+#: ../src/gtk/power.cpp:226
+msgid "Application needs to keep running"
+msgstr ""
+
+#: ../src/gtk/power.cpp:233
+msgid "Clean up before suspend"
+msgstr ""
+
+#: ../src/gtk/power.cpp:259
+#, fuzzy, c-format
+msgid "Failed to inhibit sleep: %s"
+msgstr "Zlyhalo nadviazanie telefonického pripojenia: %s"
+
+#: ../src/gtk/power.cpp:265
+msgid "Unexpected response to D-Bus \"Inhibit\" request."
+msgstr ""
+
+#: ../src/gtk/print.cpp:218
+msgid "Custom size"
+msgstr "Vlastná veľkosť"
+
+#: ../src/gtk/print.cpp:752
+#, fuzzy, c-format
+msgid "Error while printing: %s"
+msgstr "Chyba pri tlači: "
+
+#: ../src/gtk/print.cpp:816
+msgid "Page Setup"
+msgstr "Nastavenie strany"
+
+#: ../src/gtk/webview_webkit.cpp:932
+msgid "Retrieving JavaScript script output is not supported with WebKit v1"
+msgstr ""
+
+#: ../src/gtk/webview_webkit2.cpp:1098
+msgid ""
+"Setting proxy is not supported by WebKit, at least version 2.16 is required."
+msgstr ""
+
+#: ../src/gtk/webview_webkit2.cpp:1104
+msgid "This program was compiled without support for setting WebKit proxy."
+msgstr ""
+
+#: ../src/gtk/window.cpp:6289
+msgid ""
+"GTK+ installed on this machine is too old to support screen compositing, "
+"please install GTK+ 2.12 or later."
+msgstr ""
+"GTK + nainštalovaný v tomto počítači je príliš starý na to, aby podporoval "
+"vytváranie obrazoviek, nainštalujte si GTK + 2.12 alebo novší."
+
+#: ../src/gtk/window.cpp:6307
+msgid ""
+"Compositing not supported by this system, please enable it in your Window "
+"Manager."
+msgstr ""
+"Skladanie nie je podporované v tomto systéme, povoľte ho prosím v Správcovi "
+"okien."
+
+#: ../src/gtk/window.cpp:6318
+msgid ""
+"This program was compiled with a too old version of GTK+, please rebuild "
+"with GTK+ 2.12 or newer."
+msgstr ""
+"Tento program bol skompilovaný s príliš starou verziou GTK+. Znova ju "
+"zostavte s GTK+ 2.12 alebo novšou verziou."
+
+#: ../src/html/chm.cpp:138
+#, c-format
+msgid "Failed to open CHM archive '%s'."
+msgstr "Zlyhalo otvorenie CHM archívu '%s'."
+
+#: ../src/html/chm.cpp:270
+#, c-format
+msgid "Could not extract %s into %s: %s"
+msgstr "Nemožno rozbaliť %s do %s: %s"
+
+#: ../src/html/chm.cpp:324
+msgid "no error"
+msgstr "žiadna chyba"
+
+#: ../src/html/chm.cpp:326
+msgid "bad arguments to library function"
+msgstr "zlé argumenty pre funkciu knižnice"
+
+#: ../src/html/chm.cpp:328
+msgid "error opening file"
+msgstr "chyba pri otváraní súboru"
+
+#: ../src/html/chm.cpp:330
+msgid "read error"
+msgstr "chyba čítania"
+
+#: ../src/html/chm.cpp:332
+msgid "write error"
+msgstr "chyba zápisu"
+
+#: ../src/html/chm.cpp:334
+msgid "seek error"
+msgstr "chyba vyhľadávania v súbore"
+
+#: ../src/html/chm.cpp:338
+msgid "bad signature"
+msgstr "zlý podpis"
+
+#: ../src/html/chm.cpp:340
+msgid "error in data format"
+msgstr "chyba vo formáte údajov"
+
+#: ../src/html/chm.cpp:342
+msgid "checksum error"
+msgstr "chyba kontrolného súčtu"
+
+#: ../src/html/chm.cpp:344
+msgid "compression error"
+msgstr "chyba kompresie"
+
+#: ../src/html/chm.cpp:346
+msgid "decompression error"
+msgstr "chyba dekompresie"
+
+#: ../src/html/chm.cpp:437
+#, c-format
+msgid "Could not locate file '%s'."
+msgstr "Nemožno nájsť súbor '%s'."
+
+#: ../src/html/chm.cpp:711
+#, c-format
+msgid "Could not create temporary file '%s'"
+msgstr "Nemožno vytvoriť dočasný súbor '%s'"
+
+#: ../src/html/chm.cpp:718
+#, c-format
+msgid "Extraction of '%s' into '%s' failed."
+msgstr "Rozbalenie '%s' do '%s' zlyhala."
+
+#: ../src/html/chm.cpp:806 ../src/html/chm.cpp:863
+msgid "CHM handler currently supports only local files!"
+msgstr "Obsluha CHM momentálne podporuje iba lokálne súbory!"
+
+#: ../src/html/chm.cpp:827
+msgid "Link contained '//', converted to absolute link."
+msgstr "Odkaz obsahoval '//' konvertovaný na absolútny odkaz."
+
+#: ../src/html/helpctrl.cpp:59
+#, c-format
+msgid "Help: %s"
+msgstr "Pomocník: %s"
+
+#: ../src/html/helpctrl.cpp:155
+#, c-format
+msgid "Adding book %s"
+msgstr "Pridáva sa kniha %s"
+
+#: ../src/html/helpdata.cpp:295
+#, c-format
+msgid "Cannot open contents file: %s"
+msgstr "Nemožno otvoriť súbor s obsahom: %s"
+
+#: ../src/html/helpdata.cpp:309
+#, c-format
+msgid "Cannot open index file: %s"
+msgstr "Nemožno otvoriť indexový súbor: %s"
+
+#: ../src/html/helpdata.cpp:643
+msgid "noname"
+msgstr "nepomenované"
+
+#: ../src/html/helpdata.cpp:652
+#, c-format
+msgid "Cannot open HTML help book: %s"
+msgstr "Nemožno otvoriť HTML príručku: %s"
+
+#: ../src/html/helpwnd.cpp:315
+msgid "Displays help as you browse the books on the left."
+msgstr "Zobrazí pomocníka počas prehliadania kníh vľavo."
+
+#: ../src/html/helpwnd.cpp:411 ../src/html/helpwnd.cpp:1100
+#: ../src/html/helpwnd.cpp:1735
+msgid "(bookmarks)"
+msgstr "(záložky)"
+
+#: ../src/html/helpwnd.cpp:424
+msgid "Add current page to bookmarks"
+msgstr "Pridať aktuálnu stránku medzi záložky"
+
+#: ../src/html/helpwnd.cpp:425
+msgid "Remove current page from bookmarks"
+msgstr "Odstráni aktuálnu stránku zo záložiek"
+
+#: ../src/html/helpwnd.cpp:470
+msgid "Contents"
+msgstr "Obsah"
+
+#: ../src/html/helpwnd.cpp:485
+msgid "Find"
+msgstr "Hľadať"
+
+#: ../src/html/helpwnd.cpp:487
+msgid "Show all"
+msgstr "Zobraziť všetko"
+
+#: ../src/html/helpwnd.cpp:497
+msgid ""
+"Display all index items that contain given substring. Search is case "
+"insensitive."
+msgstr ""
+"Zobraziť všetky položky indexu, ktoré obsahujú daný podreťazec. Vyhľadávanie "
+"rozlišuje malé a veľké písmená."
+
+#: ../src/html/helpwnd.cpp:498
+msgid "Show all items in index"
+msgstr "Zobrazí všetky položky v indexe"
+
+#: ../src/html/helpwnd.cpp:528
+msgid "Case sensitive"
+msgstr "Rozlišovať malé/veľké"
+
+#: ../src/html/helpwnd.cpp:529
+msgid "Whole words only"
+msgstr "Iba celé slová"
+
+#: ../src/html/helpwnd.cpp:532
+msgid ""
+"Search contents of help book(s) for all occurrences of the text you typed "
+"above"
+msgstr ""
+"Vyhľadá v obsahu pomocníka všetky výskyty textu, ktorý ste napísali vyššie"
+
+#: ../src/html/helpwnd.cpp:653
+msgid "Show/hide navigation panel"
+msgstr "Zobrazí/skryje navigačný panel"
+
+#: ../src/html/helpwnd.cpp:655
+msgid "Go back"
+msgstr "Ísť späť"
+
+#: ../src/html/helpwnd.cpp:656
+msgid "Go forward"
+msgstr "Ísť vpred"
+
+#: ../src/html/helpwnd.cpp:658
+msgid "Go one level up in document hierarchy"
+msgstr "Ísť o úroveň vyššie v hierarchii dokumentov"
+
+#: ../src/html/helpwnd.cpp:666 ../src/html/helpwnd.cpp:1547
+msgid "Open HTML document"
+msgstr "Otvorte dokument HTML"
+
+#: ../src/html/helpwnd.cpp:670
+msgid "Print this page"
+msgstr "Vytlačiť túto stránku"
+
+#: ../src/html/helpwnd.cpp:674
+msgid "Display options dialog"
+msgstr "Zobraziť dialóg nastavení"
+
+#: ../src/html/helpwnd.cpp:795
+msgid "Please choose the page to display:"
+msgstr "Vyberte, prosím, stránku, ktorá sa má zobraziť:"
+
+#: ../src/html/helpwnd.cpp:796
+msgid "Help Topics"
+msgstr "Témy Pomocníka"
+
+#: ../src/html/helpwnd.cpp:852
+msgid "Searching..."
+msgstr "Hľadá sa..."
+
+#: ../src/html/helpwnd.cpp:853
+msgid "No matching page found yet"
+msgstr "Zatiaľ sa nenašla žiadna zodpovedajúca stránka"
+
+#: ../src/html/helpwnd.cpp:870
+#, c-format
+msgid "Found %i matches"
+msgstr "Nájdených %i zhôd"
+
+#: ../src/html/helpwnd.cpp:958
+msgid "(Help)"
+msgstr "(Pomoc)"
+
+#: ../src/html/helpwnd.cpp:1026
+#, c-format
+msgid "%d of %lu"
+msgstr "%d z %lu"
+
+#: ../src/html/helpwnd.cpp:1028
+#, c-format
+msgid "%lu of %lu"
+msgstr "%lu z %lu"
+
+#: ../src/html/helpwnd.cpp:1047
+msgid "Search in all books"
+msgstr "Hľadá vo všetkých knihách"
+
+#: ../src/html/helpwnd.cpp:1193
+msgid "Help Browser Options"
+msgstr "Možnosti prehliadača Pomocníka"
+
+#: ../src/html/helpwnd.cpp:1198
+msgid "Normal font:"
+msgstr "Normálne písmo:"
+
+#: ../src/html/helpwnd.cpp:1199
+msgid "Fixed font:"
+msgstr "Písmo s pevnou šírkou:"
+
+#: ../src/html/helpwnd.cpp:1200
+msgid "Font size:"
+msgstr "Veľkosť písma:"
+
+#: ../src/html/helpwnd.cpp:1245
+msgid "font size"
+msgstr "veľkosť písma"
+
+#: ../src/html/helpwnd.cpp:1256
+msgid "Normal face<br>and <u>underlined</u>. "
+msgstr "Normálna plôška<br> a <u>podčiarknuté</u>. "
+
+#: ../src/html/helpwnd.cpp:1257
+msgid "<i>Italic face.</i> "
+msgstr "<i>Kurzívou.</i> "
+
+#: ../src/html/helpwnd.cpp:1258
+msgid "<b>Bold face.</b> "
+msgstr "<b>Hrubé.</b> "
+
+#: ../src/html/helpwnd.cpp:1259
+msgid "<b><i>Bold italic face.</i></b><br>"
+msgstr "<b><i>Hrubé kurzívou.</i></b><br>"
+
+#: ../src/html/helpwnd.cpp:1262
+msgid "Fixed size face.<br> <b>bold</b> <i>italic</i> "
+msgstr "Písmo s pevnou šírkou.<br> <b>tučné</b> <i>kurzíva</i> "
+
+#: ../src/html/helpwnd.cpp:1263
+msgid "<b><i>bold italic <u>underlined</u></i></b><br>"
+msgstr "<b><i>Hrubé kurzívou, <u>podčiarknuté</u></i></b><br>"
+
+#: ../src/html/helpwnd.cpp:1524
+msgid "Help Printing"
+msgstr "Pomocník pre tlač"
+
+#: ../src/html/helpwnd.cpp:1527
+msgid "Cannot print empty page."
+msgstr "Nemožno vytlačiť prázdnu stránku."
+
+#: ../src/html/helpwnd.cpp:1540
+msgid "HTML files (*.html;*.htm)|*.html;*.htm|"
+msgstr "HTML súbory (*.html;*.htm)|*.html;*.htm|"
+
+#: ../src/html/helpwnd.cpp:1541
+msgid "Help books (*.htb)|*.htb|Help books (*.zip)|*.zip|"
+msgstr "Knihy Pomocníka (*.htb)|*.htb|Knihy Pomocníka (*.zip)|*.zip|"
+
+#: ../src/html/helpwnd.cpp:1542
+msgid "HTML Help Project (*.hhp)|*.hhp|"
+msgstr "HTML Help Project (*.hhp)|*.hhp|"
+
+#: ../src/html/helpwnd.cpp:1544
+msgid "Compressed HTML Help file (*.chm)|*.chm|"
+msgstr "Komprimovaný HTML súbor Pomocníka (*.chm)|*.chm|"
+
+#: ../src/html/helpwnd.cpp:1671
+#, c-format
+msgid "%i of %u"
+msgstr "%i z %u"
+
+#: ../src/html/helpwnd.cpp:1709
+#, c-format
+msgid "%u of %u"
+msgstr "%u z %u"
+
+#: ../src/html/htmlfilt.cpp:134
+#, c-format
+msgid "Cannot open HTML document: %s"
+msgstr "Nemožno otvoriť HTML dokument: %s"
+
+#: ../src/html/htmlwin.cpp:599
+msgid "Connecting..."
+msgstr "Pripája sa..."
+
+#: ../src/html/htmlwin.cpp:616
+#, c-format
+msgid "Unable to open requested HTML document: %s"
+msgstr "Nemožno otvoriť požadovaný dokument HTML: %s"
+
+#: ../src/html/htmlwin.cpp:630
+msgid "Loading : "
+msgstr "Načítanie: "
+
+#: ../src/html/htmlwin.cpp:673
+msgid "Done"
+msgstr "Hotovo"
+
+#: ../src/html/htmlwin.cpp:723
+#, c-format
+msgid "HTML anchor %s does not exist."
+msgstr "HTML kotva %s neexistuje."
+
+#: ../src/html/htmlwin.cpp:1057
+#, c-format
+msgid "Copied to clipboard:\"%s\""
+msgstr "Skopírované do schránky:'%s'"
+
+#: ../src/html/htmprint.cpp:269
+msgid ""
+"This document doesn't fit on the page horizontally and will be truncated "
+"when it is printed."
+msgstr "Tento dokument sa nezmestí na stránku vodorovne a pri tlači sa skráti."
+
+#: ../src/html/htmprint.cpp:285
+#, c-format
+msgid ""
+"The document \"%s\" doesn't fit on the page horizontally and will be "
+"truncated if printed.\n"
+"\n"
+"Would you like to proceed with printing it nevertheless?"
+msgstr ""
+"Dokument '%s' sa nezmestí na stránku vodorovne a pri vytlačení sa skráti.\n"
+"\n"
+"Chcete napriek tomu pokračovať v jeho tlači?"
+
+#: ../src/html/htmprint.cpp:296
+msgid ""
+"If possible, try changing the layout parameters to make the printout more "
+"narrow."
+msgstr ""
+"Ak je to možné, pokúste sa zmeniť parametre rozloženia, aby sa vytvoril "
+"výtlačok čo najužší."
+
+#: ../src/html/htmprint.cpp:445
+msgid ": file does not exist!"
+msgstr ": súbor neexistuje!"
+
+#. TRANSLATORS: %s may be a document title.
+#: ../src/html/htmprint.cpp:717
+#, fuzzy, c-format
+msgid "%s Preview"
+msgstr " Náhľad"
+
+#: ../src/html/htmprint.cpp:755 ../src/richtext/richtextprint.cpp:618
+msgid ""
+"There was a problem during page setup: you may need to set a default printer."
+msgstr ""
+"Počas nastavenia stránky nastal problém: zrejme treba nastaviť štandardnú "
+"tlačiareň."
+
+#: ../src/msw/clipbrd.cpp:80
+msgid "Failed to open the clipboard."
+msgstr "Zlyhalo otvorenie schránky."
+
+#: ../src/msw/clipbrd.cpp:101
+msgid "Failed to close the clipboard."
+msgstr "Zlyhalo zatvorenie schránky."
+
+#: ../src/msw/clipbrd.cpp:113
+msgid "Failed to empty the clipboard."
+msgstr "Zlyhalo vyprázdnenie schránky."
+
+#: ../src/msw/clipbrd.cpp:284
+msgid "Failed to put data on the clipboard"
+msgstr "Zlyhalo vloženie údajov do schránky"
+
+#: ../src/msw/clipbrd.cpp:326
+msgid "Failed to get data from the clipboard"
+msgstr "Zlyhalo získanie údajov zo schránky"
+
+#: ../src/msw/clipbrd.cpp:363
+msgid "Failed to retrieve the supported clipboard formats"
+msgstr "Zlyhalo získanie podporovaných formátov schránky"
+
+#: ../src/msw/colordlg.cpp:228
+#, c-format
+msgid "Colour selection dialog failed with error %0lx."
+msgstr "Dialógové okno výberu farby zlyhalo s chybou %0lx."
+
+#: ../src/msw/cursor.cpp:141
+msgid "Failed to create cursor."
+msgstr "Zlyhalo vytvorenie kurzora."
+
+#: ../src/msw/dde.cpp:279
+#, c-format
+msgid "Failed to register DDE server '%s'"
+msgstr "Zlyhalo zaregistrovanie DDE serveru '%s'"
+
+#: ../src/msw/dde.cpp:300
+#, c-format
+msgid "Failed to unregister DDE server '%s'"
+msgstr "Zlyhalo zrušenie registrácie DDE servera '%s'"
+
+#: ../src/msw/dde.cpp:428
+#, c-format
+msgid "Failed to create connection to server '%s' on topic '%s'"
+msgstr "Zlyhalo vytvorenie spojenia so serverom '%s' na tému '%s'"
+
+#: ../src/msw/dde.cpp:655
+msgid "DDE poke request failed"
+msgstr "Požiadavka DDE poke zlyhala"
+
+#: ../src/msw/dde.cpp:674
+msgid "Failed to establish an advise loop with DDE server"
+msgstr "Zlyhalo nadviazanie pomocného spojenia s DDE serverom"
+
+#: ../src/msw/dde.cpp:693
+msgid "Failed to terminate the advise loop with DDE server"
+msgstr "Zlyhalo ukončenie pomocného spojenia s DDE serverom"
+
+#: ../src/msw/dde.cpp:768
+msgid "Failed to send DDE advise notification"
+msgstr "Zlyhalo zaslanie DDE oznámenia"
+
+#: ../src/msw/dde.cpp:1085
+msgid "Failed to create DDE string"
+msgstr "Zlyhalo vytvorenie DDE reťazca"
+
+#: ../src/msw/dde.cpp:1131
+msgid "no DDE error."
+msgstr "žiadna DDE chyba."
+
+#: ../src/msw/dde.cpp:1135
+msgid "a request for a synchronous advise transaction has timed out."
+msgstr "vypršala platnosť žiadosti o synchrónnu transakciu upozornenia."
+
+#: ../src/msw/dde.cpp:1138
+msgid "the response to the transaction caused the DDE_FBUSY bit to be set."
+msgstr "odpoveď na transakciu spôsobila nastavenie bitu DDE_FBUSY."
+
+#: ../src/msw/dde.cpp:1141
+msgid "a request for a synchronous data transaction has timed out."
+msgstr "vypršal časový limit žiadosti o synchrónnu dátovú transakciu."
+
+#: ../src/msw/dde.cpp:1144
+msgid ""
+"a DDEML function was called without first calling the DdeInitialize "
+"function,\n"
+"or an invalid instance identifier\n"
+"was passed to a DDEML function."
+msgstr ""
+"bola volaná funkcia DDEML bez prvého volania funkcie DdeInitialize,\n"
+"alebo neplatný identifikátor inštancie\n"
+"bol odovzdaný funkcii DDEML."
+
+#: ../src/msw/dde.cpp:1147
+msgid ""
+"an application initialized as APPCLASS_MONITOR has\n"
+"attempted to perform a DDE transaction,\n"
+"or an application initialized as APPCMD_CLIENTONLY has \n"
+"attempted to perform server transactions."
+msgstr ""
+"aplikácia inicializovaná ako APPCLASS_MONITOR má\n"
+"sa pokúsil vykonať transakciu DDE,\n"
+"alebo aplikácia inicializovaná ako APPCMD_CLIENTONLY\n"
+"sa pokúsil vykonať transakcie so serverom."
+
+#: ../src/msw/dde.cpp:1150
+msgid "a request for a synchronous execute transaction has timed out."
+msgstr "vypršal čas na žiadosť o transakciu synchrónneho vykonania."
+
+#: ../src/msw/dde.cpp:1153
+msgid "a parameter failed to be validated by the DDEML."
+msgstr "parameter sa nepodarilo overiť pomocou DDEML."
+
+#: ../src/msw/dde.cpp:1156
+msgid "a DDEML application has created a prolonged race condition."
+msgstr "aplikácia DDEML vytvorila podmienku predĺženej trasy."
+
+#: ../src/msw/dde.cpp:1159
+msgid "a memory allocation failed."
+msgstr "vymedzenie pamäte zlyhalo."
+
+#: ../src/msw/dde.cpp:1162
+msgid "a client's attempt to establish a conversation has failed."
+msgstr "pokus klienta o nadviazanie konverzácie zlyhal."
+
+#: ../src/msw/dde.cpp:1165
+msgid "a transaction failed."
+msgstr "transakcia zlyhala."
+
+#: ../src/msw/dde.cpp:1168
+msgid "a request for a synchronous poke transaction has timed out."
+msgstr "časový limit žiadosti o synchrónnu transakciu poke."
+
+#: ../src/msw/dde.cpp:1171
+msgid "an internal call to the PostMessage function has failed. "
+msgstr "zlyhalo interné volanie do funkcie PostMessage. "
+
+#: ../src/msw/dde.cpp:1174
+msgid "reentrancy problem."
+msgstr "problém s opakovaným zhrnutím."
+
+#: ../src/msw/dde.cpp:1177
+msgid ""
+"a server-side transaction was attempted on a conversation\n"
+"that was terminated by the client, or the server\n"
+"terminated before completing a transaction."
+msgstr ""
+"v konverzácii sa pokúsil o transakciu na strane servera,\n"
+"ktorý bol ukončený klientom alebo serverom\n"
+"ukončená pred dokončením transakcie."
+
+#: ../src/msw/dde.cpp:1180
+msgid "an internal error has occurred in the DDEML."
+msgstr "v súbore DDEML sa vyskytla interná chyba."
+
+#: ../src/msw/dde.cpp:1183
+msgid "a request to end an advise transaction has timed out."
+msgstr "platnosť žiadosti o ukončenie transakcie s oznámením vypršala."
+
+#: ../src/msw/dde.cpp:1186
+msgid ""
+"an invalid transaction identifier was passed to a DDEML function.\n"
+"Once the application has returned from an XTYP_XACT_COMPLETE callback,\n"
+"the transaction identifier for that callback is no longer valid."
+msgstr ""
+"funkcii DDEML bol odovzdaný neplatný identifikátor transakcie.\n"
+"Len čo sa aplikácia vráti z XTYP_XACT_COMPLETE spätného volania,\n"
+"identifikátor transakcie pre dané spätné volanie už nie je platný."
+
+#: ../src/msw/dde.cpp:1189
+#, c-format
+msgid "Unknown DDE error %08x"
+msgstr "Neznáma chyba DDE %08x"
+
+#: ../src/msw/dialup.cpp:343
+msgid ""
+"Dial up functions are unavailable because the remote access service (RAS) is "
+"not installed on this machine. Please install it."
+msgstr ""
+"Funkcie vytáčaného spojenia nie sú dostupné, lebo služba vzdialeného "
+"prístupu (RAS) nie je na tomto stroji nainštalovaná. Prosím, nainštalujte ju."
+
+#: ../src/msw/dialup.cpp:402
+#, c-format
+msgid ""
+"The version of remote access service (RAS) installed on this machine is too "
+"old, please upgrade (the following required function is missing: %s)."
+msgstr ""
+"Verzia služby vzdialeného prístupu (RAS) nainštalovaná v tomto počítači je "
+"príliš stará. Aktualizujte ju (chýba nasledujúca požadovaná funkcia: %s)."
+
+#: ../src/msw/dialup.cpp:437
+msgid "Failed to retrieve text of RAS error message"
+msgstr "Zlyhalo získanie textu chybovej správy RAS"
+
+#: ../src/msw/dialup.cpp:440
+#, c-format
+msgid "unknown error (error code %08x)."
+msgstr "neznáma chyba (chybový kód %08x)."
+
+#: ../src/msw/dialup.cpp:492
+#, c-format
+msgid "Cannot find active dialup connection: %s"
+msgstr "Nemožno nájsť aktívne vytáčané spojenie: %s"
+
+#: ../src/msw/dialup.cpp:513
+msgid "Several active dialup connections found, choosing one randomly."
+msgstr ""
+"Bolo nájdených niekoľko aktívnych vytáčaných spojení, vyberám náhodne jedno."
+
+#: ../src/msw/dialup.cpp:598 ../src/msw/dialup.cpp:832
+#, c-format
+msgid "Failed to establish dialup connection: %s"
+msgstr "Zlyhalo nadviazanie vytáčaného spojenia: %s"
+
+#: ../src/msw/dialup.cpp:664
+#, c-format
+msgid "Failed to get ISP names: %s"
+msgstr "Zlyhalo získanie zoznamu názvov poskytovateľov pripojenia: %s"
+
+#: ../src/msw/dialup.cpp:712
+msgid "Failed to connect: no ISP to dial."
+msgstr ""
+"Zlyhalo pripojenie: nie je žiadny poskytovateľ, ktorého by bolo možné "
+"vytočiť."
+
+#: ../src/msw/dialup.cpp:732
+msgid "Choose ISP to dial"
+msgstr "Vyberte ISP na vytočenie"
+
+#: ../src/msw/dialup.cpp:733
+msgid "Please choose which ISP do you want to connect to"
+msgstr "Vyberte, prosím, poskytovateľa, ku ktorému sa chcete pripájať"
+
+#: ../src/msw/dialup.cpp:766
+msgid "Failed to connect: missing username/password."
+msgstr "Zlyhalo pripojenie: chýba používateľské meno/heslo."
+
+#: ../src/msw/dialup.cpp:796
+msgid "Cannot find the location of address book file"
+msgstr "Nemožno nájsť umiestnenie súboru so zoznamom kontaktov"
+
+#: ../src/msw/dialup.cpp:827
+#, c-format
+msgid "Failed to initiate dialup connection: %s"
+msgstr "Zlyhalo nadviazanie telefonického pripojenia: %s"
+
+#: ../src/msw/dialup.cpp:897
+msgid "Cannot hang up - no active dialup connection."
+msgstr "Nemožno zavesiť - nie je aktívne žiadne vytáčané spojenie."
+
+#: ../src/msw/dialup.cpp:907
+#, c-format
+msgid "Failed to terminate the dialup connection: %s"
+msgstr "Zlyhalo ukončenie vytáčaného spojenia: %s"
+
+#: ../src/msw/dib.cpp:313
+#, c-format
+msgid "Failed to save the bitmap image to file \"%s\"."
+msgstr "Zlyhalo uloženie bitmapového obrázku do súboru '%s'."
+
+#: ../src/msw/dib.cpp:543
+#, c-format
+msgid "Failed to allocate %luKb of memory for bitmap data."
+msgstr "Zlyhalo vymedzenie %lukb pamäte pre údaje bitmapy."
+
+#: ../src/msw/dir.cpp:241
+#, c-format
+msgid "Cannot enumerate files in directory '%s'"
+msgstr "Nemožno vymenovať súbory v adresári '%s'"
+
+#: ../src/msw/dirdlg.cpp:368
+msgid "Couldn't obtain folder name"
+msgstr "Nemožno získať názov priečinka"
+
+#: ../src/msw/dlmsw.cpp:163
+#, fuzzy, c-format
+msgid "(error %d: %s)"
+msgstr " (chyba %ld: %s)"
+
+#: ../src/msw/dragimag.cpp:143 ../src/msw/dragimag.cpp:178
+#: ../src/msw/imaglist.cpp:309 ../src/msw/imaglist.cpp:331
+msgid "Couldn't add an image to the image list."
+msgstr "Nemožno pridať obrázok do zoznamu obrázkov."
+
+#: ../src/msw/enhmeta.cpp:94
+#, c-format
+msgid "Failed to load metafile from file \"%s\"."
+msgstr "Zlyhalo načítanie metasúboru zo súboru '%s'."
+
+#: ../src/msw/fdrepdlg.cpp:412
+#, c-format
+msgid "Failed to create the standard find/replace dialog (error code %d)"
+msgstr ""
+"Zlyhalo vytvorenie štandardného dialógu hľadať/nahradiť (chybový kód %d)"
+
+#: ../src/msw/filedlg.cpp:1241
+msgid "Access to the file system is not allowed from secure desktop."
+msgstr ""
+
+#: ../src/msw/filedlg.cpp:1242
+msgid "Security warning"
+msgstr ""
+
+#: ../src/msw/filedlg.cpp:1533
+#, c-format
+msgid "File dialog failed with error code %0lx."
+msgstr "Súborový dialóg zlyhal s kódom chyby %0lx."
+
+#: ../src/msw/font.cpp:1120
+#, fuzzy, c-format
+msgid "Font file \"%s\" couldn't be loaded"
+msgstr "Súbor nmožno načítať."
+
+#: ../src/msw/fontdlg.cpp:220
+#, c-format
+msgid "Common dialog failed with error code %0lx."
+msgstr "Spoločné dialógové okno zlyhalo s kódom chyby %0lx."
+
+#: ../src/msw/fswatcher.cpp:67
+msgid "Ungraceful worker thread termination"
+msgstr "Nepríjemné ukončenie pracovného vlákna"
+
+#: ../src/msw/fswatcher.cpp:81
+msgid "Unable to create IOCP worker thread"
+msgstr "Nemožno vytvoriť pracovné vlákno IOCP"
+
+#: ../src/msw/fswatcher.cpp:88
+msgid "Unable to start IOCP worker thread"
+msgstr "Nemožno spustiť pracovné vlákno IOCP"
+
+#: ../src/msw/fswatcher.cpp:140
+msgid "Monitoring individual files for changes is not supported currently."
+msgstr ""
+"Monitorovanie zmien jednotlivých súborov nie je momentálne podporované."
+
+#: ../src/msw/fswatcher.cpp:165
+#, c-format
+msgid "Unable to set up watch for '%s'"
+msgstr "Nemožno nastaviť sledovanie pre \"%s\""
+
+#: ../src/msw/fswatcher.cpp:466
+#, c-format
+msgid "Can't monitor non-existent directory \"%s\" for changes."
+msgstr "Nemožno sledovať zmeny v neexistujúcom priečinku '%s'."
+
+#: ../src/msw/glcanvas.cpp:577 ../src/unix/glx11.cpp:507
+msgid "OpenGL 3.0 or later is not supported by the OpenGL driver."
+msgstr "OpenGL 3.0 alebo novší nie je ovládačom OpenGL podporovaný."
+
+#: ../src/msw/glcanvas.cpp:601 ../src/osx/glcanvas_osx.cpp:395
+#: ../src/unix/glegl.cpp:304 ../src/unix/glx11.cpp:553
+msgid "Couldn't create OpenGL context"
+msgstr "Nemožno vytvoriť kontext OpenGL"
+
+#: ../src/msw/glcanvas.cpp:1294
+msgid "Failed to initialize OpenGL"
+msgstr "Zlyhala inicializácia OpenGL"
+
+#: ../src/msw/graphicsd2d.cpp:607
+msgid "Could not register custom DirectWrite font loader."
+msgstr ""
+
+#: ../src/msw/helpchm.cpp:48
+msgid ""
+"MS HTML Help functions are unavailable because the MS HTML Help library is "
+"not installed on this machine. Please install it."
+msgstr ""
+"Funkcie pomocníka MS HTML nie sú k dispozícii, pretože v tomto zariadení nie "
+"je nainštalovaná knižnica pomocníka MS HTML. Nainštalujte si ho."
+
+#: ../src/msw/helpchm.cpp:55
+msgid "Failed to initialize MS HTML Help."
+msgstr "Zlyhala inicializácia Pomocníka MS HTML."
+
+#: ../src/msw/iniconf.cpp:458
+#, c-format
+msgid "Can't delete the INI file '%s'"
+msgstr "Nemožno zmazať INI súbor '%s'"
+
+#: ../src/msw/listctrl.cpp:995
+#, c-format
+msgid "Couldn't retrieve information about list control item %d."
+msgstr "Nemožno získať informácie o riadiacej položke zoznamu %d."
+
+#: ../src/msw/mdi.cpp:170 ../src/qt/mdi.cpp:253
+msgid "&Cascade"
+msgstr "&Kaskáda"
+
+#: ../src/msw/mdi.cpp:171
+msgid "Tile &Horizontally"
+msgstr "Dlaždice &horizontálne"
+
+#: ../src/msw/mdi.cpp:172
+msgid "Tile &Vertically"
+msgstr "Dlaždice &vertikálne"
+
+#: ../src/msw/mdi.cpp:174
+msgid "&Arrange Icons"
+msgstr "&Zoradiť ikony"
+
+#: ../src/msw/mdi.cpp:621
+msgid "Failed to create MDI parent frame."
+msgstr "Zlyhalo vytvorenie rodičovského okna MDI."
+
+#: ../src/msw/mimetype.cpp:234
+#, c-format
+msgid "Failed to create registry entry for '%s' files."
+msgstr "Zlyhalo vytvorenie záznamu registra pre súbory '%s'."
+
+#: ../src/msw/ole/automtn.cpp:495
+#, c-format
+msgid "Failed to find CLSID of \"%s\""
+msgstr "Zlyhalo nájdenie identifikátora CLSID '%s'"
+
+#: ../src/msw/ole/automtn.cpp:512
+#, c-format
+msgid "Failed to create an instance of \"%s\""
+msgstr "Zlyhalo vytvorenie priečinku '%s'"
+
+#: ../src/msw/ole/automtn.cpp:552
+#, c-format
+msgid "Cannot get an active instance of \"%s\""
+msgstr "Nemožno nájsť aktívnu inštanciu pre '%s'"
+
+#: ../src/msw/ole/automtn.cpp:564
+#, c-format
+msgid "Failed to get OLE automation interface for \"%s\""
+msgstr "Zlyhalo získanie rozhrania automatizácie OLE pre '%s'"
+
+#: ../src/msw/ole/automtn.cpp:621
+msgid "Unknown name or named argument."
+msgstr "Neznáme meno alebo pomenovaný argument."
+
+#: ../src/msw/ole/automtn.cpp:625
+msgid "Incorrect number of arguments."
+msgstr "Nekorektný počet argumentov."
+
+#: ../src/msw/ole/automtn.cpp:637
+msgid "Unknown exception"
+msgstr "Neznáma výnimka"
+
+#: ../src/msw/ole/automtn.cpp:642
+msgid "Method or property not found."
+msgstr "Metóda alebo vlastnosť sa nenašli."
+
+#: ../src/msw/ole/automtn.cpp:646
+msgid "Overflow while coercing argument values."
+msgstr "Pretečenie pri vynucovaní hodnôt argumentov."
+
+#: ../src/msw/ole/automtn.cpp:650
+msgid "Object implementation does not support named arguments."
+msgstr "Implementácia objektu nepodporuje pomenované argumenty."
+
+#: ../src/msw/ole/automtn.cpp:654
+msgid "The locale ID is unknown."
+msgstr "ID miestneho nastavenia nie je známy."
+
+#: ../src/msw/ole/automtn.cpp:658
+msgid "Missing a required parameter."
+msgstr "Chýba požadovaný parameter."
+
+#: ../src/msw/ole/automtn.cpp:662
+#, c-format
+msgid "Argument %u not found."
+msgstr "Argument %u sa nenašiel."
+
+#: ../src/msw/ole/automtn.cpp:666
+#, c-format
+msgid "Type mismatch in argument %u."
+msgstr "Nezhoda typu v argumente %u."
+
+#: ../src/msw/ole/automtn.cpp:670
+msgid "The system cannot find the file specified."
+msgstr "Systém nemôže nájsť zadaný súbor."
+
+#: ../src/msw/ole/automtn.cpp:674
+msgid "Class not registered."
+msgstr "Trieda nie je zaregistrovaná."
+
+#: ../src/msw/ole/automtn.cpp:678
+#, c-format
+msgid "Unknown error %08x"
+msgstr "Neznáma chyba %08x"
+
+#: ../src/msw/ole/automtn.cpp:682
+#, c-format
+msgid "OLE Automation error in %s: %s"
+msgstr "Chyba automatizácie OLE v %s: %s"
+
+#: ../src/msw/ole/dataobj.cpp:385
+#, c-format
+msgid "Couldn't register clipboard format '%s'."
+msgstr "Nemožno  zaregistrovať formát schránky '%s'."
+
+#: ../src/msw/ole/dataobj.cpp:402
+#, c-format
+msgid "The clipboard format '%d' doesn't exist."
+msgstr "Formát schránky '%d' neexistuje."
+
+#: ../src/msw/progdlg.cpp:1025
+msgid "Skip"
+msgstr "Preskočiť"
+
+#: ../src/msw/registry.cpp:141
+#, c-format
+msgid "unknown (%lu)"
+msgstr "neznáme (%lu)"
+
+#: ../src/msw/registry.cpp:409
+#, c-format
+msgid "Can't get info about registry key '%s'"
+msgstr "Nemožno získať info o kľúči registra '%s'"
+
+#: ../src/msw/registry.cpp:445
+#, c-format
+msgid "Can't open registry key '%s'"
+msgstr "Nemožno otvoriť kľúč registra '%s'"
+
+#: ../src/msw/registry.cpp:478
+#, c-format
+msgid "Can't create registry key '%s'"
+msgstr "Nemožno vytvoriť kľúč registra '%s'"
+
+#: ../src/msw/registry.cpp:497
+#, c-format
+msgid "Can't close registry key '%s'"
+msgstr "Nemožno zatvoriť kľúč registra '%s'"
+
+#: ../src/msw/registry.cpp:512
+#, c-format
+msgid "Registry value '%s' already exists."
+msgstr "Hodnota registra '%s' už existuje."
+
+#: ../src/msw/registry.cpp:520
+#, c-format
+msgid "Failed to rename registry value '%s' to '%s'."
+msgstr "Zlyhalo premenovanie hodnoty registra '%s' na '%s'."
+
+#: ../src/msw/registry.cpp:575
+#, c-format
+msgid "Can't copy values of unsupported type %d."
+msgstr "Nemožno skopírovať hodnoty nepodporovaného typu %d."
+
+#: ../src/msw/registry.cpp:586
+#, c-format
+msgid "Registry key '%s' does not exist, cannot rename it."
+msgstr "Kľúč registra '%s' neexistuje, nie je ho možné premenovať."
+
+#: ../src/msw/registry.cpp:617
+#, c-format
+msgid "Registry key '%s' already exists."
+msgstr "Kľúč registra '%s' už existuje."
+
+#: ../src/msw/registry.cpp:625
+#, c-format
+msgid "Failed to rename the registry key '%s' to '%s'."
+msgstr "Zlyhalo premenovanie kľúča registra '%s' na '%s'."
+
+#: ../src/msw/registry.cpp:670
+#, c-format
+msgid "Failed to copy the registry subkey '%s' to '%s'."
+msgstr "Zlyhalo skopírovanie podkľúča registra '%s' do '%s'."
+
+#: ../src/msw/registry.cpp:683
+#, c-format
+msgid "Failed to copy registry value '%s'"
+msgstr "Zlyhalo skopírovanie hodnoty registra '%s'"
+
+#: ../src/msw/registry.cpp:692
+#, c-format
+msgid "Failed to copy the contents of registry key '%s' to '%s'."
+msgstr "Zlyhalo skopírovanie obsahu kľúča registra '%s' do '%s'."
+
+#: ../src/msw/registry.cpp:718
+#, c-format
+msgid ""
+"Registry key '%s' is needed for normal system operation,\n"
+"deleting it will leave your system in unusable state:\n"
+"operation aborted."
+msgstr ""
+"Kľúč registra '%s' je potrebný pre normálnu prevádzku systému,\n"
+"jeho zmazanie by zanechalo systém v nepoužiteľnom stave:\n"
+"operácia bola zrušená."
+
+#: ../src/msw/registry.cpp:754
+#, c-format
+msgid "Can't delete key '%s'"
+msgstr "Nemožno zmazať kľúč '%s'"
+
+#: ../src/msw/registry.cpp:782
+#, c-format
+msgid "Can't delete value '%s' from key '%s'"
+msgstr "Nemožno zmazať hodnotu '%s' z kľúča '%s'"
+
+#: ../src/msw/registry.cpp:855 ../src/msw/registry.cpp:887
+#: ../src/msw/registry.cpp:929 ../src/msw/registry.cpp:1000
+#, c-format
+msgid "Can't read value of key '%s'"
+msgstr "Nemožno prečítať hodnotu kľúča '%s'"
+
+#: ../src/msw/registry.cpp:873 ../src/msw/registry.cpp:915
+#: ../src/msw/registry.cpp:963 ../src/msw/registry.cpp:1106
+#, c-format
+msgid "Can't set value of '%s'"
+msgstr "Nemožno nastaviť hodnotu '%s'"
+
+#: ../src/msw/registry.cpp:894 ../src/msw/registry.cpp:943
+#, c-format
+msgid "Registry value \"%s\" is not numeric (but of type %s)"
+msgstr "Hodnota registra '%s' nie je číselná (ale typu %s)"
+
+#: ../src/msw/registry.cpp:979
+#, c-format
+msgid "Registry value \"%s\" is not binary (but of type %s)"
+msgstr "Hodnota registra '%s' nie je binárna (ale typu %s)"
+
+#: ../src/msw/registry.cpp:1028
+#, c-format
+msgid "Registry value \"%s\" is not text (but of type %s)"
+msgstr "Hodnota registra '%s' nie je text (ale typu %s)"
+
+#: ../src/msw/registry.cpp:1089
+#, c-format
+msgid "Can't read value of '%s'"
+msgstr "Nemožno prečítať hodnotu '%s'"
+
+#: ../src/msw/registry.cpp:1157
+#, c-format
+msgid "Can't enumerate values of key '%s'"
+msgstr "Nemožno vymenovať hodnoty kľúča '%s'"
+
+#: ../src/msw/registry.cpp:1196
+#, c-format
+msgid "Can't enumerate subkeys of key '%s'"
+msgstr "Nemožno vymenovať podkľúče kľúča '%s'"
+
+#: ../src/msw/registry.cpp:1262
+#, c-format
+msgid ""
+"Exporting registry key: file \"%s\" already exists and won't be overwritten."
+msgstr ""
+"Exportovanie kľúča registra: súbor '%s' už existuje a nebude prepísaný."
+
+#: ../src/msw/registry.cpp:1411
+#, c-format
+msgid "Can't export value of unsupported type %d."
+msgstr "Nemožno exportovať hodnotu nepodporovaného typu %d."
+
+#: ../src/msw/registry.cpp:1427
+#, c-format
+msgid "Ignoring value \"%s\" of the key \"%s\"."
+msgstr "Ignorovanie hodnoty '%s' kľúča '%s'."
+
+#: ../src/msw/textctrl.cpp:596
+msgid ""
+"Impossible to create a rich edit control, using simple text control instead. "
+"Please reinstall riched32.dll"
+msgstr ""
+"Nemožno vytvoriť ovládací prvok formátu RTF použitím jednoduchého "
+"ovládacieho prvku textu. Preinštalujte, prosím, riched32.dll"
+
+#: ../src/msw/thread.cpp:522 ../src/unix/threadpsx.cpp:850
+msgid "Cannot start thread: error writing TLS."
+msgstr "Nemožno sputiť vlákno: chyba zápisu TLS."
+
+#: ../src/msw/thread.cpp:613
+msgid "Can't set thread priority"
+msgstr "Nemožno nastaviť prioritu vlákna"
+
+#: ../src/msw/thread.cpp:649
+msgid "Can't create thread"
+msgstr "Nemožno vytvoriť vlákno"
+
+#: ../src/msw/thread.cpp:668
+msgid "Couldn't terminate thread"
+msgstr "Nemožno ukončiť vlákno"
+
+#: ../src/msw/thread.cpp:799
+msgid "Cannot wait for thread termination"
+msgstr "Nemožno čakať na ukončenie vlákna"
+
+#: ../src/msw/thread.cpp:873
+#, c-format
+msgid "Cannot suspend thread %lx"
+msgstr "Nemožno pozastaviť vlákno %lx"
+
+#: ../src/msw/thread.cpp:903
+#, c-format
+msgid "Cannot resume thread %lx"
+msgstr "Nemožno znovu získať vlákno %lx"
+
+#: ../src/msw/thread.cpp:932
+msgid "Couldn't get the current thread pointer"
+msgstr "Nemožno získať ukazovateľ na súčasné vlákno"
+
+#: ../src/msw/thread.cpp:1333
+msgid ""
+"Thread module initialization failed: impossible to allocate index in thread "
+"local storage"
+msgstr ""
+"Zlyhala inicializácia modulu vlákien: nebolo možné alokovať index v lokálnom "
+"priestore vlákna"
+
+#: ../src/msw/thread.cpp:1345
+msgid ""
+"Thread module initialization failed: cannot store value in thread local "
+"storage"
+msgstr ""
+"Zlyhala inicializácia modulu vlákien: nemožno uložiť hodnotu v lokálnom "
+"priestore vlákna"
+
+#: ../src/msw/timer.cpp:133
+msgid "Couldn't create a timer"
+msgstr "Nemožno vytvoriť časovač"
+
+#: ../src/msw/utils.cpp:372
+msgid "can't find user's HOME, using current directory."
+msgstr "nemožno nájsť DOMOV používateľa pomocou aktuálneho priečinka."
+
+#: ../src/msw/utils.cpp:662
+#, c-format
+msgid "Failed to kill process %d"
+msgstr "Zlyhalo zabitie procesu %d"
+
+#: ../src/msw/utils.cpp:986
+#, c-format
+msgid "Failed to load resource \"%s\"."
+msgstr "Zlyhalo načítanie zdroja '%s'."
+
+#: ../src/msw/utils.cpp:993
+#, c-format
+msgid "Failed to lock resource \"%s\"."
+msgstr "Zlyhalo uzamknutie zdroja '%s'."
+
+#. TRANSLATORS: MS Windows build number
+#: ../src/msw/utils.cpp:1209
+#, c-format
+msgid "build %lu"
+msgstr "zostava %lu"
+
+#: ../src/msw/utils.cpp:1218
+msgid ", 64-bit edition"
+msgstr ", 64-bitové vydanie"
+
+#: ../src/msw/utilsexc.cpp:224
+msgid "Failed to create an anonymous pipe"
+msgstr "Zlyhalo vytvorenie anonymného potrubia"
+
+#: ../src/msw/utilsexc.cpp:697
+msgid "Failed to redirect the child process IO"
+msgstr "Zlyhalo presmerovanie V/V detského procesu"
+
+#: ../src/msw/utilsexc.cpp:870
+#, c-format
+msgid "Execution of command '%s' failed"
+msgstr "Vykonávanie príkazu '%s' zlyhalo"
+
+#: ../src/msw/volume.cpp:337
+msgid "Failed to load mpr.dll."
+msgstr "Zlyhalo načítanie mpr.dll."
+
+#: ../src/msw/volume.cpp:506
+#, c-format
+msgid "Cannot read typename from '%s'!"
+msgstr "Nemožno prečítať názov typu z '%s'!"
+
+#: ../src/msw/volume.cpp:615
+#, c-format
+msgid "Cannot load icon from '%s'."
+msgstr "Nemožno načítať ikonu z '%s'."
+
+#: ../src/msw/webview_edge.cpp:285
+msgid "This program was compiled without support for setting Edge proxy."
+msgstr ""
+
+#: ../src/msw/webview_ie.cpp:1010
+msgid "Failed to find web view emulation level in the registry"
+msgstr ""
+
+#: ../src/msw/webview_ie.cpp:1019
+msgid "Failed to set web view to modern emulation level"
+msgstr ""
+
+#: ../src/msw/webview_ie.cpp:1027
+msgid "Failed to reset web view to standard emulation level"
+msgstr ""
+
+#: ../src/msw/webview_ie.cpp:1049
+msgid "Can't run JavaScript script without a valid HTML document"
+msgstr ""
+
+#: ../src/msw/webview_ie.cpp:1056
+#, fuzzy
+msgid "Can't get the JavaScript object"
+msgstr "Nemožno nastaviť prioritu vlákna"
+
+#: ../src/msw/webview_ie.cpp:1070
+#, fuzzy
+msgid "failed to evaluate"
+msgstr "Zlyhalo vykonanie '%s'\n"
+
+#: ../src/osx/cocoa/filedlg.mm:412
+#, fuzzy
+msgid "File type:"
+msgstr "Ďalekopis"
+
+#: ../src/osx/cocoa/menu.mm:242
+#, fuzzy
+msgctxt "macOS menu name"
+msgid "Window"
+msgstr "Okno"
+
+#: ../src/osx/cocoa/menu.mm:259
+#, fuzzy
+msgctxt "macOS menu name"
+msgid "Help"
+msgstr "Pomocník"
+
+#: ../src/osx/cocoa/menu.mm:298
+#, fuzzy
+msgctxt "macOS menu item"
+msgid "Minimize"
+msgstr "Mi&nimalizovať"
+
+#: ../src/osx/cocoa/menu.mm:303
+#, fuzzy
+msgctxt "macOS menu item"
+msgid "Zoom"
+msgstr "Priblížiť"
+
+#: ../src/osx/cocoa/menu.mm:309
+msgctxt "macOS menu item"
+msgid "Bring All to Front"
+msgstr ""
+
+#: ../src/osx/core/sound.cpp:143
+#, c-format
+msgid "Failed to load sound from \"%s\" (error %d)."
+msgstr "Zlyhalo načítanie zvuku z '%s' (chyba %d)."
+
+#: ../src/osx/fontutil.cpp:80
+#, fuzzy, c-format
+msgid "Font file \"%s\" doesn't exist."
+msgstr "Súbor %s neexistuje."
+
+#: ../src/osx/fontutil.cpp:88
+#, c-format
+msgid ""
+"Font file \"%s\" cannot be used as it is not inside the font directory "
+"\"%s\"."
+msgstr ""
+
+#: ../src/osx/menu_osx.cpp:496
+#, c-format
+msgctxt "macOS menu item"
+msgid "About %s"
+msgstr "O aplikácii %s"
+
+#: ../src/osx/menu_osx.cpp:499
+msgctxt "macOS menu item"
+msgid "About..."
+msgstr "&O aplikácii..."
+
+#: ../src/osx/menu_osx.cpp:508
+msgctxt "macOS menu item"
+msgid "Preferences..."
+msgstr "Predvoľby..."
+
+#: ../src/osx/menu_osx.cpp:512
+msgctxt "macOS menu item"
+msgid "Services"
+msgstr "Služby"
+
+#: ../src/osx/menu_osx.cpp:519
+#, c-format
+msgctxt "macOS menu item"
+msgid "Hide %s"
+msgstr "Skryť %s"
+
+#: ../src/osx/menu_osx.cpp:522
+#, fuzzy
+msgctxt "macOS menu item"
+msgid "Hide Application"
+msgstr "Aplikácia"
+
+#: ../src/osx/menu_osx.cpp:526
+msgctxt "macOS menu item"
+msgid "Hide Others"
+msgstr "Skryť ostatné"
+
+#: ../src/osx/menu_osx.cpp:528
+msgctxt "macOS menu item"
+msgid "Show All"
+msgstr "Zobraziť všetko"
+
+#: ../src/osx/menu_osx.cpp:534
+#, c-format
+msgctxt "macOS menu item"
+msgid "Quit %s"
+msgstr "Ukončiť %s"
+
+#: ../src/osx/menu_osx.cpp:537
+#, fuzzy
+msgctxt "macOS menu item"
+msgid "Quit Application"
+msgstr "Aplikácia"
+
+#: ../src/osx/webview_webkit.mm:444
+#, fuzzy
+msgid "Printing is not supported by the system web control"
+msgstr "Táto verzia zlib nepodporuje Gzip"
+
+#: ../src/osx/webview_webkit.mm:453
+#, fuzzy
+msgid "Print operation could not be initialized"
+msgstr "Nebolo možné inicializovať obrazovku."
+
+#. TRANSLATORS: Label of font point size
+#: ../src/propgrid/advprops.cpp:605
+msgid "Point Size"
+msgstr "Veľkosť bodu"
+
+#. TRANSLATORS: Label of font face name
+#: ../src/propgrid/advprops.cpp:615
+msgid "Face Name"
+msgstr "Názov plôšky"
+
+#. TRANSLATORS: Label of font style
+#: ../src/propgrid/advprops.cpp:623 ../src/richtext/richtextformatdlg.cpp:331
+msgid "Style"
+msgstr "Štýl"
+
+#. TRANSLATORS: Label of font weight
+#: ../src/propgrid/advprops.cpp:628
+msgid "Weight"
+msgstr "Hrúbka"
+
+#. TRANSLATORS: Label of underlined font
+#: ../src/propgrid/advprops.cpp:633 ../src/richtext/richtextfontpage.cpp:358
+msgid "Underlined"
+msgstr "Podčiarknuté"
+
+#. TRANSLATORS: Label of font family
+#: ../src/propgrid/advprops.cpp:637
+msgid "Family"
+msgstr "Rodina"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:801
+msgid "AppWorkspace"
+msgstr "Priestor aplikácie"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:802
+msgid "ActiveBorder"
+msgstr "Aktívny okraj"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:803
+msgid "ActiveCaption"
+msgstr "Aktívny nadpis"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:804
+msgid "ButtonFace"
+msgstr "Plocha tlačidla"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:805
+msgid "ButtonHighlight"
+msgstr "Zvýraznenie tlačidla"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:806
+msgid "ButtonShadow"
+msgstr "Tieň tlačidla"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:807
+msgid "ButtonText"
+msgstr "Text tlačidla"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:808
+msgid "CaptionText"
+msgstr "Text popisku"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:809
+msgid "ControlDark"
+msgstr "Tmavý ovládač"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:810
+msgid "ControlLight"
+msgstr "Svetlý ovládač"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:812
+msgid "GrayText"
+msgstr "Sivý text"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:813
+msgid "Highlight"
+msgstr "Zvýraznenie"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:814
+msgid "HighlightText"
+msgstr "Zvýrazniť text"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:815
+msgid "InactiveBorder"
+msgstr "Neaktívny okraj"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:816
+msgid "InactiveCaption"
+msgstr "Neaktívny popisok"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:817
+msgid "InactiveCaptionText"
+msgstr "Neaktívny text popisku"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:818
+msgid "Menu"
+msgstr "Ponuka"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:819
+msgid "Scrollbar"
+msgstr "Posuvník"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:820
+msgid "Tooltip"
+msgstr "Popis"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:821
+msgid "TooltipText"
+msgstr "Text popisu"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:822
+msgid "Window"
+msgstr "Okno"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:823
+msgid "WindowFrame"
+msgstr "Rám okna"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:824
+msgid "WindowText"
+msgstr "Text okna"
+
+#. TRANSLATORS: Custom colour choice entry
+#: ../src/propgrid/advprops.cpp:825 ../src/propgrid/advprops.cpp:1532
+#: ../src/propgrid/advprops.cpp:1576
+msgid "Custom"
+msgstr "Vlastné"
+
+#: ../src/propgrid/advprops.cpp:1558
+msgid "Black"
+msgstr "Čierna"
+
+#: ../src/propgrid/advprops.cpp:1559
+msgid "Maroon"
+msgstr "Gaštanová"
+
+#: ../src/propgrid/advprops.cpp:1560
+msgid "Navy"
+msgstr "Námorníctvo"
+
+#: ../src/propgrid/advprops.cpp:1561
+msgid "Purple"
+msgstr "Fialová"
+
+#: ../src/propgrid/advprops.cpp:1562
+msgid "Teal"
+msgstr "Modrozelená"
+
+#: ../src/propgrid/advprops.cpp:1563
+msgid "Gray"
+msgstr "Sivá"
+
+#: ../src/propgrid/advprops.cpp:1564
+msgid "Green"
+msgstr "Zelená"
+
+#: ../src/propgrid/advprops.cpp:1565
+msgid "Olive"
+msgstr "Olivový"
+
+#: ../src/propgrid/advprops.cpp:1566
+msgid "Brown"
+msgstr "Hnedá"
+
+#: ../src/propgrid/advprops.cpp:1567
+msgid "Blue"
+msgstr "Modrá"
+
+#: ../src/propgrid/advprops.cpp:1568
+msgid "Fuchsia"
+msgstr "Červeno fialová"
+
+#: ../src/propgrid/advprops.cpp:1569
+msgid "Red"
+msgstr "Červená"
+
+#: ../src/propgrid/advprops.cpp:1570
+msgid "Orange"
+msgstr "Oranžová"
+
+#: ../src/propgrid/advprops.cpp:1571
+msgid "Silver"
+msgstr "Strieborná"
+
+#: ../src/propgrid/advprops.cpp:1572
+msgid "Lime"
+msgstr "Riadok"
+
+#: ../src/propgrid/advprops.cpp:1573
+msgid "Aqua"
+msgstr "Aqua"
+
+#: ../src/propgrid/advprops.cpp:1574
+msgid "Yellow"
+msgstr "Žltá"
+
+#: ../src/propgrid/advprops.cpp:1575
+msgid "White"
+msgstr "Biela"
+
+#: ../src/propgrid/advprops.cpp:1718
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Default"
+msgstr "Predvolené"
+
+#: ../src/propgrid/advprops.cpp:1719
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Arrow"
+msgstr "Šípka"
+
+#: ../src/propgrid/advprops.cpp:1720
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Right Arrow"
+msgstr "Šípka vpravo"
+
+#: ../src/propgrid/advprops.cpp:1721
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Blank"
+msgstr "Prázdna"
+
+#: ../src/propgrid/advprops.cpp:1722
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Bullseye"
+msgstr "Stredový znak"
+
+#: ../src/propgrid/advprops.cpp:1723
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Character"
+msgstr "Znak"
+
+#: ../src/propgrid/advprops.cpp:1724
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Cross"
+msgstr "Krížom"
+
+#: ../src/propgrid/advprops.cpp:1725
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Hand"
+msgstr "Ruka"
+
+#: ../src/propgrid/advprops.cpp:1726
+#, fuzzy
+msgctxt "system cursor name"
+msgid "I-Beam"
+msgstr "I-Beam"
+
+#: ../src/propgrid/advprops.cpp:1727
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Left Button"
+msgstr "Ľavé tlačidlo"
+
+#: ../src/propgrid/advprops.cpp:1728
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Magnifier"
+msgstr "Zväčšovač"
+
+#: ../src/propgrid/advprops.cpp:1729
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Middle Button"
+msgstr "Stredné tlačidlo"
+
+#: ../src/propgrid/advprops.cpp:1730
+#, fuzzy
+msgctxt "system cursor name"
+msgid "No Entry"
+msgstr "Nevstupovať"
+
+#: ../src/propgrid/advprops.cpp:1731
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Paint Brush"
+msgstr "Maľba štetcom"
+
+#: ../src/propgrid/advprops.cpp:1732
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Pencil"
+msgstr "Ceruzka"
+
+#: ../src/propgrid/advprops.cpp:1733
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Point Left"
+msgstr "Bod vľavo"
+
+#: ../src/propgrid/advprops.cpp:1734
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Point Right"
+msgstr "Bod vpravo"
+
+#: ../src/propgrid/advprops.cpp:1735
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Question Arrow"
+msgstr "Šípka otázky"
+
+#: ../src/propgrid/advprops.cpp:1736
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Right Button"
+msgstr "Pravé tlačidlo"
+
+#: ../src/propgrid/advprops.cpp:1737
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Sizing NE-SW"
+msgstr "Úprava veľkosti SV-JZ"
+
+#: ../src/propgrid/advprops.cpp:1738
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Sizing N-S"
+msgstr "Úprava veľkosti S-J"
+
+#: ../src/propgrid/advprops.cpp:1739
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Sizing NW-SE"
+msgstr "Úprava veľkosti SZ-JV"
+
+#: ../src/propgrid/advprops.cpp:1740
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Sizing W-E"
+msgstr "Úprava veľkosti Z-V"
+
+#: ../src/propgrid/advprops.cpp:1741
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Sizing"
+msgstr "Úprav veľkosti"
+
+#: ../src/propgrid/advprops.cpp:1742
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Spraycan"
+msgstr "Rozprašovač"
+
+#: ../src/propgrid/advprops.cpp:1743
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Wait"
+msgstr "Čakajte"
+
+#: ../src/propgrid/advprops.cpp:1744
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Watch"
+msgstr "Sledovať"
+
+#: ../src/propgrid/advprops.cpp:1745
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Wait Arrow"
+msgstr "Šípka čakania"
+
+#: ../src/propgrid/advprops.cpp:2109
+msgid "Make a selection:"
+msgstr "Vytvoriť výber:"
+
+#: ../src/propgrid/manager.cpp:394
+msgid "Property"
+msgstr "Vlastnosť"
+
+#: ../src/propgrid/manager.cpp:395
+msgid "Value"
+msgstr "Hodnota"
+
+#: ../src/propgrid/manager.cpp:1683
+msgid "Categorized Mode"
+msgstr "Kategorizovaný režim"
+
+#: ../src/propgrid/manager.cpp:1709
+msgid "Alphabetic Mode"
+msgstr "Abecedný režim"
+
+#. TRANSLATORS: Name of Boolean false value
+#: ../src/propgrid/propgrid.cpp:230
+msgid "False"
+msgstr "Nepravda"
+
+#. TRANSLATORS: Name of Boolean true value
+#: ../src/propgrid/propgrid.cpp:232
+msgid "True"
+msgstr "Pravda"
+
+#. TRANSLATORS: Text  displayed for unspecified value
+#: ../src/propgrid/propgrid.cpp:428
+msgid "Unspecified"
+msgstr "Nešpecifikované"
+
+#. TRANSLATORS: Caption of message box displaying any property error
+#: ../src/propgrid/propgrid.cpp:3145 ../src/propgrid/propgrid.cpp:3282
+msgid "Property Error"
+msgstr "Chyba vlastnosti"
+
+#: ../src/propgrid/propgrid.cpp:3259
+msgid "You have entered invalid value. Press ESC to cancel editing."
+msgstr "Zadali ste neplatnú hodnotu. Stlačením ESC editáciu zrušíte."
+
+#: ../src/propgrid/propgrid.cpp:6608
+#, c-format
+msgid "Error in resource: %s"
+msgstr "Chyba v zdroji: %s"
+
+#: ../src/propgrid/propgridiface.cpp:377
+#, c-format
+msgid ""
+"Type operation \"%s\" failed: Property labeled \"%s\" is of type \"%s\", NOT "
+"\"%s\"."
+msgstr ""
+"Zadanie typu '%s' zlyhalo: Vlastnosť s označením '%s' je typu '%s', NIE '%s'."
+
+#: ../src/propgrid/props.cpp:159
+#, c-format
+msgid "Unknown base %d. Base 10 will be used."
+msgstr ""
+
+#: ../src/propgrid/props.cpp:324
+#, c-format
+msgid "Value must be %s or higher."
+msgstr "Hodnota musí byť %s alebo vyššia."
+
+#: ../src/propgrid/props.cpp:329 ../src/propgrid/props.cpp:356
+#, c-format
+msgid "Value must be between %s and %s."
+msgstr "Hodnota musí byť medzi %s a %s."
+
+#: ../src/propgrid/props.cpp:351
+#, c-format
+msgid "Value must be %s or less."
+msgstr "Hodnota musí byť %s alebo nižšia."
+
+#: ../src/propgrid/props.cpp:1058
+#, c-format
+msgid "Not %s"
+msgstr "Bez %s"
+
+#: ../src/propgrid/props.cpp:1770
+msgid "Choose a directory:"
+msgstr "Vybrať priečinok:"
+
+#: ../src/propgrid/props.cpp:2055
+msgid "Choose a file"
+msgstr "Vybrať súbor"
+
+#: ../src/qt/mdi.cpp:254
+msgid "&Tile"
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:147
+#: ../src/richtext/richtextformatdlg.cpp:376
+msgid "Background"
+msgstr "Pozadie"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:159
+msgid "Background &colour:"
+msgstr "&Farba pozadia:"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:161
+#: ../src/richtext/richtextbackgroundpage.cpp:163
+msgid "Enables a background colour."
+msgstr "Povolí farbu pozadia."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:167
+#: ../src/richtext/richtextbackgroundpage.cpp:169
+msgid "The background colour."
+msgstr "Farba pozadia."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:178
+msgid "Shadow"
+msgstr "Tieň"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:193
+msgid "Use &shadow"
+msgstr "Použiť &tieň"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:195
+#: ../src/richtext/richtextbackgroundpage.cpp:197
+msgid "Enables a shadow."
+msgstr "Povolí tieň."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:211
+msgid "&Horizontal offset:"
+msgstr "&Vodorovný posuv:"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:218
+#: ../src/richtext/richtextbackgroundpage.cpp:220
+msgid "The horizontal offset."
+msgstr "Horizontálny posuv."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:224
+#: ../src/richtext/richtextbackgroundpage.cpp:227
+#: ../src/richtext/richtextbackgroundpage.cpp:228
+#: ../src/richtext/richtextbackgroundpage.cpp:247
+#: ../src/richtext/richtextbackgroundpage.cpp:250
+#: ../src/richtext/richtextbackgroundpage.cpp:251
+#: ../src/richtext/richtextbackgroundpage.cpp:287
+#: ../src/richtext/richtextbackgroundpage.cpp:290
+#: ../src/richtext/richtextbackgroundpage.cpp:291
+#: ../src/richtext/richtextbackgroundpage.cpp:314
+#: ../src/richtext/richtextbackgroundpage.cpp:317
+#: ../src/richtext/richtextbackgroundpage.cpp:318
+#: ../src/richtext/richtextborderspage.cpp:252
+#: ../src/richtext/richtextborderspage.cpp:255
+#: ../src/richtext/richtextborderspage.cpp:256
+#: ../src/richtext/richtextborderspage.cpp:286
+#: ../src/richtext/richtextborderspage.cpp:289
+#: ../src/richtext/richtextborderspage.cpp:290
+#: ../src/richtext/richtextborderspage.cpp:320
+#: ../src/richtext/richtextborderspage.cpp:323
+#: ../src/richtext/richtextborderspage.cpp:324
+#: ../src/richtext/richtextborderspage.cpp:354
+#: ../src/richtext/richtextborderspage.cpp:357
+#: ../src/richtext/richtextborderspage.cpp:358
+#: ../src/richtext/richtextborderspage.cpp:420
+#: ../src/richtext/richtextborderspage.cpp:423
+#: ../src/richtext/richtextborderspage.cpp:424
+#: ../src/richtext/richtextborderspage.cpp:454
+#: ../src/richtext/richtextborderspage.cpp:457
+#: ../src/richtext/richtextborderspage.cpp:458
+#: ../src/richtext/richtextborderspage.cpp:488
+#: ../src/richtext/richtextborderspage.cpp:491
+#: ../src/richtext/richtextborderspage.cpp:492
+#: ../src/richtext/richtextborderspage.cpp:522
+#: ../src/richtext/richtextborderspage.cpp:525
+#: ../src/richtext/richtextborderspage.cpp:526
+#: ../src/richtext/richtextborderspage.cpp:590
+#: ../src/richtext/richtextborderspage.cpp:593
+#: ../src/richtext/richtextborderspage.cpp:594
+#: ../src/richtext/richtextfontpage.cpp:177
+#: ../src/richtext/richtextmarginspage.cpp:199
+#: ../src/richtext/richtextmarginspage.cpp:201
+#: ../src/richtext/richtextmarginspage.cpp:202
+#: ../src/richtext/richtextmarginspage.cpp:224
+#: ../src/richtext/richtextmarginspage.cpp:226
+#: ../src/richtext/richtextmarginspage.cpp:227
+#: ../src/richtext/richtextmarginspage.cpp:247
+#: ../src/richtext/richtextmarginspage.cpp:249
+#: ../src/richtext/richtextmarginspage.cpp:250
+#: ../src/richtext/richtextmarginspage.cpp:272
+#: ../src/richtext/richtextmarginspage.cpp:274
+#: ../src/richtext/richtextmarginspage.cpp:275
+#: ../src/richtext/richtextmarginspage.cpp:313
+#: ../src/richtext/richtextmarginspage.cpp:315
+#: ../src/richtext/richtextmarginspage.cpp:316
+#: ../src/richtext/richtextmarginspage.cpp:338
+#: ../src/richtext/richtextmarginspage.cpp:340
+#: ../src/richtext/richtextmarginspage.cpp:341
+#: ../src/richtext/richtextmarginspage.cpp:361
+#: ../src/richtext/richtextmarginspage.cpp:363
+#: ../src/richtext/richtextmarginspage.cpp:364
+#: ../src/richtext/richtextmarginspage.cpp:386
+#: ../src/richtext/richtextmarginspage.cpp:388
+#: ../src/richtext/richtextmarginspage.cpp:389
+#: ../src/richtext/richtextsizepage.cpp:337
+#: ../src/richtext/richtextsizepage.cpp:340
+#: ../src/richtext/richtextsizepage.cpp:341
+#: ../src/richtext/richtextsizepage.cpp:371
+#: ../src/richtext/richtextsizepage.cpp:374
+#: ../src/richtext/richtextsizepage.cpp:375
+#: ../src/richtext/richtextsizepage.cpp:398
+#: ../src/richtext/richtextsizepage.cpp:401
+#: ../src/richtext/richtextsizepage.cpp:402
+#: ../src/richtext/richtextsizepage.cpp:425
+#: ../src/richtext/richtextsizepage.cpp:428
+#: ../src/richtext/richtextsizepage.cpp:429
+#: ../src/richtext/richtextsizepage.cpp:452
+#: ../src/richtext/richtextsizepage.cpp:455
+#: ../src/richtext/richtextsizepage.cpp:456
+#: ../src/richtext/richtextsizepage.cpp:479
+#: ../src/richtext/richtextsizepage.cpp:482
+#: ../src/richtext/richtextsizepage.cpp:483
+#: ../src/richtext/richtextsizepage.cpp:553
+#: ../src/richtext/richtextsizepage.cpp:556
+#: ../src/richtext/richtextsizepage.cpp:557
+#: ../src/richtext/richtextsizepage.cpp:588
+#: ../src/richtext/richtextsizepage.cpp:591
+#: ../src/richtext/richtextsizepage.cpp:592
+#: ../src/richtext/richtextsizepage.cpp:623
+#: ../src/richtext/richtextsizepage.cpp:626
+#: ../src/richtext/richtextsizepage.cpp:627
+#: ../src/richtext/richtextsizepage.cpp:658
+#: ../src/richtext/richtextsizepage.cpp:661
+#: ../src/richtext/richtextsizepage.cpp:662
+msgid "px"
+msgstr "px"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:225
+#: ../src/richtext/richtextbackgroundpage.cpp:248
+#: ../src/richtext/richtextbackgroundpage.cpp:288
+#: ../src/richtext/richtextbackgroundpage.cpp:315
+#: ../src/richtext/richtextborderspage.cpp:253
+#: ../src/richtext/richtextborderspage.cpp:287
+#: ../src/richtext/richtextborderspage.cpp:321
+#: ../src/richtext/richtextborderspage.cpp:355
+#: ../src/richtext/richtextborderspage.cpp:421
+#: ../src/richtext/richtextborderspage.cpp:455
+#: ../src/richtext/richtextborderspage.cpp:489
+#: ../src/richtext/richtextborderspage.cpp:523
+#: ../src/richtext/richtextborderspage.cpp:591
+#: ../src/richtext/richtextmarginspage.cpp:200
+#: ../src/richtext/richtextmarginspage.cpp:225
+#: ../src/richtext/richtextmarginspage.cpp:248
+#: ../src/richtext/richtextmarginspage.cpp:273
+#: ../src/richtext/richtextmarginspage.cpp:314
+#: ../src/richtext/richtextmarginspage.cpp:339
+#: ../src/richtext/richtextmarginspage.cpp:362
+#: ../src/richtext/richtextmarginspage.cpp:387
+#: ../src/richtext/richtextsizepage.cpp:338
+#: ../src/richtext/richtextsizepage.cpp:372
+#: ../src/richtext/richtextsizepage.cpp:399
+#: ../src/richtext/richtextsizepage.cpp:426
+#: ../src/richtext/richtextsizepage.cpp:453
+#: ../src/richtext/richtextsizepage.cpp:480
+#: ../src/richtext/richtextsizepage.cpp:554
+#: ../src/richtext/richtextsizepage.cpp:589
+#: ../src/richtext/richtextsizepage.cpp:624
+#: ../src/richtext/richtextsizepage.cpp:659
+msgid "cm"
+msgstr "cm"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:226
+#: ../src/richtext/richtextbackgroundpage.cpp:249
+#: ../src/richtext/richtextbackgroundpage.cpp:289
+#: ../src/richtext/richtextbackgroundpage.cpp:316
+#: ../src/richtext/richtextborderspage.cpp:254
+#: ../src/richtext/richtextborderspage.cpp:288
+#: ../src/richtext/richtextborderspage.cpp:322
+#: ../src/richtext/richtextborderspage.cpp:356
+#: ../src/richtext/richtextborderspage.cpp:422
+#: ../src/richtext/richtextborderspage.cpp:456
+#: ../src/richtext/richtextborderspage.cpp:490
+#: ../src/richtext/richtextborderspage.cpp:524
+#: ../src/richtext/richtextborderspage.cpp:592
+#: ../src/richtext/richtextfontpage.cpp:176
+#: ../src/richtext/richtextfontpage.cpp:179
+msgid "pt"
+msgstr "pt"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:229
+#: ../src/richtext/richtextbackgroundpage.cpp:231
+#: ../src/richtext/richtextbackgroundpage.cpp:252
+#: ../src/richtext/richtextbackgroundpage.cpp:254
+#: ../src/richtext/richtextbackgroundpage.cpp:292
+#: ../src/richtext/richtextbackgroundpage.cpp:294
+#: ../src/richtext/richtextbackgroundpage.cpp:319
+#: ../src/richtext/richtextbackgroundpage.cpp:321
+msgid "Units for this value."
+msgstr "Jednotky pre túto hodnotu."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:234
+msgid "&Vertical offset:"
+msgstr "&Vertikálny posuv:"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:241
+#: ../src/richtext/richtextbackgroundpage.cpp:243
+msgid "The vertical offset."
+msgstr "Vertikálny pusuv."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:257
+msgid "Shadow c&olour:"
+msgstr "&Farba tieňa:"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:259
+#: ../src/richtext/richtextbackgroundpage.cpp:261
+msgid "Enables the shadow colour."
+msgstr "Povolí farbu tieňa."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:265
+#: ../src/richtext/richtextbackgroundpage.cpp:267
+msgid "The shadow colour."
+msgstr "Farba tieňa."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:270
+msgid "Sh&adow spread:"
+msgstr "Rozprestrenie &tieňa:"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:272
+#: ../src/richtext/richtextbackgroundpage.cpp:274
+msgid "Enables the shadow spread."
+msgstr "Povolí rozprestrenie tieňa."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:281
+#: ../src/richtext/richtextbackgroundpage.cpp:283
+msgid "The shadow spread."
+msgstr "Rozprestrenie tieňa."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:297
+msgid "&Blur distance:"
+msgstr "&Dĺžka rozostrenia:"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:299
+#: ../src/richtext/richtextbackgroundpage.cpp:301
+msgid "Enables the blur distance."
+msgstr "Povolí vzdialenosť rozmazania."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:308
+#: ../src/richtext/richtextbackgroundpage.cpp:310
+msgid "The shadow blur distance."
+msgstr "Vzdialenosť rozmazania tieňa."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:324
+msgid "Opaci&ty:"
+msgstr "Neprie&hľadnosť:"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:326
+#: ../src/richtext/richtextbackgroundpage.cpp:328
+msgid "Enables the shadow opacity."
+msgstr "Povolí nepriehľadnosť tieňa."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:335
+#: ../src/richtext/richtextbackgroundpage.cpp:337
+msgid "The shadow opacity."
+msgstr "Nepriehľadnosť tieňa."
+
+#. TRANSLATORS: Rich text page units (percentage)
+#: ../src/richtext/richtextbackgroundpage.cpp:340
+#: ../src/richtext/richtextsizepage.cpp:339
+#: ../src/richtext/richtextsizepage.cpp:373
+#: ../src/richtext/richtextsizepage.cpp:400
+#: ../src/richtext/richtextsizepage.cpp:427
+#: ../src/richtext/richtextsizepage.cpp:454
+#: ../src/richtext/richtextsizepage.cpp:481
+#: ../src/richtext/richtextsizepage.cpp:555
+#: ../src/richtext/richtextsizepage.cpp:590
+#: ../src/richtext/richtextsizepage.cpp:625
+#: ../src/richtext/richtextsizepage.cpp:660
+msgid "%"
+msgstr "%"
+
+#: ../src/richtext/richtextborderspage.cpp:229
+#: ../src/richtext/richtextborderspage.cpp:387
+msgid "Border"
+msgstr "Okraj"
+
+#: ../src/richtext/richtextborderspage.cpp:242
+#: ../src/richtext/richtextborderspage.cpp:410
+#: ../src/richtext/richtextindentspage.cpp:194
+#: ../src/richtext/richtextliststylepage.cpp:384
+#: ../src/richtext/richtextmarginspage.cpp:185
+#: ../src/richtext/richtextmarginspage.cpp:299
+#: ../src/richtext/richtextsizepage.cpp:531
+#: ../src/richtext/richtextsizepage.cpp:538
+msgid "&Left:"
+msgstr "&Vľavo:"
+
+#: ../src/richtext/richtextborderspage.cpp:257
+#: ../src/richtext/richtextborderspage.cpp:259
+msgid "Units for the left border width."
+msgstr "Jednotky pre šírku ľavého okraja."
+
+#: ../src/richtext/richtextborderspage.cpp:266
+#: ../src/richtext/richtextborderspage.cpp:268
+#: ../src/richtext/richtextborderspage.cpp:300
+#: ../src/richtext/richtextborderspage.cpp:302
+#: ../src/richtext/richtextborderspage.cpp:334
+#: ../src/richtext/richtextborderspage.cpp:336
+#: ../src/richtext/richtextborderspage.cpp:368
+#: ../src/richtext/richtextborderspage.cpp:370
+#: ../src/richtext/richtextborderspage.cpp:434
+#: ../src/richtext/richtextborderspage.cpp:436
+#: ../src/richtext/richtextborderspage.cpp:468
+#: ../src/richtext/richtextborderspage.cpp:470
+#: ../src/richtext/richtextborderspage.cpp:502
+#: ../src/richtext/richtextborderspage.cpp:504
+#: ../src/richtext/richtextborderspage.cpp:536
+#: ../src/richtext/richtextborderspage.cpp:538
+msgid "The border line style."
+msgstr "Štýl čiary okraju."
+
+#: ../src/richtext/richtextborderspage.cpp:276
+#: ../src/richtext/richtextborderspage.cpp:444
+#: ../src/richtext/richtextindentspage.cpp:212
+#: ../src/richtext/richtextliststylepage.cpp:402
+#: ../src/richtext/richtextmarginspage.cpp:210
+#: ../src/richtext/richtextmarginspage.cpp:324
+#: ../src/richtext/richtextsizepage.cpp:601
+#: ../src/richtext/richtextsizepage.cpp:608
+msgid "&Right:"
+msgstr "&Vpravo:"
+
+#: ../src/richtext/richtextborderspage.cpp:291
+#: ../src/richtext/richtextborderspage.cpp:293
+msgid "Units for the right border width."
+msgstr "Jednotky pre šírku pravého okraja."
+
+#: ../src/richtext/richtextborderspage.cpp:310
+#: ../src/richtext/richtextborderspage.cpp:478
+#: ../src/richtext/richtextmarginspage.cpp:233
+#: ../src/richtext/richtextmarginspage.cpp:347
+#: ../src/richtext/richtextsizepage.cpp:566
+#: ../src/richtext/richtextsizepage.cpp:573
+msgid "&Top:"
+msgstr "&Navrchu:"
+
+#: ../src/richtext/richtextborderspage.cpp:325
+#: ../src/richtext/richtextborderspage.cpp:327
+msgid "Units for the top border width."
+msgstr "Jednotky pre šírku horného okraja."
+
+#: ../src/richtext/richtextborderspage.cpp:344
+#: ../src/richtext/richtextborderspage.cpp:512
+#: ../src/richtext/richtextmarginspage.cpp:258
+#: ../src/richtext/richtextmarginspage.cpp:372
+#: ../src/richtext/richtextsizepage.cpp:636
+#: ../src/richtext/richtextsizepage.cpp:643
+msgid "&Bottom:"
+msgstr "&Dole:"
+
+#: ../src/richtext/richtextborderspage.cpp:359
+#: ../src/richtext/richtextborderspage.cpp:361
+msgid "Units for the bottom border width."
+msgstr "Jednotky pre šírku spodného okraja."
+
+#: ../src/richtext/richtextborderspage.cpp:380
+#: ../src/richtext/richtextborderspage.cpp:548
+msgid "&Synchronize values"
+msgstr "&Synchronizovať hodnoty"
+
+#: ../src/richtext/richtextborderspage.cpp:382
+#: ../src/richtext/richtextborderspage.cpp:384
+#: ../src/richtext/richtextborderspage.cpp:550
+#: ../src/richtext/richtextborderspage.cpp:552
+msgid "Check to edit all borders simultaneously."
+msgstr "Zaškrtnite pre úpravu všetkých okrajov súčasne."
+
+#: ../src/richtext/richtextborderspage.cpp:397
+#: ../src/richtext/richtextborderspage.cpp:555
+msgid "Outline"
+msgstr "Obrys"
+
+#: ../src/richtext/richtextborderspage.cpp:425
+#: ../src/richtext/richtextborderspage.cpp:427
+msgid "Units for the left outline width."
+msgstr "Jednotky pre šírku ľavého obrysu."
+
+#: ../src/richtext/richtextborderspage.cpp:459
+#: ../src/richtext/richtextborderspage.cpp:461
+msgid "Units for the right outline width."
+msgstr "Jednotky pre správnu šírku obrysu."
+
+#: ../src/richtext/richtextborderspage.cpp:493
+#: ../src/richtext/richtextborderspage.cpp:495
+msgid "Units for the top outline width."
+msgstr "Jednotky pre šírku horného obrysu."
+
+#: ../src/richtext/richtextborderspage.cpp:527
+#: ../src/richtext/richtextborderspage.cpp:529
+msgid "Units for the bottom outline width."
+msgstr "Jednotky pre šírku spodného obrysu."
+
+#: ../src/richtext/richtextborderspage.cpp:565
+#: ../src/richtext/richtextborderspage.cpp:600
+msgid "Corner"
+msgstr "Rohové"
+
+#: ../src/richtext/richtextborderspage.cpp:574
+msgid "Corner &radius:"
+msgstr "Zaoblenie &rohu:"
+
+#: ../src/richtext/richtextborderspage.cpp:576
+#: ../src/richtext/richtextborderspage.cpp:578
+msgid "An optional corner radius for adding rounded corners."
+msgstr "Nepovinný polomer zaoblenia pre pridanie zaoblených rohov."
+
+#: ../src/richtext/richtextborderspage.cpp:584
+#: ../src/richtext/richtextborderspage.cpp:586
+msgid "The value of the corner radius."
+msgstr "Hodnota polomeru rohu."
+
+#: ../src/richtext/richtextborderspage.cpp:595
+#: ../src/richtext/richtextborderspage.cpp:597
+msgid "Units for the corner radius."
+msgstr "Jednotky pre polomer rohu."
+
+#: ../src/richtext/richtextborderspage.cpp:609
+#: ../src/richtext/richtextsizepage.cpp:247
+#: ../src/richtext/richtextsizepage.cpp:251
+msgid "None"
+msgstr "Nič"
+
+#: ../src/richtext/richtextborderspage.cpp:610
+msgid "Solid"
+msgstr "Plný"
+
+#: ../src/richtext/richtextborderspage.cpp:611
+msgid "Dotted"
+msgstr "Bodkovaná"
+
+#: ../src/richtext/richtextborderspage.cpp:612
+msgid "Dashed"
+msgstr "Čiarkovaná"
+
+#: ../src/richtext/richtextborderspage.cpp:613
+msgid "Double"
+msgstr "Dvojitá"
+
+#: ../src/richtext/richtextborderspage.cpp:614
+msgid "Groove"
+msgstr "Drážka"
+
+#: ../src/richtext/richtextborderspage.cpp:615
+msgid "Ridge"
+msgstr "Vrcholky"
+
+#: ../src/richtext/richtextborderspage.cpp:616
+msgid "Inset"
+msgstr "Vložiť"
+
+#: ../src/richtext/richtextborderspage.cpp:617
+msgid "Outset"
+msgstr "Napred"
+
+#: ../src/richtext/richtextbuffer.cpp:3518
+msgid "Change Style"
+msgstr "Zmeniť štýl"
+
+#: ../src/richtext/richtextbuffer.cpp:3701
+msgid "Change Object Style"
+msgstr "Zmeniť štýl objektu"
+
+#: ../src/richtext/richtextbuffer.cpp:3974
+#: ../src/richtext/richtextbuffer.cpp:8174
+msgid "Change Properties"
+msgstr "Zmeniť vlastnosti"
+
+#: ../src/richtext/richtextbuffer.cpp:4346
+msgid "Change List Style"
+msgstr "Zmeniť štýl zoznamu"
+
+#: ../src/richtext/richtextbuffer.cpp:4519
+msgid "Renumber List"
+msgstr "Prečíslovať zoznam"
+
+#: ../src/richtext/richtextbuffer.cpp:7867
+#: ../src/richtext/richtextbuffer.cpp:7897
+#: ../src/richtext/richtextbuffer.cpp:7939
+#: ../src/richtext/richtextctrl.cpp:1279 ../src/richtext/richtextctrl.cpp:1473
+msgid "Insert Text"
+msgstr "Vložiť text"
+
+#: ../src/richtext/richtextbuffer.cpp:8023
+#: ../src/richtext/richtextbuffer.cpp:8979
+msgid "Insert Image"
+msgstr "Vložiť obrázok"
+
+#: ../src/richtext/richtextbuffer.cpp:8070
+msgid "Insert Object"
+msgstr "Vložiť objekt"
+
+#: ../src/richtext/richtextbuffer.cpp:8112
+msgid "Insert Field"
+msgstr "Vložiť pole"
+
+#: ../src/richtext/richtextbuffer.cpp:8410
+msgid "Too many EndStyle calls!"
+msgstr "Príliš veľa volaní EndStyle!"
+
+#: ../src/richtext/richtextbuffer.cpp:8785
+msgid "files"
+msgstr "súborov"
+
+#: ../src/richtext/richtextbuffer.cpp:9380
+msgid "standard/circle"
+msgstr "štandardné/kruh"
+
+#: ../src/richtext/richtextbuffer.cpp:9381
+msgid "standard/circle-outline"
+msgstr "štandardné/obrys kruhu"
+
+#: ../src/richtext/richtextbuffer.cpp:9382
+msgid "standard/square"
+msgstr "štandardné/štvorec"
+
+#: ../src/richtext/richtextbuffer.cpp:9383
+msgid "standard/diamond"
+msgstr "štandardné/diamant"
+
+#: ../src/richtext/richtextbuffer.cpp:9384
+msgid "standard/triangle"
+msgstr "štandardné/trojuholník"
+
+#: ../src/richtext/richtextbuffer.cpp:9423
+msgid "Box Properties"
+msgstr "Vlastnosti schránky"
+
+#: ../src/richtext/richtextbuffer.cpp:10006
+msgid "Multiple Cell Properties"
+msgstr "Vlastnosti viacerých buniek"
+
+#: ../src/richtext/richtextbuffer.cpp:10008
+msgid "Cell Properties"
+msgstr "Vlastnosti bunky"
+
+#: ../src/richtext/richtextbuffer.cpp:11256
+msgid "Set Cell Style"
+msgstr "Nastaviť štýl bunky"
+
+#: ../src/richtext/richtextbuffer.cpp:11330
+msgid "Delete Row"
+msgstr "Odstrániť riadok"
+
+#: ../src/richtext/richtextbuffer.cpp:11380
+msgid "Delete Column"
+msgstr "Odstrániť stĺpec"
+
+#: ../src/richtext/richtextbuffer.cpp:11431
+msgid "Add Row"
+msgstr "Pridať riadok"
+
+#: ../src/richtext/richtextbuffer.cpp:11494
+msgid "Add Column"
+msgstr "Pridať stĺpec"
+
+#: ../src/richtext/richtextbuffer.cpp:11537
+msgid "Table Properties"
+msgstr "Vlastnosti tabuľky"
+
+#: ../src/richtext/richtextbuffer.cpp:12899
+msgid "Picture Properties"
+msgstr "Vlastnosti obrázka"
+
+#: ../src/richtext/richtextbuffer.cpp:13169
+#: ../src/richtext/richtextbuffer.cpp:13279
+msgid "image"
+msgstr "obrázok"
+
+#: ../src/richtext/richtextbulletspage.cpp:145
+#: ../src/richtext/richtextliststylepage.cpp:209
+msgid "&Bullet style:"
+msgstr "& Štýl odrážky:"
+
+#: ../src/richtext/richtextbulletspage.cpp:150
+#: ../src/richtext/richtextbulletspage.cpp:152
+#: ../src/richtext/richtextliststylepage.cpp:214
+#: ../src/richtext/richtextliststylepage.cpp:216
+msgid "The available bullet styles."
+msgstr "Dostupné štýly oddeľovačov položiek zoznamu."
+
+#: ../src/richtext/richtextbulletspage.cpp:158
+#: ../src/richtext/richtextliststylepage.cpp:221
+msgid "Peri&od"
+msgstr "Perió&da"
+
+#: ../src/richtext/richtextbulletspage.cpp:160
+#: ../src/richtext/richtextbulletspage.cpp:162
+#: ../src/richtext/richtextliststylepage.cpp:223
+#: ../src/richtext/richtextliststylepage.cpp:225
+msgid "Check to add a period after the bullet."
+msgstr "Zaškrtnite pre pridanie bodky za odrážku."
+
+#. TRANSLATORS: Bullet point in parentheses option
+#: ../src/richtext/richtextbulletspage.cpp:167
+#: ../src/richtext/richtextliststylepage.cpp:230
+msgid "(*)"
+msgstr "(*)"
+
+#: ../src/richtext/richtextbulletspage.cpp:169
+#: ../src/richtext/richtextbulletspage.cpp:171
+#: ../src/richtext/richtextliststylepage.cpp:232
+#: ../src/richtext/richtextliststylepage.cpp:234
+msgid "Check to enclose the bullet in parentheses."
+msgstr "Zaškrtnite pre uzatvorenie odrážok do zátvoriek."
+
+#. TRANSLATORS: Right parenthesis bullet point option
+#: ../src/richtext/richtextbulletspage.cpp:176
+#: ../src/richtext/richtextliststylepage.cpp:239
+msgid "*)"
+msgstr "*)"
+
+#: ../src/richtext/richtextbulletspage.cpp:178
+#: ../src/richtext/richtextbulletspage.cpp:180
+#: ../src/richtext/richtextliststylepage.cpp:241
+#: ../src/richtext/richtextliststylepage.cpp:243
+msgid "Check to add a right parenthesis."
+msgstr "Zaškrtnite pre pridanie pravej zátvorky."
+
+#: ../src/richtext/richtextbulletspage.cpp:185
+#: ../src/richtext/richtextliststylepage.cpp:248
+msgid "Bullet &Alignment:"
+msgstr "Odrážka a zarovnanie:"
+
+#: ../src/richtext/richtextbulletspage.cpp:190
+#: ../src/richtext/richtextliststylepage.cpp:253
+msgid "Centre"
+msgstr "Centrovať"
+
+#: ../src/richtext/richtextbulletspage.cpp:194
+#: ../src/richtext/richtextbulletspage.cpp:196
+#: ../src/richtext/richtextbulletspage.cpp:217
+#: ../src/richtext/richtextbulletspage.cpp:219
+#: ../src/richtext/richtextliststylepage.cpp:257
+#: ../src/richtext/richtextliststylepage.cpp:259
+#: ../src/richtext/richtextliststylepage.cpp:278
+#: ../src/richtext/richtextliststylepage.cpp:280
+msgid "The bullet character."
+msgstr "Znak oddeľovača položiek zoznamu."
+
+#: ../src/richtext/richtextbulletspage.cpp:212
+#: ../src/richtext/richtextliststylepage.cpp:271
+msgid "&Symbol:"
+msgstr "&Symbol:"
+
+#: ../src/richtext/richtextbulletspage.cpp:222
+#: ../src/richtext/richtextliststylepage.cpp:283
+msgid "Ch&oose..."
+msgstr "Zv&oliť..."
+
+#: ../src/richtext/richtextbulletspage.cpp:223
+#: ../src/richtext/richtextbulletspage.cpp:225
+#: ../src/richtext/richtextliststylepage.cpp:284
+#: ../src/richtext/richtextliststylepage.cpp:286
+msgid "Click to browse for a symbol."
+msgstr "Kliknite pre prechádzanie symbolmi."
+
+#: ../src/richtext/richtextbulletspage.cpp:230
+#: ../src/richtext/richtextliststylepage.cpp:291
+msgid "Symbol &font:"
+msgstr "&Písmo symbolu:"
+
+#: ../src/richtext/richtextbulletspage.cpp:235
+#: ../src/richtext/richtextbulletspage.cpp:237
+#: ../src/richtext/richtextliststylepage.cpp:297
+msgid "Available fonts."
+msgstr "Dostupné písma."
+
+#: ../src/richtext/richtextbulletspage.cpp:242
+#: ../src/richtext/richtextliststylepage.cpp:302
+msgid "S&tandard bullet name:"
+msgstr "Názov š&tandardného oddeľovača položiek zoznamu:"
+
+#: ../src/richtext/richtextbulletspage.cpp:247
+#: ../src/richtext/richtextbulletspage.cpp:249
+#: ../src/richtext/richtextliststylepage.cpp:307
+#: ../src/richtext/richtextliststylepage.cpp:309
+msgid "A standard bullet name."
+msgstr "Názov štandardného oddeľovača položiek zoznamu."
+
+#: ../src/richtext/richtextbulletspage.cpp:254
+msgid "&Number:"
+msgstr "&Číslo:"
+
+#: ../src/richtext/richtextbulletspage.cpp:258
+#: ../src/richtext/richtextbulletspage.cpp:260
+msgid "The list item number."
+msgstr "Číslo položky zoznamu."
+
+#: ../src/richtext/richtextbulletspage.cpp:266
+#: ../src/richtext/richtextbulletspage.cpp:268
+#: ../src/richtext/richtextliststylepage.cpp:475
+#: ../src/richtext/richtextliststylepage.cpp:477
+msgid "Shows a preview of the bullet settings."
+msgstr "Zobrazí náhľad nastavení oddeľovačov položiek zoznamu."
+
+#: ../src/richtext/richtextbulletspage.cpp:276
+#: ../src/richtext/richtextliststylepage.cpp:484
+msgid "(None)"
+msgstr "(Žiadny)"
+
+#: ../src/richtext/richtextbulletspage.cpp:277
+#: ../src/richtext/richtextliststylepage.cpp:485
+msgid "Arabic"
+msgstr "Arabčina"
+
+#: ../src/richtext/richtextbulletspage.cpp:278
+#: ../src/richtext/richtextliststylepage.cpp:486
+msgid "Upper case letters"
+msgstr "Veľké písmená"
+
+#: ../src/richtext/richtextbulletspage.cpp:279
+#: ../src/richtext/richtextliststylepage.cpp:487
+msgid "Lower case letters"
+msgstr "Malé písmená"
+
+#: ../src/richtext/richtextbulletspage.cpp:280
+#: ../src/richtext/richtextliststylepage.cpp:488
+msgid "Upper case roman numerals"
+msgstr "Veľké rímske číslice"
+
+#: ../src/richtext/richtextbulletspage.cpp:281
+#: ../src/richtext/richtextliststylepage.cpp:489
+msgid "Lower case roman numerals"
+msgstr "Malé rímske číslice"
+
+#: ../src/richtext/richtextbulletspage.cpp:282
+#: ../src/richtext/richtextliststylepage.cpp:490
+msgid "Numbered outline"
+msgstr "Očíslovaný obrys"
+
+#: ../src/richtext/richtextbulletspage.cpp:283
+#: ../src/richtext/richtextliststylepage.cpp:491
+msgid "Symbol"
+msgstr "Symbol"
+
+#: ../src/richtext/richtextbulletspage.cpp:284
+#: ../src/richtext/richtextliststylepage.cpp:492
+msgid "Bitmap"
+msgstr "Bitmapa"
+
+#: ../src/richtext/richtextbulletspage.cpp:285
+#: ../src/richtext/richtextliststylepage.cpp:493
+msgid "Standard"
+msgstr "Štandard"
+
+#: ../src/richtext/richtextbulletspage.cpp:287
+#: ../src/richtext/richtextliststylepage.cpp:495
+msgid "*"
+msgstr "*"
+
+#: ../src/richtext/richtextbulletspage.cpp:288
+#: ../src/richtext/richtextliststylepage.cpp:496
+msgid "-"
+msgstr "-"
+
+#: ../src/richtext/richtextbulletspage.cpp:289
+#: ../src/richtext/richtextliststylepage.cpp:497
+msgid ">"
+msgstr ">"
+
+#: ../src/richtext/richtextbulletspage.cpp:290
+#: ../src/richtext/richtextliststylepage.cpp:498
+msgid "+"
+msgstr "+"
+
+#: ../src/richtext/richtextbulletspage.cpp:291
+#: ../src/richtext/richtextliststylepage.cpp:499
+msgid "~"
+msgstr "~"
+
+#: ../src/richtext/richtextctrl.cpp:859
+msgid "Drag"
+msgstr "Ťahať"
+
+#: ../src/richtext/richtextctrl.cpp:1338 ../src/richtext/richtextctrl.cpp:1559
+msgid "Delete Text"
+msgstr "Odstrániť text"
+
+#: ../src/richtext/richtextctrl.cpp:1537
+msgid "Remove Bullet"
+msgstr "Odstrániť oddeľovač"
+
+#: ../src/richtext/richtextctrl.cpp:3070
+msgid "The text couldn't be saved."
+msgstr "Nemožno uložiť text."
+
+#: ../src/richtext/richtextctrl.cpp:3644
+msgid "Replace"
+msgstr "Nahradiť"
+
+#: ../src/richtext/richtextfontpage.cpp:146
+#: ../src/richtext/richtextsymboldlg.cpp:384
+msgid "&Font:"
+msgstr "&Písmo:"
+
+#: ../src/richtext/richtextfontpage.cpp:150
+#: ../src/richtext/richtextfontpage.cpp:152
+msgid "Type a font name."
+msgstr "Zadajte názov písma."
+
+#: ../src/richtext/richtextfontpage.cpp:158
+msgid "&Size:"
+msgstr "&Veľkosť:"
+
+#: ../src/richtext/richtextfontpage.cpp:165
+#: ../src/richtext/richtextfontpage.cpp:167
+msgid "Type a size in points."
+msgstr "Zadajte veľkosť v bodoch."
+
+#: ../src/richtext/richtextfontpage.cpp:180
+#: ../src/richtext/richtextfontpage.cpp:182
+msgid "The font size units, points or pixels."
+msgstr "Jednotky veľkosti písma, body alebo pixely."
+
+#: ../src/richtext/richtextfontpage.cpp:189
+#: ../src/richtext/richtextfontpage.cpp:191
+msgid "Lists the available fonts."
+msgstr "Zoznamy dostupných typov písma."
+
+#: ../src/richtext/richtextfontpage.cpp:196
+#: ../src/richtext/richtextfontpage.cpp:198
+msgid "Lists font sizes in points."
+msgstr "Zoznamy veľkosti písma v bodoch."
+
+#: ../src/richtext/richtextfontpage.cpp:207
+msgid "Font st&yle:"
+msgstr "Š&týl písma:"
+
+#: ../src/richtext/richtextfontpage.cpp:212
+#: ../src/richtext/richtextfontpage.cpp:214
+msgid "Select regular or italic style."
+msgstr "Vybrať obyčajné alebo kurzívu."
+
+#: ../src/richtext/richtextfontpage.cpp:220
+msgid "Font &weight:"
+msgstr "&Hrúbka písma:"
+
+#: ../src/richtext/richtextfontpage.cpp:225
+#: ../src/richtext/richtextfontpage.cpp:227
+msgid "Select regular or bold."
+msgstr "Vybrať obyčajné alebo tučné."
+
+#: ../src/richtext/richtextfontpage.cpp:233
+msgid "&Underlining:"
+msgstr "&Podčiarknuté:"
+
+#: ../src/richtext/richtextfontpage.cpp:238
+#: ../src/richtext/richtextfontpage.cpp:240
+msgid "Select underlining or no underlining."
+msgstr "Vybrať podčiarknuté alebo bez podčiarknutia."
+
+#: ../src/richtext/richtextfontpage.cpp:248
+msgid "&Colour:"
+msgstr "&Farba:"
+
+#: ../src/richtext/richtextfontpage.cpp:253
+#: ../src/richtext/richtextfontpage.cpp:255
+msgid "Click to change the text colour."
+msgstr "Kliknite pre zmenu farby písma."
+
+#: ../src/richtext/richtextfontpage.cpp:261
+msgid "&Bg colour:"
+msgstr "&Bg farba:"
+
+#: ../src/richtext/richtextfontpage.cpp:266
+#: ../src/richtext/richtextfontpage.cpp:268
+msgid "Click to change the text background colour."
+msgstr "Kliknite pre zmenu farby pozadia textu."
+
+#: ../src/richtext/richtextfontpage.cpp:276
+#: ../src/richtext/richtextfontpage.cpp:278
+msgid "Check to show a line through the text."
+msgstr "Zaškrtnite pre preškrtnuté písmo."
+
+#: ../src/richtext/richtextfontpage.cpp:281
+msgid "Ca&pitals"
+msgstr "&Kapitálky"
+
+#: ../src/richtext/richtextfontpage.cpp:283
+#: ../src/richtext/richtextfontpage.cpp:285
+msgid "Check to show the text in capitals."
+msgstr "Zaškrtnite pre zobrazenie textu kapitálkami."
+
+#: ../src/richtext/richtextfontpage.cpp:288
+msgid "Small C&apitals"
+msgstr "Malé &kapitálky"
+
+#: ../src/richtext/richtextfontpage.cpp:290
+#: ../src/richtext/richtextfontpage.cpp:292
+msgid "Check to show the text in small capitals."
+msgstr "Zaškrtnite pre zobrazenie textu malými kapitálkami."
+
+#: ../src/richtext/richtextfontpage.cpp:295
+msgid "Supe&rscript"
+msgstr "Supers&kript"
+
+#: ../src/richtext/richtextfontpage.cpp:297
+#: ../src/richtext/richtextfontpage.cpp:299
+msgid "Check to show the text in superscript."
+msgstr "Zaškrtnite pre zobrazenie textu s horným indexom."
+
+#: ../src/richtext/richtextfontpage.cpp:302
+msgid "Subscrip&t"
+msgstr "Pod&skript"
+
+#: ../src/richtext/richtextfontpage.cpp:304
+#: ../src/richtext/richtextfontpage.cpp:306
+msgid "Check to show the text in subscript."
+msgstr "Zaškrtnite pre zobrazenie textu s dolným indexom."
+
+#: ../src/richtext/richtextfontpage.cpp:312
+msgid "Rig&ht-to-left"
+msgstr "S&prava doľava"
+
+#: ../src/richtext/richtextfontpage.cpp:314
+#: ../src/richtext/richtextfontpage.cpp:316
+msgid "Check to indicate right-to-left text layout."
+msgstr "Zaškrtnite pre rozvrhnutie textu z prava doľava."
+
+#: ../src/richtext/richtextfontpage.cpp:319
+msgid "Suppress hyphe&nation"
+msgstr "Potlačiť &delenie slov"
+
+#: ../src/richtext/richtextfontpage.cpp:321
+#: ../src/richtext/richtextfontpage.cpp:323
+msgid "Check to suppress hyphenation."
+msgstr "Zaškrtnite pre potlačenie delenia slov."
+
+#: ../src/richtext/richtextfontpage.cpp:329
+#: ../src/richtext/richtextfontpage.cpp:331
+msgid "Shows a preview of the font settings."
+msgstr "Zobrazí náhľad nastavení písma."
+
+#: ../src/richtext/richtextfontpage.cpp:348
+#: ../src/richtext/richtextfontpage.cpp:352
+#: ../src/richtext/richtextfontpage.cpp:356
+#: ../src/richtext/richtextformatdlg.cpp:873
+#: ../src/richtext/richtextindentspage.cpp:273
+#: ../src/richtext/richtextindentspage.cpp:285
+#: ../src/richtext/richtextindentspage.cpp:286
+#: ../src/richtext/richtextindentspage.cpp:310
+#: ../src/richtext/richtextindentspage.cpp:325
+#: ../src/richtext/richtextliststylepage.cpp:451
+#: ../src/richtext/richtextliststylepage.cpp:463
+#: ../src/richtext/richtextliststylepage.cpp:464
+msgid "(none)"
+msgstr "(žiadny)"
+
+#: ../src/richtext/richtextfontpage.cpp:349
+#: ../src/richtext/richtextfontpage.cpp:353
+msgid "Regular"
+msgstr "Bežné"
+
+#: ../src/richtext/richtextfontpage.cpp:357
+msgid "Not underlined"
+msgstr "Nie podčiarknuté"
+
+#: ../src/richtext/richtextformatdlg.cpp:341
+msgid "Indents && Spacing"
+msgstr "Odsadenie && medzery"
+
+#: ../src/richtext/richtextformatdlg.cpp:346
+msgid "Tabs"
+msgstr "Tabelátory"
+
+#: ../src/richtext/richtextformatdlg.cpp:351
+msgid "Bullets"
+msgstr "Odrážky"
+
+#: ../src/richtext/richtextformatdlg.cpp:356
+msgid "List Style"
+msgstr "Štýl zoznamu"
+
+#: ../src/richtext/richtextformatdlg.cpp:366
+#: ../src/richtext/richtextmarginspage.cpp:170
+msgid "Margins"
+msgstr "Okraje"
+
+#: ../src/richtext/richtextformatdlg.cpp:371
+msgid "Borders"
+msgstr "Okraje"
+
+#: ../src/richtext/richtextformatdlg.cpp:765
+msgid "Colour"
+msgstr "Farba"
+
+#: ../src/richtext/richtextindentspage.cpp:127
+#: ../src/richtext/richtextliststylepage.cpp:322
+msgid "&Alignment"
+msgstr "&Zarovnanie"
+
+#: ../src/richtext/richtextindentspage.cpp:138
+#: ../src/richtext/richtextliststylepage.cpp:331
+msgid "&Left"
+msgstr "&Vľavo"
+
+#: ../src/richtext/richtextindentspage.cpp:140
+#: ../src/richtext/richtextindentspage.cpp:142
+#: ../src/richtext/richtextliststylepage.cpp:333
+#: ../src/richtext/richtextliststylepage.cpp:335
+msgid "Left-align text."
+msgstr "Zarovnať text vľavo."
+
+#: ../src/richtext/richtextindentspage.cpp:145
+#: ../src/richtext/richtextliststylepage.cpp:338
+msgid "&Right"
+msgstr "&Vpravo"
+
+#: ../src/richtext/richtextindentspage.cpp:147
+#: ../src/richtext/richtextindentspage.cpp:149
+#: ../src/richtext/richtextliststylepage.cpp:340
+#: ../src/richtext/richtextliststylepage.cpp:342
+msgid "Right-align text."
+msgstr "Zarovnať text doprava."
+
+#: ../src/richtext/richtextindentspage.cpp:152
+#: ../src/richtext/richtextliststylepage.cpp:345
+msgid "&Justified"
+msgstr "&Zarovnaný"
+
+#: ../src/richtext/richtextindentspage.cpp:154
+#: ../src/richtext/richtextindentspage.cpp:156
+#: ../src/richtext/richtextliststylepage.cpp:347
+#: ../src/richtext/richtextliststylepage.cpp:349
+msgid "Justify text left and right."
+msgstr "Zarovná text doľava a doprava."
+
+#: ../src/richtext/richtextindentspage.cpp:159
+#: ../src/richtext/richtextliststylepage.cpp:352
+msgid "Cen&tred"
+msgstr "Cen&trovaný"
+
+#: ../src/richtext/richtextindentspage.cpp:161
+#: ../src/richtext/richtextindentspage.cpp:163
+#: ../src/richtext/richtextliststylepage.cpp:354
+#: ../src/richtext/richtextliststylepage.cpp:356
+msgid "Centre text."
+msgstr "Centrovať text."
+
+#: ../src/richtext/richtextindentspage.cpp:166
+#: ../src/richtext/richtextliststylepage.cpp:359
+msgid "&Indeterminate"
+msgstr "&Neurčitý"
+
+#: ../src/richtext/richtextindentspage.cpp:168
+#: ../src/richtext/richtextindentspage.cpp:170
+#: ../src/richtext/richtextliststylepage.cpp:361
+#: ../src/richtext/richtextliststylepage.cpp:363
+msgid "Use the current alignment setting."
+msgstr "Použiť súčasné nastavenie zarovnania."
+
+#: ../src/richtext/richtextindentspage.cpp:183
+#: ../src/richtext/richtextliststylepage.cpp:375
+msgid "&Indentation (tenths of a mm)"
+msgstr "&Odsadenie (desatiny milimetra)"
+
+#: ../src/richtext/richtextindentspage.cpp:198
+#: ../src/richtext/richtextindentspage.cpp:200
+#: ../src/richtext/richtextliststylepage.cpp:388
+#: ../src/richtext/richtextliststylepage.cpp:390
+msgid "The left indent."
+msgstr "Odsadenie zľava."
+
+#: ../src/richtext/richtextindentspage.cpp:203
+#: ../src/richtext/richtextliststylepage.cpp:393
+msgid "Left (&first line):"
+msgstr "Zľava (&prvý riadok):"
+
+#: ../src/richtext/richtextindentspage.cpp:207
+#: ../src/richtext/richtextindentspage.cpp:209
+#: ../src/richtext/richtextliststylepage.cpp:397
+#: ../src/richtext/richtextliststylepage.cpp:399
+msgid "The first line indent."
+msgstr "Odsadenie prvého riadka."
+
+#: ../src/richtext/richtextindentspage.cpp:216
+#: ../src/richtext/richtextindentspage.cpp:218
+#: ../src/richtext/richtextliststylepage.cpp:406
+#: ../src/richtext/richtextliststylepage.cpp:408
+msgid "The right indent."
+msgstr "Pravé odsadenie."
+
+#: ../src/richtext/richtextindentspage.cpp:221
+msgid "&Outline level:"
+msgstr "&Úroveň osnovy:"
+
+#: ../src/richtext/richtextindentspage.cpp:226
+#: ../src/richtext/richtextindentspage.cpp:228
+msgid "The outline level."
+msgstr "Úroveň obrysu."
+
+#: ../src/richtext/richtextindentspage.cpp:241
+#: ../src/richtext/richtextliststylepage.cpp:420
+msgid "&Spacing (tenths of a mm)"
+msgstr "&Rozostup (desatiny milimetra)"
+
+#: ../src/richtext/richtextindentspage.cpp:252
+msgid "&Before a paragraph:"
+msgstr "&Pred odstavcom:"
+
+#: ../src/richtext/richtextindentspage.cpp:256
+#: ../src/richtext/richtextindentspage.cpp:258
+#: ../src/richtext/richtextliststylepage.cpp:433
+#: ../src/richtext/richtextliststylepage.cpp:435
+msgid "The spacing before the paragraph."
+msgstr "Šírka medzery pred odsekom."
+
+#: ../src/richtext/richtextindentspage.cpp:261
+msgid "&After a paragraph:"
+msgstr "& Za odsekom:"
+
+#: ../src/richtext/richtextindentspage.cpp:266
+#: ../src/richtext/richtextliststylepage.cpp:442
+#: ../src/richtext/richtextliststylepage.cpp:444
+msgid "The spacing after the paragraph."
+msgstr "Šírka medzery po odseku."
+
+#: ../src/richtext/richtextindentspage.cpp:269
+msgid "L&ine spacing:"
+msgstr "&Riadkovanie:"
+
+#: ../src/richtext/richtextindentspage.cpp:274
+#: ../src/richtext/richtextliststylepage.cpp:452
+msgid "Single"
+msgstr "Osamotene"
+
+#: ../src/richtext/richtextindentspage.cpp:275
+#: ../src/richtext/richtextliststylepage.cpp:453
+msgid "1.1"
+msgstr "1.1"
+
+#: ../src/richtext/richtextindentspage.cpp:276
+#: ../src/richtext/richtextliststylepage.cpp:454
+msgid "1.2"
+msgstr "1.2"
+
+#: ../src/richtext/richtextindentspage.cpp:277
+#: ../src/richtext/richtextliststylepage.cpp:455
+msgid "1.3"
+msgstr "1.3"
+
+#: ../src/richtext/richtextindentspage.cpp:278
+#: ../src/richtext/richtextliststylepage.cpp:456
+msgid "1.4"
+msgstr "1.4"
+
+#: ../src/richtext/richtextindentspage.cpp:279
+#: ../src/richtext/richtextliststylepage.cpp:457
+msgid "1.5"
+msgstr "1.5"
+
+#: ../src/richtext/richtextindentspage.cpp:280
+#: ../src/richtext/richtextliststylepage.cpp:458
+msgid "1.6"
+msgstr "1.6"
+
+#: ../src/richtext/richtextindentspage.cpp:281
+#: ../src/richtext/richtextliststylepage.cpp:459
+msgid "1.7"
+msgstr "1.7"
+
+#: ../src/richtext/richtextindentspage.cpp:282
+#: ../src/richtext/richtextliststylepage.cpp:460
+msgid "1.8"
+msgstr "1.8"
+
+#: ../src/richtext/richtextindentspage.cpp:283
+#: ../src/richtext/richtextliststylepage.cpp:461
+msgid "1.9"
+msgstr "1.9"
+
+#: ../src/richtext/richtextindentspage.cpp:284
+#: ../src/richtext/richtextliststylepage.cpp:462
+msgid "2"
+msgstr "2"
+
+#: ../src/richtext/richtextindentspage.cpp:287
+#: ../src/richtext/richtextindentspage.cpp:289
+#: ../src/richtext/richtextliststylepage.cpp:465
+#: ../src/richtext/richtextliststylepage.cpp:467
+msgid "The line spacing."
+msgstr "Riadkovanie."
+
+#: ../src/richtext/richtextindentspage.cpp:292
+msgid "&Page Break"
+msgstr "&Zlom strany"
+
+#: ../src/richtext/richtextindentspage.cpp:294
+#: ../src/richtext/richtextindentspage.cpp:296
+msgid "Inserts a page break before the paragraph."
+msgstr "Vloží zalomenie stránky pred odsek."
+
+#: ../src/richtext/richtextindentspage.cpp:302
+#: ../src/richtext/richtextindentspage.cpp:304
+msgid "Shows a preview of the paragraph settings."
+msgstr "Zobrazí náhľad nastavení odstavca."
+
+#: ../src/richtext/richtextliststylepage.cpp:182
+msgid "&List level:"
+msgstr "Ú&roveň zoznamu:"
+
+#: ../src/richtext/richtextliststylepage.cpp:186
+#: ../src/richtext/richtextliststylepage.cpp:188
+msgid "Selects the list level to edit."
+msgstr "Vyberá, ktorá úroveň zoznamu sa bude upravovať."
+
+#: ../src/richtext/richtextliststylepage.cpp:193
+msgid "&Font for Level..."
+msgstr "&Písmo pre úroveň..."
+
+#: ../src/richtext/richtextliststylepage.cpp:194
+#: ../src/richtext/richtextliststylepage.cpp:196
+msgid "Click to choose the font for this level."
+msgstr "Kliknite pre výber písma tejto úrovne."
+
+#: ../src/richtext/richtextliststylepage.cpp:312
+msgid "Bullet style"
+msgstr "Štýl odrážok"
+
+#: ../src/richtext/richtextliststylepage.cpp:429
+msgid "Before a paragraph:"
+msgstr "Pred odstavcom:"
+
+#: ../src/richtext/richtextliststylepage.cpp:438
+msgid "After a paragraph:"
+msgstr "Za odstavcom:"
+
+#: ../src/richtext/richtextliststylepage.cpp:447
+msgid "Line spacing:"
+msgstr "Riadkovanie:"
+
+#: ../src/richtext/richtextliststylepage.cpp:470
+msgid "Spacing"
+msgstr "Rozostup"
+
+#: ../src/richtext/richtextmarginspage.cpp:193
+#: ../src/richtext/richtextmarginspage.cpp:195
+msgid "The left margin size."
+msgstr "Veľkosť ľavého okraja."
+
+#: ../src/richtext/richtextmarginspage.cpp:203
+#: ../src/richtext/richtextmarginspage.cpp:205
+msgid "Units for the left margin."
+msgstr "Jednotky pre ľavý okraj."
+
+#: ../src/richtext/richtextmarginspage.cpp:218
+#: ../src/richtext/richtextmarginspage.cpp:220
+msgid "The right margin size."
+msgstr "Veľkosť pravého okraja."
+
+#: ../src/richtext/richtextmarginspage.cpp:228
+#: ../src/richtext/richtextmarginspage.cpp:230
+msgid "Units for the right margin."
+msgstr "Jednotky pre pravý okraj."
+
+#: ../src/richtext/richtextmarginspage.cpp:241
+#: ../src/richtext/richtextmarginspage.cpp:243
+msgid "The top margin size."
+msgstr "Veľkosť horného okraja."
+
+#: ../src/richtext/richtextmarginspage.cpp:251
+#: ../src/richtext/richtextmarginspage.cpp:253
+msgid "Units for the top margin."
+msgstr "Jednotky pre horný okraj."
+
+#: ../src/richtext/richtextmarginspage.cpp:266
+#: ../src/richtext/richtextmarginspage.cpp:268
+msgid "The bottom margin size."
+msgstr "Veľkosť spodného okraja."
+
+#: ../src/richtext/richtextmarginspage.cpp:276
+#: ../src/richtext/richtextmarginspage.cpp:278
+msgid "Units for the bottom margin."
+msgstr "Jednotky pre spodný okraj."
+
+#: ../src/richtext/richtextmarginspage.cpp:284
+msgid "Padding"
+msgstr "Priestor vyplnenia"
+
+#: ../src/richtext/richtextmarginspage.cpp:307
+#: ../src/richtext/richtextmarginspage.cpp:309
+msgid "The left padding size."
+msgstr "Veľkosť ľavého priestoru výplne."
+
+#: ../src/richtext/richtextmarginspage.cpp:317
+#: ../src/richtext/richtextmarginspage.cpp:319
+msgid "Units for the left padding."
+msgstr "Jednotky pre ľavý priestor výplne."
+
+#: ../src/richtext/richtextmarginspage.cpp:332
+#: ../src/richtext/richtextmarginspage.cpp:334
+msgid "The right padding size."
+msgstr "Veľkosť pravého priestoru výplne."
+
+#: ../src/richtext/richtextmarginspage.cpp:342
+#: ../src/richtext/richtextmarginspage.cpp:344
+msgid "Units for the right padding."
+msgstr "Jednotky pre pravé polstrovanie."
+
+#: ../src/richtext/richtextmarginspage.cpp:355
+#: ../src/richtext/richtextmarginspage.cpp:357
+msgid "The top padding size."
+msgstr "Veľkosť vrchného priestoru výplne."
+
+#: ../src/richtext/richtextmarginspage.cpp:365
+#: ../src/richtext/richtextmarginspage.cpp:367
+msgid "Units for the top padding."
+msgstr "Jednotky pre horný priestor výplne."
+
+#: ../src/richtext/richtextmarginspage.cpp:380
+#: ../src/richtext/richtextmarginspage.cpp:382
+msgid "The bottom padding size."
+msgstr "Veľkosť spodného priestoru výplne."
+
+#: ../src/richtext/richtextmarginspage.cpp:390
+#: ../src/richtext/richtextmarginspage.cpp:392
+msgid "Units for the bottom padding."
+msgstr "Jednotky pre spodný priestor výplne."
+
+#: ../src/richtext/richtextprint.cpp:592
+msgid " Preview"
+msgstr " Náhľad"
+
+#: ../src/richtext/richtextsizepage.cpp:228
+msgid "Floating"
+msgstr "Plávajúce"
+
+#: ../src/richtext/richtextsizepage.cpp:243
+msgid "&Floating mode:"
+msgstr "&Režim pohyblivej čiarky:"
+
+#: ../src/richtext/richtextsizepage.cpp:252
+#: ../src/richtext/richtextsizepage.cpp:254
+msgid "How the object will float relative to the text."
+msgstr "Ako sa bude objekt pohybovať vo vzťahu k textu."
+
+#: ../src/richtext/richtextsizepage.cpp:265
+msgid "Alignment"
+msgstr "&Zarovnanie"
+
+#: ../src/richtext/richtextsizepage.cpp:277
+msgid "&Vertical alignment:"
+msgstr "&Vertikálne zarovnanie:"
+
+#: ../src/richtext/richtextsizepage.cpp:279
+#: ../src/richtext/richtextsizepage.cpp:281
+msgid "Enable vertical alignment."
+msgstr "Povolí vertikálne zarovnanie."
+
+#: ../src/richtext/richtextsizepage.cpp:286
+msgid "Centred"
+msgstr "Na stred"
+
+#: ../src/richtext/richtextsizepage.cpp:290
+#: ../src/richtext/richtextsizepage.cpp:292
+msgid "Vertical alignment."
+msgstr "Vertikálne zarovnanie."
+
+#: ../src/richtext/richtextsizepage.cpp:316
+#: ../src/richtext/richtextsizepage.cpp:323
+msgid "&Width:"
+msgstr "Ší&rka:"
+
+#: ../src/richtext/richtextsizepage.cpp:318
+#: ../src/richtext/richtextsizepage.cpp:320
+msgid "Enable the width value."
+msgstr "Povolí hodnotu šírky."
+
+#: ../src/richtext/richtextsizepage.cpp:331
+#: ../src/richtext/richtextsizepage.cpp:333
+msgid "The object width."
+msgstr "Šírka objektu."
+
+#: ../src/richtext/richtextsizepage.cpp:342
+#: ../src/richtext/richtextsizepage.cpp:344
+msgid "Units for the object width."
+msgstr "Jednotky pre šírku objektu."
+
+#: ../src/richtext/richtextsizepage.cpp:350
+#: ../src/richtext/richtextsizepage.cpp:357
+msgid "&Height:"
+msgstr "&Výška:"
+
+#: ../src/richtext/richtextsizepage.cpp:352
+#: ../src/richtext/richtextsizepage.cpp:354
+#: ../src/richtext/richtextsizepage.cpp:464
+#: ../src/richtext/richtextsizepage.cpp:466
+msgid "Enable the height value."
+msgstr "Povolí hodnotu výšky."
+
+#: ../src/richtext/richtextsizepage.cpp:365
+#: ../src/richtext/richtextsizepage.cpp:367
+msgid "The object height."
+msgstr "Výška objektu."
+
+#: ../src/richtext/richtextsizepage.cpp:376
+#: ../src/richtext/richtextsizepage.cpp:378
+msgid "Units for the object height."
+msgstr "Jednotky pre výšku objektu."
+
+#: ../src/richtext/richtextsizepage.cpp:381
+msgid "Min width:"
+msgstr "Min. šírka:"
+
+#: ../src/richtext/richtextsizepage.cpp:383
+#: ../src/richtext/richtextsizepage.cpp:385
+msgid "Enable the minimum width value."
+msgstr "Povolí minimálnu hodnotu šírky."
+
+#: ../src/richtext/richtextsizepage.cpp:392
+#: ../src/richtext/richtextsizepage.cpp:394
+msgid "The object minimum width."
+msgstr "Minimálna šírka objektu."
+
+#: ../src/richtext/richtextsizepage.cpp:403
+#: ../src/richtext/richtextsizepage.cpp:405
+msgid "Units for the minimum object width."
+msgstr "Jednotky pre minimálnu šírku objektu."
+
+#: ../src/richtext/richtextsizepage.cpp:408
+msgid "Min height:"
+msgstr "Min. výška:"
+
+#: ../src/richtext/richtextsizepage.cpp:410
+#: ../src/richtext/richtextsizepage.cpp:412
+msgid "Enable the minimum height value."
+msgstr "Povolí minimálnu hodnotu výšky."
+
+#: ../src/richtext/richtextsizepage.cpp:419
+#: ../src/richtext/richtextsizepage.cpp:421
+msgid "The object minimum height."
+msgstr "Minimálna výška objektu."
+
+#: ../src/richtext/richtextsizepage.cpp:430
+#: ../src/richtext/richtextsizepage.cpp:432
+msgid "Units for the minimum object height."
+msgstr "Jednotky pre minimálnu výšku objektu."
+
+#: ../src/richtext/richtextsizepage.cpp:435
+msgid "Max width:"
+msgstr "Max. šírka:"
+
+#: ../src/richtext/richtextsizepage.cpp:437
+#: ../src/richtext/richtextsizepage.cpp:439
+msgid "Enable the maximum width value."
+msgstr "Povolí maximálnu hodnotu šírky."
+
+#: ../src/richtext/richtextsizepage.cpp:446
+#: ../src/richtext/richtextsizepage.cpp:448
+msgid "The object maximum width."
+msgstr "Maximálna šírka objektu."
+
+#: ../src/richtext/richtextsizepage.cpp:457
+#: ../src/richtext/richtextsizepage.cpp:459
+msgid "Units for the maximum object width."
+msgstr "Jednotky pre maximálnu šírku objektu."
+
+#: ../src/richtext/richtextsizepage.cpp:462
+msgid "Max height:"
+msgstr "Max. výška:"
+
+#: ../src/richtext/richtextsizepage.cpp:473
+#: ../src/richtext/richtextsizepage.cpp:475
+msgid "The object maximum height."
+msgstr "Maximálna výška objektu."
+
+#: ../src/richtext/richtextsizepage.cpp:484
+#: ../src/richtext/richtextsizepage.cpp:486
+msgid "Units for the maximum object height."
+msgstr "Jednotky pre maximálnu výšku objektu."
+
+#: ../src/richtext/richtextsizepage.cpp:495
+msgid "Position"
+msgstr "Poloha"
+
+#: ../src/richtext/richtextsizepage.cpp:513
+msgid "&Position mode:"
+msgstr "Režim &pozície:"
+
+#: ../src/richtext/richtextsizepage.cpp:517
+#: ../src/richtext/richtextsizepage.cpp:522
+msgid "Static"
+msgstr "Statické"
+
+#: ../src/richtext/richtextsizepage.cpp:518
+msgid "Relative"
+msgstr "Relatívne"
+
+#: ../src/richtext/richtextsizepage.cpp:519
+msgid "Absolute"
+msgstr "Absolútne"
+
+#: ../src/richtext/richtextsizepage.cpp:520
+msgid "Fixed"
+msgstr "Pevné"
+
+#: ../src/richtext/richtextsizepage.cpp:533
+#: ../src/richtext/richtextsizepage.cpp:535
+#: ../src/richtext/richtextsizepage.cpp:547
+#: ../src/richtext/richtextsizepage.cpp:549
+msgid "The left position."
+msgstr "Ľavá poloha."
+
+#: ../src/richtext/richtextsizepage.cpp:558
+#: ../src/richtext/richtextsizepage.cpp:560
+msgid "Units for the left position."
+msgstr "Jednotky pre ľavú pozíciu."
+
+#: ../src/richtext/richtextsizepage.cpp:568
+#: ../src/richtext/richtextsizepage.cpp:570
+#: ../src/richtext/richtextsizepage.cpp:582
+#: ../src/richtext/richtextsizepage.cpp:584
+msgid "The top position."
+msgstr "Horná poloha."
+
+#: ../src/richtext/richtextsizepage.cpp:593
+#: ../src/richtext/richtextsizepage.cpp:595
+msgid "Units for the top position."
+msgstr "Jednotky pre hornú polohu."
+
+#: ../src/richtext/richtextsizepage.cpp:603
+#: ../src/richtext/richtextsizepage.cpp:605
+#: ../src/richtext/richtextsizepage.cpp:617
+#: ../src/richtext/richtextsizepage.cpp:619
+msgid "The right position."
+msgstr "Poloha vpravo."
+
+#: ../src/richtext/richtextsizepage.cpp:628
+#: ../src/richtext/richtextsizepage.cpp:630
+msgid "Units for the right position."
+msgstr "Jednotky pre správnu pozíciu."
+
+#: ../src/richtext/richtextsizepage.cpp:638
+#: ../src/richtext/richtextsizepage.cpp:640
+#: ../src/richtext/richtextsizepage.cpp:652
+#: ../src/richtext/richtextsizepage.cpp:654
+msgid "The bottom position."
+msgstr "Spodná poloha."
+
+#: ../src/richtext/richtextsizepage.cpp:663
+#: ../src/richtext/richtextsizepage.cpp:665
+msgid "Units for the bottom position."
+msgstr "Jednotky pre spodnú polohu."
+
+#: ../src/richtext/richtextsizepage.cpp:671
+msgid "&Move the object to:"
+msgstr "&Presunúť objekt do:"
+
+#: ../src/richtext/richtextsizepage.cpp:674
+msgid "&Previous Paragraph"
+msgstr "&Predošlý odsek"
+
+#: ../src/richtext/richtextsizepage.cpp:675
+#: ../src/richtext/richtextsizepage.cpp:677
+msgid "Moves the object to the previous paragraph."
+msgstr "Presunie objekt na predošlý odsek."
+
+#: ../src/richtext/richtextsizepage.cpp:680
+msgid "&Next Paragraph"
+msgstr "&Nasledujúci odsek"
+
+#: ../src/richtext/richtextsizepage.cpp:681
+#: ../src/richtext/richtextsizepage.cpp:683
+msgid "Moves the object to the next paragraph."
+msgstr "Presunie objekt na nasledujúci odsek."
+
+#: ../src/richtext/richtextstyledlg.cpp:193
+msgid "&Styles:"
+msgstr "&Štýly:"
+
+#: ../src/richtext/richtextstyledlg.cpp:197
+#: ../src/richtext/richtextstyledlg.cpp:199
+msgid "The available styles."
+msgstr "Dostupné štýly."
+
+#: ../src/richtext/richtextstyledlg.cpp:205
+#: ../src/richtext/richtextstyledlg.cpp:217
+msgid " "
+msgstr " "
+
+#: ../src/richtext/richtextstyledlg.cpp:209
+#: ../src/richtext/richtextstyledlg.cpp:211
+msgid "The style preview."
+msgstr "Náhľad štýlu."
+
+#: ../src/richtext/richtextstyledlg.cpp:220
+msgid "New &Character Style..."
+msgstr "Nový štýl &znakov..."
+
+#: ../src/richtext/richtextstyledlg.cpp:221
+#: ../src/richtext/richtextstyledlg.cpp:223
+msgid "Click to create a new character style."
+msgstr "Kliknite pre vytvorenie nového štýlu znakov."
+
+#: ../src/richtext/richtextstyledlg.cpp:226
+msgid "New &Paragraph Style..."
+msgstr "Nový štýl &odseku..."
+
+#: ../src/richtext/richtextstyledlg.cpp:227
+#: ../src/richtext/richtextstyledlg.cpp:229
+msgid "Click to create a new paragraph style."
+msgstr "Kliknite pre vytvorenie nového štýlu odstavca."
+
+#: ../src/richtext/richtextstyledlg.cpp:232
+msgid "New &List Style..."
+msgstr "Nový štýl zoz&namu..."
+
+#: ../src/richtext/richtextstyledlg.cpp:233
+#: ../src/richtext/richtextstyledlg.cpp:235
+msgid "Click to create a new list style."
+msgstr "Kliknite pre vytvorenie nového štýlu zoznamu."
+
+#: ../src/richtext/richtextstyledlg.cpp:238
+msgid "New &Box Style..."
+msgstr "Nový štýl &schránky..."
+
+#: ../src/richtext/richtextstyledlg.cpp:239
+#: ../src/richtext/richtextstyledlg.cpp:241
+msgid "Click to create a new box style."
+msgstr "Kliknite pre vytvorenie nového štýlu schránky."
+
+#: ../src/richtext/richtextstyledlg.cpp:246
+msgid "&Apply Style"
+msgstr "&Použiť štýl"
+
+#: ../src/richtext/richtextstyledlg.cpp:247
+#: ../src/richtext/richtextstyledlg.cpp:249
+msgid "Click to apply the selected style."
+msgstr "Kliknite pre použitie vybraného štýlu."
+
+#: ../src/richtext/richtextstyledlg.cpp:252
+msgid "&Rename Style..."
+msgstr "&Premenovať štýl..."
+
+#: ../src/richtext/richtextstyledlg.cpp:253
+#: ../src/richtext/richtextstyledlg.cpp:255
+msgid "Click to rename the selected style."
+msgstr "Kliknite pre premenovanie vybraného štýlu."
+
+#: ../src/richtext/richtextstyledlg.cpp:258
+msgid "&Edit Style..."
+msgstr "&Upraviť štýl..."
+
+#: ../src/richtext/richtextstyledlg.cpp:259
+#: ../src/richtext/richtextstyledlg.cpp:261
+msgid "Click to edit the selected style."
+msgstr "Kliknite pre úpravu vybraného štýlu."
+
+#: ../src/richtext/richtextstyledlg.cpp:264
+msgid "&Delete Style..."
+msgstr "&Odstrániť štýl..."
+
+#: ../src/richtext/richtextstyledlg.cpp:265
+#: ../src/richtext/richtextstyledlg.cpp:267
+msgid "Click to delete the selected style."
+msgstr "Kliknite pre zmazanie vybraného štýlu."
+
+#: ../src/richtext/richtextstyledlg.cpp:274
+#: ../src/richtext/richtextstyledlg.cpp:276
+msgid "Click to close this window."
+msgstr "Kliknite pre zatvorenie tohoto okna."
+
+#: ../src/richtext/richtextstyledlg.cpp:282
+msgid "&Restart numbering"
+msgstr "&Reštartovať číslovanie"
+
+#: ../src/richtext/richtextstyledlg.cpp:284
+#: ../src/richtext/richtextstyledlg.cpp:286
+msgid "Check to restart numbering."
+msgstr "Zaškrtnite pre číslovanie od začiatku."
+
+#: ../src/richtext/richtextstyledlg.cpp:601
+msgid "Enter a character style name"
+msgstr "Zadajte názov štýlu znaku"
+
+#: ../src/richtext/richtextstyledlg.cpp:601
+#: ../src/richtext/richtextstyledlg.cpp:606
+#: ../src/richtext/richtextstyledlg.cpp:649
+#: ../src/richtext/richtextstyledlg.cpp:654
+#: ../src/richtext/richtextstyledlg.cpp:815
+#: ../src/richtext/richtextstyledlg.cpp:820
+#: ../src/richtext/richtextstyledlg.cpp:888
+#: ../src/richtext/richtextstyledlg.cpp:896
+#: ../src/richtext/richtextstyledlg.cpp:929
+#: ../src/richtext/richtextstyledlg.cpp:934
+msgid "New Style"
+msgstr "Nový štýl"
+
+#: ../src/richtext/richtextstyledlg.cpp:606
+#: ../src/richtext/richtextstyledlg.cpp:654
+#: ../src/richtext/richtextstyledlg.cpp:820
+#: ../src/richtext/richtextstyledlg.cpp:896
+#: ../src/richtext/richtextstyledlg.cpp:934
+msgid "Sorry, that name is taken. Please choose another."
+msgstr "Prepáčte, taký názov je už použitý. Vyberte, prosím, iný."
+
+#: ../src/richtext/richtextstyledlg.cpp:649
+msgid "Enter a paragraph style name"
+msgstr "Zadajte názov štýlu odstavca"
+
+#: ../src/richtext/richtextstyledlg.cpp:777
+#, c-format
+msgid "Delete style %s?"
+msgstr "Odstrániť štýl %s?"
+
+#: ../src/richtext/richtextstyledlg.cpp:777
+msgid "Delete Style"
+msgstr "Odstrániť štýl"
+
+#: ../src/richtext/richtextstyledlg.cpp:815
+msgid "Enter a list style name"
+msgstr "Zadajte názov štýlu zoznamu"
+
+#: ../src/richtext/richtextstyledlg.cpp:888
+msgid "Enter a new style name"
+msgstr "Zadajte nový názov štýlu"
+
+#: ../src/richtext/richtextstyledlg.cpp:929
+msgid "Enter a box style name"
+msgstr "Zadajte názov štýlu schránky"
+
+#: ../src/richtext/richtextstylepage.cpp:109
+#: ../src/richtext/richtextstylepage.cpp:111
+msgid "The style name."
+msgstr "Názov štýlu."
+
+#: ../src/richtext/richtextstylepage.cpp:114
+msgid "&Based on:"
+msgstr "&Založené na:"
+
+#: ../src/richtext/richtextstylepage.cpp:119
+#: ../src/richtext/richtextstylepage.cpp:121
+msgid "The style on which this style is based."
+msgstr "Štýl, na ktorom je tento štýl založený."
+
+#: ../src/richtext/richtextstylepage.cpp:124
+msgid "&Next style:"
+msgstr "&Ďalší štýl:"
+
+#: ../src/richtext/richtextstylepage.cpp:129
+#: ../src/richtext/richtextstylepage.cpp:131
+msgid "The default style for the next paragraph."
+msgstr "Štandardný štýl ďalšieho odstavca."
+
+#: ../src/richtext/richtextstyles.cpp:1057
+msgid "All styles"
+msgstr "Všetky štýly"
+
+#: ../src/richtext/richtextstyles.cpp:1058
+msgid "Paragraph styles"
+msgstr "Štýly odstavca"
+
+#: ../src/richtext/richtextstyles.cpp:1059
+msgid "Character styles"
+msgstr "Štýly znakov"
+
+#: ../src/richtext/richtextstyles.cpp:1060
+msgid "List styles"
+msgstr "Štýly zoznamu"
+
+#: ../src/richtext/richtextstyles.cpp:1061
+msgid "Box styles"
+msgstr "Štýly schránky"
+
+#: ../src/richtext/richtextsymboldlg.cpp:389
+#: ../src/richtext/richtextsymboldlg.cpp:391
+msgid "The font from which to take the symbol."
+msgstr "Písmo pre použitie symbolu."
+
+#: ../src/richtext/richtextsymboldlg.cpp:396
+msgid "&Subset:"
+msgstr "&Podmnožina:"
+
+#: ../src/richtext/richtextsymboldlg.cpp:401
+#: ../src/richtext/richtextsymboldlg.cpp:403
+msgid "Shows a Unicode subset."
+msgstr "Zobrazí náhľad podsadu Unicode."
+
+#: ../src/richtext/richtextsymboldlg.cpp:412
+msgid "xxxx"
+msgstr "xxxx"
+
+#: ../src/richtext/richtextsymboldlg.cpp:417
+msgid "&Character code:"
+msgstr "&Kód znaku:"
+
+#: ../src/richtext/richtextsymboldlg.cpp:421
+#: ../src/richtext/richtextsymboldlg.cpp:423
+msgid "The character code."
+msgstr "Kód znaku."
+
+#: ../src/richtext/richtextsymboldlg.cpp:428
+msgid "&From:"
+msgstr "&Od:"
+
+#: ../src/richtext/richtextsymboldlg.cpp:433
+#: ../src/richtext/richtextsymboldlg.cpp:434
+#: ../src/richtext/richtextsymboldlg.cpp:435
+msgid "Unicode"
+msgstr "Unicode"
+
+#: ../src/richtext/richtextsymboldlg.cpp:436
+#: ../src/richtext/richtextsymboldlg.cpp:438
+msgid "The range to show."
+msgstr "Obraziť rozsah."
+
+#: ../src/richtext/richtextsymboldlg.cpp:444
+msgid "Insert"
+msgstr "Vložiť"
+
+#: ../src/richtext/richtextsymboldlg.cpp:478
+msgid "(Normal text)"
+msgstr "(Normálny text)"
+
+#: ../src/richtext/richtexttabspage.cpp:109
+msgid "&Position (tenths of a mm):"
+msgstr "&Umiestnenie (desatiny milimetra):"
+
+#: ../src/richtext/richtexttabspage.cpp:113
+#: ../src/richtext/richtexttabspage.cpp:115
+msgid "The tab position."
+msgstr "Pozícia tabelátora."
+
+#: ../src/richtext/richtexttabspage.cpp:119
+msgid "The tab positions."
+msgstr "Pozície tabelátora."
+
+#: ../src/richtext/richtexttabspage.cpp:132
+#: ../src/richtext/richtexttabspage.cpp:134
+msgid "Click to create a new tab position."
+msgstr "Kliknite pre vytvorenie novej pozície tabulátora."
+
+#: ../src/richtext/richtexttabspage.cpp:138
+#: ../src/richtext/richtexttabspage.cpp:140
+msgid "Click to delete the selected tab position."
+msgstr "Kliknite pre zmazanie pozécií vybraných tabulátorov."
+
+#: ../src/richtext/richtexttabspage.cpp:143
+msgid "Delete A&ll"
+msgstr "Odstrániť &všetky"
+
+#: ../src/richtext/richtexttabspage.cpp:144
+#: ../src/richtext/richtexttabspage.cpp:146
+msgid "Click to delete all tab positions."
+msgstr "Kliknite pre zmazanie všetkých pozícií tabulátorov."
+
+#: ../src/univ/theme.cpp:110
+msgid "Failed to initialize GUI: no built-in themes found."
+msgstr "Zlyhala inicializácia GUI: neboli nájdené žiadne vstavané témy."
+
+#: ../src/univ/themes/gtk.cpp:521
+msgid "GTK+ theme"
+msgstr "Téma GTK+"
+
+#: ../src/univ/themes/metal.cpp:164
+msgid "Metal theme"
+msgstr "Motív kovový"
+
+#: ../src/univ/themes/mono.cpp:512
+msgid "Simple monochrome theme"
+msgstr "Jednoduchá monochromatická téma"
+
+#: ../src/univ/themes/win32.cpp:1098
+msgid "Win32 theme"
+msgstr "Motív Win32"
+
+#: ../src/univ/themes/win32.cpp:3743
+msgid "&Restore"
+msgstr "&Obnoviť"
+
+#: ../src/univ/themes/win32.cpp:3744
+msgid "&Move"
+msgstr "&Presunúť"
+
+#: ../src/univ/themes/win32.cpp:3746
+msgid "&Size"
+msgstr "&Veľkosť"
+
+#: ../src/univ/themes/win32.cpp:3748
+msgid "Mi&nimize"
+msgstr "Mi&nimalizovať"
+
+#: ../src/univ/themes/win32.cpp:3750
+msgid "Ma&ximize"
+msgstr "Ma&ximalizovať"
+
+#: ../src/univ/themes/win32.cpp:3752
+msgid "Alt+"
+msgstr "Alt+"
+
+#: ../src/unix/appunix.cpp:178
+msgid "Failed to install signal handler"
+msgstr "Zlyhala inštalácia obslužného programu signálu"
+
+#: ../src/unix/dialup.cpp:351
+msgid "Already dialling ISP."
+msgstr "Už prebieha vytáčanie poskytovateľa."
+
+#: ../src/unix/dlunix.cpp:93
+#, fuzzy
+msgid "Failed to unload shared library"
+msgstr "Zlyhalo načítanie zdieľanej knižnice '%s'"
+
+#: ../src/unix/dlunix.cpp:121
+msgid "Unknown dynamic library error"
+msgstr "Neznáma chyba dynamickej knižnice"
+
+#: ../src/unix/epolldispatcher.cpp:84
+msgid "Failed to create epoll descriptor"
+msgstr "Zlyhalo sa vytvorenie popisovača epolly"
+
+#: ../src/unix/epolldispatcher.cpp:103
+msgid "Error closing epoll descriptor"
+msgstr "Chyba pri zatváraní popisovača epoll"
+
+#: ../src/unix/epolldispatcher.cpp:116
+#, c-format
+msgid "Failed to add descriptor %d to epoll descriptor %d"
+msgstr "Zlyhalo pridanie popisovača %d do popisovača epoll %d"
+
+#: ../src/unix/epolldispatcher.cpp:136
+#, c-format
+msgid "Failed to modify descriptor %d in epoll descriptor %d"
+msgstr "Zlyhala úprava popisovača %d v popisovači epoll %d"
+
+#: ../src/unix/epolldispatcher.cpp:155
+#, c-format
+msgid "Failed to unregister descriptor %d from epoll descriptor %d"
+msgstr "Zlyhalo zrušenie registrácie popisovača %d z popisovača epoll %d"
+
+#: ../src/unix/epolldispatcher.cpp:213
+#, c-format
+msgid "Waiting for IO on epoll descriptor %d failed"
+msgstr "Čakanie na IO v popisovač epoll %d zlyhalo"
+
+#: ../src/unix/fswatcher_inotify.cpp:71
+msgid "Unable to create inotify instance"
+msgstr "Nemožno vytvoriť inštanciu inotify"
+
+#: ../src/unix/fswatcher_inotify.cpp:94
+msgid "Unable to close inotify instance"
+msgstr "Nemožno zavrieť inštanciu inotify"
+
+#: ../src/unix/fswatcher_inotify.cpp:106
+msgid "Unable to add inotify watch"
+msgstr "Nemožno pridať sledovanie inotify"
+
+#: ../src/unix/fswatcher_inotify.cpp:138
+#, c-format
+msgid "Unable to remove inotify watch %i"
+msgstr "Nemožno odstrániť sledovanie inotify %i"
+
+#: ../src/unix/fswatcher_inotify.cpp:271
+#, c-format
+msgid "Unexpected event for \"%s\": no matching watch descriptor."
+msgstr ""
+"Neočakávaná udalosť pre '%s': žiadny zodpovedajúci popisovač sledovania."
+
+#: ../src/unix/fswatcher_inotify.cpp:320
+#, c-format
+msgid "Invalid inotify event for \"%s\""
+msgstr "Neplatná udalosť inotifikácie pre dopyt '%s'"
+
+#: ../src/unix/fswatcher_inotify.cpp:553
+msgid "Unable to read from inotify descriptor"
+msgstr "Nemožno čítať z popisovača inotify"
+
+#: ../src/unix/fswatcher_inotify.cpp:558
+msgid "EOF while reading from inotify descriptor"
+msgstr "EOF pri načítaní popisovača štruktúry súborov"
+
+#: ../src/unix/fswatcher_kqueue.cpp:114
+msgid "Unable to create kqueue instance"
+msgstr "Nemožno vytvoriť inštanciu kqueue"
+
+#: ../src/unix/fswatcher_kqueue.cpp:131
+msgid "Error closing kqueue instance"
+msgstr "Chyba pri zatváraní inštancie kqueue"
+
+#: ../src/unix/fswatcher_kqueue.cpp:153
+msgid "Unable to add kqueue watch"
+msgstr "Nemožno pridať sledovanie kqueue"
+
+#: ../src/unix/fswatcher_kqueue.cpp:170
+msgid "Unable to remove kqueue watch"
+msgstr "Nemožno odstrániť sledovanie kqueue %i"
+
+#: ../src/unix/fswatcher_kqueue.cpp:202
+msgid "Unable to get events from kqueue"
+msgstr "Nemožno načítať udalosti z kqueue"
+
+#: ../src/unix/mediactrl.cpp:966
+#, c-format
+msgid "Media playback error: %s"
+msgstr "Chyba prehrávania médií: %s"
+
+#: ../src/unix/mediactrl.cpp:1228
+#, c-format
+msgid "Failed to prepare playing \"%s\"."
+msgstr "Zlyhala príprava hry '%s'."
+
+#: ../src/unix/snglinst.cpp:164
+#, c-format
+msgid "Failed to write to lock file '%s'"
+msgstr "Zlyhalo zapísanie súboru zámku '%s'"
+
+#: ../src/unix/snglinst.cpp:177
+#, c-format
+msgid "Failed to set permissions on lock file '%s'"
+msgstr "Zlyhalo nastavenie oprávnenia súboru zámku '%s'"
+
+#: ../src/unix/snglinst.cpp:194
+#, c-format
+msgid "Failed to lock the lock file '%s'"
+msgstr "Zlyhalo zamknutie súbor zámku '%s'"
+
+#: ../src/unix/snglinst.cpp:237
+#, c-format
+msgid "Failed to inspect the lock file '%s'"
+msgstr "Zlyhalo preskúmanie súboru zámku '%s'"
+
+#: ../src/unix/snglinst.cpp:242
+#, c-format
+msgid "Lock file '%s' has incorrect owner."
+msgstr "Súbor zámku '%s' má nesprávneho vlastníka."
+
+#: ../src/unix/snglinst.cpp:247
+#, c-format
+msgid "Lock file '%s' has incorrect permissions."
+msgstr "Súbor zámku '%s' má nesprávnepovolenia."
+
+#: ../src/unix/snglinst.cpp:265
+msgid "Failed to access lock file."
+msgstr "Zlyhal prístup  zamknutému súboru."
+
+#: ../src/unix/snglinst.cpp:274
+msgid "Failed to read PID from lock file."
+msgstr "Zlyhalo prečítanie PID zo súboru zámku."
+
+#: ../src/unix/snglinst.cpp:284
+#, c-format
+msgid "Failed to remove stale lock file '%s'."
+msgstr "Zlyhalo odstránenie starého súboru zámku '%s'."
+
+#: ../src/unix/snglinst.cpp:297
+#, c-format
+msgid "Deleted stale lock file '%s'."
+msgstr "Odstránený zastaralý súbor zámku ' %s'."
+
+#: ../src/unix/snglinst.cpp:308
+#, c-format
+msgid "Invalid lock file '%s'."
+msgstr "Neplatný súbor zámku '%s'."
+
+#: ../src/unix/snglinst.cpp:324
+#, c-format
+msgid "Failed to remove lock file '%s'"
+msgstr "Zlyhalo odstránenie súboru zámku '%s'"
+
+#: ../src/unix/snglinst.cpp:330
+#, c-format
+msgid "Failed to unlock lock file '%s'"
+msgstr "Zlyhalo odomknutie súboru zámku '%s'"
+
+#: ../src/unix/snglinst.cpp:336
+#, c-format
+msgid "Failed to close lock file '%s'"
+msgstr "Zlyhalo zatvorenie súboru zámku '%s'"
+
+#: ../src/unix/sound.cpp:77
+msgid "No sound"
+msgstr "Bez zvuku"
+
+#: ../src/unix/sound.cpp:364
+msgid "Unable to play sound asynchronously."
+msgstr "Nemožno prehrať zvuk asynchrónne."
+
+#: ../src/unix/sound.cpp:458
+#, c-format
+msgid "Couldn't load sound data from '%s'."
+msgstr "Nemožno načítať zvukové údaje z '%s'."
+
+#: ../src/unix/sound.cpp:465
+#, c-format
+msgid "Sound file '%s' is in unsupported format."
+msgstr "Zvukový súbor '%s' je v nepodporovanom formáte."
+
+#: ../src/unix/sound.cpp:480
+msgid "Sound data are in unsupported format."
+msgstr "Zvukové údaje sú v nepodporovanom formáte."
+
+#: ../src/unix/sound_sdl.cpp:226
+#, c-format
+msgid "Couldn't open audio: %s"
+msgstr "Nemožno otvoriť audio: %s"
+
+#: ../src/unix/threadpsx.cpp:1033
+msgid "Cannot retrieve thread scheduling policy."
+msgstr "Nemožno získať plánovaciu politiku vlákna."
+
+#: ../src/unix/threadpsx.cpp:1058
+#, c-format
+msgid "Cannot get priority range for scheduling policy %d."
+msgstr "Nemožno získať rozsah priorít pre plánovaciu politiku %d."
+
+#: ../src/unix/threadpsx.cpp:1066
+msgid "Thread priority setting is ignored."
+msgstr "Nastavenie priority vlákna bolo ignorované."
+
+#: ../src/unix/threadpsx.cpp:1221
+msgid ""
+"Failed to join a thread, potential memory leak detected - please restart the "
+"program"
+msgstr ""
+"Zlyhalo pridanie vlákna, zistený potenciálny výpadok pamäte - reštartujte, "
+"prosím, program"
+
+#: ../src/unix/threadpsx.cpp:1352
+#, c-format
+msgid "Failed to set thread concurrency level to %lu"
+msgstr "Zlyhalo nastavenie úrovne súbežnosti vlákna na %lu"
+
+#: ../src/unix/threadpsx.cpp:1481
+#, c-format
+msgid "Failed to set thread priority %d."
+msgstr "Zlyhalo nastavenie priority vlákna %d."
+
+#: ../src/unix/threadpsx.cpp:1666
+msgid "Failed to terminate a thread."
+msgstr "Zlyhalo ukončenie vlákna."
+
+#: ../src/unix/threadpsx.cpp:1893
+msgid "Thread module initialization failed: failed to create thread key"
+msgstr ""
+"Zlyhala inicializácia modulu vlákien: nepodarilo sa vytvoriť kľúč vlákna"
+
+#: ../src/unix/utilsunx.cpp:340
+msgid "Impossible to get child process input"
+msgstr "Nemožno získať podradený vstup procesu"
+
+#: ../src/unix/utilsunx.cpp:390
+msgid "Can't write to child process's stdin"
+msgstr "Nemožno zapisovať do podriadeného procesu stdin"
+
+#: ../src/unix/utilsunx.cpp:644
+#, c-format
+msgid "Failed to execute '%s'\n"
+msgstr "Zlyhalo vykonanie '%s'\n"
+
+#: ../src/unix/utilsunx.cpp:678
+msgid "Fork failed"
+msgstr "Zlyhala vidlica"
+
+#: ../src/unix/utilsunx.cpp:701
+msgid "Failed to set process priority"
+msgstr "Zlyhalo nastavenie priority procesu"
+
+#: ../src/unix/utilsunx.cpp:712
+msgid "Failed to redirect child process input/output"
+msgstr "Zlyhalo presmerovanie vstupu/výstupu detského procesu"
+
+#: ../src/unix/utilsunx.cpp:816
+msgid "Failed to set up non-blocking pipe, the program might hang."
+msgstr ""
+"Zlyhalo nastavenie neblokujúceho potrubia, program môže prestať reagovať."
+
+#: ../src/unix/utilsunx.cpp:1023
+msgid "Cannot get the hostname"
+msgstr "Nemožno získať názov hostiteľa"
+
+#: ../src/unix/utilsunx.cpp:1059
+msgid "Cannot get the official hostname"
+msgstr "Nemožno získať oficálny názov hostiteľa"
+
+#: ../src/unix/wakeuppipe.cpp:49
+msgid "Failed to create wake up pipe used by event loop."
+msgstr "Zlyhalo vytvorenie prebudenie potrubia používaného slučkou udalostí."
+
+#: ../src/unix/wakeuppipe.cpp:56
+msgid "Failed to switch wake up pipe to non-blocking mode"
+msgstr "Zlyhalo prepnutie prebudenia potrubia do neblokujúceho režimu"
+
+#: ../src/unix/wakeuppipe.cpp:117
+msgid "Failed to read from wake-up pipe"
+msgstr "Zlyhalo načítanie prebudenie potrubia"
+
+#: ../src/x11/app.cpp:124
+#, c-format
+msgid "Invalid geometry specification '%s'"
+msgstr "Neplatná špecifikácia geometrie '%s'"
+
+#: ../src/x11/app.cpp:167
+msgid "wxWidgets could not open display. Exiting."
+msgstr "wxWidgets nemohol otvoriť displej. Ukončuje sa."
+
+#: ../src/x11/utils.cpp:169
+#, c-format
+msgid "Failed to close the display \"%s\""
+msgstr "Zlyhalo zatvorenie zobrazenia '%s'"
+
+#: ../src/x11/utils.cpp:188
+#, c-format
+msgid "Failed to open display \"%s\"."
+msgstr "Zlyhalo otvorenie zobrazenia '%s'."
+
+#: ../src/xml/xml.cpp:868
+#, c-format
+msgid "XML parsing error: '%s' at line %d"
+msgstr "Chyba parsovania XML: '%s' na riadku %d"
+
+#: ../src/xrc/xh_propgrid.cpp:239
+#, fuzzy, c-format
+msgid "Page %i"
+msgstr "Strana %d"
+
+#: ../src/xrc/xmlres.cpp:448
+#, c-format
+msgid "Cannot load resources from '%s'."
+msgstr "Nemožno načítať zdroje zo '%s'."
+
+#: ../src/xrc/xmlres.cpp:799
+#, c-format
+msgid "Cannot open resources file '%s'."
+msgstr "Nemožno otvoriť zdroje súboru '%s'."
+
+#: ../src/xrc/xmlres.cpp:806
+#, c-format
+msgid "Cannot load resources from file '%s'."
+msgstr "Nemožno načítať zdroje zo súboru '%s'."
+
+#: ../src/xrc/xmlres.cpp:2767
+#, c-format
+msgid "Creating %s \"%s\" failed."
+msgstr "Vytváranie %s '%s' zlyhalo."
+
+#~ msgctxt "keyboard key"
+#~ msgid "Alt+"
+#~ msgstr "Alt+"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Ctrl+"
+#~ msgstr "Ctrl+"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Shift+"
+#~ msgstr "Shift+"
+
+#~ msgctxt "keyboard key"
+#~ msgid "RawCtrl+"
+#~ msgstr "RawCtrl+"
+
+#~ msgid "Unsupported clipboard format."
+#~ msgstr "Nepodporovaný formát schránky."
+
+#~ msgid "Background colour"
+#~ msgstr "Farba pozadia"
+
+#~ msgid "Font:"
+#~ msgstr "Písmo:"
+
+#~ msgid "Size:"
+#~ msgstr "Veľkosť:"
+
+#~ msgid "The font size in points."
+#~ msgstr "Veľkosť písma v bodoch."
+
+#~ msgid "Style:"
+#~ msgstr "Štýl:"
+
+#~ msgid "Check to make the font bold."
+#~ msgstr "Zaškrtnite pre tučné písmo."
+
+#~ msgid "Check to make the font italic."
+#~ msgstr "Zaškrtnite pre kurzívu."
+
+#~ msgid "Check to make the font underlined."
+#~ msgstr "Zaškrtnite pre podčiarknuté písmo."
+
+#~ msgid "Colour:"
+#~ msgstr "Farba:"
+
+#~ msgid "Click to change the font colour."
+#~ msgstr "Kliknite pre zmenu farby písma."
+
+#~ msgid "Shows a preview of the font."
+#~ msgstr "Zobrazí náhľad písma."
+
+#~ msgid "Click to cancel changes to the font."
+#~ msgstr "Kliknite pre zrušenie zmien v písme."
+
+#~ msgid "Click to confirm changes to the font."
+#~ msgstr "Kliknite pre potvrdenie zmien písma."
+
+#~ msgid "<Any>"
+#~ msgstr "<ľubovoľné>"
+
+#~ msgid "<Any Roman>"
+#~ msgstr "<ľubovoľné rímske>"
+
+#~ msgid "<Any Decorative>"
+#~ msgstr "<ľubovoľné okrasné>"
+
+#~ msgid "<Any Modern>"
+#~ msgstr "<ľubovoľné moderné>"
+
+#~ msgid "<Any Script>"
+#~ msgstr "<ľubovoľné písané>"
+
+#~ msgid "<Any Swiss>"
+#~ msgstr "<ľubovoľné švajčiarske>"
+
+#~ msgid "<Any Teletype>"
+#~ msgstr "<ľubovoľné terminálové>"
+
+#~ msgid "Printing "
+#~ msgstr "Tlačí sa "
+
+#~ msgid "Failed to insert text in the control."
+#~ msgstr "Zlyhalo vloženie textu do ovládacieho prvku."
+
+#~ msgid "Please choose a valid font."
+#~ msgstr "Vyberte, prosím, platné písmo."
+
+#, c-format
+#~ msgid "Failed to display HTML document in %s encoding"
+#~ msgstr "Zlyhalo zobrazenie HTML dokumentu v kódovaní %s"
+
+#, c-format
+#~ msgid "wxWidgets could not open display for '%s': exiting."
+#~ msgstr "wxWidgets nemohol otvoriť displej pre '%s': ukončuje sa."
+
+#~ msgid "Filter"
+#~ msgstr "Filter"
+
+#~ msgid "Directories"
+#~ msgstr "Priečinky"
+
+#~ msgid "Files"
+#~ msgstr "Súbory"
+
+#~ msgid "Selection"
+#~ msgstr "Výber"
+
+#~ msgid "conversion to 8-bit encoding failed"
+#~ msgstr "zlyhal prevod na 8-bitové kódovanie"
+
+#, fuzzy
+#~ msgid "failed to retrieve execution result"
+#~ msgstr "Zlyhalo získanie textu chybovej správy RAS"
+
+#~ msgid " (while overwriting an existing item)"
+#~ msgstr " (pri prepísaní existujúcej položky)"
+
+#~ msgid "&Save as"
+#~ msgstr "&Uložiť Ako"
+
+#~ msgid "'%s' doesn't consist only of valid characters"
+#~ msgstr "'%s' neobsahuje iba platné znaky"
+
+#~ msgid "'%s' should be numeric."
+#~ msgstr "'%s' by mala byť číselná hodnota."
+
+#~ msgid "'%s' should only contain ASCII characters."
+#~ msgstr "'%s' by mal obsahovať iba ASCII znaky."
+
+#~ msgid "'%s' should only contain alphabetic characters."
+#~ msgstr "'%s' by mal obsahovať iba znaky abecedy."
+
+#~ msgid "'%s' should only contain alphabetic or numeric characters."
+#~ msgstr "'%s' by mal obsahovať iba znaky abecedy alebo čísla."
+
+#~ msgid "'%s' should only contain digits."
+#~ msgstr "'%s' by mal obsahovať iba číslice."
+
+#~ msgid "Can't create window of class %s"
+#~ msgstr "Nemožno vytvoriť okno triedy %s"
+
+#~ msgid "Couldn't create the overlay window"
+#~ msgstr "Nemožno vytvoriť preložené okno"
+
+#~ msgid "Couldn't init the context on the overlay window"
+#~ msgstr "Nemožno inicializovať kontext preloženého okna"
+
+#~ msgid "Failed to convert file \"%s\" to Unicode."
+#~ msgstr "Zlyhala konverzia súboru '%s' na Unicode."
+
+#~ msgid "Failed to set text in the text control."
+#~ msgstr "Zlyhalo nastavenie textu textového ovládacieho prvku."
+
+#~ msgid "Invalid GTK+ command line option, use \"%s --help\""
+#~ msgstr ""
+#~ "Neplatná možnosť príkazového riadku GTK+, použite príkaz \"%s --help\""
+
+#~ msgid "No unused colour in image."
+#~ msgstr "Žiadna nepoužitá farba na obrázku."
+
+#~ msgid "Not available"
+#~ msgstr "Nie je k dispozícii"
+
+#~ msgid "Replace selection"
+#~ msgstr "Nahradiť výber"
+
+#~ msgid "Save as"
+#~ msgstr "Uložiť ako"
+
+#~ msgid "Style Organiser"
+#~ msgstr "Organizátor štýlov"
+
+#~ msgid "The following standard GTK+ options are also supported:\n"
+#~ msgstr "Podporované sú aj nasledujúce štandardné možnosti GTK +:\n"
+
+#~ msgid "You cannot Clear an overlay that is not inited"
+#~ msgstr "Nemôžete vymazať prekrytie, ktoré nie je pôvodné"
+
+#~ msgid "You cannot Init an overlay twice"
+#~ msgstr "Prekrytie nemôžete inicializovať dvakrát"
+
+#~ msgid "locale '%s' cannot be set."
+#~ msgstr "nemožno nastaviť miestne '%s'."
+
+#, fuzzy
+#~ msgid "Column index not found."
+#~ msgstr "Súbor Pomocníka \"%s\" nenájdený."
+
+#~ msgid "Confirm registry update"
+#~ msgstr "Potvrdiť aktualizáciu registra"
+
+#, fuzzy
+#~ msgid "Could not determine column index."
+#~ msgstr "Nebolo možné spustiť náhľad dokumentu."
+
+#, fuzzy
+#~ msgid "Could not determine number of columns."
+#~ msgstr "Nebolo možné nájsť include súbor zdroja %s."
+
+#, fuzzy
+#~ msgid "Could not determine number of items"
+#~ msgstr "Nebolo možné nájsť include súbor zdroja %s."
+
+#, fuzzy
+#~ msgid "Could not get header description."
+#~ msgstr "Nebolo možné začať tlačiť."
+
+#, fuzzy
+#~ msgid "Could not get items."
+#~ msgstr "Nebolo možné nájsť súbor '%s'."
+
+#, fuzzy
+#~ msgid "Could not get property flags."
+#~ msgstr "Nebolo možné vytvoriť dočasný súbor '%s'"
+
+#, fuzzy
+#~ msgid "Could not get selected items."
+#~ msgstr "Nebolo možné nájsť súbor '%s'."
+
+#, fuzzy
+#~ msgid "Could not remove column."
+#~ msgstr "Nebolo možné vytvoriť kurzor."
+
+#, fuzzy
+#~ msgid "Could not retrieve number of items"
+#~ msgstr "Nebolo možné vytvoriť dočasný súbor '%s'"
+
+#, fuzzy
+#~ msgid "Could not set column width."
+#~ msgstr "Nebolo možné spustiť náhľad dokumentu."
+
+#, fuzzy
+#~ msgid "Could not set header description."
+#~ msgstr "Nebolo možné začať tlačiť."
+
+#, fuzzy
+#~ msgid "Could not set icon."
+#~ msgstr "Nebolo možné začať tlačiť."
+
+#, fuzzy
+#~ msgid "Could not set maximum width."
+#~ msgstr "Nebolo možné začať tlačiť."
+
+#, fuzzy
+#~ msgid "Could not set minimum width."
+#~ msgstr "Nebolo možné začať tlačiť."
+
+#, fuzzy
+#~ msgid "Could not set property flags."
+#~ msgstr "Nebolo možné začať tlačiť."
+
+#~ msgid ""
+#~ "Do you want to overwrite the command used to %s files with extension "
+#~ "\"%s\" ?\n"
+#~ "Current value is \n"
+#~ "%s, \n"
+#~ "New value is \n"
+#~ "%s %1"
+#~ msgstr ""
+#~ "Chcete prepísať príkaz, ktorý sa používa na %s súborov s príponou "
+#~ "\"%s\" ?\n"
+#~ "Súčasná hodnota je \n"
+#~ "%s, \n"
+#~ "Nová hodnota je is \n"
+#~ "%s %1"
+
+#~ msgid "Failed to retrieve data from the clipboard."
+#~ msgstr "Nepodarilo sa získať údaje zo schránky."
+
+#~ msgid "GIF: Invalid gif index."
+#~ msgstr "GIF: neplatný gif index."
+
+#~ msgid "GIF: unknown error!!!"
+#~ msgstr "GIF: neznáma chyba!!!"
+
+#, fuzzy
+#~ msgid "Number of columns could not be determined."
+#~ msgstr "Súbor nie je možné načítať."
+
+#~ msgid ""
+#~ "Please install a newer version of comctl32.dll\n"
+#~ "(at least version 4.70 is required but you have %d.%02d)\n"
+#~ "or this program won't operate correctly."
+#~ msgstr ""
+#~ "Prosím, nainštalujte si novšiu verziu comctl32.dll\n"
+#~ "(je potrebná aspoň verzia 4.70, ale vaša verzia je %d.%02d)\n"
+#~ "inak tento program nebude fungovať správne."
+
+#, fuzzy
+#~ msgid "Rendering failed."
+#~ msgstr "Zlyhalo vytvorenie časovača."
+
+#~ msgid "Show hidden directories"
+#~ msgstr "Zobraziť skryté adresáre"
+
+#, fuzzy
+#~ msgid ""
+#~ "This system doesn't support date controls, please upgrade your version of "
+#~ "comctl32.dll"
+#~ msgstr ""
+#~ "Tento systém nepodporuje ovládací prvok pre voľbu dátumu, prosím, "
+#~ "aktualizujte vašu verziu comctl32.dll"
+
+#~ msgid "Too many colours in PNG, the image may be slightly blurred."
+#~ msgstr "Príliš veľa farieb v PNG, obrázok môže byť mierne rozmazaný."
+
+#, fuzzy
+#~ msgid "Unable to initialize Hildon program"
+#~ msgstr "Nepodarilo sa inicializovať OpenGL"
+
+#, fuzzy
+#~ msgid "Unknown data format"
+#~ msgstr "Neznámy prepínač štýlu"
+
+#~ msgid "Win32s on Windows 3.1"
+#~ msgstr "Win32s na Windows 3.1"
+
+#, fuzzy
+#~ msgid "Windows 10"
+#~ msgstr "Windows 98"
+
+#, fuzzy
+#~ msgid "Windows 2000"
+#~ msgstr "Windows 95"
+
+#, fuzzy
+#~ msgid "Windows 7"
+#~ msgstr "Windows 95"
+
+#, fuzzy
+#~ msgid "Windows 8"
+#~ msgstr "Windows 98"
+
+#, fuzzy
+#~ msgid "Windows 8.1"
+#~ msgstr "Windows 98"
+
+#~ msgid "Windows 95"
+#~ msgstr "Windows 95"
+
+#~ msgid "Windows 95 OSR2"
+#~ msgstr "Windows 95 OSR2"
+
+#~ msgid "Windows 98"
+#~ msgstr "Windows 98"
+
+#~ msgid "Windows 98 SE"
+#~ msgstr "Windows 98 SE"
+
+#~ msgid "Windows 9x (%d.%d)"
+#~ msgstr "Windows 9x (%d.%d)"
+
+#~ msgid "Windows CE (%d.%d)"
+#~ msgstr "Windows CE (%d.%d)"
+
+#~ msgid "Windows ME"
+#~ msgstr "Windows ME"
+
+#, fuzzy
+#~ msgid "Windows NT %lu.%lu"
+#~ msgstr "Windows NT %lu.%lu (zostavenie %lu"
+
+#, fuzzy
+#~ msgid "Windows Server 10"
+#~ msgstr "Windows Server 2003 (zostavenie %lu"
+
+#, fuzzy
+#~ msgid "Windows Server 2003"
+#~ msgstr "Windows Server 2003 (zostavenie %lu"
+
+#, fuzzy
+#~ msgid "Windows Server 2008"
+#~ msgstr "Windows Server 2003 (zostavenie %lu"
+
+#, fuzzy
+#~ msgid "Windows Server 2008 R2"
+#~ msgstr "Windows Server 2003 (zostavenie %lu"
+
+#, fuzzy
+#~ msgid "Windows Server 2012"
+#~ msgstr "Windows Server 2003 (zostavenie %lu"
+
+#, fuzzy
+#~ msgid "Windows Server 2012 R2"
+#~ msgstr "Windows Server 2003 (zostavenie %lu"
+
+#, fuzzy
+#~ msgid "Windows Vista"
+#~ msgstr "Windows 95"
+
+#, fuzzy
+#~ msgid "Windows XP"
+#~ msgstr "Windows 95"
+
+#~ msgid "ADD"
+#~ msgstr "PRIDAŤ"
+
+#~ msgid "BACK"
+#~ msgstr "SPÄŤ"
+
+#~ msgid "CANCEL"
+#~ msgstr "ZRUŠIŤ"
+
+#~ msgid "CAPITAL"
+#~ msgstr "VEĽKÉ"
+
+#~ msgid "CLEAR"
+#~ msgstr "VYČISTIŤ"
+
+#~ msgid "COMMAND"
+#~ msgstr "PRÍKAZ"
+
+#~ msgid "Cannot create mutex."
+#~ msgstr "Nemôžem vytvoriť mutex."
+
+#~ msgid "Cannot resume thread %lu"
+#~ msgstr "Nebolo možné obnoviť vlákno %lu"
+
+#~ msgid "Cannot suspend thread %lu"
+#~ msgstr "Nebolo možné suspendovať vlákno %lu"
+
+#~ msgid "Couldn't acquire a mutex lock"
+#~ msgstr "Nebolo možné záskať zámok mutexu"
+
+#~ msgid "Couldn't release a mutex"
+#~ msgstr "Nebolo možné uvoľniť mutex"
+
+#~ msgid "DECIMAL"
+#~ msgstr "DESATINNÉ"
+
+#~ msgid "DEL"
+#~ msgstr "ZMAZAŤ"
+
+#~ msgid "DELETE"
+#~ msgstr "ZMAZAŤ"
+
+#~ msgid "DIVIDE"
+#~ msgstr "DELIŤ"
+
+#~ msgid "DOWN"
+#~ msgstr "DOLU"
+
+#~ msgid "END"
+#~ msgstr "KONIEC"
+
+#~ msgid "ENTER"
+#~ msgstr "ENTER"
+
+#~ msgid "ESC"
+#~ msgstr "ESC"
+
+#~ msgid "ESCAPE"
+#~ msgstr "ESCAPE"
+
+#~ msgid "EXECUTE"
+#~ msgstr "VYKONAŤ"
+
+#~ msgid "Execution of command '%s' failed with error: %ul"
+#~ msgstr "Vykonávanie príkazu '%s' zlyhalo s chybou: %ul"
+
+#~ msgid ""
+#~ "File '%s' already exists.\n"
+#~ "Do you want to replace it?"
+#~ msgstr ""
+#~ "Súbor '%s' už existuje.\n"
+#~ "Chcete ho nahradiť?"
+
+#~ msgid "HELP"
+#~ msgstr "POMOC"
+
+#~ msgid "HOME"
+#~ msgstr "DOMOV"
+
+#~ msgid "INS"
+#~ msgstr "INS"
+
+#~ msgid "INSERT"
+#~ msgstr "VLOŽIŤ"
+
+#~ msgid "MENU"
+#~ msgstr "PONUKA"
+
+#~ msgid "Timer creation failed."
+#~ msgstr "Zlyhalo vytvorenie časovača."
+
+#~ msgid "UP"
+#~ msgstr "HORE"
+
+#~ msgid "WINDOWS_LEFT"
+#~ msgstr "WINDOWS_VĽAVO"
+
+#~ msgid "WINDOWS_MENU"
+#~ msgstr "WINDOWS_PONUKA"
+
+#~ msgid "WINDOWS_RIGHT"
+#~ msgstr "WINDOWS_VPRAVO"
+
+#~ msgid "Print preview"
+#~ msgstr "Náhľad pred tlačou"
+
+#, fuzzy
+#~ msgid "&Preview..."
+#~ msgstr " Náhľad"
+
+#, fuzzy
+#~ msgid "Preview..."
+#~ msgstr " Náhľad"
+
+#, fuzzy
+#~ msgid "The vertical offset relative to the paragraph."
+#~ msgstr "Štandardný štýl ďalšieho odstavca."
+
+#~ msgid "&Save..."
+#~ msgstr "&Uložiť..."
+
+#~ msgid "About "
+#~ msgstr "O aplikácii"
+
+#~ msgid "All files (*.*)|*"
+#~ msgstr "Všetky súbory (*.*)|*"
+
+#~ msgid "Cannot initialize SciTech MGL!"
+#~ msgstr "Nebolo možné inicializovať SciTech MGL!"
+
+#~ msgid "Cannot initialize display."
+#~ msgstr "Nebolo možné inicializovať obrazovku."
+
+#~ msgid "Cannot start thread: error writing TLS"
+#~ msgstr "Nebolo možné spustiť vlákno: chyba pri zápise TLS"
+
+#~ msgid "Close\tAlt-F4"
+#~ msgstr "Zatvoriť\tAlt-F4"
+
+#~ msgid "Couldn't create cursor."
+#~ msgstr "Nebolo možné vytvoriť kurzor."
+
+#~ msgid "Directory '%s' doesn't exist!"
+#~ msgstr "Adresár '%s' neexistuje!"
+
+#~ msgid "Paper Size"
+#~ msgstr "Veľkosť papiera"
+
+#~ msgid "%.*f GB"
+#~ msgstr "%.*f GB"
+
+#~ msgid "%.*f MB"
+#~ msgstr "%.*f MB"
+
+#~ msgid "%.*f TB"
+#~ msgstr "%.*f TB"
+
+#~ msgid "%.*f kB"
+#~ msgstr "%.*f kB"
+
+#~ msgid "%s B"
+#~ msgstr "%s B"
+
+#~ msgid "&Goto..."
+#~ msgstr "&Ísť na..."
+
+#~ msgid "<<"
+#~ msgstr "<<"
+
+#~ msgid ">>"
+#~ msgstr ">>"
+
+#~ msgid ">>|"
+#~ msgstr ">>|"
+
+#~ msgid "Archive doesnt contain #SYSTEM file"
+#~ msgstr "Archív neobsahuje súbor #SYSTEM"
+
+#~ msgid "BIG5"
+#~ msgstr "VEĽKÁ5"
+
+#~ msgid "Can't check image format of file '%s': file does not exist."
+#~ msgstr ""
+#~ "Nebolo možné skontrolovať formát obrázka súboru '%s': súbor neexistuje."
+
+#~ msgid "Can't load image from file '%s': file does not exist."
+#~ msgstr "Nebolo možné načítať obrázok zo súboru '%s': súbor neexistuje."
+
+#~ msgid "Cannot convert dialog units: dialog unknown."
+#~ msgstr "Nebolo možné konvertovať dialógové moduly: dialóg neznámy."
+
+#~ msgid "Cannot convert from the charset '%s'!"
+#~ msgstr "Nebolo možné konvertovať zo znakovej sady '%s'!"
+
+#~ msgid "Cannot find container for unknown control '%s'."
+#~ msgstr "Nebolo možné nájsť kontajner neznámeho ovládacieho prvku '%s'."
+
+#~ msgid "Cannot find font node '%s'."
+#~ msgstr "Nebolo možné nájsť uzol písma '%s'."
+
+#~ msgid "Cannot open file '%s'."
+#~ msgstr "Nebolo možné otvoriť súbor '%s'."
+
+#~ msgid "Cannot parse coordinates from '%s'."
+#~ msgstr "Nebolo možné interpretovať súradnice z '%s'"
+
+#~ msgid "Cannot parse dimension from '%s'."
+#~ msgstr "Nebolo možné interpretovať rozmer z '%s'"
+
+#~ msgid "Cant create the thread event queue"
+#~ msgstr "Nebolo možné vytvoriť front udalostí vlákna"
+
+#~ msgid "Click to cancel this window."
+#~ msgstr "Kliknutím zrušíte toto okno."
+
+#~ msgid "Click to confirm your selection."
+#~ msgstr "Kliknutím potvrdíte váš výber."
+
+#~ msgid "Could not unlock mutex"
+#~ msgstr "Nebolo možné odomknúť mutex"
+
+#~ msgid "Error while waiting on semaphore"
+#~ msgstr "Chyba počas čakania na semafor"
+
+#~ msgid "Failed to create a status bar."
+#~ msgstr "Nepodarilo sa vytvoriť stavový riadok."
+
+#~ msgid "Failed to register OpenGL window class."
+#~ msgstr "Nepodarilo sa zaregistrovať triedu okna OpenGL."
+
+#~ msgid "Fatal error: "
+#~ msgstr "Osudová chyba:"
+
+#~ msgid "GB-2312"
+#~ msgstr "GB-2312"
+
+#~ msgid "Go forward to the next HTML page"
+#~ msgstr "Ísť dopredu na nasledujúcu HTML stránku"
+
+#~ msgid "Goto Page"
+#~ msgstr "Ísť na stránku"
+
+#~ msgid "Help : %s"
+#~ msgstr "Pomocník : %s"
+
+#~ msgid "I64"
+#~ msgstr "I64"
+
+#, fuzzy
+#~ msgid "Owner not initialized."
+#~ msgstr "Nebolo možné inicializovať obrazovku."
+
+#, fuzzy
+#~ msgid "Passed item is invalid."
+#~ msgstr "'%s' je neplatný"
+
+#~ msgid "Preparing help window..."
+#~ msgstr "Pripravuje sa okno pomocníka..."
+
+#~ msgid "Program aborted."
+#~ msgstr "Program zrušený."
+
+#~ msgid "Referenced object node with ref=\"%s\" not found!"
+#~ msgstr "Odkazovaný uzol objektu s ref=\"%s\" nebol nájdený!"
+
+#~ msgid "Resource files must have same version number!"
+#~ msgstr "Súbory zdrojov musia mať rovnaké číslo verzie!"
+
+#~ msgid "Search!"
+#~ msgstr "Hľadať!"
+
+#~ msgid "Sorry, could not open this file for saving."
+#~ msgstr "Prepáčte, nebolo možné otvoriť tento súbor na zápis."
+
+#~ msgid "Sorry, could not save this file."
+#~ msgstr "Prepáčte, nebolo možné uložiť tento súbor."
+
+#~ msgid "Sorry, print preview needs a printer to be installed."
+#~ msgstr ""
+#~ "Prepáčte, náhľad pred tlačou vyžaduje, aby bola nainštalovaná tlačiareň."
+
+#~ msgid "Status: "
+#~ msgstr "Stav: "
+
+#~ msgid "TIFF library error."
+#~ msgstr "Chyba knižnice TIFF."
+
+#~ msgid "TIFF library warning."
+#~ msgstr "Varovanie knižnice TIFF."
+
+#~ msgid "The path '%s' contains too many \"..\"!"
+#~ msgstr "Cesta '%s' obsahuje príliš veľa \"..\"!"
+
+#~ msgid "Warning"
+#~ msgstr "Varovanie"
+
+#~ msgid "Windows 2000 (build %lu"
+#~ msgstr "Windows 2000 (zostavenie %lu"
+
+#, fuzzy
+#~ msgid ""
+#~ "XRC resource: Incorrect colour specification '%s' for attribute '%s'."
+#~ msgstr "Reťazec na farbu : Nesprávna špecifikácia farby : %s"
+
+#~ msgid "looking for catalog '%s' in path '%s'."
+#~ msgstr "hľadá sa katalóg '%s' v ceste '%s'."
+
+#~ msgid " Couldn't create the UnicodeConverter"
+#~ msgstr " Nebolo možné vytvoriť UnicodeConverter"
+
+#~ msgid "#define %s must be an integer."
+#~ msgstr "#define %s musí byť celé číslo (integer)."
+
+#~ msgid "%s not a bitmap resource specification."
+#~ msgstr "%s nie je špecifikácia zdroja s bitmapou."
+
+#~ msgid "%s not an icon resource specification."
+#~ msgstr "%s nie je špecifikácia zdroja s ikonou."
+
+#~ msgid "%s: ill-formed resource file syntax."
+#~ msgstr "%s: syntaktická chyba v súbore zdrojov."
+
+#~ msgid "&Open"
+#~ msgstr "&Otvoriť"
+
+#~ msgid "&Print"
+#~ msgstr "&Tlačiť"
+
+#~ msgid "*** It can be found in \"%s\"\n"
+#~ msgstr "*** Nachádza sa v \"%s\"\n"
+
+#~ msgid ""
+#~ ", expected static, #include or #define\n"
+#~ "while parsing resource."
+#~ msgstr ""
+#~ ", očakávalo sa static, #include alebo #define\n"
+#~ "počas parsovania zdroja."
+
+#~ msgid "Bitmap resource specification %s not found."
+#~ msgstr "Špecifikácia zdroja s bitmapu %s nenájdená."
+
+#~ msgid "Closes the dialog without inserting a symbol."
+#~ msgstr "Zatvorí dialóg bez vlkadania symbolu."
+
+#~ msgid ""
+#~ "Could not resolve control class or id '%s'. Use (non-zero) integer "
+#~ "instead\n"
+#~ " or provide #define (see manual for caveats)"
+#~ msgstr ""
+#~ "Nebolo možné zistiť riadiacu triedu alebo id '%s'. Použite namiesto toho "
+#~ "(nenulové) celé číslo\n"
+#~ " alebo poskytnite #define (pozrite si nástrahy v príručke)"
+
+#~ msgid ""
+#~ "Could not resolve menu id '%s'. Use (non-zero) integer instead\n"
+#~ "or provide #define (see manual for caveats)"
+#~ msgstr ""
+#~ "Nebolo možné zistiť id ponuky '%s'. Použite namiesto toho (nenulové) celé "
+#~ "číslo\n"
+#~ " alebo poskytnite #define (pozrite si nástrahy v príručke)"
+
+#~ msgid "Couldn't end the context on the overlay window"
+#~ msgstr "Nebolo možné skončiť kontext preloženého okna"
+
+#~ msgid "Expected '*' while parsing resource."
+#~ msgstr "Očakávalo sa '*' počas interpretácie zdroja."
+
+#~ msgid "Expected '=' while parsing resource."
+#~ msgstr "Očakávalo sa '=' počas interpretácie zdroja."
+
+#~ msgid "Expected 'char' while parsing resource."
+#~ msgstr "Očakávalo sa 'char' počas interpretácie zdroja."
+
+#~ msgid ""
+#~ "Failed to find XBM resource %s.\n"
+#~ "Forgot to use wxResourceLoadBitmapData?"
+#~ msgstr ""
+#~ "Nepodarilo sa nájsť XBM zdroj %s.\n"
+#~ "Zabudli ste použiť wxResourceLoadBitmapData?"
+
+#~ msgid ""
+#~ "Failed to find XBM resource %s.\n"
+#~ "Forgot to use wxResourceLoadIconData?"
+#~ msgstr ""
+#~ "Nepodarilo sa nájsť XBM zdroj %s.\n"
+#~ "Zabudli ste použiť wxResourceLoadIconData?"
+
+#~ msgid ""
+#~ "Failed to find XPM resource %s.\n"
+#~ "Forgot to use wxResourceLoadBitmapData?"
+#~ msgstr ""
+#~ "Nepodarilo sa nájsť XBM zdroj %s.\n"
+#~ "Zabudli ste použiť wxResourceLoadBitmapData?"
+
+#~ msgid "Failed to get clipboard data."
+#~ msgstr "Nepodarilo sa záskať údaje zo schránky."
+
+#~ msgid "Failed to load shared library '%s' Error '%s'"
+#~ msgstr "Nepodarilo sa načítať zdieľanú knižnicu '%s' Chyba '%s'"
+
+#~ msgid "Found "
+#~ msgstr "Nájdených"
+
+#~ msgid "Icon resource specification %s not found."
+#~ msgstr "Špecifikácia zdroja ikony %s nebola nájdená."
+
+#~ msgid "Ill-formed resource file syntax."
+#~ msgstr "Zle sformovaná syntax súboru so zdrojmi."
+
+#~ msgid "Select all"
+#~ msgstr "Vybrať všetky"
+
+#~ msgid ""
+#~ "Sorry, docking is not supported for ports other than wxMSW, wxMac and "
+#~ "wxGTK"
+#~ msgstr ""
+#~ "Prepáčte, dokovanie nie je podporované pre porty iné ako wxMSW, wxMac and "
+#~ "wxGTK"
+
+#~ msgid "Unexpected end of file while parsing resource."
+#~ msgstr "Neočakávaný koniec súboru počas spracúvania zdroja."
+
+#~ msgid "Unrecognized style %s while parsing resource."
+#~ msgstr "Počas parsovania zdroja nebol rozpoznaný štýl %s."
+
+#~ msgid "Video Output"
+#~ msgstr "Video výstup"
+
+#~ msgid "Warning: attempt to remove HTML tag handler from empty stack."
+#~ msgstr ""
+#~ "Varovanie: pokus odstrániť obsluhu HTML značky z prázdneho zásobníka."
+
+#~ msgid "initiate"
+#~ msgstr "začať"
+
+#~ msgid "invalid eof() return value."
+#~ msgstr "neplatná návratová hodnota okna eof()"

--- a/po_wxstd/sl.po
+++ b/po_wxstd/sl.po
@@ -1,0 +1,10606 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: wxWidgets 3.3\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-05-14 20:23+0200\n"
+"PO-Revision-Date: 2025-08-01 19:17+0200\n"
+"Last-Translator: Martin Srebotnjak <miles@filmsi.net>\n"
+"Language-Team: Martin Srebotnjak <miles@filmsi.net>\n"
+"Language: sl\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=4; plural=(n%100==1 ? 1 : n%100==2 ? 2 : n%100==3 || n"
+"%100==4 ? 3 : 0);\n"
+"X-Poedit-SourceCharset: iso-8859-1\n"
+"X-Generator: Poedit 2.2.1\n"
+
+# generic/filedlgg.cpp:825
+#: ../include/wx/defs.h:2582
+msgid "All files (*.*)|*.*"
+msgstr "Vse datoteke (*.*)|*.*"
+
+# generic/filedlgg.cpp:825
+#: ../include/wx/defs.h:2585
+msgid "All files (*)|*"
+msgstr "Vse datoteke (*)|*"
+
+#: ../include/wx/generic/progdlgg.h:85
+msgid "Elapsed time:"
+msgstr "Pretekli čas:"
+
+#: ../include/wx/generic/progdlgg.h:86
+msgid "Estimated time:"
+msgstr "Predviden čas:"
+
+#: ../include/wx/generic/progdlgg.h:87
+msgid "Remaining time:"
+msgstr "Preostali čas:"
+
+# generic/prntdlgg.cpp:113
+# generic/prntdlgg.cpp:127
+#. TRANSLATORS: HTML printout default title.
+#: ../include/wx/html/htmprint.h:121 ../include/wx/prntbase.h:273
+#: ../include/wx/richtext/richtextprint.h:109 ../src/common/docview.cpp:2161
+msgid "Printout"
+msgstr "Izpis"
+
+# common/prntbase.cpp:106
+# common/prntbase.cpp:148
+#. TRANSLATORS: HTML easy print default title.
+#: ../include/wx/html/htmprint.h:234 ../include/wx/richtext/richtextprint.h:163
+#: ../src/common/prntbase.cpp:522 ../src/html/htmprint.cpp:291
+msgid "Printing"
+msgstr "Tiskanje poteka"
+
+# common/dlgcmn.cpp:109
+# common/dlgcmn.cpp:116
+#: ../include/wx/msgdlg.h:277 ../src/common/stockitem.cpp:211
+msgid "Yes"
+msgstr "Da"
+
+# common/dlgcmn.cpp:111
+# common/dlgcmn.cpp:121
+#: ../include/wx/msgdlg.h:278 ../src/common/stockitem.cpp:182
+msgid "No"
+msgstr "Ne"
+
+# common/dlgcmn.cpp:127
+# generic/dcpsg.cpp:2270
+# generic/dirdlgg.cpp:423
+# generic/filedlgg.cpp:907
+# generic/fontdlgg.cpp:256
+# generic/logg.cpp:733
+# generic/prntdlgg.cpp:467
+# generic/proplist.cpp:511
+# html/helpfrm.cpp:909
+#: ../include/wx/msgdlg.h:279 ../src/common/stockitem.cpp:183
+#: ../src/msw/msgdlg.cpp:430 ../src/msw/msgdlg.cpp:734
+#: ../src/richtext/richtextstyledlg.cpp:292
+msgid "OK"
+msgstr "V redu"
+
+# common/dlgcmn.cpp:148
+# common/prntbase.cpp:109
+# generic/dcpsg.cpp:2271
+# generic/dirdlgg.cpp:425
+# generic/filedlgg.cpp:916
+# generic/fontdlgg.cpp:257
+# generic/prntdlgg.cpp:468
+# generic/progdlgg.cpp:179
+# generic/proplist.cpp:523
+# generic/wizard.cpp:192
+# html/helpfrm.cpp:910
+#: ../include/wx/msgdlg.h:280 ../src/common/stockitem.cpp:150
+#: ../src/msw/msgdlg.cpp:430 ../src/msw/progdlg.cpp:884
+#: ../src/richtext/richtextstyledlg.cpp:295
+msgid "Cancel"
+msgstr "Prekliči"
+
+# common/dlgcmn.cpp:144
+# generic/proplist.cpp:528
+# html/helpfrm.cpp:208
+# msw/mdi.cpp:1283
+#: ../include/wx/msgdlg.h:281 ../src/common/stockitem.cpp:168
+#: ../src/html/helpdlg.cpp:63 ../src/html/helpfrm.cpp:108
+#: ../src/osx/button_osx.cpp:38
+msgid "Help"
+msgstr "Pomoč"
+
+# msw/app.cpp:252
+#: ../include/wx/msw/ole/oleutils.h:52
+msgid "Cannot initialize OLE"
+msgstr "Inicializacija OLE ni možna"
+
+# common/ffile.cpp:182
+#: ../include/wx/msw/private/fswatcher.h:48
+#, c-format
+msgid "Unable to close the handle for '%s'"
+msgstr "Datotečne ročice za »%s« ni mogoče zapreti."
+
+# generic/dirdlgg.cpp:550
+#: ../include/wx/msw/private/fswatcher.h:92
+#, c-format
+msgid "Failed to open directory \"%s\" for monitoring."
+msgstr "Mape \"%s\" ni mogoče odpreti za spremljanje."
+
+# common/ffile.cpp:182
+#: ../include/wx/msw/private/fswatcher.h:125
+msgid "Unable to close I/O completion port handle"
+msgstr "Ni mogoče zapreti ročice vrat dokončanja V/I."
+
+#: ../include/wx/msw/private/fswatcher.h:142
+msgid "Unable to associate handle with I/O completion port"
+msgstr "Ni mogoče povezati ročice z vrati dokončanja V/I."
+
+#: ../include/wx/msw/private/fswatcher.h:148
+msgid "Unexpectedly new I/O completion port was created"
+msgstr "Nepričakovano so ustvarjena nova vrata dokončanja V/I."
+
+#: ../include/wx/msw/private/fswatcher.h:213
+msgid "Unable to post completion status"
+msgstr "Ni mogoče objaviti stanje dokončanosti."
+
+#: ../include/wx/msw/private/fswatcher.h:262
+msgid "Unable to dequeue completion packet"
+msgstr "Paketa dokončanja ni mogoče postaviti iz vrste"
+
+# common/imagbmp.cpp:266
+# common/imagbmp.cpp:278
+#: ../include/wx/msw/private/fswatcher.h:273
+msgid "Unable to create I/O completion port"
+msgstr "Ni mogoče ustvariti ročice vrat dokončanja V/I."
+
+#: ../include/wx/richmsgdlg.h:29
+msgid "&See details"
+msgstr "&Pokaži podrobnosti"
+
+#: ../include/wx/richmsgdlg.h:30
+msgid "&Hide details"
+msgstr "&Skrij podrobnosti"
+
+# generic/fontdlgg.cpp:217
+#: ../include/wx/richtext/richtextbuffer.h:3864
+msgid "&Box"
+msgstr "&Polje"
+
+#: ../include/wx/richtext/richtextbuffer.h:5008
+msgid "&Picture"
+msgstr "&Slika"
+
+# common/dlgcmn.cpp:148
+# common/prntbase.cpp:109
+# generic/dcpsg.cpp:2271
+# generic/dirdlgg.cpp:425
+# generic/filedlgg.cpp:916
+# generic/fontdlgg.cpp:257
+# generic/prntdlgg.cpp:468
+# generic/progdlgg.cpp:179
+# generic/proplist.cpp:523
+# generic/wizard.cpp:192
+# html/helpfrm.cpp:910
+#: ../include/wx/richtext/richtextbuffer.h:5958
+msgid "&Cell"
+msgstr "&Celica"
+
+#: ../include/wx/richtext/richtextbuffer.h:6067
+msgid "&Table"
+msgstr "&Tabela"
+
+# html/helpfrm.cpp:512
+#: ../include/wx/richtext/richtextimagedlg.h:37
+msgid "Object Properties"
+msgstr "Lastnosti predmeta"
+
+#: ../include/wx/richtext/richtextsymboldlg.h:39
+msgid "Symbols"
+msgstr "Simboli"
+
+#: ../include/wx/unix/pipe.h:46
+msgid "Pipe creation failed"
+msgstr "Tvorba cevovoda ni uspela."
+
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR Free Software Foundation, Inc.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+# msw/registry.cpp:399
+#: ../include/wx/unix/private/displayx11.h:65
+msgid "Failed to enumerate video modes"
+msgstr "Preštevanje video-načinov ni uspelo."
+
+# common/ffile.cpp:182
+#: ../include/wx/unix/private/displayx11.h:89
+msgid "Failed to change video mode"
+msgstr "Sprememba video načina ni uspela."
+
+# generic/dirdlgg.cpp:550
+#: ../include/wx/unix/private/fswatcher_kqueue.h:57
+#, c-format
+msgid "Unable to open path '%s'"
+msgstr "Poti »%s« ni mogoče odpreti."
+
+# common/ffile.cpp:182
+#: ../include/wx/unix/private/fswatcher_kqueue.h:74
+#, c-format
+msgid "Unable to close path '%s'"
+msgstr "Poti »%s« ni mogoče zapreti."
+
+#: ../include/wx/xtiprop.h:175
+msgid "SetProperty called w/o valid setter"
+msgstr "SetProperty klicana brez veljavnega nastavljavca"
+
+#: ../include/wx/xtiprop.h:184
+msgid "GetProperty called w/o valid getter"
+msgstr "GetProperty klicana brez veljavnega pridobivalnika"
+
+#: ../include/wx/xtiprop.h:193
+msgid "AddToPropertyCollection called w/o valid adder"
+msgstr "AddToPropertyCollection klicana brez veljavnega dodajalnika"
+
+#: ../include/wx/xtiprop.h:202
+msgid "GetPropertyCollection called w/o valid collection getter"
+msgstr "GetPropertyCollection klicana brez veljavnega pridobivalnika zbirke"
+
+#: ../include/wx/xtiprop.h:255
+msgid "AddToPropertyCollection called on a generic accessor"
+msgstr "AddToPropertyCollection klicana na splošnem dostopniku"
+
+#: ../include/wx/xtiprop.h:262
+msgid "GetPropertyCollection called on a generic accessor"
+msgstr "GetPropertyCollection klicana na splošnem dostopniku"
+
+# common/prntbase.cpp:359
+# generic/progdlgg.cpp:307
+# generic/proplist.cpp:518
+#: ../src/aui/tabmdi.cpp:106 ../src/generic/mdig.cpp:94
+msgid "Cl&ose"
+msgstr "&Zapri "
+
+# common/prntbase.cpp:359
+# generic/progdlgg.cpp:307
+# generic/proplist.cpp:518
+#: ../src/aui/tabmdi.cpp:107 ../src/generic/mdig.cpp:95
+msgid "Close All"
+msgstr "Zapri vse"
+
+# msw/mdi.cpp:188
+#: ../src/aui/tabmdi.cpp:109 ../src/generic/mdig.cpp:97 ../src/msw/mdi.cpp:175
+#: ../src/qt/mdi.cpp:258
+msgid "&Next"
+msgstr "&Naslednji"
+
+# html/helpfrm.cpp:512
+#: ../src/aui/tabmdi.cpp:110 ../src/generic/mdig.cpp:98 ../src/msw/mdi.cpp:176
+#: ../src/qt/mdi.cpp:259
+msgid "&Previous"
+msgstr "&Prejšnji"
+
+# msw/mdi.cpp:1287
+# msw/mdi.cpp:1294
+# msw/window.cpp:2286
+#: ../src/aui/tabmdi.cpp:332 ../src/aui/tabmdi.cpp:348
+#: ../src/aui/tabmdi.cpp:350 ../src/generic/mdig.cpp:291
+#: ../src/generic/mdig.cpp:307 ../src/generic/mdig.cpp:311
+#: ../src/msw/mdi.cpp:337 ../src/qt/mdi.cpp:462
+msgid "&Window"
+msgstr "&Okno"
+
+#: ../src/common/accelcmn.cpp:47
+msgctxt "keyboard key"
+msgid "Delete"
+msgstr "Bris"
+
+#: ../src/common/accelcmn.cpp:48
+msgctxt "keyboard key"
+msgid "Del"
+msgstr "Brisalka"
+
+# generic/helpwxht.cpp:157
+#: ../src/common/accelcmn.cpp:49
+msgctxt "keyboard key"
+msgid "Back"
+msgstr "Vrač"
+
+# generic/helpwxht.cpp:157
+#: ../src/common/accelcmn.cpp:49
+msgctxt "keyboard key"
+msgid "Backspace"
+msgstr "Vračalka"
+
+# html/helpfrm.cpp:372
+#: ../src/common/accelcmn.cpp:50
+msgctxt "keyboard key"
+msgid "Insert"
+msgstr "Vstavljalka"
+
+# html/helpfrm.cpp:372
+#: ../src/common/accelcmn.cpp:51
+msgctxt "keyboard key"
+msgid "Ins"
+msgstr "Vstav"
+
+# generic/prntdlgg.cpp:113
+# generic/prntdlgg.cpp:127
+#: ../src/common/accelcmn.cpp:52
+msgctxt "keyboard key"
+msgid "Enter"
+msgstr "Vnašalka"
+
+#: ../src/common/accelcmn.cpp:53
+msgctxt "keyboard key"
+msgid "Return"
+msgstr "Vračalka"
+
+# generic/prntdlgg.cpp:164
+#: ../src/common/accelcmn.cpp:54
+msgctxt "keyboard key"
+msgid "PageUp"
+msgstr "PrejStran"
+
+# common/prntbase.cpp:731
+#: ../src/common/accelcmn.cpp:54
+msgctxt "keyboard key"
+msgid "Page Up"
+msgstr "Prejšnja stran"
+
+# html/htmlwin.cpp:216
+#: ../src/common/accelcmn.cpp:55
+msgctxt "keyboard key"
+msgid "PageDown"
+msgstr "NaslStran"
+
+# common/prntbase.cpp:731
+#: ../src/common/accelcmn.cpp:55
+msgctxt "keyboard key"
+msgid "Page Down"
+msgstr "Naslednja stran"
+
+#: ../src/common/accelcmn.cpp:56
+msgctxt "keyboard key"
+msgid "PgUp"
+msgstr "Prej. stran"
+
+#: ../src/common/accelcmn.cpp:57
+msgctxt "keyboard key"
+msgid "PgDn"
+msgstr "Nasl. stran"
+
+#: ../src/common/accelcmn.cpp:58
+msgctxt "keyboard key"
+msgid "Left"
+msgstr "Levo"
+
+# generic/fontdlgg.cpp:216
+#: ../src/common/accelcmn.cpp:59
+msgctxt "keyboard key"
+msgid "Right"
+msgstr "Desno"
+
+#: ../src/common/accelcmn.cpp:60
+msgctxt "keyboard key"
+msgid "Up"
+msgstr "Navzgor"
+
+# html/htmlwin.cpp:216
+#: ../src/common/accelcmn.cpp:61
+msgctxt "keyboard key"
+msgid "Down"
+msgstr "Dol"
+
+# generic/dirdlgg.cpp:212
+#: ../src/common/accelcmn.cpp:62
+msgctxt "keyboard key"
+msgid "Home"
+msgstr "Domov"
+
+#: ../src/common/accelcmn.cpp:63
+msgctxt "keyboard key"
+msgid "End"
+msgstr "Konec"
+
+# html/helpfrm.cpp:628
+#: ../src/common/accelcmn.cpp:64
+msgctxt "keyboard key"
+msgid "Space"
+msgstr "Preslednica"
+
+#: ../src/common/accelcmn.cpp:65
+msgctxt "keyboard key"
+msgid "Tab"
+msgstr "Tabulatorka"
+
+#: ../src/common/accelcmn.cpp:66
+msgctxt "keyboard key"
+msgid "Esc"
+msgstr "Ubežnica"
+
+# generic/dcpsg.cpp:2262
+# generic/prntdlgg.cpp:441
+# generic/prntdlgg.cpp:637
+#: ../src/common/accelcmn.cpp:67
+msgctxt "keyboard key"
+msgid "Escape"
+msgstr "Ubežnica"
+
+# common/dlgcmn.cpp:148
+# common/prntbase.cpp:109
+# generic/dcpsg.cpp:2271
+# generic/dirdlgg.cpp:425
+# generic/filedlgg.cpp:916
+# generic/fontdlgg.cpp:257
+# generic/prntdlgg.cpp:468
+# generic/progdlgg.cpp:179
+# generic/proplist.cpp:523
+# generic/wizard.cpp:192
+# html/helpfrm.cpp:910
+#: ../src/common/accelcmn.cpp:68
+msgctxt "keyboard key"
+msgid "Cancel"
+msgstr "Prekliči"
+
+# generic/logg.cpp:475
+#: ../src/common/accelcmn.cpp:69
+msgctxt "keyboard key"
+msgid "Clear"
+msgstr "Počisti"
+
+#: ../src/common/accelcmn.cpp:70
+msgctxt "keyboard key"
+msgid "Menu"
+msgstr "Meni"
+
+#: ../src/common/accelcmn.cpp:71
+msgctxt "keyboard key"
+msgid "Pause"
+msgstr "Prekinitev"
+
+#: ../src/common/accelcmn.cpp:72
+msgctxt "keyboard key"
+msgid "Capital"
+msgstr "Velike začetnice"
+
+# generic/dirdlgg.cpp:191
+#: ../src/common/accelcmn.cpp:73
+msgctxt "keyboard key"
+msgid "Select"
+msgstr "Izbiralka"
+
+# generic/prntdlgg.cpp:113
+# generic/prntdlgg.cpp:127
+#: ../src/common/accelcmn.cpp:74
+msgctxt "keyboard key"
+msgid "Print"
+msgstr "Tiskalka"
+
+#: ../src/common/accelcmn.cpp:75
+msgctxt "keyboard key"
+msgid "Execute"
+msgstr "Izvedi"
+
+#: ../src/common/accelcmn.cpp:76
+msgctxt "keyboard key"
+msgid "Snapshot"
+msgstr "Posnetek"
+
+# common/dlgcmn.cpp:144
+# generic/proplist.cpp:528
+# html/helpfrm.cpp:208
+# msw/mdi.cpp:1283
+#: ../src/common/accelcmn.cpp:77
+msgctxt "keyboard key"
+msgid "Help"
+msgstr "Pomoč"
+
+#: ../src/common/accelcmn.cpp:78
+msgctxt "keyboard key"
+msgid "Add"
+msgstr "Dodaj"
+
+#: ../src/common/accelcmn.cpp:79
+msgctxt "keyboard key"
+msgid "Separator"
+msgstr "Ločilo"
+
+#: ../src/common/accelcmn.cpp:80
+msgctxt "keyboard key"
+msgid "Subtract"
+msgstr "Odštej"
+
+#: ../src/common/accelcmn.cpp:81
+msgctxt "keyboard key"
+msgid "Decimal"
+msgstr "Decimalno"
+
+#: ../src/common/accelcmn.cpp:82
+msgctxt "keyboard key"
+msgid "Multiply"
+msgstr "Pomnoži"
+
+#: ../src/common/accelcmn.cpp:83
+msgctxt "keyboard key"
+msgid "Divide"
+msgstr "Razdeli"
+
+#: ../src/common/accelcmn.cpp:84
+msgctxt "keyboard key"
+msgid "Num_lock"
+msgstr "Zakl_štev"
+
+#: ../src/common/accelcmn.cpp:84
+msgctxt "keyboard key"
+msgid "Num Lock"
+msgstr "Zaklepalka številčnice"
+
+#: ../src/common/accelcmn.cpp:85
+msgctxt "keyboard key"
+msgid "Scroll_lock"
+msgstr "Zakl_drs"
+
+#: ../src/common/accelcmn.cpp:85
+msgctxt "keyboard key"
+msgid "Scroll Lock"
+msgstr "Zaklepalka drsenja"
+
+#: ../src/common/accelcmn.cpp:86
+msgctxt "keyboard key"
+msgid "KP_Space"
+msgstr "ŠT_Preslednica"
+
+#: ../src/common/accelcmn.cpp:86
+msgctxt "keyboard key"
+msgid "Num Space"
+msgstr "Št Preslednica"
+
+#: ../src/common/accelcmn.cpp:87
+msgctxt "keyboard key"
+msgid "KP_Tab"
+msgstr "ŠT_Tabulatorka"
+
+#: ../src/common/accelcmn.cpp:87
+msgctxt "keyboard key"
+msgid "Num Tab"
+msgstr "Št Tabulatorka"
+
+# generic/prntdlgg.cpp:113
+# generic/prntdlgg.cpp:127
+#: ../src/common/accelcmn.cpp:88
+msgctxt "keyboard key"
+msgid "KP_Enter"
+msgstr "ŠT_Vnašalka"
+
+#: ../src/common/accelcmn.cpp:88
+msgctxt "keyboard key"
+msgid "Num Enter"
+msgstr "Št Vnašalka"
+
+# generic/dirdlgg.cpp:212
+#: ../src/common/accelcmn.cpp:89
+msgctxt "keyboard key"
+msgid "KP_Home"
+msgstr "ŠT_Začetek"
+
+# generic/dirdlgg.cpp:212
+#: ../src/common/accelcmn.cpp:89
+msgctxt "keyboard key"
+msgid "Num Home"
+msgstr "Št Domov"
+
+#: ../src/common/accelcmn.cpp:90
+msgctxt "keyboard key"
+msgid "KP_Left"
+msgstr "ŠT_Levo"
+
+#: ../src/common/accelcmn.cpp:90
+msgctxt "keyboard key"
+msgid "Num left"
+msgstr "Št Levo"
+
+#: ../src/common/accelcmn.cpp:91
+msgctxt "keyboard key"
+msgid "KP_Up"
+msgstr "ŠT_Navzgor"
+
+#: ../src/common/accelcmn.cpp:91
+msgctxt "keyboard key"
+msgid "Num Up"
+msgstr "Št Navzgor"
+
+# generic/fontdlgg.cpp:216
+#: ../src/common/accelcmn.cpp:92
+msgctxt "keyboard key"
+msgid "KP_Right"
+msgstr "ŠT_Desno"
+
+# generic/fontdlgg.cpp:216
+#: ../src/common/accelcmn.cpp:92
+msgctxt "keyboard key"
+msgid "Num Right"
+msgstr "Št Desno"
+
+# html/htmlwin.cpp:216
+#: ../src/common/accelcmn.cpp:93
+msgctxt "keyboard key"
+msgid "KP_Down"
+msgstr "ŠT_Navzdol"
+
+# html/htmlwin.cpp:216
+#: ../src/common/accelcmn.cpp:93
+msgctxt "keyboard key"
+msgid "Num Down"
+msgstr "Št Navzdol"
+
+#: ../src/common/accelcmn.cpp:94
+msgctxt "keyboard key"
+msgid "KP_PageUp"
+msgstr "ŠT_Prejšnjastran"
+
+#: ../src/common/accelcmn.cpp:94
+msgctxt "keyboard key"
+msgid "Num Page Up"
+msgstr "Št Prejšnja stran"
+
+#: ../src/common/accelcmn.cpp:95
+msgctxt "keyboard key"
+msgid "KP_PageDown"
+msgstr "ŠT_Naslednjastran"
+
+#: ../src/common/accelcmn.cpp:95
+msgctxt "keyboard key"
+msgid "Num Page Down"
+msgstr "Št Naslednja stran"
+
+#: ../src/common/accelcmn.cpp:96
+msgctxt "keyboard key"
+msgid "KP_Prior"
+msgstr "ŠT_Prejšnji"
+
+# msw/mdi.cpp:188
+#: ../src/common/accelcmn.cpp:97
+msgctxt "keyboard key"
+msgid "KP_Next"
+msgstr "ŠT_Naslednji"
+
+#: ../src/common/accelcmn.cpp:98
+msgctxt "keyboard key"
+msgid "KP_End"
+msgstr "ŠT_Konec"
+
+#: ../src/common/accelcmn.cpp:98
+msgctxt "keyboard key"
+msgid "Num End"
+msgstr "Št Konec"
+
+#: ../src/common/accelcmn.cpp:99
+msgctxt "keyboard key"
+msgid "KP_Begin"
+msgstr "ŠT_Začni"
+
+#: ../src/common/accelcmn.cpp:99
+msgctxt "keyboard key"
+msgid "Num Begin"
+msgstr "Št Začetek"
+
+# html/helpfrm.cpp:372
+#: ../src/common/accelcmn.cpp:100
+msgctxt "keyboard key"
+msgid "KP_Insert"
+msgstr "ŠT_Vstavljalka"
+
+# html/helpfrm.cpp:372
+#: ../src/common/accelcmn.cpp:100
+msgctxt "keyboard key"
+msgid "Num Insert"
+msgstr "Št Vstavi"
+
+#: ../src/common/accelcmn.cpp:101
+msgctxt "keyboard key"
+msgid "KP_Delete"
+msgstr "ŠT_Brisalka"
+
+#: ../src/common/accelcmn.cpp:101
+msgctxt "keyboard key"
+msgid "Num Delete"
+msgstr "Št Brisalka"
+
+#: ../src/common/accelcmn.cpp:102
+msgctxt "keyboard key"
+msgid "KP_Equal"
+msgstr "ŠT_Enako"
+
+#: ../src/common/accelcmn.cpp:102
+msgctxt "keyboard key"
+msgid "Num ="
+msgstr "Št ="
+
+#: ../src/common/accelcmn.cpp:103
+msgctxt "keyboard key"
+msgid "KP_Multiply"
+msgstr "ŠT_Množi"
+
+#: ../src/common/accelcmn.cpp:103
+msgctxt "keyboard key"
+msgid "Num *"
+msgstr "Št *"
+
+#: ../src/common/accelcmn.cpp:104
+msgctxt "keyboard key"
+msgid "KP_Add"
+msgstr "ŠT_Dodaj"
+
+#: ../src/common/accelcmn.cpp:104
+msgctxt "keyboard key"
+msgid "Num +"
+msgstr "Št +"
+
+#: ../src/common/accelcmn.cpp:105
+msgctxt "keyboard key"
+msgid "KP_Separator"
+msgstr "ŠT_Ločilo"
+
+#: ../src/common/accelcmn.cpp:105
+msgctxt "keyboard key"
+msgid "Num ,"
+msgstr "Št ,"
+
+#: ../src/common/accelcmn.cpp:106
+msgctxt "keyboard key"
+msgid "KP_Subtract"
+msgstr "ŠT_Odštej"
+
+#: ../src/common/accelcmn.cpp:106
+msgctxt "keyboard key"
+msgid "Num -"
+msgstr "Št -"
+
+#: ../src/common/accelcmn.cpp:107
+msgctxt "keyboard key"
+msgid "KP_Decimal"
+msgstr "ŠT_Vejica"
+
+#: ../src/common/accelcmn.cpp:107
+msgctxt "keyboard key"
+msgid "Num ."
+msgstr "Št ."
+
+#: ../src/common/accelcmn.cpp:108
+msgctxt "keyboard key"
+msgid "KP_Divide"
+msgstr "ŠT_Deli"
+
+#: ../src/common/accelcmn.cpp:108
+msgctxt "keyboard key"
+msgid "Num /"
+msgstr "Št /"
+
+# msw/utils.cpp:549
+#: ../src/common/accelcmn.cpp:109
+msgctxt "keyboard key"
+msgid "Windows_Left"
+msgstr "Windows_Levo"
+
+# msw/utils.cpp:549
+#: ../src/common/accelcmn.cpp:110
+msgctxt "keyboard key"
+msgid "Windows_Right"
+msgstr "Windows_Desno"
+
+# msw/utils.cpp:549
+#: ../src/common/accelcmn.cpp:111
+msgctxt "keyboard key"
+msgid "Windows_Menu"
+msgstr "Windows_Meni"
+
+#: ../src/common/accelcmn.cpp:112
+msgctxt "keyboard key"
+msgid "Command"
+msgstr "Ukazovalka"
+
+# common/utilscmn.cpp:464
+#: ../src/common/accelcmn.cpp:186 ../src/common/accelcmn.cpp:359
+msgctxt "keyboard key"
+msgid "Ctrl"
+msgstr "Krmilka"
+
+# common/utilscmn.cpp:466
+#: ../src/common/accelcmn.cpp:188 ../src/common/accelcmn.cpp:363
+msgctxt "keyboard key"
+msgid "Alt"
+msgstr "Izmenjalka"
+
+# common/utilscmn.cpp:468
+#: ../src/common/accelcmn.cpp:190 ../src/common/accelcmn.cpp:361
+msgctxt "keyboard key"
+msgid "Shift"
+msgstr "Dvigalka"
+
+#: ../src/common/accelcmn.cpp:196
+msgctxt "keyboard key"
+msgid "num "
+msgstr "Št "
+
+#: ../src/common/accelcmn.cpp:260 ../src/common/accelcmn.cpp:382
+msgctxt "keyboard key"
+msgid "F"
+msgstr "F"
+
+#: ../src/common/accelcmn.cpp:277 ../src/common/accelcmn.cpp:385
+msgctxt "keyboard key"
+msgid "KP_F"
+msgstr "ŠT_F"
+
+#: ../src/common/accelcmn.cpp:280 ../src/common/accelcmn.cpp:388
+msgctxt "keyboard key"
+msgid "KP_"
+msgstr "ŠT_"
+
+#: ../src/common/accelcmn.cpp:283 ../src/common/accelcmn.cpp:391
+msgctxt "keyboard key"
+msgid "SPECIAL"
+msgstr "POSEBNO"
+
+# common/utilscmn.cpp:464
+#: ../src/common/accelcmn.cpp:373
+msgid "Ctrl"
+msgstr "Krmilka"
+
+#: ../src/common/appbase.cpp:786
+msgid "show this help message"
+msgstr "pokaži to sporočilo pomoči"
+
+#: ../src/common/appbase.cpp:796
+msgid "generate verbose log messages"
+msgstr "ustvari obširna dnevniška sporočila"
+
+#: ../src/common/appcmn.cpp:256
+msgid "specify the theme to use"
+msgstr "določi temo za uporabo"
+
+#: ../src/common/appcmn.cpp:270
+msgid "specify display mode to use (e.g. 640x480-16)"
+msgstr "določite zaslonski način (npr. 640x480-16)"
+
+#: ../src/common/appcmn.cpp:292
+#, c-format
+msgid "Unsupported theme '%s'."
+msgstr "Nepodprta tema '%s'."
+
+# generic/filedlgg.cpp:1043
+#: ../src/common/appcmn.cpp:309
+#, c-format
+msgid "Invalid display mode specification '%s'."
+msgstr "Napačna specifikacija načina prikaza '%s'."
+
+# common/filefn.cpp:1086
+#: ../src/common/cmdline.cpp:875
+#, c-format
+msgid "Option '%s' can't be negated"
+msgstr "Možnosti »%s« ni mogoče negirati."
+
+# common/cmdline.cpp:496
+#: ../src/common/cmdline.cpp:889
+#, c-format
+msgid "Unknown long option '%s'"
+msgstr "Nepoznana dolga opcija '%s'"
+
+# common/cmdline.cpp:518
+#: ../src/common/cmdline.cpp:904 ../src/common/cmdline.cpp:926
+#, c-format
+msgid "Unknown option '%s'"
+msgstr "Nepoznana opcija '%s'"
+
+# common/cmdline.cpp:712
+#: ../src/common/cmdline.cpp:1004
+#, c-format
+msgid "Unexpected characters following option '%s'."
+msgstr "Parametru '%s' sledijo nepričakovani znaki."
+
+# common/cmdline.cpp:610
+#: ../src/common/cmdline.cpp:1039
+#, c-format
+msgid "Option '%s' requires a value."
+msgstr "Možnost '%s' zahteva vrednost."
+
+# common/cmdline.cpp:627
+#: ../src/common/cmdline.cpp:1058
+#, c-format
+msgid "Separator expected after the option '%s'."
+msgstr "Po možnosti '%s' je pričakovano ločilo."
+
+# common/cmdline.cpp:657
+#: ../src/common/cmdline.cpp:1088 ../src/common/cmdline.cpp:1106
+#, c-format
+msgid "'%s' is not a correct numeric value for option '%s'."
+msgstr "»%s« ni pravilna numerična vrednost za možnost »%s«."
+
+# common/cmdline.cpp:671
+#: ../src/common/cmdline.cpp:1122
+#, c-format
+msgid "Option '%s': '%s' cannot be converted to a date."
+msgstr "Možnosti '%s':'%s' ni mogoče pretvoriti v datum."
+
+# common/cmdline.cpp:712
+#: ../src/common/cmdline.cpp:1170
+#, c-format
+msgid "Unexpected parameter '%s'"
+msgstr "Nepričakovan parameter '%s'"
+
+# common/cmdline.cpp:735
+#. TRANSLATORS: Short name and long name for a command line option
+#: ../src/common/cmdline.cpp:1197
+#, c-format
+msgid "%s (or %s)"
+msgstr "%s (ali %s)"
+
+# common/cmdline.cpp:740
+#: ../src/common/cmdline.cpp:1208
+#, c-format
+msgid "The value for the option '%s' must be specified."
+msgstr "Vrednost opcije '%s' mora biti podana."
+
+# common/cmdline.cpp:761
+#: ../src/common/cmdline.cpp:1230
+#, c-format
+msgid "The required parameter '%s' was not specified."
+msgstr "Zahtevani parameter '%s' ni bil podan."
+
+# common/cmdline.cpp:797
+#: ../src/common/cmdline.cpp:1289
+#, c-format
+msgid "Usage: %s"
+msgstr "Uporaba: %s"
+
+# common/cmdline.cpp:910
+#: ../src/common/cmdline.cpp:1498
+msgid "str"
+msgstr "str"
+
+# common/cmdline.cpp:911
+#: ../src/common/cmdline.cpp:1502
+msgid "num"
+msgstr "št"
+
+#: ../src/common/cmdline.cpp:1506
+msgid "double"
+msgstr "dvojno"
+
+# common/cmdline.cpp:912
+#: ../src/common/cmdline.cpp:1510
+msgid "date"
+msgstr "datum"
+
+# common/docview.cpp:1923
+# common/docview.cpp:1938
+# common/docview.cpp:1965
+#: ../src/common/cmdproc.cpp:250 ../src/common/cmdproc.cpp:276
+#: ../src/common/cmdproc.cpp:296
+msgid "Unnamed command"
+msgstr "Neimenovan ukaz"
+
+# common/docview.cpp:1926
+#: ../src/common/cmdproc.cpp:253
+msgid "&Undo "
+msgstr "&Razveljavi"
+
+# common/docview.cpp:1928
+#: ../src/common/cmdproc.cpp:255
+msgid "Can't &Undo "
+msgstr "Nemogoča &razveljavitev"
+
+# common/docview.cpp:1951
+#: ../src/common/cmdproc.cpp:259 ../src/common/stockitem.cpp:208
+#: ../src/msw/textctrl.cpp:2880 ../src/osx/textctrl_osx.cpp:649
+#: ../src/richtext/richtextctrl.cpp:327
+msgid "&Undo"
+msgstr "&Razveljavi"
+
+# common/docview.cpp:1939
+# common/docview.cpp:1966
+#: ../src/common/cmdproc.cpp:277 ../src/common/cmdproc.cpp:297
+msgid "&Redo "
+msgstr "&Ponovi "
+
+# common/docview.cpp:1945
+# common/docview.cpp:1956
+#: ../src/common/cmdproc.cpp:281 ../src/common/cmdproc.cpp:288
+#: ../src/common/stockitem.cpp:190 ../src/msw/textctrl.cpp:2881
+#: ../src/osx/textctrl_osx.cpp:650 ../src/richtext/richtextctrl.cpp:328
+msgid "&Redo"
+msgstr "&Ponovi"
+
+#: ../src/common/colourcmn.cpp:41
+#, c-format
+msgid "String To Colour : Incorrect colour specification : %s"
+msgstr "Niz v barvo: nepravilna specifikacija barve: %s"
+
+#: ../src/common/config.cpp:259
+#, c-format
+msgid "Invalid value %ld for a boolean key \"%s\" in config file."
+msgstr ""
+"Neveljavna vrednost %ld za logični ključ »%s« v prilagoditveni datoteki."
+
+# common/config.cpp:349
+#: ../src/common/config.cpp:526
+#, c-format
+msgid ""
+"Environment variables expansion failed: missing '%c' at position %u in '%s'."
+msgstr ""
+"Razširitev okoljske spremenljivke ni uspela: manjka »%c« na mestu %u v »%s«."
+
+# common/config.cpp:396
+# msw/regconf.cpp:264
+#: ../src/common/config.cpp:576 ../src/msw/regconf.cpp:272
+#, c-format
+msgid "'%s' has extra '..', ignored."
+msgstr "»%s« ima dodaten »..«, prezrto."
+
+#. TRANSLATORS: Checkbox state name
+#: ../src/common/datavcmn.cpp:2166 ../src/generic/datavgen.cpp:1430
+msgid "checked"
+msgstr "potrjeno"
+
+#. TRANSLATORS: Checkbox state name
+#: ../src/common/datavcmn.cpp:2170 ../src/generic/datavgen.cpp:1432
+msgid "unchecked"
+msgstr "nepotrjeno"
+
+# generic/fontdlgg.cpp:242
+#. TRANSLATORS: Checkbox state name
+#: ../src/common/datavcmn.cpp:2174
+msgid "undetermined"
+msgstr "nedoločeno"
+
+#: ../src/common/datetimefmt.cpp:1875
+msgid "today"
+msgstr "danes"
+
+#: ../src/common/datetimefmt.cpp:1876
+msgid "yesterday"
+msgstr "včeraj"
+
+#: ../src/common/datetimefmt.cpp:1877
+msgid "tomorrow"
+msgstr "jutri"
+
+#: ../src/common/datetimefmt.cpp:2071
+msgid "first"
+msgstr "prvi"
+
+#: ../src/common/datetimefmt.cpp:2072
+msgid "second"
+msgstr "drugi"
+
+#: ../src/common/datetimefmt.cpp:2073
+msgid "third"
+msgstr "tretji"
+
+#: ../src/common/datetimefmt.cpp:2074
+msgid "fourth"
+msgstr "četrti"
+
+#: ../src/common/datetimefmt.cpp:2075
+msgid "fifth"
+msgstr "peti"
+
+#: ../src/common/datetimefmt.cpp:2076
+msgid "sixth"
+msgstr "šesti"
+
+#: ../src/common/datetimefmt.cpp:2077
+msgid "seventh"
+msgstr "sedmi"
+
+# generic/fontdlgg.cpp:216
+#: ../src/common/datetimefmt.cpp:2078
+msgid "eighth"
+msgstr "osmi"
+
+# generic/prntdlgg.cpp:113
+# generic/prntdlgg.cpp:127
+#: ../src/common/datetimefmt.cpp:2079
+msgid "ninth"
+msgstr "deveti"
+
+# generic/helpwxht.cpp:159
+# html/helpfrm.cpp:303
+# html/helpfrm.cpp:312
+#: ../src/common/datetimefmt.cpp:2080
+msgid "tenth"
+msgstr "deseti"
+
+#: ../src/common/datetimefmt.cpp:2081
+msgid "eleventh"
+msgstr "enajsti"
+
+#: ../src/common/datetimefmt.cpp:2082
+msgid "twelfth"
+msgstr "dvanajsti"
+
+#: ../src/common/datetimefmt.cpp:2083
+msgid "thirteenth"
+msgstr "trinajsti"
+
+#: ../src/common/datetimefmt.cpp:2084
+msgid "fourteenth"
+msgstr "štirinajsti"
+
+#: ../src/common/datetimefmt.cpp:2085
+msgid "fifteenth"
+msgstr "petnajsti"
+
+#: ../src/common/datetimefmt.cpp:2086
+msgid "sixteenth"
+msgstr "šestnajsti"
+
+#: ../src/common/datetimefmt.cpp:2087
+msgid "seventeenth"
+msgstr "sedemnajsti"
+
+#: ../src/common/datetimefmt.cpp:2088
+msgid "eighteenth"
+msgstr "osemnajsti"
+
+#: ../src/common/datetimefmt.cpp:2089
+msgid "nineteenth"
+msgstr "devetnajsti"
+
+#: ../src/common/datetimefmt.cpp:2090
+msgid "twentieth"
+msgstr "dvajseti"
+
+# html/helpdata.cpp:644
+#: ../src/common/datetimefmt.cpp:2248
+msgid "noon"
+msgstr "opoldne"
+
+# generic/fontdlgg.cpp:216
+#: ../src/common/datetimefmt.cpp:2249
+msgid "midnight"
+msgstr "opolnoči"
+
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR Free Software Foundation, Inc.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+# msw/registry.cpp:399
+#: ../src/common/debugrpt.cpp:209
+#, c-format
+msgid "Failed to create directory \"%s\""
+msgstr "Mape »%s« ni mogoče ustvariti."
+
+# common/filefn.cpp:1086
+#: ../src/common/debugrpt.cpp:210
+msgid "Debug report couldn't be created."
+msgstr "Poročila o razhroščevanju ni mogoče ustvariti."
+
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR Free Software Foundation, Inc.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+# common/file.cpp:552
+# common/file.cpp:562
+#: ../src/common/debugrpt.cpp:227
+#, c-format
+msgid "Failed to remove debug report file \"%s\""
+msgstr "Datoteke poročila o razhroščevanju »%s« ni mogoče odstraniti."
+
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR Free Software Foundation, Inc.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+# msw/registry.cpp:399
+#: ../src/common/debugrpt.cpp:239
+#, c-format
+msgid "Failed to clean up debug report directory \"%s\""
+msgstr "Mape poročila o razhroščevanju »%s« ni mogoče počistiti."
+
+#: ../src/common/debugrpt.cpp:514
+msgid "process context description"
+msgstr "opis konteksta procesa"
+
+#: ../src/common/debugrpt.cpp:538
+msgid "dump of the process state (binary)"
+msgstr "izmet stanja procesa (binarni)"
+
+#: ../src/common/debugrpt.cpp:553
+msgid "Debug report generation has failed."
+msgstr "Tvorba poročila o razhroščevanju ni uspela."
+
+#: ../src/common/debugrpt.cpp:560
+#, c-format
+msgid ""
+"Processing debug report has failed, leaving the files in \"%s\" directory."
+msgstr ""
+"Obdelava poročila o razhroščevanju ni uspela, datoteke so ostale v mapi \"%s"
+"\"."
+
+#: ../src/common/debugrpt.cpp:573
+msgid "A debug report has been generated. It can be found in"
+msgstr "Poročilo o razhroščevanju je bilo ustvarjeno. Nahaja se v"
+
+#: ../src/common/debugrpt.cpp:576
+msgid "And includes the following files:\n"
+msgstr "in vsebuje naslednje datoteke:\n"
+
+#: ../src/common/debugrpt.cpp:586
+msgid ""
+"\n"
+"Please send this report to the program maintainer, thank you!\n"
+msgstr ""
+"\n"
+"Prosimo, pošljite to poročilo vzdrževalcu programa, hvala!\n"
+
+#: ../src/common/debugrpt.cpp:729
+msgid "Failed to execute curl, please install it in PATH."
+msgstr "curl ni bilo mogoče izvesti, prosimo, namestite ga v poti PATH."
+
+#: ../src/common/debugrpt.cpp:742
+#, c-format
+msgid "Failed to upload the debug report (error code %d)."
+msgstr "Poročila o razhroščevanju ni bilo mogoče prenesti (koda napake %d)"
+
+# common/docview.cpp:249
+#: ../src/common/docview.cpp:366
+msgid "Save As"
+msgstr "Shrani kot"
+
+#: ../src/common/docview.cpp:457
+msgid "Discard changes and reload the last saved version?"
+msgstr ""
+"Želite opustiti spremembe in ponovno naložiti nazadnje shranjeno različico?"
+
+# common/docview.cpp:406
+#: ../src/common/docview.cpp:488
+msgid "unnamed"
+msgstr "neimenovana"
+
+# common/docview.cpp:440
+#: ../src/common/docview.cpp:513
+#, c-format
+msgid "Do you want to save changes to %s?"
+msgstr "Ali želite shraniti spremembe dokumenta %s?"
+
+# generic/logg.cpp:473
+# generic/logg.cpp:774
+#: ../src/common/docview.cpp:521 ../src/common/docview.cpp:560
+#: ../src/common/stockitem.cpp:195
+msgid "&Save"
+msgstr "&Shrani"
+
+#: ../src/common/docview.cpp:522 ../src/common/docview.cpp:560
+msgid "&Discard changes"
+msgstr "&Zavrzi spremembe"
+
+#: ../src/common/docview.cpp:523
+msgid "Do&n't close"
+msgstr "&Ne zapri"
+
+# common/docview.cpp:440
+#: ../src/common/docview.cpp:553
+#, c-format
+msgid "Do you want to save changes to %s before closing it?"
+msgstr "Ali želite shraniti spremembe v %s, preden ga zaprete?"
+
+# common/textcmn.cpp:121
+#: ../src/common/docview.cpp:559
+msgid "The document must be closed."
+msgstr "Dokument mora biti zaprt."
+
+#: ../src/common/docview.cpp:571
+#, c-format
+msgid "Saving %s failed, would you like to retry?"
+msgstr "Shranjevanje %s je spodletelo, ali želite poskusiti znova?"
+
+#: ../src/common/docview.cpp:577
+msgid "Retry"
+msgstr "Poskusi znova"
+
+#: ../src/common/docview.cpp:577
+msgid "Discard changes"
+msgstr "Zavrzi spremembe"
+
+# generic/dirdlgg.cpp:550
+#: ../src/common/docview.cpp:679
+#, c-format
+msgid "File \"%s\" could not be opened for writing."
+msgstr "Datoteke \"%s\" ni mogoče odpreti za pisanje."
+
+# common/ffile.cpp:182
+#: ../src/common/docview.cpp:685
+#, c-format
+msgid "Failed to save document to the file \"%s\"."
+msgstr "Neuspešno shranjevanje dokumenta v datoteko \"%s\"."
+
+# generic/dirdlgg.cpp:550
+#: ../src/common/docview.cpp:702
+#, c-format
+msgid "File \"%s\" could not be opened for reading."
+msgstr "Datoteke \"%s\" ni mogoče odpreti za branje."
+
+# common/ffile.cpp:182
+#: ../src/common/docview.cpp:714
+#, c-format
+msgid "Failed to read document from the file \"%s\"."
+msgstr "Dokumenta iz datoteke \"%s\" ni mogoče prebrati."
+
+# common/docview.cpp:1676
+#: ../src/common/docview.cpp:1236
+#, c-format
+msgid ""
+"The file '%s' doesn't exist and couldn't be opened.\n"
+"It has been removed from the most recently used files list."
+msgstr ""
+"Datoteka '%s' ne obstaja in je ni mogoče odpreti.\n"
+"Izbisana je bila iz seznama zadnjih uporabljenih datotek."
+
+#: ../src/common/docview.cpp:1296
+msgid "Print preview creation failed."
+msgstr "Tvorba predogleda tiskanja ni uspela."
+
+# common/docview.cpp:897
+#: ../src/common/docview.cpp:1302
+msgid "Print Preview"
+msgstr "Predogled tiskanja"
+
+#: ../src/common/docview.cpp:1517
+#, c-format
+msgid "The format of file '%s' couldn't be determined."
+msgstr "Vrste datoteke '%s' ni mogoče ugotoviti."
+
+# common/docview.cpp:1188
+#: ../src/common/docview.cpp:1643
+#, c-format
+msgid "unnamed%d"
+msgstr "neimenovana%d"
+
+# common/docview.cpp:1206
+#: ../src/common/docview.cpp:1660
+msgid " - "
+msgstr " - "
+
+#: ../src/common/docview.cpp:1791 ../src/common/docview.cpp:1844
+msgid "Open File"
+msgstr "Odpri datoteko"
+
+# common/docview.cpp:296
+# common/docview.cpp:332
+# common/docview.cpp:1388
+#: ../src/common/docview.cpp:1807
+msgid "File error"
+msgstr "Datotečna napaka"
+
+# common/docview.cpp:342
+# common/docview.cpp:354
+# common/docview.cpp:1390
+#: ../src/common/docview.cpp:1809
+msgid "Sorry, could not open this file."
+msgstr "Oprostite, te datoteke ni moč odpreti."
+
+# common/docview.cpp:342
+# common/docview.cpp:354
+# common/docview.cpp:1390
+#: ../src/common/docview.cpp:1843
+msgid "Sorry, the format for this file is unknown."
+msgstr "Oprostite, ta zapis datoteke je neznan."
+
+# common/docview.cpp:1469
+#: ../src/common/docview.cpp:1924
+msgid "Select a document template"
+msgstr "Izberi predlogo dokumenta"
+
+# common/docview.cpp:1469
+#: ../src/common/docview.cpp:1925
+msgid "Templates"
+msgstr "Šablone"
+
+# common/docview.cpp:1494
+#: ../src/common/docview.cpp:1998
+msgid "Select a document view"
+msgstr "Izberi pogled dokumenta"
+
+# common/docview.cpp:1494
+#: ../src/common/docview.cpp:1999
+msgid "Views"
+msgstr "Pogledi"
+
+# common/dynlib.cpp:239
+#: ../src/common/dynlib.cpp:81
+#, c-format
+msgid "Failed to load shared library '%s'"
+msgstr "Deljene knjižnice »%s« ni mogoče odpreti."
+
+# common/dynlib.cpp:309
+#: ../src/common/dynlib.cpp:105
+#, c-format
+msgid "Couldn't find symbol '%s' in a dynamic library"
+msgstr "Simbola »%s« v dinamični knjižnici ni mogoče najti."
+
+# common/ffile.cpp:85
+# common/file.cpp:243
+#: ../src/common/ffile.cpp:56 ../src/common/file.cpp:215
+#, c-format
+msgid "can't open file '%s'"
+msgstr "ni mogoče odpreti datoteke '%s'"
+
+# common/ffile.cpp:101
+#: ../src/common/ffile.cpp:72
+#, c-format
+msgid "can't close file '%s'"
+msgstr "ni mogoče zapreti datoteke '%s'"
+
+# common/ffile.cpp:133
+# common/ffile.cpp:154
+#: ../src/common/ffile.cpp:106 ../src/common/ffile.cpp:131
+#, c-format
+msgid "Read error on file '%s'"
+msgstr "Napaka pri branju datoteke '%s'"
+
+# common/ffile.cpp:168
+#: ../src/common/ffile.cpp:148
+#, c-format
+msgid "Write error on file '%s'"
+msgstr "Napaka pri pisanju datoteke »%s«"
+
+# common/ffile.cpp:182
+#: ../src/common/ffile.cpp:182
+#, c-format
+msgid "failed to flush the file '%s'"
+msgstr "ne morem izprazniti datoteke '%s'"
+
+#: ../src/common/ffile.cpp:222
+#, c-format
+msgid "Seek error on file '%s' (large files not supported by stdio)"
+msgstr "Najdi napako na datoteki '%s' (velike datoteke niso podprte v stdio)"
+
+# common/ffile.cpp:221
+#: ../src/common/ffile.cpp:232
+#, c-format
+msgid "Seek error on file '%s'"
+msgstr "Napaka pri iskanju v datoteki '%s'"
+
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR Free Software Foundation, Inc.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+# common/ffile.cpp:234
+#: ../src/common/ffile.cpp:248
+#, c-format
+msgid "Can't find current position in file '%s'"
+msgstr "Trenutne pozicije v datoteki »%s« ni mogoče najti."
+
+# common/ffile.cpp:182
+#: ../src/common/ffile.cpp:349 ../src/common/file.cpp:569
+msgid "Failed to set temporary file permissions"
+msgstr "Neuspešno nastavljanje pravic za trenutno datoteko"
+
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR Free Software Foundation, Inc.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+# common/file.cpp:552
+# common/file.cpp:562
+#: ../src/common/ffile.cpp:371
+#, c-format
+msgid "can't remove file '%s'"
+msgstr "ni mogoče odstraniti datoteke '%s'"
+
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR Free Software Foundation, Inc.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+# common/file.cpp:557
+# common/file.cpp:567
+#: ../src/common/ffile.cpp:376 ../src/common/file.cpp:591
+#, c-format
+msgid "can't commit changes to file '%s'"
+msgstr "ni mogoče uveljaviti sprememb datoteke '%s'"
+
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR Free Software Foundation, Inc.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+# common/file.cpp:580
+# common/file.cpp:583
+#: ../src/common/ffile.cpp:388 ../src/common/file.cpp:603
+#, c-format
+msgid "can't remove temporary file '%s'"
+msgstr "ni mogoče odstraniti začasne datoteke '%s'"
+
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR Free Software Foundation, Inc.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+# common/file.cpp:200
+#: ../src/common/file.cpp:162
+#, c-format
+msgid "can't create file '%s'"
+msgstr "ni mogoče ustvariti datoteke '%s'"
+
+# common/file.cpp:257
+#: ../src/common/file.cpp:229
+#, c-format
+msgid "can't close file descriptor %d"
+msgstr "ni mogoče zapreti datotečnega deskriptorja %d"
+
+# common/file.cpp:285
+#: ../src/common/file.cpp:332
+#, c-format
+msgid "can't read from file descriptor %d"
+msgstr "ni mogoče brati iz deskriptorja %d"
+
+# common/file.cpp:304
+#: ../src/common/file.cpp:351
+#, c-format
+msgid "can't write to file descriptor %d"
+msgstr "ni mogoče pisati na deskriptor %d"
+
+# common/file.cpp:319
+#: ../src/common/file.cpp:390
+#, c-format
+msgid "can't flush file descriptor %d"
+msgstr "ni mogoče izprazniti deskriptorja %d"
+
+# common/file.cpp:359
+#: ../src/common/file.cpp:432
+#, c-format
+msgid "can't seek on file descriptor %d"
+msgstr "ni mogoče iskati na datotečnem deskriptorju %d"
+
+# common/file.cpp:373
+#: ../src/common/file.cpp:446
+#, c-format
+msgid "can't get seek position on file descriptor %d"
+msgstr "ni mogoče najti iskalne pozicije v datotečnem deskriptorju %d"
+
+# common/file.cpp:404
+#: ../src/common/file.cpp:475
+#, c-format
+msgid "can't find length of file on file descriptor %d"
+msgstr "ni mogoče najti dolžine datoteke na datotečnem deskriptorju %d"
+
+# common/file.cpp:438
+#: ../src/common/file.cpp:505
+#, c-format
+msgid "can't determine if the end of file is reached on descriptor %d"
+msgstr ""
+"ni mogoče ugotoviti, ali je bil konec datoteke na deskriptorju %d dosežen"
+
+#: ../src/common/fileconf.cpp:352
+#, c-format
+msgid ""
+" and additionally, the existing configuration file was renamed to \"%s\" and "
+"couldn't be renamed back, please rename it to its original path \"%s\""
+msgstr ""
+" Poleg tega je bila obstoječa prilagoditvena datoteka preimenovana v »%s« in "
+"je ni bilo mogoče preimenovati nazaj; preimenujte jo v prvotno pot »%s«"
+
+#: ../src/common/fileconf.cpp:389
+msgid " due to the following error:\n"
+msgstr " zaradi naslednje napake:\n"
+
+# common/ffile.cpp:182
+#: ../src/common/fileconf.cpp:412
+msgid "failed to rename the existing file"
+msgstr "preimenovanje obstoječe datoteke ni uspelo"
+
+# generic/dirdlgg.cpp:550
+#: ../src/common/fileconf.cpp:421
+msgid "failed to create the new file directory"
+msgstr "Ustvarjanje nove mape datoteke ni uspelo"
+
+#: ../src/common/fileconf.cpp:428
+msgid "failed to move the file to the new location"
+msgstr "premik datoteke na novo mesto ni uspel"
+
+# common/fileconf.cpp:319
+#: ../src/common/fileconf.cpp:462
+#, c-format
+msgid "can't open global configuration file '%s'."
+msgstr "ni mogoče odpreti globalne konfiguracijske datoteke '%s'."
+
+# common/fileconf.cpp:331
+#: ../src/common/fileconf.cpp:478
+#, c-format
+msgid "can't open user configuration file '%s'."
+msgstr "ni mogoče odpreti uporabnikove konfiguracijske datoteke '%s'."
+
+#: ../src/common/fileconf.cpp:483
+#, c-format
+msgid "Changes won't be saved to avoid overwriting the existing file \"%s\""
+msgstr "Spremembe ne bodo shranjene v izogib prepisu obstoječe datoteke \"%s\""
+
+# generic/dirdlgg.cpp:552
+#: ../src/common/fileconf.cpp:583
+msgid "Error reading config options."
+msgstr "Napaka pri branju konfiguracijskih možnosti."
+
+# generic/dirdlgg.cpp:552
+#: ../src/common/fileconf.cpp:593
+msgid "Failed to read config options."
+msgstr "Napaka pri branju konfiguracijskih možnosti."
+
+# common/fileconf.cpp:449
+#: ../src/common/fileconf.cpp:700
+#, c-format
+msgid "file '%s': unexpected character %c at line %zu."
+msgstr "datoteka »%s«: nepričakovan znak %c v vrstici %zu."
+
+# common/fileconf.cpp:481
+#: ../src/common/fileconf.cpp:736
+#, c-format
+msgid "file '%s', line %zu: '%s' ignored after group header."
+msgstr "datoteka »%s«, vrstica %zu: »%s« je bil ignoriran po skupinski glavi."
+
+# common/fileconf.cpp:510
+#: ../src/common/fileconf.cpp:765
+#, c-format
+msgid "file '%s', line %zu: '=' expected."
+msgstr "datoteka »%s«, vrstica %zu: »=» pričakovan."
+
+# common/fileconf.cpp:526
+#: ../src/common/fileconf.cpp:778
+#, c-format
+msgid "file '%s', line %zu: value for immutable key '%s' ignored."
+msgstr ""
+"datoteka »%s«, vrstica %zu: vrednost nespremenljivega ključa »%s« ignorirana."
+
+# common/fileconf.cpp:536
+#: ../src/common/fileconf.cpp:788
+#, c-format
+msgid "file '%s', line %zu: key '%s' was first found at line %d."
+msgstr "datoteka »%s«, vrstica %zu: ključ »%s« je bil že najden v vrstici %d."
+
+# common/fileconf.cpp:760
+#: ../src/common/fileconf.cpp:1091
+#, c-format
+msgid "Config entry name cannot start with '%c'."
+msgstr "Vstopno konfiguracijsko ime se ne more začeti s »%c«."
+
+# common/fileconf.cpp:800
+#: ../src/common/fileconf.cpp:1146
+msgid "Failed to create configuration file directory."
+msgstr "Ustvarjanje mape prilagoditvene datoteke ni uspelo."
+
+# common/fileconf.cpp:800
+#: ../src/common/fileconf.cpp:1158
+msgid "can't open user configuration file."
+msgstr "ni mogoče odpreti uporabniške konfiguracijske datoteke."
+
+# common/fileconf.cpp:807
+#: ../src/common/fileconf.cpp:1172
+msgid "can't write user configuration file."
+msgstr "ni mogoče zapisati uporabniške konfiguracijske datoteke."
+
+# common/fileconf.cpp:800
+#: ../src/common/fileconf.cpp:1178
+msgid "Failed to update user configuration file."
+msgstr "Uporabniške konfiguracijske datoteke ni mogoče posodobiti."
+
+# generic/dirdlgg.cpp:552
+#: ../src/common/fileconf.cpp:1201
+msgid "Error saving user configuration data."
+msgstr "Napaka pri shranjevanju podatkov nastavitev uporabnika."
+
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR Free Software Foundation, Inc.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+# common/fileconf.cpp:920
+#: ../src/common/fileconf.cpp:1313
+#, c-format
+msgid "can't delete user configuration file '%s'"
+msgstr "ni mogoče uzbrisati uporabniške datoteke '%s'"
+
+# common/fileconf.cpp:1437
+#: ../src/common/fileconf.cpp:2007
+#, c-format
+msgid "entry '%s' appears more than once in group '%s'"
+msgstr "vnos '%s' se pojavi večkrat v skupini '%s'"
+
+# common/fileconf.cpp:1450
+#: ../src/common/fileconf.cpp:2021
+#, c-format
+msgid "attempt to change immutable key '%s' ignored."
+msgstr "poskus spremembe nestremenjivega ključa '%s' je bil ignoriran."
+
+#: ../src/common/fileconf.cpp:2118
+#, c-format
+msgid "trailing backslash ignored in '%s'"
+msgstr "leva poševnica na koncu v »%s« prezrta"
+
+# common/fileconf.cpp:1557
+#: ../src/common/fileconf.cpp:2153
+#, c-format
+msgid "unexpected \" at position %d in '%s'."
+msgstr "nepričakovan \" na poziciji %d v '%s'."
+
+# common/ffile.cpp:182
+#: ../src/common/filefn.cpp:474
+#, c-format
+msgid "Failed to copy the file '%s' to '%s'"
+msgstr "Datoteke »%s« ni mogoče kopirati v »%s«"
+
+#: ../src/common/filefn.cpp:487
+#, c-format
+msgid "Impossible to get permissions for file '%s'"
+msgstr "Pravic za datoteko »%s« ni mogoče dobiti."
+
+# common/ffile.cpp:182
+#: ../src/common/filefn.cpp:501
+#, c-format
+msgid "Impossible to overwrite the file '%s'"
+msgstr "Datoteke »%s« ni mogoče prepisati."
+
+# common/ffile.cpp:182
+#: ../src/common/filefn.cpp:508
+#, c-format
+msgid "Error copying the file '%s' to '%s'."
+msgstr "Napaka pri kopiranju datoteke »%s« v »%s«."
+
+#: ../src/common/filefn.cpp:556
+#, c-format
+msgid "Impossible to set permissions for the file '%s'"
+msgstr "Pravic za datoteko »%s« ni mogoče nastaviti."
+
+#: ../src/common/filefn.cpp:606
+#, c-format
+msgid ""
+"Failed to rename the file '%s' to '%s' because the destination file already "
+"exists."
+msgstr ""
+"Datoteke''%s' ni mogoče preimenovati v '%s', ker ciljna datoteka že obstaja."
+
+# common/filefn.cpp:1086
+#: ../src/common/filefn.cpp:623
+#, c-format
+msgid "File '%s' couldn't be renamed '%s'"
+msgstr "Datoteke »%s« ni mogoče preimenovati v »%s«."
+
+# common/filefn.cpp:1086
+#: ../src/common/filefn.cpp:639
+#, c-format
+msgid "File '%s' couldn't be removed"
+msgstr "Datoteke »%s« ni mogoče odstraniti."
+
+# common/filefn.cpp:1086
+#: ../src/common/filefn.cpp:666
+#, c-format
+msgid "Directory '%s' couldn't be created"
+msgstr "Mape »%s« ni mogoče ustvariti."
+
+# common/filefn.cpp:1086
+#: ../src/common/filefn.cpp:680
+#, c-format
+msgid "Directory '%s' couldn't be deleted"
+msgstr "Mape »%s« ni mogoče izbrisati."
+
+# common/filefn.cpp:1287
+# msw/dir.cpp:294
+#: ../src/common/filefn.cpp:714
+#, c-format
+msgid "Cannot enumerate files '%s'"
+msgstr "Oštevilčenje datotek »%s« ni možno"
+
+# generic/dirdlgg.cpp:550
+#: ../src/common/filefn.cpp:798
+msgid "Failed to get the working directory"
+msgstr "Delovne mape ni mogoče pridobiti."
+
+# generic/dirdlgg.cpp:550
+#: ../src/common/filefn.cpp:843
+msgid "Could not set current working directory"
+msgstr "Delovne mape ni mogoče določiti."
+
+# generic/filedlgg.cpp:825
+#: ../src/common/filefn.cpp:974
+#, c-format
+msgid "Files (%s)"
+msgstr "Datoteke (%s)"
+
+# generic/dirdlgg.cpp:550
+#: ../src/common/filename.cpp:182
+#, c-format
+msgid "Failed to open '%s' for reading"
+msgstr "'%s' ni mogoče odpreti za branje"
+
+# generic/dirdlgg.cpp:550
+#: ../src/common/filename.cpp:187
+#, c-format
+msgid "Failed to open '%s' for writing"
+msgstr "'%s' ni mogoče odpreti za pisanje"
+
+# common/ffile.cpp:182
+#: ../src/common/filename.cpp:199
+msgid "Failed to close file handle"
+msgstr "Neuspešno zapiranje datotečne ročice."
+
+# generic/dirdlgg.cpp:550
+#: ../src/common/filename.cpp:1046
+msgid "Failed to create a temporary file name"
+msgstr "Začasnega imena datoteke ni mogoče ustvariti."
+
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR Free Software Foundation, Inc.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+# common/file.cpp:580
+# common/file.cpp:583
+#: ../src/common/filename.cpp:1081
+msgid "Failed to open temporary file."
+msgstr "Začasne datoteke ni mogoče odpreti."
+
+# common/ffile.cpp:182
+#: ../src/common/filename.cpp:2862
+#, c-format
+msgid "Failed to modify file times for '%s'"
+msgstr "Sprememba datotečnih časov za »%s« ni uspela."
+
+# common/ffile.cpp:182
+#: ../src/common/filename.cpp:2877
+#, c-format
+msgid "Failed to touch the file '%s'"
+msgstr "Datoteke »%s« se ni mogoče dotakniti."
+
+# generic/dirdlgg.cpp:550
+#: ../src/common/filename.cpp:2958
+#, c-format
+msgid "Failed to retrieve file times for '%s'"
+msgstr "Neuspešno pridobivanje datotečnih časov za '%s'"
+
+#: ../src/common/filepickercmn.cpp:39 ../src/common/filepickercmn.cpp:40
+msgid "Browse"
+msgstr "Prebrskaj"
+
+# generic/filedlgg.cpp:825
+#: ../src/common/fldlgcmn.cpp:792 ../src/generic/filectrlg.cpp:1185
+#, c-format
+msgid "All files (%s)|%s"
+msgstr "Vse datoteke (%s)|%s"
+
+# generic/filedlgg.cpp:825
+#. TRANSLATORS: %s are a file extension used to build a file wildcard string
+#: ../src/common/fldlgcmn.cpp:810
+#, c-format
+msgid "%s files (%s)|%s"
+msgstr "datoteke %s (%s)|%s"
+
+# generic/filedlgg.cpp:1270
+# msw/filedlg.cpp:483
+#: ../src/common/fldlgcmn.cpp:1072
+#, c-format
+msgid "Load %s file"
+msgstr "Naloži datoteko %s"
+
+# generic/filedlgg.cpp:1286
+# msw/filedlg.cpp:484
+#: ../src/common/fldlgcmn.cpp:1074
+#, c-format
+msgid "Save %s file"
+msgstr "Shrani datoteko %s"
+
+#: ../src/common/fmapbase.cpp:144
+msgid "Western European (ISO-8859-1)"
+msgstr "zahodnoevropsko (ISO-8859-1)"
+
+#: ../src/common/fmapbase.cpp:145
+msgid "Central European (ISO-8859-2)"
+msgstr "srednjeevropsko (ISO-8859-2)"
+
+#: ../src/common/fmapbase.cpp:146
+msgid "Esperanto (ISO-8859-3)"
+msgstr "esperantsko (ISO-8859-3)"
+
+#: ../src/common/fmapbase.cpp:147
+msgid "Baltic (old) (ISO-8859-4)"
+msgstr "baltsko (staro) (ISO-8859-4)"
+
+#: ../src/common/fmapbase.cpp:148
+msgid "Cyrillic (ISO-8859-5)"
+msgstr "cirilično (ISO-8859-5)"
+
+#: ../src/common/fmapbase.cpp:149
+msgid "Arabic (ISO-8859-6)"
+msgstr "arabsko (ISO-8859-6)"
+
+#: ../src/common/fmapbase.cpp:150
+msgid "Greek (ISO-8859-7)"
+msgstr "grško (ISO-8859-7)"
+
+#: ../src/common/fmapbase.cpp:151
+msgid "Hebrew (ISO-8859-8)"
+msgstr "hebrejsko (ISO-8859-8)"
+
+#: ../src/common/fmapbase.cpp:152
+msgid "Turkish (ISO-8859-9)"
+msgstr "turško (ISO-8859-9)"
+
+#: ../src/common/fmapbase.cpp:153
+msgid "Nordic (ISO-8859-10)"
+msgstr "nordijsko (ISO-8859-10)"
+
+#: ../src/common/fmapbase.cpp:154
+msgid "Thai (ISO-8859-11)"
+msgstr "tajsko (ISO-8859-11)"
+
+#: ../src/common/fmapbase.cpp:155
+msgid "Indian (ISO-8859-12)"
+msgstr "indijsko (ISO-8859-12)"
+
+#: ../src/common/fmapbase.cpp:156
+msgid "Baltic (ISO-8859-13)"
+msgstr "baltsko (ISO-8859-13)"
+
+#: ../src/common/fmapbase.cpp:157
+msgid "Celtic (ISO-8859-14)"
+msgstr "keltsko (ISO-8859-14)"
+
+#: ../src/common/fmapbase.cpp:158
+msgid "Western European with Euro (ISO-8859-15)"
+msgstr "zahodnoevropsko z Evrom (ISO-8859-15)"
+
+#: ../src/common/fmapbase.cpp:159
+msgid "KOI8-R"
+msgstr "KOI8-R"
+
+#: ../src/common/fmapbase.cpp:160
+msgid "KOI8-U"
+msgstr "KOI8-U"
+
+#: ../src/common/fmapbase.cpp:161
+msgid "Windows/DOS OEM Cyrillic (CP 866)"
+msgstr "Windows/DOS OEM - cirilično (CP 866)"
+
+#: ../src/common/fmapbase.cpp:162
+msgid "Windows Thai (CP 874)"
+msgstr "Windows - tajsko (CP 874)"
+
+#: ../src/common/fmapbase.cpp:163
+msgid "Windows Japanese (CP 932) or Shift-JIS"
+msgstr "Windows - japonsko (CP 932) ali Shift-JIS"
+
+#: ../src/common/fmapbase.cpp:164
+msgid "Windows Chinese Simplified (CP 936) or GB-2312"
+msgstr "Windows - kitajsko, poenostavljeno (CP 936) ali GB-2312"
+
+#: ../src/common/fmapbase.cpp:165
+msgid "Windows Korean (CP 949)"
+msgstr "Windows - korejsko (CP 949)"
+
+#: ../src/common/fmapbase.cpp:166
+msgid "Windows Chinese Traditional (CP 950) or Big-5"
+msgstr "Windows - kitajsko, tradicionalno (CP 950) ali Big-5"
+
+#: ../src/common/fmapbase.cpp:167
+msgid "Windows Central European (CP 1250)"
+msgstr "Windows - srednjeevropsko (CP 1250)"
+
+#: ../src/common/fmapbase.cpp:168
+msgid "Windows Cyrillic (CP 1251)"
+msgstr "Windows - cirilično (CP 1251)"
+
+#: ../src/common/fmapbase.cpp:169
+msgid "Windows Western European (CP 1252)"
+msgstr "Windows - zahodnoevropsko (CP 1252)"
+
+#: ../src/common/fmapbase.cpp:170
+msgid "Windows Greek (CP 1253)"
+msgstr "Windows - grško (CP 1253)"
+
+#: ../src/common/fmapbase.cpp:171
+msgid "Windows Turkish (CP 1254)"
+msgstr "Windows - turško (CP 1254)"
+
+#: ../src/common/fmapbase.cpp:172
+msgid "Windows Hebrew (CP 1255)"
+msgstr "Windows - hebrejsko (CP 1255)"
+
+#: ../src/common/fmapbase.cpp:173
+msgid "Windows Arabic (CP 1256)"
+msgstr "Windows - arabsko (CP 1256)"
+
+#: ../src/common/fmapbase.cpp:174
+msgid "Windows Baltic (CP 1257)"
+msgstr "Windows - baltsko (CP 1257)"
+
+#: ../src/common/fmapbase.cpp:175
+msgid "Windows Vietnamese (CP 1258)"
+msgstr "Windows - vietnamsko (CP 1258)"
+
+#: ../src/common/fmapbase.cpp:176
+msgid "Windows Johab (CP 1361)"
+msgstr "Windows - johabsko (CP 1361)"
+
+#: ../src/common/fmapbase.cpp:177
+msgid "Windows/DOS OEM (CP 437)"
+msgstr "Windows/DOS OEM (CP 437)"
+
+#: ../src/common/fmapbase.cpp:178
+msgid "Unicode 7 bit (UTF-7)"
+msgstr "Unicode, 7-bitno (UTF-7)"
+
+#: ../src/common/fmapbase.cpp:179
+msgid "Unicode 8 bit (UTF-8)"
+msgstr "Unicode, 8-bitno (UTF-8)"
+
+#: ../src/common/fmapbase.cpp:181 ../src/common/fmapbase.cpp:187
+msgid "Unicode 16 bit (UTF-16)"
+msgstr "Unicode, 16-bitno (UTF-16)"
+
+#: ../src/common/fmapbase.cpp:182
+msgid "Unicode 16 bit Little Endian (UTF-16LE)"
+msgstr "Unicode, 16-bitno Little Endian (UTF-16LE)"
+
+#: ../src/common/fmapbase.cpp:183 ../src/common/fmapbase.cpp:189
+msgid "Unicode 32 bit (UTF-32)"
+msgstr "Unicode, 32-bitno (UTF-32)"
+
+#: ../src/common/fmapbase.cpp:184
+msgid "Unicode 32 bit Little Endian (UTF-32LE)"
+msgstr "Unicode, 32-bitno Little Endian (UTF-32LE)"
+
+#: ../src/common/fmapbase.cpp:186
+msgid "Unicode 16 bit Big Endian (UTF-16BE)"
+msgstr "Unicode, 16-bitno Big Endian (UTF-16BE)"
+
+#: ../src/common/fmapbase.cpp:188
+msgid "Unicode 32 bit Big Endian (UTF-32BE)"
+msgstr "Unicode, 32-bitno Big Endian (UTF-32BE)"
+
+#: ../src/common/fmapbase.cpp:191
+msgid "Extended Unix Codepage for Japanese (EUC-JP)"
+msgstr "razširjena kodna stran Unix za Japonščino (EUC-JP)"
+
+#: ../src/common/fmapbase.cpp:192
+msgid "US-ASCII"
+msgstr "US-ASCII"
+
+#: ../src/common/fmapbase.cpp:193
+msgid "ISO-2022-JP"
+msgstr "ISO-2022-JP"
+
+# generic/fontdlgg.cpp:206
+#: ../src/common/fmapbase.cpp:195
+msgid "MacRoman"
+msgstr "Mac, latinični"
+
+#: ../src/common/fmapbase.cpp:196
+msgid "MacJapanese"
+msgstr "Mac, japonski"
+
+#: ../src/common/fmapbase.cpp:197
+msgid "MacChineseTrad"
+msgstr "Mac, kitajski tradicionalni"
+
+#: ../src/common/fmapbase.cpp:198
+msgid "MacKorean"
+msgstr "Mac, korejski"
+
+#: ../src/common/fmapbase.cpp:199
+msgid "MacArabic"
+msgstr "Mac, arabski"
+
+#: ../src/common/fmapbase.cpp:200
+msgid "MacHebrew"
+msgstr "Mac, hebrejski"
+
+#: ../src/common/fmapbase.cpp:201
+msgid "MacGreek"
+msgstr "Mac, grški"
+
+#: ../src/common/fmapbase.cpp:202
+msgid "MacCyrillic"
+msgstr "Mac, cirilica"
+
+#: ../src/common/fmapbase.cpp:203
+msgid "MacDevanagari"
+msgstr "Mac, devanagarski"
+
+#: ../src/common/fmapbase.cpp:204
+msgid "MacGurmukhi"
+msgstr "Mac, gurmuški"
+
+#: ../src/common/fmapbase.cpp:205
+msgid "MacGujarati"
+msgstr "Mac, gudžaratski"
+
+#: ../src/common/fmapbase.cpp:206
+msgid "MacOriya"
+msgstr "Mac, orijski"
+
+#: ../src/common/fmapbase.cpp:207
+msgid "MacBengali"
+msgstr "Mac, bengalski"
+
+#: ../src/common/fmapbase.cpp:208
+msgid "MacTamil"
+msgstr "Mac, tamilski"
+
+#: ../src/common/fmapbase.cpp:209
+msgid "MacTelugu"
+msgstr "Mac, teluški"
+
+#: ../src/common/fmapbase.cpp:210
+msgid "MacKannada"
+msgstr "Mac, kanareški"
+
+#: ../src/common/fmapbase.cpp:211
+msgid "MacMalayalam"
+msgstr "Mac, malajalamski"
+
+#: ../src/common/fmapbase.cpp:212
+msgid "MacSinhalese"
+msgstr "Mac, sinhalski"
+
+#: ../src/common/fmapbase.cpp:213
+msgid "MacBurmese"
+msgstr "Mac, burmanski"
+
+#: ../src/common/fmapbase.cpp:214
+msgid "MacKhmer"
+msgstr "Mac, kmerski"
+
+#: ../src/common/fmapbase.cpp:215
+msgid "MacThai"
+msgstr "Mac, tajski"
+
+#: ../src/common/fmapbase.cpp:216
+msgid "MacLaotian"
+msgstr "Mac, laoški"
+
+#: ../src/common/fmapbase.cpp:217
+msgid "MacGeorgian"
+msgstr "Mac, gruzijski"
+
+#: ../src/common/fmapbase.cpp:218
+msgid "MacArmenian"
+msgstr "Mac, armenski"
+
+#: ../src/common/fmapbase.cpp:219
+msgid "MacChineseSimp"
+msgstr "Mac, kitajski poenostavljeni"
+
+#: ../src/common/fmapbase.cpp:220
+msgid "MacTibetan"
+msgstr "Mac, tibetanski"
+
+#: ../src/common/fmapbase.cpp:221
+msgid "MacMongolian"
+msgstr "Mac, mongolski"
+
+#: ../src/common/fmapbase.cpp:222
+msgid "MacEthiopic"
+msgstr "Mac, etiopski"
+
+#: ../src/common/fmapbase.cpp:223
+msgid "MacCentralEurRoman"
+msgstr "Mac, srednjeevropski, latinični"
+
+#: ../src/common/fmapbase.cpp:224
+msgid "MacVietnamese"
+msgstr "Mac, vietnamski"
+
+#: ../src/common/fmapbase.cpp:225
+msgid "MacExtArabic"
+msgstr "Mac, arabski, razširjeni"
+
+#: ../src/common/fmapbase.cpp:226
+msgid "MacSymbol"
+msgstr "Mac, simbolni"
+
+#: ../src/common/fmapbase.cpp:227
+msgid "MacDingbats"
+msgstr "Mac, znakovni"
+
+#: ../src/common/fmapbase.cpp:228
+msgid "MacTurkish"
+msgstr "Mac, turški"
+
+#: ../src/common/fmapbase.cpp:229
+msgid "MacCroatian"
+msgstr "Mac, hrvaški"
+
+#: ../src/common/fmapbase.cpp:230
+msgid "MacIcelandic"
+msgstr "Mac, islandski"
+
+# generic/fontdlgg.cpp:206
+#: ../src/common/fmapbase.cpp:231
+msgid "MacRomanian"
+msgstr "Mac, romunski"
+
+#: ../src/common/fmapbase.cpp:232
+msgid "MacCeltic"
+msgstr "Mac, keltski"
+
+#: ../src/common/fmapbase.cpp:233
+msgid "MacGaelic"
+msgstr "Mac, galski"
+
+#: ../src/common/fmapbase.cpp:234
+msgid "MacKeyboardGlyphs"
+msgstr "Mac, pismenke tipkovnice"
+
+#: ../src/common/fmapbase.cpp:791
+msgid "Default encoding"
+msgstr "Privzeto kodiranje"
+
+# common/fontmap.cpp:332
+#: ../src/common/fmapbase.cpp:805
+#, c-format
+msgid "Unknown encoding (%d)"
+msgstr "nepoznano kodiranje (%d)"
+
+#: ../src/common/fmapbase.cpp:815 ../src/richtext/richtextstyles.cpp:776
+msgid "default"
+msgstr "privzeto"
+
+# common/fontmap.cpp:354
+#: ../src/common/fmapbase.cpp:829
+#, c-format
+msgid "unknown-%d"
+msgstr "nepoznan-%d"
+
+# generic/fontdlgg.cpp:242
+#: ../src/common/fontcmn.cpp:924 ../src/common/fontcmn.cpp:1130
+msgid "underlined"
+msgstr "podčrtano"
+
+#: ../src/common/fontcmn.cpp:929
+msgid " strikethrough"
+msgstr " prečrtano"
+
+#: ../src/common/fontcmn.cpp:942
+msgid " thin"
+msgstr "tanko"
+
+# generic/fontdlgg.cpp:216
+#: ../src/common/fontcmn.cpp:946
+msgid " extra light"
+msgstr " rahlo"
+
+# generic/fontdlgg.cpp:216
+#: ../src/common/fontcmn.cpp:950
+msgid " light"
+msgstr " rahlo"
+
+#: ../src/common/fontcmn.cpp:954
+msgid " medium"
+msgstr "srednje"
+
+# generic/fontdlgg.cpp:217
+#: ../src/common/fontcmn.cpp:958
+msgid " semi bold"
+msgstr " polkrepko"
+
+# generic/fontdlgg.cpp:217
+#: ../src/common/fontcmn.cpp:962
+msgid " bold"
+msgstr " krepko"
+
+# generic/fontdlgg.cpp:217
+#: ../src/common/fontcmn.cpp:966
+msgid " extra bold"
+msgstr "zelo krepko"
+
+#: ../src/common/fontcmn.cpp:970
+msgid " heavy"
+msgstr "debelo"
+
+#: ../src/common/fontcmn.cpp:974
+msgid " extra heavy"
+msgstr "zelo debelo"
+
+# generic/fontdlgg.cpp:213
+#: ../src/common/fontcmn.cpp:990
+msgid " italic"
+msgstr " ležeče"
+
+#: ../src/common/fontcmn.cpp:1134
+msgid "strikethrough"
+msgstr "prečrtano"
+
+#: ../src/common/fontcmn.cpp:1143
+msgid "thin"
+msgstr "tanko"
+
+# generic/fontdlgg.cpp:216
+#: ../src/common/fontcmn.cpp:1156
+msgid "extralight"
+msgstr "rahlo"
+
+# generic/fontdlgg.cpp:216
+#: ../src/common/fontcmn.cpp:1161
+msgid "light"
+msgstr "svetlo"
+
+# generic/fontdlgg.cpp:212
+# generic/fontdlgg.cpp:215
+#: ../src/common/fontcmn.cpp:1169 ../src/richtext/richtextstyles.cpp:775
+msgid "normal"
+msgstr "navadno"
+
+#: ../src/common/fontcmn.cpp:1174
+msgid "medium"
+msgstr "srednje"
+
+# generic/fontdlgg.cpp:217
+#: ../src/common/fontcmn.cpp:1179 ../src/common/fontcmn.cpp:1199
+msgid "semibold"
+msgstr "polkrepko"
+
+# generic/fontdlgg.cpp:217
+#: ../src/common/fontcmn.cpp:1184
+msgid "bold"
+msgstr "krepko"
+
+# generic/fontdlgg.cpp:217
+#: ../src/common/fontcmn.cpp:1194
+msgid "extrabold"
+msgstr "zelo krepko"
+
+#: ../src/common/fontcmn.cpp:1204
+msgid "heavy"
+msgstr "debelo"
+
+#: ../src/common/fontcmn.cpp:1212
+msgid "extraheavy"
+msgstr "zelo debelo"
+
+# generic/fontdlgg.cpp:213
+#: ../src/common/fontcmn.cpp:1217
+msgid "italic"
+msgstr "ležeče"
+
+# common/fontmap.cpp:507
+#: ../src/common/fontmap.cpp:195
+msgid ": unknown charset"
+msgstr ": neznan nabor znakov"
+
+# common/fontmap.cpp:511
+#: ../src/common/fontmap.cpp:199
+#, c-format
+msgid ""
+"The charset '%s' is unknown. You may select\n"
+"another charset to replace it with or choose\n"
+"[Cancel] if it cannot be replaced"
+msgstr ""
+"Nabor znakov '%s' je neznan. Lahko izberete\n"
+"drug nabor za zamenjavo ali izberete\n"
+"[Prekličil] če ne more biti zamenjan"
+
+# common/fontmap.cpp:552
+#: ../src/common/fontmap.cpp:241
+#, c-format
+msgid "Failed to remember the encoding for the charset '%s'."
+msgstr "Kodiranja za nabor znakov '%s' ni bilo mogoče zapomniti."
+
+# common/fontmap.cpp:646
+#: ../src/common/fontmap.cpp:321
+msgid "can't load any font, aborting"
+msgstr "ni mogoče naložiti katere koli posave, prekinjam"
+
+# common/fontmap.cpp:712
+#: ../src/common/fontmap.cpp:409
+msgid ": unknown encoding"
+msgstr ": neznano kodiranje"
+
+# common/fontmap.cpp:716
+#: ../src/common/fontmap.cpp:417
+#, c-format
+msgid ""
+"No font for displaying text in encoding '%s' found,\n"
+"but an alternative encoding '%s' is available.\n"
+"Do you want to use this encoding (otherwise you will have to choose another "
+"one)?"
+msgstr ""
+"Nobena pisava za prikaz besedila, kodiranega v '%s', ne obstaja,\n"
+"na voljo pa je drugaćno kodiranje '%s'.\n"
+"Želite izbrati to kodiranje (sicer boste morali izbrati drugega)?"
+
+# common/fontmap.cpp:716
+#: ../src/common/fontmap.cpp:422
+#, c-format
+msgid ""
+"No font for displaying text in encoding '%s' found.\n"
+"Would you like to select a font to be used for this encoding\n"
+"(otherwise the text in this encoding will not be shown correctly)?"
+msgstr ""
+"Nobena pisava za prikaz besedila, kodiranega v '%s' ne obstaja.\n"
+"Želite izbrati drugo pisavo za prikaz tega kodiranja\n"
+"(secer besedilo ne bo prikazano pravilno)?"
+
+# common/fs_mem.cpp:144
+#: ../src/common/fs_mem.cpp:169
+#, c-format
+msgid "Memory VFS already contains file '%s'!"
+msgstr "Spominski VFS že vsebuje datoteko »%s«!"
+
+# common/fs_mem.cpp:202
+#: ../src/common/fs_mem.cpp:232
+#, c-format
+msgid "Trying to remove file '%s' from memory VFS, but it is not loaded!"
+msgstr ""
+"Poskus odstanitve datoteke '%s' iz spominskega VFS, vendar ni naložena!"
+
+# common/fs_mem.cpp:167
+#: ../src/common/fs_mem.cpp:262
+#, c-format
+msgid "Failed to store image '%s' to memory VFS!"
+msgstr "Slike '%s' ni mogoče shraniti v spominski VFS!"
+
+#: ../src/common/ftp.cpp:197
+msgid "Timeout while waiting for FTP server to connect, try passive mode."
+msgstr ""
+"Časovna prekoračitev pri čakanju na strežnik FTP za povezavo, poskusite "
+"pasiven način."
+
+# generic/dirdlgg.cpp:550
+#: ../src/common/ftp.cpp:399
+#, c-format
+msgid "Failed to set FTP transfer mode to %s."
+msgstr "Prenosnega načina FTP ni mogoče nastaviti na %s."
+
+#: ../src/common/ftp.cpp:400 ../src/richtext/richtextsymboldlg.cpp:432
+msgid "ASCII"
+msgstr "ASCII"
+
+#: ../src/common/ftp.cpp:400
+msgid "binary"
+msgstr "binarno"
+
+#: ../src/common/ftp.cpp:608
+msgid "The FTP server doesn't support the PORT command."
+msgstr "Strežnik FTP ne podpira ukaza PORT."
+
+#: ../src/common/ftp.cpp:622
+msgid "The FTP server doesn't support passive mode."
+msgstr "Strežnik FTP ne podpira pasivnega načina."
+
+#: ../src/common/gifdecod.cpp:822
+#, c-format
+msgid "Incorrect GIF frame size (%u, %d) for the frame #%u"
+msgstr "Nepravilna velikost okvira GIF (%u, %d) za okvir #%u"
+
+# common/imagbmp.cpp:266
+# common/imagbmp.cpp:278
+#: ../src/common/glcmn.cpp:108
+msgid "Failed to allocate colour for OpenGL"
+msgstr "Barve za OpenGL ni mogoče dodeliti."
+
+#: ../src/common/headerctrlcmn.cpp:57
+msgid "Please select the columns to show and define their order:"
+msgstr "Izberite stolpce za prikaz in določite njihovo razvrstitev:"
+
+# html/helpfrm.cpp:899
+#: ../src/common/headerctrlcmn.cpp:58
+msgid "Customize Columns"
+msgstr "Prilagodi stolpce"
+
+# html/helpfrm.cpp:899
+#: ../src/common/headerctrlcmn.cpp:304
+msgid "&Customize..."
+msgstr "Prila&godi ..."
+
+# generic/dirdlgg.cpp:550
+#: ../src/common/hyperlnkcmn.cpp:132
+#, c-format
+msgid "Failed to open URL \"%s\" in the default browser"
+msgstr "Odpiranje URL-ja »%s« v privzetem brskalniku ni uspelo"
+
+# common/ffile.cpp:182
+#: ../src/common/iconbndl.cpp:195
+#, c-format
+msgid "Failed to load image %%d from file '%s'."
+msgstr "Slike %%d iz datoteke '%s' ni mogoče naložiti."
+
+# common/ffile.cpp:182
+#: ../src/common/iconbndl.cpp:203
+#, c-format
+msgid "Failed to load image %d from stream."
+msgstr "Slike %d ni mogoče naložiti iz toka."
+
+# common/ffile.cpp:182
+#: ../src/common/iconbndl.cpp:221
+#, c-format
+msgid "Failed to load icons from resource '%s'."
+msgstr "Ikon iz vira »%s« ni mogoče naložiti."
+
+# common/imagbmp.cpp:62
+#: ../src/common/imagbmp.cpp:97
+msgid "BMP: Couldn't save invalid image."
+msgstr "BMP: nepravilne slike ni mogoče shraniti."
+
+#: ../src/common/imagbmp.cpp:137
+msgid "BMP: wxImage doesn't have own wxPalette."
+msgstr "BMP: wxImage nima lastne wxPalette."
+
+# common/imagbmp.cpp:131
+#: ../src/common/imagbmp.cpp:243
+msgid "BMP: Couldn't write the file (Bitmap) header."
+msgstr "BMP: datotečne glave (Bitmap) ni mogoče zapisati."
+
+# common/imagbmp.cpp:131
+#: ../src/common/imagbmp.cpp:266
+msgid "BMP: Couldn't write the file (BitmapInfo) header."
+msgstr "BMP: datotečne glave (BitmapInfo) ni mogoče zapisati."
+
+# common/imagbmp.cpp:154
+#: ../src/common/imagbmp.cpp:353
+msgid "BMP: Couldn't write RGB color map."
+msgstr "BMP: barvnega zemljevida RGB ni mogoče shraniti."
+
+# common/imagbmp.cpp:154
+#: ../src/common/imagbmp.cpp:487
+msgid "BMP: Couldn't write data."
+msgstr "BMP: podatkov ni mogoče zapisati"
+
+# common/imagbmp.cpp:266
+# common/imagbmp.cpp:278
+#: ../src/common/imagbmp.cpp:561 ../src/common/imagbmp.cpp:642
+msgid "BMP: Couldn't allocate memory."
+msgstr "BMP: pomnilnika ni mogoče alocirati."
+
+# common/imagbmp.cpp:214
+#: ../src/common/imagbmp.cpp:1041
+msgid "DIB Header: Image width > 32767 pixels for file."
+msgstr "Glava DIB: širina slike > 32767 pikslov za datoteko."
+
+# common/imagbmp.cpp:220
+#: ../src/common/imagbmp.cpp:1049
+msgid "DIB Header: Image height > 32767 pixels for file."
+msgstr "Glava DIB: višina slike > 32767 pikslov za datoteko."
+
+# common/imagbmp.cpp:234
+#: ../src/common/imagbmp.cpp:1081
+msgid "DIB Header: Unknown bitdepth in file."
+msgstr "Glava DIB: neznana bitna globina v datoteki."
+
+# common/imagbmp.cpp:243
+#: ../src/common/imagbmp.cpp:1156
+msgid "DIB Header: Unknown encoding in file."
+msgstr "Glava DIB: neznano kodiranje v datoteki."
+
+# common/imagbmp.cpp:257
+#: ../src/common/imagbmp.cpp:1165
+msgid "DIB Header: Encoding doesn't match bitdepth."
+msgstr "Glava DIB: kodiranje se ne ujema z bitno globino."
+
+#: ../src/common/imagbmp.cpp:1180
+#, c-format
+msgid "BMP Header: Invalid number of colors (%d)."
+msgstr "Glava BMP: Neveljavno število barv (%d)."
+
+#: ../src/common/imagbmp.cpp:1273
+msgid "Error in reading image DIB."
+msgstr "Error in reading image DIB."
+
+#: ../src/common/imagbmp.cpp:1294
+msgid "ICO: Error in reading mask DIB."
+msgstr "ICO: napaka pri branju maske DIB."
+
+#: ../src/common/imagbmp.cpp:1353
+msgid "ICO: Image too tall for an icon."
+msgstr "ICO: slika je previsoka za ikono."
+
+#: ../src/common/imagbmp.cpp:1361
+msgid "ICO: Image too wide for an icon."
+msgstr "ICO: slika je preširoka za ikono."
+
+#: ../src/common/imagbmp.cpp:1388 ../src/common/imagbmp.cpp:1488
+#: ../src/common/imagbmp.cpp:1503 ../src/common/imagbmp.cpp:1514
+#: ../src/common/imagbmp.cpp:1528 ../src/common/imagbmp.cpp:1576
+#: ../src/common/imagbmp.cpp:1591 ../src/common/imagbmp.cpp:1605
+#: ../src/common/imagbmp.cpp:1616
+msgid "ICO: Error writing the image file!"
+msgstr "ICO: napaka pri pisanju v datoteko slike!"
+
+#: ../src/common/imagbmp.cpp:1701
+msgid "ICO: Invalid icon index."
+msgstr "ICO: neveljaven indeks ikone."
+
+#: ../src/common/image.cpp:2410
+msgid "Image and mask have different sizes."
+msgstr "Slika in maska imata različno velikost."
+
+#: ../src/common/image.cpp:2418 ../src/common/image.cpp:2459
+msgid "No unused colour in image being masked."
+msgstr "Nobena neuporabljena barva v sliki ni maskirana."
+
+# common/ffile.cpp:182
+#: ../src/common/image.cpp:2641
+#, c-format
+msgid "Failed to load bitmap \"%s\" from resources."
+msgstr "Bitne slike \"%s\" iz virov ni mogoče naložiti."
+
+# common/ffile.cpp:182
+#: ../src/common/image.cpp:2650
+#, c-format
+msgid "Failed to load icon \"%s\" from resources."
+msgstr "Ikone \"%s\" iz virov ni mogoče naložiti."
+
+# common/ffile.cpp:182
+#: ../src/common/image.cpp:2728 ../src/common/image.cpp:2747
+#, c-format
+msgid "Failed to load image from file \"%s\"."
+msgstr "Slike iz datoteke \"%s\" ni mogoče naložiti."
+
+# common/image.cpp:653
+# common/image.cpp:673
+#: ../src/common/image.cpp:2761
+#, c-format
+msgid "Can't save image to file '%s': unknown extension."
+msgstr "Slike ni mogoče shraniti v datoteko »%s«: neznana končnica."
+
+# common/image.cpp:758
+#: ../src/common/image.cpp:2869
+msgid "No handler found for image type."
+msgstr "Upravljalca za vrsto slike ni mogoče najti."
+
+# common/image.cpp:766
+# common/image.cpp:800
+#: ../src/common/image.cpp:2877 ../src/common/image.cpp:3000
+#: ../src/common/image.cpp:3066
+#, c-format
+msgid "No image handler for type %d defined."
+msgstr "Za vrsto %d ni določen noben upravljalec slik."
+
+#: ../src/common/image.cpp:2887
+#, c-format
+msgid "Image file is not of type %d."
+msgstr "Datoteka slike ni vrste %d."
+
+#: ../src/common/image.cpp:2970
+msgid "Can't automatically determine the image format for non-seekable input."
+msgstr "Ni mogoče samodejno določiti obliko slike za vnos brez iskanja."
+
+#: ../src/common/image.cpp:2988
+msgid "Unknown image data format."
+msgstr "Neznana vrsta slikovnih podatkov."
+
+# common/imagpcx.cpp:434
+#: ../src/common/image.cpp:3009
+#, c-format
+msgid "This is not a %s."
+msgstr "To ni %s."
+
+# common/image.cpp:784
+# common/image.cpp:816
+#: ../src/common/image.cpp:3032 ../src/common/image.cpp:3080
+#, c-format
+msgid "No image handler for type %s defined."
+msgstr "Za vrsto %s ni določen noben upravljalec slik."
+
+#: ../src/common/image.cpp:3041
+#, c-format
+msgid "Image is not of type %s."
+msgstr "Slika ni vrste %s."
+
+# common/ffile.cpp:182
+#: ../src/common/image.cpp:3509
+#, c-format
+msgid "Failed to check format of image file \"%s\"."
+msgstr "Neuspešno preverjanje zapisa slikovne datoteke \"%s\"."
+
+# common/imaggif.cpp:58
+#: ../src/common/imaggif.cpp:124
+msgid "GIF: error in GIF image format."
+msgstr "GIF: napaka v zapisu slike GIF."
+
+# common/imaggif.cpp:61
+#: ../src/common/imaggif.cpp:129
+msgid "GIF: not enough memory."
+msgstr "GIF: premalo spomina."
+
+# common/imaggif.cpp:74
+#: ../src/common/imaggif.cpp:134
+msgid "GIF: data stream seems to be truncated."
+msgstr "GIF: podatkovni tok se zdi skrajšan."
+
+# html/helpfrm.cpp:1174
+#: ../src/common/imaggif.cpp:240
+msgid "Couldn't initialize GIF hash table."
+msgstr "Ni mogoče inicializirati zgoščene tabele GIF."
+
+#: ../src/common/imagiff.cpp:739
+msgid "IFF: error in IFF image format."
+msgstr "IFF: napaka v zapisu slike IFF."
+
+#: ../src/common/imagiff.cpp:742
+msgid "IFF: not enough memory."
+msgstr "IFF: premalo spomina."
+
+# generic/progdlgg.cpp:241
+#: ../src/common/imagiff.cpp:745
+msgid "IFF: unknown error!!!"
+msgstr "IFF: neznana napaka!!!"
+
+#: ../src/common/imagiff.cpp:755
+msgid "IFF: data stream seems to be truncated."
+msgstr "IFF: podatkovni tok se zdi okrajšan."
+
+# common/imagjpeg.cpp:202
+#: ../src/common/imagjpeg.cpp:258
+msgid "JPEG: Couldn't load - file is probably corrupted."
+msgstr "JPEG: nalaganje ni možno - datoteka je najverjetneje pokvarjena."
+
+# common/imagjpeg.cpp:315
+#: ../src/common/imagjpeg.cpp:437
+msgid "JPEG: Couldn't save image."
+msgstr "JPEG: slike ni bilo mogoče shraniti."
+
+# common/imagpcx.cpp:434
+#: ../src/common/imagpcx.cpp:439
+msgid "PCX: this is not a PCX file."
+msgstr "PCX: to ni datoteka PCX."
+
+# common/imagpcx.cpp:447
+#: ../src/common/imagpcx.cpp:453
+msgid "PCX: image format unsupported"
+msgstr "PCX: oblika zapisa slike ni podprt."
+
+# common/imagpcx.cpp:448
+# common/imagpcx.cpp:471
+#: ../src/common/imagpcx.cpp:454 ../src/common/imagpcx.cpp:477
+msgid "PCX: couldn't allocate memory"
+msgstr "PCX: pomnilnika ni mogoče alocirati."
+
+# common/imagpcx.cpp:449
+#: ../src/common/imagpcx.cpp:455
+msgid "PCX: version number too low"
+msgstr "PCX: številka različice prenizka"
+
+# common/imagpcx.cpp:450
+# common/imagpcx.cpp:472
+#: ../src/common/imagpcx.cpp:456 ../src/common/imagpcx.cpp:478
+msgid "PCX: unknown error !!!"
+msgstr "PCX: neznana napaka!"
+
+# common/imagpcx.cpp:470
+#: ../src/common/imagpcx.cpp:476
+msgid "PCX: invalid image"
+msgstr "PCX: neveljavna slika"
+
+#: ../src/common/imagpng.cpp:385
+#, c-format
+msgid "Unknown PNG resolution unit %d"
+msgstr "Neznana enota ločljivosti PNG %d"
+
+# common/imagpng.cpp:251
+#: ../src/common/imagpng.cpp:439
+msgid "Couldn't load a PNG image - file is corrupted or not enough memory."
+msgstr ""
+"Slike PNG ni mogoče naložiti - datoteka je pokvarjena ali pa primanjkuje "
+"spomina."
+
+# common/imagbmp.cpp:62
+#: ../src/common/imagpng.cpp:513 ../src/common/imagpng.cpp:524
+#: ../src/common/imagpng.cpp:534
+msgid "Couldn't save PNG image."
+msgstr "Slike PNG ni mogoče shraniti."
+
+# common/imagpnm.cpp:80
+#: ../src/common/imagpnm.cpp:71
+msgid "PNM: File format is not recognized."
+msgstr "PNM: datotečni zapis ni prepoznan."
+
+# common/imagpnm.cpp:96
+#: ../src/common/imagpnm.cpp:89
+msgid "PNM: Couldn't allocate memory."
+msgstr "PNM: alokacija pomnilnika ni uspela."
+
+# common/imagpnm.cpp:112
+#: ../src/common/imagpnm.cpp:111 ../src/common/imagpnm.cpp:134
+#: ../src/common/imagpnm.cpp:156
+msgid "PNM: File seems truncated."
+msgstr "PNM: datoteka se zdi okrnjena."
+
+#: ../src/common/imagtiff.cpp:69
+#, c-format
+msgid " (in module \"%s\")"
+msgstr " (v modulu \"%s\")"
+
+# common/imagtiff.cpp:163
+#: ../src/common/imagtiff.cpp:304
+msgid "TIFF: Error loading image."
+msgstr "TIFF: napaka pri nalaganju slike."
+
+# common/imagtiff.cpp:171
+#: ../src/common/imagtiff.cpp:314
+msgid "Invalid TIFF image index."
+msgstr "Neveljaven indeks slike TIFF."
+
+#: ../src/common/imagtiff.cpp:358
+msgid "TIFF: Image size is abnormally big."
+msgstr "TIFF: slika je nenaravno velika."
+
+# common/imagtiff.cpp:192
+# common/imagtiff.cpp:203
+# common/imagtiff.cpp:314
+#: ../src/common/imagtiff.cpp:372 ../src/common/imagtiff.cpp:385
+#: ../src/common/imagtiff.cpp:769
+msgid "TIFF: Couldn't allocate memory."
+msgstr "TIFF: spomina ni mogoče alocirati."
+
+# common/imagtiff.cpp:214
+#: ../src/common/imagtiff.cpp:471
+msgid "TIFF: Error reading image."
+msgstr "TIFF: napaka pri branju slike."
+
+#: ../src/common/imagtiff.cpp:532
+#, c-format
+msgid "Unknown TIFF resolution unit %d ignored"
+msgstr "Neznana enota ločljivosti TIFF %d bo prezrta"
+
+# common/imagtiff.cpp:291
+#: ../src/common/imagtiff.cpp:611
+msgid "TIFF: Error saving image."
+msgstr "TIFF: napaka pri shranjevanju slike."
+
+# common/imagtiff.cpp:338
+#: ../src/common/imagtiff.cpp:868
+msgid "TIFF: Error writing image."
+msgstr "TIFF: napaka pri zapisovanju slike."
+
+# common/imagtiff.cpp:291
+#: ../src/common/imagtiff.cpp:881
+msgid "TIFF: Error flushing data."
+msgstr "TIFF: Napaka pri izpraznjenju podatkov."
+
+#: ../src/common/imagwebp.cpp:56
+msgid "WebP: Invalid data (failed to get features)."
+msgstr "WebP: Neveljavni podatki (funkcij ni bilo mogoče pridobiti)."
+
+#: ../src/common/imagwebp.cpp:65
+msgid "WebP: Allocating image memory failed."
+msgstr "WebP: Dodeljevanje slikovnega pomnilnika ni uspelo."
+
+#: ../src/common/imagwebp.cpp:82
+msgid "WebP: Decoding RGBA image data failed."
+msgstr "WebP: Dekodiranje slikovnih podatkov RGBA ni uspelo."
+
+#: ../src/common/imagwebp.cpp:98
+msgid "WebP: Decoding RGB image data failed."
+msgstr "WebP: Dekodiranje slikovnih podatkov RGB ni uspelo."
+
+#: ../src/common/imagwebp.cpp:113 ../src/common/imagwebp.cpp:201
+msgid "WebP: Allocating stream buffer failed."
+msgstr "WebP: Dodeljevanje medpomnilnika toka ni uspelo."
+
+# msw/clipbrd.cpp:300
+#: ../src/common/imagwebp.cpp:131
+msgid "WebP: Failed to parse container data."
+msgstr "WebP: Razčlenjevanje podatkov vsebnika ni uspelo."
+
+# generic/dirdlgg.cpp:552
+#: ../src/common/imagwebp.cpp:222
+msgid "WebP: Error decoding animation."
+msgstr "WebP: Napaka pri dekodiranju animacije."
+
+#: ../src/common/imagwebp.cpp:240
+msgid "WebP: Error getting next animation frame."
+msgstr "WebP: Napaka pri pridobivanju naslednje sličice animacije."
+
+#: ../src/common/init.cpp:172
+#, c-format
+msgid ""
+"Command line argument %d couldn't be converted to Unicode and will be "
+"ignored."
+msgstr ""
+"Argumenta ukazne vrstice %d ni mogoče pretvoriti v Unicode, zato bo prezrt."
+
+#: ../src/common/init.cpp:344
+msgid "Initialization failed in post init, aborting."
+msgstr "Inicializacija ni uspela v po-inicializaciji, sledi prekinitev."
+
+#: ../src/common/intl.cpp:378
+#, c-format
+msgid "Cannot set locale to language \"%s\"."
+msgstr "Jezika programa ni mogoče nastaviti na \"%s\"."
+
+# common/log.cpp:362
+#: ../src/common/log.cpp:232
+msgid "Error: "
+msgstr "Napaka:"
+
+# common/log.cpp:366
+#: ../src/common/log.cpp:236
+msgid "Warning: "
+msgstr "Opozorilo: "
+
+#: ../src/common/log.cpp:284
+msgid "The previous message repeated once."
+msgstr "Prejšnje sporočilo ponovljeno enkrat."
+
+#: ../src/common/log.cpp:291
+#, c-format
+msgid "The previous message repeated %u time."
+msgid_plural "The previous message repeated %u times."
+msgstr[0] "Prejšnje sporočilo ponovljeno %u-krat."
+msgstr[1] "Prejšnje sporočilo ponovljeno %u-krat."
+msgstr[2] "Prejšnje sporočilo ponovljeno %u-krat."
+msgstr[3] "Prejšnje sporočilo ponovljeno %u-krat."
+
+#: ../src/common/log.cpp:319
+#, c-format
+msgid "Last repeated message (\"%s\", %u time) wasn't output"
+msgid_plural "Last repeated message (\"%s\", %u times) wasn't output"
+msgstr[0] "Zadnje ponovljeno sporočilo (»%s«, %u-krat) ni bilo izpisano"
+msgstr[1] "Zadnje ponovljeno sporočilo (»%s«, %u-krat) ni bilo izpisano"
+msgstr[2] "Zadnje ponovljeno sporočilo (»%s«, %u-krat) ni bilo izpisano"
+msgstr[3] "Zadnje ponovljeno sporočilo (»%s«, %u-krat) ni bilo izpisano"
+
+# common/log.cpp:242
+#: ../src/common/log.cpp:435
+#, c-format
+msgid " (error %ld: %s)"
+msgstr " (napaka %ld: %s)"
+
+# common/imagbmp.cpp:266
+# common/imagbmp.cpp:278
+#: ../src/common/lzmastream.cpp:121
+msgid "Failed to allocate memory for LZMA decompression."
+msgstr "Dodelitev pomnilnika za razširjanje LZMA ni uspela."
+
+#: ../src/common/lzmastream.cpp:125
+#, c-format
+msgid "Failed to initialize LZMA decompression: unexpected error %u."
+msgstr "Inicializacija razširjanja LZMA ni uspela: nepričakovana napaka %u."
+
+#: ../src/common/lzmastream.cpp:179
+msgid "input is not in XZ format"
+msgstr "vnos ni v obliki XZ"
+
+#: ../src/common/lzmastream.cpp:183
+msgid "input compressed using unknown XZ option"
+msgstr "vhod stisnjen z neznano možnostjo XZ"
+
+#: ../src/common/lzmastream.cpp:188
+msgid "input is corrupted"
+msgstr "vhod je poškodovan"
+
+#: ../src/common/lzmastream.cpp:192
+msgid "unknown decompression error"
+msgstr "neznana napaka razširjanja"
+
+#: ../src/common/lzmastream.cpp:196
+#, c-format
+msgid "LZMA decompression error: %s"
+msgstr "Napaka pri razširjanju LZMA: %s"
+
+# common/imagbmp.cpp:266
+# common/imagbmp.cpp:278
+#: ../src/common/lzmastream.cpp:231
+msgid "Failed to allocate memory for LZMA compression."
+msgstr "Dodelitev pomnilnika za razširjanje LZMA ni uspela."
+
+#: ../src/common/lzmastream.cpp:235
+#, c-format
+msgid "Failed to initialize LZMA compression: unexpected error %u."
+msgstr "Inicializacija stiskanja LZMA ni uspela: nepričakovana napaka %u."
+
+#: ../src/common/lzmastream.cpp:267 ../src/common/lzmastream.cpp:342
+#: ../src/html/chm.cpp:336
+msgid "out of memory"
+msgstr "premalo spomina"
+
+#: ../src/common/lzmastream.cpp:276 ../src/common/lzmastream.cpp:346
+msgid "unknown compression error"
+msgstr "neznana napaka pri stiskanju"
+
+#: ../src/common/lzmastream.cpp:280
+#, c-format
+msgid "LZMA compression error: %s"
+msgstr "Napaka pri stiskanju LZMA: %s"
+
+#: ../src/common/lzmastream.cpp:350
+#, c-format
+msgid "LZMA compression error when flushing output: %s"
+msgstr "Napaka stiskanja LZMA pri odpravi izhoda: %s"
+
+# common/mimecmn.cpp:161
+#: ../src/common/mimecmn.cpp:167
+#, c-format
+msgid "Unmatched '{' in an entry for mime type %s."
+msgstr "Neujemajoči '{' v vnosu za vsto mime %s."
+
+#: ../src/common/module.cpp:76
+#, c-format
+msgid "Circular dependency involving module \"%s\" detected."
+msgstr "Odkrita je bila krožna odvisnost, ki vključuje modul \"%s\"."
+
+#: ../src/common/module.cpp:128
+#, c-format
+msgid "Dependency \"%s\" of module \"%s\" doesn't exist."
+msgstr "Odvisnost \"%s\" od modula \"%s\" ne obstaja."
+
+#: ../src/common/module.cpp:137
+#, c-format
+msgid "Module \"%s\" initialization failed"
+msgstr "Inicializacija modula \"%s\" ni uspela"
+
+#: ../src/common/msgout.cpp:96
+msgid "Message"
+msgstr "Sporočilo"
+
+#: ../src/common/paper.cpp:70
+msgid "Letter, 8 1/2 x 11 in"
+msgstr "Letter, 8 1/2 x 11 pal."
+
+#: ../src/common/paper.cpp:71
+msgid "Legal, 8 1/2 x 14 in"
+msgstr "Legal, 8 1/2 x 14 pal."
+
+# generic/dcpsg.cpp:2547
+#: ../src/common/paper.cpp:72
+msgid "A4 sheet, 210 x 297 mm"
+msgstr "A4, 210 x 297 mm"
+
+# generic/dcpsg.cpp:2547
+#: ../src/common/paper.cpp:73
+msgid "C sheet, 17 x 22 in"
+msgstr "C, 17 x 22 pal."
+
+# generic/dcpsg.cpp:2547
+#: ../src/common/paper.cpp:74
+msgid "D sheet, 22 x 34 in"
+msgstr "D, 22 x 34 pal."
+
+#: ../src/common/paper.cpp:75
+msgid "E sheet, 34 x 44 in"
+msgstr "E, 34 x 44 pal."
+
+#: ../src/common/paper.cpp:76
+msgid "Letter Small, 8 1/2 x 11 in"
+msgstr "Letter Small, 8 1/2 x 11 pal."
+
+#: ../src/common/paper.cpp:77
+msgid "Tabloid, 11 x 17 in"
+msgstr "tabloid, 11 x 17 pal."
+
+#: ../src/common/paper.cpp:78
+msgid "Ledger, 17 x 11 in"
+msgstr "Ledger, 17 x 11 in"
+
+#: ../src/common/paper.cpp:79
+msgid "Statement, 5 1/2 x 8 1/2 in"
+msgstr "Statement, 5 1/2 x 8 1/2 pal."
+
+#: ../src/common/paper.cpp:80
+msgid "Executive, 7 1/4 x 10 1/2 in"
+msgstr "Executive, 7 1/4 x 10 1/2 pal."
+
+# generic/dcpsg.cpp:2547
+#: ../src/common/paper.cpp:81
+msgid "A3 sheet, 297 x 420 mm"
+msgstr "A3, 297 x 420 mm"
+
+# generic/dcpsg.cpp:2547
+#: ../src/common/paper.cpp:82
+msgid "A4 small sheet, 210 x 297 mm"
+msgstr "A4-mali, 210 x 297 mm"
+
+# generic/dcpsg.cpp:2547
+#: ../src/common/paper.cpp:83
+msgid "A5 sheet, 148 x 210 mm"
+msgstr "A5, 148 x 210 mm"
+
+# generic/dcpsg.cpp:2547
+#: ../src/common/paper.cpp:84
+msgid "B4 sheet, 250 x 354 mm"
+msgstr "B4, 250 x 354 mm"
+
+# generic/dcpsg.cpp:2547
+#: ../src/common/paper.cpp:85
+msgid "B5 sheet, 182 x 257 millimeter"
+msgstr "B5, 182 x 257 mm"
+
+#: ../src/common/paper.cpp:86
+msgid "Folio, 8 1/2 x 13 in"
+msgstr "Folio, 8 1/2 x 13 pal."
+
+# generic/dcpsg.cpp:2547
+#: ../src/common/paper.cpp:87
+msgid "Quarto, 215 x 275 mm"
+msgstr "Quarto, 215 x 275 mm"
+
+#: ../src/common/paper.cpp:88
+msgid "10 x 14 in"
+msgstr "10 x 14 pal."
+
+#: ../src/common/paper.cpp:89
+msgid "11 x 17 in"
+msgstr "11 x 17 pal."
+
+#: ../src/common/paper.cpp:90
+msgid "Note, 8 1/2 x 11 in"
+msgstr "Note, 8 1/2 x 11 pal."
+
+#: ../src/common/paper.cpp:91
+msgid "#9 Envelope, 3 7/8 x 8 7/8 in"
+msgstr "kuverta #9, 3 7/8 x 8 7/8 pal."
+
+#: ../src/common/paper.cpp:92
+msgid "#10 Envelope, 4 1/8 x 9 1/2 in"
+msgstr "kuverta #10, 4 1/8 x 9 1/2 pal."
+
+#: ../src/common/paper.cpp:93
+msgid "#11 Envelope, 4 1/2 x 10 3/8 in"
+msgstr "kuverta #11, 4 1/2 x 10 3/8 pal."
+
+#: ../src/common/paper.cpp:94
+msgid "#12 Envelope, 4 3/4 x 11 in"
+msgstr "kuverta #12, 4 3/4 x 11 pal."
+
+#: ../src/common/paper.cpp:95
+msgid "#14 Envelope, 5 x 11 1/2 in"
+msgstr "kuverta #14, 5 x 11 1/2 pal."
+
+#: ../src/common/paper.cpp:96
+msgid "DL Envelope, 110 x 220 mm"
+msgstr "kuverta DL, 110 x 220 mm"
+
+#: ../src/common/paper.cpp:97
+msgid "C5 Envelope, 162 x 229 mm"
+msgstr "kuverta C5, 162 x 229 mm"
+
+#: ../src/common/paper.cpp:98
+msgid "C3 Envelope, 324 x 458 mm"
+msgstr "kuverta C3, 324 x 458 mm"
+
+#: ../src/common/paper.cpp:99
+msgid "C4 Envelope, 229 x 324 mm"
+msgstr "kuverta C4, 229 x 324 mm"
+
+#: ../src/common/paper.cpp:100
+msgid "C6 Envelope, 114 x 162 mm"
+msgstr "kuverta C6, 114 x 162 mm"
+
+#: ../src/common/paper.cpp:101
+msgid "C65 Envelope, 114 x 229 mm"
+msgstr "kuverta C65, 114 x 229 mm"
+
+#: ../src/common/paper.cpp:102
+msgid "B4 Envelope, 250 x 353 mm"
+msgstr "kuverta B4, 250 x 353 mm"
+
+#: ../src/common/paper.cpp:103
+msgid "B5 Envelope, 176 x 250 mm"
+msgstr "kuverta B5, 176 x 250 mm"
+
+#: ../src/common/paper.cpp:104
+msgid "B6 Envelope, 176 x 125 mm"
+msgstr "kuverta B6, 176 x 125 mm"
+
+#: ../src/common/paper.cpp:105
+msgid "Italy Envelope, 110 x 230 mm"
+msgstr "kuverta Italijanka, 110 x 230 mm"
+
+#: ../src/common/paper.cpp:106
+msgid "Monarch Envelope, 3 7/8 x 7 1/2 in"
+msgstr "kuverta Monarch, 3 7/8 x 7 1/2 pal."
+
+#: ../src/common/paper.cpp:107
+msgid "6 3/4 Envelope, 3 5/8 x 6 1/2 in"
+msgstr "kuverta 6 3/4, 3 5/8 x 6 1/2 in."
+
+#: ../src/common/paper.cpp:108
+msgid "US Std Fanfold, 14 7/8 x 11 in"
+msgstr "US Std Fanfold, 14 7/8 x 11 pal."
+
+#: ../src/common/paper.cpp:109
+msgid "German Std Fanfold, 8 1/2 x 12 in"
+msgstr "German Std Fanfold, 8 1/2 x 12 pal."
+
+#: ../src/common/paper.cpp:110
+msgid "German Legal Fanfold, 8 1/2 x 13 in"
+msgstr "German Legal Fanfold, 8 1/2 x 13 pal."
+
+# generic/dcpsg.cpp:2547
+#: ../src/common/paper.cpp:112
+msgid "B4 (ISO) 250 x 353 mm"
+msgstr "B4 (ISO), 250 x 353 mm"
+
+#: ../src/common/paper.cpp:113
+msgid "Japanese Postcard 100 x 148 mm"
+msgstr "japonska razglednica, 100 x 148 mm"
+
+#: ../src/common/paper.cpp:114
+msgid "9 x 11 in"
+msgstr "9 x 11 pal."
+
+#: ../src/common/paper.cpp:115
+msgid "10 x 11 in"
+msgstr "10 x 11 pal."
+
+#: ../src/common/paper.cpp:116
+msgid "15 x 11 in"
+msgstr "15 x 11 pal."
+
+#: ../src/common/paper.cpp:117
+msgid "Envelope Invite 220 x 220 mm"
+msgstr "kuverta Invite, 220 x 220 mm"
+
+#: ../src/common/paper.cpp:118
+msgid "Letter Extra 9 1/2 x 12 in"
+msgstr "Letter Extra, 9 1/2 x 12 pal."
+
+#: ../src/common/paper.cpp:119
+msgid "Legal Extra 9 1/2 x 15 in"
+msgstr "Legal Extra, 9 1/2 x 15 pal."
+
+#: ../src/common/paper.cpp:120
+msgid "Tabloid Extra 11.69 x 18 in"
+msgstr "tabloid Extra, 11,69 x 18 pal."
+
+#: ../src/common/paper.cpp:121
+msgid "A4 Extra 9.27 x 12.69 in"
+msgstr "A4 posebno, 9,27 x 12,69 pal."
+
+#: ../src/common/paper.cpp:122
+msgid "Letter Transverse 8 1/2 x 11 in"
+msgstr "Letter prečno, 8 1/2 x 11 pal."
+
+# generic/dcpsg.cpp:2547
+#: ../src/common/paper.cpp:123
+msgid "A4 Transverse 210 x 297 mm"
+msgstr "A4 prečno, 210 x 297 mm"
+
+#: ../src/common/paper.cpp:124
+msgid "Letter Extra Transverse 9.275 x 12 in"
+msgstr "Letter Extra prečno, 9,275 x 12 pal."
+
+#: ../src/common/paper.cpp:125
+msgid "SuperA/SuperA/A4 227 x 356 mm"
+msgstr "SuperA/SuperA/A4, 227 x 356 mm"
+
+#: ../src/common/paper.cpp:126
+msgid "SuperB/SuperB/A3 305 x 487 mm"
+msgstr "SuperB/SuperB/A3, 305 x 487 mm"
+
+#: ../src/common/paper.cpp:127
+msgid "Letter Plus 8 1/2 x 12.69 in"
+msgstr "Letter Plus, 8 1/2 x 12,69 pal."
+
+# generic/dcpsg.cpp:2547
+#: ../src/common/paper.cpp:128
+msgid "A4 Plus 210 x 330 mm"
+msgstr "A4 Plus, 210 x 330 mm"
+
+# generic/dcpsg.cpp:2547
+#: ../src/common/paper.cpp:129
+msgid "A5 Transverse 148 x 210 mm"
+msgstr "A5 prečno, 148 x 210 mm"
+
+# generic/dcpsg.cpp:2547
+#: ../src/common/paper.cpp:130
+msgid "B5 (JIS) Transverse 182 x 257 mm"
+msgstr "B5 (JIS) prečno, 182 x 257 mm"
+
+#: ../src/common/paper.cpp:131
+msgid "A3 Extra 322 x 445 mm"
+msgstr "kuverta A3 Extra, 322 x 445 mm"
+
+# generic/dcpsg.cpp:2547
+#: ../src/common/paper.cpp:132
+msgid "A5 Extra 174 x 235 mm"
+msgstr "A5 posebno, 174 x 235 mm"
+
+#: ../src/common/paper.cpp:133
+msgid "B5 (ISO) Extra 201 x 276 mm"
+msgstr "B5 (ISO) Extra, 201 x 276 mm"
+
+#: ../src/common/paper.cpp:134
+msgid "A2 420 x 594 mm"
+msgstr "A2, 420 x 594 mm"
+
+# generic/dcpsg.cpp:2547
+#: ../src/common/paper.cpp:135
+msgid "A3 Transverse 297 x 420 mm"
+msgstr "A3 prečno, 297 x 420 mm"
+
+#: ../src/common/paper.cpp:136
+msgid "A3 Extra Transverse 322 x 445 mm"
+msgstr "kuverta A3 Extra prečno, 322 x 445 mm"
+
+#: ../src/common/paper.cpp:138
+msgid "Japanese Double Postcard 200 x 148 mm"
+msgstr "japonska dvojna razglednica, 200 x 148 mm"
+
+#: ../src/common/paper.cpp:139
+msgid "A6 105 x 148 mm"
+msgstr "A6, 105 x 148 mm"
+
+#: ../src/common/paper.cpp:140
+msgid "Japanese Envelope Kaku #2"
+msgstr "japonska kuverta Kaku #2"
+
+#: ../src/common/paper.cpp:141
+msgid "Japanese Envelope Kaku #3"
+msgstr "japonska kuverta Kaku #3"
+
+#: ../src/common/paper.cpp:142
+msgid "Japanese Envelope Chou #3"
+msgstr "japonska kuverta Čou #3"
+
+#: ../src/common/paper.cpp:143
+msgid "Japanese Envelope Chou #4"
+msgstr "japonska kuverta Čou #4"
+
+#: ../src/common/paper.cpp:144
+msgid "Letter Rotated 11 x 8 1/2 in"
+msgstr "Letter rotirano, 11 x 8 1/2 pal."
+
+# generic/dcpsg.cpp:2547
+#: ../src/common/paper.cpp:145
+msgid "A3 Rotated 420 x 297 mm"
+msgstr "A3 rotirano, 420 x 297 mm"
+
+# generic/dcpsg.cpp:2547
+#: ../src/common/paper.cpp:146
+msgid "A4 Rotated 297 x 210 mm"
+msgstr "A4 rotirano, 297 x 210 mm"
+
+#: ../src/common/paper.cpp:147
+msgid "A5 Rotated 210 x 148 mm"
+msgstr "A5 rotirano, 210 x 148 mm"
+
+#: ../src/common/paper.cpp:148
+msgid "B4 (JIS) Rotated 364 x 257 mm"
+msgstr "B4 (JIS) rotirano, 364 x 257 mm"
+
+#: ../src/common/paper.cpp:149
+msgid "B5 (JIS) Rotated 257 x 182 mm"
+msgstr "B5 (JIS) rotirano, 257 x 182 mm"
+
+#: ../src/common/paper.cpp:150
+msgid "Japanese Postcard Rotated 148 x 100 mm"
+msgstr "japonska razglednica rotirano, 148 x 100 mm"
+
+#: ../src/common/paper.cpp:151
+msgid "Double Japanese Postcard Rotated 148 x 200 mm"
+msgstr "dvojna japonska razglednica, rotirano, 148 x 200 mm"
+
+# generic/dcpsg.cpp:2547
+#: ../src/common/paper.cpp:152
+msgid "A6 Rotated 148 x 105 mm"
+msgstr "A6 rotirano, 148 x 105 mm"
+
+#: ../src/common/paper.cpp:153
+msgid "Japanese Envelope Kaku #2 Rotated"
+msgstr "japonska kuverta Kaku #2 rotirano"
+
+#: ../src/common/paper.cpp:154
+msgid "Japanese Envelope Kaku #3 Rotated"
+msgstr "japonska kuverta Kaku #3 rotirano"
+
+#: ../src/common/paper.cpp:155
+msgid "Japanese Envelope Chou #3 Rotated"
+msgstr "japonska kuverta Čou #3 rotirano"
+
+#: ../src/common/paper.cpp:156
+msgid "Japanese Envelope Chou #4 Rotated"
+msgstr "japonska kuverta Čou #4 rotirano"
+
+#: ../src/common/paper.cpp:157
+msgid "B6 (JIS) 128 x 182 mm"
+msgstr "B6 (JIS), 128 x 182 mm"
+
+#: ../src/common/paper.cpp:158
+msgid "B6 (JIS) Rotated 182 x 128 mm"
+msgstr "B6 (JIS) rotirano, 182 x 128 mm"
+
+#: ../src/common/paper.cpp:159
+msgid "12 x 11 in"
+msgstr "12 x 11 pal."
+
+#: ../src/common/paper.cpp:160
+msgid "Japanese Envelope You #4"
+msgstr "japonska kuverta Ju #4"
+
+#: ../src/common/paper.cpp:161
+msgid "Japanese Envelope You #4 Rotated"
+msgstr "japonska kuverta Ju #4 rotirano"
+
+#: ../src/common/paper.cpp:162
+msgid "PRC 16K 146 x 215 mm"
+msgstr "PRC 16K, 146 x 215 mm"
+
+#: ../src/common/paper.cpp:163
+msgid "PRC 32K 97 x 151 mm"
+msgstr "PRC 32K, 97 x 151 mm"
+
+#: ../src/common/paper.cpp:164
+msgid "PRC 32K(Big) 97 x 151 mm"
+msgstr "PRC 32K(velik), 97 x 151 mm"
+
+#: ../src/common/paper.cpp:165
+msgid "PRC Envelope #1 102 x 165 mm"
+msgstr "kuverta PRC #1, 102 x 165 mm"
+
+#: ../src/common/paper.cpp:166
+msgid "PRC Envelope #2 102 x 176 mm"
+msgstr "kuverta PRC #2, 102 x 176 mm"
+
+#: ../src/common/paper.cpp:167
+msgid "PRC Envelope #3 125 x 176 mm"
+msgstr "kuverta PRC #3, 125 x 176 mm"
+
+#: ../src/common/paper.cpp:168
+msgid "PRC Envelope #4 110 x 208 mm"
+msgstr "kuverta PRC #4, 110 x 208 mm"
+
+#: ../src/common/paper.cpp:169
+msgid "PRC Envelope #5 110 x 220 mm"
+msgstr "kuverta PRC #5, 110 x 220 mm"
+
+#: ../src/common/paper.cpp:170
+msgid "PRC Envelope #6 120 x 230 mm"
+msgstr "kuverta PRC #6, 120 x 230 mm"
+
+#: ../src/common/paper.cpp:171
+msgid "PRC Envelope #7 160 x 230 mm"
+msgstr "kuverta PRC #7, 160 x 230 mm"
+
+#: ../src/common/paper.cpp:172
+msgid "PRC Envelope #8 120 x 309 mm"
+msgstr "kuverta PRC #8, 120 x 309 mm"
+
+#: ../src/common/paper.cpp:173
+msgid "PRC Envelope #9 229 x 324 mm"
+msgstr "kuverta PRC #9, 229 x 324 mm"
+
+#: ../src/common/paper.cpp:174
+msgid "PRC Envelope #10 324 x 458 mm"
+msgstr "kuverta PRC #10, 324 x 458 mm"
+
+#: ../src/common/paper.cpp:175
+msgid "PRC 16K Rotated"
+msgstr "PRC 16K, rotirano"
+
+#: ../src/common/paper.cpp:176
+msgid "PRC 32K Rotated"
+msgstr "PRC 32K totirano"
+
+#: ../src/common/paper.cpp:177
+msgid "PRC 32K(Big) Rotated"
+msgstr "PRC 32K(velik) rotirano"
+
+#: ../src/common/paper.cpp:178
+msgid "PRC Envelope #1 Rotated 165 x 102 mm"
+msgstr "kuverta PRC #1 rotirano, 165 x 102 mm"
+
+#: ../src/common/paper.cpp:179
+msgid "PRC Envelope #2 Rotated 176 x 102 mm"
+msgstr "kuverta PRC #2 rotirano, 176 x 102 mm"
+
+#: ../src/common/paper.cpp:180
+msgid "PRC Envelope #3 Rotated 176 x 125 mm"
+msgstr "kuverta PRC #3 rotirano, 176 x 125 mm"
+
+#: ../src/common/paper.cpp:181
+msgid "PRC Envelope #4 Rotated 208 x 110 mm"
+msgstr "kuverta PRC #4 rotirano, 208 x 110 mm"
+
+#: ../src/common/paper.cpp:182
+msgid "PRC Envelope #5 Rotated 220 x 110 mm"
+msgstr "kuverta PRC #5 rotirano, 220 x 110 mm"
+
+#: ../src/common/paper.cpp:183
+msgid "PRC Envelope #6 Rotated 230 x 120 mm"
+msgstr "kuverta PRC #6 rotirano, 230 x 120 mm"
+
+#: ../src/common/paper.cpp:184
+msgid "PRC Envelope #7 Rotated 230 x 160 mm"
+msgstr "kuverta PRC #7 rotirano, 230 x 160 mm"
+
+#: ../src/common/paper.cpp:185
+msgid "PRC Envelope #8 Rotated 309 x 120 mm"
+msgstr "kuverta PRC #8 rotirana, 309 x 120 mm"
+
+#: ../src/common/paper.cpp:186
+msgid "PRC Envelope #9 Rotated 324 x 229 mm"
+msgstr "kuverta PRC #9 rotirano, 324 x 229 mm"
+
+#: ../src/common/paper.cpp:187
+msgid "PRC Envelope #10 Rotated 458 x 324 mm"
+msgstr "kuverta PRC #10 rotirano, 458 x 324 mm"
+
+# generic/dcpsg.cpp:2547
+#: ../src/common/paper.cpp:192
+msgid "A0 sheet, 841 x 1189 mm"
+msgstr "A0, 841 x 1189 mm"
+
+# generic/dcpsg.cpp:2547
+#: ../src/common/paper.cpp:193
+msgid "A1 sheet, 594 x 841 mm"
+msgstr "A1, 594 x 841 mm"
+
+#: ../src/common/preferencescmn.cpp:37
+msgid "General"
+msgstr "Splošno"
+
+#: ../src/common/preferencescmn.cpp:40
+msgid "Advanced"
+msgstr "Napredno"
+
+# generic/prntdlgg.cpp:272
+#: ../src/common/prntbase.cpp:245
+msgid "Generic PostScript"
+msgstr "Splošni PostScript"
+
+#: ../src/common/prntbase.cpp:259
+msgid "Ready"
+msgstr "Pripravljen"
+
+# common/prntbase.cpp:120
+#: ../src/common/prntbase.cpp:331
+msgid "Printing Error"
+msgstr "Napaka pri tiskanju"
+
+# generic/prntdlgg.cpp:113
+# generic/prntdlgg.cpp:127
+#: ../src/common/prntbase.cpp:413 ../src/common/prntbase.cpp:1597
+#: ../src/generic/prntdlgg.cpp:135 ../src/generic/prntdlgg.cpp:149
+#: ../src/gtk/print.cpp:628 ../src/gtk/print.cpp:646
+msgid "Print"
+msgstr "Tiskanje"
+
+# generic/prntdlgg.cpp:604
+#: ../src/common/prntbase.cpp:471 ../src/generic/prntdlgg.cpp:809
+msgid "Page setup"
+msgstr "Nastavitev strani"
+
+#: ../src/common/prntbase.cpp:525
+msgid "Please wait while printing..."
+msgstr "Prosimo, počakajte, dokler poteka tiskanje ..."
+
+#: ../src/common/prntbase.cpp:529
+msgid "Document:"
+msgstr "Dokument:"
+
+#: ../src/common/prntbase.cpp:532
+msgid "Progress:"
+msgstr "Napredek:"
+
+#: ../src/common/prntbase.cpp:533
+msgid "Preparing"
+msgstr "Priprava"
+
+# generic/printps.cpp:232
+#: ../src/common/prntbase.cpp:552
+#, c-format
+msgid "Printing page %d"
+msgstr "Tiskanje strani %d"
+
+# generic/printps.cpp:232
+#: ../src/common/prntbase.cpp:557
+#, c-format
+msgid "Printing page %d of %d"
+msgstr "Tiskanje strani %d od %d ..."
+
+# common/prntbase.cpp:729
+#: ../src/common/prntbase.cpp:560
+#, c-format
+msgid " (copy %d of %d)"
+msgstr " (kopija %d od %d)"
+
+# html/helpfrm.cpp:515
+#: ../src/common/prntbase.cpp:1604
+msgid "First page"
+msgstr "Prva stran"
+
+# html/helpfrm.cpp:512
+#: ../src/common/prntbase.cpp:1609 ../src/html/helpwnd.cpp:659
+msgid "Previous page"
+msgstr "Prejšnja stran"
+
+# html/helpfrm.cpp:515
+#: ../src/common/prntbase.cpp:1623 ../src/html/helpwnd.cpp:660
+msgid "Next page"
+msgstr "Naslednja stran"
+
+# html/helpfrm.cpp:515
+#: ../src/common/prntbase.cpp:1628
+msgid "Last page"
+msgstr "Zadnja stran"
+
+#: ../src/common/prntbase.cpp:1636 ../src/common/stockitem.cpp:215
+msgid "Zoom Out"
+msgstr "Pomanjšaj"
+
+#: ../src/common/prntbase.cpp:1650 ../src/common/stockitem.cpp:214
+msgid "Zoom In"
+msgstr "Povečaj"
+
+# generic/logg.cpp:477
+# generic/tipdlg.cpp:170
+#: ../src/common/prntbase.cpp:1656 ../src/common/stockitem.cpp:153
+#: ../src/generic/logg.cpp:553 ../src/univ/themes/win32.cpp:3752
+msgid "&Close"
+msgstr "&Zapri"
+
+# common/prntbase.cpp:711
+#: ../src/common/prntbase.cpp:2085
+msgid "Could not start document preview."
+msgstr "Predogleda dokumenta ni mogoče začeti."
+
+# common/prntbase.cpp:687
+# common/prntbase.cpp:711
+#: ../src/common/prntbase.cpp:2085 ../src/common/prntbase.cpp:2129
+#: ../src/common/prntbase.cpp:2137
+msgid "Print Preview Failure"
+msgstr "Napaka pri predogledu tiskanja"
+
+# common/prntbase.cpp:687
+#: ../src/common/prntbase.cpp:2129 ../src/common/prntbase.cpp:2137
+msgid "Sorry, not enough memory to create a preview."
+msgstr "Oprostite, ni dovolj spomina za predogled tiskanja."
+
+# common/prntbase.cpp:729
+#: ../src/common/prntbase.cpp:2144
+#, c-format
+msgid "Page %d of %d"
+msgstr "Stran %d od %d"
+
+# common/prntbase.cpp:731
+#: ../src/common/prntbase.cpp:2146
+#, c-format
+msgid "Page %d"
+msgstr "Stran %d"
+
+# generic/progdlgg.cpp:241
+#: ../src/common/regex.cpp:382 ../src/html/chm.cpp:348
+msgid "unknown error"
+msgstr "neznana napaka"
+
+#: ../src/common/regex.cpp:995
+#, c-format
+msgid "Invalid regular expression '%s': %s"
+msgstr "Neveljaven pravilni izraz '%s': %s"
+
+#: ../src/common/regex.cpp:1059
+#, c-format
+msgid "Failed to find match for regular expression: %s"
+msgstr "Ujemanje v regularnem izrazu neuspešno: %s"
+
+#: ../src/common/rendcmn.cpp:188
+#, c-format
+msgid "Renderer \"%s\" has incompatible version %d.%d and couldn't be loaded."
+msgstr ""
+"Prikazovalnik \"%s\" je nezdružljive različice %d.%d in ga ni mogoče "
+"naložiti."
+
+#: ../src/common/secretstore.cpp:162
+msgid "Not available for this platform"
+msgstr "Ni na voljo za to platformo"
+
+#: ../src/common/secretstore.cpp:183
+#, c-format
+msgid "Saving password for \"%s\" failed: %s."
+msgstr "Shranjevanje gesla za »%s« ni uspelo: %s."
+
+#: ../src/common/secretstore.cpp:205
+#, c-format
+msgid "Reading password for \"%s\" failed: %s."
+msgstr "Branje gesla za »%s« ni uspelo: %s."
+
+#: ../src/common/secretstore.cpp:228
+#, c-format
+msgid "Deleting password for \"%s\" failed: %s."
+msgstr "Brisanje gesla za »%s« ni uspelo: %s."
+
+#: ../src/common/selectdispatcher.cpp:254
+msgid "Failed to monitor I/O channels"
+msgstr "V/I kanalov ni bilo mogoče nadzirati"
+
+# generic/logg.cpp:473
+# generic/logg.cpp:774
+#: ../src/common/sizer.cpp:3054 ../src/common/stockitem.cpp:195
+msgid "Save"
+msgstr "Shrani"
+
+#: ../src/common/sizer.cpp:3056
+msgid "Don't Save"
+msgstr "Ne shrani"
+
+# msw/app.cpp:252
+#: ../src/common/socket.cpp:870
+msgid "Cannot initialize sockets"
+msgstr "Inicializacija vrat ni možna"
+
+# common/dlgcmn.cpp:144
+# generic/proplist.cpp:528
+# html/helpfrm.cpp:208
+# msw/mdi.cpp:1283
+#: ../src/common/stockitem.cpp:127
+msgctxt "standard Windows menu"
+msgid "&Help"
+msgstr "Po&moč"
+
+#: ../src/common/stockitem.cpp:144
+msgid "&About"
+msgstr "&O programu"
+
+#: ../src/common/stockitem.cpp:144
+msgid "About"
+msgstr "O programu"
+
+#: ../src/common/stockitem.cpp:145
+msgid "Add"
+msgstr "Dodaj"
+
+#: ../src/common/stockitem.cpp:146
+msgid "&Apply"
+msgstr "&Uporabi"
+
+#: ../src/common/stockitem.cpp:146
+msgid "Apply"
+msgstr "Uporabi"
+
+# generic/helpwxht.cpp:157
+#: ../src/common/stockitem.cpp:147
+msgid "&Back"
+msgstr "&Nazaj"
+
+# generic/helpwxht.cpp:157
+#: ../src/common/stockitem.cpp:147
+msgid "Back"
+msgstr "Nazaj"
+
+# generic/fontdlgg.cpp:217
+#: ../src/common/stockitem.cpp:148
+msgid "&Bold"
+msgstr "&Krepko"
+
+# generic/fontdlgg.cpp:217
+#: ../src/common/stockitem.cpp:148 ../src/generic/fontdlgg.cpp:326
+#: ../src/richtext/richtextfontpage.cpp:354
+msgid "Bold"
+msgstr "Krepko"
+
+#: ../src/common/stockitem.cpp:149
+msgid "&Bottom"
+msgstr "&Spodaj"
+
+#: ../src/common/stockitem.cpp:149 ../src/richtext/richtextsizepage.cpp:287
+msgid "Bottom"
+msgstr "Na dnu"
+
+# common/dlgcmn.cpp:148
+# common/prntbase.cpp:109
+# generic/dcpsg.cpp:2271
+# generic/dirdlgg.cpp:425
+# generic/filedlgg.cpp:916
+# generic/fontdlgg.cpp:257
+# generic/prntdlgg.cpp:468
+# generic/progdlgg.cpp:179
+# generic/proplist.cpp:523
+# generic/wizard.cpp:192
+# html/helpfrm.cpp:910
+#: ../src/common/stockitem.cpp:150 ../src/generic/fontdlgg.cpp:462
+#: ../src/generic/fontdlgg.cpp:481 ../src/generic/wizard.cpp:415
+msgid "&Cancel"
+msgstr "&Prekliči"
+
+#: ../src/common/stockitem.cpp:151
+msgid "&CD-ROM"
+msgstr "&CD-ROM"
+
+#: ../src/common/stockitem.cpp:151
+msgid "CD-ROM"
+msgstr "CD-ROM"
+
+# generic/logg.cpp:475
+#: ../src/common/stockitem.cpp:152
+msgid "&Clear"
+msgstr "&Počisti"
+
+# generic/logg.cpp:475
+#: ../src/common/stockitem.cpp:152
+msgid "Clear"
+msgstr "Počisti"
+
+# common/prntbase.cpp:359
+# generic/progdlgg.cpp:307
+# generic/proplist.cpp:518
+#: ../src/common/stockitem.cpp:153 ../src/generic/dbgrptg.cpp:93
+#: ../src/generic/progdlgg.cpp:778 ../src/html/helpdlg.cpp:86
+#: ../src/msw/progdlg.cpp:209 ../src/msw/progdlg.cpp:890
+#: ../src/richtext/richtextstyledlg.cpp:272
+#: ../src/richtext/richtextsymboldlg.cpp:448
+msgid "Close"
+msgstr "Zapri "
+
+# generic/helpwxht.cpp:159
+# html/helpfrm.cpp:303
+# html/helpfrm.cpp:312
+#: ../src/common/stockitem.cpp:154
+msgid "&Convert"
+msgstr "&Pretvori"
+
+# generic/helpwxht.cpp:159
+# html/helpfrm.cpp:303
+# html/helpfrm.cpp:312
+#: ../src/common/stockitem.cpp:154
+msgid "Convert"
+msgstr "Pretvori"
+
+#: ../src/common/stockitem.cpp:155 ../src/msw/textctrl.cpp:2884
+#: ../src/osx/textctrl_osx.cpp:653 ../src/richtext/richtextctrl.cpp:331
+msgid "&Copy"
+msgstr "&Kopiraj"
+
+#: ../src/common/stockitem.cpp:155 ../src/stc/stc_i18n.cpp:18
+msgid "Copy"
+msgstr "Kopiraj"
+
+#: ../src/common/stockitem.cpp:156 ../src/msw/textctrl.cpp:2883
+#: ../src/osx/textctrl_osx.cpp:652 ../src/richtext/richtextctrl.cpp:330
+msgid "Cu&t"
+msgstr "&Izreži"
+
+#: ../src/common/stockitem.cpp:156 ../src/stc/stc_i18n.cpp:17
+msgid "Cut"
+msgstr "Izreži"
+
+#: ../src/common/stockitem.cpp:157 ../src/msw/textctrl.cpp:2886
+#: ../src/osx/textctrl_osx.cpp:655 ../src/richtext/richtextctrl.cpp:333
+#: ../src/richtext/richtexttabspage.cpp:137
+msgid "&Delete"
+msgstr "&Izbriši"
+
+#: ../src/common/stockitem.cpp:157 ../src/richtext/richtextbuffer.cpp:8266
+#: ../src/stc/stc_i18n.cpp:20
+msgid "Delete"
+msgstr "Izbriši"
+
+# html/htmlwin.cpp:216
+#: ../src/common/stockitem.cpp:158
+msgid "&Down"
+msgstr "&Dol"
+
+# html/htmlwin.cpp:216
+#: ../src/common/stockitem.cpp:158 ../src/generic/fdrepdlg.cpp:148
+msgid "Down"
+msgstr "Dol"
+
+#: ../src/common/stockitem.cpp:159
+msgid "&Edit"
+msgstr "&Uredi"
+
+#: ../src/common/stockitem.cpp:159
+msgid "Edit"
+msgstr "Uredi"
+
+#: ../src/common/stockitem.cpp:160
+msgid "&Execute"
+msgstr "&Izvedi"
+
+#: ../src/common/stockitem.cpp:160
+msgid "Execute"
+msgstr "Izvedi"
+
+#: ../src/common/stockitem.cpp:161
+msgid "&Quit"
+msgstr "&Izhod"
+
+#: ../src/common/stockitem.cpp:161
+msgid "Quit"
+msgstr "Izhod"
+
+# generic/filedlgg.cpp:534
+#: ../src/common/stockitem.cpp:162
+msgid "&File"
+msgstr "&Datoteka"
+
+# generic/filedlgg.cpp:534
+#: ../src/common/stockitem.cpp:162
+msgid "File"
+msgstr "Datoteka"
+
+# html/helpfrm.cpp:340
+#: ../src/common/stockitem.cpp:163
+msgid "&Find..."
+msgstr "&Najdi ..."
+
+# html/helpfrm.cpp:340
+#: ../src/common/stockitem.cpp:163
+msgid "Find..."
+msgstr "Najdi ..."
+
+#: ../src/common/stockitem.cpp:164
+msgid "&First"
+msgstr "&Prvi"
+
+#: ../src/common/stockitem.cpp:164
+msgid "First"
+msgstr "Prvi"
+
+#: ../src/common/stockitem.cpp:165
+msgid "&Floppy"
+msgstr "&Disketa"
+
+#: ../src/common/stockitem.cpp:165
+msgid "Floppy"
+msgstr "Disketa"
+
+# common/dlgcmn.cpp:132
+# generic/helpwxht.cpp:158
+#: ../src/common/stockitem.cpp:166
+msgid "&Forward"
+msgstr "&Naprej"
+
+# common/dlgcmn.cpp:132
+# generic/helpwxht.cpp:158
+#: ../src/common/stockitem.cpp:166
+msgid "Forward"
+msgstr "Naprej"
+
+#: ../src/common/stockitem.cpp:167
+msgid "&Harddisk"
+msgstr "&Trdi disk"
+
+#: ../src/common/stockitem.cpp:167
+msgid "Harddisk"
+msgstr "Trdi disk"
+
+# common/dlgcmn.cpp:144
+# generic/proplist.cpp:528
+# html/helpfrm.cpp:208
+# msw/mdi.cpp:1283
+#: ../src/common/stockitem.cpp:168 ../src/generic/wizard.cpp:418
+#: ../src/osx/cocoa/menu.mm:225 ../src/richtext/richtextstyledlg.cpp:298
+#: ../src/richtext/richtextsymboldlg.cpp:451
+msgid "&Help"
+msgstr "&Pomoč"
+
+# generic/dirdlgg.cpp:212
+#: ../src/common/stockitem.cpp:169
+msgid "&Home"
+msgstr "&Domov"
+
+# generic/dirdlgg.cpp:212
+#: ../src/common/stockitem.cpp:169
+msgid "Home"
+msgstr "Domov"
+
+# html/helpfrm.cpp:372
+#: ../src/common/stockitem.cpp:170
+msgid "Indent"
+msgstr "Zamaknjeno"
+
+# html/helpfrm.cpp:372
+#: ../src/common/stockitem.cpp:171
+msgid "&Index"
+msgstr "&Kazalo"
+
+# html/helpfrm.cpp:372
+#: ../src/common/stockitem.cpp:171 ../src/html/helpwnd.cpp:510
+msgid "Index"
+msgstr "Indeks"
+
+# common/docview.cpp:1951
+#: ../src/common/stockitem.cpp:172
+msgid "&Info"
+msgstr "&Podatki"
+
+#: ../src/common/stockitem.cpp:172
+msgid "Info"
+msgstr "Podatki"
+
+# generic/fontdlgg.cpp:213
+#: ../src/common/stockitem.cpp:173
+msgid "&Italic"
+msgstr "&Ležeče"
+
+# generic/fontdlgg.cpp:213
+#: ../src/common/stockitem.cpp:173 ../src/generic/fontdlgg.cpp:322
+#: ../src/richtext/richtextfontpage.cpp:350
+msgid "Italic"
+msgstr "Kurzivno"
+
+#: ../src/common/stockitem.cpp:174
+msgid "&Jump to"
+msgstr "&Skoči na"
+
+#: ../src/common/stockitem.cpp:174
+msgid "Jump to"
+msgstr "Skoči na"
+
+# generic/dirdlgg.cpp:217
+#: ../src/common/stockitem.cpp:175
+msgid "Centered"
+msgstr "Poravnano na sredino"
+
+#: ../src/common/stockitem.cpp:176
+msgid "Justified"
+msgstr "Poravnano"
+
+#: ../src/common/stockitem.cpp:177
+msgid "Align Left"
+msgstr "Poravnaj levo"
+
+# generic/fontdlgg.cpp:216
+#: ../src/common/stockitem.cpp:178
+msgid "Align Right"
+msgstr "Poravnaj desno"
+
+# common/cmdline.cpp:912
+#: ../src/common/stockitem.cpp:179
+msgid "&Last"
+msgstr "&Zadnji"
+
+# common/cmdline.cpp:912
+#: ../src/common/stockitem.cpp:179
+msgid "Last"
+msgstr "Zadnji"
+
+# msw/mdi.cpp:188
+#: ../src/common/stockitem.cpp:180
+msgid "&Network"
+msgstr "&Omrežje"
+
+#: ../src/common/stockitem.cpp:180
+msgid "Network"
+msgstr "Omrežje"
+
+# msw/mdi.cpp:188
+#: ../src/common/stockitem.cpp:181 ../src/richtext/richtexttabspage.cpp:131
+msgid "&New"
+msgstr "&Nov"
+
+# msw/mdi.cpp:188
+#: ../src/common/stockitem.cpp:181
+msgid "New"
+msgstr "Nov"
+
+# common/dlgcmn.cpp:111
+# common/dlgcmn.cpp:121
+#: ../src/common/stockitem.cpp:182 ../src/msw/msgdlg.cpp:417
+msgid "&No"
+msgstr "&Ne"
+
+# common/dlgcmn.cpp:127
+# generic/dcpsg.cpp:2270
+# generic/dirdlgg.cpp:423
+# generic/filedlgg.cpp:907
+# generic/fontdlgg.cpp:256
+# generic/logg.cpp:733
+# generic/prntdlgg.cpp:467
+# generic/proplist.cpp:511
+# html/helpfrm.cpp:909
+#: ../src/common/stockitem.cpp:183 ../src/generic/fontdlgg.cpp:467
+#: ../src/generic/fontdlgg.cpp:474
+msgid "&OK"
+msgstr "&V redu"
+
+# generic/logg.cpp:473
+# generic/logg.cpp:774
+#: ../src/common/stockitem.cpp:184 ../src/generic/dbgrptg.cpp:341
+msgid "&Open..."
+msgstr "&Odpri ..."
+
+# generic/logg.cpp:473
+# generic/logg.cpp:774
+#: ../src/common/stockitem.cpp:184
+msgid "Open..."
+msgstr "Odpri ..."
+
+# common/cmdline.cpp:912
+#: ../src/common/stockitem.cpp:185 ../src/msw/textctrl.cpp:2885
+#: ../src/osx/textctrl_osx.cpp:654 ../src/richtext/richtextctrl.cpp:332
+msgid "&Paste"
+msgstr "&Prilepi"
+
+# common/cmdline.cpp:912
+#: ../src/common/stockitem.cpp:185 ../src/richtext/richtextctrl.cpp:3484
+#: ../src/stc/stc_i18n.cpp:19
+msgid "Paste"
+msgstr "Prilepi"
+
+#: ../src/common/stockitem.cpp:186
+msgid "&Preferences"
+msgstr "&Možnosti"
+
+#: ../src/common/stockitem.cpp:186 ../src/osx/cocoa/preferences.mm:304
+msgid "Preferences"
+msgstr "Možnosti"
+
+# common/docview.cpp:897
+#: ../src/common/stockitem.cpp:187
+msgid "Print previe&w..."
+msgstr "Predogle&d tiskanja ..."
+
+# common/docview.cpp:897
+#: ../src/common/stockitem.cpp:187
+msgid "Print preview..."
+msgstr "Predogled tiskanja ..."
+
+# common/prntbase.cpp:366
+#: ../src/common/stockitem.cpp:188
+msgid "&Print..."
+msgstr "&Natisni ..."
+
+# common/prntbase.cpp:366
+#: ../src/common/stockitem.cpp:188
+msgid "Print..."
+msgstr "Natisni ..."
+
+# html/helpfrm.cpp:512
+#: ../src/common/stockitem.cpp:189 ../src/richtext/richtextctrl.cpp:337
+#: ../src/richtext/richtextctrl.cpp:5479
+msgid "&Properties"
+msgstr "&Lastnosti"
+
+# html/helpfrm.cpp:512
+#: ../src/common/stockitem.cpp:189
+msgid "Properties"
+msgstr "Lastnosti"
+
+# common/docview.cpp:1945
+# common/docview.cpp:1956
+#: ../src/common/stockitem.cpp:190 ../src/stc/stc_i18n.cpp:16
+msgid "Redo"
+msgstr "Ponovi"
+
+#: ../src/common/stockitem.cpp:191
+msgid "Refresh"
+msgstr "Osveži"
+
+#: ../src/common/stockitem.cpp:192
+msgid "Remove"
+msgstr "Odstrani"
+
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR Free Software Foundation, Inc.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+# msw/filedlg.cpp:445
+#: ../src/common/stockitem.cpp:193
+msgid "Rep&lace..."
+msgstr "&Zamenjaj ..."
+
+#: ../src/common/stockitem.cpp:193
+msgid "Replace..."
+msgstr "Zamenjaj ..."
+
+#: ../src/common/stockitem.cpp:194
+msgid "Revert to Saved"
+msgstr "Povrni v shranjeno"
+
+# generic/logg.cpp:473
+# generic/logg.cpp:774
+#: ../src/common/stockitem.cpp:196 ../src/generic/logg.cpp:549
+msgid "Save &As..."
+msgstr "&Shrani kot ..."
+
+# generic/logg.cpp:473
+# generic/logg.cpp:774
+#: ../src/common/stockitem.cpp:196
+msgid "Save As..."
+msgstr "Shrani kot ..."
+
+# common/docview.cpp:1371
+# common/docview.cpp:1422
+#: ../src/common/stockitem.cpp:197 ../src/msw/textctrl.cpp:2888
+#: ../src/osx/textctrl_osx.cpp:657 ../src/richtext/richtextctrl.cpp:335
+msgid "Select &All"
+msgstr "Izberi &vse"
+
+# common/docview.cpp:1371
+# common/docview.cpp:1422
+#: ../src/common/stockitem.cpp:197 ../src/stc/stc_i18n.cpp:21
+msgid "Select All"
+msgstr "Izberi vse"
+
+#: ../src/common/stockitem.cpp:198
+msgid "&Color"
+msgstr "&Barva"
+
+#: ../src/common/stockitem.cpp:198
+msgid "Color"
+msgstr "Barva"
+
+# html/helpfrm.cpp:899
+#: ../src/common/stockitem.cpp:199
+msgid "&Font"
+msgstr "&Pisava"
+
+#: ../src/common/stockitem.cpp:199 ../src/richtext/richtextformatdlg.cpp:336
+msgid "Font"
+msgstr "Pisava"
+
+#: ../src/common/stockitem.cpp:200
+msgid "&Ascending"
+msgstr "&Naraščajoče"
+
+# common/fontmap.cpp:332
+#: ../src/common/stockitem.cpp:200
+msgid "Ascending"
+msgstr "Naraščajoče"
+
+#: ../src/common/stockitem.cpp:201
+msgid "&Descending"
+msgstr "&Padajoče"
+
+#: ../src/common/stockitem.cpp:201
+msgid "Descending"
+msgstr "Padajoče"
+
+#: ../src/common/stockitem.cpp:202
+msgid "&Spell Check"
+msgstr "&Preverjanje črkovanja"
+
+#: ../src/common/stockitem.cpp:202
+msgid "Spell Check"
+msgstr "Preveri črkovanje"
+
+# common/dlgcmn.cpp:138
+#: ../src/common/stockitem.cpp:203
+msgid "&Stop"
+msgstr "&Ustavi"
+
+# common/dlgcmn.cpp:138
+#: ../src/common/stockitem.cpp:203
+msgid "Stop"
+msgstr "Ustavi"
+
+#: ../src/common/stockitem.cpp:204 ../src/richtext/richtextfontpage.cpp:274
+msgid "&Strikethrough"
+msgstr "Pre&črtano"
+
+#: ../src/common/stockitem.cpp:204
+msgid "Strikethrough"
+msgstr "Prečrtano"
+
+#: ../src/common/stockitem.cpp:205
+msgid "&Top"
+msgstr "&Vrh"
+
+# generic/prntdlgg.cpp:191
+#: ../src/common/stockitem.cpp:205 ../src/richtext/richtextsizepage.cpp:285
+#: ../src/richtext/richtextsizepage.cpp:289
+msgid "Top"
+msgstr "Na vrhu"
+
+# generic/fontdlgg.cpp:242
+#: ../src/common/stockitem.cpp:206
+msgid "Undelete"
+msgstr "Razveljavi brisanje"
+
+# generic/fontdlgg.cpp:242
+#: ../src/common/stockitem.cpp:207 ../src/generic/fontdlgg.cpp:437
+msgid "&Underline"
+msgstr "&Podčrtaj"
+
+# generic/fontdlgg.cpp:242
+#: ../src/common/stockitem.cpp:207
+msgid "Underline"
+msgstr "Podčrtaj"
+
+# common/docview.cpp:1951
+#: ../src/common/stockitem.cpp:208 ../src/stc/stc_i18n.cpp:15
+msgid "Undo"
+msgstr "Razveljavi"
+
+#: ../src/common/stockitem.cpp:209
+msgid "&Unindent"
+msgstr "&Nezamaknjeno"
+
+#: ../src/common/stockitem.cpp:209
+msgid "Unindent"
+msgstr "Nezamaknjeno"
+
+#: ../src/common/stockitem.cpp:210
+msgid "&Up"
+msgstr "&Gor"
+
+#: ../src/common/stockitem.cpp:210 ../src/generic/fdrepdlg.cpp:148
+msgid "Up"
+msgstr "Navzgor"
+
+# common/dlgcmn.cpp:109
+# common/dlgcmn.cpp:116
+#: ../src/common/stockitem.cpp:211 ../src/msw/msgdlg.cpp:417
+msgid "&Yes"
+msgstr "&Da"
+
+#: ../src/common/stockitem.cpp:212
+msgid "&Actual Size"
+msgstr "&Dejanska velikost"
+
+#: ../src/common/stockitem.cpp:212
+msgid "Actual Size"
+msgstr "Dejanska velikost"
+
+#: ../src/common/stockitem.cpp:213
+msgid "Zoom to &Fit"
+msgstr "Prilagodi &pogledu"
+
+#: ../src/common/stockitem.cpp:213
+msgid "Zoom to Fit"
+msgstr "Prilagodi pogledu"
+
+#: ../src/common/stockitem.cpp:214
+msgid "Zoom &In"
+msgstr "Pove&čaj"
+
+#: ../src/common/stockitem.cpp:215
+msgid "Zoom &Out"
+msgstr "Po&manjšaj"
+
+#: ../src/common/stockitem.cpp:262
+msgid "Show about dialog"
+msgstr "Pokaži pogovorno okno o programu"
+
+# generic/dirdlgg.cpp:191
+#: ../src/common/stockitem.cpp:263
+msgid "Copy selection"
+msgstr "Kopiraj izbor"
+
+# generic/dirdlgg.cpp:191
+#: ../src/common/stockitem.cpp:264
+msgid "Cut selection"
+msgstr "Prilepi izbor"
+
+# generic/dirdlgg.cpp:191
+#: ../src/common/stockitem.cpp:265
+msgid "Delete selection"
+msgstr "Izbriši izbor"
+
+# html/helpfrm.cpp:523
+# html/helpfrm.cpp:1183
+#: ../src/common/stockitem.cpp:266
+msgid "Find in document"
+msgstr "Poišči v dokumentu"
+
+#: ../src/common/stockitem.cpp:267
+msgid "Find and replace in document"
+msgstr "Najdite in zamenjajte v dokumentu"
+
+# generic/dirdlgg.cpp:191
+#: ../src/common/stockitem.cpp:268
+msgid "Paste selection"
+msgstr "Prilepi izbor"
+
+# html/helpfrm.cpp:529
+#: ../src/common/stockitem.cpp:269
+msgid "Quit this program"
+msgstr "Zapri ta program"
+
+#: ../src/common/stockitem.cpp:270
+msgid "Redo last action"
+msgstr "Ponovi zadnje dejanje"
+
+#: ../src/common/stockitem.cpp:271
+msgid "Undo last action"
+msgstr "Razveljavi zadnje dejanje"
+
+# generic/filedlgg.cpp:883
+#: ../src/common/stockitem.cpp:272
+msgid "Create new document"
+msgstr "Ustvari nov dokument"
+
+# html/helpfrm.cpp:523
+# html/helpfrm.cpp:1183
+#: ../src/common/stockitem.cpp:273
+msgid "Open an existing document"
+msgstr "Odpri obstoječi dokument"
+
+#: ../src/common/stockitem.cpp:274
+msgid "Close current document"
+msgstr "Zapri trenutni dokument"
+
+# common/docview.cpp:1494
+#: ../src/common/stockitem.cpp:275
+msgid "Save current document"
+msgstr "Shrani trenutni dokument"
+
+#: ../src/common/stockitem.cpp:276
+msgid "Save current document with a different filename"
+msgstr "Shrani trenutni dokument pod drugim imenom datoteke."
+
+#: ../src/common/strconv.cpp:2324
+#, c-format
+msgid "Conversion to charset '%s' doesn't work."
+msgstr "Pretvorba v nabor znakov »%s« ne deluje."
+
+# generic/progdlgg.cpp:241
+#: ../src/common/tarstrm.cpp:352 ../src/common/tarstrm.cpp:375
+#: ../src/common/tarstrm.cpp:406 ../src/generic/progdlgg.cpp:373
+msgid "unknown"
+msgstr "nepoznan"
+
+#: ../src/common/tarstrm.cpp:774
+msgid "incomplete header block in tar"
+msgstr "nepopolni blok glave v tar"
+
+#: ../src/common/tarstrm.cpp:798
+msgid "checksum failure reading tar header block"
+msgstr "napaka preverjanja preizkusne vsote pri branju bloka glave tar"
+
+#: ../src/common/tarstrm.cpp:971
+msgid "invalid data in extended tar header"
+msgstr "neveljavni podatki v razširjeni glavi tar"
+
+#: ../src/common/tarstrm.cpp:981 ../src/common/tarstrm.cpp:1003
+#: ../src/common/tarstrm.cpp:1477 ../src/common/tarstrm.cpp:1499
+msgid "tar entry not open"
+msgstr "vnos tar ni odprt"
+
+#: ../src/common/tarstrm.cpp:1023
+msgid "unexpected end of file"
+msgstr "nepričakovan konec datoteke"
+
+#: ../src/common/tarstrm.cpp:1297
+#, c-format
+msgid "%s did not fit the tar header for entry '%s'"
+msgstr "%s ne ustreza glavi tar za vnos »%s«"
+
+#: ../src/common/tarstrm.cpp:1359
+msgid "incorrect size given for tar entry"
+msgstr "nepravilna velikost za vnos tar"
+
+#: ../src/common/textbuf.cpp:232
+#, c-format
+msgid "'%s' is probably a binary buffer."
+msgstr "»%s« je verjetno binarni medpomnilnik."
+
+# common/textcmn.cpp:94
+#: ../src/common/textcmn.cpp:1006 ../src/richtext/richtextctrl.cpp:3053
+msgid "File couldn't be loaded."
+msgstr "Datoteke ni mogoče naložiti."
+
+# common/ffile.cpp:182
+#: ../src/common/textfile.cpp:95
+#, c-format
+msgid "Failed to read text file \"%s\"."
+msgstr "Branje besedilne datoteke »%s« ni uspelo."
+
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR Free Software Foundation, Inc.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+# common/textfile.cpp:359
+#: ../src/common/textfile.cpp:160
+#, c-format
+msgid "can't write buffer '%s' to disk."
+msgstr "medpomnilnika '%s' ni možno zapisati na disk."
+
+# common/timercmn.cpp:196
+#: ../src/common/time.cpp:212
+msgid "Failed to get the local system time"
+msgstr "Lokalnega sistemskega časa ni mogoče razbrati."
+
+# common/timercmn.cpp:267
+#: ../src/common/time.cpp:279
+msgid "wxGetTimeOfDay failed."
+msgstr "wxGetTimeOfDay ni uspela."
+
+# common/intl.cpp:412
+#: ../src/common/translation.cpp:929
+#, c-format
+msgid "'%s' is not a valid message catalog."
+msgstr "»%s« ni veljaven katalog sporočil."
+
+# common/intl.cpp:412
+#: ../src/common/translation.cpp:954
+msgid "Invalid message catalog."
+msgstr "Neveljaven katalog sporočil."
+
+# html/helpdata.cpp:353
+#: ../src/common/translation.cpp:1013
+#, c-format
+msgid "Failed to parse Plural-Forms: '%s'"
+msgstr "Množinskih oblik ni mogoče razčleniti: »%s«"
+
+# common/intl.cpp:379
+#: ../src/common/translation.cpp:1723
+#, c-format
+msgid "using catalog '%s' from '%s'."
+msgstr "uporabljen je katalog »%s« iz »%s«."
+
+# common/intl.cpp:412
+#: ../src/common/translation.cpp:1816
+#, c-format
+msgid "Resource '%s' is not a valid message catalog."
+msgstr "Vir '%s' ni veljaven katalog sporočil."
+
+# msw/thread.cpp:958
+#: ../src/common/translation.cpp:1865
+msgid "Couldn't enumerate translations"
+msgstr "Prevodov ni mogoče oštevilčiti."
+
+#: ../src/common/utilscmn.cpp:1145
+msgid "No default application configured for HTML files."
+msgstr "Za datoteke HTML ni nastavljen privzeti program."
+
+# generic/dirdlgg.cpp:550
+#: ../src/common/utilscmn.cpp:1190
+#, c-format
+msgid "Failed to open URL \"%s\" in default browser."
+msgstr "URL-ja \"%s\" ni mogoče odpreti v privzetem brskalniku."
+
+# common/valtext.cpp:188
+#: ../src/common/valtext.cpp:144
+msgid "Validation conflict"
+msgstr "Konflikt pri preverjanju"
+
+#: ../src/common/valtext.cpp:186
+msgid "Required information entry is empty."
+msgstr "Vnos z zahtevanimi podatki je prazen."
+
+# common/valtext.cpp:140
+#: ../src/common/valtext.cpp:188
+#, c-format
+msgid "'%s' is one of the invalid strings"
+msgstr "»%s« je neveljavno sporočilo."
+
+# common/intl.cpp:412
+#: ../src/common/valtext.cpp:190
+#, c-format
+msgid "'%s' is not one of the valid strings"
+msgstr "»%s« ni veljavno sporočilo."
+
+# common/valtext.cpp:166
+#: ../src/common/valtext.cpp:199
+#, c-format
+msgid "'%s' contains invalid character(s)"
+msgstr "»%s« vsebuje neveljavne znake"
+
+# common/log.cpp:362
+#: ../src/common/webrequest.cpp:139
+#, c-format
+msgid "Error: %s (%d)"
+msgstr "Napaka: %s (%d)"
+
+#: ../src/common/webrequest.cpp:655
+#, c-format
+msgid ""
+"Not enough free disk space for download: %llu needed but only %llu available."
+msgstr ""
+"Za prenos ni dovolj prostora na disku: zahtevanih je %llu, na voljo je le "
+"%llu."
+
+# generic/dirdlgg.cpp:550
+#: ../src/common/webrequest.cpp:669
+#, c-format
+msgid "Failed to create temporary file in %s"
+msgstr "Začasne datoteke v %s ni mogoče ustvariti"
+
+# common/textcmn.cpp:94
+#: ../src/common/webrequest_curl.cpp:1106
+msgid "libcurl could not be initialized"
+msgstr "libcurl ni bilo mogoče inicializirati"
+
+#: ../src/common/webview.cpp:392
+msgid "RunScriptAsync not supported"
+msgstr "RunScriptAsync ni podprt"
+
+#: ../src/common/webview.cpp:403 ../src/msw/webview_ie.cpp:1073
+#, c-format
+msgid "Error running JavaScript: %s"
+msgstr "Napaka pri izvajanju JavaScripta: %s"
+
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR Free Software Foundation, Inc.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+# msw/registry.cpp:399
+#: ../src/common/webview_chromium.cpp:858
+#, c-format
+msgid "Failed to set proxy \"%s\": %s"
+msgstr "Ni bilo mogoče nastaviti posrednika »%s«: %s"
+
+#: ../src/common/webview_chromium.cpp:989
+msgid ""
+"Chromium can't be used because libcef.so wasn't loaded early enough; please "
+"relink the application or use LD_PRELOAD to load it earlier."
+msgstr ""
+"Chromiuma ni mogoče uporabiti, ker libcef.so ni bil naložen dovolj zgodaj; "
+"ponovno povežite aplikacijo ali uporabite LD_PRELOAD, da jo naložite prej."
+
+# msw/app.cpp:252
+#: ../src/common/webview_chromium.cpp:1108
+msgid "Could not initialize Chromium"
+msgstr "Inicializacija Chrome je spodletela"
+
+#: ../src/common/webview_chromium.cpp:1616
+msgid "Show DevTools"
+msgstr "Pokaži DevTools"
+
+# common/prntbase.cpp:359
+# generic/progdlgg.cpp:307
+# generic/proplist.cpp:518
+#: ../src/common/webview_chromium.cpp:1617
+msgid "Close DevTools"
+msgstr "Zapri DevTools"
+
+#: ../src/common/webview_chromium.cpp:1623
+msgid "Inspect"
+msgstr "Preuči"
+
+#: ../src/common/wincmn.cpp:1628
+msgid "This platform does not support background transparency."
+msgstr "Ta platforma ne podpira prosojnosti ozadja."
+
+# common/wincmn.cpp:784
+#: ../src/common/wincmn.cpp:2097
+msgid "Could not transfer data to window"
+msgstr "Podatkov ni mogoče prenesti v okno."
+
+#: ../src/common/windowid.cpp:240
+msgid "Out of window IDs.  Recommend shutting down application."
+msgstr "Zmanjkalo je ID-jev za okna.  Priporočamo zaprtje programa."
+
+#: ../src/common/xpmdecod.cpp:678
+msgid "XPM: incorrect header format!"
+msgstr "XPM: napačno oblikovana glava!"
+
+#: ../src/common/xpmdecod.cpp:703
+#, c-format
+msgid "XPM: incorrect colour description in line %d"
+msgstr "XPM: napačen opis barve v vrstici %d"
+
+#: ../src/common/xpmdecod.cpp:715 ../src/common/xpmdecod.cpp:724
+#, c-format
+msgid "XPM: malformed colour definition '%s' at line %d!"
+msgstr "XPM: napačno oblikovana definicija barve '%s' v vrstici %d!"
+
+#: ../src/common/xpmdecod.cpp:754
+msgid "XPM: no colors left to use for mask!"
+msgstr "XPM: ni več barv na voljo za masko!"
+
+#: ../src/common/xpmdecod.cpp:781
+#, c-format
+msgid "XPM: truncated image data at line %d!"
+msgstr "XPM: nedokončani podatki slike v vrstici %d!"
+
+#: ../src/common/xpmdecod.cpp:795
+msgid "XPM: Malformed pixel data!"
+msgstr "XPM: napačno oblikovani podatki točk!"
+
+#: ../src/common/xti.cpp:492
+msgid "Illegal Parameter Count for Create Method"
+msgstr "Neveljavno število parametrov za metodo ustvarjanja"
+
+#: ../src/common/xti.cpp:504
+msgid "Illegal Parameter Count for ConstructObject Method"
+msgstr "Neveljavno število parametrov za metodo ConstructObject"
+
+#: ../src/common/xtistrm.cpp:161
+#, c-format
+msgid "Create Parameter %s not found in declared RTTI Parameters"
+msgstr ""
+"V prijavljenih spremenljivkah RTTI ustvarjenega parametra %s ni mogoče najti."
+
+#: ../src/common/xtistrm.cpp:290
+msgid "Illegal Object Class (Non-wxEvtHandler) as Event Source"
+msgstr "Neveljavni razred predmetov (ne wxEvtHandler) kot izvor dogodka."
+
+#: ../src/common/xtistrm.cpp:313 ../src/common/xtixml.cpp:345
+#: ../src/common/xtixml.cpp:498
+msgid "Type must have enum - long conversion"
+msgstr "Tip mora imeti pretvorbo enum - long"
+
+#: ../src/common/xtistrm.cpp:400 ../src/common/xtistrm.cpp:415
+msgid "Invalid or Null Object ID passed to GetObjectClassInfo"
+msgstr "V GetObjectClassInfo podan neveljaven ali ničelni predmetni ID."
+
+#: ../src/common/xtistrm.cpp:405
+msgid "Unknown Object passed to GetObjectClassInfo"
+msgstr "Neznan objekt pripuščen k GetObjectClassInfo"
+
+#: ../src/common/xtistrm.cpp:420
+msgid "Already Registered Object passed to SetObjectClassInfo"
+msgstr "V SetObjectClassInfo je bil podan že registriran predmet."
+
+#: ../src/common/xtistrm.cpp:430
+msgid "Invalid or Null Object ID passed to HasObjectClassInfo"
+msgstr "V HasObjectClassInfo podan neveljaven ali ničelni predmetni ID."
+
+#: ../src/common/xtistrm.cpp:460
+msgid "Passing a already registered object to SetObject"
+msgstr "Podajanje že registriranega objekta k SetObject"
+
+#: ../src/common/xtistrm.cpp:471
+msgid "Passing an unknown object to GetObject"
+msgstr "Podajanje neznanega predmeta k GetObject"
+
+#: ../src/common/xtixml.cpp:229
+msgid "Forward hrefs are not supported"
+msgstr "Naslovi href za preusmerjanje niso podprti."
+
+# common/fontmap.cpp:507
+#: ../src/common/xtixml.cpp:247
+#, c-format
+msgid "unknown class %s"
+msgstr "neznani razred %s"
+
+#: ../src/common/xtixml.cpp:253
+msgid "objects cannot have XML Text Nodes"
+msgstr "objekti ne morejo imeti besedilnih vozlišč XML"
+
+#: ../src/common/xtixml.cpp:258
+msgid "Objects must have an id attribute"
+msgstr "Objekti morajo imeti atribut id"
+
+#: ../src/common/xtixml.cpp:267
+#, c-format
+msgid "Doubly used id : %d"
+msgstr "Dvojno uporabljen id: %d"
+
+# common/cmdline.cpp:518
+#: ../src/common/xtixml.cpp:316
+#, c-format
+msgid "Unknown Property %s"
+msgstr "Neznana lastnost %s"
+
+#: ../src/common/xtixml.cpp:407
+msgid "A non empty collection must consist of 'element' nodes"
+msgstr "Neprazno zbirko morajo tvoriti vozli 'elementov'"
+
+#: ../src/common/xtixml.cpp:478
+msgid "incorrect event handler string, missing dot"
+msgstr "nepravilen niz ročice dogodka, manjka pika"
+
+# html/helpfrm.cpp:1174
+#: ../src/common/zipstrm.cpp:559
+msgid "can't re-initialize zlib deflate stream"
+msgstr "ni mogoče ponovno incializirati upadalnega toka zlib"
+
+# html/helpfrm.cpp:1174
+#: ../src/common/zipstrm.cpp:584
+msgid "can't re-initialize zlib inflate stream"
+msgstr "ni mogoče ponovno incializirati napihovalnega toka zlib"
+
+#: ../src/common/zipstrm.cpp:1023
+msgid "Ignoring malformed extra data record, ZIP file may be corrupted"
+msgstr ""
+"Prezrt neustrezno oblikovan dodatni podatkovni zapis, datoteka ZIP je morda "
+"poškodovana"
+
+#: ../src/common/zipstrm.cpp:1502
+msgid "assuming this is a multi-part zip concatenated"
+msgstr "predvidevajoč, da gre za povezan večdelni zip"
+
+# common/ffile.cpp:101
+#: ../src/common/zipstrm.cpp:1664
+msgid "invalid zip file"
+msgstr "neveljavna datoteka zip"
+
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR Free Software Foundation, Inc.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+# common/ffile.cpp:234
+#: ../src/common/zipstrm.cpp:1723
+msgid "can't find central directory in zip"
+msgstr "ni mogoče najti osrednje mape v datoteki zip"
+
+# generic/dirdlgg.cpp:552
+#: ../src/common/zipstrm.cpp:1812
+msgid "error reading zip central directory"
+msgstr "napaka pri branju osrednje mape zip"
+
+#: ../src/common/zipstrm.cpp:1916
+msgid "error reading zip local header"
+msgstr "napaka pri branju lokalne glave zip"
+
+#: ../src/common/zipstrm.cpp:1964
+msgid "bad zipfile offset to entry"
+msgstr "slab odmik zipfile od vnosa"
+
+#: ../src/common/zipstrm.cpp:2031
+msgid "stored file length not in Zip header"
+msgstr "dolžine shranjene datoteke ni v glavi Zip"
+
+#: ../src/common/zipstrm.cpp:2045 ../src/common/zipstrm.cpp:2362
+msgid "unsupported Zip compression method"
+msgstr "nepodprta metoda stiskanja Zip"
+
+#: ../src/common/zipstrm.cpp:2126
+#, c-format
+msgid "reading zip stream (entry %s): bad length"
+msgstr "branje toka zip (vnos %s): napačna dolžina"
+
+#: ../src/common/zipstrm.cpp:2131
+#, c-format
+msgid "reading zip stream (entry %s): bad crc"
+msgstr "branje toka zip (vnos %s): napačen crc"
+
+#: ../src/common/zipstrm.cpp:2578
+#, c-format
+msgid "error writing zip entry '%s': file too large without ZIP64"
+msgstr "napaka pri pisanju vnosa zip »%s«: datoteka prevelika brez ZIP64"
+
+#: ../src/common/zipstrm.cpp:2585
+#, c-format
+msgid "error writing zip entry '%s': bad crc or length"
+msgstr "napaka pri pisanju vnosa zip '%s': slab crc ali dolžina"
+
+#: ../src/common/zstream.cpp:155 ../src/common/zstream.cpp:315
+msgid "Gzip not supported by this version of zlib"
+msgstr "Ta različica zlib ne podpira Gzip"
+
+# html/helpfrm.cpp:1174
+#: ../src/common/zstream.cpp:182
+msgid "Can't initialize zlib inflate stream."
+msgstr "Ni mogoče inicializirati napihovalnega toka zlib."
+
+#: ../src/common/zstream.cpp:241
+msgid "Can't read inflate stream: unexpected EOF in underlying stream."
+msgstr "Branje napihovalnega toka ni uspelo: nepričakovan EOF v osnovnem toku."
+
+# common/log.cpp:242
+#: ../src/common/zstream.cpp:248 ../src/common/zstream.cpp:423
+#, c-format
+msgid "zlib error %d"
+msgstr "napaka zlib %d"
+
+# common/file.cpp:285
+#: ../src/common/zstream.cpp:249
+#, c-format
+msgid "Can't read from inflate stream: %s"
+msgstr "Branje iz napihovalnega toka ni možno: %s"
+
+# html/helpfrm.cpp:1174
+#: ../src/common/zstream.cpp:343
+msgid "Can't initialize zlib deflate stream."
+msgstr "Ni mogoče inicializirati upadalnega toka zlib."
+
+# common/file.cpp:304
+#: ../src/common/zstream.cpp:424
+#, c-format
+msgid "Can't write to deflate stream: %s"
+msgstr "Pisanje v upadalni tok ni možno: %s"
+
+# common/image.cpp:766
+# common/image.cpp:800
+#: ../src/dfb/bitmap.cpp:633 ../src/dfb/bitmap.cpp:667
+#, c-format
+msgid "No bitmap handler for type %d defined."
+msgstr "Za bitne slike vrste %d ni določen noben upravljalec slik."
+
+#: ../src/dfb/evtloop.cpp:99
+msgid "Failed to read event from DirectFB pipe"
+msgstr "Branje dogodka iz cevi DirectFB je spodletelo."
+
+#: ../src/dfb/evtloop.cpp:171
+msgid "Failed to switch DirectFB pipe to non-blocking mode"
+msgstr "Preklop cevi DirectFB v neblokirani način ni uspel"
+
+#: ../src/dfb/fontmgr.cpp:171
+#, c-format
+msgid "no fonts found in %s, using builtin font"
+msgstr "v %s ni najdenih pisav, uporabljena bo vgrajena pisava"
+
+#: ../src/dfb/fontmgr.cpp:177
+msgid "Default font"
+msgstr "Privzeta pisava"
+
+#: ../src/dfb/fontmgr.cpp:195
+#, c-format
+msgid "Fonts index file %s disappeared while loading fonts."
+msgstr "Pri nalaganju pisav je datoteka kazala pisav %s izginila."
+
+#: ../src/dfb/wrapdfb.cpp:60
+#, c-format
+msgid "DirectFB error %d occurred."
+msgstr "Pojavila se je napaka DirectFB %d."
+
+#: ../src/generic/aboutdlgg.cpp:69
+msgid "Developed by "
+msgstr "Razvijalci"
+
+#: ../src/generic/aboutdlgg.cpp:72
+msgid "Documentation by "
+msgstr "Avtor dokumentacije "
+
+#: ../src/generic/aboutdlgg.cpp:75
+msgid "Graphics art by "
+msgstr "Avtor grafik "
+
+#: ../src/generic/aboutdlgg.cpp:78
+msgid "Translations by "
+msgstr "Prevajalci"
+
+#: ../src/generic/aboutdlgg.cpp:133 ../src/osx/cocoa/aboutdlg.mm:83
+msgid "Version "
+msgstr "Različica "
+
+#. TRANSLATORS: %s is application name
+#: ../src/generic/aboutdlgg.cpp:146 ../src/msw/aboutdlg.cpp:60
+#, c-format
+msgid "About %s"
+msgstr "O programu %s ..."
+
+#: ../src/generic/aboutdlgg.cpp:181
+msgid "License"
+msgstr "Licenca"
+
+#: ../src/generic/aboutdlgg.cpp:184
+msgid "Developers"
+msgstr "Razvijalci"
+
+#: ../src/generic/aboutdlgg.cpp:188
+msgid "Documentation writers"
+msgstr "Avtorji dokumentacije "
+
+#: ../src/generic/aboutdlgg.cpp:192
+msgid "Artists"
+msgstr "Oblikovalci"
+
+#: ../src/generic/aboutdlgg.cpp:196
+msgid "Translators"
+msgstr "Prevajalci"
+
+# common/image.cpp:758
+#: ../src/generic/animateg.cpp:125
+msgid "No handler found for animation type."
+msgstr "Upravljalca za vrsto animacije ni mogoče najti."
+
+# common/image.cpp:766
+# common/image.cpp:800
+#: ../src/generic/animateg.cpp:133
+#, c-format
+msgid "No animation handler for type %ld defined."
+msgstr "Ta vrsto %ld ni določen noben upravljavec animacije."
+
+#: ../src/generic/animateg.cpp:145
+#, c-format
+msgid "Animation file is not of type %ld."
+msgstr "Datoteka animacije ni vrste %ld."
+
+#: ../src/generic/colrdlgg.cpp:154 ../src/gtk/colordlg.cpp:47
+msgid "Choose colour"
+msgstr "Izberite barvo"
+
+#: ../src/generic/colrdlgg.cpp:357
+msgid "Red:"
+msgstr "Rdeča:"
+
+#: ../src/generic/colrdlgg.cpp:360
+msgid "Green:"
+msgstr "Zelena:"
+
+#: ../src/generic/colrdlgg.cpp:363
+msgid "Blue:"
+msgstr "Modra:"
+
+#: ../src/generic/colrdlgg.cpp:372
+msgid "Opacity:"
+msgstr "Prekrivnost:"
+
+# generic/colrdlgg.cpp:269
+#: ../src/generic/colrdlgg.cpp:384
+msgid "Add to custom colours"
+msgstr "Dodaj k predelanim barvam"
+
+#: ../src/generic/creddlgg.cpp:56
+msgid "Username:"
+msgstr "Uporabniško ime:"
+
+#: ../src/generic/creddlgg.cpp:63
+msgid "Password:"
+msgstr "Geslo:"
+
+#. TRANSLATORS: Name of Boolean true value
+#: ../src/generic/datavgen.cpp:1178
+msgid "true"
+msgstr "je resnično"
+
+# generic/filedlgg.cpp:534
+#. TRANSLATORS: Name of Boolean false value
+#: ../src/generic/datavgen.cpp:1180
+msgid "false"
+msgstr "ni resnično"
+
+#: ../src/generic/datavgen.cpp:6897
+#, c-format
+msgid "Row %i"
+msgstr "Vrstica %i"
+
+#. TRANSLATORS: Action for manipulating a tree control
+#: ../src/generic/datavgen.cpp:6987
+msgid "Collapse"
+msgstr "Strni"
+
+#. TRANSLATORS: Action for manipulating a tree control
+#: ../src/generic/datavgen.cpp:6990
+msgid "Expand"
+msgstr "Razpostri"
+
+# common/cmdline.cpp:735
+#. TRANSLATORS: Name of data view control and number of rows
+#: ../src/generic/datavgen.cpp:7011
+#, c-format
+msgid "%s (%d items)"
+msgstr "%s (%d elementov)"
+
+#: ../src/generic/datavgen.cpp:7062
+#, c-format
+msgid "Column %u"
+msgstr "Stolpec %u"
+
+#. TRANSLATORS: Keystroke for manipulating a tree control
+#: ../src/generic/datavgen.cpp:7131 ../src/richtext/richtextbulletspage.cpp:189
+#: ../src/richtext/richtextbulletspage.cpp:192
+#: ../src/richtext/richtextbulletspage.cpp:193
+#: ../src/richtext/richtextliststylepage.cpp:252
+#: ../src/richtext/richtextliststylepage.cpp:255
+#: ../src/richtext/richtextliststylepage.cpp:256
+#: ../src/richtext/richtextsizepage.cpp:248
+msgid "Left"
+msgstr "Levo"
+
+# generic/fontdlgg.cpp:216
+#. TRANSLATORS: Keystroke for manipulating a tree control
+#: ../src/generic/datavgen.cpp:7134 ../src/richtext/richtextbulletspage.cpp:191
+#: ../src/richtext/richtextliststylepage.cpp:254
+#: ../src/richtext/richtextsizepage.cpp:249
+msgid "Right"
+msgstr "Desno"
+
+#: ../src/generic/datectlg.cpp:90
+#, c-format
+msgid ""
+"\"%s\" is not in the expected date format, please enter it as e.g. \"%s\"."
+msgstr "»%s« ni v pričakovani datumski obliki, vnesite ga kot npr. »%s«."
+
+# common/imagpcx.cpp:470
+#: ../src/generic/datectlg.cpp:94
+msgid "Invalid date"
+msgstr "Neveljaven datum"
+
+#: ../src/generic/dbgrptg.cpp:159
+#, c-format
+msgid "Open file \"%s\""
+msgstr "Odpri datoteko \"%s\""
+
+# common/ffile.cpp:85
+# common/file.cpp:243
+#: ../src/generic/dbgrptg.cpp:170
+#, c-format
+msgid "Enter command to open file \"%s\":"
+msgstr "Vnesite ukaz za odprtje datoteke \"%s\":"
+
+#: ../src/generic/dbgrptg.cpp:230
+msgid "Executable files (*.exe)|*.exe|"
+msgstr "Izvršljive datoteke (*.exe)|*.exe|"
+
+#: ../src/generic/dbgrptg.cpp:300
+#, c-format
+msgid "Debug report \"%s\""
+msgstr "Poročilo o razhroščevanju \"%s\""
+
+#: ../src/generic/dbgrptg.cpp:316
+msgid "A debug report has been generated in the directory\n"
+msgstr "Poročilo o razhroščevanju je bilo ustvarjeno v mapi\n"
+
+#: ../src/generic/dbgrptg.cpp:317
+msgid "The following debug report will be generated\n"
+msgstr "Izdelano bo naslednje poročilo o napakah za razhroščevanje\n"
+
+#: ../src/generic/dbgrptg.cpp:321
+msgid ""
+"The report contains the files listed below. If any of these files contain "
+"private information,\n"
+"please uncheck them and they will be removed from the report.\n"
+msgstr ""
+"Poročilo vsebuje datoteke, navedene spodaj. Če katere od teh datotek "
+"vsebujejo zasebne podatke,\n"
+"jih, prosimo, odznačite in odstranjene bodo iz poročila.\n"
+
+#: ../src/generic/dbgrptg.cpp:323
+msgid ""
+"If you wish to suppress this debug report completely, please choose the "
+"\"Cancel\" button,\n"
+"but be warned that it may hinder improving the program, so if\n"
+"at all possible please do continue with the report generation.\n"
+msgstr ""
+"Če želite popolnoma preprečiti to poročilo o razhroščevanju, prosimo, "
+"izberite gumb \"Razveljavi\",\n"
+"vendar vedite, da to lahko onemogoča izboljšanje programa, tako da če je\n"
+"le mogoče, prosimo, nadaljujte s tvorbo poročila.\n"
+
+#: ../src/generic/dbgrptg.cpp:325
+msgid "              Thank you and we're sorry for the inconvenience!\n"
+msgstr "              Hvala lepa, za nevšečnosti se opravičujemo!\n"
+
+#: ../src/generic/dbgrptg.cpp:333
+msgid "&Debug report preview:"
+msgstr "&Predogled poročila o razhroščevanju:"
+
+# generic/logg.cpp:473
+# generic/logg.cpp:774
+#: ../src/generic/dbgrptg.cpp:339
+msgid "&View..."
+msgstr "&Pogled ..."
+
+#: ../src/generic/dbgrptg.cpp:359
+msgid "&Notes:"
+msgstr "&Opombe:"
+
+#: ../src/generic/dbgrptg.cpp:361
+msgid ""
+"If you have any additional information pertaining to this bug\n"
+"report, please enter it here and it will be joined to it:"
+msgstr ""
+"Če imate kakšne dodatne podatke glede tega poročila o\n"
+"razhroščevanju, jih, prosimo, tukaj vnesite in priloženi bodo poročilu:"
+
+# generic/dcpsg.cpp:1584
+#: ../src/generic/dcpsg.cpp:1627
+msgid "Cannot open file for PostScript printing!"
+msgstr "Datoteke za tiskanje PostScript ni mogoče odpreti!"
+
+# generic/dirdlgg.cpp:210
+#: ../src/generic/dirctrlg.cpp:402
+msgid "Computer"
+msgstr "Računalnik"
+
+# generic/dirdlgg.cpp:191
+#: ../src/generic/dirctrlg.cpp:404
+msgid "Sections"
+msgstr "Razdelki"
+
+# generic/dirdlgg.cpp:536
+#: ../src/generic/dirctrlg.cpp:482
+msgid "Home directory"
+msgstr "Domača mapa"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/generic/dirctrlg.cpp:484 ../src/propgrid/advprops.cpp:811
+msgid "Desktop"
+msgstr "Namizje"
+
+# generic/dirdlgg.cpp:268
+# generic/filedlgg.cpp:717
+#: ../src/generic/dirctrlg.cpp:528 ../src/generic/filectrlg.cpp:752
+msgid "Illegal directory name."
+msgstr "Neveljavno ime mape."
+
+# generic/dirdlgg.cpp:268
+# generic/dirdlgg.cpp:286
+# generic/dirdlgg.cpp:297
+# generic/dirdlgg.cpp:605
+# generic/filedlgg.cpp:625
+# generic/filedlgg.cpp:717
+# generic/filedlgg.cpp:731
+# generic/filedlgg.cpp:744
+# generic/filedlgg.cpp:1043
+# generic/filedlgg.cpp:1092
+# generic/helpxlp.cpp:241
+#: ../src/generic/dirctrlg.cpp:528 ../src/generic/dirctrlg.cpp:546
+#: ../src/generic/dirctrlg.cpp:557 ../src/generic/dirdlgg.cpp:317
+#: ../src/generic/filectrlg.cpp:638 ../src/generic/filectrlg.cpp:752
+#: ../src/generic/filectrlg.cpp:766 ../src/generic/filectrlg.cpp:782
+#: ../src/generic/filectrlg.cpp:1356 ../src/generic/filectrlg.cpp:1387
+#: ../src/generic/filedlgg.cpp:362 ../src/gtk/filedlg.cpp:76
+msgid "Error"
+msgstr "Napaka"
+
+# generic/dirdlgg.cpp:286
+# generic/filedlgg.cpp:731
+#: ../src/generic/dirctrlg.cpp:546 ../src/generic/filectrlg.cpp:766
+msgid "File name exists already."
+msgstr "Ime datoteke že obstaja."
+
+# generic/dirdlgg.cpp:297
+# generic/dirdlgg.cpp:605
+# generic/filedlgg.cpp:625
+# generic/filedlgg.cpp:744
+#: ../src/generic/dirctrlg.cpp:557 ../src/generic/dirdlgg.cpp:317
+#: ../src/generic/filectrlg.cpp:638 ../src/generic/filectrlg.cpp:782
+msgid "Operation not permitted."
+msgstr "Operacija ni dovoljena."
+
+# generic/filedlgg.cpp:883
+#: ../src/generic/dirdlgg.cpp:107 ../src/generic/filedlgg.cpp:207
+msgid "Create new directory"
+msgstr "Ustvari novo mapo"
+
+# generic/filedlgg.cpp:875
+#: ../src/generic/dirdlgg.cpp:112 ../src/generic/filedlgg.cpp:203
+msgid "Go to home directory"
+msgstr "Pojdi v domačo mapo"
+
+# generic/filedlgg.cpp:913
+#: ../src/generic/dirdlgg.cpp:143
+msgid "Show &hidden directories"
+msgstr "Pokaži skrite &mape"
+
+# generic/dirdlgg.cpp:538
+#: ../src/generic/dirdlgg.cpp:196
+#, c-format
+msgid ""
+"The directory '%s' does not exist\n"
+"Create it now?"
+msgstr ""
+"Mapa '%s' ne obstaja.\n"
+"Jo želite ustvariti?"
+
+# generic/dirdlgg.cpp:539
+#: ../src/generic/dirdlgg.cpp:198
+msgid "Directory does not exist"
+msgstr "Mapa ne obstaja"
+
+# generic/dirdlgg.cpp:551
+#: ../src/generic/dirdlgg.cpp:214
+#, c-format
+msgid ""
+"Failed to create directory '%s'\n"
+"(Do you have the required permissions?)"
+msgstr ""
+"Mape '%s' ni mogoče ustvariti.\n"
+"(Ali imate potrebna dovoljenja?)"
+
+# generic/dirdlgg.cpp:552
+#: ../src/generic/dirdlgg.cpp:216
+msgid "Error creating directory"
+msgstr "Napaka pri ustvarjanju mape"
+
+# generic/dirdlgg.cpp:571
+#: ../src/generic/dirdlgg.cpp:281
+msgid "You cannot add a new directory to this section."
+msgstr "Ne morete dodati nove mape v ta del."
+
+# generic/dirdlgg.cpp:572
+#: ../src/generic/dirdlgg.cpp:282
+msgid "Create directory"
+msgstr "Ustvari mapo"
+
+# generic/filedlgg.cpp:610
+#: ../src/generic/dirdlgg.cpp:291 ../src/generic/dirdlgg.cpp:301
+#: ../src/generic/filectrlg.cpp:614 ../src/generic/filectrlg.cpp:623
+msgid "NewName"
+msgstr "NovoIme"
+
+#: ../src/generic/editlbox.cpp:135
+msgid "Edit item"
+msgstr "Uredi element"
+
+#: ../src/generic/editlbox.cpp:143
+msgid "New item"
+msgstr "Nov element"
+
+#: ../src/generic/editlbox.cpp:151
+msgid "Delete item"
+msgstr "Izbriši element"
+
+#: ../src/generic/editlbox.cpp:159
+msgid "Move up"
+msgstr "Premakni navzgor"
+
+#: ../src/generic/editlbox.cpp:164
+msgid "Move down"
+msgstr "Premakni navzdol"
+
+# generic/helpwxht.cpp:161
+# html/helpfrm.cpp:414
+# html/helpfrm.cpp:434
+#: ../src/generic/fdrepdlg.cpp:108
+msgid "Search for:"
+msgstr "Najdi:"
+
+#: ../src/generic/fdrepdlg.cpp:120
+msgid "Replace with:"
+msgstr "Zamenjaj z:"
+
+# html/helpfrm.cpp:406
+#: ../src/generic/fdrepdlg.cpp:140
+msgid "Whole word"
+msgstr "Cela beseda"
+
+#: ../src/generic/fdrepdlg.cpp:143
+msgid "Match case"
+msgstr "Ujemanje velikosti črk"
+
+# generic/dirdlgg.cpp:572
+#: ../src/generic/fdrepdlg.cpp:156
+msgid "Search direction"
+msgstr "Smer iskanja"
+
+#: ../src/generic/fdrepdlg.cpp:175
+msgid "&Replace"
+msgstr "&Zamenjaj"
+
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR Free Software Foundation, Inc.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+# msw/filedlg.cpp:445
+#: ../src/generic/fdrepdlg.cpp:178
+msgid "Replace &all"
+msgstr "Zamenjaj &vse"
+
+# generic/filedlgg.cpp:356
+#: ../src/generic/filectrlg.cpp:246 ../src/generic/filectrlg.cpp:269
+msgid "<DIR>"
+msgstr "<MAPA>"
+
+# generic/filedlgg.cpp:357
+#: ../src/generic/filectrlg.cpp:248 ../src/generic/filectrlg.cpp:271
+msgid "<LINK>"
+msgstr "<POVEZAVA>"
+
+# generic/filedlgg.cpp:356
+#: ../src/generic/filectrlg.cpp:250 ../src/generic/filectrlg.cpp:273
+msgid "<DRIVE>"
+msgstr "<POGON>"
+
+# generic/filedlgg.cpp:328
+#: ../src/generic/filectrlg.cpp:275
+#, c-format
+msgid "%ld byte"
+msgid_plural "%ld bytes"
+msgstr[0] "%ld bajtov"
+msgstr[1] "%ld bajtov"
+msgstr[2] "%ld bajtov"
+msgstr[3] "%ld bajtov"
+
+# generic/filedlgg.cpp:533
+#: ../src/generic/filectrlg.cpp:420
+msgid "Name"
+msgstr "Ime"
+
+# generic/filedlgg.cpp:534
+#: ../src/generic/filectrlg.cpp:421 ../src/richtext/richtextformatdlg.cpp:361
+#: ../src/richtext/richtextsizepage.cpp:298
+msgid "Size"
+msgstr "Velikost"
+
+#: ../src/generic/filectrlg.cpp:422
+msgid "Type"
+msgstr "Vrsta"
+
+#: ../src/generic/filectrlg.cpp:423
+msgid "Modified"
+msgstr "Spremenjeno"
+
+# generic/filedlgg.cpp:537
+#: ../src/generic/filectrlg.cpp:426
+msgid "Permissions"
+msgstr "Dovoljenja"
+
+#: ../src/generic/filectrlg.cpp:429
+msgid "Attributes"
+msgstr "Atributi"
+
+# generic/filedlgg.cpp:890
+#: ../src/generic/filectrlg.cpp:936
+msgid "Current directory:"
+msgstr "Trenutna mapa:"
+
+# generic/filedlgg.cpp:913
+#: ../src/generic/filectrlg.cpp:979
+msgid "Show &hidden files"
+msgstr "Pokaži skrite &datoteke"
+
+# generic/filedlgg.cpp:1043
+#: ../src/generic/filectrlg.cpp:1355
+msgid "Illegal file specification."
+msgstr "Napačna specifikacija datoteke"
+
+# generic/dirdlgg.cpp:539
+#: ../src/generic/filectrlg.cpp:1387
+msgid "Directory doesn't exist."
+msgstr "Mapa ne obstaja."
+
+# generic/filedlgg.cpp:855
+#: ../src/generic/filedlgg.cpp:195
+msgid "View files as a list view"
+msgstr "Prikaži datoteke kot seznam"
+
+# generic/filedlgg.cpp:861
+#: ../src/generic/filedlgg.cpp:197
+msgid "View files as a detailed view"
+msgstr "Prikaži datoteke s podrobnostmi"
+
+# generic/filedlgg.cpp:869
+#: ../src/generic/filedlgg.cpp:200
+msgid "Go to parent directory"
+msgstr "Pojdi v starševsko mapo"
+
+# generic/filedlgg.cpp:1074
+#: ../src/generic/filedlgg.cpp:351 ../src/gtk/filedlg.cpp:59
+#, c-format
+msgid "File '%s' already exists, do you really want to overwrite it?"
+msgstr "Datoteka %s že obstaja, jo resnično želite prepisati?"
+
+# generic/filedlgg.cpp:1077
+#: ../src/generic/filedlgg.cpp:354 ../src/gtk/filedlg.cpp:62
+msgid "Confirm"
+msgstr "Potrdi"
+
+# generic/filedlgg.cpp:1092
+#: ../src/generic/filedlgg.cpp:362 ../src/gtk/filedlg.cpp:75
+msgid "Please choose an existing file."
+msgstr "Prosimo, izberite obstoječo datoteko."
+
+#: ../src/generic/filepickerg.cpp:64
+msgid "..."
+msgstr "..."
+
+# generic/fontdlgg.cpp:325
+#: ../src/generic/fontdlgg.cpp:76 ../src/richtext/richtextformatdlg.cpp:519
+msgid "ABCDEFGabcdefg12345"
+msgstr "Ščinkavec želi 12345 češenj."
+
+# generic/fontdlgg.cpp:206
+#: ../src/generic/fontdlgg.cpp:315
+msgid "Roman"
+msgstr "serifna"
+
+# generic/fontdlgg.cpp:207
+#: ../src/generic/fontdlgg.cpp:316
+msgid "Decorative"
+msgstr "Okrasno"
+
+# generic/fontdlgg.cpp:208
+#: ../src/generic/fontdlgg.cpp:317
+msgid "Modern"
+msgstr "Sodobno"
+
+# generic/fontdlgg.cpp:209
+#: ../src/generic/fontdlgg.cpp:318
+msgid "Script"
+msgstr "Skript"
+
+# generic/fontdlgg.cpp:210
+#: ../src/generic/fontdlgg.cpp:319
+msgid "Swiss"
+msgstr "neserifna"
+
+# generic/fontdlgg.cpp:211
+#: ../src/generic/fontdlgg.cpp:320
+msgid "Teletype"
+msgstr "strojna"
+
+# generic/fontdlgg.cpp:212
+# generic/fontdlgg.cpp:215
+#: ../src/generic/fontdlgg.cpp:321 ../src/generic/fontdlgg.cpp:324
+msgid "Normal"
+msgstr "Običajno"
+
+# generic/fontdlgg.cpp:214
+#: ../src/generic/fontdlgg.cpp:323
+msgid "Slant"
+msgstr "Levo kurzivno"
+
+# generic/fontdlgg.cpp:216
+#: ../src/generic/fontdlgg.cpp:325
+msgid "Light"
+msgstr "Svetlo"
+
+# html/helpfrm.cpp:899
+#: ../src/generic/fontdlgg.cpp:363
+msgid "&Font family:"
+msgstr "&Družina pisave:"
+
+#: ../src/generic/fontdlgg.cpp:367 ../src/generic/fontdlgg.cpp:369
+msgid "The font family."
+msgstr "Družina pisave."
+
+#: ../src/generic/fontdlgg.cpp:374 ../src/richtext/richtextstylepage.cpp:105
+msgid "&Style:"
+msgstr "&Slog:"
+
+#: ../src/generic/fontdlgg.cpp:378 ../src/generic/fontdlgg.cpp:380
+msgid "The font style."
+msgstr "Slog pisave."
+
+# generic/fontdlgg.cpp:216
+#: ../src/generic/fontdlgg.cpp:385
+msgid "&Weight:"
+msgstr "&Debelina:"
+
+#: ../src/generic/fontdlgg.cpp:389 ../src/generic/fontdlgg.cpp:391
+msgid "The font weight."
+msgstr "Odebeljenost pisave."
+
+#: ../src/generic/fontdlgg.cpp:399
+msgid "C&olour:"
+msgstr "&Barva:"
+
+#: ../src/generic/fontdlgg.cpp:407 ../src/generic/fontdlgg.cpp:409
+msgid "The font colour."
+msgstr "Barva pisave."
+
+# html/helpfrm.cpp:899
+#: ../src/generic/fontdlgg.cpp:415
+msgid "&Point size:"
+msgstr "&Velikost pisave:"
+
+# html/helpfrm.cpp:899
+#: ../src/generic/fontdlgg.cpp:420 ../src/generic/fontdlgg.cpp:422
+#: ../src/generic/fontdlgg.cpp:426 ../src/generic/fontdlgg.cpp:428
+msgid "The font point size."
+msgstr "Velikost pisave."
+
+#: ../src/generic/fontdlgg.cpp:439 ../src/generic/fontdlgg.cpp:441
+msgid "Whether the font is underlined."
+msgstr "Če je pisava podčrtana ali ne."
+
+# html/helpfrm.cpp:903
+#: ../src/generic/fontdlgg.cpp:448 ../src/html/helpwnd.cpp:1215
+msgid "Preview:"
+msgstr "Predogled:"
+
+#: ../src/generic/fontdlgg.cpp:452 ../src/generic/fontdlgg.cpp:454
+msgid "Shows the font preview."
+msgstr "Prikaže predogled pisave."
+
+#: ../src/generic/fontdlgg.cpp:464 ../src/generic/fontdlgg.cpp:483
+msgid "Click to cancel the font selection."
+msgstr "Kliknite za preklic izbire pisave."
+
+#: ../src/generic/fontdlgg.cpp:469 ../src/generic/fontdlgg.cpp:471
+#: ../src/generic/fontdlgg.cpp:476 ../src/generic/fontdlgg.cpp:478
+msgid "Click to confirm the font selection."
+msgstr "Kliknite za potrditev izbire pisave."
+
+#: ../src/generic/fontpickerg.cpp:50 ../src/gtk/fontdlg.cpp:77
+msgid "Choose font"
+msgstr "Izberite pisavo"
+
+#: ../src/generic/grid.cpp:6542
+msgid ""
+"Error copying grid to the clipboard. Either selected cells were not "
+"contiguous or no cell was selected."
+msgstr ""
+"Napaka pri kopiranju mreže v odložišče. Izbrane celice niso bile sosednje "
+"ali pa ni bila izbrana nobena celica."
+
+#: ../src/generic/grid.cpp:12739
+msgid "Grid Corner"
+msgstr "Oglišče mreže"
+
+#: ../src/generic/grid.cpp:12741
+#, c-format
+msgid "Column %s Header"
+msgstr "Glava stolpca %s"
+
+#: ../src/generic/grid.cpp:12743
+#, c-format
+msgid "Row %s Header"
+msgstr "Glava vrstice %s"
+
+#: ../src/generic/grid.cpp:12745
+#, c-format
+msgid "Column %s: %s"
+msgstr "Stolpec %s: %s"
+
+#: ../src/generic/grid.cpp:12749
+#, c-format
+msgid "Row %s: %s"
+msgstr "Vrstica %s: %s"
+
+#: ../src/generic/grid.cpp:12753
+#, c-format
+msgid "Row %s, Column %s: %s"
+msgstr "Vrstica %s, stolpec %s: %s"
+
+#: ../src/generic/helpext.cpp:257
+#, c-format
+msgid "Help directory \"%s\" not found."
+msgstr "Mape pomoči \"%s\" ni mogoče najti."
+
+# common/intl.cpp:374
+#: ../src/generic/helpext.cpp:265
+#, c-format
+msgid "Help file \"%s\" not found."
+msgstr "Datoteke pomoči \"%s\" ni mogoče najti."
+
+#: ../src/generic/helpext.cpp:284
+#, c-format
+msgid "Line %lu of map file \"%s\" has invalid syntax, skipped."
+msgstr "Vrstica %lu datoteke \"%s\" ima neveljavno skladnjo; preskočeno."
+
+#: ../src/generic/helpext.cpp:292
+#, c-format
+msgid "No valid mappings found in the file \"%s\"."
+msgstr "Ni veljavnih preslikav v datoteki \"%s\"."
+
+# generic/helphtml.cpp:314
+#: ../src/generic/helpext.cpp:435
+msgid "No entries found."
+msgstr "Vnosa ni mogoče najti."
+
+# generic/helphtml.cpp:319
+# generic/helphtml.cpp:320
+#: ../src/generic/helpext.cpp:444 ../src/generic/helpext.cpp:445
+msgid "Help Index"
+msgstr "Indeks pomoči"
+
+# generic/helphtml.cpp:319
+#: ../src/generic/helpext.cpp:448
+msgid "Relevant entries:"
+msgstr "Ustrezni naslovi:"
+
+# generic/helphtml.cpp:320
+#: ../src/generic/helpext.cpp:449
+msgid "Entries found"
+msgstr "Najdeni vnosi"
+
+#: ../src/generic/hyperlinkg.cpp:170
+msgid "&Copy URL"
+msgstr "&Kopiraj URL"
+
+#: ../src/generic/infobar.cpp:119
+msgid "Hide this notification message."
+msgstr "Skrij to obvestilo."
+
+# generic/logg.cpp:243
+#. TRANSLATORS: %s will be either the application name or "Application"
+#: ../src/generic/logg.cpp:257
+#, c-format
+msgid "%s Error"
+msgstr "Napaka %s"
+
+# generic/logg.cpp:247
+#. TRANSLATORS: %s will be either the application name or "Application"
+#: ../src/generic/logg.cpp:263
+#, c-format
+msgid "%s Warning"
+msgstr "Opozorilo %s"
+
+# generic/logg.cpp:251
+#. TRANSLATORS: %s will be either the application name or "Application"
+#: ../src/generic/logg.cpp:273
+#, c-format
+msgid "%s Information"
+msgstr "Informacija %s"
+
+# generic/dirdlgg.cpp:191
+#: ../src/generic/logg.cpp:276
+msgid "Application"
+msgstr "Program"
+
+# generic/logg.cpp:473
+#: ../src/generic/logg.cpp:549
+msgid "Save log contents to file"
+msgstr "Shrani vsebino dnevnika v datoteko"
+
+# generic/logg.cpp:475
+#: ../src/generic/logg.cpp:551
+msgid "C&lear"
+msgstr "&Izprazni"
+
+# generic/logg.cpp:475
+#: ../src/generic/logg.cpp:551
+msgid "Clear the log contents"
+msgstr "Izprazni vsebino dnevnika"
+
+# generic/logg.cpp:477
+#: ../src/generic/logg.cpp:553
+msgid "Close this window"
+msgstr "Zapri to okno"
+
+# generic/logg.cpp:478
+#: ../src/generic/logg.cpp:554
+msgid "&Log"
+msgstr "&Dnevnik"
+
+# generic/logg.cpp:535
+# generic/logg.cpp:932
+#: ../src/generic/logg.cpp:610 ../src/generic/logg.cpp:992
+msgid "Can't save log contents to file."
+msgstr "Vsebine dnevnika ni mogoče shraniti v datoteko."
+
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR Free Software Foundation, Inc.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+# generic/logg.cpp:538
+#: ../src/generic/logg.cpp:613
+#, c-format
+msgid "Log saved to the file '%s'."
+msgstr "Dnevnik je bil shranjen v datoteko »%s«."
+
+#: ../src/generic/logg.cpp:719
+msgid "&Details"
+msgstr "&Podrobnosti"
+
+# msw/clipbrd.cpp:102
+#: ../src/generic/logg.cpp:972
+msgid "Failed to copy dialog contents to the clipboard."
+msgstr "Vsebine pogovornega okna ni mogoče kopirati na odložišče."
+
+# generic/logg.cpp:1021
+#: ../src/generic/logg.cpp:1022
+#, c-format
+msgid "Append log to file '%s' (choosing [No] will overwrite it)?"
+msgstr ""
+"Želite dopisati dnevnik v datoteko »%s« (izbira [Ne] povzroči prepis "
+"datoteke)?"
+
+# generic/logg.cpp:1023
+#: ../src/generic/logg.cpp:1024
+msgid "Question"
+msgstr "Vprašanje"
+
+# generic/logg.cpp:1037
+#: ../src/generic/logg.cpp:1038
+msgid "invalid message box return value"
+msgstr "napačna vrnjena vrednost sporočilnega okna"
+
+#: ../src/generic/notifmsgg.cpp:129
+msgid "Notice"
+msgstr "Obvestilo"
+
+#: ../src/generic/preferencesg.cpp:118
+#, c-format
+msgid "%s Preferences"
+msgstr "Možnosti %s"
+
+# generic/printps.cpp:192
+#: ../src/generic/printps.cpp:143
+msgid "Printing..."
+msgstr "Tiskanje ..."
+
+# generic/printps.cpp:209
+# msw/printwin.cpp:252
+#: ../src/generic/printps.cpp:160 ../src/gtk/print.cpp:1076
+#: ../src/msw/printwin.cpp:235
+msgid "Could not start printing."
+msgstr "Tiskanja ni mogoče pognati."
+
+# generic/printps.cpp:232
+#: ../src/generic/printps.cpp:183
+#, c-format
+msgid "Printing page %d..."
+msgstr "Tiskanje strani %d ..."
+
+# generic/prntdlgg.cpp:149
+#: ../src/generic/prntdlgg.cpp:171
+msgid "Printer options"
+msgstr "Možnosti tiskalnika"
+
+# generic/dcpsg.cpp:2265
+# generic/prntdlgg.cpp:150
+#: ../src/generic/prntdlgg.cpp:176
+msgid "Print to File"
+msgstr "Pošli v datoteko"
+
+# generic/prntdlgg.cpp:155
+#: ../src/generic/prntdlgg.cpp:179
+msgid "Setup..."
+msgstr "Nastavitve ..."
+
+# generic/prntdlgg.cpp:682
+#: ../src/generic/prntdlgg.cpp:187
+msgid "Printer:"
+msgstr "Tiskalnik:"
+
+# generic/logg.cpp:598
+#: ../src/generic/prntdlgg.cpp:195
+msgid "Status:"
+msgstr "Stanje:"
+
+# generic/prntdlgg.cpp:163
+#: ../src/generic/prntdlgg.cpp:206
+msgid "All"
+msgstr "Vse"
+
+# generic/prntdlgg.cpp:164
+#: ../src/generic/prntdlgg.cpp:207
+msgid "Pages"
+msgstr "Strani"
+
+# generic/prntdlgg.cpp:172
+#: ../src/generic/prntdlgg.cpp:215
+msgid "Print Range"
+msgstr "Obseg tiskanja"
+
+# generic/prntdlgg.cpp:187
+#: ../src/generic/prntdlgg.cpp:229
+msgid "From:"
+msgstr "Od:"
+
+# generic/prntdlgg.cpp:191
+#: ../src/generic/prntdlgg.cpp:233
+msgid "To:"
+msgstr "Za:"
+
+# generic/prntdlgg.cpp:196
+#: ../src/generic/prntdlgg.cpp:238
+msgid "Copies:"
+msgstr "Št. kopij"
+
+# generic/prntdlgg.cpp:272
+#: ../src/generic/prntdlgg.cpp:288
+msgid "PostScript file"
+msgstr "PostScript datoteka"
+
+# generic/prntdlgg.cpp:408
+# generic/prntdlgg.cpp:415
+#: ../src/generic/prntdlgg.cpp:439
+msgid "Print Setup"
+msgstr "Nastavitev tiskanja"
+
+# generic/prntdlgg.cpp:113
+# generic/prntdlgg.cpp:127
+#: ../src/generic/prntdlgg.cpp:483
+msgid "Printer"
+msgstr "Tiskalnik"
+
+#: ../src/generic/prntdlgg.cpp:501
+msgid "Default printer"
+msgstr "Privzeti tiskalnik"
+
+# generic/prntdlgg.cpp:433
+# generic/prntdlgg.cpp:615
+# generic/prntdlgg.cpp:804
+#: ../src/generic/prntdlgg.cpp:595 ../src/generic/prntdlgg.cpp:782
+#: ../src/generic/prntdlgg.cpp:822 ../src/generic/prntdlgg.cpp:835
+#: ../src/generic/prntdlgg.cpp:1031 ../src/generic/prntdlgg.cpp:1036
+msgid "Paper size"
+msgstr "Velikost papirja"
+
+# generic/dcpsg.cpp:2261
+# generic/prntdlgg.cpp:440
+# generic/prntdlgg.cpp:636
+#: ../src/generic/prntdlgg.cpp:604 ../src/generic/prntdlgg.cpp:847
+msgid "Portrait"
+msgstr "Portet"
+
+# generic/dcpsg.cpp:2262
+# generic/prntdlgg.cpp:441
+# generic/prntdlgg.cpp:637
+#: ../src/generic/prntdlgg.cpp:605 ../src/generic/prntdlgg.cpp:848
+msgid "Landscape"
+msgstr "Ležeče"
+
+# generic/prntdlgg.cpp:443
+# generic/prntdlgg.cpp:638
+#: ../src/generic/prntdlgg.cpp:607 ../src/generic/prntdlgg.cpp:849
+msgid "Orientation"
+msgstr "Usmeritev"
+
+# generic/prntdlgg.cpp:447
+#: ../src/generic/prntdlgg.cpp:610
+msgid "Options"
+msgstr "Možnosti"
+
+# generic/prntdlgg.cpp:455
+#: ../src/generic/prntdlgg.cpp:612
+msgid "Print in colour"
+msgstr "Bravno tiskanje"
+
+# generic/prntdlgg.cpp:457
+#: ../src/generic/prntdlgg.cpp:621
+msgid "Print spooling"
+msgstr "Čakalna vrsta tiskanja"
+
+# generic/prntdlgg.cpp:459
+#: ../src/generic/prntdlgg.cpp:623
+msgid "Printer command:"
+msgstr "Ukaz tiskalniku:"
+
+# generic/prntdlgg.cpp:463
+#: ../src/generic/prntdlgg.cpp:631
+msgid "Printer options:"
+msgstr "Možnosti tiskalnika:"
+
+# generic/prntdlgg.cpp:649
+#: ../src/generic/prntdlgg.cpp:860
+msgid "Left margin (mm):"
+msgstr "Levi rob (mm):"
+
+# generic/prntdlgg.cpp:650
+#: ../src/generic/prntdlgg.cpp:861
+msgid "Top margin (mm):"
+msgstr "Zgornji rob (mm):"
+
+# generic/prntdlgg.cpp:661
+#: ../src/generic/prntdlgg.cpp:872
+msgid "Right margin (mm):"
+msgstr "Desni rob (mm):"
+
+# generic/prntdlgg.cpp:662
+#: ../src/generic/prntdlgg.cpp:873
+msgid "Bottom margin (mm):"
+msgstr "Spodnji rob (mm):"
+
+# generic/prntdlgg.cpp:682
+#: ../src/generic/prntdlgg.cpp:896
+msgid "Printer..."
+msgstr "Tiskalnik ..."
+
+#: ../src/generic/progdlgg.cpp:246
+msgid "&Skip"
+msgstr "Pres&koči"
+
+# generic/progdlgg.cpp:241
+#: ../src/generic/progdlgg.cpp:347 ../src/generic/progdlgg.cpp:626
+msgid "Unknown"
+msgstr "neznan"
+
+# generic/progdlgg.cpp:313
+#: ../src/generic/progdlgg.cpp:451 ../src/msw/progdlg.cpp:526
+msgid "Done."
+msgstr "Končano."
+
+# generic/helpwxht.cpp:161
+# html/helpfrm.cpp:414
+# html/helpfrm.cpp:434
+#: ../src/generic/srchctlg.cpp:55 ../src/gtk/srchctrl.cpp:206
+#: ../src/html/helpwnd.cpp:530 ../src/html/helpwnd.cpp:545
+msgid "Search"
+msgstr "Iskanje"
+
+# generic/tabg.cpp:1042
+#: ../src/generic/tabg.cpp:1026
+msgid "Could not find tab for id"
+msgstr "Tabulatorja za id ni mogoče najti."
+
+# generic/tipdlg.cpp:138
+#: ../src/generic/tipdlg.cpp:136
+msgid "Tips not available, sorry!"
+msgstr "Oprostite, namigi niso na voljo!"
+
+# generic/tipdlg.cpp:162
+#: ../src/generic/tipdlg.cpp:197
+msgid "Tip of the Day"
+msgstr "Namig dneva"
+
+# generic/tipdlg.cpp:177
+#: ../src/generic/tipdlg.cpp:207
+msgid "Did you know..."
+msgstr "Ali ste vedeli, da ..."
+
+# generic/tipdlg.cpp:172
+#: ../src/generic/tipdlg.cpp:232
+msgid "&Show tips at startup"
+msgstr "&Pokaži namige ob zagonu"
+
+# generic/tipdlg.cpp:175
+#: ../src/generic/tipdlg.cpp:236
+msgid "&Next Tip"
+msgstr "N&aslednji namig"
+
+# generic/wizard.cpp:189
+# generic/wizard.cpp:286
+#: ../src/generic/wizard.cpp:411
+msgid "&Next >"
+msgstr "&Naslednji >"
+
+# generic/wizard.cpp:284
+#: ../src/generic/wizard.cpp:412
+msgid "&Finish"
+msgstr "&Dokončaj"
+
+# generic/wizard.cpp:186
+#: ../src/generic/wizard.cpp:420
+msgid "< &Back"
+msgstr "< &Nazaj"
+
+#: ../src/gtk/aboutdlg.cpp:204
+msgid "translator-credits"
+msgstr "Zasluge prevajalcev"
+
+#: ../src/gtk/app.cpp:517
+msgid ""
+"WARNING: using XIM input method is unsupported and may result in problems "
+"with input handling and flickering. Consider unsetting GTK_IM_MODULE or "
+"setting to \"ibus\"."
+msgstr ""
+"OPOZORILO: uporaba vnosne metode XIM ni podprta in lahko povzroči težave z "
+"ravnanjem z vnosom in utripanje. Razmislite o GTK_IM_MODULE ali nastavitvi "
+"na »ibus«."
+
+#: ../src/gtk/app.cpp:569
+msgid "Unable to initialize GTK+, is DISPLAY set properly?"
+msgstr ""
+"GTK+ ni mogoče inicializirati, je spremenljivka DISPLAY nastavljena pravilno?"
+
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR Free Software Foundation, Inc.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+# msw/registry.cpp:399
+#: ../src/gtk/filedlg.cpp:89 ../src/gtk/filepicker.cpp:255
+#, c-format
+msgid "Changing current directory to \"%s\" failed"
+msgstr "Sprememba iz trenutne mape v »%s« je spodletela."
+
+#: ../src/gtk/font.cpp:548
+msgid ""
+"Using private fonts is not supported on this system: Pango library is too "
+"old, 1.38 or later required."
+msgstr ""
+"Uporaba zasebnih pisav ni podprta na tem sistemu: Knjižnica Pango je "
+"prestara, potrebna je 1.38 ali novejša."
+
+# common/fileconf.cpp:800
+#: ../src/gtk/font.cpp:558
+msgid "Failed to create font configuration object."
+msgstr "Predmeta prilagoditve pisave ni mogoče ustvariti."
+
+# common/ffile.cpp:182
+#: ../src/gtk/font.cpp:568
+#, c-format
+msgid "Failed to add custom font \"%s\"."
+msgstr "Dodajanje pisave po meri »%s« ni uspelo."
+
+# common/fileconf.cpp:800
+#: ../src/gtk/font.cpp:576
+msgid "Failed to register font configuration using private fonts."
+msgstr "Prilagoditve pisave z uporabo zasebnih pisav ni mogoče registrirati."
+
+# common/docview.cpp:296
+# common/docview.cpp:332
+# common/docview.cpp:1388
+#: ../src/gtk/glcanvas.cpp:117 ../src/gtk/glcanvas.cpp:132
+msgid "Fatal Error"
+msgstr "Usodna napaka"
+
+#: ../src/gtk/glcanvas.cpp:117
+msgid ""
+"This program wasn't compiled with EGL support required under Wayland, "
+"either\n"
+"install EGL libraries and rebuild or run it under X11 backend by setting\n"
+"environment variable GDK_BACKEND=x11 before starting your program."
+msgstr ""
+"Ta program ni bil preveden s podporo EGL, ki je obvezna za Wayland, zato "
+"bodisi\n"
+"namestite knjižnice EGL in ga ponovno zgradite ali zaženite pod zaledjem X11 "
+"z\n"
+"nastavitvijo spremenljivka okolja GDK_BACKEND=x11 pred zagonom programa."
+
+#: ../src/gtk/glcanvas.cpp:132
+msgid ""
+"wxGLCanvas is only supported on Wayland and X11 currently.  You may be able "
+"to\n"
+"work around this by setting environment variable GDK_BACKEND=x11 before\n"
+"starting your program."
+msgstr ""
+"wxGLCanvas je trenutno podprt samo na Wayland in X11.  Morda boste lahko\n"
+"to obšli z nastavitvijo spremenljivke okolja GDK_BACKEND=x11 pred\n"
+"zagonom programa."
+
+#: ../src/gtk/mdi.cpp:433
+msgid "MDI child"
+msgstr "Otrok MDI"
+
+# msw/dde.cpp:401
+#: ../src/gtk/power.cpp:188
+#, c-format
+msgid "Failed to open D-Bus connection to the login manager: %s"
+msgstr "Ni bilo mogoče odpreti povezave D-Bus z upraviteljem prijav: %s"
+
+# generic/dirdlgg.cpp:191
+#: ../src/gtk/power.cpp:214
+msgid "wxWidgets application"
+msgstr "Program wxWidgets"
+
+#: ../src/gtk/power.cpp:226
+msgid "Application needs to keep running"
+msgstr "Program mora še naprej delovati"
+
+#: ../src/gtk/power.cpp:233
+msgid "Clean up before suspend"
+msgstr "Počisti pred ustavitvijo"
+
+# msw/dialup.cpp:933
+#: ../src/gtk/power.cpp:259
+#, c-format
+msgid "Failed to inhibit sleep: %s"
+msgstr "Nedejavnega načina ni uspelo preprečiti: %s"
+
+#: ../src/gtk/power.cpp:265
+msgid "Unexpected response to D-Bus \"Inhibit\" request."
+msgstr "Nepričakovan odziv na zahtevo »Inhibit« D-Busa."
+
+# html/helpfrm.cpp:899
+#: ../src/gtk/print.cpp:218
+msgid "Custom size"
+msgstr "Velikost po meri"
+
+#: ../src/gtk/print.cpp:752
+#, c-format
+msgid "Error while printing: %s"
+msgstr "Napaka pri tiskanju: %s"
+
+# generic/prntdlgg.cpp:604
+#: ../src/gtk/print.cpp:816
+msgid "Page Setup"
+msgstr "Nastavitev strani"
+
+#: ../src/gtk/webview_webkit.cpp:932
+msgid "Retrieving JavaScript script output is not supported with WebKit v1"
+msgstr "Pridobivanje izhoda skripta JavaScript ni podprto z WebKit v1"
+
+#: ../src/gtk/webview_webkit2.cpp:1098
+msgid ""
+"Setting proxy is not supported by WebKit, at least version 2.16 is required."
+msgstr ""
+"WebKit ne podpira nastavitve posrednika, potrebna je vsaj različica 2.16."
+
+#: ../src/gtk/webview_webkit2.cpp:1104
+msgid "This program was compiled without support for setting WebKit proxy."
+msgstr ""
+"Ta program je bil preveden brez podpore za nastavitev posrednika WebKit."
+
+#: ../src/gtk/window.cpp:6289
+msgid ""
+"GTK+ installed on this machine is too old to support screen compositing, "
+"please install GTK+ 2.12 or later."
+msgstr ""
+"GTK+, nameščen na tem računalniku, je prestar, da bi podpiral zaslonsko "
+"skladanje, namestiti morate GTK+ 2.12 ali novejšega."
+
+#: ../src/gtk/window.cpp:6307
+msgid ""
+"Compositing not supported by this system, please enable it in your Window "
+"Manager."
+msgstr ""
+"Sestavljanja ta sistem ne podpira, omogočite ga v svojem upravitelju oken."
+
+#: ../src/gtk/window.cpp:6318
+msgid ""
+"This program was compiled with a too old version of GTK+, please rebuild "
+"with GTK+ 2.12 or newer."
+msgstr ""
+"Program je bil preveden z zastarelo različico GTK+, ponovno ga zgradite z GTK"
+"+ 2.12 ali novejšim."
+
+# generic/dirdlgg.cpp:550
+#: ../src/html/chm.cpp:138
+#, c-format
+msgid "Failed to open CHM archive '%s'."
+msgstr "Arhiva CHM '%s' ni mogoče odpreti."
+
+#: ../src/html/chm.cpp:270
+#, c-format
+msgid "Could not extract %s into %s: %s"
+msgstr "Ni mogoče izvleči %s v %s: %s"
+
+# generic/progdlgg.cpp:241
+#: ../src/html/chm.cpp:324
+msgid "no error"
+msgstr "brez napake"
+
+#: ../src/html/chm.cpp:326
+msgid "bad arguments to library function"
+msgstr "neustrezni argumenti za funkcijo iz knjižnice"
+
+# common/ffile.cpp:133
+# common/ffile.cpp:154
+#: ../src/html/chm.cpp:328
+msgid "error opening file"
+msgstr "napaka pri odpiranju datoteke"
+
+# common/docview.cpp:296
+# common/docview.cpp:332
+# common/docview.cpp:1388
+#: ../src/html/chm.cpp:330
+msgid "read error"
+msgstr "napaka pri branju"
+
+# common/docview.cpp:296
+# common/docview.cpp:332
+# common/docview.cpp:1388
+#: ../src/html/chm.cpp:332
+msgid "write error"
+msgstr "napaka pri pisanju"
+
+# common/docview.cpp:296
+# common/docview.cpp:332
+# common/docview.cpp:1388
+#: ../src/html/chm.cpp:334
+msgid "seek error"
+msgstr "napaka pri iskanju"
+
+#: ../src/html/chm.cpp:338
+msgid "bad signature"
+msgstr "neuporaben podpis"
+
+#: ../src/html/chm.cpp:340
+msgid "error in data format"
+msgstr "napaka v zapisu podatkov"
+
+#: ../src/html/chm.cpp:342
+msgid "checksum error"
+msgstr "napaka kontrolne vsote"
+
+#: ../src/html/chm.cpp:344
+msgid "compression error"
+msgstr "napaka pri stiskanju"
+
+#: ../src/html/chm.cpp:346
+msgid "decompression error"
+msgstr "napaka pri razširjanju"
+
+# msw/dib.cpp:434
+#: ../src/html/chm.cpp:437
+#, c-format
+msgid "Could not locate file '%s'."
+msgstr "Datoteke »%s« ni mogoče najti."
+
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR Free Software Foundation, Inc.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+# common/file.cpp:580
+# common/file.cpp:583
+#: ../src/html/chm.cpp:711
+#, c-format
+msgid "Could not create temporary file '%s'"
+msgstr "Začasne datoteke »%s« ni mogoče ustvariti."
+
+#: ../src/html/chm.cpp:718
+#, c-format
+msgid "Extraction of '%s' into '%s' failed."
+msgstr "Iztis »%s« v »%s« ni uspel."
+
+#: ../src/html/chm.cpp:806 ../src/html/chm.cpp:863
+msgid "CHM handler currently supports only local files!"
+msgstr "Upravljalec CHM trenutno podpira le lokalne datoteke!"
+
+#: ../src/html/chm.cpp:827
+msgid "Link contained '//', converted to absolute link."
+msgstr "Povezava je vsebovala '//', pretvorjeno nazaj v absolutno povezavo."
+
+# generic/helpwxht.cpp:251
+# html/helpctrl.cpp:38
+#: ../src/html/helpctrl.cpp:59
+#, c-format
+msgid "Help: %s"
+msgstr "Pomoč: %s"
+
+# html/helpctrl.cpp:83
+#: ../src/html/helpctrl.cpp:155
+#, c-format
+msgid "Adding book %s"
+msgstr "Dodajanje knjige %s"
+
+# html/helpdata.cpp:353
+#: ../src/html/helpdata.cpp:295
+#, c-format
+msgid "Cannot open contents file: %s"
+msgstr "Datoteke z vsebino ni mogoče odpreti: %s"
+
+# html/helpdata.cpp:368
+#: ../src/html/helpdata.cpp:309
+#, c-format
+msgid "Cannot open index file: %s"
+msgstr "Indeksne datoteke ni mogoče odpreti: %s"
+
+# html/helpdata.cpp:644
+#: ../src/html/helpdata.cpp:643
+msgid "noname"
+msgstr "neimanovana"
+
+# html/helpdata.cpp:657
+#: ../src/html/helpdata.cpp:652
+#, c-format
+msgid "Cannot open HTML help book: %s"
+msgstr "Knjige s HTML pomočjo ni mogoče odpreti: %s"
+
+#: ../src/html/helpwnd.cpp:315
+msgid "Displays help as you browse the books on the left."
+msgstr "Prikaže pomoč med brskanjem po knjigah na levi."
+
+# html/helpfrm.cpp:276
+# html/helpfrm.cpp:783
+# html/helpfrm.cpp:1330
+#: ../src/html/helpwnd.cpp:411 ../src/html/helpwnd.cpp:1100
+#: ../src/html/helpwnd.cpp:1735
+msgid "(bookmarks)"
+msgstr "(zaznamki)"
+
+# html/helpfrm.cpp:270
+#: ../src/html/helpwnd.cpp:424
+msgid "Add current page to bookmarks"
+msgstr "Dodaj trenutno stran med zaznamke"
+
+# html/helpfrm.cpp:269
+#: ../src/html/helpwnd.cpp:425
+msgid "Remove current page from bookmarks"
+msgstr "Odstrani trenutno stran iz zaznamkov"
+
+# generic/helpwxht.cpp:159
+# html/helpfrm.cpp:303
+# html/helpfrm.cpp:312
+#: ../src/html/helpwnd.cpp:470
+msgid "Contents"
+msgstr "Vsebina"
+
+# html/helpfrm.cpp:340
+#: ../src/html/helpwnd.cpp:485
+msgid "Find"
+msgstr "Poišči"
+
+# html/helpfrm.cpp:331
+#: ../src/html/helpwnd.cpp:487
+msgid "Show all"
+msgstr "Pokaži vse"
+
+# html/helpfrm.cpp:366
+#: ../src/html/helpwnd.cpp:497
+msgid ""
+"Display all index items that contain given substring. Search is case "
+"insensitive."
+msgstr ""
+"Pokaži vse indeksirane predmete, ki vsebujejo podtekst. Iskanje razlikuje "
+"glede na velikost črk."
+
+# html/helpfrm.cpp:365
+#: ../src/html/helpwnd.cpp:498
+msgid "Show all items in index"
+msgstr "Pokaži vse predmete v indeksu"
+
+# html/helpfrm.cpp:398
+#: ../src/html/helpwnd.cpp:528
+msgid "Case sensitive"
+msgstr "Razlikovanje malih/velikih črk"
+
+# html/helpfrm.cpp:406
+#: ../src/html/helpwnd.cpp:529
+msgid "Whole words only"
+msgstr "Samo cele besede"
+
+# html/helpfrm.cpp:416
+#: ../src/html/helpwnd.cpp:532
+msgid ""
+"Search contents of help book(s) for all occurrences of the text you typed "
+"above"
+msgstr ""
+"Iskanje v knjigah s pomočjo za vse pojavitve zgoraj natipkanega besedila"
+
+# html/helpfrm.cpp:496
+#: ../src/html/helpwnd.cpp:653
+msgid "Show/hide navigation panel"
+msgstr "Pokaži/skrij navigacijski pano"
+
+# html/helpfrm.cpp:501
+#: ../src/html/helpwnd.cpp:655
+msgid "Go back"
+msgstr "Pojdi nazaj"
+
+# html/helpfrm.cpp:504
+#: ../src/html/helpwnd.cpp:656
+msgid "Go forward"
+msgstr "Pojdi naprej"
+
+# html/helpfrm.cpp:509
+#: ../src/html/helpwnd.cpp:658
+msgid "Go one level up in document hierarchy"
+msgstr "Pojdi nivo višje v hierarhiji dokumenta"
+
+# html/helpfrm.cpp:523
+# html/helpfrm.cpp:1183
+#: ../src/html/helpwnd.cpp:666 ../src/html/helpwnd.cpp:1547
+msgid "Open HTML document"
+msgstr "Odpri dokument HTML"
+
+# html/helpfrm.cpp:529
+#: ../src/html/helpwnd.cpp:670
+msgid "Print this page"
+msgstr "Natisni to stran"
+
+# html/helpfrm.cpp:535
+#: ../src/html/helpwnd.cpp:674
+msgid "Display options dialog"
+msgstr "Pokaži pogovorno okno z možnostmi"
+
+# generic/filedlgg.cpp:1092
+#: ../src/html/helpwnd.cpp:795
+msgid "Please choose the page to display:"
+msgstr "Prosimo, izberite stran za prikaz:"
+
+# generic/helpwxht.cpp:251
+# html/helpctrl.cpp:38
+#: ../src/html/helpwnd.cpp:796
+msgid "Help Topics"
+msgstr "Teme pomoči"
+
+# html/helpfrm.cpp:628
+#: ../src/html/helpwnd.cpp:852
+msgid "Searching..."
+msgstr "Iskanje v teku ..."
+
+# html/helpfrm.cpp:628
+#: ../src/html/helpwnd.cpp:853
+msgid "No matching page found yet"
+msgstr "Ujemajoča stran še ni najdena."
+
+# html/helpfrm.cpp:637
+#: ../src/html/helpwnd.cpp:870
+#, c-format
+msgid "Found %i matches"
+msgstr "Najdenih %i ujemanj"
+
+# html/helpfrm.cpp:679
+#: ../src/html/helpwnd.cpp:958
+msgid "(Help)"
+msgstr "(Pomoč)"
+
+# html/helpfrm.cpp:718
+# html/helpfrm.cpp:719
+# html/helpfrm.cpp:1277
+# html/helpfrm.cpp:1304
+#: ../src/html/helpwnd.cpp:1026
+#, c-format
+msgid "%d of %lu"
+msgstr "%d od %lu"
+
+# html/helpfrm.cpp:718
+# html/helpfrm.cpp:719
+# html/helpfrm.cpp:1277
+# html/helpfrm.cpp:1304
+#: ../src/html/helpwnd.cpp:1028
+#, c-format
+msgid "%lu of %lu"
+msgstr "%lu od %lu"
+
+# html/helpfrm.cpp:735
+#: ../src/html/helpwnd.cpp:1047
+msgid "Search in all books"
+msgstr "Išči v vseh knjigah"
+
+# html/helpfrm.cpp:872
+#: ../src/html/helpwnd.cpp:1193
+msgid "Help Browser Options"
+msgstr "Možnosti brskalnika pomoči"
+
+# html/helpfrm.cpp:881
+#: ../src/html/helpwnd.cpp:1198
+msgid "Normal font:"
+msgstr "Običajna pisava:"
+
+# html/helpfrm.cpp:889
+#: ../src/html/helpwnd.cpp:1199
+msgid "Fixed font:"
+msgstr "Nespremenljiva pisava:"
+
+# html/helpfrm.cpp:899
+#: ../src/html/helpwnd.cpp:1200
+msgid "Font size:"
+msgstr "Velikost pisave"
+
+# html/helpfrm.cpp:899
+#: ../src/html/helpwnd.cpp:1245
+msgid "font size"
+msgstr "velikost pisave"
+
+#: ../src/html/helpwnd.cpp:1256
+msgid "Normal face<br>and <u>underlined</u>. "
+msgstr "Običajna pisava<br>in <u>podčrtana</u>. "
+
+#: ../src/html/helpwnd.cpp:1257
+msgid "<i>Italic face.</i> "
+msgstr "<i>Ležeča pisava.</i> "
+
+#: ../src/html/helpwnd.cpp:1258
+msgid "<b>Bold face.</b> "
+msgstr "<b>Kepka pisava.</b> "
+
+#: ../src/html/helpwnd.cpp:1259
+msgid "<b><i>Bold italic face.</i></b><br>"
+msgstr "<b><i>Krepka ležeča pisava.</i></b><br>"
+
+#: ../src/html/helpwnd.cpp:1262
+msgid "Fixed size face.<br> <b>bold</b> <i>italic</i> "
+msgstr "Pisava nespremenljive velikosti.<br> <b>krepko</b> <i>ležeče</i>"
+
+#: ../src/html/helpwnd.cpp:1263
+msgid "<b><i>bold italic <u>underlined</u></i></b><br>"
+msgstr "<b><i>krepko ležeče <u>podčrtano</u></i></b><br>"
+
+# html/helpfrm.cpp:1172
+#: ../src/html/helpwnd.cpp:1524
+msgid "Help Printing"
+msgstr "Pomoč pri tiskanju"
+
+# html/helpfrm.cpp:1174
+#: ../src/html/helpwnd.cpp:1527
+msgid "Cannot print empty page."
+msgstr "Prazne strani ni mogoče natisniti."
+
+#: ../src/html/helpwnd.cpp:1540
+msgid "HTML files (*.html;*.htm)|*.html;*.htm|"
+msgstr "Datoteke HTML (*.html;*.htm)|*.html;*.htm|"
+
+#: ../src/html/helpwnd.cpp:1541
+msgid "Help books (*.htb)|*.htb|Help books (*.zip)|*.zip|"
+msgstr "knjige pomoči (*.htb)|*.htb|knjige pomoči (*.zip)|*.zip|"
+
+#: ../src/html/helpwnd.cpp:1542
+msgid "HTML Help Project (*.hhp)|*.hhp|"
+msgstr "projekt pomoči HTML (*.hhp)|*.hhp|"
+
+#: ../src/html/helpwnd.cpp:1544
+msgid "Compressed HTML Help file (*.chm)|*.chm|"
+msgstr "datoteka stisnjene pomoči HTML (*.chm)|*.chm|"
+
+# html/helpfrm.cpp:718
+# html/helpfrm.cpp:719
+# html/helpfrm.cpp:1277
+# html/helpfrm.cpp:1304
+#: ../src/html/helpwnd.cpp:1671
+#, c-format
+msgid "%i of %u"
+msgstr "%i od %u"
+
+# html/helpfrm.cpp:718
+# html/helpfrm.cpp:719
+# html/helpfrm.cpp:1277
+# html/helpfrm.cpp:1304
+#: ../src/html/helpwnd.cpp:1709
+#, c-format
+msgid "%u of %u"
+msgstr "%u od %u"
+
+# html/htmlfilt.cpp:146
+#: ../src/html/htmlfilt.cpp:134
+#, c-format
+msgid "Cannot open HTML document: %s"
+msgstr "Dokumenta HTML ni mogoče odpreti: %s"
+
+# html/htmlwin.cpp:166
+#: ../src/html/htmlwin.cpp:599
+msgid "Connecting..."
+msgstr "Povezovanje poteka ..."
+
+# html/htmlwin.cpp:175
+#: ../src/html/htmlwin.cpp:616
+#, c-format
+msgid "Unable to open requested HTML document: %s"
+msgstr "Zahtevanega HTML dokumenta ni mogoče odpreti: %s"
+
+# html/htmlwin.cpp:187
+#: ../src/html/htmlwin.cpp:630
+msgid "Loading : "
+msgstr "Nalaganje: "
+
+# html/htmlwin.cpp:216
+#: ../src/html/htmlwin.cpp:673
+msgid "Done"
+msgstr "Končano"
+
+# html/htmlwin.cpp:251
+#: ../src/html/htmlwin.cpp:723
+#, c-format
+msgid "HTML anchor %s does not exist."
+msgstr "HTML sidro %s ne obstaja"
+
+# generic/dirdlgg.cpp:550
+#: ../src/html/htmlwin.cpp:1057
+#, c-format
+msgid "Copied to clipboard:\"%s\""
+msgstr "Kopirano v odložišče:\"%s\""
+
+#: ../src/html/htmprint.cpp:269
+msgid ""
+"This document doesn't fit on the page horizontally and will be truncated "
+"when it is printed."
+msgstr "Ta dokument je vodoravno prevelik za stran in bo pri tiskanju porezan."
+
+#: ../src/html/htmprint.cpp:285
+#, c-format
+msgid ""
+"The document \"%s\" doesn't fit on the page horizontally and will be "
+"truncated if printed.\n"
+"\n"
+"Would you like to proceed with printing it nevertheless?"
+msgstr ""
+"Dokument »%s« vodoravno presega mere strani in bo pri tiskanju porezan.\n"
+"\n"
+"Želite kljub temu nadaljevati z njegovim tiskanjem?"
+
+#: ../src/html/htmprint.cpp:296
+msgid ""
+"If possible, try changing the layout parameters to make the printout more "
+"narrow."
+msgstr ""
+"Če je mogoče, poskusite spremeniti parametre postavitve, da bo izpis ožji."
+
+# html/htmprint.cpp:272
+#: ../src/html/htmprint.cpp:445
+msgid ": file does not exist!"
+msgstr ": datoteka ne obstaja!"
+
+# html/htmprint.cpp:490
+#. TRANSLATORS: %s may be a document title.
+#: ../src/html/htmprint.cpp:717
+#, c-format
+msgid "%s Preview"
+msgstr " Predogled %s"
+
+#: ../src/html/htmprint.cpp:755 ../src/richtext/richtextprint.cpp:618
+msgid ""
+"There was a problem during page setup: you may need to set a default printer."
+msgstr ""
+"Med pripravo strani je prišlo do težave: morda morate nastaviti privzeti "
+"tiskalnik."
+
+# msw/clipbrd.cpp:102
+#: ../src/msw/clipbrd.cpp:80
+msgid "Failed to open the clipboard."
+msgstr "Odložišča ni mogoče odpreti."
+
+# msw/clipbrd.cpp:122
+#: ../src/msw/clipbrd.cpp:101
+msgid "Failed to close the clipboard."
+msgstr "Zaprtje odložišča ni uspelo."
+
+# msw/clipbrd.cpp:134
+#: ../src/msw/clipbrd.cpp:113
+msgid "Failed to empty the clipboard."
+msgstr "Izpraznitev odložišča ni uspela."
+
+# msw/clipbrd.cpp:539
+#: ../src/msw/clipbrd.cpp:284
+msgid "Failed to put data on the clipboard"
+msgstr "Podatkov ni mogoče postaviti na odložišče."
+
+# msw/clipbrd.cpp:623
+#: ../src/msw/clipbrd.cpp:326
+msgid "Failed to get data from the clipboard"
+msgstr "Podatkov z odložišča ni mogoče pridobiti."
+
+# msw/clipbrd.cpp:652
+#: ../src/msw/clipbrd.cpp:363
+msgid "Failed to retrieve the supported clipboard formats"
+msgstr "Podprte oblike zapisa odložišča ni mogoče pridobiti."
+
+#: ../src/msw/colordlg.cpp:228
+#, c-format
+msgid "Colour selection dialog failed with error %0lx."
+msgstr "Pogovorno okno izbirnika barv ni uspelo, z napako %0lx."
+
+# common/imagbmp.cpp:266
+# common/imagbmp.cpp:278
+#: ../src/msw/cursor.cpp:141
+msgid "Failed to create cursor."
+msgstr "Kazalke ni mogoče ustvariti."
+
+# msw/dde.cpp:285
+#: ../src/msw/dde.cpp:279
+#, c-format
+msgid "Failed to register DDE server '%s'"
+msgstr "Registracija strežnika DDE »%s« ni uspela."
+
+# msw/dde.cpp:301
+#: ../src/msw/dde.cpp:300
+#, c-format
+msgid "Failed to unregister DDE server '%s'"
+msgstr "Odjava strežnika DDE »%s« ni uspela."
+
+# msw/dde.cpp:401
+#: ../src/msw/dde.cpp:428
+#, c-format
+msgid "Failed to create connection to server '%s' on topic '%s'"
+msgstr "Povezava s strežnikom »%s« na temo »%s« ni uspela."
+
+# msw/dde.cpp:597
+#: ../src/msw/dde.cpp:655
+msgid "DDE poke request failed"
+msgstr "Zahteva za poke DDE ni uspela."
+
+# msw/dde.cpp:616
+#: ../src/msw/dde.cpp:674
+msgid "Failed to establish an advise loop with DDE server"
+msgstr "Vzpostavitev usklajevalne zanke s strežnikom DDE ni uspela."
+
+# msw/dde.cpp:635
+#: ../src/msw/dde.cpp:693
+msgid "Failed to terminate the advise loop with DDE server"
+msgstr "Ustavitev usklajevalne zanke s strežnikom DDE ni uspela."
+
+# msw/dde.cpp:661
+#: ../src/msw/dde.cpp:768
+msgid "Failed to send DDE advise notification"
+msgstr "Pošiljanje usklajevalne transakcije DDE ni uspelo."
+
+# msw/dde.cpp:934
+#: ../src/msw/dde.cpp:1085
+msgid "Failed to create DDE string"
+msgstr "Niza DDE ni mogoče ustvariti."
+
+# msw/dde.cpp:972
+#: ../src/msw/dde.cpp:1131
+msgid "no DDE error."
+msgstr "ni napake DDE."
+
+# msw/dde.cpp:976
+#: ../src/msw/dde.cpp:1135
+msgid "a request for a synchronous advise transaction has timed out."
+msgstr "zahteva za sinhrono usklajevalno transakcijo je časovno potekla."
+
+# msw/dde.cpp:979
+#: ../src/msw/dde.cpp:1138
+msgid "the response to the transaction caused the DDE_FBUSY bit to be set."
+msgstr "odziv na transakcijo je povzročil, da je nastavljen bit DDE_FBUSY."
+
+# msw/dde.cpp:982
+#: ../src/msw/dde.cpp:1141
+msgid "a request for a synchronous data transaction has timed out."
+msgstr "zahteva za sinhrono podatkovno transakcijo je časovno potekla."
+
+# msw/dde.cpp:985
+#: ../src/msw/dde.cpp:1144
+msgid ""
+"a DDEML function was called without first calling the DdeInitialize "
+"function,\n"
+"or an invalid instance identifier\n"
+"was passed to a DDEML function."
+msgstr ""
+"Funkcija DDEML je bil klicana brez predhodnega klica funkcije DdeInitialize\n"
+"ali pa je bil funkciji DDEML prenešen\n"
+"neveljaven določitelj instance."
+
+# msw/dde.cpp:988
+#: ../src/msw/dde.cpp:1147
+msgid ""
+"an application initialized as APPCLASS_MONITOR has\n"
+"attempted to perform a DDE transaction,\n"
+"or an application initialized as APPCMD_CLIENTONLY has \n"
+"attempted to perform server transactions."
+msgstr ""
+"aplikacija, inicializirana kot APPCLASS_MONITOR, je\n"
+"poskusila izvesti transakcijo DDE\n"
+"ali pa je aplikacija, inicializirana kot APPCMD_CLIENTONLY,\n"
+"poskusila izvesti strežniške transakcije."
+
+# msw/dde.cpp:991
+#: ../src/msw/dde.cpp:1150
+msgid "a request for a synchronous execute transaction has timed out."
+msgstr "zahteva za sinhrono izvajalno transakcijo je časovno potekla."
+
+# msw/dde.cpp:994
+#: ../src/msw/dde.cpp:1153
+msgid "a parameter failed to be validated by the DDEML."
+msgstr "DDEML ni uspešno potrdil veljavnosti parametra."
+
+# msw/dde.cpp:997
+#: ../src/msw/dde.cpp:1156
+msgid "a DDEML application has created a prolonged race condition."
+msgstr "Program DDEML je ustvaril podaljšano stanje sledenja."
+
+# msw/dde.cpp:1000
+#: ../src/msw/dde.cpp:1159
+msgid "a memory allocation failed."
+msgstr "alokacija spomina ni uspela."
+
+# msw/dde.cpp:1003
+#: ../src/msw/dde.cpp:1162
+msgid "a client's attempt to establish a conversation has failed."
+msgstr "poskus odjemalca, da bi vzpostavil pogovor, ni uspel."
+
+# msw/dde.cpp:1006
+#: ../src/msw/dde.cpp:1165
+msgid "a transaction failed."
+msgstr "transakcija ni uspela"
+
+# msw/dde.cpp:1009
+#: ../src/msw/dde.cpp:1168
+msgid "a request for a synchronous poke transaction has timed out."
+msgstr "zahteva za sinhrono transakcijo poke je časovno potekla."
+
+# msw/dde.cpp:1012
+#: ../src/msw/dde.cpp:1171
+msgid "an internal call to the PostMessage function has failed. "
+msgstr "notranji klic funkcije PostMessage ni uspel."
+
+# msw/dde.cpp:1015
+#: ../src/msw/dde.cpp:1174
+msgid "reentrancy problem."
+msgstr "napaka ponovnega vstopa."
+
+# msw/dde.cpp:1018
+#: ../src/msw/dde.cpp:1177
+msgid ""
+"a server-side transaction was attempted on a conversation\n"
+"that was terminated by the client, or the server\n"
+"terminated before completing a transaction."
+msgstr ""
+"poskus transakcije s strani strežnika je v pogovoru\n"
+"še pred dokončanjem transakcije\n"
+"prekinil odjemalec ali strežnik."
+
+# msw/dde.cpp:1021
+#: ../src/msw/dde.cpp:1180
+msgid "an internal error has occurred in the DDEML."
+msgstr "v DDEML je prišlo do notranje napake."
+
+# msw/dde.cpp:1024
+#: ../src/msw/dde.cpp:1183
+msgid "a request to end an advise transaction has timed out."
+msgstr "zahteva za prekinitev usklajevalne transakcije je časovno potekla."
+
+# msw/dde.cpp:1027
+#: ../src/msw/dde.cpp:1186
+msgid ""
+"an invalid transaction identifier was passed to a DDEML function.\n"
+"Once the application has returned from an XTYP_XACT_COMPLETE callback,\n"
+"the transaction identifier for that callback is no longer valid."
+msgstr ""
+"Funkciji DDEML je bil podan neveljaven identifikator transakcije.\n"
+"Ko se je aplikacija vrnila s povratnega klica XTYP_XACT_COMPLETE,\n"
+"identifikator transakcije za ta povratni klic ni več veljaven."
+
+# msw/dde.cpp:1030
+#: ../src/msw/dde.cpp:1189
+#, c-format
+msgid "Unknown DDE error %08x"
+msgstr "Neznana napaka DDE %08x"
+
+# msw/dialup.cpp:354
+#: ../src/msw/dialup.cpp:343
+msgid ""
+"Dial up functions are unavailable because the remote access service (RAS) is "
+"not installed on this machine. Please install it."
+msgstr ""
+"Funkcije klicne povezave niso na voljo, ker storitev oddaljenega dostopa "
+"(RAS) na tem računalniku ni nameščena. Prosimo, namestite jo."
+
+#: ../src/msw/dialup.cpp:402
+#, c-format
+msgid ""
+"The version of remote access service (RAS) installed on this machine is too "
+"old, please upgrade (the following required function is missing: %s)."
+msgstr ""
+"Različica storitve oddaljenega dostopa (RAS), nameščena na tem računalniku, "
+"je zastarela, prosimo, nadgradite jo (manjka naslednja zahtevana funkcija: "
+"%s)."
+
+# msw/dialup.cpp:463
+#: ../src/msw/dialup.cpp:437
+msgid "Failed to retrieve text of RAS error message"
+msgstr "Besedila sporočila o napaki RAS ni mogoče pridobiti."
+
+# msw/dialup.cpp:466
+#: ../src/msw/dialup.cpp:440
+#, c-format
+msgid "unknown error (error code %08x)."
+msgstr "neznana napaka (koda napake %08x)."
+
+# msw/dialup.cpp:518
+#: ../src/msw/dialup.cpp:492
+#, c-format
+msgid "Cannot find active dialup connection: %s"
+msgstr "Aktivne klicne povezave ni mogoče najti: %s"
+
+# msw/dialup.cpp:539
+#: ../src/msw/dialup.cpp:513
+msgid "Several active dialup connections found, choosing one randomly."
+msgstr ""
+"Najdenih je več aktivnih klicnih povezav, izbrana bo naključna med njimi."
+
+# msw/dialup.cpp:639
+#: ../src/msw/dialup.cpp:598 ../src/msw/dialup.cpp:832
+#, c-format
+msgid "Failed to establish dialup connection: %s"
+msgstr "Klicna povezava ni bila uspešno vzpostavljena: %s"
+
+# msw/dialup.cpp:699
+#: ../src/msw/dialup.cpp:664
+#, c-format
+msgid "Failed to get ISP names: %s"
+msgstr "Neuspešno pridobivanje imen ISP: %s"
+
+# msw/dialup.cpp:747
+#: ../src/msw/dialup.cpp:712
+msgid "Failed to connect: no ISP to dial."
+msgstr "Neuspela povezava: ni ISP za klicanje"
+
+# msw/dialup.cpp:767
+#: ../src/msw/dialup.cpp:732
+msgid "Choose ISP to dial"
+msgstr "Izberite ponudnika spletnih storitev, ki ga želite poklicati."
+
+# msw/dialup.cpp:768
+#: ../src/msw/dialup.cpp:733
+msgid "Please choose which ISP do you want to connect to"
+msgstr ""
+"Prosimo, izberite ponudnika spletnih storitev, s katerim se želite povezati."
+
+# msw/dialup.cpp:801
+#: ../src/msw/dialup.cpp:766
+msgid "Failed to connect: missing username/password."
+msgstr "Neuspela povezava: manjkajoče uporabniško ime/geslo."
+
+# msw/dialup.cpp:832
+#: ../src/msw/dialup.cpp:796
+msgid "Cannot find the location of address book file"
+msgstr "Ni možno najti mesta datoteke adresarja"
+
+# msw/dialup.cpp:933
+#: ../src/msw/dialup.cpp:827
+#, c-format
+msgid "Failed to initiate dialup connection: %s"
+msgstr "Inicializacija klicne povezave ni uspela: %s"
+
+# msw/dialup.cpp:925
+#: ../src/msw/dialup.cpp:897
+msgid "Cannot hang up - no active dialup connection."
+msgstr "Povezave ni mogoče prekiniti - ni aktivne klicne povezave."
+
+# msw/dialup.cpp:933
+#: ../src/msw/dialup.cpp:907
+#, c-format
+msgid "Failed to terminate the dialup connection: %s"
+msgstr "Prekinitev klicne povezave ni uspela: %s"
+
+# common/ffile.cpp:182
+#: ../src/msw/dib.cpp:313
+#, c-format
+msgid "Failed to save the bitmap image to file \"%s\"."
+msgstr "Neuspešno shranjevanje bitne slike v datoteko \"%s\"."
+
+#: ../src/msw/dib.cpp:543
+#, c-format
+msgid "Failed to allocate %luKb of memory for bitmap data."
+msgstr "Za podatke bitne slike alokacija %lu Kb pomnilnika ni uspela."
+
+# common/filefn.cpp:1287
+# msw/dir.cpp:294
+#: ../src/msw/dir.cpp:241
+#, c-format
+msgid "Cannot enumerate files in directory '%s'"
+msgstr "Oštevilčenje datotek v mapi »%s« ni možno."
+
+# msw/timer.cpp:96
+#: ../src/msw/dirdlg.cpp:368
+msgid "Couldn't obtain folder name"
+msgstr "Imena mape ni mogoče pridobiti"
+
+# common/log.cpp:242
+#: ../src/msw/dlmsw.cpp:163
+#, c-format
+msgid "(error %d: %s)"
+msgstr "(napaka %d: %s)"
+
+# msw/dragimag.cpp:142
+# msw/dragimag.cpp:179
+# msw/imaglist.cpp:152
+# msw/imaglist.cpp:174
+# msw/imaglist.cpp:187
+#: ../src/msw/dragimag.cpp:143 ../src/msw/dragimag.cpp:178
+#: ../src/msw/imaglist.cpp:309 ../src/msw/imaglist.cpp:331
+msgid "Couldn't add an image to the image list."
+msgstr "Na seznam slik ni mogoče dodati slike."
+
+# common/ffile.cpp:182
+#: ../src/msw/enhmeta.cpp:94
+#, c-format
+msgid "Failed to load metafile from file \"%s\"."
+msgstr "Meta-datoteke iz datoteke \"%s\" ni mogoče naložiti."
+
+#: ../src/msw/fdrepdlg.cpp:412
+#, c-format
+msgid "Failed to create the standard find/replace dialog (error code %d)"
+msgstr ""
+"Standardnega najdi/zamenjaj pogovornega okna ni bilo uspešno ustvarjeno "
+"(koda napake %d)"
+
+#: ../src/msw/filedlg.cpp:1241
+msgid "Access to the file system is not allowed from secure desktop."
+msgstr "Dostop do datotečnega sistema ni dovoljen z varnega namizja."
+
+#: ../src/msw/filedlg.cpp:1242
+msgid "Security warning"
+msgstr "Varnostno opozorilo"
+
+#: ../src/msw/filedlg.cpp:1533
+#, c-format
+msgid "File dialog failed with error code %0lx."
+msgstr "Pogovorno okno izbirnika datotek je spodletelo, napaka %0lx."
+
+# common/textcmn.cpp:94
+#: ../src/msw/font.cpp:1120
+#, c-format
+msgid "Font file \"%s\" couldn't be loaded"
+msgstr "Datoteke pisave »%s« ni mogoče naložiti"
+
+#: ../src/msw/fontdlg.cpp:220
+#, c-format
+msgid "Common dialog failed with error code %0lx."
+msgstr "Pogovorno okno je spodletelo z napako %0lx."
+
+# msw/thread.cpp:871
+#: ../src/msw/fswatcher.cpp:67
+msgid "Ungraceful worker thread termination"
+msgstr "Nerodno dokončanje niti delovanja"
+
+# msw/mdi.cpp:428
+#: ../src/msw/fswatcher.cpp:81
+msgid "Unable to create IOCP worker thread"
+msgstr "Ni mogoče ustvariti niti delovanja IOCP"
+
+#: ../src/msw/fswatcher.cpp:88
+msgid "Unable to start IOCP worker thread"
+msgstr "Ni mogoče začeti niti delovanja IOCP"
+
+#: ../src/msw/fswatcher.cpp:140
+msgid "Monitoring individual files for changes is not supported currently."
+msgstr "Spremljanje posameznih datotek za spremembe trenutno ni podprto."
+
+# common/ffile.cpp:182
+#: ../src/msw/fswatcher.cpp:165
+#, c-format
+msgid "Unable to set up watch for '%s'"
+msgstr "Datoteki »%s« ni mogoče določiti opazovanja."
+
+#: ../src/msw/fswatcher.cpp:466
+#, c-format
+msgid "Can't monitor non-existent directory \"%s\" for changes."
+msgstr "Sprememb v neobstoječi mapi »%s« ni mogoče spremljati."
+
+#: ../src/msw/glcanvas.cpp:577 ../src/unix/glx11.cpp:507
+msgid "OpenGL 3.0 or later is not supported by the OpenGL driver."
+msgstr "Gonilnik OpenGL ne podpira OpenGL 3.0 ali novejšega."
+
+# msw/timer.cpp:96
+#: ../src/msw/glcanvas.cpp:601 ../src/osx/glcanvas_osx.cpp:395
+#: ../src/unix/glegl.cpp:304 ../src/unix/glx11.cpp:553
+msgid "Couldn't create OpenGL context"
+msgstr "Konteksta OpenGL ni mogoče ustvariti"
+
+#: ../src/msw/glcanvas.cpp:1294
+msgid "Failed to initialize OpenGL"
+msgstr "OpenGl neuspešno inicializiran."
+
+#: ../src/msw/graphicsd2d.cpp:607
+msgid "Could not register custom DirectWrite font loader."
+msgstr "Nalagalnika pisave DirectWrite po meri ni mogoče registrirati."
+
+#: ../src/msw/helpchm.cpp:48
+msgid ""
+"MS HTML Help functions are unavailable because the MS HTML Help library is "
+"not installed on this machine. Please install it."
+msgstr ""
+"Funkcije MS HTML Help niso na voljo, ker knjižnica MS HTML Help ni nameščena "
+"na tem računalniku. Prosimo, namestite jo."
+
+#: ../src/msw/helpchm.cpp:55
+msgid "Failed to initialize MS HTML Help."
+msgstr "Pomoč MS HTML neuspešno inicializirana."
+
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR Free Software Foundation, Inc.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+# msw/iniconf.cpp:476
+#: ../src/msw/iniconf.cpp:458
+#, c-format
+msgid "Can't delete the INI file '%s'"
+msgstr "Datoteke INI »%s« ni mogoče izbrisati."
+
+# msw/listctrl.cpp:616
+#: ../src/msw/listctrl.cpp:995
+#, c-format
+msgid "Couldn't retrieve information about list control item %d."
+msgstr "Podatkov o kontrolnem elementu seznama %d ni mogoče pridobiti."
+
+# msw/mdi.cpp:183
+#: ../src/msw/mdi.cpp:170 ../src/qt/mdi.cpp:253
+msgid "&Cascade"
+msgstr "&Kaskadno"
+
+# msw/mdi.cpp:184
+#: ../src/msw/mdi.cpp:171
+msgid "Tile &Horizontally"
+msgstr "Razporedi &vodoravno"
+
+# msw/mdi.cpp:185
+#: ../src/msw/mdi.cpp:172
+msgid "Tile &Vertically"
+msgstr "Razporedi &navpično"
+
+# msw/mdi.cpp:187
+#: ../src/msw/mdi.cpp:174
+msgid "&Arrange Icons"
+msgstr "&Uredi ikone"
+
+# msw/mdi.cpp:428
+#: ../src/msw/mdi.cpp:621
+msgid "Failed to create MDI parent frame."
+msgstr "Ustvarjanje starševskega okvira MDI ni uspelo."
+
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR Free Software Foundation, Inc.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+# msw/registry.cpp:399
+#: ../src/msw/mimetype.cpp:234
+#, c-format
+msgid "Failed to create registry entry for '%s' files."
+msgstr "Ključa registra za datoteke '%s' ni mogoče uspešno ustvariti."
+
+# generic/dirdlgg.cpp:550
+#: ../src/msw/ole/automtn.cpp:495
+#, c-format
+msgid "Failed to find CLSID of \"%s\""
+msgstr "CLSID za »%s« ni mogoče najti."
+
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR Free Software Foundation, Inc.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+# msw/registry.cpp:399
+#: ../src/msw/ole/automtn.cpp:512
+#, c-format
+msgid "Failed to create an instance of \"%s\""
+msgstr "Ustvarjanje instance %s ni uspelo."
+
+# msw/dialup.cpp:518
+#: ../src/msw/ole/automtn.cpp:552
+#, c-format
+msgid "Cannot get an active instance of \"%s\""
+msgstr "Aktivne instance »%s« ni mogoče pridobiti"
+
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR Free Software Foundation, Inc.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+# msw/registry.cpp:399
+#: ../src/msw/ole/automtn.cpp:564
+#, c-format
+msgid "Failed to get OLE automation interface for \"%s\""
+msgstr "Vmesnika avtomatizacije OLE za »%s« ni mogoče pridobiti."
+
+#: ../src/msw/ole/automtn.cpp:621
+msgid "Unknown name or named argument."
+msgstr "Neznano ime ali imenovani argument."
+
+#: ../src/msw/ole/automtn.cpp:625
+msgid "Incorrect number of arguments."
+msgstr "Nepravilno število argumentov."
+
+# common/cmdline.cpp:518
+#: ../src/msw/ole/automtn.cpp:637
+msgid "Unknown exception"
+msgstr "Nepoznana izjema"
+
+#: ../src/msw/ole/automtn.cpp:642
+msgid "Method or property not found."
+msgstr "Metode ali lastnosti ni mogoče najti."
+
+#: ../src/msw/ole/automtn.cpp:646
+msgid "Overflow while coercing argument values."
+msgstr "Prekoračitev med prisiljevanjem vrednosti argumentov."
+
+#: ../src/msw/ole/automtn.cpp:650
+msgid "Object implementation does not support named arguments."
+msgstr "Implementacija predmeta ne podpira imenovanih argumentov."
+
+#: ../src/msw/ole/automtn.cpp:654
+msgid "The locale ID is unknown."
+msgstr "ID krajevnih nastavitev ni znan."
+
+#: ../src/msw/ole/automtn.cpp:658
+msgid "Missing a required parameter."
+msgstr "Zahtevani parameter manjka."
+
+# common/intl.cpp:374
+#: ../src/msw/ole/automtn.cpp:662
+#, c-format
+msgid "Argument %u not found."
+msgstr "Argumenta %u ni mogoče najti."
+
+#: ../src/msw/ole/automtn.cpp:666
+#, c-format
+msgid "Type mismatch in argument %u."
+msgstr "Neujemanje vrste v argumentu %u."
+
+#: ../src/msw/ole/automtn.cpp:670
+msgid "The system cannot find the file specified."
+msgstr "Sistem ne more najti navedene datoteke."
+
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR Free Software Foundation, Inc.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+# msw/thread.cpp:519
+#: ../src/msw/ole/automtn.cpp:674
+msgid "Class not registered."
+msgstr "Razred ni registriran."
+
+# msw/dde.cpp:1030
+#: ../src/msw/ole/automtn.cpp:678
+#, c-format
+msgid "Unknown error %08x"
+msgstr "Neznana napaka %08x"
+
+#: ../src/msw/ole/automtn.cpp:682
+#, c-format
+msgid "OLE Automation error in %s: %s"
+msgstr "Napaka pri avtomatizaciji OLE v %s: %s"
+
+# msw/ole/dataobj.cpp:151
+#: ../src/msw/ole/dataobj.cpp:385
+#, c-format
+msgid "Couldn't register clipboard format '%s'."
+msgstr "Registracija oblike zapisa odložišča »%s« ni uspela."
+
+# msw/ole/dataobj.cpp:169
+#: ../src/msw/ole/dataobj.cpp:402
+#, c-format
+msgid "The clipboard format '%d' doesn't exist."
+msgstr "Oblika zapisa odložišča '%d' ne obstaja."
+
+#: ../src/msw/progdlg.cpp:1025
+msgid "Skip"
+msgstr "Preskoči"
+
+# generic/progdlgg.cpp:241
+#: ../src/msw/registry.cpp:141
+#, c-format
+msgid "unknown (%lu)"
+msgstr "neznano (%lu)"
+
+# msw/registry.cpp:348
+#: ../src/msw/registry.cpp:409
+#, c-format
+msgid "Can't get info about registry key '%s'"
+msgstr "Informacije o ključu »%s« niso dosegljive."
+
+# msw/registry.cpp:374
+#: ../src/msw/registry.cpp:445
+#, c-format
+msgid "Can't open registry key '%s'"
+msgstr "Registrskega ključa »%s« ni mogoče odpreti."
+
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR Free Software Foundation, Inc.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+# msw/registry.cpp:399
+#: ../src/msw/registry.cpp:478
+#, c-format
+msgid "Can't create registry key '%s'"
+msgstr "Registrskega ključa »%s« ni mogoče ustvariti."
+
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR Free Software Foundation, Inc.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+# msw/registry.cpp:418
+#: ../src/msw/registry.cpp:497
+#, c-format
+msgid "Can't close registry key '%s'"
+msgstr "Registrskega ključa »%s« ni mogoče zapreti."
+
+# msw/registry.cpp:432
+#: ../src/msw/registry.cpp:512
+#, c-format
+msgid "Registry value '%s' already exists."
+msgstr "Vrednost registra '%s' že obstaja."
+
+# msw/registry.cpp:440
+#: ../src/msw/registry.cpp:520
+#, c-format
+msgid "Failed to rename registry value '%s' to '%s'."
+msgstr "Preimenovanje vrednosti registra iz '%s' v '%s' ni uspelo."
+
+# msw/registry.cpp:490
+#: ../src/msw/registry.cpp:575
+#, c-format
+msgid "Can't copy values of unsupported type %d."
+msgstr "Vrednosti nepodprtega tipa %d ni mogoče kopirati."
+
+# msw/registry.cpp:501
+#: ../src/msw/registry.cpp:586
+#, c-format
+msgid "Registry key '%s' does not exist, cannot rename it."
+msgstr "Ključ registra '%s' ne obstaja, ni ga mogoče preimenovati."
+
+# msw/registry.cpp:532
+#: ../src/msw/registry.cpp:617
+#, c-format
+msgid "Registry key '%s' already exists."
+msgstr "Ključ registra '%s' že obstaja."
+
+# msw/registry.cpp:540
+#: ../src/msw/registry.cpp:625
+#, c-format
+msgid "Failed to rename the registry key '%s' to '%s'."
+msgstr "Preimenovanje ključa registra '%s' v '%s' ni uspelo."
+
+# common/ffile.cpp:182
+#: ../src/msw/registry.cpp:670
+#, c-format
+msgid "Failed to copy the registry subkey '%s' to '%s'."
+msgstr "Registrskega podključa '%s' ni mogoče kopirati v '%s'."
+
+# msw/registry.cpp:594
+#: ../src/msw/registry.cpp:683
+#, c-format
+msgid "Failed to copy registry value '%s'"
+msgstr "Neuspelo kopiranje vrednosti registra »%s«"
+
+# msw/registry.cpp:603
+#: ../src/msw/registry.cpp:692
+#, c-format
+msgid "Failed to copy the contents of registry key '%s' to '%s'."
+msgstr "Kopiranje vsebine registrskega ključa »%s« v »%s« ni uspelo."
+
+# msw/registry.cpp:628
+#: ../src/msw/registry.cpp:718
+#, c-format
+msgid ""
+"Registry key '%s' is needed for normal system operation,\n"
+"deleting it will leave your system in unusable state:\n"
+"operation aborted."
+msgstr ""
+"Ključ registra '%s' je potreben za običajno delovanje sistema,\n"
+"z njegovim brisanjem svoj sistem prepuščate v neuporabno stanje:\n"
+"operacija prekinjena."
+
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR Free Software Foundation, Inc.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+# msw/registry.cpp:658
+#: ../src/msw/registry.cpp:754
+#, c-format
+msgid "Can't delete key '%s'"
+msgstr "Ključa »%s« ni mogoče izbrisati."
+
+# msw/registry.cpp:683
+#: ../src/msw/registry.cpp:782
+#, c-format
+msgid "Can't delete value '%s' from key '%s'"
+msgstr "Vrednosti »%s« ni mogoče izbrisati iz ključa »%s«."
+
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR Free Software Foundation, Inc.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+# msw/registry.cpp:774
+# msw/registry.cpp:813
+#: ../src/msw/registry.cpp:855 ../src/msw/registry.cpp:887
+#: ../src/msw/registry.cpp:929 ../src/msw/registry.cpp:1000
+#, c-format
+msgid "Can't read value of key '%s'"
+msgstr "Vrednosti ključa »%s« ni mogoče prebrati."
+
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR Free Software Foundation, Inc.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+# msw/registry.cpp:799
+# msw/registry.cpp:923
+#: ../src/msw/registry.cpp:873 ../src/msw/registry.cpp:915
+#: ../src/msw/registry.cpp:963 ../src/msw/registry.cpp:1106
+#, c-format
+msgid "Can't set value of '%s'"
+msgstr "Vrednosti ključa »%s« ni mogoče nastaviti."
+
+#: ../src/msw/registry.cpp:894 ../src/msw/registry.cpp:943
+#, c-format
+msgid "Registry value \"%s\" is not numeric (but of type %s)"
+msgstr "Vrednost registra »%s« ni numerična (temveč vrste %s)"
+
+#: ../src/msw/registry.cpp:979
+#, c-format
+msgid "Registry value \"%s\" is not binary (but of type %s)"
+msgstr "Vrednost registra »%s« ni binarna (temveč vrste %s)"
+
+#: ../src/msw/registry.cpp:1028
+#, c-format
+msgid "Registry value \"%s\" is not text (but of type %s)"
+msgstr "Vrednost registra »%s« ni besedilna (temveč vrste %s)"
+
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR Free Software Foundation, Inc.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+# msw/registry.cpp:899
+#: ../src/msw/registry.cpp:1089
+#, c-format
+msgid "Can't read value of '%s'"
+msgstr "Vrednosti »%s« ni mogoče prebrati."
+
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR Free Software Foundation, Inc.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+# msw/registry.cpp:975
+#: ../src/msw/registry.cpp:1157
+#, c-format
+msgid "Can't enumerate values of key '%s'"
+msgstr "Vrednosti ključa »%s« ni mogoče prešteti."
+
+# msw/registry.cpp:1020
+#: ../src/msw/registry.cpp:1196
+#, c-format
+msgid "Can't enumerate subkeys of key '%s'"
+msgstr "Podključev ključa »%s« ni mogoče prešteti."
+
+#: ../src/msw/registry.cpp:1262
+#, c-format
+msgid ""
+"Exporting registry key: file \"%s\" already exists and won't be overwritten."
+msgstr ""
+"Izvoz registrskega ključa: datoteka \"%s\" že obstaja in ne bo prepisana."
+
+# msw/registry.cpp:490
+#: ../src/msw/registry.cpp:1411
+#, c-format
+msgid "Can't export value of unsupported type %d."
+msgstr "Vrednosti nepodprtega tipa %d ni mogoče izvoziti."
+
+#: ../src/msw/registry.cpp:1427
+#, c-format
+msgid "Ignoring value \"%s\" of the key \"%s\"."
+msgstr "Neupoštevanje vrednosti \"%s\" ključa \"%s\"."
+
+# msw/textctrl.cpp:219
+#: ../src/msw/textctrl.cpp:596
+msgid ""
+"Impossible to create a rich edit control, using simple text control instead. "
+"Please reinstall riched32.dll"
+msgstr ""
+"Kontrolnika za bogato urejanje ni mogoče ustvariti, namesto tega bo "
+"uporabljen kontrolnik za enostavno urejanje besedila. Prosimo, ponovno "
+"namestite riched32.dll"
+
+# msw/thread.cpp:433
+#: ../src/msw/thread.cpp:522 ../src/unix/threadpsx.cpp:850
+msgid "Cannot start thread: error writing TLS."
+msgstr "Niti ni mogoče začeti: napaka pri pisanju TLS."
+
+# msw/thread.cpp:485
+#: ../src/msw/thread.cpp:613
+msgid "Can't set thread priority"
+msgstr "Prioritet niti ni bilo mogoče nastaviti."
+
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR Free Software Foundation, Inc.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+# msw/thread.cpp:519
+#: ../src/msw/thread.cpp:649
+msgid "Can't create thread"
+msgstr "Niti ni mogoče ustvariti."
+
+# msw/thread.cpp:958
+#: ../src/msw/thread.cpp:668
+msgid "Couldn't terminate thread"
+msgstr "Niti ni mogoče končati."
+
+# msw/thread.cpp:871
+#: ../src/msw/thread.cpp:799
+msgid "Cannot wait for thread termination"
+msgstr "Ustavitve niti ni mogoče pričakati."
+
+# msw/thread.cpp:537
+#: ../src/msw/thread.cpp:873
+#, c-format
+msgid "Cannot suspend thread %lx"
+msgstr "Niti %lx ni mogoče začasno ustaviti."
+
+# msw/thread.cpp:552
+#: ../src/msw/thread.cpp:903
+#, c-format
+msgid "Cannot resume thread %lx"
+msgstr "Niti %lx ni mogoče nadaljevati"
+
+# msw/thread.cpp:578
+#: ../src/msw/thread.cpp:932
+msgid "Couldn't get the current thread pointer"
+msgstr "Trenutnega kazalca niti ni mogoče dobiti"
+
+# msw/thread.cpp:1071
+#: ../src/msw/thread.cpp:1333
+msgid ""
+"Thread module initialization failed: impossible to allocate index in thread "
+"local storage"
+msgstr ""
+"Inicializacija modula niti ni uspela: indeksa ni mogoče alocirati v lokalni "
+"shrambi niti"
+
+# msw/thread.cpp:1083
+#: ../src/msw/thread.cpp:1345
+msgid ""
+"Thread module initialization failed: cannot store value in thread local "
+"storage"
+msgstr ""
+"Inicializacija modula niti ni uspela: vrednosti ni mogoče shraniti v lokalni "
+"shrambi niti"
+
+# msw/timer.cpp:96
+#: ../src/msw/timer.cpp:133
+msgid "Couldn't create a timer"
+msgstr "Časovnika ni mogoče ustvariti"
+
+# msw/utils.cpp:376
+#: ../src/msw/utils.cpp:372
+msgid "can't find user's HOME, using current directory."
+msgstr "uporabnikove mape HOME ni mogoče najti, v uporabi je trenutna mapa."
+
+#: ../src/msw/utils.cpp:662
+#, c-format
+msgid "Failed to kill process %d"
+msgstr "Neuspešen uboj procesa %d"
+
+# common/ffile.cpp:182
+#: ../src/msw/utils.cpp:986
+#, c-format
+msgid "Failed to load resource \"%s\"."
+msgstr "Vira \"%s\" ni mogoče naložiti."
+
+# common/ffile.cpp:182
+#: ../src/msw/utils.cpp:993
+#, c-format
+msgid "Failed to lock resource \"%s\"."
+msgstr "Vira \"%s\" ni mogoče zakleniti."
+
+#. TRANSLATORS: MS Windows build number
+#: ../src/msw/utils.cpp:1209
+#, c-format
+msgid "build %lu"
+msgstr "gradnja %lu"
+
+#: ../src/msw/utils.cpp:1218
+msgid ", 64-bit edition"
+msgstr ", 64-bitna izdaja"
+
+# generic/dirdlgg.cpp:550
+#: ../src/msw/utilsexc.cpp:224
+msgid "Failed to create an anonymous pipe"
+msgstr "Brezimne cevi ni mogoče ustvariti."
+
+# generic/dirdlgg.cpp:550
+#: ../src/msw/utilsexc.cpp:697
+msgid "Failed to redirect the child process IO"
+msgstr "Preusmeritev otroških procesov IO ni uspela."
+
+# msw/utilsexc.cpp:585
+#: ../src/msw/utilsexc.cpp:870
+#, c-format
+msgid "Execution of command '%s' failed"
+msgstr "Izvajanje ukaza »%s« ni uspelo."
+
+# generic/dirdlgg.cpp:550
+#: ../src/msw/volume.cpp:337
+msgid "Failed to load mpr.dll."
+msgstr "Nalaganje mpr.dll ni uspelo."
+
+# html/helpdata.cpp:353
+#: ../src/msw/volume.cpp:506
+#, c-format
+msgid "Cannot read typename from '%s'!"
+msgstr "Imena tipa ni mogoče prebrati iz »%s«!"
+
+# common/filefn.cpp:1287
+# msw/dir.cpp:294
+#: ../src/msw/volume.cpp:615
+#, c-format
+msgid "Cannot load icon from '%s'."
+msgstr "Nalaganje ikone z »%s« ni možno."
+
+#: ../src/msw/webview_edge.cpp:285
+msgid "This program was compiled without support for setting Edge proxy."
+msgstr "Ta program je bil preveden brez podpore za nastavitev posrednika Edge."
+
+#: ../src/msw/webview_ie.cpp:1010
+msgid "Failed to find web view emulation level in the registry"
+msgstr "Iskanje ravni emulacije spletnega pogleda v registru ni uspelo"
+
+#: ../src/msw/webview_ie.cpp:1019
+msgid "Failed to set web view to modern emulation level"
+msgstr "Nastavitev spletnega pogleda na sodobno raven emulacije ni uspela"
+
+#: ../src/msw/webview_ie.cpp:1027
+msgid "Failed to reset web view to standard emulation level"
+msgstr "Ponastavitev spletnega pogleda na standardno raven emulacije ni uspela"
+
+#: ../src/msw/webview_ie.cpp:1049
+msgid "Can't run JavaScript script without a valid HTML document"
+msgstr "Skripta JavaScript ni mogoče zagnati brez veljavnega HTML dokumenta"
+
+# msw/thread.cpp:485
+#: ../src/msw/webview_ie.cpp:1056
+msgid "Can't get the JavaScript object"
+msgstr "Predmeta JavaScript ni mogoče pridobiti"
+
+# common/ffile.cpp:182
+#: ../src/msw/webview_ie.cpp:1070
+msgid "failed to evaluate"
+msgstr "ni bilo mogoče oceniti"
+
+# generic/fontdlgg.cpp:211
+#: ../src/osx/cocoa/filedlg.mm:412
+msgid "File type:"
+msgstr "Vrsta datoteke:"
+
+# msw/mdi.cpp:1287
+# msw/mdi.cpp:1294
+# msw/window.cpp:2286
+#: ../src/osx/cocoa/menu.mm:242
+msgctxt "macOS menu name"
+msgid "Window"
+msgstr "Okno"
+
+# common/dlgcmn.cpp:144
+# generic/proplist.cpp:528
+# html/helpfrm.cpp:208
+# msw/mdi.cpp:1283
+#: ../src/osx/cocoa/menu.mm:259
+msgctxt "macOS menu name"
+msgid "Help"
+msgstr "Pomoč"
+
+#: ../src/osx/cocoa/menu.mm:298
+msgctxt "macOS menu item"
+msgid "Minimize"
+msgstr "Pomanjšaj"
+
+#: ../src/osx/cocoa/menu.mm:303
+msgctxt "macOS menu item"
+msgid "Zoom"
+msgstr "Povečaj"
+
+#: ../src/osx/cocoa/menu.mm:309
+msgctxt "macOS menu item"
+msgid "Bring All to Front"
+msgstr "Pomakni vse v ospredje"
+
+# common/ffile.cpp:182
+#: ../src/osx/core/sound.cpp:143
+#, c-format
+msgid "Failed to load sound from \"%s\" (error %d)."
+msgstr "Vira iz »%s« ni mogoče naložiti (napaka %d)."
+
+# html/htmprint.cpp:272
+#: ../src/osx/fontutil.cpp:80
+#, c-format
+msgid "Font file \"%s\" doesn't exist."
+msgstr "Datoteka pisave »%s« ne obstaja."
+
+#: ../src/osx/fontutil.cpp:88
+#, c-format
+msgid ""
+"Font file \"%s\" cannot be used as it is not inside the font directory \"%s"
+"\"."
+msgstr ""
+"Datoteke pisave »%s« ni mogoče uporabiti, saj je ni v mapi pisave »%s«."
+
+#: ../src/osx/menu_osx.cpp:496
+#, c-format
+msgctxt "macOS menu item"
+msgid "About %s"
+msgstr "O programu %s ..."
+
+#: ../src/osx/menu_osx.cpp:499
+msgctxt "macOS menu item"
+msgid "About..."
+msgstr "O programu …"
+
+#: ../src/osx/menu_osx.cpp:508
+msgctxt "macOS menu item"
+msgid "Preferences..."
+msgstr "Možnosti ..."
+
+#: ../src/osx/menu_osx.cpp:512
+msgctxt "macOS menu item"
+msgid "Services"
+msgstr "Storitve"
+
+# generic/helpwxht.cpp:251
+# html/helpctrl.cpp:38
+#: ../src/osx/menu_osx.cpp:519
+#, c-format
+msgctxt "macOS menu item"
+msgid "Hide %s"
+msgstr "Skrij %s"
+
+# generic/dirdlgg.cpp:191
+#: ../src/osx/menu_osx.cpp:522
+msgctxt "macOS menu item"
+msgid "Hide Application"
+msgstr "Skrij program"
+
+#: ../src/osx/menu_osx.cpp:526
+msgctxt "macOS menu item"
+msgid "Hide Others"
+msgstr "Skrij druge"
+
+# html/helpfrm.cpp:331
+#: ../src/osx/menu_osx.cpp:528
+msgctxt "macOS menu item"
+msgid "Show All"
+msgstr "Pokaži vse"
+
+#: ../src/osx/menu_osx.cpp:534
+#, c-format
+msgctxt "macOS menu item"
+msgid "Quit %s"
+msgstr "Izhod iz %s"
+
+# generic/dirdlgg.cpp:191
+#: ../src/osx/menu_osx.cpp:537
+msgctxt "macOS menu item"
+msgid "Quit Application"
+msgstr "Izhod iz programa"
+
+#: ../src/osx/webview_webkit.mm:444
+msgid "Printing is not supported by the system web control"
+msgstr "Sistemski spletni nadzor ne podpira tiskanja"
+
+#: ../src/osx/webview_webkit.mm:453
+msgid "Print operation could not be initialized"
+msgstr "Operacije tiskanja ni bilo mogoče inicializirati"
+
+# html/helpfrm.cpp:899
+#. TRANSLATORS: Label of font point size
+#: ../src/propgrid/advprops.cpp:605
+msgid "Point Size"
+msgstr "Velikost točke"
+
+# generic/filedlgg.cpp:610
+#. TRANSLATORS: Label of font face name
+#: ../src/propgrid/advprops.cpp:615
+msgid "Face Name"
+msgstr "Ime pisave"
+
+#. TRANSLATORS: Label of font style
+#: ../src/propgrid/advprops.cpp:623 ../src/richtext/richtextformatdlg.cpp:331
+msgid "Style"
+msgstr "Slog"
+
+# generic/fontdlgg.cpp:216
+#. TRANSLATORS: Label of font weight
+#: ../src/propgrid/advprops.cpp:628
+msgid "Weight"
+msgstr "Debelina"
+
+# generic/fontdlgg.cpp:242
+#. TRANSLATORS: Label of underlined font
+#: ../src/propgrid/advprops.cpp:633 ../src/richtext/richtextfontpage.cpp:358
+msgid "Underlined"
+msgstr "Podčrtano"
+
+# html/helpfrm.cpp:899
+#. TRANSLATORS: Label of font family
+#: ../src/propgrid/advprops.cpp:637
+msgid "Family"
+msgstr "Družina"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:801
+msgid "AppWorkspace"
+msgstr "Delovna površina programa"
+
+# generic/fontdlgg.cpp:208
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:802
+msgid "ActiveBorder"
+msgstr "DejavnaObroba"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:803
+msgid "ActiveCaption"
+msgstr "DejavniNapis"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:804
+msgid "ButtonFace"
+msgstr "PloskevGumba"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:805
+msgid "ButtonHighlight"
+msgstr "PoudarekGumba"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:806
+msgid "ButtonShadow"
+msgstr "SencaGumba"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:807
+msgid "ButtonText"
+msgstr "BesediloGumba"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:808
+msgid "CaptionText"
+msgstr "BesediloNapisa"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:809
+msgid "ControlDark"
+msgstr "KrmilnikTemno"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:810
+msgid "ControlLight"
+msgstr "KrmilnikSvetlo"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:812
+msgid "GrayText"
+msgstr "SivoBesedilo"
+
+# generic/fontdlgg.cpp:216
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:813
+msgid "Highlight"
+msgstr "Poudari"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:814
+msgid "HighlightText"
+msgstr "PoudariBesedilo"
+
+# generic/fontdlgg.cpp:208
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:815
+msgid "InactiveBorder"
+msgstr "NedejavnaObroba"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:816
+msgid "InactiveCaption"
+msgstr "NedejavenNapis"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:817
+msgid "InactiveCaptionText"
+msgstr "BesediloNedejavnegaNapisa"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:818
+msgid "Menu"
+msgstr "Meni"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:819
+msgid "Scrollbar"
+msgstr "Drsnik"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:820
+msgid "Tooltip"
+msgstr "Orodni namig"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:821
+msgid "TooltipText"
+msgstr "BesediloOrodnegaNamiga"
+
+# msw/mdi.cpp:1287
+# msw/mdi.cpp:1294
+# msw/window.cpp:2286
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:822
+msgid "Window"
+msgstr "Okno"
+
+# msw/mdi.cpp:1287
+# msw/mdi.cpp:1294
+# msw/window.cpp:2286
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:823
+msgid "WindowFrame"
+msgstr "OkvirOkna"
+
+# msw/mdi.cpp:1287
+# msw/mdi.cpp:1294
+# msw/window.cpp:2286
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:824
+msgid "WindowText"
+msgstr "BesediloOkna"
+
+# html/helpfrm.cpp:899
+#. TRANSLATORS: Custom colour choice entry
+#: ../src/propgrid/advprops.cpp:825 ../src/propgrid/advprops.cpp:1532
+#: ../src/propgrid/advprops.cpp:1576
+msgid "Custom"
+msgstr "Po meri"
+
+#: ../src/propgrid/advprops.cpp:1558
+msgid "Black"
+msgstr "Črna"
+
+#: ../src/propgrid/advprops.cpp:1559
+msgid "Maroon"
+msgstr "Kostanjeva"
+
+#: ../src/propgrid/advprops.cpp:1560
+msgid "Navy"
+msgstr "Mornarska"
+
+#: ../src/propgrid/advprops.cpp:1561
+msgid "Purple"
+msgstr "Škrlatna"
+
+#: ../src/propgrid/advprops.cpp:1562
+msgid "Teal"
+msgstr "Modrozelena"
+
+#: ../src/propgrid/advprops.cpp:1563
+msgid "Gray"
+msgstr "Siva"
+
+#: ../src/propgrid/advprops.cpp:1564
+msgid "Green"
+msgstr "Zelena"
+
+#: ../src/propgrid/advprops.cpp:1565
+msgid "Olive"
+msgstr "Oljčna"
+
+#: ../src/propgrid/advprops.cpp:1566
+msgid "Brown"
+msgstr "Rjava"
+
+#: ../src/propgrid/advprops.cpp:1567
+msgid "Blue"
+msgstr "Modra"
+
+#: ../src/propgrid/advprops.cpp:1568
+msgid "Fuchsia"
+msgstr "Fuksija"
+
+# common/docview.cpp:1945
+# common/docview.cpp:1956
+#: ../src/propgrid/advprops.cpp:1569
+msgid "Red"
+msgstr "Rdeča"
+
+#: ../src/propgrid/advprops.cpp:1570
+msgid "Orange"
+msgstr "Oranžna"
+
+#: ../src/propgrid/advprops.cpp:1571
+msgid "Silver"
+msgstr "Srebrna"
+
+#: ../src/propgrid/advprops.cpp:1572
+msgid "Lime"
+msgstr "Limetna"
+
+#: ../src/propgrid/advprops.cpp:1573
+msgid "Aqua"
+msgstr "Aqua"
+
+#: ../src/propgrid/advprops.cpp:1574
+msgid "Yellow"
+msgstr "Rumena"
+
+#: ../src/propgrid/advprops.cpp:1575
+msgid "White"
+msgstr "Bela"
+
+#: ../src/propgrid/advprops.cpp:1718
+msgctxt "system cursor name"
+msgid "Default"
+msgstr "Privzeto"
+
+#: ../src/propgrid/advprops.cpp:1719
+msgctxt "system cursor name"
+msgid "Arrow"
+msgstr "Puščica"
+
+# generic/fontdlgg.cpp:216
+#: ../src/propgrid/advprops.cpp:1720
+msgctxt "system cursor name"
+msgid "Right Arrow"
+msgstr "Smerna tipka desno"
+
+#: ../src/propgrid/advprops.cpp:1721
+msgctxt "system cursor name"
+msgid "Blank"
+msgstr "Prazno"
+
+#: ../src/propgrid/advprops.cpp:1722
+msgctxt "system cursor name"
+msgid "Bullseye"
+msgstr "Tarča"
+
+#: ../src/propgrid/advprops.cpp:1723
+msgctxt "system cursor name"
+msgid "Character"
+msgstr "Znak"
+
+#: ../src/propgrid/advprops.cpp:1724
+msgctxt "system cursor name"
+msgid "Cross"
+msgstr "Križec"
+
+#: ../src/propgrid/advprops.cpp:1725
+msgctxt "system cursor name"
+msgid "Hand"
+msgstr "Roka"
+
+#: ../src/propgrid/advprops.cpp:1726
+msgctxt "system cursor name"
+msgid "I-Beam"
+msgstr "I-Beam"
+
+#: ../src/propgrid/advprops.cpp:1727
+msgctxt "system cursor name"
+msgid "Left Button"
+msgstr "Levi gumb"
+
+#: ../src/propgrid/advprops.cpp:1728
+msgctxt "system cursor name"
+msgid "Magnifier"
+msgstr "Povečevalo"
+
+#: ../src/propgrid/advprops.cpp:1729
+msgctxt "system cursor name"
+msgid "Middle Button"
+msgstr "Srednji gumb"
+
+#: ../src/propgrid/advprops.cpp:1730
+msgctxt "system cursor name"
+msgid "No Entry"
+msgstr "Ni vnosa"
+
+#: ../src/propgrid/advprops.cpp:1731
+msgctxt "system cursor name"
+msgid "Paint Brush"
+msgstr "Čopič"
+
+#: ../src/propgrid/advprops.cpp:1732
+msgctxt "system cursor name"
+msgid "Pencil"
+msgstr "Pisalo"
+
+# html/helpfrm.cpp:899
+#: ../src/propgrid/advprops.cpp:1733
+msgctxt "system cursor name"
+msgid "Point Left"
+msgstr "Usmeri levo"
+
+# generic/fontdlgg.cpp:216
+#: ../src/propgrid/advprops.cpp:1734
+msgctxt "system cursor name"
+msgid "Point Right"
+msgstr "Usmeri desno"
+
+# generic/logg.cpp:1023
+#: ../src/propgrid/advprops.cpp:1735
+msgctxt "system cursor name"
+msgid "Question Arrow"
+msgstr "Vprašaj s puščico"
+
+#: ../src/propgrid/advprops.cpp:1736
+msgctxt "system cursor name"
+msgid "Right Button"
+msgstr "Desni gumb"
+
+#: ../src/propgrid/advprops.cpp:1737
+msgctxt "system cursor name"
+msgid "Sizing NE-SW"
+msgstr "Določanje velikosti SV-JZ"
+
+#: ../src/propgrid/advprops.cpp:1738
+msgctxt "system cursor name"
+msgid "Sizing N-S"
+msgstr "Določanje velikosti S-J"
+
+#: ../src/propgrid/advprops.cpp:1739
+msgctxt "system cursor name"
+msgid "Sizing NW-SE"
+msgstr "Določanje velikosti SZ-JV"
+
+#: ../src/propgrid/advprops.cpp:1740
+msgctxt "system cursor name"
+msgid "Sizing W-E"
+msgstr "Določanje velikosti Z-V"
+
+#: ../src/propgrid/advprops.cpp:1741
+msgctxt "system cursor name"
+msgid "Sizing"
+msgstr "Določanje velikosti"
+
+#: ../src/propgrid/advprops.cpp:1742
+msgctxt "system cursor name"
+msgid "Spraycan"
+msgstr "Pršilka"
+
+#: ../src/propgrid/advprops.cpp:1743
+msgctxt "system cursor name"
+msgid "Wait"
+msgstr "Čakaj"
+
+#: ../src/propgrid/advprops.cpp:1744
+msgctxt "system cursor name"
+msgid "Watch"
+msgstr "Opazuj"
+
+#: ../src/propgrid/advprops.cpp:1745
+msgctxt "system cursor name"
+msgid "Wait Arrow"
+msgstr "Puščica čakanja"
+
+# generic/dirdlgg.cpp:191
+#: ../src/propgrid/advprops.cpp:2109
+msgid "Make a selection:"
+msgstr "Opravite izbor:"
+
+# html/helpfrm.cpp:512
+#: ../src/propgrid/manager.cpp:394
+msgid "Property"
+msgstr "Lastnost"
+
+#: ../src/propgrid/manager.cpp:395
+msgid "Value"
+msgstr "Vrednost"
+
+#: ../src/propgrid/manager.cpp:1683
+msgid "Categorized Mode"
+msgstr "Kategoriziran način"
+
+#: ../src/propgrid/manager.cpp:1709
+msgid "Alphabetic Mode"
+msgstr "Abecedni način"
+
+# generic/filedlgg.cpp:534
+#. TRANSLATORS: Name of Boolean false value
+#: ../src/propgrid/propgrid.cpp:230
+msgid "False"
+msgstr "Ne velja"
+
+#. TRANSLATORS: Name of Boolean true value
+#: ../src/propgrid/propgrid.cpp:232
+msgid "True"
+msgstr "Resnično"
+
+#. TRANSLATORS: Text  displayed for unspecified value
+#: ../src/propgrid/propgrid.cpp:428
+msgid "Unspecified"
+msgstr "Nedoločeno"
+
+# common/prntbase.cpp:120
+#. TRANSLATORS: Caption of message box displaying any property error
+#: ../src/propgrid/propgrid.cpp:3145 ../src/propgrid/propgrid.cpp:3282
+msgid "Property Error"
+msgstr "Napaka lastnosti"
+
+#: ../src/propgrid/propgrid.cpp:3259
+msgid "You have entered invalid value. Press ESC to cancel editing."
+msgstr ""
+"Vnesli ste neveljavno vrednost. Pritisnite ubežnico za preklic urejanja."
+
+#: ../src/propgrid/propgrid.cpp:6608
+#, c-format
+msgid "Error in resource: %s"
+msgstr "Napaka v viru: %s"
+
+#: ../src/propgrid/propgridiface.cpp:377
+#, c-format
+msgid ""
+"Type operation \"%s\" failed: Property labeled \"%s\" is of type \"%s\", NOT "
+"\"%s\"."
+msgstr ""
+"Operacija »%s« je spodletela: lastnost z oznako »%s« je vrste »%s« in NE "
+"»%s«."
+
+#: ../src/propgrid/props.cpp:159
+#, c-format
+msgid "Unknown base %d. Base 10 will be used."
+msgstr "Neznana osnova %d. Uporabili bomo osnovo 10."
+
+#: ../src/propgrid/props.cpp:324
+#, c-format
+msgid "Value must be %s or higher."
+msgstr "Vrednost mora biti enaka %s ali višja."
+
+#: ../src/propgrid/props.cpp:329 ../src/propgrid/props.cpp:356
+#, c-format
+msgid "Value must be between %s and %s."
+msgstr "Vnesite številko strani med %s in %s."
+
+#: ../src/propgrid/props.cpp:351
+#, c-format
+msgid "Value must be %s or less."
+msgstr "Vrednost mora biti enaka %s ali manjša."
+
+#: ../src/propgrid/props.cpp:1058
+#, c-format
+msgid "Not %s"
+msgstr "Ni %s"
+
+# generic/dirdlgg.cpp:572
+#: ../src/propgrid/props.cpp:1770
+msgid "Choose a directory:"
+msgstr "Izberite mapo:"
+
+#: ../src/propgrid/props.cpp:2055
+msgid "Choose a file"
+msgstr "Izberite datoteko"
+
+#: ../src/qt/mdi.cpp:254
+msgid "&Tile"
+msgstr "&Tlakuj"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:147
+#: ../src/richtext/richtextformatdlg.cpp:376
+msgid "Background"
+msgstr "Ozadje"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:159
+msgid "Background &colour:"
+msgstr "&Barva ozadja:"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:161
+#: ../src/richtext/richtextbackgroundpage.cpp:163
+msgid "Enables a background colour."
+msgstr "Omogoči barvo ozadja."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:167
+#: ../src/richtext/richtextbackgroundpage.cpp:169
+msgid "The background colour."
+msgstr "Barva ozadja."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:178
+msgid "Shadow"
+msgstr "Senca"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:193
+msgid "Use &shadow"
+msgstr "Uporabi &senco"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:195
+#: ../src/richtext/richtextbackgroundpage.cpp:197
+msgid "Enables a shadow."
+msgstr "Omogoči senco."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:211
+msgid "&Horizontal offset:"
+msgstr "&Vodoravni odmik:"
+
+# msw/mdi.cpp:184
+#: ../src/richtext/richtextbackgroundpage.cpp:218
+#: ../src/richtext/richtextbackgroundpage.cpp:220
+msgid "The horizontal offset."
+msgstr "Vodoravni odmik."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:224
+#: ../src/richtext/richtextbackgroundpage.cpp:227
+#: ../src/richtext/richtextbackgroundpage.cpp:228
+#: ../src/richtext/richtextbackgroundpage.cpp:247
+#: ../src/richtext/richtextbackgroundpage.cpp:250
+#: ../src/richtext/richtextbackgroundpage.cpp:251
+#: ../src/richtext/richtextbackgroundpage.cpp:287
+#: ../src/richtext/richtextbackgroundpage.cpp:290
+#: ../src/richtext/richtextbackgroundpage.cpp:291
+#: ../src/richtext/richtextbackgroundpage.cpp:314
+#: ../src/richtext/richtextbackgroundpage.cpp:317
+#: ../src/richtext/richtextbackgroundpage.cpp:318
+#: ../src/richtext/richtextborderspage.cpp:252
+#: ../src/richtext/richtextborderspage.cpp:255
+#: ../src/richtext/richtextborderspage.cpp:256
+#: ../src/richtext/richtextborderspage.cpp:286
+#: ../src/richtext/richtextborderspage.cpp:289
+#: ../src/richtext/richtextborderspage.cpp:290
+#: ../src/richtext/richtextborderspage.cpp:320
+#: ../src/richtext/richtextborderspage.cpp:323
+#: ../src/richtext/richtextborderspage.cpp:324
+#: ../src/richtext/richtextborderspage.cpp:354
+#: ../src/richtext/richtextborderspage.cpp:357
+#: ../src/richtext/richtextborderspage.cpp:358
+#: ../src/richtext/richtextborderspage.cpp:420
+#: ../src/richtext/richtextborderspage.cpp:423
+#: ../src/richtext/richtextborderspage.cpp:424
+#: ../src/richtext/richtextborderspage.cpp:454
+#: ../src/richtext/richtextborderspage.cpp:457
+#: ../src/richtext/richtextborderspage.cpp:458
+#: ../src/richtext/richtextborderspage.cpp:488
+#: ../src/richtext/richtextborderspage.cpp:491
+#: ../src/richtext/richtextborderspage.cpp:492
+#: ../src/richtext/richtextborderspage.cpp:522
+#: ../src/richtext/richtextborderspage.cpp:525
+#: ../src/richtext/richtextborderspage.cpp:526
+#: ../src/richtext/richtextborderspage.cpp:590
+#: ../src/richtext/richtextborderspage.cpp:593
+#: ../src/richtext/richtextborderspage.cpp:594
+#: ../src/richtext/richtextfontpage.cpp:177
+#: ../src/richtext/richtextmarginspage.cpp:199
+#: ../src/richtext/richtextmarginspage.cpp:201
+#: ../src/richtext/richtextmarginspage.cpp:202
+#: ../src/richtext/richtextmarginspage.cpp:224
+#: ../src/richtext/richtextmarginspage.cpp:226
+#: ../src/richtext/richtextmarginspage.cpp:227
+#: ../src/richtext/richtextmarginspage.cpp:247
+#: ../src/richtext/richtextmarginspage.cpp:249
+#: ../src/richtext/richtextmarginspage.cpp:250
+#: ../src/richtext/richtextmarginspage.cpp:272
+#: ../src/richtext/richtextmarginspage.cpp:274
+#: ../src/richtext/richtextmarginspage.cpp:275
+#: ../src/richtext/richtextmarginspage.cpp:313
+#: ../src/richtext/richtextmarginspage.cpp:315
+#: ../src/richtext/richtextmarginspage.cpp:316
+#: ../src/richtext/richtextmarginspage.cpp:338
+#: ../src/richtext/richtextmarginspage.cpp:340
+#: ../src/richtext/richtextmarginspage.cpp:341
+#: ../src/richtext/richtextmarginspage.cpp:361
+#: ../src/richtext/richtextmarginspage.cpp:363
+#: ../src/richtext/richtextmarginspage.cpp:364
+#: ../src/richtext/richtextmarginspage.cpp:386
+#: ../src/richtext/richtextmarginspage.cpp:388
+#: ../src/richtext/richtextmarginspage.cpp:389
+#: ../src/richtext/richtextsizepage.cpp:337
+#: ../src/richtext/richtextsizepage.cpp:340
+#: ../src/richtext/richtextsizepage.cpp:341
+#: ../src/richtext/richtextsizepage.cpp:371
+#: ../src/richtext/richtextsizepage.cpp:374
+#: ../src/richtext/richtextsizepage.cpp:375
+#: ../src/richtext/richtextsizepage.cpp:398
+#: ../src/richtext/richtextsizepage.cpp:401
+#: ../src/richtext/richtextsizepage.cpp:402
+#: ../src/richtext/richtextsizepage.cpp:425
+#: ../src/richtext/richtextsizepage.cpp:428
+#: ../src/richtext/richtextsizepage.cpp:429
+#: ../src/richtext/richtextsizepage.cpp:452
+#: ../src/richtext/richtextsizepage.cpp:455
+#: ../src/richtext/richtextsizepage.cpp:456
+#: ../src/richtext/richtextsizepage.cpp:479
+#: ../src/richtext/richtextsizepage.cpp:482
+#: ../src/richtext/richtextsizepage.cpp:483
+#: ../src/richtext/richtextsizepage.cpp:553
+#: ../src/richtext/richtextsizepage.cpp:556
+#: ../src/richtext/richtextsizepage.cpp:557
+#: ../src/richtext/richtextsizepage.cpp:588
+#: ../src/richtext/richtextsizepage.cpp:591
+#: ../src/richtext/richtextsizepage.cpp:592
+#: ../src/richtext/richtextsizepage.cpp:623
+#: ../src/richtext/richtextsizepage.cpp:626
+#: ../src/richtext/richtextsizepage.cpp:627
+#: ../src/richtext/richtextsizepage.cpp:658
+#: ../src/richtext/richtextsizepage.cpp:661
+#: ../src/richtext/richtextsizepage.cpp:662
+msgid "px"
+msgstr "sl. točka"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:225
+#: ../src/richtext/richtextbackgroundpage.cpp:248
+#: ../src/richtext/richtextbackgroundpage.cpp:288
+#: ../src/richtext/richtextbackgroundpage.cpp:315
+#: ../src/richtext/richtextborderspage.cpp:253
+#: ../src/richtext/richtextborderspage.cpp:287
+#: ../src/richtext/richtextborderspage.cpp:321
+#: ../src/richtext/richtextborderspage.cpp:355
+#: ../src/richtext/richtextborderspage.cpp:421
+#: ../src/richtext/richtextborderspage.cpp:455
+#: ../src/richtext/richtextborderspage.cpp:489
+#: ../src/richtext/richtextborderspage.cpp:523
+#: ../src/richtext/richtextborderspage.cpp:591
+#: ../src/richtext/richtextmarginspage.cpp:200
+#: ../src/richtext/richtextmarginspage.cpp:225
+#: ../src/richtext/richtextmarginspage.cpp:248
+#: ../src/richtext/richtextmarginspage.cpp:273
+#: ../src/richtext/richtextmarginspage.cpp:314
+#: ../src/richtext/richtextmarginspage.cpp:339
+#: ../src/richtext/richtextmarginspage.cpp:362
+#: ../src/richtext/richtextmarginspage.cpp:387
+#: ../src/richtext/richtextsizepage.cpp:338
+#: ../src/richtext/richtextsizepage.cpp:372
+#: ../src/richtext/richtextsizepage.cpp:399
+#: ../src/richtext/richtextsizepage.cpp:426
+#: ../src/richtext/richtextsizepage.cpp:453
+#: ../src/richtext/richtextsizepage.cpp:480
+#: ../src/richtext/richtextsizepage.cpp:554
+#: ../src/richtext/richtextsizepage.cpp:589
+#: ../src/richtext/richtextsizepage.cpp:624
+#: ../src/richtext/richtextsizepage.cpp:659
+msgid "cm"
+msgstr "cm"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:226
+#: ../src/richtext/richtextbackgroundpage.cpp:249
+#: ../src/richtext/richtextbackgroundpage.cpp:289
+#: ../src/richtext/richtextbackgroundpage.cpp:316
+#: ../src/richtext/richtextborderspage.cpp:254
+#: ../src/richtext/richtextborderspage.cpp:288
+#: ../src/richtext/richtextborderspage.cpp:322
+#: ../src/richtext/richtextborderspage.cpp:356
+#: ../src/richtext/richtextborderspage.cpp:422
+#: ../src/richtext/richtextborderspage.cpp:456
+#: ../src/richtext/richtextborderspage.cpp:490
+#: ../src/richtext/richtextborderspage.cpp:524
+#: ../src/richtext/richtextborderspage.cpp:592
+#: ../src/richtext/richtextfontpage.cpp:176
+#: ../src/richtext/richtextfontpage.cpp:179
+msgid "pt"
+msgstr "pk"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:229
+#: ../src/richtext/richtextbackgroundpage.cpp:231
+#: ../src/richtext/richtextbackgroundpage.cpp:252
+#: ../src/richtext/richtextbackgroundpage.cpp:254
+#: ../src/richtext/richtextbackgroundpage.cpp:292
+#: ../src/richtext/richtextbackgroundpage.cpp:294
+#: ../src/richtext/richtextbackgroundpage.cpp:319
+#: ../src/richtext/richtextbackgroundpage.cpp:321
+msgid "Units for this value."
+msgstr "Enote za to vrednost."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:234
+msgid "&Vertical offset:"
+msgstr "&Navpični odmik:"
+
+# generic/printps.cpp:209
+# msw/printwin.cpp:252
+#: ../src/richtext/richtextbackgroundpage.cpp:241
+#: ../src/richtext/richtextbackgroundpage.cpp:243
+msgid "The vertical offset."
+msgstr "Navpični odmik."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:257
+msgid "Shadow c&olour:"
+msgstr "Barva sen&ce:"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:259
+#: ../src/richtext/richtextbackgroundpage.cpp:261
+msgid "Enables the shadow colour."
+msgstr "Omogoči barvo sence."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:265
+#: ../src/richtext/richtextbackgroundpage.cpp:267
+msgid "The shadow colour."
+msgstr "Barva sence."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:270
+msgid "Sh&adow spread:"
+msgstr "Raz&širjanje sence:"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:272
+#: ../src/richtext/richtextbackgroundpage.cpp:274
+msgid "Enables the shadow spread."
+msgstr "Omogoči razširjanje sence."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:281
+#: ../src/richtext/richtextbackgroundpage.cpp:283
+msgid "The shadow spread."
+msgstr "Razširjanje sence."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:297
+msgid "&Blur distance:"
+msgstr "O&ddaljenost zabrisanosti:"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:299
+#: ../src/richtext/richtextbackgroundpage.cpp:301
+msgid "Enables the blur distance."
+msgstr "Omogoči oddaljenost zabrisanosti."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:308
+#: ../src/richtext/richtextbackgroundpage.cpp:310
+msgid "The shadow blur distance."
+msgstr "Oddaljenost zabrisanosti sence."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:324
+msgid "Opaci&ty:"
+msgstr "Pre&krivnost:"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:326
+#: ../src/richtext/richtextbackgroundpage.cpp:328
+msgid "Enables the shadow opacity."
+msgstr "Omogoči prekrivnost sence."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:335
+#: ../src/richtext/richtextbackgroundpage.cpp:337
+msgid "The shadow opacity."
+msgstr "Prekrivnost sence."
+
+#. TRANSLATORS: Rich text page units (percentage)
+#: ../src/richtext/richtextbackgroundpage.cpp:340
+#: ../src/richtext/richtextsizepage.cpp:339
+#: ../src/richtext/richtextsizepage.cpp:373
+#: ../src/richtext/richtextsizepage.cpp:400
+#: ../src/richtext/richtextsizepage.cpp:427
+#: ../src/richtext/richtextsizepage.cpp:454
+#: ../src/richtext/richtextsizepage.cpp:481
+#: ../src/richtext/richtextsizepage.cpp:555
+#: ../src/richtext/richtextsizepage.cpp:590
+#: ../src/richtext/richtextsizepage.cpp:625
+#: ../src/richtext/richtextsizepage.cpp:660
+msgid "%"
+msgstr " %"
+
+# generic/fontdlgg.cpp:208
+#: ../src/richtext/richtextborderspage.cpp:229
+#: ../src/richtext/richtextborderspage.cpp:387
+msgid "Border"
+msgstr "Obroba"
+
+#: ../src/richtext/richtextborderspage.cpp:242
+#: ../src/richtext/richtextborderspage.cpp:410
+#: ../src/richtext/richtextindentspage.cpp:194
+#: ../src/richtext/richtextliststylepage.cpp:384
+#: ../src/richtext/richtextmarginspage.cpp:185
+#: ../src/richtext/richtextmarginspage.cpp:299
+#: ../src/richtext/richtextsizepage.cpp:531
+#: ../src/richtext/richtextsizepage.cpp:538
+msgid "&Left:"
+msgstr "&Levo:"
+
+#: ../src/richtext/richtextborderspage.cpp:257
+#: ../src/richtext/richtextborderspage.cpp:259
+msgid "Units for the left border width."
+msgstr "Enote za širino levega roba."
+
+#: ../src/richtext/richtextborderspage.cpp:266
+#: ../src/richtext/richtextborderspage.cpp:268
+#: ../src/richtext/richtextborderspage.cpp:300
+#: ../src/richtext/richtextborderspage.cpp:302
+#: ../src/richtext/richtextborderspage.cpp:334
+#: ../src/richtext/richtextborderspage.cpp:336
+#: ../src/richtext/richtextborderspage.cpp:368
+#: ../src/richtext/richtextborderspage.cpp:370
+#: ../src/richtext/richtextborderspage.cpp:434
+#: ../src/richtext/richtextborderspage.cpp:436
+#: ../src/richtext/richtextborderspage.cpp:468
+#: ../src/richtext/richtextborderspage.cpp:470
+#: ../src/richtext/richtextborderspage.cpp:502
+#: ../src/richtext/richtextborderspage.cpp:504
+#: ../src/richtext/richtextborderspage.cpp:536
+#: ../src/richtext/richtextborderspage.cpp:538
+msgid "The border line style."
+msgstr "Slog obrobe."
+
+# generic/fontdlgg.cpp:216
+#: ../src/richtext/richtextborderspage.cpp:276
+#: ../src/richtext/richtextborderspage.cpp:444
+#: ../src/richtext/richtextindentspage.cpp:212
+#: ../src/richtext/richtextliststylepage.cpp:402
+#: ../src/richtext/richtextmarginspage.cpp:210
+#: ../src/richtext/richtextmarginspage.cpp:324
+#: ../src/richtext/richtextsizepage.cpp:601
+#: ../src/richtext/richtextsizepage.cpp:608
+msgid "&Right:"
+msgstr "&Desno:"
+
+#: ../src/richtext/richtextborderspage.cpp:291
+#: ../src/richtext/richtextborderspage.cpp:293
+msgid "Units for the right border width."
+msgstr "Enote za širino desnega roba."
+
+# generic/prntdlgg.cpp:191
+#: ../src/richtext/richtextborderspage.cpp:310
+#: ../src/richtext/richtextborderspage.cpp:478
+#: ../src/richtext/richtextmarginspage.cpp:233
+#: ../src/richtext/richtextmarginspage.cpp:347
+#: ../src/richtext/richtextsizepage.cpp:566
+#: ../src/richtext/richtextsizepage.cpp:573
+msgid "&Top:"
+msgstr "&Vrh:"
+
+#: ../src/richtext/richtextborderspage.cpp:325
+#: ../src/richtext/richtextborderspage.cpp:327
+msgid "Units for the top border width."
+msgstr "Enote za širino gornje obrobe."
+
+#: ../src/richtext/richtextborderspage.cpp:344
+#: ../src/richtext/richtextborderspage.cpp:512
+#: ../src/richtext/richtextmarginspage.cpp:258
+#: ../src/richtext/richtextmarginspage.cpp:372
+#: ../src/richtext/richtextsizepage.cpp:636
+#: ../src/richtext/richtextsizepage.cpp:643
+msgid "&Bottom:"
+msgstr "&Spodaj:"
+
+#: ../src/richtext/richtextborderspage.cpp:359
+#: ../src/richtext/richtextborderspage.cpp:361
+msgid "Units for the bottom border width."
+msgstr "Enote za širino spodnje obrobe."
+
+#: ../src/richtext/richtextborderspage.cpp:380
+#: ../src/richtext/richtextborderspage.cpp:548
+msgid "&Synchronize values"
+msgstr "&Uskladi vrednosti"
+
+#: ../src/richtext/richtextborderspage.cpp:382
+#: ../src/richtext/richtextborderspage.cpp:384
+#: ../src/richtext/richtextborderspage.cpp:550
+#: ../src/richtext/richtextborderspage.cpp:552
+msgid "Check to edit all borders simultaneously."
+msgstr "Potrdite, če želite urejati vse robove hkrati."
+
+#: ../src/richtext/richtextborderspage.cpp:397
+#: ../src/richtext/richtextborderspage.cpp:555
+msgid "Outline"
+msgstr "Oris"
+
+#: ../src/richtext/richtextborderspage.cpp:425
+#: ../src/richtext/richtextborderspage.cpp:427
+msgid "Units for the left outline width."
+msgstr "Enote za širino levega orisa."
+
+#: ../src/richtext/richtextborderspage.cpp:459
+#: ../src/richtext/richtextborderspage.cpp:461
+msgid "Units for the right outline width."
+msgstr "Enote za širino desnega orisa."
+
+#: ../src/richtext/richtextborderspage.cpp:493
+#: ../src/richtext/richtextborderspage.cpp:495
+msgid "Units for the top outline width."
+msgstr "Enote za širino gornjega orisa."
+
+#: ../src/richtext/richtextborderspage.cpp:527
+#: ../src/richtext/richtextborderspage.cpp:529
+msgid "Units for the bottom outline width."
+msgstr "Enote za širino spodnjega orisa."
+
+#: ../src/richtext/richtextborderspage.cpp:565
+#: ../src/richtext/richtextborderspage.cpp:600
+msgid "Corner"
+msgstr "Oglišče"
+
+#: ../src/richtext/richtextborderspage.cpp:574
+msgid "Corner &radius:"
+msgstr "Polmer o&glišča:"
+
+#: ../src/richtext/richtextborderspage.cpp:576
+#: ../src/richtext/richtextborderspage.cpp:578
+msgid "An optional corner radius for adding rounded corners."
+msgstr "Neobvezni polmer kotov za zaobljanje robov."
+
+#: ../src/richtext/richtextborderspage.cpp:584
+#: ../src/richtext/richtextborderspage.cpp:586
+msgid "The value of the corner radius."
+msgstr "Vrednost polmera koda."
+
+# msw/thread.cpp:871
+#: ../src/richtext/richtextborderspage.cpp:595
+#: ../src/richtext/richtextborderspage.cpp:597
+msgid "Units for the corner radius."
+msgstr "Enote za polmer oglišča."
+
+#: ../src/richtext/richtextborderspage.cpp:609
+#: ../src/richtext/richtextsizepage.cpp:247
+#: ../src/richtext/richtextsizepage.cpp:251
+msgid "None"
+msgstr "Brez"
+
+# generic/fontdlgg.cpp:217
+#: ../src/richtext/richtextborderspage.cpp:610
+msgid "Solid"
+msgstr "Zapolnjeno"
+
+# html/htmlwin.cpp:216
+#: ../src/richtext/richtextborderspage.cpp:611
+msgid "Dotted"
+msgstr "Pikčasto"
+
+#: ../src/richtext/richtextborderspage.cpp:612
+msgid "Dashed"
+msgstr "Črtkano"
+
+#: ../src/richtext/richtextborderspage.cpp:613
+msgid "Double"
+msgstr "Dvojno"
+
+#: ../src/richtext/richtextborderspage.cpp:614
+msgid "Groove"
+msgstr "Groove"
+
+# generic/fontdlgg.cpp:216
+#: ../src/richtext/richtextborderspage.cpp:615
+msgid "Ridge"
+msgstr "Brazda"
+
+# html/helpfrm.cpp:372
+#: ../src/richtext/richtextborderspage.cpp:616
+msgid "Inset"
+msgstr "Vstavek"
+
+#: ../src/richtext/richtextborderspage.cpp:617
+msgid "Outset"
+msgstr "Izraščeno"
+
+#: ../src/richtext/richtextbuffer.cpp:3518
+msgid "Change Style"
+msgstr "Spremeni slog"
+
+#: ../src/richtext/richtextbuffer.cpp:3701
+msgid "Change Object Style"
+msgstr "Spremeni slog predmeta"
+
+# html/helpfrm.cpp:512
+#: ../src/richtext/richtextbuffer.cpp:3974
+#: ../src/richtext/richtextbuffer.cpp:8174
+msgid "Change Properties"
+msgstr "Spremeni lastnosti"
+
+#: ../src/richtext/richtextbuffer.cpp:4346
+msgid "Change List Style"
+msgstr "Spremeni slog seznama"
+
+#: ../src/richtext/richtextbuffer.cpp:4519
+msgid "Renumber List"
+msgstr "Ponovno oštevilči seznam"
+
+#: ../src/richtext/richtextbuffer.cpp:7867
+#: ../src/richtext/richtextbuffer.cpp:7897
+#: ../src/richtext/richtextbuffer.cpp:7939
+#: ../src/richtext/richtextctrl.cpp:1279 ../src/richtext/richtextctrl.cpp:1473
+msgid "Insert Text"
+msgstr "Vstavi besedilo"
+
+#: ../src/richtext/richtextbuffer.cpp:8023
+#: ../src/richtext/richtextbuffer.cpp:8979
+msgid "Insert Image"
+msgstr "Vstavi sliko"
+
+#: ../src/richtext/richtextbuffer.cpp:8070
+msgid "Insert Object"
+msgstr "Vstavi predmet"
+
+#: ../src/richtext/richtextbuffer.cpp:8112
+msgid "Insert Field"
+msgstr "Vstavi polje"
+
+#: ../src/richtext/richtextbuffer.cpp:8410
+msgid "Too many EndStyle calls!"
+msgstr "Preveč klicev EndStyle!"
+
+# generic/filedlgg.cpp:534
+#: ../src/richtext/richtextbuffer.cpp:8785
+msgid "files"
+msgstr "datotek"
+
+#: ../src/richtext/richtextbuffer.cpp:9380
+msgid "standard/circle"
+msgstr "navadno/krog"
+
+#: ../src/richtext/richtextbuffer.cpp:9381
+msgid "standard/circle-outline"
+msgstr "navadno/oris-kroga"
+
+#: ../src/richtext/richtextbuffer.cpp:9382
+msgid "standard/square"
+msgstr "navadno/kvadrat"
+
+#: ../src/richtext/richtextbuffer.cpp:9383
+msgid "standard/diamond"
+msgstr "navadno/karo"
+
+#: ../src/richtext/richtextbuffer.cpp:9384
+msgid "standard/triangle"
+msgstr "navadno/trikotnik"
+
+# html/helpfrm.cpp:512
+#: ../src/richtext/richtextbuffer.cpp:9423
+msgid "Box Properties"
+msgstr "Lastnosti polja"
+
+#: ../src/richtext/richtextbuffer.cpp:10006
+msgid "Multiple Cell Properties"
+msgstr "Lastnosti več vrstic"
+
+# html/helpfrm.cpp:512
+#: ../src/richtext/richtextbuffer.cpp:10008
+msgid "Cell Properties"
+msgstr "Lastnosti celice"
+
+#: ../src/richtext/richtextbuffer.cpp:11256
+msgid "Set Cell Style"
+msgstr "Določite slog celice"
+
+#: ../src/richtext/richtextbuffer.cpp:11330
+msgid "Delete Row"
+msgstr "Izbriši vrstico"
+
+# generic/dirdlgg.cpp:191
+#: ../src/richtext/richtextbuffer.cpp:11380
+msgid "Delete Column"
+msgstr "Izbriši stolpec"
+
+#: ../src/richtext/richtextbuffer.cpp:11431
+msgid "Add Row"
+msgstr "Dodaj vrstico"
+
+#: ../src/richtext/richtextbuffer.cpp:11494
+msgid "Add Column"
+msgstr "Dodaj stolpec"
+
+# html/helpfrm.cpp:512
+#: ../src/richtext/richtextbuffer.cpp:11537
+msgid "Table Properties"
+msgstr "Lastnosti tabele"
+
+# html/helpfrm.cpp:512
+#: ../src/richtext/richtextbuffer.cpp:12899
+msgid "Picture Properties"
+msgstr "Lastnosti slike"
+
+#: ../src/richtext/richtextbuffer.cpp:13169
+#: ../src/richtext/richtextbuffer.cpp:13279
+msgid "image"
+msgstr "slika"
+
+#: ../src/richtext/richtextbulletspage.cpp:145
+#: ../src/richtext/richtextliststylepage.cpp:209
+msgid "&Bullet style:"
+msgstr "Slog &oznak:"
+
+#: ../src/richtext/richtextbulletspage.cpp:150
+#: ../src/richtext/richtextbulletspage.cpp:152
+#: ../src/richtext/richtextliststylepage.cpp:214
+#: ../src/richtext/richtextliststylepage.cpp:216
+msgid "The available bullet styles."
+msgstr "Slogi oznak, ki so na voljo."
+
+#: ../src/richtext/richtextbulletspage.cpp:158
+#: ../src/richtext/richtextliststylepage.cpp:221
+msgid "Peri&od"
+msgstr "Pi&ka"
+
+#: ../src/richtext/richtextbulletspage.cpp:160
+#: ../src/richtext/richtextbulletspage.cpp:162
+#: ../src/richtext/richtextliststylepage.cpp:223
+#: ../src/richtext/richtextliststylepage.cpp:225
+msgid "Check to add a period after the bullet."
+msgstr "Označite polje za dodajanje pike po oznaki."
+
+#. TRANSLATORS: Bullet point in parentheses option
+#: ../src/richtext/richtextbulletspage.cpp:167
+#: ../src/richtext/richtextliststylepage.cpp:230
+msgid "(*)"
+msgstr "(*)"
+
+#: ../src/richtext/richtextbulletspage.cpp:169
+#: ../src/richtext/richtextbulletspage.cpp:171
+#: ../src/richtext/richtextliststylepage.cpp:232
+#: ../src/richtext/richtextliststylepage.cpp:234
+msgid "Check to enclose the bullet in parentheses."
+msgstr "Označite polje za umestitev oznake med oklepaj in zaklepaj."
+
+#. TRANSLATORS: Right parenthesis bullet point option
+#: ../src/richtext/richtextbulletspage.cpp:176
+#: ../src/richtext/richtextliststylepage.cpp:239
+msgid "*)"
+msgstr "*)"
+
+#: ../src/richtext/richtextbulletspage.cpp:178
+#: ../src/richtext/richtextbulletspage.cpp:180
+#: ../src/richtext/richtextliststylepage.cpp:241
+#: ../src/richtext/richtextliststylepage.cpp:243
+msgid "Check to add a right parenthesis."
+msgstr "Označite polje za dodajanje zaklepaja."
+
+#: ../src/richtext/richtextbulletspage.cpp:185
+#: ../src/richtext/richtextliststylepage.cpp:248
+msgid "Bullet &Alignment:"
+msgstr "Po&ravnava oznak:"
+
+# generic/dirdlgg.cpp:217
+#: ../src/richtext/richtextbulletspage.cpp:190
+#: ../src/richtext/richtextliststylepage.cpp:253
+msgid "Centre"
+msgstr "Sredinsko"
+
+#: ../src/richtext/richtextbulletspage.cpp:194
+#: ../src/richtext/richtextbulletspage.cpp:196
+#: ../src/richtext/richtextbulletspage.cpp:217
+#: ../src/richtext/richtextbulletspage.cpp:219
+#: ../src/richtext/richtextliststylepage.cpp:257
+#: ../src/richtext/richtextliststylepage.cpp:259
+#: ../src/richtext/richtextliststylepage.cpp:278
+#: ../src/richtext/richtextliststylepage.cpp:280
+msgid "The bullet character."
+msgstr "Znak za oznake."
+
+#: ../src/richtext/richtextbulletspage.cpp:212
+#: ../src/richtext/richtextliststylepage.cpp:271
+msgid "&Symbol:"
+msgstr "&Simbol:"
+
+#: ../src/richtext/richtextbulletspage.cpp:222
+#: ../src/richtext/richtextliststylepage.cpp:283
+msgid "Ch&oose..."
+msgstr "&Izberi ..."
+
+#: ../src/richtext/richtextbulletspage.cpp:223
+#: ../src/richtext/richtextbulletspage.cpp:225
+#: ../src/richtext/richtextliststylepage.cpp:284
+#: ../src/richtext/richtextliststylepage.cpp:286
+msgid "Click to browse for a symbol."
+msgstr "Kliknite za iskanje posebnega znaka."
+
+# html/helpfrm.cpp:881
+#: ../src/richtext/richtextbulletspage.cpp:230
+#: ../src/richtext/richtextliststylepage.cpp:291
+msgid "Symbol &font:"
+msgstr "P&isava posebnih znakov:"
+
+#: ../src/richtext/richtextbulletspage.cpp:235
+#: ../src/richtext/richtextbulletspage.cpp:237
+#: ../src/richtext/richtextliststylepage.cpp:297
+msgid "Available fonts."
+msgstr "Pisave na voljo."
+
+#: ../src/richtext/richtextbulletspage.cpp:242
+#: ../src/richtext/richtextliststylepage.cpp:302
+msgid "S&tandard bullet name:"
+msgstr "&Navadno ime oznake:"
+
+#: ../src/richtext/richtextbulletspage.cpp:247
+#: ../src/richtext/richtextbulletspage.cpp:249
+#: ../src/richtext/richtextliststylepage.cpp:307
+#: ../src/richtext/richtextliststylepage.cpp:309
+msgid "A standard bullet name."
+msgstr "Standardno ime oznake."
+
+#: ../src/richtext/richtextbulletspage.cpp:254
+msgid "&Number:"
+msgstr "&Številka:"
+
+#: ../src/richtext/richtextbulletspage.cpp:258
+#: ../src/richtext/richtextbulletspage.cpp:260
+msgid "The list item number."
+msgstr "Številka elementa seznama."
+
+#: ../src/richtext/richtextbulletspage.cpp:266
+#: ../src/richtext/richtextbulletspage.cpp:268
+#: ../src/richtext/richtextliststylepage.cpp:475
+#: ../src/richtext/richtextliststylepage.cpp:477
+msgid "Shows a preview of the bullet settings."
+msgstr "Pokaže predogled nastavitev oznak."
+
+#: ../src/richtext/richtextbulletspage.cpp:276
+#: ../src/richtext/richtextliststylepage.cpp:484
+msgid "(None)"
+msgstr "(brez)"
+
+#: ../src/richtext/richtextbulletspage.cpp:277
+#: ../src/richtext/richtextliststylepage.cpp:485
+msgid "Arabic"
+msgstr "arabsko"
+
+#: ../src/richtext/richtextbulletspage.cpp:278
+#: ../src/richtext/richtextliststylepage.cpp:486
+msgid "Upper case letters"
+msgstr "Velike začetnice"
+
+#: ../src/richtext/richtextbulletspage.cpp:279
+#: ../src/richtext/richtextliststylepage.cpp:487
+msgid "Lower case letters"
+msgstr "Male črke"
+
+#: ../src/richtext/richtextbulletspage.cpp:280
+#: ../src/richtext/richtextliststylepage.cpp:488
+msgid "Upper case roman numerals"
+msgstr "Velike rimske številke"
+
+#: ../src/richtext/richtextbulletspage.cpp:281
+#: ../src/richtext/richtextliststylepage.cpp:489
+msgid "Lower case roman numerals"
+msgstr "Majhne rimske številke"
+
+#: ../src/richtext/richtextbulletspage.cpp:282
+#: ../src/richtext/richtextliststylepage.cpp:490
+msgid "Numbered outline"
+msgstr "Oštevilčen oris"
+
+#: ../src/richtext/richtextbulletspage.cpp:283
+#: ../src/richtext/richtextliststylepage.cpp:491
+msgid "Symbol"
+msgstr "Simbol"
+
+#: ../src/richtext/richtextbulletspage.cpp:284
+#: ../src/richtext/richtextliststylepage.cpp:492
+msgid "Bitmap"
+msgstr "Bitna slika"
+
+#: ../src/richtext/richtextbulletspage.cpp:285
+#: ../src/richtext/richtextliststylepage.cpp:493
+msgid "Standard"
+msgstr "Navadno"
+
+#: ../src/richtext/richtextbulletspage.cpp:287
+#: ../src/richtext/richtextliststylepage.cpp:495
+msgid "*"
+msgstr "*"
+
+#: ../src/richtext/richtextbulletspage.cpp:288
+#: ../src/richtext/richtextliststylepage.cpp:496
+msgid "-"
+msgstr "-"
+
+#: ../src/richtext/richtextbulletspage.cpp:289
+#: ../src/richtext/richtextliststylepage.cpp:497
+msgid ">"
+msgstr ">"
+
+#: ../src/richtext/richtextbulletspage.cpp:290
+#: ../src/richtext/richtextliststylepage.cpp:498
+msgid "+"
+msgstr "+"
+
+#: ../src/richtext/richtextbulletspage.cpp:291
+#: ../src/richtext/richtextliststylepage.cpp:499
+msgid "~"
+msgstr "~"
+
+#: ../src/richtext/richtextctrl.cpp:859
+msgid "Drag"
+msgstr "Povleci"
+
+#: ../src/richtext/richtextctrl.cpp:1338 ../src/richtext/richtextctrl.cpp:1559
+msgid "Delete Text"
+msgstr "Izbriši besedilo"
+
+#: ../src/richtext/richtextctrl.cpp:1537
+msgid "Remove Bullet"
+msgstr "Odstrani oznako"
+
+# common/textcmn.cpp:121
+#: ../src/richtext/richtextctrl.cpp:3070
+msgid "The text couldn't be saved."
+msgstr "Besedila ni mogoče shraniti."
+
+#: ../src/richtext/richtextctrl.cpp:3644
+msgid "Replace"
+msgstr "Zamenjaj"
+
+# html/helpfrm.cpp:899
+#: ../src/richtext/richtextfontpage.cpp:146
+#: ../src/richtext/richtextsymboldlg.cpp:384
+msgid "&Font:"
+msgstr "&Pisava:"
+
+#: ../src/richtext/richtextfontpage.cpp:150
+#: ../src/richtext/richtextfontpage.cpp:152
+msgid "Type a font name."
+msgstr "Vpišite ime pisave."
+
+# generic/filedlgg.cpp:534
+#: ../src/richtext/richtextfontpage.cpp:158
+msgid "&Size:"
+msgstr "&Velikost:"
+
+#: ../src/richtext/richtextfontpage.cpp:165
+#: ../src/richtext/richtextfontpage.cpp:167
+msgid "Type a size in points."
+msgstr "Vnesite velikost v točkah."
+
+# html/helpfrm.cpp:899
+#: ../src/richtext/richtextfontpage.cpp:180
+#: ../src/richtext/richtextfontpage.cpp:182
+msgid "The font size units, points or pixels."
+msgstr "Enote velikosti pisave, točke ali slikovne točke."
+
+# generic/tipdlg.cpp:138
+#: ../src/richtext/richtextfontpage.cpp:189
+#: ../src/richtext/richtextfontpage.cpp:191
+msgid "Lists the available fonts."
+msgstr "Izpiše pisave, ki so na voljo."
+
+#: ../src/richtext/richtextfontpage.cpp:196
+#: ../src/richtext/richtextfontpage.cpp:198
+msgid "Lists font sizes in points."
+msgstr "Seznam velikosti pisave v točkah."
+
+# html/helpfrm.cpp:899
+#: ../src/richtext/richtextfontpage.cpp:207
+msgid "Font st&yle:"
+msgstr "Slo&g pisave:"
+
+#: ../src/richtext/richtextfontpage.cpp:212
+#: ../src/richtext/richtextfontpage.cpp:214
+msgid "Select regular or italic style."
+msgstr "Izberite navadno ali ležeče."
+
+#: ../src/richtext/richtextfontpage.cpp:220
+msgid "Font &weight:"
+msgstr "&Odebeljenost pisave:"
+
+#: ../src/richtext/richtextfontpage.cpp:225
+#: ../src/richtext/richtextfontpage.cpp:227
+msgid "Select regular or bold."
+msgstr "Izberite navadno ali krepko."
+
+# generic/fontdlgg.cpp:242
+#: ../src/richtext/richtextfontpage.cpp:233
+msgid "&Underlining:"
+msgstr "&Podčrtovanje:"
+
+#: ../src/richtext/richtextfontpage.cpp:238
+#: ../src/richtext/richtextfontpage.cpp:240
+msgid "Select underlining or no underlining."
+msgstr "Izberite podčrtano ali nepodčrtano."
+
+#: ../src/richtext/richtextfontpage.cpp:248
+msgid "&Colour:"
+msgstr "&Barva:"
+
+#: ../src/richtext/richtextfontpage.cpp:253
+#: ../src/richtext/richtextfontpage.cpp:255
+msgid "Click to change the text colour."
+msgstr "Kliknite za spremembo barve besedila."
+
+#: ../src/richtext/richtextfontpage.cpp:261
+msgid "&Bg colour:"
+msgstr "&Barva ozadja:"
+
+#: ../src/richtext/richtextfontpage.cpp:266
+#: ../src/richtext/richtextfontpage.cpp:268
+msgid "Click to change the text background colour."
+msgstr "Kliknite za spremembo barve ozadja besedila."
+
+#: ../src/richtext/richtextfontpage.cpp:276
+#: ../src/richtext/richtextfontpage.cpp:278
+msgid "Check to show a line through the text."
+msgstr "Označite polje za prečrtano besedilo."
+
+#: ../src/richtext/richtextfontpage.cpp:281
+msgid "Ca&pitals"
+msgstr "Ve&like začetnice"
+
+#: ../src/richtext/richtextfontpage.cpp:283
+#: ../src/richtext/richtextfontpage.cpp:285
+msgid "Check to show the text in capitals."
+msgstr "Označite za besedilo v velikih začetnicah."
+
+#: ../src/richtext/richtextfontpage.cpp:288
+msgid "Small C&apitals"
+msgstr "&Male začetnice"
+
+#: ../src/richtext/richtextfontpage.cpp:290
+#: ../src/richtext/richtextfontpage.cpp:292
+msgid "Check to show the text in small capitals."
+msgstr "Potrdite za besedilo v malih začetnicah."
+
+# generic/fontdlgg.cpp:209
+#: ../src/richtext/richtextfontpage.cpp:295
+msgid "Supe&rscript"
+msgstr "&Nadpisano"
+
+#: ../src/richtext/richtextfontpage.cpp:297
+#: ../src/richtext/richtextfontpage.cpp:299
+msgid "Check to show the text in superscript."
+msgstr "Označite za nadpisano besedilo."
+
+# generic/fontdlgg.cpp:209
+#: ../src/richtext/richtextfontpage.cpp:302
+msgid "Subscrip&t"
+msgstr "Po&dpisano"
+
+#: ../src/richtext/richtextfontpage.cpp:304
+#: ../src/richtext/richtextfontpage.cpp:306
+msgid "Check to show the text in subscript."
+msgstr "Označite za podpisano besedilo."
+
+#: ../src/richtext/richtextfontpage.cpp:312
+msgid "Rig&ht-to-left"
+msgstr "Z de&sne na levo"
+
+#: ../src/richtext/richtextfontpage.cpp:314
+#: ../src/richtext/richtextfontpage.cpp:316
+msgid "Check to indicate right-to-left text layout."
+msgstr "Potrdite za spremembo smeri besedila v D-L."
+
+#: ../src/richtext/richtextfontpage.cpp:319
+msgid "Suppress hyphe&nation"
+msgstr "Preskoči deljenje &besed"
+
+#: ../src/richtext/richtextfontpage.cpp:321
+#: ../src/richtext/richtextfontpage.cpp:323
+msgid "Check to suppress hyphenation."
+msgstr "Potrdite za preprečitev deljenja besed."
+
+#: ../src/richtext/richtextfontpage.cpp:329
+#: ../src/richtext/richtextfontpage.cpp:331
+msgid "Shows a preview of the font settings."
+msgstr "Pokaže predogled nastavitev pisave."
+
+# html/helpdata.cpp:644
+#: ../src/richtext/richtextfontpage.cpp:348
+#: ../src/richtext/richtextfontpage.cpp:352
+#: ../src/richtext/richtextfontpage.cpp:356
+#: ../src/richtext/richtextformatdlg.cpp:873
+#: ../src/richtext/richtextindentspage.cpp:273
+#: ../src/richtext/richtextindentspage.cpp:285
+#: ../src/richtext/richtextindentspage.cpp:286
+#: ../src/richtext/richtextindentspage.cpp:310
+#: ../src/richtext/richtextindentspage.cpp:325
+#: ../src/richtext/richtextliststylepage.cpp:451
+#: ../src/richtext/richtextliststylepage.cpp:463
+#: ../src/richtext/richtextliststylepage.cpp:464
+msgid "(none)"
+msgstr "(brez)"
+
+#: ../src/richtext/richtextfontpage.cpp:349
+#: ../src/richtext/richtextfontpage.cpp:353
+msgid "Regular"
+msgstr "Navadno"
+
+# generic/fontdlgg.cpp:242
+#: ../src/richtext/richtextfontpage.cpp:357
+msgid "Not underlined"
+msgstr "Nepodčrtano"
+
+#: ../src/richtext/richtextformatdlg.cpp:341
+msgid "Indents && Spacing"
+msgstr "Zamiki in razmiki"
+
+#: ../src/richtext/richtextformatdlg.cpp:346
+msgid "Tabs"
+msgstr "Tabulatorji"
+
+#: ../src/richtext/richtextformatdlg.cpp:351
+msgid "Bullets"
+msgstr "Oznake"
+
+#: ../src/richtext/richtextformatdlg.cpp:356
+msgid "List Style"
+msgstr "Slog seznama"
+
+#: ../src/richtext/richtextformatdlg.cpp:366
+#: ../src/richtext/richtextmarginspage.cpp:170
+msgid "Margins"
+msgstr "Robovi"
+
+# generic/fontdlgg.cpp:208
+#: ../src/richtext/richtextformatdlg.cpp:371
+msgid "Borders"
+msgstr "Obrobe"
+
+#: ../src/richtext/richtextformatdlg.cpp:765
+msgid "Colour"
+msgstr "Barva"
+
+#: ../src/richtext/richtextindentspage.cpp:127
+#: ../src/richtext/richtextliststylepage.cpp:322
+msgid "&Alignment"
+msgstr "&Poravnava"
+
+#: ../src/richtext/richtextindentspage.cpp:138
+#: ../src/richtext/richtextliststylepage.cpp:331
+msgid "&Left"
+msgstr "&Levo"
+
+#: ../src/richtext/richtextindentspage.cpp:140
+#: ../src/richtext/richtextindentspage.cpp:142
+#: ../src/richtext/richtextliststylepage.cpp:333
+#: ../src/richtext/richtextliststylepage.cpp:335
+msgid "Left-align text."
+msgstr "Levo poravnano besedilo."
+
+# generic/fontdlgg.cpp:216
+#: ../src/richtext/richtextindentspage.cpp:145
+#: ../src/richtext/richtextliststylepage.cpp:338
+msgid "&Right"
+msgstr "&Desno"
+
+#: ../src/richtext/richtextindentspage.cpp:147
+#: ../src/richtext/richtextindentspage.cpp:149
+#: ../src/richtext/richtextliststylepage.cpp:340
+#: ../src/richtext/richtextliststylepage.cpp:342
+msgid "Right-align text."
+msgstr "Desno poravnaj besedilo."
+
+#: ../src/richtext/richtextindentspage.cpp:152
+#: ../src/richtext/richtextliststylepage.cpp:345
+msgid "&Justified"
+msgstr "&Poravnano"
+
+#: ../src/richtext/richtextindentspage.cpp:154
+#: ../src/richtext/richtextindentspage.cpp:156
+#: ../src/richtext/richtextliststylepage.cpp:347
+#: ../src/richtext/richtextliststylepage.cpp:349
+msgid "Justify text left and right."
+msgstr "Poravnaj besedilo levo in desno."
+
+# generic/dirdlgg.cpp:217
+#: ../src/richtext/richtextindentspage.cpp:159
+#: ../src/richtext/richtextliststylepage.cpp:352
+msgid "Cen&tred"
+msgstr "&Sredinsko"
+
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR Free Software Foundation, Inc.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+# msw/thread.cpp:519
+#: ../src/richtext/richtextindentspage.cpp:161
+#: ../src/richtext/richtextindentspage.cpp:163
+#: ../src/richtext/richtextliststylepage.cpp:354
+#: ../src/richtext/richtextliststylepage.cpp:356
+msgid "Centre text."
+msgstr "Sredinsko poravnaj besedilo."
+
+# generic/fontdlgg.cpp:242
+#: ../src/richtext/richtextindentspage.cpp:166
+#: ../src/richtext/richtextliststylepage.cpp:359
+msgid "&Indeterminate"
+msgstr "&Nedoločeno"
+
+#: ../src/richtext/richtextindentspage.cpp:168
+#: ../src/richtext/richtextindentspage.cpp:170
+#: ../src/richtext/richtextliststylepage.cpp:361
+#: ../src/richtext/richtextliststylepage.cpp:363
+msgid "Use the current alignment setting."
+msgstr "Uporabi trenutno nastavitev poravnave."
+
+#: ../src/richtext/richtextindentspage.cpp:183
+#: ../src/richtext/richtextliststylepage.cpp:375
+msgid "&Indentation (tenths of a mm)"
+msgstr "&Zamik (v desetinkah mm)"
+
+#: ../src/richtext/richtextindentspage.cpp:198
+#: ../src/richtext/richtextindentspage.cpp:200
+#: ../src/richtext/richtextliststylepage.cpp:388
+#: ../src/richtext/richtextliststylepage.cpp:390
+msgid "The left indent."
+msgstr "Levi zamik."
+
+#: ../src/richtext/richtextindentspage.cpp:203
+#: ../src/richtext/richtextliststylepage.cpp:393
+msgid "Left (&first line):"
+msgstr "Levo (&prva vrstica):"
+
+# html/helpfrm.cpp:899
+#: ../src/richtext/richtextindentspage.cpp:207
+#: ../src/richtext/richtextindentspage.cpp:209
+#: ../src/richtext/richtextliststylepage.cpp:397
+#: ../src/richtext/richtextliststylepage.cpp:399
+msgid "The first line indent."
+msgstr "Zamik prve vrstice."
+
+#: ../src/richtext/richtextindentspage.cpp:216
+#: ../src/richtext/richtextindentspage.cpp:218
+#: ../src/richtext/richtextliststylepage.cpp:406
+#: ../src/richtext/richtextliststylepage.cpp:408
+msgid "The right indent."
+msgstr "Desni odmik."
+
+#: ../src/richtext/richtextindentspage.cpp:221
+msgid "&Outline level:"
+msgstr "&Raven orisa:"
+
+#: ../src/richtext/richtextindentspage.cpp:226
+#: ../src/richtext/richtextindentspage.cpp:228
+msgid "The outline level."
+msgstr "Raven orisa."
+
+#: ../src/richtext/richtextindentspage.cpp:241
+#: ../src/richtext/richtextliststylepage.cpp:420
+msgid "&Spacing (tenths of a mm)"
+msgstr "&Razmik (v desetinah mm)"
+
+#: ../src/richtext/richtextindentspage.cpp:252
+msgid "&Before a paragraph:"
+msgstr "&Pred odstavkom:"
+
+#: ../src/richtext/richtextindentspage.cpp:256
+#: ../src/richtext/richtextindentspage.cpp:258
+#: ../src/richtext/richtextliststylepage.cpp:433
+#: ../src/richtext/richtextliststylepage.cpp:435
+msgid "The spacing before the paragraph."
+msgstr "Razmik nad odstavkom."
+
+#: ../src/richtext/richtextindentspage.cpp:261
+msgid "&After a paragraph:"
+msgstr "&Za odstavkom:"
+
+#: ../src/richtext/richtextindentspage.cpp:266
+#: ../src/richtext/richtextliststylepage.cpp:442
+#: ../src/richtext/richtextliststylepage.cpp:444
+msgid "The spacing after the paragraph."
+msgstr "Razmik pod odstavkom."
+
+#: ../src/richtext/richtextindentspage.cpp:269
+msgid "L&ine spacing:"
+msgstr "&Razmik med vrsticami:"
+
+#: ../src/richtext/richtextindentspage.cpp:274
+#: ../src/richtext/richtextliststylepage.cpp:452
+msgid "Single"
+msgstr "Posamično"
+
+#: ../src/richtext/richtextindentspage.cpp:275
+#: ../src/richtext/richtextliststylepage.cpp:453
+msgid "1.1"
+msgstr "1.1"
+
+#: ../src/richtext/richtextindentspage.cpp:276
+#: ../src/richtext/richtextliststylepage.cpp:454
+msgid "1.2"
+msgstr "1.2"
+
+#: ../src/richtext/richtextindentspage.cpp:277
+#: ../src/richtext/richtextliststylepage.cpp:455
+msgid "1.3"
+msgstr "1.3"
+
+#: ../src/richtext/richtextindentspage.cpp:278
+#: ../src/richtext/richtextliststylepage.cpp:456
+msgid "1.4"
+msgstr "1.4"
+
+#: ../src/richtext/richtextindentspage.cpp:279
+#: ../src/richtext/richtextliststylepage.cpp:457
+msgid "1.5"
+msgstr "1,5"
+
+#: ../src/richtext/richtextindentspage.cpp:280
+#: ../src/richtext/richtextliststylepage.cpp:458
+msgid "1.6"
+msgstr "1.6"
+
+#: ../src/richtext/richtextindentspage.cpp:281
+#: ../src/richtext/richtextliststylepage.cpp:459
+msgid "1.7"
+msgstr "1.7"
+
+#: ../src/richtext/richtextindentspage.cpp:282
+#: ../src/richtext/richtextliststylepage.cpp:460
+msgid "1.8"
+msgstr "1.8"
+
+#: ../src/richtext/richtextindentspage.cpp:283
+#: ../src/richtext/richtextliststylepage.cpp:461
+msgid "1.9"
+msgstr "1.9"
+
+#: ../src/richtext/richtextindentspage.cpp:284
+#: ../src/richtext/richtextliststylepage.cpp:462
+msgid "2"
+msgstr "2"
+
+#: ../src/richtext/richtextindentspage.cpp:287
+#: ../src/richtext/richtextindentspage.cpp:289
+#: ../src/richtext/richtextliststylepage.cpp:465
+#: ../src/richtext/richtextliststylepage.cpp:467
+msgid "The line spacing."
+msgstr "Razmik med vrsticami."
+
+#: ../src/richtext/richtextindentspage.cpp:292
+msgid "&Page Break"
+msgstr "&Prelom strani"
+
+#: ../src/richtext/richtextindentspage.cpp:294
+#: ../src/richtext/richtextindentspage.cpp:296
+msgid "Inserts a page break before the paragraph."
+msgstr "Vstavi prelom strani pred odstavek."
+
+#: ../src/richtext/richtextindentspage.cpp:302
+#: ../src/richtext/richtextindentspage.cpp:304
+msgid "Shows a preview of the paragraph settings."
+msgstr "Pokaže predogled nastavitev odstavka."
+
+#: ../src/richtext/richtextliststylepage.cpp:182
+msgid "&List level:"
+msgstr "&Raven seznama:"
+
+#: ../src/richtext/richtextliststylepage.cpp:186
+#: ../src/richtext/richtextliststylepage.cpp:188
+msgid "Selects the list level to edit."
+msgstr "Izbere raven seznama za urejanje."
+
+#: ../src/richtext/richtextliststylepage.cpp:193
+msgid "&Font for Level..."
+msgstr "&Pisava za raven ..."
+
+#: ../src/richtext/richtextliststylepage.cpp:194
+#: ../src/richtext/richtextliststylepage.cpp:196
+msgid "Click to choose the font for this level."
+msgstr "Kliknite za izbor pisave za to raven."
+
+#: ../src/richtext/richtextliststylepage.cpp:312
+msgid "Bullet style"
+msgstr "Slog oznak"
+
+#: ../src/richtext/richtextliststylepage.cpp:429
+msgid "Before a paragraph:"
+msgstr "Pred odstavkom:"
+
+#: ../src/richtext/richtextliststylepage.cpp:438
+msgid "After a paragraph:"
+msgstr "Za odstavkom:"
+
+#: ../src/richtext/richtextliststylepage.cpp:447
+msgid "Line spacing:"
+msgstr "Razmik med vrsticami:"
+
+# html/helpfrm.cpp:628
+#: ../src/richtext/richtextliststylepage.cpp:470
+msgid "Spacing"
+msgstr "Razmik"
+
+# html/helpfrm.cpp:899
+#: ../src/richtext/richtextmarginspage.cpp:193
+#: ../src/richtext/richtextmarginspage.cpp:195
+msgid "The left margin size."
+msgstr "Velikost levega roba."
+
+#: ../src/richtext/richtextmarginspage.cpp:203
+#: ../src/richtext/richtextmarginspage.cpp:205
+msgid "Units for the left margin."
+msgstr "Enote za levi rob."
+
+#: ../src/richtext/richtextmarginspage.cpp:218
+#: ../src/richtext/richtextmarginspage.cpp:220
+msgid "The right margin size."
+msgstr "Velikost desnega roba."
+
+#: ../src/richtext/richtextmarginspage.cpp:228
+#: ../src/richtext/richtextmarginspage.cpp:230
+msgid "Units for the right margin."
+msgstr "Enote za desni rob."
+
+# html/helpfrm.cpp:899
+#: ../src/richtext/richtextmarginspage.cpp:241
+#: ../src/richtext/richtextmarginspage.cpp:243
+msgid "The top margin size."
+msgstr "Velikost vrhnjega roba."
+
+# msw/thread.cpp:871
+#: ../src/richtext/richtextmarginspage.cpp:251
+#: ../src/richtext/richtextmarginspage.cpp:253
+msgid "Units for the top margin."
+msgstr "Enote za gornji rob."
+
+# html/helpfrm.cpp:899
+#: ../src/richtext/richtextmarginspage.cpp:266
+#: ../src/richtext/richtextmarginspage.cpp:268
+msgid "The bottom margin size."
+msgstr "Velikost spodnjega roba."
+
+#: ../src/richtext/richtextmarginspage.cpp:276
+#: ../src/richtext/richtextmarginspage.cpp:278
+msgid "Units for the bottom margin."
+msgstr "Enote za spodnji rob."
+
+#: ../src/richtext/richtextmarginspage.cpp:284
+msgid "Padding"
+msgstr "Blazinjenje"
+
+# html/helpfrm.cpp:899
+#: ../src/richtext/richtextmarginspage.cpp:307
+#: ../src/richtext/richtextmarginspage.cpp:309
+msgid "The left padding size."
+msgstr "Velikost zapolnjevanja na levi."
+
+#: ../src/richtext/richtextmarginspage.cpp:317
+#: ../src/richtext/richtextmarginspage.cpp:319
+msgid "Units for the left padding."
+msgstr "Enote za zapolnjevanje na levi."
+
+#: ../src/richtext/richtextmarginspage.cpp:332
+#: ../src/richtext/richtextmarginspage.cpp:334
+msgid "The right padding size."
+msgstr "Velikost zapolnjevanja na desni."
+
+#: ../src/richtext/richtextmarginspage.cpp:342
+#: ../src/richtext/richtextmarginspage.cpp:344
+msgid "Units for the right padding."
+msgstr "Enote za zapolnjevanje na desni."
+
+# html/helpfrm.cpp:899
+#: ../src/richtext/richtextmarginspage.cpp:355
+#: ../src/richtext/richtextmarginspage.cpp:357
+msgid "The top padding size."
+msgstr "Velikost zapolnjevanja na vrhu."
+
+#: ../src/richtext/richtextmarginspage.cpp:365
+#: ../src/richtext/richtextmarginspage.cpp:367
+msgid "Units for the top padding."
+msgstr "Enote za zapolnjevanje na vrhu."
+
+# html/helpfrm.cpp:899
+#: ../src/richtext/richtextmarginspage.cpp:380
+#: ../src/richtext/richtextmarginspage.cpp:382
+msgid "The bottom padding size."
+msgstr "Velikost zapolnjevanja na dnu."
+
+#: ../src/richtext/richtextmarginspage.cpp:390
+#: ../src/richtext/richtextmarginspage.cpp:392
+msgid "Units for the bottom padding."
+msgstr "Enote za zapolnjevanje ne dnu."
+
+# html/htmprint.cpp:490
+#: ../src/richtext/richtextprint.cpp:592
+msgid " Preview"
+msgstr " Predogled"
+
+#: ../src/richtext/richtextsizepage.cpp:228
+msgid "Floating"
+msgstr "Plavajoče"
+
+#: ../src/richtext/richtextsizepage.cpp:243
+msgid "&Floating mode:"
+msgstr "&Plavajoči način:"
+
+#: ../src/richtext/richtextsizepage.cpp:252
+#: ../src/richtext/richtextsizepage.cpp:254
+msgid "How the object will float relative to the text."
+msgstr "Kako bo plaval predmet relativno glede na besedilo."
+
+#: ../src/richtext/richtextsizepage.cpp:265
+msgid "Alignment"
+msgstr "Poravnava"
+
+#: ../src/richtext/richtextsizepage.cpp:277
+msgid "&Vertical alignment:"
+msgstr "&Navpična poravnava:"
+
+# generic/printps.cpp:209
+# msw/printwin.cpp:252
+#: ../src/richtext/richtextsizepage.cpp:279
+#: ../src/richtext/richtextsizepage.cpp:281
+msgid "Enable vertical alignment."
+msgstr "Omogoči navpično poravnavo."
+
+# generic/dirdlgg.cpp:217
+#: ../src/richtext/richtextsizepage.cpp:286
+msgid "Centred"
+msgstr "Sredinsko"
+
+# generic/printps.cpp:209
+# msw/printwin.cpp:252
+#: ../src/richtext/richtextsizepage.cpp:290
+#: ../src/richtext/richtextsizepage.cpp:292
+msgid "Vertical alignment."
+msgstr "Navpična poravnava."
+
+# generic/fontdlgg.cpp:216
+#: ../src/richtext/richtextsizepage.cpp:316
+#: ../src/richtext/richtextsizepage.cpp:323
+msgid "&Width:"
+msgstr "&Širina:"
+
+#: ../src/richtext/richtextsizepage.cpp:318
+#: ../src/richtext/richtextsizepage.cpp:320
+msgid "Enable the width value."
+msgstr "Omogoči vrednost širine."
+
+#: ../src/richtext/richtextsizepage.cpp:331
+#: ../src/richtext/richtextsizepage.cpp:333
+msgid "The object width."
+msgstr "Širina predmeta."
+
+#: ../src/richtext/richtextsizepage.cpp:342
+#: ../src/richtext/richtextsizepage.cpp:344
+msgid "Units for the object width."
+msgstr "Enote za širino predmeta."
+
+# generic/fontdlgg.cpp:216
+#: ../src/richtext/richtextsizepage.cpp:350
+#: ../src/richtext/richtextsizepage.cpp:357
+msgid "&Height:"
+msgstr "&Višina:"
+
+#: ../src/richtext/richtextsizepage.cpp:352
+#: ../src/richtext/richtextsizepage.cpp:354
+#: ../src/richtext/richtextsizepage.cpp:464
+#: ../src/richtext/richtextsizepage.cpp:466
+msgid "Enable the height value."
+msgstr "Omogoči vrednost višine."
+
+#: ../src/richtext/richtextsizepage.cpp:365
+#: ../src/richtext/richtextsizepage.cpp:367
+msgid "The object height."
+msgstr "Višina predmeta."
+
+#: ../src/richtext/richtextsizepage.cpp:376
+#: ../src/richtext/richtextsizepage.cpp:378
+msgid "Units for the object height."
+msgstr "Enote za višino predmeta."
+
+#: ../src/richtext/richtextsizepage.cpp:381
+msgid "Min width:"
+msgstr "Najm. širina:"
+
+# generic/printps.cpp:209
+# msw/printwin.cpp:252
+#: ../src/richtext/richtextsizepage.cpp:383
+#: ../src/richtext/richtextsizepage.cpp:385
+msgid "Enable the minimum width value."
+msgstr "Omogoči vrednost najmanjše širine."
+
+#: ../src/richtext/richtextsizepage.cpp:392
+#: ../src/richtext/richtextsizepage.cpp:394
+msgid "The object minimum width."
+msgstr "Najmanjša širina predmeta."
+
+#: ../src/richtext/richtextsizepage.cpp:403
+#: ../src/richtext/richtextsizepage.cpp:405
+msgid "Units for the minimum object width."
+msgstr "Enote za najmanjšo širino predmeta."
+
+#: ../src/richtext/richtextsizepage.cpp:408
+msgid "Min height:"
+msgstr "Najm. širina:"
+
+#: ../src/richtext/richtextsizepage.cpp:410
+#: ../src/richtext/richtextsizepage.cpp:412
+msgid "Enable the minimum height value."
+msgstr "Omogoči vrednost najmanjše višine."
+
+#: ../src/richtext/richtextsizepage.cpp:419
+#: ../src/richtext/richtextsizepage.cpp:421
+msgid "The object minimum height."
+msgstr "Najmanjša višina predmeta."
+
+#: ../src/richtext/richtextsizepage.cpp:430
+#: ../src/richtext/richtextsizepage.cpp:432
+msgid "Units for the minimum object height."
+msgstr "Enote za najmanjšo višino predmeta."
+
+#: ../src/richtext/richtextsizepage.cpp:435
+msgid "Max width:"
+msgstr "Najv. širina:"
+
+# generic/printps.cpp:209
+# msw/printwin.cpp:252
+#: ../src/richtext/richtextsizepage.cpp:437
+#: ../src/richtext/richtextsizepage.cpp:439
+msgid "Enable the maximum width value."
+msgstr "Omogoči vrednost največje širine."
+
+#: ../src/richtext/richtextsizepage.cpp:446
+#: ../src/richtext/richtextsizepage.cpp:448
+msgid "The object maximum width."
+msgstr "Največja širina predmeta."
+
+#: ../src/richtext/richtextsizepage.cpp:457
+#: ../src/richtext/richtextsizepage.cpp:459
+msgid "Units for the maximum object width."
+msgstr "Enote za največjo širino predmeta."
+
+# generic/fontdlgg.cpp:216
+#: ../src/richtext/richtextsizepage.cpp:462
+msgid "Max height:"
+msgstr "Najv. višina:"
+
+#: ../src/richtext/richtextsizepage.cpp:473
+#: ../src/richtext/richtextsizepage.cpp:475
+msgid "The object maximum height."
+msgstr "Največja višina predmeta."
+
+#: ../src/richtext/richtextsizepage.cpp:484
+#: ../src/richtext/richtextsizepage.cpp:486
+msgid "Units for the maximum object height."
+msgstr "Enote za največjo višino predmeta."
+
+# generic/logg.cpp:1023
+#: ../src/richtext/richtextsizepage.cpp:495
+msgid "Position"
+msgstr "Položaj"
+
+# generic/logg.cpp:1023
+#: ../src/richtext/richtextsizepage.cpp:513
+msgid "&Position mode:"
+msgstr "&Način položaja:"
+
+# generic/logg.cpp:598
+#: ../src/richtext/richtextsizepage.cpp:517
+#: ../src/richtext/richtextsizepage.cpp:522
+msgid "Static"
+msgstr "Statično"
+
+# generic/fontdlgg.cpp:207
+#: ../src/richtext/richtextsizepage.cpp:518
+msgid "Relative"
+msgstr "Relativno"
+
+#: ../src/richtext/richtextsizepage.cpp:519
+msgid "Absolute"
+msgstr "Absolutno"
+
+# html/helpfrm.cpp:889
+#: ../src/richtext/richtextsizepage.cpp:520
+msgid "Fixed"
+msgstr "Nespremenljivo"
+
+# html/helpfrm.cpp:899
+#: ../src/richtext/richtextsizepage.cpp:533
+#: ../src/richtext/richtextsizepage.cpp:535
+#: ../src/richtext/richtextsizepage.cpp:547
+#: ../src/richtext/richtextsizepage.cpp:549
+msgid "The left position."
+msgstr "Levi položaj."
+
+# msw/thread.cpp:871
+#: ../src/richtext/richtextsizepage.cpp:558
+#: ../src/richtext/richtextsizepage.cpp:560
+msgid "Units for the left position."
+msgstr "Enote za levi položaj."
+
+# html/helpfrm.cpp:899
+#: ../src/richtext/richtextsizepage.cpp:568
+#: ../src/richtext/richtextsizepage.cpp:570
+#: ../src/richtext/richtextsizepage.cpp:582
+#: ../src/richtext/richtextsizepage.cpp:584
+msgid "The top position."
+msgstr "Vrhnji položaj."
+
+# msw/thread.cpp:871
+#: ../src/richtext/richtextsizepage.cpp:593
+#: ../src/richtext/richtextsizepage.cpp:595
+msgid "Units for the top position."
+msgstr "Enote za gornji položaj."
+
+# html/helpfrm.cpp:899
+#: ../src/richtext/richtextsizepage.cpp:603
+#: ../src/richtext/richtextsizepage.cpp:605
+#: ../src/richtext/richtextsizepage.cpp:617
+#: ../src/richtext/richtextsizepage.cpp:619
+msgid "The right position."
+msgstr "Desni položaj."
+
+# msw/thread.cpp:871
+#: ../src/richtext/richtextsizepage.cpp:628
+#: ../src/richtext/richtextsizepage.cpp:630
+msgid "Units for the right position."
+msgstr "Enote za desni položaj."
+
+# html/helpfrm.cpp:899
+#: ../src/richtext/richtextsizepage.cpp:638
+#: ../src/richtext/richtextsizepage.cpp:640
+#: ../src/richtext/richtextsizepage.cpp:652
+#: ../src/richtext/richtextsizepage.cpp:654
+msgid "The bottom position."
+msgstr "Spodnji položaj."
+
+# msw/thread.cpp:871
+#: ../src/richtext/richtextsizepage.cpp:663
+#: ../src/richtext/richtextsizepage.cpp:665
+msgid "Units for the bottom position."
+msgstr "Enote za spodnji položaj."
+
+#: ../src/richtext/richtextsizepage.cpp:671
+msgid "&Move the object to:"
+msgstr "&Premakni predmet v:"
+
+# html/helpfrm.cpp:512
+#: ../src/richtext/richtextsizepage.cpp:674
+msgid "&Previous Paragraph"
+msgstr "&Prejšnji odstavek"
+
+#: ../src/richtext/richtextsizepage.cpp:675
+#: ../src/richtext/richtextsizepage.cpp:677
+msgid "Moves the object to the previous paragraph."
+msgstr "Premakne predmet v prejšnji odstavek."
+
+#: ../src/richtext/richtextsizepage.cpp:680
+msgid "&Next Paragraph"
+msgstr "&Naslednji odstavek"
+
+#: ../src/richtext/richtextsizepage.cpp:681
+#: ../src/richtext/richtextsizepage.cpp:683
+msgid "Moves the object to the next paragraph."
+msgstr "Premakne predmet v naslednji odstavek."
+
+#: ../src/richtext/richtextstyledlg.cpp:193
+msgid "&Styles:"
+msgstr "&Slogi:"
+
+#: ../src/richtext/richtextstyledlg.cpp:197
+#: ../src/richtext/richtextstyledlg.cpp:199
+msgid "The available styles."
+msgstr "Slogi na voljo."
+
+#: ../src/richtext/richtextstyledlg.cpp:205
+#: ../src/richtext/richtextstyledlg.cpp:217
+msgid " "
+msgstr " "
+
+#: ../src/richtext/richtextstyledlg.cpp:209
+#: ../src/richtext/richtextstyledlg.cpp:211
+msgid "The style preview."
+msgstr "Predogled sloga."
+
+#: ../src/richtext/richtextstyledlg.cpp:220
+msgid "New &Character Style..."
+msgstr "Nov &znakovni slog ..."
+
+#: ../src/richtext/richtextstyledlg.cpp:221
+#: ../src/richtext/richtextstyledlg.cpp:223
+msgid "Click to create a new character style."
+msgstr "Kliknite za stvaritev novega sloga znakov."
+
+#: ../src/richtext/richtextstyledlg.cpp:226
+msgid "New &Paragraph Style..."
+msgstr "Nov slog &odstavka ..."
+
+#: ../src/richtext/richtextstyledlg.cpp:227
+#: ../src/richtext/richtextstyledlg.cpp:229
+msgid "Click to create a new paragraph style."
+msgstr "Kliknite za stvaritev novega sloga odstavka."
+
+#: ../src/richtext/richtextstyledlg.cpp:232
+msgid "New &List Style..."
+msgstr "Nov &seznamski slog ..."
+
+#: ../src/richtext/richtextstyledlg.cpp:233
+#: ../src/richtext/richtextstyledlg.cpp:235
+msgid "Click to create a new list style."
+msgstr "Kliknite za tvorbo novega seznamskega sloga."
+
+#: ../src/richtext/richtextstyledlg.cpp:238
+msgid "New &Box Style..."
+msgstr "Nov slog po&lja ..."
+
+#: ../src/richtext/richtextstyledlg.cpp:239
+#: ../src/richtext/richtextstyledlg.cpp:241
+msgid "Click to create a new box style."
+msgstr "Kliknite za tvorbo novega sloga polja."
+
+#: ../src/richtext/richtextstyledlg.cpp:246
+msgid "&Apply Style"
+msgstr "&Uporabi slog"
+
+#: ../src/richtext/richtextstyledlg.cpp:247
+#: ../src/richtext/richtextstyledlg.cpp:249
+msgid "Click to apply the selected style."
+msgstr "Kliknite za uveljavitev izbranega sloga."
+
+#: ../src/richtext/richtextstyledlg.cpp:252
+msgid "&Rename Style..."
+msgstr "&Preimenuj slog ..."
+
+#: ../src/richtext/richtextstyledlg.cpp:253
+#: ../src/richtext/richtextstyledlg.cpp:255
+msgid "Click to rename the selected style."
+msgstr "Kliknite za preimenovanje izbranega sloga."
+
+#: ../src/richtext/richtextstyledlg.cpp:258
+msgid "&Edit Style..."
+msgstr "&Uredi slog ..."
+
+#: ../src/richtext/richtextstyledlg.cpp:259
+#: ../src/richtext/richtextstyledlg.cpp:261
+msgid "Click to edit the selected style."
+msgstr "Kliknite za urejanje izbranega sloga."
+
+#: ../src/richtext/richtextstyledlg.cpp:264
+msgid "&Delete Style..."
+msgstr "&Izbriši slog ..."
+
+#: ../src/richtext/richtextstyledlg.cpp:265
+#: ../src/richtext/richtextstyledlg.cpp:267
+msgid "Click to delete the selected style."
+msgstr "Kliknite za brisanje izbranega sloga."
+
+# generic/logg.cpp:477
+#: ../src/richtext/richtextstyledlg.cpp:274
+#: ../src/richtext/richtextstyledlg.cpp:276
+msgid "Click to close this window."
+msgstr "Kliknite za zaprtje tega okna."
+
+#: ../src/richtext/richtextstyledlg.cpp:282
+msgid "&Restart numbering"
+msgstr "&Znova oštevilči"
+
+#: ../src/richtext/richtextstyledlg.cpp:284
+#: ../src/richtext/richtextstyledlg.cpp:286
+msgid "Check to restart numbering."
+msgstr "Označite za ponoven začetek oštevilčevanja."
+
+#: ../src/richtext/richtextstyledlg.cpp:601
+msgid "Enter a character style name"
+msgstr "Vnesite ime znakovnega sloga"
+
+#: ../src/richtext/richtextstyledlg.cpp:601
+#: ../src/richtext/richtextstyledlg.cpp:606
+#: ../src/richtext/richtextstyledlg.cpp:649
+#: ../src/richtext/richtextstyledlg.cpp:654
+#: ../src/richtext/richtextstyledlg.cpp:815
+#: ../src/richtext/richtextstyledlg.cpp:820
+#: ../src/richtext/richtextstyledlg.cpp:888
+#: ../src/richtext/richtextstyledlg.cpp:896
+#: ../src/richtext/richtextstyledlg.cpp:929
+#: ../src/richtext/richtextstyledlg.cpp:934
+msgid "New Style"
+msgstr "Nov slog"
+
+#: ../src/richtext/richtextstyledlg.cpp:606
+#: ../src/richtext/richtextstyledlg.cpp:654
+#: ../src/richtext/richtextstyledlg.cpp:820
+#: ../src/richtext/richtextstyledlg.cpp:896
+#: ../src/richtext/richtextstyledlg.cpp:934
+msgid "Sorry, that name is taken. Please choose another."
+msgstr "Ime je že zasedeno. Izberite drugo."
+
+#: ../src/richtext/richtextstyledlg.cpp:649
+msgid "Enter a paragraph style name"
+msgstr "Vnesite ime sloga odstavka"
+
+#: ../src/richtext/richtextstyledlg.cpp:777
+#, c-format
+msgid "Delete style %s?"
+msgstr "Želite izbrisati slog %s?"
+
+#: ../src/richtext/richtextstyledlg.cpp:777
+msgid "Delete Style"
+msgstr "Izbriši slog"
+
+#: ../src/richtext/richtextstyledlg.cpp:815
+msgid "Enter a list style name"
+msgstr "Vnesite ime sloga seznama"
+
+#: ../src/richtext/richtextstyledlg.cpp:888
+msgid "Enter a new style name"
+msgstr "Vnesite ime novega sloga"
+
+#: ../src/richtext/richtextstyledlg.cpp:929
+msgid "Enter a box style name"
+msgstr "Vnesite ime sloga polja"
+
+#: ../src/richtext/richtextstylepage.cpp:109
+#: ../src/richtext/richtextstylepage.cpp:111
+msgid "The style name."
+msgstr "Ime sloga."
+
+#: ../src/richtext/richtextstylepage.cpp:114
+msgid "&Based on:"
+msgstr "&Temelji na:"
+
+#: ../src/richtext/richtextstylepage.cpp:119
+#: ../src/richtext/richtextstylepage.cpp:121
+msgid "The style on which this style is based."
+msgstr "Slog, na katerem temelji ta slog."
+
+# generic/wizard.cpp:189
+# generic/wizard.cpp:286
+#: ../src/richtext/richtextstylepage.cpp:124
+msgid "&Next style:"
+msgstr "&Naslednji slog:"
+
+#: ../src/richtext/richtextstylepage.cpp:129
+#: ../src/richtext/richtextstylepage.cpp:131
+msgid "The default style for the next paragraph."
+msgstr "Privzeti slog za naslednji odstavek."
+
+#: ../src/richtext/richtextstyles.cpp:1057
+msgid "All styles"
+msgstr "Vsi slogi"
+
+#: ../src/richtext/richtextstyles.cpp:1058
+msgid "Paragraph styles"
+msgstr "Slogi odstavka"
+
+#: ../src/richtext/richtextstyles.cpp:1059
+msgid "Character styles"
+msgstr "Slogi znakov"
+
+#: ../src/richtext/richtextstyles.cpp:1060
+msgid "List styles"
+msgstr "Slogi seznama"
+
+#: ../src/richtext/richtextstyles.cpp:1061
+msgid "Box styles"
+msgstr "Slogi polja"
+
+#: ../src/richtext/richtextsymboldlg.cpp:389
+#: ../src/richtext/richtextsymboldlg.cpp:391
+msgid "The font from which to take the symbol."
+msgstr "Pisava, iz katere naj bodo prikazani posebni znaki."
+
+#: ../src/richtext/richtextsymboldlg.cpp:396
+msgid "&Subset:"
+msgstr "&Podmnožica:"
+
+#: ../src/richtext/richtextsymboldlg.cpp:401
+#: ../src/richtext/richtextsymboldlg.cpp:403
+msgid "Shows a Unicode subset."
+msgstr "Pokaže podmnožico Unicode."
+
+#: ../src/richtext/richtextsymboldlg.cpp:412
+msgid "xxxx"
+msgstr "xxxx"
+
+#: ../src/richtext/richtextsymboldlg.cpp:417
+msgid "&Character code:"
+msgstr "&Koda znaka:"
+
+#: ../src/richtext/richtextsymboldlg.cpp:421
+#: ../src/richtext/richtextsymboldlg.cpp:423
+msgid "The character code."
+msgstr "Koda znaka."
+
+# generic/prntdlgg.cpp:187
+#: ../src/richtext/richtextsymboldlg.cpp:428
+msgid "&From:"
+msgstr "&Od:"
+
+#: ../src/richtext/richtextsymboldlg.cpp:433
+#: ../src/richtext/richtextsymboldlg.cpp:434
+#: ../src/richtext/richtextsymboldlg.cpp:435
+msgid "Unicode"
+msgstr "Unicode"
+
+#: ../src/richtext/richtextsymboldlg.cpp:436
+#: ../src/richtext/richtextsymboldlg.cpp:438
+msgid "The range to show."
+msgstr "Prikazano območje."
+
+# html/helpfrm.cpp:372
+#: ../src/richtext/richtextsymboldlg.cpp:444
+msgid "Insert"
+msgstr "Vstavi"
+
+# html/helpfrm.cpp:881
+#: ../src/richtext/richtextsymboldlg.cpp:478
+msgid "(Normal text)"
+msgstr "(navadno besedilo)"
+
+#: ../src/richtext/richtexttabspage.cpp:109
+msgid "&Position (tenths of a mm):"
+msgstr "&Položaj (v desetinkah mm):"
+
+# html/helpfrm.cpp:899
+#: ../src/richtext/richtexttabspage.cpp:113
+#: ../src/richtext/richtexttabspage.cpp:115
+msgid "The tab position."
+msgstr "Položaj tabulatorja."
+
+# html/helpfrm.cpp:899
+#: ../src/richtext/richtexttabspage.cpp:119
+msgid "The tab positions."
+msgstr "Položaji tabulatorjev."
+
+#: ../src/richtext/richtexttabspage.cpp:132
+#: ../src/richtext/richtexttabspage.cpp:134
+msgid "Click to create a new tab position."
+msgstr "Kliknite za nastavitev novega položaja tabulatorja."
+
+#: ../src/richtext/richtexttabspage.cpp:138
+#: ../src/richtext/richtexttabspage.cpp:140
+msgid "Click to delete the selected tab position."
+msgstr "Kliknite za brisanje izbranega položaja tabulatorja."
+
+# common/docview.cpp:1371
+# common/docview.cpp:1422
+#: ../src/richtext/richtexttabspage.cpp:143
+msgid "Delete A&ll"
+msgstr "Izbriši &vse"
+
+#: ../src/richtext/richtexttabspage.cpp:144
+#: ../src/richtext/richtexttabspage.cpp:146
+msgid "Click to delete all tab positions."
+msgstr "Kliknite za brisanje vseh položajev tabulatorja."
+
+#: ../src/univ/theme.cpp:110
+msgid "Failed to initialize GUI: no built-in themes found."
+msgstr "Inicializacija GUI ni uspela: vgrajenih tem ni mogoče najti."
+
+#: ../src/univ/themes/gtk.cpp:521
+msgid "GTK+ theme"
+msgstr "Tema GTK+"
+
+#: ../src/univ/themes/metal.cpp:164
+msgid "Metal theme"
+msgstr "Metalna tema"
+
+#: ../src/univ/themes/mono.cpp:512
+msgid "Simple monochrome theme"
+msgstr "Enostavna enobarvna tema"
+
+#: ../src/univ/themes/win32.cpp:1098
+msgid "Win32 theme"
+msgstr "Tema Win32"
+
+# common/docview.cpp:1945
+# common/docview.cpp:1956
+#: ../src/univ/themes/win32.cpp:3743
+msgid "&Restore"
+msgstr "&Obnovi"
+
+#: ../src/univ/themes/win32.cpp:3744
+msgid "&Move"
+msgstr "&Premakni"
+
+# generic/filedlgg.cpp:534
+#: ../src/univ/themes/win32.cpp:3746
+msgid "&Size"
+msgstr "&Velikost"
+
+#: ../src/univ/themes/win32.cpp:3748
+msgid "Mi&nimize"
+msgstr "Po&manjšaj"
+
+#: ../src/univ/themes/win32.cpp:3750
+msgid "Ma&ximize"
+msgstr "Po&večaj"
+
+#: ../src/univ/themes/win32.cpp:3752
+msgid "Alt+"
+msgstr "Dvigalka+"
+
+# common/ffile.cpp:182
+#: ../src/unix/appunix.cpp:178
+msgid "Failed to install signal handler"
+msgstr "Nameščanje signalne ročice ni bilo uspešno."
+
+#: ../src/unix/dialup.cpp:351
+msgid "Already dialling ISP."
+msgstr "Klicanje ponudnika spletnih storitev je v teku."
+
+# common/dynlib.cpp:239
+#: ../src/unix/dlunix.cpp:93
+msgid "Failed to unload shared library"
+msgstr "Deljene knjižnice ni mogoče odložiti"
+
+#: ../src/unix/dlunix.cpp:121
+msgid "Unknown dynamic library error"
+msgstr "Neznana napaka dinamične knjižnice"
+
+# common/imagbmp.cpp:266
+# common/imagbmp.cpp:278
+#: ../src/unix/epolldispatcher.cpp:84
+msgid "Failed to create epoll descriptor"
+msgstr "Deskriptorja epoll ni mogoče ustvariti"
+
+# generic/dirdlgg.cpp:552
+#: ../src/unix/epolldispatcher.cpp:103
+msgid "Error closing epoll descriptor"
+msgstr "Napaka pri zapiranju deskriptorja epoll"
+
+# common/file.cpp:304
+#: ../src/unix/epolldispatcher.cpp:116
+#, c-format
+msgid "Failed to add descriptor %d to epoll descriptor %d"
+msgstr "Deskriptorja %d ni mogoče dodati deskriptorju epoll %d"
+
+#: ../src/unix/epolldispatcher.cpp:136
+#, c-format
+msgid "Failed to modify descriptor %d in epoll descriptor %d"
+msgstr "Deskriptorja %d v deskriptorju epoll %d ni mogoče spremeniti"
+
+# msw/clipbrd.cpp:428
+#: ../src/unix/epolldispatcher.cpp:155
+#, c-format
+msgid "Failed to unregister descriptor %d from epoll descriptor %d"
+msgstr "Deskriptorja %d ni uspelo odregistrirati iz deskriptorja epoll %d"
+
+#: ../src/unix/epolldispatcher.cpp:213
+#, c-format
+msgid "Waiting for IO on epoll descriptor %d failed"
+msgstr "Čakanje na V/I na deskriptorju epoll %d ni uspelo"
+
+# msw/dde.cpp:934
+#: ../src/unix/fswatcher_inotify.cpp:71
+msgid "Unable to create inotify instance"
+msgstr "Instance inotify ni mogoče ustvariti."
+
+# common/ffile.cpp:182
+#: ../src/unix/fswatcher_inotify.cpp:94
+msgid "Unable to close inotify instance"
+msgstr "Neuspešno zapiranje instance inotify"
+
+#: ../src/unix/fswatcher_inotify.cpp:106
+msgid "Unable to add inotify watch"
+msgstr "Ni mogoče dodati opazovalnice inotify."
+
+#: ../src/unix/fswatcher_inotify.cpp:138
+#, c-format
+msgid "Unable to remove inotify watch %i"
+msgstr "Ni mogoče odstraniti opazovalnice inotify %i."
+
+#: ../src/unix/fswatcher_inotify.cpp:271
+#, c-format
+msgid "Unexpected event for \"%s\": no matching watch descriptor."
+msgstr ""
+"Nepričakovan dogodek za »%s«: ni ujemajočega opazovalnega deskriptorja."
+
+#: ../src/unix/fswatcher_inotify.cpp:320
+#, c-format
+msgid "Invalid inotify event for \"%s\""
+msgstr "Neveljaven dogodek inotify za »%s«"
+
+# common/file.cpp:285
+#: ../src/unix/fswatcher_inotify.cpp:553
+msgid "Unable to read from inotify descriptor"
+msgstr "Ni mogoče brati iz deskriptorja inotify"
+
+# common/file.cpp:285
+#: ../src/unix/fswatcher_inotify.cpp:558
+msgid "EOF while reading from inotify descriptor"
+msgstr "EOF pri branju iz deskriptorja inotify"
+
+# msw/dde.cpp:934
+#: ../src/unix/fswatcher_kqueue.cpp:114
+msgid "Unable to create kqueue instance"
+msgstr "Instance kqueue ni mogoče ustvariti."
+
+# generic/dirdlgg.cpp:552
+#: ../src/unix/fswatcher_kqueue.cpp:131
+msgid "Error closing kqueue instance"
+msgstr "Napaka pri zapiranju instance kqueue"
+
+#: ../src/unix/fswatcher_kqueue.cpp:153
+msgid "Unable to add kqueue watch"
+msgstr "Ni mogoče dodati opazovalnice kqueue"
+
+#: ../src/unix/fswatcher_kqueue.cpp:170
+msgid "Unable to remove kqueue watch"
+msgstr "Ni mogoče odstraniti opazovalnice kqueue."
+
+#: ../src/unix/fswatcher_kqueue.cpp:202
+msgid "Unable to get events from kqueue"
+msgstr "Ni mogoče pridobiti dogodkov iz kqueue"
+
+#: ../src/unix/mediactrl.cpp:966
+#, c-format
+msgid "Media playback error: %s"
+msgstr "Napaka pri predvajanju datoteke: %s"
+
+# generic/dirdlgg.cpp:550
+#: ../src/unix/mediactrl.cpp:1228
+#, c-format
+msgid "Failed to prepare playing \"%s\"."
+msgstr "Predvajanja »%s« ni mogoče pripraviti."
+
+# common/ffile.cpp:182
+#: ../src/unix/snglinst.cpp:164
+#, c-format
+msgid "Failed to write to lock file '%s'"
+msgstr "V datoteko zaklopa »%s« ni mogoče pisati."
+
+# common/ffile.cpp:182
+#: ../src/unix/snglinst.cpp:177
+#, c-format
+msgid "Failed to set permissions on lock file '%s'"
+msgstr "Zaklenjeni datoteki »%s« ni bilo možno nastaviti pravic."
+
+# common/ffile.cpp:182
+#: ../src/unix/snglinst.cpp:194
+#, c-format
+msgid "Failed to lock the lock file '%s'"
+msgstr "Zaklenjene datoteke »%s« ni mogoče zakleniti."
+
+# common/ffile.cpp:182
+#: ../src/unix/snglinst.cpp:237
+#, c-format
+msgid "Failed to inspect the lock file '%s'"
+msgstr "Zaklenjene datoteke »%s« ni mogoče pregledati."
+
+#: ../src/unix/snglinst.cpp:242
+#, c-format
+msgid "Lock file '%s' has incorrect owner."
+msgstr "Zaklenjena datoteka '%s' ima nepravega lastnika."
+
+#: ../src/unix/snglinst.cpp:247
+#, c-format
+msgid "Lock file '%s' has incorrect permissions."
+msgstr "Zaklenjena datoteka '%s' ima nepravilna dovoljenja."
+
+#: ../src/unix/snglinst.cpp:265
+msgid "Failed to access lock file."
+msgstr "Neuspešen dostop do zaklenjene datoteke."
+
+#: ../src/unix/snglinst.cpp:274
+msgid "Failed to read PID from lock file."
+msgstr "Branje PID iz zaklenjene datoteke ni uspelo."
+
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR Free Software Foundation, Inc.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+# common/file.cpp:580
+# common/file.cpp:583
+#: ../src/unix/snglinst.cpp:284
+#, c-format
+msgid "Failed to remove stale lock file '%s'."
+msgstr "Odstranjevanje stare zaklenjene datoteke '%s' ni uspelo."
+
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR Free Software Foundation, Inc.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+# msw/iniconf.cpp:476
+#: ../src/unix/snglinst.cpp:297
+#, c-format
+msgid "Deleted stale lock file '%s'."
+msgstr "Izbrisana stara zaklenjena datoteka »%s«."
+
+# common/ffile.cpp:101
+#: ../src/unix/snglinst.cpp:308
+#, c-format
+msgid "Invalid lock file '%s'."
+msgstr "Datoteka '%s' ni veljavna datoteka zaklopa."
+
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR Free Software Foundation, Inc.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+# common/file.cpp:552
+# common/file.cpp:562
+#: ../src/unix/snglinst.cpp:324
+#, c-format
+msgid "Failed to remove lock file '%s'"
+msgstr "Zaklenjene datoteke »%s« ni mogoče odstraniti."
+
+# common/ffile.cpp:182
+#: ../src/unix/snglinst.cpp:330
+#, c-format
+msgid "Failed to unlock lock file '%s'"
+msgstr "Zaklenjene datoteke »%s« ni mogoče odkleniti."
+
+# common/ffile.cpp:182
+#: ../src/unix/snglinst.cpp:336
+#, c-format
+msgid "Failed to close lock file '%s'"
+msgstr "Zapiranje zaklenjene datoteke »%s« ni uspelo."
+
+# generic/helphtml.cpp:314
+#: ../src/unix/sound.cpp:77
+msgid "No sound"
+msgstr "Brez zvoka"
+
+#: ../src/unix/sound.cpp:364
+msgid "Unable to play sound asynchronously."
+msgstr "Zvoka ni bilo mogoče predvajati nesinhrono."
+
+# common/filefn.cpp:1287
+# msw/dir.cpp:294
+#: ../src/unix/sound.cpp:458
+#, c-format
+msgid "Couldn't load sound data from '%s'."
+msgstr "Zvočnih podatkov iz »%s« ni mogoče naložiti."
+
+#: ../src/unix/sound.cpp:465
+#, c-format
+msgid "Sound file '%s' is in unsupported format."
+msgstr "Zvočna datoteka '%s' je v nepodprtem zapisu."
+
+#: ../src/unix/sound.cpp:480
+msgid "Sound data are in unsupported format."
+msgstr "Zvočni podatki so v nepodprtem zapisu."
+
+# msw/dib.cpp:434
+#: ../src/unix/sound_sdl.cpp:226
+#, c-format
+msgid "Couldn't open audio: %s"
+msgstr "Zvoka ni mogoče odpreti: %s"
+
+#: ../src/unix/threadpsx.cpp:1033
+msgid "Cannot retrieve thread scheduling policy."
+msgstr "Ni mogoče pridobiti politiko razporejanja niti."
+
+#: ../src/unix/threadpsx.cpp:1058
+#, c-format
+msgid "Cannot get priority range for scheduling policy %d."
+msgstr "Za politiko razporejanja %d ni mogoče pridobiti razpona prioritet."
+
+#: ../src/unix/threadpsx.cpp:1066
+msgid "Thread priority setting is ignored."
+msgstr "Nastavitev prioritete niti je ignorirana."
+
+#: ../src/unix/threadpsx.cpp:1221
+msgid ""
+"Failed to join a thread, potential memory leak detected - please restart the "
+"program"
+msgstr ""
+"Pridružitev k niti ni uspela, odkrita možna izguba spomina - prosimo, "
+"ponovno zaženite program"
+
+# generic/dirdlgg.cpp:550
+#: ../src/unix/threadpsx.cpp:1352
+#, c-format
+msgid "Failed to set thread concurrency level to %lu"
+msgstr "Ravni sočasnosti niti ni bilo mogoče nastaviti na %lu."
+
+# generic/dirdlgg.cpp:550
+#: ../src/unix/threadpsx.cpp:1481
+#, c-format
+msgid "Failed to set thread priority %d."
+msgstr "Prioritete niti %d ni bilo mogoče nastaviti."
+
+# generic/dirdlgg.cpp:550
+#: ../src/unix/threadpsx.cpp:1666
+msgid "Failed to terminate a thread."
+msgstr "Niti ni mogoče prekiniti."
+
+#: ../src/unix/threadpsx.cpp:1893
+msgid "Thread module initialization failed: failed to create thread key"
+msgstr "Inicializacija modula niti ni uspela: ključa niti ni mogoče ustvariti"
+
+#: ../src/unix/utilsunx.cpp:340
+msgid "Impossible to get child process input"
+msgstr "Vhoda podrejenega procesa ni mogoče pridobiti."
+
+#: ../src/unix/utilsunx.cpp:390
+msgid "Can't write to child process's stdin"
+msgstr "Ni mogoče pisati v stdin podrejenega procesa"
+
+# common/ffile.cpp:182
+#: ../src/unix/utilsunx.cpp:644
+#, c-format
+msgid "Failed to execute '%s'\n"
+msgstr "'%s' ni mogoče izvesti\n"
+
+#: ../src/unix/utilsunx.cpp:678
+msgid "Fork failed"
+msgstr "Razcepitev ni uspela"
+
+# generic/dirdlgg.cpp:550
+#: ../src/unix/utilsunx.cpp:701
+msgid "Failed to set process priority"
+msgstr "Prioritete procesa ni bilo mogoče nastaviti."
+
+#: ../src/unix/utilsunx.cpp:712
+msgid "Failed to redirect child process input/output"
+msgstr "Preusmeritev vhoda/izhoda podrejenega procesa ni uspela."
+
+#: ../src/unix/utilsunx.cpp:816
+msgid "Failed to set up non-blocking pipe, the program might hang."
+msgstr "Neuspešno vzpostavljena neblokirana cev, program se lahko obesi."
+
+#: ../src/unix/utilsunx.cpp:1023
+msgid "Cannot get the hostname"
+msgstr "Imena gostitelja ni mogoče dobiti"
+
+#: ../src/unix/utilsunx.cpp:1059
+msgid "Cannot get the official hostname"
+msgstr "Imena uradnega gostitelja ni mogoče dobiti"
+
+# msw/statbr95.cpp:149
+#: ../src/unix/wakeuppipe.cpp:49
+msgid "Failed to create wake up pipe used by event loop."
+msgstr "Cevi z bujenjem, ki jo uporablja zanka dogodka, ni mogoče ustvariti."
+
+#: ../src/unix/wakeuppipe.cpp:56
+msgid "Failed to switch wake up pipe to non-blocking mode"
+msgstr "Preklop cevi z bujenjem v neblokirani način ni uspel"
+
+#: ../src/unix/wakeuppipe.cpp:117
+msgid "Failed to read from wake-up pipe"
+msgstr "Branje iz cevi z bujenjem ni uspelo."
+
+# generic/filedlgg.cpp:1043
+#: ../src/x11/app.cpp:124
+#, c-format
+msgid "Invalid geometry specification '%s'"
+msgstr "Neveljavna specifikacija geometrije '%s'"
+
+# common/docview.cpp:306
+#: ../src/x11/app.cpp:167
+msgid "wxWidgets could not open display. Exiting."
+msgstr "wxWidgets ne more odpreti zaslona. Izhod."
+
+# msw/clipbrd.cpp:122
+#: ../src/x11/utils.cpp:169
+#, c-format
+msgid "Failed to close the display \"%s\""
+msgstr "Zaprtje prikaza »%s« ni uspelo."
+
+# generic/dirdlgg.cpp:550
+#: ../src/x11/utils.cpp:188
+#, c-format
+msgid "Failed to open display \"%s\"."
+msgstr "Zaslona \"%s\" ni mogoče odpreti."
+
+#: ../src/xml/xml.cpp:868
+#, c-format
+msgid "XML parsing error: '%s' at line %d"
+msgstr "Napaka razčlenjevanja XML: '%s' v vrstici %d"
+
+# common/prntbase.cpp:731
+#: ../src/xrc/xh_propgrid.cpp:239
+#, c-format
+msgid "Page %i"
+msgstr "Stran %i"
+
+# common/ffile.cpp:101
+#: ../src/xrc/xmlres.cpp:448
+#, c-format
+msgid "Cannot load resources from '%s'."
+msgstr "Virov iz datoteke »%s« ni mogoče naložiti."
+
+# common/ffile.cpp:101
+#: ../src/xrc/xmlres.cpp:799
+#, c-format
+msgid "Cannot open resources file '%s'."
+msgstr "Datoteke virov »%s« ni mogoče odpreti."
+
+# common/ffile.cpp:101
+#: ../src/xrc/xmlres.cpp:806
+#, c-format
+msgid "Cannot load resources from file '%s'."
+msgstr "Ni mogoče naložiti virov iz datoteke »%s«."
+
+#: ../src/xrc/xmlres.cpp:2767
+#, c-format
+msgid "Creating %s \"%s\" failed."
+msgstr "Ustvarjanje %s »%s« ni uspelo."

--- a/po_wxstd/sq.po
+++ b/po_wxstd/sq.po
@@ -1,0 +1,9422 @@
+# Copyright (C) Besnik Bleta <besnik@programeshqip.org>, 2004, 2006, 2019, 2022, 2024.
+msgid ""
+msgstr ""
+"Project-Id-Version: wxWidgets 3.3\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-05-14 20:23+0200\n"
+"PO-Revision-Date: 2024-01-17 09:33+0200\n"
+"Last-Translator: Besnik Bleta <besnik@programeshqip.org>\n"
+"Language-Team: <wx-translators@wxwidgets.org>\n"
+"Language: sq\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Poedit 3.2.2\n"
+
+#: ../include/wx/defs.h:2582
+msgid "All files (*.*)|*.*"
+msgstr "Krejt kartelat (*.*)|*.*"
+
+#: ../include/wx/defs.h:2585
+msgid "All files (*)|*"
+msgstr "Krejt kartelat (*)|*"
+
+#: ../include/wx/generic/progdlgg.h:85
+msgid "Elapsed time:"
+msgstr "Kohë e rrjedhur:"
+
+#: ../include/wx/generic/progdlgg.h:86
+msgid "Estimated time:"
+msgstr "Kohë përafërsisht:"
+
+#: ../include/wx/generic/progdlgg.h:87
+msgid "Remaining time:"
+msgstr "Kohë e mbetur:"
+
+#. TRANSLATORS: HTML printout default title.
+#: ../include/wx/html/htmprint.h:121 ../include/wx/prntbase.h:273
+#: ../include/wx/richtext/richtextprint.h:109 ../src/common/docview.cpp:2161
+msgid "Printout"
+msgstr ""
+
+#. TRANSLATORS: HTML easy print default title.
+#: ../include/wx/html/htmprint.h:234 ../include/wx/richtext/richtextprint.h:163
+#: ../src/common/prntbase.cpp:522 ../src/html/htmprint.cpp:291
+msgid "Printing"
+msgstr "Po shtypet"
+
+#: ../include/wx/msgdlg.h:277 ../src/common/stockitem.cpp:211
+msgid "Yes"
+msgstr "Po"
+
+#: ../include/wx/msgdlg.h:278 ../src/common/stockitem.cpp:182
+msgid "No"
+msgstr "Jo"
+
+#: ../include/wx/msgdlg.h:279 ../src/common/stockitem.cpp:183
+#: ../src/msw/msgdlg.cpp:430 ../src/msw/msgdlg.cpp:734
+#: ../src/richtext/richtextstyledlg.cpp:292
+msgid "OK"
+msgstr "OK"
+
+#: ../include/wx/msgdlg.h:280 ../src/common/stockitem.cpp:150
+#: ../src/msw/msgdlg.cpp:430 ../src/msw/progdlg.cpp:884
+#: ../src/richtext/richtextstyledlg.cpp:295
+msgid "Cancel"
+msgstr "Anuloje"
+
+#: ../include/wx/msgdlg.h:281 ../src/common/stockitem.cpp:168
+#: ../src/html/helpdlg.cpp:63 ../src/html/helpfrm.cpp:108
+#: ../src/osx/button_osx.cpp:38
+msgid "Help"
+msgstr "Ndihmë"
+
+#: ../include/wx/msw/ole/oleutils.h:52
+msgid "Cannot initialize OLE"
+msgstr "S’gatitet dot OLE"
+
+#: ../include/wx/msw/private/fswatcher.h:48
+#, c-format
+msgid "Unable to close the handle for '%s'"
+msgstr "S’arrihet të mbyllet trajtuesi për '%s'"
+
+#: ../include/wx/msw/private/fswatcher.h:92
+#, c-format
+msgid "Failed to open directory \"%s\" for monitoring."
+msgstr "S’u arrit të hapej drejtoria “%s” për mbikëqyrje."
+
+#: ../include/wx/msw/private/fswatcher.h:125
+msgid "Unable to close I/O completion port handle"
+msgstr ""
+
+#: ../include/wx/msw/private/fswatcher.h:142
+msgid "Unable to associate handle with I/O completion port"
+msgstr ""
+
+#: ../include/wx/msw/private/fswatcher.h:148
+msgid "Unexpectedly new I/O completion port was created"
+msgstr "U krijua papritmas portë e re plotësimi I/O"
+
+#: ../include/wx/msw/private/fswatcher.h:213
+msgid "Unable to post completion status"
+msgstr "S’arrihet të postohet gjendje plotësimi"
+
+#: ../include/wx/msw/private/fswatcher.h:262
+msgid "Unable to dequeue completion packet"
+msgstr ""
+
+#: ../include/wx/msw/private/fswatcher.h:273
+msgid "Unable to create I/O completion port"
+msgstr "S’arrihet të krijohet portë plotësimi I/O"
+
+#: ../include/wx/richmsgdlg.h:29
+msgid "&See details"
+msgstr "&Shihni hollësi"
+
+#: ../include/wx/richmsgdlg.h:30
+msgid "&Hide details"
+msgstr "&Fshihi hollësitë"
+
+#: ../include/wx/richtext/richtextbuffer.h:3864
+msgid "&Box"
+msgstr "&Kuadrat"
+
+#: ../include/wx/richtext/richtextbuffer.h:5008
+msgid "&Picture"
+msgstr "&Foto"
+
+#: ../include/wx/richtext/richtextbuffer.h:5958
+msgid "&Cell"
+msgstr "&Kutizë"
+
+#: ../include/wx/richtext/richtextbuffer.h:6067
+msgid "&Table"
+msgstr "&Tabelë"
+
+#: ../include/wx/richtext/richtextimagedlg.h:37
+msgid "Object Properties"
+msgstr "Veti Objekti"
+
+#: ../include/wx/richtext/richtextsymboldlg.h:39
+msgid "Symbols"
+msgstr "Simbole"
+
+#: ../include/wx/unix/pipe.h:46
+msgid "Pipe creation failed"
+msgstr "Dështoi krijimi i kanalit"
+
+#: ../include/wx/unix/private/displayx11.h:65
+msgid "Failed to enumerate video modes"
+msgstr "S’u arrit të numërtoheshin mënyra video"
+
+#: ../include/wx/unix/private/displayx11.h:89
+msgid "Failed to change video mode"
+msgstr "S’u arrit të ndryshohej mënyrë video"
+
+#: ../include/wx/unix/private/fswatcher_kqueue.h:57
+#, c-format
+msgid "Unable to open path '%s'"
+msgstr "S’arrihet të hapet shtegu '%s'"
+
+#: ../include/wx/unix/private/fswatcher_kqueue.h:74
+#, c-format
+msgid "Unable to close path '%s'"
+msgstr "S’arrihet të mbyllet shtegu '%s'"
+
+#: ../include/wx/xtiprop.h:175
+msgid "SetProperty called w/o valid setter"
+msgstr "SetProperty u thirr pa marrës të vlefshëm"
+
+#: ../include/wx/xtiprop.h:184
+msgid "GetProperty called w/o valid getter"
+msgstr "GetProperty u thirr pa marrës të vlefshëm"
+
+#: ../include/wx/xtiprop.h:193
+msgid "AddToPropertyCollection called w/o valid adder"
+msgstr "AddToPropertyCollection u thirr pa shtues të vlefshëm"
+
+#: ../include/wx/xtiprop.h:202
+msgid "GetPropertyCollection called w/o valid collection getter"
+msgstr "GetPropertyCollection u thirr pa marrës të vlefshëm përmbledhjeje"
+
+#: ../include/wx/xtiprop.h:255
+msgid "AddToPropertyCollection called on a generic accessor"
+msgstr ""
+
+#: ../include/wx/xtiprop.h:262
+msgid "GetPropertyCollection called on a generic accessor"
+msgstr ""
+
+#: ../src/aui/tabmdi.cpp:106 ../src/generic/mdig.cpp:94
+msgid "Cl&ose"
+msgstr "MB&ylle"
+
+#: ../src/aui/tabmdi.cpp:107 ../src/generic/mdig.cpp:95
+msgid "Close All"
+msgstr "Mbylli Krejt"
+
+#: ../src/aui/tabmdi.cpp:109 ../src/generic/mdig.cpp:97 ../src/msw/mdi.cpp:175
+#: ../src/qt/mdi.cpp:258
+msgid "&Next"
+msgstr "&Pasuesi"
+
+#: ../src/aui/tabmdi.cpp:110 ../src/generic/mdig.cpp:98 ../src/msw/mdi.cpp:176
+#: ../src/qt/mdi.cpp:259
+msgid "&Previous"
+msgstr "&I mëparshmi"
+
+#: ../src/aui/tabmdi.cpp:332 ../src/aui/tabmdi.cpp:348
+#: ../src/aui/tabmdi.cpp:350 ../src/generic/mdig.cpp:291
+#: ../src/generic/mdig.cpp:307 ../src/generic/mdig.cpp:311
+#: ../src/msw/mdi.cpp:337 ../src/qt/mdi.cpp:462
+msgid "&Window"
+msgstr "&Dritare"
+
+#: ../src/common/accelcmn.cpp:47
+msgctxt "keyboard key"
+msgid "Delete"
+msgstr "Tasti Delete"
+
+#: ../src/common/accelcmn.cpp:48
+msgctxt "keyboard key"
+msgid "Del"
+msgstr "Tasti Del"
+
+#: ../src/common/accelcmn.cpp:49
+msgctxt "keyboard key"
+msgid "Back"
+msgstr "Tasti Back"
+
+#: ../src/common/accelcmn.cpp:49
+msgctxt "keyboard key"
+msgid "Backspace"
+msgstr "Tasti Backspace"
+
+#: ../src/common/accelcmn.cpp:50
+msgctxt "keyboard key"
+msgid "Insert"
+msgstr "Tasti Insert"
+
+#: ../src/common/accelcmn.cpp:51
+msgctxt "keyboard key"
+msgid "Ins"
+msgstr "Tasti Ins"
+
+#: ../src/common/accelcmn.cpp:52
+msgctxt "keyboard key"
+msgid "Enter"
+msgstr "Tasti Enter"
+
+#: ../src/common/accelcmn.cpp:53
+msgctxt "keyboard key"
+msgid "Return"
+msgstr "Tasti Return"
+
+#: ../src/common/accelcmn.cpp:54
+msgctxt "keyboard key"
+msgid "PageUp"
+msgstr "Tasti PageUp"
+
+#: ../src/common/accelcmn.cpp:54
+msgctxt "keyboard key"
+msgid "Page Up"
+msgstr "Tasti Page Up"
+
+#: ../src/common/accelcmn.cpp:55
+msgctxt "keyboard key"
+msgid "PageDown"
+msgstr "Tasti PageDown"
+
+#: ../src/common/accelcmn.cpp:55
+msgctxt "keyboard key"
+msgid "Page Down"
+msgstr "Tasti Page Down"
+
+#: ../src/common/accelcmn.cpp:56
+msgctxt "keyboard key"
+msgid "PgUp"
+msgstr "Tasti PgUp"
+
+#: ../src/common/accelcmn.cpp:57
+msgctxt "keyboard key"
+msgid "PgDn"
+msgstr "Tasti PgDn"
+
+#: ../src/common/accelcmn.cpp:58
+msgctxt "keyboard key"
+msgid "Left"
+msgstr "Tasti Shigjetë Majtas"
+
+#: ../src/common/accelcmn.cpp:59
+msgctxt "keyboard key"
+msgid "Right"
+msgstr "Tasti Shigjetë Djathtas"
+
+#: ../src/common/accelcmn.cpp:60
+msgctxt "keyboard key"
+msgid "Up"
+msgstr "Tasti Shigjetë Sipër"
+
+#: ../src/common/accelcmn.cpp:61
+msgctxt "keyboard key"
+msgid "Down"
+msgstr "Tasti Shigjetë Poshtë"
+
+#: ../src/common/accelcmn.cpp:62
+msgctxt "keyboard key"
+msgid "Home"
+msgstr "Tasti Home"
+
+#: ../src/common/accelcmn.cpp:63
+msgctxt "keyboard key"
+msgid "End"
+msgstr "Tasti End"
+
+#: ../src/common/accelcmn.cpp:64
+msgctxt "keyboard key"
+msgid "Space"
+msgstr "Tasti Space"
+
+#: ../src/common/accelcmn.cpp:65
+msgctxt "keyboard key"
+msgid "Tab"
+msgstr "Tasti Tab"
+
+#: ../src/common/accelcmn.cpp:66
+msgctxt "keyboard key"
+msgid "Esc"
+msgstr "Tasti Esc"
+
+#: ../src/common/accelcmn.cpp:67
+msgctxt "keyboard key"
+msgid "Escape"
+msgstr "Tasti Escape"
+
+#: ../src/common/accelcmn.cpp:68
+msgctxt "keyboard key"
+msgid "Cancel"
+msgstr "Tasti Cancel"
+
+#: ../src/common/accelcmn.cpp:69
+msgctxt "keyboard key"
+msgid "Clear"
+msgstr "Tasti Clear"
+
+#: ../src/common/accelcmn.cpp:70
+msgctxt "keyboard key"
+msgid "Menu"
+msgstr "Tasti Menu"
+
+#: ../src/common/accelcmn.cpp:71
+msgctxt "keyboard key"
+msgid "Pause"
+msgstr "Tasti Pause"
+
+#: ../src/common/accelcmn.cpp:72
+msgctxt "keyboard key"
+msgid "Capital"
+msgstr "Tasti Capital"
+
+#: ../src/common/accelcmn.cpp:73
+msgctxt "keyboard key"
+msgid "Select"
+msgstr "Tasti Select"
+
+#: ../src/common/accelcmn.cpp:74
+msgctxt "keyboard key"
+msgid "Print"
+msgstr "Tasti Print"
+
+#: ../src/common/accelcmn.cpp:75
+msgctxt "keyboard key"
+msgid "Execute"
+msgstr "Tasti Execute"
+
+#: ../src/common/accelcmn.cpp:76
+msgctxt "keyboard key"
+msgid "Snapshot"
+msgstr "Tasti Snapshot"
+
+#: ../src/common/accelcmn.cpp:77
+msgctxt "keyboard key"
+msgid "Help"
+msgstr "Tasti Help"
+
+#: ../src/common/accelcmn.cpp:78
+msgctxt "keyboard key"
+msgid "Add"
+msgstr "Tasti Add"
+
+#: ../src/common/accelcmn.cpp:79
+msgctxt "keyboard key"
+msgid "Separator"
+msgstr "Tasti Separator"
+
+#: ../src/common/accelcmn.cpp:80
+msgctxt "keyboard key"
+msgid "Subtract"
+msgstr "Tasti Subtract"
+
+#: ../src/common/accelcmn.cpp:81
+msgctxt "keyboard key"
+msgid "Decimal"
+msgstr "Tasti Decimal"
+
+#: ../src/common/accelcmn.cpp:82
+msgctxt "keyboard key"
+msgid "Multiply"
+msgstr "Tasti Shumëzim"
+
+#: ../src/common/accelcmn.cpp:83
+msgctxt "keyboard key"
+msgid "Divide"
+msgstr "Tasti Pjesëtim"
+
+#: ../src/common/accelcmn.cpp:84
+msgctxt "keyboard key"
+msgid "Num_lock"
+msgstr "Tasti Num_lock"
+
+#: ../src/common/accelcmn.cpp:84
+msgctxt "keyboard key"
+msgid "Num Lock"
+msgstr "Tasti Num Lock"
+
+#: ../src/common/accelcmn.cpp:85
+msgctxt "keyboard key"
+msgid "Scroll_lock"
+msgstr "Tasti Scroll_lock"
+
+#: ../src/common/accelcmn.cpp:85
+msgctxt "keyboard key"
+msgid "Scroll Lock"
+msgstr "Tasti Scroll Lock"
+
+#: ../src/common/accelcmn.cpp:86
+msgctxt "keyboard key"
+msgid "KP_Space"
+msgstr "Tasti KP_Space"
+
+#: ../src/common/accelcmn.cpp:86
+msgctxt "keyboard key"
+msgid "Num Space"
+msgstr "Tasti Num Space"
+
+#: ../src/common/accelcmn.cpp:87
+msgctxt "keyboard key"
+msgid "KP_Tab"
+msgstr "Tasti KP_Tab"
+
+#: ../src/common/accelcmn.cpp:87
+msgctxt "keyboard key"
+msgid "Num Tab"
+msgstr "Tasti Num Tab"
+
+#: ../src/common/accelcmn.cpp:88
+msgctxt "keyboard key"
+msgid "KP_Enter"
+msgstr "Tasti KP_Enter"
+
+#: ../src/common/accelcmn.cpp:88
+msgctxt "keyboard key"
+msgid "Num Enter"
+msgstr "Tasti Num Enter"
+
+#: ../src/common/accelcmn.cpp:89
+msgctxt "keyboard key"
+msgid "KP_Home"
+msgstr "Tasti KP_Home"
+
+#: ../src/common/accelcmn.cpp:89
+msgctxt "keyboard key"
+msgid "Num Home"
+msgstr "Tasti Num Home"
+
+#: ../src/common/accelcmn.cpp:90
+msgctxt "keyboard key"
+msgid "KP_Left"
+msgstr "Tasti KP_Left"
+
+#: ../src/common/accelcmn.cpp:90
+msgctxt "keyboard key"
+msgid "Num left"
+msgstr "Tasti Num left"
+
+#: ../src/common/accelcmn.cpp:91
+msgctxt "keyboard key"
+msgid "KP_Up"
+msgstr "Tasti KP_Up"
+
+#: ../src/common/accelcmn.cpp:91
+msgctxt "keyboard key"
+msgid "Num Up"
+msgstr "Tasti Num Up"
+
+#: ../src/common/accelcmn.cpp:92
+msgctxt "keyboard key"
+msgid "KP_Right"
+msgstr "Tasti KP_Right"
+
+#: ../src/common/accelcmn.cpp:92
+msgctxt "keyboard key"
+msgid "Num Right"
+msgstr "Tasti Num Right"
+
+#: ../src/common/accelcmn.cpp:93
+msgctxt "keyboard key"
+msgid "KP_Down"
+msgstr "Tasti KP_Down"
+
+#: ../src/common/accelcmn.cpp:93
+msgctxt "keyboard key"
+msgid "Num Down"
+msgstr "Tasti Num Down"
+
+#: ../src/common/accelcmn.cpp:94
+msgctxt "keyboard key"
+msgid "KP_PageUp"
+msgstr "Tasti KP_PageUp"
+
+#: ../src/common/accelcmn.cpp:94
+msgctxt "keyboard key"
+msgid "Num Page Up"
+msgstr "Tasti Num Page Up"
+
+#: ../src/common/accelcmn.cpp:95
+msgctxt "keyboard key"
+msgid "KP_PageDown"
+msgstr "Tasti KP_PageDown"
+
+#: ../src/common/accelcmn.cpp:95
+msgctxt "keyboard key"
+msgid "Num Page Down"
+msgstr "Tasti Num Page Down"
+
+#: ../src/common/accelcmn.cpp:96
+msgctxt "keyboard key"
+msgid "KP_Prior"
+msgstr "Tasti KP_Prior"
+
+#: ../src/common/accelcmn.cpp:97
+msgctxt "keyboard key"
+msgid "KP_Next"
+msgstr "Tasti KP_Next"
+
+#: ../src/common/accelcmn.cpp:98
+msgctxt "keyboard key"
+msgid "KP_End"
+msgstr "Tasti KP_End"
+
+#: ../src/common/accelcmn.cpp:98
+msgctxt "keyboard key"
+msgid "Num End"
+msgstr "Tasti Num End"
+
+#: ../src/common/accelcmn.cpp:99
+msgctxt "keyboard key"
+msgid "KP_Begin"
+msgstr "Tasti KP_Begin"
+
+#: ../src/common/accelcmn.cpp:99
+msgctxt "keyboard key"
+msgid "Num Begin"
+msgstr "Tasti Num Begin"
+
+#: ../src/common/accelcmn.cpp:100
+msgctxt "keyboard key"
+msgid "KP_Insert"
+msgstr "Tasti KP_Insert"
+
+#: ../src/common/accelcmn.cpp:100
+msgctxt "keyboard key"
+msgid "Num Insert"
+msgstr "Tasti Num Insert"
+
+#: ../src/common/accelcmn.cpp:101
+msgctxt "keyboard key"
+msgid "KP_Delete"
+msgstr "Tasti KP_Delete"
+
+#: ../src/common/accelcmn.cpp:101
+msgctxt "keyboard key"
+msgid "Num Delete"
+msgstr "Tasti Num Delete"
+
+#: ../src/common/accelcmn.cpp:102
+msgctxt "keyboard key"
+msgid "KP_Equal"
+msgstr "Tasti KP_Equal"
+
+#: ../src/common/accelcmn.cpp:102
+msgctxt "keyboard key"
+msgid "Num ="
+msgstr "Tasti Num ="
+
+#: ../src/common/accelcmn.cpp:103
+msgctxt "keyboard key"
+msgid "KP_Multiply"
+msgstr "Tasti KP_Multiply"
+
+#: ../src/common/accelcmn.cpp:103
+msgctxt "keyboard key"
+msgid "Num *"
+msgstr "Tasti Num *"
+
+#: ../src/common/accelcmn.cpp:104
+msgctxt "keyboard key"
+msgid "KP_Add"
+msgstr "Tasti KP_Add"
+
+#: ../src/common/accelcmn.cpp:104
+msgctxt "keyboard key"
+msgid "Num +"
+msgstr "Tasti Num +"
+
+#: ../src/common/accelcmn.cpp:105
+msgctxt "keyboard key"
+msgid "KP_Separator"
+msgstr "Tasti KP_Separator"
+
+#: ../src/common/accelcmn.cpp:105
+msgctxt "keyboard key"
+msgid "Num ,"
+msgstr "Tasti Num ,"
+
+#: ../src/common/accelcmn.cpp:106
+msgctxt "keyboard key"
+msgid "KP_Subtract"
+msgstr "Tasti KP_Subtract"
+
+#: ../src/common/accelcmn.cpp:106
+msgctxt "keyboard key"
+msgid "Num -"
+msgstr "Tasti Num -"
+
+#: ../src/common/accelcmn.cpp:107
+msgctxt "keyboard key"
+msgid "KP_Decimal"
+msgstr "Tasti KP_Decimal"
+
+#: ../src/common/accelcmn.cpp:107
+msgctxt "keyboard key"
+msgid "Num ."
+msgstr "Tasti Num ."
+
+#: ../src/common/accelcmn.cpp:108
+msgctxt "keyboard key"
+msgid "KP_Divide"
+msgstr "Tasti KP_Divide"
+
+#: ../src/common/accelcmn.cpp:108
+msgctxt "keyboard key"
+msgid "Num /"
+msgstr "Tasti Num /"
+
+#: ../src/common/accelcmn.cpp:109
+msgctxt "keyboard key"
+msgid "Windows_Left"
+msgstr "Tasti Windows_Left"
+
+#: ../src/common/accelcmn.cpp:110
+msgctxt "keyboard key"
+msgid "Windows_Right"
+msgstr "Tasti Windows_Right"
+
+#: ../src/common/accelcmn.cpp:111
+msgctxt "keyboard key"
+msgid "Windows_Menu"
+msgstr "Tasti Windows_Menu"
+
+#: ../src/common/accelcmn.cpp:112
+msgctxt "keyboard key"
+msgid "Command"
+msgstr "Tasti Command"
+
+#: ../src/common/accelcmn.cpp:186 ../src/common/accelcmn.cpp:359
+msgctxt "keyboard key"
+msgid "Ctrl"
+msgstr "Tasti ctrl"
+
+#: ../src/common/accelcmn.cpp:188 ../src/common/accelcmn.cpp:363
+msgctxt "keyboard key"
+msgid "Alt"
+msgstr "Tasti alt"
+
+#: ../src/common/accelcmn.cpp:190 ../src/common/accelcmn.cpp:361
+msgctxt "keyboard key"
+msgid "Shift"
+msgstr "Tasti shift"
+
+#: ../src/common/accelcmn.cpp:196
+msgctxt "keyboard key"
+msgid "num "
+msgstr "Tasti num "
+
+#: ../src/common/accelcmn.cpp:260 ../src/common/accelcmn.cpp:382
+msgctxt "keyboard key"
+msgid "F"
+msgstr "Tasti F"
+
+#: ../src/common/accelcmn.cpp:277 ../src/common/accelcmn.cpp:385
+msgctxt "keyboard key"
+msgid "KP_F"
+msgstr "Tasti KP_F"
+
+#: ../src/common/accelcmn.cpp:280 ../src/common/accelcmn.cpp:388
+msgctxt "keyboard key"
+msgid "KP_"
+msgstr "Tasti KP_"
+
+#: ../src/common/accelcmn.cpp:283 ../src/common/accelcmn.cpp:391
+msgctxt "keyboard key"
+msgid "SPECIAL"
+msgstr "Tasti SPECIAL"
+
+#: ../src/common/accelcmn.cpp:373
+#, fuzzy
+msgid "Ctrl"
+msgstr "Tasti ctrl"
+
+#: ../src/common/appbase.cpp:786
+msgid "show this help message"
+msgstr "shfaq këtë mesazh ndihme"
+
+#: ../src/common/appbase.cpp:796
+msgid "generate verbose log messages"
+msgstr "prodho mesazhe fjalamanë regjistrimi"
+
+#: ../src/common/appcmn.cpp:256
+msgid "specify the theme to use"
+msgstr "caktoni temë për t’u përdorur"
+
+#: ../src/common/appcmn.cpp:270
+msgid "specify display mode to use (e.g. 640x480-16)"
+msgstr "caktoni mënyrë ekrani për përdorim (p.sh., 640x480-16)"
+
+#: ../src/common/appcmn.cpp:292
+#, c-format
+msgid "Unsupported theme '%s'."
+msgstr "Temë '%s' e pambuluar."
+
+#: ../src/common/appcmn.cpp:309
+#, c-format
+msgid "Invalid display mode specification '%s'."
+msgstr "Specifikim i pavlefshëm mënyre ekrani '%s'."
+
+#: ../src/common/cmdline.cpp:875
+#, c-format
+msgid "Option '%s' can't be negated"
+msgstr "Mundësia '%s' s’mund të mohohet"
+
+#: ../src/common/cmdline.cpp:889
+#, c-format
+msgid "Unknown long option '%s'"
+msgstr "Mundësi e gjatë '%s' e panjohur"
+
+#: ../src/common/cmdline.cpp:904 ../src/common/cmdline.cpp:926
+#, c-format
+msgid "Unknown option '%s'"
+msgstr "Mundësi e panjohur '%s'"
+
+#: ../src/common/cmdline.cpp:1004
+#, c-format
+msgid "Unexpected characters following option '%s'."
+msgstr "Shenja të papritura në vijim të mundësisë '%s'."
+
+#: ../src/common/cmdline.cpp:1039
+#, c-format
+msgid "Option '%s' requires a value."
+msgstr "Mundësia '%s' lyp një vlerë."
+
+#: ../src/common/cmdline.cpp:1058
+#, c-format
+msgid "Separator expected after the option '%s'."
+msgstr "Pas mundësisë '%s' pritej ndarës."
+
+#: ../src/common/cmdline.cpp:1088 ../src/common/cmdline.cpp:1106
+#, c-format
+msgid "'%s' is not a correct numeric value for option '%s'."
+msgstr "'%s' s’është vlerë numerike e saktë për mundësinë '%s'."
+
+#: ../src/common/cmdline.cpp:1122
+#, c-format
+msgid "Option '%s': '%s' cannot be converted to a date."
+msgstr "Mundësi '%s': '%s' s’mund të shndërrohet në datë."
+
+#: ../src/common/cmdline.cpp:1170
+#, c-format
+msgid "Unexpected parameter '%s'"
+msgstr "Parametër '%s' i papritur"
+
+#. TRANSLATORS: Short name and long name for a command line option
+#: ../src/common/cmdline.cpp:1197
+#, c-format
+msgid "%s (or %s)"
+msgstr "%s (ose %s)"
+
+#: ../src/common/cmdline.cpp:1208
+#, c-format
+msgid "The value for the option '%s' must be specified."
+msgstr "Vlera për mundësinë '%s' duhet përcaktuar."
+
+#: ../src/common/cmdline.cpp:1230
+#, c-format
+msgid "The required parameter '%s' was not specified."
+msgstr "S’është përcaktuar parametri i domosdoshëm '%s'."
+
+#: ../src/common/cmdline.cpp:1289
+#, c-format
+msgid "Usage: %s"
+msgstr "Përdorim: %s"
+
+#: ../src/common/cmdline.cpp:1498
+msgid "str"
+msgstr ""
+
+#: ../src/common/cmdline.cpp:1502
+msgid "num"
+msgstr "num"
+
+#: ../src/common/cmdline.cpp:1506
+msgid "double"
+msgstr ""
+
+#: ../src/common/cmdline.cpp:1510
+msgid "date"
+msgstr "datë"
+
+#: ../src/common/cmdproc.cpp:250 ../src/common/cmdproc.cpp:276
+#: ../src/common/cmdproc.cpp:296
+msgid "Unnamed command"
+msgstr "Urdhër i paemërtuar"
+
+#: ../src/common/cmdproc.cpp:253
+msgid "&Undo "
+msgstr "&Zhbëje "
+
+#: ../src/common/cmdproc.cpp:255
+msgid "Can't &Undo "
+msgstr "S’&zhbëhet Dot "
+
+#: ../src/common/cmdproc.cpp:259 ../src/common/stockitem.cpp:208
+#: ../src/msw/textctrl.cpp:2880 ../src/osx/textctrl_osx.cpp:649
+#: ../src/richtext/richtextctrl.cpp:327
+msgid "&Undo"
+msgstr "&Zhbëje"
+
+#: ../src/common/cmdproc.cpp:277 ../src/common/cmdproc.cpp:297
+msgid "&Redo "
+msgstr "&Ribëje "
+
+#: ../src/common/cmdproc.cpp:281 ../src/common/cmdproc.cpp:288
+#: ../src/common/stockitem.cpp:190 ../src/msw/textctrl.cpp:2881
+#: ../src/osx/textctrl_osx.cpp:650 ../src/richtext/richtextctrl.cpp:328
+msgid "&Redo"
+msgstr "&Ribëje"
+
+#: ../src/common/colourcmn.cpp:41
+#, c-format
+msgid "String To Colour : Incorrect colour specification : %s"
+msgstr "Varg për Ngjyrë : Specifikim i pavlefshëm ngjyre : %s"
+
+#: ../src/common/config.cpp:259
+#, c-format
+msgid "Invalid value %ld for a boolean key \"%s\" in config file."
+msgstr "Vlerë %ld e pavlefshme për element bulean “%s” në kartelë formësimi."
+
+#: ../src/common/config.cpp:526
+#, c-format
+msgid ""
+"Environment variables expansion failed: missing '%c' at position %u in '%s'."
+msgstr ""
+"Dështoi zgjerimi i ndryshoreve të mjedisit: mungon '%c' në vendin %u te '%s'."
+
+#: ../src/common/config.cpp:576 ../src/msw/regconf.cpp:272
+#, c-format
+msgid "'%s' has extra '..', ignored."
+msgstr "'%s' ka '..' ekstra, u shpërfill."
+
+#. TRANSLATORS: Checkbox state name
+#: ../src/common/datavcmn.cpp:2166 ../src/generic/datavgen.cpp:1430
+msgid "checked"
+msgstr "me shenjë"
+
+#. TRANSLATORS: Checkbox state name
+#: ../src/common/datavcmn.cpp:2170 ../src/generic/datavgen.cpp:1432
+msgid "unchecked"
+msgstr "pa shenjë"
+
+#. TRANSLATORS: Checkbox state name
+#: ../src/common/datavcmn.cpp:2174
+msgid "undetermined"
+msgstr "e papërcaktuar"
+
+#: ../src/common/datetimefmt.cpp:1875
+msgid "today"
+msgstr "sot"
+
+#: ../src/common/datetimefmt.cpp:1876
+msgid "yesterday"
+msgstr "dje"
+
+#: ../src/common/datetimefmt.cpp:1877
+msgid "tomorrow"
+msgstr "nesër"
+
+#: ../src/common/datetimefmt.cpp:2071
+msgid "first"
+msgstr "i pari"
+
+#: ../src/common/datetimefmt.cpp:2072
+msgid "second"
+msgstr "i dyti"
+
+#: ../src/common/datetimefmt.cpp:2073
+msgid "third"
+msgstr "i treti"
+
+#: ../src/common/datetimefmt.cpp:2074
+msgid "fourth"
+msgstr "i katërti"
+
+#: ../src/common/datetimefmt.cpp:2075
+msgid "fifth"
+msgstr "i pesti"
+
+#: ../src/common/datetimefmt.cpp:2076
+msgid "sixth"
+msgstr "i gjashti"
+
+#: ../src/common/datetimefmt.cpp:2077
+msgid "seventh"
+msgstr "i shtati"
+
+#: ../src/common/datetimefmt.cpp:2078
+msgid "eighth"
+msgstr "i teti"
+
+#: ../src/common/datetimefmt.cpp:2079
+msgid "ninth"
+msgstr "i nënti"
+
+#: ../src/common/datetimefmt.cpp:2080
+msgid "tenth"
+msgstr "i dhjeti"
+
+#: ../src/common/datetimefmt.cpp:2081
+msgid "eleventh"
+msgstr "i njëmbëdhjeti"
+
+#: ../src/common/datetimefmt.cpp:2082
+msgid "twelfth"
+msgstr "i dymbëdhjeti"
+
+#: ../src/common/datetimefmt.cpp:2083
+msgid "thirteenth"
+msgstr "i trembëdhjeti"
+
+#: ../src/common/datetimefmt.cpp:2084
+msgid "fourteenth"
+msgstr "i katërmbëdhjeti"
+
+#: ../src/common/datetimefmt.cpp:2085
+msgid "fifteenth"
+msgstr "i pesëmbëdhjeti"
+
+#: ../src/common/datetimefmt.cpp:2086
+msgid "sixteenth"
+msgstr "i gjashtëmbëdhjeti"
+
+#: ../src/common/datetimefmt.cpp:2087
+msgid "seventeenth"
+msgstr "i shtatëmbëdhjeti"
+
+#: ../src/common/datetimefmt.cpp:2088
+msgid "eighteenth"
+msgstr "i tetëmbëdhjeti"
+
+#: ../src/common/datetimefmt.cpp:2089
+msgid "nineteenth"
+msgstr "i nëntëmbëdhjeti"
+
+#: ../src/common/datetimefmt.cpp:2090
+msgid "twentieth"
+msgstr "i njëzeti"
+
+#: ../src/common/datetimefmt.cpp:2248
+msgid "noon"
+msgstr "mesditë"
+
+#: ../src/common/datetimefmt.cpp:2249
+msgid "midnight"
+msgstr "mesnatë"
+
+#: ../src/common/debugrpt.cpp:209
+#, c-format
+msgid "Failed to create directory \"%s\""
+msgstr "S’u arrit të krijohej drejtori “%s”"
+
+#: ../src/common/debugrpt.cpp:210
+msgid "Debug report couldn't be created."
+msgstr "S'u krijua dot raport diagnostikimi."
+
+#: ../src/common/debugrpt.cpp:227
+#, c-format
+msgid "Failed to remove debug report file \"%s\""
+msgstr "S’u arrit të hiqej kartela raporti diagnostikimi “%s”"
+
+#: ../src/common/debugrpt.cpp:239
+#, c-format
+msgid "Failed to clean up debug report directory \"%s\""
+msgstr "S’u arrit të pastrohej drejtori “%s” raportesh diagnostikimi"
+
+#: ../src/common/debugrpt.cpp:514
+msgid "process context description"
+msgstr "përshkrim konteksti procesi"
+
+#: ../src/common/debugrpt.cpp:538
+msgid "dump of the process state (binary)"
+msgstr "zbrazje e gjendjes së procesit (dyor)"
+
+#: ../src/common/debugrpt.cpp:553
+msgid "Debug report generation has failed."
+msgstr "Dështoi prodhimi i një raporti diagnostikimi."
+
+#: ../src/common/debugrpt.cpp:560
+#, c-format
+msgid ""
+"Processing debug report has failed, leaving the files in \"%s\" directory."
+msgstr ""
+"Përpunimi i raportit të diagnostikimit dështoi, kartelat po lihen te "
+"drejtoria “%s”."
+
+#: ../src/common/debugrpt.cpp:573
+msgid "A debug report has been generated. It can be found in"
+msgstr "Te drejtoria u prodhua një raport diagnostikimi. Mund të gjendet te"
+
+#: ../src/common/debugrpt.cpp:576
+msgid "And includes the following files:\n"
+msgstr "Dhe përmban kartelat vijuese:\n"
+
+#: ../src/common/debugrpt.cpp:586
+msgid ""
+"\n"
+"Please send this report to the program maintainer, thank you!\n"
+msgstr ""
+"\n"
+"Ju lutemi, dërgojani këtë raport mirëmbajtësit të programit, faleminderit!\n"
+
+#: ../src/common/debugrpt.cpp:729
+msgid "Failed to execute curl, please install it in PATH."
+msgstr "S’u arrit të përmbushej curl-i, ju lutemi, instalojeni në PATH."
+
+#: ../src/common/debugrpt.cpp:742
+#, c-format
+msgid "Failed to upload the debug report (error code %d)."
+msgstr "S’u arrit të ngarkohej raporti i diagnostikimit (kod gabimi %d)."
+
+#: ../src/common/docview.cpp:366
+msgid "Save As"
+msgstr "Ruaje Si"
+
+#: ../src/common/docview.cpp:457
+msgid "Discard changes and reload the last saved version?"
+msgstr ""
+"Të hidhen tej ndryshimet dhe të ringarkohet versioni i fundit i ruajtur?"
+
+#: ../src/common/docview.cpp:488
+msgid "unnamed"
+msgstr "pa emër"
+
+#: ../src/common/docview.cpp:513
+#, c-format
+msgid "Do you want to save changes to %s?"
+msgstr "Doni të ruhen ndryshimet te %s?"
+
+#: ../src/common/docview.cpp:521 ../src/common/docview.cpp:560
+#: ../src/common/stockitem.cpp:195
+msgid "&Save"
+msgstr "&Ruaje"
+
+#: ../src/common/docview.cpp:522 ../src/common/docview.cpp:560
+msgid "&Discard changes"
+msgstr "&Hidhi tej ndryshimet"
+
+#: ../src/common/docview.cpp:523
+msgid "Do&n't close"
+msgstr "&Mos e mbyll"
+
+#: ../src/common/docview.cpp:553
+#, c-format
+msgid "Do you want to save changes to %s before closing it?"
+msgstr "Doni të ruhen ndryshimet te %s para se të mbyllet?"
+
+#: ../src/common/docview.cpp:559
+msgid "The document must be closed."
+msgstr "Dokumenti duhet mbyllur."
+
+#: ../src/common/docview.cpp:571
+#, c-format
+msgid "Saving %s failed, would you like to retry?"
+msgstr "Ruajtja e %s dështoi, do të donit të riprovohej?"
+
+#: ../src/common/docview.cpp:577
+msgid "Retry"
+msgstr "Riprovo"
+
+#: ../src/common/docview.cpp:577
+msgid "Discard changes"
+msgstr "Hidhi tej ndryshimet"
+
+#: ../src/common/docview.cpp:679
+#, c-format
+msgid "File \"%s\" could not be opened for writing."
+msgstr "Kartela “%s” s’u hap dot për shkrim."
+
+#: ../src/common/docview.cpp:685
+#, c-format
+msgid "Failed to save document to the file \"%s\"."
+msgstr "S’u arrit të ruhej dokument te kartela “%s”."
+
+#: ../src/common/docview.cpp:702
+#, c-format
+msgid "File \"%s\" could not be opened for reading."
+msgstr "Kartela “%s” s’u hap dot për lexim."
+
+#: ../src/common/docview.cpp:714
+#, c-format
+msgid "Failed to read document from the file \"%s\"."
+msgstr "S’u arrit të lexohej dokument prej kartelës “%s”."
+
+#: ../src/common/docview.cpp:1236
+#, c-format
+msgid ""
+"The file '%s' doesn't exist and couldn't be opened.\n"
+"It has been removed from the most recently used files list."
+msgstr ""
+"Kartela '%s' s’ekziston, ndaj s’mund të hapej.\n"
+"Është hequr nga lista e kartelave më të përdorura së fundi."
+
+#: ../src/common/docview.cpp:1296
+msgid "Print preview creation failed."
+msgstr "Krijimi i paraparjes së shtypjes dështoi."
+
+#: ../src/common/docview.cpp:1302
+msgid "Print Preview"
+msgstr "Paraparje Shtypjeje"
+
+#: ../src/common/docview.cpp:1517
+#, c-format
+msgid "The format of file '%s' couldn't be determined."
+msgstr "S’u përcaktua dot formati i kartelës '%s'."
+
+#: ../src/common/docview.cpp:1643
+#, c-format
+msgid "unnamed%d"
+msgstr "i paemër%d"
+
+#: ../src/common/docview.cpp:1660
+msgid " - "
+msgstr " - "
+
+#: ../src/common/docview.cpp:1791 ../src/common/docview.cpp:1844
+msgid "Open File"
+msgstr "Hap Kartelë"
+
+#: ../src/common/docview.cpp:1807
+msgid "File error"
+msgstr "Gabim kartele"
+
+#: ../src/common/docview.cpp:1809
+msgid "Sorry, could not open this file."
+msgstr "Na ndjeni, s’u hap dot kjo kartelë."
+
+#: ../src/common/docview.cpp:1843
+msgid "Sorry, the format for this file is unknown."
+msgstr "Na ndjeni, formati i kësaj kartele është i panjohur."
+
+#: ../src/common/docview.cpp:1924
+msgid "Select a document template"
+msgstr "Përzgjidhni një gjedhe dokumenti"
+
+#: ../src/common/docview.cpp:1925
+msgid "Templates"
+msgstr "Gjedhe"
+
+#: ../src/common/docview.cpp:1998
+msgid "Select a document view"
+msgstr "Përzgjidhni parje dokumenti"
+
+#: ../src/common/docview.cpp:1999
+msgid "Views"
+msgstr "Pamje"
+
+#: ../src/common/dynlib.cpp:81
+#, c-format
+msgid "Failed to load shared library '%s'"
+msgstr "S’u arrit të ngarkohej librari e përbashkët '%s'"
+
+#: ../src/common/dynlib.cpp:105
+#, c-format
+msgid "Couldn't find symbol '%s' in a dynamic library"
+msgstr "S’u gjet dot simbol '%s' në një librari dinamike"
+
+#: ../src/common/ffile.cpp:56 ../src/common/file.cpp:215
+#, c-format
+msgid "can't open file '%s'"
+msgstr "s’hapet dot kartelë '%s'"
+
+#: ../src/common/ffile.cpp:72
+#, c-format
+msgid "can't close file '%s'"
+msgstr "s’mbyllet dot kartela '%s'"
+
+#: ../src/common/ffile.cpp:106 ../src/common/ffile.cpp:131
+#, c-format
+msgid "Read error on file '%s'"
+msgstr "Gabim leximi në kartelën '%s'"
+
+#: ../src/common/ffile.cpp:148
+#, c-format
+msgid "Write error on file '%s'"
+msgstr "Gabim shkrimi në kartelën '%s'"
+
+#: ../src/common/ffile.cpp:182
+#, c-format
+msgid "failed to flush the file '%s'"
+msgstr "s’u arrit të zbrazej kartela '%s'"
+
+#: ../src/common/ffile.cpp:222
+#, c-format
+msgid "Seek error on file '%s' (large files not supported by stdio)"
+msgstr ""
+"Gabim kërkimi te kartela '%s' (kartela të mëdha të pambuluara nga stdio)"
+
+#: ../src/common/ffile.cpp:232
+#, c-format
+msgid "Seek error on file '%s'"
+msgstr "Gabim kërkimi te kartela '%s'"
+
+#: ../src/common/ffile.cpp:248
+#, c-format
+msgid "Can't find current position in file '%s'"
+msgstr "S’gjendet dot pozicioni i tanishëm te kartela '%s'"
+
+#: ../src/common/ffile.cpp:349 ../src/common/file.cpp:569
+msgid "Failed to set temporary file permissions"
+msgstr "S’u arrit të caktoheshin leje kartele të përkohshme"
+
+#: ../src/common/ffile.cpp:371
+#, c-format
+msgid "can't remove file '%s'"
+msgstr "s’hiqet dot kartelë '%s'"
+
+#: ../src/common/ffile.cpp:376 ../src/common/file.cpp:591
+#, c-format
+msgid "can't commit changes to file '%s'"
+msgstr "s’kryhen dot ndryshimet te kartelë '%s'"
+
+#: ../src/common/ffile.cpp:388 ../src/common/file.cpp:603
+#, c-format
+msgid "can't remove temporary file '%s'"
+msgstr "s’hiqet dot kartelë të përkohshme '%s'"
+
+#: ../src/common/file.cpp:162
+#, c-format
+msgid "can't create file '%s'"
+msgstr "s’krijohet dot kartelë '%s'"
+
+#: ../src/common/file.cpp:229
+#, c-format
+msgid "can't close file descriptor %d"
+msgstr "s’mbyllet dot përshkrues kartele %d"
+
+#: ../src/common/file.cpp:332
+#, c-format
+msgid "can't read from file descriptor %d"
+msgstr "s’lexohet dot prej përshkruesi kartele %d"
+
+#: ../src/common/file.cpp:351
+#, c-format
+msgid "can't write to file descriptor %d"
+msgstr "s’shkruhet dot te përshkrues kartele %d"
+
+#: ../src/common/file.cpp:390
+#, c-format
+msgid "can't flush file descriptor %d"
+msgstr "s’zbrazet dot përshkrues kartele %d"
+
+#: ../src/common/file.cpp:432
+#, c-format
+msgid "can't seek on file descriptor %d"
+msgstr "s’shihet dot te përshkrues kartele %d"
+
+#: ../src/common/file.cpp:446
+#, c-format
+msgid "can't get seek position on file descriptor %d"
+msgstr ""
+
+#: ../src/common/file.cpp:475
+#, c-format
+msgid "can't find length of file on file descriptor %d"
+msgstr "s’gjendet dot gjatësi kartele te përshkrues kartele %d"
+
+#: ../src/common/file.cpp:505
+#, c-format
+msgid "can't determine if the end of file is reached on descriptor %d"
+msgstr ""
+"s’përcaktohet dot nëse te përshkruesi %d është mbërritur te fund kartele"
+
+#: ../src/common/fileconf.cpp:352
+#, c-format
+msgid ""
+" and additionally, the existing configuration file was renamed to \"%s\" and "
+"couldn't be renamed back, please rename it to its original path \"%s\""
+msgstr ""
+
+#: ../src/common/fileconf.cpp:389
+#, fuzzy
+msgid " due to the following error:\n"
+msgstr "Dhe përmban kartelat vijuese:\n"
+
+#: ../src/common/fileconf.cpp:412
+#, fuzzy
+msgid "failed to rename the existing file"
+msgstr "S’u arrit të lexohej kartela tekst “%s”."
+
+#: ../src/common/fileconf.cpp:421
+#, fuzzy
+msgid "failed to create the new file directory"
+msgstr "S’u arrit të merrej drejtoria e punës"
+
+#: ../src/common/fileconf.cpp:428
+#, fuzzy
+msgid "failed to move the file to the new location"
+msgstr "S’u arrit të caktohet emulim modern si shkallë për parje web"
+
+#: ../src/common/fileconf.cpp:462
+#, c-format
+msgid "can't open global configuration file '%s'."
+msgstr "s’hapet dot kartelë formësimi të përgjithshëm '%s'."
+
+#: ../src/common/fileconf.cpp:478
+#, c-format
+msgid "can't open user configuration file '%s'."
+msgstr "s’hapet dot kartelë formësimi e përdoruesit '%s'."
+
+#: ../src/common/fileconf.cpp:483
+#, c-format
+msgid "Changes won't be saved to avoid overwriting the existing file \"%s\""
+msgstr ""
+"Ndryshimet s’do të ruhen, për të shmangur mbishkrimin e kartelës ekzistuese "
+"“%s”"
+
+#: ../src/common/fileconf.cpp:583
+msgid "Error reading config options."
+msgstr "Gabim në lexim mundësish formësimi."
+
+#: ../src/common/fileconf.cpp:593
+msgid "Failed to read config options."
+msgstr "S’u arrit të lexoheshin mundësi formësimi."
+
+#: ../src/common/fileconf.cpp:700
+#, c-format
+msgid "file '%s': unexpected character %c at line %zu."
+msgstr "kartela '%s': shenjë e papritur %c te rreshti %zu."
+
+#: ../src/common/fileconf.cpp:736
+#, c-format
+msgid "file '%s', line %zu: '%s' ignored after group header."
+msgstr "kartela '%s', rreshti %zu: '%s' u shpërfill pas kryesh grupi."
+
+#: ../src/common/fileconf.cpp:765
+#, c-format
+msgid "file '%s', line %zu: '=' expected."
+msgstr "kartela '%s', rreshti %zu: pritej '='."
+
+#: ../src/common/fileconf.cpp:778
+#, c-format
+msgid "file '%s', line %zu: value for immutable key '%s' ignored."
+msgstr ""
+"kartela '%s', rreshti %zu: u shpërfill vlerë për kyç të pandryshueshëm '%s'."
+
+#: ../src/common/fileconf.cpp:788
+#, c-format
+msgid "file '%s', line %zu: key '%s' was first found at line %d."
+msgstr "kartela '%s', rreshti %zu: kyçi '%s' u gjet së pari te rreshti %d."
+
+#: ../src/common/fileconf.cpp:1091
+#, c-format
+msgid "Config entry name cannot start with '%c'."
+msgstr "Emër zëri formësimi s’mund të fillojë me '%c'."
+
+#: ../src/common/fileconf.cpp:1146
+#, fuzzy
+msgid "Failed to create configuration file directory."
+msgstr "S’u arrit të krijohej objekt formësimi shkronjash."
+
+#: ../src/common/fileconf.cpp:1158
+msgid "can't open user configuration file."
+msgstr "s’hapet dot kartelë formësimi e përdoruesit."
+
+#: ../src/common/fileconf.cpp:1172
+msgid "can't write user configuration file."
+msgstr "s’shkruhet dot kartelë formësimi e përdoruesit."
+
+#: ../src/common/fileconf.cpp:1178
+msgid "Failed to update user configuration file."
+msgstr "S’u arrit të përditësohej kartelë përdoruesi për formësimin."
+
+#: ../src/common/fileconf.cpp:1201
+msgid "Error saving user configuration data."
+msgstr "Gabim në ruajtje të dhënash formësimi të përdoruesit."
+
+#: ../src/common/fileconf.cpp:1313
+#, c-format
+msgid "can't delete user configuration file '%s'"
+msgstr "s’fshihet dot kartelë formësimi e përdoruesit '%s'"
+
+#: ../src/common/fileconf.cpp:2007
+#, c-format
+msgid "entry '%s' appears more than once in group '%s'"
+msgstr "zëri '%s' duket në më shumë se një grup '%s'"
+
+#: ../src/common/fileconf.cpp:2021
+#, c-format
+msgid "attempt to change immutable key '%s' ignored."
+msgstr "u shpërfill përpjekja për ndryshim kyçi të pandryshueshëm '%s'."
+
+#: ../src/common/fileconf.cpp:2118
+#, c-format
+msgid "trailing backslash ignored in '%s'"
+msgstr "u shpërfill pjerrake së prapthi në fund te '%s'"
+
+#: ../src/common/fileconf.cpp:2153
+#, c-format
+msgid "unexpected \" at position %d in '%s'."
+msgstr "\" të papritura në pozicionin %d te '%s'."
+
+#: ../src/common/filefn.cpp:474
+#, c-format
+msgid "Failed to copy the file '%s' to '%s'"
+msgstr "S’u arrit të kopjohej kartela '%s' te '%s'"
+
+#: ../src/common/filefn.cpp:487
+#, c-format
+msgid "Impossible to get permissions for file '%s'"
+msgstr "E pamundur të kihen leje për kartelë '%s'"
+
+#: ../src/common/filefn.cpp:501
+#, c-format
+msgid "Impossible to overwrite the file '%s'"
+msgstr "E pamundur të mbishkruhet kartela '%s'"
+
+#: ../src/common/filefn.cpp:508
+#, c-format
+msgid "Error copying the file '%s' to '%s'."
+msgstr "Gabim në kopjimin e kartelës '%s' te '%s'."
+
+#: ../src/common/filefn.cpp:556
+#, c-format
+msgid "Impossible to set permissions for the file '%s'"
+msgstr "E pamundur të caktohen leje për kartelën '%s'"
+
+#: ../src/common/filefn.cpp:606
+#, c-format
+msgid ""
+"Failed to rename the file '%s' to '%s' because the destination file already "
+"exists."
+msgstr ""
+"S’u arrit të riemërtohej kartela '%s' si '%s', ngaqë kartela vendmbërritje "
+"ekziston tashmë."
+
+#: ../src/common/filefn.cpp:623
+#, c-format
+msgid "File '%s' couldn't be renamed '%s'"
+msgstr "Kartela '%s' s’u riemërtua dot si '%s'"
+
+#: ../src/common/filefn.cpp:639
+#, c-format
+msgid "File '%s' couldn't be removed"
+msgstr "S’u hoq dot kartela '%s'"
+
+#: ../src/common/filefn.cpp:666
+#, c-format
+msgid "Directory '%s' couldn't be created"
+msgstr "S’u krjiua dot drejtoria '%s'"
+
+#: ../src/common/filefn.cpp:680
+#, c-format
+msgid "Directory '%s' couldn't be deleted"
+msgstr "S’u fshi dot drejtoria '%s'"
+
+#: ../src/common/filefn.cpp:714
+#, c-format
+msgid "Cannot enumerate files '%s'"
+msgstr "S’numërtohen dot kartela '%s'"
+
+#: ../src/common/filefn.cpp:798
+msgid "Failed to get the working directory"
+msgstr "S’u arrit të merrej drejtoria e punës"
+
+#: ../src/common/filefn.cpp:843
+msgid "Could not set current working directory"
+msgstr "S’u caktua dot drejtori e tanishme e punës"
+
+#: ../src/common/filefn.cpp:974
+#, c-format
+msgid "Files (%s)"
+msgstr "Kartela (%s)"
+
+#: ../src/common/filename.cpp:182
+#, c-format
+msgid "Failed to open '%s' for reading"
+msgstr "S’u arrit të hapej '%s' për lexim"
+
+#: ../src/common/filename.cpp:187
+#, c-format
+msgid "Failed to open '%s' for writing"
+msgstr "S’u arrit të hapej '%s' për shkrim"
+
+#: ../src/common/filename.cpp:199
+msgid "Failed to close file handle"
+msgstr "S’u arrit të mbyllej trajtues kartele"
+
+#: ../src/common/filename.cpp:1046
+msgid "Failed to create a temporary file name"
+msgstr "S’u arrit të krijohej emër kartele të përkohshme"
+
+#: ../src/common/filename.cpp:1081
+msgid "Failed to open temporary file."
+msgstr "S’u arrit të hapej kartelë e përkohshme."
+
+#: ../src/common/filename.cpp:2862
+#, c-format
+msgid "Failed to modify file times for '%s'"
+msgstr "S’u arrit të ndryshoheshin kohë kartele për '%s'"
+
+#: ../src/common/filename.cpp:2877
+#, c-format
+msgid "Failed to touch the file '%s'"
+msgstr "S’u arrit të kryhej “touch” për kartelën '%s'"
+
+#: ../src/common/filename.cpp:2958
+#, c-format
+msgid "Failed to retrieve file times for '%s'"
+msgstr "S’u arrit të merreshin kohë kartele për '%s'"
+
+#: ../src/common/filepickercmn.cpp:39 ../src/common/filepickercmn.cpp:40
+msgid "Browse"
+msgstr "Shfletoni"
+
+#: ../src/common/fldlgcmn.cpp:792 ../src/generic/filectrlg.cpp:1185
+#, c-format
+msgid "All files (%s)|%s"
+msgstr "Krejt kartelat (%s)|%s"
+
+#. TRANSLATORS: %s are a file extension used to build a file wildcard string
+#: ../src/common/fldlgcmn.cpp:810
+#, c-format
+msgid "%s files (%s)|%s"
+msgstr "%s kartela (%s)|%s"
+
+#: ../src/common/fldlgcmn.cpp:1072
+#, c-format
+msgid "Load %s file"
+msgstr "Ngarko kartelë %s"
+
+#: ../src/common/fldlgcmn.cpp:1074
+#, c-format
+msgid "Save %s file"
+msgstr "Ruaje kartelën %s"
+
+#: ../src/common/fmapbase.cpp:144
+msgid "Western European (ISO-8859-1)"
+msgstr "Europiane Perëndimore (ISO-8859-1)"
+
+#: ../src/common/fmapbase.cpp:145
+msgid "Central European (ISO-8859-2)"
+msgstr "Europiane Qendrore (ISO-8859-2)"
+
+#: ../src/common/fmapbase.cpp:146
+msgid "Esperanto (ISO-8859-3)"
+msgstr "Esperanto (ISO-8859-3)"
+
+#: ../src/common/fmapbase.cpp:147
+msgid "Baltic (old) (ISO-8859-4)"
+msgstr "Baltike (të vjetra) (ISO-8859-4)"
+
+#: ../src/common/fmapbase.cpp:148
+msgid "Cyrillic (ISO-8859-5)"
+msgstr "Cirilike, (ISO-8859-5)"
+
+#: ../src/common/fmapbase.cpp:149
+msgid "Arabic (ISO-8859-6)"
+msgstr "Arabe (ISO-8859-6)"
+
+#: ../src/common/fmapbase.cpp:150
+msgid "Greek (ISO-8859-7)"
+msgstr "Greke (ISO-8859-7)"
+
+#: ../src/common/fmapbase.cpp:151
+msgid "Hebrew (ISO-8859-8)"
+msgstr "Hebraishte, (ISO-8859-8)"
+
+#: ../src/common/fmapbase.cpp:152
+msgid "Turkish (ISO-8859-9)"
+msgstr "Turke (ISO-8859-9)"
+
+#: ../src/common/fmapbase.cpp:153
+msgid "Nordic (ISO-8859-10)"
+msgstr "Nordike (ISO-8859-10)"
+
+#: ../src/common/fmapbase.cpp:154
+msgid "Thai (ISO-8859-11)"
+msgstr "Tai (ISO-8859-11)"
+
+#: ../src/common/fmapbase.cpp:155
+msgid "Indian (ISO-8859-12)"
+msgstr "Indiane (ISO-8859-12)"
+
+#: ../src/common/fmapbase.cpp:156
+msgid "Baltic (ISO-8859-13)"
+msgstr "Baltike (ISO-8859-13)"
+
+#: ../src/common/fmapbase.cpp:157
+msgid "Celtic (ISO-8859-14)"
+msgstr "Kelte (ISO-8859-14)"
+
+#: ../src/common/fmapbase.cpp:158
+msgid "Western European with Euro (ISO-8859-15)"
+msgstr "Europiane Perëndimore me Euro (ISO-8859-15)"
+
+#: ../src/common/fmapbase.cpp:159
+msgid "KOI8-R"
+msgstr "KOI8-R"
+
+#: ../src/common/fmapbase.cpp:160
+msgid "KOI8-U"
+msgstr "KOI8-U"
+
+#: ../src/common/fmapbase.cpp:161
+msgid "Windows/DOS OEM Cyrillic (CP 866)"
+msgstr "Cirilike Windows/DOS OEM (CP 866)"
+
+#: ../src/common/fmapbase.cpp:162
+msgid "Windows Thai (CP 874)"
+msgstr "Tajlandeze Windows (CP 874)"
+
+#: ../src/common/fmapbase.cpp:163
+msgid "Windows Japanese (CP 932) or Shift-JIS"
+msgstr "Japoneze Windows (CP 932) ose Shift-JIS"
+
+#: ../src/common/fmapbase.cpp:164
+msgid "Windows Chinese Simplified (CP 936) or GB-2312"
+msgstr "Kineze e Thjeshtuar, Windows (CP 936) ose GB-2312"
+
+#: ../src/common/fmapbase.cpp:165
+msgid "Windows Korean (CP 949)"
+msgstr "Koreane Windows (CP 949)"
+
+#: ../src/common/fmapbase.cpp:166
+msgid "Windows Chinese Traditional (CP 950) or Big-5"
+msgstr "Kineze Tradicionale, Windows (CP 950) ose Big-5"
+
+#: ../src/common/fmapbase.cpp:167
+msgid "Windows Central European (CP 1250)"
+msgstr "Europiane Qendrore Windows (CP 1250)"
+
+#: ../src/common/fmapbase.cpp:168
+msgid "Windows Cyrillic (CP 1251)"
+msgstr "Cirilike Windows (CP 1251)"
+
+#: ../src/common/fmapbase.cpp:169
+msgid "Windows Western European (CP 1252)"
+msgstr "Europiane Qendrore Windows (CP 1252)"
+
+#: ../src/common/fmapbase.cpp:170
+msgid "Windows Greek (CP 1253)"
+msgstr "Greke Windows (CP 1253)"
+
+#: ../src/common/fmapbase.cpp:171
+msgid "Windows Turkish (CP 1254)"
+msgstr "Turke Windows (CP 1254)"
+
+#: ../src/common/fmapbase.cpp:172
+msgid "Windows Hebrew (CP 1255)"
+msgstr "Hebraishte Windows (CP 1255)"
+
+#: ../src/common/fmapbase.cpp:173
+msgid "Windows Arabic (CP 1256)"
+msgstr "Arabike Windows (CP 1256)"
+
+#: ../src/common/fmapbase.cpp:174
+msgid "Windows Baltic (CP 1257)"
+msgstr "Baltike Windows (CP 1257)"
+
+#: ../src/common/fmapbase.cpp:175
+msgid "Windows Vietnamese (CP 1258)"
+msgstr "Vietnameze Windows (CP 1258)"
+
+#: ../src/common/fmapbase.cpp:176
+msgid "Windows Johab (CP 1361)"
+msgstr "Johab Windows (CP 1361)"
+
+#: ../src/common/fmapbase.cpp:177
+msgid "Windows/DOS OEM (CP 437)"
+msgstr "Windows/DOS OEM (CP 437)"
+
+#: ../src/common/fmapbase.cpp:178
+msgid "Unicode 7 bit (UTF-7)"
+msgstr "Unikod 7 bit (UTF-7)"
+
+#: ../src/common/fmapbase.cpp:179
+msgid "Unicode 8 bit (UTF-8)"
+msgstr "Unikod 8 bit (UTF-8)"
+
+#: ../src/common/fmapbase.cpp:181 ../src/common/fmapbase.cpp:187
+msgid "Unicode 16 bit (UTF-16)"
+msgstr "Unikod 16 bit (UTF-16)"
+
+#: ../src/common/fmapbase.cpp:182
+msgid "Unicode 16 bit Little Endian (UTF-16LE)"
+msgstr "Unikod 16 bit Little Endian (UTF-16LE)"
+
+#: ../src/common/fmapbase.cpp:183 ../src/common/fmapbase.cpp:189
+msgid "Unicode 32 bit (UTF-32)"
+msgstr "Unikod 32 bit (UTF-32)"
+
+#: ../src/common/fmapbase.cpp:184
+msgid "Unicode 32 bit Little Endian (UTF-32LE)"
+msgstr "Unikod 32 bit Little Endian (UTF-32LE)"
+
+#: ../src/common/fmapbase.cpp:186
+msgid "Unicode 16 bit Big Endian (UTF-16BE)"
+msgstr "Unikod 16 bit Big Endian (UTF-16BE)"
+
+#: ../src/common/fmapbase.cpp:188
+msgid "Unicode 32 bit Big Endian (UTF-32BE)"
+msgstr "Unikod 32 bit Big Endian (UTF-32BE)"
+
+#: ../src/common/fmapbase.cpp:191
+msgid "Extended Unix Codepage for Japanese (EUC-JP)"
+msgstr "Kodim i Zgjeruar Unix për Japonishten (EUC-JP)"
+
+#: ../src/common/fmapbase.cpp:192
+msgid "US-ASCII"
+msgstr "US-ASCII"
+
+#: ../src/common/fmapbase.cpp:193
+msgid "ISO-2022-JP"
+msgstr "ISO-2022-JP"
+
+#: ../src/common/fmapbase.cpp:195
+msgid "MacRoman"
+msgstr "MacRoman"
+
+#: ../src/common/fmapbase.cpp:196
+msgid "MacJapanese"
+msgstr "MacJapanese"
+
+#: ../src/common/fmapbase.cpp:197
+msgid "MacChineseTrad"
+msgstr "MacChineseTrad"
+
+#: ../src/common/fmapbase.cpp:198
+msgid "MacKorean"
+msgstr "MacKorean"
+
+#: ../src/common/fmapbase.cpp:199
+msgid "MacArabic"
+msgstr "MacArabic"
+
+#: ../src/common/fmapbase.cpp:200
+msgid "MacHebrew"
+msgstr "MacHebrew"
+
+#: ../src/common/fmapbase.cpp:201
+msgid "MacGreek"
+msgstr "MacGreek"
+
+#: ../src/common/fmapbase.cpp:202
+msgid "MacCyrillic"
+msgstr "MacCyrillic"
+
+#: ../src/common/fmapbase.cpp:203
+msgid "MacDevanagari"
+msgstr "MacDevanagari"
+
+#: ../src/common/fmapbase.cpp:204
+msgid "MacGurmukhi"
+msgstr "MacGurmukhi"
+
+#: ../src/common/fmapbase.cpp:205
+msgid "MacGujarati"
+msgstr "MacGujarati"
+
+#: ../src/common/fmapbase.cpp:206
+msgid "MacOriya"
+msgstr "MacOriya"
+
+#: ../src/common/fmapbase.cpp:207
+msgid "MacBengali"
+msgstr "MacBengali"
+
+#: ../src/common/fmapbase.cpp:208
+msgid "MacTamil"
+msgstr "MacTamil"
+
+#: ../src/common/fmapbase.cpp:209
+msgid "MacTelugu"
+msgstr "MacTelugu"
+
+#: ../src/common/fmapbase.cpp:210
+msgid "MacKannada"
+msgstr "MacKannada"
+
+#: ../src/common/fmapbase.cpp:211
+msgid "MacMalayalam"
+msgstr "MacMalayalam"
+
+#: ../src/common/fmapbase.cpp:212
+msgid "MacSinhalese"
+msgstr "MacSinhalese"
+
+#: ../src/common/fmapbase.cpp:213
+msgid "MacBurmese"
+msgstr "MacBurmese"
+
+#: ../src/common/fmapbase.cpp:214
+msgid "MacKhmer"
+msgstr "MacKhmer"
+
+#: ../src/common/fmapbase.cpp:215
+msgid "MacThai"
+msgstr "MacThai"
+
+#: ../src/common/fmapbase.cpp:216
+msgid "MacLaotian"
+msgstr "MacLaotian"
+
+#: ../src/common/fmapbase.cpp:217
+msgid "MacGeorgian"
+msgstr "MacGeorgian"
+
+#: ../src/common/fmapbase.cpp:218
+msgid "MacArmenian"
+msgstr "MacArmenian"
+
+#: ../src/common/fmapbase.cpp:219
+msgid "MacChineseSimp"
+msgstr "MacChineseSimp"
+
+#: ../src/common/fmapbase.cpp:220
+msgid "MacTibetan"
+msgstr "MacTibetan"
+
+#: ../src/common/fmapbase.cpp:221
+msgid "MacMongolian"
+msgstr "MacMongolian"
+
+#: ../src/common/fmapbase.cpp:222
+msgid "MacEthiopic"
+msgstr "MacEthiopic"
+
+#: ../src/common/fmapbase.cpp:223
+msgid "MacCentralEurRoman"
+msgstr "MacCentralEurRoman"
+
+#: ../src/common/fmapbase.cpp:224
+msgid "MacVietnamese"
+msgstr "MacVietnamese"
+
+#: ../src/common/fmapbase.cpp:225
+msgid "MacExtArabic"
+msgstr "MacExtArabic"
+
+#: ../src/common/fmapbase.cpp:226
+msgid "MacSymbol"
+msgstr "MacSymbol"
+
+#: ../src/common/fmapbase.cpp:227
+msgid "MacDingbats"
+msgstr "MacDingbats"
+
+#: ../src/common/fmapbase.cpp:228
+msgid "MacTurkish"
+msgstr "MacTurkish"
+
+#: ../src/common/fmapbase.cpp:229
+msgid "MacCroatian"
+msgstr "MacCroatian"
+
+#: ../src/common/fmapbase.cpp:230
+msgid "MacIcelandic"
+msgstr "MacIcelandic"
+
+#: ../src/common/fmapbase.cpp:231
+msgid "MacRomanian"
+msgstr "MacRomanian"
+
+#: ../src/common/fmapbase.cpp:232
+msgid "MacCeltic"
+msgstr "MacCeltic"
+
+#: ../src/common/fmapbase.cpp:233
+msgid "MacGaelic"
+msgstr "MacGaelic"
+
+#: ../src/common/fmapbase.cpp:234
+msgid "MacKeyboardGlyphs"
+msgstr "MacKeyboardGlyphs"
+
+#: ../src/common/fmapbase.cpp:791
+msgid "Default encoding"
+msgstr "Kodim parazgjedhje"
+
+#: ../src/common/fmapbase.cpp:805
+#, c-format
+msgid "Unknown encoding (%d)"
+msgstr "Kodim i panjohur (%d)"
+
+#: ../src/common/fmapbase.cpp:815 ../src/richtext/richtextstyles.cpp:776
+msgid "default"
+msgstr "parazgjedhje"
+
+#: ../src/common/fmapbase.cpp:829
+#, c-format
+msgid "unknown-%d"
+msgstr "i/e panjohur-%d"
+
+#: ../src/common/fontcmn.cpp:924 ../src/common/fontcmn.cpp:1130
+msgid "underlined"
+msgstr "nënvijëzuar"
+
+#: ../src/common/fontcmn.cpp:929
+msgid " strikethrough"
+msgstr " hequrvije"
+
+#: ../src/common/fontcmn.cpp:942
+msgid " thin"
+msgstr " të holla"
+
+#: ../src/common/fontcmn.cpp:946
+msgid " extra light"
+msgstr " tejet të holla"
+
+#: ../src/common/fontcmn.cpp:950
+msgid " light"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:954
+msgid " medium"
+msgstr " mesatare"
+
+#: ../src/common/fontcmn.cpp:958
+msgid " semi bold"
+msgstr " gjysmë të trasha"
+
+#: ../src/common/fontcmn.cpp:962
+msgid " bold"
+msgstr " të trasha"
+
+#: ../src/common/fontcmn.cpp:966
+msgid " extra bold"
+msgstr " tejet të trasha"
+
+#: ../src/common/fontcmn.cpp:970
+msgid " heavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:974
+msgid " extra heavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:990
+msgid " italic"
+msgstr " të pjerrëta"
+
+#: ../src/common/fontcmn.cpp:1134
+msgid "strikethrough"
+msgstr "hequrvije"
+
+#: ../src/common/fontcmn.cpp:1143
+msgid "thin"
+msgstr "të holla"
+
+#: ../src/common/fontcmn.cpp:1156
+msgid "extralight"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1161
+msgid "light"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1169 ../src/richtext/richtextstyles.cpp:775
+msgid "normal"
+msgstr "normale"
+
+#: ../src/common/fontcmn.cpp:1174
+msgid "medium"
+msgstr "mesatare"
+
+#: ../src/common/fontcmn.cpp:1179 ../src/common/fontcmn.cpp:1199
+msgid "semibold"
+msgstr "gjysmë të trasha"
+
+#: ../src/common/fontcmn.cpp:1184
+msgid "bold"
+msgstr "të trasha"
+
+#: ../src/common/fontcmn.cpp:1194
+msgid "extrabold"
+msgstr "tejet të trasha"
+
+#: ../src/common/fontcmn.cpp:1204
+msgid "heavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1212
+msgid "extraheavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1217
+msgid "italic"
+msgstr "të pjerrta"
+
+#: ../src/common/fontmap.cpp:195
+msgid ": unknown charset"
+msgstr ": shkronja të panjohura"
+
+#: ../src/common/fontmap.cpp:199
+#, c-format
+msgid ""
+"The charset '%s' is unknown. You may select\n"
+"another charset to replace it with or choose\n"
+"[Cancel] if it cannot be replaced"
+msgstr ""
+"Shkronjat '%s' janë të panjohura. Mund të përzgjidhni\n"
+"të tjera për zëvendësim ose zgjidhni\n"
+"[Anuloje], nëse s’mund të zëvendësohen"
+
+#: ../src/common/fontmap.cpp:241
+#, c-format
+msgid "Failed to remember the encoding for the charset '%s'."
+msgstr "S’u arrit të mbahej mend kodimi për shkronjat '%s'."
+
+#: ../src/common/fontmap.cpp:321
+msgid "can't load any font, aborting"
+msgstr "s’ngarkohet dot ndonjë shkronjë, po ndërpritet"
+
+#: ../src/common/fontmap.cpp:409
+msgid ": unknown encoding"
+msgstr ": kodim i panjohur"
+
+#: ../src/common/fontmap.cpp:417
+#, c-format
+msgid ""
+"No font for displaying text in encoding '%s' found,\n"
+"but an alternative encoding '%s' is available.\n"
+"Do you want to use this encoding (otherwise you will have to choose another "
+"one)?"
+msgstr ""
+"S’u gjetën shkronja për shfaqje teksti me kodim '%s',\n"
+"por është i passhëm një kodim alternativ '%s'.\n"
+"Doni të përdoret ky kodim (përndryshe do t’ju duhet të zgjidhni një tjetër)?"
+
+#: ../src/common/fontmap.cpp:422
+#, c-format
+msgid ""
+"No font for displaying text in encoding '%s' found.\n"
+"Would you like to select a font to be used for this encoding\n"
+"(otherwise the text in this encoding will not be shown correctly)?"
+msgstr ""
+"S’u gjetën shkronja për shfaqje teksti me kodim '%s',\n"
+"Do të donit të përzgjidhni një palë shkronja për t’u përdorur për këtë "
+"kodim\n"
+"(përndryshe teksti me këtë kodim s’do të shfaqet si duhet)?"
+
+#: ../src/common/fs_mem.cpp:169
+#, c-format
+msgid "Memory VFS already contains file '%s'!"
+msgstr "Kujtesa VFS përmban tashmë një kartelë '%s'!"
+
+#: ../src/common/fs_mem.cpp:232
+#, c-format
+msgid "Trying to remove file '%s' from memory VFS, but it is not loaded!"
+msgstr ""
+"Po provohet të hiqet kartela '%s' prej kujtese VFS, por s’është e ngarkuar!"
+
+#: ../src/common/fs_mem.cpp:262
+#, c-format
+msgid "Failed to store image '%s' to memory VFS!"
+msgstr "S’u arrit të depozitohej figura '%s' te kujtesë VFS!"
+
+#: ../src/common/ftp.cpp:197
+msgid "Timeout while waiting for FTP server to connect, try passive mode."
+msgstr ""
+"Skadim kohe teksa pritej që shërbyesi FTP të lidhej, provoni mënyrë pasive."
+
+#: ../src/common/ftp.cpp:399
+#, c-format
+msgid "Failed to set FTP transfer mode to %s."
+msgstr "S’u arrit të caktohej mënyrë shpërnguljesh FTP si %s."
+
+#: ../src/common/ftp.cpp:400 ../src/richtext/richtextsymboldlg.cpp:432
+msgid "ASCII"
+msgstr "ASCII"
+
+#: ../src/common/ftp.cpp:400
+msgid "binary"
+msgstr "dyore"
+
+#: ../src/common/ftp.cpp:608
+msgid "The FTP server doesn't support the PORT command."
+msgstr "Shërbyesi FTP s’mbulon urdhrin PORT."
+
+#: ../src/common/ftp.cpp:622
+msgid "The FTP server doesn't support passive mode."
+msgstr "Shërbyesi FTP s’mbulon mënyrë pasive."
+
+#: ../src/common/gifdecod.cpp:822
+#, c-format
+msgid "Incorrect GIF frame size (%u, %d) for the frame #%u"
+msgstr "Madhësi e pasaktë kuadri GIF (%u, %d) për kuadrin #%u"
+
+#: ../src/common/glcmn.cpp:108
+msgid "Failed to allocate colour for OpenGL"
+msgstr "S’u arrit të jepej ngjyrë për OpeGL"
+
+#: ../src/common/headerctrlcmn.cpp:57
+msgid "Please select the columns to show and define their order:"
+msgstr ""
+"Ju lutemi, përzgjidhni shtyllat për shfaqje dhe përcaktoni renditjen e tyre:"
+
+#: ../src/common/headerctrlcmn.cpp:58
+msgid "Customize Columns"
+msgstr "Përshtatni Shtylla"
+
+#: ../src/common/headerctrlcmn.cpp:304
+msgid "&Customize..."
+msgstr "&Përshtateni…"
+
+#: ../src/common/hyperlnkcmn.cpp:132
+#, c-format
+msgid "Failed to open URL \"%s\" in the default browser"
+msgstr "S’u arrit të hapej URL-ja “%s” në shfletuesin parazgjedhje"
+
+#: ../src/common/iconbndl.cpp:195
+#, c-format
+msgid "Failed to load image %%d from file '%s'."
+msgstr "S’u arrit të ngarkohej figurë %%d prej kartelës “%s”."
+
+#: ../src/common/iconbndl.cpp:203
+#, c-format
+msgid "Failed to load image %d from stream."
+msgstr "S’u arrit të ngarkohej figurë %d prej rrjedhe."
+
+#: ../src/common/iconbndl.cpp:221
+#, c-format
+msgid "Failed to load icons from resource '%s'."
+msgstr "S’u arrit të shtoheshin ikona prej burimi '%s'."
+
+#: ../src/common/imagbmp.cpp:97
+msgid "BMP: Couldn't save invalid image."
+msgstr "BMP: S’u ruajt dot figurë e pavlefshme."
+
+#: ../src/common/imagbmp.cpp:137
+msgid "BMP: wxImage doesn't have own wxPalette."
+msgstr "BMP: wxImage s’ka wxPalette të vetën."
+
+#: ../src/common/imagbmp.cpp:243
+msgid "BMP: Couldn't write the file (Bitmap) header."
+msgstr "BMP: S’u shkrua dot krye kartele (Bitmap)."
+
+#: ../src/common/imagbmp.cpp:266
+msgid "BMP: Couldn't write the file (BitmapInfo) header."
+msgstr "BMP: S’u shkrua dot krye kartele (BitmapInfo)."
+
+#: ../src/common/imagbmp.cpp:353
+msgid "BMP: Couldn't write RGB color map."
+msgstr "BMP: S’u shkrua dot hartë ngjyrash RGB."
+
+#: ../src/common/imagbmp.cpp:487
+msgid "BMP: Couldn't write data."
+msgstr "BMP: S’u shkruan dot të dhëna."
+
+#: ../src/common/imagbmp.cpp:561 ../src/common/imagbmp.cpp:642
+msgid "BMP: Couldn't allocate memory."
+msgstr "BMP: S’u sigurua dot kujtesë."
+
+#: ../src/common/imagbmp.cpp:1041
+msgid "DIB Header: Image width > 32767 pixels for file."
+msgstr "Krye DIB: Gjerësi figure > 32767 piksel për kartelë."
+
+#: ../src/common/imagbmp.cpp:1049
+msgid "DIB Header: Image height > 32767 pixels for file."
+msgstr "Krye DIB: Lartësi figure > 32767 piksel për kartelë."
+
+#: ../src/common/imagbmp.cpp:1081
+msgid "DIB Header: Unknown bitdepth in file."
+msgstr "Krye DIB: “Bitdepth” i panjohur në kartelë."
+
+#: ../src/common/imagbmp.cpp:1156
+msgid "DIB Header: Unknown encoding in file."
+msgstr "Krye DIB: Kodim i panjohur në kartelë."
+
+#: ../src/common/imagbmp.cpp:1165
+msgid "DIB Header: Encoding doesn't match bitdepth."
+msgstr "Krye DIB: Kodimi s’përputhet me “bitdepth”."
+
+#: ../src/common/imagbmp.cpp:1180
+#, c-format
+msgid "BMP Header: Invalid number of colors (%d)."
+msgstr ""
+
+#: ../src/common/imagbmp.cpp:1273
+msgid "Error in reading image DIB."
+msgstr "Gabim në lexim DIB figure."
+
+#: ../src/common/imagbmp.cpp:1294
+msgid "ICO: Error in reading mask DIB."
+msgstr "ICO: Gabim në lexim maske DIB."
+
+#: ../src/common/imagbmp.cpp:1353
+msgid "ICO: Image too tall for an icon."
+msgstr "ICO: Figurë shumë e lartë për ikonë."
+
+#: ../src/common/imagbmp.cpp:1361
+msgid "ICO: Image too wide for an icon."
+msgstr "ICO: Figurë shumë e gjerë për ikonë."
+
+#: ../src/common/imagbmp.cpp:1388 ../src/common/imagbmp.cpp:1488
+#: ../src/common/imagbmp.cpp:1503 ../src/common/imagbmp.cpp:1514
+#: ../src/common/imagbmp.cpp:1528 ../src/common/imagbmp.cpp:1576
+#: ../src/common/imagbmp.cpp:1591 ../src/common/imagbmp.cpp:1605
+#: ../src/common/imagbmp.cpp:1616
+msgid "ICO: Error writing the image file!"
+msgstr "ICO: Gabim gjatë shkrimit të kartelës figurë!"
+
+#: ../src/common/imagbmp.cpp:1701
+msgid "ICO: Invalid icon index."
+msgstr "ICO: tregues i pavlefshëm ikone."
+
+#: ../src/common/image.cpp:2410
+msgid "Image and mask have different sizes."
+msgstr "Figura dhe maska kanë madhësi të ndryshme."
+
+#: ../src/common/image.cpp:2418 ../src/common/image.cpp:2459
+msgid "No unused colour in image being masked."
+msgstr "Pa maskim ngjyre të papërdorur në figurë."
+
+#: ../src/common/image.cpp:2641
+#, c-format
+msgid "Failed to load bitmap \"%s\" from resources."
+msgstr "S’u arrit të ngarkohej bitmap “%s” prej burimesh."
+
+#: ../src/common/image.cpp:2650
+#, c-format
+msgid "Failed to load icon \"%s\" from resources."
+msgstr "S’u arrit të ngarkohej ikonë “%s” prej burimesh."
+
+#: ../src/common/image.cpp:2728 ../src/common/image.cpp:2747
+#, c-format
+msgid "Failed to load image from file \"%s\"."
+msgstr "S’u arrit të ngarkohej figurë prej kartelës “%s”."
+
+#: ../src/common/image.cpp:2761
+#, c-format
+msgid "Can't save image to file '%s': unknown extension."
+msgstr "S’ruhet dot figurë te kartela '%s': zgjatim i panjohur."
+
+#: ../src/common/image.cpp:2869
+msgid "No handler found for image type."
+msgstr "S’u gjet trajtues për llojin e figurave."
+
+#: ../src/common/image.cpp:2877 ../src/common/image.cpp:3000
+#: ../src/common/image.cpp:3066
+#, c-format
+msgid "No image handler for type %d defined."
+msgstr "S’është përcaktuar trajtues figurash për llojin %d."
+
+#: ../src/common/image.cpp:2887
+#, c-format
+msgid "Image file is not of type %d."
+msgstr "Kartela figurë s’është e llojit %d."
+
+#: ../src/common/image.cpp:2970
+msgid "Can't automatically determine the image format for non-seekable input."
+msgstr ""
+"Formati i figurës s’përcaktohet dot automatikisht prej input-i te i cili "
+"s’kërkohet dot."
+
+#: ../src/common/image.cpp:2988
+msgid "Unknown image data format."
+msgstr "Format i panjohur të dhënash figure."
+
+#: ../src/common/image.cpp:3009
+#, c-format
+msgid "This is not a %s."
+msgstr "Kjo s’është %s."
+
+#: ../src/common/image.cpp:3032 ../src/common/image.cpp:3080
+#, c-format
+msgid "No image handler for type %s defined."
+msgstr "S’është përcaktuar trajtues figurash për llojin %s."
+
+#: ../src/common/image.cpp:3041
+#, c-format
+msgid "Image is not of type %s."
+msgstr "Figura s’është e llojit %s."
+
+#: ../src/common/image.cpp:3509
+#, c-format
+msgid "Failed to check format of image file \"%s\"."
+msgstr "S’u arrit të kontrollohej format kartele figurash “%s”."
+
+#: ../src/common/imaggif.cpp:124
+msgid "GIF: error in GIF image format."
+msgstr "GIF: gabim në format figurash GIF."
+
+#: ../src/common/imaggif.cpp:129
+msgid "GIF: not enough memory."
+msgstr "GIF: kujtesë e pamjaftueshme."
+
+#: ../src/common/imaggif.cpp:134
+msgid "GIF: data stream seems to be truncated."
+msgstr "GIF: rrjedha e të dhënave duket se është e cunguar."
+
+#: ../src/common/imaggif.cpp:240
+msgid "Couldn't initialize GIF hash table."
+msgstr "S’u gatit dot tabelë hashesh GIF-i."
+
+#: ../src/common/imagiff.cpp:739
+msgid "IFF: error in IFF image format."
+msgstr "IFF: gabim në format figurash IFF."
+
+#: ../src/common/imagiff.cpp:742
+msgid "IFF: not enough memory."
+msgstr "IFF: kujtesë e pamjaftueshme."
+
+#: ../src/common/imagiff.cpp:745
+msgid "IFF: unknown error!!!"
+msgstr "IFF: gabim i panjohur!!!"
+
+#: ../src/common/imagiff.cpp:755
+msgid "IFF: data stream seems to be truncated."
+msgstr "IFF: rrjedhë të dhënash që duket të jetë e cunguar."
+
+#: ../src/common/imagjpeg.cpp:258
+msgid "JPEG: Couldn't load - file is probably corrupted."
+msgstr "JPEG: S’u ngarkua dot - mundet që kartela të jetë e dëmtuar."
+
+#: ../src/common/imagjpeg.cpp:437
+msgid "JPEG: Couldn't save image."
+msgstr "JPEG: S’u ruajt dot figura."
+
+#: ../src/common/imagpcx.cpp:439
+msgid "PCX: this is not a PCX file."
+msgstr "PCX: kjo s’është kartelë PCX."
+
+#: ../src/common/imagpcx.cpp:453
+msgid "PCX: image format unsupported"
+msgstr "PCX: format i pambuluar figurash"
+
+#: ../src/common/imagpcx.cpp:454 ../src/common/imagpcx.cpp:477
+msgid "PCX: couldn't allocate memory"
+msgstr "PCX: s’u sigurua dot kujtesë"
+
+#: ../src/common/imagpcx.cpp:455
+msgid "PCX: version number too low"
+msgstr "PCX: numër versioni shumë i vogël"
+
+#: ../src/common/imagpcx.cpp:456 ../src/common/imagpcx.cpp:478
+msgid "PCX: unknown error !!!"
+msgstr "PCX: gabim i panjohur!!!"
+
+#: ../src/common/imagpcx.cpp:476
+msgid "PCX: invalid image"
+msgstr "PCX: figurë e pavlefshme"
+
+#: ../src/common/imagpng.cpp:385
+#, c-format
+msgid "Unknown PNG resolution unit %d"
+msgstr "Njësi e panjohur qartësie PNG %d"
+
+#: ../src/common/imagpng.cpp:439
+msgid "Couldn't load a PNG image - file is corrupted or not enough memory."
+msgstr ""
+"S’u ngarkua dot figurë PNG - kartela është e dëmtuar ose kujtesë e "
+"pamjaftueshme."
+
+#: ../src/common/imagpng.cpp:513 ../src/common/imagpng.cpp:524
+#: ../src/common/imagpng.cpp:534
+msgid "Couldn't save PNG image."
+msgstr "S’u ruajt dot figurë PNG."
+
+#: ../src/common/imagpnm.cpp:71
+msgid "PNM: File format is not recognized."
+msgstr "PNM: Format kartele i papranuar."
+
+#: ../src/common/imagpnm.cpp:89
+msgid "PNM: Couldn't allocate memory."
+msgstr "PNM: S’u sigurua dot kujtesë."
+
+#: ../src/common/imagpnm.cpp:111 ../src/common/imagpnm.cpp:134
+#: ../src/common/imagpnm.cpp:156
+msgid "PNM: File seems truncated."
+msgstr "PNM: Kartela duket si e cunguar."
+
+#: ../src/common/imagtiff.cpp:69
+#, c-format
+msgid " (in module \"%s\")"
+msgstr " (në modulin “%s”)"
+
+#: ../src/common/imagtiff.cpp:304
+msgid "TIFF: Error loading image."
+msgstr "TIFF: Gabim në ngarkim figure."
+
+#: ../src/common/imagtiff.cpp:314
+msgid "Invalid TIFF image index."
+msgstr "Tregues i pavlefshëm figurash TIFF."
+
+#: ../src/common/imagtiff.cpp:358
+msgid "TIFF: Image size is abnormally big."
+msgstr "TIFF: Madhësia e figurës është në mënyrë anormale e madhe."
+
+#: ../src/common/imagtiff.cpp:372 ../src/common/imagtiff.cpp:385
+#: ../src/common/imagtiff.cpp:769
+msgid "TIFF: Couldn't allocate memory."
+msgstr "TIFF: S’u sigurua dot kujtesë."
+
+#: ../src/common/imagtiff.cpp:471
+msgid "TIFF: Error reading image."
+msgstr "TIFF: Gabim në lexim figure."
+
+#: ../src/common/imagtiff.cpp:532
+#, c-format
+msgid "Unknown TIFF resolution unit %d ignored"
+msgstr "U shpërfill njësi e panjohur qartësie TIFF %d"
+
+#: ../src/common/imagtiff.cpp:611
+msgid "TIFF: Error saving image."
+msgstr "TIFF: Gabim në ruajtje figure."
+
+#: ../src/common/imagtiff.cpp:868
+msgid "TIFF: Error writing image."
+msgstr "TIFF: Gabim në shkrim figure."
+
+#: ../src/common/imagtiff.cpp:881
+#, fuzzy
+msgid "TIFF: Error flushing data."
+msgstr "TIFF: Gabim në ruajtje figure."
+
+#: ../src/common/imagwebp.cpp:56
+msgid "WebP: Invalid data (failed to get features)."
+msgstr ""
+
+#: ../src/common/imagwebp.cpp:65
+msgid "WebP: Allocating image memory failed."
+msgstr ""
+
+#: ../src/common/imagwebp.cpp:82
+msgid "WebP: Decoding RGBA image data failed."
+msgstr ""
+
+#: ../src/common/imagwebp.cpp:98
+msgid "WebP: Decoding RGB image data failed."
+msgstr ""
+
+#: ../src/common/imagwebp.cpp:113 ../src/common/imagwebp.cpp:201
+msgid "WebP: Allocating stream buffer failed."
+msgstr ""
+
+#: ../src/common/imagwebp.cpp:131
+#, fuzzy
+msgid "WebP: Failed to parse container data."
+msgstr "S’u arrit të caktoheshin të dhëna të papastre."
+
+#: ../src/common/imagwebp.cpp:222
+#, fuzzy
+msgid "WebP: Error decoding animation."
+msgstr "Gabim në lexim mundësish formësimi."
+
+#: ../src/common/imagwebp.cpp:240
+msgid "WebP: Error getting next animation frame."
+msgstr ""
+
+#: ../src/common/init.cpp:172
+#, c-format
+msgid ""
+"Command line argument %d couldn't be converted to Unicode and will be "
+"ignored."
+msgstr ""
+"S’u shndërrua dot në Unikod argumenti %d për rresht urdhrash dhe do të "
+"shpërfillet."
+
+#: ../src/common/init.cpp:344
+msgid "Initialization failed in post init, aborting."
+msgstr "Gatitja në post init dështoi, po ndërpritet."
+
+#: ../src/common/intl.cpp:378
+#, c-format
+msgid "Cannot set locale to language \"%s\"."
+msgstr "S’caktohet dot gjuha '%s' si vendore."
+
+#: ../src/common/log.cpp:232
+msgid "Error: "
+msgstr "Gabim: "
+
+#: ../src/common/log.cpp:236
+msgid "Warning: "
+msgstr "Kujdes: "
+
+#: ../src/common/log.cpp:284
+msgid "The previous message repeated once."
+msgstr "Mesazhi i mëparshëm u përsërit një herë."
+
+#: ../src/common/log.cpp:291
+#, c-format
+msgid "The previous message repeated %u time."
+msgid_plural "The previous message repeated %u times."
+msgstr[0] "Mesazhi i mëparshëm u përsërit %u herë."
+msgstr[1] "Mesazhi i mëparshëm u përsërit %u herë."
+
+#: ../src/common/log.cpp:319
+#, c-format
+msgid "Last repeated message (\"%s\", %u time) wasn't output"
+msgid_plural "Last repeated message (\"%s\", %u times) wasn't output"
+msgstr[0] "Mesazhi i fundit i përsëritur (“%s”, %u herë) s’qe output"
+msgstr[1] "Mesazhi i fundit i përsëritur (“%s”, %u herë) s’qe output"
+
+#: ../src/common/log.cpp:435
+#, c-format
+msgid " (error %ld: %s)"
+msgstr " (gabim %ld: %s)"
+
+#: ../src/common/lzmastream.cpp:121
+msgid "Failed to allocate memory for LZMA decompression."
+msgstr "S’u arrit të jepej kujtesë për çngjeshje LZMA."
+
+#: ../src/common/lzmastream.cpp:125
+#, c-format
+msgid "Failed to initialize LZMA decompression: unexpected error %u."
+msgstr "S’u arrit të gatitej çngjeshje LZMA: gabim i papritur %u."
+
+#: ../src/common/lzmastream.cpp:179
+msgid "input is not in XZ format"
+msgstr "ç’u dha s’është në formatin XZ"
+
+#: ../src/common/lzmastream.cpp:183
+msgid "input compressed using unknown XZ option"
+msgstr "ç’u dha u ngjesh duke përdorur mundësinë e panjohur XZ"
+
+#: ../src/common/lzmastream.cpp:188
+msgid "input is corrupted"
+msgstr "ç’u dha është e dëmtuar"
+
+#: ../src/common/lzmastream.cpp:192
+msgid "unknown decompression error"
+msgstr "gabim i panjohur çngjeshjeje"
+
+#: ../src/common/lzmastream.cpp:196
+#, c-format
+msgid "LZMA decompression error: %s"
+msgstr "Gabim çngjeshjeje LZMA: %s"
+
+#: ../src/common/lzmastream.cpp:231
+msgid "Failed to allocate memory for LZMA compression."
+msgstr "S’u arrit të jepej kujtesë për ngjeshje LZMA."
+
+#: ../src/common/lzmastream.cpp:235
+#, c-format
+msgid "Failed to initialize LZMA compression: unexpected error %u."
+msgstr "S’u arrit të gatitej ngjeshje LZMA: gabim i papritur %u."
+
+#: ../src/common/lzmastream.cpp:267 ../src/common/lzmastream.cpp:342
+#: ../src/html/chm.cpp:336
+msgid "out of memory"
+msgstr "kujtesë e pamjaftueshme"
+
+#: ../src/common/lzmastream.cpp:276 ../src/common/lzmastream.cpp:346
+msgid "unknown compression error"
+msgstr "gabim i panjohur ngjeshjeje"
+
+#: ../src/common/lzmastream.cpp:280
+#, c-format
+msgid "LZMA compression error: %s"
+msgstr "Gabim ngjeshjeje LZMA: %s"
+
+#: ../src/common/lzmastream.cpp:350
+#, c-format
+msgid "LZMA compression error when flushing output: %s"
+msgstr "Gabim ngjeshjeje LZMA, kur spastrohej output-i: %s"
+
+#: ../src/common/mimecmn.cpp:167
+#, c-format
+msgid "Unmatched '{' in an entry for mime type %s."
+msgstr "'{' pa shoqe te një zë për lloj mime %s."
+
+#: ../src/common/module.cpp:76
+#, c-format
+msgid "Circular dependency involving module \"%s\" detected."
+msgstr "U pikas varësi rrethore që përfshin modulin “%s”."
+
+#: ../src/common/module.cpp:128
+#, c-format
+msgid "Dependency \"%s\" of module \"%s\" doesn't exist."
+msgstr "Varësia “%s” e modulit “%s” s’ekziston."
+
+#: ../src/common/module.cpp:137
+#, c-format
+msgid "Module \"%s\" initialization failed"
+msgstr "Gatitja e modulit “%s” dështoi"
+
+#: ../src/common/msgout.cpp:96
+msgid "Message"
+msgstr "Mesazh"
+
+#: ../src/common/paper.cpp:70
+msgid "Letter, 8 1/2 x 11 in"
+msgstr "Letër, 8 1/2 x 11 inç"
+
+#: ../src/common/paper.cpp:71
+msgid "Legal, 8 1/2 x 14 in"
+msgstr "Legal, 8 1/2 x 14 inç"
+
+#: ../src/common/paper.cpp:72
+msgid "A4 sheet, 210 x 297 mm"
+msgstr "Fletë A4, 210 x 297 mm"
+
+#: ../src/common/paper.cpp:73
+msgid "C sheet, 17 x 22 in"
+msgstr "Fletë C, 17 x 22 inç"
+
+#: ../src/common/paper.cpp:74
+msgid "D sheet, 22 x 34 in"
+msgstr "Fletë D, 22 x 34 inç"
+
+#: ../src/common/paper.cpp:75
+msgid "E sheet, 34 x 44 in"
+msgstr "Fletë E, 34 x 44 inç"
+
+#: ../src/common/paper.cpp:76
+msgid "Letter Small, 8 1/2 x 11 in"
+msgstr "Letër e Vogël, 8 1/2 x 11 inç"
+
+#: ../src/common/paper.cpp:77
+msgid "Tabloid, 11 x 17 in"
+msgstr "Tabloid, 11 x 17 inç"
+
+#: ../src/common/paper.cpp:78
+msgid "Ledger, 17 x 11 in"
+msgstr "Ledger, 17 x 11 inç"
+
+#: ../src/common/paper.cpp:79
+msgid "Statement, 5 1/2 x 8 1/2 in"
+msgstr "Deklaratë, 5 1/2 x 8 1/2 inç"
+
+#: ../src/common/paper.cpp:80
+msgid "Executive, 7 1/4 x 10 1/2 in"
+msgstr "Ekzekutive, 7 1/4 x 10 1/2 inç"
+
+#: ../src/common/paper.cpp:81
+msgid "A3 sheet, 297 x 420 mm"
+msgstr "Fletë A3, 297 x 420 mm"
+
+#: ../src/common/paper.cpp:82
+msgid "A4 small sheet, 210 x 297 mm"
+msgstr "Fletë e vogël A4, 210 x 297 mm"
+
+#: ../src/common/paper.cpp:83
+msgid "A5 sheet, 148 x 210 mm"
+msgstr "Fletë A5, 148 x 210 mm"
+
+#: ../src/common/paper.cpp:84
+msgid "B4 sheet, 250 x 354 mm"
+msgstr "Fletë B4, 250 x 354 mm"
+
+#: ../src/common/paper.cpp:85
+msgid "B5 sheet, 182 x 257 millimeter"
+msgstr "Fletë B5, 182 x 257 milimetra"
+
+#: ../src/common/paper.cpp:86
+msgid "Folio, 8 1/2 x 13 in"
+msgstr "Folio, 8 1/2 x 13 inç"
+
+#: ../src/common/paper.cpp:87
+msgid "Quarto, 215 x 275 mm"
+msgstr "Quarto, 215 x 275 mm"
+
+#: ../src/common/paper.cpp:88
+msgid "10 x 14 in"
+msgstr "10 x 14 inç"
+
+#: ../src/common/paper.cpp:89
+msgid "11 x 17 in"
+msgstr "11 x 17 inç"
+
+#: ../src/common/paper.cpp:90
+msgid "Note, 8 1/2 x 11 in"
+msgstr "Shënim, 8 1/2 x 11 inç"
+
+#: ../src/common/paper.cpp:91
+msgid "#9 Envelope, 3 7/8 x 8 7/8 in"
+msgstr "Zarf #9, 3 7/8 x 8 7/8 inç"
+
+#: ../src/common/paper.cpp:92
+msgid "#10 Envelope, 4 1/8 x 9 1/2 in"
+msgstr "Zarf #10, 4 1/8 x 9 1/2 inç"
+
+#: ../src/common/paper.cpp:93
+msgid "#11 Envelope, 4 1/2 x 10 3/8 in"
+msgstr "Zarf #11, 4 1/2 x 10 3/8 inç"
+
+#: ../src/common/paper.cpp:94
+msgid "#12 Envelope, 4 3/4 x 11 in"
+msgstr "Zarf #12, 4 3/4 x 11 inç"
+
+#: ../src/common/paper.cpp:95
+msgid "#14 Envelope, 5 x 11 1/2 in"
+msgstr "Zarf #14, 5 x 11 1/2 inç"
+
+#: ../src/common/paper.cpp:96
+msgid "DL Envelope, 110 x 220 mm"
+msgstr "Zarf DL, 110 x 220 mm"
+
+#: ../src/common/paper.cpp:97
+msgid "C5 Envelope, 162 x 229 mm"
+msgstr "Zarf C5, 162 x 229 mm"
+
+#: ../src/common/paper.cpp:98
+msgid "C3 Envelope, 324 x 458 mm"
+msgstr "Zarf C3, 324 x 458 mm"
+
+#: ../src/common/paper.cpp:99
+msgid "C4 Envelope, 229 x 324 mm"
+msgstr "Zarf C4, 229 x 324 mm"
+
+#: ../src/common/paper.cpp:100
+msgid "C6 Envelope, 114 x 162 mm"
+msgstr "Zarf C6, 114 x 162 mm"
+
+#: ../src/common/paper.cpp:101
+msgid "C65 Envelope, 114 x 229 mm"
+msgstr "Zarf C65, 114 x 229 mm"
+
+#: ../src/common/paper.cpp:102
+msgid "B4 Envelope, 250 x 353 mm"
+msgstr "Zarf B4, 250 x 353 mm"
+
+#: ../src/common/paper.cpp:103
+msgid "B5 Envelope, 176 x 250 mm"
+msgstr "Zarf B5, 176 x 250 mm"
+
+#: ../src/common/paper.cpp:104
+msgid "B6 Envelope, 176 x 125 mm"
+msgstr "Zarf B6, 176 x 125 mm"
+
+#: ../src/common/paper.cpp:105
+msgid "Italy Envelope, 110 x 230 mm"
+msgstr "Zarf Italie, 110 x 230 mm"
+
+#: ../src/common/paper.cpp:106
+msgid "Monarch Envelope, 3 7/8 x 7 1/2 in"
+msgstr "Zarf Monark, 3 7/8 x 7 1/2 inç"
+
+#: ../src/common/paper.cpp:107
+msgid "6 3/4 Envelope, 3 5/8 x 6 1/2 in"
+msgstr "Zarf 6 3/4, 3 5/8 x 6 1/2 inç"
+
+#: ../src/common/paper.cpp:108
+msgid "US Std Fanfold, 14 7/8 x 11 in"
+msgstr "Fletëpalosje ShBA Std., 14 7/8 x 11 inç"
+
+#: ../src/common/paper.cpp:109
+msgid "German Std Fanfold, 8 1/2 x 12 in"
+msgstr "Fletëpalosje Gjermane Std, 8 1/2 x 12 inç"
+
+#: ../src/common/paper.cpp:110
+msgid "German Legal Fanfold, 8 1/2 x 13 in"
+msgstr "Fletëpalosje Gjermane Legale, 8 1/2 x 13 inç"
+
+#: ../src/common/paper.cpp:112
+msgid "B4 (ISO) 250 x 353 mm"
+msgstr "B4 (ISO) 250 x 353 mm"
+
+#: ../src/common/paper.cpp:113
+msgid "Japanese Postcard 100 x 148 mm"
+msgstr "Kartolinë Japoneze 100 x 148 mm"
+
+#: ../src/common/paper.cpp:114
+msgid "9 x 11 in"
+msgstr "9 x 11 inç"
+
+#: ../src/common/paper.cpp:115
+msgid "10 x 11 in"
+msgstr "10 x 11 inç"
+
+#: ../src/common/paper.cpp:116
+msgid "15 x 11 in"
+msgstr "15 x 11 inç"
+
+#: ../src/common/paper.cpp:117
+msgid "Envelope Invite 220 x 220 mm"
+msgstr "Zarf Ftese 220 x 220 mm"
+
+#: ../src/common/paper.cpp:118
+msgid "Letter Extra 9 1/2 x 12 in"
+msgstr "Letër Ekstra 9 1/2 x 12 inç"
+
+#: ../src/common/paper.cpp:119
+msgid "Legal Extra 9 1/2 x 15 in"
+msgstr "Legal Ekstra 9 1/2 x 15 inç"
+
+#: ../src/common/paper.cpp:120
+msgid "Tabloid Extra 11.69 x 18 in"
+msgstr "Tabloid Ekstra 11.69 x 18 in"
+
+#: ../src/common/paper.cpp:121
+msgid "A4 Extra 9.27 x 12.69 in"
+msgstr "A4 Ekstra 9.27 x 12.69 inç"
+
+#: ../src/common/paper.cpp:122
+msgid "Letter Transverse 8 1/2 x 11 in"
+msgstr "Letër Transverse 8 1/2 x 11 inç"
+
+#: ../src/common/paper.cpp:123
+msgid "A4 Transverse 210 x 297 mm"
+msgstr "A4 Transverse 210 x 297 mm"
+
+#: ../src/common/paper.cpp:124
+msgid "Letter Extra Transverse 9.275 x 12 in"
+msgstr "Letër Ekstra Transverse 9.275 x 12 inç"
+
+#: ../src/common/paper.cpp:125
+msgid "SuperA/SuperA/A4 227 x 356 mm"
+msgstr "SuperA/SuperA/A4 227 x 356 mm"
+
+#: ../src/common/paper.cpp:126
+msgid "SuperB/SuperB/A3 305 x 487 mm"
+msgstr "SuperB/SuperB/A3 305 x 487 mm"
+
+#: ../src/common/paper.cpp:127
+msgid "Letter Plus 8 1/2 x 12.69 in"
+msgstr "Letër Plus 8 1/2 x 12.69 inç"
+
+#: ../src/common/paper.cpp:128
+msgid "A4 Plus 210 x 330 mm"
+msgstr "A4 Plus 210 x 330 mm"
+
+#: ../src/common/paper.cpp:129
+msgid "A5 Transverse 148 x 210 mm"
+msgstr "A5 Transverse 148 x 210 mm"
+
+#: ../src/common/paper.cpp:130
+msgid "B5 (JIS) Transverse 182 x 257 mm"
+msgstr "B5 (JIS) Transverse 182 x 257 mm"
+
+#: ../src/common/paper.cpp:131
+msgid "A3 Extra 322 x 445 mm"
+msgstr "A3 Ekstra 322 x 445 mm"
+
+#: ../src/common/paper.cpp:132
+msgid "A5 Extra 174 x 235 mm"
+msgstr "A5 Ekstra 174 x 235 mm"
+
+#: ../src/common/paper.cpp:133
+msgid "B5 (ISO) Extra 201 x 276 mm"
+msgstr "B5 (ISO) Ekstra 201 x 276 mm"
+
+#: ../src/common/paper.cpp:134
+msgid "A2 420 x 594 mm"
+msgstr "A2 420 x 594 mm"
+
+#: ../src/common/paper.cpp:135
+msgid "A3 Transverse 297 x 420 mm"
+msgstr "A3 Transverse 297 x 420 mm"
+
+#: ../src/common/paper.cpp:136
+msgid "A3 Extra Transverse 322 x 445 mm"
+msgstr "EkA3 Ekstra Transverse 322 x 445 mm"
+
+#: ../src/common/paper.cpp:138
+msgid "Japanese Double Postcard 200 x 148 mm"
+msgstr "Kartolinë Japoneze Dyshe 200 x 148 mm"
+
+#: ../src/common/paper.cpp:139
+msgid "A6 105 x 148 mm"
+msgstr "A6 105 x 148 mm"
+
+#: ../src/common/paper.cpp:140
+msgid "Japanese Envelope Kaku #2"
+msgstr "Zarf Japonez Kaku #2"
+
+#: ../src/common/paper.cpp:141
+msgid "Japanese Envelope Kaku #3"
+msgstr "Zarf Japonez Kaku #3"
+
+#: ../src/common/paper.cpp:142
+msgid "Japanese Envelope Chou #3"
+msgstr "Zarf Japonez Chou #3"
+
+#: ../src/common/paper.cpp:143
+msgid "Japanese Envelope Chou #4"
+msgstr "Zarf Japonez Chou #4"
+
+#: ../src/common/paper.cpp:144
+msgid "Letter Rotated 11 x 8 1/2 in"
+msgstr "Letër e Rrotulluar 11 x 8 1/2 inç"
+
+#: ../src/common/paper.cpp:145
+msgid "A3 Rotated 420 x 297 mm"
+msgstr "A3 e Rrotulluar 420 x 297 mm"
+
+#: ../src/common/paper.cpp:146
+msgid "A4 Rotated 297 x 210 mm"
+msgstr "A4 e Rrotulluar 297 x 210 mm"
+
+#: ../src/common/paper.cpp:147
+msgid "A5 Rotated 210 x 148 mm"
+msgstr "A5 e Rrotulluar 210 x 148 mm"
+
+#: ../src/common/paper.cpp:148
+msgid "B4 (JIS) Rotated 364 x 257 mm"
+msgstr "B4 (JIS) e Rrotulluar 364 x 257 mm"
+
+#: ../src/common/paper.cpp:149
+msgid "B5 (JIS) Rotated 257 x 182 mm"
+msgstr "B5 (JIS) e Rrotulluar 257 x 182 mm"
+
+#: ../src/common/paper.cpp:150
+msgid "Japanese Postcard Rotated 148 x 100 mm"
+msgstr "Kartolinë Japoneze e Rrotulluar 148 x 100 mm"
+
+#: ../src/common/paper.cpp:151
+msgid "Double Japanese Postcard Rotated 148 x 200 mm"
+msgstr "Kartolinë Japoneze Dyshe e Rrotulluar 148 x 200 mm"
+
+#: ../src/common/paper.cpp:152
+msgid "A6 Rotated 148 x 105 mm"
+msgstr "A6 e Rrotulluar 148 x 105 mm"
+
+#: ../src/common/paper.cpp:153
+msgid "Japanese Envelope Kaku #2 Rotated"
+msgstr "Zarf Japonez Kaku #2 i Rrotulluar"
+
+#: ../src/common/paper.cpp:154
+msgid "Japanese Envelope Kaku #3 Rotated"
+msgstr "Zarf Japonez Kaku #3 i Rrotulluar"
+
+#: ../src/common/paper.cpp:155
+msgid "Japanese Envelope Chou #3 Rotated"
+msgstr "Zarf Japonez Chou #3 i Rrotulluar"
+
+#: ../src/common/paper.cpp:156
+msgid "Japanese Envelope Chou #4 Rotated"
+msgstr "Zarf Japonez Chou #4 i Rrotulluar"
+
+#: ../src/common/paper.cpp:157
+msgid "B6 (JIS) 128 x 182 mm"
+msgstr "B6 (JIS) 128 x 182 mm"
+
+#: ../src/common/paper.cpp:158
+msgid "B6 (JIS) Rotated 182 x 128 mm"
+msgstr "B6 (JIS) e Rrotulluar 182 x 128 mm"
+
+#: ../src/common/paper.cpp:159
+msgid "12 x 11 in"
+msgstr "12 x 11 inç"
+
+#: ../src/common/paper.cpp:160
+msgid "Japanese Envelope You #4"
+msgstr "Zarf Japonez You #4"
+
+#: ../src/common/paper.cpp:161
+msgid "Japanese Envelope You #4 Rotated"
+msgstr "Zarf Japonez You #4 i Rrotulluar"
+
+#: ../src/common/paper.cpp:162
+msgid "PRC 16K 146 x 215 mm"
+msgstr "PRC 16K 146 x 215 mm"
+
+#: ../src/common/paper.cpp:163
+msgid "PRC 32K 97 x 151 mm"
+msgstr "PRC 32K 97 x 151 mm"
+
+#: ../src/common/paper.cpp:164
+msgid "PRC 32K(Big) 97 x 151 mm"
+msgstr "PRC 32K(E madhe) 97 x 151 mm"
+
+#: ../src/common/paper.cpp:165
+msgid "PRC Envelope #1 102 x 165 mm"
+msgstr "Zarf PRC #1 102 x 165 mm"
+
+#: ../src/common/paper.cpp:166
+msgid "PRC Envelope #2 102 x 176 mm"
+msgstr "Zarf PRC #2 102 x 176 mm"
+
+#: ../src/common/paper.cpp:167
+msgid "PRC Envelope #3 125 x 176 mm"
+msgstr "Zarf PRC #3 125 x 176 mm"
+
+#: ../src/common/paper.cpp:168
+msgid "PRC Envelope #4 110 x 208 mm"
+msgstr "Zarf PRC #4 110 x 208 mm"
+
+#: ../src/common/paper.cpp:169
+msgid "PRC Envelope #5 110 x 220 mm"
+msgstr "Zarf PRC #5 110 x 220 mm"
+
+#: ../src/common/paper.cpp:170
+msgid "PRC Envelope #6 120 x 230 mm"
+msgstr "Zarf PRC #6 120 x 230 mm"
+
+#: ../src/common/paper.cpp:171
+msgid "PRC Envelope #7 160 x 230 mm"
+msgstr "Zarf PRC #7 160 x 230 mm"
+
+#: ../src/common/paper.cpp:172
+msgid "PRC Envelope #8 120 x 309 mm"
+msgstr "Zarf PRC #8 120 x 309 mm"
+
+#: ../src/common/paper.cpp:173
+msgid "PRC Envelope #9 229 x 324 mm"
+msgstr "Zarf PRC #9 229 x 324 mm"
+
+#: ../src/common/paper.cpp:174
+msgid "PRC Envelope #10 324 x 458 mm"
+msgstr "Zarf PRC #10 324 x 458 mm"
+
+#: ../src/common/paper.cpp:175
+msgid "PRC 16K Rotated"
+msgstr "PRC 16K e Rrotulluar"
+
+#: ../src/common/paper.cpp:176
+msgid "PRC 32K Rotated"
+msgstr "PRC 32K e Rrotulluar"
+
+#: ../src/common/paper.cpp:177
+msgid "PRC 32K(Big) Rotated"
+msgstr "PRC 32K(E madhe) e Rrotulluar"
+
+#: ../src/common/paper.cpp:178
+msgid "PRC Envelope #1 Rotated 165 x 102 mm"
+msgstr "Zarf PRC #1 i Rrotulluar 165 x 102 mm"
+
+#: ../src/common/paper.cpp:179
+msgid "PRC Envelope #2 Rotated 176 x 102 mm"
+msgstr "Zarf PRC #2 i Rrotulluar 176 x 102 mm"
+
+#: ../src/common/paper.cpp:180
+msgid "PRC Envelope #3 Rotated 176 x 125 mm"
+msgstr "Zarf PRC #3 i Rrotulluar 176 x 125 mm"
+
+#: ../src/common/paper.cpp:181
+msgid "PRC Envelope #4 Rotated 208 x 110 mm"
+msgstr "Zarf PRC #4 i Rrotulluar 208 x 110 mm"
+
+#: ../src/common/paper.cpp:182
+msgid "PRC Envelope #5 Rotated 220 x 110 mm"
+msgstr "Zarf PRC #5 i Rrotulluar 220 x 110 mm"
+
+#: ../src/common/paper.cpp:183
+msgid "PRC Envelope #6 Rotated 230 x 120 mm"
+msgstr "Zarf PRC #6 i Rrotulluar 230 x 120 mm"
+
+#: ../src/common/paper.cpp:184
+msgid "PRC Envelope #7 Rotated 230 x 160 mm"
+msgstr "Zarf PRC #7 i Rrotulluar 230 x 160 mm"
+
+#: ../src/common/paper.cpp:185
+msgid "PRC Envelope #8 Rotated 309 x 120 mm"
+msgstr "Zarf PRC #8 i Rrotulluar 309 x 120 mm"
+
+#: ../src/common/paper.cpp:186
+msgid "PRC Envelope #9 Rotated 324 x 229 mm"
+msgstr "Zarf PRC #9 i Rrotulluar 324 x 229 mm"
+
+#: ../src/common/paper.cpp:187
+msgid "PRC Envelope #10 Rotated 458 x 324 mm"
+msgstr "Zarf PRC #10 i Rrotulluar 458 x 324 mm"
+
+#: ../src/common/paper.cpp:192
+msgid "A0 sheet, 841 x 1189 mm"
+msgstr "Fletë A0, 841 x 1189 mm"
+
+#: ../src/common/paper.cpp:193
+msgid "A1 sheet, 594 x 841 mm"
+msgstr "Fletë A1, 594 x 841 mm"
+
+#: ../src/common/preferencescmn.cpp:37
+msgid "General"
+msgstr "Të përgjithshme"
+
+#: ../src/common/preferencescmn.cpp:40
+msgid "Advanced"
+msgstr "Të mëtejshme"
+
+#: ../src/common/prntbase.cpp:245
+msgid "Generic PostScript"
+msgstr "PostScript Bazë"
+
+#: ../src/common/prntbase.cpp:259
+msgid "Ready"
+msgstr "Gati"
+
+#: ../src/common/prntbase.cpp:331
+msgid "Printing Error"
+msgstr "Gabim Shtypjeje"
+
+#: ../src/common/prntbase.cpp:413 ../src/common/prntbase.cpp:1597
+#: ../src/generic/prntdlgg.cpp:135 ../src/generic/prntdlgg.cpp:149
+#: ../src/gtk/print.cpp:628 ../src/gtk/print.cpp:646
+msgid "Print"
+msgstr "Shtyp"
+
+#: ../src/common/prntbase.cpp:471 ../src/generic/prntdlgg.cpp:809
+msgid "Page setup"
+msgstr "Rregullim faqeje"
+
+#: ../src/common/prntbase.cpp:525
+msgid "Please wait while printing..."
+msgstr "Ju lutemi, prisni, teksa shtypet…"
+
+#: ../src/common/prntbase.cpp:529
+msgid "Document:"
+msgstr "Dokument:"
+
+#: ../src/common/prntbase.cpp:532
+msgid "Progress:"
+msgstr "Ecuri:"
+
+#: ../src/common/prntbase.cpp:533
+msgid "Preparing"
+msgstr "Po përgatitet"
+
+#: ../src/common/prntbase.cpp:552
+#, c-format
+msgid "Printing page %d"
+msgstr "Po shtypet faqja %d"
+
+#: ../src/common/prntbase.cpp:557
+#, c-format
+msgid "Printing page %d of %d"
+msgstr "Po shtypet faqja %d nga %d"
+
+#: ../src/common/prntbase.cpp:560
+#, c-format
+msgid " (copy %d of %d)"
+msgstr " (kopje %d e %d)"
+
+#: ../src/common/prntbase.cpp:1604
+msgid "First page"
+msgstr "Faqja e parë"
+
+#: ../src/common/prntbase.cpp:1609 ../src/html/helpwnd.cpp:659
+msgid "Previous page"
+msgstr "Faqja e mëparshme"
+
+#: ../src/common/prntbase.cpp:1623 ../src/html/helpwnd.cpp:660
+msgid "Next page"
+msgstr "Faqe pasuese"
+
+#: ../src/common/prntbase.cpp:1628
+msgid "Last page"
+msgstr "Faqja e fundit"
+
+#: ../src/common/prntbase.cpp:1636 ../src/common/stockitem.cpp:215
+msgid "Zoom Out"
+msgstr "Zvogëloje"
+
+#: ../src/common/prntbase.cpp:1650 ../src/common/stockitem.cpp:214
+msgid "Zoom In"
+msgstr "Zmadhoje"
+
+#: ../src/common/prntbase.cpp:1656 ../src/common/stockitem.cpp:153
+#: ../src/generic/logg.cpp:553 ../src/univ/themes/win32.cpp:3752
+msgid "&Close"
+msgstr "&Mbylle"
+
+#: ../src/common/prntbase.cpp:2085
+msgid "Could not start document preview."
+msgstr "S’u nis dot paraparje dokumenti."
+
+#: ../src/common/prntbase.cpp:2085 ../src/common/prntbase.cpp:2129
+#: ../src/common/prntbase.cpp:2137
+msgid "Print Preview Failure"
+msgstr "Dështim Paraparje Shtypjeje"
+
+#: ../src/common/prntbase.cpp:2129 ../src/common/prntbase.cpp:2137
+msgid "Sorry, not enough memory to create a preview."
+msgstr "Na ndjeni, s’ka kujtesë të mjaftueshme për krijim paraparjeje."
+
+#: ../src/common/prntbase.cpp:2144
+#, c-format
+msgid "Page %d of %d"
+msgstr "Faqe %d nga %d"
+
+#: ../src/common/prntbase.cpp:2146
+#, c-format
+msgid "Page %d"
+msgstr "Faqe %d"
+
+#: ../src/common/regex.cpp:382 ../src/html/chm.cpp:348
+msgid "unknown error"
+msgstr "gabim i panjohur"
+
+#: ../src/common/regex.cpp:995
+#, c-format
+msgid "Invalid regular expression '%s': %s"
+msgstr "Shprehje e rregullt e pavlefshme '%s': %s"
+
+#: ../src/common/regex.cpp:1059
+#, c-format
+msgid "Failed to find match for regular expression: %s"
+msgstr "S’u arrit të gjendej përputhje për shprehje të rregullt: %s"
+
+#: ../src/common/rendcmn.cpp:188
+#, c-format
+msgid "Renderer \"%s\" has incompatible version %d.%d and couldn't be loaded."
+msgstr "Vizatuesi “%s” ka version %d.%d të papërputhshëm dhe s’u ngarkua dot."
+
+#: ../src/common/secretstore.cpp:162
+msgid "Not available for this platform"
+msgstr "Jo e passhme për këtë platformë"
+
+#: ../src/common/secretstore.cpp:183
+#, c-format
+msgid "Saving password for \"%s\" failed: %s."
+msgstr "S’u arrit të ruhej fjalëkalimi për “%s”: %s."
+
+#: ../src/common/secretstore.cpp:205
+#, c-format
+msgid "Reading password for \"%s\" failed: %s."
+msgstr "S’u arrit të lexohej fjalëkalimi për “%s”: %s."
+
+#: ../src/common/secretstore.cpp:228
+#, c-format
+msgid "Deleting password for \"%s\" failed: %s."
+msgstr "S’u arrit të fshihet fjalëkalimi për “%s”: %s."
+
+#: ../src/common/selectdispatcher.cpp:254
+msgid "Failed to monitor I/O channels"
+msgstr "S’u arrit të mbikëqyreshin kanale I/O"
+
+#: ../src/common/sizer.cpp:3054 ../src/common/stockitem.cpp:195
+msgid "Save"
+msgstr "Ruaje"
+
+#: ../src/common/sizer.cpp:3056
+msgid "Don't Save"
+msgstr "Mos e Ruaj"
+
+#: ../src/common/socket.cpp:870
+msgid "Cannot initialize sockets"
+msgstr "S’gatiten dot socket-e"
+
+#: ../src/common/stockitem.cpp:127
+msgctxt "standard Windows menu"
+msgid "&Help"
+msgstr "&Ndihmë"
+
+#: ../src/common/stockitem.cpp:144
+msgid "&About"
+msgstr "&Mbi"
+
+#: ../src/common/stockitem.cpp:144
+msgid "About"
+msgstr "Mbi"
+
+#: ../src/common/stockitem.cpp:145
+msgid "Add"
+msgstr "Shtoni"
+
+#: ../src/common/stockitem.cpp:146
+msgid "&Apply"
+msgstr "&Zbatoje"
+
+#: ../src/common/stockitem.cpp:146
+msgid "Apply"
+msgstr "Zbatoje"
+
+#: ../src/common/stockitem.cpp:147
+msgid "&Back"
+msgstr "&Mbrapsht"
+
+#: ../src/common/stockitem.cpp:147
+msgid "Back"
+msgstr "Mbrapsht"
+
+#: ../src/common/stockitem.cpp:148
+msgid "&Bold"
+msgstr "&Të trasha"
+
+#: ../src/common/stockitem.cpp:148 ../src/generic/fontdlgg.cpp:326
+#: ../src/richtext/richtextfontpage.cpp:354
+msgid "Bold"
+msgstr "Të trasha"
+
+#: ../src/common/stockitem.cpp:149
+msgid "&Bottom"
+msgstr "&Në fund"
+
+#: ../src/common/stockitem.cpp:149 ../src/richtext/richtextsizepage.cpp:287
+msgid "Bottom"
+msgstr "Në Fund"
+
+#: ../src/common/stockitem.cpp:150 ../src/generic/fontdlgg.cpp:462
+#: ../src/generic/fontdlgg.cpp:481 ../src/generic/wizard.cpp:415
+msgid "&Cancel"
+msgstr "&Anuloje"
+
+#: ../src/common/stockitem.cpp:151
+msgid "&CD-ROM"
+msgstr "&CD-ROM"
+
+#: ../src/common/stockitem.cpp:151
+msgid "CD-ROM"
+msgstr "CD-ROM"
+
+#: ../src/common/stockitem.cpp:152
+msgid "&Clear"
+msgstr "&Spastroje"
+
+#: ../src/common/stockitem.cpp:152
+msgid "Clear"
+msgstr "Spastroje"
+
+#: ../src/common/stockitem.cpp:153 ../src/generic/dbgrptg.cpp:93
+#: ../src/generic/progdlgg.cpp:778 ../src/html/helpdlg.cpp:86
+#: ../src/msw/progdlg.cpp:209 ../src/msw/progdlg.cpp:890
+#: ../src/richtext/richtextstyledlg.cpp:272
+#: ../src/richtext/richtextsymboldlg.cpp:448
+msgid "Close"
+msgstr "Mbylle"
+
+#: ../src/common/stockitem.cpp:154
+msgid "&Convert"
+msgstr "&Shndërroje"
+
+#: ../src/common/stockitem.cpp:154
+msgid "Convert"
+msgstr "Shndërroje"
+
+#: ../src/common/stockitem.cpp:155 ../src/msw/textctrl.cpp:2884
+#: ../src/osx/textctrl_osx.cpp:653 ../src/richtext/richtextctrl.cpp:331
+msgid "&Copy"
+msgstr "&Kopjoje"
+
+#: ../src/common/stockitem.cpp:155 ../src/stc/stc_i18n.cpp:18
+msgid "Copy"
+msgstr "Kopjoje"
+
+#: ../src/common/stockitem.cpp:156 ../src/msw/textctrl.cpp:2883
+#: ../src/osx/textctrl_osx.cpp:652 ../src/richtext/richtextctrl.cpp:330
+msgid "Cu&t"
+msgstr "P&rije"
+
+#: ../src/common/stockitem.cpp:156 ../src/stc/stc_i18n.cpp:17
+msgid "Cut"
+msgstr "Prije"
+
+#: ../src/common/stockitem.cpp:157 ../src/msw/textctrl.cpp:2886
+#: ../src/osx/textctrl_osx.cpp:655 ../src/richtext/richtextctrl.cpp:333
+#: ../src/richtext/richtexttabspage.cpp:137
+msgid "&Delete"
+msgstr "&Fshije"
+
+#: ../src/common/stockitem.cpp:157 ../src/richtext/richtextbuffer.cpp:8266
+#: ../src/stc/stc_i18n.cpp:20
+msgid "Delete"
+msgstr "Fshije"
+
+#: ../src/common/stockitem.cpp:158
+msgid "&Down"
+msgstr "&Poshtë"
+
+#: ../src/common/stockitem.cpp:158 ../src/generic/fdrepdlg.cpp:148
+msgid "Down"
+msgstr "Poshtë"
+
+#: ../src/common/stockitem.cpp:159
+msgid "&Edit"
+msgstr "&Përpunojeni"
+
+#: ../src/common/stockitem.cpp:159
+msgid "Edit"
+msgstr "Përpunoni"
+
+#: ../src/common/stockitem.cpp:160
+msgid "&Execute"
+msgstr "&Kryeje"
+
+#: ../src/common/stockitem.cpp:160
+msgid "Execute"
+msgstr "Përmbushe"
+
+#: ../src/common/stockitem.cpp:161
+msgid "&Quit"
+msgstr "&Dilni"
+
+#: ../src/common/stockitem.cpp:161
+msgid "Quit"
+msgstr "Dilni"
+
+#: ../src/common/stockitem.cpp:162
+msgid "&File"
+msgstr "&Kartelë"
+
+#: ../src/common/stockitem.cpp:162
+msgid "File"
+msgstr "Kartelë"
+
+#: ../src/common/stockitem.cpp:163
+msgid "&Find..."
+msgstr "&Gjeni…"
+
+#: ../src/common/stockitem.cpp:163
+msgid "Find..."
+msgstr "Gjeni…"
+
+#: ../src/common/stockitem.cpp:164
+msgid "&First"
+msgstr "I &pari"
+
+#: ../src/common/stockitem.cpp:164
+msgid "First"
+msgstr "E para"
+
+#: ../src/common/stockitem.cpp:165
+msgid "&Floppy"
+msgstr "&Disketë"
+
+#: ../src/common/stockitem.cpp:165
+msgid "Floppy"
+msgstr "Disketë"
+
+#: ../src/common/stockitem.cpp:166
+msgid "&Forward"
+msgstr "&Përpara"
+
+#: ../src/common/stockitem.cpp:166
+msgid "Forward"
+msgstr "Përpara"
+
+#: ../src/common/stockitem.cpp:167
+msgid "&Harddisk"
+msgstr "&HD"
+
+#: ../src/common/stockitem.cpp:167
+msgid "Harddisk"
+msgstr "HD"
+
+#: ../src/common/stockitem.cpp:168 ../src/generic/wizard.cpp:418
+#: ../src/osx/cocoa/menu.mm:225 ../src/richtext/richtextstyledlg.cpp:298
+#: ../src/richtext/richtextsymboldlg.cpp:451
+msgid "&Help"
+msgstr "&Ndihmë"
+
+#: ../src/common/stockitem.cpp:169
+msgid "&Home"
+msgstr "&Kreu"
+
+#: ../src/common/stockitem.cpp:169
+msgid "Home"
+msgstr "Hyrje"
+
+#: ../src/common/stockitem.cpp:170
+msgid "Indent"
+msgstr "Shmangie brendazi"
+
+#: ../src/common/stockitem.cpp:171
+msgid "&Index"
+msgstr "&Tregues"
+
+#: ../src/common/stockitem.cpp:171 ../src/html/helpwnd.cpp:510
+msgid "Index"
+msgstr "Tregues"
+
+#: ../src/common/stockitem.cpp:172
+msgid "&Info"
+msgstr "&Info"
+
+#: ../src/common/stockitem.cpp:172
+msgid "Info"
+msgstr "Info"
+
+#: ../src/common/stockitem.cpp:173
+msgid "&Italic"
+msgstr "&Të pjerrëta"
+
+#: ../src/common/stockitem.cpp:173 ../src/generic/fontdlgg.cpp:322
+#: ../src/richtext/richtextfontpage.cpp:350
+msgid "Italic"
+msgstr "Të pjerrta"
+
+#: ../src/common/stockitem.cpp:174
+msgid "&Jump to"
+msgstr "&Hidhu te"
+
+#: ../src/common/stockitem.cpp:174
+msgid "Jump to"
+msgstr "Hidhu te"
+
+#: ../src/common/stockitem.cpp:175
+msgid "Centered"
+msgstr "Në qendër"
+
+#: ../src/common/stockitem.cpp:176
+msgid "Justified"
+msgstr "Përligjur"
+
+#: ../src/common/stockitem.cpp:177
+msgid "Align Left"
+msgstr "Vendose Majtas"
+
+#: ../src/common/stockitem.cpp:178
+msgid "Align Right"
+msgstr "Vendose Djathtas"
+
+#: ../src/common/stockitem.cpp:179
+msgid "&Last"
+msgstr "E &fundit"
+
+#: ../src/common/stockitem.cpp:179
+msgid "Last"
+msgstr "E fundit"
+
+#: ../src/common/stockitem.cpp:180
+msgid "&Network"
+msgstr "&Rrjet"
+
+#: ../src/common/stockitem.cpp:180
+msgid "Network"
+msgstr "Rrjet"
+
+#: ../src/common/stockitem.cpp:181 ../src/richtext/richtexttabspage.cpp:131
+msgid "&New"
+msgstr "I &ri"
+
+#: ../src/common/stockitem.cpp:181
+msgid "New"
+msgstr "I ri"
+
+#: ../src/common/stockitem.cpp:182 ../src/msw/msgdlg.cpp:417
+msgid "&No"
+msgstr "&Jo"
+
+#: ../src/common/stockitem.cpp:183 ../src/generic/fontdlgg.cpp:467
+#: ../src/generic/fontdlgg.cpp:474
+msgid "&OK"
+msgstr "&OK"
+
+#: ../src/common/stockitem.cpp:184 ../src/generic/dbgrptg.cpp:341
+msgid "&Open..."
+msgstr "&Hapni…"
+
+#: ../src/common/stockitem.cpp:184
+msgid "Open..."
+msgstr "Hapni…"
+
+#: ../src/common/stockitem.cpp:185 ../src/msw/textctrl.cpp:2885
+#: ../src/osx/textctrl_osx.cpp:654 ../src/richtext/richtextctrl.cpp:332
+msgid "&Paste"
+msgstr "&Ngjite"
+
+#: ../src/common/stockitem.cpp:185 ../src/richtext/richtextctrl.cpp:3484
+#: ../src/stc/stc_i18n.cpp:19
+msgid "Paste"
+msgstr "Ngjitje"
+
+#: ../src/common/stockitem.cpp:186
+msgid "&Preferences"
+msgstr "&Parapëlqime"
+
+#: ../src/common/stockitem.cpp:186 ../src/osx/cocoa/preferences.mm:304
+msgid "Preferences"
+msgstr "Parapëlqime"
+
+#: ../src/common/stockitem.cpp:187
+msgid "Print previe&w..."
+msgstr "Par&aparje shtypjeje…"
+
+#: ../src/common/stockitem.cpp:187
+msgid "Print preview..."
+msgstr "Paraparje shtypjeje…"
+
+#: ../src/common/stockitem.cpp:188
+msgid "&Print..."
+msgstr "&Shtypni…"
+
+#: ../src/common/stockitem.cpp:188
+msgid "Print..."
+msgstr "Shtypni…"
+
+#: ../src/common/stockitem.cpp:189 ../src/richtext/richtextctrl.cpp:337
+#: ../src/richtext/richtextctrl.cpp:5479
+msgid "&Properties"
+msgstr "&Veti"
+
+#: ../src/common/stockitem.cpp:189
+msgid "Properties"
+msgstr "Veti"
+
+#: ../src/common/stockitem.cpp:190 ../src/stc/stc_i18n.cpp:16
+msgid "Redo"
+msgstr "Ribëje"
+
+#: ../src/common/stockitem.cpp:191
+msgid "Refresh"
+msgstr "Rifreskoje"
+
+#: ../src/common/stockitem.cpp:192
+msgid "Remove"
+msgstr "Hiqe"
+
+#: ../src/common/stockitem.cpp:193
+msgid "Rep&lace..."
+msgstr "&Zëvendësoni…"
+
+#: ../src/common/stockitem.cpp:193
+msgid "Replace..."
+msgstr "Zëvendësoni…"
+
+#: ../src/common/stockitem.cpp:194
+msgid "Revert to Saved"
+msgstr "Riktheje tek i Ruajturi"
+
+#: ../src/common/stockitem.cpp:196 ../src/generic/logg.cpp:549
+msgid "Save &As..."
+msgstr "Ruajeni &Si…"
+
+#: ../src/common/stockitem.cpp:196
+msgid "Save As..."
+msgstr "Ruajeni Si…"
+
+#: ../src/common/stockitem.cpp:197 ../src/msw/textctrl.cpp:2888
+#: ../src/osx/textctrl_osx.cpp:657 ../src/richtext/richtextctrl.cpp:335
+msgid "Select &All"
+msgstr "Përzgjidhni &Krejt"
+
+#: ../src/common/stockitem.cpp:197 ../src/stc/stc_i18n.cpp:21
+msgid "Select All"
+msgstr "Përzgjidhi Krejt"
+
+#: ../src/common/stockitem.cpp:198
+msgid "&Color"
+msgstr "&Ngjyrë"
+
+#: ../src/common/stockitem.cpp:198
+msgid "Color"
+msgstr "Ngjyrë"
+
+#: ../src/common/stockitem.cpp:199
+msgid "&Font"
+msgstr "&Shkronja"
+
+#: ../src/common/stockitem.cpp:199 ../src/richtext/richtextformatdlg.cpp:336
+msgid "Font"
+msgstr "Shkronja"
+
+#: ../src/common/stockitem.cpp:200
+msgid "&Ascending"
+msgstr "&Rritës"
+
+#: ../src/common/stockitem.cpp:200
+msgid "Ascending"
+msgstr "Rritës"
+
+#: ../src/common/stockitem.cpp:201
+msgid "&Descending"
+msgstr "&Zbritës"
+
+#: ../src/common/stockitem.cpp:201
+msgid "Descending"
+msgstr "Zbritës"
+
+#: ../src/common/stockitem.cpp:202
+msgid "&Spell Check"
+msgstr "&Kontroll Drejtshkrimi"
+
+#: ../src/common/stockitem.cpp:202
+msgid "Spell Check"
+msgstr "Kontroll Drejtshkrimi"
+
+#: ../src/common/stockitem.cpp:203
+msgid "&Stop"
+msgstr "&Ndal"
+
+#: ../src/common/stockitem.cpp:203
+msgid "Stop"
+msgstr "Ndal"
+
+#: ../src/common/stockitem.cpp:204 ../src/richtext/richtextfontpage.cpp:274
+msgid "&Strikethrough"
+msgstr "&Hequrvije"
+
+#: ../src/common/stockitem.cpp:204
+msgid "Strikethrough"
+msgstr "Hequrvije"
+
+#: ../src/common/stockitem.cpp:205
+msgid "&Top"
+msgstr "Në &Krye"
+
+#: ../src/common/stockitem.cpp:205 ../src/richtext/richtextsizepage.cpp:285
+#: ../src/richtext/richtextsizepage.cpp:289
+msgid "Top"
+msgstr "Në krye"
+
+#: ../src/common/stockitem.cpp:206
+msgid "Undelete"
+msgstr "Shfshije"
+
+#: ../src/common/stockitem.cpp:207 ../src/generic/fontdlgg.cpp:437
+msgid "&Underline"
+msgstr "&Nënvijë"
+
+#: ../src/common/stockitem.cpp:207
+msgid "Underline"
+msgstr "Nënvijë"
+
+#: ../src/common/stockitem.cpp:208 ../src/stc/stc_i18n.cpp:15
+msgid "Undo"
+msgstr "Zhbëje"
+
+#: ../src/common/stockitem.cpp:209
+msgid "&Unindent"
+msgstr "Hiqi &Shmangien"
+
+#: ../src/common/stockitem.cpp:209
+msgid "Unindent"
+msgstr "Hiqi shmangien"
+
+#: ../src/common/stockitem.cpp:210
+msgid "&Up"
+msgstr "&Sipër"
+
+#: ../src/common/stockitem.cpp:210 ../src/generic/fdrepdlg.cpp:148
+msgid "Up"
+msgstr "Sipër"
+
+#: ../src/common/stockitem.cpp:211 ../src/msw/msgdlg.cpp:417
+msgid "&Yes"
+msgstr "&Po"
+
+#: ../src/common/stockitem.cpp:212
+msgid "&Actual Size"
+msgstr "Madhësi &Faktike"
+
+#: ../src/common/stockitem.cpp:212
+msgid "Actual Size"
+msgstr "Madhësi Faktike"
+
+#: ../src/common/stockitem.cpp:213
+msgid "Zoom to &Fit"
+msgstr "Sa ta N&xërë"
+
+#: ../src/common/stockitem.cpp:213
+msgid "Zoom to Fit"
+msgstr "Sa ta Nxërë"
+
+#: ../src/common/stockitem.cpp:214
+msgid "Zoom &In"
+msgstr "Z&madhoje"
+
+#: ../src/common/stockitem.cpp:215
+msgid "Zoom &Out"
+msgstr "Z&vogëloje"
+
+#: ../src/common/stockitem.cpp:262
+msgid "Show about dialog"
+msgstr "Shfaq dialogun Rreth"
+
+#: ../src/common/stockitem.cpp:263
+msgid "Copy selection"
+msgstr "Kopjo përzgjedhjen"
+
+#: ../src/common/stockitem.cpp:264
+msgid "Cut selection"
+msgstr "Prije përzgjedhjen"
+
+#: ../src/common/stockitem.cpp:265
+msgid "Delete selection"
+msgstr "Fshije përzgjedhjen"
+
+#: ../src/common/stockitem.cpp:266
+msgid "Find in document"
+msgstr "Gjej në dokument"
+
+#: ../src/common/stockitem.cpp:267
+msgid "Find and replace in document"
+msgstr "Gjeni dhe zëvendësoni në dokument"
+
+#: ../src/common/stockitem.cpp:268
+msgid "Paste selection"
+msgstr "Ngjite përzgjedhjen"
+
+#: ../src/common/stockitem.cpp:269
+msgid "Quit this program"
+msgstr "Dilni nga ky program"
+
+#: ../src/common/stockitem.cpp:270
+msgid "Redo last action"
+msgstr "Ribëje veprimin e fundit"
+
+#: ../src/common/stockitem.cpp:271
+msgid "Undo last action"
+msgstr "Zhbëje veprimin e fundit"
+
+#: ../src/common/stockitem.cpp:272
+msgid "Create new document"
+msgstr "Krijoni dokument të ri"
+
+#: ../src/common/stockitem.cpp:273
+msgid "Open an existing document"
+msgstr "Hapni një dokument ekzistues"
+
+#: ../src/common/stockitem.cpp:274
+msgid "Close current document"
+msgstr "Mbyll dokumentin e tanishëm"
+
+#: ../src/common/stockitem.cpp:275
+msgid "Save current document"
+msgstr "Ruaj dokumentin e tanishëm"
+
+#: ../src/common/stockitem.cpp:276
+msgid "Save current document with a different filename"
+msgstr "Ruajeni dokumentin e tanishëm nën një tjetër emër kartele"
+
+#: ../src/common/strconv.cpp:2324
+#, c-format
+msgid "Conversion to charset '%s' doesn't work."
+msgstr "Shndërrimi në shkronjat '%s' nuk funksionon."
+
+#: ../src/common/tarstrm.cpp:352 ../src/common/tarstrm.cpp:375
+#: ../src/common/tarstrm.cpp:406 ../src/generic/progdlgg.cpp:373
+msgid "unknown"
+msgstr "i/e panjohur"
+
+#: ../src/common/tarstrm.cpp:774
+msgid "incomplete header block in tar"
+msgstr "bllok i paplotë kryesh në tar"
+
+#: ../src/common/tarstrm.cpp:798
+msgid "checksum failure reading tar header block"
+msgstr "dështim checksum-i në lexim blloku kryesh tar"
+
+#: ../src/common/tarstrm.cpp:971
+msgid "invalid data in extended tar header"
+msgstr "të dhëna të pavlefshme në krye të zgjeruara tar-i"
+
+#: ../src/common/tarstrm.cpp:981 ../src/common/tarstrm.cpp:1003
+#: ../src/common/tarstrm.cpp:1477 ../src/common/tarstrm.cpp:1499
+msgid "tar entry not open"
+msgstr "zë tar i pahapur"
+
+#: ../src/common/tarstrm.cpp:1023
+msgid "unexpected end of file"
+msgstr "fund i papritur kartele"
+
+#: ../src/common/tarstrm.cpp:1297
+#, c-format
+msgid "%s did not fit the tar header for entry '%s'"
+msgstr "%s s’u përputh dot me krye tar për zërin '%s'"
+
+#: ../src/common/tarstrm.cpp:1359
+msgid "incorrect size given for tar entry"
+msgstr "u dha madhësi i pasaktë për zë tar"
+
+#: ../src/common/textbuf.cpp:232
+#, c-format
+msgid "'%s' is probably a binary buffer."
+msgstr "'%s' ka gjasa të jetë shtytëz dyore."
+
+#: ../src/common/textcmn.cpp:1006 ../src/richtext/richtextctrl.cpp:3053
+msgid "File couldn't be loaded."
+msgstr "Kartela s’u ngarkua dot."
+
+#: ../src/common/textfile.cpp:95
+#, c-format
+msgid "Failed to read text file \"%s\"."
+msgstr "S’u arrit të lexohej kartela tekst “%s”."
+
+#: ../src/common/textfile.cpp:160
+#, c-format
+msgid "can't write buffer '%s' to disk."
+msgstr "s’shkruhet dot shtytëza '%s' në disk."
+
+#: ../src/common/time.cpp:212
+msgid "Failed to get the local system time"
+msgstr "S’u arrit të merrej koha vendore e sistemit"
+
+#: ../src/common/time.cpp:279
+msgid "wxGetTimeOfDay failed."
+msgstr "wxGetTimeOfDay dështoi."
+
+#: ../src/common/translation.cpp:929
+#, c-format
+msgid "'%s' is not a valid message catalog."
+msgstr "'%s' s’është katalog i vlefshëm mesazhesh."
+
+#: ../src/common/translation.cpp:954
+msgid "Invalid message catalog."
+msgstr "Katalog i pavlefshëm mesazhi."
+
+#: ../src/common/translation.cpp:1013
+#, c-format
+msgid "Failed to parse Plural-Forms: '%s'"
+msgstr "S’u arrit të përtypeshin Plural-Forms: '%s'"
+
+#: ../src/common/translation.cpp:1723
+#, c-format
+msgid "using catalog '%s' from '%s'."
+msgstr "po përdoret katalog '%s' prej '%s'."
+
+#: ../src/common/translation.cpp:1816
+#, c-format
+msgid "Resource '%s' is not a valid message catalog."
+msgstr "Burimi '%s' s’është katalog i vlefshëm mesazhesh."
+
+#: ../src/common/translation.cpp:1865
+msgid "Couldn't enumerate translations"
+msgstr "S’u numërtuan dot përkthimet"
+
+#: ../src/common/utilscmn.cpp:1145
+msgid "No default application configured for HTML files."
+msgstr "S’ka aplikacion parazgjedhje të formësuar për kartela HTML."
+
+#: ../src/common/utilscmn.cpp:1190
+#, c-format
+msgid "Failed to open URL \"%s\" in default browser."
+msgstr "S’u arrit të hapej URL-ja “%s” në shfletuesin parazgjedhje."
+
+#: ../src/common/valtext.cpp:144
+msgid "Validation conflict"
+msgstr "Kundërshti vleftësimesh"
+
+#: ../src/common/valtext.cpp:186
+msgid "Required information entry is empty."
+msgstr "Zë i domosdoshëm informacioni është i zbrazët."
+
+#: ../src/common/valtext.cpp:188
+#, c-format
+msgid "'%s' is one of the invalid strings"
+msgstr "'%s' është një nga vargjet e pavlefshëm"
+
+#: ../src/common/valtext.cpp:190
+#, c-format
+msgid "'%s' is not one of the valid strings"
+msgstr "'%s' s’është një nga vargjet e vlefshëm"
+
+#: ../src/common/valtext.cpp:199
+#, c-format
+msgid "'%s' contains invalid character(s)"
+msgstr "'%s' përmban shenjë(a) të pavlefshme"
+
+#: ../src/common/webrequest.cpp:139
+#, c-format
+msgid "Error: %s (%d)"
+msgstr "Gabim: %s (%d)"
+
+#: ../src/common/webrequest.cpp:655
+#, fuzzy, c-format
+msgid ""
+"Not enough free disk space for download: %llu needed but only %llu available."
+msgstr "Hapësirë disku e pamjaftueshme për shkarkim."
+
+#: ../src/common/webrequest.cpp:669
+#, fuzzy, c-format
+msgid "Failed to create temporary file in %s"
+msgstr "S’u arrit të krijohej emër kartele të përkohshme"
+
+#: ../src/common/webrequest_curl.cpp:1106
+msgid "libcurl could not be initialized"
+msgstr "S’u gatit dot përshkrim libcurl"
+
+#: ../src/common/webview.cpp:392
+msgid "RunScriptAsync not supported"
+msgstr "S’mbulohet RunScriptAsync"
+
+#: ../src/common/webview.cpp:403 ../src/msw/webview_ie.cpp:1073
+#, c-format
+msgid "Error running JavaScript: %s"
+msgstr "Gabim në xhirim JavaScript-i: %s"
+
+#: ../src/common/webview_chromium.cpp:858
+#, fuzzy, c-format
+msgid "Failed to set proxy \"%s\": %s"
+msgstr "S’u arrit të krijohej drejtori “%s”"
+
+#: ../src/common/webview_chromium.cpp:989
+msgid ""
+"Chromium can't be used because libcef.so wasn't loaded early enough; please "
+"relink the application or use LD_PRELOAD to load it earlier."
+msgstr ""
+
+#: ../src/common/webview_chromium.cpp:1108
+#, fuzzy
+msgid "Could not initialize Chromium"
+msgstr "S’gatitet dot OLE"
+
+#: ../src/common/webview_chromium.cpp:1616
+msgid "Show DevTools"
+msgstr ""
+
+#: ../src/common/webview_chromium.cpp:1617
+#, fuzzy
+msgid "Close DevTools"
+msgstr "Mbylli Krejt"
+
+#: ../src/common/webview_chromium.cpp:1623
+msgid "Inspect"
+msgstr ""
+
+#: ../src/common/wincmn.cpp:1628
+msgid "This platform does not support background transparency."
+msgstr "Kjo platformë nuk mbulon tejdukshmëri sfondesh."
+
+#: ../src/common/wincmn.cpp:2097
+msgid "Could not transfer data to window"
+msgstr "S’u shpërngulën dot të dhëna te dritare"
+
+#: ../src/common/windowid.cpp:240
+msgid "Out of window IDs.  Recommend shutting down application."
+msgstr "Mbaruan ID-të e dritareve.  Këshillohet mbyllja e aplikacionit."
+
+#: ../src/common/xpmdecod.cpp:678
+msgid "XPM: incorrect header format!"
+msgstr "XPM: Format kryesh i pasaktë!"
+
+#: ../src/common/xpmdecod.cpp:703
+#, c-format
+msgid "XPM: incorrect colour description in line %d"
+msgstr "XPM: përshkrim i pasaktë ngjyre në rreshtin %d"
+
+#: ../src/common/xpmdecod.cpp:715 ../src/common/xpmdecod.cpp:724
+#, c-format
+msgid "XPM: malformed colour definition '%s' at line %d!"
+msgstr "XPM: përcaktim i keqformuar ngjyre '%s' në rreshtin %d!"
+
+#: ../src/common/xpmdecod.cpp:754
+msgid "XPM: no colors left to use for mask!"
+msgstr "XPM: s’ka më ngjyra për t’u përdorur për maskë!"
+
+#: ../src/common/xpmdecod.cpp:781
+#, c-format
+msgid "XPM: truncated image data at line %d!"
+msgstr "XPM: të dhëna të cunguara figure në rreshtin %d!"
+
+#: ../src/common/xpmdecod.cpp:795
+msgid "XPM: Malformed pixel data!"
+msgstr "XPM: Të dhëna pikseli të keqformuara!"
+
+#: ../src/common/xti.cpp:492
+msgid "Illegal Parameter Count for Create Method"
+msgstr "Numër i Paligjshëm Parametri për Metodë Create"
+
+#: ../src/common/xti.cpp:504
+msgid "Illegal Parameter Count for ConstructObject Method"
+msgstr "Numër i Paligjshëm Parametri për Metodë ConstructObject"
+
+#: ../src/common/xtistrm.cpp:161
+#, c-format
+msgid "Create Parameter %s not found in declared RTTI Parameters"
+msgstr "S’u gjet Parametër Create %s te Parametra RTTI të deklaruar"
+
+#: ../src/common/xtistrm.cpp:290
+msgid "Illegal Object Class (Non-wxEvtHandler) as Event Source"
+msgstr "Klasë e Paligjshme Objektesh (Non-wxEvtHandler) si Burim Akti"
+
+#: ../src/common/xtistrm.cpp:313 ../src/common/xtixml.cpp:345
+#: ../src/common/xtixml.cpp:498
+msgid "Type must have enum - long conversion"
+msgstr "Lloji duhet të ketë shndërrim “enum - long”"
+
+#: ../src/common/xtistrm.cpp:400 ../src/common/xtistrm.cpp:415
+msgid "Invalid or Null Object ID passed to GetObjectClassInfo"
+msgstr "ID Objekti e pavlefshme ose Null dhënë te GetObjectClassInfo"
+
+#: ../src/common/xtistrm.cpp:405
+msgid "Unknown Object passed to GetObjectClassInfo"
+msgstr "Objekt i panjohur dhënë te GetObjectClassInfo"
+
+#: ../src/common/xtistrm.cpp:420
+msgid "Already Registered Object passed to SetObjectClassInfo"
+msgstr "SetObjectClassInfo-s iu kalua një Objekt tashmë i Regjistruar"
+
+#: ../src/common/xtistrm.cpp:430
+msgid "Invalid or Null Object ID passed to HasObjectClassInfo"
+msgstr "ID Objekti e pavlefshme ose Null dhënë te HasObjectClassInfo"
+
+#: ../src/common/xtistrm.cpp:460
+msgid "Passing a already registered object to SetObject"
+msgstr "SetObject-it po i kalohet një objekt tashmë të regjistruar"
+
+#: ../src/common/xtistrm.cpp:471
+msgid "Passing an unknown object to GetObject"
+msgstr "GetObject-it po i kalohet një objekt i panjohur"
+
+#: ../src/common/xtixml.cpp:229
+msgid "Forward hrefs are not supported"
+msgstr "Nuk mbulohen href-e përcjeIlëse"
+
+#: ../src/common/xtixml.cpp:247
+#, c-format
+msgid "unknown class %s"
+msgstr "klasë e panjohur %s"
+
+#: ../src/common/xtixml.cpp:253
+msgid "objects cannot have XML Text Nodes"
+msgstr "objektet s’mund të kenë Nyje Teksti XML"
+
+#: ../src/common/xtixml.cpp:258
+msgid "Objects must have an id attribute"
+msgstr "Objektet duhet të kenë një atribut id"
+
+#: ../src/common/xtixml.cpp:267
+#, c-format
+msgid "Doubly used id : %d"
+msgstr "Id i përdorur dy herë : %d"
+
+#: ../src/common/xtixml.cpp:316
+#, c-format
+msgid "Unknown Property %s"
+msgstr "Veti %s e Panjohur"
+
+#: ../src/common/xtixml.cpp:407
+msgid "A non empty collection must consist of 'element' nodes"
+msgstr "Një koleksion jo i zbrazët duhet të përbëhet nga nyje 'elementësh'"
+
+#: ../src/common/xtixml.cpp:478
+msgid "incorrect event handler string, missing dot"
+msgstr "varg i pasaktë trajtuesi aktesh, mungon një pikë"
+
+#: ../src/common/zipstrm.cpp:559
+msgid "can't re-initialize zlib deflate stream"
+msgstr "s’rigatitet dot rrjedhë zlib “deflate”"
+
+#: ../src/common/zipstrm.cpp:584
+msgid "can't re-initialize zlib inflate stream"
+msgstr "s’rigatitet dot rrjedhë zlib “inflate”"
+
+#: ../src/common/zipstrm.cpp:1023
+msgid "Ignoring malformed extra data record, ZIP file may be corrupted"
+msgstr ""
+"Po shpërfillet zë i keqformuar të dhënash ekstra, kartela ZIP mund të jetë e "
+"dëmtuar"
+
+#: ../src/common/zipstrm.cpp:1502
+msgid "assuming this is a multi-part zip concatenated"
+msgstr "po merret si e mirëqenë që kjo është zip shumëpjesësh i vargëzuar"
+
+#: ../src/common/zipstrm.cpp:1664
+msgid "invalid zip file"
+msgstr "kartelë zip e pavlefshme"
+
+#: ../src/common/zipstrm.cpp:1723
+msgid "can't find central directory in zip"
+msgstr "s’gjendet dot drejtori qendrore te zip-i"
+
+#: ../src/common/zipstrm.cpp:1812
+msgid "error reading zip central directory"
+msgstr "gabim në lexim drejtorie qendrore zip"
+
+#: ../src/common/zipstrm.cpp:1916
+msgid "error reading zip local header"
+msgstr "gabim në lexim kryesh vendore zip"
+
+#: ../src/common/zipstrm.cpp:1964
+msgid "bad zipfile offset to entry"
+msgstr ""
+
+#: ../src/common/zipstrm.cpp:2031
+msgid "stored file length not in Zip header"
+msgstr "gjatësi kartele jo e depozituar te kryet ZIP"
+
+#: ../src/common/zipstrm.cpp:2045 ../src/common/zipstrm.cpp:2362
+msgid "unsupported Zip compression method"
+msgstr "metodë e pambuluar ngjeshjeje Zip"
+
+#: ../src/common/zipstrm.cpp:2126
+#, c-format
+msgid "reading zip stream (entry %s): bad length"
+msgstr "po lexohet rrjedhë zip (zëri %s): gjatësi e gabuar"
+
+#: ../src/common/zipstrm.cpp:2131
+#, c-format
+msgid "reading zip stream (entry %s): bad crc"
+msgstr "po lexohet rrjedhë zip (zëri %s): crc e gabuar"
+
+#: ../src/common/zipstrm.cpp:2578
+#, c-format
+msgid "error writing zip entry '%s': file too large without ZIP64"
+msgstr "gabim në shkrim zëri zip '%s': kartelë shumë e madhe pa ZIP64"
+
+#: ../src/common/zipstrm.cpp:2585
+#, c-format
+msgid "error writing zip entry '%s': bad crc or length"
+msgstr "gabim në shkrim zëri zip '%s': crc ose gjatësi e gabuar"
+
+#: ../src/common/zstream.cpp:155 ../src/common/zstream.cpp:315
+msgid "Gzip not supported by this version of zlib"
+msgstr "Gzip-i s’mbulohet nga ky version i zlib-it"
+
+#: ../src/common/zstream.cpp:182
+msgid "Can't initialize zlib inflate stream."
+msgstr "S’gatitet dot rrjedhë zlib “inflate”."
+
+#: ../src/common/zstream.cpp:241
+msgid "Can't read inflate stream: unexpected EOF in underlying stream."
+msgstr "S’lexohet dot rrjedhë “inflate”: EOF i papritur nën rrjedhë."
+
+#: ../src/common/zstream.cpp:248 ../src/common/zstream.cpp:423
+#, c-format
+msgid "zlib error %d"
+msgstr "gabim zlib %d“"
+
+#: ../src/common/zstream.cpp:249
+#, c-format
+msgid "Can't read from inflate stream: %s"
+msgstr "S’lexohet dot prej rrjedhe “inflate”: %s"
+
+#: ../src/common/zstream.cpp:343
+msgid "Can't initialize zlib deflate stream."
+msgstr "S’gatitet dot rrjedhë zlib “deflate”."
+
+#: ../src/common/zstream.cpp:424
+#, c-format
+msgid "Can't write to deflate stream: %s"
+msgstr "S’shkruhet dot te rrjedhë “deflate”: %s"
+
+#: ../src/dfb/bitmap.cpp:633 ../src/dfb/bitmap.cpp:667
+#, c-format
+msgid "No bitmap handler for type %d defined."
+msgstr "S’ka trajtues bitmap të përcaktuar për llojin %d."
+
+#: ../src/dfb/evtloop.cpp:99
+msgid "Failed to read event from DirectFB pipe"
+msgstr "S’u arrit të lexohej akt prej kanali DirectFB"
+
+#: ../src/dfb/evtloop.cpp:171
+msgid "Failed to switch DirectFB pipe to non-blocking mode"
+msgstr "S’u arrit të kalohej kanali DirectFB në mënyrën jobllokuese"
+
+#: ../src/dfb/fontmgr.cpp:171
+#, c-format
+msgid "no fonts found in %s, using builtin font"
+msgstr "s’u gjetën shkronja te %s, po përdoren shkronja të brendshme"
+
+#: ../src/dfb/fontmgr.cpp:177
+msgid "Default font"
+msgstr "Shkronja parazgjedhje"
+
+#: ../src/dfb/fontmgr.cpp:195
+#, c-format
+msgid "Fonts index file %s disappeared while loading fonts."
+msgstr "Kartela tregues shkronjash %s u zhduk teksa ngarkoheshin shkronjat."
+
+#: ../src/dfb/wrapdfb.cpp:60
+#, c-format
+msgid "DirectFB error %d occurred."
+msgstr "Ndodhi gabim DirectFB %d."
+
+#: ../src/generic/aboutdlgg.cpp:69
+msgid "Developed by "
+msgstr "Zhvilluar prej "
+
+#: ../src/generic/aboutdlgg.cpp:72
+msgid "Documentation by "
+msgstr "Dokumentim nga "
+
+#: ../src/generic/aboutdlgg.cpp:75
+msgid "Graphics art by "
+msgstr "Art grafik nga "
+
+#: ../src/generic/aboutdlgg.cpp:78
+msgid "Translations by "
+msgstr "Përkthime nga "
+
+#: ../src/generic/aboutdlgg.cpp:133 ../src/osx/cocoa/aboutdlg.mm:83
+msgid "Version "
+msgstr "Version "
+
+#. TRANSLATORS: %s is application name
+#: ../src/generic/aboutdlgg.cpp:146 ../src/msw/aboutdlg.cpp:60
+#, c-format
+msgid "About %s"
+msgstr "Rreth %s"
+
+#: ../src/generic/aboutdlgg.cpp:181
+msgid "License"
+msgstr "Licencë"
+
+#: ../src/generic/aboutdlgg.cpp:184
+msgid "Developers"
+msgstr "Zhvillues"
+
+#: ../src/generic/aboutdlgg.cpp:188
+msgid "Documentation writers"
+msgstr "Shkrues dokumentimi"
+
+#: ../src/generic/aboutdlgg.cpp:192
+msgid "Artists"
+msgstr "Artistë"
+
+#: ../src/generic/aboutdlgg.cpp:196
+msgid "Translators"
+msgstr "Përkthyes"
+
+#: ../src/generic/animateg.cpp:125
+msgid "No handler found for animation type."
+msgstr "S’u gjet trajtues për llojin e animacionit."
+
+#: ../src/generic/animateg.cpp:133
+#, c-format
+msgid "No animation handler for type %ld defined."
+msgstr "S’ka trajtues animacioni të përcaktuar për llojin %ld."
+
+#: ../src/generic/animateg.cpp:145
+#, c-format
+msgid "Animation file is not of type %ld."
+msgstr "Kartela e animacionit s’është e llojit %ld."
+
+#: ../src/generic/colrdlgg.cpp:154 ../src/gtk/colordlg.cpp:47
+msgid "Choose colour"
+msgstr "Zgjidhni ngjyrë"
+
+#: ../src/generic/colrdlgg.cpp:357
+msgid "Red:"
+msgstr "E kuqe:"
+
+#: ../src/generic/colrdlgg.cpp:360
+msgid "Green:"
+msgstr "E gjelbër:"
+
+#: ../src/generic/colrdlgg.cpp:363
+msgid "Blue:"
+msgstr "Blu:"
+
+#: ../src/generic/colrdlgg.cpp:372
+msgid "Opacity:"
+msgstr "Patejdukshmëri:"
+
+#: ../src/generic/colrdlgg.cpp:384
+msgid "Add to custom colours"
+msgstr "Shtoje tek ngjyra vetjake"
+
+#: ../src/generic/creddlgg.cpp:56
+msgid "Username:"
+msgstr "Emër përdoruesi:"
+
+#: ../src/generic/creddlgg.cpp:63
+msgid "Password:"
+msgstr "Fjalëkalim:"
+
+#. TRANSLATORS: Name of Boolean true value
+#: ../src/generic/datavgen.cpp:1178
+msgid "true"
+msgstr "true"
+
+#. TRANSLATORS: Name of Boolean false value
+#: ../src/generic/datavgen.cpp:1180
+msgid "false"
+msgstr "false"
+
+#: ../src/generic/datavgen.cpp:6897
+#, c-format
+msgid "Row %i"
+msgstr "Rreshti %i"
+
+#. TRANSLATORS: Action for manipulating a tree control
+#: ../src/generic/datavgen.cpp:6987
+msgid "Collapse"
+msgstr "Tkurre"
+
+#. TRANSLATORS: Action for manipulating a tree control
+#: ../src/generic/datavgen.cpp:6990
+msgid "Expand"
+msgstr "Zgjeroje"
+
+#. TRANSLATORS: Name of data view control and number of rows
+#: ../src/generic/datavgen.cpp:7011
+#, c-format
+msgid "%s (%d items)"
+msgstr "%s (%d elementë)"
+
+#: ../src/generic/datavgen.cpp:7062
+#, c-format
+msgid "Column %u"
+msgstr "Shtylla %u"
+
+#. TRANSLATORS: Keystroke for manipulating a tree control
+#: ../src/generic/datavgen.cpp:7131 ../src/richtext/richtextbulletspage.cpp:189
+#: ../src/richtext/richtextbulletspage.cpp:192
+#: ../src/richtext/richtextbulletspage.cpp:193
+#: ../src/richtext/richtextliststylepage.cpp:252
+#: ../src/richtext/richtextliststylepage.cpp:255
+#: ../src/richtext/richtextliststylepage.cpp:256
+#: ../src/richtext/richtextsizepage.cpp:248
+msgid "Left"
+msgstr "Majtas"
+
+#. TRANSLATORS: Keystroke for manipulating a tree control
+#: ../src/generic/datavgen.cpp:7134 ../src/richtext/richtextbulletspage.cpp:191
+#: ../src/richtext/richtextliststylepage.cpp:254
+#: ../src/richtext/richtextsizepage.cpp:249
+msgid "Right"
+msgstr "Djathtas"
+
+#: ../src/generic/datectlg.cpp:90
+#, c-format
+msgid ""
+"\"%s\" is not in the expected date format, please enter it as e.g. \"%s\"."
+msgstr ""
+
+#: ../src/generic/datectlg.cpp:94
+#, fuzzy
+msgid "Invalid date"
+msgstr "PCX: figurë e pavlefshme"
+
+#: ../src/generic/dbgrptg.cpp:159
+#, c-format
+msgid "Open file \"%s\""
+msgstr "Hap kartelën “%s”"
+
+#: ../src/generic/dbgrptg.cpp:170
+#, c-format
+msgid "Enter command to open file \"%s\":"
+msgstr "Jepni një urdhër për hapjen e kartelës “%s”:"
+
+#: ../src/generic/dbgrptg.cpp:230
+msgid "Executable files (*.exe)|*.exe|"
+msgstr "Kartela të ekzekutueshmish (*.exe)|*.exe|"
+
+#: ../src/generic/dbgrptg.cpp:300
+#, c-format
+msgid "Debug report \"%s\""
+msgstr "Raport diagnostikimi “%s”"
+
+#: ../src/generic/dbgrptg.cpp:316
+msgid "A debug report has been generated in the directory\n"
+msgstr "Te drejtoria u prodhua një raport diagnostikimi\n"
+
+#: ../src/generic/dbgrptg.cpp:317
+msgid "The following debug report will be generated\n"
+msgstr "Do të prodhohet raporti vijues i diagnostikimit\n"
+
+#: ../src/generic/dbgrptg.cpp:321
+msgid ""
+"The report contains the files listed below. If any of these files contain "
+"private information,\n"
+"please uncheck them and they will be removed from the report.\n"
+msgstr ""
+"Raporti përmban kartelat e radhitura më poshtë. Nëse ndonjë prej tyre "
+"përmban\n"
+"të dhëna private, ju lutemi, hiquani shenjën dhe do të hiqen prej raportit.\n"
+
+#: ../src/generic/dbgrptg.cpp:323
+msgid ""
+"If you wish to suppress this debug report completely, please choose the "
+"\"Cancel\" button,\n"
+"but be warned that it may hinder improving the program, so if\n"
+"at all possible please do continue with the report generation.\n"
+msgstr ""
+"Nëse doni ta hiqni fare qafe këtë raport diagnostikimi, ju lutemi, zgjidhni "
+"butonin “Anuloje”,\n"
+"por kini parasysh që kjo mund të zvarrisë përmirësimin e programit, ndaj,\n"
+"në qoftë e mundur, ju lutemi të vazhdoni me prodhimin e raportit.\n"
+
+#: ../src/generic/dbgrptg.cpp:325
+msgid "              Thank you and we're sorry for the inconvenience!\n"
+msgstr "              Faleminderit dhe na ndjeni për këtë rast!\n"
+
+#: ../src/generic/dbgrptg.cpp:333
+msgid "&Debug report preview:"
+msgstr "Paraparjeje raporti &diagnostikimi:"
+
+#: ../src/generic/dbgrptg.cpp:339
+msgid "&View..."
+msgstr "&Shihni…"
+
+#: ../src/generic/dbgrptg.cpp:359
+msgid "&Notes:"
+msgstr "&Shënime:"
+
+#: ../src/generic/dbgrptg.cpp:361
+msgid ""
+"If you have any additional information pertaining to this bug\n"
+"report, please enter it here and it will be joined to it:"
+msgstr ""
+"Në paçi ndonjë të dhënë shtesë lidhur me këtë raport\n"
+"të mete, ju lutemi, jepeni këtu dhe do t’i bashkëngjitet:"
+
+#: ../src/generic/dcpsg.cpp:1627
+msgid "Cannot open file for PostScript printing!"
+msgstr "S’hapet dot kartelë për shtypje PostScript!"
+
+#: ../src/generic/dirctrlg.cpp:402
+msgid "Computer"
+msgstr "Kompjuter"
+
+#: ../src/generic/dirctrlg.cpp:404
+msgid "Sections"
+msgstr "Ndarje"
+
+#: ../src/generic/dirctrlg.cpp:482
+msgid "Home directory"
+msgstr "Drejtori krye"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/generic/dirctrlg.cpp:484 ../src/propgrid/advprops.cpp:811
+msgid "Desktop"
+msgstr "Desktop"
+
+#: ../src/generic/dirctrlg.cpp:528 ../src/generic/filectrlg.cpp:752
+msgid "Illegal directory name."
+msgstr "Emër i paligjshëm drejtorie."
+
+#: ../src/generic/dirctrlg.cpp:528 ../src/generic/dirctrlg.cpp:546
+#: ../src/generic/dirctrlg.cpp:557 ../src/generic/dirdlgg.cpp:317
+#: ../src/generic/filectrlg.cpp:638 ../src/generic/filectrlg.cpp:752
+#: ../src/generic/filectrlg.cpp:766 ../src/generic/filectrlg.cpp:782
+#: ../src/generic/filectrlg.cpp:1356 ../src/generic/filectrlg.cpp:1387
+#: ../src/generic/filedlgg.cpp:362 ../src/gtk/filedlg.cpp:76
+msgid "Error"
+msgstr "Gabim"
+
+#: ../src/generic/dirctrlg.cpp:546 ../src/generic/filectrlg.cpp:766
+msgid "File name exists already."
+msgstr "Ka një emër të tillë kartele."
+
+#: ../src/generic/dirctrlg.cpp:557 ../src/generic/dirdlgg.cpp:317
+#: ../src/generic/filectrlg.cpp:638 ../src/generic/filectrlg.cpp:782
+msgid "Operation not permitted."
+msgstr "Veprim i palejuar."
+
+#: ../src/generic/dirdlgg.cpp:107 ../src/generic/filedlgg.cpp:207
+msgid "Create new directory"
+msgstr "Krijoni drejtori të re"
+
+#: ../src/generic/dirdlgg.cpp:112 ../src/generic/filedlgg.cpp:203
+msgid "Go to home directory"
+msgstr "Shko te drejtoria krye"
+
+#: ../src/generic/dirdlgg.cpp:143
+msgid "Show &hidden directories"
+msgstr "Shfaq drejtori të &fshehura"
+
+#: ../src/generic/dirdlgg.cpp:196
+#, c-format
+msgid ""
+"The directory '%s' does not exist\n"
+"Create it now?"
+msgstr ""
+"Drejtoria '%s' s’ekziston\n"
+"Të krijohet tani?"
+
+#: ../src/generic/dirdlgg.cpp:198
+msgid "Directory does not exist"
+msgstr "Drejtoria s’ekziston"
+
+#: ../src/generic/dirdlgg.cpp:214
+#, c-format
+msgid ""
+"Failed to create directory '%s'\n"
+"(Do you have the required permissions?)"
+msgstr ""
+"S’u arrit të krijohej drejtori '%s'\n"
+"(I keni lejet e domosdoshme?)"
+
+#: ../src/generic/dirdlgg.cpp:216
+msgid "Error creating directory"
+msgstr "Gabim në krijim drejtorie"
+
+#: ../src/generic/dirdlgg.cpp:281
+msgid "You cannot add a new directory to this section."
+msgstr "S’mund të shtoni drejtori të re në këtë ndarje."
+
+#: ../src/generic/dirdlgg.cpp:282
+msgid "Create directory"
+msgstr "Krijoni drejtori"
+
+#: ../src/generic/dirdlgg.cpp:291 ../src/generic/dirdlgg.cpp:301
+#: ../src/generic/filectrlg.cpp:614 ../src/generic/filectrlg.cpp:623
+msgid "NewName"
+msgstr ""
+
+#: ../src/generic/editlbox.cpp:135
+msgid "Edit item"
+msgstr "Përpunoni objekt"
+
+#: ../src/generic/editlbox.cpp:143
+msgid "New item"
+msgstr "Objekt i ri"
+
+#: ../src/generic/editlbox.cpp:151
+msgid "Delete item"
+msgstr "Fshije objektin"
+
+#: ../src/generic/editlbox.cpp:159
+msgid "Move up"
+msgstr "Ngrije"
+
+#: ../src/generic/editlbox.cpp:164
+msgid "Move down"
+msgstr "Ule"
+
+#: ../src/generic/fdrepdlg.cpp:108
+msgid "Search for:"
+msgstr "Kërko për:"
+
+#: ../src/generic/fdrepdlg.cpp:120
+msgid "Replace with:"
+msgstr "Zëvendësoje me:"
+
+#: ../src/generic/fdrepdlg.cpp:140
+msgid "Whole word"
+msgstr "Tërë fjalën"
+
+#: ../src/generic/fdrepdlg.cpp:143
+msgid "Match case"
+msgstr "Siç është shkruajtur"
+
+#: ../src/generic/fdrepdlg.cpp:156
+msgid "Search direction"
+msgstr "Kah kërkimi"
+
+#: ../src/generic/fdrepdlg.cpp:175
+msgid "&Replace"
+msgstr "&Zëvendëso"
+
+#: ../src/generic/fdrepdlg.cpp:178
+msgid "Replace &all"
+msgstr "Zëvendësoji &krejt"
+
+#: ../src/generic/filectrlg.cpp:246 ../src/generic/filectrlg.cpp:269
+msgid "<DIR>"
+msgstr "<DIR>"
+
+#: ../src/generic/filectrlg.cpp:248 ../src/generic/filectrlg.cpp:271
+msgid "<LINK>"
+msgstr "<LINK>"
+
+#: ../src/generic/filectrlg.cpp:250 ../src/generic/filectrlg.cpp:273
+msgid "<DRIVE>"
+msgstr "<DRIVE>"
+
+#: ../src/generic/filectrlg.cpp:275
+#, c-format
+msgid "%ld byte"
+msgid_plural "%ld bytes"
+msgstr[0] "%ld bajt"
+msgstr[1] "%ld bajte"
+
+#: ../src/generic/filectrlg.cpp:420
+msgid "Name"
+msgstr "Emër"
+
+#: ../src/generic/filectrlg.cpp:421 ../src/richtext/richtextformatdlg.cpp:361
+#: ../src/richtext/richtextsizepage.cpp:298
+msgid "Size"
+msgstr "Madhësi"
+
+#: ../src/generic/filectrlg.cpp:422
+msgid "Type"
+msgstr "Lloj"
+
+#: ../src/generic/filectrlg.cpp:423
+msgid "Modified"
+msgstr "E ndryshuar"
+
+#: ../src/generic/filectrlg.cpp:426
+msgid "Permissions"
+msgstr "Leje"
+
+#: ../src/generic/filectrlg.cpp:429
+msgid "Attributes"
+msgstr "Atribute"
+
+#: ../src/generic/filectrlg.cpp:936
+msgid "Current directory:"
+msgstr "Drejtoria e çastit:"
+
+#: ../src/generic/filectrlg.cpp:979
+msgid "Show &hidden files"
+msgstr "Shfaq kartela të &fshehura"
+
+#: ../src/generic/filectrlg.cpp:1355
+msgid "Illegal file specification."
+msgstr "Specifikim i paligjshëm kartele."
+
+#: ../src/generic/filectrlg.cpp:1387
+msgid "Directory doesn't exist."
+msgstr "Drejtoria s’ekziston."
+
+#: ../src/generic/filedlgg.cpp:195
+msgid "View files as a list view"
+msgstr "Shihini kartelat nën pamjen listë"
+
+#: ../src/generic/filedlgg.cpp:197
+msgid "View files as a detailed view"
+msgstr "Shihini kartelat nën pamjen me hollësitë"
+
+#: ../src/generic/filedlgg.cpp:200
+msgid "Go to parent directory"
+msgstr "Shko te drejtoria mëmë"
+
+#: ../src/generic/filedlgg.cpp:351 ../src/gtk/filedlg.cpp:59
+#, c-format
+msgid "File '%s' already exists, do you really want to overwrite it?"
+msgstr "Ka tashmë një kartelë %s, doni vërtet të mbishkruhet?"
+
+#: ../src/generic/filedlgg.cpp:354 ../src/gtk/filedlg.cpp:62
+msgid "Confirm"
+msgstr "Ripohojeni"
+
+#: ../src/generic/filedlgg.cpp:362 ../src/gtk/filedlg.cpp:75
+msgid "Please choose an existing file."
+msgstr "Ju lutem, zgjidhni një kartelë ekzistuese."
+
+#: ../src/generic/filepickerg.cpp:64
+msgid "..."
+msgstr "…"
+
+#: ../src/generic/fontdlgg.cpp:76 ../src/richtext/richtextformatdlg.cpp:519
+msgid "ABCDEFGabcdefg12345"
+msgstr "ABCDEFGabcdefg12345"
+
+#: ../src/generic/fontdlgg.cpp:315
+msgid "Roman"
+msgstr "Roman"
+
+#: ../src/generic/fontdlgg.cpp:316
+msgid "Decorative"
+msgstr "Zbukures(e)"
+
+#: ../src/generic/fontdlgg.cpp:317
+msgid "Modern"
+msgstr "Moderne"
+
+#: ../src/generic/fontdlgg.cpp:318
+msgid "Script"
+msgstr "Programth"
+
+#: ../src/generic/fontdlgg.cpp:319
+msgid "Swiss"
+msgstr "Zvicerane"
+
+#: ../src/generic/fontdlgg.cpp:320
+msgid "Teletype"
+msgstr "Teleshkrim"
+
+#: ../src/generic/fontdlgg.cpp:321 ../src/generic/fontdlgg.cpp:324
+msgid "Normal"
+msgstr "Normale"
+
+#: ../src/generic/fontdlgg.cpp:323
+msgid "Slant"
+msgstr ""
+
+#: ../src/generic/fontdlgg.cpp:325
+msgid "Light"
+msgstr ""
+
+#: ../src/generic/fontdlgg.cpp:363
+msgid "&Font family:"
+msgstr "&Familje shkronjash:"
+
+#: ../src/generic/fontdlgg.cpp:367 ../src/generic/fontdlgg.cpp:369
+msgid "The font family."
+msgstr "Familja e shkronjave."
+
+#: ../src/generic/fontdlgg.cpp:374 ../src/richtext/richtextstylepage.cpp:105
+msgid "&Style:"
+msgstr "&Stil:"
+
+#: ../src/generic/fontdlgg.cpp:378 ../src/generic/fontdlgg.cpp:380
+msgid "The font style."
+msgstr "Stili i shkronjave."
+
+#: ../src/generic/fontdlgg.cpp:385
+msgid "&Weight:"
+msgstr "&Lartësi:"
+
+#: ../src/generic/fontdlgg.cpp:389 ../src/generic/fontdlgg.cpp:391
+msgid "The font weight."
+msgstr "Lartësia e shkronjave."
+
+#: ../src/generic/fontdlgg.cpp:399
+msgid "C&olour:"
+msgstr "N&gjyrë:"
+
+#: ../src/generic/fontdlgg.cpp:407 ../src/generic/fontdlgg.cpp:409
+msgid "The font colour."
+msgstr "Ngjyra e shkronjave."
+
+#: ../src/generic/fontdlgg.cpp:415
+msgid "&Point size:"
+msgstr "Madhësia në &pikë:"
+
+#: ../src/generic/fontdlgg.cpp:420 ../src/generic/fontdlgg.cpp:422
+#: ../src/generic/fontdlgg.cpp:426 ../src/generic/fontdlgg.cpp:428
+msgid "The font point size."
+msgstr "Madhësia e shkronjave në pikë."
+
+#: ../src/generic/fontdlgg.cpp:439 ../src/generic/fontdlgg.cpp:441
+msgid "Whether the font is underlined."
+msgstr "Nëse janë apo jo të nënvizuara shkronjat."
+
+#: ../src/generic/fontdlgg.cpp:448 ../src/html/helpwnd.cpp:1215
+msgid "Preview:"
+msgstr "Paraparje:"
+
+#: ../src/generic/fontdlgg.cpp:452 ../src/generic/fontdlgg.cpp:454
+msgid "Shows the font preview."
+msgstr "Shfaq paraparjen e shkronjave."
+
+#: ../src/generic/fontdlgg.cpp:464 ../src/generic/fontdlgg.cpp:483
+msgid "Click to cancel the font selection."
+msgstr "Klikoni që të anulohet përzgjedhjeje shkronjash."
+
+#: ../src/generic/fontdlgg.cpp:469 ../src/generic/fontdlgg.cpp:471
+#: ../src/generic/fontdlgg.cpp:476 ../src/generic/fontdlgg.cpp:478
+msgid "Click to confirm the font selection."
+msgstr "Klikoni për ripohim përzgjedhjeje shkronjash."
+
+#: ../src/generic/fontpickerg.cpp:50 ../src/gtk/fontdlg.cpp:77
+msgid "Choose font"
+msgstr "Zgjidhni shkronja"
+
+#: ../src/generic/grid.cpp:6542
+msgid ""
+"Error copying grid to the clipboard. Either selected cells were not "
+"contiguous or no cell was selected."
+msgstr ""
+
+#: ../src/generic/grid.cpp:12739
+#, fuzzy
+msgid "Grid Corner"
+msgstr "Cep"
+
+#: ../src/generic/grid.cpp:12741
+#, fuzzy, c-format
+msgid "Column %s Header"
+msgstr "Shtylla %u"
+
+#: ../src/generic/grid.cpp:12743
+#, c-format
+msgid "Row %s Header"
+msgstr ""
+
+#: ../src/generic/grid.cpp:12745
+#, fuzzy, c-format
+msgid "Column %s: %s"
+msgstr "Shtylla %u"
+
+#: ../src/generic/grid.cpp:12749
+#, fuzzy, c-format
+msgid "Row %s: %s"
+msgstr "Rreshti %i"
+
+#: ../src/generic/grid.cpp:12753
+#, c-format
+msgid "Row %s, Column %s: %s"
+msgstr ""
+
+#: ../src/generic/helpext.cpp:257
+#, c-format
+msgid "Help directory \"%s\" not found."
+msgstr "S’u gjet drejtori ndihme “%s”."
+
+#: ../src/generic/helpext.cpp:265
+#, c-format
+msgid "Help file \"%s\" not found."
+msgstr "S’u gjet kartelë ndihme “%s”."
+
+#: ../src/generic/helpext.cpp:284
+#, c-format
+msgid "Line %lu of map file \"%s\" has invalid syntax, skipped."
+msgstr ""
+"Rreshti %lu i kartelës së hartës “%s” pat sintaksë të pavlefshme, u "
+"anashkalua."
+
+#: ../src/generic/helpext.cpp:292
+#, c-format
+msgid "No valid mappings found in the file \"%s\"."
+msgstr "S’u gjetën përshoqërime të vlefshme te kartela “%s”."
+
+#: ../src/generic/helpext.cpp:435
+msgid "No entries found."
+msgstr "S’u gjetën zëra."
+
+#: ../src/generic/helpext.cpp:444 ../src/generic/helpext.cpp:445
+msgid "Help Index"
+msgstr "Tregues i Ndihmës"
+
+#: ../src/generic/helpext.cpp:448
+msgid "Relevant entries:"
+msgstr "Zëra me peshë:"
+
+#: ../src/generic/helpext.cpp:449
+msgid "Entries found"
+msgstr "U gjetën zëra"
+
+#: ../src/generic/hyperlinkg.cpp:170
+msgid "&Copy URL"
+msgstr "&Kopjoji URL-në"
+
+#: ../src/generic/infobar.cpp:119
+msgid "Hide this notification message."
+msgstr "Fshihe këtë mesazh njoftimi."
+
+#. TRANSLATORS: %s will be either the application name or "Application"
+#: ../src/generic/logg.cpp:257
+#, c-format
+msgid "%s Error"
+msgstr "Gabim %s"
+
+#. TRANSLATORS: %s will be either the application name or "Application"
+#: ../src/generic/logg.cpp:263
+#, c-format
+msgid "%s Warning"
+msgstr "Sinjalizim %s"
+
+#. TRANSLATORS: %s will be either the application name or "Application"
+#: ../src/generic/logg.cpp:273
+#, c-format
+msgid "%s Information"
+msgstr "Të dhëna %s"
+
+#: ../src/generic/logg.cpp:276
+msgid "Application"
+msgstr "Aplikacion"
+
+#: ../src/generic/logg.cpp:549
+msgid "Save log contents to file"
+msgstr "Ruaj lëndë regjistrimi te kartelë"
+
+#: ../src/generic/logg.cpp:551
+msgid "C&lear"
+msgstr "Spa&stroje"
+
+#: ../src/generic/logg.cpp:551
+msgid "Clear the log contents"
+msgstr "Spastro lëndën e regjistrit"
+
+#: ../src/generic/logg.cpp:553
+msgid "Close this window"
+msgstr "Mbyll këtë dritare"
+
+#: ../src/generic/logg.cpp:554
+msgid "&Log"
+msgstr "&Regjistrim"
+
+#: ../src/generic/logg.cpp:610 ../src/generic/logg.cpp:992
+msgid "Can't save log contents to file."
+msgstr "S’ruhet dot lëndë regjistrimi te kartelë."
+
+#: ../src/generic/logg.cpp:613
+#, c-format
+msgid "Log saved to the file '%s'."
+msgstr "Regjistrimi u ruajt te kartela '%s'."
+
+#: ../src/generic/logg.cpp:719
+msgid "&Details"
+msgstr "&Hollësi"
+
+#: ../src/generic/logg.cpp:972
+msgid "Failed to copy dialog contents to the clipboard."
+msgstr "S’u arrit të kopjohej në të papastër lënda e dialogut."
+
+#: ../src/generic/logg.cpp:1022
+#, c-format
+msgid "Append log to file '%s' (choosing [No] will overwrite it)?"
+msgstr ""
+"Të shtohet regjistrimi te kartela '%s' (zgjedhja e [Jo]-së do ta "
+"mbishkruajë)?"
+
+#: ../src/generic/logg.cpp:1024
+msgid "Question"
+msgstr "Pyetje"
+
+#: ../src/generic/logg.cpp:1038
+msgid "invalid message box return value"
+msgstr ""
+
+#: ../src/generic/notifmsgg.cpp:129
+msgid "Notice"
+msgstr "Shënim"
+
+#: ../src/generic/preferencesg.cpp:118
+#, c-format
+msgid "%s Preferences"
+msgstr "Parapëlqime mbi %s"
+
+#: ../src/generic/printps.cpp:143
+msgid "Printing..."
+msgstr "Po shtypet…"
+
+#: ../src/generic/printps.cpp:160 ../src/gtk/print.cpp:1076
+#: ../src/msw/printwin.cpp:235
+msgid "Could not start printing."
+msgstr "S’u nis dot shtypje."
+
+#: ../src/generic/printps.cpp:183
+#, c-format
+msgid "Printing page %d..."
+msgstr "Po shtypet faqja %d…"
+
+#: ../src/generic/prntdlgg.cpp:171
+msgid "Printer options"
+msgstr "Mundësi shtypësi"
+
+#: ../src/generic/prntdlgg.cpp:176
+msgid "Print to File"
+msgstr "Shtype në Kartelë"
+
+#: ../src/generic/prntdlgg.cpp:179
+msgid "Setup..."
+msgstr "Rregullim…"
+
+#: ../src/generic/prntdlgg.cpp:187
+msgid "Printer:"
+msgstr "Shtypës:"
+
+#: ../src/generic/prntdlgg.cpp:195
+msgid "Status:"
+msgstr "Gjendje:"
+
+#: ../src/generic/prntdlgg.cpp:206
+msgid "All"
+msgstr "Krejt"
+
+#: ../src/generic/prntdlgg.cpp:207
+msgid "Pages"
+msgstr "Faqe"
+
+#: ../src/generic/prntdlgg.cpp:215
+msgid "Print Range"
+msgstr "Interval Shtypjeje"
+
+#: ../src/generic/prntdlgg.cpp:229
+msgid "From:"
+msgstr "Prej:"
+
+#: ../src/generic/prntdlgg.cpp:233
+msgid "To:"
+msgstr "Për:"
+
+#: ../src/generic/prntdlgg.cpp:238
+msgid "Copies:"
+msgstr "Kopje:"
+
+#: ../src/generic/prntdlgg.cpp:288
+msgid "PostScript file"
+msgstr "Kartelë PostScript"
+
+#: ../src/generic/prntdlgg.cpp:439
+msgid "Print Setup"
+msgstr "Rregullim Shtypjeje"
+
+#: ../src/generic/prntdlgg.cpp:483
+msgid "Printer"
+msgstr "Shtypës"
+
+#: ../src/generic/prntdlgg.cpp:501
+msgid "Default printer"
+msgstr "Shtypës parazgjedhje"
+
+#: ../src/generic/prntdlgg.cpp:595 ../src/generic/prntdlgg.cpp:782
+#: ../src/generic/prntdlgg.cpp:822 ../src/generic/prntdlgg.cpp:835
+#: ../src/generic/prntdlgg.cpp:1031 ../src/generic/prntdlgg.cpp:1036
+msgid "Paper size"
+msgstr "Madhësi letre"
+
+#: ../src/generic/prntdlgg.cpp:604 ../src/generic/prntdlgg.cpp:847
+msgid "Portrait"
+msgstr "Portret"
+
+#: ../src/generic/prntdlgg.cpp:605 ../src/generic/prntdlgg.cpp:848
+msgid "Landscape"
+msgstr "Së gjeri"
+
+#: ../src/generic/prntdlgg.cpp:607 ../src/generic/prntdlgg.cpp:849
+msgid "Orientation"
+msgstr "Drejtim"
+
+#: ../src/generic/prntdlgg.cpp:610
+msgid "Options"
+msgstr "Mundësi"
+
+#: ../src/generic/prntdlgg.cpp:612
+msgid "Print in colour"
+msgstr "Shtyp me ngjyra"
+
+#: ../src/generic/prntdlgg.cpp:621
+msgid "Print spooling"
+msgstr ""
+
+#: ../src/generic/prntdlgg.cpp:623
+msgid "Printer command:"
+msgstr "Urdhër shtypësi:"
+
+#: ../src/generic/prntdlgg.cpp:631
+msgid "Printer options:"
+msgstr "Mundësi shtypësi:"
+
+#: ../src/generic/prntdlgg.cpp:860
+msgid "Left margin (mm):"
+msgstr "Mënjanë majtas (mm):"
+
+#: ../src/generic/prntdlgg.cpp:861
+msgid "Top margin (mm):"
+msgstr "Mënjanë në krye (mm):"
+
+#: ../src/generic/prntdlgg.cpp:872
+msgid "Right margin (mm):"
+msgstr "Mënjanë djathtas (mm):"
+
+#: ../src/generic/prntdlgg.cpp:873
+msgid "Bottom margin (mm):"
+msgstr "Mënjanë fundi (mm):"
+
+#: ../src/generic/prntdlgg.cpp:896
+msgid "Printer..."
+msgstr "Shtypës…"
+
+#: ../src/generic/progdlgg.cpp:246
+msgid "&Skip"
+msgstr "&Anashkaloje"
+
+#: ../src/generic/progdlgg.cpp:347 ../src/generic/progdlgg.cpp:626
+msgid "Unknown"
+msgstr "I panjohur"
+
+#: ../src/generic/progdlgg.cpp:451 ../src/msw/progdlg.cpp:526
+msgid "Done."
+msgstr "U bë."
+
+#: ../src/generic/srchctlg.cpp:55 ../src/gtk/srchctrl.cpp:206
+#: ../src/html/helpwnd.cpp:530 ../src/html/helpwnd.cpp:545
+msgid "Search"
+msgstr "Kërko"
+
+#: ../src/generic/tabg.cpp:1026
+msgid "Could not find tab for id"
+msgstr "S’u gjet dot skedë për id"
+
+#: ../src/generic/tipdlg.cpp:136
+msgid "Tips not available, sorry!"
+msgstr "Na ndjeni, nuk ka ndihmëza të gatshme!"
+
+#: ../src/generic/tipdlg.cpp:197
+msgid "Tip of the Day"
+msgstr "Ndihmëza e Ditës"
+
+#: ../src/generic/tipdlg.cpp:207
+msgid "Did you know..."
+msgstr "E dinit se…"
+
+#: ../src/generic/tipdlg.cpp:232
+msgid "&Show tips at startup"
+msgstr "&Shfaq ndihmëza në nisje"
+
+#: ../src/generic/tipdlg.cpp:236
+msgid "&Next Tip"
+msgstr "Ndihmëza &Pasuese"
+
+#: ../src/generic/wizard.cpp:411
+msgid "&Next >"
+msgstr "&Pasuesi >"
+
+#: ../src/generic/wizard.cpp:412
+msgid "&Finish"
+msgstr "&Përfundoje"
+
+#: ../src/generic/wizard.cpp:420
+msgid "< &Back"
+msgstr "< &Mbrapsht"
+
+#: ../src/gtk/aboutdlg.cpp:204
+msgid "translator-credits"
+msgstr "kredite përkthyesish"
+
+#: ../src/gtk/app.cpp:517
+msgid ""
+"WARNING: using XIM input method is unsupported and may result in problems "
+"with input handling and flickering. Consider unsetting GTK_IM_MODULE or "
+"setting to \"ibus\"."
+msgstr ""
+"KUJDES: nuk mbulohet përdorimi i metodës XIM për dhënie dhe mund të sjellë "
+"probleme me trajtimin e çka jepet dhe dridhje të figurës. Shihni mundësinë e "
+"çaktivizimit të GTK_IM_MODULE, ose vënien e tij si “ibus”."
+
+#: ../src/gtk/app.cpp:569
+msgid "Unable to initialize GTK+, is DISPLAY set properly?"
+msgstr "S’arrihet të gatitet GTK+, a është caktuar saktë DISPLAY?"
+
+#: ../src/gtk/filedlg.cpp:89 ../src/gtk/filepicker.cpp:255
+#, c-format
+msgid "Changing current directory to \"%s\" failed"
+msgstr "S’u arrit të ndryshohej drejtoria e tanishme si “%s”"
+
+#: ../src/gtk/font.cpp:548
+msgid ""
+"Using private fonts is not supported on this system: Pango library is too "
+"old, 1.38 or later required."
+msgstr ""
+"Në këtë sistem s’mbulohet përdorimi i shkronjave private: biblioteka Pango "
+"është shumë e vjetër, lypset 1.38 ose i mëvonshëm."
+
+#: ../src/gtk/font.cpp:558
+msgid "Failed to create font configuration object."
+msgstr "S’u arrit të krijohej objekt formësimi shkronjash."
+
+#: ../src/gtk/font.cpp:568
+#, c-format
+msgid "Failed to add custom font \"%s\"."
+msgstr "S’u arrit të shtohen shkronja vetjake “%s”."
+
+#: ../src/gtk/font.cpp:576
+msgid "Failed to register font configuration using private fonts."
+msgstr ""
+"S’u arrit të regjistrohej formësim shkronjash që përdor shkronja private."
+
+#: ../src/gtk/glcanvas.cpp:117 ../src/gtk/glcanvas.cpp:132
+msgid "Fatal Error"
+msgstr "Gabim Fatal"
+
+#: ../src/gtk/glcanvas.cpp:117
+msgid ""
+"This program wasn't compiled with EGL support required under Wayland, "
+"either\n"
+"install EGL libraries and rebuild or run it under X11 backend by setting\n"
+"environment variable GDK_BACKEND=x11 before starting your program."
+msgstr ""
+"Ky program s’është përpiluar me mbulim për EGL, i domosdoshëm nën Wayland, "
+"ose\n"
+"instaloni bibliotekat EGL dhe rimontojeni, ose xhirojeni nën X11, duke e "
+"vënë\n"
+"ndryshoren e mjedisit GDK_BACKEND=x11 para se të nisni programin tuaj."
+
+#: ../src/gtk/glcanvas.cpp:132
+msgid ""
+"wxGLCanvas is only supported on Wayland and X11 currently.  You may be able "
+"to\n"
+"work around this by setting environment variable GDK_BACKEND=x11 before\n"
+"starting your program."
+msgstr ""
+"wxGLCanvas aktualisht mbulohet vetëm në Wayland dhe X11.  Mund të jeni në "
+"gjendje\n"
+"ta zgjidhni këtë punë duke ujdisur ndryshoren e mjedisit GDK_BACKEND=x11 "
+"para se\n"
+"të nisni programin tuaj."
+
+#: ../src/gtk/mdi.cpp:433
+msgid "MDI child"
+msgstr "Pjellë MDI"
+
+#: ../src/gtk/power.cpp:188
+#, fuzzy, c-format
+msgid "Failed to open D-Bus connection to the login manager: %s"
+msgstr "S’u arrit të krijohej lidhje te shërbyes '%s' mbi temën '%s'"
+
+#: ../src/gtk/power.cpp:214
+#, fuzzy
+msgid "wxWidgets application"
+msgstr "Fshihe Aplikacionin"
+
+#: ../src/gtk/power.cpp:226
+msgid "Application needs to keep running"
+msgstr ""
+
+#: ../src/gtk/power.cpp:233
+msgid "Clean up before suspend"
+msgstr ""
+
+#: ../src/gtk/power.cpp:259
+#, fuzzy, c-format
+msgid "Failed to inhibit sleep: %s"
+msgstr "S’u arrit të nisej lidhje “dialup”: %s"
+
+#: ../src/gtk/power.cpp:265
+msgid "Unexpected response to D-Bus \"Inhibit\" request."
+msgstr ""
+
+#: ../src/gtk/print.cpp:218
+msgid "Custom size"
+msgstr "Madhësi vetjake"
+
+#: ../src/gtk/print.cpp:752
+#, fuzzy, c-format
+msgid "Error while printing: %s"
+msgstr "Gabim teksa shtypej: "
+
+#: ../src/gtk/print.cpp:816
+msgid "Page Setup"
+msgstr "Rregullim Faqeje"
+
+#: ../src/gtk/webview_webkit.cpp:932
+msgid "Retrieving JavaScript script output is not supported with WebKit v1"
+msgstr "Me WebKit v1 s’mbulohet marrje output-i programthi JavaScript"
+
+#: ../src/gtk/webview_webkit2.cpp:1098
+msgid ""
+"Setting proxy is not supported by WebKit, at least version 2.16 is required."
+msgstr ""
+
+#: ../src/gtk/webview_webkit2.cpp:1104
+msgid "This program was compiled without support for setting WebKit proxy."
+msgstr ""
+
+#: ../src/gtk/window.cpp:6289
+msgid ""
+"GTK+ installed on this machine is too old to support screen compositing, "
+"please install GTK+ 2.12 or later."
+msgstr ""
+"GTK+ i instaluar në këtë makinë është shumë i vjetër për të mbuluar hartim "
+"skenash, ju lutemi, instaloni GTK+ 2.12 ose të mëvonshëm."
+
+#: ../src/gtk/window.cpp:6307
+msgid ""
+"Compositing not supported by this system, please enable it in your Window "
+"Manager."
+msgstr ""
+"Hartimi nuk mbulohet nga ky sistem, ju lutemi, aktivizojeni te Window "
+"Manager juaj."
+
+#: ../src/gtk/window.cpp:6318
+msgid ""
+"This program was compiled with a too old version of GTK+, please rebuild "
+"with GTK+ 2.12 or newer."
+msgstr ""
+"Ky program qe përpiluar me një version shumë të vjetër të GTK+, ju lutemi, "
+"rimontojeni me GTK+ 2.12 ose më të ri."
+
+#: ../src/html/chm.cpp:138
+#, c-format
+msgid "Failed to open CHM archive '%s'."
+msgstr "S’u arrit të hapej arkiv CHM '%s'."
+
+#: ../src/html/chm.cpp:270
+#, c-format
+msgid "Could not extract %s into %s: %s"
+msgstr "S’u përftua dot %s te %s: %s"
+
+#: ../src/html/chm.cpp:324
+msgid "no error"
+msgstr "pa gabim"
+
+#: ../src/html/chm.cpp:326
+msgid "bad arguments to library function"
+msgstr "argumente të gabuar në funksion librarie"
+
+#: ../src/html/chm.cpp:328
+msgid "error opening file"
+msgstr "gabim në hapje kartele"
+
+#: ../src/html/chm.cpp:330
+msgid "read error"
+msgstr "gabim leximi"
+
+#: ../src/html/chm.cpp:332
+msgid "write error"
+msgstr "gabim shkrimi"
+
+#: ../src/html/chm.cpp:334
+msgid "seek error"
+msgstr "gabim kërkimi"
+
+#: ../src/html/chm.cpp:338
+msgid "bad signature"
+msgstr "nënshkrim i gabuar"
+
+#: ../src/html/chm.cpp:340
+msgid "error in data format"
+msgstr "gabim në format të dhënash"
+
+#: ../src/html/chm.cpp:342
+msgid "checksum error"
+msgstr "gabim checksum-i"
+
+#: ../src/html/chm.cpp:344
+msgid "compression error"
+msgstr "gabim ngjeshjeje"
+
+#: ../src/html/chm.cpp:346
+msgid "decompression error"
+msgstr "gabim çngjeshjeje"
+
+#: ../src/html/chm.cpp:437
+#, c-format
+msgid "Could not locate file '%s'."
+msgstr "S’u lokalizua dot kartelë '%s'."
+
+#: ../src/html/chm.cpp:711
+#, c-format
+msgid "Could not create temporary file '%s'"
+msgstr "S’u krijua dot kartelë të përkohshme '%s'"
+
+#: ../src/html/chm.cpp:718
+#, c-format
+msgid "Extraction of '%s' into '%s' failed."
+msgstr "Dështoi përftimi i '%s' te '%s'."
+
+#: ../src/html/chm.cpp:806 ../src/html/chm.cpp:863
+msgid "CHM handler currently supports only local files!"
+msgstr "Hëpërhë, trajtuesi CHM, mbulon vetëm kartela vendore!"
+
+#: ../src/html/chm.cpp:827
+msgid "Link contained '//', converted to absolute link."
+msgstr "Lidhja përmbante '//', u shndërrua në lidhje absolute."
+
+#: ../src/html/helpctrl.cpp:59
+#, c-format
+msgid "Help: %s"
+msgstr "Ndihmë: %s"
+
+#: ../src/html/helpctrl.cpp:155
+#, c-format
+msgid "Adding book %s"
+msgstr "Po shtohet libër %s"
+
+#: ../src/html/helpdata.cpp:295
+#, c-format
+msgid "Cannot open contents file: %s"
+msgstr "S’hapet dot kartelë lëndësh: %s"
+
+#: ../src/html/helpdata.cpp:309
+#, c-format
+msgid "Cannot open index file: %s"
+msgstr "S’hapet dot kartelë treguesi: %s"
+
+#: ../src/html/helpdata.cpp:643
+msgid "noname"
+msgstr "paemër"
+
+#: ../src/html/helpdata.cpp:652
+#, c-format
+msgid "Cannot open HTML help book: %s"
+msgstr "S’hapet dot libër HTML ndihme: %s"
+
+#: ../src/html/helpwnd.cpp:315
+msgid "Displays help as you browse the books on the left."
+msgstr "Shfaq ndihmën teksa shfletoni librat në të majtë."
+
+#: ../src/html/helpwnd.cpp:411 ../src/html/helpwnd.cpp:1100
+#: ../src/html/helpwnd.cpp:1735
+msgid "(bookmarks)"
+msgstr "(faqerojtës)"
+
+#: ../src/html/helpwnd.cpp:424
+msgid "Add current page to bookmarks"
+msgstr "Shto te faqerojtësit faqen e çastit"
+
+#: ../src/html/helpwnd.cpp:425
+msgid "Remove current page from bookmarks"
+msgstr "Hiq prej faqerojtësish faqen e tanishme"
+
+#: ../src/html/helpwnd.cpp:470
+msgid "Contents"
+msgstr "Lëndë"
+
+#: ../src/html/helpwnd.cpp:485
+msgid "Find"
+msgstr "Gjej"
+
+#: ../src/html/helpwnd.cpp:487
+msgid "Show all"
+msgstr "Shfaqi krejt"
+
+#: ../src/html/helpwnd.cpp:497
+msgid ""
+"Display all index items that contain given substring. Search is case "
+"insensitive."
+msgstr ""
+"Shfaq tërë zërat e treguesit që përmbajnë nënvargun e dhënë. Kërkim ashtu si "
+"është shkruar."
+
+#: ../src/html/helpwnd.cpp:498
+msgid "Show all items in index"
+msgstr "Shfaq tërë objektet në tregues"
+
+#: ../src/html/helpwnd.cpp:528
+msgid "Case sensitive"
+msgstr "Siç është shkruajtur"
+
+#: ../src/html/helpwnd.cpp:529
+msgid "Whole words only"
+msgstr "Vetëm fjalë të plota"
+
+#: ../src/html/helpwnd.cpp:532
+msgid ""
+"Search contents of help book(s) for all occurrences of the text you typed "
+"above"
+msgstr ""
+"Kërko në lëndën e librit(ve) të ndihmës për krejt hasjet e tekstit që "
+"shtypët më sipër"
+
+#: ../src/html/helpwnd.cpp:653
+msgid "Show/hide navigation panel"
+msgstr "Shfaq/fshih panel lëvizjeje"
+
+#: ../src/html/helpwnd.cpp:655
+msgid "Go back"
+msgstr "Shko prapa"
+
+#: ../src/html/helpwnd.cpp:656
+msgid "Go forward"
+msgstr "Shko përpara"
+
+#: ../src/html/helpwnd.cpp:658
+msgid "Go one level up in document hierarchy"
+msgstr "Shko një shkallë më sipër në hierarki dokumenti"
+
+#: ../src/html/helpwnd.cpp:666 ../src/html/helpwnd.cpp:1547
+msgid "Open HTML document"
+msgstr "Hap dokument HTML"
+
+#: ../src/html/helpwnd.cpp:670
+msgid "Print this page"
+msgstr "Shtyp këtë faqe"
+
+#: ../src/html/helpwnd.cpp:674
+msgid "Display options dialog"
+msgstr "Dialog mundësish paraqitjeje"
+
+#: ../src/html/helpwnd.cpp:795
+msgid "Please choose the page to display:"
+msgstr "Ju lutemi, zgjidhni faqen për shfaqje:"
+
+#: ../src/html/helpwnd.cpp:796
+msgid "Help Topics"
+msgstr "Tema Ndihme"
+
+#: ../src/html/helpwnd.cpp:852
+msgid "Searching..."
+msgstr "Po kërkohet…"
+
+#: ../src/html/helpwnd.cpp:853
+msgid "No matching page found yet"
+msgstr "Ende s’u gjet faqe me përputhje"
+
+#: ../src/html/helpwnd.cpp:870
+#, c-format
+msgid "Found %i matches"
+msgstr "U gjetën %i përputhje"
+
+#: ../src/html/helpwnd.cpp:958
+msgid "(Help)"
+msgstr "(Ndihmë)"
+
+#: ../src/html/helpwnd.cpp:1026
+#, c-format
+msgid "%d of %lu"
+msgstr "%d nga %lu"
+
+#: ../src/html/helpwnd.cpp:1028
+#, c-format
+msgid "%lu of %lu"
+msgstr "%lu nga %lu"
+
+#: ../src/html/helpwnd.cpp:1047
+msgid "Search in all books"
+msgstr "Kërko në tërë librat"
+
+#: ../src/html/helpwnd.cpp:1193
+msgid "Help Browser Options"
+msgstr "Mundësi Shfletuesi Ndihme"
+
+#: ../src/html/helpwnd.cpp:1198
+msgid "Normal font:"
+msgstr "Shkronja normale:"
+
+#: ../src/html/helpwnd.cpp:1199
+msgid "Fixed font:"
+msgstr "Shkronja të fiksuara:"
+
+#: ../src/html/helpwnd.cpp:1200
+msgid "Font size:"
+msgstr "Madhësi shkronjash:"
+
+#: ../src/html/helpwnd.cpp:1245
+msgid "font size"
+msgstr "madhësi shkronjash"
+
+#: ../src/html/helpwnd.cpp:1256
+msgid "Normal face<br>and <u>underlined</u>. "
+msgstr "Normale<br>dhe <u>të nënvijëzuara</u>. "
+
+#: ../src/html/helpwnd.cpp:1257
+msgid "<i>Italic face.</i> "
+msgstr "<i>Shkronja të pjerrëta.</i> "
+
+#: ../src/html/helpwnd.cpp:1258
+msgid "<b>Bold face.</b> "
+msgstr "<b>Shkronja të trasha.</b> "
+
+#: ../src/html/helpwnd.cpp:1259
+msgid "<b><i>Bold italic face.</i></b><br>"
+msgstr "<b><i>Shkronja të pjerrëta të trasha.</i></b><br>"
+
+#: ../src/html/helpwnd.cpp:1262
+msgid "Fixed size face.<br> <b>bold</b> <i>italic</i> "
+msgstr ""
+"Shkronja me madhësi të fiksuar.<br> <b>të trasha</b> <i>të pjerrëta</i> "
+
+#: ../src/html/helpwnd.cpp:1263
+msgid "<b><i>bold italic <u>underlined</u></i></b><br>"
+msgstr "<b><i>të pjerrëta të trasha <u>të nënvizuara</u></i></b><br>"
+
+#: ../src/html/helpwnd.cpp:1524
+msgid "Help Printing"
+msgstr "Ndihmë për Shtypjen"
+
+#: ../src/html/helpwnd.cpp:1527
+msgid "Cannot print empty page."
+msgstr "S’shtypet dot faqe e zbrazët."
+
+#: ../src/html/helpwnd.cpp:1540
+msgid "HTML files (*.html;*.htm)|*.html;*.htm|"
+msgstr "Kartela HTML (*.html;*.htm)|*.html;*.htm|"
+
+#: ../src/html/helpwnd.cpp:1541
+msgid "Help books (*.htb)|*.htb|Help books (*.zip)|*.zip|"
+msgstr "Libra ndihme (*.htb)|*.htb|Libra ndihme (*.zip)|*.zip|"
+
+#: ../src/html/helpwnd.cpp:1542
+msgid "HTML Help Project (*.hhp)|*.hhp|"
+msgstr "Projekt Ndihme HTML (*.hhp)|*.hhp|"
+
+#: ../src/html/helpwnd.cpp:1544
+msgid "Compressed HTML Help file (*.chm)|*.chm|"
+msgstr "Kartelë e ngjeshur HTML ndihme HTML (*.chm)|*.chm|"
+
+#: ../src/html/helpwnd.cpp:1671
+#, c-format
+msgid "%i of %u"
+msgstr "%i nga %u"
+
+#: ../src/html/helpwnd.cpp:1709
+#, c-format
+msgid "%u of %u"
+msgstr "%u nga %u"
+
+#: ../src/html/htmlfilt.cpp:134
+#, c-format
+msgid "Cannot open HTML document: %s"
+msgstr "S’hapet dot dokument HTML: %s"
+
+#: ../src/html/htmlwin.cpp:599
+msgid "Connecting..."
+msgstr "Po lidhet…"
+
+#: ../src/html/htmlwin.cpp:616
+#, c-format
+msgid "Unable to open requested HTML document: %s"
+msgstr "S’arrihet të hapet dokumenti HTML i kërkuar: %s"
+
+#: ../src/html/htmlwin.cpp:630
+msgid "Loading : "
+msgstr "Po ngarkohert : "
+
+#: ../src/html/htmlwin.cpp:673
+msgid "Done"
+msgstr "U bë"
+
+#: ../src/html/htmlwin.cpp:723
+#, c-format
+msgid "HTML anchor %s does not exist."
+msgstr "Spiranca HTML %s s’ekziston."
+
+#: ../src/html/htmlwin.cpp:1057
+#, c-format
+msgid "Copied to clipboard:\"%s\""
+msgstr "U kopjua në të papastër:“%s”"
+
+#: ../src/html/htmprint.cpp:269
+msgid ""
+"This document doesn't fit on the page horizontally and will be truncated "
+"when it is printed."
+msgstr ""
+"Këtë dokument s’e nxë faqja horizontalisht dhe do të qethet, kur të shtypet."
+
+#: ../src/html/htmprint.cpp:285
+#, c-format
+msgid ""
+"The document \"%s\" doesn't fit on the page horizontally and will be "
+"truncated if printed.\n"
+"\n"
+"Would you like to proceed with printing it nevertheless?"
+msgstr ""
+"Dokumentin “%s” s’e nxë faqja horizontalisht dhe do të qethet, në u "
+"shtyptë.\n"
+"\n"
+"Doni të vazhdohet me shtypjen, sido që të jetë?"
+
+#: ../src/html/htmprint.cpp:296
+msgid ""
+"If possible, try changing the layout parameters to make the printout more "
+"narrow."
+msgstr ""
+"Nëse mundet, provoni të ndryshoni parametrat e skemës për ta bërë çka "
+"shtypet më të ngushtë."
+
+#: ../src/html/htmprint.cpp:445
+msgid ": file does not exist!"
+msgstr ": kartela s’ekziston!"
+
+#. TRANSLATORS: %s may be a document title.
+#: ../src/html/htmprint.cpp:717
+#, fuzzy, c-format
+msgid "%s Preview"
+msgstr " Paraparje"
+
+#: ../src/html/htmprint.cpp:755 ../src/richtext/richtextprint.cpp:618
+msgid ""
+"There was a problem during page setup: you may need to set a default printer."
+msgstr ""
+"Pati një problem gjatë ujdisjes së faqes: mund t’ju duhet të caktoni një "
+"shtypës parazgjedhje."
+
+#: ../src/msw/clipbrd.cpp:80
+msgid "Failed to open the clipboard."
+msgstr "S’u arrit të hapej e papastra."
+
+#: ../src/msw/clipbrd.cpp:101
+msgid "Failed to close the clipboard."
+msgstr "S’u arrit të mbyllej e papastra."
+
+#: ../src/msw/clipbrd.cpp:113
+msgid "Failed to empty the clipboard."
+msgstr "S’u arrit të zbrazej e papastra."
+
+#: ../src/msw/clipbrd.cpp:284
+msgid "Failed to put data on the clipboard"
+msgstr "S’u arrit të hidheshin të dhëna në të papastër"
+
+#: ../src/msw/clipbrd.cpp:326
+msgid "Failed to get data from the clipboard"
+msgstr "S’u arrit të merreshin të dhëna nga e papastra"
+
+#: ../src/msw/clipbrd.cpp:363
+msgid "Failed to retrieve the supported clipboard formats"
+msgstr "S’u arrit të merreshin formate të mbuluar për të papastrën"
+
+#: ../src/msw/colordlg.cpp:228
+#, c-format
+msgid "Colour selection dialog failed with error %0lx."
+msgstr "Dialogu i përzgjedhjes së ngjyrës dështoi me gabimin %0lx."
+
+#: ../src/msw/cursor.cpp:141
+msgid "Failed to create cursor."
+msgstr "S’u arrit të krijohej kursor."
+
+#: ../src/msw/dde.cpp:279
+#, c-format
+msgid "Failed to register DDE server '%s'"
+msgstr "S’u arrit të regjistrohej shërbyesi DDE '%s'"
+
+#: ../src/msw/dde.cpp:300
+#, c-format
+msgid "Failed to unregister DDE server '%s'"
+msgstr "S’u arrit të çregjistrohej shërbyesi DDE '%s'"
+
+#: ../src/msw/dde.cpp:428
+#, c-format
+msgid "Failed to create connection to server '%s' on topic '%s'"
+msgstr "S’u arrit të krijohej lidhje te shërbyes '%s' mbi temën '%s'"
+
+#: ../src/msw/dde.cpp:655
+msgid "DDE poke request failed"
+msgstr ""
+
+#: ../src/msw/dde.cpp:674
+msgid "Failed to establish an advise loop with DDE server"
+msgstr "S’u arrit të vendosej një qerthull këshillimi me shërbyesin DDE"
+
+#: ../src/msw/dde.cpp:693
+msgid "Failed to terminate the advise loop with DDE server"
+msgstr "S’u arrit të përfundohej qerthull këshillimi me shërbyesin DDE"
+
+#: ../src/msw/dde.cpp:768
+msgid "Failed to send DDE advise notification"
+msgstr "S’u arrit të dërgohej njoftim këshillues DDE"
+
+#: ../src/msw/dde.cpp:1085
+msgid "Failed to create DDE string"
+msgstr "S’u arrit të krijohej varg DDE"
+
+#: ../src/msw/dde.cpp:1131
+msgid "no DDE error."
+msgstr "pa gabim DDE."
+
+#: ../src/msw/dde.cpp:1135
+msgid "a request for a synchronous advise transaction has timed out."
+msgstr "një kërkese për transaksion të njëkohshëm “advise” i mbaroi koha."
+
+#: ../src/msw/dde.cpp:1138
+msgid "the response to the transaction caused the DDE_FBUSY bit to be set."
+msgstr "përgjigja te transaksioni shkaktoi caktimin e bitit DDE_FBUSY."
+
+#: ../src/msw/dde.cpp:1141
+msgid "a request for a synchronous data transaction has timed out."
+msgstr "një kërkese për transaksion të njëkohshëm të dhënash i mbaroi koha."
+
+#: ../src/msw/dde.cpp:1144
+msgid ""
+"a DDEML function was called without first calling the DdeInitialize "
+"function,\n"
+"or an invalid instance identifier\n"
+"was passed to a DDEML function."
+msgstr ""
+"një funksion DDEML u thirr pa thirrur së pari funksionin DdeInitialize,\n"
+"ose funksionit DDEML iu kalua një\n"
+"identifikues i pavlefshëm instancash."
+
+#: ../src/msw/dde.cpp:1147
+msgid ""
+"an application initialized as APPCLASS_MONITOR has\n"
+"attempted to perform a DDE transaction,\n"
+"or an application initialized as APPCMD_CLIENTONLY has \n"
+"attempted to perform server transactions."
+msgstr ""
+"një zbatim i filluar si APPCLASS_MONITOR\n"
+"u përpoq të kryejë një transaksion DDE,\n"
+"ose një aplikacion i filluar si APPCMD_CLIENTONLY \n"
+"u përpoq të kryejë transaksion shërbyesish."
+
+#: ../src/msw/dde.cpp:1150
+msgid "a request for a synchronous execute transaction has timed out."
+msgstr "një kërkese për transaksion të njëkohshëm “execute” i mbaroi koha."
+
+#: ../src/msw/dde.cpp:1153
+msgid "a parameter failed to be validated by the DDEML."
+msgstr "dështoi vleftësimi nga DDEML i një parametri."
+
+#: ../src/msw/dde.cpp:1156
+msgid "a DDEML application has created a prolonged race condition."
+msgstr ""
+
+#: ../src/msw/dde.cpp:1159
+msgid "a memory allocation failed."
+msgstr "dështoi një caktim kujtese."
+
+#: ../src/msw/dde.cpp:1162
+msgid "a client's attempt to establish a conversation has failed."
+msgstr "dështoi një përpjekje klienti për të vendosur bisedë."
+
+#: ../src/msw/dde.cpp:1165
+msgid "a transaction failed."
+msgstr "dështoi një transaksion."
+
+#: ../src/msw/dde.cpp:1168
+msgid "a request for a synchronous poke transaction has timed out."
+msgstr "një kërkese për transaksion të njëkohshëm “poke” i mbaroi koha."
+
+#: ../src/msw/dde.cpp:1171
+msgid "an internal call to the PostMessage function has failed. "
+msgstr "dështoi një thirrje e brendshme për funksionin PostMessage. "
+
+#: ../src/msw/dde.cpp:1174
+msgid "reentrancy problem."
+msgstr "problem rihyrjeje."
+
+#: ../src/msw/dde.cpp:1177
+msgid ""
+"a server-side transaction was attempted on a conversation\n"
+"that was terminated by the client, or the server\n"
+"terminated before completing a transaction."
+msgstr ""
+"pati përpjekje nga krahu i shërbyesit për transaksion mbi\n"
+"një bisedë që u përfundua nga klienti, ose shërbyesi\n"
+"e mbylli me aq, para se të plotësohej transaksioni."
+
+#: ../src/msw/dde.cpp:1180
+msgid "an internal error has occurred in the DDEML."
+msgstr "te DDEML ndodhi një gabim i brendshëm."
+
+#: ../src/msw/dde.cpp:1183
+msgid "a request to end an advise transaction has timed out."
+msgstr "një kërkese për përfundim transaksioni këshille i mbaroi koha."
+
+#: ../src/msw/dde.cpp:1186
+msgid ""
+"an invalid transaction identifier was passed to a DDEML function.\n"
+"Once the application has returned from an XTYP_XACT_COMPLETE callback,\n"
+"the transaction identifier for that callback is no longer valid."
+msgstr ""
+"funksionit DDEML iu kalua një identifikues transaksion të pavlefshëm.\n"
+"Pasi aplikacioni jetë përgjigjur me një callback XTYP_XACT_COMPLETE,\n"
+"identifikuesi i transaksionit për atë callback s’është më i vlefshëm."
+
+#: ../src/msw/dde.cpp:1189
+#, c-format
+msgid "Unknown DDE error %08x"
+msgstr "Gabim i panjohur DDE %08x"
+
+#: ../src/msw/dialup.cpp:343
+msgid ""
+"Dial up functions are unavailable because the remote access service (RAS) is "
+"not installed on this machine. Please install it."
+msgstr ""
+"S’janë të passhëm funksione “dial up”, ngaqë shërbimi i hyrjes së largëti "
+"(RAS) s’është i instaluar në këtë makinë. Ju lutemi, instalojeni."
+
+#: ../src/msw/dialup.cpp:402
+#, c-format
+msgid ""
+"The version of remote access service (RAS) installed on this machine is too "
+"old, please upgrade (the following required function is missing: %s)."
+msgstr ""
+"Versioni i shërbimit të hyrjes së largëti (RAS) të instaluar në këtë makinë "
+"është shumë i vjetër, ju lutemi, përmirësojeni (mungon funksioni vijues i "
+"domosdoshëm: %s)."
+
+#: ../src/msw/dialup.cpp:437
+msgid "Failed to retrieve text of RAS error message"
+msgstr "S’u arrit të merrej tekst mesazhi gabimi RAS"
+
+#: ../src/msw/dialup.cpp:440
+#, c-format
+msgid "unknown error (error code %08x)."
+msgstr "gabim i panjohur (kod gabimi %08x)."
+
+#: ../src/msw/dialup.cpp:492
+#, c-format
+msgid "Cannot find active dialup connection: %s"
+msgstr "S’gjendet dot lidhje “dialup” aktive: %s"
+
+#: ../src/msw/dialup.cpp:513
+msgid "Several active dialup connections found, choosing one randomly."
+msgstr "U gjetën disa lidhje dialup vepruese, po zgjidhet një kuturu."
+
+#: ../src/msw/dialup.cpp:598 ../src/msw/dialup.cpp:832
+#, c-format
+msgid "Failed to establish dialup connection: %s"
+msgstr "S’u arrit të vendosej lidhjeje “dialup”: %s"
+
+#: ../src/msw/dialup.cpp:664
+#, c-format
+msgid "Failed to get ISP names: %s"
+msgstr "S’u arrit të merreshin emra ISP-sh: %s"
+
+#: ../src/msw/dialup.cpp:712
+msgid "Failed to connect: no ISP to dial."
+msgstr "S’u arrit të lidhej: pa ISP për thirrje."
+
+#: ../src/msw/dialup.cpp:732
+msgid "Choose ISP to dial"
+msgstr "Zgjidhni ISP për t’i rënë numrit"
+
+#: ../src/msw/dialup.cpp:733
+msgid "Please choose which ISP do you want to connect to"
+msgstr "Ju lutemi, zgjidhni te cili ISP doni të lidheni"
+
+#: ../src/msw/dialup.cpp:766
+msgid "Failed to connect: missing username/password."
+msgstr "S’u arrit të lidhej: mungon emër përdoruesi/fjalëkalim."
+
+#: ../src/msw/dialup.cpp:796
+msgid "Cannot find the location of address book file"
+msgstr "S’gjendet dot vendi i kartelës së librit të adresave"
+
+#: ../src/msw/dialup.cpp:827
+#, c-format
+msgid "Failed to initiate dialup connection: %s"
+msgstr "S’u arrit të nisej lidhje “dialup”: %s"
+
+#: ../src/msw/dialup.cpp:897
+msgid "Cannot hang up - no active dialup connection."
+msgstr "S’bëhet dot mbyllje - s’ka lidhje “dialup” aktive."
+
+#: ../src/msw/dialup.cpp:907
+#, c-format
+msgid "Failed to terminate the dialup connection: %s"
+msgstr "S’u arrit të ndërpritej lidhja “dialup”: %s"
+
+#: ../src/msw/dib.cpp:313
+#, c-format
+msgid "Failed to save the bitmap image to file \"%s\"."
+msgstr "S’u arrit të ruhej figurë bitmap te kartela “%s”."
+
+#: ../src/msw/dib.cpp:543
+#, c-format
+msgid "Failed to allocate %luKb of memory for bitmap data."
+msgstr "S’u arrit të jepeshin %luKb kujtesë për të dhëna bitmap."
+
+#: ../src/msw/dir.cpp:241
+#, c-format
+msgid "Cannot enumerate files in directory '%s'"
+msgstr "S’numërtohen dot kartela në drejtori '%s'"
+
+#: ../src/msw/dirdlg.cpp:368
+msgid "Couldn't obtain folder name"
+msgstr "S’u mor dot emër dosjeje"
+
+#: ../src/msw/dlmsw.cpp:163
+#, c-format
+msgid "(error %d: %s)"
+msgstr "(gabim %d: %s)"
+
+#: ../src/msw/dragimag.cpp:143 ../src/msw/dragimag.cpp:178
+#: ../src/msw/imaglist.cpp:309 ../src/msw/imaglist.cpp:331
+msgid "Couldn't add an image to the image list."
+msgstr "S’u shtua dot një figurë te lista e figurave."
+
+#: ../src/msw/enhmeta.cpp:94
+#, c-format
+msgid "Failed to load metafile from file \"%s\"."
+msgstr "S’u arrit të ngarkohej “metafile” prej kartelës “%s”."
+
+#: ../src/msw/fdrepdlg.cpp:412
+#, c-format
+msgid "Failed to create the standard find/replace dialog (error code %d)"
+msgstr "S’u arrit të krijohej dialogu standard gjej/zëvendëso (kod gabimi %d)"
+
+#: ../src/msw/filedlg.cpp:1241
+msgid "Access to the file system is not allowed from secure desktop."
+msgstr ""
+
+#: ../src/msw/filedlg.cpp:1242
+msgid "Security warning"
+msgstr ""
+
+#: ../src/msw/filedlg.cpp:1533
+#, c-format
+msgid "File dialog failed with error code %0lx."
+msgstr "Dialogu i kartelës dështoi me kod gabimi %0lx."
+
+#: ../src/msw/font.cpp:1120
+#, c-format
+msgid "Font file \"%s\" couldn't be loaded"
+msgstr "Kartela e shkronjave “%s” s’u ngarkua dot"
+
+#: ../src/msw/fontdlg.cpp:220
+#, c-format
+msgid "Common dialog failed with error code %0lx."
+msgstr "Dialogu i rëndomtë dështoi me kod gabimi %0lx."
+
+#: ../src/msw/fswatcher.cpp:67
+msgid "Ungraceful worker thread termination"
+msgstr ""
+
+#: ../src/msw/fswatcher.cpp:81
+msgid "Unable to create IOCP worker thread"
+msgstr ""
+
+#: ../src/msw/fswatcher.cpp:88
+msgid "Unable to start IOCP worker thread"
+msgstr ""
+
+#: ../src/msw/fswatcher.cpp:140
+msgid "Monitoring individual files for changes is not supported currently."
+msgstr "Hëpërhë nuk mbulohet mbikëqyrja për ndryshime e kartelave individuale."
+
+#: ../src/msw/fswatcher.cpp:165
+#, c-format
+msgid "Unable to set up watch for '%s'"
+msgstr "S’arrihet të ujdiset mbikëqyrës për '%s'"
+
+#: ../src/msw/fswatcher.cpp:466
+#, c-format
+msgid "Can't monitor non-existent directory \"%s\" for changes."
+msgstr "S’mund të mbikëqyret për ndryshime drejtori “%s” që s’ekziston."
+
+#: ../src/msw/glcanvas.cpp:577 ../src/unix/glx11.cpp:507
+msgid "OpenGL 3.0 or later is not supported by the OpenGL driver."
+msgstr "OpenGL 3.0 ose i mëvonshëm nuk mbulohet nga përudhësi OpenGL."
+
+#: ../src/msw/glcanvas.cpp:601 ../src/osx/glcanvas_osx.cpp:395
+#: ../src/unix/glegl.cpp:304 ../src/unix/glx11.cpp:553
+msgid "Couldn't create OpenGL context"
+msgstr "S’u krijua dot kontekst OpenGL"
+
+#: ../src/msw/glcanvas.cpp:1294
+msgid "Failed to initialize OpenGL"
+msgstr "S’u arrit të gatitej OpeGL-i"
+
+#: ../src/msw/graphicsd2d.cpp:607
+msgid "Could not register custom DirectWrite font loader."
+msgstr "S’u regjistrua dot ngarkues shkronjash vetjake DirectWrite."
+
+#: ../src/msw/helpchm.cpp:48
+msgid ""
+"MS HTML Help functions are unavailable because the MS HTML Help library is "
+"not installed on this machine. Please install it."
+msgstr ""
+"Funksionet MS HTML Help nuk janë të passhëm, ngaqë libraria MS HTML Help "
+"s’është e instaluar në këtë makinë. Ju lutemi, instalojeni."
+
+#: ../src/msw/helpchm.cpp:55
+msgid "Failed to initialize MS HTML Help."
+msgstr "S’u arrit të gatitej Ndihmë MS HTML."
+
+#: ../src/msw/iniconf.cpp:458
+#, c-format
+msgid "Can't delete the INI file '%s'"
+msgstr "S’fshihet dot kartela INI '%s'"
+
+#: ../src/msw/listctrl.cpp:995
+#, c-format
+msgid "Couldn't retrieve information about list control item %d."
+msgstr "S’u morën dot të dhëna rreth objekti kontrolli liste %d."
+
+#: ../src/msw/mdi.cpp:170 ../src/qt/mdi.cpp:253
+msgid "&Cascade"
+msgstr "&Ujvarë"
+
+#: ../src/msw/mdi.cpp:171
+msgid "Tile &Horizontally"
+msgstr "Tjegullzoje &Horizontalisht"
+
+#: ../src/msw/mdi.cpp:172
+msgid "Tile &Vertically"
+msgstr "Tjegullzoje &Vertikalisht"
+
+#: ../src/msw/mdi.cpp:174
+msgid "&Arrange Icons"
+msgstr "&Sistemoni Ikona"
+
+#: ../src/msw/mdi.cpp:621
+msgid "Failed to create MDI parent frame."
+msgstr "S’u arrit të krijohej kornizë mëmë MDI."
+
+#: ../src/msw/mimetype.cpp:234
+#, c-format
+msgid "Failed to create registry entry for '%s' files."
+msgstr "S’u arrit të krijohej zë regjistri për kartela '%s'."
+
+#: ../src/msw/ole/automtn.cpp:495
+#, c-format
+msgid "Failed to find CLSID of \"%s\""
+msgstr "S’u arrit të gjendej CLSID e “%s”"
+
+#: ../src/msw/ole/automtn.cpp:512
+#, c-format
+msgid "Failed to create an instance of \"%s\""
+msgstr "S’u arrit të krijohej një instancë e “%s”"
+
+#: ../src/msw/ole/automtn.cpp:552
+#, c-format
+msgid "Cannot get an active instance of \"%s\""
+msgstr "S’merret dot një instancë aktive e “%s”"
+
+#: ../src/msw/ole/automtn.cpp:564
+#, c-format
+msgid "Failed to get OLE automation interface for \"%s\""
+msgstr "S’u arrit të merrej ndërfaqe automatizimi OLE për “%s”"
+
+#: ../src/msw/ole/automtn.cpp:621
+msgid "Unknown name or named argument."
+msgstr "Emër ose argument i emërtuar i panjohur."
+
+#: ../src/msw/ole/automtn.cpp:625
+msgid "Incorrect number of arguments."
+msgstr "Numër i pasaktë argumentesh."
+
+#: ../src/msw/ole/automtn.cpp:637
+msgid "Unknown exception"
+msgstr "Përjashtim i panjohur"
+
+#: ../src/msw/ole/automtn.cpp:642
+msgid "Method or property not found."
+msgstr "S’u gjet metodë ose veti."
+
+#: ../src/msw/ole/automtn.cpp:646
+msgid "Overflow while coercing argument values."
+msgstr ""
+
+#: ../src/msw/ole/automtn.cpp:650
+msgid "Object implementation does not support named arguments."
+msgstr "Sendërtimi i objektit nuk mbulon argumente të emërtuar."
+
+#: ../src/msw/ole/automtn.cpp:654
+msgid "The locale ID is unknown."
+msgstr "ID-ja e vendores është e panjohur."
+
+#: ../src/msw/ole/automtn.cpp:658
+msgid "Missing a required parameter."
+msgstr "I mungon një parametër i domosdoshëm."
+
+#: ../src/msw/ole/automtn.cpp:662
+#, c-format
+msgid "Argument %u not found."
+msgstr "S’u gjet argumenti %u."
+
+#: ../src/msw/ole/automtn.cpp:666
+#, c-format
+msgid "Type mismatch in argument %u."
+msgstr "Mospërputhje lloji te argument %u."
+
+#: ../src/msw/ole/automtn.cpp:670
+msgid "The system cannot find the file specified."
+msgstr "Sistemi s’gjen dot kartelën e treguar."
+
+#: ../src/msw/ole/automtn.cpp:674
+msgid "Class not registered."
+msgstr "Klasë e paregjistruar."
+
+#: ../src/msw/ole/automtn.cpp:678
+#, c-format
+msgid "Unknown error %08x"
+msgstr "Gabim i panjohur %08x"
+
+#: ../src/msw/ole/automtn.cpp:682
+#, c-format
+msgid "OLE Automation error in %s: %s"
+msgstr "Gabim Automatizimi OLE te %s: %s"
+
+#: ../src/msw/ole/dataobj.cpp:385
+#, c-format
+msgid "Couldn't register clipboard format '%s'."
+msgstr "S’u regjistrua dot format të papastre '%s'."
+
+#: ../src/msw/ole/dataobj.cpp:402
+#, c-format
+msgid "The clipboard format '%d' doesn't exist."
+msgstr "Formati '%d' për të papastrën s’ekziston."
+
+#: ../src/msw/progdlg.cpp:1025
+msgid "Skip"
+msgstr "Anashkaloje"
+
+#: ../src/msw/registry.cpp:141
+#, c-format
+msgid "unknown (%lu)"
+msgstr "e panjohur (%lu)"
+
+#: ../src/msw/registry.cpp:409
+#, c-format
+msgid "Can't get info about registry key '%s'"
+msgstr "S’merren dot dhëna rreth kyçi regjistrash '%s'"
+
+#: ../src/msw/registry.cpp:445
+#, c-format
+msgid "Can't open registry key '%s'"
+msgstr "S’hapet dot kyç regjistri '%s'"
+
+#: ../src/msw/registry.cpp:478
+#, c-format
+msgid "Can't create registry key '%s'"
+msgstr "S’krijohet dot kyç regjistri '%s'"
+
+#: ../src/msw/registry.cpp:497
+#, c-format
+msgid "Can't close registry key '%s'"
+msgstr "S’mbyllet dot kyç regjistri '%s'"
+
+#: ../src/msw/registry.cpp:512
+#, c-format
+msgid "Registry value '%s' already exists."
+msgstr "Ka tashmë një vlerë '%s' regjistri."
+
+#: ../src/msw/registry.cpp:520
+#, c-format
+msgid "Failed to rename registry value '%s' to '%s'."
+msgstr "S’u arrit të riemërtohej vlerë regjistri '%s' si '%s'."
+
+#: ../src/msw/registry.cpp:575
+#, c-format
+msgid "Can't copy values of unsupported type %d."
+msgstr "S’kopjohen dot vlera lloji të pambuluar %d."
+
+#: ../src/msw/registry.cpp:586
+#, c-format
+msgid "Registry key '%s' does not exist, cannot rename it."
+msgstr "Kyçi '%s' i regjistrit s’ekziston, s’mund të riemërtohet."
+
+#: ../src/msw/registry.cpp:617
+#, c-format
+msgid "Registry key '%s' already exists."
+msgstr "Ka tashmë një kyç '%s' regjistri."
+
+#: ../src/msw/registry.cpp:625
+#, c-format
+msgid "Failed to rename the registry key '%s' to '%s'."
+msgstr "S’u arrit të riemërtohej kyç regjistri '%s' si '%s'."
+
+#: ../src/msw/registry.cpp:670
+#, c-format
+msgid "Failed to copy the registry subkey '%s' to '%s'."
+msgstr "S’u arrit të kopjohej nënkyçi i regjistrit '%s' si '%s'."
+
+#: ../src/msw/registry.cpp:683
+#, c-format
+msgid "Failed to copy registry value '%s'"
+msgstr "S’u arrit të kopjohej vlerë regjistri '%s'"
+
+#: ../src/msw/registry.cpp:692
+#, c-format
+msgid "Failed to copy the contents of registry key '%s' to '%s'."
+msgstr "S’u arrit të kopjohej lënda e kyçit të regjistrit '%s' te '%s'."
+
+#: ../src/msw/registry.cpp:718
+#, c-format
+msgid ""
+"Registry key '%s' is needed for normal system operation,\n"
+"deleting it will leave your system in unusable state:\n"
+"operation aborted."
+msgstr ""
+"Kyçi '%s' i regjistrit është i domosdoshëm për punimin normal\n"
+"të sistemit, fshirja e tij do ta lërë sistemin tuaj në gjendje\n"
+"të paqëndrueshme: veprimi u ndërpre."
+
+#: ../src/msw/registry.cpp:754
+#, c-format
+msgid "Can't delete key '%s'"
+msgstr "S’fshihet dot kyç '%s'"
+
+#: ../src/msw/registry.cpp:782
+#, c-format
+msgid "Can't delete value '%s' from key '%s'"
+msgstr "S’fshihet dot vlerë '%s' prej kyçit '%s'"
+
+#: ../src/msw/registry.cpp:855 ../src/msw/registry.cpp:887
+#: ../src/msw/registry.cpp:929 ../src/msw/registry.cpp:1000
+#, c-format
+msgid "Can't read value of key '%s'"
+msgstr "S’lexohet dot vlerë kyçi '%s'"
+
+#: ../src/msw/registry.cpp:873 ../src/msw/registry.cpp:915
+#: ../src/msw/registry.cpp:963 ../src/msw/registry.cpp:1106
+#, c-format
+msgid "Can't set value of '%s'"
+msgstr "S’caktohet dot vlerë e '%s'"
+
+#: ../src/msw/registry.cpp:894 ../src/msw/registry.cpp:943
+#, c-format
+msgid "Registry value \"%s\" is not numeric (but of type %s)"
+msgstr "Vlera “%s” e regjistrit s’është numerike (por e llojit %s)"
+
+#: ../src/msw/registry.cpp:979
+#, c-format
+msgid "Registry value \"%s\" is not binary (but of type %s)"
+msgstr "Vlera “%s” e regjistrit s’është dyore (por e llojit %s)"
+
+#: ../src/msw/registry.cpp:1028
+#, c-format
+msgid "Registry value \"%s\" is not text (but of type %s)"
+msgstr "Vlera “%s” e regjistrit s’është tekst (por e llojit %s)"
+
+#: ../src/msw/registry.cpp:1089
+#, c-format
+msgid "Can't read value of '%s'"
+msgstr "S’lexohet dot vlera e '%s'"
+
+#: ../src/msw/registry.cpp:1157
+#, c-format
+msgid "Can't enumerate values of key '%s'"
+msgstr "S’numërtohen dot vlera kyçi '%s'"
+
+#: ../src/msw/registry.cpp:1196
+#, c-format
+msgid "Can't enumerate subkeys of key '%s'"
+msgstr "S’numërtohen dot nënkyçe të kyçit '%s'"
+
+#: ../src/msw/registry.cpp:1262
+#, c-format
+msgid ""
+"Exporting registry key: file \"%s\" already exists and won't be overwritten."
+msgstr ""
+"Po eksportohet kyç regjistri: kartela “%s” ekziston tashmë dhe s’do të "
+"mbishkruhet."
+
+#: ../src/msw/registry.cpp:1411
+#, c-format
+msgid "Can't export value of unsupported type %d."
+msgstr "S’eksportohet dot vlerë lloji të pambuluar %d."
+
+#: ../src/msw/registry.cpp:1427
+#, c-format
+msgid "Ignoring value \"%s\" of the key \"%s\"."
+msgstr "Po shpërfillet vlera “%s” e kyçit “%s”."
+
+#: ../src/msw/textctrl.cpp:596
+msgid ""
+"Impossible to create a rich edit control, using simple text control instead. "
+"Please reinstall riched32.dll"
+msgstr ""
+"E pamundur të krijohet kontroll përpunimi të pasur, në vend të tij po "
+"përdoret kontroll teksti të thjeshtë. Ju lutemi, riinstaloni riched32.dll"
+
+#: ../src/msw/thread.cpp:522 ../src/unix/threadpsx.cpp:850
+msgid "Cannot start thread: error writing TLS."
+msgstr "S’fillohet dot rrjedhë: gabim në shkrim TLS-je."
+
+#: ../src/msw/thread.cpp:613
+msgid "Can't set thread priority"
+msgstr "S’caktohet dot përparësi rrjedhe"
+
+#: ../src/msw/thread.cpp:649
+msgid "Can't create thread"
+msgstr "S’krijohet dot rrjedhë"
+
+#: ../src/msw/thread.cpp:668
+msgid "Couldn't terminate thread"
+msgstr "S’u përfundua dot rrjedhë"
+
+#: ../src/msw/thread.cpp:799
+msgid "Cannot wait for thread termination"
+msgstr "S’pritet dot për përfundim rrjedhe"
+
+#: ../src/msw/thread.cpp:873
+#, c-format
+msgid "Cannot suspend thread %lx"
+msgstr "S’pezullohet dot rrjedha %lx"
+
+#: ../src/msw/thread.cpp:903
+#, c-format
+msgid "Cannot resume thread %lx"
+msgstr "S’rimerret dot rrjedha %lx"
+
+#: ../src/msw/thread.cpp:932
+msgid "Couldn't get the current thread pointer"
+msgstr ""
+
+#: ../src/msw/thread.cpp:1333
+msgid ""
+"Thread module initialization failed: impossible to allocate index in thread "
+"local storage"
+msgstr ""
+"Gatitja e modulit të rrjedhës dështoi: e pamundur të jepet tregues te depo "
+"vendore rrjedhe"
+
+#: ../src/msw/thread.cpp:1345
+msgid ""
+"Thread module initialization failed: cannot store value in thread local "
+"storage"
+msgstr ""
+"Gatitja e modulit të rrjedhës dështoi: s’mund të depozitohet vlerë në depo "
+"vendore rrjedhe"
+
+#: ../src/msw/timer.cpp:133
+msgid "Couldn't create a timer"
+msgstr "S’u krijua dot kohëmatës"
+
+#: ../src/msw/utils.cpp:372
+msgid "can't find user's HOME, using current directory."
+msgstr "s’gjendet dot SHTËPI e përdoruesit, po përdoret drejtoria e tanishme."
+
+#: ../src/msw/utils.cpp:662
+#, c-format
+msgid "Failed to kill process %d"
+msgstr "S’u arrit të asgjësohej procesi %d"
+
+#: ../src/msw/utils.cpp:986
+#, c-format
+msgid "Failed to load resource \"%s\"."
+msgstr "S’u arrit të ngarkohej burimi “%s”."
+
+#: ../src/msw/utils.cpp:993
+#, c-format
+msgid "Failed to lock resource \"%s\"."
+msgstr "S’u arrit të kyçej burimi “%s”."
+
+#. TRANSLATORS: MS Windows build number
+#: ../src/msw/utils.cpp:1209
+#, c-format
+msgid "build %lu"
+msgstr "monto %lu"
+
+#: ../src/msw/utils.cpp:1218
+msgid ", 64-bit edition"
+msgstr ", varianti 64-bitësh"
+
+#: ../src/msw/utilsexc.cpp:224
+msgid "Failed to create an anonymous pipe"
+msgstr "S’u arrit të krijohej kanal i paemër"
+
+#: ../src/msw/utilsexc.cpp:697
+msgid "Failed to redirect the child process IO"
+msgstr "S’u arrit të ridrejtohej IO procesi pjellë"
+
+#: ../src/msw/utilsexc.cpp:870
+#, c-format
+msgid "Execution of command '%s' failed"
+msgstr "Dështoi përmbushja e urdhrit '%s'"
+
+#: ../src/msw/volume.cpp:337
+msgid "Failed to load mpr.dll."
+msgstr "S’u arrit të ngarkohej mpr.dll."
+
+#: ../src/msw/volume.cpp:506
+#, c-format
+msgid "Cannot read typename from '%s'!"
+msgstr "S’lexohet dot emër lloji prej '%s'!"
+
+#: ../src/msw/volume.cpp:615
+#, c-format
+msgid "Cannot load icon from '%s'."
+msgstr "S’ngarkohet dot ikonë prej '%s'."
+
+#: ../src/msw/webview_edge.cpp:285
+msgid "This program was compiled without support for setting Edge proxy."
+msgstr ""
+
+#: ../src/msw/webview_ie.cpp:1010
+msgid "Failed to find web view emulation level in the registry"
+msgstr "S’u arrit të gjendet te regjistri shkallë emulimi parjeje web"
+
+#: ../src/msw/webview_ie.cpp:1019
+msgid "Failed to set web view to modern emulation level"
+msgstr "S’u arrit të caktohet emulim modern si shkallë për parje web"
+
+#: ../src/msw/webview_ie.cpp:1027
+msgid "Failed to reset web view to standard emulation level"
+msgstr ""
+"S’u arrit të rikthehet te parazgjedhja standarde shkalla e emulimit për "
+"parje web"
+
+#: ../src/msw/webview_ie.cpp:1049
+msgid "Can't run JavaScript script without a valid HTML document"
+msgstr "S’xhirohet dot programth JavaScript pa një dokument HTML të vlefshëm"
+
+#: ../src/msw/webview_ie.cpp:1056
+msgid "Can't get the JavaScript object"
+msgstr "S’merret dot objekt JavaScript"
+
+#: ../src/msw/webview_ie.cpp:1070
+msgid "failed to evaluate"
+msgstr "s’u arrit të bëhej vlerësim"
+
+#: ../src/osx/cocoa/filedlg.mm:412
+msgid "File type:"
+msgstr "Lloj kartele:"
+
+#: ../src/osx/cocoa/menu.mm:242
+msgctxt "macOS menu name"
+msgid "Window"
+msgstr "Dritare"
+
+#: ../src/osx/cocoa/menu.mm:259
+msgctxt "macOS menu name"
+msgid "Help"
+msgstr "Ndihmë"
+
+#: ../src/osx/cocoa/menu.mm:298
+msgctxt "macOS menu item"
+msgid "Minimize"
+msgstr "Minimizoje"
+
+#: ../src/osx/cocoa/menu.mm:303
+msgctxt "macOS menu item"
+msgid "Zoom"
+msgstr "Zoom"
+
+#: ../src/osx/cocoa/menu.mm:309
+msgctxt "macOS menu item"
+msgid "Bring All to Front"
+msgstr "Silli të Tëra Para"
+
+#: ../src/osx/core/sound.cpp:143
+#, c-format
+msgid "Failed to load sound from \"%s\" (error %d)."
+msgstr "S’u arrit të ngarkohej tingull prej “%s” (gabim %d)."
+
+#: ../src/osx/fontutil.cpp:80
+#, c-format
+msgid "Font file \"%s\" doesn't exist."
+msgstr "Kartela e shkronjave “%s” s’ekziston."
+
+#: ../src/osx/fontutil.cpp:88
+#, c-format
+msgid ""
+"Font file \"%s\" cannot be used as it is not inside the font directory "
+"\"%s\"."
+msgstr ""
+"Kartela e shkronjave “%s” s’mund të përdoret, ngaqë s’gjendet brenda "
+"drejtorisë së shkronjave “%s”."
+
+#: ../src/osx/menu_osx.cpp:496
+#, c-format
+msgctxt "macOS menu item"
+msgid "About %s"
+msgstr "Rreth %s"
+
+#: ../src/osx/menu_osx.cpp:499
+msgctxt "macOS menu item"
+msgid "About..."
+msgstr "Rreth…"
+
+#: ../src/osx/menu_osx.cpp:508
+msgctxt "macOS menu item"
+msgid "Preferences..."
+msgstr "Parapëlqime…"
+
+#: ../src/osx/menu_osx.cpp:512
+msgctxt "macOS menu item"
+msgid "Services"
+msgstr "Shërbime"
+
+#: ../src/osx/menu_osx.cpp:519
+#, c-format
+msgctxt "macOS menu item"
+msgid "Hide %s"
+msgstr "Fshihe %s"
+
+#: ../src/osx/menu_osx.cpp:522
+msgctxt "macOS menu item"
+msgid "Hide Application"
+msgstr "Fshihe Aplikacionin"
+
+#: ../src/osx/menu_osx.cpp:526
+msgctxt "macOS menu item"
+msgid "Hide Others"
+msgstr "Fshihi të Tjerat"
+
+#: ../src/osx/menu_osx.cpp:528
+msgctxt "macOS menu item"
+msgid "Show All"
+msgstr "Shfaqi Krejt"
+
+#: ../src/osx/menu_osx.cpp:534
+#, c-format
+msgctxt "macOS menu item"
+msgid "Quit %s"
+msgstr "Mbylleni %s"
+
+#: ../src/osx/menu_osx.cpp:537
+msgctxt "macOS menu item"
+msgid "Quit Application"
+msgstr "Mbylle Aplikacionin"
+
+#: ../src/osx/webview_webkit.mm:444
+msgid "Printing is not supported by the system web control"
+msgstr "Shtypja nuk mbulohet nga kontrolli web i sistemit"
+
+#: ../src/osx/webview_webkit.mm:453
+msgid "Print operation could not be initialized"
+msgstr "S’u gatit dot veprimi i shtypjes"
+
+#. TRANSLATORS: Label of font point size
+#: ../src/propgrid/advprops.cpp:605
+msgid "Point Size"
+msgstr ""
+
+#. TRANSLATORS: Label of font face name
+#: ../src/propgrid/advprops.cpp:615
+msgid "Face Name"
+msgstr "Emër Shkronjash"
+
+#. TRANSLATORS: Label of font style
+#: ../src/propgrid/advprops.cpp:623 ../src/richtext/richtextformatdlg.cpp:331
+msgid "Style"
+msgstr "Stil"
+
+#. TRANSLATORS: Label of font weight
+#: ../src/propgrid/advprops.cpp:628
+msgid "Weight"
+msgstr "Madhësi"
+
+#. TRANSLATORS: Label of underlined font
+#: ../src/propgrid/advprops.cpp:633 ../src/richtext/richtextfontpage.cpp:358
+msgid "Underlined"
+msgstr "Nënvijëzuar"
+
+#. TRANSLATORS: Label of font family
+#: ../src/propgrid/advprops.cpp:637
+msgid "Family"
+msgstr "Familje"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:801
+msgid "AppWorkspace"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:802
+msgid "ActiveBorder"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:803
+msgid "ActiveCaption"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:804
+msgid "ButtonFace"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:805
+msgid "ButtonHighlight"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:806
+msgid "ButtonShadow"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:807
+msgid "ButtonText"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:808
+msgid "CaptionText"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:809
+msgid "ControlDark"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:810
+msgid "ControlLight"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:812
+msgid "GrayText"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:813
+msgid "Highlight"
+msgstr "Theksim"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:814
+msgid "HighlightText"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:815
+msgid "InactiveBorder"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:816
+msgid "InactiveCaption"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:817
+msgid "InactiveCaptionText"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:818
+msgid "Menu"
+msgstr "Menu"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:819
+msgid "Scrollbar"
+msgstr "Rrëshqitës"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:820
+msgid "Tooltip"
+msgstr "Ndihmëz"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:821
+msgid "TooltipText"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:822
+msgid "Window"
+msgstr "Dritare"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:823
+msgid "WindowFrame"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:824
+msgid "WindowText"
+msgstr ""
+
+#. TRANSLATORS: Custom colour choice entry
+#: ../src/propgrid/advprops.cpp:825 ../src/propgrid/advprops.cpp:1532
+#: ../src/propgrid/advprops.cpp:1576
+msgid "Custom"
+msgstr "Vetjake"
+
+#: ../src/propgrid/advprops.cpp:1558
+msgid "Black"
+msgstr "E zezë"
+
+#: ../src/propgrid/advprops.cpp:1559
+msgid "Maroon"
+msgstr "Ngjyrë gështenje"
+
+#: ../src/propgrid/advprops.cpp:1560
+msgid "Navy"
+msgstr "Blu"
+
+#: ../src/propgrid/advprops.cpp:1561
+msgid "Purple"
+msgstr "E purpur"
+
+#: ../src/propgrid/advprops.cpp:1562
+msgid "Teal"
+msgstr "Blu e gjelbër"
+
+#: ../src/propgrid/advprops.cpp:1563
+msgid "Gray"
+msgstr "Gri"
+
+#: ../src/propgrid/advprops.cpp:1564
+msgid "Green"
+msgstr "E gjelbër"
+
+#: ../src/propgrid/advprops.cpp:1565
+msgid "Olive"
+msgstr "Ulli"
+
+#: ../src/propgrid/advprops.cpp:1566
+msgid "Brown"
+msgstr "Kafe"
+
+#: ../src/propgrid/advprops.cpp:1567
+msgid "Blue"
+msgstr "Blu"
+
+#: ../src/propgrid/advprops.cpp:1568
+msgid "Fuchsia"
+msgstr "Fuksia"
+
+#: ../src/propgrid/advprops.cpp:1569
+msgid "Red"
+msgstr "E kuqe"
+
+#: ../src/propgrid/advprops.cpp:1570
+msgid "Orange"
+msgstr "Portokalli"
+
+#: ../src/propgrid/advprops.cpp:1571
+msgid "Silver"
+msgstr "E argjendtë"
+
+#: ../src/propgrid/advprops.cpp:1572
+msgid "Lime"
+msgstr "Qitro"
+
+#: ../src/propgrid/advprops.cpp:1573
+msgid "Aqua"
+msgstr "Blu e gjelbër"
+
+#: ../src/propgrid/advprops.cpp:1574
+msgid "Yellow"
+msgstr "E verdhë"
+
+#: ../src/propgrid/advprops.cpp:1575
+msgid "White"
+msgstr "E bardhë"
+
+#: ../src/propgrid/advprops.cpp:1718
+msgctxt "system cursor name"
+msgid "Default"
+msgstr "Parazgjedhje"
+
+#: ../src/propgrid/advprops.cpp:1719
+msgctxt "system cursor name"
+msgid "Arrow"
+msgstr "Shigjetë"
+
+#: ../src/propgrid/advprops.cpp:1720
+msgctxt "system cursor name"
+msgid "Right Arrow"
+msgstr "Shigjetë Djathtas"
+
+#: ../src/propgrid/advprops.cpp:1721
+msgctxt "system cursor name"
+msgid "Blank"
+msgstr "E zbrazët"
+
+#: ../src/propgrid/advprops.cpp:1722
+msgctxt "system cursor name"
+msgid "Bullseye"
+msgstr "Bullseye"
+
+#: ../src/propgrid/advprops.cpp:1723
+msgctxt "system cursor name"
+msgid "Character"
+msgstr "Shenjë"
+
+#: ../src/propgrid/advprops.cpp:1724
+msgctxt "system cursor name"
+msgid "Cross"
+msgstr "Kryq"
+
+#: ../src/propgrid/advprops.cpp:1725
+msgctxt "system cursor name"
+msgid "Hand"
+msgstr "Dorë"
+
+#: ../src/propgrid/advprops.cpp:1726
+msgctxt "system cursor name"
+msgid "I-Beam"
+msgstr "I-Beam"
+
+#: ../src/propgrid/advprops.cpp:1727
+msgctxt "system cursor name"
+msgid "Left Button"
+msgstr "Butoni Majtas"
+
+#: ../src/propgrid/advprops.cpp:1728
+msgctxt "system cursor name"
+msgid "Magnifier"
+msgstr "Zmadhues"
+
+#: ../src/propgrid/advprops.cpp:1729
+msgctxt "system cursor name"
+msgid "Middle Button"
+msgstr "Butoni i Mesit"
+
+#: ../src/propgrid/advprops.cpp:1730
+msgctxt "system cursor name"
+msgid "No Entry"
+msgstr "Pa Zë"
+
+#: ../src/propgrid/advprops.cpp:1731
+msgctxt "system cursor name"
+msgid "Paint Brush"
+msgstr "Penel"
+
+#: ../src/propgrid/advprops.cpp:1732
+msgctxt "system cursor name"
+msgid "Pencil"
+msgstr "Laps"
+
+#: ../src/propgrid/advprops.cpp:1733
+msgctxt "system cursor name"
+msgid "Point Left"
+msgstr "Trego Majtas"
+
+#: ../src/propgrid/advprops.cpp:1734
+msgctxt "system cursor name"
+msgid "Point Right"
+msgstr "Trego Djathtas"
+
+#: ../src/propgrid/advprops.cpp:1735
+msgctxt "system cursor name"
+msgid "Question Arrow"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1736
+msgctxt "system cursor name"
+msgid "Right Button"
+msgstr "Butoni Djathtas"
+
+#: ../src/propgrid/advprops.cpp:1737
+msgctxt "system cursor name"
+msgid "Sizing NE-SW"
+msgstr "Ripërmasim VL-JP"
+
+#: ../src/propgrid/advprops.cpp:1738
+msgctxt "system cursor name"
+msgid "Sizing N-S"
+msgstr "Ripërmasim V-J"
+
+#: ../src/propgrid/advprops.cpp:1739
+msgctxt "system cursor name"
+msgid "Sizing NW-SE"
+msgstr "Ripërmasim VP-JL"
+
+#: ../src/propgrid/advprops.cpp:1740
+msgctxt "system cursor name"
+msgid "Sizing W-E"
+msgstr "Ripërmasim P-L"
+
+#: ../src/propgrid/advprops.cpp:1741
+msgctxt "system cursor name"
+msgid "Sizing"
+msgstr "Ripërmasim"
+
+#: ../src/propgrid/advprops.cpp:1742
+msgctxt "system cursor name"
+msgid "Spraycan"
+msgstr "Sprei"
+
+#: ../src/propgrid/advprops.cpp:1743
+msgctxt "system cursor name"
+msgid "Wait"
+msgstr "Pritni"
+
+#: ../src/propgrid/advprops.cpp:1744
+msgctxt "system cursor name"
+msgid "Watch"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1745
+msgctxt "system cursor name"
+msgid "Wait Arrow"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:2109
+msgid "Make a selection:"
+msgstr "Bëni një përzgjedhje:"
+
+#: ../src/propgrid/manager.cpp:394
+msgid "Property"
+msgstr "Veti"
+
+#: ../src/propgrid/manager.cpp:395
+msgid "Value"
+msgstr "Vlerë"
+
+#: ../src/propgrid/manager.cpp:1683
+msgid "Categorized Mode"
+msgstr "Mënyrë e Kategorizuar"
+
+#: ../src/propgrid/manager.cpp:1709
+msgid "Alphabetic Mode"
+msgstr "Mënyrë Alfabetike"
+
+#. TRANSLATORS: Name of Boolean false value
+#: ../src/propgrid/propgrid.cpp:230
+msgid "False"
+msgstr "False"
+
+#. TRANSLATORS: Name of Boolean true value
+#: ../src/propgrid/propgrid.cpp:232
+msgid "True"
+msgstr "True"
+
+#. TRANSLATORS: Text  displayed for unspecified value
+#: ../src/propgrid/propgrid.cpp:428
+msgid "Unspecified"
+msgstr "E papërcaktuar"
+
+#. TRANSLATORS: Caption of message box displaying any property error
+#: ../src/propgrid/propgrid.cpp:3145 ../src/propgrid/propgrid.cpp:3282
+msgid "Property Error"
+msgstr "Gabim Vetie"
+
+#: ../src/propgrid/propgrid.cpp:3259
+msgid "You have entered invalid value. Press ESC to cancel editing."
+msgstr ""
+"Keni dhënë vlerë të pavlefshme. Shtypni tastin ESC që të anulohet përpunimi."
+
+#: ../src/propgrid/propgrid.cpp:6608
+#, c-format
+msgid "Error in resource: %s"
+msgstr "Gabim në burim: %s"
+
+#: ../src/propgrid/propgridiface.cpp:377
+#, c-format
+msgid ""
+"Type operation \"%s\" failed: Property labeled \"%s\" is of type \"%s\", NOT "
+"\"%s\"."
+msgstr ""
+"Veprimi “%s” i shtypjes dështoi: Vetia e etiketuar me “%s” është e llojit "
+"“%s”, JO “%s”."
+
+#: ../src/propgrid/props.cpp:159
+#, c-format
+msgid "Unknown base %d. Base 10 will be used."
+msgstr "Bazë e panjohur %d. Do të përdoret 10 si bazë."
+
+#: ../src/propgrid/props.cpp:324
+#, c-format
+msgid "Value must be %s or higher."
+msgstr "Vlera duhet të jetë %s ose më e madhe."
+
+#: ../src/propgrid/props.cpp:329 ../src/propgrid/props.cpp:356
+#, c-format
+msgid "Value must be between %s and %s."
+msgstr "Vlera duhet të jetë mes %s dhe %s."
+
+#: ../src/propgrid/props.cpp:351
+#, c-format
+msgid "Value must be %s or less."
+msgstr "Vlera duhet të jetë %s ose më e vogël."
+
+#: ../src/propgrid/props.cpp:1058
+#, c-format
+msgid "Not %s"
+msgstr "Jo %s"
+
+#: ../src/propgrid/props.cpp:1770
+msgid "Choose a directory:"
+msgstr "Zgjidhni një drejtori:"
+
+#: ../src/propgrid/props.cpp:2055
+msgid "Choose a file"
+msgstr "Zgjidhni një kartelë"
+
+#: ../src/qt/mdi.cpp:254
+msgid "&Tile"
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:147
+#: ../src/richtext/richtextformatdlg.cpp:376
+msgid "Background"
+msgstr "Sfond"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:159
+msgid "Background &colour:"
+msgstr "&Ngjyrë sfondi:"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:161
+#: ../src/richtext/richtextbackgroundpage.cpp:163
+msgid "Enables a background colour."
+msgstr "Aktivizon një ngjyrë sfondi."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:167
+#: ../src/richtext/richtextbackgroundpage.cpp:169
+msgid "The background colour."
+msgstr "Ngjyra e sfondit."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:178
+msgid "Shadow"
+msgstr "Hije"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:193
+msgid "Use &shadow"
+msgstr "Përdor &hije"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:195
+#: ../src/richtext/richtextbackgroundpage.cpp:197
+msgid "Enables a shadow."
+msgstr "Aktivizon një hije."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:211
+msgid "&Horizontal offset:"
+msgstr "Shmangie &horizontale:"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:218
+#: ../src/richtext/richtextbackgroundpage.cpp:220
+msgid "The horizontal offset."
+msgstr "Shmangia horizontale."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:224
+#: ../src/richtext/richtextbackgroundpage.cpp:227
+#: ../src/richtext/richtextbackgroundpage.cpp:228
+#: ../src/richtext/richtextbackgroundpage.cpp:247
+#: ../src/richtext/richtextbackgroundpage.cpp:250
+#: ../src/richtext/richtextbackgroundpage.cpp:251
+#: ../src/richtext/richtextbackgroundpage.cpp:287
+#: ../src/richtext/richtextbackgroundpage.cpp:290
+#: ../src/richtext/richtextbackgroundpage.cpp:291
+#: ../src/richtext/richtextbackgroundpage.cpp:314
+#: ../src/richtext/richtextbackgroundpage.cpp:317
+#: ../src/richtext/richtextbackgroundpage.cpp:318
+#: ../src/richtext/richtextborderspage.cpp:252
+#: ../src/richtext/richtextborderspage.cpp:255
+#: ../src/richtext/richtextborderspage.cpp:256
+#: ../src/richtext/richtextborderspage.cpp:286
+#: ../src/richtext/richtextborderspage.cpp:289
+#: ../src/richtext/richtextborderspage.cpp:290
+#: ../src/richtext/richtextborderspage.cpp:320
+#: ../src/richtext/richtextborderspage.cpp:323
+#: ../src/richtext/richtextborderspage.cpp:324
+#: ../src/richtext/richtextborderspage.cpp:354
+#: ../src/richtext/richtextborderspage.cpp:357
+#: ../src/richtext/richtextborderspage.cpp:358
+#: ../src/richtext/richtextborderspage.cpp:420
+#: ../src/richtext/richtextborderspage.cpp:423
+#: ../src/richtext/richtextborderspage.cpp:424
+#: ../src/richtext/richtextborderspage.cpp:454
+#: ../src/richtext/richtextborderspage.cpp:457
+#: ../src/richtext/richtextborderspage.cpp:458
+#: ../src/richtext/richtextborderspage.cpp:488
+#: ../src/richtext/richtextborderspage.cpp:491
+#: ../src/richtext/richtextborderspage.cpp:492
+#: ../src/richtext/richtextborderspage.cpp:522
+#: ../src/richtext/richtextborderspage.cpp:525
+#: ../src/richtext/richtextborderspage.cpp:526
+#: ../src/richtext/richtextborderspage.cpp:590
+#: ../src/richtext/richtextborderspage.cpp:593
+#: ../src/richtext/richtextborderspage.cpp:594
+#: ../src/richtext/richtextfontpage.cpp:177
+#: ../src/richtext/richtextmarginspage.cpp:199
+#: ../src/richtext/richtextmarginspage.cpp:201
+#: ../src/richtext/richtextmarginspage.cpp:202
+#: ../src/richtext/richtextmarginspage.cpp:224
+#: ../src/richtext/richtextmarginspage.cpp:226
+#: ../src/richtext/richtextmarginspage.cpp:227
+#: ../src/richtext/richtextmarginspage.cpp:247
+#: ../src/richtext/richtextmarginspage.cpp:249
+#: ../src/richtext/richtextmarginspage.cpp:250
+#: ../src/richtext/richtextmarginspage.cpp:272
+#: ../src/richtext/richtextmarginspage.cpp:274
+#: ../src/richtext/richtextmarginspage.cpp:275
+#: ../src/richtext/richtextmarginspage.cpp:313
+#: ../src/richtext/richtextmarginspage.cpp:315
+#: ../src/richtext/richtextmarginspage.cpp:316
+#: ../src/richtext/richtextmarginspage.cpp:338
+#: ../src/richtext/richtextmarginspage.cpp:340
+#: ../src/richtext/richtextmarginspage.cpp:341
+#: ../src/richtext/richtextmarginspage.cpp:361
+#: ../src/richtext/richtextmarginspage.cpp:363
+#: ../src/richtext/richtextmarginspage.cpp:364
+#: ../src/richtext/richtextmarginspage.cpp:386
+#: ../src/richtext/richtextmarginspage.cpp:388
+#: ../src/richtext/richtextmarginspage.cpp:389
+#: ../src/richtext/richtextsizepage.cpp:337
+#: ../src/richtext/richtextsizepage.cpp:340
+#: ../src/richtext/richtextsizepage.cpp:341
+#: ../src/richtext/richtextsizepage.cpp:371
+#: ../src/richtext/richtextsizepage.cpp:374
+#: ../src/richtext/richtextsizepage.cpp:375
+#: ../src/richtext/richtextsizepage.cpp:398
+#: ../src/richtext/richtextsizepage.cpp:401
+#: ../src/richtext/richtextsizepage.cpp:402
+#: ../src/richtext/richtextsizepage.cpp:425
+#: ../src/richtext/richtextsizepage.cpp:428
+#: ../src/richtext/richtextsizepage.cpp:429
+#: ../src/richtext/richtextsizepage.cpp:452
+#: ../src/richtext/richtextsizepage.cpp:455
+#: ../src/richtext/richtextsizepage.cpp:456
+#: ../src/richtext/richtextsizepage.cpp:479
+#: ../src/richtext/richtextsizepage.cpp:482
+#: ../src/richtext/richtextsizepage.cpp:483
+#: ../src/richtext/richtextsizepage.cpp:553
+#: ../src/richtext/richtextsizepage.cpp:556
+#: ../src/richtext/richtextsizepage.cpp:557
+#: ../src/richtext/richtextsizepage.cpp:588
+#: ../src/richtext/richtextsizepage.cpp:591
+#: ../src/richtext/richtextsizepage.cpp:592
+#: ../src/richtext/richtextsizepage.cpp:623
+#: ../src/richtext/richtextsizepage.cpp:626
+#: ../src/richtext/richtextsizepage.cpp:627
+#: ../src/richtext/richtextsizepage.cpp:658
+#: ../src/richtext/richtextsizepage.cpp:661
+#: ../src/richtext/richtextsizepage.cpp:662
+msgid "px"
+msgstr "px"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:225
+#: ../src/richtext/richtextbackgroundpage.cpp:248
+#: ../src/richtext/richtextbackgroundpage.cpp:288
+#: ../src/richtext/richtextbackgroundpage.cpp:315
+#: ../src/richtext/richtextborderspage.cpp:253
+#: ../src/richtext/richtextborderspage.cpp:287
+#: ../src/richtext/richtextborderspage.cpp:321
+#: ../src/richtext/richtextborderspage.cpp:355
+#: ../src/richtext/richtextborderspage.cpp:421
+#: ../src/richtext/richtextborderspage.cpp:455
+#: ../src/richtext/richtextborderspage.cpp:489
+#: ../src/richtext/richtextborderspage.cpp:523
+#: ../src/richtext/richtextborderspage.cpp:591
+#: ../src/richtext/richtextmarginspage.cpp:200
+#: ../src/richtext/richtextmarginspage.cpp:225
+#: ../src/richtext/richtextmarginspage.cpp:248
+#: ../src/richtext/richtextmarginspage.cpp:273
+#: ../src/richtext/richtextmarginspage.cpp:314
+#: ../src/richtext/richtextmarginspage.cpp:339
+#: ../src/richtext/richtextmarginspage.cpp:362
+#: ../src/richtext/richtextmarginspage.cpp:387
+#: ../src/richtext/richtextsizepage.cpp:338
+#: ../src/richtext/richtextsizepage.cpp:372
+#: ../src/richtext/richtextsizepage.cpp:399
+#: ../src/richtext/richtextsizepage.cpp:426
+#: ../src/richtext/richtextsizepage.cpp:453
+#: ../src/richtext/richtextsizepage.cpp:480
+#: ../src/richtext/richtextsizepage.cpp:554
+#: ../src/richtext/richtextsizepage.cpp:589
+#: ../src/richtext/richtextsizepage.cpp:624
+#: ../src/richtext/richtextsizepage.cpp:659
+msgid "cm"
+msgstr "cm"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:226
+#: ../src/richtext/richtextbackgroundpage.cpp:249
+#: ../src/richtext/richtextbackgroundpage.cpp:289
+#: ../src/richtext/richtextbackgroundpage.cpp:316
+#: ../src/richtext/richtextborderspage.cpp:254
+#: ../src/richtext/richtextborderspage.cpp:288
+#: ../src/richtext/richtextborderspage.cpp:322
+#: ../src/richtext/richtextborderspage.cpp:356
+#: ../src/richtext/richtextborderspage.cpp:422
+#: ../src/richtext/richtextborderspage.cpp:456
+#: ../src/richtext/richtextborderspage.cpp:490
+#: ../src/richtext/richtextborderspage.cpp:524
+#: ../src/richtext/richtextborderspage.cpp:592
+#: ../src/richtext/richtextfontpage.cpp:176
+#: ../src/richtext/richtextfontpage.cpp:179
+msgid "pt"
+msgstr "pt"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:229
+#: ../src/richtext/richtextbackgroundpage.cpp:231
+#: ../src/richtext/richtextbackgroundpage.cpp:252
+#: ../src/richtext/richtextbackgroundpage.cpp:254
+#: ../src/richtext/richtextbackgroundpage.cpp:292
+#: ../src/richtext/richtextbackgroundpage.cpp:294
+#: ../src/richtext/richtextbackgroundpage.cpp:319
+#: ../src/richtext/richtextbackgroundpage.cpp:321
+msgid "Units for this value."
+msgstr "Njësi për këtë vlerë."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:234
+msgid "&Vertical offset:"
+msgstr "Shmangie &vertikale:"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:241
+#: ../src/richtext/richtextbackgroundpage.cpp:243
+msgid "The vertical offset."
+msgstr "Shmangia vertikale."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:257
+msgid "Shadow c&olour:"
+msgstr "&Ngjyrë hijeje:"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:259
+#: ../src/richtext/richtextbackgroundpage.cpp:261
+msgid "Enables the shadow colour."
+msgstr "Aktivizon një ngjyrë hijeje."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:265
+#: ../src/richtext/richtextbackgroundpage.cpp:267
+msgid "The shadow colour."
+msgstr "Ngjyra e hijes."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:270
+msgid "Sh&adow spread:"
+msgstr "Shtr&irje hijeje:"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:272
+#: ../src/richtext/richtextbackgroundpage.cpp:274
+msgid "Enables the shadow spread."
+msgstr "Aktivizon shtrirje hijeje."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:281
+#: ../src/richtext/richtextbackgroundpage.cpp:283
+msgid "The shadow spread."
+msgstr "Shtrirja e hijes."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:297
+msgid "&Blur distance:"
+msgstr "Distancë &turbullimi:"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:299
+#: ../src/richtext/richtextbackgroundpage.cpp:301
+msgid "Enables the blur distance."
+msgstr "Aktivizon largësi turbullimi."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:308
+#: ../src/richtext/richtextbackgroundpage.cpp:310
+msgid "The shadow blur distance."
+msgstr "Largësia e turbullimit të hijes."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:324
+msgid "Opaci&ty:"
+msgstr "Pa&tejdukshmëri:"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:326
+#: ../src/richtext/richtextbackgroundpage.cpp:328
+msgid "Enables the shadow opacity."
+msgstr "Aktivizon patejdukshmëri hijeje."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:335
+#: ../src/richtext/richtextbackgroundpage.cpp:337
+msgid "The shadow opacity."
+msgstr "Patejdukshmëria e hijes."
+
+#. TRANSLATORS: Rich text page units (percentage)
+#: ../src/richtext/richtextbackgroundpage.cpp:340
+#: ../src/richtext/richtextsizepage.cpp:339
+#: ../src/richtext/richtextsizepage.cpp:373
+#: ../src/richtext/richtextsizepage.cpp:400
+#: ../src/richtext/richtextsizepage.cpp:427
+#: ../src/richtext/richtextsizepage.cpp:454
+#: ../src/richtext/richtextsizepage.cpp:481
+#: ../src/richtext/richtextsizepage.cpp:555
+#: ../src/richtext/richtextsizepage.cpp:590
+#: ../src/richtext/richtextsizepage.cpp:625
+#: ../src/richtext/richtextsizepage.cpp:660
+msgid "%"
+msgstr "%"
+
+#: ../src/richtext/richtextborderspage.cpp:229
+#: ../src/richtext/richtextborderspage.cpp:387
+msgid "Border"
+msgstr "Anë"
+
+#: ../src/richtext/richtextborderspage.cpp:242
+#: ../src/richtext/richtextborderspage.cpp:410
+#: ../src/richtext/richtextindentspage.cpp:194
+#: ../src/richtext/richtextliststylepage.cpp:384
+#: ../src/richtext/richtextmarginspage.cpp:185
+#: ../src/richtext/richtextmarginspage.cpp:299
+#: ../src/richtext/richtextsizepage.cpp:531
+#: ../src/richtext/richtextsizepage.cpp:538
+msgid "&Left:"
+msgstr "&Majtas:"
+
+#: ../src/richtext/richtextborderspage.cpp:257
+#: ../src/richtext/richtextborderspage.cpp:259
+msgid "Units for the left border width."
+msgstr "Njësi për gjerësinë e cakut majtas."
+
+#: ../src/richtext/richtextborderspage.cpp:266
+#: ../src/richtext/richtextborderspage.cpp:268
+#: ../src/richtext/richtextborderspage.cpp:300
+#: ../src/richtext/richtextborderspage.cpp:302
+#: ../src/richtext/richtextborderspage.cpp:334
+#: ../src/richtext/richtextborderspage.cpp:336
+#: ../src/richtext/richtextborderspage.cpp:368
+#: ../src/richtext/richtextborderspage.cpp:370
+#: ../src/richtext/richtextborderspage.cpp:434
+#: ../src/richtext/richtextborderspage.cpp:436
+#: ../src/richtext/richtextborderspage.cpp:468
+#: ../src/richtext/richtextborderspage.cpp:470
+#: ../src/richtext/richtextborderspage.cpp:502
+#: ../src/richtext/richtextborderspage.cpp:504
+#: ../src/richtext/richtextborderspage.cpp:536
+#: ../src/richtext/richtextborderspage.cpp:538
+msgid "The border line style."
+msgstr "Stili i vijave të caqeve."
+
+#: ../src/richtext/richtextborderspage.cpp:276
+#: ../src/richtext/richtextborderspage.cpp:444
+#: ../src/richtext/richtextindentspage.cpp:212
+#: ../src/richtext/richtextliststylepage.cpp:402
+#: ../src/richtext/richtextmarginspage.cpp:210
+#: ../src/richtext/richtextmarginspage.cpp:324
+#: ../src/richtext/richtextsizepage.cpp:601
+#: ../src/richtext/richtextsizepage.cpp:608
+msgid "&Right:"
+msgstr "&Djathtas:"
+
+#: ../src/richtext/richtextborderspage.cpp:291
+#: ../src/richtext/richtextborderspage.cpp:293
+msgid "Units for the right border width."
+msgstr "Njësi për gjerësinë e cakut djathtas."
+
+#: ../src/richtext/richtextborderspage.cpp:310
+#: ../src/richtext/richtextborderspage.cpp:478
+#: ../src/richtext/richtextmarginspage.cpp:233
+#: ../src/richtext/richtextmarginspage.cpp:347
+#: ../src/richtext/richtextsizepage.cpp:566
+#: ../src/richtext/richtextsizepage.cpp:573
+msgid "&Top:"
+msgstr "Në &Krye:"
+
+#: ../src/richtext/richtextborderspage.cpp:325
+#: ../src/richtext/richtextborderspage.cpp:327
+msgid "Units for the top border width."
+msgstr "Njësi për gjerësinë e cakut të sipërm."
+
+#: ../src/richtext/richtextborderspage.cpp:344
+#: ../src/richtext/richtextborderspage.cpp:512
+#: ../src/richtext/richtextmarginspage.cpp:258
+#: ../src/richtext/richtextmarginspage.cpp:372
+#: ../src/richtext/richtextsizepage.cpp:636
+#: ../src/richtext/richtextsizepage.cpp:643
+msgid "&Bottom:"
+msgstr "&Në fund:"
+
+#: ../src/richtext/richtextborderspage.cpp:359
+#: ../src/richtext/richtextborderspage.cpp:361
+msgid "Units for the bottom border width."
+msgstr "Njësi për gjerësinë e caqeve të poshtëm."
+
+#: ../src/richtext/richtextborderspage.cpp:380
+#: ../src/richtext/richtextborderspage.cpp:548
+msgid "&Synchronize values"
+msgstr "&Njëkohëso vlera"
+
+#: ../src/richtext/richtextborderspage.cpp:382
+#: ../src/richtext/richtextborderspage.cpp:384
+#: ../src/richtext/richtextborderspage.cpp:550
+#: ../src/richtext/richtextborderspage.cpp:552
+msgid "Check to edit all borders simultaneously."
+msgstr "I vini shenjë që të përpunohen njëkohësisht krejt anët."
+
+#: ../src/richtext/richtextborderspage.cpp:397
+#: ../src/richtext/richtextborderspage.cpp:555
+msgid "Outline"
+msgstr "Përvijim"
+
+#: ../src/richtext/richtextborderspage.cpp:425
+#: ../src/richtext/richtextborderspage.cpp:427
+msgid "Units for the left outline width."
+msgstr "Njësi për gjerësinë e përvijimit majtas."
+
+#: ../src/richtext/richtextborderspage.cpp:459
+#: ../src/richtext/richtextborderspage.cpp:461
+msgid "Units for the right outline width."
+msgstr "Njësi për gjerësinë e përvijimit djathtas."
+
+#: ../src/richtext/richtextborderspage.cpp:493
+#: ../src/richtext/richtextborderspage.cpp:495
+msgid "Units for the top outline width."
+msgstr "Njësi për gjerësinë e përvijimit të sipërm."
+
+#: ../src/richtext/richtextborderspage.cpp:527
+#: ../src/richtext/richtextborderspage.cpp:529
+msgid "Units for the bottom outline width."
+msgstr "Njësi për gjerësinë e përvijimit të poshtëm."
+
+#: ../src/richtext/richtextborderspage.cpp:565
+#: ../src/richtext/richtextborderspage.cpp:600
+msgid "Corner"
+msgstr "Cep"
+
+#: ../src/richtext/richtextborderspage.cpp:574
+msgid "Corner &radius:"
+msgstr "&Rreze cepi:"
+
+#: ../src/richtext/richtextborderspage.cpp:576
+#: ../src/richtext/richtextborderspage.cpp:578
+msgid "An optional corner radius for adding rounded corners."
+msgstr "Një rreze opsionale cepash, për shtim cepash të rrumbullakuar."
+
+#: ../src/richtext/richtextborderspage.cpp:584
+#: ../src/richtext/richtextborderspage.cpp:586
+msgid "The value of the corner radius."
+msgstr "Vlera e rrezes së cepit."
+
+#: ../src/richtext/richtextborderspage.cpp:595
+#: ../src/richtext/richtextborderspage.cpp:597
+msgid "Units for the corner radius."
+msgstr "Njësi për rreze cepi."
+
+#: ../src/richtext/richtextborderspage.cpp:609
+#: ../src/richtext/richtextsizepage.cpp:247
+#: ../src/richtext/richtextsizepage.cpp:251
+msgid "None"
+msgstr "Asnjë"
+
+#: ../src/richtext/richtextborderspage.cpp:610
+msgid "Solid"
+msgstr "Solide"
+
+#: ../src/richtext/richtextborderspage.cpp:611
+msgid "Dotted"
+msgstr "Me pika"
+
+#: ../src/richtext/richtextborderspage.cpp:612
+msgid "Dashed"
+msgstr "Me vija"
+
+#: ../src/richtext/richtextborderspage.cpp:613
+msgid "Double"
+msgstr "Dyshe"
+
+#: ../src/richtext/richtextborderspage.cpp:614
+msgid "Groove"
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:615
+msgid "Ridge"
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:616
+msgid "Inset"
+msgstr "Brendazi"
+
+#: ../src/richtext/richtextborderspage.cpp:617
+msgid "Outset"
+msgstr "Jashtazi"
+
+#: ../src/richtext/richtextbuffer.cpp:3518
+msgid "Change Style"
+msgstr "Ndryshoni Stil"
+
+#: ../src/richtext/richtextbuffer.cpp:3701
+msgid "Change Object Style"
+msgstr "Ndryshoni Stil Objekti"
+
+#: ../src/richtext/richtextbuffer.cpp:3974
+#: ../src/richtext/richtextbuffer.cpp:8174
+msgid "Change Properties"
+msgstr "Ndryshoni Veti"
+
+#: ../src/richtext/richtextbuffer.cpp:4346
+msgid "Change List Style"
+msgstr "Ndryshoni Stil Liste"
+
+#: ../src/richtext/richtextbuffer.cpp:4519
+msgid "Renumber List"
+msgstr "Rinumërto Listën"
+
+#: ../src/richtext/richtextbuffer.cpp:7867
+#: ../src/richtext/richtextbuffer.cpp:7897
+#: ../src/richtext/richtextbuffer.cpp:7939
+#: ../src/richtext/richtextctrl.cpp:1279 ../src/richtext/richtextctrl.cpp:1473
+msgid "Insert Text"
+msgstr "Futni Tekst"
+
+#: ../src/richtext/richtextbuffer.cpp:8023
+#: ../src/richtext/richtextbuffer.cpp:8979
+msgid "Insert Image"
+msgstr "Futni Figurë"
+
+#: ../src/richtext/richtextbuffer.cpp:8070
+msgid "Insert Object"
+msgstr "Futni Objekt"
+
+#: ../src/richtext/richtextbuffer.cpp:8112
+msgid "Insert Field"
+msgstr "Futni Fushë"
+
+#: ../src/richtext/richtextbuffer.cpp:8410
+msgid "Too many EndStyle calls!"
+msgstr "Shumë thirrje EndStyle!"
+
+#: ../src/richtext/richtextbuffer.cpp:8785
+msgid "files"
+msgstr "kartela"
+
+#: ../src/richtext/richtextbuffer.cpp:9380
+msgid "standard/circle"
+msgstr "standard/rreth"
+
+#: ../src/richtext/richtextbuffer.cpp:9381
+msgid "standard/circle-outline"
+msgstr "standard/përvijim-rrethor"
+
+#: ../src/richtext/richtextbuffer.cpp:9382
+msgid "standard/square"
+msgstr "standard/katror"
+
+#: ../src/richtext/richtextbuffer.cpp:9383
+msgid "standard/diamond"
+msgstr "standard/romb"
+
+#: ../src/richtext/richtextbuffer.cpp:9384
+msgid "standard/triangle"
+msgstr "standard/trikëndësh"
+
+#: ../src/richtext/richtextbuffer.cpp:9423
+msgid "Box Properties"
+msgstr "Veti Kuadrati"
+
+#: ../src/richtext/richtextbuffer.cpp:10006
+msgid "Multiple Cell Properties"
+msgstr ""
+
+#: ../src/richtext/richtextbuffer.cpp:10008
+msgid "Cell Properties"
+msgstr "Veti Kutize"
+
+#: ../src/richtext/richtextbuffer.cpp:11256
+msgid "Set Cell Style"
+msgstr "Caktoni Stil Kutize"
+
+#: ../src/richtext/richtextbuffer.cpp:11330
+msgid "Delete Row"
+msgstr "Fshije Rreshtin"
+
+#: ../src/richtext/richtextbuffer.cpp:11380
+msgid "Delete Column"
+msgstr "Fshije Shtyllën"
+
+#: ../src/richtext/richtextbuffer.cpp:11431
+msgid "Add Row"
+msgstr "Shtoni Rresht"
+
+#: ../src/richtext/richtextbuffer.cpp:11494
+msgid "Add Column"
+msgstr "Shtoni Shtyllë"
+
+#: ../src/richtext/richtextbuffer.cpp:11537
+msgid "Table Properties"
+msgstr "Veti Tabele"
+
+#: ../src/richtext/richtextbuffer.cpp:12899
+msgid "Picture Properties"
+msgstr "Veti Fotoje"
+
+#: ../src/richtext/richtextbuffer.cpp:13169
+#: ../src/richtext/richtextbuffer.cpp:13279
+msgid "image"
+msgstr "figurë"
+
+#: ../src/richtext/richtextbulletspage.cpp:145
+#: ../src/richtext/richtextliststylepage.cpp:209
+msgid "&Bullet style:"
+msgstr "Stil me t&optha:"
+
+#: ../src/richtext/richtextbulletspage.cpp:150
+#: ../src/richtext/richtextbulletspage.cpp:152
+#: ../src/richtext/richtextliststylepage.cpp:214
+#: ../src/richtext/richtextliststylepage.cpp:216
+msgid "The available bullet styles."
+msgstr "Stilet e gatshëm me toptha."
+
+#: ../src/richtext/richtextbulletspage.cpp:158
+#: ../src/richtext/richtextliststylepage.cpp:221
+msgid "Peri&od"
+msgstr "Peri&udhë"
+
+#: ../src/richtext/richtextbulletspage.cpp:160
+#: ../src/richtext/richtextbulletspage.cpp:162
+#: ../src/richtext/richtextliststylepage.cpp:223
+#: ../src/richtext/richtextliststylepage.cpp:225
+msgid "Check to add a period after the bullet."
+msgstr "I vini shenjë që të shtohet një pikë pas topthit."
+
+#. TRANSLATORS: Bullet point in parentheses option
+#: ../src/richtext/richtextbulletspage.cpp:167
+#: ../src/richtext/richtextliststylepage.cpp:230
+msgid "(*)"
+msgstr "(*)"
+
+#: ../src/richtext/richtextbulletspage.cpp:169
+#: ../src/richtext/richtextbulletspage.cpp:171
+#: ../src/richtext/richtextliststylepage.cpp:232
+#: ../src/richtext/richtextliststylepage.cpp:234
+msgid "Check to enclose the bullet in parentheses."
+msgstr "I vini shenjë që topthit t’i vihen kllapa."
+
+#. TRANSLATORS: Right parenthesis bullet point option
+#: ../src/richtext/richtextbulletspage.cpp:176
+#: ../src/richtext/richtextliststylepage.cpp:239
+msgid "*)"
+msgstr "*)"
+
+#: ../src/richtext/richtextbulletspage.cpp:178
+#: ../src/richtext/richtextbulletspage.cpp:180
+#: ../src/richtext/richtextliststylepage.cpp:241
+#: ../src/richtext/richtextliststylepage.cpp:243
+msgid "Check to add a right parenthesis."
+msgstr "I vini shenjë që të shtohet një kllapë djathtas."
+
+#: ../src/richtext/richtextbulletspage.cpp:185
+#: ../src/richtext/richtextliststylepage.cpp:248
+msgid "Bullet &Alignment:"
+msgstr "&Drejtim Topthash:"
+
+#: ../src/richtext/richtextbulletspage.cpp:190
+#: ../src/richtext/richtextliststylepage.cpp:253
+msgid "Centre"
+msgstr "Në qendër"
+
+#: ../src/richtext/richtextbulletspage.cpp:194
+#: ../src/richtext/richtextbulletspage.cpp:196
+#: ../src/richtext/richtextbulletspage.cpp:217
+#: ../src/richtext/richtextbulletspage.cpp:219
+#: ../src/richtext/richtextliststylepage.cpp:257
+#: ../src/richtext/richtextliststylepage.cpp:259
+#: ../src/richtext/richtextliststylepage.cpp:278
+#: ../src/richtext/richtextliststylepage.cpp:280
+msgid "The bullet character."
+msgstr "Shenja e topthit."
+
+#: ../src/richtext/richtextbulletspage.cpp:212
+#: ../src/richtext/richtextliststylepage.cpp:271
+msgid "&Symbol:"
+msgstr "&Simbol:"
+
+#: ../src/richtext/richtextbulletspage.cpp:222
+#: ../src/richtext/richtextliststylepage.cpp:283
+msgid "Ch&oose..."
+msgstr "&Zgjidhni…"
+
+#: ../src/richtext/richtextbulletspage.cpp:223
+#: ../src/richtext/richtextbulletspage.cpp:225
+#: ../src/richtext/richtextliststylepage.cpp:284
+#: ../src/richtext/richtextliststylepage.cpp:286
+msgid "Click to browse for a symbol."
+msgstr "Klikoni që të shfletoni për një simbol."
+
+#: ../src/richtext/richtextbulletspage.cpp:230
+#: ../src/richtext/richtextliststylepage.cpp:291
+msgid "Symbol &font:"
+msgstr "&Shkronja simbol:"
+
+#: ../src/richtext/richtextbulletspage.cpp:235
+#: ../src/richtext/richtextbulletspage.cpp:237
+#: ../src/richtext/richtextliststylepage.cpp:297
+msgid "Available fonts."
+msgstr "Shkronja të gatshme."
+
+#: ../src/richtext/richtextbulletspage.cpp:242
+#: ../src/richtext/richtextliststylepage.cpp:302
+msgid "S&tandard bullet name:"
+msgstr "Emër topthi &standard:"
+
+#: ../src/richtext/richtextbulletspage.cpp:247
+#: ../src/richtext/richtextbulletspage.cpp:249
+#: ../src/richtext/richtextliststylepage.cpp:307
+#: ../src/richtext/richtextliststylepage.cpp:309
+msgid "A standard bullet name."
+msgstr "Emër standard stili me toptha."
+
+#: ../src/richtext/richtextbulletspage.cpp:254
+msgid "&Number:"
+msgstr "&Numër:"
+
+#: ../src/richtext/richtextbulletspage.cpp:258
+#: ../src/richtext/richtextbulletspage.cpp:260
+msgid "The list item number."
+msgstr "Numri i objektit në listë."
+
+#: ../src/richtext/richtextbulletspage.cpp:266
+#: ../src/richtext/richtextbulletspage.cpp:268
+#: ../src/richtext/richtextliststylepage.cpp:475
+#: ../src/richtext/richtextliststylepage.cpp:477
+msgid "Shows a preview of the bullet settings."
+msgstr "Shfaq një paraparje të rregullimeve të topthave."
+
+#: ../src/richtext/richtextbulletspage.cpp:276
+#: ../src/richtext/richtextliststylepage.cpp:484
+msgid "(None)"
+msgstr "(Asnjë)"
+
+#: ../src/richtext/richtextbulletspage.cpp:277
+#: ../src/richtext/richtextliststylepage.cpp:485
+msgid "Arabic"
+msgstr "Arabike"
+
+#: ../src/richtext/richtextbulletspage.cpp:278
+#: ../src/richtext/richtextliststylepage.cpp:486
+msgid "Upper case letters"
+msgstr "Shkronja të mëdha"
+
+#: ../src/richtext/richtextbulletspage.cpp:279
+#: ../src/richtext/richtextliststylepage.cpp:487
+msgid "Lower case letters"
+msgstr "Shkronja të vogla"
+
+#: ../src/richtext/richtextbulletspage.cpp:280
+#: ../src/richtext/richtextliststylepage.cpp:488
+msgid "Upper case roman numerals"
+msgstr "Numra romakë me të mëdha"
+
+#: ../src/richtext/richtextbulletspage.cpp:281
+#: ../src/richtext/richtextliststylepage.cpp:489
+msgid "Lower case roman numerals"
+msgstr "Numra romakë me të vogla"
+
+#: ../src/richtext/richtextbulletspage.cpp:282
+#: ../src/richtext/richtextliststylepage.cpp:490
+msgid "Numbered outline"
+msgstr "Përvijim i numërtuar"
+
+#: ../src/richtext/richtextbulletspage.cpp:283
+#: ../src/richtext/richtextliststylepage.cpp:491
+msgid "Symbol"
+msgstr "Simbol"
+
+#: ../src/richtext/richtextbulletspage.cpp:284
+#: ../src/richtext/richtextliststylepage.cpp:492
+msgid "Bitmap"
+msgstr "Bitmap"
+
+#: ../src/richtext/richtextbulletspage.cpp:285
+#: ../src/richtext/richtextliststylepage.cpp:493
+msgid "Standard"
+msgstr "Standarde"
+
+#: ../src/richtext/richtextbulletspage.cpp:287
+#: ../src/richtext/richtextliststylepage.cpp:495
+msgid "*"
+msgstr "*"
+
+#: ../src/richtext/richtextbulletspage.cpp:288
+#: ../src/richtext/richtextliststylepage.cpp:496
+msgid "-"
+msgstr "-"
+
+#: ../src/richtext/richtextbulletspage.cpp:289
+#: ../src/richtext/richtextliststylepage.cpp:497
+msgid ">"
+msgstr ">"
+
+#: ../src/richtext/richtextbulletspage.cpp:290
+#: ../src/richtext/richtextliststylepage.cpp:498
+msgid "+"
+msgstr "+"
+
+#: ../src/richtext/richtextbulletspage.cpp:291
+#: ../src/richtext/richtextliststylepage.cpp:499
+msgid "~"
+msgstr "~"
+
+#: ../src/richtext/richtextctrl.cpp:859
+msgid "Drag"
+msgstr "Tërhiqeni"
+
+#: ../src/richtext/richtextctrl.cpp:1338 ../src/richtext/richtextctrl.cpp:1559
+msgid "Delete Text"
+msgstr "Fshije Tekstin"
+
+#: ../src/richtext/richtextctrl.cpp:1537
+msgid "Remove Bullet"
+msgstr "Hiqe Topthin"
+
+#: ../src/richtext/richtextctrl.cpp:3070
+msgid "The text couldn't be saved."
+msgstr "Teksti s’u ruajt dot."
+
+#: ../src/richtext/richtextctrl.cpp:3644
+msgid "Replace"
+msgstr "Zëvendësoje"
+
+#: ../src/richtext/richtextfontpage.cpp:146
+#: ../src/richtext/richtextsymboldlg.cpp:384
+msgid "&Font:"
+msgstr "&Shkronja:"
+
+#: ../src/richtext/richtextfontpage.cpp:150
+#: ../src/richtext/richtextfontpage.cpp:152
+msgid "Type a font name."
+msgstr "Shtypni një emër shkronjash."
+
+#: ../src/richtext/richtextfontpage.cpp:158
+msgid "&Size:"
+msgstr "&Madhësi:"
+
+#: ../src/richtext/richtextfontpage.cpp:165
+#: ../src/richtext/richtextfontpage.cpp:167
+msgid "Type a size in points."
+msgstr "Shtypni një madhësi në pikë."
+
+#: ../src/richtext/richtextfontpage.cpp:180
+#: ../src/richtext/richtextfontpage.cpp:182
+msgid "The font size units, points or pixels."
+msgstr "Njësitë e madhësisë së shkronjave, pikë ose piksel."
+
+#: ../src/richtext/richtextfontpage.cpp:189
+#: ../src/richtext/richtextfontpage.cpp:191
+msgid "Lists the available fonts."
+msgstr "Lista shkronjash të gatshme."
+
+#: ../src/richtext/richtextfontpage.cpp:196
+#: ../src/richtext/richtextfontpage.cpp:198
+msgid "Lists font sizes in points."
+msgstr "Madhësi shkronjash liste, në pikë."
+
+#: ../src/richtext/richtextfontpage.cpp:207
+msgid "Font st&yle:"
+msgstr "&Stil shkronjash:"
+
+#: ../src/richtext/richtextfontpage.cpp:212
+#: ../src/richtext/richtextfontpage.cpp:214
+msgid "Select regular or italic style."
+msgstr "Përzgjidhni stil të rregullt ose të pjerrët."
+
+#: ../src/richtext/richtextfontpage.cpp:220
+msgid "Font &weight:"
+msgstr "&Madhësi shkronjash:"
+
+#: ../src/richtext/richtextfontpage.cpp:225
+#: ../src/richtext/richtextfontpage.cpp:227
+msgid "Select regular or bold."
+msgstr "Përzgjidhni të rregullta ose të trasha."
+
+#: ../src/richtext/richtextfontpage.cpp:233
+msgid "&Underlining:"
+msgstr "&Nënvijëzim:"
+
+#: ../src/richtext/richtextfontpage.cpp:238
+#: ../src/richtext/richtextfontpage.cpp:240
+msgid "Select underlining or no underlining."
+msgstr "Përzgjidhni nënvizim ose pa nënvizim."
+
+#: ../src/richtext/richtextfontpage.cpp:248
+msgid "&Colour:"
+msgstr "&Ngjyrë:"
+
+#: ../src/richtext/richtextfontpage.cpp:253
+#: ../src/richtext/richtextfontpage.cpp:255
+msgid "Click to change the text colour."
+msgstr "Klikoni që të ndryshohet ngjyra e tekstit."
+
+#: ../src/richtext/richtextfontpage.cpp:261
+msgid "&Bg colour:"
+msgstr "Ngjyrë &Bg:"
+
+#: ../src/richtext/richtextfontpage.cpp:266
+#: ../src/richtext/richtextfontpage.cpp:268
+msgid "Click to change the text background colour."
+msgstr "Klikoni që të ndryshohet ngjyra e sfondit të tekstit."
+
+#: ../src/richtext/richtextfontpage.cpp:276
+#: ../src/richtext/richtextfontpage.cpp:278
+msgid "Check to show a line through the text."
+msgstr "I vini shenjë që të shfaqet një vijë nëpër tekst."
+
+#: ../src/richtext/richtextfontpage.cpp:281
+msgid "Ca&pitals"
+msgstr "Ka&pitale"
+
+#: ../src/richtext/richtextfontpage.cpp:283
+#: ../src/richtext/richtextfontpage.cpp:285
+msgid "Check to show the text in capitals."
+msgstr "I vini shenjë që teksti të shfaqet me të mëdha."
+
+#: ../src/richtext/richtextfontpage.cpp:288
+msgid "Small C&apitals"
+msgstr "K&apitale të Vogla"
+
+#: ../src/richtext/richtextfontpage.cpp:290
+#: ../src/richtext/richtextfontpage.cpp:292
+msgid "Check to show the text in small capitals."
+msgstr "I vini shenjë që teksti të shfaqet me të mëdha të vogla."
+
+#: ../src/richtext/richtextfontpage.cpp:295
+msgid "Supe&rscript"
+msgstr "S&ipërshkrim"
+
+#: ../src/richtext/richtextfontpage.cpp:297
+#: ../src/richtext/richtextfontpage.cpp:299
+msgid "Check to show the text in superscript."
+msgstr "I vini shenjë që teksti të shfaqet me sipërshkrim."
+
+#: ../src/richtext/richtextfontpage.cpp:302
+msgid "Subscrip&t"
+msgstr "P&oshtëshkrim"
+
+#: ../src/richtext/richtextfontpage.cpp:304
+#: ../src/richtext/richtextfontpage.cpp:306
+msgid "Check to show the text in subscript."
+msgstr "I vini shenjë që teksti të shfaqet me poshtëshkrim."
+
+#: ../src/richtext/richtextfontpage.cpp:312
+msgid "Rig&ht-to-left"
+msgstr "Nga-e-djat&hta-në-të-majtë"
+
+#: ../src/richtext/richtextfontpage.cpp:314
+#: ../src/richtext/richtextfontpage.cpp:316
+msgid "Check to indicate right-to-left text layout."
+msgstr "I vini shenjë për të treguar skemë teksti nga-e-djathta-në-të-majtë."
+
+#: ../src/richtext/richtextfontpage.cpp:319
+msgid "Suppress hyphe&nation"
+msgstr "Ndale &ndarjen me vija"
+
+#: ../src/richtext/richtextfontpage.cpp:321
+#: ../src/richtext/richtextfontpage.cpp:323
+msgid "Check to suppress hyphenation."
+msgstr "I vini shenjë që të hiqen vijat ndarëse."
+
+#: ../src/richtext/richtextfontpage.cpp:329
+#: ../src/richtext/richtextfontpage.cpp:331
+msgid "Shows a preview of the font settings."
+msgstr "Shfaq një paraparje të rregullimeve të shkronjave."
+
+#: ../src/richtext/richtextfontpage.cpp:348
+#: ../src/richtext/richtextfontpage.cpp:352
+#: ../src/richtext/richtextfontpage.cpp:356
+#: ../src/richtext/richtextformatdlg.cpp:873
+#: ../src/richtext/richtextindentspage.cpp:273
+#: ../src/richtext/richtextindentspage.cpp:285
+#: ../src/richtext/richtextindentspage.cpp:286
+#: ../src/richtext/richtextindentspage.cpp:310
+#: ../src/richtext/richtextindentspage.cpp:325
+#: ../src/richtext/richtextliststylepage.cpp:451
+#: ../src/richtext/richtextliststylepage.cpp:463
+#: ../src/richtext/richtextliststylepage.cpp:464
+msgid "(none)"
+msgstr "(asnjë)"
+
+#: ../src/richtext/richtextfontpage.cpp:349
+#: ../src/richtext/richtextfontpage.cpp:353
+msgid "Regular"
+msgstr "Të rregullta"
+
+#: ../src/richtext/richtextfontpage.cpp:357
+msgid "Not underlined"
+msgstr "Jo të nënvijëzuara"
+
+#: ../src/richtext/richtextformatdlg.cpp:341
+msgid "Indents && Spacing"
+msgstr "Shmangie brendazi && Hapësira"
+
+#: ../src/richtext/richtextformatdlg.cpp:346
+msgid "Tabs"
+msgstr "Tabulacione"
+
+#: ../src/richtext/richtextformatdlg.cpp:351
+msgid "Bullets"
+msgstr "Toptha"
+
+#: ../src/richtext/richtextformatdlg.cpp:356
+msgid "List Style"
+msgstr "Stil Liste"
+
+#: ../src/richtext/richtextformatdlg.cpp:366
+#: ../src/richtext/richtextmarginspage.cpp:170
+msgid "Margins"
+msgstr "Mënjana"
+
+#: ../src/richtext/richtextformatdlg.cpp:371
+msgid "Borders"
+msgstr "Anë"
+
+#: ../src/richtext/richtextformatdlg.cpp:765
+msgid "Colour"
+msgstr "Ngjyrë"
+
+#: ../src/richtext/richtextindentspage.cpp:127
+#: ../src/richtext/richtextliststylepage.cpp:322
+msgid "&Alignment"
+msgstr "&Drejtim"
+
+#: ../src/richtext/richtextindentspage.cpp:138
+#: ../src/richtext/richtextliststylepage.cpp:331
+msgid "&Left"
+msgstr "&Majtas"
+
+#: ../src/richtext/richtextindentspage.cpp:140
+#: ../src/richtext/richtextindentspage.cpp:142
+#: ../src/richtext/richtextliststylepage.cpp:333
+#: ../src/richtext/richtextliststylepage.cpp:335
+msgid "Left-align text."
+msgstr "Vëre tekstin majtas."
+
+#: ../src/richtext/richtextindentspage.cpp:145
+#: ../src/richtext/richtextliststylepage.cpp:338
+msgid "&Right"
+msgstr "&Djathtas"
+
+#: ../src/richtext/richtextindentspage.cpp:147
+#: ../src/richtext/richtextindentspage.cpp:149
+#: ../src/richtext/richtextliststylepage.cpp:340
+#: ../src/richtext/richtextliststylepage.cpp:342
+msgid "Right-align text."
+msgstr "Vendose tekstin djathtas."
+
+#: ../src/richtext/richtextindentspage.cpp:152
+#: ../src/richtext/richtextliststylepage.cpp:345
+msgid "&Justified"
+msgstr "&Përligjur"
+
+#: ../src/richtext/richtextindentspage.cpp:154
+#: ../src/richtext/richtextindentspage.cpp:156
+#: ../src/richtext/richtextliststylepage.cpp:347
+#: ../src/richtext/richtextliststylepage.cpp:349
+msgid "Justify text left and right."
+msgstr "Përligje tekstin majtas dhe djathtas."
+
+#: ../src/richtext/richtextindentspage.cpp:159
+#: ../src/richtext/richtextliststylepage.cpp:352
+msgid "Cen&tred"
+msgstr "Në &qendër"
+
+#: ../src/richtext/richtextindentspage.cpp:161
+#: ../src/richtext/richtextindentspage.cpp:163
+#: ../src/richtext/richtextliststylepage.cpp:354
+#: ../src/richtext/richtextliststylepage.cpp:356
+msgid "Centre text."
+msgstr "Vendose tekstin në qendër."
+
+#: ../src/richtext/richtextindentspage.cpp:166
+#: ../src/richtext/richtextliststylepage.cpp:359
+msgid "&Indeterminate"
+msgstr "E papër&caktuar"
+
+#: ../src/richtext/richtextindentspage.cpp:168
+#: ../src/richtext/richtextindentspage.cpp:170
+#: ../src/richtext/richtextliststylepage.cpp:361
+#: ../src/richtext/richtextliststylepage.cpp:363
+msgid "Use the current alignment setting."
+msgstr "Përdor rregullimin e tanishëm të drejtimit."
+
+#: ../src/richtext/richtextindentspage.cpp:183
+#: ../src/richtext/richtextliststylepage.cpp:375
+msgid "&Indentation (tenths of a mm)"
+msgstr "&Hapësirë kryeradhe (të dhjeta të mm-it)"
+
+#: ../src/richtext/richtextindentspage.cpp:198
+#: ../src/richtext/richtextindentspage.cpp:200
+#: ../src/richtext/richtextliststylepage.cpp:388
+#: ../src/richtext/richtextliststylepage.cpp:390
+msgid "The left indent."
+msgstr "Shmangia brendazi majtas."
+
+#: ../src/richtext/richtextindentspage.cpp:203
+#: ../src/richtext/richtextliststylepage.cpp:393
+msgid "Left (&first line):"
+msgstr "Majtas (rreshti i &parë):"
+
+#: ../src/richtext/richtextindentspage.cpp:207
+#: ../src/richtext/richtextindentspage.cpp:209
+#: ../src/richtext/richtextliststylepage.cpp:397
+#: ../src/richtext/richtextliststylepage.cpp:399
+msgid "The first line indent."
+msgstr "Shmangia brendazi e rreshtit të parë."
+
+#: ../src/richtext/richtextindentspage.cpp:216
+#: ../src/richtext/richtextindentspage.cpp:218
+#: ../src/richtext/richtextliststylepage.cpp:406
+#: ../src/richtext/richtextliststylepage.cpp:408
+msgid "The right indent."
+msgstr "Shmangia brendazi djathtas."
+
+#: ../src/richtext/richtextindentspage.cpp:221
+msgid "&Outline level:"
+msgstr "Shkallë për&vijimi:"
+
+#: ../src/richtext/richtextindentspage.cpp:226
+#: ../src/richtext/richtextindentspage.cpp:228
+msgid "The outline level."
+msgstr "Shkalla e përvijimit."
+
+#: ../src/richtext/richtextindentspage.cpp:241
+#: ../src/richtext/richtextliststylepage.cpp:420
+msgid "&Spacing (tenths of a mm)"
+msgstr "&Hapësirë (të dhjeta të mm-it)"
+
+#: ../src/richtext/richtextindentspage.cpp:252
+msgid "&Before a paragraph:"
+msgstr "Pa&ra një paragrafi:"
+
+#: ../src/richtext/richtextindentspage.cpp:256
+#: ../src/richtext/richtextindentspage.cpp:258
+#: ../src/richtext/richtextliststylepage.cpp:433
+#: ../src/richtext/richtextliststylepage.cpp:435
+msgid "The spacing before the paragraph."
+msgstr "Hapësira para paragrafit."
+
+#: ../src/richtext/richtextindentspage.cpp:261
+msgid "&After a paragraph:"
+msgstr "&Pas një paragrafi:"
+
+#: ../src/richtext/richtextindentspage.cpp:266
+#: ../src/richtext/richtextliststylepage.cpp:442
+#: ../src/richtext/richtextliststylepage.cpp:444
+msgid "The spacing after the paragraph."
+msgstr "Hapësira pas paragrafit."
+
+#: ../src/richtext/richtextindentspage.cpp:269
+msgid "L&ine spacing:"
+msgstr "Hapës&irë rreshtash:"
+
+#: ../src/richtext/richtextindentspage.cpp:274
+#: ../src/richtext/richtextliststylepage.cpp:452
+msgid "Single"
+msgstr "Njëshe"
+
+#: ../src/richtext/richtextindentspage.cpp:275
+#: ../src/richtext/richtextliststylepage.cpp:453
+msgid "1.1"
+msgstr "1.1"
+
+#: ../src/richtext/richtextindentspage.cpp:276
+#: ../src/richtext/richtextliststylepage.cpp:454
+msgid "1.2"
+msgstr "1.2"
+
+#: ../src/richtext/richtextindentspage.cpp:277
+#: ../src/richtext/richtextliststylepage.cpp:455
+msgid "1.3"
+msgstr "1.3"
+
+#: ../src/richtext/richtextindentspage.cpp:278
+#: ../src/richtext/richtextliststylepage.cpp:456
+msgid "1.4"
+msgstr "1.4"
+
+#: ../src/richtext/richtextindentspage.cpp:279
+#: ../src/richtext/richtextliststylepage.cpp:457
+msgid "1.5"
+msgstr "1.5"
+
+#: ../src/richtext/richtextindentspage.cpp:280
+#: ../src/richtext/richtextliststylepage.cpp:458
+msgid "1.6"
+msgstr "1.6"
+
+#: ../src/richtext/richtextindentspage.cpp:281
+#: ../src/richtext/richtextliststylepage.cpp:459
+msgid "1.7"
+msgstr "1.7"
+
+#: ../src/richtext/richtextindentspage.cpp:282
+#: ../src/richtext/richtextliststylepage.cpp:460
+msgid "1.8"
+msgstr "1.8"
+
+#: ../src/richtext/richtextindentspage.cpp:283
+#: ../src/richtext/richtextliststylepage.cpp:461
+msgid "1.9"
+msgstr "1.9"
+
+#: ../src/richtext/richtextindentspage.cpp:284
+#: ../src/richtext/richtextliststylepage.cpp:462
+msgid "2"
+msgstr "2"
+
+#: ../src/richtext/richtextindentspage.cpp:287
+#: ../src/richtext/richtextindentspage.cpp:289
+#: ../src/richtext/richtextliststylepage.cpp:465
+#: ../src/richtext/richtextliststylepage.cpp:467
+msgid "The line spacing."
+msgstr "Hapësira mes rreshtash."
+
+#: ../src/richtext/richtextindentspage.cpp:292
+msgid "&Page Break"
+msgstr "Ndërprerje &Faqeje"
+
+#: ../src/richtext/richtextindentspage.cpp:294
+#: ../src/richtext/richtextindentspage.cpp:296
+msgid "Inserts a page break before the paragraph."
+msgstr "Fut para paragrafit një ndërprerje faqeje."
+
+#: ../src/richtext/richtextindentspage.cpp:302
+#: ../src/richtext/richtextindentspage.cpp:304
+msgid "Shows a preview of the paragraph settings."
+msgstr "Shfaq një paraparje të rregullimeve të paragrafit."
+
+#: ../src/richtext/richtextliststylepage.cpp:182
+msgid "&List level:"
+msgstr "Shkallë &Liste:"
+
+#: ../src/richtext/richtextliststylepage.cpp:186
+#: ../src/richtext/richtextliststylepage.cpp:188
+msgid "Selects the list level to edit."
+msgstr "Përzgjedh shkallë liste për përpunim."
+
+#: ../src/richtext/richtextliststylepage.cpp:193
+msgid "&Font for Level..."
+msgstr "&Shkronja për Shkallë…"
+
+#: ../src/richtext/richtextliststylepage.cpp:194
+#: ../src/richtext/richtextliststylepage.cpp:196
+msgid "Click to choose the font for this level."
+msgstr "Klikoni për të zgjedhur shkronjat për këtë shkallë."
+
+#: ../src/richtext/richtextliststylepage.cpp:312
+msgid "Bullet style"
+msgstr "Stil topthash"
+
+#: ../src/richtext/richtextliststylepage.cpp:429
+msgid "Before a paragraph:"
+msgstr "Para një paragrafi:"
+
+#: ../src/richtext/richtextliststylepage.cpp:438
+msgid "After a paragraph:"
+msgstr "Pas një paragrafi:"
+
+#: ../src/richtext/richtextliststylepage.cpp:447
+msgid "Line spacing:"
+msgstr "Hapësirë mes rreshtash:"
+
+#: ../src/richtext/richtextliststylepage.cpp:470
+msgid "Spacing"
+msgstr "Hapësirë"
+
+#: ../src/richtext/richtextmarginspage.cpp:193
+#: ../src/richtext/richtextmarginspage.cpp:195
+msgid "The left margin size."
+msgstr "Madhësia e mënjanës majtas."
+
+#: ../src/richtext/richtextmarginspage.cpp:203
+#: ../src/richtext/richtextmarginspage.cpp:205
+msgid "Units for the left margin."
+msgstr "Njësi për mënjanën majtas."
+
+#: ../src/richtext/richtextmarginspage.cpp:218
+#: ../src/richtext/richtextmarginspage.cpp:220
+msgid "The right margin size."
+msgstr "Madhësia e mënjanës djathtas."
+
+#: ../src/richtext/richtextmarginspage.cpp:228
+#: ../src/richtext/richtextmarginspage.cpp:230
+msgid "Units for the right margin."
+msgstr "Njësi për mënjanën djathtas."
+
+#: ../src/richtext/richtextmarginspage.cpp:241
+#: ../src/richtext/richtextmarginspage.cpp:243
+msgid "The top margin size."
+msgstr "Madhësia e mënjanës së sipërme."
+
+#: ../src/richtext/richtextmarginspage.cpp:251
+#: ../src/richtext/richtextmarginspage.cpp:253
+msgid "Units for the top margin."
+msgstr "Njësi për mënjanën e sipërme."
+
+#: ../src/richtext/richtextmarginspage.cpp:266
+#: ../src/richtext/richtextmarginspage.cpp:268
+msgid "The bottom margin size."
+msgstr "Madhësia e mënjanës së poshtme."
+
+#: ../src/richtext/richtextmarginspage.cpp:276
+#: ../src/richtext/richtextmarginspage.cpp:278
+msgid "Units for the bottom margin."
+msgstr "Njësi për mënjanën e poshtme."
+
+#: ../src/richtext/richtextmarginspage.cpp:284
+msgid "Padding"
+msgstr "Mbushje"
+
+#: ../src/richtext/richtextmarginspage.cpp:307
+#: ../src/richtext/richtextmarginspage.cpp:309
+msgid "The left padding size."
+msgstr "Madhësia e mbushjes majtas."
+
+#: ../src/richtext/richtextmarginspage.cpp:317
+#: ../src/richtext/richtextmarginspage.cpp:319
+msgid "Units for the left padding."
+msgstr "Njësi për mbushje majtas."
+
+#: ../src/richtext/richtextmarginspage.cpp:332
+#: ../src/richtext/richtextmarginspage.cpp:334
+msgid "The right padding size."
+msgstr "Madhësia e mbushjes djathtas."
+
+#: ../src/richtext/richtextmarginspage.cpp:342
+#: ../src/richtext/richtextmarginspage.cpp:344
+msgid "Units for the right padding."
+msgstr "Njësi për mbushjen djathtas."
+
+#: ../src/richtext/richtextmarginspage.cpp:355
+#: ../src/richtext/richtextmarginspage.cpp:357
+msgid "The top padding size."
+msgstr "Madhësia e mbushjes së sipërme."
+
+#: ../src/richtext/richtextmarginspage.cpp:365
+#: ../src/richtext/richtextmarginspage.cpp:367
+msgid "Units for the top padding."
+msgstr "Njësi për mbushjen e sipërme."
+
+#: ../src/richtext/richtextmarginspage.cpp:380
+#: ../src/richtext/richtextmarginspage.cpp:382
+msgid "The bottom padding size."
+msgstr "Madhësia e mbushjes së poshthme."
+
+#: ../src/richtext/richtextmarginspage.cpp:390
+#: ../src/richtext/richtextmarginspage.cpp:392
+msgid "Units for the bottom padding."
+msgstr "Njësi për mbushjen poshtë."
+
+#: ../src/richtext/richtextprint.cpp:592
+msgid " Preview"
+msgstr " Paraparje"
+
+#: ../src/richtext/richtextsizepage.cpp:228
+msgid "Floating"
+msgstr "Pezull"
+
+#: ../src/richtext/richtextsizepage.cpp:243
+msgid "&Floating mode:"
+msgstr "Mënyrë ndenjeje &pezull:"
+
+#: ../src/richtext/richtextsizepage.cpp:252
+#: ../src/richtext/richtextsizepage.cpp:254
+msgid "How the object will float relative to the text."
+msgstr "Si do të rrijë pezull objekti kundrejt tekstit."
+
+#: ../src/richtext/richtextsizepage.cpp:265
+msgid "Alignment"
+msgstr "Drejtim"
+
+#: ../src/richtext/richtextsizepage.cpp:277
+msgid "&Vertical alignment:"
+msgstr "Drejtim &vertikalisht:"
+
+#: ../src/richtext/richtextsizepage.cpp:279
+#: ../src/richtext/richtextsizepage.cpp:281
+msgid "Enable vertical alignment."
+msgstr "Aktivizoni drejtimin vertikalisht."
+
+#: ../src/richtext/richtextsizepage.cpp:286
+msgid "Centred"
+msgstr "Në qendër"
+
+#: ../src/richtext/richtextsizepage.cpp:290
+#: ../src/richtext/richtextsizepage.cpp:292
+msgid "Vertical alignment."
+msgstr "Drejtim vertikalisht."
+
+#: ../src/richtext/richtextsizepage.cpp:316
+#: ../src/richtext/richtextsizepage.cpp:323
+msgid "&Width:"
+msgstr "&Gjerësi:"
+
+#: ../src/richtext/richtextsizepage.cpp:318
+#: ../src/richtext/richtextsizepage.cpp:320
+msgid "Enable the width value."
+msgstr "Aktivizo vlerën e gjerësive."
+
+#: ../src/richtext/richtextsizepage.cpp:331
+#: ../src/richtext/richtextsizepage.cpp:333
+msgid "The object width."
+msgstr "Gjerësia e objektit."
+
+#: ../src/richtext/richtextsizepage.cpp:342
+#: ../src/richtext/richtextsizepage.cpp:344
+msgid "Units for the object width."
+msgstr "Njësi për gjerësinë e objektit."
+
+#: ../src/richtext/richtextsizepage.cpp:350
+#: ../src/richtext/richtextsizepage.cpp:357
+msgid "&Height:"
+msgstr "&Lartësi:"
+
+#: ../src/richtext/richtextsizepage.cpp:352
+#: ../src/richtext/richtextsizepage.cpp:354
+#: ../src/richtext/richtextsizepage.cpp:464
+#: ../src/richtext/richtextsizepage.cpp:466
+msgid "Enable the height value."
+msgstr "Aktivizo vlerën e lartësive."
+
+#: ../src/richtext/richtextsizepage.cpp:365
+#: ../src/richtext/richtextsizepage.cpp:367
+msgid "The object height."
+msgstr "Lartësia e objektit."
+
+#: ../src/richtext/richtextsizepage.cpp:376
+#: ../src/richtext/richtextsizepage.cpp:378
+msgid "Units for the object height."
+msgstr "Njësi për lartësinë e objektit."
+
+#: ../src/richtext/richtextsizepage.cpp:381
+msgid "Min width:"
+msgstr "Gjerësi minimum:"
+
+#: ../src/richtext/richtextsizepage.cpp:383
+#: ../src/richtext/richtextsizepage.cpp:385
+msgid "Enable the minimum width value."
+msgstr "Aktivizo vlerën e gjerësisë minimum."
+
+#: ../src/richtext/richtextsizepage.cpp:392
+#: ../src/richtext/richtextsizepage.cpp:394
+msgid "The object minimum width."
+msgstr "Gjerësia minimum e objektit."
+
+#: ../src/richtext/richtextsizepage.cpp:403
+#: ../src/richtext/richtextsizepage.cpp:405
+msgid "Units for the minimum object width."
+msgstr "Njësi për gjerësinë minimum të objektit."
+
+#: ../src/richtext/richtextsizepage.cpp:408
+msgid "Min height:"
+msgstr "Lartësi minimum:"
+
+#: ../src/richtext/richtextsizepage.cpp:410
+#: ../src/richtext/richtextsizepage.cpp:412
+msgid "Enable the minimum height value."
+msgstr "Aktivizo vlerën e lartësisë minimum."
+
+#: ../src/richtext/richtextsizepage.cpp:419
+#: ../src/richtext/richtextsizepage.cpp:421
+msgid "The object minimum height."
+msgstr "Lartësia minimum e objektit."
+
+#: ../src/richtext/richtextsizepage.cpp:430
+#: ../src/richtext/richtextsizepage.cpp:432
+msgid "Units for the minimum object height."
+msgstr "Njësi për lartësinë minimum të objektit."
+
+#: ../src/richtext/richtextsizepage.cpp:435
+msgid "Max width:"
+msgstr "Gjerësi maksimum:"
+
+#: ../src/richtext/richtextsizepage.cpp:437
+#: ../src/richtext/richtextsizepage.cpp:439
+msgid "Enable the maximum width value."
+msgstr "Aktivizo vlerën e gjerësisë maksimum."
+
+#: ../src/richtext/richtextsizepage.cpp:446
+#: ../src/richtext/richtextsizepage.cpp:448
+msgid "The object maximum width."
+msgstr "Gjerësia maksimum e objektit."
+
+#: ../src/richtext/richtextsizepage.cpp:457
+#: ../src/richtext/richtextsizepage.cpp:459
+msgid "Units for the maximum object width."
+msgstr "Njësi për gjerësinë maksimum të objektit."
+
+#: ../src/richtext/richtextsizepage.cpp:462
+msgid "Max height:"
+msgstr "Lartësi maksimum:"
+
+#: ../src/richtext/richtextsizepage.cpp:473
+#: ../src/richtext/richtextsizepage.cpp:475
+msgid "The object maximum height."
+msgstr "Lartësia maksimum e objektit."
+
+#: ../src/richtext/richtextsizepage.cpp:484
+#: ../src/richtext/richtextsizepage.cpp:486
+msgid "Units for the maximum object height."
+msgstr "Njësi për lartësinë maksimum të objektit."
+
+#: ../src/richtext/richtextsizepage.cpp:495
+msgid "Position"
+msgstr "Pozicion"
+
+#: ../src/richtext/richtextsizepage.cpp:513
+msgid "&Position mode:"
+msgstr "Mënyrë &pozicioni:"
+
+#: ../src/richtext/richtextsizepage.cpp:517
+#: ../src/richtext/richtextsizepage.cpp:522
+msgid "Static"
+msgstr "Statike"
+
+#: ../src/richtext/richtextsizepage.cpp:518
+msgid "Relative"
+msgstr "Relative"
+
+#: ../src/richtext/richtextsizepage.cpp:519
+msgid "Absolute"
+msgstr "Absolute"
+
+#: ../src/richtext/richtextsizepage.cpp:520
+msgid "Fixed"
+msgstr "E fiksuar"
+
+#: ../src/richtext/richtextsizepage.cpp:533
+#: ../src/richtext/richtextsizepage.cpp:535
+#: ../src/richtext/richtextsizepage.cpp:547
+#: ../src/richtext/richtextsizepage.cpp:549
+msgid "The left position."
+msgstr "Pozicioni majtas."
+
+#: ../src/richtext/richtextsizepage.cpp:558
+#: ../src/richtext/richtextsizepage.cpp:560
+msgid "Units for the left position."
+msgstr "Njësi për pozicionin majtas."
+
+#: ../src/richtext/richtextsizepage.cpp:568
+#: ../src/richtext/richtextsizepage.cpp:570
+#: ../src/richtext/richtextsizepage.cpp:582
+#: ../src/richtext/richtextsizepage.cpp:584
+msgid "The top position."
+msgstr "Pozicioni i sipërm."
+
+#: ../src/richtext/richtextsizepage.cpp:593
+#: ../src/richtext/richtextsizepage.cpp:595
+msgid "Units for the top position."
+msgstr "Njësi për pozicionin e sipërm."
+
+#: ../src/richtext/richtextsizepage.cpp:603
+#: ../src/richtext/richtextsizepage.cpp:605
+#: ../src/richtext/richtextsizepage.cpp:617
+#: ../src/richtext/richtextsizepage.cpp:619
+msgid "The right position."
+msgstr "Pozicioni djathtas."
+
+#: ../src/richtext/richtextsizepage.cpp:628
+#: ../src/richtext/richtextsizepage.cpp:630
+msgid "Units for the right position."
+msgstr "Njësi për pozicionin djathtas."
+
+#: ../src/richtext/richtextsizepage.cpp:638
+#: ../src/richtext/richtextsizepage.cpp:640
+#: ../src/richtext/richtextsizepage.cpp:652
+#: ../src/richtext/richtextsizepage.cpp:654
+msgid "The bottom position."
+msgstr "Pozicioni poshtë."
+
+#: ../src/richtext/richtextsizepage.cpp:663
+#: ../src/richtext/richtextsizepage.cpp:665
+msgid "Units for the bottom position."
+msgstr "Njësi për pozicionin poshtë."
+
+#: ../src/richtext/richtextsizepage.cpp:671
+msgid "&Move the object to:"
+msgstr "&Shpjere objektin te:"
+
+#: ../src/richtext/richtextsizepage.cpp:674
+msgid "&Previous Paragraph"
+msgstr "Paragrafi i &Mëparshëm"
+
+#: ../src/richtext/richtextsizepage.cpp:675
+#: ../src/richtext/richtextsizepage.cpp:677
+msgid "Moves the object to the previous paragraph."
+msgstr "E kalon objektin te paragrafi i mëparshëm."
+
+#: ../src/richtext/richtextsizepage.cpp:680
+msgid "&Next Paragraph"
+msgstr "Paragrafi &Pasues"
+
+#: ../src/richtext/richtextsizepage.cpp:681
+#: ../src/richtext/richtextsizepage.cpp:683
+msgid "Moves the object to the next paragraph."
+msgstr "E kalon objektin te paragrafi pasues."
+
+#: ../src/richtext/richtextstyledlg.cpp:193
+msgid "&Styles:"
+msgstr "&Stile:"
+
+#: ../src/richtext/richtextstyledlg.cpp:197
+#: ../src/richtext/richtextstyledlg.cpp:199
+msgid "The available styles."
+msgstr "Stilet e gatshëm."
+
+#: ../src/richtext/richtextstyledlg.cpp:205
+#: ../src/richtext/richtextstyledlg.cpp:217
+msgid " "
+msgstr " "
+
+#: ../src/richtext/richtextstyledlg.cpp:209
+#: ../src/richtext/richtextstyledlg.cpp:211
+msgid "The style preview."
+msgstr "Paraparja e stilit."
+
+#: ../src/richtext/richtextstyledlg.cpp:220
+msgid "New &Character Style..."
+msgstr "Stil i Ri &Shenje…"
+
+#: ../src/richtext/richtextstyledlg.cpp:221
+#: ../src/richtext/richtextstyledlg.cpp:223
+msgid "Click to create a new character style."
+msgstr "Klikoni që të krijoni një stil të ri shkronjash."
+
+#: ../src/richtext/richtextstyledlg.cpp:226
+msgid "New &Paragraph Style..."
+msgstr "Stil i Ri &Paragrafi…"
+
+#: ../src/richtext/richtextstyledlg.cpp:227
+#: ../src/richtext/richtextstyledlg.cpp:229
+msgid "Click to create a new paragraph style."
+msgstr "Klikoni që të krijoni një stil të ri paragrafësh."
+
+#: ../src/richtext/richtextstyledlg.cpp:232
+msgid "New &List Style..."
+msgstr "Stil i Ri &Liste…"
+
+#: ../src/richtext/richtextstyledlg.cpp:233
+#: ../src/richtext/richtextstyledlg.cpp:235
+msgid "Click to create a new list style."
+msgstr "Klikoni që të krijoni një stil të ri listash."
+
+#: ../src/richtext/richtextstyledlg.cpp:238
+msgid "New &Box Style..."
+msgstr "Stil i Ri &Kuadrati…"
+
+#: ../src/richtext/richtextstyledlg.cpp:239
+#: ../src/richtext/richtextstyledlg.cpp:241
+msgid "Click to create a new box style."
+msgstr "Klikoni që të krijoni një stil të ri kuadrati."
+
+#: ../src/richtext/richtextstyledlg.cpp:246
+msgid "&Apply Style"
+msgstr "&Zbatoje Stilin"
+
+#: ../src/richtext/richtextstyledlg.cpp:247
+#: ../src/richtext/richtextstyledlg.cpp:249
+msgid "Click to apply the selected style."
+msgstr "Klikoni që të zbatohet stili i përzgjedhur."
+
+#: ../src/richtext/richtextstyledlg.cpp:252
+msgid "&Rename Style..."
+msgstr "&Riemërtoni Stil…"
+
+#: ../src/richtext/richtextstyledlg.cpp:253
+#: ../src/richtext/richtextstyledlg.cpp:255
+msgid "Click to rename the selected style."
+msgstr "Klikoni që të riemërtoni stilin e përzgjedhur."
+
+#: ../src/richtext/richtextstyledlg.cpp:258
+msgid "&Edit Style..."
+msgstr "&Përpunoni Stil…"
+
+#: ../src/richtext/richtextstyledlg.cpp:259
+#: ../src/richtext/richtextstyledlg.cpp:261
+msgid "Click to edit the selected style."
+msgstr "Klikoni për përpunim të stilit të përzgjedhur."
+
+#: ../src/richtext/richtextstyledlg.cpp:264
+msgid "&Delete Style..."
+msgstr "&Fshini Stil…"
+
+#: ../src/richtext/richtextstyledlg.cpp:265
+#: ../src/richtext/richtextstyledlg.cpp:267
+msgid "Click to delete the selected style."
+msgstr "Klikoni që të fshihet stili i përzgjedhur."
+
+#: ../src/richtext/richtextstyledlg.cpp:274
+#: ../src/richtext/richtextstyledlg.cpp:276
+msgid "Click to close this window."
+msgstr "Klikoni që të mbyllet kjo dritare."
+
+#: ../src/richtext/richtextstyledlg.cpp:282
+msgid "&Restart numbering"
+msgstr "&Rinis numërimin"
+
+#: ../src/richtext/richtextstyledlg.cpp:284
+#: ../src/richtext/richtextstyledlg.cpp:286
+msgid "Check to restart numbering."
+msgstr "I vini shenjë që të rinisë numërimi."
+
+#: ../src/richtext/richtextstyledlg.cpp:601
+msgid "Enter a character style name"
+msgstr "Jepni emër stili shkronjash"
+
+#: ../src/richtext/richtextstyledlg.cpp:601
+#: ../src/richtext/richtextstyledlg.cpp:606
+#: ../src/richtext/richtextstyledlg.cpp:649
+#: ../src/richtext/richtextstyledlg.cpp:654
+#: ../src/richtext/richtextstyledlg.cpp:815
+#: ../src/richtext/richtextstyledlg.cpp:820
+#: ../src/richtext/richtextstyledlg.cpp:888
+#: ../src/richtext/richtextstyledlg.cpp:896
+#: ../src/richtext/richtextstyledlg.cpp:929
+#: ../src/richtext/richtextstyledlg.cpp:934
+msgid "New Style"
+msgstr "Stil i Ri"
+
+#: ../src/richtext/richtextstyledlg.cpp:606
+#: ../src/richtext/richtextstyledlg.cpp:654
+#: ../src/richtext/richtextstyledlg.cpp:820
+#: ../src/richtext/richtextstyledlg.cpp:896
+#: ../src/richtext/richtextstyledlg.cpp:934
+msgid "Sorry, that name is taken. Please choose another."
+msgstr "Na ndjeni, ky emër është i zënë. Ju lutemi, zgjidhni një tjetër."
+
+#: ../src/richtext/richtextstyledlg.cpp:649
+msgid "Enter a paragraph style name"
+msgstr "Jepni emër stili paragrafi"
+
+#: ../src/richtext/richtextstyledlg.cpp:777
+#, c-format
+msgid "Delete style %s?"
+msgstr "Të fshihet stili %s?"
+
+#: ../src/richtext/richtextstyledlg.cpp:777
+msgid "Delete Style"
+msgstr "Fshije Stilin"
+
+#: ../src/richtext/richtextstyledlg.cpp:815
+msgid "Enter a list style name"
+msgstr "Jepni emër stili liste"
+
+#: ../src/richtext/richtextstyledlg.cpp:888
+msgid "Enter a new style name"
+msgstr "Jepni emër stili të ri"
+
+#: ../src/richtext/richtextstyledlg.cpp:929
+msgid "Enter a box style name"
+msgstr "Jepni emër stili kuadrati"
+
+#: ../src/richtext/richtextstylepage.cpp:109
+#: ../src/richtext/richtextstylepage.cpp:111
+msgid "The style name."
+msgstr "Emri i stilit."
+
+#: ../src/richtext/richtextstylepage.cpp:114
+msgid "&Based on:"
+msgstr "&Bazuar në:"
+
+#: ../src/richtext/richtextstylepage.cpp:119
+#: ../src/richtext/richtextstylepage.cpp:121
+msgid "The style on which this style is based."
+msgstr "Stili në të cilin bazohet ky stil."
+
+#: ../src/richtext/richtextstylepage.cpp:124
+msgid "&Next style:"
+msgstr "Stili &pasues:"
+
+#: ../src/richtext/richtextstylepage.cpp:129
+#: ../src/richtext/richtextstylepage.cpp:131
+msgid "The default style for the next paragraph."
+msgstr "Stili parazgjedhje për paragrafin pasues."
+
+#: ../src/richtext/richtextstyles.cpp:1057
+msgid "All styles"
+msgstr "Krejt stilet"
+
+#: ../src/richtext/richtextstyles.cpp:1058
+msgid "Paragraph styles"
+msgstr "Stile paragrafi"
+
+#: ../src/richtext/richtextstyles.cpp:1059
+msgid "Character styles"
+msgstr "Stile shenjash"
+
+#: ../src/richtext/richtextstyles.cpp:1060
+msgid "List styles"
+msgstr "Stile liste"
+
+#: ../src/richtext/richtextstyles.cpp:1061
+msgid "Box styles"
+msgstr "Stile kuadrati"
+
+#: ../src/richtext/richtextsymboldlg.cpp:389
+#: ../src/richtext/richtextsymboldlg.cpp:391
+msgid "The font from which to take the symbol."
+msgstr "Shkronjat prej nga të merret simboli."
+
+#: ../src/richtext/richtextsymboldlg.cpp:396
+msgid "&Subset:"
+msgstr "&Nëngrup:"
+
+#: ../src/richtext/richtextsymboldlg.cpp:401
+#: ../src/richtext/richtextsymboldlg.cpp:403
+msgid "Shows a Unicode subset."
+msgstr "Shfaq një nëngrup Unikod."
+
+#: ../src/richtext/richtextsymboldlg.cpp:412
+msgid "xxxx"
+msgstr "xxxx"
+
+#: ../src/richtext/richtextsymboldlg.cpp:417
+msgid "&Character code:"
+msgstr "Kod &shenjash:"
+
+#: ../src/richtext/richtextsymboldlg.cpp:421
+#: ../src/richtext/richtextsymboldlg.cpp:423
+msgid "The character code."
+msgstr "Kodi i shenjave."
+
+#: ../src/richtext/richtextsymboldlg.cpp:428
+msgid "&From:"
+msgstr "&Nga:"
+
+#: ../src/richtext/richtextsymboldlg.cpp:433
+#: ../src/richtext/richtextsymboldlg.cpp:434
+#: ../src/richtext/richtextsymboldlg.cpp:435
+msgid "Unicode"
+msgstr "Unikod"
+
+#: ../src/richtext/richtextsymboldlg.cpp:436
+#: ../src/richtext/richtextsymboldlg.cpp:438
+msgid "The range to show."
+msgstr "Intervali për shfaqje."
+
+#: ../src/richtext/richtextsymboldlg.cpp:444
+msgid "Insert"
+msgstr "Tasti Insert"
+
+#: ../src/richtext/richtextsymboldlg.cpp:478
+msgid "(Normal text)"
+msgstr "(Tekst normal)"
+
+#: ../src/richtext/richtexttabspage.cpp:109
+msgid "&Position (tenths of a mm):"
+msgstr "&Pozicion (të dhjeta të mm-it):"
+
+#: ../src/richtext/richtexttabspage.cpp:113
+#: ../src/richtext/richtexttabspage.cpp:115
+msgid "The tab position."
+msgstr "Pozicioni i tabulacionit."
+
+#: ../src/richtext/richtexttabspage.cpp:119
+msgid "The tab positions."
+msgstr "Pozicionet e tabulacionit."
+
+#: ../src/richtext/richtexttabspage.cpp:132
+#: ../src/richtext/richtexttabspage.cpp:134
+msgid "Click to create a new tab position."
+msgstr "Klikoni që të krijoni një pozicion të ri tabulacioni."
+
+#: ../src/richtext/richtexttabspage.cpp:138
+#: ../src/richtext/richtexttabspage.cpp:140
+msgid "Click to delete the selected tab position."
+msgstr "Klikoni që të fshihet pozicioni i përzgjedhur i tabulacionit."
+
+#: ../src/richtext/richtexttabspage.cpp:143
+msgid "Delete A&ll"
+msgstr "Fshiji &Krejt"
+
+#: ../src/richtext/richtexttabspage.cpp:144
+#: ../src/richtext/richtexttabspage.cpp:146
+msgid "Click to delete all tab positions."
+msgstr "Klikoni që të fshihen krejt pozicionet e tabulacionit."
+
+#: ../src/univ/theme.cpp:110
+msgid "Failed to initialize GUI: no built-in themes found."
+msgstr "S’u arrit të gatitej GUI: s’u gjetën tema të brendshme."
+
+#: ../src/univ/themes/gtk.cpp:521
+msgid "GTK+ theme"
+msgstr "Temë GTK+"
+
+#: ../src/univ/themes/metal.cpp:164
+msgid "Metal theme"
+msgstr "Temë metal"
+
+#: ../src/univ/themes/mono.cpp:512
+msgid "Simple monochrome theme"
+msgstr "Temë e thjeshtë njëngjyrëshe"
+
+#: ../src/univ/themes/win32.cpp:1098
+msgid "Win32 theme"
+msgstr "Temë Win32"
+
+#: ../src/univ/themes/win32.cpp:3743
+msgid "&Restore"
+msgstr "&Riktheje"
+
+#: ../src/univ/themes/win32.cpp:3744
+msgid "&Move"
+msgstr "&Zhvendose"
+
+#: ../src/univ/themes/win32.cpp:3746
+msgid "&Size"
+msgstr "&Madhësi"
+
+#: ../src/univ/themes/win32.cpp:3748
+msgid "Mi&nimize"
+msgstr "Mi&nimizo"
+
+#: ../src/univ/themes/win32.cpp:3750
+msgid "Ma&ximize"
+msgstr "Ma&ksimizo"
+
+#: ../src/univ/themes/win32.cpp:3752
+msgid "Alt+"
+msgstr "Alt+"
+
+#: ../src/unix/appunix.cpp:178
+msgid "Failed to install signal handler"
+msgstr "S’u arrit të instalohej trajtues sinjali"
+
+#: ../src/unix/dialup.cpp:351
+msgid "Already dialling ISP."
+msgstr "Po provohet tashmë numri i ISP-së."
+
+#: ../src/unix/dlunix.cpp:93
+msgid "Failed to unload shared library"
+msgstr "S’u arrit të hiqej ngarkim librarie të përbashkët"
+
+#: ../src/unix/dlunix.cpp:121
+msgid "Unknown dynamic library error"
+msgstr "Gabim i panjohur librarie dinamike"
+
+#: ../src/unix/epolldispatcher.cpp:84
+msgid "Failed to create epoll descriptor"
+msgstr "S’u arrit të krijohej përshkrues epoll"
+
+#: ../src/unix/epolldispatcher.cpp:103
+msgid "Error closing epoll descriptor"
+msgstr "Gabim në mbylljen e përshkruesit epoll"
+
+#: ../src/unix/epolldispatcher.cpp:116
+#, c-format
+msgid "Failed to add descriptor %d to epoll descriptor %d"
+msgstr "S’u arrit të shtohej përshkrues %d te përshkrues epoll %d"
+
+#: ../src/unix/epolldispatcher.cpp:136
+#, c-format
+msgid "Failed to modify descriptor %d in epoll descriptor %d"
+msgstr "S’u arrit të modifikohej përshkrues %d te përshkrues epoll %d"
+
+#: ../src/unix/epolldispatcher.cpp:155
+#, c-format
+msgid "Failed to unregister descriptor %d from epoll descriptor %d"
+msgstr "S’u arrit të çregjistrohej përshkrues %d prej përshkruesi epoll %d"
+
+#: ../src/unix/epolldispatcher.cpp:213
+#, c-format
+msgid "Waiting for IO on epoll descriptor %d failed"
+msgstr "Dështoi pritja për IO në përshkrues epoll %d"
+
+#: ../src/unix/fswatcher_inotify.cpp:71
+msgid "Unable to create inotify instance"
+msgstr "S’arrihet të krijohet instancë inotify"
+
+#: ../src/unix/fswatcher_inotify.cpp:94
+msgid "Unable to close inotify instance"
+msgstr "S’arrihet të mbyllet instancë inotify"
+
+#: ../src/unix/fswatcher_inotify.cpp:106
+msgid "Unable to add inotify watch"
+msgstr "S’arrihet të shtohet mbikëqyrës inotify"
+
+#: ../src/unix/fswatcher_inotify.cpp:138
+#, c-format
+msgid "Unable to remove inotify watch %i"
+msgstr "S’arrihet të hiqet mbikëqyrës inotifyi %i"
+
+#: ../src/unix/fswatcher_inotify.cpp:271
+#, c-format
+msgid "Unexpected event for \"%s\": no matching watch descriptor."
+msgstr "Akt i papritur për “%s”: s’ka përshkrues mbikëqyrësi me përputhje."
+
+#: ../src/unix/fswatcher_inotify.cpp:320
+#, c-format
+msgid "Invalid inotify event for \"%s\""
+msgstr "Akt i paligjshëm “inotify” për “%s”"
+
+#: ../src/unix/fswatcher_inotify.cpp:553
+msgid "Unable to read from inotify descriptor"
+msgstr "S’arrihet të lexohet nga përshkrues inotify"
+
+#: ../src/unix/fswatcher_inotify.cpp:558
+msgid "EOF while reading from inotify descriptor"
+msgstr "EOF teksa lexohej prej përshkruesi inotify"
+
+#: ../src/unix/fswatcher_kqueue.cpp:114
+msgid "Unable to create kqueue instance"
+msgstr "S’arrihet të krijohet instancë kqueue"
+
+#: ../src/unix/fswatcher_kqueue.cpp:131
+msgid "Error closing kqueue instance"
+msgstr "Gabim në mbylljen e instancës kqueue"
+
+#: ../src/unix/fswatcher_kqueue.cpp:153
+msgid "Unable to add kqueue watch"
+msgstr "S’arrihet të shtohet mbikëqyrës kqueue"
+
+#: ../src/unix/fswatcher_kqueue.cpp:170
+msgid "Unable to remove kqueue watch"
+msgstr "S’arrihet të hiqet mbikëqyrës kqueue"
+
+#: ../src/unix/fswatcher_kqueue.cpp:202
+msgid "Unable to get events from kqueue"
+msgstr "S’arrihet të merret akte prej kqueue"
+
+#: ../src/unix/mediactrl.cpp:966
+#, c-format
+msgid "Media playback error: %s"
+msgstr "Gabim në luajtje mediash: %s"
+
+#: ../src/unix/mediactrl.cpp:1228
+#, c-format
+msgid "Failed to prepare playing \"%s\"."
+msgstr "S’u arrit të përgatitej për luajtje “%s”."
+
+#: ../src/unix/snglinst.cpp:164
+#, c-format
+msgid "Failed to write to lock file '%s'"
+msgstr "S’u arrit të shkruhej kartelë kyçjeje '%s'"
+
+#: ../src/unix/snglinst.cpp:177
+#, c-format
+msgid "Failed to set permissions on lock file '%s'"
+msgstr "S’u arrit të caktoheshin leje mbi kartelë kyçjeje '%s'"
+
+#: ../src/unix/snglinst.cpp:194
+#, c-format
+msgid "Failed to lock the lock file '%s'"
+msgstr "S’u arrit të kyçej kartelë kyçjeje '%s'"
+
+#: ../src/unix/snglinst.cpp:237
+#, c-format
+msgid "Failed to inspect the lock file '%s'"
+msgstr "S’u arrit të inspektohej kartela e kyçjes '%s'"
+
+#: ../src/unix/snglinst.cpp:242
+#, c-format
+msgid "Lock file '%s' has incorrect owner."
+msgstr "Kartela '%s' e kyçjes ka pronar të pasaktë."
+
+#: ../src/unix/snglinst.cpp:247
+#, c-format
+msgid "Lock file '%s' has incorrect permissions."
+msgstr "Kartela '%s' e kyçjes ka leje të pasakta."
+
+#: ../src/unix/snglinst.cpp:265
+msgid "Failed to access lock file."
+msgstr "S’u arrit të përdorej kartelë kyçjeje."
+
+#: ../src/unix/snglinst.cpp:274
+msgid "Failed to read PID from lock file."
+msgstr "S’u arrit të lexohej PID prej kartele kyçjeje."
+
+#: ../src/unix/snglinst.cpp:284
+#, c-format
+msgid "Failed to remove stale lock file '%s'."
+msgstr "S’u arrit të hiqej kartelë e ndenjur kyçjeje '%s'."
+
+#: ../src/unix/snglinst.cpp:297
+#, c-format
+msgid "Deleted stale lock file '%s'."
+msgstr "U fshi kartelë kyçjeje '%s' e ndenjur."
+
+#: ../src/unix/snglinst.cpp:308
+#, c-format
+msgid "Invalid lock file '%s'."
+msgstr "Kartelë e pavlefshme kyçjeje '%s'."
+
+#: ../src/unix/snglinst.cpp:324
+#, c-format
+msgid "Failed to remove lock file '%s'"
+msgstr "S’u arrit të hiqej kartelë kyçjeje '%s'"
+
+#: ../src/unix/snglinst.cpp:330
+#, c-format
+msgid "Failed to unlock lock file '%s'"
+msgstr "S’u arrit të shkyçej kartelë kyçje '%s'"
+
+#: ../src/unix/snglinst.cpp:336
+#, c-format
+msgid "Failed to close lock file '%s'"
+msgstr "S’u arrit të mbyllej kartelë kyçjeje '%s'"
+
+#: ../src/unix/sound.cpp:77
+msgid "No sound"
+msgstr "Pa zë"
+
+#: ../src/unix/sound.cpp:364
+msgid "Unable to play sound asynchronously."
+msgstr "S’arrihet të luhen tinguj në mënyrë jo të njëkohshme."
+
+#: ../src/unix/sound.cpp:458
+#, c-format
+msgid "Couldn't load sound data from '%s'."
+msgstr "S’u ngarkuan dot të dhëna tingujsh prej '%s'."
+
+#: ../src/unix/sound.cpp:465
+#, c-format
+msgid "Sound file '%s' is in unsupported format."
+msgstr "Kartela zanore '%s' është e një formati të pambuluar."
+
+#: ../src/unix/sound.cpp:480
+msgid "Sound data are in unsupported format."
+msgstr "Të dhëna tingulli janë në format të pambuluar."
+
+#: ../src/unix/sound_sdl.cpp:226
+#, c-format
+msgid "Couldn't open audio: %s"
+msgstr "S’u hap dot audio: %s"
+
+#: ../src/unix/threadpsx.cpp:1033
+msgid "Cannot retrieve thread scheduling policy."
+msgstr "S’merret dot rregull planifikimi rrjedhe."
+
+#: ../src/unix/threadpsx.cpp:1058
+#, c-format
+msgid "Cannot get priority range for scheduling policy %d."
+msgstr "S’merret dot interval përparësie për rregull planifikimi %d."
+
+#: ../src/unix/threadpsx.cpp:1066
+msgid "Thread priority setting is ignored."
+msgstr "U shpërfill ujdisje përparësish rrjedhash."
+
+#: ../src/unix/threadpsx.cpp:1221
+msgid ""
+"Failed to join a thread, potential memory leak detected - please restart the "
+"program"
+msgstr ""
+"S’u arrit të merrej pjesë në një rrjedhë, u zbulua rrjedhje potenciale "
+"kujtese - ju lutemi, rinisni programin"
+
+#: ../src/unix/threadpsx.cpp:1352
+#, c-format
+msgid "Failed to set thread concurrency level to %lu"
+msgstr ""
+
+#: ../src/unix/threadpsx.cpp:1481
+#, c-format
+msgid "Failed to set thread priority %d."
+msgstr "S’u arrit të caktohej përparësie rrjedhe %d."
+
+#: ../src/unix/threadpsx.cpp:1666
+msgid "Failed to terminate a thread."
+msgstr "S’u arrit të përfundohej një rrjedhë."
+
+#: ../src/unix/threadpsx.cpp:1893
+msgid "Thread module initialization failed: failed to create thread key"
+msgstr ""
+"Gatitja e modulit të rrjedhës dështoi: s’u arrit të krijohej kyç rrjedhe"
+
+#: ../src/unix/utilsunx.cpp:340
+msgid "Impossible to get child process input"
+msgstr "E pamundur të merret “input” procesi pjelle"
+
+#: ../src/unix/utilsunx.cpp:390
+msgid "Can't write to child process's stdin"
+msgstr "S’shkruhet dot te stdin procesi pjelle"
+
+#: ../src/unix/utilsunx.cpp:644
+#, c-format
+msgid "Failed to execute '%s'\n"
+msgstr "S’u arrit të përmbushej '%s'\n"
+
+#: ../src/unix/utilsunx.cpp:678
+msgid "Fork failed"
+msgstr "Degëzimi dështoi"
+
+#: ../src/unix/utilsunx.cpp:701
+msgid "Failed to set process priority"
+msgstr "S’u arrit të caktohej përparësi procesi"
+
+#: ../src/unix/utilsunx.cpp:712
+msgid "Failed to redirect child process input/output"
+msgstr "S’u arrit të ridrejtohej input/output procesi pjellë"
+
+#: ../src/unix/utilsunx.cpp:816
+msgid "Failed to set up non-blocking pipe, the program might hang."
+msgstr "S’u arrit të ujdisej kanal jobllokues, programi mund të ngecë."
+
+#: ../src/unix/utilsunx.cpp:1023
+msgid "Cannot get the hostname"
+msgstr "S’merret dot strehëemër"
+
+#: ../src/unix/utilsunx.cpp:1059
+msgid "Cannot get the official hostname"
+msgstr "S’merret dot strehëemër zyrtar"
+
+#: ../src/unix/wakeuppipe.cpp:49
+msgid "Failed to create wake up pipe used by event loop."
+msgstr "S’u arrit të krijohej kanal zgjimi i përdorur nga qerthull akti."
+
+#: ../src/unix/wakeuppipe.cpp:56
+msgid "Failed to switch wake up pipe to non-blocking mode"
+msgstr "S’u arrit të kalohej kanal zgjimi në mënyrën jobllokuese"
+
+#: ../src/unix/wakeuppipe.cpp:117
+msgid "Failed to read from wake-up pipe"
+msgstr "S’u arrit të lexohej prej kanali zgjimi"
+
+#: ../src/x11/app.cpp:124
+#, c-format
+msgid "Invalid geometry specification '%s'"
+msgstr "Specifikim i pavlefshëm gjeometrie '%s'"
+
+#: ../src/x11/app.cpp:167
+msgid "wxWidgets could not open display. Exiting."
+msgstr "wxWidgets s’hapi dot ekranin. Po dilet."
+
+#: ../src/x11/utils.cpp:169
+#, c-format
+msgid "Failed to close the display \"%s\""
+msgstr "S’u arrit të mbyllej ekrani '%s'"
+
+#: ../src/x11/utils.cpp:188
+#, c-format
+msgid "Failed to open display \"%s\"."
+msgstr "S’u arrit të hapej ekrani “%s”."
+
+#: ../src/xml/xml.cpp:868
+#, c-format
+msgid "XML parsing error: '%s' at line %d"
+msgstr "Gabim përtypjeje XML: '%s' te rresht %d"
+
+#: ../src/xrc/xh_propgrid.cpp:239
+#, fuzzy, c-format
+msgid "Page %i"
+msgstr "Faqe %d"
+
+#: ../src/xrc/xmlres.cpp:448
+#, c-format
+msgid "Cannot load resources from '%s'."
+msgstr "S’ngarkohen dot burime prej kartele '%s'."
+
+#: ../src/xrc/xmlres.cpp:799
+#, c-format
+msgid "Cannot open resources file '%s'."
+msgstr "S’hapet dot kartelë burimesh %s."
+
+#: ../src/xrc/xmlres.cpp:806
+#, c-format
+msgid "Cannot load resources from file '%s'."
+msgstr "S’ngarkohen dot burime prej kartele '%s'."
+
+#: ../src/xrc/xmlres.cpp:2767
+#, c-format
+msgid "Creating %s \"%s\" failed."
+msgstr "Krijimi i %s “%s” dështoi."
+
+#, c-format
+#~ msgid "BMP: header has biClrUsed=%d when biBitCount=%d."
+#~ msgstr "BMP: kryet kanë biClrUsed=%d, ndërkohë që biBitCount=%d."
+
+#~ msgctxt "keyboard key"
+#~ msgid "Alt+"
+#~ msgstr "Tasti Alt+"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Ctrl+"
+#~ msgstr "Tasti Ctrl+"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Shift+"
+#~ msgstr "Tasti Shift+"
+
+#~ msgctxt "keyboard key"
+#~ msgid "RawCtrl+"
+#~ msgstr "Tasti RawCtrl+"
+
+#~ msgid "Copying more than one selected block to clipboard is not supported."
+#~ msgstr ""
+#~ "Nuk mbulohet kopjimi në të papastër i më shumë se një blloku të "
+#~ "përzgjedhur."
+
+#~ msgid "Unsupported clipboard format."
+#~ msgstr "Format i pambuluar për të papastrën."
+
+#~ msgid "Background colour"
+#~ msgstr "Ngjyrë sfondi"
+
+#~ msgid "Font:"
+#~ msgstr "Shkronja:"
+
+#~ msgid "Size:"
+#~ msgstr "Madhësi:"
+
+#~ msgid "The font size in points."
+#~ msgstr "Madhësia e shkronjave në pikë."
+
+#~ msgid "Style:"
+#~ msgstr "Stil:"
+
+#~ msgid "Check to make the font bold."
+#~ msgstr "I vini shenjë për t’i bërë shkronjat të trasha."
+
+#~ msgid "Check to make the font italic."
+#~ msgstr "I vini shenjë për t’i bërë shkronjat të pjerrëta."
+
+#~ msgid "Check to make the font underlined."
+#~ msgstr "I vini shenjë për t’i bërë shkronjat të nënvizuara."
+
+#~ msgid "Colour:"
+#~ msgstr "Ngjyrë:"
+
+#~ msgid "Click to change the font colour."
+#~ msgstr "Klikoni që të ndryshohet ngjyra e shkronjave."
+
+#~ msgid "Shows a preview of the font."
+#~ msgstr "Shfaq një paraparje të shkronjave."
+
+#~ msgid "Click to cancel changes to the font."
+#~ msgstr "Klikoni që të anulohen ndryshime te shkronjat."
+
+#~ msgid "Click to confirm changes to the font."
+#~ msgstr "Klikoni për ripohim të ndryshimeve te shkronjat."
+
+#~ msgid "<Any>"
+#~ msgstr "<Çfarëdo>"
+
+#~ msgid "<Any Roman>"
+#~ msgstr "<Çfarëdo Roman>"
+
+#~ msgid "<Any Decorative>"
+#~ msgstr "<Çfarëdo Decorative>"
+
+#~ msgid "<Any Modern>"
+#~ msgstr "<Çfarëdo Modern>"
+
+#~ msgid "<Any Script>"
+#~ msgstr "<Çfarëdo Script>"
+
+#~ msgid "<Any Swiss>"
+#~ msgstr "<Çfarëdo Swiss>"
+
+#~ msgid "<Any Teletype>"
+#~ msgstr "<Çfarëdo Teletype>"

--- a/po_wxstd/sr.po
+++ b/po_wxstd/sr.po
@@ -1,0 +1,9476 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: WX Widgets\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-05-14 20:23+0200\n"
+"PO-Revision-Date: 2022-12-07 21:12+0100\n"
+"Last-Translator: Nikola Jović <wwenikola123@gmail.com>\n"
+"Language-Team: Nikola Jović <wwenikola123@gmail.com>\n"
+"Language: sr\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
+"X-Generator: Poedit 1.6.10\n"
+
+#: ../include/wx/defs.h:2582
+msgid "All files (*.*)|*.*"
+msgstr "Sve datoteke (*.*)|*.*"
+
+#: ../include/wx/defs.h:2585
+msgid "All files (*)|*"
+msgstr "Sve datoteke (*)|*"
+
+#: ../include/wx/generic/progdlgg.h:85
+msgid "Elapsed time:"
+msgstr "Proteklo vreme:"
+
+#: ../include/wx/generic/progdlgg.h:86
+msgid "Estimated time:"
+msgstr "Očekivano preostalo vreme:"
+
+#: ../include/wx/generic/progdlgg.h:87
+msgid "Remaining time:"
+msgstr "Preostalo vreme:"
+
+#. TRANSLATORS: HTML printout default title.
+#: ../include/wx/html/htmprint.h:121 ../include/wx/prntbase.h:273
+#: ../include/wx/richtext/richtextprint.h:109 ../src/common/docview.cpp:2161
+msgid "Printout"
+msgstr "Štampanje"
+
+#. TRANSLATORS: HTML easy print default title.
+#: ../include/wx/html/htmprint.h:234 ../include/wx/richtext/richtextprint.h:163
+#: ../src/common/prntbase.cpp:522 ../src/html/htmprint.cpp:291
+msgid "Printing"
+msgstr "Štampanje"
+
+#: ../include/wx/msgdlg.h:277 ../src/common/stockitem.cpp:211
+msgid "Yes"
+msgstr "Da"
+
+#: ../include/wx/msgdlg.h:278 ../src/common/stockitem.cpp:182
+msgid "No"
+msgstr "Ne"
+
+#: ../include/wx/msgdlg.h:279 ../src/common/stockitem.cpp:183
+#: ../src/msw/msgdlg.cpp:430 ../src/msw/msgdlg.cpp:734
+#: ../src/richtext/richtextstyledlg.cpp:292
+msgid "OK"
+msgstr "U redu"
+
+#: ../include/wx/msgdlg.h:280 ../src/common/stockitem.cpp:150
+#: ../src/msw/msgdlg.cpp:430 ../src/msw/progdlg.cpp:884
+#: ../src/richtext/richtextstyledlg.cpp:295
+msgid "Cancel"
+msgstr "Otkaži"
+
+#: ../include/wx/msgdlg.h:281 ../src/common/stockitem.cpp:168
+#: ../src/html/helpdlg.cpp:63 ../src/html/helpfrm.cpp:108
+#: ../src/osx/button_osx.cpp:38
+msgid "Help"
+msgstr "Pomoć"
+
+#: ../include/wx/msw/ole/oleutils.h:52
+msgid "Cannot initialize OLE"
+msgstr "Nemoguće inicijalizovati OLE"
+
+#: ../include/wx/msw/private/fswatcher.h:48
+#, c-format
+msgid "Unable to close the handle for '%s'"
+msgstr "Nemoguće zatvoriti obrađivač za '%s'"
+
+#: ../include/wx/msw/private/fswatcher.h:92
+#, c-format
+msgid "Failed to open directory \"%s\" for monitoring."
+msgstr "Otvaranje foldera \"%s\" za praćenje nije uspelo."
+
+#: ../include/wx/msw/private/fswatcher.h:125
+msgid "Unable to close I/O completion port handle"
+msgstr "Nemoguće zatvoriti I/O completion port obrađivač"
+
+#: ../include/wx/msw/private/fswatcher.h:142
+msgid "Unable to associate handle with I/O completion port"
+msgstr "Nemoguće pridružiti obrađivač I/O completion portu"
+
+#: ../include/wx/msw/private/fswatcher.h:148
+msgid "Unexpectedly new I/O completion port was created"
+msgstr "Novi I/O completion port je neočekivano napravljen"
+
+#: ../include/wx/msw/private/fswatcher.h:213
+msgid "Unable to post completion status"
+msgstr "Nemoguće objaviti status dovršavanja"
+
+#: ../include/wx/msw/private/fswatcher.h:262
+msgid "Unable to dequeue completion packet"
+msgstr "Nemoguće odraditi dequeue za završni paket"
+
+#: ../include/wx/msw/private/fswatcher.h:273
+msgid "Unable to create I/O completion port"
+msgstr "Nemoguće napraviti I/O completion port"
+
+#: ../include/wx/richmsgdlg.h:29
+msgid "&See details"
+msgstr "&Prikaži detalje"
+
+#: ../include/wx/richmsgdlg.h:30
+msgid "&Hide details"
+msgstr "&Sakrij detalje"
+
+#: ../include/wx/richtext/richtextbuffer.h:3864
+msgid "&Box"
+msgstr "&Okvir"
+
+#: ../include/wx/richtext/richtextbuffer.h:5008
+msgid "&Picture"
+msgstr "&Slika"
+
+#: ../include/wx/richtext/richtextbuffer.h:5958
+msgid "&Cell"
+msgstr "&Ćelija"
+
+#: ../include/wx/richtext/richtextbuffer.h:6067
+msgid "&Table"
+msgstr "&Tabela"
+
+#: ../include/wx/richtext/richtextimagedlg.h:37
+msgid "Object Properties"
+msgstr "Svojstva objekta"
+
+#: ../include/wx/richtext/richtextsymboldlg.h:39
+msgid "Symbols"
+msgstr "Simboli"
+
+#: ../include/wx/unix/pipe.h:46
+msgid "Pipe creation failed"
+msgstr "Kreiranje pipe-a nije uspelo"
+
+#: ../include/wx/unix/private/displayx11.h:65
+msgid "Failed to enumerate video modes"
+msgstr "Enumeracija video režima nije uspela"
+
+#: ../include/wx/unix/private/displayx11.h:89
+msgid "Failed to change video mode"
+msgstr "Promena režima videa nije uspela"
+
+#: ../include/wx/unix/private/fswatcher_kqueue.h:57
+#, c-format
+msgid "Unable to open path '%s'"
+msgstr "Nemoguće otvoriti putanju '%s'"
+
+#: ../include/wx/unix/private/fswatcher_kqueue.h:74
+#, c-format
+msgid "Unable to close path '%s'"
+msgstr "Nemoguće zatvoriti putanju '%s'"
+
+#: ../include/wx/xtiprop.h:175
+msgid "SetProperty called w/o valid setter"
+msgstr "SetProperty je pozvan bez ispravnog setter-a"
+
+#: ../include/wx/xtiprop.h:184
+msgid "GetProperty called w/o valid getter"
+msgstr "GetProperty je pozvan bez ispravnog getter-a"
+
+#: ../include/wx/xtiprop.h:193
+msgid "AddToPropertyCollection called w/o valid adder"
+msgstr "AddToPropertyCollection pozvan bez ispravnog adder-a"
+
+#: ../include/wx/xtiprop.h:202
+msgid "GetPropertyCollection called w/o valid collection getter"
+msgstr "GetPropertyCollection je pozvan bez ispravnog collection getter-a"
+
+#: ../include/wx/xtiprop.h:255
+msgid "AddToPropertyCollection called on a generic accessor"
+msgstr "AddToPropertyCollection označen na generičnom accessor-u"
+
+#: ../include/wx/xtiprop.h:262
+msgid "GetPropertyCollection called on a generic accessor"
+msgstr "GetPropertyCollection pozvan na generičnom accessor-u"
+
+#: ../src/aui/tabmdi.cpp:106 ../src/generic/mdig.cpp:94
+msgid "Cl&ose"
+msgstr "&Zatvori"
+
+#: ../src/aui/tabmdi.cpp:107 ../src/generic/mdig.cpp:95
+msgid "Close All"
+msgstr "Zatvori sve"
+
+#: ../src/aui/tabmdi.cpp:109 ../src/generic/mdig.cpp:97 ../src/msw/mdi.cpp:175
+#: ../src/qt/mdi.cpp:258
+msgid "&Next"
+msgstr "&Sledeća"
+
+#: ../src/aui/tabmdi.cpp:110 ../src/generic/mdig.cpp:98 ../src/msw/mdi.cpp:176
+#: ../src/qt/mdi.cpp:259
+msgid "&Previous"
+msgstr "&Prethodna"
+
+#: ../src/aui/tabmdi.cpp:332 ../src/aui/tabmdi.cpp:348
+#: ../src/aui/tabmdi.cpp:350 ../src/generic/mdig.cpp:291
+#: ../src/generic/mdig.cpp:307 ../src/generic/mdig.cpp:311
+#: ../src/msw/mdi.cpp:337 ../src/qt/mdi.cpp:462
+msgid "&Window"
+msgstr "&Prozor"
+
+#: ../src/common/accelcmn.cpp:47
+msgctxt "keyboard key"
+msgid "Delete"
+msgstr "Delete"
+
+#: ../src/common/accelcmn.cpp:48
+msgctxt "keyboard key"
+msgid "Del"
+msgstr "Del"
+
+#: ../src/common/accelcmn.cpp:49
+msgctxt "keyboard key"
+msgid "Back"
+msgstr "Back"
+
+#: ../src/common/accelcmn.cpp:49
+msgctxt "keyboard key"
+msgid "Backspace"
+msgstr "Backspace"
+
+#: ../src/common/accelcmn.cpp:50
+msgctxt "keyboard key"
+msgid "Insert"
+msgstr "Insert"
+
+#: ../src/common/accelcmn.cpp:51
+msgctxt "keyboard key"
+msgid "Ins"
+msgstr "Ins"
+
+#: ../src/common/accelcmn.cpp:52
+msgctxt "keyboard key"
+msgid "Enter"
+msgstr "Enter"
+
+#: ../src/common/accelcmn.cpp:53
+msgctxt "keyboard key"
+msgid "Return"
+msgstr "Return"
+
+#: ../src/common/accelcmn.cpp:54
+msgctxt "keyboard key"
+msgid "PageUp"
+msgstr "PageUp"
+
+#: ../src/common/accelcmn.cpp:54
+msgctxt "keyboard key"
+msgid "Page Up"
+msgstr "Page Up"
+
+#: ../src/common/accelcmn.cpp:55
+msgctxt "keyboard key"
+msgid "PageDown"
+msgstr "PageDown"
+
+#: ../src/common/accelcmn.cpp:55
+msgctxt "keyboard key"
+msgid "Page Down"
+msgstr "Page Down"
+
+#: ../src/common/accelcmn.cpp:56
+msgctxt "keyboard key"
+msgid "PgUp"
+msgstr "PgUp"
+
+#: ../src/common/accelcmn.cpp:57
+msgctxt "keyboard key"
+msgid "PgDn"
+msgstr "PgDn"
+
+#: ../src/common/accelcmn.cpp:58
+msgctxt "keyboard key"
+msgid "Left"
+msgstr "Levo"
+
+#: ../src/common/accelcmn.cpp:59
+msgctxt "keyboard key"
+msgid "Right"
+msgstr "Desno"
+
+#: ../src/common/accelcmn.cpp:60
+msgctxt "keyboard key"
+msgid "Up"
+msgstr "Gore"
+
+#: ../src/common/accelcmn.cpp:61
+msgctxt "keyboard key"
+msgid "Down"
+msgstr "Dole"
+
+#: ../src/common/accelcmn.cpp:62
+msgctxt "keyboard key"
+msgid "Home"
+msgstr "Home"
+
+#: ../src/common/accelcmn.cpp:63
+msgctxt "keyboard key"
+msgid "End"
+msgstr "End"
+
+#: ../src/common/accelcmn.cpp:64
+msgctxt "keyboard key"
+msgid "Space"
+msgstr "Razmak"
+
+#: ../src/common/accelcmn.cpp:65
+msgctxt "keyboard key"
+msgid "Tab"
+msgstr "Tabulator"
+
+#: ../src/common/accelcmn.cpp:66
+msgctxt "keyboard key"
+msgid "Esc"
+msgstr "Esc"
+
+#: ../src/common/accelcmn.cpp:67
+msgctxt "keyboard key"
+msgid "Escape"
+msgstr "Escape"
+
+#: ../src/common/accelcmn.cpp:68
+msgctxt "keyboard key"
+msgid "Cancel"
+msgstr "Otkaži"
+
+#: ../src/common/accelcmn.cpp:69
+msgctxt "keyboard key"
+msgid "Clear"
+msgstr "Clear"
+
+#: ../src/common/accelcmn.cpp:70
+msgctxt "keyboard key"
+msgid "Menu"
+msgstr "Meni"
+
+#: ../src/common/accelcmn.cpp:71
+msgctxt "keyboard key"
+msgid "Pause"
+msgstr "Pauza"
+
+#: ../src/common/accelcmn.cpp:72
+msgctxt "keyboard key"
+msgid "Capital"
+msgstr "Veliko slovo"
+
+#: ../src/common/accelcmn.cpp:73
+msgctxt "keyboard key"
+msgid "Select"
+msgstr "Izaberi"
+
+#: ../src/common/accelcmn.cpp:74
+msgctxt "keyboard key"
+msgid "Print"
+msgstr "Štampaj"
+
+#: ../src/common/accelcmn.cpp:75
+msgctxt "keyboard key"
+msgid "Execute"
+msgstr "Pokreni"
+
+#: ../src/common/accelcmn.cpp:76
+msgctxt "keyboard key"
+msgid "Snapshot"
+msgstr "Snimak ekrana"
+
+#: ../src/common/accelcmn.cpp:77
+msgctxt "keyboard key"
+msgid "Help"
+msgstr "Pomoć"
+
+#: ../src/common/accelcmn.cpp:78
+msgctxt "keyboard key"
+msgid "Add"
+msgstr "Dodaj"
+
+#: ../src/common/accelcmn.cpp:79
+msgctxt "keyboard key"
+msgid "Separator"
+msgstr "Separator"
+
+#: ../src/common/accelcmn.cpp:80
+msgctxt "keyboard key"
+msgid "Subtract"
+msgstr "Minus"
+
+#: ../src/common/accelcmn.cpp:81
+msgctxt "keyboard key"
+msgid "Decimal"
+msgstr "Decimalni zarez"
+
+#: ../src/common/accelcmn.cpp:82
+msgctxt "keyboard key"
+msgid "Multiply"
+msgstr "Puta"
+
+#: ../src/common/accelcmn.cpp:83
+msgctxt "keyboard key"
+msgid "Divide"
+msgstr "Podeljeno sa"
+
+#: ../src/common/accelcmn.cpp:84
+msgctxt "keyboard key"
+msgid "Num_lock"
+msgstr "Num_lock"
+
+#: ../src/common/accelcmn.cpp:84
+msgctxt "keyboard key"
+msgid "Num Lock"
+msgstr "Num Lock"
+
+#: ../src/common/accelcmn.cpp:85
+msgctxt "keyboard key"
+msgid "Scroll_lock"
+msgstr "Scroll_lock"
+
+#: ../src/common/accelcmn.cpp:85
+msgctxt "keyboard key"
+msgid "Scroll Lock"
+msgstr "Scroll Lock"
+
+#: ../src/common/accelcmn.cpp:86
+msgctxt "keyboard key"
+msgid "KP_Space"
+msgstr "KP_Space"
+
+#: ../src/common/accelcmn.cpp:86
+msgctxt "keyboard key"
+msgid "Num Space"
+msgstr "Num Space"
+
+#: ../src/common/accelcmn.cpp:87
+msgctxt "keyboard key"
+msgid "KP_Tab"
+msgstr "KP_Tab"
+
+#: ../src/common/accelcmn.cpp:87
+msgctxt "keyboard key"
+msgid "Num Tab"
+msgstr "Num Tab"
+
+#: ../src/common/accelcmn.cpp:88
+msgctxt "keyboard key"
+msgid "KP_Enter"
+msgstr "KP_Enter"
+
+#: ../src/common/accelcmn.cpp:88
+msgctxt "keyboard key"
+msgid "Num Enter"
+msgstr "Num Enter"
+
+#: ../src/common/accelcmn.cpp:89
+msgctxt "keyboard key"
+msgid "KP_Home"
+msgstr "KP_Home"
+
+#: ../src/common/accelcmn.cpp:89
+msgctxt "keyboard key"
+msgid "Num Home"
+msgstr "Num Home"
+
+#: ../src/common/accelcmn.cpp:90
+msgctxt "keyboard key"
+msgid "KP_Left"
+msgstr "KP_levo"
+
+#: ../src/common/accelcmn.cpp:90
+msgctxt "keyboard key"
+msgid "Num left"
+msgstr "Num levo"
+
+#: ../src/common/accelcmn.cpp:91
+msgctxt "keyboard key"
+msgid "KP_Up"
+msgstr "KP_gore"
+
+#: ../src/common/accelcmn.cpp:91
+msgctxt "keyboard key"
+msgid "Num Up"
+msgstr "Num gore"
+
+#: ../src/common/accelcmn.cpp:92
+msgctxt "keyboard key"
+msgid "KP_Right"
+msgstr "KP_desno"
+
+#: ../src/common/accelcmn.cpp:92
+msgctxt "keyboard key"
+msgid "Num Right"
+msgstr "Num desno"
+
+#: ../src/common/accelcmn.cpp:93
+msgctxt "keyboard key"
+msgid "KP_Down"
+msgstr "KP_dole"
+
+#: ../src/common/accelcmn.cpp:93
+msgctxt "keyboard key"
+msgid "Num Down"
+msgstr "Num dole"
+
+#: ../src/common/accelcmn.cpp:94
+msgctxt "keyboard key"
+msgid "KP_PageUp"
+msgstr "KP_PageUp"
+
+#: ../src/common/accelcmn.cpp:94
+msgctxt "keyboard key"
+msgid "Num Page Up"
+msgstr "Num Page Up"
+
+#: ../src/common/accelcmn.cpp:95
+msgctxt "keyboard key"
+msgid "KP_PageDown"
+msgstr "KP_PageDown"
+
+#: ../src/common/accelcmn.cpp:95
+msgctxt "keyboard key"
+msgid "Num Page Down"
+msgstr "Num Page Down"
+
+#: ../src/common/accelcmn.cpp:96
+msgctxt "keyboard key"
+msgid "KP_Prior"
+msgstr "KP_prethodna"
+
+#: ../src/common/accelcmn.cpp:97
+msgctxt "keyboard key"
+msgid "KP_Next"
+msgstr "KP_sledeća"
+
+#: ../src/common/accelcmn.cpp:98
+msgctxt "keyboard key"
+msgid "KP_End"
+msgstr "KP_End"
+
+#: ../src/common/accelcmn.cpp:98
+msgctxt "keyboard key"
+msgid "Num End"
+msgstr "Num End"
+
+#: ../src/common/accelcmn.cpp:99
+msgctxt "keyboard key"
+msgid "KP_Begin"
+msgstr "KP_Begin"
+
+#: ../src/common/accelcmn.cpp:99
+msgctxt "keyboard key"
+msgid "Num Begin"
+msgstr "Num Begin"
+
+#: ../src/common/accelcmn.cpp:100
+msgctxt "keyboard key"
+msgid "KP_Insert"
+msgstr "KP_Insert"
+
+#: ../src/common/accelcmn.cpp:100
+msgctxt "keyboard key"
+msgid "Num Insert"
+msgstr "Num Insert"
+
+#: ../src/common/accelcmn.cpp:101
+msgctxt "keyboard key"
+msgid "KP_Delete"
+msgstr "KP_Delete"
+
+#: ../src/common/accelcmn.cpp:101
+msgctxt "keyboard key"
+msgid "Num Delete"
+msgstr "Num Delete"
+
+#: ../src/common/accelcmn.cpp:102
+msgctxt "keyboard key"
+msgid "KP_Equal"
+msgstr "KP_Jednako"
+
+#: ../src/common/accelcmn.cpp:102
+msgctxt "keyboard key"
+msgid "Num ="
+msgstr "Num ="
+
+#: ../src/common/accelcmn.cpp:103
+msgctxt "keyboard key"
+msgid "KP_Multiply"
+msgstr "KP_Puta"
+
+#: ../src/common/accelcmn.cpp:103
+msgctxt "keyboard key"
+msgid "Num *"
+msgstr "Num *"
+
+#: ../src/common/accelcmn.cpp:104
+msgctxt "keyboard key"
+msgid "KP_Add"
+msgstr "KP_Plus"
+
+#: ../src/common/accelcmn.cpp:104
+msgctxt "keyboard key"
+msgid "Num +"
+msgstr "Num +"
+
+#: ../src/common/accelcmn.cpp:105
+msgctxt "keyboard key"
+msgid "KP_Separator"
+msgstr "KP_Separator"
+
+#: ../src/common/accelcmn.cpp:105
+msgctxt "keyboard key"
+msgid "Num ,"
+msgstr "Num ,"
+
+#: ../src/common/accelcmn.cpp:106
+msgctxt "keyboard key"
+msgid "KP_Subtract"
+msgstr "KP_Minus"
+
+#: ../src/common/accelcmn.cpp:106
+msgctxt "keyboard key"
+msgid "Num -"
+msgstr "Num -"
+
+#: ../src/common/accelcmn.cpp:107
+msgctxt "keyboard key"
+msgid "KP_Decimal"
+msgstr "KP_Decimalni zarez"
+
+#: ../src/common/accelcmn.cpp:107
+msgctxt "keyboard key"
+msgid "Num ."
+msgstr "Num ."
+
+#: ../src/common/accelcmn.cpp:108
+msgctxt "keyboard key"
+msgid "KP_Divide"
+msgstr "KP_Podeljeno sa"
+
+#: ../src/common/accelcmn.cpp:108
+msgctxt "keyboard key"
+msgid "Num /"
+msgstr "Num /"
+
+#: ../src/common/accelcmn.cpp:109
+msgctxt "keyboard key"
+msgid "Windows_Left"
+msgstr "Windows_Levi"
+
+#: ../src/common/accelcmn.cpp:110
+msgctxt "keyboard key"
+msgid "Windows_Right"
+msgstr "Windows_Desni"
+
+#: ../src/common/accelcmn.cpp:111
+msgctxt "keyboard key"
+msgid "Windows_Menu"
+msgstr "Windows_Meni"
+
+#: ../src/common/accelcmn.cpp:112
+msgctxt "keyboard key"
+msgid "Command"
+msgstr "Command"
+
+#: ../src/common/accelcmn.cpp:186 ../src/common/accelcmn.cpp:359
+msgctxt "keyboard key"
+msgid "Ctrl"
+msgstr "Ctrl"
+
+#: ../src/common/accelcmn.cpp:188 ../src/common/accelcmn.cpp:363
+msgctxt "keyboard key"
+msgid "Alt"
+msgstr "Alt"
+
+#: ../src/common/accelcmn.cpp:190 ../src/common/accelcmn.cpp:361
+msgctxt "keyboard key"
+msgid "Shift"
+msgstr "Šift"
+
+#: ../src/common/accelcmn.cpp:196
+msgctxt "keyboard key"
+msgid "num "
+msgstr "num "
+
+#: ../src/common/accelcmn.cpp:260 ../src/common/accelcmn.cpp:382
+msgctxt "keyboard key"
+msgid "F"
+msgstr "F"
+
+#: ../src/common/accelcmn.cpp:277 ../src/common/accelcmn.cpp:385
+msgctxt "keyboard key"
+msgid "KP_F"
+msgstr "KP_F"
+
+#: ../src/common/accelcmn.cpp:280 ../src/common/accelcmn.cpp:388
+msgctxt "keyboard key"
+msgid "KP_"
+msgstr "KP_"
+
+#: ../src/common/accelcmn.cpp:283 ../src/common/accelcmn.cpp:391
+msgctxt "keyboard key"
+msgid "SPECIAL"
+msgstr "SPECIAL"
+
+#: ../src/common/accelcmn.cpp:373
+#, fuzzy
+msgid "Ctrl"
+msgstr "Ctrl"
+
+#: ../src/common/appbase.cpp:786
+msgid "show this help message"
+msgstr "Prikaži ovu poruku pomoći"
+
+#: ../src/common/appbase.cpp:796
+msgid "generate verbose log messages"
+msgstr "Generiši detaljne poruke dnevnika"
+
+#: ../src/common/appcmn.cpp:256
+msgid "specify the theme to use"
+msgstr "Odredite temu koja će se koristiti"
+
+#: ../src/common/appcmn.cpp:270
+msgid "specify display mode to use (e.g. 640x480-16)"
+msgstr "Odredi režim prikaza koji će se koristiti (na primer 640x480-16)"
+
+#: ../src/common/appcmn.cpp:292
+#, c-format
+msgid "Unsupported theme '%s'."
+msgstr "Tema nije podržana '%s'."
+
+#: ../src/common/appcmn.cpp:309
+#, c-format
+msgid "Invalid display mode specification '%s'."
+msgstr "Neispravna specifikacija režima prikaza '%s'."
+
+#: ../src/common/cmdline.cpp:875
+#, c-format
+msgid "Option '%s' can't be negated"
+msgstr "Opcija '%s' ne može biti negativna"
+
+#: ../src/common/cmdline.cpp:889
+#, c-format
+msgid "Unknown long option '%s'"
+msgstr "Nepoznata duga opcija '%s'"
+
+#: ../src/common/cmdline.cpp:904 ../src/common/cmdline.cpp:926
+#, c-format
+msgid "Unknown option '%s'"
+msgstr "Nepoznata opcija '%s'"
+
+#: ../src/common/cmdline.cpp:1004
+#, c-format
+msgid "Unexpected characters following option '%s'."
+msgstr "Neočekivani znakovi koji prate opciju '%s'."
+
+#: ../src/common/cmdline.cpp:1039
+#, c-format
+msgid "Option '%s' requires a value."
+msgstr "Opcija '%s' zahteva vrednost."
+
+#: ../src/common/cmdline.cpp:1058
+#, c-format
+msgid "Separator expected after the option '%s'."
+msgstr "Očekuje se separator nakon opcije '%s'."
+
+#: ../src/common/cmdline.cpp:1088 ../src/common/cmdline.cpp:1106
+#, c-format
+msgid "'%s' is not a correct numeric value for option '%s'."
+msgstr "'%s' nije ispravna brojčana vrednost za opciju '%s'."
+
+#: ../src/common/cmdline.cpp:1122
+#, c-format
+msgid "Option '%s': '%s' cannot be converted to a date."
+msgstr "Opcija '%s': '%s' ne može biti pretvoreno u datum."
+
+#: ../src/common/cmdline.cpp:1170
+#, c-format
+msgid "Unexpected parameter '%s'"
+msgstr "Neočekivani parametar '%s'"
+
+#. TRANSLATORS: Short name and long name for a command line option
+#: ../src/common/cmdline.cpp:1197
+#, c-format
+msgid "%s (or %s)"
+msgstr "%s (ili %s)"
+
+#: ../src/common/cmdline.cpp:1208
+#, c-format
+msgid "The value for the option '%s' must be specified."
+msgstr "Vrednost za opciju '%s' mora biti određena."
+
+#: ../src/common/cmdline.cpp:1230
+#, c-format
+msgid "The required parameter '%s' was not specified."
+msgstr "Neophodni parametar '%s' nije određen."
+
+#: ../src/common/cmdline.cpp:1289
+#, c-format
+msgid "Usage: %s"
+msgstr "Način korišćenja: %s"
+
+#: ../src/common/cmdline.cpp:1498
+msgid "str"
+msgstr "str"
+
+#: ../src/common/cmdline.cpp:1502
+msgid "num"
+msgstr "num"
+
+#: ../src/common/cmdline.cpp:1506
+msgid "double"
+msgstr "double"
+
+#: ../src/common/cmdline.cpp:1510
+msgid "date"
+msgstr "Datum"
+
+#: ../src/common/cmdproc.cpp:250 ../src/common/cmdproc.cpp:276
+#: ../src/common/cmdproc.cpp:296
+msgid "Unnamed command"
+msgstr "Komanda bez imena"
+
+#: ../src/common/cmdproc.cpp:253
+msgid "&Undo "
+msgstr "&Poništi"
+
+#: ../src/common/cmdproc.cpp:255
+msgid "Can't &Undo "
+msgstr "Nemoguće &poništiti"
+
+#: ../src/common/cmdproc.cpp:259 ../src/common/stockitem.cpp:208
+#: ../src/msw/textctrl.cpp:2880 ../src/osx/textctrl_osx.cpp:649
+#: ../src/richtext/richtextctrl.cpp:327
+msgid "&Undo"
+msgstr "&Poništi"
+
+#: ../src/common/cmdproc.cpp:277 ../src/common/cmdproc.cpp:297
+msgid "&Redo "
+msgstr "pono&vi"
+
+#: ../src/common/cmdproc.cpp:281 ../src/common/cmdproc.cpp:288
+#: ../src/common/stockitem.cpp:190 ../src/msw/textctrl.cpp:2881
+#: ../src/osx/textctrl_osx.cpp:650 ../src/richtext/richtextctrl.cpp:328
+msgid "&Redo"
+msgstr "Pono&vi"
+
+#: ../src/common/colourcmn.cpp:41
+#, c-format
+msgid "String To Colour : Incorrect colour specification : %s"
+msgstr "Niz znakova u boju: neispravna specifikacija boje: %s"
+
+#: ../src/common/config.cpp:259
+#, c-format
+msgid "Invalid value %ld for a boolean key \"%s\" in config file."
+msgstr ""
+"Neispravna vrednost %ld za boolean ključ\"%s\" u datoteci sa podešavanjima."
+
+#: ../src/common/config.cpp:526
+#, c-format
+msgid ""
+"Environment variables expansion failed: missing '%c' at position %u in '%s'."
+msgstr ""
+"Proširivanje varijabli okruženja nije uspelo: nedostaje '%c' na poziciji %u "
+"u '%s'."
+
+#: ../src/common/config.cpp:576 ../src/msw/regconf.cpp:272
+#, c-format
+msgid "'%s' has extra '..', ignored."
+msgstr "'%s' ima dodatne '..', biće ignorisane."
+
+#. TRANSLATORS: Checkbox state name
+#: ../src/common/datavcmn.cpp:2166 ../src/generic/datavgen.cpp:1430
+msgid "checked"
+msgstr "Označeno"
+
+#. TRANSLATORS: Checkbox state name
+#: ../src/common/datavcmn.cpp:2170 ../src/generic/datavgen.cpp:1432
+msgid "unchecked"
+msgstr "Nije označeno"
+
+#. TRANSLATORS: Checkbox state name
+#: ../src/common/datavcmn.cpp:2174
+msgid "undetermined"
+msgstr "Nije određeno"
+
+#: ../src/common/datetimefmt.cpp:1875
+msgid "today"
+msgstr "Danas"
+
+#: ../src/common/datetimefmt.cpp:1876
+msgid "yesterday"
+msgstr "Juče"
+
+#: ../src/common/datetimefmt.cpp:1877
+msgid "tomorrow"
+msgstr "Sutra"
+
+#: ../src/common/datetimefmt.cpp:2071
+msgid "first"
+msgstr "Prvi"
+
+#: ../src/common/datetimefmt.cpp:2072
+msgid "second"
+msgstr "Drugi"
+
+#: ../src/common/datetimefmt.cpp:2073
+msgid "third"
+msgstr "Treći"
+
+#: ../src/common/datetimefmt.cpp:2074
+msgid "fourth"
+msgstr "Četvrti"
+
+#: ../src/common/datetimefmt.cpp:2075
+msgid "fifth"
+msgstr "Peti"
+
+#: ../src/common/datetimefmt.cpp:2076
+msgid "sixth"
+msgstr "Šesti"
+
+#: ../src/common/datetimefmt.cpp:2077
+msgid "seventh"
+msgstr "Sedmi"
+
+#: ../src/common/datetimefmt.cpp:2078
+msgid "eighth"
+msgstr "Osmi"
+
+#: ../src/common/datetimefmt.cpp:2079
+msgid "ninth"
+msgstr "Deveti"
+
+#: ../src/common/datetimefmt.cpp:2080
+msgid "tenth"
+msgstr "Deseti"
+
+#: ../src/common/datetimefmt.cpp:2081
+msgid "eleventh"
+msgstr "Jedanaesti"
+
+#: ../src/common/datetimefmt.cpp:2082
+msgid "twelfth"
+msgstr "Dvanaesti"
+
+#: ../src/common/datetimefmt.cpp:2083
+msgid "thirteenth"
+msgstr "Trinaesti"
+
+#: ../src/common/datetimefmt.cpp:2084
+msgid "fourteenth"
+msgstr "Četrnaesti"
+
+#: ../src/common/datetimefmt.cpp:2085
+msgid "fifteenth"
+msgstr "Petnaesti"
+
+#: ../src/common/datetimefmt.cpp:2086
+msgid "sixteenth"
+msgstr "Šesnaesti"
+
+#: ../src/common/datetimefmt.cpp:2087
+msgid "seventeenth"
+msgstr "Sedamnaesti"
+
+#: ../src/common/datetimefmt.cpp:2088
+msgid "eighteenth"
+msgstr "Osamnaesti"
+
+#: ../src/common/datetimefmt.cpp:2089
+msgid "nineteenth"
+msgstr "Devetnaesti"
+
+#: ../src/common/datetimefmt.cpp:2090
+msgid "twentieth"
+msgstr "Dvadeseti"
+
+#: ../src/common/datetimefmt.cpp:2248
+msgid "noon"
+msgstr "Podne"
+
+#: ../src/common/datetimefmt.cpp:2249
+msgid "midnight"
+msgstr "Ponoć"
+
+#: ../src/common/debugrpt.cpp:209
+#, c-format
+msgid "Failed to create directory \"%s\""
+msgstr "Neuspešno pravljenje direktorijuma \"%s\""
+
+#: ../src/common/debugrpt.cpp:210
+msgid "Debug report couldn't be created."
+msgstr "Izveštaj o otklanjanju grešaka nije mogao biti napravljen."
+
+#: ../src/common/debugrpt.cpp:227
+#, c-format
+msgid "Failed to remove debug report file \"%s\""
+msgstr "Neuspešno uklanjanje datoteke prijave o otklanjanju grešaka \"%s\""
+
+#: ../src/common/debugrpt.cpp:239
+#, c-format
+msgid "Failed to clean up debug report directory \"%s\""
+msgstr ""
+"Neuspešno čišćenje direktorijuma sa prijavama o otklanjanju grešaka \"%s\""
+
+#: ../src/common/debugrpt.cpp:514
+msgid "process context description"
+msgstr "Obradi sadržaj opisa"
+
+#: ../src/common/debugrpt.cpp:538
+msgid "dump of the process state (binary)"
+msgstr "dump stanja procesa (binarni )"
+
+#: ../src/common/debugrpt.cpp:553
+msgid "Debug report generation has failed."
+msgstr "Generisanje prijave o otklanjanju grešaka nije uspelo."
+
+#: ../src/common/debugrpt.cpp:560
+#, c-format
+msgid ""
+"Processing debug report has failed, leaving the files in \"%s\" directory."
+msgstr ""
+"Obrađivanje izveštaja o otklanjanju grešaka nije uspelo, datoteke će biti "
+"ostavljene u direktorijumu \"%s\""
+
+#: ../src/common/debugrpt.cpp:573
+msgid "A debug report has been generated. It can be found in"
+msgstr "Izveštaj o otklanjanju grešaka je generisan. Može biti pronađen u"
+
+#: ../src/common/debugrpt.cpp:576
+msgid "And includes the following files:\n"
+msgstr "I uključuje sledeće datoteke:\n"
+
+#: ../src/common/debugrpt.cpp:586
+msgid ""
+"\n"
+"Please send this report to the program maintainer, thank you!\n"
+msgstr ""
+"\n"
+"Molimo pošaljite ovaj izveštaj osobi zaduženoj za održavanje programa, "
+"hvala!\n"
+
+#: ../src/common/debugrpt.cpp:729
+msgid "Failed to execute curl, please install it in PATH."
+msgstr ""
+"Nije moguće pokrenuti curl, molimo instalirajte ga i dodajte u globalnu "
+"putanju."
+
+#: ../src/common/debugrpt.cpp:742
+#, c-format
+msgid "Failed to upload the debug report (error code %d)."
+msgstr "Nemoguće otpremiti izveštaj o otklanjanju grešaka (kod greške %d)."
+
+#: ../src/common/docview.cpp:366
+msgid "Save As"
+msgstr "Sačuvaj kao"
+
+#: ../src/common/docview.cpp:457
+msgid "Discard changes and reload the last saved version?"
+msgstr "Odbaciti promene i učitati poslednju sačuvanu verziju?"
+
+#: ../src/common/docview.cpp:488
+msgid "unnamed"
+msgstr "Bez imena"
+
+#: ../src/common/docview.cpp:513
+#, c-format
+msgid "Do you want to save changes to %s?"
+msgstr "Da li želite da sačuvate promene u %s?"
+
+#: ../src/common/docview.cpp:521 ../src/common/docview.cpp:560
+#: ../src/common/stockitem.cpp:195
+msgid "&Save"
+msgstr "&Sačuvaj"
+
+#: ../src/common/docview.cpp:522 ../src/common/docview.cpp:560
+msgid "&Discard changes"
+msgstr ""
+
+#: ../src/common/docview.cpp:523
+#, fuzzy
+msgid "Do&n't close"
+msgstr "Nemoj da sačuvaš"
+
+#: ../src/common/docview.cpp:553
+#, fuzzy, c-format
+msgid "Do you want to save changes to %s before closing it?"
+msgstr "Da li želite da sačuvate promene u %s?"
+
+#: ../src/common/docview.cpp:559
+#, fuzzy
+msgid "The document must be closed."
+msgstr "Tekst nije mogao biti sačuvan."
+
+#: ../src/common/docview.cpp:571
+#, c-format
+msgid "Saving %s failed, would you like to retry?"
+msgstr ""
+
+#: ../src/common/docview.cpp:577
+msgid "Retry"
+msgstr ""
+
+#: ../src/common/docview.cpp:577
+msgid "Discard changes"
+msgstr ""
+
+#: ../src/common/docview.cpp:679
+#, c-format
+msgid "File \"%s\" could not be opened for writing."
+msgstr "Datoteka \"%s\" ne može biti otvorena za pisanje."
+
+#: ../src/common/docview.cpp:685
+#, c-format
+msgid "Failed to save document to the file \"%s\"."
+msgstr "Neuspešno čuvanje dokumenta u datoteku \"%s\"."
+
+#: ../src/common/docview.cpp:702
+#, c-format
+msgid "File \"%s\" could not be opened for reading."
+msgstr "Datoteka \"%s\" ne može biti otvorena za čitanje."
+
+#: ../src/common/docview.cpp:714
+#, c-format
+msgid "Failed to read document from the file \"%s\"."
+msgstr "Čitanje dokumenta iz datoteke \"%s\" nije uspelo."
+
+#: ../src/common/docview.cpp:1236
+#, c-format
+msgid ""
+"The file '%s' doesn't exist and couldn't be opened.\n"
+"It has been removed from the most recently used files list."
+msgstr ""
+"Datoteka '%s' ne postoji i ne može se otvoriti.\n"
+"Uklonjena je iz liste nedavno korišćenih datoteka."
+
+#: ../src/common/docview.cpp:1296
+msgid "Print preview creation failed."
+msgstr "Pravljenje pregleda štampanja nije uspelo."
+
+#: ../src/common/docview.cpp:1302
+msgid "Print Preview"
+msgstr "Pregled štampanja"
+
+#: ../src/common/docview.cpp:1517
+#, c-format
+msgid "The format of file '%s' couldn't be determined."
+msgstr "Format datoteke '%s' ne može biti određen."
+
+#: ../src/common/docview.cpp:1643
+#, c-format
+msgid "unnamed%d"
+msgstr "Bez imena %d"
+
+#: ../src/common/docview.cpp:1660
+msgid " - "
+msgstr " - "
+
+#: ../src/common/docview.cpp:1791 ../src/common/docview.cpp:1844
+msgid "Open File"
+msgstr "Otvori datoteku"
+
+#: ../src/common/docview.cpp:1807
+msgid "File error"
+msgstr "Greška datoteke"
+
+#: ../src/common/docview.cpp:1809
+msgid "Sorry, could not open this file."
+msgstr "Žao nam je, ova datoteka se ne može otvoriti."
+
+#: ../src/common/docview.cpp:1843
+msgid "Sorry, the format for this file is unknown."
+msgstr "Žao nam je, format ove datoteke je nepoznat."
+
+#: ../src/common/docview.cpp:1924
+msgid "Select a document template"
+msgstr "Izaberi šablon dokumenta"
+
+#: ../src/common/docview.cpp:1925
+msgid "Templates"
+msgstr "Šabloni"
+
+#: ../src/common/docview.cpp:1998
+msgid "Select a document view"
+msgstr "Izaberi prikaz dokumenta"
+
+#: ../src/common/docview.cpp:1999
+msgid "Views"
+msgstr "Prikazi"
+
+#: ../src/common/dynlib.cpp:81
+#, c-format
+msgid "Failed to load shared library '%s'"
+msgstr "Nemoguće učitati deljenu biblioteku '%s'"
+
+#: ../src/common/dynlib.cpp:105
+#, c-format
+msgid "Couldn't find symbol '%s' in a dynamic library"
+msgstr "Nemoguće pronaći simbol '%s' u dinamičkoj biblioteci"
+
+#: ../src/common/ffile.cpp:56 ../src/common/file.cpp:215
+#, c-format
+msgid "can't open file '%s'"
+msgstr "Nemoguće otvoriti datoteku '%s'"
+
+#: ../src/common/ffile.cpp:72
+#, c-format
+msgid "can't close file '%s'"
+msgstr "Nemoguće zatvoriti datoteku '%s'"
+
+#: ../src/common/ffile.cpp:106 ../src/common/ffile.cpp:131
+#, c-format
+msgid "Read error on file '%s'"
+msgstr "Greška u čitanju datoteke '%s'"
+
+#: ../src/common/ffile.cpp:148
+#, c-format
+msgid "Write error on file '%s'"
+msgstr "Greška u pisanju datoteke '%s'"
+
+#: ../src/common/ffile.cpp:182
+#, c-format
+msgid "failed to flush the file '%s'"
+msgstr "Čišćenje datoteke '%s' nije uspelo"
+
+#: ../src/common/ffile.cpp:222
+#, c-format
+msgid "Seek error on file '%s' (large files not supported by stdio)"
+msgstr "Greška u pretrazi datoteke '%s' (stdio ne podržava velike datoteke )"
+
+#: ../src/common/ffile.cpp:232
+#, c-format
+msgid "Seek error on file '%s'"
+msgstr "Greška u pretrazi datoteke '%s'"
+
+#: ../src/common/ffile.cpp:248
+#, c-format
+msgid "Can't find current position in file '%s'"
+msgstr "Nemoguće pronaći trenutnu poziciju u datoteci '%s'"
+
+#: ../src/common/ffile.cpp:349 ../src/common/file.cpp:569
+msgid "Failed to set temporary file permissions"
+msgstr "Postavljanje privremenih dozvola datoteke nije uspelo"
+
+#: ../src/common/ffile.cpp:371
+#, c-format
+msgid "can't remove file '%s'"
+msgstr "Nemoguće ukloniti datoteku '%s'"
+
+#: ../src/common/ffile.cpp:376 ../src/common/file.cpp:591
+#, c-format
+msgid "can't commit changes to file '%s'"
+msgstr "Nemoguće izvršiti promene na datoteci '%s'"
+
+#: ../src/common/ffile.cpp:388 ../src/common/file.cpp:603
+#, c-format
+msgid "can't remove temporary file '%s'"
+msgstr "Nemoguće ukloniti privremenu datoteku '%s'"
+
+#: ../src/common/file.cpp:162
+#, c-format
+msgid "can't create file '%s'"
+msgstr "Nemoguće napraviti datoteku '%s'"
+
+#: ../src/common/file.cpp:229
+#, c-format
+msgid "can't close file descriptor %d"
+msgstr "Nemoguće zatvoriti opisivač datoteke %d"
+
+#: ../src/common/file.cpp:332
+#, c-format
+msgid "can't read from file descriptor %d"
+msgstr "Nemoguće čitati iz opisivača datoteke %d"
+
+#: ../src/common/file.cpp:351
+#, c-format
+msgid "can't write to file descriptor %d"
+msgstr "Nemoguće pisati u opisivač datoteke %d"
+
+#: ../src/common/file.cpp:390
+#, c-format
+msgid "can't flush file descriptor %d"
+msgstr "Nemoguće očistiti opisivač datoteke  %d"
+
+#: ../src/common/file.cpp:432
+#, c-format
+msgid "can't seek on file descriptor %d"
+msgstr "Nemoguće pretraživati na opisivaču datoteke %d"
+
+#: ../src/common/file.cpp:446
+#, c-format
+msgid "can't get seek position on file descriptor %d"
+msgstr ""
+"Nemoguće preuzeti informaciju o poziciji pretrage za opisivač datoteke %d"
+
+#: ../src/common/file.cpp:475
+#, c-format
+msgid "can't find length of file on file descriptor %d"
+msgstr "Nemoguće pronaći dužinu datoteke na opisivaču datoteke %d"
+
+#: ../src/common/file.cpp:505
+#, c-format
+msgid "can't determine if the end of file is reached on descriptor %d"
+msgstr "Nemoguće odrediti da li je dostignut kraj datoteke na opisivaču %d"
+
+#: ../src/common/fileconf.cpp:352
+#, c-format
+msgid ""
+" and additionally, the existing configuration file was renamed to \"%s\" and "
+"couldn't be renamed back, please rename it to its original path \"%s\""
+msgstr ""
+
+#: ../src/common/fileconf.cpp:389
+#, fuzzy
+msgid " due to the following error:\n"
+msgstr "I uključuje sledeće datoteke:\n"
+
+#: ../src/common/fileconf.cpp:412
+#, fuzzy
+msgid "failed to rename the existing file"
+msgstr "Neuspešno čitanje tekstualne datoteke \"%s\"."
+
+#: ../src/common/fileconf.cpp:421
+#, fuzzy
+msgid "failed to create the new file directory"
+msgstr "Preuzimanje radnog direktorijuma nije uspelo"
+
+#: ../src/common/fileconf.cpp:428
+#, fuzzy
+msgid "failed to move the file to the new location"
+msgstr "Neuspešno postavljanje web prikaza na moderni nivo emulacije"
+
+#: ../src/common/fileconf.cpp:462
+#, c-format
+msgid "can't open global configuration file '%s'."
+msgstr "Nemoguće otvoriti datoteku sa globalnim podešavanjima '%s'."
+
+#: ../src/common/fileconf.cpp:478
+#, c-format
+msgid "can't open user configuration file '%s'."
+msgstr "Nemoguće otvoriti datoteku korisničkih podešavanja '%s'."
+
+#: ../src/common/fileconf.cpp:483
+#, c-format
+msgid "Changes won't be saved to avoid overwriting the existing file \"%s\""
+msgstr ""
+"Promene neće biti sačuvane kako bi se izbeglo menjanje postojeće datoteke "
+"\"%s\""
+
+#: ../src/common/fileconf.cpp:583
+msgid "Error reading config options."
+msgstr "Greška u čitanju opcija konfiguracije."
+
+#: ../src/common/fileconf.cpp:593
+msgid "Failed to read config options."
+msgstr "Čitanje opcija konfiguracije nije uspelo."
+
+#: ../src/common/fileconf.cpp:700
+#, c-format
+msgid "file '%s': unexpected character %c at line %zu."
+msgstr "Datoteka'%s': Neočekivani znak %c u redu %zu."
+
+#: ../src/common/fileconf.cpp:736
+#, c-format
+msgid "file '%s', line %zu: '%s' ignored after group header."
+msgstr "Datoteka'%s', red %zu: '%s' ignorisan nakon zaglavlja grupe."
+
+#: ../src/common/fileconf.cpp:765
+#, c-format
+msgid "file '%s', line %zu: '=' expected."
+msgstr "Datoteka'%s', red %zu: '=' se očekuje."
+
+#: ../src/common/fileconf.cpp:778
+#, c-format
+msgid "file '%s', line %zu: value for immutable key '%s' ignored."
+msgstr "Datoteka '%s', red %zu: Vrednost za immutable ključ '%s' ignorisana."
+
+#: ../src/common/fileconf.cpp:788
+#, c-format
+msgid "file '%s', line %zu: key '%s' was first found at line %d."
+msgstr "Datoteka '%s', red %zu: Ključ '%s' je prvi put pronađen u redu %d."
+
+#: ../src/common/fileconf.cpp:1091
+#, c-format
+msgid "Config entry name cannot start with '%c'."
+msgstr "Ime unosa konfiguracije ne može početi sa '%c'."
+
+#: ../src/common/fileconf.cpp:1146
+#, fuzzy
+msgid "Failed to create configuration file directory."
+msgstr "Pravljenje objekta konfiguracije fonta nije uspelo."
+
+#: ../src/common/fileconf.cpp:1158
+msgid "can't open user configuration file."
+msgstr "Nemoguće otvoriti datoteku korisničke konfiguracije."
+
+#: ../src/common/fileconf.cpp:1172
+msgid "can't write user configuration file."
+msgstr "Nemoguće pisati u datoteci sa korisničkom konfiguracijom."
+
+#: ../src/common/fileconf.cpp:1178
+msgid "Failed to update user configuration file."
+msgstr "Ažuriranje datoteke sa korisničkom konfiguracijom nije uspelo."
+
+#: ../src/common/fileconf.cpp:1201
+msgid "Error saving user configuration data."
+msgstr "Greška pri čuvanju podataka korisničke konfiguracije."
+
+#: ../src/common/fileconf.cpp:1313
+#, c-format
+msgid "can't delete user configuration file '%s'"
+msgstr "Nemoguće obrisati datoteku korisničke konfiguracije '%s'"
+
+#: ../src/common/fileconf.cpp:2007
+#, c-format
+msgid "entry '%s' appears more than once in group '%s'"
+msgstr "Unos '%s' se pojavljuje više od jednog puta u grupi '%s'"
+
+#: ../src/common/fileconf.cpp:2021
+#, c-format
+msgid "attempt to change immutable key '%s' ignored."
+msgstr "Pokušaj da se promeni immutable ključ '%s' biće ignorisan."
+
+#: ../src/common/fileconf.cpp:2118
+#, c-format
+msgid "trailing backslash ignored in '%s'"
+msgstr "Prateća obrnuta kosa crta će biti ignorisana u '%s'"
+
+#: ../src/common/fileconf.cpp:2153
+#, c-format
+msgid "unexpected \" at position %d in '%s'."
+msgstr "Neočekivani \" na poziciji %d u '%s'."
+
+#: ../src/common/filefn.cpp:474
+#, c-format
+msgid "Failed to copy the file '%s' to '%s'"
+msgstr "Kopiranje datoteke '%s' u '%s' nije uspelo"
+
+#: ../src/common/filefn.cpp:487
+#, c-format
+msgid "Impossible to get permissions for file '%s'"
+msgstr "Nemoguće preuzeti dozvole za datoteku '%s'"
+
+#: ../src/common/filefn.cpp:501
+#, c-format
+msgid "Impossible to overwrite the file '%s'"
+msgstr "Nemoguće zameniti datoteku '%s'"
+
+#: ../src/common/filefn.cpp:508
+#, c-format
+msgid "Error copying the file '%s' to '%s'."
+msgstr "Greška pri kopiranju datoteke '%s' u '%s'."
+
+#: ../src/common/filefn.cpp:556
+#, c-format
+msgid "Impossible to set permissions for the file '%s'"
+msgstr "Nemoguće postaviti dozvole za datoteku '%s'"
+
+#: ../src/common/filefn.cpp:606
+#, c-format
+msgid ""
+"Failed to rename the file '%s' to '%s' because the destination file already "
+"exists."
+msgstr ""
+"Preimenovanje datoteke '%s' u '%s' nije uspelo zato što datoteka na ovoj "
+"destinaciji već postoji."
+
+#: ../src/common/filefn.cpp:623
+#, c-format
+msgid "File '%s' couldn't be renamed '%s'"
+msgstr "Datoteka '%s' ne može biti preimenovana '%s'"
+
+#: ../src/common/filefn.cpp:639
+#, c-format
+msgid "File '%s' couldn't be removed"
+msgstr "Datoteka '%s' ne može biti uklonjena"
+
+#: ../src/common/filefn.cpp:666
+#, c-format
+msgid "Directory '%s' couldn't be created"
+msgstr "Direktorijum '%s' ne može biti napravljen"
+
+#: ../src/common/filefn.cpp:680
+#, c-format
+msgid "Directory '%s' couldn't be deleted"
+msgstr "Direktorijum '%s' ne  može biti obrisan"
+
+#: ../src/common/filefn.cpp:714
+#, c-format
+msgid "Cannot enumerate files '%s'"
+msgstr "Nemoguća enumeracija datoteka '%s'"
+
+#: ../src/common/filefn.cpp:798
+msgid "Failed to get the working directory"
+msgstr "Preuzimanje radnog direktorijuma nije uspelo"
+
+#: ../src/common/filefn.cpp:843
+msgid "Could not set current working directory"
+msgstr "Postavljanje trenutnog radnog direktorijuma nije uspelo"
+
+#: ../src/common/filefn.cpp:974
+#, c-format
+msgid "Files (%s)"
+msgstr "Datoteke (%s)"
+
+#: ../src/common/filename.cpp:182
+#, c-format
+msgid "Failed to open '%s' for reading"
+msgstr "Otvaranje '%s' za čitanje nije uspelo"
+
+#: ../src/common/filename.cpp:187
+#, c-format
+msgid "Failed to open '%s' for writing"
+msgstr "Otvaranje '%s' za pisanje nije uspelo"
+
+#: ../src/common/filename.cpp:199
+msgid "Failed to close file handle"
+msgstr "Zatvaranje obrađivača za datoteku nije uspelo"
+
+#: ../src/common/filename.cpp:1046
+msgid "Failed to create a temporary file name"
+msgstr "Pravljenje privremenog imena datoteke nije uspelo"
+
+#: ../src/common/filename.cpp:1081
+msgid "Failed to open temporary file."
+msgstr "Otvaranje privremene datoteke nije uspelo."
+
+#: ../src/common/filename.cpp:2862
+#, c-format
+msgid "Failed to modify file times for '%s'"
+msgstr "Izmena vremena  za datoteku '%s' nije uspela"
+
+#: ../src/common/filename.cpp:2877
+#, c-format
+msgid "Failed to touch the file '%s'"
+msgstr "Dodirivanje datoteke '%s' nije uspelo"
+
+#: ../src/common/filename.cpp:2958
+#, c-format
+msgid "Failed to retrieve file times for '%s'"
+msgstr "Preuzimanje vremena za datoteku '%s' nije uspelo"
+
+#: ../src/common/filepickercmn.cpp:39 ../src/common/filepickercmn.cpp:40
+msgid "Browse"
+msgstr "Potraži"
+
+#: ../src/common/fldlgcmn.cpp:792 ../src/generic/filectrlg.cpp:1185
+#, c-format
+msgid "All files (%s)|%s"
+msgstr "Sve datoteke (%s)|%s"
+
+#. TRANSLATORS: %s are a file extension used to build a file wildcard string
+#: ../src/common/fldlgcmn.cpp:810
+#, c-format
+msgid "%s files (%s)|%s"
+msgstr "%s datoteke (%s)|%s"
+
+#: ../src/common/fldlgcmn.cpp:1072
+#, c-format
+msgid "Load %s file"
+msgstr "Učitaj datoteku %s"
+
+#: ../src/common/fldlgcmn.cpp:1074
+#, c-format
+msgid "Save %s file"
+msgstr "Sačuvaj datoteku %s"
+
+#: ../src/common/fmapbase.cpp:144
+msgid "Western European (ISO-8859-1)"
+msgstr "Zapadnoevropski (ISO-8859-1)"
+
+#: ../src/common/fmapbase.cpp:145
+msgid "Central European (ISO-8859-2)"
+msgstr "Srednjoevropski (ISO-8859-2)"
+
+#: ../src/common/fmapbase.cpp:146
+msgid "Esperanto (ISO-8859-3)"
+msgstr "Esperanto (ISO-8859-3)"
+
+#: ../src/common/fmapbase.cpp:147
+msgid "Baltic (old) (ISO-8859-4)"
+msgstr "Baltički (stari ) (ISO-8859-4)"
+
+#: ../src/common/fmapbase.cpp:148
+msgid "Cyrillic (ISO-8859-5)"
+msgstr "Ćirilica (ISO-8859-5)"
+
+#: ../src/common/fmapbase.cpp:149
+msgid "Arabic (ISO-8859-6)"
+msgstr "Arapski (ISO-8859-6)"
+
+#: ../src/common/fmapbase.cpp:150
+msgid "Greek (ISO-8859-7)"
+msgstr "Grčki (ISO-8859-7)"
+
+#: ../src/common/fmapbase.cpp:151
+msgid "Hebrew (ISO-8859-8)"
+msgstr "Hebrejski (ISO-8859-8)"
+
+#: ../src/common/fmapbase.cpp:152
+msgid "Turkish (ISO-8859-9)"
+msgstr "Turski (ISO-8859-9)"
+
+#: ../src/common/fmapbase.cpp:153
+msgid "Nordic (ISO-8859-10)"
+msgstr "Nordijski (ISO-8859-10)"
+
+#: ../src/common/fmapbase.cpp:154
+msgid "Thai (ISO-8859-11)"
+msgstr "tajlandski (ISO-8859-11)"
+
+#: ../src/common/fmapbase.cpp:155
+msgid "Indian (ISO-8859-12)"
+msgstr "Indijski (ISO-8859-12)"
+
+#: ../src/common/fmapbase.cpp:156
+msgid "Baltic (ISO-8859-13)"
+msgstr "Baltički (ISO-8859-13)"
+
+#: ../src/common/fmapbase.cpp:157
+msgid "Celtic (ISO-8859-14)"
+msgstr "Keltski (ISO-8859-14)"
+
+#: ../src/common/fmapbase.cpp:158
+msgid "Western European with Euro (ISO-8859-15)"
+msgstr "Zapadnoevropski sa Evrom (ISO-8859-15)"
+
+#: ../src/common/fmapbase.cpp:159
+msgid "KOI8-R"
+msgstr "KOI8-R"
+
+#: ../src/common/fmapbase.cpp:160
+msgid "KOI8-U"
+msgstr "KOI8-U"
+
+#: ../src/common/fmapbase.cpp:161
+msgid "Windows/DOS OEM Cyrillic (CP 866)"
+msgstr "Windows/DOS OEM ćirilica (CP 866)"
+
+#: ../src/common/fmapbase.cpp:162
+msgid "Windows Thai (CP 874)"
+msgstr "Windows Tajlandski (CP 874)"
+
+#: ../src/common/fmapbase.cpp:163
+msgid "Windows Japanese (CP 932) or Shift-JIS"
+msgstr "Windows Japanski (CP 932) ili Shift-JIS"
+
+#: ../src/common/fmapbase.cpp:164
+msgid "Windows Chinese Simplified (CP 936) or GB-2312"
+msgstr "Windows Kineski pojednostavljeni (CP 936) ili GB-2312"
+
+#: ../src/common/fmapbase.cpp:165
+msgid "Windows Korean (CP 949)"
+msgstr "Windows Korejski (CP 949)"
+
+#: ../src/common/fmapbase.cpp:166
+msgid "Windows Chinese Traditional (CP 950) or Big-5"
+msgstr "Windows Kineski tradicionalni (CP 950) ili Big-5"
+
+#: ../src/common/fmapbase.cpp:167
+msgid "Windows Central European (CP 1250)"
+msgstr "Windows Srednjoevropski (CP 1250)"
+
+#: ../src/common/fmapbase.cpp:168
+msgid "Windows Cyrillic (CP 1251)"
+msgstr "Windows Ćirilica (CP 1251)"
+
+#: ../src/common/fmapbase.cpp:169
+msgid "Windows Western European (CP 1252)"
+msgstr "Windows zapadnoevropski (CP 1252)"
+
+#: ../src/common/fmapbase.cpp:170
+msgid "Windows Greek (CP 1253)"
+msgstr "Windows Grčki (CP 1253)"
+
+#: ../src/common/fmapbase.cpp:171
+msgid "Windows Turkish (CP 1254)"
+msgstr "Windows Turski (CP 1254)"
+
+#: ../src/common/fmapbase.cpp:172
+msgid "Windows Hebrew (CP 1255)"
+msgstr "Windows Hebrejski (CP 1255)"
+
+#: ../src/common/fmapbase.cpp:173
+msgid "Windows Arabic (CP 1256)"
+msgstr "Windows Arapski (CP 1256)"
+
+#: ../src/common/fmapbase.cpp:174
+msgid "Windows Baltic (CP 1257)"
+msgstr "Windows Baltički (CP 1257)"
+
+#: ../src/common/fmapbase.cpp:175
+msgid "Windows Vietnamese (CP 1258)"
+msgstr "Windows Vijetnamski (CP 1258)"
+
+#: ../src/common/fmapbase.cpp:176
+msgid "Windows Johab (CP 1361)"
+msgstr "Windows Johab (CP 1361)"
+
+#: ../src/common/fmapbase.cpp:177
+msgid "Windows/DOS OEM (CP 437)"
+msgstr "Windows/DOS OEM (CP 437)"
+
+#: ../src/common/fmapbase.cpp:178
+msgid "Unicode 7 bit (UTF-7)"
+msgstr "Unicode 7 bitni (UTF-7)"
+
+#: ../src/common/fmapbase.cpp:179
+msgid "Unicode 8 bit (UTF-8)"
+msgstr "Unicode 8 bitni (UTF-8)"
+
+#: ../src/common/fmapbase.cpp:181 ../src/common/fmapbase.cpp:187
+msgid "Unicode 16 bit (UTF-16)"
+msgstr "Unicode 16 bitni (UTF-16)"
+
+#: ../src/common/fmapbase.cpp:182
+msgid "Unicode 16 bit Little Endian (UTF-16LE)"
+msgstr "Unicode 16 bitni little Endian (UTF-16LE)"
+
+#: ../src/common/fmapbase.cpp:183 ../src/common/fmapbase.cpp:189
+msgid "Unicode 32 bit (UTF-32)"
+msgstr "Unicode 32 bitni (UTF-32)"
+
+#: ../src/common/fmapbase.cpp:184
+msgid "Unicode 32 bit Little Endian (UTF-32LE)"
+msgstr "Unicode 32 bitni little Endian (UTF-32LE)"
+
+#: ../src/common/fmapbase.cpp:186
+msgid "Unicode 16 bit Big Endian (UTF-16BE)"
+msgstr "Unicode 16 bitni big Endian (UTF-16BE)"
+
+#: ../src/common/fmapbase.cpp:188
+msgid "Unicode 32 bit Big Endian (UTF-32BE)"
+msgstr "Unicode 32 bitni big Endian (UTF-32BE)"
+
+#: ../src/common/fmapbase.cpp:191
+msgid "Extended Unix Codepage for Japanese (EUC-JP)"
+msgstr "Proširena Unix kodna stranica za Japanski (EUC-JP)"
+
+#: ../src/common/fmapbase.cpp:192
+msgid "US-ASCII"
+msgstr "Sjedinjene američke države -ASCII"
+
+#: ../src/common/fmapbase.cpp:193
+msgid "ISO-2022-JP"
+msgstr "ISO-2022-JP"
+
+#: ../src/common/fmapbase.cpp:195
+msgid "MacRoman"
+msgstr "MacRimski"
+
+#: ../src/common/fmapbase.cpp:196
+msgid "MacJapanese"
+msgstr "MacJapanski"
+
+#: ../src/common/fmapbase.cpp:197
+msgid "MacChineseTrad"
+msgstr "MacKineskiTrad"
+
+#: ../src/common/fmapbase.cpp:198
+msgid "MacKorean"
+msgstr "MacKorejski"
+
+#: ../src/common/fmapbase.cpp:199
+msgid "MacArabic"
+msgstr "MacArapski"
+
+#: ../src/common/fmapbase.cpp:200
+msgid "MacHebrew"
+msgstr "MacHebrejski"
+
+#: ../src/common/fmapbase.cpp:201
+msgid "MacGreek"
+msgstr "MacGrčki"
+
+#: ../src/common/fmapbase.cpp:202
+msgid "MacCyrillic"
+msgstr "MacĆirilica"
+
+#: ../src/common/fmapbase.cpp:203
+msgid "MacDevanagari"
+msgstr "MacDevanagari"
+
+#: ../src/common/fmapbase.cpp:204
+msgid "MacGurmukhi"
+msgstr "MacGurmukhi"
+
+#: ../src/common/fmapbase.cpp:205
+msgid "MacGujarati"
+msgstr "MacGudžarati"
+
+#: ../src/common/fmapbase.cpp:206
+msgid "MacOriya"
+msgstr "MacOriya"
+
+#: ../src/common/fmapbase.cpp:207
+msgid "MacBengali"
+msgstr "MacBengali"
+
+#: ../src/common/fmapbase.cpp:208
+msgid "MacTamil"
+msgstr "MacTamil"
+
+#: ../src/common/fmapbase.cpp:209
+msgid "MacTelugu"
+msgstr "MacTelugu"
+
+#: ../src/common/fmapbase.cpp:210
+msgid "MacKannada"
+msgstr "MacKannada"
+
+#: ../src/common/fmapbase.cpp:211
+msgid "MacMalayalam"
+msgstr "MacMalayalam"
+
+#: ../src/common/fmapbase.cpp:212
+msgid "MacSinhalese"
+msgstr "MacSinhalese"
+
+#: ../src/common/fmapbase.cpp:213
+msgid "MacBurmese"
+msgstr "MacBurmeški"
+
+#: ../src/common/fmapbase.cpp:214
+msgid "MacKhmer"
+msgstr "MacKhmer"
+
+#: ../src/common/fmapbase.cpp:215
+msgid "MacThai"
+msgstr "MacThai"
+
+#: ../src/common/fmapbase.cpp:216
+msgid "MacLaotian"
+msgstr "MacLaotian"
+
+#: ../src/common/fmapbase.cpp:217
+msgid "MacGeorgian"
+msgstr "MacGruzijski"
+
+#: ../src/common/fmapbase.cpp:218
+msgid "MacArmenian"
+msgstr "MacJermenski"
+
+#: ../src/common/fmapbase.cpp:219
+msgid "MacChineseSimp"
+msgstr "MacKineskiPojed"
+
+#: ../src/common/fmapbase.cpp:220
+msgid "MacTibetan"
+msgstr "MacTibetan"
+
+#: ../src/common/fmapbase.cpp:221
+msgid "MacMongolian"
+msgstr "MacMongolski"
+
+#: ../src/common/fmapbase.cpp:222
+msgid "MacEthiopic"
+msgstr "MacEtiopski"
+
+#: ../src/common/fmapbase.cpp:223
+msgid "MacCentralEurRoman"
+msgstr "MacCentralEurRimski"
+
+#: ../src/common/fmapbase.cpp:224
+msgid "MacVietnamese"
+msgstr "MacVijetnamski"
+
+#: ../src/common/fmapbase.cpp:225
+msgid "MacExtArabic"
+msgstr "MacProšireniArapski"
+
+#: ../src/common/fmapbase.cpp:226
+msgid "MacSymbol"
+msgstr "MacSimbol"
+
+#: ../src/common/fmapbase.cpp:227
+msgid "MacDingbats"
+msgstr "MacDingbats"
+
+#: ../src/common/fmapbase.cpp:228
+msgid "MacTurkish"
+msgstr "MacTurski"
+
+#: ../src/common/fmapbase.cpp:229
+msgid "MacCroatian"
+msgstr "MacHrvatski"
+
+#: ../src/common/fmapbase.cpp:230
+msgid "MacIcelandic"
+msgstr "MacIslandski"
+
+#: ../src/common/fmapbase.cpp:231
+msgid "MacRomanian"
+msgstr "MacRumunski"
+
+#: ../src/common/fmapbase.cpp:232
+msgid "MacCeltic"
+msgstr "MacKeltski"
+
+#: ../src/common/fmapbase.cpp:233
+msgid "MacGaelic"
+msgstr "MacGalski"
+
+#: ../src/common/fmapbase.cpp:234
+msgid "MacKeyboardGlyphs"
+msgstr "Mac grafike tastature"
+
+#: ../src/common/fmapbase.cpp:791
+msgid "Default encoding"
+msgstr "Podrazumevano kodiranje"
+
+#: ../src/common/fmapbase.cpp:805
+#, c-format
+msgid "Unknown encoding (%d)"
+msgstr "Nepoznato kodiranje (%d)"
+
+#: ../src/common/fmapbase.cpp:815 ../src/richtext/richtextstyles.cpp:776
+msgid "default"
+msgstr "Podrazumevano"
+
+#: ../src/common/fmapbase.cpp:829
+#, c-format
+msgid "unknown-%d"
+msgstr "Nepoznato -%d"
+
+#: ../src/common/fontcmn.cpp:924 ../src/common/fontcmn.cpp:1130
+msgid "underlined"
+msgstr "Podvučeno"
+
+#: ../src/common/fontcmn.cpp:929
+msgid " strikethrough"
+msgstr "Precrtano"
+
+#: ../src/common/fontcmn.cpp:942
+msgid " thin"
+msgstr "Tanko"
+
+#: ../src/common/fontcmn.cpp:946
+msgid " extra light"
+msgstr "Izuzetno svetlo"
+
+#: ../src/common/fontcmn.cpp:950
+msgid " light"
+msgstr "Svetlo"
+
+#: ../src/common/fontcmn.cpp:954
+msgid " medium"
+msgstr "Srednje"
+
+#: ../src/common/fontcmn.cpp:958
+msgid " semi bold"
+msgstr "Polu podebljano"
+
+#: ../src/common/fontcmn.cpp:962
+msgid " bold"
+msgstr "Podebljano"
+
+#: ../src/common/fontcmn.cpp:966
+msgid " extra bold"
+msgstr "Izuzetno podebljano"
+
+#: ../src/common/fontcmn.cpp:970
+msgid " heavy"
+msgstr "Masno"
+
+#: ../src/common/fontcmn.cpp:974
+msgid " extra heavy"
+msgstr "Izuzetno masno"
+
+#: ../src/common/fontcmn.cpp:990
+msgid " italic"
+msgstr "Iskošeno"
+
+#: ../src/common/fontcmn.cpp:1134
+msgid "strikethrough"
+msgstr "Precrtano"
+
+#: ../src/common/fontcmn.cpp:1143
+msgid "thin"
+msgstr "Tanko"
+
+#: ../src/common/fontcmn.cpp:1156
+msgid "extralight"
+msgstr "IzuzetnoSvetlo"
+
+#: ../src/common/fontcmn.cpp:1161
+msgid "light"
+msgstr "Svetlo"
+
+#: ../src/common/fontcmn.cpp:1169 ../src/richtext/richtextstyles.cpp:775
+msgid "normal"
+msgstr "Normalno"
+
+#: ../src/common/fontcmn.cpp:1174
+msgid "medium"
+msgstr "Srednje"
+
+#: ../src/common/fontcmn.cpp:1179 ../src/common/fontcmn.cpp:1199
+msgid "semibold"
+msgstr "PoluPodebljano"
+
+#: ../src/common/fontcmn.cpp:1184
+msgid "bold"
+msgstr "Podebljano"
+
+#: ../src/common/fontcmn.cpp:1194
+msgid "extrabold"
+msgstr "IzuzetnoPodebljano"
+
+#: ../src/common/fontcmn.cpp:1204
+msgid "heavy"
+msgstr "Masno"
+
+#: ../src/common/fontcmn.cpp:1212
+msgid "extraheavy"
+msgstr "IzuzetnoMasno"
+
+#: ../src/common/fontcmn.cpp:1217
+msgid "italic"
+msgstr "Iskošeno"
+
+#: ../src/common/fontmap.cpp:195
+msgid ": unknown charset"
+msgstr ": Nepoznat set karaktera"
+
+#: ../src/common/fontmap.cpp:199
+#, c-format
+msgid ""
+"The charset '%s' is unknown. You may select\n"
+"another charset to replace it with or choose\n"
+"[Cancel] if it cannot be replaced"
+msgstr ""
+"Set karaktera '%s' je nepoznat. Možete izabrati \n"
+"drugi set karaktera kako biste ga zamenili ili izabrati \n"
+"[Otkaži ] ako ne može biti zamenjen"
+
+#: ../src/common/fontmap.cpp:241
+#, c-format
+msgid "Failed to remember the encoding for the charset '%s'."
+msgstr "Kodiranje za set karaktera '%s' nije uspešno zapamćeno."
+
+#: ../src/common/fontmap.cpp:321
+msgid "can't load any font, aborting"
+msgstr "Nemoguće učitati font, obustavljanje"
+
+#: ../src/common/fontmap.cpp:409
+msgid ": unknown encoding"
+msgstr ": Nepoznato kodiranje"
+
+#: ../src/common/fontmap.cpp:417
+#, c-format
+msgid ""
+"No font for displaying text in encoding '%s' found,\n"
+"but an alternative encoding '%s' is available.\n"
+"Do you want to use this encoding (otherwise you will have to choose another "
+"one)?"
+msgstr ""
+"Font za prikazivanje teksta u kodiranju '%s' nije pronađen,\n"
+"ali alternativno kodiranje '%s' je dostupno.\n"
+"Da li želite da koristite ovo kodiranje( u suprotnom ćete morati da "
+"izaberete drugo )?"
+
+#: ../src/common/fontmap.cpp:422
+#, c-format
+msgid ""
+"No font for displaying text in encoding '%s' found.\n"
+"Would you like to select a font to be used for this encoding\n"
+"(otherwise the text in this encoding will not be shown correctly)?"
+msgstr ""
+"Font za prikazivanje teksta u  kodiranju '%s' nije pronađen.\n"
+"Da li želite da izaberete font koji će se koristiti za ovo kodiranje\n"
+"(u suprotnom se tekst u ovom kodiranju neće ispravno prikazivati )?"
+
+#: ../src/common/fs_mem.cpp:169
+#, c-format
+msgid "Memory VFS already contains file '%s'!"
+msgstr "VFS memorija već sadrži datoteku '%s'!"
+
+#: ../src/common/fs_mem.cpp:232
+#, c-format
+msgid "Trying to remove file '%s' from memory VFS, but it is not loaded!"
+msgstr "Pokušaj da se ukloni datoteka '%s' iz memorije VFS, ali nije učitana!"
+
+#: ../src/common/fs_mem.cpp:262
+#, c-format
+msgid "Failed to store image '%s' to memory VFS!"
+msgstr "Čuvanje slike '%s' u VFS memoriju nije uspelo!"
+
+#: ../src/common/ftp.cpp:197
+msgid "Timeout while waiting for FTP server to connect, try passive mode."
+msgstr ""
+"Vreme je isteklo u toku čekanja na FTP server da se poveže, pokušajte "
+"pasivni režim."
+
+#: ../src/common/ftp.cpp:399
+#, c-format
+msgid "Failed to set FTP transfer mode to %s."
+msgstr "Neuspešno podešavanje režima FTP transfera na %s."
+
+#: ../src/common/ftp.cpp:400 ../src/richtext/richtextsymboldlg.cpp:432
+msgid "ASCII"
+msgstr "ASCII"
+
+#: ../src/common/ftp.cpp:400
+msgid "binary"
+msgstr "Binarni"
+
+#: ../src/common/ftp.cpp:608
+msgid "The FTP server doesn't support the PORT command."
+msgstr "FTP server ne podržava komandu za port."
+
+#: ../src/common/ftp.cpp:622
+msgid "The FTP server doesn't support passive mode."
+msgstr "FTP server ne podržava pasivni režim."
+
+#: ../src/common/gifdecod.cpp:822
+#, c-format
+msgid "Incorrect GIF frame size (%u, %d) for the frame #%u"
+msgstr "Neispravna veličina okvira  GIF-a (%u, %d) za okvir #%u"
+
+#: ../src/common/glcmn.cpp:108
+msgid "Failed to allocate colour for OpenGL"
+msgstr "Dodeljivanje boje za OpenGL nije uspelo"
+
+#: ../src/common/headerctrlcmn.cpp:57
+msgid "Please select the columns to show and define their order:"
+msgstr ""
+"Molimo izaberite kolone koje će se prikazati i odredite njihov redosled:"
+
+#: ../src/common/headerctrlcmn.cpp:58
+msgid "Customize Columns"
+msgstr "Prilagodi kolone"
+
+#: ../src/common/headerctrlcmn.cpp:304
+msgid "&Customize..."
+msgstr "&Prilagodi..."
+
+#: ../src/common/hyperlnkcmn.cpp:132
+#, c-format
+msgid "Failed to open URL \"%s\" in the default browser"
+msgstr "Otvaranje adrese \"%s\" u podrazumevanom pretraživaču nije uspelo"
+
+#: ../src/common/iconbndl.cpp:195
+#, c-format
+msgid "Failed to load image %%d from file '%s'."
+msgstr "Neuspešno učitavanje slike %%d iz datoteke '%s'."
+
+#: ../src/common/iconbndl.cpp:203
+#, c-format
+msgid "Failed to load image %d from stream."
+msgstr "Neuspešno učitavanje slike %d iz strima."
+
+#: ../src/common/iconbndl.cpp:221
+#, c-format
+msgid "Failed to load icons from resource '%s'."
+msgstr "Neuspešno učitavanje ikona iz resursa '%s'."
+
+#: ../src/common/imagbmp.cpp:97
+msgid "BMP: Couldn't save invalid image."
+msgstr "BMP: Nemoguće sačuvati neispravnu sliku."
+
+#: ../src/common/imagbmp.cpp:137
+msgid "BMP: wxImage doesn't have own wxPalette."
+msgstr "BMP: wxImage nema svoj wxPalette."
+
+#: ../src/common/imagbmp.cpp:243
+msgid "BMP: Couldn't write the file (Bitmap) header."
+msgstr "BMP: Nemoguće pisanje zaglavlja datoteke (Bitmap)."
+
+#: ../src/common/imagbmp.cpp:266
+msgid "BMP: Couldn't write the file (BitmapInfo) header."
+msgstr "BMP: Nemoguće pisanje zaglavlja datoteke (BitmapInfo)."
+
+#: ../src/common/imagbmp.cpp:353
+msgid "BMP: Couldn't write RGB color map."
+msgstr "BMP: Nemoguće pisanje mape RGB boja"
+
+#: ../src/common/imagbmp.cpp:487
+msgid "BMP: Couldn't write data."
+msgstr "BMP: Nemoguće pisanje podataka."
+
+#: ../src/common/imagbmp.cpp:561 ../src/common/imagbmp.cpp:642
+msgid "BMP: Couldn't allocate memory."
+msgstr "BMP: Nemoguće dodeljivanje memorije."
+
+#: ../src/common/imagbmp.cpp:1041
+msgid "DIB Header: Image width > 32767 pixels for file."
+msgstr "DIB zaglavlje: širina slike> 32767 piksela za datoteku."
+
+#: ../src/common/imagbmp.cpp:1049
+msgid "DIB Header: Image height > 32767 pixels for file."
+msgstr "DIB zaglavlje: visina slike> 32767 piksela za datoteku."
+
+#: ../src/common/imagbmp.cpp:1081
+msgid "DIB Header: Unknown bitdepth in file."
+msgstr "DIB zaglavlje: Nepoznata bit-dubina u datoteci."
+
+#: ../src/common/imagbmp.cpp:1156
+msgid "DIB Header: Unknown encoding in file."
+msgstr "DIB zaglavlje: nepoznato kodiranje datoteke."
+
+#: ../src/common/imagbmp.cpp:1165
+msgid "DIB Header: Encoding doesn't match bitdepth."
+msgstr "DIB zaglavlje: kodiranje se ne podudara sa bit-dubinom."
+
+#: ../src/common/imagbmp.cpp:1180
+#, c-format
+msgid "BMP Header: Invalid number of colors (%d)."
+msgstr ""
+
+#: ../src/common/imagbmp.cpp:1273
+msgid "Error in reading image DIB."
+msgstr "Greška u čitanju DIB-a slike."
+
+#: ../src/common/imagbmp.cpp:1294
+msgid "ICO: Error in reading mask DIB."
+msgstr "ICO: greška u čitanju DIB maske."
+
+#: ../src/common/imagbmp.cpp:1353
+msgid "ICO: Image too tall for an icon."
+msgstr "ICO: slika previsoka za ikonicu."
+
+#: ../src/common/imagbmp.cpp:1361
+msgid "ICO: Image too wide for an icon."
+msgstr "ICO: slika preširoka za ikonicu."
+
+#: ../src/common/imagbmp.cpp:1388 ../src/common/imagbmp.cpp:1488
+#: ../src/common/imagbmp.cpp:1503 ../src/common/imagbmp.cpp:1514
+#: ../src/common/imagbmp.cpp:1528 ../src/common/imagbmp.cpp:1576
+#: ../src/common/imagbmp.cpp:1591 ../src/common/imagbmp.cpp:1605
+#: ../src/common/imagbmp.cpp:1616
+msgid "ICO: Error writing the image file!"
+msgstr "ICO: greška pri pisanju datoteke slike!"
+
+#: ../src/common/imagbmp.cpp:1701
+msgid "ICO: Invalid icon index."
+msgstr "ICO: neispravan indeks ikonice."
+
+#: ../src/common/image.cpp:2410
+msgid "Image and mask have different sizes."
+msgstr "Slika i maska imaju različite veličine."
+
+#: ../src/common/image.cpp:2418 ../src/common/image.cpp:2459
+msgid "No unused colour in image being masked."
+msgstr "Nema boje koja se ne koristi u slici koja se maskira."
+
+#: ../src/common/image.cpp:2641
+#, c-format
+msgid "Failed to load bitmap \"%s\" from resources."
+msgstr "Nemoguće učitati bitmap \"%s\" iz resursa."
+
+#: ../src/common/image.cpp:2650
+#, c-format
+msgid "Failed to load icon \"%s\" from resources."
+msgstr "Nemoguće učitati ikonicu \"%s\" iz resursa."
+
+#: ../src/common/image.cpp:2728 ../src/common/image.cpp:2747
+#, c-format
+msgid "Failed to load image from file \"%s\"."
+msgstr "Nemoguće učitati sliku iz datoteke \"%s\"."
+
+#: ../src/common/image.cpp:2761
+#, c-format
+msgid "Can't save image to file '%s': unknown extension."
+msgstr "Nemoguće sačuvati sliku u datoteku '%s': nepoznata ekstenzija."
+
+#: ../src/common/image.cpp:2869
+msgid "No handler found for image type."
+msgstr "Nije pronađen obrađivač za vrstu slike."
+
+#: ../src/common/image.cpp:2877 ../src/common/image.cpp:3000
+#: ../src/common/image.cpp:3066
+#, c-format
+msgid "No image handler for type %d defined."
+msgstr "Nije određen obrađivač za vrstu slika %d."
+
+#: ../src/common/image.cpp:2887
+#, c-format
+msgid "Image file is not of type %d."
+msgstr "Datoteka slike nije vrste %d."
+
+#: ../src/common/image.cpp:2970
+msgid "Can't automatically determine the image format for non-seekable input."
+msgstr ""
+"Nemoguće automatski odrediti format slike za unos koji nije moguće "
+"pretražiti."
+
+#: ../src/common/image.cpp:2988
+msgid "Unknown image data format."
+msgstr "Nepoznat format podataka slike."
+
+#: ../src/common/image.cpp:3009
+#, c-format
+msgid "This is not a %s."
+msgstr "Ovo nije %s."
+
+#: ../src/common/image.cpp:3032 ../src/common/image.cpp:3080
+#, c-format
+msgid "No image handler for type %s defined."
+msgstr "Obrađivač slike za vrstu %s nije određen."
+
+#: ../src/common/image.cpp:3041
+#, c-format
+msgid "Image is not of type %s."
+msgstr "Slika nije vrste %s."
+
+#: ../src/common/image.cpp:3509
+#, c-format
+msgid "Failed to check format of image file \"%s\"."
+msgstr "Neuspešna provera formata datoteke slike \"%s\"."
+
+#: ../src/common/imaggif.cpp:124
+msgid "GIF: error in GIF image format."
+msgstr "GIF: greška u GIF formatu slike."
+
+#: ../src/common/imaggif.cpp:129
+msgid "GIF: not enough memory."
+msgstr "GIF: nema dovoljno memorije."
+
+#: ../src/common/imaggif.cpp:134
+msgid "GIF: data stream seems to be truncated."
+msgstr "GIF: strim podataka izgleda prekinuto."
+
+#: ../src/common/imaggif.cpp:240
+msgid "Couldn't initialize GIF hash table."
+msgstr "Nemoguće inicializovati GIF heš tabelu."
+
+#: ../src/common/imagiff.cpp:739
+msgid "IFF: error in IFF image format."
+msgstr "IFF: greška u IFF formatu slike."
+
+#: ../src/common/imagiff.cpp:742
+msgid "IFF: not enough memory."
+msgstr "IFF: nema dovoljno memorije."
+
+#: ../src/common/imagiff.cpp:745
+msgid "IFF: unknown error!!!"
+msgstr "IFF: nepoznata greška!!!"
+
+#: ../src/common/imagiff.cpp:755
+msgid "IFF: data stream seems to be truncated."
+msgstr "IFF: strim podataka izgleda prekinuto."
+
+#: ../src/common/imagjpeg.cpp:258
+msgid "JPEG: Couldn't load - file is probably corrupted."
+msgstr "JPEG: nemoguće učitati - datoteka je verovatno oštećena."
+
+#: ../src/common/imagjpeg.cpp:437
+msgid "JPEG: Couldn't save image."
+msgstr "JPEG: nemoguće sačuvati sliku."
+
+#: ../src/common/imagpcx.cpp:439
+msgid "PCX: this is not a PCX file."
+msgstr "PCX: Ovo nije PCX datoteka."
+
+#: ../src/common/imagpcx.cpp:453
+msgid "PCX: image format unsupported"
+msgstr "PCX: format slike nije podržan"
+
+#: ../src/common/imagpcx.cpp:454 ../src/common/imagpcx.cpp:477
+msgid "PCX: couldn't allocate memory"
+msgstr "PCX: nemoguće dodeliti memoriju"
+
+#: ../src/common/imagpcx.cpp:455
+msgid "PCX: version number too low"
+msgstr "PCX: broj verzije je prenizak"
+
+#: ../src/common/imagpcx.cpp:456 ../src/common/imagpcx.cpp:478
+msgid "PCX: unknown error !!!"
+msgstr "PCX: nepoznata greška!!!"
+
+#: ../src/common/imagpcx.cpp:476
+msgid "PCX: invalid image"
+msgstr "PCX: neispravna slika"
+
+#: ../src/common/imagpng.cpp:385
+#, c-format
+msgid "Unknown PNG resolution unit %d"
+msgstr "Nepoznata jedinica PNG rezolucije %d"
+
+#: ../src/common/imagpng.cpp:439
+msgid "Couldn't load a PNG image - file is corrupted or not enough memory."
+msgstr ""
+"Nemoguće učitati PNG sliku - datoteka je oštećena ili nema dovoljno memorije."
+
+#: ../src/common/imagpng.cpp:513 ../src/common/imagpng.cpp:524
+#: ../src/common/imagpng.cpp:534
+msgid "Couldn't save PNG image."
+msgstr "Nemoguće sačuvati PNG sliku."
+
+#: ../src/common/imagpnm.cpp:71
+msgid "PNM: File format is not recognized."
+msgstr "PNM: format datoteke nije prepoznat."
+
+#: ../src/common/imagpnm.cpp:89
+msgid "PNM: Couldn't allocate memory."
+msgstr "PNM: nemoguće dodeliti memoriju."
+
+#: ../src/common/imagpnm.cpp:111 ../src/common/imagpnm.cpp:134
+#: ../src/common/imagpnm.cpp:156
+msgid "PNM: File seems truncated."
+msgstr "PNM: datoteka izgleda prekinuto."
+
+#: ../src/common/imagtiff.cpp:69
+#, c-format
+msgid " (in module \"%s\")"
+msgstr " (u modulu \"%s\")"
+
+#: ../src/common/imagtiff.cpp:304
+msgid "TIFF: Error loading image."
+msgstr "TIFF: greška pri učitavanju slike."
+
+#: ../src/common/imagtiff.cpp:314
+msgid "Invalid TIFF image index."
+msgstr "Neispravan TIFF indeks slike."
+
+#: ../src/common/imagtiff.cpp:358
+msgid "TIFF: Image size is abnormally big."
+msgstr "TIFF: slika je abnormalno velika."
+
+#: ../src/common/imagtiff.cpp:372 ../src/common/imagtiff.cpp:385
+#: ../src/common/imagtiff.cpp:769
+msgid "TIFF: Couldn't allocate memory."
+msgstr "TIFF: nemoguće dodeliti memoriju."
+
+#: ../src/common/imagtiff.cpp:471
+msgid "TIFF: Error reading image."
+msgstr "TIFF: greška pri čitanju slike."
+
+#: ../src/common/imagtiff.cpp:532
+#, c-format
+msgid "Unknown TIFF resolution unit %d ignored"
+msgstr "Nepoznata TIFF jedinica rezolucije %d je ignorisana"
+
+#: ../src/common/imagtiff.cpp:611
+msgid "TIFF: Error saving image."
+msgstr "TIFF: greška pri čuvanju slike."
+
+#: ../src/common/imagtiff.cpp:868
+msgid "TIFF: Error writing image."
+msgstr "TIFF: greška pri pisanju slike."
+
+#: ../src/common/imagtiff.cpp:881
+#, fuzzy
+msgid "TIFF: Error flushing data."
+msgstr "TIFF: greška pri čuvanju slike."
+
+#: ../src/common/imagwebp.cpp:56
+msgid "WebP: Invalid data (failed to get features)."
+msgstr ""
+
+#: ../src/common/imagwebp.cpp:65
+msgid "WebP: Allocating image memory failed."
+msgstr ""
+
+#: ../src/common/imagwebp.cpp:82
+msgid "WebP: Decoding RGBA image data failed."
+msgstr ""
+
+#: ../src/common/imagwebp.cpp:98
+msgid "WebP: Decoding RGB image data failed."
+msgstr ""
+
+#: ../src/common/imagwebp.cpp:113 ../src/common/imagwebp.cpp:201
+msgid "WebP: Allocating stream buffer failed."
+msgstr ""
+
+#: ../src/common/imagwebp.cpp:131
+#, fuzzy
+msgid "WebP: Failed to parse container data."
+msgstr "Postavljanje podataka privremene memorije nije uspelo."
+
+#: ../src/common/imagwebp.cpp:222
+#, fuzzy
+msgid "WebP: Error decoding animation."
+msgstr "Greška u čitanju opcija konfiguracije."
+
+#: ../src/common/imagwebp.cpp:240
+msgid "WebP: Error getting next animation frame."
+msgstr ""
+
+#: ../src/common/init.cpp:172
+#, c-format
+msgid ""
+"Command line argument %d couldn't be converted to Unicode and will be "
+"ignored."
+msgstr ""
+"Argument komandne linije %d nije mogao biti pretvoren u unikodni i biće "
+"ignorisan."
+
+#: ../src/common/init.cpp:344
+msgid "Initialization failed in post init, aborting."
+msgstr "Inicijalizacija nije uspela u post init, otkazivanje."
+
+#: ../src/common/intl.cpp:378
+#, c-format
+msgid "Cannot set locale to language \"%s\"."
+msgstr "Nemoguće podesiti lokalizaciju na jezik \"%s\"."
+
+#: ../src/common/log.cpp:232
+msgid "Error: "
+msgstr "Greška:"
+
+#: ../src/common/log.cpp:236
+msgid "Warning: "
+msgstr "Upozorenje:"
+
+#: ../src/common/log.cpp:284
+msgid "The previous message repeated once."
+msgstr "Prethodna poruka se jednom ponovila."
+
+#: ../src/common/log.cpp:291
+#, c-format
+msgid "The previous message repeated %u time."
+msgid_plural "The previous message repeated %u times."
+msgstr[0] "Prethodna poruka se ponovila %u put."
+msgstr[1] "Prethodna poruka se ponovila %u puta."
+msgstr[2] "Prethodna poruka se ponovila %u puta."
+
+#: ../src/common/log.cpp:319
+#, c-format
+msgid "Last repeated message (\"%s\", %u time) wasn't output"
+msgid_plural "Last repeated message (\"%s\", %u times) wasn't output"
+msgstr[0] "Poslednja ponovljena poruka (\"%s\", %u put ) nije prikazana"
+msgstr[1] "Poslednja ponovljena poruka (\"%s\", %u puta) nije prikazana"
+msgstr[2] "Poslednja ponovljena poruka (\"%s\", %u puta) nije prikazana"
+
+#: ../src/common/log.cpp:435
+#, c-format
+msgid " (error %ld: %s)"
+msgstr " (greška %ld: %s)"
+
+#: ../src/common/lzmastream.cpp:121
+msgid "Failed to allocate memory for LZMA decompression."
+msgstr "Neuspešno dodeljivanje memorije za LZMA dekompresovanje."
+
+#: ../src/common/lzmastream.cpp:125
+#, c-format
+msgid "Failed to initialize LZMA decompression: unexpected error %u."
+msgstr "Nemoguće inicializovati LZMA dekompresovanje: neočekivana greška %u."
+
+#: ../src/common/lzmastream.cpp:179
+msgid "input is not in XZ format"
+msgstr "Unos nije u XZ formatu"
+
+#: ../src/common/lzmastream.cpp:183
+msgid "input compressed using unknown XZ option"
+msgstr "Unos kompresovan korišćenjem nepoznate XZ opcije"
+
+#: ../src/common/lzmastream.cpp:188
+msgid "input is corrupted"
+msgstr "unos je oštećen"
+
+#: ../src/common/lzmastream.cpp:192
+msgid "unknown decompression error"
+msgstr "nepoznata greška dekompresovanja"
+
+#: ../src/common/lzmastream.cpp:196
+#, c-format
+msgid "LZMA decompression error: %s"
+msgstr "Greška LZMA dekompresovanja: %s"
+
+#: ../src/common/lzmastream.cpp:231
+msgid "Failed to allocate memory for LZMA compression."
+msgstr "Nemoguće dodeliti memoriju za LZMA kompresovanje."
+
+#: ../src/common/lzmastream.cpp:235
+#, c-format
+msgid "Failed to initialize LZMA compression: unexpected error %u."
+msgstr "Neuspešna inicijalizacija LZMA kompresovanja: neočekivana greška %u."
+
+#: ../src/common/lzmastream.cpp:267 ../src/common/lzmastream.cpp:342
+#: ../src/html/chm.cpp:336
+msgid "out of memory"
+msgstr "nema memorije"
+
+#: ../src/common/lzmastream.cpp:276 ../src/common/lzmastream.cpp:346
+msgid "unknown compression error"
+msgstr "nepoznata greška kompresovanja"
+
+#: ../src/common/lzmastream.cpp:280
+#, c-format
+msgid "LZMA compression error: %s"
+msgstr "Greška LZMA kompresovanja: %s"
+
+#: ../src/common/lzmastream.cpp:350
+#, c-format
+msgid "LZMA compression error when flushing output: %s"
+msgstr "Greška LZMA kompresovanja pri čišćenju izlaza: %s"
+
+#: ../src/common/mimecmn.cpp:167
+#, c-format
+msgid "Unmatched '{' in an entry for mime type %s."
+msgstr "Nema podudaranja za '{' u unosu za mime vrstu %s."
+
+#: ../src/common/module.cpp:76
+#, c-format
+msgid "Circular dependency involving module \"%s\" detected."
+msgstr "Otkrivena je Cirkularna zavisnost koja utiče na modul\"%s\"."
+
+#: ../src/common/module.cpp:128
+#, c-format
+msgid "Dependency \"%s\" of module \"%s\" doesn't exist."
+msgstr "Zavisnost \"%s\" modula \"%s\" ne postoji."
+
+#: ../src/common/module.cpp:137
+#, c-format
+msgid "Module \"%s\" initialization failed"
+msgstr "Neuspešna inicijalizacija modula \"%s\""
+
+#: ../src/common/msgout.cpp:96
+msgid "Message"
+msgstr "Poruka"
+
+#: ../src/common/paper.cpp:70
+msgid "Letter, 8 1/2 x 11 in"
+msgstr "Pismo, 8 1/2 x 11 in"
+
+#: ../src/common/paper.cpp:71
+msgid "Legal, 8 1/2 x 14 in"
+msgstr "Pravne, 8 1/2 x 14 in"
+
+#: ../src/common/paper.cpp:72
+msgid "A4 sheet, 210 x 297 mm"
+msgstr "A4 stranica, 210 x 297 mm"
+
+#: ../src/common/paper.cpp:73
+msgid "C sheet, 17 x 22 in"
+msgstr "C stranica, 17 x 22 in"
+
+#: ../src/common/paper.cpp:74
+msgid "D sheet, 22 x 34 in"
+msgstr "D stranica, 22 x 34 in"
+
+#: ../src/common/paper.cpp:75
+msgid "E sheet, 34 x 44 in"
+msgstr "E stranica, 34 x 44 in"
+
+#: ../src/common/paper.cpp:76
+msgid "Letter Small, 8 1/2 x 11 in"
+msgstr "Malo pismo, 8 1/2 x 11 in"
+
+#: ../src/common/paper.cpp:77
+msgid "Tabloid, 11 x 17 in"
+msgstr "Tabloid, 11 x 17 in"
+
+#: ../src/common/paper.cpp:78
+msgid "Ledger, 17 x 11 in"
+msgstr "Ledger, 17 x 11 in"
+
+#: ../src/common/paper.cpp:79
+msgid "Statement, 5 1/2 x 8 1/2 in"
+msgstr "Izjava, 5 1/2 x 8 1/2 in"
+
+#: ../src/common/paper.cpp:80
+msgid "Executive, 7 1/4 x 10 1/2 in"
+msgstr "Izvršno, 7 1/4 x 10 1/2 in"
+
+#: ../src/common/paper.cpp:81
+msgid "A3 sheet, 297 x 420 mm"
+msgstr "A3 stranica, 297 x 420 mm"
+
+#: ../src/common/paper.cpp:82
+msgid "A4 small sheet, 210 x 297 mm"
+msgstr "A4 mala stranica, 210 x 297 mm"
+
+#: ../src/common/paper.cpp:83
+msgid "A5 sheet, 148 x 210 mm"
+msgstr "A5 stranica, 148 x 210 mm"
+
+#: ../src/common/paper.cpp:84
+msgid "B4 sheet, 250 x 354 mm"
+msgstr "B4 stranica, 250 x 354 mm"
+
+#: ../src/common/paper.cpp:85
+msgid "B5 sheet, 182 x 257 millimeter"
+msgstr "B5 stranica, 182 x 257 milimetara"
+
+#: ../src/common/paper.cpp:86
+msgid "Folio, 8 1/2 x 13 in"
+msgstr "Folio, 8 1/2 x 13 in"
+
+#: ../src/common/paper.cpp:87
+msgid "Quarto, 215 x 275 mm"
+msgstr "Quarto, 215 x 275 mm"
+
+#: ../src/common/paper.cpp:88
+msgid "10 x 14 in"
+msgstr "10 x 14 in"
+
+#: ../src/common/paper.cpp:89
+msgid "11 x 17 in"
+msgstr "11 x 17 in"
+
+#: ../src/common/paper.cpp:90
+msgid "Note, 8 1/2 x 11 in"
+msgstr "Beleška, 8 1/2 x 11 in"
+
+#: ../src/common/paper.cpp:91
+msgid "#9 Envelope, 3 7/8 x 8 7/8 in"
+msgstr "#9 koverta, 3 7/8 x 8 7/8 in"
+
+#: ../src/common/paper.cpp:92
+msgid "#10 Envelope, 4 1/8 x 9 1/2 in"
+msgstr "#10 koverta, 4 1/8 x 9 1/2 in"
+
+#: ../src/common/paper.cpp:93
+msgid "#11 Envelope, 4 1/2 x 10 3/8 in"
+msgstr "#11 koverta, 4 1/2 x 10 3/8 in"
+
+#: ../src/common/paper.cpp:94
+msgid "#12 Envelope, 4 3/4 x 11 in"
+msgstr "#12 koverta, 4 3/4 x 11 in"
+
+#: ../src/common/paper.cpp:95
+msgid "#14 Envelope, 5 x 11 1/2 in"
+msgstr "#14 koverta, 5 x 11 1/2 in"
+
+#: ../src/common/paper.cpp:96
+msgid "DL Envelope, 110 x 220 mm"
+msgstr "DL koverta, 110 x 220 mm"
+
+#: ../src/common/paper.cpp:97
+msgid "C5 Envelope, 162 x 229 mm"
+msgstr "C5 koverta, 162 x 229 mm"
+
+#: ../src/common/paper.cpp:98
+msgid "C3 Envelope, 324 x 458 mm"
+msgstr "C3 koverta, 324 x 458 mm"
+
+#: ../src/common/paper.cpp:99
+msgid "C4 Envelope, 229 x 324 mm"
+msgstr "C4 koverta, 229 x 324 mm"
+
+#: ../src/common/paper.cpp:100
+msgid "C6 Envelope, 114 x 162 mm"
+msgstr "C6 koverta, 114 x 162 mm"
+
+#: ../src/common/paper.cpp:101
+msgid "C65 Envelope, 114 x 229 mm"
+msgstr "C65 koverta, 114 x 229 mm"
+
+#: ../src/common/paper.cpp:102
+msgid "B4 Envelope, 250 x 353 mm"
+msgstr "B4 koverta, 250 x 353 mm"
+
+#: ../src/common/paper.cpp:103
+msgid "B5 Envelope, 176 x 250 mm"
+msgstr "B5 koverta, 176 x 250 mm"
+
+#: ../src/common/paper.cpp:104
+msgid "B6 Envelope, 176 x 125 mm"
+msgstr "B6 koverta, 176 x 125 mm"
+
+#: ../src/common/paper.cpp:105
+msgid "Italy Envelope, 110 x 230 mm"
+msgstr "Italijanska koverta, 110 x 230 mm"
+
+#: ../src/common/paper.cpp:106
+msgid "Monarch Envelope, 3 7/8 x 7 1/2 in"
+msgstr "Monarch koverta, 3 7/8 x 7 1/2 in"
+
+#: ../src/common/paper.cpp:107
+msgid "6 3/4 Envelope, 3 5/8 x 6 1/2 in"
+msgstr "6 3/4 koverta, 3 5/8 x 6 1/2 in"
+
+#: ../src/common/paper.cpp:108
+msgid "US Std Fanfold, 14 7/8 x 11 in"
+msgstr "US Std presavijen, 14 7/8 x 11 in"
+
+#: ../src/common/paper.cpp:109
+msgid "German Std Fanfold, 8 1/2 x 12 in"
+msgstr "Nemački Std presavijen, 8 1/2 x 12 in"
+
+#: ../src/common/paper.cpp:110
+msgid "German Legal Fanfold, 8 1/2 x 13 in"
+msgstr "Nemački pravni presavijen, 8 1/2 x 13 in"
+
+#: ../src/common/paper.cpp:112
+msgid "B4 (ISO) 250 x 353 mm"
+msgstr "B4 (ISO) 250 x 353 mm"
+
+#: ../src/common/paper.cpp:113
+msgid "Japanese Postcard 100 x 148 mm"
+msgstr "Japanska razglednica 100 x 148 mm"
+
+#: ../src/common/paper.cpp:114
+msgid "9 x 11 in"
+msgstr "9 x 11 in"
+
+#: ../src/common/paper.cpp:115
+msgid "10 x 11 in"
+msgstr "10 x 11 in"
+
+#: ../src/common/paper.cpp:116
+msgid "15 x 11 in"
+msgstr "15 x 11 in"
+
+#: ../src/common/paper.cpp:117
+msgid "Envelope Invite 220 x 220 mm"
+msgstr "Koverta pozivnice 220 x 220 mm"
+
+#: ../src/common/paper.cpp:118
+msgid "Letter Extra 9 1/2 x 12 in"
+msgstr "Pismo Ekstra 9 1/2 x 12 in"
+
+#: ../src/common/paper.cpp:119
+msgid "Legal Extra 9 1/2 x 15 in"
+msgstr "Pravni ekstra 9 1/2 x 15 in"
+
+#: ../src/common/paper.cpp:120
+msgid "Tabloid Extra 11.69 x 18 in"
+msgstr "Tabloid Ekstra 11.69 x 18 in"
+
+#: ../src/common/paper.cpp:121
+msgid "A4 Extra 9.27 x 12.69 in"
+msgstr "A4 Ekstra 9.27 x 12.69 in"
+
+#: ../src/common/paper.cpp:122
+msgid "Letter Transverse 8 1/2 x 11 in"
+msgstr "Pismo transverse 8 1/2 x 11 in"
+
+#: ../src/common/paper.cpp:123
+msgid "A4 Transverse 210 x 297 mm"
+msgstr "A4 Transverse 210 x 297 mm"
+
+#: ../src/common/paper.cpp:124
+msgid "Letter Extra Transverse 9.275 x 12 in"
+msgstr "Pismo ekstra Transverse 9.275 x 12 in"
+
+#: ../src/common/paper.cpp:125
+msgid "SuperA/SuperA/A4 227 x 356 mm"
+msgstr "SuperA/SuperA/A4 227 x 356 mm"
+
+#: ../src/common/paper.cpp:126
+msgid "SuperB/SuperB/A3 305 x 487 mm"
+msgstr "SuperB/SuperB/A3 305 x 487 mm"
+
+#: ../src/common/paper.cpp:127
+msgid "Letter Plus 8 1/2 x 12.69 in"
+msgstr "Pismo Plus 8 1/2 x 12.69 in"
+
+#: ../src/common/paper.cpp:128
+msgid "A4 Plus 210 x 330 mm"
+msgstr "A4 Plus 210 x 330 mm"
+
+#: ../src/common/paper.cpp:129
+msgid "A5 Transverse 148 x 210 mm"
+msgstr "A5 Transverse 148 x 210 mm"
+
+#: ../src/common/paper.cpp:130
+msgid "B5 (JIS) Transverse 182 x 257 mm"
+msgstr "B5 (JIS) Transverse 182 x 257 mm"
+
+#: ../src/common/paper.cpp:131
+msgid "A3 Extra 322 x 445 mm"
+msgstr "A3 Ekstra 322 x 445 mm"
+
+#: ../src/common/paper.cpp:132
+msgid "A5 Extra 174 x 235 mm"
+msgstr "A5 Ekstra 174 x 235 mm"
+
+#: ../src/common/paper.cpp:133
+msgid "B5 (ISO) Extra 201 x 276 mm"
+msgstr "B5 (ISO) Ekstra 201 x 276 mm"
+
+#: ../src/common/paper.cpp:134
+msgid "A2 420 x 594 mm"
+msgstr "A2 420 x 594 mm"
+
+#: ../src/common/paper.cpp:135
+msgid "A3 Transverse 297 x 420 mm"
+msgstr "A3 Transverse 297 x 420 mm"
+
+#: ../src/common/paper.cpp:136
+msgid "A3 Extra Transverse 322 x 445 mm"
+msgstr "A3 Ekstra Transverse 322 x 445 mm"
+
+#: ../src/common/paper.cpp:138
+msgid "Japanese Double Postcard 200 x 148 mm"
+msgstr "Japanska dupla razglednica 200 x 148 mm"
+
+#: ../src/common/paper.cpp:139
+msgid "A6 105 x 148 mm"
+msgstr "A6 105 x 148 mm"
+
+#: ../src/common/paper.cpp:140
+msgid "Japanese Envelope Kaku #2"
+msgstr "Japanska koverta Kaku #2"
+
+#: ../src/common/paper.cpp:141
+msgid "Japanese Envelope Kaku #3"
+msgstr "Japanska koverta Kaku #3"
+
+#: ../src/common/paper.cpp:142
+msgid "Japanese Envelope Chou #3"
+msgstr "Japanska koverta Chou #3"
+
+#: ../src/common/paper.cpp:143
+msgid "Japanese Envelope Chou #4"
+msgstr "Japanska koverta Chou #4"
+
+#: ../src/common/paper.cpp:144
+msgid "Letter Rotated 11 x 8 1/2 in"
+msgstr "Pismo rotirano 11 x 8 1/2 in"
+
+#: ../src/common/paper.cpp:145
+msgid "A3 Rotated 420 x 297 mm"
+msgstr "A3 rotirana 420 x 297 mm"
+
+#: ../src/common/paper.cpp:146
+msgid "A4 Rotated 297 x 210 mm"
+msgstr "A4 rotirana 297 x 210 mm"
+
+#: ../src/common/paper.cpp:147
+msgid "A5 Rotated 210 x 148 mm"
+msgstr "A5 rotirana 210 x 148 mm"
+
+#: ../src/common/paper.cpp:148
+msgid "B4 (JIS) Rotated 364 x 257 mm"
+msgstr "B4 (JIS) rotirana 364 x 257 mm"
+
+#: ../src/common/paper.cpp:149
+msgid "B5 (JIS) Rotated 257 x 182 mm"
+msgstr "B5 (JIS) rotirana 257 x 182 mm"
+
+#: ../src/common/paper.cpp:150
+msgid "Japanese Postcard Rotated 148 x 100 mm"
+msgstr "Japanska razglednica rotirana 148 x 100 mm"
+
+#: ../src/common/paper.cpp:151
+msgid "Double Japanese Postcard Rotated 148 x 200 mm"
+msgstr "Dupla Japanska razglednica rotirana 148 x 200 mm"
+
+#: ../src/common/paper.cpp:152
+msgid "A6 Rotated 148 x 105 mm"
+msgstr "A6 rotirana 148 x 105 mm"
+
+#: ../src/common/paper.cpp:153
+msgid "Japanese Envelope Kaku #2 Rotated"
+msgstr "Japanska koverta Kaku #2 rotirana "
+
+#: ../src/common/paper.cpp:154
+msgid "Japanese Envelope Kaku #3 Rotated"
+msgstr "Japanska koverta Kaku #3 rotirana"
+
+#: ../src/common/paper.cpp:155
+msgid "Japanese Envelope Chou #3 Rotated"
+msgstr "Japanska koverta Chou #3 rotirana"
+
+#: ../src/common/paper.cpp:156
+msgid "Japanese Envelope Chou #4 Rotated"
+msgstr "Japanska koverta Chou #4 rotirana"
+
+#: ../src/common/paper.cpp:157
+msgid "B6 (JIS) 128 x 182 mm"
+msgstr "B6 (JIS) 128 x 182 mm"
+
+#: ../src/common/paper.cpp:158
+msgid "B6 (JIS) Rotated 182 x 128 mm"
+msgstr "B6 (JIS) rotirana 182 x 128 mm"
+
+#: ../src/common/paper.cpp:159
+msgid "12 x 11 in"
+msgstr "12 x 11 in"
+
+#: ../src/common/paper.cpp:160
+msgid "Japanese Envelope You #4"
+msgstr "Japanska koverta You #4"
+
+#: ../src/common/paper.cpp:161
+msgid "Japanese Envelope You #4 Rotated"
+msgstr "Japanska koverta You #4 rotirana"
+
+#: ../src/common/paper.cpp:162
+msgid "PRC 16K 146 x 215 mm"
+msgstr "PRC 16K 146 x 215 mm"
+
+#: ../src/common/paper.cpp:163
+msgid "PRC 32K 97 x 151 mm"
+msgstr "PRC 32K 97 x 151 mm"
+
+#: ../src/common/paper.cpp:164
+msgid "PRC 32K(Big) 97 x 151 mm"
+msgstr "PRC 32K(Big) 97 x 151 mm"
+
+#: ../src/common/paper.cpp:165
+msgid "PRC Envelope #1 102 x 165 mm"
+msgstr "PRC koverta #1 102 x 165 mm"
+
+#: ../src/common/paper.cpp:166
+msgid "PRC Envelope #2 102 x 176 mm"
+msgstr "PRC koverta #2 102 x 176 mm"
+
+#: ../src/common/paper.cpp:167
+msgid "PRC Envelope #3 125 x 176 mm"
+msgstr "PRC koverta #3 125 x 176 mm"
+
+#: ../src/common/paper.cpp:168
+msgid "PRC Envelope #4 110 x 208 mm"
+msgstr "PRC koverta #4 110 x 208 mm"
+
+#: ../src/common/paper.cpp:169
+msgid "PRC Envelope #5 110 x 220 mm"
+msgstr "PRC koverta #5 110 x 220 mm"
+
+#: ../src/common/paper.cpp:170
+msgid "PRC Envelope #6 120 x 230 mm"
+msgstr "PRC koverta #6 120 x 230 mm"
+
+#: ../src/common/paper.cpp:171
+msgid "PRC Envelope #7 160 x 230 mm"
+msgstr "PRC koverta #7 160 x 230 mm"
+
+#: ../src/common/paper.cpp:172
+msgid "PRC Envelope #8 120 x 309 mm"
+msgstr "PRC koverta #8 120 x 309 mm"
+
+#: ../src/common/paper.cpp:173
+msgid "PRC Envelope #9 229 x 324 mm"
+msgstr "PRC koverta #9 229 x 324 mm"
+
+#: ../src/common/paper.cpp:174
+msgid "PRC Envelope #10 324 x 458 mm"
+msgstr "PRC koverta #10 324 x 458 mm"
+
+#: ../src/common/paper.cpp:175
+msgid "PRC 16K Rotated"
+msgstr "PRC 16K rotirana"
+
+#: ../src/common/paper.cpp:176
+msgid "PRC 32K Rotated"
+msgstr "PRC 32K rotirana"
+
+#: ../src/common/paper.cpp:177
+msgid "PRC 32K(Big) Rotated"
+msgstr "PRC 32K(Big) rotirana"
+
+#: ../src/common/paper.cpp:178
+msgid "PRC Envelope #1 Rotated 165 x 102 mm"
+msgstr "PRC koverta #1 rotirana 165 x 102 mm"
+
+#: ../src/common/paper.cpp:179
+msgid "PRC Envelope #2 Rotated 176 x 102 mm"
+msgstr "PRC koverta #2 rotirana 176 x 102 mm"
+
+#: ../src/common/paper.cpp:180
+msgid "PRC Envelope #3 Rotated 176 x 125 mm"
+msgstr "PRC koverta #3 rotirana 176 x 125 mm"
+
+#: ../src/common/paper.cpp:181
+msgid "PRC Envelope #4 Rotated 208 x 110 mm"
+msgstr "PRC koverta #4 rotirana 208 x 110 mm"
+
+#: ../src/common/paper.cpp:182
+msgid "PRC Envelope #5 Rotated 220 x 110 mm"
+msgstr "PRC koverta #5 rotirana 220 x 110 mm"
+
+#: ../src/common/paper.cpp:183
+msgid "PRC Envelope #6 Rotated 230 x 120 mm"
+msgstr "PRC koverta #6 rotirana 230 x 120 mm"
+
+#: ../src/common/paper.cpp:184
+msgid "PRC Envelope #7 Rotated 230 x 160 mm"
+msgstr "PRC koverta #7 rotirana 230 x 160 mm"
+
+#: ../src/common/paper.cpp:185
+msgid "PRC Envelope #8 Rotated 309 x 120 mm"
+msgstr "PRC koverta #8 rotirana 309 x 120 mm"
+
+#: ../src/common/paper.cpp:186
+msgid "PRC Envelope #9 Rotated 324 x 229 mm"
+msgstr "PRC koverta #9 rotirana 324 x 229 mm"
+
+#: ../src/common/paper.cpp:187
+msgid "PRC Envelope #10 Rotated 458 x 324 mm"
+msgstr "PRC koverta #10 rotirana 458 x 324 mm"
+
+#: ../src/common/paper.cpp:192
+msgid "A0 sheet, 841 x 1189 mm"
+msgstr "A0 stranica, 841 x 1189 mm"
+
+#: ../src/common/paper.cpp:193
+msgid "A1 sheet, 594 x 841 mm"
+msgstr "A1 stranica, 594 x 841 mm"
+
+#: ../src/common/preferencescmn.cpp:37
+msgid "General"
+msgstr "Opšti"
+
+#: ../src/common/preferencescmn.cpp:40
+msgid "Advanced"
+msgstr "Napredni"
+
+#: ../src/common/prntbase.cpp:245
+msgid "Generic PostScript"
+msgstr "Običan PostScript"
+
+#: ../src/common/prntbase.cpp:259
+msgid "Ready"
+msgstr "Spremno"
+
+#: ../src/common/prntbase.cpp:331
+msgid "Printing Error"
+msgstr "Greška pri štampanju"
+
+#: ../src/common/prntbase.cpp:413 ../src/common/prntbase.cpp:1597
+#: ../src/generic/prntdlgg.cpp:135 ../src/generic/prntdlgg.cpp:149
+#: ../src/gtk/print.cpp:628 ../src/gtk/print.cpp:646
+msgid "Print"
+msgstr "Štampaj"
+
+#: ../src/common/prntbase.cpp:471 ../src/generic/prntdlgg.cpp:809
+msgid "Page setup"
+msgstr "Podešavanje stranice"
+
+#: ../src/common/prntbase.cpp:525
+msgid "Please wait while printing..."
+msgstr "Molimo sačekajte dok je štampanje u toku..."
+
+#: ../src/common/prntbase.cpp:529
+msgid "Document:"
+msgstr "Dokument:"
+
+#: ../src/common/prntbase.cpp:532
+msgid "Progress:"
+msgstr "Napredak:"
+
+#: ../src/common/prntbase.cpp:533
+msgid "Preparing"
+msgstr "Priprema"
+
+#: ../src/common/prntbase.cpp:552
+#, c-format
+msgid "Printing page %d"
+msgstr "Štampanje stranice %d"
+
+#: ../src/common/prntbase.cpp:557
+#, c-format
+msgid "Printing page %d of %d"
+msgstr "Štampanje stranice %d od %d"
+
+#: ../src/common/prntbase.cpp:560
+#, c-format
+msgid " (copy %d of %d)"
+msgstr " (kopija %d od %d)"
+
+#: ../src/common/prntbase.cpp:1604
+msgid "First page"
+msgstr "Prva stranica"
+
+#: ../src/common/prntbase.cpp:1609 ../src/html/helpwnd.cpp:659
+msgid "Previous page"
+msgstr "Prethodna stranica"
+
+#: ../src/common/prntbase.cpp:1623 ../src/html/helpwnd.cpp:660
+msgid "Next page"
+msgstr "Sledeća stranica"
+
+#: ../src/common/prntbase.cpp:1628
+msgid "Last page"
+msgstr "Poslednja stranica"
+
+#: ../src/common/prntbase.cpp:1636 ../src/common/stockitem.cpp:215
+msgid "Zoom Out"
+msgstr "Umanji"
+
+#: ../src/common/prntbase.cpp:1650 ../src/common/stockitem.cpp:214
+msgid "Zoom In"
+msgstr "Uvećaj"
+
+#: ../src/common/prntbase.cpp:1656 ../src/common/stockitem.cpp:153
+#: ../src/generic/logg.cpp:553 ../src/univ/themes/win32.cpp:3752
+msgid "&Close"
+msgstr "&Zatvori"
+
+#: ../src/common/prntbase.cpp:2085
+msgid "Could not start document preview."
+msgstr "Nemoguće pokrenuti pregled dokumenta."
+
+#: ../src/common/prntbase.cpp:2085 ../src/common/prntbase.cpp:2129
+#: ../src/common/prntbase.cpp:2137
+msgid "Print Preview Failure"
+msgstr "Greška pri pregledu štampanja"
+
+#: ../src/common/prntbase.cpp:2129 ../src/common/prntbase.cpp:2137
+msgid "Sorry, not enough memory to create a preview."
+msgstr "Žao nam je, nema dovoljno memorije kako bi se napravio pregled."
+
+#: ../src/common/prntbase.cpp:2144
+#, c-format
+msgid "Page %d of %d"
+msgstr "Stranica %d od %d"
+
+#: ../src/common/prntbase.cpp:2146
+#, c-format
+msgid "Page %d"
+msgstr "Stranica %d"
+
+#: ../src/common/regex.cpp:382 ../src/html/chm.cpp:348
+msgid "unknown error"
+msgstr "Nepoznata greška"
+
+#: ../src/common/regex.cpp:995
+#, c-format
+msgid "Invalid regular expression '%s': %s"
+msgstr "Neispravan regularan izraz '%s': %s"
+
+#: ../src/common/regex.cpp:1059
+#, c-format
+msgid "Failed to find match for regular expression: %s"
+msgstr "Neuspešno pronalaženje podudaranja za regularni izraz: %s"
+
+#: ../src/common/rendcmn.cpp:188
+#, c-format
+msgid "Renderer \"%s\" has incompatible version %d.%d and couldn't be loaded."
+msgstr ""
+"Renderer \"%s\" ima nekompatibilnu verziju %d.%d i nije mogao biti učitan."
+
+#: ../src/common/secretstore.cpp:162
+msgid "Not available for this platform"
+msgstr "Nije dostupno za ovu platformu"
+
+#: ../src/common/secretstore.cpp:183
+#, c-format
+msgid "Saving password for \"%s\" failed: %s."
+msgstr "Čuvanje lozinke za \"%s\" nije uspelo: %s."
+
+#: ../src/common/secretstore.cpp:205
+#, c-format
+msgid "Reading password for \"%s\" failed: %s."
+msgstr "Čitanje lozinke za \"%s\" nije uspelo: %s."
+
+#: ../src/common/secretstore.cpp:228
+#, c-format
+msgid "Deleting password for \"%s\" failed: %s."
+msgstr "Brisanje lozinke za \"%s\" nije uspelo: %s."
+
+#: ../src/common/selectdispatcher.cpp:254
+msgid "Failed to monitor I/O channels"
+msgstr "Nemoguće posmatrati I/O kanale"
+
+#: ../src/common/sizer.cpp:3054 ../src/common/stockitem.cpp:195
+msgid "Save"
+msgstr "Sačuvaj"
+
+#: ../src/common/sizer.cpp:3056
+msgid "Don't Save"
+msgstr "Nemoj da sačuvaš"
+
+#: ../src/common/socket.cpp:870
+msgid "Cannot initialize sockets"
+msgstr "Nemoguće inicijalizovati priključke"
+
+#: ../src/common/stockitem.cpp:127
+msgctxt "standard Windows menu"
+msgid "&Help"
+msgstr "&Pomoć"
+
+#: ../src/common/stockitem.cpp:144
+msgid "&About"
+msgstr "&O"
+
+#: ../src/common/stockitem.cpp:144
+msgid "About"
+msgstr "O"
+
+#: ../src/common/stockitem.cpp:145
+msgid "Add"
+msgstr "Dodaj"
+
+#: ../src/common/stockitem.cpp:146
+msgid "&Apply"
+msgstr "&Primeni"
+
+#: ../src/common/stockitem.cpp:146
+msgid "Apply"
+msgstr "Primeni"
+
+#: ../src/common/stockitem.cpp:147
+msgid "&Back"
+msgstr "&Nazad"
+
+#: ../src/common/stockitem.cpp:147
+msgid "Back"
+msgstr "Nazad"
+
+#: ../src/common/stockitem.cpp:148
+msgid "&Bold"
+msgstr "&Podebljano"
+
+#: ../src/common/stockitem.cpp:148 ../src/generic/fontdlgg.cpp:326
+#: ../src/richtext/richtextfontpage.cpp:354
+msgid "Bold"
+msgstr "Podebljano"
+
+#: ../src/common/stockitem.cpp:149
+msgid "&Bottom"
+msgstr "&Dno"
+
+#: ../src/common/stockitem.cpp:149 ../src/richtext/richtextsizepage.cpp:287
+msgid "Bottom"
+msgstr "Dno"
+
+#: ../src/common/stockitem.cpp:150 ../src/generic/fontdlgg.cpp:462
+#: ../src/generic/fontdlgg.cpp:481 ../src/generic/wizard.cpp:415
+msgid "&Cancel"
+msgstr "&Otkaži"
+
+#: ../src/common/stockitem.cpp:151
+msgid "&CD-ROM"
+msgstr "&CD-ROM"
+
+#: ../src/common/stockitem.cpp:151
+msgid "CD-ROM"
+msgstr "CD-ROM"
+
+#: ../src/common/stockitem.cpp:152
+msgid "&Clear"
+msgstr "&Očisti"
+
+#: ../src/common/stockitem.cpp:152
+msgid "Clear"
+msgstr "Očisti"
+
+#: ../src/common/stockitem.cpp:153 ../src/generic/dbgrptg.cpp:93
+#: ../src/generic/progdlgg.cpp:778 ../src/html/helpdlg.cpp:86
+#: ../src/msw/progdlg.cpp:209 ../src/msw/progdlg.cpp:890
+#: ../src/richtext/richtextstyledlg.cpp:272
+#: ../src/richtext/richtextsymboldlg.cpp:448
+msgid "Close"
+msgstr "Zatvori"
+
+#: ../src/common/stockitem.cpp:154
+msgid "&Convert"
+msgstr "&Pretvori"
+
+#: ../src/common/stockitem.cpp:154
+msgid "Convert"
+msgstr "Pretvori"
+
+#: ../src/common/stockitem.cpp:155 ../src/msw/textctrl.cpp:2884
+#: ../src/osx/textctrl_osx.cpp:653 ../src/richtext/richtextctrl.cpp:331
+msgid "&Copy"
+msgstr "&Kopiraj"
+
+#: ../src/common/stockitem.cpp:155 ../src/stc/stc_i18n.cpp:18
+msgid "Copy"
+msgstr "Kopiraj"
+
+#: ../src/common/stockitem.cpp:156 ../src/msw/textctrl.cpp:2883
+#: ../src/osx/textctrl_osx.cpp:652 ../src/richtext/richtextctrl.cpp:330
+msgid "Cu&t"
+msgstr "&Iseci"
+
+#: ../src/common/stockitem.cpp:156 ../src/stc/stc_i18n.cpp:17
+msgid "Cut"
+msgstr "Iseci"
+
+#: ../src/common/stockitem.cpp:157 ../src/msw/textctrl.cpp:2886
+#: ../src/osx/textctrl_osx.cpp:655 ../src/richtext/richtextctrl.cpp:333
+#: ../src/richtext/richtexttabspage.cpp:137
+msgid "&Delete"
+msgstr "&Obriši"
+
+#: ../src/common/stockitem.cpp:157 ../src/richtext/richtextbuffer.cpp:8266
+#: ../src/stc/stc_i18n.cpp:20
+msgid "Delete"
+msgstr "Obriši"
+
+#: ../src/common/stockitem.cpp:158
+msgid "&Down"
+msgstr "&Dole"
+
+#: ../src/common/stockitem.cpp:158 ../src/generic/fdrepdlg.cpp:148
+msgid "Down"
+msgstr "Dole"
+
+#: ../src/common/stockitem.cpp:159
+msgid "&Edit"
+msgstr "&Uredi"
+
+#: ../src/common/stockitem.cpp:159
+msgid "Edit"
+msgstr "Uredi"
+
+#: ../src/common/stockitem.cpp:160
+msgid "&Execute"
+msgstr "&Pokreni"
+
+#: ../src/common/stockitem.cpp:160
+msgid "Execute"
+msgstr "Pokreni"
+
+#: ../src/common/stockitem.cpp:161
+msgid "&Quit"
+msgstr "&Zatvori"
+
+#: ../src/common/stockitem.cpp:161
+msgid "Quit"
+msgstr "Zatvori"
+
+#: ../src/common/stockitem.cpp:162
+msgid "&File"
+msgstr "&Datoteka"
+
+#: ../src/common/stockitem.cpp:162
+msgid "File"
+msgstr "Datoteka"
+
+#: ../src/common/stockitem.cpp:163
+msgid "&Find..."
+msgstr "&Pronađi..."
+
+#: ../src/common/stockitem.cpp:163
+msgid "Find..."
+msgstr "Pronađi..."
+
+#: ../src/common/stockitem.cpp:164
+msgid "&First"
+msgstr "&Prvo"
+
+#: ../src/common/stockitem.cpp:164
+msgid "First"
+msgstr "Prvo"
+
+#: ../src/common/stockitem.cpp:165
+msgid "&Floppy"
+msgstr "&Flopi"
+
+#: ../src/common/stockitem.cpp:165
+msgid "Floppy"
+msgstr "Flopi"
+
+#: ../src/common/stockitem.cpp:166
+msgid "&Forward"
+msgstr "&Napred"
+
+#: ../src/common/stockitem.cpp:166
+msgid "Forward"
+msgstr "Napred"
+
+#: ../src/common/stockitem.cpp:167
+msgid "&Harddisk"
+msgstr "&Hard disk"
+
+#: ../src/common/stockitem.cpp:167
+msgid "Harddisk"
+msgstr "Hard disk"
+
+#: ../src/common/stockitem.cpp:168 ../src/generic/wizard.cpp:418
+#: ../src/osx/cocoa/menu.mm:225 ../src/richtext/richtextstyledlg.cpp:298
+#: ../src/richtext/richtextsymboldlg.cpp:451
+msgid "&Help"
+msgstr "&Pomoć"
+
+#: ../src/common/stockitem.cpp:169
+msgid "&Home"
+msgstr "&Početak"
+
+#: ../src/common/stockitem.cpp:169
+msgid "Home"
+msgstr "Početak"
+
+#: ../src/common/stockitem.cpp:170
+msgid "Indent"
+msgstr "Uvlačenje"
+
+#: ../src/common/stockitem.cpp:171
+msgid "&Index"
+msgstr "&Indeks"
+
+#: ../src/common/stockitem.cpp:171 ../src/html/helpwnd.cpp:510
+msgid "Index"
+msgstr "Indeks"
+
+#: ../src/common/stockitem.cpp:172
+msgid "&Info"
+msgstr "&Informacije"
+
+#: ../src/common/stockitem.cpp:172
+msgid "Info"
+msgstr "Informacije"
+
+#: ../src/common/stockitem.cpp:173
+msgid "&Italic"
+msgstr "&Iskošeno"
+
+#: ../src/common/stockitem.cpp:173 ../src/generic/fontdlgg.cpp:322
+#: ../src/richtext/richtextfontpage.cpp:350
+msgid "Italic"
+msgstr "Iskošeno"
+
+#: ../src/common/stockitem.cpp:174
+msgid "&Jump to"
+msgstr "&Skoči na"
+
+#: ../src/common/stockitem.cpp:174
+msgid "Jump to"
+msgstr "Skoči na"
+
+#: ../src/common/stockitem.cpp:175
+msgid "Centered"
+msgstr "Centrirano"
+
+#: ../src/common/stockitem.cpp:176
+msgid "Justified"
+msgstr "Obostrano poravnato"
+
+#: ../src/common/stockitem.cpp:177
+msgid "Align Left"
+msgstr "Poravnaj levo"
+
+#: ../src/common/stockitem.cpp:178
+msgid "Align Right"
+msgstr "Poravnaj desno"
+
+#: ../src/common/stockitem.cpp:179
+msgid "&Last"
+msgstr "&Poslednje"
+
+#: ../src/common/stockitem.cpp:179
+msgid "Last"
+msgstr "Poslednje"
+
+#: ../src/common/stockitem.cpp:180
+msgid "&Network"
+msgstr "&Mreža"
+
+#: ../src/common/stockitem.cpp:180
+msgid "Network"
+msgstr "Mreža"
+
+#: ../src/common/stockitem.cpp:181 ../src/richtext/richtexttabspage.cpp:131
+msgid "&New"
+msgstr "&Novo"
+
+#: ../src/common/stockitem.cpp:181
+msgid "New"
+msgstr "Novo"
+
+#: ../src/common/stockitem.cpp:182 ../src/msw/msgdlg.cpp:417
+msgid "&No"
+msgstr "&Ne"
+
+#: ../src/common/stockitem.cpp:183 ../src/generic/fontdlgg.cpp:467
+#: ../src/generic/fontdlgg.cpp:474
+msgid "&OK"
+msgstr "&U redu"
+
+#: ../src/common/stockitem.cpp:184 ../src/generic/dbgrptg.cpp:341
+msgid "&Open..."
+msgstr "&Otvori..."
+
+#: ../src/common/stockitem.cpp:184
+msgid "Open..."
+msgstr "Otvori..."
+
+#: ../src/common/stockitem.cpp:185 ../src/msw/textctrl.cpp:2885
+#: ../src/osx/textctrl_osx.cpp:654 ../src/richtext/richtextctrl.cpp:332
+msgid "&Paste"
+msgstr "&Nalepi"
+
+#: ../src/common/stockitem.cpp:185 ../src/richtext/richtextctrl.cpp:3484
+#: ../src/stc/stc_i18n.cpp:19
+msgid "Paste"
+msgstr "Nalepi"
+
+#: ../src/common/stockitem.cpp:186
+msgid "&Preferences"
+msgstr "&Podešavanja"
+
+#: ../src/common/stockitem.cpp:186 ../src/osx/cocoa/preferences.mm:304
+msgid "Preferences"
+msgstr "Podešavanja"
+
+#: ../src/common/stockitem.cpp:187
+msgid "Print previe&w..."
+msgstr "&Pregled pre štampanja..."
+
+#: ../src/common/stockitem.cpp:187
+msgid "Print preview..."
+msgstr "Pregled pre štampanja..."
+
+#: ../src/common/stockitem.cpp:188
+msgid "&Print..."
+msgstr "&Štampaj..."
+
+#: ../src/common/stockitem.cpp:188
+msgid "Print..."
+msgstr "Štampaj..."
+
+#: ../src/common/stockitem.cpp:189 ../src/richtext/richtextctrl.cpp:337
+#: ../src/richtext/richtextctrl.cpp:5479
+msgid "&Properties"
+msgstr "&Svojstva"
+
+#: ../src/common/stockitem.cpp:189
+msgid "Properties"
+msgstr "Svojstva"
+
+#: ../src/common/stockitem.cpp:190 ../src/stc/stc_i18n.cpp:16
+msgid "Redo"
+msgstr "Ponovi"
+
+#: ../src/common/stockitem.cpp:191
+msgid "Refresh"
+msgstr "Osveži"
+
+#: ../src/common/stockitem.cpp:192
+msgid "Remove"
+msgstr "Ukloni"
+
+#: ../src/common/stockitem.cpp:193
+msgid "Rep&lace..."
+msgstr "&Zameni..."
+
+#: ../src/common/stockitem.cpp:193
+msgid "Replace..."
+msgstr "Zameni..."
+
+#: ../src/common/stockitem.cpp:194
+msgid "Revert to Saved"
+msgstr "Vrati na sačuvano"
+
+#: ../src/common/stockitem.cpp:196 ../src/generic/logg.cpp:549
+msgid "Save &As..."
+msgstr "Sačuvaj &kao..."
+
+#: ../src/common/stockitem.cpp:196
+msgid "Save As..."
+msgstr "Sačuvaj kao..."
+
+#: ../src/common/stockitem.cpp:197 ../src/msw/textctrl.cpp:2888
+#: ../src/osx/textctrl_osx.cpp:657 ../src/richtext/richtextctrl.cpp:335
+msgid "Select &All"
+msgstr "Izaberi &sve"
+
+#: ../src/common/stockitem.cpp:197 ../src/stc/stc_i18n.cpp:21
+msgid "Select All"
+msgstr "Izaberi sve"
+
+#: ../src/common/stockitem.cpp:198
+msgid "&Color"
+msgstr "&Boja"
+
+#: ../src/common/stockitem.cpp:198
+msgid "Color"
+msgstr "Boja"
+
+#: ../src/common/stockitem.cpp:199
+msgid "&Font"
+msgstr "&Font"
+
+#: ../src/common/stockitem.cpp:199 ../src/richtext/richtextformatdlg.cpp:336
+msgid "Font"
+msgstr "Font"
+
+#: ../src/common/stockitem.cpp:200
+msgid "&Ascending"
+msgstr "&Uzlazno"
+
+#: ../src/common/stockitem.cpp:200
+msgid "Ascending"
+msgstr "Uzlazno"
+
+#: ../src/common/stockitem.cpp:201
+msgid "&Descending"
+msgstr "&Silazno"
+
+#: ../src/common/stockitem.cpp:201
+msgid "Descending"
+msgstr "Silazno"
+
+#: ../src/common/stockitem.cpp:202
+msgid "&Spell Check"
+msgstr "&Provera pravopisa"
+
+#: ../src/common/stockitem.cpp:202
+msgid "Spell Check"
+msgstr "Provera pravopisa"
+
+#: ../src/common/stockitem.cpp:203
+msgid "&Stop"
+msgstr "&Zaustavi"
+
+#: ../src/common/stockitem.cpp:203
+msgid "Stop"
+msgstr "Zaustavi"
+
+#: ../src/common/stockitem.cpp:204 ../src/richtext/richtextfontpage.cpp:274
+msgid "&Strikethrough"
+msgstr "&Precrtano"
+
+#: ../src/common/stockitem.cpp:204
+msgid "Strikethrough"
+msgstr "Precrtano"
+
+#: ../src/common/stockitem.cpp:205
+msgid "&Top"
+msgstr "&Vrh"
+
+#: ../src/common/stockitem.cpp:205 ../src/richtext/richtextsizepage.cpp:285
+#: ../src/richtext/richtextsizepage.cpp:289
+msgid "Top"
+msgstr "Vrh"
+
+#: ../src/common/stockitem.cpp:206
+msgid "Undelete"
+msgstr "Poništi brisanje"
+
+#: ../src/common/stockitem.cpp:207 ../src/generic/fontdlgg.cpp:437
+msgid "&Underline"
+msgstr "&Podvuci"
+
+#: ../src/common/stockitem.cpp:207
+msgid "Underline"
+msgstr "Podvuci"
+
+#: ../src/common/stockitem.cpp:208 ../src/stc/stc_i18n.cpp:15
+msgid "Undo"
+msgstr "Poništi"
+
+#: ../src/common/stockitem.cpp:209
+msgid "&Unindent"
+msgstr "&Ukloni uvlačenje"
+
+#: ../src/common/stockitem.cpp:209
+msgid "Unindent"
+msgstr "Ukloni uvlačenje"
+
+#: ../src/common/stockitem.cpp:210
+msgid "&Up"
+msgstr "&Gore"
+
+#: ../src/common/stockitem.cpp:210 ../src/generic/fdrepdlg.cpp:148
+msgid "Up"
+msgstr "Gore"
+
+#: ../src/common/stockitem.cpp:211 ../src/msw/msgdlg.cpp:417
+msgid "&Yes"
+msgstr "&Da"
+
+#: ../src/common/stockitem.cpp:212
+msgid "&Actual Size"
+msgstr "&Stvarna veličina"
+
+#: ../src/common/stockitem.cpp:212
+msgid "Actual Size"
+msgstr "Stvarna veličina"
+
+#: ../src/common/stockitem.cpp:213
+msgid "Zoom to &Fit"
+msgstr "Prilagodi po &širini"
+
+#: ../src/common/stockitem.cpp:213
+msgid "Zoom to Fit"
+msgstr "Prilagodi po širini"
+
+#: ../src/common/stockitem.cpp:214
+msgid "Zoom &In"
+msgstr "&Uvećaj"
+
+#: ../src/common/stockitem.cpp:215
+msgid "Zoom &Out"
+msgstr "U&manji"
+
+#: ../src/common/stockitem.cpp:262
+msgid "Show about dialog"
+msgstr "Prikaži dijalog o"
+
+#: ../src/common/stockitem.cpp:263
+msgid "Copy selection"
+msgstr "Kopiraj izbor"
+
+#: ../src/common/stockitem.cpp:264
+msgid "Cut selection"
+msgstr "Iseci izbor"
+
+#: ../src/common/stockitem.cpp:265
+msgid "Delete selection"
+msgstr "Obriši izbor"
+
+#: ../src/common/stockitem.cpp:266
+msgid "Find in document"
+msgstr "Pronađi u dokumentu"
+
+#: ../src/common/stockitem.cpp:267
+msgid "Find and replace in document"
+msgstr "Pronađi i zameni u dokumentu"
+
+#: ../src/common/stockitem.cpp:268
+msgid "Paste selection"
+msgstr "Nalepi izbor"
+
+#: ../src/common/stockitem.cpp:269
+msgid "Quit this program"
+msgstr "Zatvori ovaj program"
+
+#: ../src/common/stockitem.cpp:270
+msgid "Redo last action"
+msgstr "Ponovi poslednju radnju"
+
+#: ../src/common/stockitem.cpp:271
+msgid "Undo last action"
+msgstr "Poništi poslednju radnju"
+
+#: ../src/common/stockitem.cpp:272
+msgid "Create new document"
+msgstr "Napravi novi dokument"
+
+#: ../src/common/stockitem.cpp:273
+msgid "Open an existing document"
+msgstr "Otvori postojeći dokument"
+
+#: ../src/common/stockitem.cpp:274
+msgid "Close current document"
+msgstr "Zatvori trenutni dokument"
+
+#: ../src/common/stockitem.cpp:275
+msgid "Save current document"
+msgstr "Sačuvaj trenutni dokument"
+
+#: ../src/common/stockitem.cpp:276
+msgid "Save current document with a different filename"
+msgstr "Sačuvaj trenutni dokument sa drugim nazivom datoteke"
+
+#: ../src/common/strconv.cpp:2324
+#, c-format
+msgid "Conversion to charset '%s' doesn't work."
+msgstr "Pretvaranje u set znakova '%s' ne radi."
+
+#: ../src/common/tarstrm.cpp:352 ../src/common/tarstrm.cpp:375
+#: ../src/common/tarstrm.cpp:406 ../src/generic/progdlgg.cpp:373
+msgid "unknown"
+msgstr "Nepoznato"
+
+#: ../src/common/tarstrm.cpp:774
+msgid "incomplete header block in tar"
+msgstr "Nepotpun blok zaglavlja  u TAR-u"
+
+#: ../src/common/tarstrm.cpp:798
+msgid "checksum failure reading tar header block"
+msgstr "Neuspešno čitanje kontrolnih podataka tar bloka zaglavlja"
+
+#: ../src/common/tarstrm.cpp:971
+msgid "invalid data in extended tar header"
+msgstr "Neispravni podaci u proširenom TAR zaglavlju"
+
+#: ../src/common/tarstrm.cpp:981 ../src/common/tarstrm.cpp:1003
+#: ../src/common/tarstrm.cpp:1477 ../src/common/tarstrm.cpp:1499
+msgid "tar entry not open"
+msgstr "TAR unos nije otvoren"
+
+#: ../src/common/tarstrm.cpp:1023
+msgid "unexpected end of file"
+msgstr "Neočekivani kraj datoteke"
+
+#: ../src/common/tarstrm.cpp:1297
+#, c-format
+msgid "%s did not fit the tar header for entry '%s'"
+msgstr "%s ne odgovara tar zaglavlju za unos '%s'"
+
+#: ../src/common/tarstrm.cpp:1359
+msgid "incorrect size given for tar entry"
+msgstr "Neispravna veličina određena za tar unos"
+
+#: ../src/common/textbuf.cpp:232
+#, c-format
+msgid "'%s' is probably a binary buffer."
+msgstr "'%s' je verovatno binarni kanal."
+
+#: ../src/common/textcmn.cpp:1006 ../src/richtext/richtextctrl.cpp:3053
+msgid "File couldn't be loaded."
+msgstr "Datoteka nije mogla biti učitana."
+
+#: ../src/common/textfile.cpp:95
+#, c-format
+msgid "Failed to read text file \"%s\"."
+msgstr "Neuspešno čitanje tekstualne datoteke \"%s\"."
+
+#: ../src/common/textfile.cpp:160
+#, c-format
+msgid "can't write buffer '%s' to disk."
+msgstr "Nemoguće upisati kanal '%s' na disk."
+
+#: ../src/common/time.cpp:212
+msgid "Failed to get the local system time"
+msgstr "Neuspešno preuzimanje lokalnog sistemskog vremena"
+
+#: ../src/common/time.cpp:279
+msgid "wxGetTimeOfDay failed."
+msgstr "wxGetTimeOfDay nije uspeo."
+
+#: ../src/common/translation.cpp:929
+#, c-format
+msgid "'%s' is not a valid message catalog."
+msgstr "'%s' nije ispravan katalog poruka."
+
+#: ../src/common/translation.cpp:954
+msgid "Invalid message catalog."
+msgstr "Neispravan katalog poruka."
+
+#: ../src/common/translation.cpp:1013
+#, c-format
+msgid "Failed to parse Plural-Forms: '%s'"
+msgstr "Neuspešno raščlanjivanje formi množina: '%s'"
+
+#: ../src/common/translation.cpp:1723
+#, c-format
+msgid "using catalog '%s' from '%s'."
+msgstr "Koristi se katalog '%s' iz '%s'."
+
+#: ../src/common/translation.cpp:1816
+#, c-format
+msgid "Resource '%s' is not a valid message catalog."
+msgstr "Resurs '%s' nije ispravan katalog poruka."
+
+#: ../src/common/translation.cpp:1865
+msgid "Couldn't enumerate translations"
+msgstr "Nemoguća enumeracija prevoda"
+
+#: ../src/common/utilscmn.cpp:1145
+msgid "No default application configured for HTML files."
+msgstr "Nije podešena podrazumevana aplikacija za HTML datoteke."
+
+#: ../src/common/utilscmn.cpp:1190
+#, c-format
+msgid "Failed to open URL \"%s\" in default browser."
+msgstr ""
+"Otvaranje URL adrese \"%s\" u  podrazumevanom pretraživaču nije uspelo."
+
+#: ../src/common/valtext.cpp:144
+msgid "Validation conflict"
+msgstr "Konflikt provere"
+
+#: ../src/common/valtext.cpp:186
+msgid "Required information entry is empty."
+msgstr "Polje neophodnih informacija je prazno."
+
+#: ../src/common/valtext.cpp:188
+#, c-format
+msgid "'%s' is one of the invalid strings"
+msgstr "'%s' je jedan od neispravnih unosa"
+
+#: ../src/common/valtext.cpp:190
+#, c-format
+msgid "'%s' is not one of the valid strings"
+msgstr "'%s' nije jedan od ispravnih unosa"
+
+#: ../src/common/valtext.cpp:199
+#, c-format
+msgid "'%s' contains invalid character(s)"
+msgstr "'%s' sadrži neispravne znakove"
+
+#: ../src/common/webrequest.cpp:139
+#, c-format
+msgid "Error: %s (%d)"
+msgstr "Greška: %s (%d)"
+
+#: ../src/common/webrequest.cpp:655
+#, fuzzy, c-format
+msgid ""
+"Not enough free disk space for download: %llu needed but only %llu available."
+msgstr "Nema dovoljno slobodnog prostora na disku za preuzimanje."
+
+#: ../src/common/webrequest.cpp:669
+#, fuzzy, c-format
+msgid "Failed to create temporary file in %s"
+msgstr "Pravljenje privremenog imena datoteke nije uspelo"
+
+#: ../src/common/webrequest_curl.cpp:1106
+msgid "libcurl could not be initialized"
+msgstr "libcurl se ne može inicijalizovati"
+
+#: ../src/common/webview.cpp:392
+msgid "RunScriptAsync not supported"
+msgstr "RunScriptAsync nije podržan"
+
+#: ../src/common/webview.cpp:403 ../src/msw/webview_ie.cpp:1073
+#, c-format
+msgid "Error running JavaScript: %s"
+msgstr "Greška pri pokretanju JavaScript-a: %s"
+
+#: ../src/common/webview_chromium.cpp:858
+#, fuzzy, c-format
+msgid "Failed to set proxy \"%s\": %s"
+msgstr "Neuspešno pravljenje direktorijuma \"%s\""
+
+#: ../src/common/webview_chromium.cpp:989
+msgid ""
+"Chromium can't be used because libcef.so wasn't loaded early enough; please "
+"relink the application or use LD_PRELOAD to load it earlier."
+msgstr ""
+
+#: ../src/common/webview_chromium.cpp:1108
+#, fuzzy
+msgid "Could not initialize Chromium"
+msgstr "Nemoguće inicijalizovati OLE"
+
+#: ../src/common/webview_chromium.cpp:1616
+msgid "Show DevTools"
+msgstr ""
+
+#: ../src/common/webview_chromium.cpp:1617
+#, fuzzy
+msgid "Close DevTools"
+msgstr "Zatvori sve"
+
+#: ../src/common/webview_chromium.cpp:1623
+msgid "Inspect"
+msgstr ""
+
+#: ../src/common/wincmn.cpp:1628
+msgid "This platform does not support background transparency."
+msgstr "Ova platforma ne podržava neprovidnu pozadinu."
+
+#: ../src/common/wincmn.cpp:2097
+msgid "Could not transfer data to window"
+msgstr "Nemoguće prebaciti podatke u prozor"
+
+#: ../src/common/windowid.cpp:240
+msgid "Out of window IDs.  Recommend shutting down application."
+msgstr "Nema više ID-ova za prozor.  Preporučuje se da zatvorite aplikaciju."
+
+#: ../src/common/xpmdecod.cpp:678
+msgid "XPM: incorrect header format!"
+msgstr "XPM: Neispravan format zaglavlja!"
+
+#: ../src/common/xpmdecod.cpp:703
+#, c-format
+msgid "XPM: incorrect colour description in line %d"
+msgstr "XPM: neispravan opis boje u redu %d"
+
+#: ../src/common/xpmdecod.cpp:715 ../src/common/xpmdecod.cpp:724
+#, c-format
+msgid "XPM: malformed colour definition '%s' at line %d!"
+msgstr "XPM: pogrešna forma definicije boje '%s' u redu %d!"
+
+#: ../src/common/xpmdecod.cpp:754
+msgid "XPM: no colors left to use for mask!"
+msgstr "XPM: nijedna boja nije ostala za masku!"
+
+#: ../src/common/xpmdecod.cpp:781
+#, c-format
+msgid "XPM: truncated image data at line %d!"
+msgstr "XPM: prekinuti podaci slike u redu %d!"
+
+#: ../src/common/xpmdecod.cpp:795
+msgid "XPM: Malformed pixel data!"
+msgstr "XPM: pogrešna forma podataka piksela!"
+
+#: ../src/common/xti.cpp:492
+msgid "Illegal Parameter Count for Create Method"
+msgstr "Neispravan broj parametara za Create metod"
+
+#: ../src/common/xti.cpp:504
+msgid "Illegal Parameter Count for ConstructObject Method"
+msgstr "Neispravan broj parametara za ConstructObject metod"
+
+#: ../src/common/xtistrm.cpp:161
+#, c-format
+msgid "Create Parameter %s not found in declared RTTI Parameters"
+msgstr "Parametar create %s nije pronađen u naglašenim RTTI parametrima"
+
+#: ../src/common/xtistrm.cpp:290
+msgid "Illegal Object Class (Non-wxEvtHandler) as Event Source"
+msgstr "Neispravna klasa objekata (Non-wxEvtHandler) kao izvor događaja"
+
+#: ../src/common/xtistrm.cpp:313 ../src/common/xtixml.cpp:345
+#: ../src/common/xtixml.cpp:498
+msgid "Type must have enum - long conversion"
+msgstr "Vrsta mora da ima enum - long pretvaranje"
+
+#: ../src/common/xtistrm.cpp:400 ../src/common/xtistrm.cpp:415
+msgid "Invalid or Null Object ID passed to GetObjectClassInfo"
+msgstr "Neispravan ili prazan ID objekta prosleđen u GetObjectClassInfo"
+
+#: ../src/common/xtistrm.cpp:405
+msgid "Unknown Object passed to GetObjectClassInfo"
+msgstr "Nepoznat objekat prosleđen u GetObjectClassInfo"
+
+#: ../src/common/xtistrm.cpp:420
+msgid "Already Registered Object passed to SetObjectClassInfo"
+msgstr "Objekat koji je već registrovan je prosleđen u SetObjectClassInfo"
+
+#: ../src/common/xtistrm.cpp:430
+msgid "Invalid or Null Object ID passed to HasObjectClassInfo"
+msgstr "Neispravan ili prazan ID objekta je prosleđen u HasObjectClassInfo"
+
+#: ../src/common/xtistrm.cpp:460
+msgid "Passing a already registered object to SetObject"
+msgstr "Prosleđivanje već  registrovanog objekta u SetObject"
+
+#: ../src/common/xtistrm.cpp:471
+msgid "Passing an unknown object to GetObject"
+msgstr "Prosleđivanje nepoznatog objekta u GetObject"
+
+#: ../src/common/xtixml.cpp:229
+msgid "Forward hrefs are not supported"
+msgstr "hrefovi koji vode napred nisu podržani"
+
+#: ../src/common/xtixml.cpp:247
+#, c-format
+msgid "unknown class %s"
+msgstr "Nepoznata klasa %s"
+
+#: ../src/common/xtixml.cpp:253
+msgid "objects cannot have XML Text Nodes"
+msgstr "Objekti ne mogu da imaju XML tekstualne veze"
+
+#: ../src/common/xtixml.cpp:258
+msgid "Objects must have an id attribute"
+msgstr "Objekti moraju da imaju ID atribut"
+
+#: ../src/common/xtixml.cpp:267
+#, c-format
+msgid "Doubly used id : %d"
+msgstr "ID se koristi duplo: %d"
+
+#: ../src/common/xtixml.cpp:316
+#, c-format
+msgid "Unknown Property %s"
+msgstr "Nepoznato svojstvo %s"
+
+#: ../src/common/xtixml.cpp:407
+msgid "A non empty collection must consist of 'element' nodes"
+msgstr "Kolekcija koja nije prazna mora da sadrži 'element' veze"
+
+#: ../src/common/xtixml.cpp:478
+msgid "incorrect event handler string, missing dot"
+msgstr "Neispravan niz za event handler, nedostaje tačka"
+
+#: ../src/common/zipstrm.cpp:559
+msgid "can't re-initialize zlib deflate stream"
+msgstr "Nemoguće reinicijalizovati zlib deflate strim"
+
+#: ../src/common/zipstrm.cpp:584
+msgid "can't re-initialize zlib inflate stream"
+msgstr "Nemoguće reinicijalizovati zlib inflate strim"
+
+#: ../src/common/zipstrm.cpp:1023
+msgid "Ignoring malformed extra data record, ZIP file may be corrupted"
+msgstr ""
+"Ignorisanje snimljenih podataka pogrešne forme, ZIP datoteka je možda "
+"oštećena"
+
+#: ../src/common/zipstrm.cpp:1502
+msgid "assuming this is a multi-part zip concatenated"
+msgstr "Pretpostavljanje da je ovo zip datoteka iz više delova"
+
+#: ../src/common/zipstrm.cpp:1664
+msgid "invalid zip file"
+msgstr "Neispravna zip datoteka"
+
+#: ../src/common/zipstrm.cpp:1723
+msgid "can't find central directory in zip"
+msgstr "Nemoguće pronaći centralni direktorijum u zipu"
+
+#: ../src/common/zipstrm.cpp:1812
+msgid "error reading zip central directory"
+msgstr "Greška pri čitanju centralnog direktorijuma zipa"
+
+#: ../src/common/zipstrm.cpp:1916
+msgid "error reading zip local header"
+msgstr "Greška pri čitanju lokalnog zip zaglavlja"
+
+#: ../src/common/zipstrm.cpp:1964
+msgid "bad zipfile offset to entry"
+msgstr "Loš offset zip datoteke za unos"
+
+#: ../src/common/zipstrm.cpp:2031
+msgid "stored file length not in Zip header"
+msgstr "Dužina sačuvanih datoteka nije u zip zaglavlju"
+
+#: ../src/common/zipstrm.cpp:2045 ../src/common/zipstrm.cpp:2362
+msgid "unsupported Zip compression method"
+msgstr "Metod kompresije zip datoteke nije podržan"
+
+#: ../src/common/zipstrm.cpp:2126
+#, c-format
+msgid "reading zip stream (entry %s): bad length"
+msgstr "Čitanje zip strima (unos %s): loša dužina"
+
+#: ../src/common/zipstrm.cpp:2131
+#, c-format
+msgid "reading zip stream (entry %s): bad crc"
+msgstr "Čitanje zip strima (unos %s): loš crc"
+
+#: ../src/common/zipstrm.cpp:2578
+#, c-format
+msgid "error writing zip entry '%s': file too large without ZIP64"
+msgstr "Greška pri pisanju zip unosa '%s': datoteka je prevelika bez ZIP64"
+
+#: ../src/common/zipstrm.cpp:2585
+#, c-format
+msgid "error writing zip entry '%s': bad crc or length"
+msgstr "Greška pri pisanju zip unosa '%s': loš CRC ili dužina"
+
+#: ../src/common/zstream.cpp:155 ../src/common/zstream.cpp:315
+msgid "Gzip not supported by this version of zlib"
+msgstr "Zip  nije podržan od strane ove zlib verzije"
+
+#: ../src/common/zstream.cpp:182
+msgid "Can't initialize zlib inflate stream."
+msgstr "Nemoguće inicijalizovati zlib inflate stream."
+
+#: ../src/common/zstream.cpp:241
+msgid "Can't read inflate stream: unexpected EOF in underlying stream."
+msgstr ""
+"Nemoguće pročitati inflate stream: neočekivani kraj datoteke u  osnovnom "
+"strimu."
+
+#: ../src/common/zstream.cpp:248 ../src/common/zstream.cpp:423
+#, c-format
+msgid "zlib error %d"
+msgstr "zlib greška %d"
+
+#: ../src/common/zstream.cpp:249
+#, c-format
+msgid "Can't read from inflate stream: %s"
+msgstr "Nemoguće čitati inflate stream: %s"
+
+#: ../src/common/zstream.cpp:343
+msgid "Can't initialize zlib deflate stream."
+msgstr "Nemoguće inicijalizovati zlib deflate stream."
+
+#: ../src/common/zstream.cpp:424
+#, c-format
+msgid "Can't write to deflate stream: %s"
+msgstr "Nemoguće pisati u deflate stream: %s"
+
+#: ../src/dfb/bitmap.cpp:633 ../src/dfb/bitmap.cpp:667
+#, c-format
+msgid "No bitmap handler for type %d defined."
+msgstr "Nije određen bitmap obrađivač za vrstu %d."
+
+#: ../src/dfb/evtloop.cpp:99
+msgid "Failed to read event from DirectFB pipe"
+msgstr "Čitanje događaja iz DirectFB pipe-a nije uspelo"
+
+#: ../src/dfb/evtloop.cpp:171
+msgid "Failed to switch DirectFB pipe to non-blocking mode"
+msgstr "Menjanje DirectFB pipe-a u non-blocking režim nije uspelo"
+
+#: ../src/dfb/fontmgr.cpp:171
+#, c-format
+msgid "no fonts found in %s, using builtin font"
+msgstr "Nijedan font nije pronađen u %s, koristi se ugrađeni font"
+
+#: ../src/dfb/fontmgr.cpp:177
+msgid "Default font"
+msgstr "Podrazumevani font"
+
+#: ../src/dfb/fontmgr.cpp:195
+#, c-format
+msgid "Fonts index file %s disappeared while loading fonts."
+msgstr "Indeksna datoteka fontova %s je nestala pri učitavanju fontova."
+
+#: ../src/dfb/wrapdfb.cpp:60
+#, c-format
+msgid "DirectFB error %d occurred."
+msgstr "Došlo je do DirectFB greške %d."
+
+#: ../src/generic/aboutdlgg.cpp:69
+msgid "Developed by "
+msgstr "Razvijen od strane"
+
+#: ../src/generic/aboutdlgg.cpp:72
+msgid "Documentation by "
+msgstr "Dokumentaciju napisali"
+
+#: ../src/generic/aboutdlgg.cpp:75
+msgid "Graphics art by "
+msgstr "Grafički dizajn od strane"
+
+#: ../src/generic/aboutdlgg.cpp:78
+msgid "Translations by "
+msgstr "Prevodi od strane"
+
+#: ../src/generic/aboutdlgg.cpp:133 ../src/osx/cocoa/aboutdlg.mm:83
+msgid "Version "
+msgstr "Verzija"
+
+#. TRANSLATORS: %s is application name
+#: ../src/generic/aboutdlgg.cpp:146 ../src/msw/aboutdlg.cpp:60
+#, c-format
+msgid "About %s"
+msgstr "O %s"
+
+#: ../src/generic/aboutdlgg.cpp:181
+msgid "License"
+msgstr "Licenca"
+
+#: ../src/generic/aboutdlgg.cpp:184
+msgid "Developers"
+msgstr "Programeri"
+
+#: ../src/generic/aboutdlgg.cpp:188
+msgid "Documentation writers"
+msgstr "Autori dokumentacije"
+
+#: ../src/generic/aboutdlgg.cpp:192
+msgid "Artists"
+msgstr "Ilustratori"
+
+#: ../src/generic/aboutdlgg.cpp:196
+msgid "Translators"
+msgstr "Prevodioci"
+
+#: ../src/generic/animateg.cpp:125
+msgid "No handler found for animation type."
+msgstr "Nijedan obrađivač nije pronađen za vrstu animacije."
+
+#: ../src/generic/animateg.cpp:133
+#, c-format
+msgid "No animation handler for type %ld defined."
+msgstr "Nijedan obrađivač animacija za vrstu %ld nije određen."
+
+#: ../src/generic/animateg.cpp:145
+#, c-format
+msgid "Animation file is not of type %ld."
+msgstr "Datoteka animacija nije vrste %ld."
+
+#: ../src/generic/colrdlgg.cpp:154 ../src/gtk/colordlg.cpp:47
+msgid "Choose colour"
+msgstr "Izaberite boju"
+
+#: ../src/generic/colrdlgg.cpp:357
+msgid "Red:"
+msgstr "Crvena:"
+
+#: ../src/generic/colrdlgg.cpp:360
+msgid "Green:"
+msgstr "Zelena:"
+
+#: ../src/generic/colrdlgg.cpp:363
+msgid "Blue:"
+msgstr "Plava:"
+
+#: ../src/generic/colrdlgg.cpp:372
+msgid "Opacity:"
+msgstr "Neprozirnost:"
+
+#: ../src/generic/colrdlgg.cpp:384
+msgid "Add to custom colours"
+msgstr "Dodaj u prilagođene boje"
+
+#: ../src/generic/creddlgg.cpp:56
+msgid "Username:"
+msgstr "Korisničko ime:"
+
+#: ../src/generic/creddlgg.cpp:63
+msgid "Password:"
+msgstr "Lozinka:"
+
+#. TRANSLATORS: Name of Boolean true value
+#: ../src/generic/datavgen.cpp:1178
+msgid "true"
+msgstr "Tačno"
+
+#. TRANSLATORS: Name of Boolean false value
+#: ../src/generic/datavgen.cpp:1180
+msgid "false"
+msgstr "Netačno"
+
+#: ../src/generic/datavgen.cpp:6897
+#, c-format
+msgid "Row %i"
+msgstr "Red %i"
+
+#. TRANSLATORS: Action for manipulating a tree control
+#: ../src/generic/datavgen.cpp:6987
+msgid "Collapse"
+msgstr "Skupi"
+
+#. TRANSLATORS: Action for manipulating a tree control
+#: ../src/generic/datavgen.cpp:6990
+msgid "Expand"
+msgstr "Proširi"
+
+#. TRANSLATORS: Name of data view control and number of rows
+#: ../src/generic/datavgen.cpp:7011
+#, c-format
+msgid "%s (%d items)"
+msgstr "%s (%d stavki)"
+
+#: ../src/generic/datavgen.cpp:7062
+#, c-format
+msgid "Column %u"
+msgstr "Kolona %u"
+
+#. TRANSLATORS: Keystroke for manipulating a tree control
+#: ../src/generic/datavgen.cpp:7131 ../src/richtext/richtextbulletspage.cpp:189
+#: ../src/richtext/richtextbulletspage.cpp:192
+#: ../src/richtext/richtextbulletspage.cpp:193
+#: ../src/richtext/richtextliststylepage.cpp:252
+#: ../src/richtext/richtextliststylepage.cpp:255
+#: ../src/richtext/richtextliststylepage.cpp:256
+#: ../src/richtext/richtextsizepage.cpp:248
+msgid "Left"
+msgstr "Levo"
+
+#. TRANSLATORS: Keystroke for manipulating a tree control
+#: ../src/generic/datavgen.cpp:7134 ../src/richtext/richtextbulletspage.cpp:191
+#: ../src/richtext/richtextliststylepage.cpp:254
+#: ../src/richtext/richtextsizepage.cpp:249
+msgid "Right"
+msgstr "Desno"
+
+#: ../src/generic/datectlg.cpp:90
+#, c-format
+msgid ""
+"\"%s\" is not in the expected date format, please enter it as e.g. \"%s\"."
+msgstr ""
+
+#: ../src/generic/datectlg.cpp:94
+#, fuzzy
+msgid "Invalid date"
+msgstr "PCX: neispravna slika"
+
+#: ../src/generic/dbgrptg.cpp:159
+#, c-format
+msgid "Open file \"%s\""
+msgstr "Otvori datoteku \"%s\""
+
+#: ../src/generic/dbgrptg.cpp:170
+#, c-format
+msgid "Enter command to open file \"%s\":"
+msgstr "Upišite komandu za otvaranje datoteke \"%s\":"
+
+#: ../src/generic/dbgrptg.cpp:230
+msgid "Executable files (*.exe)|*.exe|"
+msgstr "Izvršne datoteke (*.exe)|*.exe|"
+
+#: ../src/generic/dbgrptg.cpp:300
+#, c-format
+msgid "Debug report \"%s\""
+msgstr "Izveštaj za otklanjanje grešaka \"%s\""
+
+#: ../src/generic/dbgrptg.cpp:316
+msgid "A debug report has been generated in the directory\n"
+msgstr "Izveštaj za otklanjanje grešaka je napravljen u direktorijumu \n"
+
+#: ../src/generic/dbgrptg.cpp:317
+msgid "The following debug report will be generated\n"
+msgstr "Sledeći izveštaj za otklanjanje grešaka će biti generisan \n"
+
+#: ../src/generic/dbgrptg.cpp:321
+msgid ""
+"The report contains the files listed below. If any of these files contain "
+"private information,\n"
+"please uncheck them and they will be removed from the report.\n"
+msgstr ""
+"Izveštaj sadrži datoteke koje su u listi ispod. Ako neke od ovih datoteka "
+"sadrže privatne informacije,\n"
+"molimo onemogućite ih i biće uklonjene iz izveštaja.\n"
+
+#: ../src/generic/dbgrptg.cpp:323
+msgid ""
+"If you wish to suppress this debug report completely, please choose the "
+"\"Cancel\" button,\n"
+"but be warned that it may hinder improving the program, so if\n"
+"at all possible please do continue with the report generation.\n"
+msgstr ""
+"Ako želite da u potpunosti obustavite ovaj izveštaj za otklanjanje grešaka, "
+"molimo izaberite dugme \"Otkaži\",\n"
+"ali imajte na umu da će to sprečiti poboljšanje programa, pa ako\n"
+"je ikako moguće nastavite sa generisanjem izveštaja.\n"
+
+#: ../src/generic/dbgrptg.cpp:325
+msgid "              Thank you and we're sorry for the inconvenience!\n"
+msgstr "              Hvala vam i izvinjavamo se zbog neprijatnosti!\n"
+
+#: ../src/generic/dbgrptg.cpp:333
+msgid "&Debug report preview:"
+msgstr "&Pregled izveštaja za otklanjanje grešaka:"
+
+#: ../src/generic/dbgrptg.cpp:339
+msgid "&View..."
+msgstr "&Prikaži..."
+
+#: ../src/generic/dbgrptg.cpp:359
+msgid "&Notes:"
+msgstr "&Napomene:"
+
+#: ../src/generic/dbgrptg.cpp:361
+msgid ""
+"If you have any additional information pertaining to this bug\n"
+"report, please enter it here and it will be joined to it:"
+msgstr ""
+"Ako imate nekih dodatnih informacija vezanih za prijavu ove\n"
+"greške, molimo upišite ih ovde i biće dodate:"
+
+#: ../src/generic/dcpsg.cpp:1627
+msgid "Cannot open file for PostScript printing!"
+msgstr "Nemoguće otvoriti datoteku za PostScript štampanje!"
+
+#: ../src/generic/dirctrlg.cpp:402
+msgid "Computer"
+msgstr "Računar"
+
+#: ../src/generic/dirctrlg.cpp:404
+msgid "Sections"
+msgstr "Odeljci"
+
+#: ../src/generic/dirctrlg.cpp:482
+msgid "Home directory"
+msgstr "Početni direktorijum"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/generic/dirctrlg.cpp:484 ../src/propgrid/advprops.cpp:811
+msgid "Desktop"
+msgstr "Radna površina"
+
+#: ../src/generic/dirctrlg.cpp:528 ../src/generic/filectrlg.cpp:752
+msgid "Illegal directory name."
+msgstr "Neispravno ime direktorijuma."
+
+#: ../src/generic/dirctrlg.cpp:528 ../src/generic/dirctrlg.cpp:546
+#: ../src/generic/dirctrlg.cpp:557 ../src/generic/dirdlgg.cpp:317
+#: ../src/generic/filectrlg.cpp:638 ../src/generic/filectrlg.cpp:752
+#: ../src/generic/filectrlg.cpp:766 ../src/generic/filectrlg.cpp:782
+#: ../src/generic/filectrlg.cpp:1356 ../src/generic/filectrlg.cpp:1387
+#: ../src/generic/filedlgg.cpp:362 ../src/gtk/filedlg.cpp:76
+msgid "Error"
+msgstr "Greška"
+
+#: ../src/generic/dirctrlg.cpp:546 ../src/generic/filectrlg.cpp:766
+msgid "File name exists already."
+msgstr "Ime datoteke već postoji."
+
+#: ../src/generic/dirctrlg.cpp:557 ../src/generic/dirdlgg.cpp:317
+#: ../src/generic/filectrlg.cpp:638 ../src/generic/filectrlg.cpp:782
+msgid "Operation not permitted."
+msgstr "Radnja nije dozvoljena."
+
+#: ../src/generic/dirdlgg.cpp:107 ../src/generic/filedlgg.cpp:207
+msgid "Create new directory"
+msgstr "Napravi novi direktorijum"
+
+#: ../src/generic/dirdlgg.cpp:112 ../src/generic/filedlgg.cpp:203
+msgid "Go to home directory"
+msgstr "Prebaci se na početni direktorijum"
+
+#: ../src/generic/dirdlgg.cpp:143
+msgid "Show &hidden directories"
+msgstr "Prikaži &skrivene direktorijume"
+
+#: ../src/generic/dirdlgg.cpp:196
+#, c-format
+msgid ""
+"The directory '%s' does not exist\n"
+"Create it now?"
+msgstr ""
+"Direktorijum '%s' ne postoji\n"
+"Napraviti ga sada?"
+
+#: ../src/generic/dirdlgg.cpp:198
+msgid "Directory does not exist"
+msgstr "Direktorijum ne postoji"
+
+#: ../src/generic/dirdlgg.cpp:214
+#, c-format
+msgid ""
+"Failed to create directory '%s'\n"
+"(Do you have the required permissions?)"
+msgstr ""
+"Pravljenje direktorijuma '%s' nije uspelo\n"
+"(Da li imate neophodne dozvole?)"
+
+#: ../src/generic/dirdlgg.cpp:216
+msgid "Error creating directory"
+msgstr "Greška pri pravljenju direktorijuma"
+
+#: ../src/generic/dirdlgg.cpp:281
+msgid "You cannot add a new directory to this section."
+msgstr "Ne možete da dodate novi direktorijum u ovaj odeljak."
+
+#: ../src/generic/dirdlgg.cpp:282
+msgid "Create directory"
+msgstr "Napravi direktorijum"
+
+#: ../src/generic/dirdlgg.cpp:291 ../src/generic/dirdlgg.cpp:301
+#: ../src/generic/filectrlg.cpp:614 ../src/generic/filectrlg.cpp:623
+msgid "NewName"
+msgstr "Novo ime"
+
+#: ../src/generic/editlbox.cpp:135
+msgid "Edit item"
+msgstr "Uredi stavku"
+
+#: ../src/generic/editlbox.cpp:143
+msgid "New item"
+msgstr "Nova stavka"
+
+#: ../src/generic/editlbox.cpp:151
+msgid "Delete item"
+msgstr "Obriši stavku"
+
+#: ../src/generic/editlbox.cpp:159
+msgid "Move up"
+msgstr "Pomeri gore"
+
+#: ../src/generic/editlbox.cpp:164
+msgid "Move down"
+msgstr "Pomeri dole"
+
+#: ../src/generic/fdrepdlg.cpp:108
+msgid "Search for:"
+msgstr "Pretraži:"
+
+#: ../src/generic/fdrepdlg.cpp:120
+msgid "Replace with:"
+msgstr "Zameni sa:"
+
+#: ../src/generic/fdrepdlg.cpp:140
+msgid "Whole word"
+msgstr "Cele reči"
+
+#: ../src/generic/fdrepdlg.cpp:143
+msgid "Match case"
+msgstr "Osetljivost na veličinu slova"
+
+#: ../src/generic/fdrepdlg.cpp:156
+msgid "Search direction"
+msgstr "Pravac pretrage"
+
+#: ../src/generic/fdrepdlg.cpp:175
+msgid "&Replace"
+msgstr "&Zameni"
+
+#: ../src/generic/fdrepdlg.cpp:178
+msgid "Replace &all"
+msgstr "Zameni &sve"
+
+#: ../src/generic/filectrlg.cpp:246 ../src/generic/filectrlg.cpp:269
+msgid "<DIR>"
+msgstr "<DIR>"
+
+#: ../src/generic/filectrlg.cpp:248 ../src/generic/filectrlg.cpp:271
+msgid "<LINK>"
+msgstr "<LINK>"
+
+#: ../src/generic/filectrlg.cpp:250 ../src/generic/filectrlg.cpp:273
+msgid "<DRIVE>"
+msgstr "<DISK>"
+
+#: ../src/generic/filectrlg.cpp:275
+#, c-format
+msgid "%ld byte"
+msgid_plural "%ld bytes"
+msgstr[0] "%ld bajt"
+msgstr[1] "%ld bajta"
+msgstr[2] "%ld bajtova"
+
+#: ../src/generic/filectrlg.cpp:420
+msgid "Name"
+msgstr "Ime"
+
+#: ../src/generic/filectrlg.cpp:421 ../src/richtext/richtextformatdlg.cpp:361
+#: ../src/richtext/richtextsizepage.cpp:298
+msgid "Size"
+msgstr "Veličina"
+
+#: ../src/generic/filectrlg.cpp:422
+msgid "Type"
+msgstr "Vrsta"
+
+#: ../src/generic/filectrlg.cpp:423
+msgid "Modified"
+msgstr "Izmenjeno"
+
+#: ../src/generic/filectrlg.cpp:426
+msgid "Permissions"
+msgstr "Dozvole"
+
+#: ../src/generic/filectrlg.cpp:429
+msgid "Attributes"
+msgstr "Atributi"
+
+#: ../src/generic/filectrlg.cpp:936
+msgid "Current directory:"
+msgstr "Trenutni direktorijum:"
+
+#: ../src/generic/filectrlg.cpp:979
+msgid "Show &hidden files"
+msgstr "Prikaži &skrivene datoteke"
+
+#: ../src/generic/filectrlg.cpp:1355
+msgid "Illegal file specification."
+msgstr "Neispravna specifikacija datoteke."
+
+#: ../src/generic/filectrlg.cpp:1387
+msgid "Directory doesn't exist."
+msgstr "Direktorijum ne postoji."
+
+#: ../src/generic/filedlgg.cpp:195
+msgid "View files as a list view"
+msgstr "Prikaži datoteke u listi"
+
+#: ../src/generic/filedlgg.cpp:197
+msgid "View files as a detailed view"
+msgstr "Prikaži datoteke u detaljnom prikazu"
+
+#: ../src/generic/filedlgg.cpp:200
+msgid "Go to parent directory"
+msgstr "Vrati se u prvobitni direktorijum"
+
+#: ../src/generic/filedlgg.cpp:351 ../src/gtk/filedlg.cpp:59
+#, c-format
+msgid "File '%s' already exists, do you really want to overwrite it?"
+msgstr "Datoteka '%s' već postoji, da li zaista želite da je zamenite?"
+
+#: ../src/generic/filedlgg.cpp:354 ../src/gtk/filedlg.cpp:62
+msgid "Confirm"
+msgstr "Potvrdi"
+
+#: ../src/generic/filedlgg.cpp:362 ../src/gtk/filedlg.cpp:75
+msgid "Please choose an existing file."
+msgstr "Molimo izaberite postojeću datoteku."
+
+#: ../src/generic/filepickerg.cpp:64
+msgid "..."
+msgstr "..."
+
+#: ../src/generic/fontdlgg.cpp:76 ../src/richtext/richtextformatdlg.cpp:519
+msgid "ABCDEFGabcdefg12345"
+msgstr "ABCDEFGabcdefg12345"
+
+#: ../src/generic/fontdlgg.cpp:315
+msgid "Roman"
+msgstr "Rimski"
+
+#: ../src/generic/fontdlgg.cpp:316
+msgid "Decorative"
+msgstr "Dekorativni"
+
+#: ../src/generic/fontdlgg.cpp:317
+msgid "Modern"
+msgstr "Moderni"
+
+#: ../src/generic/fontdlgg.cpp:318
+msgid "Script"
+msgstr "Pismo"
+
+#: ../src/generic/fontdlgg.cpp:319
+msgid "Swiss"
+msgstr "Švajcarski"
+
+#: ../src/generic/fontdlgg.cpp:320
+msgid "Teletype"
+msgstr "Pisaća mašina"
+
+#: ../src/generic/fontdlgg.cpp:321 ../src/generic/fontdlgg.cpp:324
+msgid "Normal"
+msgstr "Normalni"
+
+#: ../src/generic/fontdlgg.cpp:323
+msgid "Slant"
+msgstr "Koso"
+
+#: ../src/generic/fontdlgg.cpp:325
+msgid "Light"
+msgstr "Svetlo"
+
+#: ../src/generic/fontdlgg.cpp:363
+msgid "&Font family:"
+msgstr "&Porodica fontova:"
+
+#: ../src/generic/fontdlgg.cpp:367 ../src/generic/fontdlgg.cpp:369
+msgid "The font family."
+msgstr "Porodica fontova."
+
+#: ../src/generic/fontdlgg.cpp:374 ../src/richtext/richtextstylepage.cpp:105
+msgid "&Style:"
+msgstr "&Stil:"
+
+#: ../src/generic/fontdlgg.cpp:378 ../src/generic/fontdlgg.cpp:380
+msgid "The font style."
+msgstr "Stil fonta."
+
+#: ../src/generic/fontdlgg.cpp:385
+msgid "&Weight:"
+msgstr "&Debljina:"
+
+#: ../src/generic/fontdlgg.cpp:389 ../src/generic/fontdlgg.cpp:391
+msgid "The font weight."
+msgstr "Debljina fonta."
+
+#: ../src/generic/fontdlgg.cpp:399
+msgid "C&olour:"
+msgstr "&Boja:"
+
+#: ../src/generic/fontdlgg.cpp:407 ../src/generic/fontdlgg.cpp:409
+msgid "The font colour."
+msgstr "Boja fonta."
+
+#: ../src/generic/fontdlgg.cpp:415
+msgid "&Point size:"
+msgstr "&Veličina"
+
+#: ../src/generic/fontdlgg.cpp:420 ../src/generic/fontdlgg.cpp:422
+#: ../src/generic/fontdlgg.cpp:426 ../src/generic/fontdlgg.cpp:428
+msgid "The font point size."
+msgstr "Veličina fonta."
+
+#: ../src/generic/fontdlgg.cpp:439 ../src/generic/fontdlgg.cpp:441
+msgid "Whether the font is underlined."
+msgstr "Da li je font podvučen."
+
+#: ../src/generic/fontdlgg.cpp:448 ../src/html/helpwnd.cpp:1215
+msgid "Preview:"
+msgstr "Pregled:"
+
+#: ../src/generic/fontdlgg.cpp:452 ../src/generic/fontdlgg.cpp:454
+msgid "Shows the font preview."
+msgstr "Prikazuje pregled fonta."
+
+#: ../src/generic/fontdlgg.cpp:464 ../src/generic/fontdlgg.cpp:483
+msgid "Click to cancel the font selection."
+msgstr "Kliknite da otkažete izbor fonta."
+
+#: ../src/generic/fontdlgg.cpp:469 ../src/generic/fontdlgg.cpp:471
+#: ../src/generic/fontdlgg.cpp:476 ../src/generic/fontdlgg.cpp:478
+msgid "Click to confirm the font selection."
+msgstr "Kliknite da potvrdite izbor fonta."
+
+#: ../src/generic/fontpickerg.cpp:50 ../src/gtk/fontdlg.cpp:77
+msgid "Choose font"
+msgstr "Izaberite font"
+
+#: ../src/generic/grid.cpp:6542
+msgid ""
+"Error copying grid to the clipboard. Either selected cells were not "
+"contiguous or no cell was selected."
+msgstr ""
+
+#: ../src/generic/grid.cpp:12739
+#, fuzzy
+msgid "Grid Corner"
+msgstr "Ugao"
+
+#: ../src/generic/grid.cpp:12741
+#, fuzzy, c-format
+msgid "Column %s Header"
+msgstr "Kolona %u"
+
+#: ../src/generic/grid.cpp:12743
+#, c-format
+msgid "Row %s Header"
+msgstr ""
+
+#: ../src/generic/grid.cpp:12745
+#, fuzzy, c-format
+msgid "Column %s: %s"
+msgstr "Kolona %u"
+
+#: ../src/generic/grid.cpp:12749
+#, fuzzy, c-format
+msgid "Row %s: %s"
+msgstr "Red %i"
+
+#: ../src/generic/grid.cpp:12753
+#, c-format
+msgid "Row %s, Column %s: %s"
+msgstr ""
+
+#: ../src/generic/helpext.cpp:257
+#, c-format
+msgid "Help directory \"%s\" not found."
+msgstr "Direktorijum pomoći \"%s\" nije pronađen."
+
+#: ../src/generic/helpext.cpp:265
+#, c-format
+msgid "Help file \"%s\" not found."
+msgstr "Datoteka pomoći \"%s\" nije pronađena."
+
+#: ../src/generic/helpext.cpp:284
+#, c-format
+msgid "Line %lu of map file \"%s\" has invalid syntax, skipped."
+msgstr "Red %lu datoteke mape \"%s\" ima neispravnu sintaksu, biće preskočen."
+
+#: ../src/generic/helpext.cpp:292
+#, c-format
+msgid "No valid mappings found in the file \"%s\"."
+msgstr "Ispravna mapiranja nisu pronađena u datoteci \"%s\"."
+
+#: ../src/generic/helpext.cpp:435
+msgid "No entries found."
+msgstr "Nema pronađenih unosa."
+
+#: ../src/generic/helpext.cpp:444 ../src/generic/helpext.cpp:445
+msgid "Help Index"
+msgstr "Indeks pomoći"
+
+#: ../src/generic/helpext.cpp:448
+msgid "Relevant entries:"
+msgstr "Relevantne stavke:"
+
+#: ../src/generic/helpext.cpp:449
+msgid "Entries found"
+msgstr "Pronađene stavke"
+
+#: ../src/generic/hyperlinkg.cpp:170
+msgid "&Copy URL"
+msgstr "&Kopiraj URL"
+
+#: ../src/generic/infobar.cpp:119
+msgid "Hide this notification message."
+msgstr "Sakrij ovu poruku obaveštenja."
+
+#. TRANSLATORS: %s will be either the application name or "Application"
+#: ../src/generic/logg.cpp:257
+#, c-format
+msgid "%s Error"
+msgstr "%s greška"
+
+#. TRANSLATORS: %s will be either the application name or "Application"
+#: ../src/generic/logg.cpp:263
+#, c-format
+msgid "%s Warning"
+msgstr "%s upozorenje"
+
+#. TRANSLATORS: %s will be either the application name or "Application"
+#: ../src/generic/logg.cpp:273
+#, c-format
+msgid "%s Information"
+msgstr "%s informacija"
+
+#: ../src/generic/logg.cpp:276
+msgid "Application"
+msgstr "Aplikacija"
+
+#: ../src/generic/logg.cpp:549
+msgid "Save log contents to file"
+msgstr "Sačuvaj sadržaj dnevnika u datoteku"
+
+#: ../src/generic/logg.cpp:551
+msgid "C&lear"
+msgstr "&Očisti"
+
+#: ../src/generic/logg.cpp:551
+msgid "Clear the log contents"
+msgstr "Očisti sadržaj dnevnika"
+
+#: ../src/generic/logg.cpp:553
+msgid "Close this window"
+msgstr "Zatvori ovaj prozor"
+
+#: ../src/generic/logg.cpp:554
+msgid "&Log"
+msgstr "&Dnevnik"
+
+#: ../src/generic/logg.cpp:610 ../src/generic/logg.cpp:992
+msgid "Can't save log contents to file."
+msgstr "Nemoguće sačuvati sadržaj dnevnika u datoteku."
+
+#: ../src/generic/logg.cpp:613
+#, c-format
+msgid "Log saved to the file '%s'."
+msgstr "Dnevnik sačuvan u datoteku '%s'."
+
+#: ../src/generic/logg.cpp:719
+msgid "&Details"
+msgstr "&Detalji"
+
+#: ../src/generic/logg.cpp:972
+msgid "Failed to copy dialog contents to the clipboard."
+msgstr "Kopiranje sadržaja dijaloga u privremenu memoriju nije uspelo."
+
+#: ../src/generic/logg.cpp:1022
+#, c-format
+msgid "Append log to file '%s' (choosing [No] will overwrite it)?"
+msgstr "Dodati dnevnik u datoteku '%s' (ako  izaberete [Ne] biće zamenjen)?"
+
+#: ../src/generic/logg.cpp:1024
+msgid "Question"
+msgstr "Pitanje"
+
+#: ../src/generic/logg.cpp:1038
+msgid "invalid message box return value"
+msgstr "Neispravna vrednost koja je vraćena od strane poruke"
+
+#: ../src/generic/notifmsgg.cpp:129
+msgid "Notice"
+msgstr "Napomena"
+
+#: ../src/generic/preferencesg.cpp:118
+#, c-format
+msgid "%s Preferences"
+msgstr "%s podešavanja"
+
+#: ../src/generic/printps.cpp:143
+msgid "Printing..."
+msgstr "Štampanje..."
+
+#: ../src/generic/printps.cpp:160 ../src/gtk/print.cpp:1076
+#: ../src/msw/printwin.cpp:235
+msgid "Could not start printing."
+msgstr "Nemoguće započeti štampanje."
+
+#: ../src/generic/printps.cpp:183
+#, c-format
+msgid "Printing page %d..."
+msgstr "Štampanje stranice %d..."
+
+#: ../src/generic/prntdlgg.cpp:171
+msgid "Printer options"
+msgstr "Opcije štampača"
+
+#: ../src/generic/prntdlgg.cpp:176
+msgid "Print to File"
+msgstr "Štampaj u datoteku"
+
+#: ../src/generic/prntdlgg.cpp:179
+msgid "Setup..."
+msgstr "Podešavanje..."
+
+#: ../src/generic/prntdlgg.cpp:187
+msgid "Printer:"
+msgstr "Štampač:"
+
+#: ../src/generic/prntdlgg.cpp:195
+msgid "Status:"
+msgstr "Status:"
+
+#: ../src/generic/prntdlgg.cpp:206
+msgid "All"
+msgstr "Sve"
+
+#: ../src/generic/prntdlgg.cpp:207
+msgid "Pages"
+msgstr "Stranice"
+
+#: ../src/generic/prntdlgg.cpp:215
+msgid "Print Range"
+msgstr "Opseg štampanja"
+
+#: ../src/generic/prntdlgg.cpp:229
+msgid "From:"
+msgstr "Od:"
+
+#: ../src/generic/prntdlgg.cpp:233
+msgid "To:"
+msgstr "Do:"
+
+#: ../src/generic/prntdlgg.cpp:238
+msgid "Copies:"
+msgstr "Kopije:"
+
+#: ../src/generic/prntdlgg.cpp:288
+msgid "PostScript file"
+msgstr "PostScript datoteka"
+
+#: ../src/generic/prntdlgg.cpp:439
+msgid "Print Setup"
+msgstr "Podešavanje štampanja"
+
+#: ../src/generic/prntdlgg.cpp:483
+msgid "Printer"
+msgstr "Štampač"
+
+#: ../src/generic/prntdlgg.cpp:501
+msgid "Default printer"
+msgstr "Podrazumevani štampač"
+
+#: ../src/generic/prntdlgg.cpp:595 ../src/generic/prntdlgg.cpp:782
+#: ../src/generic/prntdlgg.cpp:822 ../src/generic/prntdlgg.cpp:835
+#: ../src/generic/prntdlgg.cpp:1031 ../src/generic/prntdlgg.cpp:1036
+msgid "Paper size"
+msgstr "Veličina papira"
+
+#: ../src/generic/prntdlgg.cpp:604 ../src/generic/prntdlgg.cpp:847
+msgid "Portrait"
+msgstr "Uspravno"
+
+#: ../src/generic/prntdlgg.cpp:605 ../src/generic/prntdlgg.cpp:848
+msgid "Landscape"
+msgstr "Horizontalno"
+
+#: ../src/generic/prntdlgg.cpp:607 ../src/generic/prntdlgg.cpp:849
+msgid "Orientation"
+msgstr "Orijentacija"
+
+#: ../src/generic/prntdlgg.cpp:610
+msgid "Options"
+msgstr "Opcije"
+
+#: ../src/generic/prntdlgg.cpp:612
+msgid "Print in colour"
+msgstr "Štampaj u boji"
+
+#: ../src/generic/prntdlgg.cpp:621
+msgid "Print spooling"
+msgstr "Spooliranje štampanja"
+
+#: ../src/generic/prntdlgg.cpp:623
+msgid "Printer command:"
+msgstr "Komande štampača:"
+
+#: ../src/generic/prntdlgg.cpp:631
+msgid "Printer options:"
+msgstr "Opcije štampača:"
+
+#: ../src/generic/prntdlgg.cpp:860
+msgid "Left margin (mm):"
+msgstr "Leva margina (mm):"
+
+#: ../src/generic/prntdlgg.cpp:861
+msgid "Top margin (mm):"
+msgstr "Gornja margina (mm):"
+
+#: ../src/generic/prntdlgg.cpp:872
+msgid "Right margin (mm):"
+msgstr "Desna margina (mm):"
+
+#: ../src/generic/prntdlgg.cpp:873
+msgid "Bottom margin (mm):"
+msgstr "Donja margina (mm):"
+
+#: ../src/generic/prntdlgg.cpp:896
+msgid "Printer..."
+msgstr "Štampač..."
+
+#: ../src/generic/progdlgg.cpp:246
+msgid "&Skip"
+msgstr "&Preskoči"
+
+#: ../src/generic/progdlgg.cpp:347 ../src/generic/progdlgg.cpp:626
+msgid "Unknown"
+msgstr "Nepoznato"
+
+#: ../src/generic/progdlgg.cpp:451 ../src/msw/progdlg.cpp:526
+msgid "Done."
+msgstr "Gotovo."
+
+#: ../src/generic/srchctlg.cpp:55 ../src/gtk/srchctrl.cpp:206
+#: ../src/html/helpwnd.cpp:530 ../src/html/helpwnd.cpp:545
+msgid "Search"
+msgstr "Pretraži"
+
+#: ../src/generic/tabg.cpp:1026
+msgid "Could not find tab for id"
+msgstr "Nemoguće pronaći karticu za ID"
+
+#: ../src/generic/tipdlg.cpp:136
+msgid "Tips not available, sorry!"
+msgstr "Saveti nisu dostupni, žao nam je!"
+
+#: ../src/generic/tipdlg.cpp:197
+msgid "Tip of the Day"
+msgstr "Savet dana"
+
+#: ../src/generic/tipdlg.cpp:207
+msgid "Did you know..."
+msgstr "Da li ste znali..."
+
+#: ../src/generic/tipdlg.cpp:232
+msgid "&Show tips at startup"
+msgstr "&Prikaži savete pri pokretanju"
+
+#: ../src/generic/tipdlg.cpp:236
+msgid "&Next Tip"
+msgstr "&Sledeći savet"
+
+#: ../src/generic/wizard.cpp:411
+msgid "&Next >"
+msgstr "&Dalje>"
+
+#: ../src/generic/wizard.cpp:412
+msgid "&Finish"
+msgstr "&Završi"
+
+#: ../src/generic/wizard.cpp:420
+msgid "< &Back"
+msgstr "< &Nazad"
+
+#: ../src/gtk/aboutdlg.cpp:204
+msgid "translator-credits"
+msgstr "Nikola Jović <wwenikola123@gmail.com>, 2022."
+
+#: ../src/gtk/app.cpp:517
+msgid ""
+"WARNING: using XIM input method is unsupported and may result in problems "
+"with input handling and flickering. Consider unsetting GTK_IM_MODULE or "
+"setting to \"ibus\"."
+msgstr ""
+"Upozorenje: Korišćenje  XIM metoda unosa nije podržano i može uzrokovati "
+"probleme sa obradom unosa i treperenjem. Razmotrite o uklanjanju "
+"GTK_IM_MODULA ili podešavanju na \"ibus\"."
+
+#: ../src/gtk/app.cpp:569
+msgid "Unable to initialize GTK+, is DISPLAY set properly?"
+msgstr "Nemoguće inicijalizovati GTK+, da li je display ispravno podešen?"
+
+#: ../src/gtk/filedlg.cpp:89 ../src/gtk/filepicker.cpp:255
+#, c-format
+msgid "Changing current directory to \"%s\" failed"
+msgstr "Menjanje trenutnog direktorijuma na \"%s\" nije uspelo"
+
+#: ../src/gtk/font.cpp:548
+msgid ""
+"Using private fonts is not supported on this system: Pango library is too "
+"old, 1.38 or later required."
+msgstr ""
+"Korišćenje privatnih fontova nije podržano na ovom sistemu: Pango biblioteka "
+"je prestara, 1.38 ili novija je neophodna."
+
+#: ../src/gtk/font.cpp:558
+msgid "Failed to create font configuration object."
+msgstr "Pravljenje objekta konfiguracije fonta nije uspelo."
+
+#: ../src/gtk/font.cpp:568
+#, c-format
+msgid "Failed to add custom font \"%s\"."
+msgstr "Dodavanje prilagođenog fonta \"%s\" nije uspelo."
+
+#: ../src/gtk/font.cpp:576
+msgid "Failed to register font configuration using private fonts."
+msgstr ""
+"Registracija konfiguracije fonta korišćenjem privatnih fontova nije uspela."
+
+#: ../src/gtk/glcanvas.cpp:117 ../src/gtk/glcanvas.cpp:132
+msgid "Fatal Error"
+msgstr "Fatalna greška"
+
+#: ../src/gtk/glcanvas.cpp:117
+msgid ""
+"This program wasn't compiled with EGL support required under Wayland, "
+"either\n"
+"install EGL libraries and rebuild or run it under X11 backend by setting\n"
+"environment variable GDK_BACKEND=x11 before starting your program."
+msgstr ""
+"Ovaj program nije kompajliran uz EGL podršku koja je neophodna u Wayland-u, "
+"ili\n"
+"instalirajte EGL biblioteke i ponovo kompajlirajte ili pokrenite pod X11 "
+"backendom podešavanjem \n"
+"varijabli okruženja GDK_BACKEND=x11 pre nego što pokrenete vaš program."
+
+#: ../src/gtk/glcanvas.cpp:132
+msgid ""
+"wxGLCanvas is only supported on Wayland and X11 currently.  You may be able "
+"to\n"
+"work around this by setting environment variable GDK_BACKEND=x11 before\n"
+"starting your program."
+msgstr ""
+"wxGLCanvas je trenutno podržan samo uz Wayland i X11.  Možda ćete moći ovo "
+"da zaobiđete\n"
+"podešavanjem varijable okruženja GDK_BACKEND=x11 pre\n"
+"pokretanja vašeg programa."
+
+#: ../src/gtk/mdi.cpp:433
+msgid "MDI child"
+msgstr "MDI child"
+
+#: ../src/gtk/power.cpp:188
+#, fuzzy, c-format
+msgid "Failed to open D-Bus connection to the login manager: %s"
+msgstr "Neuspešno pravljenje veze sa serverom '%s' na temi '%s'"
+
+#: ../src/gtk/power.cpp:214
+#, fuzzy
+msgid "wxWidgets application"
+msgstr "Sakrij aplikaciju"
+
+#: ../src/gtk/power.cpp:226
+msgid "Application needs to keep running"
+msgstr ""
+
+#: ../src/gtk/power.cpp:233
+msgid "Clean up before suspend"
+msgstr ""
+
+#: ../src/gtk/power.cpp:259
+#, fuzzy, c-format
+msgid "Failed to inhibit sleep: %s"
+msgstr "Neuspešno uspostavljanje dialup veze: %s"
+
+#: ../src/gtk/power.cpp:265
+msgid "Unexpected response to D-Bus \"Inhibit\" request."
+msgstr ""
+
+#: ../src/gtk/print.cpp:218
+msgid "Custom size"
+msgstr "Prilagođena veličina"
+
+#: ../src/gtk/print.cpp:752
+#, fuzzy, c-format
+msgid "Error while printing: %s"
+msgstr "Greška pri štampanju:"
+
+#: ../src/gtk/print.cpp:816
+msgid "Page Setup"
+msgstr "Podešavanje stranice"
+
+#: ../src/gtk/webview_webkit.cpp:932
+msgid "Retrieving JavaScript script output is not supported with WebKit v1"
+msgstr "Preuzimanje JavaScript izlaza skripte nije podržano uz WebKit v1"
+
+#: ../src/gtk/webview_webkit2.cpp:1098
+msgid ""
+"Setting proxy is not supported by WebKit, at least version 2.16 is required."
+msgstr ""
+
+#: ../src/gtk/webview_webkit2.cpp:1104
+msgid "This program was compiled without support for setting WebKit proxy."
+msgstr ""
+
+#: ../src/gtk/window.cpp:6289
+msgid ""
+"GTK+ installed on this machine is too old to support screen compositing, "
+"please install GTK+ 2.12 or later."
+msgstr ""
+"GTK+ koji je instaliran na ovom računaru je prestar da bi podržavao deljenje "
+"ekrana, molimo instalirajte GTK+ 2.12 ili noviji."
+
+#: ../src/gtk/window.cpp:6307
+msgid ""
+"Compositing not supported by this system, please enable it in your Window "
+"Manager."
+msgstr ""
+"Deljenje nije podržano od strane ovog sistema, molimo omogućite ga u vašem "
+"upravljaču prozora."
+
+#: ../src/gtk/window.cpp:6318
+msgid ""
+"This program was compiled with a too old version of GTK+, please rebuild "
+"with GTK+ 2.12 or newer."
+msgstr ""
+"Ovaj program je kompajliran sa prestarom GTK+ verzijom, molimo ponovo "
+"kompajlirajte uz GTK+ 2.12 ili noviji."
+
+#: ../src/html/chm.cpp:138
+#, c-format
+msgid "Failed to open CHM archive '%s'."
+msgstr "Otvaranje CHM arhive '%s' nije uspelo."
+
+#: ../src/html/chm.cpp:270
+#, c-format
+msgid "Could not extract %s into %s: %s"
+msgstr "Nemoguće raspakovati %s u %s: %s"
+
+#: ../src/html/chm.cpp:324
+msgid "no error"
+msgstr "Nema greške"
+
+#: ../src/html/chm.cpp:326
+msgid "bad arguments to library function"
+msgstr "Loši argumenti u funkciji biblioteke"
+
+#: ../src/html/chm.cpp:328
+msgid "error opening file"
+msgstr "Greška pri otvaranju datoteke"
+
+#: ../src/html/chm.cpp:330
+msgid "read error"
+msgstr "Greška čitanja"
+
+#: ../src/html/chm.cpp:332
+msgid "write error"
+msgstr "Greška pisanja"
+
+#: ../src/html/chm.cpp:334
+msgid "seek error"
+msgstr "Greška pretrage"
+
+#: ../src/html/chm.cpp:338
+msgid "bad signature"
+msgstr "Loš potpis"
+
+#: ../src/html/chm.cpp:340
+msgid "error in data format"
+msgstr "Greška u formatu podataka"
+
+#: ../src/html/chm.cpp:342
+msgid "checksum error"
+msgstr "Greška kontrolnih podataka"
+
+#: ../src/html/chm.cpp:344
+msgid "compression error"
+msgstr "Greška kompresije"
+
+#: ../src/html/chm.cpp:346
+msgid "decompression error"
+msgstr "Greška dekompresije"
+
+#: ../src/html/chm.cpp:437
+#, c-format
+msgid "Could not locate file '%s'."
+msgstr "Nemoguće pronaći datoteku '%s'."
+
+#: ../src/html/chm.cpp:711
+#, c-format
+msgid "Could not create temporary file '%s'"
+msgstr "Nemoguće napraviti privremenu datoteku '%s'"
+
+#: ../src/html/chm.cpp:718
+#, c-format
+msgid "Extraction of '%s' into '%s' failed."
+msgstr "Raspakivanje '%s' u '%s' nije uspelo."
+
+#: ../src/html/chm.cpp:806 ../src/html/chm.cpp:863
+msgid "CHM handler currently supports only local files!"
+msgstr "CHM obrađivač trenutno podržava samo lokalne datoteke!"
+
+#: ../src/html/chm.cpp:827
+msgid "Link contained '//', converted to absolute link."
+msgstr "Link je sadržao '//', pretvoren je u apsolutan link."
+
+#: ../src/html/helpctrl.cpp:59
+#, c-format
+msgid "Help: %s"
+msgstr "Pomoć: %s"
+
+#: ../src/html/helpctrl.cpp:155
+#, c-format
+msgid "Adding book %s"
+msgstr "Dodavanje knjige %s"
+
+#: ../src/html/helpdata.cpp:295
+#, c-format
+msgid "Cannot open contents file: %s"
+msgstr "Nemoguće otvoriti datoteku sadržaja: %s"
+
+#: ../src/html/helpdata.cpp:309
+#, c-format
+msgid "Cannot open index file: %s"
+msgstr "Nemoguće otvoriti datoteku indeksa: %s"
+
+#: ../src/html/helpdata.cpp:643
+msgid "noname"
+msgstr "Neimenovano"
+
+#: ../src/html/helpdata.cpp:652
+#, c-format
+msgid "Cannot open HTML help book: %s"
+msgstr "Nemoguće otvoriti knjigu HTML pomoći: %s"
+
+#: ../src/html/helpwnd.cpp:315
+msgid "Displays help as you browse the books on the left."
+msgstr "Prikazuje pomoć dok se krećete po knjigama na levoj strani."
+
+#: ../src/html/helpwnd.cpp:411 ../src/html/helpwnd.cpp:1100
+#: ../src/html/helpwnd.cpp:1735
+msgid "(bookmarks)"
+msgstr "(oznake)"
+
+#: ../src/html/helpwnd.cpp:424
+msgid "Add current page to bookmarks"
+msgstr "Dodaj trenutnu stranicu u oznake"
+
+#: ../src/html/helpwnd.cpp:425
+msgid "Remove current page from bookmarks"
+msgstr "Ukloni trenutnu stranicu iz oznaka"
+
+#: ../src/html/helpwnd.cpp:470
+msgid "Contents"
+msgstr "Sadržaj"
+
+#: ../src/html/helpwnd.cpp:485
+msgid "Find"
+msgstr "Pronađi"
+
+#: ../src/html/helpwnd.cpp:487
+msgid "Show all"
+msgstr "Prikaži sve"
+
+#: ../src/html/helpwnd.cpp:497
+msgid ""
+"Display all index items that contain given substring. Search is case "
+"insensitive."
+msgstr ""
+"Prikaži sve stavke indeksa koje sadrže zadani pojam. Pretraga nije osetljiva "
+"na veličinu slova."
+
+#: ../src/html/helpwnd.cpp:498
+msgid "Show all items in index"
+msgstr "Prikaži sve stavke u indeksu"
+
+#: ../src/html/helpwnd.cpp:528
+msgid "Case sensitive"
+msgstr "Osetljivo na veličinu slova"
+
+#: ../src/html/helpwnd.cpp:529
+msgid "Whole words only"
+msgstr "Samo cele reči"
+
+#: ../src/html/helpwnd.cpp:532
+msgid ""
+"Search contents of help book(s) for all occurrences of the text you typed "
+"above"
+msgstr ""
+"Pretražuje sadržaj knjiga pomoći za sve pojave teksta kojeg ste upisali"
+
+#: ../src/html/helpwnd.cpp:653
+msgid "Show/hide navigation panel"
+msgstr "Prikaži/sakrij panel navigacije"
+
+#: ../src/html/helpwnd.cpp:655
+msgid "Go back"
+msgstr "Nazad"
+
+#: ../src/html/helpwnd.cpp:656
+msgid "Go forward"
+msgstr "Napred"
+
+#: ../src/html/helpwnd.cpp:658
+msgid "Go one level up in document hierarchy"
+msgstr "Pomeri se gore jedan nivo u hierarhiji dokumenta"
+
+#: ../src/html/helpwnd.cpp:666 ../src/html/helpwnd.cpp:1547
+msgid "Open HTML document"
+msgstr "Otvori HTML dokument"
+
+#: ../src/html/helpwnd.cpp:670
+msgid "Print this page"
+msgstr "Štampaj ovu stranicu"
+
+#: ../src/html/helpwnd.cpp:674
+msgid "Display options dialog"
+msgstr "Prikaži dijalog opcija"
+
+#: ../src/html/helpwnd.cpp:795
+msgid "Please choose the page to display:"
+msgstr "Molimo izaberite stranicu za prikazivanje:"
+
+#: ../src/html/helpwnd.cpp:796
+msgid "Help Topics"
+msgstr "Teme pomoći"
+
+#: ../src/html/helpwnd.cpp:852
+msgid "Searching..."
+msgstr "Pretraživanje..."
+
+#: ../src/html/helpwnd.cpp:853
+msgid "No matching page found yet"
+msgstr "Nijedna stranica koja se podudara još uvek nije pronađena"
+
+#: ../src/html/helpwnd.cpp:870
+#, c-format
+msgid "Found %i matches"
+msgstr "Pronađeno %i podudaranja"
+
+#: ../src/html/helpwnd.cpp:958
+msgid "(Help)"
+msgstr "(pomoć)"
+
+#: ../src/html/helpwnd.cpp:1026
+#, c-format
+msgid "%d of %lu"
+msgstr "%d od %lu"
+
+#: ../src/html/helpwnd.cpp:1028
+#, c-format
+msgid "%lu of %lu"
+msgstr "%lu od %lu"
+
+#: ../src/html/helpwnd.cpp:1047
+msgid "Search in all books"
+msgstr "Pretraži u svim knjigama"
+
+#: ../src/html/helpwnd.cpp:1193
+msgid "Help Browser Options"
+msgstr "Opcije pretraživača pomoći"
+
+#: ../src/html/helpwnd.cpp:1198
+msgid "Normal font:"
+msgstr "Normalni font:"
+
+#: ../src/html/helpwnd.cpp:1199
+msgid "Fixed font:"
+msgstr "Fiksni font:"
+
+#: ../src/html/helpwnd.cpp:1200
+msgid "Font size:"
+msgstr "Veličina fonta:"
+
+#: ../src/html/helpwnd.cpp:1245
+msgid "font size"
+msgstr "Veličina fonta"
+
+#: ../src/html/helpwnd.cpp:1256
+msgid "Normal face<br>and <u>underlined</u>. "
+msgstr "Normalni font<br>i<u>podvučeno</u>. "
+
+#: ../src/html/helpwnd.cpp:1257
+msgid "<i>Italic face.</i> "
+msgstr "<i>Iskošeni font.</i> "
+
+#: ../src/html/helpwnd.cpp:1258
+msgid "<b>Bold face.</b> "
+msgstr "<b>Podebljani font.</b> "
+
+#: ../src/html/helpwnd.cpp:1259
+msgid "<b><i>Bold italic face.</i></b><br>"
+msgstr "<b><i>Podebljano iskošeni font.</i></b><br>"
+
+#: ../src/html/helpwnd.cpp:1262
+msgid "Fixed size face.<br> <b>bold</b> <i>italic</i> "
+msgstr "Font fiksne veličine.<br> <b>podebljano</b> <i>iskošeno</i> "
+
+#: ../src/html/helpwnd.cpp:1263
+msgid "<b><i>bold italic <u>underlined</u></i></b><br>"
+msgstr "<b><i>Podebljano iskošeno<u>Podvučeno</u></i></b><br>"
+
+#: ../src/html/helpwnd.cpp:1524
+msgid "Help Printing"
+msgstr "Pomoć za štampanje"
+
+#: ../src/html/helpwnd.cpp:1527
+msgid "Cannot print empty page."
+msgstr "Nemoguće štampati praznu stranicu."
+
+#: ../src/html/helpwnd.cpp:1540
+msgid "HTML files (*.html;*.htm)|*.html;*.htm|"
+msgstr "HTML datoteke (*.html;*.htm)|*.html;*.htm|"
+
+#: ../src/html/helpwnd.cpp:1541
+msgid "Help books (*.htb)|*.htb|Help books (*.zip)|*.zip|"
+msgstr "Knjige pomoći (*.htb)|*.htb|knjige pomoći (*.zip)|*.zip|"
+
+#: ../src/html/helpwnd.cpp:1542
+msgid "HTML Help Project (*.hhp)|*.hhp|"
+msgstr "HTML projekat pomoći (*.hhp)|*.hhp|"
+
+#: ../src/html/helpwnd.cpp:1544
+msgid "Compressed HTML Help file (*.chm)|*.chm|"
+msgstr "Kompresovana HTML datoteka pomoći (*.chm)|*.chm|"
+
+#: ../src/html/helpwnd.cpp:1671
+#, c-format
+msgid "%i of %u"
+msgstr "%i od %u"
+
+#: ../src/html/helpwnd.cpp:1709
+#, c-format
+msgid "%u of %u"
+msgstr "%u od %u"
+
+#: ../src/html/htmlfilt.cpp:134
+#, c-format
+msgid "Cannot open HTML document: %s"
+msgstr "Nemoguće otvoriti HTML dokument: %s"
+
+#: ../src/html/htmlwin.cpp:599
+msgid "Connecting..."
+msgstr "Povezivanje..."
+
+#: ../src/html/htmlwin.cpp:616
+#, c-format
+msgid "Unable to open requested HTML document: %s"
+msgstr "Nemoguće otvoriti zahtevani HTML dokument: %s"
+
+#: ../src/html/htmlwin.cpp:630
+msgid "Loading : "
+msgstr "Učitavanje:"
+
+#: ../src/html/htmlwin.cpp:673
+msgid "Done"
+msgstr "Gotovo"
+
+#: ../src/html/htmlwin.cpp:723
+#, c-format
+msgid "HTML anchor %s does not exist."
+msgstr "HTML anchor %s ne postoji."
+
+#: ../src/html/htmlwin.cpp:1057
+#, c-format
+msgid "Copied to clipboard:\"%s\""
+msgstr "Kopirano u privremenu memoriju:\"%s\""
+
+#: ../src/html/htmprint.cpp:269
+msgid ""
+"This document doesn't fit on the page horizontally and will be truncated "
+"when it is printed."
+msgstr ""
+"Ovaj dokument se horizontalno ne uklapa na stranicu i  biće smanjen u toku "
+"štampanja."
+
+#: ../src/html/htmprint.cpp:285
+#, c-format
+msgid ""
+"The document \"%s\" doesn't fit on the page horizontally and will be "
+"truncated if printed.\n"
+"\n"
+"Would you like to proceed with printing it nevertheless?"
+msgstr ""
+"Dokument \"%s\" se ne uklapa na stranici horizontalno i biće smanjen ako se "
+"štampa.\n"
+"\n"
+"Da li ipak želite da ga štampate?"
+
+#: ../src/html/htmprint.cpp:296
+msgid ""
+"If possible, try changing the layout parameters to make the printout more "
+"narrow."
+msgstr ""
+"Ako je moguće, pokušajte da promenite parametre izgleda da biste učinili "
+"štampanje užim."
+
+#: ../src/html/htmprint.cpp:445
+msgid ": file does not exist!"
+msgstr ": Datoteka ne postoji!"
+
+#. TRANSLATORS: %s may be a document title.
+#: ../src/html/htmprint.cpp:717
+#, fuzzy, c-format
+msgid "%s Preview"
+msgstr "Pregled"
+
+#: ../src/html/htmprint.cpp:755 ../src/richtext/richtextprint.cpp:618
+msgid ""
+"There was a problem during page setup: you may need to set a default printer."
+msgstr ""
+"Došlo je do problema pri podešavanju stranice: možda ćete morati da podesite "
+"podrazumevani štampač."
+
+#: ../src/msw/clipbrd.cpp:80
+msgid "Failed to open the clipboard."
+msgstr "Otvaranje privremene memorije nije uspelo."
+
+#: ../src/msw/clipbrd.cpp:101
+msgid "Failed to close the clipboard."
+msgstr "Zatvaranje privremene memorije nije uspelo."
+
+#: ../src/msw/clipbrd.cpp:113
+msgid "Failed to empty the clipboard."
+msgstr "Pražnjenje privremene memorije nije uspelo."
+
+#: ../src/msw/clipbrd.cpp:284
+msgid "Failed to put data on the clipboard"
+msgstr "Stavljanje podataka u privremenu memoriju nije uspelo"
+
+#: ../src/msw/clipbrd.cpp:326
+msgid "Failed to get data from the clipboard"
+msgstr "Preuzimanje podataka iz privremene memorije nije uspelo"
+
+#: ../src/msw/clipbrd.cpp:363
+msgid "Failed to retrieve the supported clipboard formats"
+msgstr "Preuzimanje podržanih formata privremene memorije nije uspelo"
+
+#: ../src/msw/colordlg.cpp:228
+#, c-format
+msgid "Colour selection dialog failed with error %0lx."
+msgstr "Došlo je do greške u dijalogu izbora boje %0lx."
+
+#: ../src/msw/cursor.cpp:141
+msgid "Failed to create cursor."
+msgstr "Pravljenje kursora nije uspelo."
+
+#: ../src/msw/dde.cpp:279
+#, c-format
+msgid "Failed to register DDE server '%s'"
+msgstr "Registracija DDE servera '%s' nije uspela"
+
+#: ../src/msw/dde.cpp:300
+#, c-format
+msgid "Failed to unregister DDE server '%s'"
+msgstr "Deregistracija DDE servera '%s' nije uspela"
+
+#: ../src/msw/dde.cpp:428
+#, c-format
+msgid "Failed to create connection to server '%s' on topic '%s'"
+msgstr "Neuspešno pravljenje veze sa serverom '%s' na temi '%s'"
+
+#: ../src/msw/dde.cpp:655
+msgid "DDE poke request failed"
+msgstr "DDE poke zahtev nije uspeo"
+
+#: ../src/msw/dde.cpp:674
+msgid "Failed to establish an advise loop with DDE server"
+msgstr "Ostvarivanje advise loopa sa DDE serverom nije uspelo"
+
+#: ../src/msw/dde.cpp:693
+msgid "Failed to terminate the advise loop with DDE server"
+msgstr "Prekidanje advise loopa sa DDE serverom nije uspelo"
+
+#: ../src/msw/dde.cpp:768
+msgid "Failed to send DDE advise notification"
+msgstr "Slanje DDE advise obaveštenja nije uspelo"
+
+#: ../src/msw/dde.cpp:1085
+msgid "Failed to create DDE string"
+msgstr "Pravljenje DDE niza nije uspelo"
+
+#: ../src/msw/dde.cpp:1131
+msgid "no DDE error."
+msgstr "Nema DDE greške."
+
+#: ../src/msw/dde.cpp:1135
+msgid "a request for a synchronous advise transaction has timed out."
+msgstr "Zahtev za sinhronu advise transakciju je istekao."
+
+#: ../src/msw/dde.cpp:1138
+msgid "the response to the transaction caused the DDE_FBUSY bit to be set."
+msgstr "Odgovor na transakciju je izazvao da DDE_FBUSY bit bude postavljen."
+
+#: ../src/msw/dde.cpp:1141
+msgid "a request for a synchronous data transaction has timed out."
+msgstr "Zahtev za sinhronu transakciju podataka je istekao."
+
+#: ../src/msw/dde.cpp:1144
+msgid ""
+"a DDEML function was called without first calling the DdeInitialize "
+"function,\n"
+"or an invalid instance identifier\n"
+"was passed to a DDEML function."
+msgstr ""
+"DDEML funkcija je pozvana pre nego što se prvo pozvala DdeInitialize "
+"funkcija,\n"
+"ili je neispravan instance identifier\n"
+"prosleđen DDEML funkciji."
+
+#: ../src/msw/dde.cpp:1147
+msgid ""
+"an application initialized as APPCLASS_MONITOR has\n"
+"attempted to perform a DDE transaction,\n"
+"or an application initialized as APPCMD_CLIENTONLY has \n"
+"attempted to perform server transactions."
+msgstr ""
+"Aplikacija koja je inicijalizovana kao APPCLASS_MONITOR je\n"
+"pokušala da izvrši DDE transakciju,\n"
+"ili je aplikacija inicijalizovana kao APPCMD_CLIENTONLY\n"
+"pokušala da izvrši serverske transakcije."
+
+#: ../src/msw/dde.cpp:1150
+msgid "a request for a synchronous execute transaction has timed out."
+msgstr "Zahtev za sinhronu izvršnu transakciju je istekao."
+
+#: ../src/msw/dde.cpp:1153
+msgid "a parameter failed to be validated by the DDEML."
+msgstr "Parametar nije uspešno potvrđen od strane DDEML."
+
+#: ../src/msw/dde.cpp:1156
+msgid "a DDEML application has created a prolonged race condition."
+msgstr "DDEML je napravila produženi race condition."
+
+#: ../src/msw/dde.cpp:1159
+msgid "a memory allocation failed."
+msgstr "Dodeljivanje memorije nije uspelo."
+
+#: ../src/msw/dde.cpp:1162
+msgid "a client's attempt to establish a conversation has failed."
+msgstr "Pokušaj klijenta da ostvari razgovor nije uspeo."
+
+#: ../src/msw/dde.cpp:1165
+msgid "a transaction failed."
+msgstr "Transakcija nije uspela."
+
+#: ../src/msw/dde.cpp:1168
+msgid "a request for a synchronous poke transaction has timed out."
+msgstr "Zahtev za sinhronu poke transakciju je istekao."
+
+#: ../src/msw/dde.cpp:1171
+msgid "an internal call to the PostMessage function has failed. "
+msgstr "Interni poziv PostMessage funkciji nije uspeo. "
+
+#: ../src/msw/dde.cpp:1174
+msgid "reentrancy problem."
+msgstr "Problem pri ponovnom ulaženju."
+
+#: ../src/msw/dde.cpp:1177
+msgid ""
+"a server-side transaction was attempted on a conversation\n"
+"that was terminated by the client, or the server\n"
+"terminated before completing a transaction."
+msgstr ""
+"Transakcija od strane servera je pokušana na razgovoru\n"
+"koji je završen od strane klijenta, ili ju je server\n"
+"završio pre potpune transakcije."
+
+#: ../src/msw/dde.cpp:1180
+msgid "an internal error has occurred in the DDEML."
+msgstr "Došlo je do interne greške u DDEML-u."
+
+#: ../src/msw/dde.cpp:1183
+msgid "a request to end an advise transaction has timed out."
+msgstr "Zahtev za završetak advise transakcije je istekao."
+
+#: ../src/msw/dde.cpp:1186
+msgid ""
+"an invalid transaction identifier was passed to a DDEML function.\n"
+"Once the application has returned from an XTYP_XACT_COMPLETE callback,\n"
+"the transaction identifier for that callback is no longer valid."
+msgstr ""
+"Neispravan identifikator transakcije je prosleđen DDEML funkciji.\n"
+"Nakon što se aplikacija vrati iz XTYP_XACT_COMPLETE callbacka,\n"
+"identifikator transakcije iz tog callbacka više ne važi."
+
+#: ../src/msw/dde.cpp:1189
+#, c-format
+msgid "Unknown DDE error %08x"
+msgstr "Nepoznata DDE greška %08x"
+
+#: ../src/msw/dialup.cpp:343
+msgid ""
+"Dial up functions are unavailable because the remote access service (RAS) is "
+"not installed on this machine. Please install it."
+msgstr ""
+"Dial up funkcije nisu dostupne zato što servis daljinskog pristupa (RAS) "
+"nije instaliran na ovom uređaju. Molimo instalirajte ga."
+
+#: ../src/msw/dialup.cpp:402
+#, c-format
+msgid ""
+"The version of remote access service (RAS) installed on this machine is too "
+"old, please upgrade (the following required function is missing: %s)."
+msgstr ""
+"Verzija servisa daljinskog pristupa (RAS) koja je instalirana na ovom "
+"uređaju je prestara, molimo ažurirajte je (sledeća neophodna funkcija "
+"nedostaje: %s)."
+
+#: ../src/msw/dialup.cpp:437
+msgid "Failed to retrieve text of RAS error message"
+msgstr "Neuspešno preuzimanje teksta RAS poruke sa greškom"
+
+#: ../src/msw/dialup.cpp:440
+#, c-format
+msgid "unknown error (error code %08x)."
+msgstr "Nepoznata greška (kod greške %08x)."
+
+#: ../src/msw/dialup.cpp:492
+#, c-format
+msgid "Cannot find active dialup connection: %s"
+msgstr "Nemoguće pronaći aktivnu dialup vezu: %s"
+
+#: ../src/msw/dialup.cpp:513
+msgid "Several active dialup connections found, choosing one randomly."
+msgstr ""
+"Više aktivnih dialup veza je pronađeno, jedna će nasumično biti izabrana."
+
+#: ../src/msw/dialup.cpp:598 ../src/msw/dialup.cpp:832
+#, c-format
+msgid "Failed to establish dialup connection: %s"
+msgstr "Neuspešno uspostavljanje dialup veze: %s"
+
+#: ../src/msw/dialup.cpp:664
+#, c-format
+msgid "Failed to get ISP names: %s"
+msgstr "Neuspešno preuzimanje imena servisnih provajdera: %s"
+
+#: ../src/msw/dialup.cpp:712
+msgid "Failed to connect: no ISP to dial."
+msgstr "Neuspešno povezivanje: nema servisnog provajdera za biranje."
+
+#: ../src/msw/dialup.cpp:732
+msgid "Choose ISP to dial"
+msgstr "Izaberite servisnog provajdera za biranje"
+
+#: ../src/msw/dialup.cpp:733
+msgid "Please choose which ISP do you want to connect to"
+msgstr "Molimo izaberite sa kojim  servisnim provajderom želite da se povežete"
+
+#: ../src/msw/dialup.cpp:766
+msgid "Failed to connect: missing username/password."
+msgstr "Neuspešno povezivanje: Nedostaje korisničko ime ili lozinka."
+
+#: ../src/msw/dialup.cpp:796
+msgid "Cannot find the location of address book file"
+msgstr "Nemoguće pronaći lokaciju  datoteke adresara"
+
+#: ../src/msw/dialup.cpp:827
+#, c-format
+msgid "Failed to initiate dialup connection: %s"
+msgstr "Neuspešno uspostavljanje dialup veze: %s"
+
+#: ../src/msw/dialup.cpp:897
+msgid "Cannot hang up - no active dialup connection."
+msgstr "Nemoguće prekinuti - nema aktivne dialup veze."
+
+#: ../src/msw/dialup.cpp:907
+#, c-format
+msgid "Failed to terminate the dialup connection: %s"
+msgstr "Nemoguće prekinuti dialup vezu: %s"
+
+#: ../src/msw/dib.cpp:313
+#, c-format
+msgid "Failed to save the bitmap image to file \"%s\"."
+msgstr "Neuspešno čuvanje bitmap slike u datoteku \"%s\"."
+
+#: ../src/msw/dib.cpp:543
+#, c-format
+msgid "Failed to allocate %luKb of memory for bitmap data."
+msgstr "Neuspešno dodeljivanje %luKb memorije za bitmap podatke."
+
+#: ../src/msw/dir.cpp:241
+#, c-format
+msgid "Cannot enumerate files in directory '%s'"
+msgstr "Nemoguća enumeracija datoteka u direktorijumu '%s'"
+
+#: ../src/msw/dirdlg.cpp:368
+msgid "Couldn't obtain folder name"
+msgstr "Nemoguće dobiti ime foldera"
+
+#: ../src/msw/dlmsw.cpp:163
+#, c-format
+msgid "(error %d: %s)"
+msgstr "(Greška %d: %s)"
+
+#: ../src/msw/dragimag.cpp:143 ../src/msw/dragimag.cpp:178
+#: ../src/msw/imaglist.cpp:309 ../src/msw/imaglist.cpp:331
+msgid "Couldn't add an image to the image list."
+msgstr "Nemoguće dodati sliku u listu slika."
+
+#: ../src/msw/enhmeta.cpp:94
+#, c-format
+msgid "Failed to load metafile from file \"%s\"."
+msgstr "Neuspešno učitavanje meta datoteke iz datoteke \"%s\"."
+
+#: ../src/msw/fdrepdlg.cpp:412
+#, c-format
+msgid "Failed to create the standard find/replace dialog (error code %d)"
+msgstr ""
+"Neuspešno pravljenje standardnog dijaloga pronalaženja uz zamenu (kod greške "
+"%d)"
+
+#: ../src/msw/filedlg.cpp:1241
+msgid "Access to the file system is not allowed from secure desktop."
+msgstr ""
+
+#: ../src/msw/filedlg.cpp:1242
+msgid "Security warning"
+msgstr ""
+
+#: ../src/msw/filedlg.cpp:1533
+#, c-format
+msgid "File dialog failed with error code %0lx."
+msgstr "Došlo je do greške u dijalogu datoteke uz kod %0lx."
+
+#: ../src/msw/font.cpp:1120
+#, c-format
+msgid "Font file \"%s\" couldn't be loaded"
+msgstr "Datoteka fonta \"%s\" nije mogla biti učitana"
+
+#: ../src/msw/fontdlg.cpp:220
+#, c-format
+msgid "Common dialog failed with error code %0lx."
+msgstr "Došlo je do greške u zajedničkom dijalogu uz kod %0lx."
+
+#: ../src/msw/fswatcher.cpp:67
+msgid "Ungraceful worker thread termination"
+msgstr "Neočekivani završetak worker threada"
+
+#: ../src/msw/fswatcher.cpp:81
+msgid "Unable to create IOCP worker thread"
+msgstr "Nemoguće napravit iIOCP worker thread"
+
+#: ../src/msw/fswatcher.cpp:88
+msgid "Unable to start IOCP worker thread"
+msgstr "Nemoguće započeti IOCP worker thread"
+
+#: ../src/msw/fswatcher.cpp:140
+msgid "Monitoring individual files for changes is not supported currently."
+msgstr "Praćenje promena u pojedinačnim datotekama trenutno nije podržano."
+
+#: ../src/msw/fswatcher.cpp:165
+#, c-format
+msgid "Unable to set up watch for '%s'"
+msgstr "Nemoguće podesiti praćenje za '%s'"
+
+#: ../src/msw/fswatcher.cpp:466
+#, c-format
+msgid "Can't monitor non-existent directory \"%s\" for changes."
+msgstr "Nemoguće pratiti promene u nepostojećem direktorijumu \"%s\"."
+
+#: ../src/msw/glcanvas.cpp:577 ../src/unix/glx11.cpp:507
+msgid "OpenGL 3.0 or later is not supported by the OpenGL driver."
+msgstr "OpenGL 3.0 ili noviji nije podržan od strane OpenGL drajvera."
+
+#: ../src/msw/glcanvas.cpp:601 ../src/osx/glcanvas_osx.cpp:395
+#: ../src/unix/glegl.cpp:304 ../src/unix/glx11.cpp:553
+msgid "Couldn't create OpenGL context"
+msgstr "Nemoguće napraviti OpenGL kontekst"
+
+#: ../src/msw/glcanvas.cpp:1294
+msgid "Failed to initialize OpenGL"
+msgstr "Neuspešna OpenGL inicijalizacija"
+
+#: ../src/msw/graphicsd2d.cpp:607
+msgid "Could not register custom DirectWrite font loader."
+msgstr "Nemoguće registrovati prilagođeni DirectWrite čitač fontova."
+
+#: ../src/msw/helpchm.cpp:48
+msgid ""
+"MS HTML Help functions are unavailable because the MS HTML Help library is "
+"not installed on this machine. Please install it."
+msgstr ""
+"MS HTML funkcije pomoći su  nedostupne zato što MS HTML biblioteka pomoći "
+"nije instalirana na ovom uređaju. Molimo instalirajte je."
+
+#: ../src/msw/helpchm.cpp:55
+msgid "Failed to initialize MS HTML Help."
+msgstr "Neuspešna inicijalizacija MS HTML pomoći."
+
+#: ../src/msw/iniconf.cpp:458
+#, c-format
+msgid "Can't delete the INI file '%s'"
+msgstr "Nemoguće obrisati INI datoteku '%s'"
+
+#: ../src/msw/listctrl.cpp:995
+#, c-format
+msgid "Couldn't retrieve information about list control item %d."
+msgstr "Nemoguće preuzeti informacije o kontrolnoj stavki liste %d."
+
+#: ../src/msw/mdi.cpp:170 ../src/qt/mdi.cpp:253
+msgid "&Cascade"
+msgstr "&Kaskadno"
+
+#: ../src/msw/mdi.cpp:171
+msgid "Tile &Horizontally"
+msgstr "&Horizontalne pločice"
+
+#: ../src/msw/mdi.cpp:172
+msgid "Tile &Vertically"
+msgstr "&Vertikalne pločice"
+
+#: ../src/msw/mdi.cpp:174
+msgid "&Arrange Icons"
+msgstr "&Poređaj ikonice"
+
+#: ../src/msw/mdi.cpp:621
+msgid "Failed to create MDI parent frame."
+msgstr "Neuspešno pravljenje MDI glavnog okvira."
+
+#: ../src/msw/mimetype.cpp:234
+#, c-format
+msgid "Failed to create registry entry for '%s' files."
+msgstr "Neuspešno pravljenje unosa u registru za '%s' datoteke."
+
+#: ../src/msw/ole/automtn.cpp:495
+#, c-format
+msgid "Failed to find CLSID of \"%s\""
+msgstr "Neuspešno pronalaženje CLSID-a za \"%s\""
+
+#: ../src/msw/ole/automtn.cpp:512
+#, c-format
+msgid "Failed to create an instance of \"%s\""
+msgstr "Neuspešno pravljenje instance za \"%s\""
+
+#: ../src/msw/ole/automtn.cpp:552
+#, c-format
+msgid "Cannot get an active instance of \"%s\""
+msgstr "Nemoguće preuzeti aktivnu instancu za \"%s\""
+
+#: ../src/msw/ole/automtn.cpp:564
+#, c-format
+msgid "Failed to get OLE automation interface for \"%s\""
+msgstr "Neuspešno preuzimanje OLE interfejsa automatizacije za \"%s\""
+
+#: ../src/msw/ole/automtn.cpp:621
+msgid "Unknown name or named argument."
+msgstr "Nepoznato ime ili ime argumenta."
+
+#: ../src/msw/ole/automtn.cpp:625
+msgid "Incorrect number of arguments."
+msgstr "Pogrešan broj argumenata."
+
+#: ../src/msw/ole/automtn.cpp:637
+msgid "Unknown exception"
+msgstr "Nepoznat izuzetak"
+
+#: ../src/msw/ole/automtn.cpp:642
+msgid "Method or property not found."
+msgstr "Metod ili svojstvo nije pronađeno."
+
+#: ../src/msw/ole/automtn.cpp:646
+msgid "Overflow while coercing argument values."
+msgstr "Prelivanje u toku raščlanjivanja vrednosti argumenta."
+
+#: ../src/msw/ole/automtn.cpp:650
+msgid "Object implementation does not support named arguments."
+msgstr "Implementacija objekta ne podržava imenovane argumente."
+
+#: ../src/msw/ole/automtn.cpp:654
+msgid "The locale ID is unknown."
+msgstr "ID lokalizacije je nepoznat."
+
+#: ../src/msw/ole/automtn.cpp:658
+msgid "Missing a required parameter."
+msgstr "Neophodan parametar nedostaje."
+
+#: ../src/msw/ole/automtn.cpp:662
+#, c-format
+msgid "Argument %u not found."
+msgstr "Argument %u nije pronađen."
+
+#: ../src/msw/ole/automtn.cpp:666
+#, c-format
+msgid "Type mismatch in argument %u."
+msgstr "Pogrešno podudaranje vrsta u argumentu %u."
+
+#: ../src/msw/ole/automtn.cpp:670
+msgid "The system cannot find the file specified."
+msgstr "Sistem ne može da pronađe određenu datoteku."
+
+#: ../src/msw/ole/automtn.cpp:674
+msgid "Class not registered."
+msgstr "Klasa nije registrovana."
+
+#: ../src/msw/ole/automtn.cpp:678
+#, c-format
+msgid "Unknown error %08x"
+msgstr "Nepoznata greška %08x"
+
+#: ../src/msw/ole/automtn.cpp:682
+#, c-format
+msgid "OLE Automation error in %s: %s"
+msgstr "OLE greška automatizacije u %s: %s"
+
+#: ../src/msw/ole/dataobj.cpp:385
+#, c-format
+msgid "Couldn't register clipboard format '%s'."
+msgstr "Nemoguće registrovati format privremene memorije '%s'."
+
+#: ../src/msw/ole/dataobj.cpp:402
+#, c-format
+msgid "The clipboard format '%d' doesn't exist."
+msgstr "Format privremene memorije '%d' ne postoji."
+
+#: ../src/msw/progdlg.cpp:1025
+msgid "Skip"
+msgstr "Preskoči"
+
+#: ../src/msw/registry.cpp:141
+#, c-format
+msgid "unknown (%lu)"
+msgstr "Nepoznato (%lu)"
+
+#: ../src/msw/registry.cpp:409
+#, c-format
+msgid "Can't get info about registry key '%s'"
+msgstr "Nemoguće preuzeti informacije o ključu registra '%s'"
+
+#: ../src/msw/registry.cpp:445
+#, c-format
+msgid "Can't open registry key '%s'"
+msgstr "Nemoguće otvoriti ključ registra '%s'"
+
+#: ../src/msw/registry.cpp:478
+#, c-format
+msgid "Can't create registry key '%s'"
+msgstr "Nemoguće napraviti ključ registra '%s'"
+
+#: ../src/msw/registry.cpp:497
+#, c-format
+msgid "Can't close registry key '%s'"
+msgstr "Nemoguće zatvoriti ključ registra '%s'"
+
+#: ../src/msw/registry.cpp:512
+#, c-format
+msgid "Registry value '%s' already exists."
+msgstr "Vrednost registra '%s' već postoji."
+
+#: ../src/msw/registry.cpp:520
+#, c-format
+msgid "Failed to rename registry value '%s' to '%s'."
+msgstr "Neuspešno preimenovanje vrednosti registra iz '%s' u '%s'."
+
+#: ../src/msw/registry.cpp:575
+#, c-format
+msgid "Can't copy values of unsupported type %d."
+msgstr "Nemoguće kopirati vrednosti vrste koja nije podržana %d."
+
+#: ../src/msw/registry.cpp:586
+#, c-format
+msgid "Registry key '%s' does not exist, cannot rename it."
+msgstr "Ključ registra '%s' ne postoji, nemoguće preimenovati ga."
+
+#: ../src/msw/registry.cpp:617
+#, c-format
+msgid "Registry key '%s' already exists."
+msgstr "Ključ registra '%s' već postoji."
+
+#: ../src/msw/registry.cpp:625
+#, c-format
+msgid "Failed to rename the registry key '%s' to '%s'."
+msgstr "Neuspešno preimenovanje ključa registra '%s' u '%s'."
+
+#: ../src/msw/registry.cpp:670
+#, c-format
+msgid "Failed to copy the registry subkey '%s' to '%s'."
+msgstr "Neuspešno kopiranje podključa registra '%s' u '%s'."
+
+#: ../src/msw/registry.cpp:683
+#, c-format
+msgid "Failed to copy registry value '%s'"
+msgstr "Neuspešno kopiranje vrednosti registra '%s'"
+
+#: ../src/msw/registry.cpp:692
+#, c-format
+msgid "Failed to copy the contents of registry key '%s' to '%s'."
+msgstr "Neuspešno kopiranje sadržaja ključa registra '%s' u '%s'."
+
+#: ../src/msw/registry.cpp:718
+#, c-format
+msgid ""
+"Registry key '%s' is needed for normal system operation,\n"
+"deleting it will leave your system in unusable state:\n"
+"operation aborted."
+msgstr ""
+"Ključ registra '%s' je neophodan za neometan rad sistema,\n"
+"njegovo brisanje će izazvati nemogućnost korišćenja sistema:\n"
+"radnja otkazana."
+
+#: ../src/msw/registry.cpp:754
+#, c-format
+msgid "Can't delete key '%s'"
+msgstr "Nemoguće obrisati ključ '%s'"
+
+#: ../src/msw/registry.cpp:782
+#, c-format
+msgid "Can't delete value '%s' from key '%s'"
+msgstr "Nemoguće obrisati vrednost '%s' iz ključa '%s'"
+
+#: ../src/msw/registry.cpp:855 ../src/msw/registry.cpp:887
+#: ../src/msw/registry.cpp:929 ../src/msw/registry.cpp:1000
+#, c-format
+msgid "Can't read value of key '%s'"
+msgstr "Nemoguće pročitati vrednost ključa '%s'"
+
+#: ../src/msw/registry.cpp:873 ../src/msw/registry.cpp:915
+#: ../src/msw/registry.cpp:963 ../src/msw/registry.cpp:1106
+#, c-format
+msgid "Can't set value of '%s'"
+msgstr "Nemoguće postaviti vrednost za '%s'"
+
+#: ../src/msw/registry.cpp:894 ../src/msw/registry.cpp:943
+#, c-format
+msgid "Registry value \"%s\" is not numeric (but of type %s)"
+msgstr "Vrednost registra \"%s\" nije brojčana (ali je vrste %s)"
+
+#: ../src/msw/registry.cpp:979
+#, c-format
+msgid "Registry value \"%s\" is not binary (but of type %s)"
+msgstr "Vrednost registra \"%s\" nije binarna (ali je vrste %s)"
+
+#: ../src/msw/registry.cpp:1028
+#, c-format
+msgid "Registry value \"%s\" is not text (but of type %s)"
+msgstr "Vrednost registra \"%s\" nije tekstualna (ali je vrste %s)"
+
+#: ../src/msw/registry.cpp:1089
+#, c-format
+msgid "Can't read value of '%s'"
+msgstr "Nemoguće pročitati vrednost za '%s'"
+
+#: ../src/msw/registry.cpp:1157
+#, c-format
+msgid "Can't enumerate values of key '%s'"
+msgstr "Nemoguća enumeracija vrednosti ključa '%s'"
+
+#: ../src/msw/registry.cpp:1196
+#, c-format
+msgid "Can't enumerate subkeys of key '%s'"
+msgstr "Nemoguća enumeracija podključeva ključa '%s'"
+
+#: ../src/msw/registry.cpp:1262
+#, c-format
+msgid ""
+"Exporting registry key: file \"%s\" already exists and won't be overwritten."
+msgstr ""
+"Izvoz ključa registra: datoteka \"%s\" već postoji i neće biti zamenjena."
+
+#: ../src/msw/registry.cpp:1411
+#, c-format
+msgid "Can't export value of unsupported type %d."
+msgstr "Nemoguće izvoziti vrednosti vrste koja nije podržana %d."
+
+#: ../src/msw/registry.cpp:1427
+#, c-format
+msgid "Ignoring value \"%s\" of the key \"%s\"."
+msgstr "Ignorisanje vrednosti \"%s\" ključa \"%s\"."
+
+#: ../src/msw/textctrl.cpp:596
+msgid ""
+"Impossible to create a rich edit control, using simple text control instead. "
+"Please reinstall riched32.dll"
+msgstr ""
+"Nemoguće napraviti kontrolu za obogaćeno uređivanje, umesto toga koristi se "
+"jednostavna tekstualna kontrola. Molimo ponovo instalirajte riched32.dll"
+
+#: ../src/msw/thread.cpp:522 ../src/unix/threadpsx.cpp:850
+msgid "Cannot start thread: error writing TLS."
+msgstr "Nemoguće započeti thread: greška pri TLS pisanju."
+
+#: ../src/msw/thread.cpp:613
+msgid "Can't set thread priority"
+msgstr "Nemoguće postaviti prioritet za thread"
+
+#: ../src/msw/thread.cpp:649
+msgid "Can't create thread"
+msgstr "Nemoguće napraviti thread"
+
+#: ../src/msw/thread.cpp:668
+msgid "Couldn't terminate thread"
+msgstr "Nemoguće završiti thread"
+
+#: ../src/msw/thread.cpp:799
+msgid "Cannot wait for thread termination"
+msgstr "Nemoguće čekati završetak za thread"
+
+#: ../src/msw/thread.cpp:873
+#, c-format
+msgid "Cannot suspend thread %lx"
+msgstr "Nemoguće pauzirati thread %lx"
+
+#: ../src/msw/thread.cpp:903
+#, c-format
+msgid "Cannot resume thread %lx"
+msgstr "Nemoguće nastaviti thread %lx"
+
+#: ../src/msw/thread.cpp:932
+msgid "Couldn't get the current thread pointer"
+msgstr "Nemoguće preuzeti trenutni pointer za thread"
+
+#: ../src/msw/thread.cpp:1333
+msgid ""
+"Thread module initialization failed: impossible to allocate index in thread "
+"local storage"
+msgstr ""
+"Neuspešna inicijalizacija modula za thread: nemoguće dodeliti indeks u "
+"thread lokalnom skladištu"
+
+#: ../src/msw/thread.cpp:1345
+msgid ""
+"Thread module initialization failed: cannot store value in thread local "
+"storage"
+msgstr ""
+"Neuspešna inicijalizacija modula za thread: nemoguće čuvati vrednost u "
+"thread lokalnom skladištu"
+
+#: ../src/msw/timer.cpp:133
+msgid "Couldn't create a timer"
+msgstr "Nemoguće napraviti tajmer"
+
+#: ../src/msw/utils.cpp:372
+msgid "can't find user's HOME, using current directory."
+msgstr ""
+"Nemoguće pronaći početni korisnički direktorijum, koristiće se trenutni "
+"direktorijum."
+
+#: ../src/msw/utils.cpp:662
+#, c-format
+msgid "Failed to kill process %d"
+msgstr "Neuspešno zatvaranje procesa %d"
+
+#: ../src/msw/utils.cpp:986
+#, c-format
+msgid "Failed to load resource \"%s\"."
+msgstr "Neuspešno učitavanje resursa \"%s\"."
+
+#: ../src/msw/utils.cpp:993
+#, c-format
+msgid "Failed to lock resource \"%s\"."
+msgstr "Neuspešno zaključavanje resursa \"%s\"."
+
+#. TRANSLATORS: MS Windows build number
+#: ../src/msw/utils.cpp:1209
+#, c-format
+msgid "build %lu"
+msgstr "Verzija %lu"
+
+#: ../src/msw/utils.cpp:1218
+msgid ", 64-bit edition"
+msgstr ", 64-bitno izdanje"
+
+#: ../src/msw/utilsexc.cpp:224
+msgid "Failed to create an anonymous pipe"
+msgstr "Neuspešno pravljenje anonimnog pipe-a"
+
+#: ../src/msw/utilsexc.cpp:697
+msgid "Failed to redirect the child process IO"
+msgstr "Neuspešno preusmeravanje child proces IO-a"
+
+#: ../src/msw/utilsexc.cpp:870
+#, c-format
+msgid "Execution of command '%s' failed"
+msgstr "Izvršavanje komande '%s' nije uspelo"
+
+#: ../src/msw/volume.cpp:337
+msgid "Failed to load mpr.dll."
+msgstr "Neuspešno učitavanje datoteke mpr.dll."
+
+#: ../src/msw/volume.cpp:506
+#, c-format
+msgid "Cannot read typename from '%s'!"
+msgstr "Nemoguće učitati ime vrste iz '%s'!"
+
+#: ../src/msw/volume.cpp:615
+#, c-format
+msgid "Cannot load icon from '%s'."
+msgstr "Nemoguće učitati ikonicu iz '%s'."
+
+#: ../src/msw/webview_edge.cpp:285
+msgid "This program was compiled without support for setting Edge proxy."
+msgstr ""
+
+#: ../src/msw/webview_ie.cpp:1010
+msgid "Failed to find web view emulation level in the registry"
+msgstr "Neuspešno pronalaženje nivoa emulacije web prikaza u registru"
+
+#: ../src/msw/webview_ie.cpp:1019
+msgid "Failed to set web view to modern emulation level"
+msgstr "Neuspešno postavljanje web prikaza na moderni nivo emulacije"
+
+#: ../src/msw/webview_ie.cpp:1027
+msgid "Failed to reset web view to standard emulation level"
+msgstr "Neuspešno vraćanje web prikaza na standardni nivo emulacije"
+
+#: ../src/msw/webview_ie.cpp:1049
+msgid "Can't run JavaScript script without a valid HTML document"
+msgstr "Nemoguće pokrenuti JavaScript skriptu bez ispravnog HTML dokumenta"
+
+#: ../src/msw/webview_ie.cpp:1056
+msgid "Can't get the JavaScript object"
+msgstr "Nemoguće preuzeti JavaScript objekat"
+
+#: ../src/msw/webview_ie.cpp:1070
+msgid "failed to evaluate"
+msgstr "Neuspešno ocenjivanje"
+
+#: ../src/osx/cocoa/filedlg.mm:412
+msgid "File type:"
+msgstr "Vrsta datoteke:"
+
+#: ../src/osx/cocoa/menu.mm:242
+#, fuzzy
+msgctxt "macOS menu name"
+msgid "Window"
+msgstr "Prozor"
+
+#: ../src/osx/cocoa/menu.mm:259
+#, fuzzy
+msgctxt "macOS menu name"
+msgid "Help"
+msgstr "Pomoć"
+
+#: ../src/osx/cocoa/menu.mm:298
+#, fuzzy
+msgctxt "macOS menu item"
+msgid "Minimize"
+msgstr "Umanji"
+
+#: ../src/osx/cocoa/menu.mm:303
+#, fuzzy
+msgctxt "macOS menu item"
+msgid "Zoom"
+msgstr "Zumiraj"
+
+#: ../src/osx/cocoa/menu.mm:309
+#, fuzzy
+msgctxt "macOS menu item"
+msgid "Bring All to Front"
+msgstr "Prikaži sve"
+
+#: ../src/osx/core/sound.cpp:143
+#, c-format
+msgid "Failed to load sound from \"%s\" (error %d)."
+msgstr "Neuspešno učitavanje zvuka iz \"%s\" (greška %d)."
+
+#: ../src/osx/fontutil.cpp:80
+#, c-format
+msgid "Font file \"%s\" doesn't exist."
+msgstr "Datoteka fonta \"%s\" ne postoji."
+
+#: ../src/osx/fontutil.cpp:88
+#, c-format
+msgid ""
+"Font file \"%s\" cannot be used as it is not inside the font directory "
+"\"%s\"."
+msgstr ""
+"Datoteka fonta \"%s\" se  ne može koristiti budući da nije u direktorijumu "
+"fontova \"%s\"."
+
+#: ../src/osx/menu_osx.cpp:496
+#, c-format
+msgctxt "macOS menu item"
+msgid "About %s"
+msgstr "O %s"
+
+#: ../src/osx/menu_osx.cpp:499
+msgctxt "macOS menu item"
+msgid "About..."
+msgstr "O..."
+
+#: ../src/osx/menu_osx.cpp:508
+msgctxt "macOS menu item"
+msgid "Preferences..."
+msgstr "Podešavanja..."
+
+#: ../src/osx/menu_osx.cpp:512
+msgctxt "macOS menu item"
+msgid "Services"
+msgstr "Servisi"
+
+#: ../src/osx/menu_osx.cpp:519
+#, c-format
+msgctxt "macOS menu item"
+msgid "Hide %s"
+msgstr "Sakrij %s"
+
+#: ../src/osx/menu_osx.cpp:522
+msgctxt "macOS menu item"
+msgid "Hide Application"
+msgstr "Sakrij aplikaciju"
+
+#: ../src/osx/menu_osx.cpp:526
+msgctxt "macOS menu item"
+msgid "Hide Others"
+msgstr "Sakrij drugo"
+
+#: ../src/osx/menu_osx.cpp:528
+msgctxt "macOS menu item"
+msgid "Show All"
+msgstr "Prikaži sve"
+
+#: ../src/osx/menu_osx.cpp:534
+#, c-format
+msgctxt "macOS menu item"
+msgid "Quit %s"
+msgstr "Zatvori %s"
+
+#: ../src/osx/menu_osx.cpp:537
+msgctxt "macOS menu item"
+msgid "Quit Application"
+msgstr "Zatvori aplikaciju"
+
+#: ../src/osx/webview_webkit.mm:444
+msgid "Printing is not supported by the system web control"
+msgstr "Štampanje nije podržano od strane sistemske web kontrole"
+
+#: ../src/osx/webview_webkit.mm:453
+msgid "Print operation could not be initialized"
+msgstr "Radnja štampanja se ne može inicijalizovati"
+
+#. TRANSLATORS: Label of font point size
+#: ../src/propgrid/advprops.cpp:605
+msgid "Point Size"
+msgstr "Veličina pointa"
+
+#. TRANSLATORS: Label of font face name
+#: ../src/propgrid/advprops.cpp:615
+msgid "Face Name"
+msgstr "Ime fonta"
+
+#. TRANSLATORS: Label of font style
+#: ../src/propgrid/advprops.cpp:623 ../src/richtext/richtextformatdlg.cpp:331
+msgid "Style"
+msgstr "Stil"
+
+#. TRANSLATORS: Label of font weight
+#: ../src/propgrid/advprops.cpp:628
+msgid "Weight"
+msgstr "Debljina"
+
+#. TRANSLATORS: Label of underlined font
+#: ../src/propgrid/advprops.cpp:633 ../src/richtext/richtextfontpage.cpp:358
+msgid "Underlined"
+msgstr "Podvučeno"
+
+#. TRANSLATORS: Label of font family
+#: ../src/propgrid/advprops.cpp:637
+msgid "Family"
+msgstr "Porodica"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:801
+msgid "AppWorkspace"
+msgstr "Radni prostor aplikacije"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:802
+msgid "ActiveBorder"
+msgstr "Aktivan okvir"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:803
+msgid "ActiveCaption"
+msgstr "Aktivan podnaslov"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:804
+msgid "ButtonFace"
+msgstr "Font dugmeta"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:805
+msgid "ButtonHighlight"
+msgstr "Označavanje dugmeta"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:806
+msgid "ButtonShadow"
+msgstr "Senka dugmeta"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:807
+msgid "ButtonText"
+msgstr "Tekst dugmeta"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:808
+msgid "CaptionText"
+msgstr "Tekst podnaslova"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:809
+msgid "ControlDark"
+msgstr "Tamna kontrola"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:810
+msgid "ControlLight"
+msgstr "Svetla kontrola"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:812
+msgid "GrayText"
+msgstr "Sivi tekst"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:813
+msgid "Highlight"
+msgstr "Označavanje"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:814
+msgid "HighlightText"
+msgstr "Označen tekst"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:815
+msgid "InactiveBorder"
+msgstr "Neaktivan okvir"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:816
+msgid "InactiveCaption"
+msgstr "Neaktivan podnaslov"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:817
+msgid "InactiveCaptionText"
+msgstr "Tekst neaktivnog podnaslova"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:818
+msgid "Menu"
+msgstr "Meni"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:819
+msgid "Scrollbar"
+msgstr "Klizna traka"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:820
+msgid "Tooltip"
+msgstr "Opis alata"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:821
+msgid "TooltipText"
+msgstr "Tekst opisa alata"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:822
+msgid "Window"
+msgstr "Prozor"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:823
+msgid "WindowFrame"
+msgstr "Okvir prozora"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:824
+msgid "WindowText"
+msgstr "Tekst prozora"
+
+#. TRANSLATORS: Custom colour choice entry
+#: ../src/propgrid/advprops.cpp:825 ../src/propgrid/advprops.cpp:1532
+#: ../src/propgrid/advprops.cpp:1576
+msgid "Custom"
+msgstr "Prilagođena"
+
+#: ../src/propgrid/advprops.cpp:1558
+msgid "Black"
+msgstr "Crna"
+
+#: ../src/propgrid/advprops.cpp:1559
+msgid "Maroon"
+msgstr "Kestenjasta"
+
+#: ../src/propgrid/advprops.cpp:1560
+msgid "Navy"
+msgstr "Morsko plava"
+
+#: ../src/propgrid/advprops.cpp:1561
+msgid "Purple"
+msgstr "Ljubičasta"
+
+#: ../src/propgrid/advprops.cpp:1562
+msgid "Teal"
+msgstr "Plavozelena"
+
+#: ../src/propgrid/advprops.cpp:1563
+msgid "Gray"
+msgstr "Siva"
+
+#: ../src/propgrid/advprops.cpp:1564
+msgid "Green"
+msgstr "Zelena"
+
+#: ../src/propgrid/advprops.cpp:1565
+msgid "Olive"
+msgstr "Maslinasta"
+
+#: ../src/propgrid/advprops.cpp:1566
+msgid "Brown"
+msgstr "Braon"
+
+#: ../src/propgrid/advprops.cpp:1567
+msgid "Blue"
+msgstr "Plava"
+
+#: ../src/propgrid/advprops.cpp:1568
+msgid "Fuchsia"
+msgstr "Fuksija"
+
+#: ../src/propgrid/advprops.cpp:1569
+msgid "Red"
+msgstr "Crvena"
+
+#: ../src/propgrid/advprops.cpp:1570
+msgid "Orange"
+msgstr "Narandžasta"
+
+#: ../src/propgrid/advprops.cpp:1571
+msgid "Silver"
+msgstr "Srebrna"
+
+#: ../src/propgrid/advprops.cpp:1572
+msgid "Lime"
+msgstr "Kreč"
+
+#: ../src/propgrid/advprops.cpp:1573
+msgid "Aqua"
+msgstr "Akva"
+
+#: ../src/propgrid/advprops.cpp:1574
+msgid "Yellow"
+msgstr "Žuta"
+
+#: ../src/propgrid/advprops.cpp:1575
+msgid "White"
+msgstr "Bela"
+
+#: ../src/propgrid/advprops.cpp:1718
+msgctxt "system cursor name"
+msgid "Default"
+msgstr "Podrazumevani"
+
+#: ../src/propgrid/advprops.cpp:1719
+msgctxt "system cursor name"
+msgid "Arrow"
+msgstr "Strelica"
+
+#: ../src/propgrid/advprops.cpp:1720
+msgctxt "system cursor name"
+msgid "Right Arrow"
+msgstr "Strelica desno"
+
+#: ../src/propgrid/advprops.cpp:1721
+msgctxt "system cursor name"
+msgid "Blank"
+msgstr "Prazan"
+
+#: ../src/propgrid/advprops.cpp:1722
+msgctxt "system cursor name"
+msgid "Bullseye"
+msgstr "Meta"
+
+#: ../src/propgrid/advprops.cpp:1723
+msgctxt "system cursor name"
+msgid "Character"
+msgstr "Znak"
+
+#: ../src/propgrid/advprops.cpp:1724
+msgctxt "system cursor name"
+msgid "Cross"
+msgstr "Kružić"
+
+#: ../src/propgrid/advprops.cpp:1725
+msgctxt "system cursor name"
+msgid "Hand"
+msgstr "Ruka"
+
+#: ../src/propgrid/advprops.cpp:1726
+msgctxt "system cursor name"
+msgid "I-Beam"
+msgstr "I-Beam"
+
+#: ../src/propgrid/advprops.cpp:1727
+msgctxt "system cursor name"
+msgid "Left Button"
+msgstr "Levo dugme"
+
+#: ../src/propgrid/advprops.cpp:1728
+msgctxt "system cursor name"
+msgid "Magnifier"
+msgstr "Lupa"
+
+#: ../src/propgrid/advprops.cpp:1729
+msgctxt "system cursor name"
+msgid "Middle Button"
+msgstr "Srednje dugme"
+
+#: ../src/propgrid/advprops.cpp:1730
+msgctxt "system cursor name"
+msgid "No Entry"
+msgstr "Nema unosa"
+
+#: ../src/propgrid/advprops.cpp:1731
+msgctxt "system cursor name"
+msgid "Paint Brush"
+msgstr "Četkica"
+
+#: ../src/propgrid/advprops.cpp:1732
+msgctxt "system cursor name"
+msgid "Pencil"
+msgstr "Olovka"
+
+#: ../src/propgrid/advprops.cpp:1733
+msgctxt "system cursor name"
+msgid "Point Left"
+msgstr "Pokazuje levo"
+
+#: ../src/propgrid/advprops.cpp:1734
+msgctxt "system cursor name"
+msgid "Point Right"
+msgstr "Pokazuje desno"
+
+#: ../src/propgrid/advprops.cpp:1735
+msgctxt "system cursor name"
+msgid "Question Arrow"
+msgstr "Strelica upitnika"
+
+#: ../src/propgrid/advprops.cpp:1736
+msgctxt "system cursor name"
+msgid "Right Button"
+msgstr "Desno dugme"
+
+#: ../src/propgrid/advprops.cpp:1737
+msgctxt "system cursor name"
+msgid "Sizing NE-SW"
+msgstr "Veličina NE-SW"
+
+#: ../src/propgrid/advprops.cpp:1738
+msgctxt "system cursor name"
+msgid "Sizing N-S"
+msgstr "Veličina N-S"
+
+#: ../src/propgrid/advprops.cpp:1739
+msgctxt "system cursor name"
+msgid "Sizing NW-SE"
+msgstr "Veličina NW-SE"
+
+#: ../src/propgrid/advprops.cpp:1740
+msgctxt "system cursor name"
+msgid "Sizing W-E"
+msgstr "Veličina W-E"
+
+#: ../src/propgrid/advprops.cpp:1741
+msgctxt "system cursor name"
+msgid "Sizing"
+msgstr "Veličina"
+
+#: ../src/propgrid/advprops.cpp:1742
+msgctxt "system cursor name"
+msgid "Spraycan"
+msgstr "Sprej"
+
+#: ../src/propgrid/advprops.cpp:1743
+msgctxt "system cursor name"
+msgid "Wait"
+msgstr "Čekanje"
+
+#: ../src/propgrid/advprops.cpp:1744
+msgctxt "system cursor name"
+msgid "Watch"
+msgstr "Sat"
+
+#: ../src/propgrid/advprops.cpp:1745
+msgctxt "system cursor name"
+msgid "Wait Arrow"
+msgstr "Strelica za čekanje"
+
+#: ../src/propgrid/advprops.cpp:2109
+msgid "Make a selection:"
+msgstr "Izaberite:"
+
+#: ../src/propgrid/manager.cpp:394
+msgid "Property"
+msgstr "Svojstvo"
+
+#: ../src/propgrid/manager.cpp:395
+msgid "Value"
+msgstr "Vrednost"
+
+#: ../src/propgrid/manager.cpp:1683
+msgid "Categorized Mode"
+msgstr "Režim kategorizacije"
+
+#: ../src/propgrid/manager.cpp:1709
+msgid "Alphabetic Mode"
+msgstr "Režim alfabetizacije"
+
+#. TRANSLATORS: Name of Boolean false value
+#: ../src/propgrid/propgrid.cpp:230
+msgid "False"
+msgstr "Netačno"
+
+#. TRANSLATORS: Name of Boolean true value
+#: ../src/propgrid/propgrid.cpp:232
+msgid "True"
+msgstr "Tačno"
+
+#. TRANSLATORS: Text  displayed for unspecified value
+#: ../src/propgrid/propgrid.cpp:428
+msgid "Unspecified"
+msgstr "Neodređeno"
+
+#. TRANSLATORS: Caption of message box displaying any property error
+#: ../src/propgrid/propgrid.cpp:3145 ../src/propgrid/propgrid.cpp:3282
+msgid "Property Error"
+msgstr "Greška svojstva"
+
+#: ../src/propgrid/propgrid.cpp:3259
+msgid "You have entered invalid value. Press ESC to cancel editing."
+msgstr ""
+"Upisali ste neispravnu vrednost. Pritisnite esc da otkažete uređivanje."
+
+#: ../src/propgrid/propgrid.cpp:6608
+#, c-format
+msgid "Error in resource: %s"
+msgstr "Greška u resursu: %s"
+
+#: ../src/propgrid/propgridiface.cpp:377
+#, c-format
+msgid ""
+"Type operation \"%s\" failed: Property labeled \"%s\" is of type \"%s\", NOT "
+"\"%s\"."
+msgstr ""
+"Radnja sa vrstama \"%s\" nije uspela: Svojstvo sa oznakom \"%s\" je vrste "
+"\"%s\", ne \"%s\"."
+
+#: ../src/propgrid/props.cpp:159
+#, c-format
+msgid "Unknown base %d. Base 10 will be used."
+msgstr "Nepoznata osnova %d. Osnova 10 će se koristiti."
+
+#: ../src/propgrid/props.cpp:324
+#, c-format
+msgid "Value must be %s or higher."
+msgstr "Vrednost mora biti %s ili veća."
+
+#: ../src/propgrid/props.cpp:329 ../src/propgrid/props.cpp:356
+#, c-format
+msgid "Value must be between %s and %s."
+msgstr "Vrednost mora biti između %s i %s."
+
+#: ../src/propgrid/props.cpp:351
+#, c-format
+msgid "Value must be %s or less."
+msgstr "Vrednost mora biti %s ili manja."
+
+#: ../src/propgrid/props.cpp:1058
+#, c-format
+msgid "Not %s"
+msgstr "Ne %s"
+
+#: ../src/propgrid/props.cpp:1770
+msgid "Choose a directory:"
+msgstr "Izaberite direktorijum:"
+
+#: ../src/propgrid/props.cpp:2055
+msgid "Choose a file"
+msgstr "Izaberite datoteku"
+
+#: ../src/qt/mdi.cpp:254
+msgid "&Tile"
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:147
+#: ../src/richtext/richtextformatdlg.cpp:376
+msgid "Background"
+msgstr "Pozadina"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:159
+msgid "Background &colour:"
+msgstr "&Boja pozadine:"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:161
+#: ../src/richtext/richtextbackgroundpage.cpp:163
+msgid "Enables a background colour."
+msgstr "Uključuje boju pozadine."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:167
+#: ../src/richtext/richtextbackgroundpage.cpp:169
+msgid "The background colour."
+msgstr "Boja pozadine."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:178
+msgid "Shadow"
+msgstr "Senka"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:193
+msgid "Use &shadow"
+msgstr "Koristi &senku"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:195
+#: ../src/richtext/richtextbackgroundpage.cpp:197
+msgid "Enables a shadow."
+msgstr "Uključuje senku."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:211
+msgid "&Horizontal offset:"
+msgstr "&Horizontalno odvajanje:"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:218
+#: ../src/richtext/richtextbackgroundpage.cpp:220
+msgid "The horizontal offset."
+msgstr "Horizontalno odvajanje."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:224
+#: ../src/richtext/richtextbackgroundpage.cpp:227
+#: ../src/richtext/richtextbackgroundpage.cpp:228
+#: ../src/richtext/richtextbackgroundpage.cpp:247
+#: ../src/richtext/richtextbackgroundpage.cpp:250
+#: ../src/richtext/richtextbackgroundpage.cpp:251
+#: ../src/richtext/richtextbackgroundpage.cpp:287
+#: ../src/richtext/richtextbackgroundpage.cpp:290
+#: ../src/richtext/richtextbackgroundpage.cpp:291
+#: ../src/richtext/richtextbackgroundpage.cpp:314
+#: ../src/richtext/richtextbackgroundpage.cpp:317
+#: ../src/richtext/richtextbackgroundpage.cpp:318
+#: ../src/richtext/richtextborderspage.cpp:252
+#: ../src/richtext/richtextborderspage.cpp:255
+#: ../src/richtext/richtextborderspage.cpp:256
+#: ../src/richtext/richtextborderspage.cpp:286
+#: ../src/richtext/richtextborderspage.cpp:289
+#: ../src/richtext/richtextborderspage.cpp:290
+#: ../src/richtext/richtextborderspage.cpp:320
+#: ../src/richtext/richtextborderspage.cpp:323
+#: ../src/richtext/richtextborderspage.cpp:324
+#: ../src/richtext/richtextborderspage.cpp:354
+#: ../src/richtext/richtextborderspage.cpp:357
+#: ../src/richtext/richtextborderspage.cpp:358
+#: ../src/richtext/richtextborderspage.cpp:420
+#: ../src/richtext/richtextborderspage.cpp:423
+#: ../src/richtext/richtextborderspage.cpp:424
+#: ../src/richtext/richtextborderspage.cpp:454
+#: ../src/richtext/richtextborderspage.cpp:457
+#: ../src/richtext/richtextborderspage.cpp:458
+#: ../src/richtext/richtextborderspage.cpp:488
+#: ../src/richtext/richtextborderspage.cpp:491
+#: ../src/richtext/richtextborderspage.cpp:492
+#: ../src/richtext/richtextborderspage.cpp:522
+#: ../src/richtext/richtextborderspage.cpp:525
+#: ../src/richtext/richtextborderspage.cpp:526
+#: ../src/richtext/richtextborderspage.cpp:590
+#: ../src/richtext/richtextborderspage.cpp:593
+#: ../src/richtext/richtextborderspage.cpp:594
+#: ../src/richtext/richtextfontpage.cpp:177
+#: ../src/richtext/richtextmarginspage.cpp:199
+#: ../src/richtext/richtextmarginspage.cpp:201
+#: ../src/richtext/richtextmarginspage.cpp:202
+#: ../src/richtext/richtextmarginspage.cpp:224
+#: ../src/richtext/richtextmarginspage.cpp:226
+#: ../src/richtext/richtextmarginspage.cpp:227
+#: ../src/richtext/richtextmarginspage.cpp:247
+#: ../src/richtext/richtextmarginspage.cpp:249
+#: ../src/richtext/richtextmarginspage.cpp:250
+#: ../src/richtext/richtextmarginspage.cpp:272
+#: ../src/richtext/richtextmarginspage.cpp:274
+#: ../src/richtext/richtextmarginspage.cpp:275
+#: ../src/richtext/richtextmarginspage.cpp:313
+#: ../src/richtext/richtextmarginspage.cpp:315
+#: ../src/richtext/richtextmarginspage.cpp:316
+#: ../src/richtext/richtextmarginspage.cpp:338
+#: ../src/richtext/richtextmarginspage.cpp:340
+#: ../src/richtext/richtextmarginspage.cpp:341
+#: ../src/richtext/richtextmarginspage.cpp:361
+#: ../src/richtext/richtextmarginspage.cpp:363
+#: ../src/richtext/richtextmarginspage.cpp:364
+#: ../src/richtext/richtextmarginspage.cpp:386
+#: ../src/richtext/richtextmarginspage.cpp:388
+#: ../src/richtext/richtextmarginspage.cpp:389
+#: ../src/richtext/richtextsizepage.cpp:337
+#: ../src/richtext/richtextsizepage.cpp:340
+#: ../src/richtext/richtextsizepage.cpp:341
+#: ../src/richtext/richtextsizepage.cpp:371
+#: ../src/richtext/richtextsizepage.cpp:374
+#: ../src/richtext/richtextsizepage.cpp:375
+#: ../src/richtext/richtextsizepage.cpp:398
+#: ../src/richtext/richtextsizepage.cpp:401
+#: ../src/richtext/richtextsizepage.cpp:402
+#: ../src/richtext/richtextsizepage.cpp:425
+#: ../src/richtext/richtextsizepage.cpp:428
+#: ../src/richtext/richtextsizepage.cpp:429
+#: ../src/richtext/richtextsizepage.cpp:452
+#: ../src/richtext/richtextsizepage.cpp:455
+#: ../src/richtext/richtextsizepage.cpp:456
+#: ../src/richtext/richtextsizepage.cpp:479
+#: ../src/richtext/richtextsizepage.cpp:482
+#: ../src/richtext/richtextsizepage.cpp:483
+#: ../src/richtext/richtextsizepage.cpp:553
+#: ../src/richtext/richtextsizepage.cpp:556
+#: ../src/richtext/richtextsizepage.cpp:557
+#: ../src/richtext/richtextsizepage.cpp:588
+#: ../src/richtext/richtextsizepage.cpp:591
+#: ../src/richtext/richtextsizepage.cpp:592
+#: ../src/richtext/richtextsizepage.cpp:623
+#: ../src/richtext/richtextsizepage.cpp:626
+#: ../src/richtext/richtextsizepage.cpp:627
+#: ../src/richtext/richtextsizepage.cpp:658
+#: ../src/richtext/richtextsizepage.cpp:661
+#: ../src/richtext/richtextsizepage.cpp:662
+msgid "px"
+msgstr "px"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:225
+#: ../src/richtext/richtextbackgroundpage.cpp:248
+#: ../src/richtext/richtextbackgroundpage.cpp:288
+#: ../src/richtext/richtextbackgroundpage.cpp:315
+#: ../src/richtext/richtextborderspage.cpp:253
+#: ../src/richtext/richtextborderspage.cpp:287
+#: ../src/richtext/richtextborderspage.cpp:321
+#: ../src/richtext/richtextborderspage.cpp:355
+#: ../src/richtext/richtextborderspage.cpp:421
+#: ../src/richtext/richtextborderspage.cpp:455
+#: ../src/richtext/richtextborderspage.cpp:489
+#: ../src/richtext/richtextborderspage.cpp:523
+#: ../src/richtext/richtextborderspage.cpp:591
+#: ../src/richtext/richtextmarginspage.cpp:200
+#: ../src/richtext/richtextmarginspage.cpp:225
+#: ../src/richtext/richtextmarginspage.cpp:248
+#: ../src/richtext/richtextmarginspage.cpp:273
+#: ../src/richtext/richtextmarginspage.cpp:314
+#: ../src/richtext/richtextmarginspage.cpp:339
+#: ../src/richtext/richtextmarginspage.cpp:362
+#: ../src/richtext/richtextmarginspage.cpp:387
+#: ../src/richtext/richtextsizepage.cpp:338
+#: ../src/richtext/richtextsizepage.cpp:372
+#: ../src/richtext/richtextsizepage.cpp:399
+#: ../src/richtext/richtextsizepage.cpp:426
+#: ../src/richtext/richtextsizepage.cpp:453
+#: ../src/richtext/richtextsizepage.cpp:480
+#: ../src/richtext/richtextsizepage.cpp:554
+#: ../src/richtext/richtextsizepage.cpp:589
+#: ../src/richtext/richtextsizepage.cpp:624
+#: ../src/richtext/richtextsizepage.cpp:659
+msgid "cm"
+msgstr "cm"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:226
+#: ../src/richtext/richtextbackgroundpage.cpp:249
+#: ../src/richtext/richtextbackgroundpage.cpp:289
+#: ../src/richtext/richtextbackgroundpage.cpp:316
+#: ../src/richtext/richtextborderspage.cpp:254
+#: ../src/richtext/richtextborderspage.cpp:288
+#: ../src/richtext/richtextborderspage.cpp:322
+#: ../src/richtext/richtextborderspage.cpp:356
+#: ../src/richtext/richtextborderspage.cpp:422
+#: ../src/richtext/richtextborderspage.cpp:456
+#: ../src/richtext/richtextborderspage.cpp:490
+#: ../src/richtext/richtextborderspage.cpp:524
+#: ../src/richtext/richtextborderspage.cpp:592
+#: ../src/richtext/richtextfontpage.cpp:176
+#: ../src/richtext/richtextfontpage.cpp:179
+msgid "pt"
+msgstr "pt"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:229
+#: ../src/richtext/richtextbackgroundpage.cpp:231
+#: ../src/richtext/richtextbackgroundpage.cpp:252
+#: ../src/richtext/richtextbackgroundpage.cpp:254
+#: ../src/richtext/richtextbackgroundpage.cpp:292
+#: ../src/richtext/richtextbackgroundpage.cpp:294
+#: ../src/richtext/richtextbackgroundpage.cpp:319
+#: ../src/richtext/richtextbackgroundpage.cpp:321
+msgid "Units for this value."
+msgstr "Jedinice za ovu vrednost."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:234
+msgid "&Vertical offset:"
+msgstr "&Vertikalno odvajanje:"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:241
+#: ../src/richtext/richtextbackgroundpage.cpp:243
+msgid "The vertical offset."
+msgstr "Vertikalno odvajanje."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:257
+msgid "Shadow c&olour:"
+msgstr "Boja &senke:"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:259
+#: ../src/richtext/richtextbackgroundpage.cpp:261
+msgid "Enables the shadow colour."
+msgstr "Uključuje boju senke."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:265
+#: ../src/richtext/richtextbackgroundpage.cpp:267
+msgid "The shadow colour."
+msgstr "Boja senke."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:270
+msgid "Sh&adow spread:"
+msgstr "&Rasprostranjenost senke:"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:272
+#: ../src/richtext/richtextbackgroundpage.cpp:274
+msgid "Enables the shadow spread."
+msgstr "Uključuje rasprostranjenost senke."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:281
+#: ../src/richtext/richtextbackgroundpage.cpp:283
+msgid "The shadow spread."
+msgstr "Rasprostranjenost senke."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:297
+msgid "&Blur distance:"
+msgstr "&Udaljenost mutnoće:"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:299
+#: ../src/richtext/richtextbackgroundpage.cpp:301
+msgid "Enables the blur distance."
+msgstr "Uključuje udaljenost mutnoće."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:308
+#: ../src/richtext/richtextbackgroundpage.cpp:310
+msgid "The shadow blur distance."
+msgstr "Udaljenost mutnoće senke."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:324
+msgid "Opaci&ty:"
+msgstr "&Neprozirnost:"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:326
+#: ../src/richtext/richtextbackgroundpage.cpp:328
+msgid "Enables the shadow opacity."
+msgstr "Uključuje neprozirnost senke."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:335
+#: ../src/richtext/richtextbackgroundpage.cpp:337
+msgid "The shadow opacity."
+msgstr "Neprozirnost senke."
+
+#. TRANSLATORS: Rich text page units (percentage)
+#: ../src/richtext/richtextbackgroundpage.cpp:340
+#: ../src/richtext/richtextsizepage.cpp:339
+#: ../src/richtext/richtextsizepage.cpp:373
+#: ../src/richtext/richtextsizepage.cpp:400
+#: ../src/richtext/richtextsizepage.cpp:427
+#: ../src/richtext/richtextsizepage.cpp:454
+#: ../src/richtext/richtextsizepage.cpp:481
+#: ../src/richtext/richtextsizepage.cpp:555
+#: ../src/richtext/richtextsizepage.cpp:590
+#: ../src/richtext/richtextsizepage.cpp:625
+#: ../src/richtext/richtextsizepage.cpp:660
+msgid "%"
+msgstr "%"
+
+#: ../src/richtext/richtextborderspage.cpp:229
+#: ../src/richtext/richtextborderspage.cpp:387
+msgid "Border"
+msgstr "Okvir"
+
+#: ../src/richtext/richtextborderspage.cpp:242
+#: ../src/richtext/richtextborderspage.cpp:410
+#: ../src/richtext/richtextindentspage.cpp:194
+#: ../src/richtext/richtextliststylepage.cpp:384
+#: ../src/richtext/richtextmarginspage.cpp:185
+#: ../src/richtext/richtextmarginspage.cpp:299
+#: ../src/richtext/richtextsizepage.cpp:531
+#: ../src/richtext/richtextsizepage.cpp:538
+msgid "&Left:"
+msgstr "&Levi:"
+
+#: ../src/richtext/richtextborderspage.cpp:257
+#: ../src/richtext/richtextborderspage.cpp:259
+msgid "Units for the left border width."
+msgstr "Jedinice za širinu levog okvira."
+
+#: ../src/richtext/richtextborderspage.cpp:266
+#: ../src/richtext/richtextborderspage.cpp:268
+#: ../src/richtext/richtextborderspage.cpp:300
+#: ../src/richtext/richtextborderspage.cpp:302
+#: ../src/richtext/richtextborderspage.cpp:334
+#: ../src/richtext/richtextborderspage.cpp:336
+#: ../src/richtext/richtextborderspage.cpp:368
+#: ../src/richtext/richtextborderspage.cpp:370
+#: ../src/richtext/richtextborderspage.cpp:434
+#: ../src/richtext/richtextborderspage.cpp:436
+#: ../src/richtext/richtextborderspage.cpp:468
+#: ../src/richtext/richtextborderspage.cpp:470
+#: ../src/richtext/richtextborderspage.cpp:502
+#: ../src/richtext/richtextborderspage.cpp:504
+#: ../src/richtext/richtextborderspage.cpp:536
+#: ../src/richtext/richtextborderspage.cpp:538
+msgid "The border line style."
+msgstr "Stil linija okvira."
+
+#: ../src/richtext/richtextborderspage.cpp:276
+#: ../src/richtext/richtextborderspage.cpp:444
+#: ../src/richtext/richtextindentspage.cpp:212
+#: ../src/richtext/richtextliststylepage.cpp:402
+#: ../src/richtext/richtextmarginspage.cpp:210
+#: ../src/richtext/richtextmarginspage.cpp:324
+#: ../src/richtext/richtextsizepage.cpp:601
+#: ../src/richtext/richtextsizepage.cpp:608
+msgid "&Right:"
+msgstr "&Desni:"
+
+#: ../src/richtext/richtextborderspage.cpp:291
+#: ../src/richtext/richtextborderspage.cpp:293
+msgid "Units for the right border width."
+msgstr "Jedinice za širinu desnog okvira."
+
+#: ../src/richtext/richtextborderspage.cpp:310
+#: ../src/richtext/richtextborderspage.cpp:478
+#: ../src/richtext/richtextmarginspage.cpp:233
+#: ../src/richtext/richtextmarginspage.cpp:347
+#: ../src/richtext/richtextsizepage.cpp:566
+#: ../src/richtext/richtextsizepage.cpp:573
+msgid "&Top:"
+msgstr "&Gornji:"
+
+#: ../src/richtext/richtextborderspage.cpp:325
+#: ../src/richtext/richtextborderspage.cpp:327
+msgid "Units for the top border width."
+msgstr "Jedinice za širinu gornjeg okvira."
+
+#: ../src/richtext/richtextborderspage.cpp:344
+#: ../src/richtext/richtextborderspage.cpp:512
+#: ../src/richtext/richtextmarginspage.cpp:258
+#: ../src/richtext/richtextmarginspage.cpp:372
+#: ../src/richtext/richtextsizepage.cpp:636
+#: ../src/richtext/richtextsizepage.cpp:643
+msgid "&Bottom:"
+msgstr "&Donji:"
+
+#: ../src/richtext/richtextborderspage.cpp:359
+#: ../src/richtext/richtextborderspage.cpp:361
+msgid "Units for the bottom border width."
+msgstr "Jedinice za širinu donjeg okvira."
+
+#: ../src/richtext/richtextborderspage.cpp:380
+#: ../src/richtext/richtextborderspage.cpp:548
+msgid "&Synchronize values"
+msgstr "&Sinhronizuj vrednosti"
+
+#: ../src/richtext/richtextborderspage.cpp:382
+#: ../src/richtext/richtextborderspage.cpp:384
+#: ../src/richtext/richtextborderspage.cpp:550
+#: ../src/richtext/richtextborderspage.cpp:552
+msgid "Check to edit all borders simultaneously."
+msgstr "Čekirajte da uredite sve okvire u isto vreme."
+
+#: ../src/richtext/richtextborderspage.cpp:397
+#: ../src/richtext/richtextborderspage.cpp:555
+msgid "Outline"
+msgstr "Kontura"
+
+#: ../src/richtext/richtextborderspage.cpp:425
+#: ../src/richtext/richtextborderspage.cpp:427
+msgid "Units for the left outline width."
+msgstr "Jedinice za širinu leve  konture."
+
+#: ../src/richtext/richtextborderspage.cpp:459
+#: ../src/richtext/richtextborderspage.cpp:461
+msgid "Units for the right outline width."
+msgstr "Jedinice za širinu desne konture."
+
+#: ../src/richtext/richtextborderspage.cpp:493
+#: ../src/richtext/richtextborderspage.cpp:495
+msgid "Units for the top outline width."
+msgstr "Jedinice za širinu gornje konture."
+
+#: ../src/richtext/richtextborderspage.cpp:527
+#: ../src/richtext/richtextborderspage.cpp:529
+msgid "Units for the bottom outline width."
+msgstr "Jedinice za širinu donje konture."
+
+#: ../src/richtext/richtextborderspage.cpp:565
+#: ../src/richtext/richtextborderspage.cpp:600
+msgid "Corner"
+msgstr "Ugao"
+
+#: ../src/richtext/richtextborderspage.cpp:574
+msgid "Corner &radius:"
+msgstr "&Radijus ugla:"
+
+#: ../src/richtext/richtextborderspage.cpp:576
+#: ../src/richtext/richtextborderspage.cpp:578
+msgid "An optional corner radius for adding rounded corners."
+msgstr "Opcioni radijus ugla za dodavanje zaobljenih uglova."
+
+#: ../src/richtext/richtextborderspage.cpp:584
+#: ../src/richtext/richtextborderspage.cpp:586
+msgid "The value of the corner radius."
+msgstr "Vrednost radijusa ugla."
+
+#: ../src/richtext/richtextborderspage.cpp:595
+#: ../src/richtext/richtextborderspage.cpp:597
+msgid "Units for the corner radius."
+msgstr "Jedinice za radijus ugla."
+
+#: ../src/richtext/richtextborderspage.cpp:609
+#: ../src/richtext/richtextsizepage.cpp:247
+#: ../src/richtext/richtextsizepage.cpp:251
+msgid "None"
+msgstr "Nijedan"
+
+#: ../src/richtext/richtextborderspage.cpp:610
+msgid "Solid"
+msgstr "Ispunjen"
+
+#: ../src/richtext/richtextborderspage.cpp:611
+msgid "Dotted"
+msgstr "Tačkasti"
+
+#: ../src/richtext/richtextborderspage.cpp:612
+msgid "Dashed"
+msgstr "Isprekidani"
+
+#: ../src/richtext/richtextborderspage.cpp:613
+msgid "Double"
+msgstr "Dvostruki"
+
+#: ../src/richtext/richtextborderspage.cpp:614
+msgid "Groove"
+msgstr "Groove"
+
+#: ../src/richtext/richtextborderspage.cpp:615
+msgid "Ridge"
+msgstr "Grubi"
+
+#: ../src/richtext/richtextborderspage.cpp:616
+msgid "Inset"
+msgstr "Suženi"
+
+#: ../src/richtext/richtextborderspage.cpp:617
+msgid "Outset"
+msgstr "Prošireni"
+
+#: ../src/richtext/richtextbuffer.cpp:3518
+msgid "Change Style"
+msgstr "Promeni stil"
+
+#: ../src/richtext/richtextbuffer.cpp:3701
+msgid "Change Object Style"
+msgstr "Promeni stil objekata"
+
+#: ../src/richtext/richtextbuffer.cpp:3974
+#: ../src/richtext/richtextbuffer.cpp:8174
+msgid "Change Properties"
+msgstr "Promeni svojstva"
+
+#: ../src/richtext/richtextbuffer.cpp:4346
+msgid "Change List Style"
+msgstr "Promeni stil liste"
+
+#: ../src/richtext/richtextbuffer.cpp:4519
+msgid "Renumber List"
+msgstr "Ponovi nabrajanje liste"
+
+#: ../src/richtext/richtextbuffer.cpp:7867
+#: ../src/richtext/richtextbuffer.cpp:7897
+#: ../src/richtext/richtextbuffer.cpp:7939
+#: ../src/richtext/richtextctrl.cpp:1279 ../src/richtext/richtextctrl.cpp:1473
+msgid "Insert Text"
+msgstr "Ubaci tekst"
+
+#: ../src/richtext/richtextbuffer.cpp:8023
+#: ../src/richtext/richtextbuffer.cpp:8979
+msgid "Insert Image"
+msgstr "Ubaci sliku"
+
+#: ../src/richtext/richtextbuffer.cpp:8070
+msgid "Insert Object"
+msgstr "Ubaci objekat"
+
+#: ../src/richtext/richtextbuffer.cpp:8112
+msgid "Insert Field"
+msgstr "Ubaci polje"
+
+#: ../src/richtext/richtextbuffer.cpp:8410
+msgid "Too many EndStyle calls!"
+msgstr "Previše EndStyle poziva!"
+
+#: ../src/richtext/richtextbuffer.cpp:8785
+msgid "files"
+msgstr "Datoteke"
+
+#: ../src/richtext/richtextbuffer.cpp:9380
+msgid "standard/circle"
+msgstr "Standardna/krug"
+
+#: ../src/richtext/richtextbuffer.cpp:9381
+msgid "standard/circle-outline"
+msgstr "Standardna/krug kontura"
+
+#: ../src/richtext/richtextbuffer.cpp:9382
+msgid "standard/square"
+msgstr "Standardna/kvadrat"
+
+#: ../src/richtext/richtextbuffer.cpp:9383
+msgid "standard/diamond"
+msgstr "Standardna/romb"
+
+#: ../src/richtext/richtextbuffer.cpp:9384
+msgid "standard/triangle"
+msgstr "Standardna/trougao"
+
+#: ../src/richtext/richtextbuffer.cpp:9423
+msgid "Box Properties"
+msgstr "Svojstva okvira"
+
+#: ../src/richtext/richtextbuffer.cpp:10006
+msgid "Multiple Cell Properties"
+msgstr "Svojstva za više ćelija"
+
+#: ../src/richtext/richtextbuffer.cpp:10008
+msgid "Cell Properties"
+msgstr "Svojstva ćelije"
+
+#: ../src/richtext/richtextbuffer.cpp:11256
+msgid "Set Cell Style"
+msgstr "Podesi stil ćelije"
+
+#: ../src/richtext/richtextbuffer.cpp:11330
+msgid "Delete Row"
+msgstr "Obriši red"
+
+#: ../src/richtext/richtextbuffer.cpp:11380
+msgid "Delete Column"
+msgstr "Obriši kolonu"
+
+#: ../src/richtext/richtextbuffer.cpp:11431
+msgid "Add Row"
+msgstr "Dodaj red"
+
+#: ../src/richtext/richtextbuffer.cpp:11494
+msgid "Add Column"
+msgstr "Dodaj kolonu"
+
+#: ../src/richtext/richtextbuffer.cpp:11537
+msgid "Table Properties"
+msgstr "Svojstva tabele"
+
+#: ../src/richtext/richtextbuffer.cpp:12899
+msgid "Picture Properties"
+msgstr "Svojstva slike"
+
+#: ../src/richtext/richtextbuffer.cpp:13169
+#: ../src/richtext/richtextbuffer.cpp:13279
+msgid "image"
+msgstr "Slika"
+
+#: ../src/richtext/richtextbulletspage.cpp:145
+#: ../src/richtext/richtextliststylepage.cpp:209
+msgid "&Bullet style:"
+msgstr "Stil &nabrajanja:"
+
+#: ../src/richtext/richtextbulletspage.cpp:150
+#: ../src/richtext/richtextbulletspage.cpp:152
+#: ../src/richtext/richtextliststylepage.cpp:214
+#: ../src/richtext/richtextliststylepage.cpp:216
+msgid "The available bullet styles."
+msgstr "Dostupni stilovi nabrajanja."
+
+#: ../src/richtext/richtextbulletspage.cpp:158
+#: ../src/richtext/richtextliststylepage.cpp:221
+msgid "Peri&od"
+msgstr "&Tačka"
+
+#: ../src/richtext/richtextbulletspage.cpp:160
+#: ../src/richtext/richtextbulletspage.cpp:162
+#: ../src/richtext/richtextliststylepage.cpp:223
+#: ../src/richtext/richtextliststylepage.cpp:225
+msgid "Check to add a period after the bullet."
+msgstr "Čekirajte da dodate tačku nakon nabrajanja."
+
+#. TRANSLATORS: Bullet point in parentheses option
+#: ../src/richtext/richtextbulletspage.cpp:167
+#: ../src/richtext/richtextliststylepage.cpp:230
+msgid "(*)"
+msgstr "(*)"
+
+#: ../src/richtext/richtextbulletspage.cpp:169
+#: ../src/richtext/richtextbulletspage.cpp:171
+#: ../src/richtext/richtextliststylepage.cpp:232
+#: ../src/richtext/richtextliststylepage.cpp:234
+msgid "Check to enclose the bullet in parentheses."
+msgstr "Čekirajte da okružite nabrajanje zagradama."
+
+#. TRANSLATORS: Right parenthesis bullet point option
+#: ../src/richtext/richtextbulletspage.cpp:176
+#: ../src/richtext/richtextliststylepage.cpp:239
+msgid "*)"
+msgstr "*)"
+
+#: ../src/richtext/richtextbulletspage.cpp:178
+#: ../src/richtext/richtextbulletspage.cpp:180
+#: ../src/richtext/richtextliststylepage.cpp:241
+#: ../src/richtext/richtextliststylepage.cpp:243
+msgid "Check to add a right parenthesis."
+msgstr "Čekirajte da dodate zatvorenu zagradu."
+
+#: ../src/richtext/richtextbulletspage.cpp:185
+#: ../src/richtext/richtextliststylepage.cpp:248
+msgid "Bullet &Alignment:"
+msgstr "&Poravnanje nabrajanja:"
+
+#: ../src/richtext/richtextbulletspage.cpp:190
+#: ../src/richtext/richtextliststylepage.cpp:253
+msgid "Centre"
+msgstr "Centriraj"
+
+#: ../src/richtext/richtextbulletspage.cpp:194
+#: ../src/richtext/richtextbulletspage.cpp:196
+#: ../src/richtext/richtextbulletspage.cpp:217
+#: ../src/richtext/richtextbulletspage.cpp:219
+#: ../src/richtext/richtextliststylepage.cpp:257
+#: ../src/richtext/richtextliststylepage.cpp:259
+#: ../src/richtext/richtextliststylepage.cpp:278
+#: ../src/richtext/richtextliststylepage.cpp:280
+msgid "The bullet character."
+msgstr "Znak za nabrajanje."
+
+#: ../src/richtext/richtextbulletspage.cpp:212
+#: ../src/richtext/richtextliststylepage.cpp:271
+msgid "&Symbol:"
+msgstr "&Simbol:"
+
+#: ../src/richtext/richtextbulletspage.cpp:222
+#: ../src/richtext/richtextliststylepage.cpp:283
+msgid "Ch&oose..."
+msgstr "I&zaberi..."
+
+#: ../src/richtext/richtextbulletspage.cpp:223
+#: ../src/richtext/richtextbulletspage.cpp:225
+#: ../src/richtext/richtextliststylepage.cpp:284
+#: ../src/richtext/richtextliststylepage.cpp:286
+msgid "Click to browse for a symbol."
+msgstr "Kliknite da potražite simbol."
+
+#: ../src/richtext/richtextbulletspage.cpp:230
+#: ../src/richtext/richtextliststylepage.cpp:291
+msgid "Symbol &font:"
+msgstr "&Font simbola:"
+
+#: ../src/richtext/richtextbulletspage.cpp:235
+#: ../src/richtext/richtextbulletspage.cpp:237
+#: ../src/richtext/richtextliststylepage.cpp:297
+msgid "Available fonts."
+msgstr "Dostupni fontovi."
+
+#: ../src/richtext/richtextbulletspage.cpp:242
+#: ../src/richtext/richtextliststylepage.cpp:302
+msgid "S&tandard bullet name:"
+msgstr "S&tandardno ime nabrajanja:"
+
+#: ../src/richtext/richtextbulletspage.cpp:247
+#: ../src/richtext/richtextbulletspage.cpp:249
+#: ../src/richtext/richtextliststylepage.cpp:307
+#: ../src/richtext/richtextliststylepage.cpp:309
+msgid "A standard bullet name."
+msgstr "Standardno ime nabrajanja."
+
+#: ../src/richtext/richtextbulletspage.cpp:254
+msgid "&Number:"
+msgstr "&Broj:"
+
+#: ../src/richtext/richtextbulletspage.cpp:258
+#: ../src/richtext/richtextbulletspage.cpp:260
+msgid "The list item number."
+msgstr "Broj stavke liste."
+
+#: ../src/richtext/richtextbulletspage.cpp:266
+#: ../src/richtext/richtextbulletspage.cpp:268
+#: ../src/richtext/richtextliststylepage.cpp:475
+#: ../src/richtext/richtextliststylepage.cpp:477
+msgid "Shows a preview of the bullet settings."
+msgstr "Prikazuje pregled podešavanja nabrajanja."
+
+#: ../src/richtext/richtextbulletspage.cpp:276
+#: ../src/richtext/richtextliststylepage.cpp:484
+msgid "(None)"
+msgstr "(Nijedan)"
+
+#: ../src/richtext/richtextbulletspage.cpp:277
+#: ../src/richtext/richtextliststylepage.cpp:485
+msgid "Arabic"
+msgstr "Arapski"
+
+#: ../src/richtext/richtextbulletspage.cpp:278
+#: ../src/richtext/richtextliststylepage.cpp:486
+msgid "Upper case letters"
+msgstr "Velika slova"
+
+#: ../src/richtext/richtextbulletspage.cpp:279
+#: ../src/richtext/richtextliststylepage.cpp:487
+msgid "Lower case letters"
+msgstr "Mala slova"
+
+#: ../src/richtext/richtextbulletspage.cpp:280
+#: ../src/richtext/richtextliststylepage.cpp:488
+msgid "Upper case roman numerals"
+msgstr "Velika slova Rimski brojevi"
+
+#: ../src/richtext/richtextbulletspage.cpp:281
+#: ../src/richtext/richtextliststylepage.cpp:489
+msgid "Lower case roman numerals"
+msgstr "Mala slova Rimski brojevi"
+
+#: ../src/richtext/richtextbulletspage.cpp:282
+#: ../src/richtext/richtextliststylepage.cpp:490
+msgid "Numbered outline"
+msgstr "Numerisana isticanja"
+
+#: ../src/richtext/richtextbulletspage.cpp:283
+#: ../src/richtext/richtextliststylepage.cpp:491
+msgid "Symbol"
+msgstr "Simbol"
+
+#: ../src/richtext/richtextbulletspage.cpp:284
+#: ../src/richtext/richtextliststylepage.cpp:492
+msgid "Bitmap"
+msgstr "Bitmap"
+
+#: ../src/richtext/richtextbulletspage.cpp:285
+#: ../src/richtext/richtextliststylepage.cpp:493
+msgid "Standard"
+msgstr "Standardno"
+
+#: ../src/richtext/richtextbulletspage.cpp:287
+#: ../src/richtext/richtextliststylepage.cpp:495
+msgid "*"
+msgstr "*"
+
+#: ../src/richtext/richtextbulletspage.cpp:288
+#: ../src/richtext/richtextliststylepage.cpp:496
+msgid "-"
+msgstr "-"
+
+#: ../src/richtext/richtextbulletspage.cpp:289
+#: ../src/richtext/richtextliststylepage.cpp:497
+msgid ">"
+msgstr ">"
+
+#: ../src/richtext/richtextbulletspage.cpp:290
+#: ../src/richtext/richtextliststylepage.cpp:498
+msgid "+"
+msgstr "+"
+
+#: ../src/richtext/richtextbulletspage.cpp:291
+#: ../src/richtext/richtextliststylepage.cpp:499
+msgid "~"
+msgstr "~"
+
+#: ../src/richtext/richtextctrl.cpp:859
+msgid "Drag"
+msgstr "Prevuci"
+
+#: ../src/richtext/richtextctrl.cpp:1338 ../src/richtext/richtextctrl.cpp:1559
+msgid "Delete Text"
+msgstr "Obriši tekst"
+
+#: ../src/richtext/richtextctrl.cpp:1537
+msgid "Remove Bullet"
+msgstr "Ukloni nabrajanje"
+
+#: ../src/richtext/richtextctrl.cpp:3070
+msgid "The text couldn't be saved."
+msgstr "Tekst nije mogao biti sačuvan."
+
+#: ../src/richtext/richtextctrl.cpp:3644
+msgid "Replace"
+msgstr "Zameni"
+
+#: ../src/richtext/richtextfontpage.cpp:146
+#: ../src/richtext/richtextsymboldlg.cpp:384
+msgid "&Font:"
+msgstr "&Font:"
+
+#: ../src/richtext/richtextfontpage.cpp:150
+#: ../src/richtext/richtextfontpage.cpp:152
+msgid "Type a font name."
+msgstr "Upišite ime fonta."
+
+#: ../src/richtext/richtextfontpage.cpp:158
+msgid "&Size:"
+msgstr "&Veličina:"
+
+#: ../src/richtext/richtextfontpage.cpp:165
+#: ../src/richtext/richtextfontpage.cpp:167
+msgid "Type a size in points."
+msgstr "Upišite veličinu u pointima."
+
+#: ../src/richtext/richtextfontpage.cpp:180
+#: ../src/richtext/richtextfontpage.cpp:182
+msgid "The font size units, points or pixels."
+msgstr "Jedinica veličine fonta, pikseli ili pointi."
+
+#: ../src/richtext/richtextfontpage.cpp:189
+#: ../src/richtext/richtextfontpage.cpp:191
+msgid "Lists the available fonts."
+msgstr "Prikazuje dostupne fontove."
+
+#: ../src/richtext/richtextfontpage.cpp:196
+#: ../src/richtext/richtextfontpage.cpp:198
+msgid "Lists font sizes in points."
+msgstr "Prikazuje veličine fontova u pointima."
+
+#: ../src/richtext/richtextfontpage.cpp:207
+msgid "Font st&yle:"
+msgstr "&Stil fonta:"
+
+#: ../src/richtext/richtextfontpage.cpp:212
+#: ../src/richtext/richtextfontpage.cpp:214
+msgid "Select regular or italic style."
+msgstr "Izaberite standardni ili iskošen stil."
+
+#: ../src/richtext/richtextfontpage.cpp:220
+msgid "Font &weight:"
+msgstr "&Debljina fonta:"
+
+#: ../src/richtext/richtextfontpage.cpp:225
+#: ../src/richtext/richtextfontpage.cpp:227
+msgid "Select regular or bold."
+msgstr "Izaberite standardno ili podebljano."
+
+#: ../src/richtext/richtextfontpage.cpp:233
+msgid "&Underlining:"
+msgstr "&Podvlačenje:"
+
+#: ../src/richtext/richtextfontpage.cpp:238
+#: ../src/richtext/richtextfontpage.cpp:240
+msgid "Select underlining or no underlining."
+msgstr "Izaberite sa ili bez podvlačenja."
+
+#: ../src/richtext/richtextfontpage.cpp:248
+msgid "&Colour:"
+msgstr "&Boja:"
+
+#: ../src/richtext/richtextfontpage.cpp:253
+#: ../src/richtext/richtextfontpage.cpp:255
+msgid "Click to change the text colour."
+msgstr "Kliknite da promenite boju teksta."
+
+#: ../src/richtext/richtextfontpage.cpp:261
+msgid "&Bg colour:"
+msgstr "&Boja pozadine:"
+
+#: ../src/richtext/richtextfontpage.cpp:266
+#: ../src/richtext/richtextfontpage.cpp:268
+msgid "Click to change the text background colour."
+msgstr "Kliknite da promenite boju pozadine teksta."
+
+#: ../src/richtext/richtextfontpage.cpp:276
+#: ../src/richtext/richtextfontpage.cpp:278
+msgid "Check to show a line through the text."
+msgstr "Čekirajte da prikažete liniju kroz tekst."
+
+#: ../src/richtext/richtextfontpage.cpp:281
+msgid "Ca&pitals"
+msgstr "&Velika slova"
+
+#: ../src/richtext/richtextfontpage.cpp:283
+#: ../src/richtext/richtextfontpage.cpp:285
+msgid "Check to show the text in capitals."
+msgstr "Čekirajte da se tekst prikaže sa velikim slovima."
+
+#: ../src/richtext/richtextfontpage.cpp:288
+msgid "Small C&apitals"
+msgstr "Smanjena velika &slova"
+
+#: ../src/richtext/richtextfontpage.cpp:290
+#: ../src/richtext/richtextfontpage.cpp:292
+msgid "Check to show the text in small capitals."
+msgstr "Čekirajte da prikažete tekst sa smanjenim velikim slovima."
+
+#: ../src/richtext/richtextfontpage.cpp:295
+msgid "Supe&rscript"
+msgstr "&Izdignut tekst"
+
+#: ../src/richtext/richtextfontpage.cpp:297
+#: ../src/richtext/richtextfontpage.cpp:299
+msgid "Check to show the text in superscript."
+msgstr "Čekirajte da tekst bude izdignut."
+
+#: ../src/richtext/richtextfontpage.cpp:302
+msgid "Subscrip&t"
+msgstr "&Spušten tekst"
+
+#: ../src/richtext/richtextfontpage.cpp:304
+#: ../src/richtext/richtextfontpage.cpp:306
+msgid "Check to show the text in subscript."
+msgstr "Čekirajte da prikažete tekst spušten."
+
+#: ../src/richtext/richtextfontpage.cpp:312
+msgid "Rig&ht-to-left"
+msgstr "&S desna na levo"
+
+#: ../src/richtext/richtextfontpage.cpp:314
+#: ../src/richtext/richtextfontpage.cpp:316
+msgid "Check to indicate right-to-left text layout."
+msgstr "Čekirajte da označite izgled teksta s desna na levo."
+
+#: ../src/richtext/richtextfontpage.cpp:319
+msgid "Suppress hyphe&nation"
+msgstr "Ignoriši &rastavljanje reči"
+
+#: ../src/richtext/richtextfontpage.cpp:321
+#: ../src/richtext/richtextfontpage.cpp:323
+msgid "Check to suppress hyphenation."
+msgstr "Čekirajte da ignorišete rastavljanje reči."
+
+#: ../src/richtext/richtextfontpage.cpp:329
+#: ../src/richtext/richtextfontpage.cpp:331
+msgid "Shows a preview of the font settings."
+msgstr "Prikazuje pregled podešavanja fonta."
+
+#: ../src/richtext/richtextfontpage.cpp:348
+#: ../src/richtext/richtextfontpage.cpp:352
+#: ../src/richtext/richtextfontpage.cpp:356
+#: ../src/richtext/richtextformatdlg.cpp:873
+#: ../src/richtext/richtextindentspage.cpp:273
+#: ../src/richtext/richtextindentspage.cpp:285
+#: ../src/richtext/richtextindentspage.cpp:286
+#: ../src/richtext/richtextindentspage.cpp:310
+#: ../src/richtext/richtextindentspage.cpp:325
+#: ../src/richtext/richtextliststylepage.cpp:451
+#: ../src/richtext/richtextliststylepage.cpp:463
+#: ../src/richtext/richtextliststylepage.cpp:464
+msgid "(none)"
+msgstr "(Nijedan)"
+
+#: ../src/richtext/richtextfontpage.cpp:349
+#: ../src/richtext/richtextfontpage.cpp:353
+msgid "Regular"
+msgstr "Standardni"
+
+#: ../src/richtext/richtextfontpage.cpp:357
+msgid "Not underlined"
+msgstr "Bez podvlačenja"
+
+#: ../src/richtext/richtextformatdlg.cpp:341
+msgid "Indents && Spacing"
+msgstr "Uvlačenja&& odvajanje"
+
+#: ../src/richtext/richtextformatdlg.cpp:346
+msgid "Tabs"
+msgstr "Tabulatori"
+
+#: ../src/richtext/richtextformatdlg.cpp:351
+msgid "Bullets"
+msgstr "Nabrajanja"
+
+#: ../src/richtext/richtextformatdlg.cpp:356
+msgid "List Style"
+msgstr "Stil liste"
+
+#: ../src/richtext/richtextformatdlg.cpp:366
+#: ../src/richtext/richtextmarginspage.cpp:170
+msgid "Margins"
+msgstr "Margine"
+
+#: ../src/richtext/richtextformatdlg.cpp:371
+msgid "Borders"
+msgstr "Okviri"
+
+#: ../src/richtext/richtextformatdlg.cpp:765
+msgid "Colour"
+msgstr "Boja"
+
+#: ../src/richtext/richtextindentspage.cpp:127
+#: ../src/richtext/richtextliststylepage.cpp:322
+msgid "&Alignment"
+msgstr "&Poravnanje"
+
+#: ../src/richtext/richtextindentspage.cpp:138
+#: ../src/richtext/richtextliststylepage.cpp:331
+msgid "&Left"
+msgstr "&Levo"
+
+#: ../src/richtext/richtextindentspage.cpp:140
+#: ../src/richtext/richtextindentspage.cpp:142
+#: ../src/richtext/richtextliststylepage.cpp:333
+#: ../src/richtext/richtextliststylepage.cpp:335
+msgid "Left-align text."
+msgstr "Poravnaj tekst levo."
+
+#: ../src/richtext/richtextindentspage.cpp:145
+#: ../src/richtext/richtextliststylepage.cpp:338
+msgid "&Right"
+msgstr "&Desno"
+
+#: ../src/richtext/richtextindentspage.cpp:147
+#: ../src/richtext/richtextindentspage.cpp:149
+#: ../src/richtext/richtextliststylepage.cpp:340
+#: ../src/richtext/richtextliststylepage.cpp:342
+msgid "Right-align text."
+msgstr "Poravnaj tekst desno."
+
+#: ../src/richtext/richtextindentspage.cpp:152
+#: ../src/richtext/richtextliststylepage.cpp:345
+msgid "&Justified"
+msgstr "&Obostrano"
+
+#: ../src/richtext/richtextindentspage.cpp:154
+#: ../src/richtext/richtextindentspage.cpp:156
+#: ../src/richtext/richtextliststylepage.cpp:347
+#: ../src/richtext/richtextliststylepage.cpp:349
+msgid "Justify text left and right."
+msgstr "Poravnaj tekst levo i desno."
+
+#: ../src/richtext/richtextindentspage.cpp:159
+#: ../src/richtext/richtextliststylepage.cpp:352
+msgid "Cen&tred"
+msgstr "&Centrirano"
+
+#: ../src/richtext/richtextindentspage.cpp:161
+#: ../src/richtext/richtextindentspage.cpp:163
+#: ../src/richtext/richtextliststylepage.cpp:354
+#: ../src/richtext/richtextliststylepage.cpp:356
+msgid "Centre text."
+msgstr "Centriraj tekst."
+
+#: ../src/richtext/richtextindentspage.cpp:166
+#: ../src/richtext/richtextliststylepage.cpp:359
+msgid "&Indeterminate"
+msgstr "&Neodređeno"
+
+#: ../src/richtext/richtextindentspage.cpp:168
+#: ../src/richtext/richtextindentspage.cpp:170
+#: ../src/richtext/richtextliststylepage.cpp:361
+#: ../src/richtext/richtextliststylepage.cpp:363
+msgid "Use the current alignment setting."
+msgstr "Koristi trenutno podešavanje poravnanja."
+
+#: ../src/richtext/richtextindentspage.cpp:183
+#: ../src/richtext/richtextliststylepage.cpp:375
+msgid "&Indentation (tenths of a mm)"
+msgstr "&Uvlačenje (desetine milimetra)"
+
+#: ../src/richtext/richtextindentspage.cpp:198
+#: ../src/richtext/richtextindentspage.cpp:200
+#: ../src/richtext/richtextliststylepage.cpp:388
+#: ../src/richtext/richtextliststylepage.cpp:390
+msgid "The left indent."
+msgstr "Levo uvlačenje."
+
+#: ../src/richtext/richtextindentspage.cpp:203
+#: ../src/richtext/richtextliststylepage.cpp:393
+msgid "Left (&first line):"
+msgstr "Levo (&prvi red):"
+
+#: ../src/richtext/richtextindentspage.cpp:207
+#: ../src/richtext/richtextindentspage.cpp:209
+#: ../src/richtext/richtextliststylepage.cpp:397
+#: ../src/richtext/richtextliststylepage.cpp:399
+msgid "The first line indent."
+msgstr "Uvlačenje prvog reda."
+
+#: ../src/richtext/richtextindentspage.cpp:216
+#: ../src/richtext/richtextindentspage.cpp:218
+#: ../src/richtext/richtextliststylepage.cpp:406
+#: ../src/richtext/richtextliststylepage.cpp:408
+msgid "The right indent."
+msgstr "Desno uvlačenje."
+
+#: ../src/richtext/richtextindentspage.cpp:221
+msgid "&Outline level:"
+msgstr "&Nivo istaknutosti:"
+
+#: ../src/richtext/richtextindentspage.cpp:226
+#: ../src/richtext/richtextindentspage.cpp:228
+msgid "The outline level."
+msgstr "Nivo istaknutosti."
+
+#: ../src/richtext/richtextindentspage.cpp:241
+#: ../src/richtext/richtextliststylepage.cpp:420
+msgid "&Spacing (tenths of a mm)"
+msgstr "&Odvajanje (desetine milimetra)"
+
+#: ../src/richtext/richtextindentspage.cpp:252
+msgid "&Before a paragraph:"
+msgstr "&Pre pasusa:"
+
+#: ../src/richtext/richtextindentspage.cpp:256
+#: ../src/richtext/richtextindentspage.cpp:258
+#: ../src/richtext/richtextliststylepage.cpp:433
+#: ../src/richtext/richtextliststylepage.cpp:435
+msgid "The spacing before the paragraph."
+msgstr "Odvajanje pre pasusa."
+
+#: ../src/richtext/richtextindentspage.cpp:261
+msgid "&After a paragraph:"
+msgstr "&Nakon pasusa:"
+
+#: ../src/richtext/richtextindentspage.cpp:266
+#: ../src/richtext/richtextliststylepage.cpp:442
+#: ../src/richtext/richtextliststylepage.cpp:444
+msgid "The spacing after the paragraph."
+msgstr "Odvajanje nakon pasusa."
+
+#: ../src/richtext/richtextindentspage.cpp:269
+msgid "L&ine spacing:"
+msgstr "&Odvajanje redova:"
+
+#: ../src/richtext/richtextindentspage.cpp:274
+#: ../src/richtext/richtextliststylepage.cpp:452
+msgid "Single"
+msgstr "Pojedinačno"
+
+#: ../src/richtext/richtextindentspage.cpp:275
+#: ../src/richtext/richtextliststylepage.cpp:453
+msgid "1.1"
+msgstr "1.1"
+
+#: ../src/richtext/richtextindentspage.cpp:276
+#: ../src/richtext/richtextliststylepage.cpp:454
+msgid "1.2"
+msgstr "1.2"
+
+#: ../src/richtext/richtextindentspage.cpp:277
+#: ../src/richtext/richtextliststylepage.cpp:455
+msgid "1.3"
+msgstr "1.3"
+
+#: ../src/richtext/richtextindentspage.cpp:278
+#: ../src/richtext/richtextliststylepage.cpp:456
+msgid "1.4"
+msgstr "1.4"
+
+#: ../src/richtext/richtextindentspage.cpp:279
+#: ../src/richtext/richtextliststylepage.cpp:457
+msgid "1.5"
+msgstr "1.5"
+
+#: ../src/richtext/richtextindentspage.cpp:280
+#: ../src/richtext/richtextliststylepage.cpp:458
+msgid "1.6"
+msgstr "1.6"
+
+#: ../src/richtext/richtextindentspage.cpp:281
+#: ../src/richtext/richtextliststylepage.cpp:459
+msgid "1.7"
+msgstr "1.7"
+
+#: ../src/richtext/richtextindentspage.cpp:282
+#: ../src/richtext/richtextliststylepage.cpp:460
+msgid "1.8"
+msgstr "1.8"
+
+#: ../src/richtext/richtextindentspage.cpp:283
+#: ../src/richtext/richtextliststylepage.cpp:461
+msgid "1.9"
+msgstr "1.9"
+
+#: ../src/richtext/richtextindentspage.cpp:284
+#: ../src/richtext/richtextliststylepage.cpp:462
+msgid "2"
+msgstr "2"
+
+#: ../src/richtext/richtextindentspage.cpp:287
+#: ../src/richtext/richtextindentspage.cpp:289
+#: ../src/richtext/richtextliststylepage.cpp:465
+#: ../src/richtext/richtextliststylepage.cpp:467
+msgid "The line spacing."
+msgstr "Odvajanje redova."
+
+#: ../src/richtext/richtextindentspage.cpp:292
+msgid "&Page Break"
+msgstr "&Prekid stranice"
+
+#: ../src/richtext/richtextindentspage.cpp:294
+#: ../src/richtext/richtextindentspage.cpp:296
+msgid "Inserts a page break before the paragraph."
+msgstr "Ubacuje prekid stranice pre pasusa."
+
+#: ../src/richtext/richtextindentspage.cpp:302
+#: ../src/richtext/richtextindentspage.cpp:304
+msgid "Shows a preview of the paragraph settings."
+msgstr "Prikazuje pregled podešavanja pasusa."
+
+#: ../src/richtext/richtextliststylepage.cpp:182
+msgid "&List level:"
+msgstr "&Nivo liste:"
+
+#: ../src/richtext/richtextliststylepage.cpp:186
+#: ../src/richtext/richtextliststylepage.cpp:188
+msgid "Selects the list level to edit."
+msgstr "Bira nivo liste za uređivanje."
+
+#: ../src/richtext/richtextliststylepage.cpp:193
+msgid "&Font for Level..."
+msgstr "&Font za nivo..."
+
+#: ../src/richtext/richtextliststylepage.cpp:194
+#: ../src/richtext/richtextliststylepage.cpp:196
+msgid "Click to choose the font for this level."
+msgstr "Kliknite da izaberete font za ovaj nivo."
+
+#: ../src/richtext/richtextliststylepage.cpp:312
+msgid "Bullet style"
+msgstr "Stil nabrajanja"
+
+#: ../src/richtext/richtextliststylepage.cpp:429
+msgid "Before a paragraph:"
+msgstr "Pre pasusa:"
+
+#: ../src/richtext/richtextliststylepage.cpp:438
+msgid "After a paragraph:"
+msgstr "Nakon pasusa:"
+
+#: ../src/richtext/richtextliststylepage.cpp:447
+msgid "Line spacing:"
+msgstr "Odvajanje redova:"
+
+#: ../src/richtext/richtextliststylepage.cpp:470
+msgid "Spacing"
+msgstr "Odvajanje"
+
+#: ../src/richtext/richtextmarginspage.cpp:193
+#: ../src/richtext/richtextmarginspage.cpp:195
+msgid "The left margin size."
+msgstr "Veličina leve margine."
+
+#: ../src/richtext/richtextmarginspage.cpp:203
+#: ../src/richtext/richtextmarginspage.cpp:205
+msgid "Units for the left margin."
+msgstr "Jedinice za levu marginu."
+
+#: ../src/richtext/richtextmarginspage.cpp:218
+#: ../src/richtext/richtextmarginspage.cpp:220
+msgid "The right margin size."
+msgstr "Veličina desne margine."
+
+#: ../src/richtext/richtextmarginspage.cpp:228
+#: ../src/richtext/richtextmarginspage.cpp:230
+msgid "Units for the right margin."
+msgstr "Jedinice za desnu marginu."
+
+#: ../src/richtext/richtextmarginspage.cpp:241
+#: ../src/richtext/richtextmarginspage.cpp:243
+msgid "The top margin size."
+msgstr "Veličina gornje margine."
+
+#: ../src/richtext/richtextmarginspage.cpp:251
+#: ../src/richtext/richtextmarginspage.cpp:253
+msgid "Units for the top margin."
+msgstr "Jedinice za gornju marginu."
+
+#: ../src/richtext/richtextmarginspage.cpp:266
+#: ../src/richtext/richtextmarginspage.cpp:268
+msgid "The bottom margin size."
+msgstr "Veličina donje margine."
+
+#: ../src/richtext/richtextmarginspage.cpp:276
+#: ../src/richtext/richtextmarginspage.cpp:278
+msgid "Units for the bottom margin."
+msgstr "Jedinice za donju marginu."
+
+#: ../src/richtext/richtextmarginspage.cpp:284
+msgid "Padding"
+msgstr "Razmak"
+
+#: ../src/richtext/richtextmarginspage.cpp:307
+#: ../src/richtext/richtextmarginspage.cpp:309
+msgid "The left padding size."
+msgstr "Veličina levog razmaka."
+
+#: ../src/richtext/richtextmarginspage.cpp:317
+#: ../src/richtext/richtextmarginspage.cpp:319
+msgid "Units for the left padding."
+msgstr "Jedinice za levi razmak."
+
+#: ../src/richtext/richtextmarginspage.cpp:332
+#: ../src/richtext/richtextmarginspage.cpp:334
+msgid "The right padding size."
+msgstr "Veličina desnog razmaka."
+
+#: ../src/richtext/richtextmarginspage.cpp:342
+#: ../src/richtext/richtextmarginspage.cpp:344
+msgid "Units for the right padding."
+msgstr "Jedinice za desni razmak."
+
+#: ../src/richtext/richtextmarginspage.cpp:355
+#: ../src/richtext/richtextmarginspage.cpp:357
+msgid "The top padding size."
+msgstr "Veličina gornjeg razmaka."
+
+#: ../src/richtext/richtextmarginspage.cpp:365
+#: ../src/richtext/richtextmarginspage.cpp:367
+msgid "Units for the top padding."
+msgstr "Jedinice za gornji razmak."
+
+#: ../src/richtext/richtextmarginspage.cpp:380
+#: ../src/richtext/richtextmarginspage.cpp:382
+msgid "The bottom padding size."
+msgstr "Veličina donjeg razmaka."
+
+#: ../src/richtext/richtextmarginspage.cpp:390
+#: ../src/richtext/richtextmarginspage.cpp:392
+msgid "Units for the bottom padding."
+msgstr "Jedinice za donji razmak."
+
+#: ../src/richtext/richtextprint.cpp:592
+msgid " Preview"
+msgstr "Pregled"
+
+#: ../src/richtext/richtextsizepage.cpp:228
+msgid "Floating"
+msgstr "Plutanje"
+
+#: ../src/richtext/richtextsizepage.cpp:243
+msgid "&Floating mode:"
+msgstr "&Režim plutanja:"
+
+#: ../src/richtext/richtextsizepage.cpp:252
+#: ../src/richtext/richtextsizepage.cpp:254
+msgid "How the object will float relative to the text."
+msgstr "Kako će objekti plutati u odnosu na tekst."
+
+#: ../src/richtext/richtextsizepage.cpp:265
+msgid "Alignment"
+msgstr "Poravnanje"
+
+#: ../src/richtext/richtextsizepage.cpp:277
+msgid "&Vertical alignment:"
+msgstr "&Vertikalno poravnanje:"
+
+#: ../src/richtext/richtextsizepage.cpp:279
+#: ../src/richtext/richtextsizepage.cpp:281
+msgid "Enable vertical alignment."
+msgstr "Omogući vertikalno poravnanje."
+
+#: ../src/richtext/richtextsizepage.cpp:286
+msgid "Centred"
+msgstr "Centriraj"
+
+#: ../src/richtext/richtextsizepage.cpp:290
+#: ../src/richtext/richtextsizepage.cpp:292
+msgid "Vertical alignment."
+msgstr "Vertikalno poravnanje."
+
+#: ../src/richtext/richtextsizepage.cpp:316
+#: ../src/richtext/richtextsizepage.cpp:323
+msgid "&Width:"
+msgstr "&Širina:"
+
+#: ../src/richtext/richtextsizepage.cpp:318
+#: ../src/richtext/richtextsizepage.cpp:320
+msgid "Enable the width value."
+msgstr "Omogući vrednost širine."
+
+#: ../src/richtext/richtextsizepage.cpp:331
+#: ../src/richtext/richtextsizepage.cpp:333
+msgid "The object width."
+msgstr "Širina objekata."
+
+#: ../src/richtext/richtextsizepage.cpp:342
+#: ../src/richtext/richtextsizepage.cpp:344
+msgid "Units for the object width."
+msgstr "Jedinice za širinu objekata."
+
+#: ../src/richtext/richtextsizepage.cpp:350
+#: ../src/richtext/richtextsizepage.cpp:357
+msgid "&Height:"
+msgstr "&Visina:"
+
+#: ../src/richtext/richtextsizepage.cpp:352
+#: ../src/richtext/richtextsizepage.cpp:354
+#: ../src/richtext/richtextsizepage.cpp:464
+#: ../src/richtext/richtextsizepage.cpp:466
+msgid "Enable the height value."
+msgstr "Omogući vrednost visine."
+
+#: ../src/richtext/richtextsizepage.cpp:365
+#: ../src/richtext/richtextsizepage.cpp:367
+msgid "The object height."
+msgstr "Visina objekata."
+
+#: ../src/richtext/richtextsizepage.cpp:376
+#: ../src/richtext/richtextsizepage.cpp:378
+msgid "Units for the object height."
+msgstr "Jedinice za visinu objekata."
+
+#: ../src/richtext/richtextsizepage.cpp:381
+msgid "Min width:"
+msgstr "Minimalna širina:"
+
+#: ../src/richtext/richtextsizepage.cpp:383
+#: ../src/richtext/richtextsizepage.cpp:385
+msgid "Enable the minimum width value."
+msgstr "Omogući minimalnu vrednost širine."
+
+#: ../src/richtext/richtextsizepage.cpp:392
+#: ../src/richtext/richtextsizepage.cpp:394
+msgid "The object minimum width."
+msgstr "Minimalna širina objekata."
+
+#: ../src/richtext/richtextsizepage.cpp:403
+#: ../src/richtext/richtextsizepage.cpp:405
+msgid "Units for the minimum object width."
+msgstr "Jedinice za minimalnu širinu objekata."
+
+#: ../src/richtext/richtextsizepage.cpp:408
+msgid "Min height:"
+msgstr "Minimalna visina:"
+
+#: ../src/richtext/richtextsizepage.cpp:410
+#: ../src/richtext/richtextsizepage.cpp:412
+msgid "Enable the minimum height value."
+msgstr "Omogući vrednost minimalne visine."
+
+#: ../src/richtext/richtextsizepage.cpp:419
+#: ../src/richtext/richtextsizepage.cpp:421
+msgid "The object minimum height."
+msgstr "Minimalna visina objekata."
+
+#: ../src/richtext/richtextsizepage.cpp:430
+#: ../src/richtext/richtextsizepage.cpp:432
+msgid "Units for the minimum object height."
+msgstr "Jedinice za minimalnu visinu objekata."
+
+#: ../src/richtext/richtextsizepage.cpp:435
+msgid "Max width:"
+msgstr "Maksimalna širina:"
+
+#: ../src/richtext/richtextsizepage.cpp:437
+#: ../src/richtext/richtextsizepage.cpp:439
+msgid "Enable the maximum width value."
+msgstr "Omogući vrednost maksimalne širine."
+
+#: ../src/richtext/richtextsizepage.cpp:446
+#: ../src/richtext/richtextsizepage.cpp:448
+msgid "The object maximum width."
+msgstr "Maksimalna širina objekta."
+
+#: ../src/richtext/richtextsizepage.cpp:457
+#: ../src/richtext/richtextsizepage.cpp:459
+msgid "Units for the maximum object width."
+msgstr "Jedinice za maksimalnu širinu objekta."
+
+#: ../src/richtext/richtextsizepage.cpp:462
+msgid "Max height:"
+msgstr "Maksimalna visina:"
+
+#: ../src/richtext/richtextsizepage.cpp:473
+#: ../src/richtext/richtextsizepage.cpp:475
+msgid "The object maximum height."
+msgstr "Maksimalna visina objekta."
+
+#: ../src/richtext/richtextsizepage.cpp:484
+#: ../src/richtext/richtextsizepage.cpp:486
+msgid "Units for the maximum object height."
+msgstr "Jedinice za maksimalnu visinu objekta."
+
+#: ../src/richtext/richtextsizepage.cpp:495
+msgid "Position"
+msgstr "Pozicija"
+
+#: ../src/richtext/richtextsizepage.cpp:513
+msgid "&Position mode:"
+msgstr "&Režim pozicije:"
+
+#: ../src/richtext/richtextsizepage.cpp:517
+#: ../src/richtext/richtextsizepage.cpp:522
+msgid "Static"
+msgstr "Statični"
+
+#: ../src/richtext/richtextsizepage.cpp:518
+msgid "Relative"
+msgstr "Relativni"
+
+#: ../src/richtext/richtextsizepage.cpp:519
+msgid "Absolute"
+msgstr "Apsolutni"
+
+#: ../src/richtext/richtextsizepage.cpp:520
+msgid "Fixed"
+msgstr "Fiksni"
+
+#: ../src/richtext/richtextsizepage.cpp:533
+#: ../src/richtext/richtextsizepage.cpp:535
+#: ../src/richtext/richtextsizepage.cpp:547
+#: ../src/richtext/richtextsizepage.cpp:549
+msgid "The left position."
+msgstr "Leva pozicija."
+
+#: ../src/richtext/richtextsizepage.cpp:558
+#: ../src/richtext/richtextsizepage.cpp:560
+msgid "Units for the left position."
+msgstr "Jedinice za levu poziciju."
+
+#: ../src/richtext/richtextsizepage.cpp:568
+#: ../src/richtext/richtextsizepage.cpp:570
+#: ../src/richtext/richtextsizepage.cpp:582
+#: ../src/richtext/richtextsizepage.cpp:584
+msgid "The top position."
+msgstr "Gornja pozicija."
+
+#: ../src/richtext/richtextsizepage.cpp:593
+#: ../src/richtext/richtextsizepage.cpp:595
+msgid "Units for the top position."
+msgstr "Jedinice za gornju poziciju."
+
+#: ../src/richtext/richtextsizepage.cpp:603
+#: ../src/richtext/richtextsizepage.cpp:605
+#: ../src/richtext/richtextsizepage.cpp:617
+#: ../src/richtext/richtextsizepage.cpp:619
+msgid "The right position."
+msgstr "Desna pozicija."
+
+#: ../src/richtext/richtextsizepage.cpp:628
+#: ../src/richtext/richtextsizepage.cpp:630
+msgid "Units for the right position."
+msgstr "Jedinice za desnu poziciju."
+
+#: ../src/richtext/richtextsizepage.cpp:638
+#: ../src/richtext/richtextsizepage.cpp:640
+#: ../src/richtext/richtextsizepage.cpp:652
+#: ../src/richtext/richtextsizepage.cpp:654
+msgid "The bottom position."
+msgstr "Donja pozicija."
+
+#: ../src/richtext/richtextsizepage.cpp:663
+#: ../src/richtext/richtextsizepage.cpp:665
+msgid "Units for the bottom position."
+msgstr "Jedinice za donju poziciju."
+
+#: ../src/richtext/richtextsizepage.cpp:671
+msgid "&Move the object to:"
+msgstr "&Premesti objekat na:"
+
+#: ../src/richtext/richtextsizepage.cpp:674
+msgid "&Previous Paragraph"
+msgstr "&Prethodni pasus"
+
+#: ../src/richtext/richtextsizepage.cpp:675
+#: ../src/richtext/richtextsizepage.cpp:677
+msgid "Moves the object to the previous paragraph."
+msgstr "Premešta objekat na prethodni pasus."
+
+#: ../src/richtext/richtextsizepage.cpp:680
+msgid "&Next Paragraph"
+msgstr "&Sledeći pasus"
+
+#: ../src/richtext/richtextsizepage.cpp:681
+#: ../src/richtext/richtextsizepage.cpp:683
+msgid "Moves the object to the next paragraph."
+msgstr "Premešta objekat na sledeći pasus."
+
+#: ../src/richtext/richtextstyledlg.cpp:193
+msgid "&Styles:"
+msgstr "&Stilovi:"
+
+#: ../src/richtext/richtextstyledlg.cpp:197
+#: ../src/richtext/richtextstyledlg.cpp:199
+msgid "The available styles."
+msgstr "Dostupni stilovi."
+
+#: ../src/richtext/richtextstyledlg.cpp:205
+#: ../src/richtext/richtextstyledlg.cpp:217
+msgid " "
+msgstr " "
+
+#: ../src/richtext/richtextstyledlg.cpp:209
+#: ../src/richtext/richtextstyledlg.cpp:211
+msgid "The style preview."
+msgstr "Pregled stila."
+
+#: ../src/richtext/richtextstyledlg.cpp:220
+msgid "New &Character Style..."
+msgstr "Novi stil &znakova..."
+
+#: ../src/richtext/richtextstyledlg.cpp:221
+#: ../src/richtext/richtextstyledlg.cpp:223
+msgid "Click to create a new character style."
+msgstr "Kliknite da napravite novi stil znakova."
+
+#: ../src/richtext/richtextstyledlg.cpp:226
+msgid "New &Paragraph Style..."
+msgstr "Novi stil &pasusa..."
+
+#: ../src/richtext/richtextstyledlg.cpp:227
+#: ../src/richtext/richtextstyledlg.cpp:229
+msgid "Click to create a new paragraph style."
+msgstr "Kliknite da napravite novi stil pasusa."
+
+#: ../src/richtext/richtextstyledlg.cpp:232
+msgid "New &List Style..."
+msgstr "Novi stil &liste..."
+
+#: ../src/richtext/richtextstyledlg.cpp:233
+#: ../src/richtext/richtextstyledlg.cpp:235
+msgid "Click to create a new list style."
+msgstr "Kliknite da napravite novi stil liste."
+
+#: ../src/richtext/richtextstyledlg.cpp:238
+msgid "New &Box Style..."
+msgstr "Novi stil &okvira..."
+
+#: ../src/richtext/richtextstyledlg.cpp:239
+#: ../src/richtext/richtextstyledlg.cpp:241
+msgid "Click to create a new box style."
+msgstr "Kliknite da napravite novi stil okvira."
+
+#: ../src/richtext/richtextstyledlg.cpp:246
+msgid "&Apply Style"
+msgstr "&Primeni stil"
+
+#: ../src/richtext/richtextstyledlg.cpp:247
+#: ../src/richtext/richtextstyledlg.cpp:249
+msgid "Click to apply the selected style."
+msgstr "Kliknite da primenite izabrani stil."
+
+#: ../src/richtext/richtextstyledlg.cpp:252
+msgid "&Rename Style..."
+msgstr "&Preimenuj stil..."
+
+#: ../src/richtext/richtextstyledlg.cpp:253
+#: ../src/richtext/richtextstyledlg.cpp:255
+msgid "Click to rename the selected style."
+msgstr "Kliknite da preimenujete izabrani stil."
+
+#: ../src/richtext/richtextstyledlg.cpp:258
+msgid "&Edit Style..."
+msgstr "&Uredi stil..."
+
+#: ../src/richtext/richtextstyledlg.cpp:259
+#: ../src/richtext/richtextstyledlg.cpp:261
+msgid "Click to edit the selected style."
+msgstr "Kliknite da uredite izabrani stil."
+
+#: ../src/richtext/richtextstyledlg.cpp:264
+msgid "&Delete Style..."
+msgstr "&Obriši stil..."
+
+#: ../src/richtext/richtextstyledlg.cpp:265
+#: ../src/richtext/richtextstyledlg.cpp:267
+msgid "Click to delete the selected style."
+msgstr "Kliknite da obrišete izabrani stil."
+
+#: ../src/richtext/richtextstyledlg.cpp:274
+#: ../src/richtext/richtextstyledlg.cpp:276
+msgid "Click to close this window."
+msgstr "Kliknite da zatvorite ovaj prozor."
+
+#: ../src/richtext/richtextstyledlg.cpp:282
+msgid "&Restart numbering"
+msgstr "&Vrati nabrajanje"
+
+#: ../src/richtext/richtextstyledlg.cpp:284
+#: ../src/richtext/richtextstyledlg.cpp:286
+msgid "Check to restart numbering."
+msgstr "Čekirajte da vratite nabrajanje."
+
+#: ../src/richtext/richtextstyledlg.cpp:601
+msgid "Enter a character style name"
+msgstr "Upišite ime stila  znakova"
+
+#: ../src/richtext/richtextstyledlg.cpp:601
+#: ../src/richtext/richtextstyledlg.cpp:606
+#: ../src/richtext/richtextstyledlg.cpp:649
+#: ../src/richtext/richtextstyledlg.cpp:654
+#: ../src/richtext/richtextstyledlg.cpp:815
+#: ../src/richtext/richtextstyledlg.cpp:820
+#: ../src/richtext/richtextstyledlg.cpp:888
+#: ../src/richtext/richtextstyledlg.cpp:896
+#: ../src/richtext/richtextstyledlg.cpp:929
+#: ../src/richtext/richtextstyledlg.cpp:934
+msgid "New Style"
+msgstr "Novi stil"
+
+#: ../src/richtext/richtextstyledlg.cpp:606
+#: ../src/richtext/richtextstyledlg.cpp:654
+#: ../src/richtext/richtextstyledlg.cpp:820
+#: ../src/richtext/richtextstyledlg.cpp:896
+#: ../src/richtext/richtextstyledlg.cpp:934
+msgid "Sorry, that name is taken. Please choose another."
+msgstr "Žao nam je, to ime je zauzeto. Molimo izaberite drugo."
+
+#: ../src/richtext/richtextstyledlg.cpp:649
+msgid "Enter a paragraph style name"
+msgstr "Upišite ime stila pasusa"
+
+#: ../src/richtext/richtextstyledlg.cpp:777
+#, c-format
+msgid "Delete style %s?"
+msgstr "Obrisati stil %s?"
+
+#: ../src/richtext/richtextstyledlg.cpp:777
+msgid "Delete Style"
+msgstr "Obriši stil"
+
+#: ../src/richtext/richtextstyledlg.cpp:815
+msgid "Enter a list style name"
+msgstr "Upišite ime stila liste"
+
+#: ../src/richtext/richtextstyledlg.cpp:888
+msgid "Enter a new style name"
+msgstr "Upišite novo ime stila"
+
+#: ../src/richtext/richtextstyledlg.cpp:929
+msgid "Enter a box style name"
+msgstr "Upišite ime stila okvira"
+
+#: ../src/richtext/richtextstylepage.cpp:109
+#: ../src/richtext/richtextstylepage.cpp:111
+msgid "The style name."
+msgstr "Ime stila."
+
+#: ../src/richtext/richtextstylepage.cpp:114
+msgid "&Based on:"
+msgstr "&Zasnovan na:"
+
+#: ../src/richtext/richtextstylepage.cpp:119
+#: ../src/richtext/richtextstylepage.cpp:121
+msgid "The style on which this style is based."
+msgstr "Stil na kojem je ovaj stil zasnovan."
+
+#: ../src/richtext/richtextstylepage.cpp:124
+msgid "&Next style:"
+msgstr "&Sledeći stil:"
+
+#: ../src/richtext/richtextstylepage.cpp:129
+#: ../src/richtext/richtextstylepage.cpp:131
+msgid "The default style for the next paragraph."
+msgstr "Podrazumevani stil za sledeći pasus."
+
+#: ../src/richtext/richtextstyles.cpp:1057
+msgid "All styles"
+msgstr "Svi stilovi"
+
+#: ../src/richtext/richtextstyles.cpp:1058
+msgid "Paragraph styles"
+msgstr "Stilovi pasusa"
+
+#: ../src/richtext/richtextstyles.cpp:1059
+msgid "Character styles"
+msgstr "Stilovi znakova"
+
+#: ../src/richtext/richtextstyles.cpp:1060
+msgid "List styles"
+msgstr "Stilovi liste"
+
+#: ../src/richtext/richtextstyles.cpp:1061
+msgid "Box styles"
+msgstr "Stilovi okvira"
+
+#: ../src/richtext/richtextsymboldlg.cpp:389
+#: ../src/richtext/richtextsymboldlg.cpp:391
+msgid "The font from which to take the symbol."
+msgstr "Font iz kojeg treba uzeti simbol."
+
+#: ../src/richtext/richtextsymboldlg.cpp:396
+msgid "&Subset:"
+msgstr "&Podskup:"
+
+#: ../src/richtext/richtextsymboldlg.cpp:401
+#: ../src/richtext/richtextsymboldlg.cpp:403
+msgid "Shows a Unicode subset."
+msgstr "Prikazuje unikodni podskup."
+
+#: ../src/richtext/richtextsymboldlg.cpp:412
+msgid "xxxx"
+msgstr "xxxx"
+
+#: ../src/richtext/richtextsymboldlg.cpp:417
+msgid "&Character code:"
+msgstr "&Kod znaka:"
+
+#: ../src/richtext/richtextsymboldlg.cpp:421
+#: ../src/richtext/richtextsymboldlg.cpp:423
+msgid "The character code."
+msgstr "Kod znaka."
+
+#: ../src/richtext/richtextsymboldlg.cpp:428
+msgid "&From:"
+msgstr "&Iz:"
+
+#: ../src/richtext/richtextsymboldlg.cpp:433
+#: ../src/richtext/richtextsymboldlg.cpp:434
+#: ../src/richtext/richtextsymboldlg.cpp:435
+msgid "Unicode"
+msgstr "Unikodni"
+
+#: ../src/richtext/richtextsymboldlg.cpp:436
+#: ../src/richtext/richtextsymboldlg.cpp:438
+msgid "The range to show."
+msgstr "Opseg za prikazivanje."
+
+#: ../src/richtext/richtextsymboldlg.cpp:444
+msgid "Insert"
+msgstr "Ubaci"
+
+#: ../src/richtext/richtextsymboldlg.cpp:478
+msgid "(Normal text)"
+msgstr "(standardan tekst)"
+
+#: ../src/richtext/richtexttabspage.cpp:109
+msgid "&Position (tenths of a mm):"
+msgstr "&Pozicija (desetine milimetra):"
+
+#: ../src/richtext/richtexttabspage.cpp:113
+#: ../src/richtext/richtexttabspage.cpp:115
+msgid "The tab position."
+msgstr "Pozicija tabulatora."
+
+#: ../src/richtext/richtexttabspage.cpp:119
+msgid "The tab positions."
+msgstr "Pozicije tabulatora."
+
+#: ../src/richtext/richtexttabspage.cpp:132
+#: ../src/richtext/richtexttabspage.cpp:134
+msgid "Click to create a new tab position."
+msgstr "Kliknite da napravite novu poziciju tabulatora."
+
+#: ../src/richtext/richtexttabspage.cpp:138
+#: ../src/richtext/richtexttabspage.cpp:140
+msgid "Click to delete the selected tab position."
+msgstr "Kliknite da obrišete izabranu poziciju tabulatora."
+
+#: ../src/richtext/richtexttabspage.cpp:143
+msgid "Delete A&ll"
+msgstr "Obriši &sve"
+
+#: ../src/richtext/richtexttabspage.cpp:144
+#: ../src/richtext/richtexttabspage.cpp:146
+msgid "Click to delete all tab positions."
+msgstr "Kliknite da obrišete sve pozicije tabulatora."
+
+#: ../src/univ/theme.cpp:110
+msgid "Failed to initialize GUI: no built-in themes found."
+msgstr "Neuspešna GUI inicijalizacija: nijedna ugrađena tema nije pronađena."
+
+#: ../src/univ/themes/gtk.cpp:521
+msgid "GTK+ theme"
+msgstr "GTK+ tema"
+
+#: ../src/univ/themes/metal.cpp:164
+msgid "Metal theme"
+msgstr "Metal tema"
+
+#: ../src/univ/themes/mono.cpp:512
+msgid "Simple monochrome theme"
+msgstr "Simple monochrome tema"
+
+#: ../src/univ/themes/win32.cpp:1098
+msgid "Win32 theme"
+msgstr "Win32 tema"
+
+#: ../src/univ/themes/win32.cpp:3743
+msgid "&Restore"
+msgstr "&Vrati"
+
+#: ../src/univ/themes/win32.cpp:3744
+msgid "&Move"
+msgstr "&Premesti"
+
+#: ../src/univ/themes/win32.cpp:3746
+msgid "&Size"
+msgstr "&Veličina"
+
+#: ../src/univ/themes/win32.cpp:3748
+msgid "Mi&nimize"
+msgstr "&Umanji"
+
+#: ../src/univ/themes/win32.cpp:3750
+msgid "Ma&ximize"
+msgstr "U&većaj"
+
+#: ../src/univ/themes/win32.cpp:3752
+msgid "Alt+"
+msgstr "Alt+"
+
+#: ../src/unix/appunix.cpp:178
+msgid "Failed to install signal handler"
+msgstr "Neuspešno instaliranje obrađivača signala"
+
+#: ../src/unix/dialup.cpp:351
+msgid "Already dialling ISP."
+msgstr "Već se bira servisni provajder."
+
+#: ../src/unix/dlunix.cpp:93
+msgid "Failed to unload shared library"
+msgstr "Nemoguće osloboditi deljenu biblioteku"
+
+#: ../src/unix/dlunix.cpp:121
+msgid "Unknown dynamic library error"
+msgstr "Nepoznata greška dinamičke biblioteke"
+
+#: ../src/unix/epolldispatcher.cpp:84
+msgid "Failed to create epoll descriptor"
+msgstr "Neuspešno pravljenje epoll descriptor-a"
+
+#: ../src/unix/epolldispatcher.cpp:103
+msgid "Error closing epoll descriptor"
+msgstr "Neuspešno zatvaranje epoll descriptor-a"
+
+#: ../src/unix/epolldispatcher.cpp:116
+#, c-format
+msgid "Failed to add descriptor %d to epoll descriptor %d"
+msgstr "Neuspešno dodavanje descriptor-a %d epoll descriptor-u %d"
+
+#: ../src/unix/epolldispatcher.cpp:136
+#, c-format
+msgid "Failed to modify descriptor %d in epoll descriptor %d"
+msgstr "Neuspešna izmena descriptor-a %d u epoll descriptor-u %d"
+
+#: ../src/unix/epolldispatcher.cpp:155
+#, c-format
+msgid "Failed to unregister descriptor %d from epoll descriptor %d"
+msgstr "Neuspešna deregistracija descriptor-a %d od epoll descriptor-a %d"
+
+#: ../src/unix/epolldispatcher.cpp:213
+#, c-format
+msgid "Waiting for IO on epoll descriptor %d failed"
+msgstr "Čekanje na IO na epoll descriptor-u %d nije uspelo"
+
+#: ../src/unix/fswatcher_inotify.cpp:71
+msgid "Unable to create inotify instance"
+msgstr "Nemoguće napraviti inotify instancu"
+
+#: ../src/unix/fswatcher_inotify.cpp:94
+msgid "Unable to close inotify instance"
+msgstr "Nemoguće zatvoriti inotify instancu"
+
+#: ../src/unix/fswatcher_inotify.cpp:106
+msgid "Unable to add inotify watch"
+msgstr "Nemoguće dodati inotify watch"
+
+#: ../src/unix/fswatcher_inotify.cpp:138
+#, c-format
+msgid "Unable to remove inotify watch %i"
+msgstr "Nemoguće ukloniti inotify watch %i"
+
+#: ../src/unix/fswatcher_inotify.cpp:271
+#, c-format
+msgid "Unexpected event for \"%s\": no matching watch descriptor."
+msgstr "Neočekivani događaj za \"%s\": nema podudarajućih watch descriptor-a."
+
+#: ../src/unix/fswatcher_inotify.cpp:320
+#, c-format
+msgid "Invalid inotify event for \"%s\""
+msgstr "Neispravan inotify događaj za \"%s\""
+
+#: ../src/unix/fswatcher_inotify.cpp:553
+msgid "Unable to read from inotify descriptor"
+msgstr "Nemoguće čitati iz inotify descriptor-a"
+
+#: ../src/unix/fswatcher_inotify.cpp:558
+msgid "EOF while reading from inotify descriptor"
+msgstr "Neočekivani kraj datoteke u toku čitanja iz inotify descriptor-a"
+
+#: ../src/unix/fswatcher_kqueue.cpp:114
+msgid "Unable to create kqueue instance"
+msgstr "Nemoguće napraviti kqueue instancu"
+
+#: ../src/unix/fswatcher_kqueue.cpp:131
+msgid "Error closing kqueue instance"
+msgstr "Greška pri zatvaranju kqueue instance"
+
+#: ../src/unix/fswatcher_kqueue.cpp:153
+msgid "Unable to add kqueue watch"
+msgstr "Nemoguće dodati kqueue watch"
+
+#: ../src/unix/fswatcher_kqueue.cpp:170
+msgid "Unable to remove kqueue watch"
+msgstr "Nemoguće ukloniti kqueue watch"
+
+#: ../src/unix/fswatcher_kqueue.cpp:202
+msgid "Unable to get events from kqueue"
+msgstr "Nemoguće preuzeti događaje iz kqueue"
+
+#: ../src/unix/mediactrl.cpp:966
+#, c-format
+msgid "Media playback error: %s"
+msgstr "Greška pri reprodukciji medija: %s"
+
+#: ../src/unix/mediactrl.cpp:1228
+#, c-format
+msgid "Failed to prepare playing \"%s\"."
+msgstr "Neuspešna priprema reprodukcije \"%s\"."
+
+#: ../src/unix/snglinst.cpp:164
+#, c-format
+msgid "Failed to write to lock file '%s'"
+msgstr "Neuspešno pisanje u lock datoteku '%s'"
+
+#: ../src/unix/snglinst.cpp:177
+#, c-format
+msgid "Failed to set permissions on lock file '%s'"
+msgstr "Neuspešno postavljanje dozvola za lock datoteku '%s'"
+
+#: ../src/unix/snglinst.cpp:194
+#, c-format
+msgid "Failed to lock the lock file '%s'"
+msgstr "Neuspešno zaključavanje lock datoteke '%s'"
+
+#: ../src/unix/snglinst.cpp:237
+#, c-format
+msgid "Failed to inspect the lock file '%s'"
+msgstr "Neuspešan pregled lock datoteke '%s'"
+
+#: ../src/unix/snglinst.cpp:242
+#, c-format
+msgid "Lock file '%s' has incorrect owner."
+msgstr "Lock datoteka '%s' ima neispravnog vlasnika."
+
+#: ../src/unix/snglinst.cpp:247
+#, c-format
+msgid "Lock file '%s' has incorrect permissions."
+msgstr "Lock datoteka '%s' ima neispravne dozvole."
+
+#: ../src/unix/snglinst.cpp:265
+msgid "Failed to access lock file."
+msgstr "Neuspešan pristup lock datoteci."
+
+#: ../src/unix/snglinst.cpp:274
+msgid "Failed to read PID from lock file."
+msgstr "Neuspešno čitanje PID-a iz lock datoteke."
+
+#: ../src/unix/snglinst.cpp:284
+#, c-format
+msgid "Failed to remove stale lock file '%s'."
+msgstr "Neuspešno uklanjanje zastarele lock datoteke '%s'."
+
+#: ../src/unix/snglinst.cpp:297
+#, c-format
+msgid "Deleted stale lock file '%s'."
+msgstr "Obrisana zastarela lock datoteka '%s'."
+
+#: ../src/unix/snglinst.cpp:308
+#, c-format
+msgid "Invalid lock file '%s'."
+msgstr "Neispravna lock datoteka '%s'."
+
+#: ../src/unix/snglinst.cpp:324
+#, c-format
+msgid "Failed to remove lock file '%s'"
+msgstr "Neuspešno uklanjanje lock datoteke '%s'"
+
+#: ../src/unix/snglinst.cpp:330
+#, c-format
+msgid "Failed to unlock lock file '%s'"
+msgstr "Neuspešno otključavanje lock datoteke '%s'"
+
+#: ../src/unix/snglinst.cpp:336
+#, c-format
+msgid "Failed to close lock file '%s'"
+msgstr "Neuspešno zatvaranje lock datoteke '%s'"
+
+#: ../src/unix/sound.cpp:77
+msgid "No sound"
+msgstr "Nema zvuka"
+
+#: ../src/unix/sound.cpp:364
+msgid "Unable to play sound asynchronously."
+msgstr "Nemoguća sinhrona reprodukcija zvuka."
+
+#: ../src/unix/sound.cpp:458
+#, c-format
+msgid "Couldn't load sound data from '%s'."
+msgstr "Nemoguće učitavanje podataka zvuka iz '%s'."
+
+#: ../src/unix/sound.cpp:465
+#, c-format
+msgid "Sound file '%s' is in unsupported format."
+msgstr "Zvučna datoteka '%s' je u formatu koji nije podržan."
+
+#: ../src/unix/sound.cpp:480
+msgid "Sound data are in unsupported format."
+msgstr "Podaci zvuka su u formatu koji nije podržan."
+
+#: ../src/unix/sound_sdl.cpp:226
+#, c-format
+msgid "Couldn't open audio: %s"
+msgstr "Nemoguće otvoriti zvučni zapis: %s"
+
+#: ../src/unix/threadpsx.cpp:1033
+msgid "Cannot retrieve thread scheduling policy."
+msgstr "Nemoguće preuzeti polisu rasporeda threadova."
+
+#: ../src/unix/threadpsx.cpp:1058
+#, c-format
+msgid "Cannot get priority range for scheduling policy %d."
+msgstr "Nemoguće preuzeti opseg prioriteta za polisu rasporeda %d."
+
+#: ../src/unix/threadpsx.cpp:1066
+msgid "Thread priority setting is ignored."
+msgstr "Podešavanje prioriteta threadova se ignoriše."
+
+#: ../src/unix/threadpsx.cpp:1221
+msgid ""
+"Failed to join a thread, potential memory leak detected - please restart the "
+"program"
+msgstr ""
+"Neuspešno pridruživanje threadu, otkriveno potencialno zauzeće memorije - "
+"molimo ponovo  pokrenite program"
+
+#: ../src/unix/threadpsx.cpp:1352
+#, c-format
+msgid "Failed to set thread concurrency level to %lu"
+msgstr "Neuspešno podešavanje nivoa istovremenosti threada na %lu"
+
+#: ../src/unix/threadpsx.cpp:1481
+#, c-format
+msgid "Failed to set thread priority %d."
+msgstr "Neuspešno podešavanje prioriteta threada %d."
+
+#: ../src/unix/threadpsx.cpp:1666
+msgid "Failed to terminate a thread."
+msgstr "Neuspešan završetak threada."
+
+#: ../src/unix/threadpsx.cpp:1893
+msgid "Thread module initialization failed: failed to create thread key"
+msgstr ""
+"Neuspešna inicijalizacija modula threada: neuspešno pravljenje ključa threada"
+
+#: ../src/unix/utilsunx.cpp:340
+msgid "Impossible to get child process input"
+msgstr "Nemoguće preuzeti unos manjeg procesa"
+
+#: ../src/unix/utilsunx.cpp:390
+msgid "Can't write to child process's stdin"
+msgstr "Nemoguće pisati u stdin manjeg procesa"
+
+#: ../src/unix/utilsunx.cpp:644
+#, c-format
+msgid "Failed to execute '%s'\n"
+msgstr "Neuspešno pokretanje '%s'\n"
+
+#: ../src/unix/utilsunx.cpp:678
+msgid "Fork failed"
+msgstr "Fork je neuspešan"
+
+#: ../src/unix/utilsunx.cpp:701
+msgid "Failed to set process priority"
+msgstr "Neuspešno podešavanje prioriteta procesa"
+
+#: ../src/unix/utilsunx.cpp:712
+msgid "Failed to redirect child process input/output"
+msgstr "Neuspešno preusmeravanje ulaza/izlaza manjeg procesa"
+
+#: ../src/unix/utilsunx.cpp:816
+msgid "Failed to set up non-blocking pipe, the program might hang."
+msgstr "Nemoguće podesiti non-blocking pipe, program će možda čekati."
+
+#: ../src/unix/utilsunx.cpp:1023
+msgid "Cannot get the hostname"
+msgstr "Nemoguće preuzeti ime hosta"
+
+#: ../src/unix/utilsunx.cpp:1059
+msgid "Cannot get the official hostname"
+msgstr "Nemoguće preuzeti zvanično ime hosta"
+
+#: ../src/unix/wakeuppipe.cpp:49
+msgid "Failed to create wake up pipe used by event loop."
+msgstr ""
+"Neuspešno pravljenje wake up pipe-a koji se koristi od strane event loop-a."
+
+#: ../src/unix/wakeuppipe.cpp:56
+msgid "Failed to switch wake up pipe to non-blocking mode"
+msgstr "Neuspešno prebacivanje wake up pipe-a u non-blocking režim"
+
+#: ../src/unix/wakeuppipe.cpp:117
+msgid "Failed to read from wake-up pipe"
+msgstr "Neuspešno čitanje iz wake-up pipe-a"
+
+#: ../src/x11/app.cpp:124
+#, c-format
+msgid "Invalid geometry specification '%s'"
+msgstr "Neispravna geometrijska specifikacija '%s'"
+
+#: ../src/x11/app.cpp:167
+msgid "wxWidgets could not open display. Exiting."
+msgstr "wxWidgets nije mogao da pristupi ekranu. Izlaz."
+
+#: ../src/x11/utils.cpp:169
+#, c-format
+msgid "Failed to close the display \"%s\""
+msgstr "Neuspešno zatvaranje ekrana \"%s\""
+
+#: ../src/x11/utils.cpp:188
+#, c-format
+msgid "Failed to open display \"%s\"."
+msgstr "Neuspešno otvaranje ekrana \"%s\"."
+
+#: ../src/xml/xml.cpp:868
+#, c-format
+msgid "XML parsing error: '%s' at line %d"
+msgstr "Greška XML raščlanjivanja: '%s' u redu %d"
+
+#: ../src/xrc/xh_propgrid.cpp:239
+#, fuzzy, c-format
+msgid "Page %i"
+msgstr "Stranica %d"
+
+#: ../src/xrc/xmlres.cpp:448
+#, c-format
+msgid "Cannot load resources from '%s'."
+msgstr "Nemoguće učitati resurse iz '%s'."
+
+#: ../src/xrc/xmlres.cpp:799
+#, c-format
+msgid "Cannot open resources file '%s'."
+msgstr "Nemoguće otvoriti datoteku resursa '%s'."
+
+#: ../src/xrc/xmlres.cpp:806
+#, c-format
+msgid "Cannot load resources from file '%s'."
+msgstr "Nemoguće učitati resurse iz datoteke '%s'."
+
+#: ../src/xrc/xmlres.cpp:2767
+#, c-format
+msgid "Creating %s \"%s\" failed."
+msgstr "Pravljenje %s \"%s\" nije uspelo."
+
+#, c-format
+#~ msgid "BMP: header has biClrUsed=%d when biBitCount=%d."
+#~ msgstr "BMP: Zaglavlje ima biClrUsed=%d a biBitCount=%d."
+
+#~ msgctxt "keyboard key"
+#~ msgid "Alt+"
+#~ msgstr "Alt+"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Ctrl+"
+#~ msgstr "Ctrl+"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Shift+"
+#~ msgstr "Šift+"
+
+#~ msgctxt "keyboard key"
+#~ msgid "RawCtrl+"
+#~ msgstr "RawCtrl+"
+
+#~ msgid "Copying more than one selected block to clipboard is not supported."
+#~ msgstr ""
+#~ "Kopiranje više od jednog izabranog bloka u privremenu memoriju nije "
+#~ "podržano."
+
+#~ msgid "Unsupported clipboard format."
+#~ msgstr "Format privremene memorije nije podržan."
+
+#~ msgid "Background colour"
+#~ msgstr "Boja pozadine"
+
+#~ msgid "Font:"
+#~ msgstr "Font:"
+
+#~ msgid "Size:"
+#~ msgstr "Veličina:"
+
+#~ msgid "The font size in points."
+#~ msgstr "Veličina fonta u pointima."
+
+#~ msgid "Style:"
+#~ msgstr "Stil:"
+
+#~ msgid "Check to make the font bold."
+#~ msgstr "Označite da biste podebljali font."
+
+#~ msgid "Check to make the font italic."
+#~ msgstr "Označite da bi ste iskosili font."
+
+#~ msgid "Check to make the font underlined."
+#~ msgstr "Označite da biste podvukli font."
+
+#~ msgid "Colour:"
+#~ msgstr "Boja:"
+
+#~ msgid "Click to change the font colour."
+#~ msgstr "Kliknite da promenite boju fonta."
+
+#~ msgid "Shows a preview of the font."
+#~ msgstr "Prikazuje pregled fonta."
+
+#~ msgid "Click to cancel changes to the font."
+#~ msgstr "Kliknite da poništite promene fonta."
+
+#~ msgid "Click to confirm changes to the font."
+#~ msgstr "Kliknite da potvrdite promene fonta."
+
+#~ msgid "<Any>"
+#~ msgstr "<bilo koji>"
+
+#~ msgid "<Any Roman>"
+#~ msgstr "<Bilo koji Rimski>"
+
+#~ msgid "<Any Decorative>"
+#~ msgstr "<Bilo koji Dekorativni>"
+
+#~ msgid "<Any Modern>"
+#~ msgstr "<Bilo koji Moderni>"
+
+#~ msgid "<Any Script>"
+#~ msgstr "<Bilo koji pismo>"
+
+#~ msgid "<Any Swiss>"
+#~ msgstr "<Bilo koji Švajcarski>"
+
+#~ msgid "<Any Teletype>"
+#~ msgstr "<Bilo koji pisaća mašina>"
+
+#~ msgid "Printing "
+#~ msgstr "Štampanje"
+
+#~ msgid "Failed to insert text in the control."
+#~ msgstr "Ubacivanje teksta u kontrolu nije uspelo."
+
+#~ msgid "Please choose a valid font."
+#~ msgstr "Molimo izaberite ispravan font."
+
+#, c-format
+#~ msgid "Failed to display HTML document in %s encoding"
+#~ msgstr "Prikazivanje HTML dokumenta u %s kodiranju nije uspelo"
+
+#, c-format
+#~ msgid "wxWidgets could not open display for '%s': exiting."
+#~ msgstr "wxWidgets nije mogao da otvori prikazivanje za '%s': Izlaz."
+
+#~ msgid "Filter"
+#~ msgstr "Filtriranje"
+
+#~ msgid "Directories"
+#~ msgstr "Direktorijumi"
+
+#~ msgid "Files"
+#~ msgstr "Datoteke"
+
+#~ msgid "Selection"
+#~ msgstr "Izbor"
+
+#~ msgid "conversion to 8-bit encoding failed"
+#~ msgstr "Pretvaranje u 8-bitno kodiranje nije uspelo"
+
+#~ msgid "failed to retrieve execution result"
+#~ msgstr "Neuspešno preuzimanje rezultata izvršavanja"

--- a/po_wxstd/sv.po
+++ b/po_wxstd/sv.po
@@ -1,0 +1,10646 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: wxWidgets 3.3\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-05-14 20:23+0200\n"
+"PO-Revision-Date: 2014-02-23 11:45+0100\n"
+"Last-Translator: Jonas Rydberg <jonas@drevo.se>\n"
+"Language-Team: wxWidgets translators <wx-translators@googlegroups.com>\n"
+"Language: sv\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
+
+#: ../include/wx/defs.h:2582
+msgid "All files (*.*)|*.*"
+msgstr "Alla filer (*.*)|*.*"
+
+#: ../include/wx/defs.h:2585
+msgid "All files (*)|*"
+msgstr "Alla filer (*)|*"
+
+#: ../include/wx/generic/progdlgg.h:85
+msgid "Elapsed time:"
+msgstr "Passerad tid: "
+
+#: ../include/wx/generic/progdlgg.h:86
+msgid "Estimated time:"
+msgstr "Uppskattad tid: "
+
+#: ../include/wx/generic/progdlgg.h:87
+msgid "Remaining time:"
+msgstr "Återstående tid: "
+
+#. TRANSLATORS: HTML printout default title.
+#: ../include/wx/html/htmprint.h:121 ../include/wx/prntbase.h:273
+#: ../include/wx/richtext/richtextprint.h:109 ../src/common/docview.cpp:2161
+msgid "Printout"
+msgstr "Utskrift"
+
+#. TRANSLATORS: HTML easy print default title.
+#: ../include/wx/html/htmprint.h:234 ../include/wx/richtext/richtextprint.h:163
+#: ../src/common/prntbase.cpp:522 ../src/html/htmprint.cpp:291
+msgid "Printing"
+msgstr "Skriver ut "
+
+#: ../include/wx/msgdlg.h:277 ../src/common/stockitem.cpp:211
+msgid "Yes"
+msgstr "Ja"
+
+#: ../include/wx/msgdlg.h:278 ../src/common/stockitem.cpp:182
+msgid "No"
+msgstr "Nej"
+
+#: ../include/wx/msgdlg.h:279 ../src/common/stockitem.cpp:183
+#: ../src/msw/msgdlg.cpp:430 ../src/msw/msgdlg.cpp:734
+#: ../src/richtext/richtextstyledlg.cpp:292
+msgid "OK"
+msgstr "OK"
+
+#: ../include/wx/msgdlg.h:280 ../src/common/stockitem.cpp:150
+#: ../src/msw/msgdlg.cpp:430 ../src/msw/progdlg.cpp:884
+#: ../src/richtext/richtextstyledlg.cpp:295
+msgid "Cancel"
+msgstr "Avbryt"
+
+#: ../include/wx/msgdlg.h:281 ../src/common/stockitem.cpp:168
+#: ../src/html/helpdlg.cpp:63 ../src/html/helpfrm.cpp:108
+#: ../src/osx/button_osx.cpp:38
+msgid "Help"
+msgstr "Hjälp"
+
+#: ../include/wx/msw/ole/oleutils.h:52
+msgid "Cannot initialize OLE"
+msgstr "Kan inte initiera OLE"
+
+#: ../include/wx/msw/private/fswatcher.h:48
+#, c-format
+msgid "Unable to close the handle for '%s'"
+msgstr "Kunde inte stänga handtag för \"%s\""
+
+#: ../include/wx/msw/private/fswatcher.h:92
+#, c-format
+msgid "Failed to open directory \"%s\" for monitoring."
+msgstr "Kunde inte öppna katalog \"%s\" för bevakning."
+
+#: ../include/wx/msw/private/fswatcher.h:125
+msgid "Unable to close I/O completion port handle"
+msgstr "Kunde inte stänga I/O-avslutningsporthantag"
+
+#: ../include/wx/msw/private/fswatcher.h:142
+msgid "Unable to associate handle with I/O completion port"
+msgstr "Kunde inte associera handtag med I/O-avslutningsport"
+
+#: ../include/wx/msw/private/fswatcher.h:148
+msgid "Unexpectedly new I/O completion port was created"
+msgstr "Oväntad ny I/O-avslutningsport skapades"
+
+#: ../include/wx/msw/private/fswatcher.h:213
+msgid "Unable to post completion status"
+msgstr "Kunde inte skicka avslutningsstatus"
+
+#: ../include/wx/msw/private/fswatcher.h:262
+msgid "Unable to dequeue completion packet"
+msgstr "Kunde inte ta bort avslutningspaket från kö"
+
+#: ../include/wx/msw/private/fswatcher.h:273
+msgid "Unable to create I/O completion port"
+msgstr "Kunde inte skapa I/O-avslutningsport"
+
+#: ../include/wx/richmsgdlg.h:29
+msgid "&See details"
+msgstr "&Visa detaljer"
+
+#: ../include/wx/richmsgdlg.h:30
+msgid "&Hide details"
+msgstr "&Dölj detaljer"
+
+#: ../include/wx/richtext/richtextbuffer.h:3864
+msgid "&Box"
+msgstr "&Låda"
+
+#: ../include/wx/richtext/richtextbuffer.h:5008
+msgid "&Picture"
+msgstr "&Bild"
+
+#: ../include/wx/richtext/richtextbuffer.h:5958
+msgid "&Cell"
+msgstr "&Cell"
+
+#: ../include/wx/richtext/richtextbuffer.h:6067
+msgid "&Table"
+msgstr "&Tabell"
+
+#: ../include/wx/richtext/richtextimagedlg.h:37
+msgid "Object Properties"
+msgstr "Objektegenskaper"
+
+#: ../include/wx/richtext/richtextsymboldlg.h:39
+msgid "Symbols"
+msgstr "Symboler"
+
+#: ../include/wx/unix/pipe.h:46
+msgid "Pipe creation failed"
+msgstr "Kunde inte skapa rör (pipe)"
+
+#: ../include/wx/unix/private/displayx11.h:65
+msgid "Failed to enumerate video modes"
+msgstr "Kunde inte räkna upp videolägen"
+
+#: ../include/wx/unix/private/displayx11.h:89
+msgid "Failed to change video mode"
+msgstr "Kunde inte ändra videoläge"
+
+#: ../include/wx/unix/private/fswatcher_kqueue.h:57
+#, c-format
+msgid "Unable to open path '%s'"
+msgstr "Kunde inte öppna sökväg \"%s\""
+
+#: ../include/wx/unix/private/fswatcher_kqueue.h:74
+#, c-format
+msgid "Unable to close path '%s'"
+msgstr "Kunde inte stänga sökväg \"%s\""
+
+#: ../include/wx/xtiprop.h:175
+msgid "SetProperty called w/o valid setter"
+msgstr "SetProperty anropat utan giltigt tilldelningsobjekt"
+
+#: ../include/wx/xtiprop.h:184
+msgid "GetProperty called w/o valid getter"
+msgstr "GetProperty anropad utan giltigt hämtningsobjekt"
+
+#: ../include/wx/xtiprop.h:193
+msgid "AddToPropertyCollection called w/o valid adder"
+msgstr "AddToPropertyCollection anropad utan giltigt tilläggsobjekt"
+
+#: ../include/wx/xtiprop.h:202
+msgid "GetPropertyCollection called w/o valid collection getter"
+msgstr "GetPropertyCollection anropad utan giltigt samlingshämtningsobjekt"
+
+#: ../include/wx/xtiprop.h:255
+msgid "AddToPropertyCollection called on a generic accessor"
+msgstr "AddToPropertyCollection anropad på ett allmänt åtkomstobjekt"
+
+#: ../include/wx/xtiprop.h:262
+msgid "GetPropertyCollection called on a generic accessor"
+msgstr "GetPropertyCollection anropad på ett allmänt åtkomstobjekt"
+
+#: ../src/aui/tabmdi.cpp:106 ../src/generic/mdig.cpp:94
+msgid "Cl&ose"
+msgstr "St&äng"
+
+#: ../src/aui/tabmdi.cpp:107 ../src/generic/mdig.cpp:95
+msgid "Close All"
+msgstr "Stäng alla"
+
+#: ../src/aui/tabmdi.cpp:109 ../src/generic/mdig.cpp:97 ../src/msw/mdi.cpp:175
+#: ../src/qt/mdi.cpp:258
+msgid "&Next"
+msgstr "&Nästa"
+
+#: ../src/aui/tabmdi.cpp:110 ../src/generic/mdig.cpp:98 ../src/msw/mdi.cpp:176
+#: ../src/qt/mdi.cpp:259
+msgid "&Previous"
+msgstr "&Föregående"
+
+#: ../src/aui/tabmdi.cpp:332 ../src/aui/tabmdi.cpp:348
+#: ../src/aui/tabmdi.cpp:350 ../src/generic/mdig.cpp:291
+#: ../src/generic/mdig.cpp:307 ../src/generic/mdig.cpp:311
+#: ../src/msw/mdi.cpp:337 ../src/qt/mdi.cpp:462
+msgid "&Window"
+msgstr "&Fönster"
+
+#: ../src/common/accelcmn.cpp:47
+msgctxt "keyboard key"
+msgid "Delete"
+msgstr "Ta bort"
+
+#: ../src/common/accelcmn.cpp:48
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Del"
+msgstr "Ta bort"
+
+#: ../src/common/accelcmn.cpp:49
+msgctxt "keyboard key"
+msgid "Back"
+msgstr "Bakåt"
+
+#: ../src/common/accelcmn.cpp:49
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Backspace"
+msgstr "Bakåt"
+
+#: ../src/common/accelcmn.cpp:50
+msgctxt "keyboard key"
+msgid "Insert"
+msgstr "Sätt in"
+
+#: ../src/common/accelcmn.cpp:51
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Ins"
+msgstr "Infällning"
+
+#: ../src/common/accelcmn.cpp:52
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Enter"
+msgstr "Skrivare"
+
+#: ../src/common/accelcmn.cpp:53
+msgctxt "keyboard key"
+msgid "Return"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:54
+#, fuzzy
+msgctxt "keyboard key"
+msgid "PageUp"
+msgstr "Sidor"
+
+#: ../src/common/accelcmn.cpp:54
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Page Up"
+msgstr "Sida %d"
+
+#: ../src/common/accelcmn.cpp:55
+#, fuzzy
+msgctxt "keyboard key"
+msgid "PageDown"
+msgstr "Ner"
+
+#: ../src/common/accelcmn.cpp:55
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Page Down"
+msgstr "Sida %d"
+
+#: ../src/common/accelcmn.cpp:56
+msgctxt "keyboard key"
+msgid "PgUp"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:57
+msgctxt "keyboard key"
+msgid "PgDn"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:58
+msgctxt "keyboard key"
+msgid "Left"
+msgstr "Vänster"
+
+#: ../src/common/accelcmn.cpp:59
+msgctxt "keyboard key"
+msgid "Right"
+msgstr "Höger"
+
+#: ../src/common/accelcmn.cpp:60
+msgctxt "keyboard key"
+msgid "Up"
+msgstr "Upp"
+
+#: ../src/common/accelcmn.cpp:61
+msgctxt "keyboard key"
+msgid "Down"
+msgstr "Ner"
+
+#: ../src/common/accelcmn.cpp:62
+msgctxt "keyboard key"
+msgid "Home"
+msgstr "Hem"
+
+#: ../src/common/accelcmn.cpp:63
+msgctxt "keyboard key"
+msgid "End"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:64
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Space"
+msgstr "Avstånd"
+
+#: ../src/common/accelcmn.cpp:65
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Tab"
+msgstr "Tabbar"
+
+#: ../src/common/accelcmn.cpp:66
+msgctxt "keyboard key"
+msgid "Esc"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:67
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Escape"
+msgstr "Liggande"
+
+#: ../src/common/accelcmn.cpp:68
+msgctxt "keyboard key"
+msgid "Cancel"
+msgstr "Avbryt"
+
+#: ../src/common/accelcmn.cpp:69
+msgctxt "keyboard key"
+msgid "Clear"
+msgstr "Töm"
+
+#: ../src/common/accelcmn.cpp:70
+msgctxt "keyboard key"
+msgid "Menu"
+msgstr "Meny"
+
+#: ../src/common/accelcmn.cpp:71
+msgctxt "keyboard key"
+msgid "Pause"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:72
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Capital"
+msgstr "&Versaler"
+
+#: ../src/common/accelcmn.cpp:73
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Select"
+msgstr "Markering"
+
+#: ../src/common/accelcmn.cpp:74
+msgctxt "keyboard key"
+msgid "Print"
+msgstr "Skriv ut"
+
+#: ../src/common/accelcmn.cpp:75
+msgctxt "keyboard key"
+msgid "Execute"
+msgstr "Kör"
+
+#: ../src/common/accelcmn.cpp:76
+msgctxt "keyboard key"
+msgid "Snapshot"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:77
+msgctxt "keyboard key"
+msgid "Help"
+msgstr "Hjälp"
+
+#: ../src/common/accelcmn.cpp:78
+msgctxt "keyboard key"
+msgid "Add"
+msgstr "Lägg till"
+
+#: ../src/common/accelcmn.cpp:79
+msgctxt "keyboard key"
+msgid "Separator"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:80
+msgctxt "keyboard key"
+msgid "Subtract"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:81
+msgctxt "keyboard key"
+msgid "Decimal"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:82
+msgctxt "keyboard key"
+msgid "Multiply"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:83
+msgctxt "keyboard key"
+msgid "Divide"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:84
+msgctxt "keyboard key"
+msgid "Num_lock"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:84
+msgctxt "keyboard key"
+msgid "Num Lock"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:85
+msgctxt "keyboard key"
+msgid "Scroll_lock"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:85
+msgctxt "keyboard key"
+msgid "Scroll Lock"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:86
+msgctxt "keyboard key"
+msgid "KP_Space"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:86
+msgctxt "keyboard key"
+msgid "Num Space"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:87
+#, fuzzy
+msgctxt "keyboard key"
+msgid "KP_Tab"
+msgstr "KP_TABB"
+
+#: ../src/common/accelcmn.cpp:87
+msgctxt "keyboard key"
+msgid "Num Tab"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:88
+#, fuzzy
+msgctxt "keyboard key"
+msgid "KP_Enter"
+msgstr "Skrivare"
+
+#: ../src/common/accelcmn.cpp:88
+msgctxt "keyboard key"
+msgid "Num Enter"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:89
+#, fuzzy
+msgctxt "keyboard key"
+msgid "KP_Home"
+msgstr "Hem"
+
+#: ../src/common/accelcmn.cpp:89
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Num Home"
+msgstr "Hem"
+
+#: ../src/common/accelcmn.cpp:90
+#, fuzzy
+msgctxt "keyboard key"
+msgid "KP_Left"
+msgstr "Vänster"
+
+#: ../src/common/accelcmn.cpp:90
+msgctxt "keyboard key"
+msgid "Num left"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:91
+#, fuzzy
+msgctxt "keyboard key"
+msgid "KP_Up"
+msgstr "KP_UPP"
+
+#: ../src/common/accelcmn.cpp:91
+msgctxt "keyboard key"
+msgid "Num Up"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:92
+#, fuzzy
+msgctxt "keyboard key"
+msgid "KP_Right"
+msgstr "Höger"
+
+#: ../src/common/accelcmn.cpp:92
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Num Right"
+msgstr "Höger"
+
+#: ../src/common/accelcmn.cpp:93
+#, fuzzy
+msgctxt "keyboard key"
+msgid "KP_Down"
+msgstr "Ner"
+
+#: ../src/common/accelcmn.cpp:93
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Num Down"
+msgstr "Ner"
+
+#: ../src/common/accelcmn.cpp:94
+msgctxt "keyboard key"
+msgid "KP_PageUp"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:94
+msgctxt "keyboard key"
+msgid "Num Page Up"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:95
+msgctxt "keyboard key"
+msgid "KP_PageDown"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:95
+msgctxt "keyboard key"
+msgid "Num Page Down"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:96
+msgctxt "keyboard key"
+msgid "KP_Prior"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:97
+#, fuzzy
+msgctxt "keyboard key"
+msgid "KP_Next"
+msgstr "Nästa"
+
+#: ../src/common/accelcmn.cpp:98
+#, fuzzy
+msgctxt "keyboard key"
+msgid "KP_End"
+msgstr "KP_END"
+
+#: ../src/common/accelcmn.cpp:98
+msgctxt "keyboard key"
+msgid "Num End"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:99
+msgctxt "keyboard key"
+msgid "KP_Begin"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:99
+msgctxt "keyboard key"
+msgid "Num Begin"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:100
+#, fuzzy
+msgctxt "keyboard key"
+msgid "KP_Insert"
+msgstr "Sätt in"
+
+#: ../src/common/accelcmn.cpp:100
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Num Insert"
+msgstr "Sätt in"
+
+#: ../src/common/accelcmn.cpp:101
+#, fuzzy
+msgctxt "keyboard key"
+msgid "KP_Delete"
+msgstr "Ta bort"
+
+#: ../src/common/accelcmn.cpp:101
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Num Delete"
+msgstr "Ta bort"
+
+#: ../src/common/accelcmn.cpp:102
+msgctxt "keyboard key"
+msgid "KP_Equal"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:102
+msgctxt "keyboard key"
+msgid "Num ="
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:103
+msgctxt "keyboard key"
+msgid "KP_Multiply"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:103
+msgctxt "keyboard key"
+msgid "Num *"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:104
+#, fuzzy
+msgctxt "keyboard key"
+msgid "KP_Add"
+msgstr "KP_ADDERA"
+
+#: ../src/common/accelcmn.cpp:104
+msgctxt "keyboard key"
+msgid "Num +"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:105
+msgctxt "keyboard key"
+msgid "KP_Separator"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:105
+msgctxt "keyboard key"
+msgid "Num ,"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:106
+msgctxt "keyboard key"
+msgid "KP_Subtract"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:106
+msgctxt "keyboard key"
+msgid "Num -"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:107
+msgctxt "keyboard key"
+msgid "KP_Decimal"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:107
+msgctxt "keyboard key"
+msgid "Num ."
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:108
+msgctxt "keyboard key"
+msgid "KP_Divide"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:108
+msgctxt "keyboard key"
+msgid "Num /"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:109
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Windows_Left"
+msgstr "Windows 7"
+
+#: ../src/common/accelcmn.cpp:110
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Windows_Right"
+msgstr "Windows Vista"
+
+#: ../src/common/accelcmn.cpp:111
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Windows_Menu"
+msgstr "Windows ME"
+
+#: ../src/common/accelcmn.cpp:112
+msgctxt "keyboard key"
+msgid "Command"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:186 ../src/common/accelcmn.cpp:359
+msgctxt "keyboard key"
+msgid "Ctrl"
+msgstr "Ctrl"
+
+#: ../src/common/accelcmn.cpp:188 ../src/common/accelcmn.cpp:363
+msgctxt "keyboard key"
+msgid "Alt"
+msgstr "Alt"
+
+#: ../src/common/accelcmn.cpp:190 ../src/common/accelcmn.cpp:361
+msgctxt "keyboard key"
+msgid "Shift"
+msgstr "Skift"
+
+#: ../src/common/accelcmn.cpp:196
+msgctxt "keyboard key"
+msgid "num "
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:260 ../src/common/accelcmn.cpp:382
+msgctxt "keyboard key"
+msgid "F"
+msgstr "F"
+
+#: ../src/common/accelcmn.cpp:277 ../src/common/accelcmn.cpp:385
+msgctxt "keyboard key"
+msgid "KP_F"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:280 ../src/common/accelcmn.cpp:388
+msgctxt "keyboard key"
+msgid "KP_"
+msgstr "KP_"
+
+#: ../src/common/accelcmn.cpp:283 ../src/common/accelcmn.cpp:391
+msgctxt "keyboard key"
+msgid "SPECIAL"
+msgstr "SPECIAL"
+
+#: ../src/common/accelcmn.cpp:373
+#, fuzzy
+msgid "Ctrl"
+msgstr "Ctrl"
+
+#: ../src/common/appbase.cpp:786
+msgid "show this help message"
+msgstr "visa detta hjälpmeddelande"
+
+#: ../src/common/appbase.cpp:796
+msgid "generate verbose log messages"
+msgstr "skapa mångordiga loggmeddelanden"
+
+#: ../src/common/appcmn.cpp:256
+msgid "specify the theme to use"
+msgstr "ange tema att använda"
+
+#: ../src/common/appcmn.cpp:270
+msgid "specify display mode to use (e.g. 640x480-16)"
+msgstr "ange visningsläge att använda (t.ex. 640x480-16)"
+
+#: ../src/common/appcmn.cpp:292
+#, c-format
+msgid "Unsupported theme '%s'."
+msgstr "Temat \"%s\" stöds inte."
+
+#: ../src/common/appcmn.cpp:309
+#, c-format
+msgid "Invalid display mode specification '%s'."
+msgstr "Ogiltig bildskärmslägesspecifikation \"%s\"."
+
+#: ../src/common/cmdline.cpp:875
+#, c-format
+msgid "Option '%s' can't be negated"
+msgstr "Flagga \"%s\" kan inte negeras"
+
+#: ../src/common/cmdline.cpp:889
+#, c-format
+msgid "Unknown long option '%s'"
+msgstr "Okänd lång flagga \"%s\""
+
+#: ../src/common/cmdline.cpp:904 ../src/common/cmdline.cpp:926
+#, c-format
+msgid "Unknown option '%s'"
+msgstr "Okänd flagga \"%s\""
+
+#: ../src/common/cmdline.cpp:1004
+#, c-format
+msgid "Unexpected characters following option '%s'."
+msgstr "Oväntat tecken efter flagga \"%s\"."
+
+#: ../src/common/cmdline.cpp:1039
+#, c-format
+msgid "Option '%s' requires a value."
+msgstr "Flagga \"%s\" kräver ett värde."
+
+#: ../src/common/cmdline.cpp:1058
+#, c-format
+msgid "Separator expected after the option '%s'."
+msgstr "Avgränsare förväntad efter flaggan \"%s\"."
+
+#: ../src/common/cmdline.cpp:1088 ../src/common/cmdline.cpp:1106
+#, c-format
+msgid "'%s' is not a correct numeric value for option '%s'."
+msgstr "\"%s\" är inte ett korrekt numeriskt värde för flagga \"%s\"."
+
+#: ../src/common/cmdline.cpp:1122
+#, c-format
+msgid "Option '%s': '%s' cannot be converted to a date."
+msgstr "Flagga \"%s\": \"%s\" kan inte konverteras till ett datum."
+
+#: ../src/common/cmdline.cpp:1170
+#, c-format
+msgid "Unexpected parameter '%s'"
+msgstr "Oväntad parameter \"%s\""
+
+#. TRANSLATORS: Short name and long name for a command line option
+#: ../src/common/cmdline.cpp:1197
+#, c-format
+msgid "%s (or %s)"
+msgstr "%s (eller %s)"
+
+#: ../src/common/cmdline.cpp:1208
+#, c-format
+msgid "The value for the option '%s' must be specified."
+msgstr "Värdet för flaggan \"%s\" måste anges."
+
+#: ../src/common/cmdline.cpp:1230
+#, c-format
+msgid "The required parameter '%s' was not specified."
+msgstr "Den obligatoriska parametern \"%s\" angavs inte."
+
+#: ../src/common/cmdline.cpp:1289
+#, c-format
+msgid "Usage: %s"
+msgstr "Användning: %s"
+
+#: ../src/common/cmdline.cpp:1498
+msgid "str"
+msgstr "str"
+
+#: ../src/common/cmdline.cpp:1502
+msgid "num"
+msgstr "num"
+
+#: ../src/common/cmdline.cpp:1506
+msgid "double"
+msgstr "flyttal"
+
+#: ../src/common/cmdline.cpp:1510
+msgid "date"
+msgstr "datum"
+
+#: ../src/common/cmdproc.cpp:250 ../src/common/cmdproc.cpp:276
+#: ../src/common/cmdproc.cpp:296
+msgid "Unnamed command"
+msgstr "Namnlöst kommando"
+
+#: ../src/common/cmdproc.cpp:253
+msgid "&Undo "
+msgstr "&Ångra "
+
+#: ../src/common/cmdproc.cpp:255
+msgid "Can't &Undo "
+msgstr "Kan inte &ångra "
+
+#: ../src/common/cmdproc.cpp:259 ../src/common/stockitem.cpp:208
+#: ../src/msw/textctrl.cpp:2880 ../src/osx/textctrl_osx.cpp:649
+#: ../src/richtext/richtextctrl.cpp:327
+msgid "&Undo"
+msgstr "&Ångra"
+
+#: ../src/common/cmdproc.cpp:277 ../src/common/cmdproc.cpp:297
+msgid "&Redo "
+msgstr "&Upprepa "
+
+#: ../src/common/cmdproc.cpp:281 ../src/common/cmdproc.cpp:288
+#: ../src/common/stockitem.cpp:190 ../src/msw/textctrl.cpp:2881
+#: ../src/osx/textctrl_osx.cpp:650 ../src/richtext/richtextctrl.cpp:328
+msgid "&Redo"
+msgstr "&Upprepa"
+
+#: ../src/common/colourcmn.cpp:41
+#, c-format
+msgid "String To Colour : Incorrect colour specification : %s"
+msgstr "Sträng till färg: Felaktig färgspecifikation: %s"
+
+#: ../src/common/config.cpp:259
+#, c-format
+msgid "Invalid value %ld for a boolean key \"%s\" in config file."
+msgstr "Ogiltigt värde %ld för en boolsk nyckel \"%s\" i config-fil."
+
+#: ../src/common/config.cpp:526
+#, c-format
+msgid ""
+"Environment variables expansion failed: missing '%c' at position %u in '%s'."
+msgstr ""
+"Miljövariabelexpansion misslyckades: \"%c\" saknas på position %u i \"%s\"."
+
+#: ../src/common/config.cpp:576 ../src/msw/regconf.cpp:272
+#, c-format
+msgid "'%s' has extra '..', ignored."
+msgstr "\"%s\" har extra \"..\", ignoreras."
+
+#. TRANSLATORS: Checkbox state name
+#: ../src/common/datavcmn.cpp:2166 ../src/generic/datavgen.cpp:1430
+msgid "checked"
+msgstr ""
+
+#. TRANSLATORS: Checkbox state name
+#: ../src/common/datavcmn.cpp:2170 ../src/generic/datavgen.cpp:1432
+msgid "unchecked"
+msgstr ""
+
+#. TRANSLATORS: Checkbox state name
+#: ../src/common/datavcmn.cpp:2174
+#, fuzzy
+msgid "undetermined"
+msgstr "understruken"
+
+#: ../src/common/datetimefmt.cpp:1875
+msgid "today"
+msgstr "idag"
+
+#: ../src/common/datetimefmt.cpp:1876
+msgid "yesterday"
+msgstr "igår"
+
+#: ../src/common/datetimefmt.cpp:1877
+msgid "tomorrow"
+msgstr "i morgon"
+
+#: ../src/common/datetimefmt.cpp:2071
+msgid "first"
+msgstr "första"
+
+#: ../src/common/datetimefmt.cpp:2072
+msgid "second"
+msgstr "andra"
+
+#: ../src/common/datetimefmt.cpp:2073
+msgid "third"
+msgstr "tredje"
+
+#: ../src/common/datetimefmt.cpp:2074
+msgid "fourth"
+msgstr "fjärde"
+
+#: ../src/common/datetimefmt.cpp:2075
+msgid "fifth"
+msgstr "femte"
+
+#: ../src/common/datetimefmt.cpp:2076
+msgid "sixth"
+msgstr "sjätte"
+
+#: ../src/common/datetimefmt.cpp:2077
+msgid "seventh"
+msgstr "sjunde"
+
+#: ../src/common/datetimefmt.cpp:2078
+msgid "eighth"
+msgstr "åttonde"
+
+#: ../src/common/datetimefmt.cpp:2079
+msgid "ninth"
+msgstr "nionde"
+
+#: ../src/common/datetimefmt.cpp:2080
+msgid "tenth"
+msgstr "tionde"
+
+#: ../src/common/datetimefmt.cpp:2081
+msgid "eleventh"
+msgstr "elfte"
+
+#: ../src/common/datetimefmt.cpp:2082
+msgid "twelfth"
+msgstr "tolfte"
+
+#: ../src/common/datetimefmt.cpp:2083
+msgid "thirteenth"
+msgstr "trettonde"
+
+#: ../src/common/datetimefmt.cpp:2084
+msgid "fourteenth"
+msgstr "fjortonde"
+
+#: ../src/common/datetimefmt.cpp:2085
+msgid "fifteenth"
+msgstr "femtonde"
+
+#: ../src/common/datetimefmt.cpp:2086
+msgid "sixteenth"
+msgstr "sextonde"
+
+#: ../src/common/datetimefmt.cpp:2087
+msgid "seventeenth"
+msgstr "sjuttonde"
+
+#: ../src/common/datetimefmt.cpp:2088
+msgid "eighteenth"
+msgstr "artonde"
+
+#: ../src/common/datetimefmt.cpp:2089
+msgid "nineteenth"
+msgstr "nittonde"
+
+#: ../src/common/datetimefmt.cpp:2090
+msgid "twentieth"
+msgstr "tjugonde"
+
+#: ../src/common/datetimefmt.cpp:2248
+msgid "noon"
+msgstr "middag"
+
+#: ../src/common/datetimefmt.cpp:2249
+msgid "midnight"
+msgstr "midnatt"
+
+#: ../src/common/debugrpt.cpp:209
+#, c-format
+msgid "Failed to create directory \"%s\""
+msgstr "Kunde inte skapa katalog \"%s\""
+
+#: ../src/common/debugrpt.cpp:210
+msgid "Debug report couldn't be created."
+msgstr "Debugrapporten kunde inte skapas."
+
+#: ../src/common/debugrpt.cpp:227
+#, c-format
+msgid "Failed to remove debug report file \"%s\""
+msgstr "Kunde inte ta bort debugrapportfil \"%s\""
+
+#: ../src/common/debugrpt.cpp:239
+#, c-format
+msgid "Failed to clean up debug report directory \"%s\""
+msgstr "Kunde inte rensa debugrapportkatalog \"%s\""
+
+#: ../src/common/debugrpt.cpp:514
+msgid "process context description"
+msgstr "beskrivning av processammanhang"
+
+#: ../src/common/debugrpt.cpp:538
+msgid "dump of the process state (binary)"
+msgstr "dump av processtillståndet (binärt)"
+
+#: ../src/common/debugrpt.cpp:553
+msgid "Debug report generation has failed."
+msgstr "Skapande av debugrapport har misslyckats."
+
+#: ../src/common/debugrpt.cpp:560
+#, c-format
+msgid ""
+"Processing debug report has failed, leaving the files in \"%s\" directory."
+msgstr ""
+"Behandling av debugrapport har misslyckats, lämnar filerna i katalogen "
+"\"%s\"."
+
+#: ../src/common/debugrpt.cpp:573
+msgid "A debug report has been generated. It can be found in"
+msgstr "En debugrapport har skapats. Den kan hittas i"
+
+#: ../src/common/debugrpt.cpp:576
+msgid "And includes the following files:\n"
+msgstr "Och innehåller följande filer:\n"
+
+#: ../src/common/debugrpt.cpp:586
+msgid ""
+"\n"
+"Please send this report to the program maintainer, thank you!\n"
+msgstr ""
+"\n"
+"Skicka den här rapporten till programansvarig. Tack!\n"
+
+#: ../src/common/debugrpt.cpp:729
+msgid "Failed to execute curl, please install it in PATH."
+msgstr "Kunde inte köra curl, installera den i PATH."
+
+#: ../src/common/debugrpt.cpp:742
+#, c-format
+msgid "Failed to upload the debug report (error code %d)."
+msgstr "Kunde inte ladda upp debugrapport (felkod %d)."
+
+#: ../src/common/docview.cpp:366
+msgid "Save As"
+msgstr "Spara som"
+
+#: ../src/common/docview.cpp:457
+msgid "Discard changes and reload the last saved version?"
+msgstr "Bortse från ändringar och ladda om den senast sparade versionen?"
+
+#: ../src/common/docview.cpp:488
+msgid "unnamed"
+msgstr "namnlös"
+
+#: ../src/common/docview.cpp:513
+#, c-format
+msgid "Do you want to save changes to %s?"
+msgstr "Vill du spara ändringar i %s?"
+
+#: ../src/common/docview.cpp:521 ../src/common/docview.cpp:560
+#: ../src/common/stockitem.cpp:195
+msgid "&Save"
+msgstr "&Spara"
+
+#: ../src/common/docview.cpp:522 ../src/common/docview.cpp:560
+msgid "&Discard changes"
+msgstr ""
+
+#: ../src/common/docview.cpp:523
+#, fuzzy
+msgid "Do&n't close"
+msgstr "Spara inte"
+
+#: ../src/common/docview.cpp:553
+#, fuzzy, c-format
+msgid "Do you want to save changes to %s before closing it?"
+msgstr "Vill du spara ändringar i %s?"
+
+#: ../src/common/docview.cpp:559
+#, fuzzy
+msgid "The document must be closed."
+msgstr "Texten kunde inte sparas."
+
+#: ../src/common/docview.cpp:571
+#, c-format
+msgid "Saving %s failed, would you like to retry?"
+msgstr ""
+
+#: ../src/common/docview.cpp:577
+msgid "Retry"
+msgstr ""
+
+#: ../src/common/docview.cpp:577
+msgid "Discard changes"
+msgstr ""
+
+#: ../src/common/docview.cpp:679
+#, c-format
+msgid "File \"%s\" could not be opened for writing."
+msgstr "Filen \"%s\" kunde inte öppnas för skrivning."
+
+#: ../src/common/docview.cpp:685
+#, c-format
+msgid "Failed to save document to the file \"%s\"."
+msgstr "Kunde inte spara dokument till filen \"%s\"."
+
+#: ../src/common/docview.cpp:702
+#, c-format
+msgid "File \"%s\" could not be opened for reading."
+msgstr "Fil \"%s\" kunde inte öppnas för läsning."
+
+#: ../src/common/docview.cpp:714
+#, c-format
+msgid "Failed to read document from the file \"%s\"."
+msgstr "Kunde inte läsa dokument från filen \"%s\"."
+
+#: ../src/common/docview.cpp:1236
+#, c-format
+msgid ""
+"The file '%s' doesn't exist and couldn't be opened.\n"
+"It has been removed from the most recently used files list."
+msgstr ""
+"Filen \"%s\" finns inte och kunde inte öppnas.\n"
+"Den har tagits bort från senast använda filer-listan."
+
+#: ../src/common/docview.cpp:1296
+msgid "Print preview creation failed."
+msgstr "Förhandsgranskning kunde inte skapas."
+
+#: ../src/common/docview.cpp:1302
+msgid "Print Preview"
+msgstr "Förhandsgranska"
+
+#: ../src/common/docview.cpp:1517
+#, c-format
+msgid "The format of file '%s' couldn't be determined."
+msgstr "Formatet för filen \"%s\" kunde inte avgöras."
+
+#: ../src/common/docview.cpp:1643
+#, c-format
+msgid "unnamed%d"
+msgstr "namnlös%d"
+
+#: ../src/common/docview.cpp:1660
+msgid " - "
+msgstr " - "
+
+#: ../src/common/docview.cpp:1791 ../src/common/docview.cpp:1844
+msgid "Open File"
+msgstr "Öppna Fil"
+
+#: ../src/common/docview.cpp:1807
+msgid "File error"
+msgstr "Filfel"
+
+#: ../src/common/docview.cpp:1809
+msgid "Sorry, could not open this file."
+msgstr "Kunde inte öppna denna fil."
+
+#: ../src/common/docview.cpp:1843
+msgid "Sorry, the format for this file is unknown."
+msgstr "Filformatet för denna fil är okänt."
+
+#: ../src/common/docview.cpp:1924
+msgid "Select a document template"
+msgstr "Välj en dokumentmall"
+
+#: ../src/common/docview.cpp:1925
+msgid "Templates"
+msgstr "Mallar"
+
+#: ../src/common/docview.cpp:1998
+msgid "Select a document view"
+msgstr "Välj en dokumentvy"
+
+#: ../src/common/docview.cpp:1999
+msgid "Views"
+msgstr "Vyer"
+
+#: ../src/common/dynlib.cpp:81
+#, c-format
+msgid "Failed to load shared library '%s'"
+msgstr "Kunde inte läsa in delat bibliotek \"%s\""
+
+#: ../src/common/dynlib.cpp:105
+#, c-format
+msgid "Couldn't find symbol '%s' in a dynamic library"
+msgstr "Kunde inte hitta symbolen \"%s\" i ett dynamiskt bibliotek"
+
+#: ../src/common/ffile.cpp:56 ../src/common/file.cpp:215
+#, c-format
+msgid "can't open file '%s'"
+msgstr "kan inte öppna fil \"%s\""
+
+#: ../src/common/ffile.cpp:72
+#, c-format
+msgid "can't close file '%s'"
+msgstr "kan inte stänga fil \"%s\""
+
+#: ../src/common/ffile.cpp:106 ../src/common/ffile.cpp:131
+#, c-format
+msgid "Read error on file '%s'"
+msgstr "Läsfel på fil \"%s\""
+
+#: ../src/common/ffile.cpp:148
+#, c-format
+msgid "Write error on file '%s'"
+msgstr "Skrivfel på fil \"%s\""
+
+#: ../src/common/ffile.cpp:182
+#, c-format
+msgid "failed to flush the file '%s'"
+msgstr "misslyckades att spola filen \"%s\""
+
+#: ../src/common/ffile.cpp:222
+#, c-format
+msgid "Seek error on file '%s' (large files not supported by stdio)"
+msgstr "Sökfel på fil \"%s\" (stora filer stöds inte av stdio)"
+
+#: ../src/common/ffile.cpp:232
+#, c-format
+msgid "Seek error on file '%s'"
+msgstr "Sökfel på fil \"%s\""
+
+#: ../src/common/ffile.cpp:248
+#, c-format
+msgid "Can't find current position in file '%s'"
+msgstr "Kan inte hitta aktuell position i fil \"%s\""
+
+#: ../src/common/ffile.cpp:349 ../src/common/file.cpp:569
+msgid "Failed to set temporary file permissions"
+msgstr "Kunde inte sätta behörigheter på  temporär fil"
+
+#: ../src/common/ffile.cpp:371
+#, c-format
+msgid "can't remove file '%s'"
+msgstr "kan inte ta bort fil \"%s\""
+
+#: ../src/common/ffile.cpp:376 ../src/common/file.cpp:591
+#, c-format
+msgid "can't commit changes to file '%s'"
+msgstr "kan inte skriva ändringar till fil \"%s\""
+
+#: ../src/common/ffile.cpp:388 ../src/common/file.cpp:603
+#, c-format
+msgid "can't remove temporary file '%s'"
+msgstr "kan inte ta bort temporär fil \"%s\""
+
+#: ../src/common/file.cpp:162
+#, c-format
+msgid "can't create file '%s'"
+msgstr "kan inte skapa fil \"%s\""
+
+#: ../src/common/file.cpp:229
+#, c-format
+msgid "can't close file descriptor %d"
+msgstr "kan inte stänga filidentifierare %d"
+
+#: ../src/common/file.cpp:332
+#, c-format
+msgid "can't read from file descriptor %d"
+msgstr "kan inte läsa från filidentifierare %d"
+
+#: ../src/common/file.cpp:351
+#, c-format
+msgid "can't write to file descriptor %d"
+msgstr "kan inte skriva till filidentifierare %d"
+
+#: ../src/common/file.cpp:390
+#, c-format
+msgid "can't flush file descriptor %d"
+msgstr "kan inte spola filidentifierare %d"
+
+#: ../src/common/file.cpp:432
+#, c-format
+msgid "can't seek on file descriptor %d"
+msgstr "kan inte söka på filidentifierare %d"
+
+#: ../src/common/file.cpp:446
+#, c-format
+msgid "can't get seek position on file descriptor %d"
+msgstr "kan inte hitta sökposition på filidentifierare %d"
+
+#: ../src/common/file.cpp:475
+#, c-format
+msgid "can't find length of file on file descriptor %d"
+msgstr "kan inte hitta filens längd på filidentifierare %d"
+
+#: ../src/common/file.cpp:505
+#, c-format
+msgid "can't determine if the end of file is reached on descriptor %d"
+msgstr "kan inte avgöra om slutet på filen är uppnått på identifierare %d"
+
+#: ../src/common/fileconf.cpp:352
+#, c-format
+msgid ""
+" and additionally, the existing configuration file was renamed to \"%s\" and "
+"couldn't be renamed back, please rename it to its original path \"%s\""
+msgstr ""
+
+#: ../src/common/fileconf.cpp:389
+#, fuzzy
+msgid " due to the following error:\n"
+msgstr "Och innehåller följande filer:\n"
+
+#: ../src/common/fileconf.cpp:412
+#, fuzzy
+msgid "failed to rename the existing file"
+msgstr "Kunde inte läsa dokument från filen \"%s\"."
+
+#: ../src/common/fileconf.cpp:421
+#, fuzzy
+msgid "failed to create the new file directory"
+msgstr "Kunde inte hämta aktuell katalog"
+
+#: ../src/common/fileconf.cpp:428
+#, fuzzy
+msgid "failed to move the file to the new location"
+msgstr "Kunde inte avsluta den uppringda anslutningen: %s"
+
+#: ../src/common/fileconf.cpp:462
+#, c-format
+msgid "can't open global configuration file '%s'."
+msgstr "kan inte öppna global konfigurationsfil \"%s\"."
+
+#: ../src/common/fileconf.cpp:478
+#, c-format
+msgid "can't open user configuration file '%s'."
+msgstr "kan inte öppna användarkonfigurationsfil \"%s\"."
+
+#: ../src/common/fileconf.cpp:483
+#, c-format
+msgid "Changes won't be saved to avoid overwriting the existing file \"%s\""
+msgstr ""
+"Ändringar kommer inte att sparas för att undvika att den existerande filen "
+"\"%s\" skrivs över"
+
+#: ../src/common/fileconf.cpp:583
+msgid "Error reading config options."
+msgstr "Fel vid läsning av konfigureringsalternativ."
+
+#: ../src/common/fileconf.cpp:593
+msgid "Failed to read config options."
+msgstr "Kunde inte läsa konfigurationsalternativ."
+
+#: ../src/common/fileconf.cpp:700
+#, fuzzy, c-format
+msgid "file '%s': unexpected character %c at line %zu."
+msgstr "fil \"%s\": Oväntat tecken %c på rad %d."
+
+#: ../src/common/fileconf.cpp:736
+#, fuzzy, c-format
+msgid "file '%s', line %zu: '%s' ignored after group header."
+msgstr "fil \"%s\", rad %d: \"%s\" ignorerad efter grupphuvud."
+
+#: ../src/common/fileconf.cpp:765
+#, fuzzy, c-format
+msgid "file '%s', line %zu: '=' expected."
+msgstr "fil \"%s\", rad %d: \"=\" förväntat."
+
+#: ../src/common/fileconf.cpp:778
+#, fuzzy, c-format
+msgid "file '%s', line %zu: value for immutable key '%s' ignored."
+msgstr "fil \"%s\", rad %d: Värde för ej skrivbar nyckel \"%s\" ignoreras."
+
+#: ../src/common/fileconf.cpp:788
+#, fuzzy, c-format
+msgid "file '%s', line %zu: key '%s' was first found at line %d."
+msgstr "fil \"%s\", rad %d: Nyckel \"%s\" hittades först på rad %d."
+
+#: ../src/common/fileconf.cpp:1091
+#, c-format
+msgid "Config entry name cannot start with '%c'."
+msgstr "Konfigurationspost kan inte starta med \"%c\"."
+
+#: ../src/common/fileconf.cpp:1146
+#, fuzzy
+msgid "Failed to create configuration file directory."
+msgstr "Kunde inte uppdatera användarkonfigurationsfil."
+
+#: ../src/common/fileconf.cpp:1158
+msgid "can't open user configuration file."
+msgstr "kan inte öppna användarkonfigurationsfil."
+
+#: ../src/common/fileconf.cpp:1172
+msgid "can't write user configuration file."
+msgstr "kan inte skriva användarkonfigurationsfil."
+
+#: ../src/common/fileconf.cpp:1178
+msgid "Failed to update user configuration file."
+msgstr "Kunde inte uppdatera användarkonfigurationsfil."
+
+#: ../src/common/fileconf.cpp:1201
+msgid "Error saving user configuration data."
+msgstr "Fel vid sparande av användarkonfigurationsdata."
+
+#: ../src/common/fileconf.cpp:1313
+#, c-format
+msgid "can't delete user configuration file '%s'"
+msgstr "kan inte ta bort användarkonfigurationsfil \"%s\""
+
+#: ../src/common/fileconf.cpp:2007
+#, c-format
+msgid "entry '%s' appears more than once in group '%s'"
+msgstr "post \"%s\" förekommer mer än en gång i grupp \"%s\""
+
+#: ../src/common/fileconf.cpp:2021
+#, c-format
+msgid "attempt to change immutable key '%s' ignored."
+msgstr "försök att ändra ej skrivbar nyckel \"%s\" ignorerad."
+
+#: ../src/common/fileconf.cpp:2118
+#, c-format
+msgid "trailing backslash ignored in '%s'"
+msgstr "avslutande omvänt snedsträck ignorerades i \"%s\""
+
+#: ../src/common/fileconf.cpp:2153
+#, c-format
+msgid "unexpected \" at position %d in '%s'."
+msgstr "oväntat \" på position %d i \"%s\"."
+
+#: ../src/common/filefn.cpp:474
+#, c-format
+msgid "Failed to copy the file '%s' to '%s'"
+msgstr "Kunde inte kopiera filen \"%s\" till \"%s\""
+
+#: ../src/common/filefn.cpp:487
+#, c-format
+msgid "Impossible to get permissions for file '%s'"
+msgstr "Omöjligt att hämta behörigheter för fil \"%s\""
+
+#: ../src/common/filefn.cpp:501
+#, c-format
+msgid "Impossible to overwrite the file '%s'"
+msgstr "Omöjligt att skriva över fil \"%s\""
+
+#: ../src/common/filefn.cpp:508
+#, fuzzy, c-format
+msgid "Error copying the file '%s' to '%s'."
+msgstr "Kunde inte kopiera filen \"%s\" till \"%s\""
+
+#: ../src/common/filefn.cpp:556
+#, c-format
+msgid "Impossible to set permissions for the file '%s'"
+msgstr "Omöjligt att sätta behörigheter för filen \"%s\""
+
+#: ../src/common/filefn.cpp:606
+#, c-format
+msgid ""
+"Failed to rename the file '%s' to '%s' because the destination file already "
+"exists."
+msgstr ""
+"Kunde inte döpa om filen \"%s\" till \"%s\" eftersom målfilen redan finns."
+
+#: ../src/common/filefn.cpp:623
+#, c-format
+msgid "File '%s' couldn't be renamed '%s'"
+msgstr "Filen \"%s\" kunde inte byta namn till \"%s\""
+
+#: ../src/common/filefn.cpp:639
+#, c-format
+msgid "File '%s' couldn't be removed"
+msgstr "Filen \"%s\" kunde inte tas bort"
+
+#: ../src/common/filefn.cpp:666
+#, c-format
+msgid "Directory '%s' couldn't be created"
+msgstr "Katalogen \"%s\" kunde inte skapas"
+
+#: ../src/common/filefn.cpp:680
+#, c-format
+msgid "Directory '%s' couldn't be deleted"
+msgstr "Katalogen \"%s\" kunde inte tas bort"
+
+#: ../src/common/filefn.cpp:714
+#, c-format
+msgid "Cannot enumerate files '%s'"
+msgstr "Kan inte räkna upp filerna \"%s\""
+
+#: ../src/common/filefn.cpp:798
+msgid "Failed to get the working directory"
+msgstr "Kunde inte hämta aktuell katalog"
+
+#: ../src/common/filefn.cpp:843
+msgid "Could not set current working directory"
+msgstr "Kunde inte ange aktuell katalog"
+
+#: ../src/common/filefn.cpp:974
+#, c-format
+msgid "Files (%s)"
+msgstr "Filer (%s)"
+
+#: ../src/common/filename.cpp:182
+#, c-format
+msgid "Failed to open '%s' for reading"
+msgstr "Kunde inte öppna \"%s\" för läsning"
+
+#: ../src/common/filename.cpp:187
+#, c-format
+msgid "Failed to open '%s' for writing"
+msgstr "Kunde inte öppna \"%s\" för skrivning"
+
+#: ../src/common/filename.cpp:199
+msgid "Failed to close file handle"
+msgstr "Kunde inte stänga filhandtag"
+
+#: ../src/common/filename.cpp:1046
+msgid "Failed to create a temporary file name"
+msgstr "Kunde inte skapa ett namn för temporär fil"
+
+#: ../src/common/filename.cpp:1081
+msgid "Failed to open temporary file."
+msgstr "Kunde inte öppna temporär fil."
+
+#: ../src/common/filename.cpp:2862
+#, c-format
+msgid "Failed to modify file times for '%s'"
+msgstr "Kunde inte ändra filtider för \"%s\""
+
+#: ../src/common/filename.cpp:2877
+#, c-format
+msgid "Failed to touch the file '%s'"
+msgstr "Kunde inte röra (touch) filen \"%s\""
+
+#: ../src/common/filename.cpp:2958
+#, c-format
+msgid "Failed to retrieve file times for '%s'"
+msgstr "Kunde inte hämta filtider för \"%s\""
+
+#: ../src/common/filepickercmn.cpp:39 ../src/common/filepickercmn.cpp:40
+msgid "Browse"
+msgstr "Bläddra"
+
+#: ../src/common/fldlgcmn.cpp:792 ../src/generic/filectrlg.cpp:1185
+#, c-format
+msgid "All files (%s)|%s"
+msgstr "Alla filer (%s)|%s"
+
+#. TRANSLATORS: %s are a file extension used to build a file wildcard string
+#: ../src/common/fldlgcmn.cpp:810
+#, c-format
+msgid "%s files (%s)|%s"
+msgstr "%s filer (%s)|%s"
+
+#: ../src/common/fldlgcmn.cpp:1072
+#, c-format
+msgid "Load %s file"
+msgstr "Läs in %s fil"
+
+#: ../src/common/fldlgcmn.cpp:1074
+#, c-format
+msgid "Save %s file"
+msgstr "Spara %s fil"
+
+#: ../src/common/fmapbase.cpp:144
+msgid "Western European (ISO-8859-1)"
+msgstr "Västerländsk (ISO-8859-1)"
+
+#: ../src/common/fmapbase.cpp:145
+msgid "Central European (ISO-8859-2)"
+msgstr "Centraleuropeisk (ISO-8859-2)"
+
+#: ../src/common/fmapbase.cpp:146
+msgid "Esperanto (ISO-8859-3)"
+msgstr "Esperanto (ISO-8859-3)"
+
+#: ../src/common/fmapbase.cpp:147
+msgid "Baltic (old) (ISO-8859-4)"
+msgstr "Baltiska språk (gammal) (ISO-8859-4)"
+
+#: ../src/common/fmapbase.cpp:148
+msgid "Cyrillic (ISO-8859-5)"
+msgstr "Kyrillisk (ISO-8859-5)"
+
+#: ../src/common/fmapbase.cpp:149
+msgid "Arabic (ISO-8859-6)"
+msgstr "Arabiska (ISO-8859-6)"
+
+#: ../src/common/fmapbase.cpp:150
+msgid "Greek (ISO-8859-7)"
+msgstr "Grekisk (ISO-8859-7)"
+
+#: ../src/common/fmapbase.cpp:151
+msgid "Hebrew (ISO-8859-8)"
+msgstr "Hebreisk (ISO-8859-8)"
+
+#: ../src/common/fmapbase.cpp:152
+msgid "Turkish (ISO-8859-9)"
+msgstr "Turkisk (ISO-8859-9)"
+
+#: ../src/common/fmapbase.cpp:153
+msgid "Nordic (ISO-8859-10)"
+msgstr "Nordiska språk (ISO-8859-10)"
+
+#: ../src/common/fmapbase.cpp:154
+msgid "Thai (ISO-8859-11)"
+msgstr "Thailändsk (ISO-8859-11)"
+
+#: ../src/common/fmapbase.cpp:155
+msgid "Indian (ISO-8859-12)"
+msgstr "Indisk (ISO-8859-12)"
+
+#: ../src/common/fmapbase.cpp:156
+msgid "Baltic (ISO-8859-13)"
+msgstr "Baltiska språk (ISO-8859-13)"
+
+#: ../src/common/fmapbase.cpp:157
+msgid "Celtic (ISO-8859-14)"
+msgstr "Keltiska språk (ISO-8859-14)"
+
+#: ../src/common/fmapbase.cpp:158
+msgid "Western European with Euro (ISO-8859-15)"
+msgstr "Västerländsk med Euro (ISO-8859-15)"
+
+#: ../src/common/fmapbase.cpp:159
+msgid "KOI8-R"
+msgstr "KOI8-R"
+
+#: ../src/common/fmapbase.cpp:160
+msgid "KOI8-U"
+msgstr "KOI8-U"
+
+#: ../src/common/fmapbase.cpp:161
+msgid "Windows/DOS OEM Cyrillic (CP 866)"
+msgstr "Windows/DOS OEM Kyrillisk (CP 866)"
+
+#: ../src/common/fmapbase.cpp:162
+msgid "Windows Thai (CP 874)"
+msgstr "Windows thailändsk (CP 874)"
+
+#: ../src/common/fmapbase.cpp:163
+msgid "Windows Japanese (CP 932) or Shift-JIS"
+msgstr "Windows japansk (CP 932) eller Shift-JIS"
+
+#: ../src/common/fmapbase.cpp:164
+msgid "Windows Chinese Simplified (CP 936) or GB-2312"
+msgstr "Windows förenklad kinesiska (CP 936) eller GB-2312"
+
+#: ../src/common/fmapbase.cpp:165
+msgid "Windows Korean (CP 949)"
+msgstr "Windows koreansk (CP 949)"
+
+#: ../src/common/fmapbase.cpp:166
+msgid "Windows Chinese Traditional (CP 950) or Big-5"
+msgstr "Windows traditionelll kinesiska (CP 950) eller Big-5"
+
+#: ../src/common/fmapbase.cpp:167
+msgid "Windows Central European (CP 1250)"
+msgstr "Windows centraleuropeisk (CP 1250)"
+
+#: ../src/common/fmapbase.cpp:168
+msgid "Windows Cyrillic (CP 1251)"
+msgstr "Windows kyrillisk (CP 1251)"
+
+#: ../src/common/fmapbase.cpp:169
+msgid "Windows Western European (CP 1252)"
+msgstr "Windows västeuropa (CP 1252)"
+
+#: ../src/common/fmapbase.cpp:170
+msgid "Windows Greek (CP 1253)"
+msgstr "Windows grekisk (CP 1253)"
+
+#: ../src/common/fmapbase.cpp:171
+msgid "Windows Turkish (CP 1254)"
+msgstr "Windows turkisk (CP 1254)"
+
+#: ../src/common/fmapbase.cpp:172
+msgid "Windows Hebrew (CP 1255)"
+msgstr "Windows hebreisk (CP 1255)"
+
+#: ../src/common/fmapbase.cpp:173
+msgid "Windows Arabic (CP 1256)"
+msgstr "Windows arabisk (CP 1256)"
+
+#: ../src/common/fmapbase.cpp:174
+msgid "Windows Baltic (CP 1257)"
+msgstr "Windows baltiska språk (CP 1257)"
+
+#: ../src/common/fmapbase.cpp:175
+msgid "Windows Vietnamese (CP 1258)"
+msgstr "Windows Vietnamesiska (CP 1258)"
+
+#: ../src/common/fmapbase.cpp:176
+msgid "Windows Johab (CP 1361)"
+msgstr "Windows Johab (CP 1361)"
+
+#: ../src/common/fmapbase.cpp:177
+msgid "Windows/DOS OEM (CP 437)"
+msgstr "Windows/DOS OEM (CP 437)"
+
+#: ../src/common/fmapbase.cpp:178
+msgid "Unicode 7 bit (UTF-7)"
+msgstr "Unicode 7 bitar (UTF-7)"
+
+#: ../src/common/fmapbase.cpp:179
+msgid "Unicode 8 bit (UTF-8)"
+msgstr "Unicode 8 bitar (UTF-8)"
+
+#: ../src/common/fmapbase.cpp:181 ../src/common/fmapbase.cpp:187
+msgid "Unicode 16 bit (UTF-16)"
+msgstr "Unicode 16 bitar (UTF-16)"
+
+#: ../src/common/fmapbase.cpp:182
+msgid "Unicode 16 bit Little Endian (UTF-16LE)"
+msgstr "Unicode 16 bitar little endian (UTF-16LE)"
+
+#: ../src/common/fmapbase.cpp:183 ../src/common/fmapbase.cpp:189
+msgid "Unicode 32 bit (UTF-32)"
+msgstr "Unicode 32 bitar (UTF-32)"
+
+#: ../src/common/fmapbase.cpp:184
+msgid "Unicode 32 bit Little Endian (UTF-32LE)"
+msgstr "Unicode 32 bitar little endian (UTF-32LE)"
+
+#: ../src/common/fmapbase.cpp:186
+msgid "Unicode 16 bit Big Endian (UTF-16BE)"
+msgstr "Unicode 16 bitar big endian (UTF-16BE)"
+
+#: ../src/common/fmapbase.cpp:188
+msgid "Unicode 32 bit Big Endian (UTF-32BE)"
+msgstr "Unicode 32 bitar big endian (UTF-32BE)"
+
+#: ../src/common/fmapbase.cpp:191
+msgid "Extended Unix Codepage for Japanese (EUC-JP)"
+msgstr "Utökad Unix-kodsida för japanska (EUC-JP)"
+
+#: ../src/common/fmapbase.cpp:192
+msgid "US-ASCII"
+msgstr "US-ASCII"
+
+#: ../src/common/fmapbase.cpp:193
+msgid "ISO-2022-JP"
+msgstr "ISO-2022-JP"
+
+#: ../src/common/fmapbase.cpp:195
+msgid "MacRoman"
+msgstr "MacRoman"
+
+#: ../src/common/fmapbase.cpp:196
+msgid "MacJapanese"
+msgstr "MacJapanska"
+
+#: ../src/common/fmapbase.cpp:197
+msgid "MacChineseTrad"
+msgstr "MacTratitionellKinesiska"
+
+#: ../src/common/fmapbase.cpp:198
+msgid "MacKorean"
+msgstr "MacKoreanska"
+
+#: ../src/common/fmapbase.cpp:199
+msgid "MacArabic"
+msgstr "MacArabiska"
+
+#: ../src/common/fmapbase.cpp:200
+msgid "MacHebrew"
+msgstr "MacHebreiska"
+
+#: ../src/common/fmapbase.cpp:201
+msgid "MacGreek"
+msgstr "MacGrekiska"
+
+#: ../src/common/fmapbase.cpp:202
+msgid "MacCyrillic"
+msgstr "MacKyrilliska"
+
+#: ../src/common/fmapbase.cpp:203
+msgid "MacDevanagari"
+msgstr "MacDevanagari"
+
+#: ../src/common/fmapbase.cpp:204
+msgid "MacGurmukhi"
+msgstr "MacGurmukhi"
+
+#: ../src/common/fmapbase.cpp:205
+msgid "MacGujarati"
+msgstr "MacGujarati"
+
+#: ../src/common/fmapbase.cpp:206
+msgid "MacOriya"
+msgstr "MacOriya"
+
+#: ../src/common/fmapbase.cpp:207
+msgid "MacBengali"
+msgstr "MacBengaliska"
+
+#: ../src/common/fmapbase.cpp:208
+msgid "MacTamil"
+msgstr "MacTamilska"
+
+#: ../src/common/fmapbase.cpp:209
+msgid "MacTelugu"
+msgstr "MacTelugu"
+
+#: ../src/common/fmapbase.cpp:210
+msgid "MacKannada"
+msgstr "MacKannada"
+
+#: ../src/common/fmapbase.cpp:211
+msgid "MacMalayalam"
+msgstr "MacMalayalam"
+
+#: ../src/common/fmapbase.cpp:212
+msgid "MacSinhalese"
+msgstr "MacSingalesiska"
+
+#: ../src/common/fmapbase.cpp:213
+msgid "MacBurmese"
+msgstr "MacBurmesiska"
+
+#: ../src/common/fmapbase.cpp:214
+msgid "MacKhmer"
+msgstr "MacKhmer"
+
+#: ../src/common/fmapbase.cpp:215
+msgid "MacThai"
+msgstr "MacThailändska"
+
+#: ../src/common/fmapbase.cpp:216
+msgid "MacLaotian"
+msgstr "MacLaotian"
+
+#: ../src/common/fmapbase.cpp:217
+msgid "MacGeorgian"
+msgstr "MacGeorigiska"
+
+#: ../src/common/fmapbase.cpp:218
+msgid "MacArmenian"
+msgstr "MacArmeniska"
+
+#: ../src/common/fmapbase.cpp:219
+msgid "MacChineseSimp"
+msgstr "MacFörenkladKinesiska"
+
+#: ../src/common/fmapbase.cpp:220
+msgid "MacTibetan"
+msgstr "MacTibetanska"
+
+#: ../src/common/fmapbase.cpp:221
+msgid "MacMongolian"
+msgstr "MacMongoliska"
+
+#: ../src/common/fmapbase.cpp:222
+msgid "MacEthiopic"
+msgstr "MacEtiopiska"
+
+#: ../src/common/fmapbase.cpp:223
+msgid "MacCentralEurRoman"
+msgstr "MacCentraleurromanska"
+
+#: ../src/common/fmapbase.cpp:224
+msgid "MacVietnamese"
+msgstr "MacVietnamesiska"
+
+#: ../src/common/fmapbase.cpp:225
+msgid "MacExtArabic"
+msgstr "MacUtökadArabiska"
+
+#: ../src/common/fmapbase.cpp:226
+msgid "MacSymbol"
+msgstr "MacSymbol"
+
+#: ../src/common/fmapbase.cpp:227
+msgid "MacDingbats"
+msgstr "MacDingbats"
+
+#: ../src/common/fmapbase.cpp:228
+msgid "MacTurkish"
+msgstr "MacTurksiska"
+
+#: ../src/common/fmapbase.cpp:229
+msgid "MacCroatian"
+msgstr "MacKroatiska"
+
+#: ../src/common/fmapbase.cpp:230
+msgid "MacIcelandic"
+msgstr "MacIsländska"
+
+#: ../src/common/fmapbase.cpp:231
+msgid "MacRomanian"
+msgstr "MacRumänska"
+
+#: ../src/common/fmapbase.cpp:232
+msgid "MacCeltic"
+msgstr "MacKeltiska"
+
+#: ../src/common/fmapbase.cpp:233
+msgid "MacGaelic"
+msgstr "MacGaeliska"
+
+#: ../src/common/fmapbase.cpp:234
+msgid "MacKeyboardGlyphs"
+msgstr "MacTangentborstecken"
+
+#: ../src/common/fmapbase.cpp:791
+msgid "Default encoding"
+msgstr "Standardkodning"
+
+#: ../src/common/fmapbase.cpp:805
+#, c-format
+msgid "Unknown encoding (%d)"
+msgstr "Okänd kodning (%d)"
+
+#: ../src/common/fmapbase.cpp:815 ../src/richtext/richtextstyles.cpp:776
+msgid "default"
+msgstr "förvald"
+
+#: ../src/common/fmapbase.cpp:829
+#, c-format
+msgid "unknown-%d"
+msgstr "okänd-%d"
+
+#: ../src/common/fontcmn.cpp:924 ../src/common/fontcmn.cpp:1130
+msgid "underlined"
+msgstr "understruken"
+
+#: ../src/common/fontcmn.cpp:929
+msgid " strikethrough"
+msgstr " genomstruken"
+
+#: ../src/common/fontcmn.cpp:942
+msgid " thin"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:946
+#, fuzzy
+msgid " extra light"
+msgstr " tunn"
+
+#: ../src/common/fontcmn.cpp:950
+msgid " light"
+msgstr " tunn"
+
+#: ../src/common/fontcmn.cpp:954
+msgid " medium"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:958
+#, fuzzy
+msgid " semi bold"
+msgstr " fet"
+
+#: ../src/common/fontcmn.cpp:962
+msgid " bold"
+msgstr " fet"
+
+#: ../src/common/fontcmn.cpp:966
+#, fuzzy
+msgid " extra bold"
+msgstr " fet"
+
+#: ../src/common/fontcmn.cpp:970
+msgid " heavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:974
+msgid " extra heavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:990
+msgid " italic"
+msgstr " kursiv"
+
+#: ../src/common/fontcmn.cpp:1134
+msgid "strikethrough"
+msgstr "genomstruken"
+
+#: ../src/common/fontcmn.cpp:1143
+msgid "thin"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1156
+#, fuzzy
+msgid "extralight"
+msgstr "tunn"
+
+#: ../src/common/fontcmn.cpp:1161
+msgid "light"
+msgstr "tunn"
+
+#: ../src/common/fontcmn.cpp:1169 ../src/richtext/richtextstyles.cpp:775
+msgid "normal"
+msgstr "normal"
+
+#: ../src/common/fontcmn.cpp:1174
+msgid "medium"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1179 ../src/common/fontcmn.cpp:1199
+#, fuzzy
+msgid "semibold"
+msgstr "fet"
+
+#: ../src/common/fontcmn.cpp:1184
+msgid "bold"
+msgstr "fet"
+
+#: ../src/common/fontcmn.cpp:1194
+#, fuzzy
+msgid "extrabold"
+msgstr "fet"
+
+#: ../src/common/fontcmn.cpp:1204
+msgid "heavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1212
+msgid "extraheavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1217
+msgid "italic"
+msgstr "kursiv"
+
+#: ../src/common/fontmap.cpp:195
+msgid ": unknown charset"
+msgstr ": okänd teckenuppsättning"
+
+#: ../src/common/fontmap.cpp:199
+#, c-format
+msgid ""
+"The charset '%s' is unknown. You may select\n"
+"another charset to replace it with or choose\n"
+"[Cancel] if it cannot be replaced"
+msgstr ""
+"Teckenuppsättningen \"%s\" är okänd. Du kan välja\n"
+"en annan teckenuppsättning som ersättning eller välja\n"
+"[Avbryt] om den inte kan ersättas"
+
+#: ../src/common/fontmap.cpp:241
+#, c-format
+msgid "Failed to remember the encoding for the charset '%s'."
+msgstr "Kunde inte komma ihåg kodningen för teckenuppsättning \"%s\"."
+
+#: ../src/common/fontmap.cpp:321
+msgid "can't load any font, aborting"
+msgstr "kan inte läsa in något typsnitt, avbryter"
+
+#: ../src/common/fontmap.cpp:409
+msgid ": unknown encoding"
+msgstr ": okänd kodning"
+
+#: ../src/common/fontmap.cpp:417
+#, c-format
+msgid ""
+"No font for displaying text in encoding '%s' found,\n"
+"but an alternative encoding '%s' is available.\n"
+"Do you want to use this encoding (otherwise you will have to choose another "
+"one)?"
+msgstr ""
+"Inget typsnitt för att visa text med kodningen \"%s\" hittades,\n"
+"men en alternativ kodning \"%s\" är tillgänglig.\n"
+"Vill du använda denna kodning (annars måste du välja någon annat)?"
+
+#: ../src/common/fontmap.cpp:422
+#, c-format
+msgid ""
+"No font for displaying text in encoding '%s' found.\n"
+"Would you like to select a font to be used for this encoding\n"
+"(otherwise the text in this encoding will not be shown correctly)?"
+msgstr ""
+"Inget typsnitt för att visa text med kodningen \"%s\" hittades.\n"
+"Vill du välja ett typsnitt att använda för denna kodning\n"
+"(annars kommer texten med denna kodning inte att visas korrekt)?"
+
+#: ../src/common/fs_mem.cpp:169
+#, c-format
+msgid "Memory VFS already contains file '%s'!"
+msgstr "Minnes-VFS innehåller redan fil \"%s\"!"
+
+#: ../src/common/fs_mem.cpp:232
+#, c-format
+msgid "Trying to remove file '%s' from memory VFS, but it is not loaded!"
+msgstr "Försöker ta bort fil \"%s\" från minnes-VFS, men den är inte inläst!"
+
+#: ../src/common/fs_mem.cpp:262
+#, c-format
+msgid "Failed to store image '%s' to memory VFS!"
+msgstr "Kunde inte spara bild \"%s\" till minnes-VFS!"
+
+#: ../src/common/ftp.cpp:197
+msgid "Timeout while waiting for FTP server to connect, try passive mode."
+msgstr ""
+"Tiden för att vänta på att FTP-server skall ansluta har gått ut, försök med "
+"passivt läge."
+
+#: ../src/common/ftp.cpp:399
+#, c-format
+msgid "Failed to set FTP transfer mode to %s."
+msgstr "Kunde inte sätta FTP-överföringsläge till %s."
+
+#: ../src/common/ftp.cpp:400 ../src/richtext/richtextsymboldlg.cpp:432
+msgid "ASCII"
+msgstr "ASCII"
+
+#: ../src/common/ftp.cpp:400
+msgid "binary"
+msgstr "binär"
+
+#: ../src/common/ftp.cpp:608
+msgid "The FTP server doesn't support the PORT command."
+msgstr "FTP-servern stöder inte PORT-kommandot."
+
+#: ../src/common/ftp.cpp:622
+msgid "The FTP server doesn't support passive mode."
+msgstr "FTP-servern stöder inte passivt läge."
+
+#: ../src/common/gifdecod.cpp:822
+#, c-format
+msgid "Incorrect GIF frame size (%u, %d) for the frame #%u"
+msgstr "Inkorrekt GIF-ramstorlek (%u, %d) för ruta #%u"
+
+#: ../src/common/glcmn.cpp:108
+msgid "Failed to allocate colour for OpenGL"
+msgstr "Kunde inte allokera färg för OpenGL"
+
+#: ../src/common/headerctrlcmn.cpp:57
+msgid "Please select the columns to show and define their order:"
+msgstr "Välj kolumner att visa och ange ordning:"
+
+#: ../src/common/headerctrlcmn.cpp:58
+msgid "Customize Columns"
+msgstr "Anpassa kolumner"
+
+#: ../src/common/headerctrlcmn.cpp:304
+msgid "&Customize..."
+msgstr "&Anpassa..."
+
+#: ../src/common/hyperlnkcmn.cpp:132
+#, fuzzy, c-format
+msgid "Failed to open URL \"%s\" in the default browser"
+msgstr "Kunde inte öppna URL \"%s\" i standardwebbläsare."
+
+#: ../src/common/iconbndl.cpp:195
+#, c-format
+msgid "Failed to load image %%d from file '%s'."
+msgstr "Kunde inte läsa in bild %%d från fil \"%s\"."
+
+#: ../src/common/iconbndl.cpp:203
+#, c-format
+msgid "Failed to load image %d from stream."
+msgstr "Kunde inte läsa in bild %d från ström."
+
+#: ../src/common/iconbndl.cpp:221
+#, fuzzy, c-format
+msgid "Failed to load icons from resource '%s'."
+msgstr "Kunde inte läsa in ikon \"%s\" från resurser."
+
+#: ../src/common/imagbmp.cpp:97
+msgid "BMP: Couldn't save invalid image."
+msgstr "BMP: Kunde inte spara ogiltig bild."
+
+#: ../src/common/imagbmp.cpp:137
+msgid "BMP: wxImage doesn't have own wxPalette."
+msgstr "BMP: wxImage saknar egen wxPalette."
+
+#: ../src/common/imagbmp.cpp:243
+msgid "BMP: Couldn't write the file (Bitmap) header."
+msgstr "BMP: Kunde inte skriva filhuvudet (Bitmap)."
+
+#: ../src/common/imagbmp.cpp:266
+msgid "BMP: Couldn't write the file (BitmapInfo) header."
+msgstr "BMP: Kunde inte skriva filhuvudet (BitmapInfo)."
+
+#: ../src/common/imagbmp.cpp:353
+msgid "BMP: Couldn't write RGB color map."
+msgstr "BMP: Kunde inte skriva RGB-färgkarta."
+
+#: ../src/common/imagbmp.cpp:487
+msgid "BMP: Couldn't write data."
+msgstr "BMP: Kunde inte skriva data."
+
+#: ../src/common/imagbmp.cpp:561 ../src/common/imagbmp.cpp:642
+msgid "BMP: Couldn't allocate memory."
+msgstr "BMP: Kunde inte allokera minne."
+
+#: ../src/common/imagbmp.cpp:1041
+msgid "DIB Header: Image width > 32767 pixels for file."
+msgstr "DIB-huvud: Bildbredd > 32767 pixlar för fil."
+
+#: ../src/common/imagbmp.cpp:1049
+msgid "DIB Header: Image height > 32767 pixels for file."
+msgstr "DIB-huvud: Bildhöjd > 32767 pixlar för fil."
+
+#: ../src/common/imagbmp.cpp:1081
+msgid "DIB Header: Unknown bitdepth in file."
+msgstr "DIB-huvud: Okänt bitdjup i fil."
+
+#: ../src/common/imagbmp.cpp:1156
+msgid "DIB Header: Unknown encoding in file."
+msgstr "DIB-huvud: Okänd kodning i fil."
+
+#: ../src/common/imagbmp.cpp:1165
+msgid "DIB Header: Encoding doesn't match bitdepth."
+msgstr "DIB-huvud: Kodning matchar inte bitdjup."
+
+#: ../src/common/imagbmp.cpp:1180
+#, c-format
+msgid "BMP Header: Invalid number of colors (%d)."
+msgstr ""
+
+#: ../src/common/imagbmp.cpp:1273
+msgid "Error in reading image DIB."
+msgstr "Fel vid läsning av DIB-bild."
+
+#: ../src/common/imagbmp.cpp:1294
+msgid "ICO: Error in reading mask DIB."
+msgstr "ICO: Fel vid läsning av mask DIB."
+
+#: ../src/common/imagbmp.cpp:1353
+msgid "ICO: Image too tall for an icon."
+msgstr "ICO: Bilden är för hög för en ikon."
+
+#: ../src/common/imagbmp.cpp:1361
+msgid "ICO: Image too wide for an icon."
+msgstr "ICO: Bilden är för bred för en ikon."
+
+#: ../src/common/imagbmp.cpp:1388 ../src/common/imagbmp.cpp:1488
+#: ../src/common/imagbmp.cpp:1503 ../src/common/imagbmp.cpp:1514
+#: ../src/common/imagbmp.cpp:1528 ../src/common/imagbmp.cpp:1576
+#: ../src/common/imagbmp.cpp:1591 ../src/common/imagbmp.cpp:1605
+#: ../src/common/imagbmp.cpp:1616
+msgid "ICO: Error writing the image file!"
+msgstr "ICO: Fel vid skrivning till bildfilen!"
+
+#: ../src/common/imagbmp.cpp:1701
+msgid "ICO: Invalid icon index."
+msgstr "ICO: Ogiltigt ikonindex."
+
+#: ../src/common/image.cpp:2410
+msgid "Image and mask have different sizes."
+msgstr "Bild och mask har olika storlekar."
+
+#: ../src/common/image.cpp:2418 ../src/common/image.cpp:2459
+msgid "No unused colour in image being masked."
+msgstr "Ingen oanvänd färg i bilden är maskad."
+
+#: ../src/common/image.cpp:2641
+#, c-format
+msgid "Failed to load bitmap \"%s\" from resources."
+msgstr "Kunde inte läsa in bild \"%s\" från resurser."
+
+#: ../src/common/image.cpp:2650
+#, c-format
+msgid "Failed to load icon \"%s\" from resources."
+msgstr "Kunde inte läsa in ikon \"%s\" från resurser."
+
+#: ../src/common/image.cpp:2728 ../src/common/image.cpp:2747
+#, c-format
+msgid "Failed to load image from file \"%s\"."
+msgstr "Kunde inte läsa in bild från fil \"%s\"."
+
+#: ../src/common/image.cpp:2761
+#, c-format
+msgid "Can't save image to file '%s': unknown extension."
+msgstr "Kan inte spara bild till fil \"%s\": Okänd filändelse."
+
+#: ../src/common/image.cpp:2869
+msgid "No handler found for image type."
+msgstr "Ingen hanterare hittades för bildtyp."
+
+#: ../src/common/image.cpp:2877 ../src/common/image.cpp:3000
+#: ../src/common/image.cpp:3066
+#, c-format
+msgid "No image handler for type %d defined."
+msgstr "Ingen bildhanterare är definierad för typ %d."
+
+#: ../src/common/image.cpp:2887
+#, c-format
+msgid "Image file is not of type %d."
+msgstr "Bildfilen är inte av typen %d."
+
+#: ../src/common/image.cpp:2970
+msgid "Can't automatically determine the image format for non-seekable input."
+msgstr "Kan inte automatiskt avgöra bildformat för icke-sökbar indata."
+
+#: ../src/common/image.cpp:2988
+msgid "Unknown image data format."
+msgstr "Okänt bilddataformat."
+
+#: ../src/common/image.cpp:3009
+#, c-format
+msgid "This is not a %s."
+msgstr "Detta är inte en %s."
+
+#: ../src/common/image.cpp:3032 ../src/common/image.cpp:3080
+#, c-format
+msgid "No image handler for type %s defined."
+msgstr "Ingen bildhanterare är definierad för typ %s."
+
+#: ../src/common/image.cpp:3041
+#, c-format
+msgid "Image is not of type %s."
+msgstr "Bild är inte av typen %s."
+
+#: ../src/common/image.cpp:3509
+#, c-format
+msgid "Failed to check format of image file \"%s\"."
+msgstr "Kunde kontrollera bildformat för fil \"%s\"."
+
+#: ../src/common/imaggif.cpp:124
+msgid "GIF: error in GIF image format."
+msgstr "GIF: Fel i GIF bildformat."
+
+#: ../src/common/imaggif.cpp:129
+msgid "GIF: not enough memory."
+msgstr "GIF: Inte tillräckligt minne."
+
+#: ../src/common/imaggif.cpp:134
+msgid "GIF: data stream seems to be truncated."
+msgstr "GIF: Dataströmmen tycks vara trunkerad."
+
+#: ../src/common/imaggif.cpp:240
+msgid "Couldn't initialize GIF hash table."
+msgstr "Kunde inte initiera GIF-hashtabell."
+
+#: ../src/common/imagiff.cpp:739
+msgid "IFF: error in IFF image format."
+msgstr "IFF: Fel i IFF-bildformat."
+
+#: ../src/common/imagiff.cpp:742
+msgid "IFF: not enough memory."
+msgstr "IFF: Inte tillräckligt minne."
+
+#: ../src/common/imagiff.cpp:745
+msgid "IFF: unknown error!!!"
+msgstr "IFF: Okänt fel!!!"
+
+#: ../src/common/imagiff.cpp:755
+msgid "IFF: data stream seems to be truncated."
+msgstr "IFF: Dataströmmen ser ut att vara trunkerad."
+
+#: ../src/common/imagjpeg.cpp:258
+msgid "JPEG: Couldn't load - file is probably corrupted."
+msgstr "JPEG: Kunde inte läsa in - filen är troligen skadad."
+
+#: ../src/common/imagjpeg.cpp:437
+msgid "JPEG: Couldn't save image."
+msgstr "JPEG: Kunde inte spara bild."
+
+#: ../src/common/imagpcx.cpp:439
+msgid "PCX: this is not a PCX file."
+msgstr "PCX: Detta är inte en PCX fil."
+
+#: ../src/common/imagpcx.cpp:453
+msgid "PCX: image format unsupported"
+msgstr "PCX: Bildformatet stöds inte"
+
+#: ../src/common/imagpcx.cpp:454 ../src/common/imagpcx.cpp:477
+msgid "PCX: couldn't allocate memory"
+msgstr "PCX: Kunde inte allokera minne"
+
+#: ../src/common/imagpcx.cpp:455
+msgid "PCX: version number too low"
+msgstr "PCX: För lågt versionsnummer"
+
+#: ../src/common/imagpcx.cpp:456 ../src/common/imagpcx.cpp:478
+msgid "PCX: unknown error !!!"
+msgstr "PCX: Okänt fel !!!"
+
+#: ../src/common/imagpcx.cpp:476
+msgid "PCX: invalid image"
+msgstr "PCX: Ogiltig bild"
+
+#: ../src/common/imagpng.cpp:385
+#, c-format
+msgid "Unknown PNG resolution unit %d"
+msgstr "Okänd PNG-upplösningsenhet %d"
+
+#: ../src/common/imagpng.cpp:439
+msgid "Couldn't load a PNG image - file is corrupted or not enough memory."
+msgstr "Kunde inte läsa in PNG-bild - filen är förstörd eller för lite minne."
+
+#: ../src/common/imagpng.cpp:513 ../src/common/imagpng.cpp:524
+#: ../src/common/imagpng.cpp:534
+msgid "Couldn't save PNG image."
+msgstr "Kunde inte spara PNG-bild."
+
+#: ../src/common/imagpnm.cpp:71
+msgid "PNM: File format is not recognized."
+msgstr "PNM: Filformat är okänt."
+
+#: ../src/common/imagpnm.cpp:89
+msgid "PNM: Couldn't allocate memory."
+msgstr "PNM: Kunde inte allokera minne."
+
+#: ../src/common/imagpnm.cpp:111 ../src/common/imagpnm.cpp:134
+#: ../src/common/imagpnm.cpp:156
+msgid "PNM: File seems truncated."
+msgstr "PNM: Filen tycks vara trunkerad."
+
+#: ../src/common/imagtiff.cpp:69
+#, c-format
+msgid " (in module \"%s\")"
+msgstr " (i modul \"%s\")"
+
+#: ../src/common/imagtiff.cpp:304
+msgid "TIFF: Error loading image."
+msgstr "TIFF: Fel vid inläsning av bild."
+
+#: ../src/common/imagtiff.cpp:314
+msgid "Invalid TIFF image index."
+msgstr "Ogiltigt TIFF-bildindex."
+
+#: ../src/common/imagtiff.cpp:358
+msgid "TIFF: Image size is abnormally big."
+msgstr "TIFF: Bildstorlek är onormalt stor."
+
+#: ../src/common/imagtiff.cpp:372 ../src/common/imagtiff.cpp:385
+#: ../src/common/imagtiff.cpp:769
+msgid "TIFF: Couldn't allocate memory."
+msgstr "TIFF: Kunde inte allokera minne."
+
+#: ../src/common/imagtiff.cpp:471
+msgid "TIFF: Error reading image."
+msgstr "TIFF: Fel vid läsning av bild."
+
+#: ../src/common/imagtiff.cpp:532
+#, c-format
+msgid "Unknown TIFF resolution unit %d ignored"
+msgstr "Okänd TIFF-upplösningsenhet %d ignoreras"
+
+#: ../src/common/imagtiff.cpp:611
+msgid "TIFF: Error saving image."
+msgstr "TIFF: Fel vid sparande av bild."
+
+#: ../src/common/imagtiff.cpp:868
+msgid "TIFF: Error writing image."
+msgstr "TIFF: Fel vid skrivande till bild."
+
+#: ../src/common/imagtiff.cpp:881
+#, fuzzy
+msgid "TIFF: Error flushing data."
+msgstr "TIFF: Fel vid sparande av bild."
+
+#: ../src/common/imagwebp.cpp:56
+msgid "WebP: Invalid data (failed to get features)."
+msgstr ""
+
+#: ../src/common/imagwebp.cpp:65
+msgid "WebP: Allocating image memory failed."
+msgstr ""
+
+#: ../src/common/imagwebp.cpp:82
+msgid "WebP: Decoding RGBA image data failed."
+msgstr ""
+
+#: ../src/common/imagwebp.cpp:98
+msgid "WebP: Decoding RGB image data failed."
+msgstr ""
+
+#: ../src/common/imagwebp.cpp:113 ../src/common/imagwebp.cpp:201
+msgid "WebP: Allocating stream buffer failed."
+msgstr ""
+
+#: ../src/common/imagwebp.cpp:131
+#, fuzzy
+msgid "WebP: Failed to parse container data."
+msgstr "Kunde inte sätta urklippsdata."
+
+#: ../src/common/imagwebp.cpp:222
+#, fuzzy
+msgid "WebP: Error decoding animation."
+msgstr "Fel vid läsning av konfigureringsalternativ."
+
+#: ../src/common/imagwebp.cpp:240
+msgid "WebP: Error getting next animation frame."
+msgstr ""
+
+#: ../src/common/init.cpp:172
+#, c-format
+msgid ""
+"Command line argument %d couldn't be converted to Unicode and will be "
+"ignored."
+msgstr ""
+"Kommandoradsargument %d kunde inte bli konverterad till Unicode och kommer "
+"att ignoreras."
+
+#: ../src/common/init.cpp:344
+msgid "Initialization failed in post init, aborting."
+msgstr "Initiering misslyckades i post init, avbryter."
+
+#: ../src/common/intl.cpp:378
+#, c-format
+msgid "Cannot set locale to language \"%s\"."
+msgstr "Kan inte ange lokal för språk \"%s\"."
+
+#: ../src/common/log.cpp:232
+msgid "Error: "
+msgstr "Fel: "
+
+#: ../src/common/log.cpp:236
+msgid "Warning: "
+msgstr "Varning: "
+
+#: ../src/common/log.cpp:284
+msgid "The previous message repeated once."
+msgstr "Föregående meddelande upprepat en gång."
+
+#: ../src/common/log.cpp:291
+#, fuzzy, c-format
+msgid "The previous message repeated %u time."
+msgid_plural "The previous message repeated %u times."
+msgstr[0] "Föregående meddelande upprepat %lu gång."
+msgstr[1] "Föregående meddelande upprepat %lu gånger."
+
+#: ../src/common/log.cpp:319
+#, fuzzy, c-format
+msgid "Last repeated message (\"%s\", %u time) wasn't output"
+msgid_plural "Last repeated message (\"%s\", %u times) wasn't output"
+msgstr[0] "Senast upprepade meddelande(\"%s\", %lu gång) skrevs inte ut"
+msgstr[1] "Senast upprepade meddelande(\"%s\", %lu gånger) skrevs inte ut"
+
+#: ../src/common/log.cpp:435
+#, c-format
+msgid " (error %ld: %s)"
+msgstr " (fel %ld: %s)"
+
+#: ../src/common/lzmastream.cpp:121
+#, fuzzy
+msgid "Failed to allocate memory for LZMA decompression."
+msgstr "Kunde inte allokera färg för OpenGL"
+
+#: ../src/common/lzmastream.cpp:125
+#, c-format
+msgid "Failed to initialize LZMA decompression: unexpected error %u."
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:179
+msgid "input is not in XZ format"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:183
+msgid "input compressed using unknown XZ option"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:188
+msgid "input is corrupted"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:192
+#, fuzzy
+msgid "unknown decompression error"
+msgstr "dekompressionsfel"
+
+#: ../src/common/lzmastream.cpp:196
+#, fuzzy, c-format
+msgid "LZMA decompression error: %s"
+msgstr "dekompressionsfel"
+
+#: ../src/common/lzmastream.cpp:231
+#, fuzzy
+msgid "Failed to allocate memory for LZMA compression."
+msgstr "Kunde inte allokera färg för OpenGL"
+
+#: ../src/common/lzmastream.cpp:235
+#, c-format
+msgid "Failed to initialize LZMA compression: unexpected error %u."
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:267 ../src/common/lzmastream.cpp:342
+#: ../src/html/chm.cpp:336
+msgid "out of memory"
+msgstr "slut på minne"
+
+#: ../src/common/lzmastream.cpp:276 ../src/common/lzmastream.cpp:346
+#, fuzzy
+msgid "unknown compression error"
+msgstr "kompressionsfel"
+
+#: ../src/common/lzmastream.cpp:280
+#, fuzzy, c-format
+msgid "LZMA compression error: %s"
+msgstr "kompressionsfel"
+
+#: ../src/common/lzmastream.cpp:350
+#, c-format
+msgid "LZMA compression error when flushing output: %s"
+msgstr ""
+
+#: ../src/common/mimecmn.cpp:167
+#, c-format
+msgid "Unmatched '{' in an entry for mime type %s."
+msgstr "Omatchad \"{\" i en post för mime-typ %s."
+
+#: ../src/common/module.cpp:76
+#, c-format
+msgid "Circular dependency involving module \"%s\" detected."
+msgstr "Cirkulärt beroende involverande modul \"%s\" upptäckt."
+
+#: ../src/common/module.cpp:128
+#, c-format
+msgid "Dependency \"%s\" of module \"%s\" doesn't exist."
+msgstr "Beroende \"%s\" av modul \"%s\" finns inte."
+
+#: ../src/common/module.cpp:137
+#, c-format
+msgid "Module \"%s\" initialization failed"
+msgstr "Modul \"%s\" initiering misslyckades"
+
+#: ../src/common/msgout.cpp:96
+msgid "Message"
+msgstr "Meddelande"
+
+#: ../src/common/paper.cpp:70
+msgid "Letter, 8 1/2 x 11 in"
+msgstr "Letter, 8 1/2 x 11 tum"
+
+#: ../src/common/paper.cpp:71
+msgid "Legal, 8 1/2 x 14 in"
+msgstr "Legal, 8 1/2 x 14 tum"
+
+#: ../src/common/paper.cpp:72
+msgid "A4 sheet, 210 x 297 mm"
+msgstr "A4 ark, 210 x 297 mm"
+
+#: ../src/common/paper.cpp:73
+msgid "C sheet, 17 x 22 in"
+msgstr "C ark, 17 x 22 tum"
+
+#: ../src/common/paper.cpp:74
+msgid "D sheet, 22 x 34 in"
+msgstr "D ark, 22 x 34 tum"
+
+#: ../src/common/paper.cpp:75
+msgid "E sheet, 34 x 44 in"
+msgstr "E ark, 34 x 44 tum"
+
+#: ../src/common/paper.cpp:76
+msgid "Letter Small, 8 1/2 x 11 in"
+msgstr "Letter litet, 8 1/2 x 11 tum"
+
+#: ../src/common/paper.cpp:77
+msgid "Tabloid, 11 x 17 in"
+msgstr "Tabloid, 11 x 17 tum"
+
+#: ../src/common/paper.cpp:78
+msgid "Ledger, 17 x 11 in"
+msgstr "Liggare, 17 x 11 tum"
+
+#: ../src/common/paper.cpp:79
+msgid "Statement, 5 1/2 x 8 1/2 in"
+msgstr "Statement, 5 1/2 x 8 1/2 tum"
+
+#: ../src/common/paper.cpp:80
+msgid "Executive, 7 1/4 x 10 1/2 in"
+msgstr "Executive, 7 1/4 x 10 1/2 tum"
+
+#: ../src/common/paper.cpp:81
+msgid "A3 sheet, 297 x 420 mm"
+msgstr "A3 ark, 297 x 420 mm"
+
+#: ../src/common/paper.cpp:82
+msgid "A4 small sheet, 210 x 297 mm"
+msgstr "A4 litet ark, 210 x 297 mm"
+
+#: ../src/common/paper.cpp:83
+msgid "A5 sheet, 148 x 210 mm"
+msgstr "A5 ark, 148 x 210 mm"
+
+#: ../src/common/paper.cpp:84
+msgid "B4 sheet, 250 x 354 mm"
+msgstr "B4 ark, 250 x 354 mm"
+
+#: ../src/common/paper.cpp:85
+msgid "B5 sheet, 182 x 257 millimeter"
+msgstr "B5 ark, 182 x 257 millimeter"
+
+#: ../src/common/paper.cpp:86
+msgid "Folio, 8 1/2 x 13 in"
+msgstr "Foliant, 8 1/2 x 13 tum"
+
+#: ../src/common/paper.cpp:87
+msgid "Quarto, 215 x 275 mm"
+msgstr "Quarto, 215 x 275 mm"
+
+#: ../src/common/paper.cpp:88
+msgid "10 x 14 in"
+msgstr "10 x 14 tum"
+
+#: ../src/common/paper.cpp:89
+msgid "11 x 17 in"
+msgstr "11 x 17 tum"
+
+#: ../src/common/paper.cpp:90
+msgid "Note, 8 1/2 x 11 in"
+msgstr "Anteckning, 8 1/2 x 11 tum"
+
+#: ../src/common/paper.cpp:91
+msgid "#9 Envelope, 3 7/8 x 8 7/8 in"
+msgstr "#9 kuvert, 3 7/8 x 8 7/8 tum"
+
+#: ../src/common/paper.cpp:92
+msgid "#10 Envelope, 4 1/8 x 9 1/2 in"
+msgstr "#10 kuvert, 4 1/8 x 9 1/2 tum"
+
+#: ../src/common/paper.cpp:93
+msgid "#11 Envelope, 4 1/2 x 10 3/8 in"
+msgstr "#11 kuvert, 4 1/2 x 10 3/8 tum"
+
+#: ../src/common/paper.cpp:94
+msgid "#12 Envelope, 4 3/4 x 11 in"
+msgstr "#12 kuvert, 4 3/4 x 11 tum"
+
+#: ../src/common/paper.cpp:95
+msgid "#14 Envelope, 5 x 11 1/2 in"
+msgstr "#14 kuvert, 5 x 11 1/2 tum"
+
+#: ../src/common/paper.cpp:96
+msgid "DL Envelope, 110 x 220 mm"
+msgstr "DL kuvert, 110 x 220 mm"
+
+#: ../src/common/paper.cpp:97
+msgid "C5 Envelope, 162 x 229 mm"
+msgstr "C5 kuvert, 162 x 229 mm"
+
+#: ../src/common/paper.cpp:98
+msgid "C3 Envelope, 324 x 458 mm"
+msgstr "C3 kuvert, 324 x 458 mm"
+
+#: ../src/common/paper.cpp:99
+msgid "C4 Envelope, 229 x 324 mm"
+msgstr "C4 kuvert, 229 x 324 mm"
+
+#: ../src/common/paper.cpp:100
+msgid "C6 Envelope, 114 x 162 mm"
+msgstr "C6 kuvert, 114 x 162 mm"
+
+#: ../src/common/paper.cpp:101
+msgid "C65 Envelope, 114 x 229 mm"
+msgstr "C65 kuvert, 114 x 229 mm"
+
+#: ../src/common/paper.cpp:102
+msgid "B4 Envelope, 250 x 353 mm"
+msgstr "B4 kuvert, 250 x 353 mm"
+
+#: ../src/common/paper.cpp:103
+msgid "B5 Envelope, 176 x 250 mm"
+msgstr "B5 kuvert, 176 x 250 mm"
+
+#: ../src/common/paper.cpp:104
+msgid "B6 Envelope, 176 x 125 mm"
+msgstr "B6 kuvert, 176 x 125 mm"
+
+#: ../src/common/paper.cpp:105
+msgid "Italy Envelope, 110 x 230 mm"
+msgstr "Italienskt kuvert, 110 x 230 mm"
+
+#: ../src/common/paper.cpp:106
+msgid "Monarch Envelope, 3 7/8 x 7 1/2 in"
+msgstr "Monarch kuvert, 3 7/8 x 7 1/2 tum"
+
+#: ../src/common/paper.cpp:107
+msgid "6 3/4 Envelope, 3 5/8 x 6 1/2 in"
+msgstr "6 3/4 kuvert, 3 5/8 x 6 1/2 tum"
+
+#: ../src/common/paper.cpp:108
+msgid "US Std Fanfold, 14 7/8 x 11 in"
+msgstr "US standard fanfold, 14 7/8 x 11 tum"
+
+#: ../src/common/paper.cpp:109
+msgid "German Std Fanfold, 8 1/2 x 12 in"
+msgstr "Tysk standard fanfold, 8 1/2 x 12 tum"
+
+#: ../src/common/paper.cpp:110
+msgid "German Legal Fanfold, 8 1/2 x 13 in"
+msgstr "Tysk legal fanfold, 8 1/2 x 13 tum"
+
+#: ../src/common/paper.cpp:112
+msgid "B4 (ISO) 250 x 353 mm"
+msgstr "B4 (ISO) 250 x 353 mm"
+
+#: ../src/common/paper.cpp:113
+msgid "Japanese Postcard 100 x 148 mm"
+msgstr "Japanskt vykort 100 x 148"
+
+#: ../src/common/paper.cpp:114
+msgid "9 x 11 in"
+msgstr "9 x 11 tum"
+
+#: ../src/common/paper.cpp:115
+msgid "10 x 11 in"
+msgstr "10 x 11 tum"
+
+#: ../src/common/paper.cpp:116
+msgid "15 x 11 in"
+msgstr "15 x 11 tum"
+
+#: ../src/common/paper.cpp:117
+msgid "Envelope Invite 220 x 220 mm"
+msgstr "Kuvert Invite 220 x 220 mm"
+
+#: ../src/common/paper.cpp:118
+msgid "Letter Extra 9 1/2 x 12 in"
+msgstr "Letter extra 9 1/2 x 12 tum"
+
+#: ../src/common/paper.cpp:119
+msgid "Legal Extra 9 1/2 x 15 in"
+msgstr "Legal extra 9 1/2 x 15 tum"
+
+#: ../src/common/paper.cpp:120
+msgid "Tabloid Extra 11.69 x 18 in"
+msgstr "Tabloid extra 11,69 x 18 tum"
+
+#: ../src/common/paper.cpp:121
+msgid "A4 Extra 9.27 x 12.69 in"
+msgstr "A4 extra 9,27 x 12,69 tum"
+
+#: ../src/common/paper.cpp:122
+msgid "Letter Transverse 8 1/2 x 11 in"
+msgstr "Letter transverserat 8 1/2 x 11 tum"
+
+#: ../src/common/paper.cpp:123
+msgid "A4 Transverse 210 x 297 mm"
+msgstr "A4 transverserad 210 x 297 mm"
+
+#: ../src/common/paper.cpp:124
+msgid "Letter Extra Transverse 9.275 x 12 in"
+msgstr "Letter extra transverserad 9,275 x 12 tum"
+
+#: ../src/common/paper.cpp:125
+msgid "SuperA/SuperA/A4 227 x 356 mm"
+msgstr "SuperA/SuperA/A4 227 x 356 mm"
+
+#: ../src/common/paper.cpp:126
+msgid "SuperB/SuperB/A3 305 x 487 mm"
+msgstr "SuperB/SuperB/A3 305 x 487 mm"
+
+#: ../src/common/paper.cpp:127
+msgid "Letter Plus 8 1/2 x 12.69 in"
+msgstr "Letter plus 8 1/2 x 12,69 tum"
+
+#: ../src/common/paper.cpp:128
+msgid "A4 Plus 210 x 330 mm"
+msgstr "A4 plus 210 x 330 mm"
+
+#: ../src/common/paper.cpp:129
+msgid "A5 Transverse 148 x 210 mm"
+msgstr "A5 transverserad 148 x 210 mm"
+
+#: ../src/common/paper.cpp:130
+msgid "B5 (JIS) Transverse 182 x 257 mm"
+msgstr "B5 (JIS) transverserad 182 x 257 mm"
+
+#: ../src/common/paper.cpp:131
+msgid "A3 Extra 322 x 445 mm"
+msgstr "A3 extra 322 x 445 mm"
+
+#: ../src/common/paper.cpp:132
+msgid "A5 Extra 174 x 235 mm"
+msgstr "A5 extra 174 x 235 mm"
+
+#: ../src/common/paper.cpp:133
+msgid "B5 (ISO) Extra 201 x 276 mm"
+msgstr "B5 (ISO) Extra 201 x 276 mm"
+
+#: ../src/common/paper.cpp:134
+msgid "A2 420 x 594 mm"
+msgstr "A2 420 x 594 mm"
+
+#: ../src/common/paper.cpp:135
+msgid "A3 Transverse 297 x 420 mm"
+msgstr "A3 transverserad 297 x 420 mm"
+
+#: ../src/common/paper.cpp:136
+msgid "A3 Extra Transverse 322 x 445 mm"
+msgstr "A3 extra transverserad 322 x 445 mm"
+
+#: ../src/common/paper.cpp:138
+msgid "Japanese Double Postcard 200 x 148 mm"
+msgstr "Japanskt dubbelt vykort 200 x 148 mm"
+
+#: ../src/common/paper.cpp:139
+msgid "A6 105 x 148 mm"
+msgstr "A6 105 x 148 mm"
+
+#: ../src/common/paper.cpp:140
+msgid "Japanese Envelope Kaku #2"
+msgstr "Japanskt kuvert Kaku #2"
+
+#: ../src/common/paper.cpp:141
+msgid "Japanese Envelope Kaku #3"
+msgstr "Japanskt kuvert Kaku #3"
+
+#: ../src/common/paper.cpp:142
+msgid "Japanese Envelope Chou #3"
+msgstr "Japanskt kuvert Chou #3"
+
+#: ../src/common/paper.cpp:143
+msgid "Japanese Envelope Chou #4"
+msgstr "Japanskt kuvert Chou #4"
+
+#: ../src/common/paper.cpp:144
+msgid "Letter Rotated 11 x 8 1/2 in"
+msgstr "Letter roterat 11 x 8 1/2 tum"
+
+#: ../src/common/paper.cpp:145
+msgid "A3 Rotated 420 x 297 mm"
+msgstr "A3 roterad 420 x 297 mm"
+
+#: ../src/common/paper.cpp:146
+msgid "A4 Rotated 297 x 210 mm"
+msgstr "A4 roterad 297 x 210 mm"
+
+#: ../src/common/paper.cpp:147
+msgid "A5 Rotated 210 x 148 mm"
+msgstr "A5 roterad 210 x 148 mm"
+
+#: ../src/common/paper.cpp:148
+msgid "B4 (JIS) Rotated 364 x 257 mm"
+msgstr "B4 (JIS) Roterad 364 x 257 mm"
+
+#: ../src/common/paper.cpp:149
+msgid "B5 (JIS) Rotated 257 x 182 mm"
+msgstr "B5 (JIS) Roterad 257 x 182 mm"
+
+#: ../src/common/paper.cpp:150
+msgid "Japanese Postcard Rotated 148 x 100 mm"
+msgstr "Japanskt vykort roterat 148 x 100"
+
+#: ../src/common/paper.cpp:151
+msgid "Double Japanese Postcard Rotated 148 x 200 mm"
+msgstr "Dubbelt japanskt vykort roterat 148 x 200 mm"
+
+#: ../src/common/paper.cpp:152
+msgid "A6 Rotated 148 x 105 mm"
+msgstr "A6 roterad 148 x 105 mm"
+
+#: ../src/common/paper.cpp:153
+msgid "Japanese Envelope Kaku #2 Rotated"
+msgstr "Japanskt kuvert Kaku #2 roterat"
+
+#: ../src/common/paper.cpp:154
+msgid "Japanese Envelope Kaku #3 Rotated"
+msgstr "Japanskt kuvert Kaku #3 roterat"
+
+#: ../src/common/paper.cpp:155
+msgid "Japanese Envelope Chou #3 Rotated"
+msgstr "Japanskt kuvert Chou #3 roterat"
+
+#: ../src/common/paper.cpp:156
+msgid "Japanese Envelope Chou #4 Rotated"
+msgstr "Japanskt kuvert Chou #4 roterat"
+
+#: ../src/common/paper.cpp:157
+msgid "B6 (JIS) 128 x 182 mm"
+msgstr "B6 (JIS) 128 x 182 mm"
+
+#: ../src/common/paper.cpp:158
+msgid "B6 (JIS) Rotated 182 x 128 mm"
+msgstr "B6 (JIS) Roterad 182 x 128 mm"
+
+#: ../src/common/paper.cpp:159
+msgid "12 x 11 in"
+msgstr "12 x 11 tum"
+
+#: ../src/common/paper.cpp:160
+msgid "Japanese Envelope You #4"
+msgstr "Japanskt kuvert You #4"
+
+#: ../src/common/paper.cpp:161
+msgid "Japanese Envelope You #4 Rotated"
+msgstr "Japanskt kuvert You #4 roterat"
+
+#: ../src/common/paper.cpp:162
+msgid "PRC 16K 146 x 215 mm"
+msgstr "PRC 16K 146 x 215 mm"
+
+#: ../src/common/paper.cpp:163
+msgid "PRC 32K 97 x 151 mm"
+msgstr "PRC 32K 97 x 151 mm"
+
+#: ../src/common/paper.cpp:164
+msgid "PRC 32K(Big) 97 x 151 mm"
+msgstr "PRC 32K(stor) 97 x 151 mm"
+
+#: ../src/common/paper.cpp:165
+msgid "PRC Envelope #1 102 x 165 mm"
+msgstr "PRC kuvert #1 102 x 165 mm"
+
+#: ../src/common/paper.cpp:166
+msgid "PRC Envelope #2 102 x 176 mm"
+msgstr "PRC kuvert #2 102 x 176 mm"
+
+#: ../src/common/paper.cpp:167
+msgid "PRC Envelope #3 125 x 176 mm"
+msgstr "PRC kuvert #3 125 x 176 mm"
+
+#: ../src/common/paper.cpp:168
+msgid "PRC Envelope #4 110 x 208 mm"
+msgstr "PRC kuvert #4 110 x 208 mm"
+
+#: ../src/common/paper.cpp:169
+msgid "PRC Envelope #5 110 x 220 mm"
+msgstr "PRC kuvert #5 110 x 220 mm"
+
+#: ../src/common/paper.cpp:170
+msgid "PRC Envelope #6 120 x 230 mm"
+msgstr "PRC kuvert #6 120 x 230 mm"
+
+#: ../src/common/paper.cpp:171
+msgid "PRC Envelope #7 160 x 230 mm"
+msgstr "PRC kuvert #7 160 x 230 mm"
+
+#: ../src/common/paper.cpp:172
+msgid "PRC Envelope #8 120 x 309 mm"
+msgstr "PRC kuvert #8 120 x 309 mm"
+
+#: ../src/common/paper.cpp:173
+msgid "PRC Envelope #9 229 x 324 mm"
+msgstr "PRC kuvert #9 229 x 324 mm"
+
+#: ../src/common/paper.cpp:174
+msgid "PRC Envelope #10 324 x 458 mm"
+msgstr "PRC kuvert #10 324 x 458 mm"
+
+#: ../src/common/paper.cpp:175
+msgid "PRC 16K Rotated"
+msgstr "PRC 16K Rotated"
+
+#: ../src/common/paper.cpp:176
+msgid "PRC 32K Rotated"
+msgstr "PRC 32K roterad"
+
+#: ../src/common/paper.cpp:177
+msgid "PRC 32K(Big) Rotated"
+msgstr "PRC 32K(stor) roterad"
+
+#: ../src/common/paper.cpp:178
+msgid "PRC Envelope #1 Rotated 165 x 102 mm"
+msgstr "PRC kuvert #1 roterat 165 x 102 mm"
+
+#: ../src/common/paper.cpp:179
+msgid "PRC Envelope #2 Rotated 176 x 102 mm"
+msgstr "PRC kuvert #2 roterat 176 x 102 mm"
+
+#: ../src/common/paper.cpp:180
+msgid "PRC Envelope #3 Rotated 176 x 125 mm"
+msgstr "PRC kuvert #3 roterat 176 x 125 mm"
+
+#: ../src/common/paper.cpp:181
+msgid "PRC Envelope #4 Rotated 208 x 110 mm"
+msgstr "PRC kuvert #4 roterat 208 x 110 mm"
+
+#: ../src/common/paper.cpp:182
+msgid "PRC Envelope #5 Rotated 220 x 110 mm"
+msgstr "PRC kuvert #5 roterat 220 x 110 mm"
+
+#: ../src/common/paper.cpp:183
+msgid "PRC Envelope #6 Rotated 230 x 120 mm"
+msgstr "PRC kuvert #6 roterat 230 x 120 mm"
+
+#: ../src/common/paper.cpp:184
+msgid "PRC Envelope #7 Rotated 230 x 160 mm"
+msgstr "PRC kuvert #7 roterat 230 x 160 mm"
+
+#: ../src/common/paper.cpp:185
+msgid "PRC Envelope #8 Rotated 309 x 120 mm"
+msgstr "PRC kuvert #8 roterat 309 x 120 mm"
+
+#: ../src/common/paper.cpp:186
+msgid "PRC Envelope #9 Rotated 324 x 229 mm"
+msgstr "PRC kuvert #9 roterat 324 x 229 mm"
+
+#: ../src/common/paper.cpp:187
+msgid "PRC Envelope #10 Rotated 458 x 324 mm"
+msgstr "PRC kuvert #10 roterat 458 x 324 mm"
+
+#: ../src/common/paper.cpp:192
+msgid "A0 sheet, 841 x 1189 mm"
+msgstr "A0 ark, 841 x 1189 mm"
+
+#: ../src/common/paper.cpp:193
+msgid "A1 sheet, 594 x 841 mm"
+msgstr "A1 ark, 594 x 841 mm"
+
+#: ../src/common/preferencescmn.cpp:37
+msgid "General"
+msgstr "Allmän"
+
+#: ../src/common/preferencescmn.cpp:40
+msgid "Advanced"
+msgstr "Avancerad"
+
+#: ../src/common/prntbase.cpp:245
+msgid "Generic PostScript"
+msgstr "Allmän PostScript"
+
+#: ../src/common/prntbase.cpp:259
+msgid "Ready"
+msgstr "Redo"
+
+#: ../src/common/prntbase.cpp:331
+msgid "Printing Error"
+msgstr "Utskriftsfel"
+
+#: ../src/common/prntbase.cpp:413 ../src/common/prntbase.cpp:1597
+#: ../src/generic/prntdlgg.cpp:135 ../src/generic/prntdlgg.cpp:149
+#: ../src/gtk/print.cpp:628 ../src/gtk/print.cpp:646
+msgid "Print"
+msgstr "Skriv ut"
+
+#: ../src/common/prntbase.cpp:471 ../src/generic/prntdlgg.cpp:809
+msgid "Page setup"
+msgstr "Sidinställning"
+
+#: ../src/common/prntbase.cpp:525
+msgid "Please wait while printing..."
+msgstr "Vänta på utskrift..."
+
+#: ../src/common/prntbase.cpp:529
+msgid "Document:"
+msgstr "Dokument:"
+
+#: ../src/common/prntbase.cpp:532
+msgid "Progress:"
+msgstr "Förlopp:"
+
+#: ../src/common/prntbase.cpp:533
+msgid "Preparing"
+msgstr "Förbereder"
+
+#: ../src/common/prntbase.cpp:552
+#, fuzzy, c-format
+msgid "Printing page %d"
+msgstr "Skriver sida %d..."
+
+#: ../src/common/prntbase.cpp:557
+#, c-format
+msgid "Printing page %d of %d"
+msgstr "Skriver sida %d av %d"
+
+#: ../src/common/prntbase.cpp:560
+#, c-format
+msgid " (copy %d of %d)"
+msgstr " (kopia %d av %d)"
+
+#: ../src/common/prntbase.cpp:1604
+msgid "First page"
+msgstr "Första sida"
+
+#: ../src/common/prntbase.cpp:1609 ../src/html/helpwnd.cpp:659
+msgid "Previous page"
+msgstr "Föregående sida"
+
+#: ../src/common/prntbase.cpp:1623 ../src/html/helpwnd.cpp:660
+msgid "Next page"
+msgstr "Nästa sida"
+
+#: ../src/common/prntbase.cpp:1628
+msgid "Last page"
+msgstr "Sista sida"
+
+#: ../src/common/prntbase.cpp:1636 ../src/common/stockitem.cpp:215
+msgid "Zoom Out"
+msgstr "Zooma ut"
+
+#: ../src/common/prntbase.cpp:1650 ../src/common/stockitem.cpp:214
+msgid "Zoom In"
+msgstr "Zooma in"
+
+#: ../src/common/prntbase.cpp:1656 ../src/common/stockitem.cpp:153
+#: ../src/generic/logg.cpp:553 ../src/univ/themes/win32.cpp:3752
+msgid "&Close"
+msgstr "St&äng"
+
+#: ../src/common/prntbase.cpp:2085
+msgid "Could not start document preview."
+msgstr "Kunde inte påbörja förhandsgranskning av dokumentet."
+
+#: ../src/common/prntbase.cpp:2085 ../src/common/prntbase.cpp:2129
+#: ../src/common/prntbase.cpp:2137
+msgid "Print Preview Failure"
+msgstr "Förhandsgranskning misslyckades"
+
+#: ../src/common/prntbase.cpp:2129 ../src/common/prntbase.cpp:2137
+msgid "Sorry, not enough memory to create a preview."
+msgstr "Inte tillräckligt med minne för att skapa förhandsgranskning."
+
+#: ../src/common/prntbase.cpp:2144
+#, c-format
+msgid "Page %d of %d"
+msgstr "Sida %d av %d"
+
+#: ../src/common/prntbase.cpp:2146
+#, c-format
+msgid "Page %d"
+msgstr "Sida %d"
+
+#: ../src/common/regex.cpp:382 ../src/html/chm.cpp:348
+msgid "unknown error"
+msgstr "okänt fel"
+
+#: ../src/common/regex.cpp:995
+#, c-format
+msgid "Invalid regular expression '%s': %s"
+msgstr "Ogiltigt reguljärt uttryck \"%s\": %s"
+
+#: ../src/common/regex.cpp:1059
+#, c-format
+msgid "Failed to find match for regular expression: %s"
+msgstr "Kunde inte hitta träff för reguljärt uttryck: %s"
+
+#: ../src/common/rendcmn.cpp:188
+#, c-format
+msgid "Renderer \"%s\" has incompatible version %d.%d and couldn't be loaded."
+msgstr ""
+"Rendrerare \"%s\" har inkompatibel version %d.%d och kunde inte läsas in."
+
+#: ../src/common/secretstore.cpp:162
+msgid "Not available for this platform"
+msgstr ""
+
+#: ../src/common/secretstore.cpp:183
+#, fuzzy, c-format
+msgid "Saving password for \"%s\" failed: %s."
+msgstr "Uppackning av \"%s\" till \"%s\" misslyckades."
+
+#: ../src/common/secretstore.cpp:205
+#, fuzzy, c-format
+msgid "Reading password for \"%s\" failed: %s."
+msgstr "Uppackning av \"%s\" till \"%s\" misslyckades."
+
+#: ../src/common/secretstore.cpp:228
+#, fuzzy, c-format
+msgid "Deleting password for \"%s\" failed: %s."
+msgstr "Uppackning av \"%s\" till \"%s\" misslyckades."
+
+#: ../src/common/selectdispatcher.cpp:254
+msgid "Failed to monitor I/O channels"
+msgstr "Kunde inte bevaka I/O-kanaler"
+
+#: ../src/common/sizer.cpp:3054 ../src/common/stockitem.cpp:195
+msgid "Save"
+msgstr "Spara"
+
+#: ../src/common/sizer.cpp:3056
+msgid "Don't Save"
+msgstr "Spara inte"
+
+#: ../src/common/socket.cpp:870
+msgid "Cannot initialize sockets"
+msgstr "Kan inte initiera uttag (socket)"
+
+#: ../src/common/stockitem.cpp:127
+#, fuzzy
+msgctxt "standard Windows menu"
+msgid "&Help"
+msgstr "&Hjälp"
+
+#: ../src/common/stockitem.cpp:144
+msgid "&About"
+msgstr "&Om"
+
+#: ../src/common/stockitem.cpp:144
+msgid "About"
+msgstr "Om"
+
+#: ../src/common/stockitem.cpp:145
+msgid "Add"
+msgstr "Lägg till"
+
+#: ../src/common/stockitem.cpp:146
+msgid "&Apply"
+msgstr "&Verkställ"
+
+#: ../src/common/stockitem.cpp:146
+msgid "Apply"
+msgstr "Verkställ"
+
+#: ../src/common/stockitem.cpp:147
+msgid "&Back"
+msgstr "&Bakåt"
+
+#: ../src/common/stockitem.cpp:147
+msgid "Back"
+msgstr "Bakåt"
+
+#: ../src/common/stockitem.cpp:148
+msgid "&Bold"
+msgstr "&Fet"
+
+#: ../src/common/stockitem.cpp:148 ../src/generic/fontdlgg.cpp:326
+#: ../src/richtext/richtextfontpage.cpp:354
+msgid "Bold"
+msgstr "Fet"
+
+#: ../src/common/stockitem.cpp:149
+msgid "&Bottom"
+msgstr "&Botten"
+
+#: ../src/common/stockitem.cpp:149 ../src/richtext/richtextsizepage.cpp:287
+msgid "Bottom"
+msgstr "Botten"
+
+#: ../src/common/stockitem.cpp:150 ../src/generic/fontdlgg.cpp:462
+#: ../src/generic/fontdlgg.cpp:481 ../src/generic/wizard.cpp:415
+msgid "&Cancel"
+msgstr "&Avbryt"
+
+#: ../src/common/stockitem.cpp:151
+#, fuzzy
+msgid "&CD-ROM"
+msgstr "&cd-rom"
+
+#: ../src/common/stockitem.cpp:151
+#, fuzzy
+msgid "CD-ROM"
+msgstr "cd-rom"
+
+#: ../src/common/stockitem.cpp:152
+msgid "&Clear"
+msgstr "&Töm"
+
+#: ../src/common/stockitem.cpp:152
+msgid "Clear"
+msgstr "Töm"
+
+#: ../src/common/stockitem.cpp:153 ../src/generic/dbgrptg.cpp:93
+#: ../src/generic/progdlgg.cpp:778 ../src/html/helpdlg.cpp:86
+#: ../src/msw/progdlg.cpp:209 ../src/msw/progdlg.cpp:890
+#: ../src/richtext/richtextstyledlg.cpp:272
+#: ../src/richtext/richtextsymboldlg.cpp:448
+msgid "Close"
+msgstr "Stäng"
+
+#: ../src/common/stockitem.cpp:154
+msgid "&Convert"
+msgstr "&Konvertera"
+
+#: ../src/common/stockitem.cpp:154
+msgid "Convert"
+msgstr "Konvertera"
+
+#: ../src/common/stockitem.cpp:155 ../src/msw/textctrl.cpp:2884
+#: ../src/osx/textctrl_osx.cpp:653 ../src/richtext/richtextctrl.cpp:331
+msgid "&Copy"
+msgstr "K&opiera"
+
+#: ../src/common/stockitem.cpp:155 ../src/stc/stc_i18n.cpp:18
+msgid "Copy"
+msgstr "Kopiera"
+
+#: ../src/common/stockitem.cpp:156 ../src/msw/textctrl.cpp:2883
+#: ../src/osx/textctrl_osx.cpp:652 ../src/richtext/richtextctrl.cpp:330
+msgid "Cu&t"
+msgstr "&Klipp ut"
+
+#: ../src/common/stockitem.cpp:156 ../src/stc/stc_i18n.cpp:17
+msgid "Cut"
+msgstr "Klipp ut"
+
+#: ../src/common/stockitem.cpp:157 ../src/msw/textctrl.cpp:2886
+#: ../src/osx/textctrl_osx.cpp:655 ../src/richtext/richtextctrl.cpp:333
+#: ../src/richtext/richtexttabspage.cpp:137
+msgid "&Delete"
+msgstr "&Ta bort"
+
+#: ../src/common/stockitem.cpp:157 ../src/richtext/richtextbuffer.cpp:8266
+#: ../src/stc/stc_i18n.cpp:20
+msgid "Delete"
+msgstr "Ta bort"
+
+#: ../src/common/stockitem.cpp:158
+msgid "&Down"
+msgstr "&Ner"
+
+#: ../src/common/stockitem.cpp:158 ../src/generic/fdrepdlg.cpp:148
+msgid "Down"
+msgstr "Ner"
+
+#: ../src/common/stockitem.cpp:159
+msgid "&Edit"
+msgstr "&Redigera"
+
+#: ../src/common/stockitem.cpp:159
+msgid "Edit"
+msgstr "Redigera"
+
+#: ../src/common/stockitem.cpp:160
+msgid "&Execute"
+msgstr "&Kör"
+
+#: ../src/common/stockitem.cpp:160
+msgid "Execute"
+msgstr "Kör"
+
+#: ../src/common/stockitem.cpp:161
+msgid "&Quit"
+msgstr "&Avsluta"
+
+#: ../src/common/stockitem.cpp:161
+msgid "Quit"
+msgstr "Avsluta"
+
+#: ../src/common/stockitem.cpp:162
+msgid "&File"
+msgstr "&Arkiv"
+
+#: ../src/common/stockitem.cpp:162
+msgid "File"
+msgstr "Arkiv"
+
+#: ../src/common/stockitem.cpp:163
+#, fuzzy
+msgid "&Find..."
+msgstr "&Sök"
+
+#: ../src/common/stockitem.cpp:163
+#, fuzzy
+msgid "Find..."
+msgstr "Sök"
+
+#: ../src/common/stockitem.cpp:164
+msgid "&First"
+msgstr "&Första"
+
+#: ../src/common/stockitem.cpp:164
+msgid "First"
+msgstr "Första"
+
+#: ../src/common/stockitem.cpp:165
+msgid "&Floppy"
+msgstr "&Diskett"
+
+#: ../src/common/stockitem.cpp:165
+msgid "Floppy"
+msgstr "Diskett"
+
+#: ../src/common/stockitem.cpp:166
+msgid "&Forward"
+msgstr "&Framåt"
+
+#: ../src/common/stockitem.cpp:166
+msgid "Forward"
+msgstr "Framåt"
+
+#: ../src/common/stockitem.cpp:167
+msgid "&Harddisk"
+msgstr "&Hårddisk"
+
+#: ../src/common/stockitem.cpp:167
+msgid "Harddisk"
+msgstr "Hårddisk"
+
+#: ../src/common/stockitem.cpp:168 ../src/generic/wizard.cpp:418
+#: ../src/osx/cocoa/menu.mm:225 ../src/richtext/richtextstyledlg.cpp:298
+#: ../src/richtext/richtextsymboldlg.cpp:451
+msgid "&Help"
+msgstr "&Hjälp"
+
+#: ../src/common/stockitem.cpp:169
+msgid "&Home"
+msgstr "&Hem"
+
+#: ../src/common/stockitem.cpp:169
+msgid "Home"
+msgstr "Hem"
+
+#: ../src/common/stockitem.cpp:170
+msgid "Indent"
+msgstr "Indentera"
+
+#: ../src/common/stockitem.cpp:171
+msgid "&Index"
+msgstr "&Index"
+
+#: ../src/common/stockitem.cpp:171 ../src/html/helpwnd.cpp:510
+msgid "Index"
+msgstr "Index"
+
+#: ../src/common/stockitem.cpp:172
+msgid "&Info"
+msgstr "&Info"
+
+#: ../src/common/stockitem.cpp:172
+msgid "Info"
+msgstr "Info"
+
+#: ../src/common/stockitem.cpp:173
+msgid "&Italic"
+msgstr "&Kursiv"
+
+#: ../src/common/stockitem.cpp:173 ../src/generic/fontdlgg.cpp:322
+#: ../src/richtext/richtextfontpage.cpp:350
+msgid "Italic"
+msgstr "Kursiv"
+
+#: ../src/common/stockitem.cpp:174
+msgid "&Jump to"
+msgstr "&Hoppa till"
+
+#: ../src/common/stockitem.cpp:174
+msgid "Jump to"
+msgstr "Hoppa till"
+
+#: ../src/common/stockitem.cpp:175
+msgid "Centered"
+msgstr "Centrerad"
+
+#: ../src/common/stockitem.cpp:176
+msgid "Justified"
+msgstr "Marginaljusterad"
+
+#: ../src/common/stockitem.cpp:177
+msgid "Align Left"
+msgstr "Vänsterjustera"
+
+#: ../src/common/stockitem.cpp:178
+msgid "Align Right"
+msgstr "Högerjustera"
+
+#: ../src/common/stockitem.cpp:179
+msgid "&Last"
+msgstr "&Sista"
+
+#: ../src/common/stockitem.cpp:179
+msgid "Last"
+msgstr "Sista"
+
+#: ../src/common/stockitem.cpp:180
+msgid "&Network"
+msgstr "&Nätverk"
+
+#: ../src/common/stockitem.cpp:180
+msgid "Network"
+msgstr "Nätverk"
+
+#: ../src/common/stockitem.cpp:181 ../src/richtext/richtexttabspage.cpp:131
+msgid "&New"
+msgstr "&Ny"
+
+#: ../src/common/stockitem.cpp:181
+msgid "New"
+msgstr "Ny"
+
+#: ../src/common/stockitem.cpp:182 ../src/msw/msgdlg.cpp:417
+msgid "&No"
+msgstr "&Nej"
+
+#: ../src/common/stockitem.cpp:183 ../src/generic/fontdlgg.cpp:467
+#: ../src/generic/fontdlgg.cpp:474
+msgid "&OK"
+msgstr "&OK"
+
+#: ../src/common/stockitem.cpp:184 ../src/generic/dbgrptg.cpp:341
+msgid "&Open..."
+msgstr "&Öppna..."
+
+#: ../src/common/stockitem.cpp:184
+msgid "Open..."
+msgstr "Öppna..."
+
+#: ../src/common/stockitem.cpp:185 ../src/msw/textctrl.cpp:2885
+#: ../src/osx/textctrl_osx.cpp:654 ../src/richtext/richtextctrl.cpp:332
+msgid "&Paste"
+msgstr "K&listra in"
+
+#: ../src/common/stockitem.cpp:185 ../src/richtext/richtextctrl.cpp:3484
+#: ../src/stc/stc_i18n.cpp:19
+msgid "Paste"
+msgstr "Klistra in"
+
+#: ../src/common/stockitem.cpp:186
+msgid "&Preferences"
+msgstr "&Inställningar"
+
+#: ../src/common/stockitem.cpp:186 ../src/osx/cocoa/preferences.mm:304
+msgid "Preferences"
+msgstr "Inställningar"
+
+#: ../src/common/stockitem.cpp:187
+msgid "Print previe&w..."
+msgstr "För&handsgranska..."
+
+#: ../src/common/stockitem.cpp:187
+msgid "Print preview..."
+msgstr "Förhandsgranska..."
+
+#: ../src/common/stockitem.cpp:188
+msgid "&Print..."
+msgstr "Skriv &ut..."
+
+#: ../src/common/stockitem.cpp:188
+msgid "Print..."
+msgstr "Skriv ut..."
+
+#: ../src/common/stockitem.cpp:189 ../src/richtext/richtextctrl.cpp:337
+#: ../src/richtext/richtextctrl.cpp:5479
+msgid "&Properties"
+msgstr "&Egenskaper"
+
+#: ../src/common/stockitem.cpp:189
+msgid "Properties"
+msgstr "Egenskaper"
+
+#: ../src/common/stockitem.cpp:190 ../src/stc/stc_i18n.cpp:16
+msgid "Redo"
+msgstr "Gör om"
+
+#: ../src/common/stockitem.cpp:191
+msgid "Refresh"
+msgstr "Uppdatera"
+
+#: ../src/common/stockitem.cpp:192
+msgid "Remove"
+msgstr "Ta bort"
+
+#: ../src/common/stockitem.cpp:193
+#, fuzzy
+msgid "Rep&lace..."
+msgstr "&Ersätt"
+
+#: ../src/common/stockitem.cpp:193
+#, fuzzy
+msgid "Replace..."
+msgstr "Ersätt"
+
+#: ../src/common/stockitem.cpp:194
+msgid "Revert to Saved"
+msgstr "Återgå till sparad"
+
+#: ../src/common/stockitem.cpp:196 ../src/generic/logg.cpp:549
+msgid "Save &As..."
+msgstr "Spara so&m..."
+
+#: ../src/common/stockitem.cpp:196
+#, fuzzy
+msgid "Save As..."
+msgstr "Spara so&m..."
+
+#: ../src/common/stockitem.cpp:197 ../src/msw/textctrl.cpp:2888
+#: ../src/osx/textctrl_osx.cpp:657 ../src/richtext/richtextctrl.cpp:335
+msgid "Select &All"
+msgstr "Markera &allt"
+
+#: ../src/common/stockitem.cpp:197 ../src/stc/stc_i18n.cpp:21
+msgid "Select All"
+msgstr "Markera allt"
+
+#: ../src/common/stockitem.cpp:198
+msgid "&Color"
+msgstr "F&ärg"
+
+#: ../src/common/stockitem.cpp:198
+msgid "Color"
+msgstr "Färg"
+
+#: ../src/common/stockitem.cpp:199
+msgid "&Font"
+msgstr "&Typsnitt"
+
+#: ../src/common/stockitem.cpp:199 ../src/richtext/richtextformatdlg.cpp:336
+msgid "Font"
+msgstr "Typsnitt"
+
+#: ../src/common/stockitem.cpp:200
+msgid "&Ascending"
+msgstr "&Stigande"
+
+#: ../src/common/stockitem.cpp:200
+msgid "Ascending"
+msgstr "Stigande"
+
+#: ../src/common/stockitem.cpp:201
+msgid "&Descending"
+msgstr "&Fallande"
+
+#: ../src/common/stockitem.cpp:201
+msgid "Descending"
+msgstr "Fallande"
+
+#: ../src/common/stockitem.cpp:202
+msgid "&Spell Check"
+msgstr "&Stavningskontroll"
+
+#: ../src/common/stockitem.cpp:202
+msgid "Spell Check"
+msgstr "Stavningskontroll"
+
+#: ../src/common/stockitem.cpp:203
+msgid "&Stop"
+msgstr "&Stopp"
+
+#: ../src/common/stockitem.cpp:203
+msgid "Stop"
+msgstr "Stopp"
+
+#: ../src/common/stockitem.cpp:204 ../src/richtext/richtextfontpage.cpp:274
+msgid "&Strikethrough"
+msgstr "&Genomstruken"
+
+#: ../src/common/stockitem.cpp:204
+msgid "Strikethrough"
+msgstr "Genomstruken"
+
+#: ../src/common/stockitem.cpp:205
+msgid "&Top"
+msgstr "&Toppen"
+
+#: ../src/common/stockitem.cpp:205 ../src/richtext/richtextsizepage.cpp:285
+#: ../src/richtext/richtextsizepage.cpp:289
+msgid "Top"
+msgstr "Toppen"
+
+#: ../src/common/stockitem.cpp:206
+msgid "Undelete"
+msgstr "Ångra borttagning"
+
+#: ../src/common/stockitem.cpp:207 ../src/generic/fontdlgg.cpp:437
+msgid "&Underline"
+msgstr "&Understrykning"
+
+#: ../src/common/stockitem.cpp:207
+msgid "Underline"
+msgstr "Understrykning"
+
+#: ../src/common/stockitem.cpp:208 ../src/stc/stc_i18n.cpp:15
+msgid "Undo"
+msgstr "Ångra"
+
+#: ../src/common/stockitem.cpp:209
+msgid "&Unindent"
+msgstr "&Utindentera"
+
+#: ../src/common/stockitem.cpp:209
+msgid "Unindent"
+msgstr "Utindentera"
+
+#: ../src/common/stockitem.cpp:210
+msgid "&Up"
+msgstr "&Upp"
+
+#: ../src/common/stockitem.cpp:210 ../src/generic/fdrepdlg.cpp:148
+msgid "Up"
+msgstr "Upp"
+
+#: ../src/common/stockitem.cpp:211 ../src/msw/msgdlg.cpp:417
+msgid "&Yes"
+msgstr "&Ja"
+
+#: ../src/common/stockitem.cpp:212
+msgid "&Actual Size"
+msgstr "V&erklig storlek"
+
+#: ../src/common/stockitem.cpp:212
+msgid "Actual Size"
+msgstr "Verklig storlek"
+
+#: ../src/common/stockitem.cpp:213
+msgid "Zoom to &Fit"
+msgstr "&Anpassa zoom"
+
+#: ../src/common/stockitem.cpp:213
+msgid "Zoom to Fit"
+msgstr "Anpassa zoom"
+
+#: ../src/common/stockitem.cpp:214
+msgid "Zoom &In"
+msgstr "Zooma &in"
+
+#: ../src/common/stockitem.cpp:215
+msgid "Zoom &Out"
+msgstr "Zooma &ut"
+
+#: ../src/common/stockitem.cpp:262
+msgid "Show about dialog"
+msgstr "Visa om-dialogruta"
+
+#: ../src/common/stockitem.cpp:263
+msgid "Copy selection"
+msgstr "Kopiera markerat"
+
+#: ../src/common/stockitem.cpp:264
+msgid "Cut selection"
+msgstr "Klipp ut markerat"
+
+#: ../src/common/stockitem.cpp:265
+msgid "Delete selection"
+msgstr "Ta bort markerat"
+
+#: ../src/common/stockitem.cpp:266
+#, fuzzy
+msgid "Find in document"
+msgstr "Öppna HTML-dokument"
+
+#: ../src/common/stockitem.cpp:267
+msgid "Find and replace in document"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:268
+msgid "Paste selection"
+msgstr "Klistra in markerat"
+
+#: ../src/common/stockitem.cpp:269
+msgid "Quit this program"
+msgstr "Avsluta programmet"
+
+#: ../src/common/stockitem.cpp:270
+msgid "Redo last action"
+msgstr "Gör om senaste händelse"
+
+#: ../src/common/stockitem.cpp:271
+msgid "Undo last action"
+msgstr "Ångra senaste händelse"
+
+#: ../src/common/stockitem.cpp:272
+#, fuzzy
+msgid "Create new document"
+msgstr "Skapa ny katalog"
+
+#: ../src/common/stockitem.cpp:273
+#, fuzzy
+msgid "Open an existing document"
+msgstr "Öppna HTML-dokument"
+
+#: ../src/common/stockitem.cpp:274
+msgid "Close current document"
+msgstr "Stäng aktuellt dokument"
+
+#: ../src/common/stockitem.cpp:275
+msgid "Save current document"
+msgstr "Spara aktuellt dokument"
+
+#: ../src/common/stockitem.cpp:276
+msgid "Save current document with a different filename"
+msgstr "Spara aktuellt dokument med ett annat filnamn"
+
+#: ../src/common/strconv.cpp:2324
+#, c-format
+msgid "Conversion to charset '%s' doesn't work."
+msgstr "Konvertering till teckenuppsättning \"%s\" fungerar inte."
+
+#: ../src/common/tarstrm.cpp:352 ../src/common/tarstrm.cpp:375
+#: ../src/common/tarstrm.cpp:406 ../src/generic/progdlgg.cpp:373
+msgid "unknown"
+msgstr "okänd"
+
+#: ../src/common/tarstrm.cpp:774
+msgid "incomplete header block in tar"
+msgstr "ofullständigt huvudblock i tar"
+
+#: ../src/common/tarstrm.cpp:798
+msgid "checksum failure reading tar header block"
+msgstr "checksumma misslyckades när tar-huvudblock lästes"
+
+#: ../src/common/tarstrm.cpp:971
+msgid "invalid data in extended tar header"
+msgstr "felaktigt data i utökat tar-huvud"
+
+#: ../src/common/tarstrm.cpp:981 ../src/common/tarstrm.cpp:1003
+#: ../src/common/tarstrm.cpp:1477 ../src/common/tarstrm.cpp:1499
+msgid "tar entry not open"
+msgstr "tar-post är inte öppen"
+
+#: ../src/common/tarstrm.cpp:1023
+msgid "unexpected end of file"
+msgstr "oväntat slut på filen"
+
+#: ../src/common/tarstrm.cpp:1297
+#, c-format
+msgid "%s did not fit the tar header for entry '%s'"
+msgstr "%s passade inte tar-huvudet för post \"%s\""
+
+#: ../src/common/tarstrm.cpp:1359
+msgid "incorrect size given for tar entry"
+msgstr "felaktig storlek angiven för tar-post"
+
+#: ../src/common/textbuf.cpp:232
+#, c-format
+msgid "'%s' is probably a binary buffer."
+msgstr "\"%s\" är troligen en binär buffer."
+
+#: ../src/common/textcmn.cpp:1006 ../src/richtext/richtextctrl.cpp:3053
+msgid "File couldn't be loaded."
+msgstr "Filen kunde inte läsas in."
+
+#: ../src/common/textfile.cpp:95
+#, fuzzy, c-format
+msgid "Failed to read text file \"%s\"."
+msgstr "Kunde inte läsa dokument från filen \"%s\"."
+
+#: ../src/common/textfile.cpp:160
+#, c-format
+msgid "can't write buffer '%s' to disk."
+msgstr "kan inte skriva buffer \"%s\" till disk."
+
+#: ../src/common/time.cpp:212
+msgid "Failed to get the local system time"
+msgstr "Kunde inte hämta den lokala systemtiden"
+
+#: ../src/common/time.cpp:279
+msgid "wxGetTimeOfDay failed."
+msgstr "wxGetTimeOfDay misslyckades."
+
+#: ../src/common/translation.cpp:929
+#, c-format
+msgid "'%s' is not a valid message catalog."
+msgstr "\"%s\" är inte en giltig meddelandekatalog."
+
+#: ../src/common/translation.cpp:954
+msgid "Invalid message catalog."
+msgstr "Ogiltig meddelandekatalog."
+
+#: ../src/common/translation.cpp:1013
+#, c-format
+msgid "Failed to parse Plural-Forms: '%s'"
+msgstr "Kunde inte tolka pluralformer: \"%s\""
+
+#: ../src/common/translation.cpp:1723
+#, c-format
+msgid "using catalog '%s' from '%s'."
+msgstr "använder katalog \"%s\" från \"%s\"."
+
+#: ../src/common/translation.cpp:1816
+#, c-format
+msgid "Resource '%s' is not a valid message catalog."
+msgstr "Resursen \"%s\" är inte en giltig meddelandekatalog."
+
+#: ../src/common/translation.cpp:1865
+msgid "Couldn't enumerate translations"
+msgstr "Kunde inte räkna upp översättningar"
+
+#: ../src/common/utilscmn.cpp:1145
+msgid "No default application configured for HTML files."
+msgstr "Inget standardprogram för HTML-filer är konfigurerat."
+
+#: ../src/common/utilscmn.cpp:1190
+#, c-format
+msgid "Failed to open URL \"%s\" in default browser."
+msgstr "Kunde inte öppna URL \"%s\" i standardwebbläsare."
+
+#: ../src/common/valtext.cpp:144
+msgid "Validation conflict"
+msgstr "Valideringskonflikt"
+
+#: ../src/common/valtext.cpp:186
+msgid "Required information entry is empty."
+msgstr "Nödvändigt informationsfält är tomt."
+
+#: ../src/common/valtext.cpp:188
+#, fuzzy, c-format
+msgid "'%s' is one of the invalid strings"
+msgstr "\"%s\" är ogiltig"
+
+#: ../src/common/valtext.cpp:190
+#, fuzzy, c-format
+msgid "'%s' is not one of the valid strings"
+msgstr "\"%s\" är inte en giltig meddelandekatalog."
+
+#: ../src/common/valtext.cpp:199
+#, fuzzy, c-format
+msgid "'%s' contains invalid character(s)"
+msgstr "\"%s\" får bara innehålla alfabetiska tecken."
+
+#: ../src/common/webrequest.cpp:139
+#, fuzzy, c-format
+msgid "Error: %s (%d)"
+msgstr "Fel: "
+
+#: ../src/common/webrequest.cpp:655
+#, c-format
+msgid ""
+"Not enough free disk space for download: %llu needed but only %llu available."
+msgstr ""
+
+#: ../src/common/webrequest.cpp:669
+#, fuzzy, c-format
+msgid "Failed to create temporary file in %s"
+msgstr "Kunde inte skapa ett namn för temporär fil"
+
+#: ../src/common/webrequest_curl.cpp:1106
+#, fuzzy
+msgid "libcurl could not be initialized"
+msgstr "Kolumnbeskrivning kunde inte initieras."
+
+#: ../src/common/webview.cpp:392
+#, fuzzy
+msgid "RunScriptAsync not supported"
+msgstr "Strängomvandlingar stöds inte"
+
+#: ../src/common/webview.cpp:403 ../src/msw/webview_ie.cpp:1073
+#, c-format
+msgid "Error running JavaScript: %s"
+msgstr ""
+
+#: ../src/common/webview_chromium.cpp:858
+#, fuzzy, c-format
+msgid "Failed to set proxy \"%s\": %s"
+msgstr "Kunde inte skapa katalog \"%s\""
+
+#: ../src/common/webview_chromium.cpp:989
+msgid ""
+"Chromium can't be used because libcef.so wasn't loaded early enough; please "
+"relink the application or use LD_PRELOAD to load it earlier."
+msgstr ""
+
+#: ../src/common/webview_chromium.cpp:1108
+#, fuzzy
+msgid "Could not initialize Chromium"
+msgstr "Kunde inte ange justering."
+
+#: ../src/common/webview_chromium.cpp:1616
+msgid "Show DevTools"
+msgstr ""
+
+#: ../src/common/webview_chromium.cpp:1617
+#, fuzzy
+msgid "Close DevTools"
+msgstr "Stäng alla"
+
+#: ../src/common/webview_chromium.cpp:1623
+msgid "Inspect"
+msgstr ""
+
+#: ../src/common/wincmn.cpp:1628
+msgid "This platform does not support background transparency."
+msgstr "Denna plattform stöder inte bakgrundsgenomskinlighet."
+
+#: ../src/common/wincmn.cpp:2097
+msgid "Could not transfer data to window"
+msgstr "Kunde inte föra över data till fönstret"
+
+#: ../src/common/windowid.cpp:240
+msgid "Out of window IDs.  Recommend shutting down application."
+msgstr "Slut på window-ID. Nedstängning av programmet rekommenderas."
+
+#: ../src/common/xpmdecod.cpp:678
+msgid "XPM: incorrect header format!"
+msgstr "XPM: Felaktigt format i huvudet!"
+
+#: ../src/common/xpmdecod.cpp:703
+#, c-format
+msgid "XPM: incorrect colour description in line %d"
+msgstr "XPM: Felaktig färgbeskrivning på rad %d "
+
+#: ../src/common/xpmdecod.cpp:715 ../src/common/xpmdecod.cpp:724
+#, c-format
+msgid "XPM: malformed colour definition '%s' at line %d!"
+msgstr "XPM: Felaktig färgdefinition \"%s\" på rad %d!"
+
+#: ../src/common/xpmdecod.cpp:754
+msgid "XPM: no colors left to use for mask!"
+msgstr "XPM: Inga färger kvar att använda i masken!"
+
+#: ../src/common/xpmdecod.cpp:781
+#, c-format
+msgid "XPM: truncated image data at line %d!"
+msgstr "XPM: Trunkerat bilddata på rad %d!"
+
+#: ../src/common/xpmdecod.cpp:795
+msgid "XPM: Malformed pixel data!"
+msgstr "XPM: Felaktigt pixeldata!"
+
+#: ../src/common/xti.cpp:492
+msgid "Illegal Parameter Count for Create Method"
+msgstr "Otillåtet antal parametrar för Create-metod"
+
+#: ../src/common/xti.cpp:504
+msgid "Illegal Parameter Count for ConstructObject Method"
+msgstr "Otillåtet antal parametrar för ConstructObject-metod"
+
+#: ../src/common/xtistrm.cpp:161
+#, c-format
+msgid "Create Parameter %s not found in declared RTTI Parameters"
+msgstr "Skapa-parameter %s hittades inte i deklarerade RTTI-parametrar"
+
+#: ../src/common/xtistrm.cpp:290
+msgid "Illegal Object Class (Non-wxEvtHandler) as Event Source"
+msgstr "Otillåten objektklass (icke-wxEvtHandler) som händelsekälla"
+
+#: ../src/common/xtistrm.cpp:313 ../src/common/xtixml.cpp:345
+#: ../src/common/xtixml.cpp:498
+msgid "Type must have enum - long conversion"
+msgstr "Typen måste ha enum - long omvandling"
+
+#: ../src/common/xtistrm.cpp:400 ../src/common/xtistrm.cpp:415
+msgid "Invalid or Null Object ID passed to GetObjectClassInfo"
+msgstr "Ogiltigt eller null objekt-id skickat till GetObjectClassInfo"
+
+#: ../src/common/xtistrm.cpp:405
+msgid "Unknown Object passed to GetObjectClassInfo"
+msgstr "Okänt objekt skickades till GetObjectClassInfo"
+
+#: ../src/common/xtistrm.cpp:420
+msgid "Already Registered Object passed to SetObjectClassInfo"
+msgstr "Redan registrerat objekt skickades till SetObjectClassInfo"
+
+#: ../src/common/xtistrm.cpp:430
+msgid "Invalid or Null Object ID passed to HasObjectClassInfo"
+msgstr "Ogiltigt eller null objekt-id skickat till HasObjectClassInfo"
+
+#: ../src/common/xtistrm.cpp:460
+msgid "Passing a already registered object to SetObject"
+msgstr "Skickade ett redan registrerat objekt till SetObject"
+
+#: ../src/common/xtistrm.cpp:471
+msgid "Passing an unknown object to GetObject"
+msgstr "Skickar ett okänt objekt till GetObject"
+
+#: ../src/common/xtixml.cpp:229
+msgid "Forward hrefs are not supported"
+msgstr "Framåt-href stöds inte"
+
+#: ../src/common/xtixml.cpp:247
+#, c-format
+msgid "unknown class %s"
+msgstr "okänd klass %s"
+
+#: ../src/common/xtixml.cpp:253
+msgid "objects cannot have XML Text Nodes"
+msgstr "objekt kan inte ha XML-textnoder"
+
+#: ../src/common/xtixml.cpp:258
+msgid "Objects must have an id attribute"
+msgstr "Objekt måste ha ett id-attribut"
+
+#: ../src/common/xtixml.cpp:267
+#, c-format
+msgid "Doubly used id : %d"
+msgstr "Dubbelt använt id: %d"
+
+#: ../src/common/xtixml.cpp:316
+#, c-format
+msgid "Unknown Property %s"
+msgstr "Okänd egenskap %s"
+
+#: ../src/common/xtixml.cpp:407
+msgid "A non empty collection must consist of 'element' nodes"
+msgstr "En icke tom samling måste bestå av \"element\"-noder"
+
+#: ../src/common/xtixml.cpp:478
+msgid "incorrect event handler string, missing dot"
+msgstr "felaktig händelsehanterarsträng, punkt saknas"
+
+#: ../src/common/zipstrm.cpp:559
+msgid "can't re-initialize zlib deflate stream"
+msgstr "kan inte återinitiera zlib deflate-ström"
+
+#: ../src/common/zipstrm.cpp:584
+msgid "can't re-initialize zlib inflate stream"
+msgstr "kan inte återinitiera zlib inflate-ström"
+
+#: ../src/common/zipstrm.cpp:1023
+msgid "Ignoring malformed extra data record, ZIP file may be corrupted"
+msgstr ""
+
+#: ../src/common/zipstrm.cpp:1502
+msgid "assuming this is a multi-part zip concatenated"
+msgstr "antar att detta är en multi-part zip konkatenerad"
+
+#: ../src/common/zipstrm.cpp:1664
+msgid "invalid zip file"
+msgstr "ogiltig zip-fil"
+
+#: ../src/common/zipstrm.cpp:1723
+msgid "can't find central directory in zip"
+msgstr "kan inte hitta central katalog i zip"
+
+#: ../src/common/zipstrm.cpp:1812
+msgid "error reading zip central directory"
+msgstr "fel vid läsning av central katalog i zip"
+
+#: ../src/common/zipstrm.cpp:1916
+msgid "error reading zip local header"
+msgstr "fel vid läsning av lokalt ziphuvud"
+
+#: ../src/common/zipstrm.cpp:1964
+msgid "bad zipfile offset to entry"
+msgstr "felaktig zipfil offset mot ingång"
+
+#: ../src/common/zipstrm.cpp:2031
+msgid "stored file length not in Zip header"
+msgstr "lagrad fillängd finns inte i Zip-huvud"
+
+#: ../src/common/zipstrm.cpp:2045 ../src/common/zipstrm.cpp:2362
+msgid "unsupported Zip compression method"
+msgstr "komprimeringsmetod i Zip stöds inte"
+
+#: ../src/common/zipstrm.cpp:2126
+#, c-format
+msgid "reading zip stream (entry %s): bad length"
+msgstr "läser zip-ström (post %s): Felaktig längd"
+
+#: ../src/common/zipstrm.cpp:2131
+#, c-format
+msgid "reading zip stream (entry %s): bad crc"
+msgstr "läser zip-ström (post %s): Felaktig crc"
+
+#: ../src/common/zipstrm.cpp:2578
+#, fuzzy, c-format
+msgid "error writing zip entry '%s': file too large without ZIP64"
+msgstr "fel vid skrivning av zip-post \"%s\": Felaktig crc eller längd"
+
+#: ../src/common/zipstrm.cpp:2585
+#, c-format
+msgid "error writing zip entry '%s': bad crc or length"
+msgstr "fel vid skrivning av zip-post \"%s\": Felaktig crc eller längd"
+
+#: ../src/common/zstream.cpp:155 ../src/common/zstream.cpp:315
+msgid "Gzip not supported by this version of zlib"
+msgstr "Gzip stöds inte av den här versionen av zlib"
+
+#: ../src/common/zstream.cpp:182
+msgid "Can't initialize zlib inflate stream."
+msgstr "Kan inte initiera zlib inflate-ström."
+
+#: ../src/common/zstream.cpp:241
+msgid "Can't read inflate stream: unexpected EOF in underlying stream."
+msgstr "Kan inte läsa inflate-ström: Oväntat filslut i underliggande ström."
+
+#: ../src/common/zstream.cpp:248 ../src/common/zstream.cpp:423
+#, c-format
+msgid "zlib error %d"
+msgstr "zlib-fel %d"
+
+#: ../src/common/zstream.cpp:249
+#, c-format
+msgid "Can't read from inflate stream: %s"
+msgstr "Kan inte läsa från inflate-ström: %s"
+
+#: ../src/common/zstream.cpp:343
+msgid "Can't initialize zlib deflate stream."
+msgstr "Kan inte initiera zlib deflate-ström."
+
+#: ../src/common/zstream.cpp:424
+#, c-format
+msgid "Can't write to deflate stream: %s"
+msgstr "Kan inte skriva till deflate-ström: %s"
+
+#: ../src/dfb/bitmap.cpp:633 ../src/dfb/bitmap.cpp:667
+#, c-format
+msgid "No bitmap handler for type %d defined."
+msgstr "Ingen bildhanterare är definierad för typ %d."
+
+#: ../src/dfb/evtloop.cpp:99
+msgid "Failed to read event from DirectFB pipe"
+msgstr "Kunde inte läsa händelse från DirectFB-rör"
+
+#: ../src/dfb/evtloop.cpp:171
+msgid "Failed to switch DirectFB pipe to non-blocking mode"
+msgstr "Kunde inte växla DirectFB-rör till icke-blockerande läge"
+
+#: ../src/dfb/fontmgr.cpp:171
+#, c-format
+msgid "no fonts found in %s, using builtin font"
+msgstr "inga typsnitt hittades i %s, använder inbyggt typsnitt"
+
+#: ../src/dfb/fontmgr.cpp:177
+msgid "Default font"
+msgstr "Standardtypsnitt"
+
+#: ../src/dfb/fontmgr.cpp:195
+#, c-format
+msgid "Fonts index file %s disappeared while loading fonts."
+msgstr "Typsnittsindexfil %s försvann när typsnitten lästes in."
+
+#: ../src/dfb/wrapdfb.cpp:60
+#, c-format
+msgid "DirectFB error %d occurred."
+msgstr "DirectFB fel %d inträffade."
+
+#: ../src/generic/aboutdlgg.cpp:69
+msgid "Developed by "
+msgstr "Utvecklat av "
+
+#: ../src/generic/aboutdlgg.cpp:72
+msgid "Documentation by "
+msgstr "Dokumenterat av "
+
+#: ../src/generic/aboutdlgg.cpp:75
+msgid "Graphics art by "
+msgstr "Grafik av "
+
+#: ../src/generic/aboutdlgg.cpp:78
+msgid "Translations by "
+msgstr "Översättningar av "
+
+#: ../src/generic/aboutdlgg.cpp:133 ../src/osx/cocoa/aboutdlg.mm:83
+msgid "Version "
+msgstr "Version "
+
+#. TRANSLATORS: %s is application name
+#: ../src/generic/aboutdlgg.cpp:146 ../src/msw/aboutdlg.cpp:60
+#, c-format
+msgid "About %s"
+msgstr "Om %s"
+
+#: ../src/generic/aboutdlgg.cpp:181
+msgid "License"
+msgstr "Licens"
+
+#: ../src/generic/aboutdlgg.cpp:184
+msgid "Developers"
+msgstr "Utvecklare"
+
+#: ../src/generic/aboutdlgg.cpp:188
+msgid "Documentation writers"
+msgstr "Dokumentationssförfattare"
+
+#: ../src/generic/aboutdlgg.cpp:192
+msgid "Artists"
+msgstr "Konstnärer"
+
+#: ../src/generic/aboutdlgg.cpp:196
+msgid "Translators"
+msgstr "Översättare"
+
+#: ../src/generic/animateg.cpp:125
+msgid "No handler found for animation type."
+msgstr "Ingen hanterare hittades för animationstyp."
+
+#: ../src/generic/animateg.cpp:133
+#, c-format
+msgid "No animation handler for type %ld defined."
+msgstr "Ingen animationshanterare är definierad för typ %ld."
+
+#: ../src/generic/animateg.cpp:145
+#, c-format
+msgid "Animation file is not of type %ld."
+msgstr "Animationsfilen är inte av typen %ld."
+
+#: ../src/generic/colrdlgg.cpp:154 ../src/gtk/colordlg.cpp:47
+msgid "Choose colour"
+msgstr "Välj färg"
+
+#: ../src/generic/colrdlgg.cpp:357
+msgid "Red:"
+msgstr ""
+
+#: ../src/generic/colrdlgg.cpp:360
+#, fuzzy
+msgid "Green:"
+msgstr "MacGrekiska"
+
+#: ../src/generic/colrdlgg.cpp:363
+msgid "Blue:"
+msgstr ""
+
+#: ../src/generic/colrdlgg.cpp:372
+msgid "Opacity:"
+msgstr ""
+
+#: ../src/generic/colrdlgg.cpp:384
+msgid "Add to custom colours"
+msgstr "Lägg till till egendefinierade färger"
+
+#: ../src/generic/creddlgg.cpp:56
+msgid "Username:"
+msgstr ""
+
+#: ../src/generic/creddlgg.cpp:63
+msgid "Password:"
+msgstr ""
+
+#. TRANSLATORS: Name of Boolean true value
+#: ../src/generic/datavgen.cpp:1178
+msgid "true"
+msgstr ""
+
+#. TRANSLATORS: Name of Boolean false value
+#: ../src/generic/datavgen.cpp:1180
+#, fuzzy
+msgid "false"
+msgstr "Falskt"
+
+#: ../src/generic/datavgen.cpp:6897
+#, c-format
+msgid "Row %i"
+msgstr ""
+
+#. TRANSLATORS: Action for manipulating a tree control
+#: ../src/generic/datavgen.cpp:6987
+msgid "Collapse"
+msgstr ""
+
+#. TRANSLATORS: Action for manipulating a tree control
+#: ../src/generic/datavgen.cpp:6990
+msgid "Expand"
+msgstr ""
+
+#. TRANSLATORS: Name of data view control and number of rows
+#: ../src/generic/datavgen.cpp:7011
+#, fuzzy, c-format
+msgid "%s (%d items)"
+msgstr "%s (eller %s)"
+
+#: ../src/generic/datavgen.cpp:7062
+#, fuzzy, c-format
+msgid "Column %u"
+msgstr "Lägg till kolumn"
+
+#. TRANSLATORS: Keystroke for manipulating a tree control
+#: ../src/generic/datavgen.cpp:7131 ../src/richtext/richtextbulletspage.cpp:189
+#: ../src/richtext/richtextbulletspage.cpp:192
+#: ../src/richtext/richtextbulletspage.cpp:193
+#: ../src/richtext/richtextliststylepage.cpp:252
+#: ../src/richtext/richtextliststylepage.cpp:255
+#: ../src/richtext/richtextliststylepage.cpp:256
+#: ../src/richtext/richtextsizepage.cpp:248
+msgid "Left"
+msgstr "Vänster"
+
+#. TRANSLATORS: Keystroke for manipulating a tree control
+#: ../src/generic/datavgen.cpp:7134 ../src/richtext/richtextbulletspage.cpp:191
+#: ../src/richtext/richtextliststylepage.cpp:254
+#: ../src/richtext/richtextsizepage.cpp:249
+msgid "Right"
+msgstr "Höger"
+
+#: ../src/generic/datectlg.cpp:90
+#, c-format
+msgid ""
+"\"%s\" is not in the expected date format, please enter it as e.g. \"%s\"."
+msgstr ""
+
+#: ../src/generic/datectlg.cpp:94
+#, fuzzy
+msgid "Invalid date"
+msgstr "Ogiltig datavypost"
+
+#: ../src/generic/dbgrptg.cpp:159
+#, c-format
+msgid "Open file \"%s\""
+msgstr "Öppna fil \"%s\""
+
+#: ../src/generic/dbgrptg.cpp:170
+#, c-format
+msgid "Enter command to open file \"%s\":"
+msgstr "Skriv in kommando för att öppna fil \"%s\":"
+
+#: ../src/generic/dbgrptg.cpp:230
+msgid "Executable files (*.exe)|*.exe|"
+msgstr "Körbara filer (*.exe)|*.exe|"
+
+#: ../src/generic/dbgrptg.cpp:300
+#, c-format
+msgid "Debug report \"%s\""
+msgstr "Debugrapport \"%s\""
+
+#: ../src/generic/dbgrptg.cpp:316
+msgid "A debug report has been generated in the directory\n"
+msgstr "En debugrapport har skapats i katalogen\n"
+
+#: ../src/generic/dbgrptg.cpp:317
+#, fuzzy
+msgid "The following debug report will be generated\n"
+msgstr "*** En debugrapport har skapats\n"
+
+#: ../src/generic/dbgrptg.cpp:321
+msgid ""
+"The report contains the files listed below. If any of these files contain "
+"private information,\n"
+"please uncheck them and they will be removed from the report.\n"
+msgstr ""
+"Rapporten innehåller filerna nedan. Om någon av filerna innehåller\n"
+"privat information, välj bort dem så tas de bort från rapporten.\n"
+
+#: ../src/generic/dbgrptg.cpp:323
+msgid ""
+"If you wish to suppress this debug report completely, please choose the "
+"\"Cancel\" button,\n"
+"but be warned that it may hinder improving the program, so if\n"
+"at all possible please do continue with the report generation.\n"
+msgstr ""
+"Om du vill strunta i den här debugrapporten, klicka på \"Avbryt\", men var\n"
+"medveten om att det kan hindra förbättringar av programmet, så om det\n"
+"är möjligt, fortsätt med skapandet av rapporten.\n"
+
+#: ../src/generic/dbgrptg.cpp:325
+msgid "              Thank you and we're sorry for the inconvenience!\n"
+msgstr "              Tack så mycket, och vi är ledsna för besväret!\n"
+
+#: ../src/generic/dbgrptg.cpp:333
+msgid "&Debug report preview:"
+msgstr "Förhandsgranskning av &debugrapport:"
+
+#: ../src/generic/dbgrptg.cpp:339
+msgid "&View..."
+msgstr "&Visa..."
+
+#: ../src/generic/dbgrptg.cpp:359
+msgid "&Notes:"
+msgstr "&Anteckningar:"
+
+#: ../src/generic/dbgrptg.cpp:361
+msgid ""
+"If you have any additional information pertaining to this bug\n"
+"report, please enter it here and it will be joined to it:"
+msgstr ""
+"Om du har mer information angående den här buggrapporten,\n"
+"skriv in den här och den kommer att bifogas:"
+
+#: ../src/generic/dcpsg.cpp:1627
+msgid "Cannot open file for PostScript printing!"
+msgstr "Kan inte öppna fil för PostScript-utskrift!"
+
+#: ../src/generic/dirctrlg.cpp:402
+msgid "Computer"
+msgstr "Dator"
+
+#: ../src/generic/dirctrlg.cpp:404
+msgid "Sections"
+msgstr "Avdelningar"
+
+#: ../src/generic/dirctrlg.cpp:482
+msgid "Home directory"
+msgstr "Hemkatalog"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/generic/dirctrlg.cpp:484 ../src/propgrid/advprops.cpp:811
+msgid "Desktop"
+msgstr "Skrivbord"
+
+#: ../src/generic/dirctrlg.cpp:528 ../src/generic/filectrlg.cpp:752
+msgid "Illegal directory name."
+msgstr "Ogiltigt katalognamn."
+
+#: ../src/generic/dirctrlg.cpp:528 ../src/generic/dirctrlg.cpp:546
+#: ../src/generic/dirctrlg.cpp:557 ../src/generic/dirdlgg.cpp:317
+#: ../src/generic/filectrlg.cpp:638 ../src/generic/filectrlg.cpp:752
+#: ../src/generic/filectrlg.cpp:766 ../src/generic/filectrlg.cpp:782
+#: ../src/generic/filectrlg.cpp:1356 ../src/generic/filectrlg.cpp:1387
+#: ../src/generic/filedlgg.cpp:362 ../src/gtk/filedlg.cpp:76
+msgid "Error"
+msgstr "Fel"
+
+#: ../src/generic/dirctrlg.cpp:546 ../src/generic/filectrlg.cpp:766
+msgid "File name exists already."
+msgstr "Filnamnet finns redan."
+
+#: ../src/generic/dirctrlg.cpp:557 ../src/generic/dirdlgg.cpp:317
+#: ../src/generic/filectrlg.cpp:638 ../src/generic/filectrlg.cpp:782
+msgid "Operation not permitted."
+msgstr "Operation ej tillåten."
+
+#: ../src/generic/dirdlgg.cpp:107 ../src/generic/filedlgg.cpp:207
+msgid "Create new directory"
+msgstr "Skapa ny katalog"
+
+#: ../src/generic/dirdlgg.cpp:112 ../src/generic/filedlgg.cpp:203
+msgid "Go to home directory"
+msgstr "Gå till hemkatalog"
+
+#: ../src/generic/dirdlgg.cpp:143
+msgid "Show &hidden directories"
+msgstr "Visa &dolda kataloger"
+
+#: ../src/generic/dirdlgg.cpp:196
+#, c-format
+msgid ""
+"The directory '%s' does not exist\n"
+"Create it now?"
+msgstr ""
+"Katalogen \"%s\" finns inte\n"
+"Skapa den nu?"
+
+#: ../src/generic/dirdlgg.cpp:198
+msgid "Directory does not exist"
+msgstr "Katalogen finns inte"
+
+#: ../src/generic/dirdlgg.cpp:214
+#, c-format
+msgid ""
+"Failed to create directory '%s'\n"
+"(Do you have the required permissions?)"
+msgstr ""
+"Kunde inte skapa katalog \"%s\"\n"
+"(Har du de nödvändiga behörigheterna?)"
+
+#: ../src/generic/dirdlgg.cpp:216
+msgid "Error creating directory"
+msgstr "Fel vid skapande av katalog"
+
+#: ../src/generic/dirdlgg.cpp:281
+msgid "You cannot add a new directory to this section."
+msgstr "Du kan inte lägga till en ny katalog till denna avdelning."
+
+#: ../src/generic/dirdlgg.cpp:282
+msgid "Create directory"
+msgstr "Skapa katalog"
+
+#: ../src/generic/dirdlgg.cpp:291 ../src/generic/dirdlgg.cpp:301
+#: ../src/generic/filectrlg.cpp:614 ../src/generic/filectrlg.cpp:623
+msgid "NewName"
+msgstr "Nytt namn"
+
+#: ../src/generic/editlbox.cpp:135
+msgid "Edit item"
+msgstr "Redigera post"
+
+#: ../src/generic/editlbox.cpp:143
+msgid "New item"
+msgstr "Nytt post"
+
+#: ../src/generic/editlbox.cpp:151
+msgid "Delete item"
+msgstr "Ta bort post"
+
+#: ../src/generic/editlbox.cpp:159
+msgid "Move up"
+msgstr "Flytta upp"
+
+#: ../src/generic/editlbox.cpp:164
+msgid "Move down"
+msgstr "Flytta ner"
+
+#: ../src/generic/fdrepdlg.cpp:108
+msgid "Search for:"
+msgstr "Sök efter:"
+
+#: ../src/generic/fdrepdlg.cpp:120
+msgid "Replace with:"
+msgstr "Ersätt med:"
+
+#: ../src/generic/fdrepdlg.cpp:140
+msgid "Whole word"
+msgstr "Hela ord"
+
+#: ../src/generic/fdrepdlg.cpp:143
+msgid "Match case"
+msgstr "Matcha skiftläge"
+
+#: ../src/generic/fdrepdlg.cpp:156
+msgid "Search direction"
+msgstr "Sökriktning"
+
+#: ../src/generic/fdrepdlg.cpp:175
+msgid "&Replace"
+msgstr "&Ersätt"
+
+#: ../src/generic/fdrepdlg.cpp:178
+msgid "Replace &all"
+msgstr "Ersätt &alla"
+
+#: ../src/generic/filectrlg.cpp:246 ../src/generic/filectrlg.cpp:269
+msgid "<DIR>"
+msgstr "<KAT>"
+
+#: ../src/generic/filectrlg.cpp:248 ../src/generic/filectrlg.cpp:271
+msgid "<LINK>"
+msgstr "<LÄNK>"
+
+#: ../src/generic/filectrlg.cpp:250 ../src/generic/filectrlg.cpp:273
+msgid "<DRIVE>"
+msgstr "<ENHET>"
+
+#: ../src/generic/filectrlg.cpp:275
+#, c-format
+msgid "%ld byte"
+msgid_plural "%ld bytes"
+msgstr[0] "%ld byte"
+msgstr[1] "%ld byte"
+
+#: ../src/generic/filectrlg.cpp:420
+msgid "Name"
+msgstr "Namn"
+
+#: ../src/generic/filectrlg.cpp:421 ../src/richtext/richtextformatdlg.cpp:361
+#: ../src/richtext/richtextsizepage.cpp:298
+msgid "Size"
+msgstr "Storlek"
+
+#: ../src/generic/filectrlg.cpp:422
+msgid "Type"
+msgstr "Typ"
+
+#: ../src/generic/filectrlg.cpp:423
+msgid "Modified"
+msgstr "Ändrad"
+
+#: ../src/generic/filectrlg.cpp:426
+msgid "Permissions"
+msgstr "Behörigheter"
+
+#: ../src/generic/filectrlg.cpp:429
+msgid "Attributes"
+msgstr "Attribut"
+
+#: ../src/generic/filectrlg.cpp:936
+msgid "Current directory:"
+msgstr "Aktuell katalog:"
+
+#: ../src/generic/filectrlg.cpp:979
+msgid "Show &hidden files"
+msgstr "Visa &dolda filer"
+
+#: ../src/generic/filectrlg.cpp:1355
+msgid "Illegal file specification."
+msgstr "Ogiltig filspecifikation."
+
+#: ../src/generic/filectrlg.cpp:1387
+msgid "Directory doesn't exist."
+msgstr "Katalogen finns inte."
+
+#: ../src/generic/filedlgg.cpp:195
+msgid "View files as a list view"
+msgstr "Visa filer som lista"
+
+#: ../src/generic/filedlgg.cpp:197
+msgid "View files as a detailed view"
+msgstr "Visa filer som detaljerad lista"
+
+#: ../src/generic/filedlgg.cpp:200
+msgid "Go to parent directory"
+msgstr "Gå till föräldrakatalog"
+
+#: ../src/generic/filedlgg.cpp:351 ../src/gtk/filedlg.cpp:59
+#, c-format
+msgid "File '%s' already exists, do you really want to overwrite it?"
+msgstr "Filen \"%s\" finns redan, vill du verkligen skriva över den?"
+
+#: ../src/generic/filedlgg.cpp:354 ../src/gtk/filedlg.cpp:62
+msgid "Confirm"
+msgstr "Bekräfta"
+
+#: ../src/generic/filedlgg.cpp:362 ../src/gtk/filedlg.cpp:75
+msgid "Please choose an existing file."
+msgstr "Välj en existerande fil."
+
+#: ../src/generic/filepickerg.cpp:64
+msgid "..."
+msgstr "…"
+
+#: ../src/generic/fontdlgg.cpp:76 ../src/richtext/richtextformatdlg.cpp:519
+msgid "ABCDEFGabcdefg12345"
+msgstr "ABCDEFGabcdefg12345"
+
+#: ../src/generic/fontdlgg.cpp:315
+msgid "Roman"
+msgstr "Roman"
+
+#: ../src/generic/fontdlgg.cpp:316
+msgid "Decorative"
+msgstr "Dekorativ"
+
+#: ../src/generic/fontdlgg.cpp:317
+msgid "Modern"
+msgstr "Modern"
+
+#: ../src/generic/fontdlgg.cpp:318
+msgid "Script"
+msgstr "Skrivstil"
+
+#: ../src/generic/fontdlgg.cpp:319
+msgid "Swiss"
+msgstr "Swiss"
+
+#: ../src/generic/fontdlgg.cpp:320
+msgid "Teletype"
+msgstr "Teletyp"
+
+#: ../src/generic/fontdlgg.cpp:321 ../src/generic/fontdlgg.cpp:324
+msgid "Normal"
+msgstr "Normal"
+
+#: ../src/generic/fontdlgg.cpp:323
+msgid "Slant"
+msgstr "Lutande"
+
+#: ../src/generic/fontdlgg.cpp:325
+msgid "Light"
+msgstr "Tunn"
+
+#: ../src/generic/fontdlgg.cpp:363
+msgid "&Font family:"
+msgstr "&Typsnittsfamilj:"
+
+#: ../src/generic/fontdlgg.cpp:367 ../src/generic/fontdlgg.cpp:369
+msgid "The font family."
+msgstr "Typsnittets familj."
+
+#: ../src/generic/fontdlgg.cpp:374 ../src/richtext/richtextstylepage.cpp:105
+msgid "&Style:"
+msgstr "&Stil:"
+
+#: ../src/generic/fontdlgg.cpp:378 ../src/generic/fontdlgg.cpp:380
+msgid "The font style."
+msgstr "Typsnittets stil."
+
+#: ../src/generic/fontdlgg.cpp:385
+msgid "&Weight:"
+msgstr "&Vikt:"
+
+#: ../src/generic/fontdlgg.cpp:389 ../src/generic/fontdlgg.cpp:391
+msgid "The font weight."
+msgstr "Typsnittets vikt."
+
+#: ../src/generic/fontdlgg.cpp:399
+msgid "C&olour:"
+msgstr "F&ärg:"
+
+#: ../src/generic/fontdlgg.cpp:407 ../src/generic/fontdlgg.cpp:409
+msgid "The font colour."
+msgstr "Typsnittets färg."
+
+#: ../src/generic/fontdlgg.cpp:415
+msgid "&Point size:"
+msgstr "&Punktstorlek:"
+
+#: ../src/generic/fontdlgg.cpp:420 ../src/generic/fontdlgg.cpp:422
+#: ../src/generic/fontdlgg.cpp:426 ../src/generic/fontdlgg.cpp:428
+msgid "The font point size."
+msgstr "Typsnittets punktstorlek"
+
+#: ../src/generic/fontdlgg.cpp:439 ../src/generic/fontdlgg.cpp:441
+msgid "Whether the font is underlined."
+msgstr "Om typsnittet är understruket."
+
+#: ../src/generic/fontdlgg.cpp:448 ../src/html/helpwnd.cpp:1215
+msgid "Preview:"
+msgstr "Förhandsgranska:"
+
+#: ../src/generic/fontdlgg.cpp:452 ../src/generic/fontdlgg.cpp:454
+msgid "Shows the font preview."
+msgstr "Visar typsnittsgranskningen."
+
+#: ../src/generic/fontdlgg.cpp:464 ../src/generic/fontdlgg.cpp:483
+msgid "Click to cancel the font selection."
+msgstr "Klicka för att avbryta typsnittsvalet."
+
+#: ../src/generic/fontdlgg.cpp:469 ../src/generic/fontdlgg.cpp:471
+#: ../src/generic/fontdlgg.cpp:476 ../src/generic/fontdlgg.cpp:478
+msgid "Click to confirm the font selection."
+msgstr "Klicka för att bekräfta typsnittsvalet."
+
+#: ../src/generic/fontpickerg.cpp:50 ../src/gtk/fontdlg.cpp:77
+msgid "Choose font"
+msgstr "Välj typsnitt"
+
+#: ../src/generic/grid.cpp:6542
+msgid ""
+"Error copying grid to the clipboard. Either selected cells were not "
+"contiguous or no cell was selected."
+msgstr ""
+
+#: ../src/generic/grid.cpp:12739
+msgid "Grid Corner"
+msgstr ""
+
+#: ../src/generic/grid.cpp:12741
+#, fuzzy, c-format
+msgid "Column %s Header"
+msgstr "Lägg till kolumn"
+
+#: ../src/generic/grid.cpp:12743
+#, c-format
+msgid "Row %s Header"
+msgstr ""
+
+#: ../src/generic/grid.cpp:12745
+#, fuzzy, c-format
+msgid "Column %s: %s"
+msgstr "Lägg till kolumn"
+
+#: ../src/generic/grid.cpp:12749
+#, fuzzy, c-format
+msgid "Row %s: %s"
+msgstr "\t%s: %s\n"
+
+#: ../src/generic/grid.cpp:12753
+#, c-format
+msgid "Row %s, Column %s: %s"
+msgstr ""
+
+#: ../src/generic/helpext.cpp:257
+#, c-format
+msgid "Help directory \"%s\" not found."
+msgstr "Hjälpkatalog \"%s\" hittades inte."
+
+#: ../src/generic/helpext.cpp:265
+#, c-format
+msgid "Help file \"%s\" not found."
+msgstr "Hjälpfil \"%s\" hittades inte."
+
+#: ../src/generic/helpext.cpp:284
+#, c-format
+msgid "Line %lu of map file \"%s\" has invalid syntax, skipped."
+msgstr "Rad %lu i map-fil \"%s\" har felaktig syntax, hoppar över."
+
+#: ../src/generic/helpext.cpp:292
+#, c-format
+msgid "No valid mappings found in the file \"%s\"."
+msgstr "Ingen giltig mappning hittad i fil \"%s\"."
+
+#: ../src/generic/helpext.cpp:435
+msgid "No entries found."
+msgstr "Inga poster funna."
+
+#: ../src/generic/helpext.cpp:444 ../src/generic/helpext.cpp:445
+msgid "Help Index"
+msgstr "Hjälpindex"
+
+#: ../src/generic/helpext.cpp:448
+msgid "Relevant entries:"
+msgstr "Relevanta poster:"
+
+#: ../src/generic/helpext.cpp:449
+msgid "Entries found"
+msgstr "Poster funna"
+
+#: ../src/generic/hyperlinkg.cpp:170
+msgid "&Copy URL"
+msgstr "K&opiera URL"
+
+#: ../src/generic/infobar.cpp:119
+msgid "Hide this notification message."
+msgstr "Dölj detta notifieringsmeddelande."
+
+#. TRANSLATORS: %s will be either the application name or "Application"
+#: ../src/generic/logg.cpp:257
+#, c-format
+msgid "%s Error"
+msgstr "%s fel"
+
+#. TRANSLATORS: %s will be either the application name or "Application"
+#: ../src/generic/logg.cpp:263
+#, c-format
+msgid "%s Warning"
+msgstr "%s varning"
+
+#. TRANSLATORS: %s will be either the application name or "Application"
+#: ../src/generic/logg.cpp:273
+#, c-format
+msgid "%s Information"
+msgstr "%s information"
+
+#: ../src/generic/logg.cpp:276
+msgid "Application"
+msgstr "program"
+
+#: ../src/generic/logg.cpp:549
+msgid "Save log contents to file"
+msgstr "Spara logginnehållet till fil"
+
+#: ../src/generic/logg.cpp:551
+msgid "C&lear"
+msgstr "&Töm"
+
+#: ../src/generic/logg.cpp:551
+msgid "Clear the log contents"
+msgstr "Töm logginnehållet"
+
+#: ../src/generic/logg.cpp:553
+msgid "Close this window"
+msgstr "Stäng detta fönster"
+
+#: ../src/generic/logg.cpp:554
+msgid "&Log"
+msgstr "&Logga"
+
+#: ../src/generic/logg.cpp:610 ../src/generic/logg.cpp:992
+msgid "Can't save log contents to file."
+msgstr "Kan inte spara logginnehållet till fil."
+
+#: ../src/generic/logg.cpp:613
+#, c-format
+msgid "Log saved to the file '%s'."
+msgstr "Logg sparad till filen \"%s\"."
+
+#: ../src/generic/logg.cpp:719
+msgid "&Details"
+msgstr "&Detaljer"
+
+#: ../src/generic/logg.cpp:972
+msgid "Failed to copy dialog contents to the clipboard."
+msgstr "Kunde inte kopiera dialogrutans innehåll till urklippsbordet."
+
+#: ../src/generic/logg.cpp:1022
+#, c-format
+msgid "Append log to file '%s' (choosing [No] will overwrite it)?"
+msgstr "Lägg till logg till fil \"%s\" (om du väljer [Nej] skrivs den över)?"
+
+#: ../src/generic/logg.cpp:1024
+msgid "Question"
+msgstr "Fråga"
+
+#: ../src/generic/logg.cpp:1038
+msgid "invalid message box return value"
+msgstr "ogilitigt returvärde för meddelandedialog"
+
+#: ../src/generic/notifmsgg.cpp:129
+msgid "Notice"
+msgstr "Notis"
+
+#: ../src/generic/preferencesg.cpp:118
+#, c-format
+msgid "%s Preferences"
+msgstr "%s inställningar"
+
+#: ../src/generic/printps.cpp:143
+msgid "Printing..."
+msgstr "Skriver ut..."
+
+#: ../src/generic/printps.cpp:160 ../src/gtk/print.cpp:1076
+#: ../src/msw/printwin.cpp:235
+msgid "Could not start printing."
+msgstr "Kunde inte påbörja utskrift."
+
+#: ../src/generic/printps.cpp:183
+#, c-format
+msgid "Printing page %d..."
+msgstr "Skriver sida %d..."
+
+#: ../src/generic/prntdlgg.cpp:171
+msgid "Printer options"
+msgstr "Skrivaralternativ"
+
+#: ../src/generic/prntdlgg.cpp:176
+msgid "Print to File"
+msgstr "Skriv ut till fil"
+
+#: ../src/generic/prntdlgg.cpp:179
+msgid "Setup..."
+msgstr "Inställningar..."
+
+#: ../src/generic/prntdlgg.cpp:187
+msgid "Printer:"
+msgstr "Skrivare:"
+
+#: ../src/generic/prntdlgg.cpp:195
+msgid "Status:"
+msgstr "Status:"
+
+#: ../src/generic/prntdlgg.cpp:206
+msgid "All"
+msgstr "Alla"
+
+#: ../src/generic/prntdlgg.cpp:207
+msgid "Pages"
+msgstr "Sidor"
+
+#: ../src/generic/prntdlgg.cpp:215
+msgid "Print Range"
+msgstr "Sidintervall"
+
+#: ../src/generic/prntdlgg.cpp:229
+msgid "From:"
+msgstr "Från:"
+
+#: ../src/generic/prntdlgg.cpp:233
+msgid "To:"
+msgstr "Till:"
+
+#: ../src/generic/prntdlgg.cpp:238
+msgid "Copies:"
+msgstr "Kopior:"
+
+#: ../src/generic/prntdlgg.cpp:288
+msgid "PostScript file"
+msgstr "PostScript-fil"
+
+#: ../src/generic/prntdlgg.cpp:439
+msgid "Print Setup"
+msgstr "Utskriftsinställningar"
+
+#: ../src/generic/prntdlgg.cpp:483
+msgid "Printer"
+msgstr "Skrivare"
+
+#: ../src/generic/prntdlgg.cpp:501
+msgid "Default printer"
+msgstr "Standardskrivare"
+
+#: ../src/generic/prntdlgg.cpp:595 ../src/generic/prntdlgg.cpp:782
+#: ../src/generic/prntdlgg.cpp:822 ../src/generic/prntdlgg.cpp:835
+#: ../src/generic/prntdlgg.cpp:1031 ../src/generic/prntdlgg.cpp:1036
+msgid "Paper size"
+msgstr "Pappersstorlek"
+
+#: ../src/generic/prntdlgg.cpp:604 ../src/generic/prntdlgg.cpp:847
+msgid "Portrait"
+msgstr "Stående"
+
+#: ../src/generic/prntdlgg.cpp:605 ../src/generic/prntdlgg.cpp:848
+msgid "Landscape"
+msgstr "Liggande"
+
+#: ../src/generic/prntdlgg.cpp:607 ../src/generic/prntdlgg.cpp:849
+msgid "Orientation"
+msgstr "Orientering"
+
+#: ../src/generic/prntdlgg.cpp:610
+msgid "Options"
+msgstr "Alternativ"
+
+#: ../src/generic/prntdlgg.cpp:612
+msgid "Print in colour"
+msgstr "Skriv ut med färg"
+
+#: ../src/generic/prntdlgg.cpp:621
+msgid "Print spooling"
+msgstr "Utskrift-spooling"
+
+#: ../src/generic/prntdlgg.cpp:623
+msgid "Printer command:"
+msgstr "Skrivarkommando:"
+
+#: ../src/generic/prntdlgg.cpp:631
+msgid "Printer options:"
+msgstr "Skrivaralternativ:"
+
+#: ../src/generic/prntdlgg.cpp:860
+msgid "Left margin (mm):"
+msgstr "Vänster marginal (mm):"
+
+#: ../src/generic/prntdlgg.cpp:861
+msgid "Top margin (mm):"
+msgstr "Övre marginal (mm):"
+
+#: ../src/generic/prntdlgg.cpp:872
+msgid "Right margin (mm):"
+msgstr "Höger marginal (mm):"
+
+#: ../src/generic/prntdlgg.cpp:873
+msgid "Bottom margin (mm):"
+msgstr "Undre marginal (mm):"
+
+#: ../src/generic/prntdlgg.cpp:896
+msgid "Printer..."
+msgstr "Skrivare..."
+
+#: ../src/generic/progdlgg.cpp:246
+msgid "&Skip"
+msgstr "&Hoppa över"
+
+#: ../src/generic/progdlgg.cpp:347 ../src/generic/progdlgg.cpp:626
+msgid "Unknown"
+msgstr "Okänd"
+
+#: ../src/generic/progdlgg.cpp:451 ../src/msw/progdlg.cpp:526
+msgid "Done."
+msgstr "Färdigt."
+
+#: ../src/generic/srchctlg.cpp:55 ../src/gtk/srchctrl.cpp:206
+#: ../src/html/helpwnd.cpp:530 ../src/html/helpwnd.cpp:545
+msgid "Search"
+msgstr "Sök"
+
+#: ../src/generic/tabg.cpp:1026
+msgid "Could not find tab for id"
+msgstr "Kunde inte hitta flik för id"
+
+#: ../src/generic/tipdlg.cpp:136
+msgid "Tips not available, sorry!"
+msgstr "Tipsen är inte tillgängliga!"
+
+#: ../src/generic/tipdlg.cpp:197
+msgid "Tip of the Day"
+msgstr "Dagens tips"
+
+#: ../src/generic/tipdlg.cpp:207
+msgid "Did you know..."
+msgstr "Visste du att..."
+
+#: ../src/generic/tipdlg.cpp:232
+msgid "&Show tips at startup"
+msgstr "&Visa tips vid start"
+
+#: ../src/generic/tipdlg.cpp:236
+msgid "&Next Tip"
+msgstr "&Nästa tips"
+
+#: ../src/generic/wizard.cpp:411
+msgid "&Next >"
+msgstr "&Nästa >"
+
+#: ../src/generic/wizard.cpp:412
+msgid "&Finish"
+msgstr "&Avsluta"
+
+#: ../src/generic/wizard.cpp:420
+msgid "< &Back"
+msgstr "< &Bakåt"
+
+#: ../src/gtk/aboutdlg.cpp:204
+msgid "translator-credits"
+msgstr "Jonas Rydberg"
+
+#: ../src/gtk/app.cpp:517
+msgid ""
+"WARNING: using XIM input method is unsupported and may result in problems "
+"with input handling and flickering. Consider unsetting GTK_IM_MODULE or "
+"setting to \"ibus\"."
+msgstr ""
+
+#: ../src/gtk/app.cpp:569
+msgid "Unable to initialize GTK+, is DISPLAY set properly?"
+msgstr "Kunde inte initiera GTK+, är DISPLAY inställt korrekt?"
+
+#: ../src/gtk/filedlg.cpp:89 ../src/gtk/filepicker.cpp:255
+#, fuzzy, c-format
+msgid "Changing current directory to \"%s\" failed"
+msgstr "Kunde inte skapa katalog \"%s\""
+
+#: ../src/gtk/font.cpp:548
+msgid ""
+"Using private fonts is not supported on this system: Pango library is too "
+"old, 1.38 or later required."
+msgstr ""
+
+#: ../src/gtk/font.cpp:558
+#, fuzzy
+msgid "Failed to create font configuration object."
+msgstr "Kunde inte uppdatera användarkonfigurationsfil."
+
+#: ../src/gtk/font.cpp:568
+#, fuzzy, c-format
+msgid "Failed to add custom font \"%s\"."
+msgstr "Kunde inte läsa dokument från filen \"%s\"."
+
+#: ../src/gtk/font.cpp:576
+#, fuzzy
+msgid "Failed to register font configuration using private fonts."
+msgstr "Kunde inte uppdatera användarkonfigurationsfil."
+
+#: ../src/gtk/glcanvas.cpp:117 ../src/gtk/glcanvas.cpp:132
+#, fuzzy
+msgid "Fatal Error"
+msgstr "Ödesdigert fel"
+
+#: ../src/gtk/glcanvas.cpp:117
+msgid ""
+"This program wasn't compiled with EGL support required under Wayland, "
+"either\n"
+"install EGL libraries and rebuild or run it under X11 backend by setting\n"
+"environment variable GDK_BACKEND=x11 before starting your program."
+msgstr ""
+
+#: ../src/gtk/glcanvas.cpp:132
+msgid ""
+"wxGLCanvas is only supported on Wayland and X11 currently.  You may be able "
+"to\n"
+"work around this by setting environment variable GDK_BACKEND=x11 before\n"
+"starting your program."
+msgstr ""
+
+#: ../src/gtk/mdi.cpp:433
+msgid "MDI child"
+msgstr "MDI-barn"
+
+#: ../src/gtk/power.cpp:188
+#, fuzzy, c-format
+msgid "Failed to open D-Bus connection to the login manager: %s"
+msgstr "Misslyckades att %s uppringningsanslutning: %s"
+
+#: ../src/gtk/power.cpp:214
+#, fuzzy
+msgid "wxWidgets application"
+msgstr "program"
+
+#: ../src/gtk/power.cpp:226
+msgid "Application needs to keep running"
+msgstr ""
+
+#: ../src/gtk/power.cpp:233
+msgid "Clean up before suspend"
+msgstr ""
+
+#: ../src/gtk/power.cpp:259
+#, fuzzy, c-format
+msgid "Failed to inhibit sleep: %s"
+msgstr "Kunde inte initiera den uppringda anslutningen: %s"
+
+#: ../src/gtk/power.cpp:265
+msgid "Unexpected response to D-Bus \"Inhibit\" request."
+msgstr ""
+
+#: ../src/gtk/print.cpp:218
+msgid "Custom size"
+msgstr "Valfri storlek"
+
+#: ../src/gtk/print.cpp:752
+#, fuzzy, c-format
+msgid "Error while printing: %s"
+msgstr "Fel vid utskrift: "
+
+#: ../src/gtk/print.cpp:816
+msgid "Page Setup"
+msgstr "Sidinställningar"
+
+#: ../src/gtk/webview_webkit.cpp:932
+msgid "Retrieving JavaScript script output is not supported with WebKit v1"
+msgstr ""
+
+#: ../src/gtk/webview_webkit2.cpp:1098
+msgid ""
+"Setting proxy is not supported by WebKit, at least version 2.16 is required."
+msgstr ""
+
+#: ../src/gtk/webview_webkit2.cpp:1104
+msgid "This program was compiled without support for setting WebKit proxy."
+msgstr ""
+
+#: ../src/gtk/window.cpp:6289
+msgid ""
+"GTK+ installed on this machine is too old to support screen compositing, "
+"please install GTK+ 2.12 or later."
+msgstr ""
+"Den installerade GTK+ på den här maskinen är för gammal för att stöda "
+"skärmkompositering, installera GTK+ 2.12 eller senare."
+
+#: ../src/gtk/window.cpp:6307
+msgid ""
+"Compositing not supported by this system, please enable it in your Window "
+"Manager."
+msgstr ""
+"Kompositering stöds inte på detta system, slå på det i din fönsterhanterare."
+
+#: ../src/gtk/window.cpp:6318
+msgid ""
+"This program was compiled with a too old version of GTK+, please rebuild "
+"with GTK+ 2.12 or newer."
+msgstr ""
+"Det här programmet kompilerades med en för gammal version av GTK+, bygg om "
+"det med GTK+ 2.12 eller senare"
+
+#: ../src/html/chm.cpp:138
+#, c-format
+msgid "Failed to open CHM archive '%s'."
+msgstr "Kunde inte öppna CHM-arkiv \"%s\"."
+
+#: ../src/html/chm.cpp:270
+#, c-format
+msgid "Could not extract %s into %s: %s"
+msgstr "Kunde inte extrahera %s till %s: %s"
+
+#: ../src/html/chm.cpp:324
+msgid "no error"
+msgstr "inget fel"
+
+#: ../src/html/chm.cpp:326
+msgid "bad arguments to library function"
+msgstr "felaktiga argument till biblioteksfunktion"
+
+#: ../src/html/chm.cpp:328
+msgid "error opening file"
+msgstr "fel vid öppning av fil"
+
+#: ../src/html/chm.cpp:330
+msgid "read error"
+msgstr "läsfel"
+
+#: ../src/html/chm.cpp:332
+msgid "write error"
+msgstr "skrivfel"
+
+#: ../src/html/chm.cpp:334
+msgid "seek error"
+msgstr "sökfel"
+
+#: ../src/html/chm.cpp:338
+msgid "bad signature"
+msgstr "felaktig signatur"
+
+#: ../src/html/chm.cpp:340
+msgid "error in data format"
+msgstr "fel i dataformat"
+
+#: ../src/html/chm.cpp:342
+msgid "checksum error"
+msgstr "checksummefel"
+
+#: ../src/html/chm.cpp:344
+msgid "compression error"
+msgstr "kompressionsfel"
+
+#: ../src/html/chm.cpp:346
+msgid "decompression error"
+msgstr "dekompressionsfel"
+
+#: ../src/html/chm.cpp:437
+#, c-format
+msgid "Could not locate file '%s'."
+msgstr "Kunde inte hitta fil \"%s\"."
+
+#: ../src/html/chm.cpp:711
+#, c-format
+msgid "Could not create temporary file '%s'"
+msgstr "Kunde inte skapa temporär fil \"%s\""
+
+#: ../src/html/chm.cpp:718
+#, c-format
+msgid "Extraction of '%s' into '%s' failed."
+msgstr "Uppackning av \"%s\" till \"%s\" misslyckades."
+
+#: ../src/html/chm.cpp:806 ../src/html/chm.cpp:863
+msgid "CHM handler currently supports only local files!"
+msgstr "CHM-hanteraren stöder för närvarande endast lokala filer!"
+
+#: ../src/html/chm.cpp:827
+msgid "Link contained '//', converted to absolute link."
+msgstr "Länken innehöll \"//\", omvandlad till absolut länk."
+
+#: ../src/html/helpctrl.cpp:59
+#, c-format
+msgid "Help: %s"
+msgstr "Hjälp: %s"
+
+#: ../src/html/helpctrl.cpp:155
+#, c-format
+msgid "Adding book %s"
+msgstr "Lägger till bok %s"
+
+#: ../src/html/helpdata.cpp:295
+#, c-format
+msgid "Cannot open contents file: %s"
+msgstr "Kan inte öppna innehållsfil: %s"
+
+#: ../src/html/helpdata.cpp:309
+#, c-format
+msgid "Cannot open index file: %s"
+msgstr "Kan inte öppna indexfil: %s"
+
+#: ../src/html/helpdata.cpp:643
+msgid "noname"
+msgstr "namnlös"
+
+#: ../src/html/helpdata.cpp:652
+#, c-format
+msgid "Cannot open HTML help book: %s"
+msgstr "Kan inte öppna HTML-hjälpbok: %s"
+
+#: ../src/html/helpwnd.cpp:315
+msgid "Displays help as you browse the books on the left."
+msgstr "Visar hjälp medan du bläddrar i böckerna till vänster."
+
+#: ../src/html/helpwnd.cpp:411 ../src/html/helpwnd.cpp:1100
+#: ../src/html/helpwnd.cpp:1735
+msgid "(bookmarks)"
+msgstr "(bokmärken)"
+
+#: ../src/html/helpwnd.cpp:424
+msgid "Add current page to bookmarks"
+msgstr "Lägg till aktuell sida till bokmärken"
+
+#: ../src/html/helpwnd.cpp:425
+msgid "Remove current page from bookmarks"
+msgstr "Ta bort aktuell sida från bokmärken"
+
+#: ../src/html/helpwnd.cpp:470
+msgid "Contents"
+msgstr "Innehåll"
+
+#: ../src/html/helpwnd.cpp:485
+msgid "Find"
+msgstr "Sök"
+
+#: ../src/html/helpwnd.cpp:487
+msgid "Show all"
+msgstr "Visa alla"
+
+#: ../src/html/helpwnd.cpp:497
+msgid ""
+"Display all index items that contain given substring. Search is case "
+"insensitive."
+msgstr ""
+"Visa alla indexposter som innehåller given delsträng. Sökningen är "
+"skiftlägesokänslig."
+
+#: ../src/html/helpwnd.cpp:498
+msgid "Show all items in index"
+msgstr "Visa alla poster i index"
+
+#: ../src/html/helpwnd.cpp:528
+msgid "Case sensitive"
+msgstr "Skiftlägeskänslig"
+
+#: ../src/html/helpwnd.cpp:529
+msgid "Whole words only"
+msgstr "Endast hela ord"
+
+#: ../src/html/helpwnd.cpp:532
+msgid ""
+"Search contents of help book(s) for all occurrences of the text you typed "
+"above"
+msgstr ""
+"Sök i hjälpboken/böckernas innehåll efter alla förekomster av texten du "
+"skrev in ovan"
+
+#: ../src/html/helpwnd.cpp:653
+msgid "Show/hide navigation panel"
+msgstr "Visa/dölj navigeringspanel"
+
+#: ../src/html/helpwnd.cpp:655
+msgid "Go back"
+msgstr "Gå tillbaka"
+
+#: ../src/html/helpwnd.cpp:656
+msgid "Go forward"
+msgstr "Gå framåt"
+
+#: ../src/html/helpwnd.cpp:658
+msgid "Go one level up in document hierarchy"
+msgstr "Gå upp en nivå i dokumenthierarki"
+
+#: ../src/html/helpwnd.cpp:666 ../src/html/helpwnd.cpp:1547
+msgid "Open HTML document"
+msgstr "Öppna HTML-dokument"
+
+#: ../src/html/helpwnd.cpp:670
+msgid "Print this page"
+msgstr "Skriv ut denna sida"
+
+#: ../src/html/helpwnd.cpp:674
+msgid "Display options dialog"
+msgstr "Visa alternativdialog"
+
+#: ../src/html/helpwnd.cpp:795
+msgid "Please choose the page to display:"
+msgstr "Välj vilken sida som skall visas:"
+
+#: ../src/html/helpwnd.cpp:796
+msgid "Help Topics"
+msgstr "Hjälpavsnitt"
+
+#: ../src/html/helpwnd.cpp:852
+msgid "Searching..."
+msgstr "Söker..."
+
+#: ../src/html/helpwnd.cpp:853
+msgid "No matching page found yet"
+msgstr "Ingen matchande sida hittad ännu"
+
+#: ../src/html/helpwnd.cpp:870
+#, c-format
+msgid "Found %i matches"
+msgstr "Hittade %i träffar"
+
+#: ../src/html/helpwnd.cpp:958
+msgid "(Help)"
+msgstr "(Hjälp)"
+
+#: ../src/html/helpwnd.cpp:1026
+#, c-format
+msgid "%d of %lu"
+msgstr "%d av %lu"
+
+#: ../src/html/helpwnd.cpp:1028
+#, c-format
+msgid "%lu of %lu"
+msgstr "%lu av %lu"
+
+#: ../src/html/helpwnd.cpp:1047
+msgid "Search in all books"
+msgstr "Sök i alla böcker"
+
+#: ../src/html/helpwnd.cpp:1193
+msgid "Help Browser Options"
+msgstr "Hjälpbläddraralternativ"
+
+#: ../src/html/helpwnd.cpp:1198
+msgid "Normal font:"
+msgstr "Normalt typsnitt:"
+
+#: ../src/html/helpwnd.cpp:1199
+msgid "Fixed font:"
+msgstr "Fastbreddstypsnitt:"
+
+#: ../src/html/helpwnd.cpp:1200
+msgid "Font size:"
+msgstr "Typsnittsstorlek:"
+
+#: ../src/html/helpwnd.cpp:1245
+msgid "font size"
+msgstr "typsnittsstorlek"
+
+#: ../src/html/helpwnd.cpp:1256
+msgid "Normal face<br>and <u>underlined</u>. "
+msgstr "Normalt typsnitt<br>och <u>understruket</u>. "
+
+#: ../src/html/helpwnd.cpp:1257
+msgid "<i>Italic face.</i> "
+msgstr "<i>Kursiv.</i> "
+
+#: ../src/html/helpwnd.cpp:1258
+msgid "<b>Bold face.</b> "
+msgstr "<b>Fet.</b> "
+
+#: ../src/html/helpwnd.cpp:1259
+msgid "<b><i>Bold italic face.</i></b><br>"
+msgstr "<b><i>Fet kursiv.</i></b><br>"
+
+#: ../src/html/helpwnd.cpp:1262
+msgid "Fixed size face.<br> <b>bold</b> <i>italic</i> "
+msgstr "Fastbreddtypsnitt.<br> <b>fet</b> <i>kursiv</i> "
+
+#: ../src/html/helpwnd.cpp:1263
+msgid "<b><i>bold italic <u>underlined</u></i></b><br>"
+msgstr "<b><i>fet kursiv <u>understruket</u></i></b><br>"
+
+#: ../src/html/helpwnd.cpp:1524
+msgid "Help Printing"
+msgstr "Hjälputskrift"
+
+#: ../src/html/helpwnd.cpp:1527
+msgid "Cannot print empty page."
+msgstr "Kan inte skriva ut tom sida."
+
+#: ../src/html/helpwnd.cpp:1540
+msgid "HTML files (*.html;*.htm)|*.html;*.htm|"
+msgstr "HTML-filer (*.html;*.htm)|*.html;*.htm|"
+
+#: ../src/html/helpwnd.cpp:1541
+msgid "Help books (*.htb)|*.htb|Help books (*.zip)|*.zip|"
+msgstr "Hjälpböcker (*.htb)|*.htb|Hjälpböcker (*.zip)|*.zip|"
+
+#: ../src/html/helpwnd.cpp:1542
+msgid "HTML Help Project (*.hhp)|*.hhp|"
+msgstr "HTML-hjälpprojekt (*.hhp)|*.hhp|"
+
+#: ../src/html/helpwnd.cpp:1544
+msgid "Compressed HTML Help file (*.chm)|*.chm|"
+msgstr "Komprimerad HTML-hjälpfil (*.chm)|*.chm|"
+
+#: ../src/html/helpwnd.cpp:1671
+#, fuzzy, c-format
+msgid "%i of %u"
+msgstr "%i av %i"
+
+#: ../src/html/helpwnd.cpp:1709
+#, fuzzy, c-format
+msgid "%u of %u"
+msgstr "%lu av %lu"
+
+#: ../src/html/htmlfilt.cpp:134
+#, c-format
+msgid "Cannot open HTML document: %s"
+msgstr "Kan inte öppna HTML-dokument: %s"
+
+#: ../src/html/htmlwin.cpp:599
+msgid "Connecting..."
+msgstr "Ansluter..."
+
+#: ../src/html/htmlwin.cpp:616
+#, c-format
+msgid "Unable to open requested HTML document: %s"
+msgstr "Kunde inte öppna efterfrågat HTML-dokument: %s"
+
+#: ../src/html/htmlwin.cpp:630
+msgid "Loading : "
+msgstr "Läser in: "
+
+#: ../src/html/htmlwin.cpp:673
+msgid "Done"
+msgstr "Färdigt"
+
+#: ../src/html/htmlwin.cpp:723
+#, c-format
+msgid "HTML anchor %s does not exist."
+msgstr "HTML-ankare %s finns inte."
+
+#: ../src/html/htmlwin.cpp:1057
+#, c-format
+msgid "Copied to clipboard:\"%s\""
+msgstr "Kopierat till urklippsdata: \"%s\""
+
+#: ../src/html/htmprint.cpp:269
+msgid ""
+"This document doesn't fit on the page horizontally and will be truncated "
+"when it is printed."
+msgstr ""
+"Detta dokument ryms inte på sidan i liggande format, och kommer att "
+"trunkeras när det skrivs ut."
+
+#: ../src/html/htmprint.cpp:285
+#, c-format
+msgid ""
+"The document \"%s\" doesn't fit on the page horizontally and will be "
+"truncated if printed.\n"
+"\n"
+"Would you like to proceed with printing it nevertheless?"
+msgstr ""
+"Dokumentet \"%s\" ryms inte på sidan i liggande format, och kommer att "
+"trunkeras om det skrivs ut.\n"
+"\n"
+"Vill du ändå fortsätta skriva ut?"
+
+#: ../src/html/htmprint.cpp:296
+msgid ""
+"If possible, try changing the layout parameters to make the printout more "
+"narrow."
+msgstr ""
+"Om möjligt, försök ändra layoutparametrarna för att göra utskriften smalare."
+
+#: ../src/html/htmprint.cpp:445
+msgid ": file does not exist!"
+msgstr ": filen finns inte!"
+
+#. TRANSLATORS: %s may be a document title.
+#: ../src/html/htmprint.cpp:717
+#, fuzzy, c-format
+msgid "%s Preview"
+msgstr " Förhandsgranska"
+
+#: ../src/html/htmprint.cpp:755 ../src/richtext/richtextprint.cpp:618
+msgid ""
+"There was a problem during page setup: you may need to set a default printer."
+msgstr ""
+"Det var problem när sidan ställdes in: Du måste kanske ange en "
+"standardskrivare."
+
+#: ../src/msw/clipbrd.cpp:80
+msgid "Failed to open the clipboard."
+msgstr "Kunde inte öppna urklippsbordet."
+
+#: ../src/msw/clipbrd.cpp:101
+msgid "Failed to close the clipboard."
+msgstr "Kunde inte stänga urklippsbordet."
+
+#: ../src/msw/clipbrd.cpp:113
+msgid "Failed to empty the clipboard."
+msgstr "Kunde inte tömma urklippsbordet."
+
+#: ../src/msw/clipbrd.cpp:284
+msgid "Failed to put data on the clipboard"
+msgstr "Kunde inte skicka data till urklippsbordet"
+
+#: ../src/msw/clipbrd.cpp:326
+msgid "Failed to get data from the clipboard"
+msgstr "Kunde inte hämta data från urklippsbordet"
+
+#: ../src/msw/clipbrd.cpp:363
+msgid "Failed to retrieve the supported clipboard formats"
+msgstr "Kunde inte hämta vilka urklippsformat som stöds"
+
+#: ../src/msw/colordlg.cpp:228
+#, c-format
+msgid "Colour selection dialog failed with error %0lx."
+msgstr "Färgväljningsdialogrutan misslyckades med fel %0lx."
+
+#: ../src/msw/cursor.cpp:141
+msgid "Failed to create cursor."
+msgstr "Kunde inte skapa markör."
+
+#: ../src/msw/dde.cpp:279
+#, c-format
+msgid "Failed to register DDE server '%s'"
+msgstr "Kunde inte registrera DDE-server \"%s\""
+
+#: ../src/msw/dde.cpp:300
+#, c-format
+msgid "Failed to unregister DDE server '%s'"
+msgstr "Kunde inte avregistrera DDE-server \"%s\""
+
+#: ../src/msw/dde.cpp:428
+#, c-format
+msgid "Failed to create connection to server '%s' on topic '%s'"
+msgstr "Kunde inte skapa en anslutning till server \"%s\" med ämne \"%s\""
+
+#: ../src/msw/dde.cpp:655
+msgid "DDE poke request failed"
+msgstr "DDE poke-förfrågan misslyckades"
+
+#: ../src/msw/dde.cpp:674
+msgid "Failed to establish an advise loop with DDE server"
+msgstr "Kunde inte starta en meddelandeslinga med DDE-server"
+
+#: ../src/msw/dde.cpp:693
+msgid "Failed to terminate the advise loop with DDE server"
+msgstr "Kunde inte avsluta meddelandeslinga med DDE-servern"
+
+#: ../src/msw/dde.cpp:768
+msgid "Failed to send DDE advise notification"
+msgstr "Kunde inte skicka DDE-meddelandeanmälan"
+
+#: ../src/msw/dde.cpp:1085
+msgid "Failed to create DDE string"
+msgstr "Kunde inte skapa DDE-sträng"
+
+#: ../src/msw/dde.cpp:1131
+msgid "no DDE error."
+msgstr "inget DDE-fel."
+
+#: ../src/msw/dde.cpp:1135
+msgid "a request for a synchronous advise transaction has timed out."
+msgstr ""
+"tiden för en förfrågan för en synkron meddelandetransaktion har gått ut."
+
+#: ../src/msw/dde.cpp:1138
+msgid "the response to the transaction caused the DDE_FBUSY bit to be set."
+msgstr "svaret på transaktionen gjorde att DDE_FBUSY-biten sattes."
+
+#: ../src/msw/dde.cpp:1141
+msgid "a request for a synchronous data transaction has timed out."
+msgstr "tiden för en förfrågan för en synkron datatransaktion har gått ut."
+
+#: ../src/msw/dde.cpp:1144
+msgid ""
+"a DDEML function was called without first calling the DdeInitialize "
+"function,\n"
+"or an invalid instance identifier\n"
+"was passed to a DDEML function."
+msgstr ""
+"en DDEML-funktion anropades utan att först anropa DdeInitialize-funktionen,\n"
+"eller en ogiltig instansidentifierare\n"
+"sändes till en DDEML-funktion."
+
+#: ../src/msw/dde.cpp:1147
+msgid ""
+"an application initialized as APPCLASS_MONITOR has\n"
+"attempted to perform a DDE transaction,\n"
+"or an application initialized as APPCMD_CLIENTONLY has \n"
+"attempted to perform server transactions."
+msgstr ""
+"en applikation som initierades som en APPCLASS_MONITOR har\n"
+"försökt att genomföra en DDE-transaktion,\n"
+"eller en applikation initierad som en APPCMD_CLIENTONLY har \n"
+"försökt genomföra servertransaktioner."
+
+#: ../src/msw/dde.cpp:1150
+msgid "a request for a synchronous execute transaction has timed out."
+msgstr "tiden för en förfrågan för en synkron körningstransaktion har gått ut."
+
+#: ../src/msw/dde.cpp:1153
+msgid "a parameter failed to be validated by the DDEML."
+msgstr "en parameter kunde inte bekräftas av DDEML."
+
+#: ../src/msw/dde.cpp:1156
+msgid "a DDEML application has created a prolonged race condition."
+msgstr "en DDEML-applikation har skapat ett långvarigt race-tillstånd."
+
+#: ../src/msw/dde.cpp:1159
+msgid "a memory allocation failed."
+msgstr "en minnesallokering misslyckades."
+
+#: ../src/msw/dde.cpp:1162
+msgid "a client's attempt to establish a conversation has failed."
+msgstr "en klients försök att etablera en konversation har misslyckats."
+
+#: ../src/msw/dde.cpp:1165
+msgid "a transaction failed."
+msgstr "en transaktion misslyckades."
+
+#: ../src/msw/dde.cpp:1168
+msgid "a request for a synchronous poke transaction has timed out."
+msgstr "tiden för en förfrågan för en synkron poke-transaktion har gått ut."
+
+#: ../src/msw/dde.cpp:1171
+msgid "an internal call to the PostMessage function has failed. "
+msgstr "ett internt anrop till PostMessage-funktionen har misslyckats. "
+
+#: ../src/msw/dde.cpp:1174
+msgid "reentrancy problem."
+msgstr "återinträdesproblem."
+
+#: ../src/msw/dde.cpp:1177
+msgid ""
+"a server-side transaction was attempted on a conversation\n"
+"that was terminated by the client, or the server\n"
+"terminated before completing a transaction."
+msgstr ""
+"en transaktion på servern försökte sig på en konversation\n"
+"som avslutades av klienten, eller servern\n"
+"avslutades före transaktionen var genomförd."
+
+#: ../src/msw/dde.cpp:1180
+msgid "an internal error has occurred in the DDEML."
+msgstr "ett internt fel har uppstått i DDEML."
+
+#: ../src/msw/dde.cpp:1183
+msgid "a request to end an advise transaction has timed out."
+msgstr ""
+"tiden för en förfrågan att avsluta en meddelandetransaktion har gått ut."
+
+#: ../src/msw/dde.cpp:1186
+msgid ""
+"an invalid transaction identifier was passed to a DDEML function.\n"
+"Once the application has returned from an XTYP_XACT_COMPLETE callback,\n"
+"the transaction identifier for that callback is no longer valid."
+msgstr ""
+"en ogiltig transaktionsidentifierare skickades till en DDEML-funktion.\n"
+"När applikationen har återvänt från ett XTYP_XACT_COMPLETE anrop,\n"
+"är transaktionsidentifieraren för det anropet inte längre giltig."
+
+#: ../src/msw/dde.cpp:1189
+#, c-format
+msgid "Unknown DDE error %08x"
+msgstr "Okänt DDE-fel %08x"
+
+#: ../src/msw/dialup.cpp:343
+msgid ""
+"Dial up functions are unavailable because the remote access service (RAS) is "
+"not installed on this machine. Please install it."
+msgstr ""
+"Uppringningsfunktioner är inte tillgängliga på grund av att "
+"fjärråtkomstservice (RAS) inte är installerad på denna maskin. Installera "
+"den."
+
+#: ../src/msw/dialup.cpp:402
+#, c-format
+msgid ""
+"The version of remote access service (RAS) installed on this machine is too "
+"old, please upgrade (the following required function is missing: %s)."
+msgstr ""
+"Versionen av fjärråtkomsttjänsten (RAS) som är installerad på denna maskin "
+"är för gammal, uppgradera (följande nödvändig funktion saknas: %s)."
+
+#: ../src/msw/dialup.cpp:437
+msgid "Failed to retrieve text of RAS error message"
+msgstr "Kunde inte hämta text från RAS-felmeddelande"
+
+#: ../src/msw/dialup.cpp:440
+#, c-format
+msgid "unknown error (error code %08x)."
+msgstr "okänt fel (felkod %08x)."
+
+#: ../src/msw/dialup.cpp:492
+#, c-format
+msgid "Cannot find active dialup connection: %s"
+msgstr "Kan inte hitta aktiv uppringningsanslutning: %s"
+
+#: ../src/msw/dialup.cpp:513
+msgid "Several active dialup connections found, choosing one randomly."
+msgstr "Flera aktiva uppringningsanslutningar hittades, väljer en slumpvis."
+
+#: ../src/msw/dialup.cpp:598 ../src/msw/dialup.cpp:832
+#, c-format
+msgid "Failed to establish dialup connection: %s"
+msgstr "Kunde inte etablera uppringningsanslutning: %s"
+
+#: ../src/msw/dialup.cpp:664
+#, c-format
+msgid "Failed to get ISP names: %s"
+msgstr "Kunde inte hämta Internetleverantörers namn: %s"
+
+#: ../src/msw/dialup.cpp:712
+msgid "Failed to connect: no ISP to dial."
+msgstr "Kunde inte ansluta: Ingen Internetleverantör att ringa upp."
+
+#: ../src/msw/dialup.cpp:732
+msgid "Choose ISP to dial"
+msgstr "Välj Internetleverantör att ringa upp"
+
+#: ../src/msw/dialup.cpp:733
+msgid "Please choose which ISP do you want to connect to"
+msgstr "Välj vilken Internetleverantör du vill ansluta till"
+
+#: ../src/msw/dialup.cpp:766
+msgid "Failed to connect: missing username/password."
+msgstr "Kunde inte ansluta: Användarnamn/lösenord saknas."
+
+#: ../src/msw/dialup.cpp:796
+msgid "Cannot find the location of address book file"
+msgstr "Kan inte hitta platsen för adressboksfil"
+
+#: ../src/msw/dialup.cpp:827
+#, c-format
+msgid "Failed to initiate dialup connection: %s"
+msgstr "Kunde inte initiera den uppringda anslutningen: %s"
+
+#: ../src/msw/dialup.cpp:897
+msgid "Cannot hang up - no active dialup connection."
+msgstr "Kan inte lägga på - ingen aktiv uppringningsanslutning."
+
+#: ../src/msw/dialup.cpp:907
+#, c-format
+msgid "Failed to terminate the dialup connection: %s"
+msgstr "Kunde inte avsluta den uppringda anslutningen: %s"
+
+#: ../src/msw/dib.cpp:313
+#, c-format
+msgid "Failed to save the bitmap image to file \"%s\"."
+msgstr "Kunde inte spara bilden till fil \"%s\"."
+
+#: ../src/msw/dib.cpp:543
+#, c-format
+msgid "Failed to allocate %luKb of memory for bitmap data."
+msgstr "Kunde inte allokera %luKb minne för bilddata."
+
+#: ../src/msw/dir.cpp:241
+#, c-format
+msgid "Cannot enumerate files in directory '%s'"
+msgstr "Kan inte räkna upp filerna i katalogen \"%s\""
+
+#: ../src/msw/dirdlg.cpp:368
+msgid "Couldn't obtain folder name"
+msgstr "Kunde inte erhålla katalognamn"
+
+#: ../src/msw/dlmsw.cpp:163
+#, fuzzy, c-format
+msgid "(error %d: %s)"
+msgstr " (fel %ld: %s)"
+
+#: ../src/msw/dragimag.cpp:143 ../src/msw/dragimag.cpp:178
+#: ../src/msw/imaglist.cpp:309 ../src/msw/imaglist.cpp:331
+msgid "Couldn't add an image to the image list."
+msgstr "Kunde inte lägga till en bild till bildlistan."
+
+#: ../src/msw/enhmeta.cpp:94
+#, c-format
+msgid "Failed to load metafile from file \"%s\"."
+msgstr "Kunde inte läsa in metafil från fil \"%s\"."
+
+#: ../src/msw/fdrepdlg.cpp:412
+#, c-format
+msgid "Failed to create the standard find/replace dialog (error code %d)"
+msgstr "Kunde inte skapa standard sök/ersättdialogrutan (felkod %d)"
+
+#: ../src/msw/filedlg.cpp:1241
+msgid "Access to the file system is not allowed from secure desktop."
+msgstr ""
+
+#: ../src/msw/filedlg.cpp:1242
+msgid "Security warning"
+msgstr ""
+
+#: ../src/msw/filedlg.cpp:1533
+#, c-format
+msgid "File dialog failed with error code %0lx."
+msgstr "Fildialogruta misslyckades med felkod %0lx."
+
+#: ../src/msw/font.cpp:1120
+#, fuzzy, c-format
+msgid "Font file \"%s\" couldn't be loaded"
+msgstr "Filen kunde inte läsas in."
+
+#: ../src/msw/fontdlg.cpp:220
+#, c-format
+msgid "Common dialog failed with error code %0lx."
+msgstr "Vanlig dialogruta misslyckades med felkod %0lx."
+
+#: ../src/msw/fswatcher.cpp:67
+msgid "Ungraceful worker thread termination"
+msgstr "Ickeelegant avslutande av arbetstråd"
+
+#: ../src/msw/fswatcher.cpp:81
+msgid "Unable to create IOCP worker thread"
+msgstr "Kunde inte skapa IOCP arbetstråd"
+
+#: ../src/msw/fswatcher.cpp:88
+msgid "Unable to start IOCP worker thread"
+msgstr "Kunde inte starta IOCP arbetstråd"
+
+#: ../src/msw/fswatcher.cpp:140
+msgid "Monitoring individual files for changes is not supported currently."
+msgstr ""
+"Bevakning av individuella filer för ändringar stöds inte  för närvarande."
+
+#: ../src/msw/fswatcher.cpp:165
+#, c-format
+msgid "Unable to set up watch for '%s'"
+msgstr "Kunde inte starta en bevakning för \"%s\""
+
+#: ../src/msw/fswatcher.cpp:466
+#, c-format
+msgid "Can't monitor non-existent directory \"%s\" for changes."
+msgstr "Kan inte bevaka icke existerande katalog \"%s\" för ändringar."
+
+#: ../src/msw/glcanvas.cpp:577 ../src/unix/glx11.cpp:507
+msgid "OpenGL 3.0 or later is not supported by the OpenGL driver."
+msgstr ""
+
+#: ../src/msw/glcanvas.cpp:601 ../src/osx/glcanvas_osx.cpp:395
+#: ../src/unix/glegl.cpp:304 ../src/unix/glx11.cpp:553
+#, fuzzy
+msgid "Couldn't create OpenGL context"
+msgstr "Kunde inte skapa en timer"
+
+#: ../src/msw/glcanvas.cpp:1294
+msgid "Failed to initialize OpenGL"
+msgstr "Kunde inte initiera OpenGL"
+
+#: ../src/msw/graphicsd2d.cpp:607
+msgid "Could not register custom DirectWrite font loader."
+msgstr ""
+
+#: ../src/msw/helpchm.cpp:48
+msgid ""
+"MS HTML Help functions are unavailable because the MS HTML Help library is "
+"not installed on this machine. Please install it."
+msgstr ""
+"MS HTML hjälpfunktioner är inte tillgängliga på grund av att MS HTML "
+"hjälpbiblioteket inte är installerat på den här maskinen. Installera det."
+
+#: ../src/msw/helpchm.cpp:55
+msgid "Failed to initialize MS HTML Help."
+msgstr "Kunde inte initiera MS HTML-hjälp."
+
+#: ../src/msw/iniconf.cpp:458
+#, c-format
+msgid "Can't delete the INI file '%s'"
+msgstr "Kan inte ta bort INI-filen \"%s\""
+
+#: ../src/msw/listctrl.cpp:995
+#, c-format
+msgid "Couldn't retrieve information about list control item %d."
+msgstr "Kunde inte hämta information om listkontrollpost %d."
+
+#: ../src/msw/mdi.cpp:170 ../src/qt/mdi.cpp:253
+msgid "&Cascade"
+msgstr "Över&lappande"
+
+#: ../src/msw/mdi.cpp:171
+msgid "Tile &Horizontally"
+msgstr "Ordna &horisontellt"
+
+#: ../src/msw/mdi.cpp:172
+msgid "Tile &Vertically"
+msgstr "Ordna &vertikalt"
+
+#: ../src/msw/mdi.cpp:174
+msgid "&Arrange Icons"
+msgstr "Ordna &ikoner"
+
+#: ../src/msw/mdi.cpp:621
+msgid "Failed to create MDI parent frame."
+msgstr "Kunde inte skapa MDI-föräldrafönster."
+
+#: ../src/msw/mimetype.cpp:234
+#, c-format
+msgid "Failed to create registry entry for '%s' files."
+msgstr "Kunde inte skapa registerpost för \"%s\"-filer."
+
+#: ../src/msw/ole/automtn.cpp:495
+#, c-format
+msgid "Failed to find CLSID of \"%s\""
+msgstr "Kunde inte hitta CLSID för \"%s\""
+
+#: ../src/msw/ole/automtn.cpp:512
+#, c-format
+msgid "Failed to create an instance of \"%s\""
+msgstr "Kunde inte skapa en instans av \"%s\""
+
+#: ../src/msw/ole/automtn.cpp:552
+#, c-format
+msgid "Cannot get an active instance of \"%s\""
+msgstr "Kan inte hitta aktiv instans av \"%s\""
+
+#: ../src/msw/ole/automtn.cpp:564
+#, c-format
+msgid "Failed to get OLE automation interface for \"%s\""
+msgstr "Kunde inte hämta OLE-automationsgränssnitt för \"%s\""
+
+#: ../src/msw/ole/automtn.cpp:621
+msgid "Unknown name or named argument."
+msgstr "Okänt namn eller namngivet argument."
+
+#: ../src/msw/ole/automtn.cpp:625
+msgid "Incorrect number of arguments."
+msgstr "Ej korrekt antal argument."
+
+#: ../src/msw/ole/automtn.cpp:637
+msgid "Unknown exception"
+msgstr "Okänt undantag"
+
+#: ../src/msw/ole/automtn.cpp:642
+msgid "Method or property not found."
+msgstr "Metod eller egenskap hittades inte."
+
+#: ../src/msw/ole/automtn.cpp:646
+msgid "Overflow while coercing argument values."
+msgstr "Överflöde vid tvingning av argumentvärden."
+
+#: ../src/msw/ole/automtn.cpp:650
+msgid "Object implementation does not support named arguments."
+msgstr "Objektimplementation stöder inte namngivna argument."
+
+#: ../src/msw/ole/automtn.cpp:654
+msgid "The locale ID is unknown."
+msgstr "Okänt lokal-ID."
+
+#: ../src/msw/ole/automtn.cpp:658
+msgid "Missing a required parameter."
+msgstr "Saknar en nödvändig parameter."
+
+#: ../src/msw/ole/automtn.cpp:662
+#, c-format
+msgid "Argument %u not found."
+msgstr "Argument %u hittades inte."
+
+#: ../src/msw/ole/automtn.cpp:666
+#, c-format
+msgid "Type mismatch in argument %u."
+msgstr "Typerna överensstämmer inte i argument %u."
+
+#: ../src/msw/ole/automtn.cpp:670
+msgid "The system cannot find the file specified."
+msgstr "Systemet kan inte hitta den specificerade filen."
+
+#: ../src/msw/ole/automtn.cpp:674
+msgid "Class not registered."
+msgstr "Klassen är inte registrerad."
+
+#: ../src/msw/ole/automtn.cpp:678
+#, c-format
+msgid "Unknown error %08x"
+msgstr "Okänt fel %08x"
+
+#: ../src/msw/ole/automtn.cpp:682
+#, c-format
+msgid "OLE Automation error in %s: %s"
+msgstr "OLE-automationsfel i %s: %s"
+
+#: ../src/msw/ole/dataobj.cpp:385
+#, c-format
+msgid "Couldn't register clipboard format '%s'."
+msgstr "Kunde inte registrera urklippsformat \"%s\"."
+
+#: ../src/msw/ole/dataobj.cpp:402
+#, c-format
+msgid "The clipboard format '%d' doesn't exist."
+msgstr "Urklippsformatet \"%d\" finns inte."
+
+#: ../src/msw/progdlg.cpp:1025
+msgid "Skip"
+msgstr "Hoppa över"
+
+#: ../src/msw/registry.cpp:141
+#, fuzzy, c-format
+msgid "unknown (%lu)"
+msgstr "okänd"
+
+#: ../src/msw/registry.cpp:409
+#, c-format
+msgid "Can't get info about registry key '%s'"
+msgstr "Kan inte hämta information om registernyckel \"%s\""
+
+#: ../src/msw/registry.cpp:445
+#, c-format
+msgid "Can't open registry key '%s'"
+msgstr "Kan inte öppna registernyckel \"%s\""
+
+#: ../src/msw/registry.cpp:478
+#, c-format
+msgid "Can't create registry key '%s'"
+msgstr "Kan inte skapa registernyckel \"%s\""
+
+#: ../src/msw/registry.cpp:497
+#, c-format
+msgid "Can't close registry key '%s'"
+msgstr "Kan inte stänga registernyckel \"%s\""
+
+#: ../src/msw/registry.cpp:512
+#, c-format
+msgid "Registry value '%s' already exists."
+msgstr "Registervärde \"%s\" finns redan."
+
+#: ../src/msw/registry.cpp:520
+#, c-format
+msgid "Failed to rename registry value '%s' to '%s'."
+msgstr "Kunde inte byta namn på registervärde \"%s\" till \"%s\"."
+
+#: ../src/msw/registry.cpp:575
+#, c-format
+msgid "Can't copy values of unsupported type %d."
+msgstr "Kan inte kopiera värden av ej stödd typ %d."
+
+#: ../src/msw/registry.cpp:586
+#, c-format
+msgid "Registry key '%s' does not exist, cannot rename it."
+msgstr "Registernyckel \"%s\" finns inte, kan inte döpa om den."
+
+#: ../src/msw/registry.cpp:617
+#, c-format
+msgid "Registry key '%s' already exists."
+msgstr "Registernyckel \"%s\" finns redan."
+
+#: ../src/msw/registry.cpp:625
+#, c-format
+msgid "Failed to rename the registry key '%s' to '%s'."
+msgstr "Kunde inte byta namn på registernyckel \"%s\" till \"%s\"."
+
+#: ../src/msw/registry.cpp:670
+#, c-format
+msgid "Failed to copy the registry subkey '%s' to '%s'."
+msgstr "Kunde inte kopiera registerundernyckel \"%s\" till \"%s\"."
+
+#: ../src/msw/registry.cpp:683
+#, c-format
+msgid "Failed to copy registry value '%s'"
+msgstr "Kunde inte kopiera registervärde \"%s\""
+
+#: ../src/msw/registry.cpp:692
+#, c-format
+msgid "Failed to copy the contents of registry key '%s' to '%s'."
+msgstr "Kunde inte kopiera innehållet i registernyckel \"%s\" till \"%s\"."
+
+#: ../src/msw/registry.cpp:718
+#, c-format
+msgid ""
+"Registry key '%s' is needed for normal system operation,\n"
+"deleting it will leave your system in unusable state:\n"
+"operation aborted."
+msgstr ""
+"Registernyckel \"%s\" behövs för att systemet skall fungera normalt,\n"
+"om du tar bort den kommer systemet bli instabilt:\n"
+"Operationen avbruten."
+
+#: ../src/msw/registry.cpp:754
+#, c-format
+msgid "Can't delete key '%s'"
+msgstr "Kan inte ta bort nyckel \"%s\""
+
+#: ../src/msw/registry.cpp:782
+#, c-format
+msgid "Can't delete value '%s' from key '%s'"
+msgstr "Kan inte ta bort värde \"%s\" från nyckel \"%s\""
+
+#: ../src/msw/registry.cpp:855 ../src/msw/registry.cpp:887
+#: ../src/msw/registry.cpp:929 ../src/msw/registry.cpp:1000
+#, c-format
+msgid "Can't read value of key '%s'"
+msgstr "Kan inte läsa värdet av nyckel \"%s\""
+
+#: ../src/msw/registry.cpp:873 ../src/msw/registry.cpp:915
+#: ../src/msw/registry.cpp:963 ../src/msw/registry.cpp:1106
+#, c-format
+msgid "Can't set value of '%s'"
+msgstr "Kan inte sätta värdet på \"%s\""
+
+#: ../src/msw/registry.cpp:894 ../src/msw/registry.cpp:943
+#, c-format
+msgid "Registry value \"%s\" is not numeric (but of type %s)"
+msgstr ""
+
+#: ../src/msw/registry.cpp:979
+#, c-format
+msgid "Registry value \"%s\" is not binary (but of type %s)"
+msgstr ""
+
+#: ../src/msw/registry.cpp:1028
+#, c-format
+msgid "Registry value \"%s\" is not text (but of type %s)"
+msgstr ""
+
+#: ../src/msw/registry.cpp:1089
+#, c-format
+msgid "Can't read value of '%s'"
+msgstr "Kan inte läsa värdet av \"%s\""
+
+#: ../src/msw/registry.cpp:1157
+#, c-format
+msgid "Can't enumerate values of key '%s'"
+msgstr "Kan inte räkna upp värden för nyckel \"%s\""
+
+#: ../src/msw/registry.cpp:1196
+#, c-format
+msgid "Can't enumerate subkeys of key '%s'"
+msgstr "Kan inte räkna upp undernycklar för nyckel \"%s\""
+
+#: ../src/msw/registry.cpp:1262
+#, c-format
+msgid ""
+"Exporting registry key: file \"%s\" already exists and won't be overwritten."
+msgstr ""
+"Exporterar registernyckel: Filen \"%s\" finns redan och kommer inte att "
+"skrivas över."
+
+#: ../src/msw/registry.cpp:1411
+#, c-format
+msgid "Can't export value of unsupported type %d."
+msgstr "Kan inte exportera värde av ej stödd typ %d."
+
+#: ../src/msw/registry.cpp:1427
+#, c-format
+msgid "Ignoring value \"%s\" of the key \"%s\"."
+msgstr "Ignorerar värde \"%s\" i nyckeln \"%s\"."
+
+#: ../src/msw/textctrl.cpp:596
+msgid ""
+"Impossible to create a rich edit control, using simple text control instead. "
+"Please reinstall riched32.dll"
+msgstr ""
+"Omöjligt att skapa en rich edit control, använder enkel text control "
+"istället. Installera om riched32.dll"
+
+#: ../src/msw/thread.cpp:522 ../src/unix/threadpsx.cpp:850
+msgid "Cannot start thread: error writing TLS."
+msgstr "Kan inte starta tråden: Fel vid skrivning av TLS."
+
+#: ../src/msw/thread.cpp:613
+msgid "Can't set thread priority"
+msgstr "Kan inte sätta trådprioritet"
+
+#: ../src/msw/thread.cpp:649
+msgid "Can't create thread"
+msgstr "Kan inte skapa tråd"
+
+#: ../src/msw/thread.cpp:668
+msgid "Couldn't terminate thread"
+msgstr "Kunde inte avsluta tråd"
+
+#: ../src/msw/thread.cpp:799
+msgid "Cannot wait for thread termination"
+msgstr "Kan inte vänta på att tråden avslutas"
+
+#: ../src/msw/thread.cpp:873
+#, c-format
+msgid "Cannot suspend thread %lx"
+msgstr "Kan inte hålla inne tråd %lx"
+
+#: ../src/msw/thread.cpp:903
+#, c-format
+msgid "Cannot resume thread %lx"
+msgstr "Kan inte återuppta tråden %lx"
+
+#: ../src/msw/thread.cpp:932
+msgid "Couldn't get the current thread pointer"
+msgstr "Kunde inte hämta den aktuella trådpekaren"
+
+#: ../src/msw/thread.cpp:1333
+msgid ""
+"Thread module initialization failed: impossible to allocate index in thread "
+"local storage"
+msgstr ""
+"Trådmodulinitialisering misslyckades: Omöjligt att allokera index i trådens "
+"lokala lagring"
+
+#: ../src/msw/thread.cpp:1345
+msgid ""
+"Thread module initialization failed: cannot store value in thread local "
+"storage"
+msgstr ""
+"Trådmodulinitialisering misslyckades: Kan inte spara värde i trådens lokala "
+"lagring"
+
+#: ../src/msw/timer.cpp:133
+msgid "Couldn't create a timer"
+msgstr "Kunde inte skapa en timer"
+
+#: ../src/msw/utils.cpp:372
+msgid "can't find user's HOME, using current directory."
+msgstr "kan inte hitta användarens HEM, använder aktuell katalog."
+
+#: ../src/msw/utils.cpp:662
+#, c-format
+msgid "Failed to kill process %d"
+msgstr "Kunde inte döda processen %d"
+
+#: ../src/msw/utils.cpp:986
+#, c-format
+msgid "Failed to load resource \"%s\"."
+msgstr "Kunde ladda resurs \"%s\"."
+
+#: ../src/msw/utils.cpp:993
+#, c-format
+msgid "Failed to lock resource \"%s\"."
+msgstr "Kunde inte låsa resursen \"%s\"."
+
+#. TRANSLATORS: MS Windows build number
+#: ../src/msw/utils.cpp:1209
+#, c-format
+msgid "build %lu"
+msgstr "bygge %lu"
+
+#: ../src/msw/utils.cpp:1218
+msgid ", 64-bit edition"
+msgstr ", 64-bitarsutgåva"
+
+#: ../src/msw/utilsexc.cpp:224
+msgid "Failed to create an anonymous pipe"
+msgstr "Kunde inte skapa ett anonymt rör (pipe)"
+
+#: ../src/msw/utilsexc.cpp:697
+msgid "Failed to redirect the child process IO"
+msgstr "Kunde inte omdirigera barnprocessens IO"
+
+#: ../src/msw/utilsexc.cpp:870
+#, c-format
+msgid "Execution of command '%s' failed"
+msgstr "Utförande av kommando \"%s\" misslyckades"
+
+#: ../src/msw/volume.cpp:337
+msgid "Failed to load mpr.dll."
+msgstr "Kunde inte läsa in mpr.dll."
+
+#: ../src/msw/volume.cpp:506
+#, c-format
+msgid "Cannot read typename from '%s'!"
+msgstr "Kan inte läsa typnamn från \"%s\"!"
+
+#: ../src/msw/volume.cpp:615
+#, c-format
+msgid "Cannot load icon from '%s'."
+msgstr "Kan inte läsa in ikon från \"%s\"."
+
+#: ../src/msw/webview_edge.cpp:285
+msgid "This program was compiled without support for setting Edge proxy."
+msgstr ""
+
+#: ../src/msw/webview_ie.cpp:1010
+msgid "Failed to find web view emulation level in the registry"
+msgstr ""
+
+#: ../src/msw/webview_ie.cpp:1019
+msgid "Failed to set web view to modern emulation level"
+msgstr ""
+
+#: ../src/msw/webview_ie.cpp:1027
+msgid "Failed to reset web view to standard emulation level"
+msgstr ""
+
+#: ../src/msw/webview_ie.cpp:1049
+msgid "Can't run JavaScript script without a valid HTML document"
+msgstr ""
+
+#: ../src/msw/webview_ie.cpp:1056
+#, fuzzy
+msgid "Can't get the JavaScript object"
+msgstr "Kan inte sätta trådprioritet"
+
+#: ../src/msw/webview_ie.cpp:1070
+#, fuzzy
+msgid "failed to evaluate"
+msgstr "Kunde inte utföra \"%s\"\n"
+
+#: ../src/osx/cocoa/filedlg.mm:412
+#, fuzzy
+msgid "File type:"
+msgstr "Teletyp"
+
+#: ../src/osx/cocoa/menu.mm:242
+#, fuzzy
+msgctxt "macOS menu name"
+msgid "Window"
+msgstr "&Fönster"
+
+#: ../src/osx/cocoa/menu.mm:259
+#, fuzzy
+msgctxt "macOS menu name"
+msgid "Help"
+msgstr "Hjälp"
+
+#: ../src/osx/cocoa/menu.mm:298
+#, fuzzy
+msgctxt "macOS menu item"
+msgid "Minimize"
+msgstr "&Minimera"
+
+#: ../src/osx/cocoa/menu.mm:303
+#, fuzzy
+msgctxt "macOS menu item"
+msgid "Zoom"
+msgstr "Zooma in"
+
+#: ../src/osx/cocoa/menu.mm:309
+msgctxt "macOS menu item"
+msgid "Bring All to Front"
+msgstr ""
+
+#: ../src/osx/core/sound.cpp:143
+#, fuzzy, c-format
+msgid "Failed to load sound from \"%s\" (error %d)."
+msgstr "Kunde ladda resurs \"%s\"."
+
+#: ../src/osx/fontutil.cpp:80
+#, fuzzy, c-format
+msgid "Font file \"%s\" doesn't exist."
+msgstr "Filen %s finns inte."
+
+#: ../src/osx/fontutil.cpp:88
+#, c-format
+msgid ""
+"Font file \"%s\" cannot be used as it is not inside the font directory "
+"\"%s\"."
+msgstr ""
+
+#: ../src/osx/menu_osx.cpp:496
+#, c-format
+msgctxt "macOS menu item"
+msgid "About %s"
+msgstr "Om %s"
+
+#: ../src/osx/menu_osx.cpp:499
+msgctxt "macOS menu item"
+msgid "About..."
+msgstr "Om..."
+
+#: ../src/osx/menu_osx.cpp:508
+msgctxt "macOS menu item"
+msgid "Preferences..."
+msgstr "Inställningar..."
+
+#: ../src/osx/menu_osx.cpp:512
+msgctxt "macOS menu item"
+msgid "Services"
+msgstr "Tjänster"
+
+#: ../src/osx/menu_osx.cpp:519
+#, c-format
+msgctxt "macOS menu item"
+msgid "Hide %s"
+msgstr "Dölj %s"
+
+#: ../src/osx/menu_osx.cpp:522
+#, fuzzy
+msgctxt "macOS menu item"
+msgid "Hide Application"
+msgstr "program"
+
+#: ../src/osx/menu_osx.cpp:526
+msgctxt "macOS menu item"
+msgid "Hide Others"
+msgstr "Dölj övriga"
+
+#: ../src/osx/menu_osx.cpp:528
+msgctxt "macOS menu item"
+msgid "Show All"
+msgstr "Visa alla"
+
+#: ../src/osx/menu_osx.cpp:534
+#, c-format
+msgctxt "macOS menu item"
+msgid "Quit %s"
+msgstr "Avsluta %s"
+
+#: ../src/osx/menu_osx.cpp:537
+#, fuzzy
+msgctxt "macOS menu item"
+msgid "Quit Application"
+msgstr "program"
+
+#: ../src/osx/webview_webkit.mm:444
+#, fuzzy
+msgid "Printing is not supported by the system web control"
+msgstr "Gzip stöds inte av den här versionen av zlib"
+
+#: ../src/osx/webview_webkit.mm:453
+#, fuzzy
+msgid "Print operation could not be initialized"
+msgstr "Kolumnbeskrivning kunde inte initieras."
+
+#. TRANSLATORS: Label of font point size
+#: ../src/propgrid/advprops.cpp:605
+msgid "Point Size"
+msgstr "Punktstorlek"
+
+#. TRANSLATORS: Label of font face name
+#: ../src/propgrid/advprops.cpp:615
+msgid "Face Name"
+msgstr "Typsnittsnamn"
+
+#. TRANSLATORS: Label of font style
+#: ../src/propgrid/advprops.cpp:623 ../src/richtext/richtextformatdlg.cpp:331
+msgid "Style"
+msgstr "Stil"
+
+#. TRANSLATORS: Label of font weight
+#: ../src/propgrid/advprops.cpp:628
+msgid "Weight"
+msgstr "Vikt"
+
+#. TRANSLATORS: Label of underlined font
+#: ../src/propgrid/advprops.cpp:633 ../src/richtext/richtextfontpage.cpp:358
+msgid "Underlined"
+msgstr "Understruken"
+
+#. TRANSLATORS: Label of font family
+#: ../src/propgrid/advprops.cpp:637
+msgid "Family"
+msgstr "Familj"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:801
+msgid "AppWorkspace"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:802
+#, fuzzy
+msgid "ActiveBorder"
+msgstr "Ram"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:803
+msgid "ActiveCaption"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:804
+msgid "ButtonFace"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:805
+msgid "ButtonHighlight"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:806
+msgid "ButtonShadow"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:807
+msgid "ButtonText"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:808
+msgid "CaptionText"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:809
+msgid "ControlDark"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:810
+msgid "ControlLight"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:812
+msgid "GrayText"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:813
+#, fuzzy
+msgid "Highlight"
+msgstr "tunn"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:814
+#, fuzzy
+msgid "HighlightText"
+msgstr "Högerjustera text."
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:815
+#, fuzzy
+msgid "InactiveBorder"
+msgstr "Ram"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:816
+msgid "InactiveCaption"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:817
+msgid "InactiveCaptionText"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:818
+msgid "Menu"
+msgstr "Meny"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:819
+msgid "Scrollbar"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:820
+msgid "Tooltip"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:821
+msgid "TooltipText"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:822
+#, fuzzy
+msgid "Window"
+msgstr "&Fönster"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:823
+#, fuzzy
+msgid "WindowFrame"
+msgstr "&Fönster"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:824
+#, fuzzy
+msgid "WindowText"
+msgstr "&Fönster"
+
+#. TRANSLATORS: Custom colour choice entry
+#: ../src/propgrid/advprops.cpp:825 ../src/propgrid/advprops.cpp:1532
+#: ../src/propgrid/advprops.cpp:1576
+#, fuzzy
+msgid "Custom"
+msgstr "Valfri storlek"
+
+#: ../src/propgrid/advprops.cpp:1558
+msgid "Black"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1559
+msgid "Maroon"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1560
+msgid "Navy"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1561
+msgid "Purple"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1562
+msgid "Teal"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1563
+msgid "Gray"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1564
+#, fuzzy
+msgid "Green"
+msgstr "MacGrekiska"
+
+#: ../src/propgrid/advprops.cpp:1565
+msgid "Olive"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1566
+#, fuzzy
+msgid "Brown"
+msgstr "Bläddra"
+
+#: ../src/propgrid/advprops.cpp:1567
+msgid "Blue"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1568
+msgid "Fuchsia"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1569
+#, fuzzy
+msgid "Red"
+msgstr "Gör om"
+
+#: ../src/propgrid/advprops.cpp:1570
+msgid "Orange"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1571
+msgid "Silver"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1572
+msgid "Lime"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1573
+msgid "Aqua"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1574
+msgid "Yellow"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1575
+msgid "White"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1718
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Default"
+msgstr "förvald"
+
+#: ../src/propgrid/advprops.cpp:1719
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Arrow"
+msgstr "i morgon"
+
+#: ../src/propgrid/advprops.cpp:1720
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Right Arrow"
+msgstr "Höger"
+
+#: ../src/propgrid/advprops.cpp:1721
+msgctxt "system cursor name"
+msgid "Blank"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1722
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Bullseye"
+msgstr "Punktliststil"
+
+#: ../src/propgrid/advprops.cpp:1723
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Character"
+msgstr "&Teckenkod:"
+
+#: ../src/propgrid/advprops.cpp:1724
+msgctxt "system cursor name"
+msgid "Cross"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1725
+msgctxt "system cursor name"
+msgid "Hand"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1726
+msgctxt "system cursor name"
+msgid "I-Beam"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1727
+msgctxt "system cursor name"
+msgid "Left Button"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1728
+msgctxt "system cursor name"
+msgid "Magnifier"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1729
+msgctxt "system cursor name"
+msgid "Middle Button"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1730
+msgctxt "system cursor name"
+msgid "No Entry"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1731
+msgctxt "system cursor name"
+msgid "Paint Brush"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1732
+msgctxt "system cursor name"
+msgid "Pencil"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1733
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Point Left"
+msgstr "Punktstorlek"
+
+#: ../src/propgrid/advprops.cpp:1734
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Point Right"
+msgstr "Högerjustera"
+
+#: ../src/propgrid/advprops.cpp:1735
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Question Arrow"
+msgstr "Fråga"
+
+#: ../src/propgrid/advprops.cpp:1736
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Right Button"
+msgstr "Höger"
+
+#: ../src/propgrid/advprops.cpp:1737
+msgctxt "system cursor name"
+msgid "Sizing NE-SW"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1738
+msgctxt "system cursor name"
+msgid "Sizing N-S"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1739
+msgctxt "system cursor name"
+msgid "Sizing NW-SE"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1740
+msgctxt "system cursor name"
+msgid "Sizing W-E"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1741
+msgctxt "system cursor name"
+msgid "Sizing"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1742
+msgctxt "system cursor name"
+msgid "Spraycan"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1743
+msgctxt "system cursor name"
+msgid "Wait"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1744
+msgctxt "system cursor name"
+msgid "Watch"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1745
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Wait Arrow"
+msgstr "Höger"
+
+#: ../src/propgrid/advprops.cpp:2109
+msgid "Make a selection:"
+msgstr "Skapa en markering:"
+
+#: ../src/propgrid/manager.cpp:394
+msgid "Property"
+msgstr "Egenskap"
+
+#: ../src/propgrid/manager.cpp:395
+msgid "Value"
+msgstr "Värde"
+
+#: ../src/propgrid/manager.cpp:1683
+msgid "Categorized Mode"
+msgstr "Kategoriserat läge"
+
+#: ../src/propgrid/manager.cpp:1709
+msgid "Alphabetic Mode"
+msgstr "Alfabetiskt läge"
+
+#. TRANSLATORS: Name of Boolean false value
+#: ../src/propgrid/propgrid.cpp:230
+msgid "False"
+msgstr "Falskt"
+
+#. TRANSLATORS: Name of Boolean true value
+#: ../src/propgrid/propgrid.cpp:232
+msgid "True"
+msgstr "Sant"
+
+#. TRANSLATORS: Text  displayed for unspecified value
+#: ../src/propgrid/propgrid.cpp:428
+msgid "Unspecified"
+msgstr "Ospecificerad"
+
+#. TRANSLATORS: Caption of message box displaying any property error
+#: ../src/propgrid/propgrid.cpp:3145 ../src/propgrid/propgrid.cpp:3282
+msgid "Property Error"
+msgstr "Egenskapsfel"
+
+#: ../src/propgrid/propgrid.cpp:3259
+msgid "You have entered invalid value. Press ESC to cancel editing."
+msgstr ""
+"Du har angett ett ogiltigt värde. Tryck ESC för att avbryta redigering."
+
+#: ../src/propgrid/propgrid.cpp:6608
+#, c-format
+msgid "Error in resource: %s"
+msgstr "Fel i resurs: %s"
+
+#: ../src/propgrid/propgridiface.cpp:377
+#, c-format
+msgid ""
+"Type operation \"%s\" failed: Property labeled \"%s\" is of type \"%s\", NOT "
+"\"%s\"."
+msgstr ""
+"Typoperation \"%s\" misslyckades: Egenskap med etikett \"%s\" är av typ "
+"\"%s\", INTE \"%s\"."
+
+#: ../src/propgrid/props.cpp:159
+#, c-format
+msgid "Unknown base %d. Base 10 will be used."
+msgstr ""
+
+#: ../src/propgrid/props.cpp:324
+#, c-format
+msgid "Value must be %s or higher."
+msgstr "Värde måste vara %s eller högre."
+
+#: ../src/propgrid/props.cpp:329 ../src/propgrid/props.cpp:356
+#, c-format
+msgid "Value must be between %s and %s."
+msgstr "Värde måste vara mellan %s och %s."
+
+#: ../src/propgrid/props.cpp:351
+#, c-format
+msgid "Value must be %s or less."
+msgstr "Värde måste vara %s eller mindre."
+
+#: ../src/propgrid/props.cpp:1058
+#, c-format
+msgid "Not %s"
+msgstr "Inte %s"
+
+#: ../src/propgrid/props.cpp:1770
+msgid "Choose a directory:"
+msgstr "Välj en katalog:"
+
+#: ../src/propgrid/props.cpp:2055
+msgid "Choose a file"
+msgstr "Välj en fil"
+
+#: ../src/qt/mdi.cpp:254
+msgid "&Tile"
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:147
+#: ../src/richtext/richtextformatdlg.cpp:376
+msgid "Background"
+msgstr "Bakgrund"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:159
+msgid "Background &colour:"
+msgstr "Bakgrunds&färg:"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:161
+#: ../src/richtext/richtextbackgroundpage.cpp:163
+msgid "Enables a background colour."
+msgstr "Slår på en bakgrundsfärg."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:167
+#: ../src/richtext/richtextbackgroundpage.cpp:169
+msgid "The background colour."
+msgstr "Bakgrundsfärgen."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:178
+msgid "Shadow"
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:193
+msgid "Use &shadow"
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:195
+#: ../src/richtext/richtextbackgroundpage.cpp:197
+#, fuzzy
+msgid "Enables a shadow."
+msgstr "Slår på en bakgrundsfärg."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:211
+msgid "&Horizontal offset:"
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:218
+#: ../src/richtext/richtextbackgroundpage.cpp:220
+#, fuzzy
+msgid "The horizontal offset."
+msgstr "Ordna &horisontellt"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:224
+#: ../src/richtext/richtextbackgroundpage.cpp:227
+#: ../src/richtext/richtextbackgroundpage.cpp:228
+#: ../src/richtext/richtextbackgroundpage.cpp:247
+#: ../src/richtext/richtextbackgroundpage.cpp:250
+#: ../src/richtext/richtextbackgroundpage.cpp:251
+#: ../src/richtext/richtextbackgroundpage.cpp:287
+#: ../src/richtext/richtextbackgroundpage.cpp:290
+#: ../src/richtext/richtextbackgroundpage.cpp:291
+#: ../src/richtext/richtextbackgroundpage.cpp:314
+#: ../src/richtext/richtextbackgroundpage.cpp:317
+#: ../src/richtext/richtextbackgroundpage.cpp:318
+#: ../src/richtext/richtextborderspage.cpp:252
+#: ../src/richtext/richtextborderspage.cpp:255
+#: ../src/richtext/richtextborderspage.cpp:256
+#: ../src/richtext/richtextborderspage.cpp:286
+#: ../src/richtext/richtextborderspage.cpp:289
+#: ../src/richtext/richtextborderspage.cpp:290
+#: ../src/richtext/richtextborderspage.cpp:320
+#: ../src/richtext/richtextborderspage.cpp:323
+#: ../src/richtext/richtextborderspage.cpp:324
+#: ../src/richtext/richtextborderspage.cpp:354
+#: ../src/richtext/richtextborderspage.cpp:357
+#: ../src/richtext/richtextborderspage.cpp:358
+#: ../src/richtext/richtextborderspage.cpp:420
+#: ../src/richtext/richtextborderspage.cpp:423
+#: ../src/richtext/richtextborderspage.cpp:424
+#: ../src/richtext/richtextborderspage.cpp:454
+#: ../src/richtext/richtextborderspage.cpp:457
+#: ../src/richtext/richtextborderspage.cpp:458
+#: ../src/richtext/richtextborderspage.cpp:488
+#: ../src/richtext/richtextborderspage.cpp:491
+#: ../src/richtext/richtextborderspage.cpp:492
+#: ../src/richtext/richtextborderspage.cpp:522
+#: ../src/richtext/richtextborderspage.cpp:525
+#: ../src/richtext/richtextborderspage.cpp:526
+#: ../src/richtext/richtextborderspage.cpp:590
+#: ../src/richtext/richtextborderspage.cpp:593
+#: ../src/richtext/richtextborderspage.cpp:594
+#: ../src/richtext/richtextfontpage.cpp:177
+#: ../src/richtext/richtextmarginspage.cpp:199
+#: ../src/richtext/richtextmarginspage.cpp:201
+#: ../src/richtext/richtextmarginspage.cpp:202
+#: ../src/richtext/richtextmarginspage.cpp:224
+#: ../src/richtext/richtextmarginspage.cpp:226
+#: ../src/richtext/richtextmarginspage.cpp:227
+#: ../src/richtext/richtextmarginspage.cpp:247
+#: ../src/richtext/richtextmarginspage.cpp:249
+#: ../src/richtext/richtextmarginspage.cpp:250
+#: ../src/richtext/richtextmarginspage.cpp:272
+#: ../src/richtext/richtextmarginspage.cpp:274
+#: ../src/richtext/richtextmarginspage.cpp:275
+#: ../src/richtext/richtextmarginspage.cpp:313
+#: ../src/richtext/richtextmarginspage.cpp:315
+#: ../src/richtext/richtextmarginspage.cpp:316
+#: ../src/richtext/richtextmarginspage.cpp:338
+#: ../src/richtext/richtextmarginspage.cpp:340
+#: ../src/richtext/richtextmarginspage.cpp:341
+#: ../src/richtext/richtextmarginspage.cpp:361
+#: ../src/richtext/richtextmarginspage.cpp:363
+#: ../src/richtext/richtextmarginspage.cpp:364
+#: ../src/richtext/richtextmarginspage.cpp:386
+#: ../src/richtext/richtextmarginspage.cpp:388
+#: ../src/richtext/richtextmarginspage.cpp:389
+#: ../src/richtext/richtextsizepage.cpp:337
+#: ../src/richtext/richtextsizepage.cpp:340
+#: ../src/richtext/richtextsizepage.cpp:341
+#: ../src/richtext/richtextsizepage.cpp:371
+#: ../src/richtext/richtextsizepage.cpp:374
+#: ../src/richtext/richtextsizepage.cpp:375
+#: ../src/richtext/richtextsizepage.cpp:398
+#: ../src/richtext/richtextsizepage.cpp:401
+#: ../src/richtext/richtextsizepage.cpp:402
+#: ../src/richtext/richtextsizepage.cpp:425
+#: ../src/richtext/richtextsizepage.cpp:428
+#: ../src/richtext/richtextsizepage.cpp:429
+#: ../src/richtext/richtextsizepage.cpp:452
+#: ../src/richtext/richtextsizepage.cpp:455
+#: ../src/richtext/richtextsizepage.cpp:456
+#: ../src/richtext/richtextsizepage.cpp:479
+#: ../src/richtext/richtextsizepage.cpp:482
+#: ../src/richtext/richtextsizepage.cpp:483
+#: ../src/richtext/richtextsizepage.cpp:553
+#: ../src/richtext/richtextsizepage.cpp:556
+#: ../src/richtext/richtextsizepage.cpp:557
+#: ../src/richtext/richtextsizepage.cpp:588
+#: ../src/richtext/richtextsizepage.cpp:591
+#: ../src/richtext/richtextsizepage.cpp:592
+#: ../src/richtext/richtextsizepage.cpp:623
+#: ../src/richtext/richtextsizepage.cpp:626
+#: ../src/richtext/richtextsizepage.cpp:627
+#: ../src/richtext/richtextsizepage.cpp:658
+#: ../src/richtext/richtextsizepage.cpp:661
+#: ../src/richtext/richtextsizepage.cpp:662
+msgid "px"
+msgstr "px"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:225
+#: ../src/richtext/richtextbackgroundpage.cpp:248
+#: ../src/richtext/richtextbackgroundpage.cpp:288
+#: ../src/richtext/richtextbackgroundpage.cpp:315
+#: ../src/richtext/richtextborderspage.cpp:253
+#: ../src/richtext/richtextborderspage.cpp:287
+#: ../src/richtext/richtextborderspage.cpp:321
+#: ../src/richtext/richtextborderspage.cpp:355
+#: ../src/richtext/richtextborderspage.cpp:421
+#: ../src/richtext/richtextborderspage.cpp:455
+#: ../src/richtext/richtextborderspage.cpp:489
+#: ../src/richtext/richtextborderspage.cpp:523
+#: ../src/richtext/richtextborderspage.cpp:591
+#: ../src/richtext/richtextmarginspage.cpp:200
+#: ../src/richtext/richtextmarginspage.cpp:225
+#: ../src/richtext/richtextmarginspage.cpp:248
+#: ../src/richtext/richtextmarginspage.cpp:273
+#: ../src/richtext/richtextmarginspage.cpp:314
+#: ../src/richtext/richtextmarginspage.cpp:339
+#: ../src/richtext/richtextmarginspage.cpp:362
+#: ../src/richtext/richtextmarginspage.cpp:387
+#: ../src/richtext/richtextsizepage.cpp:338
+#: ../src/richtext/richtextsizepage.cpp:372
+#: ../src/richtext/richtextsizepage.cpp:399
+#: ../src/richtext/richtextsizepage.cpp:426
+#: ../src/richtext/richtextsizepage.cpp:453
+#: ../src/richtext/richtextsizepage.cpp:480
+#: ../src/richtext/richtextsizepage.cpp:554
+#: ../src/richtext/richtextsizepage.cpp:589
+#: ../src/richtext/richtextsizepage.cpp:624
+#: ../src/richtext/richtextsizepage.cpp:659
+msgid "cm"
+msgstr "cm"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:226
+#: ../src/richtext/richtextbackgroundpage.cpp:249
+#: ../src/richtext/richtextbackgroundpage.cpp:289
+#: ../src/richtext/richtextbackgroundpage.cpp:316
+#: ../src/richtext/richtextborderspage.cpp:254
+#: ../src/richtext/richtextborderspage.cpp:288
+#: ../src/richtext/richtextborderspage.cpp:322
+#: ../src/richtext/richtextborderspage.cpp:356
+#: ../src/richtext/richtextborderspage.cpp:422
+#: ../src/richtext/richtextborderspage.cpp:456
+#: ../src/richtext/richtextborderspage.cpp:490
+#: ../src/richtext/richtextborderspage.cpp:524
+#: ../src/richtext/richtextborderspage.cpp:592
+#: ../src/richtext/richtextfontpage.cpp:176
+#: ../src/richtext/richtextfontpage.cpp:179
+msgid "pt"
+msgstr "pt"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:229
+#: ../src/richtext/richtextbackgroundpage.cpp:231
+#: ../src/richtext/richtextbackgroundpage.cpp:252
+#: ../src/richtext/richtextbackgroundpage.cpp:254
+#: ../src/richtext/richtextbackgroundpage.cpp:292
+#: ../src/richtext/richtextbackgroundpage.cpp:294
+#: ../src/richtext/richtextbackgroundpage.cpp:319
+#: ../src/richtext/richtextbackgroundpage.cpp:321
+#, fuzzy
+msgid "Units for this value."
+msgstr "Enheter för vänster marginal."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:234
+#, fuzzy
+msgid "&Vertical offset:"
+msgstr "&Vertical justering:"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:241
+#: ../src/richtext/richtextbackgroundpage.cpp:243
+#, fuzzy
+msgid "The vertical offset."
+msgstr "Slå på vertikal justering."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:257
+#, fuzzy
+msgid "Shadow c&olour:"
+msgstr "Välj färg"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:259
+#: ../src/richtext/richtextbackgroundpage.cpp:261
+#, fuzzy
+msgid "Enables the shadow colour."
+msgstr "Slår på en bakgrundsfärg."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:265
+#: ../src/richtext/richtextbackgroundpage.cpp:267
+#, fuzzy
+msgid "The shadow colour."
+msgstr "Typsnittets färg."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:270
+msgid "Sh&adow spread:"
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:272
+#: ../src/richtext/richtextbackgroundpage.cpp:274
+#, fuzzy
+msgid "Enables the shadow spread."
+msgstr "Slå på breddvärdet."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:281
+#: ../src/richtext/richtextbackgroundpage.cpp:283
+msgid "The shadow spread."
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:297
+msgid "&Blur distance:"
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:299
+#: ../src/richtext/richtextbackgroundpage.cpp:301
+#, fuzzy
+msgid "Enables the blur distance."
+msgstr "Slå på breddvärdet."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:308
+#: ../src/richtext/richtextbackgroundpage.cpp:310
+msgid "The shadow blur distance."
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:324
+msgid "Opaci&ty:"
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:326
+#: ../src/richtext/richtextbackgroundpage.cpp:328
+#, fuzzy
+msgid "Enables the shadow opacity."
+msgstr "Slå på breddvärdet."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:335
+#: ../src/richtext/richtextbackgroundpage.cpp:337
+msgid "The shadow opacity."
+msgstr ""
+
+#. TRANSLATORS: Rich text page units (percentage)
+#: ../src/richtext/richtextbackgroundpage.cpp:340
+#: ../src/richtext/richtextsizepage.cpp:339
+#: ../src/richtext/richtextsizepage.cpp:373
+#: ../src/richtext/richtextsizepage.cpp:400
+#: ../src/richtext/richtextsizepage.cpp:427
+#: ../src/richtext/richtextsizepage.cpp:454
+#: ../src/richtext/richtextsizepage.cpp:481
+#: ../src/richtext/richtextsizepage.cpp:555
+#: ../src/richtext/richtextsizepage.cpp:590
+#: ../src/richtext/richtextsizepage.cpp:625
+#: ../src/richtext/richtextsizepage.cpp:660
+msgid "%"
+msgstr "%"
+
+#: ../src/richtext/richtextborderspage.cpp:229
+#: ../src/richtext/richtextborderspage.cpp:387
+msgid "Border"
+msgstr "Ram"
+
+#: ../src/richtext/richtextborderspage.cpp:242
+#: ../src/richtext/richtextborderspage.cpp:410
+#: ../src/richtext/richtextindentspage.cpp:194
+#: ../src/richtext/richtextliststylepage.cpp:384
+#: ../src/richtext/richtextmarginspage.cpp:185
+#: ../src/richtext/richtextmarginspage.cpp:299
+#: ../src/richtext/richtextsizepage.cpp:531
+#: ../src/richtext/richtextsizepage.cpp:538
+msgid "&Left:"
+msgstr "&Vänster:"
+
+#: ../src/richtext/richtextborderspage.cpp:257
+#: ../src/richtext/richtextborderspage.cpp:259
+msgid "Units for the left border width."
+msgstr "Enheter för vänster rambredd."
+
+#: ../src/richtext/richtextborderspage.cpp:266
+#: ../src/richtext/richtextborderspage.cpp:268
+#: ../src/richtext/richtextborderspage.cpp:300
+#: ../src/richtext/richtextborderspage.cpp:302
+#: ../src/richtext/richtextborderspage.cpp:334
+#: ../src/richtext/richtextborderspage.cpp:336
+#: ../src/richtext/richtextborderspage.cpp:368
+#: ../src/richtext/richtextborderspage.cpp:370
+#: ../src/richtext/richtextborderspage.cpp:434
+#: ../src/richtext/richtextborderspage.cpp:436
+#: ../src/richtext/richtextborderspage.cpp:468
+#: ../src/richtext/richtextborderspage.cpp:470
+#: ../src/richtext/richtextborderspage.cpp:502
+#: ../src/richtext/richtextborderspage.cpp:504
+#: ../src/richtext/richtextborderspage.cpp:536
+#: ../src/richtext/richtextborderspage.cpp:538
+msgid "The border line style."
+msgstr "Ramens linjestil."
+
+#: ../src/richtext/richtextborderspage.cpp:276
+#: ../src/richtext/richtextborderspage.cpp:444
+#: ../src/richtext/richtextindentspage.cpp:212
+#: ../src/richtext/richtextliststylepage.cpp:402
+#: ../src/richtext/richtextmarginspage.cpp:210
+#: ../src/richtext/richtextmarginspage.cpp:324
+#: ../src/richtext/richtextsizepage.cpp:601
+#: ../src/richtext/richtextsizepage.cpp:608
+msgid "&Right:"
+msgstr "&Höger:"
+
+#: ../src/richtext/richtextborderspage.cpp:291
+#: ../src/richtext/richtextborderspage.cpp:293
+msgid "Units for the right border width."
+msgstr "Enheter för höger rambredd."
+
+#: ../src/richtext/richtextborderspage.cpp:310
+#: ../src/richtext/richtextborderspage.cpp:478
+#: ../src/richtext/richtextmarginspage.cpp:233
+#: ../src/richtext/richtextmarginspage.cpp:347
+#: ../src/richtext/richtextsizepage.cpp:566
+#: ../src/richtext/richtextsizepage.cpp:573
+msgid "&Top:"
+msgstr "&Övre:"
+
+#: ../src/richtext/richtextborderspage.cpp:325
+#: ../src/richtext/richtextborderspage.cpp:327
+msgid "Units for the top border width."
+msgstr "Enheter för övre rambredd."
+
+#: ../src/richtext/richtextborderspage.cpp:344
+#: ../src/richtext/richtextborderspage.cpp:512
+#: ../src/richtext/richtextmarginspage.cpp:258
+#: ../src/richtext/richtextmarginspage.cpp:372
+#: ../src/richtext/richtextsizepage.cpp:636
+#: ../src/richtext/richtextsizepage.cpp:643
+msgid "&Bottom:"
+msgstr "&Undre"
+
+#: ../src/richtext/richtextborderspage.cpp:359
+#: ../src/richtext/richtextborderspage.cpp:361
+msgid "Units for the bottom border width."
+msgstr "Enheter för undre rambredd."
+
+#: ../src/richtext/richtextborderspage.cpp:380
+#: ../src/richtext/richtextborderspage.cpp:548
+msgid "&Synchronize values"
+msgstr "&Synkronisera värden"
+
+#: ../src/richtext/richtextborderspage.cpp:382
+#: ../src/richtext/richtextborderspage.cpp:384
+#: ../src/richtext/richtextborderspage.cpp:550
+#: ../src/richtext/richtextborderspage.cpp:552
+msgid "Check to edit all borders simultaneously."
+msgstr "Kryssa i för att redigera alla ramar samtidigt"
+
+#: ../src/richtext/richtextborderspage.cpp:397
+#: ../src/richtext/richtextborderspage.cpp:555
+msgid "Outline"
+msgstr "Kontur"
+
+#: ../src/richtext/richtextborderspage.cpp:425
+#: ../src/richtext/richtextborderspage.cpp:427
+msgid "Units for the left outline width."
+msgstr "Enheter för vänster konturbredd."
+
+#: ../src/richtext/richtextborderspage.cpp:459
+#: ../src/richtext/richtextborderspage.cpp:461
+msgid "Units for the right outline width."
+msgstr "Enheter för höger konturbredd."
+
+#: ../src/richtext/richtextborderspage.cpp:493
+#: ../src/richtext/richtextborderspage.cpp:495
+msgid "Units for the top outline width."
+msgstr "Enheter för övre konturbredd."
+
+#: ../src/richtext/richtextborderspage.cpp:527
+#: ../src/richtext/richtextborderspage.cpp:529
+msgid "Units for the bottom outline width."
+msgstr "Enheter för undre konturbredd."
+
+#: ../src/richtext/richtextborderspage.cpp:565
+#: ../src/richtext/richtextborderspage.cpp:600
+msgid "Corner"
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:574
+msgid "Corner &radius:"
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:576
+#: ../src/richtext/richtextborderspage.cpp:578
+msgid "An optional corner radius for adding rounded corners."
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:584
+#: ../src/richtext/richtextborderspage.cpp:586
+msgid "The value of the corner radius."
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:595
+#: ../src/richtext/richtextborderspage.cpp:597
+#, fuzzy
+msgid "Units for the corner radius."
+msgstr "Enheter för övre utfyllnadsstorlek."
+
+#: ../src/richtext/richtextborderspage.cpp:609
+#: ../src/richtext/richtextsizepage.cpp:247
+#: ../src/richtext/richtextsizepage.cpp:251
+msgid "None"
+msgstr "Ingen"
+
+#: ../src/richtext/richtextborderspage.cpp:610
+msgid "Solid"
+msgstr "Solid"
+
+#: ../src/richtext/richtextborderspage.cpp:611
+msgid "Dotted"
+msgstr "Prickad"
+
+#: ../src/richtext/richtextborderspage.cpp:612
+msgid "Dashed"
+msgstr "Streckad"
+
+#: ../src/richtext/richtextborderspage.cpp:613
+msgid "Double"
+msgstr "Dubbel"
+
+#: ../src/richtext/richtextborderspage.cpp:614
+msgid "Groove"
+msgstr "Skårad"
+
+#: ../src/richtext/richtextborderspage.cpp:615
+msgid "Ridge"
+msgstr "Upphöjd"
+
+#: ../src/richtext/richtextborderspage.cpp:616
+msgid "Inset"
+msgstr "Infällning"
+
+#: ../src/richtext/richtextborderspage.cpp:617
+msgid "Outset"
+msgstr "Utfällning"
+
+#: ../src/richtext/richtextbuffer.cpp:3518
+msgid "Change Style"
+msgstr "Ändra stil"
+
+#: ../src/richtext/richtextbuffer.cpp:3701
+msgid "Change Object Style"
+msgstr "Ändra objektstil"
+
+#: ../src/richtext/richtextbuffer.cpp:3974
+#: ../src/richtext/richtextbuffer.cpp:8174
+msgid "Change Properties"
+msgstr "Ändra egenskaper"
+
+#: ../src/richtext/richtextbuffer.cpp:4346
+msgid "Change List Style"
+msgstr "Byt liststil"
+
+#: ../src/richtext/richtextbuffer.cpp:4519
+msgid "Renumber List"
+msgstr "Omnumrera lista"
+
+#: ../src/richtext/richtextbuffer.cpp:7867
+#: ../src/richtext/richtextbuffer.cpp:7897
+#: ../src/richtext/richtextbuffer.cpp:7939
+#: ../src/richtext/richtextctrl.cpp:1279 ../src/richtext/richtextctrl.cpp:1473
+msgid "Insert Text"
+msgstr "Infoga text"
+
+#: ../src/richtext/richtextbuffer.cpp:8023
+#: ../src/richtext/richtextbuffer.cpp:8979
+msgid "Insert Image"
+msgstr "Infoga bild"
+
+#: ../src/richtext/richtextbuffer.cpp:8070
+msgid "Insert Object"
+msgstr "Infoga objekt"
+
+#: ../src/richtext/richtextbuffer.cpp:8112
+msgid "Insert Field"
+msgstr "Infoga fält"
+
+#: ../src/richtext/richtextbuffer.cpp:8410
+msgid "Too many EndStyle calls!"
+msgstr "För många EndStyle-anrop!"
+
+#: ../src/richtext/richtextbuffer.cpp:8785
+msgid "files"
+msgstr "filer"
+
+#: ../src/richtext/richtextbuffer.cpp:9380
+msgid "standard/circle"
+msgstr "standard/cirkel"
+
+#: ../src/richtext/richtextbuffer.cpp:9381
+msgid "standard/circle-outline"
+msgstr "standard/cirkelram"
+
+#: ../src/richtext/richtextbuffer.cpp:9382
+msgid "standard/square"
+msgstr "standard/kvadrat"
+
+#: ../src/richtext/richtextbuffer.cpp:9383
+msgid "standard/diamond"
+msgstr "standard/diamant"
+
+#: ../src/richtext/richtextbuffer.cpp:9384
+msgid "standard/triangle"
+msgstr "standard/triangel"
+
+#: ../src/richtext/richtextbuffer.cpp:9423
+msgid "Box Properties"
+msgstr "Egenskaper för låda"
+
+#: ../src/richtext/richtextbuffer.cpp:10006
+msgid "Multiple Cell Properties"
+msgstr "Egenskaper för flera celler"
+
+#: ../src/richtext/richtextbuffer.cpp:10008
+msgid "Cell Properties"
+msgstr "Egenskaper för cell"
+
+#: ../src/richtext/richtextbuffer.cpp:11256
+msgid "Set Cell Style"
+msgstr "Ange cellstil"
+
+#: ../src/richtext/richtextbuffer.cpp:11330
+msgid "Delete Row"
+msgstr "Ta bort rad"
+
+#: ../src/richtext/richtextbuffer.cpp:11380
+msgid "Delete Column"
+msgstr "Ta bort kolumn"
+
+#: ../src/richtext/richtextbuffer.cpp:11431
+msgid "Add Row"
+msgstr "Lägg till rad"
+
+#: ../src/richtext/richtextbuffer.cpp:11494
+msgid "Add Column"
+msgstr "Lägg till kolumn"
+
+#: ../src/richtext/richtextbuffer.cpp:11537
+msgid "Table Properties"
+msgstr "Tabellegenskaper"
+
+#: ../src/richtext/richtextbuffer.cpp:12899
+msgid "Picture Properties"
+msgstr "Bildgenskaper"
+
+#: ../src/richtext/richtextbuffer.cpp:13169
+#: ../src/richtext/richtextbuffer.cpp:13279
+msgid "image"
+msgstr "bild"
+
+#: ../src/richtext/richtextbulletspage.cpp:145
+#: ../src/richtext/richtextliststylepage.cpp:209
+msgid "&Bullet style:"
+msgstr "&Punktlisttecken:"
+
+#: ../src/richtext/richtextbulletspage.cpp:150
+#: ../src/richtext/richtextbulletspage.cpp:152
+#: ../src/richtext/richtextliststylepage.cpp:214
+#: ../src/richtext/richtextliststylepage.cpp:216
+msgid "The available bullet styles."
+msgstr "Tillgängliga punktliststilar."
+
+#: ../src/richtext/richtextbulletspage.cpp:158
+#: ../src/richtext/richtextliststylepage.cpp:221
+msgid "Peri&od"
+msgstr "P&unkt"
+
+#: ../src/richtext/richtextbulletspage.cpp:160
+#: ../src/richtext/richtextbulletspage.cpp:162
+#: ../src/richtext/richtextliststylepage.cpp:223
+#: ../src/richtext/richtextliststylepage.cpp:225
+msgid "Check to add a period after the bullet."
+msgstr "Kryssa i för att lägga till en punkt efter punktlisttecknet."
+
+#. TRANSLATORS: Bullet point in parentheses option
+#: ../src/richtext/richtextbulletspage.cpp:167
+#: ../src/richtext/richtextliststylepage.cpp:230
+msgid "(*)"
+msgstr "(*)"
+
+#: ../src/richtext/richtextbulletspage.cpp:169
+#: ../src/richtext/richtextbulletspage.cpp:171
+#: ../src/richtext/richtextliststylepage.cpp:232
+#: ../src/richtext/richtextliststylepage.cpp:234
+msgid "Check to enclose the bullet in parentheses."
+msgstr "Kryssa i för att innesluta punktlisttecknet i paranteser."
+
+#. TRANSLATORS: Right parenthesis bullet point option
+#: ../src/richtext/richtextbulletspage.cpp:176
+#: ../src/richtext/richtextliststylepage.cpp:239
+msgid "*)"
+msgstr "*)"
+
+#: ../src/richtext/richtextbulletspage.cpp:178
+#: ../src/richtext/richtextbulletspage.cpp:180
+#: ../src/richtext/richtextliststylepage.cpp:241
+#: ../src/richtext/richtextliststylepage.cpp:243
+msgid "Check to add a right parenthesis."
+msgstr "Kryssa i för att lägga till en högerparantes."
+
+#: ../src/richtext/richtextbulletspage.cpp:185
+#: ../src/richtext/richtextliststylepage.cpp:248
+msgid "Bullet &Alignment:"
+msgstr "Justering &av punktlista:"
+
+#: ../src/richtext/richtextbulletspage.cpp:190
+#: ../src/richtext/richtextliststylepage.cpp:253
+msgid "Centre"
+msgstr "Centrera"
+
+#: ../src/richtext/richtextbulletspage.cpp:194
+#: ../src/richtext/richtextbulletspage.cpp:196
+#: ../src/richtext/richtextbulletspage.cpp:217
+#: ../src/richtext/richtextbulletspage.cpp:219
+#: ../src/richtext/richtextliststylepage.cpp:257
+#: ../src/richtext/richtextliststylepage.cpp:259
+#: ../src/richtext/richtextliststylepage.cpp:278
+#: ../src/richtext/richtextliststylepage.cpp:280
+msgid "The bullet character."
+msgstr "Punktlisttecknet."
+
+#: ../src/richtext/richtextbulletspage.cpp:212
+#: ../src/richtext/richtextliststylepage.cpp:271
+msgid "&Symbol:"
+msgstr "&Symbol:"
+
+#: ../src/richtext/richtextbulletspage.cpp:222
+#: ../src/richtext/richtextliststylepage.cpp:283
+msgid "Ch&oose..."
+msgstr "V&älj..."
+
+#: ../src/richtext/richtextbulletspage.cpp:223
+#: ../src/richtext/richtextbulletspage.cpp:225
+#: ../src/richtext/richtextliststylepage.cpp:284
+#: ../src/richtext/richtextliststylepage.cpp:286
+msgid "Click to browse for a symbol."
+msgstr "Klicka för att bläddra efter en symbol."
+
+#: ../src/richtext/richtextbulletspage.cpp:230
+#: ../src/richtext/richtextliststylepage.cpp:291
+msgid "Symbol &font:"
+msgstr "Symbol&typsnitt:"
+
+#: ../src/richtext/richtextbulletspage.cpp:235
+#: ../src/richtext/richtextbulletspage.cpp:237
+#: ../src/richtext/richtextliststylepage.cpp:297
+msgid "Available fonts."
+msgstr "Tillgängliga typsnitt."
+
+#: ../src/richtext/richtextbulletspage.cpp:242
+#: ../src/richtext/richtextliststylepage.cpp:302
+msgid "S&tandard bullet name:"
+msgstr "S&tandard punktlisttecken:"
+
+#: ../src/richtext/richtextbulletspage.cpp:247
+#: ../src/richtext/richtextbulletspage.cpp:249
+#: ../src/richtext/richtextliststylepage.cpp:307
+#: ../src/richtext/richtextliststylepage.cpp:309
+msgid "A standard bullet name."
+msgstr "Ett standard punktlisttecken."
+
+#: ../src/richtext/richtextbulletspage.cpp:254
+msgid "&Number:"
+msgstr "&Nummer:"
+
+#: ../src/richtext/richtextbulletspage.cpp:258
+#: ../src/richtext/richtextbulletspage.cpp:260
+msgid "The list item number."
+msgstr "Listpostnumret."
+
+#: ../src/richtext/richtextbulletspage.cpp:266
+#: ../src/richtext/richtextbulletspage.cpp:268
+#: ../src/richtext/richtextliststylepage.cpp:475
+#: ../src/richtext/richtextliststylepage.cpp:477
+msgid "Shows a preview of the bullet settings."
+msgstr "Visar en förhandsgranskning av punktlistinställningar."
+
+#: ../src/richtext/richtextbulletspage.cpp:276
+#: ../src/richtext/richtextliststylepage.cpp:484
+msgid "(None)"
+msgstr "(Ingen)"
+
+#: ../src/richtext/richtextbulletspage.cpp:277
+#: ../src/richtext/richtextliststylepage.cpp:485
+msgid "Arabic"
+msgstr "Arabiska"
+
+#: ../src/richtext/richtextbulletspage.cpp:278
+#: ../src/richtext/richtextliststylepage.cpp:486
+msgid "Upper case letters"
+msgstr "Stora bokstäver"
+
+#: ../src/richtext/richtextbulletspage.cpp:279
+#: ../src/richtext/richtextliststylepage.cpp:487
+msgid "Lower case letters"
+msgstr "Små bokstäver"
+
+#: ../src/richtext/richtextbulletspage.cpp:280
+#: ../src/richtext/richtextliststylepage.cpp:488
+msgid "Upper case roman numerals"
+msgstr "Stora romerska siffor"
+
+#: ../src/richtext/richtextbulletspage.cpp:281
+#: ../src/richtext/richtextliststylepage.cpp:489
+msgid "Lower case roman numerals"
+msgstr "Små romerska siffor"
+
+#: ../src/richtext/richtextbulletspage.cpp:282
+#: ../src/richtext/richtextliststylepage.cpp:490
+msgid "Numbered outline"
+msgstr "Numrerad sammanfattning"
+
+#: ../src/richtext/richtextbulletspage.cpp:283
+#: ../src/richtext/richtextliststylepage.cpp:491
+msgid "Symbol"
+msgstr "Symbol"
+
+#: ../src/richtext/richtextbulletspage.cpp:284
+#: ../src/richtext/richtextliststylepage.cpp:492
+msgid "Bitmap"
+msgstr "Bitmapp"
+
+#: ../src/richtext/richtextbulletspage.cpp:285
+#: ../src/richtext/richtextliststylepage.cpp:493
+msgid "Standard"
+msgstr "Standard"
+
+#: ../src/richtext/richtextbulletspage.cpp:287
+#: ../src/richtext/richtextliststylepage.cpp:495
+msgid "*"
+msgstr "*"
+
+#: ../src/richtext/richtextbulletspage.cpp:288
+#: ../src/richtext/richtextliststylepage.cpp:496
+msgid "-"
+msgstr "-"
+
+#: ../src/richtext/richtextbulletspage.cpp:289
+#: ../src/richtext/richtextliststylepage.cpp:497
+msgid ">"
+msgstr ">"
+
+#: ../src/richtext/richtextbulletspage.cpp:290
+#: ../src/richtext/richtextliststylepage.cpp:498
+msgid "+"
+msgstr "+"
+
+#: ../src/richtext/richtextbulletspage.cpp:291
+#: ../src/richtext/richtextliststylepage.cpp:499
+msgid "~"
+msgstr "~"
+
+#: ../src/richtext/richtextctrl.cpp:859
+msgid "Drag"
+msgstr "Dra"
+
+#: ../src/richtext/richtextctrl.cpp:1338 ../src/richtext/richtextctrl.cpp:1559
+msgid "Delete Text"
+msgstr "Ta bort text"
+
+#: ../src/richtext/richtextctrl.cpp:1537
+msgid "Remove Bullet"
+msgstr "Ta bort listpunkttecken"
+
+#: ../src/richtext/richtextctrl.cpp:3070
+msgid "The text couldn't be saved."
+msgstr "Texten kunde inte sparas."
+
+#: ../src/richtext/richtextctrl.cpp:3644
+msgid "Replace"
+msgstr "Ersätt"
+
+#: ../src/richtext/richtextfontpage.cpp:146
+#: ../src/richtext/richtextsymboldlg.cpp:384
+msgid "&Font:"
+msgstr "&Typsnitt:"
+
+#: ../src/richtext/richtextfontpage.cpp:150
+#: ../src/richtext/richtextfontpage.cpp:152
+msgid "Type a font name."
+msgstr "Skriv in ett typsnittsnamn."
+
+#: ../src/richtext/richtextfontpage.cpp:158
+msgid "&Size:"
+msgstr "&Storlek:"
+
+#: ../src/richtext/richtextfontpage.cpp:165
+#: ../src/richtext/richtextfontpage.cpp:167
+msgid "Type a size in points."
+msgstr "Skriv in en storlek i punkter."
+
+#: ../src/richtext/richtextfontpage.cpp:180
+#: ../src/richtext/richtextfontpage.cpp:182
+msgid "The font size units, points or pixels."
+msgstr "Enhet för typsnittsstorlek, punkter eller pixlar."
+
+#: ../src/richtext/richtextfontpage.cpp:189
+#: ../src/richtext/richtextfontpage.cpp:191
+msgid "Lists the available fonts."
+msgstr "Listar tillgängliga typsnitt"
+
+#: ../src/richtext/richtextfontpage.cpp:196
+#: ../src/richtext/richtextfontpage.cpp:198
+msgid "Lists font sizes in points."
+msgstr "Listar typsnittstorlekar i punkter."
+
+#: ../src/richtext/richtextfontpage.cpp:207
+msgid "Font st&yle:"
+msgstr "Typsnitts&stil:"
+
+#: ../src/richtext/richtextfontpage.cpp:212
+#: ../src/richtext/richtextfontpage.cpp:214
+msgid "Select regular or italic style."
+msgstr "Välj vanlig eller kursiv stil."
+
+#: ../src/richtext/richtextfontpage.cpp:220
+msgid "Font &weight:"
+msgstr "Typsnittets &vikt."
+
+#: ../src/richtext/richtextfontpage.cpp:225
+#: ../src/richtext/richtextfontpage.cpp:227
+msgid "Select regular or bold."
+msgstr "Välj vanlig eller fet."
+
+#: ../src/richtext/richtextfontpage.cpp:233
+msgid "&Underlining:"
+msgstr "&Understrykning:"
+
+#: ../src/richtext/richtextfontpage.cpp:238
+#: ../src/richtext/richtextfontpage.cpp:240
+msgid "Select underlining or no underlining."
+msgstr "Välj understrykning eller ingen understrykning."
+
+#: ../src/richtext/richtextfontpage.cpp:248
+msgid "&Colour:"
+msgstr "F&ärg:"
+
+#: ../src/richtext/richtextfontpage.cpp:253
+#: ../src/richtext/richtextfontpage.cpp:255
+msgid "Click to change the text colour."
+msgstr "Klicka för att ändra textfärgen."
+
+#: ../src/richtext/richtextfontpage.cpp:261
+msgid "&Bg colour:"
+msgstr "&Bg-färg:"
+
+#: ../src/richtext/richtextfontpage.cpp:266
+#: ../src/richtext/richtextfontpage.cpp:268
+msgid "Click to change the text background colour."
+msgstr "Klicka för att ändra färgen för textbakgrund."
+
+#: ../src/richtext/richtextfontpage.cpp:276
+#: ../src/richtext/richtextfontpage.cpp:278
+msgid "Check to show a line through the text."
+msgstr "Kryssa i för visa en linje genom texten."
+
+#: ../src/richtext/richtextfontpage.cpp:281
+msgid "Ca&pitals"
+msgstr "&Versaler"
+
+#: ../src/richtext/richtextfontpage.cpp:283
+#: ../src/richtext/richtextfontpage.cpp:285
+msgid "Check to show the text in capitals."
+msgstr "Kryssa i för att visa texten i versaler."
+
+#: ../src/richtext/richtextfontpage.cpp:288
+msgid "Small C&apitals"
+msgstr "Kapi&täler"
+
+#: ../src/richtext/richtextfontpage.cpp:290
+#: ../src/richtext/richtextfontpage.cpp:292
+msgid "Check to show the text in small capitals."
+msgstr "Kryssa i för att visa texten i kapitäler."
+
+#: ../src/richtext/richtextfontpage.cpp:295
+msgid "Supe&rscript"
+msgstr "&Upphöjt"
+
+#: ../src/richtext/richtextfontpage.cpp:297
+#: ../src/richtext/richtextfontpage.cpp:299
+msgid "Check to show the text in superscript."
+msgstr "Kryssa i för visa texten upphöjd."
+
+#: ../src/richtext/richtextfontpage.cpp:302
+msgid "Subscrip&t"
+msgstr "&Nedsänkt"
+
+#: ../src/richtext/richtextfontpage.cpp:304
+#: ../src/richtext/richtextfontpage.cpp:306
+msgid "Check to show the text in subscript."
+msgstr "Kryssa i för att visa texten nedsänkt."
+
+#: ../src/richtext/richtextfontpage.cpp:312
+msgid "Rig&ht-to-left"
+msgstr ""
+
+#: ../src/richtext/richtextfontpage.cpp:314
+#: ../src/richtext/richtextfontpage.cpp:316
+#, fuzzy
+msgid "Check to indicate right-to-left text layout."
+msgstr "Klicka för att ändra textfärgen."
+
+#: ../src/richtext/richtextfontpage.cpp:319
+msgid "Suppress hyphe&nation"
+msgstr ""
+
+#: ../src/richtext/richtextfontpage.cpp:321
+#: ../src/richtext/richtextfontpage.cpp:323
+msgid "Check to suppress hyphenation."
+msgstr ""
+
+#: ../src/richtext/richtextfontpage.cpp:329
+#: ../src/richtext/richtextfontpage.cpp:331
+msgid "Shows a preview of the font settings."
+msgstr "Visar en förhandsgranskning av typsnittsinställningar."
+
+#: ../src/richtext/richtextfontpage.cpp:348
+#: ../src/richtext/richtextfontpage.cpp:352
+#: ../src/richtext/richtextfontpage.cpp:356
+#: ../src/richtext/richtextformatdlg.cpp:873
+#: ../src/richtext/richtextindentspage.cpp:273
+#: ../src/richtext/richtextindentspage.cpp:285
+#: ../src/richtext/richtextindentspage.cpp:286
+#: ../src/richtext/richtextindentspage.cpp:310
+#: ../src/richtext/richtextindentspage.cpp:325
+#: ../src/richtext/richtextliststylepage.cpp:451
+#: ../src/richtext/richtextliststylepage.cpp:463
+#: ../src/richtext/richtextliststylepage.cpp:464
+msgid "(none)"
+msgstr "(ingen)"
+
+#: ../src/richtext/richtextfontpage.cpp:349
+#: ../src/richtext/richtextfontpage.cpp:353
+msgid "Regular"
+msgstr "Vanlig"
+
+#: ../src/richtext/richtextfontpage.cpp:357
+msgid "Not underlined"
+msgstr "Inte understruken"
+
+#: ../src/richtext/richtextformatdlg.cpp:341
+msgid "Indents && Spacing"
+msgstr "Indrag && avstånd"
+
+#: ../src/richtext/richtextformatdlg.cpp:346
+msgid "Tabs"
+msgstr "Tabbar"
+
+#: ../src/richtext/richtextformatdlg.cpp:351
+msgid "Bullets"
+msgstr "Punktlisttecken"
+
+#: ../src/richtext/richtextformatdlg.cpp:356
+msgid "List Style"
+msgstr "Liststil"
+
+#: ../src/richtext/richtextformatdlg.cpp:366
+#: ../src/richtext/richtextmarginspage.cpp:170
+msgid "Margins"
+msgstr "Marginaler"
+
+#: ../src/richtext/richtextformatdlg.cpp:371
+msgid "Borders"
+msgstr "Ramar"
+
+#: ../src/richtext/richtextformatdlg.cpp:765
+msgid "Colour"
+msgstr "Färg"
+
+#: ../src/richtext/richtextindentspage.cpp:127
+#: ../src/richtext/richtextliststylepage.cpp:322
+msgid "&Alignment"
+msgstr "&Justering"
+
+#: ../src/richtext/richtextindentspage.cpp:138
+#: ../src/richtext/richtextliststylepage.cpp:331
+msgid "&Left"
+msgstr "&Vänster"
+
+#: ../src/richtext/richtextindentspage.cpp:140
+#: ../src/richtext/richtextindentspage.cpp:142
+#: ../src/richtext/richtextliststylepage.cpp:333
+#: ../src/richtext/richtextliststylepage.cpp:335
+msgid "Left-align text."
+msgstr "Vänsterjustera text."
+
+#: ../src/richtext/richtextindentspage.cpp:145
+#: ../src/richtext/richtextliststylepage.cpp:338
+msgid "&Right"
+msgstr "&Höger"
+
+#: ../src/richtext/richtextindentspage.cpp:147
+#: ../src/richtext/richtextindentspage.cpp:149
+#: ../src/richtext/richtextliststylepage.cpp:340
+#: ../src/richtext/richtextliststylepage.cpp:342
+msgid "Right-align text."
+msgstr "Högerjustera text."
+
+#: ../src/richtext/richtextindentspage.cpp:152
+#: ../src/richtext/richtextliststylepage.cpp:345
+msgid "&Justified"
+msgstr "Marginal&justerad"
+
+#: ../src/richtext/richtextindentspage.cpp:154
+#: ../src/richtext/richtextindentspage.cpp:156
+#: ../src/richtext/richtextliststylepage.cpp:347
+#: ../src/richtext/richtextliststylepage.cpp:349
+msgid "Justify text left and right."
+msgstr "Justera text vänster och höger."
+
+#: ../src/richtext/richtextindentspage.cpp:159
+#: ../src/richtext/richtextliststylepage.cpp:352
+msgid "Cen&tred"
+msgstr "Cen&trerad"
+
+#: ../src/richtext/richtextindentspage.cpp:161
+#: ../src/richtext/richtextindentspage.cpp:163
+#: ../src/richtext/richtextliststylepage.cpp:354
+#: ../src/richtext/richtextliststylepage.cpp:356
+msgid "Centre text."
+msgstr "Centrera text."
+
+#: ../src/richtext/richtextindentspage.cpp:166
+#: ../src/richtext/richtextliststylepage.cpp:359
+msgid "&Indeterminate"
+msgstr "&Obestämd"
+
+#: ../src/richtext/richtextindentspage.cpp:168
+#: ../src/richtext/richtextindentspage.cpp:170
+#: ../src/richtext/richtextliststylepage.cpp:361
+#: ../src/richtext/richtextliststylepage.cpp:363
+msgid "Use the current alignment setting."
+msgstr "Använd nuvarande justeringsinställningar."
+
+#: ../src/richtext/richtextindentspage.cpp:183
+#: ../src/richtext/richtextliststylepage.cpp:375
+msgid "&Indentation (tenths of a mm)"
+msgstr "&Indrag (tiondelar av mm)"
+
+#: ../src/richtext/richtextindentspage.cpp:198
+#: ../src/richtext/richtextindentspage.cpp:200
+#: ../src/richtext/richtextliststylepage.cpp:388
+#: ../src/richtext/richtextliststylepage.cpp:390
+msgid "The left indent."
+msgstr "Vänster indrag."
+
+#: ../src/richtext/richtextindentspage.cpp:203
+#: ../src/richtext/richtextliststylepage.cpp:393
+msgid "Left (&first line):"
+msgstr "Vänster (&första raden):"
+
+#: ../src/richtext/richtextindentspage.cpp:207
+#: ../src/richtext/richtextindentspage.cpp:209
+#: ../src/richtext/richtextliststylepage.cpp:397
+#: ../src/richtext/richtextliststylepage.cpp:399
+msgid "The first line indent."
+msgstr "Indrag på första raden."
+
+#: ../src/richtext/richtextindentspage.cpp:216
+#: ../src/richtext/richtextindentspage.cpp:218
+#: ../src/richtext/richtextliststylepage.cpp:406
+#: ../src/richtext/richtextliststylepage.cpp:408
+msgid "The right indent."
+msgstr "Höger indrag."
+
+#: ../src/richtext/richtextindentspage.cpp:221
+msgid "&Outline level:"
+msgstr "&Sammanfattningsnivå:"
+
+#: ../src/richtext/richtextindentspage.cpp:226
+#: ../src/richtext/richtextindentspage.cpp:228
+msgid "The outline level."
+msgstr "Sammanfattningsnivån."
+
+#: ../src/richtext/richtextindentspage.cpp:241
+#: ../src/richtext/richtextliststylepage.cpp:420
+msgid "&Spacing (tenths of a mm)"
+msgstr "&Avstånd (tiondelar av mm)"
+
+#: ../src/richtext/richtextindentspage.cpp:252
+msgid "&Before a paragraph:"
+msgstr "&Före ett stycke:"
+
+#: ../src/richtext/richtextindentspage.cpp:256
+#: ../src/richtext/richtextindentspage.cpp:258
+#: ../src/richtext/richtextliststylepage.cpp:433
+#: ../src/richtext/richtextliststylepage.cpp:435
+msgid "The spacing before the paragraph."
+msgstr "Avståndet före stycket."
+
+#: ../src/richtext/richtextindentspage.cpp:261
+msgid "&After a paragraph:"
+msgstr "&Efter ett stycke:"
+
+#: ../src/richtext/richtextindentspage.cpp:266
+#: ../src/richtext/richtextliststylepage.cpp:442
+#: ../src/richtext/richtextliststylepage.cpp:444
+msgid "The spacing after the paragraph."
+msgstr "Avståndet efter stycket."
+
+#: ../src/richtext/richtextindentspage.cpp:269
+msgid "L&ine spacing:"
+msgstr "&Radavstånd:"
+
+#: ../src/richtext/richtextindentspage.cpp:274
+#: ../src/richtext/richtextliststylepage.cpp:452
+msgid "Single"
+msgstr "Enkel"
+
+#: ../src/richtext/richtextindentspage.cpp:275
+#: ../src/richtext/richtextliststylepage.cpp:453
+msgid "1.1"
+msgstr "1.1"
+
+#: ../src/richtext/richtextindentspage.cpp:276
+#: ../src/richtext/richtextliststylepage.cpp:454
+msgid "1.2"
+msgstr "1.2"
+
+#: ../src/richtext/richtextindentspage.cpp:277
+#: ../src/richtext/richtextliststylepage.cpp:455
+msgid "1.3"
+msgstr "1.3"
+
+#: ../src/richtext/richtextindentspage.cpp:278
+#: ../src/richtext/richtextliststylepage.cpp:456
+msgid "1.4"
+msgstr "1.4"
+
+#: ../src/richtext/richtextindentspage.cpp:279
+#: ../src/richtext/richtextliststylepage.cpp:457
+msgid "1.5"
+msgstr "1.5"
+
+#: ../src/richtext/richtextindentspage.cpp:280
+#: ../src/richtext/richtextliststylepage.cpp:458
+msgid "1.6"
+msgstr "1.6"
+
+#: ../src/richtext/richtextindentspage.cpp:281
+#: ../src/richtext/richtextliststylepage.cpp:459
+msgid "1.7"
+msgstr "1.7"
+
+#: ../src/richtext/richtextindentspage.cpp:282
+#: ../src/richtext/richtextliststylepage.cpp:460
+msgid "1.8"
+msgstr "1.8"
+
+#: ../src/richtext/richtextindentspage.cpp:283
+#: ../src/richtext/richtextliststylepage.cpp:461
+msgid "1.9"
+msgstr "1.9"
+
+#: ../src/richtext/richtextindentspage.cpp:284
+#: ../src/richtext/richtextliststylepage.cpp:462
+msgid "2"
+msgstr "2"
+
+#: ../src/richtext/richtextindentspage.cpp:287
+#: ../src/richtext/richtextindentspage.cpp:289
+#: ../src/richtext/richtextliststylepage.cpp:465
+#: ../src/richtext/richtextliststylepage.cpp:467
+msgid "The line spacing."
+msgstr "Radavståndet."
+
+#: ../src/richtext/richtextindentspage.cpp:292
+msgid "&Page Break"
+msgstr "&Sidbrytning"
+
+#: ../src/richtext/richtextindentspage.cpp:294
+#: ../src/richtext/richtextindentspage.cpp:296
+msgid "Inserts a page break before the paragraph."
+msgstr "Lägger till en sidbrytning före stycket."
+
+#: ../src/richtext/richtextindentspage.cpp:302
+#: ../src/richtext/richtextindentspage.cpp:304
+msgid "Shows a preview of the paragraph settings."
+msgstr "Visar förhandsgranskning av styckeinställningarna."
+
+#: ../src/richtext/richtextliststylepage.cpp:182
+msgid "&List level:"
+msgstr "&Listnivå:"
+
+#: ../src/richtext/richtextliststylepage.cpp:186
+#: ../src/richtext/richtextliststylepage.cpp:188
+msgid "Selects the list level to edit."
+msgstr "Välj listnivå att redigera."
+
+#: ../src/richtext/richtextliststylepage.cpp:193
+msgid "&Font for Level..."
+msgstr "&Typsnitt för nivå..."
+
+#: ../src/richtext/richtextliststylepage.cpp:194
+#: ../src/richtext/richtextliststylepage.cpp:196
+msgid "Click to choose the font for this level."
+msgstr "Klicka för att välja typsnitt för den här nivån."
+
+#: ../src/richtext/richtextliststylepage.cpp:312
+msgid "Bullet style"
+msgstr "Punktliststil"
+
+#: ../src/richtext/richtextliststylepage.cpp:429
+msgid "Before a paragraph:"
+msgstr "Före ett stycke:"
+
+#: ../src/richtext/richtextliststylepage.cpp:438
+msgid "After a paragraph:"
+msgstr "Efter ett stycke:"
+
+#: ../src/richtext/richtextliststylepage.cpp:447
+msgid "Line spacing:"
+msgstr "Radavstånd:"
+
+#: ../src/richtext/richtextliststylepage.cpp:470
+msgid "Spacing"
+msgstr "Avstånd"
+
+#: ../src/richtext/richtextmarginspage.cpp:193
+#: ../src/richtext/richtextmarginspage.cpp:195
+msgid "The left margin size."
+msgstr "Storlek för vänster marginal."
+
+#: ../src/richtext/richtextmarginspage.cpp:203
+#: ../src/richtext/richtextmarginspage.cpp:205
+msgid "Units for the left margin."
+msgstr "Enheter för vänster marginal."
+
+#: ../src/richtext/richtextmarginspage.cpp:218
+#: ../src/richtext/richtextmarginspage.cpp:220
+msgid "The right margin size."
+msgstr "Storlek för höger marginal."
+
+#: ../src/richtext/richtextmarginspage.cpp:228
+#: ../src/richtext/richtextmarginspage.cpp:230
+msgid "Units for the right margin."
+msgstr "Enheter för höger marginal."
+
+#: ../src/richtext/richtextmarginspage.cpp:241
+#: ../src/richtext/richtextmarginspage.cpp:243
+msgid "The top margin size."
+msgstr "Storlek för övre marginal."
+
+#: ../src/richtext/richtextmarginspage.cpp:251
+#: ../src/richtext/richtextmarginspage.cpp:253
+msgid "Units for the top margin."
+msgstr "Enheter för övre marginal."
+
+#: ../src/richtext/richtextmarginspage.cpp:266
+#: ../src/richtext/richtextmarginspage.cpp:268
+msgid "The bottom margin size."
+msgstr "Storlek för undre marginal."
+
+#: ../src/richtext/richtextmarginspage.cpp:276
+#: ../src/richtext/richtextmarginspage.cpp:278
+msgid "Units for the bottom margin."
+msgstr "Enheter för undre marginal."
+
+#: ../src/richtext/richtextmarginspage.cpp:284
+msgid "Padding"
+msgstr "Utfyllnad"
+
+#: ../src/richtext/richtextmarginspage.cpp:307
+#: ../src/richtext/richtextmarginspage.cpp:309
+msgid "The left padding size."
+msgstr "Vänster utfyllnadsstorlek."
+
+#: ../src/richtext/richtextmarginspage.cpp:317
+#: ../src/richtext/richtextmarginspage.cpp:319
+msgid "Units for the left padding."
+msgstr "Enheter för vänster utfyllnadsstorlek."
+
+#: ../src/richtext/richtextmarginspage.cpp:332
+#: ../src/richtext/richtextmarginspage.cpp:334
+msgid "The right padding size."
+msgstr "Höger utfyllnadsstorlek."
+
+#: ../src/richtext/richtextmarginspage.cpp:342
+#: ../src/richtext/richtextmarginspage.cpp:344
+msgid "Units for the right padding."
+msgstr "Enheter för höger utfyllnadsstorlek."
+
+#: ../src/richtext/richtextmarginspage.cpp:355
+#: ../src/richtext/richtextmarginspage.cpp:357
+msgid "The top padding size."
+msgstr "Övre utfyllnadsstorlek."
+
+#: ../src/richtext/richtextmarginspage.cpp:365
+#: ../src/richtext/richtextmarginspage.cpp:367
+msgid "Units for the top padding."
+msgstr "Enheter för övre utfyllnadsstorlek."
+
+#: ../src/richtext/richtextmarginspage.cpp:380
+#: ../src/richtext/richtextmarginspage.cpp:382
+msgid "The bottom padding size."
+msgstr "Undre utfyllnadsstorlek."
+
+#: ../src/richtext/richtextmarginspage.cpp:390
+#: ../src/richtext/richtextmarginspage.cpp:392
+msgid "Units for the bottom padding."
+msgstr "Enheter för undre utfyllnadsstorlek."
+
+#: ../src/richtext/richtextprint.cpp:592
+msgid " Preview"
+msgstr " Förhandsgranska"
+
+#: ../src/richtext/richtextsizepage.cpp:228
+msgid "Floating"
+msgstr "Flytande"
+
+#: ../src/richtext/richtextsizepage.cpp:243
+msgid "&Floating mode:"
+msgstr "&Flytande läge:"
+
+#: ../src/richtext/richtextsizepage.cpp:252
+#: ../src/richtext/richtextsizepage.cpp:254
+msgid "How the object will float relative to the text."
+msgstr "Hur objektet ska flyta i förhållande till texten."
+
+#: ../src/richtext/richtextsizepage.cpp:265
+msgid "Alignment"
+msgstr "Justering"
+
+#: ../src/richtext/richtextsizepage.cpp:277
+msgid "&Vertical alignment:"
+msgstr "&Vertical justering:"
+
+#: ../src/richtext/richtextsizepage.cpp:279
+#: ../src/richtext/richtextsizepage.cpp:281
+msgid "Enable vertical alignment."
+msgstr "Slå på vertikal justering."
+
+#: ../src/richtext/richtextsizepage.cpp:286
+msgid "Centred"
+msgstr "Centrerad"
+
+#: ../src/richtext/richtextsizepage.cpp:290
+#: ../src/richtext/richtextsizepage.cpp:292
+msgid "Vertical alignment."
+msgstr "Vertikal justering."
+
+#: ../src/richtext/richtextsizepage.cpp:316
+#: ../src/richtext/richtextsizepage.cpp:323
+msgid "&Width:"
+msgstr "&Bredd:"
+
+#: ../src/richtext/richtextsizepage.cpp:318
+#: ../src/richtext/richtextsizepage.cpp:320
+msgid "Enable the width value."
+msgstr "Slå på breddvärdet."
+
+#: ../src/richtext/richtextsizepage.cpp:331
+#: ../src/richtext/richtextsizepage.cpp:333
+msgid "The object width."
+msgstr "Objektbredden."
+
+#: ../src/richtext/richtextsizepage.cpp:342
+#: ../src/richtext/richtextsizepage.cpp:344
+msgid "Units for the object width."
+msgstr "Enheter för objektvidd."
+
+#: ../src/richtext/richtextsizepage.cpp:350
+#: ../src/richtext/richtextsizepage.cpp:357
+msgid "&Height:"
+msgstr "&Höjd:"
+
+#: ../src/richtext/richtextsizepage.cpp:352
+#: ../src/richtext/richtextsizepage.cpp:354
+#: ../src/richtext/richtextsizepage.cpp:464
+#: ../src/richtext/richtextsizepage.cpp:466
+msgid "Enable the height value."
+msgstr "Slå på höjdvärdet."
+
+#: ../src/richtext/richtextsizepage.cpp:365
+#: ../src/richtext/richtextsizepage.cpp:367
+msgid "The object height."
+msgstr "Objekthöjden."
+
+#: ../src/richtext/richtextsizepage.cpp:376
+#: ../src/richtext/richtextsizepage.cpp:378
+msgid "Units for the object height."
+msgstr "Enheter för objekthöjd."
+
+#: ../src/richtext/richtextsizepage.cpp:381
+msgid "Min width:"
+msgstr "Min bredd:"
+
+#: ../src/richtext/richtextsizepage.cpp:383
+#: ../src/richtext/richtextsizepage.cpp:385
+msgid "Enable the minimum width value."
+msgstr "Slå på minumbreddvärdet."
+
+#: ../src/richtext/richtextsizepage.cpp:392
+#: ../src/richtext/richtextsizepage.cpp:394
+msgid "The object minimum width."
+msgstr "Objektets minimumbredd."
+
+#: ../src/richtext/richtextsizepage.cpp:403
+#: ../src/richtext/richtextsizepage.cpp:405
+msgid "Units for the minimum object width."
+msgstr "Enheter för objektets minimumbredd."
+
+#: ../src/richtext/richtextsizepage.cpp:408
+msgid "Min height:"
+msgstr "Min höjd:"
+
+#: ../src/richtext/richtextsizepage.cpp:410
+#: ../src/richtext/richtextsizepage.cpp:412
+msgid "Enable the minimum height value."
+msgstr "Slå på minimumhöjdvärde."
+
+#: ../src/richtext/richtextsizepage.cpp:419
+#: ../src/richtext/richtextsizepage.cpp:421
+msgid "The object minimum height."
+msgstr "Objektets minimumhöjd."
+
+#: ../src/richtext/richtextsizepage.cpp:430
+#: ../src/richtext/richtextsizepage.cpp:432
+msgid "Units for the minimum object height."
+msgstr "Enheter för objektets minimumhöjd."
+
+#: ../src/richtext/richtextsizepage.cpp:435
+msgid "Max width:"
+msgstr "Max bredd:"
+
+#: ../src/richtext/richtextsizepage.cpp:437
+#: ../src/richtext/richtextsizepage.cpp:439
+msgid "Enable the maximum width value."
+msgstr "Slå på objektets maximumbredd."
+
+#: ../src/richtext/richtextsizepage.cpp:446
+#: ../src/richtext/richtextsizepage.cpp:448
+msgid "The object maximum width."
+msgstr "Objektets maximumbredd."
+
+#: ../src/richtext/richtextsizepage.cpp:457
+#: ../src/richtext/richtextsizepage.cpp:459
+msgid "Units for the maximum object width."
+msgstr "Enheter för objektets maximumbredd."
+
+#: ../src/richtext/richtextsizepage.cpp:462
+msgid "Max height:"
+msgstr "Max höjd:"
+
+#: ../src/richtext/richtextsizepage.cpp:473
+#: ../src/richtext/richtextsizepage.cpp:475
+msgid "The object maximum height."
+msgstr "Objektets maximumhöjd."
+
+#: ../src/richtext/richtextsizepage.cpp:484
+#: ../src/richtext/richtextsizepage.cpp:486
+msgid "Units for the maximum object height."
+msgstr "Enheter för objektets maximumhöjd."
+
+#: ../src/richtext/richtextsizepage.cpp:495
+msgid "Position"
+msgstr "Position"
+
+#: ../src/richtext/richtextsizepage.cpp:513
+msgid "&Position mode:"
+msgstr "&Positionsläge:"
+
+#: ../src/richtext/richtextsizepage.cpp:517
+#: ../src/richtext/richtextsizepage.cpp:522
+msgid "Static"
+msgstr "Statiskt"
+
+#: ../src/richtext/richtextsizepage.cpp:518
+msgid "Relative"
+msgstr "Relativt"
+
+#: ../src/richtext/richtextsizepage.cpp:519
+msgid "Absolute"
+msgstr "Absolut"
+
+#: ../src/richtext/richtextsizepage.cpp:520
+msgid "Fixed"
+msgstr "Fixerat"
+
+#: ../src/richtext/richtextsizepage.cpp:533
+#: ../src/richtext/richtextsizepage.cpp:535
+#: ../src/richtext/richtextsizepage.cpp:547
+#: ../src/richtext/richtextsizepage.cpp:549
+msgid "The left position."
+msgstr "Vänster position."
+
+#: ../src/richtext/richtextsizepage.cpp:558
+#: ../src/richtext/richtextsizepage.cpp:560
+msgid "Units for the left position."
+msgstr "Enheter för vänster position."
+
+#: ../src/richtext/richtextsizepage.cpp:568
+#: ../src/richtext/richtextsizepage.cpp:570
+#: ../src/richtext/richtextsizepage.cpp:582
+#: ../src/richtext/richtextsizepage.cpp:584
+msgid "The top position."
+msgstr "Övre position."
+
+#: ../src/richtext/richtextsizepage.cpp:593
+#: ../src/richtext/richtextsizepage.cpp:595
+msgid "Units for the top position."
+msgstr "Enheter för övre position."
+
+#: ../src/richtext/richtextsizepage.cpp:603
+#: ../src/richtext/richtextsizepage.cpp:605
+#: ../src/richtext/richtextsizepage.cpp:617
+#: ../src/richtext/richtextsizepage.cpp:619
+msgid "The right position."
+msgstr "Höger position."
+
+#: ../src/richtext/richtextsizepage.cpp:628
+#: ../src/richtext/richtextsizepage.cpp:630
+msgid "Units for the right position."
+msgstr "Enheter för höger position."
+
+#: ../src/richtext/richtextsizepage.cpp:638
+#: ../src/richtext/richtextsizepage.cpp:640
+#: ../src/richtext/richtextsizepage.cpp:652
+#: ../src/richtext/richtextsizepage.cpp:654
+msgid "The bottom position."
+msgstr "Undre position."
+
+#: ../src/richtext/richtextsizepage.cpp:663
+#: ../src/richtext/richtextsizepage.cpp:665
+msgid "Units for the bottom position."
+msgstr "Enheter för undre position."
+
+#: ../src/richtext/richtextsizepage.cpp:671
+msgid "&Move the object to:"
+msgstr "&Flytta objektet till:"
+
+#: ../src/richtext/richtextsizepage.cpp:674
+msgid "&Previous Paragraph"
+msgstr "&Föregående stycke"
+
+#: ../src/richtext/richtextsizepage.cpp:675
+#: ../src/richtext/richtextsizepage.cpp:677
+msgid "Moves the object to the previous paragraph."
+msgstr "Flyttar objektet till föregående stycke."
+
+#: ../src/richtext/richtextsizepage.cpp:680
+msgid "&Next Paragraph"
+msgstr "&Nästa stycke"
+
+#: ../src/richtext/richtextsizepage.cpp:681
+#: ../src/richtext/richtextsizepage.cpp:683
+msgid "Moves the object to the next paragraph."
+msgstr "Flyttar objektet till nästa stycke."
+
+#: ../src/richtext/richtextstyledlg.cpp:193
+msgid "&Styles:"
+msgstr "&Stilar:"
+
+#: ../src/richtext/richtextstyledlg.cpp:197
+#: ../src/richtext/richtextstyledlg.cpp:199
+msgid "The available styles."
+msgstr "Tillgängliga stilar."
+
+#: ../src/richtext/richtextstyledlg.cpp:205
+#: ../src/richtext/richtextstyledlg.cpp:217
+msgid " "
+msgstr " "
+
+#: ../src/richtext/richtextstyledlg.cpp:209
+#: ../src/richtext/richtextstyledlg.cpp:211
+msgid "The style preview."
+msgstr "Stilförhandsgranskningen."
+
+#: ../src/richtext/richtextstyledlg.cpp:220
+msgid "New &Character Style..."
+msgstr "Ny &teckenstil..."
+
+#: ../src/richtext/richtextstyledlg.cpp:221
+#: ../src/richtext/richtextstyledlg.cpp:223
+msgid "Click to create a new character style."
+msgstr "Klicka för att skapa en ny teckenstil."
+
+#: ../src/richtext/richtextstyledlg.cpp:226
+msgid "New &Paragraph Style..."
+msgstr "Ny &styckestil..."
+
+#: ../src/richtext/richtextstyledlg.cpp:227
+#: ../src/richtext/richtextstyledlg.cpp:229
+msgid "Click to create a new paragraph style."
+msgstr "Klicka för att skapa en ny styckestil."
+
+#: ../src/richtext/richtextstyledlg.cpp:232
+msgid "New &List Style..."
+msgstr "Ny &liststil..."
+
+#: ../src/richtext/richtextstyledlg.cpp:233
+#: ../src/richtext/richtextstyledlg.cpp:235
+msgid "Click to create a new list style."
+msgstr "Klicka för att skapa en ny liststil."
+
+#: ../src/richtext/richtextstyledlg.cpp:238
+msgid "New &Box Style..."
+msgstr "Ny &lådstil..."
+
+#: ../src/richtext/richtextstyledlg.cpp:239
+#: ../src/richtext/richtextstyledlg.cpp:241
+msgid "Click to create a new box style."
+msgstr "Klicka för att skapa en ny lådstil."
+
+#: ../src/richtext/richtextstyledlg.cpp:246
+msgid "&Apply Style"
+msgstr "&Använd stil"
+
+#: ../src/richtext/richtextstyledlg.cpp:247
+#: ../src/richtext/richtextstyledlg.cpp:249
+msgid "Click to apply the selected style."
+msgstr "Klicka för att använda den valda stilen."
+
+#: ../src/richtext/richtextstyledlg.cpp:252
+msgid "&Rename Style..."
+msgstr "&Byt namn på stil..."
+
+#: ../src/richtext/richtextstyledlg.cpp:253
+#: ../src/richtext/richtextstyledlg.cpp:255
+msgid "Click to rename the selected style."
+msgstr "Klicka för att döpa om stilen."
+
+#: ../src/richtext/richtextstyledlg.cpp:258
+msgid "&Edit Style..."
+msgstr "&Redigera stil..."
+
+#: ../src/richtext/richtextstyledlg.cpp:259
+#: ../src/richtext/richtextstyledlg.cpp:261
+msgid "Click to edit the selected style."
+msgstr "Klicka för att redigera stilen."
+
+#: ../src/richtext/richtextstyledlg.cpp:264
+msgid "&Delete Style..."
+msgstr "Ta &bort stil..."
+
+#: ../src/richtext/richtextstyledlg.cpp:265
+#: ../src/richtext/richtextstyledlg.cpp:267
+msgid "Click to delete the selected style."
+msgstr "Klicka för att ta bort stilen."
+
+#: ../src/richtext/richtextstyledlg.cpp:274
+#: ../src/richtext/richtextstyledlg.cpp:276
+msgid "Click to close this window."
+msgstr "Klicka för att stänga fönstret."
+
+#: ../src/richtext/richtextstyledlg.cpp:282
+msgid "&Restart numbering"
+msgstr "&Börja om numrering"
+
+#: ../src/richtext/richtextstyledlg.cpp:284
+#: ../src/richtext/richtextstyledlg.cpp:286
+msgid "Check to restart numbering."
+msgstr "Kryssa i för att börja om numrering."
+
+#: ../src/richtext/richtextstyledlg.cpp:601
+msgid "Enter a character style name"
+msgstr "Ange namn för teckenstil"
+
+#: ../src/richtext/richtextstyledlg.cpp:601
+#: ../src/richtext/richtextstyledlg.cpp:606
+#: ../src/richtext/richtextstyledlg.cpp:649
+#: ../src/richtext/richtextstyledlg.cpp:654
+#: ../src/richtext/richtextstyledlg.cpp:815
+#: ../src/richtext/richtextstyledlg.cpp:820
+#: ../src/richtext/richtextstyledlg.cpp:888
+#: ../src/richtext/richtextstyledlg.cpp:896
+#: ../src/richtext/richtextstyledlg.cpp:929
+#: ../src/richtext/richtextstyledlg.cpp:934
+msgid "New Style"
+msgstr "Ny stil"
+
+#: ../src/richtext/richtextstyledlg.cpp:606
+#: ../src/richtext/richtextstyledlg.cpp:654
+#: ../src/richtext/richtextstyledlg.cpp:820
+#: ../src/richtext/richtextstyledlg.cpp:896
+#: ../src/richtext/richtextstyledlg.cpp:934
+msgid "Sorry, that name is taken. Please choose another."
+msgstr "Namnet är upptaget. Välj ett annat."
+
+#: ../src/richtext/richtextstyledlg.cpp:649
+msgid "Enter a paragraph style name"
+msgstr "Ange namn för styckestil"
+
+#: ../src/richtext/richtextstyledlg.cpp:777
+#, c-format
+msgid "Delete style %s?"
+msgstr "Ta bort stil %s?"
+
+#: ../src/richtext/richtextstyledlg.cpp:777
+msgid "Delete Style"
+msgstr "Ta bort stil"
+
+#: ../src/richtext/richtextstyledlg.cpp:815
+msgid "Enter a list style name"
+msgstr "Ange namn för liststil"
+
+#: ../src/richtext/richtextstyledlg.cpp:888
+msgid "Enter a new style name"
+msgstr "Ange ett nytt stilnamn"
+
+#: ../src/richtext/richtextstyledlg.cpp:929
+msgid "Enter a box style name"
+msgstr "Ange namn för lådstil"
+
+#: ../src/richtext/richtextstylepage.cpp:109
+#: ../src/richtext/richtextstylepage.cpp:111
+msgid "The style name."
+msgstr "Stilens namn."
+
+#: ../src/richtext/richtextstylepage.cpp:114
+msgid "&Based on:"
+msgstr "&Baserad på:"
+
+#: ../src/richtext/richtextstylepage.cpp:119
+#: ../src/richtext/richtextstylepage.cpp:121
+msgid "The style on which this style is based."
+msgstr "Stilen som den här stilen är baserad på."
+
+#: ../src/richtext/richtextstylepage.cpp:124
+msgid "&Next style:"
+msgstr "&Nästa stil:"
+
+#: ../src/richtext/richtextstylepage.cpp:129
+#: ../src/richtext/richtextstylepage.cpp:131
+msgid "The default style for the next paragraph."
+msgstr "Förvald stil för nästa stycke."
+
+#: ../src/richtext/richtextstyles.cpp:1057
+msgid "All styles"
+msgstr "Alla stilar"
+
+#: ../src/richtext/richtextstyles.cpp:1058
+msgid "Paragraph styles"
+msgstr "Styckestilar"
+
+#: ../src/richtext/richtextstyles.cpp:1059
+msgid "Character styles"
+msgstr "Teckenstilar"
+
+#: ../src/richtext/richtextstyles.cpp:1060
+msgid "List styles"
+msgstr "Liststilar"
+
+#: ../src/richtext/richtextstyles.cpp:1061
+msgid "Box styles"
+msgstr "Lådstilar"
+
+#: ../src/richtext/richtextsymboldlg.cpp:389
+#: ../src/richtext/richtextsymboldlg.cpp:391
+msgid "The font from which to take the symbol."
+msgstr "Typsnitt att hämta symbolen från."
+
+#: ../src/richtext/richtextsymboldlg.cpp:396
+msgid "&Subset:"
+msgstr "&Delmängd:"
+
+#: ../src/richtext/richtextsymboldlg.cpp:401
+#: ../src/richtext/richtextsymboldlg.cpp:403
+msgid "Shows a Unicode subset."
+msgstr "Visar en Unicode-delmängd"
+
+#: ../src/richtext/richtextsymboldlg.cpp:412
+msgid "xxxx"
+msgstr "xxxx"
+
+#: ../src/richtext/richtextsymboldlg.cpp:417
+msgid "&Character code:"
+msgstr "&Teckenkod:"
+
+#: ../src/richtext/richtextsymboldlg.cpp:421
+#: ../src/richtext/richtextsymboldlg.cpp:423
+msgid "The character code."
+msgstr "Teckenkoden."
+
+#: ../src/richtext/richtextsymboldlg.cpp:428
+msgid "&From:"
+msgstr "&Från:"
+
+#: ../src/richtext/richtextsymboldlg.cpp:433
+#: ../src/richtext/richtextsymboldlg.cpp:434
+#: ../src/richtext/richtextsymboldlg.cpp:435
+msgid "Unicode"
+msgstr "Unicode"
+
+#: ../src/richtext/richtextsymboldlg.cpp:436
+#: ../src/richtext/richtextsymboldlg.cpp:438
+msgid "The range to show."
+msgstr "Räckvidden att visa."
+
+#: ../src/richtext/richtextsymboldlg.cpp:444
+msgid "Insert"
+msgstr "Sätt in"
+
+#: ../src/richtext/richtextsymboldlg.cpp:478
+msgid "(Normal text)"
+msgstr "(Normal text)"
+
+#: ../src/richtext/richtexttabspage.cpp:109
+msgid "&Position (tenths of a mm):"
+msgstr "&Position (tiondelar av mm):"
+
+#: ../src/richtext/richtexttabspage.cpp:113
+#: ../src/richtext/richtexttabspage.cpp:115
+msgid "The tab position."
+msgstr "Tabbpositionen."
+
+#: ../src/richtext/richtexttabspage.cpp:119
+msgid "The tab positions."
+msgstr "Tabbpositionerna."
+
+#: ../src/richtext/richtexttabspage.cpp:132
+#: ../src/richtext/richtexttabspage.cpp:134
+msgid "Click to create a new tab position."
+msgstr "Klicka för att skapa en ny tabbposition"
+
+#: ../src/richtext/richtexttabspage.cpp:138
+#: ../src/richtext/richtexttabspage.cpp:140
+msgid "Click to delete the selected tab position."
+msgstr "Klicka för att ta bort tabbpositionen."
+
+#: ../src/richtext/richtexttabspage.cpp:143
+msgid "Delete A&ll"
+msgstr "Ta bort a&llt"
+
+#: ../src/richtext/richtexttabspage.cpp:144
+#: ../src/richtext/richtexttabspage.cpp:146
+msgid "Click to delete all tab positions."
+msgstr "Klicka för att ta bort alla tabbpositioner."
+
+#: ../src/univ/theme.cpp:110
+msgid "Failed to initialize GUI: no built-in themes found."
+msgstr "Kunde inte initiera GUI: Inget inbyggt tema hittades."
+
+#: ../src/univ/themes/gtk.cpp:521
+msgid "GTK+ theme"
+msgstr "GTK+ tema"
+
+#: ../src/univ/themes/metal.cpp:164
+msgid "Metal theme"
+msgstr "Metalltema"
+
+#: ../src/univ/themes/mono.cpp:512
+msgid "Simple monochrome theme"
+msgstr "Enkelt svart-vitt tema"
+
+#: ../src/univ/themes/win32.cpp:1098
+msgid "Win32 theme"
+msgstr "Win32 tema"
+
+#: ../src/univ/themes/win32.cpp:3743
+msgid "&Restore"
+msgstr "&Återställ"
+
+#: ../src/univ/themes/win32.cpp:3744
+msgid "&Move"
+msgstr "&Flytta"
+
+#: ../src/univ/themes/win32.cpp:3746
+msgid "&Size"
+msgstr "&Storlek"
+
+#: ../src/univ/themes/win32.cpp:3748
+msgid "Mi&nimize"
+msgstr "&Minimera"
+
+#: ../src/univ/themes/win32.cpp:3750
+msgid "Ma&ximize"
+msgstr "Ma&ximera"
+
+#: ../src/univ/themes/win32.cpp:3752
+msgid "Alt+"
+msgstr "Alt-"
+
+#: ../src/unix/appunix.cpp:178
+msgid "Failed to install signal handler"
+msgstr "Kunde inte installera signalhanterare"
+
+#: ../src/unix/dialup.cpp:351
+msgid "Already dialling ISP."
+msgstr "Ringer redan Internetleverantör."
+
+#: ../src/unix/dlunix.cpp:93
+#, fuzzy
+msgid "Failed to unload shared library"
+msgstr "Kunde inte läsa in delat bibliotek \"%s\""
+
+#: ../src/unix/dlunix.cpp:121
+msgid "Unknown dynamic library error"
+msgstr "Okänt fel i dynamiskt bibliotek"
+
+#: ../src/unix/epolldispatcher.cpp:84
+msgid "Failed to create epoll descriptor"
+msgstr "Kunde inte skapa epoll-identifierare"
+
+#: ../src/unix/epolldispatcher.cpp:103
+msgid "Error closing epoll descriptor"
+msgstr "Fel vid stängning av epoll-identifierare"
+
+#: ../src/unix/epolldispatcher.cpp:116
+#, c-format
+msgid "Failed to add descriptor %d to epoll descriptor %d"
+msgstr "Kunde inte lägga till identifierare %d till epoll-identifierare %d"
+
+#: ../src/unix/epolldispatcher.cpp:136
+#, c-format
+msgid "Failed to modify descriptor %d in epoll descriptor %d"
+msgstr "Kunde inte ändra identifierare %d i epoll-identifierare %d"
+
+#: ../src/unix/epolldispatcher.cpp:155
+#, c-format
+msgid "Failed to unregister descriptor %d from epoll descriptor %d"
+msgstr "Kunde inte avregistrera identifierare %d från epoll-identifierare %d"
+
+#: ../src/unix/epolldispatcher.cpp:213
+#, c-format
+msgid "Waiting for IO on epoll descriptor %d failed"
+msgstr "Väntan på IO för epoll-identifierare %d misslyckades"
+
+#: ../src/unix/fswatcher_inotify.cpp:71
+msgid "Unable to create inotify instance"
+msgstr "Kunde inte skapa en inotify-instans"
+
+#: ../src/unix/fswatcher_inotify.cpp:94
+msgid "Unable to close inotify instance"
+msgstr "Kunde inte stänga inotify-instans"
+
+#: ../src/unix/fswatcher_inotify.cpp:106
+msgid "Unable to add inotify watch"
+msgstr "Kunde inte lägga till inotify-bevakning"
+
+#: ../src/unix/fswatcher_inotify.cpp:138
+#, fuzzy, c-format
+msgid "Unable to remove inotify watch %i"
+msgstr "Kunde inte ta bort inotify-bevakning"
+
+#: ../src/unix/fswatcher_inotify.cpp:271
+#, c-format
+msgid "Unexpected event for \"%s\": no matching watch descriptor."
+msgstr "Oväntad händelse för \"%s\": ingen matchande bevakningsidentifierare."
+
+#: ../src/unix/fswatcher_inotify.cpp:320
+#, c-format
+msgid "Invalid inotify event for \"%s\""
+msgstr "Ogiltig inotify-händelse för \"%s\""
+
+#: ../src/unix/fswatcher_inotify.cpp:553
+msgid "Unable to read from inotify descriptor"
+msgstr "Kan inte läsa från inotify-identifierare"
+
+#: ../src/unix/fswatcher_inotify.cpp:558
+msgid "EOF while reading from inotify descriptor"
+msgstr "EOF under läsning från inotify-identifierare"
+
+#: ../src/unix/fswatcher_kqueue.cpp:114
+msgid "Unable to create kqueue instance"
+msgstr "Kunde inte skapa kqueue-instans"
+
+#: ../src/unix/fswatcher_kqueue.cpp:131
+msgid "Error closing kqueue instance"
+msgstr "Kunde inte stänga kqueue-instans"
+
+#: ../src/unix/fswatcher_kqueue.cpp:153
+msgid "Unable to add kqueue watch"
+msgstr "Kunde inte lägga till kqueue-bevakning"
+
+#: ../src/unix/fswatcher_kqueue.cpp:170
+msgid "Unable to remove kqueue watch"
+msgstr "Kunde inte ta bort kqueue-bevakning"
+
+#: ../src/unix/fswatcher_kqueue.cpp:202
+msgid "Unable to get events from kqueue"
+msgstr "Kunde inte hämta händelser från kqueue"
+
+#: ../src/unix/mediactrl.cpp:966
+#, c-format
+msgid "Media playback error: %s"
+msgstr "Medieuppspelningsfel: %s"
+
+#: ../src/unix/mediactrl.cpp:1228
+#, c-format
+msgid "Failed to prepare playing \"%s\"."
+msgstr "Misslyckades att förbereda uppspelning \"%s\"."
+
+#: ../src/unix/snglinst.cpp:164
+#, c-format
+msgid "Failed to write to lock file '%s'"
+msgstr "Kunde inte skriva till låsfil \"%s\""
+
+#: ../src/unix/snglinst.cpp:177
+#, c-format
+msgid "Failed to set permissions on lock file '%s'"
+msgstr "Kunde inte sätta behörigheter på låsfil \"%s\""
+
+#: ../src/unix/snglinst.cpp:194
+#, c-format
+msgid "Failed to lock the lock file '%s'"
+msgstr "Kunde inte låsa låsfilen \"%s\""
+
+#: ../src/unix/snglinst.cpp:237
+#, c-format
+msgid "Failed to inspect the lock file '%s'"
+msgstr "Kunde inte inspektera låsfilen \"%s\""
+
+#: ../src/unix/snglinst.cpp:242
+#, c-format
+msgid "Lock file '%s' has incorrect owner."
+msgstr "Låsfilen \"%s\" har felaktig ägare."
+
+#: ../src/unix/snglinst.cpp:247
+#, c-format
+msgid "Lock file '%s' has incorrect permissions."
+msgstr "Låsfilen \"%s\" har felaktig behörighet."
+
+#: ../src/unix/snglinst.cpp:265
+msgid "Failed to access lock file."
+msgstr "Kunde inte komma åt låsfil."
+
+#: ../src/unix/snglinst.cpp:274
+msgid "Failed to read PID from lock file."
+msgstr "Kunde inte läsa PID från låsfil."
+
+#: ../src/unix/snglinst.cpp:284
+#, c-format
+msgid "Failed to remove stale lock file '%s'."
+msgstr "Kunde inte ta bort förlegad låsfil \"%s\"."
+
+#: ../src/unix/snglinst.cpp:297
+#, c-format
+msgid "Deleted stale lock file '%s'."
+msgstr "Tog bort förlegad låsfil \"%s\"."
+
+#: ../src/unix/snglinst.cpp:308
+#, c-format
+msgid "Invalid lock file '%s'."
+msgstr "Ogiltig låsfil \"%s\"."
+
+#: ../src/unix/snglinst.cpp:324
+#, c-format
+msgid "Failed to remove lock file '%s'"
+msgstr "Kunde inte ta bort låsfil \"%s\""
+
+#: ../src/unix/snglinst.cpp:330
+#, c-format
+msgid "Failed to unlock lock file '%s'"
+msgstr "Kunde inte låsa upp låsfil \"%s\""
+
+#: ../src/unix/snglinst.cpp:336
+#, c-format
+msgid "Failed to close lock file '%s'"
+msgstr "Kunde inte stänga låsfil \"%s\""
+
+#: ../src/unix/sound.cpp:77
+msgid "No sound"
+msgstr "Inget ljud"
+
+#: ../src/unix/sound.cpp:364
+msgid "Unable to play sound asynchronously."
+msgstr "Kan inte spela ljud asynkront."
+
+#: ../src/unix/sound.cpp:458
+#, c-format
+msgid "Couldn't load sound data from '%s'."
+msgstr "Kunde inte läsa in ljuddata från \"%s\"."
+
+#: ../src/unix/sound.cpp:465
+#, c-format
+msgid "Sound file '%s' is in unsupported format."
+msgstr "Formatet på ljudfilen \"%s\" stöds inte."
+
+#: ../src/unix/sound.cpp:480
+msgid "Sound data are in unsupported format."
+msgstr "Formatet på ljuddata stöds inte."
+
+#: ../src/unix/sound_sdl.cpp:226
+#, c-format
+msgid "Couldn't open audio: %s"
+msgstr "Kunde inte öppna ljud: %s"
+
+#: ../src/unix/threadpsx.cpp:1033
+msgid "Cannot retrieve thread scheduling policy."
+msgstr "Kan inte hämta trådschemaläggningsregler."
+
+#: ../src/unix/threadpsx.cpp:1058
+#, c-format
+msgid "Cannot get priority range for scheduling policy %d."
+msgstr "Kan inte hämta prioritetsräckvidden för schemaläggningsregler %d."
+
+#: ../src/unix/threadpsx.cpp:1066
+msgid "Thread priority setting is ignored."
+msgstr "Trådprioritetsinställningar ignoreras."
+
+#: ../src/unix/threadpsx.cpp:1221
+msgid ""
+"Failed to join a thread, potential memory leak detected - please restart the "
+"program"
+msgstr ""
+"Kunde inte slå ihop en tråd, möjlig minnesläcka hittad - starta om programmet"
+
+#: ../src/unix/threadpsx.cpp:1352
+#, c-format
+msgid "Failed to set thread concurrency level to %lu"
+msgstr "Kunde inte ange trådkonkurrensnivå till %lu"
+
+#: ../src/unix/threadpsx.cpp:1481
+#, c-format
+msgid "Failed to set thread priority %d."
+msgstr "Kunde inte sätta trådprioritet %d."
+
+#: ../src/unix/threadpsx.cpp:1666
+msgid "Failed to terminate a thread."
+msgstr "Kunde inte avsluta en tråd."
+
+#: ../src/unix/threadpsx.cpp:1893
+msgid "Thread module initialization failed: failed to create thread key"
+msgstr "Trådmodulinitialisering misslyckades: Kunde inte skapa trådnyckel"
+
+#: ../src/unix/utilsunx.cpp:340
+msgid "Impossible to get child process input"
+msgstr "Omöjligt att hämta barnprocessindata"
+
+#: ../src/unix/utilsunx.cpp:390
+msgid "Can't write to child process's stdin"
+msgstr "Kan inte skriva till stdin för barnprocess"
+
+#: ../src/unix/utilsunx.cpp:644
+#, c-format
+msgid "Failed to execute '%s'\n"
+msgstr "Kunde inte utföra \"%s\"\n"
+
+#: ../src/unix/utilsunx.cpp:678
+msgid "Fork failed"
+msgstr "Gren misslyckades"
+
+#: ../src/unix/utilsunx.cpp:701
+msgid "Failed to set process priority"
+msgstr "Kunde inte ange processprioritet"
+
+#: ../src/unix/utilsunx.cpp:712
+msgid "Failed to redirect child process input/output"
+msgstr "Kunde inte omdirigera barnprocess-in/utdata"
+
+#: ../src/unix/utilsunx.cpp:816
+msgid "Failed to set up non-blocking pipe, the program might hang."
+msgstr "Kunde inte ställa in ickeblockerande rör, programet kan hänga sig."
+
+#: ../src/unix/utilsunx.cpp:1023
+msgid "Cannot get the hostname"
+msgstr "Kan inte hämta värdnamnet"
+
+#: ../src/unix/utilsunx.cpp:1059
+msgid "Cannot get the official hostname"
+msgstr "Kan inte hämta det officiella värdnamnet"
+
+#: ../src/unix/wakeuppipe.cpp:49
+msgid "Failed to create wake up pipe used by event loop."
+msgstr "Misslyckades att skapa wake up-rör som används av händelseslinga."
+
+#: ../src/unix/wakeuppipe.cpp:56
+msgid "Failed to switch wake up pipe to non-blocking mode"
+msgstr "Misslyckades att växla wake up-rör till ickeblockerande läge"
+
+#: ../src/unix/wakeuppipe.cpp:117
+msgid "Failed to read from wake-up pipe"
+msgstr "Kunde inte läsa från wake up-rör"
+
+#: ../src/x11/app.cpp:124
+#, c-format
+msgid "Invalid geometry specification '%s'"
+msgstr "Ogiltig geometrispecifikation \"%s\""
+
+#: ../src/x11/app.cpp:167
+msgid "wxWidgets could not open display. Exiting."
+msgstr "wxWidgets kunde inte öppna display. Avslutar."
+
+#: ../src/x11/utils.cpp:169
+#, c-format
+msgid "Failed to close the display \"%s\""
+msgstr "Kunde inte stänga display \"%s\""
+
+#: ../src/x11/utils.cpp:188
+#, c-format
+msgid "Failed to open display \"%s\"."
+msgstr "Kunde inte öppna display \"%s\"."
+
+#: ../src/xml/xml.cpp:868
+#, c-format
+msgid "XML parsing error: '%s' at line %d"
+msgstr "XML tolkningsfel: \"%s\" på rad %d"
+
+#: ../src/xrc/xh_propgrid.cpp:239
+#, fuzzy, c-format
+msgid "Page %i"
+msgstr "Sida %d"
+
+#: ../src/xrc/xmlres.cpp:448
+#, c-format
+msgid "Cannot load resources from '%s'."
+msgstr "Kan inte läsa in resurser från \"%s\"."
+
+#: ../src/xrc/xmlres.cpp:799
+#, c-format
+msgid "Cannot open resources file '%s'."
+msgstr "Kan inte öppna resursfil \"%s\"."
+
+#: ../src/xrc/xmlres.cpp:806
+#, c-format
+msgid "Cannot load resources from file '%s'."
+msgstr "Kan inte läsa in resurser från fil \"%s\"."
+
+#: ../src/xrc/xmlres.cpp:2767
+#, fuzzy, c-format
+msgid "Creating %s \"%s\" failed."
+msgstr "Uppackning av \"%s\" till \"%s\" misslyckades."
+
+#~ msgctxt "keyboard key"
+#~ msgid "Alt+"
+#~ msgstr "Alt-"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Ctrl+"
+#~ msgstr "Ctrl+"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Shift+"
+#~ msgstr "Skift+"
+
+#~ msgctxt "keyboard key"
+#~ msgid "RawCtrl+"
+#~ msgstr "ObehandladCtrl+"
+
+#~ msgid "Unsupported clipboard format."
+#~ msgstr "Urklippsformatet stöds inte."
+
+#~ msgid "Background colour"
+#~ msgstr "Bakgrundsfärg"
+
+#~ msgid "Font:"
+#~ msgstr "Typsnitt:"
+
+#~ msgid "Size:"
+#~ msgstr "Storlek:"
+
+#~ msgid "The font size in points."
+#~ msgstr "Typsnittsstorlek i punkter"
+
+#~ msgid "Style:"
+#~ msgstr "Stil:"
+
+#~ msgid "Check to make the font bold."
+#~ msgstr "Kryssa i för att göra typsnittet fet."
+
+#~ msgid "Check to make the font italic."
+#~ msgstr "Kryssa i för att göra typsnittet kursiv."
+
+#~ msgid "Check to make the font underlined."
+#~ msgstr "Kryssa i för att göra typsnittet understruket."
+
+#~ msgid "Colour:"
+#~ msgstr "Färg:"
+
+#~ msgid "Click to change the font colour."
+#~ msgstr "Klicka för att ändra typsnittsfärgen."
+
+#~ msgid "Shows a preview of the font."
+#~ msgstr "Visar förhandsgranskning av typsnittet."
+
+#~ msgid "Click to cancel changes to the font."
+#~ msgstr "Klicka för att avbryta ändringarna i typsnittet."
+
+#~ msgid "Click to confirm changes to the font."
+#~ msgstr "Klicka för att bekräfta ändringar i typsnittet."
+
+#~ msgid "<Any>"
+#~ msgstr "<Någon>"
+
+#~ msgid "<Any Roman>"
+#~ msgstr "<Någon roman>"
+
+#~ msgid "<Any Decorative>"
+#~ msgstr "<Någon dekorativ>"
+
+#~ msgid "<Any Modern>"
+#~ msgstr "<Någon modern>"
+
+#~ msgid "<Any Script>"
+#~ msgstr "<Någon skrivstil>"
+
+#~ msgid "<Any Swiss>"
+#~ msgstr "<Någon swiss>"
+
+#~ msgid "<Any Teletype>"
+#~ msgstr "<Någon teletyp>"
+
+#~ msgid "Printing "
+#~ msgstr "Skriver ut "
+
+#~ msgid "Failed to insert text in the control."
+#~ msgstr "Kunde inte sätta in text i kontrollen."
+
+#~ msgid "Please choose a valid font."
+#~ msgstr "Välj ett giltigt typsnitt."
+
+#, c-format
+#~ msgid "Failed to display HTML document in %s encoding"
+#~ msgstr "Kunde inte visa HTML-dokument i %s-kodning"
+
+#, c-format
+#~ msgid "wxWidgets could not open display for '%s': exiting."
+#~ msgstr "wxWidgets kunde inte öppna skärm för \"%s\": Avslutar."
+
+#~ msgid "Filter"
+#~ msgstr "Filter"
+
+#~ msgid "Directories"
+#~ msgstr "Kataloger"
+
+#~ msgid "Files"
+#~ msgstr "Filer"
+
+#~ msgid "Selection"
+#~ msgstr "Markering"
+
+#~ msgid "conversion to 8-bit encoding failed"
+#~ msgstr "omvandling till 8-bitskodning misslyckades"
+
+#, fuzzy
+#~ msgid "failed to retrieve execution result"
+#~ msgstr "Kunde inte hämta text från RAS-felmeddelande"
+
+#~ msgid "&Save as"
+#~ msgstr "Spara s&om"
+
+#, fuzzy
+#~ msgid "'%s' doesn't consist only of valid characters"
+#~ msgstr "\"%s\" får bara innehålla alfabetiska tecken."
+
+#~ msgid "'%s' should be numeric."
+#~ msgstr "\"%s\" skall vara numerisk."
+
+#~ msgid "'%s' should only contain ASCII characters."
+#~ msgstr "\"%s\" får bara innehålla ASCII-tecken."
+
+#~ msgid "'%s' should only contain alphabetic characters."
+#~ msgstr "\"%s\" får bara innehålla alfabetiska tecken."
+
+#~ msgid "'%s' should only contain alphabetic or numeric characters."
+#~ msgstr "\"%s\" får bara innehålla alfabetiska eller numeriska tecken."
+
+#~ msgid "'%s' should only contain digits."
+#~ msgstr "\"%s\" får bara innehålla siffror."
+
+#~ msgid "Can't create window of class %s"
+#~ msgstr "Kan inte skapa fönster av klass %s"
+
+#~ msgid "Couldn't create the overlay window"
+#~ msgstr "Kunde inte skapa överläggsfönster"
+
+#~ msgid "Couldn't init the context on the overlay window"
+#~ msgstr "Kunde inte initera kontexten på överläggsfönstret"
+
+#~ msgid "Failed to convert file \"%s\" to Unicode."
+#~ msgstr "Kunde inte konvertera filen \"%s\" till Unicode."
+
+#~ msgid "Failed to set text in the text control."
+#~ msgstr "Misslyckades med att ange text i textkontrollen."
+
+#~ msgid "Invalid GTK+ command line option, use \"%s --help\""
+#~ msgstr "Ogiltigt GTK+ kommandoradsargument, använd \"%s --help\""
+
+#~ msgid "No unused colour in image."
+#~ msgstr "Ingen oanvänd färg bilden."
+
+#~ msgid "Not available"
+#~ msgstr "Inte tillgängligt"
+
+#~ msgid "Replace selection"
+#~ msgstr "Ersätt markerat"
+
+#~ msgid "Save as"
+#~ msgstr "Spara som"
+
+#~ msgid "Style Organiser"
+#~ msgstr "Stilorganiserare"
+
+#~ msgid "The following standard GTK+ options are also supported:\n"
+#~ msgstr "Följande GTK+ standardalternativ stöds också:\n"
+
+#~ msgid "You cannot Clear an overlay that is not inited"
+#~ msgstr "Du kan inte tömma ett överlägg som inte är initierat"
+
+#~ msgid "You cannot Init an overlay twice"
+#~ msgstr "Du kan inte initiera överlägg två gånger"
+
+#~ msgid "locale '%s' cannot be set."
+#~ msgstr "lokal \"%s\" kan inte anges."
+
+#~ msgid "Adding flavor TEXT failed"
+#~ msgstr "Kunde inte lägga till typ TEXT"
+
+#~ msgid "Adding flavor utxt failed"
+#~ msgstr "Kunde inte lägga till typ utxt"
+
+#~ msgid "Bitmap renderer cannot render value; value type: "
+#~ msgstr "Bildrendrerare kan inte rendrera värde; värdetyp:"
+
+#~ msgid ""
+#~ "Cannot create new column's ID. Probably max. number of columns reached."
+#~ msgstr ""
+#~ "Kan inte skapa ny kolumns ID. Antagligen har maximalt antal kolumner "
+#~ "uppnåtts."
+
+#~ msgid "Column could not be added."
+#~ msgstr "Kolumn kunde inte läggas till."
+
+#~ msgid "Column index not found."
+#~ msgstr "Kolumnindex hittades inte."
+
+#~ msgid "Column width could not be determined"
+#~ msgstr "Kolumnbredd kunde inte avgöras"
+
+#~ msgid "Column width could not be set."
+#~ msgstr "Kolumnbredd kunde inte anges."
+
+#~ msgid "Confirm registry update"
+#~ msgstr "Bekräfta registeruppdatering"
+
+#~ msgid "Could not determine column index."
+#~ msgstr "Kunde inte avgöra kolumnindex."
+
+#~ msgid "Could not determine column's position"
+#~ msgstr "Kunde inte avgöra kolumnens position"
+
+#~ msgid "Could not determine number of columns."
+#~ msgstr "Kunde inte bestämma antal kolumner."
+
+#~ msgid "Could not determine number of items"
+#~ msgstr "Kunde inte bestämma antal poster"
+
+#~ msgid "Could not get header description."
+#~ msgstr "Kan inte hämta beskrivning för huvud."
+
+#~ msgid "Could not get items."
+#~ msgstr "Kunde inte hämta poster."
+
+#~ msgid "Could not get property flags."
+#~ msgstr "Kunde inte hämta egenskapsflaggor."
+
+#~ msgid "Could not get selected items."
+#~ msgstr "Kunde inte hämta valda poster."
+
+#~ msgid "Could not remove column."
+#~ msgstr "Kunde inte ta bort kolumn."
+
+#~ msgid "Could not retrieve number of items"
+#~ msgstr "Kunde inte hämta antal poster"
+
+#~ msgid "Could not set column width."
+#~ msgstr "Kunde inte ange kolumnbredd."
+
+#~ msgid "Could not set header description."
+#~ msgstr "Kunden inte ange beskrivning för huvud."
+
+#~ msgid "Could not set icon."
+#~ msgstr "Kunde inte ange ikon."
+
+#~ msgid "Could not set maximum width."
+#~ msgstr "Kunde inte ange maximumbredd."
+
+#~ msgid "Could not set minimum width."
+#~ msgstr "Kunde inte ange minimumbredd."
+
+#~ msgid "Could not set property flags."
+#~ msgstr "Kunde inte ange egenskapsflaggor."
+
+#~ msgid "Data object has invalid data format"
+#~ msgstr "Dataobjekt har felaktigt dataformat"
+
+#~ msgid "Date renderer cannot render value; value type: "
+#~ msgstr "Datumrendrerare kan inte rendrera värde; värdetyp:"
+
+#~ msgid ""
+#~ "Do you want to overwrite the command used to %s files with extension "
+#~ "\"%s\" ?\n"
+#~ "Current value is \n"
+#~ "%s, \n"
+#~ "New value is \n"
+#~ "%s %1"
+#~ msgstr ""
+#~ "Vill du skriva över kommandot för att %s filer med filändelse \"%s\" ?\n"
+#~ "Nuvarande värde är \n"
+#~ "%s, \n"
+#~ "Nytt värde är \n"
+#~ "%s %1"
+
+#~ msgid "Failed to retrieve data from the clipboard."
+#~ msgstr "Kunde inte hämta data från urklippsbordet."
+
+#~ msgid "GIF: Invalid gif index."
+#~ msgstr "GIF: Ogiltigt gif-index."
+
+#~ msgid "GIF: unknown error!!!"
+#~ msgstr "GIF: Okänt fel!!!"
+
+#~ msgid "Icon & text renderer cannot render value; value type: "
+#~ msgstr "Ikon- och textrendrerare kan inte rendrera värde; värdetyp:"
+
+#~ msgid "New directory"
+#~ msgstr "Ny katalog"
+
+#~ msgid "Next"
+#~ msgstr "Nästa"
+
+#~ msgid "No column existing."
+#~ msgstr "Ingen kolumn finns."
+
+#~ msgid "No column for the specified column existing."
+#~ msgstr "Ingen kolumn för den specificerade kolumnen finns."
+
+#~ msgid "No column for the specified column position existing."
+#~ msgstr "Ingen kolumn för den angivna positionen finns."
+
+#~ msgid ""
+#~ "No renderer or invalid renderer type specified for custom data column."
+#~ msgstr "Ingen rendrerare eller ogiltig rendrerartyp angiven för datakolumn."
+
+#~ msgid "No renderer specified for column."
+#~ msgstr "Ingen rendrerare specificerad för kolumn."
+
+#~ msgid "Number of columns could not be determined."
+#~ msgstr "Antal kolumner kunde inte bestämmas."
+
+#~ msgid "OpenGL function \"%s\" failed: %s (error %d)"
+#~ msgstr "OpenGL-funktion \"%s\" misslyckades: %s (fel %d)"
+
+#~ msgid ""
+#~ "Please install a newer version of comctl32.dll\n"
+#~ "(at least version 4.70 is required but you have %d.%02d)\n"
+#~ "or this program won't operate correctly."
+#~ msgstr ""
+#~ "Installera en nyare version av comctl32.dll\n"
+#~ "(minst version 4.70 behövs, men du har %d.%02d)\n"
+#~ "annars kommer programmet inte att fungera korrekt."
+
+#~ msgid "Pointer to data view control not set correctly."
+#~ msgstr "Pekare till datavykontroll är inte korrekt angiven."
+
+#~ msgid "Pointer to model not set correctly."
+#~ msgstr "Pekare till modell är inte korrekt angiven."
+
+#~ msgid "Progress renderer cannot render value type; value type: "
+#~ msgstr "Förloppsrendrerare kan inte rendrera värde; värdetyp:"
+
+#~ msgid "Rendering failed."
+#~ msgstr "Rendrering misslyckades."
+
+#~ msgid ""
+#~ "Setting directory access times is not supported under this OS version"
+#~ msgstr "Inställning av katalogåtkomsttid stöds inte i denna OS-version"
+
+#~ msgid "Show hidden directories"
+#~ msgstr "Visa dolda kataloger"
+
+#~ msgid "Text renderer cannot render value; value type: "
+#~ msgstr "Textrendrerare kan inte rendrera värde; värdetyp:"
+
+#~ msgid "There is no column or renderer for the specified column index."
+#~ msgstr ""
+#~ "Det finns ingen kolumn eller rendrerare för det angivna kolumnindexet."
+
+#~ msgid ""
+#~ "This system doesn't support date controls, please upgrade your version of "
+#~ "comctl32.dll"
+#~ msgstr ""
+#~ "Detta system stöder inte datumkontroller, uppgradera din version av "
+#~ "comctl32.dll"
+
+#~ msgid "Toggle renderer cannot render value; value type: "
+#~ msgstr "Växlingsrendrerare kan inte rendrera värde; värdetyp:"
+
+#~ msgid "Too many colours in PNG, the image may be slightly blurred."
+#~ msgstr "För många färger i PNG, bilden kan bli något suddig."
+
+#~ msgid "Unable to handle native drag&drop data"
+#~ msgstr "Kunde inte hantera inbyggd dra-och-släpp-data"
+
+#~ msgid "Unable to initialize Hildon program"
+#~ msgstr "Kunde inte initiera Hildon-program"
+
+#~ msgid "Unknown data format"
+#~ msgstr "Okänt dataformat"
+
+#~ msgid "Valid pointer to native data view control does not exist"
+#~ msgstr "Det finns ingen giltig pekare till inbyggd datavykontrol"
+
+#~ msgid "Win32s on Windows 3.1"
+#~ msgstr "Win32s på Windows 3.1"
+
+#, fuzzy
+#~ msgid "Windows 10"
+#~ msgstr "Windows 8.1"
+
+#~ msgid "Windows 2000"
+#~ msgstr "Windows 2000"
+
+#~ msgid "Windows 7"
+#~ msgstr "Windows 7"
+
+#~ msgid "Windows 8"
+#~ msgstr "Windows 8"
+
+#~ msgid "Windows 8.1"
+#~ msgstr "Windows 8.1"
+
+#~ msgid "Windows 95"
+#~ msgstr "Windows 95"
+
+#~ msgid "Windows 95 OSR2"
+#~ msgstr "Windows 95 OSR2"
+
+#~ msgid "Windows 98"
+#~ msgstr "Windows 98"
+
+#~ msgid "Windows 98 SE"
+#~ msgstr "Windows 98 SE"
+
+#~ msgid "Windows 9x (%d.%d)"
+#~ msgstr "Windows 9X (%d.%d)"
+
+#~ msgid "Windows CE (%d.%d)"
+#~ msgstr "Windows CE (%d.%d)"
+
+#~ msgid "Windows ME"
+#~ msgstr "Windows ME"
+
+#~ msgid "Windows NT %lu.%lu"
+#~ msgstr "Windows NT %lu.%lu"
+
+#, fuzzy
+#~ msgid "Windows Server 10"
+#~ msgstr "Windows Server 2003"
+
+#~ msgid "Windows Server 2003"
+#~ msgstr "Windows Server 2003"
+
+#~ msgid "Windows Server 2008"
+#~ msgstr "Windows Server 2008"
+
+#~ msgid "Windows Server 2008 R2"
+#~ msgstr "Windows Server 2008 R2"
+
+#~ msgid "Windows Server 2012"
+#~ msgstr "Windows Server 2012"
+
+#~ msgid "Windows Server 2012 R2"
+#~ msgstr "Windows Server 2012 R2"
+
+#~ msgid "Windows Vista"
+#~ msgstr "Windows Vista"
+
+#~ msgid "Windows XP"
+#~ msgstr "Windows XP"
+
+#~ msgid "can't execute '%s'"
+#~ msgstr "kan inte köra \"%s\""
+
+#~ msgid "error opening '%s'"
+#~ msgstr "fel vid öppning av \"%s\""
+
+#~ msgid "unknown seek origin"
+#~ msgstr "okänd sökstart"
+
+#~ msgid "wxWidget control pointer is not a data view pointer"
+#~ msgstr "wxWidget kontrollpekare är inte en datavypekare"
+
+#~ msgid "wxWidget's control not initialized."
+#~ msgstr "wxWidgets kontroll är inte initierad."
+
+#~ msgid "ADD"
+#~ msgstr "ADDERA"
+
+#~ msgid "BACK"
+#~ msgstr "TILLBAKA"
+
+#~ msgid "CANCEL"
+#~ msgstr "AVBRYT"
+
+#~ msgid "CAPITAL"
+#~ msgstr "CAPITAL"
+
+#~ msgid "CLEAR"
+#~ msgstr "TÖM"
+
+#~ msgid "COMMAND"
+#~ msgstr "COMMAND"
+
+#~ msgid "Cannot create mutex."
+#~ msgstr "Kan inte skapa mutex."
+
+#~ msgid "Cannot resume thread %lu"
+#~ msgstr "Kan inte återuppta tråden %lu"
+
+#~ msgid "Cannot suspend thread %lu"
+#~ msgstr "Kan inte hålla inne tråd %lu"
+
+#~ msgid "Couldn't acquire a mutex lock"
+#~ msgstr "Kunde inte förvärva ett mutexlås"
+
+#~ msgid "Couldn't get hatch style from wxBrush."
+#~ msgstr "Kunde inte hämta hatch-stil från wxBrush."
+
+#~ msgid "Couldn't release a mutex"
+#~ msgstr "Kunde inte släppa ett mutex"
+
+#~ msgid "DECIMAL"
+#~ msgstr "DECIMAL"
+
+#~ msgid "DEL"
+#~ msgstr "DEL"
+
+#~ msgid "DELETE"
+#~ msgstr "DELETE"
+
+#~ msgid "DIVIDE"
+#~ msgstr "DIVIDERA"
+
+#~ msgid "DOWN"
+#~ msgstr "NER"
+
+#~ msgid "END"
+#~ msgstr "END"
+
+#~ msgid "ENTER"
+#~ msgstr "ENTER"
+
+#~ msgid "ESC"
+#~ msgstr "ESC"
+
+#~ msgid "ESCAPE"
+#~ msgstr "ESCAPE"
+
+#~ msgid "EXECUTE"
+#~ msgstr "EXEKVERA"
+
+#~ msgid "Execution of command '%s' failed with error: %ul"
+#~ msgstr "Utförande av kommando \"%s\" misslyckades med fel: %ul"
+
+#~ msgid ""
+#~ "File '%s' already exists.\n"
+#~ "Do you want to replace it?"
+#~ msgstr ""
+#~ "Filen \"%s\" finns redan\n"
+#~ "Vill du ersätta den?"
+
+#~ msgid "HELP"
+#~ msgstr "HJÄLP"
+
+#~ msgid "HOME"
+#~ msgstr "HEM"
+
+#~ msgid "INS"
+#~ msgstr "INS"
+
+#~ msgid "INSERT"
+#~ msgstr "INSERT"
+
+#~ msgid "KP_BEGIN"
+#~ msgstr "KP_BÖRJA"
+
+#~ msgid "KP_DECIMAL"
+#~ msgstr "KP_DECIMAL"
+
+#~ msgid "KP_DELETE"
+#~ msgstr "KP_DELETE"
+
+#~ msgid "KP_DIVIDE"
+#~ msgstr "KP_DIVIDERA"
+
+#~ msgid "KP_DOWN"
+#~ msgstr "KP_NER"
+
+#~ msgid "KP_ENTER"
+#~ msgstr "KP_ENTER"
+
+#~ msgid "KP_EQUAL"
+#~ msgstr "KP_LIKAMED"
+
+#~ msgid "KP_HOME"
+#~ msgstr "KP_HEM"
+
+#~ msgid "KP_INSERT"
+#~ msgstr "KP_INSERT"
+
+#~ msgid "KP_LEFT"
+#~ msgstr "KP_VÄNSTER"
+
+#~ msgid "KP_MULTIPLY"
+#~ msgstr "KP_MULTIPLICERA"
+
+#~ msgid "KP_NEXT"
+#~ msgstr "KP_NÄSTA"
+
+#~ msgid "KP_PAGEDOWN"
+#~ msgstr "KP_SIDANER"
+
+#~ msgid "KP_PAGEUP"
+#~ msgstr "KP_SIDAUPP"
+
+#~ msgid "KP_PRIOR"
+#~ msgstr "KP_FÖREGÅENDE"
+
+#~ msgid "KP_RIGHT"
+#~ msgstr "KP_HÖGER"
+
+#~ msgid "KP_SEPARATOR"
+#~ msgstr "KP_SEPARERARE"
+
+#~ msgid "KP_SPACE"
+#~ msgstr "KP_MELLANSLAG"
+
+#~ msgid "KP_SUBTRACT"
+#~ msgstr "KP_SUBTRAHERA"
+
+#~ msgid "LEFT"
+#~ msgstr "VÄNSTER"
+
+#~ msgid "MENU"
+#~ msgstr "MENY"
+
+#~ msgid "NUM_LOCK"
+#~ msgstr "NUM_LOCK"
+
+#~ msgid "PAGEDOWN"
+#~ msgstr "SIDANER"
+
+#~ msgid "PAGEUP"
+#~ msgstr "SIDAUPP"
+
+#~ msgid "PAUSE"
+#~ msgstr "PAUSE"
+
+#~ msgid "PGDN"
+#~ msgstr "PGDN"
+
+#~ msgid "PGUP"
+#~ msgstr "PGUP"
+
+#~ msgid "PRINT"
+#~ msgstr "SKRIVUT"
+
+#~ msgid "RETURN"
+#~ msgstr "RETURN"
+
+#~ msgid "RIGHT"
+#~ msgstr "HÖGER"
+
+#~ msgid "SCROLL_LOCK"
+#~ msgstr "SCROLL_LOCK"
+
+#~ msgid "SELECT"
+#~ msgstr "SELECT"
+
+#~ msgid "SEPARATOR"
+#~ msgstr "SEPARERARE"
+
+#~ msgid "SNAPSHOT"
+#~ msgstr "SKÄRMDUMP"
+
+#~ msgid "SPACE"
+#~ msgstr "MELLANSLAG"
+
+#~ msgid "SUBTRACT"
+#~ msgstr "SUBTRAHERA"
+
+#~ msgid "TAB"
+#~ msgstr "TABB"
+
+#~ msgid "The print dialog returned an error."
+#~ msgstr "Utskriftsdialogrutan returnerade ett fel."
+
+#~ msgid "The wxGtkPrinterDC cannot be used."
+#~ msgstr "wxGtkPrinterDC kan inte användas."
+
+#~ msgid "Timer creation failed."
+#~ msgstr "Kunde inte skapa timer."
+
+#~ msgid "UP"
+#~ msgstr "UPP"
+
+#~ msgid "WINDOWS_LEFT"
+#~ msgstr "WINDOWS_VÄNSTER"
+
+#~ msgid "WINDOWS_MENU"
+#~ msgstr "WINDOWS_MENY"
+
+#~ msgid "WINDOWS_RIGHT"
+#~ msgstr "WINDOWS_HÖGER"
+
+#~ msgid "buffer is too small for Windows directory."
+#~ msgstr "buffern är för liten för Windows-katalogen."
+
+#~ msgid "not implemented"
+#~ msgstr "ej implementerat"
+
+#~ msgid "wxPrintout::GetPageInfo gives a null maxPage."
+#~ msgstr "wxPrintout::GetPageInfo gav en null maxPage."
+
+#~ msgid "Event queue overflowed"
+#~ msgstr "Händelsekö flödade över"
+
+#~ msgid "percent"
+#~ msgstr "procent"
+
+#~ msgid "Print preview"
+#~ msgstr "Förhandsgranska"
+
+#, fuzzy
+#~ msgid "&Preview..."
+#~ msgstr " Förhandsgranska"
+
+#, fuzzy
+#~ msgid "Preview..."
+#~ msgstr " Förhandsgranska"
+
+#, fuzzy
+#~ msgid "The vertical offset relative to the paragraph."
+#~ msgstr "Förvald stil för nästa stycke."
+
+#~ msgid "&Save..."
+#~ msgstr "&Spara..."
+
+#~ msgid "About "
+#~ msgstr "Om"
+
+#~ msgid "All files (*.*)|*"
+#~ msgstr "Alla filer (*.*)|*"
+
+#~ msgid "Cannot initialize SciTech MGL!"
+#~ msgstr "Kan inte initiera SciTech MGL!"
+
+#~ msgid "Cannot initialize display."
+#~ msgstr "Kan inte initiera display."
+
+#~ msgid "Cannot start thread: error writing TLS"
+#~ msgstr "Kan inte starta tråd: fel vid skrivning av TLS"
+
+#~ msgid "Close\tAlt-F4"
+#~ msgstr "Stäng\tAlt-F4"
+
+#~ msgid "Couldn't create cursor."
+#~ msgstr "Kunde inte skapa markör."
+
+#~ msgid "Directory '%s' doesn't exist!"
+#~ msgstr "Katalogen \"%s\" finns inte!"
+
+#~ msgid "Mode %ix%i-%i not available."
+#~ msgstr "Läge %ix%i-%i är inte tillgängligt."
+
+#~ msgid "Paper Size"
+#~ msgstr "Pappersstorlek"
+
+#~ msgid "%.*f GB"
+#~ msgstr "%.*f GB"
+
+#~ msgid "%.*f MB"
+#~ msgstr "%.*f MB"
+
+#~ msgid "%.*f TB"
+#~ msgstr "%.*f TB"
+
+#~ msgid "%.*f kB"
+#~ msgstr "%.*f kB"
+
+#~ msgid "%s B"
+#~ msgstr "%s B"
+
+#~ msgid "&Goto..."
+#~ msgstr "&Gå till..."
+
+#~ msgid "<<"
+#~ msgstr "<<"
+
+#~ msgid ">>"
+#~ msgstr ">>"
+
+#~ msgid ">>|"
+#~ msgstr ">>|"
+
+#~ msgid "Archive doesnt contain #SYSTEM file"
+#~ msgstr "Arkivet innehåller ingen #SYSTEM fil"
+
+#~ msgid "BIG5"
+#~ msgstr "BIG5"
+
+#~ msgid "Can't check image format of file '%s': file does not exist."
+#~ msgstr "Kan inte kontrollera bildformat för fil \"%s\": Filen finns inte."
+
+#~ msgid "Can't load image from file '%s': file does not exist."
+#~ msgstr "Kan inte läsa in bild från fil \"%s\": Filen finns inte."
+
+#~ msgid "Cannot convert dialog units: dialog unknown."
+#~ msgstr "Kan inte konvertera dialogenheter: Okänd dialog."
+
+#~ msgid "Cannot convert from the charset '%s'!"
+#~ msgstr "Kan inte konvertera från teckenuppsättningen \"%s\"!"
+
+#~ msgid "Cannot find container for unknown control '%s'."
+#~ msgstr "Kan inte hitta behållare för okänd kontroll \"%s\"."
+
+#~ msgid "Cannot find font node '%s'."
+#~ msgstr "Kan inte hitta typsnittsnod \"%s\"."
+
+#~ msgid "Cannot open file '%s'."
+#~ msgstr "Kan inte öppna fil \"%s\"."
+
+#~ msgid "Cannot parse coordinates from '%s'."
+#~ msgstr "Kan inte tolka koordinater från \"%s\"."
+
+#~ msgid "Cannot parse dimension from '%s'."
+#~ msgstr "Kan inte tolka dimension från \"%s\"."
+
+#~ msgid "Cant create the thread event queue"
+#~ msgstr "Kan inte skapa trådens händelsekö"
+
+#~ msgid "Click to cancel this window."
+#~ msgstr "Klicka för att avbryta fönstret."
+
+#~ msgid "Click to confirm your selection."
+#~ msgstr "Klicka för att bekräfta ditt val."
+
+#~ msgid "Could not unlock mutex"
+#~ msgstr "Kunde inte låsa upp mutex"
+
+#~ msgid "Error while waiting on semaphore"
+#~ msgstr "Fel vid väntande på semafor"
+
+#~ msgid "Failed to create a status bar."
+#~ msgstr "Kunde inte skapa en statusrad."
+
+#~ msgid "Failed to register OpenGL window class."
+#~ msgstr "Kunde inte registrera OpenGL-fönsterklass."
+
+#~ msgid "Fatal error: "
+#~ msgstr "Ödesdigert fel: "
+
+#~ msgid "GB-2312"
+#~ msgstr "GB-2312"
+
+#~ msgid "Go forward to the next HTML page"
+#~ msgstr "Gå till nästa HTML-sida"
+
+#~ msgid "Goto Page"
+#~ msgstr "Gå till sida"
+
+#, fuzzy
+#~ msgid ""
+#~ "HTML pagination algorithm generated more than the allowed maximum number "
+#~ "of pages and it can't continue any longer!"
+#~ msgstr ""
+#~ "HTML-sidnumreringsalgoritm skapade fler sidor än tillåtet maxantal och "
+#~ "kan inte fortsätta!"
+
+#~ msgid "Help : %s"
+#~ msgstr "Hjälp : %s"
+
+#~ msgid "I64"
+#~ msgstr "I64"
+
+#~ msgid "Internal error, illegal wxCustomTypeInfo"
+#~ msgstr "Internt fel, ogiltig wxCustomTypeInfo"
+
+#~ msgid "Invalid XRC resource '%s': doesn't have root node 'resource'."
+#~ msgstr "Ogiltig XRC-resurs \"%s\": Har inte rotnod \"resource\"."
+
+#~ msgid "No handler found for XML node '%s', class '%s'!"
+#~ msgstr "Ingen hanterare hittades för XML-nod \"%s\", klass \"%s\"!"
+
+#~ msgid "No image handler for type %ld defined."
+#~ msgstr "Ingen bildhanterare är definierad för typ %ld."
+
+#, fuzzy
+#~ msgid "Owner not initialized."
+#~ msgstr "Kan inte initiera display."
+
+#, fuzzy
+#~ msgid "Passed item is invalid."
+#~ msgstr "\"%s\" är ogiltig"
+
+#~ msgid "Passing a already registered object to SetObjectName"
+#~ msgstr "Skickade ett redan registrerat objekt till SetObjectName"
+
+#~ msgid "Preparing help window..."
+#~ msgstr "Förbereder hjälpfönster"
+
+#~ msgid "Program aborted."
+#~ msgstr "Program avbrutet."
+
+#~ msgid "Referenced object node with ref=\"%s\" not found!"
+#~ msgstr "Refererad objektnod med ref=\"%s\" hittades inte!"
+
+#~ msgid "Resource files must have same version number!"
+#~ msgstr "Resursfiler måste ha samma versionsnummer!"
+
+#~ msgid "SHIFT-JIS"
+#~ msgstr "SHIFT-JIS"
+
+#~ msgid "Search!"
+#~ msgstr "Sök!"
+
+#~ msgid "Sorry, could not open this file for saving."
+#~ msgstr "Kunde inte öppna denna fil för att spara."
+
+#~ msgid "Sorry, could not save this file."
+#~ msgstr "Kunde inte spara denna fil."
+
+#~ msgid "Sorry, print preview needs a printer to be installed."
+#~ msgstr "Förhandsgranskning kräver en installerad skrivare."
+
+#~ msgid "Status: "
+#~ msgstr "Status: "
+
+#~ msgid ""
+#~ "Streaming delegates for not already streamed objects not yet supported"
+#~ msgstr "Strömmande delegater för icke strömmande objekt stöds inte ännu"
+
+#~ msgid "Subclass '%s' not found for resource '%s', not subclassing!"
+#~ msgstr "Subklass \"%s\" hittades inte för resurs \"%s\", subklassar inte!"
+
+#~ msgid "TIFF library error."
+#~ msgstr "TIFF-bibliotek fel."
+
+#~ msgid "TIFF library warning."
+#~ msgstr "TIFF-bibliotek varning."
+
+#~ msgid ""
+#~ "The file '%s' couldn't be opened.\n"
+#~ "It has been removed from the most recently used files list."
+#~ msgstr ""
+#~ "Filen \"%s\" kunde inte öppnas.\n"
+#~ "Den har tagits bort från senast använda filer-listan."
+
+#~ msgid "The path '%s' contains too many \"..\"!"
+#~ msgstr "Sökvägen \"%s\" innehåller för många \"..\"!"
+
+#~ msgid "Trying to solve a NULL hostname: giving up"
+#~ msgstr "Försöker slå upp ett NULL värdnamn: ger upp"
+
+#~ msgid "Unknown style flag "
+#~ msgstr "Okänd stilflagga "
+
+#~ msgid "Warning"
+#~ msgstr "Varning"
+
+#~ msgid "Windows 2000 (build %lu"
+#~ msgstr "Windows 2000 (bygge %lu"
+
+#~ msgid "XRC resource '%s' (class '%s') not found!"
+#~ msgstr "XRC-resurs \"%s\" (klass \"%s\") hittades inte!"
+
+#~ msgid "XRC resource: Cannot create animation from '%s'."
+#~ msgstr "XRC-resurs: Kan inte skapa animation från \"%s\"."
+
+#~ msgid "XRC resource: Cannot create bitmap from '%s'."
+#~ msgstr "XRC-resurs: Kan inte skapa bild från \"%s\"."
+
+#, fuzzy
+#~ msgid ""
+#~ "XRC resource: Incorrect colour specification '%s' for attribute '%s'."
+#~ msgstr "XRC-resurs: Felaktig färgspecifikation \"%s\" för egenskap \"%s\"."
+
+#~ msgid "[EMPTY]"
+#~ msgstr "[TOM]"
+
+#~ msgid "catalog file for domain '%s' not found."
+#~ msgstr "katalogfil för domän \"%s\" hittades inte."
+
+#~ msgid "delegate has no type info"
+#~ msgstr "delegat har ingen typinformation"
+
+#~ msgid "encoding %i"
+#~ msgstr "kodning %i"
+
+#~ msgid "looking for catalog '%s' in path '%s'."
+#~ msgstr "söker efter katalog \"%s\" i sökväg \"%s\"."
+
+#~ msgid "wxRichTextFontPage"
+#~ msgstr "wxRichTextFontPage"
+
+#~ msgid "wxSearchEngine::LookFor must be called before scanning!"
+#~ msgstr "wxSearchEngine::LookFor måste anropas före scanning!"
+
+#~ msgid "wxSocket: invalid signature in ReadMsg."
+#~ msgstr "wxSocket: Ogiltig signatur i ReadMsg."
+
+#~ msgid "wxSocket: unknown event!."
+#~ msgstr "wxSocket: Okänd händelse!"
+
+#~ msgid "|<<"
+#~ msgstr "|<<"
+
+#~ msgid " Couldn't create the UnicodeConverter"
+#~ msgstr " Kunde inte skapa Unicode-omvandlaren"
+
+#~ msgid "#define %s must be an integer."
+#~ msgstr "#define %s måste vara ett heltal."
+
+#~ msgid "%s not a bitmap resource specification."
+#~ msgstr "%s är inte en bitmappresursspecifikation."
+
+#~ msgid "%s not an icon resource specification."
+#~ msgstr "%s är inte en ikonresursspecifikation."
+
+#~ msgid "%s: ill-formed resource file syntax."
+#~ msgstr "%s: felformaterad resursfilsyntax."
+
+#~ msgid "&Open"
+#~ msgstr "&Öppna"
+
+#~ msgid "&Print"
+#~ msgstr "Skriv &ut"
+
+#~ msgid "*** It can be found in \"%s\"\n"
+#~ msgstr "*** Den kan hittas i \"%s\"\n"
+
+#~ msgid ""
+#~ ", expected static, #include or #define\n"
+#~ "while parsing resource."
+#~ msgstr ""
+#~ ", förväntade static, #include eller #define\n"
+#~ "när resursen tolkades."
+
+#~ msgid "Bitmap resource specification %s not found."
+#~ msgstr "Bitmappresursspecifikation %s hittades inte."
+
+#~ msgid "Closes the dialog without inserting a symbol."
+#~ msgstr "Stänger dialogen utan att sätta in en symbol."
+
+#~ msgid ""
+#~ "Could not resolve control class or id '%s'. Use (non-zero) integer "
+#~ "instead\n"
+#~ " or provide #define (see manual for caveats)"
+#~ msgstr ""
+#~ "Kunde inte slå upp kontrollklass eller id \"%s\". Använd (ickenoll) "
+#~ "heltal istället\n"
+#~ "eller tillhandahåll #define (se manualen för risker)"
+
+#~ msgid ""
+#~ "Could not resolve menu id '%s'. Use (non-zero) integer instead\n"
+#~ "or provide #define (see manual for caveats)"
+#~ msgstr ""
+#~ "Kunde inte slå upp menyid \"%s\". Använd (ickenoll) heltal istället\n"
+#~ "eller tillhandahåll #define (se manualen för risker)"
+
+#~ msgid "Couldn't end the context on the overlay window"
+#~ msgstr "Kunde inte avsluta kontexten på överläggsfönstret"
+
+#~ msgid "Expected '*' while parsing resource."
+#~ msgstr "Förväntade \"*\" när resursen tolkades."
+
+#~ msgid "Expected '=' while parsing resource."
+#~ msgstr "Förväntade \"=\" när resursen tolkades."
+
+#~ msgid "Expected 'char' while parsing resource."
+#~ msgstr "Förväntade \"char\" när resursen tolkades."
+
+#~ msgid ""
+#~ "Failed to find XBM resource %s.\n"
+#~ "Forgot to use wxResourceLoadBitmapData?"
+#~ msgstr ""
+#~ "Kunde inte hitta XBM-resurs %s.\n"
+#~ "Har du glömt att använda wxResourceLoadBitmapData?"
+
+#~ msgid ""
+#~ "Failed to find XBM resource %s.\n"
+#~ "Forgot to use wxResourceLoadIconData?"
+#~ msgstr ""
+#~ "Kunde inte hitta XBM-resurs %s.\n"
+#~ "Har du glömt att använda wxResourceLoadIconData?"
+
+#~ msgid ""
+#~ "Failed to find XPM resource %s.\n"
+#~ "Forgot to use wxResourceLoadBitmapData?"
+#~ msgstr ""
+#~ "Kunde inte hitta XPM-resurs %s.\n"
+#~ "Har du glömt att använda wxResourceLoadBitmapData?"
+
+#~ msgid "Failed to get clipboard data."
+#~ msgstr "Kunde inte hämta urklippsdata."
+
+#~ msgid "Failed to load shared library '%s' Error '%s'"
+#~ msgstr "Kunde inte läsa in delat bibliotek \"%s\" Fel \"%s\""
+
+#~ msgid "Found "
+#~ msgstr "Hittade "
+
+#~ msgid "Icon resource specification %s not found."
+#~ msgstr "Ikonresursspecifikation \"%s\" hittades inte."
+
+#~ msgid "Ill-formed resource file syntax."
+#~ msgstr "Felformaterad resursfilsyntax."
+
+#~ msgid "Inserts the chosen symbol."
+#~ msgstr "Sätter in vald symbol."
+
+#~ msgid "Long Conversions not supported"
+#~ msgstr "Konvertering till long stöds inte"
+
+#~ msgid "No XPM icon facility available!"
+#~ msgstr "Inget XPM-stöd är tillgängligt!"
+
+#~ msgid "Option '%s' requires a value, '=' expected."
+#~ msgstr "Flagga \"%s\" kräver ett värde, \"=\" förväntat."
+
+#~ msgid "Select all"
+#~ msgstr "Markera allt"
+
+#~ msgid ""
+#~ "Sorry, docking is not supported for ports other than wxMSW, wxMac and "
+#~ "wxGTK"
+#~ msgstr "Dockning stöds inte för andra portningar än wxMSW, wxMac och wxGTK"
+
+#~ msgid "Unexpected end of file while parsing resource."
+#~ msgstr "Oväntat slut på filen när resursen tolkades."
+
+#~ msgid "Unrecognized style %s while parsing resource."
+#~ msgstr "Oväntad stil %s när resursen tolkades."
+
+#~ msgid "Video Output"
+#~ msgstr "Videoutdata"
+
+#~ msgid "Warning: attempt to remove HTML tag handler from empty stack."
+#~ msgstr "Varning: Försök att ta bort HTML-märkordshanterare från tom stack."
+
+#~ msgid "establish"
+#~ msgstr "etablera"
+
+#~ msgid "initiate"
+#~ msgstr "initiera"
+
+#~ msgid "invalid eof() return value."
+#~ msgstr "ogiltigt eof() returvärde."
+
+#~ msgid "unknown line terminator"
+#~ msgstr "okänt radavslut"
+
+#~ msgid "writing"
+#~ msgstr "skriver"
+
+#~ msgid "wxRichTextBulletsPage"
+#~ msgstr "wxRichTextBulletsPage"
+
+#~ msgid "wxRichTextListStylePage"
+#~ msgstr "wxRichTextListStylePage"
+
+#~ msgid "wxRichTextStylePage"
+#~ msgstr "wxRichTextStylePage"
+
+#~ msgid "."
+#~ msgstr "."
+
+#~ msgid "Cannot open URL '%s'"
+#~ msgstr "Kan inte öppna URL \"%s\""
+
+#~ msgid "Error "
+#~ msgstr "Fel "
+
+#~ msgid "Failed to create directory %s/.gnome."
+#~ msgstr "Kunde inte skapa katalog %s/.gnome."
+
+#~ msgid "Failed to create directory %s/mime-info."
+#~ msgstr "Kunde inte skapa katalog %s/mime-info."
+
+#~ msgid "MP Thread Support is not available on this System"
+#~ msgstr "MP-trådstöd är inte tillgängligt på det här systemet"
+
+#~ msgid "Mailcap file %s, line %d: incomplete entry ignored."
+#~ msgstr "Mailcap-fil %s, rad %d: ofullständig post ignorerad."
+
+#~ msgid "Mime.types file %s, line %d: unterminated quoted string."
+#~ msgstr "Mime.types fil %s, rad %d: oavslutad citerad sträng."
+
+#~ msgid "Unknown field in file %s, line %d: '%s'."
+#~ msgstr "Okänt fält i fil %s, rad %d: \"%s\"."
+
+#~ msgid "bold "
+#~ msgstr "fet "
+
+#~ msgid "can't query for GUI plugins name in console applications"
+#~ msgstr "kan inte efterfråga GUI-insticksprogram i konsollapplikationer"
+
+#~ msgid "light "
+#~ msgstr "tunn "
+
+#~ msgid "underlined "
+#~ msgstr "understruken "
+
+#~ msgid "unsupported zip archive"
+#~ msgstr "zip-arkiv stöds inte"
+
+#~ msgid ""
+#~ "Failed to get stack backtrace:\n"
+#~ "%s"
+#~ msgstr ""
+#~ "Kunde inte hämta stackbakåtspår:\n"
+#~ "%s"
+
+#~ msgid "Loading Grey Ascii PNM image is not yet implemented."
+#~ msgstr "Att ladda Grey Ascii PNM bilder är ännu inte implementerat."
+
+#~ msgid "Loading Grey Raw PNM image is not yet implemented."
+#~ msgstr "Att ladda Grey Raw PNM bilder är ännu inte implementerat."
+
+#~ msgid "Cannot wait on thread to exit."
+#~ msgstr "Kan inte vänta på att tråden avslutas."
+
+#~ msgid "Could not load Rich Edit DLL '%s'"
+#~ msgstr "Kunde inte ladda Rich Edit DLL \"%s\""
+
+#~ msgid "ZIP handler currently supports only local files!"
+#~ msgstr "ZIP-hanteraren stöder för närvarande endast lokala filer!"
+
+#~ msgid ""
+#~ "can't seek on file descriptor %d, large files support is not enabled."
+#~ msgstr ""
+#~ "kan inte söka på filidentifierare %d, stöd för stora filer är inte "
+#~ "aktiverat."
+
+#~ msgid "More..."
+#~ msgstr "Mer..."
+
+#~ msgid "Setup"
+#~ msgstr "Inställningar"
+
+#~ msgid "/#SYSTEM"
+#~ msgstr "/#SYSTEM"
+
+#~ msgid "Backward"
+#~ msgstr "Baklänges"
+
+#~ msgid "GetUnusedColour:: No Unused Color in image "
+#~ msgstr "GetUnusedColour:: Ingen oanvänd färg i bilden"
+
+#~ msgid ""
+#~ "Can't create list control window, check that comctl32.dll is installed."
+#~ msgstr ""
+#~ "Kan inte skapa listkontrollfönster, kontrollera att comctl32.dll är "
+#~ "installerad."
+
+#~ msgid "Can't delete value of key '%s'"
+#~ msgstr "Kan inte ta bort värdet från nyckel \"%s\""
+
+#~ msgid "gmtime() failed"
+#~ msgstr "gmtime() misslyckades"
+
+#~ msgid "mktime() failed"
+#~ msgstr "mktime() misslyckades"

--- a/po_wxstd/ta.po
+++ b/po_wxstd/ta.po
@@ -1,0 +1,10083 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: wxWidgets 3.3\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-05-14 20:23+0200\n"
+"PO-Revision-Date: 2025-08-28 14:50+0530\n"
+"Last-Translator: DINAKAR T.D. <td.dinkar@gmail.com>\n"
+"Language-Team: DINAKAR T.D. <td.dinkar@gmail.com>\n"
+"Language: ta\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Poedit 1.5.7\n"
+"X-Poedit-Bookmarks: 39,-1,-1,-1,-1,-1,-1,-1,-1,-1\n"
+
+#: ../include/wx/defs.h:2582
+msgid "All files (*.*)|*.*"
+msgstr "எல்லாக் கோப்புகளும் (*.*)|*.*"
+
+#: ../include/wx/defs.h:2585
+msgid "All files (*)|*"
+msgstr "எல்லாக் கோப்புகளும் (*)|*"
+
+#: ../include/wx/generic/progdlgg.h:85
+msgid "Elapsed time:"
+msgstr "கடந்துள்ள நேரம்"
+
+#: ../include/wx/generic/progdlgg.h:86
+msgid "Estimated time:"
+msgstr "மதிப்பிடப்பட்ட நேரம்:"
+
+#: ../include/wx/generic/progdlgg.h:87
+msgid "Remaining time:"
+msgstr "எஞ்சியுள்ள நேரம்"
+
+#. TRANSLATORS: HTML printout default title.
+#: ../include/wx/html/htmprint.h:121 ../include/wx/prntbase.h:273
+#: ../include/wx/richtext/richtextprint.h:109 ../src/common/docview.cpp:2161
+msgid "Printout"
+msgstr "அச்செடுப்பு"
+
+#. TRANSLATORS: HTML easy print default title.
+#: ../include/wx/html/htmprint.h:234
+#: ../include/wx/richtext/richtextprint.h:163 ../src/common/prntbase.cpp:522
+#: ../src/html/htmprint.cpp:291
+msgid "Printing"
+msgstr "அச்சிடப்படுகிறது"
+
+#: ../include/wx/msgdlg.h:277 ../src/common/stockitem.cpp:211
+msgid "Yes"
+msgstr "ஆம்"
+
+#: ../include/wx/msgdlg.h:278 ../src/common/stockitem.cpp:182
+msgid "No"
+msgstr "இல்லை"
+
+#: ../include/wx/msgdlg.h:279 ../src/common/stockitem.cpp:183
+#: ../src/msw/msgdlg.cpp:430 ../src/msw/msgdlg.cpp:734
+#: ../src/richtext/richtextstyledlg.cpp:292
+msgid "OK"
+msgstr "சரி"
+
+#: ../include/wx/msgdlg.h:280 ../src/common/stockitem.cpp:150
+#: ../src/msw/msgdlg.cpp:430 ../src/msw/progdlg.cpp:884
+#: ../src/richtext/richtextstyledlg.cpp:295
+msgid "Cancel"
+msgstr "விலக்குக"
+
+#: ../include/wx/msgdlg.h:281 ../src/common/stockitem.cpp:168
+#: ../src/html/helpdlg.cpp:63 ../src/html/helpfrm.cpp:108
+#: ../src/osx/button_osx.cpp:38
+msgid "Help"
+msgstr "உதவி"
+
+#: ../include/wx/msw/ole/oleutils.h:52
+msgid "Cannot initialize OLE"
+msgstr "OLE-இனை தொடக்கநிலையாக்க இயலவில்லை"
+
+#: ../include/wx/msw/private/fswatcher.h:48
+#, c-format
+msgid "Unable to close the handle for '%s'"
+msgstr "'%s'-ற்கான கையாளுதலை மூட இயலவில்லை"
+
+#: ../include/wx/msw/private/fswatcher.h:92
+#, c-format
+msgid "Failed to open directory \"%s\" for monitoring."
+msgstr "\"%s\" அடைவினை கண்காணிப்பதற்காக திறப்பதில் தோல்வி."
+
+#: ../include/wx/msw/private/fswatcher.h:125
+msgid "Unable to close I/O completion port handle"
+msgstr "உள்ளீடு/வெளியீடு நிறைவு நுழைவாயில் கையாளுதலை மூட இயலவில்லை"
+
+#: ../include/wx/msw/private/fswatcher.h:142
+msgid "Unable to associate handle with I/O completion port"
+msgstr "கையாளுதலை உள்ளீடு/வெளியீடு நிறைவு நுழைவாயிலுடன் தொடர்புபடுத்த இயலவில்லை."
+
+#: ../include/wx/msw/private/fswatcher.h:148
+msgid "Unexpectedly new I/O completion port was created"
+msgstr "புதிய உள்ளீடு/வெளியீடு நிறைவு ணுழைவாயில் எதிர்பாரா வண்ணம் உருவாக்கப்பட்டது."
+
+#: ../include/wx/msw/private/fswatcher.h:213
+msgid "Unable to post completion status"
+msgstr "நிறைவுநிலையை பதிய இயலவில்லை"
+
+#: ../include/wx/msw/private/fswatcher.h:262
+msgid "Unable to dequeue completion packet"
+msgstr "நிறைவுப் பொதியை வரிசையிலிருந்து நீக்க இயலவில்லை"
+
+#: ../include/wx/msw/private/fswatcher.h:273
+msgid "Unable to create I/O completion port"
+msgstr "உள்ளீடு/வெளியீடு நிறைவு நுழைவாயிலை உருவாக்க இயலவில்லை"
+
+#: ../include/wx/richmsgdlg.h:29
+msgid "&See details"
+msgstr "விவரங்களைக் காண்க (&S)"
+
+#: ../include/wx/richmsgdlg.h:30
+msgid "&Hide details"
+msgstr "விவரங்களை மறைத்திடுக (&H)"
+
+#: ../include/wx/richtext/richtextbuffer.h:3864
+msgid "&Box"
+msgstr "பெட்டி (&B)"
+
+#: ../include/wx/richtext/richtextbuffer.h:5008
+msgid "&Picture"
+msgstr "படம் (&P)"
+
+#: ../include/wx/richtext/richtextbuffer.h:5958
+msgid "&Cell"
+msgstr "களம் (&C)"
+
+#: ../include/wx/richtext/richtextbuffer.h:6067
+msgid "&Table"
+msgstr "அட்டவணை (&T)"
+
+#: ../include/wx/richtext/richtextimagedlg.h:37
+msgid "Object Properties"
+msgstr "பொருள் பண்புகள்"
+
+#: ../include/wx/richtext/richtextsymboldlg.h:39
+msgid "Symbols"
+msgstr "குறியெழுத்துகள்"
+
+#: ../include/wx/unix/pipe.h:46
+msgid "Pipe creation failed"
+msgstr "குழாய் உருவாக்கம் தோல்வியடைந்தது"
+
+#: ../include/wx/unix/private/displayx11.h:65
+msgid "Failed to enumerate video modes"
+msgstr "காணொலி முறைகளை பட்டியலிடுவதில் தோல்வி."
+
+#: ../include/wx/unix/private/displayx11.h:89
+msgid "Failed to change video mode"
+msgstr "காணொலி முறையை மாற்றுவதில் தோல்வி"
+
+#: ../include/wx/unix/private/fswatcher_kqueue.h:57
+#, c-format
+msgid "Unable to open path '%s'"
+msgstr "'%s' வழிதடத்தைத் திறக்க இயலவில்லை"
+
+#: ../include/wx/unix/private/fswatcher_kqueue.h:74
+#, c-format
+msgid "Unable to close path '%s'"
+msgstr "'%s' வழிதடத்தை மூட இயலவில்லை"
+
+#: ../include/wx/xtiprop.h:175
+msgid "SetProperty called w/o valid setter"
+msgstr "ஏற்கக்கூடிய அமைப்பி இல்லாத நிலையில் SetProperty அழைக்கப்பட்டது"
+
+#: ../include/wx/xtiprop.h:184
+msgid "GetProperty called w/o valid getter"
+msgstr "செல்லத்தக்க பெறுநர் இல்லாத நிலையில் GetProperty அழைக்கப்பட்டது"
+
+#: ../include/wx/xtiprop.h:193
+msgid "AddToPropertyCollection called w/o valid adder"
+msgstr ""
+"செல்லத்தக்க மதிப்புக்கூட்டி இல்லாத நிலையில் AddToPropertyCollection அழைக்கப்பட்டது"
+
+#: ../include/wx/xtiprop.h:202
+msgid "GetPropertyCollection called w/o valid collection getter"
+msgstr ""
+"செல்லத்தக்க சேர்மானப் பெறுநர் இல்லாத நிலையில் GetPropertyCollection அழைக்கப்பட்டது"
+
+#: ../include/wx/xtiprop.h:255
+msgid "AddToPropertyCollection called on a generic accessor"
+msgstr "பொது அணுகியின் மீதான AddToPropertyCollection அழைக்கப்பட்டது"
+
+#: ../include/wx/xtiprop.h:262
+msgid "GetPropertyCollection called on a generic accessor"
+msgstr "பொது அணுகியின் மீதான GetPropertyCollection அழைக்கப்பட்டது"
+
+#: ../src/aui/tabmdi.cpp:106 ../src/generic/mdig.cpp:94
+msgid "Cl&ose"
+msgstr "மூடுக (&O)"
+
+#: ../src/aui/tabmdi.cpp:107 ../src/generic/mdig.cpp:95
+msgid "Close All"
+msgstr "அனைத்தையும் மூடுக"
+
+#: ../src/aui/tabmdi.cpp:109 ../src/generic/mdig.cpp:97 ../src/msw/mdi.cpp:175
+#: ../src/qt/mdi.cpp:258
+msgid "&Next"
+msgstr "அடுத்தது (&N)"
+
+#: ../src/aui/tabmdi.cpp:110 ../src/generic/mdig.cpp:98 ../src/msw/mdi.cpp:176
+#: ../src/qt/mdi.cpp:259
+msgid "&Previous"
+msgstr "முந்தையது (&P)"
+
+#: ../src/aui/tabmdi.cpp:332 ../src/aui/tabmdi.cpp:348
+#: ../src/aui/tabmdi.cpp:350 ../src/generic/mdig.cpp:291
+#: ../src/generic/mdig.cpp:307 ../src/generic/mdig.cpp:311
+#: ../src/msw/mdi.cpp:337 ../src/qt/mdi.cpp:462
+msgid "&Window"
+msgstr "சாளரம் (&W)"
+
+#: ../src/common/accelcmn.cpp:47
+msgctxt "keyboard key"
+msgid "Delete"
+msgstr "அழி"
+
+#: ../src/common/accelcmn.cpp:48
+msgctxt "keyboard key"
+msgid "Del"
+msgstr "அழி"
+
+#: ../src/common/accelcmn.cpp:49
+msgctxt "keyboard key"
+msgid "Back"
+msgstr "பின்"
+
+#: ../src/common/accelcmn.cpp:49
+msgctxt "keyboard key"
+msgid "Backspace"
+msgstr "பின்னழி"
+
+#: ../src/common/accelcmn.cpp:50
+msgctxt "keyboard key"
+msgid "Insert"
+msgstr "செருகு"
+
+#: ../src/common/accelcmn.cpp:51
+msgctxt "keyboard key"
+msgid "Ins"
+msgstr "செருகு"
+
+#: ../src/common/accelcmn.cpp:52
+msgctxt "keyboard key"
+msgid "Enter"
+msgstr "உள்ளிடு"
+
+#: ../src/common/accelcmn.cpp:53
+msgctxt "keyboard key"
+msgid "Return"
+msgstr "உள்ளிடு"
+
+#: ../src/common/accelcmn.cpp:54
+msgctxt "keyboard key"
+msgid "PageUp"
+msgstr "பக்கம் மேல்"
+
+#: ../src/common/accelcmn.cpp:54
+msgctxt "keyboard key"
+msgid "Page Up"
+msgstr "பக்கம் மேல்"
+
+#: ../src/common/accelcmn.cpp:55
+msgctxt "keyboard key"
+msgid "PageDown"
+msgstr "பக்கம் கீழ்"
+
+#: ../src/common/accelcmn.cpp:55
+msgctxt "keyboard key"
+msgid "Page Down"
+msgstr "பக்கம் கீழ்"
+
+#: ../src/common/accelcmn.cpp:56
+msgctxt "keyboard key"
+msgid "PgUp"
+msgstr "பக்கம் மேல்"
+
+#: ../src/common/accelcmn.cpp:57
+msgctxt "keyboard key"
+msgid "PgDn"
+msgstr "பக்கம் கீழ்"
+
+#: ../src/common/accelcmn.cpp:58
+msgctxt "keyboard key"
+msgid "Left"
+msgstr "இடது"
+
+#: ../src/common/accelcmn.cpp:59
+msgctxt "keyboard key"
+msgid "Right"
+msgstr "வலது"
+
+#: ../src/common/accelcmn.cpp:60
+msgctxt "keyboard key"
+msgid "Up"
+msgstr "மேல்"
+
+#: ../src/common/accelcmn.cpp:61
+msgctxt "keyboard key"
+msgid "Down"
+msgstr "கீழ்"
+
+#: ../src/common/accelcmn.cpp:62
+msgctxt "keyboard key"
+msgid "Home"
+msgstr "தொடக்கம்"
+
+#: ../src/common/accelcmn.cpp:63
+msgctxt "keyboard key"
+msgid "End"
+msgstr "முடிவு"
+
+#: ../src/common/accelcmn.cpp:64
+msgctxt "keyboard key"
+msgid "Space"
+msgstr "இடைவெளி"
+
+#: ../src/common/accelcmn.cpp:65
+msgctxt "keyboard key"
+msgid "Tab"
+msgstr "தத்தல்"
+
+#: ../src/common/accelcmn.cpp:66
+msgctxt "keyboard key"
+msgid "Esc"
+msgstr "விடுபடு"
+
+#: ../src/common/accelcmn.cpp:67
+msgctxt "keyboard key"
+msgid "Escape"
+msgstr "விடுபடு"
+
+#: ../src/common/accelcmn.cpp:68
+msgctxt "keyboard key"
+msgid "Cancel"
+msgstr "விலக்குக"
+
+#: ../src/common/accelcmn.cpp:69
+msgctxt "keyboard key"
+msgid "Clear"
+msgstr "துடை"
+
+#: ../src/common/accelcmn.cpp:70
+msgctxt "keyboard key"
+msgid "Menu"
+msgstr "பட்டியல்"
+
+#: ../src/common/accelcmn.cpp:71
+msgctxt "keyboard key"
+msgid "Pause"
+msgstr "இடைநிறுத்தம்"
+
+#: ../src/common/accelcmn.cpp:72
+msgctxt "keyboard key"
+msgid "Capital"
+msgstr "முகப்பெழுத்து"
+
+#: ../src/common/accelcmn.cpp:73
+msgctxt "keyboard key"
+msgid "Select"
+msgstr "தெரிவு"
+
+#: ../src/common/accelcmn.cpp:74
+msgctxt "keyboard key"
+msgid "Print"
+msgstr "அச்சிடு"
+
+#: ../src/common/accelcmn.cpp:75
+msgctxt "keyboard key"
+msgid "Execute"
+msgstr "செயற்படுத்துக"
+
+#: ../src/common/accelcmn.cpp:76
+msgctxt "keyboard key"
+msgid "Snapshot"
+msgstr "பிடிப்புப்படம்"
+
+#: ../src/common/accelcmn.cpp:77
+msgctxt "keyboard key"
+msgid "Help"
+msgstr "உதவி"
+
+#: ../src/common/accelcmn.cpp:78
+msgctxt "keyboard key"
+msgid "Add"
+msgstr "சேர்த்திடுக"
+
+#: ../src/common/accelcmn.cpp:79
+msgctxt "keyboard key"
+msgid "Separator"
+msgstr "பிரிப்பான்"
+
+#: ../src/common/accelcmn.cpp:80
+msgctxt "keyboard key"
+msgid "Subtract"
+msgstr "கழித்தல்"
+
+#: ../src/common/accelcmn.cpp:81
+msgctxt "keyboard key"
+msgid "Decimal"
+msgstr "பதின்மம்"
+
+#: ../src/common/accelcmn.cpp:82
+msgctxt "keyboard key"
+msgid "Multiply"
+msgstr "பெருக்கல்"
+
+#: ../src/common/accelcmn.cpp:83
+msgctxt "keyboard key"
+msgid "Divide"
+msgstr "வகுத்தல்"
+
+#: ../src/common/accelcmn.cpp:84
+msgctxt "keyboard key"
+msgid "Num_lock"
+msgstr "எண் பூட்டு"
+
+#: ../src/common/accelcmn.cpp:84
+msgctxt "keyboard key"
+msgid "Num Lock"
+msgstr "எண் பூட்டு"
+
+#: ../src/common/accelcmn.cpp:85
+msgctxt "keyboard key"
+msgid "Scroll_lock"
+msgstr "உருள் பூட்டு"
+
+#: ../src/common/accelcmn.cpp:85
+msgctxt "keyboard key"
+msgid "Scroll Lock"
+msgstr "உருள் பூட்டு"
+
+#: ../src/common/accelcmn.cpp:86
+msgctxt "keyboard key"
+msgid "KP_Space"
+msgstr "KP_இடைவெளி"
+
+#: ../src/common/accelcmn.cpp:86
+msgctxt "keyboard key"
+msgid "Num Space"
+msgstr "Num இடைவெளி"
+
+#: ../src/common/accelcmn.cpp:87
+msgctxt "keyboard key"
+msgid "KP_Tab"
+msgstr "KP_தத்தல்"
+
+#: ../src/common/accelcmn.cpp:87
+msgctxt "keyboard key"
+msgid "Num Tab"
+msgstr "Num தத்தல்"
+
+#: ../src/common/accelcmn.cpp:88
+msgctxt "keyboard key"
+msgid "KP_Enter"
+msgstr "KP_உள்ளிடு"
+
+#: ../src/common/accelcmn.cpp:88
+msgctxt "keyboard key"
+msgid "Num Enter"
+msgstr "Num உள்ளிடு"
+
+#: ../src/common/accelcmn.cpp:89
+msgctxt "keyboard key"
+msgid "KP_Home"
+msgstr "KP_தொடக்கம்"
+
+#: ../src/common/accelcmn.cpp:89
+msgctxt "keyboard key"
+msgid "Num Home"
+msgstr "Num தொடக்கம்"
+
+#: ../src/common/accelcmn.cpp:90
+msgctxt "keyboard key"
+msgid "KP_Left"
+msgstr "KP_இடது"
+
+#: ../src/common/accelcmn.cpp:90
+msgctxt "keyboard key"
+msgid "Num left"
+msgstr "Num இடது"
+
+#: ../src/common/accelcmn.cpp:91
+msgctxt "keyboard key"
+msgid "KP_Up"
+msgstr "KP_மேல்"
+
+#: ../src/common/accelcmn.cpp:91
+msgctxt "keyboard key"
+msgid "Num Up"
+msgstr "Num மேல்"
+
+#: ../src/common/accelcmn.cpp:92
+msgctxt "keyboard key"
+msgid "KP_Right"
+msgstr "KP_வலது"
+
+#: ../src/common/accelcmn.cpp:92
+msgctxt "keyboard key"
+msgid "Num Right"
+msgstr "Num வலது"
+
+#: ../src/common/accelcmn.cpp:93
+msgctxt "keyboard key"
+msgid "KP_Down"
+msgstr "KP_கீழ்"
+
+#: ../src/common/accelcmn.cpp:93
+msgctxt "keyboard key"
+msgid "Num Down"
+msgstr "Num கீழ்"
+
+#: ../src/common/accelcmn.cpp:94
+msgctxt "keyboard key"
+msgid "KP_PageUp"
+msgstr "KP_பக்கம் மேல்"
+
+#: ../src/common/accelcmn.cpp:94
+msgctxt "keyboard key"
+msgid "Num Page Up"
+msgstr "Num பக்கம் மேல்"
+
+#: ../src/common/accelcmn.cpp:95
+msgctxt "keyboard key"
+msgid "KP_PageDown"
+msgstr "KP_பக்கம் கீழ்"
+
+#: ../src/common/accelcmn.cpp:95
+msgctxt "keyboard key"
+msgid "Num Page Down"
+msgstr "Num பக்கம் கீழ்"
+
+#: ../src/common/accelcmn.cpp:96
+msgctxt "keyboard key"
+msgid "KP_Prior"
+msgstr "KP_முந்தையது"
+
+#: ../src/common/accelcmn.cpp:97
+msgctxt "keyboard key"
+msgid "KP_Next"
+msgstr "KP_அடுத்தது"
+
+#: ../src/common/accelcmn.cpp:98
+msgctxt "keyboard key"
+msgid "KP_End"
+msgstr "KP_முடிவு"
+
+#: ../src/common/accelcmn.cpp:98
+msgctxt "keyboard key"
+msgid "Num End"
+msgstr "Num முடிவு"
+
+#: ../src/common/accelcmn.cpp:99
+msgctxt "keyboard key"
+msgid "KP_Begin"
+msgstr "KP_துவக்கம்"
+
+#: ../src/common/accelcmn.cpp:99
+msgctxt "keyboard key"
+msgid "Num Begin"
+msgstr "Num துவக்கம்"
+
+#: ../src/common/accelcmn.cpp:100
+msgctxt "keyboard key"
+msgid "KP_Insert"
+msgstr "KP_செருகு"
+
+#: ../src/common/accelcmn.cpp:100
+msgctxt "keyboard key"
+msgid "Num Insert"
+msgstr "Num செருகு"
+
+#: ../src/common/accelcmn.cpp:101
+msgctxt "keyboard key"
+msgid "KP_Delete"
+msgstr "KP_அழி"
+
+#: ../src/common/accelcmn.cpp:101
+msgctxt "keyboard key"
+msgid "Num Delete"
+msgstr "Num அழி"
+
+#: ../src/common/accelcmn.cpp:102
+msgctxt "keyboard key"
+msgid "KP_Equal"
+msgstr "KP_சமம்"
+
+#: ../src/common/accelcmn.cpp:102
+msgctxt "keyboard key"
+msgid "Num ="
+msgstr "Num ="
+
+#: ../src/common/accelcmn.cpp:103
+msgctxt "keyboard key"
+msgid "KP_Multiply"
+msgstr "KP_பெருக்கல்"
+
+#: ../src/common/accelcmn.cpp:103
+msgctxt "keyboard key"
+msgid "Num *"
+msgstr "Num *"
+
+#: ../src/common/accelcmn.cpp:104
+msgctxt "keyboard key"
+msgid "KP_Add"
+msgstr "KP_ஏற்று"
+
+#: ../src/common/accelcmn.cpp:104
+msgctxt "keyboard key"
+msgid "Num +"
+msgstr "Num +"
+
+#: ../src/common/accelcmn.cpp:105
+msgctxt "keyboard key"
+msgid "KP_Separator"
+msgstr "KP_பிரிப்பான்"
+
+#: ../src/common/accelcmn.cpp:105
+msgctxt "keyboard key"
+msgid "Num ,"
+msgstr "Num ,"
+
+#: ../src/common/accelcmn.cpp:106
+msgctxt "keyboard key"
+msgid "KP_Subtract"
+msgstr "KP_கழித்தல்"
+
+#: ../src/common/accelcmn.cpp:106
+msgctxt "keyboard key"
+msgid "Num -"
+msgstr "Num -"
+
+#: ../src/common/accelcmn.cpp:107
+msgctxt "keyboard key"
+msgid "KP_Decimal"
+msgstr "KP_பதின்மம்"
+
+#: ../src/common/accelcmn.cpp:107
+msgctxt "keyboard key"
+msgid "Num ."
+msgstr "Num ."
+
+#: ../src/common/accelcmn.cpp:108
+msgctxt "keyboard key"
+msgid "KP_Divide"
+msgstr "KP_வகுத்தல்"
+
+#: ../src/common/accelcmn.cpp:108
+msgctxt "keyboard key"
+msgid "Num /"
+msgstr "Num /"
+
+#: ../src/common/accelcmn.cpp:109
+msgctxt "keyboard key"
+msgid "Windows_Left"
+msgstr "இடது சாளரங்கள்"
+
+#: ../src/common/accelcmn.cpp:110
+msgctxt "keyboard key"
+msgid "Windows_Right"
+msgstr "வலது சாலரங்கள்"
+
+#: ../src/common/accelcmn.cpp:111
+msgctxt "keyboard key"
+msgid "Windows_Menu"
+msgstr "சாளரங்கள் பட்டியல்"
+
+#: ../src/common/accelcmn.cpp:112
+msgctxt "keyboard key"
+msgid "Command"
+msgstr "கட்டளை"
+
+#: ../src/common/accelcmn.cpp:186 ../src/common/accelcmn.cpp:359
+msgctxt "keyboard key"
+msgid "Ctrl"
+msgstr "கட்டுப்பாடு"
+
+#: ../src/common/accelcmn.cpp:188 ../src/common/accelcmn.cpp:363
+msgctxt "keyboard key"
+msgid "Alt"
+msgstr "நிலைமாற்றி"
+
+#: ../src/common/accelcmn.cpp:190 ../src/common/accelcmn.cpp:361
+msgctxt "keyboard key"
+msgid "Shift"
+msgstr "மாற்றழுத்தி"
+
+#: ../src/common/accelcmn.cpp:196
+msgctxt "keyboard key"
+msgid "num "
+msgstr "எண்"
+
+#: ../src/common/accelcmn.cpp:260 ../src/common/accelcmn.cpp:382
+msgctxt "keyboard key"
+msgid "F"
+msgstr "F"
+
+#: ../src/common/accelcmn.cpp:277 ../src/common/accelcmn.cpp:385
+msgctxt "keyboard key"
+msgid "KP_F"
+msgstr "KP_F"
+
+#: ../src/common/accelcmn.cpp:280 ../src/common/accelcmn.cpp:388
+msgctxt "keyboard key"
+msgid "KP_"
+msgstr "KP_"
+
+#: ../src/common/accelcmn.cpp:283 ../src/common/accelcmn.cpp:391
+msgctxt "keyboard key"
+msgid "SPECIAL"
+msgstr "சிறப்புடையது"
+
+#: ../src/common/accelcmn.cpp:373
+msgid "Ctrl"
+msgstr "கட்டுப்பாடு"
+
+#: ../src/common/appbase.cpp:786
+msgid "show this help message"
+msgstr "இவ்வுதவித் தகவலைக் காட்டுக"
+
+#: ../src/common/appbase.cpp:796
+msgid "generate verbose log messages"
+msgstr "தேவைக்கு மிகுதியானவைகளின் செயற்குறிப்பேட்டுத் தகவல்களை உருவாக்குக"
+
+#: ../src/common/appcmn.cpp:256
+msgid "specify the theme to use"
+msgstr "பயன்படுத்தப்பட வேண்டிய கருத்தோற்றத்தைக் குறிப்பிடுக"
+
+#: ../src/common/appcmn.cpp:270
+msgid "specify display mode to use (e.g. 640x480-16)"
+msgstr ""
+"பயன்படுத்தப்பட வேண்டிய காட்சியமைவு நிலையைக் குறிப்பிடுக (எடுத்துக்காட்டு: 640x480-16)"
+
+#: ../src/common/appcmn.cpp:292
+#, c-format
+msgid "Unsupported theme '%s'."
+msgstr "ஆதரிக்கப்படாத தோற்றம் '%s'"
+
+#: ../src/common/appcmn.cpp:309
+#, c-format
+msgid "Invalid display mode specification '%s'."
+msgstr "செல்லாத காட்சிப் பயன்முறை விவரக்குறிப்பு '%s'."
+
+#: ../src/common/cmdline.cpp:875
+#, c-format
+msgid "Option '%s' can't be negated"
+msgstr "'%s' விருப்பத் தேர்வினை மறுதலிக்க இயலாது"
+
+#: ../src/common/cmdline.cpp:889
+#, c-format
+msgid "Unknown long option '%s'"
+msgstr "அறியப்படாத நீள்விருப்பத்தேர்வு '%s'"
+
+#: ../src/common/cmdline.cpp:904 ../src/common/cmdline.cpp:926
+#, c-format
+msgid "Unknown option '%s'"
+msgstr "அறியப்படாத விருப்பத்தேர்வு '%s'"
+
+#: ../src/common/cmdline.cpp:1004
+#, c-format
+msgid "Unexpected characters following option '%s'."
+msgstr "'%s' விருப்பத் தேர்வுற்கு பின் எதிர்பாராத வரியுருக்கள்."
+
+#: ../src/common/cmdline.cpp:1039
+#, c-format
+msgid "Option '%s' requires a value."
+msgstr "'%s' விருப்பத் தேர்விற்கு ஒரு மதிப்பு தேவைப்படுகிறது."
+
+#: ../src/common/cmdline.cpp:1058
+#, c-format
+msgid "Separator expected after the option '%s'."
+msgstr "'%s' விருப்பத் தேர்விற்குப் பிறகு பிரிப்பான் எதிர்பார்க்கப்படுகிறது"
+
+#: ../src/common/cmdline.cpp:1088 ../src/common/cmdline.cpp:1106
+#, c-format
+msgid "'%s' is not a correct numeric value for option '%s'."
+msgstr "'%s' எண் மதிப்பு, '%s' விருப்பத் தேர்விற்கு சரியானது அல்ல."
+
+#: ../src/common/cmdline.cpp:1122
+#, c-format
+msgid "Option '%s': '%s' cannot be converted to a date."
+msgstr "'%s' விருப்பத் தேர்வு: '%s'-யினை ஒரு தேதியாக மாற்ற இயலாது."
+
+#: ../src/common/cmdline.cpp:1170
+#, c-format
+msgid "Unexpected parameter '%s'"
+msgstr "எதிர்பாராத அளவுரு '%s'"
+
+#. TRANSLATORS: Short name and long name for a command line option
+#: ../src/common/cmdline.cpp:1197
+#, c-format
+msgid "%s (or %s)"
+msgstr "%s (அல்லது %s)"
+
+#: ../src/common/cmdline.cpp:1208
+#, c-format
+msgid "The value for the option '%s' must be specified."
+msgstr "'%s' விருப்பத் தேர்விற்கான மதிப்பைக் குறிப்பிட வேண்டும்."
+
+#: ../src/common/cmdline.cpp:1230
+#, c-format
+msgid "The required parameter '%s' was not specified."
+msgstr "தேவைப்படும் '%s' அளவுக் குறியீடு குறிப்பிடப்படவில்லை."
+
+#: ../src/common/cmdline.cpp:1289
+#, c-format
+msgid "Usage: %s"
+msgstr "பயன்பாடு: %s"
+
+#: ../src/common/cmdline.cpp:1498
+msgid "str"
+msgstr "str"
+
+#: ../src/common/cmdline.cpp:1502
+msgid "num"
+msgstr "எண்"
+
+#: ../src/common/cmdline.cpp:1506
+msgid "double"
+msgstr "இரட்டை"
+
+#: ../src/common/cmdline.cpp:1510
+msgid "date"
+msgstr "தேதி"
+
+#: ../src/common/cmdproc.cpp:250 ../src/common/cmdproc.cpp:276
+#: ../src/common/cmdproc.cpp:296
+msgid "Unnamed command"
+msgstr "பெயரிடப்படாத கட்டளை"
+
+#: ../src/common/cmdproc.cpp:253
+msgid "&Undo "
+msgstr "செயல் நீக்கம் (&U)"
+
+#: ../src/common/cmdproc.cpp:255
+msgid "Can't &Undo "
+msgstr "செயலைநீக்க இயலவில்லை (&U)"
+
+#: ../src/common/cmdproc.cpp:259 ../src/common/stockitem.cpp:208
+#: ../src/msw/textctrl.cpp:2880 ../src/osx/textctrl_osx.cpp:649
+#: ../src/richtext/richtextctrl.cpp:327
+msgid "&Undo"
+msgstr "செயல் நீக்கம் (&U)"
+
+#: ../src/common/cmdproc.cpp:277 ../src/common/cmdproc.cpp:297
+msgid "&Redo "
+msgstr "மீள்செயல் (&R)"
+
+#: ../src/common/cmdproc.cpp:281 ../src/common/cmdproc.cpp:288
+#: ../src/common/stockitem.cpp:190 ../src/msw/textctrl.cpp:2881
+#: ../src/osx/textctrl_osx.cpp:650 ../src/richtext/richtextctrl.cpp:328
+msgid "&Redo"
+msgstr "மீள்செயல் (&R)"
+
+#: ../src/common/colourcmn.cpp:41
+#, c-format
+msgid "String To Colour : Incorrect colour specification : %s"
+msgstr "சரத்திலிருந்து நிறம்: தவறான நிறக் குறிப்பீடு: %s"
+
+#: ../src/common/config.cpp:259
+#, c-format
+msgid "Invalid value %ld for a boolean key \"%s\" in config file."
+msgstr "அமைவடிவக் கோப்பில் செல்லாத %ld மதிப்பு (\"%s\" பூலிய விசைக்கானது). "
+
+#: ../src/common/config.cpp:526
+#, c-format
+msgid ""
+"Environment variables expansion failed: missing '%c' at position %u in '%s'."
+msgstr ""
+"சூழல் மாறிகள் விரிவாக்கம் தோல்வியடைந்தது: '%c' தவறவிடப்பட்டுள்ளது (நிலை: %u, '%s'-உள்)."
+
+#: ../src/common/config.cpp:576 ../src/msw/regconf.cpp:272
+#, c-format
+msgid "'%s' has extra '..', ignored."
+msgstr "'%s' மிகையாகவுள்ளது '..', புறந்தள்ளப்பட்டது."
+
+#. TRANSLATORS: Checkbox state name
+#: ../src/common/datavcmn.cpp:2166 ../src/generic/datavgen.cpp:1430
+msgid "checked"
+msgstr "தேர்வானது"
+
+#. TRANSLATORS: Checkbox state name
+#: ../src/common/datavcmn.cpp:2170 ../src/generic/datavgen.cpp:1432
+msgid "unchecked"
+msgstr "தேர்வாகாதது"
+
+#. TRANSLATORS: Checkbox state name
+#: ../src/common/datavcmn.cpp:2174
+msgid "undetermined"
+msgstr "தீர்மானிக்கப்படாதது"
+
+#: ../src/common/datetimefmt.cpp:1875
+msgid "today"
+msgstr "இன்று"
+
+#: ../src/common/datetimefmt.cpp:1876
+msgid "yesterday"
+msgstr "நேற்று"
+
+#: ../src/common/datetimefmt.cpp:1877
+msgid "tomorrow"
+msgstr "நாளை"
+
+#: ../src/common/datetimefmt.cpp:2071
+msgid "first"
+msgstr "முதல்"
+
+#: ../src/common/datetimefmt.cpp:2072
+msgid "second"
+msgstr "இரண்டாம்"
+
+#: ../src/common/datetimefmt.cpp:2073
+msgid "third"
+msgstr "மூன்றாம்"
+
+#: ../src/common/datetimefmt.cpp:2074
+msgid "fourth"
+msgstr "நான்காம்"
+
+#: ../src/common/datetimefmt.cpp:2075
+msgid "fifth"
+msgstr "ஐந்தாம்"
+
+#: ../src/common/datetimefmt.cpp:2076
+msgid "sixth"
+msgstr "ஆறாம்"
+
+#: ../src/common/datetimefmt.cpp:2077
+msgid "seventh"
+msgstr "ஏழாம்"
+
+#: ../src/common/datetimefmt.cpp:2078
+msgid "eighth"
+msgstr "எட்டாம்"
+
+#: ../src/common/datetimefmt.cpp:2079
+msgid "ninth"
+msgstr "ஒன்பதாம்"
+
+#: ../src/common/datetimefmt.cpp:2080
+msgid "tenth"
+msgstr "பத்தாம்"
+
+#: ../src/common/datetimefmt.cpp:2081
+msgid "eleventh"
+msgstr "பதினொன்றாம்"
+
+#: ../src/common/datetimefmt.cpp:2082
+msgid "twelfth"
+msgstr "பன்னிரண்டாம்"
+
+#: ../src/common/datetimefmt.cpp:2083
+msgid "thirteenth"
+msgstr "பதிமூன்றாம்"
+
+#: ../src/common/datetimefmt.cpp:2084
+msgid "fourteenth"
+msgstr "பதினான்காம்"
+
+#: ../src/common/datetimefmt.cpp:2085
+msgid "fifteenth"
+msgstr "பதினைந்தாம்"
+
+#: ../src/common/datetimefmt.cpp:2086
+msgid "sixteenth"
+msgstr "பதினாறாம்"
+
+#: ../src/common/datetimefmt.cpp:2087
+msgid "seventeenth"
+msgstr "பதினேழாம்"
+
+#: ../src/common/datetimefmt.cpp:2088
+msgid "eighteenth"
+msgstr "பதினெட்டாம்"
+
+#: ../src/common/datetimefmt.cpp:2089
+msgid "nineteenth"
+msgstr "பத்தொன்பதாம்"
+
+#: ../src/common/datetimefmt.cpp:2090
+msgid "twentieth"
+msgstr "இருபதாம்"
+
+#: ../src/common/datetimefmt.cpp:2248
+msgid "noon"
+msgstr "நண்பகல்"
+
+#: ../src/common/datetimefmt.cpp:2249
+msgid "midnight"
+msgstr "நள்ளிரவு"
+
+#: ../src/common/debugrpt.cpp:209
+#, c-format
+msgid "Failed to create directory \"%s\""
+msgstr "\"%s\" அடைவினை உருவாக்குவதில் தோல்வி."
+
+#: ../src/common/debugrpt.cpp:210
+msgid "Debug report couldn't be created."
+msgstr "வழுநீக்க அறிக்கையை உருவாக்க இயலவில்லை."
+
+#: ../src/common/debugrpt.cpp:227
+#, c-format
+msgid "Failed to remove debug report file \"%s\""
+msgstr "\"%s\" வழுநீக்க அறிக்கையை நீக்குவதில் தோல்வி"
+
+#: ../src/common/debugrpt.cpp:239
+#, c-format
+msgid "Failed to clean up debug report directory \"%s\""
+msgstr "\"%s\" வழுநீக்க அறிக்கை அடைவினை தூய்மைப்படுத்துவதில் தோல்வி"
+
+#: ../src/common/debugrpt.cpp:514
+msgid "process context description"
+msgstr "செயல்முறை சூழலமைவு விளக்கம்"
+
+#: ../src/common/debugrpt.cpp:538
+msgid "dump of the process state (binary)"
+msgstr "செயல்முறை நிலை கொட்டிடம் (இருமம்)"
+
+#: ../src/common/debugrpt.cpp:553
+msgid "Debug report generation has failed."
+msgstr "வழுநீக்க அறிக்கையின் உருவாக்கம் தோல்வியடைந்துள்ளது."
+
+#: ../src/common/debugrpt.cpp:560
+#, c-format
+msgid ""
+"Processing debug report has failed, leaving the files in \"%s\" directory."
+msgstr ""
+"வழுநீக்க அறிக்கையின் செயல்முறை தோல்வியடைந்தது, கோப்புகள் \"%s\" அடைவில் விடப்படுகிறது."
+
+#: ../src/common/debugrpt.cpp:573
+msgid "A debug report has been generated. It can be found in"
+msgstr "ஒரு வழுநீக்க அறிக்கை உருவாக்கப்பட்டுள்ளது. அதை இங்கே காணலாம்:"
+
+#: ../src/common/debugrpt.cpp:576
+msgid "And includes the following files:\n"
+msgstr "பின்வரும் கோப்புகளும் சேர்க்கப்பட்டுள்ளன: \n"
+
+#: ../src/common/debugrpt.cpp:586
+msgid ""
+"\n"
+"Please send this report to the program maintainer, thank you!\n"
+msgstr ""
+"\n"
+"இந்த அறிக்கையை அருள்கூர்ந்து நிரல் காப்பாளரிடம் அனுப்பி வைக்கவும், நன்றி! \n"
+
+#: ../src/common/debugrpt.cpp:729
+msgid "Failed to execute curl, please install it in PATH."
+msgstr "curl-இனை செயலாக்குவதில் தோல்வி. அருள்கூர்ந்து வழித்தடத்தில் அதை நிறுவவும்."
+
+#: ../src/common/debugrpt.cpp:742
+#, c-format
+msgid "Failed to upload the debug report (error code %d)."
+msgstr "வழுநீக்க அறிக்கையை தரவேற்றுவதில் தோல்வி (பிழைக் குறி: %d)."
+
+#: ../src/common/docview.cpp:366
+msgid "Save As"
+msgstr "இவ்வாறு சேமித்திடுக"
+
+#: ../src/common/docview.cpp:457
+msgid "Discard changes and reload the last saved version?"
+msgstr "மாற்றங்களை நிராகரித்துவிட்டு இறுதியாக சேமிக்கப்பட்டுள்ள பதிப்பை மீளேற்ற வேண்டுமா?"
+
+#: ../src/common/docview.cpp:488
+msgid "unnamed"
+msgstr "பெயரிடப்படாதது"
+
+#: ../src/common/docview.cpp:513
+#, c-format
+msgid "Do you want to save changes to %s?"
+msgstr "%s-இல் ஏற்பட்டுள்ள மாற்றங்களை தாங்கள் சேமிக்க வேண்டுமா?"
+
+#: ../src/common/docview.cpp:521 ../src/common/docview.cpp:560
+#: ../src/common/stockitem.cpp:195
+msgid "&Save"
+msgstr "சேமித்திடுக (&S)"
+
+#: ../src/common/docview.cpp:522 ../src/common/docview.cpp:560
+msgid "&Discard changes"
+msgstr "& மாற்றங்களை நிராகரித்திடுக"
+
+#: ../src/common/docview.cpp:523
+msgid "Do&n't close"
+msgstr "மூடாதிருந்திடுக (&N)"
+
+#: ../src/common/docview.cpp:553
+#, c-format
+msgid "Do you want to save changes to %s before closing it?"
+msgstr "மூடுவதற்கு முன் %s-இல் ஏற்பட்டுள்ள மாற்றங்களை தாங்கள் சேமிக்க விரும்புகிறீர்களா?"
+
+#: ../src/common/docview.cpp:559
+msgid "The document must be closed."
+msgstr "ஆவணம் மூடப்பட வேண்டும்."
+
+#: ../src/common/docview.cpp:571
+#, c-format
+msgid "Saving %s failed, would you like to retry?"
+msgstr "%s சேமிப்பதில் தோல்வி. மீண்டும் முயல விரும்புகிறீர்களா?"
+
+#: ../src/common/docview.cpp:577
+msgid "Retry"
+msgstr "மீண்டும் முயல்க"
+
+#: ../src/common/docview.cpp:577
+msgid "Discard changes"
+msgstr "& மாற்றங்களை நிராகரித்திடுக"
+
+#: ../src/common/docview.cpp:679
+#, c-format
+msgid "File \"%s\" could not be opened for writing."
+msgstr "\"%s\" கோப்பினை எழுதுவதற்கு திறக்க இயலவில்லை."
+
+#: ../src/common/docview.cpp:685
+#, c-format
+msgid "Failed to save document to the file \"%s\"."
+msgstr "ஆவணத்தை \"%s\" கோப்பில் சேமிப்பதில் தோல்வி."
+
+#: ../src/common/docview.cpp:702
+#, c-format
+msgid "File \"%s\" could not be opened for reading."
+msgstr "\"%s\" கோப்பினை படிப்பதற்கு திறக்க இயலவில்லை."
+
+#: ../src/common/docview.cpp:714
+#, c-format
+msgid "Failed to read document from the file \"%s\"."
+msgstr "\"%s\" கோப்பிலிருந்து ஆவணத்தைப் படிப்பதில் தோல்வி."
+
+#: ../src/common/docview.cpp:1236
+#, c-format
+msgid ""
+"The file '%s' doesn't exist and couldn't be opened.\n"
+"It has been removed from the most recently used files list."
+msgstr ""
+"கோப்பு '%s' கிடைப்பிலில்லையென்பதால், அதைத் திறக்க இயலாது.\n"
+"மிக அண்மையில் பயன்படுத்தப்பட்ட கோப்புகளின் பட்டியலிலிருந்து அது நீக்கப்பட்டுள்ளது."
+
+#: ../src/common/docview.cpp:1296
+msgid "Print preview creation failed."
+msgstr "அச்சு முன்தோற்ற உருவாக்கம் தோல்வியடைந்தது."
+
+#: ../src/common/docview.cpp:1302
+msgid "Print Preview"
+msgstr "அச்சு முன்தோற்றம்"
+
+#: ../src/common/docview.cpp:1517
+#, c-format
+msgid "The format of file '%s' couldn't be determined."
+msgstr "'%s' கோப்பின் வடிவூட்டத்தை வரையறுக்க இயலவில்லை."
+
+#: ../src/common/docview.cpp:1643
+#, c-format
+msgid "unnamed%d"
+msgstr "பெயரிடப்படாதது %d"
+
+#: ../src/common/docview.cpp:1660
+msgid " - "
+msgstr " - "
+
+#: ../src/common/docview.cpp:1791 ../src/common/docview.cpp:1844
+msgid "Open File"
+msgstr "கோப்பினைத் திறவுக"
+
+#: ../src/common/docview.cpp:1807
+msgid "File error"
+msgstr "கோப்புப் பிழை"
+
+#: ../src/common/docview.cpp:1809
+msgid "Sorry, could not open this file."
+msgstr "பொறுத்தருள்க, இந்தக் கோப்பினைத் திறக்க இயலவில்லை."
+
+#: ../src/common/docview.cpp:1843
+msgid "Sorry, the format for this file is unknown."
+msgstr "பொறுத்தருள்க, இந்தக் கோப்பிற்கான வடிவூட்டம் அறியப்படாததாக உள்ளது."
+
+#: ../src/common/docview.cpp:1924
+msgid "Select a document template"
+msgstr "ஒரு ஆவண வார்ப்புருவைத் தேர்ந்தெடுத்திடுக"
+
+#: ../src/common/docview.cpp:1925
+msgid "Templates"
+msgstr "வார்ப்புருக்கள்"
+
+#: ../src/common/docview.cpp:1998
+msgid "Select a document view"
+msgstr "ஒரு ஆவணத் தோற்றத்தை தெரிவுச் செய்க"
+
+#: ../src/common/docview.cpp:1999
+msgid "Views"
+msgstr "தோற்றங்கள்"
+
+#: ../src/common/dynlib.cpp:81
+#, c-format
+msgid "Failed to load shared library '%s'"
+msgstr "'%s' பகிர்வு நூலகத்தை ஏற்றுவதில் தோல்வி"
+
+#: ../src/common/dynlib.cpp:105
+#, c-format
+msgid "Couldn't find symbol '%s' in a dynamic library"
+msgstr "'%s' குறியெழுத்தினை இயங்குநிலை நூலகத்தில் காண இயலவில்லை."
+
+#: ../src/common/ffile.cpp:56 ../src/common/file.cpp:215
+#, c-format
+msgid "can't open file '%s'"
+msgstr "'%s' கோப்பினை திறக்க இயலாது"
+
+#: ../src/common/ffile.cpp:72
+#, c-format
+msgid "can't close file '%s'"
+msgstr "'%s' கோப்பினை மூட இயலாது"
+
+#: ../src/common/ffile.cpp:106 ../src/common/ffile.cpp:131
+#, c-format
+msgid "Read error on file '%s'"
+msgstr "'%s' கோப்பின் மீதான பிழையைப் படித்திடுக"
+
+#: ../src/common/ffile.cpp:148
+#, c-format
+msgid "Write error on file '%s'"
+msgstr "'%s' கோப்பில் மீது பிழையை எழுதிடுக"
+
+#: ../src/common/ffile.cpp:182
+#, c-format
+msgid "failed to flush the file '%s'"
+msgstr "'%s' கோப்பினை வெளித்தள்ளுவதில் தோல்வி"
+
+#: ../src/common/ffile.cpp:222
+#, c-format
+msgid "Seek error on file '%s' (large files not supported by stdio)"
+msgstr "'%s' கோப்பின் மீதான  நாடல் பிழை (பெரிய கோப்புகளுக்கு stdio ஆதரவு இல்லை)"
+
+#: ../src/common/ffile.cpp:232
+#, c-format
+msgid "Seek error on file '%s'"
+msgstr "'%s' கோப்பின் மீதான நாடல் பிழை"
+
+#: ../src/common/ffile.cpp:248
+#, c-format
+msgid "Can't find current position in file '%s'"
+msgstr "'%s' கோப்பில் தற்போதைய நிலையைக் காண இயலவில்லை"
+
+#: ../src/common/ffile.cpp:349 ../src/common/file.cpp:569
+msgid "Failed to set temporary file permissions"
+msgstr "தற்காலிக கோப்பு அனுமதிகளை அமைப்பதில் தோல்வி"
+
+#: ../src/common/ffile.cpp:371
+#, c-format
+msgid "can't remove file '%s'"
+msgstr "'%s' கோப்பினை நீக்க இயலாது"
+
+#: ../src/common/ffile.cpp:376 ../src/common/file.cpp:591
+#, c-format
+msgid "can't commit changes to file '%s'"
+msgstr "'%s' கோப்பிலுள்ள மாற்றங்களை உறுதிசெய்ய இயலாது"
+
+#: ../src/common/ffile.cpp:388 ../src/common/file.cpp:603
+#, c-format
+msgid "can't remove temporary file '%s'"
+msgstr "'%s' தற்காலிக கோப்பினை நீக்க இயலாது"
+
+#: ../src/common/file.cpp:162
+#, c-format
+msgid "can't create file '%s'"
+msgstr "'%s' கோப்பினை உருவாக்க இயலாது"
+
+#: ../src/common/file.cpp:229
+#, c-format
+msgid "can't close file descriptor %d"
+msgstr "%d கோப்பு விவரிப்பானை மூட இயலாது"
+
+#: ../src/common/file.cpp:332
+#, c-format
+msgid "can't read from file descriptor %d"
+msgstr "%d கோப்பு விவரிப்பானிலிருந்து படிக்க இயலாது"
+
+#: ../src/common/file.cpp:351
+#, c-format
+msgid "can't write to file descriptor %d"
+msgstr "%d கோப்பு விவரிப்பானில் எழுத இயலாது"
+
+#: ../src/common/file.cpp:390
+#, c-format
+msgid "can't flush file descriptor %d"
+msgstr "%d கோப்பு விவரிப்பானை வெளித்தள்ள இயலாது"
+
+#: ../src/common/file.cpp:432
+#, c-format
+msgid "can't seek on file descriptor %d"
+msgstr "%d கோப்பு விவரிப்பானில் நாட இயலாது"
+
+#: ../src/common/file.cpp:446
+#, c-format
+msgid "can't get seek position on file descriptor %d"
+msgstr "%d கோப்பு விவரிப்பானில் நாடும் நிலையை பெற இயலாது"
+
+#: ../src/common/file.cpp:475
+#, c-format
+msgid "can't find length of file on file descriptor %d"
+msgstr "%d கோப்பு விவரிப்பானில் கோப்பின் நீளத்தை கண்டறிய இயலாது."
+
+#: ../src/common/file.cpp:505
+#, c-format
+msgid "can't determine if the end of file is reached on descriptor %d"
+msgstr "%d விவரிப்பானில் கோப்பின் இறுதியை அடைந்துவிட்டதை தீர்மானிக்க இயலாது"
+
+#: ../src/common/fileconf.cpp:352
+#, c-format
+msgid ""
+" and additionally, the existing configuration file was renamed to \"%s\" and "
+"couldn't be renamed back, please rename it to its original path \"%s\""
+msgstr ""
+"கூடுதலாக, தற்போதைய அமைவடிவக் கோப்பு \"%s\" என்று மறுபெயரிடப்பட்டுள்ளது. அதன் முந்தைய "
+"பெயருக்கு மாற்ற இயலவில்லை. \"%s\" என்கிற அதன் அசல் தடத்திற்கு அருள்கூர்ந்து மறுபெயரிடவும்"
+
+#: ../src/common/fileconf.cpp:389
+msgid " due to the following error:\n"
+msgstr "பின்வரும் பிழை காரணமாக:\n"
+
+#: ../src/common/fileconf.cpp:412
+msgid "failed to rename the existing file"
+msgstr "தற்போதுள்ள கோப்பை மறுபெயரிடுவதில் தோல்வி"
+
+#: ../src/common/fileconf.cpp:421
+msgid "failed to create the new file directory"
+msgstr "புதிய கோப்பு அடைவை உருவாக்குவதில் தோல்வி"
+
+#: ../src/common/fileconf.cpp:428
+msgid "failed to move the file to the new location"
+msgstr "புதிய இடத்திற்கு கோப்பை நகர்த்துவதில் தோல்வி"
+
+#: ../src/common/fileconf.cpp:462
+#, c-format
+msgid "can't open global configuration file '%s'."
+msgstr "'%s' முழுதளாவிய அமைவடிவ கோப்பினை திறக்க இயலாது"
+
+#: ../src/common/fileconf.cpp:478
+#, c-format
+msgid "can't open user configuration file '%s'."
+msgstr "'%s' பயனர் அமைவடிவக் கோப்பினை திறக்க இயலாது"
+
+#: ../src/common/fileconf.cpp:483
+#, c-format
+msgid "Changes won't be saved to avoid overwriting the existing file \"%s\""
+msgstr "\"%s\" கோப்பினை அழித்தெழுதுவதைத் தவிர்க்க, மாற்றங்கள் சேமிக்கப்பட மாட்டாது "
+
+#: ../src/common/fileconf.cpp:583
+msgid "Error reading config options."
+msgstr "அமைவடிவ விருப்பத் தேர்வுகளைப் படிப்பதில் பிழை."
+
+#: ../src/common/fileconf.cpp:593
+msgid "Failed to read config options."
+msgstr "அமைவடிவ விருப்பத் தேர்வுகளைப் படிப்பதில் தோல்வி."
+
+#: ../src/common/fileconf.cpp:700
+#, c-format
+msgid "file '%s': unexpected character %c at line %zu."
+msgstr "கோப்பு '%s': எதிர்பாராத வரியுரு %c. அமைவிடம்: வரி %zu."
+
+#: ../src/common/fileconf.cpp:736
+#, c-format
+msgid "file '%s', line %zu: '%s' ignored after group header."
+msgstr "கோப்பு '%s', வரி %zu: குழுத் தலைப்புரைக்குப் பிறகான '%s' புறந்தள்ளப்பட்டது."
+
+#: ../src/common/fileconf.cpp:765
+#, c-format
+msgid "file '%s', line %zu: '=' expected."
+msgstr "கோப்பு '%s', வரி %zu: '=' எதிர்பார்க்கப்படுகிறது."
+
+#: ../src/common/fileconf.cpp:778
+#, c-format
+msgid "file '%s', line %zu: value for immutable key '%s' ignored."
+msgstr ""
+"கோப்பு '%s', வரி %zu: '%s' மாறுமியல்பிலா திறப்புச்சொல்லின் மதிப்பு புறந்தள்ளப்படுகிறது."
+
+#: ../src/common/fileconf.cpp:788
+#, c-format
+msgid "file '%s', line %zu: key '%s' was first found at line %d."
+msgstr ""
+"கோப்பு '%s', வரி %zu: '%s' திறப்புச்சொல், %d வரியில் முதலாவதாக கண்டறியப்பட்டது."
+
+#: ../src/common/fileconf.cpp:1091
+#, c-format
+msgid "Config entry name cannot start with '%c'."
+msgstr "அமைவடிவ உள்ளிடின் பெயர் '%c' என்று துவங்க இயலாது."
+
+#: ../src/common/fileconf.cpp:1146
+msgid "Failed to create configuration file directory."
+msgstr "அமைவடிவக் கோப்பு அடைவை உருவாக்குவதில் தோல்வி."
+
+#: ../src/common/fileconf.cpp:1158
+msgid "can't open user configuration file."
+msgstr "பயனர் அமைவடிவக் கோப்பினை திறக்க இயலாது"
+
+#: ../src/common/fileconf.cpp:1172
+msgid "can't write user configuration file."
+msgstr "பயனர் அமைவடிவக் கோப்பில் எழுத இயலாது."
+
+#: ../src/common/fileconf.cpp:1178
+msgid "Failed to update user configuration file."
+msgstr "பயனர் அமைவடிவக் கோப்பினை இற்றாக்குவதில் தோல்வி."
+
+#: ../src/common/fileconf.cpp:1201
+msgid "Error saving user configuration data."
+msgstr "பயனர் அமைவடிவத் தரவினை சேமிப்பதில் பிழை."
+
+#: ../src/common/fileconf.cpp:1313
+#, c-format
+msgid "can't delete user configuration file '%s'"
+msgstr "'%s' பயனர் அமைவடிவ கோப்பினை அழிக்க இயலாது"
+
+#: ../src/common/fileconf.cpp:2007
+#, c-format
+msgid "entry '%s' appears more than once in group '%s'"
+msgstr "'%s' உள்ளிடு '%s' குழுவில் ஒரு முறைக்கும் மேல் தோன்றுகிறது"
+
+#: ../src/common/fileconf.cpp:2021
+#, c-format
+msgid "attempt to change immutable key '%s' ignored."
+msgstr "மாறுமியல்பிலா '%s' திறப்புச்சொல்லை மாற்ற மேற்கொள்ளப்பட்ட முயற்சி புறந்தள்ளப்பட்டது."
+
+#: ../src/common/fileconf.cpp:2118
+#, c-format
+msgid "trailing backslash ignored in '%s'"
+msgstr "'%s'-ல் பின்னொட்டு பின்சாய்வு புறந்தள்ளப்படுகிறது"
+
+#: ../src/common/fileconf.cpp:2153
+#, c-format
+msgid "unexpected \" at position %d in '%s'."
+msgstr "%d நிலையில் எதிர்பாராத \".  அமைவிடம்: '%s"
+
+#: ../src/common/filefn.cpp:474
+#, c-format
+msgid "Failed to copy the file '%s' to '%s'"
+msgstr "'%s' கோப்பினை '%s'-க்கு படியெடுப்பதில் தோல்வி."
+
+#: ../src/common/filefn.cpp:487
+#, c-format
+msgid "Impossible to get permissions for file '%s'"
+msgstr "'%s' கோப்பிற்கு அனுமதிகளைப் பெற இயலவில்லை."
+
+#: ../src/common/filefn.cpp:501
+#, c-format
+msgid "Impossible to overwrite the file '%s'"
+msgstr "'%s' கோப்பினை அழித்தெழுத இயலவில்லை."
+
+#: ../src/common/filefn.cpp:508
+#, c-format
+msgid "Error copying the file '%s' to '%s'."
+msgstr "'%s' கோப்பினை '%s'-க்கு படியெடுப்பதில் பிழை"
+
+#: ../src/common/filefn.cpp:556
+#, c-format
+msgid "Impossible to set permissions for the file '%s'"
+msgstr "'%s' கோப்பிற்கான அனுமதிகளை அமைக்க இயலவில்லை."
+
+#: ../src/common/filefn.cpp:606
+#, c-format
+msgid ""
+"Failed to rename the file '%s' to '%s' because the destination file already "
+"exists."
+msgstr ""
+"இலக்குக் கோப்பு ஏற்கனவே இருப்பதால், '%s' கோப்பினை '%s' என்றுப் பெயர் மாற்றுவதில் தோல்வி."
+
+#: ../src/common/filefn.cpp:623
+#, c-format
+msgid "File '%s' couldn't be renamed '%s'"
+msgstr "'%s' கோப்பு '%s' என்று மறுபெயரிடப்பட இயலவில்லை"
+
+#: ../src/common/filefn.cpp:639
+#, c-format
+msgid "File '%s' couldn't be removed"
+msgstr "'%s' கோப்பு நீக்கப்பட இயலவில்லை"
+
+#: ../src/common/filefn.cpp:666
+#, c-format
+msgid "Directory '%s' couldn't be created"
+msgstr "'%s' அடைவினை உருவாக்க இயலவில்லை"
+
+#: ../src/common/filefn.cpp:680
+#, c-format
+msgid "Directory '%s' couldn't be deleted"
+msgstr "'%s' அடைவினை அழிக்க இயலவில்லை"
+
+#: ../src/common/filefn.cpp:714
+#, c-format
+msgid "Cannot enumerate files '%s'"
+msgstr "'%s' கோப்புகளைப் பட்டியலிட இயலவில்லை"
+
+#: ../src/common/filefn.cpp:798
+msgid "Failed to get the working directory"
+msgstr "செயல்பாட்டு அடைவினைப் பெறுவதில் தோல்வி"
+
+#: ../src/common/filefn.cpp:843
+msgid "Could not set current working directory"
+msgstr "தற்போதைய செயல்பாட்டு அடைவினை அமைக்க இயலவில்லை."
+
+#: ../src/common/filefn.cpp:974
+#, c-format
+msgid "Files (%s)"
+msgstr "கோப்புகள் (%s)"
+
+#: ../src/common/filename.cpp:182
+#, c-format
+msgid "Failed to open '%s' for reading"
+msgstr "படிப்பதற்கு '%s'-ஐ திறப்பதில் தோல்வி"
+
+#: ../src/common/filename.cpp:187
+#, c-format
+msgid "Failed to open '%s' for writing"
+msgstr "எழுதுவதற்கு '%s'-ஐ திறப்பதில் தோல்வி"
+
+#: ../src/common/filename.cpp:199
+msgid "Failed to close file handle"
+msgstr "கோப்புக் குறிப்பினை மூடுவதில் தோல்வி"
+
+#: ../src/common/filename.cpp:1046
+msgid "Failed to create a temporary file name"
+msgstr "தற்காலிக கோப்புப் பெயரை உருவாக்குவதில் தோல்வி"
+
+#: ../src/common/filename.cpp:1081
+msgid "Failed to open temporary file."
+msgstr "தற்காலிக கோப்பினைத் திறப்பதில் தோல்வி."
+
+#: ../src/common/filename.cpp:2862
+#, c-format
+msgid "Failed to modify file times for '%s'"
+msgstr "'%s' கோப்பிற்கான நேர முத்திரைகளை மாற்றுவதில் தோல்வி"
+
+#: ../src/common/filename.cpp:2877
+#, c-format
+msgid "Failed to touch the file '%s'"
+msgstr "'%s' கோப்பினைத் தொடுவதில் தோல்வி"
+
+#: ../src/common/filename.cpp:2958
+#, c-format
+msgid "Failed to retrieve file times for '%s'"
+msgstr "'%s' கோப்பிற்கான நேர முத்திரைகளைப் பெறுவதில் தோல்வி"
+
+#: ../src/common/filepickercmn.cpp:39 ../src/common/filepickercmn.cpp:40
+msgid "Browse"
+msgstr "உலாவுக"
+
+#: ../src/common/fldlgcmn.cpp:792 ../src/generic/filectrlg.cpp:1185
+#, c-format
+msgid "All files (%s)|%s"
+msgstr "எல்லாக் கோப்புகளும் (%s)|%s"
+
+#. TRANSLATORS: %s are a file extension used to build a file wildcard string
+#: ../src/common/fldlgcmn.cpp:810
+#, c-format
+msgid "%s files (%s)|%s"
+msgstr "%s கோப்புகள் (%s)|%s"
+
+#: ../src/common/fldlgcmn.cpp:1072
+#, c-format
+msgid "Load %s file"
+msgstr "%s கோப்பினை ஏற்றிடுக"
+
+#: ../src/common/fldlgcmn.cpp:1074
+#, c-format
+msgid "Save %s file"
+msgstr "%s கோப்பினை சேமித்திடுக"
+
+#: ../src/common/fmapbase.cpp:144
+msgid "Western European (ISO-8859-1)"
+msgstr "மேற்கு ஐரோப்பா (ISO-8859-1)"
+
+#: ../src/common/fmapbase.cpp:145
+msgid "Central European (ISO-8859-2)"
+msgstr "மைய ஐரோப்பா (ISO-8859-2)"
+
+#: ../src/common/fmapbase.cpp:146
+msgid "Esperanto (ISO-8859-3)"
+msgstr "Esperanto (ISO-8859-3)"
+
+#: ../src/common/fmapbase.cpp:147
+msgid "Baltic (old) (ISO-8859-4)"
+msgstr "பால்டிக் (old) (ISO-8859-4)"
+
+#: ../src/common/fmapbase.cpp:148
+msgid "Cyrillic (ISO-8859-5)"
+msgstr "Cyrillic (ISO-8859-5)"
+
+#: ../src/common/fmapbase.cpp:149
+msgid "Arabic (ISO-8859-6)"
+msgstr "அரேபியம் (ISO-8859-6)"
+
+#: ../src/common/fmapbase.cpp:150
+msgid "Greek (ISO-8859-7)"
+msgstr "கிரேக்கம் (ISO-8859-7)"
+
+#: ../src/common/fmapbase.cpp:151
+msgid "Hebrew (ISO-8859-8)"
+msgstr "ஹீப்ரு (ISO-8859-8)"
+
+#: ../src/common/fmapbase.cpp:152
+msgid "Turkish (ISO-8859-9)"
+msgstr "துருக்கியம் (ISO-8859-9)"
+
+#: ../src/common/fmapbase.cpp:153
+msgid "Nordic (ISO-8859-10)"
+msgstr "நார்டிக் (ISO-8859-10)"
+
+#: ../src/common/fmapbase.cpp:154
+msgid "Thai (ISO-8859-11)"
+msgstr "தாய் (ISO-8859-11)"
+
+#: ../src/common/fmapbase.cpp:155
+msgid "Indian (ISO-8859-12)"
+msgstr "இந்தியன் (ISO-8859-12)"
+
+#: ../src/common/fmapbase.cpp:156
+msgid "Baltic (ISO-8859-13)"
+msgstr "பால்டிக் (ISO-8859-13)"
+
+#: ../src/common/fmapbase.cpp:157
+msgid "Celtic (ISO-8859-14)"
+msgstr "Celtic (ISO-8859-14)"
+
+#: ../src/common/fmapbase.cpp:158
+msgid "Western European with Euro (ISO-8859-15)"
+msgstr "மேற்கு ஐரோப்பா யுரோவுடன் (ISO-8859-15)"
+
+#: ../src/common/fmapbase.cpp:159
+msgid "KOI8-R"
+msgstr "KOI8-R"
+
+#: ../src/common/fmapbase.cpp:160
+msgid "KOI8-U"
+msgstr "KOI8-U"
+
+#: ../src/common/fmapbase.cpp:161
+msgid "Windows/DOS OEM Cyrillic (CP 866)"
+msgstr "விண்டோஸ் /DOS OEM சிரிலிக் (CP 866)"
+
+#: ../src/common/fmapbase.cpp:162
+msgid "Windows Thai (CP 874)"
+msgstr "விண்டோஸ் தாய் (CP 874)"
+
+#: ../src/common/fmapbase.cpp:163
+msgid "Windows Japanese (CP 932) or Shift-JIS"
+msgstr "விண்டோஸ் ஜப்பானியம் (CP 932) or Shift-JIS"
+
+#: ../src/common/fmapbase.cpp:164
+msgid "Windows Chinese Simplified (CP 936) or GB-2312"
+msgstr "விண்டோஸ் எளிதாக்கப்பட்ட சீனம் (CP 936) or GB-2312"
+
+#: ../src/common/fmapbase.cpp:165
+msgid "Windows Korean (CP 949)"
+msgstr "விண்டோஸ் கொரியம் (CP 949)"
+
+#: ../src/common/fmapbase.cpp:166
+msgid "Windows Chinese Traditional (CP 950) or Big-5"
+msgstr "விண்டோஸ் மரபுச் சீனம் (CP 950) or Big-5"
+
+#: ../src/common/fmapbase.cpp:167
+msgid "Windows Central European (CP 1250)"
+msgstr "விண்டோஸ் மைய ஐரோப்பா (CP 1250)"
+
+#: ../src/common/fmapbase.cpp:168
+msgid "Windows Cyrillic (CP 1251)"
+msgstr "விண்டோஸ் சிரிலிக் (CP 1251)"
+
+#: ../src/common/fmapbase.cpp:169
+msgid "Windows Western European (CP 1252)"
+msgstr "விண்டோஸ் மேற்கு ஐரோப்பா (CP 1252)"
+
+#: ../src/common/fmapbase.cpp:170
+msgid "Windows Greek (CP 1253)"
+msgstr "விண்டோஸ் கிரேக்கம் (CP 1253)"
+
+#: ../src/common/fmapbase.cpp:171
+msgid "Windows Turkish (CP 1254)"
+msgstr "விண்டோஸ் துருக்கியம் (CP 1254)"
+
+#: ../src/common/fmapbase.cpp:172
+msgid "Windows Hebrew (CP 1255)"
+msgstr "விண்டோஸ் ஹீப்ரு (CP 1255)"
+
+#: ../src/common/fmapbase.cpp:173
+msgid "Windows Arabic (CP 1256)"
+msgstr "விண்டோஸ் அரேபியம் (CP 1256)"
+
+#: ../src/common/fmapbase.cpp:174
+msgid "Windows Baltic (CP 1257)"
+msgstr "விண்டோஸ் பால்டிக் (CP 1257)"
+
+#: ../src/common/fmapbase.cpp:175
+msgid "Windows Vietnamese (CP 1258)"
+msgstr "விண்டோஸ் வியட்நாமியம் (CP 1258)"
+
+#: ../src/common/fmapbase.cpp:176
+msgid "Windows Johab (CP 1361)"
+msgstr "விண்டோஸ் ஜோஹாப் (CP 1361)"
+
+#: ../src/common/fmapbase.cpp:177
+msgid "Windows/DOS OEM (CP 437)"
+msgstr "விண்டோஸ் /DOS OEM (CP 437)"
+
+#: ../src/common/fmapbase.cpp:178
+msgid "Unicode 7 bit (UTF-7)"
+msgstr "ஒருங்குறி 7 நுண்மி (UTF-7)"
+
+#: ../src/common/fmapbase.cpp:179
+msgid "Unicode 8 bit (UTF-8)"
+msgstr "ஒருங்குறி 8 நுண்மி (UTF-8)"
+
+#: ../src/common/fmapbase.cpp:181 ../src/common/fmapbase.cpp:187
+msgid "Unicode 16 bit (UTF-16)"
+msgstr "ஒருங்குறி 16 நுண்மி (UTF-16)"
+
+#: ../src/common/fmapbase.cpp:182
+msgid "Unicode 16 bit Little Endian (UTF-16LE)"
+msgstr "ஒருங்குறி 16 நுண்மி Small Endian (UTF-16LE)"
+
+#: ../src/common/fmapbase.cpp:183 ../src/common/fmapbase.cpp:189
+msgid "Unicode 32 bit (UTF-32)"
+msgstr "ஒருங்குறி 32 நுண்மி (UTF-32)"
+
+#: ../src/common/fmapbase.cpp:184
+msgid "Unicode 32 bit Little Endian (UTF-32LE)"
+msgstr "ஒருங்குறி 32 நுண்மி Small Endian (UTF-32LE)"
+
+#: ../src/common/fmapbase.cpp:186
+msgid "Unicode 16 bit Big Endian (UTF-16BE)"
+msgstr "ஒருங்குறி 16 நுண்மி Big Endian (UTF-16BE)"
+
+#: ../src/common/fmapbase.cpp:188
+msgid "Unicode 32 bit Big Endian (UTF-32BE)"
+msgstr "ஒருங்குறி 32 நுண்மி Big Endian (UTF-32BE)"
+
+#: ../src/common/fmapbase.cpp:191
+msgid "Extended Unix Codepage for Japanese (EUC-JP)"
+msgstr "நீட்டிக்கப்பட்ட ஜப்பானிய Unix Codepage (EUC-JP)"
+
+#: ../src/common/fmapbase.cpp:192
+msgid "US-ASCII"
+msgstr "US-ASCII"
+
+#: ../src/common/fmapbase.cpp:193
+msgid "ISO-2022-JP"
+msgstr "ISO-2022-JP"
+
+#: ../src/common/fmapbase.cpp:195
+msgid "MacRoman"
+msgstr "MAC ரோமானிய"
+
+#: ../src/common/fmapbase.cpp:196
+msgid "MacJapanese"
+msgstr "MAC ஜப்பானிய"
+
+#: ../src/common/fmapbase.cpp:197
+msgid "MacChineseTrad"
+msgstr "MAC பாரம்பரிய சீனம்"
+
+#: ../src/common/fmapbase.cpp:198
+msgid "MacKorean"
+msgstr "MAC கொரிய"
+
+#: ../src/common/fmapbase.cpp:199
+msgid "MacArabic"
+msgstr "MAC அரேபியம்"
+
+#: ../src/common/fmapbase.cpp:200
+msgid "MacHebrew"
+msgstr "MAC ஹீப்ரு"
+
+#: ../src/common/fmapbase.cpp:201
+msgid "MacGreek"
+msgstr "MAC கிரேக்கம்"
+
+#: ../src/common/fmapbase.cpp:202
+msgid "MacCyrillic"
+msgstr "MAC சிரிலிக்"
+
+#: ../src/common/fmapbase.cpp:203
+msgid "MacDevanagari"
+msgstr "MAC தேவநாகரி"
+
+#: ../src/common/fmapbase.cpp:204
+msgid "MacGurmukhi"
+msgstr "MAC குர்முகி"
+
+#: ../src/common/fmapbase.cpp:205
+msgid "MacGujarati"
+msgstr "MAC குஜராத்தி"
+
+#: ../src/common/fmapbase.cpp:206
+msgid "MacOriya"
+msgstr "MAC ஒரியா"
+
+#: ../src/common/fmapbase.cpp:207
+msgid "MacBengali"
+msgstr "MAC பெங்காலி"
+
+#: ../src/common/fmapbase.cpp:208
+msgid "MacTamil"
+msgstr "MAC தமிழ்"
+
+#: ../src/common/fmapbase.cpp:209
+msgid "MacTelugu"
+msgstr "MAC தெலுங்கு"
+
+#: ../src/common/fmapbase.cpp:210
+msgid "MacKannada"
+msgstr "MAC கன்னடம்"
+
+#: ../src/common/fmapbase.cpp:211
+msgid "MacMalayalam"
+msgstr "MAC மலையாளம்"
+
+#: ../src/common/fmapbase.cpp:212
+msgid "MacSinhalese"
+msgstr "MAC சிங்களம்"
+
+#: ../src/common/fmapbase.cpp:213
+msgid "MacBurmese"
+msgstr "MAC பர்மியம்"
+
+#: ../src/common/fmapbase.cpp:214
+msgid "MacKhmer"
+msgstr "MAC கமேர்"
+
+#: ../src/common/fmapbase.cpp:215
+msgid "MacThai"
+msgstr "MAC தாய்"
+
+#: ../src/common/fmapbase.cpp:216
+msgid "MacLaotian"
+msgstr "MAC லேவோஷிய"
+
+#: ../src/common/fmapbase.cpp:217
+msgid "MacGeorgian"
+msgstr "MAC ஜார்ஜியன்"
+
+#: ../src/common/fmapbase.cpp:218
+msgid "MacArmenian"
+msgstr "MAC ஆர்மேனியம்"
+
+#: ../src/common/fmapbase.cpp:219
+msgid "MacChineseSimp"
+msgstr "MAC எளிய சீனம்"
+
+#: ../src/common/fmapbase.cpp:220
+msgid "MacTibetan"
+msgstr "MAC திபெத்திய"
+
+#: ../src/common/fmapbase.cpp:221
+msgid "MacMongolian"
+msgstr "MAC மங்கோலிய"
+
+#: ../src/common/fmapbase.cpp:222
+msgid "MacEthiopic"
+msgstr "MAC எதியோபியா"
+
+#: ../src/common/fmapbase.cpp:223
+msgid "MacCentralEurRoman"
+msgstr "MAC மைய ஐரோப்பா ரோமானியம்"
+
+#: ../src/common/fmapbase.cpp:224
+msgid "MacVietnamese"
+msgstr "MAC வியட்னாமிய"
+
+#: ../src/common/fmapbase.cpp:225
+msgid "MacExtArabic"
+msgstr "MAC அரேபிய Ext"
+
+#: ../src/common/fmapbase.cpp:226
+msgid "MacSymbol"
+msgstr "MAC குறியெழுத்து"
+
+#: ../src/common/fmapbase.cpp:227
+msgid "MacDingbats"
+msgstr "MacDingbats"
+
+#: ../src/common/fmapbase.cpp:228
+msgid "MacTurkish"
+msgstr "MAC துருக்கிய"
+
+#: ../src/common/fmapbase.cpp:229
+msgid "MacCroatian"
+msgstr "MAC குரோஷியம்"
+
+#: ../src/common/fmapbase.cpp:230
+msgid "MacIcelandic"
+msgstr "MAC ஐஸ்லாந்திய"
+
+#: ../src/common/fmapbase.cpp:231
+msgid "MacRomanian"
+msgstr "MAC ரோமானியம்"
+
+#: ../src/common/fmapbase.cpp:232
+msgid "MacCeltic"
+msgstr "MAC கெல்டிக்"
+
+#: ../src/common/fmapbase.cpp:233
+msgid "MacGaelic"
+msgstr "MAC கேலிக்"
+
+#: ../src/common/fmapbase.cpp:234
+msgid "MacKeyboardGlyphs"
+msgstr "MacKeyboardGlyphs"
+
+#: ../src/common/fmapbase.cpp:791
+msgid "Default encoding"
+msgstr "இயல்புக் குறியாக்கம்"
+
+#: ../src/common/fmapbase.cpp:805
+#, c-format
+msgid "Unknown encoding (%d)"
+msgstr "அறியப்படாதக் குறியாக்கம் (%d)"
+
+#: ../src/common/fmapbase.cpp:815 ../src/richtext/richtextstyles.cpp:776
+msgid "default"
+msgstr "இயல்பிருப்பு"
+
+#: ../src/common/fmapbase.cpp:829
+#, c-format
+msgid "unknown-%d"
+msgstr "அறியப்படாத %d"
+
+#: ../src/common/fontcmn.cpp:924 ../src/common/fontcmn.cpp:1130
+msgid "underlined"
+msgstr "அடிக்கோடு"
+
+#: ../src/common/fontcmn.cpp:929
+msgid " strikethrough"
+msgstr "ஊடானக் கோடு"
+
+#: ../src/common/fontcmn.cpp:942
+msgid " thin"
+msgstr "சன்னம்"
+
+#: ../src/common/fontcmn.cpp:946
+msgid " extra light"
+msgstr "கூடுதல் இலகு"
+
+#: ../src/common/fontcmn.cpp:950
+msgid " light"
+msgstr "இலகு"
+
+#: ../src/common/fontcmn.cpp:954
+msgid " medium"
+msgstr "நடுத்தரம்"
+
+#: ../src/common/fontcmn.cpp:958
+msgid " semi bold"
+msgstr "அரை அடர்த்தி"
+
+#: ../src/common/fontcmn.cpp:962
+msgid " bold"
+msgstr "அடர்த்தி"
+
+#: ../src/common/fontcmn.cpp:966
+msgid " extra bold"
+msgstr "கூடுதல் அடர்த்தி"
+
+#: ../src/common/fontcmn.cpp:970
+msgid " heavy"
+msgstr "கனம்"
+
+#: ../src/common/fontcmn.cpp:974
+msgid " extra heavy"
+msgstr "கூடுதல் கனம்"
+
+#: ../src/common/fontcmn.cpp:990
+msgid " italic"
+msgstr "வலச் சாய்வு"
+
+#: ../src/common/fontcmn.cpp:1134
+msgid "strikethrough"
+msgstr "ஊடானக் கோடு"
+
+#: ../src/common/fontcmn.cpp:1143
+msgid "thin"
+msgstr "சன்னம்"
+
+#: ../src/common/fontcmn.cpp:1156
+msgid "extralight"
+msgstr "கூடுதல் இலகு"
+
+#: ../src/common/fontcmn.cpp:1161
+msgid "light"
+msgstr "இலகு"
+
+#: ../src/common/fontcmn.cpp:1169 ../src/richtext/richtextstyles.cpp:775
+msgid "normal"
+msgstr "இயல்புநிலை"
+
+#: ../src/common/fontcmn.cpp:1174
+msgid "medium"
+msgstr "நடுத்தரம்"
+
+#: ../src/common/fontcmn.cpp:1179 ../src/common/fontcmn.cpp:1199
+msgid "semibold"
+msgstr "அரை அடர்த்தி"
+
+#: ../src/common/fontcmn.cpp:1184
+msgid "bold"
+msgstr "அடர்த்தி"
+
+#: ../src/common/fontcmn.cpp:1194
+msgid "extrabold"
+msgstr "கூடுதல் அடர்த்தி"
+
+#: ../src/common/fontcmn.cpp:1204
+msgid "heavy"
+msgstr "கனம்"
+
+#: ../src/common/fontcmn.cpp:1212
+msgid "extraheavy"
+msgstr "கூடுதல் கனம்"
+
+#: ../src/common/fontcmn.cpp:1217
+msgid "italic"
+msgstr "வலச் சாய்வு"
+
+#: ../src/common/fontmap.cpp:195
+msgid ": unknown charset"
+msgstr ": அறியப்படாத குறியீட்டுத் தொகுப்பு"
+
+#: ../src/common/fontmap.cpp:199
+#, c-format
+msgid ""
+"The charset '%s' is unknown. You may select\n"
+"another charset to replace it with or choose\n"
+"[Cancel] if it cannot be replaced"
+msgstr ""
+"'%s' குறியீட்டுத் தொகுப்பு அறியப்படாதது. தாங்கள்\n"
+"மற்றொரு குறியீட்டுத் தொகுப்பை மாற்றமர்வாக தேர்ந்தெடுக்கவும், அல்லது அதை மாற்றியமைக்க "
+"இயலாதென்றால், \n"
+"[விலக்குக] பொத்தானை அழுத்தவும்."
+
+#: ../src/common/fontmap.cpp:241
+#, c-format
+msgid "Failed to remember the encoding for the charset '%s'."
+msgstr "'%s' குறியீட்டுத் தொகுப்பின் குறியாக்கத்தை நினைவுப்படுத்துவதில் தோல்வி."
+
+#: ../src/common/fontmap.cpp:321
+msgid "can't load any font, aborting"
+msgstr "எந்த எழுத்துருவையும் ஏற்ற இயலவில்லை, செயல் இடைமறிக்கப்படுகிறது"
+
+#: ../src/common/fontmap.cpp:409
+msgid ": unknown encoding"
+msgstr "அறியப்படாதக் குறியாக்கம்"
+
+#: ../src/common/fontmap.cpp:417
+#, c-format
+msgid ""
+"No font for displaying text in encoding '%s' found,\n"
+"but an alternative encoding '%s' is available.\n"
+"Do you want to use this encoding (otherwise you will have to choose another "
+"one)?"
+msgstr ""
+"'%s' குறியாக்கத்தில் உரைகளைக் காட்டுவதற்கான எழுத்துரு ஏதுமில்லை,\n"
+"ஆனால், ஒரு மாற்று '%s' குறியாக்கம் உள்ளது.\n"
+"தாங்கள் இந்தக் குறியீட்டைப் பயன்படுத்த வேண்டுமா (இல்லையென்றால், மற்றொன்றைத் தாங்கள் தேர்வு செய்ய "
+"வேண்டும்)?"
+
+#: ../src/common/fontmap.cpp:422
+#, c-format
+msgid ""
+"No font for displaying text in encoding '%s' found.\n"
+"Would you like to select a font to be used for this encoding\n"
+"(otherwise the text in this encoding will not be shown correctly)?"
+msgstr ""
+"'%s' குறியீட்டில் உரைகளைக் காட்டுவதற்கான எழுத்துரு ஏதுமில்லை,\n"
+"இந்தக் குறியீட்டில் பயன்படுத்துவதற்கு ஒரு எழுத்துருவைத் தெரிவு செய்ய வேண்டுமா? \n"
+"(இல்லையென்றால், இந்தக் குறியாக்கம் கொண்ட உரை சரிவர காட்டப்பட மாட்டாது)"
+
+#: ../src/common/fs_mem.cpp:169
+#, c-format
+msgid "Memory VFS already contains file '%s'!"
+msgstr "VFS நினைவகம் '%s' கோப்பினை ஏற்கனவே கொண்டுள்ளது!"
+
+#: ../src/common/fs_mem.cpp:232
+#, c-format
+msgid "Trying to remove file '%s' from memory VFS, but it is not loaded!"
+msgstr ""
+"VFS நினைவகத்திலிருந்து '%s' கோப்பை நீக்க முயற்சி எடுக்கப்படுகிறது, ஆனால், அது "
+"ஏற்றப்படவில்லை!"
+
+#: ../src/common/fs_mem.cpp:262
+#, c-format
+msgid "Failed to store image '%s' to memory VFS!"
+msgstr "VFS நினைவகத்தில் '%s' படிமத்தை சேமிப்பதில் தோல்வி!"
+
+#: ../src/common/ftp.cpp:197
+msgid "Timeout while waiting for FTP server to connect, try passive mode."
+msgstr ""
+"FTP வழங்கி இணைப்பிற்கு காத்திருக்கும்பொழுது நேரம் காலாவதியாகிவிட்டது, முடக்க நிலையை "
+"முயன்றுபார்க்கவும்."
+
+#: ../src/common/ftp.cpp:399
+#, c-format
+msgid "Failed to set FTP transfer mode to %s."
+msgstr "FTP மாற்று நிலையை %s என்று அமைப்பதில் தோல்வி."
+
+#: ../src/common/ftp.cpp:400 ../src/richtext/richtextsymboldlg.cpp:432
+msgid "ASCII"
+msgstr "ASCII"
+
+#: ../src/common/ftp.cpp:400
+msgid "binary"
+msgstr "இருமம்"
+
+#: ../src/common/ftp.cpp:608
+msgid "The FTP server doesn't support the PORT command."
+msgstr "FTP வழங்கி PORT கட்டளையை ஆதரிப்பதில்லை."
+
+#: ../src/common/ftp.cpp:622
+msgid "The FTP server doesn't support passive mode."
+msgstr "FTP வழங்கி முடக்க நிலையை ஆதரிப்பதில்லை."
+
+#: ../src/common/gifdecod.cpp:822
+#, c-format
+msgid "Incorrect GIF frame size (%u, %d) for the frame #%u"
+msgstr "தவறான GIF சட்டக அளவு (%u, %d) - #%u சட்டகத்திற்கானது"
+
+#: ../src/common/glcmn.cpp:108
+msgid "Failed to allocate colour for OpenGL"
+msgstr "OpenGL-க்கு நிறத்தை ஒதுக்குவதில் தோல்வி. "
+
+#: ../src/common/headerctrlcmn.cpp:57
+msgid "Please select the columns to show and define their order:"
+msgstr "காட்டப்பட வேண்டிய நெடுவரிசைகளை தெரிவுசெய்து, அவைகளின் ஒழுங்கை வரையறுத்திடுக:"
+
+#: ../src/common/headerctrlcmn.cpp:58
+msgid "Customize Columns"
+msgstr "நெடுவரிசைகளை தனிப் பயனாக்குக"
+
+#: ../src/common/headerctrlcmn.cpp:304
+msgid "&Customize..."
+msgstr "தனிப் பயனாக்குக... (&C)"
+
+#: ../src/common/hyperlnkcmn.cpp:132
+#, c-format
+msgid "Failed to open URL \"%s\" in the default browser"
+msgstr "\"%s\" இணைய முகவரியை இயல்பு உலாவியில் திறப்பதில் தோல்வி."
+
+#: ../src/common/iconbndl.cpp:195
+#, c-format
+msgid "Failed to load image %%d from file '%s'."
+msgstr "%%d படிமத்தை '%s' கோப்பிலிருந்து ஏற்றுவதில் தோல்வி."
+
+#: ../src/common/iconbndl.cpp:203
+#, c-format
+msgid "Failed to load image %d from stream."
+msgstr "ஓடையிலிருந்து %d படிமத்தை ஏற்றுவதில் தோல்வி."
+
+#: ../src/common/iconbndl.cpp:221
+#, c-format
+msgid "Failed to load icons from resource '%s'."
+msgstr "படவுருக்களை '%s' வளத்திலிருந்து ஏற்றுவதில் தோல்வி."
+
+#: ../src/common/imagbmp.cpp:97
+msgid "BMP: Couldn't save invalid image."
+msgstr "BMP: செல்லாத படிமத்தை சேமிக்க இயலவில்லை."
+
+#: ../src/common/imagbmp.cpp:137
+msgid "BMP: wxImage doesn't have own wxPalette."
+msgstr "BMP: wxImage சொந்த wxPalette-ஐ கொண்டிருக்கவில்லை."
+
+#: ../src/common/imagbmp.cpp:243
+msgid "BMP: Couldn't write the file (Bitmap) header."
+msgstr "BMP: நுண்படத் தலைப்பினை எழுத இயலவில்லை."
+
+#: ../src/common/imagbmp.cpp:266
+msgid "BMP: Couldn't write the file (BitmapInfo) header."
+msgstr "BMP: நுண்படத் தகவல் தலைப்பினை எழுத இயலவில்லை."
+
+#: ../src/common/imagbmp.cpp:353
+msgid "BMP: Couldn't write RGB color map."
+msgstr "BMP: RGB நிற வரைபடத்தை எழுத இயலவில்லை."
+
+#: ../src/common/imagbmp.cpp:487
+msgid "BMP: Couldn't write data."
+msgstr "BMP: தரவினை எழுத இயலவில்லை."
+
+#: ../src/common/imagbmp.cpp:561 ../src/common/imagbmp.cpp:642
+msgid "BMP: Couldn't allocate memory."
+msgstr "BMP: நினைவகத்தை ஒதுக்க இயலவில்லை."
+
+#: ../src/common/imagbmp.cpp:1041
+msgid "DIB Header: Image width > 32767 pixels for file."
+msgstr "DIB மேலுரை: கோப்பிற்கான பட உயரம் > 32767 படவணுக்கள்."
+
+#: ../src/common/imagbmp.cpp:1049
+msgid "DIB Header: Image height > 32767 pixels for file."
+msgstr "DIB மேலுரை: கோப்பிற்கான பட உயரம் > 32767 படவணுக்கள். "
+
+#: ../src/common/imagbmp.cpp:1081
+msgid "DIB Header: Unknown bitdepth in file."
+msgstr "DIB மேலுரை: கோப்பில் அறியப்படாத bitdepth."
+
+#: ../src/common/imagbmp.cpp:1156
+msgid "DIB Header: Unknown encoding in file."
+msgstr "DIB மேலுரை: கோப்பில் அறியப்படாத குறியாக்கம்."
+
+#: ../src/common/imagbmp.cpp:1165
+msgid "DIB Header: Encoding doesn't match bitdepth."
+msgstr "DIB மேலுரை: குறியாக்கம் bitdepth-உடன் பொருந்தவில்லை."
+
+#: ../src/common/imagbmp.cpp:1180
+#, c-format
+msgid "BMP Header: Invalid number of colors (%d)."
+msgstr "BMP தலைப்புரை: செல்லாத எண்ணிக்கையிலான நிறங்கள் (%d)."
+
+#: ../src/common/imagbmp.cpp:1273
+msgid "Error in reading image DIB."
+msgstr "DIB படிமத்தை படிப்பதில் பிழை"
+
+#: ../src/common/imagbmp.cpp:1294
+msgid "ICO: Error in reading mask DIB."
+msgstr "ICO: மறைப்பு DIB படிப்பதில் பிழை."
+
+#: ../src/common/imagbmp.cpp:1353
+msgid "ICO: Image too tall for an icon."
+msgstr "ICO: படவுருவிற்கு இது மிக உயரமானப் படிமம்."
+
+#: ../src/common/imagbmp.cpp:1361
+msgid "ICO: Image too wide for an icon."
+msgstr "ICO: படவுருவிற்கு இது மிக அகலமான படிமம்."
+
+#: ../src/common/imagbmp.cpp:1388 ../src/common/imagbmp.cpp:1488
+#: ../src/common/imagbmp.cpp:1503 ../src/common/imagbmp.cpp:1514
+#: ../src/common/imagbmp.cpp:1528 ../src/common/imagbmp.cpp:1576
+#: ../src/common/imagbmp.cpp:1591 ../src/common/imagbmp.cpp:1605
+#: ../src/common/imagbmp.cpp:1616
+msgid "ICO: Error writing the image file!"
+msgstr "ICO: படிமக் கோப்பினை எழுதுவதில் பிழை!"
+
+#: ../src/common/imagbmp.cpp:1701
+msgid "ICO: Invalid icon index."
+msgstr "ICO: செல்லாத படவுரு சுட்டெண்."
+
+#: ../src/common/image.cpp:2410
+msgid "Image and mask have different sizes."
+msgstr "படிமமும் மறைப்பும் வெவ்வேறு அளவுகளைக் கொண்டிருக்கின்றன."
+
+#: ../src/common/image.cpp:2418 ../src/common/image.cpp:2459
+msgid "No unused colour in image being masked."
+msgstr "படிமத்தில் பயன்படுத்தப்படாத நிறம் ஏதும் மறைக்கப்படவில்லை."
+
+#: ../src/common/image.cpp:2641
+#, c-format
+msgid "Failed to load bitmap \"%s\" from resources."
+msgstr "\"%s\" நுண்படத்தினை வளத்திலிருந்து ஏற்றுவதில் தோல்வி."
+
+#: ../src/common/image.cpp:2650
+#, c-format
+msgid "Failed to load icon \"%s\" from resources."
+msgstr "\"%s\" படவுருவை வளத்திலிருந்து ஏற்றுவதில் தோல்வி."
+
+#: ../src/common/image.cpp:2728 ../src/common/image.cpp:2747
+#, c-format
+msgid "Failed to load image from file \"%s\"."
+msgstr "\"%s\" கோப்பிலிருந்து படிமத்தை ஏற்றுவதில் தோல்வி."
+
+#: ../src/common/image.cpp:2761
+#, c-format
+msgid "Can't save image to file '%s': unknown extension."
+msgstr "படிமத்தை '%s'- கோப்பில் சேமிக்க இயலாது: அறியப்படாத நீட்சி."
+
+#: ../src/common/image.cpp:2869
+msgid "No handler found for image type."
+msgstr "படிம வகைக்கான கையாளு நிரல் காணப்படவில்லை."
+
+#: ../src/common/image.cpp:2877 ../src/common/image.cpp:3000
+#: ../src/common/image.cpp:3066
+#, c-format
+msgid "No image handler for type %d defined."
+msgstr "%d வகைக்கான படிம கையாளு நிரல் வரையறுக்கப்படவில்லை."
+
+#: ../src/common/image.cpp:2887
+#, c-format
+msgid "Image file is not of type %d."
+msgstr "படிமக் கோப்பின் வகை %d-ஆக இல்லை."
+
+#: ../src/common/image.cpp:2970
+msgid "Can't automatically determine the image format for non-seekable input."
+msgstr "நாடிச் செல்ல இயலாத உள்ளீட்டிற்கு படிம வடிவூட்டத்தைத் தானாக வரையறுக்க இயலாது."
+
+#: ../src/common/image.cpp:2988
+msgid "Unknown image data format."
+msgstr "அறியப்படாத படிமத் தரவு வடிவூட்டம்"
+
+#: ../src/common/image.cpp:3009
+#, c-format
+msgid "This is not a %s."
+msgstr "இது ஒரு %s அல்ல."
+
+#: ../src/common/image.cpp:3032 ../src/common/image.cpp:3080
+#, c-format
+msgid "No image handler for type %s defined."
+msgstr "%s வகைக்கான படிம கையாளு நிரல் வரையறுக்கப்படவில்லை."
+
+#: ../src/common/image.cpp:3041
+#, c-format
+msgid "Image is not of type %s."
+msgstr "படிமத்தின் வகை %s-ஆக இல்லை."
+
+#: ../src/common/image.cpp:3509
+#, c-format
+msgid "Failed to check format of image file \"%s\"."
+msgstr "\"%s\" படிமக் கோப்பின் வடிவூட்டத்தை சரிபார்ப்பதில் தோல்வி."
+
+#: ../src/common/imaggif.cpp:124
+msgid "GIF: error in GIF image format."
+msgstr "GIF: GIF படிம வடிவூட்டத்தில் பிழை."
+
+#: ../src/common/imaggif.cpp:129
+msgid "GIF: not enough memory."
+msgstr "GIF: போதுமான நினைவகம் இல்லை."
+
+#: ../src/common/imaggif.cpp:134
+msgid "GIF: data stream seems to be truncated."
+msgstr "GIF: தரவு ஓடை அறுபட்டிருப்பதாகத் தோன்றுகிறது."
+
+#: ../src/common/imaggif.cpp:240
+msgid "Couldn't initialize GIF hash table."
+msgstr "GIF Hash அட்டவணையை தொடக்கநிலையாக்க இயலவில்லை."
+
+#: ../src/common/imagiff.cpp:739
+msgid "IFF: error in IFF image format."
+msgstr "IFF: IFF படிம வடிவூட்டத்தில் பிழை."
+
+#: ../src/common/imagiff.cpp:742
+msgid "IFF: not enough memory."
+msgstr "IFF: போதுமான நினைவகம் இல்லை."
+
+#: ../src/common/imagiff.cpp:745
+msgid "IFF: unknown error!!!"
+msgstr "IFF: அறியப்படாத பிழை!"
+
+#: ../src/common/imagiff.cpp:755
+msgid "IFF: data stream seems to be truncated."
+msgstr "IFF: தரவு ஓடை அறுபட்டிருப்பதாகத் தோன்றுகிறது."
+
+#: ../src/common/imagjpeg.cpp:258
+msgid "JPEG: Couldn't load - file is probably corrupted."
+msgstr "JPEG: ஏற்ற இயலவில்லை - கோப்பு ஒரு வேளை பழுதடைந்திருக்கலாம்."
+
+#: ../src/common/imagjpeg.cpp:437
+msgid "JPEG: Couldn't save image."
+msgstr "JPEG: படிமத்தை சேமிக்க இயலவில்லை."
+
+#: ../src/common/imagpcx.cpp:439
+msgid "PCX: this is not a PCX file."
+msgstr "PCX: இது ஒரு PCX கோப்பு அல்ல."
+
+#: ../src/common/imagpcx.cpp:453
+msgid "PCX: image format unsupported"
+msgstr "PCX: படிம வடிவூட்டத்திற்கு ஆதரவு இல்லை"
+
+#: ../src/common/imagpcx.cpp:454 ../src/common/imagpcx.cpp:477
+msgid "PCX: couldn't allocate memory"
+msgstr "PCX: நினைவகத்தை ஒதுக்கீடு செய்ய இயலவில்லை"
+
+#: ../src/common/imagpcx.cpp:455
+msgid "PCX: version number too low"
+msgstr "PCX: பதிப்பு எண் மிகக் குறைந்துள்ளது"
+
+#: ../src/common/imagpcx.cpp:456 ../src/common/imagpcx.cpp:478
+msgid "PCX: unknown error !!!"
+msgstr "PCX: அறியப்படாத பிழை"
+
+#: ../src/common/imagpcx.cpp:476
+msgid "PCX: invalid image"
+msgstr "PCX: செல்லாத படிமம்"
+
+#: ../src/common/imagpng.cpp:385
+#, c-format
+msgid "Unknown PNG resolution unit %d"
+msgstr "அறியப்படாத PNG பிரிதிறன் அலகு %d"
+
+#: ../src/common/imagpng.cpp:439
+msgid "Couldn't load a PNG image - file is corrupted or not enough memory."
+msgstr ""
+"PNG படிமத்தை ஏற்ற இயலவில்லை - கோப்பு பழுதாகி இருக்கலாம், அல்லது குறை நினைவகமாக "
+"இருக்கலாம்"
+
+#: ../src/common/imagpng.cpp:513 ../src/common/imagpng.cpp:524
+#: ../src/common/imagpng.cpp:534
+msgid "Couldn't save PNG image."
+msgstr "PNG படிமத்தை சேமிக்க இயலவில்லை."
+
+#: ../src/common/imagpnm.cpp:71
+msgid "PNM: File format is not recognized."
+msgstr "PNM: கோப்பின் வடிவூட்டத்தை அடையாளங்காண இயலவில்லை."
+
+#: ../src/common/imagpnm.cpp:89
+msgid "PNM: Couldn't allocate memory."
+msgstr "PNM: நினைவகத்தை ஒதுக்கீடு செய்ய இயலவில்லை."
+
+#: ../src/common/imagpnm.cpp:111 ../src/common/imagpnm.cpp:134
+#: ../src/common/imagpnm.cpp:156
+msgid "PNM: File seems truncated."
+msgstr "PNM: கோப்பு அறுபட்டிருப்பதாகத் தோன்றுகிறது."
+
+#: ../src/common/imagtiff.cpp:69
+#, c-format
+msgid " (in module \"%s\")"
+msgstr " (\"%s\" நிரற்கூறில் உள்ளது)"
+
+#: ../src/common/imagtiff.cpp:304
+msgid "TIFF: Error loading image."
+msgstr "TIF: படிமத்தை ஏற்றுவதில் பிழை."
+
+#: ../src/common/imagtiff.cpp:314
+msgid "Invalid TIFF image index."
+msgstr "ஏற்கமுடியாத TIFF படிம சுட்டெண்."
+
+#: ../src/common/imagtiff.cpp:358
+msgid "TIFF: Image size is abnormally big."
+msgstr "TIF: படிம அளவு இயல்பிற்கு மாறாக பெரிய அளவில் உள்ளது."
+
+#: ../src/common/imagtiff.cpp:372 ../src/common/imagtiff.cpp:385
+#: ../src/common/imagtiff.cpp:769
+msgid "TIFF: Couldn't allocate memory."
+msgstr "TIF: நினைவகத்தை ஒதுக்கீடு செய்ய இயலவில்லை."
+
+#: ../src/common/imagtiff.cpp:471
+msgid "TIFF: Error reading image."
+msgstr "TIF: படிமத்தை படிப்பதில் பிழை."
+
+#: ../src/common/imagtiff.cpp:532
+#, c-format
+msgid "Unknown TIFF resolution unit %d ignored"
+msgstr "அறியப்படாத TIF பிரிதிறன் அலகு %d புரந்தள்ளப்பட்டது"
+
+#: ../src/common/imagtiff.cpp:611
+msgid "TIFF: Error saving image."
+msgstr "TIF: படிமத்தை சேமிப்பதில் பிழை."
+
+#: ../src/common/imagtiff.cpp:868
+msgid "TIFF: Error writing image."
+msgstr "TIF: படிமத்தை எழுதுவதில் பிழை."
+
+#: ../src/common/imagtiff.cpp:881
+msgid "TIFF: Error flushing data."
+msgstr "TIF: தரவை வெளித்தள்ளுவதில் பிழை"
+
+#: ../src/common/imagwebp.cpp:56
+msgid "WebP: Invalid data (failed to get features)."
+msgstr "WebP: செல்லாத தரவு (கூறுகளைப் பெறுவதில் தோல்வி)."
+
+#: ../src/common/imagwebp.cpp:65
+msgid "WebP: Allocating image memory failed."
+msgstr "WebP: படிம நினைவகத்தை ஒதுக்குவதில் தோல்வி."
+
+#: ../src/common/imagwebp.cpp:82
+msgid "WebP: Decoding RGBA image data failed."
+msgstr "WebP: RGBA படத் தரவின் குறியாக்கத்தை நீக்குவதில் தோல்வி."
+
+#: ../src/common/imagwebp.cpp:98
+msgid "WebP: Decoding RGB image data failed."
+msgstr "WebP: RGB படத் தரவின் குறியாக்கத்தை நீக்குவதில் தோல்வி."
+
+#: ../src/common/imagwebp.cpp:113 ../src/common/imagwebp.cpp:201
+msgid "WebP: Allocating stream buffer failed."
+msgstr "WebP: ஓடை இடையகத்தை ஒதுக்குவதில் தோல்வி."
+
+#: ../src/common/imagwebp.cpp:131
+msgid "WebP: Failed to parse container data."
+msgstr "WebP: கொள்கலன் தரவை பகுப்பாய்வதில் தோல்வி."
+
+#: ../src/common/imagwebp.cpp:222
+msgid "WebP: Error decoding animation."
+msgstr "WebP: அசைவூட்டக் குறியாக்கத்தை நீக்குவதில் பிழை."
+
+#: ../src/common/imagwebp.cpp:240
+msgid "WebP: Error getting next animation frame."
+msgstr "WebP: அடுத்த அசைவுட்ட சட்டகத்தைப் பெறுவதில் தோல்வி."
+
+#: ../src/common/init.cpp:172
+#, c-format
+msgid ""
+"Command line argument %d couldn't be converted to Unicode and will be "
+"ignored."
+msgstr "%d கட்டளைவரி தர்க்கத்தை ஒருங்குறியாக மாற்ற இயலவில்லை. அது புறந்தள்ளப்படும்."
+
+#: ../src/common/init.cpp:344
+msgid "Initialization failed in post init, aborting."
+msgstr "Post init-ல் தொடக்கநிலையாக்கம் தோல்வியடைந்தது. செயல் இடைமறிக்கப்படுகிறது."
+
+#: ../src/common/intl.cpp:378
+#, c-format
+msgid "Cannot set locale to language \"%s\"."
+msgstr "\"%s\" மொழிக்கு வட்டார மொழியை அமைக்க இயலவில்லை"
+
+#: ../src/common/log.cpp:232
+msgid "Error: "
+msgstr "பிழை:"
+
+#: ../src/common/log.cpp:236
+msgid "Warning: "
+msgstr "எச்சரிக்கை:"
+
+#: ../src/common/log.cpp:284
+msgid "The previous message repeated once."
+msgstr "முந்தைய தகவல் ஒரு முறை மீண்டும் தோன்றியது."
+
+#: ../src/common/log.cpp:291
+#, c-format
+msgid "The previous message repeated %u time."
+msgid_plural "The previous message repeated %u times."
+msgstr[0] "முந்தைய தகவல் %u தடவை மீண்டும் தோன்றியது"
+msgstr[1] "முந்தைய தகவல் %u தடவை மீண்டும் தோன்றின"
+
+#: ../src/common/log.cpp:319
+#, c-format
+msgid "Last repeated message (\"%s\", %u time) wasn't output"
+msgid_plural "Last repeated message (\"%s\", %u times) wasn't output"
+msgstr[0] "கடைசியாக மறு அறிவிப்பு செய்யப்பட்ட தகவல் (\"%s\", %u தடவை) வெளியீடு இல்லை"
+msgstr[1] "கடைசியாக மறு அறிவிப்பு செய்யப்பட்ட தகவல் (\"%s\", %u தடவை) வெளியீடு இல்லை"
+
+#: ../src/common/log.cpp:435
+#, c-format
+msgid " (error %ld: %s)"
+msgstr " (பிழை %ld: %s)"
+
+#: ../src/common/lzmastream.cpp:121
+msgid "Failed to allocate memory for LZMA decompression."
+msgstr "LZMA விரிவாக்கத்திற்கு நினைவகத்தை ஒதுக்கீடு செய்வதில் தோல்வி. "
+
+#: ../src/common/lzmastream.cpp:125
+#, c-format
+msgid "Failed to initialize LZMA decompression: unexpected error %u."
+msgstr "LZMA விரிவாக்கத்தைத் தொடக்கநிலையாக்குவதில் தோல்வி. எதிர்பாராத பிழை %u."
+
+#: ../src/common/lzmastream.cpp:179
+msgid "input is not in XZ format"
+msgstr "உள்ளீடு XZ வடிவூட்டத்தில் இல்லை"
+
+#: ../src/common/lzmastream.cpp:183
+msgid "input compressed using unknown XZ option"
+msgstr "அறியப்படாத XZ விருப்பத் தேர்வினைப் பயன்படுத்தி உள்ளீடு குறுக்கப்பட்டது"
+
+#: ../src/common/lzmastream.cpp:188
+msgid "input is corrupted"
+msgstr "உள்ளீடு பழுதடைந்துள்ளது"
+
+#: ../src/common/lzmastream.cpp:192
+msgid "unknown decompression error"
+msgstr "அறியப்படாத விரிவாக்கப் பிழை"
+
+#: ../src/common/lzmastream.cpp:196
+#, c-format
+msgid "LZMA decompression error: %s"
+msgstr "LZMA விரிவாக்கப் பிழை: %s"
+
+#: ../src/common/lzmastream.cpp:231
+msgid "Failed to allocate memory for LZMA compression."
+msgstr "LZMA குறுக்கத்திற்கு நினைவகத்தை ஒதுக்குவதில் தோல்வி. "
+
+#: ../src/common/lzmastream.cpp:235
+#, c-format
+msgid "Failed to initialize LZMA compression: unexpected error %u."
+msgstr "LZMA குறுக்கத்தைத் தொடக்கநிலையாக்குவதில் தோல்வி. எதிர்பாராத பிழை %u."
+
+#: ../src/common/lzmastream.cpp:267 ../src/common/lzmastream.cpp:342
+#: ../src/html/chm.cpp:336
+msgid "out of memory"
+msgstr "நினைவகம் இல்லை"
+
+#: ../src/common/lzmastream.cpp:276 ../src/common/lzmastream.cpp:346
+msgid "unknown compression error"
+msgstr "அறியப்படாத குறுக்கல் பிழை"
+
+#: ../src/common/lzmastream.cpp:280
+#, c-format
+msgid "LZMA compression error: %s"
+msgstr "LZMA குறுக்கல் பிழை: %s"
+
+#: ../src/common/lzmastream.cpp:350
+#, c-format
+msgid "LZMA compression error when flushing output: %s"
+msgstr "வெளியீட்டினை வெளித்தள்ளும்பொழுது LZMA விரிவாக்கப் பிழை: %s"
+
+#: ../src/common/mimecmn.cpp:167
+#, c-format
+msgid "Unmatched '{' in an entry for mime type %s."
+msgstr "%s மைம் வகைக்கான உள்ளீட்டில் பொருந்தாத '{' "
+
+#: ../src/common/module.cpp:76
+#, c-format
+msgid "Circular dependency involving module \"%s\" detected."
+msgstr "\"%s\" நிரற்கூறு தொடர்புடைய சுற்றுச் சார்பு கண்டறியப்பட்டது."
+
+#: ../src/common/module.cpp:128
+#, c-format
+msgid "Dependency \"%s\" of module \"%s\" doesn't exist."
+msgstr "\"%s\" சார்பு இல்லை. (\"%s\" நிரற்கூறினுடையது)"
+
+#: ../src/common/module.cpp:137
+#, c-format
+msgid "Module \"%s\" initialization failed"
+msgstr "\"%s\" நிரற்கூறினைத் தொடக்க நிலையாக்குவதில் தோல்வி"
+
+#: ../src/common/msgout.cpp:96
+msgid "Message"
+msgstr "தகவல்"
+
+#: ../src/common/paper.cpp:70
+msgid "Letter, 8 1/2 x 11 in"
+msgstr "Letter, 8 1/2 x 11 அங்குலம்"
+
+#: ../src/common/paper.cpp:71
+msgid "Legal, 8 1/2 x 14 in"
+msgstr "Legal, 8 1/2 x 14 அங்குலம்"
+
+#: ../src/common/paper.cpp:72
+msgid "A4 sheet, 210 x 297 mm"
+msgstr "A4 sheet, 210 x 297 மி.மீ."
+
+#: ../src/common/paper.cpp:73
+msgid "C sheet, 17 x 22 in"
+msgstr "C sheet, 17 x 22 அங்குலம்"
+
+#: ../src/common/paper.cpp:74
+msgid "D sheet, 22 x 34 in"
+msgstr "D sheet, 22 x 34 அங்குலம்"
+
+#: ../src/common/paper.cpp:75
+msgid "E sheet, 34 x 44 in"
+msgstr "E sheet, 34 x 44 அங்குலம்"
+
+#: ../src/common/paper.cpp:76
+msgid "Letter Small, 8 1/2 x 11 in"
+msgstr "Letter Small, 8 1/2 x 11 அங்குலம்"
+
+#: ../src/common/paper.cpp:77
+msgid "Tabloid, 11 x 17 in"
+msgstr "Tabloid, 11 x 17 அங்குலம்"
+
+#: ../src/common/paper.cpp:78
+msgid "Ledger, 17 x 11 in"
+msgstr "Ledger, 17 x 11 அங்குலம்"
+
+#: ../src/common/paper.cpp:79
+msgid "Statement, 5 1/2 x 8 1/2 in"
+msgstr "Statement, 5 1/2 x 8 1/2 அங்குலம்"
+
+#: ../src/common/paper.cpp:80
+msgid "Executive, 7 1/4 x 10 1/2 in"
+msgstr "Executive, 7 1/4 x 10 1/2 அங்குலம்"
+
+#: ../src/common/paper.cpp:81
+msgid "A3 sheet, 297 x 420 mm"
+msgstr "A3 sheet, 297 x 420 மி.மீ."
+
+#: ../src/common/paper.cpp:82
+msgid "A4 small sheet, 210 x 297 mm"
+msgstr "A4 small sheet, 210 x 297 மி.மீ."
+
+#: ../src/common/paper.cpp:83
+msgid "A5 sheet, 148 x 210 mm"
+msgstr "A5 sheet, 148 x 210 மி.மீ."
+
+#: ../src/common/paper.cpp:84
+msgid "B4 sheet, 250 x 354 mm"
+msgstr "B4 sheet, 250 x 354 மி.மீ."
+
+#: ../src/common/paper.cpp:85
+msgid "B5 sheet, 182 x 257 millimeter"
+msgstr "B5 sheet, 182 x 257 மி.மீ."
+
+#: ../src/common/paper.cpp:86
+msgid "Folio, 8 1/2 x 13 in"
+msgstr "Folio, 8 1/2 x 13 அங்குலம்"
+
+#: ../src/common/paper.cpp:87
+msgid "Quarto, 215 x 275 mm"
+msgstr "Quarto, 215 x 275 மி.மீ."
+
+#: ../src/common/paper.cpp:88
+msgid "10 x 14 in"
+msgstr "10 x 14 அங்குலம்"
+
+#: ../src/common/paper.cpp:89
+msgid "11 x 17 in"
+msgstr "11 x 17 அங்குலம்"
+
+#: ../src/common/paper.cpp:90
+msgid "Note, 8 1/2 x 11 in"
+msgstr "Note, 8 1/2 x 11 அங்குலம்"
+
+#: ../src/common/paper.cpp:91
+msgid "#9 Envelope, 3 7/8 x 8 7/8 in"
+msgstr "#9 Envelope, 3 7/8 x 8 7/8 அங்குலம்"
+
+#: ../src/common/paper.cpp:92
+msgid "#10 Envelope, 4 1/8 x 9 1/2 in"
+msgstr "#10 Envelope, 4 1/8 x 9 1/2 அங்குலம்"
+
+#: ../src/common/paper.cpp:93
+msgid "#11 Envelope, 4 1/2 x 10 3/8 in"
+msgstr "#11 Envelope, 4 1/2 x 10 3/8 அங்குலம்"
+
+#: ../src/common/paper.cpp:94
+msgid "#12 Envelope, 4 3/4 x 11 in"
+msgstr "#12 Envelope, 4 3/4 x 11 அங்குலம்"
+
+#: ../src/common/paper.cpp:95
+msgid "#14 Envelope, 5 x 11 1/2 in"
+msgstr "#14 Envelope, 5 x 11 1/2 அங்குலம்"
+
+#: ../src/common/paper.cpp:96
+msgid "DL Envelope, 110 x 220 mm"
+msgstr "DL Envelope, 110 x 220 மி.மீ."
+
+#: ../src/common/paper.cpp:97
+msgid "C5 Envelope, 162 x 229 mm"
+msgstr "C5 Envelope, 162 x 229 மி.மீ."
+
+#: ../src/common/paper.cpp:98
+msgid "C3 Envelope, 324 x 458 mm"
+msgstr "C3 Envelope, 324 x 458 மி.மீ."
+
+#: ../src/common/paper.cpp:99
+msgid "C4 Envelope, 229 x 324 mm"
+msgstr "C4 Envelope, 229 x 324 மி.மீ."
+
+#: ../src/common/paper.cpp:100
+msgid "C6 Envelope, 114 x 162 mm"
+msgstr "C6 Envelope, 114 x 162 மி.மீ."
+
+#: ../src/common/paper.cpp:101
+msgid "C65 Envelope, 114 x 229 mm"
+msgstr "C65 Envelope, 114 x 229 மி.மீ."
+
+#: ../src/common/paper.cpp:102
+msgid "B4 Envelope, 250 x 353 mm"
+msgstr "B4 Envelope, 250 x 353 மி.மீ."
+
+#: ../src/common/paper.cpp:103
+msgid "B5 Envelope, 176 x 250 mm"
+msgstr "B5 Envelope, 176 x 250 மி.மீ."
+
+#: ../src/common/paper.cpp:104
+msgid "B6 Envelope, 176 x 125 mm"
+msgstr "B6 Envelope, 176 x 125 மி.மீ."
+
+#: ../src/common/paper.cpp:105
+msgid "Italy Envelope, 110 x 230 mm"
+msgstr "Italy Envelope, 110 x 230 மி.மீ."
+
+#: ../src/common/paper.cpp:106
+msgid "Monarch Envelope, 3 7/8 x 7 1/2 in"
+msgstr "Monarch Envelope, 3 7/8 x 7 1/2 அங்குலம்"
+
+#: ../src/common/paper.cpp:107
+msgid "6 3/4 Envelope, 3 5/8 x 6 1/2 in"
+msgstr "6 3/4 Envelope, 3 5/8 x 6 1/2 அங்குலம்"
+
+#: ../src/common/paper.cpp:108
+msgid "US Std Fanfold, 14 7/8 x 11 in"
+msgstr "US Std Fanfold, 14 7/8 x 11 அங்குலம்"
+
+#: ../src/common/paper.cpp:109
+msgid "German Std Fanfold, 8 1/2 x 12 in"
+msgstr "German Std Fanfold, 8 1/2 x 12 அங்குலம்"
+
+#: ../src/common/paper.cpp:110
+msgid "German Legal Fanfold, 8 1/2 x 13 in"
+msgstr "German Legal Fanfold, 8 1/2 x 13 அங்குலம்"
+
+#: ../src/common/paper.cpp:112
+msgid "B4 (ISO) 250 x 353 mm"
+msgstr "B4 (ISO) 250 x 353 மி.மீ."
+
+#: ../src/common/paper.cpp:113
+msgid "Japanese Postcard 100 x 148 mm"
+msgstr "Japanese Postcard 100 x 148 மி.மீ."
+
+#: ../src/common/paper.cpp:114
+msgid "9 x 11 in"
+msgstr "9 x 11 அங்குலம்"
+
+#: ../src/common/paper.cpp:115
+msgid "10 x 11 in"
+msgstr "10 x 11 அங்குலம்"
+
+#: ../src/common/paper.cpp:116
+msgid "15 x 11 in"
+msgstr "15 x 11 அங்குலம்"
+
+#: ../src/common/paper.cpp:117
+msgid "Envelope Invite 220 x 220 mm"
+msgstr "Envelope Invite 220 x 220 மி.மீ."
+
+#: ../src/common/paper.cpp:118
+msgid "Letter Extra 9 1/2 x 12 in"
+msgstr "Letter Extra 9 1/2 x 12 அங்குலம்"
+
+#: ../src/common/paper.cpp:119
+msgid "Legal Extra 9 1/2 x 15 in"
+msgstr "Legal Extra 9 1/2 x 15 அங்குலம்"
+
+#: ../src/common/paper.cpp:120
+msgid "Tabloid Extra 11.69 x 18 in"
+msgstr "Tabloid Extra 11.69 x 18 அங்குலம்"
+
+#: ../src/common/paper.cpp:121
+msgid "A4 Extra 9.27 x 12.69 in"
+msgstr "A4 Extra 9.27 x 12.69 அங்குலம்"
+
+#: ../src/common/paper.cpp:122
+msgid "Letter Transverse 8 1/2 x 11 in"
+msgstr "Letter Transverse 8 1/2 x 11 அங்குலம்"
+
+#: ../src/common/paper.cpp:123
+msgid "A4 Transverse 210 x 297 mm"
+msgstr "A4 Transverse 210 x 297 மி.மீ."
+
+#: ../src/common/paper.cpp:124
+msgid "Letter Extra Transverse 9.275 x 12 in"
+msgstr "Letter Extra Transverse 9.275 x 12 அங்குலம்"
+
+#: ../src/common/paper.cpp:125
+msgid "SuperA/SuperA/A4 227 x 356 mm"
+msgstr "SuperA/SuperA/A4 227 x 356 மி.மீ."
+
+#: ../src/common/paper.cpp:126
+msgid "SuperB/SuperB/A3 305 x 487 mm"
+msgstr "SuperB/SuperB/A3 305 x 487 மி.மீ."
+
+#: ../src/common/paper.cpp:127
+msgid "Letter Plus 8 1/2 x 12.69 in"
+msgstr "Letter Plus 8 1/2 x 12.69 அங்குலம்"
+
+#: ../src/common/paper.cpp:128
+msgid "A4 Plus 210 x 330 mm"
+msgstr "A4 Plus 210 x 330 மி.மீ."
+
+#: ../src/common/paper.cpp:129
+msgid "A5 Transverse 148 x 210 mm"
+msgstr "A5 Transverse 148 x 210 மி.மீ."
+
+#: ../src/common/paper.cpp:130
+msgid "B5 (JIS) Transverse 182 x 257 mm"
+msgstr "B5 (JIS) Transverse 182 x 257 மி.மீ."
+
+#: ../src/common/paper.cpp:131
+msgid "A3 Extra 322 x 445 mm"
+msgstr "A3 Extra 322 x 445 மி.மீ."
+
+#: ../src/common/paper.cpp:132
+msgid "A5 Extra 174 x 235 mm"
+msgstr "A5 Extra 174 x 235 மி.மீ."
+
+#: ../src/common/paper.cpp:133
+msgid "B5 (ISO) Extra 201 x 276 mm"
+msgstr "B5 (ISO) Extra 201 x 276 மி.மீ."
+
+#: ../src/common/paper.cpp:134
+msgid "A2 420 x 594 mm"
+msgstr "A2 420 x 594 மி.மீ."
+
+#: ../src/common/paper.cpp:135
+msgid "A3 Transverse 297 x 420 mm"
+msgstr "A3 Transverse 297 x 420 மி.மீ."
+
+#: ../src/common/paper.cpp:136
+msgid "A3 Extra Transverse 322 x 445 mm"
+msgstr "A3 Extra Transverse 322 x 445 மி.மீ."
+
+#: ../src/common/paper.cpp:138
+msgid "Japanese Double Postcard 200 x 148 mm"
+msgstr "Japanese Double Postcard 200 x 148 மி.மீ."
+
+#: ../src/common/paper.cpp:139
+msgid "A6 105 x 148 mm"
+msgstr "A6 105 x 148 மி.மீ."
+
+#: ../src/common/paper.cpp:140
+msgid "Japanese Envelope Kaku #2"
+msgstr "Japanese Envelope Kaku #2"
+
+#: ../src/common/paper.cpp:141
+msgid "Japanese Envelope Kaku #3"
+msgstr "Japanese Envelope Kaku #3"
+
+#: ../src/common/paper.cpp:142
+msgid "Japanese Envelope Chou #3"
+msgstr "Japanese Envelope Chou #3"
+
+#: ../src/common/paper.cpp:143
+msgid "Japanese Envelope Chou #4"
+msgstr "Japanese Envelope Chou #4"
+
+#: ../src/common/paper.cpp:144
+msgid "Letter Rotated 11 x 8 1/2 in"
+msgstr "Letter Rotated 11 x 8 1/2 அங்குலம்"
+
+#: ../src/common/paper.cpp:145
+msgid "A3 Rotated 420 x 297 mm"
+msgstr "A3 Rotated 420 x 297 மி.மீ."
+
+#: ../src/common/paper.cpp:146
+msgid "A4 Rotated 297 x 210 mm"
+msgstr "A4 Rotated 297 x 210 மி.மீ."
+
+#: ../src/common/paper.cpp:147
+msgid "A5 Rotated 210 x 148 mm"
+msgstr "A5 Rotated 210 x 148 மி.மீ."
+
+#: ../src/common/paper.cpp:148
+msgid "B4 (JIS) Rotated 364 x 257 mm"
+msgstr "B4 (JIS) Rotated 364 x 257 மி.மீ."
+
+#: ../src/common/paper.cpp:149
+msgid "B5 (JIS) Rotated 257 x 182 mm"
+msgstr "B5 (JIS) Rotated 257 x 182 மி.மீ."
+
+#: ../src/common/paper.cpp:150
+msgid "Japanese Postcard Rotated 148 x 100 mm"
+msgstr "Japanese Postcard Rotated 148 x 100 மி.மீ."
+
+#: ../src/common/paper.cpp:151
+msgid "Double Japanese Postcard Rotated 148 x 200 mm"
+msgstr "Double Japanese Postcard Rotated 148 x 200 மி.மீ."
+
+#: ../src/common/paper.cpp:152
+msgid "A6 Rotated 148 x 105 mm"
+msgstr "A6 Rotated 148 x 105 மி.மீ."
+
+#: ../src/common/paper.cpp:153
+msgid "Japanese Envelope Kaku #2 Rotated"
+msgstr "Japanese Envelope Kaku #2 Rotated"
+
+#: ../src/common/paper.cpp:154
+msgid "Japanese Envelope Kaku #3 Rotated"
+msgstr "Japanese Envelope Kaku #3 Rotated"
+
+#: ../src/common/paper.cpp:155
+msgid "Japanese Envelope Chou #3 Rotated"
+msgstr "Japanese Envelope Chou #3 Rotated"
+
+#: ../src/common/paper.cpp:156
+msgid "Japanese Envelope Chou #4 Rotated"
+msgstr "Japanese Envelope Chou #4 Rotated"
+
+#: ../src/common/paper.cpp:157
+msgid "B6 (JIS) 128 x 182 mm"
+msgstr "B6 (JIS) 128 x 182 மி.மீ."
+
+#: ../src/common/paper.cpp:158
+msgid "B6 (JIS) Rotated 182 x 128 mm"
+msgstr "B6 (JIS) Rotated 182 x 128 மி.மீ."
+
+#: ../src/common/paper.cpp:159
+msgid "12 x 11 in"
+msgstr "12 x 11 அங்குலம்"
+
+#: ../src/common/paper.cpp:160
+msgid "Japanese Envelope You #4"
+msgstr "Japanese Envelope You #4"
+
+#: ../src/common/paper.cpp:161
+msgid "Japanese Envelope You #4 Rotated"
+msgstr "Japanese Envelope You #4 Rotated"
+
+#: ../src/common/paper.cpp:162
+msgid "PRC 16K 146 x 215 mm"
+msgstr "PRC 16K 146 x 215 மி.மீ."
+
+#: ../src/common/paper.cpp:163
+msgid "PRC 32K 97 x 151 mm"
+msgstr "PRC 32K 97 x 151 மி.மீ."
+
+#: ../src/common/paper.cpp:164
+msgid "PRC 32K(Big) 97 x 151 mm"
+msgstr "PRC 32K(Big) 97 x 151 மி.மீ."
+
+#: ../src/common/paper.cpp:165
+msgid "PRC Envelope #1 102 x 165 mm"
+msgstr "PRC Envelope #1 102 x 165 மி.மீ."
+
+#: ../src/common/paper.cpp:166
+msgid "PRC Envelope #2 102 x 176 mm"
+msgstr "PRC Envelope #2 102 x 176 மி.மீ."
+
+#: ../src/common/paper.cpp:167
+msgid "PRC Envelope #3 125 x 176 mm"
+msgstr "PRC Envelope #3 125 x 176 மி.மீ."
+
+#: ../src/common/paper.cpp:168
+msgid "PRC Envelope #4 110 x 208 mm"
+msgstr "PRC Envelope #4 110 x 208 மி.மீ."
+
+#: ../src/common/paper.cpp:169
+msgid "PRC Envelope #5 110 x 220 mm"
+msgstr "PRC Envelope #5 110 x 220 மி.மீ."
+
+#: ../src/common/paper.cpp:170
+msgid "PRC Envelope #6 120 x 230 mm"
+msgstr "PRC Envelope #6 120 x 230 மி.மீ."
+
+#: ../src/common/paper.cpp:171
+msgid "PRC Envelope #7 160 x 230 mm"
+msgstr "PRC Envelope #7 160 x 230 மி.மீ."
+
+#: ../src/common/paper.cpp:172
+msgid "PRC Envelope #8 120 x 309 mm"
+msgstr "PRC Envelope #8 120 x 309 மி.மீ."
+
+#: ../src/common/paper.cpp:173
+msgid "PRC Envelope #9 229 x 324 mm"
+msgstr "PRC Envelope #9 229 x 324 மி.மீ."
+
+#: ../src/common/paper.cpp:174
+msgid "PRC Envelope #10 324 x 458 mm"
+msgstr "PRC Envelope #10 324 x 458 மி.மீ."
+
+#: ../src/common/paper.cpp:175
+msgid "PRC 16K Rotated"
+msgstr "PRC 16K Rotated"
+
+#: ../src/common/paper.cpp:176
+msgid "PRC 32K Rotated"
+msgstr "PRC 32K Rotated"
+
+#: ../src/common/paper.cpp:177
+msgid "PRC 32K(Big) Rotated"
+msgstr "PRC 32K(Big) Rotated"
+
+#: ../src/common/paper.cpp:178
+msgid "PRC Envelope #1 Rotated 165 x 102 mm"
+msgstr "PRC Envelope #1 Rotated 165 x 102 மி.மீ."
+
+#: ../src/common/paper.cpp:179
+msgid "PRC Envelope #2 Rotated 176 x 102 mm"
+msgstr "PRC Envelope #2 Rotated 176 x 102 மி.மீ."
+
+#: ../src/common/paper.cpp:180
+msgid "PRC Envelope #3 Rotated 176 x 125 mm"
+msgstr "PRC Envelope #3 Rotated 176 x 125 மி.மீ."
+
+#: ../src/common/paper.cpp:181
+msgid "PRC Envelope #4 Rotated 208 x 110 mm"
+msgstr "PRC Envelope #4 Rotated 208 x 110 மி.மீ."
+
+#: ../src/common/paper.cpp:182
+msgid "PRC Envelope #5 Rotated 220 x 110 mm"
+msgstr "PRC Envelope #5 Rotated 220 x 110 மி.மீ."
+
+#: ../src/common/paper.cpp:183
+msgid "PRC Envelope #6 Rotated 230 x 120 mm"
+msgstr "PRC Envelope #6 Rotated 230 x 120 மி.மீ."
+
+#: ../src/common/paper.cpp:184
+msgid "PRC Envelope #7 Rotated 230 x 160 mm"
+msgstr "PRC Envelope #7 Rotated 230 x 160 மி.மீ."
+
+#: ../src/common/paper.cpp:185
+msgid "PRC Envelope #8 Rotated 309 x 120 mm"
+msgstr "PRC Envelope #8 Rotated 309 x 120 மி.மீ."
+
+#: ../src/common/paper.cpp:186
+msgid "PRC Envelope #9 Rotated 324 x 229 mm"
+msgstr "PRC Envelope #9 Rotated 324 x 229 மி.மீ."
+
+#: ../src/common/paper.cpp:187
+msgid "PRC Envelope #10 Rotated 458 x 324 mm"
+msgstr "PRC Envelope #10 Rotated 458 x 324 மி.மீ."
+
+#: ../src/common/paper.cpp:192
+msgid "A0 sheet, 841 x 1189 mm"
+msgstr "A0 sheet, 841 x 1189 மி.மீ."
+
+#: ../src/common/paper.cpp:193
+msgid "A1 sheet, 594 x 841 mm"
+msgstr "A1 sheet, 594 x 841 மி.மீ."
+
+#: ../src/common/preferencescmn.cpp:37
+msgid "General"
+msgstr "பொது"
+
+#: ../src/common/preferencescmn.cpp:40
+msgid "Advanced"
+msgstr "மேம்பட்டது"
+
+#: ../src/common/prntbase.cpp:245
+msgid "Generic PostScript"
+msgstr "பொதுத் தரவு பின் குறிப்பு"
+
+#: ../src/common/prntbase.cpp:259
+msgid "Ready"
+msgstr "ஆயத்தமாயுள்ளது"
+
+#: ../src/common/prntbase.cpp:331
+msgid "Printing Error"
+msgstr "அச்சீட்டில் பிழை"
+
+#: ../src/common/prntbase.cpp:413 ../src/common/prntbase.cpp:1597
+#: ../src/generic/prntdlgg.cpp:135 ../src/generic/prntdlgg.cpp:149
+#: ../src/gtk/print.cpp:628 ../src/gtk/print.cpp:646
+msgid "Print"
+msgstr "அச்சிடு"
+
+#: ../src/common/prntbase.cpp:471 ../src/generic/prntdlgg.cpp:809
+msgid "Page setup"
+msgstr "பக்க அமைவு"
+
+#: ../src/common/prntbase.cpp:525
+msgid "Please wait while printing..."
+msgstr "அச்சிடப்படுகிறது, அருள்கூர்ந்து காத்திருக்கவும்..."
+
+#: ../src/common/prntbase.cpp:529
+msgid "Document:"
+msgstr "ஆவணம்:"
+
+#: ../src/common/prntbase.cpp:532
+msgid "Progress:"
+msgstr "முன்னேற்றம்:"
+
+#: ../src/common/prntbase.cpp:533
+msgid "Preparing"
+msgstr "ஆயத்தமாகிறது"
+
+#: ../src/common/prntbase.cpp:552
+#, c-format
+msgid "Printing page %d"
+msgstr "%d பக்கம் அச்சிடப்படுகிறது"
+
+#: ../src/common/prntbase.cpp:557
+#, c-format
+msgid "Printing page %d of %d"
+msgstr "%d பக்கம் அச்சிடப்படுகிறது; மொத்த பக்கங்கள் %d"
+
+#: ../src/common/prntbase.cpp:560
+#, c-format
+msgid " (copy %d of %d)"
+msgstr " (%d-யின் படி; மொத்தம் %d)"
+
+#: ../src/common/prntbase.cpp:1604
+msgid "First page"
+msgstr "முதல் பக்கம்"
+
+#: ../src/common/prntbase.cpp:1609 ../src/html/helpwnd.cpp:659
+msgid "Previous page"
+msgstr "முந்தைய பக்கம்"
+
+#: ../src/common/prntbase.cpp:1623 ../src/html/helpwnd.cpp:660
+msgid "Next page"
+msgstr "அடுத்த பக்கம்"
+
+#: ../src/common/prntbase.cpp:1628
+msgid "Last page"
+msgstr "கடைசிப் பக்கம்"
+
+#: ../src/common/prntbase.cpp:1636 ../src/common/stockitem.cpp:215
+msgid "Zoom Out"
+msgstr "குறை பெரிதாக்கம்"
+
+#: ../src/common/prntbase.cpp:1650 ../src/common/stockitem.cpp:214
+msgid "Zoom In"
+msgstr "பெரிதாக்கம்"
+
+#: ../src/common/prntbase.cpp:1656 ../src/common/stockitem.cpp:153
+#: ../src/generic/logg.cpp:553 ../src/univ/themes/win32.cpp:3752
+msgid "&Close"
+msgstr "மூடுக (&C)"
+
+#: ../src/common/prntbase.cpp:2085
+msgid "Could not start document preview."
+msgstr "ஆவணத்தின் முன்தோற்றத்தை துவக்க இயலவில்லை."
+
+#: ../src/common/prntbase.cpp:2085 ../src/common/prntbase.cpp:2129
+#: ../src/common/prntbase.cpp:2137
+msgid "Print Preview Failure"
+msgstr "அச்சு முன்தோற்றத் தோல்வி"
+
+#: ../src/common/prntbase.cpp:2129 ../src/common/prntbase.cpp:2137
+msgid "Sorry, not enough memory to create a preview."
+msgstr "பொறுத்தருள்க, முன்தோற்றத்தை உருவாக்க போதுமான நினைவகம் இல்லை."
+
+#: ../src/common/prntbase.cpp:2144
+#, c-format
+msgid "Page %d of %d"
+msgstr "பக்கம் %d, மொத்தம் %d"
+
+#: ../src/common/prntbase.cpp:2146
+#, c-format
+msgid "Page %d"
+msgstr "பக்கம் %d"
+
+#: ../src/common/regex.cpp:382 ../src/html/chm.cpp:348
+msgid "unknown error"
+msgstr "அறியப்படாத பிழை"
+
+#: ../src/common/regex.cpp:995
+#, c-format
+msgid "Invalid regular expression '%s': %s"
+msgstr "செல்லாத சுருங்குறித்தொடர் '%s': %s"
+
+#: ../src/common/regex.cpp:1059
+#, c-format
+msgid "Failed to find match for regular expression: %s"
+msgstr "சுருங்குறித்தொடருக்கு பொருத்தத்தை காண்பதில் தோல்வி: %s "
+
+#: ../src/common/rendcmn.cpp:188
+#, c-format
+msgid "Renderer \"%s\" has incompatible version %d.%d and couldn't be loaded."
+msgstr "\"%s\" வழங்கி இணக்கமற்ற %d.%d பதிப்பைக் கொண்டுள்ளது, அதை ஏற்ற இயலவில்லை."
+
+#: ../src/common/secretstore.cpp:162
+msgid "Not available for this platform"
+msgstr "இந்த இயங்குதளத்திற்கு கிடைப்பிலில்லை"
+
+#: ../src/common/secretstore.cpp:183
+#, c-format
+msgid "Saving password for \"%s\" failed: %s."
+msgstr "\"%s\"க்கு கடவுச்சொல்லினைச் சேமிப்பதில் தோல்வி: %s."
+
+#: ../src/common/secretstore.cpp:205
+#, c-format
+msgid "Reading password for \"%s\" failed: %s."
+msgstr "\"%s\"க்கு கடவுச்சொல்லினைப் படிப்பதில் தோல்வி: %s."
+
+#: ../src/common/secretstore.cpp:228
+#, c-format
+msgid "Deleting password for \"%s\" failed: %s."
+msgstr "\"%s\"க்கான கடவுச்சொல்லினை அழிப்பதில் தோல்வி: %s."
+
+#: ../src/common/selectdispatcher.cpp:254
+msgid "Failed to monitor I/O channels"
+msgstr "உள்ளிடு/வெளியிடு அலைத்தடத்தைக் கண்காணிப்பதில் தோல்வி"
+
+#: ../src/common/sizer.cpp:3054 ../src/common/stockitem.cpp:195
+msgid "Save"
+msgstr "சேமித்திடுக"
+
+#: ../src/common/sizer.cpp:3056
+msgid "Don't Save"
+msgstr "சேமிக்க வேண்டாம்"
+
+#: ../src/common/socket.cpp:870
+msgid "Cannot initialize sockets"
+msgstr "பொருத்திகளை தொடக்கநிலையாக்க இயலவில்லை"
+
+#: ../src/common/stockitem.cpp:127
+msgctxt "standard Windows menu"
+msgid "&Help"
+msgstr "உதவி (&H)"
+
+#: ../src/common/stockitem.cpp:144
+msgid "&About"
+msgstr "குறித்து... (&A)"
+
+#: ../src/common/stockitem.cpp:144
+msgid "About"
+msgstr "குறித்து..."
+
+#: ../src/common/stockitem.cpp:145
+msgid "Add"
+msgstr "சேர்த்திடுக"
+
+#: ../src/common/stockitem.cpp:146
+msgid "&Apply"
+msgstr "இடுக (&A)"
+
+#: ../src/common/stockitem.cpp:146
+msgid "Apply"
+msgstr "இடுக"
+
+#: ../src/common/stockitem.cpp:147
+msgid "&Back"
+msgstr "பின் (&B)"
+
+#: ../src/common/stockitem.cpp:147
+msgid "Back"
+msgstr "பின்"
+
+#: ../src/common/stockitem.cpp:148
+msgid "&Bold"
+msgstr "அடர்த்தி (&B)"
+
+#: ../src/common/stockitem.cpp:148 ../src/generic/fontdlgg.cpp:326
+#: ../src/richtext/richtextfontpage.cpp:354
+msgid "Bold"
+msgstr "அடர்த்தி"
+
+#: ../src/common/stockitem.cpp:149
+msgid "&Bottom"
+msgstr "அடித்தளம் (&B)"
+
+#: ../src/common/stockitem.cpp:149 ../src/richtext/richtextsizepage.cpp:287
+msgid "Bottom"
+msgstr "அடித்தளம்"
+
+#: ../src/common/stockitem.cpp:150 ../src/generic/fontdlgg.cpp:462
+#: ../src/generic/fontdlgg.cpp:481 ../src/generic/wizard.cpp:415
+msgid "&Cancel"
+msgstr "விலக்குக (&C)"
+
+#: ../src/common/stockitem.cpp:151
+msgid "&CD-ROM"
+msgstr "குறுந்தட்டு நினைவகம் (&C)"
+
+#: ../src/common/stockitem.cpp:151
+msgid "CD-ROM"
+msgstr "குறுந்தட்டு நினைவகம்"
+
+#: ../src/common/stockitem.cpp:152
+msgid "&Clear"
+msgstr "துடை (&C)"
+
+#: ../src/common/stockitem.cpp:152
+msgid "Clear"
+msgstr "துடை"
+
+#: ../src/common/stockitem.cpp:153 ../src/generic/dbgrptg.cpp:93
+#: ../src/generic/progdlgg.cpp:778 ../src/html/helpdlg.cpp:86
+#: ../src/msw/progdlg.cpp:209 ../src/msw/progdlg.cpp:890
+#: ../src/richtext/richtextstyledlg.cpp:272
+#: ../src/richtext/richtextsymboldlg.cpp:448
+msgid "Close"
+msgstr "மூடுக"
+
+#: ../src/common/stockitem.cpp:154
+msgid "&Convert"
+msgstr "மாற்றுக (&C)"
+
+#: ../src/common/stockitem.cpp:154
+msgid "Convert"
+msgstr "மாற்றுக"
+
+#: ../src/common/stockitem.cpp:155 ../src/msw/textctrl.cpp:2884
+#: ../src/osx/textctrl_osx.cpp:653 ../src/richtext/richtextctrl.cpp:331
+msgid "&Copy"
+msgstr "படியெடுத்திடுக (&C)"
+
+#: ../src/common/stockitem.cpp:155 ../src/stc/stc_i18n.cpp:18
+msgid "Copy"
+msgstr "படியெடுத்திடுக"
+
+#: ../src/common/stockitem.cpp:156 ../src/msw/textctrl.cpp:2883
+#: ../src/osx/textctrl_osx.cpp:652 ../src/richtext/richtextctrl.cpp:330
+msgid "Cu&t"
+msgstr "வெட்டுக (&T)"
+
+#: ../src/common/stockitem.cpp:156 ../src/stc/stc_i18n.cpp:17
+msgid "Cut"
+msgstr "வெட்டுக"
+
+#: ../src/common/stockitem.cpp:157 ../src/msw/textctrl.cpp:2886
+#: ../src/osx/textctrl_osx.cpp:655 ../src/richtext/richtextctrl.cpp:333
+#: ../src/richtext/richtexttabspage.cpp:137
+msgid "&Delete"
+msgstr "அழித்திடுக (&D)"
+
+#: ../src/common/stockitem.cpp:157 ../src/richtext/richtextbuffer.cpp:8266
+#: ../src/stc/stc_i18n.cpp:20
+msgid "Delete"
+msgstr "அழித்திடுக"
+
+#: ../src/common/stockitem.cpp:158
+msgid "&Down"
+msgstr "கீழ் (&D)"
+
+#: ../src/common/stockitem.cpp:158 ../src/generic/fdrepdlg.cpp:148
+msgid "Down"
+msgstr "கீழ்"
+
+#: ../src/common/stockitem.cpp:159
+msgid "&Edit"
+msgstr "தொகுத்திடுக (&E)"
+
+#: ../src/common/stockitem.cpp:159
+msgid "Edit"
+msgstr "தொகுத்திடுக"
+
+#: ../src/common/stockitem.cpp:160
+msgid "&Execute"
+msgstr "செயற்படுத்துக (&E)"
+
+#: ../src/common/stockitem.cpp:160
+msgid "Execute"
+msgstr "செயற்படுத்துக"
+
+#: ../src/common/stockitem.cpp:161
+msgid "&Quit"
+msgstr "வெளியேறுக (&Q)"
+
+#: ../src/common/stockitem.cpp:161
+msgid "Quit"
+msgstr "வெளியேறுக"
+
+#: ../src/common/stockitem.cpp:162
+msgid "&File"
+msgstr "கோப்பு (&F)"
+
+#: ../src/common/stockitem.cpp:162
+msgid "File"
+msgstr "கோப்பு"
+
+#: ../src/common/stockitem.cpp:163
+msgid "&Find..."
+msgstr "கண்டறிக (&F)"
+
+#: ../src/common/stockitem.cpp:163
+msgid "Find..."
+msgstr "கண்டறிக"
+
+#: ../src/common/stockitem.cpp:164
+msgid "&First"
+msgstr "முதல் (&F)"
+
+#: ../src/common/stockitem.cpp:164
+msgid "First"
+msgstr "முதல்"
+
+#: ../src/common/stockitem.cpp:165
+msgid "&Floppy"
+msgstr "நெகிழ்வட்டு (&F)"
+
+#: ../src/common/stockitem.cpp:165
+msgid "Floppy"
+msgstr "நெகிழ்வட்டு"
+
+#: ../src/common/stockitem.cpp:166
+msgid "&Forward"
+msgstr "மீளனுப்புக (&F)"
+
+#: ../src/common/stockitem.cpp:166
+msgid "Forward"
+msgstr "மீளனுப்புக"
+
+#: ../src/common/stockitem.cpp:167
+msgid "&Harddisk"
+msgstr "வன்தட்டு (&H)"
+
+#: ../src/common/stockitem.cpp:167
+msgid "Harddisk"
+msgstr "வன்தட்டு"
+
+#: ../src/common/stockitem.cpp:168 ../src/generic/wizard.cpp:418
+#: ../src/osx/cocoa/menu.mm:225 ../src/richtext/richtextstyledlg.cpp:298
+#: ../src/richtext/richtextsymboldlg.cpp:451
+msgid "&Help"
+msgstr "உதவி (&H)"
+
+#: ../src/common/stockitem.cpp:169
+msgid "&Home"
+msgstr "முகப்பு (&H)"
+
+#: ../src/common/stockitem.cpp:169
+msgid "Home"
+msgstr "முகப்பு"
+
+#: ../src/common/stockitem.cpp:170
+msgid "Indent"
+msgstr "வரித் துவக்க ஒழுங்கு"
+
+#: ../src/common/stockitem.cpp:171
+msgid "&Index"
+msgstr "சுட்டெண் (&I)"
+
+#: ../src/common/stockitem.cpp:171 ../src/html/helpwnd.cpp:510
+msgid "Index"
+msgstr "சுட்டெண்"
+
+#: ../src/common/stockitem.cpp:172
+msgid "&Info"
+msgstr "தகவல் (&I)"
+
+#: ../src/common/stockitem.cpp:172
+msgid "Info"
+msgstr "தகவல்"
+
+#: ../src/common/stockitem.cpp:173
+msgid "&Italic"
+msgstr "வலச் சாய்வு (&I)"
+
+#: ../src/common/stockitem.cpp:173 ../src/generic/fontdlgg.cpp:322
+#: ../src/richtext/richtextfontpage.cpp:350
+msgid "Italic"
+msgstr "வலச் சாய்வு"
+
+#: ../src/common/stockitem.cpp:174
+msgid "&Jump to"
+msgstr "இங்கு தாவுக (&J)"
+
+#: ../src/common/stockitem.cpp:174
+msgid "Jump to"
+msgstr "இங்கு தாவுக"
+
+#: ../src/common/stockitem.cpp:175
+msgid "Centered"
+msgstr "நடுசீர்"
+
+#: ../src/common/stockitem.cpp:176
+msgid "Justified"
+msgstr "இருபுற சீர்"
+
+#: ../src/common/stockitem.cpp:177
+msgid "Align Left"
+msgstr "இடச்சீர்"
+
+#: ../src/common/stockitem.cpp:178
+msgid "Align Right"
+msgstr "வலச்சீர்"
+
+#: ../src/common/stockitem.cpp:179
+msgid "&Last"
+msgstr "கடைசி (&L)"
+
+#: ../src/common/stockitem.cpp:179
+msgid "Last"
+msgstr "கடைசி"
+
+#: ../src/common/stockitem.cpp:180
+msgid "&Network"
+msgstr "வலையமைப்பு (&N)"
+
+#: ../src/common/stockitem.cpp:180
+msgid "Network"
+msgstr "வலையமைப்பு"
+
+#: ../src/common/stockitem.cpp:181 ../src/richtext/richtexttabspage.cpp:131
+msgid "&New"
+msgstr "புதிது (&N)"
+
+#: ../src/common/stockitem.cpp:181
+msgid "New"
+msgstr "புதிது"
+
+#: ../src/common/stockitem.cpp:182 ../src/msw/msgdlg.cpp:417
+msgid "&No"
+msgstr "இல்லை (&N)"
+
+#: ../src/common/stockitem.cpp:183 ../src/generic/fontdlgg.cpp:467
+#: ../src/generic/fontdlgg.cpp:474
+msgid "&OK"
+msgstr "சரி (&O)"
+
+#: ../src/common/stockitem.cpp:184 ../src/generic/dbgrptg.cpp:341
+msgid "&Open..."
+msgstr "திறவுக... (&O)"
+
+#: ../src/common/stockitem.cpp:184
+msgid "Open..."
+msgstr "திறவுக..."
+
+#: ../src/common/stockitem.cpp:185 ../src/msw/textctrl.cpp:2885
+#: ../src/osx/textctrl_osx.cpp:654 ../src/richtext/richtextctrl.cpp:332
+msgid "&Paste"
+msgstr "ஒட்டுக (&P)"
+
+#: ../src/common/stockitem.cpp:185 ../src/richtext/richtextctrl.cpp:3484
+#: ../src/stc/stc_i18n.cpp:19
+msgid "Paste"
+msgstr "ஒட்டுக"
+
+#: ../src/common/stockitem.cpp:186
+msgid "&Preferences"
+msgstr "விருப்பங்கள் (&P)"
+
+#: ../src/common/stockitem.cpp:186 ../src/osx/cocoa/preferences.mm:304
+msgid "Preferences"
+msgstr "விருப்பங்கள்"
+
+#: ../src/common/stockitem.cpp:187
+msgid "Print previe&w..."
+msgstr "அச்சு முன்தோற்றம்... (&W)"
+
+#: ../src/common/stockitem.cpp:187
+msgid "Print preview..."
+msgstr "அச்சு முன்தோற்றம்..."
+
+#: ../src/common/stockitem.cpp:188
+msgid "&Print..."
+msgstr "அச்சிடுக... (&P)"
+
+#: ../src/common/stockitem.cpp:188
+msgid "Print..."
+msgstr "அச்சிடுக..."
+
+#: ../src/common/stockitem.cpp:189 ../src/richtext/richtextctrl.cpp:337
+#: ../src/richtext/richtextctrl.cpp:5479
+msgid "&Properties"
+msgstr "பண்புகள் (&P)"
+
+#: ../src/common/stockitem.cpp:189
+msgid "Properties"
+msgstr "பண்புகள்"
+
+#: ../src/common/stockitem.cpp:190 ../src/stc/stc_i18n.cpp:16
+msgid "Redo"
+msgstr "மீள்செய்க"
+
+#: ../src/common/stockitem.cpp:191
+msgid "Refresh"
+msgstr "புத்தாக்குக"
+
+#: ../src/common/stockitem.cpp:192
+msgid "Remove"
+msgstr "நீக்குக"
+
+#: ../src/common/stockitem.cpp:193
+msgid "Rep&lace..."
+msgstr "மாற்றமர்வு... (&L)"
+
+#: ../src/common/stockitem.cpp:193
+msgid "Replace..."
+msgstr "மாற்றமர்வு..."
+
+#: ../src/common/stockitem.cpp:194
+msgid "Revert to Saved"
+msgstr "சேமித்ததற்கு திரும்புக"
+
+#: ../src/common/stockitem.cpp:196 ../src/generic/logg.cpp:549
+msgid "Save &As..."
+msgstr "இவ்வாறு சேமித்திடுக... (&A)"
+
+#: ../src/common/stockitem.cpp:196
+msgid "Save As..."
+msgstr "இவ்வாறு சேமித்திடுக..."
+
+#: ../src/common/stockitem.cpp:197 ../src/msw/textctrl.cpp:2888
+#: ../src/osx/textctrl_osx.cpp:657 ../src/richtext/richtextctrl.cpp:335
+msgid "Select &All"
+msgstr "அனைத்தையும் தெரிவுசெய்க (&A)"
+
+#: ../src/common/stockitem.cpp:197 ../src/stc/stc_i18n.cpp:21
+msgid "Select All"
+msgstr "அனைத்தையும் தெரிவுசெய்க"
+
+#: ../src/common/stockitem.cpp:198
+msgid "&Color"
+msgstr "நிறம் (&C)"
+
+#: ../src/common/stockitem.cpp:198
+msgid "Color"
+msgstr "நிறம்"
+
+#: ../src/common/stockitem.cpp:199
+msgid "&Font"
+msgstr "எழுத்துரு (&F)"
+
+#: ../src/common/stockitem.cpp:199 ../src/richtext/richtextformatdlg.cpp:336
+msgid "Font"
+msgstr "எழுத்துரு"
+
+#: ../src/common/stockitem.cpp:200
+msgid "&Ascending"
+msgstr "ஏறுமுகம் (&A)"
+
+#: ../src/common/stockitem.cpp:200
+msgid "Ascending"
+msgstr "ஏறுமுகம்"
+
+#: ../src/common/stockitem.cpp:201
+msgid "&Descending"
+msgstr "இறங்குமுகம் (&D)"
+
+#: ../src/common/stockitem.cpp:201
+msgid "Descending"
+msgstr "இறங்குமுகம்"
+
+#: ../src/common/stockitem.cpp:202
+msgid "&Spell Check"
+msgstr "சொல் திருத்தி (&S)"
+
+#: ../src/common/stockitem.cpp:202
+msgid "Spell Check"
+msgstr "சொல் திருத்தி"
+
+#: ../src/common/stockitem.cpp:203
+msgid "&Stop"
+msgstr "நிறுத்துக (&S)"
+
+#: ../src/common/stockitem.cpp:203
+msgid "Stop"
+msgstr "நிறுத்துக"
+
+#: ../src/common/stockitem.cpp:204 ../src/richtext/richtextfontpage.cpp:274
+msgid "&Strikethrough"
+msgstr "ஊடானக் கோடு (&S)"
+
+#: ../src/common/stockitem.cpp:204
+msgid "Strikethrough"
+msgstr "ஊடானக் கோடு"
+
+#: ../src/common/stockitem.cpp:205
+msgid "&Top"
+msgstr "மேல் (&T)"
+
+#: ../src/common/stockitem.cpp:205 ../src/richtext/richtextsizepage.cpp:285
+#: ../src/richtext/richtextsizepage.cpp:289
+msgid "Top"
+msgstr "மேல்"
+
+#: ../src/common/stockitem.cpp:206
+msgid "Undelete"
+msgstr "அழிநீக்கம்"
+
+#: ../src/common/stockitem.cpp:207 ../src/generic/fontdlgg.cpp:437
+msgid "&Underline"
+msgstr "அடிக்கோடு (&U)"
+
+#: ../src/common/stockitem.cpp:207
+msgid "Underline"
+msgstr "அடிக்கோடு"
+
+#: ../src/common/stockitem.cpp:208 ../src/stc/stc_i18n.cpp:15
+msgid "Undo"
+msgstr "செயல்நீக்கம்"
+
+#: ../src/common/stockitem.cpp:209
+msgid "&Unindent"
+msgstr "ஒழுங்கினை நீக்குக (&U)"
+
+#: ../src/common/stockitem.cpp:209
+msgid "Unindent"
+msgstr "ஒழுங்கினை நீக்குக"
+
+#: ../src/common/stockitem.cpp:210
+msgid "&Up"
+msgstr "மேல் (&U)"
+
+#: ../src/common/stockitem.cpp:210 ../src/generic/fdrepdlg.cpp:148
+msgid "Up"
+msgstr "மேல்"
+
+#: ../src/common/stockitem.cpp:211 ../src/msw/msgdlg.cpp:417
+msgid "&Yes"
+msgstr "ஆம் (&Y)"
+
+#: ../src/common/stockitem.cpp:212
+msgid "&Actual Size"
+msgstr "மெய்யளவு (&A)"
+
+#: ../src/common/stockitem.cpp:212
+msgid "Actual Size"
+msgstr "மெய்யளவு"
+
+#: ../src/common/stockitem.cpp:213
+msgid "Zoom to &Fit"
+msgstr "பொருந்துமாறு பெரிதாக்குக (&F)"
+
+#: ../src/common/stockitem.cpp:213
+msgid "Zoom to Fit"
+msgstr "பொருந்துமாறு பெரிதாக்குக"
+
+#: ../src/common/stockitem.cpp:214
+msgid "Zoom &In"
+msgstr "பெரிதாக்கம் (&I)"
+
+#: ../src/common/stockitem.cpp:215
+msgid "Zoom &Out"
+msgstr "குறை பெரிதாக்கம் (&O)"
+
+#: ../src/common/stockitem.cpp:262
+msgid "Show about dialog"
+msgstr "'குறித்து' உரையாடலைக் காட்டுக"
+
+#: ../src/common/stockitem.cpp:263
+msgid "Copy selection"
+msgstr "தெரிவினைப் படியெடுத்திடுக"
+
+#: ../src/common/stockitem.cpp:264
+msgid "Cut selection"
+msgstr "தெரிவினை வெட்டுக"
+
+#: ../src/common/stockitem.cpp:265
+msgid "Delete selection"
+msgstr "தெரிவினை அழித்திடுக"
+
+#: ../src/common/stockitem.cpp:266
+msgid "Find in document"
+msgstr "ஆவணத்தில் கண்டறிக"
+
+#: ../src/common/stockitem.cpp:267
+msgid "Find and replace in document"
+msgstr "ஆவணத்தில் கண்டறிந்து மாற்றி அமர்த்திடுக"
+
+#: ../src/common/stockitem.cpp:268
+msgid "Paste selection"
+msgstr "தெரிவினை ஒட்டுக"
+
+#: ../src/common/stockitem.cpp:269
+msgid "Quit this program"
+msgstr "இந்நிரலை விட்டு வெளியேறுக"
+
+#: ../src/common/stockitem.cpp:270
+msgid "Redo last action"
+msgstr "கடைசி செயலை மீள்செயலாக்குக"
+
+#: ../src/common/stockitem.cpp:271
+msgid "Undo last action"
+msgstr "கடைசி செயலைத் திரும்பப்பெருக "
+
+#: ../src/common/stockitem.cpp:272
+msgid "Create new document"
+msgstr "புது ஆவணத்தை உருவாக்குக"
+
+#: ../src/common/stockitem.cpp:273
+msgid "Open an existing document"
+msgstr "இருக்கும் ஆவணத்தைத் திறவுக"
+
+#: ../src/common/stockitem.cpp:274
+msgid "Close current document"
+msgstr "தற்போதைய ஆவணத்தை மூடுக"
+
+#: ../src/common/stockitem.cpp:275
+msgid "Save current document"
+msgstr "தற்போதைய ஆவணத்தை சேமித்திடுக"
+
+#: ../src/common/stockitem.cpp:276
+msgid "Save current document with a different filename"
+msgstr "தற்போதைய ஆவணத்தை மாற்றுப் பெயர் கொண்டு சேமித்திடுக"
+
+#: ../src/common/strconv.cpp:2324
+#, c-format
+msgid "Conversion to charset '%s' doesn't work."
+msgstr "Charset '%s'-க்கான மாற்றம் செயல்படுவதில்லை."
+
+#: ../src/common/tarstrm.cpp:352 ../src/common/tarstrm.cpp:375
+#: ../src/common/tarstrm.cpp:406 ../src/generic/progdlgg.cpp:373
+msgid "unknown"
+msgstr "அறியப்படாதது"
+
+#: ../src/common/tarstrm.cpp:774
+msgid "incomplete header block in tar"
+msgstr "tar-ல் முழுமையடையாத மேலுரைத் தொகுதி"
+
+#: ../src/common/tarstrm.cpp:798
+msgid "checksum failure reading tar header block"
+msgstr "tar மேலுரை தொகுதியை படிப்பதில் checksum தோல்வி"
+
+#: ../src/common/tarstrm.cpp:971
+msgid "invalid data in extended tar header"
+msgstr "நீட்டிக்கப்பட்ட tar மேலுரையில் ஏற்கமுடியாத தரவு"
+
+#: ../src/common/tarstrm.cpp:981 ../src/common/tarstrm.cpp:1003
+#: ../src/common/tarstrm.cpp:1477 ../src/common/tarstrm.cpp:1499
+msgid "tar entry not open"
+msgstr "tar உள்ளிடு திறந்த நிலையில் இல்லை"
+
+#: ../src/common/tarstrm.cpp:1023
+msgid "unexpected end of file"
+msgstr "எதிர்பாராத கோப்பு முடிவு"
+
+#: ../src/common/tarstrm.cpp:1297
+#, c-format
+msgid "%s did not fit the tar header for entry '%s'"
+msgstr "'%s' உள்ளீட்டின் tar மேலுரைக்குள் பொருந்தவில்லை. உள்ளீடு %s"
+
+#: ../src/common/tarstrm.cpp:1359
+msgid "incorrect size given for tar entry"
+msgstr "tar உள்ளீட்டிற்கு தவறான அளவு கொடுக்கப்பட்டுள்ளது"
+
+#: ../src/common/textbuf.cpp:232
+#, c-format
+msgid "'%s' is probably a binary buffer."
+msgstr "%s ஒரு இருமக்கூறு இடையகமாக இருக்கலாம்."
+
+#: ../src/common/textcmn.cpp:1006 ../src/richtext/richtextctrl.cpp:3053
+msgid "File couldn't be loaded."
+msgstr "கோப்பு ஏற்றப்பட இயலவில்லை."
+
+#: ../src/common/textfile.cpp:95
+#, c-format
+msgid "Failed to read text file \"%s\"."
+msgstr "\"%s\" உரைக் கோப்பினைப் படிப்பதில் தோல்வி."
+
+#: ../src/common/textfile.cpp:160
+#, c-format
+msgid "can't write buffer '%s' to disk."
+msgstr "வட்டில் '%s' இடையகத்தை எழுத இயலாது."
+
+#: ../src/common/time.cpp:212
+msgid "Failed to get the local system time"
+msgstr "அகக்கணினி நேரத்தைப் பெறுவதில் தோல்வி"
+
+#: ../src/common/time.cpp:279
+msgid "wxGetTimeOfDay failed."
+msgstr "wxGetTimeOfDay தோல்வியடைந்தது."
+
+#: ../src/common/translation.cpp:929
+#, c-format
+msgid "'%s' is not a valid message catalog."
+msgstr "'%s' செல்லத்தக்க தகவல் பட்டியல் அல்ல"
+
+#: ../src/common/translation.cpp:954
+msgid "Invalid message catalog."
+msgstr "செல்லாத தகவல் பட்டியல்."
+
+#: ../src/common/translation.cpp:1013
+#, c-format
+msgid "Failed to parse Plural-Forms: '%s'"
+msgstr "பன்மை வடிவங்களை பகுப்பாய்வதில் தோல்வி: '%s'"
+
+#: ../src/common/translation.cpp:1723
+#, c-format
+msgid "using catalog '%s' from '%s'."
+msgstr "'%s' பட்டியல், '%s'-இடமிருந்துப் பயன்படுத்தப்படுகிறது."
+
+#: ../src/common/translation.cpp:1816
+#, c-format
+msgid "Resource '%s' is not a valid message catalog."
+msgstr "'%s' வளம் ஏற்கக்கூடிய தகவல் பட்டியல் அல்ல."
+
+#: ../src/common/translation.cpp:1865
+msgid "Couldn't enumerate translations"
+msgstr "மொழிபெயர்ப்புகளை பட்டியலிட இயலவில்லை"
+
+#: ../src/common/utilscmn.cpp:1145
+msgid "No default application configured for HTML files."
+msgstr "HTML கோப்புகளுக்கு இயல்பிருப்புப் பயன்பாடு அமைவடிவமாக்கப்படவில்லை."
+
+#: ../src/common/utilscmn.cpp:1190
+#, c-format
+msgid "Failed to open URL \"%s\" in default browser."
+msgstr "\"%s\" இணைய முகவரியை இயல்பிருப்பு உலாவியில் திறப்பதில் தோல்வி."
+
+#: ../src/common/valtext.cpp:144
+msgid "Validation conflict"
+msgstr "சரிபார்ப்பு முரண்பாடு"
+
+#: ../src/common/valtext.cpp:186
+msgid "Required information entry is empty."
+msgstr "தேவைப்படும் உள்ளீட்டுத் தகவல் வெறுமையாக உள்ளது."
+
+#: ../src/common/valtext.cpp:188
+#, c-format
+msgid "'%s' is one of the invalid strings"
+msgstr "செல்லாத சரங்களில் ஒன்றாக '%s' உள்ளது"
+
+#: ../src/common/valtext.cpp:190
+#, c-format
+msgid "'%s' is not one of the valid strings"
+msgstr "செல்லும் சரங்களில் ஒன்றாக '%s' இல்லை"
+
+#: ../src/common/valtext.cpp:199
+#, c-format
+msgid "'%s' contains invalid character(s)"
+msgstr "'%s' செல்லாத வரியுருக்களைக் கொண்டுள்ளது"
+
+#: ../src/common/webrequest.cpp:139
+#, c-format
+msgid "Error: %s (%d)"
+msgstr "பிழை: %s (%d)"
+
+#: ../src/common/webrequest.cpp:655
+#, c-format
+msgid ""
+"Not enough free disk space for download: %llu needed but only %llu available."
+msgstr ""
+"தரவிறக்குவதற்கு வட்டில் போதிய இடமில்லை.: %llu தேவைப்படுகிறது. ஆனால், %llu மட்டுமே "
+"கிடைப்பிலுள்ளது."
+
+#: ../src/common/webrequest.cpp:669
+#, c-format
+msgid "Failed to create temporary file in %s"
+msgstr "%sல் தற்காலிகக் கோப்பை உருவாக்குவதில் தோல்வி"
+
+#: ../src/common/webrequest_curl.cpp:1106
+msgid "libcurl could not be initialized"
+msgstr "Libcurl-ஐ தொடக்கநிலையாக்க இயலவில்லை"
+
+#: ../src/common/webview.cpp:392
+msgid "RunScriptAsync not supported"
+msgstr "RunScriptAsync ஆதரிக்கப்படவில்லை"
+
+#: ../src/common/webview.cpp:403 ../src/msw/webview_ie.cpp:1073
+#, c-format
+msgid "Error running JavaScript: %s"
+msgstr "JavaScript இயக்கப் பிழை: %s"
+
+#: ../src/common/webview_chromium.cpp:858
+#, c-format
+msgid "Failed to set proxy \"%s\": %s"
+msgstr "\"%s\" பகரணியை அமைப்பதில் தோல்வி: %s"
+
+#: ../src/common/webview_chromium.cpp:989
+msgid ""
+"Chromium can't be used because libcef.so wasn't loaded early enough; please "
+"relink the application or use LD_PRELOAD to load it earlier."
+msgstr ""
+"libcef.so போதுமான அளவு விரைந்து ஏற்றப்படவில்லை என்பதால் குரோமியத்தைப் பயன்படுத்த "
+"இயலாது. பயன்பாட்டை மீளிணைக்கவும், அல்லது அதை விரைந்து ஏற்ற LD_PRELOAD-ஐப் "
+"பயன்படுத்தவும். "
+
+#: ../src/common/webview_chromium.cpp:1108
+msgid "Could not initialize Chromium"
+msgstr "குரோமியத்தைத் தொடக்கநிலையாக்க இயலவில்லை."
+
+#: ../src/common/webview_chromium.cpp:1616
+msgid "Show DevTools"
+msgstr "மேம்படுத்துநர் கருவிகளைக் காட்டிடுக"
+
+#: ../src/common/webview_chromium.cpp:1617
+msgid "Close DevTools"
+msgstr "மேம்படுத்துநர் கருவிகளை மூடுக"
+
+#: ../src/common/webview_chromium.cpp:1623
+msgid "Inspect"
+msgstr "ஆய்ந்திடுக"
+
+#: ../src/common/wincmn.cpp:1628
+msgid "This platform does not support background transparency."
+msgstr "இத்தளம் பின்புல ஒளிபுகுதலை ஆதரிப்பதில்லை."
+
+#: ../src/common/wincmn.cpp:2097
+msgid "Could not transfer data to window"
+msgstr "சாளரத்திற்கு தரவினை மாற்ற இயலவில்லை."
+
+#: ../src/common/windowid.cpp:240
+msgid "Out of window IDs.  Recommend shutting down application."
+msgstr "சாளர அடையாளங்கள் ஏதும் எஞ்சவில்லை. பயன்பாட்டை நிறுத்த பரிந்துரைக்கப்படுகிறது. "
+
+#: ../src/common/xpmdecod.cpp:678
+msgid "XPM: incorrect header format!"
+msgstr "XPM: தவறான தலைப்புரை வடிவூட்டம்!"
+
+#: ../src/common/xpmdecod.cpp:703
+#, c-format
+msgid "XPM: incorrect colour description in line %d"
+msgstr "XPM: %d வரியில் தவறான நிற விளக்கம்"
+
+#: ../src/common/xpmdecod.cpp:715 ../src/common/xpmdecod.cpp:724
+#, c-format
+msgid "XPM: malformed colour definition '%s' at line %d!"
+msgstr "XPM: உருசிதைந்த நிற வரையறை '%s', %d வரியில்!"
+
+#: ../src/common/xpmdecod.cpp:754
+msgid "XPM: no colors left to use for mask!"
+msgstr "XPM: மறைப்புக்குப் பயன்படுத்த நிறம் ஏதும் எஞ்சவில்லை!"
+
+#: ../src/common/xpmdecod.cpp:781
+#, c-format
+msgid "XPM: truncated image data at line %d!"
+msgstr "XPM: %d வரியில் அறுபட்ட படிமத் தரவு!"
+
+#: ../src/common/xpmdecod.cpp:795
+msgid "XPM: Malformed pixel data!"
+msgstr "XPM: உருசிதைந்த படவணுத் தரவு!"
+
+#: ../src/common/xti.cpp:492
+msgid "Illegal Parameter Count for Create Method"
+msgstr "உருவாக்கு முறைக்கு செல்லாத அளவுரு எண்ணிக்கை"
+
+#: ../src/common/xti.cpp:504
+msgid "Illegal Parameter Count for ConstructObject Method"
+msgstr "பொருள் கட்டு முறைக்கு செல்லாத அளவுரு எண்ணிக்கை"
+
+#: ../src/common/xtistrm.cpp:161
+#, c-format
+msgid "Create Parameter %s not found in declared RTTI Parameters"
+msgstr "அறிவிக்கப்பட்ட RTTI அளவுருக்களில் உருவாக்கு அளவுரு %s கண்டறியப்படவில்லை"
+
+#: ../src/common/xtistrm.cpp:290
+msgid "Illegal Object Class (Non-wxEvtHandler) as Event Source"
+msgstr "செல்லாத பொருள் வகுப்பு (Non-wxEvtHandler) நிகழ்வு மூலமாக உள்ளது"
+
+#: ../src/common/xtistrm.cpp:313 ../src/common/xtixml.cpp:345
+#: ../src/common/xtixml.cpp:498
+msgid "Type must have enum - long conversion"
+msgstr "வகை enum - long மாற்றத்தைக் கொண்டிருக்க வேண்டும். "
+
+#: ../src/common/xtistrm.cpp:400 ../src/common/xtistrm.cpp:415
+msgid "Invalid or Null Object ID passed to GetObjectClassInfo"
+msgstr "செல்லாத அல்லது இல்லாத பொருள் GetObjectClassInfo-விடம் அநுப்பப்பட்டது"
+
+#: ../src/common/xtistrm.cpp:405
+msgid "Unknown Object passed to GetObjectClassInfo"
+msgstr "அறியப்படாத பொருள் GetObjectClassInfo-விடம் அனுப்பி வைக்கப்பட்டது"
+
+#: ../src/common/xtistrm.cpp:420
+msgid "Already Registered Object passed to SetObjectClassInfo"
+msgstr "ஏற்கனவே பதிவு செய்யப்பட்ட பொருள், SetObjectClassInfo-க்கு அனுப்பப்பட்டது."
+
+#: ../src/common/xtistrm.cpp:430
+msgid "Invalid or Null Object ID passed to HasObjectClassInfo"
+msgstr "செல்லாத அல்லது இல்லாத பொருள் அடையாளம் HasObjectClassInfo-விடம் அனுப்பப்பட்டது"
+
+#: ../src/common/xtistrm.cpp:460
+msgid "Passing a already registered object to SetObject"
+msgstr "ஏற்கனவே பதிவு செய்யப்பட்ட பொருளை SetObject-ற்கு அனுப்பி வைத்தல்"
+
+#: ../src/common/xtistrm.cpp:471
+msgid "Passing an unknown object to GetObject"
+msgstr "அறியப்படாத பொருளை GetObject-ற்கு அனுப்பி வைத்தல்"
+
+#: ../src/common/xtixml.cpp:229
+msgid "Forward hrefs are not supported"
+msgstr "மீளனுப்புதல் hrefs ஆதரிக்கப்படுவதில்லை"
+
+#: ../src/common/xtixml.cpp:247
+#, c-format
+msgid "unknown class %s"
+msgstr "அறியப்படாத வகுப்பு %s"
+
+#: ../src/common/xtixml.cpp:253
+msgid "objects cannot have XML Text Nodes"
+msgstr "xml உரைக் கணுக்களை பொருட்கள் கொண்டிருக்க இயலாது"
+
+#: ../src/common/xtixml.cpp:258
+msgid "Objects must have an id attribute"
+msgstr "அடையாளப் பண்புகளை பொருட்கள் கொண்டிருக்க வேண்டும்"
+
+#: ../src/common/xtixml.cpp:267
+#, c-format
+msgid "Doubly used id : %d"
+msgstr "இருமுறை பயன்படுத்தப்பட்டுள்ள அடையாளம்: %d"
+
+#: ../src/common/xtixml.cpp:316
+#, c-format
+msgid "Unknown Property %s"
+msgstr "அறியப்படாத பண்பு %s"
+
+#: ../src/common/xtixml.cpp:407
+msgid "A non empty collection must consist of 'element' nodes"
+msgstr "ஒரு வெறுமையற்ற திரட்டு, கூறுகளின் கணுக்களைக் கொண்டிருக்க வேண்டும்"
+
+#: ../src/common/xtixml.cpp:478
+msgid "incorrect event handler string, missing dot"
+msgstr "தவறான நிகழ்வுக் கையாளுச் சரம், தவறவிடப்பட்டுள்ள புள்ளி"
+
+#: ../src/common/zipstrm.cpp:559
+msgid "can't re-initialize zlib deflate stream"
+msgstr "zlib அமிழோடையை மீள்தொடக்க நிலையாக்க இயலாது"
+
+#: ../src/common/zipstrm.cpp:584
+msgid "can't re-initialize zlib inflate stream"
+msgstr "zlib விரியோடையை மீள்தொடக்க நிலையாக்க இயலாது"
+
+#: ../src/common/zipstrm.cpp:1023
+msgid "Ignoring malformed extra data record, ZIP file may be corrupted"
+msgstr ""
+"உருசிதைந்த கூடுதல் தரவுத் திரட்டினை புறந்தள்ளுகிறது. ZIP கோப்பு பழுதடைந்திருக்கலாம்."
+
+#: ../src/common/zipstrm.cpp:1502
+msgid "assuming this is a multi-part zip concatenated"
+msgstr "இது பல பகுதிகள் ஒன்றிணைக்கப்பட்ட ஜிப் என்று அனுமானிக்கப்படுகிறது "
+
+#: ../src/common/zipstrm.cpp:1664
+msgid "invalid zip file"
+msgstr "செல்லாத ஜிப் கோப்பு"
+
+#: ../src/common/zipstrm.cpp:1723
+msgid "can't find central directory in zip"
+msgstr "zip-ல் மைய அடைவினை காண இயலவில்லை"
+
+#: ../src/common/zipstrm.cpp:1812
+msgid "error reading zip central directory"
+msgstr "ஜிப் மைய அடைவினைப் படிப்பதில் பிழை"
+
+#: ../src/common/zipstrm.cpp:1916
+msgid "error reading zip local header"
+msgstr "ஜிப் அகத்தலைப்புரையைப் படிப்பதில் பிழை"
+
+#: ../src/common/zipstrm.cpp:1964
+msgid "bad zipfile offset to entry"
+msgstr "உள்ளீட்டிற்கான ஜிப் கோப்பின் இடைமாற்றுச் சீர்ப் பிழை"
+
+#: ../src/common/zipstrm.cpp:2031
+msgid "stored file length not in Zip header"
+msgstr "சேமிக்கப்பட்ட கோப்பின் நீளம் ஜிப் தலைப்புரையில் இல்லை"
+
+#: ../src/common/zipstrm.cpp:2045 ../src/common/zipstrm.cpp:2362
+msgid "unsupported Zip compression method"
+msgstr "ஆதரிக்கப்படாத ஜிப் சுருக்கு வழிமுறை"
+
+#: ../src/common/zipstrm.cpp:2126
+#, c-format
+msgid "reading zip stream (entry %s): bad length"
+msgstr "ஜிப் ஓடை படிக்கப்படுகிறது (உள்ளிடு %s): பிழையான நீளம்"
+
+#: ../src/common/zipstrm.cpp:2131
+#, c-format
+msgid "reading zip stream (entry %s): bad crc"
+msgstr "ஜிப் ஓடை படிக்கப்படுகிறது (உள்ளிடு %s): பிழையான crc"
+
+#: ../src/common/zipstrm.cpp:2578
+#, c-format
+msgid "error writing zip entry '%s': file too large without ZIP64"
+msgstr "'%s' ஜிப் உள்ளீட்டை எழுதுவதில் பிழை: ZIP64 இல்லாத மிகப் பெரிய கோப்பு."
+
+#: ../src/common/zipstrm.cpp:2585
+#, c-format
+msgid "error writing zip entry '%s': bad crc or length"
+msgstr "'%s' ஜிப் உள்ளீட்டை எழுதுவதில் பிழை: பிழையான crc அல்லது நீளம்"
+
+#: ../src/common/zstream.cpp:155 ../src/common/zstream.cpp:315
+msgid "Gzip not supported by this version of zlib"
+msgstr "Gzip இந்த பதிப்பு Zlib-னால் ஆதரிக்கப்படுவதில்லை"
+
+#: ../src/common/zstream.cpp:182
+msgid "Can't initialize zlib inflate stream."
+msgstr "zlib விரியோடையை தொடக்க நிலையாக்க இயலாது"
+
+#: ../src/common/zstream.cpp:241
+msgid "Can't read inflate stream: unexpected EOF in underlying stream."
+msgstr "விரியோடையைப் படிக்க இயலவில்லை: அடிநிலை ஓடையில் எதிர்பாராத கோப்பு முடிவு."
+
+#: ../src/common/zstream.cpp:248 ../src/common/zstream.cpp:423
+#, c-format
+msgid "zlib error %d"
+msgstr "zlib பிழை %d"
+
+#: ../src/common/zstream.cpp:249
+#, c-format
+msgid "Can't read from inflate stream: %s"
+msgstr "விரியோடையிலிருந்து படிக்க இயலவில்லை: %s"
+
+#: ../src/common/zstream.cpp:343
+msgid "Can't initialize zlib deflate stream."
+msgstr "zlib அமிழோடையை தொடக்க நிலையாக்க இயலவில்லை"
+
+#: ../src/common/zstream.cpp:424
+#, c-format
+msgid "Can't write to deflate stream: %s"
+msgstr "அமிழோடையில் எழுத இயலவில்லை: %s"
+
+#: ../src/dfb/bitmap.cpp:633 ../src/dfb/bitmap.cpp:667
+#, c-format
+msgid "No bitmap handler for type %d defined."
+msgstr "%d வகைக்கான நுண்பட கையாளு நிரல் வரையறுக்கப்படவில்லை."
+
+#: ../src/dfb/evtloop.cpp:99
+msgid "Failed to read event from DirectFB pipe"
+msgstr "நேரடி FB குழாயிலிருந்து நிகழ்வைப் படிப்பதில் தோல்வி"
+
+#: ../src/dfb/evtloop.cpp:171
+msgid "Failed to switch DirectFB pipe to non-blocking mode"
+msgstr "நேரடி FB குழாயினை அடைப்பில்லா நிலைக்கு மாற்றுவதில் தோல்வி"
+
+#: ../src/dfb/fontmgr.cpp:171
+#, c-format
+msgid "no fonts found in %s, using builtin font"
+msgstr "%s-ல் எழுத்துரு ஏதும் காணப்படவில்லை, உள்ளமைந்த எழுத்துரு பயன்படுத்தப்படுகிறது"
+
+#: ../src/dfb/fontmgr.cpp:177
+msgid "Default font"
+msgstr "இயல்பெழுத்துரு"
+
+#: ../src/dfb/fontmgr.cpp:195
+#, c-format
+msgid "Fonts index file %s disappeared while loading fonts."
+msgstr "எழுத்துருகளை ஏற்றும்பொழுது %s எழுத்துரு சுட்டெண் கோப்பு மறைந்துவிட்டது."
+
+#: ../src/dfb/wrapdfb.cpp:60
+#, c-format
+msgid "DirectFB error %d occurred."
+msgstr "%d நேரடி FB பிழை ஏற்பட்டுள்ளது."
+
+#: ../src/generic/aboutdlgg.cpp:69
+msgid "Developed by "
+msgstr "மேம்படுத்துநர் "
+
+#: ../src/generic/aboutdlgg.cpp:72
+msgid "Documentation by "
+msgstr "ஆவணமாக்குநர் "
+
+#: ../src/generic/aboutdlgg.cpp:75
+msgid "Graphics art by "
+msgstr "வரைகலை ஓவியர் "
+
+#: ../src/generic/aboutdlgg.cpp:78
+msgid "Translations by "
+msgstr "மொழிபெயர்ப்பாளர் "
+
+#: ../src/generic/aboutdlgg.cpp:133 ../src/osx/cocoa/aboutdlg.mm:83
+msgid "Version "
+msgstr "பதிப்பு "
+
+#. TRANSLATORS: %s is application name
+#: ../src/generic/aboutdlgg.cpp:146 ../src/msw/aboutdlg.cpp:60
+#, c-format
+msgid "About %s"
+msgstr "%s குறித்து"
+
+#: ../src/generic/aboutdlgg.cpp:181
+msgid "License"
+msgstr "உரிமம்"
+
+#: ../src/generic/aboutdlgg.cpp:184
+msgid "Developers"
+msgstr "மேம்படுத்துநர்கள்"
+
+#: ../src/generic/aboutdlgg.cpp:188
+msgid "Documentation writers"
+msgstr "ஆவணமாக்குநர்கள்"
+
+#: ../src/generic/aboutdlgg.cpp:192
+msgid "Artists"
+msgstr "கலைஞர்கள்"
+
+#: ../src/generic/aboutdlgg.cpp:196
+msgid "Translators"
+msgstr "மொழிபெயர்ப்பாளர்கள்"
+
+#: ../src/generic/animateg.cpp:125
+msgid "No handler found for animation type."
+msgstr "அசைவூட்ட வகைக்கான கையாளு நிரல் காணப்படவில்லை."
+
+#: ../src/generic/animateg.cpp:133
+#, c-format
+msgid "No animation handler for type %ld defined."
+msgstr "%ld வகைக்கான அசைவூட்ட கையாளு நிரல் வரையறுக்கப்படவில்லை."
+
+#: ../src/generic/animateg.cpp:145
+#, c-format
+msgid "Animation file is not of type %ld."
+msgstr "அசைவூட்டக் கோப்பு %ld வகையில் இல்லை."
+
+#: ../src/generic/colrdlgg.cpp:154 ../src/gtk/colordlg.cpp:47
+msgid "Choose colour"
+msgstr "நிறத்தைத் தேர்ந்தெடுத்திடுக"
+
+#: ../src/generic/colrdlgg.cpp:357
+msgid "Red:"
+msgstr "சிவப்பு:"
+
+#: ../src/generic/colrdlgg.cpp:360
+msgid "Green:"
+msgstr "பச்சை:"
+
+#: ../src/generic/colrdlgg.cpp:363
+msgid "Blue:"
+msgstr "நீலம்:"
+
+#: ../src/generic/colrdlgg.cpp:372
+msgid "Opacity:"
+msgstr "ஒளிபுகாமை"
+
+#: ../src/generic/colrdlgg.cpp:384
+msgid "Add to custom colours"
+msgstr "தனிப்பயனாக்கப்பட்ட நிறங்களுடன் சேர்த்திடுக"
+
+#: ../src/generic/creddlgg.cpp:56
+msgid "Username:"
+msgstr "பயனர் பெயர்:"
+
+#: ../src/generic/creddlgg.cpp:63
+msgid "Password:"
+msgstr "கடவுச்சொல்:"
+
+#. TRANSLATORS: Name of Boolean true value
+#: ../src/generic/datavgen.cpp:1178
+msgid "true"
+msgstr "மெய்"
+
+#. TRANSLATORS: Name of Boolean false value
+#: ../src/generic/datavgen.cpp:1180
+msgid "false"
+msgstr "பொய்"
+
+#: ../src/generic/datavgen.cpp:6897
+#, c-format
+msgid "Row %i"
+msgstr "கிடைவரிசை %i"
+
+#. TRANSLATORS: Action for manipulating a tree control
+#: ../src/generic/datavgen.cpp:6987
+msgid "Collapse"
+msgstr "குறுக்குக"
+
+#. TRANSLATORS: Action for manipulating a tree control
+#: ../src/generic/datavgen.cpp:6990
+msgid "Expand"
+msgstr "விரிவாக்குக"
+
+#. TRANSLATORS: Name of data view control and number of rows
+#: ../src/generic/datavgen.cpp:7011
+#, c-format
+msgid "%s (%d items)"
+msgstr "%s (%d உருப்படிகள்)"
+
+#: ../src/generic/datavgen.cpp:7062
+#, c-format
+msgid "Column %u"
+msgstr "நெடுவரிசை %u"
+
+#. TRANSLATORS: Keystroke for manipulating a tree control
+#: ../src/generic/datavgen.cpp:7131
+#: ../src/richtext/richtextbulletspage.cpp:189
+#: ../src/richtext/richtextbulletspage.cpp:192
+#: ../src/richtext/richtextbulletspage.cpp:193
+#: ../src/richtext/richtextliststylepage.cpp:252
+#: ../src/richtext/richtextliststylepage.cpp:255
+#: ../src/richtext/richtextliststylepage.cpp:256
+#: ../src/richtext/richtextsizepage.cpp:248
+msgid "Left"
+msgstr "இடது"
+
+#. TRANSLATORS: Keystroke for manipulating a tree control
+#: ../src/generic/datavgen.cpp:7134
+#: ../src/richtext/richtextbulletspage.cpp:191
+#: ../src/richtext/richtextliststylepage.cpp:254
+#: ../src/richtext/richtextsizepage.cpp:249
+msgid "Right"
+msgstr "வலது"
+
+#: ../src/generic/datectlg.cpp:90
+#, c-format
+msgid ""
+"\"%s\" is not in the expected date format, please enter it as e.g. \"%s\"."
+msgstr "எதிர்பார்க்கப்படும் தேதி வடிவத்தில் \"%s\" இல்லை. எ.கா. \"%s\" என்று உள்ளிடவும்."
+
+#: ../src/generic/datectlg.cpp:94
+msgid "Invalid date"
+msgstr "செல்லாத தேதி"
+
+#: ../src/generic/dbgrptg.cpp:159
+#, c-format
+msgid "Open file \"%s\""
+msgstr "\"%s\" கோப்பினைத் திறவுக"
+
+#: ../src/generic/dbgrptg.cpp:170
+#, c-format
+msgid "Enter command to open file \"%s\":"
+msgstr "\"%s\" கோப்பினைத் திறக்க கட்டளையை உள்ளிடுக"
+
+#: ../src/generic/dbgrptg.cpp:230
+msgid "Executable files (*.exe)|*.exe|"
+msgstr "செயற்படு கோப்புகள் (*.exe)|*.exe|"
+
+#: ../src/generic/dbgrptg.cpp:300
+#, c-format
+msgid "Debug report \"%s\""
+msgstr "வழுநீக்க அறிக்கை \"%s\""
+
+#: ../src/generic/dbgrptg.cpp:316
+msgid "A debug report has been generated in the directory\n"
+msgstr "அடைவில் ஒரு வழுநீக்க அறிக்கை உருவாக்கப்பட்டுள்ளது\n"
+
+#: ../src/generic/dbgrptg.cpp:317
+msgid "The following debug report will be generated\n"
+msgstr "பின்வரும் வழுநீக்க அறிக்கை உருவாக்கப்படும்\n"
+
+#: ../src/generic/dbgrptg.cpp:321
+msgid ""
+"The report contains the files listed below. If any of these files contain "
+"private information,\n"
+"please uncheck them and they will be removed from the report.\n"
+msgstr ""
+"கீழே பட்டியலிடப்பட்டுள்ள கோப்புகளை அறிக்கை கொண்டுள்ளது. இந்தக் கோப்புகளில் தனிப்பட்டத் தகவல் "
+"ஏதேனும் இருந்தால்,\n"
+"அவைகள் அறிக்கையிலிருந்து நீக்கப்பட, தனிப்பட்டத் தகவல்களை தேர்வு நீக்கம் செய்யவும்.\n"
+
+#: ../src/generic/dbgrptg.cpp:323
+msgid ""
+"If you wish to suppress this debug report completely, please choose the "
+"\"Cancel\" button,\n"
+"but be warned that it may hinder improving the program, so if\n"
+"at all possible please do continue with the report generation.\n"
+msgstr ""
+"இந்த வழுநீக்க அறிக்கையை முழுமையாக மறைக்க தாங்கள் விரும்வினால், \"விலக்குக\" பொத்தானை "
+"அழுத்தவும்,\n"
+"ஆனால், இது நிரலை மேம்படுத்துவதில் இடைஞ்சலை ஏற்படுத்தும் என்று எச்சரிக்கப்படுகிறீர்கள். "
+"ஆகவே\n"
+"இயன்ற மட்டில், வழுநீக்க அறிக்கையை உருவாக்க முயலுங்கள்.\n"
+
+#: ../src/generic/dbgrptg.cpp:325
+msgid "              Thank you and we're sorry for the inconvenience!\n"
+msgstr "நன்றி. தங்களுக்கு ஏற்பட்டுள்ள இடையூறுக்கு வருந்துகிறோம்! \n"
+
+#: ../src/generic/dbgrptg.cpp:333
+msgid "&Debug report preview:"
+msgstr "வழுநீக்க அரிக்கை முன்தோற்றம் (&D)"
+
+#: ../src/generic/dbgrptg.cpp:339
+msgid "&View..."
+msgstr "தோற்றம்... (&V)"
+
+#: ../src/generic/dbgrptg.cpp:359
+msgid "&Notes:"
+msgstr "குறிப்புகள் (&N)"
+
+#: ../src/generic/dbgrptg.cpp:361
+msgid ""
+"If you have any additional information pertaining to this bug\n"
+"report, please enter it here and it will be joined to it:"
+msgstr ""
+"வழு அறிக்கை குறித்த கூடுதல் தகவல் ஏதேனும் இருந்தால், அதை இங்கே உள்ளீடுச் செய்யவும். அது "
+"இதனுடன் இணைக்கப்படும்."
+
+#: ../src/generic/dcpsg.cpp:1627
+msgid "Cannot open file for PostScript printing!"
+msgstr "Postscript அச்சிடுதலுக்கு கோப்பினை திறக்க இயலவில்லை!"
+
+#: ../src/generic/dirctrlg.cpp:402
+msgid "Computer"
+msgstr "கணினி"
+
+#: ../src/generic/dirctrlg.cpp:404
+msgid "Sections"
+msgstr "உட்பிரிவுகள்"
+
+#: ../src/generic/dirctrlg.cpp:482
+msgid "Home directory"
+msgstr "முகப்படைவு"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/generic/dirctrlg.cpp:484 ../src/propgrid/advprops.cpp:811
+msgid "Desktop"
+msgstr "மேசைத்தளம்"
+
+#: ../src/generic/dirctrlg.cpp:528 ../src/generic/filectrlg.cpp:752
+msgid "Illegal directory name."
+msgstr "செல்லாத அடைவுப் பெயர்."
+
+#: ../src/generic/dirctrlg.cpp:528 ../src/generic/dirctrlg.cpp:546
+#: ../src/generic/dirctrlg.cpp:557 ../src/generic/dirdlgg.cpp:317
+#: ../src/generic/filectrlg.cpp:638 ../src/generic/filectrlg.cpp:752
+#: ../src/generic/filectrlg.cpp:766 ../src/generic/filectrlg.cpp:782
+#: ../src/generic/filectrlg.cpp:1356 ../src/generic/filectrlg.cpp:1387
+#: ../src/generic/filedlgg.cpp:362 ../src/gtk/filedlg.cpp:76
+msgid "Error"
+msgstr "பிழை"
+
+#: ../src/generic/dirctrlg.cpp:546 ../src/generic/filectrlg.cpp:766
+msgid "File name exists already."
+msgstr "கோப்புப் பெயர் ஏற்கனவே உள்ளது."
+
+#: ../src/generic/dirctrlg.cpp:557 ../src/generic/dirdlgg.cpp:317
+#: ../src/generic/filectrlg.cpp:638 ../src/generic/filectrlg.cpp:782
+msgid "Operation not permitted."
+msgstr "செயலுக்கு அனுமதியில்லை"
+
+#: ../src/generic/dirdlgg.cpp:107 ../src/generic/filedlgg.cpp:207
+msgid "Create new directory"
+msgstr "புதிய அடைவினை உருவாக்குக"
+
+#: ../src/generic/dirdlgg.cpp:112 ../src/generic/filedlgg.cpp:203
+msgid "Go to home directory"
+msgstr "முகப்படைவிற்குச் செல்க"
+
+#: ../src/generic/dirdlgg.cpp:143
+msgid "Show &hidden directories"
+msgstr "மறைந்துள்ள அடைவுகளைக் காட்டுக (&H)"
+
+#: ../src/generic/dirdlgg.cpp:196
+#, c-format
+msgid ""
+"The directory '%s' does not exist\n"
+"Create it now?"
+msgstr ""
+"'%s' அடைவு கிடைப்பில் இல்லை\n"
+"இப்பொழுது அதை உருவாக்க வேண்டுமா?"
+
+#: ../src/generic/dirdlgg.cpp:198
+msgid "Directory does not exist"
+msgstr "அடைவு இல்லை"
+
+#: ../src/generic/dirdlgg.cpp:214
+#, c-format
+msgid ""
+"Failed to create directory '%s'\n"
+"(Do you have the required permissions?)"
+msgstr ""
+"\"%s\" அடைவினை உருவாக்குவதில் தோல்வி\n"
+"(தேவையான அனுமதி தங்களிடம் உள்ளதா?)"
+
+#: ../src/generic/dirdlgg.cpp:216
+msgid "Error creating directory"
+msgstr "அடைவினை உருவாக்குவதில் பிழை"
+
+#: ../src/generic/dirdlgg.cpp:281
+msgid "You cannot add a new directory to this section."
+msgstr "இப்பிரிவிற்கு புதிய அடைவினை சேர்க்க இயலாது."
+
+#: ../src/generic/dirdlgg.cpp:282
+msgid "Create directory"
+msgstr "அடைவினை உருவாக்குக"
+
+#: ../src/generic/dirdlgg.cpp:291 ../src/generic/dirdlgg.cpp:301
+#: ../src/generic/filectrlg.cpp:614 ../src/generic/filectrlg.cpp:623
+msgid "NewName"
+msgstr "புதுப் பெயர்"
+
+#: ../src/generic/editlbox.cpp:135
+msgid "Edit item"
+msgstr "உருப்படியை தொகுத்திடுக"
+
+#: ../src/generic/editlbox.cpp:143
+msgid "New item"
+msgstr "புது உருப்படி"
+
+#: ../src/generic/editlbox.cpp:151
+msgid "Delete item"
+msgstr "உருப்படியை அழித்திடுக"
+
+#: ../src/generic/editlbox.cpp:159
+msgid "Move up"
+msgstr "மேல் நகர்க"
+
+#: ../src/generic/editlbox.cpp:164
+msgid "Move down"
+msgstr "கீழ் நகர்க"
+
+#: ../src/generic/fdrepdlg.cpp:108
+msgid "Search for:"
+msgstr "இதனைத் தேடுக:"
+
+#: ../src/generic/fdrepdlg.cpp:120
+msgid "Replace with:"
+msgstr "இதனைக்கொண்டு மாற்றுக:"
+
+#: ../src/generic/fdrepdlg.cpp:140
+msgid "Whole word"
+msgstr "முழுச் சொல்"
+
+#: ../src/generic/fdrepdlg.cpp:143
+msgid "Match case"
+msgstr "எழுத்து வகைப் பொருத்தம்"
+
+#: ../src/generic/fdrepdlg.cpp:156
+msgid "Search direction"
+msgstr "தேடு திசை"
+
+#: ../src/generic/fdrepdlg.cpp:175
+msgid "&Replace"
+msgstr "மாற்று (&R)"
+
+#: ../src/generic/fdrepdlg.cpp:178
+msgid "Replace &all"
+msgstr "அனைத்தையும் மாற்றுக (&A)"
+
+#: ../src/generic/filectrlg.cpp:246 ../src/generic/filectrlg.cpp:269
+msgid "<DIR>"
+msgstr "<அடைவு>"
+
+#: ../src/generic/filectrlg.cpp:248 ../src/generic/filectrlg.cpp:271
+msgid "<LINK>"
+msgstr "<தொடுப்பு>"
+
+#: ../src/generic/filectrlg.cpp:250 ../src/generic/filectrlg.cpp:273
+msgid "<DRIVE>"
+msgstr "<இயக்ககம்>"
+
+#: ../src/generic/filectrlg.cpp:275
+#, c-format
+msgid "%ld byte"
+msgid_plural "%ld bytes"
+msgstr[0] "%ld byte"
+msgstr[1] "%ld bytes"
+
+#: ../src/generic/filectrlg.cpp:420
+msgid "Name"
+msgstr "பெயர்"
+
+#: ../src/generic/filectrlg.cpp:421 ../src/richtext/richtextformatdlg.cpp:361
+#: ../src/richtext/richtextsizepage.cpp:298
+msgid "Size"
+msgstr "அளவு"
+
+#: ../src/generic/filectrlg.cpp:422
+msgid "Type"
+msgstr "வகை"
+
+#: ../src/generic/filectrlg.cpp:423
+msgid "Modified"
+msgstr "மாற்றப்பட்டது"
+
+#: ../src/generic/filectrlg.cpp:426
+msgid "Permissions"
+msgstr "அனுமதிகள்"
+
+#: ../src/generic/filectrlg.cpp:429
+msgid "Attributes"
+msgstr "பண்புகள்"
+
+#: ../src/generic/filectrlg.cpp:936
+msgid "Current directory:"
+msgstr "தற்போதைய அடைவு"
+
+#: ../src/generic/filectrlg.cpp:979
+msgid "Show &hidden files"
+msgstr "மறைந்துள்ள கோப்புகளைக் காட்டுக (&H)"
+
+#: ../src/generic/filectrlg.cpp:1355
+msgid "Illegal file specification."
+msgstr "செல்லாத கோப்புக் குறிப்பு."
+
+#: ../src/generic/filectrlg.cpp:1387
+msgid "Directory doesn't exist."
+msgstr "அடைவு இல்லை"
+
+#: ../src/generic/filedlgg.cpp:195
+msgid "View files as a list view"
+msgstr "கோப்புகளை வரிசைப் பட்டியலில் காண்க"
+
+#: ../src/generic/filedlgg.cpp:197
+msgid "View files as a detailed view"
+msgstr "கோப்புகளை விளக்கங்களுடனான தோற்றத்தில் காண்க"
+
+#: ../src/generic/filedlgg.cpp:200
+msgid "Go to parent directory"
+msgstr "மேல்மட்ட அடைவிற்குச் செல்க"
+
+#: ../src/generic/filedlgg.cpp:351 ../src/gtk/filedlg.cpp:59
+#, c-format
+msgid "File '%s' already exists, do you really want to overwrite it?"
+msgstr "'%s' கோப்பு ஏற்கனவே உள்ளது, அதை கட்டாயம் அழித்தெழுத வேண்டுமா?"
+
+#: ../src/generic/filedlgg.cpp:354 ../src/gtk/filedlg.cpp:62
+msgid "Confirm"
+msgstr "உறுதிச் செய்க"
+
+#: ../src/generic/filedlgg.cpp:362 ../src/gtk/filedlg.cpp:75
+msgid "Please choose an existing file."
+msgstr "இருக்கும் கோப்பு ஒன்றினைத் தேர்ந்தெடுத்திடுக."
+
+#: ../src/generic/filepickerg.cpp:64
+msgid "..."
+msgstr "..."
+
+#: ../src/generic/fontdlgg.cpp:76 ../src/richtext/richtextformatdlg.cpp:519
+msgid "ABCDEFGabcdefg12345"
+msgstr "ABCDEFGabcdefg12345"
+
+#: ../src/generic/fontdlgg.cpp:315
+msgid "Roman"
+msgstr "ரோமானியம்"
+
+#: ../src/generic/fontdlgg.cpp:316
+msgid "Decorative"
+msgstr "அலங்காரப் பாங்கு"
+
+#: ../src/generic/fontdlgg.cpp:317
+msgid "Modern"
+msgstr "நவீனம்"
+
+#: ../src/generic/fontdlgg.cpp:318
+msgid "Script"
+msgstr "குறுநிரல்"
+
+#: ../src/generic/fontdlgg.cpp:319
+msgid "Swiss"
+msgstr "சுவிஸ்"
+
+#: ../src/generic/fontdlgg.cpp:320
+msgid "Teletype"
+msgstr "தொலையச்சு"
+
+#: ../src/generic/fontdlgg.cpp:321 ../src/generic/fontdlgg.cpp:324
+msgid "Normal"
+msgstr "இயல்பு"
+
+#: ../src/generic/fontdlgg.cpp:323
+msgid "Slant"
+msgstr "சாய்மம்"
+
+#: ../src/generic/fontdlgg.cpp:325
+msgid "Light"
+msgstr "இலகு"
+
+#: ../src/generic/fontdlgg.cpp:363
+msgid "&Font family:"
+msgstr "எழுத்துருக் குடும்பம் (&F):"
+
+#: ../src/generic/fontdlgg.cpp:367 ../src/generic/fontdlgg.cpp:369
+msgid "The font family."
+msgstr "எழுத்துருக் குடும்பம்."
+
+#: ../src/generic/fontdlgg.cpp:374 ../src/richtext/richtextstylepage.cpp:105
+msgid "&Style:"
+msgstr "பாங்கு (&S):"
+
+#: ../src/generic/fontdlgg.cpp:378 ../src/generic/fontdlgg.cpp:380
+msgid "The font style."
+msgstr "எழுத்துரு பாங்கு."
+
+#: ../src/generic/fontdlgg.cpp:385
+msgid "&Weight:"
+msgstr "அடர்த்தி (&W):"
+
+#: ../src/generic/fontdlgg.cpp:389 ../src/generic/fontdlgg.cpp:391
+msgid "The font weight."
+msgstr "எழுத்துரு அடர்த்தி"
+
+#: ../src/generic/fontdlgg.cpp:399
+msgid "C&olour:"
+msgstr "நிறம் (&O):"
+
+#: ../src/generic/fontdlgg.cpp:407 ../src/generic/fontdlgg.cpp:409
+msgid "The font colour."
+msgstr "எழுத்துரு நிறம்."
+
+#: ../src/generic/fontdlgg.cpp:415
+msgid "&Point size:"
+msgstr "புள்ளியளவு (&P)"
+
+#: ../src/generic/fontdlgg.cpp:420 ../src/generic/fontdlgg.cpp:422
+#: ../src/generic/fontdlgg.cpp:426 ../src/generic/fontdlgg.cpp:428
+msgid "The font point size."
+msgstr "எழுத்துரு புள்ளியளவு."
+
+#: ../src/generic/fontdlgg.cpp:439 ../src/generic/fontdlgg.cpp:441
+msgid "Whether the font is underlined."
+msgstr "எழுத்துரு அடிக்கோடிடப்பட்டதா? "
+
+#: ../src/generic/fontdlgg.cpp:448 ../src/html/helpwnd.cpp:1215
+msgid "Preview:"
+msgstr "முன்தோற்றம்:"
+
+#: ../src/generic/fontdlgg.cpp:452 ../src/generic/fontdlgg.cpp:454
+msgid "Shows the font preview."
+msgstr "எழுத்துரு முன்தோற்றத்தைக் காட்டுகிறது."
+
+#: ../src/generic/fontdlgg.cpp:464 ../src/generic/fontdlgg.cpp:483
+msgid "Click to cancel the font selection."
+msgstr "எழுத்துரு தெரிவினை விலக்க சொடுக்கிடுக."
+
+#: ../src/generic/fontdlgg.cpp:469 ../src/generic/fontdlgg.cpp:471
+#: ../src/generic/fontdlgg.cpp:476 ../src/generic/fontdlgg.cpp:478
+msgid "Click to confirm the font selection."
+msgstr "எழுத்துரு தெரிவினை உறுதி செய்ய சொடுக்கிடுக."
+
+#: ../src/generic/fontpickerg.cpp:50 ../src/gtk/fontdlg.cpp:77
+msgid "Choose font"
+msgstr "எழுத்துருவைத் தேர்ந்தெடுத்திடுக"
+
+#: ../src/generic/grid.cpp:6542
+msgid ""
+"Error copying grid to the clipboard. Either selected cells were not "
+"contiguous or no cell was selected."
+msgstr ""
+"வலையத்தைப் பிடிப்புப்பலகைக்கு படியெடுப்பதில் பிழை. களம் ஏதும் தெரிவுசெய்யப்படவில்லை, "
+"அல்லது தெரிவுசெய்யப்பட்டுள்ள களங்கள் தொடர்ச்சியாக இல்லை."
+
+#: ../src/generic/grid.cpp:12739
+msgid "Grid Corner"
+msgstr "வலையக் கோணம்"
+
+#: ../src/generic/grid.cpp:12741
+#, c-format
+msgid "Column %s Header"
+msgstr "நெடுவரிசை %s தலைப்புரை"
+
+#: ../src/generic/grid.cpp:12743
+#, c-format
+msgid "Row %s Header"
+msgstr "கிடைவரிசை %s தலைப்புரை"
+
+#: ../src/generic/grid.cpp:12745
+#, c-format
+msgid "Column %s: %s"
+msgstr "நெடுவரிசை %s: %s"
+
+#: ../src/generic/grid.cpp:12749
+#, c-format
+msgid "Row %s: %s"
+msgstr "கிடைவரிசை %s: %s"
+
+#: ../src/generic/grid.cpp:12753
+#, c-format
+msgid "Row %s, Column %s: %s"
+msgstr "கிடைவரிசை %s, நெடுவரிசை %s: %s"
+
+#: ../src/generic/helpext.cpp:257
+#, c-format
+msgid "Help directory \"%s\" not found."
+msgstr "\"%s\" உதவி அடைவு காணப்படவில்லை."
+
+#: ../src/generic/helpext.cpp:265
+#, c-format
+msgid "Help file \"%s\" not found."
+msgstr "\"%s\" உதவிக் கோப்பு காணப்படவில்லை."
+
+#: ../src/generic/helpext.cpp:284
+#, c-format
+msgid "Line %lu of map file \"%s\" has invalid syntax, skipped."
+msgstr "%lu வரியில் (\"%s\" இணையாக்கக் கோப்பு) செல்லாத நிரல்தொடர், தவிர்க்கப்படுகிறது."
+
+#: ../src/generic/helpext.cpp:292
+#, c-format
+msgid "No valid mappings found in the file \"%s\"."
+msgstr "\"%s\" கோப்பில் செல்லத்தக்க இணையாக்கங்கள் காணப்படவில்லை."
+
+#: ../src/generic/helpext.cpp:435
+msgid "No entries found."
+msgstr "உள்ளீடுகள் காணப்படவில்லை."
+
+#: ../src/generic/helpext.cpp:444 ../src/generic/helpext.cpp:445
+msgid "Help Index"
+msgstr "உதவிச் சுட்டெண்"
+
+#: ../src/generic/helpext.cpp:448
+msgid "Relevant entries:"
+msgstr "பொருத்தமான உள்ளீடுகள்:"
+
+#: ../src/generic/helpext.cpp:449
+msgid "Entries found"
+msgstr "உள்ளீடுகள் காணப்படுகின்றன"
+
+#: ../src/generic/hyperlinkg.cpp:170
+msgid "&Copy URL"
+msgstr "இணைய முகவரியை படியெடுத்திடுக (&C)"
+
+#: ../src/generic/infobar.cpp:119
+msgid "Hide this notification message."
+msgstr "இந்த அறிவிப்புத் தகவலை மறைத்திடுக."
+
+#. TRANSLATORS: %s will be either the application name or "Application"
+#: ../src/generic/logg.cpp:257
+#, c-format
+msgid "%s Error"
+msgstr "%s பிழை"
+
+#. TRANSLATORS: %s will be either the application name or "Application"
+#: ../src/generic/logg.cpp:263
+#, c-format
+msgid "%s Warning"
+msgstr "%s எச்சரிக்கை"
+
+#. TRANSLATORS: %s will be either the application name or "Application"
+#: ../src/generic/logg.cpp:273
+#, c-format
+msgid "%s Information"
+msgstr "%s தகவல்"
+
+#: ../src/generic/logg.cpp:276
+msgid "Application"
+msgstr "பயன்பாடு"
+
+#: ../src/generic/logg.cpp:549
+msgid "Save log contents to file"
+msgstr "செயற்குறிப்பேட்டு உள்ளடக்கங்களை கோப்பில் சேமிக்கவும்"
+
+#: ../src/generic/logg.cpp:551
+msgid "C&lear"
+msgstr "துடைத்திடுக (&L)"
+
+#: ../src/generic/logg.cpp:551
+msgid "Clear the log contents"
+msgstr "செயற்குறிப்பேட்டு உள்ளடக்கங்களை துடைத்திடுக"
+
+#: ../src/generic/logg.cpp:553
+msgid "Close this window"
+msgstr "இச்சாளரத்தை மூடுக"
+
+#: ../src/generic/logg.cpp:554
+msgid "&Log"
+msgstr "செயற்குறிப்பேடு (&L)"
+
+#: ../src/generic/logg.cpp:610 ../src/generic/logg.cpp:992
+msgid "Can't save log contents to file."
+msgstr "செயற்குறிப்பேட்டு உள்ளடக்கங்களை கோப்பில் சேமிக்க இயலவில்லை"
+
+#: ../src/generic/logg.cpp:613
+#, c-format
+msgid "Log saved to the file '%s'."
+msgstr "செயற்குறிப்பு '%s' கோப்பில் சேமிக்கப்பட்டுள்ளது."
+
+#: ../src/generic/logg.cpp:719
+msgid "&Details"
+msgstr "விவரங்கள் (&D)"
+
+#: ../src/generic/logg.cpp:972
+msgid "Failed to copy dialog contents to the clipboard."
+msgstr "உரையாடலின் உள்ளடக்கங்களை பிடிப்புப் பலகைக்கு படியெடுப்பதில் தோல்வி."
+
+#: ../src/generic/logg.cpp:1022
+#, c-format
+msgid "Append log to file '%s' (choosing [No] will overwrite it)?"
+msgstr ""
+"செயற்குறிப்பேட்டினை '%s' கோப்பினுடன் பின்னிணைப்பதா? ([இல்லை] என்றுத் தேர்வு செய்தால் "
+"கோப்பு அழித்தெழுதப்படும்)"
+
+#: ../src/generic/logg.cpp:1024
+msgid "Question"
+msgstr "கேள்வி"
+
+#: ../src/generic/logg.cpp:1038
+msgid "invalid message box return value"
+msgstr "செல்லாத செய்திப் பெட்டியின் மீள்மதிப்பு"
+
+#: ../src/generic/notifmsgg.cpp:129
+msgid "Notice"
+msgstr "கவன அறிவிப்பு"
+
+#: ../src/generic/preferencesg.cpp:118
+#, c-format
+msgid "%s Preferences"
+msgstr "%s விருப்பங்கள்"
+
+#: ../src/generic/printps.cpp:143
+msgid "Printing..."
+msgstr "அச்சிடப்படுகிறது..."
+
+#: ../src/generic/printps.cpp:160 ../src/gtk/print.cpp:1076
+#: ../src/msw/printwin.cpp:235
+msgid "Could not start printing."
+msgstr "அச்சிடுதலை துவக்க இயலவில்லை."
+
+#: ../src/generic/printps.cpp:183
+#, c-format
+msgid "Printing page %d..."
+msgstr "%d பக்கம் அச்சிடப்படுகிறது..."
+
+#: ../src/generic/prntdlgg.cpp:171
+msgid "Printer options"
+msgstr "அச்சுப் பொறி விருப்பத் தேர்வுகள்"
+
+#: ../src/generic/prntdlgg.cpp:176
+msgid "Print to File"
+msgstr "கோப்பில் அச்சிடுக"
+
+#: ../src/generic/prntdlgg.cpp:179
+msgid "Setup..."
+msgstr "அமைவு..."
+
+#: ../src/generic/prntdlgg.cpp:187
+msgid "Printer:"
+msgstr "அச்சுப் பொறி:"
+
+#: ../src/generic/prntdlgg.cpp:195
+msgid "Status:"
+msgstr "நிலை:"
+
+#: ../src/generic/prntdlgg.cpp:206
+msgid "All"
+msgstr "அனைத்தும்"
+
+#: ../src/generic/prntdlgg.cpp:207
+msgid "Pages"
+msgstr "பக்கங்கள்"
+
+#: ../src/generic/prntdlgg.cpp:215
+msgid "Print Range"
+msgstr "அச்சு வீச்சு"
+
+#: ../src/generic/prntdlgg.cpp:229
+msgid "From:"
+msgstr "அனுப்புநர்:"
+
+#: ../src/generic/prntdlgg.cpp:233
+msgid "To:"
+msgstr "பெறுநர்:"
+
+#: ../src/generic/prntdlgg.cpp:238
+msgid "Copies:"
+msgstr "படிகள்:"
+
+#: ../src/generic/prntdlgg.cpp:288
+msgid "PostScript file"
+msgstr "PostScript கோப்பு"
+
+#: ../src/generic/prntdlgg.cpp:439
+msgid "Print Setup"
+msgstr "அச்சு அமைவு"
+
+#: ../src/generic/prntdlgg.cpp:483
+msgid "Printer"
+msgstr "அச்சுப் பொறி"
+
+#: ../src/generic/prntdlgg.cpp:501
+msgid "Default printer"
+msgstr "இயல்பு அச்சுப் பொறி"
+
+#: ../src/generic/prntdlgg.cpp:595 ../src/generic/prntdlgg.cpp:782
+#: ../src/generic/prntdlgg.cpp:822 ../src/generic/prntdlgg.cpp:835
+#: ../src/generic/prntdlgg.cpp:1031 ../src/generic/prntdlgg.cpp:1036
+msgid "Paper size"
+msgstr "பக்க அளவு"
+
+#: ../src/generic/prntdlgg.cpp:604 ../src/generic/prntdlgg.cpp:847
+msgid "Portrait"
+msgstr "நெடுவாக்கு"
+
+#: ../src/generic/prntdlgg.cpp:605 ../src/generic/prntdlgg.cpp:848
+msgid "Landscape"
+msgstr "அகலவாக்கு"
+
+#: ../src/generic/prntdlgg.cpp:607 ../src/generic/prntdlgg.cpp:849
+msgid "Orientation"
+msgstr "திசையமைவு"
+
+#: ../src/generic/prntdlgg.cpp:610
+msgid "Options"
+msgstr "விருப்பத் தேர்வுகள்"
+
+#: ../src/generic/prntdlgg.cpp:612
+msgid "Print in colour"
+msgstr "நிறமாக அச்சிடுக"
+
+#: ../src/generic/prntdlgg.cpp:621
+msgid "Print spooling"
+msgstr "அச்சு வரிசையாக்கம்"
+
+#: ../src/generic/prntdlgg.cpp:623
+msgid "Printer command:"
+msgstr "அச்சுக் கட்டளை:"
+
+#: ../src/generic/prntdlgg.cpp:631
+msgid "Printer options:"
+msgstr "அச்சுப் பொறி விருப்பத் தேர்வுகள்"
+
+#: ../src/generic/prntdlgg.cpp:860
+msgid "Left margin (mm):"
+msgstr "இடது ஓரம் (மி.மீ.):"
+
+#: ../src/generic/prntdlgg.cpp:861
+msgid "Top margin (mm):"
+msgstr "மேல் ஓரம் (மி.மீ.):"
+
+#: ../src/generic/prntdlgg.cpp:872
+msgid "Right margin (mm):"
+msgstr "வலது ஓரம் (மி.மீ.):"
+
+#: ../src/generic/prntdlgg.cpp:873
+msgid "Bottom margin (mm):"
+msgstr "கீழ் ஓரம் (மி.மீ.)"
+
+#: ../src/generic/prntdlgg.cpp:896
+msgid "Printer..."
+msgstr "அச்சுப் பொறி..."
+
+#: ../src/generic/progdlgg.cpp:246
+msgid "&Skip"
+msgstr "தவிர்த்திடுக (&S)"
+
+#: ../src/generic/progdlgg.cpp:347 ../src/generic/progdlgg.cpp:626
+msgid "Unknown"
+msgstr "அறியப்படாதது"
+
+#: ../src/generic/progdlgg.cpp:451 ../src/msw/progdlg.cpp:526
+msgid "Done."
+msgstr "முடிவுற்றது"
+
+#: ../src/generic/srchctlg.cpp:55 ../src/gtk/srchctrl.cpp:206
+#: ../src/html/helpwnd.cpp:530 ../src/html/helpwnd.cpp:545
+msgid "Search"
+msgstr "தேடுக"
+
+#: ../src/generic/tabg.cpp:1026
+msgid "Could not find tab for id"
+msgstr "அடையாளத்திற்கான பட்டியைக் கண்டறிய இயலவில்லை"
+
+#: ../src/generic/tipdlg.cpp:136
+msgid "Tips not available, sorry!"
+msgstr "உதவிக் குறிப்புகள் இல்லை, பொருத்தருள்க!"
+
+#: ../src/generic/tipdlg.cpp:197
+msgid "Tip of the Day"
+msgstr "இன்றைய உதவிக் குறிப்பு"
+
+#: ../src/generic/tipdlg.cpp:207
+msgid "Did you know..."
+msgstr "தாங்கள் அறிந்திருந்தீர்களா?"
+
+#: ../src/generic/tipdlg.cpp:232
+msgid "&Show tips at startup"
+msgstr "துவக்கத்தில் உதவிக் குறிப்புகளைக் காட்டுக (&S)"
+
+#: ../src/generic/tipdlg.cpp:236
+msgid "&Next Tip"
+msgstr "அடுத்த உதவிக் குறிப்பு (&N)"
+
+#: ../src/generic/wizard.cpp:411
+msgid "&Next >"
+msgstr "அடுத்தது (&N)"
+
+#: ../src/generic/wizard.cpp:412
+msgid "&Finish"
+msgstr "நிறைவுச் செய்க (&F)"
+
+#: ../src/generic/wizard.cpp:420
+msgid "< &Back"
+msgstr "< பின் (&B)"
+
+#: ../src/gtk/aboutdlg.cpp:204
+msgid "translator-credits"
+msgstr "மொழிபெயர்ப்பாளர் அங்கீகாரம்"
+
+#: ../src/gtk/app.cpp:517
+msgid ""
+"WARNING: using XIM input method is unsupported and may result in problems "
+"with input handling and flickering. Consider unsetting GTK_IM_MODULE or "
+"setting to \"ibus\"."
+msgstr ""
+"எச்சரிக்கை: XIM உள்ளீட்டு முறை ஆதரிக்கப்படுவதில்லை. ஆகவே, உள்ளீட்டைக் கையாள்வதில் சிக்கலும், "
+"ஒளிமினுங்கலும் ஏற்படும். GTK_IM நிரற்கூறின் அமைப்பை நீக்குவதை, அல்லது \"ibus\"க்கு "
+"அமைப்பதைப் பரிசீலிக்கவும். "
+
+#: ../src/gtk/app.cpp:569
+msgid "Unable to initialize GTK+, is DISPLAY set properly?"
+msgstr "GTK+ தொடக்கநிலையாக்க இயலவில்லை, காட்சி சரியாக அமைக்கப்பட்டுள்ளதா?"
+
+#: ../src/gtk/filedlg.cpp:89 ../src/gtk/filepicker.cpp:255
+#, c-format
+msgid "Changing current directory to \"%s\" failed"
+msgstr "அடைவினை \"%s\"க்கு மாற்றுவதில் தோல்வி."
+
+#: ../src/gtk/font.cpp:548
+msgid ""
+"Using private fonts is not supported on this system: Pango library is too "
+"old, 1.38 or later required."
+msgstr ""
+"தனிப்பட்ட எழுத்துருக்களை இக்கணினியில் பயன்படுத்த ஆதரவில்லை. பாங்கோ நூலகம் மிகவும் "
+"பழமையானதாகவுள்ளது. 1.38, அல்லது அதற்கும் பிறகான பதிப்பு தேவைப்படுகிறது."
+
+#: ../src/gtk/font.cpp:558
+msgid "Failed to create font configuration object."
+msgstr "எழுத்துரு அமைவடிவப் பொருளை உருவாக்குவதில் தோல்வி."
+
+#: ../src/gtk/font.cpp:568
+#, c-format
+msgid "Failed to add custom font \"%s\"."
+msgstr "\"%s\" தனிப்பயனாக்கப்பட்ட எழுத்துருவை சேர்ப்பதில் தோல்வி."
+
+#: ../src/gtk/font.cpp:576
+msgid "Failed to register font configuration using private fonts."
+msgstr "தனிப்பட்ட எழுத்துருக்களைப் பயன்படுத்தி எழுத்துரு அமைவடிவத்தைப் பதிவதில் தோல்வி."
+
+#: ../src/gtk/glcanvas.cpp:117 ../src/gtk/glcanvas.cpp:132
+msgid "Fatal Error"
+msgstr "முறிவுப் பிழை"
+
+#: ../src/gtk/glcanvas.cpp:117
+msgid ""
+"This program wasn't compiled with EGL support required under Wayland, "
+"either\n"
+"install EGL libraries and rebuild or run it under X11 backend by setting\n"
+"environment variable GDK_BACKEND=x11 before starting your program."
+msgstr ""
+"வேலேண்டின் கீழ் தேவைப்படும் EGL ஆதரவுடன் இந்நிரல் தொகுக்கப்படவில்லை. \n"
+" EGL நூலகங்களை நிறுவி மீண்டும் கட்டமைக்கவும், அல்லது நிரலைத் துவக்குவதற்கு முன்,\n"
+" GDK_BACKEND=x11 சூழல் மாற்றியை அமைத்து, X11 பின்னிலையில் இயக்கவும். "
+
+#: ../src/gtk/glcanvas.cpp:132
+msgid ""
+"wxGLCanvas is only supported on Wayland and X11 currently.  You may be able "
+"to\n"
+"work around this by setting environment variable GDK_BACKEND=x11 before\n"
+"starting your program."
+msgstr ""
+"தற்போதைக்கு வேலேண்டிலும், X11லும் மட்டுமே wxGLCanvas ஆதரிக்கப்படுகிறது.\n"
+" தீர்வில்லாத இக்குறைபாட்டினைத் தவிர்க்க, தங்களின் நிரலைத் துவக்குவதற்கு முன்,\n"
+" GDK_BACKEND=x11 சூழல் மாற்றியை அமைக்கவும்."
+
+#: ../src/gtk/mdi.cpp:433
+msgid "MDI child"
+msgstr "MDI சேய்"
+
+#: ../src/gtk/power.cpp:188
+#, c-format
+msgid "Failed to open D-Bus connection to the login manager: %s"
+msgstr "புகுபதிவு மேலாளருக்கு D-Bus இணைப்பைத் திறப்பதில் தோல்வி: %s"
+
+#: ../src/gtk/power.cpp:214
+msgid "wxWidgets application"
+msgstr "wxWidgets பயன்பாடு"
+
+#: ../src/gtk/power.cpp:226
+msgid "Application needs to keep running"
+msgstr "பயன்பாடு தொடர்ந்து இயங்க வேண்டும்"
+
+#: ../src/gtk/power.cpp:233
+msgid "Clean up before suspend"
+msgstr "இடைநீக்குவதற்கு முன் தூய்மைப்படுத்தவும்"
+
+#: ../src/gtk/power.cpp:259
+#, c-format
+msgid "Failed to inhibit sleep: %s"
+msgstr "உறக்கநிலையை தடுப்பதில் தோல்வி: %s"
+
+#: ../src/gtk/power.cpp:265
+msgid "Unexpected response to D-Bus \"Inhibit\" request."
+msgstr "D-Bus \"Inhibit\" கோரிக்கைக்கு எதிர்பாராத மறுமொழி"
+
+#: ../src/gtk/print.cpp:218
+msgid "Custom size"
+msgstr "தனிப் பயனாக்கப்பட்ட அளவு"
+
+#: ../src/gtk/print.cpp:752
+#, c-format
+msgid "Error while printing: %s"
+msgstr "அச்சிடுகையில் பிழை: %s"
+
+#: ../src/gtk/print.cpp:816
+msgid "Page Setup"
+msgstr "பக்க அமைவு"
+
+#: ../src/gtk/webview_webkit.cpp:932
+msgid "Retrieving JavaScript script output is not supported with WebKit v1"
+msgstr "JavaScript குறுநிரல் வெளியீட்டின் மீட்டமைவை WebKit v1 ஆதரிப்பதில்லை"
+
+#: ../src/gtk/webview_webkit2.cpp:1098
+msgid ""
+"Setting proxy is not supported by WebKit, at least version 2.16 is required."
+msgstr ""
+"பினாமியை அமைப்பது வெப்கிட்டினால் ஆதரிக்கப்படவில்லை. குறைந்தபட்ச பதிப்பு 2.16 "
+"தேவைப்படுகிறது. "
+
+#: ../src/gtk/webview_webkit2.cpp:1104
+msgid "This program was compiled without support for setting WebKit proxy."
+msgstr "வெப்கிட் பினாமி அமைப்பதற்கான ஆதரவில்லாமல் இந்நிரல் தொகுக்கப்பட்டுள்ளது."
+
+#: ../src/gtk/window.cpp:6289
+msgid ""
+"GTK+ installed on this machine is too old to support screen compositing, "
+"please install GTK+ 2.12 or later."
+msgstr ""
+"இந்த கணினியில் நிறுவப்பட்டிருக்கும் GTK+, திரைக் கலவையை ஆதரிக்க இயலாத அளவிற்கு "
+"பழமையாய் உள்ளது. GTK+ 2.12 அல்லது அதற்கும் பின்னரான பதிப்பினை அருள்கூர்ந்து நிறுவவும்."
+
+#: ../src/gtk/window.cpp:6307
+msgid ""
+"Compositing not supported by this system, please enable it in your Window "
+"Manager."
+msgstr ""
+"இக்கணினி கலக்குதலை ஆதரிப்பதில்லை. அருள்கூர்ந்து தங்களின் சாளர மேலாளரில் இதை முடுக்கவும்."
+
+#: ../src/gtk/window.cpp:6318
+msgid ""
+"This program was compiled with a too old version of GTK+, please rebuild "
+"with GTK+ 2.12 or newer."
+msgstr ""
+"இந்நிரல், மிகப் பழைய GTK+ பதிப்பைக் கொண்டு உருவாக்கப்பட்டது. GTK+ 2.12 அல்லது அதைவிட "
+"புதிய பதிப்பைக் கொண்டு மறுகட்டமைப்புச் செய்யவும்."
+
+#: ../src/html/chm.cpp:138
+#, c-format
+msgid "Failed to open CHM archive '%s'."
+msgstr "'%s' CHM ஆவணகத்தைத் திறப்பதில் தோல்வி."
+
+#: ../src/html/chm.cpp:270
+#, c-format
+msgid "Could not extract %s into %s: %s"
+msgstr "%s-ஐ  %s-ற்குள் பிரித்தெடுக்க இயலவில்லை: %s"
+
+#: ../src/html/chm.cpp:324
+msgid "no error"
+msgstr "பிழை ஏதுமில்லை"
+
+#: ../src/html/chm.cpp:326
+msgid "bad arguments to library function"
+msgstr "நூலக செயலுக்கு பழுதுள்ள தர்க்கங்கள்"
+
+#: ../src/html/chm.cpp:328
+msgid "error opening file"
+msgstr "கோப்பினை திறப்பதில் பிழை"
+
+#: ../src/html/chm.cpp:330
+msgid "read error"
+msgstr "பிழையைப் படித்திடுக"
+
+#: ../src/html/chm.cpp:332
+msgid "write error"
+msgstr "பிழையை எழுதிடுக"
+
+#: ../src/html/chm.cpp:334
+msgid "seek error"
+msgstr "பிழையை நாடுக"
+
+#: ../src/html/chm.cpp:338
+msgid "bad signature"
+msgstr "பழுதுள்ள ஒப்பம்"
+
+#: ../src/html/chm.cpp:340
+msgid "error in data format"
+msgstr "தரவு வடிவூட்டத்தில் பிழை"
+
+#: ../src/html/chm.cpp:342
+msgid "checksum error"
+msgstr "checksum பிழை"
+
+#: ../src/html/chm.cpp:344
+msgid "compression error"
+msgstr "குறுக்கல் பிழை"
+
+#: ../src/html/chm.cpp:346
+msgid "decompression error"
+msgstr "விரிவாக்கப் பிழை"
+
+#: ../src/html/chm.cpp:437
+#, c-format
+msgid "Could not locate file '%s'."
+msgstr "'%s' கோப்பினை இடங்காண இயலவில்லை."
+
+#: ../src/html/chm.cpp:711
+#, c-format
+msgid "Could not create temporary file '%s'"
+msgstr "'%s' தற்காலிக கோப்பினை உருவாக்க இயலவில்லை"
+
+#: ../src/html/chm.cpp:718
+#, c-format
+msgid "Extraction of '%s' into '%s' failed."
+msgstr "'%s', '%s'-ஆக பிரித்தெடுப்பது தோல்வியடைந்தது."
+
+#: ../src/html/chm.cpp:806 ../src/html/chm.cpp:863
+msgid "CHM handler currently supports only local files!"
+msgstr "CHM கையாளுநர் தற்போதைக்கு தன்னகக் கோப்புகளை மட்டுமே ஆதரிக்கிறது!"
+
+#: ../src/html/chm.cpp:827
+msgid "Link contained '//', converted to absolute link."
+msgstr "தொடுப்பு '//' கொண்டிருந்தது, அறுதியான தொடுப்பாக மாற்றப்பட்டது."
+
+#: ../src/html/helpctrl.cpp:59
+#, c-format
+msgid "Help: %s"
+msgstr "உதவி: %s"
+
+#: ../src/html/helpctrl.cpp:155
+#, c-format
+msgid "Adding book %s"
+msgstr "%s நூல் சேர்க்கப்படுகிறது"
+
+#: ../src/html/helpdata.cpp:295
+#, c-format
+msgid "Cannot open contents file: %s"
+msgstr "உள்ளடக்கக் கோப்பினை திறக்க இயலவில்லை: %s"
+
+#: ../src/html/helpdata.cpp:309
+#, c-format
+msgid "Cannot open index file: %s"
+msgstr "சுட்டெண் கோப்பினை திறக்க இயலவில்லை: %s"
+
+#: ../src/html/helpdata.cpp:643
+msgid "noname"
+msgstr "பெயரில்லை"
+
+#: ../src/html/helpdata.cpp:652
+#, c-format
+msgid "Cannot open HTML help book: %s"
+msgstr "HTML உதவி நூலினைத் திறக்க இயலவில்லை: %s"
+
+#: ../src/html/helpwnd.cpp:315
+msgid "Displays help as you browse the books on the left."
+msgstr "இடப்புறமாக உள்ள நூல்களை உலாவித் தேடுகின்றபொழுது, உதவியைக் காட்டிடும்."
+
+#: ../src/html/helpwnd.cpp:411 ../src/html/helpwnd.cpp:1100
+#: ../src/html/helpwnd.cpp:1735
+msgid "(bookmarks)"
+msgstr "(நூற்குறிகள்)"
+
+#: ../src/html/helpwnd.cpp:424
+msgid "Add current page to bookmarks"
+msgstr "தற்போதைய பக்கத்தை நூற்குறிகளில் சேர்த்திடுக"
+
+#: ../src/html/helpwnd.cpp:425
+msgid "Remove current page from bookmarks"
+msgstr "நூற்குறிகளிலிருந்து தற்போதைய பக்கத்தை நீக்கிடுக"
+
+#: ../src/html/helpwnd.cpp:470
+msgid "Contents"
+msgstr "உள்ளடக்கங்கள்"
+
+#: ../src/html/helpwnd.cpp:485
+msgid "Find"
+msgstr "கண்டறிக"
+
+#: ../src/html/helpwnd.cpp:487
+msgid "Show all"
+msgstr "அனைத்தையும் காட்டிடுக"
+
+#: ../src/html/helpwnd.cpp:497
+msgid ""
+"Display all index items that contain given substring. Search is case "
+"insensitive."
+msgstr ""
+"கொடுக்கப்பட்ட உட்சரத்தை கொண்டுள்ள சுட்டெண் உருப்படிகளை காட்டிடுக. எழுத்து வகையைத் தேடல் "
+"கண்டுணராது."
+
+#: ../src/html/helpwnd.cpp:498
+msgid "Show all items in index"
+msgstr "சுட்டெண்ணில் உள்ள எல்லா உருப்படிகளையும் காட்டிடுக"
+
+#: ../src/html/helpwnd.cpp:528
+msgid "Case sensitive"
+msgstr "வகையுணர்"
+
+#: ../src/html/helpwnd.cpp:529
+msgid "Whole words only"
+msgstr "முழுச்சொற்கள் மட்டும்"
+
+#: ../src/html/helpwnd.cpp:532
+msgid ""
+"Search contents of help book(s) for all occurrences of the text you typed "
+"above"
+msgstr ""
+"தாங்கள் மேலே தட்டச்சிட்ட உரையின் எல்லா நிகழ்வுகளையும் உதவி நூலின் உள்ளடக்கங்களில் தேடவும்"
+
+#: ../src/html/helpwnd.cpp:653
+msgid "Show/hide navigation panel"
+msgstr "வழிநடத்துப் பலகையை காட்டிடுக/மறைத்திடுக"
+
+#: ../src/html/helpwnd.cpp:655
+msgid "Go back"
+msgstr "பின் செல்க"
+
+#: ../src/html/helpwnd.cpp:656
+msgid "Go forward"
+msgstr "முன் செல்க"
+
+#: ../src/html/helpwnd.cpp:658
+msgid "Go one level up in document hierarchy"
+msgstr "ஆவண அடுக்கில் ஒரு மட்டம் மேலே செல்க"
+
+#: ../src/html/helpwnd.cpp:666 ../src/html/helpwnd.cpp:1547
+msgid "Open HTML document"
+msgstr "HTML ஆவணத்தைத் திறவுக"
+
+#: ../src/html/helpwnd.cpp:670
+msgid "Print this page"
+msgstr "இப்பக்கத்தை அச்சிடுக"
+
+#: ../src/html/helpwnd.cpp:674
+msgid "Display options dialog"
+msgstr "காட்சி விருப்பத் தேர்வுகள் உரையாடல்"
+
+#: ../src/html/helpwnd.cpp:795
+msgid "Please choose the page to display:"
+msgstr "காட்டப்பட வேண்டிய பக்கத்தை தேர்ந்தெடுக்கவும்."
+
+#: ../src/html/helpwnd.cpp:796
+msgid "Help Topics"
+msgstr "உதவித் தலைப்புகள்"
+
+#: ../src/html/helpwnd.cpp:852
+msgid "Searching..."
+msgstr "தேடப்படுகிறது..."
+
+#: ../src/html/helpwnd.cpp:853
+msgid "No matching page found yet"
+msgstr "பொருத்தமான பக்கம் இதுவரைக் காணப்படவில்லை"
+
+#: ../src/html/helpwnd.cpp:870
+#, c-format
+msgid "Found %i matches"
+msgstr "%i பொருத்தங்கள் காணப்பட்டன"
+
+#: ../src/html/helpwnd.cpp:958
+msgid "(Help)"
+msgstr "(உதவி)"
+
+#: ../src/html/helpwnd.cpp:1026
+#, c-format
+msgid "%d of %lu"
+msgstr "%d, மொத்தம் %lu"
+
+#: ../src/html/helpwnd.cpp:1028
+#, c-format
+msgid "%lu of %lu"
+msgstr "%lu, மொத்தம் %lu"
+
+#: ../src/html/helpwnd.cpp:1047
+msgid "Search in all books"
+msgstr "எல்லா நூல்களிலும் தேடுக"
+
+#: ../src/html/helpwnd.cpp:1193
+msgid "Help Browser Options"
+msgstr "உலாவி விருப்பத் தேர்வுகள் உதவி"
+
+#: ../src/html/helpwnd.cpp:1198
+msgid "Normal font:"
+msgstr "இயல்பெழுத்துரு:"
+
+#: ../src/html/helpwnd.cpp:1199
+msgid "Fixed font:"
+msgstr "நிலையான எழுத்துரு:"
+
+#: ../src/html/helpwnd.cpp:1200
+msgid "Font size:"
+msgstr "எழுத்துரு அளவு:"
+
+#: ../src/html/helpwnd.cpp:1245
+msgid "font size"
+msgstr "எழுத்துரு அளவு"
+
+#: ../src/html/helpwnd.cpp:1256
+msgid "Normal face<br>and <u>underlined</u>. "
+msgstr "இயல் முகம்<br>மற்றும் <u>அடிக்கோடிடப்பட்டது</u>. "
+
+#: ../src/html/helpwnd.cpp:1257
+msgid "<i>Italic face.</i> "
+msgstr "<i>வலச்சாய்வு முகம்.</i> "
+
+#: ../src/html/helpwnd.cpp:1258
+msgid "<b>Bold face.</b> "
+msgstr "<b>அடர்த்தி.</b> "
+
+#: ../src/html/helpwnd.cpp:1259
+msgid "<b><i>Bold italic face.</i></b><br>"
+msgstr "<b><i>அடர்த்தி வலச்சாய்வு முகம்.</i></b><br>"
+
+#: ../src/html/helpwnd.cpp:1262
+msgid "Fixed size face.<br> <b>bold</b> <i>italic</i> "
+msgstr "நிலையான அளவு முகம். <br> <b>அடர்த்தி</b> <i>வலச்சாய்வு</i> "
+
+#: ../src/html/helpwnd.cpp:1263
+msgid "<b><i>bold italic <u>underlined</u></i></b><br>"
+msgstr "<b><i>அடர்த்தி வலச்சாய்வு <u>அடிக்கோடிடப்பட்டது</u></i></b><br>"
+
+#: ../src/html/helpwnd.cpp:1524
+msgid "Help Printing"
+msgstr "அச்சிடுதல் உதவி"
+
+#: ../src/html/helpwnd.cpp:1527
+msgid "Cannot print empty page."
+msgstr "வெற்றுப் பக்கத்தை அச்சிட இயலாது"
+
+#: ../src/html/helpwnd.cpp:1540
+msgid "HTML files (*.html;*.htm)|*.html;*.htm|"
+msgstr "HTML கோப்புகள் (*.html;*.htm)|*.html;*.htm|"
+
+#: ../src/html/helpwnd.cpp:1541
+msgid "Help books (*.htb)|*.htb|Help books (*.zip)|*.zip|"
+msgstr "உதவி நூல்கள் (*.htb)|*.htb|Help books (*.zip)|*.zip|"
+
+#: ../src/html/helpwnd.cpp:1542
+msgid "HTML Help Project (*.hhp)|*.hhp|"
+msgstr "HTML உதவிப் பணித் திட்டம் (*.hhp)|*.hhp|"
+
+#: ../src/html/helpwnd.cpp:1544
+msgid "Compressed HTML Help file (*.chm)|*.chm|"
+msgstr "குறுக்கப்பட்ட HTML உதவிக் கோப்பு (*.chm)|*.chm|"
+
+#: ../src/html/helpwnd.cpp:1671
+#, c-format
+msgid "%i of %u"
+msgstr "%i, மொத்தம் %u"
+
+#: ../src/html/helpwnd.cpp:1709
+#, c-format
+msgid "%u of %u"
+msgstr "%u, மொத்தம் %u"
+
+#: ../src/html/htmlfilt.cpp:134
+#, c-format
+msgid "Cannot open HTML document: %s"
+msgstr "HTML ஆவணத்தை திறக்க இயலவில்லை: %s"
+
+#: ../src/html/htmlwin.cpp:599
+msgid "Connecting..."
+msgstr "இணைக்கப்படுகிறது..."
+
+#: ../src/html/htmlwin.cpp:616
+#, c-format
+msgid "Unable to open requested HTML document: %s"
+msgstr "வேண்டப்பட்ட HTML ஆவணத்தை திறக்க இயலவில்லை: %s"
+
+#: ../src/html/htmlwin.cpp:630
+msgid "Loading : "
+msgstr "ஏற்றப்படுகிறது : "
+
+#: ../src/html/htmlwin.cpp:673
+msgid "Done"
+msgstr "முடிவுற்றது"
+
+#: ../src/html/htmlwin.cpp:723
+#, c-format
+msgid "HTML anchor %s does not exist."
+msgstr "%s HTML நங்கூரம் இல்லை."
+
+#: ../src/html/htmlwin.cpp:1057
+#, c-format
+msgid "Copied to clipboard:\"%s\""
+msgstr "பிடிப்புப் பலகைக்கு படியெடுக்கப்பட்டது: \"%s\""
+
+#: ../src/html/htmprint.cpp:269
+msgid ""
+"This document doesn't fit on the page horizontally and will be truncated "
+"when it is printed."
+msgstr ""
+"இந்த ஆவணம் பக்கத்தில் கிடையாக பொருந்தவில்லையென்பதால், அச்சிடும்பொழுது அது அறுபடும்."
+
+#: ../src/html/htmprint.cpp:285
+#, c-format
+msgid ""
+"The document \"%s\" doesn't fit on the page horizontally and will be "
+"truncated if printed.\n"
+"\n"
+"Would you like to proceed with printing it nevertheless?"
+msgstr ""
+"\"%s\" ஆவணம் பக்கத்தில் கிடையாக பொருந்தவில்லை. அச்சிட்டால், ஆவணம் அறுபடும்.\n"
+"\n"
+"இருந்தபோதிலும் ஆவணத்தை அச்சிட விரும்புகிறீர்களா?"
+
+#: ../src/html/htmprint.cpp:296
+msgid ""
+"If possible, try changing the layout parameters to make the printout more "
+"narrow."
+msgstr "இயன்றால், அச்சிடுதலை குறுகலாக்க தளவமைப்பின் அளவுருவை மாற்றிப் பார்க்கவும்."
+
+#: ../src/html/htmprint.cpp:445
+msgid ": file does not exist!"
+msgstr "கோப்பு இல்லை!"
+
+#. TRANSLATORS: %s may be a document title.
+#: ../src/html/htmprint.cpp:717
+#, c-format
+msgid "%s Preview"
+msgstr "%s முன்தோற்றம்"
+
+#: ../src/html/htmprint.cpp:755 ../src/richtext/richtextprint.cpp:618
+msgid ""
+"There was a problem during page setup: you may need to set a default printer."
+msgstr ""
+"பக்க அமைவில் சிக்கல் ஏற்பட்டுள்ளது. இயல்பு அச்சுப் பொறி ஒன்றைத் தாங்கள் அமைக்க "
+"வேண்டியிருக்கும்."
+
+#: ../src/msw/clipbrd.cpp:80
+msgid "Failed to open the clipboard."
+msgstr "பிடிப்புப் பலகையை திறப்பதில் தோல்வி."
+
+#: ../src/msw/clipbrd.cpp:101
+msgid "Failed to close the clipboard."
+msgstr "பிடிப்புப் பலகையை மூடுவதில் தோல்வி."
+
+#: ../src/msw/clipbrd.cpp:113
+msgid "Failed to empty the clipboard."
+msgstr "பிடிப்புப் பலகையை வெற்றாக்குவதில் தோல்வி."
+
+#: ../src/msw/clipbrd.cpp:284
+msgid "Failed to put data on the clipboard"
+msgstr "பிடிப்புப் பலகையில் தரவினை வைப்பதில் தோல்வி"
+
+#: ../src/msw/clipbrd.cpp:326
+msgid "Failed to get data from the clipboard"
+msgstr "பிடிப்புப் பலகையிலிருந்து தரவினை பெறுவதில் தோல்வி"
+
+#: ../src/msw/clipbrd.cpp:363
+msgid "Failed to retrieve the supported clipboard formats"
+msgstr "ஆதரவளிக்கப்படும் பிடிப்புப் பலகை வடிவூட்டங்களை மீட்டெடுப்பதில் தோல்வி"
+
+#: ../src/msw/colordlg.cpp:228
+#, c-format
+msgid "Colour selection dialog failed with error %0lx."
+msgstr "நிறத் தெரிவு உரையாடல் தோல்வியடைந்தது. பிழை: %0lx."
+
+#: ../src/msw/cursor.cpp:141
+msgid "Failed to create cursor."
+msgstr "சுட்டியை உருவாக்குவதில் தோல்வி."
+
+#: ../src/msw/dde.cpp:279
+#, c-format
+msgid "Failed to register DDE server '%s'"
+msgstr "'%s' DDE வழங்கியைப் பதிவு செய்வதில் தோல்வி"
+
+#: ../src/msw/dde.cpp:300
+#, c-format
+msgid "Failed to unregister DDE server '%s'"
+msgstr "'%s' DDE வழங்கியைப் பதிவுநீக்கம் செய்வதில் தோல்வி"
+
+#: ../src/msw/dde.cpp:428
+#, c-format
+msgid "Failed to create connection to server '%s' on topic '%s'"
+msgstr "'%s' வழங்கியுடன் '%s' தலைப்பில் இணைவதில் தோல்வி."
+
+#: ../src/msw/dde.cpp:655
+msgid "DDE poke request failed"
+msgstr "DDE poke வேண்டுகோள் தோல்வியடைந்தது"
+
+#: ../src/msw/dde.cpp:674
+msgid "Failed to establish an advise loop with DDE server"
+msgstr "DDE வழங்கியுடன் அறிவுறுத்தல் வளையத்தை நிலைநாட்டுவதில் தோல்வி"
+
+#: ../src/msw/dde.cpp:693
+msgid "Failed to terminate the advise loop with DDE server"
+msgstr "DDE வழங்கியுடனான அறிவுறுத்தல் வளையத்தை முடிவிற்குக் கொண்டுவருவதில் தோல்வி"
+
+#: ../src/msw/dde.cpp:768
+msgid "Failed to send DDE advise notification"
+msgstr "DDE அறிவுறுத்தல் அறிவிக்கையை அனுப்புவதில் தோல்வி"
+
+#: ../src/msw/dde.cpp:1085
+msgid "Failed to create DDE string"
+msgstr "DDE சரத்தை உருவாக்குவதில் தோல்வி."
+
+#: ../src/msw/dde.cpp:1131
+msgid "no DDE error."
+msgstr "DDE பிழை ஏதுமில்லை."
+
+#: ../src/msw/dde.cpp:1135
+msgid "a request for a synchronous advise transaction has timed out."
+msgstr "ஒத்திசைவு அறிவுறுத்தல் பரிமாற்றத்திற்கான கோரிக்கை காலாவதியாகிவிட்டது."
+
+#: ../src/msw/dde.cpp:1138
+msgid "the response to the transaction caused the DDE_FBUSY bit to be set."
+msgstr "பரிமாற்றத்திற்கான மறுமொழி, DDE_FBUSY நுண்மியை  அமைக்கச் செய்தது."
+
+#: ../src/msw/dde.cpp:1141
+msgid "a request for a synchronous data transaction has timed out."
+msgstr "ஒத்திசைவுத் தரவு பரிமாற்றத்திற்கான கோரிக்கை காலாவதியாகிவிட்டது"
+
+#: ../src/msw/dde.cpp:1144
+msgid ""
+"a DDEML function was called without first calling the DdeInitialize "
+"function,\n"
+"or an invalid instance identifier\n"
+"was passed to a DDEML function."
+msgstr ""
+"DdeInitialize செயலை முதலில் அழைக்காமல், ஒரு DDEML செயல் அழைக்கப்பட்டது,\n"
+"அள்ளது ஒரு செல்லாத நிகழ்வு இநங்காட்டி\n"
+"ஒரு DDEML செயலுக்கு அனுப்பி வைக்கப்பட்டது."
+
+#: ../src/msw/dde.cpp:1147
+msgid ""
+"an application initialized as APPCLASS_MONITOR has\n"
+"attempted to perform a DDE transaction,\n"
+"or an application initialized as APPCMD_CLIENTONLY has \n"
+"attempted to perform server transactions."
+msgstr ""
+"APPCLASS_MONITOR என்று தொடக்கநிலையாக்கப்பட்ட ஒரு செயலி\n"
+"ஒரு DDE பரிமாற்றத்தை மேற்கொள்ள முயன்றுள்ளது,\n"
+"அல்லது APPCMD_CLIENTONLY என்று தொடக்கநிலையாக்கப்பட்ட ஒரு செயலி\n"
+"வழங்கியின் பரிமாற்றங்களை மேற்கொள்ள முயன்றுள்ளது."
+
+#: ../src/msw/dde.cpp:1150
+msgid "a request for a synchronous execute transaction has timed out."
+msgstr "ஒத்திசைவு செயற்படுத்து பரிமாற்றத்திற்கான கோரிக்கை காலாவதியாகிவிட்டது"
+
+#: ../src/msw/dde.cpp:1153
+msgid "a parameter failed to be validated by the DDEML."
+msgstr "ஒரு அளவுரு DDEML-னால் சரிபார்க்கப்படுவது தோல்வியடைந்தது."
+
+#: ../src/msw/dde.cpp:1156
+msgid "a DDEML application has created a prolonged race condition."
+msgstr "ஒரு DDEML செயலி நீட்டிக்கப்பட்ட போட்டி நிலையை உருவாக்கியுள்ளது."
+
+#: ../src/msw/dde.cpp:1159
+msgid "a memory allocation failed."
+msgstr "நினைவக ஒதுக்கீடு தோல்வியடைந்தது"
+
+#: ../src/msw/dde.cpp:1162
+msgid "a client's attempt to establish a conversation has failed."
+msgstr "ஒரு உரையாடலை நிலைநாட்டும் வாங்கியின் முயற்சி தோல்வியடைந்துள்ளது."
+
+#: ../src/msw/dde.cpp:1165
+msgid "a transaction failed."
+msgstr "ஒரு பரிமாற்றம் தோல்வியடைந்தது."
+
+#: ../src/msw/dde.cpp:1168
+msgid "a request for a synchronous poke transaction has timed out."
+msgstr "ஒத்திசைவு poke பரிமாற்றத்திற்கான கோரிக்கை காலாவதியாகிவிட்டது"
+
+#: ../src/msw/dde.cpp:1171
+msgid "an internal call to the PostMessage function has failed. "
+msgstr "PostMessage செயற்பாட்டிற்கான உள்ளழைப்பு தோல்வியடைந்துள்ளது."
+
+#: ../src/msw/dde.cpp:1174
+msgid "reentrancy problem."
+msgstr "மீள்நுழைவுச் சிக்கல்"
+
+#: ../src/msw/dde.cpp:1177
+msgid ""
+"a server-side transaction was attempted on a conversation\n"
+"that was terminated by the client, or the server\n"
+"terminated before completing a transaction."
+msgstr ""
+"ஒரு உரையாடலின் மீது வழங்கியின் தரப்பிலிருந்து ஒரு பரிமாற்ற முயற்சி மேற்கொள்லப்பட்டது.\n"
+"ஆனால், அதை வழங்கியோ, வாங்கியோ முடிவிற்கு கொண்டு வந்துவிட்டது\n"
+"பரிமாற்றம் நிறைவடையும் முன் முடிக்கப்பட்டது."
+
+#: ../src/msw/dde.cpp:1180
+msgid "an internal error has occurred in the DDEML."
+msgstr "DDEML-ல் ஒரு உட்பிழை ஏற்பட்டுள்ளது."
+
+#: ../src/msw/dde.cpp:1183
+msgid "a request to end an advise transaction has timed out."
+msgstr "ஒரு அறிவுறுத்தல் பரிமாற்றத்தை முடிப்பதற்கான கோரிக்கை காலாவதியாகிவிட்டது"
+
+#: ../src/msw/dde.cpp:1186
+msgid ""
+"an invalid transaction identifier was passed to a DDEML function.\n"
+"Once the application has returned from an XTYP_XACT_COMPLETE callback,\n"
+"the transaction identifier for that callback is no longer valid."
+msgstr ""
+"செல்லாத பரிமாற்ற அடையாளங்காட்டி ஒரு DDEML செயற்பாட்டிற்கு அனுப்பி வைக்கப்பட்டுள்ளது.\n"
+"XTYP_XACT_COMPLETE திரும்ப அழைத்தலிலிருந்து செயலி திரும்பிய பின்,\n"
+"அந்த திரும்ப அழைத்தலுக்கான பரிமாற்ற அடையாளங்காட்டி இனிமேல் செல்லத்தக்கதாக இருக்காது."
+
+#: ../src/msw/dde.cpp:1189
+#, c-format
+msgid "Unknown DDE error %08x"
+msgstr "அறியப்படாத DDE பிழை %08x"
+
+#: ../src/msw/dialup.cpp:343
+msgid ""
+"Dial up functions are unavailable because the remote access service (RAS) is "
+"not installed on this machine. Please install it."
+msgstr ""
+"தொலைநிலை அணுகல் பணி (RAS) இக்கணினியில் நிறுவப்படவில்லையென்பதால், சுழல் செயல்கள் இல்லாமல் "
+"உள்ளன. அருள்கூர்ந்து RAS-ஐ நிறுவவும்."
+
+#: ../src/msw/dialup.cpp:402
+#, c-format
+msgid ""
+"The version of remote access service (RAS) installed on this machine is too "
+"old, please upgrade (the following required function is missing: %s)."
+msgstr ""
+"இக்கணினியில் நிறுவப்பட்டுள்ள தொலைநிலை அணுகல் பணி (RAS) பதிப்பு மிகப் பழையதாக உள்ளது, "
+"அருள்கூர்ந்து மேம்படுத்தவும்  (பின்வரும் தேவையான செயல் தவறவிடப்பட்டுள்ளது: %s)."
+
+#: ../src/msw/dialup.cpp:437
+msgid "Failed to retrieve text of RAS error message"
+msgstr "RAS பிழையின் உரையை மீட்டெடுப்பதில் தோல்வி."
+
+#: ../src/msw/dialup.cpp:440
+#, c-format
+msgid "unknown error (error code %08x)."
+msgstr "அறியப்படாத பிழை (பிழைக் குறி %08x)."
+
+#: ../src/msw/dialup.cpp:492
+#, c-format
+msgid "Cannot find active dialup connection: %s"
+msgstr "செயலில் இருக்கும் சுழல் இணைப்பைக் கண்டறிய இயலவில்லை: %s"
+
+#: ../src/msw/dialup.cpp:513
+msgid "Several active dialup connections found, choosing one randomly."
+msgstr "பல சுழல் இணைப்புகள் செயலில் உள்ளன, குறிப்பின்றி ஒன்று தேர்ந்தெடுக்கப்படுகிறது."
+
+#: ../src/msw/dialup.cpp:598 ../src/msw/dialup.cpp:832
+#, c-format
+msgid "Failed to establish dialup connection: %s"
+msgstr "சுழல் இணைப்பினை நிலைநாட்டுவதில் தோல்வி: %s"
+
+#: ../src/msw/dialup.cpp:664
+#, c-format
+msgid "Failed to get ISP names: %s"
+msgstr "இணையப் பணி வழங்குவோர் (ISP) பெயர்களை பெறுவதில் தோல்வி: %s"
+
+#: ../src/msw/dialup.cpp:712
+msgid "Failed to connect: no ISP to dial."
+msgstr "இணைப்பதில் தோல்வி: சுழற்ற ISP ஏதுமில்லை."
+
+#: ../src/msw/dialup.cpp:732
+msgid "Choose ISP to dial"
+msgstr "சுழற்றுவதற்கு ISP-யினை தேர்ந்தெடுக்கவும்"
+
+#: ../src/msw/dialup.cpp:733
+msgid "Please choose which ISP do you want to connect to"
+msgstr "எந்த ISP-யுடன் இணைப்பை உருவாக்க வேண்டுமென்றுத் தேர்ந்தெடுக்கவும்"
+
+#: ../src/msw/dialup.cpp:766
+msgid "Failed to connect: missing username/password."
+msgstr "இணைப்பதில் தோல்வி: பயனர் பெயர்/கடவுச்சொல் தவற விடப்பட்டுள்ளது"
+
+#: ../src/msw/dialup.cpp:796
+msgid "Cannot find the location of address book file"
+msgstr "முகவரி நூல் கோப்பின் இருப்பிடத்தை காண இயலவில்லை"
+
+#: ../src/msw/dialup.cpp:827
+#, c-format
+msgid "Failed to initiate dialup connection: %s"
+msgstr "சுழல் இணைப்பினைத் தொடக்கநிலையாக்குவதில் தோல்வி: %s"
+
+#: ../src/msw/dialup.cpp:897
+msgid "Cannot hang up - no active dialup connection."
+msgstr "துண்டிக்க இயலவில்லை - செயலில் உள்ள சுழல் இணைப்பு ஏதுமில்லை"
+
+#: ../src/msw/dialup.cpp:907
+#, c-format
+msgid "Failed to terminate the dialup connection: %s"
+msgstr "சுழல் இணைப்பினை துண்டிப்பதில் தோல்வி: %s"
+
+#: ../src/msw/dib.cpp:313
+#, c-format
+msgid "Failed to save the bitmap image to file \"%s\"."
+msgstr "நுண்பட படிமத்தை \"%s\" கோப்பினில் சேமிப்பதில் தோல்வி."
+
+#: ../src/msw/dib.cpp:543
+#, c-format
+msgid "Failed to allocate %luKb of memory for bitmap data."
+msgstr "நுண்பட தரவிற்கு நினைவுத் திறன் %luKb ஒதுக்கீடு செய்வதில் தோல்வி."
+
+#: ../src/msw/dir.cpp:241
+#, c-format
+msgid "Cannot enumerate files in directory '%s'"
+msgstr "'%s' அடைவில் இருக்கும் கோப்புகளை பட்டியலிட இயலவில்லை"
+
+#: ../src/msw/dirdlg.cpp:368
+msgid "Couldn't obtain folder name"
+msgstr "கோப்புறையின் பெயரை பெற இயலவில்லை"
+
+#: ../src/msw/dlmsw.cpp:163
+#, c-format
+msgid "(error %d: %s)"
+msgstr "(பிழை %d: %s)"
+
+#: ../src/msw/dragimag.cpp:143 ../src/msw/dragimag.cpp:178
+#: ../src/msw/imaglist.cpp:309 ../src/msw/imaglist.cpp:331
+msgid "Couldn't add an image to the image list."
+msgstr "படிமங்களின் வரிசைப் பட்டியலில் ஒரு படிமத்தை சேர்க்க இயலவில்லை."
+
+#: ../src/msw/enhmeta.cpp:94
+#, c-format
+msgid "Failed to load metafile from file \"%s\"."
+msgstr "\"%s\" கோப்பிலிருந்து meta கோப்பினை ஏற்றுவதில் தோல்வி."
+
+#: ../src/msw/fdrepdlg.cpp:412
+#, c-format
+msgid "Failed to create the standard find/replace dialog (error code %d)"
+msgstr "தரநிலை கண்டறிக/மாற்றமர்வு உரையாடலை உருவாக்குவதில் தோல்வி. (பிழைக் குறி %d)"
+
+#: ../src/msw/filedlg.cpp:1241
+msgid "Access to the file system is not allowed from secure desktop."
+msgstr "பாதுகாப்பான மேசைத்தளத்திலிருந்து கோப்பு முறைமையை அணுகுவதற்கு அனுமதியில்லை."
+
+#: ../src/msw/filedlg.cpp:1242
+msgid "Security warning"
+msgstr "பாதுகாப்பு எச்சரிக்கை"
+
+#: ../src/msw/filedlg.cpp:1533
+#, c-format
+msgid "File dialog failed with error code %0lx."
+msgstr "கோப்பு உரையாடல் தோல்வியடைந்தது. பிழைக் குறி %0lx."
+
+#: ../src/msw/font.cpp:1120
+#, c-format
+msgid "Font file \"%s\" couldn't be loaded"
+msgstr "\"%s\" எழுத்துருக் கோப்பினை ஏற்ற இயலவில்லை"
+
+#: ../src/msw/fontdlg.cpp:220
+#, c-format
+msgid "Common dialog failed with error code %0lx."
+msgstr "பொது உரையாடல் தோல்வியடைந்தது. பிழைக் குறி: %0lx."
+
+#: ../src/msw/fswatcher.cpp:67
+msgid "Ungraceful worker thread termination"
+msgstr "சீரில்லாப் பணியிழை நிறுத்தம்"
+
+#: ../src/msw/fswatcher.cpp:81
+msgid "Unable to create IOCP worker thread"
+msgstr "IOCP பணியிழையை உருவாக்க இயலவில்லை"
+
+#: ../src/msw/fswatcher.cpp:88
+msgid "Unable to start IOCP worker thread"
+msgstr "IOCP பணியிழையைத் துவக்க இயலவில்லை"
+
+#: ../src/msw/fswatcher.cpp:140
+msgid "Monitoring individual files for changes is not supported currently."
+msgstr ""
+"மாற்றங்களை கண்டறிய கோப்புகளை தனித் தனியாக கண்காணிக்கும் வசதிக்கு தற்போதைக்கு ஆதரவில்லை."
+
+#: ../src/msw/fswatcher.cpp:165
+#, c-format
+msgid "Unable to set up watch for '%s'"
+msgstr "'%s'-ற்கான கண்காணிப்பை அமைக்க இயலவில்லை"
+
+#: ../src/msw/fswatcher.cpp:466
+#, c-format
+msgid "Can't monitor non-existent directory \"%s\" for changes."
+msgstr "இல்லாத \"%s\" அடைவினை மாற்றங்களுக்காக கண்காணிக்க இயலாது"
+
+#: ../src/msw/glcanvas.cpp:577 ../src/unix/glx11.cpp:507
+msgid "OpenGL 3.0 or later is not supported by the OpenGL driver."
+msgstr "OpenGL 3.0, அல்லது அதற்கும் பிறகான பதிப்புகளை OpenGL இயக்கி ஆதரிப்பதில்லை."
+
+#: ../src/msw/glcanvas.cpp:601 ../src/osx/glcanvas_osx.cpp:395
+#: ../src/unix/glegl.cpp:304 ../src/unix/glx11.cpp:553
+msgid "Couldn't create OpenGL context"
+msgstr "OpenGL சூழலமைவை உருவாக்க இயலவில்லை"
+
+#: ../src/msw/glcanvas.cpp:1294
+msgid "Failed to initialize OpenGL"
+msgstr "OpenGL தொடக்கநிலையாக்குவதில் தோல்வி"
+
+#: ../src/msw/graphicsd2d.cpp:607
+msgid "Could not register custom DirectWrite font loader."
+msgstr "தனிப்பயனாக்கப்பட்ட DirectWrite எழுத்துரு ஏற்றியைப் பதிவிட இயலவில்லை."
+
+#: ../src/msw/helpchm.cpp:48
+msgid ""
+"MS HTML Help functions are unavailable because the MS HTML Help library is "
+"not installed on this machine. Please install it."
+msgstr ""
+"இக்கணினியில் MS HTML உதவி நூலகம்  நிறுவப்படாததால், MS HTML உதவி செயல்கள் பயன்பாட்டில் "
+"இல்லை. அருள்கூர்ந்து அதை நிறுவவும்."
+
+#: ../src/msw/helpchm.cpp:55
+msgid "Failed to initialize MS HTML Help."
+msgstr "MS HTML உதவியை தொடக்கநிலையாக்குவதில் தோல்வி."
+
+#: ../src/msw/iniconf.cpp:458
+#, c-format
+msgid "Can't delete the INI file '%s'"
+msgstr "'%s' INI கோப்பினை அழிக்க இயலவில்லை"
+
+#: ../src/msw/listctrl.cpp:995
+#, c-format
+msgid "Couldn't retrieve information about list control item %d."
+msgstr "%d வரிசைப்பட்டியல் கட்டுப்பாடு உருப்படியின் தகவலை மீட்க இயலவில்லை."
+
+#: ../src/msw/mdi.cpp:170 ../src/qt/mdi.cpp:253
+msgid "&Cascade"
+msgstr "அடுக்குக (&C)"
+
+#: ../src/msw/mdi.cpp:171
+msgid "Tile &Horizontally"
+msgstr "கிடையாக அடுக்குக (&H)"
+
+#: ../src/msw/mdi.cpp:172
+msgid "Tile &Vertically"
+msgstr "செங்குத்தாக அடுக்குக (&V)"
+
+#: ../src/msw/mdi.cpp:174
+msgid "&Arrange Icons"
+msgstr "படவுருக்களை ஒழுங்கமைத்திடுக (&A)"
+
+#: ../src/msw/mdi.cpp:621
+msgid "Failed to create MDI parent frame."
+msgstr "MDI தாய்ச் சட்டகத்தை உருவாக்குவதில் தோல்வி."
+
+#: ../src/msw/mimetype.cpp:234
+#, c-format
+msgid "Failed to create registry entry for '%s' files."
+msgstr "'%s' கோப்புகளுக்கு பதிப்பக உள்ளீட்டினை உருவாக்குவதில் தோல்வி."
+
+#: ../src/msw/ole/automtn.cpp:495
+#, c-format
+msgid "Failed to find CLSID of \"%s\""
+msgstr "\"%s\"-இன் CLSID கண்டறிவதில் தோல்வி"
+
+#: ../src/msw/ole/automtn.cpp:512
+#, c-format
+msgid "Failed to create an instance of \"%s\""
+msgstr "\"%s\"-இன் ஒரு நிகழ்வை உருவாக்குவதில் தோல்வி"
+
+#: ../src/msw/ole/automtn.cpp:552
+#, c-format
+msgid "Cannot get an active instance of \"%s\""
+msgstr "\"%s\"-இன் ஒரு செயல் நிகழ்வை பெற இயலவில்லை"
+
+#: ../src/msw/ole/automtn.cpp:564
+#, c-format
+msgid "Failed to get OLE automation interface for \"%s\""
+msgstr "\"%s\"-ற்காக OLE தானியங்கியைப் பெறுவதில் தோல்வி"
+
+#: ../src/msw/ole/automtn.cpp:621
+msgid "Unknown name or named argument."
+msgstr "அறியப்படாத பெயர் அல்லது பெயரிடப்பட்ட துணையலகு"
+
+#: ../src/msw/ole/automtn.cpp:625
+msgid "Incorrect number of arguments."
+msgstr "துணையலகுகளின் தவறான எண்ணிக்கை."
+
+#: ../src/msw/ole/automtn.cpp:637
+msgid "Unknown exception"
+msgstr "அறியப்படாத விலக்கு"
+
+#: ../src/msw/ole/automtn.cpp:642
+msgid "Method or property not found."
+msgstr "செயல்முறை அல்லது பண்பு காணப்படவில்லை."
+
+#: ../src/msw/ole/automtn.cpp:646
+msgid "Overflow while coercing argument values."
+msgstr "மதிப்புருக்களை வலுக்கட்டாயமாக மாற்றும் போது வழிதல்"
+
+#: ../src/msw/ole/automtn.cpp:650
+msgid "Object implementation does not support named arguments."
+msgstr "பெயருள்ள மதிப்புருக்களை பொருள் செயலாக்கம் ஆதரிக்கவில்லை."
+
+#: ../src/msw/ole/automtn.cpp:654
+msgid "The locale ID is unknown."
+msgstr "வட்டார அடையாளங்காட்டி அறியப்படவில்லை."
+
+#: ../src/msw/ole/automtn.cpp:658
+msgid "Missing a required parameter."
+msgstr "தேவைப்படும் ஒரு அளவுரு தவறவிடப்பட்டுள்ளது."
+
+#: ../src/msw/ole/automtn.cpp:662
+#, c-format
+msgid "Argument %u not found."
+msgstr "மதிப்புரு %u காணப்படவில்லை."
+
+#: ../src/msw/ole/automtn.cpp:666
+#, c-format
+msgid "Type mismatch in argument %u."
+msgstr "%u மதிப்புருவில் வகைப் பொருத்தமின்மை."
+
+#: ../src/msw/ole/automtn.cpp:670
+msgid "The system cannot find the file specified."
+msgstr "குறிப்பிட்ட கோப்பினை கணினியால் கண்டறிய இயலவில்லை."
+
+#: ../src/msw/ole/automtn.cpp:674
+msgid "Class not registered."
+msgstr "வகுப்பு பதியப்படவில்லை."
+
+#: ../src/msw/ole/automtn.cpp:678
+#, c-format
+msgid "Unknown error %08x"
+msgstr "அறியப்படாத பிழை %08x"
+
+#: ../src/msw/ole/automtn.cpp:682
+#, c-format
+msgid "OLE Automation error in %s: %s"
+msgstr "%s-ல் OLE தானியங்குப் பிழை: %s"
+
+#: ../src/msw/ole/dataobj.cpp:385
+#, c-format
+msgid "Couldn't register clipboard format '%s'."
+msgstr "'%s' பிடிப்புப் பலகை வடிவூட்டத்தை பதிவிட இயலவில்லை."
+
+#: ../src/msw/ole/dataobj.cpp:402
+#, c-format
+msgid "The clipboard format '%d' doesn't exist."
+msgstr "பிடிப்புப் பலகை வடிவூட்டம் '%d' இல்லை."
+
+#: ../src/msw/progdlg.cpp:1025
+msgid "Skip"
+msgstr "தவிர்"
+
+#: ../src/msw/registry.cpp:141
+#, c-format
+msgid "unknown (%lu)"
+msgstr "அறியப்படாதது (%lu)"
+
+#: ../src/msw/registry.cpp:409
+#, c-format
+msgid "Can't get info about registry key '%s'"
+msgstr "'%s' பதிவக விசையின் தகவலைப் பெற இயலவில்லை"
+
+#: ../src/msw/registry.cpp:445
+#, c-format
+msgid "Can't open registry key '%s'"
+msgstr "'%s' பதிவக விசையைத் திறக்க இயலவில்லை "
+
+#: ../src/msw/registry.cpp:478
+#, c-format
+msgid "Can't create registry key '%s'"
+msgstr "'%s' பதிவக விசையை உருவாக்க இயலவில்லை"
+
+#: ../src/msw/registry.cpp:497
+#, c-format
+msgid "Can't close registry key '%s'"
+msgstr "'%s' பதிவக விசையை மூட இயலவில்லை"
+
+#: ../src/msw/registry.cpp:512
+#, c-format
+msgid "Registry value '%s' already exists."
+msgstr "'%s' பதிவக மதிப்பு ஏற்கனவே உள்ளது."
+
+#: ../src/msw/registry.cpp:520
+#, c-format
+msgid "Failed to rename registry value '%s' to '%s'."
+msgstr "'%s' பதிவக மதிப்பினை '%s' என்றுப் பெயர் மாற்றுவதில் தோல்வி."
+
+#: ../src/msw/registry.cpp:575
+#, c-format
+msgid "Can't copy values of unsupported type %d."
+msgstr "ஆதரவளிக்கப்படாத வகை %d-யின் மதிப்பை படியெடுக்க இயலவில்லை."
+
+#: ../src/msw/registry.cpp:586
+#, c-format
+msgid "Registry key '%s' does not exist, cannot rename it."
+msgstr "'%s' பதிவக விசை இல்லை, அதை மறுபெயரிட இயலாது."
+
+#: ../src/msw/registry.cpp:617
+#, c-format
+msgid "Registry key '%s' already exists."
+msgstr "'%s' பதிவக விசை ஏற்கனவே உள்ளது."
+
+#: ../src/msw/registry.cpp:625
+#, c-format
+msgid "Failed to rename the registry key '%s' to '%s'."
+msgstr "'%s' பதிவக விசையை '%s' என்றுப் பெயர் மாற்றுவதில் தோல்வி."
+
+#: ../src/msw/registry.cpp:670
+#, c-format
+msgid "Failed to copy the registry subkey '%s' to '%s'."
+msgstr "'%s' பதிப்பக துணைவிசையை '%s'-க்கு படியெடுப்பதில் தோல்வி."
+
+#: ../src/msw/registry.cpp:683
+#, c-format
+msgid "Failed to copy registry value '%s'"
+msgstr "'%s' பதிப்பக மதிப்பை படியெடுப்பதில் தோல்வி."
+
+#: ../src/msw/registry.cpp:692
+#, c-format
+msgid "Failed to copy the contents of registry key '%s' to '%s'."
+msgstr "'%s' பதிப்பக விசை உள்ளடக்கங்களை '%s'-க்கு படியெடுப்பதில் தோல்வி."
+
+#: ../src/msw/registry.cpp:718
+#, c-format
+msgid ""
+"Registry key '%s' is needed for normal system operation,\n"
+"deleting it will leave your system in unusable state:\n"
+"operation aborted."
+msgstr ""
+"இயல்பான கணினி செயல்பாட்டிற்கு '%s' பதிவக விசை தேவைப்படுகிறது,\n"
+"இதை அழித்துவிட்டால், தங்களின் கணினி பயன்படுத்தப்பட இயலாத நிலைக்கு தள்ளப்படும்:\n"
+"நடவடிக்கை இடைமறிக்கப்படுகிறது."
+
+#: ../src/msw/registry.cpp:754
+#, c-format
+msgid "Can't delete key '%s'"
+msgstr "'%s' விசையினை அழிக்க இயலவில்லை"
+
+#: ../src/msw/registry.cpp:782
+#, c-format
+msgid "Can't delete value '%s' from key '%s'"
+msgstr "'%s\" மதிப்பை '%s' விசையிலிருந்து அழிக்க இயலவில்லை"
+
+#: ../src/msw/registry.cpp:855 ../src/msw/registry.cpp:887
+#: ../src/msw/registry.cpp:929 ../src/msw/registry.cpp:1000
+#, c-format
+msgid "Can't read value of key '%s'"
+msgstr "'%s' விசையின் மதிப்பை படிக்க இயலவில்லை"
+
+#: ../src/msw/registry.cpp:873 ../src/msw/registry.cpp:915
+#: ../src/msw/registry.cpp:963 ../src/msw/registry.cpp:1106
+#, c-format
+msgid "Can't set value of '%s'"
+msgstr "'%s'-இன் மதிப்பை அமைக்க இயலவில்லை"
+
+#: ../src/msw/registry.cpp:894 ../src/msw/registry.cpp:943
+#, c-format
+msgid "Registry value \"%s\" is not numeric (but of type %s)"
+msgstr "\"%s\" பதிப்பக மதிப்பு எண்ணாக இல்லை (ஆனால், %s வகையாக உள்ளது)"
+
+#: ../src/msw/registry.cpp:979
+#, c-format
+msgid "Registry value \"%s\" is not binary (but of type %s)"
+msgstr "பதிப்பக மதிப்பு \"%s\" இருமமாக இல்லை (ஆனால், %s வகையாக உள்ளது)"
+
+#: ../src/msw/registry.cpp:1028
+#, c-format
+msgid "Registry value \"%s\" is not text (but of type %s)"
+msgstr "\"%s\" பதிப்பக மதிப்பு உரையாக இல்லை (ஆனால், %s வகையாக உள்ளது)"
+
+#: ../src/msw/registry.cpp:1089
+#, c-format
+msgid "Can't read value of '%s'"
+msgstr "'%s'-இன் மதிப்பை படிக்க இயலவில்லை"
+
+#: ../src/msw/registry.cpp:1157
+#, c-format
+msgid "Can't enumerate values of key '%s'"
+msgstr "விசை '%s'-ன் மதிப்புகளைப் பட்டியலிட இயலவில்லை"
+
+#: ../src/msw/registry.cpp:1196
+#, c-format
+msgid "Can't enumerate subkeys of key '%s'"
+msgstr "'%s' விசையின் துணைவிசைகளைப் பட்டியலிட இயலவில்லை"
+
+#: ../src/msw/registry.cpp:1262
+#, c-format
+msgid ""
+"Exporting registry key: file \"%s\" already exists and won't be overwritten."
+msgstr ""
+"பதிப்பக விசை ஏற்றுமதி செய்யப்படுகிறது: \"%s\" கோப்பு ஏற்கனவே உள்ளது; அது "
+"அழித்தெழுதப்பட மாட்டாது."
+
+#: ../src/msw/registry.cpp:1411
+#, c-format
+msgid "Can't export value of unsupported type %d."
+msgstr "ஆதரவளிக்கப்படாத %d வகையின் மதிப்பை ஏற்றுமதி செய்ய இயலவில்லை."
+
+#: ../src/msw/registry.cpp:1427
+#, c-format
+msgid "Ignoring value \"%s\" of the key \"%s\"."
+msgstr "மதிப்பு \"%s\" (\"%s\" விசையினுடையது) புறந்தள்ளப்படுகிறது."
+
+#: ../src/msw/textctrl.cpp:596
+msgid ""
+"Impossible to create a rich edit control, using simple text control instead. "
+"Please reinstall riched32.dll"
+msgstr ""
+"செரிவூட்டப்பட்ட தொகு கட்டுப்பாட்டை உருவாக்க இயலாமையால், எளிய உரைக் கட்டுப்பாடு "
+"பயன்படுத்தப்படுகிறது. riched32.dll நிரலை மறுநிறுவு செய்யவும்."
+
+#: ../src/msw/thread.cpp:522 ../src/unix/threadpsx.cpp:850
+msgid "Cannot start thread: error writing TLS."
+msgstr "இழையைத் துவக்க இயலவில்லை: TLS எழுதுவதில் பிழை "
+
+#: ../src/msw/thread.cpp:613
+msgid "Can't set thread priority"
+msgstr "இழையின் முன்னுரிமையை அமைக்க இயலவில்லை"
+
+#: ../src/msw/thread.cpp:649
+msgid "Can't create thread"
+msgstr "இழையினை உருவாக்க இயலவில்லை"
+
+#: ../src/msw/thread.cpp:668
+msgid "Couldn't terminate thread"
+msgstr "இழையை நிறுத்த இயலவில்லை."
+
+#: ../src/msw/thread.cpp:799
+msgid "Cannot wait for thread termination"
+msgstr "இழை நிறுத்தலுக்கு காத்திருக்க இயலாது"
+
+#: ../src/msw/thread.cpp:873
+#, c-format
+msgid "Cannot suspend thread %lx"
+msgstr "%lx இழையை இடைநிறுத்த இயலவில்லை"
+
+#: ../src/msw/thread.cpp:903
+#, c-format
+msgid "Cannot resume thread %lx"
+msgstr "%lx இழையை மீண்டும் தொடர இயலவில்லை"
+
+#: ../src/msw/thread.cpp:932
+msgid "Couldn't get the current thread pointer"
+msgstr "தற்போதைய தற்போதைய இழைச்சுட்டியைப் பெற இயலவில்லை."
+
+#: ../src/msw/thread.cpp:1333
+msgid ""
+"Thread module initialization failed: impossible to allocate index in thread "
+"local storage"
+msgstr ""
+"இழை நிரற்கூறை தொடக்கநிலையாக்குவதில் தோல்வி: இழையின் உள்ளக சேமிப்பகத்தில் சுட்டெண்ணை "
+"ஒதுக்கீடு செய்ய இயலவில்லை."
+
+#: ../src/msw/thread.cpp:1345
+msgid ""
+"Thread module initialization failed: cannot store value in thread local "
+"storage"
+msgstr ""
+"இழை நிரற்கூறை தொடக்கநிலையாக்குவதில் தோல்வி: உள்ளக இழை சேமிப்பகத்தில் மதிப்பை சேமிக்க "
+"இயலவில்லை"
+
+#: ../src/msw/timer.cpp:133
+msgid "Couldn't create a timer"
+msgstr "நேரங்காட்டியை உருவாக்க இயலவில்லை."
+
+#: ../src/msw/utils.cpp:372
+msgid "can't find user's HOME, using current directory."
+msgstr "பயனரின் முகப்பு அடைவைக் கண்டறிய இயலவில்லை. நடப்பு அடைவு பயன்படுத்தப்படுகிறது."
+
+#: ../src/msw/utils.cpp:662
+#, c-format
+msgid "Failed to kill process %d"
+msgstr "%d செயல்முறையை முறிப்பதில் தோல்வி"
+
+#: ../src/msw/utils.cpp:986
+#, c-format
+msgid "Failed to load resource \"%s\"."
+msgstr "\"%s\" வளத்தை ஏற்றுவதில் தோல்வி."
+
+#: ../src/msw/utils.cpp:993
+#, c-format
+msgid "Failed to lock resource \"%s\"."
+msgstr "\"%s\" வளத்தை பூட்டுவதில் தோல்வி."
+
+#. TRANSLATORS: MS Windows build number
+#: ../src/msw/utils.cpp:1209
+#, c-format
+msgid "build %lu"
+msgstr "கட்டமை %lu"
+
+#: ../src/msw/utils.cpp:1218
+msgid ", 64-bit edition"
+msgstr "64 நுண்மி பதிப்பு"
+
+#: ../src/msw/utilsexc.cpp:224
+msgid "Failed to create an anonymous pipe"
+msgstr "அனாமதேய குழாயை உருவாக்குவதில் தோல்வி"
+
+#: ../src/msw/utilsexc.cpp:697
+msgid "Failed to redirect the child process IO"
+msgstr "சேய் செயல்முறையின் உள்ளீடு/வெளியீட்டை வழிமாற்றுவதில் தோல்வி."
+
+#: ../src/msw/utilsexc.cpp:870
+#, c-format
+msgid "Execution of command '%s' failed"
+msgstr "'%s' கட்டளையின் செயலாக்கம் தோல்வியடைந்தது"
+
+#: ../src/msw/volume.cpp:337
+msgid "Failed to load mpr.dll."
+msgstr "mpr.dll ஏற்றுவதில் தோல்வி."
+
+#: ../src/msw/volume.cpp:506
+#, c-format
+msgid "Cannot read typename from '%s'!"
+msgstr "'%s'-இலிருந்து வகைப் பெயரை படிக்க இயலவில்லை!"
+
+#: ../src/msw/volume.cpp:615
+#, c-format
+msgid "Cannot load icon from '%s'."
+msgstr "'%s'-இருந்து படவுருவை ஏற்ற இயலவில்லை."
+
+#: ../src/msw/webview_edge.cpp:285
+msgid "This program was compiled without support for setting Edge proxy."
+msgstr "எட்ஜ் பினாமியை அமைப்பதற்கான ஆதரவில்லாமல் இந்நிரல் தொகுக்கப்பட்டுள்ளது."
+
+#: ../src/msw/webview_ie.cpp:1010
+msgid "Failed to find web view emulation level in the registry"
+msgstr "வலையத் தோற்றத்தின் ஒப்புருவாக்க நிலையை பதிவகத்தில் காண இயலவில்லை"
+
+#: ../src/msw/webview_ie.cpp:1019
+msgid "Failed to set web view to modern emulation level"
+msgstr "வலைத் தோற்றத்தை நவீன ஒப்புருவாக்க நிலைக்கு அமைக்க இயலவில்லை"
+
+#: ../src/msw/webview_ie.cpp:1027
+msgid "Failed to reset web view to standard emulation level"
+msgstr "வலைத் தோற்றத்தை தரநிலை ஒப்புருவாக்க நிலைக்கு அமைக்க இயலவில்லை"
+
+#: ../src/msw/webview_ie.cpp:1049
+msgid "Can't run JavaScript script without a valid HTML document"
+msgstr "செல்லத்தக்க HTML ஆவணமில்லாமல் JavaScript குறுநிரலை இயக்க இயலாது"
+
+#: ../src/msw/webview_ie.cpp:1056
+msgid "Can't get the JavaScript object"
+msgstr "JavaScript பொருளைப் பெற இயலவில்லை"
+
+#: ../src/msw/webview_ie.cpp:1070
+msgid "failed to evaluate"
+msgstr "மதிப்பிடுவதில் தோல்வி"
+
+#: ../src/osx/cocoa/filedlg.mm:412
+msgid "File type:"
+msgstr "கோப்பு வகை:"
+
+#: ../src/osx/cocoa/menu.mm:242
+msgctxt "macOS menu name"
+msgid "Window"
+msgstr "சாளரம்"
+
+#: ../src/osx/cocoa/menu.mm:259
+msgctxt "macOS menu name"
+msgid "Help"
+msgstr "உதவி"
+
+#: ../src/osx/cocoa/menu.mm:298
+msgctxt "macOS menu item"
+msgid "Minimize"
+msgstr "சிறிதாக்கிடுக"
+
+#: ../src/osx/cocoa/menu.mm:303
+msgctxt "macOS menu item"
+msgid "Zoom"
+msgstr "பெரிதாக்கிடுக"
+
+#: ../src/osx/cocoa/menu.mm:309
+msgctxt "macOS menu item"
+msgid "Bring All to Front"
+msgstr "அனைத்தையும் முன்கொண்டுவருக"
+
+#: ../src/osx/core/sound.cpp:143
+#, c-format
+msgid "Failed to load sound from \"%s\" (error %d)."
+msgstr "\"%s\" இருந்து ஒலியை ஏற்ற இயலவில்லை (பிழை %d)."
+
+#: ../src/osx/fontutil.cpp:80
+#, c-format
+msgid "Font file \"%s\" doesn't exist."
+msgstr "\"%s\" எழுத்துருக் கோப்பு கிடைப்பில் இல்லை"
+
+#: ../src/osx/fontutil.cpp:88
+#, c-format
+msgid ""
+"Font file \"%s\" cannot be used as it is not inside the font directory \"%s"
+"\"."
+msgstr ""
+"\"%s\" எழுத்துரு கோப்பினைப் பயன்படுத்த இயலாது. ஏனென்றால், \"%s\" எழுத்துரு அடைவில் "
+"அது இல்லை."
+
+#: ../src/osx/menu_osx.cpp:496
+#, c-format
+msgctxt "macOS menu item"
+msgid "About %s"
+msgstr "%s குறித்து"
+
+#: ../src/osx/menu_osx.cpp:499
+msgctxt "macOS menu item"
+msgid "About..."
+msgstr "குறித்து..."
+
+#: ../src/osx/menu_osx.cpp:508
+msgctxt "macOS menu item"
+msgid "Preferences..."
+msgstr "விருப்பங்கள்..."
+
+#: ../src/osx/menu_osx.cpp:512
+msgctxt "macOS menu item"
+msgid "Services"
+msgstr "பணிகள்"
+
+#: ../src/osx/menu_osx.cpp:519
+#, c-format
+msgctxt "macOS menu item"
+msgid "Hide %s"
+msgstr "%s-யினை மறைத்திடுக"
+
+#: ../src/osx/menu_osx.cpp:522
+msgctxt "macOS menu item"
+msgid "Hide Application"
+msgstr "பயன்பாட்டை மறைத்திடுக"
+
+#: ../src/osx/menu_osx.cpp:526
+msgctxt "macOS menu item"
+msgid "Hide Others"
+msgstr "பிறவற்றை மறைத்திடுக"
+
+#: ../src/osx/menu_osx.cpp:528
+msgctxt "macOS menu item"
+msgid "Show All"
+msgstr "அனைத்தையும் காட்டுக"
+
+#: ../src/osx/menu_osx.cpp:534
+#, c-format
+msgctxt "macOS menu item"
+msgid "Quit %s"
+msgstr "%s-ஐ விட்டு வெளியேறுக"
+
+#: ../src/osx/menu_osx.cpp:537
+msgctxt "macOS menu item"
+msgid "Quit Application"
+msgstr "பயன்பாட்டை விட்டு வெளியேறுக"
+
+#: ../src/osx/webview_webkit.mm:444
+msgid "Printing is not supported by the system web control"
+msgstr "அச்சிடுவதை கணினி வலைக் கட்டுப்பாடு ஆதரிப்பதில்லை"
+
+#: ../src/osx/webview_webkit.mm:453
+msgid "Print operation could not be initialized"
+msgstr "அச்சிடும் செயலைத் தொடக்கநிலையாக்க இயலவில்லை."
+
+#. TRANSLATORS: Label of font point size
+#: ../src/propgrid/advprops.cpp:605
+msgid "Point Size"
+msgstr "புள்ளியளவு"
+
+#. TRANSLATORS: Label of font face name
+#: ../src/propgrid/advprops.cpp:615
+msgid "Face Name"
+msgstr "எழுத்துருப் பெயர்"
+
+#. TRANSLATORS: Label of font style
+#: ../src/propgrid/advprops.cpp:623 ../src/richtext/richtextformatdlg.cpp:331
+msgid "Style"
+msgstr "பாங்கு"
+
+#. TRANSLATORS: Label of font weight
+#: ../src/propgrid/advprops.cpp:628
+msgid "Weight"
+msgstr "அடர்த்தி"
+
+#. TRANSLATORS: Label of underlined font
+#: ../src/propgrid/advprops.cpp:633 ../src/richtext/richtextfontpage.cpp:358
+msgid "Underlined"
+msgstr "அடிக்கோடிடப்பட்டது"
+
+#. TRANSLATORS: Label of font family
+#: ../src/propgrid/advprops.cpp:637
+msgid "Family"
+msgstr "குடும்பம்"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:801
+msgid "AppWorkspace"
+msgstr "பயன்பாட்டுப் பணிவெளி"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:802
+msgid "ActiveBorder"
+msgstr "இயங்குநிலை எல்லை"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:803
+msgid "ActiveCaption"
+msgstr "இயங்குநிலைத் தலைப்பு"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:804
+msgid "ButtonFace"
+msgstr "பொத்தான் முகப்பு"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:805
+msgid "ButtonHighlight"
+msgstr "பொத்தான் துலக்கம்"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:806
+msgid "ButtonShadow"
+msgstr "பொத்தான் நிழல்"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:807
+msgid "ButtonText"
+msgstr "பொத்தான் உரை"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:808
+msgid "CaptionText"
+msgstr "தலைப்புரை"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:809
+msgid "ControlDark"
+msgstr "கட்டுப்பாட்டு அடர்நிறம்"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:810
+msgid "ControlLight"
+msgstr "கட்டுப்பாட்டு வெளிர்நிறம்"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:812
+msgid "GrayText"
+msgstr "சாம்பலுரை"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:813
+msgid "Highlight"
+msgstr "துலக்கம்"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:814
+msgid "HighlightText"
+msgstr "உரையைத் துலக்கமாக்கிடுக"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:815
+msgid "InactiveBorder"
+msgstr "இயங்காநிலை எல்லை"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:816
+msgid "InactiveCaption"
+msgstr "இயங்காநிலைத் தலைப்பு"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:817
+msgid "InactiveCaptionText"
+msgstr "இயங்காநிலைத் தலைப்புரை"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:818
+msgid "Menu"
+msgstr "பட்டியல்"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:819
+msgid "Scrollbar"
+msgstr "உருள்பட்டை"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:820
+msgid "Tooltip"
+msgstr "கருவிக்குறிப்பு"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:821
+msgid "TooltipText"
+msgstr "கருவிக்குறிப்புரை"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:822
+msgid "Window"
+msgstr "சாளரம்"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:823
+msgid "WindowFrame"
+msgstr "சாளரச் சட்டகம்"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:824
+msgid "WindowText"
+msgstr "சாளரவுரை"
+
+#. TRANSLATORS: Custom colour choice entry
+#: ../src/propgrid/advprops.cpp:825 ../src/propgrid/advprops.cpp:1532
+#: ../src/propgrid/advprops.cpp:1576
+msgid "Custom"
+msgstr "தனிப்பயனாக்கப்பட்டது "
+
+#: ../src/propgrid/advprops.cpp:1558
+msgid "Black"
+msgstr "கருப்பு"
+
+#: ../src/propgrid/advprops.cpp:1559
+msgid "Maroon"
+msgstr "அரக்கு"
+
+#: ../src/propgrid/advprops.cpp:1560
+msgid "Navy"
+msgstr "கடற்படை நீலம்"
+
+#: ../src/propgrid/advprops.cpp:1561
+msgid "Purple"
+msgstr "ஊதா"
+
+#: ../src/propgrid/advprops.cpp:1562
+msgid "Teal"
+msgstr "இளம்பச்சை"
+
+#: ../src/propgrid/advprops.cpp:1563
+msgid "Gray"
+msgstr "சாம்பல்"
+
+#: ../src/propgrid/advprops.cpp:1564
+msgid "Green"
+msgstr "பச்சை"
+
+#: ../src/propgrid/advprops.cpp:1565
+msgid "Olive"
+msgstr "ஆலிவ்"
+
+#: ../src/propgrid/advprops.cpp:1566
+msgid "Brown"
+msgstr "பிரௌன்"
+
+#: ../src/propgrid/advprops.cpp:1567
+msgid "Blue"
+msgstr "நீலம்"
+
+#: ../src/propgrid/advprops.cpp:1568
+msgid "Fuchsia"
+msgstr "ஃப்யூஷியா சிவப்பு"
+
+#: ../src/propgrid/advprops.cpp:1569
+msgid "Red"
+msgstr "சிவப்பு"
+
+#: ../src/propgrid/advprops.cpp:1570
+msgid "Orange"
+msgstr "செம்மஞ்சள்"
+
+#: ../src/propgrid/advprops.cpp:1571
+msgid "Silver"
+msgstr "வெள்ளி"
+
+#: ../src/propgrid/advprops.cpp:1572
+msgid "Lime"
+msgstr "எலுமிச்சை"
+
+#: ../src/propgrid/advprops.cpp:1573
+msgid "Aqua"
+msgstr "நீலப்பச்சை"
+
+#: ../src/propgrid/advprops.cpp:1574
+msgid "Yellow"
+msgstr "மஞ்சள்"
+
+#: ../src/propgrid/advprops.cpp:1575
+msgid "White"
+msgstr "வெள்ளை"
+
+#: ../src/propgrid/advprops.cpp:1718
+msgctxt "system cursor name"
+msgid "Default"
+msgstr "இயல்பிருப்பு"
+
+#: ../src/propgrid/advprops.cpp:1719
+msgctxt "system cursor name"
+msgid "Arrow"
+msgstr "அம்பு"
+
+#: ../src/propgrid/advprops.cpp:1720
+msgctxt "system cursor name"
+msgid "Right Arrow"
+msgstr "வலதம்பு"
+
+#: ../src/propgrid/advprops.cpp:1721
+msgctxt "system cursor name"
+msgid "Blank"
+msgstr "வெற்று"
+
+#: ../src/propgrid/advprops.cpp:1722
+msgctxt "system cursor name"
+msgid "Bullseye"
+msgstr "மைய இலக்கு"
+
+#: ../src/propgrid/advprops.cpp:1723
+msgctxt "system cursor name"
+msgid "Character"
+msgstr "வரியுரு"
+
+#: ../src/propgrid/advprops.cpp:1724
+msgctxt "system cursor name"
+msgid "Cross"
+msgstr "குறுக்கு"
+
+#: ../src/propgrid/advprops.cpp:1725
+msgctxt "system cursor name"
+msgid "Hand"
+msgstr "கை"
+
+#: ../src/propgrid/advprops.cpp:1726
+msgctxt "system cursor name"
+msgid "I-Beam"
+msgstr "I வடிவம்"
+
+#: ../src/propgrid/advprops.cpp:1727
+msgctxt "system cursor name"
+msgid "Left Button"
+msgstr "இடது பொத்தான்"
+
+#: ../src/propgrid/advprops.cpp:1728
+msgctxt "system cursor name"
+msgid "Magnifier"
+msgstr "உருப்பெருக்கி"
+
+#: ../src/propgrid/advprops.cpp:1729
+msgctxt "system cursor name"
+msgid "Middle Button"
+msgstr "நடு பொத்தான்"
+
+#: ../src/propgrid/advprops.cpp:1730
+msgctxt "system cursor name"
+msgid "No Entry"
+msgstr "உள்ளீடு ஏதுமில்லை"
+
+#: ../src/propgrid/advprops.cpp:1731
+msgctxt "system cursor name"
+msgid "Paint Brush"
+msgstr "வண்ணத் தூரிகை"
+
+#: ../src/propgrid/advprops.cpp:1732
+msgctxt "system cursor name"
+msgid "Pencil"
+msgstr "பெண்சில்"
+
+#: ../src/propgrid/advprops.cpp:1733
+msgctxt "system cursor name"
+msgid "Point Left"
+msgstr "இடது சுட்டு"
+
+#: ../src/propgrid/advprops.cpp:1734
+msgctxt "system cursor name"
+msgid "Point Right"
+msgstr "வலது சுட்டு"
+
+#: ../src/propgrid/advprops.cpp:1735
+msgctxt "system cursor name"
+msgid "Question Arrow"
+msgstr "கேள்வியம்பு"
+
+#: ../src/propgrid/advprops.cpp:1736
+msgctxt "system cursor name"
+msgid "Right Button"
+msgstr "வலது பொத்தான்"
+
+#: ../src/propgrid/advprops.cpp:1737
+msgctxt "system cursor name"
+msgid "Sizing NE-SW"
+msgstr "NE-SW அளவாக்கம் "
+
+#: ../src/propgrid/advprops.cpp:1738
+msgctxt "system cursor name"
+msgid "Sizing N-S"
+msgstr "N-S அளவாக்கம் "
+
+#: ../src/propgrid/advprops.cpp:1739
+msgctxt "system cursor name"
+msgid "Sizing NW-SE"
+msgstr "NW-SE அளவாக்கம் "
+
+#: ../src/propgrid/advprops.cpp:1740
+msgctxt "system cursor name"
+msgid "Sizing W-E"
+msgstr "W-E அளவாக்கம் "
+
+#: ../src/propgrid/advprops.cpp:1741
+msgctxt "system cursor name"
+msgid "Sizing"
+msgstr "அளவாக்கம்"
+
+#: ../src/propgrid/advprops.cpp:1742
+msgctxt "system cursor name"
+msgid "Spraycan"
+msgstr "தெளிக்குவளை"
+
+#: ../src/propgrid/advprops.cpp:1743
+msgctxt "system cursor name"
+msgid "Wait"
+msgstr "காத்திருப்பு"
+
+#: ../src/propgrid/advprops.cpp:1744
+msgctxt "system cursor name"
+msgid "Watch"
+msgstr "கடிகாரம்"
+
+#: ../src/propgrid/advprops.cpp:1745
+msgctxt "system cursor name"
+msgid "Wait Arrow"
+msgstr "காத்திருப்பு அம்பு"
+
+#: ../src/propgrid/advprops.cpp:2109
+msgid "Make a selection:"
+msgstr "தெரிவு ஒன்றினைச் செய்க:"
+
+#: ../src/propgrid/manager.cpp:394
+msgid "Property"
+msgstr "பண்பு"
+
+#: ../src/propgrid/manager.cpp:395
+msgid "Value"
+msgstr "மதிப்பு"
+
+#: ../src/propgrid/manager.cpp:1683
+msgid "Categorized Mode"
+msgstr "வகைப்படுத்தப்பட்ட முறைமை"
+
+#: ../src/propgrid/manager.cpp:1709
+msgid "Alphabetic Mode"
+msgstr "அகர முறைமை"
+
+#. TRANSLATORS: Name of Boolean false value
+#: ../src/propgrid/propgrid.cpp:230
+msgid "False"
+msgstr "பொய்"
+
+#. TRANSLATORS: Name of Boolean true value
+#: ../src/propgrid/propgrid.cpp:232
+msgid "True"
+msgstr "மெய்"
+
+#. TRANSLATORS: Text  displayed for unspecified value
+#: ../src/propgrid/propgrid.cpp:428
+msgid "Unspecified"
+msgstr "குறிப்பிடப்படாதது"
+
+#. TRANSLATORS: Caption of message box displaying any property error
+#: ../src/propgrid/propgrid.cpp:3145 ../src/propgrid/propgrid.cpp:3282
+msgid "Property Error"
+msgstr "பண்புப் பிழை"
+
+#: ../src/propgrid/propgrid.cpp:3259
+msgid "You have entered invalid value. Press ESC to cancel editing."
+msgstr ""
+"செல்லாத மதிப்பை உள்ளிட்டுள்ளீர்கள், தொகுத்தலை விலக்கிட 'விடுபடு' விசையை அழுத்தவும்."
+
+#: ../src/propgrid/propgrid.cpp:6608
+#, c-format
+msgid "Error in resource: %s"
+msgstr "வளத்தில் பிழை: %s"
+
+#: ../src/propgrid/propgridiface.cpp:377
+#, c-format
+msgid ""
+"Type operation \"%s\" failed: Property labeled \"%s\" is of type \"%s\", NOT "
+"\"%s\"."
+msgstr ""
+"செயல்வகை \"%s\" தோல்வியடைந்தது: \"%s\" என்று பெயரிடப்பட்ட பண்பு \"%s\" வகையைச் "
+"சார்ந்தது, \"%s\" அல்ல."
+
+#: ../src/propgrid/props.cpp:159
+#, c-format
+msgid "Unknown base %d. Base 10 will be used."
+msgstr "அறியப்படாத அடிப்படை %d. அடிப்படை 10 பயன்படுத்தப்படும்."
+
+#: ../src/propgrid/props.cpp:324
+#, c-format
+msgid "Value must be %s or higher."
+msgstr "மதிப்பு %s அல்லது அதற்கும் மேல் இருக்க வேண்டும்."
+
+#: ../src/propgrid/props.cpp:329 ../src/propgrid/props.cpp:356
+#, c-format
+msgid "Value must be between %s and %s."
+msgstr "மதிப்பு இதற்கிடையே இருக்க வேண்டும்: %s - %s "
+
+#: ../src/propgrid/props.cpp:351
+#, c-format
+msgid "Value must be %s or less."
+msgstr "மதிப்பு %s அல்லது அதற்கும் குறைவாக இருக்க வேண்டும்."
+
+#: ../src/propgrid/props.cpp:1058
+#, c-format
+msgid "Not %s"
+msgstr "%s அல்ல"
+
+#: ../src/propgrid/props.cpp:1770
+msgid "Choose a directory:"
+msgstr "ஒரு அடைவைத் தேர்ந்தெடுக்கவும்:"
+
+#: ../src/propgrid/props.cpp:2055
+msgid "Choose a file"
+msgstr "ஒரு கோப்பினைத் தேர்ந்தெடுக்கவும்"
+
+#: ../src/qt/mdi.cpp:254
+msgid "&Tile"
+msgstr "அடுக்குக (&T)"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:147
+#: ../src/richtext/richtextformatdlg.cpp:376
+msgid "Background"
+msgstr "பின்புலம்"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:159
+msgid "Background &colour:"
+msgstr "பின்புல நிறம் (&C):"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:161
+#: ../src/richtext/richtextbackgroundpage.cpp:163
+msgid "Enables a background colour."
+msgstr "ஒரு பின்புல நிறத்தை முடுக்குகிறது"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:167
+#: ../src/richtext/richtextbackgroundpage.cpp:169
+msgid "The background colour."
+msgstr "பின்புல நிறம்"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:178
+msgid "Shadow"
+msgstr "நிழல்"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:193
+msgid "Use &shadow"
+msgstr "நிழலைப் பயன்படுத்துக (&S)"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:195
+#: ../src/richtext/richtextbackgroundpage.cpp:197
+msgid "Enables a shadow."
+msgstr "ஒரு நிழலை முடுக்குகிறது."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:211
+msgid "&Horizontal offset:"
+msgstr "கிடைமட்ட விலகல் (&H)"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:218
+#: ../src/richtext/richtextbackgroundpage.cpp:220
+msgid "The horizontal offset."
+msgstr "கிடைமட்ட விலகல் ."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:224
+#: ../src/richtext/richtextbackgroundpage.cpp:227
+#: ../src/richtext/richtextbackgroundpage.cpp:228
+#: ../src/richtext/richtextbackgroundpage.cpp:247
+#: ../src/richtext/richtextbackgroundpage.cpp:250
+#: ../src/richtext/richtextbackgroundpage.cpp:251
+#: ../src/richtext/richtextbackgroundpage.cpp:287
+#: ../src/richtext/richtextbackgroundpage.cpp:290
+#: ../src/richtext/richtextbackgroundpage.cpp:291
+#: ../src/richtext/richtextbackgroundpage.cpp:314
+#: ../src/richtext/richtextbackgroundpage.cpp:317
+#: ../src/richtext/richtextbackgroundpage.cpp:318
+#: ../src/richtext/richtextborderspage.cpp:252
+#: ../src/richtext/richtextborderspage.cpp:255
+#: ../src/richtext/richtextborderspage.cpp:256
+#: ../src/richtext/richtextborderspage.cpp:286
+#: ../src/richtext/richtextborderspage.cpp:289
+#: ../src/richtext/richtextborderspage.cpp:290
+#: ../src/richtext/richtextborderspage.cpp:320
+#: ../src/richtext/richtextborderspage.cpp:323
+#: ../src/richtext/richtextborderspage.cpp:324
+#: ../src/richtext/richtextborderspage.cpp:354
+#: ../src/richtext/richtextborderspage.cpp:357
+#: ../src/richtext/richtextborderspage.cpp:358
+#: ../src/richtext/richtextborderspage.cpp:420
+#: ../src/richtext/richtextborderspage.cpp:423
+#: ../src/richtext/richtextborderspage.cpp:424
+#: ../src/richtext/richtextborderspage.cpp:454
+#: ../src/richtext/richtextborderspage.cpp:457
+#: ../src/richtext/richtextborderspage.cpp:458
+#: ../src/richtext/richtextborderspage.cpp:488
+#: ../src/richtext/richtextborderspage.cpp:491
+#: ../src/richtext/richtextborderspage.cpp:492
+#: ../src/richtext/richtextborderspage.cpp:522
+#: ../src/richtext/richtextborderspage.cpp:525
+#: ../src/richtext/richtextborderspage.cpp:526
+#: ../src/richtext/richtextborderspage.cpp:590
+#: ../src/richtext/richtextborderspage.cpp:593
+#: ../src/richtext/richtextborderspage.cpp:594
+#: ../src/richtext/richtextfontpage.cpp:177
+#: ../src/richtext/richtextmarginspage.cpp:199
+#: ../src/richtext/richtextmarginspage.cpp:201
+#: ../src/richtext/richtextmarginspage.cpp:202
+#: ../src/richtext/richtextmarginspage.cpp:224
+#: ../src/richtext/richtextmarginspage.cpp:226
+#: ../src/richtext/richtextmarginspage.cpp:227
+#: ../src/richtext/richtextmarginspage.cpp:247
+#: ../src/richtext/richtextmarginspage.cpp:249
+#: ../src/richtext/richtextmarginspage.cpp:250
+#: ../src/richtext/richtextmarginspage.cpp:272
+#: ../src/richtext/richtextmarginspage.cpp:274
+#: ../src/richtext/richtextmarginspage.cpp:275
+#: ../src/richtext/richtextmarginspage.cpp:313
+#: ../src/richtext/richtextmarginspage.cpp:315
+#: ../src/richtext/richtextmarginspage.cpp:316
+#: ../src/richtext/richtextmarginspage.cpp:338
+#: ../src/richtext/richtextmarginspage.cpp:340
+#: ../src/richtext/richtextmarginspage.cpp:341
+#: ../src/richtext/richtextmarginspage.cpp:361
+#: ../src/richtext/richtextmarginspage.cpp:363
+#: ../src/richtext/richtextmarginspage.cpp:364
+#: ../src/richtext/richtextmarginspage.cpp:386
+#: ../src/richtext/richtextmarginspage.cpp:388
+#: ../src/richtext/richtextmarginspage.cpp:389
+#: ../src/richtext/richtextsizepage.cpp:337
+#: ../src/richtext/richtextsizepage.cpp:340
+#: ../src/richtext/richtextsizepage.cpp:341
+#: ../src/richtext/richtextsizepage.cpp:371
+#: ../src/richtext/richtextsizepage.cpp:374
+#: ../src/richtext/richtextsizepage.cpp:375
+#: ../src/richtext/richtextsizepage.cpp:398
+#: ../src/richtext/richtextsizepage.cpp:401
+#: ../src/richtext/richtextsizepage.cpp:402
+#: ../src/richtext/richtextsizepage.cpp:425
+#: ../src/richtext/richtextsizepage.cpp:428
+#: ../src/richtext/richtextsizepage.cpp:429
+#: ../src/richtext/richtextsizepage.cpp:452
+#: ../src/richtext/richtextsizepage.cpp:455
+#: ../src/richtext/richtextsizepage.cpp:456
+#: ../src/richtext/richtextsizepage.cpp:479
+#: ../src/richtext/richtextsizepage.cpp:482
+#: ../src/richtext/richtextsizepage.cpp:483
+#: ../src/richtext/richtextsizepage.cpp:553
+#: ../src/richtext/richtextsizepage.cpp:556
+#: ../src/richtext/richtextsizepage.cpp:557
+#: ../src/richtext/richtextsizepage.cpp:588
+#: ../src/richtext/richtextsizepage.cpp:591
+#: ../src/richtext/richtextsizepage.cpp:592
+#: ../src/richtext/richtextsizepage.cpp:623
+#: ../src/richtext/richtextsizepage.cpp:626
+#: ../src/richtext/richtextsizepage.cpp:627
+#: ../src/richtext/richtextsizepage.cpp:658
+#: ../src/richtext/richtextsizepage.cpp:661
+#: ../src/richtext/richtextsizepage.cpp:662
+msgid "px"
+msgstr "படவணு"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:225
+#: ../src/richtext/richtextbackgroundpage.cpp:248
+#: ../src/richtext/richtextbackgroundpage.cpp:288
+#: ../src/richtext/richtextbackgroundpage.cpp:315
+#: ../src/richtext/richtextborderspage.cpp:253
+#: ../src/richtext/richtextborderspage.cpp:287
+#: ../src/richtext/richtextborderspage.cpp:321
+#: ../src/richtext/richtextborderspage.cpp:355
+#: ../src/richtext/richtextborderspage.cpp:421
+#: ../src/richtext/richtextborderspage.cpp:455
+#: ../src/richtext/richtextborderspage.cpp:489
+#: ../src/richtext/richtextborderspage.cpp:523
+#: ../src/richtext/richtextborderspage.cpp:591
+#: ../src/richtext/richtextmarginspage.cpp:200
+#: ../src/richtext/richtextmarginspage.cpp:225
+#: ../src/richtext/richtextmarginspage.cpp:248
+#: ../src/richtext/richtextmarginspage.cpp:273
+#: ../src/richtext/richtextmarginspage.cpp:314
+#: ../src/richtext/richtextmarginspage.cpp:339
+#: ../src/richtext/richtextmarginspage.cpp:362
+#: ../src/richtext/richtextmarginspage.cpp:387
+#: ../src/richtext/richtextsizepage.cpp:338
+#: ../src/richtext/richtextsizepage.cpp:372
+#: ../src/richtext/richtextsizepage.cpp:399
+#: ../src/richtext/richtextsizepage.cpp:426
+#: ../src/richtext/richtextsizepage.cpp:453
+#: ../src/richtext/richtextsizepage.cpp:480
+#: ../src/richtext/richtextsizepage.cpp:554
+#: ../src/richtext/richtextsizepage.cpp:589
+#: ../src/richtext/richtextsizepage.cpp:624
+#: ../src/richtext/richtextsizepage.cpp:659
+msgid "cm"
+msgstr "செ.மீ."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:226
+#: ../src/richtext/richtextbackgroundpage.cpp:249
+#: ../src/richtext/richtextbackgroundpage.cpp:289
+#: ../src/richtext/richtextbackgroundpage.cpp:316
+#: ../src/richtext/richtextborderspage.cpp:254
+#: ../src/richtext/richtextborderspage.cpp:288
+#: ../src/richtext/richtextborderspage.cpp:322
+#: ../src/richtext/richtextborderspage.cpp:356
+#: ../src/richtext/richtextborderspage.cpp:422
+#: ../src/richtext/richtextborderspage.cpp:456
+#: ../src/richtext/richtextborderspage.cpp:490
+#: ../src/richtext/richtextborderspage.cpp:524
+#: ../src/richtext/richtextborderspage.cpp:592
+#: ../src/richtext/richtextfontpage.cpp:176
+#: ../src/richtext/richtextfontpage.cpp:179
+msgid "pt"
+msgstr "புள்ளி"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:229
+#: ../src/richtext/richtextbackgroundpage.cpp:231
+#: ../src/richtext/richtextbackgroundpage.cpp:252
+#: ../src/richtext/richtextbackgroundpage.cpp:254
+#: ../src/richtext/richtextbackgroundpage.cpp:292
+#: ../src/richtext/richtextbackgroundpage.cpp:294
+#: ../src/richtext/richtextbackgroundpage.cpp:319
+#: ../src/richtext/richtextbackgroundpage.cpp:321
+msgid "Units for this value."
+msgstr "இம்மதிப்பிற்கான அலகுகள்."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:234
+msgid "&Vertical offset:"
+msgstr "செங்குத்து விலகல் (&V)"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:241
+#: ../src/richtext/richtextbackgroundpage.cpp:243
+msgid "The vertical offset."
+msgstr "செங்குத்து விலகல்"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:257
+msgid "Shadow c&olour:"
+msgstr "நிழல் நிறம் (&O):"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:259
+#: ../src/richtext/richtextbackgroundpage.cpp:261
+msgid "Enables the shadow colour."
+msgstr "நிழல் நிறத்தை முடுக்குகிறது"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:265
+#: ../src/richtext/richtextbackgroundpage.cpp:267
+msgid "The shadow colour."
+msgstr "நிழல் நிறம்."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:270
+msgid "Sh&adow spread:"
+msgstr "நிழல் பரவல் (&A):"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:272
+#: ../src/richtext/richtextbackgroundpage.cpp:274
+msgid "Enables the shadow spread."
+msgstr "நிழல் பரவலை முடுக்குகிறது."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:281
+#: ../src/richtext/richtextbackgroundpage.cpp:283
+msgid "The shadow spread."
+msgstr "நிழல் பரவல்."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:297
+msgid "&Blur distance:"
+msgstr "மங்கலாகும் தொலைவு (&B):"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:299
+#: ../src/richtext/richtextbackgroundpage.cpp:301
+msgid "Enables the blur distance."
+msgstr "மங்கலாகும் தொலைவை முடுக்குகிறது."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:308
+#: ../src/richtext/richtextbackgroundpage.cpp:310
+msgid "The shadow blur distance."
+msgstr "நிழல் மங்கலாகும் தொலைவு."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:324
+msgid "Opaci&ty:"
+msgstr "ஒளிபுகாமை (&T)"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:326
+#: ../src/richtext/richtextbackgroundpage.cpp:328
+msgid "Enables the shadow opacity."
+msgstr "நிழல் ஒளிபுகாமையை முடுக்குகிறது."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:335
+#: ../src/richtext/richtextbackgroundpage.cpp:337
+msgid "The shadow opacity."
+msgstr "நிழல் ஒளிபுகாமை"
+
+#. TRANSLATORS: Rich text page units (percentage)
+#: ../src/richtext/richtextbackgroundpage.cpp:340
+#: ../src/richtext/richtextsizepage.cpp:339
+#: ../src/richtext/richtextsizepage.cpp:373
+#: ../src/richtext/richtextsizepage.cpp:400
+#: ../src/richtext/richtextsizepage.cpp:427
+#: ../src/richtext/richtextsizepage.cpp:454
+#: ../src/richtext/richtextsizepage.cpp:481
+#: ../src/richtext/richtextsizepage.cpp:555
+#: ../src/richtext/richtextsizepage.cpp:590
+#: ../src/richtext/richtextsizepage.cpp:625
+#: ../src/richtext/richtextsizepage.cpp:660
+msgid "%"
+msgstr "%"
+
+#: ../src/richtext/richtextborderspage.cpp:229
+#: ../src/richtext/richtextborderspage.cpp:387
+msgid "Border"
+msgstr "எல்லை"
+
+#: ../src/richtext/richtextborderspage.cpp:242
+#: ../src/richtext/richtextborderspage.cpp:410
+#: ../src/richtext/richtextindentspage.cpp:194
+#: ../src/richtext/richtextliststylepage.cpp:384
+#: ../src/richtext/richtextmarginspage.cpp:185
+#: ../src/richtext/richtextmarginspage.cpp:299
+#: ../src/richtext/richtextsizepage.cpp:531
+#: ../src/richtext/richtextsizepage.cpp:538
+msgid "&Left:"
+msgstr "இடது (&L):"
+
+#: ../src/richtext/richtextborderspage.cpp:257
+#: ../src/richtext/richtextborderspage.cpp:259
+msgid "Units for the left border width."
+msgstr "இடது எல்லைக்கோட்டின் அகலத்திற்கான தொகுதிகள்."
+
+#: ../src/richtext/richtextborderspage.cpp:266
+#: ../src/richtext/richtextborderspage.cpp:268
+#: ../src/richtext/richtextborderspage.cpp:300
+#: ../src/richtext/richtextborderspage.cpp:302
+#: ../src/richtext/richtextborderspage.cpp:334
+#: ../src/richtext/richtextborderspage.cpp:336
+#: ../src/richtext/richtextborderspage.cpp:368
+#: ../src/richtext/richtextborderspage.cpp:370
+#: ../src/richtext/richtextborderspage.cpp:434
+#: ../src/richtext/richtextborderspage.cpp:436
+#: ../src/richtext/richtextborderspage.cpp:468
+#: ../src/richtext/richtextborderspage.cpp:470
+#: ../src/richtext/richtextborderspage.cpp:502
+#: ../src/richtext/richtextborderspage.cpp:504
+#: ../src/richtext/richtextborderspage.cpp:536
+#: ../src/richtext/richtextborderspage.cpp:538
+msgid "The border line style."
+msgstr "எல்லைக் கோட்டின் பாங்கு."
+
+#: ../src/richtext/richtextborderspage.cpp:276
+#: ../src/richtext/richtextborderspage.cpp:444
+#: ../src/richtext/richtextindentspage.cpp:212
+#: ../src/richtext/richtextliststylepage.cpp:402
+#: ../src/richtext/richtextmarginspage.cpp:210
+#: ../src/richtext/richtextmarginspage.cpp:324
+#: ../src/richtext/richtextsizepage.cpp:601
+#: ../src/richtext/richtextsizepage.cpp:608
+msgid "&Right:"
+msgstr "வலது (&R:)"
+
+#: ../src/richtext/richtextborderspage.cpp:291
+#: ../src/richtext/richtextborderspage.cpp:293
+msgid "Units for the right border width."
+msgstr "வலது எல்லைக்கோட்டின் அகலத்திற்கான தொகுதிகள்."
+
+#: ../src/richtext/richtextborderspage.cpp:310
+#: ../src/richtext/richtextborderspage.cpp:478
+#: ../src/richtext/richtextmarginspage.cpp:233
+#: ../src/richtext/richtextmarginspage.cpp:347
+#: ../src/richtext/richtextsizepage.cpp:566
+#: ../src/richtext/richtextsizepage.cpp:573
+msgid "&Top:"
+msgstr "மேல் (&T:)"
+
+#: ../src/richtext/richtextborderspage.cpp:325
+#: ../src/richtext/richtextborderspage.cpp:327
+msgid "Units for the top border width."
+msgstr "மேல் எல்லைக்கோட்டின் அகலத்திற்கான தொகுதிகள்."
+
+#: ../src/richtext/richtextborderspage.cpp:344
+#: ../src/richtext/richtextborderspage.cpp:512
+#: ../src/richtext/richtextmarginspage.cpp:258
+#: ../src/richtext/richtextmarginspage.cpp:372
+#: ../src/richtext/richtextsizepage.cpp:636
+#: ../src/richtext/richtextsizepage.cpp:643
+msgid "&Bottom:"
+msgstr "கீழ் (&B)"
+
+#: ../src/richtext/richtextborderspage.cpp:359
+#: ../src/richtext/richtextborderspage.cpp:361
+msgid "Units for the bottom border width."
+msgstr "கீழ் எல்லைக் கோட்டின் அகலத்திற்கான தொகுதிகள்."
+
+#: ../src/richtext/richtextborderspage.cpp:380
+#: ../src/richtext/richtextborderspage.cpp:548
+msgid "&Synchronize values"
+msgstr "மதிப்புகளை ஒத்திசைவாக்குக (&S)"
+
+#: ../src/richtext/richtextborderspage.cpp:382
+#: ../src/richtext/richtextborderspage.cpp:384
+#: ../src/richtext/richtextborderspage.cpp:550
+#: ../src/richtext/richtextborderspage.cpp:552
+msgid "Check to edit all borders simultaneously."
+msgstr "எல்லா எல்லைகளையும் ஒரே நேரத்தில் தொகுப்பதற்கு தேர்வுசெய்க"
+
+#: ../src/richtext/richtextborderspage.cpp:397
+#: ../src/richtext/richtextborderspage.cpp:555
+msgid "Outline"
+msgstr "வெளிக்கோடு"
+
+#: ../src/richtext/richtextborderspage.cpp:425
+#: ../src/richtext/richtextborderspage.cpp:427
+msgid "Units for the left outline width."
+msgstr "இடது வெளிக்கோடு அகலத்திற்கான தொகுதிகள்."
+
+#: ../src/richtext/richtextborderspage.cpp:459
+#: ../src/richtext/richtextborderspage.cpp:461
+msgid "Units for the right outline width."
+msgstr "வலது வெளிக்கோடு அகலத்திற்கான தொகுதிகள்."
+
+#: ../src/richtext/richtextborderspage.cpp:493
+#: ../src/richtext/richtextborderspage.cpp:495
+msgid "Units for the top outline width."
+msgstr "மேல் வெளிக்கோடு அகலத்திற்கான தொகுதிகள்."
+
+#: ../src/richtext/richtextborderspage.cpp:527
+#: ../src/richtext/richtextborderspage.cpp:529
+msgid "Units for the bottom outline width."
+msgstr "கீழ் வெளிக்கோடு அகலத்திற்கான தொகுதிகள்."
+
+#: ../src/richtext/richtextborderspage.cpp:565
+#: ../src/richtext/richtextborderspage.cpp:600
+msgid "Corner"
+msgstr "மூலை"
+
+#: ../src/richtext/richtextborderspage.cpp:574
+msgid "Corner &radius:"
+msgstr "மூலையின் ஆரம் (&R)"
+
+#: ../src/richtext/richtextborderspage.cpp:576
+#: ../src/richtext/richtextborderspage.cpp:578
+msgid "An optional corner radius for adding rounded corners."
+msgstr "வட்டவடிவ மூலைகளை உருவாக்க விருப்பத் தேர்வு ஆரம்."
+
+#: ../src/richtext/richtextborderspage.cpp:584
+#: ../src/richtext/richtextborderspage.cpp:586
+msgid "The value of the corner radius."
+msgstr "மூலை ஆரத்தின் மதிப்பு."
+
+#: ../src/richtext/richtextborderspage.cpp:595
+#: ../src/richtext/richtextborderspage.cpp:597
+msgid "Units for the corner radius."
+msgstr "மூலை ஆரத்திற்கான அலகுகள்"
+
+#: ../src/richtext/richtextborderspage.cpp:609
+#: ../src/richtext/richtextsizepage.cpp:247
+#: ../src/richtext/richtextsizepage.cpp:251
+msgid "None"
+msgstr "ஏதுமில்லை"
+
+#: ../src/richtext/richtextborderspage.cpp:610
+msgid "Solid"
+msgstr "திடம்"
+
+#: ../src/richtext/richtextborderspage.cpp:611
+msgid "Dotted"
+msgstr "புள்ளியிடப்பட்டது"
+
+#: ../src/richtext/richtextborderspage.cpp:612
+msgid "Dashed"
+msgstr "கோடிடப்பட்டது"
+
+#: ../src/richtext/richtextborderspage.cpp:613
+msgid "Double"
+msgstr "இரட்டை"
+
+#: ../src/richtext/richtextborderspage.cpp:614
+msgid "Groove"
+msgstr "வரிப்பள்ளம்"
+
+#: ../src/richtext/richtextborderspage.cpp:615
+msgid "Ridge"
+msgstr "முகடு"
+
+#: ../src/richtext/richtextborderspage.cpp:616
+msgid "Inset"
+msgstr "பள்ளம்"
+
+#: ../src/richtext/richtextborderspage.cpp:617
+msgid "Outset"
+msgstr "மேடு"
+
+#: ../src/richtext/richtextbuffer.cpp:3518
+msgid "Change Style"
+msgstr "பாங்கினை மாற்றுக"
+
+#: ../src/richtext/richtextbuffer.cpp:3701
+msgid "Change Object Style"
+msgstr "பொருளின் பாங்கினை மாற்றுக"
+
+#: ../src/richtext/richtextbuffer.cpp:3974
+#: ../src/richtext/richtextbuffer.cpp:8174
+msgid "Change Properties"
+msgstr "பண்புகளை மாற்றுக"
+
+#: ../src/richtext/richtextbuffer.cpp:4346
+msgid "Change List Style"
+msgstr "வரிசைப் பட்டியலின் பாங்கினை மாற்றுக"
+
+#: ../src/richtext/richtextbuffer.cpp:4519
+msgid "Renumber List"
+msgstr "பட்டியலை மறுஎண்ணிடுக"
+
+#: ../src/richtext/richtextbuffer.cpp:7867
+#: ../src/richtext/richtextbuffer.cpp:7897
+#: ../src/richtext/richtextbuffer.cpp:7939
+#: ../src/richtext/richtextctrl.cpp:1279 ../src/richtext/richtextctrl.cpp:1473
+msgid "Insert Text"
+msgstr "உரையைச் செருகுக"
+
+#: ../src/richtext/richtextbuffer.cpp:8023
+#: ../src/richtext/richtextbuffer.cpp:8979
+msgid "Insert Image"
+msgstr "படிமத்தைச் செருகுக"
+
+#: ../src/richtext/richtextbuffer.cpp:8070
+msgid "Insert Object"
+msgstr "பொருளைச் செருகுக"
+
+#: ../src/richtext/richtextbuffer.cpp:8112
+msgid "Insert Field"
+msgstr "களத்தைச் செருகுக"
+
+#: ../src/richtext/richtextbuffer.cpp:8410
+msgid "Too many EndStyle calls!"
+msgstr "மிகுதியான End Style அழைப்புகள்!"
+
+#: ../src/richtext/richtextbuffer.cpp:8785
+msgid "files"
+msgstr "கோப்புகள்"
+
+#: ../src/richtext/richtextbuffer.cpp:9380
+msgid "standard/circle"
+msgstr "தரநிலை/வட்டம்"
+
+#: ../src/richtext/richtextbuffer.cpp:9381
+msgid "standard/circle-outline"
+msgstr "தரநிலை/வட்டம்-வெளிக்கோடு"
+
+#: ../src/richtext/richtextbuffer.cpp:9382
+msgid "standard/square"
+msgstr "தரநிலை/சதுரம்"
+
+#: ../src/richtext/richtextbuffer.cpp:9383
+msgid "standard/diamond"
+msgstr "தரநிலை/வைரவடிவம்"
+
+#: ../src/richtext/richtextbuffer.cpp:9384
+msgid "standard/triangle"
+msgstr "தரநிலை/முக்கோணம்"
+
+#: ../src/richtext/richtextbuffer.cpp:9423
+msgid "Box Properties"
+msgstr "பெட்டிப் பண்புகள்"
+
+#: ../src/richtext/richtextbuffer.cpp:10006
+msgid "Multiple Cell Properties"
+msgstr "பல்களப் பண்புகள்"
+
+#: ../src/richtext/richtextbuffer.cpp:10008
+msgid "Cell Properties"
+msgstr "களப் பண்புகள்"
+
+#: ../src/richtext/richtextbuffer.cpp:11256
+msgid "Set Cell Style"
+msgstr "களப் பாங்கினை அமைத்திடுக"
+
+#: ../src/richtext/richtextbuffer.cpp:11330
+msgid "Delete Row"
+msgstr "கிடை வரிசையை அழித்திடுக"
+
+#: ../src/richtext/richtextbuffer.cpp:11380
+msgid "Delete Column"
+msgstr "நெடுவரிசையை அழித்திடுக"
+
+#: ../src/richtext/richtextbuffer.cpp:11431
+msgid "Add Row"
+msgstr "கிடை வரிசையை சேர்த்திடுக"
+
+#: ../src/richtext/richtextbuffer.cpp:11494
+msgid "Add Column"
+msgstr "நெடுவரிசையை சேர்த்திடுக"
+
+#: ../src/richtext/richtextbuffer.cpp:11537
+msgid "Table Properties"
+msgstr "அட்டவணைப் பண்புகள்"
+
+#: ../src/richtext/richtextbuffer.cpp:12899
+msgid "Picture Properties"
+msgstr "படப் பண்புகள்"
+
+#: ../src/richtext/richtextbuffer.cpp:13169
+#: ../src/richtext/richtextbuffer.cpp:13279
+msgid "image"
+msgstr "படிமம்"
+
+#: ../src/richtext/richtextbulletspage.cpp:145
+#: ../src/richtext/richtextliststylepage.cpp:209
+msgid "&Bullet style:"
+msgstr "புள்ளிப் பாங்கு (&B)"
+
+#: ../src/richtext/richtextbulletspage.cpp:150
+#: ../src/richtext/richtextbulletspage.cpp:152
+#: ../src/richtext/richtextliststylepage.cpp:214
+#: ../src/richtext/richtextliststylepage.cpp:216
+msgid "The available bullet styles."
+msgstr "கிடைப்பிலிருக்கும் புள்ளிப் பாங்குகள்."
+
+#: ../src/richtext/richtextbulletspage.cpp:158
+#: ../src/richtext/richtextliststylepage.cpp:221
+msgid "Peri&od"
+msgstr "முற்றுப் புள்ளி (&O)"
+
+#: ../src/richtext/richtextbulletspage.cpp:160
+#: ../src/richtext/richtextbulletspage.cpp:162
+#: ../src/richtext/richtextliststylepage.cpp:223
+#: ../src/richtext/richtextliststylepage.cpp:225
+msgid "Check to add a period after the bullet."
+msgstr "புள்ளிக்குப் பிறகு ஒரு முற்றுப் புள்ளியைச் சேர்க்க தேர்வுசெய்க"
+
+#. TRANSLATORS: Bullet point in parentheses option
+#: ../src/richtext/richtextbulletspage.cpp:167
+#: ../src/richtext/richtextliststylepage.cpp:230
+msgid "(*)"
+msgstr "(*)"
+
+#: ../src/richtext/richtextbulletspage.cpp:169
+#: ../src/richtext/richtextbulletspage.cpp:171
+#: ../src/richtext/richtextliststylepage.cpp:232
+#: ../src/richtext/richtextliststylepage.cpp:234
+msgid "Check to enclose the bullet in parentheses."
+msgstr "அடைப்புக்குறிக்குல் புள்ளியை இட தேர்வுசெய்க"
+
+#. TRANSLATORS: Right parenthesis bullet point option
+#: ../src/richtext/richtextbulletspage.cpp:176
+#: ../src/richtext/richtextliststylepage.cpp:239
+msgid "*)"
+msgstr "*)"
+
+#: ../src/richtext/richtextbulletspage.cpp:178
+#: ../src/richtext/richtextbulletspage.cpp:180
+#: ../src/richtext/richtextliststylepage.cpp:241
+#: ../src/richtext/richtextliststylepage.cpp:243
+msgid "Check to add a right parenthesis."
+msgstr "வலப்பிறையைச் சேர்க்க தேர்வுசெய்க"
+
+#: ../src/richtext/richtextbulletspage.cpp:185
+#: ../src/richtext/richtextliststylepage.cpp:248
+msgid "Bullet &Alignment:"
+msgstr "புள்ளி ஒழுங்கமைப்பு (&A):"
+
+#: ../src/richtext/richtextbulletspage.cpp:190
+#: ../src/richtext/richtextliststylepage.cpp:253
+msgid "Centre"
+msgstr "மையம்"
+
+#: ../src/richtext/richtextbulletspage.cpp:194
+#: ../src/richtext/richtextbulletspage.cpp:196
+#: ../src/richtext/richtextbulletspage.cpp:217
+#: ../src/richtext/richtextbulletspage.cpp:219
+#: ../src/richtext/richtextliststylepage.cpp:257
+#: ../src/richtext/richtextliststylepage.cpp:259
+#: ../src/richtext/richtextliststylepage.cpp:278
+#: ../src/richtext/richtextliststylepage.cpp:280
+msgid "The bullet character."
+msgstr "புள்ளி வரியுரு."
+
+#: ../src/richtext/richtextbulletspage.cpp:212
+#: ../src/richtext/richtextliststylepage.cpp:271
+msgid "&Symbol:"
+msgstr "குறியெழுத்து (&S):"
+
+#: ../src/richtext/richtextbulletspage.cpp:222
+#: ../src/richtext/richtextliststylepage.cpp:283
+msgid "Ch&oose..."
+msgstr "தேர்ந்தெடுத்திடுக... (&O)"
+
+#: ../src/richtext/richtextbulletspage.cpp:223
+#: ../src/richtext/richtextbulletspage.cpp:225
+#: ../src/richtext/richtextliststylepage.cpp:284
+#: ../src/richtext/richtextliststylepage.cpp:286
+msgid "Click to browse for a symbol."
+msgstr "ஒரு குறியெழுத்தினை உலாவித் தேட சொடுக்கவும்."
+
+#: ../src/richtext/richtextbulletspage.cpp:230
+#: ../src/richtext/richtextliststylepage.cpp:291
+msgid "Symbol &font:"
+msgstr "குறியெழுத்து எழுத்துரு (&F):"
+
+#: ../src/richtext/richtextbulletspage.cpp:235
+#: ../src/richtext/richtextbulletspage.cpp:237
+#: ../src/richtext/richtextliststylepage.cpp:297
+msgid "Available fonts."
+msgstr "கிடைப்பிலுள்ள எழுத்துருக்கள்"
+
+#: ../src/richtext/richtextbulletspage.cpp:242
+#: ../src/richtext/richtextliststylepage.cpp:302
+msgid "S&tandard bullet name:"
+msgstr "தரநிலைப் புள்ளியின் பெயர் (&T):"
+
+#: ../src/richtext/richtextbulletspage.cpp:247
+#: ../src/richtext/richtextbulletspage.cpp:249
+#: ../src/richtext/richtextliststylepage.cpp:307
+#: ../src/richtext/richtextliststylepage.cpp:309
+msgid "A standard bullet name."
+msgstr "தரநிலைப் புள்ளிப் பெயர்."
+
+#: ../src/richtext/richtextbulletspage.cpp:254
+msgid "&Number:"
+msgstr "எண் (&N:)"
+
+#: ../src/richtext/richtextbulletspage.cpp:258
+#: ../src/richtext/richtextbulletspage.cpp:260
+msgid "The list item number."
+msgstr "பட்டியல் உருப்படியின் எண்."
+
+#: ../src/richtext/richtextbulletspage.cpp:266
+#: ../src/richtext/richtextbulletspage.cpp:268
+#: ../src/richtext/richtextliststylepage.cpp:475
+#: ../src/richtext/richtextliststylepage.cpp:477
+msgid "Shows a preview of the bullet settings."
+msgstr "புள்ளி அமைப்புகளின் முன்தோற்றத்தைக் காட்டுகிறது."
+
+#: ../src/richtext/richtextbulletspage.cpp:276
+#: ../src/richtext/richtextliststylepage.cpp:484
+msgid "(None)"
+msgstr "(ஏதுமில்லை)"
+
+#: ../src/richtext/richtextbulletspage.cpp:277
+#: ../src/richtext/richtextliststylepage.cpp:485
+msgid "Arabic"
+msgstr "அரேபியம்"
+
+#: ../src/richtext/richtextbulletspage.cpp:278
+#: ../src/richtext/richtextliststylepage.cpp:486
+msgid "Upper case letters"
+msgstr "மேல்நிலை எழுத்துகள்"
+
+#: ../src/richtext/richtextbulletspage.cpp:279
+#: ../src/richtext/richtextliststylepage.cpp:487
+msgid "Lower case letters"
+msgstr "கீழ்நிலை எழுத்துகள்"
+
+#: ../src/richtext/richtextbulletspage.cpp:280
+#: ../src/richtext/richtextliststylepage.cpp:488
+msgid "Upper case roman numerals"
+msgstr "மேல்நிலை ரோமானிய எண்கள்"
+
+#: ../src/richtext/richtextbulletspage.cpp:281
+#: ../src/richtext/richtextliststylepage.cpp:489
+msgid "Lower case roman numerals"
+msgstr "கீழ்நிலை ரோமானிய எண்கள்"
+
+#: ../src/richtext/richtextbulletspage.cpp:282
+#: ../src/richtext/richtextliststylepage.cpp:490
+msgid "Numbered outline"
+msgstr "எண்ணிடப்பட்ட வெளிக்கோடு"
+
+#: ../src/richtext/richtextbulletspage.cpp:283
+#: ../src/richtext/richtextliststylepage.cpp:491
+msgid "Symbol"
+msgstr "குறியெழுத்து"
+
+#: ../src/richtext/richtextbulletspage.cpp:284
+#: ../src/richtext/richtextliststylepage.cpp:492
+msgid "Bitmap"
+msgstr "நுண்படம்"
+
+#: ../src/richtext/richtextbulletspage.cpp:285
+#: ../src/richtext/richtextliststylepage.cpp:493
+msgid "Standard"
+msgstr "தரநிலை"
+
+#: ../src/richtext/richtextbulletspage.cpp:287
+#: ../src/richtext/richtextliststylepage.cpp:495
+msgid "*"
+msgstr "*"
+
+#: ../src/richtext/richtextbulletspage.cpp:288
+#: ../src/richtext/richtextliststylepage.cpp:496
+msgid "-"
+msgstr "-"
+
+#: ../src/richtext/richtextbulletspage.cpp:289
+#: ../src/richtext/richtextliststylepage.cpp:497
+msgid ">"
+msgstr ">"
+
+#: ../src/richtext/richtextbulletspage.cpp:290
+#: ../src/richtext/richtextliststylepage.cpp:498
+msgid "+"
+msgstr "+"
+
+#: ../src/richtext/richtextbulletspage.cpp:291
+#: ../src/richtext/richtextliststylepage.cpp:499
+msgid "~"
+msgstr "~"
+
+#: ../src/richtext/richtextctrl.cpp:859
+msgid "Drag"
+msgstr "இழுத்திடுக"
+
+#: ../src/richtext/richtextctrl.cpp:1338 ../src/richtext/richtextctrl.cpp:1559
+msgid "Delete Text"
+msgstr "உரையை அழித்திடுக"
+
+#: ../src/richtext/richtextctrl.cpp:1537
+msgid "Remove Bullet"
+msgstr "புள்ளியை நீக்குக"
+
+#: ../src/richtext/richtextctrl.cpp:3070
+msgid "The text couldn't be saved."
+msgstr "உரையை சேமிக்க இயலவில்லை."
+
+#: ../src/richtext/richtextctrl.cpp:3644
+msgid "Replace"
+msgstr "மாற்றமர்வு"
+
+#: ../src/richtext/richtextfontpage.cpp:146
+#: ../src/richtext/richtextsymboldlg.cpp:384
+msgid "&Font:"
+msgstr "எழுத்துரு (&F)"
+
+#: ../src/richtext/richtextfontpage.cpp:150
+#: ../src/richtext/richtextfontpage.cpp:152
+msgid "Type a font name."
+msgstr "ஒரு எழுத்துரு பெயரைத் தட்டச்சிடுக."
+
+#: ../src/richtext/richtextfontpage.cpp:158
+msgid "&Size:"
+msgstr "அளவு (&S):"
+
+#: ../src/richtext/richtextfontpage.cpp:165
+#: ../src/richtext/richtextfontpage.cpp:167
+msgid "Type a size in points."
+msgstr "ஒரு அளவை புள்ளிகளில் தட்டச்சிடுக."
+
+#: ../src/richtext/richtextfontpage.cpp:180
+#: ../src/richtext/richtextfontpage.cpp:182
+msgid "The font size units, points or pixels."
+msgstr "எழுத்துரு அளவு (அலகுகள், புள்ளிகள் அல்லது படவணுக்கள்)."
+
+#: ../src/richtext/richtextfontpage.cpp:189
+#: ../src/richtext/richtextfontpage.cpp:191
+msgid "Lists the available fonts."
+msgstr "இருக்கும் எழுத்துருக்களை பட்டியலிடுகிறது."
+
+#: ../src/richtext/richtextfontpage.cpp:196
+#: ../src/richtext/richtextfontpage.cpp:198
+msgid "Lists font sizes in points."
+msgstr "எழுத்துரு அளவுகளை புள்ளிகளில் பட்டியலிடுகிறது."
+
+#: ../src/richtext/richtextfontpage.cpp:207
+msgid "Font st&yle:"
+msgstr "எழுத்துருப் பாங்கு (&Y):"
+
+#: ../src/richtext/richtextfontpage.cpp:212
+#: ../src/richtext/richtextfontpage.cpp:214
+msgid "Select regular or italic style."
+msgstr "வழக்கமான அல்லது வலச்சாய்வுப் பாங்கைத் தெரிவுசெய்க."
+
+#: ../src/richtext/richtextfontpage.cpp:220
+msgid "Font &weight:"
+msgstr "எழுத்துரு அடர்த்தி (&W):"
+
+#: ../src/richtext/richtextfontpage.cpp:225
+#: ../src/richtext/richtextfontpage.cpp:227
+msgid "Select regular or bold."
+msgstr "வழக்கமான அல்லது அடர்த்தியை தெரிவுசெய்க."
+
+#: ../src/richtext/richtextfontpage.cpp:233
+msgid "&Underlining:"
+msgstr "அடிக்கோடிடல் (&U):"
+
+#: ../src/richtext/richtextfontpage.cpp:238
+#: ../src/richtext/richtextfontpage.cpp:240
+msgid "Select underlining or no underlining."
+msgstr "அடிக்கோடிடப்பட்டது அல்லது அடிக்கோடிடப்படாததை தெரிவுசெய்க"
+
+#: ../src/richtext/richtextfontpage.cpp:248
+msgid "&Colour:"
+msgstr "நிறம் (&C)"
+
+#: ../src/richtext/richtextfontpage.cpp:253
+#: ../src/richtext/richtextfontpage.cpp:255
+msgid "Click to change the text colour."
+msgstr "உரையின் நிறத்தை மாற்ற சொடுக்கவும்."
+
+#: ../src/richtext/richtextfontpage.cpp:261
+msgid "&Bg colour:"
+msgstr "பின்புல நிறம் (&B):"
+
+#: ../src/richtext/richtextfontpage.cpp:266
+#: ../src/richtext/richtextfontpage.cpp:268
+msgid "Click to change the text background colour."
+msgstr "உரையின் பின்புல நிறத்தை மாற்ற சொடுக்கவும்."
+
+#: ../src/richtext/richtextfontpage.cpp:276
+#: ../src/richtext/richtextfontpage.cpp:278
+msgid "Check to show a line through the text."
+msgstr "உரையினூடே ஒரு கோடு காட்டப்பட தேர்வுசெய்க."
+
+#: ../src/richtext/richtextfontpage.cpp:281
+msgid "Ca&pitals"
+msgstr "முகப்பெழுத்துகள் (&P)"
+
+#: ../src/richtext/richtextfontpage.cpp:283
+#: ../src/richtext/richtextfontpage.cpp:285
+msgid "Check to show the text in capitals."
+msgstr "உரை முகப்பெழுத்துகளில் காட்டப்பட தேர்வுசெய்க."
+
+#: ../src/richtext/richtextfontpage.cpp:288
+msgid "Small C&apitals"
+msgstr "சிறு முகப்பெழுத்துகள் (&A)"
+
+#: ../src/richtext/richtextfontpage.cpp:290
+#: ../src/richtext/richtextfontpage.cpp:292
+msgid "Check to show the text in small capitals."
+msgstr "சிறு முகப்பெழுத்துகளில் உரை காட்டப்பட தேர்வுசெய்க."
+
+#: ../src/richtext/richtextfontpage.cpp:295
+msgid "Supe&rscript"
+msgstr "மேலெழுத்து (&R)"
+
+#: ../src/richtext/richtextfontpage.cpp:297
+#: ../src/richtext/richtextfontpage.cpp:299
+msgid "Check to show the text in superscript."
+msgstr "மேலெழுத்துகளில் உரை காட்டப்பட தேர்வுசெய்க."
+
+#: ../src/richtext/richtextfontpage.cpp:302
+msgid "Subscrip&t"
+msgstr "கீழெழுத்து (&T)"
+
+#: ../src/richtext/richtextfontpage.cpp:304
+#: ../src/richtext/richtextfontpage.cpp:306
+msgid "Check to show the text in subscript."
+msgstr "கீழெழுத்துகளில் உரை காட்டப்பட தேர்வுசெய்க."
+
+#: ../src/richtext/richtextfontpage.cpp:312
+msgid "Rig&ht-to-left"
+msgstr "வலமிருந்து இடமாக (&H)"
+
+#: ../src/richtext/richtextfontpage.cpp:314
+#: ../src/richtext/richtextfontpage.cpp:316
+msgid "Check to indicate right-to-left text layout."
+msgstr "உரையின் தளவமைப்பு வலமிருந்து இடமாகக் குறிக்க தேர்வுசெய்க"
+
+#: ../src/richtext/richtextfontpage.cpp:319
+msgid "Suppress hyphe&nation"
+msgstr "இணைக்கோட்டை மறைத்திடுக (&N)"
+
+#: ../src/richtext/richtextfontpage.cpp:321
+#: ../src/richtext/richtextfontpage.cpp:323
+msgid "Check to suppress hyphenation."
+msgstr "இணைக்கோடு மறைக்கப்பட தேர்வுசெய்க."
+
+#: ../src/richtext/richtextfontpage.cpp:329
+#: ../src/richtext/richtextfontpage.cpp:331
+msgid "Shows a preview of the font settings."
+msgstr "எழுத்துரு அமைப்புகளின் முன்தோற்றத்தைக் காட்டுகிறது."
+
+#: ../src/richtext/richtextfontpage.cpp:348
+#: ../src/richtext/richtextfontpage.cpp:352
+#: ../src/richtext/richtextfontpage.cpp:356
+#: ../src/richtext/richtextformatdlg.cpp:873
+#: ../src/richtext/richtextindentspage.cpp:273
+#: ../src/richtext/richtextindentspage.cpp:285
+#: ../src/richtext/richtextindentspage.cpp:286
+#: ../src/richtext/richtextindentspage.cpp:310
+#: ../src/richtext/richtextindentspage.cpp:325
+#: ../src/richtext/richtextliststylepage.cpp:451
+#: ../src/richtext/richtextliststylepage.cpp:463
+#: ../src/richtext/richtextliststylepage.cpp:464
+msgid "(none)"
+msgstr "(ஏதுமில்லை)"
+
+#: ../src/richtext/richtextfontpage.cpp:349
+#: ../src/richtext/richtextfontpage.cpp:353
+msgid "Regular"
+msgstr "வழக்கமானது"
+
+#: ../src/richtext/richtextfontpage.cpp:357
+msgid "Not underlined"
+msgstr "அடிக்கோடிடப்படாதது"
+
+#: ../src/richtext/richtextformatdlg.cpp:341
+msgid "Indents && Spacing"
+msgstr "ஒழுங்கமைவும் இடைவெளியும் (&&)"
+
+#: ../src/richtext/richtextformatdlg.cpp:346
+msgid "Tabs"
+msgstr "பட்டிகள்"
+
+#: ../src/richtext/richtextformatdlg.cpp:351
+msgid "Bullets"
+msgstr "புள்ளிகள்"
+
+#: ../src/richtext/richtextformatdlg.cpp:356
+msgid "List Style"
+msgstr "பட்டியல் பாங்கு"
+
+#: ../src/richtext/richtextformatdlg.cpp:366
+#: ../src/richtext/richtextmarginspage.cpp:170
+msgid "Margins"
+msgstr "ஓரங்கள்"
+
+#: ../src/richtext/richtextformatdlg.cpp:371
+msgid "Borders"
+msgstr "எல்லைகள்"
+
+#: ../src/richtext/richtextformatdlg.cpp:765
+msgid "Colour"
+msgstr "நிறம்"
+
+#: ../src/richtext/richtextindentspage.cpp:127
+#: ../src/richtext/richtextliststylepage.cpp:322
+msgid "&Alignment"
+msgstr "ஒழுங்கமைப்பு (&A)"
+
+#: ../src/richtext/richtextindentspage.cpp:138
+#: ../src/richtext/richtextliststylepage.cpp:331
+msgid "&Left"
+msgstr "இடது (&L)"
+
+#: ../src/richtext/richtextindentspage.cpp:140
+#: ../src/richtext/richtextindentspage.cpp:142
+#: ../src/richtext/richtextliststylepage.cpp:333
+#: ../src/richtext/richtextliststylepage.cpp:335
+msgid "Left-align text."
+msgstr "உரையை இடப்புரமாக ஒழுங்கமைத்திடுக:"
+
+#: ../src/richtext/richtextindentspage.cpp:145
+#: ../src/richtext/richtextliststylepage.cpp:338
+msgid "&Right"
+msgstr "வலது (&R)"
+
+#: ../src/richtext/richtextindentspage.cpp:147
+#: ../src/richtext/richtextindentspage.cpp:149
+#: ../src/richtext/richtextliststylepage.cpp:340
+#: ../src/richtext/richtextliststylepage.cpp:342
+msgid "Right-align text."
+msgstr "உரையை வலப்புறமாக ஒழுங்கமைத்திடுக."
+
+#: ../src/richtext/richtextindentspage.cpp:152
+#: ../src/richtext/richtextliststylepage.cpp:345
+msgid "&Justified"
+msgstr "இருபுற ஒழுங்கு (&J)"
+
+#: ../src/richtext/richtextindentspage.cpp:154
+#: ../src/richtext/richtextindentspage.cpp:156
+#: ../src/richtext/richtextliststylepage.cpp:347
+#: ../src/richtext/richtextliststylepage.cpp:349
+msgid "Justify text left and right."
+msgstr "உரையை இடதும் வலதுமாக ஒழுங்கமைத்திடுக."
+
+#: ../src/richtext/richtextindentspage.cpp:159
+#: ../src/richtext/richtextliststylepage.cpp:352
+msgid "Cen&tred"
+msgstr "மையமாக்கப்பட்டது (&T)"
+
+#: ../src/richtext/richtextindentspage.cpp:161
+#: ../src/richtext/richtextindentspage.cpp:163
+#: ../src/richtext/richtextliststylepage.cpp:354
+#: ../src/richtext/richtextliststylepage.cpp:356
+msgid "Centre text."
+msgstr "உரையை மையமாக்கு"
+
+#: ../src/richtext/richtextindentspage.cpp:166
+#: ../src/richtext/richtextliststylepage.cpp:359
+msgid "&Indeterminate"
+msgstr "வரையறுக்கப்படாதது (&I)"
+
+#: ../src/richtext/richtextindentspage.cpp:168
+#: ../src/richtext/richtextindentspage.cpp:170
+#: ../src/richtext/richtextliststylepage.cpp:361
+#: ../src/richtext/richtextliststylepage.cpp:363
+msgid "Use the current alignment setting."
+msgstr "தற்போதைய ஒழுங்கமைப்பு அமைப்புகளை பயன்படுத்தவும்."
+
+#: ../src/richtext/richtextindentspage.cpp:183
+#: ../src/richtext/richtextliststylepage.cpp:375
+msgid "&Indentation (tenths of a mm)"
+msgstr "உள் தள்ளுதல் (மில்லி மீட்டரின் பத்தில் ஒரு பகுதி) (&I)"
+
+#: ../src/richtext/richtextindentspage.cpp:198
+#: ../src/richtext/richtextindentspage.cpp:200
+#: ../src/richtext/richtextliststylepage.cpp:388
+#: ../src/richtext/richtextliststylepage.cpp:390
+msgid "The left indent."
+msgstr "இடது உள் தள்ளுதல்"
+
+#: ../src/richtext/richtextindentspage.cpp:203
+#: ../src/richtext/richtextliststylepage.cpp:393
+msgid "Left (&first line):"
+msgstr "இடது (முதல் வரி) (&F):"
+
+#: ../src/richtext/richtextindentspage.cpp:207
+#: ../src/richtext/richtextindentspage.cpp:209
+#: ../src/richtext/richtextliststylepage.cpp:397
+#: ../src/richtext/richtextliststylepage.cpp:399
+msgid "The first line indent."
+msgstr "முதல் வரி உள் தள்ளுதல்."
+
+#: ../src/richtext/richtextindentspage.cpp:216
+#: ../src/richtext/richtextindentspage.cpp:218
+#: ../src/richtext/richtextliststylepage.cpp:406
+#: ../src/richtext/richtextliststylepage.cpp:408
+msgid "The right indent."
+msgstr "வலது உள் தள்ளுதல்"
+
+#: ../src/richtext/richtextindentspage.cpp:221
+msgid "&Outline level:"
+msgstr "வெளிக்கோடு மட்டம் (&O)"
+
+#: ../src/richtext/richtextindentspage.cpp:226
+#: ../src/richtext/richtextindentspage.cpp:228
+msgid "The outline level."
+msgstr "வெளிக்கோடு மட்டம்."
+
+#: ../src/richtext/richtextindentspage.cpp:241
+#: ../src/richtext/richtextliststylepage.cpp:420
+msgid "&Spacing (tenths of a mm)"
+msgstr "இடைவெளி (மில்லி மீட்டரின் பத்தில் ஒரு பகுதி) (&S)"
+
+#: ../src/richtext/richtextindentspage.cpp:252
+msgid "&Before a paragraph:"
+msgstr "ஒரு பத்திக்கு முன்பு (&B)"
+
+#: ../src/richtext/richtextindentspage.cpp:256
+#: ../src/richtext/richtextindentspage.cpp:258
+#: ../src/richtext/richtextliststylepage.cpp:433
+#: ../src/richtext/richtextliststylepage.cpp:435
+msgid "The spacing before the paragraph."
+msgstr "பத்திக்கு முந்தைய இடைவெளி."
+
+#: ../src/richtext/richtextindentspage.cpp:261
+msgid "&After a paragraph:"
+msgstr "ஒரு பத்திக்குப் பிறகு (&A)"
+
+#: ../src/richtext/richtextindentspage.cpp:266
+#: ../src/richtext/richtextliststylepage.cpp:442
+#: ../src/richtext/richtextliststylepage.cpp:444
+msgid "The spacing after the paragraph."
+msgstr "பத்திக்கு பிறகான இடைவெளி."
+
+#: ../src/richtext/richtextindentspage.cpp:269
+msgid "L&ine spacing:"
+msgstr "வரி இடைவெளி (&I)"
+
+#: ../src/richtext/richtextindentspage.cpp:274
+#: ../src/richtext/richtextliststylepage.cpp:452
+msgid "Single"
+msgstr "ஒற்றை"
+
+#: ../src/richtext/richtextindentspage.cpp:275
+#: ../src/richtext/richtextliststylepage.cpp:453
+msgid "1.1"
+msgstr "1.1"
+
+#: ../src/richtext/richtextindentspage.cpp:276
+#: ../src/richtext/richtextliststylepage.cpp:454
+msgid "1.2"
+msgstr "1.2"
+
+#: ../src/richtext/richtextindentspage.cpp:277
+#: ../src/richtext/richtextliststylepage.cpp:455
+msgid "1.3"
+msgstr "1.3"
+
+#: ../src/richtext/richtextindentspage.cpp:278
+#: ../src/richtext/richtextliststylepage.cpp:456
+msgid "1.4"
+msgstr "1.4"
+
+#: ../src/richtext/richtextindentspage.cpp:279
+#: ../src/richtext/richtextliststylepage.cpp:457
+msgid "1.5"
+msgstr "1.5"
+
+#: ../src/richtext/richtextindentspage.cpp:280
+#: ../src/richtext/richtextliststylepage.cpp:458
+msgid "1.6"
+msgstr "1.6"
+
+#: ../src/richtext/richtextindentspage.cpp:281
+#: ../src/richtext/richtextliststylepage.cpp:459
+msgid "1.7"
+msgstr "1.7"
+
+#: ../src/richtext/richtextindentspage.cpp:282
+#: ../src/richtext/richtextliststylepage.cpp:460
+msgid "1.8"
+msgstr "1.8"
+
+#: ../src/richtext/richtextindentspage.cpp:283
+#: ../src/richtext/richtextliststylepage.cpp:461
+msgid "1.9"
+msgstr "1.9"
+
+#: ../src/richtext/richtextindentspage.cpp:284
+#: ../src/richtext/richtextliststylepage.cpp:462
+msgid "2"
+msgstr "2"
+
+#: ../src/richtext/richtextindentspage.cpp:287
+#: ../src/richtext/richtextindentspage.cpp:289
+#: ../src/richtext/richtextliststylepage.cpp:465
+#: ../src/richtext/richtextliststylepage.cpp:467
+msgid "The line spacing."
+msgstr "வரி இடைவெளி."
+
+#: ../src/richtext/richtextindentspage.cpp:292
+msgid "&Page Break"
+msgstr "பக்க முறிவு (&P)"
+
+#: ../src/richtext/richtextindentspage.cpp:294
+#: ../src/richtext/richtextindentspage.cpp:296
+msgid "Inserts a page break before the paragraph."
+msgstr "பக்க முறிவை பத்திக்கு முன் செருகுகிறது."
+
+#: ../src/richtext/richtextindentspage.cpp:302
+#: ../src/richtext/richtextindentspage.cpp:304
+msgid "Shows a preview of the paragraph settings."
+msgstr "பத்தி அமைப்புகளின் முன்தோற்றத்தைக் காட்டுகிறது."
+
+#: ../src/richtext/richtextliststylepage.cpp:182
+msgid "&List level:"
+msgstr "பட்டியல் மட்டம் (&L)"
+
+#: ../src/richtext/richtextliststylepage.cpp:186
+#: ../src/richtext/richtextliststylepage.cpp:188
+msgid "Selects the list level to edit."
+msgstr "தொகுப்பதற்காக பட்டியலின் மட்டத்தைத் தெரிவு செய்கிறது."
+
+#: ../src/richtext/richtextliststylepage.cpp:193
+msgid "&Font for Level..."
+msgstr "மட்டத்திற்கான எழுத்துரு (&F):"
+
+#: ../src/richtext/richtextliststylepage.cpp:194
+#: ../src/richtext/richtextliststylepage.cpp:196
+msgid "Click to choose the font for this level."
+msgstr "இம்மட்டத்திற்கான எழுத்துருவைத் தேர்ந்தெடுக்க சொடுக்கவும்."
+
+#: ../src/richtext/richtextliststylepage.cpp:312
+msgid "Bullet style"
+msgstr "புள்ளிப் பாங்கு"
+
+#: ../src/richtext/richtextliststylepage.cpp:429
+msgid "Before a paragraph:"
+msgstr "ஒரு பத்திக்கு முன்பு:"
+
+#: ../src/richtext/richtextliststylepage.cpp:438
+msgid "After a paragraph:"
+msgstr "ஒரு பத்திக்குப் பிறகு:"
+
+#: ../src/richtext/richtextliststylepage.cpp:447
+msgid "Line spacing:"
+msgstr "வரி இடைவெளி:"
+
+#: ../src/richtext/richtextliststylepage.cpp:470
+msgid "Spacing"
+msgstr "இடைவெளியிடல்"
+
+#: ../src/richtext/richtextmarginspage.cpp:193
+#: ../src/richtext/richtextmarginspage.cpp:195
+msgid "The left margin size."
+msgstr "இடதோரத்தின் அளவு."
+
+#: ../src/richtext/richtextmarginspage.cpp:203
+#: ../src/richtext/richtextmarginspage.cpp:205
+msgid "Units for the left margin."
+msgstr "இடதோரத்திற்கான அலகுகள்"
+
+#: ../src/richtext/richtextmarginspage.cpp:218
+#: ../src/richtext/richtextmarginspage.cpp:220
+msgid "The right margin size."
+msgstr "வலதோரத்தின் அளவு."
+
+#: ../src/richtext/richtextmarginspage.cpp:228
+#: ../src/richtext/richtextmarginspage.cpp:230
+msgid "Units for the right margin."
+msgstr "வலதோரத்திற்கான அலகுகள்."
+
+#: ../src/richtext/richtextmarginspage.cpp:241
+#: ../src/richtext/richtextmarginspage.cpp:243
+msgid "The top margin size."
+msgstr "மேலோரத்தின் அளவு."
+
+#: ../src/richtext/richtextmarginspage.cpp:251
+#: ../src/richtext/richtextmarginspage.cpp:253
+msgid "Units for the top margin."
+msgstr "மேலோரத்திற்கான அலகுகள்."
+
+#: ../src/richtext/richtextmarginspage.cpp:266
+#: ../src/richtext/richtextmarginspage.cpp:268
+msgid "The bottom margin size."
+msgstr "கீழோரத்தின் அளவு"
+
+#: ../src/richtext/richtextmarginspage.cpp:276
+#: ../src/richtext/richtextmarginspage.cpp:278
+msgid "Units for the bottom margin."
+msgstr "கீழோரத்திற்கான அலகுகள்."
+
+#: ../src/richtext/richtextmarginspage.cpp:284
+msgid "Padding"
+msgstr "உள்நிரப்புதல்"
+
+#: ../src/richtext/richtextmarginspage.cpp:307
+#: ../src/richtext/richtextmarginspage.cpp:309
+msgid "The left padding size."
+msgstr "இடது உள்நிரப்பு அளவு  "
+
+#: ../src/richtext/richtextmarginspage.cpp:317
+#: ../src/richtext/richtextmarginspage.cpp:319
+msgid "Units for the left padding."
+msgstr "இடது உள்நிரப்புதலுக்கான அலகுகள்"
+
+#: ../src/richtext/richtextmarginspage.cpp:332
+#: ../src/richtext/richtextmarginspage.cpp:334
+msgid "The right padding size."
+msgstr "வலது உள்நிரப்பு அளவு."
+
+#: ../src/richtext/richtextmarginspage.cpp:342
+#: ../src/richtext/richtextmarginspage.cpp:344
+msgid "Units for the right padding."
+msgstr "வலது உள்நிரப்புதலுக்கான அலகுகள்."
+
+#: ../src/richtext/richtextmarginspage.cpp:355
+#: ../src/richtext/richtextmarginspage.cpp:357
+msgid "The top padding size."
+msgstr "மேல் உள்நிரப்பு அளவு."
+
+#: ../src/richtext/richtextmarginspage.cpp:365
+#: ../src/richtext/richtextmarginspage.cpp:367
+msgid "Units for the top padding."
+msgstr "மேல் உள்நிரப்புதலுக்கான அலகுகள்."
+
+#: ../src/richtext/richtextmarginspage.cpp:380
+#: ../src/richtext/richtextmarginspage.cpp:382
+msgid "The bottom padding size."
+msgstr "கீழ் உள்நிரப்பு அளவு."
+
+#: ../src/richtext/richtextmarginspage.cpp:390
+#: ../src/richtext/richtextmarginspage.cpp:392
+msgid "Units for the bottom padding."
+msgstr "கீழ் உள்நிரப்புதலுக்கான அலகுகள்."
+
+#: ../src/richtext/richtextprint.cpp:592
+msgid " Preview"
+msgstr "முன்தோற்றம்"
+
+#: ../src/richtext/richtextsizepage.cpp:228
+msgid "Floating"
+msgstr "மிதக்கும்"
+
+#: ../src/richtext/richtextsizepage.cpp:243
+msgid "&Floating mode:"
+msgstr "மிதக்கும் முறை (&F):"
+
+#: ../src/richtext/richtextsizepage.cpp:252
+#: ../src/richtext/richtextsizepage.cpp:254
+msgid "How the object will float relative to the text."
+msgstr "உரைக்கு ஏற்றவாறு பொருள் எவ்வாறு மிதக்கும்."
+
+#: ../src/richtext/richtextsizepage.cpp:265
+msgid "Alignment"
+msgstr "ஒழுங்கமைப்பு"
+
+#: ../src/richtext/richtextsizepage.cpp:277
+msgid "&Vertical alignment:"
+msgstr "செங்குத்து ஒழுங்கமைப்பு (&V)"
+
+#: ../src/richtext/richtextsizepage.cpp:279
+#: ../src/richtext/richtextsizepage.cpp:281
+msgid "Enable vertical alignment."
+msgstr "செங்குத்து ஒழுங்கமைவினை முடுக்குக"
+
+#: ../src/richtext/richtextsizepage.cpp:286
+msgid "Centred"
+msgstr "மையமாக்கப்பட்டது"
+
+#: ../src/richtext/richtextsizepage.cpp:290
+#: ../src/richtext/richtextsizepage.cpp:292
+msgid "Vertical alignment."
+msgstr "செங்குத்து ஒழுங்கமைப்பு."
+
+#: ../src/richtext/richtextsizepage.cpp:316
+#: ../src/richtext/richtextsizepage.cpp:323
+msgid "&Width:"
+msgstr "அகலம் (&W):"
+
+#: ../src/richtext/richtextsizepage.cpp:318
+#: ../src/richtext/richtextsizepage.cpp:320
+msgid "Enable the width value."
+msgstr "அகலத்தின் மதிப்பை முடுக்குக"
+
+#: ../src/richtext/richtextsizepage.cpp:331
+#: ../src/richtext/richtextsizepage.cpp:333
+msgid "The object width."
+msgstr "பொருள் அகலம்."
+
+#: ../src/richtext/richtextsizepage.cpp:342
+#: ../src/richtext/richtextsizepage.cpp:344
+msgid "Units for the object width."
+msgstr "பொருள் அகலத்திற்கான அலகுகள்."
+
+#: ../src/richtext/richtextsizepage.cpp:350
+#: ../src/richtext/richtextsizepage.cpp:357
+msgid "&Height:"
+msgstr "உயரம் (&H):"
+
+#: ../src/richtext/richtextsizepage.cpp:352
+#: ../src/richtext/richtextsizepage.cpp:354
+#: ../src/richtext/richtextsizepage.cpp:464
+#: ../src/richtext/richtextsizepage.cpp:466
+msgid "Enable the height value."
+msgstr "உயரத்தின் மதிப்பை முடுக்குக"
+
+#: ../src/richtext/richtextsizepage.cpp:365
+#: ../src/richtext/richtextsizepage.cpp:367
+msgid "The object height."
+msgstr "பொருள் உயரம்."
+
+#: ../src/richtext/richtextsizepage.cpp:376
+#: ../src/richtext/richtextsizepage.cpp:378
+msgid "Units for the object height."
+msgstr "பொருள் உயரத்திற்கான அலகுகள்."
+
+#: ../src/richtext/richtextsizepage.cpp:381
+msgid "Min width:"
+msgstr "குறைந்தபட்ச அகலம்:"
+
+#: ../src/richtext/richtextsizepage.cpp:383
+#: ../src/richtext/richtextsizepage.cpp:385
+msgid "Enable the minimum width value."
+msgstr "குறைந்தபட்ச அகலத்தின் மதிப்பை முடுக்குக"
+
+#: ../src/richtext/richtextsizepage.cpp:392
+#: ../src/richtext/richtextsizepage.cpp:394
+msgid "The object minimum width."
+msgstr "பொருளின் குறைந்தபட்ச அகலம்."
+
+#: ../src/richtext/richtextsizepage.cpp:403
+#: ../src/richtext/richtextsizepage.cpp:405
+msgid "Units for the minimum object width."
+msgstr "பொருளின் குறைந்தபட்ச அகலத்திற்கான அலகுகள்."
+
+#: ../src/richtext/richtextsizepage.cpp:408
+msgid "Min height:"
+msgstr "குறைந்தபட்ச உயரம்:"
+
+#: ../src/richtext/richtextsizepage.cpp:410
+#: ../src/richtext/richtextsizepage.cpp:412
+msgid "Enable the minimum height value."
+msgstr "குறைந்தபட்ச உயரத்தின் மதிப்பை முடுக்குக"
+
+#: ../src/richtext/richtextsizepage.cpp:419
+#: ../src/richtext/richtextsizepage.cpp:421
+msgid "The object minimum height."
+msgstr "பொருளின் குறைந்தபட்ச உயரம்."
+
+#: ../src/richtext/richtextsizepage.cpp:430
+#: ../src/richtext/richtextsizepage.cpp:432
+msgid "Units for the minimum object height."
+msgstr "பொருளின் குறைந்தபட்ச உயரத்திற்கான அலகுகள்."
+
+#: ../src/richtext/richtextsizepage.cpp:435
+msgid "Max width:"
+msgstr "உட்சபட்ச அகலம்:"
+
+#: ../src/richtext/richtextsizepage.cpp:437
+#: ../src/richtext/richtextsizepage.cpp:439
+msgid "Enable the maximum width value."
+msgstr "உட்சபட்ச அகலத்தின் மதிப்பை முடுக்குக"
+
+#: ../src/richtext/richtextsizepage.cpp:446
+#: ../src/richtext/richtextsizepage.cpp:448
+msgid "The object maximum width."
+msgstr "பொருளின் உட்சபட்ச அகலம்."
+
+#: ../src/richtext/richtextsizepage.cpp:457
+#: ../src/richtext/richtextsizepage.cpp:459
+msgid "Units for the maximum object width."
+msgstr "பொருளின் உட்சபட்ச அகலத்திற்கான அலகுகள்."
+
+#: ../src/richtext/richtextsizepage.cpp:462
+msgid "Max height:"
+msgstr "உட்சபட்ச உயரம்:"
+
+#: ../src/richtext/richtextsizepage.cpp:473
+#: ../src/richtext/richtextsizepage.cpp:475
+msgid "The object maximum height."
+msgstr "பொருளின் உட்சபட்ச  உயரம்."
+
+#: ../src/richtext/richtextsizepage.cpp:484
+#: ../src/richtext/richtextsizepage.cpp:486
+msgid "Units for the maximum object height."
+msgstr "பொருளின் உட்சபட்ச  உயரத்திற்கான அலகுகள்."
+
+#: ../src/richtext/richtextsizepage.cpp:495
+msgid "Position"
+msgstr "நிலை"
+
+#: ../src/richtext/richtextsizepage.cpp:513
+msgid "&Position mode:"
+msgstr "நிலைமுறை (&P):"
+
+#: ../src/richtext/richtextsizepage.cpp:517
+#: ../src/richtext/richtextsizepage.cpp:522
+msgid "Static"
+msgstr "அசைவற்றது"
+
+#: ../src/richtext/richtextsizepage.cpp:518
+msgid "Relative"
+msgstr "சார்புடைய"
+
+#: ../src/richtext/richtextsizepage.cpp:519
+msgid "Absolute"
+msgstr "முழுமையான"
+
+#: ../src/richtext/richtextsizepage.cpp:520
+msgid "Fixed"
+msgstr "நிலையான"
+
+#: ../src/richtext/richtextsizepage.cpp:533
+#: ../src/richtext/richtextsizepage.cpp:535
+#: ../src/richtext/richtextsizepage.cpp:547
+#: ../src/richtext/richtextsizepage.cpp:549
+msgid "The left position."
+msgstr "இடது நிலை."
+
+#: ../src/richtext/richtextsizepage.cpp:558
+#: ../src/richtext/richtextsizepage.cpp:560
+msgid "Units for the left position."
+msgstr "இடது நிலைக்கான அலகுகள்."
+
+#: ../src/richtext/richtextsizepage.cpp:568
+#: ../src/richtext/richtextsizepage.cpp:570
+#: ../src/richtext/richtextsizepage.cpp:582
+#: ../src/richtext/richtextsizepage.cpp:584
+msgid "The top position."
+msgstr "மேல் நிலை."
+
+#: ../src/richtext/richtextsizepage.cpp:593
+#: ../src/richtext/richtextsizepage.cpp:595
+msgid "Units for the top position."
+msgstr "மேல் நிலைக்கான அலகுகள்."
+
+#: ../src/richtext/richtextsizepage.cpp:603
+#: ../src/richtext/richtextsizepage.cpp:605
+#: ../src/richtext/richtextsizepage.cpp:617
+#: ../src/richtext/richtextsizepage.cpp:619
+msgid "The right position."
+msgstr "வலது நிலை."
+
+#: ../src/richtext/richtextsizepage.cpp:628
+#: ../src/richtext/richtextsizepage.cpp:630
+msgid "Units for the right position."
+msgstr "வலது நிலைக்கான அலகுகள்."
+
+#: ../src/richtext/richtextsizepage.cpp:638
+#: ../src/richtext/richtextsizepage.cpp:640
+#: ../src/richtext/richtextsizepage.cpp:652
+#: ../src/richtext/richtextsizepage.cpp:654
+msgid "The bottom position."
+msgstr "கீழ் நிலை."
+
+#: ../src/richtext/richtextsizepage.cpp:663
+#: ../src/richtext/richtextsizepage.cpp:665
+msgid "Units for the bottom position."
+msgstr "கீழ் நிலைக்கான அலகுகள்."
+
+#: ../src/richtext/richtextsizepage.cpp:671
+msgid "&Move the object to:"
+msgstr "பொருளை இங்கு நகர்த்துக (&M):"
+
+#: ../src/richtext/richtextsizepage.cpp:674
+msgid "&Previous Paragraph"
+msgstr "முந்தைய பத்தி (&P)"
+
+#: ../src/richtext/richtextsizepage.cpp:675
+#: ../src/richtext/richtextsizepage.cpp:677
+msgid "Moves the object to the previous paragraph."
+msgstr "பொருளை முந்தைய பத்திக்கு நகர்த்துகிறது."
+
+#: ../src/richtext/richtextsizepage.cpp:680
+msgid "&Next Paragraph"
+msgstr "அடுத்த பத்தி (&N)"
+
+#: ../src/richtext/richtextsizepage.cpp:681
+#: ../src/richtext/richtextsizepage.cpp:683
+msgid "Moves the object to the next paragraph."
+msgstr "பொருளை அடுத்த பத்திக்கு நகர்த்துகிறது."
+
+#: ../src/richtext/richtextstyledlg.cpp:193
+msgid "&Styles:"
+msgstr "பாங்குகள் (&S):"
+
+#: ../src/richtext/richtextstyledlg.cpp:197
+#: ../src/richtext/richtextstyledlg.cpp:199
+msgid "The available styles."
+msgstr "கிடைப்பில் இருக்கும் பாங்குகள்."
+
+#: ../src/richtext/richtextstyledlg.cpp:205
+#: ../src/richtext/richtextstyledlg.cpp:217
+msgid " "
+msgstr " "
+
+#: ../src/richtext/richtextstyledlg.cpp:209
+#: ../src/richtext/richtextstyledlg.cpp:211
+msgid "The style preview."
+msgstr "பாங்கு முன்தோற்றம்."
+
+#: ../src/richtext/richtextstyledlg.cpp:220
+msgid "New &Character Style..."
+msgstr "புது வரியுருப் பாங்கு... (&C)"
+
+#: ../src/richtext/richtextstyledlg.cpp:221
+#: ../src/richtext/richtextstyledlg.cpp:223
+msgid "Click to create a new character style."
+msgstr "ஒரு புது வரியுருப் பாங்கினை உருவாக்க சொடுக்கிடுக."
+
+#: ../src/richtext/richtextstyledlg.cpp:226
+msgid "New &Paragraph Style..."
+msgstr "புதுப் பத்திப் பாங்கு... (&P)"
+
+#: ../src/richtext/richtextstyledlg.cpp:227
+#: ../src/richtext/richtextstyledlg.cpp:229
+msgid "Click to create a new paragraph style."
+msgstr "ஒரு புதுப் பத்திப் பாங்கினை உருவாக்க சொடுக்கிடுக."
+
+#: ../src/richtext/richtextstyledlg.cpp:232
+msgid "New &List Style..."
+msgstr "புதுப் பட்டியல் பாங்கு... (&N)"
+
+#: ../src/richtext/richtextstyledlg.cpp:233
+#: ../src/richtext/richtextstyledlg.cpp:235
+msgid "Click to create a new list style."
+msgstr "ஒரு புதுப் பட்டியல் பாங்கினை உருவாக்க சொடுக்கிடுக."
+
+#: ../src/richtext/richtextstyledlg.cpp:238
+msgid "New &Box Style..."
+msgstr "புதுப் பெட்டிப் பாங்கு... (&B)"
+
+#: ../src/richtext/richtextstyledlg.cpp:239
+#: ../src/richtext/richtextstyledlg.cpp:241
+msgid "Click to create a new box style."
+msgstr "ஒரு புதுப் பெட்டிப் பாங்கினை உருவாக்க சொடுக்கிடுக."
+
+#: ../src/richtext/richtextstyledlg.cpp:246
+msgid "&Apply Style"
+msgstr "பாங்கினை இடுக (&A)"
+
+#: ../src/richtext/richtextstyledlg.cpp:247
+#: ../src/richtext/richtextstyledlg.cpp:249
+msgid "Click to apply the selected style."
+msgstr "தெரிவு செய்யப்பட்ட பாங்கினை இட சொடுக்கிடுக."
+
+#: ../src/richtext/richtextstyledlg.cpp:252
+msgid "&Rename Style..."
+msgstr "பாங்கினை மறுபெயரிடுக (&R)"
+
+#: ../src/richtext/richtextstyledlg.cpp:253
+#: ../src/richtext/richtextstyledlg.cpp:255
+msgid "Click to rename the selected style."
+msgstr "தெரிவு செய்யப்பட்டுள்ள பாங்கினை மறுபெயரிட சொடுக்கிடுக."
+
+#: ../src/richtext/richtextstyledlg.cpp:258
+msgid "&Edit Style..."
+msgstr "பாங்கினைத் தொகுத்திடுக (&E)"
+
+#: ../src/richtext/richtextstyledlg.cpp:259
+#: ../src/richtext/richtextstyledlg.cpp:261
+msgid "Click to edit the selected style."
+msgstr "தெரிவு செய்யப்பட்டுள்ள பாங்கினை தொகுக்க சொடுக்கிடுக."
+
+#: ../src/richtext/richtextstyledlg.cpp:264
+msgid "&Delete Style..."
+msgstr "பாங்கினை அழித்திடுக (&D)"
+
+#: ../src/richtext/richtextstyledlg.cpp:265
+#: ../src/richtext/richtextstyledlg.cpp:267
+msgid "Click to delete the selected style."
+msgstr "தெரிவு செய்யப்பட்டுள்ள பாங்கினை நீக்க சொடுக்கிடுக."
+
+#: ../src/richtext/richtextstyledlg.cpp:274
+#: ../src/richtext/richtextstyledlg.cpp:276
+msgid "Click to close this window."
+msgstr "இச்சாளரத்தை மூட சொடுக்கிடுக."
+
+#: ../src/richtext/richtextstyledlg.cpp:282
+msgid "&Restart numbering"
+msgstr "எண்ணிடுதலை மீள்துவக்குக (&R)"
+
+#: ../src/richtext/richtextstyledlg.cpp:284
+#: ../src/richtext/richtextstyledlg.cpp:286
+msgid "Check to restart numbering."
+msgstr "எண்ணிடலை மறுதுவக்க தேர்வுசெய்க."
+
+#: ../src/richtext/richtextstyledlg.cpp:601
+msgid "Enter a character style name"
+msgstr "வரியுருப் பாங்கின் பெயரை உள்ளிடுக"
+
+#: ../src/richtext/richtextstyledlg.cpp:601
+#: ../src/richtext/richtextstyledlg.cpp:606
+#: ../src/richtext/richtextstyledlg.cpp:649
+#: ../src/richtext/richtextstyledlg.cpp:654
+#: ../src/richtext/richtextstyledlg.cpp:815
+#: ../src/richtext/richtextstyledlg.cpp:820
+#: ../src/richtext/richtextstyledlg.cpp:888
+#: ../src/richtext/richtextstyledlg.cpp:896
+#: ../src/richtext/richtextstyledlg.cpp:929
+#: ../src/richtext/richtextstyledlg.cpp:934
+msgid "New Style"
+msgstr "புதுப் பாங்கு"
+
+#: ../src/richtext/richtextstyledlg.cpp:606
+#: ../src/richtext/richtextstyledlg.cpp:654
+#: ../src/richtext/richtextstyledlg.cpp:820
+#: ../src/richtext/richtextstyledlg.cpp:896
+#: ../src/richtext/richtextstyledlg.cpp:934
+msgid "Sorry, that name is taken. Please choose another."
+msgstr "பொருத்தருள்க, அந்தப் பெயர் ஏற்கனவே உள்ளது. அருள்கூர்ந்து வேறொன்றைத் தேர்ந்தெடுக்கவும்."
+
+#: ../src/richtext/richtextstyledlg.cpp:649
+msgid "Enter a paragraph style name"
+msgstr "பத்திப் பாங்கு ஒன்றின் பெயரை உள்ளிடுக"
+
+#: ../src/richtext/richtextstyledlg.cpp:777
+#, c-format
+msgid "Delete style %s?"
+msgstr "%s பாங்கினை அழிக்க வேண்டுமா?"
+
+#: ../src/richtext/richtextstyledlg.cpp:777
+msgid "Delete Style"
+msgstr "பாங்கினை அழித்திடுக"
+
+#: ../src/richtext/richtextstyledlg.cpp:815
+msgid "Enter a list style name"
+msgstr "பட்டியல் பாங்கு ஒன்றின்  பெயரை உள்ளிடுக"
+
+#: ../src/richtext/richtextstyledlg.cpp:888
+msgid "Enter a new style name"
+msgstr "புதுப் பாங்கு ஒன்றின்  பெயரை உள்ளிடுக"
+
+#: ../src/richtext/richtextstyledlg.cpp:929
+msgid "Enter a box style name"
+msgstr "பெட்டிப் பாங்கு ஒன்றின்  பெயரை உள்ளிடுக"
+
+#: ../src/richtext/richtextstylepage.cpp:109
+#: ../src/richtext/richtextstylepage.cpp:111
+msgid "The style name."
+msgstr "பாங்கின் பெயர்."
+
+#: ../src/richtext/richtextstylepage.cpp:114
+msgid "&Based on:"
+msgstr "இதன் அடிப்படையில் (&B):"
+
+#: ../src/richtext/richtextstylepage.cpp:119
+#: ../src/richtext/richtextstylepage.cpp:121
+msgid "The style on which this style is based."
+msgstr "இப்பாங்கு அடிப்படையாகக் கொண்டிருக்கும் பாங்கு."
+
+#: ../src/richtext/richtextstylepage.cpp:124
+msgid "&Next style:"
+msgstr "அடுத்த பாங்கு (&N)"
+
+#: ../src/richtext/richtextstylepage.cpp:129
+#: ../src/richtext/richtextstylepage.cpp:131
+msgid "The default style for the next paragraph."
+msgstr "அடுத்த பத்திக்கான இயல்பிருப்புப் பாங்கு."
+
+#: ../src/richtext/richtextstyles.cpp:1057
+msgid "All styles"
+msgstr "எல்லாப் பாங்குகளும்"
+
+#: ../src/richtext/richtextstyles.cpp:1058
+msgid "Paragraph styles"
+msgstr "பத்திப் பாங்குகள்"
+
+#: ../src/richtext/richtextstyles.cpp:1059
+msgid "Character styles"
+msgstr "வரியுருப் பாங்குகள்"
+
+#: ../src/richtext/richtextstyles.cpp:1060
+msgid "List styles"
+msgstr "பட்டியல் பாங்குகள்"
+
+#: ../src/richtext/richtextstyles.cpp:1061
+msgid "Box styles"
+msgstr "பெட்டிப் பாங்குகள்"
+
+#: ../src/richtext/richtextsymboldlg.cpp:389
+#: ../src/richtext/richtextsymboldlg.cpp:391
+msgid "The font from which to take the symbol."
+msgstr "குறியெழுத்தை எடுப்பதற்கான எழுத்துரு."
+
+#: ../src/richtext/richtextsymboldlg.cpp:396
+msgid "&Subset:"
+msgstr "உட்கணம் (&S):"
+
+#: ../src/richtext/richtextsymboldlg.cpp:401
+#: ../src/richtext/richtextsymboldlg.cpp:403
+msgid "Shows a Unicode subset."
+msgstr "ஒருங்குறி உட்கணத்தை காட்டுகிறது."
+
+#: ../src/richtext/richtextsymboldlg.cpp:412
+msgid "xxxx"
+msgstr "xxxx"
+
+#: ../src/richtext/richtextsymboldlg.cpp:417
+msgid "&Character code:"
+msgstr "வரியுருக் குறியீடு (&C)"
+
+#: ../src/richtext/richtextsymboldlg.cpp:421
+#: ../src/richtext/richtextsymboldlg.cpp:423
+msgid "The character code."
+msgstr "வரியுருக் குறியீடு."
+
+#: ../src/richtext/richtextsymboldlg.cpp:428
+msgid "&From:"
+msgstr "அனுப்புநர் (&F):"
+
+#: ../src/richtext/richtextsymboldlg.cpp:433
+#: ../src/richtext/richtextsymboldlg.cpp:434
+#: ../src/richtext/richtextsymboldlg.cpp:435
+msgid "Unicode"
+msgstr "ஒருங்குறி"
+
+#: ../src/richtext/richtextsymboldlg.cpp:436
+#: ../src/richtext/richtextsymboldlg.cpp:438
+msgid "The range to show."
+msgstr "காட்டப்பட வேண்டிய வீச்சு."
+
+#: ../src/richtext/richtextsymboldlg.cpp:444
+msgid "Insert"
+msgstr "செருகு"
+
+#: ../src/richtext/richtextsymboldlg.cpp:478
+msgid "(Normal text)"
+msgstr "(இயல்புரை)"
+
+#: ../src/richtext/richtexttabspage.cpp:109
+msgid "&Position (tenths of a mm):"
+msgstr "நிலை (மில்லி மீட்டரின் பத்தில் ஒரு பகுதி) (&P):"
+
+#: ../src/richtext/richtexttabspage.cpp:113
+#: ../src/richtext/richtexttabspage.cpp:115
+msgid "The tab position."
+msgstr "பட்டி நிலை."
+
+#: ../src/richtext/richtexttabspage.cpp:119
+msgid "The tab positions."
+msgstr "பட்டி நிலைகள்."
+
+#: ../src/richtext/richtexttabspage.cpp:132
+#: ../src/richtext/richtexttabspage.cpp:134
+msgid "Click to create a new tab position."
+msgstr "ஒரு புதுப் பட்டி நிலையை உருவாக்க சொடுக்கிடுக."
+
+#: ../src/richtext/richtexttabspage.cpp:138
+#: ../src/richtext/richtexttabspage.cpp:140
+msgid "Click to delete the selected tab position."
+msgstr "தெரிவுசெய்யப்பட்டுள்ள பட்டி நிலையை நீக்க சொடுக்கிடுக."
+
+#: ../src/richtext/richtexttabspage.cpp:143
+msgid "Delete A&ll"
+msgstr "அனைத்தையும் அழித்திடுக (&L)"
+
+#: ../src/richtext/richtexttabspage.cpp:144
+#: ../src/richtext/richtexttabspage.cpp:146
+msgid "Click to delete all tab positions."
+msgstr "எல்லாப் பட்டி நிலைகளையும் நீக்க சொடுக்கிடுக."
+
+#: ../src/univ/theme.cpp:110
+msgid "Failed to initialize GUI: no built-in themes found."
+msgstr "GUI-ஐ தொடக்கநிலையாக்குவதில் தோல்வி: உள்ளமைக் கருத்தோற்றம் ஏதும் காணப்படவில்லை. "
+
+#: ../src/univ/themes/gtk.cpp:521
+msgid "GTK+ theme"
+msgstr "GTK+ கருத்தோற்றம்"
+
+#: ../src/univ/themes/metal.cpp:164
+msgid "Metal theme"
+msgstr "மெட்டல் கருத்தோற்றம்"
+
+#: ../src/univ/themes/mono.cpp:512
+msgid "Simple monochrome theme"
+msgstr "எளிய ஒற்றை நிறக் கருத்தோற்றம்"
+
+#: ../src/univ/themes/win32.cpp:1098
+msgid "Win32 theme"
+msgstr "Win32 கருத்தோற்றம்"
+
+#: ../src/univ/themes/win32.cpp:3743
+msgid "&Restore"
+msgstr "மீட்டமைத்திடுக (&R)"
+
+#: ../src/univ/themes/win32.cpp:3744
+msgid "&Move"
+msgstr "நகர்த்துக (&M)"
+
+#: ../src/univ/themes/win32.cpp:3746
+msgid "&Size"
+msgstr "அளவாக்கிடுக (&S)"
+
+#: ../src/univ/themes/win32.cpp:3748
+msgid "Mi&nimize"
+msgstr "சிறிதாக்குக (&N)"
+
+#: ../src/univ/themes/win32.cpp:3750
+msgid "Ma&ximize"
+msgstr "பெரிதாக்குக (&X)"
+
+#: ../src/univ/themes/win32.cpp:3752
+msgid "Alt+"
+msgstr "நிலை மாற்றி+"
+
+#: ../src/unix/appunix.cpp:178
+msgid "Failed to install signal handler"
+msgstr "சைகைக் கையாளுநரை நிறுவுவதில் தோல்வி"
+
+#: ../src/unix/dialup.cpp:351
+msgid "Already dialling ISP."
+msgstr "ISP ஏற்கனவே சுழற்றப்பட்டுக்கொண்டிருக்கிறது."
+
+#: ../src/unix/dlunix.cpp:93
+msgid "Failed to unload shared library"
+msgstr "பகிர்வு நூலகத்தை இறக்குவதில் தோல்வி"
+
+#: ../src/unix/dlunix.cpp:121
+msgid "Unknown dynamic library error"
+msgstr "அறியப்படாத இயங்குநிலை நூலகப் பிழை"
+
+#: ../src/unix/epolldispatcher.cpp:84
+msgid "Failed to create epoll descriptor"
+msgstr "epoll விளக்கியை உருவாக்குவதில் தோல்வி."
+
+#: ../src/unix/epolldispatcher.cpp:103
+msgid "Error closing epoll descriptor"
+msgstr "epoll விளக்கியை மூடுவதில் பிழை"
+
+#: ../src/unix/epolldispatcher.cpp:116
+#, c-format
+msgid "Failed to add descriptor %d to epoll descriptor %d"
+msgstr "விளக்கி %d-ஐ epoll விளக்கி %d-னுள் சேர்ப்பதில் தோல்வி."
+
+#: ../src/unix/epolldispatcher.cpp:136
+#, c-format
+msgid "Failed to modify descriptor %d in epoll descriptor %d"
+msgstr "%d விளக்கியை %d epoll விளக்கியினுல் மாற்றுவதில் தோல்வி."
+
+#: ../src/unix/epolldispatcher.cpp:155
+#, c-format
+msgid "Failed to unregister descriptor %d from epoll descriptor %d"
+msgstr "%d விளக்கியை %d epoll விளக்கியிடமிருந்து பதிவுநீக்குவதில் தோல்வி"
+
+#: ../src/unix/epolldispatcher.cpp:213
+#, c-format
+msgid "Waiting for IO on epoll descriptor %d failed"
+msgstr "%d epoll விளக்கியின் மீதான உள்ளிடு/வெளியிடு காத்திருப்பு தோல்வியடைந்தது"
+
+#: ../src/unix/fswatcher_inotify.cpp:71
+msgid "Unable to create inotify instance"
+msgstr "inotify நிகழ்வை உருவாக்க இயலவில்லை"
+
+#: ../src/unix/fswatcher_inotify.cpp:94
+msgid "Unable to close inotify instance"
+msgstr "inotify நிகழ்வை மூட இயலவில்லை"
+
+#: ../src/unix/fswatcher_inotify.cpp:106
+msgid "Unable to add inotify watch"
+msgstr "inotify கண்காணிப்பை சேர்க்க இயலவில்லை."
+
+#: ../src/unix/fswatcher_inotify.cpp:138
+#, c-format
+msgid "Unable to remove inotify watch %i"
+msgstr "%i inotify கண்காணிப்பை நீக்க இயலவில்லை"
+
+#: ../src/unix/fswatcher_inotify.cpp:271
+#, c-format
+msgid "Unexpected event for \"%s\": no matching watch descriptor."
+msgstr "\"%s\"-ற்கான எதிர்பாராத நிகழ்வு: பொருத்தமான கண்காணிப்பு விளக்கி இல்லை."
+
+#: ../src/unix/fswatcher_inotify.cpp:320
+#, c-format
+msgid "Invalid inotify event for \"%s\""
+msgstr "\"%s\"-ற்கான செல்லாத inotify நிகழ்வு"
+
+#: ../src/unix/fswatcher_inotify.cpp:553
+msgid "Unable to read from inotify descriptor"
+msgstr "inotify விளக்கியிலிருந்து படிக்க இயலவில்லை"
+
+#: ../src/unix/fswatcher_inotify.cpp:558
+msgid "EOF while reading from inotify descriptor"
+msgstr "inotify விளக்கியிலிருந்து படிக்கும்பொழுது கோப்பின் முடிவு"
+
+#: ../src/unix/fswatcher_kqueue.cpp:114
+msgid "Unable to create kqueue instance"
+msgstr "kqueue நிகழ்வை உருவாக்க இயலவில்லை"
+
+#: ../src/unix/fswatcher_kqueue.cpp:131
+msgid "Error closing kqueue instance"
+msgstr "kqueue நிகழ்வினை மூடுவதில் பிழை"
+
+#: ../src/unix/fswatcher_kqueue.cpp:153
+msgid "Unable to add kqueue watch"
+msgstr "kqueue கண்காணிப்பை சேர்க்க இயலவில்லை."
+
+#: ../src/unix/fswatcher_kqueue.cpp:170
+msgid "Unable to remove kqueue watch"
+msgstr "kqueue கண்காணிப்பை நீக்க இயலவில்லை"
+
+#: ../src/unix/fswatcher_kqueue.cpp:202
+msgid "Unable to get events from kqueue"
+msgstr "kqueue-விடமிருந்து நிகழ்வுகளை பெற இயலவில்லை"
+
+#: ../src/unix/mediactrl.cpp:966
+#, c-format
+msgid "Media playback error: %s"
+msgstr "ஊடக இயக்கப் பிழை: %s"
+
+#: ../src/unix/mediactrl.cpp:1228
+#, c-format
+msgid "Failed to prepare playing \"%s\"."
+msgstr "\"%s\" இயக்குதலை ஆயத்தம் செய்வதில் தோல்வி."
+
+#: ../src/unix/snglinst.cpp:164
+#, c-format
+msgid "Failed to write to lock file '%s'"
+msgstr "'%s' பூட்டுக் கோப்பினில் எழுதுவதில் தோல்வி"
+
+#: ../src/unix/snglinst.cpp:177
+#, c-format
+msgid "Failed to set permissions on lock file '%s'"
+msgstr "'%s' பூட்டுக் கோப்பிற்கான அனுமதிகளை அமைப்பதில் தோல்வி"
+
+#: ../src/unix/snglinst.cpp:194
+#, c-format
+msgid "Failed to lock the lock file '%s'"
+msgstr "'%s' பூட்டுக் கோப்பினைப் பூட்டுவதில் தோல்வி"
+
+#: ../src/unix/snglinst.cpp:237
+#, c-format
+msgid "Failed to inspect the lock file '%s'"
+msgstr "'%s' பூட்டுக் கோப்பினை ஆய்வதில் தோல்வி"
+
+#: ../src/unix/snglinst.cpp:242
+#, c-format
+msgid "Lock file '%s' has incorrect owner."
+msgstr "'%s' பூட்டுக் கோப்பு தவறான உரிமையாளரைக் கொண்டுள்ளது."
+
+#: ../src/unix/snglinst.cpp:247
+#, c-format
+msgid "Lock file '%s' has incorrect permissions."
+msgstr "'%s' பூட்டுக் கோப்பு தவறான அனுமதிகளைக் கொண்டுள்ளது."
+
+#: ../src/unix/snglinst.cpp:265
+msgid "Failed to access lock file."
+msgstr "பூட்டுக் கோப்பினை அணுகுவதில் தோல்வி."
+
+#: ../src/unix/snglinst.cpp:274
+msgid "Failed to read PID from lock file."
+msgstr "பூட்டுக் கோப்பிலிருந்து PID-ஐ படிப்பதில் தோல்வி."
+
+#: ../src/unix/snglinst.cpp:284
+#, c-format
+msgid "Failed to remove stale lock file '%s'."
+msgstr "'%s' நாள்பட்ட பூட்டுக் கோப்பினை நீக்குவதில் தோல்வி."
+
+#: ../src/unix/snglinst.cpp:297
+#, c-format
+msgid "Deleted stale lock file '%s'."
+msgstr "நாள்பட்ட பூட்டுக் கோப்பு '%s' அழிக்கப்பட்டது."
+
+#: ../src/unix/snglinst.cpp:308
+#, c-format
+msgid "Invalid lock file '%s'."
+msgstr "செல்லாத பூட்டுக் கோப்பு '%s'."
+
+#: ../src/unix/snglinst.cpp:324
+#, c-format
+msgid "Failed to remove lock file '%s'"
+msgstr "'%s' பூட்டுக் கோப்பினை நீக்குவதில் தோல்வி"
+
+#: ../src/unix/snglinst.cpp:330
+#, c-format
+msgid "Failed to unlock lock file '%s'"
+msgstr "'%s' பூட்டுக் கோப்பின் பூட்டைத் திறப்பதில் தோல்வி"
+
+#: ../src/unix/snglinst.cpp:336
+#, c-format
+msgid "Failed to close lock file '%s'"
+msgstr "'%s' பூட்டுக் கோப்பினை மூடுவதில் தோல்வி"
+
+#: ../src/unix/sound.cpp:77
+msgid "No sound"
+msgstr "ஒலி இல்லை"
+
+#: ../src/unix/sound.cpp:364
+msgid "Unable to play sound asynchronously."
+msgstr "ஒலியை ஒத்திசைவில்லாமல் ஒலிக்க இயலவில்லை"
+
+#: ../src/unix/sound.cpp:458
+#, c-format
+msgid "Couldn't load sound data from '%s'."
+msgstr "'%s' இருந்து ஒலி தரவினை ஏற்ற இயலவில்லை"
+
+#: ../src/unix/sound.cpp:465
+#, c-format
+msgid "Sound file '%s' is in unsupported format."
+msgstr "'%s' ஒலிக் கோப்பு ஆதரவளிக்கப்படாத வடிவூட்டத்தில் உள்ளது."
+
+#: ../src/unix/sound.cpp:480
+msgid "Sound data are in unsupported format."
+msgstr "ஒலித் தரவுகள் ஆதரிக்கப்படாத வடிவூட்டத்தில் உள்ளன."
+
+#: ../src/unix/sound_sdl.cpp:226
+#, c-format
+msgid "Couldn't open audio: %s"
+msgstr "ஒலியத்தை திறக்க இயலவில்லை: %s"
+
+#: ../src/unix/threadpsx.cpp:1033
+msgid "Cannot retrieve thread scheduling policy."
+msgstr "இழை காலவரையீட்டுக் கொள்கையை மீட்க இயலவில்லை"
+
+#: ../src/unix/threadpsx.cpp:1058
+#, c-format
+msgid "Cannot get priority range for scheduling policy %d."
+msgstr "%d காலவரையீட்டுக் கொள்கைக்கான முன்னுரிமை வீச்சைப் பெற இயலவில்லை."
+
+#: ../src/unix/threadpsx.cpp:1066
+msgid "Thread priority setting is ignored."
+msgstr "இழை முன்னுரிமை அமைப்பு புறந்தள்ளப்படுகிறது.."
+
+#: ../src/unix/threadpsx.cpp:1221
+msgid ""
+"Failed to join a thread, potential memory leak detected - please restart the "
+"program"
+msgstr ""
+"ஒரு இழையுடன் சேர்வதில் தோல்வி, நினைவுக் கசிவாக இருக்கக்கூடும் - அருள்கூர்ந்து நிரலை "
+"மறுதுவக்கிடவும் "
+
+#: ../src/unix/threadpsx.cpp:1352
+#, c-format
+msgid "Failed to set thread concurrency level to %lu"
+msgstr "இழையின் உடன்நிகழ் மட்டத்தை %lu-க்கு அமைப்பதில் தோல்வி."
+
+#: ../src/unix/threadpsx.cpp:1481
+#, c-format
+msgid "Failed to set thread priority %d."
+msgstr "%d இழை முன்னுரிமையை அமைப்பதில் தோல்வி."
+
+#: ../src/unix/threadpsx.cpp:1666
+msgid "Failed to terminate a thread."
+msgstr "ஒரு இழையை முடிவுக்கு கொண்டுவருவதில் தோல்வி."
+
+#: ../src/unix/threadpsx.cpp:1893
+msgid "Thread module initialization failed: failed to create thread key"
+msgstr ""
+"இழை நிரற்கூறினை தொடக்கநிலையாக்குவதில் தோல்வி: இழை விசையை உருவாக்குவதில் தோல்வி."
+
+#: ../src/unix/utilsunx.cpp:340
+msgid "Impossible to get child process input"
+msgstr "சேய் செயல்முறை உள்ளீட்டினை பெற இயலவில்லை."
+
+#: ../src/unix/utilsunx.cpp:390
+msgid "Can't write to child process's stdin"
+msgstr "stdin-ல் சேய் செயல்முறையை எழுத இயலாது"
+
+#: ../src/unix/utilsunx.cpp:644
+#, c-format
+msgid "Failed to execute '%s'\n"
+msgstr "'%s'-இனை செயலாக்குவதில் தோல்வி. \n"
+
+#: ../src/unix/utilsunx.cpp:678
+msgid "Fork failed"
+msgstr "பிளவு தோல்வியடைந்தது"
+
+#: ../src/unix/utilsunx.cpp:701
+msgid "Failed to set process priority"
+msgstr "செயல்முறை முன்னுரிமையை அமைப்பதில் தோல்வி"
+
+#: ../src/unix/utilsunx.cpp:712
+msgid "Failed to redirect child process input/output"
+msgstr "உள்ளீடு/வெளியீடு சேய் செயல்முறையை வழிமாற்றுவதில் தோல்வி"
+
+#: ../src/unix/utilsunx.cpp:816
+msgid "Failed to set up non-blocking pipe, the program might hang."
+msgstr "அடைப்பில்லா குழாயை அமைப்பதில் தோல்வி, நிரல் இயக்கம் முடிவிற்கு வரலாம்."
+
+#: ../src/unix/utilsunx.cpp:1023
+msgid "Cannot get the hostname"
+msgstr "வழங்கியின் பெயரை பெற இயலவில்லை"
+
+#: ../src/unix/utilsunx.cpp:1059
+msgid "Cannot get the official hostname"
+msgstr "வழங்கியின் அலுவல்ரீதியான பெயரை பெற இயலவில்லை"
+
+#: ../src/unix/wakeuppipe.cpp:49
+msgid "Failed to create wake up pipe used by event loop."
+msgstr "நிகழ்வுச் சுழற்சி பயன்படுத்தும் விழிப்புநிலை குழாயை உருவாக்குவதில் தோல்வி."
+
+#: ../src/unix/wakeuppipe.cpp:56
+msgid "Failed to switch wake up pipe to non-blocking mode"
+msgstr "விழிப்புநிலை குழாயை அடைப்பில்லா நிலைக்கு மாற்றுவதில் தோல்வி"
+
+#: ../src/unix/wakeuppipe.cpp:117
+msgid "Failed to read from wake-up pipe"
+msgstr "விழிப்புநிலை குழாயிலிருந்து படிப்பதில் தோல்வி"
+
+#: ../src/x11/app.cpp:124
+#, c-format
+msgid "Invalid geometry specification '%s'"
+msgstr "செல்லாத வடிவியல் குறிப்பு '%s'"
+
+#: ../src/x11/app.cpp:167
+msgid "wxWidgets could not open display. Exiting."
+msgstr "காட்சியை wxWidgets திறக்க இயலவில்லை. வெளியேறுகிறது."
+
+#: ../src/x11/utils.cpp:169
+#, c-format
+msgid "Failed to close the display \"%s\""
+msgstr "\"%s\" காட்சியை மூடுவதில் தோல்வி"
+
+#: ../src/x11/utils.cpp:188
+#, c-format
+msgid "Failed to open display \"%s\"."
+msgstr "\"%s\" காட்சியை திறப்பதில் தோல்வி"
+
+#: ../src/xml/xml.cpp:868
+#, c-format
+msgid "XML parsing error: '%s' at line %d"
+msgstr "XML பகுப்பாய்வுப் பிழை: '%s', %d வரியில்"
+
+#: ../src/xrc/xh_propgrid.cpp:239
+#, c-format
+msgid "Page %i"
+msgstr "பக்கம் %i"
+
+#: ../src/xrc/xmlres.cpp:448
+#, c-format
+msgid "Cannot load resources from '%s'."
+msgstr "'%s'-இருந்து வளங்களை ஏற்ற இயலவில்லை."
+
+#: ../src/xrc/xmlres.cpp:799
+#, c-format
+msgid "Cannot open resources file '%s'."
+msgstr "'%s' வளங்கள் கோப்பினை திறக்க இயலாது"
+
+#: ../src/xrc/xmlres.cpp:806
+#, c-format
+msgid "Cannot load resources from file '%s'."
+msgstr "'%s' கோப்பிலிருந்து வளங்களை ஏற்ற இயலவில்லை."
+
+#: ../src/xrc/xmlres.cpp:2767
+#, c-format
+msgid "Creating %s \"%s\" failed."
+msgstr "%s உருவாக்கப்படுகிறது. \"%s\" தோல்வியடைந்தது."
+
+#~ msgctxt "keyboard key"
+#~ msgid "Alt+"
+#~ msgstr "நிலை மாற்றி+"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Ctrl+"
+#~ msgstr "கட்டுப்பாடு+"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Shift+"
+#~ msgstr "மாற்றழுத்தி"
+
+#~ msgctxt "keyboard key"
+#~ msgid "RawCtrl+"
+#~ msgstr "RawCtrl+"
+
+#~ msgid "Copying more than one selected block to clipboard is not supported."
+#~ msgstr ""
+#~ "ஒன்றுக்கும் மேற்பட்ட தெரிவான தொகுதியை பிடிப்புப்பலகைக்கு படியெடுக்க ஆதரவில்லை."
+
+#~ msgid "Unsupported clipboard format."
+#~ msgstr "ஆதரவளிக்கப்படாத பிடிப்புப் பலகை வடிவூட்டம்."
+
+#~ msgid "Background colour"
+#~ msgstr "பின்புல நிறம்"
+
+#~ msgid "Font:"
+#~ msgstr "எழுத்துரு:"
+
+#~ msgid "Size:"
+#~ msgstr "அளவு:"
+
+#~ msgid "The font size in points."
+#~ msgstr "எழுத்துரு அளவு (புள்ளிகளில்)."
+
+#~ msgid "Style:"
+#~ msgstr "பாங்கு:"
+
+#~ msgid "Check to make the font bold."
+#~ msgstr "எழுத்துரு அடர்த்தியாக்கப்பட்டிருப்பதை உறுதி செய்க."
+
+#~ msgid "Check to make the font italic."
+#~ msgstr "எழுத்துரு வலப்பக்க சாய்வினை உறுதி செய்க."
+
+#~ msgid "Check to make the font underlined."
+#~ msgstr "எழுத்துரு அடிக்கோடிடப்பட்டிருப்பதை உறுதி செய்க."
+
+#~ msgid "Colour:"
+#~ msgstr "நிறம்:"
+
+#~ msgid "Click to change the font colour."
+#~ msgstr "எழுத்துரு நிறத்தை மாற்ற சொடுக்கவும்."
+
+#~ msgid "Shows a preview of the font."
+#~ msgstr "எழுத்துருவின் முன்தோற்றத்தைக் காட்டுகிறது."
+
+#~ msgid "Click to cancel changes to the font."
+#~ msgstr "எழுத்துரு மாற்றங்களை விலக்கிட, சொடுக்கிடுக."
+
+#~ msgid "Click to confirm changes to the font."
+#~ msgstr "எழுத்துருவில் ஏற்பட்டுள்ள மாற்றங்களை உறுதி செய்ய சொடுக்கவும்."
+
+#~ msgid "<Any>"
+#~ msgstr "<ஏதேனும்>"
+
+#~ msgid "<Any Roman>"
+#~ msgstr "<ஏதேனும் ரோமானியம்>"
+
+#~ msgid "<Any Decorative>"
+#~ msgstr "<ஏதேனும் அலங்காரம்>"
+
+#~ msgid "<Any Modern>"
+#~ msgstr "<ஏதேனும் புதுமை>"
+
+#~ msgid "<Any Script>"
+#~ msgstr "<ஏதேனுமொரு குறுநிரல்>"
+
+#~ msgid "<Any Swiss>"
+#~ msgstr "<ஏதேனும் சுவிஸ்>"
+
+#~ msgid "<Any Teletype>"
+#~ msgstr "<ஏதேனுமொரு தொலைத் தட்டெழுத்து>"
+
+#~ msgid "Printing "
+#~ msgstr "அச்சிடப்படுகிறது"
+
+#~ msgid "Failed to insert text in the control."
+#~ msgstr "கட்டுப்பாட்டில் உரையை செருகுவதில் தோல்வி."
+
+#~ msgid "Please choose a valid font."
+#~ msgstr "ஏற்கக்கூடிய எழுத்துருவைத் தேர்ந்தெடுக்கவும்."
+
+#~ msgid "Failed to display HTML document in %s encoding"
+#~ msgstr "%s குறியாக்கத்தில் HtML ஆவணத்தை காட்டுவதில் தோல்வி"
+
+#~ msgid "wxWidgets could not open display for '%s': exiting."
+#~ msgstr "wxWidgets, '%s'-ற்கான காட்சியளிப்பைத் திறக்க இயலவில்லை: வெளியேறுகிறது."
+
+#~ msgid "Filter"
+#~ msgstr "வடிகட்டி"
+
+#~ msgid "Directories"
+#~ msgstr "அடைவுகள்"
+
+#~ msgid "Files"
+#~ msgstr "கோப்புகள்"
+
+#~ msgid "Selection"
+#~ msgstr "தெரிவு"
+
+#~ msgid "conversion to 8-bit encoding failed"
+#~ msgstr "8-நுண்மி குறியாக்கத்திற்கு மாற்றுவதில் பிழை."
+
+#~ msgid "failed to retrieve execution result"
+#~ msgstr "செயலாக்க முடிவினை மீட்டெடுப்பதில் தோல்வி"
+
+#~ msgid "&Save as"
+#~ msgstr "இவ்வாறு சேமிக்கவும்"
+
+#~ msgid "'%s' doesn't consist only of valid characters"
+#~ msgstr "ஏற்கக் கூடிய வரியுருக்களை மட்டுமே '%s' கொண்டிருக்கவில்லை"
+
+#~ msgid "'%s' should be numeric."
+#~ msgstr "'%s' எண்ணாக இருக்க வேண்டும்"
+
+#~ msgid "'%s' should only contain ASCII characters."
+#~ msgstr "'%s' ASCII வரியுருக்களை மட்டும் உள்ளடங்கியதாக இருக்க வேண்டும்"
+
+#~ msgid "'%s' should only contain alphabetic characters."
+#~ msgstr "'%s' அகர வரியுருக்களை மட்டும் உள்ளடங்கியதாக இருக்க வேண்டும்"
+
+#~ msgid "'%s' should only contain alphabetic or numeric characters."
+#~ msgstr "'%s' எண் அல்லது அகர வரியுருக்களை மட்டும் உள்ளடங்கியதாக இருக்க வேண்டும்"
+
+#~ msgid "'%s' should only contain digits."
+#~ msgstr "'%s' இலக்கங்களை மட்டும் உள்ளடங்கியதாக இருக்க வேண்டும்"
+
+#~ msgid "Can't create window of class %s"
+#~ msgstr "%s பிரிவினைக் கொண்ட சாளரத்தை உருவாக்க இயலவில்லை"
+
+#~ msgid "Couldn't create the overlay window"
+#~ msgstr "மேலமைவுச் சாளரத்தை உருவாக்க இயலவில்லை."
+
+#~ msgid "Couldn't init the context on the overlay window"
+#~ msgstr "மேலமைவுச் சாளரத்தின் மீது சூழமைவைத் init  செய்ய இயலவில்லை."
+
+#~ msgid "Failed to convert file \"%s\" to Unicode."
+#~ msgstr "\"%s\" கோப்பினை ஒருங்குறியாக மாற்றுவதில் தோல்வி."
+
+#~ msgid "Failed to set text in the text control."
+#~ msgstr "உரைக் கட்டுப்பாட்டில் உரையை அமைப்பதில் தோல்வி."
+
+#~ msgid "Invalid GTK+ command line option, use \"%s --help\""
+#~ msgstr ""
+#~ "ஏற்கமுடியாத GTK+ கட்டளை வரி விருப்பத் தேர்வு, \"%s - help\"-யினை பயன்படுத்துங்கள்"
+
+#~ msgid "No unused colour in image."
+#~ msgstr "படிமத்தில் பயன்படுத்தப்படாத நிறம் ஏதுமில்லை."
+
+#~ msgid "Not available"
+#~ msgstr "கிடைப்பில் இல்லை"
+
+#~ msgid "Replace selection"
+#~ msgstr "தெரிவினை மாற்றியமைக்கவும்"
+
+#~ msgid "Save as"
+#~ msgstr "இவ்வாறு சேமிக்கவும்"
+
+#~ msgid "Style Organiser"
+#~ msgstr "பாங்கு அமைப்பாளர்"
+
+#~ msgid "The following standard GTK+ options are also supported:\n"
+#~ msgstr "பின்வரும் நிலையான GTK+ விருப்பத் தேர்வுகளும் ஆதரிக்கப்படுகின்றன:\n"
+
+#~ msgid "You cannot Clear an overlay that is not inited"
+#~ msgstr "init செய்யப்படாத மேலமைவை துடைக்க இயலாது"
+
+#~ msgid "You cannot Init an overlay twice"
+#~ msgstr "மேலமைவை இருமுறை init செய்ய இயலாது"
+
+#~ msgid "locale '%s' cannot be set."
+#~ msgstr "'%s' வட்டாரம் அமைக்க இயலாது."
+
+#~ msgid "Adding flavor TEXT failed"
+#~ msgstr "ஃப்ளேவர் உரையேற்றம் தோல்வியடைந்தது"
+
+#~ msgid "Adding flavor utxt failed"
+#~ msgstr "utxt ஃப்ளேவர் ஏற்றம் தோல்வியடைந்தது"
+
+#~ msgid "Bitmap renderer cannot render value; value type: "
+#~ msgstr "நுண்பட வழங்கி மதிப்பை வழங்க இயலவில்லை; மதிப்பு வகை:"
+
+#~ msgid ""
+#~ "Cannot create new column's ID. Probably max. number of columns reached."
+#~ msgstr ""
+#~ "புதிய நெடுவரிசையின் அடையாளத்தை உருவாக்க இயலவில்லை. ஒரு வேளை செங்குத்து வரிசை "
+#~ "எண்ணிக்கையின் உட்ச அளவை எட்டியிருக்கலாம்."
+
+#~ msgid "Column could not be added."
+#~ msgstr "நெடுவரிசையை சேர்க்க இயலவில்லை."
+
+#~ msgid "Column index not found."
+#~ msgstr "நெடுவரிசையின் சுட்டெண் காணப்படவில்லை."
+
+#~ msgid "Column width could not be determined"
+#~ msgstr "நெடுவரிசையின் அகலத்தை வரையறுக்க இயலவில்லை."
+
+#~ msgid "Column width could not be set."
+#~ msgstr "நெடுவரிசையின் அகலத்தை அமைக்க இயலவில்லை."
+
+#~ msgid "Confirm registry update"
+#~ msgstr "பதிவகத்தின் புதுப்பித்தல்களை உறுதிச் செய்க"
+
+#~ msgid "Could not determine column index."
+#~ msgstr "நெடுவரிசையின் சுட்டெண்ணை வரையறுக்க இயலவில்லை."
+
+#~ msgid "Could not determine column's position"
+#~ msgstr "நெடுவரிசையின் நிலையை தீர்மானிக்க இயலவில்லை"
+
+#~ msgid "Could not determine number of columns."
+#~ msgstr "நெடுவரிசையின் எண்ணிக்கையை தீர்மானிக்க இயலவில்லை"
+
+#~ msgid "Could not determine number of items"
+#~ msgstr "உருப்படிகளின் எண்ணிக்கையை தீர்மானிக்க இயலவில்லை"
+
+#~ msgid "Could not get header description."
+#~ msgstr "மேலுரையின் விளக்கத்தை பெற இயலவில்லை."
+
+#~ msgid "Could not get items."
+#~ msgstr "உருப்படிகளைப் பெற இயலவில்லை."
+
+#~ msgid "Could not get property flags."
+#~ msgstr "பண்புகளின் கொடிகளைப் பெற இயலவில்லை."
+
+#~ msgid "Could not get selected items."
+#~ msgstr "தெரிவு செய்யப்பட்ட உருப்படிகளைப் பெற இயலவில்லை."
+
+#~ msgid "Could not remove column."
+#~ msgstr "நெடுவரிசையை நீக்க இயலவில்லை."
+
+#~ msgid "Could not retrieve number of items"
+#~ msgstr "உருப்படிகளின் எண்ணிக்கையை மீட்க இயலவில்லை."
+
+#~ msgid "Could not set column width."
+#~ msgstr "நெடுவரிசையின் அகலத்தை அமைக்க இயலவில்லை."
+
+#~ msgid "Could not set header description."
+#~ msgstr "மேலுரையின் விளக்கத்தை அமைக்க இயலவில்லை."
+
+#~ msgid "Could not set icon."
+#~ msgstr "படவுருவை அமைக்க இயலவில்லை."
+
+#~ msgid "Could not set maximum width."
+#~ msgstr "உட்சபட்ச அகலத்தை அமைக்க இயலவில்லை."
+
+#~ msgid "Could not set minimum width."
+#~ msgstr "குறைந்தபட்ச அகலத்தை அமைக்க இயலவில்லை."
+
+#~ msgid "Could not set property flags."
+#~ msgstr "பண்புக் கொடிகளை அமைக்க ியலவில்லை."
+
+#~ msgid "Data object has invalid data format"
+#~ msgstr "தரவுப் பொருள், ஏற்கமுடியாத தரவு வடிவூட்டத்தைக் கொண்டுள்ளது"
+
+#~ msgid "Date renderer cannot render value; value type: "
+#~ msgstr "தேதி வழங்கி மதிப்பை வழங்க இயலாது; மதிப்பு வகை:"
+
+#~ msgid ""
+#~ "Do you want to overwrite the command used to %s files with extension \"%s"
+#~ "\" ?\n"
+#~ "Current value is \n"
+#~ "%s, \n"
+#~ "New value is \n"
+#~ "%s %1"
+#~ msgstr ""
+#~ "\"%s\" நீட்டிப்பைக் கொண்டுள்ள %s கோப்புகளில் பயன்படுத்தப்பட்டுள்ள கட்டளைகளை அழித்தெழுத "
+#~ "வேண்டுமா?\n"
+#~ "தற்போதைய மதிப்பு: \n"
+#~ "%s, \n"
+#~ "புது மதிப்பு: \n"
+#~ "%s %1"
+
+#~ msgid "Failed to retrieve data from the clipboard."
+#~ msgstr "பிடிப்புப் பலகையிலிருந்து தரவினை மீட்டெடுப்பதில் தோல்வி."
+
+#~ msgid "GIF: Invalid gif index."
+#~ msgstr "GIF: ஏற்கமுடியாத GIF சுட்டெண்."
+
+#~ msgid "GIF: unknown error!!!"
+#~ msgstr "GIF: தெரியாதப் பிழை."
+
+#~ msgid "Icon & text renderer cannot render value; value type: "
+#~ msgstr "படவுரு உரை வழங்கி மதிப்பை வழங்க இயலாது; மதிப்பின் வகை:"
+
+#~ msgid "New directory"
+#~ msgstr "புது அடைவு"
+
+#~ msgid "Next"
+#~ msgstr "அடுத்து"
+
+#~ msgid "No column existing."
+#~ msgstr "நெடுவரிசை கிடைப்பில் இல்லை."
+
+#~ msgid "No column for the specified column existing."
+#~ msgstr "குறிப்பிட்ட நெடுவரிசைக்கு நெடுவரிசை ஏதுமில்லை."
+
+#~ msgid "No column for the specified column position existing."
+#~ msgstr "குறிப்பிட்ட நெடுவரிசை நிலைக்கான நெடுவரிசை ஏதுமில்லை."
+
+#~ msgid ""
+#~ "No renderer or invalid renderer type specified for custom data column."
+#~ msgstr ""
+#~ "தனிப் பயனாக்கப்பட்ட தரவு நெடுவரிசைக்கு, இல்லாத வழங்கி அல்லது ஏற்க முடியாத வழங்கியின் "
+#~ "வகை வரையறுக்கப்பட்டுள்ளது."
+
+#~ msgid "No renderer specified for column."
+#~ msgstr "நெடுவரிசைக்கு வழங்கி வரையறுக்கப்படவில்லை."
+
+#~ msgid "Number of columns could not be determined."
+#~ msgstr "நெடுவரிசையின் எண்ணிக்கையை வரையறுக்க இயலவில்லை."
+
+#~ msgid "OpenGL function \"%s\" failed: %s (error %d)"
+#~ msgstr "OpenGL \"%s\" செயல் தோல்வியடைந்தது: %s (பிழை %d)"
+
+#~ msgid ""
+#~ "Please install a newer version of comctl32.dll\n"
+#~ "(at least version 4.70 is required but you have %d.%02d)\n"
+#~ "or this program won't operate correctly."
+#~ msgstr ""
+#~ "comctl32.dll கோப்பின் புதிய பதிப்பை நிறுவவும் \n"
+#~ "(குறைந்தபட்சம் 4.70 பதிப்பு தேவைப்படுகிறது. ஆனால், தங்களிடம் %d.%02d பதிப்புதான் "
+#~ "உள்ளது)\n"
+#~ "இல்லையென்றால், இந்த நிரல் சரிவர செயல்படாது."
+
+#~ msgid "Pointer to data view control not set correctly."
+#~ msgstr "தரவுத் தோற்றக் கட்டுப்பாட்டிற்கான சுட்டி சரிவர அமைக்கப்படவில்லை."
+
+#~ msgid "Pointer to model not set correctly."
+#~ msgstr "ஒப்புருவிற்கான சுட்டி சரிவர அமைக்கப்படவில்லை."
+
+#~ msgid "Progress renderer cannot render value type; value type: "
+#~ msgstr "முன்னேற்ற வழங்கி மதிப்பின் வகையை வழங்க இயலாது; மதிப்பின் வகை:"
+
+#~ msgid "Rendering failed."
+#~ msgstr "வழங்குதல் தோல்வியடைந்தது."
+
+#~ msgid ""
+#~ "Setting directory access times is not supported under this OS version"
+#~ msgstr "இந்த இயக்க முறைமை பதிப்பில் அடைவு டைம்ஸ் அணுகியை அமைப்பதற்கு ஆதரவு இல்லை."
+
+#~ msgid "Show hidden directories"
+#~ msgstr "மறைந்துள்ள அடைவுகளைக் காட்டுக"
+
+#~ msgid "Text renderer cannot render value; value type: "
+#~ msgstr "உரை வழங்கி மதிப்பை வழங்க இயலாது; மதிப்பின் வகை:"
+
+#~ msgid "There is no column or renderer for the specified column index."
+#~ msgstr "குறிப்பிடப்பட்ட நெடுவரிசை சுட்டெண்ணிற்கு நெடுவரிசையோ, வழங்கியோ இல்லை."
+
+#~ msgid ""
+#~ "This system doesn't support date controls, please upgrade your version of "
+#~ "comctl32.dll"
+#~ msgstr ""
+#~ "தேதிக் கட்டுப்பாடுகளை இந்தக் கணினி ஆதரிப்பதில்லை, தங்களின் comctl32.dll பதிப்பை "
+#~ "மேம்படுத்தவும்."
+
+#~ msgid "Toggle renderer cannot render value; value type: "
+#~ msgstr "நிலை பொருத்தி வழங்கி மதிப்பை வழங்க இயலாது; மதிப்பின் வகை:"
+
+#~ msgid "Too many colours in PNG, the image may be slightly blurred."
+#~ msgstr "PNG-யில் மிகுதியான நிறங்கள், படிமம் சற்றே தெளிவற்று இருக்கலாம்."
+
+#~ msgid "Unable to handle native drag&drop data"
+#~ msgstr "இயல் இழு-விடு தரவினை கையாள இயலவில்லை (&D)"
+
+#~ msgid "Unable to initialize Hildon program"
+#~ msgstr "Hildon நிரலை துவக்க நிலையாக்க இயலவில்லை"
+
+#~ msgid "Unknown data format"
+#~ msgstr "அறியப்படாத தரவு வடிவூட்டம்"
+
+#~ msgid "Valid pointer to native data view control does not exist"
+#~ msgstr "உள்ளக தரவு கட்டுப்பாடு தோற்றத்திற்கான ஏற்கக்கூடிய சுட்டி இல்லை"
+
+#~ msgid "Win32s on Windows 3.1"
+#~ msgstr "Win32s on Windows 3.1"
+
+#, fuzzy
+#~ msgid "Windows 10"
+#~ msgstr "விண்டோஸ் 8.1"
+
+#~ msgid "Windows 2000"
+#~ msgstr "விண்டோஸ் 2000"
+
+#~ msgid "Windows 7"
+#~ msgstr "விண்டோஸ் 7"
+
+#~ msgid "Windows 8"
+#~ msgstr "விண்டோஸ் 8"
+
+#~ msgid "Windows 8.1"
+#~ msgstr "விண்டோஸ் 8.1"
+
+#~ msgid "Windows 95"
+#~ msgstr "விண்டோஸ் 95"
+
+#~ msgid "Windows 95 OSR2"
+#~ msgstr "விண்டோஸ் 95 OSR2"
+
+#~ msgid "Windows 98"
+#~ msgstr "விண்டோஸ் 98"
+
+#~ msgid "Windows 98 SE"
+#~ msgstr "விண்டோஸ் 98 SE"
+
+#~ msgid "Windows 9x (%d.%d)"
+#~ msgstr "விண்டோஸ் 9x (%d.%d)"
+
+#~ msgid "Windows CE (%d.%d)"
+#~ msgstr "விண்டோஸ் CE (%d.%d)"
+
+#~ msgid "Windows ME"
+#~ msgstr "விண்டோஸ் ME"
+
+#~ msgid "Windows NT %lu.%lu"
+#~ msgstr "விண்டோஸ் NT %lu.%lu"
+
+#, fuzzy
+#~ msgid "Windows Server 10"
+#~ msgstr "விண்டோஸ் வழங்கி 2003"
+
+#~ msgid "Windows Server 2003"
+#~ msgstr "விண்டோஸ் வழங்கி 2003"
+
+#~ msgid "Windows Server 2008"
+#~ msgstr "விண்டோஸ் வழங்கி 2008"
+
+#~ msgid "Windows Server 2008 R2"
+#~ msgstr "விண்டோஸ் வழங்கி 2008 R2"
+
+#~ msgid "Windows Server 2012"
+#~ msgstr "விண்டோஸ் வழங்கி 2012"
+
+#~ msgid "Windows Server 2012 R2"
+#~ msgstr "விண்டோஸ் வழங்கி 2012 R2"
+
+#~ msgid "Windows Vista"
+#~ msgstr "விண்டோஸ் விஸ்டா"
+
+#~ msgid "Windows XP"
+#~ msgstr "விண்டோஸ் XP"
+
+#~ msgid "can't execute '%s'"
+#~ msgstr "'%s'-ஐ செயற்படுத்த இயலாது"
+
+#~ msgid "error opening '%s'"
+#~ msgstr "'%s' திறப்பதில் பிழை"
+
+#~ msgid "unknown seek origin"
+#~ msgstr "அறியப்படாத மூல நாட்டம்"
+
+#~ msgid "wxWidget control pointer is not a data view pointer"
+#~ msgstr "wxWidget கட்டுப்பாட்டுச் சுட்டி ஒரு தரவுத் தோற்ற சுட்டியல்ல."
+
+#~ msgid "wxWidget's control not initialized."
+#~ msgstr "wxWidget's கட்டுப்பாடு துவக்க நிலையாக்கப்படவில்லை."
+
+#~ msgid "ADD"
+#~ msgstr "ஏற்றிடுக"
+
+#~ msgid "BACK"
+#~ msgstr "பின்"
+
+#~ msgid "CANCEL"
+#~ msgstr "விலக்குக"
+
+#~ msgid "CAPITAL"
+#~ msgstr "முகப்பு"
+
+#~ msgid "CLEAR"
+#~ msgstr "துடை"
+
+#~ msgid "COMMAND"
+#~ msgstr "கட்டளை"
+
+#~ msgid "Cannot create mutex."
+#~ msgstr "Mutex உருவாக்க இயலாது"
+
+#~ msgid "Cannot resume thread %lu"
+#~ msgstr "%lu இழையை மீண்டும் தொடர இயலாது"
+
+#~ msgid "Cannot suspend thread %lu"
+#~ msgstr "%lu இழையை இடைநிறுத்த இயலாது"
+
+#~ msgid "Couldn't acquire a mutex lock"
+#~ msgstr "Mutex பூட்டினை பெற இயலவில்லை."
+
+#~ msgid "Couldn't get hatch style from wxBrush."
+#~ msgstr "WX பிரஷ்ஷிலிருந்து hatch பாங்கினைப் பெற இயலவில்லை."
+
+#~ msgid "Couldn't release a mutex"
+#~ msgstr "Mutex-இனை வெளியிட இயலவில்லை."
+
+#~ msgid "DECIMAL"
+#~ msgstr "பதின்மம்"
+
+#~ msgid "DEL"
+#~ msgstr "அழி"
+
+#~ msgid "DELETE"
+#~ msgstr "அழி"
+
+#~ msgid "DIVIDE"
+#~ msgstr "வகுத்தல்"
+
+#~ msgid "DOWN"
+#~ msgstr "கீழ்"
+
+#~ msgid "END"
+#~ msgstr "முடிவு"
+
+#~ msgid "ENTER"
+#~ msgstr "உள்ளிடுக"
+
+#~ msgid "ESC"
+#~ msgstr "விடுபடு"
+
+#~ msgid "ESCAPE"
+#~ msgstr "விடுபடு"
+
+#~ msgid "EXECUTE"
+#~ msgstr "செயலாக்குக"
+
+#~ msgid "Execution of command '%s' failed with error: %ul"
+#~ msgstr "'%s' கட்டளையின் செயலாக்கம் பிழையுடன் தோல்வியடைந்தது: %ul"
+
+#~ msgid ""
+#~ "File '%s' already exists.\n"
+#~ "Do you want to replace it?"
+#~ msgstr "'%s' கோப்பு ஏற்கனவே உள்ளது, அதை மாற்றியமர்த்த வேண்டுமா?"
+
+#~ msgid "HELP"
+#~ msgstr "உதவி"
+
+#~ msgid "HOME"
+#~ msgstr "முகப்பு"
+
+#~ msgid "INS"
+#~ msgstr "செருகு"
+
+#~ msgid "INSERT"
+#~ msgstr "செருகு"
+
+#~ msgid "KP_BEGIN"
+#~ msgstr "KP_துவக்கு"
+
+#~ msgid "KP_DECIMAL"
+#~ msgstr "KP_இரட்டை இலக்கு எண்"
+
+#~ msgid "KP_DELETE"
+#~ msgstr "KP_அழி"
+
+#~ msgid "KP_DIVIDE"
+#~ msgstr "KP_வகுத்தல்"
+
+#~ msgid "KP_DOWN"
+#~ msgstr "KP_கீழ்"
+
+#~ msgid "KP_ENTER"
+#~ msgstr "KP_உள்ளிடு"
+
+#~ msgid "KP_EQUAL"
+#~ msgstr "KP_சமன்பாடு"
+
+#~ msgid "KP_HOME"
+#~ msgstr "KP_முகப்பு"
+
+#~ msgid "KP_INSERT"
+#~ msgstr "KP_செருகு"
+
+#~ msgid "KP_LEFT"
+#~ msgstr "KP_இடது"
+
+#~ msgid "KP_MULTIPLY"
+#~ msgstr "KP_பெருக்கல்"
+
+#~ msgid "KP_NEXT"
+#~ msgstr "KP_அடுத்து"
+
+#~ msgid "KP_PAGEDOWN"
+#~ msgstr "KP_பக்கம் கீழ்"
+
+#~ msgid "KP_PAGEUP"
+#~ msgstr "KP_பக்கம் மேல்"
+
+#~ msgid "KP_PRIOR"
+#~ msgstr "KP_முந்தையது"
+
+#~ msgid "KP_RIGHT"
+#~ msgstr "KP_வலது"
+
+#~ msgid "KP_SEPARATOR"
+#~ msgstr "KP_பிரிப்பான்"
+
+#~ msgid "KP_SPACE"
+#~ msgstr "KP_இடைவெளி"
+
+#~ msgid "KP_SUBTRACT"
+#~ msgstr "KP_கழித்தல்"
+
+#~ msgid "LEFT"
+#~ msgstr "இடது"
+
+#~ msgid "MENU"
+#~ msgstr "பட்டியல்"
+
+#~ msgid "NUM_LOCK"
+#~ msgstr "எண் பூட்டு"
+
+#~ msgid "PAGEDOWN"
+#~ msgstr "பக்கம் கீழ்"
+
+#~ msgid "PAGEUP"
+#~ msgstr "பக்கம் மேல்"
+
+#~ msgid "PAUSE"
+#~ msgstr "இடைநிறுத்து"
+
+#~ msgid "PGDN"
+#~ msgstr "பக்கம் கீழ்"
+
+#~ msgid "PGUP"
+#~ msgstr "பக்கம் மேல்"
+
+#~ msgid "PRINT"
+#~ msgstr "அச்சிடு"
+
+#~ msgid "RETURN"
+#~ msgstr "மீட்டளி"
+
+#~ msgid "RIGHT"
+#~ msgstr "வலது"
+
+#~ msgid "SCROLL_LOCK"
+#~ msgstr "உருள் பூட்டு"
+
+#~ msgid "SELECT"
+#~ msgstr "தெரிவுச் செய்க"
+
+#~ msgid "SEPARATOR"
+#~ msgstr "பிரிப்பான்"
+
+#~ msgid "SNAPSHOT"
+#~ msgstr "பிடிபடம்"
+
+#~ msgid "SPACE"
+#~ msgstr "இடைவெளி"
+
+#~ msgid "SUBTRACT"
+#~ msgstr "கழித்தல்"
+
+#~ msgid "TAB"
+#~ msgstr "தத்தல்"
+
+#~ msgid "The print dialog returned an error."
+#~ msgstr "அச்சிடு உரையாடல் ஒரு பிழையை  அறிவித்தது."
+
+#~ msgid "The wxGtkPrinterDC cannot be used."
+#~ msgstr "wxGtkPrinterDC பயன்படுத்த இயலாது."
+
+#~ msgid "Timer creation failed."
+#~ msgstr "நேரங்காட்டி உருவாக்குவதில் தோல்வி."
+
+#~ msgid "UP"
+#~ msgstr "மேல்"
+
+#~ msgid "WINDOWS_LEFT"
+#~ msgstr "சாளரங்கள்_இடது"
+
+#~ msgid "WINDOWS_MENU"
+#~ msgstr "சாளரங்கள்-பட்டியல்"
+
+#~ msgid "WINDOWS_RIGHT"
+#~ msgstr "சாளரங்கள்-வலது"
+
+#~ msgid "buffer is too small for Windows directory."
+#~ msgstr "விண்டோஸ் அடைவிற்கு இடையகம் மிகச் சிறியதாக உள்ளது."
+
+#~ msgid "not implemented"
+#~ msgstr "நடைமுறைப்படுத்தப்படவில்லை"
+
+#~ msgid "wxPrintout::GetPageInfo gives a null maxPage."
+#~ msgstr "wxPrintout::GetPageInfo ஒரு  வெற்று maxPage-ஐ தருகிறது."
+
+#~ msgid "Event queue overflowed"
+#~ msgstr "நிகழ்வு வரிசை மிகுந்துவிட்டது"
+
+#~ msgid "percent"
+#~ msgstr "விழுக்காடு"
+
+#~ msgid "Print preview"
+#~ msgstr "அச்சு முன்தோற்றம்"
+
+#~ msgid "'"
+#~ msgstr "'"
+
+#~ msgid "1"
+#~ msgstr "1"
+
+#~ msgid "10"
+#~ msgstr "10"
+
+#~ msgid "3"
+#~ msgstr "3"
+
+#~ msgid "4"
+#~ msgstr "4"
+
+#~ msgid "5"
+#~ msgstr "5"
+
+#~ msgid "6"
+#~ msgstr "6"
+
+#~ msgid "7"
+#~ msgstr "7"
+
+#~ msgid "8"
+#~ msgstr "8"
+
+#~ msgid "9"
+#~ msgstr "9"
+
+#~ msgid "Can't monitor non-existent path \"%s\" for changes."
+#~ msgstr "இல்லாத \"%s\" வழியினை மாற்றங்களுக்காக கவனிக்க இயலாது"
+
+#~ msgid "File system containing watched object was unmounted"
+#~ msgstr "கவனிக்கப்படும் பொருளைக் கொண்டுள்ள கோப்புக் கட்டகம் இறக்கப்பட்டது"
+
+#~ msgid "&Preview..."
+#~ msgstr "முன்தோற்றம்... (&P)"
+
+#~ msgid "&Save..."
+#~ msgstr "சேமித்திடுக... (&S)"
+
+#~ msgid "About "
+#~ msgstr "குறித்து..."
+
+#~ msgid "All files (*.*)|*"
+#~ msgstr "எல்லாக் கோப்புகளும் (*.*)|*"
+
+#~ msgid "Cannot start thread: error writing TLS"
+#~ msgstr "இழையை துவக்க இயலவில்லை: TLS எழுதுவதில் பிழை "
+
+#~ msgid "Close\tAlt-F4"
+#~ msgstr "மூடுக \tAlt-F4"
+
+#~ msgid "Paper Size"
+#~ msgstr "தாளளவு"
+
+#~ msgid "Preview..."
+#~ msgstr "முன்தோற்றம்..."
+
+#~ msgid "The vertical offset relative to the paragraph."
+#~ msgstr "பத்திக்கு சார்புடைய செங்குத்து விலக்கம்."
+
+#~ msgid "Units for the object offset."
+#~ msgstr "பொருள் எதிரிடைக்கான தொகுதிகள்."

--- a/po_wxstd/tr.po
+++ b/po_wxstd/tr.po
@@ -1,0 +1,9430 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+#
+# Translators:
+# Kaya Zeren <kayazeren@gmail.com>, 2018,2021
+# Kerim Demirkaynak <kerim@post.com>, 2025
+msgid ""
+msgstr ""
+"Project-Id-Version: wxWidgets\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-05-14 20:23+0200\n"
+"PO-Revision-Date: 2025-05-24 02:24+0300\n"
+"Last-Translator: Kerim Demirkaynak <kerim@post.com>\n"
+"Language-Team: Turkish (Turkey) (http://www.transifex.com/klyok/wxwidgets/"
+"language/tr_TR/)\n"
+"Language: tr_TR\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+"X-Generator: Poedit 3.5\n"
+
+#: ../include/wx/defs.h:2582
+msgid "All files (*.*)|*.*"
+msgstr "Tüm dosyalar (*.*)|*.*"
+
+#: ../include/wx/defs.h:2585
+msgid "All files (*)|*"
+msgstr "Tüm dosyalar (*)|*"
+
+#: ../include/wx/generic/progdlgg.h:85
+msgid "Elapsed time:"
+msgstr "Geçen süre:"
+
+#: ../include/wx/generic/progdlgg.h:86
+msgid "Estimated time:"
+msgstr "Öngörülen süre:"
+
+#: ../include/wx/generic/progdlgg.h:87
+msgid "Remaining time:"
+msgstr "Kalan süre:"
+
+#. TRANSLATORS: HTML printout default title.
+#: ../include/wx/html/htmprint.h:121 ../include/wx/prntbase.h:273
+#: ../include/wx/richtext/richtextprint.h:109 ../src/common/docview.cpp:2161
+msgid "Printout"
+msgstr "Çıktı"
+
+#. TRANSLATORS: HTML easy print default title.
+#: ../include/wx/html/htmprint.h:234 ../include/wx/richtext/richtextprint.h:163
+#: ../src/common/prntbase.cpp:522 ../src/html/htmprint.cpp:291
+msgid "Printing"
+msgstr "Yazdırılıyor"
+
+#: ../include/wx/msgdlg.h:277 ../src/common/stockitem.cpp:211
+msgid "Yes"
+msgstr "Evet"
+
+#: ../include/wx/msgdlg.h:278 ../src/common/stockitem.cpp:182
+msgid "No"
+msgstr "Hayır"
+
+#: ../include/wx/msgdlg.h:279 ../src/common/stockitem.cpp:183
+#: ../src/msw/msgdlg.cpp:430 ../src/msw/msgdlg.cpp:734
+#: ../src/richtext/richtextstyledlg.cpp:292
+msgid "OK"
+msgstr "Tamam"
+
+#: ../include/wx/msgdlg.h:280 ../src/common/stockitem.cpp:150
+#: ../src/msw/msgdlg.cpp:430 ../src/msw/progdlg.cpp:884
+#: ../src/richtext/richtextstyledlg.cpp:295
+msgid "Cancel"
+msgstr "İptal"
+
+#: ../include/wx/msgdlg.h:281 ../src/common/stockitem.cpp:168
+#: ../src/html/helpdlg.cpp:63 ../src/html/helpfrm.cpp:108
+#: ../src/osx/button_osx.cpp:38
+msgid "Help"
+msgstr "Yardım"
+
+#: ../include/wx/msw/ole/oleutils.h:52
+msgid "Cannot initialize OLE"
+msgstr "OLE başlatılamadı"
+
+#: ../include/wx/msw/private/fswatcher.h:48
+#, c-format
+msgid "Unable to close the handle for '%s'"
+msgstr "'%s' işleyicisi kapatılamadı"
+
+#: ../include/wx/msw/private/fswatcher.h:92
+#, c-format
+msgid "Failed to open directory \"%s\" for monitoring."
+msgstr "\"%s\"klasörü izlenmek üzere açılamadı."
+
+#: ../include/wx/msw/private/fswatcher.h:125
+msgid "Unable to close I/O completion port handle"
+msgstr "Giriş/çıkış tamamlanma kapısı işleyicisi kapatılamadı"
+
+#: ../include/wx/msw/private/fswatcher.h:142
+msgid "Unable to associate handle with I/O completion port"
+msgstr "Giriş/çıkış tamamlanma kapısı işleyici ile ilişkilendirilemedi"
+
+#: ../include/wx/msw/private/fswatcher.h:148
+msgid "Unexpectedly new I/O completion port was created"
+msgstr "Beklenmedik şekilde yeni giriş/çıkış tamamlanma kapısı oluşturuldu"
+
+#: ../include/wx/msw/private/fswatcher.h:213
+msgid "Unable to post completion status"
+msgstr "Tamamlanma durumu gönderilemedi"
+
+#: ../include/wx/msw/private/fswatcher.h:262
+msgid "Unable to dequeue completion packet"
+msgstr "Tamamlanma paketi kuyruktan çıkarılamadı"
+
+#: ../include/wx/msw/private/fswatcher.h:273
+msgid "Unable to create I/O completion port"
+msgstr "Giriş/çıkış tamamlanma kapısı oluşturulamadı"
+
+#: ../include/wx/richmsgdlg.h:29
+msgid "&See details"
+msgstr "&Ayrıntılar"
+
+#: ../include/wx/richmsgdlg.h:30
+msgid "&Hide details"
+msgstr "Ayrıntıları &gizle"
+
+#: ../include/wx/richtext/richtextbuffer.h:3864
+msgid "&Box"
+msgstr "&Kutu"
+
+#: ../include/wx/richtext/richtextbuffer.h:5008
+msgid "&Picture"
+msgstr "&Resim"
+
+#: ../include/wx/richtext/richtextbuffer.h:5958
+msgid "&Cell"
+msgstr "&Hücre"
+
+#: ../include/wx/richtext/richtextbuffer.h:6067
+msgid "&Table"
+msgstr "&Tablo"
+
+#: ../include/wx/richtext/richtextimagedlg.h:37
+msgid "Object Properties"
+msgstr "Nesne özellikleri"
+
+#: ../include/wx/richtext/richtextsymboldlg.h:39
+msgid "Symbols"
+msgstr "Simgeler"
+
+#: ../include/wx/unix/pipe.h:46
+msgid "Pipe creation failed"
+msgstr "Tünel oluşturulamadı"
+
+#: ../include/wx/unix/private/displayx11.h:65
+msgid "Failed to enumerate video modes"
+msgstr "Görüntü kipleri sıralanamadı"
+
+#: ../include/wx/unix/private/displayx11.h:89
+msgid "Failed to change video mode"
+msgstr "Görüntü kipi değiştirilemedi"
+
+#: ../include/wx/unix/private/fswatcher_kqueue.h:57
+#, c-format
+msgid "Unable to open path '%s'"
+msgstr "'%s' yolu açılamadı"
+
+#: ../include/wx/unix/private/fswatcher_kqueue.h:74
+#, c-format
+msgid "Unable to close path '%s'"
+msgstr "'%s' yolu kapatılamadı"
+
+#: ../include/wx/xtiprop.h:175
+msgid "SetProperty called w/o valid setter"
+msgstr "'SetProperty' işlevi geçerli bir yerleştirici olmaksızın çağrıldı"
+
+#: ../include/wx/xtiprop.h:184
+msgid "GetProperty called w/o valid getter"
+msgstr "'GetProperty' işlevi geçerli bir alıcı olmaksızın çağrıldı"
+
+#: ../include/wx/xtiprop.h:193
+msgid "AddToPropertyCollection called w/o valid adder"
+msgstr "AddToPropertyCollection işlevi, geçerli bir ekleyici olmadançağrıldı"
+
+#: ../include/wx/xtiprop.h:202
+msgid "GetPropertyCollection called w/o valid collection getter"
+msgstr ""
+"'GetPropertyCollection' işlevi geçerli bir koleksiyon alıcısı olmaksızın "
+"çağrıldı"
+
+#: ../include/wx/xtiprop.h:255
+msgid "AddToPropertyCollection called on a generic accessor"
+msgstr "AddToPropertyCollection işlevi, genel bir erişici üzerinden çağrıldı"
+
+#: ../include/wx/xtiprop.h:262
+msgid "GetPropertyCollection called on a generic accessor"
+msgstr "'GetPropertyCollection' işlevi genel bir erişici üzerinden çağrıldı"
+
+#: ../src/aui/tabmdi.cpp:106 ../src/generic/mdig.cpp:94
+msgid "Cl&ose"
+msgstr "Kapa&t"
+
+#: ../src/aui/tabmdi.cpp:107 ../src/generic/mdig.cpp:95
+msgid "Close All"
+msgstr "Tümünü kapat"
+
+#: ../src/aui/tabmdi.cpp:109 ../src/generic/mdig.cpp:97 ../src/msw/mdi.cpp:175
+#: ../src/qt/mdi.cpp:258
+msgid "&Next"
+msgstr "So&nraki"
+
+#: ../src/aui/tabmdi.cpp:110 ../src/generic/mdig.cpp:98 ../src/msw/mdi.cpp:176
+#: ../src/qt/mdi.cpp:259
+msgid "&Previous"
+msgstr "Ö&nceki"
+
+#: ../src/aui/tabmdi.cpp:332 ../src/aui/tabmdi.cpp:348
+#: ../src/aui/tabmdi.cpp:350 ../src/generic/mdig.cpp:291
+#: ../src/generic/mdig.cpp:307 ../src/generic/mdig.cpp:311
+#: ../src/msw/mdi.cpp:337 ../src/qt/mdi.cpp:462
+msgid "&Window"
+msgstr "&Pencere"
+
+#: ../src/common/accelcmn.cpp:47
+msgctxt "keyboard key"
+msgid "Delete"
+msgstr "Delete"
+
+#: ../src/common/accelcmn.cpp:48
+msgctxt "keyboard key"
+msgid "Del"
+msgstr "Del"
+
+#: ../src/common/accelcmn.cpp:49
+msgctxt "keyboard key"
+msgid "Back"
+msgstr "Geri"
+
+#: ../src/common/accelcmn.cpp:49
+msgctxt "keyboard key"
+msgid "Backspace"
+msgstr "Geri silme"
+
+#: ../src/common/accelcmn.cpp:50
+msgctxt "keyboard key"
+msgid "Insert"
+msgstr "Insert"
+
+#: ../src/common/accelcmn.cpp:51
+msgctxt "keyboard key"
+msgid "Ins"
+msgstr "Ins"
+
+#: ../src/common/accelcmn.cpp:52
+msgctxt "keyboard key"
+msgid "Enter"
+msgstr "Enter"
+
+#: ../src/common/accelcmn.cpp:53
+msgctxt "keyboard key"
+msgid "Return"
+msgstr "Return"
+
+#: ../src/common/accelcmn.cpp:54
+msgctxt "keyboard key"
+msgid "PageUp"
+msgstr "PageUp"
+
+#: ../src/common/accelcmn.cpp:54
+msgctxt "keyboard key"
+msgid "Page Up"
+msgstr "Page Up"
+
+#: ../src/common/accelcmn.cpp:55
+msgctxt "keyboard key"
+msgid "PageDown"
+msgstr "PageDown"
+
+#: ../src/common/accelcmn.cpp:55
+msgctxt "keyboard key"
+msgid "Page Down"
+msgstr "Page Down"
+
+#: ../src/common/accelcmn.cpp:56
+msgctxt "keyboard key"
+msgid "PgUp"
+msgstr "PgUp"
+
+#: ../src/common/accelcmn.cpp:57
+msgctxt "keyboard key"
+msgid "PgDn"
+msgstr "PgDn"
+
+#: ../src/common/accelcmn.cpp:58
+msgctxt "keyboard key"
+msgid "Left"
+msgstr "Sol"
+
+#: ../src/common/accelcmn.cpp:59
+msgctxt "keyboard key"
+msgid "Right"
+msgstr "Sağ"
+
+#: ../src/common/accelcmn.cpp:60
+msgctxt "keyboard key"
+msgid "Up"
+msgstr "Yukarı"
+
+#: ../src/common/accelcmn.cpp:61
+msgctxt "keyboard key"
+msgid "Down"
+msgstr "Aşağı"
+
+#: ../src/common/accelcmn.cpp:62
+msgctxt "keyboard key"
+msgid "Home"
+msgstr "Açılış"
+
+#: ../src/common/accelcmn.cpp:63
+msgctxt "keyboard key"
+msgid "End"
+msgstr "End"
+
+#: ../src/common/accelcmn.cpp:64
+msgctxt "keyboard key"
+msgid "Space"
+msgstr "Boşluk"
+
+#: ../src/common/accelcmn.cpp:65
+msgctxt "keyboard key"
+msgid "Tab"
+msgstr "Sekme"
+
+#: ../src/common/accelcmn.cpp:66
+msgctxt "keyboard key"
+msgid "Esc"
+msgstr "Esc"
+
+#: ../src/common/accelcmn.cpp:67
+msgctxt "keyboard key"
+msgid "Escape"
+msgstr "Escape"
+
+#: ../src/common/accelcmn.cpp:68
+msgctxt "keyboard key"
+msgid "Cancel"
+msgstr "İptal"
+
+#: ../src/common/accelcmn.cpp:69
+msgctxt "keyboard key"
+msgid "Clear"
+msgstr "Temizle"
+
+#: ../src/common/accelcmn.cpp:70
+msgctxt "keyboard key"
+msgid "Menu"
+msgstr "Menü"
+
+#: ../src/common/accelcmn.cpp:71
+msgctxt "keyboard key"
+msgid "Pause"
+msgstr "Duraklat"
+
+#: ../src/common/accelcmn.cpp:72
+msgctxt "keyboard key"
+msgid "Capital"
+msgstr "Büyük"
+
+#: ../src/common/accelcmn.cpp:73
+msgctxt "keyboard key"
+msgid "Select"
+msgstr "Seçin"
+
+#: ../src/common/accelcmn.cpp:74
+msgctxt "keyboard key"
+msgid "Print"
+msgstr "Yazdır"
+
+#: ../src/common/accelcmn.cpp:75
+msgctxt "keyboard key"
+msgid "Execute"
+msgstr "Yürüt"
+
+#: ../src/common/accelcmn.cpp:76
+msgctxt "keyboard key"
+msgid "Snapshot"
+msgstr "Ekran görüntüsü"
+
+#: ../src/common/accelcmn.cpp:77
+msgctxt "keyboard key"
+msgid "Help"
+msgstr "Yardım"
+
+#: ../src/common/accelcmn.cpp:78
+msgctxt "keyboard key"
+msgid "Add"
+msgstr "Ekle"
+
+#: ../src/common/accelcmn.cpp:79
+msgctxt "keyboard key"
+msgid "Separator"
+msgstr "Ayraç"
+
+#: ../src/common/accelcmn.cpp:80
+msgctxt "keyboard key"
+msgid "Subtract"
+msgstr "Eksi"
+
+#: ../src/common/accelcmn.cpp:81
+msgctxt "keyboard key"
+msgid "Decimal"
+msgstr "Ondalık"
+
+#: ../src/common/accelcmn.cpp:82
+msgctxt "keyboard key"
+msgid "Multiply"
+msgstr "Çarpı"
+
+#: ../src/common/accelcmn.cpp:83
+msgctxt "keyboard key"
+msgid "Divide"
+msgstr "Bölü"
+
+#: ../src/common/accelcmn.cpp:84
+msgctxt "keyboard key"
+msgid "Num_lock"
+msgstr "Num_lock"
+
+#: ../src/common/accelcmn.cpp:84
+msgctxt "keyboard key"
+msgid "Num Lock"
+msgstr "Num Lock"
+
+#: ../src/common/accelcmn.cpp:85
+msgctxt "keyboard key"
+msgid "Scroll_lock"
+msgstr "Scroll_lock"
+
+#: ../src/common/accelcmn.cpp:85
+msgctxt "keyboard key"
+msgid "Scroll Lock"
+msgstr "Scroll Lock"
+
+#: ../src/common/accelcmn.cpp:86
+msgctxt "keyboard key"
+msgid "KP_Space"
+msgstr "TT_Boşluk"
+
+#: ../src/common/accelcmn.cpp:86
+msgctxt "keyboard key"
+msgid "Num Space"
+msgstr "Num Boşluk"
+
+#: ../src/common/accelcmn.cpp:87
+msgctxt "keyboard key"
+msgid "KP_Tab"
+msgstr "TT_Sekme"
+
+#: ../src/common/accelcmn.cpp:87
+msgctxt "keyboard key"
+msgid "Num Tab"
+msgstr "Num Sekme"
+
+#: ../src/common/accelcmn.cpp:88
+msgctxt "keyboard key"
+msgid "KP_Enter"
+msgstr "TT_Enter"
+
+#: ../src/common/accelcmn.cpp:88
+msgctxt "keyboard key"
+msgid "Num Enter"
+msgstr "Num Enter"
+
+#: ../src/common/accelcmn.cpp:89
+msgctxt "keyboard key"
+msgid "KP_Home"
+msgstr "TT_Home"
+
+#: ../src/common/accelcmn.cpp:89
+msgctxt "keyboard key"
+msgid "Num Home"
+msgstr "Num Home"
+
+#: ../src/common/accelcmn.cpp:90
+msgctxt "keyboard key"
+msgid "KP_Left"
+msgstr "TT_Sol"
+
+#: ../src/common/accelcmn.cpp:90
+msgctxt "keyboard key"
+msgid "Num left"
+msgstr "Num sol"
+
+#: ../src/common/accelcmn.cpp:91
+msgctxt "keyboard key"
+msgid "KP_Up"
+msgstr "TT_Yukarı"
+
+#: ../src/common/accelcmn.cpp:91
+msgctxt "keyboard key"
+msgid "Num Up"
+msgstr "Num Yukarı"
+
+#: ../src/common/accelcmn.cpp:92
+msgctxt "keyboard key"
+msgid "KP_Right"
+msgstr "TT_Sağ"
+
+#: ../src/common/accelcmn.cpp:92
+msgctxt "keyboard key"
+msgid "Num Right"
+msgstr "Num Sağ"
+
+#: ../src/common/accelcmn.cpp:93
+msgctxt "keyboard key"
+msgid "KP_Down"
+msgstr "TT_Aşağı"
+
+#: ../src/common/accelcmn.cpp:93
+msgctxt "keyboard key"
+msgid "Num Down"
+msgstr "Num Aşağı"
+
+#: ../src/common/accelcmn.cpp:94
+msgctxt "keyboard key"
+msgid "KP_PageUp"
+msgstr "TT_PageUp"
+
+#: ../src/common/accelcmn.cpp:94
+msgctxt "keyboard key"
+msgid "Num Page Up"
+msgstr "Num Page Up"
+
+#: ../src/common/accelcmn.cpp:95
+msgctxt "keyboard key"
+msgid "KP_PageDown"
+msgstr "TT_PageDown"
+
+#: ../src/common/accelcmn.cpp:95
+msgctxt "keyboard key"
+msgid "Num Page Down"
+msgstr "Num Page Down"
+
+#: ../src/common/accelcmn.cpp:96
+msgctxt "keyboard key"
+msgid "KP_Prior"
+msgstr "TT_Önceki"
+
+#: ../src/common/accelcmn.cpp:97
+msgctxt "keyboard key"
+msgid "KP_Next"
+msgstr "TT_Next"
+
+#: ../src/common/accelcmn.cpp:98
+msgctxt "keyboard key"
+msgid "KP_End"
+msgstr "TT_End"
+
+#: ../src/common/accelcmn.cpp:98
+msgctxt "keyboard key"
+msgid "Num End"
+msgstr "Num End"
+
+#: ../src/common/accelcmn.cpp:99
+msgctxt "keyboard key"
+msgid "KP_Begin"
+msgstr "TT_Başlangıç"
+
+#: ../src/common/accelcmn.cpp:99
+msgctxt "keyboard key"
+msgid "Num Begin"
+msgstr "Num Başlangıç"
+
+#: ../src/common/accelcmn.cpp:100
+msgctxt "keyboard key"
+msgid "KP_Insert"
+msgstr "TT_Insert"
+
+#: ../src/common/accelcmn.cpp:100
+msgctxt "keyboard key"
+msgid "Num Insert"
+msgstr "Num Insert"
+
+#: ../src/common/accelcmn.cpp:101
+msgctxt "keyboard key"
+msgid "KP_Delete"
+msgstr "TT_Delete"
+
+#: ../src/common/accelcmn.cpp:101
+msgctxt "keyboard key"
+msgid "Num Delete"
+msgstr "Num Delete"
+
+#: ../src/common/accelcmn.cpp:102
+msgctxt "keyboard key"
+msgid "KP_Equal"
+msgstr "TT_Eşit"
+
+#: ../src/common/accelcmn.cpp:102
+msgctxt "keyboard key"
+msgid "Num ="
+msgstr "Num ="
+
+#: ../src/common/accelcmn.cpp:103
+msgctxt "keyboard key"
+msgid "KP_Multiply"
+msgstr "TT_Çarpı"
+
+#: ../src/common/accelcmn.cpp:103
+msgctxt "keyboard key"
+msgid "Num *"
+msgstr "Num *"
+
+#: ../src/common/accelcmn.cpp:104
+msgctxt "keyboard key"
+msgid "KP_Add"
+msgstr "TT_Ekleme"
+
+#: ../src/common/accelcmn.cpp:104
+msgctxt "keyboard key"
+msgid "Num +"
+msgstr "Num +"
+
+#: ../src/common/accelcmn.cpp:105
+msgctxt "keyboard key"
+msgid "KP_Separator"
+msgstr "TT_Ayıraç"
+
+#: ../src/common/accelcmn.cpp:105
+msgctxt "keyboard key"
+msgid "Num ,"
+msgstr "Num ,"
+
+#: ../src/common/accelcmn.cpp:106
+msgctxt "keyboard key"
+msgid "KP_Subtract"
+msgstr "TT_Eksi"
+
+#: ../src/common/accelcmn.cpp:106
+msgctxt "keyboard key"
+msgid "Num -"
+msgstr "Num -"
+
+#: ../src/common/accelcmn.cpp:107
+msgctxt "keyboard key"
+msgid "KP_Decimal"
+msgstr "TT_Ondalık"
+
+#: ../src/common/accelcmn.cpp:107
+msgctxt "keyboard key"
+msgid "Num ."
+msgstr "Num ."
+
+#: ../src/common/accelcmn.cpp:108
+msgctxt "keyboard key"
+msgid "KP_Divide"
+msgstr "TT_Bölü"
+
+#: ../src/common/accelcmn.cpp:108
+msgctxt "keyboard key"
+msgid "Num /"
+msgstr "Num /"
+
+#: ../src/common/accelcmn.cpp:109
+msgctxt "keyboard key"
+msgid "Windows_Left"
+msgstr "Pencere_Sol"
+
+#: ../src/common/accelcmn.cpp:110
+msgctxt "keyboard key"
+msgid "Windows_Right"
+msgstr "Pencere_Sağ"
+
+#: ../src/common/accelcmn.cpp:111
+msgctxt "keyboard key"
+msgid "Windows_Menu"
+msgstr "Pencere_Menü"
+
+#: ../src/common/accelcmn.cpp:112
+msgctxt "keyboard key"
+msgid "Command"
+msgstr "Komut"
+
+#: ../src/common/accelcmn.cpp:186 ../src/common/accelcmn.cpp:359
+msgctxt "keyboard key"
+msgid "Ctrl"
+msgstr "Ctrl"
+
+#: ../src/common/accelcmn.cpp:188 ../src/common/accelcmn.cpp:363
+msgctxt "keyboard key"
+msgid "Alt"
+msgstr "Alt"
+
+#: ../src/common/accelcmn.cpp:190 ../src/common/accelcmn.cpp:361
+msgctxt "keyboard key"
+msgid "Shift"
+msgstr "Shift"
+
+#: ../src/common/accelcmn.cpp:196
+msgctxt "keyboard key"
+msgid "num "
+msgstr "num "
+
+#: ../src/common/accelcmn.cpp:260 ../src/common/accelcmn.cpp:382
+msgctxt "keyboard key"
+msgid "F"
+msgstr "F"
+
+#: ../src/common/accelcmn.cpp:277 ../src/common/accelcmn.cpp:385
+msgctxt "keyboard key"
+msgid "KP_F"
+msgstr "TT_F"
+
+#: ../src/common/accelcmn.cpp:280 ../src/common/accelcmn.cpp:388
+msgctxt "keyboard key"
+msgid "KP_"
+msgstr "KP_"
+
+#: ../src/common/accelcmn.cpp:283 ../src/common/accelcmn.cpp:391
+msgctxt "keyboard key"
+msgid "SPECIAL"
+msgstr "SPECIAL"
+
+#: ../src/common/accelcmn.cpp:373
+msgid "Ctrl"
+msgstr "Ctrl"
+
+#: ../src/common/appbase.cpp:786
+msgid "show this help message"
+msgstr "bu yardım iletisi görüntülensin"
+
+#: ../src/common/appbase.cpp:796
+msgid "generate verbose log messages"
+msgstr "ayrıntılı günlük iletileri oluşturulsun"
+
+#: ../src/common/appcmn.cpp:256
+msgid "specify the theme to use"
+msgstr "kullanılacak temayı belirleyin"
+
+#: ../src/common/appcmn.cpp:270
+msgid "specify display mode to use (e.g. 640x480-16)"
+msgstr "kullanılacak görüntü kipini belirleyin (ör. 640x480-16)"
+
+#: ../src/common/appcmn.cpp:292
+#, c-format
+msgid "Unsupported theme '%s'."
+msgstr "'%s' teması desteklenmiyor."
+
+#: ../src/common/appcmn.cpp:309
+#, c-format
+msgid "Invalid display mode specification '%s'."
+msgstr "'%s' görünüm kipi özelliği geçersiz."
+
+#: ../src/common/cmdline.cpp:875
+#, c-format
+msgid "Option '%s' can't be negated"
+msgstr "'%s' seçeneği yok sayılamaz"
+
+#: ../src/common/cmdline.cpp:889
+#, c-format
+msgid "Unknown long option '%s'"
+msgstr "'%s' long seçeneği bilinmiyor"
+
+#: ../src/common/cmdline.cpp:904 ../src/common/cmdline.cpp:926
+#, c-format
+msgid "Unknown option '%s'"
+msgstr "'%s' seçeneği bilinmiyor"
+
+#: ../src/common/cmdline.cpp:1004
+#, c-format
+msgid "Unexpected characters following option '%s'."
+msgstr "'%s' seçeneğinden sonra beklenmeyen karakterler var."
+
+#: ../src/common/cmdline.cpp:1039
+#, c-format
+msgid "Option '%s' requires a value."
+msgstr "'%s' seçeneğinin bir değeri olması gerekli."
+
+#: ../src/common/cmdline.cpp:1058
+#, c-format
+msgid "Separator expected after the option '%s'."
+msgstr "'%s' seçeneğinden sonra ayraç bekleniyor."
+
+#: ../src/common/cmdline.cpp:1088 ../src/common/cmdline.cpp:1106
+#, c-format
+msgid "'%s' is not a correct numeric value for option '%s'."
+msgstr "'%s' '%s' seçeneği için doğru bir sayısal değer değil."
+
+#: ../src/common/cmdline.cpp:1122
+#, c-format
+msgid "Option '%s': '%s' cannot be converted to a date."
+msgstr "'%s' seçeneği: '%s' tarihe dönüştürülemedi."
+
+#: ../src/common/cmdline.cpp:1170
+#, c-format
+msgid "Unexpected parameter '%s'"
+msgstr "Beklenmeyen parametre '%s'"
+
+#. TRANSLATORS: Short name and long name for a command line option
+#: ../src/common/cmdline.cpp:1197
+#, c-format
+msgid "%s (or %s)"
+msgstr "%s (ya da %s)"
+
+#: ../src/common/cmdline.cpp:1208
+#, c-format
+msgid "The value for the option '%s' must be specified."
+msgstr "'%s' seçeneği için değer belirtilmelidir."
+
+#: ../src/common/cmdline.cpp:1230
+#, c-format
+msgid "The required parameter '%s' was not specified."
+msgstr "Gerekli '%s' parametresi belirtilmemiş."
+
+#: ../src/common/cmdline.cpp:1289
+#, c-format
+msgid "Usage: %s"
+msgstr "Kullanım: %s"
+
+#: ../src/common/cmdline.cpp:1498
+msgid "str"
+msgstr "str"
+
+#: ../src/common/cmdline.cpp:1502
+msgid "num"
+msgstr "num"
+
+#: ../src/common/cmdline.cpp:1506
+msgid "double"
+msgstr "çift"
+
+#: ../src/common/cmdline.cpp:1510
+msgid "date"
+msgstr "tarih"
+
+#: ../src/common/cmdproc.cpp:250 ../src/common/cmdproc.cpp:276
+#: ../src/common/cmdproc.cpp:296
+msgid "Unnamed command"
+msgstr "Adsız komut"
+
+#: ../src/common/cmdproc.cpp:253
+msgid "&Undo "
+msgstr "&Geri al "
+
+#: ../src/common/cmdproc.cpp:255
+msgid "Can't &Undo "
+msgstr "&Geri alınamıyor "
+
+#: ../src/common/cmdproc.cpp:259 ../src/common/stockitem.cpp:208
+#: ../src/msw/textctrl.cpp:2880 ../src/osx/textctrl_osx.cpp:649
+#: ../src/richtext/richtextctrl.cpp:327
+msgid "&Undo"
+msgstr "&Geri al"
+
+#: ../src/common/cmdproc.cpp:277 ../src/common/cmdproc.cpp:297
+msgid "&Redo "
+msgstr "&Yinele "
+
+#: ../src/common/cmdproc.cpp:281 ../src/common/cmdproc.cpp:288
+#: ../src/common/stockitem.cpp:190 ../src/msw/textctrl.cpp:2881
+#: ../src/osx/textctrl_osx.cpp:650 ../src/richtext/richtextctrl.cpp:328
+msgid "&Redo"
+msgstr "&Yinele"
+
+#: ../src/common/colourcmn.cpp:41
+#, c-format
+msgid "String To Colour : Incorrect colour specification : %s"
+msgstr "Dizgeden renge: Hatalı renk tanımı: %s"
+
+#: ../src/common/config.cpp:259
+#, c-format
+msgid "Invalid value %ld for a boolean key \"%s\" in config file."
+msgstr "Ayar dosyasındaki %ld değeri \"%s\" ikili anahtarı geçersiz."
+
+#: ../src/common/config.cpp:526
+#, c-format
+msgid ""
+"Environment variables expansion failed: missing '%c' at position %u in '%s'."
+msgstr "Ortam değişkenleri açılamadı: eksik '%c', konum %u, '%s' içinde."
+
+#: ../src/common/config.cpp:576 ../src/msw/regconf.cpp:272
+#, c-format
+msgid "'%s' has extra '..', ignored."
+msgstr "'%s' içindeki fazladan '..' yok sayıldı."
+
+#. TRANSLATORS: Checkbox state name
+#: ../src/common/datavcmn.cpp:2166 ../src/generic/datavgen.cpp:1430
+msgid "checked"
+msgstr "işaretlenmiş"
+
+#. TRANSLATORS: Checkbox state name
+#: ../src/common/datavcmn.cpp:2170 ../src/generic/datavgen.cpp:1432
+msgid "unchecked"
+msgstr "işaretlenmemiş"
+
+#. TRANSLATORS: Checkbox state name
+#: ../src/common/datavcmn.cpp:2174
+msgid "undetermined"
+msgstr "belirlenmemiş"
+
+#: ../src/common/datetimefmt.cpp:1875
+msgid "today"
+msgstr "bugün"
+
+#: ../src/common/datetimefmt.cpp:1876
+msgid "yesterday"
+msgstr "dün"
+
+#: ../src/common/datetimefmt.cpp:1877
+msgid "tomorrow"
+msgstr "yarın"
+
+#: ../src/common/datetimefmt.cpp:2071
+msgid "first"
+msgstr "birinci"
+
+#: ../src/common/datetimefmt.cpp:2072
+msgid "second"
+msgstr "ikinci"
+
+#: ../src/common/datetimefmt.cpp:2073
+msgid "third"
+msgstr "üçüncü"
+
+#: ../src/common/datetimefmt.cpp:2074
+msgid "fourth"
+msgstr "dördüncü"
+
+#: ../src/common/datetimefmt.cpp:2075
+msgid "fifth"
+msgstr "beşinci"
+
+#: ../src/common/datetimefmt.cpp:2076
+msgid "sixth"
+msgstr "altıncı"
+
+#: ../src/common/datetimefmt.cpp:2077
+msgid "seventh"
+msgstr "yedinci"
+
+#: ../src/common/datetimefmt.cpp:2078
+msgid "eighth"
+msgstr "sekizinci"
+
+#: ../src/common/datetimefmt.cpp:2079
+msgid "ninth"
+msgstr "dokuzuncu"
+
+#: ../src/common/datetimefmt.cpp:2080
+msgid "tenth"
+msgstr "onuncu"
+
+#: ../src/common/datetimefmt.cpp:2081
+msgid "eleventh"
+msgstr "onbirinci"
+
+#: ../src/common/datetimefmt.cpp:2082
+msgid "twelfth"
+msgstr "yirminci"
+
+#: ../src/common/datetimefmt.cpp:2083
+msgid "thirteenth"
+msgstr "onüçüncü"
+
+#: ../src/common/datetimefmt.cpp:2084
+msgid "fourteenth"
+msgstr "ondördüncü"
+
+#: ../src/common/datetimefmt.cpp:2085
+msgid "fifteenth"
+msgstr "onbeşinci"
+
+#: ../src/common/datetimefmt.cpp:2086
+msgid "sixteenth"
+msgstr "onaltıncı"
+
+#: ../src/common/datetimefmt.cpp:2087
+msgid "seventeenth"
+msgstr "onyedinci"
+
+#: ../src/common/datetimefmt.cpp:2088
+msgid "eighteenth"
+msgstr "onsekizinci"
+
+#: ../src/common/datetimefmt.cpp:2089
+msgid "nineteenth"
+msgstr "ondokuzuncu"
+
+#: ../src/common/datetimefmt.cpp:2090
+msgid "twentieth"
+msgstr "onikinci"
+
+#: ../src/common/datetimefmt.cpp:2248
+msgid "noon"
+msgstr "öğlen"
+
+#: ../src/common/datetimefmt.cpp:2249
+msgid "midnight"
+msgstr "gece yarısı"
+
+#: ../src/common/debugrpt.cpp:209
+#, c-format
+msgid "Failed to create directory \"%s\""
+msgstr "\"%s\" klasörü oluşturulamadı"
+
+#: ../src/common/debugrpt.cpp:210
+msgid "Debug report couldn't be created."
+msgstr "Hata ayıklama raporu oluşturulamadı."
+
+#: ../src/common/debugrpt.cpp:227
+#, c-format
+msgid "Failed to remove debug report file \"%s\""
+msgstr "\"%s\" hata ayıklama rapor dosyası silinemedi"
+
+#: ../src/common/debugrpt.cpp:239
+#, c-format
+msgid "Failed to clean up debug report directory \"%s\""
+msgstr "\"%s\" hata ayıklama raporu klasörü temizlenemedi"
+
+#: ../src/common/debugrpt.cpp:514
+msgid "process context description"
+msgstr "işlem bağlamı tanımı"
+
+#: ../src/common/debugrpt.cpp:538
+msgid "dump of the process state (binary)"
+msgstr "işlem durum dökümü (ikili)"
+
+#: ../src/common/debugrpt.cpp:553
+msgid "Debug report generation has failed."
+msgstr "Hata ayıklama raporu oluşturulamadı."
+
+#: ../src/common/debugrpt.cpp:560
+#, c-format
+msgid ""
+"Processing debug report has failed, leaving the files in \"%s\" directory."
+msgstr ""
+"Hata ayıklama raporu oluşturulamadı, dosyalar \"%s\" klasöründe bırakıldı."
+
+#: ../src/common/debugrpt.cpp:573
+msgid "A debug report has been generated. It can be found in"
+msgstr "Hata ayıklama raporu oluşturuldu. Şurada bulabilirsiniz"
+
+#: ../src/common/debugrpt.cpp:576
+msgid "And includes the following files:\n"
+msgstr "Ve aşağıdaki dosyaları içeriyor:\n"
+
+#: ../src/common/debugrpt.cpp:586
+msgid ""
+"\n"
+"Please send this report to the program maintainer, thank you!\n"
+msgstr ""
+"\n"
+"Lütfen bu raporu program geliştiricisine gönderin, teşekkürler!\n"
+
+#: ../src/common/debugrpt.cpp:729
+msgid "Failed to execute curl, please install it in PATH."
+msgstr "cURL yürütülemedi, lütfen PATH içine yükleyin."
+
+#: ../src/common/debugrpt.cpp:742
+#, c-format
+msgid "Failed to upload the debug report (error code %d)."
+msgstr "Hata ayıklama raporu yüklenemedi (hata kodu %d)."
+
+#: ../src/common/docview.cpp:366
+msgid "Save As"
+msgstr "Farklı kaydet"
+
+#: ../src/common/docview.cpp:457
+msgid "Discard changes and reload the last saved version?"
+msgstr "Değişiklikler iptal edilip son kaydedilmiş sürüme dönülsün mü?"
+
+#: ../src/common/docview.cpp:488
+msgid "unnamed"
+msgstr "adsız"
+
+#: ../src/common/docview.cpp:513
+#, c-format
+msgid "Do you want to save changes to %s?"
+msgstr "%s üzerinde yapılan değişiklikleri kaydetmek istiyor musunuz?"
+
+#: ../src/common/docview.cpp:521 ../src/common/docview.cpp:560
+#: ../src/common/stockitem.cpp:195
+msgid "&Save"
+msgstr "Kay&det"
+
+#: ../src/common/docview.cpp:522 ../src/common/docview.cpp:560
+msgid "&Discard changes"
+msgstr "&Değişiklikleri yok say"
+
+#: ../src/common/docview.cpp:523
+msgid "Do&n't close"
+msgstr "&Kapatılmasın"
+
+#: ../src/common/docview.cpp:553
+#, c-format
+msgid "Do you want to save changes to %s before closing it?"
+msgstr ""
+"Kapatmadan önce %s üzerinde yapılan değişiklikleri kaydetmek istiyor musunuz?"
+
+#: ../src/common/docview.cpp:559
+msgid "The document must be closed."
+msgstr "Belge kapatılmalıdır."
+
+#: ../src/common/docview.cpp:571
+#, c-format
+msgid "Saving %s failed, would you like to retry?"
+msgstr "%s kaydedilemedi. Yeniden denemek ister misiniz?"
+
+#: ../src/common/docview.cpp:577
+msgid "Retry"
+msgstr "Yeniden dene"
+
+#: ../src/common/docview.cpp:577
+msgid "Discard changes"
+msgstr "Değişiklikleri yok say"
+
+#: ../src/common/docview.cpp:679
+#, c-format
+msgid "File \"%s\" could not be opened for writing."
+msgstr "\"%s\" dosyası yazılmak üzere açılamadı."
+
+#: ../src/common/docview.cpp:685
+#, c-format
+msgid "Failed to save document to the file \"%s\"."
+msgstr "Belge \"%s\" dosyasına kaydedilemedi."
+
+#: ../src/common/docview.cpp:702
+#, c-format
+msgid "File \"%s\" could not be opened for reading."
+msgstr "\"%s\" dosyası okunmak üzere açılamadı."
+
+#: ../src/common/docview.cpp:714
+#, c-format
+msgid "Failed to read document from the file \"%s\"."
+msgstr "\"%s\" dosyasından belge okunamadı."
+
+#: ../src/common/docview.cpp:1236
+#, c-format
+msgid ""
+"The file '%s' doesn't exist and couldn't be opened.\n"
+"It has been removed from the most recently used files list."
+msgstr ""
+"'%s' dosyası yok ve açılamadı.\n"
+"Son kullanılan dosyalar listesinden kaldırıldı."
+
+#: ../src/common/docview.cpp:1296
+msgid "Print preview creation failed."
+msgstr "Yazdırma önizlemesi oluşturulamadı."
+
+#: ../src/common/docview.cpp:1302
+msgid "Print Preview"
+msgstr "Yazdırma önizlemesi"
+
+#: ../src/common/docview.cpp:1517
+#, c-format
+msgid "The format of file '%s' couldn't be determined."
+msgstr "'%s' dosyasının biçimi belirlenemedi."
+
+#: ../src/common/docview.cpp:1643
+#, c-format
+msgid "unnamed%d"
+msgstr "adsız%d"
+
+#: ../src/common/docview.cpp:1660
+msgid " - "
+msgstr " - "
+
+#: ../src/common/docview.cpp:1791 ../src/common/docview.cpp:1844
+msgid "Open File"
+msgstr "Dosya aç"
+
+#: ../src/common/docview.cpp:1807
+msgid "File error"
+msgstr "Dosya hatası"
+
+#: ../src/common/docview.cpp:1809
+msgid "Sorry, could not open this file."
+msgstr "Ne yazık ki bu dosya açılamıyor."
+
+#: ../src/common/docview.cpp:1843
+msgid "Sorry, the format for this file is unknown."
+msgstr "Ne yazık ki bu dosyanın biçimi bilinmiyor."
+
+#: ../src/common/docview.cpp:1924
+msgid "Select a document template"
+msgstr "Bir belge kalıbı seçin"
+
+#: ../src/common/docview.cpp:1925
+msgid "Templates"
+msgstr "Kalıplar"
+
+#: ../src/common/docview.cpp:1998
+msgid "Select a document view"
+msgstr "Bir belge görünümü seçin"
+
+#: ../src/common/docview.cpp:1999
+msgid "Views"
+msgstr "Görünümler"
+
+#: ../src/common/dynlib.cpp:81
+#, c-format
+msgid "Failed to load shared library '%s'"
+msgstr "'%s' paylaşılmış kitaplığı yüklenemedi"
+
+#: ../src/common/dynlib.cpp:105
+#, c-format
+msgid "Couldn't find symbol '%s' in a dynamic library"
+msgstr "'%s' simgesi devingen kitaplıkta bulunamadı"
+
+#: ../src/common/ffile.cpp:56 ../src/common/file.cpp:215
+#, c-format
+msgid "can't open file '%s'"
+msgstr "'%s' dosyası açılamadı"
+
+#: ../src/common/ffile.cpp:72
+#, c-format
+msgid "can't close file '%s'"
+msgstr "'%s' dosyası kapatılamadı"
+
+#: ../src/common/ffile.cpp:106 ../src/common/ffile.cpp:131
+#, c-format
+msgid "Read error on file '%s'"
+msgstr "'%s' dosyasını okurken sorun çıktı"
+
+#: ../src/common/ffile.cpp:148
+#, c-format
+msgid "Write error on file '%s'"
+msgstr "'%s' dosyasına yazılırken sorun çıktı"
+
+#: ../src/common/ffile.cpp:182
+#, c-format
+msgid "failed to flush the file '%s'"
+msgstr "'%s' dosyası temizlenemedi"
+
+#: ../src/common/ffile.cpp:222
+#, c-format
+msgid "Seek error on file '%s' (large files not supported by stdio)"
+msgstr ""
+"'%s' dosyasında arama hatası (büyük dosyalar 'stdio' tarafından "
+"desteklenmiyor)"
+
+#: ../src/common/ffile.cpp:232
+#, c-format
+msgid "Seek error on file '%s'"
+msgstr "'%s' dosyasında arama sorunu"
+
+#: ../src/common/ffile.cpp:248
+#, c-format
+msgid "Can't find current position in file '%s'"
+msgstr "'%s' dosyasındaki geçerli konum bulunamadı"
+
+#: ../src/common/ffile.cpp:349 ../src/common/file.cpp:569
+msgid "Failed to set temporary file permissions"
+msgstr "Geçici dosya izinleri ayarlanamadı"
+
+#: ../src/common/ffile.cpp:371
+#, c-format
+msgid "can't remove file '%s'"
+msgstr "'%s' dosyası silinemedi"
+
+#: ../src/common/ffile.cpp:376 ../src/common/file.cpp:591
+#, c-format
+msgid "can't commit changes to file '%s'"
+msgstr "'%s' dosyasındaki değişiklikler işlenemedi"
+
+#: ../src/common/ffile.cpp:388 ../src/common/file.cpp:603
+#, c-format
+msgid "can't remove temporary file '%s'"
+msgstr "'%s' geçici dosyası silinemedi"
+
+#: ../src/common/file.cpp:162
+#, c-format
+msgid "can't create file '%s'"
+msgstr "'%s' dosyası oluşturulamadı"
+
+#: ../src/common/file.cpp:229
+#, c-format
+msgid "can't close file descriptor %d"
+msgstr "%d dosya tanımlayıcısı kapatılamadı"
+
+#: ../src/common/file.cpp:332
+#, c-format
+msgid "can't read from file descriptor %d"
+msgstr "%d dosya tanımlayıcısından okunamadı"
+
+#: ../src/common/file.cpp:351
+#, c-format
+msgid "can't write to file descriptor %d"
+msgstr "%d dosya tanımlayıcısına yazılamadı"
+
+#: ../src/common/file.cpp:390
+#, c-format
+msgid "can't flush file descriptor %d"
+msgstr "%d dosya tanımlayıcısı temizlenemedi"
+
+#: ../src/common/file.cpp:432
+#, c-format
+msgid "can't seek on file descriptor %d"
+msgstr "%d dosya tanımlayıcısı üzerinde arama yapılamadı"
+
+#: ../src/common/file.cpp:446
+#, c-format
+msgid "can't get seek position on file descriptor %d"
+msgstr "%d dosya tanımlayıcısı üstündeki arama konumu alınamadı"
+
+#: ../src/common/file.cpp:475
+#, c-format
+msgid "can't find length of file on file descriptor %d"
+msgstr "%d tanımlayıcısı üstündeki dosyanın uzunluğu bulunamadı"
+
+#: ../src/common/file.cpp:505
+#, c-format
+msgid "can't determine if the end of file is reached on descriptor %d"
+msgstr ""
+"%d tanımlayıcısı üstündeki dosyanın sonuna ulaşılıp ulaşılamadığı "
+"belirlenemedi"
+
+#: ../src/common/fileconf.cpp:352
+#, c-format
+msgid ""
+" and additionally, the existing configuration file was renamed to \"%s\" and "
+"couldn't be renamed back, please rename it to its original path \"%s\""
+msgstr ""
+" ve ayrıca, mevcut yapılandırma dosyası \"%s\" olarak yeniden adlandırıldı "
+"ve geri adlandırılamadı, lütfen orijinal yoluna \"%s\" yeniden adlandırın."
+
+#: ../src/common/fileconf.cpp:389
+msgid " due to the following error:\n"
+msgstr " aşağıdaki hata nedeniyle:\n"
+
+#: ../src/common/fileconf.cpp:412
+msgid "failed to rename the existing file"
+msgstr "mevcut dosya yeniden adlandırılamadı."
+
+#: ../src/common/fileconf.cpp:421
+msgid "failed to create the new file directory"
+msgstr "yeni dosya dizini oluşturulamadı."
+
+#: ../src/common/fileconf.cpp:428
+msgid "failed to move the file to the new location"
+msgstr "dosya yeni konuma taşınamadı."
+
+#: ../src/common/fileconf.cpp:462
+#, c-format
+msgid "can't open global configuration file '%s'."
+msgstr "'%s' genel ayar dosyası açılamadı."
+
+#: ../src/common/fileconf.cpp:478
+#, c-format
+msgid "can't open user configuration file '%s'."
+msgstr "'%s' kullanıcı ayar dosyası açılamadı."
+
+#: ../src/common/fileconf.cpp:483
+#, c-format
+msgid "Changes won't be saved to avoid overwriting the existing file \"%s\""
+msgstr ""
+"Var olan \"%s\" dosyasının üstüne yazılmasını önlemek için değişiklikler "
+"kaydedilmeyecek."
+
+#: ../src/common/fileconf.cpp:583
+msgid "Error reading config options."
+msgstr "Ayarlar okunurken sorun çıktı."
+
+#: ../src/common/fileconf.cpp:593
+msgid "Failed to read config options."
+msgstr "Ayarlar okunamadı."
+
+#: ../src/common/fileconf.cpp:700
+#, c-format
+msgid "file '%s': unexpected character %c at line %zu."
+msgstr "dosya '%s': beklenmedik karakter %c,  satır: %zu."
+
+#: ../src/common/fileconf.cpp:736
+#, c-format
+msgid "file '%s', line %zu: '%s' ignored after group header."
+msgstr "dosya '%s', satır %zu: '%s' grup başlığından sonra yok sayıldı."
+
+#: ../src/common/fileconf.cpp:765
+#, c-format
+msgid "file '%s', line %zu: '=' expected."
+msgstr "dosya '%s', satır %zu: '=' bekleniyor."
+
+#: ../src/common/fileconf.cpp:778
+#, c-format
+msgid "file '%s', line %zu: value for immutable key '%s' ignored."
+msgstr "dosya '%s', satır %zu: '%s' değişmez anahtarı için değer yok sayıldı."
+
+#: ../src/common/fileconf.cpp:788
+#, c-format
+msgid "file '%s', line %zu: key '%s' was first found at line %d."
+msgstr "dosya '%s', satır %zu: anahtar '%s' ilk olarak %d satırında bulundu."
+
+#: ../src/common/fileconf.cpp:1091
+#, c-format
+msgid "Config entry name cannot start with '%c'."
+msgstr "Ayar kaydının adı '%c' ile başlayamaz."
+
+#: ../src/common/fileconf.cpp:1146
+msgid "Failed to create configuration file directory."
+msgstr "Font yapılandırma nesnesi eklenemedi."
+
+#: ../src/common/fileconf.cpp:1158
+msgid "can't open user configuration file."
+msgstr "kullanıcı ayar dosyası açılamadı."
+
+#: ../src/common/fileconf.cpp:1172
+msgid "can't write user configuration file."
+msgstr "kullanıcı ayar dosyası yazılamadı."
+
+#: ../src/common/fileconf.cpp:1178
+msgid "Failed to update user configuration file."
+msgstr "Kullanıcı ayarları dosyası kaydedilemedi."
+
+#: ../src/common/fileconf.cpp:1201
+msgid "Error saving user configuration data."
+msgstr "Kullanıcı ayarları kaydedilirken sorun çıktı."
+
+#: ../src/common/fileconf.cpp:1313
+#, c-format
+msgid "can't delete user configuration file '%s'"
+msgstr "kullanıcı yapılandırma dosyası '%s' silinemedi"
+
+#: ../src/common/fileconf.cpp:2007
+#, c-format
+msgid "entry '%s' appears more than once in group '%s'"
+msgstr "'%s' kaydı '%s' grubunda birden çok kez geçiyor"
+
+#: ../src/common/fileconf.cpp:2021
+#, c-format
+msgid "attempt to change immutable key '%s' ignored."
+msgstr "'%s' değişmez anahtarını değiştirme denemesi yok sayıldı."
+
+#: ../src/common/fileconf.cpp:2118
+#, c-format
+msgid "trailing backslash ignored in '%s'"
+msgstr "'%s' sonundaki ters eğik çizgi yok sayıldı"
+
+#: ../src/common/fileconf.cpp:2153
+#, c-format
+msgid "unexpected \" at position %d in '%s'."
+msgstr "%d konumunda, '%s' içinde beklenmeyen \"."
+
+#: ../src/common/filefn.cpp:474
+#, c-format
+msgid "Failed to copy the file '%s' to '%s'"
+msgstr "'%s' dosyası '%s' içine kopyalanamadı"
+
+#: ../src/common/filefn.cpp:487
+#, c-format
+msgid "Impossible to get permissions for file '%s'"
+msgstr "'%s' dosyasının izinleri okunamadı"
+
+#: ../src/common/filefn.cpp:501
+#, c-format
+msgid "Impossible to overwrite the file '%s'"
+msgstr "'%s' dosyasının üzerine yazılamadı"
+
+#: ../src/common/filefn.cpp:508
+#, c-format
+msgid "Error copying the file '%s' to '%s'."
+msgstr "'%s' dosyası '%s' içine kopyalanırken sorun çıktı."
+
+#: ../src/common/filefn.cpp:556
+#, c-format
+msgid "Impossible to set permissions for the file '%s'"
+msgstr "'%s' dosyasının izinleri değiştirilemedi"
+
+#: ../src/common/filefn.cpp:606
+#, c-format
+msgid ""
+"Failed to rename the file '%s' to '%s' because the destination file already "
+"exists."
+msgstr ""
+"'%s' dosyası aynı adlı bir dosya olduğundan '%s' olarak yeniden "
+"adlandırılamadı."
+
+#: ../src/common/filefn.cpp:623
+#, c-format
+msgid "File '%s' couldn't be renamed '%s'"
+msgstr "'%s' dosyası '%s' olarak yeniden adlandırılamadı"
+
+#: ../src/common/filefn.cpp:639
+#, c-format
+msgid "File '%s' couldn't be removed"
+msgstr "'%s' dosyası silinemedi"
+
+#: ../src/common/filefn.cpp:666
+#, c-format
+msgid "Directory '%s' couldn't be created"
+msgstr "'%s' klasörü oluşturulamadı"
+
+#: ../src/common/filefn.cpp:680
+#, c-format
+msgid "Directory '%s' couldn't be deleted"
+msgstr "'%s' klasörü silinemedi"
+
+#: ../src/common/filefn.cpp:714
+#, c-format
+msgid "Cannot enumerate files '%s'"
+msgstr "'%s' dosyaları sayılamadı"
+
+#: ../src/common/filefn.cpp:798
+msgid "Failed to get the working directory"
+msgstr "Çalışma klasörü alınamadı"
+
+#: ../src/common/filefn.cpp:843
+msgid "Could not set current working directory"
+msgstr "Geçerli çalışma klasörü ayarlanamadı"
+
+#: ../src/common/filefn.cpp:974
+#, c-format
+msgid "Files (%s)"
+msgstr "Dosyalar (%s)"
+
+#: ../src/common/filename.cpp:182
+#, c-format
+msgid "Failed to open '%s' for reading"
+msgstr "'%s' okunmak üzere açılamadı"
+
+#: ../src/common/filename.cpp:187
+#, c-format
+msgid "Failed to open '%s' for writing"
+msgstr "'%s' yazılmak üzere açılamadı"
+
+#: ../src/common/filename.cpp:199
+msgid "Failed to close file handle"
+msgstr "Dosya işleyici kapatılamadı"
+
+#: ../src/common/filename.cpp:1046
+msgid "Failed to create a temporary file name"
+msgstr "Geçici dosya adı oluşturulamadı"
+
+#: ../src/common/filename.cpp:1081
+msgid "Failed to open temporary file."
+msgstr "Geçici dosya açılamadı."
+
+#: ../src/common/filename.cpp:2862
+#, c-format
+msgid "Failed to modify file times for '%s'"
+msgstr "'%s' için dosya zamanları değiştirilemedi"
+
+#: ../src/common/filename.cpp:2877
+#, c-format
+msgid "Failed to touch the file '%s'"
+msgstr "'%s' dosyasına dokunulamadı"
+
+#: ../src/common/filename.cpp:2958
+#, c-format
+msgid "Failed to retrieve file times for '%s'"
+msgstr "'%s' için dosya zamanları alınamadı"
+
+#: ../src/common/filepickercmn.cpp:39 ../src/common/filepickercmn.cpp:40
+msgid "Browse"
+msgstr "Göz at"
+
+#: ../src/common/fldlgcmn.cpp:792 ../src/generic/filectrlg.cpp:1185
+#, c-format
+msgid "All files (%s)|%s"
+msgstr "Tüm dosyalar (%s)|%s"
+
+#. TRANSLATORS: %s are a file extension used to build a file wildcard string
+#: ../src/common/fldlgcmn.cpp:810
+#, c-format
+msgid "%s files (%s)|%s"
+msgstr "%s dosya (%s)|%s"
+
+#: ../src/common/fldlgcmn.cpp:1072
+#, c-format
+msgid "Load %s file"
+msgstr "%s dosyasını yükle"
+
+#: ../src/common/fldlgcmn.cpp:1074
+#, c-format
+msgid "Save %s file"
+msgstr "%s dosyasını kaydet"
+
+#: ../src/common/fmapbase.cpp:144
+msgid "Western European (ISO-8859-1)"
+msgstr "Batı Avrupa (ISO-8859-1)"
+
+#: ../src/common/fmapbase.cpp:145
+msgid "Central European (ISO-8859-2)"
+msgstr "Orta Avrupa (ISO-8859-2)"
+
+#: ../src/common/fmapbase.cpp:146
+msgid "Esperanto (ISO-8859-3)"
+msgstr "Esperanto (ISO-8859-3)"
+
+#: ../src/common/fmapbase.cpp:147
+msgid "Baltic (old) (ISO-8859-4)"
+msgstr "Baltık (eski) (ISO-8859-4)"
+
+#: ../src/common/fmapbase.cpp:148
+msgid "Cyrillic (ISO-8859-5)"
+msgstr "Kril (ISO-8859-5)"
+
+#: ../src/common/fmapbase.cpp:149
+msgid "Arabic (ISO-8859-6)"
+msgstr "Arapça (ISO-8859-6)"
+
+#: ../src/common/fmapbase.cpp:150
+msgid "Greek (ISO-8859-7)"
+msgstr "Yunanca (ISO-8859-7)"
+
+#: ../src/common/fmapbase.cpp:151
+msgid "Hebrew (ISO-8859-8)"
+msgstr "İbranice (ISO-8859-8)"
+
+#: ../src/common/fmapbase.cpp:152
+msgid "Turkish (ISO-8859-9)"
+msgstr "Türkçe (ISO-8859-9)"
+
+#: ../src/common/fmapbase.cpp:153
+msgid "Nordic (ISO-8859-10)"
+msgstr "Norveçce (ISO-8859-10)"
+
+#: ../src/common/fmapbase.cpp:154
+msgid "Thai (ISO-8859-11)"
+msgstr "Thai (ISO-8859-11)"
+
+#: ../src/common/fmapbase.cpp:155
+msgid "Indian (ISO-8859-12)"
+msgstr "Hintçe (ISO-8859-12)"
+
+#: ../src/common/fmapbase.cpp:156
+msgid "Baltic (ISO-8859-13)"
+msgstr "Baltık (ISO-8859-13)"
+
+#: ../src/common/fmapbase.cpp:157
+msgid "Celtic (ISO-8859-14)"
+msgstr "Keltçe (ISO-8859-14)"
+
+#: ../src/common/fmapbase.cpp:158
+msgid "Western European with Euro (ISO-8859-15)"
+msgstr "Batı Avrupa (Euro) (ISO-8859-15)"
+
+#: ../src/common/fmapbase.cpp:159
+msgid "KOI8-R"
+msgstr "KOI8-R"
+
+#: ../src/common/fmapbase.cpp:160
+msgid "KOI8-U"
+msgstr "KOI8-U"
+
+#: ../src/common/fmapbase.cpp:161
+msgid "Windows/DOS OEM Cyrillic (CP 866)"
+msgstr "Windows/DOS OEM Kiril (CP 866)"
+
+#: ../src/common/fmapbase.cpp:162
+msgid "Windows Thai (CP 874)"
+msgstr "Windows Tai (CP 874)"
+
+#: ../src/common/fmapbase.cpp:163
+msgid "Windows Japanese (CP 932) or Shift-JIS"
+msgstr "Windows Japonca (CP 932) ya da Shift-JIS"
+
+#: ../src/common/fmapbase.cpp:164
+msgid "Windows Chinese Simplified (CP 936) or GB-2312"
+msgstr "Windows Basitleştirilmiş Çince (CP 936) ya da GB-2312"
+
+#: ../src/common/fmapbase.cpp:165
+msgid "Windows Korean (CP 949)"
+msgstr "Windows Korece (CP 949)"
+
+#: ../src/common/fmapbase.cpp:166
+msgid "Windows Chinese Traditional (CP 950) or Big-5"
+msgstr "Windows Geleneksel Çince (CP 950) ya da Big-5"
+
+#: ../src/common/fmapbase.cpp:167
+msgid "Windows Central European (CP 1250)"
+msgstr "Windows Orta Avrupa (CP 1250)"
+
+#: ../src/common/fmapbase.cpp:168
+msgid "Windows Cyrillic (CP 1251)"
+msgstr "Windows Kiril (CP 1251)"
+
+#: ../src/common/fmapbase.cpp:169
+msgid "Windows Western European (CP 1252)"
+msgstr "Windows Batı Avrupa (CP 1252)"
+
+#: ../src/common/fmapbase.cpp:170
+msgid "Windows Greek (CP 1253)"
+msgstr "Windows Yunanca (CP 1253)"
+
+#: ../src/common/fmapbase.cpp:171
+msgid "Windows Turkish (CP 1254)"
+msgstr "Windows Türkçe (CP 1254)"
+
+#: ../src/common/fmapbase.cpp:172
+msgid "Windows Hebrew (CP 1255)"
+msgstr "Windows İbranice (CP 1255)"
+
+#: ../src/common/fmapbase.cpp:173
+msgid "Windows Arabic (CP 1256)"
+msgstr "Windows Arapça (CP 1256)"
+
+#: ../src/common/fmapbase.cpp:174
+msgid "Windows Baltic (CP 1257)"
+msgstr "Windows Baltık (CP 1257)"
+
+#: ../src/common/fmapbase.cpp:175
+msgid "Windows Vietnamese (CP 1258)"
+msgstr "Windows Vietnamca (CP 1258)"
+
+#: ../src/common/fmapbase.cpp:176
+msgid "Windows Johab (CP 1361)"
+msgstr "Windows Johab (CP 1361)"
+
+#: ../src/common/fmapbase.cpp:177
+msgid "Windows/DOS OEM (CP 437)"
+msgstr "Windows/DOS OEM (CP 437)"
+
+#: ../src/common/fmapbase.cpp:178
+msgid "Unicode 7 bit (UTF-7)"
+msgstr "7 bit Unikod (UTF-7)"
+
+#: ../src/common/fmapbase.cpp:179
+msgid "Unicode 8 bit (UTF-8)"
+msgstr "8 bit Unikod (UTF-8)"
+
+#: ../src/common/fmapbase.cpp:181 ../src/common/fmapbase.cpp:187
+msgid "Unicode 16 bit (UTF-16)"
+msgstr "Unikod 16 bit (UTF-16)"
+
+#: ../src/common/fmapbase.cpp:182
+msgid "Unicode 16 bit Little Endian (UTF-16LE)"
+msgstr "Unikod 16 bit Little Endian (UTF-16LE)"
+
+#: ../src/common/fmapbase.cpp:183 ../src/common/fmapbase.cpp:189
+msgid "Unicode 32 bit (UTF-32)"
+msgstr "Unikod 32 bit (UTF-32)"
+
+#: ../src/common/fmapbase.cpp:184
+msgid "Unicode 32 bit Little Endian (UTF-32LE)"
+msgstr "Unikod 32 bit Little Endian (UTF-32LE)"
+
+#: ../src/common/fmapbase.cpp:186
+msgid "Unicode 16 bit Big Endian (UTF-16BE)"
+msgstr "Unikod 16 bit Big Endian (UTF-16BE)"
+
+#: ../src/common/fmapbase.cpp:188
+msgid "Unicode 32 bit Big Endian (UTF-32BE)"
+msgstr "Unikod 32 bit Big Endian (UTF-32BE)"
+
+#: ../src/common/fmapbase.cpp:191
+msgid "Extended Unix Codepage for Japanese (EUC-JP)"
+msgstr "Japonca için genişletilmiş Unix Codepage (EUC-JP)"
+
+#: ../src/common/fmapbase.cpp:192
+msgid "US-ASCII"
+msgstr "US-ASCII"
+
+#: ../src/common/fmapbase.cpp:193
+msgid "ISO-2022-JP"
+msgstr "ISO-2022-JP"
+
+#: ../src/common/fmapbase.cpp:195
+msgid "MacRoman"
+msgstr "MacRoman"
+
+#: ../src/common/fmapbase.cpp:196
+msgid "MacJapanese"
+msgstr "MacJaponca"
+
+#: ../src/common/fmapbase.cpp:197
+msgid "MacChineseTrad"
+msgstr "MacÇinceGeleneksel"
+
+#: ../src/common/fmapbase.cpp:198
+msgid "MacKorean"
+msgstr "MacKorece"
+
+#: ../src/common/fmapbase.cpp:199
+msgid "MacArabic"
+msgstr "MacArapça"
+
+#: ../src/common/fmapbase.cpp:200
+msgid "MacHebrew"
+msgstr "Macİbranice"
+
+#: ../src/common/fmapbase.cpp:201
+msgid "MacGreek"
+msgstr "MacYunanca"
+
+#: ../src/common/fmapbase.cpp:202
+msgid "MacCyrillic"
+msgstr "MacKiril"
+
+#: ../src/common/fmapbase.cpp:203
+msgid "MacDevanagari"
+msgstr "MacDevanagari"
+
+#: ../src/common/fmapbase.cpp:204
+msgid "MacGurmukhi"
+msgstr "MacGurmukhi"
+
+#: ../src/common/fmapbase.cpp:205
+msgid "MacGujarati"
+msgstr "MacGujarati"
+
+#: ../src/common/fmapbase.cpp:206
+msgid "MacOriya"
+msgstr "MacOriya"
+
+#: ../src/common/fmapbase.cpp:207
+msgid "MacBengali"
+msgstr "MacBengalce"
+
+#: ../src/common/fmapbase.cpp:208
+msgid "MacTamil"
+msgstr "MacTamil"
+
+#: ../src/common/fmapbase.cpp:209
+msgid "MacTelugu"
+msgstr "MacTelugu"
+
+#: ../src/common/fmapbase.cpp:210
+msgid "MacKannada"
+msgstr "MacKanada"
+
+#: ../src/common/fmapbase.cpp:211
+msgid "MacMalayalam"
+msgstr "MacMalayca"
+
+#: ../src/common/fmapbase.cpp:212
+msgid "MacSinhalese"
+msgstr "MacSinhalese"
+
+#: ../src/common/fmapbase.cpp:213
+msgid "MacBurmese"
+msgstr "MacBurmese"
+
+#: ../src/common/fmapbase.cpp:214
+msgid "MacKhmer"
+msgstr "MacKmerce"
+
+#: ../src/common/fmapbase.cpp:215
+msgid "MacThai"
+msgstr "MacTay"
+
+#: ../src/common/fmapbase.cpp:216
+msgid "MacLaotian"
+msgstr "MacLaotian"
+
+#: ../src/common/fmapbase.cpp:217
+msgid "MacGeorgian"
+msgstr "MacAzerice"
+
+#: ../src/common/fmapbase.cpp:218
+msgid "MacArmenian"
+msgstr "MacErmenice"
+
+#: ../src/common/fmapbase.cpp:219
+msgid "MacChineseSimp"
+msgstr "MacÇinceBasit"
+
+#: ../src/common/fmapbase.cpp:220
+msgid "MacTibetan"
+msgstr "MacTibetçe"
+
+#: ../src/common/fmapbase.cpp:221
+msgid "MacMongolian"
+msgstr "MacMongolca"
+
+#: ../src/common/fmapbase.cpp:222
+msgid "MacEthiopic"
+msgstr "MacEtyopça"
+
+#: ../src/common/fmapbase.cpp:223
+msgid "MacCentralEurRoman"
+msgstr "MacOrtaAvrupaRoman"
+
+#: ../src/common/fmapbase.cpp:224
+msgid "MacVietnamese"
+msgstr "MacVietnamca"
+
+#: ../src/common/fmapbase.cpp:225
+msgid "MacExtArabic"
+msgstr "MacExtArapça"
+
+#: ../src/common/fmapbase.cpp:226
+msgid "MacSymbol"
+msgstr "MacSimge"
+
+#: ../src/common/fmapbase.cpp:227
+msgid "MacDingbats"
+msgstr "MacDingbats"
+
+#: ../src/common/fmapbase.cpp:228
+msgid "MacTurkish"
+msgstr "MacTürkçe"
+
+#: ../src/common/fmapbase.cpp:229
+msgid "MacCroatian"
+msgstr "MacHırvatça"
+
+#: ../src/common/fmapbase.cpp:230
+msgid "MacIcelandic"
+msgstr "MacIzlandaca"
+
+#: ../src/common/fmapbase.cpp:231
+msgid "MacRomanian"
+msgstr "MacRomence"
+
+#: ../src/common/fmapbase.cpp:232
+msgid "MacCeltic"
+msgstr "MacKeltçe"
+
+#: ../src/common/fmapbase.cpp:233
+msgid "MacGaelic"
+msgstr "MacGaliçce"
+
+#: ../src/common/fmapbase.cpp:234
+msgid "MacKeyboardGlyphs"
+msgstr "MacKeyboardGlyphs"
+
+#: ../src/common/fmapbase.cpp:791
+msgid "Default encoding"
+msgstr "Varsayılan kodlama"
+
+#: ../src/common/fmapbase.cpp:805
+#, c-format
+msgid "Unknown encoding (%d)"
+msgstr "Bilinmeyen kodlama (%d)"
+
+#: ../src/common/fmapbase.cpp:815 ../src/richtext/richtextstyles.cpp:776
+msgid "default"
+msgstr "varsayılan"
+
+#: ../src/common/fmapbase.cpp:829
+#, c-format
+msgid "unknown-%d"
+msgstr "bilinmiyor-%d"
+
+#: ../src/common/fontcmn.cpp:924 ../src/common/fontcmn.cpp:1130
+msgid "underlined"
+msgstr "altıçizili"
+
+#: ../src/common/fontcmn.cpp:929
+msgid " strikethrough"
+msgstr " üstüçizili"
+
+#: ../src/common/fontcmn.cpp:942
+msgid " thin"
+msgstr " ince"
+
+#: ../src/common/fontcmn.cpp:946
+msgid " extra light"
+msgstr " ekstra ince"
+
+#: ../src/common/fontcmn.cpp:950
+msgid " light"
+msgstr " ince"
+
+#: ../src/common/fontcmn.cpp:954
+msgid " medium"
+msgstr " orta"
+
+#: ../src/common/fontcmn.cpp:958
+msgid " semi bold"
+msgstr " yarı kalın"
+
+#: ../src/common/fontcmn.cpp:962
+msgid " bold"
+msgstr " kalın"
+
+#: ../src/common/fontcmn.cpp:966
+msgid " extra bold"
+msgstr " ekstra kalın"
+
+#: ../src/common/fontcmn.cpp:970
+msgid " heavy"
+msgstr " ağır"
+
+#: ../src/common/fontcmn.cpp:974
+msgid " extra heavy"
+msgstr " ekstra ağır"
+
+#: ../src/common/fontcmn.cpp:990
+msgid " italic"
+msgstr " italik"
+
+#: ../src/common/fontcmn.cpp:1134
+msgid "strikethrough"
+msgstr "üstüçizili"
+
+#: ../src/common/fontcmn.cpp:1143
+msgid "thin"
+msgstr "ince"
+
+#: ../src/common/fontcmn.cpp:1156
+msgid "extralight"
+msgstr "ekstraince"
+
+#: ../src/common/fontcmn.cpp:1161
+msgid "light"
+msgstr "ince"
+
+#: ../src/common/fontcmn.cpp:1169 ../src/richtext/richtextstyles.cpp:775
+msgid "normal"
+msgstr "normal"
+
+#: ../src/common/fontcmn.cpp:1174
+msgid "medium"
+msgstr "orta"
+
+#: ../src/common/fontcmn.cpp:1179 ../src/common/fontcmn.cpp:1199
+msgid "semibold"
+msgstr "yarıkalın"
+
+#: ../src/common/fontcmn.cpp:1184
+msgid "bold"
+msgstr "kalın"
+
+#: ../src/common/fontcmn.cpp:1194
+msgid "extrabold"
+msgstr "ekstrakalın"
+
+#: ../src/common/fontcmn.cpp:1204
+msgid "heavy"
+msgstr "ağır"
+
+#: ../src/common/fontcmn.cpp:1212
+msgid "extraheavy"
+msgstr "ekstraağır"
+
+#: ../src/common/fontcmn.cpp:1217
+msgid "italic"
+msgstr "italik"
+
+#: ../src/common/fontmap.cpp:195
+msgid ": unknown charset"
+msgstr ": karakter kümesi bilinmiyor"
+
+#: ../src/common/fontmap.cpp:199
+#, c-format
+msgid ""
+"The charset '%s' is unknown. You may select\n"
+"another charset to replace it with or choose\n"
+"[Cancel] if it cannot be replaced"
+msgstr ""
+"'%s' karakter kümesi bilinmiyor. Yerine\n"
+"başka bir tane seçebilir ya da \n"
+"seçemiyorsanız [İptal] düğmesine tıklayabilirsiniz"
+
+#: ../src/common/fontmap.cpp:241
+#, c-format
+msgid "Failed to remember the encoding for the charset '%s'."
+msgstr "'%s' karakter kümesi için kodlama anımsanamadı."
+
+#: ../src/common/fontmap.cpp:321
+msgid "can't load any font, aborting"
+msgstr "herhangi bir font yüklenemedi, vazgeçiliyor"
+
+#: ../src/common/fontmap.cpp:409
+msgid ": unknown encoding"
+msgstr ": kodlama bilinmiyor"
+
+#: ../src/common/fontmap.cpp:417
+#, c-format
+msgid ""
+"No font for displaying text in encoding '%s' found,\n"
+"but an alternative encoding '%s' is available.\n"
+"Do you want to use this encoding (otherwise you will have to choose another "
+"one)?"
+msgstr ""
+"Metni '%s' kodlamasıyla görüntüleyecek bir font yok,\n"
+"ancak onun yerine '%s' kodlama seçeneği kullanılabilir.\n"
+"Bu kodlamayı kullanmak istiyor musunuz (aksi halde başka bir tane "
+"seçmelisiniz) ?"
+
+#: ../src/common/fontmap.cpp:422
+#, c-format
+msgid ""
+"No font for displaying text in encoding '%s' found.\n"
+"Would you like to select a font to be used for this encoding\n"
+"(otherwise the text in this encoding will not be shown correctly)?"
+msgstr ""
+"Metni '%s' kodlamasıyla görüntüleyecek bir font yok.\n"
+"Bu kodlamayı kullanabileceğiniz bir fontu seçmek istiyor musunuz\n"
+"(aksi halde bu kodlamadaki metin doğru olarak görüntülenmez) ?"
+
+#: ../src/common/fs_mem.cpp:169
+#, c-format
+msgid "Memory VFS already contains file '%s'!"
+msgstr "'%s' dosyası zaten VFS belleğinde yer alıyor!"
+
+#: ../src/common/fs_mem.cpp:232
+#, c-format
+msgid "Trying to remove file '%s' from memory VFS, but it is not loaded!"
+msgstr ""
+"'%s' dosyası yüklü olmadığı halde VFS belleğinden silinmeye çalışılıyor!"
+
+#: ../src/common/fs_mem.cpp:262
+#, c-format
+msgid "Failed to store image '%s' to memory VFS!"
+msgstr "'%s' görüntüsü VFS belleğine yerleştirilemedi!"
+
+#: ../src/common/ftp.cpp:197
+msgid "Timeout while waiting for FTP server to connect, try passive mode."
+msgstr ""
+"FTP sunucusu ile bağlantı kurulurken zaman aşımı oldu, pasif kipi deneyin."
+
+#: ../src/common/ftp.cpp:399
+#, c-format
+msgid "Failed to set FTP transfer mode to %s."
+msgstr "FTP aktarım kipi %s olarak ayarlanamadı."
+
+#: ../src/common/ftp.cpp:400 ../src/richtext/richtextsymboldlg.cpp:432
+msgid "ASCII"
+msgstr "ASCII"
+
+#: ../src/common/ftp.cpp:400
+msgid "binary"
+msgstr "ikili"
+
+#: ../src/common/ftp.cpp:608
+msgid "The FTP server doesn't support the PORT command."
+msgstr "FTP sunucusu PORT komutunu desteklemiyor."
+
+#: ../src/common/ftp.cpp:622
+msgid "The FTP server doesn't support passive mode."
+msgstr "FTP sunucusu pasif kipi desteklemiyor."
+
+#: ../src/common/gifdecod.cpp:822
+#, c-format
+msgid "Incorrect GIF frame size (%u, %d) for the frame #%u"
+msgstr "GIF kare sayısı yanlış (%u, %d) #%u karesi"
+
+#: ../src/common/glcmn.cpp:108
+msgid "Failed to allocate colour for OpenGL"
+msgstr "OpenGL için renk ayarlanamadı"
+
+#: ../src/common/headerctrlcmn.cpp:57
+msgid "Please select the columns to show and define their order:"
+msgstr "Lütfen görüntülenecek sütunları seçin ve sıralarını belirleyin:"
+
+#: ../src/common/headerctrlcmn.cpp:58
+msgid "Customize Columns"
+msgstr "Sütunları özelleştir"
+
+#: ../src/common/headerctrlcmn.cpp:304
+msgid "&Customize..."
+msgstr "Ö&zelleştir..."
+
+#: ../src/common/hyperlnkcmn.cpp:132
+#, c-format
+msgid "Failed to open URL \"%s\" in the default browser"
+msgstr "\"%s\" adresi varsayılan tarayıcıda açılamadı"
+
+#: ../src/common/iconbndl.cpp:195
+#, c-format
+msgid "Failed to load image %%d from file '%s'."
+msgstr "%%d görseli '%s' dosyasından yüklenemedi."
+
+#: ../src/common/iconbndl.cpp:203
+#, c-format
+msgid "Failed to load image %d from stream."
+msgstr "%d görseli akıştan yüklenemedi."
+
+#: ../src/common/iconbndl.cpp:221
+#, c-format
+msgid "Failed to load icons from resource '%s'."
+msgstr "'%s' kaynağından simgeler yüklenemedi."
+
+#: ../src/common/imagbmp.cpp:97
+msgid "BMP: Couldn't save invalid image."
+msgstr "BMP: Geçersiz görüntü kaydedilemedi."
+
+#: ../src/common/imagbmp.cpp:137
+msgid "BMP: wxImage doesn't have own wxPalette."
+msgstr "BMP: wxImage için wxPalette yok."
+
+#: ../src/common/imagbmp.cpp:243
+msgid "BMP: Couldn't write the file (Bitmap) header."
+msgstr "BMP: Dosya (Bitmap) başlık bilgisi yazılamadı."
+
+#: ../src/common/imagbmp.cpp:266
+msgid "BMP: Couldn't write the file (BitmapInfo) header."
+msgstr "BMP: Dosya (BitmapInfo) başlık bilgisi yazılamadı."
+
+#: ../src/common/imagbmp.cpp:353
+msgid "BMP: Couldn't write RGB color map."
+msgstr "BMP: RGB renk haritası yazılamadı."
+
+#: ../src/common/imagbmp.cpp:487
+msgid "BMP: Couldn't write data."
+msgstr "BMP: Veri yazılamadı."
+
+#: ../src/common/imagbmp.cpp:561 ../src/common/imagbmp.cpp:642
+msgid "BMP: Couldn't allocate memory."
+msgstr "BMP: bellek ayrılamadı."
+
+#: ../src/common/imagbmp.cpp:1041
+msgid "DIB Header: Image width > 32767 pixels for file."
+msgstr "DIB başlık bilgisi: Dosya için görsel genişliği > 32767 piksel."
+
+#: ../src/common/imagbmp.cpp:1049
+msgid "DIB Header: Image height > 32767 pixels for file."
+msgstr "DIB başlık bilgisi: Dosya için görsel yüksekliği > 32767 piksel."
+
+#: ../src/common/imagbmp.cpp:1081
+msgid "DIB Header: Unknown bitdepth in file."
+msgstr "DIB başlık bilgisi: Dosyada bilinmeyen bit derinliği."
+
+#: ../src/common/imagbmp.cpp:1156
+msgid "DIB Header: Unknown encoding in file."
+msgstr "DIB başlık bilgisi: Dosyada bilinmeyen kodlama."
+
+#: ../src/common/imagbmp.cpp:1165
+msgid "DIB Header: Encoding doesn't match bitdepth."
+msgstr "DIB başlık bilgisi: Kodlama, bit derinliğine uymuyor."
+
+#: ../src/common/imagbmp.cpp:1180
+#, c-format
+msgid "BMP Header: Invalid number of colors (%d)."
+msgstr "BMP Başlığı: Geçersiz renk sayısı (%d)."
+
+#: ../src/common/imagbmp.cpp:1273
+msgid "Error in reading image DIB."
+msgstr "DIB görüntüsü okunurken sorun çıktı."
+
+#: ../src/common/imagbmp.cpp:1294
+msgid "ICO: Error in reading mask DIB."
+msgstr "ICO: DIB maskesi okuma hatası."
+
+#: ../src/common/imagbmp.cpp:1353
+msgid "ICO: Image too tall for an icon."
+msgstr "ICO: Görsel simge için çok uzun."
+
+#: ../src/common/imagbmp.cpp:1361
+msgid "ICO: Image too wide for an icon."
+msgstr "ICO: Görsel simge için çok geniş."
+
+#: ../src/common/imagbmp.cpp:1388 ../src/common/imagbmp.cpp:1488
+#: ../src/common/imagbmp.cpp:1503 ../src/common/imagbmp.cpp:1514
+#: ../src/common/imagbmp.cpp:1528 ../src/common/imagbmp.cpp:1576
+#: ../src/common/imagbmp.cpp:1591 ../src/common/imagbmp.cpp:1605
+#: ../src/common/imagbmp.cpp:1616
+msgid "ICO: Error writing the image file!"
+msgstr "ICO: Görsel dosyasına yazılırken sorun çıktı!"
+
+#: ../src/common/imagbmp.cpp:1701
+msgid "ICO: Invalid icon index."
+msgstr "ICO: Simge dizini geçersiz."
+
+#: ../src/common/image.cpp:2410
+msgid "Image and mask have different sizes."
+msgstr "Görsel ve maske farklı boyutlarda."
+
+#: ../src/common/image.cpp:2418 ../src/common/image.cpp:2459
+msgid "No unused colour in image being masked."
+msgstr "Maskelenen görselde kullanılmamış renk yok."
+
+#: ../src/common/image.cpp:2641
+#, c-format
+msgid "Failed to load bitmap \"%s\" from resources."
+msgstr "Kaynaklardan \"%s\" bit eşlemi yüklenemedi."
+
+#: ../src/common/image.cpp:2650
+#, c-format
+msgid "Failed to load icon \"%s\" from resources."
+msgstr "Kaynaklardan \"%s\" simgesi yüklenemedi."
+
+#: ../src/common/image.cpp:2728 ../src/common/image.cpp:2747
+#, c-format
+msgid "Failed to load image from file \"%s\"."
+msgstr "\"%s\" dosyasından görsel yüklenemedi."
+
+#: ../src/common/image.cpp:2761
+#, c-format
+msgid "Can't save image to file '%s': unknown extension."
+msgstr "Görüntü '%s' dosyasına kaydedilemedi: bilinmeyen uzantı."
+
+#: ../src/common/image.cpp:2869
+msgid "No handler found for image type."
+msgstr "Görüntü türünün işleyicisi bulunamadı."
+
+#: ../src/common/image.cpp:2877 ../src/common/image.cpp:3000
+#: ../src/common/image.cpp:3066
+#, c-format
+msgid "No image handler for type %d defined."
+msgstr "%d türünün görüntü işleyicisi tanımlanmamış."
+
+#: ../src/common/image.cpp:2887
+#, c-format
+msgid "Image file is not of type %d."
+msgstr "Görsel dosyası %d türünde değil."
+
+#: ../src/common/image.cpp:2970
+msgid "Can't automatically determine the image format for non-seekable input."
+msgstr "Aranamayan giriş için görsel biçimi kendiliğinden belirlenemiyor."
+
+#: ../src/common/image.cpp:2988
+msgid "Unknown image data format."
+msgstr "Görsel veri biçimi bilinmiyor."
+
+#: ../src/common/image.cpp:3009
+#, c-format
+msgid "This is not a %s."
+msgstr "Bu bir %s değil."
+
+#: ../src/common/image.cpp:3032 ../src/common/image.cpp:3080
+#, c-format
+msgid "No image handler for type %s defined."
+msgstr "%s türünün görüntü işleyicisi tanımlanmamış."
+
+#: ../src/common/image.cpp:3041
+#, c-format
+msgid "Image is not of type %s."
+msgstr "Görsel dosyası %s türünde değil."
+
+#: ../src/common/image.cpp:3509
+#, c-format
+msgid "Failed to check format of image file \"%s\"."
+msgstr "\"%s\" görsel dosyasının biçimi denetlenemedi."
+
+#: ../src/common/imaggif.cpp:124
+msgid "GIF: error in GIF image format."
+msgstr "GIF: GIF görsel biçimi hatası."
+
+#: ../src/common/imaggif.cpp:129
+msgid "GIF: not enough memory."
+msgstr "GIF: Bellek yetersiz."
+
+#: ../src/common/imaggif.cpp:134
+msgid "GIF: data stream seems to be truncated."
+msgstr "GIF: Veri akışı budanmış görünüyor."
+
+#: ../src/common/imaggif.cpp:240
+msgid "Couldn't initialize GIF hash table."
+msgstr "GIF hash tablosu başlatılamadı."
+
+#: ../src/common/imagiff.cpp:739
+msgid "IFF: error in IFF image format."
+msgstr "IIF: IFF görsel biçimi hatası."
+
+#: ../src/common/imagiff.cpp:742
+msgid "IFF: not enough memory."
+msgstr "IIF: Bellek yetersiz."
+
+#: ../src/common/imagiff.cpp:745
+msgid "IFF: unknown error!!!"
+msgstr "IIF: Bilinmeyen hata!!!"
+
+#: ../src/common/imagiff.cpp:755
+msgid "IFF: data stream seems to be truncated."
+msgstr "IIF: Veri akışı budanmış görünüyor."
+
+#: ../src/common/imagjpeg.cpp:258
+msgid "JPEG: Couldn't load - file is probably corrupted."
+msgstr "JPEG: Yüklenemedi - dosya bozuk olabilir."
+
+#: ../src/common/imagjpeg.cpp:437
+msgid "JPEG: Couldn't save image."
+msgstr "JPEG: Görsel kaydedilemedi."
+
+#: ../src/common/imagpcx.cpp:439
+msgid "PCX: this is not a PCX file."
+msgstr "PCX: Bu bir PCX dosyası değil."
+
+#: ../src/common/imagpcx.cpp:453
+msgid "PCX: image format unsupported"
+msgstr "PCX: Görsel biçimi desteklenmiyor"
+
+#: ../src/common/imagpcx.cpp:454 ../src/common/imagpcx.cpp:477
+msgid "PCX: couldn't allocate memory"
+msgstr "PCX: Bellek ayrılamadı"
+
+#: ../src/common/imagpcx.cpp:455
+msgid "PCX: version number too low"
+msgstr "PCX: Sürüm numarası çok küçük"
+
+#: ../src/common/imagpcx.cpp:456 ../src/common/imagpcx.cpp:478
+msgid "PCX: unknown error !!!"
+msgstr "PCX: Bilinmeyen hata !!!"
+
+#: ../src/common/imagpcx.cpp:476
+msgid "PCX: invalid image"
+msgstr "PCX: Görsel geçersiz"
+
+#: ../src/common/imagpng.cpp:385
+#, c-format
+msgid "Unknown PNG resolution unit %d"
+msgstr "Bilinmeyen PNG çözünürlük birimi %d"
+
+#: ../src/common/imagpng.cpp:439
+msgid "Couldn't load a PNG image - file is corrupted or not enough memory."
+msgstr "PNG görseli yüklenemedi - dosya bozuk ya da bellek yetersiz."
+
+#: ../src/common/imagpng.cpp:513 ../src/common/imagpng.cpp:524
+#: ../src/common/imagpng.cpp:534
+msgid "Couldn't save PNG image."
+msgstr "PNG görseli kaydedilemedi."
+
+#: ../src/common/imagpnm.cpp:71
+msgid "PNM: File format is not recognized."
+msgstr "PNM: Dosya biçimi tanınamadı."
+
+#: ../src/common/imagpnm.cpp:89
+msgid "PNM: Couldn't allocate memory."
+msgstr "PNM: Bellek ayrılamadı."
+
+#: ../src/common/imagpnm.cpp:111 ../src/common/imagpnm.cpp:134
+#: ../src/common/imagpnm.cpp:156
+msgid "PNM: File seems truncated."
+msgstr "PNM: Dosya budanmış görünüyor."
+
+#: ../src/common/imagtiff.cpp:69
+#, c-format
+msgid " (in module \"%s\")"
+msgstr " (\"%s\" modülünde)"
+
+#: ../src/common/imagtiff.cpp:304
+msgid "TIFF: Error loading image."
+msgstr "TIFF: Görsel yüklenirken sorun çıktı."
+
+#: ../src/common/imagtiff.cpp:314
+msgid "Invalid TIFF image index."
+msgstr "TIFF görsel dizini geçersiz."
+
+#: ../src/common/imagtiff.cpp:358
+msgid "TIFF: Image size is abnormally big."
+msgstr "TIFF: Görsel boyutu anormal büyük."
+
+#: ../src/common/imagtiff.cpp:372 ../src/common/imagtiff.cpp:385
+#: ../src/common/imagtiff.cpp:769
+msgid "TIFF: Couldn't allocate memory."
+msgstr "TIFF: Bellek ayrılamadı."
+
+#: ../src/common/imagtiff.cpp:471
+msgid "TIFF: Error reading image."
+msgstr "TIFF: Görsel okunurken sorun çıktı."
+
+#: ../src/common/imagtiff.cpp:532
+#, c-format
+msgid "Unknown TIFF resolution unit %d ignored"
+msgstr "Bilinmeyen TIFF %d çözünürlük birimi yok sayıldı"
+
+#: ../src/common/imagtiff.cpp:611
+msgid "TIFF: Error saving image."
+msgstr "TIFF: Görsel kaydedilirken sorun çıktı."
+
+#: ../src/common/imagtiff.cpp:868
+msgid "TIFF: Error writing image."
+msgstr "TIFF: Görsel yazılırken sorun çıktı."
+
+#: ../src/common/imagtiff.cpp:881
+msgid "TIFF: Error flushing data."
+msgstr "TIFF: Veri boşaltma hatası."
+
+#: ../src/common/imagwebp.cpp:56
+msgid "WebP: Invalid data (failed to get features)."
+msgstr "WebP: Geçersiz veri (özellikler alınamadı)."
+
+#: ../src/common/imagwebp.cpp:65
+msgid "WebP: Allocating image memory failed."
+msgstr "WebP: Görüntü belleği ayrılamadı."
+
+#: ../src/common/imagwebp.cpp:82
+msgid "WebP: Decoding RGBA image data failed."
+msgstr "WebP: RGBA görüntü verisi çözülemedi."
+
+#: ../src/common/imagwebp.cpp:98
+msgid "WebP: Decoding RGB image data failed."
+msgstr "WebP: RGB görüntü verisi çözülemedi."
+
+#: ../src/common/imagwebp.cpp:113 ../src/common/imagwebp.cpp:201
+msgid "WebP: Allocating stream buffer failed."
+msgstr "WebP: Akış arabelleği ayrılamadı."
+
+#: ../src/common/imagwebp.cpp:131
+msgid "WebP: Failed to parse container data."
+msgstr "WebP: Konteyner verisi çözümlenemedi."
+
+#: ../src/common/imagwebp.cpp:222
+msgid "WebP: Error decoding animation."
+msgstr "WebP: Animasyonun çözülmesinde hata oluştu."
+
+#: ../src/common/imagwebp.cpp:240
+msgid "WebP: Error getting next animation frame."
+msgstr "WebP: Sonraki animasyon karesi alınırken hata oluştu."
+
+#: ../src/common/init.cpp:172
+#, c-format
+msgid ""
+"Command line argument %d couldn't be converted to Unicode and will be "
+"ignored."
+msgstr "%d komut satırı değişkeni Unikoda çevrilemediğinden yok sayılacak."
+
+#: ../src/common/init.cpp:344
+msgid "Initialization failed in post init, aborting."
+msgstr "Hazırlığın ardından başlatılamadı, vazgeçiliyor."
+
+#: ../src/common/intl.cpp:378
+#, c-format
+msgid "Cannot set locale to language \"%s\"."
+msgstr "Yerel ayarlar \"%s\" diline çevrilemedi."
+
+#: ../src/common/log.cpp:232
+msgid "Error: "
+msgstr "Hata: "
+
+#: ../src/common/log.cpp:236
+msgid "Warning: "
+msgstr "Uyarı: "
+
+#: ../src/common/log.cpp:284
+msgid "The previous message repeated once."
+msgstr "Önceki ileti bir kez yinelendi."
+
+#: ../src/common/log.cpp:291
+#, c-format
+msgid "The previous message repeated %u time."
+msgid_plural "The previous message repeated %u times."
+msgstr[0] "Önceki ileti %u kez yinelendi."
+msgstr[1] "Önceki ileti %u kez yinelendi."
+
+#: ../src/common/log.cpp:319
+#, c-format
+msgid "Last repeated message (\"%s\", %u time) wasn't output"
+msgid_plural "Last repeated message (\"%s\", %u times) wasn't output"
+msgstr[0] "Son yinelenen ileti (\"%s\", %u kez) çıkış değildi"
+msgstr[1] "Son yinelenen ileti (\"%s\", %u kez) çıkış değildi"
+
+#: ../src/common/log.cpp:435
+#, c-format
+msgid " (error %ld: %s)"
+msgstr " (hata %ld: %s)"
+
+#: ../src/common/lzmastream.cpp:121
+msgid "Failed to allocate memory for LZMA decompression."
+msgstr "LZMA ayıklaması için bellek ayrılamadı."
+
+#: ../src/common/lzmastream.cpp:125
+#, c-format
+msgid "Failed to initialize LZMA decompression: unexpected error %u."
+msgstr "LZMA ayıklaması başlatılamadı: Beklenmeyen hata %u."
+
+#: ../src/common/lzmastream.cpp:179
+msgid "input is not in XZ format"
+msgstr "giriş XZ biçiminde değil"
+
+#: ../src/common/lzmastream.cpp:183
+msgid "input compressed using unknown XZ option"
+msgstr "giriş bilinmeyen bir XZ seçeneği kullanılarak sıkıştırılmış"
+
+#: ../src/common/lzmastream.cpp:188
+msgid "input is corrupted"
+msgstr "giriş bozulmuş"
+
+#: ../src/common/lzmastream.cpp:192
+msgid "unknown decompression error"
+msgstr "bilinmeyen ayıklama sorunu"
+
+#: ../src/common/lzmastream.cpp:196
+#, c-format
+msgid "LZMA decompression error: %s"
+msgstr "LZMA ayıklama sorunu: %s"
+
+#: ../src/common/lzmastream.cpp:231
+msgid "Failed to allocate memory for LZMA compression."
+msgstr "LZMA sıkıştırması için bellek ayrılamadı."
+
+#: ../src/common/lzmastream.cpp:235
+#, c-format
+msgid "Failed to initialize LZMA compression: unexpected error %u."
+msgstr "LZMA sıkıştırması başlatılamadı: Beklenmeyen hata %u."
+
+#: ../src/common/lzmastream.cpp:267 ../src/common/lzmastream.cpp:342
+#: ../src/html/chm.cpp:336
+msgid "out of memory"
+msgstr "bellek yetersiz"
+
+#: ../src/common/lzmastream.cpp:276 ../src/common/lzmastream.cpp:346
+msgid "unknown compression error"
+msgstr "bilinmeyen sıkıştırma sorunu"
+
+#: ../src/common/lzmastream.cpp:280
+#, c-format
+msgid "LZMA compression error: %s"
+msgstr "LZMA sıkıştırma sorunu: %s"
+
+#: ../src/common/lzmastream.cpp:350
+#, c-format
+msgid "LZMA compression error when flushing output: %s"
+msgstr "Çıktı temizlenirken LZMA sıkıştırma sorunu: %s"
+
+#: ../src/common/mimecmn.cpp:167
+#, c-format
+msgid "Unmatched '{' in an entry for mime type %s."
+msgstr "%s MIME türü kaydına uymayan '{'."
+
+#: ../src/common/module.cpp:76
+#, c-format
+msgid "Circular dependency involving module \"%s\" detected."
+msgstr "\"%s\" modülü ile döngüsel bağlılık algılandı."
+
+#: ../src/common/module.cpp:128
+#, c-format
+msgid "Dependency \"%s\" of module \"%s\" doesn't exist."
+msgstr "\"%s\" bağlılığı \"%s\" modülü için bulunamadı."
+
+#: ../src/common/module.cpp:137
+#, c-format
+msgid "Module \"%s\" initialization failed"
+msgstr "\"%s\" modülü başlatılamadı"
+
+#: ../src/common/msgout.cpp:96
+msgid "Message"
+msgstr "İleti"
+
+#: ../src/common/paper.cpp:70
+msgid "Letter, 8 1/2 x 11 in"
+msgstr "Letter, 8 1/2 x 11 inç"
+
+#: ../src/common/paper.cpp:71
+msgid "Legal, 8 1/2 x 14 in"
+msgstr "Legal, 8 1/2 x 14 inç"
+
+#: ../src/common/paper.cpp:72
+msgid "A4 sheet, 210 x 297 mm"
+msgstr "A4 sayfa, 210 x 297 mm"
+
+#: ../src/common/paper.cpp:73
+msgid "C sheet, 17 x 22 in"
+msgstr "C sayfa, 17 x 22 inç"
+
+#: ../src/common/paper.cpp:74
+msgid "D sheet, 22 x 34 in"
+msgstr "D sayfa, 22 x 34 inç"
+
+#: ../src/common/paper.cpp:75
+msgid "E sheet, 34 x 44 in"
+msgstr "E sayfa, 34 x 44 inç"
+
+#: ../src/common/paper.cpp:76
+msgid "Letter Small, 8 1/2 x 11 in"
+msgstr "Letter Küçük, 8 1/2 x 11 inç"
+
+#: ../src/common/paper.cpp:77
+msgid "Tabloid, 11 x 17 in"
+msgstr "Tabloid, 11 x 17 inç"
+
+#: ../src/common/paper.cpp:78
+msgid "Ledger, 17 x 11 in"
+msgstr "Ledger, 17 x 11 inç"
+
+#: ../src/common/paper.cpp:79
+msgid "Statement, 5 1/2 x 8 1/2 in"
+msgstr "Statement, 5 1/2 x 8 1/2 inç"
+
+#: ../src/common/paper.cpp:80
+msgid "Executive, 7 1/4 x 10 1/2 in"
+msgstr "Executive, 7 1/4 x 10 1/2 inç"
+
+#: ../src/common/paper.cpp:81
+msgid "A3 sheet, 297 x 420 mm"
+msgstr "A3 sayfa, 297 x 420 mm"
+
+#: ../src/common/paper.cpp:82
+msgid "A4 small sheet, 210 x 297 mm"
+msgstr "A4 küçük sayfa, 210 x 297 mm"
+
+#: ../src/common/paper.cpp:83
+msgid "A5 sheet, 148 x 210 mm"
+msgstr "A5 sayfa, 148 x 210 mm"
+
+#: ../src/common/paper.cpp:84
+msgid "B4 sheet, 250 x 354 mm"
+msgstr "B4 sayfa, 250 x 354 mm"
+
+#: ../src/common/paper.cpp:85
+msgid "B5 sheet, 182 x 257 millimeter"
+msgstr "B5 sayfa, 182 x 257 mm"
+
+#: ../src/common/paper.cpp:86
+msgid "Folio, 8 1/2 x 13 in"
+msgstr "Kitap yaprağı, 8 1/2 x 13 inç"
+
+#: ../src/common/paper.cpp:87
+msgid "Quarto, 215 x 275 mm"
+msgstr "Quarto, 215 x 275 mm"
+
+#: ../src/common/paper.cpp:88
+msgid "10 x 14 in"
+msgstr "10 x 14 inç"
+
+#: ../src/common/paper.cpp:89
+msgid "11 x 17 in"
+msgstr "11 x 17 inç"
+
+#: ../src/common/paper.cpp:90
+msgid "Note, 8 1/2 x 11 in"
+msgstr "Not, 8 1/2 x 11 inç"
+
+#: ../src/common/paper.cpp:91
+msgid "#9 Envelope, 3 7/8 x 8 7/8 in"
+msgstr "#9 Zarf, 3 7/8 x 8 7/8 inç"
+
+#: ../src/common/paper.cpp:92
+msgid "#10 Envelope, 4 1/8 x 9 1/2 in"
+msgstr "#10 Zarf, 4 1/8 x 9 1/2 inç"
+
+#: ../src/common/paper.cpp:93
+msgid "#11 Envelope, 4 1/2 x 10 3/8 in"
+msgstr "#11 Zarf, 4 1/2 x 10 3/8 inç"
+
+#: ../src/common/paper.cpp:94
+msgid "#12 Envelope, 4 3/4 x 11 in"
+msgstr "#12 Zarf, 4 3/4 x 11 inç"
+
+#: ../src/common/paper.cpp:95
+msgid "#14 Envelope, 5 x 11 1/2 in"
+msgstr "#14 Zarf, 5 x 11 1/2 inç"
+
+#: ../src/common/paper.cpp:96
+msgid "DL Envelope, 110 x 220 mm"
+msgstr "DL Zarf, 110 x 220 mm"
+
+#: ../src/common/paper.cpp:97
+msgid "C5 Envelope, 162 x 229 mm"
+msgstr "C5 Zarf, 162 x 229 mm"
+
+#: ../src/common/paper.cpp:98
+msgid "C3 Envelope, 324 x 458 mm"
+msgstr "C3 Zarf, 324 x 458 mm"
+
+#: ../src/common/paper.cpp:99
+msgid "C4 Envelope, 229 x 324 mm"
+msgstr "C4 Zarf, 229 x 324 mm"
+
+#: ../src/common/paper.cpp:100
+msgid "C6 Envelope, 114 x 162 mm"
+msgstr "C6 Zarf, 114 x 162 mm"
+
+#: ../src/common/paper.cpp:101
+msgid "C65 Envelope, 114 x 229 mm"
+msgstr "C65 Zarf, 114 x 229 mm"
+
+#: ../src/common/paper.cpp:102
+msgid "B4 Envelope, 250 x 353 mm"
+msgstr "B4 Zarf, 250 x 353 mm"
+
+#: ../src/common/paper.cpp:103
+msgid "B5 Envelope, 176 x 250 mm"
+msgstr "B5 Zarf, 176 x 250 mm"
+
+#: ../src/common/paper.cpp:104
+msgid "B6 Envelope, 176 x 125 mm"
+msgstr "B6 Zarf, 176 x 125 mm"
+
+#: ../src/common/paper.cpp:105
+msgid "Italy Envelope, 110 x 230 mm"
+msgstr "İtalyan Zarf, 110 x 230 mm"
+
+#: ../src/common/paper.cpp:106
+msgid "Monarch Envelope, 3 7/8 x 7 1/2 in"
+msgstr "Monarşi Zarf, 3 7/8 x 7 1/2 inç"
+
+#: ../src/common/paper.cpp:107
+msgid "6 3/4 Envelope, 3 5/8 x 6 1/2 in"
+msgstr "6 3/4 Zarf, 3 5/8 x 6 1/2 inç"
+
+#: ../src/common/paper.cpp:108
+msgid "US Std Fanfold, 14 7/8 x 11 in"
+msgstr "US Std Fanfold, 14 7/8 x 11 inç"
+
+#: ../src/common/paper.cpp:109
+msgid "German Std Fanfold, 8 1/2 x 12 in"
+msgstr "Alman Standart Fanfold, 8 1/2 x 12 inç"
+
+#: ../src/common/paper.cpp:110
+msgid "German Legal Fanfold, 8 1/2 x 13 in"
+msgstr "Alman Legal Fanfold, 8 1/2 x 13 inç"
+
+#: ../src/common/paper.cpp:112
+msgid "B4 (ISO) 250 x 353 mm"
+msgstr "B4 (ISO) 250 x 353 mm"
+
+#: ../src/common/paper.cpp:113
+msgid "Japanese Postcard 100 x 148 mm"
+msgstr "Japon Postakartı 100 x 148 mm"
+
+#: ../src/common/paper.cpp:114
+msgid "9 x 11 in"
+msgstr "9 x 11 inç"
+
+#: ../src/common/paper.cpp:115
+msgid "10 x 11 in"
+msgstr "10 x 11 inç"
+
+#: ../src/common/paper.cpp:116
+msgid "15 x 11 in"
+msgstr "15 x 11 inç"
+
+#: ../src/common/paper.cpp:117
+msgid "Envelope Invite 220 x 220 mm"
+msgstr "Davetiye Zarfı 220 x 220 mm"
+
+#: ../src/common/paper.cpp:118
+msgid "Letter Extra 9 1/2 x 12 in"
+msgstr "Letter Ek 9 1/2 x 12 inç"
+
+#: ../src/common/paper.cpp:119
+msgid "Legal Extra 9 1/2 x 15 in"
+msgstr "Legal Ek 9 1/2 x 15 inç"
+
+#: ../src/common/paper.cpp:120
+msgid "Tabloid Extra 11.69 x 18 in"
+msgstr "Tabloid Ek 11.69 x 18 inç"
+
+#: ../src/common/paper.cpp:121
+msgid "A4 Extra 9.27 x 12.69 in"
+msgstr "A4 Ekstra 9.27 x 12.69 inç"
+
+#: ../src/common/paper.cpp:122
+msgid "Letter Transverse 8 1/2 x 11 in"
+msgstr "Letter Enine 8 1/2 x 11 inç"
+
+#: ../src/common/paper.cpp:123
+msgid "A4 Transverse 210 x 297 mm"
+msgstr "A4 Enine 210 x 297 mm"
+
+#: ../src/common/paper.cpp:124
+msgid "Letter Extra Transverse 9.275 x 12 in"
+msgstr "Letter Ek Enine 9.275 x 12 inç"
+
+#: ../src/common/paper.cpp:125
+msgid "SuperA/SuperA/A4 227 x 356 mm"
+msgstr "SuperA/SuperA/A4 227 x 356 mm"
+
+#: ../src/common/paper.cpp:126
+msgid "SuperB/SuperB/A3 305 x 487 mm"
+msgstr "SuperB/SuperB/A3 305 x 487 mm"
+
+#: ../src/common/paper.cpp:127
+msgid "Letter Plus 8 1/2 x 12.69 in"
+msgstr "Letter Artı 8 1/2 x 12.69 inç"
+
+#: ../src/common/paper.cpp:128
+msgid "A4 Plus 210 x 330 mm"
+msgstr "A4 Artı 210 x 330 mm"
+
+#: ../src/common/paper.cpp:129
+msgid "A5 Transverse 148 x 210 mm"
+msgstr "A5 Enine 148 x 210 mm"
+
+#: ../src/common/paper.cpp:130
+msgid "B5 (JIS) Transverse 182 x 257 mm"
+msgstr "B5 (JIS) Enine 182 x 257 mm"
+
+#: ../src/common/paper.cpp:131
+msgid "A3 Extra 322 x 445 mm"
+msgstr "A3 Ekstra 322 x 445 mm"
+
+#: ../src/common/paper.cpp:132
+msgid "A5 Extra 174 x 235 mm"
+msgstr "A5 Ekstra 174 x 235 mm"
+
+#: ../src/common/paper.cpp:133
+msgid "B5 (ISO) Extra 201 x 276 mm"
+msgstr "B5 (ISO) Ekstra 201 x 276 mm"
+
+#: ../src/common/paper.cpp:134
+msgid "A2 420 x 594 mm"
+msgstr "A2 420 x 594 mm"
+
+#: ../src/common/paper.cpp:135
+msgid "A3 Transverse 297 x 420 mm"
+msgstr "A3 Enine 297 x 420 mm"
+
+#: ../src/common/paper.cpp:136
+msgid "A3 Extra Transverse 322 x 445 mm"
+msgstr "A3 Ekstra Enine 322 x 445 mm"
+
+#: ../src/common/paper.cpp:138
+msgid "Japanese Double Postcard 200 x 148 mm"
+msgstr "Japon Çift Posta Kartı 200 x 148 mm"
+
+#: ../src/common/paper.cpp:139
+msgid "A6 105 x 148 mm"
+msgstr "A6 105 x 148 mm"
+
+#: ../src/common/paper.cpp:140
+msgid "Japanese Envelope Kaku #2"
+msgstr "Japon Zarf Kaku #2"
+
+#: ../src/common/paper.cpp:141
+msgid "Japanese Envelope Kaku #3"
+msgstr "Japon Zarf Kaku #3"
+
+#: ../src/common/paper.cpp:142
+msgid "Japanese Envelope Chou #3"
+msgstr "Japon Zarf Chou #3"
+
+#: ../src/common/paper.cpp:143
+msgid "Japanese Envelope Chou #4"
+msgstr "Japon Zarf Chou #4"
+
+#: ../src/common/paper.cpp:144
+msgid "Letter Rotated 11 x 8 1/2 in"
+msgstr "Letter Çevrilmiş 11 x 8 1/2 inç"
+
+#: ../src/common/paper.cpp:145
+msgid "A3 Rotated 420 x 297 mm"
+msgstr "A3 Çevrilmiş 420 x 297 mm"
+
+#: ../src/common/paper.cpp:146
+msgid "A4 Rotated 297 x 210 mm"
+msgstr "A4 Çevrilmiş 297 x 210 mm"
+
+#: ../src/common/paper.cpp:147
+msgid "A5 Rotated 210 x 148 mm"
+msgstr "A5 Çevrilmiş 210 x 148 mm"
+
+#: ../src/common/paper.cpp:148
+msgid "B4 (JIS) Rotated 364 x 257 mm"
+msgstr "B4 (JIS) Çevrilmiş 364 x 257 mm"
+
+#: ../src/common/paper.cpp:149
+msgid "B5 (JIS) Rotated 257 x 182 mm"
+msgstr "B5 (JIS) Çevrilmiş 257 x 182 mm"
+
+#: ../src/common/paper.cpp:150
+msgid "Japanese Postcard Rotated 148 x 100 mm"
+msgstr "Japon Posta Kartı Çevrilmiş 148 x 100 mm"
+
+#: ../src/common/paper.cpp:151
+msgid "Double Japanese Postcard Rotated 148 x 200 mm"
+msgstr "Japon Çift Posta Kartı Çevrilmiş 148 x 200 mm"
+
+#: ../src/common/paper.cpp:152
+msgid "A6 Rotated 148 x 105 mm"
+msgstr "A6 Çevrilmiş 148 x 105 mm"
+
+#: ../src/common/paper.cpp:153
+msgid "Japanese Envelope Kaku #2 Rotated"
+msgstr "Japon Zarf Kaku #2 Çevrilmiş"
+
+#: ../src/common/paper.cpp:154
+msgid "Japanese Envelope Kaku #3 Rotated"
+msgstr "Japon Zarf Kaku #3 Çevrilmiş"
+
+#: ../src/common/paper.cpp:155
+msgid "Japanese Envelope Chou #3 Rotated"
+msgstr "Japon Zarf Chou #3 Çevrilmiş"
+
+#: ../src/common/paper.cpp:156
+msgid "Japanese Envelope Chou #4 Rotated"
+msgstr "Japon Zarf Chou #4 Çevrilmiş"
+
+#: ../src/common/paper.cpp:157
+msgid "B6 (JIS) 128 x 182 mm"
+msgstr "B6 (JIS) 128 x 182 mm"
+
+#: ../src/common/paper.cpp:158
+msgid "B6 (JIS) Rotated 182 x 128 mm"
+msgstr "B6 (JIS) Çevrilmiş 182 x 128 mm"
+
+#: ../src/common/paper.cpp:159
+msgid "12 x 11 in"
+msgstr "12 x 11 inç"
+
+#: ../src/common/paper.cpp:160
+msgid "Japanese Envelope You #4"
+msgstr "Japon Zarf You #4"
+
+#: ../src/common/paper.cpp:161
+msgid "Japanese Envelope You #4 Rotated"
+msgstr "Japon Zarf You #4 Çevrilmiş"
+
+#: ../src/common/paper.cpp:162
+msgid "PRC 16K 146 x 215 mm"
+msgstr "PRC 16K 146 x 215 mm"
+
+#: ../src/common/paper.cpp:163
+msgid "PRC 32K 97 x 151 mm"
+msgstr "PRC 32K 97 x 151 mm"
+
+#: ../src/common/paper.cpp:164
+msgid "PRC 32K(Big) 97 x 151 mm"
+msgstr "PRC 32K(Büyük) 97 x 151 mm"
+
+#: ../src/common/paper.cpp:165
+msgid "PRC Envelope #1 102 x 165 mm"
+msgstr "PRC Zarf #1 102 x 165 mm"
+
+#: ../src/common/paper.cpp:166
+msgid "PRC Envelope #2 102 x 176 mm"
+msgstr "PRC Zarf #2 102 x 176 mm"
+
+#: ../src/common/paper.cpp:167
+msgid "PRC Envelope #3 125 x 176 mm"
+msgstr "PRC Zarf #3 125 x 176 mm"
+
+#: ../src/common/paper.cpp:168
+msgid "PRC Envelope #4 110 x 208 mm"
+msgstr "PRC Zarf #4 110 x 208 mm"
+
+#: ../src/common/paper.cpp:169
+msgid "PRC Envelope #5 110 x 220 mm"
+msgstr "PRC Zarf #5 110 x 220 mm"
+
+#: ../src/common/paper.cpp:170
+msgid "PRC Envelope #6 120 x 230 mm"
+msgstr "PRC Zarf #6 120 x 230 mm"
+
+#: ../src/common/paper.cpp:171
+msgid "PRC Envelope #7 160 x 230 mm"
+msgstr "PRC Zarf #7 160 x 230 mm"
+
+#: ../src/common/paper.cpp:172
+msgid "PRC Envelope #8 120 x 309 mm"
+msgstr "PRC Zarf #8 120 x 309 mm"
+
+#: ../src/common/paper.cpp:173
+msgid "PRC Envelope #9 229 x 324 mm"
+msgstr "PRC Zarf #9 229 x 324 mm"
+
+#: ../src/common/paper.cpp:174
+msgid "PRC Envelope #10 324 x 458 mm"
+msgstr "PRC Zarf #10 324 x 458 mm"
+
+#: ../src/common/paper.cpp:175
+msgid "PRC 16K Rotated"
+msgstr "PRC 16K Çevrilmiş"
+
+#: ../src/common/paper.cpp:176
+msgid "PRC 32K Rotated"
+msgstr "PRC 32K Çevrilmiş"
+
+#: ../src/common/paper.cpp:177
+msgid "PRC 32K(Big) Rotated"
+msgstr "PRC 32K(Büyük) Çevrilmiş"
+
+#: ../src/common/paper.cpp:178
+msgid "PRC Envelope #1 Rotated 165 x 102 mm"
+msgstr "PRC Zarf #1 Çevrilmiş 165 x 102 mm"
+
+#: ../src/common/paper.cpp:179
+msgid "PRC Envelope #2 Rotated 176 x 102 mm"
+msgstr "PRC Zarf #2 Çevrilmiş 176 x 102 mm"
+
+#: ../src/common/paper.cpp:180
+msgid "PRC Envelope #3 Rotated 176 x 125 mm"
+msgstr "PRC Zarf #3 Çevrilmiş 176 x 125 mm"
+
+#: ../src/common/paper.cpp:181
+msgid "PRC Envelope #4 Rotated 208 x 110 mm"
+msgstr "PRC Zarf #4 Çevrilmiş 208 x 110 mm"
+
+#: ../src/common/paper.cpp:182
+msgid "PRC Envelope #5 Rotated 220 x 110 mm"
+msgstr "PRC Zarf #5 Çevrilmiş 220 x 110 mm"
+
+#: ../src/common/paper.cpp:183
+msgid "PRC Envelope #6 Rotated 230 x 120 mm"
+msgstr "PRC Zarf #6 Çevrilmiş 230 x 120 mm"
+
+#: ../src/common/paper.cpp:184
+msgid "PRC Envelope #7 Rotated 230 x 160 mm"
+msgstr "PRC Zarf #7 Çevrilmiş 230 x 160 mm"
+
+#: ../src/common/paper.cpp:185
+msgid "PRC Envelope #8 Rotated 309 x 120 mm"
+msgstr "PRC Zarf #8 Çevrilmiş 309 x 120 mm"
+
+#: ../src/common/paper.cpp:186
+msgid "PRC Envelope #9 Rotated 324 x 229 mm"
+msgstr "PRC Zarf #9 Çevrilmiş 324 x 229 mm"
+
+#: ../src/common/paper.cpp:187
+msgid "PRC Envelope #10 Rotated 458 x 324 mm"
+msgstr "PRC Zarf #10 Çevrilmiş 458 x 324 mm"
+
+#: ../src/common/paper.cpp:192
+msgid "A0 sheet, 841 x 1189 mm"
+msgstr "A0 sayfa, 841 x 1189 mm"
+
+#: ../src/common/paper.cpp:193
+msgid "A1 sheet, 594 x 841 mm"
+msgstr "A1 sayfa, 594 x 841 mm"
+
+#: ../src/common/preferencescmn.cpp:37
+msgid "General"
+msgstr "Genel"
+
+#: ../src/common/preferencescmn.cpp:40
+msgid "Advanced"
+msgstr "Gelişmiş"
+
+#: ../src/common/prntbase.cpp:245
+msgid "Generic PostScript"
+msgstr "Genel PostScript"
+
+#: ../src/common/prntbase.cpp:259
+msgid "Ready"
+msgstr "Hazır"
+
+#: ../src/common/prntbase.cpp:331
+msgid "Printing Error"
+msgstr "Yazdırma hatası"
+
+#: ../src/common/prntbase.cpp:413 ../src/common/prntbase.cpp:1597
+#: ../src/generic/prntdlgg.cpp:135 ../src/generic/prntdlgg.cpp:149
+#: ../src/gtk/print.cpp:628 ../src/gtk/print.cpp:646
+msgid "Print"
+msgstr "Yazdır"
+
+#: ../src/common/prntbase.cpp:471 ../src/generic/prntdlgg.cpp:809
+msgid "Page setup"
+msgstr "Sayfa düzeni"
+
+#: ../src/common/prntbase.cpp:525
+msgid "Please wait while printing..."
+msgstr "Lütfen yazdırılırken bekleyin..."
+
+#: ../src/common/prntbase.cpp:529
+msgid "Document:"
+msgstr "Belge:"
+
+#: ../src/common/prntbase.cpp:532
+msgid "Progress:"
+msgstr "İşlem:"
+
+#: ../src/common/prntbase.cpp:533
+msgid "Preparing"
+msgstr "Hazırlanıyor"
+
+#: ../src/common/prntbase.cpp:552
+#, c-format
+msgid "Printing page %d"
+msgstr "%d. sayfa yazdırılıyor"
+
+#: ../src/common/prntbase.cpp:557
+#, c-format
+msgid "Printing page %d of %d"
+msgstr "Yazdırılan sayfa %d / %d"
+
+#: ../src/common/prntbase.cpp:560
+#, c-format
+msgid " (copy %d of %d)"
+msgstr " (kopya %d / %d)"
+
+#: ../src/common/prntbase.cpp:1604
+msgid "First page"
+msgstr "İlk sayfa"
+
+#: ../src/common/prntbase.cpp:1609 ../src/html/helpwnd.cpp:659
+msgid "Previous page"
+msgstr "Önceki sayfa"
+
+#: ../src/common/prntbase.cpp:1623 ../src/html/helpwnd.cpp:660
+msgid "Next page"
+msgstr "Sonraki sayfa"
+
+#: ../src/common/prntbase.cpp:1628
+msgid "Last page"
+msgstr "Son sayfa"
+
+#: ../src/common/prntbase.cpp:1636 ../src/common/stockitem.cpp:215
+msgid "Zoom Out"
+msgstr "Uzaklaştır"
+
+#: ../src/common/prntbase.cpp:1650 ../src/common/stockitem.cpp:214
+msgid "Zoom In"
+msgstr "Yakınlaştır"
+
+#: ../src/common/prntbase.cpp:1656 ../src/common/stockitem.cpp:153
+#: ../src/generic/logg.cpp:553 ../src/univ/themes/win32.cpp:3752
+msgid "&Close"
+msgstr "&Kapat"
+
+#: ../src/common/prntbase.cpp:2085
+msgid "Could not start document preview."
+msgstr "Belge önizlemesi başlatılamadı."
+
+#: ../src/common/prntbase.cpp:2085 ../src/common/prntbase.cpp:2129
+#: ../src/common/prntbase.cpp:2137
+msgid "Print Preview Failure"
+msgstr "Yazdırma önizleme hatası"
+
+#: ../src/common/prntbase.cpp:2129 ../src/common/prntbase.cpp:2137
+msgid "Sorry, not enough memory to create a preview."
+msgstr "Ne yazık ki önizlemeyi oluşturmak için yeterli bellek yok."
+
+#: ../src/common/prntbase.cpp:2144
+#, c-format
+msgid "Page %d of %d"
+msgstr "Sayfa %d / %d"
+
+#: ../src/common/prntbase.cpp:2146
+#, c-format
+msgid "Page %d"
+msgstr "%d. sayfa"
+
+#: ../src/common/regex.cpp:382 ../src/html/chm.cpp:348
+msgid "unknown error"
+msgstr "bilinmeyen sorun"
+
+#: ../src/common/regex.cpp:995
+#, c-format
+msgid "Invalid regular expression '%s': %s"
+msgstr "Kurallı ifade geçersiz '%s': %s"
+
+#: ../src/common/regex.cpp:1059
+#, c-format
+msgid "Failed to find match for regular expression: %s"
+msgstr "Kurallı ifadeye uygun veri bulunamadı: %s"
+
+#: ../src/common/rendcmn.cpp:188
+#, c-format
+msgid "Renderer \"%s\" has incompatible version %d.%d and couldn't be loaded."
+msgstr "\"%s\" görüntüleyicisinin %d.%d sürümü uyumsuz olduğundan yüklenemedi."
+
+#: ../src/common/secretstore.cpp:162
+msgid "Not available for this platform"
+msgstr "Bu platform için kullanılamaz"
+
+#: ../src/common/secretstore.cpp:183
+#, c-format
+msgid "Saving password for \"%s\" failed: %s."
+msgstr "\"%s\" parolası kaydedilirken sorun çıktı: %s."
+
+#: ../src/common/secretstore.cpp:205
+#, c-format
+msgid "Reading password for \"%s\" failed: %s."
+msgstr "\"%s\" için parola okunurken sorun çıktı: %s."
+
+#: ../src/common/secretstore.cpp:228
+#, c-format
+msgid "Deleting password for \"%s\" failed: %s."
+msgstr "\"%s\" parolası silinemedi: %s."
+
+#: ../src/common/selectdispatcher.cpp:254
+msgid "Failed to monitor I/O channels"
+msgstr "Giriş/çıkış kanalları izlenemedi"
+
+#: ../src/common/sizer.cpp:3054 ../src/common/stockitem.cpp:195
+msgid "Save"
+msgstr "Kaydet"
+
+#: ../src/common/sizer.cpp:3056
+msgid "Don't Save"
+msgstr "Kaydedilmesin"
+
+#: ../src/common/socket.cpp:870
+msgid "Cannot initialize sockets"
+msgstr "Soketler başlatılamadı"
+
+#: ../src/common/stockitem.cpp:127
+msgctxt "standard Windows menu"
+msgid "&Help"
+msgstr "&Yardım"
+
+#: ../src/common/stockitem.cpp:144
+msgid "&About"
+msgstr "H&akkında"
+
+#: ../src/common/stockitem.cpp:144
+msgid "About"
+msgstr "Hakkında"
+
+#: ../src/common/stockitem.cpp:145
+msgid "Add"
+msgstr "Ekle"
+
+#: ../src/common/stockitem.cpp:146
+msgid "&Apply"
+msgstr "Uygul&a"
+
+#: ../src/common/stockitem.cpp:146
+msgid "Apply"
+msgstr "Uygula"
+
+#: ../src/common/stockitem.cpp:147
+msgid "&Back"
+msgstr "&Geri"
+
+#: ../src/common/stockitem.cpp:147
+msgid "Back"
+msgstr "Geri"
+
+#: ../src/common/stockitem.cpp:148
+msgid "&Bold"
+msgstr "&Kalın"
+
+#: ../src/common/stockitem.cpp:148 ../src/generic/fontdlgg.cpp:326
+#: ../src/richtext/richtextfontpage.cpp:354
+msgid "Bold"
+msgstr "Kalın"
+
+#: ../src/common/stockitem.cpp:149
+msgid "&Bottom"
+msgstr "Al&t"
+
+#: ../src/common/stockitem.cpp:149 ../src/richtext/richtextsizepage.cpp:287
+msgid "Bottom"
+msgstr "Alt"
+
+#: ../src/common/stockitem.cpp:150 ../src/generic/fontdlgg.cpp:462
+#: ../src/generic/fontdlgg.cpp:481 ../src/generic/wizard.cpp:415
+msgid "&Cancel"
+msgstr "İ&ptal"
+
+#: ../src/common/stockitem.cpp:151
+msgid "&CD-ROM"
+msgstr "&CD-Rom"
+
+#: ../src/common/stockitem.cpp:151
+msgid "CD-ROM"
+msgstr "CD-Rom"
+
+#: ../src/common/stockitem.cpp:152
+msgid "&Clear"
+msgstr "T&emizle"
+
+#: ../src/common/stockitem.cpp:152
+msgid "Clear"
+msgstr "Temizle"
+
+#: ../src/common/stockitem.cpp:153 ../src/generic/dbgrptg.cpp:93
+#: ../src/generic/progdlgg.cpp:778 ../src/html/helpdlg.cpp:86
+#: ../src/msw/progdlg.cpp:209 ../src/msw/progdlg.cpp:890
+#: ../src/richtext/richtextstyledlg.cpp:272
+#: ../src/richtext/richtextsymboldlg.cpp:448
+msgid "Close"
+msgstr "Kapat"
+
+#: ../src/common/stockitem.cpp:154
+msgid "&Convert"
+msgstr "&Dönüştür"
+
+#: ../src/common/stockitem.cpp:154
+msgid "Convert"
+msgstr "Dönüştür"
+
+#: ../src/common/stockitem.cpp:155 ../src/msw/textctrl.cpp:2884
+#: ../src/osx/textctrl_osx.cpp:653 ../src/richtext/richtextctrl.cpp:331
+msgid "&Copy"
+msgstr "K&opyala"
+
+#: ../src/common/stockitem.cpp:155 ../src/stc/stc_i18n.cpp:18
+msgid "Copy"
+msgstr "Kopyala"
+
+#: ../src/common/stockitem.cpp:156 ../src/msw/textctrl.cpp:2883
+#: ../src/osx/textctrl_osx.cpp:652 ../src/richtext/richtextctrl.cpp:330
+msgid "Cu&t"
+msgstr "&Kes"
+
+#: ../src/common/stockitem.cpp:156 ../src/stc/stc_i18n.cpp:17
+msgid "Cut"
+msgstr "Kes"
+
+#: ../src/common/stockitem.cpp:157 ../src/msw/textctrl.cpp:2886
+#: ../src/osx/textctrl_osx.cpp:655 ../src/richtext/richtextctrl.cpp:333
+#: ../src/richtext/richtexttabspage.cpp:137
+msgid "&Delete"
+msgstr "&Sil"
+
+#: ../src/common/stockitem.cpp:157 ../src/richtext/richtextbuffer.cpp:8266
+#: ../src/stc/stc_i18n.cpp:20
+msgid "Delete"
+msgstr "Delete"
+
+#: ../src/common/stockitem.cpp:158
+msgid "&Down"
+msgstr "&Aşağı"
+
+#: ../src/common/stockitem.cpp:158 ../src/generic/fdrepdlg.cpp:148
+msgid "Down"
+msgstr "Aşağı"
+
+#: ../src/common/stockitem.cpp:159
+msgid "&Edit"
+msgstr "Dü&zenle"
+
+#: ../src/common/stockitem.cpp:159
+msgid "Edit"
+msgstr "Düzenle"
+
+#: ../src/common/stockitem.cpp:160
+msgid "&Execute"
+msgstr "&Yürüt"
+
+#: ../src/common/stockitem.cpp:160
+msgid "Execute"
+msgstr "Yürüt"
+
+#: ../src/common/stockitem.cpp:161
+msgid "&Quit"
+msgstr "Çı&kış"
+
+#: ../src/common/stockitem.cpp:161
+msgid "Quit"
+msgstr "Çıkış"
+
+#: ../src/common/stockitem.cpp:162
+msgid "&File"
+msgstr "&Dosya"
+
+#: ../src/common/stockitem.cpp:162
+msgid "File"
+msgstr "Dosya"
+
+#: ../src/common/stockitem.cpp:163
+msgid "&Find..."
+msgstr "&Bul..."
+
+#: ../src/common/stockitem.cpp:163
+msgid "Find..."
+msgstr "Ara..."
+
+#: ../src/common/stockitem.cpp:164
+msgid "&First"
+msgstr "İ&lk"
+
+#: ../src/common/stockitem.cpp:164
+msgid "First"
+msgstr "İlk"
+
+#: ../src/common/stockitem.cpp:165
+msgid "&Floppy"
+msgstr "&Esnek"
+
+#: ../src/common/stockitem.cpp:165
+msgid "Floppy"
+msgstr "Esnek"
+
+#: ../src/common/stockitem.cpp:166
+msgid "&Forward"
+msgstr "İ&let"
+
+#: ../src/common/stockitem.cpp:166
+msgid "Forward"
+msgstr "İlet"
+
+#: ../src/common/stockitem.cpp:167
+msgid "&Harddisk"
+msgstr "&Sabit disk"
+
+#: ../src/common/stockitem.cpp:167
+msgid "Harddisk"
+msgstr "Sabit disk"
+
+#: ../src/common/stockitem.cpp:168 ../src/generic/wizard.cpp:418
+#: ../src/osx/cocoa/menu.mm:225 ../src/richtext/richtextstyledlg.cpp:298
+#: ../src/richtext/richtextsymboldlg.cpp:451
+msgid "&Help"
+msgstr "&Yardım"
+
+#: ../src/common/stockitem.cpp:169
+msgid "&Home"
+msgstr "&Açılış"
+
+#: ../src/common/stockitem.cpp:169
+msgid "Home"
+msgstr "Açılış"
+
+#: ../src/common/stockitem.cpp:170
+msgid "Indent"
+msgstr "Girinti"
+
+#: ../src/common/stockitem.cpp:171
+msgid "&Index"
+msgstr "D&izin"
+
+#: ../src/common/stockitem.cpp:171 ../src/html/helpwnd.cpp:510
+msgid "Index"
+msgstr "Dizin"
+
+#: ../src/common/stockitem.cpp:172
+msgid "&Info"
+msgstr "&Bilgiler"
+
+#: ../src/common/stockitem.cpp:172
+msgid "Info"
+msgstr "Bilgiler"
+
+#: ../src/common/stockitem.cpp:173
+msgid "&Italic"
+msgstr "&İtalik"
+
+#: ../src/common/stockitem.cpp:173 ../src/generic/fontdlgg.cpp:322
+#: ../src/richtext/richtextfontpage.cpp:350
+msgid "Italic"
+msgstr "İtalik"
+
+#: ../src/common/stockitem.cpp:174
+msgid "&Jump to"
+msgstr "A&tla"
+
+#: ../src/common/stockitem.cpp:174
+msgid "Jump to"
+msgstr "Atla"
+
+#: ../src/common/stockitem.cpp:175
+msgid "Centered"
+msgstr "Ortalanmış"
+
+#: ../src/common/stockitem.cpp:176
+msgid "Justified"
+msgstr "Hizalanmış"
+
+#: ../src/common/stockitem.cpp:177
+msgid "Align Left"
+msgstr "Sola hizala"
+
+#: ../src/common/stockitem.cpp:178
+msgid "Align Right"
+msgstr "Sağa hizala"
+
+#: ../src/common/stockitem.cpp:179
+msgid "&Last"
+msgstr "&Son"
+
+#: ../src/common/stockitem.cpp:179
+msgid "Last"
+msgstr "Son"
+
+#: ../src/common/stockitem.cpp:180
+msgid "&Network"
+msgstr "&Ağ"
+
+#: ../src/common/stockitem.cpp:180
+msgid "Network"
+msgstr "Ağ"
+
+#: ../src/common/stockitem.cpp:181 ../src/richtext/richtexttabspage.cpp:131
+msgid "&New"
+msgstr "Ye&ni"
+
+#: ../src/common/stockitem.cpp:181
+msgid "New"
+msgstr "Yeni"
+
+#: ../src/common/stockitem.cpp:182 ../src/msw/msgdlg.cpp:417
+msgid "&No"
+msgstr "&Hayır"
+
+#: ../src/common/stockitem.cpp:183 ../src/generic/fontdlgg.cpp:467
+#: ../src/generic/fontdlgg.cpp:474
+msgid "&OK"
+msgstr "&Tamam"
+
+#: ../src/common/stockitem.cpp:184 ../src/generic/dbgrptg.cpp:341
+msgid "&Open..."
+msgstr "&Aç..."
+
+#: ../src/common/stockitem.cpp:184
+msgid "Open..."
+msgstr "Aç..."
+
+#: ../src/common/stockitem.cpp:185 ../src/msw/textctrl.cpp:2885
+#: ../src/osx/textctrl_osx.cpp:654 ../src/richtext/richtextctrl.cpp:332
+msgid "&Paste"
+msgstr "Ya&pıştır"
+
+#: ../src/common/stockitem.cpp:185 ../src/richtext/richtextctrl.cpp:3484
+#: ../src/stc/stc_i18n.cpp:19
+msgid "Paste"
+msgstr "Yapıştır"
+
+#: ../src/common/stockitem.cpp:186
+msgid "&Preferences"
+msgstr "&Ayarlar"
+
+#: ../src/common/stockitem.cpp:186 ../src/osx/cocoa/preferences.mm:304
+msgid "Preferences"
+msgstr "Ayarlar"
+
+#: ../src/common/stockitem.cpp:187
+msgid "Print previe&w..."
+msgstr "Yazdırma ö&nizleme..."
+
+#: ../src/common/stockitem.cpp:187
+msgid "Print preview..."
+msgstr "Yazdırma önizleme..."
+
+#: ../src/common/stockitem.cpp:188
+msgid "&Print..."
+msgstr "&Yazdır..."
+
+#: ../src/common/stockitem.cpp:188
+msgid "Print..."
+msgstr "Yazdır..."
+
+#: ../src/common/stockitem.cpp:189 ../src/richtext/richtextctrl.cpp:337
+#: ../src/richtext/richtextctrl.cpp:5479
+msgid "&Properties"
+msgstr "Ö&zellikler"
+
+#: ../src/common/stockitem.cpp:189
+msgid "Properties"
+msgstr "Özellikler"
+
+#: ../src/common/stockitem.cpp:190 ../src/stc/stc_i18n.cpp:16
+msgid "Redo"
+msgstr "Yinele"
+
+#: ../src/common/stockitem.cpp:191
+msgid "Refresh"
+msgstr "Yenile"
+
+#: ../src/common/stockitem.cpp:192
+msgid "Remove"
+msgstr "Sil"
+
+#: ../src/common/stockitem.cpp:193
+msgid "Rep&lace..."
+msgstr "&Değiştir..."
+
+#: ../src/common/stockitem.cpp:193
+msgid "Replace..."
+msgstr "Değiştir..."
+
+#: ../src/common/stockitem.cpp:194
+msgid "Revert to Saved"
+msgstr "Kaydedilmiş olana geri dön"
+
+#: ../src/common/stockitem.cpp:196 ../src/generic/logg.cpp:549
+msgid "Save &As..."
+msgstr "&Farklı kaydet..."
+
+#: ../src/common/stockitem.cpp:196
+msgid "Save As..."
+msgstr "Farklı kaydet..."
+
+#: ../src/common/stockitem.cpp:197 ../src/msw/textctrl.cpp:2888
+#: ../src/osx/textctrl_osx.cpp:657 ../src/richtext/richtextctrl.cpp:335
+msgid "Select &All"
+msgstr "&Tümünü seç"
+
+#: ../src/common/stockitem.cpp:197 ../src/stc/stc_i18n.cpp:21
+msgid "Select All"
+msgstr "Tümünü seç"
+
+#: ../src/common/stockitem.cpp:198
+msgid "&Color"
+msgstr "&Renk"
+
+#: ../src/common/stockitem.cpp:198
+msgid "Color"
+msgstr "Renk"
+
+#: ../src/common/stockitem.cpp:199
+msgid "&Font"
+msgstr "&Font"
+
+#: ../src/common/stockitem.cpp:199 ../src/richtext/richtextformatdlg.cpp:336
+msgid "Font"
+msgstr "Font"
+
+#: ../src/common/stockitem.cpp:200
+msgid "&Ascending"
+msgstr "&Artan"
+
+#: ../src/common/stockitem.cpp:200
+msgid "Ascending"
+msgstr "Artan"
+
+#: ../src/common/stockitem.cpp:201
+msgid "&Descending"
+msgstr "A&zalan"
+
+#: ../src/common/stockitem.cpp:201
+msgid "Descending"
+msgstr "Azalan"
+
+#: ../src/common/stockitem.cpp:202
+msgid "&Spell Check"
+msgstr "&Yazım denetimi"
+
+#: ../src/common/stockitem.cpp:202
+msgid "Spell Check"
+msgstr "Yazım denetimi"
+
+#: ../src/common/stockitem.cpp:203
+msgid "&Stop"
+msgstr "&Durdur"
+
+#: ../src/common/stockitem.cpp:203
+msgid "Stop"
+msgstr "Durdur"
+
+#: ../src/common/stockitem.cpp:204 ../src/richtext/richtextfontpage.cpp:274
+msgid "&Strikethrough"
+msgstr "Ü&stüçizili"
+
+#: ../src/common/stockitem.cpp:204
+msgid "Strikethrough"
+msgstr "Üstüçizili"
+
+#: ../src/common/stockitem.cpp:205
+msgid "&Top"
+msgstr "Üs&t"
+
+#: ../src/common/stockitem.cpp:205 ../src/richtext/richtextsizepage.cpp:285
+#: ../src/richtext/richtextsizepage.cpp:289
+msgid "Top"
+msgstr "Üst"
+
+#: ../src/common/stockitem.cpp:206
+msgid "Undelete"
+msgstr "Silmeyi geri al"
+
+#: ../src/common/stockitem.cpp:207 ../src/generic/fontdlgg.cpp:437
+msgid "&Underline"
+msgstr "&Altıçizili"
+
+#: ../src/common/stockitem.cpp:207
+msgid "Underline"
+msgstr "Altıçizili"
+
+#: ../src/common/stockitem.cpp:208 ../src/stc/stc_i18n.cpp:15
+msgid "Undo"
+msgstr "Geri al"
+
+#: ../src/common/stockitem.cpp:209
+msgid "&Unindent"
+msgstr "İçerleği &geri al"
+
+#: ../src/common/stockitem.cpp:209
+msgid "Unindent"
+msgstr "Girintiyi geri al"
+
+#: ../src/common/stockitem.cpp:210
+msgid "&Up"
+msgstr "Y&ukarı"
+
+#: ../src/common/stockitem.cpp:210 ../src/generic/fdrepdlg.cpp:148
+msgid "Up"
+msgstr "Yukarı"
+
+#: ../src/common/stockitem.cpp:211 ../src/msw/msgdlg.cpp:417
+msgid "&Yes"
+msgstr "&Evet"
+
+#: ../src/common/stockitem.cpp:212
+msgid "&Actual Size"
+msgstr "&Geçerli boyut"
+
+#: ../src/common/stockitem.cpp:212
+msgid "Actual Size"
+msgstr "Geçerli boyut"
+
+#: ../src/common/stockitem.cpp:213
+msgid "Zoom to &Fit"
+msgstr "&Sığdır"
+
+#: ../src/common/stockitem.cpp:213
+msgid "Zoom to Fit"
+msgstr "Sığdır"
+
+#: ../src/common/stockitem.cpp:214
+msgid "Zoom &In"
+msgstr "&Yakınlaştır"
+
+#: ../src/common/stockitem.cpp:215
+msgid "Zoom &Out"
+msgstr "&Uzaklaştır"
+
+#: ../src/common/stockitem.cpp:262
+msgid "Show about dialog"
+msgstr "Hakkında penceresini görüntüle"
+
+#: ../src/common/stockitem.cpp:263
+msgid "Copy selection"
+msgstr "Seçimi kopyala"
+
+#: ../src/common/stockitem.cpp:264
+msgid "Cut selection"
+msgstr "Seçimi kes"
+
+#: ../src/common/stockitem.cpp:265
+msgid "Delete selection"
+msgstr "Seçimi sil"
+
+#: ../src/common/stockitem.cpp:266
+msgid "Find in document"
+msgstr "Belgede ara"
+
+#: ../src/common/stockitem.cpp:267
+msgid "Find and replace in document"
+msgstr "Belgede ara ve değiştir"
+
+#: ../src/common/stockitem.cpp:268
+msgid "Paste selection"
+msgstr "Seçimi yapıştır"
+
+#: ../src/common/stockitem.cpp:269
+msgid "Quit this program"
+msgstr "Bu programdan çık"
+
+#: ../src/common/stockitem.cpp:270
+msgid "Redo last action"
+msgstr "Son işlemi yinele"
+
+#: ../src/common/stockitem.cpp:271
+msgid "Undo last action"
+msgstr "Son işlemi geri al"
+
+#: ../src/common/stockitem.cpp:272
+msgid "Create new document"
+msgstr "Yeni belge oluştur"
+
+#: ../src/common/stockitem.cpp:273
+msgid "Open an existing document"
+msgstr "Var olan bir dosyayı aç"
+
+#: ../src/common/stockitem.cpp:274
+msgid "Close current document"
+msgstr "Geçerli belgeyi kapat"
+
+#: ../src/common/stockitem.cpp:275
+msgid "Save current document"
+msgstr "Geçerli belgeyi kaydet"
+
+#: ../src/common/stockitem.cpp:276
+msgid "Save current document with a different filename"
+msgstr "Geçerli belgeyi farklı bir adla kaydet"
+
+#: ../src/common/strconv.cpp:2324
+#, c-format
+msgid "Conversion to charset '%s' doesn't work."
+msgstr "'%s' karakter kümesine dönüşüm çalışmıyor."
+
+#: ../src/common/tarstrm.cpp:352 ../src/common/tarstrm.cpp:375
+#: ../src/common/tarstrm.cpp:406 ../src/generic/progdlgg.cpp:373
+msgid "unknown"
+msgstr "bilinmiyor"
+
+#: ../src/common/tarstrm.cpp:774
+msgid "incomplete header block in tar"
+msgstr "tar üst bilgi bloğu eksik"
+
+#: ../src/common/tarstrm.cpp:798
+msgid "checksum failure reading tar header block"
+msgstr "tar üst bilgi bloğu okunurken sağlama toplamı hatası"
+
+#: ../src/common/tarstrm.cpp:971
+msgid "invalid data in extended tar header"
+msgstr "ek tar üst bilgisindeki veriler geçersiz"
+
+#: ../src/common/tarstrm.cpp:981 ../src/common/tarstrm.cpp:1003
+#: ../src/common/tarstrm.cpp:1477 ../src/common/tarstrm.cpp:1499
+msgid "tar entry not open"
+msgstr "tar kaydı açık değil"
+
+#: ../src/common/tarstrm.cpp:1023
+msgid "unexpected end of file"
+msgstr "beklenmeyen dosya sonu"
+
+#: ../src/common/tarstrm.cpp:1297
+#, c-format
+msgid "%s did not fit the tar header for entry '%s'"
+msgstr "%s '%s' kaydının tar başlığına sığmadı"
+
+#: ../src/common/tarstrm.cpp:1359
+msgid "incorrect size given for tar entry"
+msgstr "tar kaydının boyutu hatalı verilmiş"
+
+#: ../src/common/textbuf.cpp:232
+#, c-format
+msgid "'%s' is probably a binary buffer."
+msgstr "'%s' muhtemelen ikili ara bellek."
+
+#: ../src/common/textcmn.cpp:1006 ../src/richtext/richtextctrl.cpp:3053
+msgid "File couldn't be loaded."
+msgstr "Dosya yüklenemedi."
+
+#: ../src/common/textfile.cpp:95
+#, c-format
+msgid "Failed to read text file \"%s\"."
+msgstr "\"%s\" metin dosyası okunamadı."
+
+#: ../src/common/textfile.cpp:160
+#, c-format
+msgid "can't write buffer '%s' to disk."
+msgstr "'%s' ara belleği diske yazılamadı."
+
+#: ../src/common/time.cpp:212
+msgid "Failed to get the local system time"
+msgstr "Yerel sistem zamanı alınamadı"
+
+#: ../src/common/time.cpp:279
+msgid "wxGetTimeOfDay failed."
+msgstr "wxGetTimeOfDay başarısız."
+
+#: ../src/common/translation.cpp:929
+#, c-format
+msgid "'%s' is not a valid message catalog."
+msgstr "'%s' ileti kataloğu geçersiz."
+
+#: ../src/common/translation.cpp:954
+msgid "Invalid message catalog."
+msgstr "İleti kataloğu geçersiz."
+
+#: ../src/common/translation.cpp:1013
+#, c-format
+msgid "Failed to parse Plural-Forms: '%s'"
+msgstr "Çoğul formlar işlenemedi: '%s'"
+
+#: ../src/common/translation.cpp:1723
+#, c-format
+msgid "using catalog '%s' from '%s'."
+msgstr "'%s' kataloğu '%s' üzerinden kullanılıyor."
+
+#: ../src/common/translation.cpp:1816
+#, c-format
+msgid "Resource '%s' is not a valid message catalog."
+msgstr "'%s' kaynağı geçerli bir ileti kataloğu değil."
+
+#: ../src/common/translation.cpp:1865
+msgid "Couldn't enumerate translations"
+msgstr "Çeviriler sayılamadı"
+
+#: ../src/common/utilscmn.cpp:1145
+msgid "No default application configured for HTML files."
+msgstr "HTML dosyaları için varsayılan uygulama ayarlanmamış."
+
+#: ../src/common/utilscmn.cpp:1190
+#, c-format
+msgid "Failed to open URL \"%s\" in default browser."
+msgstr "'%s' adresi varsayılan tarayıcıyla açılamadı."
+
+#: ../src/common/valtext.cpp:144
+msgid "Validation conflict"
+msgstr "Doğrulama çelişkisi"
+
+#: ../src/common/valtext.cpp:186
+msgid "Required information entry is empty."
+msgstr "Gereken bilgi kaydı boş."
+
+#: ../src/common/valtext.cpp:188
+#, c-format
+msgid "'%s' is one of the invalid strings"
+msgstr "'%s' geçersiz bir dizge"
+
+#: ../src/common/valtext.cpp:190
+#, c-format
+msgid "'%s' is not one of the valid strings"
+msgstr "'%s' geçerli bir dizge değil"
+
+#: ../src/common/valtext.cpp:199
+#, c-format
+msgid "'%s' contains invalid character(s)"
+msgstr "'%s' içinde geçersiz karakterler var"
+
+#: ../src/common/webrequest.cpp:139
+#, c-format
+msgid "Error: %s (%d)"
+msgstr "Hata: %s (%d)"
+
+#: ../src/common/webrequest.cpp:655
+#, c-format
+msgid ""
+"Not enough free disk space for download: %llu needed but only %llu available."
+msgstr ""
+"İndirme için yeterli boş disk alanı yok: %llu gerekli, ancak yalnızca %llu "
+"mevcut."
+
+#: ../src/common/webrequest.cpp:669
+#, c-format
+msgid "Failed to create temporary file in %s"
+msgstr "%s konumunda geçici dosya oluşturulamadı."
+
+#: ../src/common/webrequest_curl.cpp:1106
+msgid "libcurl could not be initialized"
+msgstr "libcurl başlatılamadı"
+
+#: ../src/common/webview.cpp:392
+msgid "RunScriptAsync not supported"
+msgstr "RunScriptAsync desteklenmiyor"
+
+#: ../src/common/webview.cpp:403 ../src/msw/webview_ie.cpp:1073
+#, c-format
+msgid "Error running JavaScript: %s"
+msgstr "JavaScript çalıştırılırken sorun çıktı: %s"
+
+#: ../src/common/webview_chromium.cpp:858
+#, c-format
+msgid "Failed to set proxy \"%s\": %s"
+msgstr "\"%s\" proxy'si ayarlanamadı: %s"
+
+#: ../src/common/webview_chromium.cpp:989
+msgid ""
+"Chromium can't be used because libcef.so wasn't loaded early enough; please "
+"relink the application or use LD_PRELOAD to load it earlier."
+msgstr ""
+"Chromium kullanılamıyor çünkü libcef.so yeterince erken yüklenemedi; lütfen "
+"uygulamayı yeniden bağlayın ya da LD_PRELOAD kullanarak daha erken yükleyin."
+
+#: ../src/common/webview_chromium.cpp:1108
+msgid "Could not initialize Chromium"
+msgstr "Chromium başlatılamadı."
+
+#: ../src/common/webview_chromium.cpp:1616
+msgid "Show DevTools"
+msgstr "Geliştirici Araçlarını Göster"
+
+#: ../src/common/webview_chromium.cpp:1617
+msgid "Close DevTools"
+msgstr "Geliştirici Araçlarını Kapat"
+
+#: ../src/common/webview_chromium.cpp:1623
+msgid "Inspect"
+msgstr "İnceleme"
+
+#: ../src/common/wincmn.cpp:1628
+msgid "This platform does not support background transparency."
+msgstr "Bu platformda arka plan saydamlığı desteklenmiyor."
+
+#: ../src/common/wincmn.cpp:2097
+msgid "Could not transfer data to window"
+msgstr "Veri pencereye aktarılamadı"
+
+#: ../src/common/windowid.cpp:240
+msgid "Out of window IDs.  Recommend shutting down application."
+msgstr "Pencere kodları tükendi. Uygulamayı kapatmanız önerilir."
+
+#: ../src/common/xpmdecod.cpp:678
+msgid "XPM: incorrect header format!"
+msgstr "XPM: Üst bilgi biçimi hatalı!"
+
+#: ../src/common/xpmdecod.cpp:703
+#, c-format
+msgid "XPM: incorrect colour description in line %d"
+msgstr "XPM: %d satırında hatalı renk açıklaması"
+
+#: ../src/common/xpmdecod.cpp:715 ../src/common/xpmdecod.cpp:724
+#, c-format
+msgid "XPM: malformed colour definition '%s' at line %d!"
+msgstr "XPM: '%s' bozuk renk tanımı %d satırında!"
+
+#: ../src/common/xpmdecod.cpp:754
+msgid "XPM: no colors left to use for mask!"
+msgstr "XPM: Maske için kullanılacak renk kalmadı!"
+
+#: ../src/common/xpmdecod.cpp:781
+#, c-format
+msgid "XPM: truncated image data at line %d!"
+msgstr "XPM: %d satırında budanmış görüntü verisi!"
+
+#: ../src/common/xpmdecod.cpp:795
+msgid "XPM: Malformed pixel data!"
+msgstr "XPM: Piksel verileri bozuk!"
+
+#: ../src/common/xti.cpp:492
+msgid "Illegal Parameter Count for Create Method"
+msgstr "Create yordamı için parametre sayısı geçersiz"
+
+#: ../src/common/xti.cpp:504
+msgid "Illegal Parameter Count for ConstructObject Method"
+msgstr "ConstructObject yordamı için parametre sayısı geçersiz"
+
+#: ../src/common/xtistrm.cpp:161
+#, c-format
+msgid "Create Parameter %s not found in declared RTTI Parameters"
+msgstr "'Create Parameter' %s bildirilen RTTI parametreleri içinde bulunamadı"
+
+#: ../src/common/xtistrm.cpp:290
+msgid "Illegal Object Class (Non-wxEvtHandler) as Event Source"
+msgstr "Olay kaynağı nesne sınıfı geçersiz (Non-wxEvtHandler)"
+
+#: ../src/common/xtistrm.cpp:313 ../src/common/xtixml.cpp:345
+#: ../src/common/xtixml.cpp:498
+msgid "Type must have enum - long conversion"
+msgstr "Tür enum - long çevrimini desteklemelidir"
+
+#: ../src/common/xtistrm.cpp:400 ../src/common/xtistrm.cpp:415
+msgid "Invalid or Null Object ID passed to GetObjectClassInfo"
+msgstr "GetObjectClassInfo işlevine geçersiz ya da boş nesne kodu gönderildi"
+
+#: ../src/common/xtistrm.cpp:405
+msgid "Unknown Object passed to GetObjectClassInfo"
+msgstr "GetObjectClassInfo işlevi bilinmeyen nesne ile çağrıldı"
+
+#: ../src/common/xtistrm.cpp:420
+msgid "Already Registered Object passed to SetObjectClassInfo"
+msgstr "SetObjectClassInfo işlevi zaten kaydedilmiş bir nesne ile çağrıldı"
+
+#: ../src/common/xtistrm.cpp:430
+msgid "Invalid or Null Object ID passed to HasObjectClassInfo"
+msgstr "HasObjectClassInfo işlevine geçersiz ya da boş nesne kodu gönderildi"
+
+#: ../src/common/xtistrm.cpp:460
+msgid "Passing a already registered object to SetObject"
+msgstr "SetObject işlevine zaten kayıtlı olan bir nesne gönderildi"
+
+#: ../src/common/xtistrm.cpp:471
+msgid "Passing an unknown object to GetObject"
+msgstr "GetObject işlevine bilinmeyen bir nesne gönderildi"
+
+#: ../src/common/xtixml.cpp:229
+msgid "Forward hrefs are not supported"
+msgstr "Yönlendirme href biçimi desteklenmiyor"
+
+#: ../src/common/xtixml.cpp:247
+#, c-format
+msgid "unknown class %s"
+msgstr "%s sınıfı bilinmiyor"
+
+#: ../src/common/xtixml.cpp:253
+msgid "objects cannot have XML Text Nodes"
+msgstr "nesnelerin XML Metin Düğümleri olamaz"
+
+#: ../src/common/xtixml.cpp:258
+msgid "Objects must have an id attribute"
+msgstr "Nesnelerin bir kod özniteliği olmalıdır"
+
+#: ../src/common/xtixml.cpp:267
+#, c-format
+msgid "Doubly used id : %d"
+msgstr "Kod iki kez kullanılmış: %d"
+
+#: ../src/common/xtixml.cpp:316
+#, c-format
+msgid "Unknown Property %s"
+msgstr "Özellik bilinmiyor %s"
+
+#: ../src/common/xtixml.cpp:407
+msgid "A non empty collection must consist of 'element' nodes"
+msgstr "Boş olmayan bir yığın 'element' düğümlerinden oluşmalıdır"
+
+#: ../src/common/xtixml.cpp:478
+msgid "incorrect event handler string, missing dot"
+msgstr "hatalı olay işleyici dizgesi, nokta eksik"
+
+#: ../src/common/zipstrm.cpp:559
+msgid "can't re-initialize zlib deflate stream"
+msgstr "zlib ayıklama akışı yeniden başlatılamadı"
+
+#: ../src/common/zipstrm.cpp:584
+msgid "can't re-initialize zlib inflate stream"
+msgstr "zlib sıkıştırma akışı yeniden başlatılamadı"
+
+#: ../src/common/zipstrm.cpp:1023
+msgid "Ignoring malformed extra data record, ZIP file may be corrupted"
+msgstr ""
+"Hatalı biçimlendirilmiş ek veri kaydı yok sayılıyor. ZIP dosyası bozulmuş "
+"olabilir"
+
+#: ../src/common/zipstrm.cpp:1502
+msgid "assuming this is a multi-part zip concatenated"
+msgstr "bunun çok parçalı birleştirilmiş bir zip olduğu varsayılıyor"
+
+#: ../src/common/zipstrm.cpp:1664
+msgid "invalid zip file"
+msgstr "zip dosyası geçersiz"
+
+#: ../src/common/zipstrm.cpp:1723
+msgid "can't find central directory in zip"
+msgstr "zip içinde merkez klasör bulunamadı"
+
+#: ../src/common/zipstrm.cpp:1812
+msgid "error reading zip central directory"
+msgstr "zip merkez klasörü okunurken sorun çıktı"
+
+#: ../src/common/zipstrm.cpp:1916
+msgid "error reading zip local header"
+msgstr "zip yerel başlığı okunurken sorun çıktı"
+
+#: ../src/common/zipstrm.cpp:1964
+msgid "bad zipfile offset to entry"
+msgstr "kayıt için zip dosyası konumu hatalı"
+
+#: ../src/common/zipstrm.cpp:2031
+msgid "stored file length not in Zip header"
+msgstr "kayıtlı dosya uzunluğu Zip başlığında yok"
+
+#: ../src/common/zipstrm.cpp:2045 ../src/common/zipstrm.cpp:2362
+msgid "unsupported Zip compression method"
+msgstr "zip sıkıştırma yöntemi desteklenmiyor"
+
+#: ../src/common/zipstrm.cpp:2126
+#, c-format
+msgid "reading zip stream (entry %s): bad length"
+msgstr "zip akışı okuma (kayıt %s): Uzunluk hatalı"
+
+#: ../src/common/zipstrm.cpp:2131
+#, c-format
+msgid "reading zip stream (entry %s): bad crc"
+msgstr "zip akışı okuma (kayıt %s): CRC hatalı"
+
+#: ../src/common/zipstrm.cpp:2578
+#, c-format
+msgid "error writing zip entry '%s': file too large without ZIP64"
+msgstr "'%s' zip kaydı yazılırken sorun çıktı: Dosya ZIP64 olmadan çok uzun"
+
+#: ../src/common/zipstrm.cpp:2585
+#, c-format
+msgid "error writing zip entry '%s': bad crc or length"
+msgstr "'%s' zip kaydı yazılırken sorun çıktı: CRC ya da uzunluk hatalı"
+
+#: ../src/common/zstream.cpp:155 ../src/common/zstream.cpp:315
+msgid "Gzip not supported by this version of zlib"
+msgstr "Bu Zlib sürümünde Gzip desteklenmiyor"
+
+#: ../src/common/zstream.cpp:182
+msgid "Can't initialize zlib inflate stream."
+msgstr "Zlib ayıklama akışı başlatılamadı."
+
+#: ../src/common/zstream.cpp:241
+msgid "Can't read inflate stream: unexpected EOF in underlying stream."
+msgstr "Ayıklama akışı okunamadı: alt akışta beklenmeyen dosya sonu."
+
+#: ../src/common/zstream.cpp:248 ../src/common/zstream.cpp:423
+#, c-format
+msgid "zlib error %d"
+msgstr "%d zlib sorunu"
+
+#: ../src/common/zstream.cpp:249
+#, c-format
+msgid "Can't read from inflate stream: %s"
+msgstr "Ayıklama akışı okunamadı: %s"
+
+#: ../src/common/zstream.cpp:343
+msgid "Can't initialize zlib deflate stream."
+msgstr "Zlib sıkıştırma akışı başlatılamadı."
+
+#: ../src/common/zstream.cpp:424
+#, c-format
+msgid "Can't write to deflate stream: %s"
+msgstr "Sıkıştırma akışına yazılamadı: %s"
+
+#: ../src/dfb/bitmap.cpp:633 ../src/dfb/bitmap.cpp:667
+#, c-format
+msgid "No bitmap handler for type %d defined."
+msgstr "%d türü için bit eşlemi işleyicisi tanımlanmamış."
+
+#: ../src/dfb/evtloop.cpp:99
+msgid "Failed to read event from DirectFB pipe"
+msgstr "DirectFB tünelinden olay okunamadı"
+
+#: ../src/dfb/evtloop.cpp:171
+msgid "Failed to switch DirectFB pipe to non-blocking mode"
+msgstr "DirectFB tüneli engellemesiz kipe döndürülemedi"
+
+#: ../src/dfb/fontmgr.cpp:171
+#, c-format
+msgid "no fonts found in %s, using builtin font"
+msgstr "%s içinde font yok, iç font kullanılıyor"
+
+#: ../src/dfb/fontmgr.cpp:177
+msgid "Default font"
+msgstr "Varsayılan font"
+
+#: ../src/dfb/fontmgr.cpp:195
+#, c-format
+msgid "Fonts index file %s disappeared while loading fonts."
+msgstr "Fontlar yüklenirken %s font dizini dosyası kayboldu."
+
+#: ../src/dfb/wrapdfb.cpp:60
+#, c-format
+msgid "DirectFB error %d occurred."
+msgstr "%d DirectFB hatası oluştu."
+
+#: ../src/generic/aboutdlgg.cpp:69
+msgid "Developed by "
+msgstr "Geliştirici "
+
+#: ../src/generic/aboutdlgg.cpp:72
+msgid "Documentation by "
+msgstr "Belgeleyen "
+
+#: ../src/generic/aboutdlgg.cpp:75
+msgid "Graphics art by "
+msgstr "Görselleri hazırlayan "
+
+#: ../src/generic/aboutdlgg.cpp:78
+msgid "Translations by "
+msgstr "Çeviren "
+
+#: ../src/generic/aboutdlgg.cpp:133 ../src/osx/cocoa/aboutdlg.mm:83
+msgid "Version "
+msgstr "Sürüm "
+
+#. TRANSLATORS: %s is application name
+#: ../src/generic/aboutdlgg.cpp:146 ../src/msw/aboutdlg.cpp:60
+#, c-format
+msgid "About %s"
+msgstr "%s Hakkında"
+
+#: ../src/generic/aboutdlgg.cpp:181
+msgid "License"
+msgstr "Lisans"
+
+#: ../src/generic/aboutdlgg.cpp:184
+msgid "Developers"
+msgstr "Geliştiriciler"
+
+#: ../src/generic/aboutdlgg.cpp:188
+msgid "Documentation writers"
+msgstr "Belge yazarları"
+
+#: ../src/generic/aboutdlgg.cpp:192
+msgid "Artists"
+msgstr "Sanatçılar"
+
+#: ../src/generic/aboutdlgg.cpp:196
+msgid "Translators"
+msgstr "Çevirmenler"
+
+#: ../src/generic/animateg.cpp:125
+msgid "No handler found for animation type."
+msgstr "Canlandırma türünün işleyicisi bulunamadı."
+
+#: ../src/generic/animateg.cpp:133
+#, c-format
+msgid "No animation handler for type %ld defined."
+msgstr "%ld türü için canlandırma işleyicisi tanımlanmamış."
+
+#: ../src/generic/animateg.cpp:145
+#, c-format
+msgid "Animation file is not of type %ld."
+msgstr "Canlandırma dosyası %ld türünde değil."
+
+#: ../src/generic/colrdlgg.cpp:154 ../src/gtk/colordlg.cpp:47
+msgid "Choose colour"
+msgstr "Renk seçin"
+
+#: ../src/generic/colrdlgg.cpp:357
+msgid "Red:"
+msgstr "Kırmızı:"
+
+#: ../src/generic/colrdlgg.cpp:360
+msgid "Green:"
+msgstr "Yeşil:"
+
+#: ../src/generic/colrdlgg.cpp:363
+msgid "Blue:"
+msgstr "Mavi:"
+
+#: ../src/generic/colrdlgg.cpp:372
+msgid "Opacity:"
+msgstr "Matlık:"
+
+#: ../src/generic/colrdlgg.cpp:384
+msgid "Add to custom colours"
+msgstr "Özel renklere ekle"
+
+#: ../src/generic/creddlgg.cpp:56
+msgid "Username:"
+msgstr "Kullanıcı adı:"
+
+#: ../src/generic/creddlgg.cpp:63
+msgid "Password:"
+msgstr "Parola:"
+
+#. TRANSLATORS: Name of Boolean true value
+#: ../src/generic/datavgen.cpp:1178
+msgid "true"
+msgstr "doğru"
+
+#. TRANSLATORS: Name of Boolean false value
+#: ../src/generic/datavgen.cpp:1180
+msgid "false"
+msgstr "yanlış"
+
+#: ../src/generic/datavgen.cpp:6897
+#, c-format
+msgid "Row %i"
+msgstr "%i. Satır"
+
+#. TRANSLATORS: Action for manipulating a tree control
+#: ../src/generic/datavgen.cpp:6987
+msgid "Collapse"
+msgstr "Daralt"
+
+#. TRANSLATORS: Action for manipulating a tree control
+#: ../src/generic/datavgen.cpp:6990
+msgid "Expand"
+msgstr "Genişlet"
+
+#. TRANSLATORS: Name of data view control and number of rows
+#: ../src/generic/datavgen.cpp:7011
+#, c-format
+msgid "%s (%d items)"
+msgstr "%s (%d öge)"
+
+#: ../src/generic/datavgen.cpp:7062
+#, c-format
+msgid "Column %u"
+msgstr "%u. sütun"
+
+#. TRANSLATORS: Keystroke for manipulating a tree control
+#: ../src/generic/datavgen.cpp:7131 ../src/richtext/richtextbulletspage.cpp:189
+#: ../src/richtext/richtextbulletspage.cpp:192
+#: ../src/richtext/richtextbulletspage.cpp:193
+#: ../src/richtext/richtextliststylepage.cpp:252
+#: ../src/richtext/richtextliststylepage.cpp:255
+#: ../src/richtext/richtextliststylepage.cpp:256
+#: ../src/richtext/richtextsizepage.cpp:248
+msgid "Left"
+msgstr "Sol"
+
+#. TRANSLATORS: Keystroke for manipulating a tree control
+#: ../src/generic/datavgen.cpp:7134 ../src/richtext/richtextbulletspage.cpp:191
+#: ../src/richtext/richtextliststylepage.cpp:254
+#: ../src/richtext/richtextsizepage.cpp:249
+msgid "Right"
+msgstr "Sağ"
+
+#: ../src/generic/datectlg.cpp:90
+#, c-format
+msgid ""
+"\"%s\" is not in the expected date format, please enter it as e.g. \"%s\"."
+msgstr ""
+"\"%s\" beklenen tarih formatında değil, lütfen şu şekilde girin: \"%s\"."
+
+#: ../src/generic/datectlg.cpp:94
+msgid "Invalid date"
+msgstr "Geçersiz tarih"
+
+#: ../src/generic/dbgrptg.cpp:159
+#, c-format
+msgid "Open file \"%s\""
+msgstr "\"%s\" dosyasını aç"
+
+#: ../src/generic/dbgrptg.cpp:170
+#, c-format
+msgid "Enter command to open file \"%s\":"
+msgstr "\"%s\" dosyasını açacak komutu yazın:"
+
+#: ../src/generic/dbgrptg.cpp:230
+msgid "Executable files (*.exe)|*.exe|"
+msgstr "Yürütülebilir dosyalar (*.exe)|*.exe|"
+
+#: ../src/generic/dbgrptg.cpp:300
+#, c-format
+msgid "Debug report \"%s\""
+msgstr "Hata ayıklama raporu \"%s\""
+
+#: ../src/generic/dbgrptg.cpp:316
+msgid "A debug report has been generated in the directory\n"
+msgstr "Klasörde bir hata ayıklama raporu oluşturuldu\n"
+
+#: ../src/generic/dbgrptg.cpp:317
+msgid "The following debug report will be generated\n"
+msgstr "Şu hata ayıklama raporu oluşturulacak\n"
+
+#: ../src/generic/dbgrptg.cpp:321
+msgid ""
+"The report contains the files listed below. If any of these files contain "
+"private information,\n"
+"please uncheck them and they will be removed from the report.\n"
+msgstr ""
+"Bu raporda aşağıdaki dosyalar bulunuyor. Bu dosyalarda özel bilgileriniz "
+"varsa,\n"
+"rapordan çıkarmak istediğiniz dosyaların işaretini kaldırın.\n"
+
+#: ../src/generic/dbgrptg.cpp:323
+msgid ""
+"If you wish to suppress this debug report completely, please choose the "
+"\"Cancel\" button,\n"
+"but be warned that it may hinder improving the program, so if\n"
+"at all possible please do continue with the report generation.\n"
+msgstr ""
+"Bu hata raporunu göndermek istemiyorsanız, \"İptal\" düğmesine tıklayın.\n"
+"Ancak bu rapor, yazılımın geliştirilmesine yardımcı olabilir, \n"
+"bu nedenle olanağınız varsa raporu gönderin.\n"
+
+#: ../src/generic/dbgrptg.cpp:325
+msgid "              Thank you and we're sorry for the inconvenience!\n"
+msgstr "              Teşekkürler, yaşadığınız sorundan dolayı özür dileriz!\n"
+
+#: ../src/generic/dbgrptg.cpp:333
+msgid "&Debug report preview:"
+msgstr "&Hata ayıklama raporu önizlemesi:"
+
+#: ../src/generic/dbgrptg.cpp:339
+msgid "&View..."
+msgstr "&Görünüm..."
+
+#: ../src/generic/dbgrptg.cpp:359
+msgid "&Notes:"
+msgstr "&Notlar:"
+
+#: ../src/generic/dbgrptg.cpp:361
+msgid ""
+"If you have any additional information pertaining to this bug\n"
+"report, please enter it here and it will be joined to it:"
+msgstr ""
+"Bu hata raporuna ekleyeceğiniz bir bilgi varsa,\n"
+"lütfen buraya yazın:"
+
+#: ../src/generic/dcpsg.cpp:1627
+msgid "Cannot open file for PostScript printing!"
+msgstr "Dosya PostScript yazdırma için açılamadı!"
+
+#: ../src/generic/dirctrlg.cpp:402
+msgid "Computer"
+msgstr "Bilgisayarım"
+
+#: ../src/generic/dirctrlg.cpp:404
+msgid "Sections"
+msgstr "Bölümler"
+
+#: ../src/generic/dirctrlg.cpp:482
+msgid "Home directory"
+msgstr "Açılış klasörü"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/generic/dirctrlg.cpp:484 ../src/propgrid/advprops.cpp:811
+msgid "Desktop"
+msgstr "Masaüstü"
+
+#: ../src/generic/dirctrlg.cpp:528 ../src/generic/filectrlg.cpp:752
+msgid "Illegal directory name."
+msgstr "Klasör adı geçersiz."
+
+#: ../src/generic/dirctrlg.cpp:528 ../src/generic/dirctrlg.cpp:546
+#: ../src/generic/dirctrlg.cpp:557 ../src/generic/dirdlgg.cpp:317
+#: ../src/generic/filectrlg.cpp:638 ../src/generic/filectrlg.cpp:752
+#: ../src/generic/filectrlg.cpp:766 ../src/generic/filectrlg.cpp:782
+#: ../src/generic/filectrlg.cpp:1356 ../src/generic/filectrlg.cpp:1387
+#: ../src/generic/filedlgg.cpp:362 ../src/gtk/filedlg.cpp:76
+msgid "Error"
+msgstr "Hata"
+
+#: ../src/generic/dirctrlg.cpp:546 ../src/generic/filectrlg.cpp:766
+msgid "File name exists already."
+msgstr "Aynı adlı bir dosya zaten var."
+
+#: ../src/generic/dirctrlg.cpp:557 ../src/generic/dirdlgg.cpp:317
+#: ../src/generic/filectrlg.cpp:638 ../src/generic/filectrlg.cpp:782
+msgid "Operation not permitted."
+msgstr "İşleme izin verilmiyor."
+
+#: ../src/generic/dirdlgg.cpp:107 ../src/generic/filedlgg.cpp:207
+msgid "Create new directory"
+msgstr "Yeni klasör oluştur"
+
+#: ../src/generic/dirdlgg.cpp:112 ../src/generic/filedlgg.cpp:203
+msgid "Go to home directory"
+msgstr "Açılış klasörüne git"
+
+#: ../src/generic/dirdlgg.cpp:143
+msgid "Show &hidden directories"
+msgstr "Gizli &klasörleri görüntüle"
+
+#: ../src/generic/dirdlgg.cpp:196
+#, c-format
+msgid ""
+"The directory '%s' does not exist\n"
+"Create it now?"
+msgstr ""
+"'%s' klasörü bulunamadı\n"
+"Şimdi oluşturulsun mu?"
+
+#: ../src/generic/dirdlgg.cpp:198
+msgid "Directory does not exist"
+msgstr "Klasör bulunamadı"
+
+#: ../src/generic/dirdlgg.cpp:214
+#, c-format
+msgid ""
+"Failed to create directory '%s'\n"
+"(Do you have the required permissions?)"
+msgstr ""
+"'%s' klasörü oluşturulamadı\n"
+"(Yeterli izniniz var mı?)"
+
+#: ../src/generic/dirdlgg.cpp:216
+msgid "Error creating directory"
+msgstr "Klasör oluşturulurken sorun çıktı"
+
+#: ../src/generic/dirdlgg.cpp:281
+msgid "You cannot add a new directory to this section."
+msgstr "Bu bölüme yeni bir klasör ekleyemezsiniz."
+
+#: ../src/generic/dirdlgg.cpp:282
+msgid "Create directory"
+msgstr "Klasör oluştur"
+
+#: ../src/generic/dirdlgg.cpp:291 ../src/generic/dirdlgg.cpp:301
+#: ../src/generic/filectrlg.cpp:614 ../src/generic/filectrlg.cpp:623
+msgid "NewName"
+msgstr "YeniAd"
+
+#: ../src/generic/editlbox.cpp:135
+msgid "Edit item"
+msgstr "Ögeyi düzenle"
+
+#: ../src/generic/editlbox.cpp:143
+msgid "New item"
+msgstr "Yeni öge"
+
+#: ../src/generic/editlbox.cpp:151
+msgid "Delete item"
+msgstr "Ögeyi sil"
+
+#: ../src/generic/editlbox.cpp:159
+msgid "Move up"
+msgstr "Yukarı taşı"
+
+#: ../src/generic/editlbox.cpp:164
+msgid "Move down"
+msgstr "Aşağı taşı"
+
+#: ../src/generic/fdrepdlg.cpp:108
+msgid "Search for:"
+msgstr "Aranan:"
+
+#: ../src/generic/fdrepdlg.cpp:120
+msgid "Replace with:"
+msgstr "Şununla değiştir:"
+
+#: ../src/generic/fdrepdlg.cpp:140
+msgid "Whole word"
+msgstr "Tam sözcük"
+
+#: ../src/generic/fdrepdlg.cpp:143
+msgid "Match case"
+msgstr "Küçük büyük harf eşleştirilsin"
+
+#: ../src/generic/fdrepdlg.cpp:156
+msgid "Search direction"
+msgstr "Arama yönü"
+
+#: ../src/generic/fdrepdlg.cpp:175
+msgid "&Replace"
+msgstr "&Değiştir"
+
+#: ../src/generic/fdrepdlg.cpp:178
+msgid "Replace &all"
+msgstr "&Tümünü değiştir"
+
+#: ../src/generic/filectrlg.cpp:246 ../src/generic/filectrlg.cpp:269
+msgid "<DIR>"
+msgstr "<DIR>"
+
+#: ../src/generic/filectrlg.cpp:248 ../src/generic/filectrlg.cpp:271
+msgid "<LINK>"
+msgstr "<LINK>"
+
+#: ../src/generic/filectrlg.cpp:250 ../src/generic/filectrlg.cpp:273
+msgid "<DRIVE>"
+msgstr "<DRIVE>"
+
+#: ../src/generic/filectrlg.cpp:275
+#, c-format
+msgid "%ld byte"
+msgid_plural "%ld bytes"
+msgstr[0] "%ld bayt"
+msgstr[1] "%ld bayt"
+
+#: ../src/generic/filectrlg.cpp:420
+msgid "Name"
+msgstr "Ad"
+
+#: ../src/generic/filectrlg.cpp:421 ../src/richtext/richtextformatdlg.cpp:361
+#: ../src/richtext/richtextsizepage.cpp:298
+msgid "Size"
+msgstr "Boyut"
+
+#: ../src/generic/filectrlg.cpp:422
+msgid "Type"
+msgstr "Tür"
+
+#: ../src/generic/filectrlg.cpp:423
+msgid "Modified"
+msgstr "Değişiklik"
+
+#: ../src/generic/filectrlg.cpp:426
+msgid "Permissions"
+msgstr "İzinler"
+
+#: ../src/generic/filectrlg.cpp:429
+msgid "Attributes"
+msgstr "Öznitelikler"
+
+#: ../src/generic/filectrlg.cpp:936
+msgid "Current directory:"
+msgstr "Geçerli klasör:"
+
+#: ../src/generic/filectrlg.cpp:979
+msgid "Show &hidden files"
+msgstr "Gizli &dosyaları görüntüle"
+
+#: ../src/generic/filectrlg.cpp:1355
+msgid "Illegal file specification."
+msgstr "Dosya tanımı geçersiz."
+
+#: ../src/generic/filectrlg.cpp:1387
+msgid "Directory doesn't exist."
+msgstr "Klasör bulunamadı."
+
+#: ../src/generic/filedlgg.cpp:195
+msgid "View files as a list view"
+msgstr "Dosyalar liste görünümünde görüntülensin"
+
+#: ../src/generic/filedlgg.cpp:197
+msgid "View files as a detailed view"
+msgstr "Dosyalar ayrıntı görünümünde görüntülensin"
+
+#: ../src/generic/filedlgg.cpp:200
+msgid "Go to parent directory"
+msgstr "Üst klasöre git"
+
+#: ../src/generic/filedlgg.cpp:351 ../src/gtk/filedlg.cpp:59
+#, c-format
+msgid "File '%s' already exists, do you really want to overwrite it?"
+msgstr "'%s' dosyası zaten var, üzerine yazılsın mı?"
+
+#: ../src/generic/filedlgg.cpp:354 ../src/gtk/filedlg.cpp:62
+msgid "Confirm"
+msgstr "Onayla"
+
+#: ../src/generic/filedlgg.cpp:362 ../src/gtk/filedlg.cpp:75
+msgid "Please choose an existing file."
+msgstr "Lütfen var olan bir dosya seçin."
+
+#: ../src/generic/filepickerg.cpp:64
+msgid "..."
+msgstr "..."
+
+#: ../src/generic/fontdlgg.cpp:76 ../src/richtext/richtextformatdlg.cpp:519
+msgid "ABCDEFGabcdefg12345"
+msgstr "ABCDEFGabcdefg12345"
+
+#: ../src/generic/fontdlgg.cpp:315
+msgid "Roman"
+msgstr "Roman"
+
+#: ../src/generic/fontdlgg.cpp:316
+msgid "Decorative"
+msgstr "Süslü"
+
+#: ../src/generic/fontdlgg.cpp:317
+msgid "Modern"
+msgstr "Modern"
+
+#: ../src/generic/fontdlgg.cpp:318
+msgid "Script"
+msgstr "Betik"
+
+#: ../src/generic/fontdlgg.cpp:319
+msgid "Swiss"
+msgstr "İsveç"
+
+#: ../src/generic/fontdlgg.cpp:320
+msgid "Teletype"
+msgstr "Teletype"
+
+#: ../src/generic/fontdlgg.cpp:321 ../src/generic/fontdlgg.cpp:324
+msgid "Normal"
+msgstr "Normal"
+
+#: ../src/generic/fontdlgg.cpp:323
+msgid "Slant"
+msgstr "Eğik"
+
+#: ../src/generic/fontdlgg.cpp:325
+msgid "Light"
+msgstr "İnce"
+
+#: ../src/generic/fontdlgg.cpp:363
+msgid "&Font family:"
+msgstr "&Font ailesi:"
+
+#: ../src/generic/fontdlgg.cpp:367 ../src/generic/fontdlgg.cpp:369
+msgid "The font family."
+msgstr "Font ailesi."
+
+#: ../src/generic/fontdlgg.cpp:374 ../src/richtext/richtextstylepage.cpp:105
+msgid "&Style:"
+msgstr "&Stil:"
+
+#: ../src/generic/fontdlgg.cpp:378 ../src/generic/fontdlgg.cpp:380
+msgid "The font style."
+msgstr "Font stili."
+
+#: ../src/generic/fontdlgg.cpp:385
+msgid "&Weight:"
+msgstr "&Kalınlık:"
+
+#: ../src/generic/fontdlgg.cpp:389 ../src/generic/fontdlgg.cpp:391
+msgid "The font weight."
+msgstr "Font kalınlığı."
+
+#: ../src/generic/fontdlgg.cpp:399
+msgid "C&olour:"
+msgstr "&Renk:"
+
+#: ../src/generic/fontdlgg.cpp:407 ../src/generic/fontdlgg.cpp:409
+msgid "The font colour."
+msgstr "Font rengi."
+
+#: ../src/generic/fontdlgg.cpp:415
+msgid "&Point size:"
+msgstr "Yazı &boyutu:"
+
+#: ../src/generic/fontdlgg.cpp:420 ../src/generic/fontdlgg.cpp:422
+#: ../src/generic/fontdlgg.cpp:426 ../src/generic/fontdlgg.cpp:428
+msgid "The font point size."
+msgstr "Font punto boyutu."
+
+#: ../src/generic/fontdlgg.cpp:439 ../src/generic/fontdlgg.cpp:441
+msgid "Whether the font is underlined."
+msgstr "Fontun altıçizili olup olmadığı."
+
+#: ../src/generic/fontdlgg.cpp:448 ../src/html/helpwnd.cpp:1215
+msgid "Preview:"
+msgstr "Önizleme:"
+
+#: ../src/generic/fontdlgg.cpp:452 ../src/generic/fontdlgg.cpp:454
+msgid "Shows the font preview."
+msgstr "Font önizlemesini gösterir."
+
+#: ../src/generic/fontdlgg.cpp:464 ../src/generic/fontdlgg.cpp:483
+msgid "Click to cancel the font selection."
+msgstr "Font seçiminden vazgeçmek için tıklayın."
+
+#: ../src/generic/fontdlgg.cpp:469 ../src/generic/fontdlgg.cpp:471
+#: ../src/generic/fontdlgg.cpp:476 ../src/generic/fontdlgg.cpp:478
+msgid "Click to confirm the font selection."
+msgstr "Font seçimini onaylamak için tıklayın."
+
+#: ../src/generic/fontpickerg.cpp:50 ../src/gtk/fontdlg.cpp:77
+msgid "Choose font"
+msgstr "Font seçin"
+
+#: ../src/generic/grid.cpp:6542
+msgid ""
+"Error copying grid to the clipboard. Either selected cells were not "
+"contiguous or no cell was selected."
+msgstr ""
+"Panoya ızgarayı kopyalarken hata oluştu. Seçilen hücreler birbirine bitişik "
+"değildi veya hiçbir hücre seçilmemişti."
+
+#: ../src/generic/grid.cpp:12739
+msgid "Grid Corner"
+msgstr "Izgara Köşesi"
+
+#: ../src/generic/grid.cpp:12741
+#, c-format
+msgid "Column %s Header"
+msgstr "Sütun %s Başlığı"
+
+#: ../src/generic/grid.cpp:12743
+#, c-format
+msgid "Row %s Header"
+msgstr "Satır %s Başlığı"
+
+#: ../src/generic/grid.cpp:12745
+#, c-format
+msgid "Column %s: %s"
+msgstr "Sütun %s: %s"
+
+#: ../src/generic/grid.cpp:12749
+#, c-format
+msgid "Row %s: %s"
+msgstr "Satır %s: %s"
+
+#: ../src/generic/grid.cpp:12753
+#, c-format
+msgid "Row %s, Column %s: %s"
+msgstr "Satır %s, Sütun %s: %s"
+
+#: ../src/generic/helpext.cpp:257
+#, c-format
+msgid "Help directory \"%s\" not found."
+msgstr "\"%s\" yardım klasörü bulunamadı."
+
+#: ../src/generic/helpext.cpp:265
+#, c-format
+msgid "Help file \"%s\" not found."
+msgstr "\"%s\" yardım dosyası bulunamadı."
+
+#: ../src/generic/helpext.cpp:284
+#, c-format
+msgid "Line %lu of map file \"%s\" has invalid syntax, skipped."
+msgstr ""
+"%lu satırında \"%s\" eşleştirme dosyası içinde sözdizimi hatası var, atlandı."
+
+#: ../src/generic/helpext.cpp:292
+#, c-format
+msgid "No valid mappings found in the file \"%s\"."
+msgstr "\"%s\" dosyasında geçerli eşleme bulunamadı."
+
+#: ../src/generic/helpext.cpp:435
+msgid "No entries found."
+msgstr "Herhangi bir kayıt bulunamadı."
+
+#: ../src/generic/helpext.cpp:444 ../src/generic/helpext.cpp:445
+msgid "Help Index"
+msgstr "Yardım dizini"
+
+#: ../src/generic/helpext.cpp:448
+msgid "Relevant entries:"
+msgstr "İlgili kayıtlar:"
+
+#: ../src/generic/helpext.cpp:449
+msgid "Entries found"
+msgstr "Bulunan kayıt"
+
+#: ../src/generic/hyperlinkg.cpp:170
+msgid "&Copy URL"
+msgstr "Adresi k&opyala"
+
+#: ../src/generic/infobar.cpp:119
+msgid "Hide this notification message."
+msgstr "Bu uyarı iletisini gizler."
+
+#. TRANSLATORS: %s will be either the application name or "Application"
+#: ../src/generic/logg.cpp:257
+#, c-format
+msgid "%s Error"
+msgstr "%s hata"
+
+#. TRANSLATORS: %s will be either the application name or "Application"
+#: ../src/generic/logg.cpp:263
+#, c-format
+msgid "%s Warning"
+msgstr "%s uyarı"
+
+#. TRANSLATORS: %s will be either the application name or "Application"
+#: ../src/generic/logg.cpp:273
+#, c-format
+msgid "%s Information"
+msgstr "%s bilgi"
+
+#: ../src/generic/logg.cpp:276
+msgid "Application"
+msgstr "Uygulama"
+
+#: ../src/generic/logg.cpp:549
+msgid "Save log contents to file"
+msgstr "Günlük içeriğini dosyaya kaydet"
+
+#: ../src/generic/logg.cpp:551
+msgid "C&lear"
+msgstr "T&emizle"
+
+#: ../src/generic/logg.cpp:551
+msgid "Clear the log contents"
+msgstr "Günlük içeriğini temizle"
+
+#: ../src/generic/logg.cpp:553
+msgid "Close this window"
+msgstr "Bu pencereyi kapat"
+
+#: ../src/generic/logg.cpp:554
+msgid "&Log"
+msgstr "Gün&lük"
+
+#: ../src/generic/logg.cpp:610 ../src/generic/logg.cpp:992
+msgid "Can't save log contents to file."
+msgstr "Günlük içeriği dosyaya kaydedilemedi."
+
+#: ../src/generic/logg.cpp:613
+#, c-format
+msgid "Log saved to the file '%s'."
+msgstr "Günlük '%s' dosyasına kaydedildi."
+
+#: ../src/generic/logg.cpp:719
+msgid "&Details"
+msgstr "&Ayrıntılar"
+
+#: ../src/generic/logg.cpp:972
+msgid "Failed to copy dialog contents to the clipboard."
+msgstr "Pencere içeriği panoya kopyalanamadı."
+
+#: ../src/generic/logg.cpp:1022
+#, c-format
+msgid "Append log to file '%s' (choosing [No] will overwrite it)?"
+msgstr ""
+"'%s' günlük dosyasına eklensin mi ([Hayır] seçilirse üstüne yazılacak)?"
+
+#: ../src/generic/logg.cpp:1024
+msgid "Question"
+msgstr "Soru"
+
+#: ../src/generic/logg.cpp:1038
+msgid "invalid message box return value"
+msgstr "ileti penceresi dönüş değeri geçersiz"
+
+#: ../src/generic/notifmsgg.cpp:129
+msgid "Notice"
+msgstr "Bildirim"
+
+#: ../src/generic/preferencesg.cpp:118
+#, c-format
+msgid "%s Preferences"
+msgstr "%s ayarları"
+
+#: ../src/generic/printps.cpp:143
+msgid "Printing..."
+msgstr "Yazdırılıyor..."
+
+#: ../src/generic/printps.cpp:160 ../src/gtk/print.cpp:1076
+#: ../src/msw/printwin.cpp:235
+msgid "Could not start printing."
+msgstr "Yazdırma başlatılamadı."
+
+#: ../src/generic/printps.cpp:183
+#, c-format
+msgid "Printing page %d..."
+msgstr "Yazdırılan sayfa %d..."
+
+#: ../src/generic/prntdlgg.cpp:171
+msgid "Printer options"
+msgstr "Yazıcı ayarları"
+
+#: ../src/generic/prntdlgg.cpp:176
+msgid "Print to File"
+msgstr "Dosyaya yazdır"
+
+#: ../src/generic/prntdlgg.cpp:179
+msgid "Setup..."
+msgstr "Kurulum..."
+
+#: ../src/generic/prntdlgg.cpp:187
+msgid "Printer:"
+msgstr "Yazıcı:"
+
+#: ../src/generic/prntdlgg.cpp:195
+msgid "Status:"
+msgstr "Durum:"
+
+#: ../src/generic/prntdlgg.cpp:206
+msgid "All"
+msgstr "Tümü"
+
+#: ../src/generic/prntdlgg.cpp:207
+msgid "Pages"
+msgstr "Sayfalar"
+
+#: ../src/generic/prntdlgg.cpp:215
+msgid "Print Range"
+msgstr "Yazdırma aralığı"
+
+#: ../src/generic/prntdlgg.cpp:229
+msgid "From:"
+msgstr "Kaynak:"
+
+#: ../src/generic/prntdlgg.cpp:233
+msgid "To:"
+msgstr "Kime:"
+
+#: ../src/generic/prntdlgg.cpp:238
+msgid "Copies:"
+msgstr "Kopya sayısı:"
+
+#: ../src/generic/prntdlgg.cpp:288
+msgid "PostScript file"
+msgstr "PostScript dosyası"
+
+#: ../src/generic/prntdlgg.cpp:439
+msgid "Print Setup"
+msgstr "Yazdırma ayarları"
+
+#: ../src/generic/prntdlgg.cpp:483
+msgid "Printer"
+msgstr "Yazıcı"
+
+#: ../src/generic/prntdlgg.cpp:501
+msgid "Default printer"
+msgstr "Varsayılan yazıcı"
+
+#: ../src/generic/prntdlgg.cpp:595 ../src/generic/prntdlgg.cpp:782
+#: ../src/generic/prntdlgg.cpp:822 ../src/generic/prntdlgg.cpp:835
+#: ../src/generic/prntdlgg.cpp:1031 ../src/generic/prntdlgg.cpp:1036
+msgid "Paper size"
+msgstr "Kağıt boyutu"
+
+#: ../src/generic/prntdlgg.cpp:604 ../src/generic/prntdlgg.cpp:847
+msgid "Portrait"
+msgstr "Dikey"
+
+#: ../src/generic/prntdlgg.cpp:605 ../src/generic/prntdlgg.cpp:848
+msgid "Landscape"
+msgstr "Yatay"
+
+#: ../src/generic/prntdlgg.cpp:607 ../src/generic/prntdlgg.cpp:849
+msgid "Orientation"
+msgstr "Yön"
+
+#: ../src/generic/prntdlgg.cpp:610
+msgid "Options"
+msgstr "Ayarlar"
+
+#: ../src/generic/prntdlgg.cpp:612
+msgid "Print in colour"
+msgstr "Renkli yazdır"
+
+#: ../src/generic/prntdlgg.cpp:621
+msgid "Print spooling"
+msgstr "Yazdırma kuyruğu"
+
+#: ../src/generic/prntdlgg.cpp:623
+msgid "Printer command:"
+msgstr "Yazıcı komutu:"
+
+#: ../src/generic/prntdlgg.cpp:631
+msgid "Printer options:"
+msgstr "Yazıcı ayarları:"
+
+#: ../src/generic/prntdlgg.cpp:860
+msgid "Left margin (mm):"
+msgstr "Sol kenar boşluğu (mm):"
+
+#: ../src/generic/prntdlgg.cpp:861
+msgid "Top margin (mm):"
+msgstr "Üst kenar boşluğu (mm):"
+
+#: ../src/generic/prntdlgg.cpp:872
+msgid "Right margin (mm):"
+msgstr "Sağ kenar boşluğu (mm):"
+
+#: ../src/generic/prntdlgg.cpp:873
+msgid "Bottom margin (mm):"
+msgstr "Alt kenar boşluğu (mm):"
+
+#: ../src/generic/prntdlgg.cpp:896
+msgid "Printer..."
+msgstr "Yazıcı..."
+
+#: ../src/generic/progdlgg.cpp:246
+msgid "&Skip"
+msgstr "A&tla"
+
+#: ../src/generic/progdlgg.cpp:347 ../src/generic/progdlgg.cpp:626
+msgid "Unknown"
+msgstr "Bilinmeyen"
+
+#: ../src/generic/progdlgg.cpp:451 ../src/msw/progdlg.cpp:526
+msgid "Done."
+msgstr "Tamamlandı."
+
+#: ../src/generic/srchctlg.cpp:55 ../src/gtk/srchctrl.cpp:206
+#: ../src/html/helpwnd.cpp:530 ../src/html/helpwnd.cpp:545
+msgid "Search"
+msgstr "Arama"
+
+#: ../src/generic/tabg.cpp:1026
+msgid "Could not find tab for id"
+msgstr "Kodun sekmesi bulunamadı"
+
+#: ../src/generic/tipdlg.cpp:136
+msgid "Tips not available, sorry!"
+msgstr "Ne yazık ki bir ipucu yok!"
+
+#: ../src/generic/tipdlg.cpp:197
+msgid "Tip of the Day"
+msgstr "Günün ipucu"
+
+#: ../src/generic/tipdlg.cpp:207
+msgid "Did you know..."
+msgstr "Biliyor musunuz..."
+
+#: ../src/generic/tipdlg.cpp:232
+msgid "&Show tips at startup"
+msgstr "İpuçları &başlangıçta görüntülensin"
+
+#: ../src/generic/tipdlg.cpp:236
+msgid "&Next Tip"
+msgstr "So&nraki ipucu"
+
+#: ../src/generic/wizard.cpp:411
+msgid "&Next >"
+msgstr "So&nraki >"
+
+#: ../src/generic/wizard.cpp:412
+msgid "&Finish"
+msgstr "&Bitti"
+
+#: ../src/generic/wizard.cpp:420
+msgid "< &Back"
+msgstr "< &Geri"
+
+#: ../src/gtk/aboutdlg.cpp:204
+msgid "translator-credits"
+msgstr "çevirmenler"
+
+#: ../src/gtk/app.cpp:517
+msgid ""
+"WARNING: using XIM input method is unsupported and may result in problems "
+"with input handling and flickering. Consider unsetting GTK_IM_MODULE or "
+"setting to \"ibus\"."
+msgstr ""
+"Uyarı: XIM giriş yönteminin kullanılması desteklenmez ve giriş işlemesiyle "
+"ve titremeyle ilgili sorunlara neden olabilir. GTK_IM_MODULE ayarını "
+"kaldırmayı ya da \"ibus\" olarak ayarlamayı düşünün."
+
+#: ../src/gtk/app.cpp:569
+msgid "Unable to initialize GTK+, is DISPLAY set properly?"
+msgstr "GTK+ başlatılamadı, DISPLAY düzgün ayarlanmış mı?"
+
+#: ../src/gtk/filedlg.cpp:89 ../src/gtk/filepicker.cpp:255
+#, c-format
+msgid "Changing current directory to \"%s\" failed"
+msgstr "Geçerli klasör \"%s\" olarak değiştirilemedi"
+
+#: ../src/gtk/font.cpp:548
+msgid ""
+"Using private fonts is not supported on this system: Pango library is too "
+"old, 1.38 or later required."
+msgstr ""
+"Bu sistem üzerinde özel fontların kullanımı desteklenmiyor: Pango kitaplığı "
+"çok eski. 1.38 ya da üzerindeki bir sürüm gereklidir."
+
+#: ../src/gtk/font.cpp:558
+msgid "Failed to create font configuration object."
+msgstr "Font yapılandırma nesnesi eklenemedi."
+
+#: ../src/gtk/font.cpp:568
+#, c-format
+msgid "Failed to add custom font \"%s\"."
+msgstr "\"%s\" özel font eklenemedi."
+
+#: ../src/gtk/font.cpp:576
+msgid "Failed to register font configuration using private fonts."
+msgstr "Özel fontlar kullanılarak font yapılandırması kaydedilemedi."
+
+#: ../src/gtk/glcanvas.cpp:117 ../src/gtk/glcanvas.cpp:132
+msgid "Fatal Error"
+msgstr "Ciddi sorun"
+
+#: ../src/gtk/glcanvas.cpp:117
+msgid ""
+"This program wasn't compiled with EGL support required under Wayland, "
+"either\n"
+"install EGL libraries and rebuild or run it under X11 backend by setting\n"
+"environment variable GDK_BACKEND=x11 before starting your program."
+msgstr ""
+"Bu program Wayland altında EGL desteği ile derlenmemiş. EGL kitaplıklarını "
+"kurun \n"
+"ve yeniden oluşturun ya da uygulamayı başlatmadan önce GDK_BACKEND=x11 \n"
+"ortam değişkenini ayarlayıp, uygulamayı X11 arka yüzü üzerinde çalıştırın."
+
+#: ../src/gtk/glcanvas.cpp:132
+msgid ""
+"wxGLCanvas is only supported on Wayland and X11 currently.  You may be able "
+"to\n"
+"work around this by setting environment variable GDK_BACKEND=x11 before\n"
+"starting your program."
+msgstr ""
+"wxGLCanvas şu anda yalnızca Wayland ve X11 üzerinde destekleniyor. "
+"Uygulamayı\n"
+"başlatmadan önce GDK_BACKEND=x11 ortam değişkenini ayarlayıp, uygulamayı \n"
+"X11 arka yüzü üzerinde çalıştırarak bu sorunu çözebilirsiniz."
+
+#: ../src/gtk/mdi.cpp:433
+msgid "MDI child"
+msgstr "MDI alt"
+
+#: ../src/gtk/power.cpp:188
+#, c-format
+msgid "Failed to open D-Bus connection to the login manager: %s"
+msgstr "Giriş yöneticisine D-Bus bağlantısı açılamadı: %s"
+
+#: ../src/gtk/power.cpp:214
+msgid "wxWidgets application"
+msgstr "wxWidgets uygulaması"
+
+#: ../src/gtk/power.cpp:226
+msgid "Application needs to keep running"
+msgstr "Uygulamanın çalışmaya devam etmesi gerekiyor."
+
+#: ../src/gtk/power.cpp:233
+msgid "Clean up before suspend"
+msgstr "Kapanmadan önce temizle"
+
+#: ../src/gtk/power.cpp:259
+#, c-format
+msgid "Failed to inhibit sleep: %s"
+msgstr "Uyku engellenemedi: %s"
+
+#: ../src/gtk/power.cpp:265
+msgid "Unexpected response to D-Bus \"Inhibit\" request."
+msgstr "D-Bus ‘Inhibit’ isteğine beklenmeyen yanıt alındı."
+
+#: ../src/gtk/print.cpp:218
+msgid "Custom size"
+msgstr "Özel boyut"
+
+#: ../src/gtk/print.cpp:752
+#, c-format
+msgid "Error while printing: %s"
+msgstr "Yazdırırken hata oluştu: %s"
+
+#: ../src/gtk/print.cpp:816
+msgid "Page Setup"
+msgstr "Sayfa düzeni"
+
+#: ../src/gtk/webview_webkit.cpp:932
+msgid "Retrieving JavaScript script output is not supported with WebKit v1"
+msgstr "WebKit v1 üzerinde JavaScript çıktısının alınması desteklenmiyor"
+
+#: ../src/gtk/webview_webkit2.cpp:1098
+msgid ""
+"Setting proxy is not supported by WebKit, at least version 2.16 is required."
+msgstr ""
+"Proxy ayarı WebKit tarafından desteklenmiyor, en az 2.16 sürümü gereklidir."
+
+#: ../src/gtk/webview_webkit2.cpp:1104
+msgid "This program was compiled without support for setting WebKit proxy."
+msgstr "Bu program, WebKit proxy ayarları için destek olmadan derlendi."
+
+#: ../src/gtk/window.cpp:6289
+msgid ""
+"GTK+ installed on this machine is too old to support screen compositing, "
+"please install GTK+ 2.12 or later."
+msgstr ""
+"Yüklü GTK+ çok eski ve ekran karmayı desteklemiyor. Lütfen GTK+ 2.12 ya da "
+"üzeri bir sürüm yükleyin."
+
+#: ../src/gtk/window.cpp:6307
+msgid ""
+"Compositing not supported by this system, please enable it in your Window "
+"Manager."
+msgstr ""
+"Sistemin birleştirme (compositing) desteği etkin değil. Lütfen Pencere "
+"Yöneticinizden etkinleştirin."
+
+#: ../src/gtk/window.cpp:6318
+msgid ""
+"This program was compiled with a too old version of GTK+, please rebuild "
+"with GTK+ 2.12 or newer."
+msgstr ""
+"Bu program çok eski bir GTK+ sürümüyle derlenmiş. Lütfen GTK+ 2.12 ya da "
+"üzeri bir sürümle yeniden derleyin."
+
+#: ../src/html/chm.cpp:138
+#, c-format
+msgid "Failed to open CHM archive '%s'."
+msgstr "'%s' CHM arşivi açılamadı."
+
+#: ../src/html/chm.cpp:270
+#, c-format
+msgid "Could not extract %s into %s: %s"
+msgstr "%s %s içine ayıklanamadı: %s"
+
+#: ../src/html/chm.cpp:324
+msgid "no error"
+msgstr "hata yok"
+
+#: ../src/html/chm.cpp:326
+msgid "bad arguments to library function"
+msgstr "kitaplık işlevi için değişkenler hatalı"
+
+#: ../src/html/chm.cpp:328
+msgid "error opening file"
+msgstr "dosya açılırken sorun çıktı"
+
+#: ../src/html/chm.cpp:330
+msgid "read error"
+msgstr "okuma sorunu"
+
+#: ../src/html/chm.cpp:332
+msgid "write error"
+msgstr "yazma sorunu"
+
+#: ../src/html/chm.cpp:334
+msgid "seek error"
+msgstr "tarama hatası"
+
+#: ../src/html/chm.cpp:338
+msgid "bad signature"
+msgstr "kötü imza"
+
+#: ../src/html/chm.cpp:340
+msgid "error in data format"
+msgstr "veri biçimi hatası"
+
+#: ../src/html/chm.cpp:342
+msgid "checksum error"
+msgstr "sağlama toplamı hatası"
+
+#: ../src/html/chm.cpp:344
+msgid "compression error"
+msgstr "sıkıştırma hatası"
+
+#: ../src/html/chm.cpp:346
+msgid "decompression error"
+msgstr "ayıklama hatası"
+
+#: ../src/html/chm.cpp:437
+#, c-format
+msgid "Could not locate file '%s'."
+msgstr "'%s' dosyası bulunamadı."
+
+#: ../src/html/chm.cpp:711
+#, c-format
+msgid "Could not create temporary file '%s'"
+msgstr "'%s' geçici dosyası oluşturulamadı."
+
+#: ../src/html/chm.cpp:718
+#, c-format
+msgid "Extraction of '%s' into '%s' failed."
+msgstr "'%s'', '%s' içine açılamadı."
+
+#: ../src/html/chm.cpp:806 ../src/html/chm.cpp:863
+msgid "CHM handler currently supports only local files!"
+msgstr "CHM işleyici şimdilik yalnızca yerel dosyaları destekliyor!"
+
+#: ../src/html/chm.cpp:827
+msgid "Link contained '//', converted to absolute link."
+msgstr "Bağlantı '//' içeriyor, mutlak bağlantıya dönüştürüldü."
+
+#: ../src/html/helpctrl.cpp:59
+#, c-format
+msgid "Help: %s"
+msgstr "Yardım: %s"
+
+#: ../src/html/helpctrl.cpp:155
+#, c-format
+msgid "Adding book %s"
+msgstr "%s kitabı ekleniyor"
+
+#: ../src/html/helpdata.cpp:295
+#, c-format
+msgid "Cannot open contents file: %s"
+msgstr "%s içerik dosyası açılamadı"
+
+#: ../src/html/helpdata.cpp:309
+#, c-format
+msgid "Cannot open index file: %s"
+msgstr "%s dizin dosyası açılamadı"
+
+#: ../src/html/helpdata.cpp:643
+msgid "noname"
+msgstr "adsız"
+
+#: ../src/html/helpdata.cpp:652
+#, c-format
+msgid "Cannot open HTML help book: %s"
+msgstr "%s HTML yardım kitabı açılamadı"
+
+#: ../src/html/helpwnd.cpp:315
+msgid "Displays help as you browse the books on the left."
+msgstr "Soldaki kitapları gezilirken yardım görüntülenir."
+
+#: ../src/html/helpwnd.cpp:411 ../src/html/helpwnd.cpp:1100
+#: ../src/html/helpwnd.cpp:1735
+msgid "(bookmarks)"
+msgstr "(yer imleri)"
+
+#: ../src/html/helpwnd.cpp:424
+msgid "Add current page to bookmarks"
+msgstr "Geçerli sayfayı yer imlerine ekle"
+
+#: ../src/html/helpwnd.cpp:425
+msgid "Remove current page from bookmarks"
+msgstr "Geçerli sayfayı yer imlerinden sil"
+
+#: ../src/html/helpwnd.cpp:470
+msgid "Contents"
+msgstr "İçerik"
+
+#: ../src/html/helpwnd.cpp:485
+msgid "Find"
+msgstr "Bul"
+
+#: ../src/html/helpwnd.cpp:487
+msgid "Show all"
+msgstr "Tümünü görüntüle"
+
+#: ../src/html/helpwnd.cpp:497
+msgid ""
+"Display all index items that contain given substring. Search is case "
+"insensitive."
+msgstr ""
+"Verilen alt dizgeyi içeren tüm dizin elemanları görüntülensin. Arama küçük-"
+"büyük harfe duyarlıdır."
+
+#: ../src/html/helpwnd.cpp:498
+msgid "Show all items in index"
+msgstr "Dizindeki tüm ögeleri görüntüle"
+
+#: ../src/html/helpwnd.cpp:528
+msgid "Case sensitive"
+msgstr "Büyük küçük harfe duyarlı"
+
+#: ../src/html/helpwnd.cpp:529
+msgid "Whole words only"
+msgstr "Yalnızca tam sözcükler"
+
+#: ../src/html/helpwnd.cpp:532
+msgid ""
+"Search contents of help book(s) for all occurrences of the text you typed "
+"above"
+msgstr "Yukarıya yazılan metin yardım kitapları içinde her şekilde aranır"
+
+#: ../src/html/helpwnd.cpp:653
+msgid "Show/hide navigation panel"
+msgstr "Gezinti panosunu görüntüle/gizle"
+
+#: ../src/html/helpwnd.cpp:655
+msgid "Go back"
+msgstr "Geri git"
+
+#: ../src/html/helpwnd.cpp:656
+msgid "Go forward"
+msgstr "İleri git"
+
+#: ../src/html/helpwnd.cpp:658
+msgid "Go one level up in document hierarchy"
+msgstr "Belge hiyerarşisinde bir düzey yukarı git"
+
+#: ../src/html/helpwnd.cpp:666 ../src/html/helpwnd.cpp:1547
+msgid "Open HTML document"
+msgstr "HTML belgesi aç"
+
+#: ../src/html/helpwnd.cpp:670
+msgid "Print this page"
+msgstr "Bu sayfayı yazdır"
+
+#: ../src/html/helpwnd.cpp:674
+msgid "Display options dialog"
+msgstr "Ayarlar penceresi görüntülensin"
+
+#: ../src/html/helpwnd.cpp:795
+msgid "Please choose the page to display:"
+msgstr "Lütfen görüntülenecek sayfayı seçin:"
+
+#: ../src/html/helpwnd.cpp:796
+msgid "Help Topics"
+msgstr "Yardım konuları"
+
+#: ../src/html/helpwnd.cpp:852
+msgid "Searching..."
+msgstr "Aranıyor..."
+
+#: ../src/html/helpwnd.cpp:853
+msgid "No matching page found yet"
+msgstr "Henüz eşleşen bir sayfa bulunamadı"
+
+#: ../src/html/helpwnd.cpp:870
+#, c-format
+msgid "Found %i matches"
+msgstr "%i sonuç bulundu"
+
+#: ../src/html/helpwnd.cpp:958
+msgid "(Help)"
+msgstr "(Yardım)"
+
+#: ../src/html/helpwnd.cpp:1026
+#, c-format
+msgid "%d of %lu"
+msgstr "%d / %lu"
+
+#: ../src/html/helpwnd.cpp:1028
+#, c-format
+msgid "%lu of %lu"
+msgstr "%lu / %lu"
+
+#: ../src/html/helpwnd.cpp:1047
+msgid "Search in all books"
+msgstr "Tüm kitaplarda arama"
+
+#: ../src/html/helpwnd.cpp:1193
+msgid "Help Browser Options"
+msgstr "Yardım tarayıcısı ayarları"
+
+#: ../src/html/helpwnd.cpp:1198
+msgid "Normal font:"
+msgstr "Normal font:"
+
+#: ../src/html/helpwnd.cpp:1199
+msgid "Fixed font:"
+msgstr "Sabit font:"
+
+#: ../src/html/helpwnd.cpp:1200
+msgid "Font size:"
+msgstr "Font boyutu:"
+
+#: ../src/html/helpwnd.cpp:1245
+msgid "font size"
+msgstr "font boyutu"
+
+#: ../src/html/helpwnd.cpp:1256
+msgid "Normal face<br>and <u>underlined</u>. "
+msgstr "Normal font<br>ve <u>altıçizili</u>. "
+
+#: ../src/html/helpwnd.cpp:1257
+msgid "<i>Italic face.</i> "
+msgstr "<i>İtalik şekil.</i> "
+
+#: ../src/html/helpwnd.cpp:1258
+msgid "<b>Bold face.</b> "
+msgstr "<b>Kalın şekil.</b> "
+
+#: ../src/html/helpwnd.cpp:1259
+msgid "<b><i>Bold italic face.</i></b><br>"
+msgstr "<b><i>Kalın italik şekil.</i></b><br>"
+
+#: ../src/html/helpwnd.cpp:1262
+msgid "Fixed size face.<br> <b>bold</b> <i>italic</i> "
+msgstr "Sabit boyutlu tür.<br> <b>kalın</b> <i>italik</i> "
+
+#: ../src/html/helpwnd.cpp:1263
+msgid "<b><i>bold italic <u>underlined</u></i></b><br>"
+msgstr "<b><i>kalın italik<u>altıçizili</u></i></b><br>"
+
+#: ../src/html/helpwnd.cpp:1524
+msgid "Help Printing"
+msgstr "Yardım yazdırma"
+
+#: ../src/html/helpwnd.cpp:1527
+msgid "Cannot print empty page."
+msgstr "Boş sayfa yazdırılamaz."
+
+#: ../src/html/helpwnd.cpp:1540
+msgid "HTML files (*.html;*.htm)|*.html;*.htm|"
+msgstr "HTML dosyaları (*.html;*.htm)|*.html;*.htm|"
+
+#: ../src/html/helpwnd.cpp:1541
+msgid "Help books (*.htb)|*.htb|Help books (*.zip)|*.zip|"
+msgstr "Yardım kitapları (*.htb)|*.htb|Yardım kitapları (*.zip)|*.zip|"
+
+#: ../src/html/helpwnd.cpp:1542
+msgid "HTML Help Project (*.hhp)|*.hhp|"
+msgstr "HTML yardım projesi (*.hhp)|*.hhp|"
+
+#: ../src/html/helpwnd.cpp:1544
+msgid "Compressed HTML Help file (*.chm)|*.chm|"
+msgstr "Sıkıştırılmış HTML yardım dosyası (*.chm)|*.chm|"
+
+#: ../src/html/helpwnd.cpp:1671
+#, c-format
+msgid "%i of %u"
+msgstr "%i / %u"
+
+#: ../src/html/helpwnd.cpp:1709
+#, c-format
+msgid "%u of %u"
+msgstr "%u / %u"
+
+#: ../src/html/htmlfilt.cpp:134
+#, c-format
+msgid "Cannot open HTML document: %s"
+msgstr "%s HTML belgesi açılamadı"
+
+#: ../src/html/htmlwin.cpp:599
+msgid "Connecting..."
+msgstr "Bağlantı kuruluyor.."
+
+#: ../src/html/htmlwin.cpp:616
+#, c-format
+msgid "Unable to open requested HTML document: %s"
+msgstr "İstenen HTML belgesi açılamıyor: %s"
+
+#: ../src/html/htmlwin.cpp:630
+msgid "Loading : "
+msgstr "Yükleniyor : "
+
+#: ../src/html/htmlwin.cpp:673
+msgid "Done"
+msgstr "Tamamlandı"
+
+#: ../src/html/htmlwin.cpp:723
+#, c-format
+msgid "HTML anchor %s does not exist."
+msgstr "%s HTML çapası bulunamadı."
+
+#: ../src/html/htmlwin.cpp:1057
+#, c-format
+msgid "Copied to clipboard:\"%s\""
+msgstr "\"%s\" panoya kopyalandı."
+
+#: ../src/html/htmprint.cpp:269
+msgid ""
+"This document doesn't fit on the page horizontally and will be truncated "
+"when it is printed."
+msgstr "Bu belge sayfaya yatay olarak sığmıyor ve yazdırılırsa budanacak."
+
+#: ../src/html/htmprint.cpp:285
+#, c-format
+msgid ""
+"The document \"%s\" doesn't fit on the page horizontally and will be "
+"truncated if printed.\n"
+"\n"
+"Would you like to proceed with printing it nevertheless?"
+msgstr ""
+"\"%s\" belgesi sayfaya yatay olarak sığmıyor ve yazdırılırsa budanacak.\n"
+"\n"
+"Buna rağmen yazdırmak istiyor musunuz?"
+
+#: ../src/html/htmprint.cpp:296
+msgid ""
+"If possible, try changing the layout parameters to make the printout more "
+"narrow."
+msgstr ""
+"Olabiliyorsa, çıktıyı daraltmak için sayfa ayarlarını değiştirmeyi deneyin."
+
+#: ../src/html/htmprint.cpp:445
+msgid ": file does not exist!"
+msgstr ": dosya bulunamadı!"
+
+#. TRANSLATORS: %s may be a document title.
+#: ../src/html/htmprint.cpp:717
+#, c-format
+msgid "%s Preview"
+msgstr "%s Önizlemesi"
+
+#: ../src/html/htmprint.cpp:755 ../src/richtext/richtextprint.cpp:618
+msgid ""
+"There was a problem during page setup: you may need to set a default printer."
+msgstr ""
+"Sayfa ayarlanırken bir sorun çıktı: Varsayılan bir yazıcı belirlemeniz "
+"gerekebilir."
+
+#: ../src/msw/clipbrd.cpp:80
+msgid "Failed to open the clipboard."
+msgstr "Pano açılamadı."
+
+#: ../src/msw/clipbrd.cpp:101
+msgid "Failed to close the clipboard."
+msgstr "Pano kapatılamadı."
+
+#: ../src/msw/clipbrd.cpp:113
+msgid "Failed to empty the clipboard."
+msgstr "Pano temizlenemedi."
+
+#: ../src/msw/clipbrd.cpp:284
+msgid "Failed to put data on the clipboard"
+msgstr "Veri panoya konulamadı"
+
+#: ../src/msw/clipbrd.cpp:326
+msgid "Failed to get data from the clipboard"
+msgstr "Panodan veri alınamadı"
+
+#: ../src/msw/clipbrd.cpp:363
+msgid "Failed to retrieve the supported clipboard formats"
+msgstr "Desteklenen pano biçimleri alınamadı"
+
+#: ../src/msw/colordlg.cpp:228
+#, c-format
+msgid "Colour selection dialog failed with error %0lx."
+msgstr "Renk seçimi penceresi %0lx hatasıyla kapandı."
+
+#: ../src/msw/cursor.cpp:141
+msgid "Failed to create cursor."
+msgstr "İmleç oluşturulamadı."
+
+#: ../src/msw/dde.cpp:279
+#, c-format
+msgid "Failed to register DDE server '%s'"
+msgstr "'%s' DDE sunucusuna kayıt olunamadı"
+
+#: ../src/msw/dde.cpp:300
+#, c-format
+msgid "Failed to unregister DDE server '%s'"
+msgstr "'%s' DDE sunucusundan kayıt iptali yapılamadı"
+
+#: ../src/msw/dde.cpp:428
+#, c-format
+msgid "Failed to create connection to server '%s' on topic '%s'"
+msgstr "'%s' sunucusuna '%s' konusundan bağlantı kurulamadı"
+
+#: ../src/msw/dde.cpp:655
+msgid "DDE poke request failed"
+msgstr "DDE itme isteği yapılamadı"
+
+#: ../src/msw/dde.cpp:674
+msgid "Failed to establish an advise loop with DDE server"
+msgstr "DDE sunucusuyla danışma döngüsü sağlanamadı"
+
+#: ../src/msw/dde.cpp:693
+msgid "Failed to terminate the advise loop with DDE server"
+msgstr "DDE sunucusuyla danışma döngüsü sonlandırılamadı"
+
+#: ../src/msw/dde.cpp:768
+msgid "Failed to send DDE advise notification"
+msgstr "DDE danışma uyarısı gönderilemedi"
+
+#: ../src/msw/dde.cpp:1085
+msgid "Failed to create DDE string"
+msgstr "DDE dizgesi oluşturulamadı"
+
+#: ../src/msw/dde.cpp:1131
+msgid "no DDE error."
+msgstr "DDE bulunamadı hatası."
+
+#: ../src/msw/dde.cpp:1135
+msgid "a request for a synchronous advise transaction has timed out."
+msgstr "eşzamanlı danışma hareketi isteği zaman aşımına uğradı."
+
+#: ../src/msw/dde.cpp:1138
+msgid "the response to the transaction caused the DDE_FBUSY bit to be set."
+msgstr "harekete yanıt DDE_FBUSY bayrak bitinin kaldırılmasına yol açtı."
+
+#: ../src/msw/dde.cpp:1141
+msgid "a request for a synchronous data transaction has timed out."
+msgstr "eşzamanlı veri hareketi isteği zaman aşımına uğradı."
+
+#: ../src/msw/dde.cpp:1144
+msgid ""
+"a DDEML function was called without first calling the DdeInitialize "
+"function,\n"
+"or an invalid instance identifier\n"
+"was passed to a DDEML function."
+msgstr ""
+"bir DDEML işlevi önceden DdeInitialize işlevi çağrılmadan çağrıldı,\n"
+"ya da DDEML işlevine geçersiz bir \n"
+"örnek tanımlayıcısı gönderildi."
+
+#: ../src/msw/dde.cpp:1147
+msgid ""
+"an application initialized as APPCLASS_MONITOR has\n"
+"attempted to perform a DDE transaction,\n"
+"or an application initialized as APPCMD_CLIENTONLY has \n"
+"attempted to perform server transactions."
+msgstr ""
+"APPCLASS_MONITOR olarak başlatılmış bir uygulama\n"
+"DDE hareketi gerçekleştirmeyi denedi,\n"
+"ya da APPCMD_CLIENTONLY olarak başlatılmış bir uygulama\n"
+"sunucu hareketi gerçekleştirmeyi denedi."
+
+#: ../src/msw/dde.cpp:1150
+msgid "a request for a synchronous execute transaction has timed out."
+msgstr "eşzamanlı çalıştırma hareketi isteği zaman aşımına uğradı."
+
+#: ../src/msw/dde.cpp:1153
+msgid "a parameter failed to be validated by the DDEML."
+msgstr "parametre DDEML tarafından doğrulanamadı."
+
+#: ../src/msw/dde.cpp:1156
+msgid "a DDEML application has created a prolonged race condition."
+msgstr "bir DDEML uygulaması uzun koşu durumu oluşturdu."
+
+#: ../src/msw/dde.cpp:1159
+msgid "a memory allocation failed."
+msgstr "bellek ayrılamadı."
+
+#: ../src/msw/dde.cpp:1162
+msgid "a client's attempt to establish a conversation has failed."
+msgstr "bir istemcinin konuşma başlatma denemesi başarısız oldu."
+
+#: ../src/msw/dde.cpp:1165
+msgid "a transaction failed."
+msgstr "bir hareket tamamlanamadı."
+
+#: ../src/msw/dde.cpp:1168
+msgid "a request for a synchronous poke transaction has timed out."
+msgstr "eşzamanlı itme hareketi isteği zaman aşımına uğradı."
+
+#: ../src/msw/dde.cpp:1171
+msgid "an internal call to the PostMessage function has failed. "
+msgstr "PostMessage işlevine iç çağrı yapılamadı. "
+
+#: ../src/msw/dde.cpp:1174
+msgid "reentrancy problem."
+msgstr "yeniden giriş sorunu."
+
+#: ../src/msw/dde.cpp:1177
+msgid ""
+"a server-side transaction was attempted on a conversation\n"
+"that was terminated by the client, or the server\n"
+"terminated before completing a transaction."
+msgstr ""
+"istemci tarafından sonlandırılmış bir görüşme üstünde\n"
+"sunucu tarafında bir hareket denendi, ya da sunucu\n"
+"hareket tamamlanmadan sonlandırıldı."
+
+#: ../src/msw/dde.cpp:1180
+msgid "an internal error has occurred in the DDEML."
+msgstr "DDEML içinde bir sorun çıktı."
+
+#: ../src/msw/dde.cpp:1183
+msgid "a request to end an advise transaction has timed out."
+msgstr "danışma hareketi bitirme isteği zaman aşımına uğradı."
+
+#: ../src/msw/dde.cpp:1186
+msgid ""
+"an invalid transaction identifier was passed to a DDEML function.\n"
+"Once the application has returned from an XTYP_XACT_COMPLETE callback,\n"
+"the transaction identifier for that callback is no longer valid."
+msgstr ""
+"DDEML işlevine geçersiz hareket kimliği gönderilmiş.\n"
+"Uygulama XTYP_XACT_COMPLETE çağrısından döndüğünde\n"
+"bu çağrının hareket kimliği geçersiz olacak."
+
+#: ../src/msw/dde.cpp:1189
+#, c-format
+msgid "Unknown DDE error %08x"
+msgstr "Bilinmeyen DDE hatası %08x"
+
+#: ../src/msw/dialup.cpp:343
+msgid ""
+"Dial up functions are unavailable because the remote access service (RAS) is "
+"not installed on this machine. Please install it."
+msgstr ""
+"Uzaktan erişim hizmeti (RAS) kurulu olmadığı için arama işlevleri "
+"kullanılamıyor. Lütfen kurun."
+
+#: ../src/msw/dialup.cpp:402
+#, c-format
+msgid ""
+"The version of remote access service (RAS) installed on this machine is too "
+"old, please upgrade (the following required function is missing: %s)."
+msgstr ""
+"Bu bilgisayarda kurulu uzak erişim hizmetinin (RAS) sürümü çok eski, lütfen "
+"yükseltin (gereken şu işlev eksik: %s)."
+
+#: ../src/msw/dialup.cpp:437
+msgid "Failed to retrieve text of RAS error message"
+msgstr "RAS hata iletisi metni alınamadı"
+
+#: ../src/msw/dialup.cpp:440
+#, c-format
+msgid "unknown error (error code %08x)."
+msgstr "bilinmeyen sorun (hata kodu %08x)."
+
+#: ../src/msw/dialup.cpp:492
+#, c-format
+msgid "Cannot find active dialup connection: %s"
+msgstr "Etkin çevirmeli bağlantı bulunamadı: %s"
+
+#: ../src/msw/dialup.cpp:513
+msgid "Several active dialup connections found, choosing one randomly."
+msgstr "Birkaç etkin çevirmeli bağlantı bulundu, rastgele biri seçiliyor."
+
+#: ../src/msw/dialup.cpp:598 ../src/msw/dialup.cpp:832
+#, c-format
+msgid "Failed to establish dialup connection: %s"
+msgstr "Çevirmeli bağlantı kurulamadı: %s"
+
+#: ../src/msw/dialup.cpp:664
+#, c-format
+msgid "Failed to get ISP names: %s"
+msgstr "ISS adları alınamadı: %s"
+
+#: ../src/msw/dialup.cpp:712
+msgid "Failed to connect: no ISP to dial."
+msgstr "Bağlantı kurulamadı: Aranacak hizmet sağlayıcı yok."
+
+#: ../src/msw/dialup.cpp:732
+msgid "Choose ISP to dial"
+msgstr "Aranacak hizmet sağlayıcıyı seçin"
+
+#: ../src/msw/dialup.cpp:733
+msgid "Please choose which ISP do you want to connect to"
+msgstr "Lütfen bağlanmak istediğiniz hizmet sağlayıcıyı seçin"
+
+#: ../src/msw/dialup.cpp:766
+msgid "Failed to connect: missing username/password."
+msgstr "Bağlantı kurulamadı: Kullanıcı adı/parola eksik."
+
+#: ../src/msw/dialup.cpp:796
+msgid "Cannot find the location of address book file"
+msgstr "Adres defteri dosyasının yeri bulunamadı"
+
+#: ../src/msw/dialup.cpp:827
+#, c-format
+msgid "Failed to initiate dialup connection: %s"
+msgstr "Çevirmeli bağlantı başlatılamadı: %s"
+
+#: ../src/msw/dialup.cpp:897
+msgid "Cannot hang up - no active dialup connection."
+msgstr "Kapatılamadı - etkin çevirmeli bağlantı yok."
+
+#: ../src/msw/dialup.cpp:907
+#, c-format
+msgid "Failed to terminate the dialup connection: %s"
+msgstr "Çevirmeli bağlantı sonlandırılamadı: %s"
+
+#: ../src/msw/dib.cpp:313
+#, c-format
+msgid "Failed to save the bitmap image to file \"%s\"."
+msgstr "Bit eşlemi görüntüsü \"%s\" dosyasına kaydedilemedi."
+
+#: ../src/msw/dib.cpp:543
+#, c-format
+msgid "Failed to allocate %luKb of memory for bitmap data."
+msgstr "Bit eşlem verisi için %luKb bellek ayrılamadı."
+
+#: ../src/msw/dir.cpp:241
+#, c-format
+msgid "Cannot enumerate files in directory '%s'"
+msgstr "'%s' klasöründeki dosyalar sayılamadı"
+
+#: ../src/msw/dirdlg.cpp:368
+msgid "Couldn't obtain folder name"
+msgstr "Klasör adı alınamadı"
+
+#: ../src/msw/dlmsw.cpp:163
+#, c-format
+msgid "(error %d: %s)"
+msgstr "(hata %d: %s)"
+
+#: ../src/msw/dragimag.cpp:143 ../src/msw/dragimag.cpp:178
+#: ../src/msw/imaglist.cpp:309 ../src/msw/imaglist.cpp:331
+msgid "Couldn't add an image to the image list."
+msgstr "Görsel listesine bir görsel eklenemedi."
+
+#: ../src/msw/enhmeta.cpp:94
+#, c-format
+msgid "Failed to load metafile from file \"%s\"."
+msgstr "\"%s\" dosyasından metafile yüklenemedi."
+
+#: ../src/msw/fdrepdlg.cpp:412
+#, c-format
+msgid "Failed to create the standard find/replace dialog (error code %d)"
+msgstr "Standart bul/değiştir penceresi oluşturulamadı (hata kodu %d)"
+
+#: ../src/msw/filedlg.cpp:1241
+msgid "Access to the file system is not allowed from secure desktop."
+msgstr "Güvenli masaüstünden dosya sistemine erişime izin verilmemektedir."
+
+#: ../src/msw/filedlg.cpp:1242
+msgid "Security warning"
+msgstr "Güvenlik Uyarısı"
+
+#: ../src/msw/filedlg.cpp:1533
+#, c-format
+msgid "File dialog failed with error code %0lx."
+msgstr "Dosya penceresi %0lx hata koduyla kapandı."
+
+#: ../src/msw/font.cpp:1120
+#, c-format
+msgid "Font file \"%s\" couldn't be loaded"
+msgstr "\"%s\" font dosyası yüklenemedi"
+
+#: ../src/msw/fontdlg.cpp:220
+#, c-format
+msgid "Common dialog failed with error code %0lx."
+msgstr "Ortak pencere %0lx hata koduyla kapandı."
+
+#: ../src/msw/fswatcher.cpp:67
+msgid "Ungraceful worker thread termination"
+msgstr "Uygunsuz iş parçacığı sonlandırması"
+
+#: ../src/msw/fswatcher.cpp:81
+msgid "Unable to create IOCP worker thread"
+msgstr "IOCP iş parçacığı oluşturulamadı"
+
+#: ../src/msw/fswatcher.cpp:88
+msgid "Unable to start IOCP worker thread"
+msgstr "IOCP iş parçacığı başlatılamadı"
+
+#: ../src/msw/fswatcher.cpp:140
+msgid "Monitoring individual files for changes is not supported currently."
+msgstr "Tek tek dosyaların değişiminin izlenmesi şu anda desteklenmiyor."
+
+#: ../src/msw/fswatcher.cpp:165
+#, c-format
+msgid "Unable to set up watch for '%s'"
+msgstr "'%s' izlemesi kurulamadı"
+
+#: ../src/msw/fswatcher.cpp:466
+#, c-format
+msgid "Can't monitor non-existent directory \"%s\" for changes."
+msgstr "\"%s\" klasörü bulunamadığından değişiklikleri izlenemiyor."
+
+#: ../src/msw/glcanvas.cpp:577 ../src/unix/glx11.cpp:507
+msgid "OpenGL 3.0 or later is not supported by the OpenGL driver."
+msgstr "OpenGL sürücüsü OpenGl 3.0 ve üzerini desteklemez."
+
+#: ../src/msw/glcanvas.cpp:601 ../src/osx/glcanvas_osx.cpp:395
+#: ../src/unix/glegl.cpp:304 ../src/unix/glx11.cpp:553
+msgid "Couldn't create OpenGL context"
+msgstr "OpenGL içeriği oluşturulamadı"
+
+#: ../src/msw/glcanvas.cpp:1294
+msgid "Failed to initialize OpenGL"
+msgstr "OpenGL başlatılamadı"
+
+#: ../src/msw/graphicsd2d.cpp:607
+msgid "Could not register custom DirectWrite font loader."
+msgstr "Özel DirectWrite font yükleyicisi kayıt edilemedi."
+
+#: ../src/msw/helpchm.cpp:48
+msgid ""
+"MS HTML Help functions are unavailable because the MS HTML Help library is "
+"not installed on this machine. Please install it."
+msgstr ""
+"MS HTML Yardım kitaplığı yüklü olmadığından yardım işlevleri kullanılamıyor. "
+"Lütfen yükleyin."
+
+#: ../src/msw/helpchm.cpp:55
+msgid "Failed to initialize MS HTML Help."
+msgstr "MS HTML Yardım başlatılamadı."
+
+#: ../src/msw/iniconf.cpp:458
+#, c-format
+msgid "Can't delete the INI file '%s'"
+msgstr "'%s' INI dosyası silinemedi"
+
+#: ../src/msw/listctrl.cpp:995
+#, c-format
+msgid "Couldn't retrieve information about list control item %d."
+msgstr "%d liste denetimi ögesi hakkında bilgi alınamadı."
+
+#: ../src/msw/mdi.cpp:170 ../src/qt/mdi.cpp:253
+msgid "&Cascade"
+msgstr "Ard arda &diz"
+
+#: ../src/msw/mdi.cpp:171
+msgid "Tile &Horizontally"
+msgstr "&Yatay döşe"
+
+#: ../src/msw/mdi.cpp:172
+msgid "Tile &Vertically"
+msgstr "&Dikey döşe"
+
+#: ../src/msw/mdi.cpp:174
+msgid "&Arrange Icons"
+msgstr "Si&mgeleri düzenle"
+
+#: ../src/msw/mdi.cpp:621
+msgid "Failed to create MDI parent frame."
+msgstr "MDI üst çerçevesi oluşturulamadı."
+
+#: ../src/msw/mimetype.cpp:234
+#, c-format
+msgid "Failed to create registry entry for '%s' files."
+msgstr "'%s' dosyaları için kayıt anahtarı oluşturulamadı."
+
+#: ../src/msw/ole/automtn.cpp:495
+#, c-format
+msgid "Failed to find CLSID of \"%s\""
+msgstr "\"%s\" için CLSID bulunamadı"
+
+#: ../src/msw/ole/automtn.cpp:512
+#, c-format
+msgid "Failed to create an instance of \"%s\""
+msgstr "\"%s\" kopyası oluşturulamadı"
+
+#: ../src/msw/ole/automtn.cpp:552
+#, c-format
+msgid "Cannot get an active instance of \"%s\""
+msgstr "Çalışan bir \"%s\" kopyası bulunamadı"
+
+#: ../src/msw/ole/automtn.cpp:564
+#, c-format
+msgid "Failed to get OLE automation interface for \"%s\""
+msgstr "\"%s\" için OLE otomasyonu arayüzü getirilemedi"
+
+#: ../src/msw/ole/automtn.cpp:621
+msgid "Unknown name or named argument."
+msgstr "Argüman bilinmiyor ya da adlandırılmış."
+
+#: ../src/msw/ole/automtn.cpp:625
+msgid "Incorrect number of arguments."
+msgstr "Argüman sayısı hatalı."
+
+#: ../src/msw/ole/automtn.cpp:637
+msgid "Unknown exception"
+msgstr "Bilinmeyen istisna"
+
+#: ../src/msw/ole/automtn.cpp:642
+msgid "Method or property not found."
+msgstr "Yordam ya da özellik bulunamadı."
+
+#: ../src/msw/ole/automtn.cpp:646
+msgid "Overflow while coercing argument values."
+msgstr "Argüman değerleri zorlanırken taşma."
+
+#: ../src/msw/ole/automtn.cpp:650
+msgid "Object implementation does not support named arguments."
+msgstr "Nesne uygulaması adlandırılmış argümanları desteklemiyor."
+
+#: ../src/msw/ole/automtn.cpp:654
+msgid "The locale ID is unknown."
+msgstr "Yerel kodu bilinmiyor."
+
+#: ../src/msw/ole/automtn.cpp:658
+msgid "Missing a required parameter."
+msgstr "Gereken bir parametre eksik."
+
+#: ../src/msw/ole/automtn.cpp:662
+#, c-format
+msgid "Argument %u not found."
+msgstr "%u argümanı bulunamadı."
+
+#: ../src/msw/ole/automtn.cpp:666
+#, c-format
+msgid "Type mismatch in argument %u."
+msgstr "%u argümanında tür uyuşmazlığı."
+
+#: ../src/msw/ole/automtn.cpp:670
+msgid "The system cannot find the file specified."
+msgstr "Sistem belirtilen dosyayı bulamadı."
+
+#: ../src/msw/ole/automtn.cpp:674
+msgid "Class not registered."
+msgstr "Sınıf kaydedilmemiş."
+
+#: ../src/msw/ole/automtn.cpp:678
+#, c-format
+msgid "Unknown error %08x"
+msgstr "Bilinmeyen hata %08x"
+
+#: ../src/msw/ole/automtn.cpp:682
+#, c-format
+msgid "OLE Automation error in %s: %s"
+msgstr "%s içinde OLE otomasyonu hatası: %s"
+
+#: ../src/msw/ole/dataobj.cpp:385
+#, c-format
+msgid "Couldn't register clipboard format '%s'."
+msgstr "'%s' pano biçimi kaydedilemedi."
+
+#: ../src/msw/ole/dataobj.cpp:402
+#, c-format
+msgid "The clipboard format '%d' doesn't exist."
+msgstr "'%d' pano biçimi bulunamıyor."
+
+#: ../src/msw/progdlg.cpp:1025
+msgid "Skip"
+msgstr "Atla"
+
+#: ../src/msw/registry.cpp:141
+#, c-format
+msgid "unknown (%lu)"
+msgstr "bilinmiyor (%lu)"
+
+#: ../src/msw/registry.cpp:409
+#, c-format
+msgid "Can't get info about registry key '%s'"
+msgstr "'%s' kayıt anahtarı hakkında bilgi alınamadı"
+
+#: ../src/msw/registry.cpp:445
+#, c-format
+msgid "Can't open registry key '%s'"
+msgstr "'%s' kayıt anahtarı açılamadı"
+
+#: ../src/msw/registry.cpp:478
+#, c-format
+msgid "Can't create registry key '%s'"
+msgstr "'%s' kayıt anahtarı oluşturulamadı"
+
+#: ../src/msw/registry.cpp:497
+#, c-format
+msgid "Can't close registry key '%s'"
+msgstr "'%s' kayıt anahtarı kapatılamadı"
+
+#: ../src/msw/registry.cpp:512
+#, c-format
+msgid "Registry value '%s' already exists."
+msgstr "'%s' kayıt değeri zaten var."
+
+#: ../src/msw/registry.cpp:520
+#, c-format
+msgid "Failed to rename registry value '%s' to '%s'."
+msgstr "'%s' kayıt değeri '%s' olarak yeniden adlandırılamadı."
+
+#: ../src/msw/registry.cpp:575
+#, c-format
+msgid "Can't copy values of unsupported type %d."
+msgstr "Desteklenmeyen %d türünün değerleri kopyalanamadı."
+
+#: ../src/msw/registry.cpp:586
+#, c-format
+msgid "Registry key '%s' does not exist, cannot rename it."
+msgstr "'%s' kayıt anahtarı bulunamadığından yeniden adlandırılamıyor."
+
+#: ../src/msw/registry.cpp:617
+#, c-format
+msgid "Registry key '%s' already exists."
+msgstr "'%s' kayıt anahtarı zaten var."
+
+#: ../src/msw/registry.cpp:625
+#, c-format
+msgid "Failed to rename the registry key '%s' to '%s'."
+msgstr "'%s' kayıt anahtarı '%s' olarak yeniden adlandırılamadı."
+
+#: ../src/msw/registry.cpp:670
+#, c-format
+msgid "Failed to copy the registry subkey '%s' to '%s'."
+msgstr "'%s' kayıt alt anahtarı '%s' içine kopyalanamadı."
+
+#: ../src/msw/registry.cpp:683
+#, c-format
+msgid "Failed to copy registry value '%s'"
+msgstr "'%s' kayıt değeri kopyalanamadı"
+
+#: ../src/msw/registry.cpp:692
+#, c-format
+msgid "Failed to copy the contents of registry key '%s' to '%s'."
+msgstr "'%s' kayıt anahtarının içeriği '%s' içine kopyalanamadı."
+
+#: ../src/msw/registry.cpp:718
+#, c-format
+msgid ""
+"Registry key '%s' is needed for normal system operation,\n"
+"deleting it will leave your system in unusable state:\n"
+"operation aborted."
+msgstr ""
+"'%s' kayıt anahtarı normal sistem işlemleri için gerekiyor,\n"
+"silinmesi sistemi kararsız bir hale getirir:\n"
+"işlem iptal edildi."
+
+#: ../src/msw/registry.cpp:754
+#, c-format
+msgid "Can't delete key '%s'"
+msgstr "'%s' anahtarı silinemedi"
+
+#: ../src/msw/registry.cpp:782
+#, c-format
+msgid "Can't delete value '%s' from key '%s'"
+msgstr "'%s' değeri '%s' anahtarından silinemiyor"
+
+#: ../src/msw/registry.cpp:855 ../src/msw/registry.cpp:887
+#: ../src/msw/registry.cpp:929 ../src/msw/registry.cpp:1000
+#, c-format
+msgid "Can't read value of key '%s'"
+msgstr "'%s' anahtarının değeri okunamadı"
+
+#: ../src/msw/registry.cpp:873 ../src/msw/registry.cpp:915
+#: ../src/msw/registry.cpp:963 ../src/msw/registry.cpp:1106
+#, c-format
+msgid "Can't set value of '%s'"
+msgstr "'%s' değeri değiştirilemedi"
+
+#: ../src/msw/registry.cpp:894 ../src/msw/registry.cpp:943
+#, c-format
+msgid "Registry value \"%s\" is not numeric (but of type %s)"
+msgstr "\"%s\" kayıt değeri sayısal değil (ancak %s türünde)"
+
+#: ../src/msw/registry.cpp:979
+#, c-format
+msgid "Registry value \"%s\" is not binary (but of type %s)"
+msgstr "\"%s\" kayıt değeri ikili değil (ancak %s türünde)"
+
+#: ../src/msw/registry.cpp:1028
+#, c-format
+msgid "Registry value \"%s\" is not text (but of type %s)"
+msgstr "\"%s\" kayıt değeri metin değil (ancak %s türünde)"
+
+#: ../src/msw/registry.cpp:1089
+#, c-format
+msgid "Can't read value of '%s'"
+msgstr "'%s'' değeri okunamadı"
+
+#: ../src/msw/registry.cpp:1157
+#, c-format
+msgid "Can't enumerate values of key '%s'"
+msgstr "'%s' anahtarının değerleri sayılamadı"
+
+#: ../src/msw/registry.cpp:1196
+#, c-format
+msgid "Can't enumerate subkeys of key '%s'"
+msgstr "'%s' anahtarının alt anahtarları sayılamadı"
+
+#: ../src/msw/registry.cpp:1262
+#, c-format
+msgid ""
+"Exporting registry key: file \"%s\" already exists and won't be overwritten."
+msgstr "Kayıt anahtarı verme: \"%s\" dosyası zaten var, üstüne yazılmayacak."
+
+#: ../src/msw/registry.cpp:1411
+#, c-format
+msgid "Can't export value of unsupported type %d."
+msgstr "Desteklenmeyen %d türünün değeri verilemedi."
+
+#: ../src/msw/registry.cpp:1427
+#, c-format
+msgid "Ignoring value \"%s\" of the key \"%s\"."
+msgstr "\"%s\" değeri \"%s\" anahtarı için yok sayılıyor."
+
+#: ../src/msw/textctrl.cpp:596
+msgid ""
+"Impossible to create a rich edit control, using simple text control instead. "
+"Please reinstall riched32.dll"
+msgstr ""
+"Zengin metin denetimi oluşturulamıyor. Onun yerine basit metin denetimi "
+"kullanılacak. Lütfen riched32.dll kitaplığını yeniden yükleyin"
+
+#: ../src/msw/thread.cpp:522 ../src/unix/threadpsx.cpp:850
+msgid "Cannot start thread: error writing TLS."
+msgstr "İş parçacığı başlatılamadı: TLS yazma hatası."
+
+#: ../src/msw/thread.cpp:613
+msgid "Can't set thread priority"
+msgstr "İş parçacığının önceliği ayarlanamadı"
+
+#: ../src/msw/thread.cpp:649
+msgid "Can't create thread"
+msgstr "İş parçacığı oluşturulamadı"
+
+#: ../src/msw/thread.cpp:668
+msgid "Couldn't terminate thread"
+msgstr "İş parçacığı sonlandırılamadı"
+
+#: ../src/msw/thread.cpp:799
+msgid "Cannot wait for thread termination"
+msgstr "İş parçacığının sonlanması beklenemiyor"
+
+#: ../src/msw/thread.cpp:873
+#, c-format
+msgid "Cannot suspend thread %lx"
+msgstr "%lx iş parçacığı beklemeye alınamadı"
+
+#: ../src/msw/thread.cpp:903
+#, c-format
+msgid "Cannot resume thread %lx"
+msgstr "%lx iş parçacığı sürdürülemiyor"
+
+#: ../src/msw/thread.cpp:932
+msgid "Couldn't get the current thread pointer"
+msgstr "Geçerli iş parçacığı imleci alınamadı"
+
+#: ../src/msw/thread.cpp:1333
+msgid ""
+"Thread module initialization failed: impossible to allocate index in thread "
+"local storage"
+msgstr "İş parçacığı modülü başlatılamadı: Yerel depoda dizin oluşturulamıyor"
+
+#: ../src/msw/thread.cpp:1345
+msgid ""
+"Thread module initialization failed: cannot store value in thread local "
+"storage"
+msgstr "İş parçacığı modülü başlatılamadı: Yerel depoya değer koyulamıyor"
+
+#: ../src/msw/timer.cpp:133
+msgid "Couldn't create a timer"
+msgstr "Bir zamanlayıcı oluşturulamadı"
+
+#: ../src/msw/utils.cpp:372
+msgid "can't find user's HOME, using current directory."
+msgstr "kullanıcının klasörü bulunamadığından geçerli klasör kullanılamadı."
+
+#: ../src/msw/utils.cpp:662
+#, c-format
+msgid "Failed to kill process %d"
+msgstr "%d işlemi sonlandırılamadı"
+
+#: ../src/msw/utils.cpp:986
+#, c-format
+msgid "Failed to load resource \"%s\"."
+msgstr "\"%s\" kaynağı yüklenemedi."
+
+#: ../src/msw/utils.cpp:993
+#, c-format
+msgid "Failed to lock resource \"%s\"."
+msgstr "\"%s\" kaynağı kilitlenemedi."
+
+#. TRANSLATORS: MS Windows build number
+#: ../src/msw/utils.cpp:1209
+#, c-format
+msgid "build %lu"
+msgstr "yapım %lu"
+
+#: ../src/msw/utils.cpp:1218
+msgid ", 64-bit edition"
+msgstr ", 64-bit sürümü"
+
+#: ../src/msw/utilsexc.cpp:224
+msgid "Failed to create an anonymous pipe"
+msgstr "Anonim bir tünel oluşturulamadı"
+
+#: ../src/msw/utilsexc.cpp:697
+msgid "Failed to redirect the child process IO"
+msgstr "Alt iş giriş/çıkışı yönlendirilemedi"
+
+#: ../src/msw/utilsexc.cpp:870
+#, c-format
+msgid "Execution of command '%s' failed"
+msgstr "'%s' komutu yürütülemedi"
+
+#: ../src/msw/volume.cpp:337
+msgid "Failed to load mpr.dll."
+msgstr "mpr.dll yüklenemedi."
+
+#: ../src/msw/volume.cpp:506
+#, c-format
+msgid "Cannot read typename from '%s'!"
+msgstr "'%s' içinden tür adı okunamadı!"
+
+#: ../src/msw/volume.cpp:615
+#, c-format
+msgid "Cannot load icon from '%s'."
+msgstr "'%s' içinden simge yüklenemedi."
+
+#: ../src/msw/webview_edge.cpp:285
+msgid "This program was compiled without support for setting Edge proxy."
+msgstr "Bu program, Edge proxy ayarları için destek olmadan derlendi."
+
+#: ../src/msw/webview_ie.cpp:1010
+msgid "Failed to find web view emulation level in the registry"
+msgstr "Kayıt defterinde internet görünümü benzetimi düzeyi bulunamadı"
+
+#: ../src/msw/webview_ie.cpp:1019
+msgid "Failed to set web view to modern emulation level"
+msgstr "İnternet görünümü modern benzetim düzeyine ayarlanamadı"
+
+#: ../src/msw/webview_ie.cpp:1027
+msgid "Failed to reset web view to standard emulation level"
+msgstr "İnternet görünümü standart benzetim düzeyine sıfırlanamadı"
+
+#: ../src/msw/webview_ie.cpp:1049
+msgid "Can't run JavaScript script without a valid HTML document"
+msgstr "Geçerli bir HTML belgesi olmadan JavaScript betiği çalıştırılamaz"
+
+#: ../src/msw/webview_ie.cpp:1056
+msgid "Can't get the JavaScript object"
+msgstr "JavaScript nesnesi alınamadı"
+
+#: ../src/msw/webview_ie.cpp:1070
+msgid "failed to evaluate"
+msgstr "değerlendirilemedi"
+
+#: ../src/osx/cocoa/filedlg.mm:412
+msgid "File type:"
+msgstr "Dosya türü:"
+
+#: ../src/osx/cocoa/menu.mm:242
+msgctxt "macOS menu name"
+msgid "Window"
+msgstr "Pencere"
+
+#: ../src/osx/cocoa/menu.mm:259
+msgctxt "macOS menu name"
+msgid "Help"
+msgstr "Yardım"
+
+#: ../src/osx/cocoa/menu.mm:298
+msgctxt "macOS menu item"
+msgid "Minimize"
+msgstr "Küçült"
+
+#: ../src/osx/cocoa/menu.mm:303
+msgctxt "macOS menu item"
+msgid "Zoom"
+msgstr "Yakınlaştır"
+
+#: ../src/osx/cocoa/menu.mm:309
+msgctxt "macOS menu item"
+msgid "Bring All to Front"
+msgstr "Tümünü öne getir"
+
+#: ../src/osx/core/sound.cpp:143
+#, c-format
+msgid "Failed to load sound from \"%s\" (error %d)."
+msgstr "\"%s\" üzerinden ses yüklenemedi (hata %d)."
+
+#: ../src/osx/fontutil.cpp:80
+#, c-format
+msgid "Font file \"%s\" doesn't exist."
+msgstr "\"%s\" font dosyası bulunamadı."
+
+#: ../src/osx/fontutil.cpp:88
+#, c-format
+msgid ""
+"Font file \"%s\" cannot be used as it is not inside the font directory "
+"\"%s\"."
+msgstr ""
+"\"%s\" font dosyası, \"%s\" font klasöründe bulunamadığından kullanılamaz."
+
+#: ../src/osx/menu_osx.cpp:496
+#, c-format
+msgctxt "macOS menu item"
+msgid "About %s"
+msgstr "%s Hakkında"
+
+#: ../src/osx/menu_osx.cpp:499
+msgctxt "macOS menu item"
+msgid "About..."
+msgstr "Hakkında..."
+
+#: ../src/osx/menu_osx.cpp:508
+msgctxt "macOS menu item"
+msgid "Preferences..."
+msgstr "Ayarlar..."
+
+#: ../src/osx/menu_osx.cpp:512
+msgctxt "macOS menu item"
+msgid "Services"
+msgstr "Hizmetler"
+
+#: ../src/osx/menu_osx.cpp:519
+#, c-format
+msgctxt "macOS menu item"
+msgid "Hide %s"
+msgstr "%s gizle"
+
+#: ../src/osx/menu_osx.cpp:522
+msgctxt "macOS menu item"
+msgid "Hide Application"
+msgstr "Uygulamayı gizle"
+
+#: ../src/osx/menu_osx.cpp:526
+msgctxt "macOS menu item"
+msgid "Hide Others"
+msgstr "Diğerlerini gizle"
+
+#: ../src/osx/menu_osx.cpp:528
+msgctxt "macOS menu item"
+msgid "Show All"
+msgstr "Tümünü görüntüle"
+
+#: ../src/osx/menu_osx.cpp:534
+#, c-format
+msgctxt "macOS menu item"
+msgid "Quit %s"
+msgstr "%s uygulamasından çıkın"
+
+#: ../src/osx/menu_osx.cpp:537
+msgctxt "macOS menu item"
+msgid "Quit Application"
+msgstr "Uygulamadan çık"
+
+#: ../src/osx/webview_webkit.mm:444
+msgid "Printing is not supported by the system web control"
+msgstr "Sistem web denetimi tarafından yazdırma desteklenmiyor"
+
+#: ../src/osx/webview_webkit.mm:453
+msgid "Print operation could not be initialized"
+msgstr "Yazdırma işlemi başlatılamadı"
+
+#. TRANSLATORS: Label of font point size
+#: ../src/propgrid/advprops.cpp:605
+msgid "Point Size"
+msgstr "Punto boyutu"
+
+#. TRANSLATORS: Label of font face name
+#: ../src/propgrid/advprops.cpp:615
+msgid "Face Name"
+msgstr "Font Adı"
+
+#. TRANSLATORS: Label of font style
+#: ../src/propgrid/advprops.cpp:623 ../src/richtext/richtextformatdlg.cpp:331
+msgid "Style"
+msgstr "Stil"
+
+#. TRANSLATORS: Label of font weight
+#: ../src/propgrid/advprops.cpp:628
+msgid "Weight"
+msgstr "Yoğunluk"
+
+#. TRANSLATORS: Label of underlined font
+#: ../src/propgrid/advprops.cpp:633 ../src/richtext/richtextfontpage.cpp:358
+msgid "Underlined"
+msgstr "Altıçizili"
+
+#. TRANSLATORS: Label of font family
+#: ../src/propgrid/advprops.cpp:637
+msgid "Family"
+msgstr "Aile"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:801
+msgid "AppWorkspace"
+msgstr "UygulamaAlanı"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:802
+msgid "ActiveBorder"
+msgstr "EtkinKenarlık"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:803
+msgid "ActiveCaption"
+msgstr "EtkinBaşlık"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:804
+msgid "ButtonFace"
+msgstr "DüğmeÖnyüzü"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:805
+msgid "ButtonHighlight"
+msgstr "DüğmeVurgusu"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:806
+msgid "ButtonShadow"
+msgstr "DüğmeGölgesi"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:807
+msgid "ButtonText"
+msgstr "DüğmeMetni"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:808
+msgid "CaptionText"
+msgstr "BaşlıkMetni"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:809
+msgid "ControlDark"
+msgstr "DenetimKoyu"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:810
+msgid "ControlLight"
+msgstr "DenetimAçık"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:812
+msgid "GrayText"
+msgstr "GriMetin"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:813
+msgid "Highlight"
+msgstr "Vurgu"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:814
+msgid "HighlightText"
+msgstr "VurguMetni"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:815
+msgid "InactiveBorder"
+msgstr "DevreDışıKenarlık"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:816
+msgid "InactiveCaption"
+msgstr "DevreDışıBaşlık"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:817
+msgid "InactiveCaptionText"
+msgstr "DevreDışıBaşlıkMetni"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:818
+msgid "Menu"
+msgstr "Menü"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:819
+msgid "Scrollbar"
+msgstr "Kaydırma çubuğu"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:820
+msgid "Tooltip"
+msgstr "İpucu"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:821
+msgid "TooltipText"
+msgstr "İpucuMetni"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:822
+msgid "Window"
+msgstr "Pencere"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:823
+msgid "WindowFrame"
+msgstr "PencereÇerçevesi"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:824
+msgid "WindowText"
+msgstr "PencereMetni"
+
+#. TRANSLATORS: Custom colour choice entry
+#: ../src/propgrid/advprops.cpp:825 ../src/propgrid/advprops.cpp:1532
+#: ../src/propgrid/advprops.cpp:1576
+msgid "Custom"
+msgstr "İsteğe göre uyarlanmış"
+
+#: ../src/propgrid/advprops.cpp:1558
+msgid "Black"
+msgstr "Siyah"
+
+#: ../src/propgrid/advprops.cpp:1559
+msgid "Maroon"
+msgstr "Kestane"
+
+#: ../src/propgrid/advprops.cpp:1560
+msgid "Navy"
+msgstr "Lacivert"
+
+#: ../src/propgrid/advprops.cpp:1561
+msgid "Purple"
+msgstr "Mor"
+
+#: ../src/propgrid/advprops.cpp:1562
+msgid "Teal"
+msgstr "Yeşilimsi mavi"
+
+#: ../src/propgrid/advprops.cpp:1563
+msgid "Gray"
+msgstr "Gri"
+
+#: ../src/propgrid/advprops.cpp:1564
+msgid "Green"
+msgstr "Yeşil"
+
+#: ../src/propgrid/advprops.cpp:1565
+msgid "Olive"
+msgstr "Zeytin"
+
+#: ../src/propgrid/advprops.cpp:1566
+msgid "Brown"
+msgstr "Kahverengi"
+
+#: ../src/propgrid/advprops.cpp:1567
+msgid "Blue"
+msgstr "Mavi"
+
+#: ../src/propgrid/advprops.cpp:1568
+msgid "Fuchsia"
+msgstr "Fuşya"
+
+#: ../src/propgrid/advprops.cpp:1569
+msgid "Red"
+msgstr "Kırmızı"
+
+#: ../src/propgrid/advprops.cpp:1570
+msgid "Orange"
+msgstr "Turuncu"
+
+#: ../src/propgrid/advprops.cpp:1571
+msgid "Silver"
+msgstr "Gümüş"
+
+#: ../src/propgrid/advprops.cpp:1572
+msgid "Lime"
+msgstr "Limon"
+
+#: ../src/propgrid/advprops.cpp:1573
+msgid "Aqua"
+msgstr "Deniz mavisi"
+
+#: ../src/propgrid/advprops.cpp:1574
+msgid "Yellow"
+msgstr "Sarı"
+
+#: ../src/propgrid/advprops.cpp:1575
+msgid "White"
+msgstr "Beyaz"
+
+#: ../src/propgrid/advprops.cpp:1718
+msgctxt "system cursor name"
+msgid "Default"
+msgstr "Varsayılan"
+
+#: ../src/propgrid/advprops.cpp:1719
+msgctxt "system cursor name"
+msgid "Arrow"
+msgstr "Ok"
+
+#: ../src/propgrid/advprops.cpp:1720
+msgctxt "system cursor name"
+msgid "Right Arrow"
+msgstr "Sağ ok"
+
+#: ../src/propgrid/advprops.cpp:1721
+msgctxt "system cursor name"
+msgid "Blank"
+msgstr "Boş"
+
+#: ../src/propgrid/advprops.cpp:1722
+msgctxt "system cursor name"
+msgid "Bullseye"
+msgstr "Hedef"
+
+#: ../src/propgrid/advprops.cpp:1723
+msgctxt "system cursor name"
+msgid "Character"
+msgstr "Karakter"
+
+#: ../src/propgrid/advprops.cpp:1724
+msgctxt "system cursor name"
+msgid "Cross"
+msgstr "Çarpı"
+
+#: ../src/propgrid/advprops.cpp:1725
+msgctxt "system cursor name"
+msgid "Hand"
+msgstr "El"
+
+#: ../src/propgrid/advprops.cpp:1726
+msgctxt "system cursor name"
+msgid "I-Beam"
+msgstr "I-Işını"
+
+#: ../src/propgrid/advprops.cpp:1727
+msgctxt "system cursor name"
+msgid "Left Button"
+msgstr "Sol düğme"
+
+#: ../src/propgrid/advprops.cpp:1728
+msgctxt "system cursor name"
+msgid "Magnifier"
+msgstr "Büyüteç"
+
+#: ../src/propgrid/advprops.cpp:1729
+msgctxt "system cursor name"
+msgid "Middle Button"
+msgstr "Orta düğme"
+
+#: ../src/propgrid/advprops.cpp:1730
+msgctxt "system cursor name"
+msgid "No Entry"
+msgstr "Kayıt yok"
+
+#: ../src/propgrid/advprops.cpp:1731
+msgctxt "system cursor name"
+msgid "Paint Brush"
+msgstr "Boya fırçası"
+
+#: ../src/propgrid/advprops.cpp:1732
+msgctxt "system cursor name"
+msgid "Pencil"
+msgstr "Kalem"
+
+#: ../src/propgrid/advprops.cpp:1733
+msgctxt "system cursor name"
+msgid "Point Left"
+msgstr "Sola ok"
+
+#: ../src/propgrid/advprops.cpp:1734
+msgctxt "system cursor name"
+msgid "Point Right"
+msgstr "Sağa ok"
+
+#: ../src/propgrid/advprops.cpp:1735
+msgctxt "system cursor name"
+msgid "Question Arrow"
+msgstr "Soru oku"
+
+#: ../src/propgrid/advprops.cpp:1736
+msgctxt "system cursor name"
+msgid "Right Button"
+msgstr "Sağ düğme"
+
+#: ../src/propgrid/advprops.cpp:1737
+msgctxt "system cursor name"
+msgid "Sizing NE-SW"
+msgstr "Boyutlandırma KD-GB"
+
+#: ../src/propgrid/advprops.cpp:1738
+msgctxt "system cursor name"
+msgid "Sizing N-S"
+msgstr "Boyutlandırma K-G"
+
+#: ../src/propgrid/advprops.cpp:1739
+msgctxt "system cursor name"
+msgid "Sizing NW-SE"
+msgstr "Boyutlandırma KB-GD"
+
+#: ../src/propgrid/advprops.cpp:1740
+msgctxt "system cursor name"
+msgid "Sizing W-E"
+msgstr "Boyutlandırma B-D"
+
+#: ../src/propgrid/advprops.cpp:1741
+msgctxt "system cursor name"
+msgid "Sizing"
+msgstr "Boyutlandırma"
+
+#: ../src/propgrid/advprops.cpp:1742
+msgctxt "system cursor name"
+msgid "Spraycan"
+msgstr "Sprey"
+
+#: ../src/propgrid/advprops.cpp:1743
+msgctxt "system cursor name"
+msgid "Wait"
+msgstr "Bekleme"
+
+#: ../src/propgrid/advprops.cpp:1744
+msgctxt "system cursor name"
+msgid "Watch"
+msgstr "İzleme"
+
+#: ../src/propgrid/advprops.cpp:1745
+msgctxt "system cursor name"
+msgid "Wait Arrow"
+msgstr "Bekleme oku"
+
+#: ../src/propgrid/advprops.cpp:2109
+msgid "Make a selection:"
+msgstr "Bir seçim yapın:"
+
+#: ../src/propgrid/manager.cpp:394
+msgid "Property"
+msgstr "Özellik"
+
+#: ../src/propgrid/manager.cpp:395
+msgid "Value"
+msgstr "Değer"
+
+#: ../src/propgrid/manager.cpp:1683
+msgid "Categorized Mode"
+msgstr "Kategorize kip"
+
+#: ../src/propgrid/manager.cpp:1709
+msgid "Alphabetic Mode"
+msgstr "Alfabetik kip"
+
+#. TRANSLATORS: Name of Boolean false value
+#: ../src/propgrid/propgrid.cpp:230
+msgid "False"
+msgstr "Yanlış"
+
+#. TRANSLATORS: Name of Boolean true value
+#: ../src/propgrid/propgrid.cpp:232
+msgid "True"
+msgstr "Doğru"
+
+#. TRANSLATORS: Text  displayed for unspecified value
+#: ../src/propgrid/propgrid.cpp:428
+msgid "Unspecified"
+msgstr "Belirtilmemiş"
+
+#. TRANSLATORS: Caption of message box displaying any property error
+#: ../src/propgrid/propgrid.cpp:3145 ../src/propgrid/propgrid.cpp:3282
+msgid "Property Error"
+msgstr "Özellik hatası"
+
+#: ../src/propgrid/propgrid.cpp:3259
+msgid "You have entered invalid value. Press ESC to cancel editing."
+msgstr ""
+"Geçersiz bir değer yazdınız, düzenlemeyi iptal etmek için ESC tuşuna basın."
+
+#: ../src/propgrid/propgrid.cpp:6608
+#, c-format
+msgid "Error in resource: %s"
+msgstr "%s kaynağında hata"
+
+#: ../src/propgrid/propgridiface.cpp:377
+#, c-format
+msgid ""
+"Type operation \"%s\" failed: Property labeled \"%s\" is of type \"%s\", NOT "
+"\"%s\"."
+msgstr ""
+"\"%s\" tür işlemi yapılamadı: Etiketlenen özellik \"%s\" \"%s\" türünde, "
+"\"%s\" türünde DEĞİL."
+
+#: ../src/propgrid/props.cpp:159
+#, c-format
+msgid "Unknown base %d. Base 10 will be used."
+msgstr "%d base bilinmiyor. Base 10 kullanılacak."
+
+#: ../src/propgrid/props.cpp:324
+#, c-format
+msgid "Value must be %s or higher."
+msgstr "Değer %s ya da daha büyük olmalı."
+
+#: ../src/propgrid/props.cpp:329 ../src/propgrid/props.cpp:356
+#, c-format
+msgid "Value must be between %s and %s."
+msgstr "Değer %s ile %s arasında olmalı."
+
+#: ../src/propgrid/props.cpp:351
+#, c-format
+msgid "Value must be %s or less."
+msgstr "Değer %s ya da daha küçük olmalı."
+
+#: ../src/propgrid/props.cpp:1058
+#, c-format
+msgid "Not %s"
+msgstr "%s değil"
+
+#: ../src/propgrid/props.cpp:1770
+msgid "Choose a directory:"
+msgstr "Bir klasör seçin:"
+
+#: ../src/propgrid/props.cpp:2055
+msgid "Choose a file"
+msgstr "Bir dosya seçin"
+
+#: ../src/qt/mdi.cpp:254
+msgid "&Tile"
+msgstr "&Döşeme"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:147
+#: ../src/richtext/richtextformatdlg.cpp:376
+msgid "Background"
+msgstr "Arka plan"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:159
+msgid "Background &colour:"
+msgstr "Arka plan &rengi:"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:161
+#: ../src/richtext/richtextbackgroundpage.cpp:163
+msgid "Enables a background colour."
+msgstr "Bir arka plan rengini etkinleştirir."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:167
+#: ../src/richtext/richtextbackgroundpage.cpp:169
+msgid "The background colour."
+msgstr "Arka plan rengi."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:178
+msgid "Shadow"
+msgstr "Gölge"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:193
+msgid "Use &shadow"
+msgstr "Gölge kullanıl&sın"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:195
+#: ../src/richtext/richtextbackgroundpage.cpp:197
+msgid "Enables a shadow."
+msgstr "Bir gölgeyi etkinleştirir."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:211
+msgid "&Horizontal offset:"
+msgstr "&Yatay kayma:"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:218
+#: ../src/richtext/richtextbackgroundpage.cpp:220
+msgid "The horizontal offset."
+msgstr "Yatay kayma."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:224
+#: ../src/richtext/richtextbackgroundpage.cpp:227
+#: ../src/richtext/richtextbackgroundpage.cpp:228
+#: ../src/richtext/richtextbackgroundpage.cpp:247
+#: ../src/richtext/richtextbackgroundpage.cpp:250
+#: ../src/richtext/richtextbackgroundpage.cpp:251
+#: ../src/richtext/richtextbackgroundpage.cpp:287
+#: ../src/richtext/richtextbackgroundpage.cpp:290
+#: ../src/richtext/richtextbackgroundpage.cpp:291
+#: ../src/richtext/richtextbackgroundpage.cpp:314
+#: ../src/richtext/richtextbackgroundpage.cpp:317
+#: ../src/richtext/richtextbackgroundpage.cpp:318
+#: ../src/richtext/richtextborderspage.cpp:252
+#: ../src/richtext/richtextborderspage.cpp:255
+#: ../src/richtext/richtextborderspage.cpp:256
+#: ../src/richtext/richtextborderspage.cpp:286
+#: ../src/richtext/richtextborderspage.cpp:289
+#: ../src/richtext/richtextborderspage.cpp:290
+#: ../src/richtext/richtextborderspage.cpp:320
+#: ../src/richtext/richtextborderspage.cpp:323
+#: ../src/richtext/richtextborderspage.cpp:324
+#: ../src/richtext/richtextborderspage.cpp:354
+#: ../src/richtext/richtextborderspage.cpp:357
+#: ../src/richtext/richtextborderspage.cpp:358
+#: ../src/richtext/richtextborderspage.cpp:420
+#: ../src/richtext/richtextborderspage.cpp:423
+#: ../src/richtext/richtextborderspage.cpp:424
+#: ../src/richtext/richtextborderspage.cpp:454
+#: ../src/richtext/richtextborderspage.cpp:457
+#: ../src/richtext/richtextborderspage.cpp:458
+#: ../src/richtext/richtextborderspage.cpp:488
+#: ../src/richtext/richtextborderspage.cpp:491
+#: ../src/richtext/richtextborderspage.cpp:492
+#: ../src/richtext/richtextborderspage.cpp:522
+#: ../src/richtext/richtextborderspage.cpp:525
+#: ../src/richtext/richtextborderspage.cpp:526
+#: ../src/richtext/richtextborderspage.cpp:590
+#: ../src/richtext/richtextborderspage.cpp:593
+#: ../src/richtext/richtextborderspage.cpp:594
+#: ../src/richtext/richtextfontpage.cpp:177
+#: ../src/richtext/richtextmarginspage.cpp:199
+#: ../src/richtext/richtextmarginspage.cpp:201
+#: ../src/richtext/richtextmarginspage.cpp:202
+#: ../src/richtext/richtextmarginspage.cpp:224
+#: ../src/richtext/richtextmarginspage.cpp:226
+#: ../src/richtext/richtextmarginspage.cpp:227
+#: ../src/richtext/richtextmarginspage.cpp:247
+#: ../src/richtext/richtextmarginspage.cpp:249
+#: ../src/richtext/richtextmarginspage.cpp:250
+#: ../src/richtext/richtextmarginspage.cpp:272
+#: ../src/richtext/richtextmarginspage.cpp:274
+#: ../src/richtext/richtextmarginspage.cpp:275
+#: ../src/richtext/richtextmarginspage.cpp:313
+#: ../src/richtext/richtextmarginspage.cpp:315
+#: ../src/richtext/richtextmarginspage.cpp:316
+#: ../src/richtext/richtextmarginspage.cpp:338
+#: ../src/richtext/richtextmarginspage.cpp:340
+#: ../src/richtext/richtextmarginspage.cpp:341
+#: ../src/richtext/richtextmarginspage.cpp:361
+#: ../src/richtext/richtextmarginspage.cpp:363
+#: ../src/richtext/richtextmarginspage.cpp:364
+#: ../src/richtext/richtextmarginspage.cpp:386
+#: ../src/richtext/richtextmarginspage.cpp:388
+#: ../src/richtext/richtextmarginspage.cpp:389
+#: ../src/richtext/richtextsizepage.cpp:337
+#: ../src/richtext/richtextsizepage.cpp:340
+#: ../src/richtext/richtextsizepage.cpp:341
+#: ../src/richtext/richtextsizepage.cpp:371
+#: ../src/richtext/richtextsizepage.cpp:374
+#: ../src/richtext/richtextsizepage.cpp:375
+#: ../src/richtext/richtextsizepage.cpp:398
+#: ../src/richtext/richtextsizepage.cpp:401
+#: ../src/richtext/richtextsizepage.cpp:402
+#: ../src/richtext/richtextsizepage.cpp:425
+#: ../src/richtext/richtextsizepage.cpp:428
+#: ../src/richtext/richtextsizepage.cpp:429
+#: ../src/richtext/richtextsizepage.cpp:452
+#: ../src/richtext/richtextsizepage.cpp:455
+#: ../src/richtext/richtextsizepage.cpp:456
+#: ../src/richtext/richtextsizepage.cpp:479
+#: ../src/richtext/richtextsizepage.cpp:482
+#: ../src/richtext/richtextsizepage.cpp:483
+#: ../src/richtext/richtextsizepage.cpp:553
+#: ../src/richtext/richtextsizepage.cpp:556
+#: ../src/richtext/richtextsizepage.cpp:557
+#: ../src/richtext/richtextsizepage.cpp:588
+#: ../src/richtext/richtextsizepage.cpp:591
+#: ../src/richtext/richtextsizepage.cpp:592
+#: ../src/richtext/richtextsizepage.cpp:623
+#: ../src/richtext/richtextsizepage.cpp:626
+#: ../src/richtext/richtextsizepage.cpp:627
+#: ../src/richtext/richtextsizepage.cpp:658
+#: ../src/richtext/richtextsizepage.cpp:661
+#: ../src/richtext/richtextsizepage.cpp:662
+msgid "px"
+msgstr "piksel"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:225
+#: ../src/richtext/richtextbackgroundpage.cpp:248
+#: ../src/richtext/richtextbackgroundpage.cpp:288
+#: ../src/richtext/richtextbackgroundpage.cpp:315
+#: ../src/richtext/richtextborderspage.cpp:253
+#: ../src/richtext/richtextborderspage.cpp:287
+#: ../src/richtext/richtextborderspage.cpp:321
+#: ../src/richtext/richtextborderspage.cpp:355
+#: ../src/richtext/richtextborderspage.cpp:421
+#: ../src/richtext/richtextborderspage.cpp:455
+#: ../src/richtext/richtextborderspage.cpp:489
+#: ../src/richtext/richtextborderspage.cpp:523
+#: ../src/richtext/richtextborderspage.cpp:591
+#: ../src/richtext/richtextmarginspage.cpp:200
+#: ../src/richtext/richtextmarginspage.cpp:225
+#: ../src/richtext/richtextmarginspage.cpp:248
+#: ../src/richtext/richtextmarginspage.cpp:273
+#: ../src/richtext/richtextmarginspage.cpp:314
+#: ../src/richtext/richtextmarginspage.cpp:339
+#: ../src/richtext/richtextmarginspage.cpp:362
+#: ../src/richtext/richtextmarginspage.cpp:387
+#: ../src/richtext/richtextsizepage.cpp:338
+#: ../src/richtext/richtextsizepage.cpp:372
+#: ../src/richtext/richtextsizepage.cpp:399
+#: ../src/richtext/richtextsizepage.cpp:426
+#: ../src/richtext/richtextsizepage.cpp:453
+#: ../src/richtext/richtextsizepage.cpp:480
+#: ../src/richtext/richtextsizepage.cpp:554
+#: ../src/richtext/richtextsizepage.cpp:589
+#: ../src/richtext/richtextsizepage.cpp:624
+#: ../src/richtext/richtextsizepage.cpp:659
+msgid "cm"
+msgstr "cm"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:226
+#: ../src/richtext/richtextbackgroundpage.cpp:249
+#: ../src/richtext/richtextbackgroundpage.cpp:289
+#: ../src/richtext/richtextbackgroundpage.cpp:316
+#: ../src/richtext/richtextborderspage.cpp:254
+#: ../src/richtext/richtextborderspage.cpp:288
+#: ../src/richtext/richtextborderspage.cpp:322
+#: ../src/richtext/richtextborderspage.cpp:356
+#: ../src/richtext/richtextborderspage.cpp:422
+#: ../src/richtext/richtextborderspage.cpp:456
+#: ../src/richtext/richtextborderspage.cpp:490
+#: ../src/richtext/richtextborderspage.cpp:524
+#: ../src/richtext/richtextborderspage.cpp:592
+#: ../src/richtext/richtextfontpage.cpp:176
+#: ../src/richtext/richtextfontpage.cpp:179
+msgid "pt"
+msgstr "punto"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:229
+#: ../src/richtext/richtextbackgroundpage.cpp:231
+#: ../src/richtext/richtextbackgroundpage.cpp:252
+#: ../src/richtext/richtextbackgroundpage.cpp:254
+#: ../src/richtext/richtextbackgroundpage.cpp:292
+#: ../src/richtext/richtextbackgroundpage.cpp:294
+#: ../src/richtext/richtextbackgroundpage.cpp:319
+#: ../src/richtext/richtextbackgroundpage.cpp:321
+msgid "Units for this value."
+msgstr "Bu değerin birimleri."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:234
+msgid "&Vertical offset:"
+msgstr "&Dikey kayma:"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:241
+#: ../src/richtext/richtextbackgroundpage.cpp:243
+msgid "The vertical offset."
+msgstr "Dikey kayma."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:257
+msgid "Shadow c&olour:"
+msgstr "Gölge &rengi:"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:259
+#: ../src/richtext/richtextbackgroundpage.cpp:261
+msgid "Enables the shadow colour."
+msgstr "Gölge rengini etkinleştirir."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:265
+#: ../src/richtext/richtextbackgroundpage.cpp:267
+msgid "The shadow colour."
+msgstr "Gölge rengi."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:270
+msgid "Sh&adow spread:"
+msgstr "Gölge y&ayılması:"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:272
+#: ../src/richtext/richtextbackgroundpage.cpp:274
+msgid "Enables the shadow spread."
+msgstr "Gölge yayılmasını etkinleştirir."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:281
+#: ../src/richtext/richtextbackgroundpage.cpp:283
+msgid "The shadow spread."
+msgstr "Gölge yayılması."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:297
+msgid "&Blur distance:"
+msgstr "&Bulanıklık uzaklığı:"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:299
+#: ../src/richtext/richtextbackgroundpage.cpp:301
+msgid "Enables the blur distance."
+msgstr "Bulanıklık uzaklığını etkinleştirir."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:308
+#: ../src/richtext/richtextbackgroundpage.cpp:310
+msgid "The shadow blur distance."
+msgstr "Gölge bulanıklık uzaklığı."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:324
+msgid "Opaci&ty:"
+msgstr "Ma&tlık:"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:326
+#: ../src/richtext/richtextbackgroundpage.cpp:328
+msgid "Enables the shadow opacity."
+msgstr "Gölge matlığını etkinleştirir."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:335
+#: ../src/richtext/richtextbackgroundpage.cpp:337
+msgid "The shadow opacity."
+msgstr "Gölge matlığı."
+
+#. TRANSLATORS: Rich text page units (percentage)
+#: ../src/richtext/richtextbackgroundpage.cpp:340
+#: ../src/richtext/richtextsizepage.cpp:339
+#: ../src/richtext/richtextsizepage.cpp:373
+#: ../src/richtext/richtextsizepage.cpp:400
+#: ../src/richtext/richtextsizepage.cpp:427
+#: ../src/richtext/richtextsizepage.cpp:454
+#: ../src/richtext/richtextsizepage.cpp:481
+#: ../src/richtext/richtextsizepage.cpp:555
+#: ../src/richtext/richtextsizepage.cpp:590
+#: ../src/richtext/richtextsizepage.cpp:625
+#: ../src/richtext/richtextsizepage.cpp:660
+msgid "%"
+msgstr "%"
+
+#: ../src/richtext/richtextborderspage.cpp:229
+#: ../src/richtext/richtextborderspage.cpp:387
+msgid "Border"
+msgstr "Kenarlık"
+
+#: ../src/richtext/richtextborderspage.cpp:242
+#: ../src/richtext/richtextborderspage.cpp:410
+#: ../src/richtext/richtextindentspage.cpp:194
+#: ../src/richtext/richtextliststylepage.cpp:384
+#: ../src/richtext/richtextmarginspage.cpp:185
+#: ../src/richtext/richtextmarginspage.cpp:299
+#: ../src/richtext/richtextsizepage.cpp:531
+#: ../src/richtext/richtextsizepage.cpp:538
+msgid "&Left:"
+msgstr "So&l:"
+
+#: ../src/richtext/richtextborderspage.cpp:257
+#: ../src/richtext/richtextborderspage.cpp:259
+msgid "Units for the left border width."
+msgstr "Sol sınır genişliği birimleri."
+
+#: ../src/richtext/richtextborderspage.cpp:266
+#: ../src/richtext/richtextborderspage.cpp:268
+#: ../src/richtext/richtextborderspage.cpp:300
+#: ../src/richtext/richtextborderspage.cpp:302
+#: ../src/richtext/richtextborderspage.cpp:334
+#: ../src/richtext/richtextborderspage.cpp:336
+#: ../src/richtext/richtextborderspage.cpp:368
+#: ../src/richtext/richtextborderspage.cpp:370
+#: ../src/richtext/richtextborderspage.cpp:434
+#: ../src/richtext/richtextborderspage.cpp:436
+#: ../src/richtext/richtextborderspage.cpp:468
+#: ../src/richtext/richtextborderspage.cpp:470
+#: ../src/richtext/richtextborderspage.cpp:502
+#: ../src/richtext/richtextborderspage.cpp:504
+#: ../src/richtext/richtextborderspage.cpp:536
+#: ../src/richtext/richtextborderspage.cpp:538
+msgid "The border line style."
+msgstr "Kenarlık çizgisi stili."
+
+#: ../src/richtext/richtextborderspage.cpp:276
+#: ../src/richtext/richtextborderspage.cpp:444
+#: ../src/richtext/richtextindentspage.cpp:212
+#: ../src/richtext/richtextliststylepage.cpp:402
+#: ../src/richtext/richtextmarginspage.cpp:210
+#: ../src/richtext/richtextmarginspage.cpp:324
+#: ../src/richtext/richtextsizepage.cpp:601
+#: ../src/richtext/richtextsizepage.cpp:608
+msgid "&Right:"
+msgstr "&Sağ:"
+
+#: ../src/richtext/richtextborderspage.cpp:291
+#: ../src/richtext/richtextborderspage.cpp:293
+msgid "Units for the right border width."
+msgstr "Sağ sınır genişliği birimleri."
+
+#: ../src/richtext/richtextborderspage.cpp:310
+#: ../src/richtext/richtextborderspage.cpp:478
+#: ../src/richtext/richtextmarginspage.cpp:233
+#: ../src/richtext/richtextmarginspage.cpp:347
+#: ../src/richtext/richtextsizepage.cpp:566
+#: ../src/richtext/richtextsizepage.cpp:573
+msgid "&Top:"
+msgstr "Üs&t:"
+
+#: ../src/richtext/richtextborderspage.cpp:325
+#: ../src/richtext/richtextborderspage.cpp:327
+msgid "Units for the top border width."
+msgstr "Üst kenarlık genişliği birimleri."
+
+#: ../src/richtext/richtextborderspage.cpp:344
+#: ../src/richtext/richtextborderspage.cpp:512
+#: ../src/richtext/richtextmarginspage.cpp:258
+#: ../src/richtext/richtextmarginspage.cpp:372
+#: ../src/richtext/richtextsizepage.cpp:636
+#: ../src/richtext/richtextsizepage.cpp:643
+msgid "&Bottom:"
+msgstr "Al&t:"
+
+#: ../src/richtext/richtextborderspage.cpp:359
+#: ../src/richtext/richtextborderspage.cpp:361
+msgid "Units for the bottom border width."
+msgstr "Alt kenarlık genişliğinin birimleri."
+
+#: ../src/richtext/richtextborderspage.cpp:380
+#: ../src/richtext/richtextborderspage.cpp:548
+msgid "&Synchronize values"
+msgstr "&Değerleri eşleştir"
+
+#: ../src/richtext/richtextborderspage.cpp:382
+#: ../src/richtext/richtextborderspage.cpp:384
+#: ../src/richtext/richtextborderspage.cpp:550
+#: ../src/richtext/richtextborderspage.cpp:552
+msgid "Check to edit all borders simultaneously."
+msgstr "Tüm kenarlıklara aynı anda uygulanması için işaretleyin."
+
+#: ../src/richtext/richtextborderspage.cpp:397
+#: ../src/richtext/richtextborderspage.cpp:555
+msgid "Outline"
+msgstr "Kontur"
+
+#: ../src/richtext/richtextborderspage.cpp:425
+#: ../src/richtext/richtextborderspage.cpp:427
+msgid "Units for the left outline width."
+msgstr "Sol kontur genişliği birimleri."
+
+#: ../src/richtext/richtextborderspage.cpp:459
+#: ../src/richtext/richtextborderspage.cpp:461
+msgid "Units for the right outline width."
+msgstr "Sağ kontur genişliği birimleri."
+
+#: ../src/richtext/richtextborderspage.cpp:493
+#: ../src/richtext/richtextborderspage.cpp:495
+msgid "Units for the top outline width."
+msgstr "Üst kontur genişliği birimleri."
+
+#: ../src/richtext/richtextborderspage.cpp:527
+#: ../src/richtext/richtextborderspage.cpp:529
+msgid "Units for the bottom outline width."
+msgstr "Alt kontur genişliğinin birimleri."
+
+#: ../src/richtext/richtextborderspage.cpp:565
+#: ../src/richtext/richtextborderspage.cpp:600
+msgid "Corner"
+msgstr "Köşe"
+
+#: ../src/richtext/richtextborderspage.cpp:574
+msgid "Corner &radius:"
+msgstr "Köşe ça&pı:"
+
+#: ../src/richtext/richtextborderspage.cpp:576
+#: ../src/richtext/richtextborderspage.cpp:578
+msgid "An optional corner radius for adding rounded corners."
+msgstr "Yuvarlak köşeler eklemek için isteğe bağlı köşe yarıçapı."
+
+#: ../src/richtext/richtextborderspage.cpp:584
+#: ../src/richtext/richtextborderspage.cpp:586
+msgid "The value of the corner radius."
+msgstr "Köşe yarıçapı değeri."
+
+#: ../src/richtext/richtextborderspage.cpp:595
+#: ../src/richtext/richtextborderspage.cpp:597
+msgid "Units for the corner radius."
+msgstr "Köşe yarıçapı birimi."
+
+#: ../src/richtext/richtextborderspage.cpp:609
+#: ../src/richtext/richtextsizepage.cpp:247
+#: ../src/richtext/richtextsizepage.cpp:251
+msgid "None"
+msgstr "Hiçbiri"
+
+#: ../src/richtext/richtextborderspage.cpp:610
+msgid "Solid"
+msgstr "Katı"
+
+#: ../src/richtext/richtextborderspage.cpp:611
+msgid "Dotted"
+msgstr "Noktalı"
+
+#: ../src/richtext/richtextborderspage.cpp:612
+msgid "Dashed"
+msgstr "Çizgili"
+
+#: ../src/richtext/richtextborderspage.cpp:613
+msgid "Double"
+msgstr "Çift"
+
+#: ../src/richtext/richtextborderspage.cpp:614
+msgid "Groove"
+msgstr "Groove"
+
+#: ../src/richtext/richtextborderspage.cpp:615
+msgid "Ridge"
+msgstr "Sırt"
+
+#: ../src/richtext/richtextborderspage.cpp:616
+msgid "Inset"
+msgstr "Gömme"
+
+#: ../src/richtext/richtextborderspage.cpp:617
+msgid "Outset"
+msgstr "Kabartma"
+
+#: ../src/richtext/richtextbuffer.cpp:3518
+msgid "Change Style"
+msgstr "Stili değiştir"
+
+#: ../src/richtext/richtextbuffer.cpp:3701
+msgid "Change Object Style"
+msgstr "Nesne stilini değiştir"
+
+#: ../src/richtext/richtextbuffer.cpp:3974
+#: ../src/richtext/richtextbuffer.cpp:8174
+msgid "Change Properties"
+msgstr "Özellikleri değiştir"
+
+#: ../src/richtext/richtextbuffer.cpp:4346
+msgid "Change List Style"
+msgstr "Liste stilini değiştir"
+
+#: ../src/richtext/richtextbuffer.cpp:4519
+msgid "Renumber List"
+msgstr "Listeyi yeniden numarala"
+
+#: ../src/richtext/richtextbuffer.cpp:7867
+#: ../src/richtext/richtextbuffer.cpp:7897
+#: ../src/richtext/richtextbuffer.cpp:7939
+#: ../src/richtext/richtextctrl.cpp:1279 ../src/richtext/richtextctrl.cpp:1473
+msgid "Insert Text"
+msgstr "Metin ekle"
+
+#: ../src/richtext/richtextbuffer.cpp:8023
+#: ../src/richtext/richtextbuffer.cpp:8979
+msgid "Insert Image"
+msgstr "Görsel ekle"
+
+#: ../src/richtext/richtextbuffer.cpp:8070
+msgid "Insert Object"
+msgstr "Nesne ekle"
+
+#: ../src/richtext/richtextbuffer.cpp:8112
+msgid "Insert Field"
+msgstr "Alan ekle"
+
+#: ../src/richtext/richtextbuffer.cpp:8410
+msgid "Too many EndStyle calls!"
+msgstr "Çok fazla EndStyle çağrısı!"
+
+#: ../src/richtext/richtextbuffer.cpp:8785
+msgid "files"
+msgstr "dosyalar"
+
+#: ../src/richtext/richtextbuffer.cpp:9380
+msgid "standard/circle"
+msgstr "standart/daire"
+
+#: ../src/richtext/richtextbuffer.cpp:9381
+msgid "standard/circle-outline"
+msgstr "standart/daire-çerçeve"
+
+#: ../src/richtext/richtextbuffer.cpp:9382
+msgid "standard/square"
+msgstr "standart/kare"
+
+#: ../src/richtext/richtextbuffer.cpp:9383
+msgid "standard/diamond"
+msgstr "standart/elmas"
+
+#: ../src/richtext/richtextbuffer.cpp:9384
+msgid "standard/triangle"
+msgstr "standart/üçgen"
+
+#: ../src/richtext/richtextbuffer.cpp:9423
+msgid "Box Properties"
+msgstr "Kutu Özellikleri"
+
+#: ../src/richtext/richtextbuffer.cpp:10006
+msgid "Multiple Cell Properties"
+msgstr "Çoklu hücre özellikleri"
+
+#: ../src/richtext/richtextbuffer.cpp:10008
+msgid "Cell Properties"
+msgstr "Hücre özellikleri"
+
+#: ../src/richtext/richtextbuffer.cpp:11256
+msgid "Set Cell Style"
+msgstr "Hücre stilini ayarla"
+
+#: ../src/richtext/richtextbuffer.cpp:11330
+msgid "Delete Row"
+msgstr "Satırı sil"
+
+#: ../src/richtext/richtextbuffer.cpp:11380
+msgid "Delete Column"
+msgstr "Sütunu sil"
+
+#: ../src/richtext/richtextbuffer.cpp:11431
+msgid "Add Row"
+msgstr "Satır ekle"
+
+#: ../src/richtext/richtextbuffer.cpp:11494
+msgid "Add Column"
+msgstr "Sütun ekle"
+
+#: ../src/richtext/richtextbuffer.cpp:11537
+msgid "Table Properties"
+msgstr "Tablo özellikleri"
+
+#: ../src/richtext/richtextbuffer.cpp:12899
+msgid "Picture Properties"
+msgstr "Görsel özellikleri"
+
+#: ../src/richtext/richtextbuffer.cpp:13169
+#: ../src/richtext/richtextbuffer.cpp:13279
+msgid "image"
+msgstr "görsel"
+
+#: ../src/richtext/richtextbulletspage.cpp:145
+#: ../src/richtext/richtextliststylepage.cpp:209
+msgid "&Bullet style:"
+msgstr "&Madde imi stili:"
+
+#: ../src/richtext/richtextbulletspage.cpp:150
+#: ../src/richtext/richtextbulletspage.cpp:152
+#: ../src/richtext/richtextliststylepage.cpp:214
+#: ../src/richtext/richtextliststylepage.cpp:216
+msgid "The available bullet styles."
+msgstr "Kullanılabilecek madde imi stilleri."
+
+#: ../src/richtext/richtextbulletspage.cpp:158
+#: ../src/richtext/richtextliststylepage.cpp:221
+msgid "Peri&od"
+msgstr "N&okta"
+
+#: ../src/richtext/richtextbulletspage.cpp:160
+#: ../src/richtext/richtextbulletspage.cpp:162
+#: ../src/richtext/richtextliststylepage.cpp:223
+#: ../src/richtext/richtextliststylepage.cpp:225
+msgid "Check to add a period after the bullet."
+msgstr "Madde iminin ardına nokta eklenmesi için işaretleyin."
+
+#. TRANSLATORS: Bullet point in parentheses option
+#: ../src/richtext/richtextbulletspage.cpp:167
+#: ../src/richtext/richtextliststylepage.cpp:230
+msgid "(*)"
+msgstr "(*)"
+
+#: ../src/richtext/richtextbulletspage.cpp:169
+#: ../src/richtext/richtextbulletspage.cpp:171
+#: ../src/richtext/richtextliststylepage.cpp:232
+#: ../src/richtext/richtextliststylepage.cpp:234
+msgid "Check to enclose the bullet in parentheses."
+msgstr "Madde imini parantez içine almak için işaretleyin."
+
+#. TRANSLATORS: Right parenthesis bullet point option
+#: ../src/richtext/richtextbulletspage.cpp:176
+#: ../src/richtext/richtextliststylepage.cpp:239
+msgid "*)"
+msgstr "*)"
+
+#: ../src/richtext/richtextbulletspage.cpp:178
+#: ../src/richtext/richtextbulletspage.cpp:180
+#: ../src/richtext/richtextliststylepage.cpp:241
+#: ../src/richtext/richtextliststylepage.cpp:243
+msgid "Check to add a right parenthesis."
+msgstr "Sağa bir parantez eklemek için işaretleyin."
+
+#: ../src/richtext/richtextbulletspage.cpp:185
+#: ../src/richtext/richtextliststylepage.cpp:248
+msgid "Bullet &Alignment:"
+msgstr "Madde imi &hizalaması:"
+
+#: ../src/richtext/richtextbulletspage.cpp:190
+#: ../src/richtext/richtextliststylepage.cpp:253
+msgid "Centre"
+msgstr "Orta"
+
+#: ../src/richtext/richtextbulletspage.cpp:194
+#: ../src/richtext/richtextbulletspage.cpp:196
+#: ../src/richtext/richtextbulletspage.cpp:217
+#: ../src/richtext/richtextbulletspage.cpp:219
+#: ../src/richtext/richtextliststylepage.cpp:257
+#: ../src/richtext/richtextliststylepage.cpp:259
+#: ../src/richtext/richtextliststylepage.cpp:278
+#: ../src/richtext/richtextliststylepage.cpp:280
+msgid "The bullet character."
+msgstr "Madde imi karakteri."
+
+#: ../src/richtext/richtextbulletspage.cpp:212
+#: ../src/richtext/richtextliststylepage.cpp:271
+msgid "&Symbol:"
+msgstr "&Simge:"
+
+#: ../src/richtext/richtextbulletspage.cpp:222
+#: ../src/richtext/richtextliststylepage.cpp:283
+msgid "Ch&oose..."
+msgstr "S&eç..."
+
+#: ../src/richtext/richtextbulletspage.cpp:223
+#: ../src/richtext/richtextbulletspage.cpp:225
+#: ../src/richtext/richtextliststylepage.cpp:284
+#: ../src/richtext/richtextliststylepage.cpp:286
+msgid "Click to browse for a symbol."
+msgstr "Bir simge seçmek için tıklayın."
+
+#: ../src/richtext/richtextbulletspage.cpp:230
+#: ../src/richtext/richtextliststylepage.cpp:291
+msgid "Symbol &font:"
+msgstr "Simge &fontu:"
+
+#: ../src/richtext/richtextbulletspage.cpp:235
+#: ../src/richtext/richtextbulletspage.cpp:237
+#: ../src/richtext/richtextliststylepage.cpp:297
+msgid "Available fonts."
+msgstr "Kullanılabilecek fontlar."
+
+#: ../src/richtext/richtextbulletspage.cpp:242
+#: ../src/richtext/richtextliststylepage.cpp:302
+msgid "S&tandard bullet name:"
+msgstr "S&tandart madde imi adı:"
+
+#: ../src/richtext/richtextbulletspage.cpp:247
+#: ../src/richtext/richtextbulletspage.cpp:249
+#: ../src/richtext/richtextliststylepage.cpp:307
+#: ../src/richtext/richtextliststylepage.cpp:309
+msgid "A standard bullet name."
+msgstr "Standart bir madde imi adı."
+
+#: ../src/richtext/richtextbulletspage.cpp:254
+msgid "&Number:"
+msgstr "&Sayı:"
+
+#: ../src/richtext/richtextbulletspage.cpp:258
+#: ../src/richtext/richtextbulletspage.cpp:260
+msgid "The list item number."
+msgstr "Liste ögesi numarası."
+
+#: ../src/richtext/richtextbulletspage.cpp:266
+#: ../src/richtext/richtextbulletspage.cpp:268
+#: ../src/richtext/richtextliststylepage.cpp:475
+#: ../src/richtext/richtextliststylepage.cpp:477
+msgid "Shows a preview of the bullet settings."
+msgstr "Madde imi ayarlarının önizlemesini görüntüler."
+
+#: ../src/richtext/richtextbulletspage.cpp:276
+#: ../src/richtext/richtextliststylepage.cpp:484
+msgid "(None)"
+msgstr "(Hiçbiri)"
+
+#: ../src/richtext/richtextbulletspage.cpp:277
+#: ../src/richtext/richtextliststylepage.cpp:485
+msgid "Arabic"
+msgstr "Arapça"
+
+#: ../src/richtext/richtextbulletspage.cpp:278
+#: ../src/richtext/richtextliststylepage.cpp:486
+msgid "Upper case letters"
+msgstr "Büyük harfler"
+
+#: ../src/richtext/richtextbulletspage.cpp:279
+#: ../src/richtext/richtextliststylepage.cpp:487
+msgid "Lower case letters"
+msgstr "Küçük harfler"
+
+#: ../src/richtext/richtextbulletspage.cpp:280
+#: ../src/richtext/richtextliststylepage.cpp:488
+msgid "Upper case roman numerals"
+msgstr "Büyük harf romen rakamları"
+
+#: ../src/richtext/richtextbulletspage.cpp:281
+#: ../src/richtext/richtextliststylepage.cpp:489
+msgid "Lower case roman numerals"
+msgstr "Küçük harf Romen rakamları"
+
+#: ../src/richtext/richtextbulletspage.cpp:282
+#: ../src/richtext/richtextliststylepage.cpp:490
+msgid "Numbered outline"
+msgstr "Numaralı kontur"
+
+#: ../src/richtext/richtextbulletspage.cpp:283
+#: ../src/richtext/richtextliststylepage.cpp:491
+msgid "Symbol"
+msgstr "Simge"
+
+#: ../src/richtext/richtextbulletspage.cpp:284
+#: ../src/richtext/richtextliststylepage.cpp:492
+msgid "Bitmap"
+msgstr "Bitmap"
+
+#: ../src/richtext/richtextbulletspage.cpp:285
+#: ../src/richtext/richtextliststylepage.cpp:493
+msgid "Standard"
+msgstr "Standart"
+
+#: ../src/richtext/richtextbulletspage.cpp:287
+#: ../src/richtext/richtextliststylepage.cpp:495
+msgid "*"
+msgstr "*"
+
+#: ../src/richtext/richtextbulletspage.cpp:288
+#: ../src/richtext/richtextliststylepage.cpp:496
+msgid "-"
+msgstr "-"
+
+#: ../src/richtext/richtextbulletspage.cpp:289
+#: ../src/richtext/richtextliststylepage.cpp:497
+msgid ">"
+msgstr ">"
+
+#: ../src/richtext/richtextbulletspage.cpp:290
+#: ../src/richtext/richtextliststylepage.cpp:498
+msgid "+"
+msgstr "+"
+
+#: ../src/richtext/richtextbulletspage.cpp:291
+#: ../src/richtext/richtextliststylepage.cpp:499
+msgid "~"
+msgstr "~"
+
+#: ../src/richtext/richtextctrl.cpp:859
+msgid "Drag"
+msgstr "Sürükleyin"
+
+#: ../src/richtext/richtextctrl.cpp:1338 ../src/richtext/richtextctrl.cpp:1559
+msgid "Delete Text"
+msgstr "Metni sil"
+
+#: ../src/richtext/richtextctrl.cpp:1537
+msgid "Remove Bullet"
+msgstr "Madde imini kaldır"
+
+#: ../src/richtext/richtextctrl.cpp:3070
+msgid "The text couldn't be saved."
+msgstr "Metin kaydedilemedi."
+
+#: ../src/richtext/richtextctrl.cpp:3644
+msgid "Replace"
+msgstr "Değiştir"
+
+#: ../src/richtext/richtextfontpage.cpp:146
+#: ../src/richtext/richtextsymboldlg.cpp:384
+msgid "&Font:"
+msgstr "&Font:"
+
+#: ../src/richtext/richtextfontpage.cpp:150
+#: ../src/richtext/richtextfontpage.cpp:152
+msgid "Type a font name."
+msgstr "Bir font adı yazın."
+
+#: ../src/richtext/richtextfontpage.cpp:158
+msgid "&Size:"
+msgstr "&Boyut:"
+
+#: ../src/richtext/richtextfontpage.cpp:165
+#: ../src/richtext/richtextfontpage.cpp:167
+msgid "Type a size in points."
+msgstr "Punto olarak bir boyut yazın."
+
+#: ../src/richtext/richtextfontpage.cpp:180
+#: ../src/richtext/richtextfontpage.cpp:182
+msgid "The font size units, points or pixels."
+msgstr "Font boyutu birimi, punto ya da piksel."
+
+#: ../src/richtext/richtextfontpage.cpp:189
+#: ../src/richtext/richtextfontpage.cpp:191
+msgid "Lists the available fonts."
+msgstr "Kullanılabilecek fontlar listelenir."
+
+#: ../src/richtext/richtextfontpage.cpp:196
+#: ../src/richtext/richtextfontpage.cpp:198
+msgid "Lists font sizes in points."
+msgstr "Font boyutları punto olarak listelenir."
+
+#: ../src/richtext/richtextfontpage.cpp:207
+msgid "Font st&yle:"
+msgstr "Font &stili:"
+
+#: ../src/richtext/richtextfontpage.cpp:212
+#: ../src/richtext/richtextfontpage.cpp:214
+msgid "Select regular or italic style."
+msgstr "Normal ya da italik stil seçin."
+
+#: ../src/richtext/richtextfontpage.cpp:220
+msgid "Font &weight:"
+msgstr "Font &koyuluğu:"
+
+#: ../src/richtext/richtextfontpage.cpp:225
+#: ../src/richtext/richtextfontpage.cpp:227
+msgid "Select regular or bold."
+msgstr "Normal ya da kalın stil seçin."
+
+#: ../src/richtext/richtextfontpage.cpp:233
+msgid "&Underlining:"
+msgstr "&Altını çizme:"
+
+#: ../src/richtext/richtextfontpage.cpp:238
+#: ../src/richtext/richtextfontpage.cpp:240
+msgid "Select underlining or no underlining."
+msgstr "Altıçizili ya da normal stili seçin."
+
+#: ../src/richtext/richtextfontpage.cpp:248
+msgid "&Colour:"
+msgstr "&Renk:"
+
+#: ../src/richtext/richtextfontpage.cpp:253
+#: ../src/richtext/richtextfontpage.cpp:255
+msgid "Click to change the text colour."
+msgstr "Metin rengini değiştirmek için tıklayın."
+
+#: ../src/richtext/richtextfontpage.cpp:261
+msgid "&Bg colour:"
+msgstr "&Arka plan rengi:"
+
+#: ../src/richtext/richtextfontpage.cpp:266
+#: ../src/richtext/richtextfontpage.cpp:268
+msgid "Click to change the text background colour."
+msgstr "Metin arka plan rengini değiştirmek için tıklayın."
+
+#: ../src/richtext/richtextfontpage.cpp:276
+#: ../src/richtext/richtextfontpage.cpp:278
+msgid "Check to show a line through the text."
+msgstr "Metnin üzerini çizmek için işaretleyin."
+
+#: ../src/richtext/richtextfontpage.cpp:281
+msgid "Ca&pitals"
+msgstr "&Büyük harfler"
+
+#: ../src/richtext/richtextfontpage.cpp:283
+#: ../src/richtext/richtextfontpage.cpp:285
+msgid "Check to show the text in capitals."
+msgstr "Metni büyük harfe dönüştürmek için işaretleyin."
+
+#: ../src/richtext/richtextfontpage.cpp:288
+msgid "Small C&apitals"
+msgstr "Küçük H&arfler"
+
+#: ../src/richtext/richtextfontpage.cpp:290
+#: ../src/richtext/richtextfontpage.cpp:292
+msgid "Check to show the text in small capitals."
+msgstr "Metni küçük harfe dönüştürmek için işaretleyin."
+
+#: ../src/richtext/richtextfontpage.cpp:295
+msgid "Supe&rscript"
+msgstr "Ü&st yazı"
+
+#: ../src/richtext/richtextfontpage.cpp:297
+#: ../src/richtext/richtextfontpage.cpp:299
+msgid "Check to show the text in superscript."
+msgstr "Metni üst yazıya dönüştürmek için işaretleyin."
+
+#: ../src/richtext/richtextfontpage.cpp:302
+msgid "Subscrip&t"
+msgstr "Al&t yazı"
+
+#: ../src/richtext/richtextfontpage.cpp:304
+#: ../src/richtext/richtextfontpage.cpp:306
+msgid "Check to show the text in subscript."
+msgstr "Metni alt yazıya dönüştürmek için işaretleyin."
+
+#: ../src/richtext/richtextfontpage.cpp:312
+msgid "Rig&ht-to-left"
+msgstr "Sağ&dan sola"
+
+#: ../src/richtext/richtextfontpage.cpp:314
+#: ../src/richtext/richtextfontpage.cpp:316
+msgid "Check to indicate right-to-left text layout."
+msgstr "Sağdan sola yazı için işaretleyin."
+
+#: ../src/richtext/richtextfontpage.cpp:319
+msgid "Suppress hyphe&nation"
+msgstr "Heceleme e&ngellensin"
+
+#: ../src/richtext/richtextfontpage.cpp:321
+#: ../src/richtext/richtextfontpage.cpp:323
+msgid "Check to suppress hyphenation."
+msgstr "Hecelemeyi engellemek için işaretleyin."
+
+#: ../src/richtext/richtextfontpage.cpp:329
+#: ../src/richtext/richtextfontpage.cpp:331
+msgid "Shows a preview of the font settings."
+msgstr "Font ayarlarının önizlemesini görüntüler."
+
+#: ../src/richtext/richtextfontpage.cpp:348
+#: ../src/richtext/richtextfontpage.cpp:352
+#: ../src/richtext/richtextfontpage.cpp:356
+#: ../src/richtext/richtextformatdlg.cpp:873
+#: ../src/richtext/richtextindentspage.cpp:273
+#: ../src/richtext/richtextindentspage.cpp:285
+#: ../src/richtext/richtextindentspage.cpp:286
+#: ../src/richtext/richtextindentspage.cpp:310
+#: ../src/richtext/richtextindentspage.cpp:325
+#: ../src/richtext/richtextliststylepage.cpp:451
+#: ../src/richtext/richtextliststylepage.cpp:463
+#: ../src/richtext/richtextliststylepage.cpp:464
+msgid "(none)"
+msgstr "(hiçbiri)"
+
+#: ../src/richtext/richtextfontpage.cpp:349
+#: ../src/richtext/richtextfontpage.cpp:353
+msgid "Regular"
+msgstr "Normal"
+
+#: ../src/richtext/richtextfontpage.cpp:357
+msgid "Not underlined"
+msgstr "Altıçizili değil"
+
+#: ../src/richtext/richtextformatdlg.cpp:341
+msgid "Indents && Spacing"
+msgstr "Girinti ve boşluklar"
+
+#: ../src/richtext/richtextformatdlg.cpp:346
+msgid "Tabs"
+msgstr "Sekmeler"
+
+#: ../src/richtext/richtextformatdlg.cpp:351
+msgid "Bullets"
+msgstr "Madde imleri"
+
+#: ../src/richtext/richtextformatdlg.cpp:356
+msgid "List Style"
+msgstr "Liste stili"
+
+#: ../src/richtext/richtextformatdlg.cpp:366
+#: ../src/richtext/richtextmarginspage.cpp:170
+msgid "Margins"
+msgstr "Kenar Boşluğu"
+
+#: ../src/richtext/richtextformatdlg.cpp:371
+msgid "Borders"
+msgstr "Kenarlıklar"
+
+#: ../src/richtext/richtextformatdlg.cpp:765
+msgid "Colour"
+msgstr "Renk"
+
+#: ../src/richtext/richtextindentspage.cpp:127
+#: ../src/richtext/richtextliststylepage.cpp:322
+msgid "&Alignment"
+msgstr "Hiz&alama"
+
+#: ../src/richtext/richtextindentspage.cpp:138
+#: ../src/richtext/richtextliststylepage.cpp:331
+msgid "&Left"
+msgstr "So&l"
+
+#: ../src/richtext/richtextindentspage.cpp:140
+#: ../src/richtext/richtextindentspage.cpp:142
+#: ../src/richtext/richtextliststylepage.cpp:333
+#: ../src/richtext/richtextliststylepage.cpp:335
+msgid "Left-align text."
+msgstr "Metni sola hizalar."
+
+#: ../src/richtext/richtextindentspage.cpp:145
+#: ../src/richtext/richtextliststylepage.cpp:338
+msgid "&Right"
+msgstr "&Sağ"
+
+#: ../src/richtext/richtextindentspage.cpp:147
+#: ../src/richtext/richtextindentspage.cpp:149
+#: ../src/richtext/richtextliststylepage.cpp:340
+#: ../src/richtext/richtextliststylepage.cpp:342
+msgid "Right-align text."
+msgstr "Metni sağa hizalar."
+
+#: ../src/richtext/richtextindentspage.cpp:152
+#: ../src/richtext/richtextliststylepage.cpp:345
+msgid "&Justified"
+msgstr "&Hizalanmış"
+
+#: ../src/richtext/richtextindentspage.cpp:154
+#: ../src/richtext/richtextindentspage.cpp:156
+#: ../src/richtext/richtextliststylepage.cpp:347
+#: ../src/richtext/richtextliststylepage.cpp:349
+msgid "Justify text left and right."
+msgstr "Metin iki yana hizalar."
+
+#: ../src/richtext/richtextindentspage.cpp:159
+#: ../src/richtext/richtextliststylepage.cpp:352
+msgid "Cen&tred"
+msgstr "Or&talanmış"
+
+#: ../src/richtext/richtextindentspage.cpp:161
+#: ../src/richtext/richtextindentspage.cpp:163
+#: ../src/richtext/richtextliststylepage.cpp:354
+#: ../src/richtext/richtextliststylepage.cpp:356
+msgid "Centre text."
+msgstr "Metni ortalar."
+
+#: ../src/richtext/richtextindentspage.cpp:166
+#: ../src/richtext/richtextliststylepage.cpp:359
+msgid "&Indeterminate"
+msgstr "&Belirsiz"
+
+#: ../src/richtext/richtextindentspage.cpp:168
+#: ../src/richtext/richtextindentspage.cpp:170
+#: ../src/richtext/richtextliststylepage.cpp:361
+#: ../src/richtext/richtextliststylepage.cpp:363
+msgid "Use the current alignment setting."
+msgstr "Geçerli hizalama ayarları kullanılır."
+
+#: ../src/richtext/richtextindentspage.cpp:183
+#: ../src/richtext/richtextliststylepage.cpp:375
+msgid "&Indentation (tenths of a mm)"
+msgstr "İçe&rlek (1/10mm ölçeğinde)"
+
+#: ../src/richtext/richtextindentspage.cpp:198
+#: ../src/richtext/richtextindentspage.cpp:200
+#: ../src/richtext/richtextliststylepage.cpp:388
+#: ../src/richtext/richtextliststylepage.cpp:390
+msgid "The left indent."
+msgstr "Sol girinti."
+
+#: ../src/richtext/richtextindentspage.cpp:203
+#: ../src/richtext/richtextliststylepage.cpp:393
+msgid "Left (&first line):"
+msgstr "Sol (i&lk satır):"
+
+#: ../src/richtext/richtextindentspage.cpp:207
+#: ../src/richtext/richtextindentspage.cpp:209
+#: ../src/richtext/richtextliststylepage.cpp:397
+#: ../src/richtext/richtextliststylepage.cpp:399
+msgid "The first line indent."
+msgstr "İlk satır girintisi."
+
+#: ../src/richtext/richtextindentspage.cpp:216
+#: ../src/richtext/richtextindentspage.cpp:218
+#: ../src/richtext/richtextliststylepage.cpp:406
+#: ../src/richtext/richtextliststylepage.cpp:408
+msgid "The right indent."
+msgstr "Sağ girinti."
+
+#: ../src/richtext/richtextindentspage.cpp:221
+msgid "&Outline level:"
+msgstr "Kontur &düzeyi:"
+
+#: ../src/richtext/richtextindentspage.cpp:226
+#: ../src/richtext/richtextindentspage.cpp:228
+msgid "The outline level."
+msgstr "Kontur düzeyi."
+
+#: ../src/richtext/richtextindentspage.cpp:241
+#: ../src/richtext/richtextliststylepage.cpp:420
+msgid "&Spacing (tenths of a mm)"
+msgstr "&Boşluk (1/10mm)"
+
+#: ../src/richtext/richtextindentspage.cpp:252
+msgid "&Before a paragraph:"
+msgstr "&Paragraftan önce:"
+
+#: ../src/richtext/richtextindentspage.cpp:256
+#: ../src/richtext/richtextindentspage.cpp:258
+#: ../src/richtext/richtextliststylepage.cpp:433
+#: ../src/richtext/richtextliststylepage.cpp:435
+msgid "The spacing before the paragraph."
+msgstr "Paragraftan önceki boşluk."
+
+#: ../src/richtext/richtextindentspage.cpp:261
+msgid "&After a paragraph:"
+msgstr "P&aragraftan sonra:"
+
+#: ../src/richtext/richtextindentspage.cpp:266
+#: ../src/richtext/richtextliststylepage.cpp:442
+#: ../src/richtext/richtextliststylepage.cpp:444
+msgid "The spacing after the paragraph."
+msgstr "Paragraftan sonraki boşluk."
+
+#: ../src/richtext/richtextindentspage.cpp:269
+msgid "L&ine spacing:"
+msgstr "&Satır aralığı:"
+
+#: ../src/richtext/richtextindentspage.cpp:274
+#: ../src/richtext/richtextliststylepage.cpp:452
+msgid "Single"
+msgstr "Tek"
+
+#: ../src/richtext/richtextindentspage.cpp:275
+#: ../src/richtext/richtextliststylepage.cpp:453
+msgid "1.1"
+msgstr "1.1"
+
+#: ../src/richtext/richtextindentspage.cpp:276
+#: ../src/richtext/richtextliststylepage.cpp:454
+msgid "1.2"
+msgstr "1.2"
+
+#: ../src/richtext/richtextindentspage.cpp:277
+#: ../src/richtext/richtextliststylepage.cpp:455
+msgid "1.3"
+msgstr "1.3"
+
+#: ../src/richtext/richtextindentspage.cpp:278
+#: ../src/richtext/richtextliststylepage.cpp:456
+msgid "1.4"
+msgstr "1.4"
+
+#: ../src/richtext/richtextindentspage.cpp:279
+#: ../src/richtext/richtextliststylepage.cpp:457
+msgid "1.5"
+msgstr "1.5"
+
+#: ../src/richtext/richtextindentspage.cpp:280
+#: ../src/richtext/richtextliststylepage.cpp:458
+msgid "1.6"
+msgstr "1.6"
+
+#: ../src/richtext/richtextindentspage.cpp:281
+#: ../src/richtext/richtextliststylepage.cpp:459
+msgid "1.7"
+msgstr "1.7"
+
+#: ../src/richtext/richtextindentspage.cpp:282
+#: ../src/richtext/richtextliststylepage.cpp:460
+msgid "1.8"
+msgstr "1.8"
+
+#: ../src/richtext/richtextindentspage.cpp:283
+#: ../src/richtext/richtextliststylepage.cpp:461
+msgid "1.9"
+msgstr "1.9"
+
+#: ../src/richtext/richtextindentspage.cpp:284
+#: ../src/richtext/richtextliststylepage.cpp:462
+msgid "2"
+msgstr "2"
+
+#: ../src/richtext/richtextindentspage.cpp:287
+#: ../src/richtext/richtextindentspage.cpp:289
+#: ../src/richtext/richtextliststylepage.cpp:465
+#: ../src/richtext/richtextliststylepage.cpp:467
+msgid "The line spacing."
+msgstr "Satır aralığı."
+
+#: ../src/richtext/richtextindentspage.cpp:292
+msgid "&Page Break"
+msgstr "&Sayfa sonu"
+
+#: ../src/richtext/richtextindentspage.cpp:294
+#: ../src/richtext/richtextindentspage.cpp:296
+msgid "Inserts a page break before the paragraph."
+msgstr "Paragraftan önce bir sayfa sonu ekler."
+
+#: ../src/richtext/richtextindentspage.cpp:302
+#: ../src/richtext/richtextindentspage.cpp:304
+msgid "Shows a preview of the paragraph settings."
+msgstr "Paragraf ayarlarının önizlemesini görüntüler."
+
+#: ../src/richtext/richtextliststylepage.cpp:182
+msgid "&List level:"
+msgstr "&Liste düzeyi:"
+
+#: ../src/richtext/richtextliststylepage.cpp:186
+#: ../src/richtext/richtextliststylepage.cpp:188
+msgid "Selects the list level to edit."
+msgstr "Düzenlenecek liste düzeyini seçer."
+
+#: ../src/richtext/richtextliststylepage.cpp:193
+msgid "&Font for Level..."
+msgstr "&Düzeyin fontu..."
+
+#: ../src/richtext/richtextliststylepage.cpp:194
+#: ../src/richtext/richtextliststylepage.cpp:196
+msgid "Click to choose the font for this level."
+msgstr "Bu düzeyin fontunu seçmek için tıklayın."
+
+#: ../src/richtext/richtextliststylepage.cpp:312
+msgid "Bullet style"
+msgstr "Madde imi stili"
+
+#: ../src/richtext/richtextliststylepage.cpp:429
+msgid "Before a paragraph:"
+msgstr "Paragraftan önce:"
+
+#: ../src/richtext/richtextliststylepage.cpp:438
+msgid "After a paragraph:"
+msgstr "Paragraftan sonra:"
+
+#: ../src/richtext/richtextliststylepage.cpp:447
+msgid "Line spacing:"
+msgstr "Satır aralığı:"
+
+#: ../src/richtext/richtextliststylepage.cpp:470
+msgid "Spacing"
+msgstr "Aralık"
+
+#: ../src/richtext/richtextmarginspage.cpp:193
+#: ../src/richtext/richtextmarginspage.cpp:195
+msgid "The left margin size."
+msgstr "Sol kenar boşluğu boyutu."
+
+#: ../src/richtext/richtextmarginspage.cpp:203
+#: ../src/richtext/richtextmarginspage.cpp:205
+msgid "Units for the left margin."
+msgstr "Sol kenar boşluğu birimleri."
+
+#: ../src/richtext/richtextmarginspage.cpp:218
+#: ../src/richtext/richtextmarginspage.cpp:220
+msgid "The right margin size."
+msgstr "Sağ kenar boşluğu boyutu."
+
+#: ../src/richtext/richtextmarginspage.cpp:228
+#: ../src/richtext/richtextmarginspage.cpp:230
+msgid "Units for the right margin."
+msgstr "Sağ kenar boşluğu birimleri."
+
+#: ../src/richtext/richtextmarginspage.cpp:241
+#: ../src/richtext/richtextmarginspage.cpp:243
+msgid "The top margin size."
+msgstr "Üst kenar boşluğu boyutu."
+
+#: ../src/richtext/richtextmarginspage.cpp:251
+#: ../src/richtext/richtextmarginspage.cpp:253
+msgid "Units for the top margin."
+msgstr "Üst kenar boşluğu birimleri."
+
+#: ../src/richtext/richtextmarginspage.cpp:266
+#: ../src/richtext/richtextmarginspage.cpp:268
+msgid "The bottom margin size."
+msgstr "Alt kenar boşluğunun boyutu."
+
+#: ../src/richtext/richtextmarginspage.cpp:276
+#: ../src/richtext/richtextmarginspage.cpp:278
+msgid "Units for the bottom margin."
+msgstr "Alt kenar boşluğunun birimleri."
+
+#: ../src/richtext/richtextmarginspage.cpp:284
+msgid "Padding"
+msgstr "Boşluk"
+
+#: ../src/richtext/richtextmarginspage.cpp:307
+#: ../src/richtext/richtextmarginspage.cpp:309
+msgid "The left padding size."
+msgstr "Sol boşluk boyutu."
+
+#: ../src/richtext/richtextmarginspage.cpp:317
+#: ../src/richtext/richtextmarginspage.cpp:319
+msgid "Units for the left padding."
+msgstr "Sol boşluk birimleri."
+
+#: ../src/richtext/richtextmarginspage.cpp:332
+#: ../src/richtext/richtextmarginspage.cpp:334
+msgid "The right padding size."
+msgstr "Sağ boşluk boyutu."
+
+#: ../src/richtext/richtextmarginspage.cpp:342
+#: ../src/richtext/richtextmarginspage.cpp:344
+msgid "Units for the right padding."
+msgstr "Sağ boşluk birimleri."
+
+#: ../src/richtext/richtextmarginspage.cpp:355
+#: ../src/richtext/richtextmarginspage.cpp:357
+msgid "The top padding size."
+msgstr "Üst yastıklama boyutu."
+
+#: ../src/richtext/richtextmarginspage.cpp:365
+#: ../src/richtext/richtextmarginspage.cpp:367
+msgid "Units for the top padding."
+msgstr "Üst yastıklama birimleri."
+
+#: ../src/richtext/richtextmarginspage.cpp:380
+#: ../src/richtext/richtextmarginspage.cpp:382
+msgid "The bottom padding size."
+msgstr "Alt boşluk boyutu."
+
+#: ../src/richtext/richtextmarginspage.cpp:390
+#: ../src/richtext/richtextmarginspage.cpp:392
+msgid "Units for the bottom padding."
+msgstr "Alt boşluk birimleri."
+
+#: ../src/richtext/richtextprint.cpp:592
+msgid " Preview"
+msgstr " Önizleme"
+
+#: ../src/richtext/richtextsizepage.cpp:228
+msgid "Floating"
+msgstr "Yüzer"
+
+#: ../src/richtext/richtextsizepage.cpp:243
+msgid "&Floating mode:"
+msgstr "&Yüzer kip:"
+
+#: ../src/richtext/richtextsizepage.cpp:252
+#: ../src/richtext/richtextsizepage.cpp:254
+msgid "How the object will float relative to the text."
+msgstr "Nesnenin metne göre nasıl yüzeceği."
+
+#: ../src/richtext/richtextsizepage.cpp:265
+msgid "Alignment"
+msgstr "Hizalama"
+
+#: ../src/richtext/richtextsizepage.cpp:277
+msgid "&Vertical alignment:"
+msgstr "&Dikey hizalama:"
+
+#: ../src/richtext/richtextsizepage.cpp:279
+#: ../src/richtext/richtextsizepage.cpp:281
+msgid "Enable vertical alignment."
+msgstr "Dikey hizalama kullanılsın."
+
+#: ../src/richtext/richtextsizepage.cpp:286
+msgid "Centred"
+msgstr "Ortalanmış"
+
+#: ../src/richtext/richtextsizepage.cpp:290
+#: ../src/richtext/richtextsizepage.cpp:292
+msgid "Vertical alignment."
+msgstr "Dikey hizalama."
+
+#: ../src/richtext/richtextsizepage.cpp:316
+#: ../src/richtext/richtextsizepage.cpp:323
+msgid "&Width:"
+msgstr "&Genişlik:"
+
+#: ../src/richtext/richtextsizepage.cpp:318
+#: ../src/richtext/richtextsizepage.cpp:320
+msgid "Enable the width value."
+msgstr "Genişlik değeri kullanılsın."
+
+#: ../src/richtext/richtextsizepage.cpp:331
+#: ../src/richtext/richtextsizepage.cpp:333
+msgid "The object width."
+msgstr "Nesne genişliği."
+
+#: ../src/richtext/richtextsizepage.cpp:342
+#: ../src/richtext/richtextsizepage.cpp:344
+msgid "Units for the object width."
+msgstr "Nesne genişliği birimleri."
+
+#: ../src/richtext/richtextsizepage.cpp:350
+#: ../src/richtext/richtextsizepage.cpp:357
+msgid "&Height:"
+msgstr "&Yükseklik:"
+
+#: ../src/richtext/richtextsizepage.cpp:352
+#: ../src/richtext/richtextsizepage.cpp:354
+#: ../src/richtext/richtextsizepage.cpp:464
+#: ../src/richtext/richtextsizepage.cpp:466
+msgid "Enable the height value."
+msgstr "Yükseklik değeri kullanılsın."
+
+#: ../src/richtext/richtextsizepage.cpp:365
+#: ../src/richtext/richtextsizepage.cpp:367
+msgid "The object height."
+msgstr "Nesne yüksekliği."
+
+#: ../src/richtext/richtextsizepage.cpp:376
+#: ../src/richtext/richtextsizepage.cpp:378
+msgid "Units for the object height."
+msgstr "Nesne yüksekliği birimleri."
+
+#: ../src/richtext/richtextsizepage.cpp:381
+msgid "Min width:"
+msgstr "En az genişlik:"
+
+#: ../src/richtext/richtextsizepage.cpp:383
+#: ../src/richtext/richtextsizepage.cpp:385
+msgid "Enable the minimum width value."
+msgstr "En az genişlik değeri kullanılır."
+
+#: ../src/richtext/richtextsizepage.cpp:392
+#: ../src/richtext/richtextsizepage.cpp:394
+msgid "The object minimum width."
+msgstr "En az nesne genişliği."
+
+#: ../src/richtext/richtextsizepage.cpp:403
+#: ../src/richtext/richtextsizepage.cpp:405
+msgid "Units for the minimum object width."
+msgstr "En az nesne genişliği birimleri."
+
+#: ../src/richtext/richtextsizepage.cpp:408
+msgid "Min height:"
+msgstr "En az yükseklik:"
+
+#: ../src/richtext/richtextsizepage.cpp:410
+#: ../src/richtext/richtextsizepage.cpp:412
+msgid "Enable the minimum height value."
+msgstr "En büyük yükseklik değeri kullanılır."
+
+#: ../src/richtext/richtextsizepage.cpp:419
+#: ../src/richtext/richtextsizepage.cpp:421
+msgid "The object minimum height."
+msgstr "En az nesne yüksekliği."
+
+#: ../src/richtext/richtextsizepage.cpp:430
+#: ../src/richtext/richtextsizepage.cpp:432
+msgid "Units for the minimum object height."
+msgstr "En az nesne yüksekliği birimleri."
+
+#: ../src/richtext/richtextsizepage.cpp:435
+msgid "Max width:"
+msgstr "En fazla genişlik:"
+
+#: ../src/richtext/richtextsizepage.cpp:437
+#: ../src/richtext/richtextsizepage.cpp:439
+msgid "Enable the maximum width value."
+msgstr "En fazla genişlik değeri kullanılır."
+
+#: ../src/richtext/richtextsizepage.cpp:446
+#: ../src/richtext/richtextsizepage.cpp:448
+msgid "The object maximum width."
+msgstr "En fazla nesne genişliği."
+
+#: ../src/richtext/richtextsizepage.cpp:457
+#: ../src/richtext/richtextsizepage.cpp:459
+msgid "Units for the maximum object width."
+msgstr "En fazla nesne genişliği birimleri."
+
+#: ../src/richtext/richtextsizepage.cpp:462
+msgid "Max height:"
+msgstr "En fazla yükseklik:"
+
+#: ../src/richtext/richtextsizepage.cpp:473
+#: ../src/richtext/richtextsizepage.cpp:475
+msgid "The object maximum height."
+msgstr "En fazla nesne yüksekliği kullanılır."
+
+#: ../src/richtext/richtextsizepage.cpp:484
+#: ../src/richtext/richtextsizepage.cpp:486
+msgid "Units for the maximum object height."
+msgstr "En fazla nesne yüksekliği birimleri."
+
+#: ../src/richtext/richtextsizepage.cpp:495
+msgid "Position"
+msgstr "Konum"
+
+#: ../src/richtext/richtextsizepage.cpp:513
+msgid "&Position mode:"
+msgstr "&Konum kipi:"
+
+#: ../src/richtext/richtextsizepage.cpp:517
+#: ../src/richtext/richtextsizepage.cpp:522
+msgid "Static"
+msgstr "Durağan"
+
+#: ../src/richtext/richtextsizepage.cpp:518
+msgid "Relative"
+msgstr "Göreli"
+
+#: ../src/richtext/richtextsizepage.cpp:519
+msgid "Absolute"
+msgstr "Mutlak"
+
+#: ../src/richtext/richtextsizepage.cpp:520
+msgid "Fixed"
+msgstr "Sabit"
+
+#: ../src/richtext/richtextsizepage.cpp:533
+#: ../src/richtext/richtextsizepage.cpp:535
+#: ../src/richtext/richtextsizepage.cpp:547
+#: ../src/richtext/richtextsizepage.cpp:549
+msgid "The left position."
+msgstr "Sol konum."
+
+#: ../src/richtext/richtextsizepage.cpp:558
+#: ../src/richtext/richtextsizepage.cpp:560
+msgid "Units for the left position."
+msgstr "Sol konum birimleri."
+
+#: ../src/richtext/richtextsizepage.cpp:568
+#: ../src/richtext/richtextsizepage.cpp:570
+#: ../src/richtext/richtextsizepage.cpp:582
+#: ../src/richtext/richtextsizepage.cpp:584
+msgid "The top position."
+msgstr "Üst konum."
+
+#: ../src/richtext/richtextsizepage.cpp:593
+#: ../src/richtext/richtextsizepage.cpp:595
+msgid "Units for the top position."
+msgstr "Üst konum birimleri."
+
+#: ../src/richtext/richtextsizepage.cpp:603
+#: ../src/richtext/richtextsizepage.cpp:605
+#: ../src/richtext/richtextsizepage.cpp:617
+#: ../src/richtext/richtextsizepage.cpp:619
+msgid "The right position."
+msgstr "Sağ konum."
+
+#: ../src/richtext/richtextsizepage.cpp:628
+#: ../src/richtext/richtextsizepage.cpp:630
+msgid "Units for the right position."
+msgstr "Sağ konum birimleri."
+
+#: ../src/richtext/richtextsizepage.cpp:638
+#: ../src/richtext/richtextsizepage.cpp:640
+#: ../src/richtext/richtextsizepage.cpp:652
+#: ../src/richtext/richtextsizepage.cpp:654
+msgid "The bottom position."
+msgstr "Alt konum."
+
+#: ../src/richtext/richtextsizepage.cpp:663
+#: ../src/richtext/richtextsizepage.cpp:665
+msgid "Units for the bottom position."
+msgstr "Alt konum birimleri."
+
+#: ../src/richtext/richtextsizepage.cpp:671
+msgid "&Move the object to:"
+msgstr "&Nesneyi şuraya taşı:"
+
+#: ../src/richtext/richtextsizepage.cpp:674
+msgid "&Previous Paragraph"
+msgstr "Önceki &paragraf"
+
+#: ../src/richtext/richtextsizepage.cpp:675
+#: ../src/richtext/richtextsizepage.cpp:677
+msgid "Moves the object to the previous paragraph."
+msgstr "Nesneyi önceki paragrafa taşır."
+
+#: ../src/richtext/richtextsizepage.cpp:680
+msgid "&Next Paragraph"
+msgstr "So&nraki paragraf"
+
+#: ../src/richtext/richtextsizepage.cpp:681
+#: ../src/richtext/richtextsizepage.cpp:683
+msgid "Moves the object to the next paragraph."
+msgstr "Nesneyi sonraki paragrafa taşır."
+
+#: ../src/richtext/richtextstyledlg.cpp:193
+msgid "&Styles:"
+msgstr "&Stiller:"
+
+#: ../src/richtext/richtextstyledlg.cpp:197
+#: ../src/richtext/richtextstyledlg.cpp:199
+msgid "The available styles."
+msgstr "Kullanılabilecek stiller."
+
+#: ../src/richtext/richtextstyledlg.cpp:205
+#: ../src/richtext/richtextstyledlg.cpp:217
+msgid " "
+msgstr " "
+
+#: ../src/richtext/richtextstyledlg.cpp:209
+#: ../src/richtext/richtextstyledlg.cpp:211
+msgid "The style preview."
+msgstr "Stil önizlemesi."
+
+#: ../src/richtext/richtextstyledlg.cpp:220
+msgid "New &Character Style..."
+msgstr "Yeni &Karakter Stili..."
+
+#: ../src/richtext/richtextstyledlg.cpp:221
+#: ../src/richtext/richtextstyledlg.cpp:223
+msgid "Click to create a new character style."
+msgstr "Yeni bir karakter stili oluşturmak için tıklayın."
+
+#: ../src/richtext/richtextstyledlg.cpp:226
+msgid "New &Paragraph Style..."
+msgstr "Yeni &Paragraf Stili..."
+
+#: ../src/richtext/richtextstyledlg.cpp:227
+#: ../src/richtext/richtextstyledlg.cpp:229
+msgid "Click to create a new paragraph style."
+msgstr "Yeni bir paragraf stili oluşturmak için tıklayın."
+
+#: ../src/richtext/richtextstyledlg.cpp:232
+msgid "New &List Style..."
+msgstr "Yeni &Liste Stili..."
+
+#: ../src/richtext/richtextstyledlg.cpp:233
+#: ../src/richtext/richtextstyledlg.cpp:235
+msgid "Click to create a new list style."
+msgstr "Yeni bir liste stili oluşturmak için tıklayın."
+
+#: ../src/richtext/richtextstyledlg.cpp:238
+msgid "New &Box Style..."
+msgstr "Yeni &Kutu Stili..."
+
+#: ../src/richtext/richtextstyledlg.cpp:239
+#: ../src/richtext/richtextstyledlg.cpp:241
+msgid "Click to create a new box style."
+msgstr "Yeni bir kutu stili oluşturmak için tıklayın."
+
+#: ../src/richtext/richtextstyledlg.cpp:246
+msgid "&Apply Style"
+msgstr "Stili Uygul&a"
+
+#: ../src/richtext/richtextstyledlg.cpp:247
+#: ../src/richtext/richtextstyledlg.cpp:249
+msgid "Click to apply the selected style."
+msgstr "Seçili stili uygulamak için tıklayın."
+
+#: ../src/richtext/richtextstyledlg.cpp:252
+msgid "&Rename Style..."
+msgstr "Stili &Yeniden Adlandır..."
+
+#: ../src/richtext/richtextstyledlg.cpp:253
+#: ../src/richtext/richtextstyledlg.cpp:255
+msgid "Click to rename the selected style."
+msgstr "Seçili stili yeniden adlandırmak için tıklayın."
+
+#: ../src/richtext/richtextstyledlg.cpp:258
+msgid "&Edit Style..."
+msgstr "Stili Düz&enle..."
+
+#: ../src/richtext/richtextstyledlg.cpp:259
+#: ../src/richtext/richtextstyledlg.cpp:261
+msgid "Click to edit the selected style."
+msgstr "Seçili stili düzenlemek için tıklayın."
+
+#: ../src/richtext/richtextstyledlg.cpp:264
+msgid "&Delete Style..."
+msgstr "&Stili Sil..."
+
+#: ../src/richtext/richtextstyledlg.cpp:265
+#: ../src/richtext/richtextstyledlg.cpp:267
+msgid "Click to delete the selected style."
+msgstr "Seçili stili silmek için tıklayın."
+
+#: ../src/richtext/richtextstyledlg.cpp:274
+#: ../src/richtext/richtextstyledlg.cpp:276
+msgid "Click to close this window."
+msgstr "Pencereyi kapatmak için tıklayın."
+
+#: ../src/richtext/richtextstyledlg.cpp:282
+msgid "&Restart numbering"
+msgstr "Numa&ralandırmayı yeniden başlat"
+
+#: ../src/richtext/richtextstyledlg.cpp:284
+#: ../src/richtext/richtextstyledlg.cpp:286
+msgid "Check to restart numbering."
+msgstr "Yeniden numaralandırmak için işaretleyin."
+
+#: ../src/richtext/richtextstyledlg.cpp:601
+msgid "Enter a character style name"
+msgstr "Bir karakter stili adı yazın"
+
+#: ../src/richtext/richtextstyledlg.cpp:601
+#: ../src/richtext/richtextstyledlg.cpp:606
+#: ../src/richtext/richtextstyledlg.cpp:649
+#: ../src/richtext/richtextstyledlg.cpp:654
+#: ../src/richtext/richtextstyledlg.cpp:815
+#: ../src/richtext/richtextstyledlg.cpp:820
+#: ../src/richtext/richtextstyledlg.cpp:888
+#: ../src/richtext/richtextstyledlg.cpp:896
+#: ../src/richtext/richtextstyledlg.cpp:929
+#: ../src/richtext/richtextstyledlg.cpp:934
+msgid "New Style"
+msgstr "Yeni Stil"
+
+#: ../src/richtext/richtextstyledlg.cpp:606
+#: ../src/richtext/richtextstyledlg.cpp:654
+#: ../src/richtext/richtextstyledlg.cpp:820
+#: ../src/richtext/richtextstyledlg.cpp:896
+#: ../src/richtext/richtextstyledlg.cpp:934
+msgid "Sorry, that name is taken. Please choose another."
+msgstr "Ne yazık ki bu ad kullanılmış. Lütfen başka bir ad seçin."
+
+#: ../src/richtext/richtextstyledlg.cpp:649
+msgid "Enter a paragraph style name"
+msgstr "Bir paragraf stili adı yazın"
+
+#: ../src/richtext/richtextstyledlg.cpp:777
+#, c-format
+msgid "Delete style %s?"
+msgstr "%s stili silinsin mi?"
+
+#: ../src/richtext/richtextstyledlg.cpp:777
+msgid "Delete Style"
+msgstr "Stili Sil"
+
+#: ../src/richtext/richtextstyledlg.cpp:815
+msgid "Enter a list style name"
+msgstr "Bir liste stili adı yazın"
+
+#: ../src/richtext/richtextstyledlg.cpp:888
+msgid "Enter a new style name"
+msgstr "Yeni bir stil adı yazın"
+
+#: ../src/richtext/richtextstyledlg.cpp:929
+msgid "Enter a box style name"
+msgstr "Bir kutu stili adı yazın"
+
+#: ../src/richtext/richtextstylepage.cpp:109
+#: ../src/richtext/richtextstylepage.cpp:111
+msgid "The style name."
+msgstr "Stil adı."
+
+#: ../src/richtext/richtextstylepage.cpp:114
+msgid "&Based on:"
+msgstr "&Kaynak:"
+
+#: ../src/richtext/richtextstylepage.cpp:119
+#: ../src/richtext/richtextstylepage.cpp:121
+msgid "The style on which this style is based."
+msgstr "Bu stilin temel alındığı stil."
+
+#: ../src/richtext/richtextstylepage.cpp:124
+msgid "&Next style:"
+msgstr "So&nraki stil:"
+
+#: ../src/richtext/richtextstylepage.cpp:129
+#: ../src/richtext/richtextstylepage.cpp:131
+msgid "The default style for the next paragraph."
+msgstr "Sonraki paragraf için varsayılan stil."
+
+#: ../src/richtext/richtextstyles.cpp:1057
+msgid "All styles"
+msgstr "Tüm stiller"
+
+#: ../src/richtext/richtextstyles.cpp:1058
+msgid "Paragraph styles"
+msgstr "Paragraf stilleri"
+
+#: ../src/richtext/richtextstyles.cpp:1059
+msgid "Character styles"
+msgstr "Karakter stilleri"
+
+#: ../src/richtext/richtextstyles.cpp:1060
+msgid "List styles"
+msgstr "Liste stilleri"
+
+#: ../src/richtext/richtextstyles.cpp:1061
+msgid "Box styles"
+msgstr "Kutu stilleri"
+
+#: ../src/richtext/richtextsymboldlg.cpp:389
+#: ../src/richtext/richtextsymboldlg.cpp:391
+msgid "The font from which to take the symbol."
+msgstr "Simgenin alınacağı font."
+
+#: ../src/richtext/richtextsymboldlg.cpp:396
+msgid "&Subset:"
+msgstr "A&lt küme:"
+
+#: ../src/richtext/richtextsymboldlg.cpp:401
+#: ../src/richtext/richtextsymboldlg.cpp:403
+msgid "Shows a Unicode subset."
+msgstr "Bir Unikod alt kümesini görüntüler."
+
+#: ../src/richtext/richtextsymboldlg.cpp:412
+msgid "xxxx"
+msgstr "xxxx"
+
+#: ../src/richtext/richtextsymboldlg.cpp:417
+msgid "&Character code:"
+msgstr "&Karakter kodu:"
+
+#: ../src/richtext/richtextsymboldlg.cpp:421
+#: ../src/richtext/richtextsymboldlg.cpp:423
+msgid "The character code."
+msgstr "Karakter kodu."
+
+#: ../src/richtext/richtextsymboldlg.cpp:428
+msgid "&From:"
+msgstr "&Kaynak:"
+
+#: ../src/richtext/richtextsymboldlg.cpp:433
+#: ../src/richtext/richtextsymboldlg.cpp:434
+#: ../src/richtext/richtextsymboldlg.cpp:435
+msgid "Unicode"
+msgstr "Unikod"
+
+#: ../src/richtext/richtextsymboldlg.cpp:436
+#: ../src/richtext/richtextsymboldlg.cpp:438
+msgid "The range to show."
+msgstr "Görüntülenecek aralık."
+
+#: ../src/richtext/richtextsymboldlg.cpp:444
+msgid "Insert"
+msgstr "Insert"
+
+#: ../src/richtext/richtextsymboldlg.cpp:478
+msgid "(Normal text)"
+msgstr "(Normal metin)"
+
+#: ../src/richtext/richtexttabspage.cpp:109
+msgid "&Position (tenths of a mm):"
+msgstr "&Konum (1/10mm):"
+
+#: ../src/richtext/richtexttabspage.cpp:113
+#: ../src/richtext/richtexttabspage.cpp:115
+msgid "The tab position."
+msgstr "Sekme konumu."
+
+#: ../src/richtext/richtexttabspage.cpp:119
+msgid "The tab positions."
+msgstr "Sekme konumları."
+
+#: ../src/richtext/richtexttabspage.cpp:132
+#: ../src/richtext/richtexttabspage.cpp:134
+msgid "Click to create a new tab position."
+msgstr "Yeni bir sekme konumu oluşturmak için tıklayın."
+
+#: ../src/richtext/richtexttabspage.cpp:138
+#: ../src/richtext/richtexttabspage.cpp:140
+msgid "Click to delete the selected tab position."
+msgstr "Seçili sekme konumunu silmek için tıklayın."
+
+#: ../src/richtext/richtexttabspage.cpp:143
+msgid "Delete A&ll"
+msgstr "Tümünü si&l"
+
+#: ../src/richtext/richtexttabspage.cpp:144
+#: ../src/richtext/richtexttabspage.cpp:146
+msgid "Click to delete all tab positions."
+msgstr "Tüm sekme konumlarını silmek için tıklayın."
+
+#: ../src/univ/theme.cpp:110
+msgid "Failed to initialize GUI: no built-in themes found."
+msgstr "GUI başlatılamadı: içsel bir tema bulunamadı."
+
+#: ../src/univ/themes/gtk.cpp:521
+msgid "GTK+ theme"
+msgstr "GTK+ teması"
+
+#: ../src/univ/themes/metal.cpp:164
+msgid "Metal theme"
+msgstr "Metal tema"
+
+#: ../src/univ/themes/mono.cpp:512
+msgid "Simple monochrome theme"
+msgstr "Basit tek renkli tema"
+
+#: ../src/univ/themes/win32.cpp:1098
+msgid "Win32 theme"
+msgstr "Win32 teması"
+
+#: ../src/univ/themes/win32.cpp:3743
+msgid "&Restore"
+msgstr "Ge&ri yükle"
+
+#: ../src/univ/themes/win32.cpp:3744
+msgid "&Move"
+msgstr "&Taşı"
+
+#: ../src/univ/themes/win32.cpp:3746
+msgid "&Size"
+msgstr "&Boyut"
+
+#: ../src/univ/themes/win32.cpp:3748
+msgid "Mi&nimize"
+msgstr "Simge &durumuna küçült"
+
+#: ../src/univ/themes/win32.cpp:3750
+msgid "Ma&ximize"
+msgstr "Ekranı &kapla"
+
+#: ../src/univ/themes/win32.cpp:3752
+msgid "Alt+"
+msgstr "Alt+"
+
+#: ../src/unix/appunix.cpp:178
+msgid "Failed to install signal handler"
+msgstr "İşaret işleyici kurulamadı"
+
+#: ../src/unix/dialup.cpp:351
+msgid "Already dialling ISP."
+msgstr "ISP zaten aranıyor."
+
+#: ../src/unix/dlunix.cpp:93
+msgid "Failed to unload shared library"
+msgstr "Paylaşılan kitaplık kaldırılamadı"
+
+#: ../src/unix/dlunix.cpp:121
+msgid "Unknown dynamic library error"
+msgstr "Blinmeyen devingen kitaplık hatası"
+
+#: ../src/unix/epolldispatcher.cpp:84
+msgid "Failed to create epoll descriptor"
+msgstr "epoll tanımlayıcısı oluşturulamadı"
+
+#: ../src/unix/epolldispatcher.cpp:103
+msgid "Error closing epoll descriptor"
+msgstr "epoll tanımlayıcı kapatılırken sorun çıktı"
+
+#: ../src/unix/epolldispatcher.cpp:116
+#, c-format
+msgid "Failed to add descriptor %d to epoll descriptor %d"
+msgstr "%d tanımlayıcısı %d epoll tanımlayısıcına eklenemedi"
+
+#: ../src/unix/epolldispatcher.cpp:136
+#, c-format
+msgid "Failed to modify descriptor %d in epoll descriptor %d"
+msgstr "%d tanımlayıcısı değiştirilemedi (epoll %d tanımlayıcısındaki)"
+
+#: ../src/unix/epolldispatcher.cpp:155
+#, c-format
+msgid "Failed to unregister descriptor %d from epoll descriptor %d"
+msgstr "%d tanımlayıcısı kaldırılamadı (%d epoll tanımlayıcısından)"
+
+#: ../src/unix/epolldispatcher.cpp:213
+#, c-format
+msgid "Waiting for IO on epoll descriptor %d failed"
+msgstr "%d epoll tanımlayıcısı üstündeki GÇ beklemesi başarısız"
+
+#: ../src/unix/fswatcher_inotify.cpp:71
+msgid "Unable to create inotify instance"
+msgstr "inotify kopyası oluşturulamadı"
+
+#: ../src/unix/fswatcher_inotify.cpp:94
+msgid "Unable to close inotify instance"
+msgstr "inotify kopyası kapatılamadı"
+
+#: ../src/unix/fswatcher_inotify.cpp:106
+msgid "Unable to add inotify watch"
+msgstr "inotify izlemesi eklenemedi"
+
+#: ../src/unix/fswatcher_inotify.cpp:138
+#, c-format
+msgid "Unable to remove inotify watch %i"
+msgstr "%i inotify izlemesi kaldırılamadı"
+
+#: ../src/unix/fswatcher_inotify.cpp:271
+#, c-format
+msgid "Unexpected event for \"%s\": no matching watch descriptor."
+msgstr "\"%s\" için beklenmeyen etkinlik: Eşleşen bir izleme belirteci yok."
+
+#: ../src/unix/fswatcher_inotify.cpp:320
+#, c-format
+msgid "Invalid inotify event for \"%s\""
+msgstr "\"%s\" için inotify etkinliği geçersiz"
+
+#: ../src/unix/fswatcher_inotify.cpp:553
+msgid "Unable to read from inotify descriptor"
+msgstr "inotify tanımlayıcısı okunamadı"
+
+#: ../src/unix/fswatcher_inotify.cpp:558
+msgid "EOF while reading from inotify descriptor"
+msgstr "inotify belirteci okunurken dosya sonuna ulaşıldı"
+
+#: ../src/unix/fswatcher_kqueue.cpp:114
+msgid "Unable to create kqueue instance"
+msgstr "kqueue kopyası oluşturulamadı"
+
+#: ../src/unix/fswatcher_kqueue.cpp:131
+msgid "Error closing kqueue instance"
+msgstr "kqueue kopyası kapatılırken sorun çıktı"
+
+#: ../src/unix/fswatcher_kqueue.cpp:153
+msgid "Unable to add kqueue watch"
+msgstr "kqueue izlemesi eklenemedi"
+
+#: ../src/unix/fswatcher_kqueue.cpp:170
+msgid "Unable to remove kqueue watch"
+msgstr "kqueue izlemesi kaldırılamadı"
+
+#: ../src/unix/fswatcher_kqueue.cpp:202
+msgid "Unable to get events from kqueue"
+msgstr "Olaylar kqueue üzerinden alınamadı"
+
+#: ../src/unix/mediactrl.cpp:966
+#, c-format
+msgid "Media playback error: %s"
+msgstr "Ortam oynatma hatası: %s"
+
+#: ../src/unix/mediactrl.cpp:1228
+#, c-format
+msgid "Failed to prepare playing \"%s\"."
+msgstr "\"%s\" oynatmaya hazırlanamadı."
+
+#: ../src/unix/snglinst.cpp:164
+#, c-format
+msgid "Failed to write to lock file '%s'"
+msgstr "'%s' kilit dosyasına yazılamadı"
+
+#: ../src/unix/snglinst.cpp:177
+#, c-format
+msgid "Failed to set permissions on lock file '%s'"
+msgstr "'%s' kilit dosyasının izinleri ayarlanamadı"
+
+#: ../src/unix/snglinst.cpp:194
+#, c-format
+msgid "Failed to lock the lock file '%s'"
+msgstr "'%s' kilit dosyası kilitlenemedi"
+
+#: ../src/unix/snglinst.cpp:237
+#, c-format
+msgid "Failed to inspect the lock file '%s'"
+msgstr "'%s' kilit dosyası incelenemedi"
+
+#: ../src/unix/snglinst.cpp:242
+#, c-format
+msgid "Lock file '%s' has incorrect owner."
+msgstr "'%s' kilit dosyasının sahibi hatalı."
+
+#: ../src/unix/snglinst.cpp:247
+#, c-format
+msgid "Lock file '%s' has incorrect permissions."
+msgstr "'%s' kilit dosyasının izinleri doğru değil."
+
+#: ../src/unix/snglinst.cpp:265
+msgid "Failed to access lock file."
+msgstr "Kilit dosyasına erişilemedi."
+
+#: ../src/unix/snglinst.cpp:274
+msgid "Failed to read PID from lock file."
+msgstr "Kilit dosyasından PID okunamadı."
+
+#: ../src/unix/snglinst.cpp:284
+#, c-format
+msgid "Failed to remove stale lock file '%s'."
+msgstr "'%s' eski kilit dosyası silinemedi."
+
+#: ../src/unix/snglinst.cpp:297
+#, c-format
+msgid "Deleted stale lock file '%s'."
+msgstr "Eski kilit dosyası '%s' silindi."
+
+#: ../src/unix/snglinst.cpp:308
+#, c-format
+msgid "Invalid lock file '%s'."
+msgstr "'%s' kilit dosyası geçersiz."
+
+#: ../src/unix/snglinst.cpp:324
+#, c-format
+msgid "Failed to remove lock file '%s'"
+msgstr "'%s' kilit dosyası silinemedi"
+
+#: ../src/unix/snglinst.cpp:330
+#, c-format
+msgid "Failed to unlock lock file '%s'"
+msgstr "'%s' kilit dosyasının kilidi kaldırılamadı"
+
+#: ../src/unix/snglinst.cpp:336
+#, c-format
+msgid "Failed to close lock file '%s'"
+msgstr "'%s' kilit dosyası kapatılamadı"
+
+#: ../src/unix/sound.cpp:77
+msgid "No sound"
+msgstr "Ses yok"
+
+#: ../src/unix/sound.cpp:364
+msgid "Unable to play sound asynchronously."
+msgstr "Ses zaman eşlemesiz olarak çalınamıyor."
+
+#: ../src/unix/sound.cpp:458
+#, c-format
+msgid "Couldn't load sound data from '%s'."
+msgstr "'%s' içinden ses verisi yüklenemedi."
+
+#: ../src/unix/sound.cpp:465
+#, c-format
+msgid "Sound file '%s' is in unsupported format."
+msgstr "'%s' ses dosyası desteklenmeyen bir biçimde."
+
+#: ../src/unix/sound.cpp:480
+msgid "Sound data are in unsupported format."
+msgstr "Ses verisi desteklenmeyen bir biçimde."
+
+#: ../src/unix/sound_sdl.cpp:226
+#, c-format
+msgid "Couldn't open audio: %s"
+msgstr "Ses açılamadı: %s"
+
+#: ../src/unix/threadpsx.cpp:1033
+msgid "Cannot retrieve thread scheduling policy."
+msgstr "İş parçacığı zamanlama ilkesi alınamadı."
+
+#: ../src/unix/threadpsx.cpp:1058
+#, c-format
+msgid "Cannot get priority range for scheduling policy %d."
+msgstr "Zamanlama ilkesi %d için öncelik aralığı alınamadı."
+
+#: ../src/unix/threadpsx.cpp:1066
+msgid "Thread priority setting is ignored."
+msgstr "İş parçacığı öncelik ayarları yok sayıldı."
+
+#: ../src/unix/threadpsx.cpp:1221
+msgid ""
+"Failed to join a thread, potential memory leak detected - please restart the "
+"program"
+msgstr ""
+"İş parçacığına katılınamadı, olası bellek taşması bulundu - lütfen programı "
+"yeniden başlatın"
+
+#: ../src/unix/threadpsx.cpp:1352
+#, c-format
+msgid "Failed to set thread concurrency level to %lu"
+msgstr "%lu iş parçacığı öncelik düzeyi ayarlanamadı"
+
+#: ../src/unix/threadpsx.cpp:1481
+#, c-format
+msgid "Failed to set thread priority %d."
+msgstr "%d iş parçacığı önceliği ayarlanamadı."
+
+#: ../src/unix/threadpsx.cpp:1666
+msgid "Failed to terminate a thread."
+msgstr "Bir iş parçacığı sonlandırılamadı."
+
+#: ../src/unix/threadpsx.cpp:1893
+msgid "Thread module initialization failed: failed to create thread key"
+msgstr ""
+"İş parçacığı modülü başlatılamadı: İş parçacığı anahtarı oluşturulamadı"
+
+#: ../src/unix/utilsunx.cpp:340
+msgid "Impossible to get child process input"
+msgstr "Alt iş girdisi alınamıyor"
+
+#: ../src/unix/utilsunx.cpp:390
+msgid "Can't write to child process's stdin"
+msgstr "Alt işlem stdin yazılamadı"
+
+#: ../src/unix/utilsunx.cpp:644
+#, c-format
+msgid "Failed to execute '%s'\n"
+msgstr "'%s' yürütülemedi\n"
+
+#: ../src/unix/utilsunx.cpp:678
+msgid "Fork failed"
+msgstr "Ayrılma başarısız"
+
+#: ../src/unix/utilsunx.cpp:701
+msgid "Failed to set process priority"
+msgstr "İşlem önceliği ayarlanamadı"
+
+#: ../src/unix/utilsunx.cpp:712
+msgid "Failed to redirect child process input/output"
+msgstr "Alt iş giriş/çıkışı yönlendirilemedi"
+
+#: ../src/unix/utilsunx.cpp:816
+msgid "Failed to set up non-blocking pipe, the program might hang."
+msgstr "Engellemesiz tünel kurulamadı, program takılabilir."
+
+#: ../src/unix/utilsunx.cpp:1023
+msgid "Cannot get the hostname"
+msgstr "Sunucu adı alınamadı"
+
+#: ../src/unix/utilsunx.cpp:1059
+msgid "Cannot get the official hostname"
+msgstr "Resmi sunucu adı alınamadı"
+
+#: ../src/unix/wakeuppipe.cpp:49
+msgid "Failed to create wake up pipe used by event loop."
+msgstr "Olay döngüsünde kullanılan uyandırma tüneli oluşturulamadı."
+
+#: ../src/unix/wakeuppipe.cpp:56
+msgid "Failed to switch wake up pipe to non-blocking mode"
+msgstr "Uyandırma tüneli engellemesiz kipe döndürülemedi"
+
+#: ../src/unix/wakeuppipe.cpp:117
+msgid "Failed to read from wake-up pipe"
+msgstr "Uyandırma tüneli okunamadı"
+
+#: ../src/x11/app.cpp:124
+#, c-format
+msgid "Invalid geometry specification '%s'"
+msgstr "'%s' geometri özelliği geçersiz."
+
+#: ../src/x11/app.cpp:167
+msgid "wxWidgets could not open display. Exiting."
+msgstr "wxWidgets görünümü açamadı. Çıkılıyor."
+
+#: ../src/x11/utils.cpp:169
+#, c-format
+msgid "Failed to close the display \"%s\""
+msgstr "\"%s\" görüntüsü kapatılamadı"
+
+#: ../src/x11/utils.cpp:188
+#, c-format
+msgid "Failed to open display \"%s\"."
+msgstr "\"%s\" görüntüsü açılamadı."
+
+#: ../src/xml/xml.cpp:868
+#, c-format
+msgid "XML parsing error: '%s' at line %d"
+msgstr "XML işleme sorunu: '%s' %d satırında"
+
+#: ../src/xrc/xh_propgrid.cpp:239
+#, c-format
+msgid "Page %i"
+msgstr "Sayfa %i"
+
+#: ../src/xrc/xmlres.cpp:448
+#, c-format
+msgid "Cannot load resources from '%s'."
+msgstr "Kaynaklar '%s' dosyasından yüklenemedi."
+
+#: ../src/xrc/xmlres.cpp:799
+#, c-format
+msgid "Cannot open resources file '%s'."
+msgstr "'%s' kaynak dosyası açılamadı."
+
+#: ../src/xrc/xmlres.cpp:806
+#, c-format
+msgid "Cannot load resources from file '%s'."
+msgstr "Kaynaklar '%s' dosyasından yüklenemedi."
+
+#: ../src/xrc/xmlres.cpp:2767
+#, c-format
+msgid "Creating %s \"%s\" failed."
+msgstr "%s \"%s\" oluşturulamadı."
+
+#, c-format
+#~ msgid "BMP: header has biClrUsed=%d when biBitCount=%d."
+#~ msgstr "BMP: biBitCount=%d iken üst bilgide biClrUsed=%d."
+
+#~ msgctxt "keyboard key"
+#~ msgid "Alt+"
+#~ msgstr "Alt+"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Ctrl+"
+#~ msgstr "Ctrl+"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Shift+"
+#~ msgstr "Shift+"
+
+#~ msgctxt "keyboard key"
+#~ msgid "RawCtrl+"
+#~ msgstr "HamCtrl+"
+
+#~ msgid "Copying more than one selected block to clipboard is not supported."
+#~ msgstr "Seçilmiş bir bloktan fazlasının panoya kopyalanması desteklenmiyor."
+
+#~ msgid "Unsupported clipboard format."
+#~ msgstr "Pano biçimi desteklenmiyor."
+
+#~ msgid "Background colour"
+#~ msgstr "Arka plan rengi"
+
+#~ msgid "Font:"
+#~ msgstr "Yazı türü:"
+
+#~ msgid "Size:"
+#~ msgstr "Boyut:"
+
+#~ msgid "The font size in points."
+#~ msgstr "Punto olarak yazı türü boyutu."
+
+#~ msgid "Style:"
+#~ msgstr "Biçem:"
+
+#~ msgid "Check to make the font bold."
+#~ msgstr "Koyu yazı türü için işaretleyin."
+
+#~ msgid "Check to make the font italic."
+#~ msgstr "Yatık yazı türü için işaretleyin."
+
+#~ msgid "Check to make the font underlined."
+#~ msgstr "Altı çizili yazı türü için işaretleyin."
+
+#~ msgid "Colour:"
+#~ msgstr "Renk:"
+
+#~ msgid "Click to change the font colour."
+#~ msgstr "Metin rengini değiştirmek için tıklayın."
+
+#~ msgid "Shows a preview of the font."
+#~ msgstr "Yazı türünün ön izlemesini görüntüler."
+
+#~ msgid "Click to cancel changes to the font."
+#~ msgstr "Yazı türü değişikliklerinden vazgeçmek için tıklayın."
+
+#~ msgid "Click to confirm changes to the font."
+#~ msgstr "Yazı türündeki değişiklikleri onaylamak için tıklayın."
+
+#~ msgid "<Any>"
+#~ msgstr "<Any>"
+
+#~ msgid "<Any Roman>"
+#~ msgstr "<Any Roman>"
+
+#~ msgid "<Any Decorative>"
+#~ msgstr "<Any Decorative>"
+
+#~ msgid "<Any Modern>"
+#~ msgstr "<Any Modern>"
+
+#~ msgid "<Any Script>"
+#~ msgstr "<Any Script>"
+
+#~ msgid "<Any Swiss>"
+#~ msgstr "<Any Swiss>"
+
+#~ msgid "<Any Teletype>"
+#~ msgstr "<Any Teletype>"
+
+#~ msgid "Printing "
+#~ msgstr "Yazdırılıyor "
+
+#~ msgid "Failed to insert text in the control."
+#~ msgstr "Metin denetime eklenemedi."
+
+#~ msgid "Please choose a valid font."
+#~ msgstr "Lütfen geçerli bir yazı türü seçin."
+
+#, c-format
+#~ msgid "Failed to display HTML document in %s encoding"
+#~ msgstr "HTML belgesi %s kodlamasıyla görüntülenemedi"
+
+#, c-format
+#~ msgid "wxWidgets could not open display for '%s': exiting."
+#~ msgstr "wxWidgets '%s' için görünümü açamadı: Çıkılıyor."
+
+#~ msgid "Filter"
+#~ msgstr "Süzgeç"
+
+#~ msgid "Directories"
+#~ msgstr "Klasörler"
+
+#~ msgid "Files"
+#~ msgstr "Dosyalar"
+
+#~ msgid "Selection"
+#~ msgstr "Seçim"
+
+#~ msgid "conversion to 8-bit encoding failed"
+#~ msgstr "8-bit kodlama dönüşümü yapılamadı"
+
+#~ msgid "failed to retrieve execution result"
+#~ msgstr "yürütme sonucu alınamadı"

--- a/po_wxstd/uk.po
+++ b/po_wxstd/uk.po
@@ -1,0 +1,10443 @@
+# translation of wxstd.pot to Ukrainian
+# This file is distributed under the same license as the wxWidgets package.
+#
+# Yuri Chornoivan <yurchor@ukr.net>, 2007-2022, 2025.
+msgid ""
+msgstr ""
+"Project-Id-Version: wxWidgets 3.3\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-05-14 20:23+0200\n"
+"PO-Revision-Date: 2025-05-16 19:34+0300\n"
+"Last-Translator: Yuri Chornoivan <yurchor@ukr.net>\n"
+"Language-Team: Ukrainian <trans-uk@lists.fedoraproject.org>\n"
+"Language: uk\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Lokalize 23.04.3\n"
+"Plural-Forms: nplurals=4; plural=n==1 ? 3 : n%10==1 && n%100!=11 ? 0 : n"
+"%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
+
+#: ../include/wx/defs.h:2582
+msgid "All files (*.*)|*.*"
+msgstr "Всі файли (*.*)|*.*"
+
+#: ../include/wx/defs.h:2585
+msgid "All files (*)|*"
+msgstr "Всі файли (*)|*"
+
+#: ../include/wx/generic/progdlgg.h:85
+msgid "Elapsed time:"
+msgstr "Минуло часу:"
+
+#: ../include/wx/generic/progdlgg.h:86
+msgid "Estimated time:"
+msgstr "Оцінка часу:"
+
+#: ../include/wx/generic/progdlgg.h:87
+msgid "Remaining time:"
+msgstr "Час, що залишився:"
+
+#. TRANSLATORS: HTML printout default title.
+#: ../include/wx/html/htmprint.h:121 ../include/wx/prntbase.h:273
+#: ../include/wx/richtext/richtextprint.h:109 ../src/common/docview.cpp:2161
+msgid "Printout"
+msgstr "Відбиток"
+
+#. TRANSLATORS: HTML easy print default title.
+#: ../include/wx/html/htmprint.h:234 ../include/wx/richtext/richtextprint.h:163
+#: ../src/common/prntbase.cpp:522 ../src/html/htmprint.cpp:291
+msgid "Printing"
+msgstr "Друк"
+
+#: ../include/wx/msgdlg.h:277 ../src/common/stockitem.cpp:211
+msgid "Yes"
+msgstr "Так"
+
+#: ../include/wx/msgdlg.h:278 ../src/common/stockitem.cpp:182
+msgid "No"
+msgstr "Ні"
+
+#: ../include/wx/msgdlg.h:279 ../src/common/stockitem.cpp:183
+#: ../src/msw/msgdlg.cpp:430 ../src/msw/msgdlg.cpp:734
+#: ../src/richtext/richtextstyledlg.cpp:292
+msgid "OK"
+msgstr "Гаразд"
+
+#: ../include/wx/msgdlg.h:280 ../src/common/stockitem.cpp:150
+#: ../src/msw/msgdlg.cpp:430 ../src/msw/progdlg.cpp:884
+#: ../src/richtext/richtextstyledlg.cpp:295
+msgid "Cancel"
+msgstr "Скасувати"
+
+#: ../include/wx/msgdlg.h:281 ../src/common/stockitem.cpp:168
+#: ../src/html/helpdlg.cpp:63 ../src/html/helpfrm.cpp:108
+#: ../src/osx/button_osx.cpp:38
+msgid "Help"
+msgstr "Довідка"
+
+#: ../include/wx/msw/ole/oleutils.h:52
+msgid "Cannot initialize OLE"
+msgstr "Не вдалося ініціювати OLE"
+
+#: ../include/wx/msw/private/fswatcher.h:48
+#, c-format
+msgid "Unable to close the handle for '%s'"
+msgstr "Не вдалося завершити роботу обробника «%s»"
+
+#: ../include/wx/msw/private/fswatcher.h:92
+#, c-format
+msgid "Failed to open directory \"%s\" for monitoring."
+msgstr "Не вдалося відкрити каталог «%s» для спостереження."
+
+#: ../include/wx/msw/private/fswatcher.h:125
+msgid "Unable to close I/O completion port handle"
+msgstr "Не вдалося закрити обробник порту доповнення введення-виведення"
+
+#: ../include/wx/msw/private/fswatcher.h:142
+msgid "Unable to associate handle with I/O completion port"
+msgstr "Не вдалося пов’язати обробник з портом завершення введення-виведення"
+
+#: ../include/wx/msw/private/fswatcher.h:148
+msgid "Unexpectedly new I/O completion port was created"
+msgstr "Неочікувано створено новий порт доповнення введення-виведення"
+
+#: ../include/wx/msw/private/fswatcher.h:213
+msgid "Unable to post completion status"
+msgstr "Не вдалося повідомити про стан завершення"
+
+#: ../include/wx/msw/private/fswatcher.h:262
+msgid "Unable to dequeue completion packet"
+msgstr "Не вдалося вилучити з черги пакет завершення"
+
+#: ../include/wx/msw/private/fswatcher.h:273
+msgid "Unable to create I/O completion port"
+msgstr "Не вдалося створити порт завершення введення-виведення"
+
+#: ../include/wx/richmsgdlg.h:29
+msgid "&See details"
+msgstr "&Докладно"
+
+#: ../include/wx/richmsgdlg.h:30
+msgid "&Hide details"
+msgstr "С&ховати подробиці"
+
+#: ../include/wx/richtext/richtextbuffer.h:3864
+msgid "&Box"
+msgstr "&Рамка"
+
+#: ../include/wx/richtext/richtextbuffer.h:5008
+msgid "&Picture"
+msgstr "&Зображення"
+
+#: ../include/wx/richtext/richtextbuffer.h:5958
+msgid "&Cell"
+msgstr "К&омірка"
+
+#: ../include/wx/richtext/richtextbuffer.h:6067
+msgid "&Table"
+msgstr "&Таблиця"
+
+#: ../include/wx/richtext/richtextimagedlg.h:37
+msgid "Object Properties"
+msgstr "Властивості об'єкта"
+
+#: ../include/wx/richtext/richtextsymboldlg.h:39
+msgid "Symbols"
+msgstr "Символи"
+
+#: ../include/wx/unix/pipe.h:46
+msgid "Pipe creation failed"
+msgstr "Помилка створення потоку вводу-виводу"
+
+#: ../include/wx/unix/private/displayx11.h:65
+msgid "Failed to enumerate video modes"
+msgstr "Не вдалося пронумерувати відео режими"
+
+#: ../include/wx/unix/private/displayx11.h:89
+msgid "Failed to change video mode"
+msgstr "Не вдалося змінити відео режим."
+
+#: ../include/wx/unix/private/fswatcher_kqueue.h:57
+#, c-format
+msgid "Unable to open path '%s'"
+msgstr "Не вдалося відкрити адресу «%s»"
+
+#: ../include/wx/unix/private/fswatcher_kqueue.h:74
+#, c-format
+msgid "Unable to close path '%s'"
+msgstr "Не вдалося закрити адресу «%s»"
+
+#: ../include/wx/xtiprop.h:175
+msgid "SetProperty called w/o valid setter"
+msgstr "SetProperty викликано без коректного встановлювача"
+
+#: ../include/wx/xtiprop.h:184
+msgid "GetProperty called w/o valid getter"
+msgstr "GetProperty викликано без коректного отримувача"
+
+#: ../include/wx/xtiprop.h:193
+msgid "AddToPropertyCollection called w/o valid adder"
+msgstr "AddToPropertyCollection викликано без коректного параметра додавання"
+
+#: ../include/wx/xtiprop.h:202
+msgid "GetPropertyCollection called w/o valid collection getter"
+msgstr "GetPropertyCollection викликано без чинного параметра збірки"
+
+#: ../include/wx/xtiprop.h:255
+msgid "AddToPropertyCollection called on a generic accessor"
+msgstr "AddToPropertyCollection викликано для загального засобу доступу"
+
+#: ../include/wx/xtiprop.h:262
+msgid "GetPropertyCollection called on a generic accessor"
+msgstr "GetPropertyCollection викликано для загального засобу доступу"
+
+#: ../src/aui/tabmdi.cpp:106 ../src/generic/mdig.cpp:94
+msgid "Cl&ose"
+msgstr "Закрити"
+
+#: ../src/aui/tabmdi.cpp:107 ../src/generic/mdig.cpp:95
+msgid "Close All"
+msgstr "Закрити все"
+
+#: ../src/aui/tabmdi.cpp:109 ../src/generic/mdig.cpp:97 ../src/msw/mdi.cpp:175
+#: ../src/qt/mdi.cpp:258
+msgid "&Next"
+msgstr "&Наступний"
+
+#: ../src/aui/tabmdi.cpp:110 ../src/generic/mdig.cpp:98 ../src/msw/mdi.cpp:176
+#: ../src/qt/mdi.cpp:259
+msgid "&Previous"
+msgstr "Попереднє"
+
+#: ../src/aui/tabmdi.cpp:332 ../src/aui/tabmdi.cpp:348
+#: ../src/aui/tabmdi.cpp:350 ../src/generic/mdig.cpp:291
+#: ../src/generic/mdig.cpp:307 ../src/generic/mdig.cpp:311
+#: ../src/msw/mdi.cpp:337 ../src/qt/mdi.cpp:462
+msgid "&Window"
+msgstr "&Вікно"
+
+#: ../src/common/accelcmn.cpp:47
+msgctxt "keyboard key"
+msgid "Delete"
+msgstr "Вилучити"
+
+#: ../src/common/accelcmn.cpp:48
+msgctxt "keyboard key"
+msgid "Del"
+msgstr "Del"
+
+#: ../src/common/accelcmn.cpp:49
+msgctxt "keyboard key"
+msgid "Back"
+msgstr "Назад"
+
+#: ../src/common/accelcmn.cpp:49
+msgctxt "keyboard key"
+msgid "Backspace"
+msgstr "Backspace"
+
+#: ../src/common/accelcmn.cpp:50
+msgctxt "keyboard key"
+msgid "Insert"
+msgstr "Insert"
+
+#: ../src/common/accelcmn.cpp:51
+msgctxt "keyboard key"
+msgid "Ins"
+msgstr "Ins"
+
+#: ../src/common/accelcmn.cpp:52
+msgctxt "keyboard key"
+msgid "Enter"
+msgstr "Enter"
+
+#: ../src/common/accelcmn.cpp:53
+msgctxt "keyboard key"
+msgid "Return"
+msgstr "Return"
+
+#: ../src/common/accelcmn.cpp:54
+msgctxt "keyboard key"
+msgid "PageUp"
+msgstr "PageUp"
+
+#: ../src/common/accelcmn.cpp:54
+msgctxt "keyboard key"
+msgid "Page Up"
+msgstr "На сторінку вгору"
+
+#: ../src/common/accelcmn.cpp:55
+msgctxt "keyboard key"
+msgid "PageDown"
+msgstr "PageDown"
+
+#: ../src/common/accelcmn.cpp:55
+msgctxt "keyboard key"
+msgid "Page Down"
+msgstr "На сторінку вниз"
+
+#: ../src/common/accelcmn.cpp:56
+msgctxt "keyboard key"
+msgid "PgUp"
+msgstr "PgUp"
+
+#: ../src/common/accelcmn.cpp:57
+msgctxt "keyboard key"
+msgid "PgDn"
+msgstr "PgDn"
+
+#: ../src/common/accelcmn.cpp:58
+msgctxt "keyboard key"
+msgid "Left"
+msgstr "←"
+
+#: ../src/common/accelcmn.cpp:59
+msgctxt "keyboard key"
+msgid "Right"
+msgstr "→"
+
+#: ../src/common/accelcmn.cpp:60
+msgctxt "keyboard key"
+msgid "Up"
+msgstr "↑"
+
+#: ../src/common/accelcmn.cpp:61
+msgctxt "keyboard key"
+msgid "Down"
+msgstr "↓"
+
+#: ../src/common/accelcmn.cpp:62
+msgctxt "keyboard key"
+msgid "Home"
+msgstr "Домівка"
+
+#: ../src/common/accelcmn.cpp:63
+msgctxt "keyboard key"
+msgid "End"
+msgstr "End"
+
+#: ../src/common/accelcmn.cpp:64
+msgctxt "keyboard key"
+msgid "Space"
+msgstr "Пробіл"
+
+#: ../src/common/accelcmn.cpp:65
+msgctxt "keyboard key"
+msgid "Tab"
+msgstr "Tab"
+
+#: ../src/common/accelcmn.cpp:66
+msgctxt "keyboard key"
+msgid "Esc"
+msgstr "Esc"
+
+#: ../src/common/accelcmn.cpp:67
+msgctxt "keyboard key"
+msgid "Escape"
+msgstr "Escape"
+
+#: ../src/common/accelcmn.cpp:68
+msgctxt "keyboard key"
+msgid "Cancel"
+msgstr "Скасувати"
+
+#: ../src/common/accelcmn.cpp:69
+msgctxt "keyboard key"
+msgid "Clear"
+msgstr "Спорожнити"
+
+#: ../src/common/accelcmn.cpp:70
+msgctxt "keyboard key"
+msgid "Menu"
+msgstr "Меню"
+
+#: ../src/common/accelcmn.cpp:71
+msgctxt "keyboard key"
+msgid "Pause"
+msgstr "Призупинити"
+
+#: ../src/common/accelcmn.cpp:72
+msgctxt "keyboard key"
+msgid "Capital"
+msgstr "Великі"
+
+#: ../src/common/accelcmn.cpp:73
+msgctxt "keyboard key"
+msgid "Select"
+msgstr "Вибрати"
+
+#: ../src/common/accelcmn.cpp:74
+msgctxt "keyboard key"
+msgid "Print"
+msgstr "Друк"
+
+#: ../src/common/accelcmn.cpp:75
+msgctxt "keyboard key"
+msgid "Execute"
+msgstr "Виконати"
+
+#: ../src/common/accelcmn.cpp:76
+msgctxt "keyboard key"
+msgid "Snapshot"
+msgstr "Знімок"
+
+#: ../src/common/accelcmn.cpp:77
+msgctxt "keyboard key"
+msgid "Help"
+msgstr "Довідка"
+
+#: ../src/common/accelcmn.cpp:78
+msgctxt "keyboard key"
+msgid "Add"
+msgstr "Додати"
+
+#: ../src/common/accelcmn.cpp:79
+msgctxt "keyboard key"
+msgid "Separator"
+msgstr "Роздільник"
+
+#: ../src/common/accelcmn.cpp:80
+msgctxt "keyboard key"
+msgid "Subtract"
+msgstr "Віднімання"
+
+#: ../src/common/accelcmn.cpp:81
+msgctxt "keyboard key"
+msgid "Decimal"
+msgstr "Десяткове"
+
+#: ../src/common/accelcmn.cpp:82
+msgctxt "keyboard key"
+msgid "Multiply"
+msgstr "Множення"
+
+#: ../src/common/accelcmn.cpp:83
+msgctxt "keyboard key"
+msgid "Divide"
+msgstr "Ділення"
+
+#: ../src/common/accelcmn.cpp:84
+msgctxt "keyboard key"
+msgid "Num_lock"
+msgstr "Num_lock"
+
+#: ../src/common/accelcmn.cpp:84
+msgctxt "keyboard key"
+msgid "Num Lock"
+msgstr "Num Lock"
+
+#: ../src/common/accelcmn.cpp:85
+msgctxt "keyboard key"
+msgid "Scroll_lock"
+msgstr "Scroll_lock"
+
+#: ../src/common/accelcmn.cpp:85
+msgctxt "keyboard key"
+msgid "Scroll Lock"
+msgstr "Scroll Lock"
+
+#: ../src/common/accelcmn.cpp:86
+msgctxt "keyboard key"
+msgid "KP_Space"
+msgstr "KP_Space"
+
+#: ../src/common/accelcmn.cpp:86
+msgctxt "keyboard key"
+msgid "Num Space"
+msgstr "Цифр. пробіл"
+
+#: ../src/common/accelcmn.cpp:87
+msgctxt "keyboard key"
+msgid "KP_Tab"
+msgstr "KP_Tab"
+
+#: ../src/common/accelcmn.cpp:87
+msgctxt "keyboard key"
+msgid "Num Tab"
+msgstr "Цифр. Tab"
+
+#: ../src/common/accelcmn.cpp:88
+msgctxt "keyboard key"
+msgid "KP_Enter"
+msgstr "KP_Enter"
+
+#: ../src/common/accelcmn.cpp:88
+msgctxt "keyboard key"
+msgid "Num Enter"
+msgstr "Цифр. Enter"
+
+#: ../src/common/accelcmn.cpp:89
+msgctxt "keyboard key"
+msgid "KP_Home"
+msgstr "KP_Home"
+
+#: ../src/common/accelcmn.cpp:89
+msgctxt "keyboard key"
+msgid "Num Home"
+msgstr "Цифр. Home"
+
+#: ../src/common/accelcmn.cpp:90
+msgctxt "keyboard key"
+msgid "KP_Left"
+msgstr "KP_Left"
+
+#: ../src/common/accelcmn.cpp:90
+msgctxt "keyboard key"
+msgid "Num left"
+msgstr "Цифр. ліворуч"
+
+#: ../src/common/accelcmn.cpp:91
+msgctxt "keyboard key"
+msgid "KP_Up"
+msgstr "KP_Up"
+
+#: ../src/common/accelcmn.cpp:91
+msgctxt "keyboard key"
+msgid "Num Up"
+msgstr "Цифр. вгору"
+
+#: ../src/common/accelcmn.cpp:92
+msgctxt "keyboard key"
+msgid "KP_Right"
+msgstr "KP_Right"
+
+#: ../src/common/accelcmn.cpp:92
+msgctxt "keyboard key"
+msgid "Num Right"
+msgstr "Цифр. праворуч"
+
+#: ../src/common/accelcmn.cpp:93
+msgctxt "keyboard key"
+msgid "KP_Down"
+msgstr "KP_Down"
+
+#: ../src/common/accelcmn.cpp:93
+msgctxt "keyboard key"
+msgid "Num Down"
+msgstr "Цифр. донизу"
+
+#: ../src/common/accelcmn.cpp:94
+msgctxt "keyboard key"
+msgid "KP_PageUp"
+msgstr "KP_PageUp"
+
+#: ../src/common/accelcmn.cpp:94
+msgctxt "keyboard key"
+msgid "Num Page Up"
+msgstr "Цифр. Page Up"
+
+#: ../src/common/accelcmn.cpp:95
+msgctxt "keyboard key"
+msgid "KP_PageDown"
+msgstr "KP_PageDown"
+
+#: ../src/common/accelcmn.cpp:95
+msgctxt "keyboard key"
+msgid "Num Page Down"
+msgstr "Цифр. Page Down"
+
+#: ../src/common/accelcmn.cpp:96
+msgctxt "keyboard key"
+msgid "KP_Prior"
+msgstr "KP_Prior"
+
+#: ../src/common/accelcmn.cpp:97
+msgctxt "keyboard key"
+msgid "KP_Next"
+msgstr "KP_Next"
+
+#: ../src/common/accelcmn.cpp:98
+msgctxt "keyboard key"
+msgid "KP_End"
+msgstr "KP_End"
+
+#: ../src/common/accelcmn.cpp:98
+msgctxt "keyboard key"
+msgid "Num End"
+msgstr "Цифр. End"
+
+#: ../src/common/accelcmn.cpp:99
+msgctxt "keyboard key"
+msgid "KP_Begin"
+msgstr "KP_Begin"
+
+#: ../src/common/accelcmn.cpp:99
+msgctxt "keyboard key"
+msgid "Num Begin"
+msgstr "Цифр. Begin"
+
+#: ../src/common/accelcmn.cpp:100
+msgctxt "keyboard key"
+msgid "KP_Insert"
+msgstr "KP_Insert"
+
+#: ../src/common/accelcmn.cpp:100
+msgctxt "keyboard key"
+msgid "Num Insert"
+msgstr "Цифр. Insert"
+
+#: ../src/common/accelcmn.cpp:101
+msgctxt "keyboard key"
+msgid "KP_Delete"
+msgstr "KP_Delete"
+
+#: ../src/common/accelcmn.cpp:101
+msgctxt "keyboard key"
+msgid "Num Delete"
+msgstr "Цифр. Delete"
+
+#: ../src/common/accelcmn.cpp:102
+msgctxt "keyboard key"
+msgid "KP_Equal"
+msgstr "KP_Equal"
+
+#: ../src/common/accelcmn.cpp:102
+msgctxt "keyboard key"
+msgid "Num ="
+msgstr "Цифр. ="
+
+#: ../src/common/accelcmn.cpp:103
+msgctxt "keyboard key"
+msgid "KP_Multiply"
+msgstr "KP_Multiply"
+
+#: ../src/common/accelcmn.cpp:103
+msgctxt "keyboard key"
+msgid "Num *"
+msgstr "Цифр. *"
+
+#: ../src/common/accelcmn.cpp:104
+msgctxt "keyboard key"
+msgid "KP_Add"
+msgstr "KP_Add"
+
+#: ../src/common/accelcmn.cpp:104
+msgctxt "keyboard key"
+msgid "Num +"
+msgstr "Цифр. +"
+
+#: ../src/common/accelcmn.cpp:105
+msgctxt "keyboard key"
+msgid "KP_Separator"
+msgstr "KP_Separator"
+
+#: ../src/common/accelcmn.cpp:105
+msgctxt "keyboard key"
+msgid "Num ,"
+msgstr "Цифр. ,"
+
+#: ../src/common/accelcmn.cpp:106
+msgctxt "keyboard key"
+msgid "KP_Subtract"
+msgstr "KP_Subtract"
+
+#: ../src/common/accelcmn.cpp:106
+msgctxt "keyboard key"
+msgid "Num -"
+msgstr "Цифр. -"
+
+#: ../src/common/accelcmn.cpp:107
+msgctxt "keyboard key"
+msgid "KP_Decimal"
+msgstr "KP_Decimal"
+
+#: ../src/common/accelcmn.cpp:107
+msgctxt "keyboard key"
+msgid "Num ."
+msgstr "Цифр. ."
+
+#: ../src/common/accelcmn.cpp:108
+msgctxt "keyboard key"
+msgid "KP_Divide"
+msgstr "KP_Divide"
+
+#: ../src/common/accelcmn.cpp:108
+msgctxt "keyboard key"
+msgid "Num /"
+msgstr "Цифр. /"
+
+#: ../src/common/accelcmn.cpp:109
+msgctxt "keyboard key"
+msgid "Windows_Left"
+msgstr "Windows_Left"
+
+#: ../src/common/accelcmn.cpp:110
+msgctxt "keyboard key"
+msgid "Windows_Right"
+msgstr "Windows_Right"
+
+#: ../src/common/accelcmn.cpp:111
+msgctxt "keyboard key"
+msgid "Windows_Menu"
+msgstr "Меню_Windows"
+
+#: ../src/common/accelcmn.cpp:112
+msgctxt "keyboard key"
+msgid "Command"
+msgstr "Команда"
+
+#: ../src/common/accelcmn.cpp:186 ../src/common/accelcmn.cpp:359
+msgctxt "keyboard key"
+msgid "Ctrl"
+msgstr "Ctrl"
+
+#: ../src/common/accelcmn.cpp:188 ../src/common/accelcmn.cpp:363
+msgctxt "keyboard key"
+msgid "Alt"
+msgstr "Alt"
+
+#: ../src/common/accelcmn.cpp:190 ../src/common/accelcmn.cpp:361
+msgctxt "keyboard key"
+msgid "Shift"
+msgstr "Shift"
+
+#: ../src/common/accelcmn.cpp:196
+msgctxt "keyboard key"
+msgid "num "
+msgstr "num "
+
+#: ../src/common/accelcmn.cpp:260 ../src/common/accelcmn.cpp:382
+msgctxt "keyboard key"
+msgid "F"
+msgstr "F"
+
+#: ../src/common/accelcmn.cpp:277 ../src/common/accelcmn.cpp:385
+msgctxt "keyboard key"
+msgid "KP_F"
+msgstr "KP_F"
+
+#: ../src/common/accelcmn.cpp:280 ../src/common/accelcmn.cpp:388
+msgctxt "keyboard key"
+msgid "KP_"
+msgstr "KP_"
+
+#: ../src/common/accelcmn.cpp:283 ../src/common/accelcmn.cpp:391
+msgctxt "keyboard key"
+msgid "SPECIAL"
+msgstr "SPECIAL"
+
+#: ../src/common/accelcmn.cpp:373
+msgid "Ctrl"
+msgstr "Ctrl"
+
+#: ../src/common/appbase.cpp:786
+msgid "show this help message"
+msgstr "показати цю підказку"
+
+#: ../src/common/appbase.cpp:796
+msgid "generate verbose log messages"
+msgstr "генерувати багатослівні повідомлення"
+
+#: ../src/common/appcmn.cpp:256
+msgid "specify the theme to use"
+msgstr "задайте мотив"
+
+#: ../src/common/appcmn.cpp:270
+msgid "specify display mode to use (e.g. 640x480-16)"
+msgstr "задайте режим дисплею (напр. 640x480-16)"
+
+#: ../src/common/appcmn.cpp:292
+#, c-format
+msgid "Unsupported theme '%s'."
+msgstr "Непідтримувана тема «%s»."
+
+#: ../src/common/appcmn.cpp:309
+#, c-format
+msgid "Invalid display mode specification '%s'."
+msgstr "Неправильна специфікація режиму дисплею «%s»."
+
+#: ../src/common/cmdline.cpp:875
+#, c-format
+msgid "Option '%s' can't be negated"
+msgstr "Знак параметра «%s» не можна обертати"
+
+#: ../src/common/cmdline.cpp:889
+#, c-format
+msgid "Unknown long option '%s'"
+msgstr "Невідомий параметр long «%s»"
+
+#: ../src/common/cmdline.cpp:904 ../src/common/cmdline.cpp:926
+#, c-format
+msgid "Unknown option '%s'"
+msgstr "Невідомий параметр «%s»"
+
+#: ../src/common/cmdline.cpp:1004
+#, c-format
+msgid "Unexpected characters following option '%s'."
+msgstr "За параметром «%s» слідують неочікувані символи."
+
+#: ../src/common/cmdline.cpp:1039
+#, c-format
+msgid "Option '%s' requires a value."
+msgstr "Параметр «%s» потребує значення."
+
+#: ../src/common/cmdline.cpp:1058
+#, c-format
+msgid "Separator expected after the option '%s'."
+msgstr "Після параметра «%s» слід використовувати роздільник."
+
+#: ../src/common/cmdline.cpp:1088 ../src/common/cmdline.cpp:1106
+#, c-format
+msgid "'%s' is not a correct numeric value for option '%s'."
+msgstr "«%s» — помилкове числове значення для параметра «%s»."
+
+#: ../src/common/cmdline.cpp:1122
+#, c-format
+msgid "Option '%s': '%s' cannot be converted to a date."
+msgstr "Параметр «%s»: «%s» не може бути конвертована у дату."
+
+#: ../src/common/cmdline.cpp:1170
+#, c-format
+msgid "Unexpected parameter '%s'"
+msgstr "Несподіваний параметр «%s»"
+
+#. TRANSLATORS: Short name and long name for a command line option
+#: ../src/common/cmdline.cpp:1197
+#, c-format
+msgid "%s (or %s)"
+msgstr "%s (або %s)"
+
+#: ../src/common/cmdline.cpp:1208
+#, c-format
+msgid "The value for the option '%s' must be specified."
+msgstr "Значення параметра «%s» повинно бути задано."
+
+#: ../src/common/cmdline.cpp:1230
+#, c-format
+msgid "The required parameter '%s' was not specified."
+msgstr "Обов'язковий параметр «%s» не вказаний."
+
+#: ../src/common/cmdline.cpp:1289
+#, c-format
+msgid "Usage: %s"
+msgstr "Використання: %s"
+
+#: ../src/common/cmdline.cpp:1498
+msgid "str"
+msgstr "str"
+
+#: ../src/common/cmdline.cpp:1502
+msgid "num"
+msgstr "num"
+
+#: ../src/common/cmdline.cpp:1506
+msgid "double"
+msgstr "double"
+
+#: ../src/common/cmdline.cpp:1510
+msgid "date"
+msgstr "дата"
+
+#: ../src/common/cmdproc.cpp:250 ../src/common/cmdproc.cpp:276
+#: ../src/common/cmdproc.cpp:296
+msgid "Unnamed command"
+msgstr "Неназвана команда"
+
+#: ../src/common/cmdproc.cpp:253
+msgid "&Undo "
+msgstr "В&ідмінити"
+
+#: ../src/common/cmdproc.cpp:255
+msgid "Can't &Undo "
+msgstr "Не можу В&ідновити "
+
+#: ../src/common/cmdproc.cpp:259 ../src/common/stockitem.cpp:208
+#: ../src/msw/textctrl.cpp:2880 ../src/osx/textctrl_osx.cpp:649
+#: ../src/richtext/richtextctrl.cpp:327
+msgid "&Undo"
+msgstr "В&ідмінити"
+
+#: ../src/common/cmdproc.cpp:277 ../src/common/cmdproc.cpp:297
+msgid "&Redo "
+msgstr "&Переробити "
+
+#: ../src/common/cmdproc.cpp:281 ../src/common/cmdproc.cpp:288
+#: ../src/common/stockitem.cpp:190 ../src/msw/textctrl.cpp:2881
+#: ../src/osx/textctrl_osx.cpp:650 ../src/richtext/richtextctrl.cpp:328
+msgid "&Redo"
+msgstr "&Переробити"
+
+#: ../src/common/colourcmn.cpp:41
+#, c-format
+msgid "String To Colour : Incorrect colour specification : %s"
+msgstr "Рядок для кольору : Некоректна специфікація кольору : %s"
+
+#: ../src/common/config.cpp:259
+#, c-format
+msgid "Invalid value %ld for a boolean key \"%s\" in config file."
+msgstr "Некоректне значення %ld булевого ключа «%s» у файлі налаштувань."
+
+#: ../src/common/config.cpp:526
+#, c-format
+msgid ""
+"Environment variables expansion failed: missing '%c' at position %u in '%s'."
+msgstr ""
+"Розкриття змінної оточення зазнало невдачі: відсутнє '%c' на позиції %u у "
+"'%s'."
+
+#: ../src/common/config.cpp:576 ../src/msw/regconf.cpp:272
+#, c-format
+msgid "'%s' has extra '..', ignored."
+msgstr "«%s» містить додаткові «..», проігноровано."
+
+#. TRANSLATORS: Checkbox state name
+#: ../src/common/datavcmn.cpp:2166 ../src/generic/datavgen.cpp:1430
+msgid "checked"
+msgstr "позначено"
+
+#. TRANSLATORS: Checkbox state name
+#: ../src/common/datavcmn.cpp:2170 ../src/generic/datavgen.cpp:1432
+msgid "unchecked"
+msgstr "не позначено"
+
+#. TRANSLATORS: Checkbox state name
+#: ../src/common/datavcmn.cpp:2174
+msgid "undetermined"
+msgstr "не визначено"
+
+#: ../src/common/datetimefmt.cpp:1875
+msgid "today"
+msgstr "сьогодні"
+
+#: ../src/common/datetimefmt.cpp:1876
+msgid "yesterday"
+msgstr "вчора"
+
+#: ../src/common/datetimefmt.cpp:1877
+msgid "tomorrow"
+msgstr "завтра"
+
+#: ../src/common/datetimefmt.cpp:2071
+msgid "first"
+msgstr "перший"
+
+#: ../src/common/datetimefmt.cpp:2072
+msgid "second"
+msgstr "другий"
+
+#: ../src/common/datetimefmt.cpp:2073
+msgid "third"
+msgstr "третій"
+
+#: ../src/common/datetimefmt.cpp:2074
+msgid "fourth"
+msgstr "четвертий"
+
+#: ../src/common/datetimefmt.cpp:2075
+msgid "fifth"
+msgstr "п'ятий"
+
+#: ../src/common/datetimefmt.cpp:2076
+msgid "sixth"
+msgstr "шостий"
+
+#: ../src/common/datetimefmt.cpp:2077
+msgid "seventh"
+msgstr "сьомий"
+
+#: ../src/common/datetimefmt.cpp:2078
+msgid "eighth"
+msgstr "восьмий"
+
+#: ../src/common/datetimefmt.cpp:2079
+msgid "ninth"
+msgstr "дев'ятий"
+
+#: ../src/common/datetimefmt.cpp:2080
+msgid "tenth"
+msgstr "десятий"
+
+#: ../src/common/datetimefmt.cpp:2081
+msgid "eleventh"
+msgstr "одинадцятий"
+
+#: ../src/common/datetimefmt.cpp:2082
+msgid "twelfth"
+msgstr "дванадцятий"
+
+#: ../src/common/datetimefmt.cpp:2083
+msgid "thirteenth"
+msgstr "тринадцятий"
+
+#: ../src/common/datetimefmt.cpp:2084
+msgid "fourteenth"
+msgstr "чотирнадцятий"
+
+#: ../src/common/datetimefmt.cpp:2085
+msgid "fifteenth"
+msgstr "п'ятнадцятий"
+
+#: ../src/common/datetimefmt.cpp:2086
+msgid "sixteenth"
+msgstr "шістнадцятий"
+
+#: ../src/common/datetimefmt.cpp:2087
+msgid "seventeenth"
+msgstr "сімнадцятий"
+
+#: ../src/common/datetimefmt.cpp:2088
+msgid "eighteenth"
+msgstr "вісімнадцятий"
+
+#: ../src/common/datetimefmt.cpp:2089
+msgid "nineteenth"
+msgstr "дев'ятнадцятий"
+
+#: ../src/common/datetimefmt.cpp:2090
+msgid "twentieth"
+msgstr "двадцятий"
+
+#: ../src/common/datetimefmt.cpp:2248
+msgid "noon"
+msgstr "південь"
+
+#: ../src/common/datetimefmt.cpp:2249
+msgid "midnight"
+msgstr "північ"
+
+#: ../src/common/debugrpt.cpp:209
+#, c-format
+msgid "Failed to create directory \"%s\""
+msgstr "Не вдалося створити теку «%s»"
+
+#: ../src/common/debugrpt.cpp:210
+msgid "Debug report couldn't be created."
+msgstr "Звіт про помилку неможливо створити."
+
+#: ../src/common/debugrpt.cpp:227
+#, c-format
+msgid "Failed to remove debug report file \"%s\""
+msgstr "Помилка вилучення файла звіту про помилку «%s»"
+
+#: ../src/common/debugrpt.cpp:239
+#, c-format
+msgid "Failed to clean up debug report directory \"%s\""
+msgstr "Не вдалося очистити теку звітів про помилки «%s»"
+
+#: ../src/common/debugrpt.cpp:514
+msgid "process context description"
+msgstr "опис контексту процесу"
+
+#: ../src/common/debugrpt.cpp:538
+msgid "dump of the process state (binary)"
+msgstr "дамп стану процесу (бінарний)"
+
+#: ../src/common/debugrpt.cpp:553
+msgid "Debug report generation has failed."
+msgstr "Помилка під час створення звіту про помилку."
+
+#: ../src/common/debugrpt.cpp:560
+#, c-format
+msgid ""
+"Processing debug report has failed, leaving the files in \"%s\" directory."
+msgstr ""
+"Робота над звітом про помилку завершилася помилкою, файли залишено у теці "
+"\"%s\"."
+
+#: ../src/common/debugrpt.cpp:573
+msgid "A debug report has been generated. It can be found in"
+msgstr "Було створено звіт про помилку. Його збережено до"
+
+#: ../src/common/debugrpt.cpp:576
+msgid "And includes the following files:\n"
+msgstr "Та містить такі файли:\n"
+
+#: ../src/common/debugrpt.cpp:586
+msgid ""
+"\n"
+"Please send this report to the program maintainer, thank you!\n"
+msgstr ""
+"\n"
+"Будь ласка, надішліть цей звіт розробникові програми, дякуємо!\n"
+
+#: ../src/common/debugrpt.cpp:729
+msgid "Failed to execute curl, please install it in PATH."
+msgstr ""
+"Не вдалося виконати curl, будь ласка, встановіть його у теці вказаній у PATH."
+
+#: ../src/common/debugrpt.cpp:742
+#, c-format
+msgid "Failed to upload the debug report (error code %d)."
+msgstr "Не вдалося відвантажити звіт про помилку (код помилки %d)."
+
+#: ../src/common/docview.cpp:366
+msgid "Save As"
+msgstr "Зберегти як"
+
+#: ../src/common/docview.cpp:457
+msgid "Discard changes and reload the last saved version?"
+msgstr "Відкинути зміни і перезавантажити останню збережену версію?"
+
+#: ../src/common/docview.cpp:488
+msgid "unnamed"
+msgstr "безіменний"
+
+#: ../src/common/docview.cpp:513
+#, c-format
+msgid "Do you want to save changes to %s?"
+msgstr "Записати зміни до %s?"
+
+#: ../src/common/docview.cpp:521 ../src/common/docview.cpp:560
+#: ../src/common/stockitem.cpp:195
+msgid "&Save"
+msgstr "&Зберегти"
+
+#: ../src/common/docview.cpp:522 ../src/common/docview.cpp:560
+msgid "&Discard changes"
+msgstr "&Відкинути зміни"
+
+#: ../src/common/docview.cpp:523
+msgid "Do&n't close"
+msgstr "Не з&акривати"
+
+#: ../src/common/docview.cpp:553
+#, c-format
+msgid "Do you want to save changes to %s before closing it?"
+msgstr "Зберегти зміни до %s до закриття файла?"
+
+#: ../src/common/docview.cpp:559
+msgid "The document must be closed."
+msgstr "Документ доведеться закрити."
+
+#: ../src/common/docview.cpp:571
+#, c-format
+msgid "Saving %s failed, would you like to retry?"
+msgstr "Не вдалося зберегти %s, хочете повторити спробу?"
+
+#: ../src/common/docview.cpp:577
+msgid "Retry"
+msgstr "Повторити спробу"
+
+#: ../src/common/docview.cpp:577
+msgid "Discard changes"
+msgstr "Відкинути зміни"
+
+#: ../src/common/docview.cpp:679
+#, c-format
+msgid "File \"%s\" could not be opened for writing."
+msgstr "Не вдалося відкрити файл «%s» для запису."
+
+#: ../src/common/docview.cpp:685
+#, c-format
+msgid "Failed to save document to the file \"%s\"."
+msgstr "Не вдалося зберегти документ до файла «%s»."
+
+#: ../src/common/docview.cpp:702
+#, c-format
+msgid "File \"%s\" could not be opened for reading."
+msgstr "Не вдалося відкрити файл «%s» для читання."
+
+#: ../src/common/docview.cpp:714
+#, c-format
+msgid "Failed to read document from the file \"%s\"."
+msgstr "Не вдалося прочитати документ з файла «%s»."
+
+#: ../src/common/docview.cpp:1236
+#, c-format
+msgid ""
+"The file '%s' doesn't exist and couldn't be opened.\n"
+"It has been removed from the most recently used files list."
+msgstr ""
+"Файла «%s» не існує, отже його неможливо відкрити.\n"
+"Його було вилучено зі списку нещодавно використаних."
+
+#: ../src/common/docview.cpp:1296
+msgid "Print preview creation failed."
+msgstr "Не вдалося створити зображення попереднього перегляду друку."
+
+#: ../src/common/docview.cpp:1302
+msgid "Print Preview"
+msgstr "Передогляд друку"
+
+#: ../src/common/docview.cpp:1517
+#, c-format
+msgid "The format of file '%s' couldn't be determined."
+msgstr "Не вдалося визначити формат файла «%s»."
+
+#: ../src/common/docview.cpp:1643
+#, c-format
+msgid "unnamed%d"
+msgstr "безіменний%d"
+
+#: ../src/common/docview.cpp:1660
+msgid " - "
+msgstr " — "
+
+#: ../src/common/docview.cpp:1791 ../src/common/docview.cpp:1844
+msgid "Open File"
+msgstr "Відкрити файл"
+
+#: ../src/common/docview.cpp:1807
+msgid "File error"
+msgstr "Помилка файла"
+
+#: ../src/common/docview.cpp:1809
+msgid "Sorry, could not open this file."
+msgstr "Вибачте, не вдалося відкрити цей файл."
+
+#: ../src/common/docview.cpp:1843
+msgid "Sorry, the format for this file is unknown."
+msgstr "Вибачте, формат цього файла не відомий."
+
+#: ../src/common/docview.cpp:1924
+msgid "Select a document template"
+msgstr "Виберіть шаблон документа"
+
+#: ../src/common/docview.cpp:1925
+msgid "Templates"
+msgstr "Шаблони"
+
+#: ../src/common/docview.cpp:1998
+msgid "Select a document view"
+msgstr "Виберіть перегляд документа"
+
+#: ../src/common/docview.cpp:1999
+msgid "Views"
+msgstr "Перегляди"
+
+#: ../src/common/dynlib.cpp:81
+#, c-format
+msgid "Failed to load shared library '%s'"
+msgstr "Не вдалося завантажити динамічну бібліотеку «%s»"
+
+#: ../src/common/dynlib.cpp:105
+#, c-format
+msgid "Couldn't find symbol '%s' in a dynamic library"
+msgstr "Не вдалося знайти символ «%s» в динамічній бібліотеці"
+
+#: ../src/common/ffile.cpp:56 ../src/common/file.cpp:215
+#, c-format
+msgid "can't open file '%s'"
+msgstr "Не вдалося відкрити файл «%s»"
+
+#: ../src/common/ffile.cpp:72
+#, c-format
+msgid "can't close file '%s'"
+msgstr "Не вдалося закрити файл «%s»"
+
+#: ../src/common/ffile.cpp:106 ../src/common/ffile.cpp:131
+#, c-format
+msgid "Read error on file '%s'"
+msgstr "Помилка читання файла «%s»"
+
+#: ../src/common/ffile.cpp:148
+#, c-format
+msgid "Write error on file '%s'"
+msgstr "Помилка запису в файл «%s»"
+
+#: ../src/common/ffile.cpp:182
+#, c-format
+msgid "failed to flush the file '%s'"
+msgstr "не вдалося скинути буфер файла «%s»."
+
+#: ../src/common/ffile.cpp:222
+#, c-format
+msgid "Seek error on file '%s' (large files not supported by stdio)"
+msgstr "Помилка пошуку на файлі «%s» (великі файли не підтримуються stdio)"
+
+#: ../src/common/ffile.cpp:232
+#, c-format
+msgid "Seek error on file '%s'"
+msgstr "Помилка пошуку в файлі «%s»"
+
+#: ../src/common/ffile.cpp:248
+#, c-format
+msgid "Can't find current position in file '%s'"
+msgstr "Не можу знайти теперішню позицію в файлі «%s»"
+
+#: ../src/common/ffile.cpp:349 ../src/common/file.cpp:569
+msgid "Failed to set temporary file permissions"
+msgstr "Не вдалося встановити дозволи на тимчасовий файл"
+
+#: ../src/common/ffile.cpp:371
+#, c-format
+msgid "can't remove file '%s'"
+msgstr "помилка вилучення файла «%s»"
+
+#: ../src/common/ffile.cpp:376 ../src/common/file.cpp:591
+#, c-format
+msgid "can't commit changes to file '%s'"
+msgstr "Не вдалося записати зміни в файл «%s»"
+
+#: ../src/common/ffile.cpp:388 ../src/common/file.cpp:603
+#, c-format
+msgid "can't remove temporary file '%s'"
+msgstr "помилка вилучення тимчасового файла «%s»"
+
+#: ../src/common/file.cpp:162
+#, c-format
+msgid "can't create file '%s'"
+msgstr "Не вдалося створити файл «%s»"
+
+#: ../src/common/file.cpp:229
+#, c-format
+msgid "can't close file descriptor %d"
+msgstr "Не вдалося закрити дескриптор файла %d"
+
+#: ../src/common/file.cpp:332
+#, c-format
+msgid "can't read from file descriptor %d"
+msgstr "помилка читання файла з дескриптором %d"
+
+#: ../src/common/file.cpp:351
+#, c-format
+msgid "can't write to file descriptor %d"
+msgstr "Не вдалося записати в файл з дескриптором %d"
+
+#: ../src/common/file.cpp:390
+#, c-format
+msgid "can't flush file descriptor %d"
+msgstr "Не вдалося злити файл з дескриптором %d"
+
+#: ../src/common/file.cpp:432
+#, c-format
+msgid "can't seek on file descriptor %d"
+msgstr "Не вдалося пересунутись у файлі з дескриптором %d"
+
+#: ../src/common/file.cpp:446
+#, c-format
+msgid "can't get seek position on file descriptor %d"
+msgstr "неможливо отримати дану позицію файла з дескриптором %d"
+
+#: ../src/common/file.cpp:475
+#, c-format
+msgid "can't find length of file on file descriptor %d"
+msgstr "Не вдалося встановити довжину файла з дескриптором %d"
+
+#: ../src/common/file.cpp:505
+#, c-format
+msgid "can't determine if the end of file is reached on descriptor %d"
+msgstr "Не вдалося встановити досягнення кінця файла з дескриптором %d"
+
+#: ../src/common/fileconf.cpp:352
+#, c-format
+msgid ""
+" and additionally, the existing configuration file was renamed to \"%s\" and "
+"couldn't be renamed back, please rename it to its original path \"%s\""
+msgstr ""
+" і додатково, наявний файл налаштувань було перейменовано на «%s» — його не"
+" може бути перейменовано знову; будь ласка, перемістіть його до попереднього"
+" місця — «%s»"
+
+#: ../src/common/fileconf.cpp:389
+msgid " due to the following error:\n"
+msgstr " через таку помилку:\n"
+
+#: ../src/common/fileconf.cpp:412
+msgid "failed to rename the existing file"
+msgstr "не вдалося перейменувати наявний файл"
+
+#: ../src/common/fileconf.cpp:421
+msgid "failed to create the new file directory"
+msgstr "не вдалося створити каталог нового файла"
+
+#: ../src/common/fileconf.cpp:428
+msgid "failed to move the file to the new location"
+msgstr "не вдалося перемістити файл до нового каталогу"
+
+#: ../src/common/fileconf.cpp:462
+#, c-format
+msgid "can't open global configuration file '%s'."
+msgstr "Не вдалося відкрити загальний файл налаштувань «%s»."
+
+#: ../src/common/fileconf.cpp:478
+#, c-format
+msgid "can't open user configuration file '%s'."
+msgstr "Не вдалося відкрити файл налаштувань «%s»."
+
+#: ../src/common/fileconf.cpp:483
+#, c-format
+msgid "Changes won't be saved to avoid overwriting the existing file \"%s\""
+msgstr "Зміни не буде збережено, щоб уникнути перезапису наявного файла «%s»"
+
+#: ../src/common/fileconf.cpp:583
+msgid "Error reading config options."
+msgstr "Помилка під час читання параметрів налаштування."
+
+#: ../src/common/fileconf.cpp:593
+msgid "Failed to read config options."
+msgstr "Не вдалося прочитати параметри налаштування."
+
+#: ../src/common/fileconf.cpp:700
+#, c-format
+msgid "file '%s': unexpected character %c at line %zu."
+msgstr "файл «%s»: несподіваний символ %c у рядку %zu."
+
+#: ../src/common/fileconf.cpp:736
+#, c-format
+msgid "file '%s', line %zu: '%s' ignored after group header."
+msgstr "файл «%s», рядок %zu: «%s» проігноровано після заголовка групи."
+
+#: ../src/common/fileconf.cpp:765
+#, c-format
+msgid "file '%s', line %zu: '=' expected."
+msgstr "файл «%s», рядок %zu: мало бути «=»."
+
+#: ../src/common/fileconf.cpp:778
+#, c-format
+msgid "file '%s', line %zu: value for immutable key '%s' ignored."
+msgstr "файл «%s», рядок %zu: значення незмінного ключа «%s» проігноровано."
+
+#: ../src/common/fileconf.cpp:788
+#, c-format
+msgid "file '%s', line %zu: key '%s' was first found at line %d."
+msgstr "файл «%s», рядок %zu: ключ «%s» уперше було знайдено у рядку %d."
+
+#: ../src/common/fileconf.cpp:1091
+#, c-format
+msgid "Config entry name cannot start with '%c'."
+msgstr "Назва поля в файлі налаштування не може починатися з «%c»."
+
+#: ../src/common/fileconf.cpp:1146
+msgid "Failed to create configuration file directory."
+msgstr "Не вдалося створити каталог файла налаштувань."
+
+#: ../src/common/fileconf.cpp:1158
+msgid "can't open user configuration file."
+msgstr "Не вдалося відкрити файл налаштувань."
+
+#: ../src/common/fileconf.cpp:1172
+msgid "can't write user configuration file."
+msgstr "Не вдалося записати файл налаштувань."
+
+#: ../src/common/fileconf.cpp:1178
+msgid "Failed to update user configuration file."
+msgstr "Не вдалося оновити файл налаштування."
+
+#: ../src/common/fileconf.cpp:1201
+msgid "Error saving user configuration data."
+msgstr "Помилка під час збереження даних налаштування користувача."
+
+#: ../src/common/fileconf.cpp:1313
+#, c-format
+msgid "can't delete user configuration file '%s'"
+msgstr "Не вдалося вилучити файл налаштувань користувача «%s»"
+
+#: ../src/common/fileconf.cpp:2007
+#, c-format
+msgid "entry '%s' appears more than once in group '%s'"
+msgstr "поле «%s» з'являється більше одного разу в групі «%s»"
+
+#: ../src/common/fileconf.cpp:2021
+#, c-format
+msgid "attempt to change immutable key '%s' ignored."
+msgstr "спроба замінити незамінну клавішу «%s» проігнорована."
+
+#: ../src/common/fileconf.cpp:2118
+#, c-format
+msgid "trailing backslash ignored in '%s'"
+msgstr "у «%s» проігноровано кінцеву похилу риску"
+
+#: ../src/common/fileconf.cpp:2153
+#, c-format
+msgid "unexpected \" at position %d in '%s'."
+msgstr "несподіваний \" в позиції %d в «%s»."
+
+#: ../src/common/filefn.cpp:474
+#, c-format
+msgid "Failed to copy the file '%s' to '%s'"
+msgstr "Помилка копіювання файла «%s» в «%s»."
+
+#: ../src/common/filefn.cpp:487
+#, c-format
+msgid "Impossible to get permissions for file '%s'"
+msgstr "Не вдалося отримати дозволи на файл «%s»"
+
+#: ../src/common/filefn.cpp:501
+#, c-format
+msgid "Impossible to overwrite the file '%s'"
+msgstr "Не вдалося переписати файл «%s»"
+
+#: ../src/common/filefn.cpp:508
+#, c-format
+msgid "Error copying the file '%s' to '%s'."
+msgstr "Помилка копіювання файла з «%s» до «%s»."
+
+#: ../src/common/filefn.cpp:556
+#, c-format
+msgid "Impossible to set permissions for the file '%s'"
+msgstr "Не вдалося встановити доступ до файла «%s»"
+
+#: ../src/common/filefn.cpp:606
+#, c-format
+msgid ""
+"Failed to rename the file '%s' to '%s' because the destination file already "
+"exists."
+msgstr ""
+"Помилка під час перейменування файла «%s» на «%s», файл з такою назвою вже "
+"існує."
+
+#: ../src/common/filefn.cpp:623
+#, c-format
+msgid "File '%s' couldn't be renamed '%s'"
+msgstr "Не вдалося перейменувати файл «%s» на «%s»"
+
+#: ../src/common/filefn.cpp:639
+#, c-format
+msgid "File '%s' couldn't be removed"
+msgstr "Не вдалося вилучити файл «%s»"
+
+#: ../src/common/filefn.cpp:666
+#, c-format
+msgid "Directory '%s' couldn't be created"
+msgstr "Не вдалося створити каталог «%s»"
+
+#: ../src/common/filefn.cpp:680
+#, c-format
+msgid "Directory '%s' couldn't be deleted"
+msgstr "Не вдалося вилучити каталог «%s»"
+
+#: ../src/common/filefn.cpp:714
+#, c-format
+msgid "Cannot enumerate files '%s'"
+msgstr "Не можу перелічити файли «%s»"
+
+#: ../src/common/filefn.cpp:798
+msgid "Failed to get the working directory"
+msgstr "Не вдалося отримати робочий каталог"
+
+#: ../src/common/filefn.cpp:843
+msgid "Could not set current working directory"
+msgstr "Не вдалося вказати поточний робочий каталог"
+
+#: ../src/common/filefn.cpp:974
+#, c-format
+msgid "Files (%s)"
+msgstr "Файли (%s)"
+
+#: ../src/common/filename.cpp:182
+#, c-format
+msgid "Failed to open '%s' for reading"
+msgstr "Не вдалося відкрити «%s» для читання"
+
+#: ../src/common/filename.cpp:187
+#, c-format
+msgid "Failed to open '%s' for writing"
+msgstr "Не вдалося відкрити «%s» для запису"
+
+#: ../src/common/filename.cpp:199
+msgid "Failed to close file handle"
+msgstr "Не вдалося закрити обробку файла"
+
+#: ../src/common/filename.cpp:1046
+msgid "Failed to create a temporary file name"
+msgstr "Помилка створення назви тимчасового файла"
+
+#: ../src/common/filename.cpp:1081
+msgid "Failed to open temporary file."
+msgstr "Не вдалося відкрити тимчасовий файл."
+
+#: ../src/common/filename.cpp:2862
+#, c-format
+msgid "Failed to modify file times for '%s'"
+msgstr "Не вдалося змінити час файла для «%s»"
+
+#: ../src/common/filename.cpp:2877
+#, c-format
+msgid "Failed to touch the file '%s'"
+msgstr "Не вдалося відкрити файл «%s»"
+
+#: ../src/common/filename.cpp:2958
+#, c-format
+msgid "Failed to retrieve file times for '%s'"
+msgstr "Не вдалося отримати часи файла для «%s»"
+
+#: ../src/common/filepickercmn.cpp:39 ../src/common/filepickercmn.cpp:40
+msgid "Browse"
+msgstr "Навігація"
+
+#: ../src/common/fldlgcmn.cpp:792 ../src/generic/filectrlg.cpp:1185
+#, c-format
+msgid "All files (%s)|%s"
+msgstr "Всі файли (%s)|%s"
+
+#. TRANSLATORS: %s are a file extension used to build a file wildcard string
+#: ../src/common/fldlgcmn.cpp:810
+#, c-format
+msgid "%s files (%s)|%s"
+msgstr "%s файлів (%s)|%s"
+
+#: ../src/common/fldlgcmn.cpp:1072
+#, c-format
+msgid "Load %s file"
+msgstr "Завантажити файл %s"
+
+#: ../src/common/fldlgcmn.cpp:1074
+#, c-format
+msgid "Save %s file"
+msgstr "Зберегти файл %s"
+
+#: ../src/common/fmapbase.cpp:144
+msgid "Western European (ISO-8859-1)"
+msgstr "Західноєвропейська (ISO-8859-1)"
+
+#: ../src/common/fmapbase.cpp:145
+msgid "Central European (ISO-8859-2)"
+msgstr "Центральний європейський (ISO-8859-2)"
+
+#: ../src/common/fmapbase.cpp:146
+msgid "Esperanto (ISO-8859-3)"
+msgstr "Есперанто (ISO-8859-3)"
+
+#: ../src/common/fmapbase.cpp:147
+msgid "Baltic (old) (ISO-8859-4)"
+msgstr "Baltic (старе) (ISO-8859-4)"
+
+#: ../src/common/fmapbase.cpp:148
+msgid "Cyrillic (ISO-8859-5)"
+msgstr "Кирилиця (ISO-8859-5)"
+
+#: ../src/common/fmapbase.cpp:149
+msgid "Arabic (ISO-8859-6)"
+msgstr "Arabic (ISO-8859-6)"
+
+#: ../src/common/fmapbase.cpp:150
+msgid "Greek (ISO-8859-7)"
+msgstr "Greek (ISO-8859-7)"
+
+#: ../src/common/fmapbase.cpp:151
+msgid "Hebrew (ISO-8859-8)"
+msgstr "Hebrew (ISO-8859-8)"
+
+#: ../src/common/fmapbase.cpp:152
+msgid "Turkish (ISO-8859-9)"
+msgstr "Turkish (ISO-8859-9)"
+
+#: ../src/common/fmapbase.cpp:153
+msgid "Nordic (ISO-8859-10)"
+msgstr "Нордичне (ISO-8859-10)"
+
+#: ../src/common/fmapbase.cpp:154
+msgid "Thai (ISO-8859-11)"
+msgstr "Тайська (ISO-8859-11)"
+
+#: ../src/common/fmapbase.cpp:155
+msgid "Indian (ISO-8859-12)"
+msgstr "Індійська (ISO-8859-12)"
+
+#: ../src/common/fmapbase.cpp:156
+msgid "Baltic (ISO-8859-13)"
+msgstr "Baltic (ISO-8859-13)"
+
+#: ../src/common/fmapbase.cpp:157
+msgid "Celtic (ISO-8859-14)"
+msgstr "Кельтська (ISO-8859-14)"
+
+#: ../src/common/fmapbase.cpp:158
+msgid "Western European with Euro (ISO-8859-15)"
+msgstr "Західноєвропейська з Євро (ISO-8859-15)"
+
+#: ../src/common/fmapbase.cpp:159
+msgid "KOI8-R"
+msgstr "KOI8-R"
+
+#: ../src/common/fmapbase.cpp:160
+msgid "KOI8-U"
+msgstr "KOI8-U"
+
+#: ../src/common/fmapbase.cpp:161
+msgid "Windows/DOS OEM Cyrillic (CP 866)"
+msgstr "Кирилиця, Windows/DOS OEM (CP 866)"
+
+#: ../src/common/fmapbase.cpp:162
+msgid "Windows Thai (CP 874)"
+msgstr "Тайська Windows (CP 874)"
+
+#: ../src/common/fmapbase.cpp:163
+msgid "Windows Japanese (CP 932) or Shift-JIS"
+msgstr "Японська Windows (CP 932) або Shift-JIS"
+
+#: ../src/common/fmapbase.cpp:164
+msgid "Windows Chinese Simplified (CP 936) or GB-2312"
+msgstr "Китайська спрощена Windows (CP 936) або GB-2312"
+
+#: ../src/common/fmapbase.cpp:165
+msgid "Windows Korean (CP 949)"
+msgstr "Корейська Windows (CP 949)"
+
+#: ../src/common/fmapbase.cpp:166
+msgid "Windows Chinese Traditional (CP 950) or Big-5"
+msgstr "Традиційна китайська Windows (CP 950) або Big-5"
+
+#: ../src/common/fmapbase.cpp:167
+msgid "Windows Central European (CP 1250)"
+msgstr "Центральноєвропейська Windows (CP 1250)"
+
+#: ../src/common/fmapbase.cpp:168
+msgid "Windows Cyrillic (CP 1251)"
+msgstr "Кирилична Windows (CP 1251)"
+
+#: ../src/common/fmapbase.cpp:169
+msgid "Windows Western European (CP 1252)"
+msgstr "Західноєвропейська Windows (CP 1252)"
+
+#: ../src/common/fmapbase.cpp:170
+msgid "Windows Greek (CP 1253)"
+msgstr "Грецька Windows (CP 1253)"
+
+#: ../src/common/fmapbase.cpp:171
+msgid "Windows Turkish (CP 1254)"
+msgstr "Турецька Windows (CP 1254)"
+
+#: ../src/common/fmapbase.cpp:172
+msgid "Windows Hebrew (CP 1255)"
+msgstr "Єврейська Windows (CP 1255)"
+
+#: ../src/common/fmapbase.cpp:173
+msgid "Windows Arabic (CP 1256)"
+msgstr "Арабська Windows (CP 1256)"
+
+#: ../src/common/fmapbase.cpp:174
+msgid "Windows Baltic (CP 1257)"
+msgstr "Балтійська Windows (CP 1257)"
+
+#: ../src/common/fmapbase.cpp:175
+msgid "Windows Vietnamese (CP 1258)"
+msgstr "В’єтнамська Windows (CP 1258)"
+
+#: ../src/common/fmapbase.cpp:176
+msgid "Windows Johab (CP 1361)"
+msgstr "Корейська Windows (CP 1361)"
+
+#: ../src/common/fmapbase.cpp:177
+msgid "Windows/DOS OEM (CP 437)"
+msgstr "Windows/DOS OEM (CP 437)"
+
+#: ../src/common/fmapbase.cpp:178
+msgid "Unicode 7 bit (UTF-7)"
+msgstr "Unicode 7 бітів (UTF-7)"
+
+#: ../src/common/fmapbase.cpp:179
+msgid "Unicode 8 bit (UTF-8)"
+msgstr "Unicode 8 бітів (UTF-8)"
+
+#: ../src/common/fmapbase.cpp:181 ../src/common/fmapbase.cpp:187
+msgid "Unicode 16 bit (UTF-16)"
+msgstr "Unicode 16 бітів (UTF-16)"
+
+#: ../src/common/fmapbase.cpp:182
+msgid "Unicode 16 bit Little Endian (UTF-16LE)"
+msgstr "Unicode 16 бітів Little Endian (UTF-16LE)"
+
+#: ../src/common/fmapbase.cpp:183 ../src/common/fmapbase.cpp:189
+msgid "Unicode 32 bit (UTF-32)"
+msgstr "Unicode 32 бітів (UTF-32)"
+
+#: ../src/common/fmapbase.cpp:184
+msgid "Unicode 32 bit Little Endian (UTF-32LE)"
+msgstr "Unicode 32 бітів Little Endian (UTF-32LE)"
+
+#: ../src/common/fmapbase.cpp:186
+msgid "Unicode 16 bit Big Endian (UTF-16BE)"
+msgstr "Unicode 16 бітів Big Endian (UTF-16BE)"
+
+#: ../src/common/fmapbase.cpp:188
+msgid "Unicode 32 bit Big Endian (UTF-32BE)"
+msgstr "Unicode 32 бітів Big Endian (UTF-32BE)"
+
+#: ../src/common/fmapbase.cpp:191
+msgid "Extended Unix Codepage for Japanese (EUC-JP)"
+msgstr "Розширена кодова сторінка Unix для японської (EUC-JP)"
+
+#: ../src/common/fmapbase.cpp:192
+msgid "US-ASCII"
+msgstr "US-ASCII"
+
+#: ../src/common/fmapbase.cpp:193
+msgid "ISO-2022-JP"
+msgstr "ISO-2022-JP"
+
+#: ../src/common/fmapbase.cpp:195
+msgid "MacRoman"
+msgstr "Романська, Mac"
+
+#: ../src/common/fmapbase.cpp:196
+msgid "MacJapanese"
+msgstr "Японська, Mac"
+
+#: ../src/common/fmapbase.cpp:197
+msgid "MacChineseTrad"
+msgstr "Китайська традиційна, Mac"
+
+#: ../src/common/fmapbase.cpp:198
+msgid "MacKorean"
+msgstr "Корейська, Mac"
+
+#: ../src/common/fmapbase.cpp:199
+msgid "MacArabic"
+msgstr "Арабська, Mac"
+
+#: ../src/common/fmapbase.cpp:200
+msgid "MacHebrew"
+msgstr "Іврит, Mac"
+
+#: ../src/common/fmapbase.cpp:201
+msgid "MacGreek"
+msgstr "Грецька, Mac"
+
+#: ../src/common/fmapbase.cpp:202
+msgid "MacCyrillic"
+msgstr "Кирилиця, Mac"
+
+#: ../src/common/fmapbase.cpp:203
+msgid "MacDevanagari"
+msgstr "Деванагарі, Mac"
+
+#: ../src/common/fmapbase.cpp:204
+msgid "MacGurmukhi"
+msgstr "Гурмухі, Mac"
+
+#: ../src/common/fmapbase.cpp:205
+msgid "MacGujarati"
+msgstr "Гуджараті, Mac"
+
+#: ../src/common/fmapbase.cpp:206
+msgid "MacOriya"
+msgstr "Орійська, Mac"
+
+#: ../src/common/fmapbase.cpp:207
+msgid "MacBengali"
+msgstr "Бенгальська, Mac"
+
+#: ../src/common/fmapbase.cpp:208
+msgid "MacTamil"
+msgstr "Тамільська, Mac"
+
+#: ../src/common/fmapbase.cpp:209
+msgid "MacTelugu"
+msgstr "Телугу, Mac"
+
+#: ../src/common/fmapbase.cpp:210
+msgid "MacKannada"
+msgstr "Каннада, Mac"
+
+#: ../src/common/fmapbase.cpp:211
+msgid "MacMalayalam"
+msgstr "Малаялам, Mac"
+
+#: ../src/common/fmapbase.cpp:212
+msgid "MacSinhalese"
+msgstr "Сингальська, Mac"
+
+#: ../src/common/fmapbase.cpp:213
+msgid "MacBurmese"
+msgstr "Бірманська, Mac"
+
+#: ../src/common/fmapbase.cpp:214
+msgid "MacKhmer"
+msgstr "Кхмерська, Mac"
+
+#: ../src/common/fmapbase.cpp:215
+msgid "MacThai"
+msgstr "Тайська, Mac"
+
+#: ../src/common/fmapbase.cpp:216
+msgid "MacLaotian"
+msgstr "Лаоська, Mac"
+
+#: ../src/common/fmapbase.cpp:217
+msgid "MacGeorgian"
+msgstr "Грузинська, Mac"
+
+#: ../src/common/fmapbase.cpp:218
+msgid "MacArmenian"
+msgstr "Вірменська, Mac"
+
+#: ../src/common/fmapbase.cpp:219
+msgid "MacChineseSimp"
+msgstr "Китайська спрощена, Mac"
+
+#: ../src/common/fmapbase.cpp:220
+msgid "MacTibetan"
+msgstr "Тибетська, Mac"
+
+#: ../src/common/fmapbase.cpp:221
+msgid "MacMongolian"
+msgstr "Монгольська, Mac"
+
+#: ../src/common/fmapbase.cpp:222
+msgid "MacEthiopic"
+msgstr "Ефіопська, Mac"
+
+#: ../src/common/fmapbase.cpp:223
+msgid "MacCentralEurRoman"
+msgstr "Романська, Центральна Європа, Mac"
+
+#: ../src/common/fmapbase.cpp:224
+msgid "MacVietnamese"
+msgstr "В’єтнамська, Mac"
+
+#: ../src/common/fmapbase.cpp:225
+msgid "MacExtArabic"
+msgstr "Арабська, розширена, Mac"
+
+#: ../src/common/fmapbase.cpp:226
+msgid "MacSymbol"
+msgstr "Символи, Mac"
+
+#: ../src/common/fmapbase.cpp:227
+msgid "MacDingbats"
+msgstr "Декоративні, Mac"
+
+#: ../src/common/fmapbase.cpp:228
+msgid "MacTurkish"
+msgstr "Турецька, Mac"
+
+#: ../src/common/fmapbase.cpp:229
+msgid "MacCroatian"
+msgstr "Хорватська, Mac"
+
+#: ../src/common/fmapbase.cpp:230
+msgid "MacIcelandic"
+msgstr "Ісландська, Mac"
+
+#: ../src/common/fmapbase.cpp:231
+msgid "MacRomanian"
+msgstr "Румунська, Mac"
+
+#: ../src/common/fmapbase.cpp:232
+msgid "MacCeltic"
+msgstr "Кельтська, Mac"
+
+#: ../src/common/fmapbase.cpp:233
+msgid "MacGaelic"
+msgstr "Гельська, Mac"
+
+#: ../src/common/fmapbase.cpp:234
+msgid "MacKeyboardGlyphs"
+msgstr "Клавіатурні гліфи, Mac"
+
+#: ../src/common/fmapbase.cpp:791
+msgid "Default encoding"
+msgstr "Типове кодування"
+
+#: ../src/common/fmapbase.cpp:805
+#, c-format
+msgid "Unknown encoding (%d)"
+msgstr "Невідоме кодування (%d)"
+
+#: ../src/common/fmapbase.cpp:815 ../src/richtext/richtextstyles.cpp:776
+msgid "default"
+msgstr "типовий"
+
+#: ../src/common/fmapbase.cpp:829
+#, c-format
+msgid "unknown-%d"
+msgstr "невідомий-%d"
+
+#: ../src/common/fontcmn.cpp:924 ../src/common/fontcmn.cpp:1130
+msgid "underlined"
+msgstr "підкреслене"
+
+#: ../src/common/fontcmn.cpp:929
+msgid " strikethrough"
+msgstr " перекреслення"
+
+#: ../src/common/fontcmn.cpp:942
+msgid " thin"
+msgstr " тонкий"
+
+#: ../src/common/fontcmn.cpp:946
+msgid " extra light"
+msgstr " дуже світлий"
+
+#: ../src/common/fontcmn.cpp:950
+msgid " light"
+msgstr " світлий"
+
+#: ../src/common/fontcmn.cpp:954
+msgid " medium"
+msgstr "середній"
+
+#: ../src/common/fontcmn.cpp:958
+msgid " semi bold"
+msgstr "напівжирний"
+
+#: ../src/common/fontcmn.cpp:962
+msgid " bold"
+msgstr " жирний"
+
+#: ../src/common/fontcmn.cpp:966
+msgid " extra bold"
+msgstr " дуже жирний"
+
+#: ../src/common/fontcmn.cpp:970
+msgid " heavy"
+msgstr " щільний"
+
+#: ../src/common/fontcmn.cpp:974
+msgid " extra heavy"
+msgstr " дуже щільний"
+
+#: ../src/common/fontcmn.cpp:990
+msgid " italic"
+msgstr " курсив"
+
+#: ../src/common/fontcmn.cpp:1134
+msgid "strikethrough"
+msgstr "перекреслення"
+
+#: ../src/common/fontcmn.cpp:1143
+msgid "thin"
+msgstr "тонкий"
+
+#: ../src/common/fontcmn.cpp:1156
+msgid "extralight"
+msgstr "надсвітлий"
+
+#: ../src/common/fontcmn.cpp:1161
+msgid "light"
+msgstr "світлий"
+
+#: ../src/common/fontcmn.cpp:1169 ../src/richtext/richtextstyles.cpp:775
+msgid "normal"
+msgstr "звичайний"
+
+#: ../src/common/fontcmn.cpp:1174
+msgid "medium"
+msgstr "середній"
+
+#: ../src/common/fontcmn.cpp:1179 ../src/common/fontcmn.cpp:1199
+msgid "semibold"
+msgstr "напівжирний"
+
+#: ../src/common/fontcmn.cpp:1184
+msgid "bold"
+msgstr "жирний"
+
+#: ../src/common/fontcmn.cpp:1194
+msgid "extrabold"
+msgstr "наджирний"
+
+#: ../src/common/fontcmn.cpp:1204
+msgid "heavy"
+msgstr "щільний"
+
+#: ../src/common/fontcmn.cpp:1212
+msgid "extraheavy"
+msgstr "надщільний"
+
+#: ../src/common/fontcmn.cpp:1217
+msgid "italic"
+msgstr "курсив"
+
+#: ../src/common/fontmap.cpp:195
+msgid ": unknown charset"
+msgstr ": невідомий набір символів"
+
+#: ../src/common/fontmap.cpp:199
+#, c-format
+msgid ""
+"The charset '%s' is unknown. You may select\n"
+"another charset to replace it with or choose\n"
+"[Cancel] if it cannot be replaced"
+msgstr ""
+"Набір символів «%s» невідомий. Ви можете вибрати\n"
+"замість нього інший набір або натиснути [Скасувати], \n"
+"якщо його не можна замінити"
+
+#: ../src/common/fontmap.cpp:241
+#, c-format
+msgid "Failed to remember the encoding for the charset '%s'."
+msgstr "Не вдалося згадати кодування для набору символів «%s»."
+
+#: ../src/common/fontmap.cpp:321
+msgid "can't load any font, aborting"
+msgstr "неможливо завантажити жодного шрифту, зупинка"
+
+#: ../src/common/fontmap.cpp:409
+msgid ": unknown encoding"
+msgstr ": невідоме кодування"
+
+#: ../src/common/fontmap.cpp:417
+#, c-format
+msgid ""
+"No font for displaying text in encoding '%s' found,\n"
+"but an alternative encoding '%s' is available.\n"
+"Do you want to use this encoding (otherwise you will have to choose another "
+"one)?"
+msgstr ""
+"Не знайдено шрифту для показу тексту у кодуванні «%s».\n"
+"але доступне альтернативне кодування «%s».\n"
+"Хочете використовувати це кодування (інакше вам доведеться вибрати інше)?"
+
+#: ../src/common/fontmap.cpp:422
+#, c-format
+msgid ""
+"No font for displaying text in encoding '%s' found.\n"
+"Would you like to select a font to be used for this encoding\n"
+"(otherwise the text in this encoding will not be shown correctly)?"
+msgstr ""
+"Немає шрифту для показу тексту у кодуванні «%s».\n"
+"Ви бажаєте вибрати шрифт для використання з цим кодуванням\n"
+"(інакше текст у цьому кодуванні не буде показано вірно)?"
+
+#: ../src/common/fs_mem.cpp:169
+#, c-format
+msgid "Memory VFS already contains file '%s'!"
+msgstr "Пам'ять VFS вже має файл «%s»!"
+
+#: ../src/common/fs_mem.cpp:232
+#, c-format
+msgid "Trying to remove file '%s' from memory VFS, but it is not loaded!"
+msgstr ""
+"Спроба вилучення файла «%s» зі списку пам'яті VFS, але його не завантажено!"
+
+#: ../src/common/fs_mem.cpp:262
+#, c-format
+msgid "Failed to store image '%s' to memory VFS!"
+msgstr "Не вдалося записати зображення «%s» в пам'яті VFS!"
+
+#: ../src/common/ftp.cpp:197
+msgid "Timeout while waiting for FTP server to connect, try passive mode."
+msgstr ""
+"Тайм-аут очікування на з'єднання з сервером FTP, спроба пасивного режиму."
+
+#: ../src/common/ftp.cpp:399
+#, c-format
+msgid "Failed to set FTP transfer mode to %s."
+msgstr "Не вдалося встановити режим передачі FTP у значення %s."
+
+#: ../src/common/ftp.cpp:400 ../src/richtext/richtextsymboldlg.cpp:432
+msgid "ASCII"
+msgstr "ASCII"
+
+#: ../src/common/ftp.cpp:400
+msgid "binary"
+msgstr "двійковий"
+
+#: ../src/common/ftp.cpp:608
+msgid "The FTP server doesn't support the PORT command."
+msgstr "Сервер FTP не підтримує команду PORT."
+
+#: ../src/common/ftp.cpp:622
+msgid "The FTP server doesn't support passive mode."
+msgstr "Сервер FTP не підтримує пасивний режим."
+
+#: ../src/common/gifdecod.cpp:822
+#, c-format
+msgid "Incorrect GIF frame size (%u, %d) for the frame #%u"
+msgstr "Некоректна розмірність кадру GIF (%u, %d), кадр з номером %u"
+
+#: ../src/common/glcmn.cpp:108
+msgid "Failed to allocate colour for OpenGL"
+msgstr "Не вдалося виділити колір для OpenGL"
+
+#: ../src/common/headerctrlcmn.cpp:57
+msgid "Please select the columns to show and define their order:"
+msgstr "Вкажіть стовпчики, які слід показувати, і порядок показу:"
+
+#: ../src/common/headerctrlcmn.cpp:58
+msgid "Customize Columns"
+msgstr "Налаштувати стовпчики"
+
+#: ../src/common/headerctrlcmn.cpp:304
+msgid "&Customize..."
+msgstr "&Налаштувати…"
+
+#: ../src/common/hyperlnkcmn.cpp:132
+#, c-format
+msgid "Failed to open URL \"%s\" in the default browser"
+msgstr "Не вдалося відкрити адресу «%s» у типовому переглядачі"
+
+#: ../src/common/iconbndl.cpp:195
+#, c-format
+msgid "Failed to load image %%d from file '%s'."
+msgstr "Не вдалося завантажити зображення %%d з файла «%s»."
+
+#: ../src/common/iconbndl.cpp:203
+#, c-format
+msgid "Failed to load image %d from stream."
+msgstr "Не вдалося завантажити зображення %d з потоку даних."
+
+#: ../src/common/iconbndl.cpp:221
+#, c-format
+msgid "Failed to load icons from resource '%s'."
+msgstr "Не вдалося завантажити піктограми з ресурсу «%s»."
+
+#: ../src/common/imagbmp.cpp:97
+msgid "BMP: Couldn't save invalid image."
+msgstr "BMP: Не можу записати помилкове зображення."
+
+#: ../src/common/imagbmp.cpp:137
+msgid "BMP: wxImage doesn't have own wxPalette."
+msgstr " BMP: wxImage не має свого wxPalette."
+
+#: ../src/common/imagbmp.cpp:243
+msgid "BMP: Couldn't write the file (Bitmap) header."
+msgstr "BMP: Не вдалося записати заголовок (Bitmap) файла."
+
+#: ../src/common/imagbmp.cpp:266
+msgid "BMP: Couldn't write the file (BitmapInfo) header."
+msgstr "BMP: Не вдалося записати заголовок (BitmapInfo) файла."
+
+#: ../src/common/imagbmp.cpp:353
+msgid "BMP: Couldn't write RGB color map."
+msgstr "BMP: Не вдалося записати карту кольорів RGB."
+
+#: ../src/common/imagbmp.cpp:487
+msgid "BMP: Couldn't write data."
+msgstr "BMP: Не можу записати дані."
+
+#: ../src/common/imagbmp.cpp:561 ../src/common/imagbmp.cpp:642
+msgid "BMP: Couldn't allocate memory."
+msgstr "BMP: Не вдалося виділити пам'ять."
+
+#: ../src/common/imagbmp.cpp:1041
+msgid "DIB Header: Image width > 32767 pixels for file."
+msgstr "Заголовок DIB: ширина картинки у файлі > 32767 пікселів."
+
+#: ../src/common/imagbmp.cpp:1049
+msgid "DIB Header: Image height > 32767 pixels for file."
+msgstr "Заголовок DIB: Висота картинки у файлі > 32767 пікселів."
+
+#: ../src/common/imagbmp.cpp:1081
+msgid "DIB Header: Unknown bitdepth in file."
+msgstr "Заголовок DIB: невідома бітова глибина даних у файлі."
+
+#: ../src/common/imagbmp.cpp:1156
+msgid "DIB Header: Unknown encoding in file."
+msgstr "Заголовок DIB: невідоме кодування файла."
+
+#: ../src/common/imagbmp.cpp:1165
+msgid "DIB Header: Encoding doesn't match bitdepth."
+msgstr "Заголовок DIB: Кодування не відповідає глибині бітів."
+
+#: ../src/common/imagbmp.cpp:1180
+#, c-format
+msgid "BMP Header: Invalid number of colors (%d)."
+msgstr "Заголовок BMP: некоректна кількість кольорів (%d)."
+
+#: ../src/common/imagbmp.cpp:1273
+msgid "Error in reading image DIB."
+msgstr "Помилка під час читання картинки DIB."
+
+#: ../src/common/imagbmp.cpp:1294
+msgid "ICO: Error in reading mask DIB."
+msgstr "ICO: Помилка під час читання маски DIB."
+
+#: ../src/common/imagbmp.cpp:1353
+msgid "ICO: Image too tall for an icon."
+msgstr "ICO: зображення зависоке для піктограми"
+
+#: ../src/common/imagbmp.cpp:1361
+msgid "ICO: Image too wide for an icon."
+msgstr "ICO: зображення зашироке для піктограми"
+
+#: ../src/common/imagbmp.cpp:1388 ../src/common/imagbmp.cpp:1488
+#: ../src/common/imagbmp.cpp:1503 ../src/common/imagbmp.cpp:1514
+#: ../src/common/imagbmp.cpp:1528 ../src/common/imagbmp.cpp:1576
+#: ../src/common/imagbmp.cpp:1591 ../src/common/imagbmp.cpp:1605
+#: ../src/common/imagbmp.cpp:1616
+msgid "ICO: Error writing the image file!"
+msgstr "ICO: Помилка запису файла зображення!"
+
+#: ../src/common/imagbmp.cpp:1701
+msgid "ICO: Invalid icon index."
+msgstr "ICO: Помилковий індекс піктограми."
+
+#: ../src/common/image.cpp:2410
+msgid "Image and mask have different sizes."
+msgstr "Зображення і маска мають різні розміри."
+
+#: ../src/common/image.cpp:2418 ../src/common/image.cpp:2459
+msgid "No unused colour in image being masked."
+msgstr "Немає невикористаного кольору в зображенні, яке маскується."
+
+#: ../src/common/image.cpp:2641
+#, c-format
+msgid "Failed to load bitmap \"%s\" from resources."
+msgstr "Не вдалося завантажити растрове зображення «%s» з ресурсів."
+
+#: ../src/common/image.cpp:2650
+#, c-format
+msgid "Failed to load icon \"%s\" from resources."
+msgstr "Не вдалося завантажити піктограму «%s» з ресурсів."
+
+#: ../src/common/image.cpp:2728 ../src/common/image.cpp:2747
+#, c-format
+msgid "Failed to load image from file \"%s\"."
+msgstr "Не вдалося завантажити зображення з файла «%s»."
+
+#: ../src/common/image.cpp:2761
+#, c-format
+msgid "Can't save image to file '%s': unknown extension."
+msgstr "Не вдалося записати зображення до файла «%s»: невідомий суфікс назви."
+
+#: ../src/common/image.cpp:2869
+msgid "No handler found for image type."
+msgstr "Не знайдено жодного інструменту обробки для зображення."
+
+#: ../src/common/image.cpp:2877 ../src/common/image.cpp:3000
+#: ../src/common/image.cpp:3066
+#, c-format
+msgid "No image handler for type %d defined."
+msgstr "Не знайдено жодного обробника для зображення типу %d."
+
+#: ../src/common/image.cpp:2887
+#, c-format
+msgid "Image file is not of type %d."
+msgstr "Файл зображення не належить до типу %d."
+
+#: ../src/common/image.cpp:2970
+msgid "Can't automatically determine the image format for non-seekable input."
+msgstr ""
+"Неможливо визначити формат зображення у автоматичному режимі для вхідних "
+"даних без можливості позиціювання."
+
+#: ../src/common/image.cpp:2988
+msgid "Unknown image data format."
+msgstr "Невідомий формат даних зображення."
+
+#: ../src/common/image.cpp:3009
+#, c-format
+msgid "This is not a %s."
+msgstr "Це не %s."
+
+#: ../src/common/image.cpp:3032 ../src/common/image.cpp:3080
+#, c-format
+msgid "No image handler for type %s defined."
+msgstr "Не знайдено жодного обробника для зображення типу %s."
+
+#: ../src/common/image.cpp:3041
+#, c-format
+msgid "Image is not of type %s."
+msgstr "Зображення не належить до типу %s."
+
+#: ../src/common/image.cpp:3509
+#, c-format
+msgid "Failed to check format of image file \"%s\"."
+msgstr "Не вдалося перевірити формат файла зображення «%s»."
+
+#: ../src/common/imaggif.cpp:124
+msgid "GIF: error in GIF image format."
+msgstr "GIF: помилка в форматі зображення GIF."
+
+#: ../src/common/imaggif.cpp:129
+msgid "GIF: not enough memory."
+msgstr "GIF: нестача пам'яті."
+
+#: ../src/common/imaggif.cpp:134
+msgid "GIF: data stream seems to be truncated."
+msgstr "GIF: потік даних здається обрізаний."
+
+#: ../src/common/imaggif.cpp:240
+msgid "Couldn't initialize GIF hash table."
+msgstr "Не вдалося ініціалізувати таблицю хешів GIF."
+
+#: ../src/common/imagiff.cpp:739
+msgid "IFF: error in IFF image format."
+msgstr "IFF: помилка у форматі картинки IFF."
+
+#: ../src/common/imagiff.cpp:742
+msgid "IFF: not enough memory."
+msgstr "IFF: не вистачає пам'яті."
+
+#: ../src/common/imagiff.cpp:745
+msgid "IFF: unknown error!!!"
+msgstr "IIF: Невідома помилка!!!"
+
+#: ../src/common/imagiff.cpp:755
+msgid "IFF: data stream seems to be truncated."
+msgstr "IFF: потік даних здається обрізано."
+
+#: ../src/common/imagjpeg.cpp:258
+msgid "JPEG: Couldn't load - file is probably corrupted."
+msgstr "JPEG: Не вдалося завантажити — можливо файл пошкоджено."
+
+#: ../src/common/imagjpeg.cpp:437
+msgid "JPEG: Couldn't save image."
+msgstr "JPEG: Не вдалося записати зображення."
+
+#: ../src/common/imagpcx.cpp:439
+msgid "PCX: this is not a PCX file."
+msgstr "PCX: це не файл PCX."
+
+#: ../src/common/imagpcx.cpp:453
+msgid "PCX: image format unsupported"
+msgstr "PCX: формат не підтримується"
+
+#: ../src/common/imagpcx.cpp:454 ../src/common/imagpcx.cpp:477
+msgid "PCX: couldn't allocate memory"
+msgstr "PCX: не можу виділити пам'ять"
+
+#: ../src/common/imagpcx.cpp:455
+msgid "PCX: version number too low"
+msgstr "PCX: номер версії дуже довгий"
+
+#: ../src/common/imagpcx.cpp:456 ../src/common/imagpcx.cpp:478
+msgid "PCX: unknown error !!!"
+msgstr "PCX: невідома помилка !!!"
+
+#: ../src/common/imagpcx.cpp:476
+msgid "PCX: invalid image"
+msgstr "PCX: некоректне зображення"
+
+#: ../src/common/imagpng.cpp:385
+#, c-format
+msgid "Unknown PNG resolution unit %d"
+msgstr "Невідома одиниця роздільної здатності PNG, %d"
+
+#: ../src/common/imagpng.cpp:439
+msgid "Couldn't load a PNG image - file is corrupted or not enough memory."
+msgstr ""
+"Не вдалося завантажити зображення PNG. Можливо файл пошкоджено або не "
+"вистачає пам'яті."
+
+#: ../src/common/imagpng.cpp:513 ../src/common/imagpng.cpp:524
+#: ../src/common/imagpng.cpp:534
+msgid "Couldn't save PNG image."
+msgstr "Не вдалося записати зображення PNG."
+
+#: ../src/common/imagpnm.cpp:71
+msgid "PNM: File format is not recognized."
+msgstr "PNM: формат файла не розпізнано."
+
+#: ../src/common/imagpnm.cpp:89
+msgid "PNM: Couldn't allocate memory."
+msgstr "PCX: не вдалося виділити пам'ять."
+
+#: ../src/common/imagpnm.cpp:111 ../src/common/imagpnm.cpp:134
+#: ../src/common/imagpnm.cpp:156
+msgid "PNM: File seems truncated."
+msgstr "PNM: файл здається обірваним."
+
+#: ../src/common/imagtiff.cpp:69
+#, c-format
+msgid " (in module \"%s\")"
+msgstr " (у модулі «%s»)"
+
+#: ../src/common/imagtiff.cpp:304
+msgid "TIFF: Error loading image."
+msgstr "TIFF: Помилка під час завантаження зображення."
+
+#: ../src/common/imagtiff.cpp:314
+msgid "Invalid TIFF image index."
+msgstr "Неможливий індекс зображення TIFF."
+
+#: ../src/common/imagtiff.cpp:358
+msgid "TIFF: Image size is abnormally big."
+msgstr "TIFF: розмір зображення є надзвичайно великим."
+
+#: ../src/common/imagtiff.cpp:372 ../src/common/imagtiff.cpp:385
+#: ../src/common/imagtiff.cpp:769
+msgid "TIFF: Couldn't allocate memory."
+msgstr "TIFF: Не вдалося виділити пам'ять."
+
+#: ../src/common/imagtiff.cpp:471
+msgid "TIFF: Error reading image."
+msgstr "TIFF: Помилка читання зображення."
+
+#: ../src/common/imagtiff.cpp:532
+#, c-format
+msgid "Unknown TIFF resolution unit %d ignored"
+msgstr "Невідому одиницю роздільної здатності TIFF, %d, проігноровано"
+
+#: ../src/common/imagtiff.cpp:611
+msgid "TIFF: Error saving image."
+msgstr "TIFF: Помилка запису зображення."
+
+#: ../src/common/imagtiff.cpp:868
+msgid "TIFF: Error writing image."
+msgstr "TIFF: Помилка запису зображення."
+
+#: ../src/common/imagtiff.cpp:881
+msgid "TIFF: Error flushing data."
+msgstr "TIFF: Помилка витирання даних."
+
+#: ../src/common/imagwebp.cpp:56
+msgid "WebP: Invalid data (failed to get features)."
+msgstr "WebP: некоректні дані (не вдалося отримати список можливостей)."
+
+#: ../src/common/imagwebp.cpp:65
+msgid "WebP: Allocating image memory failed."
+msgstr "WebP: не вдалося отримати об'єм пам'яті для зображення."
+
+#: ../src/common/imagwebp.cpp:82
+msgid "WebP: Decoding RGBA image data failed."
+msgstr "WebP: не вдалося декодувати дані зображення RGBA."
+
+#: ../src/common/imagwebp.cpp:98
+msgid "WebP: Decoding RGB image data failed."
+msgstr "WebP: не вдалося декодувати дані зображення RGB."
+
+#: ../src/common/imagwebp.cpp:113 ../src/common/imagwebp.cpp:201
+msgid "WebP: Allocating stream buffer failed."
+msgstr "WebP: не вдалося розмістити у пам'яті буфер потоку даних."
+
+#: ../src/common/imagwebp.cpp:131
+msgid "WebP: Failed to parse container data."
+msgstr "WebP: не вдалося обробити дані контейнера."
+
+#: ../src/common/imagwebp.cpp:222
+msgid "WebP: Error decoding animation."
+msgstr "WebP: помилка під час спроби декодування анімації."
+
+#: ../src/common/imagwebp.cpp:240
+msgid "WebP: Error getting next animation frame."
+msgstr "WebP: помилка при отриманні наступного кадру анімації."
+
+#: ../src/common/init.cpp:172
+#, c-format
+msgid ""
+"Command line argument %d couldn't be converted to Unicode and will be "
+"ignored."
+msgstr ""
+"Не вдалося перетворити параметр командного рядка %d у Unicode, параметр буде "
+"проігноровано."
+
+#: ../src/common/init.cpp:344
+msgid "Initialization failed in post init, aborting."
+msgstr "Помилка ініціалізації у процесі post init, зупинка."
+
+#: ../src/common/intl.cpp:378
+#, c-format
+msgid "Cannot set locale to language \"%s\"."
+msgstr "Не вдалося встановити локаль у значення «%s»."
+
+#: ../src/common/log.cpp:232
+msgid "Error: "
+msgstr "Помилка: "
+
+#: ../src/common/log.cpp:236
+msgid "Warning: "
+msgstr "Попередження: "
+
+#: ../src/common/log.cpp:284
+msgid "The previous message repeated once."
+msgstr "Попереднє повідомлення повторено один раз."
+
+#: ../src/common/log.cpp:291
+#, c-format
+msgid "The previous message repeated %u time."
+msgid_plural "The previous message repeated %u times."
+msgstr[0] "Попереднє повідомлення повторено %u раз."
+msgstr[1] "Попереднє повідомлення повторено %u рази."
+msgstr[2] "Попереднє повідомлення повторено %u разів."
+msgstr[3] "Попереднє повідомлення повторено %u раз."
+
+#: ../src/common/log.cpp:319
+#, c-format
+msgid "Last repeated message (\"%s\", %u time) wasn't output"
+msgid_plural "Last repeated message (\"%s\", %u times) wasn't output"
+msgstr[0] "Останні повторені повідомлення («%s», %u раз) не було виведено"
+msgstr[1] "Останні повторені повідомлення («%s», %u рази) не було виведено"
+msgstr[2] "Останні повторені повідомлення («%s», %u разів) не було виведено"
+msgstr[3] "Останні повторені повідомлення («%s», %u раз) не було виведено"
+
+#: ../src/common/log.cpp:435
+#, c-format
+msgid " (error %ld: %s)"
+msgstr " (помилка %ld: %s)"
+
+#: ../src/common/lzmastream.cpp:121
+msgid "Failed to allocate memory for LZMA decompression."
+msgstr "Не вдалося отримати область пам'яті для розпаковування LZMA."
+
+#: ../src/common/lzmastream.cpp:125
+#, c-format
+msgid "Failed to initialize LZMA decompression: unexpected error %u."
+msgstr ""
+"Не вдалося ініціалізувати розпаковування LZMA: неочікувана помилка %u."
+
+#: ../src/common/lzmastream.cpp:179
+msgid "input is not in XZ format"
+msgstr "вхідні дані записано не у форматі XZ"
+
+#: ../src/common/lzmastream.cpp:183
+msgid "input compressed using unknown XZ option"
+msgstr "вхідні дані стиснуто за допомогою невідомого параметра XZ"
+
+#: ../src/common/lzmastream.cpp:188
+msgid "input is corrupted"
+msgstr "вхідні дані пошкоджено"
+
+#: ../src/common/lzmastream.cpp:192
+msgid "unknown decompression error"
+msgstr "невідома помилка розпакування"
+
+#: ../src/common/lzmastream.cpp:196
+#, c-format
+msgid "LZMA decompression error: %s"
+msgstr "Помилка розпакування LZMA: %s"
+
+#: ../src/common/lzmastream.cpp:231
+msgid "Failed to allocate memory for LZMA compression."
+msgstr "Не вдалося отримати пам'ять для пакування LZMA."
+
+#: ../src/common/lzmastream.cpp:235
+#, c-format
+msgid "Failed to initialize LZMA compression: unexpected error %u."
+msgstr "Не вдалося ініціалізувати стискання LZMA: неочікувана помилка %u."
+
+#: ../src/common/lzmastream.cpp:267 ../src/common/lzmastream.cpp:342
+#: ../src/html/chm.cpp:336
+msgid "out of memory"
+msgstr "нестача пам'яті"
+
+#: ../src/common/lzmastream.cpp:276 ../src/common/lzmastream.cpp:346
+msgid "unknown compression error"
+msgstr "невідома помилка пакування"
+
+#: ../src/common/lzmastream.cpp:280
+#, c-format
+msgid "LZMA compression error: %s"
+msgstr "Помилка пакування LZMA: %s"
+
+#: ../src/common/lzmastream.cpp:350
+#, c-format
+msgid "LZMA compression error when flushing output: %s"
+msgstr "Помилка стискання LZMA при скиданні виведених даних: %s"
+
+#: ../src/common/mimecmn.cpp:167
+#, c-format
+msgid "Unmatched '{' in an entry for mime type %s."
+msgstr "Незакрита дужка '{' в запису для типу MIME %s."
+
+#: ../src/common/module.cpp:76
+#, c-format
+msgid "Circular dependency involving module \"%s\" detected."
+msgstr "Виявлено циклічну залежність, що містить модуль «%s»."
+
+#: ../src/common/module.cpp:128
+#, c-format
+msgid "Dependency \"%s\" of module \"%s\" doesn't exist."
+msgstr "Необхідний компонент «%s» для модуля «%s» не існує."
+
+#: ../src/common/module.cpp:137
+#, c-format
+msgid "Module \"%s\" initialization failed"
+msgstr "Виклик модулі «%s» зазнав невдачі"
+
+#: ../src/common/msgout.cpp:96
+msgid "Message"
+msgstr "Повідомлення"
+
+#: ../src/common/paper.cpp:70
+msgid "Letter, 8 1/2 x 11 in"
+msgstr "Лист, 8 1/2 x 11 дюймів"
+
+#: ../src/common/paper.cpp:71
+msgid "Legal, 8 1/2 x 14 in"
+msgstr "Легал, 8 1/2 x 14 дюймів"
+
+#: ../src/common/paper.cpp:72
+msgid "A4 sheet, 210 x 297 mm"
+msgstr "Аркуш A4, 210 x 297 мм"
+
+#: ../src/common/paper.cpp:73
+msgid "C sheet, 17 x 22 in"
+msgstr "Аркуш C, 17 x 22 дюйм"
+
+#: ../src/common/paper.cpp:74
+msgid "D sheet, 22 x 34 in"
+msgstr "Аркуш D, 22 x 34 дюйм"
+
+#: ../src/common/paper.cpp:75
+msgid "E sheet, 34 x 44 in"
+msgstr "E лист, 34 x 44 дюйм"
+
+#: ../src/common/paper.cpp:76
+msgid "Letter Small, 8 1/2 x 11 in"
+msgstr "Малий лист 8 1/2 x 11 дюймів"
+
+#: ../src/common/paper.cpp:77
+msgid "Tabloid, 11 x 17 in"
+msgstr "Таблоїд, 11 x 17 дюймів"
+
+#: ../src/common/paper.cpp:78
+msgid "Ledger, 17 x 11 in"
+msgstr "Ledger, 17 x 11 дюйм"
+
+#: ../src/common/paper.cpp:79
+msgid "Statement, 5 1/2 x 8 1/2 in"
+msgstr "Statement, 5 1/2 x 8 1/2 дюйм"
+
+#: ../src/common/paper.cpp:80
+msgid "Executive, 7 1/4 x 10 1/2 in"
+msgstr "Executive, 7 1/4 x 10 1/2 дюйм"
+
+#: ../src/common/paper.cpp:81
+msgid "A3 sheet, 297 x 420 mm"
+msgstr "Аркуш A3 297 x 420 мм"
+
+#: ../src/common/paper.cpp:82
+msgid "A4 small sheet, 210 x 297 mm"
+msgstr "Малий лист A4, 210 x 297 мм"
+
+#: ../src/common/paper.cpp:83
+msgid "A5 sheet, 148 x 210 mm"
+msgstr "Аркуш A5, 148 x 210 мм"
+
+#: ../src/common/paper.cpp:84
+msgid "B4 sheet, 250 x 354 mm"
+msgstr "Аркуш B4, 250 x 354 мм"
+
+#: ../src/common/paper.cpp:85
+msgid "B5 sheet, 182 x 257 millimeter"
+msgstr "Аркуш B5, 182 x 257 мм"
+
+#: ../src/common/paper.cpp:86
+msgid "Folio, 8 1/2 x 13 in"
+msgstr "Folio, 8 1/2 x 13 дюйм"
+
+#: ../src/common/paper.cpp:87
+msgid "Quarto, 215 x 275 mm"
+msgstr "Quarto, 215 x 275 мм"
+
+#: ../src/common/paper.cpp:88
+msgid "10 x 14 in"
+msgstr "10 x 14 дюймів"
+
+#: ../src/common/paper.cpp:89
+msgid "11 x 17 in"
+msgstr "11 x 17 дюймів"
+
+#: ../src/common/paper.cpp:90
+msgid "Note, 8 1/2 x 11 in"
+msgstr "Note, 8 1/2 x 11 дюйм"
+
+#: ../src/common/paper.cpp:91
+msgid "#9 Envelope, 3 7/8 x 8 7/8 in"
+msgstr "#9 Конверт, 3 7/8 x 8 7/8 дюйм"
+
+#: ../src/common/paper.cpp:92
+msgid "#10 Envelope, 4 1/8 x 9 1/2 in"
+msgstr "#10 Конверт, 4 1/8 x 9 1/2 дюйм"
+
+#: ../src/common/paper.cpp:93
+msgid "#11 Envelope, 4 1/2 x 10 3/8 in"
+msgstr "#11 Конверт, 4 1/2 x 10 3/8 дюйм"
+
+#: ../src/common/paper.cpp:94
+msgid "#12 Envelope, 4 3/4 x 11 in"
+msgstr "#12 Конверт, 4 3/4 x 11 дюйм"
+
+#: ../src/common/paper.cpp:95
+msgid "#14 Envelope, 5 x 11 1/2 in"
+msgstr "#14 Конверт, 5 x 11 1/2 дюйм"
+
+#: ../src/common/paper.cpp:96
+msgid "DL Envelope, 110 x 220 mm"
+msgstr "DL Конверт, 110 x 220 мм"
+
+#: ../src/common/paper.cpp:97
+msgid "C5 Envelope, 162 x 229 mm"
+msgstr "C5 Конверт, 162 x 229 мм"
+
+#: ../src/common/paper.cpp:98
+msgid "C3 Envelope, 324 x 458 mm"
+msgstr "C3 Конверт, 324 x 458 мм"
+
+#: ../src/common/paper.cpp:99
+msgid "C4 Envelope, 229 x 324 mm"
+msgstr "C4 Конверт, 229 x 324 мм"
+
+#: ../src/common/paper.cpp:100
+msgid "C6 Envelope, 114 x 162 mm"
+msgstr "C6 Конверт, 114 x 162 мм"
+
+#: ../src/common/paper.cpp:101
+msgid "C65 Envelope, 114 x 229 mm"
+msgstr "C65 Конверт, 114 x 229 мм"
+
+#: ../src/common/paper.cpp:102
+msgid "B4 Envelope, 250 x 353 mm"
+msgstr "B4 Конверт, 250 x 353 мм"
+
+#: ../src/common/paper.cpp:103
+msgid "B5 Envelope, 176 x 250 mm"
+msgstr "B5 Конверт, 176 x 250 мм"
+
+#: ../src/common/paper.cpp:104
+msgid "B6 Envelope, 176 x 125 mm"
+msgstr "B6 Конверт, 176 x 125 мм"
+
+#: ../src/common/paper.cpp:105
+msgid "Italy Envelope, 110 x 230 mm"
+msgstr "Італійський Конверт, 110 x 230 мм"
+
+#: ../src/common/paper.cpp:106
+msgid "Monarch Envelope, 3 7/8 x 7 1/2 in"
+msgstr "Monarch конверт, 3 7/8 x 7 1/2 дюйм"
+
+#: ../src/common/paper.cpp:107
+msgid "6 3/4 Envelope, 3 5/8 x 6 1/2 in"
+msgstr "6 3/4 Конверт, 3 5/8 x 6 1/2 дюйм"
+
+#: ../src/common/paper.cpp:108
+msgid "US Std Fanfold, 14 7/8 x 11 in"
+msgstr "US Std Fanfold, 14 7/8 x 11 дюйм"
+
+#: ../src/common/paper.cpp:109
+msgid "German Std Fanfold, 8 1/2 x 12 in"
+msgstr "German Std Fanfold, 8 1/2 x 12 in"
+
+#: ../src/common/paper.cpp:110
+msgid "German Legal Fanfold, 8 1/2 x 13 in"
+msgstr "German Legal Fanfold, 8 1/2 x 13 дюйм"
+
+#: ../src/common/paper.cpp:112
+msgid "B4 (ISO) 250 x 353 mm"
+msgstr "B4 (ISO) 250 x 353 мм"
+
+#: ../src/common/paper.cpp:113
+msgid "Japanese Postcard 100 x 148 mm"
+msgstr "Японська листівка 100 x 148 мм"
+
+#: ../src/common/paper.cpp:114
+msgid "9 x 11 in"
+msgstr "9 x 11 дюймів"
+
+#: ../src/common/paper.cpp:115
+msgid "10 x 11 in"
+msgstr "10 x 11 дюймів"
+
+#: ../src/common/paper.cpp:116
+msgid "15 x 11 in"
+msgstr "15 x 11 дюймів"
+
+#: ../src/common/paper.cpp:117
+msgid "Envelope Invite 220 x 220 mm"
+msgstr "Конверт Запрошення 220 x 220 мм"
+
+#: ../src/common/paper.cpp:118
+msgid "Letter Extra 9 1/2 x 12 in"
+msgstr "Легал Екстра, 9 1/2 x 12 дюймів"
+
+#: ../src/common/paper.cpp:119
+msgid "Legal Extra 9 1/2 x 15 in"
+msgstr "Легал Екстра 9 1/2 x 15 дюймів"
+
+#: ../src/common/paper.cpp:120
+msgid "Tabloid Extra 11.69 x 18 in"
+msgstr "Таблоїд Екстра 11,69 x 18 дюймів"
+
+#: ../src/common/paper.cpp:121
+msgid "A4 Extra 9.27 x 12.69 in"
+msgstr "A4 Екстра 9.27 x 12.69 дюймів"
+
+#: ../src/common/paper.cpp:122
+msgid "Letter Transverse 8 1/2 x 11 in"
+msgstr "Лист поперечний 8 1/2 x 11 дюймів"
+
+#: ../src/common/paper.cpp:123
+msgid "A4 Transverse 210 x 297 mm"
+msgstr "A4 Поперечний 210 x 297 мм"
+
+#: ../src/common/paper.cpp:124
+msgid "Letter Extra Transverse 9.275 x 12 in"
+msgstr "Letter Extra Поперечний 9.275 x 12 дюймів"
+
+#: ../src/common/paper.cpp:125
+msgid "SuperA/SuperA/A4 227 x 356 mm"
+msgstr "SuperA/SuperA/A4 227 x 356 мм"
+
+#: ../src/common/paper.cpp:126
+msgid "SuperB/SuperB/A3 305 x 487 mm"
+msgstr "SuperB/SuperB/A3 305 x 487 мм"
+
+#: ../src/common/paper.cpp:127
+msgid "Letter Plus 8 1/2 x 12.69 in"
+msgstr "Легал плюс, 8 1/2 x 12,69 дюймів"
+
+#: ../src/common/paper.cpp:128
+msgid "A4 Plus 210 x 330 mm"
+msgstr "A4 Плюс 210 x 330 мм"
+
+#: ../src/common/paper.cpp:129
+msgid "A5 Transverse 148 x 210 mm"
+msgstr "A5 Поперечний 148 x 210 мм"
+
+#: ../src/common/paper.cpp:130
+msgid "B5 (JIS) Transverse 182 x 257 mm"
+msgstr "B5 (JIS) Поперечний 182 x 257 мм"
+
+#: ../src/common/paper.cpp:131
+msgid "A3 Extra 322 x 445 mm"
+msgstr "A3 Екстра 322 x 445 мм"
+
+#: ../src/common/paper.cpp:132
+msgid "A5 Extra 174 x 235 mm"
+msgstr "A5 Екстра 174 x 235 мм"
+
+#: ../src/common/paper.cpp:133
+msgid "B5 (ISO) Extra 201 x 276 mm"
+msgstr "B5 (ISO) Екстра 201 x 276 мм"
+
+#: ../src/common/paper.cpp:134
+msgid "A2 420 x 594 mm"
+msgstr "A2 420 x 594 мм"
+
+#: ../src/common/paper.cpp:135
+msgid "A3 Transverse 297 x 420 mm"
+msgstr "A3 Поперечний 297 x 420 мм"
+
+#: ../src/common/paper.cpp:136
+msgid "A3 Extra Transverse 322 x 445 mm"
+msgstr "A3 Екстра Поперечний 322 x 445 мм"
+
+#: ../src/common/paper.cpp:138
+msgid "Japanese Double Postcard 200 x 148 mm"
+msgstr "Японська подвійна листівка 200 x 148 мм"
+
+#: ../src/common/paper.cpp:139
+msgid "A6 105 x 148 mm"
+msgstr "A6 105 x 148 мм"
+
+#: ../src/common/paper.cpp:140
+msgid "Japanese Envelope Kaku #2"
+msgstr "Японський конверт Kaku #2"
+
+#: ../src/common/paper.cpp:141
+msgid "Japanese Envelope Kaku #3"
+msgstr "Японський конверт Kaku #3"
+
+#: ../src/common/paper.cpp:142
+msgid "Japanese Envelope Chou #3"
+msgstr "Японський конверт Chou #3"
+
+#: ../src/common/paper.cpp:143
+msgid "Japanese Envelope Chou #4"
+msgstr "Японський конверт Chou #4"
+
+#: ../src/common/paper.cpp:144
+msgid "Letter Rotated 11 x 8 1/2 in"
+msgstr "Лист повернутий 11 x 8 1/2 дюймів"
+
+#: ../src/common/paper.cpp:145
+msgid "A3 Rotated 420 x 297 mm"
+msgstr "A3 Повернутий 420 x 297 мм"
+
+#: ../src/common/paper.cpp:146
+msgid "A4 Rotated 297 x 210 mm"
+msgstr "A4 Повернутий 297 x 210 мм"
+
+#: ../src/common/paper.cpp:147
+msgid "A5 Rotated 210 x 148 mm"
+msgstr "A5 Повернутий 210 x 148 мм"
+
+#: ../src/common/paper.cpp:148
+msgid "B4 (JIS) Rotated 364 x 257 mm"
+msgstr "B4 (JIS) Повернутий 364 x 257 мм"
+
+#: ../src/common/paper.cpp:149
+msgid "B5 (JIS) Rotated 257 x 182 mm"
+msgstr "B5 (JIS) Повернутий 257 x 182 мм"
+
+#: ../src/common/paper.cpp:150
+msgid "Japanese Postcard Rotated 148 x 100 mm"
+msgstr "Японська листівка Повернута 148 x 100 мм"
+
+#: ../src/common/paper.cpp:151
+msgid "Double Japanese Postcard Rotated 148 x 200 mm"
+msgstr "Подвійна японська листівка повернута 148 x 200 мм"
+
+#: ../src/common/paper.cpp:152
+msgid "A6 Rotated 148 x 105 mm"
+msgstr "A6 Повернутий 148 x 105 мм"
+
+#: ../src/common/paper.cpp:153
+msgid "Japanese Envelope Kaku #2 Rotated"
+msgstr "Японський конверт Kaku #2 Повернутий"
+
+#: ../src/common/paper.cpp:154
+msgid "Japanese Envelope Kaku #3 Rotated"
+msgstr "Японський конверт Kaku #3 Повернутий"
+
+#: ../src/common/paper.cpp:155
+msgid "Japanese Envelope Chou #3 Rotated"
+msgstr "Японський конверт Chou #3 Повернутий"
+
+#: ../src/common/paper.cpp:156
+msgid "Japanese Envelope Chou #4 Rotated"
+msgstr "Японський конверт Chou #4 Повернутий"
+
+#: ../src/common/paper.cpp:157
+msgid "B6 (JIS) 128 x 182 mm"
+msgstr "B6 (JIS) 128 x 182 мм"
+
+#: ../src/common/paper.cpp:158
+msgid "B6 (JIS) Rotated 182 x 128 mm"
+msgstr "B6 (JIS) Повернутий 182 x 128 мм"
+
+#: ../src/common/paper.cpp:159
+msgid "12 x 11 in"
+msgstr "12 x 11 дюймів"
+
+#: ../src/common/paper.cpp:160
+msgid "Japanese Envelope You #4"
+msgstr "Японський конверт You #4"
+
+#: ../src/common/paper.cpp:161
+msgid "Japanese Envelope You #4 Rotated"
+msgstr "Японський конверт You #4 Повернутий"
+
+#: ../src/common/paper.cpp:162
+msgid "PRC 16K 146 x 215 mm"
+msgstr "PRC 16K 146 x 215 мм"
+
+#: ../src/common/paper.cpp:163
+msgid "PRC 32K 97 x 151 mm"
+msgstr "PRC 32K 97 x 151 мм"
+
+#: ../src/common/paper.cpp:164
+msgid "PRC 32K(Big) 97 x 151 mm"
+msgstr "PRC 32K(Великий) 97 x 151 мм"
+
+#: ../src/common/paper.cpp:165
+msgid "PRC Envelope #1 102 x 165 mm"
+msgstr "Конверт PRC #1 102 x 165 мм"
+
+#: ../src/common/paper.cpp:166
+msgid "PRC Envelope #2 102 x 176 mm"
+msgstr "Конверт PRC #2 102 x 176 мм"
+
+#: ../src/common/paper.cpp:167
+msgid "PRC Envelope #3 125 x 176 mm"
+msgstr "Конверт PRC #3 125 x 176 мм"
+
+#: ../src/common/paper.cpp:168
+msgid "PRC Envelope #4 110 x 208 mm"
+msgstr "Конверт PRC #4 110 x 208 мм"
+
+#: ../src/common/paper.cpp:169
+msgid "PRC Envelope #5 110 x 220 mm"
+msgstr "Конверт PRC #5 110 x 220 мм"
+
+#: ../src/common/paper.cpp:170
+msgid "PRC Envelope #6 120 x 230 mm"
+msgstr "Конверт PRC #6 120 x 230 мм"
+
+#: ../src/common/paper.cpp:171
+msgid "PRC Envelope #7 160 x 230 mm"
+msgstr "Конверт PRC #7 160 x 230 мм"
+
+#: ../src/common/paper.cpp:172
+msgid "PRC Envelope #8 120 x 309 mm"
+msgstr "Конверт PRC #8 120 x 309 мм"
+
+#: ../src/common/paper.cpp:173
+msgid "PRC Envelope #9 229 x 324 mm"
+msgstr "Конверт PRC #9 229 x 324 мм"
+
+#: ../src/common/paper.cpp:174
+msgid "PRC Envelope #10 324 x 458 mm"
+msgstr "Конверт PRC #10 324 x 458 мм"
+
+#: ../src/common/paper.cpp:175
+msgid "PRC 16K Rotated"
+msgstr "PRC 16K Повернутий"
+
+#: ../src/common/paper.cpp:176
+msgid "PRC 32K Rotated"
+msgstr "PRC 32K Повернутий"
+
+#: ../src/common/paper.cpp:177
+msgid "PRC 32K(Big) Rotated"
+msgstr "PRC 32K(Великий) Повернутий"
+
+#: ../src/common/paper.cpp:178
+msgid "PRC Envelope #1 Rotated 165 x 102 mm"
+msgstr "Конверт PRC #1 Повернутий 165 x 102 мм"
+
+#: ../src/common/paper.cpp:179
+msgid "PRC Envelope #2 Rotated 176 x 102 mm"
+msgstr "Конверт PRC #2 Повернутий 176 x 102 мм"
+
+#: ../src/common/paper.cpp:180
+msgid "PRC Envelope #3 Rotated 176 x 125 mm"
+msgstr "Конверт PRC #3 Повернутий 176 x 125 мм"
+
+#: ../src/common/paper.cpp:181
+msgid "PRC Envelope #4 Rotated 208 x 110 mm"
+msgstr "Конверт PRC #4 Повернутий 208 x 110 мм"
+
+#: ../src/common/paper.cpp:182
+msgid "PRC Envelope #5 Rotated 220 x 110 mm"
+msgstr "Конверт PRC #5 Повернутий 220 x 110 мм"
+
+#: ../src/common/paper.cpp:183
+msgid "PRC Envelope #6 Rotated 230 x 120 mm"
+msgstr "Конверт PRC #6 Повернутий 230 x 120 мм"
+
+#: ../src/common/paper.cpp:184
+msgid "PRC Envelope #7 Rotated 230 x 160 mm"
+msgstr "Конверт PRC #7 Повернутий 230 x 160 мм"
+
+#: ../src/common/paper.cpp:185
+msgid "PRC Envelope #8 Rotated 309 x 120 mm"
+msgstr "Конверт PRC #8 Повернутий 309 x 120 мм"
+
+#: ../src/common/paper.cpp:186
+msgid "PRC Envelope #9 Rotated 324 x 229 mm"
+msgstr "Конверт PRC #9 Повернутий 324 x 229 мм"
+
+#: ../src/common/paper.cpp:187
+msgid "PRC Envelope #10 Rotated 458 x 324 mm"
+msgstr "Конверт PRC #10 Повернутий 458 x 324 мм"
+
+#: ../src/common/paper.cpp:192
+msgid "A0 sheet, 841 x 1189 mm"
+msgstr "Аркуш A0, 841 x 1189 мм"
+
+#: ../src/common/paper.cpp:193
+msgid "A1 sheet, 594 x 841 mm"
+msgstr "Аркуш A1, 594 x 841 мм"
+
+#: ../src/common/preferencescmn.cpp:37
+msgid "General"
+msgstr "Загальне"
+
+#: ../src/common/preferencescmn.cpp:40
+msgid "Advanced"
+msgstr "Додатково"
+
+#: ../src/common/prntbase.cpp:245
+msgid "Generic PostScript"
+msgstr "Звичайний PostScript"
+
+#: ../src/common/prntbase.cpp:259
+msgid "Ready"
+msgstr "Готова"
+
+#: ../src/common/prntbase.cpp:331
+msgid "Printing Error"
+msgstr "Помилка друку"
+
+#: ../src/common/prntbase.cpp:413 ../src/common/prntbase.cpp:1597
+#: ../src/generic/prntdlgg.cpp:135 ../src/generic/prntdlgg.cpp:149
+#: ../src/gtk/print.cpp:628 ../src/gtk/print.cpp:646
+msgid "Print"
+msgstr "Друк"
+
+#: ../src/common/prntbase.cpp:471 ../src/generic/prntdlgg.cpp:809
+msgid "Page setup"
+msgstr "Налаштування сторінки"
+
+#: ../src/common/prntbase.cpp:525
+msgid "Please wait while printing..."
+msgstr "Будь ласка, зачекайте на завершення друку…"
+
+#: ../src/common/prntbase.cpp:529
+msgid "Document:"
+msgstr "Документ:"
+
+#: ../src/common/prntbase.cpp:532
+msgid "Progress:"
+msgstr "Поступ:"
+
+#: ../src/common/prntbase.cpp:533
+msgid "Preparing"
+msgstr "Приготування"
+
+#: ../src/common/prntbase.cpp:552
+#, c-format
+msgid "Printing page %d"
+msgstr "Друкуємо сторінку %d"
+
+#: ../src/common/prntbase.cpp:557
+#, c-format
+msgid "Printing page %d of %d"
+msgstr "Друкуємо сторінку %d з %d"
+
+#: ../src/common/prntbase.cpp:560
+#, c-format
+msgid " (copy %d of %d)"
+msgstr " (копія %d з %d)"
+
+#: ../src/common/prntbase.cpp:1604
+msgid "First page"
+msgstr "Перша сторінка"
+
+#: ../src/common/prntbase.cpp:1609 ../src/html/helpwnd.cpp:659
+msgid "Previous page"
+msgstr "Попередня сторінка"
+
+#: ../src/common/prntbase.cpp:1623 ../src/html/helpwnd.cpp:660
+msgid "Next page"
+msgstr "Наступна сторінка"
+
+#: ../src/common/prntbase.cpp:1628
+msgid "Last page"
+msgstr "Остання сторінка"
+
+#: ../src/common/prntbase.cpp:1636 ../src/common/stockitem.cpp:215
+msgid "Zoom Out"
+msgstr "Зменшити"
+
+#: ../src/common/prntbase.cpp:1650 ../src/common/stockitem.cpp:214
+msgid "Zoom In"
+msgstr "Збільшити"
+
+#: ../src/common/prntbase.cpp:1656 ../src/common/stockitem.cpp:153
+#: ../src/generic/logg.cpp:553 ../src/univ/themes/win32.cpp:3752
+msgid "&Close"
+msgstr "&Закрити"
+
+#: ../src/common/prntbase.cpp:2085
+msgid "Could not start document preview."
+msgstr "Не вдалося почати попередній перегляд документа."
+
+#: ../src/common/prntbase.cpp:2085 ../src/common/prntbase.cpp:2129
+#: ../src/common/prntbase.cpp:2137
+msgid "Print Preview Failure"
+msgstr "Помилка попереднього перегляду друку"
+
+#: ../src/common/prntbase.cpp:2129 ../src/common/prntbase.cpp:2137
+msgid "Sorry, not enough memory to create a preview."
+msgstr "Нестача пам'яті для створення зони попереднього перегляду."
+
+#: ../src/common/prntbase.cpp:2144
+#, c-format
+msgid "Page %d of %d"
+msgstr "Сторінка %d з %d"
+
+#: ../src/common/prntbase.cpp:2146
+#, c-format
+msgid "Page %d"
+msgstr "Сторінка %d"
+
+#: ../src/common/regex.cpp:382 ../src/html/chm.cpp:348
+msgid "unknown error"
+msgstr "Невідома помилка"
+
+#: ../src/common/regex.cpp:995
+#, c-format
+msgid "Invalid regular expression '%s': %s"
+msgstr "Неправильний регулярний вираз «%s»: %s"
+
+#: ../src/common/regex.cpp:1059
+#, c-format
+msgid "Failed to find match for regular expression: %s"
+msgstr "Не вдалося знайти відповідник для регулярного виразу: %s"
+
+#: ../src/common/rendcmn.cpp:188
+#, c-format
+msgid "Renderer \"%s\" has incompatible version %d.%d and couldn't be loaded."
+msgstr ""
+"Візуалізатор «%s» має несумісну версію %d.%d, його неможливо завантажити."
+
+#: ../src/common/secretstore.cpp:162
+msgid "Not available for this platform"
+msgstr "Є недоступним для цієї платформи"
+
+#: ../src/common/secretstore.cpp:183
+#, c-format
+msgid "Saving password for \"%s\" failed: %s."
+msgstr "Не вдалося зберегти пароль для «%s»: %s."
+
+#: ../src/common/secretstore.cpp:205
+#, c-format
+msgid "Reading password for \"%s\" failed: %s."
+msgstr "Не вдалося прочитати пароль для «%s»: %s."
+
+#: ../src/common/secretstore.cpp:228
+#, c-format
+msgid "Deleting password for \"%s\" failed: %s."
+msgstr "Не вдалося вилучити пароль для «%s»: %s."
+
+#: ../src/common/selectdispatcher.cpp:254
+msgid "Failed to monitor I/O channels"
+msgstr "Спроба спостереження за каналами вводу-виводу була невдалою"
+
+#: ../src/common/sizer.cpp:3054 ../src/common/stockitem.cpp:195
+msgid "Save"
+msgstr "Зберегти"
+
+#: ../src/common/sizer.cpp:3056
+msgid "Don't Save"
+msgstr "Не зберігати"
+
+#: ../src/common/socket.cpp:870
+msgid "Cannot initialize sockets"
+msgstr "Не вдалося ініціювати сокети"
+
+#: ../src/common/stockitem.cpp:127
+msgctxt "standard Windows menu"
+msgid "&Help"
+msgstr "&Довідка"
+
+#: ../src/common/stockitem.cpp:144
+msgid "&About"
+msgstr "&Про програму"
+
+#: ../src/common/stockitem.cpp:144
+msgid "About"
+msgstr "Про програму"
+
+#: ../src/common/stockitem.cpp:145
+msgid "Add"
+msgstr "Додати"
+
+#: ../src/common/stockitem.cpp:146
+msgid "&Apply"
+msgstr "&Застосувати"
+
+#: ../src/common/stockitem.cpp:146
+msgid "Apply"
+msgstr "Застосувати"
+
+#: ../src/common/stockitem.cpp:147
+msgid "&Back"
+msgstr "&Назад"
+
+#: ../src/common/stockitem.cpp:147
+msgid "Back"
+msgstr "Назад"
+
+#: ../src/common/stockitem.cpp:148
+msgid "&Bold"
+msgstr "&Жирний"
+
+#: ../src/common/stockitem.cpp:148 ../src/generic/fontdlgg.cpp:326
+#: ../src/richtext/richtextfontpage.cpp:354
+msgid "Bold"
+msgstr "Жирний"
+
+#: ../src/common/stockitem.cpp:149
+msgid "&Bottom"
+msgstr "В&низу"
+
+#: ../src/common/stockitem.cpp:149 ../src/richtext/richtextsizepage.cpp:287
+msgid "Bottom"
+msgstr "Внизу"
+
+#: ../src/common/stockitem.cpp:150 ../src/generic/fontdlgg.cpp:462
+#: ../src/generic/fontdlgg.cpp:481 ../src/generic/wizard.cpp:415
+msgid "&Cancel"
+msgstr "&Скасувати"
+
+#: ../src/common/stockitem.cpp:151
+msgid "&CD-ROM"
+msgstr "&CD-ROM"
+
+#: ../src/common/stockitem.cpp:151
+msgid "CD-ROM"
+msgstr "CD-ROM"
+
+#: ../src/common/stockitem.cpp:152
+msgid "&Clear"
+msgstr "О&чистити"
+
+#: ../src/common/stockitem.cpp:152
+msgid "Clear"
+msgstr "Спорожнити"
+
+#: ../src/common/stockitem.cpp:153 ../src/generic/dbgrptg.cpp:93
+#: ../src/generic/progdlgg.cpp:778 ../src/html/helpdlg.cpp:86
+#: ../src/msw/progdlg.cpp:209 ../src/msw/progdlg.cpp:890
+#: ../src/richtext/richtextstyledlg.cpp:272
+#: ../src/richtext/richtextsymboldlg.cpp:448
+msgid "Close"
+msgstr "Закрити"
+
+#: ../src/common/stockitem.cpp:154
+msgid "&Convert"
+msgstr "Пе&ретворити"
+
+#: ../src/common/stockitem.cpp:154
+msgid "Convert"
+msgstr "Перетворити"
+
+#: ../src/common/stockitem.cpp:155 ../src/msw/textctrl.cpp:2884
+#: ../src/osx/textctrl_osx.cpp:653 ../src/richtext/richtextctrl.cpp:331
+msgid "&Copy"
+msgstr "&Копія"
+
+#: ../src/common/stockitem.cpp:155 ../src/stc/stc_i18n.cpp:18
+msgid "Copy"
+msgstr "Копіювати"
+
+#: ../src/common/stockitem.cpp:156 ../src/msw/textctrl.cpp:2883
+#: ../src/osx/textctrl_osx.cpp:652 ../src/richtext/richtextctrl.cpp:330
+msgid "Cu&t"
+msgstr "В&ирізати"
+
+#: ../src/common/stockitem.cpp:156 ../src/stc/stc_i18n.cpp:17
+msgid "Cut"
+msgstr "Вирізати"
+
+#: ../src/common/stockitem.cpp:157 ../src/msw/textctrl.cpp:2886
+#: ../src/osx/textctrl_osx.cpp:655 ../src/richtext/richtextctrl.cpp:333
+#: ../src/richtext/richtexttabspage.cpp:137
+msgid "&Delete"
+msgstr "&Вилучити"
+
+#: ../src/common/stockitem.cpp:157 ../src/richtext/richtextbuffer.cpp:8266
+#: ../src/stc/stc_i18n.cpp:20
+msgid "Delete"
+msgstr "Вилучити"
+
+#: ../src/common/stockitem.cpp:158
+msgid "&Down"
+msgstr "До&низу"
+
+#: ../src/common/stockitem.cpp:158 ../src/generic/fdrepdlg.cpp:148
+msgid "Down"
+msgstr "Донизу"
+
+#: ../src/common/stockitem.cpp:159
+msgid "&Edit"
+msgstr "&Редагування"
+
+#: ../src/common/stockitem.cpp:159
+msgid "Edit"
+msgstr "Змінити"
+
+#: ../src/common/stockitem.cpp:160
+msgid "&Execute"
+msgstr "&Виконати"
+
+#: ../src/common/stockitem.cpp:160
+msgid "Execute"
+msgstr "Виконати"
+
+#: ../src/common/stockitem.cpp:161
+msgid "&Quit"
+msgstr "&Вихід"
+
+#: ../src/common/stockitem.cpp:161
+msgid "Quit"
+msgstr "Вийти"
+
+#: ../src/common/stockitem.cpp:162
+msgid "&File"
+msgstr "&Файл"
+
+#: ../src/common/stockitem.cpp:162
+msgid "File"
+msgstr "Файл"
+
+#: ../src/common/stockitem.cpp:163
+msgid "&Find..."
+msgstr "З&найти…"
+
+#: ../src/common/stockitem.cpp:163
+msgid "Find..."
+msgstr "Знайти…"
+
+#: ../src/common/stockitem.cpp:164
+msgid "&First"
+msgstr "&Перша"
+
+#: ../src/common/stockitem.cpp:164
+msgid "First"
+msgstr "Перша"
+
+#: ../src/common/stockitem.cpp:165
+msgid "&Floppy"
+msgstr "&Дискета"
+
+#: ../src/common/stockitem.cpp:165
+msgid "Floppy"
+msgstr "Дискета"
+
+#: ../src/common/stockitem.cpp:166
+msgid "&Forward"
+msgstr "&Вперед"
+
+#: ../src/common/stockitem.cpp:166
+msgid "Forward"
+msgstr "Вперед"
+
+#: ../src/common/stockitem.cpp:167
+msgid "&Harddisk"
+msgstr "&Жорсткий диск"
+
+#: ../src/common/stockitem.cpp:167
+msgid "Harddisk"
+msgstr "Жорсткий диск"
+
+#: ../src/common/stockitem.cpp:168 ../src/generic/wizard.cpp:418
+#: ../src/osx/cocoa/menu.mm:225 ../src/richtext/richtextstyledlg.cpp:298
+#: ../src/richtext/richtextsymboldlg.cpp:451
+msgid "&Help"
+msgstr "&Довідка"
+
+#: ../src/common/stockitem.cpp:169
+msgid "&Home"
+msgstr "&Домівка"
+
+#: ../src/common/stockitem.cpp:169
+msgid "Home"
+msgstr "Домівка"
+
+#: ../src/common/stockitem.cpp:170
+msgid "Indent"
+msgstr "Відступ"
+
+#: ../src/common/stockitem.cpp:171
+msgid "&Index"
+msgstr "&Індекс"
+
+#: ../src/common/stockitem.cpp:171 ../src/html/helpwnd.cpp:510
+msgid "Index"
+msgstr "Індекс"
+
+#: ../src/common/stockitem.cpp:172
+msgid "&Info"
+msgstr "&Інформація"
+
+#: ../src/common/stockitem.cpp:172
+msgid "Info"
+msgstr "Інформація"
+
+#: ../src/common/stockitem.cpp:173
+msgid "&Italic"
+msgstr "&Курсив"
+
+#: ../src/common/stockitem.cpp:173 ../src/generic/fontdlgg.cpp:322
+#: ../src/richtext/richtextfontpage.cpp:350
+msgid "Italic"
+msgstr "Курсив"
+
+#: ../src/common/stockitem.cpp:174
+msgid "&Jump to"
+msgstr "Пере&йти до"
+
+#: ../src/common/stockitem.cpp:174
+msgid "Jump to"
+msgstr "Перейти до"
+
+#: ../src/common/stockitem.cpp:175
+msgid "Centered"
+msgstr "Центроване"
+
+#: ../src/common/stockitem.cpp:176
+msgid "Justified"
+msgstr "Вирівняний"
+
+#: ../src/common/stockitem.cpp:177
+msgid "Align Left"
+msgstr "Вирівняти ліворуч"
+
+#: ../src/common/stockitem.cpp:178
+msgid "Align Right"
+msgstr "Вирівняти праворуч"
+
+#: ../src/common/stockitem.cpp:179
+msgid "&Last"
+msgstr "&Останній"
+
+#: ../src/common/stockitem.cpp:179
+msgid "Last"
+msgstr "Остання"
+
+#: ../src/common/stockitem.cpp:180
+msgid "&Network"
+msgstr "&Мережа"
+
+#: ../src/common/stockitem.cpp:180
+msgid "Network"
+msgstr "Мережа"
+
+#: ../src/common/stockitem.cpp:181 ../src/richtext/richtexttabspage.cpp:131
+msgid "&New"
+msgstr "&Створити"
+
+#: ../src/common/stockitem.cpp:181
+msgid "New"
+msgstr "Створити"
+
+#: ../src/common/stockitem.cpp:182 ../src/msw/msgdlg.cpp:417
+msgid "&No"
+msgstr "&Ні"
+
+#: ../src/common/stockitem.cpp:183 ../src/generic/fontdlgg.cpp:467
+#: ../src/generic/fontdlgg.cpp:474
+msgid "&OK"
+msgstr "&Гаразд"
+
+#: ../src/common/stockitem.cpp:184 ../src/generic/dbgrptg.cpp:341
+msgid "&Open..."
+msgstr "&Відкрити…"
+
+#: ../src/common/stockitem.cpp:184
+msgid "Open..."
+msgstr "Відкрити…"
+
+#: ../src/common/stockitem.cpp:185 ../src/msw/textctrl.cpp:2885
+#: ../src/osx/textctrl_osx.cpp:654 ../src/richtext/richtextctrl.cpp:332
+msgid "&Paste"
+msgstr "&Вставити"
+
+#: ../src/common/stockitem.cpp:185 ../src/richtext/richtextctrl.cpp:3484
+#: ../src/stc/stc_i18n.cpp:19
+msgid "Paste"
+msgstr "Вставити"
+
+#: ../src/common/stockitem.cpp:186
+msgid "&Preferences"
+msgstr "&Налаштування"
+
+#: ../src/common/stockitem.cpp:186 ../src/osx/cocoa/preferences.mm:304
+msgid "Preferences"
+msgstr "Налаштування"
+
+#: ../src/common/stockitem.cpp:187
+msgid "Print previe&w..."
+msgstr "П&ерегляд друку…"
+
+#: ../src/common/stockitem.cpp:187
+msgid "Print preview..."
+msgstr "Перегляд друку…"
+
+#: ../src/common/stockitem.cpp:188
+msgid "&Print..."
+msgstr "&Друкувати…"
+
+#: ../src/common/stockitem.cpp:188
+msgid "Print..."
+msgstr "Надрукувати…"
+
+#: ../src/common/stockitem.cpp:189 ../src/richtext/richtextctrl.cpp:337
+#: ../src/richtext/richtextctrl.cpp:5479
+msgid "&Properties"
+msgstr "&Властивості"
+
+#: ../src/common/stockitem.cpp:189
+msgid "Properties"
+msgstr "Властивості"
+
+#: ../src/common/stockitem.cpp:190 ../src/stc/stc_i18n.cpp:16
+msgid "Redo"
+msgstr "Повторити"
+
+#: ../src/common/stockitem.cpp:191
+msgid "Refresh"
+msgstr "Оновити"
+
+#: ../src/common/stockitem.cpp:192
+msgid "Remove"
+msgstr "Вилучити"
+
+#: ../src/common/stockitem.cpp:193
+msgid "Rep&lace..."
+msgstr "Замі&нити…"
+
+#: ../src/common/stockitem.cpp:193
+msgid "Replace..."
+msgstr "Замінити…"
+
+#: ../src/common/stockitem.cpp:194
+msgid "Revert to Saved"
+msgstr "Повернутися до збереженого"
+
+#: ../src/common/stockitem.cpp:196 ../src/generic/logg.cpp:549
+msgid "Save &As..."
+msgstr "Зберегти &як..."
+
+#: ../src/common/stockitem.cpp:196
+msgid "Save As..."
+msgstr "Зберегти як…"
+
+#: ../src/common/stockitem.cpp:197 ../src/msw/textctrl.cpp:2888
+#: ../src/osx/textctrl_osx.cpp:657 ../src/richtext/richtextctrl.cpp:335
+msgid "Select &All"
+msgstr "В&ибрати все"
+
+#: ../src/common/stockitem.cpp:197 ../src/stc/stc_i18n.cpp:21
+msgid "Select All"
+msgstr "Вибрати все"
+
+#: ../src/common/stockitem.cpp:198
+msgid "&Color"
+msgstr "&Колір"
+
+#: ../src/common/stockitem.cpp:198
+msgid "Color"
+msgstr "Колір"
+
+#: ../src/common/stockitem.cpp:199
+msgid "&Font"
+msgstr "&Шрифт"
+
+#: ../src/common/stockitem.cpp:199 ../src/richtext/richtextformatdlg.cpp:336
+msgid "Font"
+msgstr "Шрифт"
+
+#: ../src/common/stockitem.cpp:200
+msgid "&Ascending"
+msgstr "За з&ростанням"
+
+#: ../src/common/stockitem.cpp:200
+msgid "Ascending"
+msgstr "За зростанням"
+
+#: ../src/common/stockitem.cpp:201
+msgid "&Descending"
+msgstr "&За спаданням"
+
+#: ../src/common/stockitem.cpp:201
+msgid "Descending"
+msgstr "За спаданням"
+
+#: ../src/common/stockitem.cpp:202
+msgid "&Spell Check"
+msgstr "П&еревірити правопис"
+
+#: ../src/common/stockitem.cpp:202
+msgid "Spell Check"
+msgstr "Перевірка правопису"
+
+#: ../src/common/stockitem.cpp:203
+msgid "&Stop"
+msgstr "&Зупинити"
+
+#: ../src/common/stockitem.cpp:203
+msgid "Stop"
+msgstr "Зупинити"
+
+#: ../src/common/stockitem.cpp:204 ../src/richtext/richtextfontpage.cpp:274
+msgid "&Strikethrough"
+msgstr "П&ерекреслення"
+
+#: ../src/common/stockitem.cpp:204
+msgid "Strikethrough"
+msgstr "Перекреслення"
+
+#: ../src/common/stockitem.cpp:205
+msgid "&Top"
+msgstr "&Згори"
+
+#: ../src/common/stockitem.cpp:205 ../src/richtext/richtextsizepage.cpp:285
+#: ../src/richtext/richtextsizepage.cpp:289
+msgid "Top"
+msgstr "Вгорі"
+
+#: ../src/common/stockitem.cpp:206
+msgid "Undelete"
+msgstr "Скасувати вилучення"
+
+#: ../src/common/stockitem.cpp:207 ../src/generic/fontdlgg.cpp:437
+msgid "&Underline"
+msgstr "&Підкреслення"
+
+#: ../src/common/stockitem.cpp:207
+msgid "Underline"
+msgstr "Підкреслити"
+
+#: ../src/common/stockitem.cpp:208 ../src/stc/stc_i18n.cpp:15
+msgid "Undo"
+msgstr "Вернути"
+
+#: ../src/common/stockitem.cpp:209
+msgid "&Unindent"
+msgstr "&Без відступу"
+
+#: ../src/common/stockitem.cpp:209
+msgid "Unindent"
+msgstr "Скасувати відступ"
+
+#: ../src/common/stockitem.cpp:210
+msgid "&Up"
+msgstr "До&гори"
+
+#: ../src/common/stockitem.cpp:210 ../src/generic/fdrepdlg.cpp:148
+msgid "Up"
+msgstr "Вверх"
+
+#: ../src/common/stockitem.cpp:211 ../src/msw/msgdlg.cpp:417
+msgid "&Yes"
+msgstr "&Так"
+
+#: ../src/common/stockitem.cpp:212
+msgid "&Actual Size"
+msgstr "&Справжній розмір"
+
+#: ../src/common/stockitem.cpp:212
+msgid "Actual Size"
+msgstr "Фактичний розмір"
+
+#: ../src/common/stockitem.cpp:213
+msgid "Zoom to &Fit"
+msgstr "Масштабувати до &заповнення"
+
+#: ../src/common/stockitem.cpp:213
+msgid "Zoom to Fit"
+msgstr "Підібрати за розмірами"
+
+#: ../src/common/stockitem.cpp:214
+msgid "Zoom &In"
+msgstr "&Збільшити"
+
+#: ../src/common/stockitem.cpp:215
+msgid "Zoom &Out"
+msgstr "З&меншити"
+
+#: ../src/common/stockitem.cpp:262
+msgid "Show about dialog"
+msgstr "Показати діалог інформації про програму"
+
+#: ../src/common/stockitem.cpp:263
+msgid "Copy selection"
+msgstr "Копіювати позначене"
+
+#: ../src/common/stockitem.cpp:264
+msgid "Cut selection"
+msgstr "Вирізати позначене"
+
+#: ../src/common/stockitem.cpp:265
+msgid "Delete selection"
+msgstr "Вилучити позначене"
+
+#: ../src/common/stockitem.cpp:266
+msgid "Find in document"
+msgstr "Знайти у документі"
+
+#: ../src/common/stockitem.cpp:267
+msgid "Find and replace in document"
+msgstr "Знайти і замінити у документі"
+
+#: ../src/common/stockitem.cpp:268
+msgid "Paste selection"
+msgstr "Вставити позначене"
+
+#: ../src/common/stockitem.cpp:269
+msgid "Quit this program"
+msgstr "Вийти з цієї програми"
+
+#: ../src/common/stockitem.cpp:270
+msgid "Redo last action"
+msgstr "Повторити останню дію"
+
+#: ../src/common/stockitem.cpp:271
+msgid "Undo last action"
+msgstr "Скасувати останню дію"
+
+#: ../src/common/stockitem.cpp:272
+msgid "Create new document"
+msgstr "Створити новий документ"
+
+#: ../src/common/stockitem.cpp:273
+msgid "Open an existing document"
+msgstr "Відкрити наявний документ"
+
+#: ../src/common/stockitem.cpp:274
+msgid "Close current document"
+msgstr "Закрити поточний документ"
+
+#: ../src/common/stockitem.cpp:275
+msgid "Save current document"
+msgstr "Зберегти поточний документ"
+
+#: ../src/common/stockitem.cpp:276
+msgid "Save current document with a different filename"
+msgstr "Зберегти поточний документ з іншою назвою"
+
+#: ../src/common/strconv.cpp:2324
+#, c-format
+msgid "Conversion to charset '%s' doesn't work."
+msgstr "Перетворення до набору символів «%s» не працює."
+
+#: ../src/common/tarstrm.cpp:352 ../src/common/tarstrm.cpp:375
+#: ../src/common/tarstrm.cpp:406 ../src/generic/progdlgg.cpp:373
+msgid "unknown"
+msgstr "невідомий"
+
+#: ../src/common/tarstrm.cpp:774
+msgid "incomplete header block in tar"
+msgstr "блок заголовка у tar не повний"
+
+#: ../src/common/tarstrm.cpp:798
+msgid "checksum failure reading tar header block"
+msgstr "помилка під час перевірки контрольної суми у заголовку tar"
+
+#: ../src/common/tarstrm.cpp:971
+msgid "invalid data in extended tar header"
+msgstr "некоректні дані у розширеному заголовку tar"
+
+#: ../src/common/tarstrm.cpp:981 ../src/common/tarstrm.cpp:1003
+#: ../src/common/tarstrm.cpp:1477 ../src/common/tarstrm.cpp:1499
+msgid "tar entry not open"
+msgstr "елемент tar не відкрито"
+
+#: ../src/common/tarstrm.cpp:1023
+msgid "unexpected end of file"
+msgstr "несподіваний кінець файла"
+
+#: ../src/common/tarstrm.cpp:1297
+#, c-format
+msgid "%s did not fit the tar header for entry '%s'"
+msgstr "%s не відповідало заголовку архіву tar для елемента «%s»"
+
+#: ../src/common/tarstrm.cpp:1359
+msgid "incorrect size given for tar entry"
+msgstr "некоректно задано розмір для елемента tar"
+
+#: ../src/common/textbuf.cpp:232
+#, c-format
+msgid "'%s' is probably a binary buffer."
+msgstr "«%s» — можливо бінарний файл."
+
+#: ../src/common/textcmn.cpp:1006 ../src/richtext/richtextctrl.cpp:3053
+msgid "File couldn't be loaded."
+msgstr "Файл не можна завантажити."
+
+#: ../src/common/textfile.cpp:95
+#, c-format
+msgid "Failed to read text file \"%s\"."
+msgstr "Не вдалося прочитати текстовий файл «%s»."
+
+#: ../src/common/textfile.cpp:160
+#, c-format
+msgid "can't write buffer '%s' to disk."
+msgstr "неможливо записати буфер «%s» на диск."
+
+#: ../src/common/time.cpp:212
+msgid "Failed to get the local system time"
+msgstr "Не вдалося отримати локальний системний час"
+
+#: ../src/common/time.cpp:279
+msgid "wxGetTimeOfDay failed."
+msgstr "помилка wxGetTimeOfDay."
+
+#: ../src/common/translation.cpp:929
+#, c-format
+msgid "'%s' is not a valid message catalog."
+msgstr "«%s» — помилковий каталог повідомлень."
+
+#: ../src/common/translation.cpp:954
+msgid "Invalid message catalog."
+msgstr "Помилковий каталог повідомлень."
+
+#: ../src/common/translation.cpp:1013
+#, c-format
+msgid "Failed to parse Plural-Forms: '%s'"
+msgstr "Не вдалося обробити форми множини: «%s»"
+
+#: ../src/common/translation.cpp:1723
+#, c-format
+msgid "using catalog '%s' from '%s'."
+msgstr "використовується каталог «%s» з «%s»."
+
+#: ../src/common/translation.cpp:1816
+#, c-format
+msgid "Resource '%s' is not a valid message catalog."
+msgstr "Ресурс «%s» не є коректним каталогом повідомлень."
+
+#: ../src/common/translation.cpp:1865
+msgid "Couldn't enumerate translations"
+msgstr "Не вдалося пронумерувати переклади"
+
+#: ../src/common/utilscmn.cpp:1145
+msgid "No default application configured for HTML files."
+msgstr "Для файлів HTML не вказано типової програми."
+
+#: ../src/common/utilscmn.cpp:1190
+#, c-format
+msgid "Failed to open URL \"%s\" in default browser."
+msgstr "Не вдалося відкрити адресу «%s» у типовому переглядачі."
+
+#: ../src/common/valtext.cpp:144
+msgid "Validation conflict"
+msgstr "Конфлікт перевірки"
+
+#: ../src/common/valtext.cpp:186
+msgid "Required information entry is empty."
+msgstr "Потрібний запис даних виявився порожнім."
+
+#: ../src/common/valtext.cpp:188
+#, c-format
+msgid "'%s' is one of the invalid strings"
+msgstr "«%s» є одним з помилкових рядків"
+
+#: ../src/common/valtext.cpp:190
+#, c-format
+msgid "'%s' is not one of the valid strings"
+msgstr "«%s» немає серед коректних рядків"
+
+#: ../src/common/valtext.cpp:199
+#, c-format
+msgid "'%s' contains invalid character(s)"
+msgstr "«%s» містить некоректні символи"
+
+#: ../src/common/webrequest.cpp:139
+#, c-format
+msgid "Error: %s (%d)"
+msgstr "Помилка: %s (%d)"
+
+#: ../src/common/webrequest.cpp:655
+#, c-format
+msgid ""
+"Not enough free disk space for download: %llu needed but only %llu available."
+msgstr ""
+"Недостатньо вільного місця для отримання даних: потрібно %llu, але маємо"
+" лише %llu."
+
+#: ../src/common/webrequest.cpp:669
+#, c-format
+msgid "Failed to create temporary file in %s"
+msgstr "Не вдалося створити тимчасовий файл у %s"
+
+#: ../src/common/webrequest_curl.cpp:1106
+msgid "libcurl could not be initialized"
+msgstr "Не вдалося ініціалізувати libcurl"
+
+#: ../src/common/webview.cpp:392
+msgid "RunScriptAsync not supported"
+msgstr "Підтримки RunScriptAsync не передбачено"
+
+#: ../src/common/webview.cpp:403 ../src/msw/webview_ie.cpp:1073
+#, c-format
+msgid "Error running JavaScript: %s"
+msgstr "Помилка під час спроби запустити JavaScript: %s"
+
+#: ../src/common/webview_chromium.cpp:858
+#, c-format
+msgid "Failed to set proxy \"%s\": %s"
+msgstr "Не вдалося встановити проксі-сервер «%s»: %s"
+
+#: ../src/common/webview_chromium.cpp:989
+msgid ""
+"Chromium can't be used because libcef.so wasn't loaded early enough; please "
+"relink the application or use LD_PRELOAD to load it earlier."
+msgstr ""
+"Chromium не можна скористатися, оскільки libcef.so не було завантажено"
+" досить рано; будь ласка, повторно скомпонуйте програму з бібліотеками або"
+" скористайтеся LD_PRELOAD для завантаження бібліотеки на раніших кроках"
+" запуску."
+
+#: ../src/common/webview_chromium.cpp:1108
+msgid "Could not initialize Chromium"
+msgstr "Не вдалося ініціалізувати Chromium"
+
+#: ../src/common/webview_chromium.cpp:1616
+msgid "Show DevTools"
+msgstr "Показати інструменти розробника"
+
+#: ../src/common/webview_chromium.cpp:1617
+msgid "Close DevTools"
+msgstr "Закрити інструменти розробника"
+
+#: ../src/common/webview_chromium.cpp:1623
+msgid "Inspect"
+msgstr "Інспектор"
+
+#: ../src/common/wincmn.cpp:1628
+msgid "This platform does not support background transparency."
+msgstr "На цій платформі підтримки прозорості тла не передбачено."
+
+#: ../src/common/wincmn.cpp:2097
+msgid "Could not transfer data to window"
+msgstr "Не вдалося передати дані в вікно"
+
+#: ../src/common/windowid.cpp:240
+msgid "Out of window IDs.  Recommend shutting down application."
+msgstr ""
+"Значення поза межами ідентифікаторів вікон. Рекомендуємо вам завершити "
+"роботу програми."
+
+#: ../src/common/xpmdecod.cpp:678
+msgid "XPM: incorrect header format!"
+msgstr "XPM: некоректний формат заголовку!"
+
+#: ../src/common/xpmdecod.cpp:703
+#, c-format
+msgid "XPM: incorrect colour description in line %d"
+msgstr "XPM: некоректний опис кольору у рядку %d"
+
+#: ../src/common/xpmdecod.cpp:715 ../src/common/xpmdecod.cpp:724
+#, c-format
+msgid "XPM: malformed colour definition '%s' at line %d!"
+msgstr "XPM: погано сформоване визначення кольору «%s» у рядку %d!"
+
+#: ../src/common/xpmdecod.cpp:754
+msgid "XPM: no colors left to use for mask!"
+msgstr "XPM: не залишилося кольорів для маски!"
+
+#: ../src/common/xpmdecod.cpp:781
+#, c-format
+msgid "XPM: truncated image data at line %d!"
+msgstr "XPM: обрізані дані картинки у рядку %d!"
+
+#: ../src/common/xpmdecod.cpp:795
+msgid "XPM: Malformed pixel data!"
+msgstr "XPM: Помилкові дані пікселя!"
+
+#: ../src/common/xti.cpp:492
+msgid "Illegal Parameter Count for Create Method"
+msgstr "Неправильна кількість параметрів у методі Create"
+
+#: ../src/common/xti.cpp:504
+msgid "Illegal Parameter Count for ConstructObject Method"
+msgstr "Неправильна кількість параметрів у методі ConstructObject"
+
+#: ../src/common/xtistrm.cpp:161
+#, c-format
+msgid "Create Parameter %s not found in declared RTTI Parameters"
+msgstr "Параметр Create %s не знайдено серед описаних параметрів RTTI"
+
+#: ../src/common/xtistrm.cpp:290
+msgid "Illegal Object Class (Non-wxEvtHandler) as Event Source"
+msgstr "Некоректний клас об'єктів (Не-wxEvtHandler) як джерело подій"
+
+#: ../src/common/xtistrm.cpp:313 ../src/common/xtixml.cpp:345
+#: ../src/common/xtixml.cpp:498
+msgid "Type must have enum - long conversion"
+msgstr "Тип має містити перетворення enum — long"
+
+#: ../src/common/xtistrm.cpp:400 ../src/common/xtistrm.cpp:415
+msgid "Invalid or Null Object ID passed to GetObjectClassInfo"
+msgstr ""
+"До GetObjectClassInfo передано помилковий або нульовий ідентифікатор об'єкта"
+
+#: ../src/common/xtistrm.cpp:405
+msgid "Unknown Object passed to GetObjectClassInfo"
+msgstr "До GetObjectClassInfo передано невідомий об'єкт"
+
+#: ../src/common/xtistrm.cpp:420
+msgid "Already Registered Object passed to SetObjectClassInfo"
+msgstr "До SetObjectClassInfo передано повідомлення Об'єкт Вже Зареєстровано"
+
+#: ../src/common/xtistrm.cpp:430
+msgid "Invalid or Null Object ID passed to HasObjectClassInfo"
+msgstr ""
+"До HasObjectClassInfo передано помилковий або нульовий ідентифікатор об'єкта"
+
+#: ../src/common/xtistrm.cpp:460
+msgid "Passing a already registered object to SetObject"
+msgstr "Передача вже зареєстрованого об'єкта до SetObject"
+
+#: ../src/common/xtistrm.cpp:471
+msgid "Passing an unknown object to GetObject"
+msgstr "GetObject передано невідомий об’єкт"
+
+#: ../src/common/xtixml.cpp:229
+msgid "Forward hrefs are not supported"
+msgstr "Форвардні href не підтримуються"
+
+#: ../src/common/xtixml.cpp:247
+#, c-format
+msgid "unknown class %s"
+msgstr "невідомий клас %s"
+
+#: ../src/common/xtixml.cpp:253
+msgid "objects cannot have XML Text Nodes"
+msgstr "об'єкти не повинні мати текстових вузлів XML"
+
+#: ../src/common/xtixml.cpp:258
+msgid "Objects must have an id attribute"
+msgstr "Об'єкти повинні мати атрибут id"
+
+#: ../src/common/xtixml.cpp:267
+#, c-format
+msgid "Doubly used id : %d"
+msgstr "Двічі використаний id : %d"
+
+#: ../src/common/xtixml.cpp:316
+#, c-format
+msgid "Unknown Property %s"
+msgstr "Невідома властивість %s"
+
+#: ../src/common/xtixml.cpp:407
+msgid "A non empty collection must consist of 'element' nodes"
+msgstr "Непорожня колекція має складатися з вузлів-\"елементів\""
+
+#: ../src/common/xtixml.cpp:478
+msgid "incorrect event handler string, missing dot"
+msgstr "помилковий рядок обробника події, відсутня точка"
+
+#: ../src/common/zipstrm.cpp:559
+msgid "can't re-initialize zlib deflate stream"
+msgstr "неможливо переініціювати потік стискання zlib"
+
+#: ../src/common/zipstrm.cpp:584
+msgid "can't re-initialize zlib inflate stream"
+msgstr "неможливо переініціювати потік розпакування zlib"
+
+#: ../src/common/zipstrm.cpp:1023
+msgid "Ignoring malformed extra data record, ZIP file may be corrupted"
+msgstr ""
+"Ігноруємо помилково форматований зайвий запис даних, файл ZIP може бути "
+"пошкоджено"
+
+#: ../src/common/zipstrm.cpp:1502
+msgid "assuming this is a multi-part zip concatenated"
+msgstr "припускається, що це ланцюговий zip з багатьох частин"
+
+#: ../src/common/zipstrm.cpp:1664
+msgid "invalid zip file"
+msgstr "некоректний файл zip"
+
+#: ../src/common/zipstrm.cpp:1723
+msgid "can't find central directory in zip"
+msgstr "неможливо знайти центральну теку у zip"
+
+#: ../src/common/zipstrm.cpp:1812
+msgid "error reading zip central directory"
+msgstr "помилка під час читання центральної теки zip"
+
+#: ../src/common/zipstrm.cpp:1916
+msgid "error reading zip local header"
+msgstr "помилка читання локального заголовка zip"
+
+#: ../src/common/zipstrm.cpp:1964
+msgid "bad zipfile offset to entry"
+msgstr "некоректний відступ для входу у zip-файлі"
+
+#: ../src/common/zipstrm.cpp:2031
+msgid "stored file length not in Zip header"
+msgstr "довжина запакованого файла не у заголовку Zip"
+
+#: ../src/common/zipstrm.cpp:2045 ../src/common/zipstrm.cpp:2362
+msgid "unsupported Zip compression method"
+msgstr "непідтримуваний метод стиснення Zip"
+
+#: ../src/common/zipstrm.cpp:2126
+#, c-format
+msgid "reading zip stream (entry %s): bad length"
+msgstr "читання потоку zip (елемент %s): помилкова довжина"
+
+#: ../src/common/zipstrm.cpp:2131
+#, c-format
+msgid "reading zip stream (entry %s): bad crc"
+msgstr "читання потоку zip (елемент %s): помилкова контрольна сума"
+
+#: ../src/common/zipstrm.cpp:2578
+#, c-format
+msgid "error writing zip entry '%s': file too large without ZIP64"
+msgstr "помилка запису елемента zip «%s»: файл є надто великим без ZIP64"
+
+#: ../src/common/zipstrm.cpp:2585
+#, c-format
+msgid "error writing zip entry '%s': bad crc or length"
+msgstr ""
+"помилка запису елемента zip «%s»: помилкова контрольна сума або довжина"
+
+#: ../src/common/zstream.cpp:155 ../src/common/zstream.cpp:315
+msgid "Gzip not supported by this version of zlib"
+msgstr "Gzip не підтримується цією версією zlib"
+
+#: ../src/common/zstream.cpp:182
+msgid "Can't initialize zlib inflate stream."
+msgstr "Не вдалося ініціювати потік розпакування zlib."
+
+#: ../src/common/zstream.cpp:241
+msgid "Can't read inflate stream: unexpected EOF in underlying stream."
+msgstr ""
+"Не вдалося прочитати потік, що розширюється: неочікуваний кінець файла у "
+"підлеглому потоці."
+
+#: ../src/common/zstream.cpp:248 ../src/common/zstream.cpp:423
+#, c-format
+msgid "zlib error %d"
+msgstr "помилка zlib %d"
+
+#: ../src/common/zstream.cpp:249
+#, c-format
+msgid "Can't read from inflate stream: %s"
+msgstr "Не вдалося прочитати з потоку розпакування %s"
+
+#: ../src/common/zstream.cpp:343
+msgid "Can't initialize zlib deflate stream."
+msgstr "Не вдалося ініціювати потік стиснення zlib."
+
+#: ../src/common/zstream.cpp:424
+#, c-format
+msgid "Can't write to deflate stream: %s"
+msgstr "Не вдалося записати до потоку розпакування: %s"
+
+#: ../src/dfb/bitmap.cpp:633 ../src/dfb/bitmap.cpp:667
+#, c-format
+msgid "No bitmap handler for type %d defined."
+msgstr "Не знайдено жодного інструмент обробки растру для типу %d."
+
+#: ../src/dfb/evtloop.cpp:99
+msgid "Failed to read event from DirectFB pipe"
+msgstr "Не вдалося прочитати подію з каналу обробки DirectFB"
+
+#: ../src/dfb/evtloop.cpp:171
+msgid "Failed to switch DirectFB pipe to non-blocking mode"
+msgstr "Не вдалося перемкнути канал DirectFB у режим без блокування"
+
+#: ../src/dfb/fontmgr.cpp:171
+#, c-format
+msgid "no fonts found in %s, using builtin font"
+msgstr "У %s записів шрифтів не знайдено, використовуємо вбудований шрифт"
+
+#: ../src/dfb/fontmgr.cpp:177
+msgid "Default font"
+msgstr "Типовий шрифт"
+
+#: ../src/dfb/fontmgr.cpp:195
+#, c-format
+msgid "Fonts index file %s disappeared while loading fonts."
+msgstr "Файл покажчика шрифтів %s було вилучено під час завантаження шрифтів."
+
+#: ../src/dfb/wrapdfb.cpp:60
+#, c-format
+msgid "DirectFB error %d occurred."
+msgstr "У DirectFB сталася помилка %d."
+
+#: ../src/generic/aboutdlgg.cpp:69
+msgid "Developed by "
+msgstr "Розроблено "
+
+#: ../src/generic/aboutdlgg.cpp:72
+msgid "Documentation by "
+msgstr "Документація від "
+
+#: ../src/generic/aboutdlgg.cpp:75
+msgid "Graphics art by "
+msgstr "Графічні елементи від "
+
+#: ../src/generic/aboutdlgg.cpp:78
+msgid "Translations by "
+msgstr "Переклад "
+
+#: ../src/generic/aboutdlgg.cpp:133 ../src/osx/cocoa/aboutdlg.mm:83
+msgid "Version "
+msgstr "Версія "
+
+#. TRANSLATORS: %s is application name
+#: ../src/generic/aboutdlgg.cpp:146 ../src/msw/aboutdlg.cpp:60
+#, c-format
+msgid "About %s"
+msgstr "Про %s"
+
+#: ../src/generic/aboutdlgg.cpp:181
+msgid "License"
+msgstr "Ліцензія"
+
+#: ../src/generic/aboutdlgg.cpp:184
+msgid "Developers"
+msgstr "Розробники"
+
+#: ../src/generic/aboutdlgg.cpp:188
+msgid "Documentation writers"
+msgstr "Автори документації"
+
+#: ../src/generic/aboutdlgg.cpp:192
+msgid "Artists"
+msgstr "Художники"
+
+#: ../src/generic/aboutdlgg.cpp:196
+msgid "Translators"
+msgstr "Перекладачі"
+
+#: ../src/generic/animateg.cpp:125
+msgid "No handler found for animation type."
+msgstr "Не знайдено обробника для цього типу анімації."
+
+#: ../src/generic/animateg.cpp:133
+#, c-format
+msgid "No animation handler for type %ld defined."
+msgstr "Не визначено рушія анімації для типу %ld."
+
+#: ../src/generic/animateg.cpp:145
+#, c-format
+msgid "Animation file is not of type %ld."
+msgstr "Анімаційний файл не належить до типу %ld."
+
+#: ../src/generic/colrdlgg.cpp:154 ../src/gtk/colordlg.cpp:47
+msgid "Choose colour"
+msgstr "Оберіть колір"
+
+#: ../src/generic/colrdlgg.cpp:357
+msgid "Red:"
+msgstr "Червоний:"
+
+#: ../src/generic/colrdlgg.cpp:360
+msgid "Green:"
+msgstr "Зелений:"
+
+#: ../src/generic/colrdlgg.cpp:363
+msgid "Blue:"
+msgstr "Синій:"
+
+#: ../src/generic/colrdlgg.cpp:372
+msgid "Opacity:"
+msgstr "Непрозорість:"
+
+#: ../src/generic/colrdlgg.cpp:384
+msgid "Add to custom colours"
+msgstr "Додати до створених кольорів "
+
+#: ../src/generic/creddlgg.cpp:56
+msgid "Username:"
+msgstr "Користувач:"
+
+#: ../src/generic/creddlgg.cpp:63
+msgid "Password:"
+msgstr "Пароль:"
+
+#. TRANSLATORS: Name of Boolean true value
+#: ../src/generic/datavgen.cpp:1178
+msgid "true"
+msgstr "істина"
+
+#. TRANSLATORS: Name of Boolean false value
+#: ../src/generic/datavgen.cpp:1180
+msgid "false"
+msgstr "хибність"
+
+#: ../src/generic/datavgen.cpp:6897
+#, c-format
+msgid "Row %i"
+msgstr "Рядок %i"
+
+#. TRANSLATORS: Action for manipulating a tree control
+#: ../src/generic/datavgen.cpp:6987
+msgid "Collapse"
+msgstr "Згорнути"
+
+#. TRANSLATORS: Action for manipulating a tree control
+#: ../src/generic/datavgen.cpp:6990
+msgid "Expand"
+msgstr "Розгорнути"
+
+#. TRANSLATORS: Name of data view control and number of rows
+#: ../src/generic/datavgen.cpp:7011
+#, c-format
+msgid "%s (%d items)"
+msgstr "%s (%d елемент)"
+
+#: ../src/generic/datavgen.cpp:7062
+#, c-format
+msgid "Column %u"
+msgstr "Стовпчик %u"
+
+#. TRANSLATORS: Keystroke for manipulating a tree control
+#: ../src/generic/datavgen.cpp:7131 ../src/richtext/richtextbulletspage.cpp:189
+#: ../src/richtext/richtextbulletspage.cpp:192
+#: ../src/richtext/richtextbulletspage.cpp:193
+#: ../src/richtext/richtextliststylepage.cpp:252
+#: ../src/richtext/richtextliststylepage.cpp:255
+#: ../src/richtext/richtextliststylepage.cpp:256
+#: ../src/richtext/richtextsizepage.cpp:248
+msgid "Left"
+msgstr "Ліворуч"
+
+#. TRANSLATORS: Keystroke for manipulating a tree control
+#: ../src/generic/datavgen.cpp:7134 ../src/richtext/richtextbulletspage.cpp:191
+#: ../src/richtext/richtextliststylepage.cpp:254
+#: ../src/richtext/richtextsizepage.cpp:249
+msgid "Right"
+msgstr "Праворуч"
+
+#: ../src/generic/datectlg.cpp:90
+#, c-format
+msgid ""
+"\"%s\" is not in the expected date format, please enter it as e.g. \"%s\"."
+msgstr ""
+"«%s» не є очікуваним форматом дати, будь ласка, введіть її як, наприклад» «"
+"%s»."
+
+#: ../src/generic/datectlg.cpp:94
+msgid "Invalid date"
+msgstr "Некоректна дата"
+
+#: ../src/generic/dbgrptg.cpp:159
+#, c-format
+msgid "Open file \"%s\""
+msgstr "Відкрити файл «%s»"
+
+#: ../src/generic/dbgrptg.cpp:170
+#, c-format
+msgid "Enter command to open file \"%s\":"
+msgstr "Введіть команду для відкриття файла «%s»:"
+
+#: ../src/generic/dbgrptg.cpp:230
+msgid "Executable files (*.exe)|*.exe|"
+msgstr "Виконувані файли (*.exe)|*.exe|"
+
+#: ../src/generic/dbgrptg.cpp:300
+#, c-format
+msgid "Debug report \"%s\""
+msgstr "Доповідь про помилку «%s»"
+
+#: ../src/generic/dbgrptg.cpp:316
+msgid "A debug report has been generated in the directory\n"
+msgstr "Звіт про помилку сформовано у теці\n"
+
+#: ../src/generic/dbgrptg.cpp:317
+msgid "The following debug report will be generated\n"
+msgstr "Буде створено вказаний нижче діагностичний звіт\n"
+
+#: ../src/generic/dbgrptg.cpp:321
+msgid ""
+"The report contains the files listed below. If any of these files contain "
+"private information,\n"
+"please uncheck them and they will be removed from the report.\n"
+msgstr ""
+"Звіт містить файли зазначені нижче. Якщо хоч якийсь з цих файлів містить "
+"особисту інформацію,\n"
+"будь ласка, зніміть з них позначення, їх буде вилучено зі звіту.\n"
+
+#: ../src/generic/dbgrptg.cpp:323
+msgid ""
+"If you wish to suppress this debug report completely, please choose the "
+"\"Cancel\" button,\n"
+"but be warned that it may hinder improving the program, so if\n"
+"at all possible please do continue with the report generation.\n"
+msgstr ""
+"Якщо ви бажаєте повністю придушити надсилання звітів про помилку, будь "
+"ласка, натисніть кнопку «Скасувати»,\n"
+"але майте на увазі, що це може зашкодити покращенню програми, отож,\n"
+"за будь-якої нагоди продовжіть роботу над звітом.\n"
+
+#: ../src/generic/dbgrptg.cpp:325
+msgid "              Thank you and we're sorry for the inconvenience!\n"
+msgstr "              Дякуємо вам і вибачте за незручності!\n"
+
+#: ../src/generic/dbgrptg.cpp:333
+msgid "&Debug report preview:"
+msgstr "Попередній перегляд звіту про &помилку:"
+
+#: ../src/generic/dbgrptg.cpp:339
+msgid "&View..."
+msgstr "П&ереглянути…"
+
+#: ../src/generic/dbgrptg.cpp:359
+msgid "&Notes:"
+msgstr "&Помітки:"
+
+#: ../src/generic/dbgrptg.cpp:361
+msgid ""
+"If you have any additional information pertaining to this bug\n"
+"report, please enter it here and it will be joined to it:"
+msgstr ""
+"Якщо ви маєте додаткову інформацію, що стосується помилки,\n"
+"будь ласка, введіть її тут, її буде додано до звіту:"
+
+#: ../src/generic/dcpsg.cpp:1627
+msgid "Cannot open file for PostScript printing!"
+msgstr "Не вдалося відкрити файл для друку в PostScript!"
+
+#: ../src/generic/dirctrlg.cpp:402
+msgid "Computer"
+msgstr "Комп'ютер"
+
+#: ../src/generic/dirctrlg.cpp:404
+msgid "Sections"
+msgstr "Розділи"
+
+#: ../src/generic/dirctrlg.cpp:482
+msgid "Home directory"
+msgstr "Домашня тека"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/generic/dirctrlg.cpp:484 ../src/propgrid/advprops.cpp:811
+msgid "Desktop"
+msgstr "Робочий стіл"
+
+#: ../src/generic/dirctrlg.cpp:528 ../src/generic/filectrlg.cpp:752
+msgid "Illegal directory name."
+msgstr "Неправильне назва теки."
+
+#: ../src/generic/dirctrlg.cpp:528 ../src/generic/dirctrlg.cpp:546
+#: ../src/generic/dirctrlg.cpp:557 ../src/generic/dirdlgg.cpp:317
+#: ../src/generic/filectrlg.cpp:638 ../src/generic/filectrlg.cpp:752
+#: ../src/generic/filectrlg.cpp:766 ../src/generic/filectrlg.cpp:782
+#: ../src/generic/filectrlg.cpp:1356 ../src/generic/filectrlg.cpp:1387
+#: ../src/generic/filedlgg.cpp:362 ../src/gtk/filedlg.cpp:76
+msgid "Error"
+msgstr "Помилка"
+
+#: ../src/generic/dirctrlg.cpp:546 ../src/generic/filectrlg.cpp:766
+msgid "File name exists already."
+msgstr "Файл з такою назвою вже існує."
+
+#: ../src/generic/dirctrlg.cpp:557 ../src/generic/dirdlgg.cpp:317
+#: ../src/generic/filectrlg.cpp:638 ../src/generic/filectrlg.cpp:782
+msgid "Operation not permitted."
+msgstr "Заборонена дія."
+
+#: ../src/generic/dirdlgg.cpp:107 ../src/generic/filedlgg.cpp:207
+msgid "Create new directory"
+msgstr "Створити новий каталог"
+
+#: ../src/generic/dirdlgg.cpp:112 ../src/generic/filedlgg.cpp:203
+msgid "Go to home directory"
+msgstr "В домашню теку"
+
+#: ../src/generic/dirdlgg.cpp:143
+msgid "Show &hidden directories"
+msgstr "Показати при&ховані теки"
+
+#: ../src/generic/dirdlgg.cpp:196
+#, c-format
+msgid ""
+"The directory '%s' does not exist\n"
+"Create it now?"
+msgstr ""
+"Каталог «%s» не присутній\n"
+"Створити його зараз?"
+
+#: ../src/generic/dirdlgg.cpp:198
+msgid "Directory does not exist"
+msgstr "Каталог не існує"
+
+#: ../src/generic/dirdlgg.cpp:214
+#, c-format
+msgid ""
+"Failed to create directory '%s'\n"
+"(Do you have the required permissions?)"
+msgstr ""
+"Збій створення каталогу «%s»\n"
+"(Чи маєте ви потрібні права доступу?)"
+
+#: ../src/generic/dirdlgg.cpp:216
+msgid "Error creating directory"
+msgstr "Помилка створення каталогу"
+
+#: ../src/generic/dirdlgg.cpp:281
+msgid "You cannot add a new directory to this section."
+msgstr "Ви не можете додати нову теку в цю секцію."
+
+#: ../src/generic/dirdlgg.cpp:282
+msgid "Create directory"
+msgstr "Створити каталог"
+
+#: ../src/generic/dirdlgg.cpp:291 ../src/generic/dirdlgg.cpp:301
+#: ../src/generic/filectrlg.cpp:614 ../src/generic/filectrlg.cpp:623
+msgid "NewName"
+msgstr "НоваНазва"
+
+#: ../src/generic/editlbox.cpp:135
+msgid "Edit item"
+msgstr "Редагувати елемент"
+
+#: ../src/generic/editlbox.cpp:143
+msgid "New item"
+msgstr "Новий елемент"
+
+#: ../src/generic/editlbox.cpp:151
+msgid "Delete item"
+msgstr "Вилучити елемент"
+
+#: ../src/generic/editlbox.cpp:159
+msgid "Move up"
+msgstr "Пересунути вгору"
+
+#: ../src/generic/editlbox.cpp:164
+msgid "Move down"
+msgstr "Пересунути нижче"
+
+#: ../src/generic/fdrepdlg.cpp:108
+msgid "Search for:"
+msgstr "Шукати:"
+
+#: ../src/generic/fdrepdlg.cpp:120
+msgid "Replace with:"
+msgstr "Замінити на:"
+
+#: ../src/generic/fdrepdlg.cpp:140
+msgid "Whole word"
+msgstr "Тільки цілі слова"
+
+#: ../src/generic/fdrepdlg.cpp:143
+msgid "Match case"
+msgstr "Великі/малі літери"
+
+#: ../src/generic/fdrepdlg.cpp:156
+msgid "Search direction"
+msgstr "Напрямок пошуку"
+
+#: ../src/generic/fdrepdlg.cpp:175
+msgid "&Replace"
+msgstr "&Замінити"
+
+#: ../src/generic/fdrepdlg.cpp:178
+msgid "Replace &all"
+msgstr "Замінити всі"
+
+#: ../src/generic/filectrlg.cpp:246 ../src/generic/filectrlg.cpp:269
+msgid "<DIR>"
+msgstr "<ТЕКА>"
+
+#: ../src/generic/filectrlg.cpp:248 ../src/generic/filectrlg.cpp:271
+msgid "<LINK>"
+msgstr "<ПОСИЛАННЯ>"
+
+#: ../src/generic/filectrlg.cpp:250 ../src/generic/filectrlg.cpp:273
+msgid "<DRIVE>"
+msgstr "<ДИСК>"
+
+#: ../src/generic/filectrlg.cpp:275
+#, c-format
+msgid "%ld byte"
+msgid_plural "%ld bytes"
+msgstr[0] "%ld байт"
+msgstr[1] "%ld байт"
+msgstr[2] "%ld байт"
+msgstr[3] "%ld байт"
+
+#: ../src/generic/filectrlg.cpp:420
+msgid "Name"
+msgstr "Назва"
+
+#: ../src/generic/filectrlg.cpp:421 ../src/richtext/richtextformatdlg.cpp:361
+#: ../src/richtext/richtextsizepage.cpp:298
+msgid "Size"
+msgstr "Розмір"
+
+#: ../src/generic/filectrlg.cpp:422
+msgid "Type"
+msgstr "Тип"
+
+#: ../src/generic/filectrlg.cpp:423
+msgid "Modified"
+msgstr "Змінено"
+
+#: ../src/generic/filectrlg.cpp:426
+msgid "Permissions"
+msgstr "Дозволи"
+
+#: ../src/generic/filectrlg.cpp:429
+msgid "Attributes"
+msgstr "Атрибути"
+
+#: ../src/generic/filectrlg.cpp:936
+msgid "Current directory:"
+msgstr "Поточний каталог:"
+
+#: ../src/generic/filectrlg.cpp:979
+msgid "Show &hidden files"
+msgstr "Показати при&ховані файли"
+
+#: ../src/generic/filectrlg.cpp:1355
+msgid "Illegal file specification."
+msgstr "Неправильна специфікація файла."
+
+#: ../src/generic/filectrlg.cpp:1387
+msgid "Directory doesn't exist."
+msgstr "Тека не існує."
+
+#: ../src/generic/filedlgg.cpp:195
+msgid "View files as a list view"
+msgstr "Перегляд файлів в вигляді списку"
+
+#: ../src/generic/filedlgg.cpp:197
+msgid "View files as a detailed view"
+msgstr "Перегляд файлів з подробицями"
+
+#: ../src/generic/filedlgg.cpp:200
+msgid "Go to parent directory"
+msgstr "В батьківську теку"
+
+#: ../src/generic/filedlgg.cpp:351 ../src/gtk/filedlg.cpp:59
+#, c-format
+msgid "File '%s' already exists, do you really want to overwrite it?"
+msgstr "Файл «%s» вже присутній, ви справді хочете його переписати?"
+
+#: ../src/generic/filedlgg.cpp:354 ../src/gtk/filedlg.cpp:62
+msgid "Confirm"
+msgstr "Підтвердити"
+
+#: ../src/generic/filedlgg.cpp:362 ../src/gtk/filedlg.cpp:75
+msgid "Please choose an existing file."
+msgstr "Будь ласка, виберіть наявний файл."
+
+#: ../src/generic/filepickerg.cpp:64
+msgid "..."
+msgstr "…"
+
+#: ../src/generic/fontdlgg.cpp:76 ../src/richtext/richtextformatdlg.cpp:519
+msgid "ABCDEFGabcdefg12345"
+msgstr "ABCDEFGabcdefg12345"
+
+#: ../src/generic/fontdlgg.cpp:315
+msgid "Roman"
+msgstr "Roman"
+
+#: ../src/generic/fontdlgg.cpp:316
+msgid "Decorative"
+msgstr "Декоративний"
+
+#: ../src/generic/fontdlgg.cpp:317
+msgid "Modern"
+msgstr "Модерний"
+
+#: ../src/generic/fontdlgg.cpp:318
+msgid "Script"
+msgstr "Рукописний"
+
+#: ../src/generic/fontdlgg.cpp:319
+msgid "Swiss"
+msgstr "Swiss"
+
+#: ../src/generic/fontdlgg.cpp:320
+msgid "Teletype"
+msgstr "Телетайп"
+
+#: ../src/generic/fontdlgg.cpp:321 ../src/generic/fontdlgg.cpp:324
+msgid "Normal"
+msgstr "Звичайний"
+
+#: ../src/generic/fontdlgg.cpp:323
+msgid "Slant"
+msgstr "Нахилений"
+
+#: ../src/generic/fontdlgg.cpp:325
+msgid "Light"
+msgstr "Світлий"
+
+#: ../src/generic/fontdlgg.cpp:363
+msgid "&Font family:"
+msgstr "&Гарнітура шрифту:"
+
+#: ../src/generic/fontdlgg.cpp:367 ../src/generic/fontdlgg.cpp:369
+msgid "The font family."
+msgstr "Гарнітура шрифту."
+
+#: ../src/generic/fontdlgg.cpp:374 ../src/richtext/richtextstylepage.cpp:105
+msgid "&Style:"
+msgstr "&Стиль:"
+
+#: ../src/generic/fontdlgg.cpp:378 ../src/generic/fontdlgg.cpp:380
+msgid "The font style."
+msgstr "Стиль шрифту."
+
+#: ../src/generic/fontdlgg.cpp:385
+msgid "&Weight:"
+msgstr "&Вага:"
+
+#: ../src/generic/fontdlgg.cpp:389 ../src/generic/fontdlgg.cpp:391
+msgid "The font weight."
+msgstr "Вага шрифту."
+
+#: ../src/generic/fontdlgg.cpp:399
+msgid "C&olour:"
+msgstr "К&олір:"
+
+#: ../src/generic/fontdlgg.cpp:407 ../src/generic/fontdlgg.cpp:409
+msgid "The font colour."
+msgstr "Колір шрифту."
+
+#: ../src/generic/fontdlgg.cpp:415
+msgid "&Point size:"
+msgstr "Розмір &точки:"
+
+#: ../src/generic/fontdlgg.cpp:420 ../src/generic/fontdlgg.cpp:422
+#: ../src/generic/fontdlgg.cpp:426 ../src/generic/fontdlgg.cpp:428
+msgid "The font point size."
+msgstr "Розмір шрифту:"
+
+#: ../src/generic/fontdlgg.cpp:439 ../src/generic/fontdlgg.cpp:441
+msgid "Whether the font is underlined."
+msgstr "Чи буде шрифт з підкресленням."
+
+#: ../src/generic/fontdlgg.cpp:448 ../src/html/helpwnd.cpp:1215
+msgid "Preview:"
+msgstr "Передогляд:"
+
+#: ../src/generic/fontdlgg.cpp:452 ../src/generic/fontdlgg.cpp:454
+msgid "Shows the font preview."
+msgstr "Попередній перегляд шрифту."
+
+#: ../src/generic/fontdlgg.cpp:464 ../src/generic/fontdlgg.cpp:483
+msgid "Click to cancel the font selection."
+msgstr "Клацніть, щоб скасувати вибір шрифту."
+
+#: ../src/generic/fontdlgg.cpp:469 ../src/generic/fontdlgg.cpp:471
+#: ../src/generic/fontdlgg.cpp:476 ../src/generic/fontdlgg.cpp:478
+msgid "Click to confirm the font selection."
+msgstr "Клацніть, щоб підтвердити вибір шрифту."
+
+#: ../src/generic/fontpickerg.cpp:50 ../src/gtk/fontdlg.cpp:77
+msgid "Choose font"
+msgstr "Виберіть шрифт"
+
+#: ../src/generic/grid.cpp:6542
+msgid ""
+"Error copying grid to the clipboard. Either selected cells were not "
+"contiguous or no cell was selected."
+msgstr ""
+"Помилка копіювання таблиці до буфера обміну даними. Або позначені комірки не"
+" є неперервним блоком, або не позначено жодної комірки."
+
+#: ../src/generic/grid.cpp:12739
+msgid "Grid Corner"
+msgstr "Кут таблиці"
+
+#: ../src/generic/grid.cpp:12741
+#, c-format
+msgid "Column %s Header"
+msgstr "Заголовок стовпчика %s"
+
+#: ../src/generic/grid.cpp:12743
+#, c-format
+msgid "Row %s Header"
+msgstr "Заголовок рядка %s"
+
+#: ../src/generic/grid.cpp:12745
+#, c-format
+msgid "Column %s: %s"
+msgstr "Стовпчик %s: %s"
+
+#: ../src/generic/grid.cpp:12749
+#, c-format
+msgid "Row %s: %s"
+msgstr "Рядок %s: %s"
+
+#: ../src/generic/grid.cpp:12753
+#, c-format
+msgid "Row %s, Column %s: %s"
+msgstr "Рядок %s, стовпчик %s: %s"
+
+#: ../src/generic/helpext.cpp:257
+#, c-format
+msgid "Help directory \"%s\" not found."
+msgstr "Теку довідки «%s» не знайдено."
+
+#: ../src/generic/helpext.cpp:265
+#, c-format
+msgid "Help file \"%s\" not found."
+msgstr "Файл довідки «%s» не знайдено."
+
+#: ../src/generic/helpext.cpp:284
+#, c-format
+msgid "Line %lu of map file \"%s\" has invalid syntax, skipped."
+msgstr "Рядок %lu файла карти «%s» має помилковий синтаксис, пропущено."
+
+#: ../src/generic/helpext.cpp:292
+#, c-format
+msgid "No valid mappings found in the file \"%s\"."
+msgstr "Не знайдено дійсних відповідників у файлі «%s»."
+
+#: ../src/generic/helpext.cpp:435
+msgid "No entries found."
+msgstr "Запис не знайдений."
+
+#: ../src/generic/helpext.cpp:444 ../src/generic/helpext.cpp:445
+msgid "Help Index"
+msgstr "Індекс довідки"
+
+#: ../src/generic/helpext.cpp:448
+msgid "Relevant entries:"
+msgstr "Відповідні записи:"
+
+#: ../src/generic/helpext.cpp:449
+msgid "Entries found"
+msgstr "Знайдені записи"
+
+#: ../src/generic/hyperlinkg.cpp:170
+msgid "&Copy URL"
+msgstr "&Копіювати адресу"
+
+#: ../src/generic/infobar.cpp:119
+msgid "Hide this notification message."
+msgstr "Сховати це сповіщення."
+
+#. TRANSLATORS: %s will be either the application name or "Application"
+#: ../src/generic/logg.cpp:257
+#, c-format
+msgid "%s Error"
+msgstr "Помилка %s"
+
+#. TRANSLATORS: %s will be either the application name or "Application"
+#: ../src/generic/logg.cpp:263
+#, c-format
+msgid "%s Warning"
+msgstr "Попередження %s"
+
+#. TRANSLATORS: %s will be either the application name or "Application"
+#: ../src/generic/logg.cpp:273
+#, c-format
+msgid "%s Information"
+msgstr "Інформація %s"
+
+#: ../src/generic/logg.cpp:276
+msgid "Application"
+msgstr "Програма"
+
+#: ../src/generic/logg.cpp:549
+msgid "Save log contents to file"
+msgstr "Зберегти вміст журналу до файла"
+
+#: ../src/generic/logg.cpp:551
+msgid "C&lear"
+msgstr "О&чистити"
+
+#: ../src/generic/logg.cpp:551
+msgid "Clear the log contents"
+msgstr "Почистити записи в журналі"
+
+#: ../src/generic/logg.cpp:553
+msgid "Close this window"
+msgstr "Закрити це вікно"
+
+#: ../src/generic/logg.cpp:554
+msgid "&Log"
+msgstr "&Журнал"
+
+#: ../src/generic/logg.cpp:610 ../src/generic/logg.cpp:992
+msgid "Can't save log contents to file."
+msgstr "Не можу записати вміст журналу в файл."
+
+#: ../src/generic/logg.cpp:613
+#, c-format
+msgid "Log saved to the file '%s'."
+msgstr "Журнал записаний в файл «%s»."
+
+#: ../src/generic/logg.cpp:719
+msgid "&Details"
+msgstr "&Деталі"
+
+#: ../src/generic/logg.cpp:972
+msgid "Failed to copy dialog contents to the clipboard."
+msgstr "Не вдалося скопіювати вміст діалогового вікна до буфера."
+
+#: ../src/generic/logg.cpp:1022
+#, c-format
+msgid "Append log to file '%s' (choosing [No] will overwrite it)?"
+msgstr "Додати до файла журналу «%s» (вибір [Ні] перепише його)?"
+
+#: ../src/generic/logg.cpp:1024
+msgid "Question"
+msgstr "Питання"
+
+#: ../src/generic/logg.cpp:1038
+msgid "invalid message box return value"
+msgstr "з вікна повідомлення повернуто помилкове значення"
+
+#: ../src/generic/notifmsgg.cpp:129
+msgid "Notice"
+msgstr "Зауваження"
+
+#: ../src/generic/preferencesg.cpp:118
+#, c-format
+msgid "%s Preferences"
+msgstr "Налаштування %s"
+
+#: ../src/generic/printps.cpp:143
+msgid "Printing..."
+msgstr "Друк…"
+
+#: ../src/generic/printps.cpp:160 ../src/gtk/print.cpp:1076
+#: ../src/msw/printwin.cpp:235
+msgid "Could not start printing."
+msgstr "Не вдалося почати друк."
+
+#: ../src/generic/printps.cpp:183
+#, c-format
+msgid "Printing page %d..."
+msgstr "Друк сторінки %d…"
+
+#: ../src/generic/prntdlgg.cpp:171
+msgid "Printer options"
+msgstr "Параметри принтера"
+
+#: ../src/generic/prntdlgg.cpp:176
+msgid "Print to File"
+msgstr "Друк в файл"
+
+#: ../src/generic/prntdlgg.cpp:179
+msgid "Setup..."
+msgstr "Налаштування…"
+
+#: ../src/generic/prntdlgg.cpp:187
+msgid "Printer:"
+msgstr "Друкарка:"
+
+#: ../src/generic/prntdlgg.cpp:195
+msgid "Status:"
+msgstr "Статус:"
+
+#: ../src/generic/prntdlgg.cpp:206
+msgid "All"
+msgstr "Всі"
+
+#: ../src/generic/prntdlgg.cpp:207
+msgid "Pages"
+msgstr "Сторінки"
+
+#: ../src/generic/prntdlgg.cpp:215
+msgid "Print Range"
+msgstr "Друк інтервалу"
+
+#: ../src/generic/prntdlgg.cpp:229
+msgid "From:"
+msgstr "Від:"
+
+#: ../src/generic/prntdlgg.cpp:233
+msgid "To:"
+msgstr "До:"
+
+#: ../src/generic/prntdlgg.cpp:238
+msgid "Copies:"
+msgstr "Копії:"
+
+#: ../src/generic/prntdlgg.cpp:288
+msgid "PostScript file"
+msgstr "Файл PostScript"
+
+#: ../src/generic/prntdlgg.cpp:439
+msgid "Print Setup"
+msgstr "Налаштування друку"
+
+#: ../src/generic/prntdlgg.cpp:483
+msgid "Printer"
+msgstr "Друкарка"
+
+#: ../src/generic/prntdlgg.cpp:501
+msgid "Default printer"
+msgstr "Типова друкарка"
+
+#: ../src/generic/prntdlgg.cpp:595 ../src/generic/prntdlgg.cpp:782
+#: ../src/generic/prntdlgg.cpp:822 ../src/generic/prntdlgg.cpp:835
+#: ../src/generic/prntdlgg.cpp:1031 ../src/generic/prntdlgg.cpp:1036
+msgid "Paper size"
+msgstr "Розмір паперу"
+
+#: ../src/generic/prntdlgg.cpp:604 ../src/generic/prntdlgg.cpp:847
+msgid "Portrait"
+msgstr "Книжкова"
+
+#: ../src/generic/prntdlgg.cpp:605 ../src/generic/prntdlgg.cpp:848
+msgid "Landscape"
+msgstr "Альбомна"
+
+#: ../src/generic/prntdlgg.cpp:607 ../src/generic/prntdlgg.cpp:849
+msgid "Orientation"
+msgstr "Орієнтація"
+
+#: ../src/generic/prntdlgg.cpp:610
+msgid "Options"
+msgstr "Параметри"
+
+#: ../src/generic/prntdlgg.cpp:612
+msgid "Print in colour"
+msgstr "Друк в кольорі"
+
+#: ../src/generic/prntdlgg.cpp:621
+msgid "Print spooling"
+msgstr "Спулінг друку"
+
+#: ../src/generic/prntdlgg.cpp:623
+msgid "Printer command:"
+msgstr "Команда принтеру:"
+
+#: ../src/generic/prntdlgg.cpp:631
+msgid "Printer options:"
+msgstr "Параметри принтера:"
+
+#: ../src/generic/prntdlgg.cpp:860
+msgid "Left margin (mm):"
+msgstr "Ліве поле (мм):"
+
+#: ../src/generic/prntdlgg.cpp:861
+msgid "Top margin (mm):"
+msgstr "Верхня межа (мм):"
+
+#: ../src/generic/prntdlgg.cpp:872
+msgid "Right margin (mm):"
+msgstr "Права межа (мм):"
+
+#: ../src/generic/prntdlgg.cpp:873
+msgid "Bottom margin (mm):"
+msgstr "Нижнє поле (мм):"
+
+#: ../src/generic/prntdlgg.cpp:896
+msgid "Printer..."
+msgstr "Принтер…"
+
+#: ../src/generic/progdlgg.cpp:246
+msgid "&Skip"
+msgstr "Проп&устити"
+
+#: ../src/generic/progdlgg.cpp:347 ../src/generic/progdlgg.cpp:626
+msgid "Unknown"
+msgstr "Невідомий"
+
+#: ../src/generic/progdlgg.cpp:451 ../src/msw/progdlg.cpp:526
+msgid "Done."
+msgstr "Зроблено."
+
+#: ../src/generic/srchctlg.cpp:55 ../src/gtk/srchctrl.cpp:206
+#: ../src/html/helpwnd.cpp:530 ../src/html/helpwnd.cpp:545
+msgid "Search"
+msgstr "Пошук"
+
+#: ../src/generic/tabg.cpp:1026
+msgid "Could not find tab for id"
+msgstr "Не вдалося знайти вкладку для ідентифікатора"
+
+#: ../src/generic/tipdlg.cpp:136
+msgid "Tips not available, sorry!"
+msgstr "Вибачте, підказки недоступні!"
+
+#: ../src/generic/tipdlg.cpp:197
+msgid "Tip of the Day"
+msgstr "Підказка дня"
+
+#: ../src/generic/tipdlg.cpp:207
+msgid "Did you know..."
+msgstr "А ви знали що…"
+
+#: ../src/generic/tipdlg.cpp:232
+msgid "&Show tips at startup"
+msgstr "&Показувати підказки під час запуску"
+
+#: ../src/generic/tipdlg.cpp:236
+msgid "&Next Tip"
+msgstr "&Наступна підказка"
+
+#: ../src/generic/wizard.cpp:411
+msgid "&Next >"
+msgstr "&Наступний >"
+
+#: ../src/generic/wizard.cpp:412
+msgid "&Finish"
+msgstr "&Закінчити"
+
+#: ../src/generic/wizard.cpp:420
+msgid "< &Back"
+msgstr "< &Назад"
+
+#: ../src/gtk/aboutdlg.cpp:204
+msgid "translator-credits"
+msgstr "подяки перекладачам"
+
+#: ../src/gtk/app.cpp:517
+msgid ""
+"WARNING: using XIM input method is unsupported and may result in problems "
+"with input handling and flickering. Consider unsetting GTK_IM_MODULE or "
+"setting to \"ibus\"."
+msgstr ""
+"УВАГА! Підтримки використання способу введення XIM не передбачено. "
+"Використання цього способу введення може призвести до проблем із обробкою "
+"вхідних даних і блимання. Спробуйте скасувати встановлення GTK_IM_MODULE або "
+"встановіть спосіб введення «ibus»."
+
+#: ../src/gtk/app.cpp:569
+msgid "Unable to initialize GTK+, is DISPLAY set properly?"
+msgstr ""
+"Не вдалося ініціалізувати GTK+, чи правильно встановлено змінну DISPLAY?"
+
+#: ../src/gtk/filedlg.cpp:89 ../src/gtk/filepicker.cpp:255
+#, c-format
+msgid "Changing current directory to \"%s\" failed"
+msgstr "Не вдалося змінити поточний каталог на «%s»"
+
+#: ../src/gtk/font.cpp:548
+msgid ""
+"Using private fonts is not supported on this system: Pango library is too "
+"old, 1.38 or later required."
+msgstr ""
+"У цій системі не можна користуватися приватними шрифтами: бібліотека Pango є "
+"надто старою, потрібна версія 1.38 або новіша."
+
+#: ../src/gtk/font.cpp:558
+msgid "Failed to create font configuration object."
+msgstr "Не вдалося створити об'єкт налаштовування шрифтів."
+
+#: ../src/gtk/font.cpp:568
+#, c-format
+msgid "Failed to add custom font \"%s\"."
+msgstr "Не вдалося додати нетиповий шрифт «%s»."
+
+#: ../src/gtk/font.cpp:576
+msgid "Failed to register font configuration using private fonts."
+msgstr ""
+"Не вдалося зареєструвати налаштування шрифтів з використанням приватних "
+"шрифтів."
+
+#: ../src/gtk/glcanvas.cpp:117 ../src/gtk/glcanvas.cpp:132
+msgid "Fatal Error"
+msgstr "Критична помилка"
+
+#: ../src/gtk/glcanvas.cpp:117
+msgid ""
+"This program wasn't compiled with EGL support required under Wayland, "
+"either\n"
+"install EGL libraries and rebuild or run it under X11 backend by setting\n"
+"environment variable GDK_BACKEND=x11 before starting your program."
+msgstr ""
+"Цю програму не було зібрано з підтримкою EGL, яка потрібна у Wayland; або\n"
+"встановіть бібліотеки EGL і повторно зберіть пакунок, або запустіть програму "
+"під керуванням модуля X11,\n"
+"встановивши значення змінної середовища GDK_BACKEND=x11 перед запуском вашої "
+"програми."
+
+#: ../src/gtk/glcanvas.cpp:132
+msgid ""
+"wxGLCanvas is only supported on Wayland and X11 currently.  You may be able "
+"to\n"
+"work around this by setting environment variable GDK_BACKEND=x11 before\n"
+"starting your program."
+msgstr ""
+"Підтримку wxGLCanvas у поточній версії передбачено лише у Wayland та X11. Ви "
+"можете обійти цю проблему\n"
+"встановленням значення змінної середовища GDK_BACKEND=x11 перед запуском\n"
+"вашої програми."
+
+#: ../src/gtk/mdi.cpp:433
+msgid "MDI child"
+msgstr "Нащадок MDI"
+
+#: ../src/gtk/power.cpp:188
+#, c-format
+msgid "Failed to open D-Bus connection to the login manager: %s"
+msgstr "Не вдалося встановити з'єднання D-Bus із засобом керування входом: %s"
+
+#: ../src/gtk/power.cpp:214
+msgid "wxWidgets application"
+msgstr "Програма wxWidgets"
+
+#: ../src/gtk/power.cpp:226
+msgid "Application needs to keep running"
+msgstr "Програма потребує продовження виконання"
+
+#: ../src/gtk/power.cpp:233
+msgid "Clean up before suspend"
+msgstr "Очистити до присипляння"
+
+#: ../src/gtk/power.cpp:259
+#, c-format
+msgid "Failed to inhibit sleep: %s"
+msgstr "Не вдалося заборонити присипляння: %s"
+
+#: ../src/gtk/power.cpp:265
+msgid "Unexpected response to D-Bus \"Inhibit\" request."
+msgstr "Неочікувана відповідь на запит D-Bus «Inhibit»."
+
+#: ../src/gtk/print.cpp:218
+msgid "Custom size"
+msgstr "Нетиповий розмір"
+
+#: ../src/gtk/print.cpp:752
+#, c-format
+msgid "Error while printing: %s"
+msgstr "Помилка під час друку: %s"
+
+#: ../src/gtk/print.cpp:816
+msgid "Page Setup"
+msgstr "Налаштування сторінки"
+
+#: ../src/gtk/webview_webkit.cpp:932
+msgid "Retrieving JavaScript script output is not supported with WebKit v1"
+msgstr ""
+"При використанні WebKit 1 не передбачено підтримки отримання виведених "
+"скриптом JavaScript даних"
+
+#: ../src/gtk/webview_webkit2.cpp:1098
+msgid ""
+"Setting proxy is not supported by WebKit, at least version 2.16 is required."
+msgstr ""
+"Підтримки встановлення проксі-сервера не передбачено у WebKit, потрібна"
+" принаймні версія 2.16."
+
+#: ../src/gtk/webview_webkit2.cpp:1104
+msgid "This program was compiled without support for setting WebKit proxy."
+msgstr ""
+"Цю програму було зібрано без підтримки встановлення проксі-сервера у WebKit."
+
+#: ../src/gtk/window.cpp:6289
+msgid ""
+"GTK+ installed on this machine is too old to support screen compositing, "
+"please install GTK+ 2.12 or later."
+msgstr ""
+"Встановлені у цій системі бібліотеки GTK+ є надто старими, щоб підтримувати "
+"композитне відтворення належним чином. Будь ласка, встановіть версію "
+"бібліотек GTK+ 2.12 або пізнішу."
+
+#: ../src/gtk/window.cpp:6307
+msgid ""
+"Compositing not supported by this system, please enable it in your Window "
+"Manager."
+msgstr ""
+"У цій системі не передбачено можливості композитного відтворення, будь "
+"ласка, увімкніть композитне відтворення у вашій програмі для керування "
+"вікнами."
+
+#: ../src/gtk/window.cpp:6318
+msgid ""
+"This program was compiled with a too old version of GTK+, please rebuild "
+"with GTK+ 2.12 or newer."
+msgstr ""
+"Цю програму було зібрано з надто старою версією GTK+. Будь ласка, виконайте "
+"повторне збирання з версією GTK+ 2.12 або новішою."
+
+#: ../src/html/chm.cpp:138
+#, c-format
+msgid "Failed to open CHM archive '%s'."
+msgstr "Не вдалося відкрити архів CHM «%s»."
+
+#: ../src/html/chm.cpp:270
+#, c-format
+msgid "Could not extract %s into %s: %s"
+msgstr "Не вдалося розпакувати %s до %s: %s"
+
+#: ../src/html/chm.cpp:324
+msgid "no error"
+msgstr "без помилок"
+
+#: ../src/html/chm.cpp:326
+msgid "bad arguments to library function"
+msgstr "некоректні аргументи бібліотечної функції"
+
+#: ../src/html/chm.cpp:328
+msgid "error opening file"
+msgstr "помилка під час відкриття файла"
+
+#: ../src/html/chm.cpp:330
+msgid "read error"
+msgstr "помилка читання"
+
+#: ../src/html/chm.cpp:332
+msgid "write error"
+msgstr "помилка запису"
+
+#: ../src/html/chm.cpp:334
+msgid "seek error"
+msgstr "помилка пошуку"
+
+#: ../src/html/chm.cpp:338
+msgid "bad signature"
+msgstr "некоректний підпис"
+
+#: ../src/html/chm.cpp:340
+msgid "error in data format"
+msgstr "помилка в форматі даних"
+
+#: ../src/html/chm.cpp:342
+msgid "checksum error"
+msgstr "помилка у контрольній сумі"
+
+#: ../src/html/chm.cpp:344
+msgid "compression error"
+msgstr "помилка стиснення"
+
+#: ../src/html/chm.cpp:346
+msgid "decompression error"
+msgstr "помилка розпакування"
+
+#: ../src/html/chm.cpp:437
+#, c-format
+msgid "Could not locate file '%s'."
+msgstr "Не вдалося знайти розташування файла «%s»."
+
+#: ../src/html/chm.cpp:711
+#, c-format
+msgid "Could not create temporary file '%s'"
+msgstr "Не вдалося створити тимчасовий файл «%s»"
+
+#: ../src/html/chm.cpp:718
+#, c-format
+msgid "Extraction of '%s' into '%s' failed."
+msgstr "Розпакування «%s» до «%s» закінчилося з помилкою."
+
+#: ../src/html/chm.cpp:806 ../src/html/chm.cpp:863
+msgid "CHM handler currently supports only local files!"
+msgstr "Обробник CHM у цій версії підтримує лише локальні файли!"
+
+#: ../src/html/chm.cpp:827
+msgid "Link contained '//', converted to absolute link."
+msgstr "Посилання, що містило '//', перетворено на абсолютне посилання."
+
+#: ../src/html/helpctrl.cpp:59
+#, c-format
+msgid "Help: %s"
+msgstr "Довідка: %s"
+
+#: ../src/html/helpctrl.cpp:155
+#, c-format
+msgid "Adding book %s"
+msgstr "Додавання книги %s"
+
+#: ../src/html/helpdata.cpp:295
+#, c-format
+msgid "Cannot open contents file: %s"
+msgstr "Не вдалося відкрити файл змісту: %s"
+
+#: ../src/html/helpdata.cpp:309
+#, c-format
+msgid "Cannot open index file: %s"
+msgstr "Не вдалося відкрити файл індексу: %s"
+
+#: ../src/html/helpdata.cpp:643
+msgid "noname"
+msgstr "без назви"
+
+#: ../src/html/helpdata.cpp:652
+#, c-format
+msgid "Cannot open HTML help book: %s"
+msgstr "Не вдалося відкрити книгу довідки HTML: %s"
+
+#: ../src/html/helpwnd.cpp:315
+msgid "Displays help as you browse the books on the left."
+msgstr "Показує довідку у той час, коли ви гортаєте книжки ліворуч."
+
+#: ../src/html/helpwnd.cpp:411 ../src/html/helpwnd.cpp:1100
+#: ../src/html/helpwnd.cpp:1735
+msgid "(bookmarks)"
+msgstr "(закладки)"
+
+#: ../src/html/helpwnd.cpp:424
+msgid "Add current page to bookmarks"
+msgstr "Додати цю сторінку до закладок"
+
+#: ../src/html/helpwnd.cpp:425
+msgid "Remove current page from bookmarks"
+msgstr "Вилучити цю сторінку з закладок"
+
+#: ../src/html/helpwnd.cpp:470
+msgid "Contents"
+msgstr "Зміст"
+
+#: ../src/html/helpwnd.cpp:485
+msgid "Find"
+msgstr "Знайти"
+
+#: ../src/html/helpwnd.cpp:487
+msgid "Show all"
+msgstr "Показати всі"
+
+#: ../src/html/helpwnd.cpp:497
+msgid ""
+"Display all index items that contain given substring. Search is case "
+"insensitive."
+msgstr ""
+"Вивести всі рядки індексу, що містять даний підрядок. Пошук без врахування \n"
+"регістру."
+
+#: ../src/html/helpwnd.cpp:498
+msgid "Show all items in index"
+msgstr "Показати всі рядки індексу"
+
+#: ../src/html/helpwnd.cpp:528
+msgid "Case sensitive"
+msgstr "З врахуванням регістру"
+
+#: ../src/html/helpwnd.cpp:529
+msgid "Whole words only"
+msgstr "Тільки цілі слова"
+
+#: ../src/html/helpwnd.cpp:532
+msgid ""
+"Search contents of help book(s) for all occurrences of the text you typed "
+"above"
+msgstr "Пошук в книгах довідки всіх згадок введеного вище тексту"
+
+#: ../src/html/helpwnd.cpp:653
+msgid "Show/hide navigation panel"
+msgstr "Показати/сховати навігаційну панель"
+
+#: ../src/html/helpwnd.cpp:655
+msgid "Go back"
+msgstr "Іти назад"
+
+#: ../src/html/helpwnd.cpp:656
+msgid "Go forward"
+msgstr "Іти вперед"
+
+#: ../src/html/helpwnd.cpp:658
+msgid "Go one level up in document hierarchy"
+msgstr "Перейти на рівень вгору ієрархією документа"
+
+#: ../src/html/helpwnd.cpp:666 ../src/html/helpwnd.cpp:1547
+msgid "Open HTML document"
+msgstr "Відкрити документ HTML"
+
+#: ../src/html/helpwnd.cpp:670
+msgid "Print this page"
+msgstr "Надрукувати цю сторінку"
+
+#: ../src/html/helpwnd.cpp:674
+msgid "Display options dialog"
+msgstr "Відкрити діалогове вікно параметрів"
+
+#: ../src/html/helpwnd.cpp:795
+msgid "Please choose the page to display:"
+msgstr "Будь ласка, виберіть сторінку для показу:"
+
+#: ../src/html/helpwnd.cpp:796
+msgid "Help Topics"
+msgstr "Розділи довідки"
+
+#: ../src/html/helpwnd.cpp:852
+msgid "Searching..."
+msgstr "Пошук…"
+
+#: ../src/html/helpwnd.cpp:853
+msgid "No matching page found yet"
+msgstr "Відповідної сторінки ще не знайдено"
+
+#: ../src/html/helpwnd.cpp:870
+#, c-format
+msgid "Found %i matches"
+msgstr "Знайдено %i відповідностей"
+
+#: ../src/html/helpwnd.cpp:958
+msgid "(Help)"
+msgstr "(Довідка)"
+
+#: ../src/html/helpwnd.cpp:1026
+#, c-format
+msgid "%d of %lu"
+msgstr "%d з %lu"
+
+#: ../src/html/helpwnd.cpp:1028
+#, c-format
+msgid "%lu of %lu"
+msgstr "%lu з %lu"
+
+#: ../src/html/helpwnd.cpp:1047
+msgid "Search in all books"
+msgstr "Пошук в усіх книгах"
+
+#: ../src/html/helpwnd.cpp:1193
+msgid "Help Browser Options"
+msgstr "Параметри перегляду довідки"
+
+#: ../src/html/helpwnd.cpp:1198
+msgid "Normal font:"
+msgstr "Звичайний шрифт:"
+
+#: ../src/html/helpwnd.cpp:1199
+msgid "Fixed font:"
+msgstr "Фіксований шрифт:"
+
+#: ../src/html/helpwnd.cpp:1200
+msgid "Font size:"
+msgstr "Розмір шрифту:"
+
+#: ../src/html/helpwnd.cpp:1245
+msgid "font size"
+msgstr "Розмір шрифту:"
+
+#: ../src/html/helpwnd.cpp:1256
+msgid "Normal face<br>and <u>underlined</u>. "
+msgstr "Звичайний шрифт<br>та <u>підкреслений</u>. "
+
+#: ../src/html/helpwnd.cpp:1257
+msgid "<i>Italic face.</i> "
+msgstr "<i>Курсивний шрифт.</i> "
+
+#: ../src/html/helpwnd.cpp:1258
+msgid "<b>Bold face.</b> "
+msgstr "<b>Жирний шрифт.</b> "
+
+#: ../src/html/helpwnd.cpp:1259
+msgid "<b><i>Bold italic face.</i></b><br>"
+msgstr "<b><i>Жирний курсивний шрифт.</i></b><br>"
+
+#: ../src/html/helpwnd.cpp:1262
+msgid "Fixed size face.<br> <b>bold</b> <i>italic</i> "
+msgstr "Шрифт з фіксованою шириною.<br> <b>жирний</b> <i>курсивний</i> "
+
+#: ../src/html/helpwnd.cpp:1263
+msgid "<b><i>bold italic <u>underlined</u></i></b><br>"
+msgstr "<b><i>жирний курсивний шрифт <u>з підкресленням</u></i></b><br>"
+
+#: ../src/html/helpwnd.cpp:1524
+msgid "Help Printing"
+msgstr "Довідка друку"
+
+#: ../src/html/helpwnd.cpp:1527
+msgid "Cannot print empty page."
+msgstr "Не вдалося надрукувати порожню сторінку."
+
+#: ../src/html/helpwnd.cpp:1540
+msgid "HTML files (*.html;*.htm)|*.html;*.htm|"
+msgstr "Файли HTML (*.html;*.htm)|*.html;*.htm|"
+
+#: ../src/html/helpwnd.cpp:1541
+msgid "Help books (*.htb)|*.htb|Help books (*.zip)|*.zip|"
+msgstr "Книги довідки (*.htb)|*.htb|Книги довідки (*.zip)|*.zip|"
+
+#: ../src/html/helpwnd.cpp:1542
+msgid "HTML Help Project (*.hhp)|*.hhp|"
+msgstr "Проект довідки HTML (*.hhp)|*.hhp|"
+
+#: ../src/html/helpwnd.cpp:1544
+msgid "Compressed HTML Help file (*.chm)|*.chm|"
+msgstr "Стиснутий файл довідки HTML (*.chm)|*.chm|"
+
+#: ../src/html/helpwnd.cpp:1671
+#, c-format
+msgid "%i of %u"
+msgstr "%i з %u"
+
+#: ../src/html/helpwnd.cpp:1709
+#, c-format
+msgid "%u of %u"
+msgstr "%u з %u"
+
+#: ../src/html/htmlfilt.cpp:134
+#, c-format
+msgid "Cannot open HTML document: %s"
+msgstr "Не вдалося відкрити документ HTML: %s"
+
+#: ../src/html/htmlwin.cpp:599
+msgid "Connecting..."
+msgstr "Під'єднання…"
+
+#: ../src/html/htmlwin.cpp:616
+#, c-format
+msgid "Unable to open requested HTML document: %s"
+msgstr "Не вдалося відкрити запрошений документ HTML: %s"
+
+#: ../src/html/htmlwin.cpp:630
+msgid "Loading : "
+msgstr "Завантаження : "
+
+#: ../src/html/htmlwin.cpp:673
+msgid "Done"
+msgstr "Зроблено"
+
+#: ../src/html/htmlwin.cpp:723
+#, c-format
+msgid "HTML anchor %s does not exist."
+msgstr "HTML-якір %s не присутній."
+
+#: ../src/html/htmlwin.cpp:1057
+#, c-format
+msgid "Copied to clipboard:\"%s\""
+msgstr "Скопійовано до буфера: «%s»"
+
+#: ../src/html/htmprint.cpp:269
+msgid ""
+"This document doesn't fit on the page horizontally and will be truncated "
+"when it is printed."
+msgstr ""
+"Цей документ не можна вмістити на сторінку у горизонтальному напрямку, його "
+"буде обрізано під час друку."
+
+#: ../src/html/htmprint.cpp:285
+#, c-format
+msgid ""
+"The document \"%s\" doesn't fit on the page horizontally and will be "
+"truncated if printed.\n"
+"\n"
+"Would you like to proceed with printing it nevertheless?"
+msgstr ""
+"Документ %s не можна вмістити на сторінку у горизонтальному напрямку, його "
+"буде обрізано під час друку.\n"
+"\n"
+"Бажаєте надрукувати його попри це?"
+
+#: ../src/html/htmprint.cpp:296
+msgid ""
+"If possible, try changing the layout parameters to make the printout more "
+"narrow."
+msgstr ""
+"Спробуйте змінити параметри компонування так, що зробити відбиток вужчим."
+
+#: ../src/html/htmprint.cpp:445
+msgid ": file does not exist!"
+msgstr ": файл не існує!"
+
+#. TRANSLATORS: %s may be a document title.
+#: ../src/html/htmprint.cpp:717
+#, c-format
+msgid "%s Preview"
+msgstr "Попередній перегляд %s"
+
+#: ../src/html/htmprint.cpp:755 ../src/richtext/richtextprint.cpp:618
+msgid ""
+"There was a problem during page setup: you may need to set a default printer."
+msgstr ""
+"Під час створення сторінки виникла проблема: можливо, вам слід встановити "
+"типовий принтер."
+
+#: ../src/msw/clipbrd.cpp:80
+msgid "Failed to open the clipboard."
+msgstr "Не вдалося відкрити clipboard."
+
+#: ../src/msw/clipbrd.cpp:101
+msgid "Failed to close the clipboard."
+msgstr "Не вдалося закрити буфер обміну."
+
+#: ../src/msw/clipbrd.cpp:113
+msgid "Failed to empty the clipboard."
+msgstr "Не вдалося почистити clipboard."
+
+#: ../src/msw/clipbrd.cpp:284
+msgid "Failed to put data on the clipboard"
+msgstr "Не вдалося покласти дані в clipboard."
+
+#: ../src/msw/clipbrd.cpp:326
+msgid "Failed to get data from the clipboard"
+msgstr "Не вдалося встановити дані з clipboard."
+
+#: ../src/msw/clipbrd.cpp:363
+msgid "Failed to retrieve the supported clipboard formats"
+msgstr "Не вдалося прочитати формати підтримані clipboard"
+
+#: ../src/msw/colordlg.cpp:228
+#, c-format
+msgid "Colour selection dialog failed with error %0lx."
+msgstr "Діалогове вікно вибору кольору повідомило про помилку %0lx."
+
+#: ../src/msw/cursor.cpp:141
+msgid "Failed to create cursor."
+msgstr "Не вдалося створити курсор."
+
+#: ../src/msw/dde.cpp:279
+#, c-format
+msgid "Failed to register DDE server '%s'"
+msgstr "Не вдалося зареєструвати сервер DDE «%s»"
+
+#: ../src/msw/dde.cpp:300
+#, c-format
+msgid "Failed to unregister DDE server '%s'"
+msgstr "Не вдалося скасувати реєстрацію сервера DDE «%s»"
+
+#: ../src/msw/dde.cpp:428
+#, c-format
+msgid "Failed to create connection to server '%s' on topic '%s'"
+msgstr "Не вдалося підключитись до серверу «%s» по темі «%s»"
+
+#: ../src/msw/dde.cpp:655
+msgid "DDE poke request failed"
+msgstr "Помилка читання DDE"
+
+#: ../src/msw/dde.cpp:674
+msgid "Failed to establish an advise loop with DDE server"
+msgstr "Не вдалося встановити зв'язок помочі з DDE сервером"
+
+#: ../src/msw/dde.cpp:693
+msgid "Failed to terminate the advise loop with DDE server"
+msgstr "Не вдалося закінчити 'advise loop' з DDE сервером."
+
+#: ../src/msw/dde.cpp:768
+msgid "Failed to send DDE advise notification"
+msgstr "Не вдалося надіслати повідомлення DDE"
+
+#: ../src/msw/dde.cpp:1085
+msgid "Failed to create DDE string"
+msgstr "Помилка створення рядка DDE"
+
+#: ../src/msw/dde.cpp:1131
+msgid "no DDE error."
+msgstr "немає помилки"
+
+#: ../src/msw/dde.cpp:1135
+msgid "a request for a synchronous advise transaction has timed out."
+msgstr "запит на синхронну дію з надання поради перевищив границю часу"
+
+#: ../src/msw/dde.cpp:1138
+msgid "the response to the transaction caused the DDE_FBUSY bit to be set."
+msgstr "відповідь на дію викликала встановлення біта DDE_FBUSY."
+
+#: ../src/msw/dde.cpp:1141
+msgid "a request for a synchronous data transaction has timed out."
+msgstr "строк виконання запиту на синхронне передавання даних вичерпано."
+
+#: ../src/msw/dde.cpp:1144
+msgid ""
+"a DDEML function was called without first calling the DdeInitialize "
+"function,\n"
+"or an invalid instance identifier\n"
+"was passed to a DDEML function."
+msgstr ""
+"Функція DDEML була викликана без попереднього виклику функції "
+"DdeInitialize,\n"
+"або неправильний ідентифікатор інстанції\n"
+"було передано до DDEML функції."
+
+#: ../src/msw/dde.cpp:1147
+msgid ""
+"an application initialized as APPCLASS_MONITOR has\n"
+"attempted to perform a DDE transaction,\n"
+"or an application initialized as APPCMD_CLIENTONLY has \n"
+"attempted to perform server transactions."
+msgstr ""
+"програма запущена як APPCLASS_MONITOR\n"
+"спробувала виконати DDE-дію,\n"
+"або програма запущена як APPCMD_CLIENTONLY \n"
+"спробувала виконати серверні дії."
+
+#: ../src/msw/dde.cpp:1150
+msgid "a request for a synchronous execute transaction has timed out."
+msgstr "строк виконання запиту на синхронну дію з виконання вичерпано."
+
+#: ../src/msw/dde.cpp:1153
+msgid "a parameter failed to be validated by the DDEML."
+msgstr "параметр не пройшов перевірку DDEML."
+
+#: ../src/msw/dde.cpp:1156
+msgid "a DDEML application has created a prolonged race condition."
+msgstr "застосування DDEML створило затяжні перегони."
+
+#: ../src/msw/dde.cpp:1159
+msgid "a memory allocation failed."
+msgstr "помилка виділення пам'яті."
+
+#: ../src/msw/dde.cpp:1162
+msgid "a client's attempt to establish a conversation has failed."
+msgstr "спроба клієнту встановити зв'язок не вдалася."
+
+#: ../src/msw/dde.cpp:1165
+msgid "a transaction failed."
+msgstr "помилкова дія."
+
+#: ../src/msw/dde.cpp:1168
+msgid "a request for a synchronous poke transaction has timed out."
+msgstr ""
+"строк виконання запиту на синхронну дію з запису елемента даних вичерпано."
+
+#: ../src/msw/dde.cpp:1171
+msgid "an internal call to the PostMessage function has failed. "
+msgstr "внутрішній виклик до PostMessage не пройшов"
+
+#: ../src/msw/dde.cpp:1174
+msgid "reentrancy problem."
+msgstr "проблема з повторним входом."
+
+#: ../src/msw/dde.cpp:1177
+msgid ""
+"a server-side transaction was attempted on a conversation\n"
+"that was terminated by the client, or the server\n"
+"terminated before completing a transaction."
+msgstr ""
+"виконано спробу дії з боку сервера під час обміну даними,\n"
+"її перервано клієнтом, або сервер було\n"
+"зупинено до завершення дії."
+
+#: ../src/msw/dde.cpp:1180
+msgid "an internal error has occurred in the DDEML."
+msgstr "внутрішня помилка у DDEML."
+
+#: ../src/msw/dde.cpp:1183
+msgid "a request to end an advise transaction has timed out."
+msgstr ""
+"строк виконання запиту щодо завершення дії з надання поради вичерпано."
+
+#: ../src/msw/dde.cpp:1186
+msgid ""
+"an invalid transaction identifier was passed to a DDEML function.\n"
+"Once the application has returned from an XTYP_XACT_COMPLETE callback,\n"
+"the transaction identifier for that callback is no longer valid."
+msgstr ""
+"до функції DDEML передано помилковий ідентифікатор дії.\n"
+"Тільки-но програма повернулася зі зворотного виклику XTYP_XACT_COMPLETE,\n"
+"ідентифікатор дії для цього виклику вже не є дійсним."
+
+#: ../src/msw/dde.cpp:1189
+#, c-format
+msgid "Unknown DDE error %08x"
+msgstr "Невідома помилка DDE %08x"
+
+#: ../src/msw/dialup.cpp:343
+msgid ""
+"Dial up functions are unavailable because the remote access service (RAS) is "
+"not installed on this machine. Please install it."
+msgstr ""
+"Службу віддаленого з'єднання (RAS) на цьому комп’ютері не встановлено. Будь "
+"ласка, встановіть її."
+
+#: ../src/msw/dialup.cpp:402
+#, c-format
+msgid ""
+"The version of remote access service (RAS) installed on this machine is too "
+"old, please upgrade (the following required function is missing: %s)."
+msgstr ""
+"Версія служби віддаленого доступу (RAS), встановлена на цій машині "
+"застаріла, будь ласка, оновіть її (не вистачає функції %s)."
+
+#: ../src/msw/dialup.cpp:437
+msgid "Failed to retrieve text of RAS error message"
+msgstr "Не вдалося прочитати повідомлення про помилку RAS"
+
+#: ../src/msw/dialup.cpp:440
+#, c-format
+msgid "unknown error (error code %08x)."
+msgstr "Невідома помилка (код помилки %08x)"
+
+#: ../src/msw/dialup.cpp:492
+#, c-format
+msgid "Cannot find active dialup connection: %s"
+msgstr "Не вдалося знайти активне модемне з'єднання: %s"
+
+#: ../src/msw/dialup.cpp:513
+msgid "Several active dialup connections found, choosing one randomly."
+msgstr ""
+"Знайдено декілька активних комутованих з'єднань, випадково вибираємо одне."
+
+#: ../src/msw/dialup.cpp:598 ../src/msw/dialup.cpp:832
+#, c-format
+msgid "Failed to establish dialup connection: %s"
+msgstr "Не вдалося додзвонитись: %s"
+
+#: ../src/msw/dialup.cpp:664
+#, c-format
+msgid "Failed to get ISP names: %s"
+msgstr "Не вдалося отримати номеру ISP: %s"
+
+#: ../src/msw/dialup.cpp:712
+msgid "Failed to connect: no ISP to dial."
+msgstr "Не вдалося додзвонитись: відсутній інтернет-провайдер."
+
+#: ../src/msw/dialup.cpp:732
+msgid "Choose ISP to dial"
+msgstr "Оберіть інтернет провайдера"
+
+#: ../src/msw/dialup.cpp:733
+msgid "Please choose which ISP do you want to connect to"
+msgstr ""
+"Будь ласка, виберіть надавача послуг інтернету, з яким слід з’єднатися"
+
+#: ../src/msw/dialup.cpp:766
+msgid "Failed to connect: missing username/password."
+msgstr "Не вдалося підключитись: не вказано користувача/пароля."
+
+#: ../src/msw/dialup.cpp:796
+msgid "Cannot find the location of address book file"
+msgstr "Файл з адресною книгою не знайдений"
+
+#: ../src/msw/dialup.cpp:827
+#, c-format
+msgid "Failed to initiate dialup connection: %s"
+msgstr "Не вдалося ініціалізувати комутоване з’єднання: %s"
+
+#: ../src/msw/dialup.cpp:897
+msgid "Cannot hang up - no active dialup connection."
+msgstr "Не вдалося повісити трубку — немає з'єднання."
+
+#: ../src/msw/dialup.cpp:907
+#, c-format
+msgid "Failed to terminate the dialup connection: %s"
+msgstr "Не вдалося повісити трубку: %s"
+
+#: ../src/msw/dib.cpp:313
+#, c-format
+msgid "Failed to save the bitmap image to file \"%s\"."
+msgstr "Не вдалося зберегти растрове зображення до файла «%s»."
+
+#: ../src/msw/dib.cpp:543
+#, c-format
+msgid "Failed to allocate %luKb of memory for bitmap data."
+msgstr "Не вдалося виділити %lu кБ пам'яті для даних растрової картинки."
+
+#: ../src/msw/dir.cpp:241
+#, c-format
+msgid "Cannot enumerate files in directory '%s'"
+msgstr "Не можу перелічити файли в каталозі «%s»"
+
+#: ../src/msw/dirdlg.cpp:368
+msgid "Couldn't obtain folder name"
+msgstr "Не вдалося отримати назву теки"
+
+#: ../src/msw/dlmsw.cpp:163
+#, c-format
+msgid "(error %d: %s)"
+msgstr "(помилка %d: %s)"
+
+#: ../src/msw/dragimag.cpp:143 ../src/msw/dragimag.cpp:178
+#: ../src/msw/imaglist.cpp:309 ../src/msw/imaglist.cpp:331
+msgid "Couldn't add an image to the image list."
+msgstr "Не вдалося додати зображення до списку зображень."
+
+#: ../src/msw/enhmeta.cpp:94
+#, c-format
+msgid "Failed to load metafile from file \"%s\"."
+msgstr "Не вдалося завантажити метазображення з файла «%s»."
+
+#: ../src/msw/fdrepdlg.cpp:412
+#, c-format
+msgid "Failed to create the standard find/replace dialog (error code %d)"
+msgstr ""
+"Не вдалося створити стандартний діалог знайти/замінити (код помилки %d)"
+
+#: ../src/msw/filedlg.cpp:1241
+msgid "Access to the file system is not allowed from secure desktop."
+msgstr "Доступ до файлової системи заборонено засобами захисту стільниці."
+
+#: ../src/msw/filedlg.cpp:1242
+msgid "Security warning"
+msgstr "Попередження безпеки"
+
+#: ../src/msw/filedlg.cpp:1533
+#, c-format
+msgid "File dialog failed with error code %0lx."
+msgstr "Помилка діалогового вікна роботи з файлами з кодом %0lx."
+
+#: ../src/msw/font.cpp:1120
+#, c-format
+msgid "Font file \"%s\" couldn't be loaded"
+msgstr "Не вдалося завантажити файл шрифту «%s»"
+
+#: ../src/msw/fontdlg.cpp:220
+#, c-format
+msgid "Common dialog failed with error code %0lx."
+msgstr "Помилка типового діалогового вікна з кодом %0lx."
+
+#: ../src/msw/fswatcher.cpp:67
+msgid "Ungraceful worker thread termination"
+msgstr "Некоректне завершення роботи нитки"
+
+#: ../src/msw/fswatcher.cpp:81
+msgid "Unable to create IOCP worker thread"
+msgstr "Не вдалося створити нитку обробки IOCP"
+
+#: ../src/msw/fswatcher.cpp:88
+msgid "Unable to start IOCP worker thread"
+msgstr "Не вдалося започаткувати нитку обробки IOCP"
+
+#: ../src/msw/fswatcher.cpp:140
+msgid "Monitoring individual files for changes is not supported currently."
+msgstr ""
+"Спостереження за змінами у окремих файлах у поточній версії не передбачено."
+
+#: ../src/msw/fswatcher.cpp:165
+#, c-format
+msgid "Unable to set up watch for '%s'"
+msgstr "Не вдалося налаштувати спостереження за «%s»"
+
+#: ../src/msw/fswatcher.cpp:466
+#, c-format
+msgid "Can't monitor non-existent directory \"%s\" for changes."
+msgstr "Спостереження за змінами у каталозі «%s», якого не існує, неможливе."
+
+#: ../src/msw/glcanvas.cpp:577 ../src/unix/glx11.cpp:507
+msgid "OpenGL 3.0 or later is not supported by the OpenGL driver."
+msgstr ""
+"У драйвері OpenGL  не передбачено підтримки OpenGL 3.0 або пізнішої версії."
+
+#: ../src/msw/glcanvas.cpp:601 ../src/osx/glcanvas_osx.cpp:395
+#: ../src/unix/glegl.cpp:304 ../src/unix/glx11.cpp:553
+msgid "Couldn't create OpenGL context"
+msgstr "Не вдалося створити контекст OpenGL"
+
+#: ../src/msw/glcanvas.cpp:1294
+msgid "Failed to initialize OpenGL"
+msgstr "Не вдалося ініціалізувати OpenGL"
+
+#: ../src/msw/graphicsd2d.cpp:607
+msgid "Could not register custom DirectWrite font loader."
+msgstr "Не вдалося зареєструвати нетиповий завантажувач шрифтів DirectWrite."
+
+#: ../src/msw/helpchm.cpp:48
+msgid ""
+"MS HTML Help functions are unavailable because the MS HTML Help library is "
+"not installed on this machine. Please install it."
+msgstr ""
+"Функції довідки MS HTML недоступні, оскільки на цій машині не встановлено "
+"бібліотеку довідки MS HTML. Будь ласка, встановіть її."
+
+#: ../src/msw/helpchm.cpp:55
+msgid "Failed to initialize MS HTML Help."
+msgstr "Не вдалося ініціалізувати MS HTML Help."
+
+#: ../src/msw/iniconf.cpp:458
+#, c-format
+msgid "Can't delete the INI file '%s'"
+msgstr "Не вдалося вилучити INI-файл «%s»"
+
+#: ../src/msw/listctrl.cpp:995
+#, c-format
+msgid "Couldn't retrieve information about list control item %d."
+msgstr "Не вдалося встановити інформацію про елемент списку %d."
+
+#: ../src/msw/mdi.cpp:170 ../src/qt/mdi.cpp:253
+msgid "&Cascade"
+msgstr "&Каскад"
+
+#: ../src/msw/mdi.cpp:171
+msgid "Tile &Horizontally"
+msgstr "Розставити &горизонтально"
+
+#: ../src/msw/mdi.cpp:172
+msgid "Tile &Vertically"
+msgstr "Розставити &вертикально"
+
+#: ../src/msw/mdi.cpp:174
+msgid "&Arrange Icons"
+msgstr "&Розташувати піктограми"
+
+#: ../src/msw/mdi.cpp:621
+msgid "Failed to create MDI parent frame."
+msgstr "Помилка створення батьківського фрейма MDI."
+
+#: ../src/msw/mimetype.cpp:234
+#, c-format
+msgid "Failed to create registry entry for '%s' files."
+msgstr "Не вдалося створити елемент реєстру для «%s» файлів."
+
+#: ../src/msw/ole/automtn.cpp:495
+#, c-format
+msgid "Failed to find CLSID of \"%s\""
+msgstr "Не вдалося знайти CLSID «%s»"
+
+#: ../src/msw/ole/automtn.cpp:512
+#, c-format
+msgid "Failed to create an instance of \"%s\""
+msgstr "Не вдалося створити екземпляр «%s»"
+
+#: ../src/msw/ole/automtn.cpp:552
+#, c-format
+msgid "Cannot get an active instance of \"%s\""
+msgstr "Не вдалося отримати дані активного екземпляра «%s»"
+
+#: ../src/msw/ole/automtn.cpp:564
+#, c-format
+msgid "Failed to get OLE automation interface for \"%s\""
+msgstr "Не вдалося отримати інтерфейс автоматичної обробки OLE для «%s»"
+
+#: ../src/msw/ole/automtn.cpp:621
+msgid "Unknown name or named argument."
+msgstr "Невідома назва або іменований аргумент."
+
+#: ../src/msw/ole/automtn.cpp:625
+msgid "Incorrect number of arguments."
+msgstr "Некоректна кількість аргументів."
+
+#: ../src/msw/ole/automtn.cpp:637
+msgid "Unknown exception"
+msgstr "Невідомий виняток"
+
+#: ../src/msw/ole/automtn.cpp:642
+msgid "Method or property not found."
+msgstr "Метод або властивість не знайдено."
+
+#: ../src/msw/ole/automtn.cpp:646
+msgid "Overflow while coercing argument values."
+msgstr "Переповнення під час примусового встановлення значень аргументів."
+
+#: ../src/msw/ole/automtn.cpp:650
+msgid "Object implementation does not support named arguments."
+msgstr "Реалізацією об’єкта не підтримуються іменовані аргументи."
+
+#: ../src/msw/ole/automtn.cpp:654
+msgid "The locale ID is unknown."
+msgstr "Невідомий ідентифікатор локалі."
+
+#: ../src/msw/ole/automtn.cpp:658
+msgid "Missing a required parameter."
+msgstr "Не виявлено потрібного параметра."
+
+#: ../src/msw/ole/automtn.cpp:662
+#, c-format
+msgid "Argument %u not found."
+msgstr "Не знайдено аргументу %u."
+
+#: ../src/msw/ole/automtn.cpp:666
+#, c-format
+msgid "Type mismatch in argument %u."
+msgstr "Невідповідність типів у аргументі %u."
+
+#: ../src/msw/ole/automtn.cpp:670
+msgid "The system cannot find the file specified."
+msgstr "Системі не вдалося знайти вказаного файла."
+
+#: ../src/msw/ole/automtn.cpp:674
+msgid "Class not registered."
+msgstr "Клас не зареєстровано."
+
+#: ../src/msw/ole/automtn.cpp:678
+#, c-format
+msgid "Unknown error %08x"
+msgstr "Невідома помилка %08x"
+
+#: ../src/msw/ole/automtn.cpp:682
+#, c-format
+msgid "OLE Automation error in %s: %s"
+msgstr "Помилка автоматизації OLE у %s: %s"
+
+#: ../src/msw/ole/dataobj.cpp:385
+#, c-format
+msgid "Couldn't register clipboard format '%s'."
+msgstr "Не вдалося зареєструвати формат «%s»"
+
+#: ../src/msw/ole/dataobj.cpp:402
+#, c-format
+msgid "The clipboard format '%d' doesn't exist."
+msgstr "Формату буфера даних «%d» не існує."
+
+#: ../src/msw/progdlg.cpp:1025
+msgid "Skip"
+msgstr "Пропустити"
+
+#: ../src/msw/registry.cpp:141
+#, c-format
+msgid "unknown (%lu)"
+msgstr "невідомий (%lu)"
+
+#: ../src/msw/registry.cpp:409
+#, c-format
+msgid "Can't get info about registry key '%s'"
+msgstr "Не вдалося отримати інформацію про ключ реєстру «%s»"
+
+#: ../src/msw/registry.cpp:445
+#, c-format
+msgid "Can't open registry key '%s'"
+msgstr "Не вдалося відкрити ключ реєстру «%s»"
+
+#: ../src/msw/registry.cpp:478
+#, c-format
+msgid "Can't create registry key '%s'"
+msgstr "Не вдалося створити ключ реєстру «%s»"
+
+#: ../src/msw/registry.cpp:497
+#, c-format
+msgid "Can't close registry key '%s'"
+msgstr "Не вдалося закрити ключ реєстру «%s»"
+
+#: ../src/msw/registry.cpp:512
+#, c-format
+msgid "Registry value '%s' already exists."
+msgstr "Значення реєстру «%s» вже присутнє."
+
+#: ../src/msw/registry.cpp:520
+#, c-format
+msgid "Failed to rename registry value '%s' to '%s'."
+msgstr "Не вдалося перейменувати значення реєстру з «%s» в '%s."
+
+#: ../src/msw/registry.cpp:575
+#, c-format
+msgid "Can't copy values of unsupported type %d."
+msgstr "Не вдалося копіювати значення непідтримуваного типу %d."
+
+#: ../src/msw/registry.cpp:586
+#, c-format
+msgid "Registry key '%s' does not exist, cannot rename it."
+msgstr "Ключ реєстру «%s» не присутній, Не вдалося його перейменувати."
+
+#: ../src/msw/registry.cpp:617
+#, c-format
+msgid "Registry key '%s' already exists."
+msgstr "Ключ реєстру «%s» вже присутній."
+
+#: ../src/msw/registry.cpp:625
+#, c-format
+msgid "Failed to rename the registry key '%s' to '%s'."
+msgstr "Не вдалося перейменувати ключ реєстру з «%s» в '%s."
+
+#: ../src/msw/registry.cpp:670
+#, c-format
+msgid "Failed to copy the registry subkey '%s' to '%s'."
+msgstr "Не вдалося копіювати підключ реєстру «%s» до «%s»."
+
+#: ../src/msw/registry.cpp:683
+#, c-format
+msgid "Failed to copy registry value '%s'"
+msgstr "Не вдалося скопіювати значення реєстру «%s»"
+
+#: ../src/msw/registry.cpp:692
+#, c-format
+msgid "Failed to copy the contents of registry key '%s' to '%s'."
+msgstr "Не вдалося копіювати дані ключу реєстру «%s» в «%s»."
+
+#: ../src/msw/registry.cpp:718
+#, c-format
+msgid ""
+"Registry key '%s' is needed for normal system operation,\n"
+"deleting it will leave your system in unusable state:\n"
+"operation aborted."
+msgstr ""
+"Ключ реєстру «%s» необхідний для нормальної праці системи,\n"
+"його знищення приведе вашу систему в недієздатний стан:\n"
+"дію скасовано."
+
+#: ../src/msw/registry.cpp:754
+#, c-format
+msgid "Can't delete key '%s'"
+msgstr "Не вдалося вилучити ключ «%s»"
+
+#: ../src/msw/registry.cpp:782
+#, c-format
+msgid "Can't delete value '%s' from key '%s'"
+msgstr "Не вдалося вилучити значення «%s» ключа «%s»"
+
+#: ../src/msw/registry.cpp:855 ../src/msw/registry.cpp:887
+#: ../src/msw/registry.cpp:929 ../src/msw/registry.cpp:1000
+#, c-format
+msgid "Can't read value of key '%s'"
+msgstr "Не вдалося прочитати значення ключа «%s»"
+
+#: ../src/msw/registry.cpp:873 ../src/msw/registry.cpp:915
+#: ../src/msw/registry.cpp:963 ../src/msw/registry.cpp:1106
+#, c-format
+msgid "Can't set value of '%s'"
+msgstr "Не вдалося встановити значення «%s»"
+
+#: ../src/msw/registry.cpp:894 ../src/msw/registry.cpp:943
+#, c-format
+msgid "Registry value \"%s\" is not numeric (but of type %s)"
+msgstr "Значення реєстру «%s» не є числовим (а належить до типу %s)"
+
+#: ../src/msw/registry.cpp:979
+#, c-format
+msgid "Registry value \"%s\" is not binary (but of type %s)"
+msgstr "Значення реєстру «%s» не є двійковим (а належить до типу %s)"
+
+#: ../src/msw/registry.cpp:1028
+#, c-format
+msgid "Registry value \"%s\" is not text (but of type %s)"
+msgstr "Значення реєстру «%s» не є текстовим (а належить до типу %s)"
+
+#: ../src/msw/registry.cpp:1089
+#, c-format
+msgid "Can't read value of '%s'"
+msgstr "Не вдалося прочитати значення «%s»"
+
+#: ../src/msw/registry.cpp:1157
+#, c-format
+msgid "Can't enumerate values of key '%s'"
+msgstr "Не вдалося підрахувати значення ключа «%s»"
+
+#: ../src/msw/registry.cpp:1196
+#, c-format
+msgid "Can't enumerate subkeys of key '%s'"
+msgstr "Не вдалося підрахувати підключі ключа «%s»"
+
+#: ../src/msw/registry.cpp:1262
+#, c-format
+msgid ""
+"Exporting registry key: file \"%s\" already exists and won't be overwritten."
+msgstr ""
+"Експорт ключа реєстру: файл «%s» вже існує, його не буде перезаписано."
+
+#: ../src/msw/registry.cpp:1411
+#, c-format
+msgid "Can't export value of unsupported type %d."
+msgstr "Не вдалося експортувати значення непідтримуваного типу %d."
+
+#: ../src/msw/registry.cpp:1427
+#, c-format
+msgid "Ignoring value \"%s\" of the key \"%s\"."
+msgstr "Значенням «%s» ключа «%s» знехтувано."
+
+#: ../src/msw/textctrl.cpp:596
+msgid ""
+"Impossible to create a rich edit control, using simple text control instead. "
+"Please reinstall riched32.dll"
+msgstr ""
+"Не вдалося створити модуль редагування з форматуванням, натомість "
+"використовується звичайний модуль показу тексту. Будь ласка, перевстановіть "
+"riched32.dll"
+
+#: ../src/msw/thread.cpp:522 ../src/unix/threadpsx.cpp:850
+msgid "Cannot start thread: error writing TLS."
+msgstr "Не вдалося запустити нитку: помилка запису TLS."
+
+#: ../src/msw/thread.cpp:613
+msgid "Can't set thread priority"
+msgstr "Не вдалося встановити пріоритет нитки"
+
+#: ../src/msw/thread.cpp:649
+msgid "Can't create thread"
+msgstr "Не вдалося створити нитку"
+
+#: ../src/msw/thread.cpp:668
+msgid "Couldn't terminate thread"
+msgstr "Не вдалося закінчити нитку"
+
+#: ../src/msw/thread.cpp:799
+msgid "Cannot wait for thread termination"
+msgstr "Не вдалося дочекатись закінчення нитки"
+
+#: ../src/msw/thread.cpp:873
+#, c-format
+msgid "Cannot suspend thread %lx"
+msgstr "Не вдалося зупинити нитку %lx"
+
+#: ../src/msw/thread.cpp:903
+#, c-format
+msgid "Cannot resume thread %lx"
+msgstr "Не вдалося відновити нитку %lx"
+
+#: ../src/msw/thread.cpp:932
+msgid "Couldn't get the current thread pointer"
+msgstr "Не вдалося отримати показник на дану нитку"
+
+#: ../src/msw/thread.cpp:1333
+msgid ""
+"Thread module initialization failed: impossible to allocate index in thread "
+"local storage"
+msgstr ""
+"Помилка ініціалізації модуля ниток: Не вдалося виділити індекс в локальному "
+"просторі нитки"
+
+#: ../src/msw/thread.cpp:1345
+msgid ""
+"Thread module initialization failed: cannot store value in thread local "
+"storage"
+msgstr ""
+"Помилка ініціалізації модуля ниток: Не вдалося записати значення в "
+"локальному просторі нитки"
+
+#: ../src/msw/timer.cpp:133
+msgid "Couldn't create a timer"
+msgstr "Не вдалося створити таймер"
+
+#: ../src/msw/utils.cpp:372
+msgid "can't find user's HOME, using current directory."
+msgstr ""
+"Не вдалося встановити HOME користувача, буде використаний даний каталог."
+
+#: ../src/msw/utils.cpp:662
+#, c-format
+msgid "Failed to kill process %d"
+msgstr "Не вдалося вбити процес %d"
+
+#: ../src/msw/utils.cpp:986
+#, c-format
+msgid "Failed to load resource \"%s\"."
+msgstr "Не вдалося завантажити ресурс «%s»."
+
+#: ../src/msw/utils.cpp:993
+#, c-format
+msgid "Failed to lock resource \"%s\"."
+msgstr "Не вдалося заблокувати ресурс «%s»."
+
+#. TRANSLATORS: MS Windows build number
+#: ../src/msw/utils.cpp:1209
+#, c-format
+msgid "build %lu"
+msgstr "збірка %lu"
+
+#: ../src/msw/utils.cpp:1218
+msgid ", 64-bit edition"
+msgstr ", 64-бітова версія"
+
+#: ../src/msw/utilsexc.cpp:224
+msgid "Failed to create an anonymous pipe"
+msgstr "Не вдалося створити анонімну трубу"
+
+#: ../src/msw/utilsexc.cpp:697
+msgid "Failed to redirect the child process IO"
+msgstr "Не вдалося переспрямувати IO дочірнього процесу"
+
+#: ../src/msw/utilsexc.cpp:870
+#, c-format
+msgid "Execution of command '%s' failed"
+msgstr "Помилка виконання команди «%s»"
+
+#: ../src/msw/volume.cpp:337
+msgid "Failed to load mpr.dll."
+msgstr "Не вдалося завантажити mpr.dll."
+
+#: ../src/msw/volume.cpp:506
+#, c-format
+msgid "Cannot read typename from '%s'!"
+msgstr "Не вдалося прочитати назву типу з «%s»!"
+
+#: ../src/msw/volume.cpp:615
+#, c-format
+msgid "Cannot load icon from '%s'."
+msgstr "Не вдалося завантажити піктограму з «%s»."
+
+#: ../src/msw/webview_edge.cpp:285
+msgid "This program was compiled without support for setting Edge proxy."
+msgstr ""
+"Цю програму було зібрано без підтримки встановлення проксі-сервера у Edge."
+
+#: ../src/msw/webview_ie.cpp:1010
+msgid "Failed to find web view emulation level in the registry"
+msgstr ""
+"Не вдалося знайти рівень емуляції для перегляду сторінок інтернету у регістрі"
+
+#: ../src/msw/webview_ie.cpp:1019
+msgid "Failed to set web view to modern emulation level"
+msgstr ""
+"Не вдалося встановити для перегляду сторінок інтернету сучасний рівень "
+"емуляції"
+
+#: ../src/msw/webview_ie.cpp:1027
+msgid "Failed to reset web view to standard emulation level"
+msgstr ""
+"Не вдалося відновити для перегляду сторінок інтернету стандартний рівень "
+"емуляції"
+
+#: ../src/msw/webview_ie.cpp:1049
+msgid "Can't run JavaScript script without a valid HTML document"
+msgstr "Неможливо запустити скрипт JavaScript без коректного документа HTML"
+
+#: ../src/msw/webview_ie.cpp:1056
+msgid "Can't get the JavaScript object"
+msgstr "Не вдалося отримати об'єкт JavaScript"
+
+#: ../src/msw/webview_ie.cpp:1070
+msgid "failed to evaluate"
+msgstr "не вдалося обчислити"
+
+#: ../src/osx/cocoa/filedlg.mm:412
+msgid "File type:"
+msgstr "Тип файлів:"
+
+#: ../src/osx/cocoa/menu.mm:242
+msgctxt "macOS menu name"
+msgid "Window"
+msgstr "Вікно"
+
+#: ../src/osx/cocoa/menu.mm:259
+msgctxt "macOS menu name"
+msgid "Help"
+msgstr "Довідка"
+
+#: ../src/osx/cocoa/menu.mm:298
+msgctxt "macOS menu item"
+msgid "Minimize"
+msgstr "Мінімізувати"
+
+#: ../src/osx/cocoa/menu.mm:303
+msgctxt "macOS menu item"
+msgid "Zoom"
+msgstr "Масштаб"
+
+#: ../src/osx/cocoa/menu.mm:309
+msgctxt "macOS menu item"
+msgid "Bring All to Front"
+msgstr "Пересунути все на передній план"
+
+#: ../src/osx/core/sound.cpp:143
+#, c-format
+msgid "Failed to load sound from \"%s\" (error %d)."
+msgstr "Не вдалося завантажити звукові дані з «%s» (помилка %d)."
+
+#: ../src/osx/fontutil.cpp:80
+#, c-format
+msgid "Font file \"%s\" doesn't exist."
+msgstr "Файла шрифту «%s» не існує."
+
+#: ../src/osx/fontutil.cpp:88
+#, c-format
+msgid ""
+"Font file \"%s\" cannot be used as it is not inside the font directory "
+"\"%s\"."
+msgstr ""
+"Файлом шрифту «%s» неможливо скористатися, оскільки він не зберігається у "
+"каталозі шрифтів «%s»."
+
+#: ../src/osx/menu_osx.cpp:496
+#, c-format
+msgctxt "macOS menu item"
+msgid "About %s"
+msgstr "Про %s"
+
+#: ../src/osx/menu_osx.cpp:499
+msgctxt "macOS menu item"
+msgid "About..."
+msgstr "Про програму…"
+
+#: ../src/osx/menu_osx.cpp:508
+msgctxt "macOS menu item"
+msgid "Preferences..."
+msgstr "Налаштування…"
+
+#: ../src/osx/menu_osx.cpp:512
+msgctxt "macOS menu item"
+msgid "Services"
+msgstr "Служби"
+
+#: ../src/osx/menu_osx.cpp:519
+#, c-format
+msgctxt "macOS menu item"
+msgid "Hide %s"
+msgstr "Сховати %s"
+
+#: ../src/osx/menu_osx.cpp:522
+msgctxt "macOS menu item"
+msgid "Hide Application"
+msgstr "Приховати програму"
+
+#: ../src/osx/menu_osx.cpp:526
+msgctxt "macOS menu item"
+msgid "Hide Others"
+msgstr "Сховати решту"
+
+#: ../src/osx/menu_osx.cpp:528
+msgctxt "macOS menu item"
+msgid "Show All"
+msgstr "Показати всі"
+
+#: ../src/osx/menu_osx.cpp:534
+#, c-format
+msgctxt "macOS menu item"
+msgid "Quit %s"
+msgstr "Вийти з %s"
+
+#: ../src/osx/menu_osx.cpp:537
+msgctxt "macOS menu item"
+msgid "Quit Application"
+msgstr "Вийти з програми"
+
+#: ../src/osx/webview_webkit.mm:444
+msgid "Printing is not supported by the system web control"
+msgstr "Загальносистемним вебкеруванням не передбачено підтримки друку"
+
+#: ../src/osx/webview_webkit.mm:453
+msgid "Print operation could not be initialized"
+msgstr "Не вдалося ініціалізувати дію з друку"
+
+#. TRANSLATORS: Label of font point size
+#: ../src/propgrid/advprops.cpp:605
+msgid "Point Size"
+msgstr "Розмір точки"
+
+#. TRANSLATORS: Label of font face name
+#: ../src/propgrid/advprops.cpp:615
+msgid "Face Name"
+msgstr "Нарис"
+
+#. TRANSLATORS: Label of font style
+#: ../src/propgrid/advprops.cpp:623 ../src/richtext/richtextformatdlg.cpp:331
+msgid "Style"
+msgstr "Стиль"
+
+#. TRANSLATORS: Label of font weight
+#: ../src/propgrid/advprops.cpp:628
+msgid "Weight"
+msgstr "Вага"
+
+#. TRANSLATORS: Label of underlined font
+#: ../src/propgrid/advprops.cpp:633 ../src/richtext/richtextfontpage.cpp:358
+msgid "Underlined"
+msgstr "Підкреслене"
+
+#. TRANSLATORS: Label of font family
+#: ../src/propgrid/advprops.cpp:637
+msgid "Family"
+msgstr "Гарнітура"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:801
+msgid "AppWorkspace"
+msgstr "РобочаОбластьДодатків"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:802
+msgid "ActiveBorder"
+msgstr "АктивнаРамка"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:803
+msgid "ActiveCaption"
+msgstr "АктивнийЗаголовок"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:804
+msgid "ButtonFace"
+msgstr "ВерхКнопки"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:805
+msgid "ButtonHighlight"
+msgstr "ПідсвічуванняКнопки"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:806
+msgid "ButtonShadow"
+msgstr "ЗатінитиКнопку"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:807
+msgid "ButtonText"
+msgstr "ТекстКнопки"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:808
+msgid "CaptionText"
+msgstr "ТекстЗаголовка"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:809
+msgid "ControlDark"
+msgstr "КонтрольТемний"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:810
+msgid "ControlLight"
+msgstr "КонтрольСвітлий"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:812
+msgid "GrayText"
+msgstr "СірийТекст"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:813
+msgid "Highlight"
+msgstr "Підсвічування"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:814
+msgid "HighlightText"
+msgstr "ПідсвічуванняТексту"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:815
+msgid "InactiveBorder"
+msgstr "НеактивнаРамка"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:816
+msgid "InactiveCaption"
+msgstr "НеактивнийЗаголовок"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:817
+msgid "InactiveCaptionText"
+msgstr "ТекстНеактивногоЗаголовка"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:818
+msgid "Menu"
+msgstr "Меню"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:819
+msgid "Scrollbar"
+msgstr "СмужкаГортання"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:820
+msgid "Tooltip"
+msgstr "Підказка"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:821
+msgid "TooltipText"
+msgstr "ТекстПідказки"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:822
+msgid "Window"
+msgstr "Вікно"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:823
+msgid "WindowFrame"
+msgstr "РамкаВікна"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:824
+msgid "WindowText"
+msgstr "ТекстВікна"
+
+#. TRANSLATORS: Custom colour choice entry
+#: ../src/propgrid/advprops.cpp:825 ../src/propgrid/advprops.cpp:1532
+#: ../src/propgrid/advprops.cpp:1576
+msgid "Custom"
+msgstr "Нетиповий"
+
+#: ../src/propgrid/advprops.cpp:1558
+msgid "Black"
+msgstr "Чорний"
+
+#: ../src/propgrid/advprops.cpp:1559
+msgid "Maroon"
+msgstr "Брунато-малиновий"
+
+#: ../src/propgrid/advprops.cpp:1560
+msgid "Navy"
+msgstr "Темно-синій"
+
+#: ../src/propgrid/advprops.cpp:1561
+msgid "Purple"
+msgstr "Пурпуровий"
+
+#: ../src/propgrid/advprops.cpp:1562
+msgid "Teal"
+msgstr "Зеленувато-блакитний"
+
+#: ../src/propgrid/advprops.cpp:1563
+msgid "Gray"
+msgstr "Сірий"
+
+#: ../src/propgrid/advprops.cpp:1564
+msgid "Green"
+msgstr "Зелений"
+
+#: ../src/propgrid/advprops.cpp:1565
+msgid "Olive"
+msgstr "Оливковий"
+
+#: ../src/propgrid/advprops.cpp:1566
+msgid "Brown"
+msgstr "Коричневий"
+
+#: ../src/propgrid/advprops.cpp:1567
+msgid "Blue"
+msgstr "Синій"
+
+#: ../src/propgrid/advprops.cpp:1568
+msgid "Fuchsia"
+msgstr "Фуксія"
+
+#: ../src/propgrid/advprops.cpp:1569
+msgid "Red"
+msgstr "Червоний"
+
+#: ../src/propgrid/advprops.cpp:1570
+msgid "Orange"
+msgstr "Помаранчевий"
+
+#: ../src/propgrid/advprops.cpp:1571
+msgid "Silver"
+msgstr "Срібний"
+
+#: ../src/propgrid/advprops.cpp:1572
+msgid "Lime"
+msgstr "Лайм"
+
+#: ../src/propgrid/advprops.cpp:1573
+msgid "Aqua"
+msgstr "Аква"
+
+#: ../src/propgrid/advprops.cpp:1574
+msgid "Yellow"
+msgstr "Жовтий"
+
+#: ../src/propgrid/advprops.cpp:1575
+msgid "White"
+msgstr "Білий"
+
+#: ../src/propgrid/advprops.cpp:1718
+msgctxt "system cursor name"
+msgid "Default"
+msgstr "Типовий"
+
+#: ../src/propgrid/advprops.cpp:1719
+msgctxt "system cursor name"
+msgid "Arrow"
+msgstr "Стрілка"
+
+#: ../src/propgrid/advprops.cpp:1720
+msgctxt "system cursor name"
+msgid "Right Arrow"
+msgstr "Стрілка праворуч"
+
+#: ../src/propgrid/advprops.cpp:1721
+msgctxt "system cursor name"
+msgid "Blank"
+msgstr "Порожній"
+
+#: ../src/propgrid/advprops.cpp:1722
+msgctxt "system cursor name"
+msgid "Bullseye"
+msgstr "Центр мішені"
+
+#: ../src/propgrid/advprops.cpp:1723
+msgctxt "system cursor name"
+msgid "Character"
+msgstr "Символ"
+
+#: ../src/propgrid/advprops.cpp:1724
+msgctxt "system cursor name"
+msgid "Cross"
+msgstr "Хрест"
+
+#: ../src/propgrid/advprops.cpp:1725
+msgctxt "system cursor name"
+msgid "Hand"
+msgstr "Рука"
+
+#: ../src/propgrid/advprops.cpp:1726
+msgctxt "system cursor name"
+msgid "I-Beam"
+msgstr "I-подібний"
+
+#: ../src/propgrid/advprops.cpp:1727
+msgctxt "system cursor name"
+msgid "Left Button"
+msgstr "Ліва кнопка"
+
+#: ../src/propgrid/advprops.cpp:1728
+msgctxt "system cursor name"
+msgid "Magnifier"
+msgstr "Лупа"
+
+#: ../src/propgrid/advprops.cpp:1729
+msgctxt "system cursor name"
+msgid "Middle Button"
+msgstr "Середня кнопка"
+
+#: ../src/propgrid/advprops.cpp:1730
+msgctxt "system cursor name"
+msgid "No Entry"
+msgstr "Вхід заборонено"
+
+#: ../src/propgrid/advprops.cpp:1731
+msgctxt "system cursor name"
+msgid "Paint Brush"
+msgstr "Кінчик пензля"
+
+#: ../src/propgrid/advprops.cpp:1732
+msgctxt "system cursor name"
+msgid "Pencil"
+msgstr "Олівець"
+
+#: ../src/propgrid/advprops.cpp:1733
+msgctxt "system cursor name"
+msgid "Point Left"
+msgstr "Вказівник ліворуч"
+
+#: ../src/propgrid/advprops.cpp:1734
+msgctxt "system cursor name"
+msgid "Point Right"
+msgstr "Вказівник праворуч"
+
+#: ../src/propgrid/advprops.cpp:1735
+msgctxt "system cursor name"
+msgid "Question Arrow"
+msgstr "Стрілка зі знаком питання"
+
+#: ../src/propgrid/advprops.cpp:1736
+msgctxt "system cursor name"
+msgid "Right Button"
+msgstr "Права кнопка"
+
+#: ../src/propgrid/advprops.cpp:1737
+msgctxt "system cursor name"
+msgid "Sizing NE-SW"
+msgstr "Розмірний ПнСх-ПдЗх"
+
+#: ../src/propgrid/advprops.cpp:1738
+msgctxt "system cursor name"
+msgid "Sizing N-S"
+msgstr "Розмірний Пн-Пд"
+
+#: ../src/propgrid/advprops.cpp:1739
+msgctxt "system cursor name"
+msgid "Sizing NW-SE"
+msgstr "Розмірний ПнЗх-ПдСх"
+
+#: ../src/propgrid/advprops.cpp:1740
+msgctxt "system cursor name"
+msgid "Sizing W-E"
+msgstr "Розмірний Зх-Сх"
+
+#: ../src/propgrid/advprops.cpp:1741
+msgctxt "system cursor name"
+msgid "Sizing"
+msgstr "Зміна розміру"
+
+#: ../src/propgrid/advprops.cpp:1742
+msgctxt "system cursor name"
+msgid "Spraycan"
+msgstr "Пульверизатор"
+
+#: ../src/propgrid/advprops.cpp:1743
+msgctxt "system cursor name"
+msgid "Wait"
+msgstr "Очікування"
+
+#: ../src/propgrid/advprops.cpp:1744
+msgctxt "system cursor name"
+msgid "Watch"
+msgstr "Спостереження"
+
+#: ../src/propgrid/advprops.cpp:1745
+msgctxt "system cursor name"
+msgid "Wait Arrow"
+msgstr "Стрілка очікування"
+
+#: ../src/propgrid/advprops.cpp:2109
+msgid "Make a selection:"
+msgstr "Зробіть вибір:"
+
+#: ../src/propgrid/manager.cpp:394
+msgid "Property"
+msgstr "Властивість"
+
+#: ../src/propgrid/manager.cpp:395
+msgid "Value"
+msgstr "Значення"
+
+#: ../src/propgrid/manager.cpp:1683
+msgid "Categorized Mode"
+msgstr "Режим з категоризацією"
+
+#: ../src/propgrid/manager.cpp:1709
+msgid "Alphabetic Mode"
+msgstr "Абетковий режим"
+
+#. TRANSLATORS: Name of Boolean false value
+#: ../src/propgrid/propgrid.cpp:230
+msgid "False"
+msgstr "Ні"
+
+#. TRANSLATORS: Name of Boolean true value
+#: ../src/propgrid/propgrid.cpp:232
+msgid "True"
+msgstr "Так"
+
+#. TRANSLATORS: Text  displayed for unspecified value
+#: ../src/propgrid/propgrid.cpp:428
+msgid "Unspecified"
+msgstr "Не вказано"
+
+#. TRANSLATORS: Caption of message box displaying any property error
+#: ../src/propgrid/propgrid.cpp:3145 ../src/propgrid/propgrid.cpp:3282
+msgid "Property Error"
+msgstr "Редактор властивостей"
+
+#: ../src/propgrid/propgrid.cpp:3259
+msgid "You have entered invalid value. Press ESC to cancel editing."
+msgstr ""
+"Вами введено некоректне значення. Натисніть ESC, щоб скасувати редагування."
+
+#: ../src/propgrid/propgrid.cpp:6608
+#, c-format
+msgid "Error in resource: %s"
+msgstr "Помилка у ресурсі: %s"
+
+#: ../src/propgrid/propgridiface.cpp:377
+#, c-format
+msgid ""
+"Type operation \"%s\" failed: Property labeled \"%s\" is of type \"%s\", NOT "
+"\"%s\"."
+msgstr ""
+"Помилка дії з типами «%s»: властивість з міткою «%s» належить до типу «%s», "
+"а не «%s»."
+
+#: ../src/propgrid/props.cpp:159
+#, c-format
+msgid "Unknown base %d. Base 10 will be used."
+msgstr "Невідома основа числення %d. Буде використано основу числення 10."
+
+#: ../src/propgrid/props.cpp:324
+#, c-format
+msgid "Value must be %s or higher."
+msgstr "Значення має бути рівним або більшим за %s."
+
+#: ../src/propgrid/props.cpp:329 ../src/propgrid/props.cpp:356
+#, c-format
+msgid "Value must be between %s and %s."
+msgstr "Значення має належати проміжку від %s до %s."
+
+#: ../src/propgrid/props.cpp:351
+#, c-format
+msgid "Value must be %s or less."
+msgstr "Значення має бути рівним або меншим за %s."
+
+#: ../src/propgrid/props.cpp:1058
+#, c-format
+msgid "Not %s"
+msgstr "Не %s"
+
+#: ../src/propgrid/props.cpp:1770
+msgid "Choose a directory:"
+msgstr "Виберіть каталог:"
+
+#: ../src/propgrid/props.cpp:2055
+msgid "Choose a file"
+msgstr "Виберіть файл"
+
+#: ../src/qt/mdi.cpp:254
+msgid "&Tile"
+msgstr "&Мозаїка"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:147
+#: ../src/richtext/richtextformatdlg.cpp:376
+msgid "Background"
+msgstr "Тло"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:159
+msgid "Background &colour:"
+msgstr "Колір т&ла:"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:161
+#: ../src/richtext/richtextbackgroundpage.cpp:163
+msgid "Enables a background colour."
+msgstr "Вмикає колір тла."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:167
+#: ../src/richtext/richtextbackgroundpage.cpp:169
+msgid "The background colour."
+msgstr "Колір тла."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:178
+msgid "Shadow"
+msgstr "Тінь"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:193
+msgid "Use &shadow"
+msgstr "&Тінь"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:195
+#: ../src/richtext/richtextbackgroundpage.cpp:197
+msgid "Enables a shadow."
+msgstr "Вмикає тінь."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:211
+msgid "&Horizontal offset:"
+msgstr "&Горизонтальний зсув:"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:218
+#: ../src/richtext/richtextbackgroundpage.cpp:220
+msgid "The horizontal offset."
+msgstr "Горизонтальний зсув."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:224
+#: ../src/richtext/richtextbackgroundpage.cpp:227
+#: ../src/richtext/richtextbackgroundpage.cpp:228
+#: ../src/richtext/richtextbackgroundpage.cpp:247
+#: ../src/richtext/richtextbackgroundpage.cpp:250
+#: ../src/richtext/richtextbackgroundpage.cpp:251
+#: ../src/richtext/richtextbackgroundpage.cpp:287
+#: ../src/richtext/richtextbackgroundpage.cpp:290
+#: ../src/richtext/richtextbackgroundpage.cpp:291
+#: ../src/richtext/richtextbackgroundpage.cpp:314
+#: ../src/richtext/richtextbackgroundpage.cpp:317
+#: ../src/richtext/richtextbackgroundpage.cpp:318
+#: ../src/richtext/richtextborderspage.cpp:252
+#: ../src/richtext/richtextborderspage.cpp:255
+#: ../src/richtext/richtextborderspage.cpp:256
+#: ../src/richtext/richtextborderspage.cpp:286
+#: ../src/richtext/richtextborderspage.cpp:289
+#: ../src/richtext/richtextborderspage.cpp:290
+#: ../src/richtext/richtextborderspage.cpp:320
+#: ../src/richtext/richtextborderspage.cpp:323
+#: ../src/richtext/richtextborderspage.cpp:324
+#: ../src/richtext/richtextborderspage.cpp:354
+#: ../src/richtext/richtextborderspage.cpp:357
+#: ../src/richtext/richtextborderspage.cpp:358
+#: ../src/richtext/richtextborderspage.cpp:420
+#: ../src/richtext/richtextborderspage.cpp:423
+#: ../src/richtext/richtextborderspage.cpp:424
+#: ../src/richtext/richtextborderspage.cpp:454
+#: ../src/richtext/richtextborderspage.cpp:457
+#: ../src/richtext/richtextborderspage.cpp:458
+#: ../src/richtext/richtextborderspage.cpp:488
+#: ../src/richtext/richtextborderspage.cpp:491
+#: ../src/richtext/richtextborderspage.cpp:492
+#: ../src/richtext/richtextborderspage.cpp:522
+#: ../src/richtext/richtextborderspage.cpp:525
+#: ../src/richtext/richtextborderspage.cpp:526
+#: ../src/richtext/richtextborderspage.cpp:590
+#: ../src/richtext/richtextborderspage.cpp:593
+#: ../src/richtext/richtextborderspage.cpp:594
+#: ../src/richtext/richtextfontpage.cpp:177
+#: ../src/richtext/richtextmarginspage.cpp:199
+#: ../src/richtext/richtextmarginspage.cpp:201
+#: ../src/richtext/richtextmarginspage.cpp:202
+#: ../src/richtext/richtextmarginspage.cpp:224
+#: ../src/richtext/richtextmarginspage.cpp:226
+#: ../src/richtext/richtextmarginspage.cpp:227
+#: ../src/richtext/richtextmarginspage.cpp:247
+#: ../src/richtext/richtextmarginspage.cpp:249
+#: ../src/richtext/richtextmarginspage.cpp:250
+#: ../src/richtext/richtextmarginspage.cpp:272
+#: ../src/richtext/richtextmarginspage.cpp:274
+#: ../src/richtext/richtextmarginspage.cpp:275
+#: ../src/richtext/richtextmarginspage.cpp:313
+#: ../src/richtext/richtextmarginspage.cpp:315
+#: ../src/richtext/richtextmarginspage.cpp:316
+#: ../src/richtext/richtextmarginspage.cpp:338
+#: ../src/richtext/richtextmarginspage.cpp:340
+#: ../src/richtext/richtextmarginspage.cpp:341
+#: ../src/richtext/richtextmarginspage.cpp:361
+#: ../src/richtext/richtextmarginspage.cpp:363
+#: ../src/richtext/richtextmarginspage.cpp:364
+#: ../src/richtext/richtextmarginspage.cpp:386
+#: ../src/richtext/richtextmarginspage.cpp:388
+#: ../src/richtext/richtextmarginspage.cpp:389
+#: ../src/richtext/richtextsizepage.cpp:337
+#: ../src/richtext/richtextsizepage.cpp:340
+#: ../src/richtext/richtextsizepage.cpp:341
+#: ../src/richtext/richtextsizepage.cpp:371
+#: ../src/richtext/richtextsizepage.cpp:374
+#: ../src/richtext/richtextsizepage.cpp:375
+#: ../src/richtext/richtextsizepage.cpp:398
+#: ../src/richtext/richtextsizepage.cpp:401
+#: ../src/richtext/richtextsizepage.cpp:402
+#: ../src/richtext/richtextsizepage.cpp:425
+#: ../src/richtext/richtextsizepage.cpp:428
+#: ../src/richtext/richtextsizepage.cpp:429
+#: ../src/richtext/richtextsizepage.cpp:452
+#: ../src/richtext/richtextsizepage.cpp:455
+#: ../src/richtext/richtextsizepage.cpp:456
+#: ../src/richtext/richtextsizepage.cpp:479
+#: ../src/richtext/richtextsizepage.cpp:482
+#: ../src/richtext/richtextsizepage.cpp:483
+#: ../src/richtext/richtextsizepage.cpp:553
+#: ../src/richtext/richtextsizepage.cpp:556
+#: ../src/richtext/richtextsizepage.cpp:557
+#: ../src/richtext/richtextsizepage.cpp:588
+#: ../src/richtext/richtextsizepage.cpp:591
+#: ../src/richtext/richtextsizepage.cpp:592
+#: ../src/richtext/richtextsizepage.cpp:623
+#: ../src/richtext/richtextsizepage.cpp:626
+#: ../src/richtext/richtextsizepage.cpp:627
+#: ../src/richtext/richtextsizepage.cpp:658
+#: ../src/richtext/richtextsizepage.cpp:661
+#: ../src/richtext/richtextsizepage.cpp:662
+msgid "px"
+msgstr "пк"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:225
+#: ../src/richtext/richtextbackgroundpage.cpp:248
+#: ../src/richtext/richtextbackgroundpage.cpp:288
+#: ../src/richtext/richtextbackgroundpage.cpp:315
+#: ../src/richtext/richtextborderspage.cpp:253
+#: ../src/richtext/richtextborderspage.cpp:287
+#: ../src/richtext/richtextborderspage.cpp:321
+#: ../src/richtext/richtextborderspage.cpp:355
+#: ../src/richtext/richtextborderspage.cpp:421
+#: ../src/richtext/richtextborderspage.cpp:455
+#: ../src/richtext/richtextborderspage.cpp:489
+#: ../src/richtext/richtextborderspage.cpp:523
+#: ../src/richtext/richtextborderspage.cpp:591
+#: ../src/richtext/richtextmarginspage.cpp:200
+#: ../src/richtext/richtextmarginspage.cpp:225
+#: ../src/richtext/richtextmarginspage.cpp:248
+#: ../src/richtext/richtextmarginspage.cpp:273
+#: ../src/richtext/richtextmarginspage.cpp:314
+#: ../src/richtext/richtextmarginspage.cpp:339
+#: ../src/richtext/richtextmarginspage.cpp:362
+#: ../src/richtext/richtextmarginspage.cpp:387
+#: ../src/richtext/richtextsizepage.cpp:338
+#: ../src/richtext/richtextsizepage.cpp:372
+#: ../src/richtext/richtextsizepage.cpp:399
+#: ../src/richtext/richtextsizepage.cpp:426
+#: ../src/richtext/richtextsizepage.cpp:453
+#: ../src/richtext/richtextsizepage.cpp:480
+#: ../src/richtext/richtextsizepage.cpp:554
+#: ../src/richtext/richtextsizepage.cpp:589
+#: ../src/richtext/richtextsizepage.cpp:624
+#: ../src/richtext/richtextsizepage.cpp:659
+msgid "cm"
+msgstr "см"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:226
+#: ../src/richtext/richtextbackgroundpage.cpp:249
+#: ../src/richtext/richtextbackgroundpage.cpp:289
+#: ../src/richtext/richtextbackgroundpage.cpp:316
+#: ../src/richtext/richtextborderspage.cpp:254
+#: ../src/richtext/richtextborderspage.cpp:288
+#: ../src/richtext/richtextborderspage.cpp:322
+#: ../src/richtext/richtextborderspage.cpp:356
+#: ../src/richtext/richtextborderspage.cpp:422
+#: ../src/richtext/richtextborderspage.cpp:456
+#: ../src/richtext/richtextborderspage.cpp:490
+#: ../src/richtext/richtextborderspage.cpp:524
+#: ../src/richtext/richtextborderspage.cpp:592
+#: ../src/richtext/richtextfontpage.cpp:176
+#: ../src/richtext/richtextfontpage.cpp:179
+msgid "pt"
+msgstr "пт"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:229
+#: ../src/richtext/richtextbackgroundpage.cpp:231
+#: ../src/richtext/richtextbackgroundpage.cpp:252
+#: ../src/richtext/richtextbackgroundpage.cpp:254
+#: ../src/richtext/richtextbackgroundpage.cpp:292
+#: ../src/richtext/richtextbackgroundpage.cpp:294
+#: ../src/richtext/richtextbackgroundpage.cpp:319
+#: ../src/richtext/richtextbackgroundpage.cpp:321
+msgid "Units for this value."
+msgstr "Одиниці виміру цього значення."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:234
+msgid "&Vertical offset:"
+msgstr "&Вертикальний зсув:"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:241
+#: ../src/richtext/richtextbackgroundpage.cpp:243
+msgid "The vertical offset."
+msgstr "Вертикальний зсув."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:257
+msgid "Shadow c&olour:"
+msgstr "Ко&лір тіні:"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:259
+#: ../src/richtext/richtextbackgroundpage.cpp:261
+msgid "Enables the shadow colour."
+msgstr "Вмикає колір тіні."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:265
+#: ../src/richtext/richtextbackgroundpage.cpp:267
+msgid "The shadow colour."
+msgstr "Колір тіні."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:270
+msgid "Sh&adow spread:"
+msgstr "По&ширення тіні:"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:272
+#: ../src/richtext/richtextbackgroundpage.cpp:274
+msgid "Enables the shadow spread."
+msgstr "Вмикає поширення тіні."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:281
+#: ../src/richtext/richtextbackgroundpage.cpp:283
+msgid "The shadow spread."
+msgstr "Поширення тіні."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:297
+msgid "&Blur distance:"
+msgstr "Відстань &розмиття"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:299
+#: ../src/richtext/richtextbackgroundpage.cpp:301
+msgid "Enables the blur distance."
+msgstr "Вмикає відстань розмиття."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:308
+#: ../src/richtext/richtextbackgroundpage.cpp:310
+msgid "The shadow blur distance."
+msgstr "Відстань розмиття тіні."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:324
+msgid "Opaci&ty:"
+msgstr "Н&епрозорість:"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:326
+#: ../src/richtext/richtextbackgroundpage.cpp:328
+msgid "Enables the shadow opacity."
+msgstr "Вмикає непрозорість тіні."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:335
+#: ../src/richtext/richtextbackgroundpage.cpp:337
+msgid "The shadow opacity."
+msgstr "Непрозорість тіні."
+
+#. TRANSLATORS: Rich text page units (percentage)
+#: ../src/richtext/richtextbackgroundpage.cpp:340
+#: ../src/richtext/richtextsizepage.cpp:339
+#: ../src/richtext/richtextsizepage.cpp:373
+#: ../src/richtext/richtextsizepage.cpp:400
+#: ../src/richtext/richtextsizepage.cpp:427
+#: ../src/richtext/richtextsizepage.cpp:454
+#: ../src/richtext/richtextsizepage.cpp:481
+#: ../src/richtext/richtextsizepage.cpp:555
+#: ../src/richtext/richtextsizepage.cpp:590
+#: ../src/richtext/richtextsizepage.cpp:625
+#: ../src/richtext/richtextsizepage.cpp:660
+msgid "%"
+msgstr "%"
+
+#: ../src/richtext/richtextborderspage.cpp:229
+#: ../src/richtext/richtextborderspage.cpp:387
+msgid "Border"
+msgstr "Рамка"
+
+#: ../src/richtext/richtextborderspage.cpp:242
+#: ../src/richtext/richtextborderspage.cpp:410
+#: ../src/richtext/richtextindentspage.cpp:194
+#: ../src/richtext/richtextliststylepage.cpp:384
+#: ../src/richtext/richtextmarginspage.cpp:185
+#: ../src/richtext/richtextmarginspage.cpp:299
+#: ../src/richtext/richtextsizepage.cpp:531
+#: ../src/richtext/richtextsizepage.cpp:538
+msgid "&Left:"
+msgstr "&Ліворуч:"
+
+#: ../src/richtext/richtextborderspage.cpp:257
+#: ../src/richtext/richtextborderspage.cpp:259
+msgid "Units for the left border width."
+msgstr "Одиниці виміру ширини лівої частини рамки."
+
+#: ../src/richtext/richtextborderspage.cpp:266
+#: ../src/richtext/richtextborderspage.cpp:268
+#: ../src/richtext/richtextborderspage.cpp:300
+#: ../src/richtext/richtextborderspage.cpp:302
+#: ../src/richtext/richtextborderspage.cpp:334
+#: ../src/richtext/richtextborderspage.cpp:336
+#: ../src/richtext/richtextborderspage.cpp:368
+#: ../src/richtext/richtextborderspage.cpp:370
+#: ../src/richtext/richtextborderspage.cpp:434
+#: ../src/richtext/richtextborderspage.cpp:436
+#: ../src/richtext/richtextborderspage.cpp:468
+#: ../src/richtext/richtextborderspage.cpp:470
+#: ../src/richtext/richtextborderspage.cpp:502
+#: ../src/richtext/richtextborderspage.cpp:504
+#: ../src/richtext/richtextborderspage.cpp:536
+#: ../src/richtext/richtextborderspage.cpp:538
+msgid "The border line style."
+msgstr "Стиль лінії рамки."
+
+#: ../src/richtext/richtextborderspage.cpp:276
+#: ../src/richtext/richtextborderspage.cpp:444
+#: ../src/richtext/richtextindentspage.cpp:212
+#: ../src/richtext/richtextliststylepage.cpp:402
+#: ../src/richtext/richtextmarginspage.cpp:210
+#: ../src/richtext/richtextmarginspage.cpp:324
+#: ../src/richtext/richtextsizepage.cpp:601
+#: ../src/richtext/richtextsizepage.cpp:608
+msgid "&Right:"
+msgstr "&Правий:"
+
+#: ../src/richtext/richtextborderspage.cpp:291
+#: ../src/richtext/richtextborderspage.cpp:293
+msgid "Units for the right border width."
+msgstr "Одиниці виміру ширини правої частини рамки."
+
+#: ../src/richtext/richtextborderspage.cpp:310
+#: ../src/richtext/richtextborderspage.cpp:478
+#: ../src/richtext/richtextmarginspage.cpp:233
+#: ../src/richtext/richtextmarginspage.cpp:347
+#: ../src/richtext/richtextsizepage.cpp:566
+#: ../src/richtext/richtextsizepage.cpp:573
+msgid "&Top:"
+msgstr "В&ерхнє:"
+
+#: ../src/richtext/richtextborderspage.cpp:325
+#: ../src/richtext/richtextborderspage.cpp:327
+msgid "Units for the top border width."
+msgstr "Одиниці виміру ширини верхньої частини рамки."
+
+#: ../src/richtext/richtextborderspage.cpp:344
+#: ../src/richtext/richtextborderspage.cpp:512
+#: ../src/richtext/richtextmarginspage.cpp:258
+#: ../src/richtext/richtextmarginspage.cpp:372
+#: ../src/richtext/richtextsizepage.cpp:636
+#: ../src/richtext/richtextsizepage.cpp:643
+msgid "&Bottom:"
+msgstr "&Нижнє:"
+
+#: ../src/richtext/richtextborderspage.cpp:359
+#: ../src/richtext/richtextborderspage.cpp:361
+msgid "Units for the bottom border width."
+msgstr "Одиниці виміру ширини нижньої частини рамки."
+
+#: ../src/richtext/richtextborderspage.cpp:380
+#: ../src/richtext/richtextborderspage.cpp:548
+msgid "&Synchronize values"
+msgstr "С&инхронізувати значення"
+
+#: ../src/richtext/richtextborderspage.cpp:382
+#: ../src/richtext/richtextborderspage.cpp:384
+#: ../src/richtext/richtextborderspage.cpp:550
+#: ../src/richtext/richtextborderspage.cpp:552
+msgid "Check to edit all borders simultaneously."
+msgstr "Позначте, якщо слід редагувати усі межі одночасно."
+
+#: ../src/richtext/richtextborderspage.cpp:397
+#: ../src/richtext/richtextborderspage.cpp:555
+msgid "Outline"
+msgstr "Контур"
+
+#: ../src/richtext/richtextborderspage.cpp:425
+#: ../src/richtext/richtextborderspage.cpp:427
+msgid "Units for the left outline width."
+msgstr "Одиниці виміру лівої частини контуру."
+
+#: ../src/richtext/richtextborderspage.cpp:459
+#: ../src/richtext/richtextborderspage.cpp:461
+msgid "Units for the right outline width."
+msgstr "Одиниці виміру правої частини контуру."
+
+#: ../src/richtext/richtextborderspage.cpp:493
+#: ../src/richtext/richtextborderspage.cpp:495
+msgid "Units for the top outline width."
+msgstr "Одиниці виміру верхньої частини контуру."
+
+#: ../src/richtext/richtextborderspage.cpp:527
+#: ../src/richtext/richtextborderspage.cpp:529
+msgid "Units for the bottom outline width."
+msgstr "Одиниці виміру нижньої частини контуру."
+
+#: ../src/richtext/richtextborderspage.cpp:565
+#: ../src/richtext/richtextborderspage.cpp:600
+msgid "Corner"
+msgstr "Кут"
+
+#: ../src/richtext/richtextborderspage.cpp:574
+msgid "Corner &radius:"
+msgstr "&Радіус закруглення:"
+
+#: ../src/richtext/richtextborderspage.cpp:576
+#: ../src/richtext/richtextborderspage.cpp:578
+msgid "An optional corner radius for adding rounded corners."
+msgstr "Необов’язковий радіус закруглення кутів."
+
+#: ../src/richtext/richtextborderspage.cpp:584
+#: ../src/richtext/richtextborderspage.cpp:586
+msgid "The value of the corner radius."
+msgstr "Значення радіуса закруглення."
+
+#: ../src/richtext/richtextborderspage.cpp:595
+#: ../src/richtext/richtextborderspage.cpp:597
+msgid "Units for the corner radius."
+msgstr "Одиниці виміру радіуса закруглення."
+
+#: ../src/richtext/richtextborderspage.cpp:609
+#: ../src/richtext/richtextsizepage.cpp:247
+#: ../src/richtext/richtextsizepage.cpp:251
+msgid "None"
+msgstr "Немає"
+
+#: ../src/richtext/richtextborderspage.cpp:610
+msgid "Solid"
+msgstr "Суцільна"
+
+#: ../src/richtext/richtextborderspage.cpp:611
+msgid "Dotted"
+msgstr "Пунктир"
+
+#: ../src/richtext/richtextborderspage.cpp:612
+msgid "Dashed"
+msgstr "Штрихова"
+
+#: ../src/richtext/richtextborderspage.cpp:613
+msgid "Double"
+msgstr "Подвійна"
+
+#: ../src/richtext/richtextborderspage.cpp:614
+msgid "Groove"
+msgstr "Виступ"
+
+#: ../src/richtext/richtextborderspage.cpp:615
+msgid "Ridge"
+msgstr "Гребінь"
+
+#: ../src/richtext/richtextborderspage.cpp:616
+msgid "Inset"
+msgstr "Вкладка"
+
+#: ../src/richtext/richtextborderspage.cpp:617
+msgid "Outset"
+msgstr "Накладка"
+
+#: ../src/richtext/richtextbuffer.cpp:3518
+msgid "Change Style"
+msgstr "Змінити стиль"
+
+#: ../src/richtext/richtextbuffer.cpp:3701
+msgid "Change Object Style"
+msgstr "Змінити стиль об’єкта"
+
+#: ../src/richtext/richtextbuffer.cpp:3974
+#: ../src/richtext/richtextbuffer.cpp:8174
+msgid "Change Properties"
+msgstr "Змінити властивості"
+
+#: ../src/richtext/richtextbuffer.cpp:4346
+msgid "Change List Style"
+msgstr "Змінити стиль списку"
+
+#: ../src/richtext/richtextbuffer.cpp:4519
+msgid "Renumber List"
+msgstr "Перенумерувати список"
+
+#: ../src/richtext/richtextbuffer.cpp:7867
+#: ../src/richtext/richtextbuffer.cpp:7897
+#: ../src/richtext/richtextbuffer.cpp:7939
+#: ../src/richtext/richtextctrl.cpp:1279 ../src/richtext/richtextctrl.cpp:1473
+msgid "Insert Text"
+msgstr "Вставити текст"
+
+#: ../src/richtext/richtextbuffer.cpp:8023
+#: ../src/richtext/richtextbuffer.cpp:8979
+msgid "Insert Image"
+msgstr "Вставити картинку"
+
+#: ../src/richtext/richtextbuffer.cpp:8070
+msgid "Insert Object"
+msgstr "Вставити об’єкт"
+
+#: ../src/richtext/richtextbuffer.cpp:8112
+msgid "Insert Field"
+msgstr "Вставити поле"
+
+#: ../src/richtext/richtextbuffer.cpp:8410
+msgid "Too many EndStyle calls!"
+msgstr "Забагато викликів EndStyle!"
+
+#: ../src/richtext/richtextbuffer.cpp:8785
+msgid "files"
+msgstr "файли"
+
+#: ../src/richtext/richtextbuffer.cpp:9380
+msgid "standard/circle"
+msgstr "стандартний/коло"
+
+#: ../src/richtext/richtextbuffer.cpp:9381
+msgid "standard/circle-outline"
+msgstr "стандартний/круговий контур"
+
+#: ../src/richtext/richtextbuffer.cpp:9382
+msgid "standard/square"
+msgstr "стандартний/квадрат"
+
+#: ../src/richtext/richtextbuffer.cpp:9383
+msgid "standard/diamond"
+msgstr "стандартний/ромб"
+
+#: ../src/richtext/richtextbuffer.cpp:9384
+msgid "standard/triangle"
+msgstr "стандартний/трикутник"
+
+#: ../src/richtext/richtextbuffer.cpp:9423
+msgid "Box Properties"
+msgstr "Властивості рамок"
+
+#: ../src/richtext/richtextbuffer.cpp:10006
+msgid "Multiple Cell Properties"
+msgstr "Властивості декількох комірок"
+
+#: ../src/richtext/richtextbuffer.cpp:10008
+msgid "Cell Properties"
+msgstr "Властивості комірки"
+
+#: ../src/richtext/richtextbuffer.cpp:11256
+msgid "Set Cell Style"
+msgstr "Встановити стиль комірки"
+
+#: ../src/richtext/richtextbuffer.cpp:11330
+msgid "Delete Row"
+msgstr "Вилучити рядок"
+
+#: ../src/richtext/richtextbuffer.cpp:11380
+msgid "Delete Column"
+msgstr "Вилучити стовпчик"
+
+#: ../src/richtext/richtextbuffer.cpp:11431
+msgid "Add Row"
+msgstr "Додати рядок"
+
+#: ../src/richtext/richtextbuffer.cpp:11494
+msgid "Add Column"
+msgstr "Додати стовпчик"
+
+#: ../src/richtext/richtextbuffer.cpp:11537
+msgid "Table Properties"
+msgstr "Властивості таблиці"
+
+#: ../src/richtext/richtextbuffer.cpp:12899
+msgid "Picture Properties"
+msgstr "Властивості малюнка"
+
+#: ../src/richtext/richtextbuffer.cpp:13169
+#: ../src/richtext/richtextbuffer.cpp:13279
+msgid "image"
+msgstr "картинка"
+
+#: ../src/richtext/richtextbulletspage.cpp:145
+#: ../src/richtext/richtextliststylepage.cpp:209
+msgid "&Bullet style:"
+msgstr "Стиль &позначки:"
+
+#: ../src/richtext/richtextbulletspage.cpp:150
+#: ../src/richtext/richtextbulletspage.cpp:152
+#: ../src/richtext/richtextliststylepage.cpp:214
+#: ../src/richtext/richtextliststylepage.cpp:216
+msgid "The available bullet styles."
+msgstr "Доступні стилі позначок."
+
+#: ../src/richtext/richtextbulletspage.cpp:158
+#: ../src/richtext/richtextliststylepage.cpp:221
+msgid "Peri&od"
+msgstr "То&чка"
+
+#: ../src/richtext/richtextbulletspage.cpp:160
+#: ../src/richtext/richtextbulletspage.cpp:162
+#: ../src/richtext/richtextliststylepage.cpp:223
+#: ../src/richtext/richtextliststylepage.cpp:225
+msgid "Check to add a period after the bullet."
+msgstr "Позначте, щоб додати точку після позначки."
+
+#. TRANSLATORS: Bullet point in parentheses option
+#: ../src/richtext/richtextbulletspage.cpp:167
+#: ../src/richtext/richtextliststylepage.cpp:230
+msgid "(*)"
+msgstr "(*)"
+
+#: ../src/richtext/richtextbulletspage.cpp:169
+#: ../src/richtext/richtextbulletspage.cpp:171
+#: ../src/richtext/richtextliststylepage.cpp:232
+#: ../src/richtext/richtextliststylepage.cpp:234
+msgid "Check to enclose the bullet in parentheses."
+msgstr "Позначте, щоб додати до позначки дужку."
+
+#. TRANSLATORS: Right parenthesis bullet point option
+#: ../src/richtext/richtextbulletspage.cpp:176
+#: ../src/richtext/richtextliststylepage.cpp:239
+msgid "*)"
+msgstr "*)"
+
+#: ../src/richtext/richtextbulletspage.cpp:178
+#: ../src/richtext/richtextbulletspage.cpp:180
+#: ../src/richtext/richtextliststylepage.cpp:241
+#: ../src/richtext/richtextliststylepage.cpp:243
+msgid "Check to add a right parenthesis."
+msgstr "Позначте, щоб додати праву дужку"
+
+#: ../src/richtext/richtextbulletspage.cpp:185
+#: ../src/richtext/richtextliststylepage.cpp:248
+msgid "Bullet &Alignment:"
+msgstr "&Вирівнювання позначки:"
+
+#: ../src/richtext/richtextbulletspage.cpp:190
+#: ../src/richtext/richtextliststylepage.cpp:253
+msgid "Centre"
+msgstr "Центр"
+
+#: ../src/richtext/richtextbulletspage.cpp:194
+#: ../src/richtext/richtextbulletspage.cpp:196
+#: ../src/richtext/richtextbulletspage.cpp:217
+#: ../src/richtext/richtextbulletspage.cpp:219
+#: ../src/richtext/richtextliststylepage.cpp:257
+#: ../src/richtext/richtextliststylepage.cpp:259
+#: ../src/richtext/richtextliststylepage.cpp:278
+#: ../src/richtext/richtextliststylepage.cpp:280
+msgid "The bullet character."
+msgstr "Символ позначки."
+
+#: ../src/richtext/richtextbulletspage.cpp:212
+#: ../src/richtext/richtextliststylepage.cpp:271
+msgid "&Symbol:"
+msgstr "&Символ:"
+
+#: ../src/richtext/richtextbulletspage.cpp:222
+#: ../src/richtext/richtextliststylepage.cpp:283
+msgid "Ch&oose..."
+msgstr "Об&рати…"
+
+#: ../src/richtext/richtextbulletspage.cpp:223
+#: ../src/richtext/richtextbulletspage.cpp:225
+#: ../src/richtext/richtextliststylepage.cpp:284
+#: ../src/richtext/richtextliststylepage.cpp:286
+msgid "Click to browse for a symbol."
+msgstr "Клацніть, щоб відшукати символ."
+
+#: ../src/richtext/richtextbulletspage.cpp:230
+#: ../src/richtext/richtextliststylepage.cpp:291
+msgid "Symbol &font:"
+msgstr "Шрифт для &символів:"
+
+#: ../src/richtext/richtextbulletspage.cpp:235
+#: ../src/richtext/richtextbulletspage.cpp:237
+#: ../src/richtext/richtextliststylepage.cpp:297
+msgid "Available fonts."
+msgstr "Доступні шрифти."
+
+#: ../src/richtext/richtextbulletspage.cpp:242
+#: ../src/richtext/richtextliststylepage.cpp:302
+msgid "S&tandard bullet name:"
+msgstr "Назва ста&ндартної позначки:"
+
+#: ../src/richtext/richtextbulletspage.cpp:247
+#: ../src/richtext/richtextbulletspage.cpp:249
+#: ../src/richtext/richtextliststylepage.cpp:307
+#: ../src/richtext/richtextliststylepage.cpp:309
+msgid "A standard bullet name."
+msgstr "Назва стандартної позначки."
+
+#: ../src/richtext/richtextbulletspage.cpp:254
+msgid "&Number:"
+msgstr "&Номер:"
+
+#: ../src/richtext/richtextbulletspage.cpp:258
+#: ../src/richtext/richtextbulletspage.cpp:260
+msgid "The list item number."
+msgstr "Номер елемента у списку."
+
+#: ../src/richtext/richtextbulletspage.cpp:266
+#: ../src/richtext/richtextbulletspage.cpp:268
+#: ../src/richtext/richtextliststylepage.cpp:475
+#: ../src/richtext/richtextliststylepage.cpp:477
+msgid "Shows a preview of the bullet settings."
+msgstr "Показує попередній перегляд параметрів для позначок."
+
+#: ../src/richtext/richtextbulletspage.cpp:276
+#: ../src/richtext/richtextliststylepage.cpp:484
+msgid "(None)"
+msgstr "(Відсутній)"
+
+#: ../src/richtext/richtextbulletspage.cpp:277
+#: ../src/richtext/richtextliststylepage.cpp:485
+msgid "Arabic"
+msgstr "Арабські"
+
+#: ../src/richtext/richtextbulletspage.cpp:278
+#: ../src/richtext/richtextliststylepage.cpp:486
+msgid "Upper case letters"
+msgstr "Літери у верхньому регістрі"
+
+#: ../src/richtext/richtextbulletspage.cpp:279
+#: ../src/richtext/richtextliststylepage.cpp:487
+msgid "Lower case letters"
+msgstr "Літери нижнього регістру"
+
+#: ../src/richtext/richtextbulletspage.cpp:280
+#: ../src/richtext/richtextliststylepage.cpp:488
+msgid "Upper case roman numerals"
+msgstr "Римські цифри у верхньому регістрі"
+
+#: ../src/richtext/richtextbulletspage.cpp:281
+#: ../src/richtext/richtextliststylepage.cpp:489
+msgid "Lower case roman numerals"
+msgstr "Римські цифри у нижньому регістрі"
+
+#: ../src/richtext/richtextbulletspage.cpp:282
+#: ../src/richtext/richtextliststylepage.cpp:490
+msgid "Numbered outline"
+msgstr "Нумерована структура"
+
+#: ../src/richtext/richtextbulletspage.cpp:283
+#: ../src/richtext/richtextliststylepage.cpp:491
+msgid "Symbol"
+msgstr "Символ"
+
+#: ../src/richtext/richtextbulletspage.cpp:284
+#: ../src/richtext/richtextliststylepage.cpp:492
+msgid "Bitmap"
+msgstr "Растровий"
+
+#: ../src/richtext/richtextbulletspage.cpp:285
+#: ../src/richtext/richtextliststylepage.cpp:493
+msgid "Standard"
+msgstr "Стандартна"
+
+#: ../src/richtext/richtextbulletspage.cpp:287
+#: ../src/richtext/richtextliststylepage.cpp:495
+msgid "*"
+msgstr "*"
+
+#: ../src/richtext/richtextbulletspage.cpp:288
+#: ../src/richtext/richtextliststylepage.cpp:496
+msgid "-"
+msgstr "-"
+
+#: ../src/richtext/richtextbulletspage.cpp:289
+#: ../src/richtext/richtextliststylepage.cpp:497
+msgid ">"
+msgstr ">"
+
+#: ../src/richtext/richtextbulletspage.cpp:290
+#: ../src/richtext/richtextliststylepage.cpp:498
+msgid "+"
+msgstr "+"
+
+#: ../src/richtext/richtextbulletspage.cpp:291
+#: ../src/richtext/richtextliststylepage.cpp:499
+msgid "~"
+msgstr "~"
+
+#: ../src/richtext/richtextctrl.cpp:859
+msgid "Drag"
+msgstr "Перетягування"
+
+#: ../src/richtext/richtextctrl.cpp:1338 ../src/richtext/richtextctrl.cpp:1559
+msgid "Delete Text"
+msgstr "Вилучити текст"
+
+#: ../src/richtext/richtextctrl.cpp:1537
+msgid "Remove Bullet"
+msgstr "Вилучити позначку"
+
+#: ../src/richtext/richtextctrl.cpp:3070
+msgid "The text couldn't be saved."
+msgstr "Текст не може бути записаний."
+
+#: ../src/richtext/richtextctrl.cpp:3644
+msgid "Replace"
+msgstr "Замінити"
+
+#: ../src/richtext/richtextfontpage.cpp:146
+#: ../src/richtext/richtextsymboldlg.cpp:384
+msgid "&Font:"
+msgstr "&Шрифт:"
+
+#: ../src/richtext/richtextfontpage.cpp:150
+#: ../src/richtext/richtextfontpage.cpp:152
+msgid "Type a font name."
+msgstr "Наберіть назву шрифту."
+
+#: ../src/richtext/richtextfontpage.cpp:158
+msgid "&Size:"
+msgstr "&Розмір:"
+
+#: ../src/richtext/richtextfontpage.cpp:165
+#: ../src/richtext/richtextfontpage.cpp:167
+msgid "Type a size in points."
+msgstr "Наберіть розмір у пунктах."
+
+#: ../src/richtext/richtextfontpage.cpp:180
+#: ../src/richtext/richtextfontpage.cpp:182
+msgid "The font size units, points or pixels."
+msgstr "Одиниці виміру розміру символів шрифту, пункти або пікселі."
+
+#: ../src/richtext/richtextfontpage.cpp:189
+#: ../src/richtext/richtextfontpage.cpp:191
+msgid "Lists the available fonts."
+msgstr "Списки доступних шрифтів."
+
+#: ../src/richtext/richtextfontpage.cpp:196
+#: ../src/richtext/richtextfontpage.cpp:198
+msgid "Lists font sizes in points."
+msgstr "Показує список розмірів шрифтів у пунктах."
+
+#: ../src/richtext/richtextfontpage.cpp:207
+msgid "Font st&yle:"
+msgstr "Розмір шрифту:"
+
+#: ../src/richtext/richtextfontpage.cpp:212
+#: ../src/richtext/richtextfontpage.cpp:214
+msgid "Select regular or italic style."
+msgstr "Оберіть звичайний або курсивний стиль."
+
+#: ../src/richtext/richtextfontpage.cpp:220
+msgid "Font &weight:"
+msgstr "Вага шри&фту:"
+
+#: ../src/richtext/richtextfontpage.cpp:225
+#: ../src/richtext/richtextfontpage.cpp:227
+msgid "Select regular or bold."
+msgstr "Оберіть звичайний чи жирний."
+
+#: ../src/richtext/richtextfontpage.cpp:233
+msgid "&Underlining:"
+msgstr "&Підкреслення:"
+
+#: ../src/richtext/richtextfontpage.cpp:238
+#: ../src/richtext/richtextfontpage.cpp:240
+msgid "Select underlining or no underlining."
+msgstr "Виберіть, чи буде текст підкреслено."
+
+#: ../src/richtext/richtextfontpage.cpp:248
+msgid "&Colour:"
+msgstr "&Колір:"
+
+#: ../src/richtext/richtextfontpage.cpp:253
+#: ../src/richtext/richtextfontpage.cpp:255
+msgid "Click to change the text colour."
+msgstr "Клацніть, щоб змінити колір тексту."
+
+#: ../src/richtext/richtextfontpage.cpp:261
+msgid "&Bg colour:"
+msgstr "Ко&лір тла:"
+
+#: ../src/richtext/richtextfontpage.cpp:266
+#: ../src/richtext/richtextfontpage.cpp:268
+msgid "Click to change the text background colour."
+msgstr "Клацніть, щоб змінити колір тла."
+
+#: ../src/richtext/richtextfontpage.cpp:276
+#: ../src/richtext/richtextfontpage.cpp:278
+msgid "Check to show a line through the text."
+msgstr "Позначте, щоб додати риску перекреслення тексту."
+
+#: ../src/richtext/richtextfontpage.cpp:281
+msgid "Ca&pitals"
+msgstr "Пр&описні"
+
+#: ../src/richtext/richtextfontpage.cpp:283
+#: ../src/richtext/richtextfontpage.cpp:285
+msgid "Check to show the text in capitals."
+msgstr "Позначте, щоб текст було показано прописними літерами."
+
+#: ../src/richtext/richtextfontpage.cpp:288
+msgid "Small C&apitals"
+msgstr "&Мала капітель"
+
+#: ../src/richtext/richtextfontpage.cpp:290
+#: ../src/richtext/richtextfontpage.cpp:292
+msgid "Check to show the text in small capitals."
+msgstr "Позначте, щоб текст було показано малими прописними літерами."
+
+#: ../src/richtext/richtextfontpage.cpp:295
+msgid "Supe&rscript"
+msgstr "Вер&хній індекс"
+
+#: ../src/richtext/richtextfontpage.cpp:297
+#: ../src/richtext/richtextfontpage.cpp:299
+msgid "Check to show the text in superscript."
+msgstr "Позначте, щоб перетворити текст на верхні індекси."
+
+#: ../src/richtext/richtextfontpage.cpp:302
+msgid "Subscrip&t"
+msgstr "Ни&жній індекс"
+
+#: ../src/richtext/richtextfontpage.cpp:304
+#: ../src/richtext/richtextfontpage.cpp:306
+msgid "Check to show the text in subscript."
+msgstr "Позначте, щоб перетворити текст на нижні індекси."
+
+#: ../src/richtext/richtextfontpage.cpp:312
+msgid "Rig&ht-to-left"
+msgstr "С&права ліворуч"
+
+#: ../src/richtext/richtextfontpage.cpp:314
+#: ../src/richtext/richtextfontpage.cpp:316
+msgid "Check to indicate right-to-left text layout."
+msgstr ""
+"Позначте, щоб визначити використання писемності із записом справа ліворуч."
+
+#: ../src/richtext/richtextfontpage.cpp:319
+msgid "Suppress hyphe&nation"
+msgstr "Приду&шити перенесення слів"
+
+#: ../src/richtext/richtextfontpage.cpp:321
+#: ../src/richtext/richtextfontpage.cpp:323
+msgid "Check to suppress hyphenation."
+msgstr "Позначте, щоб придушити перенесення слів."
+
+#: ../src/richtext/richtextfontpage.cpp:329
+#: ../src/richtext/richtextfontpage.cpp:331
+msgid "Shows a preview of the font settings."
+msgstr "Показує попередній перегляд для параметрів шрифту."
+
+#: ../src/richtext/richtextfontpage.cpp:348
+#: ../src/richtext/richtextfontpage.cpp:352
+#: ../src/richtext/richtextfontpage.cpp:356
+#: ../src/richtext/richtextformatdlg.cpp:873
+#: ../src/richtext/richtextindentspage.cpp:273
+#: ../src/richtext/richtextindentspage.cpp:285
+#: ../src/richtext/richtextindentspage.cpp:286
+#: ../src/richtext/richtextindentspage.cpp:310
+#: ../src/richtext/richtextindentspage.cpp:325
+#: ../src/richtext/richtextliststylepage.cpp:451
+#: ../src/richtext/richtextliststylepage.cpp:463
+#: ../src/richtext/richtextliststylepage.cpp:464
+msgid "(none)"
+msgstr "(нічого)"
+
+#: ../src/richtext/richtextfontpage.cpp:349
+#: ../src/richtext/richtextfontpage.cpp:353
+msgid "Regular"
+msgstr "Звичайний"
+
+#: ../src/richtext/richtextfontpage.cpp:357
+msgid "Not underlined"
+msgstr "Без підкреслювання"
+
+#: ../src/richtext/richtextformatdlg.cpp:341
+msgid "Indents && Spacing"
+msgstr "Відступи та проміжки"
+
+#: ../src/richtext/richtextformatdlg.cpp:346
+msgid "Tabs"
+msgstr "Табуляції"
+
+#: ../src/richtext/richtextformatdlg.cpp:351
+msgid "Bullets"
+msgstr "Позначки"
+
+#: ../src/richtext/richtextformatdlg.cpp:356
+msgid "List Style"
+msgstr "Стиль списку"
+
+#: ../src/richtext/richtextformatdlg.cpp:366
+#: ../src/richtext/richtextmarginspage.cpp:170
+msgid "Margins"
+msgstr "Поля"
+
+#: ../src/richtext/richtextformatdlg.cpp:371
+msgid "Borders"
+msgstr "Рамки"
+
+#: ../src/richtext/richtextformatdlg.cpp:765
+msgid "Colour"
+msgstr "Колір"
+
+#: ../src/richtext/richtextindentspage.cpp:127
+#: ../src/richtext/richtextliststylepage.cpp:322
+msgid "&Alignment"
+msgstr "&Вирівнювання"
+
+#: ../src/richtext/richtextindentspage.cpp:138
+#: ../src/richtext/richtextliststylepage.cpp:331
+msgid "&Left"
+msgstr "&Ліворуч"
+
+#: ../src/richtext/richtextindentspage.cpp:140
+#: ../src/richtext/richtextindentspage.cpp:142
+#: ../src/richtext/richtextliststylepage.cpp:333
+#: ../src/richtext/richtextliststylepage.cpp:335
+msgid "Left-align text."
+msgstr "Вирівняти текст ліворуч."
+
+#: ../src/richtext/richtextindentspage.cpp:145
+#: ../src/richtext/richtextliststylepage.cpp:338
+msgid "&Right"
+msgstr "&Праворуч"
+
+#: ../src/richtext/richtextindentspage.cpp:147
+#: ../src/richtext/richtextindentspage.cpp:149
+#: ../src/richtext/richtextliststylepage.cpp:340
+#: ../src/richtext/richtextliststylepage.cpp:342
+msgid "Right-align text."
+msgstr "Текст вирівняний праворуч."
+
+#: ../src/richtext/richtextindentspage.cpp:152
+#: ../src/richtext/richtextliststylepage.cpp:345
+msgid "&Justified"
+msgstr "&Вирівняне"
+
+#: ../src/richtext/richtextindentspage.cpp:154
+#: ../src/richtext/richtextindentspage.cpp:156
+#: ../src/richtext/richtextliststylepage.cpp:347
+#: ../src/richtext/richtextliststylepage.cpp:349
+msgid "Justify text left and right."
+msgstr "Розподілити текст за шириною."
+
+#: ../src/richtext/richtextindentspage.cpp:159
+#: ../src/richtext/richtextliststylepage.cpp:352
+msgid "Cen&tred"
+msgstr "Цент&роване"
+
+#: ../src/richtext/richtextindentspage.cpp:161
+#: ../src/richtext/richtextindentspage.cpp:163
+#: ../src/richtext/richtextliststylepage.cpp:354
+#: ../src/richtext/richtextliststylepage.cpp:356
+msgid "Centre text."
+msgstr "Текст по центру."
+
+#: ../src/richtext/richtextindentspage.cpp:166
+#: ../src/richtext/richtextliststylepage.cpp:359
+msgid "&Indeterminate"
+msgstr "&Зняти визначене"
+
+#: ../src/richtext/richtextindentspage.cpp:168
+#: ../src/richtext/richtextindentspage.cpp:170
+#: ../src/richtext/richtextliststylepage.cpp:361
+#: ../src/richtext/richtextliststylepage.cpp:363
+msgid "Use the current alignment setting."
+msgstr "Використовувати поточні параметри вирівнювання."
+
+#: ../src/richtext/richtextindentspage.cpp:183
+#: ../src/richtext/richtextliststylepage.cpp:375
+msgid "&Indentation (tenths of a mm)"
+msgstr "&Відступ (у десятках мм)"
+
+#: ../src/richtext/richtextindentspage.cpp:198
+#: ../src/richtext/richtextindentspage.cpp:200
+#: ../src/richtext/richtextliststylepage.cpp:388
+#: ../src/richtext/richtextliststylepage.cpp:390
+msgid "The left indent."
+msgstr "Лівий відступ."
+
+#: ../src/richtext/richtextindentspage.cpp:203
+#: ../src/richtext/richtextliststylepage.cpp:393
+msgid "Left (&first line):"
+msgstr "Ліворуч (&перший рядок):"
+
+#: ../src/richtext/richtextindentspage.cpp:207
+#: ../src/richtext/richtextindentspage.cpp:209
+#: ../src/richtext/richtextliststylepage.cpp:397
+#: ../src/richtext/richtextliststylepage.cpp:399
+msgid "The first line indent."
+msgstr "Розмір шрифту:"
+
+#: ../src/richtext/richtextindentspage.cpp:216
+#: ../src/richtext/richtextindentspage.cpp:218
+#: ../src/richtext/richtextliststylepage.cpp:406
+#: ../src/richtext/richtextliststylepage.cpp:408
+msgid "The right indent."
+msgstr "Відступ праворуч."
+
+#: ../src/richtext/richtextindentspage.cpp:221
+msgid "&Outline level:"
+msgstr "&Рівень відступу:"
+
+#: ../src/richtext/richtextindentspage.cpp:226
+#: ../src/richtext/richtextindentspage.cpp:228
+msgid "The outline level."
+msgstr "Рівень відступу."
+
+#: ../src/richtext/richtextindentspage.cpp:241
+#: ../src/richtext/richtextliststylepage.cpp:420
+msgid "&Spacing (tenths of a mm)"
+msgstr "&Проміжок (у десятках мм)"
+
+#: ../src/richtext/richtextindentspage.cpp:252
+msgid "&Before a paragraph:"
+msgstr "Пе&ред абзацом:"
+
+#: ../src/richtext/richtextindentspage.cpp:256
+#: ../src/richtext/richtextindentspage.cpp:258
+#: ../src/richtext/richtextliststylepage.cpp:433
+#: ../src/richtext/richtextliststylepage.cpp:435
+msgid "The spacing before the paragraph."
+msgstr "Проміжок перед абзацом."
+
+#: ../src/richtext/richtextindentspage.cpp:261
+msgid "&After a paragraph:"
+msgstr "&Після абзацу:"
+
+#: ../src/richtext/richtextindentspage.cpp:266
+#: ../src/richtext/richtextliststylepage.cpp:442
+#: ../src/richtext/richtextliststylepage.cpp:444
+msgid "The spacing after the paragraph."
+msgstr "Проміжок після абзацу."
+
+#: ../src/richtext/richtextindentspage.cpp:269
+msgid "L&ine spacing:"
+msgstr "Ін&тервал між рядками:"
+
+#: ../src/richtext/richtextindentspage.cpp:274
+#: ../src/richtext/richtextliststylepage.cpp:452
+msgid "Single"
+msgstr "Одинарний"
+
+#: ../src/richtext/richtextindentspage.cpp:275
+#: ../src/richtext/richtextliststylepage.cpp:453
+msgid "1.1"
+msgstr "1,1"
+
+#: ../src/richtext/richtextindentspage.cpp:276
+#: ../src/richtext/richtextliststylepage.cpp:454
+msgid "1.2"
+msgstr "1,2"
+
+#: ../src/richtext/richtextindentspage.cpp:277
+#: ../src/richtext/richtextliststylepage.cpp:455
+msgid "1.3"
+msgstr "1,3"
+
+#: ../src/richtext/richtextindentspage.cpp:278
+#: ../src/richtext/richtextliststylepage.cpp:456
+msgid "1.4"
+msgstr "1,4"
+
+#: ../src/richtext/richtextindentspage.cpp:279
+#: ../src/richtext/richtextliststylepage.cpp:457
+msgid "1.5"
+msgstr "1,5"
+
+#: ../src/richtext/richtextindentspage.cpp:280
+#: ../src/richtext/richtextliststylepage.cpp:458
+msgid "1.6"
+msgstr "1,6"
+
+#: ../src/richtext/richtextindentspage.cpp:281
+#: ../src/richtext/richtextliststylepage.cpp:459
+msgid "1.7"
+msgstr "1,7"
+
+#: ../src/richtext/richtextindentspage.cpp:282
+#: ../src/richtext/richtextliststylepage.cpp:460
+msgid "1.8"
+msgstr "1,8"
+
+#: ../src/richtext/richtextindentspage.cpp:283
+#: ../src/richtext/richtextliststylepage.cpp:461
+msgid "1.9"
+msgstr "1,9"
+
+#: ../src/richtext/richtextindentspage.cpp:284
+#: ../src/richtext/richtextliststylepage.cpp:462
+msgid "2"
+msgstr "2"
+
+#: ../src/richtext/richtextindentspage.cpp:287
+#: ../src/richtext/richtextindentspage.cpp:289
+#: ../src/richtext/richtextliststylepage.cpp:465
+#: ../src/richtext/richtextliststylepage.cpp:467
+msgid "The line spacing."
+msgstr "Проміжок між рядками."
+
+#: ../src/richtext/richtextindentspage.cpp:292
+msgid "&Page Break"
+msgstr "&Розрив сторінки"
+
+#: ../src/richtext/richtextindentspage.cpp:294
+#: ../src/richtext/richtextindentspage.cpp:296
+msgid "Inserts a page break before the paragraph."
+msgstr "Додає розрив сторінки до абзацу."
+
+#: ../src/richtext/richtextindentspage.cpp:302
+#: ../src/richtext/richtextindentspage.cpp:304
+msgid "Shows a preview of the paragraph settings."
+msgstr "Показує попередній перегляд параметрів абзацу."
+
+#: ../src/richtext/richtextliststylepage.cpp:182
+msgid "&List level:"
+msgstr "&Рівень у списку:"
+
+#: ../src/richtext/richtextliststylepage.cpp:186
+#: ../src/richtext/richtextliststylepage.cpp:188
+msgid "Selects the list level to edit."
+msgstr "Оберіть рівень списку для редагування."
+
+#: ../src/richtext/richtextliststylepage.cpp:193
+msgid "&Font for Level..."
+msgstr "&Шрифт для рівня…"
+
+#: ../src/richtext/richtextliststylepage.cpp:194
+#: ../src/richtext/richtextliststylepage.cpp:196
+msgid "Click to choose the font for this level."
+msgstr "Клацніть, щоб обрати шрифт для цього рівня."
+
+#: ../src/richtext/richtextliststylepage.cpp:312
+msgid "Bullet style"
+msgstr "Стиль позначки"
+
+#: ../src/richtext/richtextliststylepage.cpp:429
+msgid "Before a paragraph:"
+msgstr "Перед абзацом:"
+
+#: ../src/richtext/richtextliststylepage.cpp:438
+msgid "After a paragraph:"
+msgstr "Після абзацу:"
+
+#: ../src/richtext/richtextliststylepage.cpp:447
+msgid "Line spacing:"
+msgstr "Проміжок між рядками:"
+
+#: ../src/richtext/richtextliststylepage.cpp:470
+msgid "Spacing"
+msgstr "Проміжки"
+
+#: ../src/richtext/richtextmarginspage.cpp:193
+#: ../src/richtext/richtextmarginspage.cpp:195
+msgid "The left margin size."
+msgstr "Ширина нижнього поля."
+
+#: ../src/richtext/richtextmarginspage.cpp:203
+#: ../src/richtext/richtextmarginspage.cpp:205
+msgid "Units for the left margin."
+msgstr "Одиниці виміру лівого поля."
+
+#: ../src/richtext/richtextmarginspage.cpp:218
+#: ../src/richtext/richtextmarginspage.cpp:220
+msgid "The right margin size."
+msgstr "Ширина правого поля."
+
+#: ../src/richtext/richtextmarginspage.cpp:228
+#: ../src/richtext/richtextmarginspage.cpp:230
+msgid "Units for the right margin."
+msgstr "Одиниці виміру правого поля."
+
+#: ../src/richtext/richtextmarginspage.cpp:241
+#: ../src/richtext/richtextmarginspage.cpp:243
+msgid "The top margin size."
+msgstr "Ширина верхнього поля."
+
+#: ../src/richtext/richtextmarginspage.cpp:251
+#: ../src/richtext/richtextmarginspage.cpp:253
+msgid "Units for the top margin."
+msgstr "Одиниці виміру верхнього поля."
+
+#: ../src/richtext/richtextmarginspage.cpp:266
+#: ../src/richtext/richtextmarginspage.cpp:268
+msgid "The bottom margin size."
+msgstr "Ширина нижнього поля."
+
+#: ../src/richtext/richtextmarginspage.cpp:276
+#: ../src/richtext/richtextmarginspage.cpp:278
+msgid "Units for the bottom margin."
+msgstr "Одиниці виміру нижнього поля."
+
+#: ../src/richtext/richtextmarginspage.cpp:284
+msgid "Padding"
+msgstr "Фаска"
+
+#: ../src/richtext/richtextmarginspage.cpp:307
+#: ../src/richtext/richtextmarginspage.cpp:309
+msgid "The left padding size."
+msgstr "Ширина лівої фаски."
+
+#: ../src/richtext/richtextmarginspage.cpp:317
+#: ../src/richtext/richtextmarginspage.cpp:319
+msgid "Units for the left padding."
+msgstr "Одиниці виміру лівої фаски."
+
+#: ../src/richtext/richtextmarginspage.cpp:332
+#: ../src/richtext/richtextmarginspage.cpp:334
+msgid "The right padding size."
+msgstr "Ширина правої фаски."
+
+#: ../src/richtext/richtextmarginspage.cpp:342
+#: ../src/richtext/richtextmarginspage.cpp:344
+msgid "Units for the right padding."
+msgstr "Одиниці виміру правої фаски."
+
+#: ../src/richtext/richtextmarginspage.cpp:355
+#: ../src/richtext/richtextmarginspage.cpp:357
+msgid "The top padding size."
+msgstr "Ширина верхньої фаски."
+
+#: ../src/richtext/richtextmarginspage.cpp:365
+#: ../src/richtext/richtextmarginspage.cpp:367
+msgid "Units for the top padding."
+msgstr "Одиниці виміру верхньої фаски."
+
+#: ../src/richtext/richtextmarginspage.cpp:380
+#: ../src/richtext/richtextmarginspage.cpp:382
+msgid "The bottom padding size."
+msgstr "Ширина нижньої фаски."
+
+#: ../src/richtext/richtextmarginspage.cpp:390
+#: ../src/richtext/richtextmarginspage.cpp:392
+msgid "Units for the bottom padding."
+msgstr "Одиниці виміру нижньої фаски."
+
+#: ../src/richtext/richtextprint.cpp:592
+msgid " Preview"
+msgstr " Перегляд"
+
+#: ../src/richtext/richtextsizepage.cpp:228
+msgid "Floating"
+msgstr "Вільний"
+
+#: ../src/richtext/richtextsizepage.cpp:243
+msgid "&Floating mode:"
+msgstr "&Рухомий режим:"
+
+#: ../src/richtext/richtextsizepage.cpp:252
+#: ../src/richtext/richtextsizepage.cpp:254
+msgid "How the object will float relative to the text."
+msgstr "Спосіб взаємного розташування об’єкта і тексту."
+
+#: ../src/richtext/richtextsizepage.cpp:265
+msgid "Alignment"
+msgstr "Вирівнювання"
+
+#: ../src/richtext/richtextsizepage.cpp:277
+msgid "&Vertical alignment:"
+msgstr "&Вертикальне вирівнювання:"
+
+#: ../src/richtext/richtextsizepage.cpp:279
+#: ../src/richtext/richtextsizepage.cpp:281
+msgid "Enable vertical alignment."
+msgstr "Увімкнути вертикальне вирівнювання."
+
+#: ../src/richtext/richtextsizepage.cpp:286
+msgid "Centred"
+msgstr "За центром"
+
+#: ../src/richtext/richtextsizepage.cpp:290
+#: ../src/richtext/richtextsizepage.cpp:292
+msgid "Vertical alignment."
+msgstr "Вертикальне вирівнювання."
+
+#: ../src/richtext/richtextsizepage.cpp:316
+#: ../src/richtext/richtextsizepage.cpp:323
+msgid "&Width:"
+msgstr "&Ширина:"
+
+#: ../src/richtext/richtextsizepage.cpp:318
+#: ../src/richtext/richtextsizepage.cpp:320
+msgid "Enable the width value."
+msgstr "Увімкнути значення ширини."
+
+#: ../src/richtext/richtextsizepage.cpp:331
+#: ../src/richtext/richtextsizepage.cpp:333
+msgid "The object width."
+msgstr "Ширина об’єкта."
+
+#: ../src/richtext/richtextsizepage.cpp:342
+#: ../src/richtext/richtextsizepage.cpp:344
+msgid "Units for the object width."
+msgstr "Одиниці виміру ширини об’єкта."
+
+#: ../src/richtext/richtextsizepage.cpp:350
+#: ../src/richtext/richtextsizepage.cpp:357
+msgid "&Height:"
+msgstr "&Висота:"
+
+#: ../src/richtext/richtextsizepage.cpp:352
+#: ../src/richtext/richtextsizepage.cpp:354
+#: ../src/richtext/richtextsizepage.cpp:464
+#: ../src/richtext/richtextsizepage.cpp:466
+msgid "Enable the height value."
+msgstr "Увімкнути значення висоти."
+
+#: ../src/richtext/richtextsizepage.cpp:365
+#: ../src/richtext/richtextsizepage.cpp:367
+msgid "The object height."
+msgstr "Висота об’єкта."
+
+#: ../src/richtext/richtextsizepage.cpp:376
+#: ../src/richtext/richtextsizepage.cpp:378
+msgid "Units for the object height."
+msgstr "Одиниці виміру висоти об’єкта."
+
+#: ../src/richtext/richtextsizepage.cpp:381
+msgid "Min width:"
+msgstr "Мінімальна ширина:"
+
+#: ../src/richtext/richtextsizepage.cpp:383
+#: ../src/richtext/richtextsizepage.cpp:385
+msgid "Enable the minimum width value."
+msgstr "Увімкнути значення мінімальної ширини."
+
+#: ../src/richtext/richtextsizepage.cpp:392
+#: ../src/richtext/richtextsizepage.cpp:394
+msgid "The object minimum width."
+msgstr "Мінімальна ширина об’єкта."
+
+#: ../src/richtext/richtextsizepage.cpp:403
+#: ../src/richtext/richtextsizepage.cpp:405
+msgid "Units for the minimum object width."
+msgstr "Одиниці виміру мінімальної ширини об’єкта."
+
+#: ../src/richtext/richtextsizepage.cpp:408
+msgid "Min height:"
+msgstr "Мін. висота:"
+
+#: ../src/richtext/richtextsizepage.cpp:410
+#: ../src/richtext/richtextsizepage.cpp:412
+msgid "Enable the minimum height value."
+msgstr "Увімкнути значення мінімальної висоти."
+
+#: ../src/richtext/richtextsizepage.cpp:419
+#: ../src/richtext/richtextsizepage.cpp:421
+msgid "The object minimum height."
+msgstr "Мінімальна висота об’єкта."
+
+#: ../src/richtext/richtextsizepage.cpp:430
+#: ../src/richtext/richtextsizepage.cpp:432
+msgid "Units for the minimum object height."
+msgstr "Одиниці виміру мінімальної висоти об’єкта."
+
+#: ../src/richtext/richtextsizepage.cpp:435
+msgid "Max width:"
+msgstr "Макс. ширина:"
+
+#: ../src/richtext/richtextsizepage.cpp:437
+#: ../src/richtext/richtextsizepage.cpp:439
+msgid "Enable the maximum width value."
+msgstr "Увімкнути значення максимальної ширини."
+
+#: ../src/richtext/richtextsizepage.cpp:446
+#: ../src/richtext/richtextsizepage.cpp:448
+msgid "The object maximum width."
+msgstr "Максимальна ширина об’єкта."
+
+#: ../src/richtext/richtextsizepage.cpp:457
+#: ../src/richtext/richtextsizepage.cpp:459
+msgid "Units for the maximum object width."
+msgstr "Одиниці виміру максимальної ширини об’єкта."
+
+#: ../src/richtext/richtextsizepage.cpp:462
+msgid "Max height:"
+msgstr "Макс. висота:"
+
+#: ../src/richtext/richtextsizepage.cpp:473
+#: ../src/richtext/richtextsizepage.cpp:475
+msgid "The object maximum height."
+msgstr "Максимальна висота об’єкта."
+
+#: ../src/richtext/richtextsizepage.cpp:484
+#: ../src/richtext/richtextsizepage.cpp:486
+msgid "Units for the maximum object height."
+msgstr "Одиниці виміру максимальної висоти об’єкта."
+
+#: ../src/richtext/richtextsizepage.cpp:495
+msgid "Position"
+msgstr "Позиція"
+
+#: ../src/richtext/richtextsizepage.cpp:513
+msgid "&Position mode:"
+msgstr "Режим &позиції:"
+
+#: ../src/richtext/richtextsizepage.cpp:517
+#: ../src/richtext/richtextsizepage.cpp:522
+msgid "Static"
+msgstr "Статична"
+
+#: ../src/richtext/richtextsizepage.cpp:518
+msgid "Relative"
+msgstr "Відносна"
+
+#: ../src/richtext/richtextsizepage.cpp:519
+msgid "Absolute"
+msgstr "Абсолютна"
+
+#: ../src/richtext/richtextsizepage.cpp:520
+msgid "Fixed"
+msgstr "Фіксована"
+
+#: ../src/richtext/richtextsizepage.cpp:533
+#: ../src/richtext/richtextsizepage.cpp:535
+#: ../src/richtext/richtextsizepage.cpp:547
+#: ../src/richtext/richtextsizepage.cpp:549
+msgid "The left position."
+msgstr "Ліва позиція."
+
+#: ../src/richtext/richtextsizepage.cpp:558
+#: ../src/richtext/richtextsizepage.cpp:560
+msgid "Units for the left position."
+msgstr "Одиниці виміру лівої позиції."
+
+#: ../src/richtext/richtextsizepage.cpp:568
+#: ../src/richtext/richtextsizepage.cpp:570
+#: ../src/richtext/richtextsizepage.cpp:582
+#: ../src/richtext/richtextsizepage.cpp:584
+msgid "The top position."
+msgstr "Верхня позиція."
+
+#: ../src/richtext/richtextsizepage.cpp:593
+#: ../src/richtext/richtextsizepage.cpp:595
+msgid "Units for the top position."
+msgstr "Одиниці виміру верхньої позиції."
+
+#: ../src/richtext/richtextsizepage.cpp:603
+#: ../src/richtext/richtextsizepage.cpp:605
+#: ../src/richtext/richtextsizepage.cpp:617
+#: ../src/richtext/richtextsizepage.cpp:619
+msgid "The right position."
+msgstr "Права позиція."
+
+#: ../src/richtext/richtextsizepage.cpp:628
+#: ../src/richtext/richtextsizepage.cpp:630
+msgid "Units for the right position."
+msgstr "Одиниці виміру правої позиції."
+
+#: ../src/richtext/richtextsizepage.cpp:638
+#: ../src/richtext/richtextsizepage.cpp:640
+#: ../src/richtext/richtextsizepage.cpp:652
+#: ../src/richtext/richtextsizepage.cpp:654
+msgid "The bottom position."
+msgstr "Нижня позиція."
+
+#: ../src/richtext/richtextsizepage.cpp:663
+#: ../src/richtext/richtextsizepage.cpp:665
+msgid "Units for the bottom position."
+msgstr "Одиниці виміру нижньої позиції."
+
+#: ../src/richtext/richtextsizepage.cpp:671
+msgid "&Move the object to:"
+msgstr "Місце п&ересування об’єкта:"
+
+#: ../src/richtext/richtextsizepage.cpp:674
+msgid "&Previous Paragraph"
+msgstr "&Попередній абзац"
+
+#: ../src/richtext/richtextsizepage.cpp:675
+#: ../src/richtext/richtextsizepage.cpp:677
+msgid "Moves the object to the previous paragraph."
+msgstr "Пересуває об’єкт до попереднього абзацу."
+
+#: ../src/richtext/richtextsizepage.cpp:680
+msgid "&Next Paragraph"
+msgstr "&Наступний абзац"
+
+#: ../src/richtext/richtextsizepage.cpp:681
+#: ../src/richtext/richtextsizepage.cpp:683
+msgid "Moves the object to the next paragraph."
+msgstr "Пересуває об’єкт до наступного абзацу."
+
+#: ../src/richtext/richtextstyledlg.cpp:193
+msgid "&Styles:"
+msgstr "&Стилі:"
+
+#: ../src/richtext/richtextstyledlg.cpp:197
+#: ../src/richtext/richtextstyledlg.cpp:199
+msgid "The available styles."
+msgstr "Доступні стилі."
+
+#: ../src/richtext/richtextstyledlg.cpp:205
+#: ../src/richtext/richtextstyledlg.cpp:217
+msgid " "
+msgstr " "
+
+#: ../src/richtext/richtextstyledlg.cpp:209
+#: ../src/richtext/richtextstyledlg.cpp:211
+msgid "The style preview."
+msgstr "Перегляд стилю."
+
+#: ../src/richtext/richtextstyledlg.cpp:220
+msgid "New &Character Style..."
+msgstr "Новий &стиль символів…"
+
+#: ../src/richtext/richtextstyledlg.cpp:221
+#: ../src/richtext/richtextstyledlg.cpp:223
+msgid "Click to create a new character style."
+msgstr "Клацніть, щоб створити новий стиль символів."
+
+#: ../src/richtext/richtextstyledlg.cpp:226
+msgid "New &Paragraph Style..."
+msgstr "Створити стиль &абзацу…"
+
+#: ../src/richtext/richtextstyledlg.cpp:227
+#: ../src/richtext/richtextstyledlg.cpp:229
+msgid "Click to create a new paragraph style."
+msgstr "Клацніть, щоб створити новий стиль абзацу."
+
+#: ../src/richtext/richtextstyledlg.cpp:232
+msgid "New &List Style..."
+msgstr "Створити стиль &списку…"
+
+#: ../src/richtext/richtextstyledlg.cpp:233
+#: ../src/richtext/richtextstyledlg.cpp:235
+msgid "Click to create a new list style."
+msgstr "Клацніть, щоб створити новий стиль списку."
+
+#: ../src/richtext/richtextstyledlg.cpp:238
+msgid "New &Box Style..."
+msgstr "Створити стиль &панелі…"
+
+#: ../src/richtext/richtextstyledlg.cpp:239
+#: ../src/richtext/richtextstyledlg.cpp:241
+msgid "Click to create a new box style."
+msgstr "Клацніть, щоб створити новий стиль панелі."
+
+#: ../src/richtext/richtextstyledlg.cpp:246
+msgid "&Apply Style"
+msgstr "&Застосувати стиль"
+
+#: ../src/richtext/richtextstyledlg.cpp:247
+#: ../src/richtext/richtextstyledlg.cpp:249
+msgid "Click to apply the selected style."
+msgstr "Клацніть, щоб застосувати обраний стиль."
+
+#: ../src/richtext/richtextstyledlg.cpp:252
+msgid "&Rename Style..."
+msgstr "&Перейменувати стиль…"
+
+#: ../src/richtext/richtextstyledlg.cpp:253
+#: ../src/richtext/richtextstyledlg.cpp:255
+msgid "Click to rename the selected style."
+msgstr "Клацніть, щоб перейменувати обраний стиль."
+
+#: ../src/richtext/richtextstyledlg.cpp:258
+msgid "&Edit Style..."
+msgstr "&Редагувати стиль…"
+
+#: ../src/richtext/richtextstyledlg.cpp:259
+#: ../src/richtext/richtextstyledlg.cpp:261
+msgid "Click to edit the selected style."
+msgstr "Клацніть, щоб редагувати обраний стиль."
+
+#: ../src/richtext/richtextstyledlg.cpp:264
+msgid "&Delete Style..."
+msgstr "&Вилучити стиль…"
+
+#: ../src/richtext/richtextstyledlg.cpp:265
+#: ../src/richtext/richtextstyledlg.cpp:267
+msgid "Click to delete the selected style."
+msgstr "Клацніть, щоб вилучити обраний стиль."
+
+#: ../src/richtext/richtextstyledlg.cpp:274
+#: ../src/richtext/richtextstyledlg.cpp:276
+msgid "Click to close this window."
+msgstr "Клацніть, щоб закрити це вікно"
+
+#: ../src/richtext/richtextstyledlg.cpp:282
+msgid "&Restart numbering"
+msgstr "&Почати відлік з початку"
+
+#: ../src/richtext/richtextstyledlg.cpp:284
+#: ../src/richtext/richtextstyledlg.cpp:286
+msgid "Check to restart numbering."
+msgstr "Позначте, щоб знову розпочати нумерацію."
+
+#: ../src/richtext/richtextstyledlg.cpp:601
+msgid "Enter a character style name"
+msgstr "Введіть назву стилю символу"
+
+#: ../src/richtext/richtextstyledlg.cpp:601
+#: ../src/richtext/richtextstyledlg.cpp:606
+#: ../src/richtext/richtextstyledlg.cpp:649
+#: ../src/richtext/richtextstyledlg.cpp:654
+#: ../src/richtext/richtextstyledlg.cpp:815
+#: ../src/richtext/richtextstyledlg.cpp:820
+#: ../src/richtext/richtextstyledlg.cpp:888
+#: ../src/richtext/richtextstyledlg.cpp:896
+#: ../src/richtext/richtextstyledlg.cpp:929
+#: ../src/richtext/richtextstyledlg.cpp:934
+msgid "New Style"
+msgstr "Новий стиль"
+
+#: ../src/richtext/richtextstyledlg.cpp:606
+#: ../src/richtext/richtextstyledlg.cpp:654
+#: ../src/richtext/richtextstyledlg.cpp:820
+#: ../src/richtext/richtextstyledlg.cpp:896
+#: ../src/richtext/richtextstyledlg.cpp:934
+msgid "Sorry, that name is taken. Please choose another."
+msgstr "Вибачте, цю назву вже використано. Будь ласка, виберіть іншу."
+
+#: ../src/richtext/richtextstyledlg.cpp:649
+msgid "Enter a paragraph style name"
+msgstr "Введіть назву стилю абзацу"
+
+#: ../src/richtext/richtextstyledlg.cpp:777
+#, c-format
+msgid "Delete style %s?"
+msgstr "Вилучити стиль %s?"
+
+#: ../src/richtext/richtextstyledlg.cpp:777
+msgid "Delete Style"
+msgstr "Вилучити стиль"
+
+#: ../src/richtext/richtextstyledlg.cpp:815
+msgid "Enter a list style name"
+msgstr "Введіть назву стилю списку"
+
+#: ../src/richtext/richtextstyledlg.cpp:888
+msgid "Enter a new style name"
+msgstr "Введіть назву нового стилю"
+
+#: ../src/richtext/richtextstyledlg.cpp:929
+msgid "Enter a box style name"
+msgstr "Введіть назву стилю панелі"
+
+#: ../src/richtext/richtextstylepage.cpp:109
+#: ../src/richtext/richtextstylepage.cpp:111
+msgid "The style name."
+msgstr "Назва стилю."
+
+#: ../src/richtext/richtextstylepage.cpp:114
+msgid "&Based on:"
+msgstr "На &основі:"
+
+#: ../src/richtext/richtextstylepage.cpp:119
+#: ../src/richtext/richtextstylepage.cpp:121
+msgid "The style on which this style is based."
+msgstr "Стиль, на якому засновано цей стиль."
+
+#: ../src/richtext/richtextstylepage.cpp:124
+msgid "&Next style:"
+msgstr "&Наступний стиль:"
+
+#: ../src/richtext/richtextstylepage.cpp:129
+#: ../src/richtext/richtextstylepage.cpp:131
+msgid "The default style for the next paragraph."
+msgstr "Типовий стиль для наступного абзацу."
+
+#: ../src/richtext/richtextstyles.cpp:1057
+msgid "All styles"
+msgstr "Всі стилі"
+
+#: ../src/richtext/richtextstyles.cpp:1058
+msgid "Paragraph styles"
+msgstr "Стилі абзаців"
+
+#: ../src/richtext/richtextstyles.cpp:1059
+msgid "Character styles"
+msgstr "Стиль символів"
+
+#: ../src/richtext/richtextstyles.cpp:1060
+msgid "List styles"
+msgstr "Стилі списку"
+
+#: ../src/richtext/richtextstyles.cpp:1061
+msgid "Box styles"
+msgstr "Стилі рамок"
+
+#: ../src/richtext/richtextsymboldlg.cpp:389
+#: ../src/richtext/richtextsymboldlg.cpp:391
+msgid "The font from which to take the symbol."
+msgstr "Шрифт, з якого слід брати символ."
+
+#: ../src/richtext/richtextsymboldlg.cpp:396
+msgid "&Subset:"
+msgstr "&Підмножина:"
+
+#: ../src/richtext/richtextsymboldlg.cpp:401
+#: ../src/richtext/richtextsymboldlg.cpp:403
+msgid "Shows a Unicode subset."
+msgstr "Показує підмножину Unicode."
+
+#: ../src/richtext/richtextsymboldlg.cpp:412
+msgid "xxxx"
+msgstr "xxxx"
+
+#: ../src/richtext/richtextsymboldlg.cpp:417
+msgid "&Character code:"
+msgstr "Код &символу:"
+
+#: ../src/richtext/richtextsymboldlg.cpp:421
+#: ../src/richtext/richtextsymboldlg.cpp:423
+msgid "The character code."
+msgstr "Код символу."
+
+#: ../src/richtext/richtextsymboldlg.cpp:428
+msgid "&From:"
+msgstr "&Від:"
+
+#: ../src/richtext/richtextsymboldlg.cpp:433
+#: ../src/richtext/richtextsymboldlg.cpp:434
+#: ../src/richtext/richtextsymboldlg.cpp:435
+msgid "Unicode"
+msgstr "Unicode"
+
+#: ../src/richtext/richtextsymboldlg.cpp:436
+#: ../src/richtext/richtextsymboldlg.cpp:438
+msgid "The range to show."
+msgstr "Діапазон показу."
+
+#: ../src/richtext/richtextsymboldlg.cpp:444
+msgid "Insert"
+msgstr "Вставити"
+
+#: ../src/richtext/richtextsymboldlg.cpp:478
+msgid "(Normal text)"
+msgstr "(Звичайний шрифт)"
+
+#: ../src/richtext/richtexttabspage.cpp:109
+msgid "&Position (tenths of a mm):"
+msgstr "&Розміщення (у десятках мм):"
+
+#: ../src/richtext/richtexttabspage.cpp:113
+#: ../src/richtext/richtexttabspage.cpp:115
+msgid "The tab position."
+msgstr "Позиція табуляції."
+
+#: ../src/richtext/richtexttabspage.cpp:119
+msgid "The tab positions."
+msgstr "Позиції табуляції."
+
+#: ../src/richtext/richtexttabspage.cpp:132
+#: ../src/richtext/richtexttabspage.cpp:134
+msgid "Click to create a new tab position."
+msgstr "Клацніть, щоб створити нову позицію табуляції."
+
+#: ../src/richtext/richtexttabspage.cpp:138
+#: ../src/richtext/richtexttabspage.cpp:140
+msgid "Click to delete the selected tab position."
+msgstr "Клацніть, щоб вилучити обрану позицію табуляції."
+
+#: ../src/richtext/richtexttabspage.cpp:143
+msgid "Delete A&ll"
+msgstr "Вилучити в&се"
+
+#: ../src/richtext/richtexttabspage.cpp:144
+#: ../src/richtext/richtexttabspage.cpp:146
+msgid "Click to delete all tab positions."
+msgstr "Клацніть, щоб вилучити всі позиції табуляції."
+
+#: ../src/univ/theme.cpp:110
+msgid "Failed to initialize GUI: no built-in themes found."
+msgstr "Не вдалося ініціювати GUI: не знайдено вбудованих тем."
+
+#: ../src/univ/themes/gtk.cpp:521
+msgid "GTK+ theme"
+msgstr "GTK+ мотив"
+
+#: ../src/univ/themes/metal.cpp:164
+msgid "Metal theme"
+msgstr "Металічний мотив"
+
+#: ../src/univ/themes/mono.cpp:512
+msgid "Simple monochrome theme"
+msgstr "Проста чорно-біла тема"
+
+#: ../src/univ/themes/win32.cpp:1098
+msgid "Win32 theme"
+msgstr "Win32 мотив "
+
+#: ../src/univ/themes/win32.cpp:3743
+msgid "&Restore"
+msgstr "&Відновити"
+
+#: ../src/univ/themes/win32.cpp:3744
+msgid "&Move"
+msgstr "&Перенести"
+
+#: ../src/univ/themes/win32.cpp:3746
+msgid "&Size"
+msgstr "&Розмір"
+
+#: ../src/univ/themes/win32.cpp:3748
+msgid "Mi&nimize"
+msgstr "З&меншити"
+
+#: ../src/univ/themes/win32.cpp:3750
+msgid "Ma&ximize"
+msgstr "З&більшити"
+
+#: ../src/univ/themes/win32.cpp:3752
+msgid "Alt+"
+msgstr "Alt+"
+
+#: ../src/unix/appunix.cpp:178
+msgid "Failed to install signal handler"
+msgstr "Не вдалося встановити інструмент обробки сигналу"
+
+#: ../src/unix/dialup.cpp:351
+msgid "Already dialling ISP."
+msgstr "Вже дзвонимо ISP."
+
+#: ../src/unix/dlunix.cpp:93
+msgid "Failed to unload shared library"
+msgstr "Не вдалося вивантажити бібліотеку спільного використання"
+
+#: ../src/unix/dlunix.cpp:121
+msgid "Unknown dynamic library error"
+msgstr "Невідома помилка динамічної бібліотеки"
+
+#: ../src/unix/epolldispatcher.cpp:84
+msgid "Failed to create epoll descriptor"
+msgstr "Не вдалося створити дескриптор epoll"
+
+#: ../src/unix/epolldispatcher.cpp:103
+msgid "Error closing epoll descriptor"
+msgstr "Помилка під час закриття дескриптора epoll"
+
+#: ../src/unix/epolldispatcher.cpp:116
+#, c-format
+msgid "Failed to add descriptor %d to epoll descriptor %d"
+msgstr "Не вдалося додати дескриптор %d в дескриптора epoll %d"
+
+#: ../src/unix/epolldispatcher.cpp:136
+#, c-format
+msgid "Failed to modify descriptor %d in epoll descriptor %d"
+msgstr "Не вдалося змінити дескриптор %d у дескрипторі epoll %d"
+
+#: ../src/unix/epolldispatcher.cpp:155
+#, c-format
+msgid "Failed to unregister descriptor %d from epoll descriptor %d"
+msgstr ""
+"Не вдалося скасувати реєстрацію дескриптора %d для дескриптора epoll %d"
+
+#: ../src/unix/epolldispatcher.cpp:213
+#, c-format
+msgid "Waiting for IO on epoll descriptor %d failed"
+msgstr "Помилка очікування на ввід-вивід для дескриптора epoll %d"
+
+#: ../src/unix/fswatcher_inotify.cpp:71
+msgid "Unable to create inotify instance"
+msgstr "Не вдалося створити екземпляр inotify"
+
+#: ../src/unix/fswatcher_inotify.cpp:94
+msgid "Unable to close inotify instance"
+msgstr "Не вдалося завершити роботу екземпляра inotify"
+
+#: ../src/unix/fswatcher_inotify.cpp:106
+msgid "Unable to add inotify watch"
+msgstr "Не вдалося додати спостереження inotify"
+
+#: ../src/unix/fswatcher_inotify.cpp:138
+#, c-format
+msgid "Unable to remove inotify watch %i"
+msgstr "Не вдалося вилучити спостереження inotify %i"
+
+#: ../src/unix/fswatcher_inotify.cpp:271
+#, c-format
+msgid "Unexpected event for \"%s\": no matching watch descriptor."
+msgstr ""
+"Неочікувана подія для «%s»: немає відповідного дескриптора спостереження."
+
+#: ../src/unix/fswatcher_inotify.cpp:320
+#, c-format
+msgid "Invalid inotify event for \"%s\""
+msgstr "Некоректна подія inotify для «%s»"
+
+#: ../src/unix/fswatcher_inotify.cpp:553
+msgid "Unable to read from inotify descriptor"
+msgstr "Не вдалося прочитати дані з дескриптора inotify"
+
+#: ../src/unix/fswatcher_inotify.cpp:558
+msgid "EOF while reading from inotify descriptor"
+msgstr "Символ EOF під час читання з дескриптора inotify"
+
+#: ../src/unix/fswatcher_kqueue.cpp:114
+msgid "Unable to create kqueue instance"
+msgstr "Не вдалося створити екземпляр kqueue"
+
+#: ../src/unix/fswatcher_kqueue.cpp:131
+msgid "Error closing kqueue instance"
+msgstr "Помилка під час закриття екземпляра kqueue"
+
+#: ../src/unix/fswatcher_kqueue.cpp:153
+msgid "Unable to add kqueue watch"
+msgstr "Не вдалося додати спостереження kqueue"
+
+#: ../src/unix/fswatcher_kqueue.cpp:170
+msgid "Unable to remove kqueue watch"
+msgstr "Не вдалося вилучити спостереження kqueue"
+
+#: ../src/unix/fswatcher_kqueue.cpp:202
+msgid "Unable to get events from kqueue"
+msgstr "Не вдалося отримати список подій від kqueue"
+
+#: ../src/unix/mediactrl.cpp:966
+#, c-format
+msgid "Media playback error: %s"
+msgstr "Помилка відтворення мультимедійних даних: %s"
+
+#: ../src/unix/mediactrl.cpp:1228
+#, c-format
+msgid "Failed to prepare playing \"%s\"."
+msgstr "Не вдалося приготувати «%s» до відтворення."
+
+#: ../src/unix/snglinst.cpp:164
+#, c-format
+msgid "Failed to write to lock file '%s'"
+msgstr "Не вдалося провести запис до файла замка «%s»"
+
+#: ../src/unix/snglinst.cpp:177
+#, c-format
+msgid "Failed to set permissions on lock file '%s'"
+msgstr "Не вдалося встановити дозволи на файл замка «%s»"
+
+#: ../src/unix/snglinst.cpp:194
+#, c-format
+msgid "Failed to lock the lock file '%s'"
+msgstr "Не вдалося замкнути файл замка «%s»"
+
+#: ../src/unix/snglinst.cpp:237
+#, c-format
+msgid "Failed to inspect the lock file '%s'"
+msgstr "Не вдалося перевірити файл замка «%s»."
+
+#: ../src/unix/snglinst.cpp:242
+#, c-format
+msgid "Lock file '%s' has incorrect owner."
+msgstr "Файл блокування «%s» має помилкового власника."
+
+#: ../src/unix/snglinst.cpp:247
+#, c-format
+msgid "Lock file '%s' has incorrect permissions."
+msgstr "Файл блокування «%s» має помилкові дозволи."
+
+#: ../src/unix/snglinst.cpp:265
+msgid "Failed to access lock file."
+msgstr "Не вдалося отримати доступ до файла замка."
+
+#: ../src/unix/snglinst.cpp:274
+msgid "Failed to read PID from lock file."
+msgstr "Не вдалося прочитати PID з файла замка."
+
+#: ../src/unix/snglinst.cpp:284
+#, c-format
+msgid "Failed to remove stale lock file '%s'."
+msgstr "Не вдалося вилучити застарілий файл блокування «%s»."
+
+#: ../src/unix/snglinst.cpp:297
+#, c-format
+msgid "Deleted stale lock file '%s'."
+msgstr "Вилучено застарілий файл замка «%s»."
+
+#: ../src/unix/snglinst.cpp:308
+#, c-format
+msgid "Invalid lock file '%s'."
+msgstr "Помилковий файл блокування «%s»."
+
+#: ../src/unix/snglinst.cpp:324
+#, c-format
+msgid "Failed to remove lock file '%s'"
+msgstr "Помилка вилучення файла замка «%s»"
+
+#: ../src/unix/snglinst.cpp:330
+#, c-format
+msgid "Failed to unlock lock file '%s'"
+msgstr "Не вдалося відімкнути файл замка «%s»"
+
+#: ../src/unix/snglinst.cpp:336
+#, c-format
+msgid "Failed to close lock file '%s'"
+msgstr "Не вдалося закрити файла замка «%s»"
+
+#: ../src/unix/sound.cpp:77
+msgid "No sound"
+msgstr "Без звуку"
+
+#: ../src/unix/sound.cpp:364
+msgid "Unable to play sound asynchronously."
+msgstr "Не вдалося асинхронно відтворити звук."
+
+#: ../src/unix/sound.cpp:458
+#, c-format
+msgid "Couldn't load sound data from '%s'."
+msgstr "Не вдалося завантажити піктограму з «%s»."
+
+#: ../src/unix/sound.cpp:465
+#, c-format
+msgid "Sound file '%s' is in unsupported format."
+msgstr "Звуковий файл «%s» має непідтримуваний формат."
+
+#: ../src/unix/sound.cpp:480
+msgid "Sound data are in unsupported format."
+msgstr "Звукові дані знаходяться у непідтримуваному форматі."
+
+#: ../src/unix/sound_sdl.cpp:226
+#, c-format
+msgid "Couldn't open audio: %s"
+msgstr "Не вдалося відкрити аудіо: «%s»"
+
+#: ../src/unix/threadpsx.cpp:1033
+msgid "Cannot retrieve thread scheduling policy."
+msgstr "Не вдалося встановити порядок нитки."
+
+#: ../src/unix/threadpsx.cpp:1058
+#, c-format
+msgid "Cannot get priority range for scheduling policy %d."
+msgstr "Не вдалося отримати інтервал пріоритету для розпорядку %d."
+
+#: ../src/unix/threadpsx.cpp:1066
+msgid "Thread priority setting is ignored."
+msgstr "Пріоритет нитки проігноровано."
+
+#: ../src/unix/threadpsx.cpp:1221
+msgid ""
+"Failed to join a thread, potential memory leak detected - please restart the "
+"program"
+msgstr ""
+"Не вдалося з'єднатися з ниткою, можливий виток пам'яті, будь ласка, "
+"перезапустіть програму"
+
+#: ../src/unix/threadpsx.cpp:1352
+#, c-format
+msgid "Failed to set thread concurrency level to %lu"
+msgstr "Не вдалося встановити рівень пріоритетності нитки у значення %lu"
+
+#: ../src/unix/threadpsx.cpp:1481
+#, c-format
+msgid "Failed to set thread priority %d."
+msgstr "Не вдалося встановити пріоритет нитки %d."
+
+#: ../src/unix/threadpsx.cpp:1666
+msgid "Failed to terminate a thread."
+msgstr "Не вдалося закінчити нитку."
+
+#: ../src/unix/threadpsx.cpp:1893
+msgid "Thread module initialization failed: failed to create thread key"
+msgstr "Помилка ініціалізації модуля ниток: не вдалося створити ключ нитки"
+
+#: ../src/unix/utilsunx.cpp:340
+msgid "Impossible to get child process input"
+msgstr "Не вдалося отримати дані від зародженого процесу"
+
+#: ../src/unix/utilsunx.cpp:390
+msgid "Can't write to child process's stdin"
+msgstr "Запис до стандартного входу дочірнього процесу неможливий"
+
+#: ../src/unix/utilsunx.cpp:644
+#, c-format
+msgid "Failed to execute '%s'\n"
+msgstr "Не вдалося виконати «%s»\n"
+
+#: ../src/unix/utilsunx.cpp:678
+msgid "Fork failed"
+msgstr "Невдале розгалуження"
+
+#: ../src/unix/utilsunx.cpp:701
+msgid "Failed to set process priority"
+msgstr "Не вдалося встановити пріоритет процесу"
+
+#: ../src/unix/utilsunx.cpp:712
+msgid "Failed to redirect child process input/output"
+msgstr "Не вдалося переспрямувати ввід/вивід зародженого процесу"
+
+#: ../src/unix/utilsunx.cpp:816
+msgid "Failed to set up non-blocking pipe, the program might hang."
+msgstr ""
+"Не вдалося налаштувати канал обробки без блокування, програма може "
+"«зависнути»."
+
+#: ../src/unix/utilsunx.cpp:1023
+msgid "Cannot get the hostname"
+msgstr "Не вдалося отримати назву вузла"
+
+#: ../src/unix/utilsunx.cpp:1059
+msgid "Cannot get the official hostname"
+msgstr "Не вдалося отримати офіційне назву вузла"
+
+#: ../src/unix/wakeuppipe.cpp:49
+msgid "Failed to create wake up pipe used by event loop."
+msgstr ""
+"Не вдалося створити канал повернення зі сну, що використовується циклом "
+"події."
+
+#: ../src/unix/wakeuppipe.cpp:56
+msgid "Failed to switch wake up pipe to non-blocking mode"
+msgstr "Не вдалося перемкнути канал повернення зі сну у режим без блокування"
+
+#: ../src/unix/wakeuppipe.cpp:117
+msgid "Failed to read from wake-up pipe"
+msgstr "Не вдалося прочитати дані з каналу повернення зі сну"
+
+#: ../src/x11/app.cpp:124
+#, c-format
+msgid "Invalid geometry specification '%s'"
+msgstr "Неправильна специфікація геометрії «%s»"
+
+#: ../src/x11/app.cpp:167
+msgid "wxWidgets could not open display. Exiting."
+msgstr "wxWidgets не вдалося відкрити дисплей. Завершення роботи."
+
+#: ../src/x11/utils.cpp:169
+#, c-format
+msgid "Failed to close the display \"%s\""
+msgstr "Не вдалося закрити дисплей «%s»"
+
+#: ../src/x11/utils.cpp:188
+#, c-format
+msgid "Failed to open display \"%s\"."
+msgstr "Не вдалося відкрити дисплей «%s»."
+
+#: ../src/xml/xml.cpp:868
+#, c-format
+msgid "XML parsing error: '%s' at line %d"
+msgstr "Помилка розбору XML: «%s» у рядку %d"
+
+#: ../src/xrc/xh_propgrid.cpp:239
+#, c-format
+msgid "Page %i"
+msgstr "Сторінка %i"
+
+#: ../src/xrc/xmlres.cpp:448
+#, c-format
+msgid "Cannot load resources from '%s'."
+msgstr "Не вдалося завантажити ресурси з «%s»."
+
+#: ../src/xrc/xmlres.cpp:799
+#, c-format
+msgid "Cannot open resources file '%s'."
+msgstr "Не вдалося відкрити файл ресурсів «%s»."
+
+#: ../src/xrc/xmlres.cpp:806
+#, c-format
+msgid "Cannot load resources from file '%s'."
+msgstr "Не вдалося завантажити ресурси з файла «%s»."
+
+#: ../src/xrc/xmlres.cpp:2767
+#, c-format
+msgid "Creating %s \"%s\" failed."
+msgstr "Не вдалося створити %s «%s»."
+
+#, c-format
+#~ msgid "BMP: header has biClrUsed=%d when biBitCount=%d."
+#~ msgstr "BMP: у заголовку вказано biClrUsed=%d, а biBitCount=%d."
+
+#~ msgctxt "keyboard key"
+#~ msgid "Alt+"
+#~ msgstr "Alt+"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Ctrl+"
+#~ msgstr "Ctrl+"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Shift+"
+#~ msgstr "Shift+"
+
+#~ msgctxt "keyboard key"
+#~ msgid "RawCtrl+"
+#~ msgstr "RawCtrl+"
+
+#~ msgid "Copying more than one selected block to clipboard is not supported."
+#~ msgstr ""
+#~ "Підтримки копіювання декількох позначених блоків до буфера обміну даними "
+#~ "не передбачено."
+
+#~ msgid "Unsupported clipboard format."
+#~ msgstr "Непідтримуваний формат clipboard."
+
+#~ msgid "Background colour"
+#~ msgstr "Колір тла"
+
+#~ msgid "Font:"
+#~ msgstr "Шрифт:"
+
+#~ msgid "Size:"
+#~ msgstr "Розмір:"
+
+#~ msgid "The font size in points."
+#~ msgstr "Розмір шрифту у пунктах."
+
+#~ msgid "Style:"
+#~ msgstr "Стиль:"
+
+#~ msgid "Check to make the font bold."
+#~ msgstr "Позначте, щоб зробити шрифт жирним."
+
+#~ msgid "Check to make the font italic."
+#~ msgstr "Позначте, щоб зробити шрифт курсивним."
+
+#~ msgid "Check to make the font underlined."
+#~ msgstr "Позначте, щоб зробити шрифт підкресленим."
+
+#~ msgid "Colour:"
+#~ msgstr "Колір:"
+
+#~ msgid "Click to change the font colour."
+#~ msgstr "Клацніть, щоб змінити колір шрифту."
+
+#~ msgid "Shows a preview of the font."
+#~ msgstr "Показує попередній перегляд шрифту."
+
+#~ msgid "Click to cancel changes to the font."
+#~ msgstr "Клацніть, щоб скасувати зміну шрифту."
+
+#~ msgid "Click to confirm changes to the font."
+#~ msgstr "Клацніть, щоб підтвердити зміну шрифту."
+
+#~ msgid "<Any>"
+#~ msgstr "<Будь-який>"
+
+#~ msgid "<Any Roman>"
+#~ msgstr "<Будь-який романський>"
+
+#~ msgid "<Any Decorative>"
+#~ msgstr "<Будь-який декоративний>"
+
+#~ msgid "<Any Modern>"
+#~ msgstr "<Будь-який модерний>"
+
+#~ msgid "<Any Script>"
+#~ msgstr "<Будь-який для індексів>"
+
+#~ msgid "<Any Swiss>"
+#~ msgstr "<Будь-який Swiss>"
+
+#~ msgid "<Any Teletype>"
+#~ msgstr "<Будь-який машинописний>"
+
+#~ msgid "Printing "
+#~ msgstr "Друк"
+
+#~ msgid "Failed to insert text in the control."
+#~ msgstr "Не вдалося додати текст до контрола."
+
+#~ msgid "Please choose a valid font."
+#~ msgstr "Будь ласка, виберіть коректний шрифт."
+
+#, c-format
+#~ msgid "Failed to display HTML document in %s encoding"
+#~ msgstr "Не вдалося показати документ HTML у кодуванні %s"
+
+#, c-format
+#~ msgid "wxWidgets could not open display for '%s': exiting."
+#~ msgstr "wxWidgets не зміг відкрити дисплей для «%s»: виходжу."
+
+#~ msgid "Filter"
+#~ msgstr "Фільтр"
+
+#~ msgid "Directories"
+#~ msgstr "Теки"
+
+#~ msgid "Files"
+#~ msgstr "Файли"
+
+#~ msgid "Selection"
+#~ msgstr "Позначене"
+
+#~ msgid "conversion to 8-bit encoding failed"
+#~ msgstr "перетворення у 8-бітове кодування зазнало невдачі"
+
+#, fuzzy
+#~ msgid "failed to retrieve execution result"
+#~ msgstr "Не вдалося прочитати повідомлення про помилку RAS"
+
+#~ msgid "&Save as"
+#~ msgstr "З&берегти як"
+
+#~ msgid "'%s' doesn't consist only of valid characters"
+#~ msgstr "«%s» містить некоректні символи"
+
+#~ msgid "'%s' should be numeric."
+#~ msgstr "«%s» повинно бути числом."
+
+#~ msgid "'%s' should only contain ASCII characters."
+#~ msgstr "«%s» має містити тільки символи ASCII."
+
+#~ msgid "'%s' should only contain alphabetic characters."
+#~ msgstr "«%s» має містити тільки символи алфавіту."
+
+#~ msgid "'%s' should only contain alphabetic or numeric characters."
+#~ msgstr "«%s» має містити тільки символи алфавіту або цифри."
+
+#~ msgid "'%s' should only contain digits."
+#~ msgstr "«%s» має містити лише цифри."
+
+#~ msgid "Can't create window of class %s"
+#~ msgstr "Не вдалося створити вікно класу %s"
+
+#~ msgid "Couldn't create the overlay window"
+#~ msgstr "Не вдалося створити вікно оверлею"
+
+#~ msgid "Couldn't init the context on the overlay window"
+#~ msgstr "Не вдалося ініціювати контекст вікна оверлею"
+
+#~ msgid "Failed to convert file \"%s\" to Unicode."
+#~ msgstr "Не вдалося перетворити вміст файла «%s» на Unicode."
+
+#~ msgid "Failed to set text in the text control."
+#~ msgstr "Не вдалося встановити текст у контрол тексту."
+
+#~ msgid "Invalid GTK+ command line option, use \"%s --help\""
+#~ msgstr ""
+#~ "Некоректний параметр командного рядка GTK+, скористайтеся командою «%s --"
+#~ "help»"
+
+#~ msgid "No unused colour in image."
+#~ msgstr "У зображенні немає невикористаного кольору."
+
+#~ msgid "Not available"
+#~ msgstr "Недоступний"
+
+#~ msgid "Replace selection"
+#~ msgstr "Замінити позначене"
+
+#~ msgid "Save as"
+#~ msgstr "Зберегти як"
+
+#~ msgid "Style Organiser"
+#~ msgstr "Записник стилів"
+
+#~ msgid "The following standard GTK+ options are also supported:\n"
+#~ msgstr "Крім того, підтримуються такі стандартні параметри GTK+:\n"
+
+#~ msgid "You cannot Clear an overlay that is not inited"
+#~ msgstr "Ви не можете спорожнити оверлей, який не ініційовано"
+
+#~ msgid "You cannot Init an overlay twice"
+#~ msgstr "Ви не можете двічі викликати Init для оверлеїв"
+
+#~ msgid "locale '%s' cannot be set."
+#~ msgstr "локаль «%s» не може бути встановлена."
+
+#~ msgid "Adding flavor TEXT failed"
+#~ msgstr "Спроба додавання варіанта TEXT зазнала невдачі"
+
+#~ msgid "Adding flavor utxt failed"
+#~ msgstr "Спроба додавання варіанта utxt зазнала невдачі"
+
+#~ msgid "Bitmap renderer cannot render value; value type: "
+#~ msgstr ""
+#~ "Інструменту обробки растру не вдалося обробити значення; тип значення: "
+
+#~ msgid ""
+#~ "Cannot create new column's ID. Probably max. number of columns reached."
+#~ msgstr ""
+#~ "Не вдалося створити ідентифікатор нового стовпчика. Ймовірно, перевищено "
+#~ "значення максимальної кількості стовпчиків."
+
+#~ msgid "Column could not be added."
+#~ msgstr "Не вдалося додати стовпчик."
+
+#~ msgid "Column index not found."
+#~ msgstr "Не знайдено стовпчика з відповідним номером."
+
+#~ msgid "Column width could not be determined"
+#~ msgstr "Не вдалося визначити ширину стовпчика"
+
+#~ msgid "Column width could not be set."
+#~ msgstr "Не вдалося встановити ширину стовпчика."
+
+#~ msgid "Confirm registry update"
+#~ msgstr "Підтвердити запис реєстру"
+
+#~ msgid "Could not determine column index."
+#~ msgstr "Не вдалося визначити номер стовпчика."
+
+#~ msgid "Could not determine column's position"
+#~ msgstr "Не вдалося визначити позицію стовпчика"
+
+#~ msgid "Could not determine number of columns."
+#~ msgstr "Не вдалося визначити кількість стовпчиків."
+
+#~ msgid "Could not determine number of items"
+#~ msgstr "Не вдалося визначити кількість пунктів"
+
+#~ msgid "Could not get header description."
+#~ msgstr "Не вдалося отримати опис заголовка."
+
+#~ msgid "Could not get items."
+#~ msgstr "Не вдалося отримати пункти."
+
+#~ msgid "Could not get property flags."
+#~ msgstr "Не вдалося отримати прапорці властивості."
+
+#~ msgid "Could not get selected items."
+#~ msgstr "Не вдалося отримати позначені пункти."
+
+#~ msgid "Could not remove column."
+#~ msgstr "Не вдалося вилучити стовпчик."
+
+#~ msgid "Could not retrieve number of items"
+#~ msgstr "Не вдалося отримати кількість пунктів"
+
+#~ msgid "Could not set column width."
+#~ msgstr "Не вдалося встановити ширину стовпчика."
+
+#~ msgid "Could not set header description."
+#~ msgstr "Не вдалося встановити опис заголовка."
+
+#~ msgid "Could not set icon."
+#~ msgstr "Не вдалося встановити піктограму."
+
+#~ msgid "Could not set maximum width."
+#~ msgstr "Не вдалося встановити максимальну ширину."
+
+#~ msgid "Could not set minimum width."
+#~ msgstr "Не вдалося встановити мінімальну ширину."
+
+#~ msgid "Could not set property flags."
+#~ msgstr "Не вдалося встановити прапорці властивості."
+
+#~ msgid "Data object has invalid data format"
+#~ msgstr "Дані об’єкта даних мають некоректний формат"
+
+#~ msgid "Date renderer cannot render value; value type: "
+#~ msgstr ""
+#~ "Інструменту обробки даних не вдалося обробити значення; тип значення: "
+
+#~ msgid ""
+#~ "Do you want to overwrite the command used to %s files with extension "
+#~ "\"%s\" ?\n"
+#~ "Current value is \n"
+#~ "%s, \n"
+#~ "New value is \n"
+#~ "%s %1"
+#~ msgstr ""
+#~ "Ви бажаєте перезаписати команду використану для %s файлів з суфіксом "
+#~ "назви «%s»?\n"
+#~ "Поточне значення \n"
+#~ "%s, \n"
+#~ "Нове значення \n"
+#~ "%s %1"
+
+#~ msgid "Failed to retrieve data from the clipboard."
+#~ msgstr "Не вдалося прочитати дані з clipboard."
+
+#~ msgid "GIF: Invalid gif index."
+#~ msgstr "GIF: Помилковий індекс gif."
+
+#~ msgid "GIF: unknown error!!!"
+#~ msgstr "GIF: невідома помилка!!!"
+
+#~ msgid "Icon & text renderer cannot render value; value type: "
+#~ msgstr ""
+#~ "Інструменту обробки піктограм і тексту не вдалося обробити значення; тип "
+#~ "значення: "
+
+#~ msgid "New directory"
+#~ msgstr "Створити теку"
+
+#~ msgid "Next"
+#~ msgstr "Далі"
+
+#~ msgid "No column existing."
+#~ msgstr "Не знайдено стовпчика."
+
+#~ msgid "No column for the specified column existing."
+#~ msgstr "Для вказаного номера не існує відповідного стовпчика."
+
+#~ msgid "No column for the specified column position existing."
+#~ msgstr "Для вказаної позиції не існує відповідного стовпчика."
+
+#~ msgid ""
+#~ "No renderer or invalid renderer type specified for custom data column."
+#~ msgstr ""
+#~ "Для стовпчика нетипових даних не вказано інструменту обробки або вказано "
+#~ "помилковий інструмент."
+
+#~ msgid "No renderer specified for column."
+#~ msgstr "Для стовпчика не вказано інструменту обробки."
+
+#~ msgid "Number of columns could not be determined."
+#~ msgstr "Не вдалося визначити кількість стовпчиків."
+
+#~ msgid "OpenGL function \"%s\" failed: %s (error %d)"
+#~ msgstr "Помилка у функції OpenGL «%s»: %s (помилка %d)"
+
+#~ msgid ""
+#~ "Please install a newer version of comctl32.dll\n"
+#~ "(at least version 4.70 is required but you have %d.%02d)\n"
+#~ "or this program won't operate correctly."
+#~ msgstr ""
+#~ "Будь ласка, встановіть новішу версію comctl32.dll\n"
+#~ "(потрібна принаймні версія 4.70, а ви маєте лише %d.%02d),\n"
+#~ "інакше ця програма працюватиме некоректно."
+
+#~ msgid "Pointer to data view control not set correctly."
+#~ msgstr ""
+#~ "Встановлено помилкове значення вказівника на інструмент керування "
+#~ "переглядом даних."
+
+#~ msgid "Pointer to model not set correctly."
+#~ msgstr "Встановлено помилкове значення вказівника на модель."
+
+#~ msgid "Progress renderer cannot render value type; value type: "
+#~ msgstr ""
+#~ "Інструменту обробки поступу не вдалося обробити тип значення; тип "
+#~ "значення: "
+
+#~ msgid "Rendering failed."
+#~ msgstr "Спроба показу зазнала невдачі."
+
+#~ msgid ""
+#~ "Setting directory access times is not supported under this OS version"
+#~ msgstr ""
+#~ "У цій версії операційної системи не передбачено встановлення часу доступу "
+#~ "до каталогів"
+
+#~ msgid "Show hidden directories"
+#~ msgstr "Показати приховані теки"
+
+#~ msgid "Text renderer cannot render value; value type: "
+#~ msgstr ""
+#~ "Інструменту обробки тексту не вдалося обробити значення; тип значення: "
+
+#~ msgid "There is no column or renderer for the specified column index."
+#~ msgstr ""
+#~ "Для вказаного номера стовпчика не передбачено стовпчика або інструменту "
+#~ "обробки."
+
+#~ msgid ""
+#~ "This system doesn't support date controls, please upgrade your version of "
+#~ "comctl32.dll"
+#~ msgstr ""
+#~ "Ця система не підтримує елементи визначення дати, будь ласка, оновіть "
+#~ "вашу версію comctl32.dll"
+
+#~ msgid "Toggle renderer cannot render value; value type: "
+#~ msgstr ""
+#~ "Інструменту обробки перемикання не вдалося обробити значення; тип "
+#~ "значення: "
+
+#~ msgid "Too many colours in PNG, the image may be slightly blurred."
+#~ msgstr "Забагато кольорів у PNG, картинка може бути трохи змазаною."
+
+#~ msgid "Unable to handle native drag&drop data"
+#~ msgstr "Не вдалося обробити власні дані перетягування зі скиданням"
+
+#~ msgid "Unable to initialize Hildon program"
+#~ msgstr "Не вдалося ініціалізувати програму Hildon"
+
+#~ msgid "Unknown data format"
+#~ msgstr "Невідомий формат даних"
+
+#~ msgid "Valid pointer to native data view control does not exist"
+#~ msgstr ""
+#~ "Не існує коректного вказівника на типовий інструмент керування переглядом"
+
+#~ msgid "Win32s on Windows 3.1"
+#~ msgstr "Win32s на Windows 3.1"
+
+#, fuzzy
+#~ msgid "Windows 10"
+#~ msgstr "Windows 8.1"
+
+#~ msgid "Windows 2000"
+#~ msgstr "Windows 2000"
+
+#~ msgid "Windows 7"
+#~ msgstr "Windows 7"
+
+#~ msgid "Windows 8"
+#~ msgstr "Windows 8"
+
+#~ msgid "Windows 8.1"
+#~ msgstr "Windows 8.1"
+
+#~ msgid "Windows 95"
+#~ msgstr "Windows 95"
+
+#~ msgid "Windows 95 OSR2"
+#~ msgstr "Windows 95 OSR2"
+
+#~ msgid "Windows 98"
+#~ msgstr "Windows 98"
+
+#~ msgid "Windows 98 SE"
+#~ msgstr "Windows 98 SE"
+
+#~ msgid "Windows 9x (%d.%d)"
+#~ msgstr "Windows 9x (%d.%d)"
+
+#~ msgid "Windows CE (%d.%d)"
+#~ msgstr "Windows CE (%d.%d)"
+
+#~ msgid "Windows ME"
+#~ msgstr "Windows ME"
+
+#~ msgid "Windows NT %lu.%lu"
+#~ msgstr "Windows NT %lu.%lu"
+
+#, fuzzy
+#~ msgid "Windows Server 10"
+#~ msgstr "Windows Server 2003"
+
+#~ msgid "Windows Server 2003"
+#~ msgstr "Windows Server 2003"
+
+#~ msgid "Windows Server 2008"
+#~ msgstr "Windows Server 2008"
+
+#~ msgid "Windows Server 2008 R2"
+#~ msgstr "Windows Server 2008 R2"
+
+#~ msgid "Windows Server 2012"
+#~ msgstr "Windows Server 2012"
+
+#~ msgid "Windows Server 2012 R2"
+#~ msgstr "Windows Server 2012 R2"
+
+#~ msgid "Windows Vista"
+#~ msgstr "Windows Vista"
+
+#~ msgid "Windows XP"
+#~ msgstr "Windows XP"
+
+#~ msgid "can't execute '%s'"
+#~ msgstr "неможливо виконати «%s»"
+
+#~ msgid "error opening '%s'"
+#~ msgstr "помилка під час відкриття «%s»"
+
+#~ msgid "unknown seek origin"
+#~ msgstr "невідомий відлік пошуку"
+
+#~ msgid "wxWidget control pointer is not a data view pointer"
+#~ msgstr ""
+#~ "Вказівник елемента керування wxWidget не є вказівником перегляду даних"
+
+#~ msgid "wxWidget's control not initialized."
+#~ msgstr "Керування wxWidget не ініціалізовано."
+
+#~ msgid "ADD"
+#~ msgstr "ДОДАТИ"
+
+#~ msgid "BACK"
+#~ msgstr "НАЗАД"
+
+#~ msgid "CANCEL"
+#~ msgstr "СКАСУВАТИ"
+
+#~ msgid "CAPITAL"
+#~ msgstr "ПРОПИСНА"
+
+#~ msgid "CLEAR"
+#~ msgstr "ОЧИСТИТИ"
+
+#~ msgid "COMMAND"
+#~ msgstr "КОМАНДА"
+
+#~ msgid "Cannot create mutex."
+#~ msgstr "Не вдалося створити синхронізацію."
+
+#~ msgid "Cannot resume thread %lu"
+#~ msgstr "Не вдалося відновити нитку %lu"
+
+#~ msgid "Cannot suspend thread %lu"
+#~ msgstr "Не вдалося призупинити нитку %lu"
+
+#~ msgid "Couldn't acquire a mutex lock"
+#~ msgstr "Не вдалося опитати замок семафора"
+
+#~ msgid "Couldn't get hatch style from wxBrush."
+#~ msgstr "Не вдалося отримати стиль штриха з wxBrush."
+
+#~ msgid "Couldn't release a mutex"
+#~ msgstr "Не вдалося звільнити семафор"
+
+#~ msgid "DECIMAL"
+#~ msgstr "ДЕСЯТКОВИЙ"
+
+#~ msgid "DEL"
+#~ msgstr "DEL"
+
+#~ msgid "DELETE"
+#~ msgstr "ВИЛУЧИТИ"
+
+#~ msgid "DIVIDE"
+#~ msgstr "DIVIDE"
+
+#~ msgid "DOWN"
+#~ msgstr "ВНИЗ"
+
+#~ msgid "END"
+#~ msgstr "КІНЕЦЬ"
+
+#~ msgid "ENTER"
+#~ msgstr "ENTER"
+
+#~ msgid "ESC"
+#~ msgstr "ESC"
+
+#~ msgid "ESCAPE"
+#~ msgstr "ESCAPE"
+
+#~ msgid "EXECUTE"
+#~ msgstr "ВИКОНАТИ"
+
+#~ msgid "Execution of command '%s' failed with error: %ul"
+#~ msgstr "Виконання команди «%s» закінчилося з помилкою: %ul"
+
+#~ msgid ""
+#~ "File '%s' already exists.\n"
+#~ "Do you want to replace it?"
+#~ msgstr ""
+#~ "Файл «%s» вже присутній.\n"
+#~ "Ви справді хочете його переписати?"
+
+#~ msgid "HELP"
+#~ msgstr "ДОПОМОГА"
+
+#~ msgid "HOME"
+#~ msgstr "HOME"
+
+#~ msgid "INS"
+#~ msgstr "ВСТ"
+
+#~ msgid "INSERT"
+#~ msgstr "ВСТАВИТИ"
+
+#~ msgid "KP_BEGIN"
+#~ msgstr "KP_BEGIN"
+
+#~ msgid "KP_DECIMAL"
+#~ msgstr "KP_DECIMAL"
+
+#~ msgid "KP_DELETE"
+#~ msgstr "KP_DELETE"
+
+#~ msgid "KP_DIVIDE"
+#~ msgstr "KP_DIVIDE"
+
+#~ msgid "KP_DOWN"
+#~ msgstr "KP_DOWN"
+
+#~ msgid "KP_ENTER"
+#~ msgstr "KP_ENTER"
+
+#~ msgid "KP_EQUAL"
+#~ msgstr "KP_EQUAL"
+
+#~ msgid "KP_HOME"
+#~ msgstr "KP_HOME"
+
+#~ msgid "KP_INSERT"
+#~ msgstr "KP_INSERT"
+
+#~ msgid "KP_LEFT"
+#~ msgstr "KP_LEFT"
+
+#~ msgid "KP_MULTIPLY"
+#~ msgstr "KP_MULTIPLY"
+
+#~ msgid "KP_NEXT"
+#~ msgstr "KP_NEXT"
+
+#~ msgid "KP_PAGEDOWN"
+#~ msgstr "KP_PAGEDOWN"
+
+#~ msgid "KP_PAGEUP"
+#~ msgstr "KP_PAGEUP"
+
+#~ msgid "KP_PRIOR"
+#~ msgstr "KP_PRIOR"
+
+#~ msgid "KP_RIGHT"
+#~ msgstr "KP_RIGHT"
+
+#~ msgid "KP_SEPARATOR"
+#~ msgstr "KP_SEPARATOR"
+
+#~ msgid "KP_SPACE"
+#~ msgstr "KP_SPACE"
+
+#~ msgid "KP_SUBTRACT"
+#~ msgstr "KP_SUBTRACT"
+
+#~ msgid "LEFT"
+#~ msgstr "LEFT"
+
+#~ msgid "MENU"
+#~ msgstr "MENU"
+
+#~ msgid "NUM_LOCK"
+#~ msgstr "NUM_LOCK"
+
+#~ msgid "PAGEDOWN"
+#~ msgstr "PAGEDOWN"
+
+#~ msgid "PAGEUP"
+#~ msgstr "PAGEUP"
+
+#~ msgid "PAUSE"
+#~ msgstr "PAUSE"
+
+#~ msgid "PGDN"
+#~ msgstr "PGDN"
+
+#~ msgid "PGUP"
+#~ msgstr "PGUP"
+
+#~ msgid "PRINT"
+#~ msgstr "ДРУК"
+
+#~ msgid "RETURN"
+#~ msgstr "RETURN"
+
+#~ msgid "RIGHT"
+#~ msgstr "RIGHT"
+
+#~ msgid "SCROLL_LOCK"
+#~ msgstr "SCROLL_LOCK"
+
+#~ msgid "SELECT"
+#~ msgstr "SELECT"
+
+#~ msgid "SEPARATOR"
+#~ msgstr "SEPARATOR"
+
+#~ msgid "SNAPSHOT"
+#~ msgstr "SNAPSHOT"
+
+#~ msgid "SPACE"
+#~ msgstr "ПРОБІЛ"
+
+#~ msgid "SUBTRACT"
+#~ msgstr "МІНУС"
+
+#~ msgid "TAB"
+#~ msgstr "TAB"
+
+#~ msgid "The print dialog returned an error."
+#~ msgstr "Діалоговим вікном друку повернуто повідомлення про помилку."
+
+#~ msgid "The wxGtkPrinterDC cannot be used."
+#~ msgstr "Не вдалося використати wxGtkPrinterDC."
+
+#~ msgid "Timer creation failed."
+#~ msgstr "Помилка створення таймера."
+
+#~ msgid "UP"
+#~ msgstr "ВГОРУ"
+
+#~ msgid "WINDOWS_LEFT"
+#~ msgstr "WINDOWS_LEFT"
+
+#~ msgid "WINDOWS_MENU"
+#~ msgstr "WINDOWS_MENU"
+
+#~ msgid "WINDOWS_RIGHT"
+#~ msgstr "WINDOWS_RIGHT"
+
+#~ msgid "buffer is too small for Windows directory."
+#~ msgstr "буфер замалий для теки Windows."
+
+#~ msgid "not implemented"
+#~ msgstr "не реалізовано"
+
+#~ msgid "wxPrintout::GetPageInfo gives a null maxPage."
+#~ msgstr "wxPrintout::GetPageInfo надано значення null для maxPage."
+
+#~ msgid "Event queue overflowed"
+#~ msgstr "Чергу подій переповнено"
+
+#~ msgid "percent"
+#~ msgstr "відсоток"
+
+#~ msgid "Print preview"
+#~ msgstr "Попередній перегляд друку"
+
+#~ msgid "'"
+#~ msgstr "'"
+
+#~ msgid "1"
+#~ msgstr "1"
+
+#~ msgid "10"
+#~ msgstr "10"
+
+#~ msgid "3"
+#~ msgstr "3"
+
+#~ msgid "4"
+#~ msgstr "4"
+
+#~ msgid "5"
+#~ msgstr "5"
+
+#~ msgid "6"
+#~ msgstr "6"
+
+#~ msgid "7"
+#~ msgstr "7"
+
+#~ msgid "8"
+#~ msgstr "8"
+
+#~ msgid "9"
+#~ msgstr "9"
+
+#~ msgid "Can't monitor non-existent path \"%s\" for changes."
+#~ msgstr ""
+#~ "Спостереження за змінами у каталозі «%s», якого не існує, неможливе."
+
+#~ msgid "File system containing watched object was unmounted"
+#~ msgstr ""
+#~ "Файлову систему, на якій зберігається об’єкт спостереження, було "
+#~ "демонтовано"
+
+#~ msgid "&Preview..."
+#~ msgstr "П&ереглянути…"
+
+#~ msgid "Preview..."
+#~ msgstr "Перегляд…"
+
+#~ msgid "The vertical offset relative to the paragraph."
+#~ msgstr "Вертикальний відступ відносно абзацу."
+
+#~ msgid "Units for the object offset."
+#~ msgstr "Одиниці виміру відступу об’єкта."
+
+#~ msgid "&Save..."
+#~ msgstr "&Зберегти…"
+
+#~ msgid "About "
+#~ msgstr "Про програму "
+
+#~ msgid "All files (*.*)|*"
+#~ msgstr "Всі файли (*.*)|*"
+
+#~ msgid "Cannot initialize SciTech MGL!"
+#~ msgstr "Не вдалося ініціювати SciTech MGL!"
+
+#~ msgid "Cannot initialize display."
+#~ msgstr "Не вдалося ініціювати дисплей."
+
+#~ msgid "Cannot start thread: error writing TLS"
+#~ msgstr "Не вдалося стартувати нитку: помилка запису TLS"
+
+#~ msgid "Close\tAlt-F4"
+#~ msgstr "Закрити\tAlt-F4"
+
+#~ msgid "Couldn't create cursor."
+#~ msgstr "Не вдалося створити курсор"
+
+#~ msgid "Directory '%s' doesn't exist!"
+#~ msgstr "Каталог «%s» не існує!"
+
+#~ msgid "Mode %ix%i-%i not available."
+#~ msgstr "Режим %ix%i-%i не працює."
+
+#~ msgid "Paper Size"
+#~ msgstr "Розмір паперу"
+
+#~ msgid "%.*f GB"
+#~ msgstr "%.*f ГБ"
+
+#~ msgid "%.*f MB"
+#~ msgstr "%.*f МБ"
+
+#~ msgid "%.*f TB"
+#~ msgstr "%.*f ТБ"
+
+#~ msgid "%.*f kB"
+#~ msgstr "%.*f КБ"
+
+#~ msgid "%s B"
+#~ msgstr "%s Б"
+
+#~ msgid "&Goto..."
+#~ msgstr "Перейти..."
+
+#~ msgid "<<"
+#~ msgstr "<<"
+
+#~ msgid ">>"
+#~ msgstr ">>"
+
+#~ msgid ">>|"
+#~ msgstr ">>|"
+
+#~ msgid "Added item is invalid."
+#~ msgstr "Доданий пункт є некоректним."
+
+#~ msgid "Archive doesnt contain #SYSTEM file"
+#~ msgstr "Архів не містить файла #SYSTEM"
+
+#~ msgid "BIG5"
+#~ msgstr "BIG5"
+
+#~ msgid "Can't check image format of file '%s': file does not exist."
+#~ msgstr "Не можу перевірити формат зображення файла «%s»: файла не існує."
+
+#~ msgid "Can't load image from file '%s': file does not exist."
+#~ msgstr "Не можу завантажити зображення з файла «%s»: файла не існує."
+
+#~ msgid "Cannot convert dialog units: dialog unknown."
+#~ msgstr "Не можу перетворити одиниці діалогу: невідомий діалог"
+
+#~ msgid "Cannot convert from the charset '%s'!"
+#~ msgstr "Не вдалося перетворити з кодування «%s»!"
+
+#~ msgid "Cannot find container for unknown control '%s'."
+#~ msgstr "Не вдалося знайти контейнер для невідомого контрола «%s»."
+
+#~ msgid "Cannot find font node '%s'."
+#~ msgstr "Не вдалося знайти вузол шрифту «%s»."
+
+#~ msgid "Cannot open file '%s'."
+#~ msgstr "Не вдалося відкрити файл «%s»."
+
+#~ msgid "Cannot parse coordinates from '%s'."
+#~ msgstr "Не вдалося обробити координати з %s"
+
+#~ msgid "Cannot parse dimension from '%s'."
+#~ msgstr "Не вдалося обробити розміри з «%s»"
+
+#~ msgid "Cant create the thread event queue"
+#~ msgstr "Не вдалося створити чергу подій нитки"
+
+#~ msgid "Changed item is invalid."
+#~ msgstr "Змінений пункт є некоректним."
+
+#~ msgid "Click to cancel this window."
+#~ msgstr "Клацніть, щоб закрити це вікно."
+
+#~ msgid "Click to confirm your selection."
+#~ msgstr "Клацніть, щоб підтвердити ваш вибір."
+
+#~ msgid "Column does not have a renderer."
+#~ msgstr "Не визначено обробника для стовпчика."
+
+#~ msgid "Column pointer must not be NULL."
+#~ msgstr "Вказівник стовпчика не повинен дорівнювати NULL."
+
+#~ msgid "Column's model column has no equivalent in the associated model."
+#~ msgstr "Не вдалося виявити еквівалент моделі стовпчика у пов’язаній моделі."
+
+#~ msgid "Control is wrongly initialized."
+#~ msgstr "Помилкова ініціалізація інструменту керування."
+
+#~ msgid "Could not add column to internal structures."
+#~ msgstr "Не вдалося додати стовпчик до вбудованих структур."
+
+#~ msgid "Could not unlock mutex"
+#~ msgstr "Не вдалося відімкнути семафор"
+
+#~ msgid "Data view control is not correctly initialized"
+#~ msgstr "Інструмент керування переглядом даних ініціалізовано з помилкою"
+
+#~ msgid "Error while waiting on semaphore"
+#~ msgstr "Помилка під час очікування семафору"
+
+#~ msgid "Failed to create a status bar."
+#~ msgstr "Помилка створення рядка стану."
+
+#~ msgid "Failed to register OpenGL window class."
+#~ msgstr "Не вдалося зареєструвати клас вікон OpenGL."
+
+#~ msgid "Fatal error: "
+#~ msgstr "Критична помилка: "
+
+#~ msgid "GB-2312"
+#~ msgstr "GB-2312"
+
+#~ msgid "Go forward to the next HTML page"
+#~ msgstr "Перейти до наступної сторінки HTML"
+
+#~ msgid "Goto Page"
+#~ msgstr "Іти на сторінку"
+
+#~ msgid ""
+#~ "HTML pagination algorithm generated more than the allowed maximum number "
+#~ "of pages and it can't continue any longer!"
+#~ msgstr ""
+#~ "Алгоритм розбиття на сторінки HTML виробив кількість сторінок, більшу за "
+#~ "максимальну дозволену, він не може продовжувати далі!"
+
+#~ msgid "Help : %s"
+#~ msgstr "Довідка: %s"
+
+#~ msgid "I64"
+#~ msgstr "I64"
+
+#~ msgid "Internal error, illegal wxCustomTypeInfo"
+#~ msgstr "Внутрішня помилка, некоректна wxCustomTypeInfo"
+
+#~ msgid "Invalid XRC resource '%s': doesn't have root node 'resource'."
+#~ msgstr "Неправильний ресурс XRC «%s»: немає коріння дерева 'ресурсу'."
+
+#~ msgid "No handler found for XML node '%s', class '%s'!"
+#~ msgstr "Не знайдено обробника на XML листок «%s», клас «%s»!"
+
+#~ msgid "No image handler for type %ld defined."
+#~ msgstr "Не визначено обробника для типу картинок %ld."
+
+#~ msgid "No model associated with control."
+#~ msgstr "З цим елементом керування не пов’язано моделі."
+
+#~ msgid "Owner not initialized."
+#~ msgstr "Не вдалося ініціювати власника."
+
+#~ msgid "Passed item is invalid."
+#~ msgstr "Переданий пункт є некоректним."
+
+#~ msgid "Passing a already registered object to SetObjectName"
+#~ msgstr "Передача вже зареєстрованого об'єкта до SetObjectName"
+
+#~ msgid "Preparing help window..."
+#~ msgstr "Підготовка вікна довідки..."
+
+#~ msgid "Program aborted."
+#~ msgstr "Програму зупинено."
+
+#~ msgid "Referenced object node with ref=\"%s\" not found!"
+#~ msgstr "Загаданий об'єкт листку з згадкою=«%s» не знайдений!"
+
+#~ msgid "Resource files must have same version number!"
+#~ msgstr "Файли ресурсів повинні мати однаковий номер версії!"
+
+#~ msgid "SHIFT-JIS"
+#~ msgstr "SHIFT-JIS"
+
+#~ msgid "Search!"
+#~ msgstr "Пошук!"
+
+#~ msgid "Sorry, could not open this file for saving."
+#~ msgstr "Цей файл не може бути відкритий для запису."
+
+#~ msgid "Sorry, could not save this file."
+#~ msgstr "Не вдалося записати цей файл."
+
+#~ msgid "Sorry, print preview needs a printer to be installed."
+#~ msgstr "Вибачте, для перегляду друку має бути встановлено друкарку."
+
+#~ msgid "Status: "
+#~ msgstr "Статус: "
+
+#~ msgid ""
+#~ "Streaming delegates for not already streamed objects not yet supported"
+#~ msgstr ""
+#~ "Streaming delegates для об'єктів, що ще не в потоці, ще не підтримується"
+
+#~ msgid "Subclass '%s' not found for resource '%s', not subclassing!"
+#~ msgstr "Підклас «%s» не знайдений для ресурсу «%s», не успадковується!"
+
+#~ msgid "TIFF library error."
+#~ msgstr "Помилка бібліотеки TIFF."
+
+#~ msgid "TIFF library warning."
+#~ msgstr "Попередження бібліотеки TIFF."
+
+#~ msgid ""
+#~ "The file '%s' couldn't be opened.\n"
+#~ "It has been removed from the most recently used files list."
+#~ msgstr ""
+#~ "Файл «%s» неможливо відкрити.\n"
+#~ "Його було вилучено зі списку файлів, що нещодавно використовувалися."
+
+#~ msgid "The path '%s' contains too many \"..\"!"
+#~ msgstr "Шлях «%s» має забагато «..»!"
+
+#~ msgid "Trying to solve a NULL hostname: giving up"
+#~ msgstr "Спроба встановити назву вузла NULL: скасування"
+
+#~ msgid "Unknown style flag "
+#~ msgstr "Невідомий стиль прапорця "
+
+#~ msgid "Warning"
+#~ msgstr "Попередження"
+
+#~ msgid "Windows 2000 (build %lu"
+#~ msgstr "Windows 2000 (build %lu"
+
+#~ msgid "XRC resource '%s' (class '%s') not found!"
+#~ msgstr "Не знайдено XRC ресурсу «%s» (клас «%s»)!"
+
+#~ msgid "XRC resource: Cannot create animation from '%s'."
+#~ msgstr "Ресурс XRC: Не вдалося створити анімацію з «%s»."
+
+#~ msgid "XRC resource: Cannot create bitmap from '%s'."
+#~ msgstr "XRC ресурс: Не можу створити bitmap з «%s»"
+
+#~ msgid ""
+#~ "XRC resource: Incorrect colour specification '%s' for attribute '%s'."
+#~ msgstr "XRC-ресурс: неправильно заданий колір «%s» для атрибута «%s»."
+
+#~ msgid "[EMPTY]"
+#~ msgstr "[ПУСТО]"
+
+#~ msgid "catalog file for domain '%s' not found."
+#~ msgstr "файл каталогу для домену «%s» не знайдений."
+
+#~ msgid "delegate has no type info"
+#~ msgstr "delegate не містить інформації про тип"
+
+#~ msgid "looking for catalog '%s' in path '%s'."
+#~ msgstr "Пошук каталогу «%s» у шляху «%s»."
+
+#~ msgid "m_peer is not or incorrectly initialized"
+#~ msgstr "m_peer не ініціалізовано або ініціалізовано з помилкою"
+
+#~ msgid "wxRichTextFontPage"
+#~ msgstr "wxRichTextFontPage"
+
+#~ msgid "wxSearchEngine::LookFor must be called before scanning!"
+#~ msgstr "wxSearchEngine::LookFor слід викликати до сканування!"
+
+#~ msgid "wxSocket: invalid signature in ReadMsg."
+#~ msgstr "wxSocket: недійсний підпис в ReadMsg."
+
+#~ msgid "wxSocket: unknown event!."
+#~ msgstr "wxSocket: невідома подія!"
+
+#~ msgid "|<<"
+#~ msgstr "|<<"

--- a/po_wxstd/vi.po
+++ b/po_wxstd/vi.po
@@ -1,0 +1,10527 @@
+# wxWidgets translation for Vietnamese.
+# This file is distributed under the same license as the wxWidgets package.
+# First translator Trần Ngọc Quân <vnwildman@gmail.com>, 2008-2014.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: wxWidgets 3.3\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-05-14 20:23+0200\n"
+"PO-Revision-Date: 2014-03-30 09:14+0700\n"
+"Last-Translator: Trần Ngọc Quân <vnwildman@gmail.com>\n"
+"Language-Team: Vietnamese <translation-team-vi@lists.sourceforge.net>\n"
+"Language: vi\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Poedit-SourceCharset: UTF-8\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"X-Generator: Poedit 1.5.5\n"
+
+#: ../include/wx/defs.h:2582
+msgid "All files (*.*)|*.*"
+msgstr "Mọi tập tin (*.*)|*.*"
+
+#: ../include/wx/defs.h:2585
+msgid "All files (*)|*"
+msgstr "Mọi tập tin (*)|*"
+
+#: ../include/wx/generic/progdlgg.h:85
+msgid "Elapsed time:"
+msgstr "Thời gian đã trôi qua:"
+
+#: ../include/wx/generic/progdlgg.h:86
+msgid "Estimated time:"
+msgstr "Thời gian ước tính:"
+
+#: ../include/wx/generic/progdlgg.h:87
+msgid "Remaining time:"
+msgstr "Thời gian còn lại:"
+
+#. TRANSLATORS: HTML printout default title.
+#: ../include/wx/html/htmprint.h:121 ../include/wx/prntbase.h:273
+#: ../include/wx/richtext/richtextprint.h:109 ../src/common/docview.cpp:2161
+msgid "Printout"
+msgstr "Dữ liệu in"
+
+#. TRANSLATORS: HTML easy print default title.
+#: ../include/wx/html/htmprint.h:234 ../include/wx/richtext/richtextprint.h:163
+#: ../src/common/prntbase.cpp:522 ../src/html/htmprint.cpp:291
+msgid "Printing"
+msgstr "In ấn"
+
+#: ../include/wx/msgdlg.h:277 ../src/common/stockitem.cpp:211
+msgid "Yes"
+msgstr "Đồng ý"
+
+#: ../include/wx/msgdlg.h:278 ../src/common/stockitem.cpp:182
+msgid "No"
+msgstr "Không"
+
+#: ../include/wx/msgdlg.h:279 ../src/common/stockitem.cpp:183
+#: ../src/msw/msgdlg.cpp:430 ../src/msw/msgdlg.cpp:734
+#: ../src/richtext/richtextstyledlg.cpp:292
+msgid "OK"
+msgstr "Đồng ý"
+
+#: ../include/wx/msgdlg.h:280 ../src/common/stockitem.cpp:150
+#: ../src/msw/msgdlg.cpp:430 ../src/msw/progdlg.cpp:884
+#: ../src/richtext/richtextstyledlg.cpp:295
+msgid "Cancel"
+msgstr "Hủy bỏ"
+
+#: ../include/wx/msgdlg.h:281 ../src/common/stockitem.cpp:168
+#: ../src/html/helpdlg.cpp:63 ../src/html/helpfrm.cpp:108
+#: ../src/osx/button_osx.cpp:38
+msgid "Help"
+msgstr "Trợ giúp"
+
+#: ../include/wx/msw/ole/oleutils.h:52
+msgid "Cannot initialize OLE"
+msgstr "Không thể khởi tạo OLE"
+
+#: ../include/wx/msw/private/fswatcher.h:48
+#, c-format
+msgid "Unable to close the handle for '%s'"
+msgstr "Không thể đóng thẻ quản handle cho '%s'"
+
+#: ../include/wx/msw/private/fswatcher.h:92
+#, c-format
+msgid "Failed to open directory \"%s\" for monitoring."
+msgstr "Lỗi khi mở thư mục \"%s\" để theo dõi."
+
+#: ../include/wx/msw/private/fswatcher.h:125
+msgid "Unable to close I/O completion port handle"
+msgstr "Không thể đóng handle cổng Vào/Ra"
+
+#: ../include/wx/msw/private/fswatcher.h:142
+msgid "Unable to associate handle with I/O completion port"
+msgstr "Không thể kết giao"
+
+#: ../include/wx/msw/private/fswatcher.h:148
+msgid "Unexpectedly new I/O completion port was created"
+msgstr "Một cổng I/O bất ngờ đã được tạo ra"
+
+#: ../include/wx/msw/private/fswatcher.h:213
+msgid "Unable to post completion status"
+msgstr "Không thể gửi hoàn thiện trạng thái"
+
+#: ../include/wx/msw/private/fswatcher.h:262
+msgid "Unable to dequeue completion packet"
+msgstr "Không thể tạo rút ra từ hàng đợi"
+
+#: ../include/wx/msw/private/fswatcher.h:273
+msgid "Unable to create I/O completion port"
+msgstr "Không thể tạo handle cổng Vào/Ra"
+
+#: ../include/wx/richmsgdlg.h:29
+msgid "&See details"
+msgstr "&Xem chi tiết"
+
+#: ../include/wx/richmsgdlg.h:30
+msgid "&Hide details"
+msgstr "Ẩ&n Chi tiết"
+
+#: ../include/wx/richtext/richtextbuffer.h:3864
+msgid "&Box"
+msgstr "Hộ&p:"
+
+#: ../include/wx/richtext/richtextbuffer.h:5008
+msgid "&Picture"
+msgstr "&Hình ảnh"
+
+#: ../include/wx/richtext/richtextbuffer.h:5958
+msgid "&Cell"
+msgstr "Ô"
+
+#: ../include/wx/richtext/richtextbuffer.h:6067
+msgid "&Table"
+msgstr "&Bảng"
+
+#: ../include/wx/richtext/richtextimagedlg.h:37
+msgid "Object Properties"
+msgstr "Thuộc tính Đối tượng"
+
+#: ../include/wx/richtext/richtextsymboldlg.h:39
+msgid "Symbols"
+msgstr "Ký tự đặc biệt"
+
+#: ../include/wx/unix/pipe.h:46
+msgid "Pipe creation failed"
+msgstr "Việc tạo đường ống gặp lỗi"
+
+#: ../include/wx/unix/private/displayx11.h:65
+msgid "Failed to enumerate video modes"
+msgstr "Đếm các chế độ video gặp lỗi"
+
+#: ../include/wx/unix/private/displayx11.h:89
+msgid "Failed to change video mode"
+msgstr "Thay đổi chế độ video gặp lỗi"
+
+#: ../include/wx/unix/private/fswatcher_kqueue.h:57
+#, c-format
+msgid "Unable to open path '%s'"
+msgstr "Không thể mở đường dẫn '%s'"
+
+#: ../include/wx/unix/private/fswatcher_kqueue.h:74
+#, c-format
+msgid "Unable to close path '%s'"
+msgstr "Không thể đóng đường dẫn '%s'"
+
+#: ../include/wx/xtiprop.h:175
+msgid "SetProperty called w/o valid setter"
+msgstr "SetProperty được gọi bởi bộ đặt w/o hợp lệ"
+
+#: ../include/wx/xtiprop.h:184
+msgid "GetProperty called w/o valid getter"
+msgstr "GetProperty được gọi bởi bộ nhận w/o hợp lệ"
+
+#: ../include/wx/xtiprop.h:193
+msgid "AddToPropertyCollection called w/o valid adder"
+msgstr "AddToPropertyCollection được gọi bởi bộ thêm w/o hợp lệ"
+
+#: ../include/wx/xtiprop.h:202
+msgid "GetPropertyCollection called w/o valid collection getter"
+msgstr "GetPropertyCollection được gọi bởi bộ nhận thu thập w/o hợp lệ"
+
+#: ../include/wx/xtiprop.h:255
+msgid "AddToPropertyCollection called on a generic accessor"
+msgstr "AddToPropertyCollection được gọi bởi một bộ truy cập chung"
+
+#: ../include/wx/xtiprop.h:262
+msgid "GetPropertyCollection called on a generic accessor"
+msgstr "GetPropertyCollection được gọi bởi một bộ truy cập chung"
+
+#: ../src/aui/tabmdi.cpp:106 ../src/generic/mdig.cpp:94
+msgid "Cl&ose"
+msgstr "Đón&g"
+
+#: ../src/aui/tabmdi.cpp:107 ../src/generic/mdig.cpp:95
+msgid "Close All"
+msgstr "Đóng hết"
+
+#: ../src/aui/tabmdi.cpp:109 ../src/generic/mdig.cpp:97 ../src/msw/mdi.cpp:175
+#: ../src/qt/mdi.cpp:258
+msgid "&Next"
+msgstr "Tiếp &theo"
+
+#: ../src/aui/tabmdi.cpp:110 ../src/generic/mdig.cpp:98 ../src/msw/mdi.cpp:176
+#: ../src/qt/mdi.cpp:259
+msgid "&Previous"
+msgstr "&Trước"
+
+#: ../src/aui/tabmdi.cpp:332 ../src/aui/tabmdi.cpp:348
+#: ../src/aui/tabmdi.cpp:350 ../src/generic/mdig.cpp:291
+#: ../src/generic/mdig.cpp:307 ../src/generic/mdig.cpp:311
+#: ../src/msw/mdi.cpp:337 ../src/qt/mdi.cpp:462
+msgid "&Window"
+msgstr "&Cửa sổ"
+
+#: ../src/common/accelcmn.cpp:47
+msgctxt "keyboard key"
+msgid "Delete"
+msgstr "Xóa bỏ"
+
+#: ../src/common/accelcmn.cpp:48
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Del"
+msgstr "Xóa bỏ"
+
+#: ../src/common/accelcmn.cpp:49
+msgctxt "keyboard key"
+msgid "Back"
+msgstr "Quay lại"
+
+#: ../src/common/accelcmn.cpp:49
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Backspace"
+msgstr "Quay lại"
+
+#: ../src/common/accelcmn.cpp:50
+msgctxt "keyboard key"
+msgid "Insert"
+msgstr "Chèn"
+
+#: ../src/common/accelcmn.cpp:51
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Ins"
+msgstr "Chèn"
+
+#: ../src/common/accelcmn.cpp:52
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Enter"
+msgstr "Máy in"
+
+#: ../src/common/accelcmn.cpp:53
+msgctxt "keyboard key"
+msgid "Return"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:54
+#, fuzzy
+msgctxt "keyboard key"
+msgid "PageUp"
+msgstr "Giấy"
+
+#: ../src/common/accelcmn.cpp:54
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Page Up"
+msgstr "Trang %d"
+
+#: ../src/common/accelcmn.cpp:55
+#, fuzzy
+msgctxt "keyboard key"
+msgid "PageDown"
+msgstr "Xuống"
+
+#: ../src/common/accelcmn.cpp:55
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Page Down"
+msgstr "Trang %d"
+
+#: ../src/common/accelcmn.cpp:56
+msgctxt "keyboard key"
+msgid "PgUp"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:57
+msgctxt "keyboard key"
+msgid "PgDn"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:58
+msgctxt "keyboard key"
+msgid "Left"
+msgstr "Trái"
+
+#: ../src/common/accelcmn.cpp:59
+msgctxt "keyboard key"
+msgid "Right"
+msgstr "Phải"
+
+#: ../src/common/accelcmn.cpp:60
+msgctxt "keyboard key"
+msgid "Up"
+msgstr "Lên"
+
+#: ../src/common/accelcmn.cpp:61
+msgctxt "keyboard key"
+msgid "Down"
+msgstr "Xuống"
+
+#: ../src/common/accelcmn.cpp:62
+msgctxt "keyboard key"
+msgid "Home"
+msgstr "Thư mục Home"
+
+#: ../src/common/accelcmn.cpp:63
+msgctxt "keyboard key"
+msgid "End"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:64
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Space"
+msgstr "Khoảng cách"
+
+#: ../src/common/accelcmn.cpp:65
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Tab"
+msgstr "Tabs"
+
+#: ../src/common/accelcmn.cpp:66
+msgctxt "keyboard key"
+msgid "Esc"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:67
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Escape"
+msgstr "Nằm ngang"
+
+#: ../src/common/accelcmn.cpp:68
+msgctxt "keyboard key"
+msgid "Cancel"
+msgstr "Hủy bỏ"
+
+#: ../src/common/accelcmn.cpp:69
+msgctxt "keyboard key"
+msgid "Clear"
+msgstr "Xóa sạch"
+
+#: ../src/common/accelcmn.cpp:70
+msgctxt "keyboard key"
+msgid "Menu"
+msgstr "Trình đơn"
+
+#: ../src/common/accelcmn.cpp:71
+msgctxt "keyboard key"
+msgid "Pause"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:72
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Capital"
+msgstr "Chữ viết &hoa"
+
+#: ../src/common/accelcmn.cpp:73
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Select"
+msgstr "Vùng chọn"
+
+#: ../src/common/accelcmn.cpp:74
+msgctxt "keyboard key"
+msgid "Print"
+msgstr "In"
+
+#: ../src/common/accelcmn.cpp:75
+msgctxt "keyboard key"
+msgid "Execute"
+msgstr "Thi hành"
+
+#: ../src/common/accelcmn.cpp:76
+msgctxt "keyboard key"
+msgid "Snapshot"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:77
+msgctxt "keyboard key"
+msgid "Help"
+msgstr "Trợ giúp"
+
+#: ../src/common/accelcmn.cpp:78
+msgctxt "keyboard key"
+msgid "Add"
+msgstr "Thêm"
+
+#: ../src/common/accelcmn.cpp:79
+msgctxt "keyboard key"
+msgid "Separator"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:80
+msgctxt "keyboard key"
+msgid "Subtract"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:81
+msgctxt "keyboard key"
+msgid "Decimal"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:82
+msgctxt "keyboard key"
+msgid "Multiply"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:83
+msgctxt "keyboard key"
+msgid "Divide"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:84
+msgctxt "keyboard key"
+msgid "Num_lock"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:84
+msgctxt "keyboard key"
+msgid "Num Lock"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:85
+msgctxt "keyboard key"
+msgid "Scroll_lock"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:85
+msgctxt "keyboard key"
+msgid "Scroll Lock"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:86
+msgctxt "keyboard key"
+msgid "KP_Space"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:86
+msgctxt "keyboard key"
+msgid "Num Space"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:87
+#, fuzzy
+msgctxt "keyboard key"
+msgid "KP_Tab"
+msgstr "KP_TAB"
+
+#: ../src/common/accelcmn.cpp:87
+msgctxt "keyboard key"
+msgid "Num Tab"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:88
+#, fuzzy
+msgctxt "keyboard key"
+msgid "KP_Enter"
+msgstr "Máy in"
+
+#: ../src/common/accelcmn.cpp:88
+msgctxt "keyboard key"
+msgid "Num Enter"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:89
+#, fuzzy
+msgctxt "keyboard key"
+msgid "KP_Home"
+msgstr "Thư mục Home"
+
+#: ../src/common/accelcmn.cpp:89
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Num Home"
+msgstr "Thư mục Home"
+
+#: ../src/common/accelcmn.cpp:90
+#, fuzzy
+msgctxt "keyboard key"
+msgid "KP_Left"
+msgstr "Trái"
+
+#: ../src/common/accelcmn.cpp:90
+msgctxt "keyboard key"
+msgid "Num left"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:91
+#, fuzzy
+msgctxt "keyboard key"
+msgid "KP_Up"
+msgstr "KP_UP"
+
+#: ../src/common/accelcmn.cpp:91
+msgctxt "keyboard key"
+msgid "Num Up"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:92
+#, fuzzy
+msgctxt "keyboard key"
+msgid "KP_Right"
+msgstr "Phải"
+
+#: ../src/common/accelcmn.cpp:92
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Num Right"
+msgstr "Phải"
+
+#: ../src/common/accelcmn.cpp:93
+#, fuzzy
+msgctxt "keyboard key"
+msgid "KP_Down"
+msgstr "Xuống"
+
+#: ../src/common/accelcmn.cpp:93
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Num Down"
+msgstr "Xuống"
+
+#: ../src/common/accelcmn.cpp:94
+msgctxt "keyboard key"
+msgid "KP_PageUp"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:94
+msgctxt "keyboard key"
+msgid "Num Page Up"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:95
+msgctxt "keyboard key"
+msgid "KP_PageDown"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:95
+msgctxt "keyboard key"
+msgid "Num Page Down"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:96
+msgctxt "keyboard key"
+msgid "KP_Prior"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:97
+#, fuzzy
+msgctxt "keyboard key"
+msgid "KP_Next"
+msgstr "Tiếp theo"
+
+#: ../src/common/accelcmn.cpp:98
+#, fuzzy
+msgctxt "keyboard key"
+msgid "KP_End"
+msgstr "KP_END"
+
+#: ../src/common/accelcmn.cpp:98
+msgctxt "keyboard key"
+msgid "Num End"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:99
+msgctxt "keyboard key"
+msgid "KP_Begin"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:99
+msgctxt "keyboard key"
+msgid "Num Begin"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:100
+#, fuzzy
+msgctxt "keyboard key"
+msgid "KP_Insert"
+msgstr "Chèn"
+
+#: ../src/common/accelcmn.cpp:100
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Num Insert"
+msgstr "Chèn"
+
+#: ../src/common/accelcmn.cpp:101
+#, fuzzy
+msgctxt "keyboard key"
+msgid "KP_Delete"
+msgstr "Xóa bỏ"
+
+#: ../src/common/accelcmn.cpp:101
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Num Delete"
+msgstr "Xóa bỏ"
+
+#: ../src/common/accelcmn.cpp:102
+msgctxt "keyboard key"
+msgid "KP_Equal"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:102
+msgctxt "keyboard key"
+msgid "Num ="
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:103
+msgctxt "keyboard key"
+msgid "KP_Multiply"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:103
+msgctxt "keyboard key"
+msgid "Num *"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:104
+#, fuzzy
+msgctxt "keyboard key"
+msgid "KP_Add"
+msgstr "KP_ADD"
+
+#: ../src/common/accelcmn.cpp:104
+msgctxt "keyboard key"
+msgid "Num +"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:105
+msgctxt "keyboard key"
+msgid "KP_Separator"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:105
+msgctxt "keyboard key"
+msgid "Num ,"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:106
+msgctxt "keyboard key"
+msgid "KP_Subtract"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:106
+msgctxt "keyboard key"
+msgid "Num -"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:107
+msgctxt "keyboard key"
+msgid "KP_Decimal"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:107
+msgctxt "keyboard key"
+msgid "Num ."
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:108
+msgctxt "keyboard key"
+msgid "KP_Divide"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:108
+msgctxt "keyboard key"
+msgid "Num /"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:109
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Windows_Left"
+msgstr "Windows 7"
+
+#: ../src/common/accelcmn.cpp:110
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Windows_Right"
+msgstr "Windows Vista"
+
+#: ../src/common/accelcmn.cpp:111
+#, fuzzy
+msgctxt "keyboard key"
+msgid "Windows_Menu"
+msgstr "Windows ME"
+
+#: ../src/common/accelcmn.cpp:112
+msgctxt "keyboard key"
+msgid "Command"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:186 ../src/common/accelcmn.cpp:359
+msgctxt "keyboard key"
+msgid "Ctrl"
+msgstr "Ctrl"
+
+#: ../src/common/accelcmn.cpp:188 ../src/common/accelcmn.cpp:363
+msgctxt "keyboard key"
+msgid "Alt"
+msgstr "Alt"
+
+#: ../src/common/accelcmn.cpp:190 ../src/common/accelcmn.cpp:361
+msgctxt "keyboard key"
+msgid "Shift"
+msgstr "Shift"
+
+#: ../src/common/accelcmn.cpp:196
+msgctxt "keyboard key"
+msgid "num "
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:260 ../src/common/accelcmn.cpp:382
+msgctxt "keyboard key"
+msgid "F"
+msgstr "F"
+
+#: ../src/common/accelcmn.cpp:277 ../src/common/accelcmn.cpp:385
+msgctxt "keyboard key"
+msgid "KP_F"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:280 ../src/common/accelcmn.cpp:388
+msgctxt "keyboard key"
+msgid "KP_"
+msgstr "KP_"
+
+#: ../src/common/accelcmn.cpp:283 ../src/common/accelcmn.cpp:391
+msgctxt "keyboard key"
+msgid "SPECIAL"
+msgstr "SPECIAL"
+
+#: ../src/common/accelcmn.cpp:373
+#, fuzzy
+msgid "Ctrl"
+msgstr "Ctrl"
+
+#: ../src/common/appbase.cpp:786
+msgid "show this help message"
+msgstr "hiển thị thông tin trợ giúp này"
+
+#: ../src/common/appbase.cpp:796
+msgid "generate verbose log messages"
+msgstr "tạo ra nhật ký thông tin đầy đủ"
+
+#: ../src/common/appcmn.cpp:256
+msgid "specify the theme to use"
+msgstr "định rõ theme cần dùng"
+
+#: ../src/common/appcmn.cpp:270
+msgid "specify display mode to use (e.g. 640x480-16)"
+msgstr "định rõ chế độ hiển thị sử dụng (ví dụ 640x480-16)"
+
+#: ../src/common/appcmn.cpp:292
+#, c-format
+msgid "Unsupported theme '%s'."
+msgstr "Theme '%s' không được hỗ trợ."
+
+#: ../src/common/appcmn.cpp:309
+#, c-format
+msgid "Invalid display mode specification '%s'."
+msgstr "Chi tiết chế độ hiển thị '%s' không hợp lệ."
+
+#: ../src/common/cmdline.cpp:875
+#, c-format
+msgid "Option '%s' can't be negated"
+msgstr "Tuỳ chọn '%s' không thể bị phủ định"
+
+#: ../src/common/cmdline.cpp:889
+#, c-format
+msgid "Unknown long option '%s'"
+msgstr "Không rõ tùy chọn dài '%s'"
+
+#: ../src/common/cmdline.cpp:904 ../src/common/cmdline.cpp:926
+#, c-format
+msgid "Unknown option '%s'"
+msgstr "Không biết tùy chọn %s"
+
+#: ../src/common/cmdline.cpp:1004
+#, c-format
+msgid "Unexpected characters following option '%s'."
+msgstr "Không cần ký tự đi sau tùy chọn '%s'."
+
+#: ../src/common/cmdline.cpp:1039
+#, c-format
+msgid "Option '%s' requires a value."
+msgstr "Tùy chọn '%s' yêu cầu một giá trị."
+
+#: ../src/common/cmdline.cpp:1058
+#, c-format
+msgid "Separator expected after the option '%s'."
+msgstr "Cần dấu phân cách sau tùy chọn '%s'."
+
+#: ../src/common/cmdline.cpp:1088 ../src/common/cmdline.cpp:1106
+#, c-format
+msgid "'%s' is not a correct numeric value for option '%s'."
+msgstr "'%s' không phải là một giá trị bằng số đúng cho tùy chọn '%s'."
+
+#: ../src/common/cmdline.cpp:1122
+#, c-format
+msgid "Option '%s': '%s' cannot be converted to a date."
+msgstr "Tùy chọn '%s': '%s' không thể chuyển thành dạng ngày tháng."
+
+#: ../src/common/cmdline.cpp:1170
+#, c-format
+msgid "Unexpected parameter '%s'"
+msgstr "Tham số không cần thiết '%s'"
+
+#. TRANSLATORS: Short name and long name for a command line option
+#: ../src/common/cmdline.cpp:1197
+#, c-format
+msgid "%s (or %s)"
+msgstr "%s (hoặc %s)"
+
+#: ../src/common/cmdline.cpp:1208
+#, c-format
+msgid "The value for the option '%s' must be specified."
+msgstr "Giá trị cho tùy chọn '%s' phải được định rõ."
+
+#: ../src/common/cmdline.cpp:1230
+#, c-format
+msgid "The required parameter '%s' was not specified."
+msgstr "Tham số yêu cầu '%s' đã không được định rõ."
+
+#: ../src/common/cmdline.cpp:1289
+#, c-format
+msgid "Usage: %s"
+msgstr "Cách dùng: %s"
+
+#: ../src/common/cmdline.cpp:1498
+msgid "str"
+msgstr "str"
+
+#: ../src/common/cmdline.cpp:1502
+msgid "num"
+msgstr "số"
+
+#: ../src/common/cmdline.cpp:1506
+msgid "double"
+msgstr "kép"
+
+#: ../src/common/cmdline.cpp:1510
+msgid "date"
+msgstr "ngày tháng"
+
+#: ../src/common/cmdproc.cpp:250 ../src/common/cmdproc.cpp:276
+#: ../src/common/cmdproc.cpp:296
+msgid "Unnamed command"
+msgstr "Câu lệnh vô danh"
+
+#: ../src/common/cmdproc.cpp:253
+msgid "&Undo "
+msgstr "&Undo "
+
+#: ../src/common/cmdproc.cpp:255
+msgid "Can't &Undo "
+msgstr "Không thể &Undo"
+
+#: ../src/common/cmdproc.cpp:259 ../src/common/stockitem.cpp:208
+#: ../src/msw/textctrl.cpp:2880 ../src/osx/textctrl_osx.cpp:649
+#: ../src/richtext/richtextctrl.cpp:327
+msgid "&Undo"
+msgstr "&Undo"
+
+#: ../src/common/cmdproc.cpp:277 ../src/common/cmdproc.cpp:297
+msgid "&Redo "
+msgstr "&Redo "
+
+#: ../src/common/cmdproc.cpp:281 ../src/common/cmdproc.cpp:288
+#: ../src/common/stockitem.cpp:190 ../src/msw/textctrl.cpp:2881
+#: ../src/osx/textctrl_osx.cpp:650 ../src/richtext/richtextctrl.cpp:328
+msgid "&Redo"
+msgstr "&Redo"
+
+#: ../src/common/colourcmn.cpp:41
+#, c-format
+msgid "String To Colour : Incorrect colour specification : %s"
+msgstr "Màu từ Xâu chữ : Đặc tả màu không chính xác : %s"
+
+#: ../src/common/config.cpp:259
+#, c-format
+msgid "Invalid value %ld for a boolean key \"%s\" in config file."
+msgstr ""
+"Giá trị %ld không hợp lệ cho một khoá thuộc kiểu lôgíc \"%s\" trong tập tin "
+"dùng cho cấu hình."
+
+#: ../src/common/config.cpp:526
+#, c-format
+msgid ""
+"Environment variables expansion failed: missing '%c' at position %u in '%s'."
+msgstr ""
+"Sự mở rộng các biến môi trường gặp lỗi: mất '%c' tại vị trí %u trong '%s'."
+
+#: ../src/common/config.cpp:576 ../src/msw/regconf.cpp:272
+#, c-format
+msgid "'%s' has extra '..', ignored."
+msgstr "'%s' có thêm '..', bỏ qua."
+
+#. TRANSLATORS: Checkbox state name
+#: ../src/common/datavcmn.cpp:2166 ../src/generic/datavgen.cpp:1430
+msgid "checked"
+msgstr ""
+
+#. TRANSLATORS: Checkbox state name
+#: ../src/common/datavcmn.cpp:2170 ../src/generic/datavgen.cpp:1432
+msgid "unchecked"
+msgstr ""
+
+#. TRANSLATORS: Checkbox state name
+#: ../src/common/datavcmn.cpp:2174
+#, fuzzy
+msgid "undetermined"
+msgstr "gạch chân"
+
+#: ../src/common/datetimefmt.cpp:1875
+msgid "today"
+msgstr "hôm nay"
+
+#: ../src/common/datetimefmt.cpp:1876
+msgid "yesterday"
+msgstr "hôm qua"
+
+#: ../src/common/datetimefmt.cpp:1877
+msgid "tomorrow"
+msgstr "ngày mai"
+
+#: ../src/common/datetimefmt.cpp:2071
+msgid "first"
+msgstr "đầu tiên"
+
+#: ../src/common/datetimefmt.cpp:2072
+msgid "second"
+msgstr "giây"
+
+#: ../src/common/datetimefmt.cpp:2073
+msgid "third"
+msgstr "thứ ba"
+
+#: ../src/common/datetimefmt.cpp:2074
+msgid "fourth"
+msgstr "thứ tư"
+
+#: ../src/common/datetimefmt.cpp:2075
+msgid "fifth"
+msgstr "thứ năm"
+
+#: ../src/common/datetimefmt.cpp:2076
+msgid "sixth"
+msgstr "thứ sáu"
+
+#: ../src/common/datetimefmt.cpp:2077
+msgid "seventh"
+msgstr "thứ bảy"
+
+#: ../src/common/datetimefmt.cpp:2078
+msgid "eighth"
+msgstr "thứ tám"
+
+#: ../src/common/datetimefmt.cpp:2079
+msgid "ninth"
+msgstr "thứ chín"
+
+#: ../src/common/datetimefmt.cpp:2080
+msgid "tenth"
+msgstr "thứ mười"
+
+#: ../src/common/datetimefmt.cpp:2081
+msgid "eleventh"
+msgstr "thứ mười một"
+
+#: ../src/common/datetimefmt.cpp:2082
+msgid "twelfth"
+msgstr "thứ mười hai"
+
+#: ../src/common/datetimefmt.cpp:2083
+msgid "thirteenth"
+msgstr "thứ mười ba"
+
+#: ../src/common/datetimefmt.cpp:2084
+msgid "fourteenth"
+msgstr "thứ mười bốn"
+
+#: ../src/common/datetimefmt.cpp:2085
+msgid "fifteenth"
+msgstr "thứ mười lăm"
+
+#: ../src/common/datetimefmt.cpp:2086
+msgid "sixteenth"
+msgstr "thứ mười sáu"
+
+#: ../src/common/datetimefmt.cpp:2087
+msgid "seventeenth"
+msgstr "thứ mười bảy"
+
+#: ../src/common/datetimefmt.cpp:2088
+msgid "eighteenth"
+msgstr "thứ mười tám"
+
+#: ../src/common/datetimefmt.cpp:2089
+msgid "nineteenth"
+msgstr "thứ mười chín"
+
+#: ../src/common/datetimefmt.cpp:2090
+msgid "twentieth"
+msgstr "thứ hai mươi"
+
+#: ../src/common/datetimefmt.cpp:2248
+msgid "noon"
+msgstr "buổi trưa"
+
+#: ../src/common/datetimefmt.cpp:2249
+msgid "midnight"
+msgstr "nửa đêm"
+
+#: ../src/common/debugrpt.cpp:209
+#, c-format
+msgid "Failed to create directory \"%s\""
+msgstr "Tạo thư mục \"%s\" gặp lỗi"
+
+#: ../src/common/debugrpt.cpp:210
+msgid "Debug report couldn't be created."
+msgstr "Báo cáo gỡ lỗi không thể được tạo ra."
+
+#: ../src/common/debugrpt.cpp:227
+#, c-format
+msgid "Failed to remove debug report file \"%s\""
+msgstr "Gỡ bỏ tập tin báo cáo gỡ lỗi \"%s\" gặp lỗi"
+
+#: ../src/common/debugrpt.cpp:239
+#, c-format
+msgid "Failed to clean up debug report directory \"%s\""
+msgstr "Việc xóa sạch thư mục báo cáo lỗi \"%s\" gặp lỗi"
+
+#: ../src/common/debugrpt.cpp:514
+msgid "process context description"
+msgstr "mô tả ngữ cảnh tiến trình"
+
+#: ../src/common/debugrpt.cpp:538
+msgid "dump of the process state (binary)"
+msgstr "kết xuất trạng thái qui trình (dạng nhị phân)"
+
+#: ../src/common/debugrpt.cpp:553
+msgid "Debug report generation has failed."
+msgstr "Việc tạo ra bản báo cáo lỗi gặp lỗi."
+
+#: ../src/common/debugrpt.cpp:560
+#, c-format
+msgid ""
+"Processing debug report has failed, leaving the files in \"%s\" directory."
+msgstr "Sự tạo báo cáo gỡ lỗi bị lỗi, tập tin xuất ra trong thư mục \"%s\"."
+
+#: ../src/common/debugrpt.cpp:573
+msgid "A debug report has been generated. It can be found in"
+msgstr "Một báo cáo lỗi đã được tạo ra. Nó có thể tìm thấy trong"
+
+#: ../src/common/debugrpt.cpp:576
+msgid "And includes the following files:\n"
+msgstr "Và bao gồm các tập tin sau đây:\n"
+
+#: ../src/common/debugrpt.cpp:586
+msgid ""
+"\n"
+"Please send this report to the program maintainer, thank you!\n"
+msgstr ""
+"\n"
+"Xin hãy gửi bản báo cáo này tới người bảo trì chương trình, xin cảm ơn!\n"
+
+#: ../src/common/debugrpt.cpp:729
+msgid "Failed to execute curl, please install it in PATH."
+msgstr "Thực thi curl gặp lỗi, xin thiết đặt nó trong ĐƯỜNG DẪN."
+
+#: ../src/common/debugrpt.cpp:742
+#, c-format
+msgid "Failed to upload the debug report (error code %d)."
+msgstr "Tải lên báo cáo lỗi gặp lỗi (mã lỗi %d)."
+
+#: ../src/common/docview.cpp:366
+msgid "Save As"
+msgstr "Ghi Lại Bằng Tên Mới"
+
+#: ../src/common/docview.cpp:457
+msgid "Discard changes and reload the last saved version?"
+msgstr "Không dùng những thay đổi này và tải lại dữ liệu đã lưu lần trước?"
+
+#: ../src/common/docview.cpp:488
+msgid "unnamed"
+msgstr "không_tên"
+
+#: ../src/common/docview.cpp:513
+#, c-format
+msgid "Do you want to save changes to %s?"
+msgstr "Bạn có muốn ghi lại các thay đổi với %s không?"
+
+#: ../src/common/docview.cpp:521 ../src/common/docview.cpp:560
+#: ../src/common/stockitem.cpp:195
+msgid "&Save"
+msgstr "&Ghi lại"
+
+#: ../src/common/docview.cpp:522 ../src/common/docview.cpp:560
+msgid "&Discard changes"
+msgstr ""
+
+#: ../src/common/docview.cpp:523
+#, fuzzy
+msgid "Do&n't close"
+msgstr "Không Ghi Lại"
+
+#: ../src/common/docview.cpp:553
+#, fuzzy, c-format
+msgid "Do you want to save changes to %s before closing it?"
+msgstr "Bạn có muốn ghi lại các thay đổi với %s không?"
+
+#: ../src/common/docview.cpp:559
+#, fuzzy
+msgid "The document must be closed."
+msgstr "Dữ liệu dạng chữ không thể được ghi lại."
+
+#: ../src/common/docview.cpp:571
+#, c-format
+msgid "Saving %s failed, would you like to retry?"
+msgstr ""
+
+#: ../src/common/docview.cpp:577
+msgid "Retry"
+msgstr ""
+
+#: ../src/common/docview.cpp:577
+msgid "Discard changes"
+msgstr ""
+
+#: ../src/common/docview.cpp:679
+#, c-format
+msgid "File \"%s\" could not be opened for writing."
+msgstr "Tập tin  \"%s\" không thể mở để ghi."
+
+#: ../src/common/docview.cpp:685
+#, c-format
+msgid "Failed to save document to the file \"%s\"."
+msgstr "Gặp lỗi khi ghi tài liệu vào tập tin \"%s\"."
+
+#: ../src/common/docview.cpp:702
+#, c-format
+msgid "File \"%s\" could not be opened for reading."
+msgstr "Tập tin  \"%s\" không thể mở để đọc."
+
+#: ../src/common/docview.cpp:714
+#, c-format
+msgid "Failed to read document from the file \"%s\"."
+msgstr "Lỗi đọc từ tập tin \"%s\" gặp lỗi."
+
+#: ../src/common/docview.cpp:1236
+#, c-format
+msgid ""
+"The file '%s' doesn't exist and couldn't be opened.\n"
+"It has been removed from the most recently used files list."
+msgstr ""
+"Tập tin '%s' không tồn tại và không thể mở được.\n"
+"Nó đã bị gỡ bỏ từ danh sách tập tin mới được dùng gần đây nhất."
+
+#: ../src/common/docview.cpp:1296
+msgid "Print preview creation failed."
+msgstr "Tạo bản xem thử khi in gặp lỗi."
+
+#: ../src/common/docview.cpp:1302
+msgid "Print Preview"
+msgstr "Mô Phỏng Bản In"
+
+#: ../src/common/docview.cpp:1517
+#, c-format
+msgid "The format of file '%s' couldn't be determined."
+msgstr "Định dạng của tập tin '%s' không phân tách đúng định dạng."
+
+#: ../src/common/docview.cpp:1643
+#, c-format
+msgid "unnamed%d"
+msgstr "Không_tên%d"
+
+#: ../src/common/docview.cpp:1660
+msgid " - "
+msgstr " - "
+
+#: ../src/common/docview.cpp:1791 ../src/common/docview.cpp:1844
+msgid "Open File"
+msgstr "Mở tập tin"
+
+#: ../src/common/docview.cpp:1807
+msgid "File error"
+msgstr "Lỗi tập tin"
+
+#: ../src/common/docview.cpp:1809
+msgid "Sorry, could not open this file."
+msgstr "Xin lỗi, không thể mở tập tin này."
+
+#: ../src/common/docview.cpp:1843
+msgid "Sorry, the format for this file is unknown."
+msgstr "Rất tiếc, định dạng tập tin này không hiểu."
+
+#: ../src/common/docview.cpp:1924
+msgid "Select a document template"
+msgstr "Chọn một tài liệu tạm thời"
+
+#: ../src/common/docview.cpp:1925
+msgid "Templates"
+msgstr "Biểu mẫu"
+
+#: ../src/common/docview.cpp:1998
+msgid "Select a document view"
+msgstr "Chọn một bộ hiển thị tài liệu"
+
+#: ../src/common/docview.cpp:1999
+msgid "Views"
+msgstr "Trình bày"
+
+#: ../src/common/dynlib.cpp:81
+#, c-format
+msgid "Failed to load shared library '%s'"
+msgstr "Tải thư viện chia sẻ %s gặp lỗi"
+
+#: ../src/common/dynlib.cpp:105
+#, c-format
+msgid "Couldn't find symbol '%s' in a dynamic library"
+msgstr "Không thể tìm thấy ký tự đặc biệt '%s' trong thư viện liên kết động"
+
+#: ../src/common/ffile.cpp:56 ../src/common/file.cpp:215
+#, c-format
+msgid "can't open file '%s'"
+msgstr "không thể mở tập tin '%s'"
+
+#: ../src/common/ffile.cpp:72
+#, c-format
+msgid "can't close file '%s'"
+msgstr "không thể đóng tập tin '%s'"
+
+#: ../src/common/ffile.cpp:106 ../src/common/ffile.cpp:131
+#, c-format
+msgid "Read error on file '%s'"
+msgstr "Lỗi đọc trong tập tin '%s'"
+
+#: ../src/common/ffile.cpp:148
+#, c-format
+msgid "Write error on file '%s'"
+msgstr "Lỗi ghi trên tập tin '%s'"
+
+#: ../src/common/ffile.cpp:182
+#, c-format
+msgid "failed to flush the file '%s'"
+msgstr "làm phẳng tập tin '%s' gặp lỗi"
+
+#: ../src/common/ffile.cpp:222
+#, c-format
+msgid "Seek error on file '%s' (large files not supported by stdio)"
+msgstr ""
+"Lỗi khi di chuyển vị trí đọc trên tập tin '%s' (tập tin có kích thước lớn "
+"không được hỗ trợ bởi stdio)"
+
+#: ../src/common/ffile.cpp:232
+#, c-format
+msgid "Seek error on file '%s'"
+msgstr "Lỗi khi di chuyển vị trí đọc trên tập tin '%s'"
+
+#: ../src/common/ffile.cpp:248
+#, c-format
+msgid "Can't find current position in file '%s'"
+msgstr "Không thể tìm được vị trí hiện hành trong tập tin '%s'"
+
+#: ../src/common/ffile.cpp:349 ../src/common/file.cpp:569
+msgid "Failed to set temporary file permissions"
+msgstr "Đặt quyền cho tập tin tạm gặp lỗi"
+
+#: ../src/common/ffile.cpp:371
+#, c-format
+msgid "can't remove file '%s'"
+msgstr "không thể gỡ bỏ tập tin '%s'"
+
+#: ../src/common/ffile.cpp:376 ../src/common/file.cpp:591
+#, c-format
+msgid "can't commit changes to file '%s'"
+msgstr "không thể chuyển các thay đổi tới tập tin '%s'"
+
+#: ../src/common/ffile.cpp:388 ../src/common/file.cpp:603
+#, c-format
+msgid "can't remove temporary file '%s'"
+msgstr "không thể gỡ bỏ tập tin tạm thời '%s'"
+
+#: ../src/common/file.cpp:162
+#, c-format
+msgid "can't create file '%s'"
+msgstr "không thể tạo tập tin '%s'"
+
+#: ../src/common/file.cpp:229
+#, c-format
+msgid "can't close file descriptor %d"
+msgstr "không thể đóng phần mô tả tập tin %d"
+
+#: ../src/common/file.cpp:332
+#, c-format
+msgid "can't read from file descriptor %d"
+msgstr "không thể đọc từ phần mô tả tập tin %d"
+
+#: ../src/common/file.cpp:351
+#, c-format
+msgid "can't write to file descriptor %d"
+msgstr "không thể ghi dữ liệu vào phần mô tả tập tin %d"
+
+#: ../src/common/file.cpp:390
+#, c-format
+msgid "can't flush file descriptor %d"
+msgstr "không thể vào thẳng phần mô tả tập tin %d"
+
+#: ../src/common/file.cpp:432
+#, c-format
+msgid "can't seek on file descriptor %d"
+msgstr "không thể tìm kiếm trên phần mô tả tập tin %d"
+
+#: ../src/common/file.cpp:446
+#, c-format
+msgid "can't get seek position on file descriptor %d"
+msgstr "không thể tìm thấy vị trí trên phần mô tả tập tin %d"
+
+#: ../src/common/file.cpp:475
+#, c-format
+msgid "can't find length of file on file descriptor %d"
+msgstr "không thể tìm thấy độ dài của tập tin trên phần mô tả tập tin %d"
+
+#: ../src/common/file.cpp:505
+#, c-format
+msgid "can't determine if the end of file is reached on descriptor %d"
+msgstr "không thể kết thúc nếu kết thúc tập tin nằm trên phần mô tả %d"
+
+#: ../src/common/fileconf.cpp:352
+#, c-format
+msgid ""
+" and additionally, the existing configuration file was renamed to \"%s\" and "
+"couldn't be renamed back, please rename it to its original path \"%s\""
+msgstr ""
+
+#: ../src/common/fileconf.cpp:389
+#, fuzzy
+msgid " due to the following error:\n"
+msgstr "Và bao gồm các tập tin sau đây:\n"
+
+#: ../src/common/fileconf.cpp:412
+#, fuzzy
+msgid "failed to rename the existing file"
+msgstr "Lỗi đọc từ tập tin \"%s\" gặp lỗi."
+
+#: ../src/common/fileconf.cpp:421
+#, fuzzy
+msgid "failed to create the new file directory"
+msgstr "Lấy thư mục đang làm việc gặp lỗi"
+
+#: ../src/common/fileconf.cpp:428
+#, fuzzy
+msgid "failed to move the file to the new location"
+msgstr "Chấm dứt kết nối quay số gặp lỗi: %s"
+
+#: ../src/common/fileconf.cpp:462
+#, c-format
+msgid "can't open global configuration file '%s'."
+msgstr "không thể mở tập tin cấu hình chung '%s'."
+
+#: ../src/common/fileconf.cpp:478
+#, c-format
+msgid "can't open user configuration file '%s'."
+msgstr "không thể mở tập tin '%s' cấu hình của người dùng."
+
+#: ../src/common/fileconf.cpp:483
+#, c-format
+msgid "Changes won't be saved to avoid overwriting the existing file \"%s\""
+msgstr ""
+"Các thay đổi không thể ghi lại mà không ghi đè lên tập tin đã tồn tại \"%s\""
+
+#: ../src/common/fileconf.cpp:583
+msgid "Error reading config options."
+msgstr "Lỗi trong việc đọc các tùy chọn cấu hình."
+
+#: ../src/common/fileconf.cpp:593
+msgid "Failed to read config options."
+msgstr "Đọc cấu hình tùy chọn gặp lỗi."
+
+#: ../src/common/fileconf.cpp:700
+#, fuzzy, c-format
+msgid "file '%s': unexpected character %c at line %zu."
+msgstr "tập tin '%s': không mong ký tự %c tại dòng %d."
+
+#: ../src/common/fileconf.cpp:736
+#, fuzzy, c-format
+msgid "file '%s', line %zu: '%s' ignored after group header."
+msgstr "tập tin '%s', dòng %d: '%s' được bỏ qua trước phần đầu nhóm."
+
+#: ../src/common/fileconf.cpp:765
+#, fuzzy, c-format
+msgid "file '%s', line %zu: '=' expected."
+msgstr "tập tin '%s', dòng %d: cần '='."
+
+#: ../src/common/fileconf.cpp:778
+#, fuzzy, c-format
+msgid "file '%s', line %zu: value for immutable key '%s' ignored."
+msgstr "tập tin '%s', dòng %d: giá trị khóa bất biến '%s' bị bỏ qua."
+
+#: ../src/common/fileconf.cpp:788
+#, fuzzy, c-format
+msgid "file '%s', line %zu: key '%s' was first found at line %d."
+msgstr "tập tin '%s', dòng %d: khóa '%s' được tìm thấy đầu tiên tại dòng %d."
+
+#: ../src/common/fileconf.cpp:1091
+#, c-format
+msgid "Config entry name cannot start with '%c'."
+msgstr "Tên mục tin cấu hình không thể bắt đầu bằng '%c'."
+
+#: ../src/common/fileconf.cpp:1146
+#, fuzzy
+msgid "Failed to create configuration file directory."
+msgstr "Cập nhật tập tin cấu hình gặp lỗi."
+
+#: ../src/common/fileconf.cpp:1158
+msgid "can't open user configuration file."
+msgstr "không thể mở tập tin cấu hình của người dùng."
+
+#: ../src/common/fileconf.cpp:1172
+msgid "can't write user configuration file."
+msgstr "không thể ghi tập tin cấu hình của người dùng."
+
+#: ../src/common/fileconf.cpp:1178
+msgid "Failed to update user configuration file."
+msgstr "Cập nhật tập tin cấu hình gặp lỗi."
+
+#: ../src/common/fileconf.cpp:1201
+msgid "Error saving user configuration data."
+msgstr "Lỗi ghi lại dữ liệu cấu hình người dùng."
+
+#: ../src/common/fileconf.cpp:1313
+#, c-format
+msgid "can't delete user configuration file '%s'"
+msgstr "không thể xóa tập tin cấu hình '%s' của người dùng"
+
+#: ../src/common/fileconf.cpp:2007
+#, c-format
+msgid "entry '%s' appears more than once in group '%s'"
+msgstr "mục từ '%s' xuất hiện nhiều hơn một lần trong nhóm '%s'"
+
+#: ../src/common/fileconf.cpp:2021
+#, c-format
+msgid "attempt to change immutable key '%s' ignored."
+msgstr "cố gắng đổi khóa bất biến '%s' bị bỏ qua."
+
+#: ../src/common/fileconf.cpp:2118
+#, c-format
+msgid "trailing backslash ignored in '%s'"
+msgstr "dấu gạch ngược bị bỏ qua trong '%s'"
+
+#: ../src/common/fileconf.cpp:2153
+#, c-format
+msgid "unexpected \" at position %d in '%s'."
+msgstr "không cần \" tại vị trí %d trong '%s'."
+
+#: ../src/common/filefn.cpp:474
+#, c-format
+msgid "Failed to copy the file '%s' to '%s'"
+msgstr "Sao chép tập tin từ '%s' sang '%s' gặp lỗi"
+
+#: ../src/common/filefn.cpp:487
+#, c-format
+msgid "Impossible to get permissions for file '%s'"
+msgstr "Không thể nào lấy được quyền cho tập tin '%s'"
+
+#: ../src/common/filefn.cpp:501
+#, c-format
+msgid "Impossible to overwrite the file '%s'"
+msgstr "Không thể xảy ra việc ghi đè lên tập tin '%s'"
+
+#: ../src/common/filefn.cpp:508
+#, fuzzy, c-format
+msgid "Error copying the file '%s' to '%s'."
+msgstr "Sao chép tập tin từ '%s' sang '%s' gặp lỗi"
+
+#: ../src/common/filefn.cpp:556
+#, c-format
+msgid "Impossible to set permissions for the file '%s'"
+msgstr "Không thể nào đặt được quyền cho tập tin '%s'"
+
+#: ../src/common/filefn.cpp:606
+#, c-format
+msgid ""
+"Failed to rename the file '%s' to '%s' because the destination file already "
+"exists."
+msgstr ""
+"Đổi tên tập tin '%s' thành '%s' gặp lỗi bởi vì tập tin đích đã tồn tại rồi."
+
+#: ../src/common/filefn.cpp:623
+#, c-format
+msgid "File '%s' couldn't be renamed '%s'"
+msgstr "Tập tin '%s' không thể bị đổi tên '%s'"
+
+#: ../src/common/filefn.cpp:639
+#, c-format
+msgid "File '%s' couldn't be removed"
+msgstr "Tập tin  '%s' gỡ bỏ được"
+
+#: ../src/common/filefn.cpp:666
+#, c-format
+msgid "Directory '%s' couldn't be created"
+msgstr "Thư mục '%s' không thể được tạo"
+
+#: ../src/common/filefn.cpp:680
+#, c-format
+msgid "Directory '%s' couldn't be deleted"
+msgstr "Thư mục '%s' không thể xóa được"
+
+#: ../src/common/filefn.cpp:714
+#, c-format
+msgid "Cannot enumerate files '%s'"
+msgstr "Không thể liệt kê các tập tin '%s'"
+
+#: ../src/common/filefn.cpp:798
+msgid "Failed to get the working directory"
+msgstr "Lấy thư mục đang làm việc gặp lỗi"
+
+#: ../src/common/filefn.cpp:843
+msgid "Could not set current working directory"
+msgstr "Không thể đặt thư mục làm việc hiện hành"
+
+#: ../src/common/filefn.cpp:974
+#, c-format
+msgid "Files (%s)"
+msgstr "Tập tin (%s)"
+
+#: ../src/common/filename.cpp:182
+#, c-format
+msgid "Failed to open '%s' for reading"
+msgstr "Mở '%s' để đọc gặp lỗi"
+
+#: ../src/common/filename.cpp:187
+#, c-format
+msgid "Failed to open '%s' for writing"
+msgstr "Mở '%s' để ghi gặp lỗi"
+
+#: ../src/common/filename.cpp:199
+msgid "Failed to close file handle"
+msgstr "Đóng handle tập tin gặp lỗi"
+
+#: ../src/common/filename.cpp:1046
+msgid "Failed to create a temporary file name"
+msgstr "Tạo tên tập tin tạm gặp lỗi"
+
+#: ../src/common/filename.cpp:1081
+msgid "Failed to open temporary file."
+msgstr "Mở tập tin tạm thời gặp lỗi."
+
+#: ../src/common/filename.cpp:2862
+#, c-format
+msgid "Failed to modify file times for '%s'"
+msgstr "Chỉnh sửa thời gian tập tin '%s' gặp lỗi"
+
+#: ../src/common/filename.cpp:2877
+#, c-format
+msgid "Failed to touch the file '%s'"
+msgstr "Mở tập tin '%s' gặp lỗi"
+
+#: ../src/common/filename.cpp:2958
+#, c-format
+msgid "Failed to retrieve file times for '%s'"
+msgstr "Khôi phục thời gian tập tin cho '%s' gặp lỗi"
+
+#: ../src/common/filepickercmn.cpp:39 ../src/common/filepickercmn.cpp:40
+msgid "Browse"
+msgstr "Tìm duyệt"
+
+#: ../src/common/fldlgcmn.cpp:792 ../src/generic/filectrlg.cpp:1185
+#, c-format
+msgid "All files (%s)|%s"
+msgstr "Mọi tập tin (%s)|%s"
+
+#. TRANSLATORS: %s are a file extension used to build a file wildcard string
+#: ../src/common/fldlgcmn.cpp:810
+#, c-format
+msgid "%s files (%s)|%s"
+msgstr "%s tập tin (%s)|%s"
+
+#: ../src/common/fldlgcmn.cpp:1072
+#, c-format
+msgid "Load %s file"
+msgstr "Tải %s tập tin"
+
+#: ../src/common/fldlgcmn.cpp:1074
+#, c-format
+msgid "Save %s file"
+msgstr "Ghi lại %s tập tin"
+
+#: ../src/common/fmapbase.cpp:144
+msgid "Western European (ISO-8859-1)"
+msgstr "Western European (ISO-8859-1)"
+
+#: ../src/common/fmapbase.cpp:145
+msgid "Central European (ISO-8859-2)"
+msgstr "Central European (ISO-8859-2)"
+
+#: ../src/common/fmapbase.cpp:146
+msgid "Esperanto (ISO-8859-3)"
+msgstr "Esperanto (ISO-8859-3)"
+
+#: ../src/common/fmapbase.cpp:147
+msgid "Baltic (old) (ISO-8859-4)"
+msgstr "Baltic (cũ) (ISO-8859-4)"
+
+#: ../src/common/fmapbase.cpp:148
+msgid "Cyrillic (ISO-8859-5)"
+msgstr "Cyrillic (ISO-8859-5)"
+
+#: ../src/common/fmapbase.cpp:149
+msgid "Arabic (ISO-8859-6)"
+msgstr "Arabic (ISO-8859-6)"
+
+#: ../src/common/fmapbase.cpp:150
+msgid "Greek (ISO-8859-7)"
+msgstr "Greek (ISO-8859-7)"
+
+#: ../src/common/fmapbase.cpp:151
+msgid "Hebrew (ISO-8859-8)"
+msgstr "Hebrew (ISO-8859-8)"
+
+#: ../src/common/fmapbase.cpp:152
+msgid "Turkish (ISO-8859-9)"
+msgstr "Thổ Nhĩ Kỳ (ISO-8859-9)"
+
+#: ../src/common/fmapbase.cpp:153
+msgid "Nordic (ISO-8859-10)"
+msgstr "Nordic (ISO-8859-10)"
+
+#: ../src/common/fmapbase.cpp:154
+msgid "Thai (ISO-8859-11)"
+msgstr "Thai (ISO-8859-11)"
+
+#: ../src/common/fmapbase.cpp:155
+msgid "Indian (ISO-8859-12)"
+msgstr "Ấn Độ (ISO-8859-12)"
+
+#: ../src/common/fmapbase.cpp:156
+msgid "Baltic (ISO-8859-13)"
+msgstr "Baltic (ISO-8859-13)"
+
+#: ../src/common/fmapbase.cpp:157
+msgid "Celtic (ISO-8859-14)"
+msgstr "Celtic (ISO-8859-14)"
+
+#: ../src/common/fmapbase.cpp:158
+msgid "Western European with Euro (ISO-8859-15)"
+msgstr "Western European with Euro (ISO-8859-15)"
+
+#: ../src/common/fmapbase.cpp:159
+msgid "KOI8-R"
+msgstr "KOI8-R"
+
+#: ../src/common/fmapbase.cpp:160
+msgid "KOI8-U"
+msgstr "KOI8-U"
+
+#: ../src/common/fmapbase.cpp:161
+msgid "Windows/DOS OEM Cyrillic (CP 866)"
+msgstr "Windows/DOS OEM Cyrillic (CP 866)"
+
+#: ../src/common/fmapbase.cpp:162
+msgid "Windows Thai (CP 874)"
+msgstr "Windows Thái Lan(CP 874)"
+
+#: ../src/common/fmapbase.cpp:163
+msgid "Windows Japanese (CP 932) or Shift-JIS"
+msgstr "Windows Tiếng Nhật (CP 932) hoặc Shift-JIS"
+
+#: ../src/common/fmapbase.cpp:164
+msgid "Windows Chinese Simplified (CP 936) or GB-2312"
+msgstr "Windows Trung Quốc Giản thể (CP 936) hoặc GB-2312"
+
+#: ../src/common/fmapbase.cpp:165
+msgid "Windows Korean (CP 949)"
+msgstr "Windows Tiếng Hàn (CP 949)"
+
+#: ../src/common/fmapbase.cpp:166
+msgid "Windows Chinese Traditional (CP 950) or Big-5"
+msgstr "Windows Trung Quốc Cổ Điển (CP 950)"
+
+#: ../src/common/fmapbase.cpp:167
+msgid "Windows Central European (CP 1250)"
+msgstr "Windows Central European (CP 1250)"
+
+#: ../src/common/fmapbase.cpp:168
+msgid "Windows Cyrillic (CP 1251)"
+msgstr "Windows Cyrillic (CP 1251)"
+
+#: ../src/common/fmapbase.cpp:169
+msgid "Windows Western European (CP 1252)"
+msgstr "Windows Trung Âu (CP 1252)"
+
+#: ../src/common/fmapbase.cpp:170
+msgid "Windows Greek (CP 1253)"
+msgstr "Windows Hi Lạp (CP 1253)"
+
+#: ../src/common/fmapbase.cpp:171
+msgid "Windows Turkish (CP 1254)"
+msgstr "Windows Thổ Nhĩ Kỳ (CP 1254)"
+
+#: ../src/common/fmapbase.cpp:172
+msgid "Windows Hebrew (CP 1255)"
+msgstr "Windows Hebrew (CP 1255)"
+
+#: ../src/common/fmapbase.cpp:173
+msgid "Windows Arabic (CP 1256)"
+msgstr "Windows Ả Rập (CP 1256)"
+
+#: ../src/common/fmapbase.cpp:174
+msgid "Windows Baltic (CP 1257)"
+msgstr "Windows Baltic (CP 1257)"
+
+#: ../src/common/fmapbase.cpp:175
+msgid "Windows Vietnamese (CP 1258)"
+msgstr "Windows Tiếng Việt (CP 1258)"
+
+#: ../src/common/fmapbase.cpp:176
+msgid "Windows Johab (CP 1361)"
+msgstr "Windows Johab (CP 1361)"
+
+#: ../src/common/fmapbase.cpp:177
+msgid "Windows/DOS OEM (CP 437)"
+msgstr "Windows/DOS OEM (CP 437)"
+
+#: ../src/common/fmapbase.cpp:178
+msgid "Unicode 7 bit (UTF-7)"
+msgstr "Unicode 7 bit (UTF-7)"
+
+#: ../src/common/fmapbase.cpp:179
+msgid "Unicode 8 bit (UTF-8)"
+msgstr "Unicode 8 bit (UTF-8)"
+
+#: ../src/common/fmapbase.cpp:181 ../src/common/fmapbase.cpp:187
+msgid "Unicode 16 bit (UTF-16)"
+msgstr "Unicode 16 bit (UTF-16)"
+
+#: ../src/common/fmapbase.cpp:182
+msgid "Unicode 16 bit Little Endian (UTF-16LE)"
+msgstr "Unicode 16 bit Little Endian (UTF-16LE)"
+
+#: ../src/common/fmapbase.cpp:183 ../src/common/fmapbase.cpp:189
+msgid "Unicode 32 bit (UTF-32)"
+msgstr "Unicode 32 bit (UTF-32)"
+
+#: ../src/common/fmapbase.cpp:184
+msgid "Unicode 32 bit Little Endian (UTF-32LE)"
+msgstr "Unicode 32 bit Little Endian (UTF-32LE)"
+
+#: ../src/common/fmapbase.cpp:186
+msgid "Unicode 16 bit Big Endian (UTF-16BE)"
+msgstr "Unicode 16 bit Big Endian (UTF-16BE)"
+
+#: ../src/common/fmapbase.cpp:188
+msgid "Unicode 32 bit Big Endian (UTF-32BE)"
+msgstr "Unicode 32 bit Big Endian (UTF-32BE)"
+
+#: ../src/common/fmapbase.cpp:191
+msgid "Extended Unix Codepage for Japanese (EUC-JP)"
+msgstr "Extended Unix Codepage for Japanese (EUC-JP)"
+
+#: ../src/common/fmapbase.cpp:192
+msgid "US-ASCII"
+msgstr "US-ASCII"
+
+#: ../src/common/fmapbase.cpp:193
+msgid "ISO-2022-JP"
+msgstr "ISO-2022-JP"
+
+#: ../src/common/fmapbase.cpp:195
+msgid "MacRoman"
+msgstr "MacRoman"
+
+#: ../src/common/fmapbase.cpp:196
+msgid "MacJapanese"
+msgstr "MacJapanese"
+
+#: ../src/common/fmapbase.cpp:197
+msgid "MacChineseTrad"
+msgstr "MacChineseTrad"
+
+#: ../src/common/fmapbase.cpp:198
+msgid "MacKorean"
+msgstr "MacKorean"
+
+#: ../src/common/fmapbase.cpp:199
+msgid "MacArabic"
+msgstr "MacArabic"
+
+#: ../src/common/fmapbase.cpp:200
+msgid "MacHebrew"
+msgstr "MacHebrew"
+
+#: ../src/common/fmapbase.cpp:201
+msgid "MacGreek"
+msgstr "MacGreek"
+
+#: ../src/common/fmapbase.cpp:202
+msgid "MacCyrillic"
+msgstr "MacCyrillic"
+
+#: ../src/common/fmapbase.cpp:203
+msgid "MacDevanagari"
+msgstr "MacDevanagari"
+
+#: ../src/common/fmapbase.cpp:204
+msgid "MacGurmukhi"
+msgstr "MacGurmukhi"
+
+#: ../src/common/fmapbase.cpp:205
+msgid "MacGujarati"
+msgstr "MacGujarati"
+
+#: ../src/common/fmapbase.cpp:206
+msgid "MacOriya"
+msgstr "MacOriya"
+
+#: ../src/common/fmapbase.cpp:207
+msgid "MacBengali"
+msgstr "MacBengali"
+
+#: ../src/common/fmapbase.cpp:208
+msgid "MacTamil"
+msgstr "MacTamil"
+
+#: ../src/common/fmapbase.cpp:209
+msgid "MacTelugu"
+msgstr "MacTelugu"
+
+#: ../src/common/fmapbase.cpp:210
+msgid "MacKannada"
+msgstr "MacKannada"
+
+#: ../src/common/fmapbase.cpp:211
+msgid "MacMalayalam"
+msgstr "MacMalayalam"
+
+#: ../src/common/fmapbase.cpp:212
+msgid "MacSinhalese"
+msgstr "MacSinhalese"
+
+#: ../src/common/fmapbase.cpp:213
+msgid "MacBurmese"
+msgstr "MacBurmese"
+
+#: ../src/common/fmapbase.cpp:214
+msgid "MacKhmer"
+msgstr "MacKhmer"
+
+#: ../src/common/fmapbase.cpp:215
+msgid "MacThai"
+msgstr "MacThai"
+
+#: ../src/common/fmapbase.cpp:216
+msgid "MacLaotian"
+msgstr "MacLaotian"
+
+#: ../src/common/fmapbase.cpp:217
+msgid "MacGeorgian"
+msgstr "MacGeorgian"
+
+#: ../src/common/fmapbase.cpp:218
+msgid "MacArmenian"
+msgstr "MacArmenian"
+
+#: ../src/common/fmapbase.cpp:219
+msgid "MacChineseSimp"
+msgstr "MacChineseSimp"
+
+#: ../src/common/fmapbase.cpp:220
+msgid "MacTibetan"
+msgstr "MacTibetan"
+
+#: ../src/common/fmapbase.cpp:221
+msgid "MacMongolian"
+msgstr "MacMongolian"
+
+#: ../src/common/fmapbase.cpp:222
+msgid "MacEthiopic"
+msgstr "MacEthiopic"
+
+#: ../src/common/fmapbase.cpp:223
+msgid "MacCentralEurRoman"
+msgstr "MacCentralEurRoman"
+
+#: ../src/common/fmapbase.cpp:224
+msgid "MacVietnamese"
+msgstr "MacVietnamese"
+
+#: ../src/common/fmapbase.cpp:225
+msgid "MacExtArabic"
+msgstr "MacExtArabic"
+
+#: ../src/common/fmapbase.cpp:226
+msgid "MacSymbol"
+msgstr "MacSymbol"
+
+#: ../src/common/fmapbase.cpp:227
+msgid "MacDingbats"
+msgstr "MacDingbats"
+
+#: ../src/common/fmapbase.cpp:228
+msgid "MacTurkish"
+msgstr "MacTurkish"
+
+#: ../src/common/fmapbase.cpp:229
+msgid "MacCroatian"
+msgstr "MacCroatian"
+
+#: ../src/common/fmapbase.cpp:230
+msgid "MacIcelandic"
+msgstr "MacIcelandic"
+
+#: ../src/common/fmapbase.cpp:231
+msgid "MacRomanian"
+msgstr "MacRomanian"
+
+#: ../src/common/fmapbase.cpp:232
+msgid "MacCeltic"
+msgstr "MacCeltic"
+
+#: ../src/common/fmapbase.cpp:233
+msgid "MacGaelic"
+msgstr "MacGaelic"
+
+#: ../src/common/fmapbase.cpp:234
+msgid "MacKeyboardGlyphs"
+msgstr "MacKeyboardGlyphs"
+
+#: ../src/common/fmapbase.cpp:791
+msgid "Default encoding"
+msgstr "Bộ mã mặc định"
+
+#: ../src/common/fmapbase.cpp:805
+#, c-format
+msgid "Unknown encoding (%d)"
+msgstr "Không rõ bộ giải mã (%d)"
+
+#: ../src/common/fmapbase.cpp:815 ../src/richtext/richtextstyles.cpp:776
+msgid "default"
+msgstr "mặc định"
+
+#: ../src/common/fmapbase.cpp:829
+#, c-format
+msgid "unknown-%d"
+msgstr "không_hiểu-%d"
+
+#: ../src/common/fontcmn.cpp:924 ../src/common/fontcmn.cpp:1130
+msgid "underlined"
+msgstr "gạch chân"
+
+#: ../src/common/fontcmn.cpp:929
+msgid " strikethrough"
+msgstr " gạch giữa"
+
+#: ../src/common/fontcmn.cpp:942
+msgid " thin"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:946
+#, fuzzy
+msgid " extra light"
+msgstr " sáng"
+
+#: ../src/common/fontcmn.cpp:950
+msgid " light"
+msgstr " sáng"
+
+#: ../src/common/fontcmn.cpp:954
+msgid " medium"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:958
+#, fuzzy
+msgid " semi bold"
+msgstr " đậm"
+
+#: ../src/common/fontcmn.cpp:962
+msgid " bold"
+msgstr " đậm"
+
+#: ../src/common/fontcmn.cpp:966
+#, fuzzy
+msgid " extra bold"
+msgstr " đậm"
+
+#: ../src/common/fontcmn.cpp:970
+msgid " heavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:974
+msgid " extra heavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:990
+msgid " italic"
+msgstr " nghiêng"
+
+#: ../src/common/fontcmn.cpp:1134
+msgid "strikethrough"
+msgstr "Gạch giữa"
+
+#: ../src/common/fontcmn.cpp:1143
+msgid "thin"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1156
+#, fuzzy
+msgid "extralight"
+msgstr "ánh sáng"
+
+#: ../src/common/fontcmn.cpp:1161
+msgid "light"
+msgstr "ánh sáng"
+
+#: ../src/common/fontcmn.cpp:1169 ../src/richtext/richtextstyles.cpp:775
+msgid "normal"
+msgstr "thường"
+
+#: ../src/common/fontcmn.cpp:1174
+msgid "medium"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1179 ../src/common/fontcmn.cpp:1199
+#, fuzzy
+msgid "semibold"
+msgstr "đậm"
+
+#: ../src/common/fontcmn.cpp:1184
+msgid "bold"
+msgstr "đậm"
+
+#: ../src/common/fontcmn.cpp:1194
+#, fuzzy
+msgid "extrabold"
+msgstr "đậm"
+
+#: ../src/common/fontcmn.cpp:1204
+msgid "heavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1212
+msgid "extraheavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1217
+msgid "italic"
+msgstr "nghiêng"
+
+#: ../src/common/fontmap.cpp:195
+msgid ": unknown charset"
+msgstr ": không hiểu bộ ký tự"
+
+#: ../src/common/fontmap.cpp:199
+#, c-format
+msgid ""
+"The charset '%s' is unknown. You may select\n"
+"another charset to replace it with or choose\n"
+"[Cancel] if it cannot be replaced"
+msgstr ""
+"Bộ ký tự '%s' không rõ. Bạn có thể chọn\n"
+"bộ ký tự khác để thay thế cho nó hay chọn\n"
+"[Hủy] nếu nó không thể thay thế được"
+
+#: ../src/common/fontmap.cpp:241
+#, c-format
+msgid "Failed to remember the encoding for the charset '%s'."
+msgstr "Ghi nhớ bộ mã của bộ ký tự '%s' gặp lỗi."
+
+#: ../src/common/fontmap.cpp:321
+msgid "can't load any font, aborting"
+msgstr "không tải được phông chữ nào, bãi bỏ"
+
+#: ../src/common/fontmap.cpp:409
+msgid ": unknown encoding"
+msgstr ": không hiểu bảng mã"
+
+#: ../src/common/fontmap.cpp:417
+#, c-format
+msgid ""
+"No font for displaying text in encoding '%s' found,\n"
+"but an alternative encoding '%s' is available.\n"
+"Do you want to use this encoding (otherwise you will have to choose another "
+"one)?"
+msgstr ""
+"Không có phông chữ nào hiển thị chữ ở bộ mã '%s' được tìm thấy,\n"
+"nhưng bộ mã thay thế '%s' thì sẵn có.\n"
+"Bạn có muốn sử dụng bộ mã này không (nếu không bạn sẽ phải chọn một cái "
+"khác)?"
+
+#: ../src/common/fontmap.cpp:422
+#, c-format
+msgid ""
+"No font for displaying text in encoding '%s' found.\n"
+"Would you like to select a font to be used for this encoding\n"
+"(otherwise the text in this encoding will not be shown correctly)?"
+msgstr ""
+"Không có phông chữ nào hiển thị chữ ở bộ mã '%s' được tìm thấy,\n"
+"Bạn có muốn chọn một phông chữ sử dụng cho bộ mã này không\n"
+"(nếu không chữ với bộ mã này sẽ hiện lên không chính xác)?"
+
+#: ../src/common/fs_mem.cpp:169
+#, c-format
+msgid "Memory VFS already contains file '%s'!"
+msgstr "Bộ nhớ VFS đã chứa tập tin '%s' rồi!"
+
+#: ../src/common/fs_mem.cpp:232
+#, c-format
+msgid "Trying to remove file '%s' from memory VFS, but it is not loaded!"
+msgstr "Cố gắng gỡ bỏ tập tin '%s' từ bộ nhớ VFS, nhưng nó chưa được tải lên!"
+
+#: ../src/common/fs_mem.cpp:262
+#, c-format
+msgid "Failed to store image '%s' to memory VFS!"
+msgstr "Lưu trữ ảnh '%s' vào bộ nhớ VFS gặp lỗi!"
+
+#: ../src/common/ftp.cpp:197
+msgid "Timeout while waiting for FTP server to connect, try passive mode."
+msgstr ""
+"Lỗi quá thời gian khi chờ kết nối với máy chủ FTP, hãy thử chế độ thụ động."
+
+#: ../src/common/ftp.cpp:399
+#, c-format
+msgid "Failed to set FTP transfer mode to %s."
+msgstr "Đặt chế độ truyền FTP thành %s gặp lỗi."
+
+#: ../src/common/ftp.cpp:400 ../src/richtext/richtextsymboldlg.cpp:432
+msgid "ASCII"
+msgstr "ASCII"
+
+#: ../src/common/ftp.cpp:400
+msgid "binary"
+msgstr "nhị phân"
+
+#: ../src/common/ftp.cpp:608
+msgid "The FTP server doesn't support the PORT command."
+msgstr "Máy chủ FTP không hỗ trợ lệnh PORT."
+
+#: ../src/common/ftp.cpp:622
+msgid "The FTP server doesn't support passive mode."
+msgstr "Máy chủ FTP không hỗ trợ chế độ tích cực."
+
+#: ../src/common/gifdecod.cpp:822
+#, c-format
+msgid "Incorrect GIF frame size (%u, %d) for the frame #%u"
+msgstr "Frame của ảnh  GIF (%u, %d) cho frame #%u không đúng"
+
+#: ../src/common/glcmn.cpp:108
+msgid "Failed to allocate colour for OpenGL"
+msgstr "Cấp phát màu cho OpenGL gặp lỗi"
+
+#: ../src/common/headerctrlcmn.cpp:57
+msgid "Please select the columns to show and define their order:"
+msgstr "Xin hãy chọn các cột sẽ hiển thị và xác định thứ tự của chúng:"
+
+#: ../src/common/headerctrlcmn.cpp:58
+msgid "Customize Columns"
+msgstr "Tùy Chỉnh Số Cột"
+
+#: ../src/common/headerctrlcmn.cpp:304
+msgid "&Customize..."
+msgstr "&Cá nhân..."
+
+#: ../src/common/hyperlnkcmn.cpp:132
+#, fuzzy, c-format
+msgid "Failed to open URL \"%s\" in the default browser"
+msgstr "Mở URL \"%s\" trong trình duyệt mặc định gặp lỗi."
+
+#: ../src/common/iconbndl.cpp:195
+#, c-format
+msgid "Failed to load image %%d from file '%s'."
+msgstr "Tải ảnh %%d từ tập tin '%s' gặp lỗi."
+
+#: ../src/common/iconbndl.cpp:203
+#, c-format
+msgid "Failed to load image %d from stream."
+msgstr "Lỗi khi tải ảnh %d từ dòng dữ liệu."
+
+#: ../src/common/iconbndl.cpp:221
+#, fuzzy, c-format
+msgid "Failed to load icons from resource '%s'."
+msgstr "Tải biểu tượng \"%s\" từ nguồn tài nguyên gặp lỗi."
+
+#: ../src/common/imagbmp.cpp:97
+msgid "BMP: Couldn't save invalid image."
+msgstr "BMP: Không thể ghi ảnh không hợp lệ."
+
+#: ../src/common/imagbmp.cpp:137
+msgid "BMP: wxImage doesn't have own wxPalette."
+msgstr "BMP: wxImage không có quyền sở hữu wxPalette."
+
+#: ../src/common/imagbmp.cpp:243
+msgid "BMP: Couldn't write the file (Bitmap) header."
+msgstr "BMP: Không thể ghi phần đầu tập tin (Bitmap)."
+
+#: ../src/common/imagbmp.cpp:266
+msgid "BMP: Couldn't write the file (BitmapInfo) header."
+msgstr "BMP: Không thể ghi phần đầu tập tin (BitmapInfo)."
+
+#: ../src/common/imagbmp.cpp:353
+msgid "BMP: Couldn't write RGB color map."
+msgstr "BMP: Không thể ghi bản đồ màu RGB."
+
+#: ../src/common/imagbmp.cpp:487
+msgid "BMP: Couldn't write data."
+msgstr "BMP: Không thể ghi dữ liệu."
+
+#: ../src/common/imagbmp.cpp:561 ../src/common/imagbmp.cpp:642
+msgid "BMP: Couldn't allocate memory."
+msgstr "BMP: Không thể cấp phát bộ nhớ."
+
+#: ../src/common/imagbmp.cpp:1041
+msgid "DIB Header: Image width > 32767 pixels for file."
+msgstr "Phần đầu DIB: Độ rộng ảnh > 32767 điểm ảnh cho tập tin."
+
+#: ../src/common/imagbmp.cpp:1049
+msgid "DIB Header: Image height > 32767 pixels for file."
+msgstr "Phần đầu DIB: Độ cao ảnh > 32767 điểm ảnh cho tập tin."
+
+#: ../src/common/imagbmp.cpp:1081
+msgid "DIB Header: Unknown bitdepth in file."
+msgstr "Phần đầu DIB: Không rõ độ sâu bit trong tập tin."
+
+#: ../src/common/imagbmp.cpp:1156
+msgid "DIB Header: Unknown encoding in file."
+msgstr "Phần Đầu DIB: Không hiểu bộ giải mã trong tập tin."
+
+#: ../src/common/imagbmp.cpp:1165
+msgid "DIB Header: Encoding doesn't match bitdepth."
+msgstr "Phần đầu DIB: Bộ giải mã không khớp với độ sâu bit."
+
+#: ../src/common/imagbmp.cpp:1180
+#, c-format
+msgid "BMP Header: Invalid number of colors (%d)."
+msgstr ""
+
+#: ../src/common/imagbmp.cpp:1273
+msgid "Error in reading image DIB."
+msgstr "Lỗi trong việc đọc ảnh DIB."
+
+#: ../src/common/imagbmp.cpp:1294
+msgid "ICO: Error in reading mask DIB."
+msgstr "ICO: Lỗi trong việc đọc mặt nạ DIB."
+
+#: ../src/common/imagbmp.cpp:1353
+msgid "ICO: Image too tall for an icon."
+msgstr "ICO: Ảnh quá cao đối với biểu tượng."
+
+#: ../src/common/imagbmp.cpp:1361
+msgid "ICO: Image too wide for an icon."
+msgstr "ICO: Ảnh quá rộng đối với biểu tượng."
+
+#: ../src/common/imagbmp.cpp:1388 ../src/common/imagbmp.cpp:1488
+#: ../src/common/imagbmp.cpp:1503 ../src/common/imagbmp.cpp:1514
+#: ../src/common/imagbmp.cpp:1528 ../src/common/imagbmp.cpp:1576
+#: ../src/common/imagbmp.cpp:1591 ../src/common/imagbmp.cpp:1605
+#: ../src/common/imagbmp.cpp:1616
+msgid "ICO: Error writing the image file!"
+msgstr "ICO: Lỗi khi đang ghi tập tin ảnh!"
+
+#: ../src/common/imagbmp.cpp:1701
+msgid "ICO: Invalid icon index."
+msgstr "ICO: Chỉ mục biểu tượng không hợp lệ."
+
+#: ../src/common/image.cpp:2410
+msgid "Image and mask have different sizes."
+msgstr "Ảnh và mặt nạ có sự khác biệt kích thước."
+
+#: ../src/common/image.cpp:2418 ../src/common/image.cpp:2459
+msgid "No unused colour in image being masked."
+msgstr "Không có màu không dùng đến trong mặt nạ ảnh này."
+
+#: ../src/common/image.cpp:2641
+#, c-format
+msgid "Failed to load bitmap \"%s\" from resources."
+msgstr "Gặp lỗi tải ảnh \"%s\" từ nguồn tài nguyên."
+
+#: ../src/common/image.cpp:2650
+#, c-format
+msgid "Failed to load icon \"%s\" from resources."
+msgstr "Tải biểu tượng \"%s\" từ nguồn tài nguyên gặp lỗi."
+
+#: ../src/common/image.cpp:2728 ../src/common/image.cpp:2747
+#, c-format
+msgid "Failed to load image from file \"%s\"."
+msgstr "Tải ảnh từ tập tin \"%s\" gặp lỗi."
+
+#: ../src/common/image.cpp:2761
+#, c-format
+msgid "Can't save image to file '%s': unknown extension."
+msgstr "Không thể ghi ảnh ra tập tin '%s': không hiểu phần mở rộng."
+
+#: ../src/common/image.cpp:2869
+msgid "No handler found for image type."
+msgstr "Không có phần điều khiển cho kiểu ảnh này."
+
+#: ../src/common/image.cpp:2877 ../src/common/image.cpp:3000
+#: ../src/common/image.cpp:3066
+#, c-format
+msgid "No image handler for type %d defined."
+msgstr "Không có bộ điều khiển ảnh cho kiểu %d được định nghĩa."
+
+#: ../src/common/image.cpp:2887
+#, c-format
+msgid "Image file is not of type %d."
+msgstr "Tập tin ảnh không thuộc kiểu %d."
+
+#: ../src/common/image.cpp:2970
+msgid "Can't automatically determine the image format for non-seekable input."
+msgstr ""
+"Không thể tự động dò tìm định dạng ảnh cho đầu vào không-di-chuyển-vị-trí-"
+"đọc-được."
+
+#: ../src/common/image.cpp:2988
+msgid "Unknown image data format."
+msgstr "Không hiểu định dạng dữ liệu ảnh"
+
+#: ../src/common/image.cpp:3009
+#, c-format
+msgid "This is not a %s."
+msgstr "Cái này không phải là một %s."
+
+#: ../src/common/image.cpp:3032 ../src/common/image.cpp:3080
+#, c-format
+msgid "No image handler for type %s defined."
+msgstr "Không có bộ điều khiển ảnh cho kiểu %s được định nghĩa."
+
+#: ../src/common/image.cpp:3041
+#, c-format
+msgid "Image is not of type %s."
+msgstr "Ảnh không thuộc kiểu %s."
+
+#: ../src/common/image.cpp:3509
+#, c-format
+msgid "Failed to check format of image file \"%s\"."
+msgstr "Gặp lỗi khi kiểm tra định dạng của tập tin ảnh \"%s\"."
+
+#: ../src/common/imaggif.cpp:124
+msgid "GIF: error in GIF image format."
+msgstr "GIF: lỗi trong định dạng ảnh GIF."
+
+#: ../src/common/imaggif.cpp:129
+msgid "GIF: not enough memory."
+msgstr "GIF: không có đủ bộ nhớ."
+
+#: ../src/common/imaggif.cpp:134
+msgid "GIF: data stream seems to be truncated."
+msgstr "GIF: dòng dữ liệu dường như bị cắt xén."
+
+#: ../src/common/imaggif.cpp:240
+msgid "Couldn't initialize GIF hash table."
+msgstr "Không thể khởi tạo bảng mã băm GIF."
+
+#: ../src/common/imagiff.cpp:739
+msgid "IFF: error in IFF image format."
+msgstr "IFF: lỗi trong định dạng ảnh IFF."
+
+#: ../src/common/imagiff.cpp:742
+msgid "IFF: not enough memory."
+msgstr "IFF: không có đủ bộ nhớ."
+
+#: ../src/common/imagiff.cpp:745
+msgid "IFF: unknown error!!!"
+msgstr "IFF: lỗi không rõ!!!"
+
+#: ../src/common/imagiff.cpp:755
+msgid "IFF: data stream seems to be truncated."
+msgstr "IFF: dòng dữ liệu dường như bị cắt xén."
+
+#: ../src/common/imagjpeg.cpp:258
+msgid "JPEG: Couldn't load - file is probably corrupted."
+msgstr "JPEG: Không thể tải - tập tin hầu như chắc chắn đã sai hỏng."
+
+#: ../src/common/imagjpeg.cpp:437
+msgid "JPEG: Couldn't save image."
+msgstr "JPEG: Không thể ghi lại ảnh."
+
+#: ../src/common/imagpcx.cpp:439
+msgid "PCX: this is not a PCX file."
+msgstr "PCX: cái này không phải là tập tin PCX."
+
+#: ../src/common/imagpcx.cpp:453
+msgid "PCX: image format unsupported"
+msgstr "PCX: không hỗ trợ định dạng ảnh"
+
+#: ../src/common/imagpcx.cpp:454 ../src/common/imagpcx.cpp:477
+msgid "PCX: couldn't allocate memory"
+msgstr "PCX: không thể cấp phát bộ nhớ"
+
+#: ../src/common/imagpcx.cpp:455
+msgid "PCX: version number too low"
+msgstr "PCX: phiên bản quá thấp"
+
+#: ../src/common/imagpcx.cpp:456 ../src/common/imagpcx.cpp:478
+msgid "PCX: unknown error !!!"
+msgstr "PCX: lỗi không rõ!!!"
+
+#: ../src/common/imagpcx.cpp:476
+msgid "PCX: invalid image"
+msgstr "PCX: ảnh không hợp lệ"
+
+#: ../src/common/imagpng.cpp:385
+#, c-format
+msgid "Unknown PNG resolution unit %d"
+msgstr "Không hiểu đơn vị độ phân giải  PNG %d"
+
+#: ../src/common/imagpng.cpp:439
+msgid "Couldn't load a PNG image - file is corrupted or not enough memory."
+msgstr "Không thể tải ảnh PNG- tập tin bị hỏng hay không đủ bộ nhớ."
+
+#: ../src/common/imagpng.cpp:513 ../src/common/imagpng.cpp:524
+#: ../src/common/imagpng.cpp:534
+msgid "Couldn't save PNG image."
+msgstr "Không thể ghi lại ảnh PNG."
+
+#: ../src/common/imagpnm.cpp:71
+msgid "PNM: File format is not recognized."
+msgstr "PNM: Định dạng tập tin không được thừa nhận."
+
+#: ../src/common/imagpnm.cpp:89
+msgid "PNM: Couldn't allocate memory."
+msgstr "PNM: Không thể cấp phát bộ nhớ."
+
+#: ../src/common/imagpnm.cpp:111 ../src/common/imagpnm.cpp:134
+#: ../src/common/imagpnm.cpp:156
+msgid "PNM: File seems truncated."
+msgstr "PNM: Tập tin dường như đã bị cắt xén."
+
+#: ../src/common/imagtiff.cpp:69
+#, c-format
+msgid " (in module \"%s\")"
+msgstr " (trong mô-đun \"%s\")"
+
+#: ../src/common/imagtiff.cpp:304
+msgid "TIFF: Error loading image."
+msgstr "TIFF: Lỗi tải ảnh."
+
+#: ../src/common/imagtiff.cpp:314
+msgid "Invalid TIFF image index."
+msgstr "Chỉ mục ảnh TIFF không hợp lệ."
+
+#: ../src/common/imagtiff.cpp:358
+msgid "TIFF: Image size is abnormally big."
+msgstr "TIFF: Kích cỡ ảnh thường lớn."
+
+#: ../src/common/imagtiff.cpp:372 ../src/common/imagtiff.cpp:385
+#: ../src/common/imagtiff.cpp:769
+msgid "TIFF: Couldn't allocate memory."
+msgstr "TIFF: Không thể cấp phát bộ nhớ."
+
+#: ../src/common/imagtiff.cpp:471
+msgid "TIFF: Error reading image."
+msgstr "TIFF: Lỗi trong khi đọc tập tin ảnh."
+
+#: ../src/common/imagtiff.cpp:532
+#, c-format
+msgid "Unknown TIFF resolution unit %d ignored"
+msgstr "Không hiểu đơn vị độ phân giải TIFF %d bỏ qua"
+
+#: ../src/common/imagtiff.cpp:611
+msgid "TIFF: Error saving image."
+msgstr "TIFF: Gặp lỗi khi ghi tập tin ảnh."
+
+#: ../src/common/imagtiff.cpp:868
+msgid "TIFF: Error writing image."
+msgstr "TIFF: Gặp lỗi khi ghi tập tin ảnh."
+
+#: ../src/common/imagtiff.cpp:881
+#, fuzzy
+msgid "TIFF: Error flushing data."
+msgstr "TIFF: Gặp lỗi khi ghi tập tin ảnh."
+
+#: ../src/common/imagwebp.cpp:56
+msgid "WebP: Invalid data (failed to get features)."
+msgstr ""
+
+#: ../src/common/imagwebp.cpp:65
+msgid "WebP: Allocating image memory failed."
+msgstr ""
+
+#: ../src/common/imagwebp.cpp:82
+msgid "WebP: Decoding RGBA image data failed."
+msgstr ""
+
+#: ../src/common/imagwebp.cpp:98
+msgid "WebP: Decoding RGB image data failed."
+msgstr ""
+
+#: ../src/common/imagwebp.cpp:113 ../src/common/imagwebp.cpp:201
+msgid "WebP: Allocating stream buffer failed."
+msgstr ""
+
+#: ../src/common/imagwebp.cpp:131
+#, fuzzy
+msgid "WebP: Failed to parse container data."
+msgstr "Đặt dữ liệu clipboard gặp lỗi."
+
+#: ../src/common/imagwebp.cpp:222
+#, fuzzy
+msgid "WebP: Error decoding animation."
+msgstr "Lỗi trong việc đọc các tùy chọn cấu hình."
+
+#: ../src/common/imagwebp.cpp:240
+msgid "WebP: Error getting next animation frame."
+msgstr ""
+
+#: ../src/common/init.cpp:172
+#, c-format
+msgid ""
+"Command line argument %d couldn't be converted to Unicode and will be "
+"ignored."
+msgstr ""
+"Tham số dòng lệnh %d không thể chuyển đổi sang Unicode và sẽ bị bỏ qua."
+
+#: ../src/common/init.cpp:344
+msgid "Initialization failed in post init, aborting."
+msgstr "Khởi tạo lỗi trong việc post init, đang bãi bỏ."
+
+#: ../src/common/intl.cpp:378
+#, c-format
+msgid "Cannot set locale to language \"%s\"."
+msgstr "Không thể đặt ngôn ngữ thành \"%s\"."
+
+#: ../src/common/log.cpp:232
+msgid "Error: "
+msgstr "Lỗi: "
+
+#: ../src/common/log.cpp:236
+msgid "Warning: "
+msgstr "Cảnh báo: "
+
+#: ../src/common/log.cpp:284
+msgid "The previous message repeated once."
+msgstr "Thông điệp liền trước lặp đi lặp lại thông điệp."
+
+#: ../src/common/log.cpp:291
+#, fuzzy, c-format
+msgid "The previous message repeated %u time."
+msgid_plural "The previous message repeated %u times."
+msgstr[0] "Thông điệp kế trước lặp lại %lu lần."
+
+#: ../src/common/log.cpp:319
+#, fuzzy, c-format
+msgid "Last repeated message (\"%s\", %u time) wasn't output"
+msgid_plural "Last repeated message (\"%s\", %u times) wasn't output"
+msgstr[0] "Thông điệp lặp cuối cùng (\"%s\", %lu lần) đã không được kết xuất"
+
+#: ../src/common/log.cpp:435
+#, c-format
+msgid " (error %ld: %s)"
+msgstr " (lỗi %ld: %s)"
+
+#: ../src/common/lzmastream.cpp:121
+#, fuzzy
+msgid "Failed to allocate memory for LZMA decompression."
+msgstr "Cấp phát màu cho OpenGL gặp lỗi"
+
+#: ../src/common/lzmastream.cpp:125
+#, c-format
+msgid "Failed to initialize LZMA decompression: unexpected error %u."
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:179
+msgid "input is not in XZ format"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:183
+msgid "input compressed using unknown XZ option"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:188
+msgid "input is corrupted"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:192
+#, fuzzy
+msgid "unknown decompression error"
+msgstr "lỗi giải nén"
+
+#: ../src/common/lzmastream.cpp:196
+#, fuzzy, c-format
+msgid "LZMA decompression error: %s"
+msgstr "lỗi giải nén"
+
+#: ../src/common/lzmastream.cpp:231
+#, fuzzy
+msgid "Failed to allocate memory for LZMA compression."
+msgstr "Cấp phát màu cho OpenGL gặp lỗi"
+
+#: ../src/common/lzmastream.cpp:235
+#, c-format
+msgid "Failed to initialize LZMA compression: unexpected error %u."
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:267 ../src/common/lzmastream.cpp:342
+#: ../src/html/chm.cpp:336
+msgid "out of memory"
+msgstr "hết bộ nhớ"
+
+#: ../src/common/lzmastream.cpp:276 ../src/common/lzmastream.cpp:346
+#, fuzzy
+msgid "unknown compression error"
+msgstr "lỗi nén"
+
+#: ../src/common/lzmastream.cpp:280
+#, fuzzy, c-format
+msgid "LZMA compression error: %s"
+msgstr "lỗi nén"
+
+#: ../src/common/lzmastream.cpp:350
+#, c-format
+msgid "LZMA compression error when flushing output: %s"
+msgstr ""
+
+#: ../src/common/mimecmn.cpp:167
+#, c-format
+msgid "Unmatched '{' in an entry for mime type %s."
+msgstr "Không khớp '{' trong một mục từ cho kiểu diễn tả %s."
+
+#: ../src/common/module.cpp:76
+#, c-format
+msgid "Circular dependency involving module \"%s\" detected."
+msgstr "Circular dependency đòi hỏi phải tìm được mô đun \"%s\"."
+
+#: ../src/common/module.cpp:128
+#, c-format
+msgid "Dependency \"%s\" of module \"%s\" doesn't exist."
+msgstr "Phần phụ thuộc \"%s\" của mô đun \"%s\" chưa tồn tại."
+
+#: ../src/common/module.cpp:137
+#, c-format
+msgid "Module \"%s\" initialization failed"
+msgstr "Sự khởi tạo mô-đun \"%s\" gặp lỗi"
+
+#: ../src/common/msgout.cpp:96
+msgid "Message"
+msgstr "Tin nhắn"
+
+#: ../src/common/paper.cpp:70
+msgid "Letter, 8 1/2 x 11 in"
+msgstr "Letter, 8 1/2 x 11 in"
+
+#: ../src/common/paper.cpp:71
+msgid "Legal, 8 1/2 x 14 in"
+msgstr "Legal, 8 1/2 x 14 in"
+
+#: ../src/common/paper.cpp:72
+msgid "A4 sheet, 210 x 297 mm"
+msgstr "A4 sheet, 210 x 297 mm"
+
+#: ../src/common/paper.cpp:73
+msgid "C sheet, 17 x 22 in"
+msgstr "C sheet, 17 x 22 in"
+
+#: ../src/common/paper.cpp:74
+msgid "D sheet, 22 x 34 in"
+msgstr "D sheet, 22 x 34 in"
+
+#: ../src/common/paper.cpp:75
+msgid "E sheet, 34 x 44 in"
+msgstr "E sheet, 34 x 44 in"
+
+#: ../src/common/paper.cpp:76
+msgid "Letter Small, 8 1/2 x 11 in"
+msgstr "Letter Small, 8 1/2 x 11 in"
+
+#: ../src/common/paper.cpp:77
+msgid "Tabloid, 11 x 17 in"
+msgstr "Tabloid, 11 x 17 in"
+
+#: ../src/common/paper.cpp:78
+msgid "Ledger, 17 x 11 in"
+msgstr "Ledger, 17 x 11 in"
+
+#: ../src/common/paper.cpp:79
+msgid "Statement, 5 1/2 x 8 1/2 in"
+msgstr "Statement, 5 1/2 x 8 1/2 in"
+
+#: ../src/common/paper.cpp:80
+msgid "Executive, 7 1/4 x 10 1/2 in"
+msgstr "Executive, 7 1/4 x 10 1/2 in"
+
+#: ../src/common/paper.cpp:81
+msgid "A3 sheet, 297 x 420 mm"
+msgstr "A3 sheet, 297 x 420 mm"
+
+#: ../src/common/paper.cpp:82
+msgid "A4 small sheet, 210 x 297 mm"
+msgstr "A4 small sheet, 210 x 297 mm"
+
+#: ../src/common/paper.cpp:83
+msgid "A5 sheet, 148 x 210 mm"
+msgstr "A5 sheet, 148 x 210 mm"
+
+#: ../src/common/paper.cpp:84
+msgid "B4 sheet, 250 x 354 mm"
+msgstr "B4 sheet, 250 x 354 mm"
+
+#: ../src/common/paper.cpp:85
+msgid "B5 sheet, 182 x 257 millimeter"
+msgstr "B5 sheet, 182 x 257 millimeter"
+
+#: ../src/common/paper.cpp:86
+msgid "Folio, 8 1/2 x 13 in"
+msgstr "Folio, 8 1/2 x 13 in"
+
+#: ../src/common/paper.cpp:87
+msgid "Quarto, 215 x 275 mm"
+msgstr "Quarto, 215 x 275 mm"
+
+#: ../src/common/paper.cpp:88
+msgid "10 x 14 in"
+msgstr "10 x 14 in"
+
+#: ../src/common/paper.cpp:89
+msgid "11 x 17 in"
+msgstr "11 x 17 in"
+
+#: ../src/common/paper.cpp:90
+msgid "Note, 8 1/2 x 11 in"
+msgstr "Note, 8 1/2 x 11 in"
+
+#: ../src/common/paper.cpp:91
+msgid "#9 Envelope, 3 7/8 x 8 7/8 in"
+msgstr "#9 Envelope, 3 7/8 x 8 7/8 in"
+
+#: ../src/common/paper.cpp:92
+msgid "#10 Envelope, 4 1/8 x 9 1/2 in"
+msgstr "#10 Envelope, 4 1/8 x 9 1/2 in"
+
+#: ../src/common/paper.cpp:93
+msgid "#11 Envelope, 4 1/2 x 10 3/8 in"
+msgstr "#11 Envelope, 4 1/2 x 10 3/8 in"
+
+#: ../src/common/paper.cpp:94
+msgid "#12 Envelope, 4 3/4 x 11 in"
+msgstr "#12 Envelope, 4 3/4 x 11 in"
+
+#: ../src/common/paper.cpp:95
+msgid "#14 Envelope, 5 x 11 1/2 in"
+msgstr "#14 Envelope, 5 x 11 1/2 in"
+
+#: ../src/common/paper.cpp:96
+msgid "DL Envelope, 110 x 220 mm"
+msgstr "DL Envelope, 110 x 220 mm"
+
+#: ../src/common/paper.cpp:97
+msgid "C5 Envelope, 162 x 229 mm"
+msgstr "C5 Envelope, 162 x 229 mm"
+
+#: ../src/common/paper.cpp:98
+msgid "C3 Envelope, 324 x 458 mm"
+msgstr "C3 Envelope, 324 x 458 mm"
+
+#: ../src/common/paper.cpp:99
+msgid "C4 Envelope, 229 x 324 mm"
+msgstr "C4 Envelope, 229 x 324 mm"
+
+#: ../src/common/paper.cpp:100
+msgid "C6 Envelope, 114 x 162 mm"
+msgstr "C6 Envelope, 114 x 162 mm"
+
+#: ../src/common/paper.cpp:101
+msgid "C65 Envelope, 114 x 229 mm"
+msgstr "C65 Envelope, 114 x 229 mm"
+
+#: ../src/common/paper.cpp:102
+msgid "B4 Envelope, 250 x 353 mm"
+msgstr "B4 Envelope, 250 x 353 mm"
+
+#: ../src/common/paper.cpp:103
+msgid "B5 Envelope, 176 x 250 mm"
+msgstr "B5 Envelope, 176 x 250 mm"
+
+#: ../src/common/paper.cpp:104
+msgid "B6 Envelope, 176 x 125 mm"
+msgstr "B6 Envelope, 176 x 125 mm"
+
+#: ../src/common/paper.cpp:105
+msgid "Italy Envelope, 110 x 230 mm"
+msgstr "Phong bì Ý, 110 x 230 mm"
+
+#: ../src/common/paper.cpp:106
+msgid "Monarch Envelope, 3 7/8 x 7 1/2 in"
+msgstr "Monarch Envelope, 3 7/8 x 7 1/2 in"
+
+#: ../src/common/paper.cpp:107
+msgid "6 3/4 Envelope, 3 5/8 x 6 1/2 in"
+msgstr "6 3/4 Envelope, 3 5/8 x 6 1/2 in"
+
+#: ../src/common/paper.cpp:108
+msgid "US Std Fanfold, 14 7/8 x 11 in"
+msgstr "US Std Fanfold, 14 7/8 x 11 in"
+
+#: ../src/common/paper.cpp:109
+msgid "German Std Fanfold, 8 1/2 x 12 in"
+msgstr "German Std Fanfold, 8 1/2 x 12 in"
+
+#: ../src/common/paper.cpp:110
+msgid "German Legal Fanfold, 8 1/2 x 13 in"
+msgstr "German Legal Fanfold, 8 1/2 x 13 in"
+
+#: ../src/common/paper.cpp:112
+msgid "B4 (ISO) 250 x 353 mm"
+msgstr "B4 (ISO) 250 x 353 mm"
+
+#: ../src/common/paper.cpp:113
+msgid "Japanese Postcard 100 x 148 mm"
+msgstr "Bưu Thiếp Kiểu Nhật Bản 100 x 148 mm"
+
+#: ../src/common/paper.cpp:114
+msgid "9 x 11 in"
+msgstr "9 x 11 in"
+
+#: ../src/common/paper.cpp:115
+msgid "10 x 11 in"
+msgstr "10 x 11 in"
+
+#: ../src/common/paper.cpp:116
+msgid "15 x 11 in"
+msgstr "15 x 11 in"
+
+#: ../src/common/paper.cpp:117
+msgid "Envelope Invite 220 x 220 mm"
+msgstr "Envelope Invite 220 x 220 mm"
+
+#: ../src/common/paper.cpp:118
+msgid "Letter Extra 9 1/2 x 12 in"
+msgstr "Letter Extra 9 1/2 x 12 in"
+
+#: ../src/common/paper.cpp:119
+msgid "Legal Extra 9 1/2 x 15 in"
+msgstr "Legal Extra 9 1/2 x 15 in"
+
+#: ../src/common/paper.cpp:120
+msgid "Tabloid Extra 11.69 x 18 in"
+msgstr "Tabloid Extra 11.69 x 18 in"
+
+#: ../src/common/paper.cpp:121
+msgid "A4 Extra 9.27 x 12.69 in"
+msgstr "A4 Extra 9.27 x 12.69 in"
+
+#: ../src/common/paper.cpp:122
+msgid "Letter Transverse 8 1/2 x 11 in"
+msgstr "Letter Transverse 8 1/2 x 11 in"
+
+#: ../src/common/paper.cpp:123
+msgid "A4 Transverse 210 x 297 mm"
+msgstr "A4 Transverse 210 x 297 mm"
+
+#: ../src/common/paper.cpp:124
+msgid "Letter Extra Transverse 9.275 x 12 in"
+msgstr "Letter Extra Transverse 9.275 x 12 in"
+
+#: ../src/common/paper.cpp:125
+msgid "SuperA/SuperA/A4 227 x 356 mm"
+msgstr "SuperA/SuperA/A4 227 x 356 mm"
+
+#: ../src/common/paper.cpp:126
+msgid "SuperB/SuperB/A3 305 x 487 mm"
+msgstr "SuperB/SuperB/A3 305 x 487 mm"
+
+#: ../src/common/paper.cpp:127
+msgid "Letter Plus 8 1/2 x 12.69 in"
+msgstr "Letter Plus 8 1/2 x 12.69 in"
+
+#: ../src/common/paper.cpp:128
+msgid "A4 Plus 210 x 330 mm"
+msgstr "A4 Plus 210 x 330 mm"
+
+#: ../src/common/paper.cpp:129
+msgid "A5 Transverse 148 x 210 mm"
+msgstr "A5 Transverse 148 x 210 mm"
+
+#: ../src/common/paper.cpp:130
+msgid "B5 (JIS) Transverse 182 x 257 mm"
+msgstr "B5 (JIS) Transverse 182 x 257 mm"
+
+#: ../src/common/paper.cpp:131
+msgid "A3 Extra 322 x 445 mm"
+msgstr "A3 Extra 322 x 445 mm"
+
+#: ../src/common/paper.cpp:132
+msgid "A5 Extra 174 x 235 mm"
+msgstr "A5 Extra 174 x 235 mm"
+
+#: ../src/common/paper.cpp:133
+msgid "B5 (ISO) Extra 201 x 276 mm"
+msgstr "B5 (ISO) Extra 201 x 276 mm"
+
+#: ../src/common/paper.cpp:134
+msgid "A2 420 x 594 mm"
+msgstr "A2 420 x 594 mm"
+
+#: ../src/common/paper.cpp:135
+msgid "A3 Transverse 297 x 420 mm"
+msgstr "A3 Transverse 297 x 420 mm"
+
+#: ../src/common/paper.cpp:136
+msgid "A3 Extra Transverse 322 x 445 mm"
+msgstr "A3 Extra Transverse 322 x 445 mm"
+
+#: ../src/common/paper.cpp:138
+msgid "Japanese Double Postcard 200 x 148 mm"
+msgstr "Japanese Double Postcard 200 x 148 mm"
+
+#: ../src/common/paper.cpp:139
+msgid "A6 105 x 148 mm"
+msgstr "A6 105 x 148 mm"
+
+#: ../src/common/paper.cpp:140
+msgid "Japanese Envelope Kaku #2"
+msgstr "Phong bì Nhật Bản Kaku #2"
+
+#: ../src/common/paper.cpp:141
+msgid "Japanese Envelope Kaku #3"
+msgstr "Phong bì Nhật Bản Kaku #3"
+
+#: ../src/common/paper.cpp:142
+msgid "Japanese Envelope Chou #3"
+msgstr "Japanese Envelope Chou #3"
+
+#: ../src/common/paper.cpp:143
+msgid "Japanese Envelope Chou #4"
+msgstr "Phong bì Nhật Bản Chou #4"
+
+#: ../src/common/paper.cpp:144
+msgid "Letter Rotated 11 x 8 1/2 in"
+msgstr "Letter Rotated 11 x 8 1/2 in"
+
+#: ../src/common/paper.cpp:145
+msgid "A3 Rotated 420 x 297 mm"
+msgstr "A3 Rotated 420 x 297 mm"
+
+#: ../src/common/paper.cpp:146
+msgid "A4 Rotated 297 x 210 mm"
+msgstr "A4 Rotated 297 x 210 mm"
+
+#: ../src/common/paper.cpp:147
+msgid "A5 Rotated 210 x 148 mm"
+msgstr "A5 Rotated 210 x 148 mm"
+
+#: ../src/common/paper.cpp:148
+msgid "B4 (JIS) Rotated 364 x 257 mm"
+msgstr "B4 (JIS) Rotated 364 x 257 mm"
+
+#: ../src/common/paper.cpp:149
+msgid "B5 (JIS) Rotated 257 x 182 mm"
+msgstr "B5 (JIS) Rotated 257 x 182 mm"
+
+#: ../src/common/paper.cpp:150
+msgid "Japanese Postcard Rotated 148 x 100 mm"
+msgstr "Bưu Thiếp Kiểu Nhật Bản Đã Xoay lại 148 x 100 mm"
+
+#: ../src/common/paper.cpp:151
+msgid "Double Japanese Postcard Rotated 148 x 200 mm"
+msgstr "Double Japanese Postcard Rotated 148 x 200 mm"
+
+#: ../src/common/paper.cpp:152
+msgid "A6 Rotated 148 x 105 mm"
+msgstr "A6 Rotated 148 x 105 mm"
+
+#: ../src/common/paper.cpp:153
+msgid "Japanese Envelope Kaku #2 Rotated"
+msgstr "Phong bì Nhật Bản Kaku #2 Rotated"
+
+#: ../src/common/paper.cpp:154
+msgid "Japanese Envelope Kaku #3 Rotated"
+msgstr "Phong bì Nhật Bản Kaku #3 Rotated"
+
+#: ../src/common/paper.cpp:155
+msgid "Japanese Envelope Chou #3 Rotated"
+msgstr "Phong bì Nhật Bản Chou #3 Rotated"
+
+#: ../src/common/paper.cpp:156
+msgid "Japanese Envelope Chou #4 Rotated"
+msgstr "Phong bì Nhật Bản Chou #4 Rotated"
+
+#: ../src/common/paper.cpp:157
+msgid "B6 (JIS) 128 x 182 mm"
+msgstr "B6 (JIS) 128 x 182 mm"
+
+#: ../src/common/paper.cpp:158
+msgid "B6 (JIS) Rotated 182 x 128 mm"
+msgstr "B6 (JIS) Rotated 182 x 128 mm"
+
+#: ../src/common/paper.cpp:159
+msgid "12 x 11 in"
+msgstr "12 x 11 in"
+
+#: ../src/common/paper.cpp:160
+msgid "Japanese Envelope You #4"
+msgstr "Phong bì Nhật Bản You #4"
+
+#: ../src/common/paper.cpp:161
+msgid "Japanese Envelope You #4 Rotated"
+msgstr "Phong bì Nhật Bản You #4 Rotated"
+
+#: ../src/common/paper.cpp:162
+msgid "PRC 16K 146 x 215 mm"
+msgstr "PRC 16K 146 x 215 mm"
+
+#: ../src/common/paper.cpp:163
+msgid "PRC 32K 97 x 151 mm"
+msgstr "PRC 32K 97 x 151 mm"
+
+#: ../src/common/paper.cpp:164
+msgid "PRC 32K(Big) 97 x 151 mm"
+msgstr "PRC 32K(Big) 97 x 151 mm"
+
+#: ../src/common/paper.cpp:165
+msgid "PRC Envelope #1 102 x 165 mm"
+msgstr "PRC Envelope #1 102 x 165 mm"
+
+#: ../src/common/paper.cpp:166
+msgid "PRC Envelope #2 102 x 176 mm"
+msgstr "PRC Envelope #2 102 x 176 mm"
+
+#: ../src/common/paper.cpp:167
+msgid "PRC Envelope #3 125 x 176 mm"
+msgstr "PRC Envelope #3 125 x 176 mm"
+
+#: ../src/common/paper.cpp:168
+msgid "PRC Envelope #4 110 x 208 mm"
+msgstr "PRC Envelope #4 110 x 208 mm"
+
+#: ../src/common/paper.cpp:169
+msgid "PRC Envelope #5 110 x 220 mm"
+msgstr "PRC Envelope #5 110 x 220 mm"
+
+#: ../src/common/paper.cpp:170
+msgid "PRC Envelope #6 120 x 230 mm"
+msgstr "PRC Envelope #6 120 x 230 mm"
+
+#: ../src/common/paper.cpp:171
+msgid "PRC Envelope #7 160 x 230 mm"
+msgstr "PRC Envelope #7 160 x 230 mm"
+
+#: ../src/common/paper.cpp:172
+msgid "PRC Envelope #8 120 x 309 mm"
+msgstr "PRC Envelope #8 120 x 309 mm"
+
+#: ../src/common/paper.cpp:173
+msgid "PRC Envelope #9 229 x 324 mm"
+msgstr "PRC Envelope #9 229 x 324 mm"
+
+#: ../src/common/paper.cpp:174
+msgid "PRC Envelope #10 324 x 458 mm"
+msgstr "PRC Envelope #10 324 x 458 mm"
+
+#: ../src/common/paper.cpp:175
+msgid "PRC 16K Rotated"
+msgstr "PRC 16K Rotated"
+
+#: ../src/common/paper.cpp:176
+msgid "PRC 32K Rotated"
+msgstr "PRC 32K Rotated"
+
+#: ../src/common/paper.cpp:177
+msgid "PRC 32K(Big) Rotated"
+msgstr "PRC 32K(Big) Rotated"
+
+#: ../src/common/paper.cpp:178
+msgid "PRC Envelope #1 Rotated 165 x 102 mm"
+msgstr "PRC Envelope #1 Rotated 165 x 102 mm"
+
+#: ../src/common/paper.cpp:179
+msgid "PRC Envelope #2 Rotated 176 x 102 mm"
+msgstr "PRC Envelope #2 Rotated 176 x 102 mm"
+
+#: ../src/common/paper.cpp:180
+msgid "PRC Envelope #3 Rotated 176 x 125 mm"
+msgstr "PRC Envelope #3 Rotated 176 x 125 mm"
+
+#: ../src/common/paper.cpp:181
+msgid "PRC Envelope #4 Rotated 208 x 110 mm"
+msgstr "PRC Envelope #4 Rotated 208 x 110 mm"
+
+#: ../src/common/paper.cpp:182
+msgid "PRC Envelope #5 Rotated 220 x 110 mm"
+msgstr "PRC Envelope #5 Rotated 220 x 110 mm"
+
+#: ../src/common/paper.cpp:183
+msgid "PRC Envelope #6 Rotated 230 x 120 mm"
+msgstr "PRC Envelope #6 Rotated 230 x 120 mm"
+
+#: ../src/common/paper.cpp:184
+msgid "PRC Envelope #7 Rotated 230 x 160 mm"
+msgstr "PRC Envelope #7 Rotated 230 x 160 mm"
+
+#: ../src/common/paper.cpp:185
+msgid "PRC Envelope #8 Rotated 309 x 120 mm"
+msgstr "PRC Envelope #8 Rotated 309 x 120 mm"
+
+#: ../src/common/paper.cpp:186
+msgid "PRC Envelope #9 Rotated 324 x 229 mm"
+msgstr "PRC Envelope #9 Rotated 324 x 229 mm"
+
+#: ../src/common/paper.cpp:187
+msgid "PRC Envelope #10 Rotated 458 x 324 mm"
+msgstr "PRC Envelope #10 Rotated 458 x 324 mm"
+
+#: ../src/common/paper.cpp:192
+msgid "A0 sheet, 841 x 1189 mm"
+msgstr "A0 sheet, 841 x 1189 mm"
+
+#: ../src/common/paper.cpp:193
+msgid "A1 sheet, 594 x 841 mm"
+msgstr "A1 sheet, 594 x 841 mm"
+
+#: ../src/common/preferencescmn.cpp:37
+msgid "General"
+msgstr "Chung"
+
+#: ../src/common/preferencescmn.cpp:40
+msgid "Advanced"
+msgstr "Cao cấp"
+
+#: ../src/common/prntbase.cpp:245
+msgid "Generic PostScript"
+msgstr "Generic PostScript"
+
+#: ../src/common/prntbase.cpp:259
+msgid "Ready"
+msgstr "Sẵn sàng"
+
+#: ../src/common/prntbase.cpp:331
+msgid "Printing Error"
+msgstr "Lỗi In"
+
+#: ../src/common/prntbase.cpp:413 ../src/common/prntbase.cpp:1597
+#: ../src/generic/prntdlgg.cpp:135 ../src/generic/prntdlgg.cpp:149
+#: ../src/gtk/print.cpp:628 ../src/gtk/print.cpp:646
+msgid "Print"
+msgstr "In"
+
+#: ../src/common/prntbase.cpp:471 ../src/generic/prntdlgg.cpp:809
+msgid "Page setup"
+msgstr "Cài đặt giấy"
+
+#: ../src/common/prntbase.cpp:525
+msgid "Please wait while printing..."
+msgstr "Xin hãy đợi khi đang in..."
+
+#: ../src/common/prntbase.cpp:529
+msgid "Document:"
+msgstr "Tài liệu:"
+
+#: ../src/common/prntbase.cpp:532
+msgid "Progress:"
+msgstr "Tiến triển:"
+
+#: ../src/common/prntbase.cpp:533
+msgid "Preparing"
+msgstr "Đang chuẩn bị"
+
+#: ../src/common/prntbase.cpp:552
+#, fuzzy, c-format
+msgid "Printing page %d"
+msgstr "Đang in trang %d..."
+
+#: ../src/common/prntbase.cpp:557
+#, c-format
+msgid "Printing page %d of %d"
+msgstr "Đang in trang %d trong tổng số %d"
+
+#: ../src/common/prntbase.cpp:560
+#, c-format
+msgid " (copy %d of %d)"
+msgstr " (chép %d trong số %d)"
+
+#: ../src/common/prntbase.cpp:1604
+msgid "First page"
+msgstr "Trang đầu"
+
+#: ../src/common/prntbase.cpp:1609 ../src/html/helpwnd.cpp:659
+msgid "Previous page"
+msgstr "Trang trước"
+
+#: ../src/common/prntbase.cpp:1623 ../src/html/helpwnd.cpp:660
+msgid "Next page"
+msgstr "Trang tiếp theo"
+
+#: ../src/common/prntbase.cpp:1628
+msgid "Last page"
+msgstr "Trang cuối"
+
+#: ../src/common/prntbase.cpp:1636 ../src/common/stockitem.cpp:215
+msgid "Zoom Out"
+msgstr "Thu nhỏ"
+
+#: ../src/common/prntbase.cpp:1650 ../src/common/stockitem.cpp:214
+msgid "Zoom In"
+msgstr "Phóng to"
+
+#: ../src/common/prntbase.cpp:1656 ../src/common/stockitem.cpp:153
+#: ../src/generic/logg.cpp:553 ../src/univ/themes/win32.cpp:3752
+msgid "&Close"
+msgstr "Đó&ng"
+
+#: ../src/common/prntbase.cpp:2085
+msgid "Could not start document preview."
+msgstr "Không thể bắt đầu việc xem thử tài liệu."
+
+#: ../src/common/prntbase.cpp:2085 ../src/common/prntbase.cpp:2129
+#: ../src/common/prntbase.cpp:2137
+msgid "Print Preview Failure"
+msgstr "Mô Phỏng Bản In Bị Lỗi"
+
+#: ../src/common/prntbase.cpp:2129 ../src/common/prntbase.cpp:2137
+msgid "Sorry, not enough memory to create a preview."
+msgstr "Rất tiếc, không đủ bộ nhớ để tạo lập việc xem thử."
+
+#: ../src/common/prntbase.cpp:2144
+#, c-format
+msgid "Page %d of %d"
+msgstr "Trang %d của %d"
+
+#: ../src/common/prntbase.cpp:2146
+#, c-format
+msgid "Page %d"
+msgstr "Trang %d"
+
+#: ../src/common/regex.cpp:382 ../src/html/chm.cpp:348
+msgid "unknown error"
+msgstr "lỗi lạ"
+
+#: ../src/common/regex.cpp:995
+#, c-format
+msgid "Invalid regular expression '%s': %s"
+msgstr "Biểu thức thông thường '%s' không hợp lệ: %s"
+
+#: ../src/common/regex.cpp:1059
+#, c-format
+msgid "Failed to find match for regular expression: %s"
+msgstr "Việc tìm khớp với biểu thức thông thường gặp lỗi: %s"
+
+#: ../src/common/rendcmn.cpp:188
+#, c-format
+msgid "Renderer \"%s\" has incompatible version %d.%d and couldn't be loaded."
+msgstr ""
+"Renderer \"%s\" đã không tương thích với phiên bản %d.%d và không thể được "
+"nạp."
+
+#: ../src/common/secretstore.cpp:162
+msgid "Not available for this platform"
+msgstr ""
+
+#: ../src/common/secretstore.cpp:183
+#, fuzzy, c-format
+msgid "Saving password for \"%s\" failed: %s."
+msgstr "Rút trích '%s' vào '%s' gặp lỗi."
+
+#: ../src/common/secretstore.cpp:205
+#, fuzzy, c-format
+msgid "Reading password for \"%s\" failed: %s."
+msgstr "Rút trích '%s' vào '%s' gặp lỗi."
+
+#: ../src/common/secretstore.cpp:228
+#, fuzzy, c-format
+msgid "Deleting password for \"%s\" failed: %s."
+msgstr "Rút trích '%s' vào '%s' gặp lỗi."
+
+#: ../src/common/selectdispatcher.cpp:254
+msgid "Failed to monitor I/O channels"
+msgstr "Kênh vào ra màn hình gặp lỗi"
+
+#: ../src/common/sizer.cpp:3054 ../src/common/stockitem.cpp:195
+msgid "Save"
+msgstr "Ghi lại"
+
+#: ../src/common/sizer.cpp:3056
+msgid "Don't Save"
+msgstr "Không Ghi Lại"
+
+#: ../src/common/socket.cpp:870
+msgid "Cannot initialize sockets"
+msgstr "Không thể khởi tạo socket"
+
+#: ../src/common/stockitem.cpp:127
+#, fuzzy
+msgctxt "standard Windows menu"
+msgid "&Help"
+msgstr "Trợ &giúp"
+
+#: ../src/common/stockitem.cpp:144
+msgid "&About"
+msgstr "&Giới thiệu"
+
+#: ../src/common/stockitem.cpp:144
+msgid "About"
+msgstr "Giới thiệu"
+
+#: ../src/common/stockitem.cpp:145
+msgid "Add"
+msgstr "Thêm"
+
+#: ../src/common/stockitem.cpp:146
+msgid "&Apply"
+msgstr "Chấ&p nhận"
+
+#: ../src/common/stockitem.cpp:146
+msgid "Apply"
+msgstr "Áp dụng"
+
+#: ../src/common/stockitem.cpp:147
+msgid "&Back"
+msgstr "&Quay lại"
+
+#: ../src/common/stockitem.cpp:147
+msgid "Back"
+msgstr "Quay lại"
+
+#: ../src/common/stockitem.cpp:148
+msgid "&Bold"
+msgstr "Đậ&m"
+
+#: ../src/common/stockitem.cpp:148 ../src/generic/fontdlgg.cpp:326
+#: ../src/richtext/richtextfontpage.cpp:354
+msgid "Bold"
+msgstr "Đậm"
+
+#: ../src/common/stockitem.cpp:149
+msgid "&Bottom"
+msgstr "&Dưới"
+
+#: ../src/common/stockitem.cpp:149 ../src/richtext/richtextsizepage.cpp:287
+msgid "Bottom"
+msgstr "Dưới"
+
+#: ../src/common/stockitem.cpp:150 ../src/generic/fontdlgg.cpp:462
+#: ../src/generic/fontdlgg.cpp:481 ../src/generic/wizard.cpp:415
+msgid "&Cancel"
+msgstr "&Hủy bỏ"
+
+#: ../src/common/stockitem.cpp:151
+#, fuzzy
+msgid "&CD-ROM"
+msgstr "&CD-Rom"
+
+#: ../src/common/stockitem.cpp:151
+#, fuzzy
+msgid "CD-ROM"
+msgstr "CD-Rom"
+
+#: ../src/common/stockitem.cpp:152
+msgid "&Clear"
+msgstr "&Xóa"
+
+#: ../src/common/stockitem.cpp:152
+msgid "Clear"
+msgstr "Xóa sạch"
+
+#: ../src/common/stockitem.cpp:153 ../src/generic/dbgrptg.cpp:93
+#: ../src/generic/progdlgg.cpp:778 ../src/html/helpdlg.cpp:86
+#: ../src/msw/progdlg.cpp:209 ../src/msw/progdlg.cpp:890
+#: ../src/richtext/richtextstyledlg.cpp:272
+#: ../src/richtext/richtextsymboldlg.cpp:448
+msgid "Close"
+msgstr "Đóng"
+
+#: ../src/common/stockitem.cpp:154
+msgid "&Convert"
+msgstr "&Chuyển đổi"
+
+#: ../src/common/stockitem.cpp:154
+msgid "Convert"
+msgstr "Chuyển đổi"
+
+#: ../src/common/stockitem.cpp:155 ../src/msw/textctrl.cpp:2884
+#: ../src/osx/textctrl_osx.cpp:653 ../src/richtext/richtextctrl.cpp:331
+msgid "&Copy"
+msgstr "&Sao chép"
+
+#: ../src/common/stockitem.cpp:155 ../src/stc/stc_i18n.cpp:18
+msgid "Copy"
+msgstr "Chép"
+
+#: ../src/common/stockitem.cpp:156 ../src/msw/textctrl.cpp:2883
+#: ../src/osx/textctrl_osx.cpp:652 ../src/richtext/richtextctrl.cpp:330
+msgid "Cu&t"
+msgstr "Cắ&t"
+
+#: ../src/common/stockitem.cpp:156 ../src/stc/stc_i18n.cpp:17
+msgid "Cut"
+msgstr "Cắt"
+
+#: ../src/common/stockitem.cpp:157 ../src/msw/textctrl.cpp:2886
+#: ../src/osx/textctrl_osx.cpp:655 ../src/richtext/richtextctrl.cpp:333
+#: ../src/richtext/richtexttabspage.cpp:137
+msgid "&Delete"
+msgstr "&Xóa"
+
+#: ../src/common/stockitem.cpp:157 ../src/richtext/richtextbuffer.cpp:8266
+#: ../src/stc/stc_i18n.cpp:20
+msgid "Delete"
+msgstr "Xóa bỏ"
+
+#: ../src/common/stockitem.cpp:158
+msgid "&Down"
+msgstr "X&uống"
+
+#: ../src/common/stockitem.cpp:158 ../src/generic/fdrepdlg.cpp:148
+msgid "Down"
+msgstr "Xuống"
+
+#: ../src/common/stockitem.cpp:159
+msgid "&Edit"
+msgstr "&Hiệu chỉnh"
+
+#: ../src/common/stockitem.cpp:159
+msgid "Edit"
+msgstr "Chỉnh sửa"
+
+#: ../src/common/stockitem.cpp:160
+msgid "&Execute"
+msgstr "&Thi hành"
+
+#: ../src/common/stockitem.cpp:160
+msgid "Execute"
+msgstr "Thi hành"
+
+#: ../src/common/stockitem.cpp:161
+msgid "&Quit"
+msgstr "T&hoát"
+
+#: ../src/common/stockitem.cpp:161
+msgid "Quit"
+msgstr "Thoát"
+
+#: ../src/common/stockitem.cpp:162
+msgid "&File"
+msgstr "&Chính"
+
+#: ../src/common/stockitem.cpp:162
+msgid "File"
+msgstr "Tập tin"
+
+#: ../src/common/stockitem.cpp:163
+#, fuzzy
+msgid "&Find..."
+msgstr "&Tìm"
+
+#: ../src/common/stockitem.cpp:163
+#, fuzzy
+msgid "Find..."
+msgstr "Tìm"
+
+#: ../src/common/stockitem.cpp:164
+msgid "&First"
+msgstr "Đầ&u tiên"
+
+#: ../src/common/stockitem.cpp:164
+msgid "First"
+msgstr "Đầu tiên"
+
+#: ../src/common/stockitem.cpp:165
+msgid "&Floppy"
+msgstr "Đĩa &mềm"
+
+#: ../src/common/stockitem.cpp:165
+msgid "Floppy"
+msgstr "Đĩa mềm"
+
+#: ../src/common/stockitem.cpp:166
+msgid "&Forward"
+msgstr "&Tiếp tới"
+
+#: ../src/common/stockitem.cpp:166
+msgid "Forward"
+msgstr "Chuyển tiếp"
+
+#: ../src/common/stockitem.cpp:167
+msgid "&Harddisk"
+msgstr "Đĩa &cứng"
+
+#: ../src/common/stockitem.cpp:167
+msgid "Harddisk"
+msgstr "Đĩa cứng"
+
+#: ../src/common/stockitem.cpp:168 ../src/generic/wizard.cpp:418
+#: ../src/osx/cocoa/menu.mm:225 ../src/richtext/richtextstyledlg.cpp:298
+#: ../src/richtext/richtextsymboldlg.cpp:451
+msgid "&Help"
+msgstr "Trợ &giúp"
+
+#: ../src/common/stockitem.cpp:169
+msgid "&Home"
+msgstr "&Home"
+
+#: ../src/common/stockitem.cpp:169
+msgid "Home"
+msgstr "Thư mục Home"
+
+#: ../src/common/stockitem.cpp:170
+msgid "Indent"
+msgstr "Thụt lề"
+
+#: ../src/common/stockitem.cpp:171
+msgid "&Index"
+msgstr "&Chỉ mục"
+
+#: ../src/common/stockitem.cpp:171 ../src/html/helpwnd.cpp:510
+msgid "Index"
+msgstr "Chỉ mục"
+
+#: ../src/common/stockitem.cpp:172
+msgid "&Info"
+msgstr "&Thông tin"
+
+#: ../src/common/stockitem.cpp:172
+msgid "Info"
+msgstr "Thông tin"
+
+#: ../src/common/stockitem.cpp:173
+msgid "&Italic"
+msgstr "Ngh&iêng"
+
+#: ../src/common/stockitem.cpp:173 ../src/generic/fontdlgg.cpp:322
+#: ../src/richtext/richtextfontpage.cpp:350
+msgid "Italic"
+msgstr "Nghiêng"
+
+#: ../src/common/stockitem.cpp:174
+msgid "&Jump to"
+msgstr "&Nhảy tới"
+
+#: ../src/common/stockitem.cpp:174
+msgid "Jump to"
+msgstr "Nhảy tới"
+
+#: ../src/common/stockitem.cpp:175
+msgid "Centered"
+msgstr "Trung tâm"
+
+#: ../src/common/stockitem.cpp:176
+msgid "Justified"
+msgstr "Xắp xếp chữ"
+
+#: ../src/common/stockitem.cpp:177
+msgid "Align Left"
+msgstr "Canh lề Trái"
+
+#: ../src/common/stockitem.cpp:178
+msgid "Align Right"
+msgstr "Canh lề Phải"
+
+#: ../src/common/stockitem.cpp:179
+msgid "&Last"
+msgstr "&Cuối"
+
+#: ../src/common/stockitem.cpp:179
+msgid "Last"
+msgstr "Cuối"
+
+#: ../src/common/stockitem.cpp:180
+msgid "&Network"
+msgstr "Mạ&ng"
+
+#: ../src/common/stockitem.cpp:180
+msgid "Network"
+msgstr "Mạng"
+
+#: ../src/common/stockitem.cpp:181 ../src/richtext/richtexttabspage.cpp:131
+msgid "&New"
+msgstr "Tạo &mới"
+
+#: ../src/common/stockitem.cpp:181
+msgid "New"
+msgstr "Mới"
+
+#: ../src/common/stockitem.cpp:182 ../src/msw/msgdlg.cpp:417
+msgid "&No"
+msgstr "&Không"
+
+#: ../src/common/stockitem.cpp:183 ../src/generic/fontdlgg.cpp:467
+#: ../src/generic/fontdlgg.cpp:474
+msgid "&OK"
+msgstr "&Đồng ý"
+
+#: ../src/common/stockitem.cpp:184 ../src/generic/dbgrptg.cpp:341
+msgid "&Open..."
+msgstr "&Mở..."
+
+#: ../src/common/stockitem.cpp:184
+msgid "Open..."
+msgstr "Mở..."
+
+#: ../src/common/stockitem.cpp:185 ../src/msw/textctrl.cpp:2885
+#: ../src/osx/textctrl_osx.cpp:654 ../src/richtext/richtextctrl.cpp:332
+msgid "&Paste"
+msgstr "&Dán"
+
+#: ../src/common/stockitem.cpp:185 ../src/richtext/richtextctrl.cpp:3484
+#: ../src/stc/stc_i18n.cpp:19
+msgid "Paste"
+msgstr "Dán"
+
+#: ../src/common/stockitem.cpp:186
+msgid "&Preferences"
+msgstr "&Sở thích riêng"
+
+#: ../src/common/stockitem.cpp:186 ../src/osx/cocoa/preferences.mm:304
+msgid "Preferences"
+msgstr "Cá nhân hóa"
+
+#: ../src/common/stockitem.cpp:187
+msgid "Print previe&w..."
+msgstr "&Mô phỏng bản in..."
+
+#: ../src/common/stockitem.cpp:187
+msgid "Print preview..."
+msgstr "Xem thử bản in..."
+
+#: ../src/common/stockitem.cpp:188
+msgid "&Print..."
+msgstr "&In..."
+
+#: ../src/common/stockitem.cpp:188
+msgid "Print..."
+msgstr "In..."
+
+#: ../src/common/stockitem.cpp:189 ../src/richtext/richtextctrl.cpp:337
+#: ../src/richtext/richtextctrl.cpp:5479
+msgid "&Properties"
+msgstr "&Thuộc tính"
+
+#: ../src/common/stockitem.cpp:189
+msgid "Properties"
+msgstr "Thuộc tính"
+
+#: ../src/common/stockitem.cpp:190 ../src/stc/stc_i18n.cpp:16
+msgid "Redo"
+msgstr "Redo"
+
+#: ../src/common/stockitem.cpp:191
+msgid "Refresh"
+msgstr "Làm tươi lại"
+
+#: ../src/common/stockitem.cpp:192
+msgid "Remove"
+msgstr "Gỡ bỏ"
+
+#: ../src/common/stockitem.cpp:193
+#, fuzzy
+msgid "Rep&lace..."
+msgstr "Tha&y thế"
+
+#: ../src/common/stockitem.cpp:193
+#, fuzzy
+msgid "Replace..."
+msgstr "Thay thế"
+
+#: ../src/common/stockitem.cpp:194
+msgid "Revert to Saved"
+msgstr "Hoàn nguyên để Ghi Lại"
+
+#: ../src/common/stockitem.cpp:196 ../src/generic/logg.cpp:549
+msgid "Save &As..."
+msgstr "&Ghi Lại Bằng Tên Mới..."
+
+#: ../src/common/stockitem.cpp:196
+#, fuzzy
+msgid "Save As..."
+msgstr "&Ghi Lại Bằng Tên Mới..."
+
+#: ../src/common/stockitem.cpp:197 ../src/msw/textctrl.cpp:2888
+#: ../src/osx/textctrl_osx.cpp:657 ../src/richtext/richtextctrl.cpp:335
+msgid "Select &All"
+msgstr "Chọn &Hết"
+
+#: ../src/common/stockitem.cpp:197 ../src/stc/stc_i18n.cpp:21
+msgid "Select All"
+msgstr "Chọn Hết"
+
+#: ../src/common/stockitem.cpp:198
+msgid "&Color"
+msgstr "&Màu"
+
+#: ../src/common/stockitem.cpp:198
+msgid "Color"
+msgstr "Màu"
+
+#: ../src/common/stockitem.cpp:199
+msgid "&Font"
+msgstr "&Phông chữ"
+
+#: ../src/common/stockitem.cpp:199 ../src/richtext/richtextformatdlg.cpp:336
+msgid "Font"
+msgstr "Phông chữ"
+
+#: ../src/common/stockitem.cpp:200
+msgid "&Ascending"
+msgstr "&Tăng dần"
+
+#: ../src/common/stockitem.cpp:200
+msgid "Ascending"
+msgstr "Tăng dần"
+
+#: ../src/common/stockitem.cpp:201
+msgid "&Descending"
+msgstr "&Giảm dần"
+
+#: ../src/common/stockitem.cpp:201
+msgid "Descending"
+msgstr "Giảm dần"
+
+#: ../src/common/stockitem.cpp:202
+msgid "&Spell Check"
+msgstr "&Kiểm tra chính tả"
+
+#: ../src/common/stockitem.cpp:202
+msgid "Spell Check"
+msgstr "Kiểm tra chính tả"
+
+#: ../src/common/stockitem.cpp:203
+msgid "&Stop"
+msgstr "&Dừng"
+
+#: ../src/common/stockitem.cpp:203
+msgid "Stop"
+msgstr "Dừng"
+
+#: ../src/common/stockitem.cpp:204 ../src/richtext/richtextfontpage.cpp:274
+msgid "&Strikethrough"
+msgstr "Gạch giữ&a"
+
+#: ../src/common/stockitem.cpp:204
+msgid "Strikethrough"
+msgstr "Gạch giữa"
+
+#: ../src/common/stockitem.cpp:205
+msgid "&Top"
+msgstr "&Trên"
+
+#: ../src/common/stockitem.cpp:205 ../src/richtext/richtextsizepage.cpp:285
+#: ../src/richtext/richtextsizepage.cpp:289
+msgid "Top"
+msgstr "Trên"
+
+#: ../src/common/stockitem.cpp:206
+msgid "Undelete"
+msgstr "Không thể xóa"
+
+#: ../src/common/stockitem.cpp:207 ../src/generic/fontdlgg.cpp:437
+msgid "&Underline"
+msgstr "&Gạch chân"
+
+#: ../src/common/stockitem.cpp:207
+msgid "Underline"
+msgstr "Gạch dưới"
+
+#: ../src/common/stockitem.cpp:208 ../src/stc/stc_i18n.cpp:15
+msgid "Undo"
+msgstr "Undo"
+
+#: ../src/common/stockitem.cpp:209
+msgid "&Unindent"
+msgstr "&Không thụt lề"
+
+#: ../src/common/stockitem.cpp:209
+msgid "Unindent"
+msgstr "Không thụt lề"
+
+#: ../src/common/stockitem.cpp:210
+msgid "&Up"
+msgstr "&Lên"
+
+#: ../src/common/stockitem.cpp:210 ../src/generic/fdrepdlg.cpp:148
+msgid "Up"
+msgstr "Lên"
+
+#: ../src/common/stockitem.cpp:211 ../src/msw/msgdlg.cpp:417
+msgid "&Yes"
+msgstr "Đồn&g ý"
+
+#: ../src/common/stockitem.cpp:212
+msgid "&Actual Size"
+msgstr "&Kích thước Thật"
+
+#: ../src/common/stockitem.cpp:212
+msgid "Actual Size"
+msgstr "Kích thước Thật"
+
+#: ../src/common/stockitem.cpp:213
+msgid "Zoom to &Fit"
+msgstr "Vừa &Khít Cửa Sổ"
+
+#: ../src/common/stockitem.cpp:213
+msgid "Zoom to Fit"
+msgstr "Phóng to Khít Cửa Sổ"
+
+#: ../src/common/stockitem.cpp:214
+msgid "Zoom &In"
+msgstr "Phóng T&o"
+
+#: ../src/common/stockitem.cpp:215
+msgid "Zoom &Out"
+msgstr "Th&u Nhỏ"
+
+#: ../src/common/stockitem.cpp:262
+msgid "Show about dialog"
+msgstr "Hiển thị hộp thoại thông tin thêm"
+
+#: ../src/common/stockitem.cpp:263
+msgid "Copy selection"
+msgstr "Chép vùng chọn"
+
+#: ../src/common/stockitem.cpp:264
+msgid "Cut selection"
+msgstr "Cắt vùng chọn"
+
+#: ../src/common/stockitem.cpp:265
+msgid "Delete selection"
+msgstr "Xóa bỏ vùng chọn"
+
+#: ../src/common/stockitem.cpp:266
+#, fuzzy
+msgid "Find in document"
+msgstr "Mở tài liệu định dạng HTML"
+
+#: ../src/common/stockitem.cpp:267
+msgid "Find and replace in document"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:268
+msgid "Paste selection"
+msgstr "Dán vùng chọn"
+
+#: ../src/common/stockitem.cpp:269
+msgid "Quit this program"
+msgstr "Thoát khỏi chương trình này"
+
+#: ../src/common/stockitem.cpp:270
+msgid "Redo last action"
+msgstr "Redo bước cuối cùng"
+
+#: ../src/common/stockitem.cpp:271
+msgid "Undo last action"
+msgstr "Undo thao tác cuối cùng"
+
+#: ../src/common/stockitem.cpp:272
+#, fuzzy
+msgid "Create new document"
+msgstr "Tạo thư mục mới"
+
+#: ../src/common/stockitem.cpp:273
+#, fuzzy
+msgid "Open an existing document"
+msgstr "Mở tài liệu định dạng HTML"
+
+#: ../src/common/stockitem.cpp:274
+msgid "Close current document"
+msgstr "Đóng tài liệu hiện thời"
+
+#: ../src/common/stockitem.cpp:275
+msgid "Save current document"
+msgstr "Ghi lại tài liệu hiện tại"
+
+#: ../src/common/stockitem.cpp:276
+msgid "Save current document with a different filename"
+msgstr "Ghi lại tài liệu hiện hành với một cái tên khác"
+
+#: ../src/common/strconv.cpp:2324
+#, c-format
+msgid "Conversion to charset '%s' doesn't work."
+msgstr "Việc chuyển đổi bộ ký tự thành '%s' không làm việc."
+
+#: ../src/common/tarstrm.cpp:352 ../src/common/tarstrm.cpp:375
+#: ../src/common/tarstrm.cpp:406 ../src/generic/progdlgg.cpp:373
+msgid "unknown"
+msgstr "không rõ"
+
+#: ../src/common/tarstrm.cpp:774
+msgid "incomplete header block in tar"
+msgstr "không hoàn thành khối đầu trong gói tar"
+
+#: ../src/common/tarstrm.cpp:798
+msgid "checksum failure reading tar header block"
+msgstr "tổng kiểm tra việc đọc khối đầu gói tar bị thất bại"
+
+#: ../src/common/tarstrm.cpp:971
+msgid "invalid data in extended tar header"
+msgstr "dữ liệu trong phần đầu mở rộng của gói tar không hợp lệ"
+
+#: ../src/common/tarstrm.cpp:981 ../src/common/tarstrm.cpp:1003
+#: ../src/common/tarstrm.cpp:1477 ../src/common/tarstrm.cpp:1499
+msgid "tar entry not open"
+msgstr "mục tin tar không mở được"
+
+#: ../src/common/tarstrm.cpp:1023
+msgid "unexpected end of file"
+msgstr "kết thúc tập tin đột xuất"
+
+#: ../src/common/tarstrm.cpp:1297
+#, c-format
+msgid "%s did not fit the tar header for entry '%s'"
+msgstr "%s không vừa khớp với phần đầu tar cho mục vào '%s'"
+
+#: ../src/common/tarstrm.cpp:1359
+msgid "incorrect size given for tar entry"
+msgstr "kích thước định sẵn cho mục tin của gói tar không hợp lệ"
+
+#: ../src/common/textbuf.cpp:232
+#, c-format
+msgid "'%s' is probably a binary buffer."
+msgstr "'%s' chắc chắn là một bộ đệm nhị phân."
+
+#: ../src/common/textcmn.cpp:1006 ../src/richtext/richtextctrl.cpp:3053
+msgid "File couldn't be loaded."
+msgstr "Không thể tải tập tin lên."
+
+#: ../src/common/textfile.cpp:95
+#, fuzzy, c-format
+msgid "Failed to read text file \"%s\"."
+msgstr "Lỗi đọc từ tập tin \"%s\" gặp lỗi."
+
+#: ../src/common/textfile.cpp:160
+#, c-format
+msgid "can't write buffer '%s' to disk."
+msgstr "không thể ghi dữ liệu đệm '%s' vào đĩa."
+
+#: ../src/common/time.cpp:212
+msgid "Failed to get the local system time"
+msgstr "Lấy thời gian từ hệ thống gặp lỗi"
+
+#: ../src/common/time.cpp:279
+msgid "wxGetTimeOfDay failed."
+msgstr "wxGetTimeOfDay bị lỗi."
+
+#: ../src/common/translation.cpp:929
+#, c-format
+msgid "'%s' is not a valid message catalog."
+msgstr "'%s' không phải là catalog thông điệp hợp lệ."
+
+#: ../src/common/translation.cpp:954
+msgid "Invalid message catalog."
+msgstr "Catalog không hợp lệ."
+
+#: ../src/common/translation.cpp:1013
+#, c-format
+msgid "Failed to parse Plural-Forms: '%s'"
+msgstr "Lỗi khi phân tích dạng thức số nhiều: '%s'"
+
+#: ../src/common/translation.cpp:1723
+#, c-format
+msgid "using catalog '%s' from '%s'."
+msgstr "sử dụng catalog '%s' từ '%s'."
+
+#: ../src/common/translation.cpp:1816
+#, c-format
+msgid "Resource '%s' is not a valid message catalog."
+msgstr "Tài nguyên '%s' không đúng định dạng."
+
+#: ../src/common/translation.cpp:1865
+msgid "Couldn't enumerate translations"
+msgstr "Không thể liệt kê các bản dịch"
+
+#: ../src/common/utilscmn.cpp:1145
+msgid "No default application configured for HTML files."
+msgstr "Không có ứng dụng mặc định được cấu hình tập tin HTML."
+
+#: ../src/common/utilscmn.cpp:1190
+#, c-format
+msgid "Failed to open URL \"%s\" in default browser."
+msgstr "Mở URL \"%s\" trong trình duyệt mặc định gặp lỗi."
+
+#: ../src/common/valtext.cpp:144
+msgid "Validation conflict"
+msgstr "Bộ xác định tính hợp lệ bị xung đột"
+
+#: ../src/common/valtext.cpp:186
+msgid "Required information entry is empty."
+msgstr "Mục thông tin đã yêu cầu bị rỗng."
+
+#: ../src/common/valtext.cpp:188
+#, c-format
+msgid "'%s' is one of the invalid strings"
+msgstr "'%s' là một trong số những chuỗi không hợp lệ"
+
+#: ../src/common/valtext.cpp:190
+#, c-format
+msgid "'%s' is not one of the valid strings"
+msgstr "'%s' không phải là một chuỗi hợp lệ"
+
+#: ../src/common/valtext.cpp:199
+#, fuzzy, c-format
+msgid "'%s' contains invalid character(s)"
+msgstr "'%s' chứa các ký tự không hợp lệ"
+
+#: ../src/common/webrequest.cpp:139
+#, fuzzy, c-format
+msgid "Error: %s (%d)"
+msgstr "Lỗi: "
+
+#: ../src/common/webrequest.cpp:655
+#, c-format
+msgid ""
+"Not enough free disk space for download: %llu needed but only %llu available."
+msgstr ""
+
+#: ../src/common/webrequest.cpp:669
+#, fuzzy, c-format
+msgid "Failed to create temporary file in %s"
+msgstr "Tạo tên tập tin tạm gặp lỗi"
+
+#: ../src/common/webrequest_curl.cpp:1106
+#, fuzzy
+msgid "libcurl could not be initialized"
+msgstr "Phần miêu tả cột không thể được khởi tạo."
+
+#: ../src/common/webview.cpp:392
+msgid "RunScriptAsync not supported"
+msgstr ""
+
+#: ../src/common/webview.cpp:403 ../src/msw/webview_ie.cpp:1073
+#, c-format
+msgid "Error running JavaScript: %s"
+msgstr ""
+
+#: ../src/common/webview_chromium.cpp:858
+#, fuzzy, c-format
+msgid "Failed to set proxy \"%s\": %s"
+msgstr "Tạo thư mục \"%s\" gặp lỗi"
+
+#: ../src/common/webview_chromium.cpp:989
+msgid ""
+"Chromium can't be used because libcef.so wasn't loaded early enough; please "
+"relink the application or use LD_PRELOAD to load it earlier."
+msgstr ""
+
+#: ../src/common/webview_chromium.cpp:1108
+#, fuzzy
+msgid "Could not initialize Chromium"
+msgstr "Không thể đặt sự căn chỉnh."
+
+#: ../src/common/webview_chromium.cpp:1616
+msgid "Show DevTools"
+msgstr ""
+
+#: ../src/common/webview_chromium.cpp:1617
+#, fuzzy
+msgid "Close DevTools"
+msgstr "Đóng hết"
+
+#: ../src/common/webview_chromium.cpp:1623
+msgid "Inspect"
+msgstr ""
+
+#: ../src/common/wincmn.cpp:1628
+msgid "This platform does not support background transparency."
+msgstr "Hệ thống này không hỗ trợ làm trong suốt nền"
+
+#: ../src/common/wincmn.cpp:2097
+msgid "Could not transfer data to window"
+msgstr "Không thể truyền dữ liệu tới cửa sổ"
+
+#: ../src/common/windowid.cpp:240
+msgid "Out of window IDs.  Recommend shutting down application."
+msgstr "Thiếu chỉ số cửa sổ IDs. Đề nghị đóng ứng dụng."
+
+#: ../src/common/xpmdecod.cpp:678
+msgid "XPM: incorrect header format!"
+msgstr "XPM: định dạng phần đầu không đúng!"
+
+#: ../src/common/xpmdecod.cpp:703
+#, c-format
+msgid "XPM: incorrect colour description in line %d"
+msgstr "XPM: phần mô tả màu sắc không đúng tại dòng %d"
+
+#: ../src/common/xpmdecod.cpp:715 ../src/common/xpmdecod.cpp:724
+#, c-format
+msgid "XPM: malformed colour definition '%s' at line %d!"
+msgstr "XPM: định nghĩa màu sắc dị hình '%s' tại dòng %d!"
+
+#: ../src/common/xpmdecod.cpp:754
+msgid "XPM: no colors left to use for mask!"
+msgstr "XPM: không tìm thấy màu sử dụng cho mặt nạ!"
+
+#: ../src/common/xpmdecod.cpp:781
+#, c-format
+msgid "XPM: truncated image data at line %d!"
+msgstr "XPM: dữ liệu bị cắt xén ảnh tại dòng %d!"
+
+#: ../src/common/xpmdecod.cpp:795
+msgid "XPM: Malformed pixel data!"
+msgstr "XPM: Dữ liệu điểm ảnh của ảnh bị hỏng!"
+
+#: ../src/common/xti.cpp:492
+msgid "Illegal Parameter Count for Create Method"
+msgstr "Tham số Số lượng không hợp lệ cho Phương thức Tạo"
+
+#: ../src/common/xti.cpp:504
+msgid "Illegal Parameter Count for ConstructObject Method"
+msgstr ""
+"Tham số Số lượng không hợp lệ cho Phương thức ConstructObject (khởi tạo đối "
+"tượng, hay cấu tử)"
+
+#: ../src/common/xtistrm.cpp:161
+#, c-format
+msgid "Create Parameter %s not found in declared RTTI Parameters"
+msgstr "Tạo Tham Số %s không tìm thấy trong khai báo Tham Số RTTI"
+
+#: ../src/common/xtistrm.cpp:290
+msgid "Illegal Object Class (Non-wxEvtHandler) as Event Source"
+msgstr "Illegal Object Class (Non-wxEvtHandler) as Event Source"
+
+#: ../src/common/xtistrm.cpp:313 ../src/common/xtixml.cpp:345
+#: ../src/common/xtixml.cpp:498
+msgid "Type must have enum - long conversion"
+msgstr "Kiểu phải ở dạng enum - long chuyển đổi"
+
+#: ../src/common/xtistrm.cpp:400 ../src/common/xtistrm.cpp:415
+msgid "Invalid or Null Object ID passed to GetObjectClassInfo"
+msgstr "Không hợp lệ hay Null Object ID được chuyển tới GetObjectClassInfo"
+
+#: ../src/common/xtistrm.cpp:405
+msgid "Unknown Object passed to GetObjectClassInfo"
+msgstr "Đối Tượng không rõ được truyền tới GetObjectClassInfo"
+
+#: ../src/common/xtistrm.cpp:420
+msgid "Already Registered Object passed to SetObjectClassInfo"
+msgstr "Already Registered Object được chuyển cho SetObjectClassInfo"
+
+#: ../src/common/xtistrm.cpp:430
+msgid "Invalid or Null Object ID passed to HasObjectClassInfo"
+msgstr "Không hợp lệ hay Null Object ID được chuyển tới HasObjectClassInfo"
+
+#: ../src/common/xtistrm.cpp:460
+msgid "Passing a already registered object to SetObject"
+msgstr "Chuyển qua một đối tượng đã được đăng ký rồi để SetObject"
+
+#: ../src/common/xtistrm.cpp:471
+msgid "Passing an unknown object to GetObject"
+msgstr "Chuyển một đối tượng không hợp lệ cho SetObject"
+
+#: ../src/common/xtixml.cpp:229
+msgid "Forward hrefs are not supported"
+msgstr "Liên kết tiến tới chưa được hỗ trợ"
+
+#: ../src/common/xtixml.cpp:247
+#, c-format
+msgid "unknown class %s"
+msgstr "chưa biết lớp %s"
+
+#: ../src/common/xtixml.cpp:253
+msgid "objects cannot have XML Text Nodes"
+msgstr "đối tượng không thể có XML Text Nodes"
+
+#: ../src/common/xtixml.cpp:258
+msgid "Objects must have an id attribute"
+msgstr "Đối tượng phải có giá trị thuộc tính id"
+
+#: ../src/common/xtixml.cpp:267
+#, c-format
+msgid "Doubly used id : %d"
+msgstr "Chỉ số id người dùng kép: %d"
+
+#: ../src/common/xtixml.cpp:316
+#, c-format
+msgid "Unknown Property %s"
+msgstr "Không Rõ Thuộc Tính %s"
+
+#: ../src/common/xtixml.cpp:407
+msgid "A non empty collection must consist of 'element' nodes"
+msgstr "Một tập hợp không trống rỗng phải gồm có những nút 'phần tử'"
+
+#: ../src/common/xtixml.cpp:478
+msgid "incorrect event handler string, missing dot"
+msgstr "xâu chữ bộ điều khiển sự kiện không hợp lệ, thiếu dấu chấm"
+
+#: ../src/common/zipstrm.cpp:559
+msgid "can't re-initialize zlib deflate stream"
+msgstr "không thể khởi tạo lại zlib deflate stream"
+
+#: ../src/common/zipstrm.cpp:584
+msgid "can't re-initialize zlib inflate stream"
+msgstr "không thể khởi tạo lại zlib inflate stream"
+
+#: ../src/common/zipstrm.cpp:1023
+msgid "Ignoring malformed extra data record, ZIP file may be corrupted"
+msgstr ""
+
+#: ../src/common/zipstrm.cpp:1502
+msgid "assuming this is a multi-part zip concatenated"
+msgstr "xác nhận rằng đây là các phần móc nối của tập tin zip"
+
+#: ../src/common/zipstrm.cpp:1664
+msgid "invalid zip file"
+msgstr "tập tin zip không hợp lệ"
+
+#: ../src/common/zipstrm.cpp:1723
+msgid "can't find central directory in zip"
+msgstr "không thể tìm thấy thư mục trung tâm trong zip"
+
+#: ../src/common/zipstrm.cpp:1812
+msgid "error reading zip central directory"
+msgstr "lỗi đọc thư mục trung tâm zip"
+
+#: ../src/common/zipstrm.cpp:1916
+msgid "error reading zip local header"
+msgstr "lỗi đọc phần đầu nội bộ của zip"
+
+#: ../src/common/zipstrm.cpp:1964
+msgid "bad zipfile offset to entry"
+msgstr "đoạn offset tập tin zipfile hỏng được ghi vào"
+
+#: ../src/common/zipstrm.cpp:2031
+msgid "stored file length not in Zip header"
+msgstr "phần lưu giữ độ dài tập tin không ở trong phần đầu của Zip"
+
+#: ../src/common/zipstrm.cpp:2045 ../src/common/zipstrm.cpp:2362
+msgid "unsupported Zip compression method"
+msgstr "không hỗ trợ phương thức nén Zip"
+
+#: ../src/common/zipstrm.cpp:2126
+#, c-format
+msgid "reading zip stream (entry %s): bad length"
+msgstr "đang đọc dòng dữ liệu zip (mục vào %s): chiều dài lỗi"
+
+#: ../src/common/zipstrm.cpp:2131
+#, c-format
+msgid "reading zip stream (entry %s): bad crc"
+msgstr "đang đọc dòng dữ liệu zip (mục vào %s): kiểm tra độ dư vòng(crc) hỏng"
+
+#: ../src/common/zipstrm.cpp:2578
+#, fuzzy, c-format
+msgid "error writing zip entry '%s': file too large without ZIP64"
+msgstr "lỗi ghi mục tin zip '%s': kiểm tra crc hay độ dài hỏng"
+
+#: ../src/common/zipstrm.cpp:2585
+#, c-format
+msgid "error writing zip entry '%s': bad crc or length"
+msgstr "lỗi ghi mục tin zip '%s': kiểm tra crc hay độ dài hỏng"
+
+#: ../src/common/zstream.cpp:155 ../src/common/zstream.cpp:315
+msgid "Gzip not supported by this version of zlib"
+msgstr "Gzip không được hỗ trợ bởi phiên bản này của zlib"
+
+#: ../src/common/zstream.cpp:182
+msgid "Can't initialize zlib inflate stream."
+msgstr "Không thể khởi tạo zlib inflate stream."
+
+#: ../src/common/zstream.cpp:241
+msgid "Can't read inflate stream: unexpected EOF in underlying stream."
+msgstr ""
+"Không thể đọc inflate stream: không mong chờ kết thúc tập tin EOF nằm ở dưới "
+"dòng dữ liệu."
+
+#: ../src/common/zstream.cpp:248 ../src/common/zstream.cpp:423
+#, c-format
+msgid "zlib error %d"
+msgstr "lỗi zlib %d"
+
+#: ../src/common/zstream.cpp:249
+#, c-format
+msgid "Can't read from inflate stream: %s"
+msgstr "Không thể đọc từ inflate stream: %s"
+
+#: ../src/common/zstream.cpp:343
+msgid "Can't initialize zlib deflate stream."
+msgstr "Không thể khởi tạo zlib deflate stream."
+
+#: ../src/common/zstream.cpp:424
+#, c-format
+msgid "Can't write to deflate stream: %s"
+msgstr "Không thể ghi vào deflate stream: %s"
+
+#: ../src/dfb/bitmap.cpp:633 ../src/dfb/bitmap.cpp:667
+#, c-format
+msgid "No bitmap handler for type %d defined."
+msgstr "Không có bộ điều khiển ảnh cho kiểu %d được định nghĩa."
+
+#: ../src/dfb/evtloop.cpp:99
+msgid "Failed to read event from DirectFB pipe"
+msgstr "Đọc từ ống dẫn DirectFB gặp lỗi"
+
+#: ../src/dfb/evtloop.cpp:171
+msgid "Failed to switch DirectFB pipe to non-blocking mode"
+msgstr ""
+"Chuyển sang chế độ từ đường ống DirectFB sang chế độ non-blocking gặp lỗi"
+
+#: ../src/dfb/fontmgr.cpp:171
+#, c-format
+msgid "no fonts found in %s, using builtin font"
+msgstr "không phông chữ nào được tìm thấy trong %s, sử dụng phông dựng sẵn"
+
+#: ../src/dfb/fontmgr.cpp:177
+msgid "Default font"
+msgstr "Phông chữ mặc định"
+
+#: ../src/dfb/fontmgr.cpp:195
+#, c-format
+msgid "Fonts index file %s disappeared while loading fonts."
+msgstr "Tập tin chỉ số phông chữ %s bị mất khi đang tải lên."
+
+#: ../src/dfb/wrapdfb.cpp:60
+#, c-format
+msgid "DirectFB error %d occurred."
+msgstr "Lỗi DirectFB %d đã xảy ra."
+
+#: ../src/generic/aboutdlgg.cpp:69
+msgid "Developed by "
+msgstr "Được phát triển bởi "
+
+#: ../src/generic/aboutdlgg.cpp:72
+msgid "Documentation by "
+msgstr "Viết bởi "
+
+#: ../src/generic/aboutdlgg.cpp:75
+msgid "Graphics art by "
+msgstr "Đồ họa bởi "
+
+#: ../src/generic/aboutdlgg.cpp:78
+msgid "Translations by "
+msgstr "Dịch bởi "
+
+#: ../src/generic/aboutdlgg.cpp:133 ../src/osx/cocoa/aboutdlg.mm:83
+msgid "Version "
+msgstr "Phiên bản "
+
+#. TRANSLATORS: %s is application name
+#: ../src/generic/aboutdlgg.cpp:146 ../src/msw/aboutdlg.cpp:60
+#, c-format
+msgid "About %s"
+msgstr "Giới thiệu %s"
+
+#: ../src/generic/aboutdlgg.cpp:181
+msgid "License"
+msgstr "Giấy phép"
+
+#: ../src/generic/aboutdlgg.cpp:184
+msgid "Developers"
+msgstr "Những người phát triển"
+
+#: ../src/generic/aboutdlgg.cpp:188
+msgid "Documentation writers"
+msgstr "Những người viết tài liệu"
+
+#: ../src/generic/aboutdlgg.cpp:192
+msgid "Artists"
+msgstr "Nghệ sĩ"
+
+#: ../src/generic/aboutdlgg.cpp:196
+msgid "Translators"
+msgstr "Người dịch"
+
+#: ../src/generic/animateg.cpp:125
+msgid "No handler found for animation type."
+msgstr "Không có phần điều khiển cho kiểu hoạt hình."
+
+#: ../src/generic/animateg.cpp:133
+#, c-format
+msgid "No animation handler for type %ld defined."
+msgstr "Không có bộ điều khiển hoạt hình cho kiểu %ld đã định nghĩa."
+
+#: ../src/generic/animateg.cpp:145
+#, c-format
+msgid "Animation file is not of type %ld."
+msgstr "Tập tin hoạt hình thì không phải thuộc kiểu %ld."
+
+#: ../src/generic/colrdlgg.cpp:154 ../src/gtk/colordlg.cpp:47
+msgid "Choose colour"
+msgstr "Chọn màu"
+
+#: ../src/generic/colrdlgg.cpp:357
+msgid "Red:"
+msgstr ""
+
+#: ../src/generic/colrdlgg.cpp:360
+#, fuzzy
+msgid "Green:"
+msgstr "MacGreek"
+
+#: ../src/generic/colrdlgg.cpp:363
+msgid "Blue:"
+msgstr ""
+
+#: ../src/generic/colrdlgg.cpp:372
+msgid "Opacity:"
+msgstr ""
+
+#: ../src/generic/colrdlgg.cpp:384
+msgid "Add to custom colours"
+msgstr "Thêm vào màu tự chọn"
+
+#: ../src/generic/creddlgg.cpp:56
+msgid "Username:"
+msgstr ""
+
+#: ../src/generic/creddlgg.cpp:63
+msgid "Password:"
+msgstr ""
+
+#. TRANSLATORS: Name of Boolean true value
+#: ../src/generic/datavgen.cpp:1178
+msgid "true"
+msgstr ""
+
+#. TRANSLATORS: Name of Boolean false value
+#: ../src/generic/datavgen.cpp:1180
+#, fuzzy
+msgid "false"
+msgstr "Sai"
+
+#: ../src/generic/datavgen.cpp:6897
+#, c-format
+msgid "Row %i"
+msgstr ""
+
+#. TRANSLATORS: Action for manipulating a tree control
+#: ../src/generic/datavgen.cpp:6987
+msgid "Collapse"
+msgstr ""
+
+#. TRANSLATORS: Action for manipulating a tree control
+#: ../src/generic/datavgen.cpp:6990
+msgid "Expand"
+msgstr ""
+
+#. TRANSLATORS: Name of data view control and number of rows
+#: ../src/generic/datavgen.cpp:7011
+#, fuzzy, c-format
+msgid "%s (%d items)"
+msgstr "%s (hoặc %s)"
+
+#: ../src/generic/datavgen.cpp:7062
+#, fuzzy, c-format
+msgid "Column %u"
+msgstr "Thêm cột"
+
+#. TRANSLATORS: Keystroke for manipulating a tree control
+#: ../src/generic/datavgen.cpp:7131 ../src/richtext/richtextbulletspage.cpp:189
+#: ../src/richtext/richtextbulletspage.cpp:192
+#: ../src/richtext/richtextbulletspage.cpp:193
+#: ../src/richtext/richtextliststylepage.cpp:252
+#: ../src/richtext/richtextliststylepage.cpp:255
+#: ../src/richtext/richtextliststylepage.cpp:256
+#: ../src/richtext/richtextsizepage.cpp:248
+msgid "Left"
+msgstr "Trái"
+
+#. TRANSLATORS: Keystroke for manipulating a tree control
+#: ../src/generic/datavgen.cpp:7134 ../src/richtext/richtextbulletspage.cpp:191
+#: ../src/richtext/richtextliststylepage.cpp:254
+#: ../src/richtext/richtextsizepage.cpp:249
+msgid "Right"
+msgstr "Phải"
+
+#: ../src/generic/datectlg.cpp:90
+#, c-format
+msgid ""
+"\"%s\" is not in the expected date format, please enter it as e.g. \"%s\"."
+msgstr ""
+
+#: ../src/generic/datectlg.cpp:94
+#, fuzzy
+msgid "Invalid date"
+msgstr "Dữ liệu hiển thị mục tin không hợp lệ"
+
+#: ../src/generic/dbgrptg.cpp:159
+#, c-format
+msgid "Open file \"%s\""
+msgstr "Mở tập tin \"%s\""
+
+#: ../src/generic/dbgrptg.cpp:170
+#, c-format
+msgid "Enter command to open file \"%s\":"
+msgstr "Nhập vào lệnh mở tập tin \"%s\":"
+
+#: ../src/generic/dbgrptg.cpp:230
+msgid "Executable files (*.exe)|*.exe|"
+msgstr "Tập tin thực thi (*.exe)|*.exe|"
+
+#: ../src/generic/dbgrptg.cpp:300
+#, c-format
+msgid "Debug report \"%s\""
+msgstr "Báo cáo lỗi \"%s\""
+
+#: ../src/generic/dbgrptg.cpp:316
+msgid "A debug report has been generated in the directory\n"
+msgstr "Một báo cáo lỗi đã được tạo ra trong thư mục\n"
+
+#: ../src/generic/dbgrptg.cpp:317
+msgid "The following debug report will be generated\n"
+msgstr ""
+
+#: ../src/generic/dbgrptg.cpp:321
+msgid ""
+"The report contains the files listed below. If any of these files contain "
+"private information,\n"
+"please uncheck them and they will be removed from the report.\n"
+msgstr ""
+"Bản báo cáo này chứa danh sách tập tin bên dưới. Nếu bất kỳ tập tin nào chứa "
+"thông tin cá nhân,\n"
+"xin hãy bỏ dấu kiểm và chúng sẽ được gỡ bỏ khỏi báo cáo.\n"
+
+#: ../src/generic/dbgrptg.cpp:323
+msgid ""
+"If you wish to suppress this debug report completely, please choose the "
+"\"Cancel\" button,\n"
+"but be warned that it may hinder improving the program, so if\n"
+"at all possible please do continue with the report generation.\n"
+msgstr ""
+"Nếu bạn mong muốn ngăn cản toàn bộ báo cáo lỗi này, xin hãy bấm vào nút "
+"\"Hủy bỏ\" ,\n"
+"nhưng xin cảnh báo rằng nó có thể gây cản trở việc phát triển chương trình, "
+"do đó\n"
+"nếu có thể xin hãy tiếp tục việc báo cáo với chúng tôi.\n"
+
+#: ../src/generic/dbgrptg.cpp:325
+msgid "              Thank you and we're sorry for the inconvenience!\n"
+msgstr ""
+"              Xin cảm ơn và chúng tôi lấy làm tiếc về sự bất tiện này!\n"
+
+#: ../src/generic/dbgrptg.cpp:333
+msgid "&Debug report preview:"
+msgstr "Xem thử &báo cáo lỗi:"
+
+#: ../src/generic/dbgrptg.cpp:339
+msgid "&View..."
+msgstr "&Trình bày..."
+
+#: ../src/generic/dbgrptg.cpp:359
+msgid "&Notes:"
+msgstr "Ghi c&hú:"
+
+#: ../src/generic/dbgrptg.cpp:361
+msgid ""
+"If you have any additional information pertaining to this bug\n"
+"report, please enter it here and it will be joined to it:"
+msgstr ""
+"Nếu bạn có thêm thông tin liên quan về lỗi báo cáo này,\n"
+"xin hãy nhập chúng vào đây và nó sẽ nối thêm vào nó:"
+
+#: ../src/generic/dcpsg.cpp:1627
+msgid "Cannot open file for PostScript printing!"
+msgstr "Không thể mở tập tin cho việc in dạng PostScript!"
+
+#: ../src/generic/dirctrlg.cpp:402
+msgid "Computer"
+msgstr "Thư mục Computer"
+
+#: ../src/generic/dirctrlg.cpp:404
+msgid "Sections"
+msgstr "Vùng chọn"
+
+#: ../src/generic/dirctrlg.cpp:482
+msgid "Home directory"
+msgstr "Thư mục Home"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/generic/dirctrlg.cpp:484 ../src/propgrid/advprops.cpp:811
+msgid "Desktop"
+msgstr "Thư mục Desktop"
+
+#: ../src/generic/dirctrlg.cpp:528 ../src/generic/filectrlg.cpp:752
+msgid "Illegal directory name."
+msgstr "Tên thư mục không hợp lệ."
+
+#: ../src/generic/dirctrlg.cpp:528 ../src/generic/dirctrlg.cpp:546
+#: ../src/generic/dirctrlg.cpp:557 ../src/generic/dirdlgg.cpp:317
+#: ../src/generic/filectrlg.cpp:638 ../src/generic/filectrlg.cpp:752
+#: ../src/generic/filectrlg.cpp:766 ../src/generic/filectrlg.cpp:782
+#: ../src/generic/filectrlg.cpp:1356 ../src/generic/filectrlg.cpp:1387
+#: ../src/generic/filedlgg.cpp:362 ../src/gtk/filedlg.cpp:76
+msgid "Error"
+msgstr "Lỗi"
+
+#: ../src/generic/dirctrlg.cpp:546 ../src/generic/filectrlg.cpp:766
+msgid "File name exists already."
+msgstr "Tên tập tin đã tồn tại rồi."
+
+#: ../src/generic/dirctrlg.cpp:557 ../src/generic/dirdlgg.cpp:317
+#: ../src/generic/filectrlg.cpp:638 ../src/generic/filectrlg.cpp:782
+msgid "Operation not permitted."
+msgstr "Thao tác không được phép."
+
+#: ../src/generic/dirdlgg.cpp:107 ../src/generic/filedlgg.cpp:207
+msgid "Create new directory"
+msgstr "Tạo thư mục mới"
+
+#: ../src/generic/dirdlgg.cpp:112 ../src/generic/filedlgg.cpp:203
+msgid "Go to home directory"
+msgstr "Chuyển sang thư mục gốc(home)"
+
+#: ../src/generic/dirdlgg.cpp:143
+msgid "Show &hidden directories"
+msgstr "&Hiện thư mục ẩn"
+
+#: ../src/generic/dirdlgg.cpp:196
+#, c-format
+msgid ""
+"The directory '%s' does not exist\n"
+"Create it now?"
+msgstr ""
+"Thư mục '%s' chưa tồn tại\n"
+"Có tạo bây giờ không?"
+
+#: ../src/generic/dirdlgg.cpp:198
+msgid "Directory does not exist"
+msgstr "Thư mục chưa tồn tại"
+
+#: ../src/generic/dirdlgg.cpp:214
+#, c-format
+msgid ""
+"Failed to create directory '%s'\n"
+"(Do you have the required permissions?)"
+msgstr ""
+"Tạo thư mục '%s' gặp lỗi\n"
+"(bạn có quyền yêu cầu không?)"
+
+#: ../src/generic/dirdlgg.cpp:216
+msgid "Error creating directory"
+msgstr "Lỗi tạo thư mục"
+
+#: ../src/generic/dirdlgg.cpp:281
+msgid "You cannot add a new directory to this section."
+msgstr "Bạn không thể thêm một thư mục mới vào section này."
+
+#: ../src/generic/dirdlgg.cpp:282
+msgid "Create directory"
+msgstr "Tạo thư mục"
+
+#: ../src/generic/dirdlgg.cpp:291 ../src/generic/dirdlgg.cpp:301
+#: ../src/generic/filectrlg.cpp:614 ../src/generic/filectrlg.cpp:623
+msgid "NewName"
+msgstr "TênMới"
+
+#: ../src/generic/editlbox.cpp:135
+msgid "Edit item"
+msgstr "Biên tập mục tin"
+
+#: ../src/generic/editlbox.cpp:143
+msgid "New item"
+msgstr "Mục tin mới"
+
+#: ../src/generic/editlbox.cpp:151
+msgid "Delete item"
+msgstr "Xóa bỏ mục tin"
+
+#: ../src/generic/editlbox.cpp:159
+msgid "Move up"
+msgstr "Di chuyển lên"
+
+#: ../src/generic/editlbox.cpp:164
+msgid "Move down"
+msgstr "Di chuyển xuống"
+
+#: ../src/generic/fdrepdlg.cpp:108
+msgid "Search for:"
+msgstr "Tìm kiếm cho:"
+
+#: ../src/generic/fdrepdlg.cpp:120
+msgid "Replace with:"
+msgstr "Thay thế bằng:"
+
+#: ../src/generic/fdrepdlg.cpp:140
+msgid "Whole word"
+msgstr "Toàn bộ từ"
+
+#: ../src/generic/fdrepdlg.cpp:143
+msgid "Match case"
+msgstr "Phân biệt HOA/thường"
+
+#: ../src/generic/fdrepdlg.cpp:156
+msgid "Search direction"
+msgstr "Hướng tìm kiếm"
+
+#: ../src/generic/fdrepdlg.cpp:175
+msgid "&Replace"
+msgstr "Th&ay thế"
+
+#: ../src/generic/fdrepdlg.cpp:178
+msgid "Replace &all"
+msgstr "Th&ay thế tất cả"
+
+#: ../src/generic/filectrlg.cpp:246 ../src/generic/filectrlg.cpp:269
+msgid "<DIR>"
+msgstr "<DIR>"
+
+#: ../src/generic/filectrlg.cpp:248 ../src/generic/filectrlg.cpp:271
+msgid "<LINK>"
+msgstr "<LINK>"
+
+#: ../src/generic/filectrlg.cpp:250 ../src/generic/filectrlg.cpp:273
+msgid "<DRIVE>"
+msgstr "<DRIVE>"
+
+#: ../src/generic/filectrlg.cpp:275
+#, c-format
+msgid "%ld byte"
+msgid_plural "%ld bytes"
+msgstr[0] "%ld byte"
+
+#: ../src/generic/filectrlg.cpp:420
+msgid "Name"
+msgstr "Tên"
+
+#: ../src/generic/filectrlg.cpp:421 ../src/richtext/richtextformatdlg.cpp:361
+#: ../src/richtext/richtextsizepage.cpp:298
+msgid "Size"
+msgstr "Kích thước"
+
+#: ../src/generic/filectrlg.cpp:422
+msgid "Type"
+msgstr "Kiểu"
+
+#: ../src/generic/filectrlg.cpp:423
+msgid "Modified"
+msgstr "Đã bị sửa"
+
+#: ../src/generic/filectrlg.cpp:426
+msgid "Permissions"
+msgstr "Các quyền"
+
+#: ../src/generic/filectrlg.cpp:429
+msgid "Attributes"
+msgstr "Thuộc tính"
+
+#: ../src/generic/filectrlg.cpp:936
+msgid "Current directory:"
+msgstr "Thư mục hiện thời:"
+
+#: ../src/generic/filectrlg.cpp:979
+msgid "Show &hidden files"
+msgstr "&Hiện tập tin ẩn"
+
+#: ../src/generic/filectrlg.cpp:1355
+msgid "Illegal file specification."
+msgstr "Chi tiết tập tin không hợp lệ."
+
+#: ../src/generic/filectrlg.cpp:1387
+msgid "Directory doesn't exist."
+msgstr "Thư mục chưa tồn tại."
+
+#: ../src/generic/filedlgg.cpp:195
+msgid "View files as a list view"
+msgstr "Hiển thị tập tin bằng kiểu danh sách liệt kê"
+
+#: ../src/generic/filedlgg.cpp:197
+msgid "View files as a detailed view"
+msgstr "Hiển thị tập tin dạng chi tiết"
+
+#: ../src/generic/filedlgg.cpp:200
+msgid "Go to parent directory"
+msgstr "Chuyển sang thư mục cha"
+
+#: ../src/generic/filedlgg.cpp:351 ../src/gtk/filedlg.cpp:59
+#, c-format
+msgid "File '%s' already exists, do you really want to overwrite it?"
+msgstr "Tập tin '%s' đã tồn tại. Bạn có muốn ghi đè lên nó không?"
+
+#: ../src/generic/filedlgg.cpp:354 ../src/gtk/filedlg.cpp:62
+msgid "Confirm"
+msgstr "Xác nhận"
+
+#: ../src/generic/filedlgg.cpp:362 ../src/gtk/filedlg.cpp:75
+msgid "Please choose an existing file."
+msgstr "Xin hãy chọn một tập tin đã tồn tại."
+
+#: ../src/generic/filepickerg.cpp:64
+msgid "..."
+msgstr "..."
+
+#: ../src/generic/fontdlgg.cpp:76 ../src/richtext/richtextformatdlg.cpp:519
+msgid "ABCDEFGabcdefg12345"
+msgstr "ABCDEFGabcdefg12345"
+
+#: ../src/generic/fontdlgg.cpp:315
+msgid "Roman"
+msgstr "Roman"
+
+#: ../src/generic/fontdlgg.cpp:316
+msgid "Decorative"
+msgstr "Trang trí"
+
+#: ../src/generic/fontdlgg.cpp:317
+msgid "Modern"
+msgstr "Hiện đại"
+
+#: ../src/generic/fontdlgg.cpp:318
+msgid "Script"
+msgstr "Script"
+
+#: ../src/generic/fontdlgg.cpp:319
+msgid "Swiss"
+msgstr "Swiss"
+
+#: ../src/generic/fontdlgg.cpp:320
+msgid "Teletype"
+msgstr "Dạng Teletype"
+
+#: ../src/generic/fontdlgg.cpp:321 ../src/generic/fontdlgg.cpp:324
+msgid "Normal"
+msgstr "Bình thường"
+
+#: ../src/generic/fontdlgg.cpp:323
+msgid "Slant"
+msgstr "Nghiêng"
+
+#: ../src/generic/fontdlgg.cpp:325
+msgid "Light"
+msgstr "Ánh sáng"
+
+#: ../src/generic/fontdlgg.cpp:363
+msgid "&Font family:"
+msgstr "Họ &phông chữ:"
+
+#: ../src/generic/fontdlgg.cpp:367 ../src/generic/fontdlgg.cpp:369
+msgid "The font family."
+msgstr "Họ phông chữ."
+
+#: ../src/generic/fontdlgg.cpp:374 ../src/richtext/richtextstylepage.cpp:105
+msgid "&Style:"
+msgstr "&Kiểu dáng:"
+
+#: ../src/generic/fontdlgg.cpp:378 ../src/generic/fontdlgg.cpp:380
+msgid "The font style."
+msgstr "Kiểu phông chữ."
+
+#: ../src/generic/fontdlgg.cpp:385
+msgid "&Weight:"
+msgstr "Độ đậ&m:"
+
+#: ../src/generic/fontdlgg.cpp:389 ../src/generic/fontdlgg.cpp:391
+msgid "The font weight."
+msgstr "Độ đậm phông chữ."
+
+#: ../src/generic/fontdlgg.cpp:399
+msgid "C&olour:"
+msgstr "Mà&u:"
+
+#: ../src/generic/fontdlgg.cpp:407 ../src/generic/fontdlgg.cpp:409
+msgid "The font colour."
+msgstr "Màu phông chữ."
+
+#: ../src/generic/fontdlgg.cpp:415
+msgid "&Point size:"
+msgstr "&Kích thước điểm:"
+
+#: ../src/generic/fontdlgg.cpp:420 ../src/generic/fontdlgg.cpp:422
+#: ../src/generic/fontdlgg.cpp:426 ../src/generic/fontdlgg.cpp:428
+msgid "The font point size."
+msgstr "Cỡ phông chữ theo đơn vị point."
+
+#: ../src/generic/fontdlgg.cpp:439 ../src/generic/fontdlgg.cpp:441
+msgid "Whether the font is underlined."
+msgstr "Không biết phông chữ có gạch chân hay không."
+
+#: ../src/generic/fontdlgg.cpp:448 ../src/html/helpwnd.cpp:1215
+msgid "Preview:"
+msgstr "Xem trước:"
+
+#: ../src/generic/fontdlgg.cpp:452 ../src/generic/fontdlgg.cpp:454
+msgid "Shows the font preview."
+msgstr "Hiện bộ xem thử phông chữ."
+
+#: ../src/generic/fontdlgg.cpp:464 ../src/generic/fontdlgg.cpp:483
+msgid "Click to cancel the font selection."
+msgstr "Bấm vào để hủy việc chọn phông chữ."
+
+#: ../src/generic/fontdlgg.cpp:469 ../src/generic/fontdlgg.cpp:471
+#: ../src/generic/fontdlgg.cpp:476 ../src/generic/fontdlgg.cpp:478
+msgid "Click to confirm the font selection."
+msgstr "Bấm vào để xác nhận việc chọn phông chữ."
+
+#: ../src/generic/fontpickerg.cpp:50 ../src/gtk/fontdlg.cpp:77
+msgid "Choose font"
+msgstr "Chọn phông chữ"
+
+#: ../src/generic/grid.cpp:6542
+msgid ""
+"Error copying grid to the clipboard. Either selected cells were not "
+"contiguous or no cell was selected."
+msgstr ""
+
+#: ../src/generic/grid.cpp:12739
+#, fuzzy
+msgid "Grid Corner"
+msgstr "Góc"
+
+#: ../src/generic/grid.cpp:12741
+#, fuzzy, c-format
+msgid "Column %s Header"
+msgstr "Thêm cột"
+
+#: ../src/generic/grid.cpp:12743
+#, c-format
+msgid "Row %s Header"
+msgstr ""
+
+#: ../src/generic/grid.cpp:12745
+#, fuzzy, c-format
+msgid "Column %s: %s"
+msgstr "Thêm cột"
+
+#: ../src/generic/grid.cpp:12749
+#, c-format
+msgid "Row %s: %s"
+msgstr ""
+
+#: ../src/generic/grid.cpp:12753
+#, c-format
+msgid "Row %s, Column %s: %s"
+msgstr ""
+
+#: ../src/generic/helpext.cpp:257
+#, c-format
+msgid "Help directory \"%s\" not found."
+msgstr "Không tìm thấy thư mục trợ giúp \"%s\"."
+
+#: ../src/generic/helpext.cpp:265
+#, c-format
+msgid "Help file \"%s\" not found."
+msgstr "Tập tin trợ giúp \"%s\" không tìm thấy."
+
+#: ../src/generic/helpext.cpp:284
+#, c-format
+msgid "Line %lu of map file \"%s\" has invalid syntax, skipped."
+msgstr "Dòng %lu của tập tin ánh xạ \"%s\" có cú pháp không hợp lệ, đã bỏ qua."
+
+#: ../src/generic/helpext.cpp:292
+#, c-format
+msgid "No valid mappings found in the file \"%s\"."
+msgstr "Không có ánh xạ hợp lệ nào được tìm thấy trong tập tin \"%s\"."
+
+#: ../src/generic/helpext.cpp:435
+msgid "No entries found."
+msgstr "Không tìm thấy đề mục nào."
+
+#: ../src/generic/helpext.cpp:444 ../src/generic/helpext.cpp:445
+msgid "Help Index"
+msgstr "Mục lục Trợ Giúp"
+
+#: ../src/generic/helpext.cpp:448
+msgid "Relevant entries:"
+msgstr "Các đề mục tin hợp:"
+
+#: ../src/generic/helpext.cpp:449
+msgid "Entries found"
+msgstr "Các mục tin tìm thấy"
+
+#: ../src/generic/hyperlinkg.cpp:170
+msgid "&Copy URL"
+msgstr "&Sao chép URL"
+
+#: ../src/generic/infobar.cpp:119
+msgid "Hide this notification message."
+msgstr "Tắt phần thông báo."
+
+#. TRANSLATORS: %s will be either the application name or "Application"
+#: ../src/generic/logg.cpp:257
+#, c-format
+msgid "%s Error"
+msgstr "%s Lỗi"
+
+#. TRANSLATORS: %s will be either the application name or "Application"
+#: ../src/generic/logg.cpp:263
+#, c-format
+msgid "%s Warning"
+msgstr "%s Cảnh báo"
+
+#. TRANSLATORS: %s will be either the application name or "Application"
+#: ../src/generic/logg.cpp:273
+#, c-format
+msgid "%s Information"
+msgstr "%s Thông tin"
+
+#: ../src/generic/logg.cpp:276
+msgid "Application"
+msgstr "Ứng dụng"
+
+#: ../src/generic/logg.cpp:549
+msgid "Save log contents to file"
+msgstr "Ghi lại nội dung nhật ký vào tập tin"
+
+#: ../src/generic/logg.cpp:551
+msgid "C&lear"
+msgstr "&Xóa tất cả"
+
+#: ../src/generic/logg.cpp:551
+msgid "Clear the log contents"
+msgstr "Xóa nội dung nhật ký thông tin"
+
+#: ../src/generic/logg.cpp:553
+msgid "Close this window"
+msgstr "Đóng cửa sổ này"
+
+#: ../src/generic/logg.cpp:554
+msgid "&Log"
+msgstr "Tập ti&n ghi thông tin"
+
+#: ../src/generic/logg.cpp:610 ../src/generic/logg.cpp:992
+msgid "Can't save log contents to file."
+msgstr "Không thể ghi nội dung nhật ký ra tập tin."
+
+#: ../src/generic/logg.cpp:613
+#, c-format
+msgid "Log saved to the file '%s'."
+msgstr "Ghi nhật ký thông tin vào tập tin '%s'."
+
+#: ../src/generic/logg.cpp:719
+msgid "&Details"
+msgstr "&Chi tiết"
+
+#: ../src/generic/logg.cpp:972
+msgid "Failed to copy dialog contents to the clipboard."
+msgstr "Sao chép nội dung từ hộp thoại vào bộ nhớ clipboard gặp lỗi."
+
+#: ../src/generic/logg.cpp:1022
+#, c-format
+msgid "Append log to file '%s' (choosing [No] will overwrite it)?"
+msgstr "Nối thêm nhật ký vào tập tin '%s' (chọn [No] sẽ ghi đè lên nó)?"
+
+#: ../src/generic/logg.cpp:1024
+msgid "Question"
+msgstr "Câu hỏi"
+
+#: ../src/generic/logg.cpp:1038
+msgid "invalid message box return value"
+msgstr "hộp thoại thông điệp trả về giá trị không hợp lệ"
+
+#: ../src/generic/notifmsgg.cpp:129
+msgid "Notice"
+msgstr "Chú ý"
+
+#: ../src/generic/preferencesg.cpp:118
+#, c-format
+msgid "%s Preferences"
+msgstr "Cá nhân hóa %s"
+
+#: ../src/generic/printps.cpp:143
+msgid "Printing..."
+msgstr "Đang in..."
+
+#: ../src/generic/printps.cpp:160 ../src/gtk/print.cpp:1076
+#: ../src/msw/printwin.cpp:235
+msgid "Could not start printing."
+msgstr "Không thể bắt đầu in."
+
+#: ../src/generic/printps.cpp:183
+#, c-format
+msgid "Printing page %d..."
+msgstr "Đang in trang %d..."
+
+#: ../src/generic/prntdlgg.cpp:171
+msgid "Printer options"
+msgstr "Tùy chọn về máy in"
+
+#: ../src/generic/prntdlgg.cpp:176
+msgid "Print to File"
+msgstr "In ra Tập tin"
+
+#: ../src/generic/prntdlgg.cpp:179
+msgid "Setup..."
+msgstr "Cài đặt..."
+
+#: ../src/generic/prntdlgg.cpp:187
+msgid "Printer:"
+msgstr "Máy in:"
+
+#: ../src/generic/prntdlgg.cpp:195
+msgid "Status:"
+msgstr "Tình trạng:"
+
+#: ../src/generic/prntdlgg.cpp:206
+msgid "All"
+msgstr "Tất cả"
+
+#: ../src/generic/prntdlgg.cpp:207
+msgid "Pages"
+msgstr "Giấy"
+
+#: ../src/generic/prntdlgg.cpp:215
+msgid "Print Range"
+msgstr "Vùng cần in"
+
+#: ../src/generic/prntdlgg.cpp:229
+msgid "From:"
+msgstr "Từ :"
+
+#: ../src/generic/prntdlgg.cpp:233
+msgid "To:"
+msgstr "Đến:"
+
+#: ../src/generic/prntdlgg.cpp:238
+msgid "Copies:"
+msgstr "Bản sao:"
+
+#: ../src/generic/prntdlgg.cpp:288
+msgid "PostScript file"
+msgstr "tập tin PostScript"
+
+#: ../src/generic/prntdlgg.cpp:439
+msgid "Print Setup"
+msgstr "Cài Đặt In"
+
+#: ../src/generic/prntdlgg.cpp:483
+msgid "Printer"
+msgstr "Máy in"
+
+#: ../src/generic/prntdlgg.cpp:501
+msgid "Default printer"
+msgstr "Máy in mặc định"
+
+#: ../src/generic/prntdlgg.cpp:595 ../src/generic/prntdlgg.cpp:782
+#: ../src/generic/prntdlgg.cpp:822 ../src/generic/prntdlgg.cpp:835
+#: ../src/generic/prntdlgg.cpp:1031 ../src/generic/prntdlgg.cpp:1036
+msgid "Paper size"
+msgstr "Cỡ giấy"
+
+#: ../src/generic/prntdlgg.cpp:604 ../src/generic/prntdlgg.cpp:847
+msgid "Portrait"
+msgstr "Thẳng đứng"
+
+#: ../src/generic/prntdlgg.cpp:605 ../src/generic/prntdlgg.cpp:848
+msgid "Landscape"
+msgstr "Nằm ngang"
+
+#: ../src/generic/prntdlgg.cpp:607 ../src/generic/prntdlgg.cpp:849
+msgid "Orientation"
+msgstr "Hướng"
+
+#: ../src/generic/prntdlgg.cpp:610
+msgid "Options"
+msgstr "Tùy chọn"
+
+#: ../src/generic/prntdlgg.cpp:612
+msgid "Print in colour"
+msgstr "In màu"
+
+#: ../src/generic/prntdlgg.cpp:621
+msgid "Print spooling"
+msgstr "In vào bộ nhớ"
+
+#: ../src/generic/prntdlgg.cpp:623
+msgid "Printer command:"
+msgstr "Lệnh in:"
+
+#: ../src/generic/prntdlgg.cpp:631
+msgid "Printer options:"
+msgstr "Tùy chọn về máy in:"
+
+#: ../src/generic/prntdlgg.cpp:860
+msgid "Left margin (mm):"
+msgstr "Lề trái (mm):"
+
+#: ../src/generic/prntdlgg.cpp:861
+msgid "Top margin (mm):"
+msgstr "Để lề trên (mm):"
+
+#: ../src/generic/prntdlgg.cpp:872
+msgid "Right margin (mm):"
+msgstr "Lề phải (mm):"
+
+#: ../src/generic/prntdlgg.cpp:873
+msgid "Bottom margin (mm):"
+msgstr "Lề dưới chân (mm):"
+
+#: ../src/generic/prntdlgg.cpp:896
+msgid "Printer..."
+msgstr "Máy in..."
+
+#: ../src/generic/progdlgg.cpp:246
+msgid "&Skip"
+msgstr "Giữ &nguyên"
+
+#: ../src/generic/progdlgg.cpp:347 ../src/generic/progdlgg.cpp:626
+msgid "Unknown"
+msgstr "Không hiểu"
+
+#: ../src/generic/progdlgg.cpp:451 ../src/msw/progdlg.cpp:526
+msgid "Done."
+msgstr "Hoàn tất."
+
+#: ../src/generic/srchctlg.cpp:55 ../src/gtk/srchctrl.cpp:206
+#: ../src/html/helpwnd.cpp:530 ../src/html/helpwnd.cpp:545
+msgid "Search"
+msgstr "Tìm kiếm"
+
+#: ../src/generic/tabg.cpp:1026
+msgid "Could not find tab for id"
+msgstr "Không thể tìm thấy tab cho id"
+
+#: ../src/generic/tipdlg.cpp:136
+msgid "Tips not available, sorry!"
+msgstr "Các mẹo nhỏ vẫn chưa có, thành thật xin lỗi!"
+
+#: ../src/generic/tipdlg.cpp:197
+msgid "Tip of the Day"
+msgstr "Mẹo Nhỏ"
+
+#: ../src/generic/tipdlg.cpp:207
+msgid "Did you know..."
+msgstr "Bạn có biết..."
+
+#: ../src/generic/tipdlg.cpp:232
+msgid "&Show tips at startup"
+msgstr "&Hiện hướng dẫn nhỏ lúc mới mở"
+
+#: ../src/generic/tipdlg.cpp:236
+msgid "&Next Tip"
+msgstr "Mẹo kế &tiếp"
+
+#: ../src/generic/wizard.cpp:411
+msgid "&Next >"
+msgstr "Tiếp &theo >"
+
+#: ../src/generic/wizard.cpp:412
+msgid "&Finish"
+msgstr "&Hoàn tất"
+
+#: ../src/generic/wizard.cpp:420
+msgid "< &Back"
+msgstr "< &Quay lại"
+
+#: ../src/gtk/aboutdlg.cpp:204
+msgid "translator-credits"
+msgstr "công-trạng-dịch-thuật"
+
+#: ../src/gtk/app.cpp:517
+msgid ""
+"WARNING: using XIM input method is unsupported and may result in problems "
+"with input handling and flickering. Consider unsetting GTK_IM_MODULE or "
+"setting to \"ibus\"."
+msgstr ""
+
+#: ../src/gtk/app.cpp:569
+msgid "Unable to initialize GTK+, is DISPLAY set properly?"
+msgstr ""
+"Không thể khởi tạo GTK+, BỘ HIỂN THỊ đã cài đặt các thuộc tính hay chưa?"
+
+#: ../src/gtk/filedlg.cpp:89 ../src/gtk/filepicker.cpp:255
+#, fuzzy, c-format
+msgid "Changing current directory to \"%s\" failed"
+msgstr "Tạo thư mục \"%s\" gặp lỗi"
+
+#: ../src/gtk/font.cpp:548
+msgid ""
+"Using private fonts is not supported on this system: Pango library is too "
+"old, 1.38 or later required."
+msgstr ""
+
+#: ../src/gtk/font.cpp:558
+#, fuzzy
+msgid "Failed to create font configuration object."
+msgstr "Cập nhật tập tin cấu hình gặp lỗi."
+
+#: ../src/gtk/font.cpp:568
+#, fuzzy, c-format
+msgid "Failed to add custom font \"%s\"."
+msgstr "Lỗi đọc từ tập tin \"%s\" gặp lỗi."
+
+#: ../src/gtk/font.cpp:576
+#, fuzzy
+msgid "Failed to register font configuration using private fonts."
+msgstr "Cập nhật tập tin cấu hình gặp lỗi."
+
+#: ../src/gtk/glcanvas.cpp:117 ../src/gtk/glcanvas.cpp:132
+#, fuzzy
+msgid "Fatal Error"
+msgstr "Lỗi nghiêm trọng"
+
+#: ../src/gtk/glcanvas.cpp:117
+msgid ""
+"This program wasn't compiled with EGL support required under Wayland, "
+"either\n"
+"install EGL libraries and rebuild or run it under X11 backend by setting\n"
+"environment variable GDK_BACKEND=x11 before starting your program."
+msgstr ""
+
+#: ../src/gtk/glcanvas.cpp:132
+msgid ""
+"wxGLCanvas is only supported on Wayland and X11 currently.  You may be able "
+"to\n"
+"work around this by setting environment variable GDK_BACKEND=x11 before\n"
+"starting your program."
+msgstr ""
+
+#: ../src/gtk/mdi.cpp:433
+msgid "MDI child"
+msgstr "cửa sổ MDI con"
+
+#: ../src/gtk/power.cpp:188
+#, fuzzy, c-format
+msgid "Failed to open D-Bus connection to the login manager: %s"
+msgstr "Kết nối tới quản lý session gặp lỗi: %s"
+
+#: ../src/gtk/power.cpp:214
+#, fuzzy
+msgid "wxWidgets application"
+msgstr "Ứng dụng"
+
+#: ../src/gtk/power.cpp:226
+msgid "Application needs to keep running"
+msgstr ""
+
+#: ../src/gtk/power.cpp:233
+msgid "Clean up before suspend"
+msgstr ""
+
+#: ../src/gtk/power.cpp:259
+#, fuzzy, c-format
+msgid "Failed to inhibit sleep: %s"
+msgstr "Khởi tạo kết nối quay số gặp lỗi: %s"
+
+#: ../src/gtk/power.cpp:265
+msgid "Unexpected response to D-Bus \"Inhibit\" request."
+msgstr ""
+
+#: ../src/gtk/print.cpp:218
+msgid "Custom size"
+msgstr "Cỡ riêng"
+
+#: ../src/gtk/print.cpp:752
+#, fuzzy, c-format
+msgid "Error while printing: %s"
+msgstr "Lỗi trong khi in: "
+
+#: ../src/gtk/print.cpp:816
+msgid "Page Setup"
+msgstr "Cài đặt giấy"
+
+#: ../src/gtk/webview_webkit.cpp:932
+msgid "Retrieving JavaScript script output is not supported with WebKit v1"
+msgstr ""
+
+#: ../src/gtk/webview_webkit2.cpp:1098
+msgid ""
+"Setting proxy is not supported by WebKit, at least version 2.16 is required."
+msgstr ""
+
+#: ../src/gtk/webview_webkit2.cpp:1104
+msgid "This program was compiled without support for setting WebKit proxy."
+msgstr ""
+
+#: ../src/gtk/window.cpp:6289
+msgid ""
+"GTK+ installed on this machine is too old to support screen compositing, "
+"please install GTK+ 2.12 or later."
+msgstr ""
+"GTK+ đã cài đặt trên máy này quá cũ để nó có thể hỗ trợ ghép màn hình, hãy "
+"cài GTK+ 2.12 hay mới hơn."
+
+#: ../src/gtk/window.cpp:6307
+msgid ""
+"Compositing not supported by this system, please enable it in your Window "
+"Manager."
+msgstr ""
+"Sự kết hợp không được hỗ trợ bởi hệ thống này, xin hãy bật nó lên trong "
+"Window Manager."
+
+#: ../src/gtk/window.cpp:6318
+msgid ""
+"This program was compiled with a too old version of GTK+, please rebuild "
+"with GTK+ 2.12 or newer."
+msgstr ""
+"Chương trình này được dịch với phiên bản cũ của GTK+, xin hãy dịch lại với "
+"GTK+ 2.12 hay mới hơn."
+
+#: ../src/html/chm.cpp:138
+#, c-format
+msgid "Failed to open CHM archive '%s'."
+msgstr "Mở CHM để lưu giữ '%s' gặp lỗi."
+
+#: ../src/html/chm.cpp:270
+#, c-format
+msgid "Could not extract %s into %s: %s"
+msgstr "Không thể rút trích %s vào trong %s: %s"
+
+#: ../src/html/chm.cpp:324
+msgid "no error"
+msgstr "không lỗi"
+
+#: ../src/html/chm.cpp:326
+msgid "bad arguments to library function"
+msgstr "tham số sai tới hàm thư viện"
+
+#: ../src/html/chm.cpp:328
+msgid "error opening file"
+msgstr "lỗi khi mở tập tin"
+
+#: ../src/html/chm.cpp:330
+msgid "read error"
+msgstr "lỗi đọc"
+
+#: ../src/html/chm.cpp:332
+msgid "write error"
+msgstr "lỗi ghi tập tin"
+
+#: ../src/html/chm.cpp:334
+msgid "seek error"
+msgstr "lỗi di chuyển vị trí đọc"
+
+#: ../src/html/chm.cpp:338
+msgid "bad signature"
+msgstr "chữ ký sai"
+
+#: ../src/html/chm.cpp:340
+msgid "error in data format"
+msgstr "lỗi định dạng dữ liệu"
+
+#: ../src/html/chm.cpp:342
+msgid "checksum error"
+msgstr "tổng kiểm tra sai"
+
+#: ../src/html/chm.cpp:344
+msgid "compression error"
+msgstr "lỗi nén"
+
+#: ../src/html/chm.cpp:346
+msgid "decompression error"
+msgstr "lỗi giải nén"
+
+#: ../src/html/chm.cpp:437
+#, c-format
+msgid "Could not locate file '%s'."
+msgstr "Không thể cấp phát tập tin '%s'."
+
+#: ../src/html/chm.cpp:711
+#, c-format
+msgid "Could not create temporary file '%s'"
+msgstr "Không thể tạo tập tin tạm thời '%s'"
+
+#: ../src/html/chm.cpp:718
+#, c-format
+msgid "Extraction of '%s' into '%s' failed."
+msgstr "Rút trích '%s' vào '%s' gặp lỗi."
+
+#: ../src/html/chm.cpp:806 ../src/html/chm.cpp:863
+msgid "CHM handler currently supports only local files!"
+msgstr "CHM handler hiện tại chỉ hỗ trợ các tập tin nội bộ!"
+
+#: ../src/html/chm.cpp:827
+msgid "Link contained '//', converted to absolute link."
+msgstr "Liên kết có chứa '//', đã chuyển đổi sang liên kết đúng đắn."
+
+#: ../src/html/helpctrl.cpp:59
+#, c-format
+msgid "Help: %s"
+msgstr "Trợ giúp: %s"
+
+#: ../src/html/helpctrl.cpp:155
+#, c-format
+msgid "Adding book %s"
+msgstr "Thêm sách %s"
+
+#: ../src/html/helpdata.cpp:295
+#, c-format
+msgid "Cannot open contents file: %s"
+msgstr "Không thể mở tập tin nội dung: %s"
+
+#: ../src/html/helpdata.cpp:309
+#, c-format
+msgid "Cannot open index file: %s"
+msgstr "Không thể mở tập tin chỉ mục: %s"
+
+#: ../src/html/helpdata.cpp:643
+msgid "noname"
+msgstr "không tên"
+
+#: ../src/html/helpdata.cpp:652
+#, c-format
+msgid "Cannot open HTML help book: %s"
+msgstr "Không thể mở sách trợ giúp dạng HTML: %s"
+
+#: ../src/html/helpwnd.cpp:315
+msgid "Displays help as you browse the books on the left."
+msgstr "Hiện phần trợ giúp như là một trình duyệt sách trên phần bên trái."
+
+#: ../src/html/helpwnd.cpp:411 ../src/html/helpwnd.cpp:1100
+#: ../src/html/helpwnd.cpp:1735
+msgid "(bookmarks)"
+msgstr "(Dấu trang)"
+
+#: ../src/html/helpwnd.cpp:424
+msgid "Add current page to bookmarks"
+msgstr "Thêm trang hiện thời vào dấu trang"
+
+#: ../src/html/helpwnd.cpp:425
+msgid "Remove current page from bookmarks"
+msgstr "Gỡ bỏ trang hiện hành từ dấu trang"
+
+#: ../src/html/helpwnd.cpp:470
+msgid "Contents"
+msgstr "Nội dung"
+
+#: ../src/html/helpwnd.cpp:485
+msgid "Find"
+msgstr "Tìm"
+
+#: ../src/html/helpwnd.cpp:487
+msgid "Show all"
+msgstr "Hiện tất"
+
+#: ../src/html/helpwnd.cpp:497
+msgid ""
+"Display all index items that contain given substring. Search is case "
+"insensitive."
+msgstr ""
+"Hiện tất cả chỉ số mục tin mà có chứa chuỗi con định sẵn. Tìm kiếm phân biệt "
+"Hoa/thường."
+
+#: ../src/html/helpwnd.cpp:498
+msgid "Show all items in index"
+msgstr "Hiển thị tất cả các mục tin trong mục lục"
+
+#: ../src/html/helpwnd.cpp:528
+msgid "Case sensitive"
+msgstr "Phân biệt chữ HOA/thường"
+
+#: ../src/html/helpwnd.cpp:529
+msgid "Whole words only"
+msgstr "Chỉ khi khớp cả từ"
+
+#: ../src/html/helpwnd.cpp:532
+msgid ""
+"Search contents of help book(s) for all occurrences of the text you typed "
+"above"
+msgstr ""
+"Tìm kiếm nội dung của cuốn sách trợ giúp cho tất cả các lần xuất hiện của "
+"chữ bạn đã gõ ở trên"
+
+#: ../src/html/helpwnd.cpp:653
+msgid "Show/hide navigation panel"
+msgstr "Hiện/ẩn bản điều hướng"
+
+#: ../src/html/helpwnd.cpp:655
+msgid "Go back"
+msgstr "Đi lùi"
+
+#: ../src/html/helpwnd.cpp:656
+msgid "Go forward"
+msgstr "Đi tiếp"
+
+#: ../src/html/helpwnd.cpp:658
+msgid "Go one level up in document hierarchy"
+msgstr "Tăng một cấp trong thứ bậc tài liệu"
+
+#: ../src/html/helpwnd.cpp:666 ../src/html/helpwnd.cpp:1547
+msgid "Open HTML document"
+msgstr "Mở tài liệu định dạng HTML"
+
+#: ../src/html/helpwnd.cpp:670
+msgid "Print this page"
+msgstr "In ra trang này"
+
+#: ../src/html/helpwnd.cpp:674
+msgid "Display options dialog"
+msgstr "Hiển thị hộp thoại tùy chọn"
+
+#: ../src/html/helpwnd.cpp:795
+msgid "Please choose the page to display:"
+msgstr "Xin hãy chọn trang bạn muốn hiển thị:"
+
+#: ../src/html/helpwnd.cpp:796
+msgid "Help Topics"
+msgstr "Trợ Giúp Theo Chủ Đề..."
+
+#: ../src/html/helpwnd.cpp:852
+msgid "Searching..."
+msgstr "Đang tìm kiếm..."
+
+#: ../src/html/helpwnd.cpp:853
+msgid "No matching page found yet"
+msgstr "Không tìm thấy trang phù hợp"
+
+#: ../src/html/helpwnd.cpp:870
+#, c-format
+msgid "Found %i matches"
+msgstr "Tìm thấy %i cái khớp"
+
+#: ../src/html/helpwnd.cpp:958
+msgid "(Help)"
+msgstr "(Trợ giúp)"
+
+#: ../src/html/helpwnd.cpp:1026
+#, c-format
+msgid "%d of %lu"
+msgstr "%d của %lu"
+
+#: ../src/html/helpwnd.cpp:1028
+#, c-format
+msgid "%lu of %lu"
+msgstr "%lu của %lu"
+
+#: ../src/html/helpwnd.cpp:1047
+msgid "Search in all books"
+msgstr "Tìm trong tất cả các sách"
+
+#: ../src/html/helpwnd.cpp:1193
+msgid "Help Browser Options"
+msgstr "Các tùy chọn Duyệt Trợ Giúp"
+
+#: ../src/html/helpwnd.cpp:1198
+msgid "Normal font:"
+msgstr "Phông chữ thường:"
+
+#: ../src/html/helpwnd.cpp:1199
+msgid "Fixed font:"
+msgstr "Phông chữ cố định:"
+
+#: ../src/html/helpwnd.cpp:1200
+msgid "Font size:"
+msgstr "Cỡ phông chữ:"
+
+#: ../src/html/helpwnd.cpp:1245
+msgid "font size"
+msgstr "cỡ phông chữ"
+
+#: ../src/html/helpwnd.cpp:1256
+msgid "Normal face<br>and <u>underlined</u>. "
+msgstr "Bình thường<br>và <u>gạch chân</u>. "
+
+#: ../src/html/helpwnd.cpp:1257
+msgid "<i>Italic face.</i> "
+msgstr "<i>Chữ nghiêng.</i> "
+
+#: ../src/html/helpwnd.cpp:1258
+msgid "<b>Bold face.</b> "
+msgstr "<b>Chữ đậm.</b> "
+
+#: ../src/html/helpwnd.cpp:1259
+msgid "<b><i>Bold italic face.</i></b><br>"
+msgstr "<b><i>Chữ vừa đậm vừa nghiêng.</i></b><br>"
+
+#: ../src/html/helpwnd.cpp:1262
+msgid "Fixed size face.<br> <b>bold</b> <i>italic</i> "
+msgstr "Kích thước bình thường.<br> <b>đậm</b> <i>nghiêng</i> "
+
+#: ../src/html/helpwnd.cpp:1263
+msgid "<b><i>bold italic <u>underlined</u></i></b><br>"
+msgstr "<b><i>đậm và nghiêng <u>có gạch chân</u></i></b><br>"
+
+#: ../src/html/helpwnd.cpp:1524
+msgid "Help Printing"
+msgstr "Trợ Giúp In Ấn"
+
+#: ../src/html/helpwnd.cpp:1527
+msgid "Cannot print empty page."
+msgstr "Không thể in một trang rỗng."
+
+#: ../src/html/helpwnd.cpp:1540
+msgid "HTML files (*.html;*.htm)|*.html;*.htm|"
+msgstr "Tập tin HTML (*.html;*.htm)|*.html;*.htm|"
+
+#: ../src/html/helpwnd.cpp:1541
+msgid "Help books (*.htb)|*.htb|Help books (*.zip)|*.zip|"
+msgstr "Sách trợ giúp (*.htb)|*.htb|Sách trợ giúp (*.zip)|*.zip|"
+
+#: ../src/html/helpwnd.cpp:1542
+msgid "HTML Help Project (*.hhp)|*.hhp|"
+msgstr "HTML Đề án Trợ giúp (*.hhp)|*.hhp|"
+
+#: ../src/html/helpwnd.cpp:1544
+msgid "Compressed HTML Help file (*.chm)|*.chm|"
+msgstr "Nén tập tin Trợ Giúp dạng HTML (*.chm)|*.chm|"
+
+#: ../src/html/helpwnd.cpp:1671
+#, fuzzy, c-format
+msgid "%i of %u"
+msgstr "%i của %u"
+
+#: ../src/html/helpwnd.cpp:1709
+#, fuzzy, c-format
+msgid "%u of %u"
+msgstr "%u của %u"
+
+#: ../src/html/htmlfilt.cpp:134
+#, c-format
+msgid "Cannot open HTML document: %s"
+msgstr "Không thể mở tài liệu HTML: %s"
+
+#: ../src/html/htmlwin.cpp:599
+msgid "Connecting..."
+msgstr "Đang kết nối..."
+
+#: ../src/html/htmlwin.cpp:616
+#, c-format
+msgid "Unable to open requested HTML document: %s"
+msgstr "Không thể mở tài liệu HTML đã yêu cầu: %s"
+
+#: ../src/html/htmlwin.cpp:630
+msgid "Loading : "
+msgstr "Đang tải :"
+
+#: ../src/html/htmlwin.cpp:673
+msgid "Done"
+msgstr "Hoàn tất"
+
+#: ../src/html/htmlwin.cpp:723
+#, c-format
+msgid "HTML anchor %s does not exist."
+msgstr "Điểm neo HTML %s không tồn tại."
+
+#: ../src/html/htmlwin.cpp:1057
+#, c-format
+msgid "Copied to clipboard:\"%s\""
+msgstr "Đã sao chép vào clipboard:\"%s\""
+
+#: ../src/html/htmprint.cpp:269
+msgid ""
+"This document doesn't fit on the page horizontally and will be truncated "
+"when it is printed."
+msgstr ""
+"Tài liệu này không vừa khớp theo chiều ngang của giấy và sẽ bị cắt cụt đi "
+"khi được in."
+
+#: ../src/html/htmprint.cpp:285
+#, c-format
+msgid ""
+"The document \"%s\" doesn't fit on the page horizontally and will be "
+"truncated if printed.\n"
+"\n"
+"Would you like to proceed with printing it nevertheless?"
+msgstr ""
+"Tài liệu  \"%s\" không vừa khớp với khổ giấy theo chiều ngang và sẽ bị cắt "
+"cụt đi khi nếu được in.\n"
+"\n"
+"Bạn có thực sự muốn in nó không?"
+
+#: ../src/html/htmprint.cpp:296
+msgid ""
+"If possible, try changing the layout parameters to make the printout more "
+"narrow."
+msgstr ""
+"Nếu có thể, hay thử thay đổi cách bố trí các tham số để mà in ra nhiều mũi "
+"tên hơn."
+
+#: ../src/html/htmprint.cpp:445
+msgid ": file does not exist!"
+msgstr ": tập tin không tồn tại!"
+
+#. TRANSLATORS: %s may be a document title.
+#: ../src/html/htmprint.cpp:717
+#, fuzzy, c-format
+msgid "%s Preview"
+msgstr " Xem trước"
+
+#: ../src/html/htmprint.cpp:755 ../src/richtext/richtextprint.cpp:618
+msgid ""
+"There was a problem during page setup: you may need to set a default printer."
+msgstr ""
+"Có trục trặc xảy ra khi cài đặt kiểu giấy: có lẽ bạn cần phải đặt một máy in "
+"mặc định."
+
+#: ../src/msw/clipbrd.cpp:80
+msgid "Failed to open the clipboard."
+msgstr "Mở clipboard gặp lỗi."
+
+#: ../src/msw/clipbrd.cpp:101
+msgid "Failed to close the clipboard."
+msgstr "Đóng clipboard gặp lỗi."
+
+#: ../src/msw/clipbrd.cpp:113
+msgid "Failed to empty the clipboard."
+msgstr "Làm rỗng clipboard gặp lỗi."
+
+#: ../src/msw/clipbrd.cpp:284
+msgid "Failed to put data on the clipboard"
+msgstr "Đặt dữ liệu vào clipboard gặp lỗi"
+
+#: ../src/msw/clipbrd.cpp:326
+msgid "Failed to get data from the clipboard"
+msgstr "Lấy dữ liệu từ clipboard gặp lỗi"
+
+#: ../src/msw/clipbrd.cpp:363
+msgid "Failed to retrieve the supported clipboard formats"
+msgstr "Khôi phục định dạng clipboard được hỗ trợ gặp lỗi"
+
+#: ../src/msw/colordlg.cpp:228
+#, c-format
+msgid "Colour selection dialog failed with error %0lx."
+msgstr "Hộp thoại chọn màu gặp lỗi %0lx."
+
+#: ../src/msw/cursor.cpp:141
+msgid "Failed to create cursor."
+msgstr "Tạo con trỏ chuột gặp lỗi."
+
+#: ../src/msw/dde.cpp:279
+#, c-format
+msgid "Failed to register DDE server '%s'"
+msgstr "Đăng ký máy chủ DDE '%s' gặp lỗi."
+
+#: ../src/msw/dde.cpp:300
+#, c-format
+msgid "Failed to unregister DDE server '%s'"
+msgstr "Việc bỏ đăng ký máy chủ DDE '%s' gặp lỗi"
+
+#: ../src/msw/dde.cpp:428
+#, c-format
+msgid "Failed to create connection to server '%s' on topic '%s'"
+msgstr "Tạo kết nối tới máy chủ '%s' với chủ đề '%s' gặp lỗi"
+
+#: ../src/msw/dde.cpp:655
+msgid "DDE poke request failed"
+msgstr "Yêu cầu poke DDE gặp lỗi"
+
+#: ../src/msw/dde.cpp:674
+msgid "Failed to establish an advise loop with DDE server"
+msgstr "Thiết lập một vòng lặp advise máy chủ DDE gặp lỗi"
+
+#: ../src/msw/dde.cpp:693
+msgid "Failed to terminate the advise loop with DDE server"
+msgstr "Chấm dứt vòng lặp advise với máy chủ DDE gặp lỗi"
+
+#: ../src/msw/dde.cpp:768
+msgid "Failed to send DDE advise notification"
+msgstr "Gửi thông báo DDE advise gặp lỗi"
+
+#: ../src/msw/dde.cpp:1085
+msgid "Failed to create DDE string"
+msgstr "Tạo chuỗi DDE gặp lỗi"
+
+#: ../src/msw/dde.cpp:1131
+msgid "no DDE error."
+msgstr "không có lỗi DDE."
+
+#: ../src/msw/dde.cpp:1135
+msgid "a request for a synchronous advise transaction has timed out."
+msgstr "yêu cầu cho chuyển tác advise đồng bộ gặp lỗi quá lâu."
+
+#: ../src/msw/dde.cpp:1138
+msgid "the response to the transaction caused the DDE_FBUSY bit to be set."
+msgstr "đáp ứng chuyển tác này là nguyên nhân bít DDE_FBUSY được đặt."
+
+#: ../src/msw/dde.cpp:1141
+msgid "a request for a synchronous data transaction has timed out."
+msgstr "yêu cầu chuyển tác dữ liệu đồng bộ gặp lỗi quá lâu."
+
+#: ../src/msw/dde.cpp:1144
+msgid ""
+"a DDEML function was called without first calling the DdeInitialize "
+"function,\n"
+"or an invalid instance identifier\n"
+"was passed to a DDEML function."
+msgstr ""
+"hàm DDEML được gọi mà không gọi hàm DdeInitialize trước,\n"
+"hay bộ nhận dạng instance không hợp lệ\n"
+"đã được chuyển qua hàm DDEML."
+
+#: ../src/msw/dde.cpp:1147
+msgid ""
+"an application initialized as APPCLASS_MONITOR has\n"
+"attempted to perform a DDE transaction,\n"
+"or an application initialized as APPCMD_CLIENTONLY has \n"
+"attempted to perform server transactions."
+msgstr ""
+"một ứng dụng khởi tạo như APPCLASS_MONITOR đã\n"
+"cố gắng thi hành một chuyển tác DDE,\n"
+"hay một ứng dụng khởi tạo như APPCMD_CLIENTONLY đã\n"
+"cố gắng thi hành một chuyển tác phía máy chủ."
+
+#: ../src/msw/dde.cpp:1150
+msgid "a request for a synchronous execute transaction has timed out."
+msgstr "yêu cầu cho chuyển tác thi hành đồng bộ gặp lỗi quá lâu."
+
+#: ../src/msw/dde.cpp:1153
+msgid "a parameter failed to be validated by the DDEML."
+msgstr "một tham số gặp lỗi được công nhận bởi DDEML."
+
+#: ../src/msw/dde.cpp:1156
+msgid "a DDEML application has created a prolonged race condition."
+msgstr "một ứng dụng DDEML đã tạo ra một loại điều kiện nối dài."
+
+#: ../src/msw/dde.cpp:1159
+msgid "a memory allocation failed."
+msgstr "sự cấp phát bộ nhớ bị lỗi."
+
+#: ../src/msw/dde.cpp:1162
+msgid "a client's attempt to establish a conversation has failed."
+msgstr "sự có gắng của máy khách để thiết lập một cuộc đàm thoại bị lỗi."
+
+#: ../src/msw/dde.cpp:1165
+msgid "a transaction failed."
+msgstr "một chuyển tác bị lỗi."
+
+#: ../src/msw/dde.cpp:1168
+msgid "a request for a synchronous poke transaction has timed out."
+msgstr "yêu cầu cho chuyển tác poke đồng bộ gặp lỗi quá lâu."
+
+#: ../src/msw/dde.cpp:1171
+msgid "an internal call to the PostMessage function has failed. "
+msgstr "cuộc gọi nội tới hàm PostMessage gặp lỗi."
+
+#: ../src/msw/dde.cpp:1174
+msgid "reentrancy problem."
+msgstr "trục trặc reentrancy."
+
+#: ../src/msw/dde.cpp:1177
+msgid ""
+"a server-side transaction was attempted on a conversation\n"
+"that was terminated by the client, or the server\n"
+"terminated before completing a transaction."
+msgstr ""
+"chuyển tác phía máy chủ nỗ lực để giao tiếp\n"
+"với chuyển tác đã chấm dứt phía máy khách, hay máy chủ\n"
+"chấm dứt trước khi hoàn tất chuyển tác."
+
+#: ../src/msw/dde.cpp:1180
+msgid "an internal error has occurred in the DDEML."
+msgstr "một lỗi nội bộ phát sinh trong DDEML."
+
+#: ../src/msw/dde.cpp:1183
+msgid "a request to end an advise transaction has timed out."
+msgstr "yêu cầu cho chuyển tác end và advise đồng bộ gặp lỗi quá lâu."
+
+#: ../src/msw/dde.cpp:1186
+msgid ""
+"an invalid transaction identifier was passed to a DDEML function.\n"
+"Once the application has returned from an XTYP_XACT_COMPLETE callback,\n"
+"the transaction identifier for that callback is no longer valid."
+msgstr ""
+"một bộ nhận dạng chuyển tác không hợp lệ được chuyển tới hàm DDEML.\n"
+"Một khi ứng dụng trả về từ một XTYP_XACT_COMPLETE callback,\n"
+"bộ nhận dạng chuyển tác cho callback đó sẽ không còn hợp lệ."
+
+#: ../src/msw/dde.cpp:1189
+#, c-format
+msgid "Unknown DDE error %08x"
+msgstr "Không hiểu lỗi DDE %08x"
+
+#: ../src/msw/dialup.cpp:343
+msgid ""
+"Dial up functions are unavailable because the remote access service (RAS) is "
+"not installed on this machine. Please install it."
+msgstr ""
+"Hàm quay số không sẵn sàng bởi vì dịch vụ truy cập từ xa (RAS) chưa được cài "
+"trong máy này. Xin hãy cài nó vào."
+
+#: ../src/msw/dialup.cpp:402
+#, c-format
+msgid ""
+"The version of remote access service (RAS) installed on this machine is too "
+"old, please upgrade (the following required function is missing: %s)."
+msgstr ""
+"Phiên bản của chương trình truy cập dữ liệu từ xa (RAS) được cài đặt trong "
+"máy này đã quá cũ, xin hãy cập nhật (hàm yêu cầu sau đây bị thiếu: %s)."
+
+#: ../src/msw/dialup.cpp:437
+msgid "Failed to retrieve text of RAS error message"
+msgstr "Khôi phục chữ của thông điệp lỗi RAS gặp lỗi"
+
+#: ../src/msw/dialup.cpp:440
+#, c-format
+msgid "unknown error (error code %08x)."
+msgstr "chưa biết lỗi (mã sai %08x)."
+
+#: ../src/msw/dialup.cpp:492
+#, c-format
+msgid "Cannot find active dialup connection: %s"
+msgstr "Không thể tìm thấy kết nối quay số đang hoạt động: %s"
+
+#: ../src/msw/dialup.cpp:513
+msgid "Several active dialup connections found, choosing one randomly."
+msgstr ""
+"Tìm thấy nhiều kết nối quay số đang hoạt động, đang chọn một cái ngẫu nhiên."
+
+#: ../src/msw/dialup.cpp:598 ../src/msw/dialup.cpp:832
+#, c-format
+msgid "Failed to establish dialup connection: %s"
+msgstr "Thiết lập kết nối quay số gặp lỗi: %s"
+
+#: ../src/msw/dialup.cpp:664
+#, c-format
+msgid "Failed to get ISP names: %s"
+msgstr "Lấy tên của nhà cung cấp dịch vụ Internet ISP gặp lỗi: %s"
+
+#: ../src/msw/dialup.cpp:712
+msgid "Failed to connect: no ISP to dial."
+msgstr "Kết nối lỗi: không có nhà cung cấp dịch vụ Internet ISP để quay số."
+
+#: ../src/msw/dialup.cpp:732
+msgid "Choose ISP to dial"
+msgstr "Chọn nhà cung cấp dịch vụ Internet ISP để quay số"
+
+#: ../src/msw/dialup.cpp:733
+msgid "Please choose which ISP do you want to connect to"
+msgstr "Xin hãy chọn nhà cung cấp dịch vụ Internet ISP mà bạn muốn kết nối tới"
+
+#: ../src/msw/dialup.cpp:766
+msgid "Failed to connect: missing username/password."
+msgstr "Kết nối lỗi: không có tên người dùng/mật khẩu."
+
+#: ../src/msw/dialup.cpp:796
+msgid "Cannot find the location of address book file"
+msgstr "Không tìm thấy vị trí trong tập tin sổ địa chỉ"
+
+#: ../src/msw/dialup.cpp:827
+#, c-format
+msgid "Failed to initiate dialup connection: %s"
+msgstr "Khởi tạo kết nối quay số gặp lỗi: %s"
+
+#: ../src/msw/dialup.cpp:897
+msgid "Cannot hang up - no active dialup connection."
+msgstr "Không thể gác máy - không có kết nối quay số nào đang hoạt động."
+
+#: ../src/msw/dialup.cpp:907
+#, c-format
+msgid "Failed to terminate the dialup connection: %s"
+msgstr "Chấm dứt kết nối quay số gặp lỗi: %s"
+
+#: ../src/msw/dib.cpp:313
+#, c-format
+msgid "Failed to save the bitmap image to file \"%s\"."
+msgstr "Ghi ảnh bitmap thành tập tin \"%s\" gặp lỗi."
+
+#: ../src/msw/dib.cpp:543
+#, c-format
+msgid "Failed to allocate %luKb of memory for bitmap data."
+msgstr "Việc cấp phát %luKb bộ nhớ cho dữ liệu ảnh bitmap gặp lỗi."
+
+#: ../src/msw/dir.cpp:241
+#, c-format
+msgid "Cannot enumerate files in directory '%s'"
+msgstr "Không thể đếm các tập tin trong thư mục '%s'"
+
+#: ../src/msw/dirdlg.cpp:368
+msgid "Couldn't obtain folder name"
+msgstr "Không thể lấy được tên thư mục"
+
+#: ../src/msw/dlmsw.cpp:163
+#, fuzzy, c-format
+msgid "(error %d: %s)"
+msgstr " (lỗi %ld: %s)"
+
+#: ../src/msw/dragimag.cpp:143 ../src/msw/dragimag.cpp:178
+#: ../src/msw/imaglist.cpp:309 ../src/msw/imaglist.cpp:331
+msgid "Couldn't add an image to the image list."
+msgstr "Không thể thêm ảnh vào trong danh sách ảnh."
+
+#: ../src/msw/enhmeta.cpp:94
+#, c-format
+msgid "Failed to load metafile from file \"%s\"."
+msgstr "Tải metafile từ tập tin \"%s\" gặp lỗi."
+
+#: ../src/msw/fdrepdlg.cpp:412
+#, c-format
+msgid "Failed to create the standard find/replace dialog (error code %d)"
+msgstr "Tạo hộp thoại tìm/thay thế tiêu chuẩn gặp lỗi (mã lỗi %d)"
+
+#: ../src/msw/filedlg.cpp:1241
+msgid "Access to the file system is not allowed from secure desktop."
+msgstr ""
+
+#: ../src/msw/filedlg.cpp:1242
+msgid "Security warning"
+msgstr ""
+
+#: ../src/msw/filedlg.cpp:1533
+#, c-format
+msgid "File dialog failed with error code %0lx."
+msgstr "Hộp thoại chọn tập tin bị lỗi %0lx."
+
+#: ../src/msw/font.cpp:1120
+#, fuzzy, c-format
+msgid "Font file \"%s\" couldn't be loaded"
+msgstr "Không thể tải tập tin lên."
+
+#: ../src/msw/fontdlg.cpp:220
+#, c-format
+msgid "Common dialog failed with error code %0lx."
+msgstr "Hộp thoại dùng chung gặp lỗi %0lx."
+
+#: ../src/msw/fswatcher.cpp:67
+msgid "Ungraceful worker thread termination"
+msgstr "Sự kết thúc một tuyến trình công việc không đúng đắn"
+
+#: ../src/msw/fswatcher.cpp:81
+msgid "Unable to create IOCP worker thread"
+msgstr "Không thể tạo tuyến làm việc IOCP được"
+
+#: ../src/msw/fswatcher.cpp:88
+msgid "Unable to start IOCP worker thread"
+msgstr "Không thể khởi tạo tuyến trình làm việc IOCP"
+
+#: ../src/msw/fswatcher.cpp:140
+msgid "Monitoring individual files for changes is not supported currently."
+msgstr ""
+"Theo dõi các tập tin riêng lẻ để biết nó thay đổi gì hiện tại không được hỗ "
+"trợ."
+
+#: ../src/msw/fswatcher.cpp:165
+#, c-format
+msgid "Unable to set up watch for '%s'"
+msgstr "Không thể cài đặt cửa sổ theo dõi cho '%s'"
+
+#: ../src/msw/fswatcher.cpp:466
+#, c-format
+msgid "Can't monitor non-existent directory \"%s\" for changes."
+msgstr ""
+"Không thể theo dõi thư mục không-hiện-có \"%s\" để thấy được các thay đổi."
+
+#: ../src/msw/glcanvas.cpp:577 ../src/unix/glx11.cpp:507
+msgid "OpenGL 3.0 or later is not supported by the OpenGL driver."
+msgstr ""
+
+#: ../src/msw/glcanvas.cpp:601 ../src/osx/glcanvas_osx.cpp:395
+#: ../src/unix/glegl.cpp:304 ../src/unix/glx11.cpp:553
+#, fuzzy
+msgid "Couldn't create OpenGL context"
+msgstr "Không tạo được một timer"
+
+#: ../src/msw/glcanvas.cpp:1294
+msgid "Failed to initialize OpenGL"
+msgstr "Khởi tạo OpenGL gặp lỗi."
+
+#: ../src/msw/graphicsd2d.cpp:607
+msgid "Could not register custom DirectWrite font loader."
+msgstr ""
+
+#: ../src/msw/helpchm.cpp:48
+msgid ""
+"MS HTML Help functions are unavailable because the MS HTML Help library is "
+"not installed on this machine. Please install it."
+msgstr ""
+"Hàm MS HTML Help không sẵn sàng bởi vì thư viện MS HTML Help không được cài "
+"đặt trong máy này. Xin hãy cài nó vào."
+
+#: ../src/msw/helpchm.cpp:55
+msgid "Failed to initialize MS HTML Help."
+msgstr "Khởi tạo Trợ Giúp MS HTML gặp lỗi."
+
+#: ../src/msw/iniconf.cpp:458
+#, c-format
+msgid "Can't delete the INI file '%s'"
+msgstr "Không thể xóa tập tin INI '%s'"
+
+#: ../src/msw/listctrl.cpp:995
+#, c-format
+msgid "Couldn't retrieve information about list control item %d."
+msgstr "Không thể phục hồi thông tin về điều khiển danh sách mục tin %d."
+
+#: ../src/msw/mdi.cpp:170 ../src/qt/mdi.cpp:253
+msgid "&Cascade"
+msgstr "&Kiểu xếp chồng"
+
+#: ../src/msw/mdi.cpp:171
+msgid "Tile &Horizontally"
+msgstr "Xếp Kề Nhau Theo C&hiều Ngang"
+
+#: ../src/msw/mdi.cpp:172
+msgid "Tile &Vertically"
+msgstr "Xếp &Kề Nhau Theo Chiều Đứng"
+
+#: ../src/msw/mdi.cpp:174
+msgid "&Arrange Icons"
+msgstr "Xắp xế&p Biểu Tượng"
+
+#: ../src/msw/mdi.cpp:621
+msgid "Failed to create MDI parent frame."
+msgstr "Tạo khung cửa sổ cha MDI gặp lỗi."
+
+#: ../src/msw/mimetype.cpp:234
+#, c-format
+msgid "Failed to create registry entry for '%s' files."
+msgstr "Tạo mục đăng ký cho '%s' tập tin gặp lỗi."
+
+#: ../src/msw/ole/automtn.cpp:495
+#, c-format
+msgid "Failed to find CLSID of \"%s\""
+msgstr "Gặp lỗi khi tìm CLSID của \"%s\""
+
+#: ../src/msw/ole/automtn.cpp:512
+#, c-format
+msgid "Failed to create an instance of \"%s\""
+msgstr "Gặp lỗi khi tạo một minh dụ của \"%s\""
+
+#: ../src/msw/ole/automtn.cpp:552
+#, c-format
+msgid "Cannot get an active instance of \"%s\""
+msgstr "Không lấy được minh dụ đang hoạt động của  \"%s\""
+
+#: ../src/msw/ole/automtn.cpp:564
+#, c-format
+msgid "Failed to get OLE automation interface for \"%s\""
+msgstr "Gặp lỗi khi lấy giao diện tự động OLE cho \"%s\""
+
+#: ../src/msw/ole/automtn.cpp:621
+msgid "Unknown name or named argument."
+msgstr "Không hiểu tên hay tham số tên."
+
+#: ../src/msw/ole/automtn.cpp:625
+msgid "Incorrect number of arguments."
+msgstr "Số lượng đối số không đúng."
+
+#: ../src/msw/ole/automtn.cpp:637
+msgid "Unknown exception"
+msgstr "Không hiểu ngoại lệ"
+
+#: ../src/msw/ole/automtn.cpp:642
+msgid "Method or property not found."
+msgstr "Phương thức hay thuộc tính không tìm thấy."
+
+#: ../src/msw/ole/automtn.cpp:646
+msgid "Overflow while coercing argument values."
+msgstr "Tràn khi ép buộc các giá trị tham số."
+
+#: ../src/msw/ole/automtn.cpp:650
+msgid "Object implementation does not support named arguments."
+msgstr "Phần thực thi đối tượng không hỗ trợ các đối số có tên."
+
+#: ../src/msw/ole/automtn.cpp:654
+msgid "The locale ID is unknown."
+msgstr "ID nơi chốn không được biết."
+
+#: ../src/msw/ole/automtn.cpp:658
+msgid "Missing a required parameter."
+msgstr "Thiếu tham số yêu cầu."
+
+#: ../src/msw/ole/automtn.cpp:662
+#, c-format
+msgid "Argument %u not found."
+msgstr "Tham số %u không tìm thấy."
+
+#: ../src/msw/ole/automtn.cpp:666
+#, c-format
+msgid "Type mismatch in argument %u."
+msgstr "Không khớp kiểu trong tham số %u."
+
+#: ../src/msw/ole/automtn.cpp:670
+msgid "The system cannot find the file specified."
+msgstr "Hệ thống không tìm thấy tập tin đã chỉ ra."
+
+#: ../src/msw/ole/automtn.cpp:674
+msgid "Class not registered."
+msgstr "Lớp chưa được đăng ký."
+
+#: ../src/msw/ole/automtn.cpp:678
+#, c-format
+msgid "Unknown error %08x"
+msgstr "Không hiểu lỗi %08x"
+
+#: ../src/msw/ole/automtn.cpp:682
+#, c-format
+msgid "OLE Automation error in %s: %s"
+msgstr "Lỗi hoạt hình OLE trong %s: %s"
+
+#: ../src/msw/ole/dataobj.cpp:385
+#, c-format
+msgid "Couldn't register clipboard format '%s'."
+msgstr "Không thể đăng ký định dạng clipboard '%s'."
+
+#: ../src/msw/ole/dataobj.cpp:402
+#, c-format
+msgid "The clipboard format '%d' doesn't exist."
+msgstr "Định dạng clipboard '%d' chưa tồn tại."
+
+#: ../src/msw/progdlg.cpp:1025
+msgid "Skip"
+msgstr "Bỏ qua"
+
+#: ../src/msw/registry.cpp:141
+#, fuzzy, c-format
+msgid "unknown (%lu)"
+msgstr "không rõ"
+
+#: ../src/msw/registry.cpp:409
+#, c-format
+msgid "Can't get info about registry key '%s'"
+msgstr "Không thể nhận được thông tin về khóa đăng ký '%s'"
+
+#: ../src/msw/registry.cpp:445
+#, c-format
+msgid "Can't open registry key '%s'"
+msgstr "Không thể mở khóa đăng ký '%s'"
+
+#: ../src/msw/registry.cpp:478
+#, c-format
+msgid "Can't create registry key '%s'"
+msgstr "Không thể tạo một khóa đăng ký '%s'"
+
+#: ../src/msw/registry.cpp:497
+#, c-format
+msgid "Can't close registry key '%s'"
+msgstr "Không thể đóng khóa đăng ký '%s'"
+
+#: ../src/msw/registry.cpp:512
+#, c-format
+msgid "Registry value '%s' already exists."
+msgstr "Giá trị đăng ký '%s' đã tồn tại rồi."
+
+#: ../src/msw/registry.cpp:520
+#, c-format
+msgid "Failed to rename registry value '%s' to '%s'."
+msgstr "Đổi tên giá trị đăng ký '%s' thành '%s' gặp lỗi."
+
+#: ../src/msw/registry.cpp:575
+#, c-format
+msgid "Can't copy values of unsupported type %d."
+msgstr "Không thể sao chép giá trị của kiểu không được hỗ trợ %d."
+
+#: ../src/msw/registry.cpp:586
+#, c-format
+msgid "Registry key '%s' does not exist, cannot rename it."
+msgstr "Khóa đăng ký '%s' chưa tồn tại, không thể đổi tên được."
+
+#: ../src/msw/registry.cpp:617
+#, c-format
+msgid "Registry key '%s' already exists."
+msgstr "Khóa đăng ký '%s' đã tồn tại rồi."
+
+#: ../src/msw/registry.cpp:625
+#, c-format
+msgid "Failed to rename the registry key '%s' to '%s'."
+msgstr "Đổi tên khóa đăng ký '%s' thành '%s' gặp lỗi."
+
+#: ../src/msw/registry.cpp:670
+#, c-format
+msgid "Failed to copy the registry subkey '%s' to '%s'."
+msgstr "Sao chép khóa đăng ký phụ '%s' tới '%s' gặp lỗi."
+
+#: ../src/msw/registry.cpp:683
+#, c-format
+msgid "Failed to copy registry value '%s'"
+msgstr "Sao chép giá trị đăng ký '%s' gặp lỗi"
+
+#: ../src/msw/registry.cpp:692
+#, c-format
+msgid "Failed to copy the contents of registry key '%s' to '%s'."
+msgstr "Sao chép nội dung khóa đăng ký '%s' tới '%s' gặp lỗi."
+
+#: ../src/msw/registry.cpp:718
+#, c-format
+msgid ""
+"Registry key '%s' is needed for normal system operation,\n"
+"deleting it will leave your system in unusable state:\n"
+"operation aborted."
+msgstr ""
+"Khóa đăng ký '%s' là cần thiết cho hệ thống hoạt động bình thường,\n"
+"việc xóa nó sẽ làm cho hệ thống của bạn rơi vào trạng thái không ổn định:\n"
+"thao tác đã bị hủy bỏ."
+
+#: ../src/msw/registry.cpp:754
+#, c-format
+msgid "Can't delete key '%s'"
+msgstr "Không thể xóa khóa '%s'"
+
+#: ../src/msw/registry.cpp:782
+#, c-format
+msgid "Can't delete value '%s' from key '%s'"
+msgstr "Không thể xóa giá trị '%s' từ khóa '%s'"
+
+#: ../src/msw/registry.cpp:855 ../src/msw/registry.cpp:887
+#: ../src/msw/registry.cpp:929 ../src/msw/registry.cpp:1000
+#, c-format
+msgid "Can't read value of key '%s'"
+msgstr "Không thể đọc giá trị của khóa '%s'"
+
+#: ../src/msw/registry.cpp:873 ../src/msw/registry.cpp:915
+#: ../src/msw/registry.cpp:963 ../src/msw/registry.cpp:1106
+#, c-format
+msgid "Can't set value of '%s'"
+msgstr "Không thể đặt giá trị của '%s'"
+
+#: ../src/msw/registry.cpp:894 ../src/msw/registry.cpp:943
+#, c-format
+msgid "Registry value \"%s\" is not numeric (but of type %s)"
+msgstr ""
+
+#: ../src/msw/registry.cpp:979
+#, c-format
+msgid "Registry value \"%s\" is not binary (but of type %s)"
+msgstr ""
+
+#: ../src/msw/registry.cpp:1028
+#, c-format
+msgid "Registry value \"%s\" is not text (but of type %s)"
+msgstr ""
+
+#: ../src/msw/registry.cpp:1089
+#, c-format
+msgid "Can't read value of '%s'"
+msgstr "Không thể đọc giá trị của '%s'"
+
+#: ../src/msw/registry.cpp:1157
+#, c-format
+msgid "Can't enumerate values of key '%s'"
+msgstr "Không thể liệt kê các giá trị của khóa '%s'"
+
+#: ../src/msw/registry.cpp:1196
+#, c-format
+msgid "Can't enumerate subkeys of key '%s'"
+msgstr "Không thể liệt kê khóa phụ từ khóa '%s'"
+
+#: ../src/msw/registry.cpp:1262
+#, c-format
+msgid ""
+"Exporting registry key: file \"%s\" already exists and won't be overwritten."
+msgstr ""
+"Sự xuất khóa đăng ký: tập tin \"%s\" đã tồn tại và không thể ghi đè lên."
+
+#: ../src/msw/registry.cpp:1411
+#, c-format
+msgid "Can't export value of unsupported type %d."
+msgstr "Không thể xuất ra giá trị của kiểu không được hỗ trợ %d."
+
+#: ../src/msw/registry.cpp:1427
+#, c-format
+msgid "Ignoring value \"%s\" of the key \"%s\"."
+msgstr "Bỏ qua giá trị \"%s\" của khóa \"%s\"."
+
+#: ../src/msw/textctrl.cpp:596
+msgid ""
+"Impossible to create a rich edit control, using simple text control instead. "
+"Please reinstall riched32.dll"
+msgstr ""
+"Không thể nào khởi tạo điều khiển văn bản (rich edit), đang sử dụng điều "
+"khiển văn bản đơn giản để thay thế. Xin hãy cài lại riched32.dll"
+
+#: ../src/msw/thread.cpp:522 ../src/unix/threadpsx.cpp:850
+msgid "Cannot start thread: error writing TLS."
+msgstr "Không thể khởi động tuyến trình: lỗi ghi TLS."
+
+#: ../src/msw/thread.cpp:613
+msgid "Can't set thread priority"
+msgstr "Không thể đặt mức ưu tiên tuyến trình"
+
+#: ../src/msw/thread.cpp:649
+msgid "Can't create thread"
+msgstr "Không thể tạo tuyến trình"
+
+#: ../src/msw/thread.cpp:668
+msgid "Couldn't terminate thread"
+msgstr "Không thể chấm dứt tuyến trình"
+
+#: ../src/msw/thread.cpp:799
+msgid "Cannot wait for thread termination"
+msgstr "Không thể chờ tuyến trình thiết bị cuối"
+
+#: ../src/msw/thread.cpp:873
+#, c-format
+msgid "Cannot suspend thread %lx"
+msgstr "Không thể đình chỉ tuyến trình %lx"
+
+#: ../src/msw/thread.cpp:903
+#, c-format
+msgid "Cannot resume thread %lx"
+msgstr "Không thể phục hồi tuyến trình %lx"
+
+#: ../src/msw/thread.cpp:932
+msgid "Couldn't get the current thread pointer"
+msgstr "Không thể lấy con trỏ tuyến trình hiện hành"
+
+#: ../src/msw/thread.cpp:1333
+msgid ""
+"Thread module initialization failed: impossible to allocate index in thread "
+"local storage"
+msgstr ""
+"Khởi tạo mô đun tuyến trình gặp lỗi: không thể cấp phát chỉ số trong phần "
+"lưu trữ nội bộ tuyến trình"
+
+#: ../src/msw/thread.cpp:1345
+msgid ""
+"Thread module initialization failed: cannot store value in thread local "
+"storage"
+msgstr ""
+"Khởi tạo mô đun tuyến trình gặp lỗi: không thể lưu giá trị trong phần lưu "
+"trữ nội bộ tuyến trình"
+
+#: ../src/msw/timer.cpp:133
+msgid "Couldn't create a timer"
+msgstr "Không tạo được một timer"
+
+#: ../src/msw/utils.cpp:372
+msgid "can't find user's HOME, using current directory."
+msgstr ""
+"không thể tìm thấy thư mục HOME của người dùng, sử dụng thư mục hiện hành."
+
+#: ../src/msw/utils.cpp:662
+#, c-format
+msgid "Failed to kill process %d"
+msgstr "Loại bỏ quá trình %d gặp lỗi"
+
+#: ../src/msw/utils.cpp:986
+#, c-format
+msgid "Failed to load resource \"%s\"."
+msgstr "Lỗi khi tải tài nguyên \"%s\"."
+
+#: ../src/msw/utils.cpp:993
+#, c-format
+msgid "Failed to lock resource \"%s\"."
+msgstr "Lỗi khi khóa tài nguyên \"%s\"."
+
+#. TRANSLATORS: MS Windows build number
+#: ../src/msw/utils.cpp:1209
+#, c-format
+msgid "build %lu"
+msgstr "xây dựng %lu"
+
+#: ../src/msw/utils.cpp:1218
+msgid ", 64-bit edition"
+msgstr ", bản 64-bit"
+
+#: ../src/msw/utilsexc.cpp:224
+msgid "Failed to create an anonymous pipe"
+msgstr "Tạo anonymous pipe gặp lỗi"
+
+#: ../src/msw/utilsexc.cpp:697
+msgid "Failed to redirect the child process IO"
+msgstr "Chuyển hướng vào xử lý IO con gặp lỗi"
+
+#: ../src/msw/utilsexc.cpp:870
+#, c-format
+msgid "Execution of command '%s' failed"
+msgstr "Thi hành lệnh '%s' gặp lỗi"
+
+#: ../src/msw/volume.cpp:337
+msgid "Failed to load mpr.dll."
+msgstr "Tải thư viện mpr.dll gặp lỗi."
+
+#: ../src/msw/volume.cpp:506
+#, c-format
+msgid "Cannot read typename from '%s'!"
+msgstr "Không thể đọc kiểu tên từ '%s'!"
+
+#: ../src/msw/volume.cpp:615
+#, c-format
+msgid "Cannot load icon from '%s'."
+msgstr "Không thể tải biểu tượng từ '%s'."
+
+#: ../src/msw/webview_edge.cpp:285
+msgid "This program was compiled without support for setting Edge proxy."
+msgstr ""
+
+#: ../src/msw/webview_ie.cpp:1010
+msgid "Failed to find web view emulation level in the registry"
+msgstr ""
+
+#: ../src/msw/webview_ie.cpp:1019
+msgid "Failed to set web view to modern emulation level"
+msgstr ""
+
+#: ../src/msw/webview_ie.cpp:1027
+msgid "Failed to reset web view to standard emulation level"
+msgstr ""
+
+#: ../src/msw/webview_ie.cpp:1049
+msgid "Can't run JavaScript script without a valid HTML document"
+msgstr ""
+
+#: ../src/msw/webview_ie.cpp:1056
+#, fuzzy
+msgid "Can't get the JavaScript object"
+msgstr "Không thể đặt mức ưu tiên tuyến trình"
+
+#: ../src/msw/webview_ie.cpp:1070
+#, fuzzy
+msgid "failed to evaluate"
+msgstr "Thực thi '%s' gặp lỗi\n"
+
+#: ../src/osx/cocoa/filedlg.mm:412
+#, fuzzy
+msgid "File type:"
+msgstr "Dạng Teletype"
+
+#: ../src/osx/cocoa/menu.mm:242
+#, fuzzy
+msgctxt "macOS menu name"
+msgid "Window"
+msgstr "&Cửa sổ"
+
+#: ../src/osx/cocoa/menu.mm:259
+#, fuzzy
+msgctxt "macOS menu name"
+msgid "Help"
+msgstr "Trợ giúp"
+
+#: ../src/osx/cocoa/menu.mm:298
+#, fuzzy
+msgctxt "macOS menu item"
+msgid "Minimize"
+msgstr "&Nhỏ nhất"
+
+#: ../src/osx/cocoa/menu.mm:303
+#, fuzzy
+msgctxt "macOS menu item"
+msgid "Zoom"
+msgstr "Phóng to"
+
+#: ../src/osx/cocoa/menu.mm:309
+msgctxt "macOS menu item"
+msgid "Bring All to Front"
+msgstr ""
+
+#: ../src/osx/core/sound.cpp:143
+#, fuzzy, c-format
+msgid "Failed to load sound from \"%s\" (error %d)."
+msgstr "Lỗi khi tải tài nguyên \"%s\"."
+
+#: ../src/osx/fontutil.cpp:80
+#, fuzzy, c-format
+msgid "Font file \"%s\" doesn't exist."
+msgstr "Tập tin %s chưa tồn tại."
+
+#: ../src/osx/fontutil.cpp:88
+#, c-format
+msgid ""
+"Font file \"%s\" cannot be used as it is not inside the font directory "
+"\"%s\"."
+msgstr ""
+
+#: ../src/osx/menu_osx.cpp:496
+#, c-format
+msgctxt "macOS menu item"
+msgid "About %s"
+msgstr "Giới thiệu %s"
+
+#: ../src/osx/menu_osx.cpp:499
+msgctxt "macOS menu item"
+msgid "About..."
+msgstr "Giới thiệu..."
+
+#: ../src/osx/menu_osx.cpp:508
+msgctxt "macOS menu item"
+msgid "Preferences..."
+msgstr "Cá nhân hóa..."
+
+#: ../src/osx/menu_osx.cpp:512
+msgctxt "macOS menu item"
+msgid "Services"
+msgstr "Dịch vụ"
+
+#: ../src/osx/menu_osx.cpp:519
+#, c-format
+msgctxt "macOS menu item"
+msgid "Hide %s"
+msgstr "Ẩn %s"
+
+#: ../src/osx/menu_osx.cpp:522
+#, fuzzy
+msgctxt "macOS menu item"
+msgid "Hide Application"
+msgstr "Ứng dụng"
+
+#: ../src/osx/menu_osx.cpp:526
+msgctxt "macOS menu item"
+msgid "Hide Others"
+msgstr "Các thứ khác ẩn"
+
+#: ../src/osx/menu_osx.cpp:528
+msgctxt "macOS menu item"
+msgid "Show All"
+msgstr "Hiện tất"
+
+#: ../src/osx/menu_osx.cpp:534
+#, c-format
+msgctxt "macOS menu item"
+msgid "Quit %s"
+msgstr "Thoát %s"
+
+#: ../src/osx/menu_osx.cpp:537
+#, fuzzy
+msgctxt "macOS menu item"
+msgid "Quit Application"
+msgstr "Ứng dụng"
+
+#: ../src/osx/webview_webkit.mm:444
+#, fuzzy
+msgid "Printing is not supported by the system web control"
+msgstr "Gzip không được hỗ trợ bởi phiên bản này của zlib"
+
+#: ../src/osx/webview_webkit.mm:453
+#, fuzzy
+msgid "Print operation could not be initialized"
+msgstr "Phần miêu tả cột không thể được khởi tạo."
+
+#. TRANSLATORS: Label of font point size
+#: ../src/propgrid/advprops.cpp:605
+msgid "Point Size"
+msgstr "&Kích thước Phông chữ:"
+
+#. TRANSLATORS: Label of font face name
+#: ../src/propgrid/advprops.cpp:615
+msgid "Face Name"
+msgstr "Tên Mặt"
+
+#. TRANSLATORS: Label of font style
+#: ../src/propgrid/advprops.cpp:623 ../src/richtext/richtextformatdlg.cpp:331
+msgid "Style"
+msgstr "Kiểu dáng"
+
+#. TRANSLATORS: Label of font weight
+#: ../src/propgrid/advprops.cpp:628
+msgid "Weight"
+msgstr "Độ rộng"
+
+#. TRANSLATORS: Label of underlined font
+#: ../src/propgrid/advprops.cpp:633 ../src/richtext/richtextfontpage.cpp:358
+msgid "Underlined"
+msgstr "Bị gạch dưới"
+
+#. TRANSLATORS: Label of font family
+#: ../src/propgrid/advprops.cpp:637
+msgid "Family"
+msgstr "Họ"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:801
+msgid "AppWorkspace"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:802
+#, fuzzy
+msgid "ActiveBorder"
+msgstr "Viền"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:803
+msgid "ActiveCaption"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:804
+msgid "ButtonFace"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:805
+msgid "ButtonHighlight"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:806
+msgid "ButtonShadow"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:807
+msgid "ButtonText"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:808
+msgid "CaptionText"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:809
+msgid "ControlDark"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:810
+msgid "ControlLight"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:812
+msgid "GrayText"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:813
+#, fuzzy
+msgid "Highlight"
+msgstr "ánh sáng"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:814
+#, fuzzy
+msgid "HighlightText"
+msgstr "Canh lề chữ phải."
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:815
+#, fuzzy
+msgid "InactiveBorder"
+msgstr "Viền"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:816
+msgid "InactiveCaption"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:817
+msgid "InactiveCaptionText"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:818
+msgid "Menu"
+msgstr "Trình đơn"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:819
+msgid "Scrollbar"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:820
+msgid "Tooltip"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:821
+msgid "TooltipText"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:822
+#, fuzzy
+msgid "Window"
+msgstr "&Cửa sổ"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:823
+#, fuzzy
+msgid "WindowFrame"
+msgstr "&Cửa sổ"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:824
+#, fuzzy
+msgid "WindowText"
+msgstr "&Cửa sổ"
+
+#. TRANSLATORS: Custom colour choice entry
+#: ../src/propgrid/advprops.cpp:825 ../src/propgrid/advprops.cpp:1532
+#: ../src/propgrid/advprops.cpp:1576
+#, fuzzy
+msgid "Custom"
+msgstr "Cỡ riêng"
+
+#: ../src/propgrid/advprops.cpp:1558
+msgid "Black"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1559
+msgid "Maroon"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1560
+msgid "Navy"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1561
+msgid "Purple"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1562
+msgid "Teal"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1563
+msgid "Gray"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1564
+#, fuzzy
+msgid "Green"
+msgstr "MacGreek"
+
+#: ../src/propgrid/advprops.cpp:1565
+msgid "Olive"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1566
+#, fuzzy
+msgid "Brown"
+msgstr "Tìm duyệt"
+
+#: ../src/propgrid/advprops.cpp:1567
+msgid "Blue"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1568
+msgid "Fuchsia"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1569
+#, fuzzy
+msgid "Red"
+msgstr "Redo"
+
+#: ../src/propgrid/advprops.cpp:1570
+msgid "Orange"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1571
+msgid "Silver"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1572
+msgid "Lime"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1573
+msgid "Aqua"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1574
+msgid "Yellow"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1575
+msgid "White"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1718
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Default"
+msgstr "mặc định"
+
+#: ../src/propgrid/advprops.cpp:1719
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Arrow"
+msgstr "ngày mai"
+
+#: ../src/propgrid/advprops.cpp:1720
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Right Arrow"
+msgstr "Phải"
+
+#: ../src/propgrid/advprops.cpp:1721
+msgctxt "system cursor name"
+msgid "Blank"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1722
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Bullseye"
+msgstr "Kiểu dáng bullet"
+
+#: ../src/propgrid/advprops.cpp:1723
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Character"
+msgstr "&Mã ký tự:"
+
+#: ../src/propgrid/advprops.cpp:1724
+msgctxt "system cursor name"
+msgid "Cross"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1725
+msgctxt "system cursor name"
+msgid "Hand"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1726
+msgctxt "system cursor name"
+msgid "I-Beam"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1727
+msgctxt "system cursor name"
+msgid "Left Button"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1728
+msgctxt "system cursor name"
+msgid "Magnifier"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1729
+msgctxt "system cursor name"
+msgid "Middle Button"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1730
+msgctxt "system cursor name"
+msgid "No Entry"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1731
+msgctxt "system cursor name"
+msgid "Paint Brush"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1732
+msgctxt "system cursor name"
+msgid "Pencil"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1733
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Point Left"
+msgstr "&Kích thước Phông chữ:"
+
+#: ../src/propgrid/advprops.cpp:1734
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Point Right"
+msgstr "Canh lề Phải"
+
+#: ../src/propgrid/advprops.cpp:1735
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Question Arrow"
+msgstr "Câu hỏi"
+
+#: ../src/propgrid/advprops.cpp:1736
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Right Button"
+msgstr "Phải"
+
+#: ../src/propgrid/advprops.cpp:1737
+msgctxt "system cursor name"
+msgid "Sizing NE-SW"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1738
+msgctxt "system cursor name"
+msgid "Sizing N-S"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1739
+msgctxt "system cursor name"
+msgid "Sizing NW-SE"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1740
+msgctxt "system cursor name"
+msgid "Sizing W-E"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1741
+msgctxt "system cursor name"
+msgid "Sizing"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1742
+msgctxt "system cursor name"
+msgid "Spraycan"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1743
+msgctxt "system cursor name"
+msgid "Wait"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1744
+msgctxt "system cursor name"
+msgid "Watch"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1745
+#, fuzzy
+msgctxt "system cursor name"
+msgid "Wait Arrow"
+msgstr "Phải"
+
+#: ../src/propgrid/advprops.cpp:2109
+msgid "Make a selection:"
+msgstr "Làm với vùng chọn:"
+
+#: ../src/propgrid/manager.cpp:394
+msgid "Property"
+msgstr "Thuộc tính"
+
+#: ../src/propgrid/manager.cpp:395
+msgid "Value"
+msgstr "Giá trị"
+
+#: ../src/propgrid/manager.cpp:1683
+msgid "Categorized Mode"
+msgstr "Chế độ Cá nhân hóa"
+
+#: ../src/propgrid/manager.cpp:1709
+msgid "Alphabetic Mode"
+msgstr "Chế độ Bảng chữ cái"
+
+#. TRANSLATORS: Name of Boolean false value
+#: ../src/propgrid/propgrid.cpp:230
+msgid "False"
+msgstr "Sai"
+
+#. TRANSLATORS: Name of Boolean true value
+#: ../src/propgrid/propgrid.cpp:232
+msgid "True"
+msgstr "Đúng"
+
+#. TRANSLATORS: Text  displayed for unspecified value
+#: ../src/propgrid/propgrid.cpp:428
+msgid "Unspecified"
+msgstr "Chưa định danh"
+
+#. TRANSLATORS: Caption of message box displaying any property error
+#: ../src/propgrid/propgrid.cpp:3145 ../src/propgrid/propgrid.cpp:3282
+msgid "Property Error"
+msgstr "Lỗi Thuộc tính"
+
+#: ../src/propgrid/propgrid.cpp:3259
+msgid "You have entered invalid value. Press ESC to cancel editing."
+msgstr ""
+"Bạn đã nhập vào giá trị không hợp lệ. Hãy bấm phím ESC để huỷ bỏ việc chỉnh "
+"sửa."
+
+#: ../src/propgrid/propgrid.cpp:6608
+#, c-format
+msgid "Error in resource: %s"
+msgstr "Lỗi trong tài nguyên: %s"
+
+#: ../src/propgrid/propgridiface.cpp:377
+#, c-format
+msgid ""
+"Type operation \"%s\" failed: Property labeled \"%s\" is of type \"%s\", NOT "
+"\"%s\"."
+msgstr ""
+"Toán tử kiểu \"%s\" gặp lỗi: Tên thuộc tính \"%s\" là kiểu  \"%s\", KHÔNG "
+"PHẢI \"%s\"."
+
+#: ../src/propgrid/props.cpp:159
+#, c-format
+msgid "Unknown base %d. Base 10 will be used."
+msgstr ""
+
+#: ../src/propgrid/props.cpp:324
+#, c-format
+msgid "Value must be %s or higher."
+msgstr "Giá trị phải là %s hay lớn hơn."
+
+#: ../src/propgrid/props.cpp:329 ../src/propgrid/props.cpp:356
+#, c-format
+msgid "Value must be between %s and %s."
+msgstr "Giá trị phải nằm giữa %s và %s."
+
+#: ../src/propgrid/props.cpp:351
+#, c-format
+msgid "Value must be %s or less."
+msgstr "Giá trị phải là %s hay nhỏ hơn."
+
+#: ../src/propgrid/props.cpp:1058
+#, c-format
+msgid "Not %s"
+msgstr "Không %s"
+
+#: ../src/propgrid/props.cpp:1770
+msgid "Choose a directory:"
+msgstr "Chọn thư mục:"
+
+#: ../src/propgrid/props.cpp:2055
+msgid "Choose a file"
+msgstr "Chọn một tập tin"
+
+#: ../src/qt/mdi.cpp:254
+msgid "&Tile"
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:147
+#: ../src/richtext/richtextformatdlg.cpp:376
+msgid "Background"
+msgstr "Nền"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:159
+msgid "Background &colour:"
+msgstr "Mà&u nền:"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:161
+#: ../src/richtext/richtextbackgroundpage.cpp:163
+msgid "Enables a background colour."
+msgstr "Cho phép màu nền."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:167
+#: ../src/richtext/richtextbackgroundpage.cpp:169
+msgid "The background colour."
+msgstr "Màu nền."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:178
+msgid "Shadow"
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:193
+msgid "Use &shadow"
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:195
+#: ../src/richtext/richtextbackgroundpage.cpp:197
+#, fuzzy
+msgid "Enables a shadow."
+msgstr "Cho phép màu nền."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:211
+#, fuzzy
+msgid "&Horizontal offset:"
+msgstr "&Vị trí tương đối theo chiều dọc:"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:218
+#: ../src/richtext/richtextbackgroundpage.cpp:220
+#, fuzzy
+msgid "The horizontal offset."
+msgstr "Cho phép đoạn bù (offset) theo chiều dọc."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:224
+#: ../src/richtext/richtextbackgroundpage.cpp:227
+#: ../src/richtext/richtextbackgroundpage.cpp:228
+#: ../src/richtext/richtextbackgroundpage.cpp:247
+#: ../src/richtext/richtextbackgroundpage.cpp:250
+#: ../src/richtext/richtextbackgroundpage.cpp:251
+#: ../src/richtext/richtextbackgroundpage.cpp:287
+#: ../src/richtext/richtextbackgroundpage.cpp:290
+#: ../src/richtext/richtextbackgroundpage.cpp:291
+#: ../src/richtext/richtextbackgroundpage.cpp:314
+#: ../src/richtext/richtextbackgroundpage.cpp:317
+#: ../src/richtext/richtextbackgroundpage.cpp:318
+#: ../src/richtext/richtextborderspage.cpp:252
+#: ../src/richtext/richtextborderspage.cpp:255
+#: ../src/richtext/richtextborderspage.cpp:256
+#: ../src/richtext/richtextborderspage.cpp:286
+#: ../src/richtext/richtextborderspage.cpp:289
+#: ../src/richtext/richtextborderspage.cpp:290
+#: ../src/richtext/richtextborderspage.cpp:320
+#: ../src/richtext/richtextborderspage.cpp:323
+#: ../src/richtext/richtextborderspage.cpp:324
+#: ../src/richtext/richtextborderspage.cpp:354
+#: ../src/richtext/richtextborderspage.cpp:357
+#: ../src/richtext/richtextborderspage.cpp:358
+#: ../src/richtext/richtextborderspage.cpp:420
+#: ../src/richtext/richtextborderspage.cpp:423
+#: ../src/richtext/richtextborderspage.cpp:424
+#: ../src/richtext/richtextborderspage.cpp:454
+#: ../src/richtext/richtextborderspage.cpp:457
+#: ../src/richtext/richtextborderspage.cpp:458
+#: ../src/richtext/richtextborderspage.cpp:488
+#: ../src/richtext/richtextborderspage.cpp:491
+#: ../src/richtext/richtextborderspage.cpp:492
+#: ../src/richtext/richtextborderspage.cpp:522
+#: ../src/richtext/richtextborderspage.cpp:525
+#: ../src/richtext/richtextborderspage.cpp:526
+#: ../src/richtext/richtextborderspage.cpp:590
+#: ../src/richtext/richtextborderspage.cpp:593
+#: ../src/richtext/richtextborderspage.cpp:594
+#: ../src/richtext/richtextfontpage.cpp:177
+#: ../src/richtext/richtextmarginspage.cpp:199
+#: ../src/richtext/richtextmarginspage.cpp:201
+#: ../src/richtext/richtextmarginspage.cpp:202
+#: ../src/richtext/richtextmarginspage.cpp:224
+#: ../src/richtext/richtextmarginspage.cpp:226
+#: ../src/richtext/richtextmarginspage.cpp:227
+#: ../src/richtext/richtextmarginspage.cpp:247
+#: ../src/richtext/richtextmarginspage.cpp:249
+#: ../src/richtext/richtextmarginspage.cpp:250
+#: ../src/richtext/richtextmarginspage.cpp:272
+#: ../src/richtext/richtextmarginspage.cpp:274
+#: ../src/richtext/richtextmarginspage.cpp:275
+#: ../src/richtext/richtextmarginspage.cpp:313
+#: ../src/richtext/richtextmarginspage.cpp:315
+#: ../src/richtext/richtextmarginspage.cpp:316
+#: ../src/richtext/richtextmarginspage.cpp:338
+#: ../src/richtext/richtextmarginspage.cpp:340
+#: ../src/richtext/richtextmarginspage.cpp:341
+#: ../src/richtext/richtextmarginspage.cpp:361
+#: ../src/richtext/richtextmarginspage.cpp:363
+#: ../src/richtext/richtextmarginspage.cpp:364
+#: ../src/richtext/richtextmarginspage.cpp:386
+#: ../src/richtext/richtextmarginspage.cpp:388
+#: ../src/richtext/richtextmarginspage.cpp:389
+#: ../src/richtext/richtextsizepage.cpp:337
+#: ../src/richtext/richtextsizepage.cpp:340
+#: ../src/richtext/richtextsizepage.cpp:341
+#: ../src/richtext/richtextsizepage.cpp:371
+#: ../src/richtext/richtextsizepage.cpp:374
+#: ../src/richtext/richtextsizepage.cpp:375
+#: ../src/richtext/richtextsizepage.cpp:398
+#: ../src/richtext/richtextsizepage.cpp:401
+#: ../src/richtext/richtextsizepage.cpp:402
+#: ../src/richtext/richtextsizepage.cpp:425
+#: ../src/richtext/richtextsizepage.cpp:428
+#: ../src/richtext/richtextsizepage.cpp:429
+#: ../src/richtext/richtextsizepage.cpp:452
+#: ../src/richtext/richtextsizepage.cpp:455
+#: ../src/richtext/richtextsizepage.cpp:456
+#: ../src/richtext/richtextsizepage.cpp:479
+#: ../src/richtext/richtextsizepage.cpp:482
+#: ../src/richtext/richtextsizepage.cpp:483
+#: ../src/richtext/richtextsizepage.cpp:553
+#: ../src/richtext/richtextsizepage.cpp:556
+#: ../src/richtext/richtextsizepage.cpp:557
+#: ../src/richtext/richtextsizepage.cpp:588
+#: ../src/richtext/richtextsizepage.cpp:591
+#: ../src/richtext/richtextsizepage.cpp:592
+#: ../src/richtext/richtextsizepage.cpp:623
+#: ../src/richtext/richtextsizepage.cpp:626
+#: ../src/richtext/richtextsizepage.cpp:627
+#: ../src/richtext/richtextsizepage.cpp:658
+#: ../src/richtext/richtextsizepage.cpp:661
+#: ../src/richtext/richtextsizepage.cpp:662
+msgid "px"
+msgstr "px (pi-xeo)"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:225
+#: ../src/richtext/richtextbackgroundpage.cpp:248
+#: ../src/richtext/richtextbackgroundpage.cpp:288
+#: ../src/richtext/richtextbackgroundpage.cpp:315
+#: ../src/richtext/richtextborderspage.cpp:253
+#: ../src/richtext/richtextborderspage.cpp:287
+#: ../src/richtext/richtextborderspage.cpp:321
+#: ../src/richtext/richtextborderspage.cpp:355
+#: ../src/richtext/richtextborderspage.cpp:421
+#: ../src/richtext/richtextborderspage.cpp:455
+#: ../src/richtext/richtextborderspage.cpp:489
+#: ../src/richtext/richtextborderspage.cpp:523
+#: ../src/richtext/richtextborderspage.cpp:591
+#: ../src/richtext/richtextmarginspage.cpp:200
+#: ../src/richtext/richtextmarginspage.cpp:225
+#: ../src/richtext/richtextmarginspage.cpp:248
+#: ../src/richtext/richtextmarginspage.cpp:273
+#: ../src/richtext/richtextmarginspage.cpp:314
+#: ../src/richtext/richtextmarginspage.cpp:339
+#: ../src/richtext/richtextmarginspage.cpp:362
+#: ../src/richtext/richtextmarginspage.cpp:387
+#: ../src/richtext/richtextsizepage.cpp:338
+#: ../src/richtext/richtextsizepage.cpp:372
+#: ../src/richtext/richtextsizepage.cpp:399
+#: ../src/richtext/richtextsizepage.cpp:426
+#: ../src/richtext/richtextsizepage.cpp:453
+#: ../src/richtext/richtextsizepage.cpp:480
+#: ../src/richtext/richtextsizepage.cpp:554
+#: ../src/richtext/richtextsizepage.cpp:589
+#: ../src/richtext/richtextsizepage.cpp:624
+#: ../src/richtext/richtextsizepage.cpp:659
+msgid "cm"
+msgstr "cm"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:226
+#: ../src/richtext/richtextbackgroundpage.cpp:249
+#: ../src/richtext/richtextbackgroundpage.cpp:289
+#: ../src/richtext/richtextbackgroundpage.cpp:316
+#: ../src/richtext/richtextborderspage.cpp:254
+#: ../src/richtext/richtextborderspage.cpp:288
+#: ../src/richtext/richtextborderspage.cpp:322
+#: ../src/richtext/richtextborderspage.cpp:356
+#: ../src/richtext/richtextborderspage.cpp:422
+#: ../src/richtext/richtextborderspage.cpp:456
+#: ../src/richtext/richtextborderspage.cpp:490
+#: ../src/richtext/richtextborderspage.cpp:524
+#: ../src/richtext/richtextborderspage.cpp:592
+#: ../src/richtext/richtextfontpage.cpp:176
+#: ../src/richtext/richtextfontpage.cpp:179
+msgid "pt"
+msgstr "pt"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:229
+#: ../src/richtext/richtextbackgroundpage.cpp:231
+#: ../src/richtext/richtextbackgroundpage.cpp:252
+#: ../src/richtext/richtextbackgroundpage.cpp:254
+#: ../src/richtext/richtextbackgroundpage.cpp:292
+#: ../src/richtext/richtextbackgroundpage.cpp:294
+#: ../src/richtext/richtextbackgroundpage.cpp:319
+#: ../src/richtext/richtextbackgroundpage.cpp:321
+#, fuzzy
+msgid "Units for this value."
+msgstr "Đơn vị cho lề trái."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:234
+#, fuzzy
+msgid "&Vertical offset:"
+msgstr "&Vị trí tương đối theo chiều dọc:"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:241
+#: ../src/richtext/richtextbackgroundpage.cpp:243
+#, fuzzy
+msgid "The vertical offset."
+msgstr "Cho phép đoạn bù (offset) theo chiều dọc."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:257
+#, fuzzy
+msgid "Shadow c&olour:"
+msgstr "Chọn màu"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:259
+#: ../src/richtext/richtextbackgroundpage.cpp:261
+#, fuzzy
+msgid "Enables the shadow colour."
+msgstr "Cho phép màu nền."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:265
+#: ../src/richtext/richtextbackgroundpage.cpp:267
+#, fuzzy
+msgid "The shadow colour."
+msgstr "Màu phông chữ."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:270
+msgid "Sh&adow spread:"
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:272
+#: ../src/richtext/richtextbackgroundpage.cpp:274
+#, fuzzy
+msgid "Enables the shadow spread."
+msgstr "Cho phép giá trị độ rộng."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:281
+#: ../src/richtext/richtextbackgroundpage.cpp:283
+msgid "The shadow spread."
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:297
+msgid "&Blur distance:"
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:299
+#: ../src/richtext/richtextbackgroundpage.cpp:301
+#, fuzzy
+msgid "Enables the blur distance."
+msgstr "Cho phép giá trị độ rộng."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:308
+#: ../src/richtext/richtextbackgroundpage.cpp:310
+msgid "The shadow blur distance."
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:324
+msgid "Opaci&ty:"
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:326
+#: ../src/richtext/richtextbackgroundpage.cpp:328
+#, fuzzy
+msgid "Enables the shadow opacity."
+msgstr "Cho phép giá trị độ rộng."
+
+#: ../src/richtext/richtextbackgroundpage.cpp:335
+#: ../src/richtext/richtextbackgroundpage.cpp:337
+msgid "The shadow opacity."
+msgstr ""
+
+#. TRANSLATORS: Rich text page units (percentage)
+#: ../src/richtext/richtextbackgroundpage.cpp:340
+#: ../src/richtext/richtextsizepage.cpp:339
+#: ../src/richtext/richtextsizepage.cpp:373
+#: ../src/richtext/richtextsizepage.cpp:400
+#: ../src/richtext/richtextsizepage.cpp:427
+#: ../src/richtext/richtextsizepage.cpp:454
+#: ../src/richtext/richtextsizepage.cpp:481
+#: ../src/richtext/richtextsizepage.cpp:555
+#: ../src/richtext/richtextsizepage.cpp:590
+#: ../src/richtext/richtextsizepage.cpp:625
+#: ../src/richtext/richtextsizepage.cpp:660
+msgid "%"
+msgstr "%"
+
+#: ../src/richtext/richtextborderspage.cpp:229
+#: ../src/richtext/richtextborderspage.cpp:387
+msgid "Border"
+msgstr "Viền"
+
+#: ../src/richtext/richtextborderspage.cpp:242
+#: ../src/richtext/richtextborderspage.cpp:410
+#: ../src/richtext/richtextindentspage.cpp:194
+#: ../src/richtext/richtextliststylepage.cpp:384
+#: ../src/richtext/richtextmarginspage.cpp:185
+#: ../src/richtext/richtextmarginspage.cpp:299
+#: ../src/richtext/richtextsizepage.cpp:531
+#: ../src/richtext/richtextsizepage.cpp:538
+msgid "&Left:"
+msgstr "&Bên trái:"
+
+#: ../src/richtext/richtextborderspage.cpp:257
+#: ../src/richtext/richtextborderspage.cpp:259
+msgid "Units for the left border width."
+msgstr "Đơn vị cho độ rộng biên trái."
+
+#: ../src/richtext/richtextborderspage.cpp:266
+#: ../src/richtext/richtextborderspage.cpp:268
+#: ../src/richtext/richtextborderspage.cpp:300
+#: ../src/richtext/richtextborderspage.cpp:302
+#: ../src/richtext/richtextborderspage.cpp:334
+#: ../src/richtext/richtextborderspage.cpp:336
+#: ../src/richtext/richtextborderspage.cpp:368
+#: ../src/richtext/richtextborderspage.cpp:370
+#: ../src/richtext/richtextborderspage.cpp:434
+#: ../src/richtext/richtextborderspage.cpp:436
+#: ../src/richtext/richtextborderspage.cpp:468
+#: ../src/richtext/richtextborderspage.cpp:470
+#: ../src/richtext/richtextborderspage.cpp:502
+#: ../src/richtext/richtextborderspage.cpp:504
+#: ../src/richtext/richtextborderspage.cpp:536
+#: ../src/richtext/richtextborderspage.cpp:538
+msgid "The border line style."
+msgstr "Kiểu đường viền."
+
+#: ../src/richtext/richtextborderspage.cpp:276
+#: ../src/richtext/richtextborderspage.cpp:444
+#: ../src/richtext/richtextindentspage.cpp:212
+#: ../src/richtext/richtextliststylepage.cpp:402
+#: ../src/richtext/richtextmarginspage.cpp:210
+#: ../src/richtext/richtextmarginspage.cpp:324
+#: ../src/richtext/richtextsizepage.cpp:601
+#: ../src/richtext/richtextsizepage.cpp:608
+msgid "&Right:"
+msgstr "&Phải:"
+
+#: ../src/richtext/richtextborderspage.cpp:291
+#: ../src/richtext/richtextborderspage.cpp:293
+msgid "Units for the right border width."
+msgstr "Đơn vị cho độ rộng biên phải."
+
+#: ../src/richtext/richtextborderspage.cpp:310
+#: ../src/richtext/richtextborderspage.cpp:478
+#: ../src/richtext/richtextmarginspage.cpp:233
+#: ../src/richtext/richtextmarginspage.cpp:347
+#: ../src/richtext/richtextsizepage.cpp:566
+#: ../src/richtext/richtextsizepage.cpp:573
+msgid "&Top:"
+msgstr "&Trên:"
+
+#: ../src/richtext/richtextborderspage.cpp:325
+#: ../src/richtext/richtextborderspage.cpp:327
+msgid "Units for the top border width."
+msgstr "Đơn vị cho độ rộng biên trên."
+
+#: ../src/richtext/richtextborderspage.cpp:344
+#: ../src/richtext/richtextborderspage.cpp:512
+#: ../src/richtext/richtextmarginspage.cpp:258
+#: ../src/richtext/richtextmarginspage.cpp:372
+#: ../src/richtext/richtextsizepage.cpp:636
+#: ../src/richtext/richtextsizepage.cpp:643
+msgid "&Bottom:"
+msgstr "&Dưới đáy:"
+
+#: ../src/richtext/richtextborderspage.cpp:359
+#: ../src/richtext/richtextborderspage.cpp:361
+msgid "Units for the bottom border width."
+msgstr "Đơn vị cho độ rộng biên đáy."
+
+#: ../src/richtext/richtextborderspage.cpp:380
+#: ../src/richtext/richtextborderspage.cpp:548
+msgid "&Synchronize values"
+msgstr "Đồng &bộ hóa các giá trị"
+
+#: ../src/richtext/richtextborderspage.cpp:382
+#: ../src/richtext/richtextborderspage.cpp:384
+#: ../src/richtext/richtextborderspage.cpp:550
+#: ../src/richtext/richtextborderspage.cpp:552
+msgid "Check to edit all borders simultaneously."
+msgstr "Chọn để chỉnh sửa mọi đường viền một cách đồng thời."
+
+#: ../src/richtext/richtextborderspage.cpp:397
+#: ../src/richtext/richtextborderspage.cpp:555
+msgid "Outline"
+msgstr "Viền ngoài"
+
+#: ../src/richtext/richtextborderspage.cpp:425
+#: ../src/richtext/richtextborderspage.cpp:427
+msgid "Units for the left outline width."
+msgstr "Đơn vị cho độ rộng viền trái"
+
+#: ../src/richtext/richtextborderspage.cpp:459
+#: ../src/richtext/richtextborderspage.cpp:461
+msgid "Units for the right outline width."
+msgstr "Đơn vị cho độ rộng viền phải."
+
+#: ../src/richtext/richtextborderspage.cpp:493
+#: ../src/richtext/richtextborderspage.cpp:495
+msgid "Units for the top outline width."
+msgstr "Đơn vị cho độ rộng viền trên."
+
+#: ../src/richtext/richtextborderspage.cpp:527
+#: ../src/richtext/richtextborderspage.cpp:529
+msgid "Units for the bottom outline width."
+msgstr "Đơn vị cho độ rộng viền đáy"
+
+#: ../src/richtext/richtextborderspage.cpp:565
+#: ../src/richtext/richtextborderspage.cpp:600
+msgid "Corner"
+msgstr "Góc"
+
+#: ../src/richtext/richtextborderspage.cpp:574
+msgid "Corner &radius:"
+msgstr "Bán &kính góc:"
+
+#: ../src/richtext/richtextborderspage.cpp:576
+#: ../src/richtext/richtextborderspage.cpp:578
+msgid "An optional corner radius for adding rounded corners."
+msgstr "Bán kính góc tự chọn để thêm góc được bo tròn."
+
+#: ../src/richtext/richtextborderspage.cpp:584
+#: ../src/richtext/richtextborderspage.cpp:586
+msgid "The value of the corner radius."
+msgstr "Giá trị cho bán kính góc."
+
+#: ../src/richtext/richtextborderspage.cpp:595
+#: ../src/richtext/richtextborderspage.cpp:597
+msgid "Units for the corner radius."
+msgstr "Đơn vị cho bo tròn góc."
+
+#: ../src/richtext/richtextborderspage.cpp:609
+#: ../src/richtext/richtextsizepage.cpp:247
+#: ../src/richtext/richtextsizepage.cpp:251
+msgid "None"
+msgstr "Không"
+
+#: ../src/richtext/richtextborderspage.cpp:610
+msgid "Solid"
+msgstr "Đặc"
+
+#: ../src/richtext/richtextborderspage.cpp:611
+msgid "Dotted"
+msgstr "Chấm chấm"
+
+#: ../src/richtext/richtextborderspage.cpp:612
+msgid "Dashed"
+msgstr "Đã gạch"
+
+#: ../src/richtext/richtextborderspage.cpp:613
+msgid "Double"
+msgstr "Đôi"
+
+#: ../src/richtext/richtextborderspage.cpp:614
+msgid "Groove"
+msgstr "Khía"
+
+#: ../src/richtext/richtextborderspage.cpp:615
+msgid "Ridge"
+msgstr "Nhấp nhô"
+
+#: ../src/richtext/richtextborderspage.cpp:616
+msgid "Inset"
+msgstr "Chèn"
+
+#: ../src/richtext/richtextborderspage.cpp:617
+msgid "Outset"
+msgstr "Bắt đầu"
+
+#: ../src/richtext/richtextbuffer.cpp:3518
+msgid "Change Style"
+msgstr "Thay đổi Kiểu Dáng"
+
+#: ../src/richtext/richtextbuffer.cpp:3701
+msgid "Change Object Style"
+msgstr "Thay đổi Kiểu dáng Đối tượng"
+
+#: ../src/richtext/richtextbuffer.cpp:3974
+#: ../src/richtext/richtextbuffer.cpp:8174
+msgid "Change Properties"
+msgstr "Thay đổi các thuộc tính"
+
+#: ../src/richtext/richtextbuffer.cpp:4346
+msgid "Change List Style"
+msgstr "Thay Đổi Kiểu Dáng List"
+
+#: ../src/richtext/richtextbuffer.cpp:4519
+msgid "Renumber List"
+msgstr "Đánh số lại List"
+
+#: ../src/richtext/richtextbuffer.cpp:7867
+#: ../src/richtext/richtextbuffer.cpp:7897
+#: ../src/richtext/richtextbuffer.cpp:7939
+#: ../src/richtext/richtextctrl.cpp:1279 ../src/richtext/richtextctrl.cpp:1473
+msgid "Insert Text"
+msgstr "Chèn Chữ"
+
+#: ../src/richtext/richtextbuffer.cpp:8023
+#: ../src/richtext/richtextbuffer.cpp:8979
+msgid "Insert Image"
+msgstr "Chèn Ảnh"
+
+#: ../src/richtext/richtextbuffer.cpp:8070
+msgid "Insert Object"
+msgstr "Chèn Đối tượng"
+
+#: ../src/richtext/richtextbuffer.cpp:8112
+msgid "Insert Field"
+msgstr "Chèn trường"
+
+#: ../src/richtext/richtextbuffer.cpp:8410
+msgid "Too many EndStyle calls!"
+msgstr "Quá nhiều cú gọi EndStyle!"
+
+#: ../src/richtext/richtextbuffer.cpp:8785
+msgid "files"
+msgstr "tập tin"
+
+#: ../src/richtext/richtextbuffer.cpp:9380
+msgid "standard/circle"
+msgstr "Tiêu chuẩn/ hình tròn"
+
+#: ../src/richtext/richtextbuffer.cpp:9381
+msgid "standard/circle-outline"
+msgstr "tiêu-chuẩn/viền-tròn"
+
+#: ../src/richtext/richtextbuffer.cpp:9382
+msgid "standard/square"
+msgstr "Tiêu chuẩn/vuông"
+
+#: ../src/richtext/richtextbuffer.cpp:9383
+msgid "standard/diamond"
+msgstr "Tiêu chuẩn/Thoi"
+
+#: ../src/richtext/richtextbuffer.cpp:9384
+msgid "standard/triangle"
+msgstr "Tiêu chuẩn/chữ nhật"
+
+#: ../src/richtext/richtextbuffer.cpp:9423
+msgid "Box Properties"
+msgstr "Các tính chất Hộp"
+
+#: ../src/richtext/richtextbuffer.cpp:10006
+msgid "Multiple Cell Properties"
+msgstr "Thuộc tính Đa Ô"
+
+#: ../src/richtext/richtextbuffer.cpp:10008
+msgid "Cell Properties"
+msgstr "Các thuộc tính của ô"
+
+#: ../src/richtext/richtextbuffer.cpp:11256
+msgid "Set Cell Style"
+msgstr "Đặt Kiểu Dáng Ô"
+
+#: ../src/richtext/richtextbuffer.cpp:11330
+msgid "Delete Row"
+msgstr "Xóa hàng"
+
+#: ../src/richtext/richtextbuffer.cpp:11380
+msgid "Delete Column"
+msgstr "Xóa cột"
+
+#: ../src/richtext/richtextbuffer.cpp:11431
+msgid "Add Row"
+msgstr "Thêm hàng"
+
+#: ../src/richtext/richtextbuffer.cpp:11494
+msgid "Add Column"
+msgstr "Thêm cột"
+
+#: ../src/richtext/richtextbuffer.cpp:11537
+msgid "Table Properties"
+msgstr "Các thuộc tính Bảng"
+
+#: ../src/richtext/richtextbuffer.cpp:12899
+msgid "Picture Properties"
+msgstr "Các thuộc tính Hình ảnh"
+
+#: ../src/richtext/richtextbuffer.cpp:13169
+#: ../src/richtext/richtextbuffer.cpp:13279
+msgid "image"
+msgstr "hình ảnh"
+
+#: ../src/richtext/richtextbulletspage.cpp:145
+#: ../src/richtext/richtextliststylepage.cpp:209
+msgid "&Bullet style:"
+msgstr "Kiểu dáng &Bullet:"
+
+#: ../src/richtext/richtextbulletspage.cpp:150
+#: ../src/richtext/richtextbulletspage.cpp:152
+#: ../src/richtext/richtextliststylepage.cpp:214
+#: ../src/richtext/richtextliststylepage.cpp:216
+msgid "The available bullet styles."
+msgstr "Các kiểu dáng bullet sẵn có."
+
+#: ../src/richtext/richtextbulletspage.cpp:158
+#: ../src/richtext/richtextliststylepage.cpp:221
+msgid "Peri&od"
+msgstr "Dấu chấ&m"
+
+#: ../src/richtext/richtextbulletspage.cpp:160
+#: ../src/richtext/richtextbulletspage.cpp:162
+#: ../src/richtext/richtextliststylepage.cpp:223
+#: ../src/richtext/richtextliststylepage.cpp:225
+msgid "Check to add a period after the bullet."
+msgstr "Kiểm tra để thêm một dấu chấm sau bullet."
+
+#. TRANSLATORS: Bullet point in parentheses option
+#: ../src/richtext/richtextbulletspage.cpp:167
+#: ../src/richtext/richtextliststylepage.cpp:230
+msgid "(*)"
+msgstr "(*)"
+
+#: ../src/richtext/richtextbulletspage.cpp:169
+#: ../src/richtext/richtextbulletspage.cpp:171
+#: ../src/richtext/richtextliststylepage.cpp:232
+#: ../src/richtext/richtextliststylepage.cpp:234
+msgid "Check to enclose the bullet in parentheses."
+msgstr "Kiểm tra để bao bullet bằng dấu ngoặc đơn."
+
+#. TRANSLATORS: Right parenthesis bullet point option
+#: ../src/richtext/richtextbulletspage.cpp:176
+#: ../src/richtext/richtextliststylepage.cpp:239
+msgid "*)"
+msgstr "*)"
+
+#: ../src/richtext/richtextbulletspage.cpp:178
+#: ../src/richtext/richtextbulletspage.cpp:180
+#: ../src/richtext/richtextliststylepage.cpp:241
+#: ../src/richtext/richtextliststylepage.cpp:243
+msgid "Check to add a right parenthesis."
+msgstr "Đánh đấu kiểm để thêm dấu mở ngoặc đơn."
+
+#: ../src/richtext/richtextbulletspage.cpp:185
+#: ../src/richtext/richtextliststylepage.cpp:248
+msgid "Bullet &Alignment:"
+msgstr "&Căn lề Bullet:"
+
+#: ../src/richtext/richtextbulletspage.cpp:190
+#: ../src/richtext/richtextliststylepage.cpp:253
+msgid "Centre"
+msgstr "Chính giữa"
+
+#: ../src/richtext/richtextbulletspage.cpp:194
+#: ../src/richtext/richtextbulletspage.cpp:196
+#: ../src/richtext/richtextbulletspage.cpp:217
+#: ../src/richtext/richtextbulletspage.cpp:219
+#: ../src/richtext/richtextliststylepage.cpp:257
+#: ../src/richtext/richtextliststylepage.cpp:259
+#: ../src/richtext/richtextliststylepage.cpp:278
+#: ../src/richtext/richtextliststylepage.cpp:280
+msgid "The bullet character."
+msgstr "Ký tự dùng với bullet."
+
+#: ../src/richtext/richtextbulletspage.cpp:212
+#: ../src/richtext/richtextliststylepage.cpp:271
+msgid "&Symbol:"
+msgstr "Ký hiệu đặc &biệt:"
+
+#: ../src/richtext/richtextbulletspage.cpp:222
+#: ../src/richtext/richtextliststylepage.cpp:283
+msgid "Ch&oose..."
+msgstr "&Chọn lựa..."
+
+#: ../src/richtext/richtextbulletspage.cpp:223
+#: ../src/richtext/richtextbulletspage.cpp:225
+#: ../src/richtext/richtextliststylepage.cpp:284
+#: ../src/richtext/richtextliststylepage.cpp:286
+msgid "Click to browse for a symbol."
+msgstr "Bấm chọn để tìm duyệt ký tự đặc biệt."
+
+#: ../src/richtext/richtextbulletspage.cpp:230
+#: ../src/richtext/richtextliststylepage.cpp:291
+msgid "Symbol &font:"
+msgstr "&Phông chữ ký tự đặc biệt:"
+
+#: ../src/richtext/richtextbulletspage.cpp:235
+#: ../src/richtext/richtextbulletspage.cpp:237
+#: ../src/richtext/richtextliststylepage.cpp:297
+msgid "Available fonts."
+msgstr "Phông chữ sẵn có."
+
+#: ../src/richtext/richtextbulletspage.cpp:242
+#: ../src/richtext/richtextliststylepage.cpp:302
+msgid "S&tandard bullet name:"
+msgstr "&Tên bullet tiêu chuẩn:"
+
+#: ../src/richtext/richtextbulletspage.cpp:247
+#: ../src/richtext/richtextbulletspage.cpp:249
+#: ../src/richtext/richtextliststylepage.cpp:307
+#: ../src/richtext/richtextliststylepage.cpp:309
+msgid "A standard bullet name."
+msgstr "Một tên bullet tiêu chuẩn."
+
+#: ../src/richtext/richtextbulletspage.cpp:254
+msgid "&Number:"
+msgstr "&Số:"
+
+#: ../src/richtext/richtextbulletspage.cpp:258
+#: ../src/richtext/richtextbulletspage.cpp:260
+msgid "The list item number."
+msgstr "Số mẩu tin của danh sách."
+
+#: ../src/richtext/richtextbulletspage.cpp:266
+#: ../src/richtext/richtextbulletspage.cpp:268
+#: ../src/richtext/richtextliststylepage.cpp:475
+#: ../src/richtext/richtextliststylepage.cpp:477
+msgid "Shows a preview of the bullet settings."
+msgstr "Xem thử các cài đặt về bullet."
+
+#: ../src/richtext/richtextbulletspage.cpp:276
+#: ../src/richtext/richtextliststylepage.cpp:484
+msgid "(None)"
+msgstr "(Không)"
+
+#: ../src/richtext/richtextbulletspage.cpp:277
+#: ../src/richtext/richtextliststylepage.cpp:485
+msgid "Arabic"
+msgstr "Arabic"
+
+#: ../src/richtext/richtextbulletspage.cpp:278
+#: ../src/richtext/richtextliststylepage.cpp:486
+msgid "Upper case letters"
+msgstr "Chuyển thành chữ hoa"
+
+#: ../src/richtext/richtextbulletspage.cpp:279
+#: ../src/richtext/richtextliststylepage.cpp:487
+msgid "Lower case letters"
+msgstr "Chữ thường"
+
+#: ../src/richtext/richtextbulletspage.cpp:280
+#: ../src/richtext/richtextliststylepage.cpp:488
+msgid "Upper case roman numerals"
+msgstr "Đổi thành chữ số La Mã in hoa"
+
+#: ../src/richtext/richtextbulletspage.cpp:281
+#: ../src/richtext/richtextliststylepage.cpp:489
+msgid "Lower case roman numerals"
+msgstr "Chữ số La Mã thường"
+
+#: ../src/richtext/richtextbulletspage.cpp:282
+#: ../src/richtext/richtextliststylepage.cpp:490
+msgid "Numbered outline"
+msgstr "Số đường bao"
+
+#: ../src/richtext/richtextbulletspage.cpp:283
+#: ../src/richtext/richtextliststylepage.cpp:491
+msgid "Symbol"
+msgstr "Ký hiệu"
+
+#: ../src/richtext/richtextbulletspage.cpp:284
+#: ../src/richtext/richtextliststylepage.cpp:492
+msgid "Bitmap"
+msgstr "Ảnh mảng bitmap"
+
+#: ../src/richtext/richtextbulletspage.cpp:285
+#: ../src/richtext/richtextliststylepage.cpp:493
+msgid "Standard"
+msgstr "Tiêu chuẩn"
+
+#: ../src/richtext/richtextbulletspage.cpp:287
+#: ../src/richtext/richtextliststylepage.cpp:495
+msgid "*"
+msgstr "*"
+
+#: ../src/richtext/richtextbulletspage.cpp:288
+#: ../src/richtext/richtextliststylepage.cpp:496
+msgid "-"
+msgstr "-"
+
+#: ../src/richtext/richtextbulletspage.cpp:289
+#: ../src/richtext/richtextliststylepage.cpp:497
+msgid ">"
+msgstr ">"
+
+#: ../src/richtext/richtextbulletspage.cpp:290
+#: ../src/richtext/richtextliststylepage.cpp:498
+msgid "+"
+msgstr "+"
+
+#: ../src/richtext/richtextbulletspage.cpp:291
+#: ../src/richtext/richtextliststylepage.cpp:499
+msgid "~"
+msgstr "~"
+
+#: ../src/richtext/richtextctrl.cpp:859
+msgid "Drag"
+msgstr "Kéo"
+
+#: ../src/richtext/richtextctrl.cpp:1338 ../src/richtext/richtextctrl.cpp:1559
+msgid "Delete Text"
+msgstr "Xóa Chữ"
+
+#: ../src/richtext/richtextctrl.cpp:1537
+msgid "Remove Bullet"
+msgstr "Gỡ bỏ Bullet"
+
+#: ../src/richtext/richtextctrl.cpp:3070
+msgid "The text couldn't be saved."
+msgstr "Dữ liệu dạng chữ không thể được ghi lại."
+
+#: ../src/richtext/richtextctrl.cpp:3644
+msgid "Replace"
+msgstr "Thay thế"
+
+#: ../src/richtext/richtextfontpage.cpp:146
+#: ../src/richtext/richtextsymboldlg.cpp:384
+msgid "&Font:"
+msgstr "&Phông chữ:"
+
+#: ../src/richtext/richtextfontpage.cpp:150
+#: ../src/richtext/richtextfontpage.cpp:152
+msgid "Type a font name."
+msgstr "Gõ một tên phông chữ."
+
+#: ../src/richtext/richtextfontpage.cpp:158
+msgid "&Size:"
+msgstr "&Kích thước:"
+
+#: ../src/richtext/richtextfontpage.cpp:165
+#: ../src/richtext/richtextfontpage.cpp:167
+msgid "Type a size in points."
+msgstr "Kích thước phông chữ theo points."
+
+#: ../src/richtext/richtextfontpage.cpp:180
+#: ../src/richtext/richtextfontpage.cpp:182
+msgid "The font size units, points or pixels."
+msgstr "Các đơn vị cỡ chữ, point hay pixel."
+
+#: ../src/richtext/richtextfontpage.cpp:189
+#: ../src/richtext/richtextfontpage.cpp:191
+msgid "Lists the available fonts."
+msgstr "Danh sách phông chữ sẵn có."
+
+#: ../src/richtext/richtextfontpage.cpp:196
+#: ../src/richtext/richtextfontpage.cpp:198
+msgid "Lists font sizes in points."
+msgstr ""
+"Danh sách kích thước phông chữ bằng đơn vị point (72 point xấp xỉ bằng một "
+"inch)."
+
+#: ../src/richtext/richtextfontpage.cpp:207
+msgid "Font st&yle:"
+msgstr "Kiể&u dáng phông chữ:"
+
+#: ../src/richtext/richtextfontpage.cpp:212
+#: ../src/richtext/richtextfontpage.cpp:214
+msgid "Select regular or italic style."
+msgstr "Chọn kiểu dáng thông thường hay nghiêng."
+
+#: ../src/richtext/richtextfontpage.cpp:220
+msgid "Font &weight:"
+msgstr "Độ đậm phông &chữ"
+
+#: ../src/richtext/richtextfontpage.cpp:225
+#: ../src/richtext/richtextfontpage.cpp:227
+msgid "Select regular or bold."
+msgstr "Chọn kiểu thường hay đậm."
+
+#: ../src/richtext/richtextfontpage.cpp:233
+msgid "&Underlining:"
+msgstr "&Gạch chân:"
+
+#: ../src/richtext/richtextfontpage.cpp:238
+#: ../src/richtext/richtextfontpage.cpp:240
+msgid "Select underlining or no underlining."
+msgstr "Chọn có gạch dưới hay không có gạch dưới."
+
+#: ../src/richtext/richtextfontpage.cpp:248
+msgid "&Colour:"
+msgstr "&Màu sắc:"
+
+#: ../src/richtext/richtextfontpage.cpp:253
+#: ../src/richtext/richtextfontpage.cpp:255
+msgid "Click to change the text colour."
+msgstr "Bấm vào để thay đổi màu của chữ."
+
+#: ../src/richtext/richtextfontpage.cpp:261
+msgid "&Bg colour:"
+msgstr "Màu &nền:"
+
+#: ../src/richtext/richtextfontpage.cpp:266
+#: ../src/richtext/richtextfontpage.cpp:268
+msgid "Click to change the text background colour."
+msgstr "Bấm vào để thay đổi màu nền của chữ."
+
+#: ../src/richtext/richtextfontpage.cpp:276
+#: ../src/richtext/richtextfontpage.cpp:278
+msgid "Check to show a line through the text."
+msgstr "Đánh dấu kiểm để chữ bị gạch ngang."
+
+#: ../src/richtext/richtextfontpage.cpp:281
+msgid "Ca&pitals"
+msgstr "Chữ viết &hoa"
+
+#: ../src/richtext/richtextfontpage.cpp:283
+#: ../src/richtext/richtextfontpage.cpp:285
+msgid "Check to show the text in capitals."
+msgstr "Đánh dấu kiểm để chữ được viết hoa."
+
+#: ../src/richtext/richtextfontpage.cpp:288
+msgid "Small C&apitals"
+msgstr "Chữ viết &Hoa nhỏ"
+
+#: ../src/richtext/richtextfontpage.cpp:290
+#: ../src/richtext/richtextfontpage.cpp:292
+msgid "Check to show the text in small capitals."
+msgstr "Đánh dấu kiểm để chữ được viết HOA nhưng dạng nhỏ hơn."
+
+#: ../src/richtext/richtextfontpage.cpp:295
+msgid "Supe&rscript"
+msgstr "Chỉ số t&rên dòng"
+
+#: ../src/richtext/richtextfontpage.cpp:297
+#: ../src/richtext/richtextfontpage.cpp:299
+msgid "Check to show the text in superscript."
+msgstr "Đánh dấu kiểm để chữ đẩy lên."
+
+#: ../src/richtext/richtextfontpage.cpp:302
+msgid "Subscrip&t"
+msgstr "Chỉ số dưới &dòng"
+
+#: ../src/richtext/richtextfontpage.cpp:304
+#: ../src/richtext/richtextfontpage.cpp:306
+msgid "Check to show the text in subscript."
+msgstr "Đánh dấu kiểm để chữ thụt xuống."
+
+#: ../src/richtext/richtextfontpage.cpp:312
+msgid "Rig&ht-to-left"
+msgstr "P&hải-sang-trái"
+
+#: ../src/richtext/richtextfontpage.cpp:314
+#: ../src/richtext/richtextfontpage.cpp:316
+msgid "Check to indicate right-to-left text layout."
+msgstr "Bấm chọn để bố trí chữ từ phải sang trái."
+
+#: ../src/richtext/richtextfontpage.cpp:319
+msgid "Suppress hyphe&nation"
+msgstr "Cấm tá&ch từ"
+
+#: ../src/richtext/richtextfontpage.cpp:321
+#: ../src/richtext/richtextfontpage.cpp:323
+msgid "Check to suppress hyphenation."
+msgstr "Kiểm tra để cấm tách từ."
+
+#: ../src/richtext/richtextfontpage.cpp:329
+#: ../src/richtext/richtextfontpage.cpp:331
+msgid "Shows a preview of the font settings."
+msgstr "Xem thử các cài đặt về phông chữ."
+
+#: ../src/richtext/richtextfontpage.cpp:348
+#: ../src/richtext/richtextfontpage.cpp:352
+#: ../src/richtext/richtextfontpage.cpp:356
+#: ../src/richtext/richtextformatdlg.cpp:873
+#: ../src/richtext/richtextindentspage.cpp:273
+#: ../src/richtext/richtextindentspage.cpp:285
+#: ../src/richtext/richtextindentspage.cpp:286
+#: ../src/richtext/richtextindentspage.cpp:310
+#: ../src/richtext/richtextindentspage.cpp:325
+#: ../src/richtext/richtextliststylepage.cpp:451
+#: ../src/richtext/richtextliststylepage.cpp:463
+#: ../src/richtext/richtextliststylepage.cpp:464
+msgid "(none)"
+msgstr "(không)"
+
+#: ../src/richtext/richtextfontpage.cpp:349
+#: ../src/richtext/richtextfontpage.cpp:353
+msgid "Regular"
+msgstr "Thông thường"
+
+#: ../src/richtext/richtextfontpage.cpp:357
+msgid "Not underlined"
+msgstr "Không gạch chân"
+
+#: ../src/richtext/richtextformatdlg.cpp:341
+msgid "Indents && Spacing"
+msgstr "Thụt lề && Khoảng Trắng"
+
+#: ../src/richtext/richtextformatdlg.cpp:346
+msgid "Tabs"
+msgstr "Tabs"
+
+#: ../src/richtext/richtextformatdlg.cpp:351
+msgid "Bullets"
+msgstr "Bullets"
+
+#: ../src/richtext/richtextformatdlg.cpp:356
+msgid "List Style"
+msgstr "Kiểu dáng Danh sách"
+
+#: ../src/richtext/richtextformatdlg.cpp:366
+#: ../src/richtext/richtextmarginspage.cpp:170
+msgid "Margins"
+msgstr "Lề"
+
+#: ../src/richtext/richtextformatdlg.cpp:371
+msgid "Borders"
+msgstr "Viền mép"
+
+#: ../src/richtext/richtextformatdlg.cpp:765
+msgid "Colour"
+msgstr "Màu sắc"
+
+#: ../src/richtext/richtextindentspage.cpp:127
+#: ../src/richtext/richtextliststylepage.cpp:322
+msgid "&Alignment"
+msgstr "C&anh hàng"
+
+#: ../src/richtext/richtextindentspage.cpp:138
+#: ../src/richtext/richtextliststylepage.cpp:331
+msgid "&Left"
+msgstr "&Bên trái"
+
+#: ../src/richtext/richtextindentspage.cpp:140
+#: ../src/richtext/richtextindentspage.cpp:142
+#: ../src/richtext/richtextliststylepage.cpp:333
+#: ../src/richtext/richtextliststylepage.cpp:335
+msgid "Left-align text."
+msgstr "Canh lề cạnh bên trái chữ."
+
+#: ../src/richtext/richtextindentspage.cpp:145
+#: ../src/richtext/richtextliststylepage.cpp:338
+msgid "&Right"
+msgstr "&Phải"
+
+#: ../src/richtext/richtextindentspage.cpp:147
+#: ../src/richtext/richtextindentspage.cpp:149
+#: ../src/richtext/richtextliststylepage.cpp:340
+#: ../src/richtext/richtextliststylepage.cpp:342
+msgid "Right-align text."
+msgstr "Canh lề chữ phải."
+
+#: ../src/richtext/richtextindentspage.cpp:152
+#: ../src/richtext/richtextliststylepage.cpp:345
+msgid "&Justified"
+msgstr "Căn chỉn&h"
+
+#: ../src/richtext/richtextindentspage.cpp:154
+#: ../src/richtext/richtextindentspage.cpp:156
+#: ../src/richtext/richtextliststylepage.cpp:347
+#: ../src/richtext/richtextliststylepage.cpp:349
+msgid "Justify text left and right."
+msgstr "Xắp xếp chữ canh lề trái và phải."
+
+#: ../src/richtext/richtextindentspage.cpp:159
+#: ../src/richtext/richtextliststylepage.cpp:352
+msgid "Cen&tred"
+msgstr "&Trung tâm"
+
+#: ../src/richtext/richtextindentspage.cpp:161
+#: ../src/richtext/richtextindentspage.cpp:163
+#: ../src/richtext/richtextliststylepage.cpp:354
+#: ../src/richtext/richtextliststylepage.cpp:356
+msgid "Centre text."
+msgstr "Chữ ở chính giữa."
+
+#: ../src/richtext/richtextindentspage.cpp:166
+#: ../src/richtext/richtextliststylepage.cpp:359
+msgid "&Indeterminate"
+msgstr "&Vô định"
+
+#: ../src/richtext/richtextindentspage.cpp:168
+#: ../src/richtext/richtextindentspage.cpp:170
+#: ../src/richtext/richtextliststylepage.cpp:361
+#: ../src/richtext/richtextliststylepage.cpp:363
+msgid "Use the current alignment setting."
+msgstr "Sử dụng cài đặt về căn chỉnh hiện hành."
+
+#: ../src/richtext/richtextindentspage.cpp:183
+#: ../src/richtext/richtextliststylepage.cpp:375
+msgid "&Indentation (tenths of a mm)"
+msgstr "Thụt lề dòng đầu(mỗ&i mười mm)"
+
+#: ../src/richtext/richtextindentspage.cpp:198
+#: ../src/richtext/richtextindentspage.cpp:200
+#: ../src/richtext/richtextliststylepage.cpp:388
+#: ../src/richtext/richtextliststylepage.cpp:390
+msgid "The left indent."
+msgstr "Thụt lề trái."
+
+#: ../src/richtext/richtextindentspage.cpp:203
+#: ../src/richtext/richtextliststylepage.cpp:393
+msgid "Left (&first line):"
+msgstr "Bên trái (dòng đầ&u):"
+
+#: ../src/richtext/richtextindentspage.cpp:207
+#: ../src/richtext/richtextindentspage.cpp:209
+#: ../src/richtext/richtextliststylepage.cpp:397
+#: ../src/richtext/richtextliststylepage.cpp:399
+msgid "The first line indent."
+msgstr "Thụt lề dòng đầu tiên."
+
+#: ../src/richtext/richtextindentspage.cpp:216
+#: ../src/richtext/richtextindentspage.cpp:218
+#: ../src/richtext/richtextliststylepage.cpp:406
+#: ../src/richtext/richtextliststylepage.cpp:408
+msgid "The right indent."
+msgstr "Thụt lề phải."
+
+#: ../src/richtext/richtextindentspage.cpp:221
+msgid "&Outline level:"
+msgstr "Mức đường ba&o:"
+
+#: ../src/richtext/richtextindentspage.cpp:226
+#: ../src/richtext/richtextindentspage.cpp:228
+msgid "The outline level."
+msgstr "Mức đường bao."
+
+#: ../src/richtext/richtextindentspage.cpp:241
+#: ../src/richtext/richtextliststylepage.cpp:420
+msgid "&Spacing (tenths of a mm)"
+msgstr "&Khoảng cách chữ (mỗi 10mm)"
+
+#: ../src/richtext/richtextindentspage.cpp:252
+msgid "&Before a paragraph:"
+msgstr "T&rước một đoạn văn:"
+
+#: ../src/richtext/richtextindentspage.cpp:256
+#: ../src/richtext/richtextindentspage.cpp:258
+#: ../src/richtext/richtextliststylepage.cpp:433
+#: ../src/richtext/richtextliststylepage.cpp:435
+msgid "The spacing before the paragraph."
+msgstr "Khoảng trắng trước một đoạn văn."
+
+#: ../src/richtext/richtextindentspage.cpp:261
+msgid "&After a paragraph:"
+msgstr "S&au một đoạn văn:"
+
+#: ../src/richtext/richtextindentspage.cpp:266
+#: ../src/richtext/richtextliststylepage.cpp:442
+#: ../src/richtext/richtextliststylepage.cpp:444
+msgid "The spacing after the paragraph."
+msgstr "Khoảng trắng sau một đoạn văn."
+
+#: ../src/richtext/richtextindentspage.cpp:269
+msgid "L&ine spacing:"
+msgstr "Khoảng cách &dòng:"
+
+#: ../src/richtext/richtextindentspage.cpp:274
+#: ../src/richtext/richtextliststylepage.cpp:452
+msgid "Single"
+msgstr "Đơn"
+
+#: ../src/richtext/richtextindentspage.cpp:275
+#: ../src/richtext/richtextliststylepage.cpp:453
+msgid "1.1"
+msgstr "1.1"
+
+#: ../src/richtext/richtextindentspage.cpp:276
+#: ../src/richtext/richtextliststylepage.cpp:454
+msgid "1.2"
+msgstr "1.2"
+
+#: ../src/richtext/richtextindentspage.cpp:277
+#: ../src/richtext/richtextliststylepage.cpp:455
+msgid "1.3"
+msgstr "1.3"
+
+#: ../src/richtext/richtextindentspage.cpp:278
+#: ../src/richtext/richtextliststylepage.cpp:456
+msgid "1.4"
+msgstr "1.4"
+
+#: ../src/richtext/richtextindentspage.cpp:279
+#: ../src/richtext/richtextliststylepage.cpp:457
+msgid "1.5"
+msgstr "1.5"
+
+#: ../src/richtext/richtextindentspage.cpp:280
+#: ../src/richtext/richtextliststylepage.cpp:458
+msgid "1.6"
+msgstr "1.6"
+
+#: ../src/richtext/richtextindentspage.cpp:281
+#: ../src/richtext/richtextliststylepage.cpp:459
+msgid "1.7"
+msgstr "1.7"
+
+#: ../src/richtext/richtextindentspage.cpp:282
+#: ../src/richtext/richtextliststylepage.cpp:460
+msgid "1.8"
+msgstr "1.8"
+
+#: ../src/richtext/richtextindentspage.cpp:283
+#: ../src/richtext/richtextliststylepage.cpp:461
+msgid "1.9"
+msgstr "1.9"
+
+#: ../src/richtext/richtextindentspage.cpp:284
+#: ../src/richtext/richtextliststylepage.cpp:462
+msgid "2"
+msgstr "2"
+
+#: ../src/richtext/richtextindentspage.cpp:287
+#: ../src/richtext/richtextindentspage.cpp:289
+#: ../src/richtext/richtextliststylepage.cpp:465
+#: ../src/richtext/richtextliststylepage.cpp:467
+msgid "The line spacing."
+msgstr "Chỉnh khoảng cách dòng."
+
+#: ../src/richtext/richtextindentspage.cpp:292
+msgid "&Page Break"
+msgstr "Ngắt T&rang"
+
+#: ../src/richtext/richtextindentspage.cpp:294
+#: ../src/richtext/richtextindentspage.cpp:296
+msgid "Inserts a page break before the paragraph."
+msgstr "Chèn ngắt trang trước một đoạn văn."
+
+#: ../src/richtext/richtextindentspage.cpp:302
+#: ../src/richtext/richtextindentspage.cpp:304
+msgid "Shows a preview of the paragraph settings."
+msgstr "Xem thử cài đặt về đoạn văn."
+
+#: ../src/richtext/richtextliststylepage.cpp:182
+msgid "&List level:"
+msgstr "&Mức danh sách:"
+
+#: ../src/richtext/richtextliststylepage.cpp:186
+#: ../src/richtext/richtextliststylepage.cpp:188
+msgid "Selects the list level to edit."
+msgstr "Chọn mức danh sách muốn chỉnh sửa."
+
+#: ../src/richtext/richtextliststylepage.cpp:193
+msgid "&Font for Level..."
+msgstr "&Phông chữ cho Mức..."
+
+#: ../src/richtext/richtextliststylepage.cpp:194
+#: ../src/richtext/richtextliststylepage.cpp:196
+msgid "Click to choose the font for this level."
+msgstr "Bấm vào để chọn phông chữ cho mức này."
+
+#: ../src/richtext/richtextliststylepage.cpp:312
+msgid "Bullet style"
+msgstr "Kiểu dáng bullet"
+
+#: ../src/richtext/richtextliststylepage.cpp:429
+msgid "Before a paragraph:"
+msgstr "Phía trước đoạn văn:"
+
+#: ../src/richtext/richtextliststylepage.cpp:438
+msgid "After a paragraph:"
+msgstr "Sau một đoạn văn:"
+
+#: ../src/richtext/richtextliststylepage.cpp:447
+msgid "Line spacing:"
+msgstr "Khoảng cách dòng:"
+
+#: ../src/richtext/richtextliststylepage.cpp:470
+msgid "Spacing"
+msgstr "Khoảng cách"
+
+#: ../src/richtext/richtextmarginspage.cpp:193
+#: ../src/richtext/richtextmarginspage.cpp:195
+msgid "The left margin size."
+msgstr "Kích thước lề trái."
+
+#: ../src/richtext/richtextmarginspage.cpp:203
+#: ../src/richtext/richtextmarginspage.cpp:205
+msgid "Units for the left margin."
+msgstr "Đơn vị cho lề trái."
+
+#: ../src/richtext/richtextmarginspage.cpp:218
+#: ../src/richtext/richtextmarginspage.cpp:220
+msgid "The right margin size."
+msgstr "Kích thước lề phải."
+
+#: ../src/richtext/richtextmarginspage.cpp:228
+#: ../src/richtext/richtextmarginspage.cpp:230
+msgid "Units for the right margin."
+msgstr "Đơn vị cho lề phải."
+
+#: ../src/richtext/richtextmarginspage.cpp:241
+#: ../src/richtext/richtextmarginspage.cpp:243
+msgid "The top margin size."
+msgstr "Kích thước lề trên."
+
+#: ../src/richtext/richtextmarginspage.cpp:251
+#: ../src/richtext/richtextmarginspage.cpp:253
+msgid "Units for the top margin."
+msgstr "Đơn vị cho lề trên."
+
+#: ../src/richtext/richtextmarginspage.cpp:266
+#: ../src/richtext/richtextmarginspage.cpp:268
+msgid "The bottom margin size."
+msgstr "Kích thước lề dưới đáy."
+
+#: ../src/richtext/richtextmarginspage.cpp:276
+#: ../src/richtext/richtextmarginspage.cpp:278
+msgid "Units for the bottom margin."
+msgstr "Đơn vị cho lề đáy."
+
+#: ../src/richtext/richtextmarginspage.cpp:284
+msgid "Padding"
+msgstr "Đệm"
+
+#: ../src/richtext/richtextmarginspage.cpp:307
+#: ../src/richtext/richtextmarginspage.cpp:309
+msgid "The left padding size."
+msgstr "Kích thước đệm bên trái."
+
+#: ../src/richtext/richtextmarginspage.cpp:317
+#: ../src/richtext/richtextmarginspage.cpp:319
+msgid "Units for the left padding."
+msgstr "Đơn vị cho đệm trái."
+
+#: ../src/richtext/richtextmarginspage.cpp:332
+#: ../src/richtext/richtextmarginspage.cpp:334
+msgid "The right padding size."
+msgstr "Kích thứoc đệm bên phải."
+
+#: ../src/richtext/richtextmarginspage.cpp:342
+#: ../src/richtext/richtextmarginspage.cpp:344
+msgid "Units for the right padding."
+msgstr "Đơn vị cho đệm phải."
+
+#: ../src/richtext/richtextmarginspage.cpp:355
+#: ../src/richtext/richtextmarginspage.cpp:357
+msgid "The top padding size."
+msgstr "Kích thước đệm trên."
+
+#: ../src/richtext/richtextmarginspage.cpp:365
+#: ../src/richtext/richtextmarginspage.cpp:367
+msgid "Units for the top padding."
+msgstr "Đơn vị cho đệm trên."
+
+#: ../src/richtext/richtextmarginspage.cpp:380
+#: ../src/richtext/richtextmarginspage.cpp:382
+msgid "The bottom padding size."
+msgstr "Kích thước đệm dưới đáy."
+
+#: ../src/richtext/richtextmarginspage.cpp:390
+#: ../src/richtext/richtextmarginspage.cpp:392
+msgid "Units for the bottom padding."
+msgstr "Đơn vị cho đệm đáy."
+
+#: ../src/richtext/richtextprint.cpp:592
+msgid " Preview"
+msgstr " Xem trước"
+
+#: ../src/richtext/richtextsizepage.cpp:228
+msgid "Floating"
+msgstr "Trôi nổi"
+
+#: ../src/richtext/richtextsizepage.cpp:243
+msgid "&Floating mode:"
+msgstr "&Chế độ trôi nổi:"
+
+#: ../src/richtext/richtextsizepage.cpp:252
+#: ../src/richtext/richtextsizepage.cpp:254
+msgid "How the object will float relative to the text."
+msgstr "Để thấy đối tượng sẽ trôi nổi liên quan đến chữ."
+
+#: ../src/richtext/richtextsizepage.cpp:265
+msgid "Alignment"
+msgstr "C&anh hàng"
+
+#: ../src/richtext/richtextsizepage.cpp:277
+msgid "&Vertical alignment:"
+msgstr "&Căn chiều ngang:"
+
+#: ../src/richtext/richtextsizepage.cpp:279
+#: ../src/richtext/richtextsizepage.cpp:281
+msgid "Enable vertical alignment."
+msgstr "Cho phép xắp hàng theo chiều dọc."
+
+#: ../src/richtext/richtextsizepage.cpp:286
+msgid "Centred"
+msgstr "Trung tâm"
+
+#: ../src/richtext/richtextsizepage.cpp:290
+#: ../src/richtext/richtextsizepage.cpp:292
+msgid "Vertical alignment."
+msgstr "Căn lề dọc."
+
+#: ../src/richtext/richtextsizepage.cpp:316
+#: ../src/richtext/richtextsizepage.cpp:323
+msgid "&Width:"
+msgstr "&Rộng"
+
+#: ../src/richtext/richtextsizepage.cpp:318
+#: ../src/richtext/richtextsizepage.cpp:320
+msgid "Enable the width value."
+msgstr "Cho phép giá trị độ rộng."
+
+#: ../src/richtext/richtextsizepage.cpp:331
+#: ../src/richtext/richtextsizepage.cpp:333
+msgid "The object width."
+msgstr "Độ rộng đối tượng"
+
+#: ../src/richtext/richtextsizepage.cpp:342
+#: ../src/richtext/richtextsizepage.cpp:344
+msgid "Units for the object width."
+msgstr "Đơn vị cho độ rộng đối tượng."
+
+#: ../src/richtext/richtextsizepage.cpp:350
+#: ../src/richtext/richtextsizepage.cpp:357
+msgid "&Height:"
+msgstr "&Cao:"
+
+#: ../src/richtext/richtextsizepage.cpp:352
+#: ../src/richtext/richtextsizepage.cpp:354
+#: ../src/richtext/richtextsizepage.cpp:464
+#: ../src/richtext/richtextsizepage.cpp:466
+msgid "Enable the height value."
+msgstr "Cho phép giá trị cao."
+
+#: ../src/richtext/richtextsizepage.cpp:365
+#: ../src/richtext/richtextsizepage.cpp:367
+msgid "The object height."
+msgstr "Độ cao đối tượng."
+
+#: ../src/richtext/richtextsizepage.cpp:376
+#: ../src/richtext/richtextsizepage.cpp:378
+msgid "Units for the object height."
+msgstr "Đơn vị cho độ cao đối tượng."
+
+#: ../src/richtext/richtextsizepage.cpp:381
+msgid "Min width:"
+msgstr "Chiều rộng tối thiểu:"
+
+#: ../src/richtext/richtextsizepage.cpp:383
+#: ../src/richtext/richtextsizepage.cpp:385
+msgid "Enable the minimum width value."
+msgstr "Cho phép giá trị độ rộng tối thiểu."
+
+#: ../src/richtext/richtextsizepage.cpp:392
+#: ../src/richtext/richtextsizepage.cpp:394
+msgid "The object minimum width."
+msgstr "Độ rộng đối tượng tối thiểu."
+
+#: ../src/richtext/richtextsizepage.cpp:403
+#: ../src/richtext/richtextsizepage.cpp:405
+msgid "Units for the minimum object width."
+msgstr "Đơn vị cho độ rộng đối tượng tối thiểu."
+
+#: ../src/richtext/richtextsizepage.cpp:408
+msgid "Min height:"
+msgstr "Độ cao tối thiểu:"
+
+#: ../src/richtext/richtextsizepage.cpp:410
+#: ../src/richtext/richtextsizepage.cpp:412
+msgid "Enable the minimum height value."
+msgstr "Cho phép giá trị cao tối đa"
+
+#: ../src/richtext/richtextsizepage.cpp:419
+#: ../src/richtext/richtextsizepage.cpp:421
+msgid "The object minimum height."
+msgstr "Độ cao đối tượng tối thiểu."
+
+#: ../src/richtext/richtextsizepage.cpp:430
+#: ../src/richtext/richtextsizepage.cpp:432
+msgid "Units for the minimum object height."
+msgstr "Đơn vị cho độ cao đối tượng tối thiểu."
+
+#: ../src/richtext/richtextsizepage.cpp:435
+msgid "Max width:"
+msgstr "Chiều rộng tối đa:"
+
+#: ../src/richtext/richtextsizepage.cpp:437
+#: ../src/richtext/richtextsizepage.cpp:439
+msgid "Enable the maximum width value."
+msgstr "Cho phép giá trị độ rộng tối đa."
+
+#: ../src/richtext/richtextsizepage.cpp:446
+#: ../src/richtext/richtextsizepage.cpp:448
+msgid "The object maximum width."
+msgstr "Độ rộng đối tượng tối đa."
+
+#: ../src/richtext/richtextsizepage.cpp:457
+#: ../src/richtext/richtextsizepage.cpp:459
+msgid "Units for the maximum object width."
+msgstr "Đơn vị cho độ rộng đối tượng tối đa."
+
+#: ../src/richtext/richtextsizepage.cpp:462
+msgid "Max height:"
+msgstr "Độ cao tối đa:"
+
+#: ../src/richtext/richtextsizepage.cpp:473
+#: ../src/richtext/richtextsizepage.cpp:475
+msgid "The object maximum height."
+msgstr "Độ cao đối tượng tối đa."
+
+#: ../src/richtext/richtextsizepage.cpp:484
+#: ../src/richtext/richtextsizepage.cpp:486
+msgid "Units for the maximum object height."
+msgstr "Đơn vị cho độ cao đối tượng tối đa."
+
+#: ../src/richtext/richtextsizepage.cpp:495
+msgid "Position"
+msgstr "Vị trí"
+
+#: ../src/richtext/richtextsizepage.cpp:513
+msgid "&Position mode:"
+msgstr "&Chế độ vị trí:"
+
+#: ../src/richtext/richtextsizepage.cpp:517
+#: ../src/richtext/richtextsizepage.cpp:522
+msgid "Static"
+msgstr "Thống kê"
+
+#: ../src/richtext/richtextsizepage.cpp:518
+msgid "Relative"
+msgstr "Tương đối"
+
+#: ../src/richtext/richtextsizepage.cpp:519
+msgid "Absolute"
+msgstr "Tuyệt đối"
+
+#: ../src/richtext/richtextsizepage.cpp:520
+msgid "Fixed"
+msgstr "Cố định"
+
+#: ../src/richtext/richtextsizepage.cpp:533
+#: ../src/richtext/richtextsizepage.cpp:535
+#: ../src/richtext/richtextsizepage.cpp:547
+#: ../src/richtext/richtextsizepage.cpp:549
+msgid "The left position."
+msgstr "Vị trí trái."
+
+#: ../src/richtext/richtextsizepage.cpp:558
+#: ../src/richtext/richtextsizepage.cpp:560
+msgid "Units for the left position."
+msgstr "Đơn vị cho vị trí trái."
+
+#: ../src/richtext/richtextsizepage.cpp:568
+#: ../src/richtext/richtextsizepage.cpp:570
+#: ../src/richtext/richtextsizepage.cpp:582
+#: ../src/richtext/richtextsizepage.cpp:584
+msgid "The top position."
+msgstr "Vị trí trên cùng."
+
+#: ../src/richtext/richtextsizepage.cpp:593
+#: ../src/richtext/richtextsizepage.cpp:595
+msgid "Units for the top position."
+msgstr "Đơn vị cho vị trí trên."
+
+#: ../src/richtext/richtextsizepage.cpp:603
+#: ../src/richtext/richtextsizepage.cpp:605
+#: ../src/richtext/richtextsizepage.cpp:617
+#: ../src/richtext/richtextsizepage.cpp:619
+msgid "The right position."
+msgstr "Vị trí phải."
+
+#: ../src/richtext/richtextsizepage.cpp:628
+#: ../src/richtext/richtextsizepage.cpp:630
+msgid "Units for the right position."
+msgstr "Đơn vị cho vị trí phải."
+
+#: ../src/richtext/richtextsizepage.cpp:638
+#: ../src/richtext/richtextsizepage.cpp:640
+#: ../src/richtext/richtextsizepage.cpp:652
+#: ../src/richtext/richtextsizepage.cpp:654
+msgid "The bottom position."
+msgstr "Vị trí đáy."
+
+#: ../src/richtext/richtextsizepage.cpp:663
+#: ../src/richtext/richtextsizepage.cpp:665
+msgid "Units for the bottom position."
+msgstr "Đơn vị cho vị trí đáy."
+
+#: ../src/richtext/richtextsizepage.cpp:671
+msgid "&Move the object to:"
+msgstr "&Di chuyển đối tượng tới:"
+
+#: ../src/richtext/richtextsizepage.cpp:674
+msgid "&Previous Paragraph"
+msgstr "Đoạn T&rước"
+
+#: ../src/richtext/richtextsizepage.cpp:675
+#: ../src/richtext/richtextsizepage.cpp:677
+msgid "Moves the object to the previous paragraph."
+msgstr "Di chuyển đối tượng đến đoạn trước đây."
+
+#: ../src/richtext/richtextsizepage.cpp:680
+msgid "&Next Paragraph"
+msgstr "Đoạn Tiế&p"
+
+#: ../src/richtext/richtextsizepage.cpp:681
+#: ../src/richtext/richtextsizepage.cpp:683
+msgid "Moves the object to the next paragraph."
+msgstr "Di chuyển đối tượng đến đoạn tiếp theo."
+
+#: ../src/richtext/richtextstyledlg.cpp:193
+msgid "&Styles:"
+msgstr "&Kiểu dáng:"
+
+#: ../src/richtext/richtextstyledlg.cpp:197
+#: ../src/richtext/richtextstyledlg.cpp:199
+msgid "The available styles."
+msgstr "Các kiểu dáng sẵn có."
+
+#: ../src/richtext/richtextstyledlg.cpp:205
+#: ../src/richtext/richtextstyledlg.cpp:217
+msgid " "
+msgstr " "
+
+#: ../src/richtext/richtextstyledlg.cpp:209
+#: ../src/richtext/richtextstyledlg.cpp:211
+msgid "The style preview."
+msgstr "Xem thử kiểu dáng."
+
+#: ../src/richtext/richtextstyledlg.cpp:220
+msgid "New &Character Style..."
+msgstr "Kiểu Dáng Ký &Tự mới..."
+
+#: ../src/richtext/richtextstyledlg.cpp:221
+#: ../src/richtext/richtextstyledlg.cpp:223
+msgid "Click to create a new character style."
+msgstr "Bấm vào để tạo kiểu dáng ký tự mới."
+
+#: ../src/richtext/richtextstyledlg.cpp:226
+msgid "New &Paragraph Style..."
+msgstr "Kiểu Dáng Đ&oạn mới..."
+
+#: ../src/richtext/richtextstyledlg.cpp:227
+#: ../src/richtext/richtextstyledlg.cpp:229
+msgid "Click to create a new paragraph style."
+msgstr "Bấm vào để tạo một kiểu dáng đoạn văn mới."
+
+#: ../src/richtext/richtextstyledlg.cpp:232
+msgid "New &List Style..."
+msgstr "&List Style mới..."
+
+#: ../src/richtext/richtextstyledlg.cpp:233
+#: ../src/richtext/richtextstyledlg.cpp:235
+msgid "Click to create a new list style."
+msgstr "Bấm vào để tạo kiểu dáng danh sách mới."
+
+#: ../src/richtext/richtextstyledlg.cpp:238
+msgid "New &Box Style..."
+msgstr "Kiểu Dáng &Hộp mới..."
+
+#: ../src/richtext/richtextstyledlg.cpp:239
+#: ../src/richtext/richtextstyledlg.cpp:241
+msgid "Click to create a new box style."
+msgstr "Bấm vào để tạo kiểu dáng ký hộp mới."
+
+#: ../src/richtext/richtextstyledlg.cpp:246
+msgid "&Apply Style"
+msgstr "Á&p dụng Kiểu Dáng"
+
+#: ../src/richtext/richtextstyledlg.cpp:247
+#: ../src/richtext/richtextstyledlg.cpp:249
+msgid "Click to apply the selected style."
+msgstr "Bấm vào để chấp nhận kiểu dáng đã chọn."
+
+#: ../src/richtext/richtextstyledlg.cpp:252
+msgid "&Rename Style..."
+msgstr "Đổ&i tên Kiểu Dáng..."
+
+#: ../src/richtext/richtextstyledlg.cpp:253
+#: ../src/richtext/richtextstyledlg.cpp:255
+msgid "Click to rename the selected style."
+msgstr "Bấm vào để đổi tên kiểu dáng đã chọn."
+
+#: ../src/richtext/richtextstyledlg.cpp:258
+msgid "&Edit Style..."
+msgstr "&Hiệu Chỉnh Kiểu Dáng..."
+
+#: ../src/richtext/richtextstyledlg.cpp:259
+#: ../src/richtext/richtextstyledlg.cpp:261
+msgid "Click to edit the selected style."
+msgstr "Bấm vào để biên tập kiểu dáng đã chọn."
+
+#: ../src/richtext/richtextstyledlg.cpp:264
+msgid "&Delete Style..."
+msgstr "&Xóa Kiểu Dáng..."
+
+#: ../src/richtext/richtextstyledlg.cpp:265
+#: ../src/richtext/richtextstyledlg.cpp:267
+msgid "Click to delete the selected style."
+msgstr "Bấm vào để xóa kiểu dáng đã chọn."
+
+#: ../src/richtext/richtextstyledlg.cpp:274
+#: ../src/richtext/richtextstyledlg.cpp:276
+msgid "Click to close this window."
+msgstr "Bấm vào để đóng cửa sổ này."
+
+#: ../src/richtext/richtextstyledlg.cpp:282
+msgid "&Restart numbering"
+msgstr "&Khởi động lại sự đánh số"
+
+#: ../src/richtext/richtextstyledlg.cpp:284
+#: ../src/richtext/richtextstyledlg.cpp:286
+msgid "Check to restart numbering."
+msgstr "Đánh đấu kiểm để bắt đầu đánh số."
+
+#: ../src/richtext/richtextstyledlg.cpp:601
+msgid "Enter a character style name"
+msgstr "Nhập vào tên kiểu dáng ký tự"
+
+#: ../src/richtext/richtextstyledlg.cpp:601
+#: ../src/richtext/richtextstyledlg.cpp:606
+#: ../src/richtext/richtextstyledlg.cpp:649
+#: ../src/richtext/richtextstyledlg.cpp:654
+#: ../src/richtext/richtextstyledlg.cpp:815
+#: ../src/richtext/richtextstyledlg.cpp:820
+#: ../src/richtext/richtextstyledlg.cpp:888
+#: ../src/richtext/richtextstyledlg.cpp:896
+#: ../src/richtext/richtextstyledlg.cpp:929
+#: ../src/richtext/richtextstyledlg.cpp:934
+msgid "New Style"
+msgstr "Kiểu dáng Mới"
+
+#: ../src/richtext/richtextstyledlg.cpp:606
+#: ../src/richtext/richtextstyledlg.cpp:654
+#: ../src/richtext/richtextstyledlg.cpp:820
+#: ../src/richtext/richtextstyledlg.cpp:896
+#: ../src/richtext/richtextstyledlg.cpp:934
+msgid "Sorry, that name is taken. Please choose another."
+msgstr "Rất tiếc, tên đó đã được dùng. Xin hãy chọn một cái khác."
+
+#: ../src/richtext/richtextstyledlg.cpp:649
+msgid "Enter a paragraph style name"
+msgstr "Nhập vào tên kiểu dáng đoạn văn"
+
+#: ../src/richtext/richtextstyledlg.cpp:777
+#, c-format
+msgid "Delete style %s?"
+msgstr "Xóa kiểu dáng %s?"
+
+#: ../src/richtext/richtextstyledlg.cpp:777
+msgid "Delete Style"
+msgstr "Xóa Kiểu Dáng"
+
+#: ../src/richtext/richtextstyledlg.cpp:815
+msgid "Enter a list style name"
+msgstr "Nhập vào tên kiểu dáng danh sách"
+
+#: ../src/richtext/richtextstyledlg.cpp:888
+msgid "Enter a new style name"
+msgstr "Nhập vào tên kiểu dáng danh sách mới"
+
+#: ../src/richtext/richtextstyledlg.cpp:929
+msgid "Enter a box style name"
+msgstr "Nhập vào tên kiểu dáng hộp"
+
+#: ../src/richtext/richtextstylepage.cpp:109
+#: ../src/richtext/richtextstylepage.cpp:111
+msgid "The style name."
+msgstr "Tên kiểu dáng."
+
+#: ../src/richtext/richtextstylepage.cpp:114
+msgid "&Based on:"
+msgstr "&Trên cơ sở:"
+
+#: ../src/richtext/richtextstylepage.cpp:119
+#: ../src/richtext/richtextstylepage.cpp:121
+msgid "The style on which this style is based."
+msgstr "Kiểu dáng lấy chính kiểu dáng này làm cơ sở."
+
+#: ../src/richtext/richtextstylepage.cpp:124
+msgid "&Next style:"
+msgstr "Kiểu dáng kế &tiếp:"
+
+#: ../src/richtext/richtextstylepage.cpp:129
+#: ../src/richtext/richtextstylepage.cpp:131
+msgid "The default style for the next paragraph."
+msgstr "Kiểu dáng mặc định cho đoạn tiếp theo."
+
+#: ../src/richtext/richtextstyles.cpp:1057
+msgid "All styles"
+msgstr "Mọi kiểu dáng"
+
+#: ../src/richtext/richtextstyles.cpp:1058
+msgid "Paragraph styles"
+msgstr "Kiểu đoạn văn"
+
+#: ../src/richtext/richtextstyles.cpp:1059
+msgid "Character styles"
+msgstr "Kiểu dáng ký tự"
+
+#: ../src/richtext/richtextstyles.cpp:1060
+msgid "List styles"
+msgstr "Kiểu dáng của danh sách"
+
+#: ../src/richtext/richtextstyles.cpp:1061
+msgid "Box styles"
+msgstr "Kiểu dáng Hộp"
+
+#: ../src/richtext/richtextsymboldlg.cpp:389
+#: ../src/richtext/richtextsymboldlg.cpp:391
+msgid "The font from which to take the symbol."
+msgstr "Phông chữ từ đó đã lấy ký tự đặc biệt."
+
+#: ../src/richtext/richtextsymboldlg.cpp:396
+msgid "&Subset:"
+msgstr "Tập c&on:"
+
+#: ../src/richtext/richtextsymboldlg.cpp:401
+#: ../src/richtext/richtextsymboldlg.cpp:403
+msgid "Shows a Unicode subset."
+msgstr "Hiển thị tập con của bộ mã Unicode."
+
+#: ../src/richtext/richtextsymboldlg.cpp:412
+msgid "xxxx"
+msgstr "xxxx"
+
+#: ../src/richtext/richtextsymboldlg.cpp:417
+msgid "&Character code:"
+msgstr "&Mã ký tự:"
+
+#: ../src/richtext/richtextsymboldlg.cpp:421
+#: ../src/richtext/richtextsymboldlg.cpp:423
+msgid "The character code."
+msgstr "Mã ký tự."
+
+#: ../src/richtext/richtextsymboldlg.cpp:428
+msgid "&From:"
+msgstr "&Từ:"
+
+#: ../src/richtext/richtextsymboldlg.cpp:433
+#: ../src/richtext/richtextsymboldlg.cpp:434
+#: ../src/richtext/richtextsymboldlg.cpp:435
+msgid "Unicode"
+msgstr "Unicode"
+
+#: ../src/richtext/richtextsymboldlg.cpp:436
+#: ../src/richtext/richtextsymboldlg.cpp:438
+msgid "The range to show."
+msgstr "Chọn vùng cần hiện."
+
+#: ../src/richtext/richtextsymboldlg.cpp:444
+msgid "Insert"
+msgstr "Chèn"
+
+#: ../src/richtext/richtextsymboldlg.cpp:478
+msgid "(Normal text)"
+msgstr "(Chữ thường)"
+
+#: ../src/richtext/richtexttabspage.cpp:109
+msgid "&Position (tenths of a mm):"
+msgstr "&Vị trí (mỗi 10mm):"
+
+#: ../src/richtext/richtexttabspage.cpp:113
+#: ../src/richtext/richtexttabspage.cpp:115
+msgid "The tab position."
+msgstr "Vị trí tab."
+
+#: ../src/richtext/richtexttabspage.cpp:119
+msgid "The tab positions."
+msgstr "Vị trí tab."
+
+#: ../src/richtext/richtexttabspage.cpp:132
+#: ../src/richtext/richtexttabspage.cpp:134
+msgid "Click to create a new tab position."
+msgstr "Bấm vào để tạo một vị trí tab mới."
+
+#: ../src/richtext/richtexttabspage.cpp:138
+#: ../src/richtext/richtexttabspage.cpp:140
+msgid "Click to delete the selected tab position."
+msgstr "Bấm vào để xóa các vị trí tab đã chọn."
+
+#: ../src/richtext/richtexttabspage.cpp:143
+msgid "Delete A&ll"
+msgstr "Xó&a Tất"
+
+#: ../src/richtext/richtexttabspage.cpp:144
+#: ../src/richtext/richtexttabspage.cpp:146
+msgid "Click to delete all tab positions."
+msgstr "Bấm vào để xóa tất cả vị trí tab."
+
+#: ../src/univ/theme.cpp:110
+msgid "Failed to initialize GUI: no built-in themes found."
+msgstr ""
+"Khởi tạo GUI gặp lỗi: không có built-in giao diện hiển thị nào được tìm thấy."
+
+#: ../src/univ/themes/gtk.cpp:521
+msgid "GTK+ theme"
+msgstr "Giao diện hiển thị GTK+"
+
+#: ../src/univ/themes/metal.cpp:164
+msgid "Metal theme"
+msgstr "Chủ đề giống kim loại"
+
+#: ../src/univ/themes/mono.cpp:512
+msgid "Simple monochrome theme"
+msgstr "Theme màu đơn sắc đơn giản"
+
+#: ../src/univ/themes/win32.cpp:1098
+msgid "Win32 theme"
+msgstr "kiểu Win32"
+
+#: ../src/univ/themes/win32.cpp:3743
+msgid "&Restore"
+msgstr "&Phục hồi lại"
+
+#: ../src/univ/themes/win32.cpp:3744
+msgid "&Move"
+msgstr "Di chuyể&n"
+
+#: ../src/univ/themes/win32.cpp:3746
+msgid "&Size"
+msgstr "&Kích thước"
+
+#: ../src/univ/themes/win32.cpp:3748
+msgid "Mi&nimize"
+msgstr "&Nhỏ nhất"
+
+#: ../src/univ/themes/win32.cpp:3750
+msgid "Ma&ximize"
+msgstr "Tối đ&a"
+
+#: ../src/univ/themes/win32.cpp:3752
+msgid "Alt+"
+msgstr "Alt+"
+
+#: ../src/unix/appunix.cpp:178
+msgid "Failed to install signal handler"
+msgstr "Cài đặt bộ điều khiển tín hiệu gặp lỗi"
+
+#: ../src/unix/dialup.cpp:351
+msgid "Already dialling ISP."
+msgstr "Sẵn sàng quay số tới nhà cung cấp dịch vụ Internet ISP."
+
+#: ../src/unix/dlunix.cpp:93
+#, fuzzy
+msgid "Failed to unload shared library"
+msgstr "Tải thư viện chia sẻ %s gặp lỗi"
+
+#: ../src/unix/dlunix.cpp:121
+msgid "Unknown dynamic library error"
+msgstr "Không rõ lỗi thư viện liên kết động"
+
+#: ../src/unix/epolldispatcher.cpp:84
+msgid "Failed to create epoll descriptor"
+msgstr "Tạo phần mô tả epoll gặp lỗi"
+
+#: ../src/unix/epolldispatcher.cpp:103
+msgid "Error closing epoll descriptor"
+msgstr "Lỗi khi đóng phần mô tả epoll"
+
+#: ../src/unix/epolldispatcher.cpp:116
+#, c-format
+msgid "Failed to add descriptor %d to epoll descriptor %d"
+msgstr "Khi thêm phần mô tả %d vào phần mô tả epoll %d gặp lỗi"
+
+#: ../src/unix/epolldispatcher.cpp:136
+#, c-format
+msgid "Failed to modify descriptor %d in epoll descriptor %d"
+msgstr "Chỉnh sửa phần mô tả %d trong phần mô tả epoll %d gặp lỗi"
+
+#: ../src/unix/epolldispatcher.cpp:155
+#, c-format
+msgid "Failed to unregister descriptor %d from epoll descriptor %d"
+msgstr "Bỏ đăng ký phần mô tả %d từ phần mô tả epoll %d gặp lỗi."
+
+#: ../src/unix/epolldispatcher.cpp:213
+#, c-format
+msgid "Waiting for IO on epoll descriptor %d failed"
+msgstr "Đợi IO trên phần mô tả epoll %d gặp lỗi"
+
+#: ../src/unix/fswatcher_inotify.cpp:71
+msgid "Unable to create inotify instance"
+msgstr "Không thể tạo inotify được"
+
+#: ../src/unix/fswatcher_inotify.cpp:94
+msgid "Unable to close inotify instance"
+msgstr "Không thể đóng inotify"
+
+#: ../src/unix/fswatcher_inotify.cpp:106
+msgid "Unable to add inotify watch"
+msgstr "Không thể đóng bộ theo dõi inotify"
+
+#: ../src/unix/fswatcher_inotify.cpp:138
+#, fuzzy, c-format
+msgid "Unable to remove inotify watch %i"
+msgstr "Không thể gỡ bỏ bộ theo dõi inotify"
+
+#: ../src/unix/fswatcher_inotify.cpp:271
+#, c-format
+msgid "Unexpected event for \"%s\": no matching watch descriptor."
+msgstr ""
+"Gặp sự kiện bất ngờ dành cho \"%s\": không có bộ mô tả theo dõi nào tương "
+"ứng với nó."
+
+#: ../src/unix/fswatcher_inotify.cpp:320
+#, c-format
+msgid "Invalid inotify event for \"%s\""
+msgstr "Sự kiện inotify (theo dõi tập tin) dành cho \"%s\" không hợp lệ"
+
+#: ../src/unix/fswatcher_inotify.cpp:553
+msgid "Unable to read from inotify descriptor"
+msgstr "Không đọc được phần mô tả của inotify"
+
+#: ../src/unix/fswatcher_inotify.cpp:558
+msgid "EOF while reading from inotify descriptor"
+msgstr "Việc đọc bộ mô tả inotify gặp lỗi EOF"
+
+#: ../src/unix/fswatcher_kqueue.cpp:114
+msgid "Unable to create kqueue instance"
+msgstr "Không thể tạo kqueue được"
+
+#: ../src/unix/fswatcher_kqueue.cpp:131
+msgid "Error closing kqueue instance"
+msgstr "Lỗi khi đóng kqueue"
+
+#: ../src/unix/fswatcher_kqueue.cpp:153
+msgid "Unable to add kqueue watch"
+msgstr "Không thể tạo bộ theo dõi kqueue"
+
+#: ../src/unix/fswatcher_kqueue.cpp:170
+msgid "Unable to remove kqueue watch"
+msgstr "Không thể gỡ bỏ bộ theo dõi kqueue"
+
+#: ../src/unix/fswatcher_kqueue.cpp:202
+msgid "Unable to get events from kqueue"
+msgstr "Không thể lấy các sự kiện từ kqueue"
+
+#: ../src/unix/mediactrl.cpp:966
+#, c-format
+msgid "Media playback error: %s"
+msgstr "Lỗi phát đa phương tiện: %s"
+
+#: ../src/unix/mediactrl.cpp:1228
+#, c-format
+msgid "Failed to prepare playing \"%s\"."
+msgstr "Gặp lỗi khi chuẩn bị phát \"%s\"."
+
+#: ../src/unix/snglinst.cpp:164
+#, c-format
+msgid "Failed to write to lock file '%s'"
+msgstr "Ghi vào tập tin khóa '%s' gặp lỗi"
+
+#: ../src/unix/snglinst.cpp:177
+#, c-format
+msgid "Failed to set permissions on lock file '%s'"
+msgstr "Đặt quyền trên tập tin khóa '%s' gặp lỗi"
+
+#: ../src/unix/snglinst.cpp:194
+#, c-format
+msgid "Failed to lock the lock file '%s'"
+msgstr "Khóa tập tin khóa %s gặp lỗi"
+
+#: ../src/unix/snglinst.cpp:237
+#, c-format
+msgid "Failed to inspect the lock file '%s'"
+msgstr "Kiểm tra tập tin khóa '%s' gặp lỗi"
+
+#: ../src/unix/snglinst.cpp:242
+#, c-format
+msgid "Lock file '%s' has incorrect owner."
+msgstr "Tập tin khóa '%s' có chủ sở hữu không đúng."
+
+#: ../src/unix/snglinst.cpp:247
+#, c-format
+msgid "Lock file '%s' has incorrect permissions."
+msgstr "Tập tin khóa '%s' có quyền không đúng."
+
+#: ../src/unix/snglinst.cpp:265
+msgid "Failed to access lock file."
+msgstr "Truy cập tập tin khóa gặp lỗi."
+
+#: ../src/unix/snglinst.cpp:274
+msgid "Failed to read PID from lock file."
+msgstr "Đọc PID từ tập tin khóa gặp lỗi."
+
+#: ../src/unix/snglinst.cpp:284
+#, c-format
+msgid "Failed to remove stale lock file '%s'."
+msgstr "Gỡ bỏ tập tin khóa cũ '%s' gặp lỗi."
+
+#: ../src/unix/snglinst.cpp:297
+#, c-format
+msgid "Deleted stale lock file '%s'."
+msgstr "Xóa tập tin khóa cũ '%s'."
+
+#: ../src/unix/snglinst.cpp:308
+#, c-format
+msgid "Invalid lock file '%s'."
+msgstr "Tập tin khóa '%s' không hợp lệ."
+
+#: ../src/unix/snglinst.cpp:324
+#, c-format
+msgid "Failed to remove lock file '%s'"
+msgstr "Gỡ bỏ tập tin khóa '%s' gặp lỗi"
+
+#: ../src/unix/snglinst.cpp:330
+#, c-format
+msgid "Failed to unlock lock file '%s'"
+msgstr "Không khóa tập tin khóa '%s' gặp lỗi"
+
+#: ../src/unix/snglinst.cpp:336
+#, c-format
+msgid "Failed to close lock file '%s'"
+msgstr "Đóng tập tin khóa '%s' gặp lỗi"
+
+#: ../src/unix/sound.cpp:77
+msgid "No sound"
+msgstr "Không có âm thanh"
+
+#: ../src/unix/sound.cpp:364
+msgid "Unable to play sound asynchronously."
+msgstr "Không thể chạy đoạn âm thanh dị bộ."
+
+#: ../src/unix/sound.cpp:458
+#, c-format
+msgid "Couldn't load sound data from '%s'."
+msgstr "Không thể tải dữ liệu âm thanh từ '%s'."
+
+#: ../src/unix/sound.cpp:465
+#, c-format
+msgid "Sound file '%s' is in unsupported format."
+msgstr "Có vẻ như tập tin '%s' không được hỗ trợ định dạng."
+
+#: ../src/unix/sound.cpp:480
+msgid "Sound data are in unsupported format."
+msgstr "Có vẻ như dữ liệu có định dạng không được hỗ trợ."
+
+#: ../src/unix/sound_sdl.cpp:226
+#, c-format
+msgid "Couldn't open audio: %s"
+msgstr "Không mở âm thanh: %s"
+
+#: ../src/unix/threadpsx.cpp:1033
+msgid "Cannot retrieve thread scheduling policy."
+msgstr "Không thể khôi phục chính sách tạo lập tác vụ tuyến trình."
+
+#: ../src/unix/threadpsx.cpp:1058
+#, c-format
+msgid "Cannot get priority range for scheduling policy %d."
+msgstr "Không thể nhận vùng ưu tiên cho việc tạo lập chính sách %d."
+
+#: ../src/unix/threadpsx.cpp:1066
+msgid "Thread priority setting is ignored."
+msgstr "Cài đặt quyền ưu tiên tuyến trình bị bỏ qua."
+
+#: ../src/unix/threadpsx.cpp:1221
+msgid ""
+"Failed to join a thread, potential memory leak detected - please restart the "
+"program"
+msgstr ""
+"Gia nhập tuyến trình gặp lỗi, đã phát hiện lỗ thủng bộ nhớ tiềm tàng - xin "
+"hãy khởi động lại chương trình"
+
+#: ../src/unix/threadpsx.cpp:1352
+#, c-format
+msgid "Failed to set thread concurrency level to %lu"
+msgstr "Gặp lỗi khi đặt mức tuyến trình đồng thời thành %lu"
+
+#: ../src/unix/threadpsx.cpp:1481
+#, c-format
+msgid "Failed to set thread priority %d."
+msgstr "Đặt mức ưu tiên tuyến trình %d gặp lỗi."
+
+#: ../src/unix/threadpsx.cpp:1666
+msgid "Failed to terminate a thread."
+msgstr "Chấm dứt một tuyến trình gặp lỗi."
+
+#: ../src/unix/threadpsx.cpp:1893
+msgid "Thread module initialization failed: failed to create thread key"
+msgstr "Khởi tạo mô đun tuyến trình gặp lỗi: lỗi tạo khóa tuyến trình"
+
+#: ../src/unix/utilsunx.cpp:340
+msgid "Impossible to get child process input"
+msgstr "Không thể lấy đầu vào của tiến trình con"
+
+#: ../src/unix/utilsunx.cpp:390
+msgid "Can't write to child process's stdin"
+msgstr "Không thể ghi ra đầu vào chuẩn của quá trình con"
+
+#: ../src/unix/utilsunx.cpp:644
+#, c-format
+msgid "Failed to execute '%s'\n"
+msgstr "Thực thi '%s' gặp lỗi\n"
+
+#: ../src/unix/utilsunx.cpp:678
+msgid "Fork failed"
+msgstr "Gặp lỗi khi rẽ nhánh tiến trình"
+
+#: ../src/unix/utilsunx.cpp:701
+msgid "Failed to set process priority"
+msgstr "Gặp lỗi khi đặt mức ưu tiên tuyến trình"
+
+#: ../src/unix/utilsunx.cpp:712
+msgid "Failed to redirect child process input/output"
+msgstr "Chuyển hướng quá trình kết nhập/kết xuất của tiến trình con gặp lỗi"
+
+#: ../src/unix/utilsunx.cpp:816
+msgid "Failed to set up non-blocking pipe, the program might hang."
+msgstr ""
+"Gặp lỗi khi cài đặt đường ống không-khối (non-blocking pipe), chương trình "
+"có lẽ bị treo."
+
+#: ../src/unix/utilsunx.cpp:1023
+msgid "Cannot get the hostname"
+msgstr "Không thể lấy được tên máy chủ"
+
+#: ../src/unix/utilsunx.cpp:1059
+msgid "Cannot get the official hostname"
+msgstr "Không lấy được tên máy chủ văn phòng"
+
+#: ../src/unix/wakeuppipe.cpp:49
+msgid "Failed to create wake up pipe used by event loop."
+msgstr "Tạo wake up pipe sử dụng cho vòng lặp sự kiện gặp lỗi."
+
+#: ../src/unix/wakeuppipe.cpp:56
+msgid "Failed to switch wake up pipe to non-blocking mode"
+msgstr "Chuyển sang chế độ từ wake up pipe sang non-blocking gặp lỗi"
+
+#: ../src/unix/wakeuppipe.cpp:117
+msgid "Failed to read from wake-up pipe"
+msgstr "Đọc từ ống dẫn wake-up gặp lỗi"
+
+#: ../src/x11/app.cpp:124
+#, c-format
+msgid "Invalid geometry specification '%s'"
+msgstr "Chi tiết hình học '%s' không hợp lệ"
+
+#: ../src/x11/app.cpp:167
+msgid "wxWidgets could not open display. Exiting."
+msgstr "wxWidgets không thể mở bộ hiển thị. Đang thoát ra."
+
+#: ../src/x11/utils.cpp:169
+#, c-format
+msgid "Failed to close the display \"%s\""
+msgstr "Đóng bộ hiển thị \"%s\" gặp lỗi"
+
+#: ../src/x11/utils.cpp:188
+#, c-format
+msgid "Failed to open display \"%s\"."
+msgstr "Mở bộ hiển thị \"%s\" gặp lỗi."
+
+#: ../src/xml/xml.cpp:868
+#, c-format
+msgid "XML parsing error: '%s' at line %d"
+msgstr "Gặp lỗi khi phân tách XML: '%s' trên dòng %d"
+
+#: ../src/xrc/xh_propgrid.cpp:239
+#, fuzzy, c-format
+msgid "Page %i"
+msgstr "Trang %d"
+
+#: ../src/xrc/xmlres.cpp:448
+#, c-format
+msgid "Cannot load resources from '%s'."
+msgstr "Không thể tải tài nguyên từ  '%s'."
+
+#: ../src/xrc/xmlres.cpp:799
+#, c-format
+msgid "Cannot open resources file '%s'."
+msgstr "Không thể mở tập tin tài nguyên '%s'."
+
+#: ../src/xrc/xmlres.cpp:806
+#, c-format
+msgid "Cannot load resources from file '%s'."
+msgstr "Không thể tải tài nguyên từ tập tin '%s'."
+
+#: ../src/xrc/xmlres.cpp:2767
+#, fuzzy, c-format
+msgid "Creating %s \"%s\" failed."
+msgstr "Rút trích '%s' vào '%s' gặp lỗi."
+
+#~ msgctxt "keyboard key"
+#~ msgid "Alt+"
+#~ msgstr "Alt+"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Ctrl+"
+#~ msgstr "Ctrl+"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Shift+"
+#~ msgstr "Shift+"
+
+#~ msgctxt "keyboard key"
+#~ msgid "RawCtrl+"
+#~ msgstr "RawCtrl+"
+
+#~ msgid "Unsupported clipboard format."
+#~ msgstr "Dạng thức clipboard không được hỗ trợ."
+
+#~ msgid "Background colour"
+#~ msgstr "Màu nền"
+
+#~ msgid "Font:"
+#~ msgstr "Phông chữ:"
+
+#~ msgid "Size:"
+#~ msgstr "Kích thước:"
+
+#~ msgid "The font size in points."
+#~ msgstr "Cỡ phông chữ theo đơn vị point."
+
+#~ msgid "Style:"
+#~ msgstr "Kiểu dáng"
+
+#~ msgid "Check to make the font bold."
+#~ msgstr "Đánh đấu kiểm để làm cho phông chữ đậm."
+
+#~ msgid "Check to make the font italic."
+#~ msgstr "Đánh đấu kiểm để làm cho phông chữ nghiêng."
+
+#~ msgid "Check to make the font underlined."
+#~ msgstr "Đánh đấu kiểm để làm cho phông chữ có gạch chân."
+
+#~ msgid "Colour:"
+#~ msgstr "Màu sắc:"
+
+#~ msgid "Click to change the font colour."
+#~ msgstr "Bấm vào để thay đổi màu sắc phông chữ."
+
+#~ msgid "Shows a preview of the font."
+#~ msgstr "Xem thử phông chữ."
+
+#~ msgid "Click to cancel changes to the font."
+#~ msgstr "Bấm vào để hủy thay đổi phông chữ."
+
+#~ msgid "Click to confirm changes to the font."
+#~ msgstr "Bấm vào để xác nhận thay đổi phông chữ."
+
+#~ msgid "<Any>"
+#~ msgstr "<Bất kỳ>"
+
+#~ msgid "<Any Roman>"
+#~ msgstr "<Dạng La Mã bất kỳ>"
+
+#~ msgid "<Any Decorative>"
+#~ msgstr "<Dạng Chữ Trang Trí bất kỳ>"
+
+#~ msgid "<Any Modern>"
+#~ msgstr "<Dạng Hiện Đại bất kỳ >"
+
+#~ msgid "<Any Script>"
+#~ msgstr "<Dạng Script bất kỳ>"
+
+#~ msgid "<Any Swiss>"
+#~ msgstr "<Dạng Thụy Sỹ bất kỳ>"
+
+#~ msgid "<Any Teletype>"
+#~ msgstr "<Dạng Teletype bất kỳ>"
+
+#~ msgid "Printing "
+#~ msgstr "Đang in "
+
+#~ msgid "Failed to insert text in the control."
+#~ msgstr "Chèn chữ vào điều khiển gặp lỗi."
+
+#~ msgid "Please choose a valid font."
+#~ msgstr "Hãy chọn một phông chữ hợp lệ."
+
+#, c-format
+#~ msgid "Failed to display HTML document in %s encoding"
+#~ msgstr "Hiển thị tài liệu HTML trong bộ mã %s gặp lỗi"
+
+#, c-format
+#~ msgid "wxWidgets could not open display for '%s': exiting."
+#~ msgstr "wxWidgets không thể mở' %s' ra, đang thoát ra."
+
+#~ msgid "Filter"
+#~ msgstr "Bộ lọc"
+
+#~ msgid "Directories"
+#~ msgstr "Thư mục"
+
+#~ msgid "Files"
+#~ msgstr "Tập tin"
+
+#~ msgid "Selection"
+#~ msgstr "Vùng chọn"
+
+#~ msgid "conversion to 8-bit encoding failed"
+#~ msgstr "chuyển đổi sang bộ mã 8-bit gặp lỗi"
+
+#, fuzzy
+#~ msgid "failed to retrieve execution result"
+#~ msgstr "Khôi phục chữ của thông điệp lỗi RAS gặp lỗi"
+
+#~ msgid "&Save as"
+#~ msgstr "&Ghi Lại Bằng Tên Mới"
+
+#~ msgid "'%s' doesn't consist only of valid characters"
+#~ msgstr "'%s' không gồm có ký tự nào hợp lệ"
+
+#~ msgid "'%s' should be numeric."
+#~ msgstr "'%s' có thể thuộc kiểu số."
+
+#~ msgid "'%s' should only contain ASCII characters."
+#~ msgstr "'%s' chỉ nên chứa chữ cái trong bảng mã ASCII."
+
+#~ msgid "'%s' should only contain alphabetic characters."
+#~ msgstr "'%s' chỉ nên chứa ký tự trong bảng chữ cái."
+
+#~ msgid "'%s' should only contain alphabetic or numeric characters."
+#~ msgstr "'%s' chỉ nên chứa ký tự trong bảng chữ cái hay chữ số."
+
+#~ msgid "'%s' should only contain digits."
+#~ msgstr "'%s' chỉ có thể chứa các chữ số."
+
+#~ msgid "Can't create window of class %s"
+#~ msgstr "Không thể tạo cửa sổ của lớp %s"
+
+#~ msgid "Couldn't create the overlay window"
+#~ msgstr "Không tạo được cửa sổ xếp chồng"
+
+#~ msgid "Couldn't init the context on the overlay window"
+#~ msgstr "Không thể khởi tạo context trên cửa sổ overlay"
+
+#~ msgid "Failed to convert file \"%s\" to Unicode."
+#~ msgstr "Chuyển đổi tập tin \"%s\" sang Unicode gặp lỗi."
+
+#~ msgid "Failed to set text in the text control."
+#~ msgstr "Gán văn bản vào điều khiển văn bản gặp lỗi."
+
+#~ msgid "Invalid GTK+ command line option, use \"%s --help\""
+#~ msgstr "Tùy chọn dòng lệnh GTK+ không hợp lệ, sử dụng \"%s --help\""
+
+#~ msgid "No unused colour in image."
+#~ msgstr "Không có màu không dùng trong ảnh."
+
+#~ msgid "Not available"
+#~ msgstr "Không sẵn sàng"
+
+#~ msgid "Replace selection"
+#~ msgstr "Thay thế vùng chọn hiện thời"
+
+#~ msgid "Save as"
+#~ msgstr "Ghi Lại Bằng Tên Mới"
+
+#~ msgid "Style Organiser"
+#~ msgstr "Kiểu dáng Bộ Tổ Chức"
+
+#~ msgid "The following standard GTK+ options are also supported:\n"
+#~ msgstr "Các tùy chọn GTK+ tiêu chuẩn sau đây đều được hỗ trợ:\n"
+
+#~ msgid "You cannot Clear an overlay that is not inited"
+#~ msgstr "Bạn không thể Xóa một overlay mà nó chưa được khởi tạo"
+
+#~ msgid "You cannot Init an overlay twice"
+#~ msgstr "Bạn không thể khởi tạo overlay lần nữa"
+
+#~ msgid "locale '%s' cannot be set."
+#~ msgstr "địa phương '%s' không thể đặt được."
+
+#~ msgid "Adding flavor TEXT failed"
+#~ msgstr "Việc thêm flavor TEXT gặp lỗi"
+
+#~ msgid "Adding flavor utxt failed"
+#~ msgstr "Việc thêm flavor utxt gặp lỗi"
+
+#~ msgid "Bitmap renderer cannot render value; value type: "
+#~ msgstr "Bộ đáp ứng ảnh bitmap không thể trả về giá trị; kiểu giá trị: "
+
+#~ msgid ""
+#~ "Cannot create new column's ID. Probably max. number of columns reached."
+#~ msgstr ""
+#~ "Không thể tạo mới chỉ số ID của cột. Hầu như chắc chắn trị số lớn nhất "
+#~ "của cột đã được dùng."
+
+#~ msgid "Column could not be added."
+#~ msgstr "Cột không thể chèn thêm"
+
+#~ msgid "Column index not found."
+#~ msgstr "Chỉ mục cột không thấy."
+
+#~ msgid "Column width could not be determined"
+#~ msgstr "Chiều rộng cột không thể được định rõ"
+
+#~ msgid "Column width could not be set."
+#~ msgstr "Chiều rộng cột không thể đặt được."
+
+#~ msgid "Confirm registry update"
+#~ msgstr "Xác nhận cập nhật đăng ký"
+
+#~ msgid "Could not determine column index."
+#~ msgstr "Không thể định rõ chỉ mục của cột."
+
+#~ msgid "Could not determine column's position"
+#~ msgstr "Không thể xác định rõ vị trí của cột"
+
+#~ msgid "Could not determine number of columns."
+#~ msgstr "Không thể định rõ số các cột."
+
+#~ msgid "Could not determine number of items"
+#~ msgstr "Không thể định rõ số các mục tin"
+
+#~ msgid "Could not get header description."
+#~ msgstr "Không thể lấy phần mô tả phần đầu."
+
+#~ msgid "Could not get items."
+#~ msgstr "Không thể lấy các mục tin."
+
+#~ msgid "Could not get property flags."
+#~ msgstr "Không thể lấy thuộc tính của các cờ."
+
+#~ msgid "Could not get selected items."
+#~ msgstr "Không thể lấy mục tin đã chọn."
+
+#~ msgid "Could not remove column."
+#~ msgstr "Không thể gỡ bỏ cột."
+
+#~ msgid "Could not retrieve number of items"
+#~ msgstr "Không thể lấy số mục tin."
+
+#~ msgid "Could not set column width."
+#~ msgstr "Không thể đặt độ rộng cột."
+
+#~ msgid "Could not set header description."
+#~ msgstr "Không thể đặt phần mô tả phần đầu."
+
+#~ msgid "Could not set icon."
+#~ msgstr "Không thể đặt biểu tượng."
+
+#~ msgid "Could not set maximum width."
+#~ msgstr "Không thể đặt độ rộng cột tối đa."
+
+#~ msgid "Could not set minimum width."
+#~ msgstr "Không thể đặt độ rộng cột tối thiểu."
+
+#~ msgid "Could not set property flags."
+#~ msgstr "Không thể đặt thuộc tính của các cờ."
+
+#~ msgid "Data object has invalid data format"
+#~ msgstr "Đối tượng dữ liệu không đúng định dạng"
+
+#~ msgid "Date renderer cannot render value; value type: "
+#~ msgstr "Bộ đáp ứng Ngày tháng không trả về giá trị; giá trị kiểu: "
+
+#~ msgid ""
+#~ "Do you want to overwrite the command used to %s files with extension "
+#~ "\"%s\" ?\n"
+#~ "Current value is \n"
+#~ "%s, \n"
+#~ "New value is \n"
+#~ "%s %1"
+#~ msgstr ""
+#~ "Bạn có muốn ghi đè lệnh thường dùng với tập tin %s với phần mở rộng "
+#~ "\"%s\" ?\n"
+#~ "Giá trị hiện hành là \n"
+#~ "%s, \n"
+#~ "Giá trị mới là \n"
+#~ "%s %1"
+
+#~ msgid "Failed to retrieve data from the clipboard."
+#~ msgstr "Khôi phục dữ liệu từ clipboard gặp lỗi."
+
+#~ msgid "GIF: Invalid gif index."
+#~ msgstr "GIF: Chỉ mục gif không hợp lệ."
+
+#~ msgid "GIF: unknown error!!!"
+#~ msgstr "GIF: lỗi không rõ!!!"
+
+#~ msgid "Icon & text renderer cannot render value; value type: "
+#~ msgstr "Bộ đáp ứng Biểu tượng & text không trả về giá trị; giá trị kiểu: "
+
+#~ msgid "New directory"
+#~ msgstr "Thư mục mới"
+
+#~ msgid "Next"
+#~ msgstr "Tiếp theo"
+
+#~ msgid "No column existing."
+#~ msgstr "Chưa có cột nào tồn tại."
+
+#~ msgid "No column for the specified column existing."
+#~ msgstr "Không cột nào đã tạo cho vị trí cột đã chỉ ra."
+
+#~ msgid "No column for the specified column position existing."
+#~ msgstr "Không cột nào cho vị trí cột đã tồn tại theo danh nghĩa."
+
+#~ msgid ""
+#~ "No renderer or invalid renderer type specified for custom data column."
+#~ msgstr ""
+#~ "Không có renderer hoặc kiểu renderer không hợp lệ chỉ định cho kiểu cột "
+#~ "dữ liệu tùy chỉnh."
+
+#~ msgid "No renderer specified for column."
+#~ msgstr "Không có renderer định rõ cho cột."
+
+#~ msgid "Number of columns could not be determined."
+#~ msgstr "Không thể dò tìm số cột."
+
+#~ msgid "OpenGL function \"%s\" failed: %s (error %d)"
+#~ msgstr "Hàm \"%s\" của OpenGL bị lỗi: %s (lỗi %d)"
+
+#~ msgid ""
+#~ "Please install a newer version of comctl32.dll\n"
+#~ "(at least version 4.70 is required but you have %d.%02d)\n"
+#~ "or this program won't operate correctly."
+#~ msgstr ""
+#~ "Xin hãy cài đặt phiên bản comctl32.dll mới hơn\n"
+#~ "(ít nhất yêu cầu phiên bản 4.70 nhưng bạn phải có %d.%02d)\n"
+#~ "nếu không chương trình sẽ không làm việc đúng."
+
+#~ msgid "Pointer to data view control not set correctly."
+#~ msgstr ""
+#~ "Con trỏ tới điều khiển hiển thị dữ liệu không được đặt một cách chính xác."
+
+#~ msgid "Pointer to model not set correctly."
+#~ msgstr "Con trỏ tới mô hình không được đặt một cách chính xác."
+
+#~ msgid "Progress renderer cannot render value type; value type: "
+#~ msgstr ""
+#~ "Tiến trình renderer không thể trả về kiểu giá trị loại; kiểu giá trị: "
+
+#~ msgid "Rendering failed."
+#~ msgstr "Rendering gặp lỗi."
+
+#~ msgid ""
+#~ "Setting directory access times is not supported under this OS version"
+#~ msgstr ""
+#~ "Cài đặt về thời gian truy cập thư mục không được hỗ trợ trong phiên bản "
+#~ "hệ điều hành này"
+
+#~ msgid "Show hidden directories"
+#~ msgstr "Hiện thư mục ẩn"
+
+#~ msgid "Text renderer cannot render value; value type: "
+#~ msgstr "Text renderer không trả về giá trị; giá trị kiểu: "
+
+#~ msgid "There is no column or renderer for the specified column index."
+#~ msgstr "Không có cột hay bộ xử lý nào cho chỉ số cột đã định sẵn."
+
+#~ msgid ""
+#~ "This system doesn't support date controls, please upgrade your version of "
+#~ "comctl32.dll"
+#~ msgstr ""
+#~ "Hệ thống không hỗ trợ điều khiển ngày tháng, xin hãy cập nhật phiên bản "
+#~ "mới của comctl32.dll"
+
+#~ msgid "Toggle renderer cannot render value; value type: "
+#~ msgstr "Toggle renderer không trả về giá trị; giá trị kiểu: "
+
+#~ msgid "Too many colours in PNG, the image may be slightly blurred."
+#~ msgstr "Quá nhiều màu trong PNG, ảnh có thể hơi nhòe."
+
+#~ msgid "Unable to handle native drag&drop data"
+#~ msgstr "Không thể kéo&thả dữ liệu được"
+
+#~ msgid "Unable to initialize Hildon program"
+#~ msgstr "Không thể khởi tạo chương trình Hildon"
+
+#~ msgid "Unknown data format"
+#~ msgstr "Định dạng dữ liệu chưa rõ"
+
+#~ msgid "Valid pointer to native data view control does not exist"
+#~ msgstr "Con trỏ hợp lệ cho điều khiển hiển thị dữ liệu nội tại chưa tồn tại"
+
+#~ msgid "Win32s on Windows 3.1"
+#~ msgstr "Win32s trên Windows 3.1"
+
+#, fuzzy
+#~ msgid "Windows 10"
+#~ msgstr "Windows 8.1"
+
+#~ msgid "Windows 2000"
+#~ msgstr "Windows 2000"
+
+#~ msgid "Windows 7"
+#~ msgstr "Windows 7"
+
+#~ msgid "Windows 8"
+#~ msgstr "Windows 8"
+
+#~ msgid "Windows 8.1"
+#~ msgstr "Windows 8.1"
+
+#~ msgid "Windows 95"
+#~ msgstr "Windows 95"
+
+#~ msgid "Windows 95 OSR2"
+#~ msgstr "Windows 95 OSR2"
+
+#~ msgid "Windows 98"
+#~ msgstr "Windows 98"
+
+#~ msgid "Windows 98 SE"
+#~ msgstr "Windows 98 SE"
+
+#~ msgid "Windows 9x (%d.%d)"
+#~ msgstr "Windows 9x (%d.%d)"
+
+#~ msgid "Windows CE (%d.%d)"
+#~ msgstr "Windows CE (%d.%d)"
+
+#~ msgid "Windows ME"
+#~ msgstr "Windows ME"
+
+#~ msgid "Windows NT %lu.%lu"
+#~ msgstr "Windows NT %lu.%lu"
+
+#, fuzzy
+#~ msgid "Windows Server 10"
+#~ msgstr "Windows Server 2003"
+
+#~ msgid "Windows Server 2003"
+#~ msgstr "Windows Server 2003"
+
+#~ msgid "Windows Server 2008"
+#~ msgstr "Windows Server 2008"
+
+#~ msgid "Windows Server 2008 R2"
+#~ msgstr "Windows Server 2008 R2"
+
+#~ msgid "Windows Server 2012"
+#~ msgstr "Windows Server 2012"
+
+#~ msgid "Windows Server 2012 R2"
+#~ msgstr "Windows Server 2012 R2"
+
+#~ msgid "Windows Vista"
+#~ msgstr "Windows Vista"
+
+#~ msgid "Windows XP"
+#~ msgstr "Windows XP"
+
+#~ msgid "can't execute '%s'"
+#~ msgstr "không thể thực hiện '%s'"
+
+#~ msgid "error opening '%s'"
+#~ msgstr "lỗi khi mở '%s'"
+
+#~ msgid "unknown seek origin"
+#~ msgstr "không hiểu vị trí đọc ban đầu"
+
+#~ msgid "wxWidget control pointer is not a data view pointer"
+#~ msgstr ""
+#~ "Con trỏ điều khiển wxWidget không phải là kiểu con trỏ hiển thị dữ liệu"
+
+#~ msgid "wxWidget's control not initialized."
+#~ msgstr "điểu khiển của wxWidget chưa được khởi tạo."
+
+#~ msgid "ADD"
+#~ msgstr "THÊM"
+
+#~ msgid "BACK"
+#~ msgstr "QUAY LẠI"
+
+#~ msgid "CANCEL"
+#~ msgstr "HỦY BỎ"
+
+#~ msgid "CAPITAL"
+#~ msgstr "CHỮ VIẾT HOA"
+
+#~ msgid "CLEAR"
+#~ msgstr "XÓA"
+
+#~ msgid "COMMAND"
+#~ msgstr "LỆNH"
+
+#~ msgid "Cannot create mutex."
+#~ msgstr "không thể tạo mutex"
+
+#~ msgid "Cannot resume thread %lu"
+#~ msgstr "Không thể phục hồi tuyến trình %lu"
+
+#~ msgid "Cannot suspend thread %lu"
+#~ msgstr "Không thể đình chỉ tuyến trình %lu"
+
+#~ msgid "Couldn't acquire a mutex lock"
+#~ msgstr "Không thể có được khóa mutex"
+
+#~ msgid "Couldn't get hatch style from wxBrush."
+#~ msgstr "Không thể lấy kiểu dáng hatch từ wxBrush."
+
+#~ msgid "Couldn't release a mutex"
+#~ msgstr "Không thể giải phóng mutex"
+
+#~ msgid "DECIMAL"
+#~ msgstr "HỆ THẬP PHÂN"
+
+#~ msgid "DEL"
+#~ msgstr "DEL"
+
+#~ msgid "DELETE"
+#~ msgstr "DELETE"
+
+#~ msgid "DIVIDE"
+#~ msgstr "DIVIDE"
+
+#~ msgid "DOWN"
+#~ msgstr "DOWN"
+
+#~ msgid "END"
+#~ msgstr "END"
+
+#~ msgid "ENTER"
+#~ msgstr "ENTER"
+
+#~ msgid "ESC"
+#~ msgstr "ESC"
+
+#~ msgid "ESCAPE"
+#~ msgstr "ESCAPE"
+
+#~ msgid "EXECUTE"
+#~ msgstr "THI HÀNH"
+
+#~ msgid "Execution of command '%s' failed with error: %ul"
+#~ msgstr "Thi hành lệnh '%s' gặp lỗi với lỗi: %ul"
+
+#~ msgid ""
+#~ "File '%s' already exists.\n"
+#~ "Do you want to replace it?"
+#~ msgstr ""
+#~ "Tập tin '%s' đã tồn tại. \n"
+#~ "Bạn có muốn thay thế nó không?"
+
+#~ msgid "HELP"
+#~ msgstr "TRỢ GIÚP"
+
+#~ msgid "HOME"
+#~ msgstr "HOME"
+
+#~ msgid "INS"
+#~ msgstr "INS"
+
+#~ msgid "INSERT"
+#~ msgstr "CHÈN"
+
+#~ msgid "KP_BEGIN"
+#~ msgstr "KP_BEGIN"
+
+#~ msgid "KP_DECIMAL"
+#~ msgstr "KP_DECIMAL"
+
+#~ msgid "KP_DELETE"
+#~ msgstr "KP_DELETE"
+
+#~ msgid "KP_DIVIDE"
+#~ msgstr "KP_DIVIDE"
+
+#~ msgid "KP_DOWN"
+#~ msgstr "KP_DOWN"
+
+#~ msgid "KP_ENTER"
+#~ msgstr "KP_ENTER"
+
+#~ msgid "KP_EQUAL"
+#~ msgstr "KP_EQUAL"
+
+#~ msgid "KP_HOME"
+#~ msgstr "KP_HOME"
+
+#~ msgid "KP_INSERT"
+#~ msgstr "KP_INSERT"
+
+#~ msgid "KP_LEFT"
+#~ msgstr "KP_LEFT"
+
+#~ msgid "KP_MULTIPLY"
+#~ msgstr "KP_MULTIPLY"
+
+#~ msgid "KP_NEXT"
+#~ msgstr "KP_NEXT"
+
+#~ msgid "KP_PAGEDOWN"
+#~ msgstr "KP_PAGEDOWN"
+
+#~ msgid "KP_PAGEUP"
+#~ msgstr "KP_PAGEUP"
+
+#~ msgid "KP_PRIOR"
+#~ msgstr "KP_PRIOR"
+
+#~ msgid "KP_RIGHT"
+#~ msgstr "KP_RIGHT"
+
+#~ msgid "KP_SEPARATOR"
+#~ msgstr "KP_SEPARATOR"
+
+#~ msgid "KP_SPACE"
+#~ msgstr "KP_SPACE"
+
+#~ msgid "KP_SUBTRACT"
+#~ msgstr "KP_SUBTRACT"
+
+#~ msgid "LEFT"
+#~ msgstr "LEFT"
+
+#~ msgid "MENU"
+#~ msgstr "TRÌNH ĐƠN"
+
+#~ msgid "NUM_LOCK"
+#~ msgstr "NUM_LOCK"
+
+#~ msgid "PAGEDOWN"
+#~ msgstr "PAGEDOWN"
+
+#~ msgid "PAGEUP"
+#~ msgstr "PAGEUP"
+
+#~ msgid "PAUSE"
+#~ msgstr "PAUSE"
+
+#~ msgid "PGDN"
+#~ msgstr "PGDN"
+
+#~ msgid "PGUP"
+#~ msgstr "PGUP"
+
+#~ msgid "PRINT"
+#~ msgstr "IN"
+
+#~ msgid "RETURN"
+#~ msgstr "RETURN"
+
+#~ msgid "RIGHT"
+#~ msgstr "RIGHT"
+
+#~ msgid "SCROLL_LOCK"
+#~ msgstr "SCROLL_LOCK"
+
+#~ msgid "SELECT"
+#~ msgstr "SELECT"
+
+#~ msgid "SEPARATOR"
+#~ msgstr "SEPARATOR"
+
+#~ msgid "SNAPSHOT"
+#~ msgstr "SNAPSHOT"
+
+#~ msgid "SPACE"
+#~ msgstr "SPACE"
+
+#~ msgid "SUBTRACT"
+#~ msgstr "SUBTRACT"
+
+#~ msgid "TAB"
+#~ msgstr "TAB"
+
+#~ msgid "The print dialog returned an error."
+#~ msgstr "Hộp thoại in trả về một lỗi."
+
+#~ msgid "The wxGtkPrinterDC cannot be used."
+#~ msgstr "Hàm wxGtkPrinterDC không thể sử dụng."
+
+#~ msgid "Timer creation failed."
+#~ msgstr "Tạo lập bộ định thời Timer gặp lỗi."
+
+#~ msgid "UP"
+#~ msgstr "UP"
+
+#~ msgid "WINDOWS_LEFT"
+#~ msgstr "WINDOWS_LEFT"
+
+#~ msgid "WINDOWS_MENU"
+#~ msgstr "WINDOWS_MENU"
+
+#~ msgid "WINDOWS_RIGHT"
+#~ msgstr "WINDOWS_RIGHT"
+
+#~ msgid "buffer is too small for Windows directory."
+#~ msgstr "bộ đệm quá nhỏ cho thư mục Windows."
+
+#~ msgid "not implemented"
+#~ msgstr "chưa được viết mã thực thi."
+
+#~ msgid "wxPrintout::GetPageInfo gives a null maxPage."
+#~ msgstr "wxPrintout::GetPageInfo trả lại một maxPage rỗng."
+
+#~ msgid "Event queue overflowed"
+#~ msgstr "Hàng đợi sự kiện bị tràn"
+
+#~ msgid "percent"
+#~ msgstr "phần trăm"
+
+#~ msgid "Print preview"
+#~ msgstr "Mô phỏng bản in"
+
+#~ msgid "'"
+#~ msgstr "'"
+
+#~ msgid "1"
+#~ msgstr "1"
+
+#~ msgid "10"
+#~ msgstr "10"
+
+#~ msgid "3"
+#~ msgstr "3"
+
+#~ msgid "4"
+#~ msgstr "4"
+
+#~ msgid "5"
+#~ msgstr "5"
+
+#~ msgid "6"
+#~ msgstr "6"
+
+#~ msgid "7"
+#~ msgstr "7"
+
+#~ msgid "8"
+#~ msgstr "8"
+
+#~ msgid "9"
+#~ msgstr "9"
+
+#~ msgid "Can't monitor non-existent path \"%s\" for changes."
+#~ msgstr ""
+#~ "Không thể theo dõi đường dẫn không-hiện-có \"%s\" để thấy được các thay "
+#~ "đổi."
+
+#~ msgid "File system containing watched object was unmounted"
+#~ msgstr "Hệ thống tập tin chứa đối tượng theo dõi chưa được gắn vào"
+
+#~ msgid "&Preview..."
+#~ msgstr "&Xem trước..."
+
+#~ msgid "Passing an unkown object to GetObject"
+#~ msgstr "Chuyển qua một đối tượng không rõ để SetObject"
+
+#~ msgid "Preview..."
+#~ msgstr "Xem trước..."
+
+#~ msgid "The vertical offset relative to the paragraph."
+#~ msgstr "Khoảng bù (offset) dọc liên quan đến đoạn."
+
+#~ msgid "Units for the object offset."
+#~ msgstr "Đơn vị cho khoảng bù (offset) đối tượng."
+
+#~ msgid "&Goto..."
+#~ msgstr "Nhả&y tới..."
+
+#~ msgid "&Save..."
+#~ msgstr "&Ghi lại..."
+
+#~ msgid "<<"
+#~ msgstr "<<"
+
+#~ msgid ">>"
+#~ msgstr ">>"
+
+#~ msgid ">>|"
+#~ msgstr ">>|"
+
+#~ msgid "Added item is invalid."
+#~ msgstr "Thêm mục tin là không hợp lệ."
+
+#~ msgid "All files (*.*)|*"
+#~ msgstr "Mọi tập tin (*.*)|*"
+
+#~ msgid "BIG5"
+#~ msgstr "BIG5"
+
+#~ msgid "Can't check image format of file '%s': file does not exist."
+#~ msgstr ""
+#~ "Không thể kiểm tra định dạng tập tin ảnh '%s': tập tin không tồn tại."
+
+#~ msgid "Can't load image from file '%s': file does not exist."
+#~ msgstr "Không thể tải ảnh từ tập tin '%s': tập tin không tồn tại."
+
+#~ msgid "Cannot initialize SciTech MGL!"
+#~ msgstr "Không thể khởi tạo SciTech MGL!"
+
+#~ msgid "Cannot initialize display."
+#~ msgstr "Không thể khỏi tạo bộ hiển thị."
+
+#~ msgid "Cannot open file '%s'."
+#~ msgstr "Không thể mở tập tin %s."
+
+#~ msgid "Cannot start thread: error writing TLS"
+#~ msgstr "Không thể khởi động tuyến trình: lỗi ghi TLS."
+
+#~ msgid "Changed item is invalid."
+#~ msgstr "Thay đổi mục tin không hợp lệ."
+
+#~ msgid "Click to cancel this window."
+#~ msgstr "Bấm vào để hủy cửa sổ này."
+
+#~ msgid "Click to confirm your selection."
+#~ msgstr "Nhấn để xác thực việc chọn."
+
+#~ msgid "Close\tAlt-F4"
+#~ msgstr "Đóng lại\tAlt-F4"
+
+#~ msgid "Column could not be added to native control."
+#~ msgstr "Cột không thể chèn thêm vào một điều khiển cơ bản"
+
+#~ msgid "Column does not have a renderer."
+#~ msgstr "Cột không có bộ xử lý."
+
+#~ msgid "Column pointer must not be NULL."
+#~ msgstr "Con trỏ cột phải khác NULL."
+
+#~ msgid "Column's model column has no equivalent in the associated model."
+#~ msgstr "Mô hình của cột phải không tương đương với mô hình liên quan."
+
+#~ msgid "Could not add column to internal structures."
+#~ msgstr "Không thể thêm cột vào cấu trúc nội tại."
+
+#~ msgid "Couldn't create cursor."
+#~ msgstr "Không tạo được con trỏ chuột."
+
+#~ msgid "Directory '%s' doesn't exist!"
+#~ msgstr "Thư mục '%s' chưa tồn tại!"
+
+#~ msgid "Enter a page number between %d and %d:"
+#~ msgstr "Nhập vào số trang nằm giữa %d và %d:"
+
+#~ msgid "Failed to create a status bar."
+#~ msgstr "Tạo thanh trạng thái gặp lỗi."
+
+#~ msgid "GB-2312"
+#~ msgstr "GB-2312"
+
+#~ msgid "Goto Page"
+#~ msgstr "Nhảy tới Trang"
+
+#~ msgid ""
+#~ "HTML pagination algorithm generated more than the allowed maximum number "
+#~ "of pages and it can't continue any longer!"
+#~ msgstr ""
+#~ "Thuật toán chia trang HTML tạo ra nhiều hơn số tối đa trang được phép và "
+#~ "nó không thể tiếp tục được nữa!"
+
+#~ msgid "I64"
+#~ msgstr "I64"
+
+#~ msgid "Internal error, illegal wxCustomTypeInfo"
+#~ msgstr "Lỗi nội bộ, wxCustomTypeInfo không hợp lệ"
+
+#~ msgid "Mode %ix%i-%i not available."
+#~ msgstr "Chế độ %ix%i-%i không sẵn sàng."
+
+#~ msgid "Model pointer not initialized."
+#~ msgstr "Mô hình con trỏ không thể khởi tạo."
+
+#~ msgid "No image handler for type %ld defined."
+#~ msgstr "Không có bộ điều khiển ảnh cho kiểu %ld đã định nghĩa."
+
+#~ msgid "No model associated with control."
+#~ msgstr "Không có mô hình liên kết với điều khiển này."
+
+#~ msgid "Owner not initialized."
+#~ msgstr "Chủ sở hữu không khởi tạo."
+
+#~ msgid "Paper Size"
+#~ msgstr "Cỡ giấy"
+
+#~ msgid "Passed item is invalid."
+#~ msgstr "Mục tin chuyển tới không hợp lệ."
+
+#~ msgid "Passing a already registered object to SetObjectName"
+#~ msgstr "Chuyển qua một đối tượng đã được đăng ký rồi để SetObjectName"
+
+#~ msgid "Pointer to dataview control must not be NULL"
+#~ msgstr "Con trỏ tới điều khiển hiển thị dữ liệu không được đặt bằng NULL."
+
+#~ msgid "Pointer to native control must not be NULL."
+#~ msgstr "Con trỏ tới điều khiển native không được đặt bằng NULL."
+
+#~ msgid "SHIFT-JIS"
+#~ msgstr "SHIFT-JIS"
+
+#~ msgid ""
+#~ "Streaming delegates for not already streamed objects not yet supported"
+#~ msgstr "Đại diện Streaming cho đối tượng streamed vẫn chưa được hỗ trợ"
+
+#~ msgid ""
+#~ "The data format for the GET-direction of the to be added data object "
+#~ "already exists"
+#~ msgstr ""
+#~ "Định dạng dữ liệu cho bộ điều hướng GET của đối tượng dữ liệu được thêm "
+#~ "vào đã có rồi"
+
+#~ msgid ""
+#~ "The data format for the SET-direction of the to be added data object "
+#~ "already exists"
+#~ msgstr ""
+#~ "Định dạng dữ liệu cho bộ điều hướng SET của đối tượng dữ liệu được thêm "
+#~ "vào đã có rồi"
+
+#~ msgid "The file '%s' doesn't exist and couldn't be opened."
+#~ msgstr "Tập tin '%s' chưa tồn tại và không thể mở."
+
+#~ msgid "The path '%s' contains too many \"..\"!"
+#~ msgstr "Đường dẫn '%s' chứa quá nhiều \"..\"!"
+
+#~ msgid "To be deleted item is invalid."
+#~ msgstr "Xóa mục tin là không hợp lệ."
+
+#~ msgid "Update"
+#~ msgstr "Cập nhật"
+
+#~ msgid "Value must be %lld or higher"
+#~ msgstr "Giá trị phải là %lld hay lớn hơn"
+
+#~ msgid "Value must be %llu or higher"
+#~ msgstr "Giá trị phải là %llu hay nhỏ hơn"
+
+#~ msgid "Value must be %llu or less"
+#~ msgstr "Giá trị phải là %llu hay nhỏ hơn"
+
+#~ msgid "Warning"
+#~ msgstr "Cảnh báo"
+
+#~ msgid "Windows 2000 (build %lu"
+#~ msgstr "Windows 2000 (build %lu"
+
+#~ msgid "delegate has no type info"
+#~ msgstr "delegate không có thông tin kiểu"
+
+#~ msgid "wxSearchEngine::LookFor must be called before scanning!"
+#~ msgstr "wxSearchEngine::LookFor phải được gọi trước khi quét!"
+
+#~ msgid "|<<"
+#~ msgstr "|<<"
+
+#~ msgid "%.*f GB"
+#~ msgstr "%.*f GB"
+
+#~ msgid "%.*f MB"
+#~ msgstr "%.*f MB"
+
+#~ msgid "%.*f TB"
+#~ msgstr "%.*f TB"
+
+#~ msgid "%.*f kB"
+#~ msgstr "%.*f kB"
+
+#~ msgid "%s B"
+#~ msgstr "%s B"
+
+#~ msgid "Archive doesnt contain #SYSTEM file"
+#~ msgstr "Phần lưu trữ không chứa tập tin hệ thống #SYSTEM"
+
+#~ msgid "Cannot convert dialog units: dialog unknown."
+#~ msgstr "Không thể chuyển đổi đơn vị hộp thoại: hộp thoại chưa được biết."
+
+#~ msgid "Cannot convert from the charset '%s'!"
+#~ msgstr "Không thể chuyển đổi từ bộ ký tự '%s'!"
+
+#~ msgid "Cannot find container for unknown control '%s'."
+#~ msgstr "Không tìm thấy container cho điều khiển không rõ '%s'."
+
+#~ msgid "Cannot find font node '%s'."
+#~ msgstr "Không thể tìm thấy nút phông chữ '%s'."
+
+#~ msgid "Cannot parse coordinates from '%s'."
+#~ msgstr "Không thể phân tách hệ tọa độ từ '%s'."
+
+#~ msgid "Cannot parse dimension from '%s'."
+#~ msgstr "Không thể phân tách kích thước từ '%s'."
+
+#~ msgid "Cant create the thread event queue"
+#~ msgstr "Không thể tạo hàng đợi sự kiện tuyến trình"
+
+#~ msgid "Control is wrongly initialized."
+#~ msgstr "Điều khiển khởi tạo sai."
+
+#~ msgid "Could not unlock mutex"
+#~ msgstr "Không thể bỏ khóa mutex"
+
+#~ msgid "Data view control is not correctly initialized"
+#~ msgstr "Điều khiển hiển thị dữ liệu không được khởi tạo một cách đúng đắn."
+
+#~ msgid "Error while waiting on semaphore"
+#~ msgstr "Lỗi khi chờ cờ hiệu"
+
+#~ msgid "Failed to register OpenGL window class."
+#~ msgstr "Đăng ký một lớp cửa sổ OpenGL gặp lỗi."
+
+#~ msgid "Fatal error: "
+#~ msgstr "Lỗi nghiêm trọng: "
+
+#~ msgid "Go forward to the next HTML page"
+#~ msgstr "Tiến tới trang HTML tiếp theo"
+
+#~ msgid "Help : %s"
+#~ msgstr "Trợ giúp : %s"
+
+#~ msgid "Invalid XRC resource '%s': doesn't have root node 'resource'."
+#~ msgstr "Tài nguyên XRC '%s' không hợp lệ: không có nút gốc 'resource'."
+
+#~ msgid "No handler found for XML node '%s', class '%s'!"
+#~ msgstr "Không tìm thấy handler XML cho nút '%s', lớp '%s'!"
+
+#~ msgid "Preparing help window..."
+#~ msgstr "Đang chuẩn bị cửa sổ trợ giúp..."
+
+#~ msgid "Program aborted."
+#~ msgstr "Chương trình bị bãi bỏ."
+
+#~ msgid "Referenced object node with ref=\"%s\" not found!"
+#~ msgstr "Nốt đối tượng có liên quan đến ref=\"%s\" không tìm thấy!"
+
+#~ msgid "Resource files must have same version number!"
+#~ msgstr "Tập tin tài nguyên phải có cùng số phiên bản!"
+
+#~ msgid "Search!"
+#~ msgstr "Tìm kiếm!"
+
+#~ msgid "Sorry, could not open this file for saving."
+#~ msgstr "Rất tiếc, không thể mở tập tin này để ghi."
+
+#~ msgid "Sorry, could not save this file."
+#~ msgstr "Rất tiếc, không thể ghi lại tập tin này."
+
+#~ msgid "Sorry, print preview needs a printer to be installed."
+#~ msgstr "Rất tiếc, việc mô phỏng bản in cần một máy in đã được cài đặt."
+
+#~ msgid "Status: "
+#~ msgstr "Tình trạng: "
+
+#~ msgid "Subclass '%s' not found for resource '%s', not subclassing!"
+#~ msgstr ""
+#~ "Lớp con '%s' không được tìm thấy cho tài nguyên '%s', không có lớp con!"
+
+#~ msgid "TIFF library error."
+#~ msgstr "Thư viện TIFF bị lỗi."
+
+#~ msgid "TIFF library warning."
+#~ msgstr "Cảnh giác với thư viện TIFF."
+
+#~ msgid "Trying to solve a NULL hostname: giving up"
+#~ msgstr "Đang cố gắng giải quyết một tên máy chủ RỖNG: đưa lên"
+
+#~ msgid "Unknown style flag "
+#~ msgstr "Không rõ kiểu cờ "
+
+#~ msgid "XRC resource '%s' (class '%s') not found!"
+#~ msgstr "Tài nguyên XRC '%s' (lớp '%s') không tìm thấy!"
+
+#~ msgid "XRC resource: Cannot create animation from '%s'."
+#~ msgstr "Tài nguyên XRC: Không thể tạo hoạt hình từ '%s'."
+
+#~ msgid "XRC resource: Cannot create bitmap from '%s'."
+#~ msgstr "Tài nguyên XRC: Không thể tạo ảnh bitmap từ '%s'."
+
+#~ msgid ""
+#~ "XRC resource: Incorrect colour specification '%s' for attribute '%s'."
+#~ msgstr ""
+#~ "Tài nguyên XRC: Sự định màu '%s' không chính xác cho thuộc tính '%s'."
+
+#~ msgid "[EMPTY]"
+#~ msgstr "[EMPTY]"
+
+#~ msgid "catalog file for domain '%s' not found."
+#~ msgstr "tập tin catalog cho tên miền '%s' không tìm thấy."
+
+#~ msgid "encoding %i"
+#~ msgstr "bộ mã %i"
+
+#~ msgid "looking for catalog '%s' in path '%s'."
+#~ msgstr "tìm catalog '%s' trong đường dẫn '%s'."
+
+#~ msgid "m_peer is not or incorrectly initialized"
+#~ msgstr "khởi tạo m_peer không được hay không chính xác"
+
+#~ msgid "wxRichTextFontPage"
+#~ msgstr "wxRichTextFontPage"
+
+#~ msgid "wxSocket: invalid signature in ReadMsg."
+#~ msgstr "wxSocket: chữ ký không hợp lệ trong ReadMsg."
+
+#~ msgid "wxSocket: unknown event!."
+#~ msgstr "wxSocket: không rõ sự kiện!."

--- a/po_wxstd/wxstd.pot
+++ b/po_wxstd/wxstd.pot
@@ -1,0 +1,9194 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-05-14 20:23+0200\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=CHARSET\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
+
+#: ../include/wx/defs.h:2582
+msgid "All files (*.*)|*.*"
+msgstr ""
+
+#: ../include/wx/defs.h:2585
+msgid "All files (*)|*"
+msgstr ""
+
+#: ../include/wx/generic/progdlgg.h:85
+msgid "Elapsed time:"
+msgstr ""
+
+#: ../include/wx/generic/progdlgg.h:86
+msgid "Estimated time:"
+msgstr ""
+
+#: ../include/wx/generic/progdlgg.h:87
+msgid "Remaining time:"
+msgstr ""
+
+#. TRANSLATORS: HTML printout default title.
+#: ../include/wx/html/htmprint.h:121 ../include/wx/prntbase.h:273
+#: ../include/wx/richtext/richtextprint.h:109 ../src/common/docview.cpp:2161
+msgid "Printout"
+msgstr ""
+
+#. TRANSLATORS: HTML easy print default title.
+#: ../include/wx/html/htmprint.h:234 ../include/wx/richtext/richtextprint.h:163
+#: ../src/common/prntbase.cpp:522 ../src/html/htmprint.cpp:291
+msgid "Printing"
+msgstr ""
+
+#: ../include/wx/msgdlg.h:277 ../src/common/stockitem.cpp:211
+msgid "Yes"
+msgstr ""
+
+#: ../include/wx/msgdlg.h:278 ../src/common/stockitem.cpp:182
+msgid "No"
+msgstr ""
+
+#: ../include/wx/msgdlg.h:279 ../src/common/stockitem.cpp:183
+#: ../src/msw/msgdlg.cpp:430 ../src/msw/msgdlg.cpp:734
+#: ../src/richtext/richtextstyledlg.cpp:292
+msgid "OK"
+msgstr ""
+
+#: ../include/wx/msgdlg.h:280 ../src/common/stockitem.cpp:150
+#: ../src/msw/msgdlg.cpp:430 ../src/msw/progdlg.cpp:884
+#: ../src/richtext/richtextstyledlg.cpp:295
+msgid "Cancel"
+msgstr ""
+
+#: ../include/wx/msgdlg.h:281 ../src/common/stockitem.cpp:168
+#: ../src/html/helpdlg.cpp:63 ../src/html/helpfrm.cpp:108
+#: ../src/osx/button_osx.cpp:38
+msgid "Help"
+msgstr ""
+
+#: ../include/wx/msw/ole/oleutils.h:52
+msgid "Cannot initialize OLE"
+msgstr ""
+
+#: ../include/wx/msw/private/fswatcher.h:48
+#, c-format
+msgid "Unable to close the handle for '%s'"
+msgstr ""
+
+#: ../include/wx/msw/private/fswatcher.h:92
+#, c-format
+msgid "Failed to open directory \"%s\" for monitoring."
+msgstr ""
+
+#: ../include/wx/msw/private/fswatcher.h:125
+msgid "Unable to close I/O completion port handle"
+msgstr ""
+
+#: ../include/wx/msw/private/fswatcher.h:142
+msgid "Unable to associate handle with I/O completion port"
+msgstr ""
+
+#: ../include/wx/msw/private/fswatcher.h:148
+msgid "Unexpectedly new I/O completion port was created"
+msgstr ""
+
+#: ../include/wx/msw/private/fswatcher.h:213
+msgid "Unable to post completion status"
+msgstr ""
+
+#: ../include/wx/msw/private/fswatcher.h:262
+msgid "Unable to dequeue completion packet"
+msgstr ""
+
+#: ../include/wx/msw/private/fswatcher.h:273
+msgid "Unable to create I/O completion port"
+msgstr ""
+
+#: ../include/wx/richmsgdlg.h:29
+msgid "&See details"
+msgstr ""
+
+#: ../include/wx/richmsgdlg.h:30
+msgid "&Hide details"
+msgstr ""
+
+#: ../include/wx/richtext/richtextbuffer.h:3864
+msgid "&Box"
+msgstr ""
+
+#: ../include/wx/richtext/richtextbuffer.h:5008
+msgid "&Picture"
+msgstr ""
+
+#: ../include/wx/richtext/richtextbuffer.h:5958
+msgid "&Cell"
+msgstr ""
+
+#: ../include/wx/richtext/richtextbuffer.h:6067
+msgid "&Table"
+msgstr ""
+
+#: ../include/wx/richtext/richtextimagedlg.h:37
+msgid "Object Properties"
+msgstr ""
+
+#: ../include/wx/richtext/richtextsymboldlg.h:39
+msgid "Symbols"
+msgstr ""
+
+#: ../include/wx/unix/pipe.h:46
+msgid "Pipe creation failed"
+msgstr ""
+
+#: ../include/wx/unix/private/displayx11.h:65
+msgid "Failed to enumerate video modes"
+msgstr ""
+
+#: ../include/wx/unix/private/displayx11.h:89
+msgid "Failed to change video mode"
+msgstr ""
+
+#: ../include/wx/unix/private/fswatcher_kqueue.h:57
+#, c-format
+msgid "Unable to open path '%s'"
+msgstr ""
+
+#: ../include/wx/unix/private/fswatcher_kqueue.h:74
+#, c-format
+msgid "Unable to close path '%s'"
+msgstr ""
+
+#: ../include/wx/xtiprop.h:175
+msgid "SetProperty called w/o valid setter"
+msgstr ""
+
+#: ../include/wx/xtiprop.h:184
+msgid "GetProperty called w/o valid getter"
+msgstr ""
+
+#: ../include/wx/xtiprop.h:193
+msgid "AddToPropertyCollection called w/o valid adder"
+msgstr ""
+
+#: ../include/wx/xtiprop.h:202
+msgid "GetPropertyCollection called w/o valid collection getter"
+msgstr ""
+
+#: ../include/wx/xtiprop.h:255
+msgid "AddToPropertyCollection called on a generic accessor"
+msgstr ""
+
+#: ../include/wx/xtiprop.h:262
+msgid "GetPropertyCollection called on a generic accessor"
+msgstr ""
+
+#: ../src/aui/tabmdi.cpp:106 ../src/generic/mdig.cpp:94
+msgid "Cl&ose"
+msgstr ""
+
+#: ../src/aui/tabmdi.cpp:107 ../src/generic/mdig.cpp:95
+msgid "Close All"
+msgstr ""
+
+#: ../src/aui/tabmdi.cpp:109 ../src/generic/mdig.cpp:97 ../src/msw/mdi.cpp:175
+#: ../src/qt/mdi.cpp:258
+msgid "&Next"
+msgstr ""
+
+#: ../src/aui/tabmdi.cpp:110 ../src/generic/mdig.cpp:98 ../src/msw/mdi.cpp:176
+#: ../src/qt/mdi.cpp:259
+msgid "&Previous"
+msgstr ""
+
+#: ../src/aui/tabmdi.cpp:332 ../src/aui/tabmdi.cpp:348
+#: ../src/aui/tabmdi.cpp:350 ../src/generic/mdig.cpp:291
+#: ../src/generic/mdig.cpp:307 ../src/generic/mdig.cpp:311
+#: ../src/msw/mdi.cpp:337 ../src/qt/mdi.cpp:462
+msgid "&Window"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:47
+msgctxt "keyboard key"
+msgid "Delete"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:48
+msgctxt "keyboard key"
+msgid "Del"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:49
+msgctxt "keyboard key"
+msgid "Back"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:49
+msgctxt "keyboard key"
+msgid "Backspace"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:50
+msgctxt "keyboard key"
+msgid "Insert"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:51
+msgctxt "keyboard key"
+msgid "Ins"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:52
+msgctxt "keyboard key"
+msgid "Enter"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:53
+msgctxt "keyboard key"
+msgid "Return"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:54
+msgctxt "keyboard key"
+msgid "PageUp"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:54
+msgctxt "keyboard key"
+msgid "Page Up"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:55
+msgctxt "keyboard key"
+msgid "PageDown"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:55
+msgctxt "keyboard key"
+msgid "Page Down"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:56
+msgctxt "keyboard key"
+msgid "PgUp"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:57
+msgctxt "keyboard key"
+msgid "PgDn"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:58
+msgctxt "keyboard key"
+msgid "Left"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:59
+msgctxt "keyboard key"
+msgid "Right"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:60
+msgctxt "keyboard key"
+msgid "Up"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:61
+msgctxt "keyboard key"
+msgid "Down"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:62
+msgctxt "keyboard key"
+msgid "Home"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:63
+msgctxt "keyboard key"
+msgid "End"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:64
+msgctxt "keyboard key"
+msgid "Space"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:65
+msgctxt "keyboard key"
+msgid "Tab"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:66
+msgctxt "keyboard key"
+msgid "Esc"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:67
+msgctxt "keyboard key"
+msgid "Escape"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:68
+msgctxt "keyboard key"
+msgid "Cancel"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:69
+msgctxt "keyboard key"
+msgid "Clear"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:70
+msgctxt "keyboard key"
+msgid "Menu"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:71
+msgctxt "keyboard key"
+msgid "Pause"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:72
+msgctxt "keyboard key"
+msgid "Capital"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:73
+msgctxt "keyboard key"
+msgid "Select"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:74
+msgctxt "keyboard key"
+msgid "Print"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:75
+msgctxt "keyboard key"
+msgid "Execute"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:76
+msgctxt "keyboard key"
+msgid "Snapshot"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:77
+msgctxt "keyboard key"
+msgid "Help"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:78
+msgctxt "keyboard key"
+msgid "Add"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:79
+msgctxt "keyboard key"
+msgid "Separator"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:80
+msgctxt "keyboard key"
+msgid "Subtract"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:81
+msgctxt "keyboard key"
+msgid "Decimal"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:82
+msgctxt "keyboard key"
+msgid "Multiply"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:83
+msgctxt "keyboard key"
+msgid "Divide"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:84
+msgctxt "keyboard key"
+msgid "Num_lock"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:84
+msgctxt "keyboard key"
+msgid "Num Lock"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:85
+msgctxt "keyboard key"
+msgid "Scroll_lock"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:85
+msgctxt "keyboard key"
+msgid "Scroll Lock"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:86
+msgctxt "keyboard key"
+msgid "KP_Space"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:86
+msgctxt "keyboard key"
+msgid "Num Space"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:87
+msgctxt "keyboard key"
+msgid "KP_Tab"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:87
+msgctxt "keyboard key"
+msgid "Num Tab"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:88
+msgctxt "keyboard key"
+msgid "KP_Enter"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:88
+msgctxt "keyboard key"
+msgid "Num Enter"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:89
+msgctxt "keyboard key"
+msgid "KP_Home"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:89
+msgctxt "keyboard key"
+msgid "Num Home"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:90
+msgctxt "keyboard key"
+msgid "KP_Left"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:90
+msgctxt "keyboard key"
+msgid "Num left"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:91
+msgctxt "keyboard key"
+msgid "KP_Up"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:91
+msgctxt "keyboard key"
+msgid "Num Up"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:92
+msgctxt "keyboard key"
+msgid "KP_Right"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:92
+msgctxt "keyboard key"
+msgid "Num Right"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:93
+msgctxt "keyboard key"
+msgid "KP_Down"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:93
+msgctxt "keyboard key"
+msgid "Num Down"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:94
+msgctxt "keyboard key"
+msgid "KP_PageUp"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:94
+msgctxt "keyboard key"
+msgid "Num Page Up"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:95
+msgctxt "keyboard key"
+msgid "KP_PageDown"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:95
+msgctxt "keyboard key"
+msgid "Num Page Down"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:96
+msgctxt "keyboard key"
+msgid "KP_Prior"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:97
+msgctxt "keyboard key"
+msgid "KP_Next"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:98
+msgctxt "keyboard key"
+msgid "KP_End"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:98
+msgctxt "keyboard key"
+msgid "Num End"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:99
+msgctxt "keyboard key"
+msgid "KP_Begin"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:99
+msgctxt "keyboard key"
+msgid "Num Begin"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:100
+msgctxt "keyboard key"
+msgid "KP_Insert"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:100
+msgctxt "keyboard key"
+msgid "Num Insert"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:101
+msgctxt "keyboard key"
+msgid "KP_Delete"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:101
+msgctxt "keyboard key"
+msgid "Num Delete"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:102
+msgctxt "keyboard key"
+msgid "KP_Equal"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:102
+msgctxt "keyboard key"
+msgid "Num ="
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:103
+msgctxt "keyboard key"
+msgid "KP_Multiply"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:103
+msgctxt "keyboard key"
+msgid "Num *"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:104
+msgctxt "keyboard key"
+msgid "KP_Add"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:104
+msgctxt "keyboard key"
+msgid "Num +"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:105
+msgctxt "keyboard key"
+msgid "KP_Separator"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:105
+msgctxt "keyboard key"
+msgid "Num ,"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:106
+msgctxt "keyboard key"
+msgid "KP_Subtract"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:106
+msgctxt "keyboard key"
+msgid "Num -"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:107
+msgctxt "keyboard key"
+msgid "KP_Decimal"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:107
+msgctxt "keyboard key"
+msgid "Num ."
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:108
+msgctxt "keyboard key"
+msgid "KP_Divide"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:108
+msgctxt "keyboard key"
+msgid "Num /"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:109
+msgctxt "keyboard key"
+msgid "Windows_Left"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:110
+msgctxt "keyboard key"
+msgid "Windows_Right"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:111
+msgctxt "keyboard key"
+msgid "Windows_Menu"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:112
+msgctxt "keyboard key"
+msgid "Command"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:186 ../src/common/accelcmn.cpp:359
+msgctxt "keyboard key"
+msgid "Ctrl"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:188 ../src/common/accelcmn.cpp:363
+msgctxt "keyboard key"
+msgid "Alt"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:190 ../src/common/accelcmn.cpp:361
+msgctxt "keyboard key"
+msgid "Shift"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:196
+msgctxt "keyboard key"
+msgid "num "
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:260 ../src/common/accelcmn.cpp:382
+msgctxt "keyboard key"
+msgid "F"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:277 ../src/common/accelcmn.cpp:385
+msgctxt "keyboard key"
+msgid "KP_F"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:280 ../src/common/accelcmn.cpp:388
+msgctxt "keyboard key"
+msgid "KP_"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:283 ../src/common/accelcmn.cpp:391
+msgctxt "keyboard key"
+msgid "SPECIAL"
+msgstr ""
+
+#: ../src/common/accelcmn.cpp:373
+msgid "Ctrl"
+msgstr ""
+
+#: ../src/common/appbase.cpp:786
+msgid "show this help message"
+msgstr ""
+
+#: ../src/common/appbase.cpp:796
+msgid "generate verbose log messages"
+msgstr ""
+
+#: ../src/common/appcmn.cpp:256
+msgid "specify the theme to use"
+msgstr ""
+
+#: ../src/common/appcmn.cpp:270
+msgid "specify display mode to use (e.g. 640x480-16)"
+msgstr ""
+
+#: ../src/common/appcmn.cpp:292
+#, c-format
+msgid "Unsupported theme '%s'."
+msgstr ""
+
+#: ../src/common/appcmn.cpp:309
+#, c-format
+msgid "Invalid display mode specification '%s'."
+msgstr ""
+
+#: ../src/common/cmdline.cpp:875
+#, c-format
+msgid "Option '%s' can't be negated"
+msgstr ""
+
+#: ../src/common/cmdline.cpp:889
+#, c-format
+msgid "Unknown long option '%s'"
+msgstr ""
+
+#: ../src/common/cmdline.cpp:904 ../src/common/cmdline.cpp:926
+#, c-format
+msgid "Unknown option '%s'"
+msgstr ""
+
+#: ../src/common/cmdline.cpp:1004
+#, c-format
+msgid "Unexpected characters following option '%s'."
+msgstr ""
+
+#: ../src/common/cmdline.cpp:1039
+#, c-format
+msgid "Option '%s' requires a value."
+msgstr ""
+
+#: ../src/common/cmdline.cpp:1058
+#, c-format
+msgid "Separator expected after the option '%s'."
+msgstr ""
+
+#: ../src/common/cmdline.cpp:1088 ../src/common/cmdline.cpp:1106
+#, c-format
+msgid "'%s' is not a correct numeric value for option '%s'."
+msgstr ""
+
+#: ../src/common/cmdline.cpp:1122
+#, c-format
+msgid "Option '%s': '%s' cannot be converted to a date."
+msgstr ""
+
+#: ../src/common/cmdline.cpp:1170
+#, c-format
+msgid "Unexpected parameter '%s'"
+msgstr ""
+
+#. TRANSLATORS: Short name and long name for a command line option
+#: ../src/common/cmdline.cpp:1197
+#, c-format
+msgid "%s (or %s)"
+msgstr ""
+
+#: ../src/common/cmdline.cpp:1208
+#, c-format
+msgid "The value for the option '%s' must be specified."
+msgstr ""
+
+#: ../src/common/cmdline.cpp:1230
+#, c-format
+msgid "The required parameter '%s' was not specified."
+msgstr ""
+
+#: ../src/common/cmdline.cpp:1289
+#, c-format
+msgid "Usage: %s"
+msgstr ""
+
+#: ../src/common/cmdline.cpp:1498
+msgid "str"
+msgstr ""
+
+#: ../src/common/cmdline.cpp:1502
+msgid "num"
+msgstr ""
+
+#: ../src/common/cmdline.cpp:1506
+msgid "double"
+msgstr ""
+
+#: ../src/common/cmdline.cpp:1510
+msgid "date"
+msgstr ""
+
+#: ../src/common/cmdproc.cpp:250 ../src/common/cmdproc.cpp:276
+#: ../src/common/cmdproc.cpp:296
+msgid "Unnamed command"
+msgstr ""
+
+#: ../src/common/cmdproc.cpp:253
+msgid "&Undo "
+msgstr ""
+
+#: ../src/common/cmdproc.cpp:255
+msgid "Can't &Undo "
+msgstr ""
+
+#: ../src/common/cmdproc.cpp:259 ../src/common/stockitem.cpp:208
+#: ../src/msw/textctrl.cpp:2880 ../src/osx/textctrl_osx.cpp:649
+#: ../src/richtext/richtextctrl.cpp:327
+msgid "&Undo"
+msgstr ""
+
+#: ../src/common/cmdproc.cpp:277 ../src/common/cmdproc.cpp:297
+msgid "&Redo "
+msgstr ""
+
+#: ../src/common/cmdproc.cpp:281 ../src/common/cmdproc.cpp:288
+#: ../src/common/stockitem.cpp:190 ../src/msw/textctrl.cpp:2881
+#: ../src/osx/textctrl_osx.cpp:650 ../src/richtext/richtextctrl.cpp:328
+msgid "&Redo"
+msgstr ""
+
+#: ../src/common/colourcmn.cpp:41
+#, c-format
+msgid "String To Colour : Incorrect colour specification : %s"
+msgstr ""
+
+#: ../src/common/config.cpp:259
+#, c-format
+msgid "Invalid value %ld for a boolean key \"%s\" in config file."
+msgstr ""
+
+#: ../src/common/config.cpp:526
+#, c-format
+msgid ""
+"Environment variables expansion failed: missing '%c' at position %u in '%s'."
+msgstr ""
+
+#: ../src/common/config.cpp:576 ../src/msw/regconf.cpp:272
+#, c-format
+msgid "'%s' has extra '..', ignored."
+msgstr ""
+
+#. TRANSLATORS: Checkbox state name
+#: ../src/common/datavcmn.cpp:2166 ../src/generic/datavgen.cpp:1430
+msgid "checked"
+msgstr ""
+
+#. TRANSLATORS: Checkbox state name
+#: ../src/common/datavcmn.cpp:2170 ../src/generic/datavgen.cpp:1432
+msgid "unchecked"
+msgstr ""
+
+#. TRANSLATORS: Checkbox state name
+#: ../src/common/datavcmn.cpp:2174
+msgid "undetermined"
+msgstr ""
+
+#: ../src/common/datetimefmt.cpp:1875
+msgid "today"
+msgstr ""
+
+#: ../src/common/datetimefmt.cpp:1876
+msgid "yesterday"
+msgstr ""
+
+#: ../src/common/datetimefmt.cpp:1877
+msgid "tomorrow"
+msgstr ""
+
+#: ../src/common/datetimefmt.cpp:2071
+msgid "first"
+msgstr ""
+
+#: ../src/common/datetimefmt.cpp:2072
+msgid "second"
+msgstr ""
+
+#: ../src/common/datetimefmt.cpp:2073
+msgid "third"
+msgstr ""
+
+#: ../src/common/datetimefmt.cpp:2074
+msgid "fourth"
+msgstr ""
+
+#: ../src/common/datetimefmt.cpp:2075
+msgid "fifth"
+msgstr ""
+
+#: ../src/common/datetimefmt.cpp:2076
+msgid "sixth"
+msgstr ""
+
+#: ../src/common/datetimefmt.cpp:2077
+msgid "seventh"
+msgstr ""
+
+#: ../src/common/datetimefmt.cpp:2078
+msgid "eighth"
+msgstr ""
+
+#: ../src/common/datetimefmt.cpp:2079
+msgid "ninth"
+msgstr ""
+
+#: ../src/common/datetimefmt.cpp:2080
+msgid "tenth"
+msgstr ""
+
+#: ../src/common/datetimefmt.cpp:2081
+msgid "eleventh"
+msgstr ""
+
+#: ../src/common/datetimefmt.cpp:2082
+msgid "twelfth"
+msgstr ""
+
+#: ../src/common/datetimefmt.cpp:2083
+msgid "thirteenth"
+msgstr ""
+
+#: ../src/common/datetimefmt.cpp:2084
+msgid "fourteenth"
+msgstr ""
+
+#: ../src/common/datetimefmt.cpp:2085
+msgid "fifteenth"
+msgstr ""
+
+#: ../src/common/datetimefmt.cpp:2086
+msgid "sixteenth"
+msgstr ""
+
+#: ../src/common/datetimefmt.cpp:2087
+msgid "seventeenth"
+msgstr ""
+
+#: ../src/common/datetimefmt.cpp:2088
+msgid "eighteenth"
+msgstr ""
+
+#: ../src/common/datetimefmt.cpp:2089
+msgid "nineteenth"
+msgstr ""
+
+#: ../src/common/datetimefmt.cpp:2090
+msgid "twentieth"
+msgstr ""
+
+#: ../src/common/datetimefmt.cpp:2248
+msgid "noon"
+msgstr ""
+
+#: ../src/common/datetimefmt.cpp:2249
+msgid "midnight"
+msgstr ""
+
+#: ../src/common/debugrpt.cpp:209
+#, c-format
+msgid "Failed to create directory \"%s\""
+msgstr ""
+
+#: ../src/common/debugrpt.cpp:210
+msgid "Debug report couldn't be created."
+msgstr ""
+
+#: ../src/common/debugrpt.cpp:227
+#, c-format
+msgid "Failed to remove debug report file \"%s\""
+msgstr ""
+
+#: ../src/common/debugrpt.cpp:239
+#, c-format
+msgid "Failed to clean up debug report directory \"%s\""
+msgstr ""
+
+#: ../src/common/debugrpt.cpp:514
+msgid "process context description"
+msgstr ""
+
+#: ../src/common/debugrpt.cpp:538
+msgid "dump of the process state (binary)"
+msgstr ""
+
+#: ../src/common/debugrpt.cpp:553
+msgid "Debug report generation has failed."
+msgstr ""
+
+#: ../src/common/debugrpt.cpp:560
+#, c-format
+msgid ""
+"Processing debug report has failed, leaving the files in \"%s\" directory."
+msgstr ""
+
+#: ../src/common/debugrpt.cpp:573
+msgid "A debug report has been generated. It can be found in"
+msgstr ""
+
+#: ../src/common/debugrpt.cpp:576
+msgid "And includes the following files:\n"
+msgstr ""
+
+#: ../src/common/debugrpt.cpp:586
+msgid ""
+"\n"
+"Please send this report to the program maintainer, thank you!\n"
+msgstr ""
+
+#: ../src/common/debugrpt.cpp:729
+msgid "Failed to execute curl, please install it in PATH."
+msgstr ""
+
+#: ../src/common/debugrpt.cpp:742
+#, c-format
+msgid "Failed to upload the debug report (error code %d)."
+msgstr ""
+
+#: ../src/common/docview.cpp:366
+msgid "Save As"
+msgstr ""
+
+#: ../src/common/docview.cpp:457
+msgid "Discard changes and reload the last saved version?"
+msgstr ""
+
+#: ../src/common/docview.cpp:488
+msgid "unnamed"
+msgstr ""
+
+#: ../src/common/docview.cpp:513
+#, c-format
+msgid "Do you want to save changes to %s?"
+msgstr ""
+
+#: ../src/common/docview.cpp:521 ../src/common/docview.cpp:560
+#: ../src/common/stockitem.cpp:195
+msgid "&Save"
+msgstr ""
+
+#: ../src/common/docview.cpp:522 ../src/common/docview.cpp:560
+msgid "&Discard changes"
+msgstr ""
+
+#: ../src/common/docview.cpp:523
+msgid "Do&n't close"
+msgstr ""
+
+#: ../src/common/docview.cpp:553
+#, c-format
+msgid "Do you want to save changes to %s before closing it?"
+msgstr ""
+
+#: ../src/common/docview.cpp:559
+msgid "The document must be closed."
+msgstr ""
+
+#: ../src/common/docview.cpp:571
+#, c-format
+msgid "Saving %s failed, would you like to retry?"
+msgstr ""
+
+#: ../src/common/docview.cpp:577
+msgid "Retry"
+msgstr ""
+
+#: ../src/common/docview.cpp:577
+msgid "Discard changes"
+msgstr ""
+
+#: ../src/common/docview.cpp:679
+#, c-format
+msgid "File \"%s\" could not be opened for writing."
+msgstr ""
+
+#: ../src/common/docview.cpp:685
+#, c-format
+msgid "Failed to save document to the file \"%s\"."
+msgstr ""
+
+#: ../src/common/docview.cpp:702
+#, c-format
+msgid "File \"%s\" could not be opened for reading."
+msgstr ""
+
+#: ../src/common/docview.cpp:714
+#, c-format
+msgid "Failed to read document from the file \"%s\"."
+msgstr ""
+
+#: ../src/common/docview.cpp:1236
+#, c-format
+msgid ""
+"The file '%s' doesn't exist and couldn't be opened.\n"
+"It has been removed from the most recently used files list."
+msgstr ""
+
+#: ../src/common/docview.cpp:1296
+msgid "Print preview creation failed."
+msgstr ""
+
+#: ../src/common/docview.cpp:1302
+msgid "Print Preview"
+msgstr ""
+
+#: ../src/common/docview.cpp:1517
+#, c-format
+msgid "The format of file '%s' couldn't be determined."
+msgstr ""
+
+#: ../src/common/docview.cpp:1643
+#, c-format
+msgid "unnamed%d"
+msgstr ""
+
+#: ../src/common/docview.cpp:1660
+msgid " - "
+msgstr ""
+
+#: ../src/common/docview.cpp:1791 ../src/common/docview.cpp:1844
+msgid "Open File"
+msgstr ""
+
+#: ../src/common/docview.cpp:1807
+msgid "File error"
+msgstr ""
+
+#: ../src/common/docview.cpp:1809
+msgid "Sorry, could not open this file."
+msgstr ""
+
+#: ../src/common/docview.cpp:1843
+msgid "Sorry, the format for this file is unknown."
+msgstr ""
+
+#: ../src/common/docview.cpp:1924
+msgid "Select a document template"
+msgstr ""
+
+#: ../src/common/docview.cpp:1925
+msgid "Templates"
+msgstr ""
+
+#: ../src/common/docview.cpp:1998
+msgid "Select a document view"
+msgstr ""
+
+#: ../src/common/docview.cpp:1999
+msgid "Views"
+msgstr ""
+
+#: ../src/common/dynlib.cpp:81
+#, c-format
+msgid "Failed to load shared library '%s'"
+msgstr ""
+
+#: ../src/common/dynlib.cpp:105
+#, c-format
+msgid "Couldn't find symbol '%s' in a dynamic library"
+msgstr ""
+
+#: ../src/common/ffile.cpp:56 ../src/common/file.cpp:215
+#, c-format
+msgid "can't open file '%s'"
+msgstr ""
+
+#: ../src/common/ffile.cpp:72
+#, c-format
+msgid "can't close file '%s'"
+msgstr ""
+
+#: ../src/common/ffile.cpp:106 ../src/common/ffile.cpp:131
+#, c-format
+msgid "Read error on file '%s'"
+msgstr ""
+
+#: ../src/common/ffile.cpp:148
+#, c-format
+msgid "Write error on file '%s'"
+msgstr ""
+
+#: ../src/common/ffile.cpp:182
+#, c-format
+msgid "failed to flush the file '%s'"
+msgstr ""
+
+#: ../src/common/ffile.cpp:222
+#, c-format
+msgid "Seek error on file '%s' (large files not supported by stdio)"
+msgstr ""
+
+#: ../src/common/ffile.cpp:232
+#, c-format
+msgid "Seek error on file '%s'"
+msgstr ""
+
+#: ../src/common/ffile.cpp:248
+#, c-format
+msgid "Can't find current position in file '%s'"
+msgstr ""
+
+#: ../src/common/ffile.cpp:349 ../src/common/file.cpp:569
+msgid "Failed to set temporary file permissions"
+msgstr ""
+
+#: ../src/common/ffile.cpp:371
+#, c-format
+msgid "can't remove file '%s'"
+msgstr ""
+
+#: ../src/common/ffile.cpp:376 ../src/common/file.cpp:591
+#, c-format
+msgid "can't commit changes to file '%s'"
+msgstr ""
+
+#: ../src/common/ffile.cpp:388 ../src/common/file.cpp:603
+#, c-format
+msgid "can't remove temporary file '%s'"
+msgstr ""
+
+#: ../src/common/file.cpp:162
+#, c-format
+msgid "can't create file '%s'"
+msgstr ""
+
+#: ../src/common/file.cpp:229
+#, c-format
+msgid "can't close file descriptor %d"
+msgstr ""
+
+#: ../src/common/file.cpp:332
+#, c-format
+msgid "can't read from file descriptor %d"
+msgstr ""
+
+#: ../src/common/file.cpp:351
+#, c-format
+msgid "can't write to file descriptor %d"
+msgstr ""
+
+#: ../src/common/file.cpp:390
+#, c-format
+msgid "can't flush file descriptor %d"
+msgstr ""
+
+#: ../src/common/file.cpp:432
+#, c-format
+msgid "can't seek on file descriptor %d"
+msgstr ""
+
+#: ../src/common/file.cpp:446
+#, c-format
+msgid "can't get seek position on file descriptor %d"
+msgstr ""
+
+#: ../src/common/file.cpp:475
+#, c-format
+msgid "can't find length of file on file descriptor %d"
+msgstr ""
+
+#: ../src/common/file.cpp:505
+#, c-format
+msgid "can't determine if the end of file is reached on descriptor %d"
+msgstr ""
+
+#: ../src/common/fileconf.cpp:352
+#, c-format
+msgid ""
+" and additionally, the existing configuration file was renamed to \"%s\" and "
+"couldn't be renamed back, please rename it to its original path \"%s\""
+msgstr ""
+
+#: ../src/common/fileconf.cpp:389
+msgid " due to the following error:\n"
+msgstr ""
+
+#: ../src/common/fileconf.cpp:412
+msgid "failed to rename the existing file"
+msgstr ""
+
+#: ../src/common/fileconf.cpp:421
+msgid "failed to create the new file directory"
+msgstr ""
+
+#: ../src/common/fileconf.cpp:428
+msgid "failed to move the file to the new location"
+msgstr ""
+
+#: ../src/common/fileconf.cpp:462
+#, c-format
+msgid "can't open global configuration file '%s'."
+msgstr ""
+
+#: ../src/common/fileconf.cpp:478
+#, c-format
+msgid "can't open user configuration file '%s'."
+msgstr ""
+
+#: ../src/common/fileconf.cpp:483
+#, c-format
+msgid "Changes won't be saved to avoid overwriting the existing file \"%s\""
+msgstr ""
+
+#: ../src/common/fileconf.cpp:583
+msgid "Error reading config options."
+msgstr ""
+
+#: ../src/common/fileconf.cpp:593
+msgid "Failed to read config options."
+msgstr ""
+
+#: ../src/common/fileconf.cpp:700
+#, c-format
+msgid "file '%s': unexpected character %c at line %zu."
+msgstr ""
+
+#: ../src/common/fileconf.cpp:736
+#, c-format
+msgid "file '%s', line %zu: '%s' ignored after group header."
+msgstr ""
+
+#: ../src/common/fileconf.cpp:765
+#, c-format
+msgid "file '%s', line %zu: '=' expected."
+msgstr ""
+
+#: ../src/common/fileconf.cpp:778
+#, c-format
+msgid "file '%s', line %zu: value for immutable key '%s' ignored."
+msgstr ""
+
+#: ../src/common/fileconf.cpp:788
+#, c-format
+msgid "file '%s', line %zu: key '%s' was first found at line %d."
+msgstr ""
+
+#: ../src/common/fileconf.cpp:1091
+#, c-format
+msgid "Config entry name cannot start with '%c'."
+msgstr ""
+
+#: ../src/common/fileconf.cpp:1146
+msgid "Failed to create configuration file directory."
+msgstr ""
+
+#: ../src/common/fileconf.cpp:1158
+msgid "can't open user configuration file."
+msgstr ""
+
+#: ../src/common/fileconf.cpp:1172
+msgid "can't write user configuration file."
+msgstr ""
+
+#: ../src/common/fileconf.cpp:1178
+msgid "Failed to update user configuration file."
+msgstr ""
+
+#: ../src/common/fileconf.cpp:1201
+msgid "Error saving user configuration data."
+msgstr ""
+
+#: ../src/common/fileconf.cpp:1313
+#, c-format
+msgid "can't delete user configuration file '%s'"
+msgstr ""
+
+#: ../src/common/fileconf.cpp:2007
+#, c-format
+msgid "entry '%s' appears more than once in group '%s'"
+msgstr ""
+
+#: ../src/common/fileconf.cpp:2021
+#, c-format
+msgid "attempt to change immutable key '%s' ignored."
+msgstr ""
+
+#: ../src/common/fileconf.cpp:2118
+#, c-format
+msgid "trailing backslash ignored in '%s'"
+msgstr ""
+
+#: ../src/common/fileconf.cpp:2153
+#, c-format
+msgid "unexpected \" at position %d in '%s'."
+msgstr ""
+
+#: ../src/common/filefn.cpp:474
+#, c-format
+msgid "Failed to copy the file '%s' to '%s'"
+msgstr ""
+
+#: ../src/common/filefn.cpp:487
+#, c-format
+msgid "Impossible to get permissions for file '%s'"
+msgstr ""
+
+#: ../src/common/filefn.cpp:501
+#, c-format
+msgid "Impossible to overwrite the file '%s'"
+msgstr ""
+
+#: ../src/common/filefn.cpp:508
+#, c-format
+msgid "Error copying the file '%s' to '%s'."
+msgstr ""
+
+#: ../src/common/filefn.cpp:556
+#, c-format
+msgid "Impossible to set permissions for the file '%s'"
+msgstr ""
+
+#: ../src/common/filefn.cpp:606
+#, c-format
+msgid ""
+"Failed to rename the file '%s' to '%s' because the destination file already "
+"exists."
+msgstr ""
+
+#: ../src/common/filefn.cpp:623
+#, c-format
+msgid "File '%s' couldn't be renamed '%s'"
+msgstr ""
+
+#: ../src/common/filefn.cpp:639
+#, c-format
+msgid "File '%s' couldn't be removed"
+msgstr ""
+
+#: ../src/common/filefn.cpp:666
+#, c-format
+msgid "Directory '%s' couldn't be created"
+msgstr ""
+
+#: ../src/common/filefn.cpp:680
+#, c-format
+msgid "Directory '%s' couldn't be deleted"
+msgstr ""
+
+#: ../src/common/filefn.cpp:714
+#, c-format
+msgid "Cannot enumerate files '%s'"
+msgstr ""
+
+#: ../src/common/filefn.cpp:798
+msgid "Failed to get the working directory"
+msgstr ""
+
+#: ../src/common/filefn.cpp:843
+msgid "Could not set current working directory"
+msgstr ""
+
+#: ../src/common/filefn.cpp:974
+#, c-format
+msgid "Files (%s)"
+msgstr ""
+
+#: ../src/common/filename.cpp:182
+#, c-format
+msgid "Failed to open '%s' for reading"
+msgstr ""
+
+#: ../src/common/filename.cpp:187
+#, c-format
+msgid "Failed to open '%s' for writing"
+msgstr ""
+
+#: ../src/common/filename.cpp:199
+msgid "Failed to close file handle"
+msgstr ""
+
+#: ../src/common/filename.cpp:1046
+msgid "Failed to create a temporary file name"
+msgstr ""
+
+#: ../src/common/filename.cpp:1081
+msgid "Failed to open temporary file."
+msgstr ""
+
+#: ../src/common/filename.cpp:2862
+#, c-format
+msgid "Failed to modify file times for '%s'"
+msgstr ""
+
+#: ../src/common/filename.cpp:2877
+#, c-format
+msgid "Failed to touch the file '%s'"
+msgstr ""
+
+#: ../src/common/filename.cpp:2958
+#, c-format
+msgid "Failed to retrieve file times for '%s'"
+msgstr ""
+
+#: ../src/common/filepickercmn.cpp:39 ../src/common/filepickercmn.cpp:40
+msgid "Browse"
+msgstr ""
+
+#: ../src/common/fldlgcmn.cpp:792 ../src/generic/filectrlg.cpp:1185
+#, c-format
+msgid "All files (%s)|%s"
+msgstr ""
+
+#. TRANSLATORS: %s are a file extension used to build a file wildcard string
+#: ../src/common/fldlgcmn.cpp:810
+#, c-format
+msgid "%s files (%s)|%s"
+msgstr ""
+
+#: ../src/common/fldlgcmn.cpp:1072
+#, c-format
+msgid "Load %s file"
+msgstr ""
+
+#: ../src/common/fldlgcmn.cpp:1074
+#, c-format
+msgid "Save %s file"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:144
+msgid "Western European (ISO-8859-1)"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:145
+msgid "Central European (ISO-8859-2)"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:146
+msgid "Esperanto (ISO-8859-3)"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:147
+msgid "Baltic (old) (ISO-8859-4)"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:148
+msgid "Cyrillic (ISO-8859-5)"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:149
+msgid "Arabic (ISO-8859-6)"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:150
+msgid "Greek (ISO-8859-7)"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:151
+msgid "Hebrew (ISO-8859-8)"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:152
+msgid "Turkish (ISO-8859-9)"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:153
+msgid "Nordic (ISO-8859-10)"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:154
+msgid "Thai (ISO-8859-11)"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:155
+msgid "Indian (ISO-8859-12)"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:156
+msgid "Baltic (ISO-8859-13)"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:157
+msgid "Celtic (ISO-8859-14)"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:158
+msgid "Western European with Euro (ISO-8859-15)"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:159
+msgid "KOI8-R"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:160
+msgid "KOI8-U"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:161
+msgid "Windows/DOS OEM Cyrillic (CP 866)"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:162
+msgid "Windows Thai (CP 874)"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:163
+msgid "Windows Japanese (CP 932) or Shift-JIS"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:164
+msgid "Windows Chinese Simplified (CP 936) or GB-2312"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:165
+msgid "Windows Korean (CP 949)"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:166
+msgid "Windows Chinese Traditional (CP 950) or Big-5"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:167
+msgid "Windows Central European (CP 1250)"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:168
+msgid "Windows Cyrillic (CP 1251)"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:169
+msgid "Windows Western European (CP 1252)"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:170
+msgid "Windows Greek (CP 1253)"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:171
+msgid "Windows Turkish (CP 1254)"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:172
+msgid "Windows Hebrew (CP 1255)"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:173
+msgid "Windows Arabic (CP 1256)"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:174
+msgid "Windows Baltic (CP 1257)"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:175
+msgid "Windows Vietnamese (CP 1258)"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:176
+msgid "Windows Johab (CP 1361)"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:177
+msgid "Windows/DOS OEM (CP 437)"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:178
+msgid "Unicode 7 bit (UTF-7)"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:179
+msgid "Unicode 8 bit (UTF-8)"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:181 ../src/common/fmapbase.cpp:187
+msgid "Unicode 16 bit (UTF-16)"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:182
+msgid "Unicode 16 bit Little Endian (UTF-16LE)"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:183 ../src/common/fmapbase.cpp:189
+msgid "Unicode 32 bit (UTF-32)"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:184
+msgid "Unicode 32 bit Little Endian (UTF-32LE)"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:186
+msgid "Unicode 16 bit Big Endian (UTF-16BE)"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:188
+msgid "Unicode 32 bit Big Endian (UTF-32BE)"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:191
+msgid "Extended Unix Codepage for Japanese (EUC-JP)"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:192
+msgid "US-ASCII"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:193
+msgid "ISO-2022-JP"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:195
+msgid "MacRoman"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:196
+msgid "MacJapanese"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:197
+msgid "MacChineseTrad"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:198
+msgid "MacKorean"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:199
+msgid "MacArabic"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:200
+msgid "MacHebrew"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:201
+msgid "MacGreek"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:202
+msgid "MacCyrillic"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:203
+msgid "MacDevanagari"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:204
+msgid "MacGurmukhi"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:205
+msgid "MacGujarati"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:206
+msgid "MacOriya"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:207
+msgid "MacBengali"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:208
+msgid "MacTamil"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:209
+msgid "MacTelugu"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:210
+msgid "MacKannada"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:211
+msgid "MacMalayalam"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:212
+msgid "MacSinhalese"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:213
+msgid "MacBurmese"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:214
+msgid "MacKhmer"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:215
+msgid "MacThai"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:216
+msgid "MacLaotian"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:217
+msgid "MacGeorgian"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:218
+msgid "MacArmenian"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:219
+msgid "MacChineseSimp"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:220
+msgid "MacTibetan"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:221
+msgid "MacMongolian"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:222
+msgid "MacEthiopic"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:223
+msgid "MacCentralEurRoman"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:224
+msgid "MacVietnamese"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:225
+msgid "MacExtArabic"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:226
+msgid "MacSymbol"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:227
+msgid "MacDingbats"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:228
+msgid "MacTurkish"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:229
+msgid "MacCroatian"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:230
+msgid "MacIcelandic"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:231
+msgid "MacRomanian"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:232
+msgid "MacCeltic"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:233
+msgid "MacGaelic"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:234
+msgid "MacKeyboardGlyphs"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:791
+msgid "Default encoding"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:805
+#, c-format
+msgid "Unknown encoding (%d)"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:815 ../src/richtext/richtextstyles.cpp:776
+msgid "default"
+msgstr ""
+
+#: ../src/common/fmapbase.cpp:829
+#, c-format
+msgid "unknown-%d"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:924 ../src/common/fontcmn.cpp:1130
+msgid "underlined"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:929
+msgid " strikethrough"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:942
+msgid " thin"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:946
+msgid " extra light"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:950
+msgid " light"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:954
+msgid " medium"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:958
+msgid " semi bold"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:962
+msgid " bold"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:966
+msgid " extra bold"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:970
+msgid " heavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:974
+msgid " extra heavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:990
+msgid " italic"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1134
+msgid "strikethrough"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1143
+msgid "thin"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1156
+msgid "extralight"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1161
+msgid "light"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1169 ../src/richtext/richtextstyles.cpp:775
+msgid "normal"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1174
+msgid "medium"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1179 ../src/common/fontcmn.cpp:1199
+msgid "semibold"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1184
+msgid "bold"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1194
+msgid "extrabold"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1204
+msgid "heavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1212
+msgid "extraheavy"
+msgstr ""
+
+#: ../src/common/fontcmn.cpp:1217
+msgid "italic"
+msgstr ""
+
+#: ../src/common/fontmap.cpp:195
+msgid ": unknown charset"
+msgstr ""
+
+#: ../src/common/fontmap.cpp:199
+#, c-format
+msgid ""
+"The charset '%s' is unknown. You may select\n"
+"another charset to replace it with or choose\n"
+"[Cancel] if it cannot be replaced"
+msgstr ""
+
+#: ../src/common/fontmap.cpp:241
+#, c-format
+msgid "Failed to remember the encoding for the charset '%s'."
+msgstr ""
+
+#: ../src/common/fontmap.cpp:321
+msgid "can't load any font, aborting"
+msgstr ""
+
+#: ../src/common/fontmap.cpp:409
+msgid ": unknown encoding"
+msgstr ""
+
+#: ../src/common/fontmap.cpp:417
+#, c-format
+msgid ""
+"No font for displaying text in encoding '%s' found,\n"
+"but an alternative encoding '%s' is available.\n"
+"Do you want to use this encoding (otherwise you will have to choose another "
+"one)?"
+msgstr ""
+
+#: ../src/common/fontmap.cpp:422
+#, c-format
+msgid ""
+"No font for displaying text in encoding '%s' found.\n"
+"Would you like to select a font to be used for this encoding\n"
+"(otherwise the text in this encoding will not be shown correctly)?"
+msgstr ""
+
+#: ../src/common/fs_mem.cpp:169
+#, c-format
+msgid "Memory VFS already contains file '%s'!"
+msgstr ""
+
+#: ../src/common/fs_mem.cpp:232
+#, c-format
+msgid "Trying to remove file '%s' from memory VFS, but it is not loaded!"
+msgstr ""
+
+#: ../src/common/fs_mem.cpp:262
+#, c-format
+msgid "Failed to store image '%s' to memory VFS!"
+msgstr ""
+
+#: ../src/common/ftp.cpp:197
+msgid "Timeout while waiting for FTP server to connect, try passive mode."
+msgstr ""
+
+#: ../src/common/ftp.cpp:399
+#, c-format
+msgid "Failed to set FTP transfer mode to %s."
+msgstr ""
+
+#: ../src/common/ftp.cpp:400 ../src/richtext/richtextsymboldlg.cpp:432
+msgid "ASCII"
+msgstr ""
+
+#: ../src/common/ftp.cpp:400
+msgid "binary"
+msgstr ""
+
+#: ../src/common/ftp.cpp:608
+msgid "The FTP server doesn't support the PORT command."
+msgstr ""
+
+#: ../src/common/ftp.cpp:622
+msgid "The FTP server doesn't support passive mode."
+msgstr ""
+
+#: ../src/common/gifdecod.cpp:822
+#, c-format
+msgid "Incorrect GIF frame size (%u, %d) for the frame #%u"
+msgstr ""
+
+#: ../src/common/glcmn.cpp:108
+msgid "Failed to allocate colour for OpenGL"
+msgstr ""
+
+#: ../src/common/headerctrlcmn.cpp:57
+msgid "Please select the columns to show and define their order:"
+msgstr ""
+
+#: ../src/common/headerctrlcmn.cpp:58
+msgid "Customize Columns"
+msgstr ""
+
+#: ../src/common/headerctrlcmn.cpp:304
+msgid "&Customize..."
+msgstr ""
+
+#: ../src/common/hyperlnkcmn.cpp:132
+#, c-format
+msgid "Failed to open URL \"%s\" in the default browser"
+msgstr ""
+
+#: ../src/common/iconbndl.cpp:195
+#, c-format
+msgid "Failed to load image %%d from file '%s'."
+msgstr ""
+
+#: ../src/common/iconbndl.cpp:203
+#, c-format
+msgid "Failed to load image %d from stream."
+msgstr ""
+
+#: ../src/common/iconbndl.cpp:221
+#, c-format
+msgid "Failed to load icons from resource '%s'."
+msgstr ""
+
+#: ../src/common/imagbmp.cpp:97
+msgid "BMP: Couldn't save invalid image."
+msgstr ""
+
+#: ../src/common/imagbmp.cpp:137
+msgid "BMP: wxImage doesn't have own wxPalette."
+msgstr ""
+
+#: ../src/common/imagbmp.cpp:243
+msgid "BMP: Couldn't write the file (Bitmap) header."
+msgstr ""
+
+#: ../src/common/imagbmp.cpp:266
+msgid "BMP: Couldn't write the file (BitmapInfo) header."
+msgstr ""
+
+#: ../src/common/imagbmp.cpp:353
+msgid "BMP: Couldn't write RGB color map."
+msgstr ""
+
+#: ../src/common/imagbmp.cpp:487
+msgid "BMP: Couldn't write data."
+msgstr ""
+
+#: ../src/common/imagbmp.cpp:561 ../src/common/imagbmp.cpp:642
+msgid "BMP: Couldn't allocate memory."
+msgstr ""
+
+#: ../src/common/imagbmp.cpp:1041
+msgid "DIB Header: Image width > 32767 pixels for file."
+msgstr ""
+
+#: ../src/common/imagbmp.cpp:1049
+msgid "DIB Header: Image height > 32767 pixels for file."
+msgstr ""
+
+#: ../src/common/imagbmp.cpp:1081
+msgid "DIB Header: Unknown bitdepth in file."
+msgstr ""
+
+#: ../src/common/imagbmp.cpp:1156
+msgid "DIB Header: Unknown encoding in file."
+msgstr ""
+
+#: ../src/common/imagbmp.cpp:1165
+msgid "DIB Header: Encoding doesn't match bitdepth."
+msgstr ""
+
+#: ../src/common/imagbmp.cpp:1180
+#, c-format
+msgid "BMP Header: Invalid number of colors (%d)."
+msgstr ""
+
+#: ../src/common/imagbmp.cpp:1273
+msgid "Error in reading image DIB."
+msgstr ""
+
+#: ../src/common/imagbmp.cpp:1294
+msgid "ICO: Error in reading mask DIB."
+msgstr ""
+
+#: ../src/common/imagbmp.cpp:1353
+msgid "ICO: Image too tall for an icon."
+msgstr ""
+
+#: ../src/common/imagbmp.cpp:1361
+msgid "ICO: Image too wide for an icon."
+msgstr ""
+
+#: ../src/common/imagbmp.cpp:1388 ../src/common/imagbmp.cpp:1488
+#: ../src/common/imagbmp.cpp:1503 ../src/common/imagbmp.cpp:1514
+#: ../src/common/imagbmp.cpp:1528 ../src/common/imagbmp.cpp:1576
+#: ../src/common/imagbmp.cpp:1591 ../src/common/imagbmp.cpp:1605
+#: ../src/common/imagbmp.cpp:1616
+msgid "ICO: Error writing the image file!"
+msgstr ""
+
+#: ../src/common/imagbmp.cpp:1701
+msgid "ICO: Invalid icon index."
+msgstr ""
+
+#: ../src/common/image.cpp:2410
+msgid "Image and mask have different sizes."
+msgstr ""
+
+#: ../src/common/image.cpp:2418 ../src/common/image.cpp:2459
+msgid "No unused colour in image being masked."
+msgstr ""
+
+#: ../src/common/image.cpp:2641
+#, c-format
+msgid "Failed to load bitmap \"%s\" from resources."
+msgstr ""
+
+#: ../src/common/image.cpp:2650
+#, c-format
+msgid "Failed to load icon \"%s\" from resources."
+msgstr ""
+
+#: ../src/common/image.cpp:2728 ../src/common/image.cpp:2747
+#, c-format
+msgid "Failed to load image from file \"%s\"."
+msgstr ""
+
+#: ../src/common/image.cpp:2761
+#, c-format
+msgid "Can't save image to file '%s': unknown extension."
+msgstr ""
+
+#: ../src/common/image.cpp:2869
+msgid "No handler found for image type."
+msgstr ""
+
+#: ../src/common/image.cpp:2877 ../src/common/image.cpp:3000
+#: ../src/common/image.cpp:3066
+#, c-format
+msgid "No image handler for type %d defined."
+msgstr ""
+
+#: ../src/common/image.cpp:2887
+#, c-format
+msgid "Image file is not of type %d."
+msgstr ""
+
+#: ../src/common/image.cpp:2970
+msgid "Can't automatically determine the image format for non-seekable input."
+msgstr ""
+
+#: ../src/common/image.cpp:2988
+msgid "Unknown image data format."
+msgstr ""
+
+#: ../src/common/image.cpp:3009
+#, c-format
+msgid "This is not a %s."
+msgstr ""
+
+#: ../src/common/image.cpp:3032 ../src/common/image.cpp:3080
+#, c-format
+msgid "No image handler for type %s defined."
+msgstr ""
+
+#: ../src/common/image.cpp:3041
+#, c-format
+msgid "Image is not of type %s."
+msgstr ""
+
+#: ../src/common/image.cpp:3509
+#, c-format
+msgid "Failed to check format of image file \"%s\"."
+msgstr ""
+
+#: ../src/common/imaggif.cpp:124
+msgid "GIF: error in GIF image format."
+msgstr ""
+
+#: ../src/common/imaggif.cpp:129
+msgid "GIF: not enough memory."
+msgstr ""
+
+#: ../src/common/imaggif.cpp:134
+msgid "GIF: data stream seems to be truncated."
+msgstr ""
+
+#: ../src/common/imaggif.cpp:240
+msgid "Couldn't initialize GIF hash table."
+msgstr ""
+
+#: ../src/common/imagiff.cpp:739
+msgid "IFF: error in IFF image format."
+msgstr ""
+
+#: ../src/common/imagiff.cpp:742
+msgid "IFF: not enough memory."
+msgstr ""
+
+#: ../src/common/imagiff.cpp:745
+msgid "IFF: unknown error!!!"
+msgstr ""
+
+#: ../src/common/imagiff.cpp:755
+msgid "IFF: data stream seems to be truncated."
+msgstr ""
+
+#: ../src/common/imagjpeg.cpp:258
+msgid "JPEG: Couldn't load - file is probably corrupted."
+msgstr ""
+
+#: ../src/common/imagjpeg.cpp:437
+msgid "JPEG: Couldn't save image."
+msgstr ""
+
+#: ../src/common/imagpcx.cpp:439
+msgid "PCX: this is not a PCX file."
+msgstr ""
+
+#: ../src/common/imagpcx.cpp:453
+msgid "PCX: image format unsupported"
+msgstr ""
+
+#: ../src/common/imagpcx.cpp:454 ../src/common/imagpcx.cpp:477
+msgid "PCX: couldn't allocate memory"
+msgstr ""
+
+#: ../src/common/imagpcx.cpp:455
+msgid "PCX: version number too low"
+msgstr ""
+
+#: ../src/common/imagpcx.cpp:456 ../src/common/imagpcx.cpp:478
+msgid "PCX: unknown error !!!"
+msgstr ""
+
+#: ../src/common/imagpcx.cpp:476
+msgid "PCX: invalid image"
+msgstr ""
+
+#: ../src/common/imagpng.cpp:385
+#, c-format
+msgid "Unknown PNG resolution unit %d"
+msgstr ""
+
+#: ../src/common/imagpng.cpp:439
+msgid "Couldn't load a PNG image - file is corrupted or not enough memory."
+msgstr ""
+
+#: ../src/common/imagpng.cpp:513 ../src/common/imagpng.cpp:524
+#: ../src/common/imagpng.cpp:534
+msgid "Couldn't save PNG image."
+msgstr ""
+
+#: ../src/common/imagpnm.cpp:71
+msgid "PNM: File format is not recognized."
+msgstr ""
+
+#: ../src/common/imagpnm.cpp:89
+msgid "PNM: Couldn't allocate memory."
+msgstr ""
+
+#: ../src/common/imagpnm.cpp:111 ../src/common/imagpnm.cpp:134
+#: ../src/common/imagpnm.cpp:156
+msgid "PNM: File seems truncated."
+msgstr ""
+
+#: ../src/common/imagtiff.cpp:69
+#, c-format
+msgid " (in module \"%s\")"
+msgstr ""
+
+#: ../src/common/imagtiff.cpp:304
+msgid "TIFF: Error loading image."
+msgstr ""
+
+#: ../src/common/imagtiff.cpp:314
+msgid "Invalid TIFF image index."
+msgstr ""
+
+#: ../src/common/imagtiff.cpp:358
+msgid "TIFF: Image size is abnormally big."
+msgstr ""
+
+#: ../src/common/imagtiff.cpp:372 ../src/common/imagtiff.cpp:385
+#: ../src/common/imagtiff.cpp:769
+msgid "TIFF: Couldn't allocate memory."
+msgstr ""
+
+#: ../src/common/imagtiff.cpp:471
+msgid "TIFF: Error reading image."
+msgstr ""
+
+#: ../src/common/imagtiff.cpp:532
+#, c-format
+msgid "Unknown TIFF resolution unit %d ignored"
+msgstr ""
+
+#: ../src/common/imagtiff.cpp:611
+msgid "TIFF: Error saving image."
+msgstr ""
+
+#: ../src/common/imagtiff.cpp:868
+msgid "TIFF: Error writing image."
+msgstr ""
+
+#: ../src/common/imagtiff.cpp:881
+msgid "TIFF: Error flushing data."
+msgstr ""
+
+#: ../src/common/imagwebp.cpp:56
+msgid "WebP: Invalid data (failed to get features)."
+msgstr ""
+
+#: ../src/common/imagwebp.cpp:65
+msgid "WebP: Allocating image memory failed."
+msgstr ""
+
+#: ../src/common/imagwebp.cpp:82
+msgid "WebP: Decoding RGBA image data failed."
+msgstr ""
+
+#: ../src/common/imagwebp.cpp:98
+msgid "WebP: Decoding RGB image data failed."
+msgstr ""
+
+#: ../src/common/imagwebp.cpp:113 ../src/common/imagwebp.cpp:201
+msgid "WebP: Allocating stream buffer failed."
+msgstr ""
+
+#: ../src/common/imagwebp.cpp:131
+msgid "WebP: Failed to parse container data."
+msgstr ""
+
+#: ../src/common/imagwebp.cpp:222
+msgid "WebP: Error decoding animation."
+msgstr ""
+
+#: ../src/common/imagwebp.cpp:240
+msgid "WebP: Error getting next animation frame."
+msgstr ""
+
+#: ../src/common/init.cpp:172
+#, c-format
+msgid ""
+"Command line argument %d couldn't be converted to Unicode and will be "
+"ignored."
+msgstr ""
+
+#: ../src/common/init.cpp:344
+msgid "Initialization failed in post init, aborting."
+msgstr ""
+
+#: ../src/common/intl.cpp:378
+#, c-format
+msgid "Cannot set locale to language \"%s\"."
+msgstr ""
+
+#: ../src/common/log.cpp:232
+msgid "Error: "
+msgstr ""
+
+#: ../src/common/log.cpp:236
+msgid "Warning: "
+msgstr ""
+
+#: ../src/common/log.cpp:284
+msgid "The previous message repeated once."
+msgstr ""
+
+#: ../src/common/log.cpp:291
+#, c-format
+msgid "The previous message repeated %u time."
+msgid_plural "The previous message repeated %u times."
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../src/common/log.cpp:319
+#, c-format
+msgid "Last repeated message (\"%s\", %u time) wasn't output"
+msgid_plural "Last repeated message (\"%s\", %u times) wasn't output"
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../src/common/log.cpp:435
+#, c-format
+msgid " (error %ld: %s)"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:121
+msgid "Failed to allocate memory for LZMA decompression."
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:125
+#, c-format
+msgid "Failed to initialize LZMA decompression: unexpected error %u."
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:179
+msgid "input is not in XZ format"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:183
+msgid "input compressed using unknown XZ option"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:188
+msgid "input is corrupted"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:192
+msgid "unknown decompression error"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:196
+#, c-format
+msgid "LZMA decompression error: %s"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:231
+msgid "Failed to allocate memory for LZMA compression."
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:235
+#, c-format
+msgid "Failed to initialize LZMA compression: unexpected error %u."
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:267 ../src/common/lzmastream.cpp:342
+#: ../src/html/chm.cpp:336
+msgid "out of memory"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:276 ../src/common/lzmastream.cpp:346
+msgid "unknown compression error"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:280
+#, c-format
+msgid "LZMA compression error: %s"
+msgstr ""
+
+#: ../src/common/lzmastream.cpp:350
+#, c-format
+msgid "LZMA compression error when flushing output: %s"
+msgstr ""
+
+#: ../src/common/mimecmn.cpp:167
+#, c-format
+msgid "Unmatched '{' in an entry for mime type %s."
+msgstr ""
+
+#: ../src/common/module.cpp:76
+#, c-format
+msgid "Circular dependency involving module \"%s\" detected."
+msgstr ""
+
+#: ../src/common/module.cpp:128
+#, c-format
+msgid "Dependency \"%s\" of module \"%s\" doesn't exist."
+msgstr ""
+
+#: ../src/common/module.cpp:137
+#, c-format
+msgid "Module \"%s\" initialization failed"
+msgstr ""
+
+#: ../src/common/msgout.cpp:96
+msgid "Message"
+msgstr ""
+
+#: ../src/common/paper.cpp:70
+msgid "Letter, 8 1/2 x 11 in"
+msgstr ""
+
+#: ../src/common/paper.cpp:71
+msgid "Legal, 8 1/2 x 14 in"
+msgstr ""
+
+#: ../src/common/paper.cpp:72
+msgid "A4 sheet, 210 x 297 mm"
+msgstr ""
+
+#: ../src/common/paper.cpp:73
+msgid "C sheet, 17 x 22 in"
+msgstr ""
+
+#: ../src/common/paper.cpp:74
+msgid "D sheet, 22 x 34 in"
+msgstr ""
+
+#: ../src/common/paper.cpp:75
+msgid "E sheet, 34 x 44 in"
+msgstr ""
+
+#: ../src/common/paper.cpp:76
+msgid "Letter Small, 8 1/2 x 11 in"
+msgstr ""
+
+#: ../src/common/paper.cpp:77
+msgid "Tabloid, 11 x 17 in"
+msgstr ""
+
+#: ../src/common/paper.cpp:78
+msgid "Ledger, 17 x 11 in"
+msgstr ""
+
+#: ../src/common/paper.cpp:79
+msgid "Statement, 5 1/2 x 8 1/2 in"
+msgstr ""
+
+#: ../src/common/paper.cpp:80
+msgid "Executive, 7 1/4 x 10 1/2 in"
+msgstr ""
+
+#: ../src/common/paper.cpp:81
+msgid "A3 sheet, 297 x 420 mm"
+msgstr ""
+
+#: ../src/common/paper.cpp:82
+msgid "A4 small sheet, 210 x 297 mm"
+msgstr ""
+
+#: ../src/common/paper.cpp:83
+msgid "A5 sheet, 148 x 210 mm"
+msgstr ""
+
+#: ../src/common/paper.cpp:84
+msgid "B4 sheet, 250 x 354 mm"
+msgstr ""
+
+#: ../src/common/paper.cpp:85
+msgid "B5 sheet, 182 x 257 millimeter"
+msgstr ""
+
+#: ../src/common/paper.cpp:86
+msgid "Folio, 8 1/2 x 13 in"
+msgstr ""
+
+#: ../src/common/paper.cpp:87
+msgid "Quarto, 215 x 275 mm"
+msgstr ""
+
+#: ../src/common/paper.cpp:88
+msgid "10 x 14 in"
+msgstr ""
+
+#: ../src/common/paper.cpp:89
+msgid "11 x 17 in"
+msgstr ""
+
+#: ../src/common/paper.cpp:90
+msgid "Note, 8 1/2 x 11 in"
+msgstr ""
+
+#: ../src/common/paper.cpp:91
+msgid "#9 Envelope, 3 7/8 x 8 7/8 in"
+msgstr ""
+
+#: ../src/common/paper.cpp:92
+msgid "#10 Envelope, 4 1/8 x 9 1/2 in"
+msgstr ""
+
+#: ../src/common/paper.cpp:93
+msgid "#11 Envelope, 4 1/2 x 10 3/8 in"
+msgstr ""
+
+#: ../src/common/paper.cpp:94
+msgid "#12 Envelope, 4 3/4 x 11 in"
+msgstr ""
+
+#: ../src/common/paper.cpp:95
+msgid "#14 Envelope, 5 x 11 1/2 in"
+msgstr ""
+
+#: ../src/common/paper.cpp:96
+msgid "DL Envelope, 110 x 220 mm"
+msgstr ""
+
+#: ../src/common/paper.cpp:97
+msgid "C5 Envelope, 162 x 229 mm"
+msgstr ""
+
+#: ../src/common/paper.cpp:98
+msgid "C3 Envelope, 324 x 458 mm"
+msgstr ""
+
+#: ../src/common/paper.cpp:99
+msgid "C4 Envelope, 229 x 324 mm"
+msgstr ""
+
+#: ../src/common/paper.cpp:100
+msgid "C6 Envelope, 114 x 162 mm"
+msgstr ""
+
+#: ../src/common/paper.cpp:101
+msgid "C65 Envelope, 114 x 229 mm"
+msgstr ""
+
+#: ../src/common/paper.cpp:102
+msgid "B4 Envelope, 250 x 353 mm"
+msgstr ""
+
+#: ../src/common/paper.cpp:103
+msgid "B5 Envelope, 176 x 250 mm"
+msgstr ""
+
+#: ../src/common/paper.cpp:104
+msgid "B6 Envelope, 176 x 125 mm"
+msgstr ""
+
+#: ../src/common/paper.cpp:105
+msgid "Italy Envelope, 110 x 230 mm"
+msgstr ""
+
+#: ../src/common/paper.cpp:106
+msgid "Monarch Envelope, 3 7/8 x 7 1/2 in"
+msgstr ""
+
+#: ../src/common/paper.cpp:107
+msgid "6 3/4 Envelope, 3 5/8 x 6 1/2 in"
+msgstr ""
+
+#: ../src/common/paper.cpp:108
+msgid "US Std Fanfold, 14 7/8 x 11 in"
+msgstr ""
+
+#: ../src/common/paper.cpp:109
+msgid "German Std Fanfold, 8 1/2 x 12 in"
+msgstr ""
+
+#: ../src/common/paper.cpp:110
+msgid "German Legal Fanfold, 8 1/2 x 13 in"
+msgstr ""
+
+#: ../src/common/paper.cpp:112
+msgid "B4 (ISO) 250 x 353 mm"
+msgstr ""
+
+#: ../src/common/paper.cpp:113
+msgid "Japanese Postcard 100 x 148 mm"
+msgstr ""
+
+#: ../src/common/paper.cpp:114
+msgid "9 x 11 in"
+msgstr ""
+
+#: ../src/common/paper.cpp:115
+msgid "10 x 11 in"
+msgstr ""
+
+#: ../src/common/paper.cpp:116
+msgid "15 x 11 in"
+msgstr ""
+
+#: ../src/common/paper.cpp:117
+msgid "Envelope Invite 220 x 220 mm"
+msgstr ""
+
+#: ../src/common/paper.cpp:118
+msgid "Letter Extra 9 1/2 x 12 in"
+msgstr ""
+
+#: ../src/common/paper.cpp:119
+msgid "Legal Extra 9 1/2 x 15 in"
+msgstr ""
+
+#: ../src/common/paper.cpp:120
+msgid "Tabloid Extra 11.69 x 18 in"
+msgstr ""
+
+#: ../src/common/paper.cpp:121
+msgid "A4 Extra 9.27 x 12.69 in"
+msgstr ""
+
+#: ../src/common/paper.cpp:122
+msgid "Letter Transverse 8 1/2 x 11 in"
+msgstr ""
+
+#: ../src/common/paper.cpp:123
+msgid "A4 Transverse 210 x 297 mm"
+msgstr ""
+
+#: ../src/common/paper.cpp:124
+msgid "Letter Extra Transverse 9.275 x 12 in"
+msgstr ""
+
+#: ../src/common/paper.cpp:125
+msgid "SuperA/SuperA/A4 227 x 356 mm"
+msgstr ""
+
+#: ../src/common/paper.cpp:126
+msgid "SuperB/SuperB/A3 305 x 487 mm"
+msgstr ""
+
+#: ../src/common/paper.cpp:127
+msgid "Letter Plus 8 1/2 x 12.69 in"
+msgstr ""
+
+#: ../src/common/paper.cpp:128
+msgid "A4 Plus 210 x 330 mm"
+msgstr ""
+
+#: ../src/common/paper.cpp:129
+msgid "A5 Transverse 148 x 210 mm"
+msgstr ""
+
+#: ../src/common/paper.cpp:130
+msgid "B5 (JIS) Transverse 182 x 257 mm"
+msgstr ""
+
+#: ../src/common/paper.cpp:131
+msgid "A3 Extra 322 x 445 mm"
+msgstr ""
+
+#: ../src/common/paper.cpp:132
+msgid "A5 Extra 174 x 235 mm"
+msgstr ""
+
+#: ../src/common/paper.cpp:133
+msgid "B5 (ISO) Extra 201 x 276 mm"
+msgstr ""
+
+#: ../src/common/paper.cpp:134
+msgid "A2 420 x 594 mm"
+msgstr ""
+
+#: ../src/common/paper.cpp:135
+msgid "A3 Transverse 297 x 420 mm"
+msgstr ""
+
+#: ../src/common/paper.cpp:136
+msgid "A3 Extra Transverse 322 x 445 mm"
+msgstr ""
+
+#: ../src/common/paper.cpp:138
+msgid "Japanese Double Postcard 200 x 148 mm"
+msgstr ""
+
+#: ../src/common/paper.cpp:139
+msgid "A6 105 x 148 mm"
+msgstr ""
+
+#: ../src/common/paper.cpp:140
+msgid "Japanese Envelope Kaku #2"
+msgstr ""
+
+#: ../src/common/paper.cpp:141
+msgid "Japanese Envelope Kaku #3"
+msgstr ""
+
+#: ../src/common/paper.cpp:142
+msgid "Japanese Envelope Chou #3"
+msgstr ""
+
+#: ../src/common/paper.cpp:143
+msgid "Japanese Envelope Chou #4"
+msgstr ""
+
+#: ../src/common/paper.cpp:144
+msgid "Letter Rotated 11 x 8 1/2 in"
+msgstr ""
+
+#: ../src/common/paper.cpp:145
+msgid "A3 Rotated 420 x 297 mm"
+msgstr ""
+
+#: ../src/common/paper.cpp:146
+msgid "A4 Rotated 297 x 210 mm"
+msgstr ""
+
+#: ../src/common/paper.cpp:147
+msgid "A5 Rotated 210 x 148 mm"
+msgstr ""
+
+#: ../src/common/paper.cpp:148
+msgid "B4 (JIS) Rotated 364 x 257 mm"
+msgstr ""
+
+#: ../src/common/paper.cpp:149
+msgid "B5 (JIS) Rotated 257 x 182 mm"
+msgstr ""
+
+#: ../src/common/paper.cpp:150
+msgid "Japanese Postcard Rotated 148 x 100 mm"
+msgstr ""
+
+#: ../src/common/paper.cpp:151
+msgid "Double Japanese Postcard Rotated 148 x 200 mm"
+msgstr ""
+
+#: ../src/common/paper.cpp:152
+msgid "A6 Rotated 148 x 105 mm"
+msgstr ""
+
+#: ../src/common/paper.cpp:153
+msgid "Japanese Envelope Kaku #2 Rotated"
+msgstr ""
+
+#: ../src/common/paper.cpp:154
+msgid "Japanese Envelope Kaku #3 Rotated"
+msgstr ""
+
+#: ../src/common/paper.cpp:155
+msgid "Japanese Envelope Chou #3 Rotated"
+msgstr ""
+
+#: ../src/common/paper.cpp:156
+msgid "Japanese Envelope Chou #4 Rotated"
+msgstr ""
+
+#: ../src/common/paper.cpp:157
+msgid "B6 (JIS) 128 x 182 mm"
+msgstr ""
+
+#: ../src/common/paper.cpp:158
+msgid "B6 (JIS) Rotated 182 x 128 mm"
+msgstr ""
+
+#: ../src/common/paper.cpp:159
+msgid "12 x 11 in"
+msgstr ""
+
+#: ../src/common/paper.cpp:160
+msgid "Japanese Envelope You #4"
+msgstr ""
+
+#: ../src/common/paper.cpp:161
+msgid "Japanese Envelope You #4 Rotated"
+msgstr ""
+
+#: ../src/common/paper.cpp:162
+msgid "PRC 16K 146 x 215 mm"
+msgstr ""
+
+#: ../src/common/paper.cpp:163
+msgid "PRC 32K 97 x 151 mm"
+msgstr ""
+
+#: ../src/common/paper.cpp:164
+msgid "PRC 32K(Big) 97 x 151 mm"
+msgstr ""
+
+#: ../src/common/paper.cpp:165
+msgid "PRC Envelope #1 102 x 165 mm"
+msgstr ""
+
+#: ../src/common/paper.cpp:166
+msgid "PRC Envelope #2 102 x 176 mm"
+msgstr ""
+
+#: ../src/common/paper.cpp:167
+msgid "PRC Envelope #3 125 x 176 mm"
+msgstr ""
+
+#: ../src/common/paper.cpp:168
+msgid "PRC Envelope #4 110 x 208 mm"
+msgstr ""
+
+#: ../src/common/paper.cpp:169
+msgid "PRC Envelope #5 110 x 220 mm"
+msgstr ""
+
+#: ../src/common/paper.cpp:170
+msgid "PRC Envelope #6 120 x 230 mm"
+msgstr ""
+
+#: ../src/common/paper.cpp:171
+msgid "PRC Envelope #7 160 x 230 mm"
+msgstr ""
+
+#: ../src/common/paper.cpp:172
+msgid "PRC Envelope #8 120 x 309 mm"
+msgstr ""
+
+#: ../src/common/paper.cpp:173
+msgid "PRC Envelope #9 229 x 324 mm"
+msgstr ""
+
+#: ../src/common/paper.cpp:174
+msgid "PRC Envelope #10 324 x 458 mm"
+msgstr ""
+
+#: ../src/common/paper.cpp:175
+msgid "PRC 16K Rotated"
+msgstr ""
+
+#: ../src/common/paper.cpp:176
+msgid "PRC 32K Rotated"
+msgstr ""
+
+#: ../src/common/paper.cpp:177
+msgid "PRC 32K(Big) Rotated"
+msgstr ""
+
+#: ../src/common/paper.cpp:178
+msgid "PRC Envelope #1 Rotated 165 x 102 mm"
+msgstr ""
+
+#: ../src/common/paper.cpp:179
+msgid "PRC Envelope #2 Rotated 176 x 102 mm"
+msgstr ""
+
+#: ../src/common/paper.cpp:180
+msgid "PRC Envelope #3 Rotated 176 x 125 mm"
+msgstr ""
+
+#: ../src/common/paper.cpp:181
+msgid "PRC Envelope #4 Rotated 208 x 110 mm"
+msgstr ""
+
+#: ../src/common/paper.cpp:182
+msgid "PRC Envelope #5 Rotated 220 x 110 mm"
+msgstr ""
+
+#: ../src/common/paper.cpp:183
+msgid "PRC Envelope #6 Rotated 230 x 120 mm"
+msgstr ""
+
+#: ../src/common/paper.cpp:184
+msgid "PRC Envelope #7 Rotated 230 x 160 mm"
+msgstr ""
+
+#: ../src/common/paper.cpp:185
+msgid "PRC Envelope #8 Rotated 309 x 120 mm"
+msgstr ""
+
+#: ../src/common/paper.cpp:186
+msgid "PRC Envelope #9 Rotated 324 x 229 mm"
+msgstr ""
+
+#: ../src/common/paper.cpp:187
+msgid "PRC Envelope #10 Rotated 458 x 324 mm"
+msgstr ""
+
+#: ../src/common/paper.cpp:192
+msgid "A0 sheet, 841 x 1189 mm"
+msgstr ""
+
+#: ../src/common/paper.cpp:193
+msgid "A1 sheet, 594 x 841 mm"
+msgstr ""
+
+#: ../src/common/preferencescmn.cpp:37
+msgid "General"
+msgstr ""
+
+#: ../src/common/preferencescmn.cpp:40
+msgid "Advanced"
+msgstr ""
+
+#: ../src/common/prntbase.cpp:245
+msgid "Generic PostScript"
+msgstr ""
+
+#: ../src/common/prntbase.cpp:259
+msgid "Ready"
+msgstr ""
+
+#: ../src/common/prntbase.cpp:331
+msgid "Printing Error"
+msgstr ""
+
+#: ../src/common/prntbase.cpp:413 ../src/common/prntbase.cpp:1597
+#: ../src/generic/prntdlgg.cpp:135 ../src/generic/prntdlgg.cpp:149
+#: ../src/gtk/print.cpp:628 ../src/gtk/print.cpp:646
+msgid "Print"
+msgstr ""
+
+#: ../src/common/prntbase.cpp:471 ../src/generic/prntdlgg.cpp:809
+msgid "Page setup"
+msgstr ""
+
+#: ../src/common/prntbase.cpp:525
+msgid "Please wait while printing..."
+msgstr ""
+
+#: ../src/common/prntbase.cpp:529
+msgid "Document:"
+msgstr ""
+
+#: ../src/common/prntbase.cpp:532
+msgid "Progress:"
+msgstr ""
+
+#: ../src/common/prntbase.cpp:533
+msgid "Preparing"
+msgstr ""
+
+#: ../src/common/prntbase.cpp:552
+#, c-format
+msgid "Printing page %d"
+msgstr ""
+
+#: ../src/common/prntbase.cpp:557
+#, c-format
+msgid "Printing page %d of %d"
+msgstr ""
+
+#: ../src/common/prntbase.cpp:560
+#, c-format
+msgid " (copy %d of %d)"
+msgstr ""
+
+#: ../src/common/prntbase.cpp:1604
+msgid "First page"
+msgstr ""
+
+#: ../src/common/prntbase.cpp:1609 ../src/html/helpwnd.cpp:659
+msgid "Previous page"
+msgstr ""
+
+#: ../src/common/prntbase.cpp:1623 ../src/html/helpwnd.cpp:660
+msgid "Next page"
+msgstr ""
+
+#: ../src/common/prntbase.cpp:1628
+msgid "Last page"
+msgstr ""
+
+#: ../src/common/prntbase.cpp:1636 ../src/common/stockitem.cpp:215
+msgid "Zoom Out"
+msgstr ""
+
+#: ../src/common/prntbase.cpp:1650 ../src/common/stockitem.cpp:214
+msgid "Zoom In"
+msgstr ""
+
+#: ../src/common/prntbase.cpp:1656 ../src/common/stockitem.cpp:153
+#: ../src/generic/logg.cpp:553 ../src/univ/themes/win32.cpp:3752
+msgid "&Close"
+msgstr ""
+
+#: ../src/common/prntbase.cpp:2085
+msgid "Could not start document preview."
+msgstr ""
+
+#: ../src/common/prntbase.cpp:2085 ../src/common/prntbase.cpp:2129
+#: ../src/common/prntbase.cpp:2137
+msgid "Print Preview Failure"
+msgstr ""
+
+#: ../src/common/prntbase.cpp:2129 ../src/common/prntbase.cpp:2137
+msgid "Sorry, not enough memory to create a preview."
+msgstr ""
+
+#: ../src/common/prntbase.cpp:2144
+#, c-format
+msgid "Page %d of %d"
+msgstr ""
+
+#: ../src/common/prntbase.cpp:2146
+#, c-format
+msgid "Page %d"
+msgstr ""
+
+#: ../src/common/regex.cpp:382 ../src/html/chm.cpp:348
+msgid "unknown error"
+msgstr ""
+
+#: ../src/common/regex.cpp:995
+#, c-format
+msgid "Invalid regular expression '%s': %s"
+msgstr ""
+
+#: ../src/common/regex.cpp:1059
+#, c-format
+msgid "Failed to find match for regular expression: %s"
+msgstr ""
+
+#: ../src/common/rendcmn.cpp:188
+#, c-format
+msgid "Renderer \"%s\" has incompatible version %d.%d and couldn't be loaded."
+msgstr ""
+
+#: ../src/common/secretstore.cpp:162
+msgid "Not available for this platform"
+msgstr ""
+
+#: ../src/common/secretstore.cpp:183
+#, c-format
+msgid "Saving password for \"%s\" failed: %s."
+msgstr ""
+
+#: ../src/common/secretstore.cpp:205
+#, c-format
+msgid "Reading password for \"%s\" failed: %s."
+msgstr ""
+
+#: ../src/common/secretstore.cpp:228
+#, c-format
+msgid "Deleting password for \"%s\" failed: %s."
+msgstr ""
+
+#: ../src/common/selectdispatcher.cpp:254
+msgid "Failed to monitor I/O channels"
+msgstr ""
+
+#: ../src/common/sizer.cpp:3054 ../src/common/stockitem.cpp:195
+msgid "Save"
+msgstr ""
+
+#: ../src/common/sizer.cpp:3056
+msgid "Don't Save"
+msgstr ""
+
+#: ../src/common/socket.cpp:870
+msgid "Cannot initialize sockets"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:127
+msgctxt "standard Windows menu"
+msgid "&Help"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:144
+msgid "&About"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:144
+msgid "About"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:145
+msgid "Add"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:146
+msgid "&Apply"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:146
+msgid "Apply"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:147
+msgid "&Back"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:147
+msgid "Back"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:148
+msgid "&Bold"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:148 ../src/generic/fontdlgg.cpp:326
+#: ../src/richtext/richtextfontpage.cpp:354
+msgid "Bold"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:149
+msgid "&Bottom"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:149 ../src/richtext/richtextsizepage.cpp:287
+msgid "Bottom"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:150 ../src/generic/fontdlgg.cpp:462
+#: ../src/generic/fontdlgg.cpp:481 ../src/generic/wizard.cpp:415
+msgid "&Cancel"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:151
+msgid "&CD-ROM"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:151
+msgid "CD-ROM"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:152
+msgid "&Clear"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:152
+msgid "Clear"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:153 ../src/generic/dbgrptg.cpp:93
+#: ../src/generic/progdlgg.cpp:778 ../src/html/helpdlg.cpp:86
+#: ../src/msw/progdlg.cpp:209 ../src/msw/progdlg.cpp:890
+#: ../src/richtext/richtextstyledlg.cpp:272
+#: ../src/richtext/richtextsymboldlg.cpp:448
+msgid "Close"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:154
+msgid "&Convert"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:154
+msgid "Convert"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:155 ../src/msw/textctrl.cpp:2884
+#: ../src/osx/textctrl_osx.cpp:653 ../src/richtext/richtextctrl.cpp:331
+msgid "&Copy"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:155 ../src/stc/stc_i18n.cpp:18
+msgid "Copy"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:156 ../src/msw/textctrl.cpp:2883
+#: ../src/osx/textctrl_osx.cpp:652 ../src/richtext/richtextctrl.cpp:330
+msgid "Cu&t"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:156 ../src/stc/stc_i18n.cpp:17
+msgid "Cut"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:157 ../src/msw/textctrl.cpp:2886
+#: ../src/osx/textctrl_osx.cpp:655 ../src/richtext/richtextctrl.cpp:333
+#: ../src/richtext/richtexttabspage.cpp:137
+msgid "&Delete"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:157 ../src/richtext/richtextbuffer.cpp:8266
+#: ../src/stc/stc_i18n.cpp:20
+msgid "Delete"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:158
+msgid "&Down"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:158 ../src/generic/fdrepdlg.cpp:148
+msgid "Down"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:159
+msgid "&Edit"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:159
+msgid "Edit"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:160
+msgid "&Execute"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:160
+msgid "Execute"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:161
+msgid "&Quit"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:161
+msgid "Quit"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:162
+msgid "&File"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:162
+msgid "File"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:163
+msgid "&Find..."
+msgstr ""
+
+#: ../src/common/stockitem.cpp:163
+msgid "Find..."
+msgstr ""
+
+#: ../src/common/stockitem.cpp:164
+msgid "&First"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:164
+msgid "First"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:165
+msgid "&Floppy"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:165
+msgid "Floppy"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:166
+msgid "&Forward"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:166
+msgid "Forward"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:167
+msgid "&Harddisk"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:167
+msgid "Harddisk"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:168 ../src/generic/wizard.cpp:418
+#: ../src/osx/cocoa/menu.mm:225 ../src/richtext/richtextstyledlg.cpp:298
+#: ../src/richtext/richtextsymboldlg.cpp:451
+msgid "&Help"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:169
+msgid "&Home"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:169
+msgid "Home"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:170
+msgid "Indent"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:171
+msgid "&Index"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:171 ../src/html/helpwnd.cpp:510
+msgid "Index"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:172
+msgid "&Info"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:172
+msgid "Info"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:173
+msgid "&Italic"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:173 ../src/generic/fontdlgg.cpp:322
+#: ../src/richtext/richtextfontpage.cpp:350
+msgid "Italic"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:174
+msgid "&Jump to"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:174
+msgid "Jump to"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:175
+msgid "Centered"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:176
+msgid "Justified"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:177
+msgid "Align Left"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:178
+msgid "Align Right"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:179
+msgid "&Last"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:179
+msgid "Last"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:180
+msgid "&Network"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:180
+msgid "Network"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:181 ../src/richtext/richtexttabspage.cpp:131
+msgid "&New"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:181
+msgid "New"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:182 ../src/msw/msgdlg.cpp:417
+msgid "&No"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:183 ../src/generic/fontdlgg.cpp:467
+#: ../src/generic/fontdlgg.cpp:474
+msgid "&OK"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:184 ../src/generic/dbgrptg.cpp:341
+msgid "&Open..."
+msgstr ""
+
+#: ../src/common/stockitem.cpp:184
+msgid "Open..."
+msgstr ""
+
+#: ../src/common/stockitem.cpp:185 ../src/msw/textctrl.cpp:2885
+#: ../src/osx/textctrl_osx.cpp:654 ../src/richtext/richtextctrl.cpp:332
+msgid "&Paste"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:185 ../src/richtext/richtextctrl.cpp:3484
+#: ../src/stc/stc_i18n.cpp:19
+msgid "Paste"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:186
+msgid "&Preferences"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:186 ../src/osx/cocoa/preferences.mm:304
+msgid "Preferences"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:187
+msgid "Print previe&w..."
+msgstr ""
+
+#: ../src/common/stockitem.cpp:187
+msgid "Print preview..."
+msgstr ""
+
+#: ../src/common/stockitem.cpp:188
+msgid "&Print..."
+msgstr ""
+
+#: ../src/common/stockitem.cpp:188
+msgid "Print..."
+msgstr ""
+
+#: ../src/common/stockitem.cpp:189 ../src/richtext/richtextctrl.cpp:337
+#: ../src/richtext/richtextctrl.cpp:5479
+msgid "&Properties"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:189
+msgid "Properties"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:190 ../src/stc/stc_i18n.cpp:16
+msgid "Redo"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:191
+msgid "Refresh"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:192
+msgid "Remove"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:193
+msgid "Rep&lace..."
+msgstr ""
+
+#: ../src/common/stockitem.cpp:193
+msgid "Replace..."
+msgstr ""
+
+#: ../src/common/stockitem.cpp:194
+msgid "Revert to Saved"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:196 ../src/generic/logg.cpp:549
+msgid "Save &As..."
+msgstr ""
+
+#: ../src/common/stockitem.cpp:196
+msgid "Save As..."
+msgstr ""
+
+#: ../src/common/stockitem.cpp:197 ../src/msw/textctrl.cpp:2888
+#: ../src/osx/textctrl_osx.cpp:657 ../src/richtext/richtextctrl.cpp:335
+msgid "Select &All"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:197 ../src/stc/stc_i18n.cpp:21
+msgid "Select All"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:198
+msgid "&Color"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:198
+msgid "Color"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:199
+msgid "&Font"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:199 ../src/richtext/richtextformatdlg.cpp:336
+msgid "Font"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:200
+msgid "&Ascending"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:200
+msgid "Ascending"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:201
+msgid "&Descending"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:201
+msgid "Descending"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:202
+msgid "&Spell Check"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:202
+msgid "Spell Check"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:203
+msgid "&Stop"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:203
+msgid "Stop"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:204 ../src/richtext/richtextfontpage.cpp:274
+msgid "&Strikethrough"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:204
+msgid "Strikethrough"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:205
+msgid "&Top"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:205 ../src/richtext/richtextsizepage.cpp:285
+#: ../src/richtext/richtextsizepage.cpp:289
+msgid "Top"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:206
+msgid "Undelete"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:207 ../src/generic/fontdlgg.cpp:437
+msgid "&Underline"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:207
+msgid "Underline"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:208 ../src/stc/stc_i18n.cpp:15
+msgid "Undo"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:209
+msgid "&Unindent"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:209
+msgid "Unindent"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:210
+msgid "&Up"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:210 ../src/generic/fdrepdlg.cpp:148
+msgid "Up"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:211 ../src/msw/msgdlg.cpp:417
+msgid "&Yes"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:212
+msgid "&Actual Size"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:212
+msgid "Actual Size"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:213
+msgid "Zoom to &Fit"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:213
+msgid "Zoom to Fit"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:214
+msgid "Zoom &In"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:215
+msgid "Zoom &Out"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:262
+msgid "Show about dialog"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:263
+msgid "Copy selection"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:264
+msgid "Cut selection"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:265
+msgid "Delete selection"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:266
+msgid "Find in document"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:267
+msgid "Find and replace in document"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:268
+msgid "Paste selection"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:269
+msgid "Quit this program"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:270
+msgid "Redo last action"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:271
+msgid "Undo last action"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:272
+msgid "Create new document"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:273
+msgid "Open an existing document"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:274
+msgid "Close current document"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:275
+msgid "Save current document"
+msgstr ""
+
+#: ../src/common/stockitem.cpp:276
+msgid "Save current document with a different filename"
+msgstr ""
+
+#: ../src/common/strconv.cpp:2324
+#, c-format
+msgid "Conversion to charset '%s' doesn't work."
+msgstr ""
+
+#: ../src/common/tarstrm.cpp:352 ../src/common/tarstrm.cpp:375
+#: ../src/common/tarstrm.cpp:406 ../src/generic/progdlgg.cpp:373
+msgid "unknown"
+msgstr ""
+
+#: ../src/common/tarstrm.cpp:774
+msgid "incomplete header block in tar"
+msgstr ""
+
+#: ../src/common/tarstrm.cpp:798
+msgid "checksum failure reading tar header block"
+msgstr ""
+
+#: ../src/common/tarstrm.cpp:971
+msgid "invalid data in extended tar header"
+msgstr ""
+
+#: ../src/common/tarstrm.cpp:981 ../src/common/tarstrm.cpp:1003
+#: ../src/common/tarstrm.cpp:1477 ../src/common/tarstrm.cpp:1499
+msgid "tar entry not open"
+msgstr ""
+
+#: ../src/common/tarstrm.cpp:1023
+msgid "unexpected end of file"
+msgstr ""
+
+#: ../src/common/tarstrm.cpp:1297
+#, c-format
+msgid "%s did not fit the tar header for entry '%s'"
+msgstr ""
+
+#: ../src/common/tarstrm.cpp:1359
+msgid "incorrect size given for tar entry"
+msgstr ""
+
+#: ../src/common/textbuf.cpp:232
+#, c-format
+msgid "'%s' is probably a binary buffer."
+msgstr ""
+
+#: ../src/common/textcmn.cpp:1006 ../src/richtext/richtextctrl.cpp:3053
+msgid "File couldn't be loaded."
+msgstr ""
+
+#: ../src/common/textfile.cpp:95
+#, c-format
+msgid "Failed to read text file \"%s\"."
+msgstr ""
+
+#: ../src/common/textfile.cpp:160
+#, c-format
+msgid "can't write buffer '%s' to disk."
+msgstr ""
+
+#: ../src/common/time.cpp:212
+msgid "Failed to get the local system time"
+msgstr ""
+
+#: ../src/common/time.cpp:279
+msgid "wxGetTimeOfDay failed."
+msgstr ""
+
+#: ../src/common/translation.cpp:929
+#, c-format
+msgid "'%s' is not a valid message catalog."
+msgstr ""
+
+#: ../src/common/translation.cpp:954
+msgid "Invalid message catalog."
+msgstr ""
+
+#: ../src/common/translation.cpp:1013
+#, c-format
+msgid "Failed to parse Plural-Forms: '%s'"
+msgstr ""
+
+#: ../src/common/translation.cpp:1723
+#, c-format
+msgid "using catalog '%s' from '%s'."
+msgstr ""
+
+#: ../src/common/translation.cpp:1816
+#, c-format
+msgid "Resource '%s' is not a valid message catalog."
+msgstr ""
+
+#: ../src/common/translation.cpp:1865
+msgid "Couldn't enumerate translations"
+msgstr ""
+
+#: ../src/common/utilscmn.cpp:1145
+msgid "No default application configured for HTML files."
+msgstr ""
+
+#: ../src/common/utilscmn.cpp:1190
+#, c-format
+msgid "Failed to open URL \"%s\" in default browser."
+msgstr ""
+
+#: ../src/common/valtext.cpp:144
+msgid "Validation conflict"
+msgstr ""
+
+#: ../src/common/valtext.cpp:186
+msgid "Required information entry is empty."
+msgstr ""
+
+#: ../src/common/valtext.cpp:188
+#, c-format
+msgid "'%s' is one of the invalid strings"
+msgstr ""
+
+#: ../src/common/valtext.cpp:190
+#, c-format
+msgid "'%s' is not one of the valid strings"
+msgstr ""
+
+#: ../src/common/valtext.cpp:199
+#, c-format
+msgid "'%s' contains invalid character(s)"
+msgstr ""
+
+#: ../src/common/webrequest.cpp:139
+#, c-format
+msgid "Error: %s (%d)"
+msgstr ""
+
+#: ../src/common/webrequest.cpp:655
+#, c-format
+msgid ""
+"Not enough free disk space for download: %llu needed but only %llu available."
+msgstr ""
+
+#: ../src/common/webrequest.cpp:669
+#, c-format
+msgid "Failed to create temporary file in %s"
+msgstr ""
+
+#: ../src/common/webrequest_curl.cpp:1106
+msgid "libcurl could not be initialized"
+msgstr ""
+
+#: ../src/common/webview.cpp:392
+msgid "RunScriptAsync not supported"
+msgstr ""
+
+#: ../src/common/webview.cpp:403 ../src/msw/webview_ie.cpp:1073
+#, c-format
+msgid "Error running JavaScript: %s"
+msgstr ""
+
+#: ../src/common/webview_chromium.cpp:858
+#, c-format
+msgid "Failed to set proxy \"%s\": %s"
+msgstr ""
+
+#: ../src/common/webview_chromium.cpp:989
+msgid ""
+"Chromium can't be used because libcef.so wasn't loaded early enough; please "
+"relink the application or use LD_PRELOAD to load it earlier."
+msgstr ""
+
+#: ../src/common/webview_chromium.cpp:1108
+msgid "Could not initialize Chromium"
+msgstr ""
+
+#: ../src/common/webview_chromium.cpp:1616
+msgid "Show DevTools"
+msgstr ""
+
+#: ../src/common/webview_chromium.cpp:1617
+msgid "Close DevTools"
+msgstr ""
+
+#: ../src/common/webview_chromium.cpp:1623
+msgid "Inspect"
+msgstr ""
+
+#: ../src/common/wincmn.cpp:1628
+msgid "This platform does not support background transparency."
+msgstr ""
+
+#: ../src/common/wincmn.cpp:2097
+msgid "Could not transfer data to window"
+msgstr ""
+
+#: ../src/common/windowid.cpp:240
+msgid "Out of window IDs.  Recommend shutting down application."
+msgstr ""
+
+#: ../src/common/xpmdecod.cpp:678
+msgid "XPM: incorrect header format!"
+msgstr ""
+
+#: ../src/common/xpmdecod.cpp:703
+#, c-format
+msgid "XPM: incorrect colour description in line %d"
+msgstr ""
+
+#: ../src/common/xpmdecod.cpp:715 ../src/common/xpmdecod.cpp:724
+#, c-format
+msgid "XPM: malformed colour definition '%s' at line %d!"
+msgstr ""
+
+#: ../src/common/xpmdecod.cpp:754
+msgid "XPM: no colors left to use for mask!"
+msgstr ""
+
+#: ../src/common/xpmdecod.cpp:781
+#, c-format
+msgid "XPM: truncated image data at line %d!"
+msgstr ""
+
+#: ../src/common/xpmdecod.cpp:795
+msgid "XPM: Malformed pixel data!"
+msgstr ""
+
+#: ../src/common/xti.cpp:492
+msgid "Illegal Parameter Count for Create Method"
+msgstr ""
+
+#: ../src/common/xti.cpp:504
+msgid "Illegal Parameter Count for ConstructObject Method"
+msgstr ""
+
+#: ../src/common/xtistrm.cpp:161
+#, c-format
+msgid "Create Parameter %s not found in declared RTTI Parameters"
+msgstr ""
+
+#: ../src/common/xtistrm.cpp:290
+msgid "Illegal Object Class (Non-wxEvtHandler) as Event Source"
+msgstr ""
+
+#: ../src/common/xtistrm.cpp:313 ../src/common/xtixml.cpp:345
+#: ../src/common/xtixml.cpp:498
+msgid "Type must have enum - long conversion"
+msgstr ""
+
+#: ../src/common/xtistrm.cpp:400 ../src/common/xtistrm.cpp:415
+msgid "Invalid or Null Object ID passed to GetObjectClassInfo"
+msgstr ""
+
+#: ../src/common/xtistrm.cpp:405
+msgid "Unknown Object passed to GetObjectClassInfo"
+msgstr ""
+
+#: ../src/common/xtistrm.cpp:420
+msgid "Already Registered Object passed to SetObjectClassInfo"
+msgstr ""
+
+#: ../src/common/xtistrm.cpp:430
+msgid "Invalid or Null Object ID passed to HasObjectClassInfo"
+msgstr ""
+
+#: ../src/common/xtistrm.cpp:460
+msgid "Passing a already registered object to SetObject"
+msgstr ""
+
+#: ../src/common/xtistrm.cpp:471
+msgid "Passing an unknown object to GetObject"
+msgstr ""
+
+#: ../src/common/xtixml.cpp:229
+msgid "Forward hrefs are not supported"
+msgstr ""
+
+#: ../src/common/xtixml.cpp:247
+#, c-format
+msgid "unknown class %s"
+msgstr ""
+
+#: ../src/common/xtixml.cpp:253
+msgid "objects cannot have XML Text Nodes"
+msgstr ""
+
+#: ../src/common/xtixml.cpp:258
+msgid "Objects must have an id attribute"
+msgstr ""
+
+#: ../src/common/xtixml.cpp:267
+#, c-format
+msgid "Doubly used id : %d"
+msgstr ""
+
+#: ../src/common/xtixml.cpp:316
+#, c-format
+msgid "Unknown Property %s"
+msgstr ""
+
+#: ../src/common/xtixml.cpp:407
+msgid "A non empty collection must consist of 'element' nodes"
+msgstr ""
+
+#: ../src/common/xtixml.cpp:478
+msgid "incorrect event handler string, missing dot"
+msgstr ""
+
+#: ../src/common/zipstrm.cpp:559
+msgid "can't re-initialize zlib deflate stream"
+msgstr ""
+
+#: ../src/common/zipstrm.cpp:584
+msgid "can't re-initialize zlib inflate stream"
+msgstr ""
+
+#: ../src/common/zipstrm.cpp:1023
+msgid "Ignoring malformed extra data record, ZIP file may be corrupted"
+msgstr ""
+
+#: ../src/common/zipstrm.cpp:1502
+msgid "assuming this is a multi-part zip concatenated"
+msgstr ""
+
+#: ../src/common/zipstrm.cpp:1664
+msgid "invalid zip file"
+msgstr ""
+
+#: ../src/common/zipstrm.cpp:1723
+msgid "can't find central directory in zip"
+msgstr ""
+
+#: ../src/common/zipstrm.cpp:1812
+msgid "error reading zip central directory"
+msgstr ""
+
+#: ../src/common/zipstrm.cpp:1916
+msgid "error reading zip local header"
+msgstr ""
+
+#: ../src/common/zipstrm.cpp:1964
+msgid "bad zipfile offset to entry"
+msgstr ""
+
+#: ../src/common/zipstrm.cpp:2031
+msgid "stored file length not in Zip header"
+msgstr ""
+
+#: ../src/common/zipstrm.cpp:2045 ../src/common/zipstrm.cpp:2362
+msgid "unsupported Zip compression method"
+msgstr ""
+
+#: ../src/common/zipstrm.cpp:2126
+#, c-format
+msgid "reading zip stream (entry %s): bad length"
+msgstr ""
+
+#: ../src/common/zipstrm.cpp:2131
+#, c-format
+msgid "reading zip stream (entry %s): bad crc"
+msgstr ""
+
+#: ../src/common/zipstrm.cpp:2578
+#, c-format
+msgid "error writing zip entry '%s': file too large without ZIP64"
+msgstr ""
+
+#: ../src/common/zipstrm.cpp:2585
+#, c-format
+msgid "error writing zip entry '%s': bad crc or length"
+msgstr ""
+
+#: ../src/common/zstream.cpp:155 ../src/common/zstream.cpp:315
+msgid "Gzip not supported by this version of zlib"
+msgstr ""
+
+#: ../src/common/zstream.cpp:182
+msgid "Can't initialize zlib inflate stream."
+msgstr ""
+
+#: ../src/common/zstream.cpp:241
+msgid "Can't read inflate stream: unexpected EOF in underlying stream."
+msgstr ""
+
+#: ../src/common/zstream.cpp:248 ../src/common/zstream.cpp:423
+#, c-format
+msgid "zlib error %d"
+msgstr ""
+
+#: ../src/common/zstream.cpp:249
+#, c-format
+msgid "Can't read from inflate stream: %s"
+msgstr ""
+
+#: ../src/common/zstream.cpp:343
+msgid "Can't initialize zlib deflate stream."
+msgstr ""
+
+#: ../src/common/zstream.cpp:424
+#, c-format
+msgid "Can't write to deflate stream: %s"
+msgstr ""
+
+#: ../src/dfb/bitmap.cpp:633 ../src/dfb/bitmap.cpp:667
+#, c-format
+msgid "No bitmap handler for type %d defined."
+msgstr ""
+
+#: ../src/dfb/evtloop.cpp:99
+msgid "Failed to read event from DirectFB pipe"
+msgstr ""
+
+#: ../src/dfb/evtloop.cpp:171
+msgid "Failed to switch DirectFB pipe to non-blocking mode"
+msgstr ""
+
+#: ../src/dfb/fontmgr.cpp:171
+#, c-format
+msgid "no fonts found in %s, using builtin font"
+msgstr ""
+
+#: ../src/dfb/fontmgr.cpp:177
+msgid "Default font"
+msgstr ""
+
+#: ../src/dfb/fontmgr.cpp:195
+#, c-format
+msgid "Fonts index file %s disappeared while loading fonts."
+msgstr ""
+
+#: ../src/dfb/wrapdfb.cpp:60
+#, c-format
+msgid "DirectFB error %d occurred."
+msgstr ""
+
+#: ../src/generic/aboutdlgg.cpp:69
+msgid "Developed by "
+msgstr ""
+
+#: ../src/generic/aboutdlgg.cpp:72
+msgid "Documentation by "
+msgstr ""
+
+#: ../src/generic/aboutdlgg.cpp:75
+msgid "Graphics art by "
+msgstr ""
+
+#: ../src/generic/aboutdlgg.cpp:78
+msgid "Translations by "
+msgstr ""
+
+#: ../src/generic/aboutdlgg.cpp:133 ../src/osx/cocoa/aboutdlg.mm:83
+msgid "Version "
+msgstr ""
+
+#. TRANSLATORS: %s is application name
+#: ../src/generic/aboutdlgg.cpp:146 ../src/msw/aboutdlg.cpp:60
+#, c-format
+msgid "About %s"
+msgstr ""
+
+#: ../src/generic/aboutdlgg.cpp:181
+msgid "License"
+msgstr ""
+
+#: ../src/generic/aboutdlgg.cpp:184
+msgid "Developers"
+msgstr ""
+
+#: ../src/generic/aboutdlgg.cpp:188
+msgid "Documentation writers"
+msgstr ""
+
+#: ../src/generic/aboutdlgg.cpp:192
+msgid "Artists"
+msgstr ""
+
+#: ../src/generic/aboutdlgg.cpp:196
+msgid "Translators"
+msgstr ""
+
+#: ../src/generic/animateg.cpp:125
+msgid "No handler found for animation type."
+msgstr ""
+
+#: ../src/generic/animateg.cpp:133
+#, c-format
+msgid "No animation handler for type %ld defined."
+msgstr ""
+
+#: ../src/generic/animateg.cpp:145
+#, c-format
+msgid "Animation file is not of type %ld."
+msgstr ""
+
+#: ../src/generic/colrdlgg.cpp:154 ../src/gtk/colordlg.cpp:47
+msgid "Choose colour"
+msgstr ""
+
+#: ../src/generic/colrdlgg.cpp:357
+msgid "Red:"
+msgstr ""
+
+#: ../src/generic/colrdlgg.cpp:360
+msgid "Green:"
+msgstr ""
+
+#: ../src/generic/colrdlgg.cpp:363
+msgid "Blue:"
+msgstr ""
+
+#: ../src/generic/colrdlgg.cpp:372
+msgid "Opacity:"
+msgstr ""
+
+#: ../src/generic/colrdlgg.cpp:384
+msgid "Add to custom colours"
+msgstr ""
+
+#: ../src/generic/creddlgg.cpp:56
+msgid "Username:"
+msgstr ""
+
+#: ../src/generic/creddlgg.cpp:63
+msgid "Password:"
+msgstr ""
+
+#. TRANSLATORS: Name of Boolean true value
+#: ../src/generic/datavgen.cpp:1178
+msgid "true"
+msgstr ""
+
+#. TRANSLATORS: Name of Boolean false value
+#: ../src/generic/datavgen.cpp:1180
+msgid "false"
+msgstr ""
+
+#: ../src/generic/datavgen.cpp:6897
+#, c-format
+msgid "Row %i"
+msgstr ""
+
+#. TRANSLATORS: Action for manipulating a tree control
+#: ../src/generic/datavgen.cpp:6987
+msgid "Collapse"
+msgstr ""
+
+#. TRANSLATORS: Action for manipulating a tree control
+#: ../src/generic/datavgen.cpp:6990
+msgid "Expand"
+msgstr ""
+
+#. TRANSLATORS: Name of data view control and number of rows
+#: ../src/generic/datavgen.cpp:7011
+#, c-format
+msgid "%s (%d items)"
+msgstr ""
+
+#: ../src/generic/datavgen.cpp:7062
+#, c-format
+msgid "Column %u"
+msgstr ""
+
+#. TRANSLATORS: Keystroke for manipulating a tree control
+#: ../src/generic/datavgen.cpp:7131 ../src/richtext/richtextbulletspage.cpp:189
+#: ../src/richtext/richtextbulletspage.cpp:192
+#: ../src/richtext/richtextbulletspage.cpp:193
+#: ../src/richtext/richtextliststylepage.cpp:252
+#: ../src/richtext/richtextliststylepage.cpp:255
+#: ../src/richtext/richtextliststylepage.cpp:256
+#: ../src/richtext/richtextsizepage.cpp:248
+msgid "Left"
+msgstr ""
+
+#. TRANSLATORS: Keystroke for manipulating a tree control
+#: ../src/generic/datavgen.cpp:7134 ../src/richtext/richtextbulletspage.cpp:191
+#: ../src/richtext/richtextliststylepage.cpp:254
+#: ../src/richtext/richtextsizepage.cpp:249
+msgid "Right"
+msgstr ""
+
+#: ../src/generic/datectlg.cpp:90
+#, c-format
+msgid ""
+"\"%s\" is not in the expected date format, please enter it as e.g. \"%s\"."
+msgstr ""
+
+#: ../src/generic/datectlg.cpp:94
+msgid "Invalid date"
+msgstr ""
+
+#: ../src/generic/dbgrptg.cpp:159
+#, c-format
+msgid "Open file \"%s\""
+msgstr ""
+
+#: ../src/generic/dbgrptg.cpp:170
+#, c-format
+msgid "Enter command to open file \"%s\":"
+msgstr ""
+
+#: ../src/generic/dbgrptg.cpp:230
+msgid "Executable files (*.exe)|*.exe|"
+msgstr ""
+
+#: ../src/generic/dbgrptg.cpp:300
+#, c-format
+msgid "Debug report \"%s\""
+msgstr ""
+
+#: ../src/generic/dbgrptg.cpp:316
+msgid "A debug report has been generated in the directory\n"
+msgstr ""
+
+#: ../src/generic/dbgrptg.cpp:317
+msgid "The following debug report will be generated\n"
+msgstr ""
+
+#: ../src/generic/dbgrptg.cpp:321
+msgid ""
+"The report contains the files listed below. If any of these files contain "
+"private information,\n"
+"please uncheck them and they will be removed from the report.\n"
+msgstr ""
+
+#: ../src/generic/dbgrptg.cpp:323
+msgid ""
+"If you wish to suppress this debug report completely, please choose the "
+"\"Cancel\" button,\n"
+"but be warned that it may hinder improving the program, so if\n"
+"at all possible please do continue with the report generation.\n"
+msgstr ""
+
+#: ../src/generic/dbgrptg.cpp:325
+msgid "              Thank you and we're sorry for the inconvenience!\n"
+msgstr ""
+
+#: ../src/generic/dbgrptg.cpp:333
+msgid "&Debug report preview:"
+msgstr ""
+
+#: ../src/generic/dbgrptg.cpp:339
+msgid "&View..."
+msgstr ""
+
+#: ../src/generic/dbgrptg.cpp:359
+msgid "&Notes:"
+msgstr ""
+
+#: ../src/generic/dbgrptg.cpp:361
+msgid ""
+"If you have any additional information pertaining to this bug\n"
+"report, please enter it here and it will be joined to it:"
+msgstr ""
+
+#: ../src/generic/dcpsg.cpp:1627
+msgid "Cannot open file for PostScript printing!"
+msgstr ""
+
+#: ../src/generic/dirctrlg.cpp:402
+msgid "Computer"
+msgstr ""
+
+#: ../src/generic/dirctrlg.cpp:404
+msgid "Sections"
+msgstr ""
+
+#: ../src/generic/dirctrlg.cpp:482
+msgid "Home directory"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/generic/dirctrlg.cpp:484 ../src/propgrid/advprops.cpp:811
+msgid "Desktop"
+msgstr ""
+
+#: ../src/generic/dirctrlg.cpp:528 ../src/generic/filectrlg.cpp:752
+msgid "Illegal directory name."
+msgstr ""
+
+#: ../src/generic/dirctrlg.cpp:528 ../src/generic/dirctrlg.cpp:546
+#: ../src/generic/dirctrlg.cpp:557 ../src/generic/dirdlgg.cpp:317
+#: ../src/generic/filectrlg.cpp:638 ../src/generic/filectrlg.cpp:752
+#: ../src/generic/filectrlg.cpp:766 ../src/generic/filectrlg.cpp:782
+#: ../src/generic/filectrlg.cpp:1356 ../src/generic/filectrlg.cpp:1387
+#: ../src/generic/filedlgg.cpp:362 ../src/gtk/filedlg.cpp:76
+msgid "Error"
+msgstr ""
+
+#: ../src/generic/dirctrlg.cpp:546 ../src/generic/filectrlg.cpp:766
+msgid "File name exists already."
+msgstr ""
+
+#: ../src/generic/dirctrlg.cpp:557 ../src/generic/dirdlgg.cpp:317
+#: ../src/generic/filectrlg.cpp:638 ../src/generic/filectrlg.cpp:782
+msgid "Operation not permitted."
+msgstr ""
+
+#: ../src/generic/dirdlgg.cpp:107 ../src/generic/filedlgg.cpp:207
+msgid "Create new directory"
+msgstr ""
+
+#: ../src/generic/dirdlgg.cpp:112 ../src/generic/filedlgg.cpp:203
+msgid "Go to home directory"
+msgstr ""
+
+#: ../src/generic/dirdlgg.cpp:143
+msgid "Show &hidden directories"
+msgstr ""
+
+#: ../src/generic/dirdlgg.cpp:196
+#, c-format
+msgid ""
+"The directory '%s' does not exist\n"
+"Create it now?"
+msgstr ""
+
+#: ../src/generic/dirdlgg.cpp:198
+msgid "Directory does not exist"
+msgstr ""
+
+#: ../src/generic/dirdlgg.cpp:214
+#, c-format
+msgid ""
+"Failed to create directory '%s'\n"
+"(Do you have the required permissions?)"
+msgstr ""
+
+#: ../src/generic/dirdlgg.cpp:216
+msgid "Error creating directory"
+msgstr ""
+
+#: ../src/generic/dirdlgg.cpp:281
+msgid "You cannot add a new directory to this section."
+msgstr ""
+
+#: ../src/generic/dirdlgg.cpp:282
+msgid "Create directory"
+msgstr ""
+
+#: ../src/generic/dirdlgg.cpp:291 ../src/generic/dirdlgg.cpp:301
+#: ../src/generic/filectrlg.cpp:614 ../src/generic/filectrlg.cpp:623
+msgid "NewName"
+msgstr ""
+
+#: ../src/generic/editlbox.cpp:135
+msgid "Edit item"
+msgstr ""
+
+#: ../src/generic/editlbox.cpp:143
+msgid "New item"
+msgstr ""
+
+#: ../src/generic/editlbox.cpp:151
+msgid "Delete item"
+msgstr ""
+
+#: ../src/generic/editlbox.cpp:159
+msgid "Move up"
+msgstr ""
+
+#: ../src/generic/editlbox.cpp:164
+msgid "Move down"
+msgstr ""
+
+#: ../src/generic/fdrepdlg.cpp:108
+msgid "Search for:"
+msgstr ""
+
+#: ../src/generic/fdrepdlg.cpp:120
+msgid "Replace with:"
+msgstr ""
+
+#: ../src/generic/fdrepdlg.cpp:140
+msgid "Whole word"
+msgstr ""
+
+#: ../src/generic/fdrepdlg.cpp:143
+msgid "Match case"
+msgstr ""
+
+#: ../src/generic/fdrepdlg.cpp:156
+msgid "Search direction"
+msgstr ""
+
+#: ../src/generic/fdrepdlg.cpp:175
+msgid "&Replace"
+msgstr ""
+
+#: ../src/generic/fdrepdlg.cpp:178
+msgid "Replace &all"
+msgstr ""
+
+#: ../src/generic/filectrlg.cpp:246 ../src/generic/filectrlg.cpp:269
+msgid "<DIR>"
+msgstr ""
+
+#: ../src/generic/filectrlg.cpp:248 ../src/generic/filectrlg.cpp:271
+msgid "<LINK>"
+msgstr ""
+
+#: ../src/generic/filectrlg.cpp:250 ../src/generic/filectrlg.cpp:273
+msgid "<DRIVE>"
+msgstr ""
+
+#: ../src/generic/filectrlg.cpp:275
+#, c-format
+msgid "%ld byte"
+msgid_plural "%ld bytes"
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../src/generic/filectrlg.cpp:420
+msgid "Name"
+msgstr ""
+
+#: ../src/generic/filectrlg.cpp:421 ../src/richtext/richtextformatdlg.cpp:361
+#: ../src/richtext/richtextsizepage.cpp:298
+msgid "Size"
+msgstr ""
+
+#: ../src/generic/filectrlg.cpp:422
+msgid "Type"
+msgstr ""
+
+#: ../src/generic/filectrlg.cpp:423
+msgid "Modified"
+msgstr ""
+
+#: ../src/generic/filectrlg.cpp:426
+msgid "Permissions"
+msgstr ""
+
+#: ../src/generic/filectrlg.cpp:429
+msgid "Attributes"
+msgstr ""
+
+#: ../src/generic/filectrlg.cpp:936
+msgid "Current directory:"
+msgstr ""
+
+#: ../src/generic/filectrlg.cpp:979
+msgid "Show &hidden files"
+msgstr ""
+
+#: ../src/generic/filectrlg.cpp:1355
+msgid "Illegal file specification."
+msgstr ""
+
+#: ../src/generic/filectrlg.cpp:1387
+msgid "Directory doesn't exist."
+msgstr ""
+
+#: ../src/generic/filedlgg.cpp:195
+msgid "View files as a list view"
+msgstr ""
+
+#: ../src/generic/filedlgg.cpp:197
+msgid "View files as a detailed view"
+msgstr ""
+
+#: ../src/generic/filedlgg.cpp:200
+msgid "Go to parent directory"
+msgstr ""
+
+#: ../src/generic/filedlgg.cpp:351 ../src/gtk/filedlg.cpp:59
+#, c-format
+msgid "File '%s' already exists, do you really want to overwrite it?"
+msgstr ""
+
+#: ../src/generic/filedlgg.cpp:354 ../src/gtk/filedlg.cpp:62
+msgid "Confirm"
+msgstr ""
+
+#: ../src/generic/filedlgg.cpp:362 ../src/gtk/filedlg.cpp:75
+msgid "Please choose an existing file."
+msgstr ""
+
+#: ../src/generic/filepickerg.cpp:64
+msgid "..."
+msgstr ""
+
+#: ../src/generic/fontdlgg.cpp:76 ../src/richtext/richtextformatdlg.cpp:519
+msgid "ABCDEFGabcdefg12345"
+msgstr ""
+
+#: ../src/generic/fontdlgg.cpp:315
+msgid "Roman"
+msgstr ""
+
+#: ../src/generic/fontdlgg.cpp:316
+msgid "Decorative"
+msgstr ""
+
+#: ../src/generic/fontdlgg.cpp:317
+msgid "Modern"
+msgstr ""
+
+#: ../src/generic/fontdlgg.cpp:318
+msgid "Script"
+msgstr ""
+
+#: ../src/generic/fontdlgg.cpp:319
+msgid "Swiss"
+msgstr ""
+
+#: ../src/generic/fontdlgg.cpp:320
+msgid "Teletype"
+msgstr ""
+
+#: ../src/generic/fontdlgg.cpp:321 ../src/generic/fontdlgg.cpp:324
+msgid "Normal"
+msgstr ""
+
+#: ../src/generic/fontdlgg.cpp:323
+msgid "Slant"
+msgstr ""
+
+#: ../src/generic/fontdlgg.cpp:325
+msgid "Light"
+msgstr ""
+
+#: ../src/generic/fontdlgg.cpp:363
+msgid "&Font family:"
+msgstr ""
+
+#: ../src/generic/fontdlgg.cpp:367 ../src/generic/fontdlgg.cpp:369
+msgid "The font family."
+msgstr ""
+
+#: ../src/generic/fontdlgg.cpp:374 ../src/richtext/richtextstylepage.cpp:105
+msgid "&Style:"
+msgstr ""
+
+#: ../src/generic/fontdlgg.cpp:378 ../src/generic/fontdlgg.cpp:380
+msgid "The font style."
+msgstr ""
+
+#: ../src/generic/fontdlgg.cpp:385
+msgid "&Weight:"
+msgstr ""
+
+#: ../src/generic/fontdlgg.cpp:389 ../src/generic/fontdlgg.cpp:391
+msgid "The font weight."
+msgstr ""
+
+#: ../src/generic/fontdlgg.cpp:399
+msgid "C&olour:"
+msgstr ""
+
+#: ../src/generic/fontdlgg.cpp:407 ../src/generic/fontdlgg.cpp:409
+msgid "The font colour."
+msgstr ""
+
+#: ../src/generic/fontdlgg.cpp:415
+msgid "&Point size:"
+msgstr ""
+
+#: ../src/generic/fontdlgg.cpp:420 ../src/generic/fontdlgg.cpp:422
+#: ../src/generic/fontdlgg.cpp:426 ../src/generic/fontdlgg.cpp:428
+msgid "The font point size."
+msgstr ""
+
+#: ../src/generic/fontdlgg.cpp:439 ../src/generic/fontdlgg.cpp:441
+msgid "Whether the font is underlined."
+msgstr ""
+
+#: ../src/generic/fontdlgg.cpp:448 ../src/html/helpwnd.cpp:1215
+msgid "Preview:"
+msgstr ""
+
+#: ../src/generic/fontdlgg.cpp:452 ../src/generic/fontdlgg.cpp:454
+msgid "Shows the font preview."
+msgstr ""
+
+#: ../src/generic/fontdlgg.cpp:464 ../src/generic/fontdlgg.cpp:483
+msgid "Click to cancel the font selection."
+msgstr ""
+
+#: ../src/generic/fontdlgg.cpp:469 ../src/generic/fontdlgg.cpp:471
+#: ../src/generic/fontdlgg.cpp:476 ../src/generic/fontdlgg.cpp:478
+msgid "Click to confirm the font selection."
+msgstr ""
+
+#: ../src/generic/fontpickerg.cpp:50 ../src/gtk/fontdlg.cpp:77
+msgid "Choose font"
+msgstr ""
+
+#: ../src/generic/grid.cpp:6542
+msgid ""
+"Error copying grid to the clipboard. Either selected cells were not "
+"contiguous or no cell was selected."
+msgstr ""
+
+#: ../src/generic/grid.cpp:12739
+msgid "Grid Corner"
+msgstr ""
+
+#: ../src/generic/grid.cpp:12741
+#, c-format
+msgid "Column %s Header"
+msgstr ""
+
+#: ../src/generic/grid.cpp:12743
+#, c-format
+msgid "Row %s Header"
+msgstr ""
+
+#: ../src/generic/grid.cpp:12745
+#, c-format
+msgid "Column %s: %s"
+msgstr ""
+
+#: ../src/generic/grid.cpp:12749
+#, c-format
+msgid "Row %s: %s"
+msgstr ""
+
+#: ../src/generic/grid.cpp:12753
+#, c-format
+msgid "Row %s, Column %s: %s"
+msgstr ""
+
+#: ../src/generic/helpext.cpp:257
+#, c-format
+msgid "Help directory \"%s\" not found."
+msgstr ""
+
+#: ../src/generic/helpext.cpp:265
+#, c-format
+msgid "Help file \"%s\" not found."
+msgstr ""
+
+#: ../src/generic/helpext.cpp:284
+#, c-format
+msgid "Line %lu of map file \"%s\" has invalid syntax, skipped."
+msgstr ""
+
+#: ../src/generic/helpext.cpp:292
+#, c-format
+msgid "No valid mappings found in the file \"%s\"."
+msgstr ""
+
+#: ../src/generic/helpext.cpp:435
+msgid "No entries found."
+msgstr ""
+
+#: ../src/generic/helpext.cpp:444 ../src/generic/helpext.cpp:445
+msgid "Help Index"
+msgstr ""
+
+#: ../src/generic/helpext.cpp:448
+msgid "Relevant entries:"
+msgstr ""
+
+#: ../src/generic/helpext.cpp:449
+msgid "Entries found"
+msgstr ""
+
+#: ../src/generic/hyperlinkg.cpp:170
+msgid "&Copy URL"
+msgstr ""
+
+#: ../src/generic/infobar.cpp:119
+msgid "Hide this notification message."
+msgstr ""
+
+#. TRANSLATORS: %s will be either the application name or "Application"
+#: ../src/generic/logg.cpp:257
+#, c-format
+msgid "%s Error"
+msgstr ""
+
+#. TRANSLATORS: %s will be either the application name or "Application"
+#: ../src/generic/logg.cpp:263
+#, c-format
+msgid "%s Warning"
+msgstr ""
+
+#. TRANSLATORS: %s will be either the application name or "Application"
+#: ../src/generic/logg.cpp:273
+#, c-format
+msgid "%s Information"
+msgstr ""
+
+#: ../src/generic/logg.cpp:276
+msgid "Application"
+msgstr ""
+
+#: ../src/generic/logg.cpp:549
+msgid "Save log contents to file"
+msgstr ""
+
+#: ../src/generic/logg.cpp:551
+msgid "C&lear"
+msgstr ""
+
+#: ../src/generic/logg.cpp:551
+msgid "Clear the log contents"
+msgstr ""
+
+#: ../src/generic/logg.cpp:553
+msgid "Close this window"
+msgstr ""
+
+#: ../src/generic/logg.cpp:554
+msgid "&Log"
+msgstr ""
+
+#: ../src/generic/logg.cpp:610 ../src/generic/logg.cpp:992
+msgid "Can't save log contents to file."
+msgstr ""
+
+#: ../src/generic/logg.cpp:613
+#, c-format
+msgid "Log saved to the file '%s'."
+msgstr ""
+
+#: ../src/generic/logg.cpp:719
+msgid "&Details"
+msgstr ""
+
+#: ../src/generic/logg.cpp:972
+msgid "Failed to copy dialog contents to the clipboard."
+msgstr ""
+
+#: ../src/generic/logg.cpp:1022
+#, c-format
+msgid "Append log to file '%s' (choosing [No] will overwrite it)?"
+msgstr ""
+
+#: ../src/generic/logg.cpp:1024
+msgid "Question"
+msgstr ""
+
+#: ../src/generic/logg.cpp:1038
+msgid "invalid message box return value"
+msgstr ""
+
+#: ../src/generic/notifmsgg.cpp:129
+msgid "Notice"
+msgstr ""
+
+#: ../src/generic/preferencesg.cpp:118
+#, c-format
+msgid "%s Preferences"
+msgstr ""
+
+#: ../src/generic/printps.cpp:143
+msgid "Printing..."
+msgstr ""
+
+#: ../src/generic/printps.cpp:160 ../src/gtk/print.cpp:1076
+#: ../src/msw/printwin.cpp:235
+msgid "Could not start printing."
+msgstr ""
+
+#: ../src/generic/printps.cpp:183
+#, c-format
+msgid "Printing page %d..."
+msgstr ""
+
+#: ../src/generic/prntdlgg.cpp:171
+msgid "Printer options"
+msgstr ""
+
+#: ../src/generic/prntdlgg.cpp:176
+msgid "Print to File"
+msgstr ""
+
+#: ../src/generic/prntdlgg.cpp:179
+msgid "Setup..."
+msgstr ""
+
+#: ../src/generic/prntdlgg.cpp:187
+msgid "Printer:"
+msgstr ""
+
+#: ../src/generic/prntdlgg.cpp:195
+msgid "Status:"
+msgstr ""
+
+#: ../src/generic/prntdlgg.cpp:206
+msgid "All"
+msgstr ""
+
+#: ../src/generic/prntdlgg.cpp:207
+msgid "Pages"
+msgstr ""
+
+#: ../src/generic/prntdlgg.cpp:215
+msgid "Print Range"
+msgstr ""
+
+#: ../src/generic/prntdlgg.cpp:229
+msgid "From:"
+msgstr ""
+
+#: ../src/generic/prntdlgg.cpp:233
+msgid "To:"
+msgstr ""
+
+#: ../src/generic/prntdlgg.cpp:238
+msgid "Copies:"
+msgstr ""
+
+#: ../src/generic/prntdlgg.cpp:288
+msgid "PostScript file"
+msgstr ""
+
+#: ../src/generic/prntdlgg.cpp:439
+msgid "Print Setup"
+msgstr ""
+
+#: ../src/generic/prntdlgg.cpp:483
+msgid "Printer"
+msgstr ""
+
+#: ../src/generic/prntdlgg.cpp:501
+msgid "Default printer"
+msgstr ""
+
+#: ../src/generic/prntdlgg.cpp:595 ../src/generic/prntdlgg.cpp:782
+#: ../src/generic/prntdlgg.cpp:822 ../src/generic/prntdlgg.cpp:835
+#: ../src/generic/prntdlgg.cpp:1031 ../src/generic/prntdlgg.cpp:1036
+msgid "Paper size"
+msgstr ""
+
+#: ../src/generic/prntdlgg.cpp:604 ../src/generic/prntdlgg.cpp:847
+msgid "Portrait"
+msgstr ""
+
+#: ../src/generic/prntdlgg.cpp:605 ../src/generic/prntdlgg.cpp:848
+msgid "Landscape"
+msgstr ""
+
+#: ../src/generic/prntdlgg.cpp:607 ../src/generic/prntdlgg.cpp:849
+msgid "Orientation"
+msgstr ""
+
+#: ../src/generic/prntdlgg.cpp:610
+msgid "Options"
+msgstr ""
+
+#: ../src/generic/prntdlgg.cpp:612
+msgid "Print in colour"
+msgstr ""
+
+#: ../src/generic/prntdlgg.cpp:621
+msgid "Print spooling"
+msgstr ""
+
+#: ../src/generic/prntdlgg.cpp:623
+msgid "Printer command:"
+msgstr ""
+
+#: ../src/generic/prntdlgg.cpp:631
+msgid "Printer options:"
+msgstr ""
+
+#: ../src/generic/prntdlgg.cpp:860
+msgid "Left margin (mm):"
+msgstr ""
+
+#: ../src/generic/prntdlgg.cpp:861
+msgid "Top margin (mm):"
+msgstr ""
+
+#: ../src/generic/prntdlgg.cpp:872
+msgid "Right margin (mm):"
+msgstr ""
+
+#: ../src/generic/prntdlgg.cpp:873
+msgid "Bottom margin (mm):"
+msgstr ""
+
+#: ../src/generic/prntdlgg.cpp:896
+msgid "Printer..."
+msgstr ""
+
+#: ../src/generic/progdlgg.cpp:246
+msgid "&Skip"
+msgstr ""
+
+#: ../src/generic/progdlgg.cpp:347 ../src/generic/progdlgg.cpp:626
+msgid "Unknown"
+msgstr ""
+
+#: ../src/generic/progdlgg.cpp:451 ../src/msw/progdlg.cpp:526
+msgid "Done."
+msgstr ""
+
+#: ../src/generic/srchctlg.cpp:55 ../src/gtk/srchctrl.cpp:206
+#: ../src/html/helpwnd.cpp:530 ../src/html/helpwnd.cpp:545
+msgid "Search"
+msgstr ""
+
+#: ../src/generic/tabg.cpp:1026
+msgid "Could not find tab for id"
+msgstr ""
+
+#: ../src/generic/tipdlg.cpp:136
+msgid "Tips not available, sorry!"
+msgstr ""
+
+#: ../src/generic/tipdlg.cpp:197
+msgid "Tip of the Day"
+msgstr ""
+
+#: ../src/generic/tipdlg.cpp:207
+msgid "Did you know..."
+msgstr ""
+
+#: ../src/generic/tipdlg.cpp:232
+msgid "&Show tips at startup"
+msgstr ""
+
+#: ../src/generic/tipdlg.cpp:236
+msgid "&Next Tip"
+msgstr ""
+
+#: ../src/generic/wizard.cpp:411
+msgid "&Next >"
+msgstr ""
+
+#: ../src/generic/wizard.cpp:412
+msgid "&Finish"
+msgstr ""
+
+#: ../src/generic/wizard.cpp:420
+msgid "< &Back"
+msgstr ""
+
+#: ../src/gtk/aboutdlg.cpp:204
+msgid "translator-credits"
+msgstr ""
+
+#: ../src/gtk/app.cpp:517
+msgid ""
+"WARNING: using XIM input method is unsupported and may result in problems "
+"with input handling and flickering. Consider unsetting GTK_IM_MODULE or "
+"setting to \"ibus\"."
+msgstr ""
+
+#: ../src/gtk/app.cpp:569
+msgid "Unable to initialize GTK+, is DISPLAY set properly?"
+msgstr ""
+
+#: ../src/gtk/filedlg.cpp:89 ../src/gtk/filepicker.cpp:255
+#, c-format
+msgid "Changing current directory to \"%s\" failed"
+msgstr ""
+
+#: ../src/gtk/font.cpp:548
+msgid ""
+"Using private fonts is not supported on this system: Pango library is too "
+"old, 1.38 or later required."
+msgstr ""
+
+#: ../src/gtk/font.cpp:558
+msgid "Failed to create font configuration object."
+msgstr ""
+
+#: ../src/gtk/font.cpp:568
+#, c-format
+msgid "Failed to add custom font \"%s\"."
+msgstr ""
+
+#: ../src/gtk/font.cpp:576
+msgid "Failed to register font configuration using private fonts."
+msgstr ""
+
+#: ../src/gtk/glcanvas.cpp:117 ../src/gtk/glcanvas.cpp:132
+msgid "Fatal Error"
+msgstr ""
+
+#: ../src/gtk/glcanvas.cpp:117
+msgid ""
+"This program wasn't compiled with EGL support required under Wayland, "
+"either\n"
+"install EGL libraries and rebuild or run it under X11 backend by setting\n"
+"environment variable GDK_BACKEND=x11 before starting your program."
+msgstr ""
+
+#: ../src/gtk/glcanvas.cpp:132
+msgid ""
+"wxGLCanvas is only supported on Wayland and X11 currently.  You may be able "
+"to\n"
+"work around this by setting environment variable GDK_BACKEND=x11 before\n"
+"starting your program."
+msgstr ""
+
+#: ../src/gtk/mdi.cpp:433
+msgid "MDI child"
+msgstr ""
+
+#: ../src/gtk/power.cpp:188
+#, c-format
+msgid "Failed to open D-Bus connection to the login manager: %s"
+msgstr ""
+
+#: ../src/gtk/power.cpp:214
+msgid "wxWidgets application"
+msgstr ""
+
+#: ../src/gtk/power.cpp:226
+msgid "Application needs to keep running"
+msgstr ""
+
+#: ../src/gtk/power.cpp:233
+msgid "Clean up before suspend"
+msgstr ""
+
+#: ../src/gtk/power.cpp:259
+#, c-format
+msgid "Failed to inhibit sleep: %s"
+msgstr ""
+
+#: ../src/gtk/power.cpp:265
+msgid "Unexpected response to D-Bus \"Inhibit\" request."
+msgstr ""
+
+#: ../src/gtk/print.cpp:218
+msgid "Custom size"
+msgstr ""
+
+#: ../src/gtk/print.cpp:752
+#, c-format
+msgid "Error while printing: %s"
+msgstr ""
+
+#: ../src/gtk/print.cpp:816
+msgid "Page Setup"
+msgstr ""
+
+#: ../src/gtk/webview_webkit.cpp:932
+msgid "Retrieving JavaScript script output is not supported with WebKit v1"
+msgstr ""
+
+#: ../src/gtk/webview_webkit2.cpp:1098
+msgid ""
+"Setting proxy is not supported by WebKit, at least version 2.16 is required."
+msgstr ""
+
+#: ../src/gtk/webview_webkit2.cpp:1104
+msgid "This program was compiled without support for setting WebKit proxy."
+msgstr ""
+
+#: ../src/gtk/window.cpp:6289
+msgid ""
+"GTK+ installed on this machine is too old to support screen compositing, "
+"please install GTK+ 2.12 or later."
+msgstr ""
+
+#: ../src/gtk/window.cpp:6307
+msgid ""
+"Compositing not supported by this system, please enable it in your Window "
+"Manager."
+msgstr ""
+
+#: ../src/gtk/window.cpp:6318
+msgid ""
+"This program was compiled with a too old version of GTK+, please rebuild "
+"with GTK+ 2.12 or newer."
+msgstr ""
+
+#: ../src/html/chm.cpp:138
+#, c-format
+msgid "Failed to open CHM archive '%s'."
+msgstr ""
+
+#: ../src/html/chm.cpp:270
+#, c-format
+msgid "Could not extract %s into %s: %s"
+msgstr ""
+
+#: ../src/html/chm.cpp:324
+msgid "no error"
+msgstr ""
+
+#: ../src/html/chm.cpp:326
+msgid "bad arguments to library function"
+msgstr ""
+
+#: ../src/html/chm.cpp:328
+msgid "error opening file"
+msgstr ""
+
+#: ../src/html/chm.cpp:330
+msgid "read error"
+msgstr ""
+
+#: ../src/html/chm.cpp:332
+msgid "write error"
+msgstr ""
+
+#: ../src/html/chm.cpp:334
+msgid "seek error"
+msgstr ""
+
+#: ../src/html/chm.cpp:338
+msgid "bad signature"
+msgstr ""
+
+#: ../src/html/chm.cpp:340
+msgid "error in data format"
+msgstr ""
+
+#: ../src/html/chm.cpp:342
+msgid "checksum error"
+msgstr ""
+
+#: ../src/html/chm.cpp:344
+msgid "compression error"
+msgstr ""
+
+#: ../src/html/chm.cpp:346
+msgid "decompression error"
+msgstr ""
+
+#: ../src/html/chm.cpp:437
+#, c-format
+msgid "Could not locate file '%s'."
+msgstr ""
+
+#: ../src/html/chm.cpp:711
+#, c-format
+msgid "Could not create temporary file '%s'"
+msgstr ""
+
+#: ../src/html/chm.cpp:718
+#, c-format
+msgid "Extraction of '%s' into '%s' failed."
+msgstr ""
+
+#: ../src/html/chm.cpp:806 ../src/html/chm.cpp:863
+msgid "CHM handler currently supports only local files!"
+msgstr ""
+
+#: ../src/html/chm.cpp:827
+msgid "Link contained '//', converted to absolute link."
+msgstr ""
+
+#: ../src/html/helpctrl.cpp:59
+#, c-format
+msgid "Help: %s"
+msgstr ""
+
+#: ../src/html/helpctrl.cpp:155
+#, c-format
+msgid "Adding book %s"
+msgstr ""
+
+#: ../src/html/helpdata.cpp:295
+#, c-format
+msgid "Cannot open contents file: %s"
+msgstr ""
+
+#: ../src/html/helpdata.cpp:309
+#, c-format
+msgid "Cannot open index file: %s"
+msgstr ""
+
+#: ../src/html/helpdata.cpp:643
+msgid "noname"
+msgstr ""
+
+#: ../src/html/helpdata.cpp:652
+#, c-format
+msgid "Cannot open HTML help book: %s"
+msgstr ""
+
+#: ../src/html/helpwnd.cpp:315
+msgid "Displays help as you browse the books on the left."
+msgstr ""
+
+#: ../src/html/helpwnd.cpp:411 ../src/html/helpwnd.cpp:1100
+#: ../src/html/helpwnd.cpp:1735
+msgid "(bookmarks)"
+msgstr ""
+
+#: ../src/html/helpwnd.cpp:424
+msgid "Add current page to bookmarks"
+msgstr ""
+
+#: ../src/html/helpwnd.cpp:425
+msgid "Remove current page from bookmarks"
+msgstr ""
+
+#: ../src/html/helpwnd.cpp:470
+msgid "Contents"
+msgstr ""
+
+#: ../src/html/helpwnd.cpp:485
+msgid "Find"
+msgstr ""
+
+#: ../src/html/helpwnd.cpp:487
+msgid "Show all"
+msgstr ""
+
+#: ../src/html/helpwnd.cpp:497
+msgid ""
+"Display all index items that contain given substring. Search is case "
+"insensitive."
+msgstr ""
+
+#: ../src/html/helpwnd.cpp:498
+msgid "Show all items in index"
+msgstr ""
+
+#: ../src/html/helpwnd.cpp:528
+msgid "Case sensitive"
+msgstr ""
+
+#: ../src/html/helpwnd.cpp:529
+msgid "Whole words only"
+msgstr ""
+
+#: ../src/html/helpwnd.cpp:532
+msgid ""
+"Search contents of help book(s) for all occurrences of the text you typed "
+"above"
+msgstr ""
+
+#: ../src/html/helpwnd.cpp:653
+msgid "Show/hide navigation panel"
+msgstr ""
+
+#: ../src/html/helpwnd.cpp:655
+msgid "Go back"
+msgstr ""
+
+#: ../src/html/helpwnd.cpp:656
+msgid "Go forward"
+msgstr ""
+
+#: ../src/html/helpwnd.cpp:658
+msgid "Go one level up in document hierarchy"
+msgstr ""
+
+#: ../src/html/helpwnd.cpp:666 ../src/html/helpwnd.cpp:1547
+msgid "Open HTML document"
+msgstr ""
+
+#: ../src/html/helpwnd.cpp:670
+msgid "Print this page"
+msgstr ""
+
+#: ../src/html/helpwnd.cpp:674
+msgid "Display options dialog"
+msgstr ""
+
+#: ../src/html/helpwnd.cpp:795
+msgid "Please choose the page to display:"
+msgstr ""
+
+#: ../src/html/helpwnd.cpp:796
+msgid "Help Topics"
+msgstr ""
+
+#: ../src/html/helpwnd.cpp:852
+msgid "Searching..."
+msgstr ""
+
+#: ../src/html/helpwnd.cpp:853
+msgid "No matching page found yet"
+msgstr ""
+
+#: ../src/html/helpwnd.cpp:870
+#, c-format
+msgid "Found %i matches"
+msgstr ""
+
+#: ../src/html/helpwnd.cpp:958
+msgid "(Help)"
+msgstr ""
+
+#: ../src/html/helpwnd.cpp:1026
+#, c-format
+msgid "%d of %lu"
+msgstr ""
+
+#: ../src/html/helpwnd.cpp:1028
+#, c-format
+msgid "%lu of %lu"
+msgstr ""
+
+#: ../src/html/helpwnd.cpp:1047
+msgid "Search in all books"
+msgstr ""
+
+#: ../src/html/helpwnd.cpp:1193
+msgid "Help Browser Options"
+msgstr ""
+
+#: ../src/html/helpwnd.cpp:1198
+msgid "Normal font:"
+msgstr ""
+
+#: ../src/html/helpwnd.cpp:1199
+msgid "Fixed font:"
+msgstr ""
+
+#: ../src/html/helpwnd.cpp:1200
+msgid "Font size:"
+msgstr ""
+
+#: ../src/html/helpwnd.cpp:1245
+msgid "font size"
+msgstr ""
+
+#: ../src/html/helpwnd.cpp:1256
+msgid "Normal face<br>and <u>underlined</u>. "
+msgstr ""
+
+#: ../src/html/helpwnd.cpp:1257
+msgid "<i>Italic face.</i> "
+msgstr ""
+
+#: ../src/html/helpwnd.cpp:1258
+msgid "<b>Bold face.</b> "
+msgstr ""
+
+#: ../src/html/helpwnd.cpp:1259
+msgid "<b><i>Bold italic face.</i></b><br>"
+msgstr ""
+
+#: ../src/html/helpwnd.cpp:1262
+msgid "Fixed size face.<br> <b>bold</b> <i>italic</i> "
+msgstr ""
+
+#: ../src/html/helpwnd.cpp:1263
+msgid "<b><i>bold italic <u>underlined</u></i></b><br>"
+msgstr ""
+
+#: ../src/html/helpwnd.cpp:1524
+msgid "Help Printing"
+msgstr ""
+
+#: ../src/html/helpwnd.cpp:1527
+msgid "Cannot print empty page."
+msgstr ""
+
+#: ../src/html/helpwnd.cpp:1540
+msgid "HTML files (*.html;*.htm)|*.html;*.htm|"
+msgstr ""
+
+#: ../src/html/helpwnd.cpp:1541
+msgid "Help books (*.htb)|*.htb|Help books (*.zip)|*.zip|"
+msgstr ""
+
+#: ../src/html/helpwnd.cpp:1542
+msgid "HTML Help Project (*.hhp)|*.hhp|"
+msgstr ""
+
+#: ../src/html/helpwnd.cpp:1544
+msgid "Compressed HTML Help file (*.chm)|*.chm|"
+msgstr ""
+
+#: ../src/html/helpwnd.cpp:1671
+#, c-format
+msgid "%i of %u"
+msgstr ""
+
+#: ../src/html/helpwnd.cpp:1709
+#, c-format
+msgid "%u of %u"
+msgstr ""
+
+#: ../src/html/htmlfilt.cpp:134
+#, c-format
+msgid "Cannot open HTML document: %s"
+msgstr ""
+
+#: ../src/html/htmlwin.cpp:599
+msgid "Connecting..."
+msgstr ""
+
+#: ../src/html/htmlwin.cpp:616
+#, c-format
+msgid "Unable to open requested HTML document: %s"
+msgstr ""
+
+#: ../src/html/htmlwin.cpp:630
+msgid "Loading : "
+msgstr ""
+
+#: ../src/html/htmlwin.cpp:673
+msgid "Done"
+msgstr ""
+
+#: ../src/html/htmlwin.cpp:723
+#, c-format
+msgid "HTML anchor %s does not exist."
+msgstr ""
+
+#: ../src/html/htmlwin.cpp:1057
+#, c-format
+msgid "Copied to clipboard:\"%s\""
+msgstr ""
+
+#: ../src/html/htmprint.cpp:269
+msgid ""
+"This document doesn't fit on the page horizontally and will be truncated "
+"when it is printed."
+msgstr ""
+
+#: ../src/html/htmprint.cpp:285
+#, c-format
+msgid ""
+"The document \"%s\" doesn't fit on the page horizontally and will be "
+"truncated if printed.\n"
+"\n"
+"Would you like to proceed with printing it nevertheless?"
+msgstr ""
+
+#: ../src/html/htmprint.cpp:296
+msgid ""
+"If possible, try changing the layout parameters to make the printout more "
+"narrow."
+msgstr ""
+
+#: ../src/html/htmprint.cpp:445
+msgid ": file does not exist!"
+msgstr ""
+
+#. TRANSLATORS: %s may be a document title.
+#: ../src/html/htmprint.cpp:717
+#, c-format
+msgid "%s Preview"
+msgstr ""
+
+#: ../src/html/htmprint.cpp:755 ../src/richtext/richtextprint.cpp:618
+msgid ""
+"There was a problem during page setup: you may need to set a default printer."
+msgstr ""
+
+#: ../src/msw/clipbrd.cpp:80
+msgid "Failed to open the clipboard."
+msgstr ""
+
+#: ../src/msw/clipbrd.cpp:101
+msgid "Failed to close the clipboard."
+msgstr ""
+
+#: ../src/msw/clipbrd.cpp:113
+msgid "Failed to empty the clipboard."
+msgstr ""
+
+#: ../src/msw/clipbrd.cpp:284
+msgid "Failed to put data on the clipboard"
+msgstr ""
+
+#: ../src/msw/clipbrd.cpp:326
+msgid "Failed to get data from the clipboard"
+msgstr ""
+
+#: ../src/msw/clipbrd.cpp:363
+msgid "Failed to retrieve the supported clipboard formats"
+msgstr ""
+
+#: ../src/msw/colordlg.cpp:228
+#, c-format
+msgid "Colour selection dialog failed with error %0lx."
+msgstr ""
+
+#: ../src/msw/cursor.cpp:141
+msgid "Failed to create cursor."
+msgstr ""
+
+#: ../src/msw/dde.cpp:279
+#, c-format
+msgid "Failed to register DDE server '%s'"
+msgstr ""
+
+#: ../src/msw/dde.cpp:300
+#, c-format
+msgid "Failed to unregister DDE server '%s'"
+msgstr ""
+
+#: ../src/msw/dde.cpp:428
+#, c-format
+msgid "Failed to create connection to server '%s' on topic '%s'"
+msgstr ""
+
+#: ../src/msw/dde.cpp:655
+msgid "DDE poke request failed"
+msgstr ""
+
+#: ../src/msw/dde.cpp:674
+msgid "Failed to establish an advise loop with DDE server"
+msgstr ""
+
+#: ../src/msw/dde.cpp:693
+msgid "Failed to terminate the advise loop with DDE server"
+msgstr ""
+
+#: ../src/msw/dde.cpp:768
+msgid "Failed to send DDE advise notification"
+msgstr ""
+
+#: ../src/msw/dde.cpp:1085
+msgid "Failed to create DDE string"
+msgstr ""
+
+#: ../src/msw/dde.cpp:1131
+msgid "no DDE error."
+msgstr ""
+
+#: ../src/msw/dde.cpp:1135
+msgid "a request for a synchronous advise transaction has timed out."
+msgstr ""
+
+#: ../src/msw/dde.cpp:1138
+msgid "the response to the transaction caused the DDE_FBUSY bit to be set."
+msgstr ""
+
+#: ../src/msw/dde.cpp:1141
+msgid "a request for a synchronous data transaction has timed out."
+msgstr ""
+
+#: ../src/msw/dde.cpp:1144
+msgid ""
+"a DDEML function was called without first calling the DdeInitialize "
+"function,\n"
+"or an invalid instance identifier\n"
+"was passed to a DDEML function."
+msgstr ""
+
+#: ../src/msw/dde.cpp:1147
+msgid ""
+"an application initialized as APPCLASS_MONITOR has\n"
+"attempted to perform a DDE transaction,\n"
+"or an application initialized as APPCMD_CLIENTONLY has \n"
+"attempted to perform server transactions."
+msgstr ""
+
+#: ../src/msw/dde.cpp:1150
+msgid "a request for a synchronous execute transaction has timed out."
+msgstr ""
+
+#: ../src/msw/dde.cpp:1153
+msgid "a parameter failed to be validated by the DDEML."
+msgstr ""
+
+#: ../src/msw/dde.cpp:1156
+msgid "a DDEML application has created a prolonged race condition."
+msgstr ""
+
+#: ../src/msw/dde.cpp:1159
+msgid "a memory allocation failed."
+msgstr ""
+
+#: ../src/msw/dde.cpp:1162
+msgid "a client's attempt to establish a conversation has failed."
+msgstr ""
+
+#: ../src/msw/dde.cpp:1165
+msgid "a transaction failed."
+msgstr ""
+
+#: ../src/msw/dde.cpp:1168
+msgid "a request for a synchronous poke transaction has timed out."
+msgstr ""
+
+#: ../src/msw/dde.cpp:1171
+msgid "an internal call to the PostMessage function has failed. "
+msgstr ""
+
+#: ../src/msw/dde.cpp:1174
+msgid "reentrancy problem."
+msgstr ""
+
+#: ../src/msw/dde.cpp:1177
+msgid ""
+"a server-side transaction was attempted on a conversation\n"
+"that was terminated by the client, or the server\n"
+"terminated before completing a transaction."
+msgstr ""
+
+#: ../src/msw/dde.cpp:1180
+msgid "an internal error has occurred in the DDEML."
+msgstr ""
+
+#: ../src/msw/dde.cpp:1183
+msgid "a request to end an advise transaction has timed out."
+msgstr ""
+
+#: ../src/msw/dde.cpp:1186
+msgid ""
+"an invalid transaction identifier was passed to a DDEML function.\n"
+"Once the application has returned from an XTYP_XACT_COMPLETE callback,\n"
+"the transaction identifier for that callback is no longer valid."
+msgstr ""
+
+#: ../src/msw/dde.cpp:1189
+#, c-format
+msgid "Unknown DDE error %08x"
+msgstr ""
+
+#: ../src/msw/dialup.cpp:343
+msgid ""
+"Dial up functions are unavailable because the remote access service (RAS) is "
+"not installed on this machine. Please install it."
+msgstr ""
+
+#: ../src/msw/dialup.cpp:402
+#, c-format
+msgid ""
+"The version of remote access service (RAS) installed on this machine is too "
+"old, please upgrade (the following required function is missing: %s)."
+msgstr ""
+
+#: ../src/msw/dialup.cpp:437
+msgid "Failed to retrieve text of RAS error message"
+msgstr ""
+
+#: ../src/msw/dialup.cpp:440
+#, c-format
+msgid "unknown error (error code %08x)."
+msgstr ""
+
+#: ../src/msw/dialup.cpp:492
+#, c-format
+msgid "Cannot find active dialup connection: %s"
+msgstr ""
+
+#: ../src/msw/dialup.cpp:513
+msgid "Several active dialup connections found, choosing one randomly."
+msgstr ""
+
+#: ../src/msw/dialup.cpp:598 ../src/msw/dialup.cpp:832
+#, c-format
+msgid "Failed to establish dialup connection: %s"
+msgstr ""
+
+#: ../src/msw/dialup.cpp:664
+#, c-format
+msgid "Failed to get ISP names: %s"
+msgstr ""
+
+#: ../src/msw/dialup.cpp:712
+msgid "Failed to connect: no ISP to dial."
+msgstr ""
+
+#: ../src/msw/dialup.cpp:732
+msgid "Choose ISP to dial"
+msgstr ""
+
+#: ../src/msw/dialup.cpp:733
+msgid "Please choose which ISP do you want to connect to"
+msgstr ""
+
+#: ../src/msw/dialup.cpp:766
+msgid "Failed to connect: missing username/password."
+msgstr ""
+
+#: ../src/msw/dialup.cpp:796
+msgid "Cannot find the location of address book file"
+msgstr ""
+
+#: ../src/msw/dialup.cpp:827
+#, c-format
+msgid "Failed to initiate dialup connection: %s"
+msgstr ""
+
+#: ../src/msw/dialup.cpp:897
+msgid "Cannot hang up - no active dialup connection."
+msgstr ""
+
+#: ../src/msw/dialup.cpp:907
+#, c-format
+msgid "Failed to terminate the dialup connection: %s"
+msgstr ""
+
+#: ../src/msw/dib.cpp:313
+#, c-format
+msgid "Failed to save the bitmap image to file \"%s\"."
+msgstr ""
+
+#: ../src/msw/dib.cpp:543
+#, c-format
+msgid "Failed to allocate %luKb of memory for bitmap data."
+msgstr ""
+
+#: ../src/msw/dir.cpp:241
+#, c-format
+msgid "Cannot enumerate files in directory '%s'"
+msgstr ""
+
+#: ../src/msw/dirdlg.cpp:368
+msgid "Couldn't obtain folder name"
+msgstr ""
+
+#: ../src/msw/dlmsw.cpp:163
+#, c-format
+msgid "(error %d: %s)"
+msgstr ""
+
+#: ../src/msw/dragimag.cpp:143 ../src/msw/dragimag.cpp:178
+#: ../src/msw/imaglist.cpp:309 ../src/msw/imaglist.cpp:331
+msgid "Couldn't add an image to the image list."
+msgstr ""
+
+#: ../src/msw/enhmeta.cpp:94
+#, c-format
+msgid "Failed to load metafile from file \"%s\"."
+msgstr ""
+
+#: ../src/msw/fdrepdlg.cpp:412
+#, c-format
+msgid "Failed to create the standard find/replace dialog (error code %d)"
+msgstr ""
+
+#: ../src/msw/filedlg.cpp:1241
+msgid "Access to the file system is not allowed from secure desktop."
+msgstr ""
+
+#: ../src/msw/filedlg.cpp:1242
+msgid "Security warning"
+msgstr ""
+
+#: ../src/msw/filedlg.cpp:1533
+#, c-format
+msgid "File dialog failed with error code %0lx."
+msgstr ""
+
+#: ../src/msw/font.cpp:1120
+#, c-format
+msgid "Font file \"%s\" couldn't be loaded"
+msgstr ""
+
+#: ../src/msw/fontdlg.cpp:220
+#, c-format
+msgid "Common dialog failed with error code %0lx."
+msgstr ""
+
+#: ../src/msw/fswatcher.cpp:67
+msgid "Ungraceful worker thread termination"
+msgstr ""
+
+#: ../src/msw/fswatcher.cpp:81
+msgid "Unable to create IOCP worker thread"
+msgstr ""
+
+#: ../src/msw/fswatcher.cpp:88
+msgid "Unable to start IOCP worker thread"
+msgstr ""
+
+#: ../src/msw/fswatcher.cpp:140
+msgid "Monitoring individual files for changes is not supported currently."
+msgstr ""
+
+#: ../src/msw/fswatcher.cpp:165
+#, c-format
+msgid "Unable to set up watch for '%s'"
+msgstr ""
+
+#: ../src/msw/fswatcher.cpp:466
+#, c-format
+msgid "Can't monitor non-existent directory \"%s\" for changes."
+msgstr ""
+
+#: ../src/msw/glcanvas.cpp:577 ../src/unix/glx11.cpp:507
+msgid "OpenGL 3.0 or later is not supported by the OpenGL driver."
+msgstr ""
+
+#: ../src/msw/glcanvas.cpp:601 ../src/osx/glcanvas_osx.cpp:395
+#: ../src/unix/glegl.cpp:304 ../src/unix/glx11.cpp:553
+msgid "Couldn't create OpenGL context"
+msgstr ""
+
+#: ../src/msw/glcanvas.cpp:1294
+msgid "Failed to initialize OpenGL"
+msgstr ""
+
+#: ../src/msw/graphicsd2d.cpp:607
+msgid "Could not register custom DirectWrite font loader."
+msgstr ""
+
+#: ../src/msw/helpchm.cpp:48
+msgid ""
+"MS HTML Help functions are unavailable because the MS HTML Help library is "
+"not installed on this machine. Please install it."
+msgstr ""
+
+#: ../src/msw/helpchm.cpp:55
+msgid "Failed to initialize MS HTML Help."
+msgstr ""
+
+#: ../src/msw/iniconf.cpp:458
+#, c-format
+msgid "Can't delete the INI file '%s'"
+msgstr ""
+
+#: ../src/msw/listctrl.cpp:995
+#, c-format
+msgid "Couldn't retrieve information about list control item %d."
+msgstr ""
+
+#: ../src/msw/mdi.cpp:170 ../src/qt/mdi.cpp:253
+msgid "&Cascade"
+msgstr ""
+
+#: ../src/msw/mdi.cpp:171
+msgid "Tile &Horizontally"
+msgstr ""
+
+#: ../src/msw/mdi.cpp:172
+msgid "Tile &Vertically"
+msgstr ""
+
+#: ../src/msw/mdi.cpp:174
+msgid "&Arrange Icons"
+msgstr ""
+
+#: ../src/msw/mdi.cpp:621
+msgid "Failed to create MDI parent frame."
+msgstr ""
+
+#: ../src/msw/mimetype.cpp:234
+#, c-format
+msgid "Failed to create registry entry for '%s' files."
+msgstr ""
+
+#: ../src/msw/ole/automtn.cpp:495
+#, c-format
+msgid "Failed to find CLSID of \"%s\""
+msgstr ""
+
+#: ../src/msw/ole/automtn.cpp:512
+#, c-format
+msgid "Failed to create an instance of \"%s\""
+msgstr ""
+
+#: ../src/msw/ole/automtn.cpp:552
+#, c-format
+msgid "Cannot get an active instance of \"%s\""
+msgstr ""
+
+#: ../src/msw/ole/automtn.cpp:564
+#, c-format
+msgid "Failed to get OLE automation interface for \"%s\""
+msgstr ""
+
+#: ../src/msw/ole/automtn.cpp:621
+msgid "Unknown name or named argument."
+msgstr ""
+
+#: ../src/msw/ole/automtn.cpp:625
+msgid "Incorrect number of arguments."
+msgstr ""
+
+#: ../src/msw/ole/automtn.cpp:637
+msgid "Unknown exception"
+msgstr ""
+
+#: ../src/msw/ole/automtn.cpp:642
+msgid "Method or property not found."
+msgstr ""
+
+#: ../src/msw/ole/automtn.cpp:646
+msgid "Overflow while coercing argument values."
+msgstr ""
+
+#: ../src/msw/ole/automtn.cpp:650
+msgid "Object implementation does not support named arguments."
+msgstr ""
+
+#: ../src/msw/ole/automtn.cpp:654
+msgid "The locale ID is unknown."
+msgstr ""
+
+#: ../src/msw/ole/automtn.cpp:658
+msgid "Missing a required parameter."
+msgstr ""
+
+#: ../src/msw/ole/automtn.cpp:662
+#, c-format
+msgid "Argument %u not found."
+msgstr ""
+
+#: ../src/msw/ole/automtn.cpp:666
+#, c-format
+msgid "Type mismatch in argument %u."
+msgstr ""
+
+#: ../src/msw/ole/automtn.cpp:670
+msgid "The system cannot find the file specified."
+msgstr ""
+
+#: ../src/msw/ole/automtn.cpp:674
+msgid "Class not registered."
+msgstr ""
+
+#: ../src/msw/ole/automtn.cpp:678
+#, c-format
+msgid "Unknown error %08x"
+msgstr ""
+
+#: ../src/msw/ole/automtn.cpp:682
+#, c-format
+msgid "OLE Automation error in %s: %s"
+msgstr ""
+
+#: ../src/msw/ole/dataobj.cpp:385
+#, c-format
+msgid "Couldn't register clipboard format '%s'."
+msgstr ""
+
+#: ../src/msw/ole/dataobj.cpp:402
+#, c-format
+msgid "The clipboard format '%d' doesn't exist."
+msgstr ""
+
+#: ../src/msw/progdlg.cpp:1025
+msgid "Skip"
+msgstr ""
+
+#: ../src/msw/registry.cpp:141
+#, c-format
+msgid "unknown (%lu)"
+msgstr ""
+
+#: ../src/msw/registry.cpp:409
+#, c-format
+msgid "Can't get info about registry key '%s'"
+msgstr ""
+
+#: ../src/msw/registry.cpp:445
+#, c-format
+msgid "Can't open registry key '%s'"
+msgstr ""
+
+#: ../src/msw/registry.cpp:478
+#, c-format
+msgid "Can't create registry key '%s'"
+msgstr ""
+
+#: ../src/msw/registry.cpp:497
+#, c-format
+msgid "Can't close registry key '%s'"
+msgstr ""
+
+#: ../src/msw/registry.cpp:512
+#, c-format
+msgid "Registry value '%s' already exists."
+msgstr ""
+
+#: ../src/msw/registry.cpp:520
+#, c-format
+msgid "Failed to rename registry value '%s' to '%s'."
+msgstr ""
+
+#: ../src/msw/registry.cpp:575
+#, c-format
+msgid "Can't copy values of unsupported type %d."
+msgstr ""
+
+#: ../src/msw/registry.cpp:586
+#, c-format
+msgid "Registry key '%s' does not exist, cannot rename it."
+msgstr ""
+
+#: ../src/msw/registry.cpp:617
+#, c-format
+msgid "Registry key '%s' already exists."
+msgstr ""
+
+#: ../src/msw/registry.cpp:625
+#, c-format
+msgid "Failed to rename the registry key '%s' to '%s'."
+msgstr ""
+
+#: ../src/msw/registry.cpp:670
+#, c-format
+msgid "Failed to copy the registry subkey '%s' to '%s'."
+msgstr ""
+
+#: ../src/msw/registry.cpp:683
+#, c-format
+msgid "Failed to copy registry value '%s'"
+msgstr ""
+
+#: ../src/msw/registry.cpp:692
+#, c-format
+msgid "Failed to copy the contents of registry key '%s' to '%s'."
+msgstr ""
+
+#: ../src/msw/registry.cpp:718
+#, c-format
+msgid ""
+"Registry key '%s' is needed for normal system operation,\n"
+"deleting it will leave your system in unusable state:\n"
+"operation aborted."
+msgstr ""
+
+#: ../src/msw/registry.cpp:754
+#, c-format
+msgid "Can't delete key '%s'"
+msgstr ""
+
+#: ../src/msw/registry.cpp:782
+#, c-format
+msgid "Can't delete value '%s' from key '%s'"
+msgstr ""
+
+#: ../src/msw/registry.cpp:855 ../src/msw/registry.cpp:887
+#: ../src/msw/registry.cpp:929 ../src/msw/registry.cpp:1000
+#, c-format
+msgid "Can't read value of key '%s'"
+msgstr ""
+
+#: ../src/msw/registry.cpp:873 ../src/msw/registry.cpp:915
+#: ../src/msw/registry.cpp:963 ../src/msw/registry.cpp:1106
+#, c-format
+msgid "Can't set value of '%s'"
+msgstr ""
+
+#: ../src/msw/registry.cpp:894 ../src/msw/registry.cpp:943
+#, c-format
+msgid "Registry value \"%s\" is not numeric (but of type %s)"
+msgstr ""
+
+#: ../src/msw/registry.cpp:979
+#, c-format
+msgid "Registry value \"%s\" is not binary (but of type %s)"
+msgstr ""
+
+#: ../src/msw/registry.cpp:1028
+#, c-format
+msgid "Registry value \"%s\" is not text (but of type %s)"
+msgstr ""
+
+#: ../src/msw/registry.cpp:1089
+#, c-format
+msgid "Can't read value of '%s'"
+msgstr ""
+
+#: ../src/msw/registry.cpp:1157
+#, c-format
+msgid "Can't enumerate values of key '%s'"
+msgstr ""
+
+#: ../src/msw/registry.cpp:1196
+#, c-format
+msgid "Can't enumerate subkeys of key '%s'"
+msgstr ""
+
+#: ../src/msw/registry.cpp:1262
+#, c-format
+msgid ""
+"Exporting registry key: file \"%s\" already exists and won't be overwritten."
+msgstr ""
+
+#: ../src/msw/registry.cpp:1411
+#, c-format
+msgid "Can't export value of unsupported type %d."
+msgstr ""
+
+#: ../src/msw/registry.cpp:1427
+#, c-format
+msgid "Ignoring value \"%s\" of the key \"%s\"."
+msgstr ""
+
+#: ../src/msw/textctrl.cpp:596
+msgid ""
+"Impossible to create a rich edit control, using simple text control instead. "
+"Please reinstall riched32.dll"
+msgstr ""
+
+#: ../src/msw/thread.cpp:522 ../src/unix/threadpsx.cpp:850
+msgid "Cannot start thread: error writing TLS."
+msgstr ""
+
+#: ../src/msw/thread.cpp:613
+msgid "Can't set thread priority"
+msgstr ""
+
+#: ../src/msw/thread.cpp:649
+msgid "Can't create thread"
+msgstr ""
+
+#: ../src/msw/thread.cpp:668
+msgid "Couldn't terminate thread"
+msgstr ""
+
+#: ../src/msw/thread.cpp:799
+msgid "Cannot wait for thread termination"
+msgstr ""
+
+#: ../src/msw/thread.cpp:873
+#, c-format
+msgid "Cannot suspend thread %lx"
+msgstr ""
+
+#: ../src/msw/thread.cpp:903
+#, c-format
+msgid "Cannot resume thread %lx"
+msgstr ""
+
+#: ../src/msw/thread.cpp:932
+msgid "Couldn't get the current thread pointer"
+msgstr ""
+
+#: ../src/msw/thread.cpp:1333
+msgid ""
+"Thread module initialization failed: impossible to allocate index in thread "
+"local storage"
+msgstr ""
+
+#: ../src/msw/thread.cpp:1345
+msgid ""
+"Thread module initialization failed: cannot store value in thread local "
+"storage"
+msgstr ""
+
+#: ../src/msw/timer.cpp:133
+msgid "Couldn't create a timer"
+msgstr ""
+
+#: ../src/msw/utils.cpp:372
+msgid "can't find user's HOME, using current directory."
+msgstr ""
+
+#: ../src/msw/utils.cpp:662
+#, c-format
+msgid "Failed to kill process %d"
+msgstr ""
+
+#: ../src/msw/utils.cpp:986
+#, c-format
+msgid "Failed to load resource \"%s\"."
+msgstr ""
+
+#: ../src/msw/utils.cpp:993
+#, c-format
+msgid "Failed to lock resource \"%s\"."
+msgstr ""
+
+#. TRANSLATORS: MS Windows build number
+#: ../src/msw/utils.cpp:1209
+#, c-format
+msgid "build %lu"
+msgstr ""
+
+#: ../src/msw/utils.cpp:1218
+msgid ", 64-bit edition"
+msgstr ""
+
+#: ../src/msw/utilsexc.cpp:224
+msgid "Failed to create an anonymous pipe"
+msgstr ""
+
+#: ../src/msw/utilsexc.cpp:697
+msgid "Failed to redirect the child process IO"
+msgstr ""
+
+#: ../src/msw/utilsexc.cpp:870
+#, c-format
+msgid "Execution of command '%s' failed"
+msgstr ""
+
+#: ../src/msw/volume.cpp:337
+msgid "Failed to load mpr.dll."
+msgstr ""
+
+#: ../src/msw/volume.cpp:506
+#, c-format
+msgid "Cannot read typename from '%s'!"
+msgstr ""
+
+#: ../src/msw/volume.cpp:615
+#, c-format
+msgid "Cannot load icon from '%s'."
+msgstr ""
+
+#: ../src/msw/webview_edge.cpp:285
+msgid "This program was compiled without support for setting Edge proxy."
+msgstr ""
+
+#: ../src/msw/webview_ie.cpp:1010
+msgid "Failed to find web view emulation level in the registry"
+msgstr ""
+
+#: ../src/msw/webview_ie.cpp:1019
+msgid "Failed to set web view to modern emulation level"
+msgstr ""
+
+#: ../src/msw/webview_ie.cpp:1027
+msgid "Failed to reset web view to standard emulation level"
+msgstr ""
+
+#: ../src/msw/webview_ie.cpp:1049
+msgid "Can't run JavaScript script without a valid HTML document"
+msgstr ""
+
+#: ../src/msw/webview_ie.cpp:1056
+msgid "Can't get the JavaScript object"
+msgstr ""
+
+#: ../src/msw/webview_ie.cpp:1070
+msgid "failed to evaluate"
+msgstr ""
+
+#: ../src/osx/cocoa/filedlg.mm:412
+msgid "File type:"
+msgstr ""
+
+#: ../src/osx/cocoa/menu.mm:242
+msgctxt "macOS menu name"
+msgid "Window"
+msgstr ""
+
+#: ../src/osx/cocoa/menu.mm:259
+msgctxt "macOS menu name"
+msgid "Help"
+msgstr ""
+
+#: ../src/osx/cocoa/menu.mm:298
+msgctxt "macOS menu item"
+msgid "Minimize"
+msgstr ""
+
+#: ../src/osx/cocoa/menu.mm:303
+msgctxt "macOS menu item"
+msgid "Zoom"
+msgstr ""
+
+#: ../src/osx/cocoa/menu.mm:309
+msgctxt "macOS menu item"
+msgid "Bring All to Front"
+msgstr ""
+
+#: ../src/osx/core/sound.cpp:143
+#, c-format
+msgid "Failed to load sound from \"%s\" (error %d)."
+msgstr ""
+
+#: ../src/osx/fontutil.cpp:80
+#, c-format
+msgid "Font file \"%s\" doesn't exist."
+msgstr ""
+
+#: ../src/osx/fontutil.cpp:88
+#, c-format
+msgid ""
+"Font file \"%s\" cannot be used as it is not inside the font directory "
+"\"%s\"."
+msgstr ""
+
+#: ../src/osx/menu_osx.cpp:496
+#, c-format
+msgctxt "macOS menu item"
+msgid "About %s"
+msgstr ""
+
+#: ../src/osx/menu_osx.cpp:499
+msgctxt "macOS menu item"
+msgid "About..."
+msgstr ""
+
+#: ../src/osx/menu_osx.cpp:508
+msgctxt "macOS menu item"
+msgid "Preferences..."
+msgstr ""
+
+#: ../src/osx/menu_osx.cpp:512
+msgctxt "macOS menu item"
+msgid "Services"
+msgstr ""
+
+#: ../src/osx/menu_osx.cpp:519
+#, c-format
+msgctxt "macOS menu item"
+msgid "Hide %s"
+msgstr ""
+
+#: ../src/osx/menu_osx.cpp:522
+msgctxt "macOS menu item"
+msgid "Hide Application"
+msgstr ""
+
+#: ../src/osx/menu_osx.cpp:526
+msgctxt "macOS menu item"
+msgid "Hide Others"
+msgstr ""
+
+#: ../src/osx/menu_osx.cpp:528
+msgctxt "macOS menu item"
+msgid "Show All"
+msgstr ""
+
+#: ../src/osx/menu_osx.cpp:534
+#, c-format
+msgctxt "macOS menu item"
+msgid "Quit %s"
+msgstr ""
+
+#: ../src/osx/menu_osx.cpp:537
+msgctxt "macOS menu item"
+msgid "Quit Application"
+msgstr ""
+
+#: ../src/osx/webview_webkit.mm:444
+msgid "Printing is not supported by the system web control"
+msgstr ""
+
+#: ../src/osx/webview_webkit.mm:453
+msgid "Print operation could not be initialized"
+msgstr ""
+
+#. TRANSLATORS: Label of font point size
+#: ../src/propgrid/advprops.cpp:605
+msgid "Point Size"
+msgstr ""
+
+#. TRANSLATORS: Label of font face name
+#: ../src/propgrid/advprops.cpp:615
+msgid "Face Name"
+msgstr ""
+
+#. TRANSLATORS: Label of font style
+#: ../src/propgrid/advprops.cpp:623 ../src/richtext/richtextformatdlg.cpp:331
+msgid "Style"
+msgstr ""
+
+#. TRANSLATORS: Label of font weight
+#: ../src/propgrid/advprops.cpp:628
+msgid "Weight"
+msgstr ""
+
+#. TRANSLATORS: Label of underlined font
+#: ../src/propgrid/advprops.cpp:633 ../src/richtext/richtextfontpage.cpp:358
+msgid "Underlined"
+msgstr ""
+
+#. TRANSLATORS: Label of font family
+#: ../src/propgrid/advprops.cpp:637
+msgid "Family"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:801
+msgid "AppWorkspace"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:802
+msgid "ActiveBorder"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:803
+msgid "ActiveCaption"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:804
+msgid "ButtonFace"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:805
+msgid "ButtonHighlight"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:806
+msgid "ButtonShadow"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:807
+msgid "ButtonText"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:808
+msgid "CaptionText"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:809
+msgid "ControlDark"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:810
+msgid "ControlLight"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:812
+msgid "GrayText"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:813
+msgid "Highlight"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:814
+msgid "HighlightText"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:815
+msgid "InactiveBorder"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:816
+msgid "InactiveCaption"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:817
+msgid "InactiveCaptionText"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:818
+msgid "Menu"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:819
+msgid "Scrollbar"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:820
+msgid "Tooltip"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:821
+msgid "TooltipText"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:822
+msgid "Window"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:823
+msgid "WindowFrame"
+msgstr ""
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:824
+msgid "WindowText"
+msgstr ""
+
+#. TRANSLATORS: Custom colour choice entry
+#: ../src/propgrid/advprops.cpp:825 ../src/propgrid/advprops.cpp:1532
+#: ../src/propgrid/advprops.cpp:1576
+msgid "Custom"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1558
+msgid "Black"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1559
+msgid "Maroon"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1560
+msgid "Navy"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1561
+msgid "Purple"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1562
+msgid "Teal"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1563
+msgid "Gray"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1564
+msgid "Green"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1565
+msgid "Olive"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1566
+msgid "Brown"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1567
+msgid "Blue"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1568
+msgid "Fuchsia"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1569
+msgid "Red"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1570
+msgid "Orange"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1571
+msgid "Silver"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1572
+msgid "Lime"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1573
+msgid "Aqua"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1574
+msgid "Yellow"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1575
+msgid "White"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1718
+msgctxt "system cursor name"
+msgid "Default"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1719
+msgctxt "system cursor name"
+msgid "Arrow"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1720
+msgctxt "system cursor name"
+msgid "Right Arrow"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1721
+msgctxt "system cursor name"
+msgid "Blank"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1722
+msgctxt "system cursor name"
+msgid "Bullseye"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1723
+msgctxt "system cursor name"
+msgid "Character"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1724
+msgctxt "system cursor name"
+msgid "Cross"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1725
+msgctxt "system cursor name"
+msgid "Hand"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1726
+msgctxt "system cursor name"
+msgid "I-Beam"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1727
+msgctxt "system cursor name"
+msgid "Left Button"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1728
+msgctxt "system cursor name"
+msgid "Magnifier"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1729
+msgctxt "system cursor name"
+msgid "Middle Button"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1730
+msgctxt "system cursor name"
+msgid "No Entry"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1731
+msgctxt "system cursor name"
+msgid "Paint Brush"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1732
+msgctxt "system cursor name"
+msgid "Pencil"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1733
+msgctxt "system cursor name"
+msgid "Point Left"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1734
+msgctxt "system cursor name"
+msgid "Point Right"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1735
+msgctxt "system cursor name"
+msgid "Question Arrow"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1736
+msgctxt "system cursor name"
+msgid "Right Button"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1737
+msgctxt "system cursor name"
+msgid "Sizing NE-SW"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1738
+msgctxt "system cursor name"
+msgid "Sizing N-S"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1739
+msgctxt "system cursor name"
+msgid "Sizing NW-SE"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1740
+msgctxt "system cursor name"
+msgid "Sizing W-E"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1741
+msgctxt "system cursor name"
+msgid "Sizing"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1742
+msgctxt "system cursor name"
+msgid "Spraycan"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1743
+msgctxt "system cursor name"
+msgid "Wait"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1744
+msgctxt "system cursor name"
+msgid "Watch"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:1745
+msgctxt "system cursor name"
+msgid "Wait Arrow"
+msgstr ""
+
+#: ../src/propgrid/advprops.cpp:2109
+msgid "Make a selection:"
+msgstr ""
+
+#: ../src/propgrid/manager.cpp:394
+msgid "Property"
+msgstr ""
+
+#: ../src/propgrid/manager.cpp:395
+msgid "Value"
+msgstr ""
+
+#: ../src/propgrid/manager.cpp:1683
+msgid "Categorized Mode"
+msgstr ""
+
+#: ../src/propgrid/manager.cpp:1709
+msgid "Alphabetic Mode"
+msgstr ""
+
+#. TRANSLATORS: Name of Boolean false value
+#: ../src/propgrid/propgrid.cpp:230
+msgid "False"
+msgstr ""
+
+#. TRANSLATORS: Name of Boolean true value
+#: ../src/propgrid/propgrid.cpp:232
+msgid "True"
+msgstr ""
+
+#. TRANSLATORS: Text  displayed for unspecified value
+#: ../src/propgrid/propgrid.cpp:428
+msgid "Unspecified"
+msgstr ""
+
+#. TRANSLATORS: Caption of message box displaying any property error
+#: ../src/propgrid/propgrid.cpp:3145 ../src/propgrid/propgrid.cpp:3282
+msgid "Property Error"
+msgstr ""
+
+#: ../src/propgrid/propgrid.cpp:3259
+msgid "You have entered invalid value. Press ESC to cancel editing."
+msgstr ""
+
+#: ../src/propgrid/propgrid.cpp:6608
+#, c-format
+msgid "Error in resource: %s"
+msgstr ""
+
+#: ../src/propgrid/propgridiface.cpp:377
+#, c-format
+msgid ""
+"Type operation \"%s\" failed: Property labeled \"%s\" is of type \"%s\", NOT "
+"\"%s\"."
+msgstr ""
+
+#: ../src/propgrid/props.cpp:159
+#, c-format
+msgid "Unknown base %d. Base 10 will be used."
+msgstr ""
+
+#: ../src/propgrid/props.cpp:324
+#, c-format
+msgid "Value must be %s or higher."
+msgstr ""
+
+#: ../src/propgrid/props.cpp:329 ../src/propgrid/props.cpp:356
+#, c-format
+msgid "Value must be between %s and %s."
+msgstr ""
+
+#: ../src/propgrid/props.cpp:351
+#, c-format
+msgid "Value must be %s or less."
+msgstr ""
+
+#: ../src/propgrid/props.cpp:1058
+#, c-format
+msgid "Not %s"
+msgstr ""
+
+#: ../src/propgrid/props.cpp:1770
+msgid "Choose a directory:"
+msgstr ""
+
+#: ../src/propgrid/props.cpp:2055
+msgid "Choose a file"
+msgstr ""
+
+#: ../src/qt/mdi.cpp:254
+msgid "&Tile"
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:147
+#: ../src/richtext/richtextformatdlg.cpp:376
+msgid "Background"
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:159
+msgid "Background &colour:"
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:161
+#: ../src/richtext/richtextbackgroundpage.cpp:163
+msgid "Enables a background colour."
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:167
+#: ../src/richtext/richtextbackgroundpage.cpp:169
+msgid "The background colour."
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:178
+msgid "Shadow"
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:193
+msgid "Use &shadow"
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:195
+#: ../src/richtext/richtextbackgroundpage.cpp:197
+msgid "Enables a shadow."
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:211
+msgid "&Horizontal offset:"
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:218
+#: ../src/richtext/richtextbackgroundpage.cpp:220
+msgid "The horizontal offset."
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:224
+#: ../src/richtext/richtextbackgroundpage.cpp:227
+#: ../src/richtext/richtextbackgroundpage.cpp:228
+#: ../src/richtext/richtextbackgroundpage.cpp:247
+#: ../src/richtext/richtextbackgroundpage.cpp:250
+#: ../src/richtext/richtextbackgroundpage.cpp:251
+#: ../src/richtext/richtextbackgroundpage.cpp:287
+#: ../src/richtext/richtextbackgroundpage.cpp:290
+#: ../src/richtext/richtextbackgroundpage.cpp:291
+#: ../src/richtext/richtextbackgroundpage.cpp:314
+#: ../src/richtext/richtextbackgroundpage.cpp:317
+#: ../src/richtext/richtextbackgroundpage.cpp:318
+#: ../src/richtext/richtextborderspage.cpp:252
+#: ../src/richtext/richtextborderspage.cpp:255
+#: ../src/richtext/richtextborderspage.cpp:256
+#: ../src/richtext/richtextborderspage.cpp:286
+#: ../src/richtext/richtextborderspage.cpp:289
+#: ../src/richtext/richtextborderspage.cpp:290
+#: ../src/richtext/richtextborderspage.cpp:320
+#: ../src/richtext/richtextborderspage.cpp:323
+#: ../src/richtext/richtextborderspage.cpp:324
+#: ../src/richtext/richtextborderspage.cpp:354
+#: ../src/richtext/richtextborderspage.cpp:357
+#: ../src/richtext/richtextborderspage.cpp:358
+#: ../src/richtext/richtextborderspage.cpp:420
+#: ../src/richtext/richtextborderspage.cpp:423
+#: ../src/richtext/richtextborderspage.cpp:424
+#: ../src/richtext/richtextborderspage.cpp:454
+#: ../src/richtext/richtextborderspage.cpp:457
+#: ../src/richtext/richtextborderspage.cpp:458
+#: ../src/richtext/richtextborderspage.cpp:488
+#: ../src/richtext/richtextborderspage.cpp:491
+#: ../src/richtext/richtextborderspage.cpp:492
+#: ../src/richtext/richtextborderspage.cpp:522
+#: ../src/richtext/richtextborderspage.cpp:525
+#: ../src/richtext/richtextborderspage.cpp:526
+#: ../src/richtext/richtextborderspage.cpp:590
+#: ../src/richtext/richtextborderspage.cpp:593
+#: ../src/richtext/richtextborderspage.cpp:594
+#: ../src/richtext/richtextfontpage.cpp:177
+#: ../src/richtext/richtextmarginspage.cpp:199
+#: ../src/richtext/richtextmarginspage.cpp:201
+#: ../src/richtext/richtextmarginspage.cpp:202
+#: ../src/richtext/richtextmarginspage.cpp:224
+#: ../src/richtext/richtextmarginspage.cpp:226
+#: ../src/richtext/richtextmarginspage.cpp:227
+#: ../src/richtext/richtextmarginspage.cpp:247
+#: ../src/richtext/richtextmarginspage.cpp:249
+#: ../src/richtext/richtextmarginspage.cpp:250
+#: ../src/richtext/richtextmarginspage.cpp:272
+#: ../src/richtext/richtextmarginspage.cpp:274
+#: ../src/richtext/richtextmarginspage.cpp:275
+#: ../src/richtext/richtextmarginspage.cpp:313
+#: ../src/richtext/richtextmarginspage.cpp:315
+#: ../src/richtext/richtextmarginspage.cpp:316
+#: ../src/richtext/richtextmarginspage.cpp:338
+#: ../src/richtext/richtextmarginspage.cpp:340
+#: ../src/richtext/richtextmarginspage.cpp:341
+#: ../src/richtext/richtextmarginspage.cpp:361
+#: ../src/richtext/richtextmarginspage.cpp:363
+#: ../src/richtext/richtextmarginspage.cpp:364
+#: ../src/richtext/richtextmarginspage.cpp:386
+#: ../src/richtext/richtextmarginspage.cpp:388
+#: ../src/richtext/richtextmarginspage.cpp:389
+#: ../src/richtext/richtextsizepage.cpp:337
+#: ../src/richtext/richtextsizepage.cpp:340
+#: ../src/richtext/richtextsizepage.cpp:341
+#: ../src/richtext/richtextsizepage.cpp:371
+#: ../src/richtext/richtextsizepage.cpp:374
+#: ../src/richtext/richtextsizepage.cpp:375
+#: ../src/richtext/richtextsizepage.cpp:398
+#: ../src/richtext/richtextsizepage.cpp:401
+#: ../src/richtext/richtextsizepage.cpp:402
+#: ../src/richtext/richtextsizepage.cpp:425
+#: ../src/richtext/richtextsizepage.cpp:428
+#: ../src/richtext/richtextsizepage.cpp:429
+#: ../src/richtext/richtextsizepage.cpp:452
+#: ../src/richtext/richtextsizepage.cpp:455
+#: ../src/richtext/richtextsizepage.cpp:456
+#: ../src/richtext/richtextsizepage.cpp:479
+#: ../src/richtext/richtextsizepage.cpp:482
+#: ../src/richtext/richtextsizepage.cpp:483
+#: ../src/richtext/richtextsizepage.cpp:553
+#: ../src/richtext/richtextsizepage.cpp:556
+#: ../src/richtext/richtextsizepage.cpp:557
+#: ../src/richtext/richtextsizepage.cpp:588
+#: ../src/richtext/richtextsizepage.cpp:591
+#: ../src/richtext/richtextsizepage.cpp:592
+#: ../src/richtext/richtextsizepage.cpp:623
+#: ../src/richtext/richtextsizepage.cpp:626
+#: ../src/richtext/richtextsizepage.cpp:627
+#: ../src/richtext/richtextsizepage.cpp:658
+#: ../src/richtext/richtextsizepage.cpp:661
+#: ../src/richtext/richtextsizepage.cpp:662
+msgid "px"
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:225
+#: ../src/richtext/richtextbackgroundpage.cpp:248
+#: ../src/richtext/richtextbackgroundpage.cpp:288
+#: ../src/richtext/richtextbackgroundpage.cpp:315
+#: ../src/richtext/richtextborderspage.cpp:253
+#: ../src/richtext/richtextborderspage.cpp:287
+#: ../src/richtext/richtextborderspage.cpp:321
+#: ../src/richtext/richtextborderspage.cpp:355
+#: ../src/richtext/richtextborderspage.cpp:421
+#: ../src/richtext/richtextborderspage.cpp:455
+#: ../src/richtext/richtextborderspage.cpp:489
+#: ../src/richtext/richtextborderspage.cpp:523
+#: ../src/richtext/richtextborderspage.cpp:591
+#: ../src/richtext/richtextmarginspage.cpp:200
+#: ../src/richtext/richtextmarginspage.cpp:225
+#: ../src/richtext/richtextmarginspage.cpp:248
+#: ../src/richtext/richtextmarginspage.cpp:273
+#: ../src/richtext/richtextmarginspage.cpp:314
+#: ../src/richtext/richtextmarginspage.cpp:339
+#: ../src/richtext/richtextmarginspage.cpp:362
+#: ../src/richtext/richtextmarginspage.cpp:387
+#: ../src/richtext/richtextsizepage.cpp:338
+#: ../src/richtext/richtextsizepage.cpp:372
+#: ../src/richtext/richtextsizepage.cpp:399
+#: ../src/richtext/richtextsizepage.cpp:426
+#: ../src/richtext/richtextsizepage.cpp:453
+#: ../src/richtext/richtextsizepage.cpp:480
+#: ../src/richtext/richtextsizepage.cpp:554
+#: ../src/richtext/richtextsizepage.cpp:589
+#: ../src/richtext/richtextsizepage.cpp:624
+#: ../src/richtext/richtextsizepage.cpp:659
+msgid "cm"
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:226
+#: ../src/richtext/richtextbackgroundpage.cpp:249
+#: ../src/richtext/richtextbackgroundpage.cpp:289
+#: ../src/richtext/richtextbackgroundpage.cpp:316
+#: ../src/richtext/richtextborderspage.cpp:254
+#: ../src/richtext/richtextborderspage.cpp:288
+#: ../src/richtext/richtextborderspage.cpp:322
+#: ../src/richtext/richtextborderspage.cpp:356
+#: ../src/richtext/richtextborderspage.cpp:422
+#: ../src/richtext/richtextborderspage.cpp:456
+#: ../src/richtext/richtextborderspage.cpp:490
+#: ../src/richtext/richtextborderspage.cpp:524
+#: ../src/richtext/richtextborderspage.cpp:592
+#: ../src/richtext/richtextfontpage.cpp:176
+#: ../src/richtext/richtextfontpage.cpp:179
+msgid "pt"
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:229
+#: ../src/richtext/richtextbackgroundpage.cpp:231
+#: ../src/richtext/richtextbackgroundpage.cpp:252
+#: ../src/richtext/richtextbackgroundpage.cpp:254
+#: ../src/richtext/richtextbackgroundpage.cpp:292
+#: ../src/richtext/richtextbackgroundpage.cpp:294
+#: ../src/richtext/richtextbackgroundpage.cpp:319
+#: ../src/richtext/richtextbackgroundpage.cpp:321
+msgid "Units for this value."
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:234
+msgid "&Vertical offset:"
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:241
+#: ../src/richtext/richtextbackgroundpage.cpp:243
+msgid "The vertical offset."
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:257
+msgid "Shadow c&olour:"
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:259
+#: ../src/richtext/richtextbackgroundpage.cpp:261
+msgid "Enables the shadow colour."
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:265
+#: ../src/richtext/richtextbackgroundpage.cpp:267
+msgid "The shadow colour."
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:270
+msgid "Sh&adow spread:"
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:272
+#: ../src/richtext/richtextbackgroundpage.cpp:274
+msgid "Enables the shadow spread."
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:281
+#: ../src/richtext/richtextbackgroundpage.cpp:283
+msgid "The shadow spread."
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:297
+msgid "&Blur distance:"
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:299
+#: ../src/richtext/richtextbackgroundpage.cpp:301
+msgid "Enables the blur distance."
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:308
+#: ../src/richtext/richtextbackgroundpage.cpp:310
+msgid "The shadow blur distance."
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:324
+msgid "Opaci&ty:"
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:326
+#: ../src/richtext/richtextbackgroundpage.cpp:328
+msgid "Enables the shadow opacity."
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:335
+#: ../src/richtext/richtextbackgroundpage.cpp:337
+msgid "The shadow opacity."
+msgstr ""
+
+#. TRANSLATORS: Rich text page units (percentage)
+#: ../src/richtext/richtextbackgroundpage.cpp:340
+#: ../src/richtext/richtextsizepage.cpp:339
+#: ../src/richtext/richtextsizepage.cpp:373
+#: ../src/richtext/richtextsizepage.cpp:400
+#: ../src/richtext/richtextsizepage.cpp:427
+#: ../src/richtext/richtextsizepage.cpp:454
+#: ../src/richtext/richtextsizepage.cpp:481
+#: ../src/richtext/richtextsizepage.cpp:555
+#: ../src/richtext/richtextsizepage.cpp:590
+#: ../src/richtext/richtextsizepage.cpp:625
+#: ../src/richtext/richtextsizepage.cpp:660
+msgid "%"
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:229
+#: ../src/richtext/richtextborderspage.cpp:387
+msgid "Border"
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:242
+#: ../src/richtext/richtextborderspage.cpp:410
+#: ../src/richtext/richtextindentspage.cpp:194
+#: ../src/richtext/richtextliststylepage.cpp:384
+#: ../src/richtext/richtextmarginspage.cpp:185
+#: ../src/richtext/richtextmarginspage.cpp:299
+#: ../src/richtext/richtextsizepage.cpp:531
+#: ../src/richtext/richtextsizepage.cpp:538
+msgid "&Left:"
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:257
+#: ../src/richtext/richtextborderspage.cpp:259
+msgid "Units for the left border width."
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:266
+#: ../src/richtext/richtextborderspage.cpp:268
+#: ../src/richtext/richtextborderspage.cpp:300
+#: ../src/richtext/richtextborderspage.cpp:302
+#: ../src/richtext/richtextborderspage.cpp:334
+#: ../src/richtext/richtextborderspage.cpp:336
+#: ../src/richtext/richtextborderspage.cpp:368
+#: ../src/richtext/richtextborderspage.cpp:370
+#: ../src/richtext/richtextborderspage.cpp:434
+#: ../src/richtext/richtextborderspage.cpp:436
+#: ../src/richtext/richtextborderspage.cpp:468
+#: ../src/richtext/richtextborderspage.cpp:470
+#: ../src/richtext/richtextborderspage.cpp:502
+#: ../src/richtext/richtextborderspage.cpp:504
+#: ../src/richtext/richtextborderspage.cpp:536
+#: ../src/richtext/richtextborderspage.cpp:538
+msgid "The border line style."
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:276
+#: ../src/richtext/richtextborderspage.cpp:444
+#: ../src/richtext/richtextindentspage.cpp:212
+#: ../src/richtext/richtextliststylepage.cpp:402
+#: ../src/richtext/richtextmarginspage.cpp:210
+#: ../src/richtext/richtextmarginspage.cpp:324
+#: ../src/richtext/richtextsizepage.cpp:601
+#: ../src/richtext/richtextsizepage.cpp:608
+msgid "&Right:"
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:291
+#: ../src/richtext/richtextborderspage.cpp:293
+msgid "Units for the right border width."
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:310
+#: ../src/richtext/richtextborderspage.cpp:478
+#: ../src/richtext/richtextmarginspage.cpp:233
+#: ../src/richtext/richtextmarginspage.cpp:347
+#: ../src/richtext/richtextsizepage.cpp:566
+#: ../src/richtext/richtextsizepage.cpp:573
+msgid "&Top:"
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:325
+#: ../src/richtext/richtextborderspage.cpp:327
+msgid "Units for the top border width."
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:344
+#: ../src/richtext/richtextborderspage.cpp:512
+#: ../src/richtext/richtextmarginspage.cpp:258
+#: ../src/richtext/richtextmarginspage.cpp:372
+#: ../src/richtext/richtextsizepage.cpp:636
+#: ../src/richtext/richtextsizepage.cpp:643
+msgid "&Bottom:"
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:359
+#: ../src/richtext/richtextborderspage.cpp:361
+msgid "Units for the bottom border width."
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:380
+#: ../src/richtext/richtextborderspage.cpp:548
+msgid "&Synchronize values"
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:382
+#: ../src/richtext/richtextborderspage.cpp:384
+#: ../src/richtext/richtextborderspage.cpp:550
+#: ../src/richtext/richtextborderspage.cpp:552
+msgid "Check to edit all borders simultaneously."
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:397
+#: ../src/richtext/richtextborderspage.cpp:555
+msgid "Outline"
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:425
+#: ../src/richtext/richtextborderspage.cpp:427
+msgid "Units for the left outline width."
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:459
+#: ../src/richtext/richtextborderspage.cpp:461
+msgid "Units for the right outline width."
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:493
+#: ../src/richtext/richtextborderspage.cpp:495
+msgid "Units for the top outline width."
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:527
+#: ../src/richtext/richtextborderspage.cpp:529
+msgid "Units for the bottom outline width."
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:565
+#: ../src/richtext/richtextborderspage.cpp:600
+msgid "Corner"
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:574
+msgid "Corner &radius:"
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:576
+#: ../src/richtext/richtextborderspage.cpp:578
+msgid "An optional corner radius for adding rounded corners."
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:584
+#: ../src/richtext/richtextborderspage.cpp:586
+msgid "The value of the corner radius."
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:595
+#: ../src/richtext/richtextborderspage.cpp:597
+msgid "Units for the corner radius."
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:609
+#: ../src/richtext/richtextsizepage.cpp:247
+#: ../src/richtext/richtextsizepage.cpp:251
+msgid "None"
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:610
+msgid "Solid"
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:611
+msgid "Dotted"
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:612
+msgid "Dashed"
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:613
+msgid "Double"
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:614
+msgid "Groove"
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:615
+msgid "Ridge"
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:616
+msgid "Inset"
+msgstr ""
+
+#: ../src/richtext/richtextborderspage.cpp:617
+msgid "Outset"
+msgstr ""
+
+#: ../src/richtext/richtextbuffer.cpp:3518
+msgid "Change Style"
+msgstr ""
+
+#: ../src/richtext/richtextbuffer.cpp:3701
+msgid "Change Object Style"
+msgstr ""
+
+#: ../src/richtext/richtextbuffer.cpp:3974
+#: ../src/richtext/richtextbuffer.cpp:8174
+msgid "Change Properties"
+msgstr ""
+
+#: ../src/richtext/richtextbuffer.cpp:4346
+msgid "Change List Style"
+msgstr ""
+
+#: ../src/richtext/richtextbuffer.cpp:4519
+msgid "Renumber List"
+msgstr ""
+
+#: ../src/richtext/richtextbuffer.cpp:7867
+#: ../src/richtext/richtextbuffer.cpp:7897
+#: ../src/richtext/richtextbuffer.cpp:7939
+#: ../src/richtext/richtextctrl.cpp:1279 ../src/richtext/richtextctrl.cpp:1473
+msgid "Insert Text"
+msgstr ""
+
+#: ../src/richtext/richtextbuffer.cpp:8023
+#: ../src/richtext/richtextbuffer.cpp:8979
+msgid "Insert Image"
+msgstr ""
+
+#: ../src/richtext/richtextbuffer.cpp:8070
+msgid "Insert Object"
+msgstr ""
+
+#: ../src/richtext/richtextbuffer.cpp:8112
+msgid "Insert Field"
+msgstr ""
+
+#: ../src/richtext/richtextbuffer.cpp:8410
+msgid "Too many EndStyle calls!"
+msgstr ""
+
+#: ../src/richtext/richtextbuffer.cpp:8785
+msgid "files"
+msgstr ""
+
+#: ../src/richtext/richtextbuffer.cpp:9380
+msgid "standard/circle"
+msgstr ""
+
+#: ../src/richtext/richtextbuffer.cpp:9381
+msgid "standard/circle-outline"
+msgstr ""
+
+#: ../src/richtext/richtextbuffer.cpp:9382
+msgid "standard/square"
+msgstr ""
+
+#: ../src/richtext/richtextbuffer.cpp:9383
+msgid "standard/diamond"
+msgstr ""
+
+#: ../src/richtext/richtextbuffer.cpp:9384
+msgid "standard/triangle"
+msgstr ""
+
+#: ../src/richtext/richtextbuffer.cpp:9423
+msgid "Box Properties"
+msgstr ""
+
+#: ../src/richtext/richtextbuffer.cpp:10006
+msgid "Multiple Cell Properties"
+msgstr ""
+
+#: ../src/richtext/richtextbuffer.cpp:10008
+msgid "Cell Properties"
+msgstr ""
+
+#: ../src/richtext/richtextbuffer.cpp:11256
+msgid "Set Cell Style"
+msgstr ""
+
+#: ../src/richtext/richtextbuffer.cpp:11330
+msgid "Delete Row"
+msgstr ""
+
+#: ../src/richtext/richtextbuffer.cpp:11380
+msgid "Delete Column"
+msgstr ""
+
+#: ../src/richtext/richtextbuffer.cpp:11431
+msgid "Add Row"
+msgstr ""
+
+#: ../src/richtext/richtextbuffer.cpp:11494
+msgid "Add Column"
+msgstr ""
+
+#: ../src/richtext/richtextbuffer.cpp:11537
+msgid "Table Properties"
+msgstr ""
+
+#: ../src/richtext/richtextbuffer.cpp:12899
+msgid "Picture Properties"
+msgstr ""
+
+#: ../src/richtext/richtextbuffer.cpp:13169
+#: ../src/richtext/richtextbuffer.cpp:13279
+msgid "image"
+msgstr ""
+
+#: ../src/richtext/richtextbulletspage.cpp:145
+#: ../src/richtext/richtextliststylepage.cpp:209
+msgid "&Bullet style:"
+msgstr ""
+
+#: ../src/richtext/richtextbulletspage.cpp:150
+#: ../src/richtext/richtextbulletspage.cpp:152
+#: ../src/richtext/richtextliststylepage.cpp:214
+#: ../src/richtext/richtextliststylepage.cpp:216
+msgid "The available bullet styles."
+msgstr ""
+
+#: ../src/richtext/richtextbulletspage.cpp:158
+#: ../src/richtext/richtextliststylepage.cpp:221
+msgid "Peri&od"
+msgstr ""
+
+#: ../src/richtext/richtextbulletspage.cpp:160
+#: ../src/richtext/richtextbulletspage.cpp:162
+#: ../src/richtext/richtextliststylepage.cpp:223
+#: ../src/richtext/richtextliststylepage.cpp:225
+msgid "Check to add a period after the bullet."
+msgstr ""
+
+#. TRANSLATORS: Bullet point in parentheses option
+#: ../src/richtext/richtextbulletspage.cpp:167
+#: ../src/richtext/richtextliststylepage.cpp:230
+msgid "(*)"
+msgstr ""
+
+#: ../src/richtext/richtextbulletspage.cpp:169
+#: ../src/richtext/richtextbulletspage.cpp:171
+#: ../src/richtext/richtextliststylepage.cpp:232
+#: ../src/richtext/richtextliststylepage.cpp:234
+msgid "Check to enclose the bullet in parentheses."
+msgstr ""
+
+#. TRANSLATORS: Right parenthesis bullet point option
+#: ../src/richtext/richtextbulletspage.cpp:176
+#: ../src/richtext/richtextliststylepage.cpp:239
+msgid "*)"
+msgstr ""
+
+#: ../src/richtext/richtextbulletspage.cpp:178
+#: ../src/richtext/richtextbulletspage.cpp:180
+#: ../src/richtext/richtextliststylepage.cpp:241
+#: ../src/richtext/richtextliststylepage.cpp:243
+msgid "Check to add a right parenthesis."
+msgstr ""
+
+#: ../src/richtext/richtextbulletspage.cpp:185
+#: ../src/richtext/richtextliststylepage.cpp:248
+msgid "Bullet &Alignment:"
+msgstr ""
+
+#: ../src/richtext/richtextbulletspage.cpp:190
+#: ../src/richtext/richtextliststylepage.cpp:253
+msgid "Centre"
+msgstr ""
+
+#: ../src/richtext/richtextbulletspage.cpp:194
+#: ../src/richtext/richtextbulletspage.cpp:196
+#: ../src/richtext/richtextbulletspage.cpp:217
+#: ../src/richtext/richtextbulletspage.cpp:219
+#: ../src/richtext/richtextliststylepage.cpp:257
+#: ../src/richtext/richtextliststylepage.cpp:259
+#: ../src/richtext/richtextliststylepage.cpp:278
+#: ../src/richtext/richtextliststylepage.cpp:280
+msgid "The bullet character."
+msgstr ""
+
+#: ../src/richtext/richtextbulletspage.cpp:212
+#: ../src/richtext/richtextliststylepage.cpp:271
+msgid "&Symbol:"
+msgstr ""
+
+#: ../src/richtext/richtextbulletspage.cpp:222
+#: ../src/richtext/richtextliststylepage.cpp:283
+msgid "Ch&oose..."
+msgstr ""
+
+#: ../src/richtext/richtextbulletspage.cpp:223
+#: ../src/richtext/richtextbulletspage.cpp:225
+#: ../src/richtext/richtextliststylepage.cpp:284
+#: ../src/richtext/richtextliststylepage.cpp:286
+msgid "Click to browse for a symbol."
+msgstr ""
+
+#: ../src/richtext/richtextbulletspage.cpp:230
+#: ../src/richtext/richtextliststylepage.cpp:291
+msgid "Symbol &font:"
+msgstr ""
+
+#: ../src/richtext/richtextbulletspage.cpp:235
+#: ../src/richtext/richtextbulletspage.cpp:237
+#: ../src/richtext/richtextliststylepage.cpp:297
+msgid "Available fonts."
+msgstr ""
+
+#: ../src/richtext/richtextbulletspage.cpp:242
+#: ../src/richtext/richtextliststylepage.cpp:302
+msgid "S&tandard bullet name:"
+msgstr ""
+
+#: ../src/richtext/richtextbulletspage.cpp:247
+#: ../src/richtext/richtextbulletspage.cpp:249
+#: ../src/richtext/richtextliststylepage.cpp:307
+#: ../src/richtext/richtextliststylepage.cpp:309
+msgid "A standard bullet name."
+msgstr ""
+
+#: ../src/richtext/richtextbulletspage.cpp:254
+msgid "&Number:"
+msgstr ""
+
+#: ../src/richtext/richtextbulletspage.cpp:258
+#: ../src/richtext/richtextbulletspage.cpp:260
+msgid "The list item number."
+msgstr ""
+
+#: ../src/richtext/richtextbulletspage.cpp:266
+#: ../src/richtext/richtextbulletspage.cpp:268
+#: ../src/richtext/richtextliststylepage.cpp:475
+#: ../src/richtext/richtextliststylepage.cpp:477
+msgid "Shows a preview of the bullet settings."
+msgstr ""
+
+#: ../src/richtext/richtextbulletspage.cpp:276
+#: ../src/richtext/richtextliststylepage.cpp:484
+msgid "(None)"
+msgstr ""
+
+#: ../src/richtext/richtextbulletspage.cpp:277
+#: ../src/richtext/richtextliststylepage.cpp:485
+msgid "Arabic"
+msgstr ""
+
+#: ../src/richtext/richtextbulletspage.cpp:278
+#: ../src/richtext/richtextliststylepage.cpp:486
+msgid "Upper case letters"
+msgstr ""
+
+#: ../src/richtext/richtextbulletspage.cpp:279
+#: ../src/richtext/richtextliststylepage.cpp:487
+msgid "Lower case letters"
+msgstr ""
+
+#: ../src/richtext/richtextbulletspage.cpp:280
+#: ../src/richtext/richtextliststylepage.cpp:488
+msgid "Upper case roman numerals"
+msgstr ""
+
+#: ../src/richtext/richtextbulletspage.cpp:281
+#: ../src/richtext/richtextliststylepage.cpp:489
+msgid "Lower case roman numerals"
+msgstr ""
+
+#: ../src/richtext/richtextbulletspage.cpp:282
+#: ../src/richtext/richtextliststylepage.cpp:490
+msgid "Numbered outline"
+msgstr ""
+
+#: ../src/richtext/richtextbulletspage.cpp:283
+#: ../src/richtext/richtextliststylepage.cpp:491
+msgid "Symbol"
+msgstr ""
+
+#: ../src/richtext/richtextbulletspage.cpp:284
+#: ../src/richtext/richtextliststylepage.cpp:492
+msgid "Bitmap"
+msgstr ""
+
+#: ../src/richtext/richtextbulletspage.cpp:285
+#: ../src/richtext/richtextliststylepage.cpp:493
+msgid "Standard"
+msgstr ""
+
+#: ../src/richtext/richtextbulletspage.cpp:287
+#: ../src/richtext/richtextliststylepage.cpp:495
+msgid "*"
+msgstr ""
+
+#: ../src/richtext/richtextbulletspage.cpp:288
+#: ../src/richtext/richtextliststylepage.cpp:496
+msgid "-"
+msgstr ""
+
+#: ../src/richtext/richtextbulletspage.cpp:289
+#: ../src/richtext/richtextliststylepage.cpp:497
+msgid ">"
+msgstr ""
+
+#: ../src/richtext/richtextbulletspage.cpp:290
+#: ../src/richtext/richtextliststylepage.cpp:498
+msgid "+"
+msgstr ""
+
+#: ../src/richtext/richtextbulletspage.cpp:291
+#: ../src/richtext/richtextliststylepage.cpp:499
+msgid "~"
+msgstr ""
+
+#: ../src/richtext/richtextctrl.cpp:859
+msgid "Drag"
+msgstr ""
+
+#: ../src/richtext/richtextctrl.cpp:1338 ../src/richtext/richtextctrl.cpp:1559
+msgid "Delete Text"
+msgstr ""
+
+#: ../src/richtext/richtextctrl.cpp:1537
+msgid "Remove Bullet"
+msgstr ""
+
+#: ../src/richtext/richtextctrl.cpp:3070
+msgid "The text couldn't be saved."
+msgstr ""
+
+#: ../src/richtext/richtextctrl.cpp:3644
+msgid "Replace"
+msgstr ""
+
+#: ../src/richtext/richtextfontpage.cpp:146
+#: ../src/richtext/richtextsymboldlg.cpp:384
+msgid "&Font:"
+msgstr ""
+
+#: ../src/richtext/richtextfontpage.cpp:150
+#: ../src/richtext/richtextfontpage.cpp:152
+msgid "Type a font name."
+msgstr ""
+
+#: ../src/richtext/richtextfontpage.cpp:158
+msgid "&Size:"
+msgstr ""
+
+#: ../src/richtext/richtextfontpage.cpp:165
+#: ../src/richtext/richtextfontpage.cpp:167
+msgid "Type a size in points."
+msgstr ""
+
+#: ../src/richtext/richtextfontpage.cpp:180
+#: ../src/richtext/richtextfontpage.cpp:182
+msgid "The font size units, points or pixels."
+msgstr ""
+
+#: ../src/richtext/richtextfontpage.cpp:189
+#: ../src/richtext/richtextfontpage.cpp:191
+msgid "Lists the available fonts."
+msgstr ""
+
+#: ../src/richtext/richtextfontpage.cpp:196
+#: ../src/richtext/richtextfontpage.cpp:198
+msgid "Lists font sizes in points."
+msgstr ""
+
+#: ../src/richtext/richtextfontpage.cpp:207
+msgid "Font st&yle:"
+msgstr ""
+
+#: ../src/richtext/richtextfontpage.cpp:212
+#: ../src/richtext/richtextfontpage.cpp:214
+msgid "Select regular or italic style."
+msgstr ""
+
+#: ../src/richtext/richtextfontpage.cpp:220
+msgid "Font &weight:"
+msgstr ""
+
+#: ../src/richtext/richtextfontpage.cpp:225
+#: ../src/richtext/richtextfontpage.cpp:227
+msgid "Select regular or bold."
+msgstr ""
+
+#: ../src/richtext/richtextfontpage.cpp:233
+msgid "&Underlining:"
+msgstr ""
+
+#: ../src/richtext/richtextfontpage.cpp:238
+#: ../src/richtext/richtextfontpage.cpp:240
+msgid "Select underlining or no underlining."
+msgstr ""
+
+#: ../src/richtext/richtextfontpage.cpp:248
+msgid "&Colour:"
+msgstr ""
+
+#: ../src/richtext/richtextfontpage.cpp:253
+#: ../src/richtext/richtextfontpage.cpp:255
+msgid "Click to change the text colour."
+msgstr ""
+
+#: ../src/richtext/richtextfontpage.cpp:261
+msgid "&Bg colour:"
+msgstr ""
+
+#: ../src/richtext/richtextfontpage.cpp:266
+#: ../src/richtext/richtextfontpage.cpp:268
+msgid "Click to change the text background colour."
+msgstr ""
+
+#: ../src/richtext/richtextfontpage.cpp:276
+#: ../src/richtext/richtextfontpage.cpp:278
+msgid "Check to show a line through the text."
+msgstr ""
+
+#: ../src/richtext/richtextfontpage.cpp:281
+msgid "Ca&pitals"
+msgstr ""
+
+#: ../src/richtext/richtextfontpage.cpp:283
+#: ../src/richtext/richtextfontpage.cpp:285
+msgid "Check to show the text in capitals."
+msgstr ""
+
+#: ../src/richtext/richtextfontpage.cpp:288
+msgid "Small C&apitals"
+msgstr ""
+
+#: ../src/richtext/richtextfontpage.cpp:290
+#: ../src/richtext/richtextfontpage.cpp:292
+msgid "Check to show the text in small capitals."
+msgstr ""
+
+#: ../src/richtext/richtextfontpage.cpp:295
+msgid "Supe&rscript"
+msgstr ""
+
+#: ../src/richtext/richtextfontpage.cpp:297
+#: ../src/richtext/richtextfontpage.cpp:299
+msgid "Check to show the text in superscript."
+msgstr ""
+
+#: ../src/richtext/richtextfontpage.cpp:302
+msgid "Subscrip&t"
+msgstr ""
+
+#: ../src/richtext/richtextfontpage.cpp:304
+#: ../src/richtext/richtextfontpage.cpp:306
+msgid "Check to show the text in subscript."
+msgstr ""
+
+#: ../src/richtext/richtextfontpage.cpp:312
+msgid "Rig&ht-to-left"
+msgstr ""
+
+#: ../src/richtext/richtextfontpage.cpp:314
+#: ../src/richtext/richtextfontpage.cpp:316
+msgid "Check to indicate right-to-left text layout."
+msgstr ""
+
+#: ../src/richtext/richtextfontpage.cpp:319
+msgid "Suppress hyphe&nation"
+msgstr ""
+
+#: ../src/richtext/richtextfontpage.cpp:321
+#: ../src/richtext/richtextfontpage.cpp:323
+msgid "Check to suppress hyphenation."
+msgstr ""
+
+#: ../src/richtext/richtextfontpage.cpp:329
+#: ../src/richtext/richtextfontpage.cpp:331
+msgid "Shows a preview of the font settings."
+msgstr ""
+
+#: ../src/richtext/richtextfontpage.cpp:348
+#: ../src/richtext/richtextfontpage.cpp:352
+#: ../src/richtext/richtextfontpage.cpp:356
+#: ../src/richtext/richtextformatdlg.cpp:873
+#: ../src/richtext/richtextindentspage.cpp:273
+#: ../src/richtext/richtextindentspage.cpp:285
+#: ../src/richtext/richtextindentspage.cpp:286
+#: ../src/richtext/richtextindentspage.cpp:310
+#: ../src/richtext/richtextindentspage.cpp:325
+#: ../src/richtext/richtextliststylepage.cpp:451
+#: ../src/richtext/richtextliststylepage.cpp:463
+#: ../src/richtext/richtextliststylepage.cpp:464
+msgid "(none)"
+msgstr ""
+
+#: ../src/richtext/richtextfontpage.cpp:349
+#: ../src/richtext/richtextfontpage.cpp:353
+msgid "Regular"
+msgstr ""
+
+#: ../src/richtext/richtextfontpage.cpp:357
+msgid "Not underlined"
+msgstr ""
+
+#: ../src/richtext/richtextformatdlg.cpp:341
+msgid "Indents && Spacing"
+msgstr ""
+
+#: ../src/richtext/richtextformatdlg.cpp:346
+msgid "Tabs"
+msgstr ""
+
+#: ../src/richtext/richtextformatdlg.cpp:351
+msgid "Bullets"
+msgstr ""
+
+#: ../src/richtext/richtextformatdlg.cpp:356
+msgid "List Style"
+msgstr ""
+
+#: ../src/richtext/richtextformatdlg.cpp:366
+#: ../src/richtext/richtextmarginspage.cpp:170
+msgid "Margins"
+msgstr ""
+
+#: ../src/richtext/richtextformatdlg.cpp:371
+msgid "Borders"
+msgstr ""
+
+#: ../src/richtext/richtextformatdlg.cpp:765
+msgid "Colour"
+msgstr ""
+
+#: ../src/richtext/richtextindentspage.cpp:127
+#: ../src/richtext/richtextliststylepage.cpp:322
+msgid "&Alignment"
+msgstr ""
+
+#: ../src/richtext/richtextindentspage.cpp:138
+#: ../src/richtext/richtextliststylepage.cpp:331
+msgid "&Left"
+msgstr ""
+
+#: ../src/richtext/richtextindentspage.cpp:140
+#: ../src/richtext/richtextindentspage.cpp:142
+#: ../src/richtext/richtextliststylepage.cpp:333
+#: ../src/richtext/richtextliststylepage.cpp:335
+msgid "Left-align text."
+msgstr ""
+
+#: ../src/richtext/richtextindentspage.cpp:145
+#: ../src/richtext/richtextliststylepage.cpp:338
+msgid "&Right"
+msgstr ""
+
+#: ../src/richtext/richtextindentspage.cpp:147
+#: ../src/richtext/richtextindentspage.cpp:149
+#: ../src/richtext/richtextliststylepage.cpp:340
+#: ../src/richtext/richtextliststylepage.cpp:342
+msgid "Right-align text."
+msgstr ""
+
+#: ../src/richtext/richtextindentspage.cpp:152
+#: ../src/richtext/richtextliststylepage.cpp:345
+msgid "&Justified"
+msgstr ""
+
+#: ../src/richtext/richtextindentspage.cpp:154
+#: ../src/richtext/richtextindentspage.cpp:156
+#: ../src/richtext/richtextliststylepage.cpp:347
+#: ../src/richtext/richtextliststylepage.cpp:349
+msgid "Justify text left and right."
+msgstr ""
+
+#: ../src/richtext/richtextindentspage.cpp:159
+#: ../src/richtext/richtextliststylepage.cpp:352
+msgid "Cen&tred"
+msgstr ""
+
+#: ../src/richtext/richtextindentspage.cpp:161
+#: ../src/richtext/richtextindentspage.cpp:163
+#: ../src/richtext/richtextliststylepage.cpp:354
+#: ../src/richtext/richtextliststylepage.cpp:356
+msgid "Centre text."
+msgstr ""
+
+#: ../src/richtext/richtextindentspage.cpp:166
+#: ../src/richtext/richtextliststylepage.cpp:359
+msgid "&Indeterminate"
+msgstr ""
+
+#: ../src/richtext/richtextindentspage.cpp:168
+#: ../src/richtext/richtextindentspage.cpp:170
+#: ../src/richtext/richtextliststylepage.cpp:361
+#: ../src/richtext/richtextliststylepage.cpp:363
+msgid "Use the current alignment setting."
+msgstr ""
+
+#: ../src/richtext/richtextindentspage.cpp:183
+#: ../src/richtext/richtextliststylepage.cpp:375
+msgid "&Indentation (tenths of a mm)"
+msgstr ""
+
+#: ../src/richtext/richtextindentspage.cpp:198
+#: ../src/richtext/richtextindentspage.cpp:200
+#: ../src/richtext/richtextliststylepage.cpp:388
+#: ../src/richtext/richtextliststylepage.cpp:390
+msgid "The left indent."
+msgstr ""
+
+#: ../src/richtext/richtextindentspage.cpp:203
+#: ../src/richtext/richtextliststylepage.cpp:393
+msgid "Left (&first line):"
+msgstr ""
+
+#: ../src/richtext/richtextindentspage.cpp:207
+#: ../src/richtext/richtextindentspage.cpp:209
+#: ../src/richtext/richtextliststylepage.cpp:397
+#: ../src/richtext/richtextliststylepage.cpp:399
+msgid "The first line indent."
+msgstr ""
+
+#: ../src/richtext/richtextindentspage.cpp:216
+#: ../src/richtext/richtextindentspage.cpp:218
+#: ../src/richtext/richtextliststylepage.cpp:406
+#: ../src/richtext/richtextliststylepage.cpp:408
+msgid "The right indent."
+msgstr ""
+
+#: ../src/richtext/richtextindentspage.cpp:221
+msgid "&Outline level:"
+msgstr ""
+
+#: ../src/richtext/richtextindentspage.cpp:226
+#: ../src/richtext/richtextindentspage.cpp:228
+msgid "The outline level."
+msgstr ""
+
+#: ../src/richtext/richtextindentspage.cpp:241
+#: ../src/richtext/richtextliststylepage.cpp:420
+msgid "&Spacing (tenths of a mm)"
+msgstr ""
+
+#: ../src/richtext/richtextindentspage.cpp:252
+msgid "&Before a paragraph:"
+msgstr ""
+
+#: ../src/richtext/richtextindentspage.cpp:256
+#: ../src/richtext/richtextindentspage.cpp:258
+#: ../src/richtext/richtextliststylepage.cpp:433
+#: ../src/richtext/richtextliststylepage.cpp:435
+msgid "The spacing before the paragraph."
+msgstr ""
+
+#: ../src/richtext/richtextindentspage.cpp:261
+msgid "&After a paragraph:"
+msgstr ""
+
+#: ../src/richtext/richtextindentspage.cpp:266
+#: ../src/richtext/richtextliststylepage.cpp:442
+#: ../src/richtext/richtextliststylepage.cpp:444
+msgid "The spacing after the paragraph."
+msgstr ""
+
+#: ../src/richtext/richtextindentspage.cpp:269
+msgid "L&ine spacing:"
+msgstr ""
+
+#: ../src/richtext/richtextindentspage.cpp:274
+#: ../src/richtext/richtextliststylepage.cpp:452
+msgid "Single"
+msgstr ""
+
+#: ../src/richtext/richtextindentspage.cpp:275
+#: ../src/richtext/richtextliststylepage.cpp:453
+msgid "1.1"
+msgstr ""
+
+#: ../src/richtext/richtextindentspage.cpp:276
+#: ../src/richtext/richtextliststylepage.cpp:454
+msgid "1.2"
+msgstr ""
+
+#: ../src/richtext/richtextindentspage.cpp:277
+#: ../src/richtext/richtextliststylepage.cpp:455
+msgid "1.3"
+msgstr ""
+
+#: ../src/richtext/richtextindentspage.cpp:278
+#: ../src/richtext/richtextliststylepage.cpp:456
+msgid "1.4"
+msgstr ""
+
+#: ../src/richtext/richtextindentspage.cpp:279
+#: ../src/richtext/richtextliststylepage.cpp:457
+msgid "1.5"
+msgstr ""
+
+#: ../src/richtext/richtextindentspage.cpp:280
+#: ../src/richtext/richtextliststylepage.cpp:458
+msgid "1.6"
+msgstr ""
+
+#: ../src/richtext/richtextindentspage.cpp:281
+#: ../src/richtext/richtextliststylepage.cpp:459
+msgid "1.7"
+msgstr ""
+
+#: ../src/richtext/richtextindentspage.cpp:282
+#: ../src/richtext/richtextliststylepage.cpp:460
+msgid "1.8"
+msgstr ""
+
+#: ../src/richtext/richtextindentspage.cpp:283
+#: ../src/richtext/richtextliststylepage.cpp:461
+msgid "1.9"
+msgstr ""
+
+#: ../src/richtext/richtextindentspage.cpp:284
+#: ../src/richtext/richtextliststylepage.cpp:462
+msgid "2"
+msgstr ""
+
+#: ../src/richtext/richtextindentspage.cpp:287
+#: ../src/richtext/richtextindentspage.cpp:289
+#: ../src/richtext/richtextliststylepage.cpp:465
+#: ../src/richtext/richtextliststylepage.cpp:467
+msgid "The line spacing."
+msgstr ""
+
+#: ../src/richtext/richtextindentspage.cpp:292
+msgid "&Page Break"
+msgstr ""
+
+#: ../src/richtext/richtextindentspage.cpp:294
+#: ../src/richtext/richtextindentspage.cpp:296
+msgid "Inserts a page break before the paragraph."
+msgstr ""
+
+#: ../src/richtext/richtextindentspage.cpp:302
+#: ../src/richtext/richtextindentspage.cpp:304
+msgid "Shows a preview of the paragraph settings."
+msgstr ""
+
+#: ../src/richtext/richtextliststylepage.cpp:182
+msgid "&List level:"
+msgstr ""
+
+#: ../src/richtext/richtextliststylepage.cpp:186
+#: ../src/richtext/richtextliststylepage.cpp:188
+msgid "Selects the list level to edit."
+msgstr ""
+
+#: ../src/richtext/richtextliststylepage.cpp:193
+msgid "&Font for Level..."
+msgstr ""
+
+#: ../src/richtext/richtextliststylepage.cpp:194
+#: ../src/richtext/richtextliststylepage.cpp:196
+msgid "Click to choose the font for this level."
+msgstr ""
+
+#: ../src/richtext/richtextliststylepage.cpp:312
+msgid "Bullet style"
+msgstr ""
+
+#: ../src/richtext/richtextliststylepage.cpp:429
+msgid "Before a paragraph:"
+msgstr ""
+
+#: ../src/richtext/richtextliststylepage.cpp:438
+msgid "After a paragraph:"
+msgstr ""
+
+#: ../src/richtext/richtextliststylepage.cpp:447
+msgid "Line spacing:"
+msgstr ""
+
+#: ../src/richtext/richtextliststylepage.cpp:470
+msgid "Spacing"
+msgstr ""
+
+#: ../src/richtext/richtextmarginspage.cpp:193
+#: ../src/richtext/richtextmarginspage.cpp:195
+msgid "The left margin size."
+msgstr ""
+
+#: ../src/richtext/richtextmarginspage.cpp:203
+#: ../src/richtext/richtextmarginspage.cpp:205
+msgid "Units for the left margin."
+msgstr ""
+
+#: ../src/richtext/richtextmarginspage.cpp:218
+#: ../src/richtext/richtextmarginspage.cpp:220
+msgid "The right margin size."
+msgstr ""
+
+#: ../src/richtext/richtextmarginspage.cpp:228
+#: ../src/richtext/richtextmarginspage.cpp:230
+msgid "Units for the right margin."
+msgstr ""
+
+#: ../src/richtext/richtextmarginspage.cpp:241
+#: ../src/richtext/richtextmarginspage.cpp:243
+msgid "The top margin size."
+msgstr ""
+
+#: ../src/richtext/richtextmarginspage.cpp:251
+#: ../src/richtext/richtextmarginspage.cpp:253
+msgid "Units for the top margin."
+msgstr ""
+
+#: ../src/richtext/richtextmarginspage.cpp:266
+#: ../src/richtext/richtextmarginspage.cpp:268
+msgid "The bottom margin size."
+msgstr ""
+
+#: ../src/richtext/richtextmarginspage.cpp:276
+#: ../src/richtext/richtextmarginspage.cpp:278
+msgid "Units for the bottom margin."
+msgstr ""
+
+#: ../src/richtext/richtextmarginspage.cpp:284
+msgid "Padding"
+msgstr ""
+
+#: ../src/richtext/richtextmarginspage.cpp:307
+#: ../src/richtext/richtextmarginspage.cpp:309
+msgid "The left padding size."
+msgstr ""
+
+#: ../src/richtext/richtextmarginspage.cpp:317
+#: ../src/richtext/richtextmarginspage.cpp:319
+msgid "Units for the left padding."
+msgstr ""
+
+#: ../src/richtext/richtextmarginspage.cpp:332
+#: ../src/richtext/richtextmarginspage.cpp:334
+msgid "The right padding size."
+msgstr ""
+
+#: ../src/richtext/richtextmarginspage.cpp:342
+#: ../src/richtext/richtextmarginspage.cpp:344
+msgid "Units for the right padding."
+msgstr ""
+
+#: ../src/richtext/richtextmarginspage.cpp:355
+#: ../src/richtext/richtextmarginspage.cpp:357
+msgid "The top padding size."
+msgstr ""
+
+#: ../src/richtext/richtextmarginspage.cpp:365
+#: ../src/richtext/richtextmarginspage.cpp:367
+msgid "Units for the top padding."
+msgstr ""
+
+#: ../src/richtext/richtextmarginspage.cpp:380
+#: ../src/richtext/richtextmarginspage.cpp:382
+msgid "The bottom padding size."
+msgstr ""
+
+#: ../src/richtext/richtextmarginspage.cpp:390
+#: ../src/richtext/richtextmarginspage.cpp:392
+msgid "Units for the bottom padding."
+msgstr ""
+
+#: ../src/richtext/richtextprint.cpp:592
+msgid " Preview"
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:228
+msgid "Floating"
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:243
+msgid "&Floating mode:"
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:252
+#: ../src/richtext/richtextsizepage.cpp:254
+msgid "How the object will float relative to the text."
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:265
+msgid "Alignment"
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:277
+msgid "&Vertical alignment:"
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:279
+#: ../src/richtext/richtextsizepage.cpp:281
+msgid "Enable vertical alignment."
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:286
+msgid "Centred"
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:290
+#: ../src/richtext/richtextsizepage.cpp:292
+msgid "Vertical alignment."
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:316
+#: ../src/richtext/richtextsizepage.cpp:323
+msgid "&Width:"
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:318
+#: ../src/richtext/richtextsizepage.cpp:320
+msgid "Enable the width value."
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:331
+#: ../src/richtext/richtextsizepage.cpp:333
+msgid "The object width."
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:342
+#: ../src/richtext/richtextsizepage.cpp:344
+msgid "Units for the object width."
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:350
+#: ../src/richtext/richtextsizepage.cpp:357
+msgid "&Height:"
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:352
+#: ../src/richtext/richtextsizepage.cpp:354
+#: ../src/richtext/richtextsizepage.cpp:464
+#: ../src/richtext/richtextsizepage.cpp:466
+msgid "Enable the height value."
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:365
+#: ../src/richtext/richtextsizepage.cpp:367
+msgid "The object height."
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:376
+#: ../src/richtext/richtextsizepage.cpp:378
+msgid "Units for the object height."
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:381
+msgid "Min width:"
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:383
+#: ../src/richtext/richtextsizepage.cpp:385
+msgid "Enable the minimum width value."
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:392
+#: ../src/richtext/richtextsizepage.cpp:394
+msgid "The object minimum width."
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:403
+#: ../src/richtext/richtextsizepage.cpp:405
+msgid "Units for the minimum object width."
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:408
+msgid "Min height:"
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:410
+#: ../src/richtext/richtextsizepage.cpp:412
+msgid "Enable the minimum height value."
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:419
+#: ../src/richtext/richtextsizepage.cpp:421
+msgid "The object minimum height."
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:430
+#: ../src/richtext/richtextsizepage.cpp:432
+msgid "Units for the minimum object height."
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:435
+msgid "Max width:"
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:437
+#: ../src/richtext/richtextsizepage.cpp:439
+msgid "Enable the maximum width value."
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:446
+#: ../src/richtext/richtextsizepage.cpp:448
+msgid "The object maximum width."
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:457
+#: ../src/richtext/richtextsizepage.cpp:459
+msgid "Units for the maximum object width."
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:462
+msgid "Max height:"
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:473
+#: ../src/richtext/richtextsizepage.cpp:475
+msgid "The object maximum height."
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:484
+#: ../src/richtext/richtextsizepage.cpp:486
+msgid "Units for the maximum object height."
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:495
+msgid "Position"
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:513
+msgid "&Position mode:"
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:517
+#: ../src/richtext/richtextsizepage.cpp:522
+msgid "Static"
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:518
+msgid "Relative"
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:519
+msgid "Absolute"
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:520
+msgid "Fixed"
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:533
+#: ../src/richtext/richtextsizepage.cpp:535
+#: ../src/richtext/richtextsizepage.cpp:547
+#: ../src/richtext/richtextsizepage.cpp:549
+msgid "The left position."
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:558
+#: ../src/richtext/richtextsizepage.cpp:560
+msgid "Units for the left position."
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:568
+#: ../src/richtext/richtextsizepage.cpp:570
+#: ../src/richtext/richtextsizepage.cpp:582
+#: ../src/richtext/richtextsizepage.cpp:584
+msgid "The top position."
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:593
+#: ../src/richtext/richtextsizepage.cpp:595
+msgid "Units for the top position."
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:603
+#: ../src/richtext/richtextsizepage.cpp:605
+#: ../src/richtext/richtextsizepage.cpp:617
+#: ../src/richtext/richtextsizepage.cpp:619
+msgid "The right position."
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:628
+#: ../src/richtext/richtextsizepage.cpp:630
+msgid "Units for the right position."
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:638
+#: ../src/richtext/richtextsizepage.cpp:640
+#: ../src/richtext/richtextsizepage.cpp:652
+#: ../src/richtext/richtextsizepage.cpp:654
+msgid "The bottom position."
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:663
+#: ../src/richtext/richtextsizepage.cpp:665
+msgid "Units for the bottom position."
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:671
+msgid "&Move the object to:"
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:674
+msgid "&Previous Paragraph"
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:675
+#: ../src/richtext/richtextsizepage.cpp:677
+msgid "Moves the object to the previous paragraph."
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:680
+msgid "&Next Paragraph"
+msgstr ""
+
+#: ../src/richtext/richtextsizepage.cpp:681
+#: ../src/richtext/richtextsizepage.cpp:683
+msgid "Moves the object to the next paragraph."
+msgstr ""
+
+#: ../src/richtext/richtextstyledlg.cpp:193
+msgid "&Styles:"
+msgstr ""
+
+#: ../src/richtext/richtextstyledlg.cpp:197
+#: ../src/richtext/richtextstyledlg.cpp:199
+msgid "The available styles."
+msgstr ""
+
+#: ../src/richtext/richtextstyledlg.cpp:205
+#: ../src/richtext/richtextstyledlg.cpp:217
+msgid " "
+msgstr ""
+
+#: ../src/richtext/richtextstyledlg.cpp:209
+#: ../src/richtext/richtextstyledlg.cpp:211
+msgid "The style preview."
+msgstr ""
+
+#: ../src/richtext/richtextstyledlg.cpp:220
+msgid "New &Character Style..."
+msgstr ""
+
+#: ../src/richtext/richtextstyledlg.cpp:221
+#: ../src/richtext/richtextstyledlg.cpp:223
+msgid "Click to create a new character style."
+msgstr ""
+
+#: ../src/richtext/richtextstyledlg.cpp:226
+msgid "New &Paragraph Style..."
+msgstr ""
+
+#: ../src/richtext/richtextstyledlg.cpp:227
+#: ../src/richtext/richtextstyledlg.cpp:229
+msgid "Click to create a new paragraph style."
+msgstr ""
+
+#: ../src/richtext/richtextstyledlg.cpp:232
+msgid "New &List Style..."
+msgstr ""
+
+#: ../src/richtext/richtextstyledlg.cpp:233
+#: ../src/richtext/richtextstyledlg.cpp:235
+msgid "Click to create a new list style."
+msgstr ""
+
+#: ../src/richtext/richtextstyledlg.cpp:238
+msgid "New &Box Style..."
+msgstr ""
+
+#: ../src/richtext/richtextstyledlg.cpp:239
+#: ../src/richtext/richtextstyledlg.cpp:241
+msgid "Click to create a new box style."
+msgstr ""
+
+#: ../src/richtext/richtextstyledlg.cpp:246
+msgid "&Apply Style"
+msgstr ""
+
+#: ../src/richtext/richtextstyledlg.cpp:247
+#: ../src/richtext/richtextstyledlg.cpp:249
+msgid "Click to apply the selected style."
+msgstr ""
+
+#: ../src/richtext/richtextstyledlg.cpp:252
+msgid "&Rename Style..."
+msgstr ""
+
+#: ../src/richtext/richtextstyledlg.cpp:253
+#: ../src/richtext/richtextstyledlg.cpp:255
+msgid "Click to rename the selected style."
+msgstr ""
+
+#: ../src/richtext/richtextstyledlg.cpp:258
+msgid "&Edit Style..."
+msgstr ""
+
+#: ../src/richtext/richtextstyledlg.cpp:259
+#: ../src/richtext/richtextstyledlg.cpp:261
+msgid "Click to edit the selected style."
+msgstr ""
+
+#: ../src/richtext/richtextstyledlg.cpp:264
+msgid "&Delete Style..."
+msgstr ""
+
+#: ../src/richtext/richtextstyledlg.cpp:265
+#: ../src/richtext/richtextstyledlg.cpp:267
+msgid "Click to delete the selected style."
+msgstr ""
+
+#: ../src/richtext/richtextstyledlg.cpp:274
+#: ../src/richtext/richtextstyledlg.cpp:276
+msgid "Click to close this window."
+msgstr ""
+
+#: ../src/richtext/richtextstyledlg.cpp:282
+msgid "&Restart numbering"
+msgstr ""
+
+#: ../src/richtext/richtextstyledlg.cpp:284
+#: ../src/richtext/richtextstyledlg.cpp:286
+msgid "Check to restart numbering."
+msgstr ""
+
+#: ../src/richtext/richtextstyledlg.cpp:601
+msgid "Enter a character style name"
+msgstr ""
+
+#: ../src/richtext/richtextstyledlg.cpp:601
+#: ../src/richtext/richtextstyledlg.cpp:606
+#: ../src/richtext/richtextstyledlg.cpp:649
+#: ../src/richtext/richtextstyledlg.cpp:654
+#: ../src/richtext/richtextstyledlg.cpp:815
+#: ../src/richtext/richtextstyledlg.cpp:820
+#: ../src/richtext/richtextstyledlg.cpp:888
+#: ../src/richtext/richtextstyledlg.cpp:896
+#: ../src/richtext/richtextstyledlg.cpp:929
+#: ../src/richtext/richtextstyledlg.cpp:934
+msgid "New Style"
+msgstr ""
+
+#: ../src/richtext/richtextstyledlg.cpp:606
+#: ../src/richtext/richtextstyledlg.cpp:654
+#: ../src/richtext/richtextstyledlg.cpp:820
+#: ../src/richtext/richtextstyledlg.cpp:896
+#: ../src/richtext/richtextstyledlg.cpp:934
+msgid "Sorry, that name is taken. Please choose another."
+msgstr ""
+
+#: ../src/richtext/richtextstyledlg.cpp:649
+msgid "Enter a paragraph style name"
+msgstr ""
+
+#: ../src/richtext/richtextstyledlg.cpp:777
+#, c-format
+msgid "Delete style %s?"
+msgstr ""
+
+#: ../src/richtext/richtextstyledlg.cpp:777
+msgid "Delete Style"
+msgstr ""
+
+#: ../src/richtext/richtextstyledlg.cpp:815
+msgid "Enter a list style name"
+msgstr ""
+
+#: ../src/richtext/richtextstyledlg.cpp:888
+msgid "Enter a new style name"
+msgstr ""
+
+#: ../src/richtext/richtextstyledlg.cpp:929
+msgid "Enter a box style name"
+msgstr ""
+
+#: ../src/richtext/richtextstylepage.cpp:109
+#: ../src/richtext/richtextstylepage.cpp:111
+msgid "The style name."
+msgstr ""
+
+#: ../src/richtext/richtextstylepage.cpp:114
+msgid "&Based on:"
+msgstr ""
+
+#: ../src/richtext/richtextstylepage.cpp:119
+#: ../src/richtext/richtextstylepage.cpp:121
+msgid "The style on which this style is based."
+msgstr ""
+
+#: ../src/richtext/richtextstylepage.cpp:124
+msgid "&Next style:"
+msgstr ""
+
+#: ../src/richtext/richtextstylepage.cpp:129
+#: ../src/richtext/richtextstylepage.cpp:131
+msgid "The default style for the next paragraph."
+msgstr ""
+
+#: ../src/richtext/richtextstyles.cpp:1057
+msgid "All styles"
+msgstr ""
+
+#: ../src/richtext/richtextstyles.cpp:1058
+msgid "Paragraph styles"
+msgstr ""
+
+#: ../src/richtext/richtextstyles.cpp:1059
+msgid "Character styles"
+msgstr ""
+
+#: ../src/richtext/richtextstyles.cpp:1060
+msgid "List styles"
+msgstr ""
+
+#: ../src/richtext/richtextstyles.cpp:1061
+msgid "Box styles"
+msgstr ""
+
+#: ../src/richtext/richtextsymboldlg.cpp:389
+#: ../src/richtext/richtextsymboldlg.cpp:391
+msgid "The font from which to take the symbol."
+msgstr ""
+
+#: ../src/richtext/richtextsymboldlg.cpp:396
+msgid "&Subset:"
+msgstr ""
+
+#: ../src/richtext/richtextsymboldlg.cpp:401
+#: ../src/richtext/richtextsymboldlg.cpp:403
+msgid "Shows a Unicode subset."
+msgstr ""
+
+#: ../src/richtext/richtextsymboldlg.cpp:412
+msgid "xxxx"
+msgstr ""
+
+#: ../src/richtext/richtextsymboldlg.cpp:417
+msgid "&Character code:"
+msgstr ""
+
+#: ../src/richtext/richtextsymboldlg.cpp:421
+#: ../src/richtext/richtextsymboldlg.cpp:423
+msgid "The character code."
+msgstr ""
+
+#: ../src/richtext/richtextsymboldlg.cpp:428
+msgid "&From:"
+msgstr ""
+
+#: ../src/richtext/richtextsymboldlg.cpp:433
+#: ../src/richtext/richtextsymboldlg.cpp:434
+#: ../src/richtext/richtextsymboldlg.cpp:435
+msgid "Unicode"
+msgstr ""
+
+#: ../src/richtext/richtextsymboldlg.cpp:436
+#: ../src/richtext/richtextsymboldlg.cpp:438
+msgid "The range to show."
+msgstr ""
+
+#: ../src/richtext/richtextsymboldlg.cpp:444
+msgid "Insert"
+msgstr ""
+
+#: ../src/richtext/richtextsymboldlg.cpp:478
+msgid "(Normal text)"
+msgstr ""
+
+#: ../src/richtext/richtexttabspage.cpp:109
+msgid "&Position (tenths of a mm):"
+msgstr ""
+
+#: ../src/richtext/richtexttabspage.cpp:113
+#: ../src/richtext/richtexttabspage.cpp:115
+msgid "The tab position."
+msgstr ""
+
+#: ../src/richtext/richtexttabspage.cpp:119
+msgid "The tab positions."
+msgstr ""
+
+#: ../src/richtext/richtexttabspage.cpp:132
+#: ../src/richtext/richtexttabspage.cpp:134
+msgid "Click to create a new tab position."
+msgstr ""
+
+#: ../src/richtext/richtexttabspage.cpp:138
+#: ../src/richtext/richtexttabspage.cpp:140
+msgid "Click to delete the selected tab position."
+msgstr ""
+
+#: ../src/richtext/richtexttabspage.cpp:143
+msgid "Delete A&ll"
+msgstr ""
+
+#: ../src/richtext/richtexttabspage.cpp:144
+#: ../src/richtext/richtexttabspage.cpp:146
+msgid "Click to delete all tab positions."
+msgstr ""
+
+#: ../src/univ/theme.cpp:110
+msgid "Failed to initialize GUI: no built-in themes found."
+msgstr ""
+
+#: ../src/univ/themes/gtk.cpp:521
+msgid "GTK+ theme"
+msgstr ""
+
+#: ../src/univ/themes/metal.cpp:164
+msgid "Metal theme"
+msgstr ""
+
+#: ../src/univ/themes/mono.cpp:512
+msgid "Simple monochrome theme"
+msgstr ""
+
+#: ../src/univ/themes/win32.cpp:1098
+msgid "Win32 theme"
+msgstr ""
+
+#: ../src/univ/themes/win32.cpp:3743
+msgid "&Restore"
+msgstr ""
+
+#: ../src/univ/themes/win32.cpp:3744
+msgid "&Move"
+msgstr ""
+
+#: ../src/univ/themes/win32.cpp:3746
+msgid "&Size"
+msgstr ""
+
+#: ../src/univ/themes/win32.cpp:3748
+msgid "Mi&nimize"
+msgstr ""
+
+#: ../src/univ/themes/win32.cpp:3750
+msgid "Ma&ximize"
+msgstr ""
+
+#: ../src/univ/themes/win32.cpp:3752
+msgid "Alt+"
+msgstr ""
+
+#: ../src/unix/appunix.cpp:178
+msgid "Failed to install signal handler"
+msgstr ""
+
+#: ../src/unix/dialup.cpp:351
+msgid "Already dialling ISP."
+msgstr ""
+
+#: ../src/unix/dlunix.cpp:93
+msgid "Failed to unload shared library"
+msgstr ""
+
+#: ../src/unix/dlunix.cpp:121
+msgid "Unknown dynamic library error"
+msgstr ""
+
+#: ../src/unix/epolldispatcher.cpp:84
+msgid "Failed to create epoll descriptor"
+msgstr ""
+
+#: ../src/unix/epolldispatcher.cpp:103
+msgid "Error closing epoll descriptor"
+msgstr ""
+
+#: ../src/unix/epolldispatcher.cpp:116
+#, c-format
+msgid "Failed to add descriptor %d to epoll descriptor %d"
+msgstr ""
+
+#: ../src/unix/epolldispatcher.cpp:136
+#, c-format
+msgid "Failed to modify descriptor %d in epoll descriptor %d"
+msgstr ""
+
+#: ../src/unix/epolldispatcher.cpp:155
+#, c-format
+msgid "Failed to unregister descriptor %d from epoll descriptor %d"
+msgstr ""
+
+#: ../src/unix/epolldispatcher.cpp:213
+#, c-format
+msgid "Waiting for IO on epoll descriptor %d failed"
+msgstr ""
+
+#: ../src/unix/fswatcher_inotify.cpp:71
+msgid "Unable to create inotify instance"
+msgstr ""
+
+#: ../src/unix/fswatcher_inotify.cpp:94
+msgid "Unable to close inotify instance"
+msgstr ""
+
+#: ../src/unix/fswatcher_inotify.cpp:106
+msgid "Unable to add inotify watch"
+msgstr ""
+
+#: ../src/unix/fswatcher_inotify.cpp:138
+#, c-format
+msgid "Unable to remove inotify watch %i"
+msgstr ""
+
+#: ../src/unix/fswatcher_inotify.cpp:271
+#, c-format
+msgid "Unexpected event for \"%s\": no matching watch descriptor."
+msgstr ""
+
+#: ../src/unix/fswatcher_inotify.cpp:320
+#, c-format
+msgid "Invalid inotify event for \"%s\""
+msgstr ""
+
+#: ../src/unix/fswatcher_inotify.cpp:553
+msgid "Unable to read from inotify descriptor"
+msgstr ""
+
+#: ../src/unix/fswatcher_inotify.cpp:558
+msgid "EOF while reading from inotify descriptor"
+msgstr ""
+
+#: ../src/unix/fswatcher_kqueue.cpp:114
+msgid "Unable to create kqueue instance"
+msgstr ""
+
+#: ../src/unix/fswatcher_kqueue.cpp:131
+msgid "Error closing kqueue instance"
+msgstr ""
+
+#: ../src/unix/fswatcher_kqueue.cpp:153
+msgid "Unable to add kqueue watch"
+msgstr ""
+
+#: ../src/unix/fswatcher_kqueue.cpp:170
+msgid "Unable to remove kqueue watch"
+msgstr ""
+
+#: ../src/unix/fswatcher_kqueue.cpp:202
+msgid "Unable to get events from kqueue"
+msgstr ""
+
+#: ../src/unix/mediactrl.cpp:966
+#, c-format
+msgid "Media playback error: %s"
+msgstr ""
+
+#: ../src/unix/mediactrl.cpp:1228
+#, c-format
+msgid "Failed to prepare playing \"%s\"."
+msgstr ""
+
+#: ../src/unix/snglinst.cpp:164
+#, c-format
+msgid "Failed to write to lock file '%s'"
+msgstr ""
+
+#: ../src/unix/snglinst.cpp:177
+#, c-format
+msgid "Failed to set permissions on lock file '%s'"
+msgstr ""
+
+#: ../src/unix/snglinst.cpp:194
+#, c-format
+msgid "Failed to lock the lock file '%s'"
+msgstr ""
+
+#: ../src/unix/snglinst.cpp:237
+#, c-format
+msgid "Failed to inspect the lock file '%s'"
+msgstr ""
+
+#: ../src/unix/snglinst.cpp:242
+#, c-format
+msgid "Lock file '%s' has incorrect owner."
+msgstr ""
+
+#: ../src/unix/snglinst.cpp:247
+#, c-format
+msgid "Lock file '%s' has incorrect permissions."
+msgstr ""
+
+#: ../src/unix/snglinst.cpp:265
+msgid "Failed to access lock file."
+msgstr ""
+
+#: ../src/unix/snglinst.cpp:274
+msgid "Failed to read PID from lock file."
+msgstr ""
+
+#: ../src/unix/snglinst.cpp:284
+#, c-format
+msgid "Failed to remove stale lock file '%s'."
+msgstr ""
+
+#: ../src/unix/snglinst.cpp:297
+#, c-format
+msgid "Deleted stale lock file '%s'."
+msgstr ""
+
+#: ../src/unix/snglinst.cpp:308
+#, c-format
+msgid "Invalid lock file '%s'."
+msgstr ""
+
+#: ../src/unix/snglinst.cpp:324
+#, c-format
+msgid "Failed to remove lock file '%s'"
+msgstr ""
+
+#: ../src/unix/snglinst.cpp:330
+#, c-format
+msgid "Failed to unlock lock file '%s'"
+msgstr ""
+
+#: ../src/unix/snglinst.cpp:336
+#, c-format
+msgid "Failed to close lock file '%s'"
+msgstr ""
+
+#: ../src/unix/sound.cpp:77
+msgid "No sound"
+msgstr ""
+
+#: ../src/unix/sound.cpp:364
+msgid "Unable to play sound asynchronously."
+msgstr ""
+
+#: ../src/unix/sound.cpp:458
+#, c-format
+msgid "Couldn't load sound data from '%s'."
+msgstr ""
+
+#: ../src/unix/sound.cpp:465
+#, c-format
+msgid "Sound file '%s' is in unsupported format."
+msgstr ""
+
+#: ../src/unix/sound.cpp:480
+msgid "Sound data are in unsupported format."
+msgstr ""
+
+#: ../src/unix/sound_sdl.cpp:226
+#, c-format
+msgid "Couldn't open audio: %s"
+msgstr ""
+
+#: ../src/unix/threadpsx.cpp:1033
+msgid "Cannot retrieve thread scheduling policy."
+msgstr ""
+
+#: ../src/unix/threadpsx.cpp:1058
+#, c-format
+msgid "Cannot get priority range for scheduling policy %d."
+msgstr ""
+
+#: ../src/unix/threadpsx.cpp:1066
+msgid "Thread priority setting is ignored."
+msgstr ""
+
+#: ../src/unix/threadpsx.cpp:1221
+msgid ""
+"Failed to join a thread, potential memory leak detected - please restart the "
+"program"
+msgstr ""
+
+#: ../src/unix/threadpsx.cpp:1352
+#, c-format
+msgid "Failed to set thread concurrency level to %lu"
+msgstr ""
+
+#: ../src/unix/threadpsx.cpp:1481
+#, c-format
+msgid "Failed to set thread priority %d."
+msgstr ""
+
+#: ../src/unix/threadpsx.cpp:1666
+msgid "Failed to terminate a thread."
+msgstr ""
+
+#: ../src/unix/threadpsx.cpp:1893
+msgid "Thread module initialization failed: failed to create thread key"
+msgstr ""
+
+#: ../src/unix/utilsunx.cpp:340
+msgid "Impossible to get child process input"
+msgstr ""
+
+#: ../src/unix/utilsunx.cpp:390
+msgid "Can't write to child process's stdin"
+msgstr ""
+
+#: ../src/unix/utilsunx.cpp:644
+#, c-format
+msgid "Failed to execute '%s'\n"
+msgstr ""
+
+#: ../src/unix/utilsunx.cpp:678
+msgid "Fork failed"
+msgstr ""
+
+#: ../src/unix/utilsunx.cpp:701
+msgid "Failed to set process priority"
+msgstr ""
+
+#: ../src/unix/utilsunx.cpp:712
+msgid "Failed to redirect child process input/output"
+msgstr ""
+
+#: ../src/unix/utilsunx.cpp:816
+msgid "Failed to set up non-blocking pipe, the program might hang."
+msgstr ""
+
+#: ../src/unix/utilsunx.cpp:1023
+msgid "Cannot get the hostname"
+msgstr ""
+
+#: ../src/unix/utilsunx.cpp:1059
+msgid "Cannot get the official hostname"
+msgstr ""
+
+#: ../src/unix/wakeuppipe.cpp:49
+msgid "Failed to create wake up pipe used by event loop."
+msgstr ""
+
+#: ../src/unix/wakeuppipe.cpp:56
+msgid "Failed to switch wake up pipe to non-blocking mode"
+msgstr ""
+
+#: ../src/unix/wakeuppipe.cpp:117
+msgid "Failed to read from wake-up pipe"
+msgstr ""
+
+#: ../src/x11/app.cpp:124
+#, c-format
+msgid "Invalid geometry specification '%s'"
+msgstr ""
+
+#: ../src/x11/app.cpp:167
+msgid "wxWidgets could not open display. Exiting."
+msgstr ""
+
+#: ../src/x11/utils.cpp:169
+#, c-format
+msgid "Failed to close the display \"%s\""
+msgstr ""
+
+#: ../src/x11/utils.cpp:188
+#, c-format
+msgid "Failed to open display \"%s\"."
+msgstr ""
+
+#: ../src/xml/xml.cpp:868
+#, c-format
+msgid "XML parsing error: '%s' at line %d"
+msgstr ""
+
+#: ../src/xrc/xh_propgrid.cpp:239
+#, c-format
+msgid "Page %i"
+msgstr ""
+
+#: ../src/xrc/xmlres.cpp:448
+#, c-format
+msgid "Cannot load resources from '%s'."
+msgstr ""
+
+#: ../src/xrc/xmlres.cpp:799
+#, c-format
+msgid "Cannot open resources file '%s'."
+msgstr ""
+
+#: ../src/xrc/xmlres.cpp:806
+#, c-format
+msgid "Cannot load resources from file '%s'."
+msgstr ""
+
+#: ../src/xrc/xmlres.cpp:2767
+#, c-format
+msgid "Creating %s \"%s\" failed."
+msgstr ""

--- a/po_wxstd/zh_CN.po
+++ b/po_wxstd/zh_CN.po
@@ -1,0 +1,10434 @@
+# Simplified Chinese Messages for wxWidgets
+# Copyright (C) 2005 Free Software Foundation, Inc.
+# This file is distributed under the same license as the wxWidgets package.
+# mrfx <mrfx@fm365.com>
+# Liu Xiao Xi <liouxiao@hotmail.com>, 2005
+# Jiawei Huang <hjiawei@gmail.com>, 2011-2014
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: wxWidgets 3.3\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-05-14 20:23+0200\n"
+"PO-Revision-Date: 2025-05-26 22:50+0800\n"
+"Last-Translator: 0tkl <tkl.zhaoqing@gmail.com>\n"
+"Language-Team: wxWidgets translators <wx-translators@wxwidgets.org>\n"
+"Language: zh_CN\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"X-Generator: Poedit 3.6\n"
+
+#: ../include/wx/defs.h:2582
+msgid "All files (*.*)|*.*"
+msgstr "所有文件 (*.*)|*.*"
+
+#: ../include/wx/defs.h:2585
+msgid "All files (*)|*"
+msgstr "所有文件 (*)|*"
+
+#: ../include/wx/generic/progdlgg.h:85
+msgid "Elapsed time:"
+msgstr "已用时间："
+
+#: ../include/wx/generic/progdlgg.h:86
+msgid "Estimated time:"
+msgstr "预计时间："
+
+#: ../include/wx/generic/progdlgg.h:87
+msgid "Remaining time:"
+msgstr "剩余时间："
+
+#. TRANSLATORS: HTML printout default title.
+#: ../include/wx/html/htmprint.h:121 ../include/wx/prntbase.h:273
+#: ../include/wx/richtext/richtextprint.h:109 ../src/common/docview.cpp:2161
+msgid "Printout"
+msgstr "打印输出"
+
+#. TRANSLATORS: HTML easy print default title.
+#: ../include/wx/html/htmprint.h:234 ../include/wx/richtext/richtextprint.h:163
+#: ../src/common/prntbase.cpp:522 ../src/html/htmprint.cpp:291
+msgid "Printing"
+msgstr "正在打印"
+
+#: ../include/wx/msgdlg.h:277 ../src/common/stockitem.cpp:211
+msgid "Yes"
+msgstr "是"
+
+#: ../include/wx/msgdlg.h:278 ../src/common/stockitem.cpp:182
+msgid "No"
+msgstr "否"
+
+#: ../include/wx/msgdlg.h:279 ../src/common/stockitem.cpp:183
+#: ../src/msw/msgdlg.cpp:430 ../src/msw/msgdlg.cpp:734
+#: ../src/richtext/richtextstyledlg.cpp:292
+msgid "OK"
+msgstr "确定"
+
+#: ../include/wx/msgdlg.h:280 ../src/common/stockitem.cpp:150
+#: ../src/msw/msgdlg.cpp:430 ../src/msw/progdlg.cpp:884
+#: ../src/richtext/richtextstyledlg.cpp:295
+msgid "Cancel"
+msgstr "取消"
+
+#: ../include/wx/msgdlg.h:281 ../src/common/stockitem.cpp:168
+#: ../src/html/helpdlg.cpp:63 ../src/html/helpfrm.cpp:108
+#: ../src/osx/button_osx.cpp:38
+msgid "Help"
+msgstr "帮助"
+
+#: ../include/wx/msw/ole/oleutils.h:52
+msgid "Cannot initialize OLE"
+msgstr "无法初始化 OLE"
+
+#: ../include/wx/msw/private/fswatcher.h:48
+#, c-format
+msgid "Unable to close the handle for '%s'"
+msgstr "无法关闭 '%s' 的句柄"
+
+#: ../include/wx/msw/private/fswatcher.h:92
+#, c-format
+msgid "Failed to open directory \"%s\" for monitoring."
+msgstr "无法打开目录 \"%s\" 以进行监视。"
+
+#: ../include/wx/msw/private/fswatcher.h:125
+msgid "Unable to close I/O completion port handle"
+msgstr "无法关闭 I/O 完成端口的句柄"
+
+#: ../include/wx/msw/private/fswatcher.h:142
+msgid "Unable to associate handle with I/O completion port"
+msgstr "无法将句柄关联到 I/O 完成端口"
+
+#: ../include/wx/msw/private/fswatcher.h:148
+msgid "Unexpectedly new I/O completion port was created"
+msgstr "意外创建了新的 I/O 完成端口"
+
+#: ../include/wx/msw/private/fswatcher.h:213
+msgid "Unable to post completion status"
+msgstr "无法发送完成状态"
+
+#: ../include/wx/msw/private/fswatcher.h:262
+msgid "Unable to dequeue completion packet"
+msgstr "无法从队列中取出完成包"
+
+#: ../include/wx/msw/private/fswatcher.h:273
+msgid "Unable to create I/O completion port"
+msgstr "无法创建 I/O 完成端口"
+
+#: ../include/wx/richmsgdlg.h:29
+msgid "&See details"
+msgstr "查看详情(&S)"
+
+#: ../include/wx/richmsgdlg.h:30
+msgid "&Hide details"
+msgstr "隐藏详情(&H)"
+
+#: ../include/wx/richtext/richtextbuffer.h:3864
+msgid "&Box"
+msgstr "文本框(&B)"
+
+#: ../include/wx/richtext/richtextbuffer.h:5008
+msgid "&Picture"
+msgstr "图片(&P)"
+
+#: ../include/wx/richtext/richtextbuffer.h:5958
+msgid "&Cell"
+msgstr "单元格(&C)"
+
+#: ../include/wx/richtext/richtextbuffer.h:6067
+msgid "&Table"
+msgstr "表格(&T)"
+
+#: ../include/wx/richtext/richtextimagedlg.h:37
+msgid "Object Properties"
+msgstr "对象属性"
+
+#: ../include/wx/richtext/richtextsymboldlg.h:39
+msgid "Symbols"
+msgstr "符号"
+
+#: ../include/wx/unix/pipe.h:46
+msgid "Pipe creation failed"
+msgstr "管道创建失败"
+
+#: ../include/wx/unix/private/displayx11.h:65
+msgid "Failed to enumerate video modes"
+msgstr "无法枚举视频模式"
+
+#: ../include/wx/unix/private/displayx11.h:89
+msgid "Failed to change video mode"
+msgstr "无法改变视频模式"
+
+#: ../include/wx/unix/private/fswatcher_kqueue.h:57
+#, c-format
+msgid "Unable to open path '%s'"
+msgstr "无法打开路径 '%s'"
+
+#: ../include/wx/unix/private/fswatcher_kqueue.h:74
+#, c-format
+msgid "Unable to close path '%s'"
+msgstr "无法关闭路径 '%s'"
+
+#: ../include/wx/xtiprop.h:175
+msgid "SetProperty called w/o valid setter"
+msgstr "调用 SetProperty 时未找到有效的 setter"
+
+#: ../include/wx/xtiprop.h:184
+msgid "GetProperty called w/o valid getter"
+msgstr "调用 GetProperty 时未找到有效的 getter"
+
+#: ../include/wx/xtiprop.h:193
+msgid "AddToPropertyCollection called w/o valid adder"
+msgstr "调用 AddToPropertyCollection 时未找到有效的 adder"
+
+#: ../include/wx/xtiprop.h:202
+msgid "GetPropertyCollection called w/o valid collection getter"
+msgstr "调用 GetPropertyCollection 时未找到有效的 collection getter"
+
+#: ../include/wx/xtiprop.h:255
+msgid "AddToPropertyCollection called on a generic accessor"
+msgstr "在通用访问器上调用 AddToPropertyCollection"
+
+#: ../include/wx/xtiprop.h:262
+msgid "GetPropertyCollection called on a generic accessor"
+msgstr "在通用访问器上调用 GetPropertyCollection"
+
+#: ../src/aui/tabmdi.cpp:106 ../src/generic/mdig.cpp:94
+msgid "Cl&ose"
+msgstr "关闭(&O)"
+
+#: ../src/aui/tabmdi.cpp:107 ../src/generic/mdig.cpp:95
+msgid "Close All"
+msgstr "全部关闭"
+
+#: ../src/aui/tabmdi.cpp:109 ../src/generic/mdig.cpp:97 ../src/msw/mdi.cpp:175
+#: ../src/qt/mdi.cpp:258
+msgid "&Next"
+msgstr "下一个(&N)"
+
+#: ../src/aui/tabmdi.cpp:110 ../src/generic/mdig.cpp:98 ../src/msw/mdi.cpp:176
+#: ../src/qt/mdi.cpp:259
+msgid "&Previous"
+msgstr "上一个(&P)"
+
+#: ../src/aui/tabmdi.cpp:332 ../src/aui/tabmdi.cpp:348
+#: ../src/aui/tabmdi.cpp:350 ../src/generic/mdig.cpp:291
+#: ../src/generic/mdig.cpp:307 ../src/generic/mdig.cpp:311
+#: ../src/msw/mdi.cpp:337 ../src/qt/mdi.cpp:462
+msgid "&Window"
+msgstr "窗口(&W)"
+
+#: ../src/common/accelcmn.cpp:47
+msgctxt "keyboard key"
+msgid "Delete"
+msgstr "Delete"
+
+#: ../src/common/accelcmn.cpp:48
+msgctxt "keyboard key"
+msgid "Del"
+msgstr "Del"
+
+#: ../src/common/accelcmn.cpp:49
+msgctxt "keyboard key"
+msgid "Back"
+msgstr "Back"
+
+#: ../src/common/accelcmn.cpp:49
+msgctxt "keyboard key"
+msgid "Backspace"
+msgstr "Backspace"
+
+#: ../src/common/accelcmn.cpp:50
+msgctxt "keyboard key"
+msgid "Insert"
+msgstr "Insert"
+
+#: ../src/common/accelcmn.cpp:51
+msgctxt "keyboard key"
+msgid "Ins"
+msgstr "Ins"
+
+#: ../src/common/accelcmn.cpp:52
+msgctxt "keyboard key"
+msgid "Enter"
+msgstr "Enter"
+
+#: ../src/common/accelcmn.cpp:53
+msgctxt "keyboard key"
+msgid "Return"
+msgstr "Return"
+
+#: ../src/common/accelcmn.cpp:54
+msgctxt "keyboard key"
+msgid "PageUp"
+msgstr "PageUp"
+
+#: ../src/common/accelcmn.cpp:54
+msgctxt "keyboard key"
+msgid "Page Up"
+msgstr "Page Up"
+
+#: ../src/common/accelcmn.cpp:55
+msgctxt "keyboard key"
+msgid "PageDown"
+msgstr "PageDown"
+
+#: ../src/common/accelcmn.cpp:55
+msgctxt "keyboard key"
+msgid "Page Down"
+msgstr "Page Down"
+
+#: ../src/common/accelcmn.cpp:56
+msgctxt "keyboard key"
+msgid "PgUp"
+msgstr "PgUp"
+
+#: ../src/common/accelcmn.cpp:57
+msgctxt "keyboard key"
+msgid "PgDn"
+msgstr "PgDn"
+
+#: ../src/common/accelcmn.cpp:58
+msgctxt "keyboard key"
+msgid "Left"
+msgstr "Left"
+
+#: ../src/common/accelcmn.cpp:59
+msgctxt "keyboard key"
+msgid "Right"
+msgstr "Right"
+
+#: ../src/common/accelcmn.cpp:60
+msgctxt "keyboard key"
+msgid "Up"
+msgstr "Up"
+
+#: ../src/common/accelcmn.cpp:61
+msgctxt "keyboard key"
+msgid "Down"
+msgstr "Down"
+
+#: ../src/common/accelcmn.cpp:62
+msgctxt "keyboard key"
+msgid "Home"
+msgstr "Home"
+
+#: ../src/common/accelcmn.cpp:63
+msgctxt "keyboard key"
+msgid "End"
+msgstr "End"
+
+#: ../src/common/accelcmn.cpp:64
+msgctxt "keyboard key"
+msgid "Space"
+msgstr "Space"
+
+#: ../src/common/accelcmn.cpp:65
+msgctxt "keyboard key"
+msgid "Tab"
+msgstr "Tab"
+
+#: ../src/common/accelcmn.cpp:66
+msgctxt "keyboard key"
+msgid "Esc"
+msgstr "Esc"
+
+#: ../src/common/accelcmn.cpp:67
+msgctxt "keyboard key"
+msgid "Escape"
+msgstr "Escape"
+
+#: ../src/common/accelcmn.cpp:68
+msgctxt "keyboard key"
+msgid "Cancel"
+msgstr "Cancel"
+
+#: ../src/common/accelcmn.cpp:69
+msgctxt "keyboard key"
+msgid "Clear"
+msgstr "Clear"
+
+#: ../src/common/accelcmn.cpp:70
+msgctxt "keyboard key"
+msgid "Menu"
+msgstr "Menu"
+
+#: ../src/common/accelcmn.cpp:71
+msgctxt "keyboard key"
+msgid "Pause"
+msgstr "Pause"
+
+#: ../src/common/accelcmn.cpp:72
+msgctxt "keyboard key"
+msgid "Capital"
+msgstr "Capital"
+
+#: ../src/common/accelcmn.cpp:73
+msgctxt "keyboard key"
+msgid "Select"
+msgstr "Select"
+
+#: ../src/common/accelcmn.cpp:74
+msgctxt "keyboard key"
+msgid "Print"
+msgstr "Print"
+
+#: ../src/common/accelcmn.cpp:75
+msgctxt "keyboard key"
+msgid "Execute"
+msgstr "Execute"
+
+#: ../src/common/accelcmn.cpp:76
+msgctxt "keyboard key"
+msgid "Snapshot"
+msgstr "Snapshot"
+
+#: ../src/common/accelcmn.cpp:77
+msgctxt "keyboard key"
+msgid "Help"
+msgstr "Help"
+
+#: ../src/common/accelcmn.cpp:78
+msgctxt "keyboard key"
+msgid "Add"
+msgstr "Add"
+
+#: ../src/common/accelcmn.cpp:79
+msgctxt "keyboard key"
+msgid "Separator"
+msgstr "Separator"
+
+#: ../src/common/accelcmn.cpp:80
+msgctxt "keyboard key"
+msgid "Subtract"
+msgstr "Subtract"
+
+#: ../src/common/accelcmn.cpp:81
+msgctxt "keyboard key"
+msgid "Decimal"
+msgstr "Decimal"
+
+#: ../src/common/accelcmn.cpp:82
+msgctxt "keyboard key"
+msgid "Multiply"
+msgstr "Multiply"
+
+#: ../src/common/accelcmn.cpp:83
+msgctxt "keyboard key"
+msgid "Divide"
+msgstr "Divide"
+
+#: ../src/common/accelcmn.cpp:84
+msgctxt "keyboard key"
+msgid "Num_lock"
+msgstr "Num_lock"
+
+#: ../src/common/accelcmn.cpp:84
+msgctxt "keyboard key"
+msgid "Num Lock"
+msgstr "Num Lock"
+
+#: ../src/common/accelcmn.cpp:85
+msgctxt "keyboard key"
+msgid "Scroll_lock"
+msgstr "Scroll_lock"
+
+#: ../src/common/accelcmn.cpp:85
+msgctxt "keyboard key"
+msgid "Scroll Lock"
+msgstr "Scroll Lock"
+
+#: ../src/common/accelcmn.cpp:86
+msgctxt "keyboard key"
+msgid "KP_Space"
+msgstr "KP_Space"
+
+#: ../src/common/accelcmn.cpp:86
+msgctxt "keyboard key"
+msgid "Num Space"
+msgstr "小键盘 Space"
+
+#: ../src/common/accelcmn.cpp:87
+msgctxt "keyboard key"
+msgid "KP_Tab"
+msgstr "KP_Tab"
+
+#: ../src/common/accelcmn.cpp:87
+msgctxt "keyboard key"
+msgid "Num Tab"
+msgstr "小键盘 Tab"
+
+#: ../src/common/accelcmn.cpp:88
+msgctxt "keyboard key"
+msgid "KP_Enter"
+msgstr "KP_Enter"
+
+#: ../src/common/accelcmn.cpp:88
+msgctxt "keyboard key"
+msgid "Num Enter"
+msgstr "小键盘 Enter"
+
+#: ../src/common/accelcmn.cpp:89
+msgctxt "keyboard key"
+msgid "KP_Home"
+msgstr "KP_Home"
+
+#: ../src/common/accelcmn.cpp:89
+msgctxt "keyboard key"
+msgid "Num Home"
+msgstr "小键盘 Home"
+
+#: ../src/common/accelcmn.cpp:90
+msgctxt "keyboard key"
+msgid "KP_Left"
+msgstr "KP_Left"
+
+#: ../src/common/accelcmn.cpp:90
+msgctxt "keyboard key"
+msgid "Num left"
+msgstr "小键盘 Left"
+
+#: ../src/common/accelcmn.cpp:91
+msgctxt "keyboard key"
+msgid "KP_Up"
+msgstr "KP_Up"
+
+#: ../src/common/accelcmn.cpp:91
+msgctxt "keyboard key"
+msgid "Num Up"
+msgstr "小键盘 Up"
+
+#: ../src/common/accelcmn.cpp:92
+msgctxt "keyboard key"
+msgid "KP_Right"
+msgstr "KP_Right"
+
+#: ../src/common/accelcmn.cpp:92
+msgctxt "keyboard key"
+msgid "Num Right"
+msgstr "小键盘 Right"
+
+#: ../src/common/accelcmn.cpp:93
+msgctxt "keyboard key"
+msgid "KP_Down"
+msgstr "KP_Down"
+
+#: ../src/common/accelcmn.cpp:93
+msgctxt "keyboard key"
+msgid "Num Down"
+msgstr "小键盘 Down"
+
+#: ../src/common/accelcmn.cpp:94
+msgctxt "keyboard key"
+msgid "KP_PageUp"
+msgstr "KP_PageUp"
+
+#: ../src/common/accelcmn.cpp:94
+msgctxt "keyboard key"
+msgid "Num Page Up"
+msgstr "小键盘 Page Up"
+
+#: ../src/common/accelcmn.cpp:95
+msgctxt "keyboard key"
+msgid "KP_PageDown"
+msgstr "KP_PageDown"
+
+#: ../src/common/accelcmn.cpp:95
+msgctxt "keyboard key"
+msgid "Num Page Down"
+msgstr "小键盘 Page Down"
+
+#: ../src/common/accelcmn.cpp:96
+msgctxt "keyboard key"
+msgid "KP_Prior"
+msgstr "KP_Prior"
+
+#: ../src/common/accelcmn.cpp:97
+msgctxt "keyboard key"
+msgid "KP_Next"
+msgstr "KP_Next"
+
+#: ../src/common/accelcmn.cpp:98
+msgctxt "keyboard key"
+msgid "KP_End"
+msgstr "KP_End"
+
+#: ../src/common/accelcmn.cpp:98
+msgctxt "keyboard key"
+msgid "Num End"
+msgstr "小键盘 End"
+
+#: ../src/common/accelcmn.cpp:99
+msgctxt "keyboard key"
+msgid "KP_Begin"
+msgstr "KP_Begin"
+
+#: ../src/common/accelcmn.cpp:99
+msgctxt "keyboard key"
+msgid "Num Begin"
+msgstr "小键盘 Begin"
+
+#: ../src/common/accelcmn.cpp:100
+msgctxt "keyboard key"
+msgid "KP_Insert"
+msgstr "KP_Insert"
+
+#: ../src/common/accelcmn.cpp:100
+msgctxt "keyboard key"
+msgid "Num Insert"
+msgstr "小键盘 Insert"
+
+#: ../src/common/accelcmn.cpp:101
+msgctxt "keyboard key"
+msgid "KP_Delete"
+msgstr "小键盘 Delete"
+
+#: ../src/common/accelcmn.cpp:101
+msgctxt "keyboard key"
+msgid "Num Delete"
+msgstr "小键盘 Delete"
+
+#: ../src/common/accelcmn.cpp:102
+msgctxt "keyboard key"
+msgid "KP_Equal"
+msgstr "KP_Equal"
+
+#: ../src/common/accelcmn.cpp:102
+msgctxt "keyboard key"
+msgid "Num ="
+msgstr "小键盘 ="
+
+#: ../src/common/accelcmn.cpp:103
+msgctxt "keyboard key"
+msgid "KP_Multiply"
+msgstr "KP_Multiply"
+
+#: ../src/common/accelcmn.cpp:103
+msgctxt "keyboard key"
+msgid "Num *"
+msgstr "小键盘 *"
+
+#: ../src/common/accelcmn.cpp:104
+msgctxt "keyboard key"
+msgid "KP_Add"
+msgstr "KP_Add"
+
+#: ../src/common/accelcmn.cpp:104
+msgctxt "keyboard key"
+msgid "Num +"
+msgstr "小键盘 +"
+
+#: ../src/common/accelcmn.cpp:105
+msgctxt "keyboard key"
+msgid "KP_Separator"
+msgstr "KP_Separator"
+
+#: ../src/common/accelcmn.cpp:105
+msgctxt "keyboard key"
+msgid "Num ,"
+msgstr "小键盘 ,"
+
+#: ../src/common/accelcmn.cpp:106
+msgctxt "keyboard key"
+msgid "KP_Subtract"
+msgstr "KP_Subtract"
+
+#: ../src/common/accelcmn.cpp:106
+msgctxt "keyboard key"
+msgid "Num -"
+msgstr "小键盘 -"
+
+#: ../src/common/accelcmn.cpp:107
+msgctxt "keyboard key"
+msgid "KP_Decimal"
+msgstr "KP_Decimal"
+
+#: ../src/common/accelcmn.cpp:107
+msgctxt "keyboard key"
+msgid "Num ."
+msgstr "小键盘 ."
+
+#: ../src/common/accelcmn.cpp:108
+msgctxt "keyboard key"
+msgid "KP_Divide"
+msgstr "KP_Divide"
+
+#: ../src/common/accelcmn.cpp:108
+msgctxt "keyboard key"
+msgid "Num /"
+msgstr "小键盘 /"
+
+#: ../src/common/accelcmn.cpp:109
+msgctxt "keyboard key"
+msgid "Windows_Left"
+msgstr "Windows_Left"
+
+#: ../src/common/accelcmn.cpp:110
+msgctxt "keyboard key"
+msgid "Windows_Right"
+msgstr "Windows_Right"
+
+#: ../src/common/accelcmn.cpp:111
+msgctxt "keyboard key"
+msgid "Windows_Menu"
+msgstr "Windows_Menu"
+
+#: ../src/common/accelcmn.cpp:112
+msgctxt "keyboard key"
+msgid "Command"
+msgstr "Command"
+
+#: ../src/common/accelcmn.cpp:186 ../src/common/accelcmn.cpp:359
+msgctxt "keyboard key"
+msgid "Ctrl"
+msgstr "Ctrl"
+
+#: ../src/common/accelcmn.cpp:188 ../src/common/accelcmn.cpp:363
+msgctxt "keyboard key"
+msgid "Alt"
+msgstr "Alt"
+
+#: ../src/common/accelcmn.cpp:190 ../src/common/accelcmn.cpp:361
+msgctxt "keyboard key"
+msgid "Shift"
+msgstr "Shift"
+
+#: ../src/common/accelcmn.cpp:196
+msgctxt "keyboard key"
+msgid "num "
+msgstr "num "
+
+#: ../src/common/accelcmn.cpp:260 ../src/common/accelcmn.cpp:382
+msgctxt "keyboard key"
+msgid "F"
+msgstr "F"
+
+#: ../src/common/accelcmn.cpp:277 ../src/common/accelcmn.cpp:385
+msgctxt "keyboard key"
+msgid "KP_F"
+msgstr "KP_F"
+
+#: ../src/common/accelcmn.cpp:280 ../src/common/accelcmn.cpp:388
+msgctxt "keyboard key"
+msgid "KP_"
+msgstr "KP_"
+
+#: ../src/common/accelcmn.cpp:283 ../src/common/accelcmn.cpp:391
+msgctxt "keyboard key"
+msgid "SPECIAL"
+msgstr "SPECIAL"
+
+#: ../src/common/accelcmn.cpp:373
+msgid "Ctrl"
+msgstr "Ctrl"
+
+#: ../src/common/appbase.cpp:786
+msgid "show this help message"
+msgstr "显示此帮助信息"
+
+#: ../src/common/appbase.cpp:796
+msgid "generate verbose log messages"
+msgstr "输出详细日志信息"
+
+#: ../src/common/appcmn.cpp:256
+msgid "specify the theme to use"
+msgstr "指定要使用的主题"
+
+#: ../src/common/appcmn.cpp:270
+msgid "specify display mode to use (e.g. 640x480-16)"
+msgstr "指定要使用的显示模式（例如：640x480-16）"
+
+#: ../src/common/appcmn.cpp:292
+#, c-format
+msgid "Unsupported theme '%s'."
+msgstr "不支持主题 '%s'。"
+
+#: ../src/common/appcmn.cpp:309
+#, c-format
+msgid "Invalid display mode specification '%s'."
+msgstr "无效的显示模式描述 '%s'。"
+
+#: ../src/common/cmdline.cpp:875
+#, c-format
+msgid "Option '%s' can't be negated"
+msgstr "选项 '%s' 不支持否定形式"
+
+#: ../src/common/cmdline.cpp:889
+#, c-format
+msgid "Unknown long option '%s'"
+msgstr "未知的长选项 '%s'"
+
+#: ../src/common/cmdline.cpp:904 ../src/common/cmdline.cpp:926
+#, c-format
+msgid "Unknown option '%s'"
+msgstr "未知选项 '%s'"
+
+#: ../src/common/cmdline.cpp:1004
+#, c-format
+msgid "Unexpected characters following option '%s'."
+msgstr "选项 '%s' 后包含意外字符。"
+
+#: ../src/common/cmdline.cpp:1039
+#, c-format
+msgid "Option '%s' requires a value."
+msgstr "选项 '%s' 需要一个值。"
+
+#: ../src/common/cmdline.cpp:1058
+#, c-format
+msgid "Separator expected after the option '%s'."
+msgstr "选项 '%s' 后缺少分隔符。"
+
+#: ../src/common/cmdline.cpp:1088 ../src/common/cmdline.cpp:1106
+#, c-format
+msgid "'%s' is not a correct numeric value for option '%s'."
+msgstr "'%s' 不是选项 '%s' 的有效数值。"
+
+#: ../src/common/cmdline.cpp:1122
+#, c-format
+msgid "Option '%s': '%s' cannot be converted to a date."
+msgstr "选项 '%s'：无法将 '%s' 转换为日期。"
+
+#: ../src/common/cmdline.cpp:1170
+#, c-format
+msgid "Unexpected parameter '%s'"
+msgstr "意外的参数 '%s'"
+
+#. TRANSLATORS: Short name and long name for a command line option
+#: ../src/common/cmdline.cpp:1197
+#, c-format
+msgid "%s (or %s)"
+msgstr "%s (或 %s)"
+
+#: ../src/common/cmdline.cpp:1208
+#, c-format
+msgid "The value for the option '%s' must be specified."
+msgstr "必须指定 '%s' 选项的值。"
+
+#: ../src/common/cmdline.cpp:1230
+#, c-format
+msgid "The required parameter '%s' was not specified."
+msgstr "未指定必要的参数 '%s'。"
+
+#: ../src/common/cmdline.cpp:1289
+#, c-format
+msgid "Usage: %s"
+msgstr "用法：%s"
+
+#: ../src/common/cmdline.cpp:1498
+msgid "str"
+msgstr "str"
+
+#: ../src/common/cmdline.cpp:1502
+msgid "num"
+msgstr "num"
+
+#: ../src/common/cmdline.cpp:1506
+msgid "double"
+msgstr "double"
+
+#: ../src/common/cmdline.cpp:1510
+msgid "date"
+msgstr "date"
+
+#: ../src/common/cmdproc.cpp:250 ../src/common/cmdproc.cpp:276
+#: ../src/common/cmdproc.cpp:296
+msgid "Unnamed command"
+msgstr "未命名的命令"
+
+#: ../src/common/cmdproc.cpp:253
+msgid "&Undo "
+msgstr "撤销(&U) "
+
+#: ../src/common/cmdproc.cpp:255
+msgid "Can't &Undo "
+msgstr "无法撤销(&U) "
+
+#: ../src/common/cmdproc.cpp:259 ../src/common/stockitem.cpp:208
+#: ../src/msw/textctrl.cpp:2880 ../src/osx/textctrl_osx.cpp:649
+#: ../src/richtext/richtextctrl.cpp:327
+msgid "&Undo"
+msgstr "撤销(&U)"
+
+#: ../src/common/cmdproc.cpp:277 ../src/common/cmdproc.cpp:297
+msgid "&Redo "
+msgstr "重做(&R) "
+
+#: ../src/common/cmdproc.cpp:281 ../src/common/cmdproc.cpp:288
+#: ../src/common/stockitem.cpp:190 ../src/msw/textctrl.cpp:2881
+#: ../src/osx/textctrl_osx.cpp:650 ../src/richtext/richtextctrl.cpp:328
+msgid "&Redo"
+msgstr "重做(&R)"
+
+#: ../src/common/colourcmn.cpp:41
+#, c-format
+msgid "String To Colour : Incorrect colour specification : %s"
+msgstr "字符串转颜色：颜色格式无效：%s"
+
+#: ../src/common/config.cpp:259
+#, c-format
+msgid "Invalid value %ld for a boolean key \"%s\" in config file."
+msgstr "配置文件中布尔键 \"%2$s\" 的值 %1$ld 无效。"
+
+#: ../src/common/config.cpp:526
+#, c-format
+msgid ""
+"Environment variables expansion failed: missing '%c' at position %u in '%s'."
+msgstr "环境变量展开失败：'%3$s' 中在位置 %2$u 处缺少 '%1$c'。"
+
+#: ../src/common/config.cpp:576 ../src/msw/regconf.cpp:272
+#, c-format
+msgid "'%s' has extra '..', ignored."
+msgstr "'%s' 存在额外的 '..'，已忽略。"
+
+#. TRANSLATORS: Checkbox state name
+#: ../src/common/datavcmn.cpp:2166 ../src/generic/datavgen.cpp:1430
+msgid "checked"
+msgstr "已选中"
+
+#. TRANSLATORS: Checkbox state name
+#: ../src/common/datavcmn.cpp:2170 ../src/generic/datavgen.cpp:1432
+msgid "unchecked"
+msgstr "未选中"
+
+#. TRANSLATORS: Checkbox state name
+#: ../src/common/datavcmn.cpp:2174
+msgid "undetermined"
+msgstr "部分选中"
+
+#: ../src/common/datetimefmt.cpp:1875
+msgid "today"
+msgstr "今天"
+
+#: ../src/common/datetimefmt.cpp:1876
+msgid "yesterday"
+msgstr "昨天"
+
+#: ../src/common/datetimefmt.cpp:1877
+msgid "tomorrow"
+msgstr "明天"
+
+#: ../src/common/datetimefmt.cpp:2071
+msgid "first"
+msgstr "第一"
+
+#: ../src/common/datetimefmt.cpp:2072
+msgid "second"
+msgstr "第二"
+
+#: ../src/common/datetimefmt.cpp:2073
+msgid "third"
+msgstr "第三"
+
+#: ../src/common/datetimefmt.cpp:2074
+msgid "fourth"
+msgstr "第四"
+
+#: ../src/common/datetimefmt.cpp:2075
+msgid "fifth"
+msgstr "第五"
+
+#: ../src/common/datetimefmt.cpp:2076
+msgid "sixth"
+msgstr "第六"
+
+#: ../src/common/datetimefmt.cpp:2077
+msgid "seventh"
+msgstr "第七"
+
+#: ../src/common/datetimefmt.cpp:2078
+msgid "eighth"
+msgstr "第八"
+
+#: ../src/common/datetimefmt.cpp:2079
+msgid "ninth"
+msgstr "第九"
+
+#: ../src/common/datetimefmt.cpp:2080
+msgid "tenth"
+msgstr "第十"
+
+#: ../src/common/datetimefmt.cpp:2081
+msgid "eleventh"
+msgstr "第十一"
+
+#: ../src/common/datetimefmt.cpp:2082
+msgid "twelfth"
+msgstr "第十二"
+
+#: ../src/common/datetimefmt.cpp:2083
+msgid "thirteenth"
+msgstr "第十三"
+
+#: ../src/common/datetimefmt.cpp:2084
+msgid "fourteenth"
+msgstr "第十四"
+
+#: ../src/common/datetimefmt.cpp:2085
+msgid "fifteenth"
+msgstr "第十五"
+
+#: ../src/common/datetimefmt.cpp:2086
+msgid "sixteenth"
+msgstr "第十六"
+
+#: ../src/common/datetimefmt.cpp:2087
+msgid "seventeenth"
+msgstr "第十七"
+
+#: ../src/common/datetimefmt.cpp:2088
+msgid "eighteenth"
+msgstr "第十八"
+
+#: ../src/common/datetimefmt.cpp:2089
+msgid "nineteenth"
+msgstr "第十九"
+
+#: ../src/common/datetimefmt.cpp:2090
+msgid "twentieth"
+msgstr "第二十"
+
+#: ../src/common/datetimefmt.cpp:2248
+msgid "noon"
+msgstr "中午"
+
+#: ../src/common/datetimefmt.cpp:2249
+msgid "midnight"
+msgstr "午夜"
+
+#: ../src/common/debugrpt.cpp:209
+#, c-format
+msgid "Failed to create directory \"%s\""
+msgstr "无法创建目录 \"%s\""
+
+#: ../src/common/debugrpt.cpp:210
+msgid "Debug report couldn't be created."
+msgstr "无法创建调试报告。"
+
+#: ../src/common/debugrpt.cpp:227
+#, c-format
+msgid "Failed to remove debug report file \"%s\""
+msgstr "无法移除调试报告文件 \"%s\""
+
+#: ../src/common/debugrpt.cpp:239
+#, c-format
+msgid "Failed to clean up debug report directory \"%s\""
+msgstr "无法清理调试报告目录 \"%s\""
+
+#: ../src/common/debugrpt.cpp:514
+msgid "process context description"
+msgstr "进程上下文信息"
+
+#: ../src/common/debugrpt.cpp:538
+msgid "dump of the process state (binary)"
+msgstr "进程状态转储（二进制）"
+
+#: ../src/common/debugrpt.cpp:553
+msgid "Debug report generation has failed."
+msgstr "无法生成调试报告。"
+
+#: ../src/common/debugrpt.cpp:560
+#, c-format
+msgid ""
+"Processing debug report has failed, leaving the files in \"%s\" directory."
+msgstr "处理调试报告失败，文件已保留在目录 \"%s\" 中。"
+
+#: ../src/common/debugrpt.cpp:573
+msgid "A debug report has been generated. It can be found in"
+msgstr "已生成调试报告，保存位置："
+
+#: ../src/common/debugrpt.cpp:576
+msgid "And includes the following files:\n"
+msgstr "并包含以下文件：\n"
+
+#: ../src/common/debugrpt.cpp:586
+msgid ""
+"\n"
+"Please send this report to the program maintainer, thank you!\n"
+msgstr ""
+"\n"
+"请将此报告发送给程序维护者，谢谢！\n"
+
+#: ../src/common/debugrpt.cpp:729
+msgid "Failed to execute curl, please install it in PATH."
+msgstr "无法执行 curl，请确保已安装并在 PATH 中可用。"
+
+#: ../src/common/debugrpt.cpp:742
+#, c-format
+msgid "Failed to upload the debug report (error code %d)."
+msgstr "无法上传调试报告（错误代码 %d）。"
+
+#: ../src/common/docview.cpp:366
+msgid "Save As"
+msgstr "另存为"
+
+#: ../src/common/docview.cpp:457
+msgid "Discard changes and reload the last saved version?"
+msgstr "放弃更改并重新加载上次保存的版本吗？"
+
+#: ../src/common/docview.cpp:488
+msgid "unnamed"
+msgstr "未命名"
+
+#: ../src/common/docview.cpp:513
+#, c-format
+msgid "Do you want to save changes to %s?"
+msgstr "是否保存对 %s 的更改？"
+
+#: ../src/common/docview.cpp:521 ../src/common/docview.cpp:560
+#: ../src/common/stockitem.cpp:195
+msgid "&Save"
+msgstr "保存(&S)"
+
+#: ../src/common/docview.cpp:522 ../src/common/docview.cpp:560
+msgid "&Discard changes"
+msgstr "放弃更改(&D)"
+
+#: ../src/common/docview.cpp:523
+msgid "Do&n't close"
+msgstr "取消(&N)"
+
+#: ../src/common/docview.cpp:553
+#, c-format
+msgid "Do you want to save changes to %s before closing it?"
+msgstr "是否在关闭 %s 前保存更改？"
+
+#: ../src/common/docview.cpp:559
+msgid "The document must be closed."
+msgstr "必须关闭此文档。"
+
+#: ../src/common/docview.cpp:571
+#, c-format
+msgid "Saving %s failed, would you like to retry?"
+msgstr "保存 %s 失败，是否重试？"
+
+#: ../src/common/docview.cpp:577
+msgid "Retry"
+msgstr "重试"
+
+#: ../src/common/docview.cpp:577
+msgid "Discard changes"
+msgstr "放弃更改"
+
+#: ../src/common/docview.cpp:679
+#, c-format
+msgid "File \"%s\" could not be opened for writing."
+msgstr "无法以写入方式打开文件 \"%s\"。"
+
+#: ../src/common/docview.cpp:685
+#, c-format
+msgid "Failed to save document to the file \"%s\"."
+msgstr "无法将文档保存到文件 \"%s\"。"
+
+#: ../src/common/docview.cpp:702
+#, c-format
+msgid "File \"%s\" could not be opened for reading."
+msgstr "无法以读取方式打开文件 \"%s\"。"
+
+#: ../src/common/docview.cpp:714
+#, c-format
+msgid "Failed to read document from the file \"%s\"."
+msgstr "无法从文件 \"%s\" 读取文档。"
+
+#: ../src/common/docview.cpp:1236
+#, c-format
+msgid ""
+"The file '%s' doesn't exist and couldn't be opened.\n"
+"It has been removed from the most recently used files list."
+msgstr ""
+"文件 \"%s\" 不存在，无法打开。\n"
+"已将其从最近使用的文件列表中移除。"
+
+#: ../src/common/docview.cpp:1296
+msgid "Print preview creation failed."
+msgstr "创建打印预览失败。"
+
+#: ../src/common/docview.cpp:1302
+msgid "Print Preview"
+msgstr "打印预览"
+
+#: ../src/common/docview.cpp:1517
+#, c-format
+msgid "The format of file '%s' couldn't be determined."
+msgstr "无法确定文件 '%s' 的格式。"
+
+#: ../src/common/docview.cpp:1643
+#, c-format
+msgid "unnamed%d"
+msgstr "未命名%d"
+
+#: ../src/common/docview.cpp:1660
+msgid " - "
+msgstr " - "
+
+#: ../src/common/docview.cpp:1791 ../src/common/docview.cpp:1844
+msgid "Open File"
+msgstr "打开文件"
+
+#: ../src/common/docview.cpp:1807
+msgid "File error"
+msgstr "文件错误"
+
+#: ../src/common/docview.cpp:1809
+msgid "Sorry, could not open this file."
+msgstr "抱歉，无法打开此文件。"
+
+#: ../src/common/docview.cpp:1843
+msgid "Sorry, the format for this file is unknown."
+msgstr "抱歉，无法识别此文件的格式。"
+
+#: ../src/common/docview.cpp:1924
+msgid "Select a document template"
+msgstr "选择文档模板"
+
+#: ../src/common/docview.cpp:1925
+msgid "Templates"
+msgstr "模板"
+
+#: ../src/common/docview.cpp:1998
+msgid "Select a document view"
+msgstr "选择文档视图"
+
+#: ../src/common/docview.cpp:1999
+msgid "Views"
+msgstr "视图"
+
+#: ../src/common/dynlib.cpp:81
+#, c-format
+msgid "Failed to load shared library '%s'"
+msgstr "无法加载共享库 '%s'"
+
+#: ../src/common/dynlib.cpp:105
+#, c-format
+msgid "Couldn't find symbol '%s' in a dynamic library"
+msgstr "在动态库中找不到符号 '%s'"
+
+#: ../src/common/ffile.cpp:56 ../src/common/file.cpp:215
+#, c-format
+msgid "can't open file '%s'"
+msgstr "无法打开文件 '%s'"
+
+#: ../src/common/ffile.cpp:72
+#, c-format
+msgid "can't close file '%s'"
+msgstr "无法关闭文件 '%s'"
+
+#: ../src/common/ffile.cpp:106 ../src/common/ffile.cpp:131
+#, c-format
+msgid "Read error on file '%s'"
+msgstr "读取文件 '%s' 出错"
+
+#: ../src/common/ffile.cpp:148
+#, c-format
+msgid "Write error on file '%s'"
+msgstr "写入文件 '%s' 出错"
+
+#: ../src/common/ffile.cpp:182
+#, c-format
+msgid "failed to flush the file '%s'"
+msgstr "无法刷新文件 '%s'"
+
+#: ../src/common/ffile.cpp:222
+#, c-format
+msgid "Seek error on file '%s' (large files not supported by stdio)"
+msgstr "定位文件 '%s' 失败（stdio 不支持大文件）"
+
+#: ../src/common/ffile.cpp:232
+#, c-format
+msgid "Seek error on file '%s'"
+msgstr "定位文件 '%s' 失败"
+
+#: ../src/common/ffile.cpp:248
+#, c-format
+msgid "Can't find current position in file '%s'"
+msgstr "在文件 '%s' 中无法找到当前位置"
+
+#: ../src/common/ffile.cpp:349 ../src/common/file.cpp:569
+msgid "Failed to set temporary file permissions"
+msgstr "无法设置临时文件权限"
+
+#: ../src/common/ffile.cpp:371
+#, c-format
+msgid "can't remove file '%s'"
+msgstr "无法移除文件 '%s'"
+
+#: ../src/common/ffile.cpp:376 ../src/common/file.cpp:591
+#, c-format
+msgid "can't commit changes to file '%s'"
+msgstr "无法将更改写入文件 '%s'"
+
+#: ../src/common/ffile.cpp:388 ../src/common/file.cpp:603
+#, c-format
+msgid "can't remove temporary file '%s'"
+msgstr "无法移除临时文件 '%s'"
+
+#: ../src/common/file.cpp:162
+#, c-format
+msgid "can't create file '%s'"
+msgstr "无法创建文件 '%s'"
+
+#: ../src/common/file.cpp:229
+#, c-format
+msgid "can't close file descriptor %d"
+msgstr "无法关闭文件描述符 %d"
+
+#: ../src/common/file.cpp:332
+#, c-format
+msgid "can't read from file descriptor %d"
+msgstr "无法读取文件描述符 %d"
+
+#: ../src/common/file.cpp:351
+#, c-format
+msgid "can't write to file descriptor %d"
+msgstr "无法写入文件描述符 %d"
+
+#: ../src/common/file.cpp:390
+#, c-format
+msgid "can't flush file descriptor %d"
+msgstr "无法刷新文件描述符 %d"
+
+#: ../src/common/file.cpp:432
+#, c-format
+msgid "can't seek on file descriptor %d"
+msgstr "无法定位文件描述符 %d"
+
+#: ../src/common/file.cpp:446
+#, c-format
+msgid "can't get seek position on file descriptor %d"
+msgstr "无法从文件描述符 %d 中定位当前位置"
+
+#: ../src/common/file.cpp:475
+#, c-format
+msgid "can't find length of file on file descriptor %d"
+msgstr "无法从文件描述符 %d 中获得文件长度"
+
+#: ../src/common/file.cpp:505
+#, c-format
+msgid "can't determine if the end of file is reached on descriptor %d"
+msgstr "无法从文件描述符 %d 确定是否已到达文件末尾"
+
+#: ../src/common/fileconf.cpp:352
+#, c-format
+msgid ""
+" and additionally, the existing configuration file was renamed to \"%s\" and "
+"couldn't be renamed back, please rename it to its original path \"%s\""
+msgstr ""
+"此外，现有的配置文件已被重命名为 \"%s\"，且无法恢复原名"
+"请手动将其重命名回其原始路径 \"%s\""
+
+#: ../src/common/fileconf.cpp:389
+msgid " due to the following error:\n"
+msgstr "由于以下错误：\n"
+
+#: ../src/common/fileconf.cpp:412
+msgid "failed to rename the existing file"
+msgstr "无法重命名现有文件"
+
+#: ../src/common/fileconf.cpp:421
+msgid "failed to create the new file directory"
+msgstr "无法创建新文件目录"
+
+#: ../src/common/fileconf.cpp:428
+msgid "failed to move the file to the new location"
+msgstr "无法将文件移动到新位置"
+
+#: ../src/common/fileconf.cpp:462
+#, c-format
+msgid "can't open global configuration file '%s'."
+msgstr "无法打开全局配置文件 '%s'。"
+
+#: ../src/common/fileconf.cpp:478
+#, c-format
+msgid "can't open user configuration file '%s'."
+msgstr "无法打开用户配置文件 '%s'。"
+
+#: ../src/common/fileconf.cpp:483
+#, c-format
+msgid "Changes won't be saved to avoid overwriting the existing file \"%s\""
+msgstr "为避免覆盖现有文件 \"%s\"，更改将不会被保存"
+
+#: ../src/common/fileconf.cpp:583
+msgid "Error reading config options."
+msgstr "读取配置选项时出错。"
+
+#: ../src/common/fileconf.cpp:593
+msgid "Failed to read config options."
+msgstr "无法读取配置选项。"
+
+#: ../src/common/fileconf.cpp:700
+#, c-format
+msgid "file '%s': unexpected character %c at line %zu."
+msgstr "文件 '%1$s'：第 %3$zu 行存在异常字符 %2$c。"
+
+#: ../src/common/fileconf.cpp:736
+#, c-format
+msgid "file '%s', line %zu: '%s' ignored after group header."
+msgstr "文件 '%s'，第 %zu 行：组标题之后的 '%s' 已被忽略。"
+
+#: ../src/common/fileconf.cpp:765
+#, c-format
+msgid "file '%s', line %zu: '=' expected."
+msgstr "文件 '%s'，第 %zu 行：缺少 '='。"
+
+#: ../src/common/fileconf.cpp:778
+#, c-format
+msgid "file '%s', line %zu: value for immutable key '%s' ignored."
+msgstr "文件 '%s'，第 %zu 行：已忽略不可变键 '%s' 的值。"
+
+#: ../src/common/fileconf.cpp:788
+#, c-format
+msgid "file '%s', line %zu: key '%s' was first found at line %d."
+msgstr "文件 '%s'，第 %zu 行：键 '%s' 第一次出现在第 %d 行。"
+
+#: ../src/common/fileconf.cpp:1091
+#, c-format
+msgid "Config entry name cannot start with '%c'."
+msgstr "配置条目名不能以 '%c' 开头。"
+
+#: ../src/common/fileconf.cpp:1146
+msgid "Failed to create configuration file directory."
+msgstr "无法创建配置文件目录。"
+
+#: ../src/common/fileconf.cpp:1158
+msgid "can't open user configuration file."
+msgstr "无法打开用户配置文件。"
+
+#: ../src/common/fileconf.cpp:1172
+msgid "can't write user configuration file."
+msgstr "无法写入用户配置文件。"
+
+#: ../src/common/fileconf.cpp:1178
+msgid "Failed to update user configuration file."
+msgstr "无法更新用户配置文件。"
+
+#: ../src/common/fileconf.cpp:1201
+msgid "Error saving user configuration data."
+msgstr "保存用户配置数据时出错。"
+
+#: ../src/common/fileconf.cpp:1313
+#, c-format
+msgid "can't delete user configuration file '%s'"
+msgstr "无法删除用户配置文件 '%s'"
+
+#: ../src/common/fileconf.cpp:2007
+#, c-format
+msgid "entry '%s' appears more than once in group '%s'"
+msgstr "条目 '%s' 在组 '%s' 中出现多次"
+
+#: ../src/common/fileconf.cpp:2021
+#, c-format
+msgid "attempt to change immutable key '%s' ignored."
+msgstr "已忽略对不可变键 '%s' 的修改。"
+
+#: ../src/common/fileconf.cpp:2118
+#, c-format
+msgid "trailing backslash ignored in '%s'"
+msgstr "'%s' 尾部的反斜杠将被忽略"
+
+#: ../src/common/fileconf.cpp:2153
+#, c-format
+msgid "unexpected \" at position %d in '%s'."
+msgstr "在 '%2$s' 的位置 %1$d 处出现意外的 \"。"
+
+#: ../src/common/filefn.cpp:474
+#, c-format
+msgid "Failed to copy the file '%s' to '%s'"
+msgstr "无法将文件 '%s' 复制到 '%s'"
+
+#: ../src/common/filefn.cpp:487
+#, c-format
+msgid "Impossible to get permissions for file '%s'"
+msgstr "无法获取文件 '%s' 的权限"
+
+#: ../src/common/filefn.cpp:501
+#, c-format
+msgid "Impossible to overwrite the file '%s'"
+msgstr "无法覆盖文件 '%s'"
+
+#: ../src/common/filefn.cpp:508
+#, c-format
+msgid "Error copying the file '%s' to '%s'."
+msgstr "无法将文件 '%s' 复制到 '%s'。"
+
+#: ../src/common/filefn.cpp:556
+#, c-format
+msgid "Impossible to set permissions for the file '%s'"
+msgstr "无法为文件 '%s' 设置权限"
+
+#: ../src/common/filefn.cpp:606
+#, c-format
+msgid ""
+"Failed to rename the file '%s' to '%s' because the destination file already "
+"exists."
+msgstr "无法将文件 '%s' 重命名为 '%s'，因为目标文件已存在。"
+
+#: ../src/common/filefn.cpp:623
+#, c-format
+msgid "File '%s' couldn't be renamed '%s'"
+msgstr "无法将文件 '%s' 重命名为 '%s'"
+
+#: ../src/common/filefn.cpp:639
+#, c-format
+msgid "File '%s' couldn't be removed"
+msgstr "无法移除文件 '%s'"
+
+#: ../src/common/filefn.cpp:666
+#, c-format
+msgid "Directory '%s' couldn't be created"
+msgstr "无法创建目录 '%s'"
+
+#: ../src/common/filefn.cpp:680
+#, c-format
+msgid "Directory '%s' couldn't be deleted"
+msgstr "无法删除目录 '%s'"
+
+#: ../src/common/filefn.cpp:714
+#, c-format
+msgid "Cannot enumerate files '%s'"
+msgstr "无法枚举文件 '%s'"
+
+#: ../src/common/filefn.cpp:798
+msgid "Failed to get the working directory"
+msgstr "无法获取工作目录"
+
+#: ../src/common/filefn.cpp:843
+msgid "Could not set current working directory"
+msgstr "无法设置当前工作目录"
+
+#: ../src/common/filefn.cpp:974
+#, c-format
+msgid "Files (%s)"
+msgstr "文件 (%s)"
+
+#: ../src/common/filename.cpp:182
+#, c-format
+msgid "Failed to open '%s' for reading"
+msgstr "无法以读取方式打开 '%s'"
+
+#: ../src/common/filename.cpp:187
+#, c-format
+msgid "Failed to open '%s' for writing"
+msgstr "无法以写入方式打开 '%s'"
+
+#: ../src/common/filename.cpp:199
+msgid "Failed to close file handle"
+msgstr "无法关闭文件句柄"
+
+#: ../src/common/filename.cpp:1046
+msgid "Failed to create a temporary file name"
+msgstr "无法创建临时文件名"
+
+#: ../src/common/filename.cpp:1081
+msgid "Failed to open temporary file."
+msgstr "无法打开临时文件。"
+
+#: ../src/common/filename.cpp:2862
+#, c-format
+msgid "Failed to modify file times for '%s'"
+msgstr "无法修改文件 '%s' 的时间"
+
+#: ../src/common/filename.cpp:2877
+#, c-format
+msgid "Failed to touch the file '%s'"
+msgstr "无法更新文件 '%s' 的时间"
+
+#: ../src/common/filename.cpp:2958
+#, c-format
+msgid "Failed to retrieve file times for '%s'"
+msgstr "无法获取文件 '%s' 的时间"
+
+#: ../src/common/filepickercmn.cpp:39 ../src/common/filepickercmn.cpp:40
+msgid "Browse"
+msgstr "浏览"
+
+#: ../src/common/fldlgcmn.cpp:792 ../src/generic/filectrlg.cpp:1185
+#, c-format
+msgid "All files (%s)|%s"
+msgstr "所有文件 (%s)|%s"
+
+#. TRANSLATORS: %s are a file extension used to build a file wildcard string
+#: ../src/common/fldlgcmn.cpp:810
+#, c-format
+msgid "%s files (%s)|%s"
+msgstr "%s 文件 (%s)|%s"
+
+#: ../src/common/fldlgcmn.cpp:1072
+#, c-format
+msgid "Load %s file"
+msgstr "打开 %s 文件"
+
+#: ../src/common/fldlgcmn.cpp:1074
+#, c-format
+msgid "Save %s file"
+msgstr "保存 %s 文件"
+
+#: ../src/common/fmapbase.cpp:144
+msgid "Western European (ISO-8859-1)"
+msgstr "西欧语言 (ISO-8859-1)"
+
+#: ../src/common/fmapbase.cpp:145
+msgid "Central European (ISO-8859-2)"
+msgstr "中欧语言 (ISO-8859-2)"
+
+#: ../src/common/fmapbase.cpp:146
+msgid "Esperanto (ISO-8859-3)"
+msgstr "世界语 (ISO-8859-3)"
+
+#: ../src/common/fmapbase.cpp:147
+msgid "Baltic (old) (ISO-8859-4)"
+msgstr "波罗的语（旧） (ISO-8859-4)"
+
+#: ../src/common/fmapbase.cpp:148
+msgid "Cyrillic (ISO-8859-5)"
+msgstr "西里尔文 (ISO-8859-5)"
+
+#: ../src/common/fmapbase.cpp:149
+msgid "Arabic (ISO-8859-6)"
+msgstr "阿拉伯文 (ISO-8859-6)"
+
+#: ../src/common/fmapbase.cpp:150
+msgid "Greek (ISO-8859-7)"
+msgstr "希腊文 (ISO-8859-7)"
+
+#: ../src/common/fmapbase.cpp:151
+msgid "Hebrew (ISO-8859-8)"
+msgstr "希伯来文 (ISO-8859-8)"
+
+#: ../src/common/fmapbase.cpp:152
+msgid "Turkish (ISO-8859-9)"
+msgstr "土耳其语 (ISO-8859-9)"
+
+#: ../src/common/fmapbase.cpp:153
+msgid "Nordic (ISO-8859-10)"
+msgstr "北欧语言 (ISO-8859-10)"
+
+#: ../src/common/fmapbase.cpp:154
+msgid "Thai (ISO-8859-11)"
+msgstr "泰文 (ISO-8859-11)"
+
+#: ../src/common/fmapbase.cpp:155
+msgid "Indian (ISO-8859-12)"
+msgstr "印度文 (ISO-8859-12)"
+
+#: ../src/common/fmapbase.cpp:156
+msgid "Baltic (ISO-8859-13)"
+msgstr "波罗的语 (ISO-8859-13)"
+
+#: ../src/common/fmapbase.cpp:157
+msgid "Celtic (ISO-8859-14)"
+msgstr "凯尔特语 (ISO-8859-14)"
+
+#: ../src/common/fmapbase.cpp:158
+msgid "Western European with Euro (ISO-8859-15)"
+msgstr "西欧语言（含欧元符号）(ISO-8859-15)"
+
+#: ../src/common/fmapbase.cpp:159
+msgid "KOI8-R"
+msgstr "KOI8-R"
+
+#: ../src/common/fmapbase.cpp:160
+msgid "KOI8-U"
+msgstr "KOI8-U"
+
+#: ../src/common/fmapbase.cpp:161
+msgid "Windows/DOS OEM Cyrillic (CP 866)"
+msgstr "Windows/DOS OEM 西里尔文 (CP 866)"
+
+#: ../src/common/fmapbase.cpp:162
+msgid "Windows Thai (CP 874)"
+msgstr "Windows 泰文 (CP 874)"
+
+#: ../src/common/fmapbase.cpp:163
+msgid "Windows Japanese (CP 932) or Shift-JIS"
+msgstr "Windows 日文 (CP 932) 或 Shift-JIS"
+
+#: ../src/common/fmapbase.cpp:164
+msgid "Windows Chinese Simplified (CP 936) or GB-2312"
+msgstr "Windows 简体中文 (CP 936) 或 GB-2312"
+
+#: ../src/common/fmapbase.cpp:165
+msgid "Windows Korean (CP 949)"
+msgstr "Windows 韩文 (CP 949)"
+
+#: ../src/common/fmapbase.cpp:166
+msgid "Windows Chinese Traditional (CP 950) or Big-5"
+msgstr "Windows 繁体中文 (CP 950) 或 Big-5"
+
+#: ../src/common/fmapbase.cpp:167
+msgid "Windows Central European (CP 1250)"
+msgstr "Windows 中欧语言 (CP 1250)"
+
+#: ../src/common/fmapbase.cpp:168
+msgid "Windows Cyrillic (CP 1251)"
+msgstr "Windows 西里尔文 (CP 1251)"
+
+#: ../src/common/fmapbase.cpp:169
+msgid "Windows Western European (CP 1252)"
+msgstr "Windows 西欧语言 (CP 1252)"
+
+#: ../src/common/fmapbase.cpp:170
+msgid "Windows Greek (CP 1253)"
+msgstr "Windows 希腊文 (CP 1253)"
+
+#: ../src/common/fmapbase.cpp:171
+msgid "Windows Turkish (CP 1254)"
+msgstr "Windows 土耳其语 (CP 1254)"
+
+#: ../src/common/fmapbase.cpp:172
+msgid "Windows Hebrew (CP 1255)"
+msgstr "Windows 希伯来文 (CP 1255)"
+
+#: ../src/common/fmapbase.cpp:173
+msgid "Windows Arabic (CP 1256)"
+msgstr "Windows 阿拉伯文 (CP 1256)"
+
+#: ../src/common/fmapbase.cpp:174
+msgid "Windows Baltic (CP 1257)"
+msgstr "Windows 波罗的语 (CP 1257)"
+
+#: ../src/common/fmapbase.cpp:175
+msgid "Windows Vietnamese (CP 1258)"
+msgstr "Windows 越南文 (CP 1258)"
+
+#: ../src/common/fmapbase.cpp:176
+msgid "Windows Johab (CP 1361)"
+msgstr "Windows Johab (CP 1361)"
+
+#: ../src/common/fmapbase.cpp:177
+msgid "Windows/DOS OEM (CP 437)"
+msgstr "Windows/DOS OEM (CP 437)"
+
+#: ../src/common/fmapbase.cpp:178
+msgid "Unicode 7 bit (UTF-7)"
+msgstr "Unicode 7 位 (UTF-7)"
+
+#: ../src/common/fmapbase.cpp:179
+msgid "Unicode 8 bit (UTF-8)"
+msgstr "Unicode 8 位 (UTF-8)"
+
+#: ../src/common/fmapbase.cpp:181 ../src/common/fmapbase.cpp:187
+msgid "Unicode 16 bit (UTF-16)"
+msgstr "Unicode 16 位 (UTF-16)"
+
+#: ../src/common/fmapbase.cpp:182
+msgid "Unicode 16 bit Little Endian (UTF-16LE)"
+msgstr "Unicode 16 位（小端序）(UTF-16LE)"
+
+#: ../src/common/fmapbase.cpp:183 ../src/common/fmapbase.cpp:189
+msgid "Unicode 32 bit (UTF-32)"
+msgstr "Unicode 32 位 (UTF-32)"
+
+#: ../src/common/fmapbase.cpp:184
+msgid "Unicode 32 bit Little Endian (UTF-32LE)"
+msgstr "Unicode 32 位（小端序）(UTF-32LE)"
+
+#: ../src/common/fmapbase.cpp:186
+msgid "Unicode 16 bit Big Endian (UTF-16BE)"
+msgstr "Unicode 16 位（大端序）(UTF-16BE)"
+
+#: ../src/common/fmapbase.cpp:188
+msgid "Unicode 32 bit Big Endian (UTF-32BE)"
+msgstr "Unicode 32 位（大端序）(UTF-32BE)"
+
+#: ../src/common/fmapbase.cpp:191
+msgid "Extended Unix Codepage for Japanese (EUC-JP)"
+msgstr "日文扩展 Unix 代码页 (EUC-JP)"
+
+#: ../src/common/fmapbase.cpp:192
+msgid "US-ASCII"
+msgstr "US-ASCII"
+
+#: ../src/common/fmapbase.cpp:193
+msgid "ISO-2022-JP"
+msgstr "ISO-2022-JP"
+
+#: ../src/common/fmapbase.cpp:195
+msgid "MacRoman"
+msgstr "MacRoman"
+
+#: ../src/common/fmapbase.cpp:196
+msgid "MacJapanese"
+msgstr "MacJapanese"
+
+#: ../src/common/fmapbase.cpp:197
+msgid "MacChineseTrad"
+msgstr "MacChineseTrad"
+
+#: ../src/common/fmapbase.cpp:198
+msgid "MacKorean"
+msgstr "MacKorean"
+
+#: ../src/common/fmapbase.cpp:199
+msgid "MacArabic"
+msgstr "MacArabic"
+
+#: ../src/common/fmapbase.cpp:200
+msgid "MacHebrew"
+msgstr "MacHebrew"
+
+#: ../src/common/fmapbase.cpp:201
+msgid "MacGreek"
+msgstr "MacGreek"
+
+#: ../src/common/fmapbase.cpp:202
+msgid "MacCyrillic"
+msgstr "MacCyrillic"
+
+#: ../src/common/fmapbase.cpp:203
+msgid "MacDevanagari"
+msgstr "MacDevanagari"
+
+#: ../src/common/fmapbase.cpp:204
+msgid "MacGurmukhi"
+msgstr "MacGurmukhi"
+
+#: ../src/common/fmapbase.cpp:205
+msgid "MacGujarati"
+msgstr "MacGujarati"
+
+#: ../src/common/fmapbase.cpp:206
+msgid "MacOriya"
+msgstr "MacOriya"
+
+#: ../src/common/fmapbase.cpp:207
+msgid "MacBengali"
+msgstr "MacBengali"
+
+#: ../src/common/fmapbase.cpp:208
+msgid "MacTamil"
+msgstr "MacTamil"
+
+#: ../src/common/fmapbase.cpp:209
+msgid "MacTelugu"
+msgstr "MacTelugu"
+
+#: ../src/common/fmapbase.cpp:210
+msgid "MacKannada"
+msgstr "MacKannada"
+
+#: ../src/common/fmapbase.cpp:211
+msgid "MacMalayalam"
+msgstr "MacMalayalam"
+
+#: ../src/common/fmapbase.cpp:212
+msgid "MacSinhalese"
+msgstr "MacSinhalese"
+
+#: ../src/common/fmapbase.cpp:213
+msgid "MacBurmese"
+msgstr "MacBurmese"
+
+#: ../src/common/fmapbase.cpp:214
+msgid "MacKhmer"
+msgstr "MacKhmer"
+
+#: ../src/common/fmapbase.cpp:215
+msgid "MacThai"
+msgstr "MacThai"
+
+#: ../src/common/fmapbase.cpp:216
+msgid "MacLaotian"
+msgstr "MacLaotian"
+
+#: ../src/common/fmapbase.cpp:217
+msgid "MacGeorgian"
+msgstr "MacGeorgian"
+
+#: ../src/common/fmapbase.cpp:218
+msgid "MacArmenian"
+msgstr "MacArmenian"
+
+#: ../src/common/fmapbase.cpp:219
+msgid "MacChineseSimp"
+msgstr "MacChineseSimp"
+
+#: ../src/common/fmapbase.cpp:220
+msgid "MacTibetan"
+msgstr "MacTibetan"
+
+#: ../src/common/fmapbase.cpp:221
+msgid "MacMongolian"
+msgstr "MacMongolian"
+
+#: ../src/common/fmapbase.cpp:222
+msgid "MacEthiopic"
+msgstr "MacEthiopic"
+
+#: ../src/common/fmapbase.cpp:223
+msgid "MacCentralEurRoman"
+msgstr "MacCentralEurRoman"
+
+#: ../src/common/fmapbase.cpp:224
+msgid "MacVietnamese"
+msgstr "MacVietnamese"
+
+#: ../src/common/fmapbase.cpp:225
+msgid "MacExtArabic"
+msgstr "MacExtArabic"
+
+#: ../src/common/fmapbase.cpp:226
+msgid "MacSymbol"
+msgstr "MacSymbol"
+
+#: ../src/common/fmapbase.cpp:227
+msgid "MacDingbats"
+msgstr "MacDingbats"
+
+#: ../src/common/fmapbase.cpp:228
+msgid "MacTurkish"
+msgstr "MacTurkish"
+
+#: ../src/common/fmapbase.cpp:229
+msgid "MacCroatian"
+msgstr "MacCroatian"
+
+#: ../src/common/fmapbase.cpp:230
+msgid "MacIcelandic"
+msgstr "MacIcelandic"
+
+#: ../src/common/fmapbase.cpp:231
+msgid "MacRomanian"
+msgstr "MacRomanian"
+
+#: ../src/common/fmapbase.cpp:232
+msgid "MacCeltic"
+msgstr "MacCeltic"
+
+#: ../src/common/fmapbase.cpp:233
+msgid "MacGaelic"
+msgstr "MacGaelic"
+
+#: ../src/common/fmapbase.cpp:234
+msgid "MacKeyboardGlyphs"
+msgstr "MacKeyboardGlyphs"
+
+#: ../src/common/fmapbase.cpp:791
+msgid "Default encoding"
+msgstr "默认编码"
+
+#: ../src/common/fmapbase.cpp:805
+#, c-format
+msgid "Unknown encoding (%d)"
+msgstr "未知编码 (%d)"
+
+#: ../src/common/fmapbase.cpp:815 ../src/richtext/richtextstyles.cpp:776
+msgid "default"
+msgstr "默认"
+
+#: ../src/common/fmapbase.cpp:829
+#, c-format
+msgid "unknown-%d"
+msgstr "未知-%d"
+
+#: ../src/common/fontcmn.cpp:924 ../src/common/fontcmn.cpp:1130
+msgid "underlined"
+msgstr "下划线"
+
+#: ../src/common/fontcmn.cpp:929
+msgid " strikethrough"
+msgstr " 删除线"
+
+#: ../src/common/fontcmn.cpp:942
+msgid " thin"
+msgstr " 极细"
+
+#: ../src/common/fontcmn.cpp:946
+msgid " extra light"
+msgstr " 特细"
+
+#: ../src/common/fontcmn.cpp:950
+msgid " light"
+msgstr " 细"
+
+#: ../src/common/fontcmn.cpp:954
+msgid " medium"
+msgstr " 中等"
+
+#: ../src/common/fontcmn.cpp:958
+msgid " semi bold"
+msgstr " 半粗"
+
+#: ../src/common/fontcmn.cpp:962
+msgid " bold"
+msgstr " 粗体"
+
+#: ../src/common/fontcmn.cpp:966
+msgid " extra bold"
+msgstr " 特粗"
+
+#: ../src/common/fontcmn.cpp:970
+msgid " heavy"
+msgstr " 粗黑"
+
+#: ../src/common/fontcmn.cpp:974
+msgid " extra heavy"
+msgstr " 特黑"
+
+#: ../src/common/fontcmn.cpp:990
+msgid " italic"
+msgstr " 斜体"
+
+#: ../src/common/fontcmn.cpp:1134
+msgid "strikethrough"
+msgstr "删除线"
+
+#: ../src/common/fontcmn.cpp:1143
+msgid "thin"
+msgstr "极细"
+
+#: ../src/common/fontcmn.cpp:1156
+msgid "extralight"
+msgstr "特细"
+
+#: ../src/common/fontcmn.cpp:1161
+msgid "light"
+msgstr "细"
+
+#: ../src/common/fontcmn.cpp:1169 ../src/richtext/richtextstyles.cpp:775
+msgid "normal"
+msgstr "常规"
+
+#: ../src/common/fontcmn.cpp:1174
+msgid "medium"
+msgstr "中等"
+
+#: ../src/common/fontcmn.cpp:1179 ../src/common/fontcmn.cpp:1199
+msgid "semibold"
+msgstr "半粗"
+
+#: ../src/common/fontcmn.cpp:1184
+msgid "bold"
+msgstr "粗体"
+
+#: ../src/common/fontcmn.cpp:1194
+msgid "extrabold"
+msgstr "特粗"
+
+#: ../src/common/fontcmn.cpp:1204
+msgid "heavy"
+msgstr "粗黑"
+
+#: ../src/common/fontcmn.cpp:1212
+msgid "extraheavy"
+msgstr "特黑"
+
+#: ../src/common/fontcmn.cpp:1217
+msgid "italic"
+msgstr "斜体"
+
+#: ../src/common/fontmap.cpp:195
+msgid ": unknown charset"
+msgstr "：未知字符集"
+
+#: ../src/common/fontmap.cpp:199
+#, c-format
+msgid ""
+"The charset '%s' is unknown. You may select\n"
+"another charset to replace it with or choose\n"
+"[Cancel] if it cannot be replaced"
+msgstr ""
+"未知字符集 '%s'。\n"
+"你可以选择另一个字符集来替代，\n"
+"如果无法替代请选择「取消」"
+
+#: ../src/common/fontmap.cpp:241
+#, c-format
+msgid "Failed to remember the encoding for the charset '%s'."
+msgstr "未能记住字符集 '%s' 的编码。"
+
+#: ../src/common/fontmap.cpp:321
+msgid "can't load any font, aborting"
+msgstr "无法加载任何字体，正在中止"
+
+#: ../src/common/fontmap.cpp:409
+msgid ": unknown encoding"
+msgstr "：未知编码"
+
+#: ../src/common/fontmap.cpp:417
+#, c-format
+msgid ""
+"No font for displaying text in encoding '%s' found,\n"
+"but an alternative encoding '%s' is available.\n"
+"Do you want to use this encoding (otherwise you will have to choose another "
+"one)?"
+msgstr ""
+"未找到用于显示编码为 '%s' 的文本的字体。\n"
+"但有可用的替代编码 '%s'。\n"
+"是否使用该编码？(否则必须选择其他编码)"
+
+#: ../src/common/fontmap.cpp:422
+#, c-format
+msgid ""
+"No font for displaying text in encoding '%s' found.\n"
+"Would you like to select a font to be used for this encoding\n"
+"(otherwise the text in this encoding will not be shown correctly)?"
+msgstr ""
+"未找到用于显示编码为 '%s' 的文本的字体。\n"
+"是否要为该编码选择一种字体？\n"
+"(否则该编码的文本将无法正确显示)"
+
+#: ../src/common/fs_mem.cpp:169
+#, c-format
+msgid "Memory VFS already contains file '%s'!"
+msgstr "内存 VFS 已包含文件 '%s'！"
+
+#: ../src/common/fs_mem.cpp:232
+#, c-format
+msgid "Trying to remove file '%s' from memory VFS, but it is not loaded!"
+msgstr "试图从内存 VFS 中移除文件 '%s'，但它并没有被装入内存！"
+
+#: ../src/common/fs_mem.cpp:262
+#, c-format
+msgid "Failed to store image '%s' to memory VFS!"
+msgstr "无法将图像 '%s' 存到内存 VFS！"
+
+#: ../src/common/ftp.cpp:197
+msgid "Timeout while waiting for FTP server to connect, try passive mode."
+msgstr "等待 FTP 服务器连接时超时，请尝试用被动模式。"
+
+#: ../src/common/ftp.cpp:399
+#, c-format
+msgid "Failed to set FTP transfer mode to %s."
+msgstr "无法设置 FTP 传输模式为 %s。"
+
+#: ../src/common/ftp.cpp:400 ../src/richtext/richtextsymboldlg.cpp:432
+msgid "ASCII"
+msgstr "ASCII"
+
+#: ../src/common/ftp.cpp:400
+msgid "binary"
+msgstr "二进制"
+
+#: ../src/common/ftp.cpp:608
+msgid "The FTP server doesn't support the PORT command."
+msgstr "FTP 服务器不支持 PORT 命令。"
+
+#: ../src/common/ftp.cpp:622
+msgid "The FTP server doesn't support passive mode."
+msgstr "FTP 服务器不支持被动模式。"
+
+#: ../src/common/gifdecod.cpp:822
+#, c-format
+msgid "Incorrect GIF frame size (%u, %d) for the frame #%u"
+msgstr "GIF 第 %3$u 帧的尺寸 (%1$u, %2$d) 不正确"
+
+#: ../src/common/glcmn.cpp:108
+msgid "Failed to allocate colour for OpenGL"
+msgstr "无法为 OpenGL 分配颜色"
+
+#: ../src/common/headerctrlcmn.cpp:57
+msgid "Please select the columns to show and define their order:"
+msgstr "请选择列并显示和定义它们的顺序："
+
+#: ../src/common/headerctrlcmn.cpp:58
+msgid "Customize Columns"
+msgstr "自定义列"
+
+#: ../src/common/headerctrlcmn.cpp:304
+msgid "&Customize..."
+msgstr "自定义(&C)..."
+
+#: ../src/common/hyperlnkcmn.cpp:132
+#, c-format
+msgid "Failed to open URL \"%s\" in the default browser"
+msgstr "无法在默认浏览器中打开 URL \"%s\""
+
+#: ../src/common/iconbndl.cpp:195
+#, c-format
+msgid "Failed to load image %%d from file '%s'."
+msgstr "无法从文件 '%s' 中读取图像 %%d。"
+
+#: ../src/common/iconbndl.cpp:203
+#, c-format
+msgid "Failed to load image %d from stream."
+msgstr "无法从数据流中加载图像 %d。"
+
+#: ../src/common/iconbndl.cpp:221
+#, c-format
+msgid "Failed to load icons from resource '%s'."
+msgstr "无法从资源 '%s' 中加载图标 。"
+
+#: ../src/common/imagbmp.cpp:97
+msgid "BMP: Couldn't save invalid image."
+msgstr "BMP：无法保存无效图像。"
+
+#: ../src/common/imagbmp.cpp:137
+msgid "BMP: wxImage doesn't have own wxPalette."
+msgstr "BMP：wxImage 没有自己的 wxPalette。"
+
+#: ../src/common/imagbmp.cpp:243
+msgid "BMP: Couldn't write the file (Bitmap) header."
+msgstr "BMP：无法写入位图文件头。"
+
+#: ../src/common/imagbmp.cpp:266
+msgid "BMP: Couldn't write the file (BitmapInfo) header."
+msgstr "BMP：无法写入位图信息头。"
+
+#: ../src/common/imagbmp.cpp:353
+msgid "BMP: Couldn't write RGB color map."
+msgstr "BMP：无法写入 RGB 色彩表。"
+
+#: ../src/common/imagbmp.cpp:487
+msgid "BMP: Couldn't write data."
+msgstr "BMP：无法写入数据。"
+
+#: ../src/common/imagbmp.cpp:561 ../src/common/imagbmp.cpp:642
+msgid "BMP: Couldn't allocate memory."
+msgstr "BMP：无法分配内存。"
+
+#: ../src/common/imagbmp.cpp:1041
+msgid "DIB Header: Image width > 32767 pixels for file."
+msgstr "DIB 头：文件中图像宽度大于 32767 像素。"
+
+#: ../src/common/imagbmp.cpp:1049
+msgid "DIB Header: Image height > 32767 pixels for file."
+msgstr "DIB 头：文件中图像高度大于 32767 像素。"
+
+#: ../src/common/imagbmp.cpp:1081
+msgid "DIB Header: Unknown bitdepth in file."
+msgstr "DIB 头：文件中色彩的位深未知。"
+
+#: ../src/common/imagbmp.cpp:1156
+msgid "DIB Header: Unknown encoding in file."
+msgstr "DIB 头：文件编码未知。"
+
+#: ../src/common/imagbmp.cpp:1165
+msgid "DIB Header: Encoding doesn't match bitdepth."
+msgstr "DIB 头：编码与色彩的位深度不匹配。"
+
+#: ../src/common/imagbmp.cpp:1180
+#, c-format
+msgid "BMP Header: Invalid number of colors (%d)."
+msgstr "BMP 头：颜色数无效 (%d)。"
+
+#: ../src/common/imagbmp.cpp:1273
+msgid "Error in reading image DIB."
+msgstr "读取图像 DIB 时出错。"
+
+#: ../src/common/imagbmp.cpp:1294
+msgid "ICO: Error in reading mask DIB."
+msgstr "ICO：读取掩码 DIB 错误。"
+
+#: ../src/common/imagbmp.cpp:1353
+msgid "ICO: Image too tall for an icon."
+msgstr "ICO：图像高度超出范围，不适合做图标。"
+
+#: ../src/common/imagbmp.cpp:1361
+msgid "ICO: Image too wide for an icon."
+msgstr "ICO：图像宽度超出范围，不适合做图标。"
+
+#: ../src/common/imagbmp.cpp:1388 ../src/common/imagbmp.cpp:1488
+#: ../src/common/imagbmp.cpp:1503 ../src/common/imagbmp.cpp:1514
+#: ../src/common/imagbmp.cpp:1528 ../src/common/imagbmp.cpp:1576
+#: ../src/common/imagbmp.cpp:1591 ../src/common/imagbmp.cpp:1605
+#: ../src/common/imagbmp.cpp:1616
+msgid "ICO: Error writing the image file!"
+msgstr "ICO：写入图像文件错误！"
+
+#: ../src/common/imagbmp.cpp:1701
+msgid "ICO: Invalid icon index."
+msgstr "ICO：图标索引无效。"
+
+#: ../src/common/image.cpp:2410
+msgid "Image and mask have different sizes."
+msgstr "图像和蒙版尺寸不同。"
+
+#: ../src/common/image.cpp:2418 ../src/common/image.cpp:2459
+msgid "No unused colour in image being masked."
+msgstr "被蒙版遮挡的图像中没有未使用的颜色。"
+
+#: ../src/common/image.cpp:2641
+#, c-format
+msgid "Failed to load bitmap \"%s\" from resources."
+msgstr "无法从资源中加载图像 \"%s\"。"
+
+#: ../src/common/image.cpp:2650
+#, c-format
+msgid "Failed to load icon \"%s\" from resources."
+msgstr "无法从资源中加载图标 \"%s\"。"
+
+#: ../src/common/image.cpp:2728 ../src/common/image.cpp:2747
+#, c-format
+msgid "Failed to load image from file \"%s\"."
+msgstr "无法从文件 \"%s\" 中加载图像。"
+
+#: ../src/common/image.cpp:2761
+#, c-format
+msgid "Can't save image to file '%s': unknown extension."
+msgstr "无法将图像保存到文件 '%s'：未知的扩展名。"
+
+#: ../src/common/image.cpp:2869
+msgid "No handler found for image type."
+msgstr "未找到该图像类型的处理程序。"
+
+#: ../src/common/image.cpp:2877 ../src/common/image.cpp:3000
+#: ../src/common/image.cpp:3066
+#, c-format
+msgid "No image handler for type %d defined."
+msgstr "未定义 %d 类型的图像处理程序。"
+
+#: ../src/common/image.cpp:2887
+#, c-format
+msgid "Image file is not of type %d."
+msgstr "图像文件不是 %d 类型。"
+
+#: ../src/common/image.cpp:2970
+msgid "Can't automatically determine the image format for non-seekable input."
+msgstr "无法自动确定不可定位输入的图像格式。"
+
+#: ../src/common/image.cpp:2988
+msgid "Unknown image data format."
+msgstr "未知图像数据格式。"
+
+#: ../src/common/image.cpp:3009
+#, c-format
+msgid "This is not a %s."
+msgstr "这不是 %s。"
+
+#: ../src/common/image.cpp:3032 ../src/common/image.cpp:3080
+#, c-format
+msgid "No image handler for type %s defined."
+msgstr "未定义用于处理类型为 %s 的图像处理程序。"
+
+#: ../src/common/image.cpp:3041
+#, c-format
+msgid "Image is not of type %s."
+msgstr "图像的类型不是 %s。"
+
+#: ../src/common/image.cpp:3509
+#, c-format
+msgid "Failed to check format of image file \"%s\"."
+msgstr "无法确认图像文件 \"%s\" 的格式。"
+
+#: ../src/common/imaggif.cpp:124
+msgid "GIF: error in GIF image format."
+msgstr "GIF：GIF 文件格式错误。"
+
+#: ../src/common/imaggif.cpp:129
+msgid "GIF: not enough memory."
+msgstr "GIF：没有足够内存。"
+
+#: ../src/common/imaggif.cpp:134
+msgid "GIF: data stream seems to be truncated."
+msgstr "GIF：数据流似乎已被截断。"
+
+#: ../src/common/imaggif.cpp:240
+msgid "Couldn't initialize GIF hash table."
+msgstr "无法初始化 GIF 哈希表。"
+
+#: ../src/common/imagiff.cpp:739
+msgid "IFF: error in IFF image format."
+msgstr "IFF：IFF 文件格式错误。"
+
+#: ../src/common/imagiff.cpp:742
+msgid "IFF: not enough memory."
+msgstr "IFF：没有足够内存。"
+
+#: ../src/common/imagiff.cpp:745
+msgid "IFF: unknown error!!!"
+msgstr "IFF：未知错误！"
+
+#: ../src/common/imagiff.cpp:755
+msgid "IFF: data stream seems to be truncated."
+msgstr "IFF：数据流似乎已被截断。"
+
+#: ../src/common/imagjpeg.cpp:258
+msgid "JPEG: Couldn't load - file is probably corrupted."
+msgstr "JPEG：无法加载 - 文件可能已损坏。"
+
+#: ../src/common/imagjpeg.cpp:437
+msgid "JPEG: Couldn't save image."
+msgstr "JPEG：无法保存图像。"
+
+#: ../src/common/imagpcx.cpp:439
+msgid "PCX: this is not a PCX file."
+msgstr "PCX：不是 PCX 文件。"
+
+#: ../src/common/imagpcx.cpp:453
+msgid "PCX: image format unsupported"
+msgstr "PCX：图像格式不支持"
+
+#: ../src/common/imagpcx.cpp:454 ../src/common/imagpcx.cpp:477
+msgid "PCX: couldn't allocate memory"
+msgstr "PCX：无法分配内存"
+
+#: ../src/common/imagpcx.cpp:455
+msgid "PCX: version number too low"
+msgstr "PCX：版本号太小"
+
+#: ../src/common/imagpcx.cpp:456 ../src/common/imagpcx.cpp:478
+msgid "PCX: unknown error !!!"
+msgstr "PCX：未知错误！！！"
+
+#: ../src/common/imagpcx.cpp:476
+msgid "PCX: invalid image"
+msgstr "PCX：无效图像"
+
+#: ../src/common/imagpng.cpp:385
+#, c-format
+msgid "Unknown PNG resolution unit %d"
+msgstr "未知的 PNG 分辨率单位 %d"
+
+#: ../src/common/imagpng.cpp:439
+msgid "Couldn't load a PNG image - file is corrupted or not enough memory."
+msgstr "无法加载 PNG 图像 - 文件已损坏，或者没有足够内存。"
+
+#: ../src/common/imagpng.cpp:513 ../src/common/imagpng.cpp:524
+#: ../src/common/imagpng.cpp:534
+msgid "Couldn't save PNG image."
+msgstr "无法保存 PNG 图像。"
+
+#: ../src/common/imagpnm.cpp:71
+msgid "PNM: File format is not recognized."
+msgstr "PNM：无法识别文件格式。"
+
+#: ../src/common/imagpnm.cpp:89
+msgid "PNM: Couldn't allocate memory."
+msgstr "PNM：无法分配内存。"
+
+#: ../src/common/imagpnm.cpp:111 ../src/common/imagpnm.cpp:134
+#: ../src/common/imagpnm.cpp:156
+msgid "PNM: File seems truncated."
+msgstr "PNM：文件似乎已被截断。"
+
+#: ../src/common/imagtiff.cpp:69
+#, c-format
+msgid " (in module \"%s\")"
+msgstr "（在模块 \"%s\" 中）"
+
+#: ../src/common/imagtiff.cpp:304
+msgid "TIFF: Error loading image."
+msgstr "TIFF：加载图像时出错。"
+
+#: ../src/common/imagtiff.cpp:314
+msgid "Invalid TIFF image index."
+msgstr "无效 TIFF 图像索引。"
+
+#: ../src/common/imagtiff.cpp:358
+msgid "TIFF: Image size is abnormally big."
+msgstr "TIFF：图像大小过大。"
+
+#: ../src/common/imagtiff.cpp:372 ../src/common/imagtiff.cpp:385
+#: ../src/common/imagtiff.cpp:769
+msgid "TIFF: Couldn't allocate memory."
+msgstr "TIFF：无法分配内存。"
+
+#: ../src/common/imagtiff.cpp:471
+msgid "TIFF: Error reading image."
+msgstr "TIFF：读取图像时出错。"
+
+#: ../src/common/imagtiff.cpp:532
+#, c-format
+msgid "Unknown TIFF resolution unit %d ignored"
+msgstr "未知 TIFF 分辨率单位 %d，已忽略"
+
+#: ../src/common/imagtiff.cpp:611
+msgid "TIFF: Error saving image."
+msgstr "TIFF：保存图像时出错。"
+
+#: ../src/common/imagtiff.cpp:868
+msgid "TIFF: Error writing image."
+msgstr "TIFF：写入图像时出错。"
+
+#: ../src/common/imagtiff.cpp:881
+msgid "TIFF: Error flushing data."
+msgstr "TIFF：刷新数据时出错。"
+
+#: ../src/common/imagwebp.cpp:56
+msgid "WebP: Invalid data (failed to get features)."
+msgstr "WebP：数据无效（未能获取特性）。"
+
+#: ../src/common/imagwebp.cpp:65
+msgid "WebP: Allocating image memory failed."
+msgstr "WebP：分配图像内存失败。"
+
+#: ../src/common/imagwebp.cpp:82
+msgid "WebP: Decoding RGBA image data failed."
+msgstr "WebP：无法解码 RGBA 图像数据。"
+
+#: ../src/common/imagwebp.cpp:98
+msgid "WebP: Decoding RGB image data failed."
+msgstr "WebP：解码 RGB 图像数据失败。"
+
+#: ../src/common/imagwebp.cpp:113 ../src/common/imagwebp.cpp:201
+msgid "WebP: Allocating stream buffer failed."
+msgstr "WebP：无法分配流缓冲区。"
+
+#: ../src/common/imagwebp.cpp:131
+msgid "WebP: Failed to parse container data."
+msgstr "WebP：无法解析容器数据。"
+
+#: ../src/common/imagwebp.cpp:222
+msgid "WebP: Error decoding animation."
+msgstr "WebP：动画解码出错。"
+
+#: ../src/common/imagwebp.cpp:240
+msgid "WebP: Error getting next animation frame."
+msgstr "WebP：获取下一动画帧时出错。"
+
+#: ../src/common/init.cpp:172
+#, c-format
+msgid ""
+"Command line argument %d couldn't be converted to Unicode and will be "
+"ignored."
+msgstr "命令行参数 %d 无法转化成 Unicode，将被忽略。"
+
+#: ../src/common/init.cpp:344
+msgid "Initialization failed in post init, aborting."
+msgstr "后期初始化失败，正在中止。"
+
+#: ../src/common/intl.cpp:378
+#, c-format
+msgid "Cannot set locale to language \"%s\"."
+msgstr "无法设定区域语言为 \"%s\"。"
+
+#: ../src/common/log.cpp:232
+msgid "Error: "
+msgstr "错误： "
+
+#: ../src/common/log.cpp:236
+msgid "Warning: "
+msgstr "警告： "
+
+#: ../src/common/log.cpp:284
+msgid "The previous message repeated once."
+msgstr "上一条消息已重复一次。"
+
+#: ../src/common/log.cpp:291
+#, c-format
+msgid "The previous message repeated %u time."
+msgid_plural "The previous message repeated %u times."
+msgstr[0] "上一条消息已重复 %u 次。"
+
+#: ../src/common/log.cpp:319
+#, c-format
+msgid "Last repeated message (\"%s\", %u time) wasn't output"
+msgid_plural "Last repeated message (\"%s\", %u times) wasn't output"
+msgstr[0] "最后重复的消息（\"%s\"，%u 次）未输出"
+
+#: ../src/common/log.cpp:435
+#, c-format
+msgid " (error %ld: %s)"
+msgstr "（错误 %ld：%s）"
+
+#: ../src/common/lzmastream.cpp:121
+msgid "Failed to allocate memory for LZMA decompression."
+msgstr "无法分配用于 LZMA 解压的内存。"
+
+#: ../src/common/lzmastream.cpp:125
+#, c-format
+msgid "Failed to initialize LZMA decompression: unexpected error %u."
+msgstr "LZMA 解压初始化失败：意外错误 %u。"
+
+#: ../src/common/lzmastream.cpp:179
+msgid "input is not in XZ format"
+msgstr "输入不是 XZ 格式"
+
+#: ../src/common/lzmastream.cpp:183
+msgid "input compressed using unknown XZ option"
+msgstr "压缩输入使用未知 XZ 选项"
+
+#: ../src/common/lzmastream.cpp:188
+msgid "input is corrupted"
+msgstr "输入已损坏"
+
+#: ../src/common/lzmastream.cpp:192
+msgid "unknown decompression error"
+msgstr "未知的解压缩错误"
+
+#: ../src/common/lzmastream.cpp:196
+#, c-format
+msgid "LZMA decompression error: %s"
+msgstr "LZMA 解压出错：%s"
+
+#: ../src/common/lzmastream.cpp:231
+msgid "Failed to allocate memory for LZMA compression."
+msgstr "无法为 LZMA 压缩分配内存。"
+
+#: ../src/common/lzmastream.cpp:235
+#, c-format
+msgid "Failed to initialize LZMA compression: unexpected error %u."
+msgstr "初始化 LZMA 压缩失败：意外错误 %u。"
+
+#: ../src/common/lzmastream.cpp:267 ../src/common/lzmastream.cpp:342
+#: ../src/html/chm.cpp:336
+msgid "out of memory"
+msgstr "内存耗尽"
+
+#: ../src/common/lzmastream.cpp:276 ../src/common/lzmastream.cpp:346
+msgid "unknown compression error"
+msgstr "未知的压缩错误"
+
+#: ../src/common/lzmastream.cpp:280
+#, c-format
+msgid "LZMA compression error: %s"
+msgstr "LZMA 压缩错误：%s"
+
+#: ../src/common/lzmastream.cpp:350
+#, c-format
+msgid "LZMA compression error when flushing output: %s"
+msgstr "刷新输出时 LZMA 压缩出错：%s"
+
+#: ../src/common/mimecmn.cpp:167
+#, c-format
+msgid "Unmatched '{' in an entry for mime type %s."
+msgstr "MIME 类型 %s 的条目中 '{' 未闭合。"
+
+#: ../src/common/module.cpp:76
+#, c-format
+msgid "Circular dependency involving module \"%s\" detected."
+msgstr "检测到模块 \"%s\" 涉及循环依赖。"
+
+#: ../src/common/module.cpp:128
+#, c-format
+msgid "Dependency \"%s\" of module \"%s\" doesn't exist."
+msgstr "找不到模块 \"%2$s\" 的依赖项 \"%1$s\"。"
+
+#: ../src/common/module.cpp:137
+#, c-format
+msgid "Module \"%s\" initialization failed"
+msgstr "模块 \"%s\" 初始化失败"
+
+#: ../src/common/msgout.cpp:96
+msgid "Message"
+msgstr "消息"
+
+#: ../src/common/paper.cpp:70
+msgid "Letter, 8 1/2 x 11 in"
+msgstr "Letter, 8 1/2 x 11 in"
+
+#: ../src/common/paper.cpp:71
+msgid "Legal, 8 1/2 x 14 in"
+msgstr "Legal, 8 1/2 x 14 in"
+
+#: ../src/common/paper.cpp:72
+msgid "A4 sheet, 210 x 297 mm"
+msgstr "A4 sheet, 210 x 297 mm"
+
+#: ../src/common/paper.cpp:73
+msgid "C sheet, 17 x 22 in"
+msgstr "C sheet, 17 x 22 in"
+
+#: ../src/common/paper.cpp:74
+msgid "D sheet, 22 x 34 in"
+msgstr "D sheet, 22 x 34 in"
+
+#: ../src/common/paper.cpp:75
+msgid "E sheet, 34 x 44 in"
+msgstr "E sheet, 34 x 44 in"
+
+#: ../src/common/paper.cpp:76
+msgid "Letter Small, 8 1/2 x 11 in"
+msgstr "Letter Small, 8 1/2 x 11 in"
+
+#: ../src/common/paper.cpp:77
+msgid "Tabloid, 11 x 17 in"
+msgstr "Tabloid, 11 x 17 in"
+
+#: ../src/common/paper.cpp:78
+msgid "Ledger, 17 x 11 in"
+msgstr "Ledger, 17 x 11 in"
+
+#: ../src/common/paper.cpp:79
+msgid "Statement, 5 1/2 x 8 1/2 in"
+msgstr "Statement, 5 1/2 x 8 1/2 in"
+
+#: ../src/common/paper.cpp:80
+msgid "Executive, 7 1/4 x 10 1/2 in"
+msgstr "Executive, 7 1/4 x 10 1/2 in"
+
+#: ../src/common/paper.cpp:81
+msgid "A3 sheet, 297 x 420 mm"
+msgstr "A3 sheet, 297 x 420 mm"
+
+#: ../src/common/paper.cpp:82
+msgid "A4 small sheet, 210 x 297 mm"
+msgstr "A4 small sheet, 210 x 297 mm"
+
+#: ../src/common/paper.cpp:83
+msgid "A5 sheet, 148 x 210 mm"
+msgstr "A5 sheet, 148 x 210 mm"
+
+#: ../src/common/paper.cpp:84
+msgid "B4 sheet, 250 x 354 mm"
+msgstr "B4 sheet, 250 x 354 mm"
+
+#: ../src/common/paper.cpp:85
+msgid "B5 sheet, 182 x 257 millimeter"
+msgstr "B5 sheet, 182 x 257 mm"
+
+#: ../src/common/paper.cpp:86
+msgid "Folio, 8 1/2 x 13 in"
+msgstr "Folio, 8 1/2 x 13 in"
+
+#: ../src/common/paper.cpp:87
+msgid "Quarto, 215 x 275 mm"
+msgstr "Quarto, 215 x 275 mm"
+
+#: ../src/common/paper.cpp:88
+msgid "10 x 14 in"
+msgstr "10 x 14 in"
+
+#: ../src/common/paper.cpp:89
+msgid "11 x 17 in"
+msgstr "11 x 17 in"
+
+#: ../src/common/paper.cpp:90
+msgid "Note, 8 1/2 x 11 in"
+msgstr "Note, 8 1/2 x 11 in"
+
+#: ../src/common/paper.cpp:91
+msgid "#9 Envelope, 3 7/8 x 8 7/8 in"
+msgstr "#9 Envelope, 3 7/8 x 8 7/8 in"
+
+#: ../src/common/paper.cpp:92
+msgid "#10 Envelope, 4 1/8 x 9 1/2 in"
+msgstr "#10 Envelope, 4 1/8 x 9 1/2 in"
+
+#: ../src/common/paper.cpp:93
+msgid "#11 Envelope, 4 1/2 x 10 3/8 in"
+msgstr "#11 Envelope, 4 1/2 x 10 3/8 in"
+
+#: ../src/common/paper.cpp:94
+msgid "#12 Envelope, 4 3/4 x 11 in"
+msgstr "#12 Envelope, 4 3/4 x 11 in"
+
+#: ../src/common/paper.cpp:95
+msgid "#14 Envelope, 5 x 11 1/2 in"
+msgstr "#14 Envelope, 5 x 11 1/2 in"
+
+#: ../src/common/paper.cpp:96
+msgid "DL Envelope, 110 x 220 mm"
+msgstr "DL Envelope, 110 x 220 mm"
+
+#: ../src/common/paper.cpp:97
+msgid "C5 Envelope, 162 x 229 mm"
+msgstr "C5 Envelope, 162 x 229 mm"
+
+#: ../src/common/paper.cpp:98
+msgid "C3 Envelope, 324 x 458 mm"
+msgstr "C3 Envelope, 324 x 458 mm"
+
+#: ../src/common/paper.cpp:99
+msgid "C4 Envelope, 229 x 324 mm"
+msgstr "C4 Envelope, 229 x 324 mm"
+
+#: ../src/common/paper.cpp:100
+msgid "C6 Envelope, 114 x 162 mm"
+msgstr "C6 Envelope, 114 x 162 mm"
+
+#: ../src/common/paper.cpp:101
+msgid "C65 Envelope, 114 x 229 mm"
+msgstr "C65 Envelope, 114 x 229 mm"
+
+#: ../src/common/paper.cpp:102
+msgid "B4 Envelope, 250 x 353 mm"
+msgstr "B4 Envelope, 250 x 353 mm"
+
+#: ../src/common/paper.cpp:103
+msgid "B5 Envelope, 176 x 250 mm"
+msgstr "B5 Envelope, 176 x 250 mm"
+
+#: ../src/common/paper.cpp:104
+msgid "B6 Envelope, 176 x 125 mm"
+msgstr "B6 Envelope, 176 x 125 mm"
+
+#: ../src/common/paper.cpp:105
+msgid "Italy Envelope, 110 x 230 mm"
+msgstr "Italy Envelope, 110 x 230 mm"
+
+#: ../src/common/paper.cpp:106
+msgid "Monarch Envelope, 3 7/8 x 7 1/2 in"
+msgstr "Monarch Envelope, 3 7/8 x 7 1/2 in"
+
+#: ../src/common/paper.cpp:107
+msgid "6 3/4 Envelope, 3 5/8 x 6 1/2 in"
+msgstr "6 3/4 Envelope, 3 5/8 x 6 1/2 in"
+
+#: ../src/common/paper.cpp:108
+msgid "US Std Fanfold, 14 7/8 x 11 in"
+msgstr "US Std Fanfold, 14 7/8 x 11 in"
+
+#: ../src/common/paper.cpp:109
+msgid "German Std Fanfold, 8 1/2 x 12 in"
+msgstr "German Std Fanfold, 8 1/2 x 12 in"
+
+#: ../src/common/paper.cpp:110
+msgid "German Legal Fanfold, 8 1/2 x 13 in"
+msgstr "German Legal Fanfold, 8 1/2 x 13 in"
+
+#: ../src/common/paper.cpp:112
+msgid "B4 (ISO) 250 x 353 mm"
+msgstr "B4 sheet (ISO), 250 x 353 mm"
+
+#: ../src/common/paper.cpp:113
+msgid "Japanese Postcard 100 x 148 mm"
+msgstr "Japanese Postcard 100 x 148 mm"
+
+#: ../src/common/paper.cpp:114
+msgid "9 x 11 in"
+msgstr "9 x 11 in"
+
+#: ../src/common/paper.cpp:115
+msgid "10 x 11 in"
+msgstr "10 x 11 in"
+
+#: ../src/common/paper.cpp:116
+msgid "15 x 11 in"
+msgstr "15 x 11 in"
+
+#: ../src/common/paper.cpp:117
+msgid "Envelope Invite 220 x 220 mm"
+msgstr "Envelope Invite 220 x 220 mm"
+
+#: ../src/common/paper.cpp:118
+msgid "Letter Extra 9 1/2 x 12 in"
+msgstr "Letter Extra 9 1/2 x 12 in"
+
+#: ../src/common/paper.cpp:119
+msgid "Legal Extra 9 1/2 x 15 in"
+msgstr "Legal Extra 9 1/2 x 15 in"
+
+#: ../src/common/paper.cpp:120
+msgid "Tabloid Extra 11.69 x 18 in"
+msgstr "Tabloid Extra 11.69 x 18 in"
+
+#: ../src/common/paper.cpp:121
+msgid "A4 Extra 9.27 x 12.69 in"
+msgstr "A4 Extra 9.27 x 12.69 in"
+
+#: ../src/common/paper.cpp:122
+msgid "Letter Transverse 8 1/2 x 11 in"
+msgstr "Letter Transverse 8 1/2 x 11 in"
+
+#: ../src/common/paper.cpp:123
+msgid "A4 Transverse 210 x 297 mm"
+msgstr "A4 Transverse 210 x 297 mm"
+
+#: ../src/common/paper.cpp:124
+msgid "Letter Extra Transverse 9.275 x 12 in"
+msgstr "Letter Extra Transverse 9.275 x 12 in"
+
+#: ../src/common/paper.cpp:125
+msgid "SuperA/SuperA/A4 227 x 356 mm"
+msgstr "SuperA/SuperA/A4 227 x 356 mm"
+
+#: ../src/common/paper.cpp:126
+msgid "SuperB/SuperB/A3 305 x 487 mm"
+msgstr "SuperB/SuperB/A3 305 x 487 mm"
+
+#: ../src/common/paper.cpp:127
+msgid "Letter Plus 8 1/2 x 12.69 in"
+msgstr "Letter Plus 8 1/2 x 12.69 in"
+
+#: ../src/common/paper.cpp:128
+msgid "A4 Plus 210 x 330 mm"
+msgstr "A4 Plus 210 x 330 mm"
+
+#: ../src/common/paper.cpp:129
+msgid "A5 Transverse 148 x 210 mm"
+msgstr "A5 Transverse 148 x 210 mm"
+
+#: ../src/common/paper.cpp:130
+msgid "B5 (JIS) Transverse 182 x 257 mm"
+msgstr "B5 (JIS) Transverse 182 x 257 mm"
+
+#: ../src/common/paper.cpp:131
+msgid "A3 Extra 322 x 445 mm"
+msgstr "A3 Extra 322 x 445 mm"
+
+#: ../src/common/paper.cpp:132
+msgid "A5 Extra 174 x 235 mm"
+msgstr "A5 Extra 174 x 235 mm"
+
+#: ../src/common/paper.cpp:133
+msgid "B5 (ISO) Extra 201 x 276 mm"
+msgstr "B5 (ISO) Extra 201 x 276 mm"
+
+#: ../src/common/paper.cpp:134
+msgid "A2 420 x 594 mm"
+msgstr "A2 420 x 594 mm"
+
+#: ../src/common/paper.cpp:135
+msgid "A3 Transverse 297 x 420 mm"
+msgstr "A3 Transverse 297 x 420 mm"
+
+#: ../src/common/paper.cpp:136
+msgid "A3 Extra Transverse 322 x 445 mm"
+msgstr "A3 Extra Transverse 322 x 445 mm"
+
+#: ../src/common/paper.cpp:138
+msgid "Japanese Double Postcard 200 x 148 mm"
+msgstr "Japanese Double Postcard 200 x 148 mm"
+
+#: ../src/common/paper.cpp:139
+msgid "A6 105 x 148 mm"
+msgstr "A6 105 x 148 mm"
+
+#: ../src/common/paper.cpp:140
+msgid "Japanese Envelope Kaku #2"
+msgstr "Japanese Envelope Kaku #2"
+
+#: ../src/common/paper.cpp:141
+msgid "Japanese Envelope Kaku #3"
+msgstr "Japanese Envelope Kaku #3"
+
+#: ../src/common/paper.cpp:142
+msgid "Japanese Envelope Chou #3"
+msgstr "Japanese Envelope Chou #3"
+
+#: ../src/common/paper.cpp:143
+msgid "Japanese Envelope Chou #4"
+msgstr "Japanese Envelope Chou #4"
+
+#: ../src/common/paper.cpp:144
+msgid "Letter Rotated 11 x 8 1/2 in"
+msgstr "Letter Rotated 11 x 8 1/2 in"
+
+#: ../src/common/paper.cpp:145
+msgid "A3 Rotated 420 x 297 mm"
+msgstr "A3 Rotated 420 x 297 mm"
+
+#: ../src/common/paper.cpp:146
+msgid "A4 Rotated 297 x 210 mm"
+msgstr "A4 Rotated 297 x 210 mm"
+
+#: ../src/common/paper.cpp:147
+msgid "A5 Rotated 210 x 148 mm"
+msgstr "A5 Rotated 210 x 148 mm"
+
+#: ../src/common/paper.cpp:148
+msgid "B4 (JIS) Rotated 364 x 257 mm"
+msgstr "B4 (JIS) Rotated 364 x 257 mm"
+
+#: ../src/common/paper.cpp:149
+msgid "B5 (JIS) Rotated 257 x 182 mm"
+msgstr "B5 (JIS) Rotated 257 x 182 mm"
+
+#: ../src/common/paper.cpp:150
+msgid "Japanese Postcard Rotated 148 x 100 mm"
+msgstr "Japanese Postcard Rotated 148 x 100 mm"
+
+#: ../src/common/paper.cpp:151
+msgid "Double Japanese Postcard Rotated 148 x 200 mm"
+msgstr "Double Japanese Postcard Rotated 148 x 200 mm"
+
+#: ../src/common/paper.cpp:152
+msgid "A6 Rotated 148 x 105 mm"
+msgstr "A6 Rotated 148 x 105 mm"
+
+#: ../src/common/paper.cpp:153
+msgid "Japanese Envelope Kaku #2 Rotated"
+msgstr "Japanese Envelope Kaku #2 Rotated"
+
+#: ../src/common/paper.cpp:154
+msgid "Japanese Envelope Kaku #3 Rotated"
+msgstr "Japanese Envelope Kaku #3 Rotated"
+
+#: ../src/common/paper.cpp:155
+msgid "Japanese Envelope Chou #3 Rotated"
+msgstr "Japanese Envelope Chou #3 Rotated"
+
+#: ../src/common/paper.cpp:156
+msgid "Japanese Envelope Chou #4 Rotated"
+msgstr "Japanese Envelope Chou #4 Rotated"
+
+#: ../src/common/paper.cpp:157
+msgid "B6 (JIS) 128 x 182 mm"
+msgstr "B6 (JIS) 128 x 182 mm"
+
+#: ../src/common/paper.cpp:158
+msgid "B6 (JIS) Rotated 182 x 128 mm"
+msgstr "B6 (JIS) Rotated 182 x 128 mm"
+
+#: ../src/common/paper.cpp:159
+msgid "12 x 11 in"
+msgstr "12 x 11 in"
+
+#: ../src/common/paper.cpp:160
+msgid "Japanese Envelope You #4"
+msgstr "Japanese Envelope You #4"
+
+#: ../src/common/paper.cpp:161
+msgid "Japanese Envelope You #4 Rotated"
+msgstr "Japanese Envelope You #4 Rotated"
+
+#: ../src/common/paper.cpp:162
+msgid "PRC 16K 146 x 215 mm"
+msgstr "PRC 16K 146 x 215 mm"
+
+#: ../src/common/paper.cpp:163
+msgid "PRC 32K 97 x 151 mm"
+msgstr "PRC 32K 97 x 151 mm"
+
+#: ../src/common/paper.cpp:164
+msgid "PRC 32K(Big) 97 x 151 mm"
+msgstr "PRC 32K(Big) 97 x 151 mm"
+
+#: ../src/common/paper.cpp:165
+msgid "PRC Envelope #1 102 x 165 mm"
+msgstr "PRC Envelope #1 102 x 165 mm"
+
+#: ../src/common/paper.cpp:166
+msgid "PRC Envelope #2 102 x 176 mm"
+msgstr "PRC Envelope #2 102 x 176 mm"
+
+#: ../src/common/paper.cpp:167
+msgid "PRC Envelope #3 125 x 176 mm"
+msgstr "PRC Envelope #3 125 x 176 mm"
+
+#: ../src/common/paper.cpp:168
+msgid "PRC Envelope #4 110 x 208 mm"
+msgstr "PRC Envelope #4 110 x 208 mm"
+
+#: ../src/common/paper.cpp:169
+msgid "PRC Envelope #5 110 x 220 mm"
+msgstr "PRC Envelope #5 110 x 220 mm"
+
+#: ../src/common/paper.cpp:170
+msgid "PRC Envelope #6 120 x 230 mm"
+msgstr "PRC Envelope #6 120 x 230 mm"
+
+#: ../src/common/paper.cpp:171
+msgid "PRC Envelope #7 160 x 230 mm"
+msgstr "PRC Envelope #7 160 x 230 mm"
+
+#: ../src/common/paper.cpp:172
+msgid "PRC Envelope #8 120 x 309 mm"
+msgstr "PRC Envelope #8 120 x 309 mm"
+
+#: ../src/common/paper.cpp:173
+msgid "PRC Envelope #9 229 x 324 mm"
+msgstr "PRC Envelope #9 229 x 324 mm"
+
+#: ../src/common/paper.cpp:174
+msgid "PRC Envelope #10 324 x 458 mm"
+msgstr "PRC Envelope #10 324 x 458 mm"
+
+#: ../src/common/paper.cpp:175
+msgid "PRC 16K Rotated"
+msgstr "PRC 16K Rotated"
+
+#: ../src/common/paper.cpp:176
+msgid "PRC 32K Rotated"
+msgstr "PRC 32K Rotated"
+
+#: ../src/common/paper.cpp:177
+msgid "PRC 32K(Big) Rotated"
+msgstr "PRC 32K(Big) Rotated"
+
+#: ../src/common/paper.cpp:178
+msgid "PRC Envelope #1 Rotated 165 x 102 mm"
+msgstr "PRC Envelope #1 Rotated 165 x 102 mm"
+
+#: ../src/common/paper.cpp:179
+msgid "PRC Envelope #2 Rotated 176 x 102 mm"
+msgstr "PRC Envelope #2 Rotated 176 x 102 mm"
+
+#: ../src/common/paper.cpp:180
+msgid "PRC Envelope #3 Rotated 176 x 125 mm"
+msgstr "PRC Envelope #3 Rotated 176 x 125 mm"
+
+#: ../src/common/paper.cpp:181
+msgid "PRC Envelope #4 Rotated 208 x 110 mm"
+msgstr "PRC Envelope #4 Rotated 208 x 110 mm"
+
+#: ../src/common/paper.cpp:182
+msgid "PRC Envelope #5 Rotated 220 x 110 mm"
+msgstr "PRC Envelope #5 Rotated 220 x 110 mm"
+
+#: ../src/common/paper.cpp:183
+msgid "PRC Envelope #6 Rotated 230 x 120 mm"
+msgstr "PRC Envelope #6 Rotated 230 x 120 mm"
+
+#: ../src/common/paper.cpp:184
+msgid "PRC Envelope #7 Rotated 230 x 160 mm"
+msgstr "PRC Envelope #7 Rotated 230 x 160 mm"
+
+#: ../src/common/paper.cpp:185
+msgid "PRC Envelope #8 Rotated 309 x 120 mm"
+msgstr "PRC Envelope #8 Rotated 309 x 120 mm"
+
+#: ../src/common/paper.cpp:186
+msgid "PRC Envelope #9 Rotated 324 x 229 mm"
+msgstr "PRC Envelope #9 Rotated 324 x 229 mm"
+
+#: ../src/common/paper.cpp:187
+msgid "PRC Envelope #10 Rotated 458 x 324 mm"
+msgstr "PRC Envelope #10 Rotated 458 x 324 mm"
+
+#: ../src/common/paper.cpp:192
+msgid "A0 sheet, 841 x 1189 mm"
+msgstr "A0 sheet, 841 x 1189 mm"
+
+#: ../src/common/paper.cpp:193
+msgid "A1 sheet, 594 x 841 mm"
+msgstr "A1 sheet, 594 x 841 mm"
+
+#: ../src/common/preferencescmn.cpp:37
+msgid "General"
+msgstr "通用"
+
+#: ../src/common/preferencescmn.cpp:40
+msgid "Advanced"
+msgstr "高级"
+
+#: ../src/common/prntbase.cpp:245
+msgid "Generic PostScript"
+msgstr "通用 PostScript"
+
+#: ../src/common/prntbase.cpp:259
+msgid "Ready"
+msgstr "就绪"
+
+#: ../src/common/prntbase.cpp:331
+msgid "Printing Error"
+msgstr "打印错误"
+
+#: ../src/common/prntbase.cpp:413 ../src/common/prntbase.cpp:1597
+#: ../src/generic/prntdlgg.cpp:135 ../src/generic/prntdlgg.cpp:149
+#: ../src/gtk/print.cpp:628 ../src/gtk/print.cpp:646
+msgid "Print"
+msgstr "打印"
+
+#: ../src/common/prntbase.cpp:471 ../src/generic/prntdlgg.cpp:809
+msgid "Page setup"
+msgstr "页面设置"
+
+#: ../src/common/prntbase.cpp:525
+msgid "Please wait while printing..."
+msgstr "正在打印，请稍候..."
+
+#: ../src/common/prntbase.cpp:529
+msgid "Document:"
+msgstr "文档："
+
+#: ../src/common/prntbase.cpp:532
+msgid "Progress:"
+msgstr "进度："
+
+#: ../src/common/prntbase.cpp:533
+msgid "Preparing"
+msgstr "准备中"
+
+#: ../src/common/prntbase.cpp:552
+#, c-format
+msgid "Printing page %d"
+msgstr "正在打印第 %d 页"
+
+#: ../src/common/prntbase.cpp:557
+#, c-format
+msgid "Printing page %d of %d"
+msgstr "正在打印第 %d 页，共 %d 页"
+
+#: ../src/common/prntbase.cpp:560
+#, c-format
+msgid " (copy %d of %d)"
+msgstr "（第 %d 份，共 %d 份）"
+
+#: ../src/common/prntbase.cpp:1604
+msgid "First page"
+msgstr "第一页"
+
+#: ../src/common/prntbase.cpp:1609 ../src/html/helpwnd.cpp:659
+msgid "Previous page"
+msgstr "上一页"
+
+#: ../src/common/prntbase.cpp:1623 ../src/html/helpwnd.cpp:660
+msgid "Next page"
+msgstr "下一页"
+
+#: ../src/common/prntbase.cpp:1628
+msgid "Last page"
+msgstr "最后一页"
+
+#: ../src/common/prntbase.cpp:1636 ../src/common/stockitem.cpp:215
+msgid "Zoom Out"
+msgstr "缩小"
+
+#: ../src/common/prntbase.cpp:1650 ../src/common/stockitem.cpp:214
+msgid "Zoom In"
+msgstr "放大"
+
+#: ../src/common/prntbase.cpp:1656 ../src/common/stockitem.cpp:153
+#: ../src/generic/logg.cpp:553 ../src/univ/themes/win32.cpp:3752
+msgid "&Close"
+msgstr "关闭(&C)"
+
+#: ../src/common/prntbase.cpp:2085
+msgid "Could not start document preview."
+msgstr "无法启动文档预览。"
+
+#: ../src/common/prntbase.cpp:2085 ../src/common/prntbase.cpp:2129
+#: ../src/common/prntbase.cpp:2137
+msgid "Print Preview Failure"
+msgstr "打印预览失败"
+
+#: ../src/common/prntbase.cpp:2129 ../src/common/prntbase.cpp:2137
+msgid "Sorry, not enough memory to create a preview."
+msgstr "内存不足，无法创建预览。"
+
+#: ../src/common/prntbase.cpp:2144
+#, c-format
+msgid "Page %d of %d"
+msgstr "第 %d 页，共 %d 页"
+
+#: ../src/common/prntbase.cpp:2146
+#, c-format
+msgid "Page %d"
+msgstr "第 %d 页"
+
+#: ../src/common/regex.cpp:382 ../src/html/chm.cpp:348
+msgid "unknown error"
+msgstr "未知错误"
+
+#: ../src/common/regex.cpp:995
+#, c-format
+msgid "Invalid regular expression '%s': %s"
+msgstr "无效正则表达式 '%s'：%s"
+
+#: ../src/common/regex.cpp:1059
+#, c-format
+msgid "Failed to find match for regular expression: %s"
+msgstr "未找到与该正则表达式匹配的内容：%s"
+
+#: ../src/common/rendcmn.cpp:188
+#, c-format
+msgid "Renderer \"%s\" has incompatible version %d.%d and couldn't be loaded."
+msgstr "渲染器 \"%s\" 的版本 %d.%d 不兼容，无法加载。"
+
+#: ../src/common/secretstore.cpp:162
+msgid "Not available for this platform"
+msgstr "此平台不支持"
+
+#: ../src/common/secretstore.cpp:183
+#, c-format
+msgid "Saving password for \"%s\" failed: %s."
+msgstr "保存 \"%s\" 的密码失败：%s。"
+
+#: ../src/common/secretstore.cpp:205
+#, c-format
+msgid "Reading password for \"%s\" failed: %s."
+msgstr "读取 \"%s\" 的密码失败：%s。"
+
+#: ../src/common/secretstore.cpp:228
+#, c-format
+msgid "Deleting password for \"%s\" failed: %s."
+msgstr "无法删除 \"%s\" 的密码：%s。"
+
+#: ../src/common/selectdispatcher.cpp:254
+msgid "Failed to monitor I/O channels"
+msgstr "无法监视 I/O 通道"
+
+#: ../src/common/sizer.cpp:3054 ../src/common/stockitem.cpp:195
+msgid "Save"
+msgstr "保存"
+
+#: ../src/common/sizer.cpp:3056
+msgid "Don't Save"
+msgstr "不保存"
+
+#: ../src/common/socket.cpp:870
+msgid "Cannot initialize sockets"
+msgstr "无法初始化套接字"
+
+#: ../src/common/stockitem.cpp:127
+msgctxt "standard Windows menu"
+msgid "&Help"
+msgstr "帮助(&H)"
+
+#: ../src/common/stockitem.cpp:144
+msgid "&About"
+msgstr "关于(&A)"
+
+#: ../src/common/stockitem.cpp:144
+msgid "About"
+msgstr "关于"
+
+#: ../src/common/stockitem.cpp:145
+msgid "Add"
+msgstr "添加"
+
+#: ../src/common/stockitem.cpp:146
+msgid "&Apply"
+msgstr "应用(&A)"
+
+#: ../src/common/stockitem.cpp:146
+msgid "Apply"
+msgstr "应用"
+
+#: ../src/common/stockitem.cpp:147
+msgid "&Back"
+msgstr "返回(&B)"
+
+#: ../src/common/stockitem.cpp:147
+msgid "Back"
+msgstr "返回"
+
+#: ../src/common/stockitem.cpp:148
+msgid "&Bold"
+msgstr "粗体(&B)"
+
+#: ../src/common/stockitem.cpp:148 ../src/generic/fontdlgg.cpp:326
+#: ../src/richtext/richtextfontpage.cpp:354
+msgid "Bold"
+msgstr "粗体"
+
+#: ../src/common/stockitem.cpp:149
+msgid "&Bottom"
+msgstr "底部(&B)"
+
+#: ../src/common/stockitem.cpp:149 ../src/richtext/richtextsizepage.cpp:287
+msgid "Bottom"
+msgstr "底部"
+
+#: ../src/common/stockitem.cpp:150 ../src/generic/fontdlgg.cpp:462
+#: ../src/generic/fontdlgg.cpp:481 ../src/generic/wizard.cpp:415
+msgid "&Cancel"
+msgstr "取消(&C)"
+
+#: ../src/common/stockitem.cpp:151
+msgid "&CD-ROM"
+msgstr "CD 光驱(&C)"
+
+#: ../src/common/stockitem.cpp:151
+msgid "CD-ROM"
+msgstr "CD 光驱"
+
+#: ../src/common/stockitem.cpp:152
+msgid "&Clear"
+msgstr "清除(&C)"
+
+#: ../src/common/stockitem.cpp:152
+msgid "Clear"
+msgstr "清除"
+
+#: ../src/common/stockitem.cpp:153 ../src/generic/dbgrptg.cpp:93
+#: ../src/generic/progdlgg.cpp:778 ../src/html/helpdlg.cpp:86
+#: ../src/msw/progdlg.cpp:209 ../src/msw/progdlg.cpp:890
+#: ../src/richtext/richtextstyledlg.cpp:272
+#: ../src/richtext/richtextsymboldlg.cpp:448
+msgid "Close"
+msgstr "关闭"
+
+#: ../src/common/stockitem.cpp:154
+msgid "&Convert"
+msgstr "转换(&C)"
+
+#: ../src/common/stockitem.cpp:154
+msgid "Convert"
+msgstr "转换"
+
+#: ../src/common/stockitem.cpp:155 ../src/msw/textctrl.cpp:2884
+#: ../src/osx/textctrl_osx.cpp:653 ../src/richtext/richtextctrl.cpp:331
+msgid "&Copy"
+msgstr "复制(&C)"
+
+#: ../src/common/stockitem.cpp:155 ../src/stc/stc_i18n.cpp:18
+msgid "Copy"
+msgstr "复制"
+
+#: ../src/common/stockitem.cpp:156 ../src/msw/textctrl.cpp:2883
+#: ../src/osx/textctrl_osx.cpp:652 ../src/richtext/richtextctrl.cpp:330
+msgid "Cu&t"
+msgstr "剪切(&T)"
+
+#: ../src/common/stockitem.cpp:156 ../src/stc/stc_i18n.cpp:17
+msgid "Cut"
+msgstr "剪切"
+
+#: ../src/common/stockitem.cpp:157 ../src/msw/textctrl.cpp:2886
+#: ../src/osx/textctrl_osx.cpp:655 ../src/richtext/richtextctrl.cpp:333
+#: ../src/richtext/richtexttabspage.cpp:137
+msgid "&Delete"
+msgstr "删除(&D)"
+
+#: ../src/common/stockitem.cpp:157 ../src/richtext/richtextbuffer.cpp:8266
+#: ../src/stc/stc_i18n.cpp:20
+msgid "Delete"
+msgstr "删除"
+
+#: ../src/common/stockitem.cpp:158
+msgid "&Down"
+msgstr "向下(&D)"
+
+#: ../src/common/stockitem.cpp:158 ../src/generic/fdrepdlg.cpp:148
+msgid "Down"
+msgstr "向下"
+
+#: ../src/common/stockitem.cpp:159
+msgid "&Edit"
+msgstr "编辑(&E)"
+
+#: ../src/common/stockitem.cpp:159
+msgid "Edit"
+msgstr "编辑"
+
+#: ../src/common/stockitem.cpp:160
+msgid "&Execute"
+msgstr "执行(&E)"
+
+#: ../src/common/stockitem.cpp:160
+msgid "Execute"
+msgstr "执行"
+
+#: ../src/common/stockitem.cpp:161
+msgid "&Quit"
+msgstr "退出(&Q)"
+
+#: ../src/common/stockitem.cpp:161
+msgid "Quit"
+msgstr "退出"
+
+#: ../src/common/stockitem.cpp:162
+msgid "&File"
+msgstr "文件(&F)"
+
+#: ../src/common/stockitem.cpp:162
+msgid "File"
+msgstr "文件"
+
+#: ../src/common/stockitem.cpp:163
+msgid "&Find..."
+msgstr "查找(&F)..."
+
+#: ../src/common/stockitem.cpp:163
+msgid "Find..."
+msgstr "查找..."
+
+#: ../src/common/stockitem.cpp:164
+msgid "&First"
+msgstr "最前(&F)"
+
+#: ../src/common/stockitem.cpp:164
+msgid "First"
+msgstr "最前"
+
+#: ../src/common/stockitem.cpp:165
+msgid "&Floppy"
+msgstr "软盘(&F)"
+
+#: ../src/common/stockitem.cpp:165
+msgid "Floppy"
+msgstr "软盘"
+
+#: ../src/common/stockitem.cpp:166
+msgid "&Forward"
+msgstr "前进(&F)"
+
+#: ../src/common/stockitem.cpp:166
+msgid "Forward"
+msgstr "前进"
+
+#: ../src/common/stockitem.cpp:167
+msgid "&Harddisk"
+msgstr "硬盘(&H)"
+
+#: ../src/common/stockitem.cpp:167
+msgid "Harddisk"
+msgstr "硬盘"
+
+#: ../src/common/stockitem.cpp:168 ../src/generic/wizard.cpp:418
+#: ../src/osx/cocoa/menu.mm:225 ../src/richtext/richtextstyledlg.cpp:298
+#: ../src/richtext/richtextsymboldlg.cpp:451
+msgid "&Help"
+msgstr "帮助(&H)"
+
+#: ../src/common/stockitem.cpp:169
+msgid "&Home"
+msgstr "主页(&H)"
+
+#: ../src/common/stockitem.cpp:169
+msgid "Home"
+msgstr "主页"
+
+#: ../src/common/stockitem.cpp:170
+msgid "Indent"
+msgstr "缩进"
+
+#: ../src/common/stockitem.cpp:171
+msgid "&Index"
+msgstr "索引(&I)"
+
+#: ../src/common/stockitem.cpp:171 ../src/html/helpwnd.cpp:510
+msgid "Index"
+msgstr "索引"
+
+#: ../src/common/stockitem.cpp:172
+msgid "&Info"
+msgstr "信息(&I)"
+
+#: ../src/common/stockitem.cpp:172
+msgid "Info"
+msgstr "信息"
+
+#: ../src/common/stockitem.cpp:173
+msgid "&Italic"
+msgstr "斜体(&I)"
+
+#: ../src/common/stockitem.cpp:173 ../src/generic/fontdlgg.cpp:322
+#: ../src/richtext/richtextfontpage.cpp:350
+msgid "Italic"
+msgstr "斜体"
+
+#: ../src/common/stockitem.cpp:174
+msgid "&Jump to"
+msgstr "转到(&J)"
+
+#: ../src/common/stockitem.cpp:174
+msgid "Jump to"
+msgstr "转到"
+
+#: ../src/common/stockitem.cpp:175
+msgid "Centered"
+msgstr "居中"
+
+#: ../src/common/stockitem.cpp:176
+msgid "Justified"
+msgstr "两端对齐"
+
+#: ../src/common/stockitem.cpp:177
+msgid "Align Left"
+msgstr "左对齐"
+
+#: ../src/common/stockitem.cpp:178
+msgid "Align Right"
+msgstr "右对齐"
+
+#: ../src/common/stockitem.cpp:179
+msgid "&Last"
+msgstr "最后(&L)"
+
+#: ../src/common/stockitem.cpp:179
+msgid "Last"
+msgstr "最后"
+
+#: ../src/common/stockitem.cpp:180
+msgid "&Network"
+msgstr "网络(&N)"
+
+#: ../src/common/stockitem.cpp:180
+msgid "Network"
+msgstr "网络"
+
+#: ../src/common/stockitem.cpp:181 ../src/richtext/richtexttabspage.cpp:131
+msgid "&New"
+msgstr "新建(&N)"
+
+#: ../src/common/stockitem.cpp:181
+msgid "New"
+msgstr "新建"
+
+#: ../src/common/stockitem.cpp:182 ../src/msw/msgdlg.cpp:417
+msgid "&No"
+msgstr "否(&N)"
+
+#: ../src/common/stockitem.cpp:183 ../src/generic/fontdlgg.cpp:467
+#: ../src/generic/fontdlgg.cpp:474
+msgid "&OK"
+msgstr "确定(&O)"
+
+#: ../src/common/stockitem.cpp:184 ../src/generic/dbgrptg.cpp:341
+msgid "&Open..."
+msgstr "打开(&O)..."
+
+#: ../src/common/stockitem.cpp:184
+msgid "Open..."
+msgstr "打开..."
+
+#: ../src/common/stockitem.cpp:185 ../src/msw/textctrl.cpp:2885
+#: ../src/osx/textctrl_osx.cpp:654 ../src/richtext/richtextctrl.cpp:332
+msgid "&Paste"
+msgstr "粘贴(&P)"
+
+#: ../src/common/stockitem.cpp:185 ../src/richtext/richtextctrl.cpp:3484
+#: ../src/stc/stc_i18n.cpp:19
+msgid "Paste"
+msgstr "粘贴"
+
+#: ../src/common/stockitem.cpp:186
+msgid "&Preferences"
+msgstr "首选项(&P)"
+
+#: ../src/common/stockitem.cpp:186 ../src/osx/cocoa/preferences.mm:304
+msgid "Preferences"
+msgstr "首选项"
+
+#: ../src/common/stockitem.cpp:187
+msgid "Print previe&w..."
+msgstr "打印预览(&W)..."
+
+#: ../src/common/stockitem.cpp:187
+msgid "Print preview..."
+msgstr "打印预览..."
+
+#: ../src/common/stockitem.cpp:188
+msgid "&Print..."
+msgstr "打印(&P)..."
+
+#: ../src/common/stockitem.cpp:188
+msgid "Print..."
+msgstr "打印..."
+
+#: ../src/common/stockitem.cpp:189 ../src/richtext/richtextctrl.cpp:337
+#: ../src/richtext/richtextctrl.cpp:5479
+msgid "&Properties"
+msgstr "属性(&P)"
+
+#: ../src/common/stockitem.cpp:189
+msgid "Properties"
+msgstr "属性"
+
+#: ../src/common/stockitem.cpp:190 ../src/stc/stc_i18n.cpp:16
+msgid "Redo"
+msgstr "重做"
+
+#: ../src/common/stockitem.cpp:191
+msgid "Refresh"
+msgstr "刷新"
+
+#: ../src/common/stockitem.cpp:192
+msgid "Remove"
+msgstr "移除"
+
+#: ../src/common/stockitem.cpp:193
+msgid "Rep&lace..."
+msgstr "替换(&L)..."
+
+#: ../src/common/stockitem.cpp:193
+msgid "Replace..."
+msgstr "替换..."
+
+#: ../src/common/stockitem.cpp:194
+msgid "Revert to Saved"
+msgstr "还原到已保存状态"
+
+#: ../src/common/stockitem.cpp:196 ../src/generic/logg.cpp:549
+msgid "Save &As..."
+msgstr "另存为(&A)..."
+
+#: ../src/common/stockitem.cpp:196
+msgid "Save As..."
+msgstr "另存为..."
+
+#: ../src/common/stockitem.cpp:197 ../src/msw/textctrl.cpp:2888
+#: ../src/osx/textctrl_osx.cpp:657 ../src/richtext/richtextctrl.cpp:335
+msgid "Select &All"
+msgstr "全选(&A)"
+
+#: ../src/common/stockitem.cpp:197 ../src/stc/stc_i18n.cpp:21
+msgid "Select All"
+msgstr "全选"
+
+#: ../src/common/stockitem.cpp:198
+msgid "&Color"
+msgstr "颜色(&C)"
+
+#: ../src/common/stockitem.cpp:198
+msgid "Color"
+msgstr "颜色"
+
+#: ../src/common/stockitem.cpp:199
+msgid "&Font"
+msgstr "字体(&F)"
+
+#: ../src/common/stockitem.cpp:199 ../src/richtext/richtextformatdlg.cpp:336
+msgid "Font"
+msgstr "字体"
+
+#: ../src/common/stockitem.cpp:200
+msgid "&Ascending"
+msgstr "升序(&A)"
+
+#: ../src/common/stockitem.cpp:200
+msgid "Ascending"
+msgstr "升序"
+
+#: ../src/common/stockitem.cpp:201
+msgid "&Descending"
+msgstr "降序(&D)"
+
+#: ../src/common/stockitem.cpp:201
+msgid "Descending"
+msgstr "降序"
+
+#: ../src/common/stockitem.cpp:202
+msgid "&Spell Check"
+msgstr "拼写检查(&S)"
+
+#: ../src/common/stockitem.cpp:202
+msgid "Spell Check"
+msgstr "拼写检查"
+
+#: ../src/common/stockitem.cpp:203
+msgid "&Stop"
+msgstr "停止(&S)"
+
+#: ../src/common/stockitem.cpp:203
+msgid "Stop"
+msgstr "停止"
+
+#: ../src/common/stockitem.cpp:204 ../src/richtext/richtextfontpage.cpp:274
+msgid "&Strikethrough"
+msgstr "删除线(&S)"
+
+#: ../src/common/stockitem.cpp:204
+msgid "Strikethrough"
+msgstr "删除线"
+
+#: ../src/common/stockitem.cpp:205
+msgid "&Top"
+msgstr "顶部(&T)"
+
+#: ../src/common/stockitem.cpp:205 ../src/richtext/richtextsizepage.cpp:285
+#: ../src/richtext/richtextsizepage.cpp:289
+msgid "Top"
+msgstr "顶部"
+
+#: ../src/common/stockitem.cpp:206
+msgid "Undelete"
+msgstr "取消删除"
+
+#: ../src/common/stockitem.cpp:207 ../src/generic/fontdlgg.cpp:437
+msgid "&Underline"
+msgstr "下划线(&U)"
+
+#: ../src/common/stockitem.cpp:207
+msgid "Underline"
+msgstr "下划线"
+
+#: ../src/common/stockitem.cpp:208 ../src/stc/stc_i18n.cpp:15
+msgid "Undo"
+msgstr "撤销"
+
+#: ../src/common/stockitem.cpp:209
+msgid "&Unindent"
+msgstr "取消缩进(&U)"
+
+#: ../src/common/stockitem.cpp:209
+msgid "Unindent"
+msgstr "取消缩进"
+
+#: ../src/common/stockitem.cpp:210
+msgid "&Up"
+msgstr "向上(&U)"
+
+#: ../src/common/stockitem.cpp:210 ../src/generic/fdrepdlg.cpp:148
+msgid "Up"
+msgstr "向上"
+
+#: ../src/common/stockitem.cpp:211 ../src/msw/msgdlg.cpp:417
+msgid "&Yes"
+msgstr "是(&Y)"
+
+#: ../src/common/stockitem.cpp:212
+msgid "&Actual Size"
+msgstr "实际大小(&A)"
+
+#: ../src/common/stockitem.cpp:212
+msgid "Actual Size"
+msgstr "实际大小"
+
+#: ../src/common/stockitem.cpp:213
+msgid "Zoom to &Fit"
+msgstr "缩放以适应窗口(&F)"
+
+#: ../src/common/stockitem.cpp:213
+msgid "Zoom to Fit"
+msgstr "缩放以适应窗口"
+
+#: ../src/common/stockitem.cpp:214
+msgid "Zoom &In"
+msgstr "放大(&I)"
+
+#: ../src/common/stockitem.cpp:215
+msgid "Zoom &Out"
+msgstr "缩小(&O)"
+
+#: ../src/common/stockitem.cpp:262
+msgid "Show about dialog"
+msgstr "显示关于对话框"
+
+#: ../src/common/stockitem.cpp:263
+msgid "Copy selection"
+msgstr "复制所选内容"
+
+#: ../src/common/stockitem.cpp:264
+msgid "Cut selection"
+msgstr "剪切所选内容"
+
+#: ../src/common/stockitem.cpp:265
+msgid "Delete selection"
+msgstr "删除所选内容"
+
+#: ../src/common/stockitem.cpp:266
+msgid "Find in document"
+msgstr "在文档中查找"
+
+#: ../src/common/stockitem.cpp:267
+msgid "Find and replace in document"
+msgstr "在文档中查找和替换"
+
+#: ../src/common/stockitem.cpp:268
+msgid "Paste selection"
+msgstr "粘贴所选内容"
+
+#: ../src/common/stockitem.cpp:269
+msgid "Quit this program"
+msgstr "退出此程序"
+
+#: ../src/common/stockitem.cpp:270
+msgid "Redo last action"
+msgstr "重做上一次操作"
+
+#: ../src/common/stockitem.cpp:271
+msgid "Undo last action"
+msgstr "撤销上一次操作"
+
+#: ../src/common/stockitem.cpp:272
+msgid "Create new document"
+msgstr "创建新文档"
+
+#: ../src/common/stockitem.cpp:273
+msgid "Open an existing document"
+msgstr "打开现有文档"
+
+#: ../src/common/stockitem.cpp:274
+msgid "Close current document"
+msgstr "关闭当前文档"
+
+#: ../src/common/stockitem.cpp:275
+msgid "Save current document"
+msgstr "保存当前文档"
+
+#: ../src/common/stockitem.cpp:276
+msgid "Save current document with a different filename"
+msgstr "以其他文件名保存当前文档"
+
+#: ../src/common/strconv.cpp:2324
+#, c-format
+msgid "Conversion to charset '%s' doesn't work."
+msgstr "无法转换为字符集 '%s'。"
+
+#: ../src/common/tarstrm.cpp:352 ../src/common/tarstrm.cpp:375
+#: ../src/common/tarstrm.cpp:406 ../src/generic/progdlgg.cpp:373
+msgid "unknown"
+msgstr "未知"
+
+#: ../src/common/tarstrm.cpp:774
+msgid "incomplete header block in tar"
+msgstr "tar 头块不完整"
+
+#: ../src/common/tarstrm.cpp:798
+msgid "checksum failure reading tar header block"
+msgstr "读取 tar 头块时校验和错误"
+
+#: ../src/common/tarstrm.cpp:971
+msgid "invalid data in extended tar header"
+msgstr "tar 扩展头中的数据无效"
+
+#: ../src/common/tarstrm.cpp:981 ../src/common/tarstrm.cpp:1003
+#: ../src/common/tarstrm.cpp:1477 ../src/common/tarstrm.cpp:1499
+msgid "tar entry not open"
+msgstr "tar 条目尚未打开"
+
+#: ../src/common/tarstrm.cpp:1023
+msgid "unexpected end of file"
+msgstr "文件意外结束"
+
+#: ../src/common/tarstrm.cpp:1297
+#, c-format
+msgid "%s did not fit the tar header for entry '%s'"
+msgstr "%1$s 无法写入 tar 条目 '%2$s' 的头部"
+
+#: ../src/common/tarstrm.cpp:1359
+msgid "incorrect size given for tar entry"
+msgstr "tar 条目给定的大小不正确"
+
+#: ../src/common/textbuf.cpp:232
+#, c-format
+msgid "'%s' is probably a binary buffer."
+msgstr "'%s' 可能是二进制缓冲区。"
+
+#: ../src/common/textcmn.cpp:1006 ../src/richtext/richtextctrl.cpp:3053
+msgid "File couldn't be loaded."
+msgstr "无法加载文件。"
+
+#: ../src/common/textfile.cpp:95
+#, c-format
+msgid "Failed to read text file \"%s\"."
+msgstr "无法读取文本文件 \"%s\"。"
+
+#: ../src/common/textfile.cpp:160
+#, c-format
+msgid "can't write buffer '%s' to disk."
+msgstr "无法将缓冲区 '%s' 写入磁盘。"
+
+#: ../src/common/time.cpp:212
+msgid "Failed to get the local system time"
+msgstr "无法获取本地系统时间"
+
+#: ../src/common/time.cpp:279
+msgid "wxGetTimeOfDay failed."
+msgstr "wxGetTimeOfDay 失败。"
+
+#: ../src/common/translation.cpp:929
+#, c-format
+msgid "'%s' is not a valid message catalog."
+msgstr "'%s' 不是有效的消息目录。"
+
+#: ../src/common/translation.cpp:954
+msgid "Invalid message catalog."
+msgstr "无效的消息目录。"
+
+#: ../src/common/translation.cpp:1013
+#, c-format
+msgid "Failed to parse Plural-Forms: '%s'"
+msgstr "无法解析复数形式：'%s'"
+
+#: ../src/common/translation.cpp:1723
+#, c-format
+msgid "using catalog '%s' from '%s'."
+msgstr "正在使用消息目录 '%s'（来自 '%s'）。"
+
+#: ../src/common/translation.cpp:1816
+#, c-format
+msgid "Resource '%s' is not a valid message catalog."
+msgstr "资源 '%s' 不是有效的消息目录。"
+
+#: ../src/common/translation.cpp:1865
+msgid "Couldn't enumerate translations"
+msgstr "无法列出可用翻译"
+
+#: ../src/common/utilscmn.cpp:1145
+msgid "No default application configured for HTML files."
+msgstr "未为 HTML 文件配置默认应用程序。"
+
+#: ../src/common/utilscmn.cpp:1190
+#, c-format
+msgid "Failed to open URL \"%s\" in default browser."
+msgstr "无法在默认浏览器中打开 URL \"%s\"。"
+
+#: ../src/common/valtext.cpp:144
+msgid "Validation conflict"
+msgstr "验证失败"
+
+#: ../src/common/valtext.cpp:186
+msgid "Required information entry is empty."
+msgstr "必填项不能为空。"
+
+#: ../src/common/valtext.cpp:188
+#, c-format
+msgid "'%s' is one of the invalid strings"
+msgstr "'%s' 是无效的字符串"
+
+#: ../src/common/valtext.cpp:190
+#, c-format
+msgid "'%s' is not one of the valid strings"
+msgstr "'%s' 不是有效的字符串"
+
+#: ../src/common/valtext.cpp:199
+#, c-format
+msgid "'%s' contains invalid character(s)"
+msgstr "'%s' 包含无效字符"
+
+#: ../src/common/webrequest.cpp:139
+#, c-format
+msgid "Error: %s (%d)"
+msgstr "错误：%s（%d）"
+
+#: ../src/common/webrequest.cpp:655
+#, c-format
+msgid ""
+"Not enough free disk space for download: %llu needed but only %llu available."
+msgstr "磁盘剩余空间不足，无法下载：需要 %llu 字节，但仅有 %llu 字节可用。"
+
+#: ../src/common/webrequest.cpp:669
+#, c-format
+msgid "Failed to create temporary file in %s"
+msgstr "无法在 %s 中创建临时文件"
+
+#: ../src/common/webrequest_curl.cpp:1106
+msgid "libcurl could not be initialized"
+msgstr "libcurl 无法初始化"
+
+#: ../src/common/webview.cpp:392
+msgid "RunScriptAsync not supported"
+msgstr "不支持 RunScriptAsync"
+
+#: ../src/common/webview.cpp:403 ../src/msw/webview_ie.cpp:1073
+#, c-format
+msgid "Error running JavaScript: %s"
+msgstr "运行 JavaScript 时出错：%s"
+
+#: ../src/common/webview_chromium.cpp:858
+#, c-format
+msgid "Failed to set proxy \"%s\": %s"
+msgstr "设置代理 \"%s\" 失败：%s"
+
+#: ../src/common/webview_chromium.cpp:989
+msgid ""
+"Chromium can't be used because libcef.so wasn't loaded early enough; please "
+"relink the application or use LD_PRELOAD to load it earlier."
+msgstr ""
+"无法使用 Chromium，因为 libcef.so 未被提前加载；请重新链接应用程序或使用 "
+"LD_PRELOAD 提前加载。"
+
+#: ../src/common/webview_chromium.cpp:1108
+msgid "Could not initialize Chromium"
+msgstr "无法初始化 Chromium"
+
+#: ../src/common/webview_chromium.cpp:1616
+msgid "Show DevTools"
+msgstr "显示开发者工具"
+
+#: ../src/common/webview_chromium.cpp:1617
+msgid "Close DevTools"
+msgstr "关闭开发者工具"
+
+#: ../src/common/webview_chromium.cpp:1623
+msgid "Inspect"
+msgstr "检查元素"
+
+#: ../src/common/wincmn.cpp:1628
+msgid "This platform does not support background transparency."
+msgstr "该平台不支持背景透明度。"
+
+#: ../src/common/wincmn.cpp:2097
+msgid "Could not transfer data to window"
+msgstr "无法将数据传输到窗口"
+
+#: ../src/common/windowid.cpp:240
+msgid "Out of window IDs.  Recommend shutting down application."
+msgstr "窗口 ID 已耗尽。建议退出应用程序。"
+
+#: ../src/common/xpmdecod.cpp:678
+msgid "XPM: incorrect header format!"
+msgstr "XPM：头部格式不正确！"
+
+#: ../src/common/xpmdecod.cpp:703
+#, c-format
+msgid "XPM: incorrect colour description in line %d"
+msgstr "XPM：第 %d 行的颜色描述不正确"
+
+#: ../src/common/xpmdecod.cpp:715 ../src/common/xpmdecod.cpp:724
+#, c-format
+msgid "XPM: malformed colour definition '%s' at line %d!"
+msgstr "XPM：第 %2$d 行的颜色定义 '%1$s' 格式错误！"
+
+#: ../src/common/xpmdecod.cpp:754
+msgid "XPM: no colors left to use for mask!"
+msgstr "XPM：没有剩余颜色可用于蒙版！"
+
+#: ../src/common/xpmdecod.cpp:781
+#, c-format
+msgid "XPM: truncated image data at line %d!"
+msgstr "XPM：第 %d 行的图像数据被截断！"
+
+#: ../src/common/xpmdecod.cpp:795
+msgid "XPM: Malformed pixel data!"
+msgstr "XPM：像素数据格式错误！"
+
+#: ../src/common/xti.cpp:492
+msgid "Illegal Parameter Count for Create Method"
+msgstr "Create 方法的参数数量无效"
+
+#: ../src/common/xti.cpp:504
+msgid "Illegal Parameter Count for ConstructObject Method"
+msgstr "ConstructObject 方法的参数个数不正确"
+
+#: ../src/common/xtistrm.cpp:161
+#, c-format
+msgid "Create Parameter %s not found in declared RTTI Parameters"
+msgstr "在声明的 RTTI 参数里找不到创建参数 %s"
+
+#: ../src/common/xtistrm.cpp:290
+msgid "Illegal Object Class (Non-wxEvtHandler) as Event Source"
+msgstr "事件源对象类型无效（非 wxEvtHandler）"
+
+#: ../src/common/xtistrm.cpp:313 ../src/common/xtixml.cpp:345
+#: ../src/common/xtixml.cpp:498
+msgid "Type must have enum - long conversion"
+msgstr "类型必须支持 enum 与 long 的转换"
+
+#: ../src/common/xtistrm.cpp:400 ../src/common/xtistrm.cpp:415
+msgid "Invalid or Null Object ID passed to GetObjectClassInfo"
+msgstr "向 GetObjectClassInfo 传入无效或空的对象 ID"
+
+#: ../src/common/xtistrm.cpp:405
+msgid "Unknown Object passed to GetObjectClassInfo"
+msgstr "向 GetObjectClassInfo 传入未知对象"
+
+#: ../src/common/xtistrm.cpp:420
+msgid "Already Registered Object passed to SetObjectClassInfo"
+msgstr "向 SetObjectClassInfo 传入已注册对象"
+
+#: ../src/common/xtistrm.cpp:430
+msgid "Invalid or Null Object ID passed to HasObjectClassInfo"
+msgstr "向 HasObjectClassInfo 传入无效或空的对象 ID"
+
+#: ../src/common/xtistrm.cpp:460
+msgid "Passing a already registered object to SetObject"
+msgstr "向 SetObject 传入已注册对象"
+
+#: ../src/common/xtistrm.cpp:471
+msgid "Passing an unknown object to GetObject"
+msgstr "向 GetObject 传入未知对象"
+
+#: ../src/common/xtixml.cpp:229
+msgid "Forward hrefs are not supported"
+msgstr "不支持前向 href（引用尚未读取的对象）"
+
+#: ../src/common/xtixml.cpp:247
+#, c-format
+msgid "unknown class %s"
+msgstr "未知类 %s"
+
+#: ../src/common/xtixml.cpp:253
+msgid "objects cannot have XML Text Nodes"
+msgstr "对象不能包含 XML 文本节点"
+
+#: ../src/common/xtixml.cpp:258
+msgid "Objects must have an id attribute"
+msgstr "对象必须具有 id 属性"
+
+#: ../src/common/xtixml.cpp:267
+#, c-format
+msgid "Doubly used id : %d"
+msgstr "重复的 id：%d"
+
+#: ../src/common/xtixml.cpp:316
+#, c-format
+msgid "Unknown Property %s"
+msgstr "未知属性：%s"
+
+#: ../src/common/xtixml.cpp:407
+msgid "A non empty collection must consist of 'element' nodes"
+msgstr "非空集合必须包含 'element' 节点"
+
+#: ../src/common/xtixml.cpp:478
+msgid "incorrect event handler string, missing dot"
+msgstr "事件处理函数字符串无效：缺少点号('.')"
+
+#: ../src/common/zipstrm.cpp:559
+msgid "can't re-initialize zlib deflate stream"
+msgstr "无法重新初始化 zlib 压缩流"
+
+#: ../src/common/zipstrm.cpp:584
+msgid "can't re-initialize zlib inflate stream"
+msgstr "无法重新初始化 zlib 解压流"
+
+#: ../src/common/zipstrm.cpp:1023
+msgid "Ignoring malformed extra data record, ZIP file may be corrupted"
+msgstr "忽略格式错误的额外数据记录，ZIP 文件可能已损坏"
+
+#: ../src/common/zipstrm.cpp:1502
+msgid "assuming this is a multi-part zip concatenated"
+msgstr "推测这是拼接的分卷 ZIP 文件"
+
+#: ../src/common/zipstrm.cpp:1664
+msgid "invalid zip file"
+msgstr "无效的 zip 文件"
+
+#: ../src/common/zipstrm.cpp:1723
+msgid "can't find central directory in zip"
+msgstr "ZIP 文件中找不到中央目录"
+
+#: ../src/common/zipstrm.cpp:1812
+msgid "error reading zip central directory"
+msgstr "读取 ZIP 中央目录时出错"
+
+#: ../src/common/zipstrm.cpp:1916
+msgid "error reading zip local header"
+msgstr "读取 ZIP 本地文件头时出错"
+
+#: ../src/common/zipstrm.cpp:1964
+msgid "bad zipfile offset to entry"
+msgstr "ZIP 文件到条目的偏移值错误"
+
+#: ../src/common/zipstrm.cpp:2031
+msgid "stored file length not in Zip header"
+msgstr "ZIP 文件头中缺少已存文件长度信息"
+
+#: ../src/common/zipstrm.cpp:2045 ../src/common/zipstrm.cpp:2362
+msgid "unsupported Zip compression method"
+msgstr "不支持的 ZIP 压缩方法"
+
+#: ../src/common/zipstrm.cpp:2126
+#, c-format
+msgid "reading zip stream (entry %s): bad length"
+msgstr "读取 ZIP 流（条目 %s）：长度错误"
+
+#: ../src/common/zipstrm.cpp:2131
+#, c-format
+msgid "reading zip stream (entry %s): bad crc"
+msgstr "读取 ZIP 流（条目 %s）：CRC 校验错误"
+
+#: ../src/common/zipstrm.cpp:2578
+#, c-format
+msgid "error writing zip entry '%s': file too large without ZIP64"
+msgstr "写入 ZIP 条目 '%s' 时出错：文件过大且未使用 ZIP64"
+
+#: ../src/common/zipstrm.cpp:2585
+#, c-format
+msgid "error writing zip entry '%s': bad crc or length"
+msgstr "写入 ZIP 条目 '%s' 时出错：CRC 校验或长度错误"
+
+#: ../src/common/zstream.cpp:155 ../src/common/zstream.cpp:315
+msgid "Gzip not supported by this version of zlib"
+msgstr "此版本的 zlib 不支持 Gzip"
+
+#: ../src/common/zstream.cpp:182
+msgid "Can't initialize zlib inflate stream."
+msgstr "无法初始化 zlib 解压流。"
+
+#: ../src/common/zstream.cpp:241
+msgid "Can't read inflate stream: unexpected EOF in underlying stream."
+msgstr "无法读取解压流：底层流意外到达 EOF。"
+
+#: ../src/common/zstream.cpp:248 ../src/common/zstream.cpp:423
+#, c-format
+msgid "zlib error %d"
+msgstr "zlib 错误 %d"
+
+#: ../src/common/zstream.cpp:249
+#, c-format
+msgid "Can't read from inflate stream: %s"
+msgstr "无法从解压流读取：%s"
+
+#: ../src/common/zstream.cpp:343
+msgid "Can't initialize zlib deflate stream."
+msgstr "无法初始化 zlib 压缩流。"
+
+#: ../src/common/zstream.cpp:424
+#, c-format
+msgid "Can't write to deflate stream: %s"
+msgstr "无法写入压缩流：%s"
+
+#: ../src/dfb/bitmap.cpp:633 ../src/dfb/bitmap.cpp:667
+#, c-format
+msgid "No bitmap handler for type %d defined."
+msgstr "未定义类型 %d 的位图处理程序。"
+
+#: ../src/dfb/evtloop.cpp:99
+msgid "Failed to read event from DirectFB pipe"
+msgstr "无法从 DirectFB 管道中读取事件"
+
+#: ../src/dfb/evtloop.cpp:171
+msgid "Failed to switch DirectFB pipe to non-blocking mode"
+msgstr "无法将 DirectFB 管道切换为非阻塞模式"
+
+#: ../src/dfb/fontmgr.cpp:171
+#, c-format
+msgid "no fonts found in %s, using builtin font"
+msgstr "在 %s 中未找到字体，将使用内置字体"
+
+#: ../src/dfb/fontmgr.cpp:177
+msgid "Default font"
+msgstr "默认字体"
+
+#: ../src/dfb/fontmgr.cpp:195
+#, c-format
+msgid "Fonts index file %s disappeared while loading fonts."
+msgstr "加载字体时，字体索引文件 %s 已不存在。"
+
+#: ../src/dfb/wrapdfb.cpp:60
+#, c-format
+msgid "DirectFB error %d occurred."
+msgstr "发生 DirectFB 错误 %d。"
+
+#: ../src/generic/aboutdlgg.cpp:69
+msgid "Developed by "
+msgstr "开发： "
+
+#: ../src/generic/aboutdlgg.cpp:72
+msgid "Documentation by "
+msgstr "文档： "
+
+#: ../src/generic/aboutdlgg.cpp:75
+msgid "Graphics art by "
+msgstr "美术： "
+
+#: ../src/generic/aboutdlgg.cpp:78
+msgid "Translations by "
+msgstr "翻译："
+
+#: ../src/generic/aboutdlgg.cpp:133 ../src/osx/cocoa/aboutdlg.mm:83
+msgid "Version "
+msgstr "版本 "
+
+#. TRANSLATORS: %s is application name
+#: ../src/generic/aboutdlgg.cpp:146 ../src/msw/aboutdlg.cpp:60
+#, c-format
+msgid "About %s"
+msgstr "关于 %s"
+
+#: ../src/generic/aboutdlgg.cpp:181
+msgid "License"
+msgstr "许可证"
+
+#: ../src/generic/aboutdlgg.cpp:184
+msgid "Developers"
+msgstr "开发者"
+
+#: ../src/generic/aboutdlgg.cpp:188
+msgid "Documentation writers"
+msgstr "文档作者"
+
+#: ../src/generic/aboutdlgg.cpp:192
+msgid "Artists"
+msgstr "美术"
+
+#: ../src/generic/aboutdlgg.cpp:196
+msgid "Translators"
+msgstr "译者"
+
+#: ../src/generic/animateg.cpp:125
+msgid "No handler found for animation type."
+msgstr "未找到用于该动画类型的处理程序。"
+
+#: ../src/generic/animateg.cpp:133
+#, c-format
+msgid "No animation handler for type %ld defined."
+msgstr "未定义用于类型 %ld 的动画处理程序。"
+
+#: ../src/generic/animateg.cpp:145
+#, c-format
+msgid "Animation file is not of type %ld."
+msgstr "动画文件不是 %ld 类型。"
+
+#: ../src/generic/colrdlgg.cpp:154 ../src/gtk/colordlg.cpp:47
+msgid "Choose colour"
+msgstr "选择颜色"
+
+#: ../src/generic/colrdlgg.cpp:357
+msgid "Red:"
+msgstr "红："
+
+#: ../src/generic/colrdlgg.cpp:360
+msgid "Green:"
+msgstr "绿："
+
+#: ../src/generic/colrdlgg.cpp:363
+msgid "Blue:"
+msgstr "蓝："
+
+#: ../src/generic/colrdlgg.cpp:372
+msgid "Opacity:"
+msgstr "不透明度："
+
+#: ../src/generic/colrdlgg.cpp:384
+msgid "Add to custom colours"
+msgstr "添加到自定义颜色"
+
+#: ../src/generic/creddlgg.cpp:56
+msgid "Username:"
+msgstr "用户名："
+
+#: ../src/generic/creddlgg.cpp:63
+msgid "Password:"
+msgstr "密码："
+
+#. TRANSLATORS: Name of Boolean true value
+#: ../src/generic/datavgen.cpp:1178
+msgid "true"
+msgstr "true"
+
+#. TRANSLATORS: Name of Boolean false value
+#: ../src/generic/datavgen.cpp:1180
+msgid "false"
+msgstr "false"
+
+#: ../src/generic/datavgen.cpp:6897
+#, c-format
+msgid "Row %i"
+msgstr "第 %i 行"
+
+#. TRANSLATORS: Action for manipulating a tree control
+#: ../src/generic/datavgen.cpp:6987
+msgid "Collapse"
+msgstr "折叠"
+
+#. TRANSLATORS: Action for manipulating a tree control
+#: ../src/generic/datavgen.cpp:6990
+msgid "Expand"
+msgstr "展开"
+
+#. TRANSLATORS: Name of data view control and number of rows
+#: ../src/generic/datavgen.cpp:7011
+#, c-format
+msgid "%s (%d items)"
+msgstr "%s（%d 项）"
+
+#: ../src/generic/datavgen.cpp:7062
+#, c-format
+msgid "Column %u"
+msgstr "第 %u 列"
+
+#. TRANSLATORS: Keystroke for manipulating a tree control
+#: ../src/generic/datavgen.cpp:7131 ../src/richtext/richtextbulletspage.cpp:189
+#: ../src/richtext/richtextbulletspage.cpp:192
+#: ../src/richtext/richtextbulletspage.cpp:193
+#: ../src/richtext/richtextliststylepage.cpp:252
+#: ../src/richtext/richtextliststylepage.cpp:255
+#: ../src/richtext/richtextliststylepage.cpp:256
+#: ../src/richtext/richtextsizepage.cpp:248
+msgid "Left"
+msgstr "左"
+
+#. TRANSLATORS: Keystroke for manipulating a tree control
+#: ../src/generic/datavgen.cpp:7134 ../src/richtext/richtextbulletspage.cpp:191
+#: ../src/richtext/richtextliststylepage.cpp:254
+#: ../src/richtext/richtextsizepage.cpp:249
+msgid "Right"
+msgstr "右"
+
+#: ../src/generic/datectlg.cpp:90
+#, c-format
+msgid ""
+"\"%s\" is not in the expected date format, please enter it as e.g. \"%s\"."
+msgstr "\"%s\" 的日期格式不正确，请参照 \"%s\" 的格式输入。"
+
+#: ../src/generic/datectlg.cpp:94
+msgid "Invalid date"
+msgstr "无效日期"
+
+#: ../src/generic/dbgrptg.cpp:159
+#, c-format
+msgid "Open file \"%s\""
+msgstr "打开文件 \"%s\""
+
+#: ../src/generic/dbgrptg.cpp:170
+#, c-format
+msgid "Enter command to open file \"%s\":"
+msgstr "输入命令以打开文件 \"%s\"："
+
+#: ../src/generic/dbgrptg.cpp:230
+msgid "Executable files (*.exe)|*.exe|"
+msgstr "可执行文件 (*.exe)|*.exe|"
+
+#: ../src/generic/dbgrptg.cpp:300
+#, c-format
+msgid "Debug report \"%s\""
+msgstr "调试报告 \"%s\""
+
+#: ../src/generic/dbgrptg.cpp:316
+msgid "A debug report has been generated in the directory\n"
+msgstr "调试报告已生成到以下目录\n"
+
+#: ../src/generic/dbgrptg.cpp:317
+msgid "The following debug report will be generated\n"
+msgstr "将生成以下调试报告\n"
+
+#: ../src/generic/dbgrptg.cpp:321
+msgid ""
+"The report contains the files listed below. If any of these files contain "
+"private information,\n"
+"please uncheck them and they will be removed from the report.\n"
+msgstr ""
+"报告包含下列文件。如果其中包含隐私信息，\n"
+"请取消勾选，它们将从报告中移除。\n"
+
+#: ../src/generic/dbgrptg.cpp:323
+msgid ""
+"If you wish to suppress this debug report completely, please choose the "
+"\"Cancel\" button,\n"
+"but be warned that it may hinder improving the program, so if\n"
+"at all possible please do continue with the report generation.\n"
+msgstr ""
+"如果想完全禁用调试报告，请点击「取消」按钮。\n"
+"但请注意，这可能会阻碍我们改进程序。如果条件允许，请务必继续生成报告。\n"
+
+#: ../src/generic/dbgrptg.cpp:325
+msgid "              Thank you and we're sorry for the inconvenience!\n"
+msgstr "              谢谢，对于给您带来的不便，我们深表歉意！\n"
+
+#: ../src/generic/dbgrptg.cpp:333
+msgid "&Debug report preview:"
+msgstr "调试报告预览(&D)："
+
+#: ../src/generic/dbgrptg.cpp:339
+msgid "&View..."
+msgstr "查看(&V)..."
+
+#: ../src/generic/dbgrptg.cpp:359
+msgid "&Notes:"
+msgstr "备注(&N)："
+
+#: ../src/generic/dbgrptg.cpp:361
+msgid ""
+"If you have any additional information pertaining to this bug\n"
+"report, please enter it here and it will be joined to it:"
+msgstr ""
+"如果您有关于此错误的任何附加信息，\n"
+"请在此输入，将附加到报告中："
+
+#: ../src/generic/dcpsg.cpp:1627
+msgid "Cannot open file for PostScript printing!"
+msgstr "无法打开文件进行 PostScript 打印！"
+
+#: ../src/generic/dirctrlg.cpp:402
+msgid "Computer"
+msgstr "计算机"
+
+#: ../src/generic/dirctrlg.cpp:404
+msgid "Sections"
+msgstr "位置"
+
+#: ../src/generic/dirctrlg.cpp:482
+msgid "Home directory"
+msgstr "主目录"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/generic/dirctrlg.cpp:484 ../src/propgrid/advprops.cpp:811
+msgid "Desktop"
+msgstr "桌面"
+
+#: ../src/generic/dirctrlg.cpp:528 ../src/generic/filectrlg.cpp:752
+msgid "Illegal directory name."
+msgstr "非法目录名。"
+
+#: ../src/generic/dirctrlg.cpp:528 ../src/generic/dirctrlg.cpp:546
+#: ../src/generic/dirctrlg.cpp:557 ../src/generic/dirdlgg.cpp:317
+#: ../src/generic/filectrlg.cpp:638 ../src/generic/filectrlg.cpp:752
+#: ../src/generic/filectrlg.cpp:766 ../src/generic/filectrlg.cpp:782
+#: ../src/generic/filectrlg.cpp:1356 ../src/generic/filectrlg.cpp:1387
+#: ../src/generic/filedlgg.cpp:362 ../src/gtk/filedlg.cpp:76
+msgid "Error"
+msgstr "错误"
+
+#: ../src/generic/dirctrlg.cpp:546 ../src/generic/filectrlg.cpp:766
+msgid "File name exists already."
+msgstr "文件名已存在。"
+
+#: ../src/generic/dirctrlg.cpp:557 ../src/generic/dirdlgg.cpp:317
+#: ../src/generic/filectrlg.cpp:638 ../src/generic/filectrlg.cpp:782
+msgid "Operation not permitted."
+msgstr "不允许此操作。"
+
+#: ../src/generic/dirdlgg.cpp:107 ../src/generic/filedlgg.cpp:207
+msgid "Create new directory"
+msgstr "创建新目录"
+
+#: ../src/generic/dirdlgg.cpp:112 ../src/generic/filedlgg.cpp:203
+msgid "Go to home directory"
+msgstr "转到用户主目录"
+
+#: ../src/generic/dirdlgg.cpp:143
+msgid "Show &hidden directories"
+msgstr "显示隐藏目录(&H)"
+
+#: ../src/generic/dirdlgg.cpp:196
+#, c-format
+msgid ""
+"The directory '%s' does not exist\n"
+"Create it now?"
+msgstr ""
+"目录 '%s' 不存在\n"
+"是否现在创建？"
+
+#: ../src/generic/dirdlgg.cpp:198
+msgid "Directory does not exist"
+msgstr "目录不存在"
+
+#: ../src/generic/dirdlgg.cpp:214
+#, c-format
+msgid ""
+"Failed to create directory '%s'\n"
+"(Do you have the required permissions?)"
+msgstr ""
+"无法创建目录 '%s'\n"
+"(是否具备所需权限？)"
+
+#: ../src/generic/dirdlgg.cpp:216
+msgid "Error creating directory"
+msgstr "创建目录时出错"
+
+#: ../src/generic/dirdlgg.cpp:281
+msgid "You cannot add a new directory to this section."
+msgstr "无法在此位置创建新目录。"
+
+#: ../src/generic/dirdlgg.cpp:282
+msgid "Create directory"
+msgstr "创建目录"
+
+#: ../src/generic/dirdlgg.cpp:291 ../src/generic/dirdlgg.cpp:301
+#: ../src/generic/filectrlg.cpp:614 ../src/generic/filectrlg.cpp:623
+msgid "NewName"
+msgstr "新名称"
+
+#: ../src/generic/editlbox.cpp:135
+msgid "Edit item"
+msgstr "编辑项"
+
+#: ../src/generic/editlbox.cpp:143
+msgid "New item"
+msgstr "新建项"
+
+#: ../src/generic/editlbox.cpp:151
+msgid "Delete item"
+msgstr "删除项"
+
+#: ../src/generic/editlbox.cpp:159
+msgid "Move up"
+msgstr "上移"
+
+#: ../src/generic/editlbox.cpp:164
+msgid "Move down"
+msgstr "下移"
+
+#: ../src/generic/fdrepdlg.cpp:108
+msgid "Search for:"
+msgstr "查找内容："
+
+#: ../src/generic/fdrepdlg.cpp:120
+msgid "Replace with:"
+msgstr "替换为："
+
+#: ../src/generic/fdrepdlg.cpp:140
+msgid "Whole word"
+msgstr "全词匹配"
+
+#: ../src/generic/fdrepdlg.cpp:143
+msgid "Match case"
+msgstr "区分大小写"
+
+#: ../src/generic/fdrepdlg.cpp:156
+msgid "Search direction"
+msgstr "搜索方向"
+
+#: ../src/generic/fdrepdlg.cpp:175
+msgid "&Replace"
+msgstr "替换(&R)"
+
+#: ../src/generic/fdrepdlg.cpp:178
+msgid "Replace &all"
+msgstr "全部替换(&A)"
+
+#: ../src/generic/filectrlg.cpp:246 ../src/generic/filectrlg.cpp:269
+msgid "<DIR>"
+msgstr "<DIR>"
+
+#: ../src/generic/filectrlg.cpp:248 ../src/generic/filectrlg.cpp:271
+msgid "<LINK>"
+msgstr "<LINK>"
+
+#: ../src/generic/filectrlg.cpp:250 ../src/generic/filectrlg.cpp:273
+msgid "<DRIVE>"
+msgstr "<DRIVE>"
+
+#: ../src/generic/filectrlg.cpp:275
+#, c-format
+msgid "%ld byte"
+msgid_plural "%ld bytes"
+msgstr[0] "%ld 字节"
+
+#: ../src/generic/filectrlg.cpp:420
+msgid "Name"
+msgstr "名称"
+
+#: ../src/generic/filectrlg.cpp:421 ../src/richtext/richtextformatdlg.cpp:361
+#: ../src/richtext/richtextsizepage.cpp:298
+msgid "Size"
+msgstr "大小"
+
+#: ../src/generic/filectrlg.cpp:422
+msgid "Type"
+msgstr "类型"
+
+#: ../src/generic/filectrlg.cpp:423
+msgid "Modified"
+msgstr "修改日期"
+
+#: ../src/generic/filectrlg.cpp:426
+msgid "Permissions"
+msgstr "权限"
+
+#: ../src/generic/filectrlg.cpp:429
+msgid "Attributes"
+msgstr "属性"
+
+#: ../src/generic/filectrlg.cpp:936
+msgid "Current directory:"
+msgstr "当前目录："
+
+#: ../src/generic/filectrlg.cpp:979
+msgid "Show &hidden files"
+msgstr "显示隐藏文件(&H)"
+
+#: ../src/generic/filectrlg.cpp:1355
+msgid "Illegal file specification."
+msgstr "文件通配符不合法。"
+
+#: ../src/generic/filectrlg.cpp:1387
+msgid "Directory doesn't exist."
+msgstr "目录不存在。"
+
+#: ../src/generic/filedlgg.cpp:195
+msgid "View files as a list view"
+msgstr "以列表视图查看文件"
+
+#: ../src/generic/filedlgg.cpp:197
+msgid "View files as a detailed view"
+msgstr "以详细视图查看文件"
+
+#: ../src/generic/filedlgg.cpp:200
+msgid "Go to parent directory"
+msgstr "转到上级目录"
+
+#: ../src/generic/filedlgg.cpp:351 ../src/gtk/filedlg.cpp:59
+#, c-format
+msgid "File '%s' already exists, do you really want to overwrite it?"
+msgstr "文件 '%s' 已存在，是否要覆盖？"
+
+#: ../src/generic/filedlgg.cpp:354 ../src/gtk/filedlg.cpp:62
+msgid "Confirm"
+msgstr "确认"
+
+#: ../src/generic/filedlgg.cpp:362 ../src/gtk/filedlg.cpp:75
+msgid "Please choose an existing file."
+msgstr "请选择一个已存在的文件。"
+
+#: ../src/generic/filepickerg.cpp:64
+msgid "..."
+msgstr "..."
+
+#: ../src/generic/fontdlgg.cpp:76 ../src/richtext/richtextformatdlg.cpp:519
+msgid "ABCDEFGabcdefg12345"
+msgstr "ABCDEFGabcdefg12345"
+
+#: ../src/generic/fontdlgg.cpp:315
+msgid "Roman"
+msgstr "衬线体"
+
+#: ../src/generic/fontdlgg.cpp:316
+msgid "Decorative"
+msgstr "装饰体"
+
+#: ../src/generic/fontdlgg.cpp:317
+msgid "Modern"
+msgstr "等宽体"
+
+#: ../src/generic/fontdlgg.cpp:318
+msgid "Script"
+msgstr "手写体"
+
+#: ../src/generic/fontdlgg.cpp:319
+msgid "Swiss"
+msgstr "无衬线体"
+
+#: ../src/generic/fontdlgg.cpp:320
+msgid "Teletype"
+msgstr "打字机体"
+
+#: ../src/generic/fontdlgg.cpp:321 ../src/generic/fontdlgg.cpp:324
+msgid "Normal"
+msgstr "正常"
+
+#: ../src/generic/fontdlgg.cpp:323
+msgid "Slant"
+msgstr "倾斜体"
+
+#: ../src/generic/fontdlgg.cpp:325
+msgid "Light"
+msgstr "细体"
+
+#: ../src/generic/fontdlgg.cpp:363
+msgid "&Font family:"
+msgstr "字体系列(&F)："
+
+#: ../src/generic/fontdlgg.cpp:367 ../src/generic/fontdlgg.cpp:369
+msgid "The font family."
+msgstr "字体系列。"
+
+#: ../src/generic/fontdlgg.cpp:374 ../src/richtext/richtextstylepage.cpp:105
+msgid "&Style:"
+msgstr "样式(&S)："
+
+#: ../src/generic/fontdlgg.cpp:378 ../src/generic/fontdlgg.cpp:380
+msgid "The font style."
+msgstr "字体样式。"
+
+#: ../src/generic/fontdlgg.cpp:385
+msgid "&Weight:"
+msgstr "字体粗细(&W)："
+
+#: ../src/generic/fontdlgg.cpp:389 ../src/generic/fontdlgg.cpp:391
+msgid "The font weight."
+msgstr "字体粗细。"
+
+#: ../src/generic/fontdlgg.cpp:399
+msgid "C&olour:"
+msgstr "颜色(&O)："
+
+#: ../src/generic/fontdlgg.cpp:407 ../src/generic/fontdlgg.cpp:409
+msgid "The font colour."
+msgstr "字体颜色。"
+
+#: ../src/generic/fontdlgg.cpp:415
+msgid "&Point size:"
+msgstr "字号(&P)："
+
+#: ../src/generic/fontdlgg.cpp:420 ../src/generic/fontdlgg.cpp:422
+#: ../src/generic/fontdlgg.cpp:426 ../src/generic/fontdlgg.cpp:428
+msgid "The font point size."
+msgstr "字号。"
+
+#: ../src/generic/fontdlgg.cpp:439 ../src/generic/fontdlgg.cpp:441
+msgid "Whether the font is underlined."
+msgstr "字体是否加下划线。"
+
+#: ../src/generic/fontdlgg.cpp:448 ../src/html/helpwnd.cpp:1215
+msgid "Preview:"
+msgstr "预览："
+
+#: ../src/generic/fontdlgg.cpp:452 ../src/generic/fontdlgg.cpp:454
+msgid "Shows the font preview."
+msgstr "显示字体预览。"
+
+#: ../src/generic/fontdlgg.cpp:464 ../src/generic/fontdlgg.cpp:483
+msgid "Click to cancel the font selection."
+msgstr "点击取消字体选择。"
+
+#: ../src/generic/fontdlgg.cpp:469 ../src/generic/fontdlgg.cpp:471
+#: ../src/generic/fontdlgg.cpp:476 ../src/generic/fontdlgg.cpp:478
+msgid "Click to confirm the font selection."
+msgstr "点击确认字体选择。"
+
+#: ../src/generic/fontpickerg.cpp:50 ../src/gtk/fontdlg.cpp:77
+msgid "Choose font"
+msgstr "选择字体"
+
+#: ../src/generic/grid.cpp:6542
+msgid ""
+"Error copying grid to the clipboard. Either selected cells were not "
+"contiguous or no cell was selected."
+msgstr ""
+"无法将网格复制到剪贴板。所选单元格不连续，或未选择任何单元格。"
+
+#: ../src/generic/grid.cpp:12739
+msgid "Grid Corner"
+msgstr "网格角"
+
+#: ../src/generic/grid.cpp:12741
+#, c-format
+msgid "Column %s Header"
+msgstr "第 %s 列标题"
+
+#: ../src/generic/grid.cpp:12743
+#, c-format
+msgid "Row %s Header"
+msgstr "第 %s 行标题"
+
+#: ../src/generic/grid.cpp:12745
+#, c-format
+msgid "Column %s: %s"
+msgstr "第 %s 列：%s"
+
+#: ../src/generic/grid.cpp:12749
+#, c-format
+msgid "Row %s: %s"
+msgstr "第 %s 行：%s"
+
+#: ../src/generic/grid.cpp:12753
+#, c-format
+msgid "Row %s, Column %s: %s"
+msgstr "第 %s 行，第 %s 列：%s"
+
+#: ../src/generic/helpext.cpp:257
+#, c-format
+msgid "Help directory \"%s\" not found."
+msgstr "找不到帮助目录 \"%s\"。"
+
+#: ../src/generic/helpext.cpp:265
+#, c-format
+msgid "Help file \"%s\" not found."
+msgstr "找不到帮助文件 \"%s\"。"
+
+#: ../src/generic/helpext.cpp:284
+#, c-format
+msgid "Line %lu of map file \"%s\" has invalid syntax, skipped."
+msgstr "映射文件 \"%2$s\" 的第 %1$lu 行存在无效语法，已跳过。"
+
+#: ../src/generic/helpext.cpp:292
+#, c-format
+msgid "No valid mappings found in the file \"%s\"."
+msgstr "文件 \"%s\" 中未找到有效映射。"
+
+#: ../src/generic/helpext.cpp:435
+msgid "No entries found."
+msgstr "未找到条目。"
+
+#: ../src/generic/helpext.cpp:444 ../src/generic/helpext.cpp:445
+msgid "Help Index"
+msgstr "帮助索引"
+
+#: ../src/generic/helpext.cpp:448
+msgid "Relevant entries:"
+msgstr "相关条目："
+
+#: ../src/generic/helpext.cpp:449
+msgid "Entries found"
+msgstr "找到的条目"
+
+#: ../src/generic/hyperlinkg.cpp:170
+msgid "&Copy URL"
+msgstr "复制 URL(&C)"
+
+#: ../src/generic/infobar.cpp:119
+msgid "Hide this notification message."
+msgstr "隐藏此通知。"
+
+#. TRANSLATORS: %s will be either the application name or "Application"
+#: ../src/generic/logg.cpp:257
+#, c-format
+msgid "%s Error"
+msgstr "%s 错误"
+
+#. TRANSLATORS: %s will be either the application name or "Application"
+#: ../src/generic/logg.cpp:263
+#, c-format
+msgid "%s Warning"
+msgstr "%s 警告"
+
+#. TRANSLATORS: %s will be either the application name or "Application"
+#: ../src/generic/logg.cpp:273
+#, c-format
+msgid "%s Information"
+msgstr "%s 信息"
+
+#: ../src/generic/logg.cpp:276
+msgid "Application"
+msgstr "应用程序"
+
+#: ../src/generic/logg.cpp:549
+msgid "Save log contents to file"
+msgstr "将日志内容保存到文件"
+
+#: ../src/generic/logg.cpp:551
+msgid "C&lear"
+msgstr "清除(&L)"
+
+#: ../src/generic/logg.cpp:551
+msgid "Clear the log contents"
+msgstr "清除日志内容"
+
+#: ../src/generic/logg.cpp:553
+msgid "Close this window"
+msgstr "关闭此窗口"
+
+#: ../src/generic/logg.cpp:554
+msgid "&Log"
+msgstr "日志(&L)"
+
+#: ../src/generic/logg.cpp:610 ../src/generic/logg.cpp:992
+msgid "Can't save log contents to file."
+msgstr "无法将日志内容保存到文件。"
+
+#: ../src/generic/logg.cpp:613
+#, c-format
+msgid "Log saved to the file '%s'."
+msgstr "日志已保存到文件 '%s'。"
+
+#: ../src/generic/logg.cpp:719
+msgid "&Details"
+msgstr "详细信息(&D)"
+
+#: ../src/generic/logg.cpp:972
+msgid "Failed to copy dialog contents to the clipboard."
+msgstr "无法将对话框内容复制到剪贴板。"
+
+#: ../src/generic/logg.cpp:1022
+#, c-format
+msgid "Append log to file '%s' (choosing [No] will overwrite it)?"
+msgstr "将日志追加到文件 '%s' 中？（选择「否」将覆盖该文件）"
+
+#: ../src/generic/logg.cpp:1024
+msgid "Question"
+msgstr "询问"
+
+#: ../src/generic/logg.cpp:1038
+msgid "invalid message box return value"
+msgstr "无效消息框返回值"
+
+#: ../src/generic/notifmsgg.cpp:129
+msgid "Notice"
+msgstr "通知"
+
+#: ../src/generic/preferencesg.cpp:118
+#, c-format
+msgid "%s Preferences"
+msgstr "%s 首选项"
+
+#: ../src/generic/printps.cpp:143
+msgid "Printing..."
+msgstr "正在打印..."
+
+#: ../src/generic/printps.cpp:160 ../src/gtk/print.cpp:1076
+#: ../src/msw/printwin.cpp:235
+msgid "Could not start printing."
+msgstr "无法启动打印。"
+
+#: ../src/generic/printps.cpp:183
+#, c-format
+msgid "Printing page %d..."
+msgstr "正在打印第 %d 页..."
+
+#: ../src/generic/prntdlgg.cpp:171
+msgid "Printer options"
+msgstr "打印机选项"
+
+#: ../src/generic/prntdlgg.cpp:176
+msgid "Print to File"
+msgstr "打印到文件"
+
+#: ../src/generic/prntdlgg.cpp:179
+msgid "Setup..."
+msgstr "设置..."
+
+#: ../src/generic/prntdlgg.cpp:187
+msgid "Printer:"
+msgstr "打印机："
+
+#: ../src/generic/prntdlgg.cpp:195
+msgid "Status:"
+msgstr "状态："
+
+#: ../src/generic/prntdlgg.cpp:206
+msgid "All"
+msgstr "全部"
+
+#: ../src/generic/prntdlgg.cpp:207
+msgid "Pages"
+msgstr "页码范围"
+
+#: ../src/generic/prntdlgg.cpp:215
+msgid "Print Range"
+msgstr "打印范围"
+
+#: ../src/generic/prntdlgg.cpp:229
+msgid "From:"
+msgstr "从："
+
+#: ../src/generic/prntdlgg.cpp:233
+msgid "To:"
+msgstr "到："
+
+#: ../src/generic/prntdlgg.cpp:238
+msgid "Copies:"
+msgstr "份数："
+
+#: ../src/generic/prntdlgg.cpp:288
+msgid "PostScript file"
+msgstr "PostScript 文件"
+
+#: ../src/generic/prntdlgg.cpp:439
+msgid "Print Setup"
+msgstr "打印设置"
+
+#: ../src/generic/prntdlgg.cpp:483
+msgid "Printer"
+msgstr "打印机"
+
+#: ../src/generic/prntdlgg.cpp:501
+msgid "Default printer"
+msgstr "默认打印机"
+
+#: ../src/generic/prntdlgg.cpp:595 ../src/generic/prntdlgg.cpp:782
+#: ../src/generic/prntdlgg.cpp:822 ../src/generic/prntdlgg.cpp:835
+#: ../src/generic/prntdlgg.cpp:1031 ../src/generic/prntdlgg.cpp:1036
+msgid "Paper size"
+msgstr "纸张大小"
+
+#: ../src/generic/prntdlgg.cpp:604 ../src/generic/prntdlgg.cpp:847
+msgid "Portrait"
+msgstr "纵向"
+
+#: ../src/generic/prntdlgg.cpp:605 ../src/generic/prntdlgg.cpp:848
+msgid "Landscape"
+msgstr "横向"
+
+#: ../src/generic/prntdlgg.cpp:607 ../src/generic/prntdlgg.cpp:849
+msgid "Orientation"
+msgstr "方向"
+
+#: ../src/generic/prntdlgg.cpp:610
+msgid "Options"
+msgstr "选项"
+
+#: ../src/generic/prntdlgg.cpp:612
+msgid "Print in colour"
+msgstr "彩色打印"
+
+#: ../src/generic/prntdlgg.cpp:621
+msgid "Print spooling"
+msgstr "打印后台处理"
+
+#: ../src/generic/prntdlgg.cpp:623
+msgid "Printer command:"
+msgstr "打印机命令："
+
+#: ../src/generic/prntdlgg.cpp:631
+msgid "Printer options:"
+msgstr "打印机选项："
+
+#: ../src/generic/prntdlgg.cpp:860
+msgid "Left margin (mm):"
+msgstr "左边距（毫米）："
+
+#: ../src/generic/prntdlgg.cpp:861
+msgid "Top margin (mm):"
+msgstr "上边距（毫米）："
+
+#: ../src/generic/prntdlgg.cpp:872
+msgid "Right margin (mm):"
+msgstr "右边距（毫米）："
+
+#: ../src/generic/prntdlgg.cpp:873
+msgid "Bottom margin (mm):"
+msgstr "底边距（毫米）："
+
+#: ../src/generic/prntdlgg.cpp:896
+msgid "Printer..."
+msgstr "打印机..."
+#: ../src/generic/progdlgg.cpp:246
+msgid "&Skip"
+msgstr "跳过(&S)"
+
+#: ../src/generic/progdlgg.cpp:347 ../src/generic/progdlgg.cpp:626
+msgid "Unknown"
+msgstr "未知"
+
+#: ../src/generic/progdlgg.cpp:451 ../src/msw/progdlg.cpp:526
+msgid "Done."
+msgstr "完成。"
+
+#: ../src/generic/srchctlg.cpp:55 ../src/gtk/srchctrl.cpp:206
+#: ../src/html/helpwnd.cpp:530 ../src/html/helpwnd.cpp:545
+msgid "Search"
+msgstr "搜索"
+
+#: ../src/generic/tabg.cpp:1026
+msgid "Could not find tab for id"
+msgstr "未找到 id 对应的标签"
+
+#: ../src/generic/tipdlg.cpp:136
+msgid "Tips not available, sorry!"
+msgstr "抱歉，暂无提示！"
+
+#: ../src/generic/tipdlg.cpp:197
+msgid "Tip of the Day"
+msgstr "每日提示"
+
+#: ../src/generic/tipdlg.cpp:207
+msgid "Did you know..."
+msgstr "使用技巧..."
+
+#: ../src/generic/tipdlg.cpp:232
+msgid "&Show tips at startup"
+msgstr "启动时显示提示(&S)"
+
+#: ../src/generic/tipdlg.cpp:236
+msgid "&Next Tip"
+msgstr "下一条(&N)"
+
+#: ../src/generic/wizard.cpp:411
+msgid "&Next >"
+msgstr "下一步(&N) >"
+
+#: ../src/generic/wizard.cpp:412
+msgid "&Finish"
+msgstr "完成(&F)"
+
+#: ../src/generic/wizard.cpp:420
+msgid "< &Back"
+msgstr "< 上一步(&B)"
+
+#: ../src/gtk/aboutdlg.cpp:204
+msgid "translator-credits"
+msgstr "翻译人员"
+
+#: ../src/gtk/app.cpp:517
+msgid ""
+"WARNING: using XIM input method is unsupported and may result in problems "
+"with input handling and flickering. Consider unsetting GTK_IM_MODULE or "
+"setting to \"ibus\"."
+msgstr ""
+"警告：不支持使用 XIM 输入法，可能会导致输入处理和闪烁问题。考虑取消设置 "
+"GTK_IM_MODULE 或设置为 \"ibus\"。"
+
+#: ../src/gtk/app.cpp:569
+msgid "Unable to initialize GTK+, is DISPLAY set properly?"
+msgstr "无法初始化 GTK+，DISPLAY 是否已正确设置？"
+
+#: ../src/gtk/filedlg.cpp:89 ../src/gtk/filepicker.cpp:255
+#, c-format
+msgid "Changing current directory to \"%s\" failed"
+msgstr "切换当前目录到 \"%s\" 失败"
+
+#: ../src/gtk/font.cpp:548
+msgid ""
+"Using private fonts is not supported on this system: Pango library is too "
+"old, 1.38 or later required."
+msgstr "此系统不支持使用私有字体：Pango 库太旧，需要 1.38 或更高版本。"
+
+#: ../src/gtk/font.cpp:558
+msgid "Failed to create font configuration object."
+msgstr "无法创建字体配置对象。"
+
+#: ../src/gtk/font.cpp:568
+#, c-format
+msgid "Failed to add custom font \"%s\"."
+msgstr "无法添加自定义字体 \"%s\"。"
+
+#: ../src/gtk/font.cpp:576
+msgid "Failed to register font configuration using private fonts."
+msgstr "无法使用私有字体注册字体配置。"
+
+#: ../src/gtk/glcanvas.cpp:117 ../src/gtk/glcanvas.cpp:132
+msgid "Fatal Error"
+msgstr "致命错误"
+
+#: ../src/gtk/glcanvas.cpp:117
+msgid ""
+"This program wasn't compiled with EGL support required under Wayland, "
+"either\n"
+"install EGL libraries and rebuild or run it under X11 backend by setting\n"
+"environment variable GDK_BACKEND=x11 before starting your program."
+msgstr ""
+"本程序编译时缺少 Wayland 环境下所需的 EGL 支持。请安装 EGL 库并重新构建\n"
+"本程序，或在启动程序前设置环境变量 GDK_BACKEND=x11，以便在 X11 后端运行。"
+
+#: ../src/gtk/glcanvas.cpp:132
+msgid ""
+"wxGLCanvas is only supported on Wayland and X11 currently.  You may be able "
+"to\n"
+"work around this by setting environment variable GDK_BACKEND=x11 before\n"
+"starting your program."
+msgstr ""
+"wxGLCanvas 目前仅支持 Wayland 和 X11。您可以尝试\n"
+"在启动程序前设置环境变量 GDK_BACKEND=x11 来解决此问题。"
+
+#: ../src/gtk/mdi.cpp:433
+msgid "MDI child"
+msgstr "MDI 子窗口"
+
+#: ../src/gtk/power.cpp:188
+#, c-format
+msgid "Failed to open D-Bus connection to the login manager: %s"
+msgstr "无法打开与登录管理器的 D-Bus 连接：%s"
+
+#: ../src/gtk/power.cpp:214
+msgid "wxWidgets application"
+msgstr "wxWidgets 应用程序"
+
+#: ../src/gtk/power.cpp:226
+msgid "Application needs to keep running"
+msgstr "应用程序需要保持运行"
+
+#: ../src/gtk/power.cpp:233
+msgid "Clean up before suspend"
+msgstr "挂起前清理"
+
+#: ../src/gtk/power.cpp:259
+#, c-format
+msgid "Failed to inhibit sleep: %s"
+msgstr "无法阻止睡眠：%s"
+
+#: ../src/gtk/power.cpp:265
+msgid "Unexpected response to D-Bus \"Inhibit\" request."
+msgstr "D-Bus \"Inhibit\" 请求收到意外响应。"
+
+#: ../src/gtk/print.cpp:218
+msgid "Custom size"
+msgstr "自定义大小"
+
+#: ../src/gtk/print.cpp:752
+#, c-format
+msgid "Error while printing: %s"
+msgstr "打印时出错：%s"
+
+#: ../src/gtk/print.cpp:816
+msgid "Page Setup"
+msgstr "页面设置"
+
+#: ../src/gtk/webview_webkit.cpp:932
+msgid "Retrieving JavaScript script output is not supported with WebKit v1"
+msgstr "WebKit v1 不支持获取 JavaScript 脚本输出"
+
+#: ../src/gtk/webview_webkit2.cpp:1098
+msgid ""
+"Setting proxy is not supported by WebKit, at least version 2.16 is required."
+msgstr "WebKit 不支持设置代理，至少需要 2.16 版本。"
+
+#: ../src/gtk/webview_webkit2.cpp:1104
+msgid "This program was compiled without support for setting WebKit proxy."
+msgstr "本程序编译时缺少对设置 WebKit 代理的支持。"
+
+#: ../src/gtk/window.cpp:6289
+msgid ""
+"GTK+ installed on this machine is too old to support screen compositing, "
+"please install GTK+ 2.12 or later."
+msgstr ""
+"本机安装的 GTK+ 版本过低，无法支持屏幕合成。请安装 GTK+ 2.12 或更高版本。"
+
+#: ../src/gtk/window.cpp:6307
+msgid ""
+"Compositing not supported by this system, please enable it in your Window "
+"Manager."
+msgstr "当前系统不支持屏幕合成，请在窗口管理器中启用。"
+
+#: ../src/gtk/window.cpp:6318
+msgid ""
+"This program was compiled with a too old version of GTK+, please rebuild "
+"with GTK+ 2.12 or newer."
+msgstr "本程序使用过旧版本的 GTK+ 编译，请使用 GTK+ 2.12 或更高版本重新构建。"
+
+#: ../src/html/chm.cpp:138
+#, c-format
+msgid "Failed to open CHM archive '%s'."
+msgstr "无法打开 CHM 文件 '%s'。"
+
+#: ../src/html/chm.cpp:270
+#, c-format
+msgid "Could not extract %s into %s: %s"
+msgstr "无法将 %s 提取到 %s：%s"
+
+#: ../src/html/chm.cpp:324
+msgid "no error"
+msgstr "无错误"
+
+#: ../src/html/chm.cpp:326
+msgid "bad arguments to library function"
+msgstr "库函数参数错误"
+
+#: ../src/html/chm.cpp:328
+msgid "error opening file"
+msgstr "打开文件时出错"
+
+#: ../src/html/chm.cpp:330
+msgid "read error"
+msgstr "读取时出错"
+
+#: ../src/html/chm.cpp:332
+msgid "write error"
+msgstr "写入时出错"
+
+#: ../src/html/chm.cpp:334
+msgid "seek error"
+msgstr "定位时出错"
+
+#: ../src/html/chm.cpp:338
+msgid "bad signature"
+msgstr "签名无效"
+
+#: ../src/html/chm.cpp:340
+msgid "error in data format"
+msgstr "文件格式错误"
+
+#: ../src/html/chm.cpp:342
+msgid "checksum error"
+msgstr "校验和出错"
+
+#: ../src/html/chm.cpp:344
+msgid "compression error"
+msgstr "压缩出错"
+
+#: ../src/html/chm.cpp:346
+msgid "decompression error"
+msgstr "解压缩出错"
+
+#: ../src/html/chm.cpp:437
+#, c-format
+msgid "Could not locate file '%s'."
+msgstr "未找到文件 '%s'。"
+
+#: ../src/html/chm.cpp:711
+#, c-format
+msgid "Could not create temporary file '%s'"
+msgstr "无法创建临时文件 '%s'"
+
+#: ../src/html/chm.cpp:718
+#, c-format
+msgid "Extraction of '%s' into '%s' failed."
+msgstr "无法将 '%s' 提取到 '%s'。"
+
+#: ../src/html/chm.cpp:806 ../src/html/chm.cpp:863
+msgid "CHM handler currently supports only local files!"
+msgstr "CHM 处理程序目前只支持本地文件！"
+
+#: ../src/html/chm.cpp:827
+msgid "Link contained '//', converted to absolute link."
+msgstr "链接包含 '//'，转换为绝对链接。"
+
+#: ../src/html/helpctrl.cpp:59
+#, c-format
+msgid "Help: %s"
+msgstr "帮助：%s"
+
+#: ../src/html/helpctrl.cpp:155
+#, c-format
+msgid "Adding book %s"
+msgstr "正在添加帮助手册 %s"
+
+#: ../src/html/helpdata.cpp:295
+#, c-format
+msgid "Cannot open contents file: %s"
+msgstr "无法打开目录文件：%s"
+
+#: ../src/html/helpdata.cpp:309
+#, c-format
+msgid "Cannot open index file: %s"
+msgstr "无法打开索引文件：%s"
+
+#: ../src/html/helpdata.cpp:643
+msgid "noname"
+msgstr "无名称"
+
+#: ../src/html/helpdata.cpp:652
+#, c-format
+msgid "Cannot open HTML help book: %s"
+msgstr "无法打开 HTML 帮助手册：%s"
+
+#: ../src/html/helpwnd.cpp:315
+msgid "Displays help as you browse the books on the left."
+msgstr "浏览左侧的帮助手册时在此显示帮助内容。"
+
+#: ../src/html/helpwnd.cpp:411 ../src/html/helpwnd.cpp:1100
+#: ../src/html/helpwnd.cpp:1735
+msgid "(bookmarks)"
+msgstr "(书签)"
+
+#: ../src/html/helpwnd.cpp:424
+msgid "Add current page to bookmarks"
+msgstr "将当前页添加到书签"
+
+#: ../src/html/helpwnd.cpp:425
+msgid "Remove current page from bookmarks"
+msgstr "从书签中移除当前页"
+
+#: ../src/html/helpwnd.cpp:470
+msgid "Contents"
+msgstr "目录"
+
+#: ../src/html/helpwnd.cpp:485
+msgid "Find"
+msgstr "查找"
+
+#: ../src/html/helpwnd.cpp:487
+msgid "Show all"
+msgstr "显示全部"
+
+#: ../src/html/helpwnd.cpp:497
+msgid ""
+"Display all index items that contain given substring. Search is case "
+"insensitive."
+msgstr "显示包含指定子串的所有索引项。搜索不区分大小写。"
+
+#: ../src/html/helpwnd.cpp:498
+msgid "Show all items in index"
+msgstr "显示索引中的所有项"
+
+#: ../src/html/helpwnd.cpp:528
+msgid "Case sensitive"
+msgstr "区分大小写"
+
+#: ../src/html/helpwnd.cpp:529
+msgid "Whole words only"
+msgstr "全词匹配"
+
+#: ../src/html/helpwnd.cpp:532
+msgid ""
+"Search contents of help book(s) for all occurrences of the text you typed "
+"above"
+msgstr "在帮助手册内容中查找上方输入文本的所有匹配项"
+
+#: ../src/html/helpwnd.cpp:653
+msgid "Show/hide navigation panel"
+msgstr "显示/隐藏导航面板"
+
+#: ../src/html/helpwnd.cpp:655
+msgid "Go back"
+msgstr "返回"
+
+#: ../src/html/helpwnd.cpp:656
+msgid "Go forward"
+msgstr "前进"
+
+#: ../src/html/helpwnd.cpp:658
+msgid "Go one level up in document hierarchy"
+msgstr "转到文档层级的上一级"
+
+#: ../src/html/helpwnd.cpp:666 ../src/html/helpwnd.cpp:1547
+msgid "Open HTML document"
+msgstr "打开 HTML 文档"
+
+#: ../src/html/helpwnd.cpp:670
+msgid "Print this page"
+msgstr "打印本页"
+
+#: ../src/html/helpwnd.cpp:674
+msgid "Display options dialog"
+msgstr "显示选项对话框"
+
+#: ../src/html/helpwnd.cpp:795
+msgid "Please choose the page to display:"
+msgstr "请选择要显示的页面："
+
+#: ../src/html/helpwnd.cpp:796
+msgid "Help Topics"
+msgstr "帮助主题"
+
+#: ../src/html/helpwnd.cpp:852
+msgid "Searching..."
+msgstr "正在搜索..."
+
+#: ../src/html/helpwnd.cpp:853
+msgid "No matching page found yet"
+msgstr "尚未找到匹配的页面"
+
+#: ../src/html/helpwnd.cpp:870
+#, c-format
+msgid "Found %i matches"
+msgstr "找到 %i 个匹配项"
+
+#: ../src/html/helpwnd.cpp:958
+msgid "(Help)"
+msgstr "(帮助)"
+
+#: ../src/html/helpwnd.cpp:1026
+#, c-format
+msgid "%d of %lu"
+msgstr "%d / %lu"
+
+#: ../src/html/helpwnd.cpp:1028
+#, c-format
+msgid "%lu of %lu"
+msgstr "%lu / %lu"
+
+#: ../src/html/helpwnd.cpp:1047
+msgid "Search in all books"
+msgstr "在所有帮助手册中搜索"
+
+#: ../src/html/helpwnd.cpp:1193
+msgid "Help Browser Options"
+msgstr "帮助浏览器选项"
+
+#: ../src/html/helpwnd.cpp:1198
+msgid "Normal font:"
+msgstr "正常字体："
+
+#: ../src/html/helpwnd.cpp:1199
+msgid "Fixed font:"
+msgstr "等宽字体："
+
+#: ../src/html/helpwnd.cpp:1200
+msgid "Font size:"
+msgstr "字体大小："
+
+#: ../src/html/helpwnd.cpp:1245
+msgid "font size"
+msgstr "字体大小"
+
+#: ../src/html/helpwnd.cpp:1256
+msgid "Normal face<br>and <u>underlined</u>. "
+msgstr "正常字体<br>且<u>带下划线</u>。 "
+
+#: ../src/html/helpwnd.cpp:1257
+msgid "<i>Italic face.</i> "
+msgstr "<i>斜体</i> "
+
+#: ../src/html/helpwnd.cpp:1258
+msgid "<b>Bold face.</b> "
+msgstr "<b>粗体</b> "
+
+#: ../src/html/helpwnd.cpp:1259
+msgid "<b><i>Bold italic face.</i></b><br>"
+msgstr "<b><i>粗斜体</i></b><br>"
+
+#: ../src/html/helpwnd.cpp:1262
+msgid "Fixed size face.<br> <b>bold</b> <i>italic</i> "
+msgstr "等宽字体。<br> <b>粗体</b> <i>斜体</i> "
+
+#: ../src/html/helpwnd.cpp:1263
+msgid "<b><i>bold italic <u>underlined</u></i></b><br>"
+msgstr "<b><i>粗斜体<u>加下划线</u></i></b><br>"
+
+#: ../src/html/helpwnd.cpp:1524
+msgid "Help Printing"
+msgstr "打印帮助"
+
+#: ../src/html/helpwnd.cpp:1527
+msgid "Cannot print empty page."
+msgstr "无法打印空白页面。"
+
+#: ../src/html/helpwnd.cpp:1540
+msgid "HTML files (*.html;*.htm)|*.html;*.htm|"
+msgstr "HTML 文件 (*.html;*.htm)|*.html;*.htm|"
+
+#: ../src/html/helpwnd.cpp:1541
+msgid "Help books (*.htb)|*.htb|Help books (*.zip)|*.zip|"
+msgstr "帮助手册 (*.htb)|*.htb|帮助手册 (*.zip)|*.zip|"
+
+#: ../src/html/helpwnd.cpp:1542
+msgid "HTML Help Project (*.hhp)|*.hhp|"
+msgstr "HTML 帮助工程 (*.hhp)|*.hhp|"
+
+#: ../src/html/helpwnd.cpp:1544
+msgid "Compressed HTML Help file (*.chm)|*.chm|"
+msgstr "压缩的 HTML 帮助文件 (*.chm)|*.chm|"
+
+#: ../src/html/helpwnd.cpp:1671
+#, c-format
+msgid "%i of %u"
+msgstr "%i / %u"
+
+#: ../src/html/helpwnd.cpp:1709
+#, c-format
+msgid "%u of %u"
+msgstr "%u / %u"
+
+#: ../src/html/htmlfilt.cpp:134
+#, c-format
+msgid "Cannot open HTML document: %s"
+msgstr "无法打开 HTML 文档：%s"
+
+#: ../src/html/htmlwin.cpp:599
+msgid "Connecting..."
+msgstr "正在连接..."
+
+#: ../src/html/htmlwin.cpp:616
+#, c-format
+msgid "Unable to open requested HTML document: %s"
+msgstr "无法打开请求的 HTML 文档：%s"
+
+#: ../src/html/htmlwin.cpp:630
+msgid "Loading : "
+msgstr "正在加载： "
+
+#: ../src/html/htmlwin.cpp:673
+msgid "Done"
+msgstr "完成"
+
+#: ../src/html/htmlwin.cpp:723
+#, c-format
+msgid "HTML anchor %s does not exist."
+msgstr "HTML 锚点 %s 不存在。"
+
+#: ../src/html/htmlwin.cpp:1057
+#, c-format
+msgid "Copied to clipboard:\"%s\""
+msgstr "已复制到剪贴板：\"%s\""
+
+#: ../src/html/htmprint.cpp:269
+msgid ""
+"This document doesn't fit on the page horizontally and will be truncated "
+"when it is printed."
+msgstr "此文档宽度超出页面，打印时将被截断。"
+
+#: ../src/html/htmprint.cpp:285
+#, c-format
+msgid ""
+"The document \"%s\" doesn't fit on the page horizontally and will be "
+"truncated if printed.\n"
+"\n"
+"Would you like to proceed with printing it nevertheless?"
+msgstr ""
+"文档 \"%s\" 的宽度超出页面，打印时将被截断。\n"
+"\n"
+"仍要继续打印吗？"
+
+#: ../src/html/htmprint.cpp:296
+msgid ""
+"If possible, try changing the layout parameters to make the printout more "
+"narrow."
+msgstr "如有可能，请尝试调整布局参数，使打印输出更窄。"
+
+#: ../src/html/htmprint.cpp:445
+msgid ": file does not exist!"
+msgstr ": 文件不存在！"
+
+#. TRANSLATORS: %s may be a document title.
+#: ../src/html/htmprint.cpp:717
+#, c-format
+msgid "%s Preview"
+msgstr "%s 预览"
+
+#: ../src/html/htmprint.cpp:755 ../src/richtext/richtextprint.cpp:618
+msgid ""
+"There was a problem during page setup: you may need to set a default printer."
+msgstr "页面设置时出现问题：可能需要设置默认打印机。"
+
+#: ../src/msw/clipbrd.cpp:80
+msgid "Failed to open the clipboard."
+msgstr "无法打开剪贴板。"
+
+#: ../src/msw/clipbrd.cpp:101
+msgid "Failed to close the clipboard."
+msgstr "无法关闭剪贴板。"
+
+#: ../src/msw/clipbrd.cpp:113
+msgid "Failed to empty the clipboard."
+msgstr "无法清空剪贴板。"
+
+#: ../src/msw/clipbrd.cpp:284
+msgid "Failed to put data on the clipboard"
+msgstr "无法将数据放入剪贴板"
+
+#: ../src/msw/clipbrd.cpp:326
+msgid "Failed to get data from the clipboard"
+msgstr "无法从剪贴板获取数据"
+
+#: ../src/msw/clipbrd.cpp:363
+msgid "Failed to retrieve the supported clipboard formats"
+msgstr "无法获取支持的剪贴板格式"
+
+#: ../src/msw/colordlg.cpp:228
+#, c-format
+msgid "Colour selection dialog failed with error %0lx."
+msgstr "颜色选择对话框出错，代码 %0lx。"
+
+#: ../src/msw/cursor.cpp:141
+msgid "Failed to create cursor."
+msgstr "无法创建光标。"
+
+#: ../src/msw/dde.cpp:279
+#, c-format
+msgid "Failed to register DDE server '%s'"
+msgstr "无法注册 DDE 服务器 '%s'"
+
+#: ../src/msw/dde.cpp:300
+#, c-format
+msgid "Failed to unregister DDE server '%s'"
+msgstr "无法取消注册 DDE 服务器 '%s'"
+
+#: ../src/msw/dde.cpp:428
+#, c-format
+msgid "Failed to create connection to server '%s' on topic '%s'"
+msgstr "无法创建到服务器 '%s' 的连接（主题 '%s'）"
+
+#: ../src/msw/dde.cpp:655
+msgid "DDE poke request failed"
+msgstr "DDE Poke 请求失败"
+
+#: ../src/msw/dde.cpp:674
+msgid "Failed to establish an advise loop with DDE server"
+msgstr "无法与 DDE 服务器建立 Advise 循环"
+
+#: ../src/msw/dde.cpp:693
+msgid "Failed to terminate the advise loop with DDE server"
+msgstr "无法终止与 DDE 服务器的 Advise 循环"
+
+#: ../src/msw/dde.cpp:768
+msgid "Failed to send DDE advise notification"
+msgstr "无法发送 DDE Advise 通知"
+
+#: ../src/msw/dde.cpp:1085
+msgid "Failed to create DDE string"
+msgstr "无法创建 DDE 字符串"
+
+#: ../src/msw/dde.cpp:1131
+msgid "no DDE error."
+msgstr "无 DDE 错误。"
+
+#: ../src/msw/dde.cpp:1135
+msgid "a request for a synchronous advise transaction has timed out."
+msgstr "同步 Advise 事务请求已超时。"
+
+#: ../src/msw/dde.cpp:1138
+msgid "the response to the transaction caused the DDE_FBUSY bit to be set."
+msgstr "事务响应导致 DDE_FBUSY 位被置位。"
+
+#: ../src/msw/dde.cpp:1141
+msgid "a request for a synchronous data transaction has timed out."
+msgstr "同步数据事务请求已超时。"
+
+#: ../src/msw/dde.cpp:1144
+msgid ""
+"a DDEML function was called without first calling the DdeInitialize "
+"function,\n"
+"or an invalid instance identifier\n"
+"was passed to a DDEML function."
+msgstr ""
+"调用了 DDEML 函数，但未先调用 DdeInitialize 函数，\n"
+"或向 DDEML 函数传递了无效的实例标识符。"
+
+#: ../src/msw/dde.cpp:1147
+msgid ""
+"an application initialized as APPCLASS_MONITOR has\n"
+"attempted to perform a DDE transaction,\n"
+"or an application initialized as APPCMD_CLIENTONLY has \n"
+"attempted to perform server transactions."
+msgstr ""
+"初始化为 APPCLASS_MONITOR 的应用程序\n"
+"尝试执行 DDE 事务，\n"
+"或初始化为 APPCMD_CLIENTONLY 的应用程序\n"
+"尝试执行服务器事务。"
+
+#: ../src/msw/dde.cpp:1150
+msgid "a request for a synchronous execute transaction has timed out."
+msgstr "同步执行事务请求已超时。"
+
+#: ../src/msw/dde.cpp:1153
+msgid "a parameter failed to be validated by the DDEML."
+msgstr "参数未能通过 DDEML 验证。"
+
+#: ../src/msw/dde.cpp:1156
+msgid "a DDEML application has created a prolonged race condition."
+msgstr "DDEML 应用程序造成了长时间的竞争条件。"
+
+#: ../src/msw/dde.cpp:1159
+msgid "a memory allocation failed."
+msgstr "内存分配失败。"
+
+#: ../src/msw/dde.cpp:1162
+msgid "a client's attempt to establish a conversation has failed."
+msgstr "客户端建立会话的尝试失败。"
+
+#: ../src/msw/dde.cpp:1165
+msgid "a transaction failed."
+msgstr "事务失败。"
+
+#: ../src/msw/dde.cpp:1168
+msgid "a request for a synchronous poke transaction has timed out."
+msgstr "同步 Poke 事务请求已超时。"
+
+#: ../src/msw/dde.cpp:1171
+msgid "an internal call to the PostMessage function has failed. "
+msgstr "内部调用 PostMessage 函数失败。"
+
+#: ../src/msw/dde.cpp:1174
+msgid "reentrancy problem."
+msgstr "重入问题。"
+
+#: ../src/msw/dde.cpp:1177
+msgid ""
+"a server-side transaction was attempted on a conversation\n"
+"that was terminated by the client, or the server\n"
+"terminated before completing a transaction."
+msgstr ""
+"尝试在客户端已终止的会话上执行服务器端事务，\n"
+"或服务器在完成事务前已终止。"
+
+#: ../src/msw/dde.cpp:1180
+msgid "an internal error has occurred in the DDEML."
+msgstr "DDEML 发生内部错误。"
+
+#: ../src/msw/dde.cpp:1183
+msgid "a request to end an advise transaction has timed out."
+msgstr "结束 Advise 事务的请求已超时。"
+
+#: ../src/msw/dde.cpp:1186
+msgid ""
+"an invalid transaction identifier was passed to a DDEML function.\n"
+"Once the application has returned from an XTYP_XACT_COMPLETE callback,\n"
+"the transaction identifier for that callback is no longer valid."
+msgstr ""
+"向 DDEML 函数传递了无效的事务标识符。\n"
+"一旦应用程序从 XTYP_XACT_COMPLETE 回调返回，\n"
+"该回调的事务标识符即不再有效。"
+
+#: ../src/msw/dde.cpp:1189
+#, c-format
+msgid "Unknown DDE error %08x"
+msgstr "未知 DDE 错误 %08x"
+
+#: ../src/msw/dialup.cpp:343
+msgid ""
+"Dial up functions are unavailable because the remote access service (RAS) is "
+"not installed on this machine. Please install it."
+msgstr "本机未安装远程访问服务 (RAS)，拨号功能不可用。请安装该服务。"
+
+#: ../src/msw/dialup.cpp:402
+#, c-format
+msgid ""
+"The version of remote access service (RAS) installed on this machine is too "
+"old, please upgrade (the following required function is missing: %s)."
+msgstr ""
+"本机安装的远程访问服务 (RAS) 版本过旧，请升级（缺少下列必要的函数：%s）。"
+
+#: ../src/msw/dialup.cpp:437
+msgid "Failed to retrieve text of RAS error message"
+msgstr "无法获取 RAS 错误消息文本"
+
+#: ../src/msw/dialup.cpp:440
+#, c-format
+msgid "unknown error (error code %08x)."
+msgstr "未知错误（错误代码 %08x）。"
+
+#: ../src/msw/dialup.cpp:492
+#, c-format
+msgid "Cannot find active dialup connection: %s"
+msgstr "无法找到活动的拨号连接：%s"
+
+#: ../src/msw/dialup.cpp:513
+msgid "Several active dialup connections found, choosing one randomly."
+msgstr "找到多个活动拨号连接，随机选择一个。"
+
+#: ../src/msw/dialup.cpp:598 ../src/msw/dialup.cpp:832
+#, c-format
+msgid "Failed to establish dialup connection: %s"
+msgstr "无法建立拨号连接：%s"
+
+#: ../src/msw/dialup.cpp:664
+#, c-format
+msgid "Failed to get ISP names: %s"
+msgstr "无法获取 ISP 名称：%s"
+
+#: ../src/msw/dialup.cpp:712
+msgid "Failed to connect: no ISP to dial."
+msgstr "连接失败：没有 ISP 可拨号。"
+
+#: ../src/msw/dialup.cpp:732
+msgid "Choose ISP to dial"
+msgstr "选择 ISP 进行拨号"
+
+#: ../src/msw/dialup.cpp:733
+msgid "Please choose which ISP do you want to connect to"
+msgstr "请选择要连接的 ISP"
+
+#: ../src/msw/dialup.cpp:766
+msgid "Failed to connect: missing username/password."
+msgstr "连接失败：缺少用户名/密码。"
+
+#: ../src/msw/dialup.cpp:796
+msgid "Cannot find the location of address book file"
+msgstr "无法找到地址簿文件的位置"
+
+#: ../src/msw/dialup.cpp:827
+#, c-format
+msgid "Failed to initiate dialup connection: %s"
+msgstr "无法初始化拨号连接：%s"
+
+#: ../src/msw/dialup.cpp:897
+msgid "Cannot hang up - no active dialup connection."
+msgstr "无法挂断：没有活动的拨号连接。"
+
+#: ../src/msw/dialup.cpp:907
+#, c-format
+msgid "Failed to terminate the dialup connection: %s"
+msgstr "无法终止拨号连接：%s"
+
+#: ../src/msw/dib.cpp:313
+#, c-format
+msgid "Failed to save the bitmap image to file \"%s\"."
+msgstr "无法将位图图像保存到文件 \"%s\"。"
+
+#: ../src/msw/dib.cpp:543
+#, c-format
+msgid "Failed to allocate %luKb of memory for bitmap data."
+msgstr "无法为位图数据分配 %lu KB 内存。"
+
+#: ../src/msw/dir.cpp:241
+#, c-format
+msgid "Cannot enumerate files in directory '%s'"
+msgstr "无法枚举目录 '%s' 中的文件"
+
+#: ../src/msw/dirdlg.cpp:368
+msgid "Couldn't obtain folder name"
+msgstr "无法获取文件夹名称"
+
+#: ../src/msw/dlmsw.cpp:163
+#, c-format
+msgid "(error %d: %s)"
+msgstr "(错误 %d：%s)"
+
+#: ../src/msw/dragimag.cpp:143 ../src/msw/dragimag.cpp:178
+#: ../src/msw/imaglist.cpp:309 ../src/msw/imaglist.cpp:331
+msgid "Couldn't add an image to the image list."
+msgstr "无法将图像添加到图像列表。"
+
+#: ../src/msw/enhmeta.cpp:94
+#, c-format
+msgid "Failed to load metafile from file \"%s\"."
+msgstr "无法从文件 \"%s\" 加载图元文件。"
+
+#: ../src/msw/fdrepdlg.cpp:412
+#, c-format
+msgid "Failed to create the standard find/replace dialog (error code %d)"
+msgstr "无法创建标准「查找/替换」对话框（错误代码 %d）"
+
+#: ../src/msw/filedlg.cpp:1241
+msgid "Access to the file system is not allowed from secure desktop."
+msgstr "在安全桌面环境下不允许访问文件系统。"
+
+#: ../src/msw/filedlg.cpp:1242
+msgid "Security warning"
+msgstr "安全警告"
+
+#: ../src/msw/filedlg.cpp:1533
+#, c-format
+msgid "File dialog failed with error code %0lx."
+msgstr "文件对话框出错，代码 %0lx。"
+
+#: ../src/msw/font.cpp:1120
+#, c-format
+msgid "Font file \"%s\" couldn't be loaded"
+msgstr "无法加载字体文件 \"%s\""
+
+#: ../src/msw/fontdlg.cpp:220
+#, c-format
+msgid "Common dialog failed with error code %0lx."
+msgstr "通用对话框出错，代码 %0lx。"
+
+#: ../src/msw/fswatcher.cpp:67
+msgid "Ungraceful worker thread termination"
+msgstr "工作线程非正常终止"
+
+#: ../src/msw/fswatcher.cpp:81
+msgid "Unable to create IOCP worker thread"
+msgstr "无法创建 IOCP 工作线程"
+
+#: ../src/msw/fswatcher.cpp:88
+msgid "Unable to start IOCP worker thread"
+msgstr "无法启动 IOCP 工作线程"
+
+#: ../src/msw/fswatcher.cpp:140
+msgid "Monitoring individual files for changes is not supported currently."
+msgstr "当前不支持监视单独文件的更改。"
+
+#: ../src/msw/fswatcher.cpp:165
+#, c-format
+msgid "Unable to set up watch for '%s'"
+msgstr "无法为 '%s' 设置监视"
+
+#: ../src/msw/fswatcher.cpp:466
+#, c-format
+msgid "Can't monitor non-existent directory \"%s\" for changes."
+msgstr "无法监视不存在的目录 \"%s\" 的更改。"
+
+#: ../src/msw/glcanvas.cpp:577 ../src/unix/glx11.cpp:507
+msgid "OpenGL 3.0 or later is not supported by the OpenGL driver."
+msgstr "OpenGL 驱动程序不支持 OpenGL 3.0 或更高版本。"
+
+#: ../src/msw/glcanvas.cpp:601 ../src/osx/glcanvas_osx.cpp:395
+#: ../src/unix/glegl.cpp:304 ../src/unix/glx11.cpp:553
+msgid "Couldn't create OpenGL context"
+msgstr "无法创建 OpenGL 上下文"
+
+#: ../src/msw/glcanvas.cpp:1294
+msgid "Failed to initialize OpenGL"
+msgstr "无法初始化 OpenGL"
+
+#: ../src/msw/graphicsd2d.cpp:607
+msgid "Could not register custom DirectWrite font loader."
+msgstr "无法注册自定义 DirectWrite 字体加载器。"
+
+#: ../src/msw/helpchm.cpp:48
+msgid ""
+"MS HTML Help functions are unavailable because the MS HTML Help library is "
+"not installed on this machine. Please install it."
+msgstr "缺少微软 HTML 帮助库，无法使用微软 HTML 帮助功能。请安装该库。"
+
+#: ../src/msw/helpchm.cpp:55
+msgid "Failed to initialize MS HTML Help."
+msgstr "无法初始化微软 HTML 帮助。"
+
+#: ../src/msw/iniconf.cpp:458
+#, c-format
+msgid "Can't delete the INI file '%s'"
+msgstr "无法删除 INI 文件 '%s'"
+
+#: ../src/msw/listctrl.cpp:995
+#, c-format
+msgid "Couldn't retrieve information about list control item %d."
+msgstr "无法获取列表控件第 %d 项的信息。"
+
+#: ../src/msw/mdi.cpp:170 ../src/qt/mdi.cpp:253
+msgid "&Cascade"
+msgstr "层叠(&C)"
+
+#: ../src/msw/mdi.cpp:171
+msgid "Tile &Horizontally"
+msgstr "水平平铺(&H)"
+
+#: ../src/msw/mdi.cpp:172
+msgid "Tile &Vertically"
+msgstr "垂直平铺(&V)"
+
+#: ../src/msw/mdi.cpp:174
+msgid "&Arrange Icons"
+msgstr "排列图标(&A)"
+
+#: ../src/msw/mdi.cpp:621
+msgid "Failed to create MDI parent frame."
+msgstr "无法创建 MDI 父框架。"
+
+#: ../src/msw/mimetype.cpp:234
+#, c-format
+msgid "Failed to create registry entry for '%s' files."
+msgstr "无法为 '%s' 文件创建注册表条目。"
+
+#: ../src/msw/ole/automtn.cpp:495
+#, c-format
+msgid "Failed to find CLSID of \"%s\""
+msgstr "无法找到 \"%s\" 的 CLSID"
+
+#: ../src/msw/ole/automtn.cpp:512
+#, c-format
+msgid "Failed to create an instance of \"%s\""
+msgstr "无法创建 \"%s\" 的实例"
+
+#: ../src/msw/ole/automtn.cpp:552
+#, c-format
+msgid "Cannot get an active instance of \"%s\""
+msgstr "无法获取 \"%s\" 的活动实例"
+
+#: ../src/msw/ole/automtn.cpp:564
+#, c-format
+msgid "Failed to get OLE automation interface for \"%s\""
+msgstr "无法获取 \"%s\" 的 OLE 自动化接口"
+
+#: ../src/msw/ole/automtn.cpp:621
+msgid "Unknown name or named argument."
+msgstr "未知名称或命名参数。"
+
+#: ../src/msw/ole/automtn.cpp:625
+msgid "Incorrect number of arguments."
+msgstr "参数数量不正确。"
+
+#: ../src/msw/ole/automtn.cpp:637
+msgid "Unknown exception"
+msgstr "未知异常"
+#: ../src/msw/ole/automtn.cpp:642
+msgid "Method or property not found."
+msgstr "未找到方法或属性。"
+
+#: ../src/msw/ole/automtn.cpp:646
+msgid "Overflow while coercing argument values."
+msgstr "强制转换参数值时发生溢出。"
+
+#: ../src/msw/ole/automtn.cpp:650
+msgid "Object implementation does not support named arguments."
+msgstr "对象实现不支持命名参数。"
+
+#: ../src/msw/ole/automtn.cpp:654
+msgid "The locale ID is unknown."
+msgstr "区域设置 ID 未知。"
+
+#: ../src/msw/ole/automtn.cpp:658
+msgid "Missing a required parameter."
+msgstr "缺少必要参数。"
+
+#: ../src/msw/ole/automtn.cpp:662
+#, c-format
+msgid "Argument %u not found."
+msgstr "未找到参数 %u。"
+
+#: ../src/msw/ole/automtn.cpp:666
+#, c-format
+msgid "Type mismatch in argument %u."
+msgstr "参数 %u 的类型不匹配。"
+
+#: ../src/msw/ole/automtn.cpp:670
+msgid "The system cannot find the file specified."
+msgstr "系统未找到指定文件。"
+
+#: ../src/msw/ole/automtn.cpp:674
+msgid "Class not registered."
+msgstr "类未注册。"
+
+#: ../src/msw/ole/automtn.cpp:678
+#, c-format
+msgid "Unknown error %08x"
+msgstr "未知错误 %08x"
+
+#: ../src/msw/ole/automtn.cpp:682
+#, c-format
+msgid "OLE Automation error in %s: %s"
+msgstr "在 %s 中发生 OLE 自动化错误：%s"
+
+#: ../src/msw/ole/dataobj.cpp:385
+#, c-format
+msgid "Couldn't register clipboard format '%s'."
+msgstr "无法注册剪贴板格式 '%s'。"
+
+#: ../src/msw/ole/dataobj.cpp:402
+#, c-format
+msgid "The clipboard format '%d' doesn't exist."
+msgstr "剪贴板格式 '%d' 不存在。"
+
+#: ../src/msw/progdlg.cpp:1025
+msgid "Skip"
+msgstr "跳过"
+
+#: ../src/msw/registry.cpp:141
+#, c-format
+msgid "unknown (%lu)"
+msgstr "未知（%lu）"
+
+#: ../src/msw/registry.cpp:409
+#, c-format
+msgid "Can't get info about registry key '%s'"
+msgstr "无法获取注册表项 '%s' 的信息"
+
+#: ../src/msw/registry.cpp:445
+#, c-format
+msgid "Can't open registry key '%s'"
+msgstr "无法打开注册表项 '%s'"
+
+#: ../src/msw/registry.cpp:478
+#, c-format
+msgid "Can't create registry key '%s'"
+msgstr "无法创建注册表项 '%s'"
+
+#: ../src/msw/registry.cpp:497
+#, c-format
+msgid "Can't close registry key '%s'"
+msgstr "无法关闭注册表项 '%s'"
+
+#: ../src/msw/registry.cpp:512
+#, c-format
+msgid "Registry value '%s' already exists."
+msgstr "注册表值 '%s' 已存在。"
+
+#: ../src/msw/registry.cpp:520
+#, c-format
+msgid "Failed to rename registry value '%s' to '%s'."
+msgstr "无法将注册表值 '%s' 重命名为 '%s'。"
+
+#: ../src/msw/registry.cpp:575
+#, c-format
+msgid "Can't copy values of unsupported type %d."
+msgstr "无法复制不支持的类型 %d 的值。"
+
+#: ../src/msw/registry.cpp:586
+#, c-format
+msgid "Registry key '%s' does not exist, cannot rename it."
+msgstr "注册表项 '%s' 不存在，无法重命名。"
+
+#: ../src/msw/registry.cpp:617
+#, c-format
+msgid "Registry key '%s' already exists."
+msgstr "注册表项 '%s' 已存在。"
+
+#: ../src/msw/registry.cpp:625
+#, c-format
+msgid "Failed to rename the registry key '%s' to '%s'."
+msgstr "无法将注册表项 '%s' 重命名为 '%s'。"
+
+#: ../src/msw/registry.cpp:670
+#, c-format
+msgid "Failed to copy the registry subkey '%s' to '%s'."
+msgstr "无法将注册表子项 '%s' 复制到 '%s'。"
+
+#: ../src/msw/registry.cpp:683
+#, c-format
+msgid "Failed to copy registry value '%s'"
+msgstr "无法复制注册表值 '%s'"
+
+#: ../src/msw/registry.cpp:692
+#, c-format
+msgid "Failed to copy the contents of registry key '%s' to '%s'."
+msgstr "无法将注册表项 '%s' 的内容复制到 '%s'。"
+
+#: ../src/msw/registry.cpp:718
+#, c-format
+msgid ""
+"Registry key '%s' is needed for normal system operation,\n"
+"deleting it will leave your system in unusable state:\n"
+"operation aborted."
+msgstr ""
+"系统正常运行需要注册表项 '%s'。\n"
+"删除它会导致系统无法使用：\n"
+"操作已中止。"
+
+#: ../src/msw/registry.cpp:754
+#, c-format
+msgid "Can't delete key '%s'"
+msgstr "无法删除注册表项 '%s'"
+
+#: ../src/msw/registry.cpp:782
+#, c-format
+msgid "Can't delete value '%s' from key '%s'"
+msgstr "无法从注册表项 '%2$s' 中删除值 '%1$s'"
+
+#: ../src/msw/registry.cpp:855 ../src/msw/registry.cpp:887
+#: ../src/msw/registry.cpp:929 ../src/msw/registry.cpp:1000
+#, c-format
+msgid "Can't read value of key '%s'"
+msgstr "无法读取注册表项 '%s' 的值"
+
+#: ../src/msw/registry.cpp:873 ../src/msw/registry.cpp:915
+#: ../src/msw/registry.cpp:963 ../src/msw/registry.cpp:1106
+#, c-format
+msgid "Can't set value of '%s'"
+msgstr "无法设置 '%s' 的值"
+
+#: ../src/msw/registry.cpp:894 ../src/msw/registry.cpp:943
+#, c-format
+msgid "Registry value \"%s\" is not numeric (but of type %s)"
+msgstr "注册表值 \"%s\" 不是数字类型（而是 %s 类型）"
+
+#: ../src/msw/registry.cpp:979
+#, c-format
+msgid "Registry value \"%s\" is not binary (but of type %s)"
+msgstr "注册表值 \"%s\" 不是二进制类型（而是 %s 类型）"
+
+#: ../src/msw/registry.cpp:1028
+#, c-format
+msgid "Registry value \"%s\" is not text (but of type %s)"
+msgstr "注册表值 \"%s\" 不是文本类型（而是 %s 类型）"
+
+#: ../src/msw/registry.cpp:1089
+#, c-format
+msgid "Can't read value of '%s'"
+msgstr "无法读取 '%s' 的值"
+
+#: ../src/msw/registry.cpp:1157
+#, c-format
+msgid "Can't enumerate values of key '%s'"
+msgstr "无法枚举注册表项 '%s' 的值"
+
+#: ../src/msw/registry.cpp:1196
+#, c-format
+msgid "Can't enumerate subkeys of key '%s'"
+msgstr "无法枚举注册表项 '%s' 的子项"
+
+#: ../src/msw/registry.cpp:1262
+#, c-format
+msgid ""
+"Exporting registry key: file \"%s\" already exists and won't be overwritten."
+msgstr "导出注册表项：文件 \"%s\" 已存在，不会被覆盖。"
+
+#: ../src/msw/registry.cpp:1411
+#, c-format
+msgid "Can't export value of unsupported type %d."
+msgstr "无法导出不支持的类型 %d 的值。"
+
+#: ../src/msw/registry.cpp:1427
+#, c-format
+msgid "Ignoring value \"%s\" of the key \"%s\"."
+msgstr "忽略注册表项 \"%2$s\" 的值 \"%1$s\"。"
+
+#: ../src/msw/textctrl.cpp:596
+msgid ""
+"Impossible to create a rich edit control, using simple text control instead. "
+"Please reinstall riched32.dll"
+msgstr ""
+"无法创建富文本编辑控件，将改用普通文本控件。请重新安装 riched32.dll"
+
+#: ../src/msw/thread.cpp:522 ../src/unix/threadpsx.cpp:850
+msgid "Cannot start thread: error writing TLS."
+msgstr "无法启动线程：写入 TLS 出错。"
+
+#: ../src/msw/thread.cpp:613
+msgid "Can't set thread priority"
+msgstr "无法设置线程优先级"
+
+#: ../src/msw/thread.cpp:649
+msgid "Can't create thread"
+msgstr "无法创建线程"
+
+#: ../src/msw/thread.cpp:668
+msgid "Couldn't terminate thread"
+msgstr "无法终止线程"
+
+#: ../src/msw/thread.cpp:799
+msgid "Cannot wait for thread termination"
+msgstr "无法等待线程终止"
+
+#: ../src/msw/thread.cpp:873
+#, c-format
+msgid "Cannot suspend thread %lx"
+msgstr "无法挂起线程 %lx"
+
+#: ../src/msw/thread.cpp:903
+#, c-format
+msgid "Cannot resume thread %lx"
+msgstr "无法恢复线程 %lx"
+
+#: ../src/msw/thread.cpp:932
+msgid "Couldn't get the current thread pointer"
+msgstr "无法获取当前线程指针"
+
+#: ../src/msw/thread.cpp:1333
+msgid ""
+"Thread module initialization failed: impossible to allocate index in thread "
+"local storage"
+msgstr "线程模块初始化失败：无法在线程本地存储区中分配索引"
+
+#: ../src/msw/thread.cpp:1345
+msgid ""
+"Thread module initialization failed: cannot store value in thread local "
+"storage"
+msgstr "线程模块初始化失败：无法在线程本地存储区中存放值"
+
+#: ../src/msw/timer.cpp:133
+msgid "Couldn't create a timer"
+msgstr "无法创建定时器"
+
+#: ../src/msw/utils.cpp:372
+msgid "can't find user's HOME, using current directory."
+msgstr "找不到用户的 HOME，改用当前目录。"
+
+#: ../src/msw/utils.cpp:662
+#, c-format
+msgid "Failed to kill process %d"
+msgstr "无法终止进程 %d"
+
+#: ../src/msw/utils.cpp:986
+#, c-format
+msgid "Failed to load resource \"%s\"."
+msgstr "无法加载资源 \"%s\"。"
+
+#: ../src/msw/utils.cpp:993
+#, c-format
+msgid "Failed to lock resource \"%s\"."
+msgstr "无法锁定资源 \"%s\"。"
+
+#. TRANSLATORS: MS Windows build number
+#: ../src/msw/utils.cpp:1209
+#, c-format
+msgid "build %lu"
+msgstr "内部版本 %lu"
+
+#: ../src/msw/utils.cpp:1218
+msgid ", 64-bit edition"
+msgstr "，64位版"
+
+#: ../src/msw/utilsexc.cpp:224
+msgid "Failed to create an anonymous pipe"
+msgstr "无法创建匿名管道"
+
+#: ../src/msw/utilsexc.cpp:697
+msgid "Failed to redirect the child process IO"
+msgstr "无法重定向子进程 I/O"
+
+#: ../src/msw/utilsexc.cpp:870
+#, c-format
+msgid "Execution of command '%s' failed"
+msgstr "命令 '%s' 执行失败"
+
+#: ../src/msw/volume.cpp:337
+msgid "Failed to load mpr.dll."
+msgstr "无法加载 mpr.dll。"
+
+#: ../src/msw/volume.cpp:506
+#, c-format
+msgid "Cannot read typename from '%s'!"
+msgstr "无法从 '%s' 中读取类型名称！"
+
+#: ../src/msw/volume.cpp:615
+#, c-format
+msgid "Cannot load icon from '%s'."
+msgstr "无法从 '%s' 加载图标。"
+
+#: ../src/msw/webview_edge.cpp:285
+msgid "This program was compiled without support for setting Edge proxy."
+msgstr "本程序编译时未启用设置 Edge 代理的支持。"
+
+#: ../src/msw/webview_ie.cpp:1010
+msgid "Failed to find web view emulation level in the registry"
+msgstr "无法在注册表中找到 WebView 仿真级别"
+
+#: ../src/msw/webview_ie.cpp:1019
+msgid "Failed to set web view to modern emulation level"
+msgstr "无法将 WebView 设置为现代仿真级别"
+
+#: ../src/msw/webview_ie.cpp:1027
+msgid "Failed to reset web view to standard emulation level"
+msgstr "无法将 WebView 重置为标准仿真级别"
+
+#: ../src/msw/webview_ie.cpp:1049
+msgid "Can't run JavaScript script without a valid HTML document"
+msgstr "没有有效的 HTML 文档，无法运行 JavaScript 脚本"
+
+#: ../src/msw/webview_ie.cpp:1056
+msgid "Can't get the JavaScript object"
+msgstr "无法获取 JavaScript 对象"
+
+#: ../src/msw/webview_ie.cpp:1070
+msgid "failed to evaluate"
+msgstr "求值失败"
+
+#: ../src/osx/cocoa/filedlg.mm:412
+msgid "File type:"
+msgstr "文件类型："
+
+#: ../src/osx/cocoa/menu.mm:242
+msgctxt "macOS menu name"
+msgid "Window"
+msgstr "窗口"
+
+#: ../src/osx/cocoa/menu.mm:259
+msgctxt "macOS menu name"
+msgid "Help"
+msgstr "帮助"
+
+#: ../src/osx/cocoa/menu.mm:298
+msgctxt "macOS menu item"
+msgid "Minimize"
+msgstr "最小化"
+
+#: ../src/osx/cocoa/menu.mm:303
+msgctxt "macOS menu item"
+msgid "Zoom"
+msgstr "缩放"
+
+#: ../src/osx/cocoa/menu.mm:309
+msgctxt "macOS menu item"
+msgid "Bring All to Front"
+msgstr "前置全部窗口"
+
+#: ../src/osx/core/sound.cpp:143
+#, c-format
+msgid "Failed to load sound from \"%s\" (error %d)."
+msgstr "无法从 \"%s\" 加载声音（错误 %d）。"
+
+#: ../src/osx/fontutil.cpp:80
+#, c-format
+msgid "Font file \"%s\" doesn't exist."
+msgstr "字体文件 \"%s\" 不存在。"
+
+#: ../src/osx/fontutil.cpp:88
+#, c-format
+msgid ""
+"Font file \"%s\" cannot be used as it is not inside the font directory "
+"\"%s\"."
+msgstr "无法使用字体文件 \"%s\"，因为它不在字体目录 \"%s\" 内。"
+
+#: ../src/osx/menu_osx.cpp:496
+#, c-format
+msgctxt "macOS menu item"
+msgid "About %s"
+msgstr "关于 %s"
+
+#: ../src/osx/menu_osx.cpp:499
+msgctxt "macOS menu item"
+msgid "About..."
+msgstr "关于..."
+
+#: ../src/osx/menu_osx.cpp:508
+msgctxt "macOS menu item"
+msgid "Preferences..."
+msgstr "偏好设置..."
+
+#: ../src/osx/menu_osx.cpp:512
+msgctxt "macOS menu item"
+msgid "Services"
+msgstr "服务"
+
+#: ../src/osx/menu_osx.cpp:519
+#, c-format
+msgctxt "macOS menu item"
+msgid "Hide %s"
+msgstr "隐藏 %s"
+
+#: ../src/osx/menu_osx.cpp:522
+msgctxt "macOS menu item"
+msgid "Hide Application"
+msgstr "隐藏应用程序"
+
+#: ../src/osx/menu_osx.cpp:526
+msgctxt "macOS menu item"
+msgid "Hide Others"
+msgstr "隐藏其他"
+
+#: ../src/osx/menu_osx.cpp:528
+msgctxt "macOS menu item"
+msgid "Show All"
+msgstr "显示全部"
+
+#: ../src/osx/menu_osx.cpp:534
+#, c-format
+msgctxt "macOS menu item"
+msgid "Quit %s"
+msgstr "退出 %s"
+
+#: ../src/osx/menu_osx.cpp:537
+msgctxt "macOS menu item"
+msgid "Quit Application"
+msgstr "退出应用程序"
+
+#: ../src/osx/webview_webkit.mm:444
+msgid "Printing is not supported by the system web control"
+msgstr "系统 Web 控件不支持打印"
+
+#: ../src/osx/webview_webkit.mm:453
+msgid "Print operation could not be initialized"
+msgstr "无法初始化打印操作"
+
+#. TRANSLATORS: Label of font point size
+#: ../src/propgrid/advprops.cpp:605
+msgid "Point Size"
+msgstr "字号"
+
+#. TRANSLATORS: Label of font face name
+#: ../src/propgrid/advprops.cpp:615
+msgid "Face Name"
+msgstr "字体名称"
+
+#. TRANSLATORS: Label of font style
+#: ../src/propgrid/advprops.cpp:623 ../src/richtext/richtextformatdlg.cpp:331
+msgid "Style"
+msgstr "样式"
+
+#. TRANSLATORS: Label of font weight
+#: ../src/propgrid/advprops.cpp:628
+msgid "Weight"
+msgstr "字体粗细"
+
+#. TRANSLATORS: Label of underlined font
+#: ../src/propgrid/advprops.cpp:633 ../src/richtext/richtextfontpage.cpp:358
+msgid "Underlined"
+msgstr "下划线"
+
+#. TRANSLATORS: Label of font family
+#: ../src/propgrid/advprops.cpp:637
+msgid "Family"
+msgstr "字体族"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:801
+msgid "AppWorkspace"
+msgstr "应用程序工作区"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:802
+msgid "ActiveBorder"
+msgstr "活动窗口边框"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:803
+msgid "ActiveCaption"
+msgstr "活动窗口标题栏"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:804
+msgid "ButtonFace"
+msgstr "按钮面"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:805
+msgid "ButtonHighlight"
+msgstr "按钮高亮"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:806
+msgid "ButtonShadow"
+msgstr "按钮阴影"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:807
+msgid "ButtonText"
+msgstr "按钮文本"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:808
+msgid "CaptionText"
+msgstr "标题栏文本"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:809
+msgid "ControlDark"
+msgstr "控件暗色"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:810
+msgid "ControlLight"
+msgstr "控件亮色"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:812
+msgid "GrayText"
+msgstr "灰色文本"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:813
+msgid "Highlight"
+msgstr "高亮"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:814
+msgid "HighlightText"
+msgstr "高亮文本"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:815
+msgid "InactiveBorder"
+msgstr "非活动窗口边框"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:816
+msgid "InactiveCaption"
+msgstr "非活动窗口标题栏"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:817
+msgid "InactiveCaptionText"
+msgstr "非活动窗口标题栏文本"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:818
+msgid "Menu"
+msgstr "菜单"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:819
+msgid "Scrollbar"
+msgstr "滚动条"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:820
+msgid "Tooltip"
+msgstr "工具提示"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:821
+msgid "TooltipText"
+msgstr "工具提示文本"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:822
+msgid "Window"
+msgstr "窗口"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:823
+msgid "WindowFrame"
+msgstr "窗口框架"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:824
+msgid "WindowText"
+msgstr "窗口文本"
+
+#. TRANSLATORS: Custom colour choice entry
+#: ../src/propgrid/advprops.cpp:825 ../src/propgrid/advprops.cpp:1532
+#: ../src/propgrid/advprops.cpp:1576
+msgid "Custom"
+msgstr "自定义"
+
+#: ../src/propgrid/advprops.cpp:1558
+msgid "Black"
+msgstr "黑色"
+
+#: ../src/propgrid/advprops.cpp:1559
+msgid "Maroon"
+msgstr "栗色"
+
+#: ../src/propgrid/advprops.cpp:1560
+msgid "Navy"
+msgstr "海军蓝"
+
+#: ../src/propgrid/advprops.cpp:1561
+msgid "Purple"
+msgstr "紫色"
+
+#: ../src/propgrid/advprops.cpp:1562
+msgid "Teal"
+msgstr "青绿色"
+
+#: ../src/propgrid/advprops.cpp:1563
+msgid "Gray"
+msgstr "灰色"
+
+#: ../src/propgrid/advprops.cpp:1564
+msgid "Green"
+msgstr "绿色"
+
+#: ../src/propgrid/advprops.cpp:1565
+msgid "Olive"
+msgstr "橄榄色"
+
+#: ../src/propgrid/advprops.cpp:1566
+msgid "Brown"
+msgstr "棕色"
+
+#: ../src/propgrid/advprops.cpp:1567
+msgid "Blue"
+msgstr "蓝色"
+
+#: ../src/propgrid/advprops.cpp:1568
+msgid "Fuchsia"
+msgstr "品红"
+
+#: ../src/propgrid/advprops.cpp:1569
+msgid "Red"
+msgstr "红色"
+
+#: ../src/propgrid/advprops.cpp:1570
+msgid "Orange"
+msgstr "橙色"
+
+#: ../src/propgrid/advprops.cpp:1571
+msgid "Silver"
+msgstr "银色"
+
+#: ../src/propgrid/advprops.cpp:1572
+msgid "Lime"
+msgstr "酸橙色"
+
+#: ../src/propgrid/advprops.cpp:1573
+msgid "Aqua"
+msgstr "青色"
+
+#: ../src/propgrid/advprops.cpp:1574
+msgid "Yellow"
+msgstr "黄色"
+
+#: ../src/propgrid/advprops.cpp:1575
+msgid "White"
+msgstr "白色"
+
+#: ../src/propgrid/advprops.cpp:1718
+msgctxt "system cursor name"
+msgid "Default"
+msgstr "默认"
+
+#: ../src/propgrid/advprops.cpp:1719
+msgctxt "system cursor name"
+msgid "Arrow"
+msgstr "箭头"
+
+#: ../src/propgrid/advprops.cpp:1720
+msgctxt "system cursor name"
+msgid "Right Arrow"
+msgstr "右箭头"
+
+#: ../src/propgrid/advprops.cpp:1721
+msgctxt "system cursor name"
+msgid "Blank"
+msgstr "空白"
+
+#: ../src/propgrid/advprops.cpp:1722
+msgctxt "system cursor name"
+msgid "Bullseye"
+msgstr "靶心"
+
+#: ../src/propgrid/advprops.cpp:1723
+msgctxt "system cursor name"
+msgid "Character"
+msgstr "文字"
+
+#: ../src/propgrid/advprops.cpp:1724
+msgctxt "system cursor name"
+msgid "Cross"
+msgstr "十字"
+
+#: ../src/propgrid/advprops.cpp:1725
+msgctxt "system cursor name"
+msgid "Hand"
+msgstr "手形"
+
+#: ../src/propgrid/advprops.cpp:1726
+msgctxt "system cursor name"
+msgid "I-Beam"
+msgstr "I 形光标"
+
+#: ../src/propgrid/advprops.cpp:1727
+msgctxt "system cursor name"
+msgid "Left Button"
+msgstr "左键"
+
+#: ../src/propgrid/advprops.cpp:1728
+msgctxt "system cursor name"
+msgid "Magnifier"
+msgstr "放大镜"
+
+#: ../src/propgrid/advprops.cpp:1729
+msgctxt "system cursor name"
+msgid "Middle Button"
+msgstr "中键"
+
+#: ../src/propgrid/advprops.cpp:1730
+msgctxt "system cursor name"
+msgid "No Entry"
+msgstr "禁止"
+
+#: ../src/propgrid/advprops.cpp:1731
+msgctxt "system cursor name"
+msgid "Paint Brush"
+msgstr "画笔"
+
+#: ../src/propgrid/advprops.cpp:1732
+msgctxt "system cursor name"
+msgid "Pencil"
+msgstr "铅笔"
+
+#: ../src/propgrid/advprops.cpp:1733
+msgctxt "system cursor name"
+msgid "Point Left"
+msgstr "向左指"
+
+#: ../src/propgrid/advprops.cpp:1734
+msgctxt "system cursor name"
+msgid "Point Right"
+msgstr "向右指"
+
+#: ../src/propgrid/advprops.cpp:1735
+msgctxt "system cursor name"
+msgid "Question Arrow"
+msgstr "问号箭头"
+
+#: ../src/propgrid/advprops.cpp:1736
+msgctxt "system cursor name"
+msgid "Right Button"
+msgstr "右键"
+
+#: ../src/propgrid/advprops.cpp:1737
+msgctxt "system cursor name"
+msgid "Sizing NE-SW"
+msgstr "调整大小（右上-左下）"
+
+#: ../src/propgrid/advprops.cpp:1738
+msgctxt "system cursor name"
+msgid "Sizing N-S"
+msgstr "调整大小（上-下）"
+
+#: ../src/propgrid/advprops.cpp:1739
+msgctxt "system cursor name"
+msgid "Sizing NW-SE"
+msgstr "调整大小（左上-右下）"
+
+#: ../src/propgrid/advprops.cpp:1740
+msgctxt "system cursor name"
+msgid "Sizing W-E"
+msgstr "调整大小（左-右）"
+
+#: ../src/propgrid/advprops.cpp:1741
+msgctxt "system cursor name"
+msgid "Sizing"
+msgstr "调整大小"
+
+#: ../src/propgrid/advprops.cpp:1742
+msgctxt "system cursor name"
+msgid "Spraycan"
+msgstr "喷漆罐"
+
+#: ../src/propgrid/advprops.cpp:1743
+msgctxt "system cursor name"
+msgid "Wait"
+msgstr "等待"
+
+#: ../src/propgrid/advprops.cpp:1744
+msgctxt "system cursor name"
+msgid "Watch"
+msgstr "沙漏"
+
+#: ../src/propgrid/advprops.cpp:1745
+msgctxt "system cursor name"
+msgid "Wait Arrow"
+msgstr "等待箭头"
+
+#: ../src/propgrid/advprops.cpp:2109
+msgid "Make a selection:"
+msgstr "请选择："
+
+#: ../src/propgrid/manager.cpp:394
+msgid "Property"
+msgstr "属性"
+
+#: ../src/propgrid/manager.cpp:395
+msgid "Value"
+msgstr "值"
+
+#: ../src/propgrid/manager.cpp:1683
+msgid "Categorized Mode"
+msgstr "分类模式"
+
+#: ../src/propgrid/manager.cpp:1709
+msgid "Alphabetic Mode"
+msgstr "字母顺序模式"
+
+#. TRANSLATORS: Name of Boolean false value
+#: ../src/propgrid/propgrid.cpp:230
+msgid "False"
+msgstr "False"
+
+#. TRANSLATORS: Name of Boolean true value
+#: ../src/propgrid/propgrid.cpp:232
+msgid "True"
+msgstr "True"
+
+#. TRANSLATORS: Text  displayed for unspecified value
+#: ../src/propgrid/propgrid.cpp:428
+msgid "Unspecified"
+msgstr "未指定"
+
+#. TRANSLATORS: Caption of message box displaying any property error
+#: ../src/propgrid/propgrid.cpp:3145 ../src/propgrid/propgrid.cpp:3282
+msgid "Property Error"
+msgstr "属性错误"
+
+#: ../src/propgrid/propgrid.cpp:3259
+msgid "You have entered invalid value. Press ESC to cancel editing."
+msgstr "输入的值无效。按 Esc 取消编辑。"
+
+#: ../src/propgrid/propgrid.cpp:6608
+#, c-format
+msgid "Error in resource: %s"
+msgstr "资源错误：%s"
+
+#: ../src/propgrid/propgridiface.cpp:377
+#, c-format
+msgid ""
+"Type operation \"%s\" failed: Property labeled \"%s\" is of type \"%s\", NOT "
+"\"%s\"."
+msgstr ""
+"类型操作 \"%s\" 失败：标记为 \"%s\" 的属性类型为 \"%s\"，而不是 \"%s\""
+
+#: ../src/propgrid/props.cpp:159
+#, c-format
+msgid "Unknown base %d. Base 10 will be used."
+msgstr "未知基数 %d，将使用 10 进制。"
+
+#: ../src/propgrid/props.cpp:324
+#, c-format
+msgid "Value must be %s or higher."
+msgstr "数值必须大于或等于 %s。"
+
+#: ../src/propgrid/props.cpp:329 ../src/propgrid/props.cpp:356
+#, c-format
+msgid "Value must be between %s and %s."
+msgstr "数值必须在 %s 和 %s 之间。"
+
+#: ../src/propgrid/props.cpp:351
+#, c-format
+msgid "Value must be %s or less."
+msgstr "数值必须小于或等于 %s。"
+
+#: ../src/propgrid/props.cpp:1058
+#, c-format
+msgid "Not %s"
+msgstr "非 %s"
+
+#: ../src/propgrid/props.cpp:1770
+msgid "Choose a directory:"
+msgstr "选择目录："
+
+#: ../src/propgrid/props.cpp:2055
+msgid "Choose a file"
+msgstr "选择文件"
+
+#: ../src/qt/mdi.cpp:254
+msgid "&Tile"
+msgstr "平铺(&T)"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:147
+#: ../src/richtext/richtextformatdlg.cpp:376
+msgid "Background"
+msgstr "背景"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:159
+msgid "Background &colour:"
+msgstr "背景颜色(&c)："
+
+#: ../src/richtext/richtextbackgroundpage.cpp:161
+#: ../src/richtext/richtextbackgroundpage.cpp:163
+msgid "Enables a background colour."
+msgstr "启用背景颜色。"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:167
+#: ../src/richtext/richtextbackgroundpage.cpp:169
+msgid "The background colour."
+msgstr "背景色。"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:178
+msgid "Shadow"
+msgstr "阴影"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:193
+msgid "Use &shadow"
+msgstr "使用阴影(&s)"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:195
+#: ../src/richtext/richtextbackgroundpage.cpp:197
+msgid "Enables a shadow."
+msgstr "启用阴影。"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:211
+msgid "&Horizontal offset:"
+msgstr "水平偏移(&H)："
+
+#: ../src/richtext/richtextbackgroundpage.cpp:218
+#: ../src/richtext/richtextbackgroundpage.cpp:220
+msgid "The horizontal offset."
+msgstr "水平偏移。"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:224
+#: ../src/richtext/richtextbackgroundpage.cpp:227
+#: ../src/richtext/richtextbackgroundpage.cpp:228
+#: ../src/richtext/richtextbackgroundpage.cpp:247
+#: ../src/richtext/richtextbackgroundpage.cpp:250
+#: ../src/richtext/richtextbackgroundpage.cpp:251
+#: ../src/richtext/richtextbackgroundpage.cpp:287
+#: ../src/richtext/richtextbackgroundpage.cpp:290
+#: ../src/richtext/richtextbackgroundpage.cpp:291
+#: ../src/richtext/richtextbackgroundpage.cpp:314
+#: ../src/richtext/richtextbackgroundpage.cpp:317
+#: ../src/richtext/richtextbackgroundpage.cpp:318
+#: ../src/richtext/richtextborderspage.cpp:252
+#: ../src/richtext/richtextborderspage.cpp:255
+#: ../src/richtext/richtextborderspage.cpp:256
+#: ../src/richtext/richtextborderspage.cpp:286
+#: ../src/richtext/richtextborderspage.cpp:289
+#: ../src/richtext/richtextborderspage.cpp:290
+#: ../src/richtext/richtextborderspage.cpp:320
+#: ../src/richtext/richtextborderspage.cpp:323
+#: ../src/richtext/richtextborderspage.cpp:324
+#: ../src/richtext/richtextborderspage.cpp:354
+#: ../src/richtext/richtextborderspage.cpp:357
+#: ../src/richtext/richtextborderspage.cpp:358
+#: ../src/richtext/richtextborderspage.cpp:420
+#: ../src/richtext/richtextborderspage.cpp:423
+#: ../src/richtext/richtextborderspage.cpp:424
+#: ../src/richtext/richtextborderspage.cpp:454
+#: ../src/richtext/richtextborderspage.cpp:457
+#: ../src/richtext/richtextborderspage.cpp:458
+#: ../src/richtext/richtextborderspage.cpp:488
+#: ../src/richtext/richtextborderspage.cpp:491
+#: ../src/richtext/richtextborderspage.cpp:492
+#: ../src/richtext/richtextborderspage.cpp:522
+#: ../src/richtext/richtextborderspage.cpp:525
+#: ../src/richtext/richtextborderspage.cpp:526
+#: ../src/richtext/richtextborderspage.cpp:590
+#: ../src/richtext/richtextborderspage.cpp:593
+#: ../src/richtext/richtextborderspage.cpp:594
+#: ../src/richtext/richtextfontpage.cpp:177
+#: ../src/richtext/richtextmarginspage.cpp:199
+#: ../src/richtext/richtextmarginspage.cpp:201
+#: ../src/richtext/richtextmarginspage.cpp:202
+#: ../src/richtext/richtextmarginspage.cpp:224
+#: ../src/richtext/richtextmarginspage.cpp:226
+#: ../src/richtext/richtextmarginspage.cpp:227
+#: ../src/richtext/richtextmarginspage.cpp:247
+#: ../src/richtext/richtextmarginspage.cpp:249
+#: ../src/richtext/richtextmarginspage.cpp:250
+#: ../src/richtext/richtextmarginspage.cpp:272
+#: ../src/richtext/richtextmarginspage.cpp:274
+#: ../src/richtext/richtextmarginspage.cpp:275
+#: ../src/richtext/richtextmarginspage.cpp:313
+#: ../src/richtext/richtextmarginspage.cpp:315
+#: ../src/richtext/richtextmarginspage.cpp:316
+#: ../src/richtext/richtextmarginspage.cpp:338
+#: ../src/richtext/richtextmarginspage.cpp:340
+#: ../src/richtext/richtextmarginspage.cpp:341
+#: ../src/richtext/richtextmarginspage.cpp:361
+#: ../src/richtext/richtextmarginspage.cpp:363
+#: ../src/richtext/richtextmarginspage.cpp:364
+#: ../src/richtext/richtextmarginspage.cpp:386
+#: ../src/richtext/richtextmarginspage.cpp:388
+#: ../src/richtext/richtextmarginspage.cpp:389
+#: ../src/richtext/richtextsizepage.cpp:337
+#: ../src/richtext/richtextsizepage.cpp:340
+#: ../src/richtext/richtextsizepage.cpp:341
+#: ../src/richtext/richtextsizepage.cpp:371
+#: ../src/richtext/richtextsizepage.cpp:374
+#: ../src/richtext/richtextsizepage.cpp:375
+#: ../src/richtext/richtextsizepage.cpp:398
+#: ../src/richtext/richtextsizepage.cpp:401
+#: ../src/richtext/richtextsizepage.cpp:402
+#: ../src/richtext/richtextsizepage.cpp:425
+#: ../src/richtext/richtextsizepage.cpp:428
+#: ../src/richtext/richtextsizepage.cpp:429
+#: ../src/richtext/richtextsizepage.cpp:452
+#: ../src/richtext/richtextsizepage.cpp:455
+#: ../src/richtext/richtextsizepage.cpp:456
+#: ../src/richtext/richtextsizepage.cpp:479
+#: ../src/richtext/richtextsizepage.cpp:482
+#: ../src/richtext/richtextsizepage.cpp:483
+#: ../src/richtext/richtextsizepage.cpp:553
+#: ../src/richtext/richtextsizepage.cpp:556
+#: ../src/richtext/richtextsizepage.cpp:557
+#: ../src/richtext/richtextsizepage.cpp:588
+#: ../src/richtext/richtextsizepage.cpp:591
+#: ../src/richtext/richtextsizepage.cpp:592
+#: ../src/richtext/richtextsizepage.cpp:623
+#: ../src/richtext/richtextsizepage.cpp:626
+#: ../src/richtext/richtextsizepage.cpp:627
+#: ../src/richtext/richtextsizepage.cpp:658
+#: ../src/richtext/richtextsizepage.cpp:661
+#: ../src/richtext/richtextsizepage.cpp:662
+msgid "px"
+msgstr "px"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:225
+#: ../src/richtext/richtextbackgroundpage.cpp:248
+#: ../src/richtext/richtextbackgroundpage.cpp:288
+#: ../src/richtext/richtextbackgroundpage.cpp:315
+#: ../src/richtext/richtextborderspage.cpp:253
+#: ../src/richtext/richtextborderspage.cpp:287
+#: ../src/richtext/richtextborderspage.cpp:321
+#: ../src/richtext/richtextborderspage.cpp:355
+#: ../src/richtext/richtextborderspage.cpp:421
+#: ../src/richtext/richtextborderspage.cpp:455
+#: ../src/richtext/richtextborderspage.cpp:489
+#: ../src/richtext/richtextborderspage.cpp:523
+#: ../src/richtext/richtextborderspage.cpp:591
+#: ../src/richtext/richtextmarginspage.cpp:200
+#: ../src/richtext/richtextmarginspage.cpp:225
+#: ../src/richtext/richtextmarginspage.cpp:248
+#: ../src/richtext/richtextmarginspage.cpp:273
+#: ../src/richtext/richtextmarginspage.cpp:314
+#: ../src/richtext/richtextmarginspage.cpp:339
+#: ../src/richtext/richtextmarginspage.cpp:362
+#: ../src/richtext/richtextmarginspage.cpp:387
+#: ../src/richtext/richtextsizepage.cpp:338
+#: ../src/richtext/richtextsizepage.cpp:372
+#: ../src/richtext/richtextsizepage.cpp:399
+#: ../src/richtext/richtextsizepage.cpp:426
+#: ../src/richtext/richtextsizepage.cpp:453
+#: ../src/richtext/richtextsizepage.cpp:480
+#: ../src/richtext/richtextsizepage.cpp:554
+#: ../src/richtext/richtextsizepage.cpp:589
+#: ../src/richtext/richtextsizepage.cpp:624
+#: ../src/richtext/richtextsizepage.cpp:659
+msgid "cm"
+msgstr "cm"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:226
+#: ../src/richtext/richtextbackgroundpage.cpp:249
+#: ../src/richtext/richtextbackgroundpage.cpp:289
+#: ../src/richtext/richtextbackgroundpage.cpp:316
+#: ../src/richtext/richtextborderspage.cpp:254
+#: ../src/richtext/richtextborderspage.cpp:288
+#: ../src/richtext/richtextborderspage.cpp:322
+#: ../src/richtext/richtextborderspage.cpp:356
+#: ../src/richtext/richtextborderspage.cpp:422
+#: ../src/richtext/richtextborderspage.cpp:456
+#: ../src/richtext/richtextborderspage.cpp:490
+#: ../src/richtext/richtextborderspage.cpp:524
+#: ../src/richtext/richtextborderspage.cpp:592
+#: ../src/richtext/richtextfontpage.cpp:176
+#: ../src/richtext/richtextfontpage.cpp:179
+msgid "pt"
+msgstr "pt"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:229
+#: ../src/richtext/richtextbackgroundpage.cpp:231
+#: ../src/richtext/richtextbackgroundpage.cpp:252
+#: ../src/richtext/richtextbackgroundpage.cpp:254
+#: ../src/richtext/richtextbackgroundpage.cpp:292
+#: ../src/richtext/richtextbackgroundpage.cpp:294
+#: ../src/richtext/richtextbackgroundpage.cpp:319
+#: ../src/richtext/richtextbackgroundpage.cpp:321
+msgid "Units for this value."
+msgstr "此值的单位。"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:234
+msgid "&Vertical offset:"
+msgstr "垂直偏移(&V)："
+
+#: ../src/richtext/richtextbackgroundpage.cpp:241
+#: ../src/richtext/richtextbackgroundpage.cpp:243
+msgid "The vertical offset."
+msgstr "垂直偏移。"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:257
+msgid "Shadow c&olour:"
+msgstr "阴影颜色(&o)："
+
+#: ../src/richtext/richtextbackgroundpage.cpp:259
+#: ../src/richtext/richtextbackgroundpage.cpp:261
+msgid "Enables the shadow colour."
+msgstr "启用阴影颜色。"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:265
+#: ../src/richtext/richtextbackgroundpage.cpp:267
+msgid "The shadow colour."
+msgstr "阴影颜色。"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:270
+msgid "Sh&adow spread:"
+msgstr "阴影扩展半径(&a)："
+
+#: ../src/richtext/richtextbackgroundpage.cpp:272
+#: ../src/richtext/richtextbackgroundpage.cpp:274
+msgid "Enables the shadow spread."
+msgstr "启用阴影扩展半径。"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:281
+#: ../src/richtext/richtextbackgroundpage.cpp:283
+msgid "The shadow spread."
+msgstr "阴影扩展半径。"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:297
+msgid "&Blur distance:"
+msgstr "模糊半径(&B)："
+
+#: ../src/richtext/richtextbackgroundpage.cpp:299
+#: ../src/richtext/richtextbackgroundpage.cpp:301
+msgid "Enables the blur distance."
+msgstr "启用模糊半径。"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:308
+#: ../src/richtext/richtextbackgroundpage.cpp:310
+msgid "The shadow blur distance."
+msgstr "阴影模糊半径。"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:324
+msgid "Opaci&ty:"
+msgstr "不透明度(&t)："
+
+#: ../src/richtext/richtextbackgroundpage.cpp:326
+#: ../src/richtext/richtextbackgroundpage.cpp:328
+msgid "Enables the shadow opacity."
+msgstr "启用阴影不透明度。"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:335
+#: ../src/richtext/richtextbackgroundpage.cpp:337
+msgid "The shadow opacity."
+msgstr "阴影不透明度。"
+
+#. TRANSLATORS: Rich text page units (percentage)
+#: ../src/richtext/richtextbackgroundpage.cpp:340
+#: ../src/richtext/richtextsizepage.cpp:339
+#: ../src/richtext/richtextsizepage.cpp:373
+#: ../src/richtext/richtextsizepage.cpp:400
+#: ../src/richtext/richtextsizepage.cpp:427
+#: ../src/richtext/richtextsizepage.cpp:454
+#: ../src/richtext/richtextsizepage.cpp:481
+#: ../src/richtext/richtextsizepage.cpp:555
+#: ../src/richtext/richtextsizepage.cpp:590
+#: ../src/richtext/richtextsizepage.cpp:625
+#: ../src/richtext/richtextsizepage.cpp:660
+msgid "%"
+msgstr "%"
+
+#: ../src/richtext/richtextborderspage.cpp:229
+#: ../src/richtext/richtextborderspage.cpp:387
+msgid "Border"
+msgstr "边框"
+
+#: ../src/richtext/richtextborderspage.cpp:242
+#: ../src/richtext/richtextborderspage.cpp:410
+#: ../src/richtext/richtextindentspage.cpp:194
+#: ../src/richtext/richtextliststylepage.cpp:384
+#: ../src/richtext/richtextmarginspage.cpp:185
+#: ../src/richtext/richtextmarginspage.cpp:299
+#: ../src/richtext/richtextsizepage.cpp:531
+#: ../src/richtext/richtextsizepage.cpp:538
+msgid "&Left:"
+msgstr "左(&L)："
+
+#: ../src/richtext/richtextborderspage.cpp:257
+#: ../src/richtext/richtextborderspage.cpp:259
+msgid "Units for the left border width."
+msgstr "左边框宽度的单位。"
+
+#: ../src/richtext/richtextborderspage.cpp:266
+#: ../src/richtext/richtextborderspage.cpp:268
+#: ../src/richtext/richtextborderspage.cpp:300
+#: ../src/richtext/richtextborderspage.cpp:302
+#: ../src/richtext/richtextborderspage.cpp:334
+#: ../src/richtext/richtextborderspage.cpp:336
+#: ../src/richtext/richtextborderspage.cpp:368
+#: ../src/richtext/richtextborderspage.cpp:370
+#: ../src/richtext/richtextborderspage.cpp:434
+#: ../src/richtext/richtextborderspage.cpp:436
+#: ../src/richtext/richtextborderspage.cpp:468
+#: ../src/richtext/richtextborderspage.cpp:470
+#: ../src/richtext/richtextborderspage.cpp:502
+#: ../src/richtext/richtextborderspage.cpp:504
+#: ../src/richtext/richtextborderspage.cpp:536
+#: ../src/richtext/richtextborderspage.cpp:538
+msgid "The border line style."
+msgstr "边框线样式。"
+
+#: ../src/richtext/richtextborderspage.cpp:276
+#: ../src/richtext/richtextborderspage.cpp:444
+#: ../src/richtext/richtextindentspage.cpp:212
+#: ../src/richtext/richtextliststylepage.cpp:402
+#: ../src/richtext/richtextmarginspage.cpp:210
+#: ../src/richtext/richtextmarginspage.cpp:324
+#: ../src/richtext/richtextsizepage.cpp:601
+#: ../src/richtext/richtextsizepage.cpp:608
+msgid "&Right:"
+msgstr "右(&R)："
+
+#: ../src/richtext/richtextborderspage.cpp:291
+#: ../src/richtext/richtextborderspage.cpp:293
+msgid "Units for the right border width."
+msgstr "右边框宽度的单位。"
+
+#: ../src/richtext/richtextborderspage.cpp:310
+#: ../src/richtext/richtextborderspage.cpp:478
+#: ../src/richtext/richtextmarginspage.cpp:233
+#: ../src/richtext/richtextmarginspage.cpp:347
+#: ../src/richtext/richtextsizepage.cpp:566
+#: ../src/richtext/richtextsizepage.cpp:573
+msgid "&Top:"
+msgstr "上(&T)："
+
+#: ../src/richtext/richtextborderspage.cpp:325
+#: ../src/richtext/richtextborderspage.cpp:327
+msgid "Units for the top border width."
+msgstr "上边框宽度的单位。"
+
+#: ../src/richtext/richtextborderspage.cpp:344
+#: ../src/richtext/richtextborderspage.cpp:512
+#: ../src/richtext/richtextmarginspage.cpp:258
+#: ../src/richtext/richtextmarginspage.cpp:372
+#: ../src/richtext/richtextsizepage.cpp:636
+#: ../src/richtext/richtextsizepage.cpp:643
+msgid "&Bottom:"
+msgstr "下(&B)："
+
+#: ../src/richtext/richtextborderspage.cpp:359
+#: ../src/richtext/richtextborderspage.cpp:361
+msgid "Units for the bottom border width."
+msgstr "下边框宽度的单位。"
+
+#: ../src/richtext/richtextborderspage.cpp:380
+#: ../src/richtext/richtextborderspage.cpp:548
+msgid "&Synchronize values"
+msgstr "同步数值(&S)"
+
+#: ../src/richtext/richtextborderspage.cpp:382
+#: ../src/richtext/richtextborderspage.cpp:384
+#: ../src/richtext/richtextborderspage.cpp:550
+#: ../src/richtext/richtextborderspage.cpp:552
+msgid "Check to edit all borders simultaneously."
+msgstr "勾选后同时编辑所有边框。"
+
+#: ../src/richtext/richtextborderspage.cpp:397
+#: ../src/richtext/richtextborderspage.cpp:555
+msgid "Outline"
+msgstr "轮廓"
+
+#: ../src/richtext/richtextborderspage.cpp:425
+#: ../src/richtext/richtextborderspage.cpp:427
+msgid "Units for the left outline width."
+msgstr "左轮廓宽度的单位。"
+
+#: ../src/richtext/richtextborderspage.cpp:459
+#: ../src/richtext/richtextborderspage.cpp:461
+msgid "Units for the right outline width."
+msgstr "右轮廓宽度的单位。"
+
+#: ../src/richtext/richtextborderspage.cpp:493
+#: ../src/richtext/richtextborderspage.cpp:495
+msgid "Units for the top outline width."
+msgstr "上轮廓宽度的单位。"
+
+#: ../src/richtext/richtextborderspage.cpp:527
+#: ../src/richtext/richtextborderspage.cpp:529
+msgid "Units for the bottom outline width."
+msgstr "下轮廓宽度的单位。"
+
+#: ../src/richtext/richtextborderspage.cpp:565
+#: ../src/richtext/richtextborderspage.cpp:600
+msgid "Corner"
+msgstr "圆角"
+
+#: ../src/richtext/richtextborderspage.cpp:574
+msgid "Corner &radius:"
+msgstr "圆角半径(&r)："
+
+#: ../src/richtext/richtextborderspage.cpp:576
+#: ../src/richtext/richtextborderspage.cpp:578
+msgid "An optional corner radius for adding rounded corners."
+msgstr "可选的圆角半径。"
+
+#: ../src/richtext/richtextborderspage.cpp:584
+#: ../src/richtext/richtextborderspage.cpp:586
+msgid "The value of the corner radius."
+msgstr "圆角半径数值。"
+
+#: ../src/richtext/richtextborderspage.cpp:595
+#: ../src/richtext/richtextborderspage.cpp:597
+msgid "Units for the corner radius."
+msgstr "圆角半径单位。"
+
+#: ../src/richtext/richtextborderspage.cpp:609
+#: ../src/richtext/richtextsizepage.cpp:247
+#: ../src/richtext/richtextsizepage.cpp:251
+msgid "None"
+msgstr "无"
+
+#: ../src/richtext/richtextborderspage.cpp:610
+msgid "Solid"
+msgstr "实线"
+
+#: ../src/richtext/richtextborderspage.cpp:611
+msgid "Dotted"
+msgstr "点线"
+
+#: ../src/richtext/richtextborderspage.cpp:612
+msgid "Dashed"
+msgstr "虚线"
+
+#: ../src/richtext/richtextborderspage.cpp:613
+msgid "Double"
+msgstr "双线"
+
+#: ../src/richtext/richtextborderspage.cpp:614
+msgid "Groove"
+msgstr "凹槽"
+
+#: ../src/richtext/richtextborderspage.cpp:615
+msgid "Ridge"
+msgstr "凸脊"
+
+#: ../src/richtext/richtextborderspage.cpp:616
+msgid "Inset"
+msgstr "内凹"
+
+#: ../src/richtext/richtextborderspage.cpp:617
+msgid "Outset"
+msgstr "外凸"
+
+#: ../src/richtext/richtextbuffer.cpp:3518
+msgid "Change Style"
+msgstr "更改样式"
+
+#: ../src/richtext/richtextbuffer.cpp:3701
+msgid "Change Object Style"
+msgstr "更改对象样式"
+
+#: ../src/richtext/richtextbuffer.cpp:3974
+#: ../src/richtext/richtextbuffer.cpp:8174
+msgid "Change Properties"
+msgstr "更改属性"
+
+#: ../src/richtext/richtextbuffer.cpp:4346
+msgid "Change List Style"
+msgstr "更改列表样式"
+
+#: ../src/richtext/richtextbuffer.cpp:4519
+msgid "Renumber List"
+msgstr "重新编号列表"
+
+#: ../src/richtext/richtextbuffer.cpp:7867
+#: ../src/richtext/richtextbuffer.cpp:7897
+#: ../src/richtext/richtextbuffer.cpp:7939
+#: ../src/richtext/richtextctrl.cpp:1279 ../src/richtext/richtextctrl.cpp:1473
+msgid "Insert Text"
+msgstr "插入文本"
+
+#: ../src/richtext/richtextbuffer.cpp:8023
+#: ../src/richtext/richtextbuffer.cpp:8979
+msgid "Insert Image"
+msgstr "插入图片"
+
+#: ../src/richtext/richtextbuffer.cpp:8070
+msgid "Insert Object"
+msgstr "插入对象"
+
+#: ../src/richtext/richtextbuffer.cpp:8112
+msgid "Insert Field"
+msgstr "插入字段"
+
+#: ../src/richtext/richtextbuffer.cpp:8410
+msgid "Too many EndStyle calls!"
+msgstr "EndStyle 调用次数过多！"
+
+#: ../src/richtext/richtextbuffer.cpp:8785
+msgid "files"
+msgstr "文件"
+
+#: ../src/richtext/richtextbuffer.cpp:9380
+msgid "standard/circle"
+msgstr "standard/circle"
+
+#: ../src/richtext/richtextbuffer.cpp:9381
+msgid "standard/circle-outline"
+msgstr "standard/circle-outline"
+
+#: ../src/richtext/richtextbuffer.cpp:9382
+msgid "standard/square"
+msgstr "standard/square"
+
+#: ../src/richtext/richtextbuffer.cpp:9383
+msgid "standard/diamond"
+msgstr "standard/diamond"
+
+#: ../src/richtext/richtextbuffer.cpp:9384
+msgid "standard/triangle"
+msgstr "standard/triangle"
+
+#: ../src/richtext/richtextbuffer.cpp:9423
+msgid "Box Properties"
+msgstr "文本框属性"
+
+#: ../src/richtext/richtextbuffer.cpp:10006
+msgid "Multiple Cell Properties"
+msgstr "多个单元格属性"
+
+#: ../src/richtext/richtextbuffer.cpp:10008
+msgid "Cell Properties"
+msgstr "单元格属性"
+
+#: ../src/richtext/richtextbuffer.cpp:11256
+msgid "Set Cell Style"
+msgstr "设置单元格样式"
+
+#: ../src/richtext/richtextbuffer.cpp:11330
+msgid "Delete Row"
+msgstr "删除行"
+
+#: ../src/richtext/richtextbuffer.cpp:11380
+msgid "Delete Column"
+msgstr "删除列"
+
+#: ../src/richtext/richtextbuffer.cpp:11431
+msgid "Add Row"
+msgstr "添加行"
+
+#: ../src/richtext/richtextbuffer.cpp:11494
+msgid "Add Column"
+msgstr "添加列"
+
+#: ../src/richtext/richtextbuffer.cpp:11537
+msgid "Table Properties"
+msgstr "表格属性"
+
+#: ../src/richtext/richtextbuffer.cpp:12899
+msgid "Picture Properties"
+msgstr "图片属性"
+
+#: ../src/richtext/richtextbuffer.cpp:13169
+#: ../src/richtext/richtextbuffer.cpp:13279
+msgid "image"
+msgstr "图片"
+
+#: ../src/richtext/richtextbulletspage.cpp:145
+#: ../src/richtext/richtextliststylepage.cpp:209
+msgid "&Bullet style:"
+msgstr "项目符号样式(&B)："
+
+#: ../src/richtext/richtextbulletspage.cpp:150
+#: ../src/richtext/richtextbulletspage.cpp:152
+#: ../src/richtext/richtextliststylepage.cpp:214
+#: ../src/richtext/richtextliststylepage.cpp:216
+msgid "The available bullet styles."
+msgstr "可用的项目符号样式。"
+
+#: ../src/richtext/richtextbulletspage.cpp:158
+#: ../src/richtext/richtextliststylepage.cpp:221
+msgid "Peri&od"
+msgstr "句号(&o)"
+
+#: ../src/richtext/richtextbulletspage.cpp:160
+#: ../src/richtext/richtextbulletspage.cpp:162
+#: ../src/richtext/richtextliststylepage.cpp:223
+#: ../src/richtext/richtextliststylepage.cpp:225
+msgid "Check to add a period after the bullet."
+msgstr "勾选以在项目符号后添加句号。"
+
+#. TRANSLATORS: Bullet point in parentheses option
+#: ../src/richtext/richtextbulletspage.cpp:167
+#: ../src/richtext/richtextliststylepage.cpp:230
+msgid "(*)"
+msgstr "(*)"
+
+#: ../src/richtext/richtextbulletspage.cpp:169
+#: ../src/richtext/richtextbulletspage.cpp:171
+#: ../src/richtext/richtextliststylepage.cpp:232
+#: ../src/richtext/richtextliststylepage.cpp:234
+msgid "Check to enclose the bullet in parentheses."
+msgstr "勾选以将项目符号加上一对括号。"
+
+#. TRANSLATORS: Right parenthesis bullet point option
+#: ../src/richtext/richtextbulletspage.cpp:176
+#: ../src/richtext/richtextliststylepage.cpp:239
+msgid "*)"
+msgstr "*)"
+
+#: ../src/richtext/richtextbulletspage.cpp:178
+#: ../src/richtext/richtextbulletspage.cpp:180
+#: ../src/richtext/richtextliststylepage.cpp:241
+#: ../src/richtext/richtextliststylepage.cpp:243
+msgid "Check to add a right parenthesis."
+msgstr "勾选以添加右括号。"
+
+#: ../src/richtext/richtextbulletspage.cpp:185
+#: ../src/richtext/richtextliststylepage.cpp:248
+msgid "Bullet &Alignment:"
+msgstr "项目符号对齐(&A)："
+
+#: ../src/richtext/richtextbulletspage.cpp:190
+#: ../src/richtext/richtextliststylepage.cpp:253
+msgid "Centre"
+msgstr "居中"
+
+#: ../src/richtext/richtextbulletspage.cpp:194
+#: ../src/richtext/richtextbulletspage.cpp:196
+#: ../src/richtext/richtextbulletspage.cpp:217
+#: ../src/richtext/richtextbulletspage.cpp:219
+#: ../src/richtext/richtextliststylepage.cpp:257
+#: ../src/richtext/richtextliststylepage.cpp:259
+#: ../src/richtext/richtextliststylepage.cpp:278
+#: ../src/richtext/richtextliststylepage.cpp:280
+msgid "The bullet character."
+msgstr "项目符号字符。"
+
+#: ../src/richtext/richtextbulletspage.cpp:212
+#: ../src/richtext/richtextliststylepage.cpp:271
+msgid "&Symbol:"
+msgstr "符号(&S)："
+
+#: ../src/richtext/richtextbulletspage.cpp:222
+#: ../src/richtext/richtextliststylepage.cpp:283
+msgid "Ch&oose..."
+msgstr "选择(&o)..."
+
+#: ../src/richtext/richtextbulletspage.cpp:223
+#: ../src/richtext/richtextbulletspage.cpp:225
+#: ../src/richtext/richtextliststylepage.cpp:284
+#: ../src/richtext/richtextliststylepage.cpp:286
+msgid "Click to browse for a symbol."
+msgstr "点击浏览并选择符号。"
+
+#: ../src/richtext/richtextbulletspage.cpp:230
+#: ../src/richtext/richtextliststylepage.cpp:291
+msgid "Symbol &font:"
+msgstr "符号字体(&f)："
+
+#: ../src/richtext/richtextbulletspage.cpp:235
+#: ../src/richtext/richtextbulletspage.cpp:237
+#: ../src/richtext/richtextliststylepage.cpp:297
+msgid "Available fonts."
+msgstr "可用字体。"
+
+#: ../src/richtext/richtextbulletspage.cpp:242
+#: ../src/richtext/richtextliststylepage.cpp:302
+msgid "S&tandard bullet name:"
+msgstr "标准项目符号名称(&t)："
+
+#: ../src/richtext/richtextbulletspage.cpp:247
+#: ../src/richtext/richtextbulletspage.cpp:249
+#: ../src/richtext/richtextliststylepage.cpp:307
+#: ../src/richtext/richtextliststylepage.cpp:309
+msgid "A standard bullet name."
+msgstr "标准项目符号名称。"
+
+#: ../src/richtext/richtextbulletspage.cpp:254
+msgid "&Number:"
+msgstr "编号(&N)："
+
+#: ../src/richtext/richtextbulletspage.cpp:258
+#: ../src/richtext/richtextbulletspage.cpp:260
+msgid "The list item number."
+msgstr "列表项编号。"
+
+#: ../src/richtext/richtextbulletspage.cpp:266
+#: ../src/richtext/richtextbulletspage.cpp:268
+#: ../src/richtext/richtextliststylepage.cpp:475
+#: ../src/richtext/richtextliststylepage.cpp:477
+msgid "Shows a preview of the bullet settings."
+msgstr "显示项目符号设置预览。"
+
+#: ../src/richtext/richtextbulletspage.cpp:276
+#: ../src/richtext/richtextliststylepage.cpp:484
+msgid "(None)"
+msgstr "(无)"
+
+#: ../src/richtext/richtextbulletspage.cpp:277
+#: ../src/richtext/richtextliststylepage.cpp:485
+msgid "Arabic"
+msgstr "阿拉伯数字"
+
+#: ../src/richtext/richtextbulletspage.cpp:278
+#: ../src/richtext/richtextliststylepage.cpp:486
+msgid "Upper case letters"
+msgstr "大写字母"
+
+#: ../src/richtext/richtextbulletspage.cpp:279
+#: ../src/richtext/richtextliststylepage.cpp:487
+msgid "Lower case letters"
+msgstr "小写字母"
+
+#: ../src/richtext/richtextbulletspage.cpp:280
+#: ../src/richtext/richtextliststylepage.cpp:488
+msgid "Upper case roman numerals"
+msgstr "大写罗马数字"
+
+#: ../src/richtext/richtextbulletspage.cpp:281
+#: ../src/richtext/richtextliststylepage.cpp:489
+msgid "Lower case roman numerals"
+msgstr "小写罗马数字"
+
+#: ../src/richtext/richtextbulletspage.cpp:282
+#: ../src/richtext/richtextliststylepage.cpp:490
+msgid "Numbered outline"
+msgstr "大纲编号"
+
+#: ../src/richtext/richtextbulletspage.cpp:283
+#: ../src/richtext/richtextliststylepage.cpp:491
+msgid "Symbol"
+msgstr "符号"
+
+#: ../src/richtext/richtextbulletspage.cpp:284
+#: ../src/richtext/richtextliststylepage.cpp:492
+msgid "Bitmap"
+msgstr "位图"
+
+#: ../src/richtext/richtextbulletspage.cpp:285
+#: ../src/richtext/richtextliststylepage.cpp:493
+msgid "Standard"
+msgstr "标准"
+
+#: ../src/richtext/richtextbulletspage.cpp:287
+#: ../src/richtext/richtextliststylepage.cpp:495
+msgid "*"
+msgstr "*"
+
+#: ../src/richtext/richtextbulletspage.cpp:288
+#: ../src/richtext/richtextliststylepage.cpp:496
+msgid "-"
+msgstr "-"
+
+#: ../src/richtext/richtextbulletspage.cpp:289
+#: ../src/richtext/richtextliststylepage.cpp:497
+msgid ">"
+msgstr ">"
+
+#: ../src/richtext/richtextbulletspage.cpp:290
+#: ../src/richtext/richtextliststylepage.cpp:498
+msgid "+"
+msgstr "+"
+
+#: ../src/richtext/richtextbulletspage.cpp:291
+#: ../src/richtext/richtextliststylepage.cpp:499
+msgid "~"
+msgstr "~"
+
+#: ../src/richtext/richtextctrl.cpp:859
+msgid "Drag"
+msgstr "拖动"
+
+#: ../src/richtext/richtextctrl.cpp:1338 ../src/richtext/richtextctrl.cpp:1559
+msgid "Delete Text"
+msgstr "删除文本"
+
+#: ../src/richtext/richtextctrl.cpp:1537
+msgid "Remove Bullet"
+msgstr "移除项目符号"
+
+#: ../src/richtext/richtextctrl.cpp:3070
+msgid "The text couldn't be saved."
+msgstr "无法保存文本。"
+
+#: ../src/richtext/richtextctrl.cpp:3644
+msgid "Replace"
+msgstr "替换"
+
+#: ../src/richtext/richtextfontpage.cpp:146
+#: ../src/richtext/richtextsymboldlg.cpp:384
+msgid "&Font:"
+msgstr "字体(&F)："
+
+#: ../src/richtext/richtextfontpage.cpp:150
+#: ../src/richtext/richtextfontpage.cpp:152
+msgid "Type a font name."
+msgstr "输入字体名称。"
+
+#: ../src/richtext/richtextfontpage.cpp:158
+msgid "&Size:"
+msgstr "大小(&S)："
+
+#: ../src/richtext/richtextfontpage.cpp:165
+#: ../src/richtext/richtextfontpage.cpp:167
+msgid "Type a size in points."
+msgstr "输入字号（单位：磅）。"
+
+#: ../src/richtext/richtextfontpage.cpp:180
+#: ../src/richtext/richtextfontpage.cpp:182
+msgid "The font size units, points or pixels."
+msgstr "字号单位：磅或像素。"
+
+#: ../src/richtext/richtextfontpage.cpp:189
+#: ../src/richtext/richtextfontpage.cpp:191
+msgid "Lists the available fonts."
+msgstr "列出可用字体。"
+
+#: ../src/richtext/richtextfontpage.cpp:196
+#: ../src/richtext/richtextfontpage.cpp:198
+msgid "Lists font sizes in points."
+msgstr "列出字号（磅）。"
+
+#: ../src/richtext/richtextfontpage.cpp:207
+msgid "Font st&yle:"
+msgstr "字体样式(&y)："
+
+#: ../src/richtext/richtextfontpage.cpp:212
+#: ../src/richtext/richtextfontpage.cpp:214
+msgid "Select regular or italic style."
+msgstr "选择常规或斜体样式。"
+
+#: ../src/richtext/richtextfontpage.cpp:220
+msgid "Font &weight:"
+msgstr "字体粗细(&w)："
+
+#: ../src/richtext/richtextfontpage.cpp:225
+#: ../src/richtext/richtextfontpage.cpp:227
+msgid "Select regular or bold."
+msgstr "选择常规或粗体。"
+
+#: ../src/richtext/richtextfontpage.cpp:233
+msgid "&Underlining:"
+msgstr "下划线(&U)："
+
+#: ../src/richtext/richtextfontpage.cpp:238
+#: ../src/richtext/richtextfontpage.cpp:240
+msgid "Select underlining or no underlining."
+msgstr "选择下划线或无下划线。"
+
+#: ../src/richtext/richtextfontpage.cpp:248
+msgid "&Colour:"
+msgstr "颜色(&C)："
+
+#: ../src/richtext/richtextfontpage.cpp:253
+#: ../src/richtext/richtextfontpage.cpp:255
+msgid "Click to change the text colour."
+msgstr "点击更改文本颜色。"
+
+#: ../src/richtext/richtextfontpage.cpp:261
+msgid "&Bg colour:"
+msgstr "背景颜色(&B)："
+
+#: ../src/richtext/richtextfontpage.cpp:266
+#: ../src/richtext/richtextfontpage.cpp:268
+msgid "Click to change the text background colour."
+msgstr "点击更改文本背景颜色。"
+
+#: ../src/richtext/richtextfontpage.cpp:276
+#: ../src/richtext/richtextfontpage.cpp:278
+msgid "Check to show a line through the text."
+msgstr "勾选以添加删除线。"
+
+#: ../src/richtext/richtextfontpage.cpp:281
+msgid "Ca&pitals"
+msgstr "全大写(&p)"
+
+#: ../src/richtext/richtextfontpage.cpp:283
+#: ../src/richtext/richtextfontpage.cpp:285
+msgid "Check to show the text in capitals."
+msgstr "勾选以将文本显示为全大写。"
+
+#: ../src/richtext/richtextfontpage.cpp:288
+msgid "Small C&apitals"
+msgstr "小型大写字母(&a)"
+
+#: ../src/richtext/richtextfontpage.cpp:290
+#: ../src/richtext/richtextfontpage.cpp:292
+msgid "Check to show the text in small capitals."
+msgstr "勾选以将文本显示为小型大写字母。"
+
+#: ../src/richtext/richtextfontpage.cpp:295
+msgid "Supe&rscript"
+msgstr "上标(&r)"
+
+#: ../src/richtext/richtextfontpage.cpp:297
+#: ../src/richtext/richtextfontpage.cpp:299
+msgid "Check to show the text in superscript."
+msgstr "勾选以将文本显示为上标。"
+
+#: ../src/richtext/richtextfontpage.cpp:302
+msgid "Subscrip&t"
+msgstr "下标(&t)"
+
+#: ../src/richtext/richtextfontpage.cpp:304
+#: ../src/richtext/richtextfontpage.cpp:306
+msgid "Check to show the text in subscript."
+msgstr "勾选以将文本显示为下标。"
+
+#: ../src/richtext/richtextfontpage.cpp:312
+msgid "Rig&ht-to-left"
+msgstr "从右到左(&h)"
+
+#: ../src/richtext/richtextfontpage.cpp:314
+#: ../src/richtext/richtextfontpage.cpp:316
+msgid "Check to indicate right-to-left text layout."
+msgstr "勾选以使用从右到左的文本布局。"
+
+#: ../src/richtext/richtextfontpage.cpp:319
+msgid "Suppress hyphe&nation"
+msgstr "禁用断字(&n)"
+
+#: ../src/richtext/richtextfontpage.cpp:321
+#: ../src/richtext/richtextfontpage.cpp:323
+msgid "Check to suppress hyphenation."
+msgstr "勾选以禁用断字。"
+
+#: ../src/richtext/richtextfontpage.cpp:329
+#: ../src/richtext/richtextfontpage.cpp:331
+msgid "Shows a preview of the font settings."
+msgstr "显示字体设置预览。"
+
+#: ../src/richtext/richtextfontpage.cpp:348
+#: ../src/richtext/richtextfontpage.cpp:352
+#: ../src/richtext/richtextfontpage.cpp:356
+#: ../src/richtext/richtextformatdlg.cpp:873
+#: ../src/richtext/richtextindentspage.cpp:273
+#: ../src/richtext/richtextindentspage.cpp:285
+#: ../src/richtext/richtextindentspage.cpp:286
+#: ../src/richtext/richtextindentspage.cpp:310
+#: ../src/richtext/richtextindentspage.cpp:325
+#: ../src/richtext/richtextliststylepage.cpp:451
+#: ../src/richtext/richtextliststylepage.cpp:463
+#: ../src/richtext/richtextliststylepage.cpp:464
+msgid "(none)"
+msgstr "(无)"
+
+#: ../src/richtext/richtextfontpage.cpp:349
+#: ../src/richtext/richtextfontpage.cpp:353
+msgid "Regular"
+msgstr "常规"
+
+#: ../src/richtext/richtextfontpage.cpp:357
+msgid "Not underlined"
+msgstr "无下划线"
+
+#: ../src/richtext/richtextformatdlg.cpp:341
+msgid "Indents && Spacing"
+msgstr "缩进和间距"
+
+#: ../src/richtext/richtextformatdlg.cpp:346
+msgid "Tabs"
+msgstr "制表位"
+
+#: ../src/richtext/richtextformatdlg.cpp:351
+msgid "Bullets"
+msgstr "项目符号"
+
+#: ../src/richtext/richtextformatdlg.cpp:356
+msgid "List Style"
+msgstr "列表样式"
+
+#: ../src/richtext/richtextformatdlg.cpp:366
+#: ../src/richtext/richtextmarginspage.cpp:170
+msgid "Margins"
+msgstr "边距"
+
+#: ../src/richtext/richtextformatdlg.cpp:371
+msgid "Borders"
+msgstr "边框"
+
+#: ../src/richtext/richtextformatdlg.cpp:765
+msgid "Colour"
+msgstr "颜色"
+
+#: ../src/richtext/richtextindentspage.cpp:127
+#: ../src/richtext/richtextliststylepage.cpp:322
+msgid "&Alignment"
+msgstr "对齐(&A)"
+
+#: ../src/richtext/richtextindentspage.cpp:138
+#: ../src/richtext/richtextliststylepage.cpp:331
+msgid "&Left"
+msgstr "左(&L)"
+
+#: ../src/richtext/richtextindentspage.cpp:140
+#: ../src/richtext/richtextindentspage.cpp:142
+#: ../src/richtext/richtextliststylepage.cpp:333
+#: ../src/richtext/richtextliststylepage.cpp:335
+msgid "Left-align text."
+msgstr "文本左对齐。"
+
+#: ../src/richtext/richtextindentspage.cpp:145
+#: ../src/richtext/richtextliststylepage.cpp:338
+msgid "&Right"
+msgstr "右(&R)"
+
+#: ../src/richtext/richtextindentspage.cpp:147
+#: ../src/richtext/richtextindentspage.cpp:149
+#: ../src/richtext/richtextliststylepage.cpp:340
+#: ../src/richtext/richtextliststylepage.cpp:342
+msgid "Right-align text."
+msgstr "文本右对齐。"
+
+#: ../src/richtext/richtextindentspage.cpp:152
+#: ../src/richtext/richtextliststylepage.cpp:345
+msgid "&Justified"
+msgstr "两端对齐(&J)"
+
+#: ../src/richtext/richtextindentspage.cpp:154
+#: ../src/richtext/richtextindentspage.cpp:156
+#: ../src/richtext/richtextliststylepage.cpp:347
+#: ../src/richtext/richtextliststylepage.cpp:349
+msgid "Justify text left and right."
+msgstr "文本两端对齐。"
+
+#: ../src/richtext/richtextindentspage.cpp:159
+#: ../src/richtext/richtextliststylepage.cpp:352
+msgid "Cen&tred"
+msgstr "居中(&t)"
+
+#: ../src/richtext/richtextindentspage.cpp:161
+#: ../src/richtext/richtextindentspage.cpp:163
+#: ../src/richtext/richtextliststylepage.cpp:354
+#: ../src/richtext/richtextliststylepage.cpp:356
+msgid "Centre text."
+msgstr "文本居中。"
+
+#: ../src/richtext/richtextindentspage.cpp:166
+#: ../src/richtext/richtextliststylepage.cpp:359
+msgid "&Indeterminate"
+msgstr "保持当前(&I)"
+
+#: ../src/richtext/richtextindentspage.cpp:168
+#: ../src/richtext/richtextindentspage.cpp:170
+#: ../src/richtext/richtextliststylepage.cpp:361
+#: ../src/richtext/richtextliststylepage.cpp:363
+msgid "Use the current alignment setting."
+msgstr "使用当前对齐设置。"
+
+#: ../src/richtext/richtextindentspage.cpp:183
+#: ../src/richtext/richtextliststylepage.cpp:375
+msgid "&Indentation (tenths of a mm)"
+msgstr "缩进(&I)（单位：0.1 毫米）"
+
+#: ../src/richtext/richtextindentspage.cpp:198
+#: ../src/richtext/richtextindentspage.cpp:200
+#: ../src/richtext/richtextliststylepage.cpp:388
+#: ../src/richtext/richtextliststylepage.cpp:390
+msgid "The left indent."
+msgstr "左缩进。"
+
+#: ../src/richtext/richtextindentspage.cpp:203
+#: ../src/richtext/richtextliststylepage.cpp:393
+msgid "Left (&first line):"
+msgstr "左（首行）(&F)："
+
+#: ../src/richtext/richtextindentspage.cpp:207
+#: ../src/richtext/richtextindentspage.cpp:209
+#: ../src/richtext/richtextliststylepage.cpp:397
+#: ../src/richtext/richtextliststylepage.cpp:399
+msgid "The first line indent."
+msgstr "首行缩进。"
+
+#: ../src/richtext/richtextindentspage.cpp:216
+#: ../src/richtext/richtextindentspage.cpp:218
+#: ../src/richtext/richtextliststylepage.cpp:406
+#: ../src/richtext/richtextliststylepage.cpp:408
+msgid "The right indent."
+msgstr "右缩进。"
+
+#: ../src/richtext/richtextindentspage.cpp:221
+msgid "&Outline level:"
+msgstr "大纲层级(&O)："
+
+#: ../src/richtext/richtextindentspage.cpp:226
+#: ../src/richtext/richtextindentspage.cpp:228
+msgid "The outline level."
+msgstr "大纲层级。"
+
+#: ../src/richtext/richtextindentspage.cpp:241
+#: ../src/richtext/richtextliststylepage.cpp:420
+msgid "&Spacing (tenths of a mm)"
+msgstr "间距(&S)（单位：0.1 毫米）"
+
+#: ../src/richtext/richtextindentspage.cpp:252
+msgid "&Before a paragraph:"
+msgstr "段前(&B)："
+
+#: ../src/richtext/richtextindentspage.cpp:256
+#: ../src/richtext/richtextindentspage.cpp:258
+#: ../src/richtext/richtextliststylepage.cpp:433
+#: ../src/richtext/richtextliststylepage.cpp:435
+msgid "The spacing before the paragraph."
+msgstr "段落前的间距。"
+
+#: ../src/richtext/richtextindentspage.cpp:261
+msgid "&After a paragraph:"
+msgstr "段后(&A)："
+
+#: ../src/richtext/richtextindentspage.cpp:266
+#: ../src/richtext/richtextliststylepage.cpp:442
+#: ../src/richtext/richtextliststylepage.cpp:444
+msgid "The spacing after the paragraph."
+msgstr "段落后的间距。"
+
+#: ../src/richtext/richtextindentspage.cpp:269
+msgid "L&ine spacing:"
+msgstr "行距(&I)："
+
+#: ../src/richtext/richtextindentspage.cpp:274
+#: ../src/richtext/richtextliststylepage.cpp:452
+msgid "Single"
+msgstr "单倍"
+
+#: ../src/richtext/richtextindentspage.cpp:275
+#: ../src/richtext/richtextliststylepage.cpp:453
+msgid "1.1"
+msgstr "1.1"
+
+#: ../src/richtext/richtextindentspage.cpp:276
+#: ../src/richtext/richtextliststylepage.cpp:454
+msgid "1.2"
+msgstr "1.2"
+
+#: ../src/richtext/richtextindentspage.cpp:277
+#: ../src/richtext/richtextliststylepage.cpp:455
+msgid "1.3"
+msgstr "1.3"
+
+#: ../src/richtext/richtextindentspage.cpp:278
+#: ../src/richtext/richtextliststylepage.cpp:456
+msgid "1.4"
+msgstr "1.4"
+
+#: ../src/richtext/richtextindentspage.cpp:279
+#: ../src/richtext/richtextliststylepage.cpp:457
+msgid "1.5"
+msgstr "1.5"
+
+#: ../src/richtext/richtextindentspage.cpp:280
+#: ../src/richtext/richtextliststylepage.cpp:458
+msgid "1.6"
+msgstr "1.6"
+
+#: ../src/richtext/richtextindentspage.cpp:281
+#: ../src/richtext/richtextliststylepage.cpp:459
+msgid "1.7"
+msgstr "1.7"
+
+#: ../src/richtext/richtextindentspage.cpp:282
+#: ../src/richtext/richtextliststylepage.cpp:460
+msgid "1.8"
+msgstr "1.8"
+
+#: ../src/richtext/richtextindentspage.cpp:283
+#: ../src/richtext/richtextliststylepage.cpp:461
+msgid "1.9"
+msgstr "1.9"
+
+#: ../src/richtext/richtextindentspage.cpp:284
+#: ../src/richtext/richtextliststylepage.cpp:462
+msgid "2"
+msgstr "2"
+
+#: ../src/richtext/richtextindentspage.cpp:287
+#: ../src/richtext/richtextindentspage.cpp:289
+#: ../src/richtext/richtextliststylepage.cpp:465
+#: ../src/richtext/richtextliststylepage.cpp:467
+msgid "The line spacing."
+msgstr "行距。"
+
+#: ../src/richtext/richtextindentspage.cpp:292
+msgid "&Page Break"
+msgstr "分页符(&P)"
+
+#: ../src/richtext/richtextindentspage.cpp:294
+#: ../src/richtext/richtextindentspage.cpp:296
+msgid "Inserts a page break before the paragraph."
+msgstr "在段落前插入分页符。"
+
+#: ../src/richtext/richtextindentspage.cpp:302
+#: ../src/richtext/richtextindentspage.cpp:304
+msgid "Shows a preview of the paragraph settings."
+msgstr "显示段落设置预览。"
+
+#: ../src/richtext/richtextliststylepage.cpp:182
+msgid "&List level:"
+msgstr "列表层级(&L)："
+
+#: ../src/richtext/richtextliststylepage.cpp:186
+#: ../src/richtext/richtextliststylepage.cpp:188
+msgid "Selects the list level to edit."
+msgstr "选择要编辑的列表层级。"
+
+#: ../src/richtext/richtextliststylepage.cpp:193
+msgid "&Font for Level..."
+msgstr "层级字体(&F)..."
+
+#: ../src/richtext/richtextliststylepage.cpp:194
+#: ../src/richtext/richtextliststylepage.cpp:196
+msgid "Click to choose the font for this level."
+msgstr "点击选择此层级字体。"
+
+#: ../src/richtext/richtextliststylepage.cpp:312
+msgid "Bullet style"
+msgstr "项目符号样式"
+
+#: ../src/richtext/richtextliststylepage.cpp:429
+msgid "Before a paragraph:"
+msgstr "段前："
+
+#: ../src/richtext/richtextliststylepage.cpp:438
+msgid "After a paragraph:"
+msgstr "段后："
+
+#: ../src/richtext/richtextliststylepage.cpp:447
+msgid "Line spacing:"
+msgstr "行距："
+
+#: ../src/richtext/richtextliststylepage.cpp:470
+msgid "Spacing"
+msgstr "间距"
+
+#: ../src/richtext/richtextmarginspage.cpp:193
+#: ../src/richtext/richtextmarginspage.cpp:195
+msgid "The left margin size."
+msgstr "左边距大小。"
+
+#: ../src/richtext/richtextmarginspage.cpp:203
+#: ../src/richtext/richtextmarginspage.cpp:205
+msgid "Units for the left margin."
+msgstr "左边距单位。"
+
+#: ../src/richtext/richtextmarginspage.cpp:218
+#: ../src/richtext/richtextmarginspage.cpp:220
+msgid "The right margin size."
+msgstr "右边距大小。"
+
+#: ../src/richtext/richtextmarginspage.cpp:228
+#: ../src/richtext/richtextmarginspage.cpp:230
+msgid "Units for the right margin."
+msgstr "右边距单位。"
+
+#: ../src/richtext/richtextmarginspage.cpp:241
+#: ../src/richtext/richtextmarginspage.cpp:243
+msgid "The top margin size."
+msgstr "上边距大小。"
+
+#: ../src/richtext/richtextmarginspage.cpp:251
+#: ../src/richtext/richtextmarginspage.cpp:253
+msgid "Units for the top margin."
+msgstr "上边距单位。"
+
+#: ../src/richtext/richtextmarginspage.cpp:266
+#: ../src/richtext/richtextmarginspage.cpp:268
+msgid "The bottom margin size."
+msgstr "下边距大小。"
+
+#: ../src/richtext/richtextmarginspage.cpp:276
+#: ../src/richtext/richtextmarginspage.cpp:278
+msgid "Units for the bottom margin."
+msgstr "下边距单位。"
+
+#: ../src/richtext/richtextmarginspage.cpp:284
+msgid "Padding"
+msgstr "内边距"
+
+#: ../src/richtext/richtextmarginspage.cpp:307
+#: ../src/richtext/richtextmarginspage.cpp:309
+msgid "The left padding size."
+msgstr "左内边距大小。"
+
+#: ../src/richtext/richtextmarginspage.cpp:317
+#: ../src/richtext/richtextmarginspage.cpp:319
+msgid "Units for the left padding."
+msgstr "左内边距单位。"
+
+#: ../src/richtext/richtextmarginspage.cpp:332
+#: ../src/richtext/richtextmarginspage.cpp:334
+msgid "The right padding size."
+msgstr "右内边距大小。"
+
+#: ../src/richtext/richtextmarginspage.cpp:342
+#: ../src/richtext/richtextmarginspage.cpp:344
+msgid "Units for the right padding."
+msgstr "右内边距单位。"
+
+#: ../src/richtext/richtextmarginspage.cpp:355
+#: ../src/richtext/richtextmarginspage.cpp:357
+msgid "The top padding size."
+msgstr "上内边距大小。"
+
+#: ../src/richtext/richtextmarginspage.cpp:365
+#: ../src/richtext/richtextmarginspage.cpp:367
+msgid "Units for the top padding."
+msgstr "上内边距单位。"
+
+#: ../src/richtext/richtextmarginspage.cpp:380
+#: ../src/richtext/richtextmarginspage.cpp:382
+msgid "The bottom padding size."
+msgstr "下内边距大小。"
+
+#: ../src/richtext/richtextmarginspage.cpp:390
+#: ../src/richtext/richtextmarginspage.cpp:392
+msgid "Units for the bottom padding."
+msgstr "下内边距单位。"
+
+#: ../src/richtext/richtextprint.cpp:592
+msgid " Preview"
+msgstr " 预览"
+
+#: ../src/richtext/richtextsizepage.cpp:228
+msgid "Floating"
+msgstr "浮动"
+
+#: ../src/richtext/richtextsizepage.cpp:243
+msgid "&Floating mode:"
+msgstr "浮动模式(&F)："
+
+#: ../src/richtext/richtextsizepage.cpp:252
+#: ../src/richtext/richtextsizepage.cpp:254
+msgid "How the object will float relative to the text."
+msgstr "对象相对于文本的浮动方式。"
+
+#: ../src/richtext/richtextsizepage.cpp:265
+msgid "Alignment"
+msgstr "对齐"
+
+#: ../src/richtext/richtextsizepage.cpp:277
+msgid "&Vertical alignment:"
+msgstr "垂直对齐(&V)："
+
+#: ../src/richtext/richtextsizepage.cpp:279
+#: ../src/richtext/richtextsizepage.cpp:281
+msgid "Enable vertical alignment."
+msgstr "启用垂直对齐。"
+
+#: ../src/richtext/richtextsizepage.cpp:286
+msgid "Centred"
+msgstr "居中"
+
+#: ../src/richtext/richtextsizepage.cpp:290
+#: ../src/richtext/richtextsizepage.cpp:292
+msgid "Vertical alignment."
+msgstr "垂直对齐。"
+
+#: ../src/richtext/richtextsizepage.cpp:316
+#: ../src/richtext/richtextsizepage.cpp:323
+msgid "&Width:"
+msgstr "宽度(&W)："
+
+#: ../src/richtext/richtextsizepage.cpp:318
+#: ../src/richtext/richtextsizepage.cpp:320
+msgid "Enable the width value."
+msgstr "启用宽度值。"
+
+#: ../src/richtext/richtextsizepage.cpp:331
+#: ../src/richtext/richtextsizepage.cpp:333
+msgid "The object width."
+msgstr "对象宽度。"
+
+#: ../src/richtext/richtextsizepage.cpp:342
+#: ../src/richtext/richtextsizepage.cpp:344
+msgid "Units for the object width."
+msgstr "对象宽度单位。"
+
+#: ../src/richtext/richtextsizepage.cpp:350
+#: ../src/richtext/richtextsizepage.cpp:357
+msgid "&Height:"
+msgstr "高度(&H)："
+
+#: ../src/richtext/richtextsizepage.cpp:352
+#: ../src/richtext/richtextsizepage.cpp:354
+#: ../src/richtext/richtextsizepage.cpp:464
+#: ../src/richtext/richtextsizepage.cpp:466
+msgid "Enable the height value."
+msgstr "启用高度值。"
+
+#: ../src/richtext/richtextsizepage.cpp:365
+#: ../src/richtext/richtextsizepage.cpp:367
+msgid "The object height."
+msgstr "对象高度。"
+
+#: ../src/richtext/richtextsizepage.cpp:376
+#: ../src/richtext/richtextsizepage.cpp:378
+msgid "Units for the object height."
+msgstr "对象高度单位。"
+
+#: ../src/richtext/richtextsizepage.cpp:381
+msgid "Min width:"
+msgstr "最小宽度："
+
+#: ../src/richtext/richtextsizepage.cpp:383
+#: ../src/richtext/richtextsizepage.cpp:385
+msgid "Enable the minimum width value."
+msgstr "启用最小宽度值。"
+
+#: ../src/richtext/richtextsizepage.cpp:392
+#: ../src/richtext/richtextsizepage.cpp:394
+msgid "The object minimum width."
+msgstr "对象最小宽度。"
+
+#: ../src/richtext/richtextsizepage.cpp:403
+#: ../src/richtext/richtextsizepage.cpp:405
+msgid "Units for the minimum object width."
+msgstr "对象最小宽度单位。"
+
+#: ../src/richtext/richtextsizepage.cpp:408
+msgid "Min height:"
+msgstr "最小高度："
+
+#: ../src/richtext/richtextsizepage.cpp:410
+#: ../src/richtext/richtextsizepage.cpp:412
+msgid "Enable the minimum height value."
+msgstr "启用最小高度值。"
+
+#: ../src/richtext/richtextsizepage.cpp:419
+#: ../src/richtext/richtextsizepage.cpp:421
+msgid "The object minimum height."
+msgstr "对象最小高度。"
+
+#: ../src/richtext/richtextsizepage.cpp:430
+#: ../src/richtext/richtextsizepage.cpp:432
+msgid "Units for the minimum object height."
+msgstr "对象最小高度单位。"
+
+#: ../src/richtext/richtextsizepage.cpp:435
+msgid "Max width:"
+msgstr "最大宽度："
+
+#: ../src/richtext/richtextsizepage.cpp:437
+#: ../src/richtext/richtextsizepage.cpp:439
+msgid "Enable the maximum width value."
+msgstr "启用最大宽度值。"
+
+#: ../src/richtext/richtextsizepage.cpp:446
+#: ../src/richtext/richtextsizepage.cpp:448
+msgid "The object maximum width."
+msgstr "对象最大宽度。"
+
+#: ../src/richtext/richtextsizepage.cpp:457
+#: ../src/richtext/richtextsizepage.cpp:459
+msgid "Units for the maximum object width."
+msgstr "对象最大宽度单位。"
+
+#: ../src/richtext/richtextsizepage.cpp:462
+msgid "Max height:"
+msgstr "最大高度："
+
+#: ../src/richtext/richtextsizepage.cpp:473
+#: ../src/richtext/richtextsizepage.cpp:475
+msgid "The object maximum height."
+msgstr "对象最大高度。"
+
+#: ../src/richtext/richtextsizepage.cpp:484
+#: ../src/richtext/richtextsizepage.cpp:486
+msgid "Units for the maximum object height."
+msgstr "对象最大高度单位。"
+
+#: ../src/richtext/richtextsizepage.cpp:495
+msgid "Position"
+msgstr "位置"
+
+#: ../src/richtext/richtextsizepage.cpp:513
+msgid "&Position mode:"
+msgstr "位置模式(&P)："
+
+#: ../src/richtext/richtextsizepage.cpp:517
+#: ../src/richtext/richtextsizepage.cpp:522
+msgid "Static"
+msgstr "静态"
+
+#: ../src/richtext/richtextsizepage.cpp:518
+msgid "Relative"
+msgstr "相对"
+
+#: ../src/richtext/richtextsizepage.cpp:519
+msgid "Absolute"
+msgstr "绝对"
+
+#: ../src/richtext/richtextsizepage.cpp:520
+msgid "Fixed"
+msgstr "固定"
+
+#: ../src/richtext/richtextsizepage.cpp:533
+#: ../src/richtext/richtextsizepage.cpp:535
+#: ../src/richtext/richtextsizepage.cpp:547
+#: ../src/richtext/richtextsizepage.cpp:549
+msgid "The left position."
+msgstr "左侧偏移量。"
+
+#: ../src/richtext/richtextsizepage.cpp:558
+#: ../src/richtext/richtextsizepage.cpp:560
+msgid "Units for the left position."
+msgstr "左侧偏移量单位。"
+
+#: ../src/richtext/richtextsizepage.cpp:568
+#: ../src/richtext/richtextsizepage.cpp:570
+#: ../src/richtext/richtextsizepage.cpp:582
+#: ../src/richtext/richtextsizepage.cpp:584
+msgid "The top position."
+msgstr "上方偏移量。"
+
+#: ../src/richtext/richtextsizepage.cpp:593
+#: ../src/richtext/richtextsizepage.cpp:595
+msgid "Units for the top position."
+msgstr "上方偏移量单位。"
+
+#: ../src/richtext/richtextsizepage.cpp:603
+#: ../src/richtext/richtextsizepage.cpp:605
+#: ../src/richtext/richtextsizepage.cpp:617
+#: ../src/richtext/richtextsizepage.cpp:619
+msgid "The right position."
+msgstr "右侧偏移量。"
+
+#: ../src/richtext/richtextsizepage.cpp:628
+#: ../src/richtext/richtextsizepage.cpp:630
+msgid "Units for the right position."
+msgstr "右侧偏移量单位。"
+
+#: ../src/richtext/richtextsizepage.cpp:638
+#: ../src/richtext/richtextsizepage.cpp:640
+#: ../src/richtext/richtextsizepage.cpp:652
+#: ../src/richtext/richtextsizepage.cpp:654
+msgid "The bottom position."
+msgstr "下方偏移量。"
+
+#: ../src/richtext/richtextsizepage.cpp:663
+#: ../src/richtext/richtextsizepage.cpp:665
+msgid "Units for the bottom position."
+msgstr "下方偏移量单位。"
+
+#: ../src/richtext/richtextsizepage.cpp:671
+msgid "&Move the object to:"
+msgstr "移动对象至(&M)："
+
+#: ../src/richtext/richtextsizepage.cpp:674
+msgid "&Previous Paragraph"
+msgstr "前一段落(&P)"
+
+#: ../src/richtext/richtextsizepage.cpp:675
+#: ../src/richtext/richtextsizepage.cpp:677
+msgid "Moves the object to the previous paragraph."
+msgstr "将对象移至前一段落。"
+
+#: ../src/richtext/richtextsizepage.cpp:680
+msgid "&Next Paragraph"
+msgstr "下一段落(&N)"
+
+#: ../src/richtext/richtextsizepage.cpp:681
+#: ../src/richtext/richtextsizepage.cpp:683
+msgid "Moves the object to the next paragraph."
+msgstr "将对象移至下一段落。"
+
+#: ../src/richtext/richtextstyledlg.cpp:193
+msgid "&Styles:"
+msgstr "样式(&S)："
+
+#: ../src/richtext/richtextstyledlg.cpp:197
+#: ../src/richtext/richtextstyledlg.cpp:199
+msgid "The available styles."
+msgstr "可用样式。"
+
+#: ../src/richtext/richtextstyledlg.cpp:205
+#: ../src/richtext/richtextstyledlg.cpp:217
+msgid " "
+msgstr " "
+
+#: ../src/richtext/richtextstyledlg.cpp:209
+#: ../src/richtext/richtextstyledlg.cpp:211
+msgid "The style preview."
+msgstr "样式预览。"
+
+#: ../src/richtext/richtextstyledlg.cpp:220
+msgid "New &Character Style..."
+msgstr "新建字符样式(&C)..."
+
+#: ../src/richtext/richtextstyledlg.cpp:221
+#: ../src/richtext/richtextstyledlg.cpp:223
+msgid "Click to create a new character style."
+msgstr "点击新建字符样式。"
+
+#: ../src/richtext/richtextstyledlg.cpp:226
+msgid "New &Paragraph Style..."
+msgstr "新建段落样式(&P)..."
+
+#: ../src/richtext/richtextstyledlg.cpp:227
+#: ../src/richtext/richtextstyledlg.cpp:229
+msgid "Click to create a new paragraph style."
+msgstr "点击新建段落样式。"
+
+#: ../src/richtext/richtextstyledlg.cpp:232
+msgid "New &List Style..."
+msgstr "新建列表样式(&L)..."
+
+#: ../src/richtext/richtextstyledlg.cpp:233
+#: ../src/richtext/richtextstyledlg.cpp:235
+msgid "Click to create a new list style."
+msgstr "点击新建列表样式。"
+
+#: ../src/richtext/richtextstyledlg.cpp:238
+msgid "New &Box Style..."
+msgstr "新建文本框样式(&B)..."
+
+#: ../src/richtext/richtextstyledlg.cpp:239
+#: ../src/richtext/richtextstyledlg.cpp:241
+msgid "Click to create a new box style."
+msgstr "点击新建文本框样式。"
+
+#: ../src/richtext/richtextstyledlg.cpp:246
+msgid "&Apply Style"
+msgstr "应用样式(&A)"
+
+#: ../src/richtext/richtextstyledlg.cpp:247
+#: ../src/richtext/richtextstyledlg.cpp:249
+msgid "Click to apply the selected style."
+msgstr "点击应用所选样式。"
+
+#: ../src/richtext/richtextstyledlg.cpp:252
+msgid "&Rename Style..."
+msgstr "重命名样式(&R)..."
+
+#: ../src/richtext/richtextstyledlg.cpp:253
+#: ../src/richtext/richtextstyledlg.cpp:255
+msgid "Click to rename the selected style."
+msgstr "点击重命名所选样式。"
+
+#: ../src/richtext/richtextstyledlg.cpp:258
+msgid "&Edit Style..."
+msgstr "编辑样式(&E)..."
+
+#: ../src/richtext/richtextstyledlg.cpp:259
+#: ../src/richtext/richtextstyledlg.cpp:261
+msgid "Click to edit the selected style."
+msgstr "点击编辑所选样式。"
+
+#: ../src/richtext/richtextstyledlg.cpp:264
+msgid "&Delete Style..."
+msgstr "删除样式(&D)..."
+
+#: ../src/richtext/richtextstyledlg.cpp:265
+#: ../src/richtext/richtextstyledlg.cpp:267
+msgid "Click to delete the selected style."
+msgstr "点击删除所选样式。"
+
+#: ../src/richtext/richtextstyledlg.cpp:274
+#: ../src/richtext/richtextstyledlg.cpp:276
+msgid "Click to close this window."
+msgstr "点击关闭此窗口。"
+
+#: ../src/richtext/richtextstyledlg.cpp:282
+msgid "&Restart numbering"
+msgstr "重新编号(&R)"
+
+#: ../src/richtext/richtextstyledlg.cpp:284
+#: ../src/richtext/richtextstyledlg.cpp:286
+msgid "Check to restart numbering."
+msgstr "勾选以重新编号。"
+
+#: ../src/richtext/richtextstyledlg.cpp:601
+msgid "Enter a character style name"
+msgstr "输入字符样式名称"
+
+#: ../src/richtext/richtextstyledlg.cpp:601
+#: ../src/richtext/richtextstyledlg.cpp:606
+#: ../src/richtext/richtextstyledlg.cpp:649
+#: ../src/richtext/richtextstyledlg.cpp:654
+#: ../src/richtext/richtextstyledlg.cpp:815
+#: ../src/richtext/richtextstyledlg.cpp:820
+#: ../src/richtext/richtextstyledlg.cpp:888
+#: ../src/richtext/richtextstyledlg.cpp:896
+#: ../src/richtext/richtextstyledlg.cpp:929
+#: ../src/richtext/richtextstyledlg.cpp:934
+msgid "New Style"
+msgstr "新建样式"
+
+#: ../src/richtext/richtextstyledlg.cpp:606
+#: ../src/richtext/richtextstyledlg.cpp:654
+#: ../src/richtext/richtextstyledlg.cpp:820
+#: ../src/richtext/richtextstyledlg.cpp:896
+#: ../src/richtext/richtextstyledlg.cpp:934
+msgid "Sorry, that name is taken. Please choose another."
+msgstr "抱歉，该名称已被占用。请选择其他名称。"
+
+#: ../src/richtext/richtextstyledlg.cpp:649
+msgid "Enter a paragraph style name"
+msgstr "输入段落样式名称"
+
+#: ../src/richtext/richtextstyledlg.cpp:777
+#, c-format
+msgid "Delete style %s?"
+msgstr "删除样式 %s？"
+
+#: ../src/richtext/richtextstyledlg.cpp:777
+msgid "Delete Style"
+msgstr "删除样式"
+
+#: ../src/richtext/richtextstyledlg.cpp:815
+msgid "Enter a list style name"
+msgstr "输入列表样式名称"
+
+#: ../src/richtext/richtextstyledlg.cpp:888
+msgid "Enter a new style name"
+msgstr "输入新样式名称"
+
+#: ../src/richtext/richtextstyledlg.cpp:929
+msgid "Enter a box style name"
+msgstr "输入文本框样式名称"
+
+#: ../src/richtext/richtextstylepage.cpp:109
+#: ../src/richtext/richtextstylepage.cpp:111
+msgid "The style name."
+msgstr "样式名称。"
+
+#: ../src/richtext/richtextstylepage.cpp:114
+msgid "&Based on:"
+msgstr "基于(&B)："
+
+#: ../src/richtext/richtextstylepage.cpp:119
+#: ../src/richtext/richtextstylepage.cpp:121
+msgid "The style on which this style is based."
+msgstr "此样式的基础样式。"
+
+#: ../src/richtext/richtextstylepage.cpp:124
+msgid "&Next style:"
+msgstr "下一个样式(&N)："
+
+#: ../src/richtext/richtextstylepage.cpp:129
+#: ../src/richtext/richtextstylepage.cpp:131
+msgid "The default style for the next paragraph."
+msgstr "下一段落默认样式。"
+
+#: ../src/richtext/richtextstyles.cpp:1057
+msgid "All styles"
+msgstr "所有样式"
+
+#: ../src/richtext/richtextstyles.cpp:1058
+msgid "Paragraph styles"
+msgstr "段落样式"
+
+#: ../src/richtext/richtextstyles.cpp:1059
+msgid "Character styles"
+msgstr "字符样式"
+
+#: ../src/richtext/richtextstyles.cpp:1060
+msgid "List styles"
+msgstr "列表样式"
+
+#: ../src/richtext/richtextstyles.cpp:1061
+msgid "Box styles"
+msgstr "文本框样式"
+
+#: ../src/richtext/richtextsymboldlg.cpp:389
+#: ../src/richtext/richtextsymboldlg.cpp:391
+msgid "The font from which to take the symbol."
+msgstr "从中选取符号的字体。"
+
+#: ../src/richtext/richtextsymboldlg.cpp:396
+msgid "&Subset:"
+msgstr "子集(&S)："
+
+#: ../src/richtext/richtextsymboldlg.cpp:401
+#: ../src/richtext/richtextsymboldlg.cpp:403
+msgid "Shows a Unicode subset."
+msgstr "显示 Unicode 子集。"
+
+#: ../src/richtext/richtextsymboldlg.cpp:412
+msgid "xxxx"
+msgstr "xxxx"
+
+#: ../src/richtext/richtextsymboldlg.cpp:417
+msgid "&Character code:"
+msgstr "字符编码(&C)："
+
+#: ../src/richtext/richtextsymboldlg.cpp:421
+#: ../src/richtext/richtextsymboldlg.cpp:423
+msgid "The character code."
+msgstr "字符编码。"
+
+#: ../src/richtext/richtextsymboldlg.cpp:428
+msgid "&From:"
+msgstr "从(&F)："
+
+#: ../src/richtext/richtextsymboldlg.cpp:433
+#: ../src/richtext/richtextsymboldlg.cpp:434
+#: ../src/richtext/richtextsymboldlg.cpp:435
+msgid "Unicode"
+msgstr "Unicode"
+
+#: ../src/richtext/richtextsymboldlg.cpp:436
+#: ../src/richtext/richtextsymboldlg.cpp:438
+msgid "The range to show."
+msgstr "显示的范围。"
+
+#: ../src/richtext/richtextsymboldlg.cpp:444
+msgid "Insert"
+msgstr "插入"
+
+#: ../src/richtext/richtextsymboldlg.cpp:478
+msgid "(Normal text)"
+msgstr "(普通文本)"
+
+#: ../src/richtext/richtexttabspage.cpp:109
+msgid "&Position (tenths of a mm):"
+msgstr "位置(&P)（单位：0.1 毫米）："
+
+#: ../src/richtext/richtexttabspage.cpp:113
+#: ../src/richtext/richtexttabspage.cpp:115
+msgid "The tab position."
+msgstr "制表位。"
+
+#: ../src/richtext/richtexttabspage.cpp:119
+msgid "The tab positions."
+msgstr "制表位。"
+
+#: ../src/richtext/richtexttabspage.cpp:132
+#: ../src/richtext/richtexttabspage.cpp:134
+msgid "Click to create a new tab position."
+msgstr "点击新建制表位。"
+
+#: ../src/richtext/richtexttabspage.cpp:138
+#: ../src/richtext/richtexttabspage.cpp:140
+msgid "Click to delete the selected tab position."
+msgstr "点击删除所选制表位。"
+
+#: ../src/richtext/richtexttabspage.cpp:143
+msgid "Delete A&ll"
+msgstr "全部删除(&L)"
+
+#: ../src/richtext/richtexttabspage.cpp:144
+#: ../src/richtext/richtexttabspage.cpp:146
+msgid "Click to delete all tab positions."
+msgstr "点击删除所有制表位。"
+
+#: ../src/univ/theme.cpp:110
+msgid "Failed to initialize GUI: no built-in themes found."
+msgstr "无法初始化 GUI：未找到内置主题。"
+
+#: ../src/univ/themes/gtk.cpp:521
+msgid "GTK+ theme"
+msgstr "GTK+ 主题"
+
+#: ../src/univ/themes/metal.cpp:164
+msgid "Metal theme"
+msgstr "Metal 主题"
+
+#: ../src/univ/themes/mono.cpp:512
+msgid "Simple monochrome theme"
+msgstr "简易黑白主题"
+
+#: ../src/univ/themes/win32.cpp:1098
+msgid "Win32 theme"
+msgstr "Win32 主题"
+
+#: ../src/univ/themes/win32.cpp:3743
+msgid "&Restore"
+msgstr "还原(&R)"
+
+#: ../src/univ/themes/win32.cpp:3744
+msgid "&Move"
+msgstr "移动(&M)"
+
+#: ../src/univ/themes/win32.cpp:3746
+msgid "&Size"
+msgstr "大小(&S)"
+
+#: ../src/univ/themes/win32.cpp:3748
+msgid "Mi&nimize"
+msgstr "最小化(&N)"
+
+#: ../src/univ/themes/win32.cpp:3750
+msgid "Ma&ximize"
+msgstr "最大化(&X)"
+
+#: ../src/univ/themes/win32.cpp:3752
+msgid "Alt+"
+msgstr "Alt+"
+
+#: ../src/unix/appunix.cpp:178
+msgid "Failed to install signal handler"
+msgstr "无法安装信号处理程序"
+
+#: ../src/unix/dialup.cpp:351
+msgid "Already dialling ISP."
+msgstr "已在拨号连接 ISP。"
+
+#: ../src/unix/dlunix.cpp:93
+msgid "Failed to unload shared library"
+msgstr "无法卸载共享库"
+
+#: ../src/unix/dlunix.cpp:121
+msgid "Unknown dynamic library error"
+msgstr "未知的动态库错误"
+
+#: ../src/unix/epolldispatcher.cpp:84
+msgid "Failed to create epoll descriptor"
+msgstr "无法创建 epoll 描述符"
+
+#: ../src/unix/epolldispatcher.cpp:103
+msgid "Error closing epoll descriptor"
+msgstr "关闭 epoll 描述符时发生错误"
+
+#: ../src/unix/epolldispatcher.cpp:116
+#, c-format
+msgid "Failed to add descriptor %d to epoll descriptor %d"
+msgstr "无法将描述符 %d 添加到 epoll 描述符 %d"
+
+#: ../src/unix/epolldispatcher.cpp:136
+#, c-format
+msgid "Failed to modify descriptor %d in epoll descriptor %d"
+msgstr "无法修改 epoll 描述符 %2$d 中的描述符 %1$d"
+
+#: ../src/unix/epolldispatcher.cpp:155
+#, c-format
+msgid "Failed to unregister descriptor %d from epoll descriptor %d"
+msgstr "无法从 epoll 描述符 %2$d 中注销描述符 %1$d"
+
+#: ../src/unix/epolldispatcher.cpp:213
+#, c-format
+msgid "Waiting for IO on epoll descriptor %d failed"
+msgstr "在 epoll 描述符 %d 上等待 IO 失败"
+
+#: ../src/unix/fswatcher_inotify.cpp:71
+msgid "Unable to create inotify instance"
+msgstr "无法创建 inotify 实例"
+
+#: ../src/unix/fswatcher_inotify.cpp:94
+msgid "Unable to close inotify instance"
+msgstr "无法关闭 inotify 实例"
+
+#: ../src/unix/fswatcher_inotify.cpp:106
+msgid "Unable to add inotify watch"
+msgstr "无法添加 inotify 监视项"
+
+#: ../src/unix/fswatcher_inotify.cpp:138
+#, c-format
+msgid "Unable to remove inotify watch %i"
+msgstr "无法移除 inotify 监视项 %i"
+
+#: ../src/unix/fswatcher_inotify.cpp:271
+#, c-format
+msgid "Unexpected event for \"%s\": no matching watch descriptor."
+msgstr "\"%s\" 出现意外事件：无匹配的监视描述符。"
+
+#: ../src/unix/fswatcher_inotify.cpp:320
+#, c-format
+msgid "Invalid inotify event for \"%s\""
+msgstr "\"%s\" 的无效 inotify 事件"
+
+#: ../src/unix/fswatcher_inotify.cpp:553
+msgid "Unable to read from inotify descriptor"
+msgstr "无法读取 inotify 描述符"
+
+#: ../src/unix/fswatcher_inotify.cpp:558
+msgid "EOF while reading from inotify descriptor"
+msgstr "读取 inotify 描述符时遇到 EOF"
+
+#: ../src/unix/fswatcher_kqueue.cpp:114
+msgid "Unable to create kqueue instance"
+msgstr "无法创建 kqueue 实例"
+
+#: ../src/unix/fswatcher_kqueue.cpp:131
+msgid "Error closing kqueue instance"
+msgstr "关闭 kqueue 实例时发生错误"
+
+#: ../src/unix/fswatcher_kqueue.cpp:153
+msgid "Unable to add kqueue watch"
+msgstr "无法添加 kqueue 监视项"
+
+#: ../src/unix/fswatcher_kqueue.cpp:170
+msgid "Unable to remove kqueue watch"
+msgstr "无法移除 kqueue 监视项"
+
+#: ../src/unix/fswatcher_kqueue.cpp:202
+msgid "Unable to get events from kqueue"
+msgstr "无法从 kqueue 中获取事件"
+
+#: ../src/unix/mediactrl.cpp:966
+#, c-format
+msgid "Media playback error: %s"
+msgstr "媒体播放错误：%s"
+
+#: ../src/unix/mediactrl.cpp:1228
+#, c-format
+msgid "Failed to prepare playing \"%s\"."
+msgstr "无法准备播放“%s”。"
+
+#: ../src/unix/snglinst.cpp:164
+#, c-format
+msgid "Failed to write to lock file '%s'"
+msgstr "无法写入锁定文件 '%s'"
+
+#: ../src/unix/snglinst.cpp:177
+#, c-format
+msgid "Failed to set permissions on lock file '%s'"
+msgstr "无法设置锁定文件 '%s' 的权限"
+
+#: ../src/unix/snglinst.cpp:194
+#, c-format
+msgid "Failed to lock the lock file '%s'"
+msgstr "无法锁定文件 '%s'"
+
+#: ../src/unix/snglinst.cpp:237
+#, c-format
+msgid "Failed to inspect the lock file '%s'"
+msgstr "无法检查锁定文件 '%s'"
+
+#: ../src/unix/snglinst.cpp:242
+#, c-format
+msgid "Lock file '%s' has incorrect owner."
+msgstr "锁定文件 '%s' 的所有者不正确。"
+
+#: ../src/unix/snglinst.cpp:247
+#, c-format
+msgid "Lock file '%s' has incorrect permissions."
+msgstr "锁定文件 '%s' 的权限不正确。"
+
+#: ../src/unix/snglinst.cpp:265
+msgid "Failed to access lock file."
+msgstr "无法访问锁定文件。"
+
+#: ../src/unix/snglinst.cpp:274
+msgid "Failed to read PID from lock file."
+msgstr "无法从锁定文件读取 PID。"
+
+#: ../src/unix/snglinst.cpp:284
+#, c-format
+msgid "Failed to remove stale lock file '%s'."
+msgstr "无法移除过期的锁定文件 '%s'。"
+
+#: ../src/unix/snglinst.cpp:297
+#, c-format
+msgid "Deleted stale lock file '%s'."
+msgstr "已删除过期的锁定文件 '%s'。"
+
+#: ../src/unix/snglinst.cpp:308
+#, c-format
+msgid "Invalid lock file '%s'."
+msgstr "无效的锁定文件 '%s'。"
+
+#: ../src/unix/snglinst.cpp:324
+#, c-format
+msgid "Failed to remove lock file '%s'"
+msgstr "无法移除锁定文件 '%s'"
+
+#: ../src/unix/snglinst.cpp:330
+#, c-format
+msgid "Failed to unlock lock file '%s'"
+msgstr "无法对锁定文件 '%s' 解锁"
+
+#: ../src/unix/snglinst.cpp:336
+#, c-format
+msgid "Failed to close lock file '%s'"
+msgstr "无法关闭锁定文件 '%s'"
+
+#: ../src/unix/sound.cpp:77
+msgid "No sound"
+msgstr "没有声音"
+
+#: ../src/unix/sound.cpp:364
+msgid "Unable to play sound asynchronously."
+msgstr "无法异步播放声音。"
+
+#: ../src/unix/sound.cpp:458
+#, c-format
+msgid "Couldn't load sound data from '%s'."
+msgstr "无法从 '%s' 中加载声音数据。"
+
+#: ../src/unix/sound.cpp:465
+#, c-format
+msgid "Sound file '%s' is in unsupported format."
+msgstr "声音文件 '%s' 格式不受支持。"
+
+#: ../src/unix/sound.cpp:480
+msgid "Sound data are in unsupported format."
+msgstr "声音数据格式不受支持。"
+
+#: ../src/unix/sound_sdl.cpp:226
+#, c-format
+msgid "Couldn't open audio: %s"
+msgstr "无法打开音频：%s"
+
+#: ../src/unix/threadpsx.cpp:1033
+msgid "Cannot retrieve thread scheduling policy."
+msgstr "无法读取线程调度策略。"
+
+#: ../src/unix/threadpsx.cpp:1058
+#, c-format
+msgid "Cannot get priority range for scheduling policy %d."
+msgstr "无法获得调度策略 %d 的优先级范围。"
+
+#: ../src/unix/threadpsx.cpp:1066
+msgid "Thread priority setting is ignored."
+msgstr "线程优先级设置被忽略。"
+
+#: ../src/unix/threadpsx.cpp:1221
+msgid ""
+"Failed to join a thread, potential memory leak detected - please restart the "
+"program"
+msgstr "等待线程结束失败，检测到潜在的内存泄漏——请重启程序"
+
+#: ../src/unix/threadpsx.cpp:1352
+#, c-format
+msgid "Failed to set thread concurrency level to %lu"
+msgstr "无法将线程并发级别设置为 %lu"
+
+#: ../src/unix/threadpsx.cpp:1481
+#, c-format
+msgid "Failed to set thread priority %d."
+msgstr "无法设置线程优先级 %d。"
+
+#: ../src/unix/threadpsx.cpp:1666
+msgid "Failed to terminate a thread."
+msgstr "无法终止线程。"
+
+#: ../src/unix/threadpsx.cpp:1893
+msgid "Thread module initialization failed: failed to create thread key"
+msgstr "线程模块初始化失败：创建线程局部存储键失败"
+
+#: ../src/unix/utilsunx.cpp:340
+msgid "Impossible to get child process input"
+msgstr "无法获取子进程输入"
+
+#: ../src/unix/utilsunx.cpp:390
+msgid "Can't write to child process's stdin"
+msgstr "无法写入子进程的标准输入"
+
+#: ../src/unix/utilsunx.cpp:644
+#, c-format
+msgid "Failed to execute '%s'\n"
+msgstr "无法执行 '%s'\n"
+
+#: ../src/unix/utilsunx.cpp:678
+msgid "Fork failed"
+msgstr "Fork 失败"
+
+#: ../src/unix/utilsunx.cpp:701
+msgid "Failed to set process priority"
+msgstr "无法设置进程优先级"
+
+#: ../src/unix/utilsunx.cpp:712
+msgid "Failed to redirect child process input/output"
+msgstr "无法重定向子进程输入/输出"
+
+#: ../src/unix/utilsunx.cpp:816
+msgid "Failed to set up non-blocking pipe, the program might hang."
+msgstr "设置非阻塞管道失败，程序可能会挂起。"
+
+#: ../src/unix/utilsunx.cpp:1023
+msgid "Cannot get the hostname"
+msgstr "无法获取主机名"
+
+#: ../src/unix/utilsunx.cpp:1059
+msgid "Cannot get the official hostname"
+msgstr "无法获取规范主机名"
+
+#: ../src/unix/wakeuppipe.cpp:49
+msgid "Failed to create wake up pipe used by event loop."
+msgstr "无法创建用于事件循环的唤醒管道。"
+
+#: ../src/unix/wakeuppipe.cpp:56
+msgid "Failed to switch wake up pipe to non-blocking mode"
+msgstr "无法将唤醒管道切换至非阻塞模式"
+
+#: ../src/unix/wakeuppipe.cpp:117
+msgid "Failed to read from wake-up pipe"
+msgstr "无法读取唤醒管道"
+
+#: ../src/x11/app.cpp:124
+#, c-format
+msgid "Invalid geometry specification '%s'"
+msgstr "几何规格 '%s' 无效"
+
+#: ../src/x11/app.cpp:167
+msgid "wxWidgets could not open display. Exiting."
+msgstr "wxWidgets 无法打开显示。正在退出。"
+
+#: ../src/x11/utils.cpp:169
+#, c-format
+msgid "Failed to close the display \"%s\""
+msgstr "无法关闭显示 \"%s\""
+
+#: ../src/x11/utils.cpp:188
+#, c-format
+msgid "Failed to open display \"%s\"."
+msgstr "无法打开显示 \"%s\"。"
+
+#: ../src/xml/xml.cpp:868
+#, c-format
+msgid "XML parsing error: '%s' at line %d"
+msgstr "XML 解析错误：'%s'，位于第 %d 行"
+
+#: ../src/xrc/xh_propgrid.cpp:239
+#, c-format
+msgid "Page %i"
+msgstr "第 %i 页"
+
+#: ../src/xrc/xmlres.cpp:448
+#, c-format
+msgid "Cannot load resources from '%s'."
+msgstr "无法从文件 '%s' 中加载资源。"
+
+#: ../src/xrc/xmlres.cpp:799
+#, c-format
+msgid "Cannot open resources file '%s'."
+msgstr "无法打开资源文件 '%s'。"
+
+#: ../src/xrc/xmlres.cpp:806
+#, c-format
+msgid "Cannot load resources from file '%s'."
+msgstr "无法从文件 '%s' 中加载资源。"
+
+#: ../src/xrc/xmlres.cpp:2767
+#, c-format
+msgid "Creating %s \"%s\" failed."
+msgstr "创建 %s \"%s\" 失败。"
+
+#, c-format
+#~ msgid "BMP: header has biClrUsed=%d when biBitCount=%d."
+#~ msgstr "BMP：当 biBitCount=%d 时，表头则为 biClrUsed=%d。"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Alt+"
+#~ msgstr "Alt+"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Ctrl+"
+#~ msgstr "Ctrl+"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Shift+"
+#~ msgstr "Shift+"
+
+#~ msgctxt "keyboard key"
+#~ msgid "RawCtrl+"
+#~ msgstr "RawCtrl+"
+
+#~ msgid "Copying more than one selected block to clipboard is not supported."
+#~ msgstr "不支持将多个选定块复制到剪贴板。"
+
+#~ msgid "Unsupported clipboard format."
+#~ msgstr "不支持的剪贴板格式。"
+
+#~ msgid "Background colour"
+#~ msgstr "背景颜色"
+
+#~ msgid "Font:"
+#~ msgstr "字体："
+
+#~ msgid "Size:"
+#~ msgstr "大小："
+
+#~ msgid "The font size in points."
+#~ msgstr "字体大小点数。"
+
+#~ msgid "Style:"
+#~ msgstr "样式："
+
+#~ msgid "Check to make the font bold."
+#~ msgstr "勾选设置为粗体。"
+
+#~ msgid "Check to make the font italic."
+#~ msgstr "勾选设置为斜体。"
+
+#~ msgid "Check to make the font underlined."
+#~ msgstr "勾选加下划线。"
+
+#~ msgid "Colour:"
+#~ msgstr "颜色："
+
+#~ msgid "Click to change the font colour."
+#~ msgstr "点击更改字体颜色。"
+
+#~ msgid "Shows a preview of the font."
+#~ msgstr "展示预览字体。"
+
+#~ msgid "Click to cancel changes to the font."
+#~ msgstr "点击取消字体变更。"
+
+#~ msgid "Click to confirm changes to the font."
+#~ msgstr "点击确认字体更改。"
+
+#~ msgid "<Any>"
+#~ msgstr "<任一>"
+
+#~ msgid "<Any Roman>"
+#~ msgstr "<任一 Roman>"
+
+#~ msgid "<Any Decorative>"
+#~ msgstr "<任一 Decorative>"
+
+#~ msgid "<Any Modern>"
+#~ msgstr "<任一 Modern>"
+
+#~ msgid "<Any Script>"
+#~ msgstr "<任一 Script>"
+
+#~ msgid "<Any Swiss>"
+#~ msgstr "<任一 Swiss>"
+
+#~ msgid "<Any Teletype>"
+#~ msgstr "<任一 Teletype>"
+
+#~ msgid "Printing "
+#~ msgstr "正在打印 "
+
+#~ msgid "Failed to insert text in the control."
+#~ msgstr "无法在控件中插入文字。"
+
+#~ msgid "Please choose a valid font."
+#~ msgstr "请选择一个有效的字体。"
+
+#, c-format
+#~ msgid "Failed to display HTML document in %s encoding"
+#~ msgstr "无法按编码 %s 显示 HTML 文档"
+
+#, c-format
+#~ msgid "wxWidgets could not open display for '%s': exiting."
+#~ msgstr "wxWidgets 无法为 '%s' 打开显示设备：退出。"
+
+#~ msgid "Filter"
+#~ msgstr "过滤器"
+
+#~ msgid "Directories"
+#~ msgstr "目录"
+
+#~ msgid "Files"
+#~ msgstr "文件"
+
+#~ msgid "Selection"
+#~ msgstr "选区"
+
+#~ msgid "conversion to 8-bit encoding failed"
+#~ msgstr "无法转换为 8 位编码"
+
+#~ msgid "failed to retrieve execution result"
+#~ msgstr "检索执行结果失败"
+
+#~ msgid "&Save as"
+#~ msgstr "另存为(&S)"
+
+#~ msgid "'%s' doesn't consist only of valid characters"
+#~ msgstr "'%s' 不仅包含有效字符"
+
+#~ msgid "'%s' should be numeric."
+#~ msgstr "'%s' 应该是一个数值。"
+
+#~ msgid "'%s' should only contain ASCII characters."
+#~ msgstr "'%s' 应该仅包含 ASCII 字符。"
+
+#~ msgid "'%s' should only contain alphabetic characters."
+#~ msgstr "'%s' 应仅包含字母字符。"
+
+#~ msgid "'%s' should only contain alphabetic or numeric characters."
+#~ msgstr "'%s' 应仅包含字母或数字字符。"
+
+#~ msgid "'%s' should only contain digits."
+#~ msgstr "'%s' 应该仅包含数字。"
+
+#~ msgid "Can't create window of class %s"
+#~ msgstr "无法创建窗口类 %s"
+
+#~ msgid "Couldn't create the overlay window"
+#~ msgstr "无法创建 overlay 窗口"
+
+#, fuzzy
+#~ msgid "Couldn't init the context on the overlay window"
+#~ msgstr "无法获得当前线程指针"
+
+#~ msgid "Failed to convert file \"%s\" to Unicode."
+#~ msgstr "无法转换文件 \"%s\" 为统一编码。"
+
+#~ msgid "Failed to set text in the text control."
+#~ msgstr "无法设置文本编辑器控件的文字。"
+
+#~ msgid "Invalid GTK+ command line option, use \"%s --help\""
+#~ msgstr "无效的GTK+命令行选项，使用 \"%s --help\""
+
+#~ msgid "No unused colour in image."
+#~ msgstr "图像中没有未用的颜色。"
+
+#~ msgid "Not available"
+#~ msgstr "不可用"
+
+#~ msgid "Replace selection"
+#~ msgstr "替换选区"
+
+#~ msgid "Save as"
+#~ msgstr "另存为"
+
+#~ msgid "Style Organiser"
+#~ msgstr "样式组织器"
+
+#~ msgid "The following standard GTK+ options are also supported:\n"
+#~ msgstr "以下标准GTK+选项也被支持:\n"
+
+#~ msgid "You cannot Clear an overlay that is not inited"
+#~ msgstr "你无法清除未初始化的 overlay。"
+
+#~ msgid "You cannot Init an overlay twice"
+#~ msgstr "你不能初始化 overlay 两次"
+
+#~ msgid "locale '%s' cannot be set."
+#~ msgstr "无法设置地区为 '%s'。"
+
+#~ msgid "Adding flavor TEXT failed"
+#~ msgstr "添加风格 TEXT 失败"
+
+#~ msgid "Adding flavor utxt failed"
+#~ msgstr "添加风格 utxt 失败"
+
+#~ msgid "Bitmap renderer cannot render value; value type: "
+#~ msgstr "位图渲染器无法渲染该值; 类型为:"
+
+#~ msgid ""
+#~ "Cannot create new column's ID. Probably max. number of columns reached."
+#~ msgstr "无法建立新的列 ID。可能已达到列数量的上限。"
+
+#~ msgid "Column could not be added."
+#~ msgstr "无法增加列。"
+
+#~ msgid "Column index not found."
+#~ msgstr "找不到列索引。"
+
+#~ msgid "Column width could not be determined"
+#~ msgstr "无法确定列宽"
+
+#~ msgid "Column width could not be set."
+#~ msgstr "无法设定列宽。"
+
+#~ msgid "Confirm registry update"
+#~ msgstr "确认更新注册表"
+
+#~ msgid "Could not determine column index."
+#~ msgstr "无法确定列索引。"
+
+#~ msgid "Could not determine column's position"
+#~ msgstr "无法确定列位置"
+
+#~ msgid "Could not determine number of columns."
+#~ msgstr "无法确定列数量。"
+
+#~ msgid "Could not determine number of items"
+#~ msgstr "无法确定项目数量"
+
+#~ msgid "Could not get header description."
+#~ msgstr "无法获取表头描述。"
+
+#~ msgid "Could not get items."
+#~ msgstr "无法获取项目。"
+
+#~ msgid "Could not get property flags."
+#~ msgstr "无法获取属性标志。"
+
+#~ msgid "Could not get selected items."
+#~ msgstr "无法获取所选项目。"
+
+#~ msgid "Could not remove column."
+#~ msgstr "无法删除列。"
+
+#~ msgid "Could not retrieve number of items"
+#~ msgstr "无法获取项目数量"
+
+#~ msgid "Could not set column width."
+#~ msgstr "无法启动文档预览。"
+
+#~ msgid "Could not set header description."
+#~ msgstr "无法启动打印。"
+
+#~ msgid "Could not set icon."
+#~ msgstr "无法启动打印。"
+
+#~ msgid "Could not set maximum width."
+#~ msgstr "无法设定最大宽度。"
+
+#~ msgid "Could not set minimum width."
+#~ msgstr "无法设定最小宽度。"
+
+#~ msgid "Could not set property flags."
+#~ msgstr "无法设定属性标志。"
+
+#~ msgid "Data object has invalid data format"
+#~ msgstr "数据对象有无效数据格式"
+
+#~ msgid "Date renderer cannot render value; value type: "
+#~ msgstr "数据渲染器无法渲染该值；类型为:"
+
+#~ msgid ""
+#~ "Do you want to overwrite the command used to %s files with extension "
+#~ "\"%s\" ?\n"
+#~ "Current value is \n"
+#~ "%s, \n"
+#~ "New value is \n"
+#~ "%s %1"
+#~ msgstr ""
+#~ "是否要覆盖用于%s文件(扩展名为\"%s\")的命令？\n"
+#~ "当前值为 \n"
+#~ "%s, \n"
+#~ "新的值为 \n"
+#~ "%s %1"
+
+#~ msgid "Failed to retrieve data from the clipboard."
+#~ msgstr "无法从剪贴板检取数据。"
+
+#~ msgid "GIF: Invalid gif index."
+#~ msgstr "GIF: 无效的 gif 图像索引。"
+
+#~ msgid "GIF: unknown error!!!"
+#~ msgstr "GIF: 位置错误！！！"
+
+#~ msgid "Icon & text renderer cannot render value; value type: "
+#~ msgstr "图标和文本渲染器无法渲染该值；类型为: "
+
+#~ msgid "New directory"
+#~ msgstr "新目录"
+
+#~ msgid "Next"
+#~ msgstr "下一个"
+
+#~ msgid "No column existing."
+#~ msgstr "没有任何列存在。"
+
+#~ msgid "No column for the specified column existing."
+#~ msgstr "没有指定的列存在。"
+
+#~ msgid "No column for the specified column position existing."
+#~ msgstr "没有指定的列位置存在。"
+
+#~ msgid ""
+#~ "No renderer or invalid renderer type specified for custom data column."
+#~ msgstr "无渲染器或为该数据列指定了无效的渲染器"
+
+#~ msgid "No renderer specified for column."
+#~ msgstr "该列未指定渲染器"
+
+#~ msgid "Number of columns could not be determined."
+#~ msgstr "无法确定列数量。"
+
+#~ msgid "OpenGL function \"%s\" failed: %s (error %d)"
+#~ msgstr "OpenGL函数 \"%s\"失败： %s (error %d)"
+
+#~ msgid ""
+#~ "Please install a newer version of comctl32.dll\n"
+#~ "(at least version 4.70 is required but you have %d.%02d)\n"
+#~ "or this program won't operate correctly."
+#~ msgstr ""
+#~ "请安装较新版本的 comctl32.dll\n"
+#~ "(至少需要 4.70 版，您现有的版本是 %d.%02d)，\n"
+#~ "否则此程序无法正确运行。"
+
+#~ msgid "Pointer to data view control not set correctly."
+#~ msgstr "数据视图控制指针设定错误"
+
+#~ msgid "Pointer to model not set correctly."
+#~ msgstr "模型指针设定错误"
+
+#~ msgid "Progress renderer cannot render value type; value type: "
+#~ msgstr "程序渲染器无法渲染该值；类型为："
+
+#~ msgid "Rendering failed."
+#~ msgstr "渲染失败。"
+
+#~ msgid ""
+#~ "Setting directory access times is not supported under this OS version"
+#~ msgstr "当前操作系统不支持目录访问次数设定"
+
+#~ msgid "Show hidden directories"
+#~ msgstr "显示隐藏目录"
+
+#~ msgid "Text renderer cannot render value; value type: "
+#~ msgstr "文本渲染器无法渲染该值；类型为："
+
+#~ msgid "There is no column or renderer for the specified column index."
+#~ msgstr "所指定的列索引或渲染器不存在"
+
+#~ msgid ""
+#~ "This system doesn't support date controls, please upgrade your version of "
+#~ "comctl32.dll"
+#~ msgstr "本系统不支持日期控制, 请升级您的 comctl32.dll"
+
+#~ msgid "Toggle renderer cannot render value; value type: "
+#~ msgstr "切换渲染器无法渲染该；类型为："
+
+#~ msgid "Too many colours in PNG, the image may be slightly blurred."
+#~ msgstr "PNG中的颜色数过多，图像可能会有点模糊。"
+
+#~ msgid "Unable to handle native drag&drop data"
+#~ msgstr "无法处理原生的拖放数据"
+
+#~ msgid "Unable to initialize Hildon program"
+#~ msgstr "无法初始化 Hildon 程序"
+
+#~ msgid "Unknown data format"
+#~ msgstr "未知数据格式"
+
+#~ msgid "Win32s on Windows 3.1"
+#~ msgstr "Windows 3.1 上的 Win32s"
+
+#, fuzzy
+#~ msgid "Windows 10"
+#~ msgstr "Windows 10"
+
+#~ msgid "Windows 2000"
+#~ msgstr "Windows 2000"
+
+#~ msgid "Windows 7"
+#~ msgstr "Windows 7"
+
+#~ msgid "Windows 8"
+#~ msgstr "Windows 8"
+
+#~ msgid "Windows 8.1"
+#~ msgstr "Windows 8.1"
+
+#~ msgid "Windows 95"
+#~ msgstr "Windows 95"
+
+#~ msgid "Windows 95 OSR2"
+#~ msgstr "Windows 95 OSR2"
+
+#~ msgid "Windows 98"
+#~ msgstr "Windows 98"
+
+#~ msgid "Windows 98 SE"
+#~ msgstr "Windows 98 SE"
+
+#~ msgid "Windows 9x (%d.%d)"
+#~ msgstr "Windows 9x (%d.%d)"
+
+#~ msgid "Windows CE (%d.%d)"
+#~ msgstr "Windows CE (%d.%d)"
+
+#~ msgid "Windows ME"
+#~ msgstr "Windows ME"
+
+#~ msgid "Windows NT %lu.%lu"
+#~ msgstr "Windows NT %lu.%lu"
+
+#, fuzzy
+#~ msgid "Windows Server 10"
+#~ msgstr "Windows Server 2003"
+
+#~ msgid "Windows Server 2003"
+#~ msgstr "Windows Server 2003"
+
+#~ msgid "Windows Server 2008"
+#~ msgstr "Windows Server 2008"
+
+#~ msgid "Windows Server 2008 R2"
+#~ msgstr "Windows Server 2008 R2"
+
+#~ msgid "Windows Server 2012"
+#~ msgstr "Windows Server 2012"
+
+#~ msgid "Windows Server 2012 R2"
+#~ msgstr "Windows Server 2012 R2"
+
+#~ msgid "Windows Vista"
+#~ msgstr "Windows Vista"
+
+#~ msgid "Windows XP"
+#~ msgstr "Windows XP"
+
+#~ msgid "can't execute '%s'"
+#~ msgstr "执行 '%s'失败"
+
+#~ msgid "error opening '%s'"
+#~ msgstr "打开 '%s' 出错"
+
+#~ msgid "unknown seek origin"
+#~ msgstr "未知搜索原点"
+
+#~ msgid "wxWidget control pointer is not a data view pointer"
+#~ msgstr "wxWidget 控制指针不是一个数据视图指针"
+
+#~ msgid "wxWidget's control not initialized."
+#~ msgstr "wxWidgets 的控件未初始化。"
+
+#~ msgid "ADD"
+#~ msgstr "ADD"
+
+#~ msgid "BACK"
+#~ msgstr "BACK"
+
+#~ msgid "CANCEL"
+#~ msgstr "CANCEL"
+
+#~ msgid "CAPITAL"
+#~ msgstr "CAPITAL"
+
+#~ msgid "CLEAR"
+#~ msgstr "CLEAR"
+
+#~ msgid "COMMAND"
+#~ msgstr "COMMAND"
+
+#~ msgid "Cannot create mutex."
+#~ msgstr "无法创建互斥子。"
+
+#~ msgid "Cannot resume thread %lu"
+#~ msgstr "无法恢复线程 %lu"
+
+#~ msgid "Cannot suspend thread %lu"
+#~ msgstr "无法挂起线程 %lu"
+
+#~ msgid "Couldn't acquire a mutex lock"
+#~ msgstr "无法得到互斥锁"
+
+#~ msgid "Couldn't get hatch style from wxBrush."
+#~ msgstr "无法从 wxBrush 获取阴影样式。"
+
+#~ msgid "Couldn't release a mutex"
+#~ msgstr "无法释放互斥子"
+
+#~ msgid "DECIMAL"
+#~ msgstr "DECIMAL"
+
+#~ msgid "DEL"
+#~ msgstr "DEL"
+
+#~ msgid "DELETE"
+#~ msgstr "DELETE"
+
+#~ msgid "DIVIDE"
+#~ msgstr "DIVIDE"
+
+#~ msgid "DOWN"
+#~ msgstr "DOWN"
+
+#~ msgid "END"
+#~ msgstr "END"
+
+#~ msgid "ENTER"
+#~ msgstr "ENTER"
+
+#~ msgid "ESC"
+#~ msgstr "ESC"
+
+#~ msgid "ESCAPE"
+#~ msgstr "ESCAPE"
+
+#~ msgid "EXECUTE"
+#~ msgstr "EXECUTE"
+
+#~ msgid "Execution of command '%s' failed with error: %ul"
+#~ msgstr "命令 '%s' 执行失败，错误码：%ul"
+
+#~ msgid ""
+#~ "File '%s' already exists.\n"
+#~ "Do you want to replace it?"
+#~ msgstr ""
+#~ "文件 '%s' 已存在。\n"
+#~ "真的需要替换它?"
+
+#~ msgid "HELP"
+#~ msgstr "HELP"
+
+#~ msgid "HOME"
+#~ msgstr "HOME"
+
+#~ msgid "INS"
+#~ msgstr "INS"
+
+#~ msgid "INSERT"
+#~ msgstr "INSERT"
+
+#~ msgid "KP_BEGIN"
+#~ msgstr "KP_BEGIN"
+
+#~ msgid "KP_DECIMAL"
+#~ msgstr "KP_DECIMAL"
+
+#~ msgid "KP_DELETE"
+#~ msgstr "KP_DELETE"
+
+#~ msgid "KP_DIVIDE"
+#~ msgstr "KP_DIVIDE"
+
+#~ msgid "KP_DOWN"
+#~ msgstr "KP_DOWN"
+
+#~ msgid "KP_ENTER"
+#~ msgstr "KP_ENTER"
+
+#~ msgid "KP_EQUAL"
+#~ msgstr "KP_EQUAL"
+
+#~ msgid "KP_HOME"
+#~ msgstr "KP_HOME"
+
+#~ msgid "KP_INSERT"
+#~ msgstr "KP_INSERT"
+
+#~ msgid "KP_LEFT"
+#~ msgstr "KP_LEFT"
+
+#~ msgid "KP_MULTIPLY"
+#~ msgstr "KP_MULTIPLY"
+
+#~ msgid "KP_NEXT"
+#~ msgstr "KP_NEXT"
+
+#~ msgid "KP_PAGEDOWN"
+#~ msgstr "KP_PAGEDOWN"
+
+#~ msgid "KP_PAGEUP"
+#~ msgstr "KP_PAGEUP"
+
+#~ msgid "KP_PRIOR"
+#~ msgstr "KP_PRIOR"
+
+#~ msgid "KP_RIGHT"
+#~ msgstr "KP_RIGHT"
+
+#~ msgid "KP_SEPARATOR"
+#~ msgstr "KP_SEPARATOR"
+
+#~ msgid "KP_SPACE"
+#~ msgstr "KP_SPACE"
+
+#~ msgid "KP_SUBTRACT"
+#~ msgstr "KP_SUBTRACT"
+
+#~ msgid "LEFT"
+#~ msgstr "LEFT"
+
+#~ msgid "MENU"
+#~ msgstr "MENU"
+
+#~ msgid "NUM_LOCK"
+#~ msgstr "NUM_LOCK"
+
+#~ msgid "PAGEDOWN"
+#~ msgstr "PAGEDOWN"
+
+#~ msgid "PAGEUP"
+#~ msgstr "PAGEUP"
+
+#~ msgid "PAUSE"
+#~ msgstr "PAUSE"
+
+#~ msgid "PGDN"
+#~ msgstr "PGDN"
+
+#~ msgid "PGUP"
+#~ msgstr "PGUP"
+
+#~ msgid "PRINT"
+#~ msgstr "PRINT"
+
+#~ msgid "RETURN"
+#~ msgstr "RETURN"
+
+#~ msgid "RIGHT"
+#~ msgstr "RIGHT"
+
+#~ msgid "SCROLL_LOCK"
+#~ msgstr "SCROLL_LOCK"
+
+#~ msgid "SELECT"
+#~ msgstr "SELECT"
+
+#~ msgid "SEPARATOR"
+#~ msgstr "SEPARATOR"
+
+#~ msgid "SNAPSHOT"
+#~ msgstr "SNAPSHOT"
+
+#~ msgid "SPACE"
+#~ msgstr "SPACE"
+
+#~ msgid "SUBTRACT"
+#~ msgstr "SUBTRACT"
+
+#~ msgid "TAB"
+#~ msgstr "TAB"
+
+#~ msgid "The print dialog returned an error."
+#~ msgstr "打印对话返回错误"
+
+#~ msgid "The wxGtkPrinterDC cannot be used."
+#~ msgstr "wxGtkPrinterDC无法使用"
+
+#~ msgid "Timer creation failed."
+#~ msgstr "计时器创建失败"
+
+#~ msgid "UP"
+#~ msgstr "UP"
+
+#~ msgid "WINDOWS_LEFT"
+#~ msgstr "WINDOWS_LEFT"
+
+#~ msgid "WINDOWS_MENU"
+#~ msgstr "WINDOWS_MENU"
+
+#~ msgid "WINDOWS_RIGHT"
+#~ msgstr "WINDOWS_RIGHT"
+
+#~ msgid "buffer is too small for Windows directory."
+#~ msgstr "Windows 目录的缓存太小。"
+
+#~ msgid "not implemented"
+#~ msgstr "为实现"
+
+#~ msgid "wxPrintout::GetPageInfo gives a null maxPage."
+#~ msgstr "wxPrintout::GetPageInfo 给出无效 maxPage"
+
+#~ msgid "Event queue overflowed"
+#~ msgstr "消息队列溢出"
+
+#~ msgid "percent"
+#~ msgstr "百分比"
+
+#~ msgid "Print preview"
+#~ msgstr "打印预览"
+
+#~ msgid "'"
+#~ msgstr "'"
+
+#~ msgid "1"
+#~ msgstr "1"
+
+#~ msgid "10"
+#~ msgstr "10"
+
+#~ msgid "3"
+#~ msgstr "3"
+
+#~ msgid "4"
+#~ msgstr "4"
+
+#~ msgid "5"
+#~ msgstr "5"
+
+#~ msgid "6"
+#~ msgstr "6"
+
+#~ msgid "7"
+#~ msgstr "7"
+
+#~ msgid "8"
+#~ msgstr "8"
+
+#~ msgid "9"
+#~ msgstr "9"
+
+#~ msgid "Can't monitor non-existent path \"%s\" for changes."
+#~ msgstr "无法监视不存在路径 \"%s\" 的更新。"
+
+#~ msgid "File system containing watched object was unmounted"
+#~ msgstr "包含监控对象的文件系统已被卸载"
+
+#~ msgid "&Preview..."
+#~ msgstr "预览(&P)..."
+
+#~ msgid "Passing an unkown object to GetObject"
+#~ msgstr "传递一个未知对象给 GetObject"
+
+#~ msgid "Preview..."
+#~ msgstr "预览..."
+
+#~ msgid "&Save..."
+#~ msgstr "保存(&S)..."
+
+#~ msgid "About "
+#~ msgstr "关于"
+
+#~ msgid "All files (*.*)|*"
+#~ msgstr "所有文件 (*.*)|*"
+
+#~ msgid "Cannot initialize SciTech MGL!"
+#~ msgstr "无法初始化 SciTech MGL!"
+
+#~ msgid "Cannot initialize display."
+#~ msgstr "无法初始化显示。"
+
+#~ msgid "Cannot start thread: error writing TLS"
+#~ msgstr "无法启动线程：写 TLS 错误"
+
+#~ msgid "Close\tAlt-F4"
+#~ msgstr "关闭 \tAlt-F4"
+
+#~ msgid "Couldn't create cursor."
+#~ msgstr "无法创建光标。"
+
+#~ msgid "Directory '%s' doesn't exist!"
+#~ msgstr "目录 '%s' 不存在!"
+
+#~ msgid "Mode %ix%i-%i not available."
+#~ msgstr "显示模式 %ix%i-%i位色 不支持。"
+
+#~ msgid "Paper Size"
+#~ msgstr "纸张大小"
+
+#~ msgid "&Goto..."
+#~ msgstr "跳转(&G)..."
+
+#~ msgid "<<"
+#~ msgstr "<<"
+
+#~ msgid ">>"
+#~ msgstr ">>"
+
+#~ msgid ">>|"
+#~ msgstr ">>|"
+
+#~ msgid "Can't check image format of file '%s': file does not exist."
+#~ msgstr "不能检查文件格式 '%s'：文件不存在。"
+
+#~ msgid "Can't load image from file '%s': file does not exist."
+#~ msgstr "不能从文件 '%s' 中装入图像：文件不存在。"
+
+#~ msgid "Cannot open file '%s'."
+#~ msgstr "不能打开文件 '%s'。"
+
+#, fuzzy
+#~ msgid "Click to cancel this window."
+#~ msgstr "关闭此窗口。"
+
+#, fuzzy
+#~ msgid "Click to confirm your selection."
+#~ msgstr "点击确认字体选择。"
+
+#, fuzzy
+#~ msgid "Column could not be added to native control."
+#~ msgstr "文件不能被装载。"
+
+#~ msgid "Failed to create a status bar."
+#~ msgstr "创建状态条失败。"
+
+#~ msgid "Goto Page"
+#~ msgstr "跳转页面"
+
+#~ msgid "I64"
+#~ msgstr "I64"
+
+#~ msgid "Internal error, illegal wxCustomTypeInfo"
+#~ msgstr "整数错误，不合规范的 wxCustomTypeInfo"
+
+#, fuzzy
+#~ msgid "Model pointer not initialized."
+#~ msgstr "不能初始化显示。"
+
+#, fuzzy
+#~ msgid "No image handler for type %ld defined."
+#~ msgstr "没有类型 %d 的图像处理器。"
+
+#, fuzzy
+#~ msgid "Owner not initialized."
+#~ msgstr "不能初始化显示。"
+
+#, fuzzy
+#~ msgid "Passed item is invalid."
+#~ msgstr "'%s' 是无效的"
+
+#~ msgid "Passing a already registered object to SetObjectName"
+#~ msgstr "传递一个已注册的对象给 SetObjectName"
+
+#~ msgid ""
+#~ "Streaming delegates for not already streamed objects not yet supported"
+#~ msgstr "不支持针对尚未形成流的对象的流委派"
+
+#, fuzzy
+#~ msgid "The file '%s' doesn't exist and couldn't be opened."
+#~ msgstr ""
+#~ "文件 '%s' 不存在，不能被打开。\n"
+#~ "已从最近使用的文件列表 (MRU) 中移去。"
+
+#~ msgid "The path '%s' contains too many \"..\"!"
+#~ msgstr "路径 '%s' 包含了过多的\"..\"！"
+
+#, fuzzy
+#~ msgid "To be deleted item is invalid."
+#~ msgstr "'%s' 是无效的。"
+
+#~ msgid "Update"
+#~ msgstr "更新"
+
+#~ msgid "Warning"
+#~ msgstr "警告"
+
+#~ msgid "Windows 2000 (build %lu"
+#~ msgstr "Windows 2000 (build %lu"
+
+#~ msgid "delegate has no type info"
+#~ msgstr "委派没有类型信息"
+
+#~ msgid "|<<"
+#~ msgstr "|<<"
+
+#~ msgid "Archive doesnt contain #SYSTEM file"
+#~ msgstr "存档里没有包含 #SYSTEM 文件"
+
+#~ msgid "Cannot convert dialog units: dialog unknown."
+#~ msgstr "不能转换对话框单元：未知的对话框。"
+
+#~ msgid "Cannot convert from the charset '%s'!"
+#~ msgstr "不能从字符集 '%s' 转换！"
+
+#~ msgid "Cannot find container for unknown control '%s'."
+#~ msgstr "找不到可以对应于未知控件 '%s' 的容器。"
+
+#~ msgid "Cannot find font node '%s'."
+#~ msgstr "找不到字体节点 '%s'。"
+
+#~ msgid "Cannot parse coordinates from '%s'."
+#~ msgstr "不能从 '%s' 中粘贴坐标。"
+
+#~ msgid "Cannot parse dimension from '%s'."
+#~ msgstr "不能从 '%s' 中解析尺寸。"
+
+#~ msgid "Cant create the thread event queue"
+#~ msgstr "不能创建线程事件队列"
+
+#~ msgid "Could not unlock mutex"
+#~ msgstr "不能释放互斥体"
+
+#~ msgid "Error while waiting on semaphore"
+#~ msgstr "等待信号量时出错"
+
+#~ msgid "Failed to register OpenGL window class."
+#~ msgstr "不能注册 OpenGL窗口类。"
+
+#~ msgid "Fatal error: "
+#~ msgstr "致命错误："
+
+#, fuzzy
+#~ msgid "Help : %s"
+#~ msgstr "帮助：%s"
+
+#~ msgid "Invalid XRC resource '%s': doesn't have root node 'resource'."
+#~ msgstr "无效的XRC资源 '%s': 根节点'resource'不存在。"
+
+#~ msgid "No handler found for XML node '%s', class '%s'!"
+#~ msgstr "没有找到 XML 节点 '%s'，类 '%s' 的处理器！"
+
+#~ msgid "Program aborted."
+#~ msgstr "程序终止。"
+
+#~ msgid "Referenced object node with ref=\"%s\" not found!"
+#~ msgstr "ref=\"%s\"的引用对象节点不存在！"
+
+#~ msgid "Resource files must have same version number!"
+#~ msgstr "资源文件必须有相同的版本号！"
+
+#, fuzzy
+#~ msgid "Search!"
+#~ msgstr "搜索"
+
+#~ msgid "Sorry, could not open this file for saving."
+#~ msgstr "抱歉，不能打开文件供保存。"
+
+#~ msgid "Sorry, could not save this file."
+#~ msgstr "抱歉，不能保存文件。"
+
+#~ msgid "Sorry, print preview needs a printer to be installed."
+#~ msgstr "对不起, 需要先安装打印机才能创建打印预览."
+
+#~ msgid "Status: "
+#~ msgstr "状态："
+
+#~ msgid "Subclass '%s' not found for resource '%s', not subclassing!"
+#~ msgstr "子类 '%s' 在资源 '%s'中不存在，无法子类化！"
+
+#~ msgid "TIFF library error."
+#~ msgstr "TIFF库错误。"
+
+#~ msgid "TIFF library warning."
+#~ msgstr "TIFF库警告。"
+
+#~ msgid "Trying to solve a NULL hostname: giving up"
+#~ msgstr "试图解析 NULL 主机名：放弃"
+
+#~ msgid "Unknown style flag "
+#~ msgstr "未知的风格标志 "
+
+#~ msgid "XRC resource '%s' (class '%s') not found!"
+#~ msgstr "没有找到XRC资源 '%s' （类 '%s')!"
+
+#, fuzzy
+#~ msgid "XRC resource: Cannot create animation from '%s'."
+#~ msgstr "XRC资源：不能从 '%s'创建位图.。"
+
+#~ msgid "XRC resource: Cannot create bitmap from '%s'."
+#~ msgstr "XRC资源：不能从 '%s'创建位图。"
+
+#, fuzzy
+#~ msgid ""
+#~ "XRC resource: Incorrect colour specification '%s' for attribute '%s'."
+#~ msgstr "XRC资源：错误的颜色 '%s' 对于 属性 '%s'。"
+
+#~ msgid "[EMPTY]"
+#~ msgstr "[空]"
+
+#~ msgid "catalog file for domain '%s' not found."
+#~ msgstr "找不到域 '%s'的目录文件。"
+
+#, fuzzy
+#~ msgid "encoding %i"
+#~ msgstr "编码 %s"
+
+#~ msgid "looking for catalog '%s' in path '%s'."
+#~ msgstr "查找目录 '%s' 在路径 '%s'下。"
+
+#~ msgid "wxSocket: invalid signature in ReadMsg."
+#~ msgstr "wxSocket：ReadMsg中无效的签名。"
+
+#~ msgid "wxSocket: unknown event!."
+#~ msgstr "wxSocket: 未知事件。"
+
+#, fuzzy
+#~ msgid " Couldn't create the UnicodeConverter"
+#~ msgstr "不能创建计时器"
+
+#~ msgid "#define %s must be an integer."
+#~ msgstr "#所定义的 %s 必须是整数。"
+
+#~ msgid "%s not a bitmap resource specification."
+#~ msgstr "%s 不是位图资源。"
+
+#~ msgid "%s not an icon resource specification."
+#~ msgstr "%s 不是图标资源。"
+
+#~ msgid "%s: ill-formed resource file syntax."
+#~ msgstr "%s：不良资源文件语法。"
+
+#~ msgid "&Open"
+#~ msgstr "打开(&O)"
+
+#~ msgid "&Print"
+#~ msgstr "打印(&P)"
+
+#~ msgid "*** It can be found in \"%s\"\n"
+#~ msgstr "*** 可在此找到：\"%s\"\n"
+
+#~ msgid ""
+#~ ", expected static, #include or #define\n"
+#~ "while parsing resource."
+#~ msgstr ""
+#~ ", 在对资源进行语法分析时\n"
+#~ ", 期望如下关键字 static，#include 或 #define。"
+
+#~ msgid "Bitmap resource specification %s not found."
+#~ msgstr "找不到位图规格 %s。"
+
+#~ msgid ""
+#~ "Could not resolve control class or id '%s'. Use (non-zero) integer "
+#~ "instead\n"
+#~ " or provide #define (see manual for caveats)"
+#~ msgstr ""
+#~ "不能解析控件类或者id '%s'. 用(非零)整数代替\n"
+#~ "或 提供 #define (详细信息见手册)"
+
+#~ msgid ""
+#~ "Could not resolve menu id '%s'. Use (non-zero) integer instead\n"
+#~ "or provide #define (see manual for caveats)"
+#~ msgstr ""
+#~ "不能解析菜单id '%s'. 用(非零)整数代替\n"
+#~ "或 提供 #define (详细信息见手册)"
+
+#, fuzzy
+#~ msgid "Couldn't end the context on the overlay window"
+#~ msgstr "不能获得当前线程指针"
+
+#~ msgid "Expected '*' while parsing resource."
+#~ msgstr "解析资源时期待出现 '*'。"
+
+#~ msgid "Expected '=' while parsing resource."
+#~ msgstr "解析资源时期待出现 '='。"
+
+#~ msgid "Expected 'char' while parsing resource."
+#~ msgstr "解析资源时期待遇到 'char'。"
+
+#~ msgid ""
+#~ "Failed to find XBM resource %s.\n"
+#~ "Forgot to use wxResourceLoadBitmapData?"
+#~ msgstr ""
+#~ "查找 XBM 资源 %s 失败.\n"
+#~ "没有使用 wxResourceLoadBitmapData？"
+
+#~ msgid ""
+#~ "Failed to find XBM resource %s.\n"
+#~ "Forgot to use wxResourceLoadIconData?"
+#~ msgstr ""
+#~ "查找 XBM 资源 %s 失败。\n"
+#~ "没有使用 wxResourceLoadIconData？"
+
+#~ msgid ""
+#~ "Failed to find XPM resource %s.\n"
+#~ "Forgot to use wxResourceLoadBitmapData?"
+#~ msgstr ""
+#~ "查找XPM资源 %s失败.\n"
+#~ "没有使用 wxResourceLoadBitmapData？"
+
+#~ msgid "Failed to get clipboard data."
+#~ msgstr "获取剪贴板数据失败。"
+
+#~ msgid "Failed to load shared library '%s' Error '%s'"
+#~ msgstr "不能装载共享库 '%s'。错误信息: '%s'"
+
+#~ msgid "Found "
+#~ msgstr "找到 "
+
+#~ msgid "Icon resource specification %s not found."
+#~ msgstr "没有找到图标资源规范 %s。"
+
+#~ msgid "Ill-formed resource file syntax."
+#~ msgstr "不良的资源文件语法。"
+
+#~ msgid "Long Conversions not supported"
+#~ msgstr "不支持长转换"
+
+#~ msgid "No XPM icon facility available!"
+#~ msgstr "没有可用的XPM图标设备！"
+
+#~ msgid "Option '%s' requires a value, '=' expected."
+#~ msgstr "选项 '%s' 要求一个值, 期望 '='。"
+
+#, fuzzy
+#~ msgid "Select all"
+#~ msgstr "全部选择"
+
+#~ msgid "Unexpected end of file while parsing resource."
+#~ msgstr "在解析资源时异常到达文件结尾。"
+
+#~ msgid "Unrecognized style %s while parsing resource."
+#~ msgstr "解析资源时遇到无法识别的风格 %s。"
+
+#~ msgid "Video Output"
+#~ msgstr "视频输出"
+
+#~ msgid "Warning: attempt to remove HTML tag handler from empty stack."
+#~ msgstr "警告: 试图从空栈中移去 HTML 标签处理器。"
+
+#~ msgid "establish"
+#~ msgstr "建立"
+
+#~ msgid "initiate"
+#~ msgstr "初始化"
+
+#~ msgid "invalid eof() return value."
+#~ msgstr "无效的 eof() 返回值。"
+
+#~ msgid "unknown line terminator"
+#~ msgstr "未知行终止符"
+
+#~ msgid "writing"
+#~ msgstr "正在写入"
+
+#~ msgid "."
+#~ msgstr "."
+
+#~ msgid "Cannot open URL '%s'"
+#~ msgstr "不能打开 URL '%s'"
+
+#~ msgid "Error "
+#~ msgstr "错误 "
+
+#~ msgid "Failed to create directory %s/.gnome."
+#~ msgstr "创建目录 %s/.gnome 失败。"
+
+#~ msgid "Failed to create directory %s/mime-info."
+#~ msgstr "创建目录 %s/.mime-info 失败。"
+
+#~ msgid "MP Thread Support is not available on this System"
+#~ msgstr "此系统不提供MP线程支持。"
+
+#~ msgid "Mailcap file %s, line %d: incomplete entry ignored."
+#~ msgstr "Mailcap 文件 %s，行 %d：不完整条目被忽略。"
+
+#~ msgid "Mime.types file %s, line %d: unterminated quoted string."
+#~ msgstr "Mime.类型文件 %s，行 %d：没有结束符号的引用字符串."
+
+#~ msgid "Unknown field in file %s, line %d: '%s'."
+#~ msgstr "在文件 %s，行 %d 是未知字段：'%s'。"
+
+#~ msgid "bold "
+#~ msgstr "粗体 "
+
+#~ msgid "can't query for GUI plugins name in console applications"
+#~ msgstr "无法在控制台程序里查询 GUI 插件"
+
+#, fuzzy
+#~ msgid "light "
+#~ msgstr "细 "
+
+#~ msgid "underlined "
+#~ msgstr "下划线 "
+
+#~ msgid "unsupported zip archive"
+#~ msgstr "不支持的 zip 存档"
+
+#~ msgid ""
+#~ "Failed to get stack backtrace:\n"
+#~ "%s"
+#~ msgstr ""
+#~ "不能获取堆栈的回溯路径：\n"
+#~ " %s"
+
+#~ msgid "Loading Grey Ascii PNM image is not yet implemented."
+#~ msgstr "装入灰度 Ascii PNM图像功能还没有实现："
+
+#~ msgid "Loading Grey Raw PNM image is not yet implemented."
+#~ msgstr "装入灰度 Raw PNM 图像功能还没有实现。"

--- a/po_wxstd/zh_TW.po
+++ b/po_wxstd/zh_TW.po
@@ -1,0 +1,10042 @@
+# Traditional Chinese Messages for wxWidgets.
+# Copyright (C) 2005 Free Software Foundation, Inc.
+# This file is distributed under the same license as the wxWidgets package.
+#
+# PAL <lyh37@ntu.edu.tw>, 2004.
+# Wei-Lun Chao <bluebat@member.fsf.org>, 2005, 2006, 2013.
+# cw.ahbong <cwahbong@users.sourceforge.net>, 2011.
+# Walter Cheuk <wwycheuk@gmail.com>, 2019.
+# Yi-Jyun Pan <pan93412@gmail.com>, 2020.
+msgid ""
+msgstr ""
+"Project-Id-Version: wxWidgets 3.3\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-05-14 20:23+0200\n"
+"PO-Revision-Date: 2022-07-09 10:45+0800\n"
+"Last-Translator: James Pan <bojaypan@mail.ru>\n"
+"Language-Team: Chinese <zh-l10n@lists.linux.org.tw>\n"
+"Language: zh_TW\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"X-Generator: Poedit 3.1.1\n"
+
+#: ../include/wx/defs.h:2582
+msgid "All files (*.*)|*.*"
+msgstr "所有檔案 (*.*)|*.*"
+
+#: ../include/wx/defs.h:2585
+msgid "All files (*)|*"
+msgstr "所有檔案 (*)|*"
+
+#: ../include/wx/generic/progdlgg.h:85
+msgid "Elapsed time:"
+msgstr "耗用時間："
+
+#: ../include/wx/generic/progdlgg.h:86
+msgid "Estimated time:"
+msgstr "預計時間："
+
+#: ../include/wx/generic/progdlgg.h:87
+msgid "Remaining time:"
+msgstr "剩餘時間："
+
+#. TRANSLATORS: HTML printout default title.
+#: ../include/wx/html/htmprint.h:121 ../include/wx/prntbase.h:273
+#: ../include/wx/richtext/richtextprint.h:109 ../src/common/docview.cpp:2161
+msgid "Printout"
+msgstr "列印"
+
+#. TRANSLATORS: HTML easy print default title.
+#: ../include/wx/html/htmprint.h:234 ../include/wx/richtext/richtextprint.h:163
+#: ../src/common/prntbase.cpp:522 ../src/html/htmprint.cpp:291
+msgid "Printing"
+msgstr "列印"
+
+#: ../include/wx/msgdlg.h:277 ../src/common/stockitem.cpp:211
+msgid "Yes"
+msgstr "是"
+
+#: ../include/wx/msgdlg.h:278 ../src/common/stockitem.cpp:182
+msgid "No"
+msgstr "否"
+
+#: ../include/wx/msgdlg.h:279 ../src/common/stockitem.cpp:183
+#: ../src/msw/msgdlg.cpp:430 ../src/msw/msgdlg.cpp:734
+#: ../src/richtext/richtextstyledlg.cpp:292
+msgid "OK"
+msgstr "確認"
+
+#: ../include/wx/msgdlg.h:280 ../src/common/stockitem.cpp:150
+#: ../src/msw/msgdlg.cpp:430 ../src/msw/progdlg.cpp:884
+#: ../src/richtext/richtextstyledlg.cpp:295
+msgid "Cancel"
+msgstr "取消"
+
+#: ../include/wx/msgdlg.h:281 ../src/common/stockitem.cpp:168
+#: ../src/html/helpdlg.cpp:63 ../src/html/helpfrm.cpp:108
+#: ../src/osx/button_osx.cpp:38
+msgid "Help"
+msgstr "說明"
+
+#: ../include/wx/msw/ole/oleutils.h:52
+msgid "Cannot initialize OLE"
+msgstr "無法初始化 OLE"
+
+#: ../include/wx/msw/private/fswatcher.h:48
+#, c-format
+msgid "Unable to close the handle for '%s'"
+msgstr "無法關閉 '%s' 的處理常式"
+
+# c-format
+#: ../include/wx/msw/private/fswatcher.h:92
+#, c-format
+msgid "Failed to open directory \"%s\" for monitoring."
+msgstr "無法開啟監控用的 %s 目錄。"
+
+#: ../include/wx/msw/private/fswatcher.h:125
+msgid "Unable to close I/O completion port handle"
+msgstr "無法關閉 I/O 完成通訊埠的處理常式"
+
+#: ../include/wx/msw/private/fswatcher.h:142
+msgid "Unable to associate handle with I/O completion port"
+msgstr "無法將處理常式與 I/O 完成的通訊埠關聯"
+
+#: ../include/wx/msw/private/fswatcher.h:148
+msgid "Unexpectedly new I/O completion port was created"
+msgstr "異常地創建了新的 I/O 完成通訊埠"
+
+#: ../include/wx/msw/private/fswatcher.h:213
+msgid "Unable to post completion status"
+msgstr "無法發布完成狀態"
+
+#: ../include/wx/msw/private/fswatcher.h:262
+msgid "Unable to dequeue completion packet"
+msgstr "無法移出佇列完成封包"
+
+#: ../include/wx/msw/private/fswatcher.h:273
+msgid "Unable to create I/O completion port"
+msgstr "無法創建 I/O 完成通訊埠"
+
+#: ../include/wx/richmsgdlg.h:29
+msgid "&See details"
+msgstr "查看細節(&S)"
+
+#: ../include/wx/richmsgdlg.h:30
+msgid "&Hide details"
+msgstr "隱藏細節(&H)"
+
+#: ../include/wx/richtext/richtextbuffer.h:3864
+msgid "&Box"
+msgstr "文字方塊(&B)"
+
+#: ../include/wx/richtext/richtextbuffer.h:5008
+msgid "&Picture"
+msgstr "圖片(&P)"
+
+#: ../include/wx/richtext/richtextbuffer.h:5958
+msgid "&Cell"
+msgstr "儲存格(&C)"
+
+#: ../include/wx/richtext/richtextbuffer.h:6067
+msgid "&Table"
+msgstr "表格(&T)"
+
+#: ../include/wx/richtext/richtextimagedlg.h:37
+msgid "Object Properties"
+msgstr "物件屬性"
+
+#: ../include/wx/richtext/richtextsymboldlg.h:39
+msgid "Symbols"
+msgstr "符號"
+
+#: ../include/wx/unix/pipe.h:46
+msgid "Pipe creation failed"
+msgstr "創建管道失敗"
+
+#: ../include/wx/unix/private/displayx11.h:65
+msgid "Failed to enumerate video modes"
+msgstr "無法列舉視訊模式"
+
+#: ../include/wx/unix/private/displayx11.h:89
+msgid "Failed to change video mode"
+msgstr "無法變更視訊模式"
+
+#: ../include/wx/unix/private/fswatcher_kqueue.h:57
+#, c-format
+msgid "Unable to open path '%s'"
+msgstr "無法開啟 '%s' 路徑"
+
+#: ../include/wx/unix/private/fswatcher_kqueue.h:74
+#, c-format
+msgid "Unable to close path '%s'"
+msgstr "無法關閉 '%s' 路徑"
+
+#: ../include/wx/xtiprop.h:175
+msgid "SetProperty called w/o valid setter"
+msgstr "調用 SetProperty 時未帶有效的 setter"
+
+#: ../include/wx/xtiprop.h:184
+msgid "GetProperty called w/o valid getter"
+msgstr "調用 GetProperty 時未帶有效的 getter"
+
+#: ../include/wx/xtiprop.h:193
+msgid "AddToPropertyCollection called w/o valid adder"
+msgstr "調用 AddToPropertyCollection 時未帶有效的 adder"
+
+#: ../include/wx/xtiprop.h:202
+msgid "GetPropertyCollection called w/o valid collection getter"
+msgstr "調用 GetPropertyCollection 時未帶有效的 collection getter"
+
+#: ../include/wx/xtiprop.h:255
+msgid "AddToPropertyCollection called on a generic accessor"
+msgstr "在通用存取函式上調用 AddToPropertyCollection"
+
+#: ../include/wx/xtiprop.h:262
+msgid "GetPropertyCollection called on a generic accessor"
+msgstr "在通用存取函式上調用 GetPropertyCollection"
+
+#: ../src/aui/tabmdi.cpp:106 ../src/generic/mdig.cpp:94
+msgid "Cl&ose"
+msgstr "關閉(&o)"
+
+#: ../src/aui/tabmdi.cpp:107 ../src/generic/mdig.cpp:95
+msgid "Close All"
+msgstr "全部關閉"
+
+#: ../src/aui/tabmdi.cpp:109 ../src/generic/mdig.cpp:97 ../src/msw/mdi.cpp:175
+#: ../src/qt/mdi.cpp:258
+msgid "&Next"
+msgstr "下一個(&N)"
+
+#: ../src/aui/tabmdi.cpp:110 ../src/generic/mdig.cpp:98 ../src/msw/mdi.cpp:176
+#: ../src/qt/mdi.cpp:259
+msgid "&Previous"
+msgstr "上一個(&P)"
+
+#: ../src/aui/tabmdi.cpp:332 ../src/aui/tabmdi.cpp:348
+#: ../src/aui/tabmdi.cpp:350 ../src/generic/mdig.cpp:291
+#: ../src/generic/mdig.cpp:307 ../src/generic/mdig.cpp:311
+#: ../src/msw/mdi.cpp:337 ../src/qt/mdi.cpp:462
+msgid "&Window"
+msgstr "視窗(&W)"
+
+#: ../src/common/accelcmn.cpp:47
+msgctxt "keyboard key"
+msgid "Delete"
+msgstr "刪除"
+
+#: ../src/common/accelcmn.cpp:48
+msgctxt "keyboard key"
+msgid "Del"
+msgstr "刪除"
+
+#: ../src/common/accelcmn.cpp:49
+msgctxt "keyboard key"
+msgid "Back"
+msgstr "退位"
+
+#: ../src/common/accelcmn.cpp:49
+msgctxt "keyboard key"
+msgid "Backspace"
+msgstr "退位"
+
+#: ../src/common/accelcmn.cpp:50
+msgctxt "keyboard key"
+msgid "Insert"
+msgstr "插入"
+
+#: ../src/common/accelcmn.cpp:51
+msgctxt "keyboard key"
+msgid "Ins"
+msgstr "插入"
+
+#: ../src/common/accelcmn.cpp:52
+msgctxt "keyboard key"
+msgid "Enter"
+msgstr "輸入"
+
+#: ../src/common/accelcmn.cpp:53
+msgctxt "keyboard key"
+msgid "Return"
+msgstr "換行"
+
+#: ../src/common/accelcmn.cpp:54
+msgctxt "keyboard key"
+msgid "PageUp"
+msgstr "上頁"
+
+#: ../src/common/accelcmn.cpp:54
+msgctxt "keyboard key"
+msgid "Page Up"
+msgstr "上頁"
+
+#: ../src/common/accelcmn.cpp:55
+msgctxt "keyboard key"
+msgid "PageDown"
+msgstr "下頁"
+
+#: ../src/common/accelcmn.cpp:55
+msgctxt "keyboard key"
+msgid "Page Down"
+msgstr "下頁"
+
+#: ../src/common/accelcmn.cpp:56
+msgctxt "keyboard key"
+msgid "PgUp"
+msgstr "上頁"
+
+#: ../src/common/accelcmn.cpp:57
+msgctxt "keyboard key"
+msgid "PgDn"
+msgstr "下頁"
+
+#: ../src/common/accelcmn.cpp:58
+msgctxt "keyboard key"
+msgid "Left"
+msgstr "左"
+
+#: ../src/common/accelcmn.cpp:59
+msgctxt "keyboard key"
+msgid "Right"
+msgstr "右"
+
+#: ../src/common/accelcmn.cpp:60
+msgctxt "keyboard key"
+msgid "Up"
+msgstr "上"
+
+#: ../src/common/accelcmn.cpp:61
+msgctxt "keyboard key"
+msgid "Down"
+msgstr "下"
+
+#: ../src/common/accelcmn.cpp:62
+msgctxt "keyboard key"
+msgid "Home"
+msgstr "行頭"
+
+#: ../src/common/accelcmn.cpp:63
+msgctxt "keyboard key"
+msgid "End"
+msgstr "行末"
+
+#: ../src/common/accelcmn.cpp:64
+msgctxt "keyboard key"
+msgid "Space"
+msgstr "空格"
+
+#: ../src/common/accelcmn.cpp:65
+msgctxt "keyboard key"
+msgid "Tab"
+msgstr "跳格"
+
+#: ../src/common/accelcmn.cpp:66
+msgctxt "keyboard key"
+msgid "Esc"
+msgstr "跳離"
+
+#: ../src/common/accelcmn.cpp:67
+msgctxt "keyboard key"
+msgid "Escape"
+msgstr "跳離"
+
+#: ../src/common/accelcmn.cpp:68
+msgctxt "keyboard key"
+msgid "Cancel"
+msgstr "取消"
+
+#: ../src/common/accelcmn.cpp:69
+msgctxt "keyboard key"
+msgid "Clear"
+msgstr "清除"
+
+#: ../src/common/accelcmn.cpp:70
+msgctxt "keyboard key"
+msgid "Menu"
+msgstr "選單"
+
+#: ../src/common/accelcmn.cpp:71
+msgctxt "keyboard key"
+msgid "Pause"
+msgstr "暫停"
+
+#: ../src/common/accelcmn.cpp:72
+msgctxt "keyboard key"
+msgid "Capital"
+msgstr "大寫"
+
+#: ../src/common/accelcmn.cpp:73
+msgctxt "keyboard key"
+msgid "Select"
+msgstr "選取"
+
+#: ../src/common/accelcmn.cpp:74
+msgctxt "keyboard key"
+msgid "Print"
+msgstr "列印"
+
+#: ../src/common/accelcmn.cpp:75
+msgctxt "keyboard key"
+msgid "Execute"
+msgstr "執行"
+
+#: ../src/common/accelcmn.cpp:76
+msgctxt "keyboard key"
+msgid "Snapshot"
+msgstr "快照"
+
+#: ../src/common/accelcmn.cpp:77
+msgctxt "keyboard key"
+msgid "Help"
+msgstr "說明"
+
+#: ../src/common/accelcmn.cpp:78
+msgctxt "keyboard key"
+msgid "Add"
+msgstr "加入"
+
+#: ../src/common/accelcmn.cpp:79
+msgctxt "keyboard key"
+msgid "Separator"
+msgstr "分隔字元"
+
+#: ../src/common/accelcmn.cpp:80
+msgctxt "keyboard key"
+msgid "Subtract"
+msgstr "減號"
+
+#: ../src/common/accelcmn.cpp:81
+msgctxt "keyboard key"
+msgid "Decimal"
+msgstr "小數點"
+
+#: ../src/common/accelcmn.cpp:82
+msgctxt "keyboard key"
+msgid "Multiply"
+msgstr "乘號"
+
+#: ../src/common/accelcmn.cpp:83
+msgctxt "keyboard key"
+msgid "Divide"
+msgstr "除號"
+
+#: ../src/common/accelcmn.cpp:84
+msgctxt "keyboard key"
+msgid "Num_lock"
+msgstr "數字鍵_鎖定"
+
+#: ../src/common/accelcmn.cpp:84
+msgctxt "keyboard key"
+msgid "Num Lock"
+msgstr "數字鍵 鎖定"
+
+#: ../src/common/accelcmn.cpp:85
+msgctxt "keyboard key"
+msgid "Scroll_lock"
+msgstr "捲動鎖定"
+
+#: ../src/common/accelcmn.cpp:85
+msgctxt "keyboard key"
+msgid "Scroll Lock"
+msgstr "捲動鎖定"
+
+#: ../src/common/accelcmn.cpp:86
+msgctxt "keyboard key"
+msgid "KP_Space"
+msgstr "字元鍵_空白"
+
+#: ../src/common/accelcmn.cpp:86
+msgctxt "keyboard key"
+msgid "Num Space"
+msgstr "數字鍵 空白"
+
+#: ../src/common/accelcmn.cpp:87
+msgctxt "keyboard key"
+msgid "KP_Tab"
+msgstr "字元鍵_跳格"
+
+#: ../src/common/accelcmn.cpp:87
+msgctxt "keyboard key"
+msgid "Num Tab"
+msgstr "數字鍵 跳格"
+
+#: ../src/common/accelcmn.cpp:88
+msgctxt "keyboard key"
+msgid "KP_Enter"
+msgstr "字元鍵_確認"
+
+#: ../src/common/accelcmn.cpp:88
+msgctxt "keyboard key"
+msgid "Num Enter"
+msgstr "數字鍵 確認"
+
+#: ../src/common/accelcmn.cpp:89
+msgctxt "keyboard key"
+msgid "KP_Home"
+msgstr "編輯鍵_行頭"
+
+#: ../src/common/accelcmn.cpp:89
+msgctxt "keyboard key"
+msgid "Num Home"
+msgstr "數字鍵 行頭"
+
+#: ../src/common/accelcmn.cpp:90
+msgctxt "keyboard key"
+msgid "KP_Left"
+msgstr "編輯鍵_左"
+
+#: ../src/common/accelcmn.cpp:90
+msgctxt "keyboard key"
+msgid "Num left"
+msgstr "數字鍵 左"
+
+#: ../src/common/accelcmn.cpp:91
+msgctxt "keyboard key"
+msgid "KP_Up"
+msgstr "編輯鍵_上"
+
+#: ../src/common/accelcmn.cpp:91
+msgctxt "keyboard key"
+msgid "Num Up"
+msgstr "數字鍵 上"
+
+#: ../src/common/accelcmn.cpp:92
+msgctxt "keyboard key"
+msgid "KP_Right"
+msgstr "編輯鍵_右"
+
+#: ../src/common/accelcmn.cpp:92
+msgctxt "keyboard key"
+msgid "Num Right"
+msgstr "數字鍵 右"
+
+#: ../src/common/accelcmn.cpp:93
+msgctxt "keyboard key"
+msgid "KP_Down"
+msgstr "編輯鍵_下"
+
+#: ../src/common/accelcmn.cpp:93
+msgctxt "keyboard key"
+msgid "Num Down"
+msgstr "數字鍵 下"
+
+#: ../src/common/accelcmn.cpp:94
+msgctxt "keyboard key"
+msgid "KP_PageUp"
+msgstr "編輯鍵_上頁"
+
+#: ../src/common/accelcmn.cpp:94
+msgctxt "keyboard key"
+msgid "Num Page Up"
+msgstr "數字鍵 上頁"
+
+#: ../src/common/accelcmn.cpp:95
+msgctxt "keyboard key"
+msgid "KP_PageDown"
+msgstr "編輯鍵_下頁"
+
+#: ../src/common/accelcmn.cpp:95
+msgctxt "keyboard key"
+msgid "Num Page Down"
+msgstr "數字鍵 下頁"
+
+#: ../src/common/accelcmn.cpp:96
+msgctxt "keyboard key"
+msgid "KP_Prior"
+msgstr "編輯鍵_前一個"
+
+#: ../src/common/accelcmn.cpp:97
+msgctxt "keyboard key"
+msgid "KP_Next"
+msgstr "編輯鍵_下一個"
+
+#: ../src/common/accelcmn.cpp:98
+msgctxt "keyboard key"
+msgid "KP_End"
+msgstr "編輯鍵_行末"
+
+#: ../src/common/accelcmn.cpp:98
+msgctxt "keyboard key"
+msgid "Num End"
+msgstr "數字鍵 行末"
+
+#: ../src/common/accelcmn.cpp:99
+msgctxt "keyboard key"
+msgid "KP_Begin"
+msgstr "編輯鍵_行首"
+
+#: ../src/common/accelcmn.cpp:99
+msgctxt "keyboard key"
+msgid "Num Begin"
+msgstr "數字鍵 行首"
+
+#: ../src/common/accelcmn.cpp:100
+msgctxt "keyboard key"
+msgid "KP_Insert"
+msgstr "編輯鍵_插入"
+
+#: ../src/common/accelcmn.cpp:100
+msgctxt "keyboard key"
+msgid "Num Insert"
+msgstr "數字鍵 插入"
+
+#: ../src/common/accelcmn.cpp:101
+msgctxt "keyboard key"
+msgid "KP_Delete"
+msgstr "編輯鍵_刪除"
+
+#: ../src/common/accelcmn.cpp:101
+msgctxt "keyboard key"
+msgid "Num Delete"
+msgstr "編輯鍵鍵 刪除"
+
+#: ../src/common/accelcmn.cpp:102
+msgctxt "keyboard key"
+msgid "KP_Equal"
+msgstr "字元鍵_等號"
+
+#: ../src/common/accelcmn.cpp:102
+msgctxt "keyboard key"
+msgid "Num ="
+msgstr "數字鍵 ="
+
+#: ../src/common/accelcmn.cpp:103
+msgctxt "keyboard key"
+msgid "KP_Multiply"
+msgstr "字元鍵_乘號"
+
+#: ../src/common/accelcmn.cpp:103
+msgctxt "keyboard key"
+msgid "Num *"
+msgstr "數字鍵 *"
+
+#: ../src/common/accelcmn.cpp:104
+msgctxt "keyboard key"
+msgid "KP_Add"
+msgstr "字元鍵_加號"
+
+#: ../src/common/accelcmn.cpp:104
+msgctxt "keyboard key"
+msgid "Num +"
+msgstr "數字鍵 +"
+
+#: ../src/common/accelcmn.cpp:105
+msgctxt "keyboard key"
+msgid "KP_Separator"
+msgstr "字元鍵_分隔字元"
+
+#: ../src/common/accelcmn.cpp:105
+msgctxt "keyboard key"
+msgid "Num ,"
+msgstr "數字鍵 ,"
+
+#: ../src/common/accelcmn.cpp:106
+msgctxt "keyboard key"
+msgid "KP_Subtract"
+msgstr "字元鍵_減號"
+
+#: ../src/common/accelcmn.cpp:106
+msgctxt "keyboard key"
+msgid "Num -"
+msgstr "數字鍵 -"
+
+#: ../src/common/accelcmn.cpp:107
+msgctxt "keyboard key"
+msgid "KP_Decimal"
+msgstr "字元鍵_小數點"
+
+#: ../src/common/accelcmn.cpp:107
+msgctxt "keyboard key"
+msgid "Num ."
+msgstr "數字鍵 ."
+
+#: ../src/common/accelcmn.cpp:108
+msgctxt "keyboard key"
+msgid "KP_Divide"
+msgstr "字元鍵_除號"
+
+#: ../src/common/accelcmn.cpp:108
+msgctxt "keyboard key"
+msgid "Num /"
+msgstr "數字鍵 /"
+
+#: ../src/common/accelcmn.cpp:109
+msgctxt "keyboard key"
+msgid "Windows_Left"
+msgstr "Windows_左鍵"
+
+#: ../src/common/accelcmn.cpp:110
+msgctxt "keyboard key"
+msgid "Windows_Right"
+msgstr "Windows_右鍵"
+
+#: ../src/common/accelcmn.cpp:111
+msgctxt "keyboard key"
+msgid "Windows_Menu"
+msgstr "Windows_功能表"
+
+#: ../src/common/accelcmn.cpp:112
+msgctxt "keyboard key"
+msgid "Command"
+msgstr "指令"
+
+#: ../src/common/accelcmn.cpp:186 ../src/common/accelcmn.cpp:359
+msgctxt "keyboard key"
+msgid "Ctrl"
+msgstr "控制鍵"
+
+#: ../src/common/accelcmn.cpp:188 ../src/common/accelcmn.cpp:363
+msgctxt "keyboard key"
+msgid "Alt"
+msgstr "轉換鍵"
+
+#: ../src/common/accelcmn.cpp:190 ../src/common/accelcmn.cpp:361
+msgctxt "keyboard key"
+msgid "Shift"
+msgstr "移位鍵"
+
+#: ../src/common/accelcmn.cpp:196
+msgctxt "keyboard key"
+msgid "num "
+msgstr "數字鍵 "
+
+#: ../src/common/accelcmn.cpp:260 ../src/common/accelcmn.cpp:382
+msgctxt "keyboard key"
+msgid "F"
+msgstr "F"
+
+#: ../src/common/accelcmn.cpp:277 ../src/common/accelcmn.cpp:385
+msgctxt "keyboard key"
+msgid "KP_F"
+msgstr "功能鍵_F"
+
+#: ../src/common/accelcmn.cpp:280 ../src/common/accelcmn.cpp:388
+msgctxt "keyboard key"
+msgid "KP_"
+msgstr "字元鍵_"
+
+#: ../src/common/accelcmn.cpp:283 ../src/common/accelcmn.cpp:391
+msgctxt "keyboard key"
+msgid "SPECIAL"
+msgstr "特殊鍵"
+
+#: ../src/common/accelcmn.cpp:373
+#, fuzzy
+msgid "Ctrl"
+msgstr "控制鍵"
+
+#: ../src/common/appbase.cpp:786
+msgid "show this help message"
+msgstr "顯示說明訊息"
+
+#: ../src/common/appbase.cpp:796
+msgid "generate verbose log messages"
+msgstr "產生詳細日誌訊息"
+
+#: ../src/common/appcmn.cpp:256
+msgid "specify the theme to use"
+msgstr "指定視覺主題"
+
+#: ../src/common/appcmn.cpp:270
+msgid "specify display mode to use (e.g. 640x480-16)"
+msgstr "指定顯示模式 (例如 640x480-16)"
+
+#: ../src/common/appcmn.cpp:292
+#, c-format
+msgid "Unsupported theme '%s'."
+msgstr "不支援的視覺主題 '%s'。"
+
+#: ../src/common/appcmn.cpp:309
+#, c-format
+msgid "Invalid display mode specification '%s'."
+msgstr "無效的顯示模式規格 '%s'。"
+
+#: ../src/common/cmdline.cpp:875
+#, c-format
+msgid "Option '%s' can't be negated"
+msgstr "選項 '%s' 無法取消"
+
+#: ../src/common/cmdline.cpp:889
+#, c-format
+msgid "Unknown long option '%s'"
+msgstr "未知的長選項 '%s'"
+
+#: ../src/common/cmdline.cpp:904 ../src/common/cmdline.cpp:926
+#, c-format
+msgid "Unknown option '%s'"
+msgstr "未知的選項 '%s'"
+
+#: ../src/common/cmdline.cpp:1004
+#, c-format
+msgid "Unexpected characters following option '%s'."
+msgstr "'%s' 選項後出現異常的字元。"
+
+#: ../src/common/cmdline.cpp:1039
+#, c-format
+msgid "Option '%s' requires a value."
+msgstr "選項 ’%s’ 須有一個值。"
+
+#: ../src/common/cmdline.cpp:1058
+#, c-format
+msgid "Separator expected after the option '%s'."
+msgstr "在 '%s' 選項後應接著分隔字元。"
+
+#: ../src/common/cmdline.cpp:1088 ../src/common/cmdline.cpp:1106
+#, c-format
+msgid "'%s' is not a correct numeric value for option '%s'."
+msgstr "‘%s’ 不是 ‘%s’ 選項的正確數值。"
+
+#: ../src/common/cmdline.cpp:1122
+#, c-format
+msgid "Option '%s': '%s' cannot be converted to a date."
+msgstr "'%s' 選項：'%s' 無法轉換成日期。"
+
+#: ../src/common/cmdline.cpp:1170
+#, c-format
+msgid "Unexpected parameter '%s'"
+msgstr "異常參數 '%s'"
+
+#. TRANSLATORS: Short name and long name for a command line option
+#: ../src/common/cmdline.cpp:1197
+#, c-format
+msgid "%s (or %s)"
+msgstr "%s (或 %s)"
+
+#: ../src/common/cmdline.cpp:1208
+#, c-format
+msgid "The value for the option '%s' must be specified."
+msgstr "必須指定 '%s' 選項的值。"
+
+#: ../src/common/cmdline.cpp:1230
+#, c-format
+msgid "The required parameter '%s' was not specified."
+msgstr "未指定必要的參數 '%s'。"
+
+#: ../src/common/cmdline.cpp:1289
+#, c-format
+msgid "Usage: %s"
+msgstr "用法：%s"
+
+#: ../src/common/cmdline.cpp:1498
+msgid "str"
+msgstr "字串"
+
+#: ../src/common/cmdline.cpp:1502
+msgid "num"
+msgstr "數字"
+
+#: ../src/common/cmdline.cpp:1506
+msgid "double"
+msgstr "雙倍"
+
+#: ../src/common/cmdline.cpp:1510
+msgid "date"
+msgstr "日期"
+
+#: ../src/common/cmdproc.cpp:250 ../src/common/cmdproc.cpp:276
+#: ../src/common/cmdproc.cpp:296
+msgid "Unnamed command"
+msgstr "未命名的指令"
+
+#: ../src/common/cmdproc.cpp:253
+msgid "&Undo "
+msgstr "復原(&U) "
+
+#: ../src/common/cmdproc.cpp:255
+msgid "Can't &Undo "
+msgstr "不能復原(&U) "
+
+#: ../src/common/cmdproc.cpp:259 ../src/common/stockitem.cpp:208
+#: ../src/msw/textctrl.cpp:2880 ../src/osx/textctrl_osx.cpp:649
+#: ../src/richtext/richtextctrl.cpp:327
+msgid "&Undo"
+msgstr "復原(&U)"
+
+#: ../src/common/cmdproc.cpp:277 ../src/common/cmdproc.cpp:297
+msgid "&Redo "
+msgstr "重做(&R) "
+
+#: ../src/common/cmdproc.cpp:281 ../src/common/cmdproc.cpp:288
+#: ../src/common/stockitem.cpp:190 ../src/msw/textctrl.cpp:2881
+#: ../src/osx/textctrl_osx.cpp:650 ../src/richtext/richtextctrl.cpp:328
+msgid "&Redo"
+msgstr "重做(&R)"
+
+#: ../src/common/colourcmn.cpp:41
+#, c-format
+msgid "String To Colour : Incorrect colour specification : %s"
+msgstr "顏色名稱：不正確的顏色規格：%s"
+
+#: ../src/common/config.cpp:259
+#, c-format
+msgid "Invalid value %ld for a boolean key \"%s\" in config file."
+msgstr "組態檔的 %ld 值 (對應到布林 \"%s\" 機碼) 無效。"
+
+#: ../src/common/config.cpp:526
+#, c-format
+msgid ""
+"Environment variables expansion failed: missing '%c' at position %u in '%s'."
+msgstr "環境變數擴充失敗:  '%c' 沒有出現在位置 %u / '%s'。"
+
+#: ../src/common/config.cpp:576 ../src/msw/regconf.cpp:272
+#, c-format
+msgid "'%s' has extra '..', ignored."
+msgstr "'%s' 有額外的 '..'，已忽略。"
+
+#. TRANSLATORS: Checkbox state name
+#: ../src/common/datavcmn.cpp:2166 ../src/generic/datavgen.cpp:1430
+msgid "checked"
+msgstr "已勾選"
+
+#. TRANSLATORS: Checkbox state name
+#: ../src/common/datavcmn.cpp:2170 ../src/generic/datavgen.cpp:1432
+msgid "unchecked"
+msgstr "未勾選"
+
+#. TRANSLATORS: Checkbox state name
+#: ../src/common/datavcmn.cpp:2174
+msgid "undetermined"
+msgstr "未判定"
+
+#: ../src/common/datetimefmt.cpp:1875
+msgid "today"
+msgstr "今天"
+
+#: ../src/common/datetimefmt.cpp:1876
+msgid "yesterday"
+msgstr "昨天"
+
+#: ../src/common/datetimefmt.cpp:1877
+msgid "tomorrow"
+msgstr "明天"
+
+#: ../src/common/datetimefmt.cpp:2071
+msgid "first"
+msgstr "第一"
+
+#: ../src/common/datetimefmt.cpp:2072
+msgid "second"
+msgstr "第二"
+
+#: ../src/common/datetimefmt.cpp:2073
+msgid "third"
+msgstr "第三"
+
+#: ../src/common/datetimefmt.cpp:2074
+msgid "fourth"
+msgstr "第四"
+
+#: ../src/common/datetimefmt.cpp:2075
+msgid "fifth"
+msgstr "第五"
+
+#: ../src/common/datetimefmt.cpp:2076
+msgid "sixth"
+msgstr "第六"
+
+#: ../src/common/datetimefmt.cpp:2077
+msgid "seventh"
+msgstr "第七"
+
+#: ../src/common/datetimefmt.cpp:2078
+msgid "eighth"
+msgstr "第八"
+
+#: ../src/common/datetimefmt.cpp:2079
+msgid "ninth"
+msgstr "第九"
+
+#: ../src/common/datetimefmt.cpp:2080
+msgid "tenth"
+msgstr "第十"
+
+#: ../src/common/datetimefmt.cpp:2081
+msgid "eleventh"
+msgstr "第十一"
+
+#: ../src/common/datetimefmt.cpp:2082
+msgid "twelfth"
+msgstr "第十二"
+
+#: ../src/common/datetimefmt.cpp:2083
+msgid "thirteenth"
+msgstr "第十三"
+
+#: ../src/common/datetimefmt.cpp:2084
+msgid "fourteenth"
+msgstr "第十四"
+
+#: ../src/common/datetimefmt.cpp:2085
+msgid "fifteenth"
+msgstr "第十五"
+
+#: ../src/common/datetimefmt.cpp:2086
+msgid "sixteenth"
+msgstr "第十六"
+
+#: ../src/common/datetimefmt.cpp:2087
+msgid "seventeenth"
+msgstr "第十七"
+
+#: ../src/common/datetimefmt.cpp:2088
+msgid "eighteenth"
+msgstr "第十八"
+
+#: ../src/common/datetimefmt.cpp:2089
+msgid "nineteenth"
+msgstr "第十九"
+
+#: ../src/common/datetimefmt.cpp:2090
+msgid "twentieth"
+msgstr "第廿十"
+
+#: ../src/common/datetimefmt.cpp:2248
+msgid "noon"
+msgstr "中午"
+
+#: ../src/common/datetimefmt.cpp:2249
+msgid "midnight"
+msgstr "午夜"
+
+#: ../src/common/debugrpt.cpp:209
+#, c-format
+msgid "Failed to create directory \"%s\""
+msgstr "無法創建目錄 \"%s”"
+
+#: ../src/common/debugrpt.cpp:210
+msgid "Debug report couldn't be created."
+msgstr "無法創建偵錯報告。"
+
+#: ../src/common/debugrpt.cpp:227
+#, c-format
+msgid "Failed to remove debug report file \"%s\""
+msgstr "無法移除偵錯報告檔案 “%s”"
+
+#: ../src/common/debugrpt.cpp:239
+#, c-format
+msgid "Failed to clean up debug report directory \"%s\""
+msgstr "無法清理偵錯報告目錄 “%s”。"
+
+#: ../src/common/debugrpt.cpp:514
+msgid "process context description"
+msgstr "程序上下文說明"
+
+#: ../src/common/debugrpt.cpp:538
+msgid "dump of the process state (binary)"
+msgstr "傾印程序狀態 (二進位)"
+
+#: ../src/common/debugrpt.cpp:553
+msgid "Debug report generation has failed."
+msgstr "無法產生偵錯報告。"
+
+#: ../src/common/debugrpt.cpp:560
+#, c-format
+msgid ""
+"Processing debug report has failed, leaving the files in \"%s\" directory."
+msgstr "處理偵錯報告失敗，檔案儲存在 '%s' 目錄。"
+
+#: ../src/common/debugrpt.cpp:573
+msgid "A debug report has been generated. It can be found in"
+msgstr "產生了一份偵錯報告，位置在"
+
+#: ../src/common/debugrpt.cpp:576
+msgid "And includes the following files:\n"
+msgstr "且包含以下檔案：\n"
+
+#: ../src/common/debugrpt.cpp:586
+msgid ""
+"\n"
+"Please send this report to the program maintainer, thank you!\n"
+msgstr ""
+"\n"
+"請將報告傳送給程式維護人員，謝謝！\n"
+
+#: ../src/common/debugrpt.cpp:729
+msgid "Failed to execute curl, please install it in PATH."
+msgstr "無法執行 curl，請在 PATH 變數所指的目錄安裝 curl。"
+
+#: ../src/common/debugrpt.cpp:742
+#, c-format
+msgid "Failed to upload the debug report (error code %d)."
+msgstr "無法上載偵錯報告 (錯誤代號 %d)。"
+
+#: ../src/common/docview.cpp:366
+msgid "Save As"
+msgstr "另存新檔"
+
+#: ../src/common/docview.cpp:457
+msgid "Discard changes and reload the last saved version?"
+msgstr "是否捨棄變更，並重新載入上次儲存的版本？"
+
+#: ../src/common/docview.cpp:488
+msgid "unnamed"
+msgstr "未命名"
+
+#: ../src/common/docview.cpp:513
+#, c-format
+msgid "Do you want to save changes to %s?"
+msgstr "是否儲存變更至 %s？"
+
+#: ../src/common/docview.cpp:521 ../src/common/docview.cpp:560
+#: ../src/common/stockitem.cpp:195
+msgid "&Save"
+msgstr "儲存(&S)"
+
+#: ../src/common/docview.cpp:522 ../src/common/docview.cpp:560
+msgid "&Discard changes"
+msgstr ""
+
+#: ../src/common/docview.cpp:523
+#, fuzzy
+msgid "Do&n't close"
+msgstr "不儲存"
+
+#: ../src/common/docview.cpp:553
+#, fuzzy, c-format
+msgid "Do you want to save changes to %s before closing it?"
+msgstr "是否儲存變更至 %s？"
+
+#: ../src/common/docview.cpp:559
+#, fuzzy
+msgid "The document must be closed."
+msgstr "無法儲存文字。"
+
+#: ../src/common/docview.cpp:571
+#, c-format
+msgid "Saving %s failed, would you like to retry?"
+msgstr ""
+
+#: ../src/common/docview.cpp:577
+msgid "Retry"
+msgstr ""
+
+#: ../src/common/docview.cpp:577
+msgid "Discard changes"
+msgstr ""
+
+#: ../src/common/docview.cpp:679
+#, c-format
+msgid "File \"%s\" could not be opened for writing."
+msgstr "檔案 “%s” 無法開啟為寫入模式。"
+
+#: ../src/common/docview.cpp:685
+#, c-format
+msgid "Failed to save document to the file \"%s\"."
+msgstr "無法將文件儲存至 \"'%s'\"檔案。"
+
+#: ../src/common/docview.cpp:702
+#, c-format
+msgid "File \"%s\" could not be opened for reading."
+msgstr "檔案 “%s” 無法開啟為讀取模式。"
+
+#: ../src/common/docview.cpp:714
+#, c-format
+msgid "Failed to read document from the file \"%s\"."
+msgstr "無法從 “%s” 檔案讀取文件。"
+
+#: ../src/common/docview.cpp:1236
+#, c-format
+msgid ""
+"The file '%s' doesn't exist and couldn't be opened.\n"
+"It has been removed from the most recently used files list."
+msgstr ""
+"'%s' 檔案不存在，無法開啟。\n"
+"檔案已從最近使用的檔案清單中移除。"
+
+#: ../src/common/docview.cpp:1296
+msgid "Print preview creation failed."
+msgstr "創建列印預覽失敗。"
+
+#: ../src/common/docview.cpp:1302
+msgid "Print Preview"
+msgstr "預覽列印"
+
+#: ../src/common/docview.cpp:1517
+#, c-format
+msgid "The format of file '%s' couldn't be determined."
+msgstr "無法確定 ’%s’ 檔案格式。"
+
+#: ../src/common/docview.cpp:1643
+#, c-format
+msgid "unnamed%d"
+msgstr "未命名%d"
+
+#: ../src/common/docview.cpp:1660
+msgid " - "
+msgstr " - "
+
+#: ../src/common/docview.cpp:1791 ../src/common/docview.cpp:1844
+msgid "Open File"
+msgstr "開啟檔案"
+
+#: ../src/common/docview.cpp:1807
+msgid "File error"
+msgstr "檔案錯誤"
+
+#: ../src/common/docview.cpp:1809
+msgid "Sorry, could not open this file."
+msgstr "抱歉，無法開啟檔案。"
+
+#: ../src/common/docview.cpp:1843
+msgid "Sorry, the format for this file is unknown."
+msgstr "抱歉，此檔案格式不明。"
+
+#: ../src/common/docview.cpp:1924
+msgid "Select a document template"
+msgstr "選擇文件範本"
+
+#: ../src/common/docview.cpp:1925
+msgid "Templates"
+msgstr "範本"
+
+#: ../src/common/docview.cpp:1998
+msgid "Select a document view"
+msgstr "選擇文件檢視"
+
+#: ../src/common/docview.cpp:1999
+msgid "Views"
+msgstr "檢視"
+
+#: ../src/common/dynlib.cpp:81
+#, c-format
+msgid "Failed to load shared library '%s'"
+msgstr "無法載入‘%s’共享函式庫"
+
+#: ../src/common/dynlib.cpp:105
+#, c-format
+msgid "Couldn't find symbol '%s' in a dynamic library"
+msgstr "在動態函式庫找不到 ‘%s’ 符號"
+
+#: ../src/common/ffile.cpp:56 ../src/common/file.cpp:215
+#, c-format
+msgid "can't open file '%s'"
+msgstr "無法開啟檔案 '%s'"
+
+#: ../src/common/ffile.cpp:72
+#, c-format
+msgid "can't close file '%s'"
+msgstr "無法關閉檔案 '%s'"
+
+#: ../src/common/ffile.cpp:106 ../src/common/ffile.cpp:131
+#, c-format
+msgid "Read error on file '%s'"
+msgstr "讀取 '%s' 檔案時發生錯誤"
+
+#: ../src/common/ffile.cpp:148
+#, c-format
+msgid "Write error on file '%s'"
+msgstr "寫入 '%s' 檔案時發生錯誤"
+
+#: ../src/common/ffile.cpp:182
+#, c-format
+msgid "failed to flush the file '%s'"
+msgstr "排清檔案 '%s' 失敗"
+
+#: ../src/common/ffile.cpp:222
+#, c-format
+msgid "Seek error on file '%s' (large files not supported by stdio)"
+msgstr "'%s' 檔案定位錯誤 (stdio 不支援大檔案)"
+
+#: ../src/common/ffile.cpp:232
+#, c-format
+msgid "Seek error on file '%s'"
+msgstr "'%s' 檔案定位錯誤"
+
+#: ../src/common/ffile.cpp:248
+#, c-format
+msgid "Can't find current position in file '%s'"
+msgstr "無法在 '%s' 檔案中找到目前位置"
+
+#: ../src/common/ffile.cpp:349 ../src/common/file.cpp:569
+msgid "Failed to set temporary file permissions"
+msgstr "無法設定暫存檔的存取權限"
+
+#: ../src/common/ffile.cpp:371
+#, c-format
+msgid "can't remove file '%s'"
+msgstr "無法移除檔案 '%s'"
+
+#: ../src/common/ffile.cpp:376 ../src/common/file.cpp:591
+#, c-format
+msgid "can't commit changes to file '%s'"
+msgstr "無法交付修改至檔案 '%s'"
+
+#: ../src/common/ffile.cpp:388 ../src/common/file.cpp:603
+#, c-format
+msgid "can't remove temporary file '%s'"
+msgstr "無法移除暫存檔 '%s'"
+
+#: ../src/common/file.cpp:162
+#, c-format
+msgid "can't create file '%s'"
+msgstr "無法創建檔案 '%s'"
+
+#: ../src/common/file.cpp:229
+#, c-format
+msgid "can't close file descriptor %d"
+msgstr "無法關閉檔案描述符 %d"
+
+#: ../src/common/file.cpp:332
+#, c-format
+msgid "can't read from file descriptor %d"
+msgstr "無法讀取檔案描述符 %d"
+
+#: ../src/common/file.cpp:351
+#, c-format
+msgid "can't write to file descriptor %d"
+msgstr "無法寫入檔案描述符 %d"
+
+#: ../src/common/file.cpp:390
+#, c-format
+msgid "can't flush file descriptor %d"
+msgstr "無法排清檔案描述符 %d"
+
+#: ../src/common/file.cpp:432
+#, c-format
+msgid "can't seek on file descriptor %d"
+msgstr "無法定位檔案描述符 %d"
+
+#: ../src/common/file.cpp:446
+#, c-format
+msgid "can't get seek position on file descriptor %d"
+msgstr "無法獲得檔案描述符 %d 的定位位置"
+
+#: ../src/common/file.cpp:475
+#, c-format
+msgid "can't find length of file on file descriptor %d"
+msgstr "無法獲得檔案描述符 %d 的檔案長度"
+
+#: ../src/common/file.cpp:505
+#, c-format
+msgid "can't determine if the end of file is reached on descriptor %d"
+msgstr "無法確定檔案是否已達描述符 %d 的檔尾"
+
+#: ../src/common/fileconf.cpp:352
+#, c-format
+msgid ""
+" and additionally, the existing configuration file was renamed to \"%s\" and "
+"couldn't be renamed back, please rename it to its original path \"%s\""
+msgstr ""
+
+#: ../src/common/fileconf.cpp:389
+#, fuzzy
+msgid " due to the following error:\n"
+msgstr "且包含以下檔案：\n"
+
+#: ../src/common/fileconf.cpp:412
+#, fuzzy
+msgid "failed to rename the existing file"
+msgstr "無法讀取 “%s” 文字檔案。"
+
+#: ../src/common/fileconf.cpp:421
+#, fuzzy
+msgid "failed to create the new file directory"
+msgstr "無法取得工作目錄"
+
+#: ../src/common/fileconf.cpp:428
+#, fuzzy
+msgid "failed to move the file to the new location"
+msgstr "無法設定網頁檢視至現代模擬等級"
+
+#: ../src/common/fileconf.cpp:462
+#, c-format
+msgid "can't open global configuration file '%s'."
+msgstr "無法開啟全局組態檔案 '%s'。"
+
+#: ../src/common/fileconf.cpp:478
+#, c-format
+msgid "can't open user configuration file '%s'."
+msgstr "無法開啟使用者組態檔案 '%s'。"
+
+#: ../src/common/fileconf.cpp:483
+#, c-format
+msgid "Changes won't be saved to avoid overwriting the existing file \"%s\""
+msgstr "為了避免覆寫已有的 '%s' 檔案，將不會儲存變更。"
+
+#: ../src/common/fileconf.cpp:583
+msgid "Error reading config options."
+msgstr "讀取組態選項時發生錯誤。"
+
+#: ../src/common/fileconf.cpp:593
+msgid "Failed to read config options."
+msgstr "無法讀取組態選項。"
+
+#: ../src/common/fileconf.cpp:700
+#, c-format
+msgid "file '%s': unexpected character %c at line %zu."
+msgstr "檔案 '%s'： 異常字元 %c 存在於第 %zu 列。"
+
+#: ../src/common/fileconf.cpp:736
+#, c-format
+msgid "file '%s', line %zu: '%s' ignored after group header."
+msgstr "檔案 '%s' 第 %zu 列：忽略位於群組表頭之後的 '%s' 。"
+
+#: ../src/common/fileconf.cpp:765
+#, c-format
+msgid "file '%s', line %zu: '=' expected."
+msgstr "檔案 '%s' 第 %zu 列：應有 '='。"
+
+#: ../src/common/fileconf.cpp:778
+#, c-format
+msgid "file '%s', line %zu: value for immutable key '%s' ignored."
+msgstr "檔案 '%s' 第 %zu 列：已忽略不可變金鑰 '%s' 的值。"
+
+#: ../src/common/fileconf.cpp:788
+#, c-format
+msgid "file '%s', line %zu: key '%s' was first found at line %d."
+msgstr "檔案 '%s', 第 %zu 列：機碼 '%s' 第一次出現在第 %d 列。"
+
+#: ../src/common/fileconf.cpp:1091
+#, c-format
+msgid "Config entry name cannot start with '%c'."
+msgstr "組態項目名稱不能以 '%c' 開頭。"
+
+#: ../src/common/fileconf.cpp:1146
+#, fuzzy
+msgid "Failed to create configuration file directory."
+msgstr "無法創建字型組態物件。"
+
+#: ../src/common/fileconf.cpp:1158
+msgid "can't open user configuration file."
+msgstr "無法開啟使用者組態檔案。"
+
+#: ../src/common/fileconf.cpp:1172
+msgid "can't write user configuration file."
+msgstr "無法寫入使用者組態檔案。"
+
+#: ../src/common/fileconf.cpp:1178
+msgid "Failed to update user configuration file."
+msgstr "無法更新使用者組態檔案。"
+
+#: ../src/common/fileconf.cpp:1201
+msgid "Error saving user configuration data."
+msgstr "儲存使用者組態資料錯誤。"
+
+#: ../src/common/fileconf.cpp:1313
+#, c-format
+msgid "can't delete user configuration file '%s'"
+msgstr "無法刪除使用者組態檔案 '%s'"
+
+#: ../src/common/fileconf.cpp:2007
+#, c-format
+msgid "entry '%s' appears more than once in group '%s'"
+msgstr "項目 '%s' 在 '%s' 群中已出現一次以上"
+
+#: ../src/common/fileconf.cpp:2021
+#, c-format
+msgid "attempt to change immutable key '%s' ignored."
+msgstr "嘗試變更不可變機碼 '%s' 已被忽略。"
+
+#: ../src/common/fileconf.cpp:2118
+#, c-format
+msgid "trailing backslash ignored in '%s'"
+msgstr "忽略 %s’ 裡的結尾反斜線"
+
+#: ../src/common/fileconf.cpp:2153
+#, c-format
+msgid "unexpected \" at position %d in '%s'."
+msgstr "異常 \" 出現在 %d 位於'%s'。"
+
+#: ../src/common/filefn.cpp:474
+#, c-format
+msgid "Failed to copy the file '%s' to '%s'"
+msgstr "無法複製 '%s' 檔案到 '%s'"
+
+#: ../src/common/filefn.cpp:487
+#, c-format
+msgid "Impossible to get permissions for file '%s'"
+msgstr "無法獲得權限以存取 '%s' 檔案"
+
+#: ../src/common/filefn.cpp:501
+#, c-format
+msgid "Impossible to overwrite the file '%s'"
+msgstr "無法覆寫 '%s' 檔案"
+
+#: ../src/common/filefn.cpp:508
+#, c-format
+msgid "Error copying the file '%s' to '%s'."
+msgstr "複製 %s 檔案至 %s 時發生錯誤。"
+
+#: ../src/common/filefn.cpp:556
+#, c-format
+msgid "Impossible to set permissions for the file '%s'"
+msgstr "無法設定 '%s' 檔案的存取權限"
+
+#: ../src/common/filefn.cpp:606
+#, c-format
+msgid ""
+"Failed to rename the file '%s' to '%s' because the destination file already "
+"exists."
+msgstr "無法將檔案 ‘%s’ 重新命名為 ‘%s’，因目的檔案已存在。"
+
+#: ../src/common/filefn.cpp:623
+#, c-format
+msgid "File '%s' couldn't be renamed '%s'"
+msgstr "檔案 '%s' 無法重新命名為 '%s'"
+
+#: ../src/common/filefn.cpp:639
+#, c-format
+msgid "File '%s' couldn't be removed"
+msgstr "無法移除 '%s' 檔案"
+
+#: ../src/common/filefn.cpp:666
+#, c-format
+msgid "Directory '%s' couldn't be created"
+msgstr "無法創建 '%s' 目錄"
+
+#: ../src/common/filefn.cpp:680
+#, c-format
+msgid "Directory '%s' couldn't be deleted"
+msgstr "無法刪除 '%s' 目錄"
+
+#: ../src/common/filefn.cpp:714
+#, c-format
+msgid "Cannot enumerate files '%s'"
+msgstr "無法列舉檔案 '%s'"
+
+#: ../src/common/filefn.cpp:798
+msgid "Failed to get the working directory"
+msgstr "無法取得工作目錄"
+
+#: ../src/common/filefn.cpp:843
+msgid "Could not set current working directory"
+msgstr "無法設定目前工作目錄"
+
+#: ../src/common/filefn.cpp:974
+#, c-format
+msgid "Files (%s)"
+msgstr "檔案 (%s)"
+
+#: ../src/common/filename.cpp:182
+#, c-format
+msgid "Failed to open '%s' for reading"
+msgstr "無法開啟 '%s' 為讀取模式"
+
+#: ../src/common/filename.cpp:187
+#, c-format
+msgid "Failed to open '%s' for writing"
+msgstr "無法開啟 '%s' 為寫入模式"
+
+#: ../src/common/filename.cpp:199
+msgid "Failed to close file handle"
+msgstr "無法關閉檔案處理常式"
+
+#: ../src/common/filename.cpp:1046
+msgid "Failed to create a temporary file name"
+msgstr "無法創建暫存檔的檔名"
+
+#: ../src/common/filename.cpp:1081
+msgid "Failed to open temporary file."
+msgstr "無法開啟暫存檔。"
+
+#: ../src/common/filename.cpp:2862
+#, c-format
+msgid "Failed to modify file times for '%s'"
+msgstr "無法在 '%s' 修改檔案時間"
+
+#: ../src/common/filename.cpp:2877
+#, c-format
+msgid "Failed to touch the file '%s'"
+msgstr "無法設定 '%s' 檔案的修改與存取時間"
+
+#: ../src/common/filename.cpp:2958
+#, c-format
+msgid "Failed to retrieve file times for '%s'"
+msgstr "無法擷取 '%s' 檔案的各項時間"
+
+#: ../src/common/filepickercmn.cpp:39 ../src/common/filepickercmn.cpp:40
+msgid "Browse"
+msgstr "瀏覽"
+
+#: ../src/common/fldlgcmn.cpp:792 ../src/generic/filectrlg.cpp:1185
+#, c-format
+msgid "All files (%s)|%s"
+msgstr "所有檔案 (%s)|%s"
+
+#. TRANSLATORS: %s are a file extension used to build a file wildcard string
+#: ../src/common/fldlgcmn.cpp:810
+#, c-format
+msgid "%s files (%s)|%s"
+msgstr "%s 個檔案 (%s)|%s"
+
+#: ../src/common/fldlgcmn.cpp:1072
+#, c-format
+msgid "Load %s file"
+msgstr "載入 %s 檔案"
+
+#: ../src/common/fldlgcmn.cpp:1074
+#, c-format
+msgid "Save %s file"
+msgstr "儲存 %s 檔案"
+
+#: ../src/common/fmapbase.cpp:144
+msgid "Western European (ISO-8859-1)"
+msgstr "西歐語系 (ISO-8859-1)"
+
+#: ../src/common/fmapbase.cpp:145
+msgid "Central European (ISO-8859-2)"
+msgstr "中歐語系 (ISO-8859-2)"
+
+#: ../src/common/fmapbase.cpp:146
+msgid "Esperanto (ISO-8859-3)"
+msgstr "世界語 (ISO-8859-3)"
+
+#: ../src/common/fmapbase.cpp:147
+msgid "Baltic (old) (ISO-8859-4)"
+msgstr "波羅的海語系 (舊) (ISO-8859-4)"
+
+#: ../src/common/fmapbase.cpp:148
+msgid "Cyrillic (ISO-8859-5)"
+msgstr "斯拉夫語系 (ISO-8859-5)"
+
+#: ../src/common/fmapbase.cpp:149
+msgid "Arabic (ISO-8859-6)"
+msgstr "阿拉伯語 (ISO-8859-6)"
+
+#: ../src/common/fmapbase.cpp:150
+msgid "Greek (ISO-8859-7)"
+msgstr "希臘文 (ISO-8859-7)"
+
+#: ../src/common/fmapbase.cpp:151
+msgid "Hebrew (ISO-8859-8)"
+msgstr "希伯來文 (ISO-8859-8)"
+
+#: ../src/common/fmapbase.cpp:152
+msgid "Turkish (ISO-8859-9)"
+msgstr "土耳其文 (ISO-8859-9)"
+
+#: ../src/common/fmapbase.cpp:153
+msgid "Nordic (ISO-8859-10)"
+msgstr "北歐語系 (ISO-8859-10)"
+
+#: ../src/common/fmapbase.cpp:154
+msgid "Thai (ISO-8859-11)"
+msgstr "泰文 (ISO-8859-11)"
+
+#: ../src/common/fmapbase.cpp:155
+msgid "Indian (ISO-8859-12)"
+msgstr "印度語系 (ISO-8859-12)"
+
+#: ../src/common/fmapbase.cpp:156
+msgid "Baltic (ISO-8859-13)"
+msgstr "波羅的海語系 (ISO-8859-13)"
+
+#: ../src/common/fmapbase.cpp:157
+msgid "Celtic (ISO-8859-14)"
+msgstr "凱爾特語 (ISO-8859-14)"
+
+#: ../src/common/fmapbase.cpp:158
+msgid "Western European with Euro (ISO-8859-15)"
+msgstr "西歐語系 (附歐元) (ISO-8859-15)"
+
+#: ../src/common/fmapbase.cpp:159
+msgid "KOI8-R"
+msgstr "KOI8-R"
+
+#: ../src/common/fmapbase.cpp:160
+msgid "KOI8-U"
+msgstr "KOI8-U"
+
+#: ../src/common/fmapbase.cpp:161
+msgid "Windows/DOS OEM Cyrillic (CP 866)"
+msgstr "Windows/DOS OEM 斯拉夫語系 (CP 866)"
+
+#: ../src/common/fmapbase.cpp:162
+msgid "Windows Thai (CP 874)"
+msgstr "Windows 泰文 (CP 874)"
+
+#: ../src/common/fmapbase.cpp:163
+msgid "Windows Japanese (CP 932) or Shift-JIS"
+msgstr "Windows 日文 (CP 932) 或 Shift-JIS"
+
+#: ../src/common/fmapbase.cpp:164
+msgid "Windows Chinese Simplified (CP 936) or GB-2312"
+msgstr "Windows 简体中文 (CP 936) 或 GB-2312"
+
+#: ../src/common/fmapbase.cpp:165
+msgid "Windows Korean (CP 949)"
+msgstr "Windows 韓文 (CP 949)"
+
+#: ../src/common/fmapbase.cpp:166
+msgid "Windows Chinese Traditional (CP 950) or Big-5"
+msgstr "Windows 正體中文 (CP 950) 或 Big-5"
+
+#: ../src/common/fmapbase.cpp:167
+msgid "Windows Central European (CP 1250)"
+msgstr "Windows 中歐語系 (CP 1250)"
+
+#: ../src/common/fmapbase.cpp:168
+msgid "Windows Cyrillic (CP 1251)"
+msgstr "Windows 斯拉夫語系 (CP 1251)"
+
+#: ../src/common/fmapbase.cpp:169
+msgid "Windows Western European (CP 1252)"
+msgstr "Windows 西歐語系 (CP 1252)"
+
+#: ../src/common/fmapbase.cpp:170
+msgid "Windows Greek (CP 1253)"
+msgstr "Windows 希臘文 (CP 1253)"
+
+#: ../src/common/fmapbase.cpp:171
+msgid "Windows Turkish (CP 1254)"
+msgstr "Windows 土耳其文 (CP 1254)"
+
+#: ../src/common/fmapbase.cpp:172
+msgid "Windows Hebrew (CP 1255)"
+msgstr "Windows 希伯來文 (CP 1255)"
+
+#: ../src/common/fmapbase.cpp:173
+msgid "Windows Arabic (CP 1256)"
+msgstr "Windows 阿拉伯文 (CP 1256)"
+
+#: ../src/common/fmapbase.cpp:174
+msgid "Windows Baltic (CP 1257)"
+msgstr "Windows 波羅的海語系 (CP 1257)"
+
+#: ../src/common/fmapbase.cpp:175
+msgid "Windows Vietnamese (CP 1258)"
+msgstr "Windows 越南文 (CP 1258)"
+
+#: ../src/common/fmapbase.cpp:176
+msgid "Windows Johab (CP 1361)"
+msgstr "Windows 韓文 (Johab) (CP 1361)"
+
+#: ../src/common/fmapbase.cpp:177
+msgid "Windows/DOS OEM (CP 437)"
+msgstr "Windows/DOS OEM (CP 437)"
+
+#: ../src/common/fmapbase.cpp:178
+msgid "Unicode 7 bit (UTF-7)"
+msgstr "七位元萬國碼 (UTF-7)"
+
+#: ../src/common/fmapbase.cpp:179
+msgid "Unicode 8 bit (UTF-8)"
+msgstr "八位元萬國碼 (UTF-8)"
+
+#: ../src/common/fmapbase.cpp:181 ../src/common/fmapbase.cpp:187
+msgid "Unicode 16 bit (UTF-16)"
+msgstr "十六位元萬國碼 (UTF-16)"
+
+#: ../src/common/fmapbase.cpp:182
+msgid "Unicode 16 bit Little Endian (UTF-16LE)"
+msgstr "十六位元萬國碼小尾序 (UTF-16LE)"
+
+#: ../src/common/fmapbase.cpp:183 ../src/common/fmapbase.cpp:189
+msgid "Unicode 32 bit (UTF-32)"
+msgstr "三十二位元萬國碼 (UTF-32)"
+
+#: ../src/common/fmapbase.cpp:184
+msgid "Unicode 32 bit Little Endian (UTF-32LE)"
+msgstr "三十二位元萬國碼小尾序 (UTF-32LE)"
+
+#: ../src/common/fmapbase.cpp:186
+msgid "Unicode 16 bit Big Endian (UTF-16BE)"
+msgstr "十六位元萬國碼大尾序 (UTF-16BE)"
+
+#: ../src/common/fmapbase.cpp:188
+msgid "Unicode 32 bit Big Endian (UTF-32BE)"
+msgstr "三十二位元萬國碼大尾序 (UTF-32BE)"
+
+#: ../src/common/fmapbase.cpp:191
+msgid "Extended Unix Codepage for Japanese (EUC-JP)"
+msgstr "延伸的 Unix 日文頁碼 (EUC-JP)"
+
+#: ../src/common/fmapbase.cpp:192
+msgid "US-ASCII"
+msgstr "US-ASCII"
+
+#: ../src/common/fmapbase.cpp:193
+msgid "ISO-2022-JP"
+msgstr "ISO-2022-JP"
+
+#: ../src/common/fmapbase.cpp:195
+msgid "MacRoman"
+msgstr "MacRoman"
+
+#: ../src/common/fmapbase.cpp:196
+msgid "MacJapanese"
+msgstr "MacJapanese"
+
+#: ../src/common/fmapbase.cpp:197
+msgid "MacChineseTrad"
+msgstr "MacChineseTrad"
+
+#: ../src/common/fmapbase.cpp:198
+msgid "MacKorean"
+msgstr "MacKorean"
+
+#: ../src/common/fmapbase.cpp:199
+msgid "MacArabic"
+msgstr "MacArabic"
+
+#: ../src/common/fmapbase.cpp:200
+msgid "MacHebrew"
+msgstr "MacHebrew"
+
+#: ../src/common/fmapbase.cpp:201
+msgid "MacGreek"
+msgstr "MacGreek"
+
+#: ../src/common/fmapbase.cpp:202
+msgid "MacCyrillic"
+msgstr "MacCyrillic"
+
+#: ../src/common/fmapbase.cpp:203
+msgid "MacDevanagari"
+msgstr "MacDevanagari"
+
+#: ../src/common/fmapbase.cpp:204
+msgid "MacGurmukhi"
+msgstr "MacGurmukhi"
+
+#: ../src/common/fmapbase.cpp:205
+msgid "MacGujarati"
+msgstr "MacGujarati"
+
+#: ../src/common/fmapbase.cpp:206
+msgid "MacOriya"
+msgstr "MacOriya"
+
+#: ../src/common/fmapbase.cpp:207
+msgid "MacBengali"
+msgstr "MacBengali"
+
+#: ../src/common/fmapbase.cpp:208
+msgid "MacTamil"
+msgstr "MacTamil"
+
+#: ../src/common/fmapbase.cpp:209
+msgid "MacTelugu"
+msgstr "MacTelugu"
+
+#: ../src/common/fmapbase.cpp:210
+msgid "MacKannada"
+msgstr "MacKannada"
+
+#: ../src/common/fmapbase.cpp:211
+msgid "MacMalayalam"
+msgstr "MacMalayalam"
+
+#: ../src/common/fmapbase.cpp:212
+msgid "MacSinhalese"
+msgstr "MacSinhalese"
+
+#: ../src/common/fmapbase.cpp:213
+msgid "MacBurmese"
+msgstr "MacBurmese"
+
+#: ../src/common/fmapbase.cpp:214
+msgid "MacKhmer"
+msgstr "MacKhmer"
+
+#: ../src/common/fmapbase.cpp:215
+msgid "MacThai"
+msgstr "MacThai"
+
+#: ../src/common/fmapbase.cpp:216
+msgid "MacLaotian"
+msgstr "MacLaotian"
+
+#: ../src/common/fmapbase.cpp:217
+msgid "MacGeorgian"
+msgstr "MacGeorgian"
+
+#: ../src/common/fmapbase.cpp:218
+msgid "MacArmenian"
+msgstr "MacArmenian"
+
+#: ../src/common/fmapbase.cpp:219
+msgid "MacChineseSimp"
+msgstr "MacChineseSimp"
+
+#: ../src/common/fmapbase.cpp:220
+msgid "MacTibetan"
+msgstr "MacTibetan"
+
+#: ../src/common/fmapbase.cpp:221
+msgid "MacMongolian"
+msgstr "MacMongolian"
+
+#: ../src/common/fmapbase.cpp:222
+msgid "MacEthiopic"
+msgstr "MacEthiopic"
+
+#: ../src/common/fmapbase.cpp:223
+msgid "MacCentralEurRoman"
+msgstr "MacCentralEurRoman"
+
+#: ../src/common/fmapbase.cpp:224
+msgid "MacVietnamese"
+msgstr "MacVietnamese"
+
+#: ../src/common/fmapbase.cpp:225
+msgid "MacExtArabic"
+msgstr "MacExtArabic"
+
+#: ../src/common/fmapbase.cpp:226
+msgid "MacSymbol"
+msgstr "MacSymbol"
+
+#: ../src/common/fmapbase.cpp:227
+msgid "MacDingbats"
+msgstr "MacDingbats"
+
+#: ../src/common/fmapbase.cpp:228
+msgid "MacTurkish"
+msgstr "MacTurkish"
+
+#: ../src/common/fmapbase.cpp:229
+msgid "MacCroatian"
+msgstr "MacCroatian"
+
+#: ../src/common/fmapbase.cpp:230
+msgid "MacIcelandic"
+msgstr "MacIcelandic"
+
+#: ../src/common/fmapbase.cpp:231
+msgid "MacRomanian"
+msgstr "MacRomanian"
+
+#: ../src/common/fmapbase.cpp:232
+msgid "MacCeltic"
+msgstr "MacCeltic"
+
+#: ../src/common/fmapbase.cpp:233
+msgid "MacGaelic"
+msgstr "MacGaelic"
+
+#: ../src/common/fmapbase.cpp:234
+msgid "MacKeyboardGlyphs"
+msgstr "MacKeyboardGlyphs"
+
+#: ../src/common/fmapbase.cpp:791
+msgid "Default encoding"
+msgstr "預設編碼"
+
+#: ../src/common/fmapbase.cpp:805
+#, c-format
+msgid "Unknown encoding (%d)"
+msgstr "未知的編碼 (%d)"
+
+#: ../src/common/fmapbase.cpp:815 ../src/richtext/richtextstyles.cpp:776
+msgid "default"
+msgstr "預設值"
+
+#: ../src/common/fmapbase.cpp:829
+#, c-format
+msgid "unknown-%d"
+msgstr "未知-%d"
+
+#: ../src/common/fontcmn.cpp:924 ../src/common/fontcmn.cpp:1130
+msgid "underlined"
+msgstr "下底線"
+
+#: ../src/common/fontcmn.cpp:929
+msgid " strikethrough"
+msgstr " 刪除線"
+
+#: ../src/common/fontcmn.cpp:942
+msgid " thin"
+msgstr " 淡體"
+
+#: ../src/common/fontcmn.cpp:946
+msgid " extra light"
+msgstr " 特細"
+
+#: ../src/common/fontcmn.cpp:950
+msgid " light"
+msgstr " 細體"
+
+#: ../src/common/fontcmn.cpp:954
+msgid " medium"
+msgstr " 適中"
+
+#: ../src/common/fontcmn.cpp:958
+msgid " semi bold"
+msgstr " 次粗"
+
+#: ../src/common/fontcmn.cpp:962
+msgid " bold"
+msgstr " 粗體"
+
+#: ../src/common/fontcmn.cpp:966
+msgid " extra bold"
+msgstr " 特粗"
+
+#: ../src/common/fontcmn.cpp:970
+msgid " heavy"
+msgstr " 濃體"
+
+#: ../src/common/fontcmn.cpp:974
+msgid " extra heavy"
+msgstr " 特濃"
+
+#: ../src/common/fontcmn.cpp:990
+msgid " italic"
+msgstr " 斜體"
+
+#: ../src/common/fontcmn.cpp:1134
+msgid "strikethrough"
+msgstr "刪除線"
+
+#: ../src/common/fontcmn.cpp:1143
+msgid "thin"
+msgstr "淡體"
+
+#: ../src/common/fontcmn.cpp:1156
+msgid "extralight"
+msgstr "特細"
+
+#: ../src/common/fontcmn.cpp:1161
+msgid "light"
+msgstr "細體"
+
+#: ../src/common/fontcmn.cpp:1169 ../src/richtext/richtextstyles.cpp:775
+msgid "normal"
+msgstr "標準"
+
+#: ../src/common/fontcmn.cpp:1174
+msgid "medium"
+msgstr "適中"
+
+#: ../src/common/fontcmn.cpp:1179 ../src/common/fontcmn.cpp:1199
+msgid "semibold"
+msgstr "次粗"
+
+#: ../src/common/fontcmn.cpp:1184
+msgid "bold"
+msgstr "粗體"
+
+#: ../src/common/fontcmn.cpp:1194
+msgid "extrabold"
+msgstr "特粗"
+
+#: ../src/common/fontcmn.cpp:1204
+msgid "heavy"
+msgstr "濃體"
+
+#: ../src/common/fontcmn.cpp:1212
+msgid "extraheavy"
+msgstr "特濃"
+
+#: ../src/common/fontcmn.cpp:1217
+msgid "italic"
+msgstr "斜體"
+
+#: ../src/common/fontmap.cpp:195
+msgid ": unknown charset"
+msgstr ": 不明的字集"
+
+#: ../src/common/fontmap.cpp:199
+#, c-format
+msgid ""
+"The charset '%s' is unknown. You may select\n"
+"another charset to replace it with or choose\n"
+"[Cancel] if it cannot be replaced"
+msgstr ""
+"不明的 ’%s’ 字集。\n"
+"您可選取其它字集更換\n"
+"倘若無法更換字集，則選擇「取消」"
+
+#: ../src/common/fontmap.cpp:241
+#, c-format
+msgid "Failed to remember the encoding for the charset '%s'."
+msgstr "無法記憶字集 '%s' 的編碼。"
+
+#: ../src/common/fontmap.cpp:321
+msgid "can't load any font, aborting"
+msgstr "不能載入任何字型，中斷動作"
+
+#: ../src/common/fontmap.cpp:409
+msgid ": unknown encoding"
+msgstr ": 不明的編碼"
+
+#: ../src/common/fontmap.cpp:417
+#, c-format
+msgid ""
+"No font for displaying text in encoding '%s' found,\n"
+"but an alternative encoding '%s' is available.\n"
+"Do you want to use this encoding (otherwise you will have to choose another "
+"one)?"
+msgstr ""
+"找不到 '%s' 編碼的字型，無法顯示文字。\n"
+"但是系統有另一種編碼 '%s'。\n"
+"要使用該編碼嗎？(否則必須選擇另一種)"
+
+#: ../src/common/fontmap.cpp:422
+#, c-format
+msgid ""
+"No font for displaying text in encoding '%s' found.\n"
+"Would you like to select a font to be used for this encoding\n"
+"(otherwise the text in this encoding will not be shown correctly)?"
+msgstr ""
+"找不到 '%s' 編碼的字型，無法顯示文字。\n"
+"要選擇對應這個編碼的字型嗎？\n"
+"(否則此種編碼的文字無法正確顯示)"
+
+#: ../src/common/fs_mem.cpp:169
+#, c-format
+msgid "Memory VFS already contains file '%s'!"
+msgstr "虛擬檔案系統 (VFS) 記憶體已有 '%s' 檔案！"
+
+#: ../src/common/fs_mem.cpp:232
+#, c-format
+msgid "Trying to remove file '%s' from memory VFS, but it is not loaded!"
+msgstr "嘗試從虛擬檔案系統 (VFS) 記憶體移除 '%s' 檔案，但它並未被載入！"
+
+#: ../src/common/fs_mem.cpp:262
+#, c-format
+msgid "Failed to store image '%s' to memory VFS!"
+msgstr "無法將 '%s' 影像儲存到「記憶體虛擬檔案系統」！"
+
+#: ../src/common/ftp.cpp:197
+msgid "Timeout while waiting for FTP server to connect, try passive mode."
+msgstr "等待 FTP 伺服器連線時逾時，請嘗試用被動模式。"
+
+#: ../src/common/ftp.cpp:399
+#, c-format
+msgid "Failed to set FTP transfer mode to %s."
+msgstr "無法設定檔案傳輸 FTP 模式為 %s。"
+
+#: ../src/common/ftp.cpp:400 ../src/richtext/richtextsymboldlg.cpp:432
+msgid "ASCII"
+msgstr "ASCII"
+
+#: ../src/common/ftp.cpp:400
+msgid "binary"
+msgstr "二進位"
+
+#: ../src/common/ftp.cpp:608
+msgid "The FTP server doesn't support the PORT command."
+msgstr "FTP 伺服器不支援 PORT 指令。"
+
+#: ../src/common/ftp.cpp:622
+msgid "The FTP server doesn't support passive mode."
+msgstr "檔案傳輸 FTP 伺服器不支援被動模式。"
+
+#: ../src/common/gifdecod.cpp:822
+#, c-format
+msgid "Incorrect GIF frame size (%u, %d) for the frame #%u"
+msgstr "GIF 影格大小 (%u, %d) 不正確，無法用於影格 #%u"
+
+#: ../src/common/glcmn.cpp:108
+msgid "Failed to allocate colour for OpenGL"
+msgstr "無法為 OpenGL 分配顏色"
+
+#: ../src/common/headerctrlcmn.cpp:57
+msgid "Please select the columns to show and define their order:"
+msgstr "請選取欄位，以顯示並定義其排序："
+
+#: ../src/common/headerctrlcmn.cpp:58
+msgid "Customize Columns"
+msgstr "自訂欄位"
+
+#: ../src/common/headerctrlcmn.cpp:304
+msgid "&Customize..."
+msgstr "自訂(&C)..."
+
+#: ../src/common/hyperlnkcmn.cpp:132
+#, c-format
+msgid "Failed to open URL \"%s\" in the default browser"
+msgstr "無法在預設瀏覽器中開啟網址 \"'%s\""
+
+#: ../src/common/iconbndl.cpp:195
+#, c-format
+msgid "Failed to load image %%d from file '%s'."
+msgstr "無法從 ‘%s’ 檔案載入 %%d 影像。"
+
+#: ../src/common/iconbndl.cpp:203
+#, c-format
+msgid "Failed to load image %d from stream."
+msgstr "無法從串流載入 %d 影像。"
+
+#: ../src/common/iconbndl.cpp:221
+#, c-format
+msgid "Failed to load icons from resource '%s'."
+msgstr "無法從 '%s' 資源載入圖示。"
+
+#: ../src/common/imagbmp.cpp:97
+msgid "BMP: Couldn't save invalid image."
+msgstr "BMP: 不能儲存無效的影像。"
+
+#: ../src/common/imagbmp.cpp:137
+msgid "BMP: wxImage doesn't have own wxPalette."
+msgstr "BMP: wxImage 沒有原生的 wxPalette。"
+
+#: ../src/common/imagbmp.cpp:243
+msgid "BMP: Couldn't write the file (Bitmap) header."
+msgstr "BMP: 無法寫入檔案表頭 (Bitmap)。"
+
+#: ../src/common/imagbmp.cpp:266
+msgid "BMP: Couldn't write the file (BitmapInfo) header."
+msgstr "BMP: 無法寫入檔案表頭 (BitmapInfo)。"
+
+#: ../src/common/imagbmp.cpp:353
+msgid "BMP: Couldn't write RGB color map."
+msgstr "BMP: 無法寫入 RGB 顏色對應表。"
+
+#: ../src/common/imagbmp.cpp:487
+msgid "BMP: Couldn't write data."
+msgstr "BMP: 無法寫入資料。"
+
+#: ../src/common/imagbmp.cpp:561 ../src/common/imagbmp.cpp:642
+msgid "BMP: Couldn't allocate memory."
+msgstr "BMP: 無法分配記憶體。"
+
+#: ../src/common/imagbmp.cpp:1041
+msgid "DIB Header: Image width > 32767 pixels for file."
+msgstr "DIB 表頭：影像寬度大於 32767 個像素。"
+
+#: ../src/common/imagbmp.cpp:1049
+msgid "DIB Header: Image height > 32767 pixels for file."
+msgstr "DIB 表頭：影像高度大於 32767 個像素。"
+
+#: ../src/common/imagbmp.cpp:1081
+msgid "DIB Header: Unknown bitdepth in file."
+msgstr "DIB 表頭：未知的顏色位元數。"
+
+#: ../src/common/imagbmp.cpp:1156
+msgid "DIB Header: Unknown encoding in file."
+msgstr "DIB 表頭：未知的檔案編碼。"
+
+#: ../src/common/imagbmp.cpp:1165
+msgid "DIB Header: Encoding doesn't match bitdepth."
+msgstr "DIB 表頭：編碼與顏色位元數不符合。"
+
+#: ../src/common/imagbmp.cpp:1180
+#, c-format
+msgid "BMP Header: Invalid number of colors (%d)."
+msgstr ""
+
+#: ../src/common/imagbmp.cpp:1273
+msgid "Error in reading image DIB."
+msgstr "讀取影像 DIB 時發生錯誤。"
+
+#: ../src/common/imagbmp.cpp:1294
+msgid "ICO: Error in reading mask DIB."
+msgstr "ICO：讀取遮罩式 DIB 時發生錯誤。"
+
+#: ../src/common/imagbmp.cpp:1353
+msgid "ICO: Image too tall for an icon."
+msgstr "ICO：影像太高，不合於圖示。"
+
+#: ../src/common/imagbmp.cpp:1361
+msgid "ICO: Image too wide for an icon."
+msgstr "ICO：影像太寬，不合於圖示。"
+
+#: ../src/common/imagbmp.cpp:1388 ../src/common/imagbmp.cpp:1488
+#: ../src/common/imagbmp.cpp:1503 ../src/common/imagbmp.cpp:1514
+#: ../src/common/imagbmp.cpp:1528 ../src/common/imagbmp.cpp:1576
+#: ../src/common/imagbmp.cpp:1591 ../src/common/imagbmp.cpp:1605
+#: ../src/common/imagbmp.cpp:1616
+msgid "ICO: Error writing the image file!"
+msgstr "ICO：寫入影像檔時發生錯誤！"
+
+#: ../src/common/imagbmp.cpp:1701
+msgid "ICO: Invalid icon index."
+msgstr "ICO：無效的圖示索引。"
+
+#: ../src/common/image.cpp:2410
+msgid "Image and mask have different sizes."
+msgstr "影像和遮罩的大小不一致。"
+
+#: ../src/common/image.cpp:2418 ../src/common/image.cpp:2459
+msgid "No unused colour in image being masked."
+msgstr "影像裡沒有被遮罩的未用顏色。"
+
+#: ../src/common/image.cpp:2641
+#, c-format
+msgid "Failed to load bitmap \"%s\" from resources."
+msgstr "無法從資源載入 ”%s” 位元圖。"
+
+#: ../src/common/image.cpp:2650
+#, c-format
+msgid "Failed to load icon \"%s\" from resources."
+msgstr "無法從資源載入 ”%s” 圖示。"
+
+#: ../src/common/image.cpp:2728 ../src/common/image.cpp:2747
+#, c-format
+msgid "Failed to load image from file \"%s\"."
+msgstr "無法從 '%s' 檔案載入影像。"
+
+#: ../src/common/image.cpp:2761
+#, c-format
+msgid "Can't save image to file '%s': unknown extension."
+msgstr "無法儲存影像到 '%s' 檔案：未知的副檔名。"
+
+#: ../src/common/image.cpp:2869
+msgid "No handler found for image type."
+msgstr "沒有找到影像類型處理常式。"
+
+#: ../src/common/image.cpp:2877 ../src/common/image.cpp:3000
+#: ../src/common/image.cpp:3066
+#, c-format
+msgid "No image handler for type %d defined."
+msgstr "沒有定義 %d 類型的影像處理常式。"
+
+#: ../src/common/image.cpp:2887
+#, c-format
+msgid "Image file is not of type %d."
+msgstr "影像檔不是 %d 類型。"
+
+#: ../src/common/image.cpp:2970
+msgid "Can't automatically determine the image format for non-seekable input."
+msgstr "無法自動判定用於不可定位輸入的影像格式。"
+
+#: ../src/common/image.cpp:2988
+msgid "Unknown image data format."
+msgstr "未知的影像資料格式。"
+
+#: ../src/common/image.cpp:3009
+#, c-format
+msgid "This is not a %s."
+msgstr "這不是 %s。"
+
+#: ../src/common/image.cpp:3032 ../src/common/image.cpp:3080
+#, c-format
+msgid "No image handler for type %s defined."
+msgstr "沒有定義 %s 類型的影像處理常式。"
+
+#: ../src/common/image.cpp:3041
+#, c-format
+msgid "Image is not of type %s."
+msgstr "影像不是 %s 類型。"
+
+#: ../src/common/image.cpp:3509
+#, c-format
+msgid "Failed to check format of image file \"%s\"."
+msgstr "無法確認圖片檔 “%s” 的格式。"
+
+#: ../src/common/imaggif.cpp:124
+msgid "GIF: error in GIF image format."
+msgstr "GIF: GIF 影像格式錯誤。"
+
+#: ../src/common/imaggif.cpp:129
+msgid "GIF: not enough memory."
+msgstr "GIF: 記憶體不足。"
+
+#: ../src/common/imaggif.cpp:134
+msgid "GIF: data stream seems to be truncated."
+msgstr "GIF: 資料串流看似已被截斷。"
+
+#: ../src/common/imaggif.cpp:240
+msgid "Couldn't initialize GIF hash table."
+msgstr "無法初始化 GIF 雜湊表。"
+
+#: ../src/common/imagiff.cpp:739
+msgid "IFF: error in IFF image format."
+msgstr "IFF：IFF 影像格式錯誤。"
+
+#: ../src/common/imagiff.cpp:742
+msgid "IFF: not enough memory."
+msgstr "IFF：記憶體不足。"
+
+#: ../src/common/imagiff.cpp:745
+msgid "IFF: unknown error!!!"
+msgstr "IFF：未知錯誤！"
+
+#: ../src/common/imagiff.cpp:755
+msgid "IFF: data stream seems to be truncated."
+msgstr "IFF：資料串流看似已被截斷。"
+
+#: ../src/common/imagjpeg.cpp:258
+msgid "JPEG: Couldn't load - file is probably corrupted."
+msgstr "JPEG：無法載入 - 檔案也許損壞。"
+
+#: ../src/common/imagjpeg.cpp:437
+msgid "JPEG: Couldn't save image."
+msgstr "JPEG：無法儲存影像。"
+
+#: ../src/common/imagpcx.cpp:439
+msgid "PCX: this is not a PCX file."
+msgstr "PCX：這不是 PCX 檔案。"
+
+#: ../src/common/imagpcx.cpp:453
+msgid "PCX: image format unsupported"
+msgstr "PCX：影像格式不支援"
+
+#: ../src/common/imagpcx.cpp:454 ../src/common/imagpcx.cpp:477
+msgid "PCX: couldn't allocate memory"
+msgstr "PCX：無法分配記憶體"
+
+#: ../src/common/imagpcx.cpp:455
+msgid "PCX: version number too low"
+msgstr "PCX：版本號碼太舊"
+
+#: ../src/common/imagpcx.cpp:456 ../src/common/imagpcx.cpp:478
+msgid "PCX: unknown error !!!"
+msgstr "PCX：未知錯誤！"
+
+#: ../src/common/imagpcx.cpp:476
+msgid "PCX: invalid image"
+msgstr "PCX：無效的影像"
+
+#: ../src/common/imagpng.cpp:385
+#, c-format
+msgid "Unknown PNG resolution unit %d"
+msgstr "未知的 PNG 解析度單位 %d"
+
+#: ../src/common/imagpng.cpp:439
+msgid "Couldn't load a PNG image - file is corrupted or not enough memory."
+msgstr "無法載入 PNG 影像 — 檔案損壞或是沒有足夠記憶體。"
+
+#: ../src/common/imagpng.cpp:513 ../src/common/imagpng.cpp:524
+#: ../src/common/imagpng.cpp:534
+msgid "Couldn't save PNG image."
+msgstr "無法儲存 PNG 影像。"
+
+#: ../src/common/imagpnm.cpp:71
+msgid "PNM: File format is not recognized."
+msgstr "PNM：無法識別檔案格式。"
+
+#: ../src/common/imagpnm.cpp:89
+msgid "PNM: Couldn't allocate memory."
+msgstr "PNM：無法分配記憶體。"
+
+#: ../src/common/imagpnm.cpp:111 ../src/common/imagpnm.cpp:134
+#: ../src/common/imagpnm.cpp:156
+msgid "PNM: File seems truncated."
+msgstr "PNM：檔案似乎被截斷。"
+
+#: ../src/common/imagtiff.cpp:69
+#, c-format
+msgid " (in module \"%s\")"
+msgstr " (在 ‘%s’ 模組中）"
+
+#: ../src/common/imagtiff.cpp:304
+msgid "TIFF: Error loading image."
+msgstr "TIFF：載入影像錯誤。"
+
+#: ../src/common/imagtiff.cpp:314
+msgid "Invalid TIFF image index."
+msgstr "無效的 TIFF 影像索引。"
+
+#: ../src/common/imagtiff.cpp:358
+msgid "TIFF: Image size is abnormally big."
+msgstr "TIFF：影像太大。"
+
+#: ../src/common/imagtiff.cpp:372 ../src/common/imagtiff.cpp:385
+#: ../src/common/imagtiff.cpp:769
+msgid "TIFF: Couldn't allocate memory."
+msgstr "TIFF：無法分配記憶體。"
+
+#: ../src/common/imagtiff.cpp:471
+msgid "TIFF: Error reading image."
+msgstr "TIFF：讀取影像錯誤。"
+
+#: ../src/common/imagtiff.cpp:532
+#, c-format
+msgid "Unknown TIFF resolution unit %d ignored"
+msgstr "未知 TIFF 解析度單位 %d，已忽略"
+
+#: ../src/common/imagtiff.cpp:611
+msgid "TIFF: Error saving image."
+msgstr "TIFF：儲存影像錯誤。"
+
+#: ../src/common/imagtiff.cpp:868
+msgid "TIFF: Error writing image."
+msgstr "TIFF：寫入影像錯誤。"
+
+#: ../src/common/imagtiff.cpp:881
+#, fuzzy
+msgid "TIFF: Error flushing data."
+msgstr "TIFF：儲存影像錯誤。"
+
+#: ../src/common/imagwebp.cpp:56
+msgid "WebP: Invalid data (failed to get features)."
+msgstr ""
+
+#: ../src/common/imagwebp.cpp:65
+msgid "WebP: Allocating image memory failed."
+msgstr ""
+
+#: ../src/common/imagwebp.cpp:82
+msgid "WebP: Decoding RGBA image data failed."
+msgstr ""
+
+#: ../src/common/imagwebp.cpp:98
+msgid "WebP: Decoding RGB image data failed."
+msgstr ""
+
+#: ../src/common/imagwebp.cpp:113 ../src/common/imagwebp.cpp:201
+msgid "WebP: Allocating stream buffer failed."
+msgstr ""
+
+#: ../src/common/imagwebp.cpp:131
+#, fuzzy
+msgid "WebP: Failed to parse container data."
+msgstr "無法設定剪貼簿資料。"
+
+#: ../src/common/imagwebp.cpp:222
+#, fuzzy
+msgid "WebP: Error decoding animation."
+msgstr "讀取組態選項時發生錯誤。"
+
+#: ../src/common/imagwebp.cpp:240
+msgid "WebP: Error getting next animation frame."
+msgstr ""
+
+#: ../src/common/init.cpp:172
+#, c-format
+msgid ""
+"Command line argument %d couldn't be converted to Unicode and will be "
+"ignored."
+msgstr "由於指令列引數 %d 無法轉換為 Unicode 編碼，其將被忽略。"
+
+#: ../src/common/init.cpp:344
+msgid "Initialization failed in post init, aborting."
+msgstr "安裝後續的啟始失敗，正在中斷。"
+
+#: ../src/common/intl.cpp:378
+#, c-format
+msgid "Cannot set locale to language \"%s\"."
+msgstr "無法將地區語言設定為 '%s'。"
+
+#: ../src/common/log.cpp:232
+msgid "Error: "
+msgstr "錯誤： "
+
+#: ../src/common/log.cpp:236
+msgid "Warning: "
+msgstr "警告： "
+
+#: ../src/common/log.cpp:284
+msgid "The previous message repeated once."
+msgstr "上一則訊息已重複一次。"
+
+#: ../src/common/log.cpp:291
+#, c-format
+msgid "The previous message repeated %u time."
+msgid_plural "The previous message repeated %u times."
+msgstr[0] "上一則訊息已重複 %u 次。"
+
+#: ../src/common/log.cpp:319
+#, c-format
+msgid "Last repeated message (\"%s\", %u time) wasn't output"
+msgid_plural "Last repeated message (\"%s\", %u times) wasn't output"
+msgstr[0] "最近重複的訊息 (“%s”, %u 次) 並無輸出"
+
+#: ../src/common/log.cpp:435
+#, c-format
+msgid " (error %ld: %s)"
+msgstr " (錯誤 %ld: %s)"
+
+#: ../src/common/lzmastream.cpp:121
+msgid "Failed to allocate memory for LZMA decompression."
+msgstr "無法分配供 LZMA 解壓縮的記憶體。"
+
+#: ../src/common/lzmastream.cpp:125
+#, c-format
+msgid "Failed to initialize LZMA decompression: unexpected error %u."
+msgstr "無法初始化 LZMA 解壓縮：異常的錯誤 %u。"
+
+#: ../src/common/lzmastream.cpp:179
+msgid "input is not in XZ format"
+msgstr "輸入不是 XZ 格式"
+
+#: ../src/common/lzmastream.cpp:183
+msgid "input compressed using unknown XZ option"
+msgstr "輸入壓縮採用未知的 XZ 選項"
+
+#: ../src/common/lzmastream.cpp:188
+msgid "input is corrupted"
+msgstr "輸入損壞"
+
+#: ../src/common/lzmastream.cpp:192
+msgid "unknown decompression error"
+msgstr "未知的解壓縮錯誤"
+
+#: ../src/common/lzmastream.cpp:196
+#, c-format
+msgid "LZMA decompression error: %s"
+msgstr "LZMA 解壓縮錯誤：%s"
+
+#: ../src/common/lzmastream.cpp:231
+msgid "Failed to allocate memory for LZMA compression."
+msgstr "無法分配供 LZMA 壓縮的記憶體。"
+
+#: ../src/common/lzmastream.cpp:235
+#, c-format
+msgid "Failed to initialize LZMA compression: unexpected error %u."
+msgstr "無法初始化 LZMA 壓縮：異常的錯誤 %u。"
+
+#: ../src/common/lzmastream.cpp:267 ../src/common/lzmastream.cpp:342
+#: ../src/html/chm.cpp:336
+msgid "out of memory"
+msgstr "記憶體不足"
+
+#: ../src/common/lzmastream.cpp:276 ../src/common/lzmastream.cpp:346
+msgid "unknown compression error"
+msgstr "未知的壓縮錯誤"
+
+#: ../src/common/lzmastream.cpp:280
+#, c-format
+msgid "LZMA compression error: %s"
+msgstr "LZMA 壓縮錯誤：%s"
+
+#: ../src/common/lzmastream.cpp:350
+#, c-format
+msgid "LZMA compression error when flushing output: %s"
+msgstr "排清輸出時發生 LZMA 壓縮錯誤：%s"
+
+#: ../src/common/mimecmn.cpp:167
+#, c-format
+msgid "Unmatched '{' in an entry for mime type %s."
+msgstr "%s mime 類型中，有不成對的{ 項目。"
+
+#: ../src/common/module.cpp:76
+#, c-format
+msgid "Circular dependency involving module \"%s\" detected."
+msgstr "偵測到含有 “%s” 模組的循環相關性。"
+
+# "相依性「%s」的模組「%s」不存在。"
+#: ../src/common/module.cpp:128
+#, c-format
+msgid "Dependency \"%s\" of module \"%s\" doesn't exist."
+msgstr "“%s” 模組的 “%s” 不存在。"
+
+#: ../src/common/module.cpp:137
+#, c-format
+msgid "Module \"%s\" initialization failed"
+msgstr "'%s' 模組初始化失敗"
+
+#: ../src/common/msgout.cpp:96
+msgid "Message"
+msgstr "郵件"
+
+#: ../src/common/paper.cpp:70
+msgid "Letter, 8 1/2 x 11 in"
+msgstr "美式信紙 (Letter)，8 1/2 x 11 英吋"
+
+#: ../src/common/paper.cpp:71
+msgid "Legal, 8 1/2 x 14 in"
+msgstr "美式長信紙 (Legal)，8 1/2 x 14 英吋"
+
+#: ../src/common/paper.cpp:72
+msgid "A4 sheet, 210 x 297 mm"
+msgstr "A4 印刷紙，210 x 297 公釐"
+
+#: ../src/common/paper.cpp:73
+msgid "C sheet, 17 x 22 in"
+msgstr "C 印刷紙, 17 x 22 英吋"
+
+#: ../src/common/paper.cpp:74
+msgid "D sheet, 22 x 34 in"
+msgstr "D 印刷紙，22 x 34 英吋"
+
+#: ../src/common/paper.cpp:75
+msgid "E sheet, 34 x 44 in"
+msgstr "E 紙張, 34 x 44 英吋"
+
+#: ../src/common/paper.cpp:76
+msgid "Letter Small, 8 1/2 x 11 in"
+msgstr "美式信紙 (Letter)縮小，8 1/2 x 11 英吋"
+
+#: ../src/common/paper.cpp:77
+msgid "Tabloid, 11 x 17 in"
+msgstr "小報, 11 x 17 英吋"
+
+#: ../src/common/paper.cpp:78
+msgid "Ledger, 17 x 11 in"
+msgstr "橫板紙 (Ledger)，17 x 11 英吋"
+
+#: ../src/common/paper.cpp:79
+msgid "Statement, 5 1/2 x 8 1/2 in"
+msgstr "結算單, 5 1/2 x 8 1/2 英吋"
+
+#: ../src/common/paper.cpp:80
+msgid "Executive, 7 1/4 x 10 1/2 in"
+msgstr "Executive, 7 1/4 x 10 1/2 英吋"
+
+#: ../src/common/paper.cpp:81
+msgid "A3 sheet, 297 x 420 mm"
+msgstr "A3 印刷紙，297 x 420 公釐"
+
+#: ../src/common/paper.cpp:82
+msgid "A4 small sheet, 210 x 297 mm"
+msgstr "A4 印刷小紙張，210 x 297 公釐"
+
+#: ../src/common/paper.cpp:83
+msgid "A5 sheet, 148 x 210 mm"
+msgstr "A5 印刷紙，148 x 210 公釐"
+
+#: ../src/common/paper.cpp:84
+msgid "B4 sheet, 250 x 354 mm"
+msgstr "B4 印刷紙，250 x 354 公釐"
+
+#: ../src/common/paper.cpp:85
+msgid "B5 sheet, 182 x 257 millimeter"
+msgstr "B5 印刷紙，182 x 257 公釐"
+
+#: ../src/common/paper.cpp:86
+msgid "Folio, 8 1/2 x 13 in"
+msgstr "對開紙 (Folio)，8 1/2 x 13 英吋"
+
+#: ../src/common/paper.cpp:87
+msgid "Quarto, 215 x 275 mm"
+msgstr "四開，215 x 275 mm"
+
+#: ../src/common/paper.cpp:88
+msgid "10 x 14 in"
+msgstr "10 x 14 英吋"
+
+#: ../src/common/paper.cpp:89
+msgid "11 x 17 in"
+msgstr "11 x 17 英吋"
+
+#: ../src/common/paper.cpp:90
+msgid "Note, 8 1/2 x 11 in"
+msgstr "筆記簿，8 1/2 x 11 英吋"
+
+#: ../src/common/paper.cpp:91
+msgid "#9 Envelope, 3 7/8 x 8 7/8 in"
+msgstr "#9 信封, 3 7/8 x 8 7/8 英吋"
+
+#: ../src/common/paper.cpp:92
+msgid "#10 Envelope, 4 1/8 x 9 1/2 in"
+msgstr "#10 信封，4 1/8 x 9 1/2 英吋"
+
+#: ../src/common/paper.cpp:93
+msgid "#11 Envelope, 4 1/2 x 10 3/8 in"
+msgstr "#11 信封，4 1/2 x 10 3/8 英吋"
+
+#: ../src/common/paper.cpp:94
+msgid "#12 Envelope, 4 3/4 x 11 in"
+msgstr "#12 信封，4 3/4 x 11 英吋"
+
+#: ../src/common/paper.cpp:95
+msgid "#14 Envelope, 5 x 11 1/2 in"
+msgstr "#14 信封，5 x 11 1/2 英吋"
+
+#: ../src/common/paper.cpp:96
+msgid "DL Envelope, 110 x 220 mm"
+msgstr "DL 信封，110 x 220 公釐"
+
+#: ../src/common/paper.cpp:97
+msgid "C5 Envelope, 162 x 229 mm"
+msgstr "C5 信封，162 x 229 公釐"
+
+#: ../src/common/paper.cpp:98
+msgid "C3 Envelope, 324 x 458 mm"
+msgstr "C3 信封，324 x 458 公釐"
+
+#: ../src/common/paper.cpp:99
+msgid "C4 Envelope, 229 x 324 mm"
+msgstr "C4 信封，229 x 324 公釐"
+
+#: ../src/common/paper.cpp:100
+msgid "C6 Envelope, 114 x 162 mm"
+msgstr "C6 信封，114 x 162 公釐"
+
+#: ../src/common/paper.cpp:101
+msgid "C65 Envelope, 114 x 229 mm"
+msgstr "C65 信封, 114 x 229 公釐"
+
+#: ../src/common/paper.cpp:102
+msgid "B4 Envelope, 250 x 353 mm"
+msgstr "B4 信封，250 x 353 公釐"
+
+#: ../src/common/paper.cpp:103
+msgid "B5 Envelope, 176 x 250 mm"
+msgstr "B5 信封，176 x 250 公釐"
+
+#: ../src/common/paper.cpp:104
+msgid "B6 Envelope, 176 x 125 mm"
+msgstr "B6 信封，176 x 125 公釐"
+
+#: ../src/common/paper.cpp:105
+msgid "Italy Envelope, 110 x 230 mm"
+msgstr "意大利信封，110 x 230 mm"
+
+#: ../src/common/paper.cpp:106
+msgid "Monarch Envelope, 3 7/8 x 7 1/2 in"
+msgstr "御用信封，3 7/8 x 7 1/2 英吋"
+
+#: ../src/common/paper.cpp:107
+msgid "6 3/4 Envelope, 3 5/8 x 6 1/2 in"
+msgstr "6 3/4 信封，3 5/8 x 6 1/2 英吋"
+
+#: ../src/common/paper.cpp:108
+msgid "US Std Fanfold, 14 7/8 x 11 in"
+msgstr "美國標準複寫簿, 14 7/8 x 11 英吋"
+
+#: ../src/common/paper.cpp:109
+msgid "German Std Fanfold, 8 1/2 x 12 in"
+msgstr "德國標準複寫簿, 8 1/2 x 12 in"
+
+#: ../src/common/paper.cpp:110
+msgid "German Legal Fanfold, 8 1/2 x 13 in"
+msgstr "德國法定複寫簿, 8 1/2 x 13 in"
+
+#: ../src/common/paper.cpp:112
+msgid "B4 (ISO) 250 x 353 mm"
+msgstr "B4 (ISO) 250 x 353 公釐"
+
+#: ../src/common/paper.cpp:113
+msgid "Japanese Postcard 100 x 148 mm"
+msgstr "日式明信片 100 x 148 公釐"
+
+#: ../src/common/paper.cpp:114
+msgid "9 x 11 in"
+msgstr "9 x 11 英吋"
+
+#: ../src/common/paper.cpp:115
+msgid "10 x 11 in"
+msgstr "10 x 11 英吋"
+
+#: ../src/common/paper.cpp:116
+msgid "15 x 11 in"
+msgstr "15 x 11 英吋"
+
+#: ../src/common/paper.cpp:117
+msgid "Envelope Invite 220 x 220 mm"
+msgstr "邀請信封 220 x 220 公釐"
+
+#: ../src/common/paper.cpp:118
+msgid "Letter Extra 9 1/2 x 12 in"
+msgstr "美式信紙 (Letter)增大 9 1/2 x 12 英吋"
+
+#: ../src/common/paper.cpp:119
+msgid "Legal Extra 9 1/2 x 15 in"
+msgstr "美式長信紙 (Legal)增大 9 1/2 x 15 英吋"
+
+#: ../src/common/paper.cpp:120
+msgid "Tabloid Extra 11.69 x 18 in"
+msgstr "小報加長 11.69 x 18 英吋"
+
+#: ../src/common/paper.cpp:121
+msgid "A4 Extra 9.27 x 12.69 in"
+msgstr "A4 加長 9.27 x 12.69 英吋"
+
+#: ../src/common/paper.cpp:122
+msgid "Letter Transverse 8 1/2 x 11 in"
+msgstr "美式信紙 (Letter) 橫向 8 1/2 x 11 英吋"
+
+#: ../src/common/paper.cpp:123
+msgid "A4 Transverse 210 x 297 mm"
+msgstr "A4 橫向 210 x 297 公釐"
+
+#: ../src/common/paper.cpp:124
+msgid "Letter Extra Transverse 9.275 x 12 in"
+msgstr "美式信紙 (Letter) 增大橫向 9.275 x 12 英吋"
+
+#: ../src/common/paper.cpp:125
+msgid "SuperA/SuperA/A4 227 x 356 mm"
+msgstr "SuperA/SuperA/A4 227 x 356 公釐"
+
+#: ../src/common/paper.cpp:126
+msgid "SuperB/SuperB/A3 305 x 487 mm"
+msgstr "SuperB/SuperB/A3 305 x 487 公釐"
+
+#: ../src/common/paper.cpp:127
+msgid "Letter Plus 8 1/2 x 12.69 in"
+msgstr "美式信紙 (Letter) 加長 8 1/2 x 12.69 英吋"
+
+#: ../src/common/paper.cpp:128
+msgid "A4 Plus 210 x 330 mm"
+msgstr "A4 增大 210 x 330 公釐"
+
+#: ../src/common/paper.cpp:129
+msgid "A5 Transverse 148 x 210 mm"
+msgstr "A5 橫向 148 x 210 公釐"
+
+#: ../src/common/paper.cpp:130
+msgid "B5 (JIS) Transverse 182 x 257 mm"
+msgstr "B5 (JIS) 橫向 182 x 257 公釐"
+
+#: ../src/common/paper.cpp:131
+msgid "A3 Extra 322 x 445 mm"
+msgstr "A3 加長 322 x 445 公釐"
+
+#: ../src/common/paper.cpp:132
+msgid "A5 Extra 174 x 235 mm"
+msgstr "A5 加長 174 x 235 公釐"
+
+#: ../src/common/paper.cpp:133
+msgid "B5 (ISO) Extra 201 x 276 mm"
+msgstr "B5 (ISO) 加長 201 x 276 公釐"
+
+#: ../src/common/paper.cpp:134
+msgid "A2 420 x 594 mm"
+msgstr "A2 420 x 594 公釐"
+
+#: ../src/common/paper.cpp:135
+msgid "A3 Transverse 297 x 420 mm"
+msgstr "A3 轉向 297 x 420 公釐"
+
+#: ../src/common/paper.cpp:136
+msgid "A3 Extra Transverse 322 x 445 mm"
+msgstr "A3 加長橫向 322 x 445 公釐"
+
+#: ../src/common/paper.cpp:138
+msgid "Japanese Double Postcard 200 x 148 mm"
+msgstr "日式雙倍明信片 200 x 148 公釐"
+
+#: ../src/common/paper.cpp:139
+msgid "A6 105 x 148 mm"
+msgstr "A6 105 x 148 公釐"
+
+#: ../src/common/paper.cpp:140
+msgid "Japanese Envelope Kaku #2"
+msgstr "日式信封 Kaku #2"
+
+#: ../src/common/paper.cpp:141
+msgid "Japanese Envelope Kaku #3"
+msgstr "日式信封 Kaku #3"
+
+#: ../src/common/paper.cpp:142
+msgid "Japanese Envelope Chou #3"
+msgstr "日式信封 Chou #3"
+
+#: ../src/common/paper.cpp:143
+msgid "Japanese Envelope Chou #4"
+msgstr "日式信封 Chou #4"
+
+#: ../src/common/paper.cpp:144
+msgid "Letter Rotated 11 x 8 1/2 in"
+msgstr "美式信紙 (Letter) 轉向，11 x 8 1/2 英吋"
+
+#: ../src/common/paper.cpp:145
+msgid "A3 Rotated 420 x 297 mm"
+msgstr "A3 轉向 420 x 297 公釐"
+
+#: ../src/common/paper.cpp:146
+msgid "A4 Rotated 297 x 210 mm"
+msgstr "A4 轉向 297 x 210 公釐"
+
+#: ../src/common/paper.cpp:147
+msgid "A5 Rotated 210 x 148 mm"
+msgstr "A5 轉向 210 x 148 公釐"
+
+#: ../src/common/paper.cpp:148
+msgid "B4 (JIS) Rotated 364 x 257 mm"
+msgstr "B4 (JIS) 轉向 364 x 257 公釐"
+
+#: ../src/common/paper.cpp:149
+msgid "B5 (JIS) Rotated 257 x 182 mm"
+msgstr "B5 (JIS) 轉向 257 x 182 公釐"
+
+#: ../src/common/paper.cpp:150
+msgid "Japanese Postcard Rotated 148 x 100 mm"
+msgstr "日式明信片轉向 148 x 100 公釐"
+
+#: ../src/common/paper.cpp:151
+msgid "Double Japanese Postcard Rotated 148 x 200 mm"
+msgstr "雙倍日式明信片(轉向) 148 x 200 mm"
+
+#: ../src/common/paper.cpp:152
+msgid "A6 Rotated 148 x 105 mm"
+msgstr "A6 轉向 148 x 105 公釐"
+
+#: ../src/common/paper.cpp:153
+msgid "Japanese Envelope Kaku #2 Rotated"
+msgstr "日式信封 Kaku #2 轉向"
+
+#: ../src/common/paper.cpp:154
+msgid "Japanese Envelope Kaku #3 Rotated"
+msgstr "日式信封 Kaku #3 轉向"
+
+#: ../src/common/paper.cpp:155
+msgid "Japanese Envelope Chou #3 Rotated"
+msgstr "日式信封 Chou #3 轉向"
+
+#: ../src/common/paper.cpp:156
+msgid "Japanese Envelope Chou #4 Rotated"
+msgstr "日式信封 Chou #4 轉向"
+
+#: ../src/common/paper.cpp:157
+msgid "B6 (JIS) 128 x 182 mm"
+msgstr "B6 (JIS) 128 x 182 公釐"
+
+#: ../src/common/paper.cpp:158
+msgid "B6 (JIS) Rotated 182 x 128 mm"
+msgstr "B6 (JIS) 轉向 182 x 128 公釐"
+
+#: ../src/common/paper.cpp:159
+msgid "12 x 11 in"
+msgstr "12 x 11 英吋"
+
+#: ../src/common/paper.cpp:160
+msgid "Japanese Envelope You #4"
+msgstr "日式信封 You #4"
+
+#: ../src/common/paper.cpp:161
+msgid "Japanese Envelope You #4 Rotated"
+msgstr "日式信封 You #4 轉向"
+
+#: ../src/common/paper.cpp:162
+msgid "PRC 16K 146 x 215 mm"
+msgstr "中式 16開 146 x 215 公釐"
+
+#: ../src/common/paper.cpp:163
+msgid "PRC 32K 97 x 151 mm"
+msgstr "中式 32開 97 x 151 公釐"
+
+#: ../src/common/paper.cpp:164
+msgid "PRC 32K(Big) 97 x 151 mm"
+msgstr "中式 32開 (大) 97 x 151 公釐"
+
+#: ../src/common/paper.cpp:165
+msgid "PRC Envelope #1 102 x 165 mm"
+msgstr "中式信封 #1 102 x 165 公釐"
+
+#: ../src/common/paper.cpp:166
+msgid "PRC Envelope #2 102 x 176 mm"
+msgstr "中式信封 #2 102 x 176 公釐"
+
+#: ../src/common/paper.cpp:167
+msgid "PRC Envelope #3 125 x 176 mm"
+msgstr "中式信封 #3 125 x 176 公釐"
+
+#: ../src/common/paper.cpp:168
+msgid "PRC Envelope #4 110 x 208 mm"
+msgstr "中式信封 #4 110 x 208 公釐"
+
+#: ../src/common/paper.cpp:169
+msgid "PRC Envelope #5 110 x 220 mm"
+msgstr "中式信封 #5 110 x 220 公釐"
+
+#: ../src/common/paper.cpp:170
+msgid "PRC Envelope #6 120 x 230 mm"
+msgstr "中式信封 #6 120 x 230 公釐"
+
+#: ../src/common/paper.cpp:171
+msgid "PRC Envelope #7 160 x 230 mm"
+msgstr "中式信封 #7 160 x 230 公釐"
+
+#: ../src/common/paper.cpp:172
+msgid "PRC Envelope #8 120 x 309 mm"
+msgstr "中式信封 #8 120 x 309 公釐"
+
+#: ../src/common/paper.cpp:173
+msgid "PRC Envelope #9 229 x 324 mm"
+msgstr "中式信封 #9 229 x 324 公釐"
+
+#: ../src/common/paper.cpp:174
+msgid "PRC Envelope #10 324 x 458 mm"
+msgstr "中式信封 #10 324 x 458 公釐"
+
+#: ../src/common/paper.cpp:175
+msgid "PRC 16K Rotated"
+msgstr "中式 16開 轉向"
+
+#: ../src/common/paper.cpp:176
+msgid "PRC 32K Rotated"
+msgstr "中式 32開 轉向"
+
+#: ../src/common/paper.cpp:177
+msgid "PRC 32K(Big) Rotated"
+msgstr "中式 32開 (大) 轉向"
+
+#: ../src/common/paper.cpp:178
+msgid "PRC Envelope #1 Rotated 165 x 102 mm"
+msgstr "中式信封 #1 轉向 165 x 102 公釐"
+
+#: ../src/common/paper.cpp:179
+msgid "PRC Envelope #2 Rotated 176 x 102 mm"
+msgstr "中式信封 #2 轉向 176 x 102 公釐"
+
+#: ../src/common/paper.cpp:180
+msgid "PRC Envelope #3 Rotated 176 x 125 mm"
+msgstr "中式信封 #3 轉向 176 x 125 公釐"
+
+#: ../src/common/paper.cpp:181
+msgid "PRC Envelope #4 Rotated 208 x 110 mm"
+msgstr "中式信封 #4 轉向 208 x 110 公釐"
+
+#: ../src/common/paper.cpp:182
+msgid "PRC Envelope #5 Rotated 220 x 110 mm"
+msgstr "中式信封 #5 轉向 220 x 110 公釐"
+
+#: ../src/common/paper.cpp:183
+msgid "PRC Envelope #6 Rotated 230 x 120 mm"
+msgstr "中式信封 #6 轉向 230 x 120 公釐"
+
+#: ../src/common/paper.cpp:184
+msgid "PRC Envelope #7 Rotated 230 x 160 mm"
+msgstr "中式信封 #7 轉向 230 x 160 公釐"
+
+#: ../src/common/paper.cpp:185
+msgid "PRC Envelope #8 Rotated 309 x 120 mm"
+msgstr "中式信封 #8 轉向 309 x 120 公釐"
+
+#: ../src/common/paper.cpp:186
+msgid "PRC Envelope #9 Rotated 324 x 229 mm"
+msgstr "中式信封 #9 轉向 324 x 229 公釐"
+
+#: ../src/common/paper.cpp:187
+msgid "PRC Envelope #10 Rotated 458 x 324 mm"
+msgstr "中式信封 #10 轉向 458 x 324 公釐"
+
+#: ../src/common/paper.cpp:192
+msgid "A0 sheet, 841 x 1189 mm"
+msgstr "A0 印刷紙，841 x 1189 公釐"
+
+#: ../src/common/paper.cpp:193
+msgid "A1 sheet, 594 x 841 mm"
+msgstr "A1 印刷紙，594 x 841 公釐"
+
+#: ../src/common/preferencescmn.cpp:37
+msgid "General"
+msgstr "一般"
+
+#: ../src/common/preferencescmn.cpp:40
+msgid "Advanced"
+msgstr "進階"
+
+#: ../src/common/prntbase.cpp:245
+msgid "Generic PostScript"
+msgstr "通用 PostScript"
+
+#: ../src/common/prntbase.cpp:259
+msgid "Ready"
+msgstr "就緒"
+
+#: ../src/common/prntbase.cpp:331
+msgid "Printing Error"
+msgstr "列印時發生錯誤"
+
+#: ../src/common/prntbase.cpp:413 ../src/common/prntbase.cpp:1597
+#: ../src/generic/prntdlgg.cpp:135 ../src/generic/prntdlgg.cpp:149
+#: ../src/gtk/print.cpp:628 ../src/gtk/print.cpp:646
+msgid "Print"
+msgstr "列印"
+
+#: ../src/common/prntbase.cpp:471 ../src/generic/prntdlgg.cpp:809
+msgid "Page setup"
+msgstr "頁面設定"
+
+#: ../src/common/prntbase.cpp:525
+msgid "Please wait while printing..."
+msgstr "列印中，請稍待..."
+
+#: ../src/common/prntbase.cpp:529
+msgid "Document:"
+msgstr "文件："
+
+#: ../src/common/prntbase.cpp:532
+msgid "Progress:"
+msgstr "進度："
+
+#: ../src/common/prntbase.cpp:533
+msgid "Preparing"
+msgstr "正在準備"
+
+#: ../src/common/prntbase.cpp:552
+#, c-format
+msgid "Printing page %d"
+msgstr "正在列印第 %d 頁"
+
+#: ../src/common/prntbase.cpp:557
+#, c-format
+msgid "Printing page %d of %d"
+msgstr "正在列印第 %d 頁 (共 %d 頁)"
+
+#: ../src/common/prntbase.cpp:560
+#, c-format
+msgid " (copy %d of %d)"
+msgstr " (複製 %d / %d )"
+
+#: ../src/common/prntbase.cpp:1604
+msgid "First page"
+msgstr "第一頁"
+
+#: ../src/common/prntbase.cpp:1609 ../src/html/helpwnd.cpp:659
+msgid "Previous page"
+msgstr "上一頁"
+
+#: ../src/common/prntbase.cpp:1623 ../src/html/helpwnd.cpp:660
+msgid "Next page"
+msgstr "下一頁"
+
+#: ../src/common/prntbase.cpp:1628
+msgid "Last page"
+msgstr "最後一頁"
+
+#: ../src/common/prntbase.cpp:1636 ../src/common/stockitem.cpp:215
+msgid "Zoom Out"
+msgstr "縮小"
+
+#: ../src/common/prntbase.cpp:1650 ../src/common/stockitem.cpp:214
+msgid "Zoom In"
+msgstr "放大"
+
+#: ../src/common/prntbase.cpp:1656 ../src/common/stockitem.cpp:153
+#: ../src/generic/logg.cpp:553 ../src/univ/themes/win32.cpp:3752
+msgid "&Close"
+msgstr "關閉(&C)"
+
+#: ../src/common/prntbase.cpp:2085
+msgid "Could not start document preview."
+msgstr "無法啟動文件預覽。"
+
+#: ../src/common/prntbase.cpp:2085 ../src/common/prntbase.cpp:2129
+#: ../src/common/prntbase.cpp:2137
+msgid "Print Preview Failure"
+msgstr "預覽列印失敗"
+
+#: ../src/common/prntbase.cpp:2129 ../src/common/prntbase.cpp:2137
+msgid "Sorry, not enough memory to create a preview."
+msgstr "抱歉，記憶體不足，以致無法創建預覽。"
+
+#: ../src/common/prntbase.cpp:2144
+#, c-format
+msgid "Page %d of %d"
+msgstr "第 %d / %d 頁"
+
+#: ../src/common/prntbase.cpp:2146
+#, c-format
+msgid "Page %d"
+msgstr "第 %d 頁"
+
+#: ../src/common/regex.cpp:382 ../src/html/chm.cpp:348
+msgid "unknown error"
+msgstr "未知的錯誤"
+
+#: ../src/common/regex.cpp:995
+#, c-format
+msgid "Invalid regular expression '%s': %s"
+msgstr "無效的正則表達式 ‘%s’: %s"
+
+#: ../src/common/regex.cpp:1059
+#, c-format
+msgid "Failed to find match for regular expression: %s"
+msgstr "找不到與正規運算式 %s 相符的字串"
+
+#: ../src/common/rendcmn.cpp:188
+#, c-format
+msgid "Renderer \"%s\" has incompatible version %d.%d and couldn't be loaded."
+msgstr "模擬描繪器 “%s” 的 %d.%d 版本有相容性問題，無法載入。"
+
+#: ../src/common/secretstore.cpp:162
+msgid "Not available for this platform"
+msgstr "不適用於此平台"
+
+#: ../src/common/secretstore.cpp:183
+#, c-format
+msgid "Saving password for \"%s\" failed: %s."
+msgstr "無法儲存 “%s” 的密碼：%s。"
+
+#: ../src/common/secretstore.cpp:205
+#, c-format
+msgid "Reading password for \"%s\" failed: %s."
+msgstr "讀取 “%s” 的密碼失敗：%s。"
+
+#: ../src/common/secretstore.cpp:228
+#, c-format
+msgid "Deleting password for \"%s\" failed: %s."
+msgstr "刪除 “%s” 密碼失敗：%s。"
+
+#: ../src/common/selectdispatcher.cpp:254
+msgid "Failed to monitor I/O channels"
+msgstr "無法監控輸入輸出通道"
+
+#: ../src/common/sizer.cpp:3054 ../src/common/stockitem.cpp:195
+msgid "Save"
+msgstr "儲存"
+
+#: ../src/common/sizer.cpp:3056
+msgid "Don't Save"
+msgstr "不儲存"
+
+#: ../src/common/socket.cpp:870
+msgid "Cannot initialize sockets"
+msgstr "無法初始化通訊端"
+
+#: ../src/common/stockitem.cpp:127
+msgctxt "standard Windows menu"
+msgid "&Help"
+msgstr "說明(&H)"
+
+#: ../src/common/stockitem.cpp:144
+msgid "&About"
+msgstr "關於(&A)"
+
+#: ../src/common/stockitem.cpp:144
+msgid "About"
+msgstr "關於"
+
+#: ../src/common/stockitem.cpp:145
+msgid "Add"
+msgstr "加入"
+
+#: ../src/common/stockitem.cpp:146
+msgid "&Apply"
+msgstr "套用(&A)"
+
+#: ../src/common/stockitem.cpp:146
+msgid "Apply"
+msgstr "套用"
+
+#: ../src/common/stockitem.cpp:147
+msgid "&Back"
+msgstr "上一步(&B)"
+
+#: ../src/common/stockitem.cpp:147
+msgid "Back"
+msgstr "上一步"
+
+#: ../src/common/stockitem.cpp:148
+msgid "&Bold"
+msgstr "粗體(&B)"
+
+#: ../src/common/stockitem.cpp:148 ../src/generic/fontdlgg.cpp:326
+#: ../src/richtext/richtextfontpage.cpp:354
+msgid "Bold"
+msgstr "粗體"
+
+#: ../src/common/stockitem.cpp:149
+msgid "&Bottom"
+msgstr "底端(&B)"
+
+#: ../src/common/stockitem.cpp:149 ../src/richtext/richtextsizepage.cpp:287
+msgid "Bottom"
+msgstr "底端"
+
+#: ../src/common/stockitem.cpp:150 ../src/generic/fontdlgg.cpp:462
+#: ../src/generic/fontdlgg.cpp:481 ../src/generic/wizard.cpp:415
+msgid "&Cancel"
+msgstr "取消(&C)"
+
+#: ../src/common/stockitem.cpp:151
+msgid "&CD-ROM"
+msgstr "光碟(&C)"
+
+#: ../src/common/stockitem.cpp:151
+msgid "CD-ROM"
+msgstr "光碟"
+
+#: ../src/common/stockitem.cpp:152
+msgid "&Clear"
+msgstr "清除(&C)"
+
+#: ../src/common/stockitem.cpp:152
+msgid "Clear"
+msgstr "清除"
+
+#: ../src/common/stockitem.cpp:153 ../src/generic/dbgrptg.cpp:93
+#: ../src/generic/progdlgg.cpp:778 ../src/html/helpdlg.cpp:86
+#: ../src/msw/progdlg.cpp:209 ../src/msw/progdlg.cpp:890
+#: ../src/richtext/richtextstyledlg.cpp:272
+#: ../src/richtext/richtextsymboldlg.cpp:448
+msgid "Close"
+msgstr "關閉"
+
+#: ../src/common/stockitem.cpp:154
+msgid "&Convert"
+msgstr "轉換(&C)"
+
+#: ../src/common/stockitem.cpp:154
+msgid "Convert"
+msgstr "轉換"
+
+#: ../src/common/stockitem.cpp:155 ../src/msw/textctrl.cpp:2884
+#: ../src/osx/textctrl_osx.cpp:653 ../src/richtext/richtextctrl.cpp:331
+msgid "&Copy"
+msgstr "複製(&C)"
+
+#: ../src/common/stockitem.cpp:155 ../src/stc/stc_i18n.cpp:18
+msgid "Copy"
+msgstr "複製"
+
+#: ../src/common/stockitem.cpp:156 ../src/msw/textctrl.cpp:2883
+#: ../src/osx/textctrl_osx.cpp:652 ../src/richtext/richtextctrl.cpp:330
+msgid "Cu&t"
+msgstr "剪下(&T)"
+
+#: ../src/common/stockitem.cpp:156 ../src/stc/stc_i18n.cpp:17
+msgid "Cut"
+msgstr "剪下"
+
+#: ../src/common/stockitem.cpp:157 ../src/msw/textctrl.cpp:2886
+#: ../src/osx/textctrl_osx.cpp:655 ../src/richtext/richtextctrl.cpp:333
+#: ../src/richtext/richtexttabspage.cpp:137
+msgid "&Delete"
+msgstr "刪除(&D)"
+
+#: ../src/common/stockitem.cpp:157 ../src/richtext/richtextbuffer.cpp:8266
+#: ../src/stc/stc_i18n.cpp:20
+msgid "Delete"
+msgstr "刪除"
+
+#: ../src/common/stockitem.cpp:158
+msgid "&Down"
+msgstr "下(&D)"
+
+#: ../src/common/stockitem.cpp:158 ../src/generic/fdrepdlg.cpp:148
+msgid "Down"
+msgstr "下"
+
+#: ../src/common/stockitem.cpp:159
+msgid "&Edit"
+msgstr "編輯(&E)"
+
+#: ../src/common/stockitem.cpp:159
+msgid "Edit"
+msgstr "編輯"
+
+#: ../src/common/stockitem.cpp:160
+msgid "&Execute"
+msgstr "執行(&E)"
+
+#: ../src/common/stockitem.cpp:160
+msgid "Execute"
+msgstr "執行"
+
+#: ../src/common/stockitem.cpp:161
+msgid "&Quit"
+msgstr "結束(&Q)"
+
+#: ../src/common/stockitem.cpp:161
+msgid "Quit"
+msgstr "結束"
+
+#: ../src/common/stockitem.cpp:162
+msgid "&File"
+msgstr "檔案(&F)"
+
+#: ../src/common/stockitem.cpp:162
+msgid "File"
+msgstr "檔案"
+
+#: ../src/common/stockitem.cpp:163
+msgid "&Find..."
+msgstr "尋找(&F)…"
+
+#: ../src/common/stockitem.cpp:163
+msgid "Find..."
+msgstr "尋找…"
+
+#: ../src/common/stockitem.cpp:164
+msgid "&First"
+msgstr "最前(&F)"
+
+#: ../src/common/stockitem.cpp:164
+msgid "First"
+msgstr "最前"
+
+#: ../src/common/stockitem.cpp:165
+msgid "&Floppy"
+msgstr "磁片(&F)"
+
+#: ../src/common/stockitem.cpp:165
+msgid "Floppy"
+msgstr "磁片"
+
+#: ../src/common/stockitem.cpp:166
+msgid "&Forward"
+msgstr "進行轉送"
+
+#: ../src/common/stockitem.cpp:166
+msgid "Forward"
+msgstr "轉送"
+
+#: ../src/common/stockitem.cpp:167
+msgid "&Harddisk"
+msgstr "硬碟(&H)"
+
+#: ../src/common/stockitem.cpp:167
+msgid "Harddisk"
+msgstr "硬碟"
+
+#: ../src/common/stockitem.cpp:168 ../src/generic/wizard.cpp:418
+#: ../src/osx/cocoa/menu.mm:225 ../src/richtext/richtextstyledlg.cpp:298
+#: ../src/richtext/richtextsymboldlg.cpp:451
+msgid "&Help"
+msgstr "說明(&H)"
+
+#: ../src/common/stockitem.cpp:169
+msgid "&Home"
+msgstr "首頁(&H)"
+
+#: ../src/common/stockitem.cpp:169
+msgid "Home"
+msgstr "主目錄"
+
+#: ../src/common/stockitem.cpp:170
+msgid "Indent"
+msgstr "縮排"
+
+#: ../src/common/stockitem.cpp:171
+msgid "&Index"
+msgstr "索引(&I)"
+
+#: ../src/common/stockitem.cpp:171 ../src/html/helpwnd.cpp:510
+msgid "Index"
+msgstr "索引"
+
+#: ../src/common/stockitem.cpp:172
+msgid "&Info"
+msgstr "資訊(&I)"
+
+#: ../src/common/stockitem.cpp:172
+msgid "Info"
+msgstr "資訊"
+
+#: ../src/common/stockitem.cpp:173
+msgid "&Italic"
+msgstr "斜體(&I)"
+
+#: ../src/common/stockitem.cpp:173 ../src/generic/fontdlgg.cpp:322
+#: ../src/richtext/richtextfontpage.cpp:350
+msgid "Italic"
+msgstr "斜體"
+
+#: ../src/common/stockitem.cpp:174
+msgid "&Jump to"
+msgstr "跳至(&J)"
+
+#: ../src/common/stockitem.cpp:174
+msgid "Jump to"
+msgstr "跳至"
+
+#: ../src/common/stockitem.cpp:175
+msgid "Centered"
+msgstr "置中對齊"
+
+#: ../src/common/stockitem.cpp:176
+msgid "Justified"
+msgstr "分散對齊"
+
+#: ../src/common/stockitem.cpp:177
+msgid "Align Left"
+msgstr "靠左對齊"
+
+#: ../src/common/stockitem.cpp:178
+msgid "Align Right"
+msgstr "靠右對齊"
+
+#: ../src/common/stockitem.cpp:179
+msgid "&Last"
+msgstr "最後(&L)"
+
+#: ../src/common/stockitem.cpp:179
+msgid "Last"
+msgstr "最後"
+
+#: ../src/common/stockitem.cpp:180
+msgid "&Network"
+msgstr "網路(&N)"
+
+#: ../src/common/stockitem.cpp:180
+msgid "Network"
+msgstr "網路"
+
+#: ../src/common/stockitem.cpp:181 ../src/richtext/richtexttabspage.cpp:131
+msgid "&New"
+msgstr "新增(&N)"
+
+#: ../src/common/stockitem.cpp:181
+msgid "New"
+msgstr "新增"
+
+#: ../src/common/stockitem.cpp:182 ../src/msw/msgdlg.cpp:417
+msgid "&No"
+msgstr "否(&N)"
+
+#: ../src/common/stockitem.cpp:183 ../src/generic/fontdlgg.cpp:467
+#: ../src/generic/fontdlgg.cpp:474
+msgid "&OK"
+msgstr "確認(&O)"
+
+#: ../src/common/stockitem.cpp:184 ../src/generic/dbgrptg.cpp:341
+msgid "&Open..."
+msgstr "開啟(&O)…"
+
+#: ../src/common/stockitem.cpp:184
+msgid "Open..."
+msgstr "開啟..."
+
+#: ../src/common/stockitem.cpp:185 ../src/msw/textctrl.cpp:2885
+#: ../src/osx/textctrl_osx.cpp:654 ../src/richtext/richtextctrl.cpp:332
+msgid "&Paste"
+msgstr "貼上(&P)"
+
+#: ../src/common/stockitem.cpp:185 ../src/richtext/richtextctrl.cpp:3484
+#: ../src/stc/stc_i18n.cpp:19
+msgid "Paste"
+msgstr "貼上"
+
+#: ../src/common/stockitem.cpp:186
+msgid "&Preferences"
+msgstr "喜好設定(&P)"
+
+#: ../src/common/stockitem.cpp:186 ../src/osx/cocoa/preferences.mm:304
+msgid "Preferences"
+msgstr "喜好設定"
+
+#: ../src/common/stockitem.cpp:187
+msgid "Print previe&w..."
+msgstr "預覽列印(&W)..."
+
+#: ../src/common/stockitem.cpp:187
+msgid "Print preview..."
+msgstr "預覽列印..."
+
+#: ../src/common/stockitem.cpp:188
+msgid "&Print..."
+msgstr "列印(&P)…"
+
+#: ../src/common/stockitem.cpp:188
+msgid "Print..."
+msgstr "列印..."
+
+#: ../src/common/stockitem.cpp:189 ../src/richtext/richtextctrl.cpp:337
+#: ../src/richtext/richtextctrl.cpp:5479
+msgid "&Properties"
+msgstr "屬性(&P)"
+
+#: ../src/common/stockitem.cpp:189
+msgid "Properties"
+msgstr "屬性"
+
+#: ../src/common/stockitem.cpp:190 ../src/stc/stc_i18n.cpp:16
+msgid "Redo"
+msgstr "重做"
+
+#: ../src/common/stockitem.cpp:191
+msgid "Refresh"
+msgstr "重新整理"
+
+#: ../src/common/stockitem.cpp:192
+msgid "Remove"
+msgstr "移除"
+
+#: ../src/common/stockitem.cpp:193
+msgid "Rep&lace..."
+msgstr "更換(&L)…"
+
+#: ../src/common/stockitem.cpp:193
+msgid "Replace..."
+msgstr "更換…"
+
+#: ../src/common/stockitem.cpp:194
+msgid "Revert to Saved"
+msgstr "恢復為上次儲存的檔案"
+
+#: ../src/common/stockitem.cpp:196 ../src/generic/logg.cpp:549
+msgid "Save &As..."
+msgstr "另存新檔(&A)…"
+
+#: ../src/common/stockitem.cpp:196
+msgid "Save As..."
+msgstr "另存新檔(&A)…"
+
+#: ../src/common/stockitem.cpp:197 ../src/msw/textctrl.cpp:2888
+#: ../src/osx/textctrl_osx.cpp:657 ../src/richtext/richtextctrl.cpp:335
+msgid "Select &All"
+msgstr "全部選擇(&A)"
+
+#: ../src/common/stockitem.cpp:197 ../src/stc/stc_i18n.cpp:21
+msgid "Select All"
+msgstr "全部選擇"
+
+#: ../src/common/stockitem.cpp:198
+msgid "&Color"
+msgstr "顏色(&C)"
+
+#: ../src/common/stockitem.cpp:198
+msgid "Color"
+msgstr "顏色"
+
+#: ../src/common/stockitem.cpp:199
+msgid "&Font"
+msgstr "字型(&F)"
+
+#: ../src/common/stockitem.cpp:199 ../src/richtext/richtextformatdlg.cpp:336
+msgid "Font"
+msgstr "字型"
+
+#: ../src/common/stockitem.cpp:200
+msgid "&Ascending"
+msgstr "遞增(&A)"
+
+#: ../src/common/stockitem.cpp:200
+msgid "Ascending"
+msgstr "遞增"
+
+#: ../src/common/stockitem.cpp:201
+msgid "&Descending"
+msgstr "遞減(&D)"
+
+#: ../src/common/stockitem.cpp:201
+msgid "Descending"
+msgstr "遞減"
+
+#: ../src/common/stockitem.cpp:202
+msgid "&Spell Check"
+msgstr "拼字檢查(&S)"
+
+#: ../src/common/stockitem.cpp:202
+msgid "Spell Check"
+msgstr "拼字檢查"
+
+#: ../src/common/stockitem.cpp:203
+msgid "&Stop"
+msgstr "停止(&S)"
+
+#: ../src/common/stockitem.cpp:203
+msgid "Stop"
+msgstr "停止"
+
+#: ../src/common/stockitem.cpp:204 ../src/richtext/richtextfontpage.cpp:274
+msgid "&Strikethrough"
+msgstr "刪除線(&S)"
+
+#: ../src/common/stockitem.cpp:204
+msgid "Strikethrough"
+msgstr "刪除線"
+
+#: ../src/common/stockitem.cpp:205
+msgid "&Top"
+msgstr "頂端(&T)"
+
+#: ../src/common/stockitem.cpp:205 ../src/richtext/richtextsizepage.cpp:285
+#: ../src/richtext/richtextsizepage.cpp:289
+msgid "Top"
+msgstr "頂端"
+
+#: ../src/common/stockitem.cpp:206
+msgid "Undelete"
+msgstr "取消刪除"
+
+#: ../src/common/stockitem.cpp:207 ../src/generic/fontdlgg.cpp:437
+msgid "&Underline"
+msgstr "底線(&U)"
+
+#: ../src/common/stockitem.cpp:207
+msgid "Underline"
+msgstr "底線"
+
+#: ../src/common/stockitem.cpp:208 ../src/stc/stc_i18n.cpp:15
+msgid "Undo"
+msgstr "復原"
+
+#: ../src/common/stockitem.cpp:209
+msgid "&Unindent"
+msgstr "取消縮排(&U)"
+
+#: ../src/common/stockitem.cpp:209
+msgid "Unindent"
+msgstr "取消縮排"
+
+#: ../src/common/stockitem.cpp:210
+msgid "&Up"
+msgstr "向上(&U)"
+
+#: ../src/common/stockitem.cpp:210 ../src/generic/fdrepdlg.cpp:148
+msgid "Up"
+msgstr "上"
+
+#: ../src/common/stockitem.cpp:211 ../src/msw/msgdlg.cpp:417
+msgid "&Yes"
+msgstr "是(&Y)"
+
+#: ../src/common/stockitem.cpp:212
+msgid "&Actual Size"
+msgstr "實際大小(&A)"
+
+#: ../src/common/stockitem.cpp:212
+msgid "Actual Size"
+msgstr "實際大小`"
+
+#: ../src/common/stockitem.cpp:213
+msgid "Zoom to &Fit"
+msgstr "縮放以適應視窗(&F)"
+
+#: ../src/common/stockitem.cpp:213
+msgid "Zoom to Fit"
+msgstr "縮放以適應視窗"
+
+#: ../src/common/stockitem.cpp:214
+msgid "Zoom &In"
+msgstr "放大(&I)"
+
+#: ../src/common/stockitem.cpp:215
+msgid "Zoom &Out"
+msgstr "縮小(&O)"
+
+#: ../src/common/stockitem.cpp:262
+msgid "Show about dialog"
+msgstr "顯示關於對話方塊"
+
+#: ../src/common/stockitem.cpp:263
+msgid "Copy selection"
+msgstr "複製選取"
+
+#: ../src/common/stockitem.cpp:264
+msgid "Cut selection"
+msgstr "剪下選取"
+
+#: ../src/common/stockitem.cpp:265
+msgid "Delete selection"
+msgstr "刪除選取"
+
+#: ../src/common/stockitem.cpp:266
+msgid "Find in document"
+msgstr "在文件中尋找"
+
+#: ../src/common/stockitem.cpp:267
+msgid "Find and replace in document"
+msgstr "在文件中尋找並更換"
+
+#: ../src/common/stockitem.cpp:268
+msgid "Paste selection"
+msgstr "貼上選取"
+
+#: ../src/common/stockitem.cpp:269
+msgid "Quit this program"
+msgstr "結束這個程式"
+
+#: ../src/common/stockitem.cpp:270
+msgid "Redo last action"
+msgstr "重做上一個動作"
+
+#: ../src/common/stockitem.cpp:271
+msgid "Undo last action"
+msgstr "復原最後一個動作"
+
+#: ../src/common/stockitem.cpp:272
+msgid "Create new document"
+msgstr "創建新文件"
+
+#: ../src/common/stockitem.cpp:273
+msgid "Open an existing document"
+msgstr "開啟現有文件"
+
+#: ../src/common/stockitem.cpp:274
+msgid "Close current document"
+msgstr "關閉目前文件"
+
+#: ../src/common/stockitem.cpp:275
+msgid "Save current document"
+msgstr "儲存目前文件"
+
+#: ../src/common/stockitem.cpp:276
+msgid "Save current document with a different filename"
+msgstr "儲存目前文件並使用不同檔名"
+
+#: ../src/common/strconv.cpp:2324
+#, c-format
+msgid "Conversion to charset '%s' doesn't work."
+msgstr "無法轉換到 '%s' 字集。"
+
+#: ../src/common/tarstrm.cpp:352 ../src/common/tarstrm.cpp:375
+#: ../src/common/tarstrm.cpp:406 ../src/generic/progdlgg.cpp:373
+msgid "unknown"
+msgstr "未知"
+
+#: ../src/common/tarstrm.cpp:774
+msgid "incomplete header block in tar"
+msgstr "tar 的表頭區塊不完整"
+
+#: ../src/common/tarstrm.cpp:798
+msgid "checksum failure reading tar header block"
+msgstr "讀取 tar 表頭區塊時發生檢查碼錯誤"
+
+#: ../src/common/tarstrm.cpp:971
+msgid "invalid data in extended tar header"
+msgstr "tar 擴充表頭中有無效的資料"
+
+#: ../src/common/tarstrm.cpp:981 ../src/common/tarstrm.cpp:1003
+#: ../src/common/tarstrm.cpp:1477 ../src/common/tarstrm.cpp:1499
+msgid "tar entry not open"
+msgstr "tar 項目未開啟"
+
+#: ../src/common/tarstrm.cpp:1023
+msgid "unexpected end of file"
+msgstr "異常的檔案結尾"
+
+#: ../src/common/tarstrm.cpp:1297
+#, c-format
+msgid "%s did not fit the tar header for entry '%s'"
+msgstr "%s 不適用於 ‘%s’ 項目的 tar 表頭"
+
+#: ../src/common/tarstrm.cpp:1359
+msgid "incorrect size given for tar entry"
+msgstr "指定的 tar 項目大小不正確"
+
+#: ../src/common/textbuf.cpp:232
+#, c-format
+msgid "'%s' is probably a binary buffer."
+msgstr "'%s' 或許是個二進位緩衝區。"
+
+#: ../src/common/textcmn.cpp:1006 ../src/richtext/richtextctrl.cpp:3053
+msgid "File couldn't be loaded."
+msgstr "無法載入檔案。"
+
+#: ../src/common/textfile.cpp:95
+#, c-format
+msgid "Failed to read text file \"%s\"."
+msgstr "無法讀取 “%s” 文字檔案。"
+
+#: ../src/common/textfile.cpp:160
+#, c-format
+msgid "can't write buffer '%s' to disk."
+msgstr "無法將緩衝區 '%s' 寫到磁碟。"
+
+#: ../src/common/time.cpp:212
+msgid "Failed to get the local system time"
+msgstr "無法取得本機系統的時間"
+
+#: ../src/common/time.cpp:279
+msgid "wxGetTimeOfDay failed."
+msgstr "wxGetTimeOfDay 失敗。"
+
+#: ../src/common/translation.cpp:929
+#, c-format
+msgid "'%s' is not a valid message catalog."
+msgstr "'%s' 不是有效的訊息記錄。"
+
+#: ../src/common/translation.cpp:954
+msgid "Invalid message catalog."
+msgstr "無效的訊息記錄。"
+
+#: ../src/common/translation.cpp:1013
+#, c-format
+msgid "Failed to parse Plural-Forms: '%s'"
+msgstr "無法解析眾數型式(Plural-Forms)：'%s'"
+
+#: ../src/common/translation.cpp:1723
+#, c-format
+msgid "using catalog '%s' from '%s'."
+msgstr "使用記錄 '%s' — '%s'。"
+
+#: ../src/common/translation.cpp:1816
+#, c-format
+msgid "Resource '%s' is not a valid message catalog."
+msgstr "'%s' 資源不是有效的訊息記錄。"
+
+#: ../src/common/translation.cpp:1865
+msgid "Couldn't enumerate translations"
+msgstr "無法列舉翻譯"
+
+#: ../src/common/utilscmn.cpp:1145
+msgid "No default application configured for HTML files."
+msgstr "沒有專為 HTML 檔案而架構的預設程式。"
+
+#: ../src/common/utilscmn.cpp:1190
+#, c-format
+msgid "Failed to open URL \"%s\" in default browser."
+msgstr "無法在預設瀏覽器中開啟網址 ”%s”。"
+
+#: ../src/common/valtext.cpp:144
+msgid "Validation conflict"
+msgstr "驗證衝突"
+
+#: ../src/common/valtext.cpp:186
+msgid "Required information entry is empty."
+msgstr "必要的資訊項目仍空無一物。"
+
+#: ../src/common/valtext.cpp:188
+#, c-format
+msgid "'%s' is one of the invalid strings"
+msgstr "'%s' 是無效字串之一"
+
+#: ../src/common/valtext.cpp:190
+#, c-format
+msgid "'%s' is not one of the valid strings"
+msgstr "‘%s’ 不是有效的字串"
+
+#: ../src/common/valtext.cpp:199
+#, c-format
+msgid "'%s' contains invalid character(s)"
+msgstr "'%s' 含有無效字元"
+
+#: ../src/common/webrequest.cpp:139
+#, c-format
+msgid "Error: %s (%d)"
+msgstr "錯誤：%s (%d)"
+
+#: ../src/common/webrequest.cpp:655
+#, fuzzy, c-format
+msgid ""
+"Not enough free disk space for download: %llu needed but only %llu available."
+msgstr "沒有足夠磁碟空間可供下載。"
+
+#: ../src/common/webrequest.cpp:669
+#, fuzzy, c-format
+msgid "Failed to create temporary file in %s"
+msgstr "無法創建暫存檔的檔名"
+
+#: ../src/common/webrequest_curl.cpp:1106
+msgid "libcurl could not be initialized"
+msgstr "無法初始化 libcurl"
+
+#: ../src/common/webview.cpp:392
+msgid "RunScriptAsync not supported"
+msgstr "RunScriptAsync 仍未支援"
+
+#: ../src/common/webview.cpp:403 ../src/msw/webview_ie.cpp:1073
+#, c-format
+msgid "Error running JavaScript: %s"
+msgstr "執行 JavaScript 時發生錯誤：%s"
+
+#: ../src/common/webview_chromium.cpp:858
+#, fuzzy, c-format
+msgid "Failed to set proxy \"%s\": %s"
+msgstr "無法創建目錄 \"%s”"
+
+#: ../src/common/webview_chromium.cpp:989
+msgid ""
+"Chromium can't be used because libcef.so wasn't loaded early enough; please "
+"relink the application or use LD_PRELOAD to load it earlier."
+msgstr ""
+
+#: ../src/common/webview_chromium.cpp:1108
+#, fuzzy
+msgid "Could not initialize Chromium"
+msgstr "無法初始化 libnotify。"
+
+#: ../src/common/webview_chromium.cpp:1616
+msgid "Show DevTools"
+msgstr ""
+
+#: ../src/common/webview_chromium.cpp:1617
+#, fuzzy
+msgid "Close DevTools"
+msgstr "全部關閉"
+
+#: ../src/common/webview_chromium.cpp:1623
+msgid "Inspect"
+msgstr ""
+
+#: ../src/common/wincmn.cpp:1628
+msgid "This platform does not support background transparency."
+msgstr "這個平臺不支援透明背景。"
+
+#: ../src/common/wincmn.cpp:2097
+msgid "Could not transfer data to window"
+msgstr "無法傳輸資料到視窗中"
+
+#: ../src/common/windowid.cpp:240
+msgid "Out of window IDs.  Recommend shutting down application."
+msgstr "Window ID 已用完，建議關閉應用程式。"
+
+#: ../src/common/xpmdecod.cpp:678
+msgid "XPM: incorrect header format!"
+msgstr "XPM：表頭格式不正確！"
+
+#: ../src/common/xpmdecod.cpp:703
+#, c-format
+msgid "XPM: incorrect colour description in line %d"
+msgstr "XPM：第 %d 列裡的顏色說明不正確"
+
+#: ../src/common/xpmdecod.cpp:715 ../src/common/xpmdecod.cpp:724
+#, c-format
+msgid "XPM: malformed colour definition '%s' at line %d!"
+msgstr "XPM：顏色定義 '%s' 於第 %d 列不正確！"
+
+#: ../src/common/xpmdecod.cpp:754
+msgid "XPM: no colors left to use for mask!"
+msgstr "XPM：已無可用於遮罩的顏色！"
+
+#: ../src/common/xpmdecod.cpp:781
+#, c-format
+msgid "XPM: truncated image data at line %d!"
+msgstr "XPM：影像資料於第 %d 列被截切！"
+
+#: ../src/common/xpmdecod.cpp:795
+msgid "XPM: Malformed pixel data!"
+msgstr "XPM：圖素資料格式不對！"
+
+#: ../src/common/xti.cpp:492
+msgid "Illegal Parameter Count for Create Method"
+msgstr "針對 Create 方法的參數計數不合規範"
+
+#: ../src/common/xti.cpp:504
+msgid "Illegal Parameter Count for ConstructObject Method"
+msgstr "針對 ConstructObject 方法的參數計數不合規範"
+
+#: ../src/common/xtistrm.cpp:161
+#, c-format
+msgid "Create Parameter %s not found in declared RTTI Parameters"
+msgstr "宣告的 RTTI 參數中找不到創建的參數 %s"
+
+#: ../src/common/xtistrm.cpp:290
+msgid "Illegal Object Class (Non-wxEvtHandler) as Event Source"
+msgstr "作為事件來源的物件類別 (非-wxEvtHandler) 不合規範"
+
+#: ../src/common/xtistrm.cpp:313 ../src/common/xtixml.cpp:345
+#: ../src/common/xtixml.cpp:498
+msgid "Type must have enum - long conversion"
+msgstr "必須進行 enum - long 的類型轉換"
+
+#: ../src/common/xtistrm.cpp:400 ../src/common/xtistrm.cpp:415
+msgid "Invalid or Null Object ID passed to GetObjectClassInfo"
+msgstr "傳給 GetObjectClassInfo 的物件 ID 是無效或是空的"
+
+#: ../src/common/xtistrm.cpp:405
+msgid "Unknown Object passed to GetObjectClassInfo"
+msgstr "傳給 GetObjectClassInfo 是未知物件"
+
+#: ../src/common/xtistrm.cpp:420
+msgid "Already Registered Object passed to SetObjectClassInfo"
+msgstr "傳給 SetObjectClassInfo 的是已註冊物件"
+
+#: ../src/common/xtistrm.cpp:430
+msgid "Invalid or Null Object ID passed to HasObjectClassInfo"
+msgstr "傳給HasObjectClassInfo的物件ID無效或是空的"
+
+#: ../src/common/xtistrm.cpp:460
+msgid "Passing a already registered object to SetObject"
+msgstr "傳入已註冊的物件給 SetObject"
+
+#: ../src/common/xtistrm.cpp:471
+msgid "Passing an unknown object to GetObject"
+msgstr "傳入未知物件給 GetObject"
+
+#: ../src/common/xtixml.cpp:229
+msgid "Forward hrefs are not supported"
+msgstr "不支援轉送 hrefs"
+
+#: ../src/common/xtixml.cpp:247
+#, c-format
+msgid "unknown class %s"
+msgstr "未知的類別 %s"
+
+#: ../src/common/xtixml.cpp:253
+msgid "objects cannot have XML Text Nodes"
+msgstr "物件不能有 XML 文字子節點"
+
+#: ../src/common/xtixml.cpp:258
+msgid "Objects must have an id attribute"
+msgstr "物件必須有 id 屬性"
+
+#: ../src/common/xtixml.cpp:267
+#, c-format
+msgid "Doubly used id : %d"
+msgstr "雙重使用 id ：%d"
+
+#: ../src/common/xtixml.cpp:316
+#, c-format
+msgid "Unknown Property %s"
+msgstr "未知屬性 %s"
+
+#: ../src/common/xtixml.cpp:407
+msgid "A non empty collection must consist of 'element' nodes"
+msgstr "非空集合必須包含 'element' 節點"
+
+#: ../src/common/xtixml.cpp:478
+msgid "incorrect event handler string, missing dot"
+msgstr "不正確的事件處理常式字串，缺少小點"
+
+#: ../src/common/zipstrm.cpp:559
+msgid "can't re-initialize zlib deflate stream"
+msgstr "無法重新初始化 zlib 壓縮串流"
+
+#: ../src/common/zipstrm.cpp:584
+msgid "can't re-initialize zlib inflate stream"
+msgstr "無法重新初始化 zlib 解壓串流"
+
+#: ../src/common/zipstrm.cpp:1023
+msgid "Ignoring malformed extra data record, ZIP file may be corrupted"
+msgstr "忽略格式錯誤的延伸資料記錄，ZIP 檔案可能已損壞"
+
+#: ../src/common/zipstrm.cpp:1502
+msgid "assuming this is a multi-part zip concatenated"
+msgstr "假設這是一個多重部分 zip 的結合"
+
+#: ../src/common/zipstrm.cpp:1664
+msgid "invalid zip file"
+msgstr "無效的 zip 檔案"
+
+#: ../src/common/zipstrm.cpp:1723
+msgid "can't find central directory in zip"
+msgstr "無法在 zip 檔中找到中心目錄"
+
+#: ../src/common/zipstrm.cpp:1812
+msgid "error reading zip central directory"
+msgstr "讀取 zip 中心目錄發生錯誤"
+
+#: ../src/common/zipstrm.cpp:1916
+msgid "error reading zip local header"
+msgstr "讀取 zip 本地表頭時發生錯誤"
+
+#: ../src/common/zipstrm.cpp:1964
+msgid "bad zipfile offset to entry"
+msgstr "損壞的 zip 檔案移動至項目"
+
+#: ../src/common/zipstrm.cpp:2031
+msgid "stored file length not in Zip header"
+msgstr "儲存的檔案長度不在 Zip 表頭中"
+
+#: ../src/common/zipstrm.cpp:2045 ../src/common/zipstrm.cpp:2362
+msgid "unsupported Zip compression method"
+msgstr "不支援的 Zip 壓縮方法"
+
+#: ../src/common/zipstrm.cpp:2126
+#, c-format
+msgid "reading zip stream (entry %s): bad length"
+msgstr "讀取 zip 串流 (條目 %s): 不良的長度"
+
+#: ../src/common/zipstrm.cpp:2131
+#, c-format
+msgid "reading zip stream (entry %s): bad crc"
+msgstr "讀取 zip 串流 (條目 %s): 不良的 crc"
+
+#: ../src/common/zipstrm.cpp:2578
+#, c-format
+msgid "error writing zip entry '%s': file too large without ZIP64"
+msgstr "寫入 zip 條目 '%s' 時發生錯誤：檔案過大，且沒有 ZIP64"
+
+#: ../src/common/zipstrm.cpp:2585
+#, c-format
+msgid "error writing zip entry '%s': bad crc or length"
+msgstr "寫入 zip 條目 '%s' 時發生錯誤：不當的 crc 或長度"
+
+#: ../src/common/zstream.cpp:155 ../src/common/zstream.cpp:315
+msgid "Gzip not supported by this version of zlib"
+msgstr "這一版的 zlib 不支援 Gzip"
+
+#: ../src/common/zstream.cpp:182
+msgid "Can't initialize zlib inflate stream."
+msgstr "無法初始化 zlib 解壓資料流。"
+
+#: ../src/common/zstream.cpp:241
+msgid "Can't read inflate stream: unexpected EOF in underlying stream."
+msgstr "無法讀取解壓資料流：資料流中有異樣的結尾。"
+
+#: ../src/common/zstream.cpp:248 ../src/common/zstream.cpp:423
+#, c-format
+msgid "zlib error %d"
+msgstr "zlib 錯誤碼 %d"
+
+#: ../src/common/zstream.cpp:249
+#, c-format
+msgid "Can't read from inflate stream: %s"
+msgstr "無法讀取解壓資料流：%s"
+
+#: ../src/common/zstream.cpp:343
+msgid "Can't initialize zlib deflate stream."
+msgstr "無法初始化 zlib 壓縮資料流。"
+
+#: ../src/common/zstream.cpp:424
+#, c-format
+msgid "Can't write to deflate stream: %s"
+msgstr "無法寫入壓縮資料流：%s"
+
+#: ../src/dfb/bitmap.cpp:633 ../src/dfb/bitmap.cpp:667
+#, c-format
+msgid "No bitmap handler for type %d defined."
+msgstr "沒有定義 %d 類型的點陣圖處理常式。"
+
+#: ../src/dfb/evtloop.cpp:99
+msgid "Failed to read event from DirectFB pipe"
+msgstr "無法從 DirectFB 管線讀取事件"
+
+#: ../src/dfb/evtloop.cpp:171
+msgid "Failed to switch DirectFB pipe to non-blocking mode"
+msgstr "無法切換 DirectFB 管線到非阻斷模式"
+
+#: ../src/dfb/fontmgr.cpp:171
+#, c-format
+msgid "no fonts found in %s, using builtin font"
+msgstr "在 %s 裡沒有找到字型，將使用內建字型"
+
+#: ../src/dfb/fontmgr.cpp:177
+msgid "Default font"
+msgstr "預設字型"
+
+#: ../src/dfb/fontmgr.cpp:195
+#, c-format
+msgid "Fonts index file %s disappeared while loading fonts."
+msgstr "字型索引檔 %s 在載入字型時不見了。"
+
+#: ../src/dfb/wrapdfb.cpp:60
+#, c-format
+msgid "DirectFB error %d occurred."
+msgstr "發生 DirectFB %d 錯誤。"
+
+#: ../src/generic/aboutdlgg.cpp:69
+msgid "Developed by "
+msgstr "開發團隊： "
+
+#: ../src/generic/aboutdlgg.cpp:72
+msgid "Documentation by "
+msgstr "說明文件發布者： "
+
+#: ../src/generic/aboutdlgg.cpp:75
+msgid "Graphics art by "
+msgstr "美術設計： "
+
+#: ../src/generic/aboutdlgg.cpp:78
+msgid "Translations by "
+msgstr "翻譯團隊： "
+
+#: ../src/generic/aboutdlgg.cpp:133 ../src/osx/cocoa/aboutdlg.mm:83
+msgid "Version "
+msgstr "版本 "
+
+#. TRANSLATORS: %s is application name
+#: ../src/generic/aboutdlgg.cpp:146 ../src/msw/aboutdlg.cpp:60
+#, c-format
+msgid "About %s"
+msgstr "關於 %s"
+
+#: ../src/generic/aboutdlgg.cpp:181
+msgid "License"
+msgstr "授權"
+
+#: ../src/generic/aboutdlgg.cpp:184
+msgid "Developers"
+msgstr "開發者"
+
+#: ../src/generic/aboutdlgg.cpp:188
+msgid "Documentation writers"
+msgstr "文件撰寫者"
+
+#: ../src/generic/aboutdlgg.cpp:192
+msgid "Artists"
+msgstr "藝術家"
+
+#: ../src/generic/aboutdlgg.cpp:196
+msgid "Translators"
+msgstr "翻譯者"
+
+#: ../src/generic/animateg.cpp:125
+msgid "No handler found for animation type."
+msgstr "沒有找到動畫類型處理常式。"
+
+#: ../src/generic/animateg.cpp:133
+#, c-format
+msgid "No animation handler for type %ld defined."
+msgstr "沒有定義 %ld 類型的動畫處理常式。"
+
+#: ../src/generic/animateg.cpp:145
+#, c-format
+msgid "Animation file is not of type %ld."
+msgstr "動畫檔不是 %ld 的型態。"
+
+#: ../src/generic/colrdlgg.cpp:154 ../src/gtk/colordlg.cpp:47
+msgid "Choose colour"
+msgstr "選擇顏色"
+
+#: ../src/generic/colrdlgg.cpp:357
+msgid "Red:"
+msgstr "紅色："
+
+#: ../src/generic/colrdlgg.cpp:360
+msgid "Green:"
+msgstr "綠色："
+
+#: ../src/generic/colrdlgg.cpp:363
+msgid "Blue:"
+msgstr "藍色："
+
+#: ../src/generic/colrdlgg.cpp:372
+msgid "Opacity:"
+msgstr "混濁度："
+
+#: ../src/generic/colrdlgg.cpp:384
+msgid "Add to custom colours"
+msgstr "加到自訂顏色"
+
+#: ../src/generic/creddlgg.cpp:56
+msgid "Username:"
+msgstr "使用者名稱："
+
+#: ../src/generic/creddlgg.cpp:63
+msgid "Password:"
+msgstr "密碼："
+
+#. TRANSLATORS: Name of Boolean true value
+#: ../src/generic/datavgen.cpp:1178
+msgid "true"
+msgstr "真"
+
+#. TRANSLATORS: Name of Boolean false value
+#: ../src/generic/datavgen.cpp:1180
+msgid "false"
+msgstr "假"
+
+#: ../src/generic/datavgen.cpp:6897
+#, c-format
+msgid "Row %i"
+msgstr "第 %i 行"
+
+#. TRANSLATORS: Action for manipulating a tree control
+#: ../src/generic/datavgen.cpp:6987
+msgid "Collapse"
+msgstr "摺疊"
+
+#. TRANSLATORS: Action for manipulating a tree control
+#: ../src/generic/datavgen.cpp:6990
+msgid "Expand"
+msgstr "展開"
+
+#. TRANSLATORS: Name of data view control and number of rows
+#: ../src/generic/datavgen.cpp:7011
+#, c-format
+msgid "%s (%d items)"
+msgstr "%s (%d 個項目)"
+
+#: ../src/generic/datavgen.cpp:7062
+#, c-format
+msgid "Column %u"
+msgstr "欄位 %u"
+
+#. TRANSLATORS: Keystroke for manipulating a tree control
+#: ../src/generic/datavgen.cpp:7131 ../src/richtext/richtextbulletspage.cpp:189
+#: ../src/richtext/richtextbulletspage.cpp:192
+#: ../src/richtext/richtextbulletspage.cpp:193
+#: ../src/richtext/richtextliststylepage.cpp:252
+#: ../src/richtext/richtextliststylepage.cpp:255
+#: ../src/richtext/richtextliststylepage.cpp:256
+#: ../src/richtext/richtextsizepage.cpp:248
+msgid "Left"
+msgstr "左"
+
+#. TRANSLATORS: Keystroke for manipulating a tree control
+#: ../src/generic/datavgen.cpp:7134 ../src/richtext/richtextbulletspage.cpp:191
+#: ../src/richtext/richtextliststylepage.cpp:254
+#: ../src/richtext/richtextsizepage.cpp:249
+msgid "Right"
+msgstr "右"
+
+#: ../src/generic/datectlg.cpp:90
+#, c-format
+msgid ""
+"\"%s\" is not in the expected date format, please enter it as e.g. \"%s\"."
+msgstr ""
+
+#: ../src/generic/datectlg.cpp:94
+#, fuzzy
+msgid "Invalid date"
+msgstr "無效的資料檢視項目"
+
+#: ../src/generic/dbgrptg.cpp:159
+#, c-format
+msgid "Open file \"%s\""
+msgstr "開啟 “%s” 檔案"
+
+#: ../src/generic/dbgrptg.cpp:170
+#, c-format
+msgid "Enter command to open file \"%s\":"
+msgstr "輸入指令以開啟 “%s” 檔案:"
+
+#: ../src/generic/dbgrptg.cpp:230
+msgid "Executable files (*.exe)|*.exe|"
+msgstr "可執行檔 (*.exe)|*.exe|"
+
+#: ../src/generic/dbgrptg.cpp:300
+#, c-format
+msgid "Debug report \"%s\""
+msgstr "偵錯報告 \"%s\""
+
+#: ../src/generic/dbgrptg.cpp:316
+msgid "A debug report has been generated in the directory\n"
+msgstr "產生了一份偵錯報告, 位於目錄\n"
+
+#: ../src/generic/dbgrptg.cpp:317
+msgid "The following debug report will be generated\n"
+msgstr "即將產出下列的偵錯報告\n"
+
+#: ../src/generic/dbgrptg.cpp:321
+msgid ""
+"The report contains the files listed below. If any of these files contain "
+"private information,\n"
+"please uncheck them and they will be removed from the report.\n"
+msgstr ""
+"報告包含了以下檔案。如果這些檔案含有私人資訊，\n"
+"請去掉其勾選，那些檔案就會從報告移除。\n"
+
+#: ../src/generic/dbgrptg.cpp:323
+msgid ""
+"If you wish to suppress this debug report completely, please choose the "
+"\"Cancel\" button,\n"
+"but be warned that it may hinder improving the program, so if\n"
+"at all possible please do continue with the report generation.\n"
+msgstr ""
+"如果想完全停用偵錯報告，請按「取消」按鈕，\n"
+"但不建議這樣做，因為偵錯報告有助於改善本程式。\n"
+"如果可以，請盡量選擇讓程式產生偵錯報告。\n"
+
+#: ../src/generic/dbgrptg.cpp:325
+msgid "              Thank you and we're sorry for the inconvenience!\n"
+msgstr "              謝謝，給您帶來不便請多包涵！\n"
+
+#: ../src/generic/dbgrptg.cpp:333
+msgid "&Debug report preview:"
+msgstr "偵錯報告預覽(&D)："
+
+#: ../src/generic/dbgrptg.cpp:339
+msgid "&View..."
+msgstr "檢視(&V)…"
+
+#: ../src/generic/dbgrptg.cpp:359
+msgid "&Notes:"
+msgstr "附註(&N)："
+
+#: ../src/generic/dbgrptg.cpp:361
+msgid ""
+"If you have any additional information pertaining to this bug\n"
+"report, please enter it here and it will be joined to it:"
+msgstr ""
+"如果有任何與此錯誤報告有關的資訊, \n"
+"請在此輸入，其會被加到錯誤報告："
+
+#: ../src/generic/dcpsg.cpp:1627
+msgid "Cannot open file for PostScript printing!"
+msgstr "無法開啟檔案進行 PostScript 列印！"
+
+#: ../src/generic/dirctrlg.cpp:402
+msgid "Computer"
+msgstr "電腦"
+
+#: ../src/generic/dirctrlg.cpp:404
+msgid "Sections"
+msgstr "章節"
+
+#: ../src/generic/dirctrlg.cpp:482
+msgid "Home directory"
+msgstr "主目錄"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/generic/dirctrlg.cpp:484 ../src/propgrid/advprops.cpp:811
+msgid "Desktop"
+msgstr "桌面"
+
+#: ../src/generic/dirctrlg.cpp:528 ../src/generic/filectrlg.cpp:752
+msgid "Illegal directory name."
+msgstr "目錄名稱不合規範。"
+
+#: ../src/generic/dirctrlg.cpp:528 ../src/generic/dirctrlg.cpp:546
+#: ../src/generic/dirctrlg.cpp:557 ../src/generic/dirdlgg.cpp:317
+#: ../src/generic/filectrlg.cpp:638 ../src/generic/filectrlg.cpp:752
+#: ../src/generic/filectrlg.cpp:766 ../src/generic/filectrlg.cpp:782
+#: ../src/generic/filectrlg.cpp:1356 ../src/generic/filectrlg.cpp:1387
+#: ../src/generic/filedlgg.cpp:362 ../src/gtk/filedlg.cpp:76
+msgid "Error"
+msgstr "錯誤"
+
+#: ../src/generic/dirctrlg.cpp:546 ../src/generic/filectrlg.cpp:766
+msgid "File name exists already."
+msgstr "檔案名稱已存在。"
+
+#: ../src/generic/dirctrlg.cpp:557 ../src/generic/dirdlgg.cpp:317
+#: ../src/generic/filectrlg.cpp:638 ../src/generic/filectrlg.cpp:782
+msgid "Operation not permitted."
+msgstr "非允許的操作。"
+
+#: ../src/generic/dirdlgg.cpp:107 ../src/generic/filedlgg.cpp:207
+msgid "Create new directory"
+msgstr "創建新目錄"
+
+#: ../src/generic/dirdlgg.cpp:112 ../src/generic/filedlgg.cpp:203
+msgid "Go to home directory"
+msgstr "前往主目錄"
+
+#: ../src/generic/dirdlgg.cpp:143
+msgid "Show &hidden directories"
+msgstr "顯示隱藏目錄(&H)"
+
+#: ../src/generic/dirdlgg.cpp:196
+#, c-format
+msgid ""
+"The directory '%s' does not exist\n"
+"Create it now?"
+msgstr ""
+"目錄 '%s' 不存在\n"
+"是否馬上創建？"
+
+#: ../src/generic/dirdlgg.cpp:198
+msgid "Directory does not exist"
+msgstr "目錄不存在"
+
+#: ../src/generic/dirdlgg.cpp:214
+#, c-format
+msgid ""
+"Failed to create directory '%s'\n"
+"(Do you have the required permissions?)"
+msgstr ""
+"無法創建 '%s' 目錄\n"
+"(是否有足夠權限？)"
+
+#: ../src/generic/dirdlgg.cpp:216
+msgid "Error creating directory"
+msgstr "創建目錄錯誤"
+
+#: ../src/generic/dirdlgg.cpp:281
+msgid "You cannot add a new directory to this section."
+msgstr "不能在這區段加入新的目錄。"
+
+#: ../src/generic/dirdlgg.cpp:282
+msgid "Create directory"
+msgstr "創建目錄"
+
+#: ../src/generic/dirdlgg.cpp:291 ../src/generic/dirdlgg.cpp:301
+#: ../src/generic/filectrlg.cpp:614 ../src/generic/filectrlg.cpp:623
+msgid "NewName"
+msgstr "新名稱"
+
+#: ../src/generic/editlbox.cpp:135
+msgid "Edit item"
+msgstr "編輯項目"
+
+#: ../src/generic/editlbox.cpp:143
+msgid "New item"
+msgstr "新增項目"
+
+#: ../src/generic/editlbox.cpp:151
+msgid "Delete item"
+msgstr "刪除項目"
+
+#: ../src/generic/editlbox.cpp:159
+msgid "Move up"
+msgstr "上移"
+
+#: ../src/generic/editlbox.cpp:164
+msgid "Move down"
+msgstr "下移"
+
+#: ../src/generic/fdrepdlg.cpp:108
+msgid "Search for:"
+msgstr "搜尋："
+
+#: ../src/generic/fdrepdlg.cpp:120
+msgid "Replace with:"
+msgstr "更改成："
+
+#: ../src/generic/fdrepdlg.cpp:140
+msgid "Whole word"
+msgstr "整個字"
+
+#: ../src/generic/fdrepdlg.cpp:143
+msgid "Match case"
+msgstr "區分大小寫"
+
+#: ../src/generic/fdrepdlg.cpp:156
+msgid "Search direction"
+msgstr "搜尋方向"
+
+#: ../src/generic/fdrepdlg.cpp:175
+msgid "&Replace"
+msgstr "更改(&R)"
+
+#: ../src/generic/fdrepdlg.cpp:178
+msgid "Replace &all"
+msgstr "全部更改(&A)"
+
+#: ../src/generic/filectrlg.cpp:246 ../src/generic/filectrlg.cpp:269
+msgid "<DIR>"
+msgstr "<目錄>"
+
+#: ../src/generic/filectrlg.cpp:248 ../src/generic/filectrlg.cpp:271
+msgid "<LINK>"
+msgstr "<連結>"
+
+#: ../src/generic/filectrlg.cpp:250 ../src/generic/filectrlg.cpp:273
+msgid "<DRIVE>"
+msgstr "<磁碟機>"
+
+#: ../src/generic/filectrlg.cpp:275
+#, c-format
+msgid "%ld byte"
+msgid_plural "%ld bytes"
+msgstr[0] "%ld 位元"
+
+#: ../src/generic/filectrlg.cpp:420
+msgid "Name"
+msgstr "名稱"
+
+#: ../src/generic/filectrlg.cpp:421 ../src/richtext/richtextformatdlg.cpp:361
+#: ../src/richtext/richtextsizepage.cpp:298
+msgid "Size"
+msgstr "大小"
+
+#: ../src/generic/filectrlg.cpp:422
+msgid "Type"
+msgstr "類型"
+
+#: ../src/generic/filectrlg.cpp:423
+msgid "Modified"
+msgstr "修改日期"
+
+#: ../src/generic/filectrlg.cpp:426
+msgid "Permissions"
+msgstr "權限"
+
+#: ../src/generic/filectrlg.cpp:429
+msgid "Attributes"
+msgstr "屬性"
+
+#: ../src/generic/filectrlg.cpp:936
+msgid "Current directory:"
+msgstr "目前目錄："
+
+#: ../src/generic/filectrlg.cpp:979
+msgid "Show &hidden files"
+msgstr "顯示隱藏檔案(&H)"
+
+#: ../src/generic/filectrlg.cpp:1355
+msgid "Illegal file specification."
+msgstr "檔案描述不合規範。"
+
+#: ../src/generic/filectrlg.cpp:1387
+msgid "Directory doesn't exist."
+msgstr "目錄不存在。"
+
+#: ../src/generic/filedlgg.cpp:195
+msgid "View files as a list view"
+msgstr "按清單檢視檔案"
+
+#: ../src/generic/filedlgg.cpp:197
+msgid "View files as a detailed view"
+msgstr "按詳細資料檢視檔案"
+
+#: ../src/generic/filedlgg.cpp:200
+msgid "Go to parent directory"
+msgstr "前往父系目錄"
+
+#: ../src/generic/filedlgg.cpp:351 ../src/gtk/filedlg.cpp:59
+#, c-format
+msgid "File '%s' already exists, do you really want to overwrite it?"
+msgstr "檔案 '%s' 已存在，是否要覆寫？"
+
+#: ../src/generic/filedlgg.cpp:354 ../src/gtk/filedlg.cpp:62
+msgid "Confirm"
+msgstr "確認"
+
+#: ../src/generic/filedlgg.cpp:362 ../src/gtk/filedlg.cpp:75
+msgid "Please choose an existing file."
+msgstr "請選擇現存的檔案。"
+
+#: ../src/generic/filepickerg.cpp:64
+msgid "..."
+msgstr "..."
+
+#: ../src/generic/fontdlgg.cpp:76 ../src/richtext/richtextformatdlg.cpp:519
+msgid "ABCDEFGabcdefg12345"
+msgstr "ABCDEFGabcdefg12345"
+
+#: ../src/generic/fontdlgg.cpp:315
+msgid "Roman"
+msgstr "羅馬"
+
+#: ../src/generic/fontdlgg.cpp:316
+msgid "Decorative"
+msgstr "修飾"
+
+#: ../src/generic/fontdlgg.cpp:317
+msgid "Modern"
+msgstr "現代"
+
+#: ../src/generic/fontdlgg.cpp:318
+msgid "Script"
+msgstr "程序檔"
+
+#: ../src/generic/fontdlgg.cpp:319
+msgid "Swiss"
+msgstr "瑞士"
+
+#: ../src/generic/fontdlgg.cpp:320
+msgid "Teletype"
+msgstr "電傳打字機"
+
+#: ../src/generic/fontdlgg.cpp:321 ../src/generic/fontdlgg.cpp:324
+msgid "Normal"
+msgstr "正常"
+
+#: ../src/generic/fontdlgg.cpp:323
+msgid "Slant"
+msgstr "傾斜"
+
+#: ../src/generic/fontdlgg.cpp:325
+msgid "Light"
+msgstr "細體"
+
+#: ../src/generic/fontdlgg.cpp:363
+msgid "&Font family:"
+msgstr "字族(&F)："
+
+#: ../src/generic/fontdlgg.cpp:367 ../src/generic/fontdlgg.cpp:369
+msgid "The font family."
+msgstr "字族。"
+
+#: ../src/generic/fontdlgg.cpp:374 ../src/richtext/richtextstylepage.cpp:105
+msgid "&Style:"
+msgstr "樣式(&S)："
+
+#: ../src/generic/fontdlgg.cpp:378 ../src/generic/fontdlgg.cpp:380
+msgid "The font style."
+msgstr "字型樣式。"
+
+#: ../src/generic/fontdlgg.cpp:385
+msgid "&Weight:"
+msgstr "粗細(&W)："
+
+#: ../src/generic/fontdlgg.cpp:389 ../src/generic/fontdlgg.cpp:391
+msgid "The font weight."
+msgstr "字型粗細。"
+
+#: ../src/generic/fontdlgg.cpp:399
+msgid "C&olour:"
+msgstr "顏色(&O)："
+
+#: ../src/generic/fontdlgg.cpp:407 ../src/generic/fontdlgg.cpp:409
+msgid "The font colour."
+msgstr "字型顏色。"
+
+#: ../src/generic/fontdlgg.cpp:415
+msgid "&Point size:"
+msgstr "字點大小(&P)："
+
+#: ../src/generic/fontdlgg.cpp:420 ../src/generic/fontdlgg.cpp:422
+#: ../src/generic/fontdlgg.cpp:426 ../src/generic/fontdlgg.cpp:428
+msgid "The font point size."
+msgstr "字點大小。"
+
+#: ../src/generic/fontdlgg.cpp:439 ../src/generic/fontdlgg.cpp:441
+msgid "Whether the font is underlined."
+msgstr "字型是否加底線。"
+
+#: ../src/generic/fontdlgg.cpp:448 ../src/html/helpwnd.cpp:1215
+msgid "Preview:"
+msgstr "預覽："
+
+#: ../src/generic/fontdlgg.cpp:452 ../src/generic/fontdlgg.cpp:454
+msgid "Shows the font preview."
+msgstr "顯示字型預覽。"
+
+#: ../src/generic/fontdlgg.cpp:464 ../src/generic/fontdlgg.cpp:483
+msgid "Click to cancel the font selection."
+msgstr "點擊取消字型選擇。"
+
+#: ../src/generic/fontdlgg.cpp:469 ../src/generic/fontdlgg.cpp:471
+#: ../src/generic/fontdlgg.cpp:476 ../src/generic/fontdlgg.cpp:478
+msgid "Click to confirm the font selection."
+msgstr "點擊確認字型選擇。"
+
+#: ../src/generic/fontpickerg.cpp:50 ../src/gtk/fontdlg.cpp:77
+msgid "Choose font"
+msgstr "選擇字型"
+
+#: ../src/generic/grid.cpp:6542
+msgid ""
+"Error copying grid to the clipboard. Either selected cells were not "
+"contiguous or no cell was selected."
+msgstr ""
+
+#: ../src/generic/grid.cpp:12739
+#, fuzzy
+msgid "Grid Corner"
+msgstr "角位"
+
+#: ../src/generic/grid.cpp:12741
+#, fuzzy, c-format
+msgid "Column %s Header"
+msgstr "欄位 %u"
+
+#: ../src/generic/grid.cpp:12743
+#, c-format
+msgid "Row %s Header"
+msgstr ""
+
+#: ../src/generic/grid.cpp:12745
+#, fuzzy, c-format
+msgid "Column %s: %s"
+msgstr "欄位 %u"
+
+#: ../src/generic/grid.cpp:12749
+#, fuzzy, c-format
+msgid "Row %s: %s"
+msgstr "第 %i 行"
+
+#: ../src/generic/grid.cpp:12753
+#, c-format
+msgid "Row %s, Column %s: %s"
+msgstr ""
+
+#: ../src/generic/helpext.cpp:257
+#, c-format
+msgid "Help directory \"%s\" not found."
+msgstr "找不到說明目錄 '%s'。"
+
+#: ../src/generic/helpext.cpp:265
+#, c-format
+msgid "Help file \"%s\" not found."
+msgstr "找不到 '%s' 檔案。"
+
+#: ../src/generic/helpext.cpp:284
+#, c-format
+msgid "Line %lu of map file \"%s\" has invalid syntax, skipped."
+msgstr "對應檔案「%2$s」的第 %1$lu 列語法無效，已略過。"
+
+#: ../src/generic/helpext.cpp:292
+#, c-format
+msgid "No valid mappings found in the file \"%s\"."
+msgstr "在 '%s' 檔案找不到有效對應。"
+
+#: ../src/generic/helpext.cpp:435
+msgid "No entries found."
+msgstr "找不到項目。"
+
+#: ../src/generic/helpext.cpp:444 ../src/generic/helpext.cpp:445
+msgid "Help Index"
+msgstr "說明索引"
+
+#: ../src/generic/helpext.cpp:448
+msgid "Relevant entries:"
+msgstr "相關項目："
+
+#: ../src/generic/helpext.cpp:449
+msgid "Entries found"
+msgstr "找到的項目"
+
+#: ../src/generic/hyperlinkg.cpp:170
+msgid "&Copy URL"
+msgstr "複製網址(&C)"
+
+#: ../src/generic/infobar.cpp:119
+msgid "Hide this notification message."
+msgstr "隱藏這個通知訊息。"
+
+#. TRANSLATORS: %s will be either the application name or "Application"
+#: ../src/generic/logg.cpp:257
+#, c-format
+msgid "%s Error"
+msgstr "%s 錯誤"
+
+#. TRANSLATORS: %s will be either the application name or "Application"
+#: ../src/generic/logg.cpp:263
+#, c-format
+msgid "%s Warning"
+msgstr "%s 警告"
+
+#. TRANSLATORS: %s will be either the application name or "Application"
+#: ../src/generic/logg.cpp:273
+#, c-format
+msgid "%s Information"
+msgstr "%s 資訊"
+
+#: ../src/generic/logg.cpp:276
+msgid "Application"
+msgstr "應用程式"
+
+#: ../src/generic/logg.cpp:549
+msgid "Save log contents to file"
+msgstr "將日誌內容儲存到檔案"
+
+#: ../src/generic/logg.cpp:551
+msgid "C&lear"
+msgstr "清除(&L)"
+
+#: ../src/generic/logg.cpp:551
+msgid "Clear the log contents"
+msgstr "清除日誌內容"
+
+#: ../src/generic/logg.cpp:553
+msgid "Close this window"
+msgstr "關閉視窗"
+
+#: ../src/generic/logg.cpp:554
+msgid "&Log"
+msgstr "日誌(&L)"
+
+#: ../src/generic/logg.cpp:610 ../src/generic/logg.cpp:992
+msgid "Can't save log contents to file."
+msgstr "無法將日誌內容儲存到檔案。"
+
+#: ../src/generic/logg.cpp:613
+#, c-format
+msgid "Log saved to the file '%s'."
+msgstr "儲存日誌到 '%s' 檔案。"
+
+#: ../src/generic/logg.cpp:719
+msgid "&Details"
+msgstr "細節(&D)"
+
+#: ../src/generic/logg.cpp:972
+msgid "Failed to copy dialog contents to the clipboard."
+msgstr "無法複製對話視窗內容至剪貼簿。"
+
+#: ../src/generic/logg.cpp:1022
+#, c-format
+msgid "Append log to file '%s' (choosing [No] will overwrite it)?"
+msgstr "是否把日誌加到檔案 '%s' 的尾端 (選擇 [否] 將覆寫該檔案)？"
+
+#: ../src/generic/logg.cpp:1024
+msgid "Question"
+msgstr "問題"
+
+#: ../src/generic/logg.cpp:1038
+msgid "invalid message box return value"
+msgstr "訊息框傳回無效的值"
+
+#: ../src/generic/notifmsgg.cpp:129
+msgid "Notice"
+msgstr "聲明"
+
+#: ../src/generic/preferencesg.cpp:118
+#, c-format
+msgid "%s Preferences"
+msgstr "%s 喜好設定"
+
+#: ../src/generic/printps.cpp:143
+msgid "Printing..."
+msgstr "列印中…"
+
+#: ../src/generic/printps.cpp:160 ../src/gtk/print.cpp:1076
+#: ../src/msw/printwin.cpp:235
+msgid "Could not start printing."
+msgstr "無法啟動列印。"
+
+#: ../src/generic/printps.cpp:183
+#, c-format
+msgid "Printing page %d..."
+msgstr "正在列印第 %d 頁…"
+
+#: ../src/generic/prntdlgg.cpp:171
+msgid "Printer options"
+msgstr "印表機選項"
+
+#: ../src/generic/prntdlgg.cpp:176
+msgid "Print to File"
+msgstr "輸出成檔案"
+
+#: ../src/generic/prntdlgg.cpp:179
+msgid "Setup..."
+msgstr "設定…"
+
+#: ../src/generic/prntdlgg.cpp:187
+msgid "Printer:"
+msgstr "印表機:"
+
+#: ../src/generic/prntdlgg.cpp:195
+msgid "Status:"
+msgstr "狀態:"
+
+#: ../src/generic/prntdlgg.cpp:206
+msgid "All"
+msgstr "所有"
+
+#: ../src/generic/prntdlgg.cpp:207
+msgid "Pages"
+msgstr "頁"
+
+#: ../src/generic/prntdlgg.cpp:215
+msgid "Print Range"
+msgstr "列印範圍"
+
+#: ../src/generic/prntdlgg.cpp:229
+msgid "From:"
+msgstr "從："
+
+#: ../src/generic/prntdlgg.cpp:233
+msgid "To:"
+msgstr "到："
+
+#: ../src/generic/prntdlgg.cpp:238
+msgid "Copies:"
+msgstr "副本數："
+
+#: ../src/generic/prntdlgg.cpp:288
+msgid "PostScript file"
+msgstr "PostScript 文件"
+
+#: ../src/generic/prntdlgg.cpp:439
+msgid "Print Setup"
+msgstr "列印設定"
+
+#: ../src/generic/prntdlgg.cpp:483
+msgid "Printer"
+msgstr "印表機"
+
+#: ../src/generic/prntdlgg.cpp:501
+msgid "Default printer"
+msgstr "預設印表機"
+
+#: ../src/generic/prntdlgg.cpp:595 ../src/generic/prntdlgg.cpp:782
+#: ../src/generic/prntdlgg.cpp:822 ../src/generic/prntdlgg.cpp:835
+#: ../src/generic/prntdlgg.cpp:1031 ../src/generic/prntdlgg.cpp:1036
+msgid "Paper size"
+msgstr "紙張大小"
+
+#: ../src/generic/prntdlgg.cpp:604 ../src/generic/prntdlgg.cpp:847
+msgid "Portrait"
+msgstr "直向列印"
+
+#: ../src/generic/prntdlgg.cpp:605 ../src/generic/prntdlgg.cpp:848
+msgid "Landscape"
+msgstr "橫向列印"
+
+#: ../src/generic/prntdlgg.cpp:607 ../src/generic/prntdlgg.cpp:849
+msgid "Orientation"
+msgstr "方向"
+
+#: ../src/generic/prntdlgg.cpp:610
+msgid "Options"
+msgstr "選項"
+
+#: ../src/generic/prntdlgg.cpp:612
+msgid "Print in colour"
+msgstr "彩色列印"
+
+#: ../src/generic/prntdlgg.cpp:621
+msgid "Print spooling"
+msgstr "列印佇列中"
+
+#: ../src/generic/prntdlgg.cpp:623
+msgid "Printer command:"
+msgstr "印表機指令："
+
+#: ../src/generic/prntdlgg.cpp:631
+msgid "Printer options:"
+msgstr "印表機選項："
+
+#: ../src/generic/prntdlgg.cpp:860
+msgid "Left margin (mm):"
+msgstr "左邊距(公釐[mm])："
+
+#: ../src/generic/prntdlgg.cpp:861
+msgid "Top margin (mm):"
+msgstr "頂邊距(公釐)："
+
+#: ../src/generic/prntdlgg.cpp:872
+msgid "Right margin (mm):"
+msgstr "右邊距(公釐)："
+
+#: ../src/generic/prntdlgg.cpp:873
+msgid "Bottom margin (mm):"
+msgstr "底邊距(公釐[mm])："
+
+#: ../src/generic/prntdlgg.cpp:896
+msgid "Printer..."
+msgstr "印表機…"
+
+#: ../src/generic/progdlgg.cpp:246
+msgid "&Skip"
+msgstr "略過(&S)"
+
+#: ../src/generic/progdlgg.cpp:347 ../src/generic/progdlgg.cpp:626
+msgid "Unknown"
+msgstr "未知"
+
+#: ../src/generic/progdlgg.cpp:451 ../src/msw/progdlg.cpp:526
+msgid "Done."
+msgstr "完成。"
+
+#: ../src/generic/srchctlg.cpp:55 ../src/gtk/srchctrl.cpp:206
+#: ../src/html/helpwnd.cpp:530 ../src/html/helpwnd.cpp:545
+msgid "Search"
+msgstr "搜尋"
+
+#: ../src/generic/tabg.cpp:1026
+msgid "Could not find tab for id"
+msgstr "找不到識別碼標籤"
+
+#: ../src/generic/tipdlg.cpp:136
+msgid "Tips not available, sorry!"
+msgstr "抱歉，無可用的提示！"
+
+#: ../src/generic/tipdlg.cpp:197
+msgid "Tip of the Day"
+msgstr "今日提示"
+
+#: ../src/generic/tipdlg.cpp:207
+msgid "Did you know..."
+msgstr "您知道嗎…"
+
+#: ../src/generic/tipdlg.cpp:232
+msgid "&Show tips at startup"
+msgstr "啟動時顯示小祕訣(&S)"
+
+#: ../src/generic/tipdlg.cpp:236
+msgid "&Next Tip"
+msgstr "下一個提示(&N)"
+
+#: ../src/generic/wizard.cpp:411
+msgid "&Next >"
+msgstr "下一步(&N) 》"
+
+#: ../src/generic/wizard.cpp:412
+msgid "&Finish"
+msgstr "完成(&F)"
+
+#: ../src/generic/wizard.cpp:420
+msgid "< &Back"
+msgstr "《 返回(&B)"
+
+#: ../src/gtk/aboutdlg.cpp:204
+msgid "translator-credits"
+msgstr ""
+"譯者名單：\n"
+"PAL <lyh37@ntu.edu.tw>\n"
+"張家偉 <cwahbong@users.sourceforge.net>\n"
+"趙惟倫 <bluebat@member.fsf.org>\n"
+"Walter Cheuk <wwycheuk@gmail.com>, 2019.\n"
+"James Pan <gag247@mail.ru>"
+
+#: ../src/gtk/app.cpp:517
+msgid ""
+"WARNING: using XIM input method is unsupported and may result in problems "
+"with input handling and flickering. Consider unsetting GTK_IM_MODULE or "
+"setting to \"ibus\"."
+msgstr ""
+"警告：不支援使用 XIM 輸入方法，可能會導致輸入處理和閃爍的問題。 可考慮不設定 "
+"gtk_im_module 或設定為 “ibus”。"
+
+#: ../src/gtk/app.cpp:569
+msgid "Unable to initialize GTK+, is DISPLAY set properly?"
+msgstr "無法初始化 gtk+，DISPLAY 是否已經正確設定？"
+
+#: ../src/gtk/filedlg.cpp:89 ../src/gtk/filepicker.cpp:255
+#, c-format
+msgid "Changing current directory to \"%s\" failed"
+msgstr "無法將目前目錄變更為 '%s'"
+
+#: ../src/gtk/font.cpp:548
+msgid ""
+"Using private fonts is not supported on this system: Pango library is too "
+"old, 1.38 or later required."
+msgstr "不支援在此系統使用私人字型：Pango 函式庫過舊，需要 1.38 或更新版本。"
+
+#: ../src/gtk/font.cpp:558
+msgid "Failed to create font configuration object."
+msgstr "無法創建字型組態物件。"
+
+#: ../src/gtk/font.cpp:568
+#, c-format
+msgid "Failed to add custom font \"%s\"."
+msgstr "無法加入 ”%s” 自訂字型。"
+
+#: ../src/gtk/font.cpp:576
+msgid "Failed to register font configuration using private fonts."
+msgstr "無法使用私用字型註冊字型組態。"
+
+#: ../src/gtk/glcanvas.cpp:117 ../src/gtk/glcanvas.cpp:132
+msgid "Fatal Error"
+msgstr "嚴重錯誤"
+
+#: ../src/gtk/glcanvas.cpp:117
+msgid ""
+"This program wasn't compiled with EGL support required under Wayland, "
+"either\n"
+"install EGL libraries and rebuild or run it under X11 backend by setting\n"
+"environment variable GDK_BACKEND=x11 before starting your program."
+msgstr ""
+"此程式並非在 Wayland 必要的 EGL 支援下編纂\n"
+"安裝 EGL 函式庫，並透過設定在 X11 後端進行重建或運行\n"
+"啟動此程式之前的環境變數為 GDK_BACKEND=x11。"
+
+#: ../src/gtk/glcanvas.cpp:132
+msgid ""
+"wxGLCanvas is only supported on Wayland and X11 currently.  You may be able "
+"to\n"
+"work around this by setting environment variable GDK_BACKEND=x11 before\n"
+"starting your program."
+msgstr ""
+"wxGLCanvas 目前僅支援 Wayland 和 X11。您也許可以\n"
+"在啟動程式之前透過設定環境變數 GDK_BACKEND×x11 \n"
+"來解決這個問題。"
+
+#: ../src/gtk/mdi.cpp:433
+msgid "MDI child"
+msgstr "媒體相依介面子表單"
+
+#: ../src/gtk/power.cpp:188
+#, fuzzy, c-format
+msgid "Failed to open D-Bus connection to the login manager: %s"
+msgstr "無法創建連線到 '%s' 伺服器的主題 '%s'"
+
+#: ../src/gtk/power.cpp:214
+#, fuzzy
+msgid "wxWidgets application"
+msgstr "隱藏應用程式"
+
+#: ../src/gtk/power.cpp:226
+msgid "Application needs to keep running"
+msgstr ""
+
+#: ../src/gtk/power.cpp:233
+msgid "Clean up before suspend"
+msgstr ""
+
+#: ../src/gtk/power.cpp:259
+#, fuzzy, c-format
+msgid "Failed to inhibit sleep: %s"
+msgstr "無法初始撥號連線：%s"
+
+#: ../src/gtk/power.cpp:265
+msgid "Unexpected response to D-Bus \"Inhibit\" request."
+msgstr ""
+
+#: ../src/gtk/print.cpp:218
+msgid "Custom size"
+msgstr "自訂大小"
+
+#: ../src/gtk/print.cpp:752
+#, fuzzy, c-format
+msgid "Error while printing: %s"
+msgstr "列印時發生錯誤: "
+
+#: ../src/gtk/print.cpp:816
+msgid "Page Setup"
+msgstr "頁面設定"
+
+#: ../src/gtk/webview_webkit.cpp:932
+msgid "Retrieving JavaScript script output is not supported with WebKit v1"
+msgstr "WebKit v1 不支援擷取 JavaScript 程序檔輸出"
+
+#: ../src/gtk/webview_webkit2.cpp:1098
+msgid ""
+"Setting proxy is not supported by WebKit, at least version 2.16 is required."
+msgstr ""
+
+#: ../src/gtk/webview_webkit2.cpp:1104
+msgid "This program was compiled without support for setting WebKit proxy."
+msgstr ""
+
+#: ../src/gtk/window.cpp:6289
+msgid ""
+"GTK+ installed on this machine is too old to support screen compositing, "
+"please install GTK+ 2.12 or later."
+msgstr ""
+"安裝於這臺機器的 GTK+ 太舊而不支援螢幕組合，請安裝 GTK+2.12 或後續版本。"
+
+#: ../src/gtk/window.cpp:6307
+msgid ""
+"Compositing not supported by this system, please enable it in your Window "
+"Manager."
+msgstr "這個系統不支援組合介面，請在視窗管理員啟用之。"
+
+#: ../src/gtk/window.cpp:6318
+msgid ""
+"This program was compiled with a too old version of GTK+, please rebuild "
+"with GTK+ 2.12 or newer."
+msgstr "這個程式是以很舊版本的 GTK+ 所編譯，請以 GTK+2.12 或更新版本重新組建。"
+
+#: ../src/html/chm.cpp:138
+#, c-format
+msgid "Failed to open CHM archive '%s'."
+msgstr "無法開啟 '%s' CHM 檔。"
+
+#: ../src/html/chm.cpp:270
+#, c-format
+msgid "Could not extract %s into %s: %s"
+msgstr "無法將 %s 解壓至 %s： %s"
+
+#: ../src/html/chm.cpp:324
+msgid "no error"
+msgstr "沒有任何錯誤"
+
+#: ../src/html/chm.cpp:326
+msgid "bad arguments to library function"
+msgstr "損壞的引數傳入程式庫函式"
+
+#: ../src/html/chm.cpp:328
+msgid "error opening file"
+msgstr "檔案開啟失敗"
+
+#: ../src/html/chm.cpp:330
+msgid "read error"
+msgstr "讀取出錯"
+
+#: ../src/html/chm.cpp:332
+msgid "write error"
+msgstr "寫入失敗"
+
+#: ../src/html/chm.cpp:334
+msgid "seek error"
+msgstr "定位失敗"
+
+#: ../src/html/chm.cpp:338
+msgid "bad signature"
+msgstr "錯誤的簽名"
+
+#: ../src/html/chm.cpp:340
+msgid "error in data format"
+msgstr "資料格式錯誤"
+
+#: ../src/html/chm.cpp:342
+msgid "checksum error"
+msgstr "總和檢查碼錯誤"
+
+#: ../src/html/chm.cpp:344
+msgid "compression error"
+msgstr "壓縮失敗"
+
+#: ../src/html/chm.cpp:346
+msgid "decompression error"
+msgstr "解壓失敗"
+
+#: ../src/html/chm.cpp:437
+#, c-format
+msgid "Could not locate file '%s'."
+msgstr "找不到檔案 '%s'。"
+
+#: ../src/html/chm.cpp:711
+#, c-format
+msgid "Could not create temporary file '%s'"
+msgstr "無法創建暫存檔 '%s'"
+
+#: ../src/html/chm.cpp:718
+#, c-format
+msgid "Extraction of '%s' into '%s' failed."
+msgstr "無法將 '%s' 解開至 '%s'。"
+
+#: ../src/html/chm.cpp:806 ../src/html/chm.cpp:863
+msgid "CHM handler currently supports only local files!"
+msgstr "CHM 處理常式目前只支援本機檔案！"
+
+#: ../src/html/chm.cpp:827
+msgid "Link contained '//', converted to absolute link."
+msgstr "連結包含 '//'，已轉換為絕對連結。"
+
+#: ../src/html/helpctrl.cpp:59
+#, c-format
+msgid "Help: %s"
+msgstr "說明：%s"
+
+#: ../src/html/helpctrl.cpp:155
+#, c-format
+msgid "Adding book %s"
+msgstr "正在加入卷輯 %s"
+
+#: ../src/html/helpdata.cpp:295
+#, c-format
+msgid "Cannot open contents file: %s"
+msgstr "無法開啟目錄檔案： %s"
+
+#: ../src/html/helpdata.cpp:309
+#, c-format
+msgid "Cannot open index file: %s"
+msgstr "無法開啟索引檔： %s"
+
+#: ../src/html/helpdata.cpp:643
+msgid "noname"
+msgstr "未命名"
+
+#: ../src/html/helpdata.cpp:652
+#, c-format
+msgid "Cannot open HTML help book: %s"
+msgstr "無法開啟 HTML 說明書：%s"
+
+#: ../src/html/helpwnd.cpp:315
+msgid "Displays help as you browse the books on the left."
+msgstr "當瀏覽書籍時，於左側顯示說明。"
+
+#: ../src/html/helpwnd.cpp:411 ../src/html/helpwnd.cpp:1100
+#: ../src/html/helpwnd.cpp:1735
+msgid "(bookmarks)"
+msgstr "(書籤)"
+
+#: ../src/html/helpwnd.cpp:424
+msgid "Add current page to bookmarks"
+msgstr "把目前頁面加到書籤"
+
+#: ../src/html/helpwnd.cpp:425
+msgid "Remove current page from bookmarks"
+msgstr "從書籤移除目前頁面"
+
+#: ../src/html/helpwnd.cpp:470
+msgid "Contents"
+msgstr "內容表格"
+
+#: ../src/html/helpwnd.cpp:485
+msgid "Find"
+msgstr "尋找"
+
+#: ../src/html/helpwnd.cpp:487
+msgid "Show all"
+msgstr "全部顯示"
+
+#: ../src/html/helpwnd.cpp:497
+msgid ""
+"Display all index items that contain given substring. Search is case "
+"insensitive."
+msgstr "顯示包含該字串的所有索引項目。搜尋不區分大小寫。"
+
+#: ../src/html/helpwnd.cpp:498
+msgid "Show all items in index"
+msgstr "以索引的方式顯示所有項目"
+
+#: ../src/html/helpwnd.cpp:528
+msgid "Case sensitive"
+msgstr "區分大小寫"
+
+#: ../src/html/helpwnd.cpp:529
+msgid "Whole words only"
+msgstr "只限整個字"
+
+#: ../src/html/helpwnd.cpp:532
+msgid ""
+"Search contents of help book(s) for all occurrences of the text you typed "
+"above"
+msgstr "搜尋說明文件內容中，您所輸入文字的所有出現過的地方"
+
+#: ../src/html/helpwnd.cpp:653
+msgid "Show/hide navigation panel"
+msgstr "顯示/隱藏導覽面板"
+
+#: ../src/html/helpwnd.cpp:655
+msgid "Go back"
+msgstr "返回"
+
+#: ../src/html/helpwnd.cpp:656
+msgid "Go forward"
+msgstr "進行轉送"
+
+#: ../src/html/helpwnd.cpp:658
+msgid "Go one level up in document hierarchy"
+msgstr "到上一階文件層級"
+
+#: ../src/html/helpwnd.cpp:666 ../src/html/helpwnd.cpp:1547
+msgid "Open HTML document"
+msgstr "開啟 HTML 文件"
+
+#: ../src/html/helpwnd.cpp:670
+msgid "Print this page"
+msgstr "列印本頁"
+
+#: ../src/html/helpwnd.cpp:674
+msgid "Display options dialog"
+msgstr "顯示選項對話方塊"
+
+#: ../src/html/helpwnd.cpp:795
+msgid "Please choose the page to display:"
+msgstr "請選擇要顯示的頁面:"
+
+#: ../src/html/helpwnd.cpp:796
+msgid "Help Topics"
+msgstr "說明主題"
+
+#: ../src/html/helpwnd.cpp:852
+msgid "Searching..."
+msgstr "搜尋中…"
+
+#: ../src/html/helpwnd.cpp:853
+msgid "No matching page found yet"
+msgstr "未找到符合的頁面"
+
+#: ../src/html/helpwnd.cpp:870
+#, c-format
+msgid "Found %i matches"
+msgstr "找到 %i 個符合項"
+
+#: ../src/html/helpwnd.cpp:958
+msgid "(Help)"
+msgstr "(說明)"
+
+#: ../src/html/helpwnd.cpp:1026
+#, c-format
+msgid "%d of %lu"
+msgstr "%d / %lu"
+
+#: ../src/html/helpwnd.cpp:1028
+#, c-format
+msgid "%lu of %lu"
+msgstr "%lu / %lu"
+
+#: ../src/html/helpwnd.cpp:1047
+msgid "Search in all books"
+msgstr "搜尋所有說明書"
+
+#: ../src/html/helpwnd.cpp:1193
+msgid "Help Browser Options"
+msgstr "說明瀏覽器選項"
+
+#: ../src/html/helpwnd.cpp:1198
+msgid "Normal font:"
+msgstr "正常字型："
+
+#: ../src/html/helpwnd.cpp:1199
+msgid "Fixed font:"
+msgstr "固定字型："
+
+#: ../src/html/helpwnd.cpp:1200
+msgid "Font size:"
+msgstr "字型大小："
+
+#: ../src/html/helpwnd.cpp:1245
+msgid "font size"
+msgstr "字型大小"
+
+#: ../src/html/helpwnd.cpp:1256
+msgid "Normal face<br>and <u>underlined</u>. "
+msgstr "正常字體<br>且<u>加底線</u>。 "
+
+#: ../src/html/helpwnd.cpp:1257
+msgid "<i>Italic face.</i> "
+msgstr "<i>斜體</i> "
+
+#: ../src/html/helpwnd.cpp:1258
+msgid "<b>Bold face.</b> "
+msgstr "<b>粗體</b> "
+
+#: ../src/html/helpwnd.cpp:1259
+msgid "<b><i>Bold italic face.</i></b><br>"
+msgstr "<b><i>粗斜體</i></b><br>"
+
+#: ../src/html/helpwnd.cpp:1262
+msgid "Fixed size face.<br> <b>bold</b> <i>italic</i> "
+msgstr "固定大小字體<br> <b>粗體</b> <i>斜體</i> "
+
+#: ../src/html/helpwnd.cpp:1263
+msgid "<b><i>bold italic <u>underlined</u></i></b><br>"
+msgstr "<b><i>粗斜<u>加底線</u></i></b><br>"
+
+#: ../src/html/helpwnd.cpp:1524
+msgid "Help Printing"
+msgstr "說明列印"
+
+#: ../src/html/helpwnd.cpp:1527
+msgid "Cannot print empty page."
+msgstr "無法列印空頁面。"
+
+#: ../src/html/helpwnd.cpp:1540
+msgid "HTML files (*.html;*.htm)|*.html;*.htm|"
+msgstr "HTML 檔 (*.html;*.htm)|*.html;*.htm|"
+
+#: ../src/html/helpwnd.cpp:1541
+msgid "Help books (*.htb)|*.htb|Help books (*.zip)|*.zip|"
+msgstr "說明書 (*.htb)|*.htb|說明書 (*.zip)|*.zip|"
+
+#: ../src/html/helpwnd.cpp:1542
+msgid "HTML Help Project (*.hhp)|*.hhp|"
+msgstr "HTML 說明檔專案 (*.hhp)|*.hhp|"
+
+#: ../src/html/helpwnd.cpp:1544
+msgid "Compressed HTML Help file (*.chm)|*.chm|"
+msgstr "壓縮超文件說明檔 (*.chm)|*.chm|"
+
+#: ../src/html/helpwnd.cpp:1671
+#, c-format
+msgid "%i of %u"
+msgstr "%i / %u"
+
+#: ../src/html/helpwnd.cpp:1709
+#, c-format
+msgid "%u of %u"
+msgstr "%u / %u"
+
+#: ../src/html/htmlfilt.cpp:134
+#, c-format
+msgid "Cannot open HTML document: %s"
+msgstr "無法開啟 HTML 文件：%s"
+
+#: ../src/html/htmlwin.cpp:599
+msgid "Connecting..."
+msgstr "連線中…"
+
+#: ../src/html/htmlwin.cpp:616
+#, c-format
+msgid "Unable to open requested HTML document: %s"
+msgstr "無法開啟 HTML 文件：%s"
+
+#: ../src/html/htmlwin.cpp:630
+msgid "Loading : "
+msgstr "載入中： "
+
+#: ../src/html/htmlwin.cpp:673
+msgid "Done"
+msgstr "完成"
+
+#: ../src/html/htmlwin.cpp:723
+#, c-format
+msgid "HTML anchor %s does not exist."
+msgstr "HTML 錨定 %s 不存在。"
+
+#: ../src/html/htmlwin.cpp:1057
+#, c-format
+msgid "Copied to clipboard:\"%s\""
+msgstr "複製到剪貼簿：”%s”"
+
+#: ../src/html/htmprint.cpp:269
+msgid ""
+"This document doesn't fit on the page horizontally and will be truncated "
+"when it is printed."
+msgstr "文件的水平尺寸與頁面不一致，列印輸出將會出現版面裁切。"
+
+#: ../src/html/htmprint.cpp:285
+#, c-format
+msgid ""
+"The document \"%s\" doesn't fit on the page horizontally and will be "
+"truncated if printed.\n"
+"\n"
+"Would you like to proceed with printing it nevertheless?"
+msgstr ""
+"文件 '%s' 的水平尺寸與頁面不一致，列印輸出將會出現版面裁切。\n"
+"\n"
+"儘管如此，您仍想繼續列印此份文件？"
+
+#: ../src/html/htmprint.cpp:296
+msgid ""
+"If possible, try changing the layout parameters to make the printout more "
+"narrow."
+msgstr "儘量嘗試變更版面配置參數，讓列印輸出更窄。"
+
+#: ../src/html/htmprint.cpp:445
+msgid ": file does not exist!"
+msgstr ": 檔案不存在！"
+
+#. TRANSLATORS: %s may be a document title.
+#: ../src/html/htmprint.cpp:717
+#, fuzzy, c-format
+msgid "%s Preview"
+msgstr " 預覽"
+
+#: ../src/html/htmprint.cpp:755 ../src/richtext/richtextprint.cpp:618
+msgid ""
+"There was a problem during page setup: you may need to set a default printer."
+msgstr "頁面設定時有問題：必須設定預設印表機。"
+
+#: ../src/msw/clipbrd.cpp:80
+msgid "Failed to open the clipboard."
+msgstr "無法開啟剪貼簿。"
+
+#: ../src/msw/clipbrd.cpp:101
+msgid "Failed to close the clipboard."
+msgstr "無法關閉剪貼簿。"
+
+#: ../src/msw/clipbrd.cpp:113
+msgid "Failed to empty the clipboard."
+msgstr "無法清空剪貼簿。"
+
+#: ../src/msw/clipbrd.cpp:284
+msgid "Failed to put data on the clipboard"
+msgstr "無法存放資料到剪貼簿"
+
+#: ../src/msw/clipbrd.cpp:326
+msgid "Failed to get data from the clipboard"
+msgstr "無法從剪貼簿取得資料"
+
+#: ../src/msw/clipbrd.cpp:363
+msgid "Failed to retrieve the supported clipboard formats"
+msgstr "無法擷取支援的剪貼簿格式"
+
+#: ../src/msw/colordlg.cpp:228
+#, c-format
+msgid "Colour selection dialog failed with error %0lx."
+msgstr "顏色選擇對話框無效，錯誤碼：%0lx。"
+
+#: ../src/msw/cursor.cpp:141
+msgid "Failed to create cursor."
+msgstr "無法創建游標。"
+
+#: ../src/msw/dde.cpp:279
+#, c-format
+msgid "Failed to register DDE server '%s'"
+msgstr "無法註冊動態資料交換 (DDE) 伺服器 '%s'"
+
+#: ../src/msw/dde.cpp:300
+#, c-format
+msgid "Failed to unregister DDE server '%s'"
+msgstr "無法取消註冊’%s’ DDE 伺服器"
+
+#: ../src/msw/dde.cpp:428
+#, c-format
+msgid "Failed to create connection to server '%s' on topic '%s'"
+msgstr "無法創建連線到 '%s' 伺服器的主題 '%s'"
+
+#: ../src/msw/dde.cpp:655
+msgid "DDE poke request failed"
+msgstr "動態資料交換 (DDE) 存數指令要求失敗"
+
+#: ../src/msw/dde.cpp:674
+msgid "Failed to establish an advise loop with DDE server"
+msgstr "無法建立與動態資料交換 (DDE) 伺服器溝通的連結"
+
+#: ../src/msw/dde.cpp:693
+msgid "Failed to terminate the advise loop with DDE server"
+msgstr "無法終止與動態資料交換 (DDE) 伺服器溝通的連結"
+
+#: ../src/msw/dde.cpp:768
+msgid "Failed to send DDE advise notification"
+msgstr "無法傳送動態資料交換 (DDE) 連結通知訊息"
+
+#: ../src/msw/dde.cpp:1085
+msgid "Failed to create DDE string"
+msgstr "無法創建動態資料交換 (DDE) 字串"
+
+#: ../src/msw/dde.cpp:1131
+msgid "no DDE error."
+msgstr "未發現動態資料交換 (DDE) 錯誤。"
+
+#: ../src/msw/dde.cpp:1135
+msgid "a request for a synchronous advise transaction has timed out."
+msgstr "同步「連結交易」請求已逾時。"
+
+#: ../src/msw/dde.cpp:1138
+msgid "the response to the transaction caused the DDE_FBUSY bit to be set."
+msgstr "交易的回應，設定了 DDE_FBUSY 位元。"
+
+#: ../src/msw/dde.cpp:1141
+msgid "a request for a synchronous data transaction has timed out."
+msgstr "同步「資料交易」請求已逾時。"
+
+#: ../src/msw/dde.cpp:1144
+msgid ""
+"a DDEML function was called without first calling the DdeInitialize "
+"function,\n"
+"or an invalid instance identifier\n"
+"was passed to a DDEML function."
+msgstr ""
+"在調用 DDEML 其它函式之前，未事先調用 DdeInitialize 函式，\n"
+"或傳給 DDEML 函式的是\n"
+"無效的執行個體物件識別。"
+
+#: ../src/msw/dde.cpp:1147
+msgid ""
+"an application initialized as APPCLASS_MONITOR has\n"
+"attempted to perform a DDE transaction,\n"
+"or an application initialized as APPCMD_CLIENTONLY has \n"
+"attempted to perform server transactions."
+msgstr ""
+"初始化為 APPCLASS_MONITOR 的應用程式\n"
+"試圖執行動態資料交換 (DDE) 交易，\n"
+"或初始化為 APPCMD_CLIENTONLY 的應用程式\n"
+"試圖執行伺服器的交易。"
+
+#: ../src/msw/dde.cpp:1150
+msgid "a request for a synchronous execute transaction has timed out."
+msgstr "同步「執行交易」請求已逾時。"
+
+#: ../src/msw/dde.cpp:1153
+msgid "a parameter failed to be validated by the DDEML."
+msgstr "此參數無法通過 DDEML 驗證。"
+
+#: ../src/msw/dde.cpp:1156
+msgid "a DDEML application has created a prolonged race condition."
+msgstr "在 DDEML 應用程式產生了拖延的競態情況。"
+
+#: ../src/msw/dde.cpp:1159
+msgid "a memory allocation failed."
+msgstr "記憶體分配失敗。"
+
+#: ../src/msw/dde.cpp:1162
+msgid "a client's attempt to establish a conversation has failed."
+msgstr "用戶端的嘗試創建通訊失敗。"
+
+#: ../src/msw/dde.cpp:1165
+msgid "a transaction failed."
+msgstr "交易失敗。"
+
+#: ../src/msw/dde.cpp:1168
+msgid "a request for a synchronous poke transaction has timed out."
+msgstr "同步「資料存數指令交易」請求已逾時。"
+
+#: ../src/msw/dde.cpp:1171
+msgid "an internal call to the PostMessage function has failed. "
+msgstr "一例內部調用 PostMessage 函式已失效。 "
+
+#: ../src/msw/dde.cpp:1174
+msgid "reentrancy problem."
+msgstr "重複進入問題。"
+
+#: ../src/msw/dde.cpp:1177
+msgid ""
+"a server-side transaction was attempted on a conversation\n"
+"that was terminated by the client, or the server\n"
+"terminated before completing a transaction."
+msgstr ""
+"啟動伺服器端交易的對話\n"
+"被用戶端終止，或伺服器\n"
+"在完成交易前終止。"
+
+#: ../src/msw/dde.cpp:1180
+msgid "an internal error has occurred in the DDEML."
+msgstr "在 DDEML 發生內部錯誤。"
+
+#: ../src/msw/dde.cpp:1183
+msgid "a request to end an advise transaction has timed out."
+msgstr "終止「連結交易」的請求已逾時。"
+
+#: ../src/msw/dde.cpp:1186
+msgid ""
+"an invalid transaction identifier was passed to a DDEML function.\n"
+"Once the application has returned from an XTYP_XACT_COMPLETE callback,\n"
+"the transaction identifier for that callback is no longer valid."
+msgstr ""
+"傳給 DDEML 函式的是無效的交易識別碼。\n"
+"一旦應用程式從 XTYP_XACT_COMPLETE 回調函式返回，\n"
+"該回調函式的交易識別碼就不再有效。"
+
+#: ../src/msw/dde.cpp:1189
+#, c-format
+msgid "Unknown DDE error %08x"
+msgstr "未知的動態資料交換 (DDE) 錯誤 %08x"
+
+#: ../src/msw/dialup.cpp:343
+msgid ""
+"Dial up functions are unavailable because the remote access service (RAS) is "
+"not installed on this machine. Please install it."
+msgstr "由於沒有安裝遠端存取服務 (RAS)，撥號功能無法使用。請先安裝。"
+
+#: ../src/msw/dialup.cpp:402
+#, c-format
+msgid ""
+"The version of remote access service (RAS) installed on this machine is too "
+"old, please upgrade (the following required function is missing: %s)."
+msgstr ""
+"於此電腦安裝的遠端存取服務 (RAS) 版本太舊， (缺少以下必要函式：%s ) 請進行升"
+"級。"
+
+#: ../src/msw/dialup.cpp:437
+msgid "Failed to retrieve text of RAS error message"
+msgstr "無法擷取 RAS 錯誤訊息的對應文字"
+
+#: ../src/msw/dialup.cpp:440
+#, c-format
+msgid "unknown error (error code %08x)."
+msgstr "未知的錯誤 (錯誤碼 %08x)。"
+
+#: ../src/msw/dialup.cpp:492
+#, c-format
+msgid "Cannot find active dialup connection: %s"
+msgstr "找不到可用的撥號連線：%s"
+
+#: ../src/msw/dialup.cpp:513
+msgid "Several active dialup connections found, choosing one randomly."
+msgstr "找到多個可用的撥號連線，隨機選擇一個。"
+
+#: ../src/msw/dialup.cpp:598 ../src/msw/dialup.cpp:832
+#, c-format
+msgid "Failed to establish dialup connection: %s"
+msgstr "無法建立撥號連線：%s"
+
+#: ../src/msw/dialup.cpp:664
+#, c-format
+msgid "Failed to get ISP names: %s"
+msgstr "無法取得 ISP 名稱：%s"
+
+#: ../src/msw/dialup.cpp:712
+msgid "Failed to connect: no ISP to dial."
+msgstr "連線失敗：無可用的 ISP 供撥號。"
+
+#: ../src/msw/dialup.cpp:732
+msgid "Choose ISP to dial"
+msgstr "選擇 ISP 進行撥號"
+
+#: ../src/msw/dialup.cpp:733
+msgid "Please choose which ISP do you want to connect to"
+msgstr "請選擇要連線的 ISP"
+
+#: ../src/msw/dialup.cpp:766
+msgid "Failed to connect: missing username/password."
+msgstr "連線失敗：缺少使用者名稱或密碼。"
+
+#: ../src/msw/dialup.cpp:796
+msgid "Cannot find the location of address book file"
+msgstr "找不到通訊錄檔案的位置"
+
+#: ../src/msw/dialup.cpp:827
+#, c-format
+msgid "Failed to initiate dialup connection: %s"
+msgstr "無法初始撥號連線：%s"
+
+#: ../src/msw/dialup.cpp:897
+msgid "Cannot hang up - no active dialup connection."
+msgstr "無法掛斷—沒有可用的撥號連線。"
+
+#: ../src/msw/dialup.cpp:907
+#, c-format
+msgid "Failed to terminate the dialup connection: %s"
+msgstr "無法終止撥號連線：%s"
+
+#: ../src/msw/dib.cpp:313
+#, c-format
+msgid "Failed to save the bitmap image to file \"%s\"."
+msgstr "無法將點陣圖影像儲存至 '%s' 檔案。"
+
+#: ../src/msw/dib.cpp:543
+#, c-format
+msgid "Failed to allocate %luKb of memory for bitmap data."
+msgstr "無法分配點陣圖資料 %luKb 的記憶體。"
+
+#: ../src/msw/dir.cpp:241
+#, c-format
+msgid "Cannot enumerate files in directory '%s'"
+msgstr "無法列舉 '%s' 資料夾的檔案"
+
+#: ../src/msw/dirdlg.cpp:368
+msgid "Couldn't obtain folder name"
+msgstr "無法取得資料夾名稱"
+
+#: ../src/msw/dlmsw.cpp:163
+#, c-format
+msgid "(error %d: %s)"
+msgstr "(錯誤 %d: %s)"
+
+#: ../src/msw/dragimag.cpp:143 ../src/msw/dragimag.cpp:178
+#: ../src/msw/imaglist.cpp:309 ../src/msw/imaglist.cpp:331
+msgid "Couldn't add an image to the image list."
+msgstr "無法把影像加到影像清單。"
+
+#: ../src/msw/enhmeta.cpp:94
+#, c-format
+msgid "Failed to load metafile from file \"%s\"."
+msgstr "從 '%s' 檔案讀取中繼檔案失敗。"
+
+#: ../src/msw/fdrepdlg.cpp:412
+#, c-format
+msgid "Failed to create the standard find/replace dialog (error code %d)"
+msgstr "無法創建標準的「尋找/更改」對話窗 (錯誤碼 %d)"
+
+#: ../src/msw/filedlg.cpp:1241
+msgid "Access to the file system is not allowed from secure desktop."
+msgstr ""
+
+#: ../src/msw/filedlg.cpp:1242
+msgid "Security warning"
+msgstr ""
+
+#: ../src/msw/filedlg.cpp:1533
+#, c-format
+msgid "File dialog failed with error code %0lx."
+msgstr "檔案對話視窗錯誤，錯誤碼 %0lx。"
+
+#: ../src/msw/font.cpp:1120
+#, c-format
+msgid "Font file \"%s\" couldn't be loaded"
+msgstr "無法載入 “%s” 字型檔案"
+
+#: ../src/msw/fontdlg.cpp:220
+#, c-format
+msgid "Common dialog failed with error code %0lx."
+msgstr "共同對話視窗無效，錯誤碼 %0lx。"
+
+#: ../src/msw/fswatcher.cpp:67
+msgid "Ungraceful worker thread termination"
+msgstr "意外的工作執行緒終止"
+
+#: ../src/msw/fswatcher.cpp:81
+msgid "Unable to create IOCP worker thread"
+msgstr "無法創建 IOCP 背景工作執行緒"
+
+#: ../src/msw/fswatcher.cpp:88
+msgid "Unable to start IOCP worker thread"
+msgstr "無法開始 IOCP 背景工作執行緒"
+
+#: ../src/msw/fswatcher.cpp:140
+msgid "Monitoring individual files for changes is not supported currently."
+msgstr "目前不支援監控個別檔案是否有變更。"
+
+#: ../src/msw/fswatcher.cpp:165
+#, c-format
+msgid "Unable to set up watch for '%s'"
+msgstr "無法設定監看至 '%s'"
+
+#: ../src/msw/fswatcher.cpp:466
+#, c-format
+msgid "Can't monitor non-existent directory \"%s\" for changes."
+msgstr "無法監控不存在的 “%s” 目錄是否有變更。"
+
+#: ../src/msw/glcanvas.cpp:577 ../src/unix/glx11.cpp:507
+msgid "OpenGL 3.0 or later is not supported by the OpenGL driver."
+msgstr "此 OpenGL 驅動程式不支援 OpenGL 3.0 或更新版本。"
+
+#: ../src/msw/glcanvas.cpp:601 ../src/osx/glcanvas_osx.cpp:395
+#: ../src/unix/glegl.cpp:304 ../src/unix/glx11.cpp:553
+msgid "Couldn't create OpenGL context"
+msgstr "無法創建 OpenGL 內容"
+
+#: ../src/msw/glcanvas.cpp:1294
+msgid "Failed to initialize OpenGL"
+msgstr "無法初始化 OpenGL"
+
+#: ../src/msw/graphicsd2d.cpp:607
+msgid "Could not register custom DirectWrite font loader."
+msgstr "無法註冊自訂 DirectWrite 字型載入器。"
+
+#: ../src/msw/helpchm.cpp:48
+msgid ""
+"MS HTML Help functions are unavailable because the MS HTML Help library is "
+"not installed on this machine. Please install it."
+msgstr ""
+"MS HTML Help 函式目前不可用，起因於未安裝 MS HTML Help 函式庫，請先安裝。"
+
+#: ../src/msw/helpchm.cpp:55
+msgid "Failed to initialize MS HTML Help."
+msgstr "無法初始化 MS HTML Help。"
+
+#: ../src/msw/iniconf.cpp:458
+#, c-format
+msgid "Can't delete the INI file '%s'"
+msgstr "無法刪除 INI 檔 '%s'"
+
+#: ../src/msw/listctrl.cpp:995
+#, c-format
+msgid "Couldn't retrieve information about list control item %d."
+msgstr "無法擷取控管項目清單中細項 %d 的資訊。"
+
+#: ../src/msw/mdi.cpp:170 ../src/qt/mdi.cpp:253
+msgid "&Cascade"
+msgstr "層疊排列(&C)"
+
+#: ../src/msw/mdi.cpp:171
+msgid "Tile &Horizontally"
+msgstr "水平排列(&H)"
+
+#: ../src/msw/mdi.cpp:172
+msgid "Tile &Vertically"
+msgstr "垂直排列(&V)"
+
+#: ../src/msw/mdi.cpp:174
+msgid "&Arrange Icons"
+msgstr "排列圖示(&A)"
+
+#: ../src/msw/mdi.cpp:621
+msgid "Failed to create MDI parent frame."
+msgstr "無法創建 MDI 主框架。"
+
+#: ../src/msw/mimetype.cpp:234
+#, c-format
+msgid "Failed to create registry entry for '%s' files."
+msgstr "無法為 '%s' 檔案創建登錄項目。"
+
+#: ../src/msw/ole/automtn.cpp:495
+#, c-format
+msgid "Failed to find CLSID of \"%s\""
+msgstr "找不到 '%s' 的 CLSID"
+
+#: ../src/msw/ole/automtn.cpp:512
+#, c-format
+msgid "Failed to create an instance of \"%s\""
+msgstr "創建 “%s” 的執行個體失敗"
+
+#: ../src/msw/ole/automtn.cpp:552
+#, c-format
+msgid "Cannot get an active instance of \"%s\""
+msgstr "無法取得 ”%s” 的作用中執行個體"
+
+#: ../src/msw/ole/automtn.cpp:564
+#, c-format
+msgid "Failed to get OLE automation interface for \"%s\""
+msgstr "無法取得 '%s' 的 OLE 自動作業介面"
+
+#: ../src/msw/ole/automtn.cpp:621
+msgid "Unknown name or named argument."
+msgstr "未知名稱或具名引數。"
+
+#: ../src/msw/ole/automtn.cpp:625
+msgid "Incorrect number of arguments."
+msgstr "引數的數量不正確。"
+
+#: ../src/msw/ole/automtn.cpp:637
+msgid "Unknown exception"
+msgstr "不明的異常狀況"
+
+#: ../src/msw/ole/automtn.cpp:642
+msgid "Method or property not found."
+msgstr "找不到方法或屬性。"
+
+#: ../src/msw/ole/automtn.cpp:646
+msgid "Overflow while coercing argument values."
+msgstr "強制變更引數值時發生溢位。"
+
+#: ../src/msw/ole/automtn.cpp:650
+msgid "Object implementation does not support named arguments."
+msgstr "物件操作不支援具名參數。"
+
+#: ../src/msw/ole/automtn.cpp:654
+msgid "The locale ID is unknown."
+msgstr "區域 ID 不詳。"
+
+#: ../src/msw/ole/automtn.cpp:658
+msgid "Missing a required parameter."
+msgstr "缺少必要參數。"
+
+#: ../src/msw/ole/automtn.cpp:662
+#, c-format
+msgid "Argument %u not found."
+msgstr "找不到引數 '%u'。"
+
+#: ../src/msw/ole/automtn.cpp:666
+#, c-format
+msgid "Type mismatch in argument %u."
+msgstr "引數 %u 的類別不符合。"
+
+#: ../src/msw/ole/automtn.cpp:670
+msgid "The system cannot find the file specified."
+msgstr "系統無法找到指定的檔案。"
+
+#: ../src/msw/ole/automtn.cpp:674
+msgid "Class not registered."
+msgstr "類別未註冊。"
+
+#: ../src/msw/ole/automtn.cpp:678
+#, c-format
+msgid "Unknown error %08x"
+msgstr "未知的錯誤代碼 %08x"
+
+#: ../src/msw/ole/automtn.cpp:682
+#, c-format
+msgid "OLE Automation error in %s: %s"
+msgstr "OLE 自動化發生錯誤於 %s：%s"
+
+#: ../src/msw/ole/dataobj.cpp:385
+#, c-format
+msgid "Couldn't register clipboard format '%s'."
+msgstr "無法註冊剪貼簿格式 '%s'。"
+
+#: ../src/msw/ole/dataobj.cpp:402
+#, c-format
+msgid "The clipboard format '%d' doesn't exist."
+msgstr "剪貼簿格式「%d」不存在。"
+
+#: ../src/msw/progdlg.cpp:1025
+msgid "Skip"
+msgstr "略過"
+
+#: ../src/msw/registry.cpp:141
+#, c-format
+msgid "unknown (%lu)"
+msgstr "未知 (%lu)"
+
+#: ../src/msw/registry.cpp:409
+#, c-format
+msgid "Can't get info about registry key '%s'"
+msgstr "無法取得登錄機碼 '%s' 的資訊"
+
+#: ../src/msw/registry.cpp:445
+#, c-format
+msgid "Can't open registry key '%s'"
+msgstr "無法開啟登錄機碼 '%s'"
+
+#: ../src/msw/registry.cpp:478
+#, c-format
+msgid "Can't create registry key '%s'"
+msgstr "無法創建登錄機碼 '%s'"
+
+#: ../src/msw/registry.cpp:497
+#, c-format
+msgid "Can't close registry key '%s'"
+msgstr "無法關閉登錄機碼 '%s'"
+
+#: ../src/msw/registry.cpp:512
+#, c-format
+msgid "Registry value '%s' already exists."
+msgstr "登錄機值 '%s' 已存在。"
+
+#: ../src/msw/registry.cpp:520
+#, c-format
+msgid "Failed to rename registry value '%s' to '%s'."
+msgstr "無法將登錄值 '%s' 更名為 '%s'。"
+
+#: ../src/msw/registry.cpp:575
+#, c-format
+msgid "Can't copy values of unsupported type %d."
+msgstr "無法複製不支援類型 %d 的值。"
+
+#: ../src/msw/registry.cpp:586
+#, c-format
+msgid "Registry key '%s' does not exist, cannot rename it."
+msgstr "登錄機碼 '%s' 不存在, 無法更名。"
+
+#: ../src/msw/registry.cpp:617
+#, c-format
+msgid "Registry key '%s' already exists."
+msgstr "登錄機碼 '%s' 已存在。"
+
+#: ../src/msw/registry.cpp:625
+#, c-format
+msgid "Failed to rename the registry key '%s' to '%s'."
+msgstr "無法將登錄機碼 '%s' 更名為 '%s'。"
+
+#: ../src/msw/registry.cpp:670
+#, c-format
+msgid "Failed to copy the registry subkey '%s' to '%s'."
+msgstr "無法複製登錄子機碼 '%s'至 '%s' 。"
+
+#: ../src/msw/registry.cpp:683
+#, c-format
+msgid "Failed to copy registry value '%s'"
+msgstr "無法複製登錄機值 '%s'"
+
+#: ../src/msw/registry.cpp:692
+#, c-format
+msgid "Failed to copy the contents of registry key '%s' to '%s'."
+msgstr "無法複製登錄機碼 '%s' 的內容到 '%s'。"
+
+#: ../src/msw/registry.cpp:718
+#, c-format
+msgid ""
+"Registry key '%s' is needed for normal system operation,\n"
+"deleting it will leave your system in unusable state:\n"
+"operation aborted."
+msgstr ""
+"正常的系統操作需要登錄機碼 '%s'，\n"
+"刪除它會使系統處於無法使用的狀態：\n"
+"操作中斷。"
+
+#: ../src/msw/registry.cpp:754
+#, c-format
+msgid "Can't delete key '%s'"
+msgstr "無法刪除機碼 '%s'"
+
+#: ../src/msw/registry.cpp:782
+#, c-format
+msgid "Can't delete value '%s' from key '%s'"
+msgstr "無法從 ‘%s’ 機碼刪除 '%s' 值"
+
+#: ../src/msw/registry.cpp:855 ../src/msw/registry.cpp:887
+#: ../src/msw/registry.cpp:929 ../src/msw/registry.cpp:1000
+#, c-format
+msgid "Can't read value of key '%s'"
+msgstr "無法讀取機碼 '%s' 的值"
+
+#: ../src/msw/registry.cpp:873 ../src/msw/registry.cpp:915
+#: ../src/msw/registry.cpp:963 ../src/msw/registry.cpp:1106
+#, c-format
+msgid "Can't set value of '%s'"
+msgstr "無法設定 '%s' 的值"
+
+#: ../src/msw/registry.cpp:894 ../src/msw/registry.cpp:943
+#, c-format
+msgid "Registry value \"%s\" is not numeric (but of type %s)"
+msgstr "登錄機碼 “%s” 不是數字 (但卻是 %s 類型)"
+
+#: ../src/msw/registry.cpp:979
+#, c-format
+msgid "Registry value \"%s\" is not binary (but of type %s)"
+msgstr "登錄機碼 “%s” 不是二進位 (但卻是 %s 類型)"
+
+#: ../src/msw/registry.cpp:1028
+#, c-format
+msgid "Registry value \"%s\" is not text (but of type %s)"
+msgstr "登錄機碼 “%s” 不是文字 (但卻是 %s 類型)"
+
+#: ../src/msw/registry.cpp:1089
+#, c-format
+msgid "Can't read value of '%s'"
+msgstr "無法讀取 '%s' 的值"
+
+#: ../src/msw/registry.cpp:1157
+#, c-format
+msgid "Can't enumerate values of key '%s'"
+msgstr "無法列舉機碼 '%s' 的值"
+
+#: ../src/msw/registry.cpp:1196
+#, c-format
+msgid "Can't enumerate subkeys of key '%s'"
+msgstr "無法列舉機碼 '%s' 的子機碼"
+
+#: ../src/msw/registry.cpp:1262
+#, c-format
+msgid ""
+"Exporting registry key: file \"%s\" already exists and won't be overwritten."
+msgstr "匯出登錄機碼 已有 “%s” 檔案，無法覆寫。"
+
+#: ../src/msw/registry.cpp:1411
+#, c-format
+msgid "Can't export value of unsupported type %d."
+msgstr "無法匯出不支援類型 %d 的值。"
+
+#: ../src/msw/registry.cpp:1427
+#, c-format
+msgid "Ignoring value \"%s\" of the key \"%s\"."
+msgstr "忽略 “%s” 機碼的 “%s” 值。"
+
+#: ../src/msw/textctrl.cpp:596
+msgid ""
+"Impossible to create a rich edit control, using simple text control instead. "
+"Please reinstall riched32.dll"
+msgstr ""
+"無法創建 rich edit 控制元件，使用 simple text 控制元件代替。請重新安裝 "
+"riched32.dll"
+
+#: ../src/msw/thread.cpp:522 ../src/unix/threadpsx.cpp:850
+msgid "Cannot start thread: error writing TLS."
+msgstr "無法啟動執行緒：寫入「執行緒內部儲存區」時發生錯誤。"
+
+#: ../src/msw/thread.cpp:613
+msgid "Can't set thread priority"
+msgstr "無法設定執行緒的優先等級"
+
+#: ../src/msw/thread.cpp:649
+msgid "Can't create thread"
+msgstr "無法創建執行緒"
+
+#: ../src/msw/thread.cpp:668
+msgid "Couldn't terminate thread"
+msgstr "無法終止執行緒"
+
+#: ../src/msw/thread.cpp:799
+msgid "Cannot wait for thread termination"
+msgstr "無法等候執行緒終結"
+
+#: ../src/msw/thread.cpp:873
+#, c-format
+msgid "Cannot suspend thread %lx"
+msgstr "無法中止執行緒 %lx"
+
+#: ../src/msw/thread.cpp:903
+#, c-format
+msgid "Cannot resume thread %lx"
+msgstr "無法繼續執行緒 %lx"
+
+#: ../src/msw/thread.cpp:932
+msgid "Couldn't get the current thread pointer"
+msgstr "無法取得目前執行緒指標"
+
+#: ../src/msw/thread.cpp:1333
+msgid ""
+"Thread module initialization failed: impossible to allocate index in thread "
+"local storage"
+msgstr "執行緒模組初始化失敗：無法在「執行緒內部儲存區」配置索引"
+
+#: ../src/msw/thread.cpp:1345
+msgid ""
+"Thread module initialization failed: cannot store value in thread local "
+"storage"
+msgstr "執行緒模組初始化失敗：無法將值儲存到執行緒內部儲存區"
+
+#: ../src/msw/timer.cpp:133
+msgid "Couldn't create a timer"
+msgstr "無法創建計時器"
+
+#: ../src/msw/utils.cpp:372
+msgid "can't find user's HOME, using current directory."
+msgstr "找不到使用者主目錄，使用目前目錄。"
+
+#: ../src/msw/utils.cpp:662
+#, c-format
+msgid "Failed to kill process %d"
+msgstr "無法消滅程序 %d"
+
+#: ../src/msw/utils.cpp:986
+#, c-format
+msgid "Failed to load resource \"%s\"."
+msgstr "無法載入 “%s” 資源。"
+
+#: ../src/msw/utils.cpp:993
+#, c-format
+msgid "Failed to lock resource \"%s\"."
+msgstr "無法鎖定 “%s” 資源。"
+
+#. TRANSLATORS: MS Windows build number
+#: ../src/msw/utils.cpp:1209
+#, c-format
+msgid "build %lu"
+msgstr "組建 %lu"
+
+#: ../src/msw/utils.cpp:1218
+msgid ", 64-bit edition"
+msgstr "，64 位元版"
+
+#: ../src/msw/utilsexc.cpp:224
+msgid "Failed to create an anonymous pipe"
+msgstr "無法創建匿名管道"
+
+#: ../src/msw/utilsexc.cpp:697
+msgid "Failed to redirect the child process IO"
+msgstr "重新導向子程序的「輸入/輸出」失敗"
+
+#: ../src/msw/utilsexc.cpp:870
+#, c-format
+msgid "Execution of command '%s' failed"
+msgstr "'%s' 指令執行失敗"
+
+#: ../src/msw/volume.cpp:337
+msgid "Failed to load mpr.dll."
+msgstr "無法載入 mpr.dll。"
+
+#: ../src/msw/volume.cpp:506
+#, c-format
+msgid "Cannot read typename from '%s'!"
+msgstr "無法從 ”%s” 讀取類型名稱！"
+
+#: ../src/msw/volume.cpp:615
+#, c-format
+msgid "Cannot load icon from '%s'."
+msgstr "無法從 '%s' 載入圖示。"
+
+#: ../src/msw/webview_edge.cpp:285
+msgid "This program was compiled without support for setting Edge proxy."
+msgstr ""
+
+#: ../src/msw/webview_ie.cpp:1010
+msgid "Failed to find web view emulation level in the registry"
+msgstr "無法在登錄檔尋找網頁檢視模擬等級"
+
+#: ../src/msw/webview_ie.cpp:1019
+msgid "Failed to set web view to modern emulation level"
+msgstr "無法設定網頁檢視至現代模擬等級"
+
+#: ../src/msw/webview_ie.cpp:1027
+msgid "Failed to reset web view to standard emulation level"
+msgstr "無法重設網頁檢視至標準模擬等級"
+
+#: ../src/msw/webview_ie.cpp:1049
+msgid "Can't run JavaScript script without a valid HTML document"
+msgstr "需要有效 HTML 文件才能執行 JavaScript 文稿"
+
+#: ../src/msw/webview_ie.cpp:1056
+msgid "Can't get the JavaScript object"
+msgstr "無法取得 JavaScript 物件"
+
+#: ../src/msw/webview_ie.cpp:1070
+msgid "failed to evaluate"
+msgstr "無法評估"
+
+#: ../src/osx/cocoa/filedlg.mm:412
+msgid "File type:"
+msgstr "檔案類型："
+
+#: ../src/osx/cocoa/menu.mm:242
+#, fuzzy
+msgctxt "macOS menu name"
+msgid "Window"
+msgstr "視窗"
+
+#: ../src/osx/cocoa/menu.mm:259
+#, fuzzy
+msgctxt "macOS menu name"
+msgid "Help"
+msgstr "說明"
+
+#: ../src/osx/cocoa/menu.mm:298
+#, fuzzy
+msgctxt "macOS menu item"
+msgid "Minimize"
+msgstr "最小化(&N)"
+
+#: ../src/osx/cocoa/menu.mm:303
+#, fuzzy
+msgctxt "macOS menu item"
+msgid "Zoom"
+msgstr "縮放"
+
+#: ../src/osx/cocoa/menu.mm:309
+#, fuzzy
+msgctxt "macOS menu item"
+msgid "Bring All to Front"
+msgstr "全部放置最上層"
+
+#: ../src/osx/core/sound.cpp:143
+#, c-format
+msgid "Failed to load sound from \"%s\" (error %d)."
+msgstr "無法從 ”%s” 載入聲音 (錯誤 %d)。"
+
+#: ../src/osx/fontutil.cpp:80
+#, c-format
+msgid "Font file \"%s\" doesn't exist."
+msgstr "'%s' 字型檔案不存在。"
+
+#: ../src/osx/fontutil.cpp:88
+#, c-format
+msgid ""
+"Font file \"%s\" cannot be used as it is not inside the font directory "
+"\"%s\"."
+msgstr "'%s' 字型檔因為不在' %s' 字型目錄內而無法使用。"
+
+#: ../src/osx/menu_osx.cpp:496
+#, c-format
+msgctxt "macOS menu item"
+msgid "About %s"
+msgstr "關於 %s"
+
+#: ../src/osx/menu_osx.cpp:499
+msgctxt "macOS menu item"
+msgid "About..."
+msgstr "關於..."
+
+#: ../src/osx/menu_osx.cpp:508
+msgctxt "macOS menu item"
+msgid "Preferences..."
+msgstr "喜好設定..."
+
+#: ../src/osx/menu_osx.cpp:512
+msgctxt "macOS menu item"
+msgid "Services"
+msgstr "服務"
+
+#: ../src/osx/menu_osx.cpp:519
+#, c-format
+msgctxt "macOS menu item"
+msgid "Hide %s"
+msgstr "隱藏 %s"
+
+#: ../src/osx/menu_osx.cpp:522
+msgctxt "macOS menu item"
+msgid "Hide Application"
+msgstr "隱藏應用程式"
+
+#: ../src/osx/menu_osx.cpp:526
+msgctxt "macOS menu item"
+msgid "Hide Others"
+msgstr "隱藏其他"
+
+#: ../src/osx/menu_osx.cpp:528
+msgctxt "macOS menu item"
+msgid "Show All"
+msgstr "全部顯示"
+
+#: ../src/osx/menu_osx.cpp:534
+#, c-format
+msgctxt "macOS menu item"
+msgid "Quit %s"
+msgstr "結束 %s"
+
+#: ../src/osx/menu_osx.cpp:537
+msgctxt "macOS menu item"
+msgid "Quit Application"
+msgstr "結束應用程式"
+
+#: ../src/osx/webview_webkit.mm:444
+msgid "Printing is not supported by the system web control"
+msgstr "系統網頁控制元件不支援列印"
+
+#: ../src/osx/webview_webkit.mm:453
+msgid "Print operation could not be initialized"
+msgstr "無法初始化列印作業"
+
+#. TRANSLATORS: Label of font point size
+#: ../src/propgrid/advprops.cpp:605
+msgid "Point Size"
+msgstr "字點大小"
+
+#. TRANSLATORS: Label of font face name
+#: ../src/propgrid/advprops.cpp:615
+msgid "Face Name"
+msgstr "字體名稱"
+
+#. TRANSLATORS: Label of font style
+#: ../src/propgrid/advprops.cpp:623 ../src/richtext/richtextformatdlg.cpp:331
+msgid "Style"
+msgstr "樣式"
+
+#. TRANSLATORS: Label of font weight
+#: ../src/propgrid/advprops.cpp:628
+msgid "Weight"
+msgstr "粗細"
+
+#. TRANSLATORS: Label of underlined font
+#: ../src/propgrid/advprops.cpp:633 ../src/richtext/richtextfontpage.cpp:358
+msgid "Underlined"
+msgstr "加底線"
+
+#. TRANSLATORS: Label of font family
+#: ../src/propgrid/advprops.cpp:637
+msgid "Family"
+msgstr "字族"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:801
+msgid "AppWorkspace"
+msgstr "AppWorkspace"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:802
+msgid "ActiveBorder"
+msgstr "有效邊框"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:803
+msgid "ActiveCaption"
+msgstr "有效標題"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:804
+msgid "ButtonFace"
+msgstr "按鈕正面"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:805
+msgid "ButtonHighlight"
+msgstr "按鈕反白"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:806
+msgid "ButtonShadow"
+msgstr "按鈕陰影"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:807
+msgid "ButtonText"
+msgstr "按鈕文字"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:808
+msgid "CaptionText"
+msgstr "CaptionText"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:809
+msgid "ControlDark"
+msgstr "ControlDark"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:810
+msgid "ControlLight"
+msgstr "ControlLight"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:812
+msgid "GrayText"
+msgstr "灰階文字"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:813
+msgid "Highlight"
+msgstr "反白"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:814
+msgid "HighlightText"
+msgstr "反白文字"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:815
+msgid "InactiveBorder"
+msgstr "InactiveBorder"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:816
+msgid "InactiveCaption"
+msgstr "InactiveCaption"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:817
+msgid "InactiveCaptionText"
+msgstr "InactiveCaptionText"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:818
+msgid "Menu"
+msgstr "選單"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:819
+msgid "Scrollbar"
+msgstr "Scrollbar"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:820
+msgid "Tooltip"
+msgstr "工具提示"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:821
+msgid "TooltipText"
+msgstr "工具提示文字"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:822
+msgid "Window"
+msgstr "視窗"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:823
+msgid "WindowFrame"
+msgstr "視窗框"
+
+#. TRANSLATORS: Keyword of system colour
+#: ../src/propgrid/advprops.cpp:824
+msgid "WindowText"
+msgstr "視窗文字"
+
+#. TRANSLATORS: Custom colour choice entry
+#: ../src/propgrid/advprops.cpp:825 ../src/propgrid/advprops.cpp:1532
+#: ../src/propgrid/advprops.cpp:1576
+msgid "Custom"
+msgstr "自訂"
+
+#: ../src/propgrid/advprops.cpp:1558
+msgid "Black"
+msgstr "黑色"
+
+#: ../src/propgrid/advprops.cpp:1559
+msgid "Maroon"
+msgstr "栗子色"
+
+#: ../src/propgrid/advprops.cpp:1560
+msgid "Navy"
+msgstr "海軍藍"
+
+#: ../src/propgrid/advprops.cpp:1561
+msgid "Purple"
+msgstr "紫色"
+
+#: ../src/propgrid/advprops.cpp:1562
+msgid "Teal"
+msgstr "鴨綠色"
+
+#: ../src/propgrid/advprops.cpp:1563
+msgid "Gray"
+msgstr "灰色"
+
+#: ../src/propgrid/advprops.cpp:1564
+msgid "Green"
+msgstr "綠色"
+
+#: ../src/propgrid/advprops.cpp:1565
+msgid "Olive"
+msgstr "橄欖色"
+
+#: ../src/propgrid/advprops.cpp:1566
+msgid "Brown"
+msgstr "梡色"
+
+#: ../src/propgrid/advprops.cpp:1567
+msgid "Blue"
+msgstr "藍色"
+
+#: ../src/propgrid/advprops.cpp:1568
+msgid "Fuchsia"
+msgstr "紫紅色"
+
+#: ../src/propgrid/advprops.cpp:1569
+msgid "Red"
+msgstr "紅色"
+
+#: ../src/propgrid/advprops.cpp:1570
+msgid "Orange"
+msgstr "橙色"
+
+#: ../src/propgrid/advprops.cpp:1571
+msgid "Silver"
+msgstr "銀色"
+
+#: ../src/propgrid/advprops.cpp:1572
+msgid "Lime"
+msgstr "青檸色"
+
+#: ../src/propgrid/advprops.cpp:1573
+msgid "Aqua"
+msgstr "水藍色"
+
+#: ../src/propgrid/advprops.cpp:1574
+msgid "Yellow"
+msgstr "黃色"
+
+#: ../src/propgrid/advprops.cpp:1575
+msgid "White"
+msgstr "白色"
+
+#: ../src/propgrid/advprops.cpp:1718
+msgctxt "system cursor name"
+msgid "Default"
+msgstr "預設名"
+
+#: ../src/propgrid/advprops.cpp:1719
+msgctxt "system cursor name"
+msgid "Arrow"
+msgstr "箭頭"
+
+#: ../src/propgrid/advprops.cpp:1720
+msgctxt "system cursor name"
+msgid "Right Arrow"
+msgstr "右箭頭"
+
+#: ../src/propgrid/advprops.cpp:1721
+msgctxt "system cursor name"
+msgid "Blank"
+msgstr "空白"
+
+#: ../src/propgrid/advprops.cpp:1722
+msgctxt "system cursor name"
+msgid "Bullseye"
+msgstr "標靶"
+
+#: ../src/propgrid/advprops.cpp:1723
+msgctxt "system cursor name"
+msgid "Character"
+msgstr "字元"
+
+#: ../src/propgrid/advprops.cpp:1724
+msgctxt "system cursor name"
+msgid "Cross"
+msgstr "十字"
+
+#: ../src/propgrid/advprops.cpp:1725
+msgctxt "system cursor name"
+msgid "Hand"
+msgstr "處理"
+
+#: ../src/propgrid/advprops.cpp:1726
+msgctxt "system cursor name"
+msgid "I-Beam"
+msgstr "工字"
+
+#: ../src/propgrid/advprops.cpp:1727
+msgctxt "system cursor name"
+msgid "Left Button"
+msgstr "左鍵"
+
+#: ../src/propgrid/advprops.cpp:1728
+msgctxt "system cursor name"
+msgid "Magnifier"
+msgstr "放大鏡"
+
+#: ../src/propgrid/advprops.cpp:1729
+msgctxt "system cursor name"
+msgid "Middle Button"
+msgstr "中鍵"
+
+#: ../src/propgrid/advprops.cpp:1730
+msgctxt "system cursor name"
+msgid "No Entry"
+msgstr "禁止入內"
+
+#: ../src/propgrid/advprops.cpp:1731
+msgctxt "system cursor name"
+msgid "Paint Brush"
+msgstr "筆刷"
+
+#: ../src/propgrid/advprops.cpp:1732
+msgctxt "system cursor name"
+msgid "Pencil"
+msgstr "鉛筆"
+
+#: ../src/propgrid/advprops.cpp:1733
+msgctxt "system cursor name"
+msgid "Point Left"
+msgstr "向左指"
+
+#: ../src/propgrid/advprops.cpp:1734
+msgctxt "system cursor name"
+msgid "Point Right"
+msgstr "向右指"
+
+#: ../src/propgrid/advprops.cpp:1735
+msgctxt "system cursor name"
+msgid "Question Arrow"
+msgstr "問題箭頭"
+
+#: ../src/propgrid/advprops.cpp:1736
+msgctxt "system cursor name"
+msgid "Right Button"
+msgstr "右鍵"
+
+#: ../src/propgrid/advprops.cpp:1737
+msgctxt "system cursor name"
+msgid "Sizing NE-SW"
+msgstr "縮放 (東北至西南)"
+
+#: ../src/propgrid/advprops.cpp:1738
+msgctxt "system cursor name"
+msgid "Sizing N-S"
+msgstr "縮放 (南至北)"
+
+#: ../src/propgrid/advprops.cpp:1739
+msgctxt "system cursor name"
+msgid "Sizing NW-SE"
+msgstr "縮放 (東南至西北)"
+
+#: ../src/propgrid/advprops.cpp:1740
+msgctxt "system cursor name"
+msgid "Sizing W-E"
+msgstr "縮放 (東至西)"
+
+#: ../src/propgrid/advprops.cpp:1741
+msgctxt "system cursor name"
+msgid "Sizing"
+msgstr "縮放"
+
+#: ../src/propgrid/advprops.cpp:1742
+msgctxt "system cursor name"
+msgid "Spraycan"
+msgstr "噴漆"
+
+#: ../src/propgrid/advprops.cpp:1743
+msgctxt "system cursor name"
+msgid "Wait"
+msgstr "等待"
+
+#: ../src/propgrid/advprops.cpp:1744
+msgctxt "system cursor name"
+msgid "Watch"
+msgstr "計時"
+
+#: ../src/propgrid/advprops.cpp:1745
+msgctxt "system cursor name"
+msgid "Wait Arrow"
+msgstr "等待箭頭"
+
+#: ../src/propgrid/advprops.cpp:2109
+msgid "Make a selection:"
+msgstr "請選擇："
+
+#: ../src/propgrid/manager.cpp:394
+msgid "Property"
+msgstr "屬性"
+
+#: ../src/propgrid/manager.cpp:395
+msgid "Value"
+msgstr "值"
+
+#: ../src/propgrid/manager.cpp:1683
+msgid "Categorized Mode"
+msgstr "分類化模式"
+
+#: ../src/propgrid/manager.cpp:1709
+msgid "Alphabetic Mode"
+msgstr "字母順序模式"
+
+#. TRANSLATORS: Name of Boolean false value
+#: ../src/propgrid/propgrid.cpp:230
+msgid "False"
+msgstr "假"
+
+#. TRANSLATORS: Name of Boolean true value
+#: ../src/propgrid/propgrid.cpp:232
+msgid "True"
+msgstr "真"
+
+#. TRANSLATORS: Text  displayed for unspecified value
+#: ../src/propgrid/propgrid.cpp:428
+msgid "Unspecified"
+msgstr "未指定"
+
+#. TRANSLATORS: Caption of message box displaying any property error
+#: ../src/propgrid/propgrid.cpp:3145 ../src/propgrid/propgrid.cpp:3282
+msgid "Property Error"
+msgstr "屬性錯誤"
+
+#: ../src/propgrid/propgrid.cpp:3259
+msgid "You have entered invalid value. Press ESC to cancel editing."
+msgstr "輸入了無效的值，按 ESC 以取消編輯。"
+
+#: ../src/propgrid/propgrid.cpp:6608
+#, c-format
+msgid "Error in resource: %s"
+msgstr "資源錯誤：%s"
+
+#: ../src/propgrid/propgridiface.cpp:377
+#, c-format
+msgid ""
+"Type operation \"%s\" failed: Property labeled \"%s\" is of type \"%s\", NOT "
+"\"%s\"."
+msgstr "類型操作 “%s” 失敗：標示為 “%s” 的屬性是 “%s” 類型，而非 “%s”。"
+
+#: ../src/propgrid/props.cpp:159
+#, c-format
+msgid "Unknown base %d. Base 10 will be used."
+msgstr "未知 Base %d。將使用 Base 10。"
+
+#: ../src/propgrid/props.cpp:324
+#, c-format
+msgid "Value must be %s or higher."
+msgstr "值必須大於或等於 %s。"
+
+#: ../src/propgrid/props.cpp:329 ../src/propgrid/props.cpp:356
+#, c-format
+msgid "Value must be between %s and %s."
+msgstr "值必須介於 %s 和 %s 之間。"
+
+#: ../src/propgrid/props.cpp:351
+#, c-format
+msgid "Value must be %s or less."
+msgstr "值必須小於或等於 %s。"
+
+#: ../src/propgrid/props.cpp:1058
+#, c-format
+msgid "Not %s"
+msgstr "非 %s"
+
+#: ../src/propgrid/props.cpp:1770
+msgid "Choose a directory:"
+msgstr "選擇目錄："
+
+#: ../src/propgrid/props.cpp:2055
+msgid "Choose a file"
+msgstr "選擇檔案"
+
+#: ../src/qt/mdi.cpp:254
+msgid "&Tile"
+msgstr ""
+
+#: ../src/richtext/richtextbackgroundpage.cpp:147
+#: ../src/richtext/richtextformatdlg.cpp:376
+msgid "Background"
+msgstr "背景"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:159
+msgid "Background &colour:"
+msgstr "背景顏色(&C)："
+
+#: ../src/richtext/richtextbackgroundpage.cpp:161
+#: ../src/richtext/richtextbackgroundpage.cpp:163
+msgid "Enables a background colour."
+msgstr "啟用背景顏色。"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:167
+#: ../src/richtext/richtextbackgroundpage.cpp:169
+msgid "The background colour."
+msgstr "背景顏色。"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:178
+msgid "Shadow"
+msgstr "陰影"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:193
+msgid "Use &shadow"
+msgstr "使用陰影(&S)"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:195
+#: ../src/richtext/richtextbackgroundpage.cpp:197
+msgid "Enables a shadow."
+msgstr "啟用陰影。"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:211
+msgid "&Horizontal offset:"
+msgstr "水平偏移值(&H)："
+
+#: ../src/richtext/richtextbackgroundpage.cpp:218
+#: ../src/richtext/richtextbackgroundpage.cpp:220
+msgid "The horizontal offset."
+msgstr "水平偏移值。"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:224
+#: ../src/richtext/richtextbackgroundpage.cpp:227
+#: ../src/richtext/richtextbackgroundpage.cpp:228
+#: ../src/richtext/richtextbackgroundpage.cpp:247
+#: ../src/richtext/richtextbackgroundpage.cpp:250
+#: ../src/richtext/richtextbackgroundpage.cpp:251
+#: ../src/richtext/richtextbackgroundpage.cpp:287
+#: ../src/richtext/richtextbackgroundpage.cpp:290
+#: ../src/richtext/richtextbackgroundpage.cpp:291
+#: ../src/richtext/richtextbackgroundpage.cpp:314
+#: ../src/richtext/richtextbackgroundpage.cpp:317
+#: ../src/richtext/richtextbackgroundpage.cpp:318
+#: ../src/richtext/richtextborderspage.cpp:252
+#: ../src/richtext/richtextborderspage.cpp:255
+#: ../src/richtext/richtextborderspage.cpp:256
+#: ../src/richtext/richtextborderspage.cpp:286
+#: ../src/richtext/richtextborderspage.cpp:289
+#: ../src/richtext/richtextborderspage.cpp:290
+#: ../src/richtext/richtextborderspage.cpp:320
+#: ../src/richtext/richtextborderspage.cpp:323
+#: ../src/richtext/richtextborderspage.cpp:324
+#: ../src/richtext/richtextborderspage.cpp:354
+#: ../src/richtext/richtextborderspage.cpp:357
+#: ../src/richtext/richtextborderspage.cpp:358
+#: ../src/richtext/richtextborderspage.cpp:420
+#: ../src/richtext/richtextborderspage.cpp:423
+#: ../src/richtext/richtextborderspage.cpp:424
+#: ../src/richtext/richtextborderspage.cpp:454
+#: ../src/richtext/richtextborderspage.cpp:457
+#: ../src/richtext/richtextborderspage.cpp:458
+#: ../src/richtext/richtextborderspage.cpp:488
+#: ../src/richtext/richtextborderspage.cpp:491
+#: ../src/richtext/richtextborderspage.cpp:492
+#: ../src/richtext/richtextborderspage.cpp:522
+#: ../src/richtext/richtextborderspage.cpp:525
+#: ../src/richtext/richtextborderspage.cpp:526
+#: ../src/richtext/richtextborderspage.cpp:590
+#: ../src/richtext/richtextborderspage.cpp:593
+#: ../src/richtext/richtextborderspage.cpp:594
+#: ../src/richtext/richtextfontpage.cpp:177
+#: ../src/richtext/richtextmarginspage.cpp:199
+#: ../src/richtext/richtextmarginspage.cpp:201
+#: ../src/richtext/richtextmarginspage.cpp:202
+#: ../src/richtext/richtextmarginspage.cpp:224
+#: ../src/richtext/richtextmarginspage.cpp:226
+#: ../src/richtext/richtextmarginspage.cpp:227
+#: ../src/richtext/richtextmarginspage.cpp:247
+#: ../src/richtext/richtextmarginspage.cpp:249
+#: ../src/richtext/richtextmarginspage.cpp:250
+#: ../src/richtext/richtextmarginspage.cpp:272
+#: ../src/richtext/richtextmarginspage.cpp:274
+#: ../src/richtext/richtextmarginspage.cpp:275
+#: ../src/richtext/richtextmarginspage.cpp:313
+#: ../src/richtext/richtextmarginspage.cpp:315
+#: ../src/richtext/richtextmarginspage.cpp:316
+#: ../src/richtext/richtextmarginspage.cpp:338
+#: ../src/richtext/richtextmarginspage.cpp:340
+#: ../src/richtext/richtextmarginspage.cpp:341
+#: ../src/richtext/richtextmarginspage.cpp:361
+#: ../src/richtext/richtextmarginspage.cpp:363
+#: ../src/richtext/richtextmarginspage.cpp:364
+#: ../src/richtext/richtextmarginspage.cpp:386
+#: ../src/richtext/richtextmarginspage.cpp:388
+#: ../src/richtext/richtextmarginspage.cpp:389
+#: ../src/richtext/richtextsizepage.cpp:337
+#: ../src/richtext/richtextsizepage.cpp:340
+#: ../src/richtext/richtextsizepage.cpp:341
+#: ../src/richtext/richtextsizepage.cpp:371
+#: ../src/richtext/richtextsizepage.cpp:374
+#: ../src/richtext/richtextsizepage.cpp:375
+#: ../src/richtext/richtextsizepage.cpp:398
+#: ../src/richtext/richtextsizepage.cpp:401
+#: ../src/richtext/richtextsizepage.cpp:402
+#: ../src/richtext/richtextsizepage.cpp:425
+#: ../src/richtext/richtextsizepage.cpp:428
+#: ../src/richtext/richtextsizepage.cpp:429
+#: ../src/richtext/richtextsizepage.cpp:452
+#: ../src/richtext/richtextsizepage.cpp:455
+#: ../src/richtext/richtextsizepage.cpp:456
+#: ../src/richtext/richtextsizepage.cpp:479
+#: ../src/richtext/richtextsizepage.cpp:482
+#: ../src/richtext/richtextsizepage.cpp:483
+#: ../src/richtext/richtextsizepage.cpp:553
+#: ../src/richtext/richtextsizepage.cpp:556
+#: ../src/richtext/richtextsizepage.cpp:557
+#: ../src/richtext/richtextsizepage.cpp:588
+#: ../src/richtext/richtextsizepage.cpp:591
+#: ../src/richtext/richtextsizepage.cpp:592
+#: ../src/richtext/richtextsizepage.cpp:623
+#: ../src/richtext/richtextsizepage.cpp:626
+#: ../src/richtext/richtextsizepage.cpp:627
+#: ../src/richtext/richtextsizepage.cpp:658
+#: ../src/richtext/richtextsizepage.cpp:661
+#: ../src/richtext/richtextsizepage.cpp:662
+msgid "px"
+msgstr "像素"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:225
+#: ../src/richtext/richtextbackgroundpage.cpp:248
+#: ../src/richtext/richtextbackgroundpage.cpp:288
+#: ../src/richtext/richtextbackgroundpage.cpp:315
+#: ../src/richtext/richtextborderspage.cpp:253
+#: ../src/richtext/richtextborderspage.cpp:287
+#: ../src/richtext/richtextborderspage.cpp:321
+#: ../src/richtext/richtextborderspage.cpp:355
+#: ../src/richtext/richtextborderspage.cpp:421
+#: ../src/richtext/richtextborderspage.cpp:455
+#: ../src/richtext/richtextborderspage.cpp:489
+#: ../src/richtext/richtextborderspage.cpp:523
+#: ../src/richtext/richtextborderspage.cpp:591
+#: ../src/richtext/richtextmarginspage.cpp:200
+#: ../src/richtext/richtextmarginspage.cpp:225
+#: ../src/richtext/richtextmarginspage.cpp:248
+#: ../src/richtext/richtextmarginspage.cpp:273
+#: ../src/richtext/richtextmarginspage.cpp:314
+#: ../src/richtext/richtextmarginspage.cpp:339
+#: ../src/richtext/richtextmarginspage.cpp:362
+#: ../src/richtext/richtextmarginspage.cpp:387
+#: ../src/richtext/richtextsizepage.cpp:338
+#: ../src/richtext/richtextsizepage.cpp:372
+#: ../src/richtext/richtextsizepage.cpp:399
+#: ../src/richtext/richtextsizepage.cpp:426
+#: ../src/richtext/richtextsizepage.cpp:453
+#: ../src/richtext/richtextsizepage.cpp:480
+#: ../src/richtext/richtextsizepage.cpp:554
+#: ../src/richtext/richtextsizepage.cpp:589
+#: ../src/richtext/richtextsizepage.cpp:624
+#: ../src/richtext/richtextsizepage.cpp:659
+msgid "cm"
+msgstr "公分 (cm)"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:226
+#: ../src/richtext/richtextbackgroundpage.cpp:249
+#: ../src/richtext/richtextbackgroundpage.cpp:289
+#: ../src/richtext/richtextbackgroundpage.cpp:316
+#: ../src/richtext/richtextborderspage.cpp:254
+#: ../src/richtext/richtextborderspage.cpp:288
+#: ../src/richtext/richtextborderspage.cpp:322
+#: ../src/richtext/richtextborderspage.cpp:356
+#: ../src/richtext/richtextborderspage.cpp:422
+#: ../src/richtext/richtextborderspage.cpp:456
+#: ../src/richtext/richtextborderspage.cpp:490
+#: ../src/richtext/richtextborderspage.cpp:524
+#: ../src/richtext/richtextborderspage.cpp:592
+#: ../src/richtext/richtextfontpage.cpp:176
+#: ../src/richtext/richtextfontpage.cpp:179
+msgid "pt"
+msgstr "pt"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:229
+#: ../src/richtext/richtextbackgroundpage.cpp:231
+#: ../src/richtext/richtextbackgroundpage.cpp:252
+#: ../src/richtext/richtextbackgroundpage.cpp:254
+#: ../src/richtext/richtextbackgroundpage.cpp:292
+#: ../src/richtext/richtextbackgroundpage.cpp:294
+#: ../src/richtext/richtextbackgroundpage.cpp:319
+#: ../src/richtext/richtextbackgroundpage.cpp:321
+msgid "Units for this value."
+msgstr "值的單位。"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:234
+msgid "&Vertical offset:"
+msgstr "垂直偏移值(&V)："
+
+#: ../src/richtext/richtextbackgroundpage.cpp:241
+#: ../src/richtext/richtextbackgroundpage.cpp:243
+msgid "The vertical offset."
+msgstr "垂直偏移值。"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:257
+msgid "Shadow c&olour:"
+msgstr "陰影顏色(&O)："
+
+#: ../src/richtext/richtextbackgroundpage.cpp:259
+#: ../src/richtext/richtextbackgroundpage.cpp:261
+msgid "Enables the shadow colour."
+msgstr "啟用陰影顏色。"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:265
+#: ../src/richtext/richtextbackgroundpage.cpp:267
+msgid "The shadow colour."
+msgstr "陰影顏色。"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:270
+msgid "Sh&adow spread:"
+msgstr "陰影擴散(&A)："
+
+#: ../src/richtext/richtextbackgroundpage.cpp:272
+#: ../src/richtext/richtextbackgroundpage.cpp:274
+msgid "Enables the shadow spread."
+msgstr "啟用陰影擴散。"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:281
+#: ../src/richtext/richtextbackgroundpage.cpp:283
+msgid "The shadow spread."
+msgstr "陰影擴散。"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:297
+msgid "&Blur distance:"
+msgstr "模糊距離(&B)："
+
+#: ../src/richtext/richtextbackgroundpage.cpp:299
+#: ../src/richtext/richtextbackgroundpage.cpp:301
+msgid "Enables the blur distance."
+msgstr "啟用模糊距離。"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:308
+#: ../src/richtext/richtextbackgroundpage.cpp:310
+msgid "The shadow blur distance."
+msgstr "陰影模糊距離。"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:324
+msgid "Opaci&ty:"
+msgstr "混濁度(&T)："
+
+#: ../src/richtext/richtextbackgroundpage.cpp:326
+#: ../src/richtext/richtextbackgroundpage.cpp:328
+msgid "Enables the shadow opacity."
+msgstr "啟用陰影混濁度。"
+
+#: ../src/richtext/richtextbackgroundpage.cpp:335
+#: ../src/richtext/richtextbackgroundpage.cpp:337
+msgid "The shadow opacity."
+msgstr "陰影混濁度。"
+
+#. TRANSLATORS: Rich text page units (percentage)
+#: ../src/richtext/richtextbackgroundpage.cpp:340
+#: ../src/richtext/richtextsizepage.cpp:339
+#: ../src/richtext/richtextsizepage.cpp:373
+#: ../src/richtext/richtextsizepage.cpp:400
+#: ../src/richtext/richtextsizepage.cpp:427
+#: ../src/richtext/richtextsizepage.cpp:454
+#: ../src/richtext/richtextsizepage.cpp:481
+#: ../src/richtext/richtextsizepage.cpp:555
+#: ../src/richtext/richtextsizepage.cpp:590
+#: ../src/richtext/richtextsizepage.cpp:625
+#: ../src/richtext/richtextsizepage.cpp:660
+msgid "%"
+msgstr "%"
+
+#: ../src/richtext/richtextborderspage.cpp:229
+#: ../src/richtext/richtextborderspage.cpp:387
+msgid "Border"
+msgstr "邊框"
+
+#: ../src/richtext/richtextborderspage.cpp:242
+#: ../src/richtext/richtextborderspage.cpp:410
+#: ../src/richtext/richtextindentspage.cpp:194
+#: ../src/richtext/richtextliststylepage.cpp:384
+#: ../src/richtext/richtextmarginspage.cpp:185
+#: ../src/richtext/richtextmarginspage.cpp:299
+#: ../src/richtext/richtextsizepage.cpp:531
+#: ../src/richtext/richtextsizepage.cpp:538
+msgid "&Left:"
+msgstr "左側(&L)："
+
+#: ../src/richtext/richtextborderspage.cpp:257
+#: ../src/richtext/richtextborderspage.cpp:259
+msgid "Units for the left border width."
+msgstr "左邊框單位。"
+
+#: ../src/richtext/richtextborderspage.cpp:266
+#: ../src/richtext/richtextborderspage.cpp:268
+#: ../src/richtext/richtextborderspage.cpp:300
+#: ../src/richtext/richtextborderspage.cpp:302
+#: ../src/richtext/richtextborderspage.cpp:334
+#: ../src/richtext/richtextborderspage.cpp:336
+#: ../src/richtext/richtextborderspage.cpp:368
+#: ../src/richtext/richtextborderspage.cpp:370
+#: ../src/richtext/richtextborderspage.cpp:434
+#: ../src/richtext/richtextborderspage.cpp:436
+#: ../src/richtext/richtextborderspage.cpp:468
+#: ../src/richtext/richtextborderspage.cpp:470
+#: ../src/richtext/richtextborderspage.cpp:502
+#: ../src/richtext/richtextborderspage.cpp:504
+#: ../src/richtext/richtextborderspage.cpp:536
+#: ../src/richtext/richtextborderspage.cpp:538
+msgid "The border line style."
+msgstr "邊框線條樣式。"
+
+#: ../src/richtext/richtextborderspage.cpp:276
+#: ../src/richtext/richtextborderspage.cpp:444
+#: ../src/richtext/richtextindentspage.cpp:212
+#: ../src/richtext/richtextliststylepage.cpp:402
+#: ../src/richtext/richtextmarginspage.cpp:210
+#: ../src/richtext/richtextmarginspage.cpp:324
+#: ../src/richtext/richtextsizepage.cpp:601
+#: ../src/richtext/richtextsizepage.cpp:608
+msgid "&Right:"
+msgstr "右側(&R)："
+
+#: ../src/richtext/richtextborderspage.cpp:291
+#: ../src/richtext/richtextborderspage.cpp:293
+msgid "Units for the right border width."
+msgstr "右邊框單位。"
+
+#: ../src/richtext/richtextborderspage.cpp:310
+#: ../src/richtext/richtextborderspage.cpp:478
+#: ../src/richtext/richtextmarginspage.cpp:233
+#: ../src/richtext/richtextmarginspage.cpp:347
+#: ../src/richtext/richtextsizepage.cpp:566
+#: ../src/richtext/richtextsizepage.cpp:573
+msgid "&Top:"
+msgstr "頂端(&T):"
+
+#: ../src/richtext/richtextborderspage.cpp:325
+#: ../src/richtext/richtextborderspage.cpp:327
+msgid "Units for the top border width."
+msgstr "上邊框單位。"
+
+#: ../src/richtext/richtextborderspage.cpp:344
+#: ../src/richtext/richtextborderspage.cpp:512
+#: ../src/richtext/richtextmarginspage.cpp:258
+#: ../src/richtext/richtextmarginspage.cpp:372
+#: ../src/richtext/richtextsizepage.cpp:636
+#: ../src/richtext/richtextsizepage.cpp:643
+msgid "&Bottom:"
+msgstr "底端(&B):"
+
+#: ../src/richtext/richtextborderspage.cpp:359
+#: ../src/richtext/richtextborderspage.cpp:361
+msgid "Units for the bottom border width."
+msgstr "下邊框單位。"
+
+#: ../src/richtext/richtextborderspage.cpp:380
+#: ../src/richtext/richtextborderspage.cpp:548
+msgid "&Synchronize values"
+msgstr "將值同步化(&S)"
+
+#: ../src/richtext/richtextborderspage.cpp:382
+#: ../src/richtext/richtextborderspage.cpp:384
+#: ../src/richtext/richtextborderspage.cpp:550
+#: ../src/richtext/richtextborderspage.cpp:552
+msgid "Check to edit all borders simultaneously."
+msgstr "勾選後可同時編輯所有邊框。"
+
+#: ../src/richtext/richtextborderspage.cpp:397
+#: ../src/richtext/richtextborderspage.cpp:555
+msgid "Outline"
+msgstr "輪廓"
+
+#: ../src/richtext/richtextborderspage.cpp:425
+#: ../src/richtext/richtextborderspage.cpp:427
+msgid "Units for the left outline width."
+msgstr "左輪廓單位。"
+
+#: ../src/richtext/richtextborderspage.cpp:459
+#: ../src/richtext/richtextborderspage.cpp:461
+msgid "Units for the right outline width."
+msgstr "右輪廓單位。"
+
+#: ../src/richtext/richtextborderspage.cpp:493
+#: ../src/richtext/richtextborderspage.cpp:495
+msgid "Units for the top outline width."
+msgstr "上輪廓單位。"
+
+#: ../src/richtext/richtextborderspage.cpp:527
+#: ../src/richtext/richtextborderspage.cpp:529
+msgid "Units for the bottom outline width."
+msgstr "下輪廓單位。"
+
+#: ../src/richtext/richtextborderspage.cpp:565
+#: ../src/richtext/richtextborderspage.cpp:600
+msgid "Corner"
+msgstr "角位"
+
+#: ../src/richtext/richtextborderspage.cpp:574
+msgid "Corner &radius:"
+msgstr "角位半徑(&r)："
+
+#: ../src/richtext/richtextborderspage.cpp:576
+#: ../src/richtext/richtextborderspage.cpp:578
+msgid "An optional corner radius for adding rounded corners."
+msgstr "加入圓角時的半徑 （可有可無）"
+
+#: ../src/richtext/richtextborderspage.cpp:584
+#: ../src/richtext/richtextborderspage.cpp:586
+msgid "The value of the corner radius."
+msgstr "角位半徑值。"
+
+#: ../src/richtext/richtextborderspage.cpp:595
+#: ../src/richtext/richtextborderspage.cpp:597
+msgid "Units for the corner radius."
+msgstr "角位半徑單位。"
+
+#: ../src/richtext/richtextborderspage.cpp:609
+#: ../src/richtext/richtextsizepage.cpp:247
+#: ../src/richtext/richtextsizepage.cpp:251
+msgid "None"
+msgstr "無"
+
+#: ../src/richtext/richtextborderspage.cpp:610
+msgid "Solid"
+msgstr "單色"
+
+#: ../src/richtext/richtextborderspage.cpp:611
+msgid "Dotted"
+msgstr "點線"
+
+#: ../src/richtext/richtextborderspage.cpp:612
+msgid "Dashed"
+msgstr "虛線"
+
+#: ../src/richtext/richtextborderspage.cpp:613
+msgid "Double"
+msgstr "雙線"
+
+#: ../src/richtext/richtextborderspage.cpp:614
+msgid "Groove"
+msgstr "溝槽"
+
+#: ../src/richtext/richtextborderspage.cpp:615
+msgid "Ridge"
+msgstr "背脊"
+
+#: ../src/richtext/richtextborderspage.cpp:616
+msgid "Inset"
+msgstr "內縮"
+
+#: ../src/richtext/richtextborderspage.cpp:617
+msgid "Outset"
+msgstr "外貼"
+
+#: ../src/richtext/richtextbuffer.cpp:3518
+msgid "Change Style"
+msgstr "變更樣式"
+
+#: ../src/richtext/richtextbuffer.cpp:3701
+msgid "Change Object Style"
+msgstr "變更物件樣式"
+
+#: ../src/richtext/richtextbuffer.cpp:3974
+#: ../src/richtext/richtextbuffer.cpp:8174
+msgid "Change Properties"
+msgstr "變更屬性"
+
+#: ../src/richtext/richtextbuffer.cpp:4346
+msgid "Change List Style"
+msgstr "變更清單樣式"
+
+#: ../src/richtext/richtextbuffer.cpp:4519
+msgid "Renumber List"
+msgstr "重新編號清單"
+
+#: ../src/richtext/richtextbuffer.cpp:7867
+#: ../src/richtext/richtextbuffer.cpp:7897
+#: ../src/richtext/richtextbuffer.cpp:7939
+#: ../src/richtext/richtextctrl.cpp:1279 ../src/richtext/richtextctrl.cpp:1473
+msgid "Insert Text"
+msgstr "插入文字"
+
+#: ../src/richtext/richtextbuffer.cpp:8023
+#: ../src/richtext/richtextbuffer.cpp:8979
+msgid "Insert Image"
+msgstr "插入圖片"
+
+#: ../src/richtext/richtextbuffer.cpp:8070
+msgid "Insert Object"
+msgstr "插入物件"
+
+#: ../src/richtext/richtextbuffer.cpp:8112
+msgid "Insert Field"
+msgstr "插入欄位"
+
+#: ../src/richtext/richtextbuffer.cpp:8410
+msgid "Too many EndStyle calls!"
+msgstr "調用 EndStyle 太多次！"
+
+#: ../src/richtext/richtextbuffer.cpp:8785
+msgid "files"
+msgstr "檔案"
+
+#: ../src/richtext/richtextbuffer.cpp:9380
+msgid "standard/circle"
+msgstr "標準/圓形"
+
+#: ../src/richtext/richtextbuffer.cpp:9381
+msgid "standard/circle-outline"
+msgstr "標準/圓框"
+
+#: ../src/richtext/richtextbuffer.cpp:9382
+msgid "standard/square"
+msgstr "標準/方形"
+
+#: ../src/richtext/richtextbuffer.cpp:9383
+msgid "standard/diamond"
+msgstr "標準/菱形"
+
+#: ../src/richtext/richtextbuffer.cpp:9384
+msgid "standard/triangle"
+msgstr "標準/三角形"
+
+#: ../src/richtext/richtextbuffer.cpp:9423
+msgid "Box Properties"
+msgstr "文字方塊屬性"
+
+#: ../src/richtext/richtextbuffer.cpp:10006
+msgid "Multiple Cell Properties"
+msgstr "儲存格屬性 (多個)"
+
+#: ../src/richtext/richtextbuffer.cpp:10008
+msgid "Cell Properties"
+msgstr "儲存格屬性"
+
+#: ../src/richtext/richtextbuffer.cpp:11256
+msgid "Set Cell Style"
+msgstr "設定儲存格樣式"
+
+#: ../src/richtext/richtextbuffer.cpp:11330
+msgid "Delete Row"
+msgstr "刪除橫列"
+
+#: ../src/richtext/richtextbuffer.cpp:11380
+msgid "Delete Column"
+msgstr "刪除欄位"
+
+#: ../src/richtext/richtextbuffer.cpp:11431
+msgid "Add Row"
+msgstr "加入橫列"
+
+#: ../src/richtext/richtextbuffer.cpp:11494
+msgid "Add Column"
+msgstr "加入欄位"
+
+#: ../src/richtext/richtextbuffer.cpp:11537
+msgid "Table Properties"
+msgstr "表格屬性"
+
+#: ../src/richtext/richtextbuffer.cpp:12899
+msgid "Picture Properties"
+msgstr "圖片屬性"
+
+#: ../src/richtext/richtextbuffer.cpp:13169
+#: ../src/richtext/richtextbuffer.cpp:13279
+msgid "image"
+msgstr "影像"
+
+#: ../src/richtext/richtextbulletspage.cpp:145
+#: ../src/richtext/richtextliststylepage.cpp:209
+msgid "&Bullet style:"
+msgstr "項目符號樣式(&B):"
+
+#: ../src/richtext/richtextbulletspage.cpp:150
+#: ../src/richtext/richtextbulletspage.cpp:152
+#: ../src/richtext/richtextliststylepage.cpp:214
+#: ../src/richtext/richtextliststylepage.cpp:216
+msgid "The available bullet styles."
+msgstr "可用的項目符號樣式。"
+
+#: ../src/richtext/richtextbulletspage.cpp:158
+#: ../src/richtext/richtextliststylepage.cpp:221
+msgid "Peri&od"
+msgstr "週期(&O)"
+
+#: ../src/richtext/richtextbulletspage.cpp:160
+#: ../src/richtext/richtextbulletspage.cpp:162
+#: ../src/richtext/richtextliststylepage.cpp:223
+#: ../src/richtext/richtextliststylepage.cpp:225
+msgid "Check to add a period after the bullet."
+msgstr "勾選後可在項目符號後加上半形句點。"
+
+#. TRANSLATORS: Bullet point in parentheses option
+#: ../src/richtext/richtextbulletspage.cpp:167
+#: ../src/richtext/richtextliststylepage.cpp:230
+msgid "(*)"
+msgstr "(*)"
+
+#: ../src/richtext/richtextbulletspage.cpp:169
+#: ../src/richtext/richtextbulletspage.cpp:171
+#: ../src/richtext/richtextliststylepage.cpp:232
+#: ../src/richtext/richtextliststylepage.cpp:234
+msgid "Check to enclose the bullet in parentheses."
+msgstr "勾選後可將項目符號加上一對括號。"
+
+#. TRANSLATORS: Right parenthesis bullet point option
+#: ../src/richtext/richtextbulletspage.cpp:176
+#: ../src/richtext/richtextliststylepage.cpp:239
+msgid "*)"
+msgstr "*)"
+
+#: ../src/richtext/richtextbulletspage.cpp:178
+#: ../src/richtext/richtextbulletspage.cpp:180
+#: ../src/richtext/richtextliststylepage.cpp:241
+#: ../src/richtext/richtextliststylepage.cpp:243
+msgid "Check to add a right parenthesis."
+msgstr "勾選後可加上右括號。"
+
+#: ../src/richtext/richtextbulletspage.cpp:185
+#: ../src/richtext/richtextliststylepage.cpp:248
+msgid "Bullet &Alignment:"
+msgstr "項目符號對齊(&A):"
+
+#: ../src/richtext/richtextbulletspage.cpp:190
+#: ../src/richtext/richtextliststylepage.cpp:253
+msgid "Centre"
+msgstr "置中對齊"
+
+#: ../src/richtext/richtextbulletspage.cpp:194
+#: ../src/richtext/richtextbulletspage.cpp:196
+#: ../src/richtext/richtextbulletspage.cpp:217
+#: ../src/richtext/richtextbulletspage.cpp:219
+#: ../src/richtext/richtextliststylepage.cpp:257
+#: ../src/richtext/richtextliststylepage.cpp:259
+#: ../src/richtext/richtextliststylepage.cpp:278
+#: ../src/richtext/richtextliststylepage.cpp:280
+msgid "The bullet character."
+msgstr "項目符號字元。"
+
+#: ../src/richtext/richtextbulletspage.cpp:212
+#: ../src/richtext/richtextliststylepage.cpp:271
+msgid "&Symbol:"
+msgstr "符號(&S)："
+
+#: ../src/richtext/richtextbulletspage.cpp:222
+#: ../src/richtext/richtextliststylepage.cpp:283
+msgid "Ch&oose..."
+msgstr "選擇(&O)…"
+
+#: ../src/richtext/richtextbulletspage.cpp:223
+#: ../src/richtext/richtextbulletspage.cpp:225
+#: ../src/richtext/richtextliststylepage.cpp:284
+#: ../src/richtext/richtextliststylepage.cpp:286
+msgid "Click to browse for a symbol."
+msgstr "點擊瀏覽該符號。"
+
+#: ../src/richtext/richtextbulletspage.cpp:230
+#: ../src/richtext/richtextliststylepage.cpp:291
+msgid "Symbol &font:"
+msgstr "符號字型(&F)："
+
+#: ../src/richtext/richtextbulletspage.cpp:235
+#: ../src/richtext/richtextbulletspage.cpp:237
+#: ../src/richtext/richtextliststylepage.cpp:297
+msgid "Available fonts."
+msgstr "可用的字型。"
+
+#: ../src/richtext/richtextbulletspage.cpp:242
+#: ../src/richtext/richtextliststylepage.cpp:302
+msgid "S&tandard bullet name:"
+msgstr "標準項目符號名稱(&T):"
+
+#: ../src/richtext/richtextbulletspage.cpp:247
+#: ../src/richtext/richtextbulletspage.cpp:249
+#: ../src/richtext/richtextliststylepage.cpp:307
+#: ../src/richtext/richtextliststylepage.cpp:309
+msgid "A standard bullet name."
+msgstr "標準的項目符號名稱。"
+
+#: ../src/richtext/richtextbulletspage.cpp:254
+msgid "&Number:"
+msgstr "編號(&N)："
+
+#: ../src/richtext/richtextbulletspage.cpp:258
+#: ../src/richtext/richtextbulletspage.cpp:260
+msgid "The list item number."
+msgstr "清單項目編號。"
+
+#: ../src/richtext/richtextbulletspage.cpp:266
+#: ../src/richtext/richtextbulletspage.cpp:268
+#: ../src/richtext/richtextliststylepage.cpp:475
+#: ../src/richtext/richtextliststylepage.cpp:477
+msgid "Shows a preview of the bullet settings."
+msgstr "預覽項目符號設定。"
+
+#: ../src/richtext/richtextbulletspage.cpp:276
+#: ../src/richtext/richtextliststylepage.cpp:484
+msgid "(None)"
+msgstr "(無)"
+
+#: ../src/richtext/richtextbulletspage.cpp:277
+#: ../src/richtext/richtextliststylepage.cpp:485
+msgid "Arabic"
+msgstr "阿拉伯文"
+
+#: ../src/richtext/richtextbulletspage.cpp:278
+#: ../src/richtext/richtextliststylepage.cpp:486
+msgid "Upper case letters"
+msgstr "大寫字母"
+
+#: ../src/richtext/richtextbulletspage.cpp:279
+#: ../src/richtext/richtextliststylepage.cpp:487
+msgid "Lower case letters"
+msgstr "小寫字母"
+
+#: ../src/richtext/richtextbulletspage.cpp:280
+#: ../src/richtext/richtextliststylepage.cpp:488
+msgid "Upper case roman numerals"
+msgstr "大寫羅馬數字"
+
+#: ../src/richtext/richtextbulletspage.cpp:281
+#: ../src/richtext/richtextliststylepage.cpp:489
+msgid "Lower case roman numerals"
+msgstr "小寫羅馬數字"
+
+#: ../src/richtext/richtextbulletspage.cpp:282
+#: ../src/richtext/richtextliststylepage.cpp:490
+msgid "Numbered outline"
+msgstr "大綱編號"
+
+#: ../src/richtext/richtextbulletspage.cpp:283
+#: ../src/richtext/richtextliststylepage.cpp:491
+msgid "Symbol"
+msgstr "符號"
+
+#: ../src/richtext/richtextbulletspage.cpp:284
+#: ../src/richtext/richtextliststylepage.cpp:492
+msgid "Bitmap"
+msgstr "點陣圖"
+
+#: ../src/richtext/richtextbulletspage.cpp:285
+#: ../src/richtext/richtextliststylepage.cpp:493
+msgid "Standard"
+msgstr "標準"
+
+#: ../src/richtext/richtextbulletspage.cpp:287
+#: ../src/richtext/richtextliststylepage.cpp:495
+msgid "*"
+msgstr "*"
+
+#: ../src/richtext/richtextbulletspage.cpp:288
+#: ../src/richtext/richtextliststylepage.cpp:496
+msgid "-"
+msgstr "-"
+
+#: ../src/richtext/richtextbulletspage.cpp:289
+#: ../src/richtext/richtextliststylepage.cpp:497
+msgid ">"
+msgstr ">"
+
+#: ../src/richtext/richtextbulletspage.cpp:290
+#: ../src/richtext/richtextliststylepage.cpp:498
+msgid "+"
+msgstr "+"
+
+#: ../src/richtext/richtextbulletspage.cpp:291
+#: ../src/richtext/richtextliststylepage.cpp:499
+msgid "~"
+msgstr "~"
+
+#: ../src/richtext/richtextctrl.cpp:859
+msgid "Drag"
+msgstr "拖曳"
+
+#: ../src/richtext/richtextctrl.cpp:1338 ../src/richtext/richtextctrl.cpp:1559
+msgid "Delete Text"
+msgstr "刪除文字"
+
+#: ../src/richtext/richtextctrl.cpp:1537
+msgid "Remove Bullet"
+msgstr "移除項目符號"
+
+#: ../src/richtext/richtextctrl.cpp:3070
+msgid "The text couldn't be saved."
+msgstr "無法儲存文字。"
+
+#: ../src/richtext/richtextctrl.cpp:3644
+msgid "Replace"
+msgstr "更改"
+
+#: ../src/richtext/richtextfontpage.cpp:146
+#: ../src/richtext/richtextsymboldlg.cpp:384
+msgid "&Font:"
+msgstr "字型(&F)："
+
+#: ../src/richtext/richtextfontpage.cpp:150
+#: ../src/richtext/richtextfontpage.cpp:152
+msgid "Type a font name."
+msgstr "輸入字型名稱。"
+
+#: ../src/richtext/richtextfontpage.cpp:158
+msgid "&Size:"
+msgstr "大小(&S)："
+
+#: ../src/richtext/richtextfontpage.cpp:165
+#: ../src/richtext/richtextfontpage.cpp:167
+msgid "Type a size in points."
+msgstr "輸入大小，單位為點數。"
+
+#: ../src/richtext/richtextfontpage.cpp:180
+#: ../src/richtext/richtextfontpage.cpp:182
+msgid "The font size units, points or pixels."
+msgstr "字型大小單位，以點或像素計。"
+
+#: ../src/richtext/richtextfontpage.cpp:189
+#: ../src/richtext/richtextfontpage.cpp:191
+msgid "Lists the available fonts."
+msgstr "可用字型的清單。"
+
+#: ../src/richtext/richtextfontpage.cpp:196
+#: ../src/richtext/richtextfontpage.cpp:198
+msgid "Lists font sizes in points."
+msgstr "清單字型大小。"
+
+#: ../src/richtext/richtextfontpage.cpp:207
+msgid "Font st&yle:"
+msgstr "字型樣式(&Y)："
+
+#: ../src/richtext/richtextfontpage.cpp:212
+#: ../src/richtext/richtextfontpage.cpp:214
+msgid "Select regular or italic style."
+msgstr "選擇是否斜體。"
+
+#: ../src/richtext/richtextfontpage.cpp:220
+msgid "Font &weight:"
+msgstr "字型粗細(&W)："
+
+#: ../src/richtext/richtextfontpage.cpp:225
+#: ../src/richtext/richtextfontpage.cpp:227
+msgid "Select regular or bold."
+msgstr "選擇是否粗體。"
+
+#: ../src/richtext/richtextfontpage.cpp:233
+msgid "&Underlining:"
+msgstr "加底線(&U)："
+
+#: ../src/richtext/richtextfontpage.cpp:238
+#: ../src/richtext/richtextfontpage.cpp:240
+msgid "Select underlining or no underlining."
+msgstr "選擇是否加底線。"
+
+#: ../src/richtext/richtextfontpage.cpp:248
+msgid "&Colour:"
+msgstr "顏色(&C)："
+
+#: ../src/richtext/richtextfontpage.cpp:253
+#: ../src/richtext/richtextfontpage.cpp:255
+msgid "Click to change the text colour."
+msgstr "點擊變更文字顏色。"
+
+#: ../src/richtext/richtextfontpage.cpp:261
+msgid "&Bg colour:"
+msgstr "背景顏色(&B)："
+
+#: ../src/richtext/richtextfontpage.cpp:266
+#: ../src/richtext/richtextfontpage.cpp:268
+msgid "Click to change the text background colour."
+msgstr "點擊變更文字背景顏色。"
+
+#: ../src/richtext/richtextfontpage.cpp:276
+#: ../src/richtext/richtextfontpage.cpp:278
+msgid "Check to show a line through the text."
+msgstr "勾選後可將字加上刪除線。"
+
+#: ../src/richtext/richtextfontpage.cpp:281
+msgid "Ca&pitals"
+msgstr "大寫(&P)"
+
+#: ../src/richtext/richtextfontpage.cpp:283
+#: ../src/richtext/richtextfontpage.cpp:285
+msgid "Check to show the text in capitals."
+msgstr "勾選後可將字變成大寫。"
+
+#: ../src/richtext/richtextfontpage.cpp:288
+msgid "Small C&apitals"
+msgstr "小型大寫字(&A)"
+
+#: ../src/richtext/richtextfontpage.cpp:290
+#: ../src/richtext/richtextfontpage.cpp:292
+msgid "Check to show the text in small capitals."
+msgstr "勾選後可將字變成小型大寫字。"
+
+#: ../src/richtext/richtextfontpage.cpp:295
+msgid "Supe&rscript"
+msgstr "下標(&R)"
+
+#: ../src/richtext/richtextfontpage.cpp:297
+#: ../src/richtext/richtextfontpage.cpp:299
+msgid "Check to show the text in superscript."
+msgstr "勾選後可將字上標。"
+
+#: ../src/richtext/richtextfontpage.cpp:302
+msgid "Subscrip&t"
+msgstr "下標(&T)"
+
+#: ../src/richtext/richtextfontpage.cpp:304
+#: ../src/richtext/richtextfontpage.cpp:306
+msgid "Check to show the text in subscript."
+msgstr "勾選後可將字下標。"
+
+#: ../src/richtext/richtextfontpage.cpp:312
+msgid "Rig&ht-to-left"
+msgstr "右至左(&H)"
+
+#: ../src/richtext/richtextfontpage.cpp:314
+#: ../src/richtext/richtextfontpage.cpp:316
+msgid "Check to indicate right-to-left text layout."
+msgstr "勾選後可指明右至左文字配置。"
+
+#: ../src/richtext/richtextfontpage.cpp:319
+msgid "Suppress hyphe&nation"
+msgstr "抑制將同一英文字分行顯示(&n)"
+
+#: ../src/richtext/richtextfontpage.cpp:321
+#: ../src/richtext/richtextfontpage.cpp:323
+msgid "Check to suppress hyphenation."
+msgstr "勾選後可抑制將同一英文字分行顯示。"
+
+#: ../src/richtext/richtextfontpage.cpp:329
+#: ../src/richtext/richtextfontpage.cpp:331
+msgid "Shows a preview of the font settings."
+msgstr "顯示字型設定預覽。"
+
+#: ../src/richtext/richtextfontpage.cpp:348
+#: ../src/richtext/richtextfontpage.cpp:352
+#: ../src/richtext/richtextfontpage.cpp:356
+#: ../src/richtext/richtextformatdlg.cpp:873
+#: ../src/richtext/richtextindentspage.cpp:273
+#: ../src/richtext/richtextindentspage.cpp:285
+#: ../src/richtext/richtextindentspage.cpp:286
+#: ../src/richtext/richtextindentspage.cpp:310
+#: ../src/richtext/richtextindentspage.cpp:325
+#: ../src/richtext/richtextliststylepage.cpp:451
+#: ../src/richtext/richtextliststylepage.cpp:463
+#: ../src/richtext/richtextliststylepage.cpp:464
+msgid "(none)"
+msgstr "(無)"
+
+#: ../src/richtext/richtextfontpage.cpp:349
+#: ../src/richtext/richtextfontpage.cpp:353
+msgid "Regular"
+msgstr "正規"
+
+#: ../src/richtext/richtextfontpage.cpp:357
+msgid "Not underlined"
+msgstr "未加底線"
+
+#: ../src/richtext/richtextformatdlg.cpp:341
+msgid "Indents && Spacing"
+msgstr "縮排與間距"
+
+#: ../src/richtext/richtextformatdlg.cpp:346
+msgid "Tabs"
+msgstr "欄標"
+
+#: ../src/richtext/richtextformatdlg.cpp:351
+msgid "Bullets"
+msgstr "項目符號"
+
+#: ../src/richtext/richtextformatdlg.cpp:356
+msgid "List Style"
+msgstr "清單樣式"
+
+#: ../src/richtext/richtextformatdlg.cpp:366
+#: ../src/richtext/richtextmarginspage.cpp:170
+msgid "Margins"
+msgstr "外邊距"
+
+#: ../src/richtext/richtextformatdlg.cpp:371
+msgid "Borders"
+msgstr "邊框"
+
+#: ../src/richtext/richtextformatdlg.cpp:765
+msgid "Colour"
+msgstr "顏色"
+
+#: ../src/richtext/richtextindentspage.cpp:127
+#: ../src/richtext/richtextliststylepage.cpp:322
+msgid "&Alignment"
+msgstr "對齊(&A)"
+
+#: ../src/richtext/richtextindentspage.cpp:138
+#: ../src/richtext/richtextliststylepage.cpp:331
+msgid "&Left"
+msgstr "左側(&L)"
+
+#: ../src/richtext/richtextindentspage.cpp:140
+#: ../src/richtext/richtextindentspage.cpp:142
+#: ../src/richtext/richtextliststylepage.cpp:333
+#: ../src/richtext/richtextliststylepage.cpp:335
+msgid "Left-align text."
+msgstr "文字向左對齊。"
+
+#: ../src/richtext/richtextindentspage.cpp:145
+#: ../src/richtext/richtextliststylepage.cpp:338
+msgid "&Right"
+msgstr "右側(&R)"
+
+#: ../src/richtext/richtextindentspage.cpp:147
+#: ../src/richtext/richtextindentspage.cpp:149
+#: ../src/richtext/richtextliststylepage.cpp:340
+#: ../src/richtext/richtextliststylepage.cpp:342
+msgid "Right-align text."
+msgstr "文字向右對齊。"
+
+#: ../src/richtext/richtextindentspage.cpp:152
+#: ../src/richtext/richtextliststylepage.cpp:345
+msgid "&Justified"
+msgstr "分散對齊(&J)"
+
+#: ../src/richtext/richtextindentspage.cpp:154
+#: ../src/richtext/richtextindentspage.cpp:156
+#: ../src/richtext/richtextliststylepage.cpp:347
+#: ../src/richtext/richtextliststylepage.cpp:349
+msgid "Justify text left and right."
+msgstr "文字左右對齊。"
+
+#: ../src/richtext/richtextindentspage.cpp:159
+#: ../src/richtext/richtextliststylepage.cpp:352
+msgid "Cen&tred"
+msgstr "置中對齊(&T)"
+
+#: ../src/richtext/richtextindentspage.cpp:161
+#: ../src/richtext/richtextindentspage.cpp:163
+#: ../src/richtext/richtextliststylepage.cpp:354
+#: ../src/richtext/richtextliststylepage.cpp:356
+msgid "Centre text."
+msgstr "置中對齊文字。"
+
+#: ../src/richtext/richtextindentspage.cpp:166
+#: ../src/richtext/richtextliststylepage.cpp:359
+msgid "&Indeterminate"
+msgstr "尚未確定&I)"
+
+#: ../src/richtext/richtextindentspage.cpp:168
+#: ../src/richtext/richtextindentspage.cpp:170
+#: ../src/richtext/richtextliststylepage.cpp:361
+#: ../src/richtext/richtextliststylepage.cpp:363
+msgid "Use the current alignment setting."
+msgstr "使用目前的對齊設定。"
+
+#: ../src/richtext/richtextindentspage.cpp:183
+#: ../src/richtext/richtextliststylepage.cpp:375
+msgid "&Indentation (tenths of a mm)"
+msgstr "縮排(&I) (十分之一公釐[mm])"
+
+#: ../src/richtext/richtextindentspage.cpp:198
+#: ../src/richtext/richtextindentspage.cpp:200
+#: ../src/richtext/richtextliststylepage.cpp:388
+#: ../src/richtext/richtextliststylepage.cpp:390
+msgid "The left indent."
+msgstr "左側縮排。"
+
+#: ../src/richtext/richtextindentspage.cpp:203
+#: ../src/richtext/richtextliststylepage.cpp:393
+msgid "Left (&first line):"
+msgstr "左(第一列)(&F):"
+
+#: ../src/richtext/richtextindentspage.cpp:207
+#: ../src/richtext/richtextindentspage.cpp:209
+#: ../src/richtext/richtextliststylepage.cpp:397
+#: ../src/richtext/richtextliststylepage.cpp:399
+msgid "The first line indent."
+msgstr "首列縮排。"
+
+#: ../src/richtext/richtextindentspage.cpp:216
+#: ../src/richtext/richtextindentspage.cpp:218
+#: ../src/richtext/richtextliststylepage.cpp:406
+#: ../src/richtext/richtextliststylepage.cpp:408
+msgid "The right indent."
+msgstr "右側縮排。"
+
+#: ../src/richtext/richtextindentspage.cpp:221
+msgid "&Outline level:"
+msgstr "大綱層級(&O)："
+
+#: ../src/richtext/richtextindentspage.cpp:226
+#: ../src/richtext/richtextindentspage.cpp:228
+msgid "The outline level."
+msgstr "大綱層級。"
+
+#: ../src/richtext/richtextindentspage.cpp:241
+#: ../src/richtext/richtextliststylepage.cpp:420
+msgid "&Spacing (tenths of a mm)"
+msgstr "間距(&S) (十分之一公釐[mm])"
+
+#: ../src/richtext/richtextindentspage.cpp:252
+msgid "&Before a paragraph:"
+msgstr "段落之前(&B)："
+
+#: ../src/richtext/richtextindentspage.cpp:256
+#: ../src/richtext/richtextindentspage.cpp:258
+#: ../src/richtext/richtextliststylepage.cpp:433
+#: ../src/richtext/richtextliststylepage.cpp:435
+msgid "The spacing before the paragraph."
+msgstr "段落之前的間距。"
+
+#: ../src/richtext/richtextindentspage.cpp:261
+msgid "&After a paragraph:"
+msgstr "段落之後(&A)："
+
+#: ../src/richtext/richtextindentspage.cpp:266
+#: ../src/richtext/richtextliststylepage.cpp:442
+#: ../src/richtext/richtextliststylepage.cpp:444
+msgid "The spacing after the paragraph."
+msgstr "段落之後的間距。"
+
+#: ../src/richtext/richtextindentspage.cpp:269
+msgid "L&ine spacing:"
+msgstr "列距(&I):"
+
+#: ../src/richtext/richtextindentspage.cpp:274
+#: ../src/richtext/richtextliststylepage.cpp:452
+msgid "Single"
+msgstr "單一"
+
+#: ../src/richtext/richtextindentspage.cpp:275
+#: ../src/richtext/richtextliststylepage.cpp:453
+msgid "1.1"
+msgstr "1.1"
+
+#: ../src/richtext/richtextindentspage.cpp:276
+#: ../src/richtext/richtextliststylepage.cpp:454
+msgid "1.2"
+msgstr "1.2"
+
+#: ../src/richtext/richtextindentspage.cpp:277
+#: ../src/richtext/richtextliststylepage.cpp:455
+msgid "1.3"
+msgstr "1.3"
+
+#: ../src/richtext/richtextindentspage.cpp:278
+#: ../src/richtext/richtextliststylepage.cpp:456
+msgid "1.4"
+msgstr "1.4"
+
+#: ../src/richtext/richtextindentspage.cpp:279
+#: ../src/richtext/richtextliststylepage.cpp:457
+msgid "1.5"
+msgstr "1.5"
+
+#: ../src/richtext/richtextindentspage.cpp:280
+#: ../src/richtext/richtextliststylepage.cpp:458
+msgid "1.6"
+msgstr "1.6"
+
+#: ../src/richtext/richtextindentspage.cpp:281
+#: ../src/richtext/richtextliststylepage.cpp:459
+msgid "1.7"
+msgstr "1.7"
+
+#: ../src/richtext/richtextindentspage.cpp:282
+#: ../src/richtext/richtextliststylepage.cpp:460
+msgid "1.8"
+msgstr "1.8"
+
+#: ../src/richtext/richtextindentspage.cpp:283
+#: ../src/richtext/richtextliststylepage.cpp:461
+msgid "1.9"
+msgstr "1.9"
+
+#: ../src/richtext/richtextindentspage.cpp:284
+#: ../src/richtext/richtextliststylepage.cpp:462
+msgid "2"
+msgstr "2"
+
+#: ../src/richtext/richtextindentspage.cpp:287
+#: ../src/richtext/richtextindentspage.cpp:289
+#: ../src/richtext/richtextliststylepage.cpp:465
+#: ../src/richtext/richtextliststylepage.cpp:467
+msgid "The line spacing."
+msgstr "列距。"
+
+#: ../src/richtext/richtextindentspage.cpp:292
+msgid "&Page Break"
+msgstr "換頁符號(&P)"
+
+#: ../src/richtext/richtextindentspage.cpp:294
+#: ../src/richtext/richtextindentspage.cpp:296
+msgid "Inserts a page break before the paragraph."
+msgstr "在段落前插入換頁符號。"
+
+#: ../src/richtext/richtextindentspage.cpp:302
+#: ../src/richtext/richtextindentspage.cpp:304
+msgid "Shows a preview of the paragraph settings."
+msgstr "預覽段落設定。"
+
+#: ../src/richtext/richtextliststylepage.cpp:182
+msgid "&List level:"
+msgstr "清單層級(&L)："
+
+#: ../src/richtext/richtextliststylepage.cpp:186
+#: ../src/richtext/richtextliststylepage.cpp:188
+msgid "Selects the list level to edit."
+msgstr "選取並編輯該清單層級。"
+
+#: ../src/richtext/richtextliststylepage.cpp:193
+msgid "&Font for Level..."
+msgstr "層級字型(&F)..."
+
+#: ../src/richtext/richtextliststylepage.cpp:194
+#: ../src/richtext/richtextliststylepage.cpp:196
+msgid "Click to choose the font for this level."
+msgstr "點擊選擇此層級的字型。"
+
+#: ../src/richtext/richtextliststylepage.cpp:312
+msgid "Bullet style"
+msgstr "項目符號樣式"
+
+#: ../src/richtext/richtextliststylepage.cpp:429
+msgid "Before a paragraph:"
+msgstr "段落之前："
+
+#: ../src/richtext/richtextliststylepage.cpp:438
+msgid "After a paragraph:"
+msgstr "段落之後："
+
+#: ../src/richtext/richtextliststylepage.cpp:447
+msgid "Line spacing:"
+msgstr "列距:"
+
+#: ../src/richtext/richtextliststylepage.cpp:470
+msgid "Spacing"
+msgstr "間距"
+
+#: ../src/richtext/richtextmarginspage.cpp:193
+#: ../src/richtext/richtextmarginspage.cpp:195
+msgid "The left margin size."
+msgstr "左外邊距。"
+
+#: ../src/richtext/richtextmarginspage.cpp:203
+#: ../src/richtext/richtextmarginspage.cpp:205
+msgid "Units for the left margin."
+msgstr "左外邊距單位。"
+
+#: ../src/richtext/richtextmarginspage.cpp:218
+#: ../src/richtext/richtextmarginspage.cpp:220
+msgid "The right margin size."
+msgstr "右外邊距。"
+
+#: ../src/richtext/richtextmarginspage.cpp:228
+#: ../src/richtext/richtextmarginspage.cpp:230
+msgid "Units for the right margin."
+msgstr "右外邊距單位。"
+
+#: ../src/richtext/richtextmarginspage.cpp:241
+#: ../src/richtext/richtextmarginspage.cpp:243
+msgid "The top margin size."
+msgstr "上外邊距。"
+
+#: ../src/richtext/richtextmarginspage.cpp:251
+#: ../src/richtext/richtextmarginspage.cpp:253
+msgid "Units for the top margin."
+msgstr "上外邊距單位。"
+
+#: ../src/richtext/richtextmarginspage.cpp:266
+#: ../src/richtext/richtextmarginspage.cpp:268
+msgid "The bottom margin size."
+msgstr "下外邊距大小。"
+
+#: ../src/richtext/richtextmarginspage.cpp:276
+#: ../src/richtext/richtextmarginspage.cpp:278
+msgid "Units for the bottom margin."
+msgstr "下外邊距單位。"
+
+#: ../src/richtext/richtextmarginspage.cpp:284
+msgid "Padding"
+msgstr "內邊距"
+
+#: ../src/richtext/richtextmarginspage.cpp:307
+#: ../src/richtext/richtextmarginspage.cpp:309
+msgid "The left padding size."
+msgstr "左內邊距。"
+
+#: ../src/richtext/richtextmarginspage.cpp:317
+#: ../src/richtext/richtextmarginspage.cpp:319
+msgid "Units for the left padding."
+msgstr "左內邊距單位。"
+
+#: ../src/richtext/richtextmarginspage.cpp:332
+#: ../src/richtext/richtextmarginspage.cpp:334
+msgid "The right padding size."
+msgstr "右內邊距。"
+
+#: ../src/richtext/richtextmarginspage.cpp:342
+#: ../src/richtext/richtextmarginspage.cpp:344
+msgid "Units for the right padding."
+msgstr "右內邊距單位。"
+
+#: ../src/richtext/richtextmarginspage.cpp:355
+#: ../src/richtext/richtextmarginspage.cpp:357
+msgid "The top padding size."
+msgstr "上內邊距。"
+
+#: ../src/richtext/richtextmarginspage.cpp:365
+#: ../src/richtext/richtextmarginspage.cpp:367
+msgid "Units for the top padding."
+msgstr "上內邊距單位。"
+
+#: ../src/richtext/richtextmarginspage.cpp:380
+#: ../src/richtext/richtextmarginspage.cpp:382
+msgid "The bottom padding size."
+msgstr "下內邊距。"
+
+#: ../src/richtext/richtextmarginspage.cpp:390
+#: ../src/richtext/richtextmarginspage.cpp:392
+msgid "Units for the bottom padding."
+msgstr "下內邊距單位。"
+
+#: ../src/richtext/richtextprint.cpp:592
+msgid " Preview"
+msgstr " 預覽"
+
+#: ../src/richtext/richtextsizepage.cpp:228
+msgid "Floating"
+msgstr "浮動"
+
+#: ../src/richtext/richtextsizepage.cpp:243
+msgid "&Floating mode:"
+msgstr "浮動模式(&F):"
+
+#: ../src/richtext/richtextsizepage.cpp:252
+#: ../src/richtext/richtextsizepage.cpp:254
+msgid "How the object will float relative to the text."
+msgstr "物件與文字之間的相對位置。"
+
+#: ../src/richtext/richtextsizepage.cpp:265
+msgid "Alignment"
+msgstr "對齊"
+
+#: ../src/richtext/richtextsizepage.cpp:277
+msgid "&Vertical alignment:"
+msgstr "垂直對齊(&V)："
+
+#: ../src/richtext/richtextsizepage.cpp:279
+#: ../src/richtext/richtextsizepage.cpp:281
+msgid "Enable vertical alignment."
+msgstr "啟用垂直對齊。"
+
+#: ../src/richtext/richtextsizepage.cpp:286
+msgid "Centred"
+msgstr "置中"
+
+#: ../src/richtext/richtextsizepage.cpp:290
+#: ../src/richtext/richtextsizepage.cpp:292
+msgid "Vertical alignment."
+msgstr "垂直對齊。"
+
+#: ../src/richtext/richtextsizepage.cpp:316
+#: ../src/richtext/richtextsizepage.cpp:323
+msgid "&Width:"
+msgstr "寬度(&W)："
+
+#: ../src/richtext/richtextsizepage.cpp:318
+#: ../src/richtext/richtextsizepage.cpp:320
+msgid "Enable the width value."
+msgstr "啟用寬度值。"
+
+#: ../src/richtext/richtextsizepage.cpp:331
+#: ../src/richtext/richtextsizepage.cpp:333
+msgid "The object width."
+msgstr "物件寬度。"
+
+#: ../src/richtext/richtextsizepage.cpp:342
+#: ../src/richtext/richtextsizepage.cpp:344
+msgid "Units for the object width."
+msgstr "物件寬度單位。"
+
+#: ../src/richtext/richtextsizepage.cpp:350
+#: ../src/richtext/richtextsizepage.cpp:357
+msgid "&Height:"
+msgstr "高度(&H):"
+
+#: ../src/richtext/richtextsizepage.cpp:352
+#: ../src/richtext/richtextsizepage.cpp:354
+#: ../src/richtext/richtextsizepage.cpp:464
+#: ../src/richtext/richtextsizepage.cpp:466
+msgid "Enable the height value."
+msgstr "啟用高度值。"
+
+#: ../src/richtext/richtextsizepage.cpp:365
+#: ../src/richtext/richtextsizepage.cpp:367
+msgid "The object height."
+msgstr "物件高度。"
+
+#: ../src/richtext/richtextsizepage.cpp:376
+#: ../src/richtext/richtextsizepage.cpp:378
+msgid "Units for the object height."
+msgstr "物件高度單位。"
+
+#: ../src/richtext/richtextsizepage.cpp:381
+msgid "Min width:"
+msgstr "最小寬度："
+
+#: ../src/richtext/richtextsizepage.cpp:383
+#: ../src/richtext/richtextsizepage.cpp:385
+msgid "Enable the minimum width value."
+msgstr "啟用最小寬度值。"
+
+#: ../src/richtext/richtextsizepage.cpp:392
+#: ../src/richtext/richtextsizepage.cpp:394
+msgid "The object minimum width."
+msgstr "物件最小寬度。"
+
+#: ../src/richtext/richtextsizepage.cpp:403
+#: ../src/richtext/richtextsizepage.cpp:405
+msgid "Units for the minimum object width."
+msgstr "最小物件寬度的單位。"
+
+#: ../src/richtext/richtextsizepage.cpp:408
+msgid "Min height:"
+msgstr "最小高度："
+
+#: ../src/richtext/richtextsizepage.cpp:410
+#: ../src/richtext/richtextsizepage.cpp:412
+msgid "Enable the minimum height value."
+msgstr "啟用最小高度值。"
+
+#: ../src/richtext/richtextsizepage.cpp:419
+#: ../src/richtext/richtextsizepage.cpp:421
+msgid "The object minimum height."
+msgstr "物件最小高度。"
+
+#: ../src/richtext/richtextsizepage.cpp:430
+#: ../src/richtext/richtextsizepage.cpp:432
+msgid "Units for the minimum object height."
+msgstr "最小物件高度的單位。"
+
+#: ../src/richtext/richtextsizepage.cpp:435
+msgid "Max width:"
+msgstr "最大寬度："
+
+#: ../src/richtext/richtextsizepage.cpp:437
+#: ../src/richtext/richtextsizepage.cpp:439
+msgid "Enable the maximum width value."
+msgstr "啟用最大寬度值。"
+
+#: ../src/richtext/richtextsizepage.cpp:446
+#: ../src/richtext/richtextsizepage.cpp:448
+msgid "The object maximum width."
+msgstr "物件最大寬度。"
+
+#: ../src/richtext/richtextsizepage.cpp:457
+#: ../src/richtext/richtextsizepage.cpp:459
+msgid "Units for the maximum object width."
+msgstr "最大物件寬度的單位。"
+
+#: ../src/richtext/richtextsizepage.cpp:462
+msgid "Max height:"
+msgstr "最大高度："
+
+#: ../src/richtext/richtextsizepage.cpp:473
+#: ../src/richtext/richtextsizepage.cpp:475
+msgid "The object maximum height."
+msgstr "物件最大高度。"
+
+#: ../src/richtext/richtextsizepage.cpp:484
+#: ../src/richtext/richtextsizepage.cpp:486
+msgid "Units for the maximum object height."
+msgstr "最大物件高度的單位。"
+
+#: ../src/richtext/richtextsizepage.cpp:495
+msgid "Position"
+msgstr "定位"
+
+#: ../src/richtext/richtextsizepage.cpp:513
+msgid "&Position mode:"
+msgstr "定位模式(&P)："
+
+#: ../src/richtext/richtextsizepage.cpp:517
+#: ../src/richtext/richtextsizepage.cpp:522
+msgid "Static"
+msgstr "靜態"
+
+#: ../src/richtext/richtextsizepage.cpp:518
+msgid "Relative"
+msgstr "相對"
+
+#: ../src/richtext/richtextsizepage.cpp:519
+msgid "Absolute"
+msgstr "絕對"
+
+#: ../src/richtext/richtextsizepage.cpp:520
+msgid "Fixed"
+msgstr "固定"
+
+#: ../src/richtext/richtextsizepage.cpp:533
+#: ../src/richtext/richtextsizepage.cpp:535
+#: ../src/richtext/richtextsizepage.cpp:547
+#: ../src/richtext/richtextsizepage.cpp:549
+msgid "The left position."
+msgstr "左邊位置。"
+
+#: ../src/richtext/richtextsizepage.cpp:558
+#: ../src/richtext/richtextsizepage.cpp:560
+msgid "Units for the left position."
+msgstr "左方位置單位。"
+
+#: ../src/richtext/richtextsizepage.cpp:568
+#: ../src/richtext/richtextsizepage.cpp:570
+#: ../src/richtext/richtextsizepage.cpp:582
+#: ../src/richtext/richtextsizepage.cpp:584
+msgid "The top position."
+msgstr "上方位置。"
+
+#: ../src/richtext/richtextsizepage.cpp:593
+#: ../src/richtext/richtextsizepage.cpp:595
+msgid "Units for the top position."
+msgstr "上方位置單位。"
+
+#: ../src/richtext/richtextsizepage.cpp:603
+#: ../src/richtext/richtextsizepage.cpp:605
+#: ../src/richtext/richtextsizepage.cpp:617
+#: ../src/richtext/richtextsizepage.cpp:619
+msgid "The right position."
+msgstr "右方位置。"
+
+#: ../src/richtext/richtextsizepage.cpp:628
+#: ../src/richtext/richtextsizepage.cpp:630
+msgid "Units for the right position."
+msgstr "右方位置單位。"
+
+#: ../src/richtext/richtextsizepage.cpp:638
+#: ../src/richtext/richtextsizepage.cpp:640
+#: ../src/richtext/richtextsizepage.cpp:652
+#: ../src/richtext/richtextsizepage.cpp:654
+msgid "The bottom position."
+msgstr "頁尾位置。"
+
+#: ../src/richtext/richtextsizepage.cpp:663
+#: ../src/richtext/richtextsizepage.cpp:665
+msgid "Units for the bottom position."
+msgstr "下方位置單位。"
+
+#: ../src/richtext/richtextsizepage.cpp:671
+msgid "&Move the object to:"
+msgstr "移動物件至(&M)："
+
+#: ../src/richtext/richtextsizepage.cpp:674
+msgid "&Previous Paragraph"
+msgstr "上一個段落(&P)"
+
+#: ../src/richtext/richtextsizepage.cpp:675
+#: ../src/richtext/richtextsizepage.cpp:677
+msgid "Moves the object to the previous paragraph."
+msgstr "將物件移至上一個段落。"
+
+#: ../src/richtext/richtextsizepage.cpp:680
+msgid "&Next Paragraph"
+msgstr "下一個段落(&N)"
+
+#: ../src/richtext/richtextsizepage.cpp:681
+#: ../src/richtext/richtextsizepage.cpp:683
+msgid "Moves the object to the next paragraph."
+msgstr "將物件移至下一個段落。"
+
+#: ../src/richtext/richtextstyledlg.cpp:193
+msgid "&Styles:"
+msgstr "樣式(&S)："
+
+#: ../src/richtext/richtextstyledlg.cpp:197
+#: ../src/richtext/richtextstyledlg.cpp:199
+msgid "The available styles."
+msgstr "可用的樣式。"
+
+#: ../src/richtext/richtextstyledlg.cpp:205
+#: ../src/richtext/richtextstyledlg.cpp:217
+msgid " "
+msgstr " "
+
+#: ../src/richtext/richtextstyledlg.cpp:209
+#: ../src/richtext/richtextstyledlg.cpp:211
+msgid "The style preview."
+msgstr "樣式預覽。"
+
+#: ../src/richtext/richtextstyledlg.cpp:220
+msgid "New &Character Style..."
+msgstr "新增字元樣式(&C)…"
+
+#: ../src/richtext/richtextstyledlg.cpp:221
+#: ../src/richtext/richtextstyledlg.cpp:223
+msgid "Click to create a new character style."
+msgstr "點擊新增字元樣式。"
+
+#: ../src/richtext/richtextstyledlg.cpp:226
+msgid "New &Paragraph Style..."
+msgstr "新增段落樣式(&P)…"
+
+#: ../src/richtext/richtextstyledlg.cpp:227
+#: ../src/richtext/richtextstyledlg.cpp:229
+msgid "Click to create a new paragraph style."
+msgstr "點擊新增段落樣式。"
+
+#: ../src/richtext/richtextstyledlg.cpp:232
+msgid "New &List Style..."
+msgstr "新增清單樣式(&L)…"
+
+#: ../src/richtext/richtextstyledlg.cpp:233
+#: ../src/richtext/richtextstyledlg.cpp:235
+msgid "Click to create a new list style."
+msgstr "點擊新增清單樣式。"
+
+#: ../src/richtext/richtextstyledlg.cpp:238
+msgid "New &Box Style..."
+msgstr "新增文字方塊樣式(&B)…"
+
+#: ../src/richtext/richtextstyledlg.cpp:239
+#: ../src/richtext/richtextstyledlg.cpp:241
+msgid "Click to create a new box style."
+msgstr "點擊新增文字方塊樣式。"
+
+#: ../src/richtext/richtextstyledlg.cpp:246
+msgid "&Apply Style"
+msgstr "套用樣式(&A)"
+
+#: ../src/richtext/richtextstyledlg.cpp:247
+#: ../src/richtext/richtextstyledlg.cpp:249
+msgid "Click to apply the selected style."
+msgstr "點擊以套用所選樣式。"
+
+#: ../src/richtext/richtextstyledlg.cpp:252
+msgid "&Rename Style..."
+msgstr "重新命名樣式(&R)…"
+
+#: ../src/richtext/richtextstyledlg.cpp:253
+#: ../src/richtext/richtextstyledlg.cpp:255
+msgid "Click to rename the selected style."
+msgstr "點擊重新命名所選樣式。"
+
+#: ../src/richtext/richtextstyledlg.cpp:258
+msgid "&Edit Style..."
+msgstr "編輯樣式(&E)…"
+
+#: ../src/richtext/richtextstyledlg.cpp:259
+#: ../src/richtext/richtextstyledlg.cpp:261
+msgid "Click to edit the selected style."
+msgstr "點擊編輯所選樣式。"
+
+#: ../src/richtext/richtextstyledlg.cpp:264
+msgid "&Delete Style..."
+msgstr "刪除樣式(&D)"
+
+#: ../src/richtext/richtextstyledlg.cpp:265
+#: ../src/richtext/richtextstyledlg.cpp:267
+msgid "Click to delete the selected style."
+msgstr "點擊刪除所選樣式。"
+
+#: ../src/richtext/richtextstyledlg.cpp:274
+#: ../src/richtext/richtextstyledlg.cpp:276
+msgid "Click to close this window."
+msgstr "點擊以關閉視窗。"
+
+#: ../src/richtext/richtextstyledlg.cpp:282
+msgid "&Restart numbering"
+msgstr "重新編號(&R)"
+
+#: ../src/richtext/richtextstyledlg.cpp:284
+#: ../src/richtext/richtextstyledlg.cpp:286
+msgid "Check to restart numbering."
+msgstr "勾選後可重新編號。"
+
+#: ../src/richtext/richtextstyledlg.cpp:601
+msgid "Enter a character style name"
+msgstr "輸入字元樣式名稱"
+
+#: ../src/richtext/richtextstyledlg.cpp:601
+#: ../src/richtext/richtextstyledlg.cpp:606
+#: ../src/richtext/richtextstyledlg.cpp:649
+#: ../src/richtext/richtextstyledlg.cpp:654
+#: ../src/richtext/richtextstyledlg.cpp:815
+#: ../src/richtext/richtextstyledlg.cpp:820
+#: ../src/richtext/richtextstyledlg.cpp:888
+#: ../src/richtext/richtextstyledlg.cpp:896
+#: ../src/richtext/richtextstyledlg.cpp:929
+#: ../src/richtext/richtextstyledlg.cpp:934
+msgid "New Style"
+msgstr "新增樣式"
+
+#: ../src/richtext/richtextstyledlg.cpp:606
+#: ../src/richtext/richtextstyledlg.cpp:654
+#: ../src/richtext/richtextstyledlg.cpp:820
+#: ../src/richtext/richtextstyledlg.cpp:896
+#: ../src/richtext/richtextstyledlg.cpp:934
+msgid "Sorry, that name is taken. Please choose another."
+msgstr "抱歉，此名稱已被使用，請再挑選試試。"
+
+#: ../src/richtext/richtextstyledlg.cpp:649
+msgid "Enter a paragraph style name"
+msgstr "輸入段落樣式名稱"
+
+#: ../src/richtext/richtextstyledlg.cpp:777
+#, c-format
+msgid "Delete style %s?"
+msgstr "是否刪除樣式 %s？"
+
+#: ../src/richtext/richtextstyledlg.cpp:777
+msgid "Delete Style"
+msgstr "刪除樣式"
+
+#: ../src/richtext/richtextstyledlg.cpp:815
+msgid "Enter a list style name"
+msgstr "輸入清單樣式名稱"
+
+#: ../src/richtext/richtextstyledlg.cpp:888
+msgid "Enter a new style name"
+msgstr "輸入新的樣式名稱"
+
+#: ../src/richtext/richtextstyledlg.cpp:929
+msgid "Enter a box style name"
+msgstr "輸入文字方塊樣式名稱"
+
+#: ../src/richtext/richtextstylepage.cpp:109
+#: ../src/richtext/richtextstylepage.cpp:111
+msgid "The style name."
+msgstr "樣式名稱。"
+
+#: ../src/richtext/richtextstylepage.cpp:114
+msgid "&Based on:"
+msgstr "基於(&B)："
+
+#: ../src/richtext/richtextstylepage.cpp:119
+#: ../src/richtext/richtextstylepage.cpp:121
+msgid "The style on which this style is based."
+msgstr "此樣式的基底樣式。"
+
+#: ../src/richtext/richtextstylepage.cpp:124
+msgid "&Next style:"
+msgstr "下一個樣式(&N)："
+
+#: ../src/richtext/richtextstylepage.cpp:129
+#: ../src/richtext/richtextstylepage.cpp:131
+msgid "The default style for the next paragraph."
+msgstr "下一個段落的預設樣式。"
+
+#: ../src/richtext/richtextstyles.cpp:1057
+msgid "All styles"
+msgstr "所有樣式"
+
+#: ../src/richtext/richtextstyles.cpp:1058
+msgid "Paragraph styles"
+msgstr "段落樣式"
+
+#: ../src/richtext/richtextstyles.cpp:1059
+msgid "Character styles"
+msgstr "字元樣式"
+
+#: ../src/richtext/richtextstyles.cpp:1060
+msgid "List styles"
+msgstr "清單樣式"
+
+#: ../src/richtext/richtextstyles.cpp:1061
+msgid "Box styles"
+msgstr "文字方塊樣式"
+
+#: ../src/richtext/richtextsymboldlg.cpp:389
+#: ../src/richtext/richtextsymboldlg.cpp:391
+msgid "The font from which to take the symbol."
+msgstr "符號使用該字型。"
+
+#: ../src/richtext/richtextsymboldlg.cpp:396
+msgid "&Subset:"
+msgstr "子集合(&S):"
+
+#: ../src/richtext/richtextsymboldlg.cpp:401
+#: ../src/richtext/richtextsymboldlg.cpp:403
+msgid "Shows a Unicode subset."
+msgstr "顯示 Unicode 子集。"
+
+#: ../src/richtext/richtextsymboldlg.cpp:412
+msgid "xxxx"
+msgstr "xxxx"
+
+#: ../src/richtext/richtextsymboldlg.cpp:417
+msgid "&Character code:"
+msgstr "字元碼(&C):"
+
+#: ../src/richtext/richtextsymboldlg.cpp:421
+#: ../src/richtext/richtextsymboldlg.cpp:423
+msgid "The character code."
+msgstr "字元碼。"
+
+#: ../src/richtext/richtextsymboldlg.cpp:428
+msgid "&From:"
+msgstr "從(&F)："
+
+#: ../src/richtext/richtextsymboldlg.cpp:433
+#: ../src/richtext/richtextsymboldlg.cpp:434
+#: ../src/richtext/richtextsymboldlg.cpp:435
+msgid "Unicode"
+msgstr "萬國碼(Unicode)"
+
+#: ../src/richtext/richtextsymboldlg.cpp:436
+#: ../src/richtext/richtextsymboldlg.cpp:438
+msgid "The range to show."
+msgstr "顯示範圍。"
+
+#: ../src/richtext/richtextsymboldlg.cpp:444
+msgid "Insert"
+msgstr "插入"
+
+#: ../src/richtext/richtextsymboldlg.cpp:478
+msgid "(Normal text)"
+msgstr "(正常文字)"
+
+#: ../src/richtext/richtexttabspage.cpp:109
+msgid "&Position (tenths of a mm):"
+msgstr "定位(&P) (十分之一公釐[mm])："
+
+#: ../src/richtext/richtexttabspage.cpp:113
+#: ../src/richtext/richtexttabspage.cpp:115
+msgid "The tab position."
+msgstr "標籤定位。"
+
+#: ../src/richtext/richtexttabspage.cpp:119
+msgid "The tab positions."
+msgstr "欄標定位。"
+
+#: ../src/richtext/richtexttabspage.cpp:132
+#: ../src/richtext/richtexttabspage.cpp:134
+msgid "Click to create a new tab position."
+msgstr "點擊新增定位點。"
+
+#: ../src/richtext/richtexttabspage.cpp:138
+#: ../src/richtext/richtexttabspage.cpp:140
+msgid "Click to delete the selected tab position."
+msgstr "點擊刪除所選定位點。"
+
+#: ../src/richtext/richtexttabspage.cpp:143
+msgid "Delete A&ll"
+msgstr "全部刪除(&l)"
+
+#: ../src/richtext/richtexttabspage.cpp:144
+#: ../src/richtext/richtexttabspage.cpp:146
+msgid "Click to delete all tab positions."
+msgstr "點擊刪除所有定位點。"
+
+#: ../src/univ/theme.cpp:110
+msgid "Failed to initialize GUI: no built-in themes found."
+msgstr "無法初始化圖形使用者介面：沒有找到內建的視覺主題。"
+
+#: ../src/univ/themes/gtk.cpp:521
+msgid "GTK+ theme"
+msgstr "GTK+ 視覺主題"
+
+#: ../src/univ/themes/metal.cpp:164
+msgid "Metal theme"
+msgstr "金屬視覺主題"
+
+#: ../src/univ/themes/mono.cpp:512
+msgid "Simple monochrome theme"
+msgstr "簡單的單色視覺主題"
+
+#: ../src/univ/themes/win32.cpp:1098
+msgid "Win32 theme"
+msgstr "Win32 視覺主題"
+
+#: ../src/univ/themes/win32.cpp:3743
+msgid "&Restore"
+msgstr "還原(&R)"
+
+#: ../src/univ/themes/win32.cpp:3744
+msgid "&Move"
+msgstr "移動(&M)"
+
+#: ../src/univ/themes/win32.cpp:3746
+msgid "&Size"
+msgstr "大小(&S)"
+
+#: ../src/univ/themes/win32.cpp:3748
+msgid "Mi&nimize"
+msgstr "最小化(&n)"
+
+#: ../src/univ/themes/win32.cpp:3750
+msgid "Ma&ximize"
+msgstr "最大化(&x)"
+
+#: ../src/univ/themes/win32.cpp:3752
+msgid "Alt+"
+msgstr "Alt+"
+
+#: ../src/unix/appunix.cpp:178
+msgid "Failed to install signal handler"
+msgstr "無法安裝信號處理函式"
+
+#: ../src/unix/dialup.cpp:351
+msgid "Already dialling ISP."
+msgstr "已正在撥接 ISP。"
+
+#: ../src/unix/dlunix.cpp:93
+msgid "Failed to unload shared library"
+msgstr "無法載入共享函式庫"
+
+#: ../src/unix/dlunix.cpp:121
+msgid "Unknown dynamic library error"
+msgstr "未知的動態函式庫錯誤"
+
+#: ../src/unix/epolldispatcher.cpp:84
+msgid "Failed to create epoll descriptor"
+msgstr "無法創建 epoll 描述符"
+
+#: ../src/unix/epolldispatcher.cpp:103
+msgid "Error closing epoll descriptor"
+msgstr "關閉 epoll 描述符時發生錯誤"
+
+#: ../src/unix/epolldispatcher.cpp:116
+#, c-format
+msgid "Failed to add descriptor %d to epoll descriptor %d"
+msgstr "無法加入描述符 %d 至 epoll 描述符 %d"
+
+#: ../src/unix/epolldispatcher.cpp:136
+#, c-format
+msgid "Failed to modify descriptor %d in epoll descriptor %d"
+msgstr "無法修改描述符 %d (於 epoll 描述符 %d)"
+
+#: ../src/unix/epolldispatcher.cpp:155
+#, c-format
+msgid "Failed to unregister descriptor %d from epoll descriptor %d"
+msgstr "無法取消註冊描述符 %d (於 epoll 描述符 %d)"
+
+#: ../src/unix/epolldispatcher.cpp:213
+#, c-format
+msgid "Waiting for IO on epoll descriptor %d failed"
+msgstr "等候 epoll 描述符 %d 輸入輸出時失敗"
+
+#: ../src/unix/fswatcher_inotify.cpp:71
+msgid "Unable to create inotify instance"
+msgstr "無法創建 inotify 執行個體"
+
+#: ../src/unix/fswatcher_inotify.cpp:94
+msgid "Unable to close inotify instance"
+msgstr "無法關閉 inotify 執行個體"
+
+#: ../src/unix/fswatcher_inotify.cpp:106
+msgid "Unable to add inotify watch"
+msgstr "無法加入 inotify 監看"
+
+#: ../src/unix/fswatcher_inotify.cpp:138
+#, c-format
+msgid "Unable to remove inotify watch %i"
+msgstr "無法移除 inotify 監看 %i"
+
+#: ../src/unix/fswatcher_inotify.cpp:271
+#, c-format
+msgid "Unexpected event for \"%s\": no matching watch descriptor."
+msgstr "'%s' 的意外事件：沒有相符監看的描述符。"
+
+#: ../src/unix/fswatcher_inotify.cpp:320
+#, c-format
+msgid "Invalid inotify event for \"%s\""
+msgstr "%s 的 inotify 事件無效"
+
+#: ../src/unix/fswatcher_inotify.cpp:553
+msgid "Unable to read from inotify descriptor"
+msgstr "無法讀取 inotify 描述符"
+
+#: ../src/unix/fswatcher_inotify.cpp:558
+msgid "EOF while reading from inotify descriptor"
+msgstr "讀取 inotify 描述符時遇檔案結尾"
+
+#: ../src/unix/fswatcher_kqueue.cpp:114
+msgid "Unable to create kqueue instance"
+msgstr "無法創建 kqueue 執行實體"
+
+#: ../src/unix/fswatcher_kqueue.cpp:131
+msgid "Error closing kqueue instance"
+msgstr "關閉 kqueue 執行個體時發生錯誤"
+
+#: ../src/unix/fswatcher_kqueue.cpp:153
+msgid "Unable to add kqueue watch"
+msgstr "無法加入 kqueue 監看"
+
+#: ../src/unix/fswatcher_kqueue.cpp:170
+msgid "Unable to remove kqueue watch"
+msgstr "無法移除 kqueue 監看"
+
+#: ../src/unix/fswatcher_kqueue.cpp:202
+msgid "Unable to get events from kqueue"
+msgstr "無法從 kqueue 取得事件"
+
+#: ../src/unix/mediactrl.cpp:966
+#, c-format
+msgid "Media playback error: %s"
+msgstr "媒體播放出錯：%s"
+
+#: ../src/unix/mediactrl.cpp:1228
+#, c-format
+msgid "Failed to prepare playing \"%s\"."
+msgstr "無法準備以播放 “%s”。"
+
+#: ../src/unix/snglinst.cpp:164
+#, c-format
+msgid "Failed to write to lock file '%s'"
+msgstr "無法寫入以鎖定 ‘%s’ 檔案"
+
+#: ../src/unix/snglinst.cpp:177
+#, c-format
+msgid "Failed to set permissions on lock file '%s'"
+msgstr "無法在鎖定檔案 '%s' 設定許可權限"
+
+#: ../src/unix/snglinst.cpp:194
+#, c-format
+msgid "Failed to lock the lock file '%s'"
+msgstr "無法鎖定已鎖定的 '%s' 檔案"
+
+#: ../src/unix/snglinst.cpp:237
+#, c-format
+msgid "Failed to inspect the lock file '%s'"
+msgstr "無法檢查鎖定檔案 '%s'"
+
+#: ../src/unix/snglinst.cpp:242
+#, c-format
+msgid "Lock file '%s' has incorrect owner."
+msgstr "上鎖檔案 '%s' 的使用者設定錯誤。"
+
+#: ../src/unix/snglinst.cpp:247
+#, c-format
+msgid "Lock file '%s' has incorrect permissions."
+msgstr "上鎖檔案 '%s' 的權限設定錯誤。"
+
+#: ../src/unix/snglinst.cpp:265
+msgid "Failed to access lock file."
+msgstr "無法存取鎖定檔。"
+
+#: ../src/unix/snglinst.cpp:274
+msgid "Failed to read PID from lock file."
+msgstr "無法從鎖定的檔案讀取程序識別碼 (PID)。"
+
+#: ../src/unix/snglinst.cpp:284
+#, c-format
+msgid "Failed to remove stale lock file '%s'."
+msgstr "無法移除過時的鎖定檔案 '%s'。"
+
+#: ../src/unix/snglinst.cpp:297
+#, c-format
+msgid "Deleted stale lock file '%s'."
+msgstr "刪除過期的鎖定檔案 '%s'。"
+
+#: ../src/unix/snglinst.cpp:308
+#, c-format
+msgid "Invalid lock file '%s'."
+msgstr "無效的鎖定檔案 ‘%s’。"
+
+#: ../src/unix/snglinst.cpp:324
+#, c-format
+msgid "Failed to remove lock file '%s'"
+msgstr "無法移除鎖定檔案 '%s'"
+
+#: ../src/unix/snglinst.cpp:330
+#, c-format
+msgid "Failed to unlock lock file '%s'"
+msgstr "無法解除鎖定檔案 '%s'"
+
+#: ../src/unix/snglinst.cpp:336
+#, c-format
+msgid "Failed to close lock file '%s'"
+msgstr "無法關閉鎖定檔案 '%s'"
+
+#: ../src/unix/sound.cpp:77
+msgid "No sound"
+msgstr "沒有聲音"
+
+#: ../src/unix/sound.cpp:364
+msgid "Unable to play sound asynchronously."
+msgstr "無法非同步播放聲音。"
+
+#: ../src/unix/sound.cpp:458
+#, c-format
+msgid "Couldn't load sound data from '%s'."
+msgstr "無法從 '%s' 載入聲音資料。"
+
+#: ../src/unix/sound.cpp:465
+#, c-format
+msgid "Sound file '%s' is in unsupported format."
+msgstr "'%s' 聲音檔案格式不支援。"
+
+#: ../src/unix/sound.cpp:480
+msgid "Sound data are in unsupported format."
+msgstr "聲音資料格式不支援。"
+
+#: ../src/unix/sound_sdl.cpp:226
+#, c-format
+msgid "Couldn't open audio: %s"
+msgstr "無法開啟音訊：%s"
+
+#: ../src/unix/threadpsx.cpp:1033
+msgid "Cannot retrieve thread scheduling policy."
+msgstr "無法擷取執行緒排程政策。"
+
+#: ../src/unix/threadpsx.cpp:1058
+#, c-format
+msgid "Cannot get priority range for scheduling policy %d."
+msgstr "無法取得排程政策 %d 的優先順序範圍。"
+
+#: ../src/unix/threadpsx.cpp:1066
+msgid "Thread priority setting is ignored."
+msgstr "忽略執行緒優先順序設定。"
+
+#: ../src/unix/threadpsx.cpp:1221
+msgid ""
+"Failed to join a thread, potential memory leak detected - please restart the "
+"program"
+msgstr "無法加入執行緒，偵測到潛在的記憶體流失 - 請重新啟動程式"
+
+#: ../src/unix/threadpsx.cpp:1352
+#, c-format
+msgid "Failed to set thread concurrency level to %lu"
+msgstr "無法設定執行緒的同時性等級為 %lu"
+
+#: ../src/unix/threadpsx.cpp:1481
+#, c-format
+msgid "Failed to set thread priority %d."
+msgstr "無法設定執行緒的優先等級為 %d。"
+
+#: ../src/unix/threadpsx.cpp:1666
+msgid "Failed to terminate a thread."
+msgstr "無法終止執行緒。"
+
+#: ../src/unix/threadpsx.cpp:1893
+msgid "Thread module initialization failed: failed to create thread key"
+msgstr "執行緒模組初始化失敗：無法創建執行緒機碼"
+
+#: ../src/unix/utilsunx.cpp:340
+msgid "Impossible to get child process input"
+msgstr "無法取得子程序的輸入"
+
+#: ../src/unix/utilsunx.cpp:390
+msgid "Can't write to child process's stdin"
+msgstr "無法寫入子系程序的標準輸入"
+
+#: ../src/unix/utilsunx.cpp:644
+#, c-format
+msgid "Failed to execute '%s'\n"
+msgstr "無法執行 '%s'\n"
+
+#: ../src/unix/utilsunx.cpp:678
+msgid "Fork failed"
+msgstr "創建分支失敗"
+
+#: ../src/unix/utilsunx.cpp:701
+msgid "Failed to set process priority"
+msgstr "無法設定執行緒的優先等級"
+
+#: ../src/unix/utilsunx.cpp:712
+msgid "Failed to redirect child process input/output"
+msgstr "重新導向子程序的「輸入/輸出」失敗"
+
+#: ../src/unix/utilsunx.cpp:816
+msgid "Failed to set up non-blocking pipe, the program might hang."
+msgstr "無法設置非阻斷管線，程式也許已經當掉。"
+
+#: ../src/unix/utilsunx.cpp:1023
+msgid "Cannot get the hostname"
+msgstr "無法取得主機名稱"
+
+#: ../src/unix/utilsunx.cpp:1059
+msgid "Cannot get the official hostname"
+msgstr "無法取得正式的主機名稱"
+
+#: ../src/unix/wakeuppipe.cpp:49
+msgid "Failed to create wake up pipe used by event loop."
+msgstr "無法創建事件迴路所用的喚醒管線時。"
+
+#: ../src/unix/wakeuppipe.cpp:56
+msgid "Failed to switch wake up pipe to non-blocking mode"
+msgstr "無法切換喚醒管線到非阻斷模式"
+
+#: ../src/unix/wakeuppipe.cpp:117
+msgid "Failed to read from wake-up pipe"
+msgstr "無法從喚醒管線讀取"
+
+#: ../src/x11/app.cpp:124
+#, c-format
+msgid "Invalid geometry specification '%s'"
+msgstr "幾何規格 '%s' 無效"
+
+#: ../src/x11/app.cpp:167
+msgid "wxWidgets could not open display. Exiting."
+msgstr "wxWidgets 無法開啟顯示設備。程式結束中。"
+
+#: ../src/x11/utils.cpp:169
+#, c-format
+msgid "Failed to close the display \"%s\""
+msgstr "關閉 “%s” 顯示器時失敗"
+
+#: ../src/x11/utils.cpp:188
+#, c-format
+msgid "Failed to open display \"%s\"."
+msgstr "無法開啟顯示 “%s”。"
+
+#: ../src/xml/xml.cpp:868
+#, c-format
+msgid "XML parsing error: '%s' at line %d"
+msgstr "XML 解析錯誤： '%s' 在第 %d 列"
+
+#: ../src/xrc/xh_propgrid.cpp:239
+#, fuzzy, c-format
+msgid "Page %i"
+msgstr "第 %d 頁"
+
+#: ../src/xrc/xmlres.cpp:448
+#, c-format
+msgid "Cannot load resources from '%s'."
+msgstr "無法從 '%s' 檔案載入資源。"
+
+#: ../src/xrc/xmlres.cpp:799
+#, c-format
+msgid "Cannot open resources file '%s'."
+msgstr "無法開啟資源檔 '%s'。"
+
+#: ../src/xrc/xmlres.cpp:806
+#, c-format
+msgid "Cannot load resources from file '%s'."
+msgstr "無法從 '%s' 檔案載入資源。"
+
+#: ../src/xrc/xmlres.cpp:2767
+#, c-format
+msgid "Creating %s \"%s\" failed."
+msgstr "無法創建 %s “%s”。"
+
+#, c-format
+#~ msgid "BMP: header has biClrUsed=%d when biBitCount=%d."
+#~ msgstr "BMP: 當 biBitCount=%d 時，表頭則為 biClrUsed=%d。"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Alt+"
+#~ msgstr "Alt+"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Ctrl+"
+#~ msgstr "Ctrl+"
+
+#~ msgctxt "keyboard key"
+#~ msgid "Shift+"
+#~ msgstr "Shift+"
+
+#~ msgctxt "keyboard key"
+#~ msgid "RawCtrl+"
+#~ msgstr "RawCtrl+"
+
+#~ msgid "Copying more than one selected block to clipboard is not supported."
+#~ msgstr "不支援將多個選定區塊複製至剪貼簿。"
+
+#~ msgid "Unsupported clipboard format."
+#~ msgstr "不支援的剪貼簿格式。"
+
+#~ msgid "Background colour"
+#~ msgstr "背景顏色"
+
+#~ msgid "Font:"
+#~ msgstr "字型："
+
+#~ msgid "Size:"
+#~ msgstr "大小："
+
+#~ msgid "The font size in points."
+#~ msgstr "字型大小以點計。"
+
+#~ msgid "Style:"
+#~ msgstr "樣式："
+
+#~ msgid "Check to make the font bold."
+#~ msgstr "勾選後可設定為粗體。"
+
+#~ msgid "Check to make the font italic."
+#~ msgstr "勾選後可設定為斜體。"
+
+#~ msgid "Check to make the font underlined."
+#~ msgstr "勾選後可將字加底線。"
+
+#~ msgid "Colour:"
+#~ msgstr "顏色："
+
+#~ msgid "Click to change the font colour."
+#~ msgstr "點擊變更字型顏色。"
+
+#~ msgid "Shows a preview of the font."
+#~ msgstr "預覽字型。"
+
+#~ msgid "Click to cancel changes to the font."
+#~ msgstr "點擊取消字型變更。"
+
+#~ msgid "Click to confirm changes to the font."
+#~ msgstr "點擊確認字型變更。"
+
+#~ msgid "<Any>"
+#~ msgstr "<任何字體>"
+
+#~ msgid "<Any Roman>"
+#~ msgstr "<任何羅馬字體>"
+
+#~ msgid "<Any Decorative>"
+#~ msgstr "<任何修飾字體>"
+
+#~ msgid "<Any Modern>"
+#~ msgstr "<任何現代字體>"
+
+#~ msgid "<Any Script>"
+#~ msgstr "<任何手寫字體>"
+
+#~ msgid "<Any Swiss>"
+#~ msgstr "<任何瑞士字體>"
+
+#~ msgid "<Any Teletype>"
+#~ msgstr "<任何打字字體>"
+
+#~ msgid "Printing "
+#~ msgstr "正在列印 "
+
+#~ msgid "Failed to insert text in the control."
+#~ msgstr "無法於控制元件插入文字。"
+
+#~ msgid "Please choose a valid font."
+#~ msgstr "請選擇有效字型。"
+
+#, c-format
+#~ msgid "Failed to display HTML document in %s encoding"
+#~ msgstr "無法以 %s 編碼顯示 HTML 文件"
+
+#, c-format
+#~ msgid "wxWidgets could not open display for '%s': exiting."
+#~ msgstr "wxWidgets 無法開啟 ‘%s’ 顯示設備：已經存在。"
+
+#~ msgid "Filter"
+#~ msgstr "篩選器"
+
+#~ msgid "Directories"
+#~ msgstr "目錄"
+
+#~ msgid "Files"
+#~ msgstr "檔案"
+
+#~ msgid "Selection"
+#~ msgstr "選擇"
+
+#~ msgid "conversion to 8-bit encoding failed"
+#~ msgstr "無法轉換成八位元編碼"
+
+#~ msgid "failed to retrieve execution result"
+#~ msgstr "無法取回執行結果"
+
+#~ msgid "Couldn't create the overlay window"
+#~ msgstr "無法建立覆蓋視窗"
+
+#~ msgid "Couldn't init the context on the overlay window"
+#~ msgstr "無法初始化覆蓋視窗的內容"
+
+#~ msgid "No unused colour in image."
+#~ msgstr "圖像沒有未用的顏色。"
+
+#~ msgid "Not available"
+#~ msgstr "無法提供"
+
+#~ msgid "Style Organiser"
+#~ msgstr "樣式組織器"
+
+#~ msgid ""
+#~ "Web extension not found in \"%s\", some wxWebView functionality will be "
+#~ "not available"
+#~ msgstr "在「%s」找不到網頁擴充套件，部份 wxWebView 功能會無法使用。"
+
+#~ msgid "You cannot Clear an overlay that is not inited"
+#~ msgstr "不能清除未初始化的覆蓋"
+
+#~ msgid "You cannot Init an overlay twice"
+#~ msgstr "不能初始化覆蓋兩次"
+
+#~ msgid " (while overwriting an existing item)"
+#~ msgstr " (正在覆寫現有項目時)"
+
+#~ msgid "&Save as"
+#~ msgstr "另存為(&S)"
+
+#~ msgid "'%s' doesn't consist only of valid characters"
+#~ msgstr "「%s」沒有包含有效字元"
+
+#~ msgid "'%s' should be numeric."
+#~ msgstr "「%s」應該是數值。"
+
+#~ msgid "'%s' should only contain ASCII characters."
+#~ msgstr "「%s」應該只含有 ASCII 字元。"
+
+#~ msgid "'%s' should only contain alphabetic characters."
+#~ msgstr "「%s」應該只含有字母。"
+
+#~ msgid "'%s' should only contain alphabetic or numeric characters."
+#~ msgstr "「%s」應該只含有字母或數字。"
+
+#~ msgid "'%s' should only contain digits."
+#~ msgstr "「%s」應該只含有數字。"
+
+#~ msgid "Can't create window of class %s"
+#~ msgstr "無法建立類別 '%s' 的視窗"
+
+#~ msgid "Failed to convert file \"%s\" to Unicode."
+#~ msgstr "無法轉換「%s」檔案為 Unicode"
+
+#~ msgid "Failed to set text in the text control."
+#~ msgstr "無法在文字控制項設定文字。"
+
+#~ msgid "Invalid GTK+ command line option, use \"%s --help\""
+#~ msgstr "GTK+ 指令列選項無效，請使用 \"%s --help\" 以獲得進一步的說明。"
+
+#~ msgid "Replace selection"
+#~ msgstr "置換所選項目"
+
+#~ msgid "Save as"
+#~ msgstr "另存為"
+
+#~ msgid "The following standard GTK+ options are also supported:\n"
+#~ msgstr "也支援以下的標準 GTK+ 選項:\n"
+
+#~ msgid "locale '%s' cannot be set."
+#~ msgstr "無法設定語區為 '%s'。"
+
+#~ msgid "Adding flavor TEXT failed"
+#~ msgstr "加入風格 TEXT 失敗"
+
+#~ msgid "Adding flavor utxt failed"
+#~ msgstr "加入風格 utxt 失敗"
+
+#~ msgid "Bitmap renderer cannot render value; value type: "
+#~ msgstr "點陣圖渲染器無法渲染該值，型態為: "
+
+#~ msgid ""
+#~ "Cannot create new column's ID. Probably max. number of columns reached."
+#~ msgstr "無法建立新欄位的 ID 。可能是因為已達到欄位數量的上限。"
+
+#~ msgid "Column could not be added."
+#~ msgstr "無法加入欄位。"
+
+#~ msgid "Column index not found."
+#~ msgstr "找不到欄位索引。"
+
+#~ msgid "Column width could not be determined"
+#~ msgstr "無法決定欄位寬度"
+
+#~ msgid "Column width could not be set."
+#~ msgstr "無法設定欄位寬度。"
+
+#~ msgid "Confirm registry update"
+#~ msgstr "確認登錄變更"
+
+#~ msgid "Could not determine column index."
+#~ msgstr "無法決定欄位索引。"
+
+#~ msgid "Could not determine column's position"
+#~ msgstr "無法決定欄位位置"
+
+#~ msgid "Could not determine number of columns."
+#~ msgstr "無法決定欄位數量。"
+
+#~ msgid "Could not determine number of items"
+#~ msgstr "無法決定項目數量。"
+
+#~ msgid "Could not get header description."
+#~ msgstr "無法取得標頭資訊。"
+
+#~ msgid "Could not get items."
+#~ msgstr "無法取得項目。"
+
+#~ msgid "Could not get property flags."
+#~ msgstr "'"
+
+#~ msgid "Could not get selected items."
+#~ msgstr "無法取得所選項目。"
+
+#~ msgid "Could not remove column."
+#~ msgstr "無法移除欄位。"
+
+#~ msgid "Could not retrieve number of items"
+#~ msgstr "'"
+
+#~ msgid "Could not set column width."
+#~ msgstr "無法設定欄位寬度。"
+
+#~ msgid "Could not set header description."
+#~ msgstr "無法設定標頭資訊。"
+
+#~ msgid "Could not set icon."
+#~ msgstr "無法設定圖示。"
+
+#~ msgid "Could not set maximum width."
+#~ msgstr "無法設定最大寬度。"
+
+#~ msgid "Could not set minimum width."
+#~ msgstr "無法設定最小寬度。"
+
+#~ msgid "Could not set property flags."
+#~ msgstr "無法設定性質旗標。"
+
+#~ msgid "Data object has invalid data format"
+#~ msgstr "資料物件中有無效的資料格式"
+
+#~ msgid "Date renderer cannot render value; value type: "
+#~ msgstr "資料渲染器無法渲染該值，型態為: "
+
+#~ msgid ""
+#~ "Do you want to overwrite the command used to %s files with extension "
+#~ "\"%s\" ?\n"
+#~ "Current value is \n"
+#~ "%s, \n"
+#~ "New value is \n"
+#~ "%s %1"
+#~ msgstr ""
+#~ "您要改變用以%s附檔名為 \"%s\" 檔案的命令嗎？\n"
+#~ "目前的值是\n"
+#~ "%s，\n"
+#~ "新的值是\n"
+#~ "%s %1"
+
+#~ msgid "Failed to retrieve data from the clipboard."
+#~ msgstr "無法從剪貼簿取得資料。"
+
+#~ msgid "GIF: Invalid gif index."
+#~ msgstr "GIF: 無效的 gif 索引。"
+
+#~ msgid "GIF: unknown error!!!"
+#~ msgstr "GIF: 不明的錯誤！！！"
+
+#~ msgid "Icon & text renderer cannot render value; value type: "
+#~ msgstr "圖示與文字渲染器無法渲染該值，型態為: "
+
+#~ msgid "New directory"
+#~ msgstr "新目錄"
+
+#~ msgid "Next"
+#~ msgstr "下一個"
+
+#~ msgid "No column existing."
+#~ msgstr "不存在任何欄位。"
+
+#~ msgid "No column for the specified column existing."
+#~ msgstr "不存在指定的欄位。"
+
+#~ msgid "No column for the specified column position existing."
+#~ msgstr "不存在指定的欄位位置。"
+
+#~ msgid ""
+#~ "No renderer or invalid renderer type specified for custom data column."
+#~ msgstr "自訂資料欄位無渲染器，或該欄位指定了一個無效的渲染器類型。"
+
+#~ msgid "No renderer specified for column."
+#~ msgstr "該欄位無指定任何渲染器。"
+
+#~ msgid "Number of columns could not be determined."
+#~ msgstr "無法決定欄位數量。"
+
+#~ msgid "OpenGL function \"%s\" failed: %s (error %d)"
+#~ msgstr "OpenGL 函數 \"%s\" 失敗: %s (錯誤碼 %d)"
+
+#~ msgid ""
+#~ "Please install a newer version of comctl32.dll\n"
+#~ "(at least version 4.70 is required but you have %d.%02d)\n"
+#~ "or this program won't operate correctly."
+#~ msgstr ""
+#~ "請安裝較新版本的 comctl32.dll\n"
+#~ "(最低需求 4.70 版，但目前是 %d.%02d)\n"
+#~ "否則此程式將無法正常運作。"
+
+#~ msgid "Pointer to data view control not set correctly."
+#~ msgstr "未正確設定資料檢視控制項的指標。"
+
+#~ msgid "Pointer to model not set correctly."
+#~ msgstr "未正確設定式樣的指標。"
+
+#~ msgid "Progress renderer cannot render value type; value type: "
+#~ msgstr "程序渲染器無法渲染該值，型態為: "
+
+#~ msgid "Rendering failed."
+#~ msgstr "潤算失敗。"
+
+#~ msgid ""
+#~ "Setting directory access times is not supported under this OS version"
+#~ msgstr "此作業系統不支援設定目錄存取次數"
+
+#~ msgid "Show hidden directories"
+#~ msgstr "顯示隱藏目錄"
+
+#~ msgid "Text renderer cannot render value; value type: "
+#~ msgstr "文字渲染器無法渲染該值，型態為: "
+
+#~ msgid "There is no column or renderer for the specified column index."
+#~ msgstr "所指定的欄位索引或是該欄位索引的渲染器不存在。"
+
+#~ msgid ""
+#~ "This system doesn't support date controls, please upgrade your version of "
+#~ "comctl32.dll"
+#~ msgstr "本系統不支援日期擷取控制, 請升級您的 comctl32.dll 版本"
+
+#~ msgid "Toggle renderer cannot render value; value type: "
+#~ msgstr "切換渲染器無法渲染該值，型態為: "
+
+#~ msgid "Too many colours in PNG, the image may be slightly blurred."
+#~ msgstr "太多顏色在 PNG 中，圖像可能有點模糊。"
+
+#~ msgid "Unable to handle native drag&drop data"
+#~ msgstr "無法處理原生的拖放資料(&D)"
+
+#~ msgid "Unable to initialize Hildon program"
+#~ msgstr "無法初始化 Hildon 程式"
+
+#~ msgid "Unknown data format"
+#~ msgstr "不明的資料格式"
+
+#~ msgid "Valid pointer to native data view control does not exist"
+#~ msgstr "不存在原生資料檢視控制項的有效指標"
+
+#~ msgid "Win32s on Windows 3.1"
+#~ msgstr "Windows 3.1 上的 Win32s"
+
+#, fuzzy
+#~ msgid "Windows 10"
+#~ msgstr "Windows 10"
+
+#~ msgid "Windows 2000"
+#~ msgstr "Windows 2000"
+
+#~ msgid "Windows 7"
+#~ msgstr "Windows 7"
+
+#, fuzzy
+#~ msgid "Windows 8"
+#~ msgstr "Windows 8"
+
+#, fuzzy
+#~ msgid "Windows 8.1"
+#~ msgstr "Windows 8.1"
+
+#~ msgid "Windows 95"
+#~ msgstr "Windows 95"
+
+#~ msgid "Windows 95 OSR2"
+#~ msgstr "Windows 95 OSR2"
+
+#~ msgid "Windows 98"
+#~ msgstr "Windows 98"
+
+#~ msgid "Windows 98 SE"
+#~ msgstr "Windows 98 SE"
+
+#~ msgid "Windows 9x (%d.%d)"
+#~ msgstr "Windows 9x (%d.%d)"
+
+#~ msgid "Windows CE (%d.%d)"
+#~ msgstr "Windows CE (%d.%d)"
+
+#~ msgid "Windows ME"
+#~ msgstr "Windows ME"
+
+#~ msgid "Windows NT %lu.%lu"
+#~ msgstr "Windows NT %lu.%lu"
+
+#, fuzzy
+#~ msgid "Windows Server 10"
+#~ msgstr "Windows Server 2003"
+
+#~ msgid "Windows Server 2003"
+#~ msgstr "Windows Server 2003"
+
+#~ msgid "Windows Server 2008"
+#~ msgstr "Windows Server 2008"
+
+#~ msgid "Windows Server 2008 R2"
+#~ msgstr "Windows Server 2008 R2"
+
+#, fuzzy
+#~ msgid "Windows Server 2012"
+#~ msgstr "Windows Server 2012"
+
+#, fuzzy
+#~ msgid "Windows Server 2012 R2"
+#~ msgstr "Windows Server 2012 R2"
+
+#~ msgid "Windows Vista"
+#~ msgstr "Windows Vista"
+
+#~ msgid "Windows XP"
+#~ msgstr "Windows XP"
+
+#~ msgid "can't execute '%s'"
+#~ msgstr "無法執行 '%s'"
+
+#~ msgid "error opening '%s'"
+#~ msgstr "開啟 '%s' 失敗"
+
+#~ msgid "unknown seek origin"
+#~ msgstr "不明的搜尋基準點"
+
+#~ msgid "wxWidget control pointer is not a data view pointer"
+#~ msgstr "wxWidget control pointer 不是一個 data view pointer"
+
+#~ msgid "wxWidget's control not initialized."
+#~ msgstr "無法初始化 wxWidgets 的控制項。"
+
+#~ msgid "ADD"
+#~ msgstr "ADD"
+
+#~ msgid "BACK"
+#~ msgstr "BACK"
+
+#~ msgid "CANCEL"
+#~ msgstr "CANCEL"
+
+#~ msgid "CAPITAL"
+#~ msgstr "CAPITAL"
+
+#~ msgid "CLEAR"
+#~ msgstr "CLEAR"
+
+#~ msgid "COMMAND"
+#~ msgstr "COMMAND"
+
+#~ msgid "Cannot create mutex."
+#~ msgstr "無法建立 mutex。"
+
+#~ msgid "Cannot resume thread %lu"
+#~ msgstr "無法恢復執行緒 %lu"
+
+#~ msgid "Cannot suspend thread %lu"
+#~ msgstr "無法暫停執行緒 %lu"
+
+#~ msgid "Couldn't acquire a mutex lock"
+#~ msgstr "無法鎖定 mutex。"
+
+#~ msgid "Couldn't get hatch style from wxBrush."
+#~ msgstr "無法從 wxBrush 取得矩形填充樣式。"
+
+#~ msgid "Couldn't release a mutex"
+#~ msgstr "無法釋放 mutex。"
+
+#~ msgid "DECIMAL"
+#~ msgstr "DECIMAL"
+
+#~ msgid "DEL"
+#~ msgstr "DEL"
+
+#~ msgid "DELETE"
+#~ msgstr "DELETE"
+
+#~ msgid "DIVIDE"
+#~ msgstr "DIVIDE"
+
+#~ msgid "DOWN"
+#~ msgstr "DOWN"
+
+#~ msgid "END"
+#~ msgstr "END"
+
+#~ msgid "ENTER"
+#~ msgstr "ENTER"
+
+#~ msgid "ESC"
+#~ msgstr "ESC"
+
+#~ msgid "ESCAPE"
+#~ msgstr "ESCAPE"
+
+#~ msgid "EXECUTE"
+#~ msgstr "EXECUTE"
+
+#~ msgid "Execution of command '%s' failed with error: %ul"
+#~ msgstr "指令 '%s' 執行失敗，錯誤碼：%ul"
+
+#~ msgid ""
+#~ "File '%s' already exists.\n"
+#~ "Do you want to replace it?"
+#~ msgstr ""
+#~ "檔案 '%s' 已存在，\n"
+#~ "是否覆寫？"
+
+#~ msgid "HELP"
+#~ msgstr "HELP"
+
+#~ msgid "HOME"
+#~ msgstr "HOME"
+
+#~ msgid "INS"
+#~ msgstr "INS"
+
+#~ msgid "INSERT"
+#~ msgstr "INSERT"
+
+#~ msgid "KP_BEGIN"
+#~ msgstr "KP_BEGIN"
+
+#~ msgid "KP_DECIMAL"
+#~ msgstr "KP_DECIMAL"
+
+#~ msgid "KP_DELETE"
+#~ msgstr "KP_DELETE"
+
+#~ msgid "KP_DIVIDE"
+#~ msgstr "KP_DIVIDE"
+
+#~ msgid "KP_DOWN"
+#~ msgstr "KP_DOWN"
+
+#~ msgid "KP_ENTER"
+#~ msgstr "KP_ENTER"
+
+#~ msgid "KP_EQUAL"
+#~ msgstr "KP_EQUAL"
+
+#~ msgid "KP_HOME"
+#~ msgstr "KP_HOME"
+
+#~ msgid "KP_INSERT"
+#~ msgstr "KP_INSERT"
+
+#~ msgid "KP_LEFT"
+#~ msgstr "KP_LEFT"
+
+#~ msgid "KP_MULTIPLY"
+#~ msgstr "KP_MULTIPLY"
+
+#~ msgid "KP_NEXT"
+#~ msgstr "KP_NEXT"
+
+#~ msgid "KP_PAGEDOWN"
+#~ msgstr "KP_PAGEDOWN"
+
+#~ msgid "KP_PAGEUP"
+#~ msgstr "KP_PAGEUP"
+
+#~ msgid "KP_PRIOR"
+#~ msgstr "KP_PRIOR"
+
+#~ msgid "KP_RIGHT"
+#~ msgstr "KP_RIGHT"
+
+#~ msgid "KP_SEPARATOR"
+#~ msgstr "KP_SEPARATOR"
+
+#~ msgid "KP_SPACE"
+#~ msgstr "KP_SPACE"
+
+#~ msgid "KP_SUBTRACT"
+#~ msgstr "KP_SUBTRACT"
+
+#~ msgid "LEFT"
+#~ msgstr "LEFT"
+
+#~ msgid "MENU"
+#~ msgstr "MENU"
+
+#~ msgid "NUM_LOCK"
+#~ msgstr "NUM_LOCK"
+
+#~ msgid "PAGEDOWN"
+#~ msgstr "PAGEDOWN"
+
+#~ msgid "PAGEUP"
+#~ msgstr "PAGEUP"
+
+#~ msgid "PAUSE"
+#~ msgstr "PAUSE"
+
+#~ msgid "PGDN"
+#~ msgstr "PGDN"
+
+#~ msgid "PGUP"
+#~ msgstr "PGUP"
+
+#~ msgid "PRINT"
+#~ msgstr "PRINT"
+
+#~ msgid "RETURN"
+#~ msgstr "RETURN"
+
+#~ msgid "RIGHT"
+#~ msgstr "RIGHT"
+
+#~ msgid "SCROLL_LOCK"
+#~ msgstr "SCROLL_LOCK"
+
+#~ msgid "SELECT"
+#~ msgstr "SELECT"
+
+#~ msgid "SEPARATOR"
+#~ msgstr "SEPARATOR"
+
+#~ msgid "SNAPSHOT"
+#~ msgstr "SNAPSHOT"
+
+#~ msgid "SPACE"
+#~ msgstr "SPACE"
+
+#~ msgid "SUBTRACT"
+#~ msgstr "SUBTRACT"
+
+#~ msgid "TAB"
+#~ msgstr "TAB"
+
+#~ msgid "The print dialog returned an error."
+#~ msgstr "列印對話方塊傳回一個錯誤。"
+
+#~ msgid "The wxGtkPrinterDC cannot be used."
+#~ msgstr "無法使用 wxGtkPrinterDC。"
+
+#~ msgid "Timer creation failed."
+#~ msgstr "計時器建立失敗。"
+
+#~ msgid "UP"
+#~ msgstr "UP"
+
+#~ msgid "WINDOWS_LEFT"
+#~ msgstr "WINDOWS_LEFT"
+
+#~ msgid "WINDOWS_MENU"
+#~ msgstr "WINDOWS_MENU"
+
+#~ msgid "WINDOWS_RIGHT"
+#~ msgstr "WINDOWS_RIGHT"
+
+#~ msgid "buffer is too small for Windows directory."
+#~ msgstr "Windows 目錄緩衝區太小。"
+
+#~ msgid "not implemented"
+#~ msgstr "尚未實作"
+
+#~ msgid "wxPrintout::GetPageInfo gives a null maxPage."
+#~ msgstr "wxPrintout::GetPageInfo 給了一個空的 maxPage。"
+
+#~ msgid "Event queue overflowed"
+#~ msgstr "事件佇列溢位"
+
+#~ msgid "percent"
+#~ msgstr "百分比"
+
+#~ msgid "Print preview"
+#~ msgstr "預覽列印"
+
+#~ msgid "'"
+#~ msgstr "'"
+
+#~ msgid "&Preview..."
+#~ msgstr "預覽(&P)..."
+
+#~ msgid "1"
+#~ msgstr "1"
+
+#~ msgid "10"
+#~ msgstr "10"
+
+#~ msgid "3"
+#~ msgstr "3"
+
+#~ msgid "4"
+#~ msgstr "4"
+
+#~ msgid "5"
+#~ msgstr "5"
+
+#~ msgid "6"
+#~ msgstr "6"
+
+#~ msgid "7"
+#~ msgstr "7"
+
+#~ msgid "8"
+#~ msgstr "8"
+
+#~ msgid "9"
+#~ msgstr "9"
+
+#~ msgid "Can't monitor non-existent path \"%s\" for changes."
+#~ msgstr "無法監控不存在的路徑 \"%s\" 是否有變更。"
+
+#~ msgid "File system containing watched object was unmounted"
+#~ msgstr "被監看的物件所在的檔案系統未掛載"
+
+#~ msgid "Preview..."
+#~ msgstr "預覽..."
+
+#~ msgid "The vertical offset relative to the paragraph."
+#~ msgstr "相對於段落的垂直距離。"
+
+#~ msgid "Units for the object offset."
+#~ msgstr "物件位置單位。"

--- a/src/base/constants.cpp
+++ b/src/base/constants.cpp
@@ -73,14 +73,16 @@ const wxSizerFlags g_flagsCenter = wxSizerFlags().Align(wxALIGN_CENTER).Border(w
 const wxSizerFlags g_flagsExpand = wxSizerFlags().Align(wxALIGN_LEFT | wxEXPAND).Border(wxALL, 5).Proportion(1);
 const wxSizerFlags g_flagsExpandBorder1 = wxSizerFlags().Align(wxALIGN_LEFT | wxEXPAND).Border(wxALL, 1).Proportion(1);
 
-// The following labels are used by default in wxWidgets, but do not appear
-// anywhere else in MMEX code. They are listed here in order to be translated.
+// Labels used in 3rd party libraries are listed here in order to be translated.
+// Notice that wxWidgets labels are translated in ${wxWidgets_ROOT_DIR}/locate/ .
 const wxArrayString g_default_labels = {
+/*
     _n("&Next >"),
     _n("< &Back"),
     _n("&Finish"),
     _n("Yes"),
     _n("No"),
+*/
 };
 
 const wxString g_OkLabel =

--- a/src/base/constants.cpp
+++ b/src/base/constants.cpp
@@ -70,6 +70,22 @@ const wxSizerFlags g_flagsCenter = wxSizerFlags().Align(wxALIGN_CENTER).Border(w
 const wxSizerFlags g_flagsExpand = wxSizerFlags().Align(wxALIGN_LEFT | wxEXPAND).Border(wxALL, 5).Proportion(1);
 const wxSizerFlags g_flagsExpandBorder1 = wxSizerFlags().Align(wxALIGN_LEFT | wxEXPAND).Border(wxALL, 1).Proportion(1);
 
+// The following labels are used by default in wxWidgets, but do not appear
+// anywhere else in MMEX code. They are listed here in order to be translated.
+const wxArrayString g_default_labels = {
+    _n("&Next >"),
+    _n("< &Back"),
+    _n("&Finish"),
+    _n("Yes"),
+    _n("No"),
+};
+
+const wxString g_OkLabel =
+#if defined(__APPLE__)
+_n("OK");
+#else
+_n("&OK ");
+#endif
 const wxString g_CancelLabel =
 #if defined(__APPLE__)
     _n("Cancel");
@@ -81,12 +97,6 @@ const wxString g_CloseLabel =
     _n("Close");
 #else
     _n("&Close ");
-#endif
-const wxString g_OkLabel =
-#if defined(__APPLE__)
-_n("OK");
-#else
-_n("&OK ");
 #endif
 
 //bug #5590

--- a/src/base/constants.h
+++ b/src/base/constants.h
@@ -33,8 +33,9 @@ extern const wxSizerFlags g_flagsCenter;
 extern const wxSizerFlags g_flagsExpand;
 extern const wxSizerFlags g_flagsExpandBorder1;
 
-extern const wxString g_CancelLabel;
+extern const wxArrayString g_default_labels;
 extern const wxString g_OkLabel;
+extern const wxString g_CancelLabel;
 extern const wxString g_CloseLabel;
 
 namespace mmex

--- a/src/mmex.cpp
+++ b/src/mmex.cpp
@@ -75,9 +75,7 @@ wxLanguage mmGUIApp::getGUILanguage() const
 bool mmGUIApp::setGUILanguage(wxLanguage lang)
 {
     if (lang == this->m_lang && lang != wxLANGUAGE_UNKNOWN)
-    {
         return false;
-    }
     wxTranslations* trans = new wxTranslations;
 
     // Add the common UI Language translation catalog
@@ -85,39 +83,37 @@ bool mmGUIApp::setGUILanguage(wxLanguage lang)
     trans->AddCatalog("common", wxLANGUAGE_ENGLISH_US);
 
     trans->SetLanguage(lang);
-    trans->AddStdCatalog();
-    if (trans->AddCatalog("mmex", wxLANGUAGE_ENGLISH_US) || lang == wxLANGUAGE_ENGLISH_US || lang == wxLANGUAGE_DEFAULT)
-    {
+    if (!trans->AddStdCatalog()) {
+        wxLogDebug("ERROR: mmGUIApp::setGUILanguage(): cannot add std catalog");
+    }
+    if (trans->AddCatalog("mmex", wxLANGUAGE_ENGLISH_US) ||
+        lang == wxLANGUAGE_ENGLISH_US || lang == wxLANGUAGE_DEFAULT
+    ) {
         wxTranslations::Set(trans);
         this->m_lang = lang;
         PrefModel::instance().setLanguage(lang);
         return true;
     }
-    else
-    {
+    else {
         wxArrayString lang_files = trans->GetAvailableTranslations("mmex");
         if (lang_files.Index("en_US") == wxNOT_FOUND)
             lang_files.Add("en_US");
         wxArrayString lang_names;
-        for (const auto& file : lang_files)
-        {
+        for (const auto& file : lang_files) {
             const wxLanguageInfo* info = wxLocale::FindLanguageInfo(file);
-            if (info)
-            {
+            if (info) {
                 lang_names.Add(wxGetTranslation(info->Description));
             }
         }
         lang_names.Sort();
 
         wxString languages_list;
-        for (const auto& name : lang_names)
-        {
+        for (const auto& name : lang_names) {
             languages_list += (languages_list.empty() ? "" : ", ") + name;
         }
 
         wxString msg;
-        if (lang != wxLANGUAGE_UNKNOWN)
-        {
+        if (lang != wxLANGUAGE_UNKNOWN) {
             wxString best;
 #if wxCHECK_VERSION(3, 1, 2) && !wxCHECK_VERSION(3, 1, 3)
             // workaround for https://github.com/wxWidgets/wxWidgets/pull/1082
@@ -129,8 +125,7 @@ bool mmGUIApp::setGUILanguage(wxLanguage lang)
             msg = wxString::Format("Cannot load a translation for the language: %s", best);
             lang = wxLANGUAGE_UNKNOWN;
         }
-        if (lang == wxLANGUAGE_UNKNOWN)
-        {
+        if (lang == wxLANGUAGE_UNKNOWN) {
             msg += "\n\n";
             msg += wxString::Format("Please use the Switch Application Language option in "
                                     "View menu to select one of the following available languages:\n\n%s",
@@ -159,8 +154,7 @@ bool mmGUIApp::OnCmdLineParsed(wxCmdLineParser& parser)
     if (parser.GetParamCount() > 0)
         m_optParam1 = parser.GetParam(0);
 
-    if (parser.FoundSwitch("s"))
-    {
+    if (parser.FoundSwitch("s")) {
         m_optParamSilent = true;
     }
 


### PR DESCRIPTION
### Changes
* create `po_wxstd/`
* copy wxWidgets locale/*.po files into `po_wxstd/`
* `po_wxstd/CMakeLists.txt` packages the compiled wxstd.mo files together with the mmex.mo files

### Other changes
* in the build directory, create subdirectory `grm/` and move .grm files there

### Notes

wxWidgets translations are processed in a separate source and build directory (`po_wxstd`) in order to avoid conflicts with MMEX translation files. wxWidgets translations can be disabled by commenting out the `add_subdirectory(po_wxstd)` command in `CMakeLists.txt`.

The MMEX translation files are of the form `<LANG>_<COUNTRY>.po`, while the wxWidgets translation files are mostly of the form `<LANG>.po` (with some exceptions). A mapping from MMEX basename to wxWidsgets basename is defined in `po_wxstd/CMakeLists.txt` using commands of the form `set(WXSTD_MAP_<MMEX_BASENAME> "<WXSTD_BASENAME>")`.

Most languages available in MMEX are also available in wxWidgets, but a few are missing.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneymanagerex/moneymanagerex/8195)
<!-- Reviewable:end -->
